### PR TITLE
Categorized Labels: Return empty JSON object if no parsed nor structured metadata labels

### DIFF
--- a/integration/loki_micro_services_test.go
+++ b/integration/loki_micro_services_test.go
@@ -888,6 +888,7 @@ func TestCategorizedLabels(t *testing.T) {
 					},
 					Lines: []string{"lineA", "lineB", "lineC msg=foo", "lineD msg=foo text=bar"},
 					CategorizedLabels: []map[string]map[string]string{
+						{},
 						{
 							"structuredMetadata": {
 								"traceID": "123",
@@ -923,6 +924,7 @@ func TestCategorizedLabels(t *testing.T) {
 					},
 					Lines: []string{"lineA", "lineB", "lineC msg=foo", "lineD msg=foo text=bar"},
 					CategorizedLabels: []map[string]map[string]string{
+						{},
 						{
 							"structuredMetadata": {
 								"traceID": "123",

--- a/pkg/querier/queryrange/codec_test.go
+++ b/pkg/querier/queryrange/codec_test.go
@@ -1738,7 +1738,7 @@ var (
 						"test": "test"
 					},
 					"values":[
-						[ "123456789012345", "super line"],
+						[ "123456789012345", "super line", {}],
 						[ "123456789012346", "super line2", {
 							"structuredMetadata": {
 								"x": "a",

--- a/pkg/util/marshal/marshal_test.go
+++ b/pkg/util/marshal/marshal_test.go
@@ -177,7 +177,7 @@ var queryTestWithEncodingFlags = []struct {
 							"test": "test"
 						},
 						"values":[
-							[ "123456789012345", "super line"],
+							[ "123456789012345", "super line", {}],
 							[ "123456789012346", "super line with labels", {
 								"structuredMetadata": {
 									"foo": "a",
@@ -518,7 +518,7 @@ var tailTestWithEncodingFlags = []struct {
 						"test": "test"
 					},
 					"values":[
-						[ "123456789012345", "super line"],
+						[ "123456789012345", "super line", {}],
 						[ "123456789012346", "super line with labels", {
 							"structuredMetadata": {
 								"foo": "a",
@@ -812,7 +812,7 @@ func Test_WriteQueryResponseJSON_EncodeFlags(t *testing.T) {
 								"test": "test"
 							},
 							"values":[
-								[ "123456789012346", "super line"]
+								[ "123456789012346", "super line", {}]
 							]
 						},
 						{
@@ -965,7 +965,7 @@ func Test_EncodeResult_And_ResultValue_Parity(t *testing.T) {
 	f := func(w wrappedValue) bool {
 		var buf bytes.Buffer
 		js := json.NewStream(json.ConfigFastest, &buf, 0)
-		err := encodeResult(w.Value, js, httpreq.NewEncodingFlags(httpreq.FlagCategorizeLabels))
+		err := encodeResult(w.Value, js, nil)
 		require.NoError(t, err)
 		js.Flush()
 		actual := buf.String()

--- a/pkg/util/marshal/query.go
+++ b/pkg/util/marshal/query.go
@@ -401,7 +401,7 @@ func encodeStream(stream logproto.Stream, s *jsoniter.Stream, encodeFlags httpre
 		s.WriteMore()
 		s.WriteStringWithHTMLEscaped(e.Line)
 
-		if categorizeLabels && (len(e.StructuredMetadata) > 0 || len(e.Parsed) > 0) {
+		if categorizeLabels {
 			s.WriteMore()
 			s.WriteObjectStart()
 


### PR DESCRIPTION
This is a followup PR for https://github.com/grafana/loki/pull/10419 wrt this comment https://github.com/grafana/loki/pull/10419#discussion_r1406285386.

If there is no parsed nor structured-metadata labels in a given entry, and the categorize-labels header is set, add an empty object to the entry array. For example, we currently return:

```json
{
    "data": {
        "encodingFlags": [
            "categorize-labels"
        ],
        "result": [
            {
                "stream": {
                    "agent": "promtail",
                    "filename": "/var/log/nginx/json_access.log",
                    "host": "appfelstrudel",
                    "job": "nginx_access_log"
                },
                "values": [
                    [
                        "1701096036028751750",
                        "example line"
                    ]
                ]
            }
        ]
    }
}
```

But we want:
```json
{
    "data": {
        "encodingFlags": [
            "categorize-labels"
        ],
        "result": [
            {
                "stream": {
                    "agent": "promtail",
                    "filename": "/var/log/nginx/json_access.log",
                    "host": "appfelstrudel",
                    "job": "nginx_access_log"
                },
                "values": [
                    [
                        "1701096036028751750",
                        "example line",
                        {} <<<--- WE WANT THIS
                    ]
                ]
            }
        ]
    }
}
```
