### PR TITLE
Fix S3 Helm example

### DIFF
--- a/docs/sources/setup/install/helm/install-monolithic/_index.md
+++ b/docs/sources/setup/install/helm/install-monolithic/_index.md
@@ -55,10 +55,13 @@ If you set the `singleBinary.replicas` value to 2 or more, this chart configures
         commonConfig:
           replication_factor: 3
         storage:
+          bucketNames:
+            chunks: loki-chunks
+            ruler: loki-ruler
+            admin: loki-admin
           type: 's3'
           s3:
             endpoint: foo.aws.com
-            bucketnames: loki-chunks
             secretAccessKey: supersecret
             accessKeyId: secret
       singleBinary:

--- a/docs/sources/setup/install/helm/install-monolithic/_index.md
+++ b/docs/sources/setup/install/helm/install-monolithic/_index.md
@@ -59,8 +59,8 @@ If you set the `singleBinary.replicas` value to 2 or more, this chart configures
           s3:
             endpoint: foo.aws.com
             bucketnames: loki-chunks
-            secret_access_key: supersecret
-            access_key_id: secret
+            secretAccessKey: supersecret
+            accessKeyId: secret
       singleBinary:
         replicas: 3
       ```


### PR DESCRIPTION
**What this PR does / why we need it**:

S3 Helm example uses the wrong keys. See: https://github.com/grafana/loki/blob/cc6f0eca9849409a10cd1f5e0c87f03e46cf6dd2/production/helm/loki/values.yaml#L280-L281


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
