### PR TITLE
compactor: fix metric name for a compactor

### DIFF
--- a/pkg/compactor/metrics.go
+++ b/pkg/compactor/metrics.go
@@ -49,7 +49,7 @@ func newMetrics(r prometheus.Registerer) *metrics {
 			Help:      "Time (in seconds) spent in applying retention",
 		}),
 		applyRetentionLastSuccess: promauto.With(r).NewGauge(prometheus.GaugeOpts{
-			Namespace: "loki_boltdb_shipper",
+			Namespace: "loki_compactor",
 			Name:      "apply_retention_last_successful_run_timestamp_seconds",
 			Help:      "Unix timestamp of the last successful retention run",
 		}),


### PR DESCRIPTION
**What this PR does / why we need it**:
I added a new metric but prefixed it by mistake with `loki_boltdb_shipper` instead of `loki_compactor`. This PR fixes it.
