### PR TITLE
Bloom Gateway: process blocks immediately when they are available

### DIFF
--- a/pkg/bloomgateway/bloomgateway.go
+++ b/pkg/bloomgateway/bloomgateway.go
@@ -180,8 +180,9 @@ func New(cfg Config, schemaCfg config.SchemaConfig, storageCfg storage.Config, o
 		sharding:     shardingStrategy,
 		pendingTasks: makePendingTasks(pendingTasksInitialCap),
 		workerConfig: workerConfig{
-			maxWaitTime: 200 * time.Millisecond,
-			maxItems:    100,
+			maxWaitTime:               200 * time.Millisecond,
+			maxItems:                  100,
+			processBlocksSequentially: false,
 		},
 		workerMetrics: newWorkerMetrics(reg, constants.Loki, metricsSubsystem),
 		queueMetrics:  queue.NewMetrics(reg, constants.Loki, metricsSubsystem),

--- a/pkg/bloomgateway/bloomgateway_test.go
+++ b/pkg/bloomgateway/bloomgateway_test.go
@@ -255,78 +255,89 @@ func TestBloomGateway_FilterChunkRefs(t *testing.T) {
 	})
 
 	t.Run("use fuse queriers to filter chunks", func(t *testing.T) {
-		reg := prometheus.NewRegistry()
-		gw, err := New(cfg, schemaCfg, storageCfg, limits, ss, cm, logger, reg)
-		require.NoError(t, err)
+		for _, tc := range []struct {
+			name  string
+			value bool
+		}{
+			{"sequentially", true},
+			{"callback", false},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
 
-		now := mktime("2023-10-03 10:00")
+				reg := prometheus.NewRegistry()
+				gw, err := New(cfg, schemaCfg, storageCfg, limits, ss, cm, logger, reg)
+				require.NoError(t, err)
 
-		// replace store implementation and re-initialize workers and sub-services
-		bqs, data := createBlockQueriers(t, 5, now.Add(-8*time.Hour), now, 0, 1024)
-		gw.bloomStore = newMockBloomStore(bqs)
-		// randomize between sequentical processing and processing using callback
-		gw.workerConfig.processBlocksSequentially = rand.Float32() > 0.5
-		err = gw.initServices()
-		require.NoError(t, err)
+				now := mktime("2023-10-03 10:00")
 
-		t.Log("process blocks in worker sequentially", gw.workerConfig.processBlocksSequentially)
+				// replace store implementation and re-initialize workers and sub-services
+				bqs, data := createBlockQueriers(t, 5, now.Add(-8*time.Hour), now, 0, 1024)
+				gw.bloomStore = newMockBloomStore(bqs)
+				gw.workerConfig.processBlocksSequentially = tc.value
+				err = gw.initServices()
+				require.NoError(t, err)
 
-		err = services.StartAndAwaitRunning(context.Background(), gw)
-		require.NoError(t, err)
-		t.Cleanup(func() {
-			err = services.StopAndAwaitTerminated(context.Background(), gw)
-			require.NoError(t, err)
-		})
+				t.Log("process blocks in worker sequentially", gw.workerConfig.processBlocksSequentially)
 
-		chunkRefs := createQueryInputFromBlockData(t, tenantID, data, 100)
+				err = services.StartAndAwaitRunning(context.Background(), gw)
+				require.NoError(t, err)
+				t.Cleanup(func() {
+					err = services.StopAndAwaitTerminated(context.Background(), gw)
+					require.NoError(t, err)
+				})
 
-		t.Run("no match - return empty response", func(t *testing.T) {
-			inputChunkRefs := groupRefs(t, chunkRefs)
-			req := &logproto.FilterChunkRefRequest{
-				From:    now.Add(-8 * time.Hour),
-				Through: now,
-				Refs:    inputChunkRefs,
-				Filters: []*logproto.LineFilterExpression{
-					{Operator: 1, Match: "does not match"},
-				},
-			}
-			ctx := user.InjectOrgID(context.Background(), tenantID)
-			res, err := gw.FilterChunkRefs(ctx, req)
-			require.NoError(t, err)
+				chunkRefs := createQueryInputFromBlockData(t, tenantID, data, 100)
 
-			expectedResponse := &logproto.FilterChunkRefResponse{
-				ChunkRefs: []*logproto.GroupedChunkRefs{},
-			}
-			require.Equal(t, expectedResponse, res)
-		})
+				t.Run("no match - return empty response", func(t *testing.T) {
+					inputChunkRefs := groupRefs(t, chunkRefs)
+					req := &logproto.FilterChunkRefRequest{
+						From:    now.Add(-8 * time.Hour),
+						Through: now,
+						Refs:    inputChunkRefs,
+						Filters: []*logproto.LineFilterExpression{
+							{Operator: 1, Match: "does not match"},
+						},
+					}
+					ctx := user.InjectOrgID(context.Background(), tenantID)
+					res, err := gw.FilterChunkRefs(ctx, req)
+					require.NoError(t, err)
 
-		t.Run("match - return filtered", func(t *testing.T) {
-			inputChunkRefs := groupRefs(t, chunkRefs)
-			// hack to get indexed key for a specific series
-			// the indexed key range for a series is defined as
-			// i * keysPerSeries ... i * keysPerSeries + keysPerSeries - 1
-			// where i is the nth series in a block
-			// fortunately, i is also used as Checksum for the single chunk of a series
-			// see mkBasicSeriesWithBlooms() in pkg/storage/bloom/v1/test_util.go
-			key := inputChunkRefs[0].Refs[0].Checksum*1000 + 500
+					expectedResponse := &logproto.FilterChunkRefResponse{
+						ChunkRefs: []*logproto.GroupedChunkRefs{},
+					}
+					require.Equal(t, expectedResponse, res)
+				})
 
-			req := &logproto.FilterChunkRefRequest{
-				From:    now.Add(-8 * time.Hour),
-				Through: now,
-				Refs:    inputChunkRefs,
-				Filters: []*logproto.LineFilterExpression{
-					{Operator: 1, Match: fmt.Sprint(key)},
-				},
-			}
-			ctx := user.InjectOrgID(context.Background(), tenantID)
-			res, err := gw.FilterChunkRefs(ctx, req)
-			require.NoError(t, err)
+				t.Run("match - return filtered", func(t *testing.T) {
+					inputChunkRefs := groupRefs(t, chunkRefs)
+					// hack to get indexed key for a specific series
+					// the indexed key range for a series is defined as
+					// i * keysPerSeries ... i * keysPerSeries + keysPerSeries - 1
+					// where i is the nth series in a block
+					// fortunately, i is also used as Checksum for the single chunk of a series
+					// see mkBasicSeriesWithBlooms() in pkg/storage/bloom/v1/test_util.go
+					key := inputChunkRefs[0].Refs[0].Checksum*1000 + 500
 
-			expectedResponse := &logproto.FilterChunkRefResponse{
-				ChunkRefs: inputChunkRefs[:1],
-			}
-			require.Equal(t, expectedResponse, res)
-		})
+					req := &logproto.FilterChunkRefRequest{
+						From:    now.Add(-8 * time.Hour),
+						Through: now,
+						Refs:    inputChunkRefs,
+						Filters: []*logproto.LineFilterExpression{
+							{Operator: 1, Match: fmt.Sprint(key)},
+						},
+					}
+					ctx := user.InjectOrgID(context.Background(), tenantID)
+					res, err := gw.FilterChunkRefs(ctx, req)
+					require.NoError(t, err)
+
+					expectedResponse := &logproto.FilterChunkRefResponse{
+						ChunkRefs: inputChunkRefs[:1],
+					}
+					require.Equal(t, expectedResponse, res)
+				})
+
+			})
+		}
 
 	})
 }

