### PR TITLE
Bloom-Gateway: Use pools to reduce allocations

### DIFF
--- a/pkg/bloomgateway/bloomgateway.go
+++ b/pkg/bloomgateway/bloomgateway.go
@@ -82,7 +82,7 @@ const (
 
 var (
 	// responsesPool pooling array of v1.Output [64, 128, 256, ..., 65536]
-	responsesPool = queue.NewSlicePool[v1.Output](1<<6, 1<<32, 2)
+	responsesPool = queue.NewSlicePool[v1.Output](1<<6, 1<<16, 2)
 )
 
 type metrics struct {

--- a/pkg/bloomgateway/client.go
+++ b/pkg/bloomgateway/client.go
@@ -31,9 +31,9 @@ import (
 
 var (
 	// groupedChunksRefPool pooling slice of logproto.GroupedChunkRefs [64, 128, 256, ..., 65536]
-	groupedChunksRefPool = queue.NewSlicePool[*logproto.GroupedChunkRefs](1<<6, 1<<32, 2)
+	groupedChunksRefPool = queue.NewSlicePool[*logproto.GroupedChunkRefs](1<<6, 1<<16, 2)
 	// chunkRefsByAddrsPool pooling slice of chunkRefsByAddrs [64, 128, 256, ..., 65536]
-	chunkRefsByAddrsPool = queue.NewSlicePool[chunkRefsByAddrs](1<<6, 1<<32, 2)
+	chunkRefsByAddrsPool = queue.NewSlicePool[chunkRefsByAddrs](1<<6, 1<<16, 2)
 	// ringGetBuffersPool pooling for ringGetBuffers to avoid calling ring.MakeBuffersForGet() for each request
 	ringGetBuffersPool = sync.Pool{
 		New: func() interface{} {

--- a/pkg/bloomgateway/querier.go
+++ b/pkg/bloomgateway/querier.go
@@ -32,7 +32,7 @@ func (bq *BloomQuerier) FilterChunkRefs(ctx context.Context, tenant string, from
 	}
 
 	// The indexes of the chunks slice correspond to the indexes of the fingerprint slice.
-	grouped := groupedChunksRefPool.Get(len(chunkRefs)).([]*logproto.GroupedChunkRefs)
+	grouped := groupedChunksRefPool.Get(len(chunkRefs))
 	defer groupedChunksRefPool.Put(grouped)
 	grouped = groupChunkRefs(chunkRefs, grouped)
 

--- a/pkg/bloomgateway/querier.go
+++ b/pkg/bloomgateway/querier.go
@@ -31,9 +31,9 @@ func (bq *BloomQuerier) FilterChunkRefs(ctx context.Context, tenant string, from
 		return chunkRefs, nil
 	}
 
-	// TODO(chaudum): Make buffer pool to reduce allocations.
 	// The indexes of the chunks slice correspond to the indexes of the fingerprint slice.
-	grouped := make([]*logproto.GroupedChunkRefs, 0, len(chunkRefs))
+	grouped := groupedChunksRefPool.Get(len(chunkRefs)).([]*logproto.GroupedChunkRefs)
+	defer groupedChunksRefPool.Put(grouped)
 	grouped = groupChunkRefs(chunkRefs, grouped)
 
 	refs, err := bq.c.FilterChunks(ctx, tenant, from, through, grouped, filters...)


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR addresses some TODOs in the Bloom-Gateway component to reduce allocations by pooling.

**Note for reviewers:**
- I'm not really sure about the max size for the preallocated pools. Used 16K for all of them but that's probably too much for pools such as the `responsesPool`, `addressesPool`... Feel free to leave a comment in the PR with an estimate on the size you think it would make sense to set as the max.


