### PR TITLE
feat(Helm): Allows to configure client_max_body_size and location block

### DIFF
--- a/docs/sources/setup/install/helm/reference.md
+++ b/docs/sources/setup/install/helm/reference.md
@@ -1218,6 +1218,15 @@ false
 </td>
 		</tr>
 		<tr>
+			<td>gateway.nginxConfig.clientMaxBodySize</td>
+			<td>string</td>
+			<td>Allows customizing the `client_max_body_size` directive</td>
+			<td><pre lang="json">
+"4m"
+</pre>
+</td>
+		</tr>
+		<tr>
 			<td>gateway.nginxConfig.customBackendUrl</td>
 			<td>string</td>
 			<td>Override Backend URL</td>
@@ -1259,6 +1268,15 @@ See values.yaml
 			<td>Allows appending custom configuration to the http block, passed through the `tpl` function to allow templating</td>
 			<td><pre lang="json">
 "{{ if .Values.loki.tenants }}proxy_set_header X-Scope-OrgID $remote_user;{{ end }}"
+</pre>
+</td>
+		</tr>
+		<tr>
+			<td>gateway.nginxConfig.locationSnippet</td>
+			<td>string</td>
+			<td>Allows appending custom configuration to the location block, passed through the `tpl` function to allow templating</td>
+			<td><pre lang="json">
+""
 </pre>
 </td>
 		</tr>

