### PR TITLE
fix(promtail): Emit "enable watchConfig" log as Debug not Warn

### DIFF
--- a/clients/pkg/promtail/promtail.go
+++ b/clients/pkg/promtail/promtail.go
@@ -260,7 +260,7 @@ func (p *Promtail) watchConfig() {
 		level.Warn(p.logger).Log("msg", "disable watchConfig", "reason", "promtailServer cast fail")
 		return
 	}
-	level.Warn(p.logger).Log("msg", "enable watchConfig")
+	level.Debug(p.logger).Log("msg", "enable watchConfig")
 	hup := make(chan os.Signal, 1)
 	signal.Notify(hup, syscall.SIGHUP)
 	for {


### PR DESCRIPTION
Closes https://github.com/grafana/loki/issues/10230

**What this PR does / why we need it**:

This should be a Debug statement, not a Warning.

**Which issue(s) this PR fixes**:
Fixes #10230

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