--- a/pkg/bloomgateway/worker.go
+++ b/pkg/bloomgateway/worker.go
@@ -20,6 +20,8 @@ import (
 type workerConfig struct {
 	maxWaitTime time.Duration
 	maxItems    int
+
+	processBlocksSequentially bool
 }
 
 type workerMetrics struct {
@@ -186,30 +188,17 @@ func (w *worker) running(ctx context.Context) error {
 					blockRefs = append(blockRefs, b.blockRef)
 				}
 
-				// GetBlockQueriersForBlockRefs() waits until all blocks are downloaded and available for querying.
-				// TODO(chaudum): Add API that allows to process blocks as soon as they become available.
-				// This will require to change the taskMergeIterator to a slice of requests so we can seek
-				// to the appropriate fingerprint range within the slice that matches the block's fingerprint range.
-				storeFetchStart = time.Now()
-				blockQueriers, err := w.store.GetBlockQueriersForBlockRefs(taskCtx, tasks[0].Tenant, blockRefs)
-				w.metrics.storeAccessLatency.WithLabelValues(w.id, "GetBlockQueriersForBlockRefs").Observe(time.Since(storeFetchStart).Seconds())
+				if w.cfg.processBlocksSequentially {
+					err = w.processBlocksSequentially(taskCtx, tasks[0].Tenant, day, blockRefs, boundedRefs)
+				} else {
+					err = w.processBlocksWithCallback(taskCtx, tasks[0].Tenant, day, blockRefs, boundedRefs)
+				}
 				if err != nil {
 					for _, t := range tasks {
 						t.ErrCh <- err
 					}
 					// continue with tasks of next day
 					continue
-				}
-
-				for i, blockQuerier := range blockQueriers {
-					it := newTaskMergeIterator(day, boundedRefs[i].tasks...)
-					fq := blockQuerier.Fuse([]v1.PeekingIterator[v1.Request]{it})
-					err := fq.Run()
-					if err != nil {
-						for _, t := range boundedRefs[i].tasks {
-							t.ErrCh <- errors.Wrap(err, "failed to run chunk check")
-						}
-					}
 				}
 			}
 
@@ -224,4 +213,41 @@ func (w *worker) stopping(err error) error {
 	level.Debug(w.logger).Log("msg", "stopping worker", "err", err)
 	w.queue.UnregisterConsumerConnection(w.id)
 	return nil
+}
+
+func (w *worker) processBlocksWithCallback(taskCtx context.Context, tenant string, day time.Time, blockRefs []bloomshipper.BlockRef, boundedRefs []boundedTasks) error {
+	return w.store.ForEach(taskCtx, tenant, blockRefs, func(bq *v1.BlockQuerier, minFp, maxFp uint64) error {
+		for _, b := range boundedRefs {
+			if b.blockRef.MinFingerprint == minFp && b.blockRef.MaxFingerprint == maxFp {
+				processBlock(bq, day, b.tasks)
+				return nil
+			}
+		}
+		return nil
+	})
+}
+
+func (w *worker) processBlocksSequentially(taskCtx context.Context, tenant string, day time.Time, blockRefs []bloomshipper.BlockRef, boundedRefs []boundedTasks) error {
+	storeFetchStart := time.Now()
+	blockQueriers, err := w.store.GetBlockQueriersForBlockRefs(taskCtx, tenant, blockRefs)
+	w.metrics.storeAccessLatency.WithLabelValues(w.id, "GetBlockQueriersForBlockRefs").Observe(time.Since(storeFetchStart).Seconds())
+	if err != nil {
+		return err
+	}
+
+	for i := range blockQueriers {
+		processBlock(blockQueriers[i].BlockQuerier, day, boundedRefs[i].tasks)
+	}
+	return nil
+}
+
+func processBlock(blockQuerier *v1.BlockQuerier, day time.Time, tasks []Task) {
+	it := newTaskMergeIterator(day, tasks...)
+	fq := blockQuerier.Fuse([]v1.PeekingIterator[v1.Request]{it})
+	err := fq.Run()
+	if err != nil {
+		for _, t := range tasks {
+			t.ErrCh <- errors.Wrap(err, "failed to run chunk check")
+		}
+	}
 }

--- a/pkg/storage/stores/shipper/bloomshipper/store.go
+++ b/pkg/storage/stores/shipper/bloomshipper/store.go
@@ -32,6 +32,7 @@ type Store interface {
 	GetBlockRefs(ctx context.Context, tenant string, from, through time.Time) ([]BlockRef, error)
 	GetBlockQueriers(ctx context.Context, tenant string, from, through time.Time, fingerprints []uint64) ([]BlockQuerierWithFingerprintRange, error)
 	GetBlockQueriersForBlockRefs(ctx context.Context, tenant string, blocks []BlockRef) ([]BlockQuerierWithFingerprintRange, error)
+	ForEach(ctx context.Context, tenant string, blocks []BlockRef, callback ForEachBlockCallback) error
 	Stop()
 }
 
@@ -52,6 +53,11 @@ func (bs *BloomStore) Stop() {
 // GetBlockRefs implements Store
 func (bs *BloomStore) GetBlockRefs(ctx context.Context, tenant string, from, through time.Time) ([]BlockRef, error) {
 	return bs.shipper.GetBlockRefs(ctx, tenant, from, through)
+}
+
+// ForEach implements Store
+func (bs *BloomStore) ForEach(ctx context.Context, tenant string, blocks []BlockRef, callback ForEachBlockCallback) error {
+	return bs.shipper.Fetch(ctx, tenant, blocks, callback)
 }
 
 // GetQueriersForBlocks implements Store


### PR DESCRIPTION
At current point in time, the worker calls `w.store.GetBlockQueriersForBlockRefs()` to obtain a list of block queriers sorted by fingerprint in ascending order.
However, the shipper used by the store to fetch blocks by its refs, calls a callback function when a requested block is available. Instead of waiting for all callbacks to be called and then returning a single list of block queriers, the store now exposes a new function `ForEach()` that also accepts a callback that is passed to the underlying shipper.

This allows to process blocks in the worker as soon as they become available. Some block may be served from cache, some may need to be downloaded. That way, we reduce waiting time.
