### PR TITLE
Make Blooms-Gateway queue settings configurable

### DIFF
--- a/docs/sources/configure/_index.md
+++ b/docs/sources/configure/_index.md
@@ -1845,10 +1845,6 @@ client:
 # Maximum number of outstanding tasks per tenant.
 # CLI flag: -bloom-gateway.max-outstanding-per-tenant
 [max_outstanding_per_tenant: <int> | default = 1024]
-
-# Initial capacity of the pending tasks queue.
-# CLI flag: -bloom-gateway.pending-tasks-initial-capacity
-[pending_tasks_initial_capacity: <int> | default = 1024]
 ```
 
 ### storage_config

--- a/docs/sources/configure/_index.md
+++ b/docs/sources/configure/_index.md
@@ -1837,6 +1837,18 @@ client:
   # not.
   # CLI flag: -bloom-gateway-client.log-gateway-requests
   [log_gateway_requests: <boolean> | default = false]
+
+# Number of workers to use for filtering chunks concurrently.
+# CLI flag: -bloom-gateway.worker-concurrency
+[worker_concurrency: <int> | default = 4]
+
+# Maximum number of outstanding tasks per tenant.
+# CLI flag: -bloom-gateway.max-outstanding-per-tenant
+[max_outstanding_per_tenant: <int> | default = 1024]
+
+# Initial capacity of the pending tasks queue.
+# CLI flag: -bloom-gateway.pending-tasks-initial-capacity
+[pending_tasks_initial_capacity: <int> | default = 1024]
 ```
 
 ### storage_config

--- a/pkg/bloomgateway/bloomgateway.go
+++ b/pkg/bloomgateway/bloomgateway.go
@@ -70,7 +70,8 @@ import (
 var errGatewayUnhealthy = errors.New("bloom-gateway is unhealthy in the ring")
 
 const (
-	metricsSubsystem = "bloom_gateway"
+	pendingTasksInitialCap = 1024
+	metricsSubsystem       = "bloom_gateway"
 )
 
 type metrics struct {
@@ -164,7 +165,7 @@ func New(cfg Config, schemaCfg config.SchemaConfig, storageCfg storage.Config, o
 		logger:       logger,
 		metrics:      newMetrics(reg, constants.Loki, metricsSubsystem),
 		sharding:     shardingStrategy,
-		pendingTasks: makePendingTasks(cfg.PendingTasksInitialCapacity),
+		pendingTasks: makePendingTasks(pendingTasksInitialCap),
 		workerConfig: workerConfig{
 			maxWaitTime: 200 * time.Millisecond,
 			maxItems:    100,

--- a/pkg/bloomgateway/bloomgateway_test.go
+++ b/pkg/bloomgateway/bloomgateway_test.go
@@ -103,6 +103,9 @@ func TestBloomGateway_StartStopService(t *testing.T) {
 				},
 				ReplicationFactor: 1,
 			},
+			WorkerConcurrency:           4,
+			MaxOutstandingPerTenant:     1024,
+			PendingTasksInitialCapacity: 1024,
 		}
 
 		gw, err := New(cfg, schemaCfg, storageCfg, limits, ss, cm, logger, reg)
@@ -113,7 +116,7 @@ func TestBloomGateway_StartStopService(t *testing.T) {
 
 		// Wait for workers to connect to queue
 		time.Sleep(50 * time.Millisecond)
-		require.Equal(t, float64(numWorkers), gw.queue.GetConnectedConsumersMetric())
+		require.Equal(t, float64(cfg.WorkerConcurrency), gw.queue.GetConnectedConsumersMetric())
 
 		err = services.StopAndAwaitTerminated(context.Background(), gw)
 		require.NoError(t, err)
@@ -162,6 +165,9 @@ func TestBloomGateway_FilterChunkRefs(t *testing.T) {
 			},
 			ReplicationFactor: 1,
 		},
+		WorkerConcurrency:           4,
+		MaxOutstandingPerTenant:     1024,
+		PendingTasksInitialCapacity: 1024,
 	}
 
 	t.Run("returns unfiltered chunk refs if no filters provided", func(t *testing.T) {

--- a/pkg/bloomgateway/bloomgateway_test.go
+++ b/pkg/bloomgateway/bloomgateway_test.go
@@ -103,9 +103,8 @@ func TestBloomGateway_StartStopService(t *testing.T) {
 				},
 				ReplicationFactor: 1,
 			},
-			WorkerConcurrency:           4,
-			MaxOutstandingPerTenant:     1024,
-			PendingTasksInitialCapacity: 1024,
+			WorkerConcurrency:       4,
+			MaxOutstandingPerTenant: 1024,
 		}
 
 		gw, err := New(cfg, schemaCfg, storageCfg, limits, ss, cm, logger, reg)
@@ -165,9 +164,8 @@ func TestBloomGateway_FilterChunkRefs(t *testing.T) {
 			},
 			ReplicationFactor: 1,
 		},
