### PR TITLE
helm: fix typo in read-deployment's annotations causing them to be ignored

### DIFF
--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -13,6 +13,10 @@ Entries should include a reference to the pull request that introduced the chang
 
 [//]: # (<AUTOMATED_UPDATES_LOCATOR> : do not remove this line. This locator is used by the CI pipeline to automatically create a changelog entry for each new Loki release. Add other chart versions and respective changelog entries bellow this line.)
 
+## 5.40.1
+
+- [BUGFIX] Fix typo in read-deployment causing `read` annotations to be ignored
+
 ## 5.40.0
 
 - [CHANGE] Add extraContainers parameter for the write pod
@@ -28,9 +32,6 @@ Entries should include a reference to the pull request that introduced the chang
 ## 5.37.0
 
 - [FEATURE] Add support for enabling tracing.
-## 5.36.3
-## 5.36.4
-- [BUGFIX] Fix typo in read-deployment causing `read` annotations to be ignored
 
 ## 5.36.2
 

--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -29,6 +29,7 @@ Entries should include a reference to the pull request that introduced the chang
 
 - [FEATURE] Add support for enabling tracing.
 ## 5.36.3
+## 5.36.4
 - [BUGFIX] Fix typo in read-deployment causing `read` annotations to be ignored
 
 ## 5.36.2

--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -28,6 +28,8 @@ Entries should include a reference to the pull request that introduced the chang
 ## 5.37.0
 
 - [FEATURE] Add support for enabling tracing.
+## 5.36.3
+- [BUGFIX] Fix typo in read-deployment causing `read` annotations to be ignored
 
 ## 5.36.2
 

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -3,7 +3,7 @@ name: loki
 description: Helm chart for Grafana Loki in simple, scalable mode
 type: application
 appVersion: 2.9.2
-version: 5.40.0
+version: 5.40.1
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -1,6 +1,6 @@
 # loki
 
-![Version: 5.40.0](https://img.shields.io/badge/Version-5.40.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.9.2](https://img.shields.io/badge/AppVersion-2.9.2-informational?style=flat-square)
+![Version: 5.40.1](https://img.shields.io/badge/Version-5.40.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.9.2](https://img.shields.io/badge/AppVersion-2.9.2-informational?style=flat-square)
 
 Helm chart for Grafana Loki in simple, scalable mode
 

--- a/production/helm/loki/templates/read/deployment-read.yaml
+++ b/production/helm/loki/templates/read/deployment-read.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
     app.kubernetes.io/part-of: memberlist
     {{- include "loki.readLabels" . | nindent 4 }}
-  {{- if or (not (empty .Values.loki.annotations)) (not (empty .Values.backend.annotations))}}
+  {{- if or (not (empty .Values.loki.annotations)) (not (empty .Values.read.annotations))}}
   annotations:
     {{- with .Values.loki.annotations }}
     {{- toYaml . | nindent 4 }}


### PR DESCRIPTION
**What this PR does / why we need it**:
A typo in [deployment-read.yaml](production/helm/loki/templates/read/deployment-read.yaml) makes the annotations from values.yaml being ignored if no backend annotations are specified

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [X] Documentation added
- [X] Tests updated
- [X] `CHANGELOG.md` updated
  - [X] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [X] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [X] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [X] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
