### PR TITLE
Paul1r/bloom blocks and compression

### DIFF
--- a/pkg/bloomcompactor/bloomcompactor.go
+++ b/pkg/bloomcompactor/bloomcompactor.go
@@ -64,6 +64,7 @@ import (
 const (
 	fpRate        = 0.01
 	bloomFileName = "bloom"
+	indexFileName = "index"
 )
 
 type Compactor struct {
@@ -485,6 +486,11 @@ func buildBloomBlock(ctx context.Context, logger log.Logger, bloomForChks v1.Ser
 		level.Error(logger).Log("reading bloomBlock", err)
 	}
 
+	indexFile, err := os.Open(filepath.Join(localDst, indexFileName))
+	if err != nil {
+		level.Error(logger).Log("reading bloomBlock", err)
+	}
+
 	blocks := bloomshipper.Block{
 		BlockRef: bloomshipper.BlockRef{
 			Ref: bloomshipper.Ref{
@@ -498,7 +504,8 @@ func buildBloomBlock(ctx context.Context, logger log.Logger, bloomForChks v1.Ser
 			},
 			IndexPath: job.IndexPath(),
 		},
-		Data: blockFile,
+		BloomData: blockFile,
+		IndexData: indexFile,
 	}
 
 	return blocks, nil

--- a/pkg/bloomcompactor/bloomcompactor.go
+++ b/pkg/bloomcompactor/bloomcompactor.go
@@ -62,9 +62,9 @@ import (
 )
 
 const (
-	fpRate        = 0.01
-	bloomFileName = "bloom"
-	indexFileName = "index"
+	fpRate         = 0.01
+	bloomFileName  = "bloom"
+	seriesFileName = "series"
 )
 
 type Compactor struct {
@@ -486,7 +486,7 @@ func buildBloomBlock(ctx context.Context, logger log.Logger, bloomForChks v1.Ser
 		level.Error(logger).Log("reading bloomBlock", err)
 	}
 
-	indexFile, err := os.Open(filepath.Join(localDst, indexFileName))
+	indexFile, err := os.Open(filepath.Join(localDst, seriesFileName))
 	if err != nil {
 		level.Error(logger).Log("reading bloomBlock", err)
 	}

--- a/pkg/storage/bloom/v1/archive.go
+++ b/pkg/storage/bloom/v1/archive.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/pkg/errors"
 
@@ -110,7 +111,12 @@ func UnTarGz(dst string, r io.Reader) error {
 
 		// if it's a file create it
 		case tar.TypeReg:
-			f, err := os.OpenFile(target, os.O_CREATE|os.O_RDWR|os.O_TRUNC, os.FileMode(header.Mode))
+			err := os.MkdirAll(target[:strings.LastIndex(target, "/")], 0755)
+			if err != nil {
+				return errors.Wrapf(err, "error creating directory %s", target)
+			}
+			//f, err := os.OpenFile(target, os.O_CREATE|os.O_RDWR|os.O_TRUNC, os.FileMode(header.Mode))
+			f, err := os.OpenFile(target, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0755)
 			if err != nil {
 				return errors.Wrapf(err, "error creating file %s", target)
 			}

--- a/pkg/storage/bloom/v1/block_writer.go
+++ b/pkg/storage/bloom/v1/block_writer.go
@@ -12,8 +12,8 @@ import (
 )
 
 const (
-	bloomFileName  = "bloom"
-	seriesFileName = "series"
+	BloomFileName  = "bloom"
+	SeriesFileName = "series"
 )
 
 type BlockWriter interface {
@@ -66,12 +66,12 @@ func (b *DirectoryBlockWriter) Init() error {
 			return errors.Wrap(err, "creating bloom block dir")
 		}
 
-		b.index, err = os.Create(filepath.Join(b.dir, seriesFileName))
+		b.index, err = os.Create(filepath.Join(b.dir, SeriesFileName))
 		if err != nil {
 			return errors.Wrap(err, "creating series file")
 		}
 
-		b.blooms, err = os.Create(filepath.Join(b.dir, bloomFileName))
+		b.blooms, err = os.Create(filepath.Join(b.dir, BloomFileName))
 		if err != nil {
 			return errors.Wrap(err, "creating bloom file")
 		}

--- a/pkg/storage/bloom/v1/reader.go
+++ b/pkg/storage/bloom/v1/reader.go
@@ -49,12 +49,12 @@ func NewDirectoryBlockReader(dir string) *DirectoryBlockReader {
 func (r *DirectoryBlockReader) Init() error {
 	if !r.initialized {
 		var err error
-		r.index, err = os.Open(filepath.Join(r.dir, seriesFileName))
+		r.index, err = os.Open(filepath.Join(r.dir, SeriesFileName))
 		if err != nil {
 			return errors.Wrap(err, "opening series file")
 		}
 
-		r.blooms, err = os.Open(filepath.Join(r.dir, bloomFileName))
+		r.blooms, err = os.Open(filepath.Join(r.dir, BloomFileName))
 		if err != nil {
 			return errors.Wrap(err, "opening bloom file")
 		}

--- a/pkg/storage/stores/shipper/bloomshipper/client.go
+++ b/pkg/storage/stores/shipper/bloomshipper/client.go
@@ -216,10 +216,8 @@ func (b *BloomClient) GetBlocks(ctx context.Context, references []BlockRef) (cha
 			defer func() {
 				compressedObjectReadCloser.Close()
 			}()
-			// TODO: This - how best to get the working directory here
-			workingDirectoryPath := ""
 
-			//workingDirectoryPath := filepath.Join(b.storageConfig.BloomShipperConfig.WorkingDirectory, block.BlockPath, strconv.FormatInt(time.Now().UTC().UnixMilli(), 10))
+			workingDirectoryPath := filepath.Join(b.storageConfig.BloomShipperConfig.WorkingDirectory, reference.BlockPath, strconv.FormatInt(time.Now().UTC().UnixMilli(), 10))
 			err = v1.UnTarGz(workingDirectoryPath, compressedObjectReadCloser)
 			if err != nil {
 				return fmt.Errorf("error while untarring: %w", err)

--- a/pkg/storage/stores/shipper/bloomshipper/client.go
+++ b/pkg/storage/stores/shipper/bloomshipper/client.go
@@ -236,6 +236,10 @@ func (b *BloomClient) PutBlocks(ctx context.Context, blocks []Block) ([]Block, e
 			_ = Data.Close()
 		}(block.BloomData)
 
+		defer func(Data io.ReadCloser) {
+			_ = Data.Close()
+		}(block.IndexData)
+
 		period, err := findPeriod(b.periodicConfigs, block.StartTimestamp)
 		if err != nil {
 			return fmt.Errorf("error updloading block file: %w", err)

--- a/pkg/storage/stores/shipper/bloomshipper/client.go
+++ b/pkg/storage/stores/shipper/bloomshipper/client.go
@@ -1,11 +1,14 @@
 package bloomshipper
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	v1 "github.com/grafana/loki/pkg/storage/bloom/v1"
 	"io"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -206,13 +209,37 @@ func (b *BloomClient) GetBlocks(ctx context.Context, references []BlockRef) (cha
 				return fmt.Errorf("error while period lookup: %w", err)
 			}
 			objectClient := b.periodicObjectClients[period]
-			readCloser, _, err := objectClient.GetObject(ctx, createBlockObjectKey(reference.Ref))
+			compressedObjectReadCloser, _, err := objectClient.GetObject(ctx, createBlockObjectKey(reference.Ref))
 			if err != nil {
 				return fmt.Errorf("error while fetching object from storage: %w", err)
 			}
+			defer func() {
+				compressedObjectReadCloser.Close()
+			}()
+			// TODO: This - how best to get the working directory here
+			workingDirectoryPath := ""
+
+			//workingDirectoryPath := filepath.Join(s.config.WorkingDirectory, block.BlockPath, strconv.FormatInt(ts.UnixMilli(), 10))
+			err = v1.UnTarGz(workingDirectoryPath, compressedObjectReadCloser)
+			if err != nil {
+				return fmt.Errorf("error while untarring: %w", err)
+			}
+
+			indexFile, err := os.Open(filepath.Join(workingDirectoryPath, v1.SeriesFileName))
+			if err != nil {
+				return fmt.Errorf("error while opening index file: %w", err)
+			}
+			indexReader := bufio.NewReader(indexFile)
+
+			bloomFile, err := os.Open(filepath.Join(workingDirectoryPath, v1.BloomFileName))
+			if err != nil {
+				return fmt.Errorf("error while opening bloom file: %w", err)
+			}
+			bloomReader := bufio.NewReader(bloomFile)
 			blocksChannel <- Block{
 				BlockRef:  reference,
-				BloomData: readCloser,
+				BloomData: io.NopCloser(bloomReader),
+				IndexData: io.NopCloser(indexReader),
 			}
 			return nil
 		})
@@ -226,7 +253,25 @@ func (b *BloomClient) GetBlocks(ctx context.Context, references []BlockRef) (cha
 	return blocksChannel, errChannel
 }
 
-// TODO zip (archive) blocks before uploading to storage
+func readCloserToBuffer(rc io.ReadCloser) *bytes.Buffer {
+	defer rc.Close()
+
+	// Read the data from io.ReadCloser
+	data, err := io.ReadAll(rc)
+	if err != nil {
+		return nil
+	}
+
+	// Write the data into a bytes.Buffer
+	var buf bytes.Buffer
+	_, err = buf.Write(data)
+	if err != nil {
+		return nil
+	}
+
+	return &buf
+}
+
 func (b *BloomClient) PutBlocks(ctx context.Context, blocks []Block) ([]Block, error) {
 	results := make([]Block, len(blocks))
 	//todo move concurrency to the config
@@ -246,11 +291,16 @@ func (b *BloomClient) PutBlocks(ctx context.Context, blocks []Block) ([]Block, e
 		}
 		key := createBlockObjectKey(block.Ref)
 		objectClient := b.periodicObjectClients[period]
-		data, err := io.ReadAll(block.BloomData)
+		byteReader := v1.NewByteReader(readCloserToBuffer(block.IndexData), readCloserToBuffer(block.BloomData))
+
+		// Create a buffer to write data
+		buf := new(bytes.Buffer)
+		err = v1.TarGzMemory(buf, byteReader)
 		if err != nil {
-			return fmt.Errorf("error while reading object data: %w", err)
+			return fmt.Errorf("error while tarring object data: %w", err)
 		}
-		err = objectClient.PutObject(ctx, key, bytes.NewReader(data))
+
+		err = objectClient.PutObject(ctx, key, bytes.NewReader(buf.Bytes()))
 		if err != nil {
 			return fmt.Errorf("error updloading block file: %w", err)
 		}

--- a/pkg/storage/stores/shipper/bloomshipper/client.go
+++ b/pkg/storage/stores/shipper/bloomshipper/client.go
@@ -219,7 +219,7 @@ func (b *BloomClient) GetBlocks(ctx context.Context, references []BlockRef) (cha
 			// TODO: This - how best to get the working directory here
 			workingDirectoryPath := ""
 
-			//workingDirectoryPath := filepath.Join(s.config.WorkingDirectory, block.BlockPath, strconv.FormatInt(ts.UnixMilli(), 10))
+			//workingDirectoryPath := filepath.Join(b.storageConfig.BloomShipperConfig.WorkingDirectory, block.BlockPath, strconv.FormatInt(time.Now().UTC().UnixMilli(), 10))
 			err = v1.UnTarGz(workingDirectoryPath, compressedObjectReadCloser)
 			if err != nil {
 				return fmt.Errorf("error while untarring: %w", err)

--- a/pkg/storage/stores/shipper/bloomshipper/client_test.go
+++ b/pkg/storage/stores/shipper/bloomshipper/client_test.go
@@ -226,7 +226,7 @@ func Test_BloomClient_GetBlocks(t *testing.T) {
 				if !ok {
 					return
 				}
-				blockData, err := io.ReadAll(block.Data)
+				blockData, err := io.ReadAll(block.BloomData)
 				require.NoError(t, err)
 				blocks[block.BlockRef.BlockPath] = string(blockData)
 
@@ -261,7 +261,7 @@ func Test_BloomClient_PutBlocks(t *testing.T) {
 			},
 			IndexPath: uuid.New().String(),
 		},
-		Data: aws_io.ReadSeekNopCloser{ReadSeeker: bytes.NewReader([]byte(blockForFirstFolderData))},
+		BloomData: aws_io.ReadSeekNopCloser{ReadSeeker: bytes.NewReader([]byte(blockForFirstFolderData))},
 	}
 
 	blockForSecondFolderData := "data2"
@@ -278,7 +278,7 @@ func Test_BloomClient_PutBlocks(t *testing.T) {
 			},
 			IndexPath: uuid.New().String(),
 		},
-		Data: aws_io.ReadSeekNopCloser{ReadSeeker: bytes.NewReader([]byte(blockForSecondFolderData))},
+		BloomData: aws_io.ReadSeekNopCloser{ReadSeeker: bytes.NewReader([]byte(blockForSecondFolderData))},
 	}
 
 	results, err := shipper.PutBlocks(context.Background(), []Block{blockForFirstFolder, blockForSecondFolder})

--- a/pkg/storage/stores/shipper/bloomshipper/client_test.go
+++ b/pkg/storage/stores/shipper/bloomshipper/client_test.go
@@ -186,6 +186,8 @@ func Test_BloomClient_GetBlocks(t *testing.T) {
 	secondBlockData := createBlockFile(t, secondBlockFullPath)
 	require.FileExists(t, firstBlockFullPath)
 	require.FileExists(t, secondBlockFullPath)
+	rootDir := filepath.Join(fsNamedStores["folder-1"].Directory, "bloom")
+	defer os.RemoveAll(rootDir)
 
 	firstBlockRef := BlockRef{
 		Ref: Ref{
@@ -236,6 +238,7 @@ func Test_BloomClient_GetBlocks(t *testing.T) {
 			}
 		}
 	}()
+	defer os.RemoveAll("./bloom")
 
 	firstBlockActualData, exists := blocks[firstBlockRef.BlockPath]
 	require.Truef(t, exists, "data for the first block must be present in the results: %+v", blocks)

--- a/pkg/storage/stores/shipper/bloomshipper/client_test.go
+++ b/pkg/storage/stores/shipper/bloomshipper/client_test.go
@@ -1,10 +1,13 @@
 package bloomshipper
 
 import (
+	"archive/tar"
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"fmt"
+	v1 "github.com/grafana/loki/pkg/storage/bloom/v1"
 	"io"
 	"math/rand"
 	"os"
@@ -212,7 +215,7 @@ func Test_BloomClient_GetBlocks(t *testing.T) {
 	blocksToDownload := []BlockRef{firstBlockRef, secondBlockRef}
 
 	blocksCh, errorsCh := shipper.GetBlocks(context.Background(), blocksToDownload)
-	blocks := make(map[string]string)
+	blocks := make(map[string][]byte)
 	func() {
 		timout := time.After(5 * time.Second)
 		for {
@@ -228,7 +231,7 @@ func Test_BloomClient_GetBlocks(t *testing.T) {
 				}
 				blockData, err := io.ReadAll(block.BloomData)
 				require.NoError(t, err)
-				blocks[block.BlockRef.BlockPath] = string(blockData)
+				blocks[block.BlockRef.BlockPath] = blockData
 
 			}
 		}
@@ -245,9 +248,42 @@ func Test_BloomClient_GetBlocks(t *testing.T) {
 	require.Len(t, blocks, 2)
 }
 
+func extractFileFromTGZ(tarGzData []byte, targetFileName string) []byte {
+	gzReader, err := gzip.NewReader(bytes.NewReader(tarGzData))
+	if err != nil {
+		return nil
+	}
+	defer gzReader.Close()
+
+	tarReader := tar.NewReader(gzReader)
+
+	for {
+		header, err := tarReader.Next()
+
+		if err == io.EOF {
+			break
+		}
+
+		if err != nil {
+			return nil
+		}
+
+		if header.Name == targetFileName {
+			buffer := new(bytes.Buffer)
+			if _, err := io.Copy(buffer, tarReader); err != nil {
+				return nil
+			}
+			return buffer.Bytes()
+		}
+	}
+
+	return nil
+}
+
 func Test_BloomClient_PutBlocks(t *testing.T) {
 	shipper := createShipper(t)
 	blockForFirstFolderData := "data1"
+	indexForFirstFolderData := "index1"
 	blockForFirstFolder := Block{
 		BlockRef: BlockRef{
 			Ref: Ref{
@@ -262,9 +298,11 @@ func Test_BloomClient_PutBlocks(t *testing.T) {
 			IndexPath: uuid.New().String(),
 		},
 		BloomData: aws_io.ReadSeekNopCloser{ReadSeeker: bytes.NewReader([]byte(blockForFirstFolderData))},
+		IndexData: aws_io.ReadSeekNopCloser{ReadSeeker: bytes.NewReader([]byte(indexForFirstFolderData))},
 	}
 
 	blockForSecondFolderData := "data2"
+	indexForSecondFolderData := "index2"
 	blockForSecondFolder := Block{
 		BlockRef: BlockRef{
 			Ref: Ref{
@@ -279,6 +317,7 @@ func Test_BloomClient_PutBlocks(t *testing.T) {
 			IndexPath: uuid.New().String(),
 		},
 		BloomData: aws_io.ReadSeekNopCloser{ReadSeeker: bytes.NewReader([]byte(blockForSecondFolderData))},
+		IndexData: aws_io.ReadSeekNopCloser{ReadSeeker: bytes.NewReader([]byte(indexForSecondFolderData))},
 	}
 
 	results, err := shipper.PutBlocks(context.Background(), []Block{blockForFirstFolder, blockForSecondFolder})
@@ -300,7 +339,7 @@ func Test_BloomClient_PutBlocks(t *testing.T) {
 	require.FileExists(t, savedFilePath)
 	savedData, err := os.ReadFile(savedFilePath)
 	require.NoError(t, err)
-	require.Equal(t, blockForFirstFolderData, string(savedData))
+	require.Equal(t, blockForFirstFolderData, string(extractFileFromTGZ(savedData, "bloom")))
 
 	secondResultBlock := results[1]
 	path = secondResultBlock.BlockPath
@@ -319,7 +358,7 @@ func Test_BloomClient_PutBlocks(t *testing.T) {
 	require.FileExists(t, savedFilePath)
 	savedData, err = os.ReadFile(savedFilePath)
 	require.NoError(t, err)
-	require.Equal(t, blockForSecondFolderData, string(savedData))
+	require.Equal(t, blockForSecondFolderData, string(extractFileFromTGZ(savedData, "bloom")))
 }
 
 func Test_BloomClient_DeleteBlocks(t *testing.T) {
@@ -364,13 +403,19 @@ func Test_BloomClient_DeleteBlocks(t *testing.T) {
 	require.NoFileExists(t, block2Path)
 }
 
-func createBlockFile(t *testing.T, path string) string {
+func createBlockFile(t *testing.T, path string) []byte {
 	err := os.MkdirAll(path[:strings.LastIndex(path, "/")], 0755)
 	require.NoError(t, err)
-	fileContent := uuid.NewString()
-	err = os.WriteFile(path, []byte(fileContent), 0700)
+	dataContent := []byte(uuid.NewString())
+	indexContent := []byte(uuid.NewString())
+	outputFile, err := os.Create(path)
 	require.NoError(t, err)
-	return fileContent
+	byteReader := v1.NewByteReader(bytes.NewBuffer(indexContent), bytes.NewBuffer(dataContent))
+	err = v1.TarGzMemory(outputFile, byteReader)
+	require.NoError(t, err)
+	err = outputFile.Close()
+	require.NoError(t, err)
+	return dataContent
 }
 
 func Test_TablesByPeriod(t *testing.T) {

--- a/pkg/storage/stores/shipper/bloomshipper/shipper.go
+++ b/pkg/storage/stores/shipper/bloomshipper/shipper.go
@@ -207,7 +207,8 @@ func (s *Shipper) createBlockQuerier(directory string) *v1.BlockQuerier {
 }
 
 func writeDataToTempFile(workingDirectoryPath string, block *Block) (string, error) {
-	defer block.Data.Close()
+	defer block.BloomData.Close()
+	defer block.IndexData.Close()
 	archivePath := filepath.Join(workingDirectoryPath, block.BlockPath[strings.LastIndex(block.BlockPath, delimiter)+1:])
 
 	archiveFile, err := os.Create(archivePath)
@@ -215,7 +216,7 @@ func writeDataToTempFile(workingDirectoryPath string, block *Block) (string, err
 		return "", fmt.Errorf("error creating empty file to store the archiver: %w", err)
 	}
 	defer archiveFile.Close()
-	_, err = io.Copy(archiveFile, block.Data)
+	_, err = io.Copy(archiveFile, block.BloomData)
 	if err != nil {
 		return "", fmt.Errorf("error writing data to archive file: %w", err)
 	}

--- a/pkg/storage/stores/shipper/bloomshipper/shipper_test.go
+++ b/pkg/storage/stores/shipper/bloomshipper/shipper_test.go
@@ -247,6 +247,7 @@ func Test_Shipper_extractBlock(t *testing.T) {
 	block := Block{
 		BlockRef:  BlockRef{BlockPath: "first-period-19621/tenantA/metas/ff-fff-1695272400-1695276000-aaa"},
 		BloomData: blockFile,
+		IndexData: seriesFile,
 	}
 
 	actualPath, err := shipper.extractBlock(&block, ts)

--- a/pkg/storage/stores/shipper/bloomshipper/shipper_test.go
+++ b/pkg/storage/stores/shipper/bloomshipper/shipper_test.go
@@ -245,8 +245,8 @@ func Test_Shipper_extractBlock(t *testing.T) {
 	shipper := Shipper{config: config.Config{WorkingDirectory: workingDir}}
 	ts := time.Now().UTC()
 	block := Block{
-		BlockRef: BlockRef{BlockPath: "first-period-19621/tenantA/metas/ff-fff-1695272400-1695276000-aaa"},
-		Data:     blockFile,
+		BlockRef:  BlockRef{BlockPath: "first-period-19621/tenantA/metas/ff-fff-1695272400-1695276000-aaa"},
+		BloomData: blockFile,
 	}
 
 	actualPath, err := shipper.extractBlock(&block, ts)


### PR DESCRIPTION
**What this PR does / why we need it**:
Compress bloom blocks when writing to object storage, and uncompress when reading from object storage.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