-		WorkerConcurrency:           4,
-		MaxOutstandingPerTenant:     1024,
-		PendingTasksInitialCapacity: 1024,
+		WorkerConcurrency:       4,
+		MaxOutstandingPerTenant: 1024,
 	}
 
 	t.Run("returns unfiltered chunk refs if no filters provided", func(t *testing.T) {

--- a/pkg/bloomgateway/config.go
+++ b/pkg/bloomgateway/config.go
@@ -17,9 +17,8 @@ type Config struct {
 	// Client configures the Bloom Gateway client
 	Client ClientConfig `yaml:"client,omitempty" doc:""`
 
-	WorkerConcurrency           int `yaml:"worker_concurrency"`
-	MaxOutstandingPerTenant     int `yaml:"max_outstanding_per_tenant"`
-	PendingTasksInitialCapacity int `yaml:"pending_tasks_initial_capacity"`
+	WorkerConcurrency       int `yaml:"worker_concurrency"`
+	MaxOutstandingPerTenant int `yaml:"max_outstanding_per_tenant"`
 }
 
 // RegisterFlags registers flags for the Bloom Gateway configuration.
@@ -33,7 +32,6 @@ func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.BoolVar(&cfg.Enabled, prefix+"enabled", false, "Flag to enable or disable the bloom gateway component globally.")
 	f.IntVar(&cfg.WorkerConcurrency, prefix+"worker-concurrency", 4, "Number of workers to use for filtering chunks concurrently.")
 	f.IntVar(&cfg.MaxOutstandingPerTenant, prefix+"max-outstanding-per-tenant", 1024, "Maximum number of outstanding tasks per tenant.")
-	f.IntVar(&cfg.PendingTasksInitialCapacity, prefix+"pending-tasks-initial-capacity", 1024, "Initial capacity of the pending tasks queue.")
 	// TODO(chaudum): Figure out what the better place is for registering flags
 	// -bloom-gateway.client.* or -bloom-gateway-client.*
 	cfg.Client.RegisterFlags(f)

--- a/pkg/bloomgateway/sharding.go
+++ b/pkg/bloomgateway/sharding.go
@@ -35,12 +35,6 @@ var (
 	})
 )
 
-type Limits interface {
-	BloomGatewayShardSize(tenantID string) int
-	BloomGatewayEnabled(tenantID string) bool
-	BloomGatewayBlocksDownloadingParallelism(userID string) int
-}
-
 type ShardingStrategy interface {
 	// FilterTenants whose indexes should be loaded by the index gateway.
 	// Returns the list of user IDs that should be synced by the index gateway.


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds three new settings to the Bloom-Gateway config:

- `worker_concurrency`: replaces the `numWorkers` constant. Named after the scheduler's `scheduler_worker_concurrency` config.
- `max_outstanding_per_tenant`: replaces the `maxTasksPerTenant` constant. Named after the frontend's  `max_outstanding_per_tenant` config.
- `pending_tasks_initial_capacity`: replaces the pendingTasksInitialCap constant.

**Note to the reviewers:**
- I think in the future `max_outstanding_per_tenant` should be configurable per-tenant. This would require refactoring the queue pkg and the frontend/scheduler, so I think it doesn't make sense it in this PR.
- I moved the `Limits` struct definition to `config.go` so have all the adjustable settings in the same place.
