### PR TITLE
iterable tokenizer w/ comparison benching

### DIFF
--- a/pkg/storage/bloom/v1/tokenizer.go
+++ b/pkg/storage/bloom/v1/tokenizer.go
@@ -81,7 +81,7 @@ func (t *NgramTokenizer) Tokens(line string) []Token {
 			t.buffers[j][pos] = r
 
 			if i >= n-1 && (i+1-n)%(t.skip+1) == 0 {
-				t.runeBuffer = reassemble(t.buffers[j], (i+1)%n, t.runeBuffer)
+				t.runeBuffer = reassemble(t.buffers[j], len(t.buffers[j]), (i+1)%n, t.runeBuffer)
 				if numToks >= cap(t.internalTokenBuffer) || numToks == len(t.internalTokenBuffer) {
 					t.internalTokenBuffer = append(t.internalTokenBuffer, Token{Key: make([]byte, 0, TokenKeySize)})
 				}
@@ -95,9 +95,9 @@ func (t *NgramTokenizer) Tokens(line string) []Token {
 	return t.internalTokenBuffer[0:numToks]
 }
 
-func reassemble(buf []rune, pos int, result []byte) []byte {
+func reassemble(buf []rune, ln, pos int, result []byte) []byte {
 	result = result[:0] // Reset the result slice
-	for i := 0; i < len(buf); i++ {
+	for i := 0; i < ln; i++ {
 		cur := (pos + i) % len(buf)
 		result = utf8.AppendRune(result, buf[cur])
 	}
@@ -167,4 +167,99 @@ func (w *WrappedTokenizer) Reinit(chk logproto.ChunkRef) {
 	w.prefix = append(w.prefix, w.i64buf...)
 	binary.LittleEndian.PutUint32(w.i32buf, chk.Checksum)
 	w.prefix = append(w.prefix, w.i32buf...)
+}
+
+// Iterable variants (more performant, less space)
+
+type NGramTokenizerV2 struct {
+	n, skip int
+	buffer  []rune // circular buffer used for ngram generation
+	res     []byte // buffer used for token generation
+}
+
+/*
+N-Grams (https://en.wikipedia.org/wiki/N-gram) are a series of 'n' adjacent characters in a string.
+These will be utilized for the bloom filters to allow for fuzzy searching.
+*/
+func NewNGramTokenizerV2(n, skip int) *NGramTokenizerV2 {
+	t := &NGramTokenizerV2{
+		n:      n,
+		skip:   skip,
+		buffer: make([]rune, n+skip),
+		res:    make([]byte, 0, n*4), // maximum 4 bytes per rune
+	}
+
+	return t
+}
+
+// The Token iterator uses shared buffers for performance. The []byte returned by At()
+// is not safe for use after subsequent calls to Next()
+func (t *NGramTokenizerV2) Tokens(line string) NGramTokenIter {
+	return NGramTokenIter{
+		n:    t.n,
+		skip: t.skip,
+
+		line: line,
+
+		buffer: t.buffer,
+		res:    t.res,
+	}
+}
+
+type NGramTokenIter struct {
+	n, skip int
+
+	runeIndex, offset int
+	line              string // source
+
+	buffer []rune // circular buffers used for ngram generation
+	res    []byte
+}
+
+func (t *NGramTokenIter) Next() bool {
+	for i, r := range t.line[t.offset:] {
+		t.buffer[t.runeIndex%len(t.buffer)] = r
+		t.runeIndex++
+
+		if t.runeIndex < t.n {
+			continue
+		}
+
+		// if the start of the ngram is at the interval of our skip factor, emit it.
+		// we increment the skip due to modulo logic:
+		//   because `n % 0 is a divide by zero and n % 1 is always 0`
+		if (t.runeIndex-t.n)%(t.skip+1) == 0 {
+			t.offset += (i + utf8.RuneLen(r))
+			return true
+		}
+
+	}
+	return false
+}
+
+func (t *NGramTokenIter) At() []byte {
+	return reassemble(t.buffer, t.n, (t.runeIndex-t.n)%len(t.buffer), t.res[:0])
+}
+
+func (t *NGramTokenIter) Err() error {
+	return nil
+}
+
+type PrefixedTokenIter struct {
+	prefix    []byte
+	prefixLen int
+
+	NGramTokenIter
+}
+
+func (t *PrefixedTokenIter) At() []byte {
+	return append(t.prefix[:t.prefixLen], t.NGramTokenIter.At()...)
+}
+
+func NewPrefixedTokenIter(prefix []byte, iter NGramTokenIter) *PrefixedTokenIter {
+	return &PrefixedTokenIter{
+		prefix:         prefix,
+		prefixLen:      len(prefix),
+		NGramTokenIter: iter,
+	}
 }


### PR DESCRIPTION
Rebuilds tokenizers based on an iterable approach. This ends up being significantly faster -- benchmarks below.

This PR doesn't remove the old tokenizers, just adds the new ones. Revamping tokenizer consumers & removing the old variants can be done in a separate PR.

Roughly, raw tokenizers complete in 66% of the time and chunkID prefixed tokenizers in ~55-60% of the time.

```
pkg: github.com/grafana/loki/pkg/storage/bloom/v1
BenchmarkTokens/three/v1-10      	  134811	      8648 ns/op	       0 B/op	       0 allocs/op
BenchmarkTokens/three/v2-10      	  179797	      5728 ns/op	       0 B/op	       0 allocs/op
BenchmarkTokens/threeSkip1/v1-10 	  215822	      5260 ns/op	       0 B/op	       0 allocs/op
BenchmarkTokens/threeSkip1/v2-10 	  343784	      3514 ns/op	       0 B/op	       0 allocs/op
BenchmarkTokens/threeChunk/v1-10 	   82394	     14559 ns/op	       0 B/op	       0 allocs/op
BenchmarkTokens/threeChunk/v2-10 	  146973	      8138 ns/op	     128 B/op	       1 allocs/op
BenchmarkTokens/threeSkip1Chunk/v1-10      	  152475	      7878 ns/op	       0 B/op	       0 allocs/op
BenchmarkTokens/threeSkip1Chunk/v2-10      	  251373	      4776 ns/op	     128 B/op	       1 allocs/op
PASS
ok  	github.com/grafana/loki/pkg/storage/bloom/v1	10.206s
```