### PR TITLE
jsonnet: Introduce backend target for Simple Scalable deployment mode

### DIFF
--- a/docs/sources/setup/upgrade/_index.md
+++ b/docs/sources/setup/upgrade/_index.md
@@ -1,4 +1,4 @@
----
+d---
 title: Upgrade Loki
 menuTitle:  Upgrade
 description: Upgrading Grafana Loki
@@ -342,6 +342,10 @@ No impact is expected if you use Kubernetes v1.21 or newer.
 
 Please refer to [official migration guide](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#poddisruptionbudget-v125) for more details.
 
+###### Resource type changed for read target in Simple Scalable deployment mode
+
+The inroduction of the `backend` target allows for the `read` target to run as Kubernetes Deployment resource.
+The new jsonnet files reflect this change, thus upgrading might result in coexisting Deplpyment and StatefulSet for the `read` component, so be sure to do a clean-up.
 
 ## 2.8.0
 

--- a/production/ksonnet/loki-simple-scalable/backend.libsonnet
+++ b/production/ksonnet/loki-simple-scalable/backend.libsonnet
@@ -1,0 +1,56 @@
+local k = import 'ksonnet-util/kausal.libsonnet';
+
+{
+  local container = k.core.v1.container,
+  local pvc = k.core.v1.persistentVolumeClaim,
+  local statefulSet = k.apps.v1.statefulSet,
+  local volumeMount = k.core.v1.volumeMount,
+  local service = k.core.v1.service,
+
+  _config+:: {
+    backend_replicas: 1,
+  },
+
+  backend_pvc::
+    pvc.new('backend-data') +
+    pvc.mixin.spec.resources.withRequests({ storage: '10Gi' }) +
+    pvc.mixin.spec.withAccessModes(['ReadWriteOnce']) +
+    pvc.mixin.spec.withStorageClassName('fast'),
+
+  backend_args::
+    $._config.commonArgs {
+      target: 'backend',
+    },
+
+  backend_container::
+    container.new('backend', $._images.backend) +
+    container.withPorts($.util.defaultPorts) +
+    container.withArgsMixin(k.util.mapToFlags($.backend_args)) +
+    container.withVolumeMountsMixin([volumeMount.new('backend-data', '/data')]) +
+    container.mixin.readinessProbe.httpGet.withPath('/ready') +
+    container.mixin.readinessProbe.httpGet.withPort($._config.http_listen_port) +
+    container.mixin.readinessProbe.withInitialDelaySeconds(15) +
+    container.mixin.readinessProbe.withTimeoutSeconds(1),
+
+  backend_statefulset:
+    statefulSet.new('backend', $._config.backend_replicas, [$.backend_container], $.backend_pvc) +
+    statefulSet.mixin.spec.withServiceName('backend') +
+    statefulSet.mixin.metadata.withLabels({ app: $._config.headless_service_name, name: 'backend' }) +
+    statefulSet.mixin.spec.selector.withMatchLabels({ name: 'backend' }) +
+    statefulSet.mixin.spec.template.metadata.withLabels({ name: 'backend', app: $._config.headless_service_name }) +
+    $._config.config_hash_mixin +
+    k.util.configVolumeMount('loki', '/etc/loki') +
+    k.util.antiAffinity +
+    statefulSet.mixin.spec.updateStrategy.withType('RollingUpdate') +
+    statefulSet.mixin.spec.template.spec.securityContext.withFsGroup(10001) +  // 10001 is the group ID assigned to Loki in the Dockerfile
+    statefulSet.mixin.spec.template.spec.withTerminationGracePeriodSeconds(4800) +
+    statefulSet.mixin.spec.withPodManagementPolicy('Parallel'),
+
+  backend_service:
+    k.util.serviceFor($.backend_statefulset) +
+    service.mixin.spec.withType('ClusterIP') +
+    service.mixin.spec.withPorts([
+      k.core.v1.servicePort.newNamed('backend-http-metrics', 80, 'http-metrics'),
+      k.core.v1.servicePort.newNamed('backend-grpc', 9095, 'grpc'),
+    ]),
+}

--- a/production/ksonnet/loki-simple-scalable/example/main.jsonnet
+++ b/production/ksonnet/loki-simple-scalable/example/main.jsonnet
@@ -30,6 +30,9 @@ loki {
       common: {
         path_prefix: '/loki',
         replication_factor: 1,
+        compactor: {
+          compactor_grpc_address: '%s.%s.svc.cluster.local:%d' % [$.backend_service.metadata.name, namespace, grpc_listen_port],
+        },
         storage: {
           s3: {
             s3: s3Url,

--- a/production/ksonnet/loki-simple-scalable/images.libsonnet
+++ b/production/ksonnet/loki-simple-scalable/images.libsonnet
@@ -4,5 +4,6 @@
 
     read: self.loki,
     write: self.loki,
+    backend: self.loki, 
   },
 }

--- a/production/ksonnet/loki-simple-scalable/loki.libsonnet
+++ b/production/ksonnet/loki-simple-scalable/loki.libsonnet
@@ -5,4 +5,5 @@
 // Loki services
 (import 'read.libsonnet') +
 (import 'write.libsonnet') +
+(import 'backend.libsonnet') +
 (import 'headless.libsonnet')

--- a/production/ksonnet/loki-simple-scalable/read.libsonnet
+++ b/production/ksonnet/loki-simple-scalable/read.libsonnet
@@ -3,7 +3,7 @@ local k = import 'ksonnet-util/kausal.libsonnet';
 {
   local container = k.core.v1.container,
   local pvc = k.core.v1.persistentVolumeClaim,
-  local statefulSet = k.apps.v1.statefulSet,
+  local deployment = k.apps.v1.deployment,
   local volumeMount = k.core.v1.volumeMount,
   local service = k.core.v1.service,
 
@@ -32,22 +32,20 @@ local k = import 'ksonnet-util/kausal.libsonnet';
     container.mixin.readinessProbe.withInitialDelaySeconds(15) +
     container.mixin.readinessProbe.withTimeoutSeconds(1),
 
-  read_statefulset:
-    statefulSet.new('read', $._config.read_replicas, [$.read_container], $.read_pvc) +
-    statefulSet.mixin.spec.withServiceName('read') +
-    statefulSet.mixin.metadata.withLabels({ app: $._config.headless_service_name, name: 'read' }) +
-    statefulSet.mixin.spec.selector.withMatchLabels({ name: 'read' }) +
-    statefulSet.mixin.spec.template.metadata.withLabels({ name: 'read', app: $._config.headless_service_name }) +
+  read_deployment:
+    deployment.new('read', $._config.read_replicas, [$.read_container], $.read_pvc) +
+    deployment.mixin.metadata.withLabels({ app: $._config.headless_service_name, name: 'read' }) +
+    deployment.mixin.spec.selector.withMatchLabels({ name: 'read' }) +
+    deployment.mixin.spec.template.metadata.withLabels({ name: 'read', app: $._config.headless_service_name }) +
     $._config.config_hash_mixin +
     k.util.configVolumeMount('loki', '/etc/loki') +
     k.util.antiAffinity +
-    statefulSet.mixin.spec.updateStrategy.withType('RollingUpdate') +
-    statefulSet.mixin.spec.template.spec.securityContext.withFsGroup(10001) +  // 10001 is the group ID assigned to Loki in the Dockerfile
-    statefulSet.mixin.spec.template.spec.withTerminationGracePeriodSeconds(4800) +
-    statefulSet.mixin.spec.withPodManagementPolicy('Parallel'),
+    deployment.mixin.spec.strategy.withType('RollingUpdate') +
+    deployment.mixin.spec.template.spec.securityContext.withFsGroup(10001) +  // 10001 is the group ID assigned to Loki in the Dockerfile
+    deployment.mixin.spec.template.spec.withTerminationGracePeriodSeconds(4800) ,
 
   read_service:
-    k.util.serviceFor($.read_statefulset) +
+    k.util.serviceFor($.read_deployment) +
     service.mixin.spec.withType('ClusterIP') +
     service.mixin.spec.withPorts([
       k.core.v1.servicePort.newNamed('read-http-metrics', 80, 'http-metrics'),

--- a/production/ksonnet/loki-simple-scalable/read.libsonnet
+++ b/production/ksonnet/loki-simple-scalable/read.libsonnet
@@ -20,6 +20,7 @@ local k = import 'ksonnet-util/kausal.libsonnet';
   read_args::
     $._config.commonArgs {
       target: 'read',
+      'legacy-read-mode': false
     },
 
   read_container::


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds the backend target for Simple Scalable deployment mode.
It also changes the read target deployment mode from StatefulSet to Deployment as per docs:
```
-target=read - The read target is stateless and can be run as a Kubernetes Deployment that can be scaled automatically. It contains the following components: – Query front end – Queriers
```

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
