### PR TITLE
Per-tenant n-gram length and skip factor, and bloom false-positive rate

### DIFF
--- a/pkg/bloomcompactor/config.go
+++ b/pkg/bloomcompactor/config.go
@@ -44,4 +44,6 @@ type Limits interface {
 	BloomCompactorMaxTableAge(tenantID string) time.Duration
 	BloomCompactorMinTableAge(tenantID string) time.Duration
 	BloomCompactorEnabled(tenantID string) bool
+	BloomNGramLength(tenantID string) int
+	BloomNGramSkip(tenantID string) int
 }

--- a/pkg/bloomcompactor/config.go
+++ b/pkg/bloomcompactor/config.go
@@ -46,4 +46,5 @@ type Limits interface {
 	BloomCompactorEnabled(tenantID string) bool
 	BloomNGramLength(tenantID string) int
 	BloomNGramSkip(tenantID string) int
+	BloomFalsePositiveRate(tenantID string) float64
 }

--- a/pkg/bloomcompactor/sharding_test.go
+++ b/pkg/bloomcompactor/sharding_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/loki/pkg/storage/stores/shipper/indexshipper/downloads"
 	util_log "github.com/grafana/loki/pkg/util/log"
 	lokiring "github.com/grafana/loki/pkg/util/ring"
 	"github.com/grafana/loki/pkg/validation"
