### PR TITLE
still return response when we cannot generate extents

### DIFF
--- a/pkg/querier/queryrange/queryrangebase/results_cache.go
+++ b/pkg/querier/queryrange/queryrangebase/results_cache.go
@@ -391,7 +391,7 @@ func (s resultsCache) handleMiss(ctx context.Context, r Request, maxCacheTime in
 
 	extent, err := toExtent(ctx, r, s.extractor.ResponseWithoutHeaders(response))
 	if err != nil {
-		return nil, nil, err
+		return response, []Extent{}, nil
 	}
 
 	extents := []Extent{


### PR DESCRIPTION
**What this PR does / why we need it**:

I'm not sure why we would want to no return the `response`, and return an `error`, when we can't generate the extents we need to be able to cache the response. I feel like we should handle this case the same as when we shouldn't cache, as we wouldn't want a failure to cache to response to result in a failed request.

The caller of this function checks `len(extents) > 1` anyway, so I don't see a need to propagate the error. Please let me know if I'm missing something.