### PR TITLE
populate empty resonse for IndexStatsResponse and VolumeResponse

### DIFF
--- a/.github/workflows/vulnerability-scan.yml
+++ b/.github/workflows/vulnerability-scan.yml
@@ -9,6 +9,9 @@ jobs:
   snyk:
     name: Snyk Scan
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - name: Checkout code
         uses: actions/checkout@master
@@ -47,6 +50,9 @@ jobs:
   trivy:
     name: Trivy Scan
     runs-on: ubuntu-20.04
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/pkg/querier/queryrange/codec.go
+++ b/pkg/querier/queryrange/codec.go
@@ -1608,9 +1608,13 @@ func NewEmptyResponse(r queryrangebase.Request) (queryrangebase.Response, error)
 			},
 		}, nil
 	case *logproto.IndexStatsRequest:
-		return &IndexStatsResponse{}, nil
+		return &IndexStatsResponse{
+			Response: &logproto.IndexStatsResponse{},
+		}, nil
 	case *logproto.VolumeRequest:
-		return &VolumeResponse{}, nil
+		return &VolumeResponse{
+			Response: &logproto.VolumeResponse{},
+		}, nil
 	default:
 		return nil, fmt.Errorf("unsupported request type %T", req)
 	}


### PR DESCRIPTION
Fixes a panic when the underlying response struct is accessed but not populated after an out-of-bounds request is short-circuited via `NewEmptyResponse` [here](https://github.com/grafana/loki/blob/main/pkg/querier/queryrange/limits.go#L155-L164). This PR ensures the embedded types are not nil in accordance with the other variants in this function.