### PR TITLE
chore(jsonnet): Fix the storage config on shipper.libsonnet

### DIFF
--- a/production/ksonnet/loki/shipper.libsonnet
+++ b/production/ksonnet/loki/shipper.libsonnet
@@ -19,17 +19,16 @@
     compactor_pvc_class: 'fast',
     index_period_hours: if self.using_shipper_store then 24 else super.index_period_hours,
     loki+: if self.using_shipper_store then {
-      storage_config+: if $._config.using_boltdb_shipper then {
-        boltdb_shipper+: {
+      storage_config+: {
+        boltdb_shipper+: if $._config.using_boltdb_shipper then {
           active_index_directory: '/data/index',
           cache_location: '/data/boltdb-cache',
-        },
-      } else {} + if $._config.using_tsdb_shipper then {
-        tsdb_shipper+: {
+        } else {},
+        tsdb_shipper+: if $._config.using_tsdb_shipper then {
           active_index_directory: '/data/tsdb-index',
           cache_location: '/data/tsdb-cache',
-        },
-      } else {},
+        } else {},
+      },
       compactor+: {
         working_directory: '/data/compactor',
       },


### PR DESCRIPTION
**What this PR does / why we need it**:
We found this is wrongly configured which removes some config(`active_index_directory` and `cache_location`) in our Loki clusters

Introduced via this PR https://github.com/grafana/loki/pull/11195/files

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
-