### PR TITLE
Fix `getFromThrough()` function for ShortRefs

### DIFF
--- a/pkg/bloomgateway/util_test.go
+++ b/pkg/bloomgateway/util_test.go
@@ -3,6 +3,7 @@ package bloomgateway
 import (
 	"testing"
 
+	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/loki/pkg/logproto"
@@ -35,6 +36,23 @@ func TestSliceIterWithIndex(t *testing.T) {
 		require.Equal(t, "", p.val) // "" is zero value for type string
 		require.Equal(t, 123, p.idx)
 	})
+}
+
+func TestGetFromThrough(t *testing.T) {
+	chunks := []*logproto.ShortRef{
+		{From: 0, Through: 6},
+		{From: 1, Through: 5},
+		{From: 2, Through: 9},
+		{From: 3, Through: 8},
+		{From: 4, Through: 7},
+	}
+	from, through := getFromThrough(chunks)
+	require.Equal(t, model.Time(0), from)
+	require.Equal(t, model.Time(9), through)
+
+	// assert that slice order did not change
+	require.Equal(t, model.Time(0), chunks[0].From)
+	require.Equal(t, model.Time(4), chunks[len(chunks)-1].From)
 }
 
 func mkBlockRef(minFp, maxFp uint64) bloomshipper.BlockRef {


### PR DESCRIPTION
**What this PR does / why we need it**:

Since chunks don't necessarily have the same duration, we cannot assume that the last item of a slice sorted by `From` time also has the greatest `Through` time.
