### PR TITLE
Fix bloom compactor startup when using unsupported index type

### DIFF
--- a/pkg/bloomcompactor/bloomcompactor.go
+++ b/pkg/bloomcompactor/bloomcompactor.go
@@ -119,14 +119,8 @@ func New(
 	c.storeClients = make(map[config.DayTime]storeClient)
 
 	for i, periodicConfig := range schemaConfig.Configs {
-		var indexStorageCfg indexshipper.Config
-		switch periodicConfig.IndexType {
-		case config.TSDBType:
-			indexStorageCfg = storageCfg.TSDBShipperConfig
-		case config.BoltDBShipperType:
-			indexStorageCfg = storageCfg.BoltDBShipperConfig.Config
-		default:
-			level.Warn(c.logger).Log("msg", "skipping period because index type is unsupported")
+		if periodicConfig.IndexType != config.TSDBType {
+			level.Warn(c.logger).Log("msg", "skipping schema period because index type is not supported", "index_type", periodicConfig.IndexType, "period", periodicConfig.From)
 			continue
 		}
 
@@ -143,7 +137,7 @@ func New(
 
 		indexShipper, err := indexshipper.NewIndexShipper(
 			periodicConfig.IndexTables.PathPrefix,
-			indexStorageCfg,
+			storageCfg.TSDBShipperConfig,
 			objectClient,
 			limits,
 			nil,

--- a/pkg/bloomcompactor/bloomcompactor.go
+++ b/pkg/bloomcompactor/bloomcompactor.go
@@ -340,8 +340,8 @@ func (c *Compactor) compactUsers(ctx context.Context, logger log.Logger, sc stor
 	// TODO: Delete local files for unowned tenants, if there are any.
 }
 
-func (c *Compactor) compactTenant(ctx context.Context, sc storeClient, tableName string, tenant string) error {
-	level.Info(c.logger).Log("msg", "starting compaction of tenant")
+func (c *Compactor) compactTenant(ctx context.Context, logger log.Logger, sc storeClient, tableName string, tenant string) error {
+	level.Info(logger).Log("msg", "starting compaction of tenant")
 
 	// Ensure the context has not been canceled (ie. compactor shutdown has been triggered).
 	if err := ctx.Err(); err != nil {
@@ -432,7 +432,7 @@ func (c *Compactor) compactTenantWithRetries(ctx context.Context, logger log.Log
 		c.cfg.RetryMaxBackoff,
 		c.cfg.CompactionRetries,
 		func(ctx context.Context) error {
-			return c.compactTenant(ctx, sc, tableName, tenant)
+			return c.compactTenant(ctx, logger, sc, tableName, tenant)
 		},
 	)
 }

--- a/pkg/bloomcompactor/bloomcompactor.go
+++ b/pkg/bloomcompactor/bloomcompactor.go
@@ -364,7 +364,7 @@ func (c *Compactor) compactTenant(ctx context.Context, logger log.Logger, sc sto
 			0, math.MaxInt64, // TODO: Replace with MaxLookBackPeriod
 			func(labels labels.Labels, fingerprint model.Fingerprint, chksMetas []tsdbindex.ChunkMeta) {
 				job := NewJob(tenant, tableName, idx.Path(), fingerprint, labels, chksMetas)
-				jobLogger := log.With(c.logger, "job", job.String())
+				jobLogger := log.With(logger, "job", job.String())
 
 				ownsJob, err := c.sharding.OwnsJob(job)
 				if err != nil {

--- a/pkg/bloomcompactor/sharding.go
+++ b/pkg/bloomcompactor/sharding.go
@@ -41,3 +41,18 @@ func (s *ShuffleShardingStrategy) OwnsJob(job Job) (bool, error) {
 	fpSharding := util_ring.NewFingerprintShuffleSharding(tenantRing, s.ringLifeCycler, RingOp)
 	return fpSharding.OwnsFingerprint(uint64(job.Fingerprint()))
 }
+
+// NoopStrategy is an implementation of the ShardingStrategy that does not
+// filter anything.
+type NoopStrategy struct {
+	util_ring.NoopStrategy
+}
+
+// OwnsJob implements TenantShuffleSharding.
+func (s *NoopStrategy) OwnsJob(_ Job) (bool, error) {
+	return true, nil
+}
+
+func NewNoopStrategy() *NoopStrategy {
+	return &NoopStrategy{NoopStrategy: util_ring.NoopStrategy{}}
+}

--- a/pkg/util/ring/sharding.go
+++ b/pkg/util/ring/sharding.go
@@ -83,3 +83,22 @@ func (s *FingerprintShuffleSharding) OwnsFingerprint(fp uint64) (bool, error) {
 
 	return rs.Includes(s.ringLifeCycler.GetInstanceAddr()), nil
 }
+
+// NoopStrategy is an implementation of the ShardingStrategy that does not
+// shard anything.
+type NoopStrategy struct{}
+
+// OwnsTenant implements TenantShuffleSharding.
+func (s *NoopStrategy) OwnsTenant(_ string) bool {
+	return false
+}
+
+// GetTenantSubRing implements TenantShuffleSharding.
+func (s *NoopStrategy) GetTenantSubRing(_ string) ring.ReadRing {
+	return nil
+}
+
+// OwnsFingerprint implements FingerprintSharding.
+func (s *NoopStrategy) OwnsFingerprint(_ uint64) (bool, error) {
+	return false, nil
+}


### PR DESCRIPTION
This PR fixes the check in the bloom compactor startup to ignore all other index types than TSDB.

When updating an existing Loki installation that uses BoltDB Shipper in the schema config, you get the following error:

```
invalid tsdb path:
/data/boltdb-shipper-cache/XXXXXXXXX_index_19682/write-0-1639160260677624223-1700595900
││ create index shipper
││ github.com/grafana/loki/pkg/bloomcompactor.New
││     /src/loki/pkg/bloomcompactor/bloomcompactor.go:159
││ github.com/grafana/loki/pkg/loki.(*Loki).initBloomCompactor
││     /src/loki/pkg/loki/modules.go:1406
││ github.com/grafana/dskit/modules.(*Manager).initModule
││     /src/loki/vendor/github.com/grafana/dskit/modules/modules.go:136
││ github.com/grafana/dskit/modules.(*Manager).InitModuleServices
││     /src/loki/vendor/github.com/grafana/dskit/modules/modules.go:108
││ github.com/grafana/loki/pkg/loki.(*Loki).Run
```
