### PR TITLE
Helm: remove ruler.enabled condition in networkpolicies which lead to linting errors

### DIFF
--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -13,6 +13,10 @@ Entries should include a reference to the pull request that introduced the chang
 
 [//]: # (<AUTOMATED_UPDATES_LOCATOR> : do not remove this line. This locator is used by the CI pipeline to automatically create a changelog entry for each new Loki release. Add other chart versions and respective changelog entries bellow this line.)
 
+## 5.38.1
+
+- [BUGFIX] Remove ruler enabled condition in networkpolicies.
+
 ## 5.38.0
 
 - [CHANGE] Changed MinIO Helm Chart version to 4.0.15

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -3,7 +3,7 @@ name: loki
 description: Helm chart for Grafana Loki in simple, scalable mode
 type: application
 appVersion: 2.9.2
-version: 5.38.0
+version: 5.38.1
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/production/helm/loki/templates/networkpolicy.yaml
+++ b/production/helm/loki/templates/networkpolicy.yaml
@@ -112,7 +112,6 @@ spec:
       {{- end }}
     {{- end }}
 
-{{- if .Values.ruler.enabled }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -126,7 +125,7 @@ spec:
     - Egress
   podSelector:
     matchLabels:
-      {{- include "loki.rulerSelectorLabels" . | nindent 6 }}
+      {{- include "loki.backendSelectorLabels" . | nindent 6 }}
   egress:
     - ports:
         - port: {{ .Values.networkPolicy.alertmanager.port }}
@@ -140,7 +139,6 @@ spec:
           {{- toYaml .Values.networkPolicy.alertmanager.podSelector | nindent 12 }}
           {{- end }}
   {{- end }}
-{{- end }}
 
 {{- if .Values.networkPolicy.externalStorage.ports }}
 ---


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR removes the `if .Values.ruler.enabled` condition from the `loki-egress-alertmanager` networkpolicy as this was causing linting issues (i.e nil pointer) whenever enabling the networkpolicies since the `ruler` field is not present in the values.

From what I know, the ruler is now part of the backend, thus I also replaced the `rulerSelectorLabels` by the `backendSelectorLabels`. 

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
