### PR TITLE
Handle unexpected response types in volume API

### DIFF
--- a/pkg/querier/queryrange/volume.go
+++ b/pkg/querier/queryrange/volume.go
@@ -109,16 +109,17 @@ func ToPrometheusResponse(respsCh chan *bucketedVolumeResponse, aggregateBySerie
 	var headers []*definitions.PrometheusResponseHeader
 	samplesByName := make(map[string][]logproto.LegacySample)
 
-	for bucketedVolumeResponse := range respsCh {
-		if bucketedVolumeResponse == nil {
+	for response := range respsCh {
+		if response == nil {
 			continue
 		}
 
-		bucket, resp := bucketedVolumeResponse.bucket, bucketedVolumeResponse.response
+		bucket, resp := response.bucket, response.response
+
 
 		if headers == nil {
-			headers := make([]*definitions.PrometheusResponseHeader, len(resp.Headers))
-			for i, header := range resp.Headers {
+			headers = make([]*definitions.PrometheusResponseHeader, len(r.Headers))
+			for i, header := range r.Headers {
 				h := header
 				headers[i] = &h
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:
We're currently seeing panics in `k174` due to `nil` responses being passed due to an unsuccessful type assertion which was not checked.

This PR moves the type assertion to where it's needed and handles it gracefully.

We don't yet know what response is being passed into the channel; this log line will help us identify it.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
There was also some variable shadowing in this code which could produce some interesting bugs, so I renamed the variables to avoid that.