### PR TITLE
tests: Disable some `clients/cmd/fluent-bit` tests when `CGO_ENABLED=0`

### DIFF
--- a/clients/cmd/fluent-bit/loki_test.go
+++ b/clients/cmd/fluent-bit/loki_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package main
 
 import (


### PR DESCRIPTION
**What this PR does / why we need it**:

`CGO_ENABLED=0 go test ./...` fails with compile-time errors because the tests are assuming a `logger` variable is defined. However, that variable is defined (and initialized in an `init()`) here, in a file that imports `"C"` and thus requires CGO to be enabled: https://github.com/grafana/loki/blob/5b8d0e666de2221f08a4537d7b5eda0be79f939b/clients/cmd/fluent-bit/out_grafana_loki.go#L3-L34

**Which issue(s) this PR fixes**:
No related issue, but running the tests with `CGO_ENABLED=0 go test -count 1 ./...` results in:
```
# github.com/grafana/loki/clients/cmd/fluent-bit [github.com/grafana/loki/clients/cmd/fluent-bit.test]
./loki_test.go:92:13: undefined: logger
./loki_test.go:133:13: undefined: logger
FAIL	github.com/grafana/loki/clients/cmd/fluent-bit [build failed]
FAIL
```

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
