### PR TITLE
Bloom tokenization performance tweaks

### DIFF
--- a/pkg/storage/bloom/v1/bloom_tokenizer.go
+++ b/pkg/storage/bloom/v1/bloom_tokenizer.go
@@ -115,10 +115,7 @@ func newMetrics(r prometheus.Registerer, namespace, subsystem string) *metrics {
 }
 
 func clearCache(cache map[string]interface{}) {
-	// TODO: Once we move Loki to Go 1.21, we can just use clear() here.
-	for k := range cache {
-		delete(cache, k)
-	}
+	clear(cache)
 }
 
 // prefixedToken returns a byte slice with sufficient capacity for a chunk-ref prefixed token

--- a/pkg/storage/bloom/v1/bloom_tokenizer.go
+++ b/pkg/storage/bloom/v1/bloom_tokenizer.go
@@ -115,6 +115,7 @@ func newMetrics(r prometheus.Registerer, namespace, subsystem string) *metrics {
 }
 
 func clearCache(cache map[string]interface{}) {
+	// TODO: Once we move Loki to Go 1.21, we can just use clear() here.
 	for k := range cache {
 		delete(cache, k)
 	}

--- a/pkg/storage/bloom/v1/tokenizer.go
+++ b/pkg/storage/bloom/v1/tokenizer.go
@@ -11,7 +11,8 @@ const (
 func reassemble(buf []rune, ln, pos int, result []byte) []byte {
 	result = result[:0] // Reset the result slice
 	for i := 0; i < ln; i++ {
-		cur := (pos + i) % len(buf)
+		cur := pos % len(buf)
+		pos++
 		result = utf8.AppendRune(result, buf[cur])
 	}
 	return result


### PR DESCRIPTION
**What this PR does / why we need it**:

The main work of this PR is to improve the performance of the reassemble() function.  By changing the assignment of the 'cur' variable to not do addition, and incrementing the 'pos' variable separately, the benchmarks improved as follows:

BenchmarkTokens/threeSkip1Chunk/v2-10  	   88864	     13487 ns/op
BenchmarkTokens/threeSkip1ChunkAt2/v2At2-10         	   98607	     12256 ns/op

(This was validated with multiple runs, on multiple size inputs)

The remaining changes in the PR are just to add some benchmarking for PopulateSeriesWithBloom, in case we need to do other comparisons for future improvements.