### PR TITLE
Set query plan when copying LokiRequest

### DIFF
--- a/pkg/querier/queryrange/split_by_interval.go
+++ b/pkg/querier/queryrange/split_by_interval.go
@@ -259,6 +259,7 @@ func splitByTime(req queryrangebase.Request, interval time.Duration) ([]queryran
 				Path:      r.Path,
 				StartTs:   start,
 				EndTs:     end,
+				Plan:      r.Plan,
 			})
 		})
 	case *LokiSeriesRequest:

--- a/pkg/querier/queryrange/split_by_interval_test.go
+++ b/pkg/querier/queryrange/split_by_interval_test.go
@@ -17,7 +17,9 @@ import (
 
 	"github.com/grafana/loki/pkg/loghttp"
 	"github.com/grafana/loki/pkg/logproto"
+	"github.com/grafana/loki/pkg/logql/syntax"
 	"github.com/grafana/loki/pkg/logqlmodel/stats"
+	"github.com/grafana/loki/pkg/querier/plan"
 	"github.com/grafana/loki/pkg/querier/queryrange/queryrangebase"
 	"github.com/grafana/loki/pkg/storage/config"
 )
@@ -57,25 +59,31 @@ var testSchemasTSDB = func() []config.PeriodConfig {
 func Test_splitQuery(t *testing.T) {
 	buildLokiRequest := func(start, end time.Time) queryrangebase.Request {
 		return &LokiRequest{
-			Query:     "foo",
+			Query:     `{app="foo"}`,
 			Limit:     1,
 			Step:      2,
 			StartTs:   start,
 			EndTs:     end,
 			Direction: logproto.BACKWARD,
 			Path:      "/path",
+			Plan: &plan.QueryPlan{
+				AST: syntax.MustParseExpr(`{app="foo"}`),
+			},
 		}
 	}
 
 	buildLokiRequestWithInterval := func(start, end time.Time) queryrangebase.Request {
 		return &LokiRequest{
-			Query:     "foo",
+			Query:     `{app="foo"}`,
 			Limit:     1,
 			Interval:  2,
 			StartTs:   start,
 			EndTs:     end,
 			Direction: logproto.BACKWARD,
 			Path:      "/path",
+			Plan: &plan.QueryPlan{
+				AST: syntax.MustParseExpr(`{app="foo"}`),
+			},
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The recent change https://github.com/grafana/loki/pull/11246 requires that `LokiRequest.Plan` is always set.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