@@ -44,7 +43,7 @@ func TestShuffleSharding(t *testing.T) {
 		require.NoError(t, ringManager.StartAsync(context.Background()))
 
 		sharding := NewShuffleShardingStrategy(ringManager.Ring, ringManager.RingLifecycler, mockLimits{
-			Limits:                  overrides,
+			Overrides:               overrides,
 			bloomCompactorShardSize: shardSize,
 		})
 
@@ -128,22 +127,10 @@ func TestShuffleSharding(t *testing.T) {
 }
 
 type mockLimits struct {
-	downloads.Limits
+	*validation.Overrides
 	bloomCompactorShardSize int
 }
 
 func (m mockLimits) BloomCompactorShardSize(_ string) int {
 	return m.bloomCompactorShardSize
-}
-
-func (m mockLimits) BloomCompactorMaxTableAge(_ string) time.Duration {
-	return 0
-}
-
-func (m mockLimits) BloomCompactorMinTableAge(_ string) time.Duration {
-	return 0
-}
-
-func (m mockLimits) BloomCompactorEnabled(_ string) bool {
-	return false
 }

--- a/pkg/storage/bloom/v1/bloom_tokenizer.go
+++ b/pkg/storage/bloom/v1/bloom_tokenizer.go
@@ -33,20 +33,18 @@ type BloomTokenizer struct {
 }
 
 const CacheSize = 150000
-const DefaultNGramLength = 4
-const DefaultNGramSkip = 0
 
 // NewBloomTokenizer returns a new instance of the Bloom Tokenizer.
 // Warning: the tokens returned use the same byte slice to reduce allocations. This has two consequences:
 // 1) The token slices generated must not be mutated externally
 // 2) The token slice must not be used after the next call to `Tokens()` as it will repopulate the slice.
 // 2) This is not thread safe.
-func NewBloomTokenizer(reg prometheus.Registerer) (*BloomTokenizer, error) {
+func NewBloomTokenizer(reg prometheus.Registerer, NGramLength, NGramSkip int) (*BloomTokenizer, error) {
 	t := &BloomTokenizer{
 		metrics: newMetrics(reg),
 	}
 	t.cache = make(map[string]interface{}, CacheSize)
-	t.lineTokenizer = NewNGramTokenizer(DefaultNGramLength, DefaultNGramSkip) // default to 4-grams, no skip
+	t.lineTokenizer = NewNGramTokenizer(NGramLength, NGramSkip)
 
 	level.Info(util_log.Logger).Log("bloom tokenizer created")
 
@@ -55,6 +53,14 @@ func NewBloomTokenizer(reg prometheus.Registerer) (*BloomTokenizer, error) {
 
 func (bt *BloomTokenizer) SetLineTokenizer(t *NGramTokenizer) {
 	bt.lineTokenizer = t
+}
+
+func (bt *BloomTokenizer) GetNGramLength() uint64 {
+	return uint64(bt.lineTokenizer.N)
+}
+
+func (bt *BloomTokenizer) GetNGramSkip() uint64 {
+	return uint64(bt.lineTokenizer.Skip)
 }
 
 // TODO: Something real here with metrics

--- a/pkg/storage/bloom/v1/bloom_tokenizer_test.go
+++ b/pkg/storage/bloom/v1/bloom_tokenizer_test.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"fmt"
+	"testing"
 	"time"
 
 	"github.com/prometheus/prometheus/model/labels"
@@ -9,8 +10,6 @@ import (
 	"github.com/grafana/loki/pkg/chunkenc"
 	"github.com/grafana/loki/pkg/push"
 	"github.com/grafana/loki/pkg/storage/chunk"
-
-	"testing"
 
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
@@ -20,12 +19,17 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+const (
+	DefaultNGramLength = 4
+	DefaultNGramSkip   = 0
+)
+
 var (
 	four = NewNGramTokenizer(4, 0)
 )
 
 func TestSetLineTokenizer(t *testing.T) {
-	bt, _ := NewBloomTokenizer(prometheus.DefaultRegisterer)
+	bt, _ := NewBloomTokenizer(prometheus.DefaultRegisterer, DefaultNGramLength, DefaultNGramSkip)
 
 	// Validate defaults
 	require.Equal(t, bt.lineTokenizer.N, DefaultNGramLength)
@@ -39,7 +43,7 @@ func TestSetLineTokenizer(t *testing.T) {
 
 func TestPopulateSeriesWithBloom(t *testing.T) {
 	var testLine = "this is a log line"
-	bt, _ := NewBloomTokenizer(prometheus.DefaultRegisterer)
+	bt, _ := NewBloomTokenizer(prometheus.DefaultRegisterer, DefaultNGramLength, DefaultNGramSkip)
 
 	sbf := filter.NewScalableBloomFilter(1024, 0.01, 0.8)
 	var lbsList []labels.Labels
@@ -84,7 +88,7 @@ func TestPopulateSeriesWithBloom(t *testing.T) {
 }
 
 func BenchmarkMapClear(b *testing.B) {
-	bt, _ := NewBloomTokenizer(prometheus.DefaultRegisterer)
+	bt, _ := NewBloomTokenizer(prometheus.DefaultRegisterer, DefaultNGramLength, DefaultNGramSkip)
 	for i := 0; i < b.N; i++ {
 		for k := 0; k < CacheSize; k++ {
 			bt.cache[fmt.Sprint(k)] = k
@@ -95,7 +99,7 @@ func BenchmarkMapClear(b *testing.B) {
 }
 
 func BenchmarkNewMap(b *testing.B) {
-	bt, _ := NewBloomTokenizer(prometheus.DefaultRegisterer)
+	bt, _ := NewBloomTokenizer(prometheus.DefaultRegisterer, DefaultNGramLength, DefaultNGramSkip)
 	for i := 0; i < b.N; i++ {
 		for k := 0; k < CacheSize; k++ {
 			bt.cache[fmt.Sprint(k)] = k

--- a/pkg/storage/bloom/v1/builder.go
+++ b/pkg/storage/bloom/v1/builder.go
@@ -30,10 +30,12 @@ type BlockBuilder struct {
 	blooms *BloomBlockBuilder
 }
 
-func NewBlockOptions() BlockOptions {
+func NewBlockOptions(NGramLength, NGramSkip uint64) BlockOptions {
 	return BlockOptions{
 		schema: Schema{
-			version: byte(1),
+			version:     byte(1),
+			NGramLength: NGramLength,
+			NGramSkip:   NGramSkip,
 		},
 		SeriesPageSize: 100,
 		BloomPageSize:  10 << 10, // 0.01MB

--- a/pkg/storage/bloom/v1/builder_test.go
+++ b/pkg/storage/bloom/v1/builder_test.go
@@ -90,8 +90,10 @@ func TestBlockBuilderRoundTrip(t *testing.T) {
 			builder, err := NewBlockBuilder(
 				BlockOptions{
 					schema: Schema{
-						version:  DefaultSchemaVersion,
-						encoding: chunkenc.EncSnappy,
+						version:     DefaultSchemaVersion,
+						encoding:    chunkenc.EncSnappy,
+						NGramLength: 10,
+						NGramSkip:   2,
 					},
 					SeriesPageSize: 100,
 					BloomPageSize:  10 << 10,
@@ -105,6 +107,13 @@ func TestBlockBuilderRoundTrip(t *testing.T) {
 			require.Nil(t, err)
 			block := NewBlock(tc.reader)
 			querier := NewBlockQuerier(block)
+
+			err = block.LoadHeaders()
+			require.Nil(t, err)
+			require.Equal(t, block.blooms.schema.version, DefaultSchemaVersion)
+			require.Equal(t, block.blooms.schema.encoding, chunkenc.EncSnappy)
+			require.Equal(t, block.blooms.schema.NGramLength, uint64(10))
+			require.Equal(t, block.blooms.schema.NGramSkip, uint64(2))
 
 			for i := 0; i < len(data); i++ {
 				require.Equal(t, true, querier.Next(), "on iteration %d with error %v", i, querier.Err())

--- a/pkg/storage/bloom/v1/index.go
+++ b/pkg/storage/bloom/v1/index.go
@@ -12,14 +12,15 @@ import (
 )
 
 type Schema struct {
-	version  byte
-	encoding chunkenc.Encoding
+	version                byte
+	encoding               chunkenc.Encoding
+	NGramLength, NGramSkip uint64
 }
 
 // byte length
 func (s Schema) Len() int {
-	// magic number + version + encoding
-	return 4 + 1 + 1
+	// magic number + version + encoding + ngram length + ngram skip
+	return 4 + 1 + 1 + 8 + 8
 }
 
 func (s *Schema) DecompressorPool() chunkenc.ReaderPool {
@@ -35,6 +36,9 @@ func (s *Schema) Encode(enc *encoding.Encbuf) {
 	enc.PutBE32(magicNumber)
 	enc.PutByte(s.version)
 	enc.PutByte(byte(s.encoding))
+	enc.PutBE64(s.NGramLength)
+	enc.PutBE64(s.NGramSkip)
+
 }
 
 func (s *Schema) DecodeFrom(r io.ReadSeeker) error {
@@ -63,6 +67,9 @@ func (s *Schema) Decode(dec *encoding.Decbuf) error {
 	if _, err := chunkenc.ParseEncoding(s.encoding.String()); err != nil {
 		return errors.Wrap(err, "parsing encoding")
 	}
+
+	s.NGramLength = dec.Be64()
+	s.NGramSkip = dec.Be64()
 
 	return dec.Err()
 }

--- a/pkg/storage/bloom/v1/reader.go
+++ b/pkg/storage/bloom/v1/reader.go
@@ -33,8 +33,9 @@ func (r *ByteReader) Blooms() (io.ReadSeeker, error) {
 
 // File reader
 type DirectoryBlockReader struct {
-	dir           string
-	blooms, index *os.File
+	dir                    string
+	nGramLength, nGramSkip uint64
+	blooms, index          *os.File
 
 	initialized bool
 }

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -188,6 +188,7 @@ type Limits struct {
 	BloomCompactorEnabled     bool          `yaml:"bloom_compactor_enable_compaction" json:"bloom_compactor_enable_compaction"`
 	BloomNGramLength          int           `yaml:"bloom_ngram_length" json:"bloom_ngram_length"`
 	BloomNGramSkip            int           `yaml:"bloom_ngram_skip" json:"bloom_ngram_skip"`
+	BloomFalsePositiveRate    float64       `yaml:"bloom_false_positive_rate" json:"bloom_false_positive_rate"`
 
 	AllowStructuredMetadata           bool             `yaml:"allow_structured_metadata,omitempty" json:"allow_structured_metadata,omitempty" doc:"description=Allow user to send structured metadata in push payload."`
 	MaxStructuredMetadataSize         flagext.ByteSize `yaml:"max_structured_metadata_size" json:"max_structured_metadata_size" doc:"description=Maximum size accepted for structured metadata per log line."`
@@ -307,6 +308,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&l.BloomCompactorEnabled, "bloom-compactor.enable-compaction", false, "Whether to compact chunks into bloom filters.")
 	f.IntVar(&l.BloomNGramLength, "bloom-compactor.ngram-length", 4, "Length of the n-grams created when computing blooms from log lines.")
 	f.IntVar(&l.BloomNGramSkip, "bloom-compactor.ngram-skip", 0, "Skip factor for the n-grams created when computing blooms from log lines.")
+	f.Float64Var(&l.BloomFalsePositiveRate, "bloom-compactor.false-positive-rate", 0.01, "Scalable Bloom Filter desired false-positive rate.")
 
 	l.ShardStreams = &shardstreams.Config{}
 	l.ShardStreams.RegisterFlagsWithPrefix("shard-streams", f)
@@ -812,6 +814,10 @@ func (o *Overrides) BloomNGramLength(userID string) int {
 
 func (o *Overrides) BloomNGramSkip(userID string) int {
 	return o.getOverridesForUser(userID).BloomNGramSkip
+}
+
+func (o *Overrides) BloomFalsePositiveRate(userID string) float64 {
+	return o.getOverridesForUser(userID).BloomFalsePositiveRate
 }
 
 func (o *Overrides) AllowStructuredMetadata(userID string) bool {

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -186,6 +186,8 @@ type Limits struct {
 	BloomCompactorMaxTableAge time.Duration `yaml:"bloom_compactor_max_table_age" json:"bloom_compactor_max_table_age"`
 	BloomCompactorMinTableAge time.Duration `yaml:"bloom_compactor_min_table_age" json:"bloom_compactor_min_table_age"`
 	BloomCompactorEnabled     bool          `yaml:"bloom_compactor_enable_compaction" json:"bloom_compactor_enable_compaction"`
+	BloomNGramLength          int           `yaml:"bloom_ngram_length" json:"bloom_ngram_length"`
+	BloomNGramSkip            int           `yaml:"bloom_ngram_skip" json:"bloom_ngram_skip"`
 
 	AllowStructuredMetadata           bool             `yaml:"allow_structured_metadata,omitempty" json:"allow_structured_metadata,omitempty" doc:"description=Allow user to send structured metadata in push payload."`
 	MaxStructuredMetadataSize         flagext.ByteSize `yaml:"max_structured_metadata_size" json:"max_structured_metadata_size" doc:"description=Maximum size accepted for structured metadata per log line."`
@@ -303,6 +305,8 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.DurationVar(&l.BloomCompactorMaxTableAge, "bloom-compactor.max-table-age", 7*24*time.Hour, "The maximum age of a table before it is compacted. Do not compact tables older than the the configured time. Default to 7 days. 0s means no limit.")
 	f.DurationVar(&l.BloomCompactorMinTableAge, "bloom-compactor.min-table-age", 1*time.Hour, "The minimum age of a table before it is compacted. Do not compact tables newer than the the configured time. Default to 1 hour. 0s means no limit. This is useful to avoid compacting tables that will be updated with out-of-order writes.")
 	f.BoolVar(&l.BloomCompactorEnabled, "bloom-compactor.enable-compaction", false, "Whether to compact chunks into bloom filters.")
+	f.IntVar(&l.BloomNGramLength, "bloom-compactor.ngram-length", 4, "Length of the n-grams created when computing blooms from log lines.")
+	f.IntVar(&l.BloomNGramSkip, "bloom-compactor.ngram-skip", 0, "Skip factor for the n-grams created when computing blooms from log lines.")
 
 	l.ShardStreams = &shardstreams.Config{}
 	l.ShardStreams.RegisterFlagsWithPrefix("shard-streams", f)
@@ -800,6 +804,14 @@ func (o *Overrides) BloomCompactorMinTableAge(userID string) time.Duration {
 
 func (o *Overrides) BloomCompactorEnabled(userID string) bool {
 	return o.getOverridesForUser(userID).BloomCompactorEnabled
+}
+
+func (o *Overrides) BloomNGramLength(userID string) int {
+	return o.getOverridesForUser(userID).BloomNGramLength
+}
+
+func (o *Overrides) BloomNGramSkip(userID string) int {
+	return o.getOverridesForUser(userID).BloomNGramSkip
 }
 
 func (o *Overrides) AllowStructuredMetadata(userID string) bool {

--- a/tools/tsdb/bloom-tester/lib.go
+++ b/tools/tsdb/bloom-tester/lib.go
@@ -36,6 +36,11 @@ import (
 	"github.com/grafana/loki/tools/tsdb/helpers"
 )
 
+const (
+	DefaultNGramLength = 4
+	DefaultNGramSkip   = 0
+)
+
 func execute() {
 	conf, svc, bucket, err := helpers.Setup()
 	helpers.ExitErr("setting up", err)
@@ -259,9 +264,9 @@ func analyze(metrics *Metrics, sampler Sampler, indexShipper indexshipper.IndexS
 	level.Info(util_log.Logger).Log("msg", "starting analyze()", "tester", testerNumber, "total", numTesters)
 
 	var n int // count iterated series
-	//pool := newPool(runtime.NumCPU())
-	//pool := newPool(1)
-	bloomTokenizer, _ := bt.NewBloomTokenizer(prometheus.DefaultRegisterer)
+	// pool := newPool(runtime.NumCPU())
+	// pool := newPool(1)
+	bloomTokenizer, _ := bt.NewBloomTokenizer(prometheus.DefaultRegisterer, DefaultNGramLength, DefaultNGramSkip)
 	for _, tenant := range tenants {
 		level.Info(util_log.Logger).Log("Analyzing tenant", tenant, "table", tableName)
 		err := indexShipper.ForEach(

--- a/tools/tsdb/bloom-tester/readlib.go
+++ b/tools/tsdb/bloom-tester/readlib.go
@@ -118,14 +118,14 @@ func analyzeRead(metrics *Metrics, sampler Sampler, shipper indexshipper.IndexSh
 	}
 	level.Info(util_log.Logger).Log("msg", "starting analyze()", "tester", testerNumber, "total", numTesters)
 
-	//var n int // count iterated series
-	//reportEvery := 10 // report every n chunks
-	//pool := newPool(runtime.NumCPU())
-	//pool := newPool(16)
-	//searchString := os.Getenv("SEARCH_STRING")
-	//147854,148226,145541,145603,147159,147836,145551,145599,147393,147841,145265,145620,146181,147225,147167,146131,146189,146739,147510,145572,146710,148031,29,146205,147175,146984,147345
-	//mytenants := []string{"29"}
-	bloomTokenizer, _ := bt.NewBloomTokenizer(prometheus.DefaultRegisterer)
+	// var n int // count iterated series
+	// reportEvery := 10 // report every n chunks
+	// pool := newPool(runtime.NumCPU())
+	// pool := newPool(16)
+	// searchString := os.Getenv("SEARCH_STRING")
+	// 147854,148226,145541,145603,147159,147836,145551,145599,147393,147841,145265,145620,146181,147225,147167,146131,146189,146739,147510,145572,146710,148031,29,146205,147175,146984,147345
+	// mytenants := []string{"29"}
+	bloomTokenizer, _ := bt.NewBloomTokenizer(prometheus.DefaultRegisterer, DefaultNGramLength, DefaultNGramSkip)
 	for _, tenant := range tenants {
 		level.Info(util_log.Logger).Log("Analyzing tenant", tenant, "table", tableName)
 		err := shipper.ForEach(


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds three per tenant configs:
- `bloom_ngram_length`: Configures the n-gram length.
- `bloom_ngram_skip`: Configures the n-gram skip factor.
- `bloom_false_positive_rate`: Configures the target false-positive rate of the scalable bloom filters.

Since the n-gram length and skip factor are now configurable, these values are written into the block metadata so queriers can use the n-gram settings used when creating the blocks to build n-grams compatible with the block.
