### PR TITLE
Wrap VolumeResponse.

### DIFF
--- a/pkg/querier/queryrange/marshal.go
+++ b/pkg/querier/queryrange/marshal.go
@@ -234,6 +234,8 @@ func QueryResponseWrap(res queryrangebase.Response) (*QueryResponse, error) {
 		p.Response = &QueryResponse_Labels{response}
 	case *IndexStatsResponse:
 		p.Response = &QueryResponse_Stats{response}
+	case *VolumeResponse:
+		p.Response = &QueryResponse_Volume{response}
 	case *TopKSketchesResponse:
 		p.Response = &QueryResponse_TopkSketches{response}
 	case *QuantileSketchResponse:

--- a/pkg/querier/queryrange/marshal_test.go
+++ b/pkg/querier/queryrange/marshal_test.go
@@ -47,7 +47,7 @@ func TestResultToResponse(t *testing.T) {
 func TestResponseWrap(t *testing.T) {
 	for _, tt := range []struct {
 		name     string
-		respone  queryrangebase.Response
+		response  queryrangebase.Response
 		expected isQueryResponse_Response
 	}{
 		{"volume", &VolumeResponse{}, &QueryResponse_Volume{}},
@@ -60,7 +60,7 @@ func TestResponseWrap(t *testing.T) {
 		{"quantile", &QuantileSketchResponse{}, &QueryResponse_QuantileSketches{}},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			actual, err := QueryResponseWrap(tt.respone)
+			actual, err := QueryResponseWrap(tt.response)
 			require.NoError(t, err)
 			require.IsType(t, tt.expected, actual.Response)
 		})

--- a/pkg/querier/queryrange/marshal_test.go
+++ b/pkg/querier/queryrange/marshal_test.go
@@ -43,3 +43,26 @@ func TestResultToResponse(t *testing.T) {
 		})
 	}
 }
+
+func TestResponseWrap(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		respone  queryrangebase.Response
+		expected isQueryResponse_Response
+	}{
+		{"volume", &VolumeResponse{}, &QueryResponse_Volume{}},
+		{"series", &LokiSeriesResponse{}, &QueryResponse_Series{}},
+		{"label", &LokiLabelNamesResponse{}, &QueryResponse_Labels{}},
+		{"stats", &IndexStatsResponse{}, &QueryResponse_Stats{}},
+		{"prom", &LokiPromResponse{}, &QueryResponse_Prom{}},
+		{"streams", &LokiResponse{}, &QueryResponse_Streams{}},
+		{"topk", &TopKSketchesResponse{}, &QueryResponse_TopkSketches{}},
+		{"quantile", &QuantileSketchResponse{}, &QueryResponse_QuantileSketches{}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			actual, err := QueryResponseWrap(tt.respone)
+			require.NoError(t, err)
+			require.IsType(t, tt.expected, actual.Response)
+		})
+	}
+}

--- a/pkg/querier/queryrange/marshal_test.go
+++ b/pkg/querier/queryrange/marshal_test.go
@@ -47,7 +47,7 @@ func TestResultToResponse(t *testing.T) {
 func TestResponseWrap(t *testing.T) {
 	for _, tt := range []struct {
 		name     string
-		response  queryrangebase.Response
+		response queryrangebase.Response
 		expected isQueryResponse_Response
 	}{
 		{"volume", &VolumeResponse{}, &QueryResponse_Volume{}},


### PR DESCRIPTION
**What this PR does / why we need it**:
This fixes a regression in `frontend.encoding=protobuf`:

```
body rpc error: code = Internal desc = invalid response format, got (*queryrange.VolumeResponse)
```

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
