### PR TITLE
Revert "Compression of bloom blocks (#11267)"

### DIFF
--- a/pkg/bloomcompactor/bloomcompactor.go
+++ b/pkg/bloomcompactor/bloomcompactor.go
@@ -491,11 +491,6 @@ func buildBloomBlock(
 		level.Error(logger).Log("reading bloomBlock", err)
 	}
 
-	indexFile, err := os.Open(filepath.Join(localDst, seriesFileName))
-	if err != nil {
-		level.Error(logger).Log("reading bloomBlock", err)
-	}
-
 	blocks := bloomshipper.Block{
 		BlockRef: bloomshipper.BlockRef{
 			Ref: bloomshipper.Ref{
@@ -509,8 +504,7 @@ func buildBloomBlock(
 			},
 			IndexPath: job.IndexPath(),
 		},
-		BloomData: blockFile,
-		IndexData: indexFile,
+		Data: blockFile,
 	}
 
 	return blocks, nil

--- a/pkg/storage/bloom/v1/archive.go
+++ b/pkg/storage/bloom/v1/archive.go
@@ -5,45 +5,11 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/pkg/errors"
 
 	"github.com/grafana/loki/pkg/chunkenc"
 )
-
-func TarGzMemory(dst io.Writer, src *ByteReader) error {
-	gzipper := chunkenc.GetWriterPool(chunkenc.EncGZIP).GetWriter(dst)
-	defer gzipper.Close()
-
-	tarballer := tar.NewWriter(gzipper)
-	defer tarballer.Close()
-
-	header := &tar.Header{
-		Name: SeriesFileName,
-		Size: int64(src.index.Len()),
-	}
-	// Write the header
-	if err := tarballer.WriteHeader(header); err != nil {
-		return errors.Wrapf(err, "error writing tar header for index file")
-	}
-	// Write the file contents
-	if _, err := tarballer.Write(src.index.Bytes()); err != nil {
-		return errors.Wrapf(err, "error writing file contents for index file")
-	}
-
-	header = &tar.Header{
-		Name: BloomFileName,
-		Size: int64(src.blooms.Len()),
-	}
-	if err := tarballer.WriteHeader(header); err != nil {
-		return errors.Wrapf(err, "error writing tar header for bloom file")
-	}
-	if _, err := tarballer.Write(src.blooms.Bytes()); err != nil {
-		return errors.Wrapf(err, "error writing file contents for bloom file")
-	}
-	return nil
-}
 
 func TarGz(dst io.Writer, src *DirectoryBlockReader) error {
 	if err := src.Init(); err != nil {
@@ -111,13 +77,7 @@ func UnTarGz(dst string, r io.Reader) error {
 
 		// if it's a file create it
 		case tar.TypeReg:
-			err := os.MkdirAll(target[:strings.LastIndex(target, "/")], 0755)
-			if err != nil {
-				return errors.Wrapf(err, "error creating directory %s", target)
-			}
-			// TODO: We need to settle on how best to handle file permissions and ownership
-			// This may be utilizing a zip file instead of tar.gz
-			f, err := os.OpenFile(target, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0755)
+			f, err := os.OpenFile(target, os.O_CREATE|os.O_RDWR|os.O_TRUNC, os.FileMode(header.Mode))
 			if err != nil {
 				return errors.Wrapf(err, "error creating file %s", target)
 			}

--- a/pkg/storage/bloom/v1/block_writer.go
+++ b/pkg/storage/bloom/v1/block_writer.go
@@ -12,8 +12,8 @@ import (
 )
 
 const (
-	BloomFileName  = "bloom"
-	SeriesFileName = "series"
+	bloomFileName  = "bloom"
+	seriesFileName = "series"
 )
 
 type BlockWriter interface {
@@ -66,12 +66,12 @@ func (b *DirectoryBlockWriter) Init() error {
 			return errors.Wrap(err, "creating bloom block dir")
 		}
 
-		b.index, err = os.Create(filepath.Join(b.dir, SeriesFileName))
+		b.index, err = os.Create(filepath.Join(b.dir, seriesFileName))
 		if err != nil {
 			return errors.Wrap(err, "creating series file")
 		}
 
-		b.blooms, err = os.Create(filepath.Join(b.dir, BloomFileName))
+		b.blooms, err = os.Create(filepath.Join(b.dir, bloomFileName))
 		if err != nil {
 			return errors.Wrap(err, "creating bloom file")
 		}

--- a/pkg/storage/bloom/v1/reader.go
+++ b/pkg/storage/bloom/v1/reader.go
@@ -49,12 +49,12 @@ func NewDirectoryBlockReader(dir string) *DirectoryBlockReader {
 func (r *DirectoryBlockReader) Init() error {
 	if !r.initialized {
 		var err error
-		r.index, err = os.Open(filepath.Join(r.dir, SeriesFileName))
+		r.index, err = os.Open(filepath.Join(r.dir, seriesFileName))
 		if err != nil {
 			return errors.Wrap(err, "opening series file")
 		}
 
-		r.blooms, err = os.Open(filepath.Join(r.dir, BloomFileName))
+		r.blooms, err = os.Open(filepath.Join(r.dir, bloomFileName))
 		if err != nil {
 			return errors.Wrap(err, "opening bloom file")
 		}

--- a/pkg/storage/stores/shipper/bloomshipper/client.go
+++ b/pkg/storage/stores/shipper/bloomshipper/client.go
@@ -1,19 +1,15 @@
 package bloomshipper
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"io"
-	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
-
-	v1 "github.com/grafana/loki/pkg/storage/bloom/v1"
 
 	"github.com/prometheus/common/model"
 
@@ -79,8 +75,7 @@ type MetaClient interface {
 type Block struct {
 	BlockRef
 
-	IndexData io.ReadCloser
-	BloomData io.ReadCloser
+	Data io.ReadCloser
 }
 
 type BlockClient interface {
@@ -210,35 +205,13 @@ func (b *BloomClient) GetBlocks(ctx context.Context, references []BlockRef) (cha
 				return fmt.Errorf("error while period lookup: %w", err)
 			}
 			objectClient := b.periodicObjectClients[period]
-			compressedObjectReadCloser, _, err := objectClient.GetObject(ctx, createBlockObjectKey(reference.Ref))
+			readCloser, _, err := objectClient.GetObject(ctx, createBlockObjectKey(reference.Ref))
 			if err != nil {
 				return fmt.Errorf("error while fetching object from storage: %w", err)
 			}
-			defer func() {
-				compressedObjectReadCloser.Close()
-			}()
-
-			workingDirectoryPath := filepath.Join(b.storageConfig.BloomShipperConfig.WorkingDirectory, reference.BlockPath, strconv.FormatInt(time.Now().UTC().UnixMilli(), 10))
-			err = v1.UnTarGz(workingDirectoryPath, compressedObjectReadCloser)
-			if err != nil {
-				return fmt.Errorf("error while untarring: %w", err)
-			}
-
-			indexFile, err := os.Open(filepath.Join(workingDirectoryPath, v1.SeriesFileName))
-			if err != nil {
-				return fmt.Errorf("error while opening index file: %w", err)
-			}
-			indexReader := bufio.NewReader(indexFile)
-
-			bloomFile, err := os.Open(filepath.Join(workingDirectoryPath, v1.BloomFileName))
-			if err != nil {
-				return fmt.Errorf("error while opening bloom file: %w", err)
-			}
-			bloomReader := bufio.NewReader(bloomFile)
 			blocksChannel <- Block{
-				BlockRef:  reference,
-				BloomData: io.NopCloser(bloomReader),
-				IndexData: io.NopCloser(indexReader),
+				BlockRef: reference,
+				Data:     readCloser,
 			}
 			return nil
 		})
@@ -252,25 +225,7 @@ func (b *BloomClient) GetBlocks(ctx context.Context, references []BlockRef) (cha
 	return blocksChannel, errChannel
 }
 
-func readCloserToBuffer(rc io.ReadCloser) *bytes.Buffer {
-	defer rc.Close()
-
-	// Read the data from io.ReadCloser
-	data, err := io.ReadAll(rc)
-	if err != nil {
-		return nil
-	}
-
-	// Write the data into a bytes.Buffer
-	var buf bytes.Buffer
-	_, err = buf.Write(data)
-	if err != nil {
-		return nil
-	}
-
-	return &buf
-}
-
+// TODO zip (archive) blocks before uploading to storage
 func (b *BloomClient) PutBlocks(ctx context.Context, blocks []Block) ([]Block, error) {
 	results := make([]Block, len(blocks))
 	//todo move concurrency to the config
@@ -278,11 +233,7 @@ func (b *BloomClient) PutBlocks(ctx context.Context, blocks []Block) ([]Block, e
 		block := blocks[idx]
 		defer func(Data io.ReadCloser) {
 			_ = Data.Close()
-		}(block.BloomData)
-
-		defer func(Data io.ReadCloser) {
-			_ = Data.Close()
-		}(block.IndexData)
+		}(block.Data)
 
 		period, err := findPeriod(b.periodicConfigs, block.StartTimestamp)
 		if err != nil {
@@ -290,19 +241,11 @@ func (b *BloomClient) PutBlocks(ctx context.Context, blocks []Block) ([]Block, e
 		}
 		key := createBlockObjectKey(block.Ref)
 		objectClient := b.periodicObjectClients[period]
-		byteReader := v1.NewByteReader(readCloserToBuffer(block.IndexData), readCloserToBuffer(block.BloomData))
-
-		// TODO: Right now, this is asymetrical with the GetBlocks path. We have all the pieces
-		// in memory now, so it doesn't necessarily make sense to write the files to disk. That may change
-		// as we finalize on an archive format, and we may want to just house the downloaded files in memory instead.
-		// Create a buffer to write data
-		buf := new(bytes.Buffer)
-		err = v1.TarGzMemory(buf, byteReader)
+		data, err := io.ReadAll(block.Data)
 		if err != nil {
-			return fmt.Errorf("error while tarring object data: %w", err)
+			return fmt.Errorf("error while reading object data: %w", err)
 		}
-
-		err = objectClient.PutObject(ctx, key, bytes.NewReader(buf.Bytes()))
+		err = objectClient.PutObject(ctx, key, bytes.NewReader(data))
 		if err != nil {
 			return fmt.Errorf("error updloading block file: %w", err)
 		}

--- a/pkg/storage/stores/shipper/bloomshipper/shipper.go
+++ b/pkg/storage/stores/shipper/bloomshipper/shipper.go
@@ -207,8 +207,7 @@ func (s *Shipper) createBlockQuerier(directory string) *v1.BlockQuerier {
 }
 
 func writeDataToTempFile(workingDirectoryPath string, block *Block) (string, error) {
-	defer block.BloomData.Close()
-	defer block.IndexData.Close()
+	defer block.Data.Close()
 	archivePath := filepath.Join(workingDirectoryPath, block.BlockPath[strings.LastIndex(block.BlockPath, delimiter)+1:])
 
 	archiveFile, err := os.Create(archivePath)
@@ -216,7 +215,7 @@ func writeDataToTempFile(workingDirectoryPath string, block *Block) (string, err
 		return "", fmt.Errorf("error creating empty file to store the archiver: %w", err)
 	}
 	defer archiveFile.Close()
-	_, err = io.Copy(archiveFile, block.BloomData)
+	_, err = io.Copy(archiveFile, block.Data)
 	if err != nil {
 		return "", fmt.Errorf("error writing data to archive file: %w", err)
 	}

--- a/pkg/storage/stores/shipper/bloomshipper/shipper_test.go
+++ b/pkg/storage/stores/shipper/bloomshipper/shipper_test.go
@@ -245,9 +245,8 @@ func Test_Shipper_extractBlock(t *testing.T) {
 	shipper := Shipper{config: config.Config{WorkingDirectory: workingDir}}
 	ts := time.Now().UTC()
 	block := Block{
-		BlockRef:  BlockRef{BlockPath: "first-period-19621/tenantA/metas/ff-fff-1695272400-1695276000-aaa"},
-		BloomData: blockFile,
-		IndexData: seriesFile,
+		BlockRef: BlockRef{BlockPath: "first-period-19621/tenantA/metas/ff-fff-1695272400-1695276000-aaa"},
+		Data:     blockFile,
 	}
 
 	actualPath, err := shipper.extractBlock(&block, ts)


### PR DESCRIPTION
This reverts commit af177034 (https://github.com/grafana/loki/pull/11267)
because the compression/uncompression must be done outside of the client
context: https://raintank-corp.slack.com/archives/C056KUQFBFT/p1700494151990649