### PR TITLE
Fix bloom compactor startup duplicate metric registration

### DIFF
--- a/pkg/bloomcompactor/bloomcompactor.go
+++ b/pkg/bloomcompactor/bloomcompactor.go
@@ -149,7 +149,7 @@ func New(
 				return tsdb.OpenShippableTSDB(p)
 			},
 			periodicConfig.GetIndexTableNumberRange(periodEndTime),
-			prometheus.WrapRegistererWithPrefix("loki_tsdb_shipper_", r),
+			prometheus.WrapRegistererWithPrefix("loki_bloom_compactor_tsdb_shipper_", r),
 			logger,
 		)
 

--- a/production/docker/config/loki.yaml
+++ b/production/docker/config/loki.yaml
@@ -97,9 +97,6 @@ limits_config:
   split_queries_by_interval: 15m
   volume_enabled: true
 
-chunk_store_config:
-  max_look_back_period: 336h
-
 table_manager:
   retention_deletes_enabled: true
   retention_period: 336h


### PR DESCRIPTION
**What this PR does / why we need it**:
Follow up from https://github.com/grafana/loki/pull/11285/, where Loki doesn't start up due to duplicate metric registration. 
```
2023-11-22 22:43:32     /src/loki/vendor/github.com/prometheus/client_golang/prometheus/promauto/auto.go:276 +0x178
2023-11-22 22:43:32 github.com/grafana/loki/pkg/storage/stores/shipper/indexshipper/downloads.newMetrics({0x2a62040, 0x4001baa660})
2023-11-22 22:43:32     /src/loki/pkg/storage/stores/shipper/indexshipper/downloads/metrics.go:21 +0xa4
2023-11-22 22:43:32 github.com/grafana/loki/pkg/storage/stores/shipper/indexshipper/downloads.NewTableManager({{0x4000cdae58, 0x18}, 0x45d964b800, 0x4e94914f0000, 0x0, {0xffff4f32e908, 0x40009c6750}}, 0x24192e0, {0x2a89f50?, 0x40004e7320}, ...)
2023-11-22 22:43:32     /src/loki/pkg/storage/stores/shipper/indexshipper/downloads/table_manager.go:92 +0xa8
2023-11-22 22:43:32 github.com/grafana/loki/pkg/storage/stores/shipper/indexshipper.(*indexShipper).init(0x4001b9a480, {0x231b106?, 0x0?}, {0x2a80bf8?, 0x40018b9340?}, {0xffff4f32e908, 0x40009c6750}, 0x0?, {0x0?, 0x0?, ...}, ...)
2023-11-22 22:43:32     /src/loki/pkg/storage/stores/shipper/indexshipper/shipper.go:190 +0x28c
2023-11-22 22:43:32 github.com/grafana/loki/pkg/storage/stores/shipper/indexshipper.NewIndexShipper({_, _}, {{0x4000685900, 0x19}, {0x4000cdae58, 0x18}, 0x4e94914f0000, 0x45d964b800, 0x0, {{0x2313cd3, ...}, ...}, ...}, ...)
2023-11-22 22:43:32     /src/loki/pkg/storage/stores/shipper/indexshipper/shipper.go:155 +0x194
2023-11-22 22:43:32 github.com/grafana/loki/pkg/bloomcompactor.New({{{{0x232535d, 0xa}, {0x232789e, 0xb}, {{...}, {...}, {...}, _}, {_, _}}, ...}, ...}, ...)
2023-11-22 22:43:32     /src/loki/pkg/bloomcompactor/bloomcompactor.go:142 +0x6d4
2023-11-22 22:43:32 github.com/grafana/loki/pkg/loki.(*Loki).initBloomCompactor(0x40006dc000)
2023-11-22 22:43:32     /src/loki/pkg/loki/modules.go:1404 +0x358
2023-11-22 22:43:32 github.com/grafana/dskit/modules.(*Manager).initModule(0x4000b48318, {0xffffe15d6f7d, 0x4}, 0x403b88?, 0x2313cb3?)
2023-11-22 22:43:32     /src/loki/vendor/github.com/grafana/dskit/modules/modules.go:136 +0x1a4
2023-11-22 22:43:32 github.com/grafana/dskit/modules.(*Manager).InitModuleServices(0x4000b1a718?, {0x400071c520, 0x1, 0x4000946ec0?})
2023-11-22 22:43:32     /src/loki/vendor/github.com/grafana/dskit/modules/modules.go:108 +0xb4
2023-11-22 22:43:32 github.com/grafana/loki/pkg/loki.(*Loki).Run(0x40006dc000, {0x0?, {0x4?, 0x3?, 0x3ff40c0?}})
2023-11-22 22:43:32     /src/loki/pkg/loki/loki.go:416 +0x74
2023-11-22 22:43:32 main.main()
2023-11-22 22:43:32     /src/loki/cmd/loki/main.go:114 +0xcdc
2023-11-22 22:43:33 panic: a previously registered descriptor with the same fully-qualified name as Desc{fqName: "loki_tsdb_shipper_query_time_table_download_duration_seconds", help: "Time (in seconds) spent in downloading of files per table at query time", constLabels: {}, variableLabels: [{table <nil>}]} has different label names or a different help string
```

Plus a sneaky fix to our loki config, removing a deprecated field. See deprecation clean up here: https://github.com/grafana/loki/pull/11038/files

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
