### PR TITLE
operator: Move sensitive storage information out of LokiStack ConfigMap

### DIFF
--- a/operator/internal/manifests/internal/config/loki-config.yaml
+++ b/operator/internal/manifests/internal/config/loki-config.yaml
@@ -7,67 +7,6 @@ chunk_store_config:
       enabled: true
       max_size_mb: 500
 common:
-  storage:
-    {{- with .ObjectStorage.Azure }}
-    azure:
-      environment: {{ .Env }}
-      container_name: {{ .Container }}
-      account_name: {{ .AccountName }}
-      account_key: {{ .AccountKey }}
-      {{- with .EndpointSuffix }}
-      endpoint_suffix: {{ . }}
-      {{- end }}
-    {{- end }}
-    {{- with .ObjectStorage.GCS }}
-    gcs:
-      bucket_name: {{ .Bucket }}
-    {{- end }}
-    {{- with .ObjectStorage.S3 }}
-    s3:
-      s3: {{ .Endpoint }}
-      bucketnames: {{ .Buckets }}
-      region: {{ .Region }}
-      access_key_id: {{ .AccessKeyID }}
-      secret_access_key: {{ .AccessKeySecret }}
-      {{- with .SSE }}
-      {{- if .Type }}
-      sse:
-        type: {{ .Type }}
-        {{- if eq .Type "SSE-KMS" }}
-        kms_key_id: {{ .KMSKeyID }}
-        {{- with .KMSEncryptionContext }}
-        kms_encryption_context: |
-          {{ . }}
-        {{- end }}
-        {{- end}}
-      {{- end }}
-      {{- end }}
-      s3forcepathstyle: true
-    {{- end }}
-    {{- with .ObjectStorage.Swift }}
-    swift:
-      auth_url: {{ .AuthURL }}
-      username: {{ .Username }}
-      user_domain_name: {{ .UserDomainName }}
-      user_domain_id: {{ .UserDomainID }}
-      user_id: {{ .UserID }}
-      password: {{ .Password }}
-      domain_id: {{ .DomainID }}
-      domain_name: {{ .DomainName }}
-      project_id: {{ .ProjectID }}
-      project_name: {{ .ProjectName }}
-      project_domain_id: {{ .ProjectDomainID }}
-      project_domain_name: {{ .ProjectDomainName }}
-      region_name: {{ .Region }}
-      container_name: {{ .Container }}
-    {{- end }}
-    {{- with .ObjectStorage.AlibabaCloud}}
-    alibabacloud:
-      bucket: {{ .Bucket }}
-      endpoint: {{ .Endpoint }}
-      access_key_id: {{ .AccessKeyID }}
-      secret_access_key: {{ .SecretAccessKey }}
-    {{- end }}
   compactor_grpc_address: {{ .Compactor.FQDN }}:{{ .Compactor.Port }}
   {{- with .GossipRing }}
   ring:


### PR DESCRIPTION
**What this PR does / why we need it**:
The generated Loki ConfigMap currently contains object storage information that are extracted from a Secret. Since ConfigMaps are available to a larger audience, this poses a risk of disclosing these values to users who were denied access to the original Secret.

This PR removes this part from the Loki config.yaml and places it in a separate Secret.

**Which issue(s) this PR fixes**:
Fixes [LOG-4596](https://issues.redhat.com/browse/LOG-4596)

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
