### PR TITLE
Initial pass at metrics for bloom tokenizer

### DIFF
--- a/pkg/storage/bloom/v1/bloom_tokenizer.go
+++ b/pkg/storage/bloom/v1/bloom_tokenizer.go
@@ -5,6 +5,10 @@ import (
 	"math"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	"github.com/grafana/loki/pkg/util/constants"
+
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -17,7 +21,13 @@ import (
 	util_log "github.com/grafana/loki/pkg/util/log"
 )
 
-type metrics struct{}
+type metrics struct {
+	sbfCreationTime    prometheus.Counter   // time spent creating sbfs
+	chunkSize          prometheus.Histogram // uncompressed size of all chunks summed per series
+	bloomSize          prometheus.Histogram // size of the bloom filter in bytes
+	hammingWeightRatio prometheus.Histogram // ratio of the hamming weight of the bloom filter to the number of bits in the bloom filter
+	estimatedCount     prometheus.Histogram // estimated number of elements in the bloom filter
+}
 
 /*
 BloomTokenizer is a utility that converts either Loki chunks or individual lines into tokens.
@@ -33,6 +43,7 @@ type BloomTokenizer struct {
 }
 
 const CacheSize = 150000
+const BloomTokenizerMetricsSubsystem = "bloom_tokenizer"
 
 // NewBloomTokenizer returns a new instance of the Bloom Tokenizer.
 // Warning: the tokens returned use the same byte slice to reduce allocations. This has two consequences:
@@ -41,7 +52,7 @@ const CacheSize = 150000
 // 2) This is not thread safe.
 func NewBloomTokenizer(reg prometheus.Registerer, NGramLength, NGramSkip int) (*BloomTokenizer, error) {
 	t := &BloomTokenizer{
-		metrics: newMetrics(reg),
+		metrics: newMetrics(reg, constants.Loki, BloomTokenizerMetricsSubsystem),
 	}
 	t.cache = make(map[string]interface{}, CacheSize)
 	t.lineTokenizer = NewNGramTokenizer(NGramLength, NGramSkip)
@@ -63,9 +74,43 @@ func (bt *BloomTokenizer) GetNGramSkip() uint64 {
 	return uint64(bt.lineTokenizer.Skip)
 }
 
-// TODO: Something real here with metrics
-func newMetrics(_ prometheus.Registerer) *metrics {
-	return &metrics{}
+func newMetrics(r prometheus.Registerer, namespace, subsystem string) *metrics {
+	return &metrics{
+		sbfCreationTime: promauto.With(r).NewCounter(prometheus.CounterOpts{
+			Name:      "bloom_creation_time",
+			Help:      "Time spent creating sbfs",
+			Namespace: namespace,
+			Subsystem: subsystem,
+		}),
+		chunkSize: promauto.With(r).NewHistogram(prometheus.HistogramOpts{
+			Name:      "bloom_chunk_series_size",
+			Help:      "Uncompressed size of chunks in a series",
+			Buckets:   prometheus.ExponentialBucketsRange(1<<10, 1<<30, 10),
+			Namespace: namespace,
+			Subsystem: subsystem,
+		}),
+		bloomSize: promauto.With(r).NewHistogram(prometheus.HistogramOpts{
+			Name:      "bloom_size",
+			Help:      "Size of the bloom filter in bytes",
+			Buckets:   prometheus.ExponentialBucketsRange(128, 16<<20, 8),
+			Namespace: namespace,
+			Subsystem: subsystem,
+		}),
+		hammingWeightRatio: promauto.With(r).NewHistogram(prometheus.HistogramOpts{
+			Name:      "bloom_hamming_weight_ratio",
+			Help:      "Ratio of the hamming weight of the bloom filter to the number of bits in the bloom filter",
+			Buckets:   prometheus.ExponentialBucketsRange(0.001, 1, 12),
+			Namespace: namespace,
+			Subsystem: subsystem,
+		}),
+		estimatedCount: promauto.With(r).NewHistogram(prometheus.HistogramOpts{
+			Name:      "bloom_estimated_count",
+			Help:      "Estimated number of elements in the bloom filter",
+			Buckets:   prometheus.ExponentialBucketsRange(1, 32<<20, 10),
+			Namespace: namespace,
+			Subsystem: subsystem,
+		}),
+	}
 }
 
 func clearCache(cache map[string]interface{}) {
@@ -93,13 +138,15 @@ func prefixedToken(ngram int, chk logproto.ChunkRef) ([]byte, int) {
 
 // PopulateSeriesWithBloom is intended to be called on the write path, and is used to populate the bloom filter for a given series.
 func (bt *BloomTokenizer) PopulateSeriesWithBloom(seriesWithBloom *SeriesWithBloom, chunks []chunk.Chunk) {
-	clearCache(bt.cache)
+	startTime := time.Now().UnixMilli()
 
-	// allocate a reusable key buffer long enough to store both the chunk ref and the ngram
+	clearCache(bt.cache)
+	chunkTotalUncompressedSize := 0
 
 	for idx := range chunks {
 		lc := chunks[idx].Data.(*chunkenc.Facade).LokiChunk()
 		tokenBuf, prefixLn := prefixedToken(bt.lineTokenizer.N, chunks[idx].ChunkRef)
+		chunkTotalUncompressedSize += lc.UncompressedSize()
 
 		// TODO: error handling
 		itr, err := lc.Iterator(
@@ -159,4 +206,20 @@ func (bt *BloomTokenizer) PopulateSeriesWithBloom(seriesWithBloom *SeriesWithBlo
 			Checksum: chunks[idx].Checksum,
 		})
 	} // for each chunk
+
+	endTime := time.Now().UnixMilli()
+
+	fillRatio := seriesWithBloom.Bloom.ScalableBloomFilter.FillRatio()
+	bt.metrics.hammingWeightRatio.Observe(fillRatio)
+	bt.metrics.estimatedCount.Observe(
+		float64(estimatedCount(seriesWithBloom.Bloom.ScalableBloomFilter.Capacity(), fillRatio)),
+	)
+	bt.metrics.bloomSize.Observe(float64(seriesWithBloom.Bloom.ScalableBloomFilter.Capacity() / 8))
+	bt.metrics.sbfCreationTime.Add(float64(endTime - startTime))
+	bt.metrics.chunkSize.Observe(float64(chunkTotalUncompressedSize))
+}
+
+// n ≈ −m ln(1 − p).
+func estimatedCount(m uint, p float64) uint {
+	return uint(-float64(m) * math.Log(1-p))
 }

--- a/pkg/storage/bloom/v1/bloom_tokenizer_test.go
+++ b/pkg/storage/bloom/v1/bloom_tokenizer_test.go
@@ -134,7 +134,7 @@ func TestPopulateSeriesWithBloom(t *testing.T) {
 func BenchmarkMapClear(b *testing.B) {
 	bt, _ := NewBloomTokenizer(prometheus.DefaultRegisterer, DefaultNGramLength, DefaultNGramSkip)
 	for i := 0; i < b.N; i++ {
-		for k := 0; k < CacheSize; k++ {
+		for k := 0; k < cacheSize; k++ {
 			bt.cache[fmt.Sprint(k)] = k
 		}
 
@@ -145,10 +145,10 @@ func BenchmarkMapClear(b *testing.B) {
 func BenchmarkNewMap(b *testing.B) {
 	bt, _ := NewBloomTokenizer(prometheus.DefaultRegisterer, DefaultNGramLength, DefaultNGramSkip)
 	for i := 0; i < b.N; i++ {
-		for k := 0; k < CacheSize; k++ {
+		for k := 0; k < cacheSize; k++ {
 			bt.cache[fmt.Sprint(k)] = k
 		}
 
-		bt.cache = make(map[string]interface{}, CacheSize)
+		bt.cache = make(map[string]interface{}, cacheSize)
 	}
 }

--- a/pkg/storage/bloom/v1/bloom_tokenizer_test.go
+++ b/pkg/storage/bloom/v1/bloom_tokenizer_test.go
@@ -73,7 +73,7 @@ func TestPrefixedKeyCreation(t *testing.T) {
 }
 
 func TestSetLineTokenizer(t *testing.T) {
-	bt, _ := NewBloomTokenizer(prometheus.DefaultRegisterer, DefaultNGramLength, DefaultNGramSkip)
+	bt, _ := NewBloomTokenizer(prometheus.NewRegistry(), DefaultNGramLength, DefaultNGramSkip)
 
 	// Validate defaults
 	require.Equal(t, bt.lineTokenizer.N, DefaultNGramLength)
@@ -87,7 +87,7 @@ func TestSetLineTokenizer(t *testing.T) {
 
 func TestPopulateSeriesWithBloom(t *testing.T) {
 	var testLine = "this is a log line"
-	bt, _ := NewBloomTokenizer(prometheus.DefaultRegisterer, DefaultNGramLength, DefaultNGramSkip)
+	bt, _ := NewBloomTokenizer(prometheus.NewRegistry(), DefaultNGramLength, DefaultNGramSkip)
 
 	sbf := filter.NewScalableBloomFilter(1024, 0.01, 0.8)
 	var lbsList []labels.Labels

--- a/tools/tsdb/bloom-tester/lib.go
+++ b/tools/tsdb/bloom-tester/lib.go
@@ -378,7 +378,6 @@ func analyze(metrics *Metrics, sampler Sampler, indexShipper indexshipper.IndexS
 
 											metrics.sbfCreationTime.WithLabelValues(experiment.name).Add(float64(endTime - startTime))
 											metrics.sbfsCreated.WithLabelValues(experiment.name).Inc()
-											metrics.chunkSize.Observe(float64(chunkTotalUncompressedSize))
 
 											if err != nil {
 												helpers.ExitErr("writing sbf to file", err)


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes the stubbed out metrics from the Bloom Tokenizer, and puts in metrics that were being captured and deemed useful during initial POC testing.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
