### PR TITLE
[k175] Propagate trace ID with HTTP gRPC request.

### DIFF
--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -519,6 +519,7 @@ func (t *Loki) initQuerier() (services.Service, error) {
 	internalHandler := queryrangebase.MergeMiddlewares(
 		serverutil.RecoveryMiddleware,
 		queryrange.Instrument{Metrics: t.Metrics},
+		queryrange.Tracer{},
 	).Wrap(handler)
 
 	svc, err := querier.InitWorkerService(


### PR DESCRIPTION
Backport 8d34f857bcb41120fca71948f9b7dc3504047228 from #11251

---

The changes in https://github.com/grafana/loki/pull/10688 did not propage the trace ID from the context. `Frontend.RoundTripGRPC` would inject the trace ID into the request. That's not done in `Frontend.Do`. This changes extends the `codec.EncodeRequest` to inject the trace ID there. This is more inline with other metadata.