### PR TITLE
boundscheck & partitioning fingerprints between blocks

### DIFF
--- a/pkg/storage/bloom/v1/fuse.go
+++ b/pkg/storage/bloom/v1/fuse.go
@@ -1,6 +1,8 @@
 package v1
 
 import (
+	"sort"
+
 	"github.com/efficientgo/core/errors"
 	"github.com/prometheus/common/model"
 )
@@ -141,4 +143,44 @@ func (fq *FusedQuerier) Run() error {
 	}
 
 	return nil
+}
+
+// boundedRequests is a set of requests that are clamped to a specific range
+type boundedRequests struct {
+	bounds FingerprintBounds
+	reqs   [][]model.Fingerprint
+}
+
+// reqs models a set of requests covering many fingerprints.
+// consumers models a set of blocks covering different fingerprint ranges
+func partitionFingerprintRange(reqs [][]model.Fingerprint, blocks []FingerprintBounds) (res []boundedRequests) {
+	for _, block := range blocks {
+		bounded := boundedRequests{
+			bounds: block,
+		}
+
+		for _, req := range reqs {
+			min := sort.Search(len(req), func(i int) bool {
+				return block.Cmp(req[i]) > Before
+			})
+
+			max := sort.Search(len(req), func(i int) bool {
+				return block.Cmp(req[i]) == After
+			})
+
+			// All fingerprints fall outside of the consumer's range
+			if min == len(req) || max == 0 {
+				continue
+			}
+
+			bounded.reqs = append(bounded.reqs, req[min:max])
+		}
+
+		if len(bounded.reqs) > 0 {
+			res = append(res, bounded)
+		}
+
+	}
+
+	return res
 }

--- a/pkg/storage/bloom/v1/fuse_test.go
+++ b/pkg/storage/bloom/v1/fuse_test.go
@@ -7,10 +7,43 @@ import (
 	"testing"
 
 	"github.com/grafana/dskit/concurrency"
+	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/loki/pkg/chunkenc"
 )
+
+func TestPartitionFingerprintRange(t *testing.T) {
+	seriesPerBound := 100
+	bounds := []FingerprintBounds{
+		{0, 99},
+		{100, 199},
+		{200, 299},
+		{300, 399}, // one out of bounds block
+	}
+
+	nReqs := 4
+	nSeries := 300
+	reqs := make([][]model.Fingerprint, nReqs)
+	for i := 0; i < nSeries; i++ {
+		reqs[i%4] = append(reqs[i%nReqs], model.Fingerprint(i))
+	}
+
+	results := partitionFingerprintRange(reqs, bounds)
+	require.Equal(t, 3, len(results)) // ensure we only return bounds in range
+	for _, res := range results {
+		// ensure we have the right number of requests per bound
+		for i := 0; i < nReqs; i++ {
+			require.Equal(t, seriesPerBound/nReqs, len(res.reqs[i]))
+		}
+	}
+
+	// ensure bound membership
+	for i := 0; i < nSeries; i++ {
+		require.Equal(t, model.Fingerprint(i), results[i/seriesPerBound].reqs[i%nReqs][i%seriesPerBound/nReqs])
+	}
+
+}
 
 func TestFusedQuerier(t *testing.T) {
 	// references for linking in memory reader+writer


### PR DESCRIPTION
Adds a few utilities for comparing fingerprints to blocks that cover a specific fingerprint range. Will likely need to be refactored with more comprehensive types, but the logic still applies.