### PR TITLE
Cast volume response on receive.

### DIFF
--- a/pkg/util/marshal/marshal_test.go
+++ b/pkg/util/marshal/marshal_test.go
@@ -714,6 +714,34 @@ func Test_WriteSeriesResponseJSON(t *testing.T) {
 			require.NoError(t, err)
 
 			require.JSONEqf(t, tc.expected, b.String(), "Series Test %d failed", i)
+
+		})
+	}
+}
+
+func Test_WriteVolumeResponseJSON(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		input    *logproto.VolumeResponse
+		expected string
+	}{
+		{
+			name:     "empty",
+			input:    &logproto.VolumeResponse{Volumes: []logproto.Volume{}},
+			expected: `{"volumes":[]}`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var b bytes.Buffer
+			err := WriteVolumeResponseJSON(tc.input, &b)
+			require.NoError(t, err)
+
+			require.JSONEq(t, tc.expected, b.String())
+
+			var resp logproto.VolumeResponse
+			err = json.Unmarshal([]byte(tc.expected), &resp)
+			require.NoError(t, err)
+			require.Equal(t, tc.input, &resp)
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Relates to #11196. The responses should be cast and check on receive.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
