### PR TITLE
Bloom Compactor: Optimize check for fingerprint ownership

### DIFF
--- a/pkg/bloomcompactor/bloomcompactor.go
+++ b/pkg/bloomcompactor/bloomcompactor.go
@@ -348,7 +348,7 @@ func (c *Compactor) compactTenant(ctx context.Context, logger log.Logger, sc sto
 	if err != nil {
 		return err
 	}
-	tokenRanges := bloomutils.GetInstancesWithTokenRanges(c.cfg.Ring.InstanceID, rs.Instances)
+	tokenRanges := bloomutils.GetInstanceWithTokenRange(c.cfg.Ring.InstanceID, rs.Instances)
 
 	_ = sc.indexShipper.ForEach(ctx, tableName, tenant, func(isMultiTenantIndex bool, idx shipperindex.Index) error {
 		if isMultiTenantIndex {

--- a/pkg/bloomgateway/client_test.go
+++ b/pkg/bloomgateway/client_test.go
@@ -162,7 +162,20 @@ func TestBloomGatewayClient_ServerAddressesWithTokenRanges(t *testing.T) {
 		instances []ring.InstanceDesc
 		expected  []addrsWithTokenRange
 	}{
-		"MinUint32 and MaxUint32 are actual tokens in the ring": {
+		"one token per instance": {
+			instances: []ring.InstanceDesc{
+				{Id: "instance-1", Addr: "10.0.0.1", Tokens: []uint32{math.MaxUint32 / 6 * 1}},
+				{Id: "instance-2", Addr: "10.0.0.2", Tokens: []uint32{math.MaxUint32 / 6 * 3}},
+				{Id: "instance-3", Addr: "10.0.0.3", Tokens: []uint32{math.MaxUint32 / 6 * 5}},
+			},
+			expected: []addrsWithTokenRange{
+				{id: "instance-1", addrs: []string{"10.0.0.1"}, minToken: 0, maxToken: math.MaxUint32 / 6 * 1},
+				{id: "instance-2", addrs: []string{"10.0.0.2"}, minToken: math.MaxUint32/6*1 + 1, maxToken: math.MaxUint32 / 6 * 3},
+				{id: "instance-3", addrs: []string{"10.0.0.3"}, minToken: math.MaxUint32/6*3 + 1, maxToken: math.MaxUint32 / 6 * 5},
+				{id: "instance-1", addrs: []string{"10.0.0.1"}, minToken: math.MaxUint32/6*5 + 1, maxToken: math.MaxUint32},
+			},
+		},
+		"MinUint32 and MaxUint32 are tokens in the ring": {
 			instances: []ring.InstanceDesc{
 				{Id: "instance-1", Addr: "10.0.0.1", Tokens: []uint32{0, math.MaxUint32 / 3 * 2}},
 				{Id: "instance-2", Addr: "10.0.0.2", Tokens: []uint32{math.MaxUint32 / 3 * 1, math.MaxUint32}},

--- a/pkg/bloomgateway/util.go
+++ b/pkg/bloomgateway/util.go
@@ -12,67 +12,6 @@ import (
 	"github.com/grafana/loki/pkg/storage/stores/shipper/bloomshipper"
 )
 
-type IndexedValue[T any] struct {
-	idx int
-	val T
-}
-
-type IterWithIndex[T any] struct {
-	v1.Iterator[T]
-	zero  T // zero value of T
-	cache IndexedValue[T]
-}
-
-func (it *IterWithIndex[T]) At() IndexedValue[T] {
-	it.cache.val = it.Iterator.At()
-	return it.cache
-}
-
-func NewIterWithIndex[T any](iter v1.Iterator[T], idx int) v1.Iterator[IndexedValue[T]] {
-	return &IterWithIndex[T]{
-		Iterator: iter,
-		cache:    IndexedValue[T]{idx: idx},
-	}
-}
-
-type SliceIterWithIndex[T any] struct {
-	xs    []T // source slice
-	pos   int // position within the slice
-	zero  T   // zero value of T
-	cache IndexedValue[T]
-}
-
-func (it *SliceIterWithIndex[T]) Next() bool {
-	it.pos++
-	return it.pos < len(it.xs)
-}
-
-func (it *SliceIterWithIndex[T]) Err() error {
-	return nil
-}
-
-func (it *SliceIterWithIndex[T]) At() IndexedValue[T] {
-	it.cache.val = it.xs[it.pos]
-	return it.cache
-}
-
-func (it *SliceIterWithIndex[T]) Peek() (IndexedValue[T], bool) {
-	if it.pos+1 >= len(it.xs) {
-		it.cache.val = it.zero
-		return it.cache, false
-	}
-	it.cache.val = it.xs[it.pos+1]
-	return it.cache, true
-}
-
-func NewSliceIterWithIndex[T any](xs []T, idx int) v1.PeekingIterator[IndexedValue[T]] {
-	return &SliceIterWithIndex[T]{
-		xs:    xs,
-		pos:   -1,
-		cache: IndexedValue[T]{idx: idx},
-	}
-}
-
 func getDayTime(ts model.Time) time.Time {
 	return time.Date(ts.Time().Year(), ts.Time().Month(), ts.Time().Day(), 0, 0, 0, 0, time.UTC)
 }

--- a/pkg/bloomgateway/util_test.go
+++ b/pkg/bloomgateway/util_test.go
@@ -10,34 +10,6 @@ import (
 	"github.com/grafana/loki/pkg/storage/stores/shipper/bloomshipper"
 )
 
-func TestSliceIterWithIndex(t *testing.T) {
-	t.Run("SliceIterWithIndex implements v1.PeekingIterator interface", func(t *testing.T) {
-		xs := []string{"a", "b", "c"}
-		it := NewSliceIterWithIndex(xs, 123)
-
-		// peek at first item
-		p, ok := it.Peek()
-		require.True(t, ok)
-		require.Equal(t, "a", p.val)
-		require.Equal(t, 123, p.idx)
-
-		// proceed to first item
-		require.True(t, it.Next())
-		require.Equal(t, "a", it.At().val)
-		require.Equal(t, 123, it.At().idx)
-
-		// proceed to second and third item
-		require.True(t, it.Next())
-		require.True(t, it.Next())
-
-		// peek at non-existing fourth item
-		p, ok = it.Peek()
-		require.False(t, ok)
-		require.Equal(t, "", p.val) // "" is zero value for type string
-		require.Equal(t, 123, p.idx)
-	})
-}
-
 func TestGetFromThrough(t *testing.T) {
 	chunks := []*logproto.ShortRef{
 		{From: 0, Through: 6},

--- a/pkg/bloomutils/iter.go
+++ b/pkg/bloomutils/iter.go
@@ -1,0 +1,37 @@
+package bloomutils
+
+import (
+	"io"
+
+	v1 "github.com/grafana/loki/pkg/storage/bloom/v1"
+)
+
+// sortMergeIterator implements v1.Iterator
+type sortMergeIterator[T any, C comparable, R any] struct {
+	curr      R
+	heap      *v1.HeapIterator[v1.IndexedValue[C]]
+	items     []T
+	transform func(T, C, R) R
+	err       error
+}
+
+func (it *sortMergeIterator[T, C, R]) Next() bool {
+	ok := it.heap.Next()
+	if !ok {
+		it.err = io.EOF
+		return false
+	}
+
+	group := it.heap.At()
+	it.curr = it.transform(it.items[group.Index()], group.Value(), it.curr)
+
+	return true
+}
+
+func (it *sortMergeIterator[T, C, R]) At() R {
+	return it.curr
+}
+
+func (it *sortMergeIterator[T, C, R]) Err() error {
+	return it.err
+}

--- a/pkg/bloomutils/iter.go
+++ b/pkg/bloomutils/iter.go
@@ -8,10 +8,10 @@ import (
 
 // sortMergeIterator implements v1.Iterator
 type sortMergeIterator[T any, C comparable, R any] struct {
-	curr      R
+	curr      *R
 	heap      *v1.HeapIterator[v1.IndexedValue[C]]
 	items     []T
-	transform func(T, C, R) R
+	transform func(T, C, *R) *R
 	err       error
 }
 
@@ -29,7 +29,7 @@ func (it *sortMergeIterator[T, C, R]) Next() bool {
 }
 
 func (it *sortMergeIterator[T, C, R]) At() R {
-	return it.curr
+	return *it.curr
 }
 
 func (it *sortMergeIterator[T, C, R]) Err() error {

--- a/pkg/bloomutils/ring.go
+++ b/pkg/bloomutils/ring.go
@@ -1,0 +1,89 @@
+// This file contains a bunch of utility functions for bloom components.
+// TODO: Find a better location for this package
+
+package bloomutils
+
+import (
+	"math"
+	"sort"
+
+	"github.com/grafana/dskit/ring"
+
+	v1 "github.com/grafana/loki/pkg/storage/bloom/v1"
+)
+
+type InstanceWithTokenRange struct {
+	Instance           ring.InstanceDesc
+	MinToken, MaxToken uint32
+}
+
+func (i InstanceWithTokenRange) Cmp(token uint32) v1.BoundsCheck {
+	if token < i.MinToken {
+		return v1.Before
+	} else if token > i.MaxToken {
+		return v1.After
+	}
+	return v1.Overlap
+}
+
+type InstancesWithTokenRange []InstanceWithTokenRange
+
+func (i InstancesWithTokenRange) Contains(token uint32) bool {
+	for _, instance := range i {
+		if instance.Cmp(token) == v1.Overlap {
+			return true
+		}
+	}
+	return false
+}
+
+func GetInstancesWithTokenRanges(id string, instances []ring.InstanceDesc) InstancesWithTokenRange {
+	servers := make([]InstanceWithTokenRange, 0, len(instances))
+	it := NewInstanceSortMergeIterator(instances)
+	for it.Next() {
+		if it.At().Instance.Id == id {
+			servers = append(servers, it.At())
+		}
+	}
+	// wrap around ring
+	if len(servers) > 0 && servers[0].Instance.Id == id {
+		servers = append(servers, InstanceWithTokenRange{
+			MinToken: servers[len(servers)-1].MaxToken + 1,
+			MaxToken: math.MaxUint32,
+			Instance: servers[0].Instance,
+		})
+	}
+	return servers
+}
+
+// NewInstanceSortMergeIterator creates an iterator that yields instanceWithToken elements
+// where the token of the elements are sorted in ascending order.
+func NewInstanceSortMergeIterator(instances []ring.InstanceDesc) v1.Iterator[InstanceWithTokenRange] {
+	it := &sortMergeIterator[ring.InstanceDesc, uint32, InstanceWithTokenRange]{
+		items: instances,
+		transform: func(item ring.InstanceDesc, val uint32, prev InstanceWithTokenRange) InstanceWithTokenRange {
+			prevToken := prev.MaxToken + 1
+			if prev.MaxToken == 0 {
+				prevToken = 0
+			}
+			return InstanceWithTokenRange{Instance: item, MinToken: prevToken, MaxToken: val}
+		},
+	}
+	sequences := make([]v1.PeekingIterator[v1.IndexedValue[uint32]], 0, len(instances))
+	for i := range instances {
+		sort.Slice(instances[i].Tokens, func(a, b int) bool {
+			return instances[i].Tokens[a] < instances[i].Tokens[b]
+		})
+		iter := v1.NewIterWithIndex[uint32](v1.NewSliceIter(instances[i].Tokens), i)
+		sequences = append(sequences, v1.NewPeekingIter[v1.IndexedValue[uint32]](iter))
+	}
+	it.heap = v1.NewHeapIterator(
+		func(i, j v1.IndexedValue[uint32]) bool {
+			return i.Value() < j.Value()
+		},
+		sequences...,
+	)
+	it.err = nil
+
+	return it
+}

--- a/pkg/bloomutils/ring.go
+++ b/pkg/bloomutils/ring.go
@@ -68,12 +68,12 @@ func GetInstancesWithTokenRanges(id string, instances []ring.InstanceDesc) Insta
 func NewInstanceSortMergeIterator(instances []ring.InstanceDesc) v1.Iterator[InstanceWithTokenRange] {
 	it := &sortMergeIterator[ring.InstanceDesc, uint32, InstanceWithTokenRange]{
 		items: instances,
-		transform: func(item ring.InstanceDesc, val uint32, prev InstanceWithTokenRange) InstanceWithTokenRange {
-			prevToken := prev.MaxToken + 1
-			if prev.MaxToken == 0 {
-				prevToken = 0
+		transform: func(item ring.InstanceDesc, val uint32, prev *InstanceWithTokenRange) *InstanceWithTokenRange {
+			var prevToken uint32
+			if prev != nil {
+				prevToken = prev.MaxToken + 1
 			}
-			return InstanceWithTokenRange{Instance: item, MinToken: prevToken, MaxToken: val}
+			return &InstanceWithTokenRange{Instance: item, MinToken: prevToken, MaxToken: val}
 		},
 	}
 	sequences := make([]v1.PeekingIterator[v1.IndexedValue[uint32]], 0, len(instances))

--- a/pkg/bloomutils/ring.go
+++ b/pkg/bloomutils/ring.go
@@ -67,18 +67,19 @@ func GetInstanceWithTokenRange(id string, instances []ring.InstanceDesc) Instanc
 		return InstancesWithTokenRange{}
 	}
 
-	n := len(instances)
+	i := uint32(idx)
+	n := uint32(len(instances))
 	step := math.MaxUint32 / n
 
-	minToken := uint32(step * idx)
-	maxToken := uint32(step*idx + step - 1)
-	if idx == n-1 {
+	minToken := step * i
+	maxToken := step*i + step - 1
+	if i == n-1 {
 		// extend the last token tange to MaxUint32
 		maxToken = math.MaxUint32
 	}
 
 	return InstancesWithTokenRange{
-		{MinToken: minToken, MaxToken: maxToken, Instance: instances[idx]},
+		{MinToken: minToken, MaxToken: maxToken, Instance: instances[i]},
 	}
 }
 

--- a/pkg/bloomutils/ring_test.go
+++ b/pkg/bloomutils/ring_test.go
@@ -1,0 +1,31 @@
+package bloomutils
+
+import (
+	"testing"
+
+	"github.com/grafana/dskit/ring"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBloomGatewayClient_SortInstancesByToken(t *testing.T) {
+	input := []ring.InstanceDesc{
+		{Id: "1", Tokens: []uint32{5, 9}},
+		{Id: "2", Tokens: []uint32{3, 7}},
+		{Id: "3", Tokens: []uint32{1}},
+	}
+	expected := []InstanceWithTokenRange{
+		{Instance: input[2], MinToken: 0, MaxToken: 1},
+		{Instance: input[1], MinToken: 2, MaxToken: 3},
+		{Instance: input[0], MinToken: 4, MaxToken: 5},
+		{Instance: input[1], MinToken: 6, MaxToken: 7},
+		{Instance: input[0], MinToken: 8, MaxToken: 9},
+	}
+
+	var i int
+	it := NewInstanceSortMergeIterator(input)
+	for it.Next() {
+		t.Log(expected[i], it.At())
+		require.Equal(t, expected[i], it.At())
+		i++
+	}
+}

--- a/pkg/bloomutils/ring_test.go
+++ b/pkg/bloomutils/ring_test.go
@@ -1,6 +1,7 @@
 package bloomutils
 
 import (
+	"math"
 	"testing"
 
 	"github.com/grafana/dskit/ring"
@@ -28,4 +29,36 @@ func TestBloomGatewayClient_SortInstancesByToken(t *testing.T) {
 		require.Equal(t, expected[i], it.At())
 		i++
 	}
+}
+
+func TestBloomGatewayClient_GetInstancesWithTokenRanges(t *testing.T) {
+	t.Run("instance does not own first token in the ring", func(t *testing.T) {
+		input := []ring.InstanceDesc{
+			{Id: "1", Tokens: []uint32{5, 9}},
+			{Id: "2", Tokens: []uint32{3, 7}},
+			{Id: "3", Tokens: []uint32{1}},
+		}
+		expected := InstancesWithTokenRange{
+			{Instance: input[1], MinToken: 2, MaxToken: 3},
+			{Instance: input[1], MinToken: 6, MaxToken: 7},
+		}
+
+		result := GetInstancesWithTokenRanges("2", input)
+		require.Equal(t, expected, result)
+	})
+
+	t.Run("instance owns first token in the ring", func(t *testing.T) {
+		input := []ring.InstanceDesc{
+			{Id: "1", Tokens: []uint32{5, 9}},
+			{Id: "2", Tokens: []uint32{3, 7}},
+			{Id: "3", Tokens: []uint32{1}},
+		}
+		expected := InstancesWithTokenRange{
+			{Instance: input[2], MinToken: 0, MaxToken: 1},
+			{Instance: input[2], MinToken: 10, MaxToken: math.MaxUint32},
+		}
+
+		result := GetInstancesWithTokenRanges("3", input)
+		require.Equal(t, expected, result)
+	})
 }

--- a/pkg/bloomutils/ring_test.go
+++ b/pkg/bloomutils/ring_test.go
@@ -62,3 +62,51 @@ func TestBloomGatewayClient_GetInstancesWithTokenRanges(t *testing.T) {
 		require.Equal(t, expected, result)
 	})
 }
+
+func TestBloomGatewayClient_GetInstanceWithTokenRange(t *testing.T) {
+	for name, tc := range map[string]struct {
+		id       string
+		input    []ring.InstanceDesc
+		expected InstancesWithTokenRange
+	}{
+		"first instance includes 0 token": {
+			id: "3",
+			input: []ring.InstanceDesc{
+				{Id: "1", Tokens: []uint32{3}},
+				{Id: "2", Tokens: []uint32{5}},
+				{Id: "3", Tokens: []uint32{1}},
+			},
+			expected: InstancesWithTokenRange{
+				{Instance: ring.InstanceDesc{Id: "3", Tokens: []uint32{1}}, MinToken: 0, MaxToken: math.MaxUint32/3 - 1},
+			},
+		},
+		"middle instance": {
+			id: "1",
+			input: []ring.InstanceDesc{
+				{Id: "1", Tokens: []uint32{3}},
+				{Id: "2", Tokens: []uint32{5}},
+				{Id: "3", Tokens: []uint32{1}},
+			},
+			expected: InstancesWithTokenRange{
+				{Instance: ring.InstanceDesc{Id: "1", Tokens: []uint32{3}}, MinToken: math.MaxUint32 / 3, MaxToken: math.MaxUint32/3*2 - 1},
+			},
+		},
+		"last instance includes MaxUint32 token": {
+			id: "2",
+			input: []ring.InstanceDesc{
+				{Id: "1", Tokens: []uint32{3}},
+				{Id: "2", Tokens: []uint32{5}},
+				{Id: "3", Tokens: []uint32{1}},
+			},
+			expected: InstancesWithTokenRange{
+				{Instance: ring.InstanceDesc{Id: "2", Tokens: []uint32{5}}, MinToken: math.MaxUint32 / 3 * 2, MaxToken: math.MaxUint32},
+			},
+		},
+	} {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			result := GetInstanceWithTokenRange(tc.id, tc.input)
+			require.Equal(t, tc.expected, result)
+		})
+	}
+}

--- a/pkg/storage/bloom/v1/iter.go
+++ b/pkg/storage/bloom/v1/iter.go
@@ -1,0 +1,70 @@
+package v1
+
+type IndexedValue[T any] struct {
+	idx int
+	val T
+}
+
+func (iv IndexedValue[T]) Value() T {
+	return iv.val
+}
+
+func (iv IndexedValue[T]) Index() int {
+	return iv.idx
+}
+
+type IterWithIndex[T any] struct {
+	Iterator[T]
+	zero  T // zero value of T
+	cache IndexedValue[T]
+}
+
+func (it *IterWithIndex[T]) At() IndexedValue[T] {
+	it.cache.val = it.Iterator.At()
+	return it.cache
+}
+
+func NewIterWithIndex[T any](iter Iterator[T], idx int) Iterator[IndexedValue[T]] {
+	return &IterWithIndex[T]{
+		Iterator: iter,
+		cache:    IndexedValue[T]{idx: idx},
+	}
+}
+
+type SliceIterWithIndex[T any] struct {
+	xs    []T // source slice
+	pos   int // position within the slice
+	zero  T   // zero value of T
+	cache IndexedValue[T]
+}
+
+func (it *SliceIterWithIndex[T]) Next() bool {
+	it.pos++
+	return it.pos < len(it.xs)
+}
+
+func (it *SliceIterWithIndex[T]) Err() error {
+	return nil
+}
+
+func (it *SliceIterWithIndex[T]) At() IndexedValue[T] {
+	it.cache.val = it.xs[it.pos]
+	return it.cache
+}
+
+func (it *SliceIterWithIndex[T]) Peek() (IndexedValue[T], bool) {
+	if it.pos+1 >= len(it.xs) {
+		it.cache.val = it.zero
+		return it.cache, false
+	}
+	it.cache.val = it.xs[it.pos+1]
+	return it.cache, true
+}
+
+func NewSliceIterWithIndex[T any](xs []T, idx int) PeekingIterator[IndexedValue[T]] {
+	return &SliceIterWithIndex[T]{
+		xs:    xs,
+		pos:   -1,
+		cache: IndexedValue[T]{idx: idx},
+	}
+}

--- a/pkg/storage/bloom/v1/iter_test.go
+++ b/pkg/storage/bloom/v1/iter_test.go
@@ -1,0 +1,35 @@
+package v1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSliceIterWithIndex(t *testing.T) {
+	t.Run("SliceIterWithIndex implements PeekingIterator interface", func(t *testing.T) {
+		xs := []string{"a", "b", "c"}
+		it := NewSliceIterWithIndex(xs, 123)
+
+		// peek at first item
+		p, ok := it.Peek()
+		require.True(t, ok)
+		require.Equal(t, "a", p.val)
+		require.Equal(t, 123, p.idx)
+
+		// proceed to first item
+		require.True(t, it.Next())
+		require.Equal(t, "a", it.At().val)
+		require.Equal(t, 123, it.At().idx)
+
+		// proceed to second and third item
+		require.True(t, it.Next())
+		require.True(t, it.Next())
+
+		// peek at non-existing fourth item
+		p, ok = it.Peek()
+		require.False(t, ok)
+		require.Equal(t, "", p.val) // "" is zero value for type string
+		require.Equal(t, 123, p.idx)
+	})
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Calling `c.sharding.OwnsFingerprint(tenant, uint64(fingerprint))` for each Series of a TSDB index is very expensive, because it not only creates the tenant's sub-ring but also needs to check the fingerprint against it.

Instead, we can pre-calculate the current instance's token ranges and check if the (uint32 converted) fingerprint is contained within these ranges.
 
**Special notes for your reviewer**:

The main change of this PR is https://github.com/grafana/loki/commit/5b58326c19eba7058823a5317ff0af2aa0ce8d2c
