### PR TITLE
config: fix index periodic config unmarshal

### DIFF
--- a/pkg/storage/config/schema_config.go
+++ b/pkg/storage/config/schema_config.go
@@ -491,6 +491,42 @@ func (cfg *IndexPeriodicTableConfig) Validate() error {
 	return ValidatePathPrefix(cfg.PathPrefix)
 }
 
+// UnmarshalYAML implements the yaml.Unmarshaler interface.
+func (cfg *IndexPeriodicTableConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	g := struct {
+		PathPrefix string         `yaml:"path_prefix"`
+		Prefix     string         `yaml:"prefix"`
+		Period     model.Duration `yaml:"period"`
+		Tags       Tags           `yaml:"tags"`
+	}{}
+	if err := unmarshal(&g); err != nil {
+		return err
+	}
+
+	cfg.PathPrefix = g.PathPrefix
+	cfg.Prefix = g.Prefix
+	cfg.Period = time.Duration(g.Period)
+	cfg.Tags = g.Tags
+
+	return nil
+}
+
+// MarshalYAML implements the yaml.Marshaler interface.
+func (cfg IndexPeriodicTableConfig) MarshalYAML() (interface{}, error) {
+	g := &struct {
+		PathPrefix string         `yaml:"path_prefix"`
+		Prefix     string         `yaml:"prefix"`
+		Period     model.Duration `yaml:"period"`
+		Tags       Tags           `yaml:"tags"`
+	}{
+		PathPrefix: cfg.PathPrefix,
+		Prefix:     cfg.Prefix,
+		Period:     model.Duration(cfg.Period),
+		Tags:       cfg.Tags,
+	}
+
+	return g, nil
+}
 func ValidatePathPrefix(prefix string) error {
 	if prefix == "" {
 		return errors.New("prefix must be set")

--- a/pkg/storage/config/schema_config_test.go
+++ b/pkg/storage/config/schema_config_test.go
@@ -503,6 +503,37 @@ func MustParseDayTime(s string) DayTime {
 	return DayTime{model.TimeFromUnix(t.Unix())}
 }
 
+func TestIndexPeriodicTableConfigCustomUnmarshalling(t *testing.T) {
+	yamlFile := `path_prefix: loki_index/
+prefix: cortex_
+period: 1w
+tags:
+  foo: bar
+`
+
+	cfg := IndexPeriodicTableConfig{}
+	err := yaml.Unmarshal([]byte(yamlFile), &cfg)
+	require.NoError(t, err)
+
+	expectedCfg := IndexPeriodicTableConfig{
+		PathPrefix: "loki_index/",
+		PeriodicTableConfig: PeriodicTableConfig{
+			Prefix: "cortex_",
+			Period: 7 * 24 * time.Hour,
+			Tags: map[string]string{
+				"foo": "bar",
+			},
+		},
+	}
+
+	require.Equal(t, expectedCfg, cfg)
+
+	yamlGenerated, err := yaml.Marshal(&cfg)
+	require.NoError(t, err)
+
+	require.Equal(t, yamlFile, string(yamlGenerated))
+}
+
 func TestPeriodicTableConfigCustomUnmarshalling(t *testing.T) {
 	yamlFile := `prefix: cortex_
 period: 1w


### PR DESCRIPTION
**What this PR does / why we need it**:
Unmarshalling for `IndexPeriodicTableConfig` is not working as expected since it contains an inline field that implements `yaml.Unmarshaler` interface. Configuring `path_prefix` is resulting in a error because it tries to Unmarshal to the parent inline field directly.

Fix this by implementing `yaml.Unmarshaler` interface for `IndexPeriodicTableConfig`

related to: https://github.com/go-yaml/yaml/issues/125

```
field path_prefix not found in type struct { Prefix string "yaml:\"prefix\""; Period model.Duration "yaml:\"period\""; Tags config.Tags "yaml:\"tags\"" }
```

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
