### PR TITLE
Update out_grafana_loki.go to handle timestamp slice

### DIFF
--- a/clients/cmd/fluent-bit/out_grafana_loki.go
+++ b/clients/cmd/fluent-bit/out_grafana_loki.go
@@ -126,6 +126,9 @@ func FLBPluginFlushCtx(ctx, data unsafe.Pointer, length C.int, _ *C.char) int {
 
 		// Get timestamp
 		var timestamp time.Time
+		if tsSlice, ok := ts.([]interface{}); ok && len(tsSlice) > 0 {
+			ts = tsSlice[0]
+		}
 		switch t := ts.(type) {
 		case output.FLBTime:
 			timestamp = ts.(output.FLBTime).Time


### PR DESCRIPTION
If you, like me, have encountered the error "level=warn caller=out_grafana_loki.go:135 id=0 msg='timestamp isn't known format. Use current time.'" while using Fluent Bit ~ version 2.2.0 along with the fluent-bit-go-loki plugin ~ version 2.9.2, this fix might be beneficial for you.

This commit updates the out_grafana_loki.go file to handle cases where the timestamp is received as a slice of interfaces ([]interface{}). The update includes a check and extraction process for timestamps provided as a slice, ensuring proper recognition and processing of the time data.

This fix is particularly relevant for users who are experiencing issues with timestamp formatting in logs sent to Loki from Fluent Bit using the fluent-bit-go-loki plugin. It aims to provide a more reliable logging data flow and resolve the timestamp format issues that have been observed in these versions.

**What this PR does / why we need it**: fix "timestamp isn't known format. Use current time."

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
