### PR TITLE
Bloom Compactor: Use distributor's RejectOldSamplesMaxAge to filter newer chunks

### DIFF
--- a/pkg/bloomcompactor/TODO.md
+++ b/pkg/bloomcompactor/TODO.md
@@ -1,4 +1,3 @@
 * Adding falsePosRate of sbf into config
 * Add per-tenant bool to enable compaction
 * Use tarGz, untarGz before uploding blocks to storage
-* Introduce back `maxLookBackPeriod` as `RejectOldSamplesMaxAge` limit in distributors

--- a/pkg/bloomcompactor/config.go
+++ b/pkg/bloomcompactor/config.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"time"
 
+	"github.com/grafana/loki/pkg/distributor"
 	"github.com/grafana/loki/pkg/storage/stores/shipper/indexshipper/downloads"
 	"github.com/grafana/loki/pkg/util/ring"
 )
@@ -39,7 +40,9 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 }
 
 type Limits interface {
-	downloads.Limits
+	downloads.Limits   // Needed to initialize the IndexShipper
+	distributor.Limits // Needed for RejectOldSamplesMaxAge
+
 	BloomCompactorShardSize(tenantID string) int
 	BloomCompactorMaxTableAge(tenantID string) time.Duration
 	BloomCompactorMinTableAge(tenantID string) time.Duration

--- a/pkg/bloomcompactor/sharding_test.go
+++ b/pkg/bloomcompactor/sharding_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/loki/pkg/storage/stores/shipper/indexshipper/downloads"
 	util_log "github.com/grafana/loki/pkg/util/log"
 	lokiring "github.com/grafana/loki/pkg/util/ring"
 	"github.com/grafana/loki/pkg/validation"
@@ -44,7 +43,7 @@ func TestShuffleSharding(t *testing.T) {
 		require.NoError(t, ringManager.StartAsync(context.Background()))
 
 		sharding := NewShuffleShardingStrategy(ringManager.Ring, ringManager.RingLifecycler, mockLimits{
-			Limits:                  overrides,
+			Overrides:               overrides,
 			bloomCompactorShardSize: shardSize,
 		})
 
@@ -128,22 +127,10 @@ func TestShuffleSharding(t *testing.T) {
 }
 
 type mockLimits struct {
-	downloads.Limits
+	*validation.Overrides
 	bloomCompactorShardSize int
 }
 
 func (m mockLimits) BloomCompactorShardSize(_ string) int {
 	return m.bloomCompactorShardSize
-}
-
-func (m mockLimits) BloomCompactorMaxTableAge(_ string) time.Duration {
-	return 0
-}
-
-func (m mockLimits) BloomCompactorMinTableAge(_ string) time.Duration {
-	return 0
-}
-
-func (m mockLimits) BloomCompactorEnabled(_ string) bool {
-	return false
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR limits the chunks that will be processed by the bloom compactor by filtering out chunks older than `RejectOldSamplesMaxAge` (aka `reject_old_samples_max_age`).