--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -13,6 +13,10 @@ Entries should include a reference to the pull request that introduced the chang
 
 [//]: # (<AUTOMATED_UPDATES_LOCATOR> : do not remove this line. This locator is used by the CI pipeline to automatically create a changelog entry for each new Loki release. Add other chart versions and respective changelog entries bellow this line.)
 
+## 5.39.1
+
+- [ENHANCEMENT] Allow to customize `client_max_body_size` and locations snippets when using Loki Gateway.
+
 ## 5.39.0
 
 - [FEATURE] Add support for adding OpenStack swift container credentials via helm chart

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -3,7 +3,7 @@ name: loki
 description: Helm chart for Grafana Loki in simple, scalable mode
 type: application
 appVersion: 2.9.2
-version: 5.39.0
+version: 5.39.1
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -1,6 +1,6 @@
 # loki
 
-![Version: 5.39.0](https://img.shields.io/badge/Version-5.39.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.9.2](https://img.shields.io/badge/AppVersion-2.9.2-informational?style=flat-square)
+![Version: 5.39.1](https://img.shields.io/badge/Version-5.39.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.9.2](https://img.shields.io/badge/AppVersion-2.9.2-informational?style=flat-square)
 
 Helm chart for Grafana Loki in simple, scalable mode
 

--- a/production/helm/loki/templates/_helpers.tpl
+++ b/production/helm/loki/templates/_helpers.tpl
@@ -646,7 +646,7 @@ http {
   uwsgi_temp_path       /tmp/uwsgi_temp;
   scgi_temp_path        /tmp/scgi_temp;
 
-  client_max_body_size  4M;
+  client_max_body_size  {{ .Values.gateway.nginxConfig.clientMaxBodySize }};
 
   proxy_read_timeout    600; ## 10 minutes
   proxy_send_timeout    600;
@@ -726,20 +726,35 @@ http {
     # Distributor
     location = /api/prom/push {
       proxy_pass       {{ $writeUrl }}$request_uri;
+      {{- if .Values.gateway.nginxConfig.locationSnippet }}
+      {{- tpl .Values.gateway.nginxConfig.locationSnippet $ | nindent 6 }}
+      {{- end }}
     }
     location = /loki/api/v1/push {
       proxy_pass       {{ $writeUrl }}$request_uri;
+      {{- if .Values.gateway.nginxConfig.locationSnippet }}
+      {{- tpl .Values.gateway.nginxConfig.locationSnippet $ | nindent 6 }}
+      {{- end }}
     }
     location = /distributor/ring {
       proxy_pass       {{ $writeUrl }}$request_uri;
+      {{- if .Values.gateway.nginxConfig.locationSnippet }}
+      {{- tpl .Values.gateway.nginxConfig.locationSnippet $ | nindent 6 }}
+      {{- end }}
     }
 
     # Ingester
     location = /flush {
       proxy_pass       {{ $writeUrl }}$request_uri;
+      {{- if .Values.gateway.nginxConfig.locationSnippet }}
+      {{- tpl .Values.gateway.nginxConfig.locationSnippet $ | nindent 6 }}
+      {{- end }}
     }
     location ^~ /ingester/ {
       proxy_pass       {{ $writeUrl }}$request_uri;
+      {{- if .Values.gateway.nginxConfig.locationSnippet }}
+      {{- tpl .Values.gateway.nginxConfig.locationSnippet $ | nindent 6 }}
+      {{- end }}
     }
     location = /ingester {
       internal;        # to suppress 301
@@ -748,67 +763,115 @@ http {
     # Ring
     location = /ring {
       proxy_pass       {{ $writeUrl }}$request_uri;
+      {{- if .Values.gateway.nginxConfig.locationSnippet }}
+      {{- tpl .Values.gateway.nginxConfig.locationSnippet $ | nindent 6 }}
+      {{- end }}
     }
 
     # MemberListKV
     location = /memberlist {
       proxy_pass       {{ $writeUrl }}$request_uri;
+      {{- if .Values.gateway.nginxConfig.locationSnippet }}
+      {{- tpl .Values.gateway.nginxConfig.locationSnippet $ | nindent 6 }}
+      {{- end }}
     }
 
 
     # Ruler
     location = /ruler/ring {
       proxy_pass       {{ $backendUrl }}$request_uri;
+      {{- if .Values.gateway.nginxConfig.locationSnippet }}
+      {{- tpl .Values.gateway.nginxConfig.locationSnippet $ | nindent 6 }}
+      {{- end }}
     }
     location = /api/prom/rules {
       proxy_pass       {{ $backendUrl }}$request_uri;
+      {{- if .Values.gateway.nginxConfig.locationSnippet }}
+      {{- tpl .Values.gateway.nginxConfig.locationSnippet $ | nindent 6 }}
+      {{- end }}
     }
     location ^~ /api/prom/rules/ {
       proxy_pass       {{ $backendUrl }}$request_uri;
+      {{- if .Values.gateway.nginxConfig.locationSnippet }}
+      {{- tpl .Values.gateway.nginxConfig.locationSnippet $ | nindent 6 }}
+      {{- end }}
     }
     location = /loki/api/v1/rules {
       proxy_pass       {{ $backendUrl }}$request_uri;
+      {{- if .Values.gateway.nginxConfig.locationSnippet }}
+      {{- tpl .Values.gateway.nginxConfig.locationSnippet $ | nindent 6 }}
+      {{- end }}
     }
     location ^~ /loki/api/v1/rules/ {
       proxy_pass       {{ $backendUrl }}$request_uri;
+      {{- if .Values.gateway.nginxConfig.locationSnippet }}
+      {{- tpl .Values.gateway.nginxConfig.locationSnippet $ | nindent 6 }}
+      {{- end }}
     }
     location = /prometheus/api/v1/alerts {
       proxy_pass       {{ $backendUrl }}$request_uri;
+      {{- if .Values.gateway.nginxConfig.locationSnippet }}
+      {{- tpl .Values.gateway.nginxConfig.locationSnippet $ | nindent 6 }}
+      {{- end }}
     }
     location = /prometheus/api/v1/rules {
       proxy_pass       {{ $backendUrl }}$request_uri;
+      {{- if .Values.gateway.nginxConfig.locationSnippet }}
+      {{- tpl .Values.gateway.nginxConfig.locationSnippet $ | nindent 6 }}
+      {{- end }}
     }
 
     # Compactor
     location = /compactor/ring {
       proxy_pass       {{ $backendUrl }}$request_uri;
+      {{- if .Values.gateway.nginxConfig.locationSnippet }}
+      {{- tpl .Values.gateway.nginxConfig.locationSnippet $ | nindent 6 }}
+      {{- end }}
     }
     location = /loki/api/v1/delete {
       proxy_pass       {{ $backendUrl }}$request_uri;
+      {{- if .Values.gateway.nginxConfig.locationSnippet }}
+      {{- tpl .Values.gateway.nginxConfig.locationSnippet $ | nindent 6 }}
+      {{- end }}
     }
     location = /loki/api/v1/cache/generation_numbers {
       proxy_pass       {{ $backendUrl }}$request_uri;
+      {{- if .Values.gateway.nginxConfig.locationSnippet }}
+      {{- tpl .Values.gateway.nginxConfig.locationSnippet $ | nindent 6 }}
+      {{- end }}
     }
 
     # IndexGateway
     location = /indexgateway/ring {
       proxy_pass       {{ $backendUrl }}$request_uri;
+      {{- if .Values.gateway.nginxConfig.locationSnippet }}
+      {{- tpl .Values.gateway.nginxConfig.locationSnippet $ | nindent 6 }}
+      {{- end }}
     }
 
     # QueryScheduler
     location = /scheduler/ring {
       proxy_pass       {{ $backendUrl }}$request_uri;
+      {{- if .Values.gateway.nginxConfig.locationSnippet }}
+      {{- tpl .Values.gateway.nginxConfig.locationSnippet $ | nindent 6 }}
+      {{- end }}
     }
 
     # Config
     location = /config {
       proxy_pass       {{ $backendUrl }}$request_uri;
+      {{- if .Values.gateway.nginxConfig.locationSnippet }}
+      {{- tpl .Values.gateway.nginxConfig.locationSnippet $ | nindent 6 }}
+      {{- end }}
     }
 
     {{- if and .Values.enterprise.enabled .Values.enterprise.adminApi.enabled }}
     # Admin API
     location ^~ /admin/api/ {
       proxy_pass       {{ $backendUrl }}$request_uri;
+      {{- if .Values.gateway.nginxConfig.locationSnippet }}
+      {{- tpl .Values.gateway.nginxConfig.locationSnippet $ | nindent 6 }}
+      {{- end }}
     }
     location = /admin/api {
       internal;        # to suppress 301
@@ -821,20 +884,32 @@ http {
       proxy_pass       {{ $readUrl }}$request_uri;
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection "upgrade";
+      {{- if .Values.gateway.nginxConfig.locationSnippet }}
+      {{- tpl .Values.gateway.nginxConfig.locationSnippet $ | nindent 6 }}
+      {{- end }}
     }
     location = /loki/api/v1/tail {
       proxy_pass       {{ $readUrl }}$request_uri;
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection "upgrade";
+      {{- if .Values.gateway.nginxConfig.locationSnippet }}
+      {{- tpl .Values.gateway.nginxConfig.locationSnippet $ | nindent 6 }}
+      {{- end }}
     }
     location ^~ /api/prom/ {
       proxy_pass       {{ $readUrl }}$request_uri;
+      {{- if .Values.gateway.nginxConfig.locationSnippet }}
+      {{- tpl .Values.gateway.nginxConfig.locationSnippet $ | nindent 6 }}
+      {{- end }}
     }
     location = /api/prom {
       internal;        # to suppress 301
     }
     location ^~ /loki/api/v1/ {
       proxy_pass       {{ $readUrl }}$request_uri;
+      {{- if .Values.gateway.nginxConfig.locationSnippet }}
+      {{- tpl .Values.gateway.nginxConfig.locationSnippet $ | nindent 6 }}
+      {{- end }}
     }
     location = /loki/api/v1 {
       internal;        # to suppress 301

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -1451,7 +1451,7 @@ gateway:
     # -- Allows appending custom configuration to the location block, passed through the `tpl` function to allow templating
     locationSnippet: ""
     # -- Allows customizing the `client_max_body_size` directive
-    clientMaxBodySize: 4m
+    clientMaxBodySize: 4M
     # -- Override Read URL
     customReadUrl: null
     # -- Override Write URL

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -1448,6 +1448,10 @@ gateway:
     # -- Allows appending custom configuration to the http block, passed through the `tpl` function to allow templating
     httpSnippet: >-
       {{ if .Values.loki.tenants }}proxy_set_header X-Scope-OrgID $remote_user;{{ end }}
+    # -- Allows appending custom configuration to the location block, passed through the `tpl` function to allow templating
+    locationSnippet: ""
+    # -- Allows customizing the `client_max_body_size` directive
+    clientMaxBodySize: 4m
     # -- Override Read URL
     customReadUrl: null
     # -- Override Write URL


### PR DESCRIPTION
**What this PR does / why we need it**:

Adjusting client_max_body_size in Nginx could allow me fixing nginx errors `client intended to send too large body`.
Adjusting location snippets would allow me to add custom headers on individual endpoints, ensuring tailored optimizations where needed.

**Which issue(s) this PR fixes**:
Fixes #10521

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
