### PR TITLE
Wait for all workers to stop when stopping blockdownloader

### DIFF
--- a/pkg/storage/stores/shipper/bloomshipper/block_downloader_test.go
+++ b/pkg/storage/stores/shipper/bloomshipper/block_downloader_test.go
@@ -64,9 +64,7 @@ func Test_blockDownloader_downloadBlocks(t *testing.T) {
 	require.Len(t, downloadedBlocks, 20, "all 20 block must be downloaded")
 
 	downloader.stop()
-	require.Eventuallyf(t, func() bool {
-		return stoppedWorkersCount.Load() == int32(workersCount)
-	}, 1*time.Second, 10*time.Millisecond, "expected all %d workers to be stopped", workersCount)
+	require.Equal(t, int32(workersCount), stoppedWorkersCount.Load())
 }
 
 // creates fake blocks and returns map[block-path]Block and mockBlockClient


### PR DESCRIPTION
**What this PR does / why we need it**:
The `blockDownloader` does not wait until all of its worker goroutines are finished. This leads to a flaky test, see #11347 

To properly fix the behaviour, the `stop()` function should wait until all workers are done.

**Which issue(s) this PR fixes**:

Closes #11347
