### PR TITLE
utilities for reducing ngram allocations in token iterator construction

### DIFF
--- a/pkg/storage/bloom/v1/bloom_tokenizer_test.go
+++ b/pkg/storage/bloom/v1/bloom_tokenizer_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 
 	"github.com/grafana/loki/pkg/chunkenc"
+	"github.com/grafana/loki/pkg/logproto"
 	"github.com/grafana/loki/pkg/push"
 	"github.com/grafana/loki/pkg/storage/chunk"
 
@@ -23,6 +24,49 @@ import (
 var (
 	four = NewNGramTokenizer(4, 0)
 )
+
+func TestPrefixedKeyCreation(t *testing.T) {
+	var ones uint64 = 0xffffffffffffffff
+
+	ref := logproto.ChunkRef{
+		From:     0,
+		Through:  model.Time(int64(ones)),
+		Checksum: 0xffffffff,
+	}
+	for _, tc := range []struct {
+		desc          string
+		ngram, expLen int
+	}{
+		{
+			desc:   "0-gram",
+			ngram:  0,
+			expLen: 20,
+		},
+		{
+			desc:   "4-gram",
+			ngram:  4,
+			expLen: 20 + 4*MaxRuneLen,
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			token, prefixLn := prefixedToken(tc.ngram, ref)
+			require.Equal(t, 20, prefixLn)
+			require.Equal(t, tc.expLen, len(token))
+			// first 8 bytes should be zeros from `from`
+			for i := 0; i < 8; i++ {
+				require.Equal(t, byte(0), token[i])
+			}
+			// next 8 bytes should be ones from `through`
+			for i := 8; i < 16; i++ {
+				require.Equal(t, byte(255), token[i])
+			}
+			// next 4 bytes should be ones from `checksum`
+			for i := 16; i < 20; i++ {
+				require.Equal(t, byte(255), token[i])
+			}
+		})
+	}
+}
 
 func TestSetLineTokenizer(t *testing.T) {
 	bt, _ := NewBloomTokenizer(prometheus.DefaultRegisterer)

--- a/pkg/storage/bloom/v1/tokenizer.go
+++ b/pkg/storage/bloom/v1/tokenizer.go
@@ -4,6 +4,10 @@ import (
 	"unicode/utf8"
 )
 
+const (
+	MaxRuneLen = 4
+)
+
 func reassemble(buf []rune, ln, pos int, result []byte) []byte {
 	result = result[:0] // Reset the result slice
 	for i := 0; i < ln; i++ {
@@ -29,7 +33,7 @@ func NewNGramTokenizer(n, skip int) *NGramTokenizer {
 		N:      n,
 		Skip:   skip,
 		buffer: make([]rune, n+skip),
-		res:    make([]byte, 0, n*4), // maximum 4 bytes per rune
+		res:    make([]byte, 0, n*MaxRuneLen), // maximum 4 bytes per rune
 	}
 
 	return t
@@ -89,20 +93,20 @@ func (t *NGramTokenIter) Err() error {
 }
 
 type PrefixedTokenIter struct {
-	prefix    []byte
+	buf       []byte
 	prefixLen int
 
 	NGramTokenIter
 }
 
 func (t *PrefixedTokenIter) At() []byte {
-	return append(t.prefix[:t.prefixLen], t.NGramTokenIter.At()...)
+	return append(t.buf[:t.prefixLen], t.NGramTokenIter.At()...)
 }
 
-func NewPrefixedTokenIter(prefix []byte, iter NGramTokenIter) *PrefixedTokenIter {
+func NewPrefixedTokenIter(buf []byte, prefixLn int, iter NGramTokenIter) *PrefixedTokenIter {
 	return &PrefixedTokenIter{
-		prefix:         prefix,
-		prefixLen:      len(prefix),
+		buf:            buf,
+		prefixLen:      prefixLn,
 		NGramTokenIter: iter,
 	}
 }

--- a/pkg/storage/bloom/v1/tokenizer_test.go
+++ b/pkg/storage/bloom/v1/tokenizer_test.go
@@ -3,8 +3,9 @@ package v1
 import (
 	"testing"
 
-	"github.com/grafana/loki/pkg/logproto"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/pkg/logproto"
 )
 
 const BigFile = "../../../logql/sketch/testdata/war_peace.txt"

--- a/pkg/storage/bloom/v1/tokenizer_test.go
+++ b/pkg/storage/bloom/v1/tokenizer_test.go
@@ -3,6 +3,7 @@ package v1
 import (
 	"testing"
 
+	"github.com/grafana/loki/pkg/logproto"
 	"github.com/stretchr/testify/require"
 )
 
@@ -101,7 +102,7 @@ func TestPrefixedIterator(t *testing.T) {
 	} {
 		prefix := []byte("0123")
 		t.Run(tc.desc, func(t *testing.T) {
-			itr := NewPrefixedTokenIter(prefix, three.Tokens(tc.input))
+			itr := NewPrefixedTokenIter(prefix, len(prefix), three.Tokens(tc.input))
 			for _, exp := range tc.exp {
 				require.True(t, itr.Next())
 				require.Equal(t, exp, string(itr.At()))
@@ -126,9 +127,6 @@ func BenchmarkTokens(b *testing.B) {
 	var (
 		v2Three      = NewNGramTokenizer(3, 0)
 		v2ThreeSkip1 = NewNGramTokenizer(3, 1)
-
-		// fp + from + through + checksum
-		chunkPrefixLen = 8 + 8 + 8 + 4
 	)
 
 	type impl struct {
@@ -174,9 +172,9 @@ func BenchmarkTokens(b *testing.B) {
 				{
 					desc: "v2",
 					f: func() func() {
-						prefix := make([]byte, chunkPrefixLen, 512)
+						buf, prefixLn := prefixedToken(v2Three.N, logproto.ChunkRef{})
 						return func() {
-							itr := NewPrefixedTokenIter(prefix, v2Three.Tokens(lorem))
+							itr := NewPrefixedTokenIter(buf, prefixLn, v2Three.Tokens(lorem))
 							for itr.Next() {
 								_ = itr.At()
 							}
@@ -191,9 +189,9 @@ func BenchmarkTokens(b *testing.B) {
 				{
 					desc: "v2",
 					f: func() func() {
-						prefix := make([]byte, chunkPrefixLen, 512)
+						buf, prefixLn := prefixedToken(v2Three.N, logproto.ChunkRef{})
 						return func() {
-							itr := NewPrefixedTokenIter(prefix, v2ThreeSkip1.Tokens(lorem))
+							itr := NewPrefixedTokenIter(buf, prefixLn, v2ThreeSkip1.Tokens(lorem))
 							for itr.Next() {
 								_ = itr.At()
 							}


### PR DESCRIPTION
Previously, the `calculatePrefix` function was used to generate the token buffer used, but this wouldn't necessarily have enough space to append the ngram afterwards without reallocating+copying the token buffer. This PR ensures we allocate enough space for both prefix and ngram in the token buffer.