### PR TITLE
Fix flaky test with eventuallyf

### DIFF
--- a/pkg/storage/stores/shipper/bloomshipper/block_downloader_test.go
+++ b/pkg/storage/stores/shipper/bloomshipper/block_downloader_test.go
@@ -64,7 +64,7 @@ func Test_blockDownloader_downloadBlocks(t *testing.T) {
 	require.Len(t, downloadedBlocks, 20, "all 20 block must be downloaded")
 
 	downloader.stop()
-	require.Eventuallyf(t, func() bool {
+	require.Eventually(t, func() bool {
 		return stoppedWorkersCount.Load() == int32(workersCount)
 	}, 1*time.Second, 10*time.Millisecond, "expected all %d workers to be stopped", workersCount)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
I noticed `Test_blockDownloader_downloadBlocks` test was failing in some my builds. I reproduced it by running it 50 times on my local. 
I cannot find why `eventually` vs `eventuallyf` behaves differently. Because documentation is exactly the same for both. But with `eventuallyf` the test was occasionally finishing before the conditions were met with the error below:
```
--- FAIL: Test_blockDownloader_downloadBlocks (1.26s)
    block_downloader_test.go:67: 
        	Error Trace:	/Users/poyzannur/workspace/loki/pkg/storage/stores/shipper/bloomshipper/block_downloader_test.go:67
        	Error:      	Condition never satisfied
        	Test:       	Test_blockDownloader_downloadBlocks
        	Messages:   	expected all 10 workers to be stopped
```
Instead of increasing the time, i switched back to `eventually`. I can't reproduce the failure anymore.
