### PR TITLE
alphabetize headings and add mini-TOC

### DIFF
--- a/docs/sources/send-data/promtail/scraping.md
+++ b/docs/sources/send-data/promtail/scraping.md
@@ -9,6 +9,65 @@ weight:  400
 
 # Configuring Promtail for service discovery
 
+Promtail currently supports scraping from the following sources:
+
+- [Azure event hubs]({{< relref "#azure-event-hubs" >}})
+- [Cloudflare]({{< relref "#cloudflare" >}})
+- [File target discovery]({{< relref "#file-target-discovery" >}})
+- [GCP Logs]({{< relref "#gcp-log-scraping" >}})
+- [GELF]({{< relref "#gelf" >}})
+- [Heroku Drain]({{< relref "#gcp-log-scraping" >}})
+- [HTTP client]({{< relref "#http-client" >}})
+- [journal scraping]({{< relref "#journal-scraping-linux-only" >}}) 
+- [Kafka]({{< relref "#kafka" >}})
+- [Relabeling]({{< relref "#relabeling" >}})
+- [Syslog]({{< relref "#syslog-receiver" >}})
+- [Windows]({{< relref "#windows-event-log" >}})
+
+## Azure Event Hubs
+
+Promtail supports reading messages from Azure Event Hubs.
+Targets can be configured using the `azure_event_hubs` stanza:
+
+```yaml
+- job_name: azure_event_hubs
+  azure_event_hubs:
+    group_id: "mygroup"
+    fully_qualified_namespace: my-namespace.servicebus.windows.net:9093
+    connection_string: "my-connection-string"
+    event_hubs:
+      - event-hub-name
+    labels:
+      job: azure_event_hub
+  relabel_configs:
+    - action: replace
+      source_labels:
+        - __azure_event_hubs_category
+      target_label: category
+```
+
+Only `fully_qualified_namespace`, `connection_string` and `event_hubs` are required fields.
+Read the [configuration]({{< relref "./configuration#azure-event-hubs" >}}) section for more information.
+
+## Cloudflare
+
+Promtail supports pulling HTTP log messages from Cloudflare using the [Logpull API](https://developers.cloudflare.com/logs/logpull).
+The Cloudflare targets can be configured with a `cloudflare` block:
+
+```yaml
+scrape_configs:
+- job_name: cloudflare
+  cloudflare:
+    api_token: REDACTED
+    zone_id: REDACTED
+    fields_type: all
+    labels:
+      job: cloudflare-foo.com
+```
+
+Only `api_token` and `zone_id` are required.
+Refer to the [Cloudfare]({{< relref "./configuration#cloudflare" >}}) configuration section for details.
+
 ## File Target Discovery
 
 Promtail discovers locations of log files and extract labels from them through
@@ -89,118 +148,6 @@ relabel_configs:
 ```
 
 See [Relabeling](#relabeling) for more information. For more information on how to configure the service discovery see the [Kubernetes Service Discovery configuration]({{< relref "./configuration#kubernetes_sd_config" >}}).
-
-## Journal Scraping (Linux Only)
-
-On systems with `systemd`, Promtail also supports reading from the journal. Unlike
-file scraping which is defined in the `static_configs` stanza, journal scraping is
-defined in a `journal` stanza:
-
-```yaml
-scrape_configs:
-  - job_name: journal
-    journal:
-      json: false
-      max_age: 12h
-      path: /var/log/journal
-      matches: _TRANSPORT=kernel
-      labels:
-        job: systemd-journal
-    relabel_configs:
-      - source_labels: ['__journal__systemd_unit']
-        target_label: 'unit'
-```
-
-All fields defined in the `journal` section are optional, and are just provided
-here for reference. The `max_age` field ensures that no older entry than the
-time specified will be sent to Loki; this circumvents "entry too old" errors.
-The `path` field tells Promtail where to read journal entries from. The labels
-map defines a constant list of labels to add to every journal entry that Promtail
-reads. The `matches` field adds journal filters. If multiple filters are specified
-matching different fields, the log entries are filtered by both, if two filters
-apply to the same field, then they are automatically matched as alternatives.
-
-When the `json` field is set to `true`, messages from the journal will be
-passed through the pipeline as JSON, keeping all of the original fields from the
-journal entry. This is useful when you don't want to index some fields but you
-still want to know what values they contained.
-
-By default, Promtail reads from the journal by looking in the `/var/log/journal`
-and `/run/log/journal` paths. If running Promtail inside of a Docker container,
-the path appropriate to your distribution should be bind mounted inside of
-Promtail along with binding `/etc/machine-id`. Bind mounting `/etc/machine-id`
-to the path of the same name is required for the journal reader to know which
-specific journal to read from. For example:
-
-```bash
-docker run \
-  -v /var/log/journal/:/var/log/journal/ \
-  -v /run/log/journal/:/run/log/journal/ \
-  -v /etc/machine-id:/etc/machine-id \
-  grafana/promtail:latest \
-  -config.file=/path/to/config/file.yaml
-```
-
-When Promtail reads from the journal, it brings in all fields prefixed with
-`__journal_` as internal labels. Like in the example above, the `_SYSTEMD_UNIT`
-field from the journal was transformed into a label called `unit` through
-`relabel_configs`. See [Relabeling](#relabeling) for more information, also look at [the systemd man pages](https://www.freedesktop.org/software/systemd/man/systemd.journal-fields.html) for a list of fields exposed by the journal.
-
-Here's an example where the `SYSTEMD_UNIT`, `HOSTNAME`, and `SYSLOG_IDENTIFIER` are relabeled for use in Loki.
-
-Keep in mind that labels prefixed with `__` will be dropped, so relabeling is required to keep these labels.
-
-```yaml
-- job_name: systemd-journal
-  journal:
-    labels:
-      cluster: ops-tools1
-      job: default/systemd-journal
-    path: /var/log/journal
-  relabel_configs:
-  - source_labels:
-    - __journal__systemd_unit
-    target_label: systemd_unit
-  - source_labels:
-    - __journal__hostname
-    target_label: nodename
-  - source_labels:
-    - __journal_syslog_identifier
-    target_label: syslog_identifier
-```
-
-## Windows Event Log
-
-On Windows Promtail supports reading from the event log.
-Windows event targets can be configured using the `windows_events` stanza:
-
-
-```yaml
-scrape_configs:
-- job_name: windows
-  windows_events:
-    use_incoming_timestamp: false
-    bookmark_path: "./bookmark.xml"
-    eventlog_name: "Application"
-    xpath_query: '*'
-    labels:
-      job: windows
-  relabel_configs:
-    - source_labels: ['computer']
-      target_label: 'host'
-```
-
-When Promtail receives an event it will attach the `channel` and `computer` labels
-and serialize the event in json.
-You can relabel default labels via [Relabeling](#relabeling) if required.
-
-Providing a path to a bookmark is mandatory, it will be used to persist the last event processed and allow
-resuming the target without skipping logs.
-
-Read the [configuration]({{< relref "./configuration#windows_events" >}}) section for more information.
-
-See the [eventlogmessage]({{< relref "./stages/eventlogmessage" >}}) stage for extracting
-data from the `message`.
 
 ## GCP Log scraping
 
@@ -287,6 +234,284 @@ In the example above, the `__gcp_message_id` and the `__gcp_attributes_logging_g
 transformed to `message_id` and `incoming_ts` through `relabel_configs`. All other internal labels, for example some other attribute,
 will be dropped by the target if not transformed.
 
+## GELF
+
+Promtail supports listening message using the [GELF](https://docs.graylog.org/docs/gelf) UDP protocol.
+The GELF targets can be configured using the `gelf` stanza:
+
+```yaml
+scrape_configs:
+- job_name: gelf
+  gelf:
+    listen_address: "0.0.0.0:12201"
+    use_incoming_timestamp: true
+    labels:
+      job: gelf
+  relabel_configs:
+      - action: replace
+        source_labels:
+          - __gelf_message_host
+        target_label: host
+      - action: replace
+        source_labels:
+          - __gelf_message_level
+        target_label: level
+      - action: replace
+        source_labels:
+          - __gelf_message_facility
+        target_label: facility
+```
+
+## Heroku Drain
+Promtail supports receiving logs from a Heroku application by using a [Heroku HTTPS Drain](https://devcenter.heroku.com/articles/log-drains#https-drains).
+Configuration is specified in a`heroku_drain` block within the Promtail `scrape_config` configuration.
+
+```yaml
+- job_name: heroku_drain
+    heroku_drain:
+      server:
+        http_listen_address: 0.0.0.0
+        http_listen_port: 8080
+      labels:
+        job: heroku_drain_docs
+      use_incoming_timestamp: true
+    relabel_configs:
+      - source_labels: ['__heroku_drain_host']
+        target_label: 'host'
+      - source_labels: ['__heroku_drain_app']
+        target_label: 'source'
+      - source_labels: ['__heroku_drain_proc']
+        target_label: 'proc'
+      - source_labels: ['__heroku_drain_log_id']
+        target_label: 'log_id'
+```
+Within the `scrape_configs` configuration for a Heroku Drain target, the `job_name` must be a Prometheus-compatible [metric name](https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels).
+
+The [server]({{< relref "./configuration#server" >}}) section configures the HTTP server created for receiving logs.
+`labels` defines a static set of label values added to each received log entry. `use_incoming_timestamp` can be used to pass
+the timestamp received from Heroku.
+
+Before using a `heroku_drain` target, Heroku should be configured with the URL where the Promtail instance will be listening.
+Follow the steps in [Heroku HTTPS Drain docs](https://devcenter.heroku.com/articles/log-drains#https-drains) for using the Heroku CLI
+with a command like the following:
+
+```
+heroku drains:add [http|https]://HOSTNAME:8080/heroku/api/v1/drain -a HEROKU_APP_NAME
+```
+
+### Getting the Heroku application name
+
+Note that the `__heroku_drain_app` label will contain the source of the log line, either `app` or `heroku` and not the name of the heroku application.
+
+The easiest way to provide the actual application name is to include a query parameter when creating the heroku drain and then relabel that parameter in your scraping config, for example:
+
+```
+heroku drains:add [http|https]://HOSTNAME:8080/heroku/api/v1/drain?app_name=HEROKU_APP_NAME -a HEROKU_APP_NAME
+
+```
+
+And then in a relabel_config:
+
+```yaml
+    relabel_configs:
+      - source_labels: ['__heroku_drain_param_app_name']
+        target_label: 'app'
+```
+
+It also supports `relabeling` and `pipeline` stages just like other targets.
+
+When Promtail receives Heroku Drain logs, various internal labels are made available for [relabeling](#relabeling):
+- `__heroku_drain_host`
+- `__heroku_drain_app`
+- `__heroku_drain_proc`
+- `__heroku_drain_log_id`
+In the example above, the `project_id` label from a GCP resource was transformed into a label called `project` through `relabel_configs`.
+
+## HTTP client
+
+Promtail uses the Prometheus HTTP client implementation for all calls to Loki.
+Therefore it can be configured using the `clients` stanza, where one or more
+connections to Loki can be established:
+
+```yaml
+clients:
+  - [ <client_option> ]
+```
+
+Refer to [`client_config`]({{< relref "./configuration#clients" >}}) from the Promtail
+Configuration reference for all available options.
+
+## Journal Scraping (Linux Only)
+
+On systems with `systemd`, Promtail also supports reading from the journal. Unlike
+file scraping which is defined in the `static_configs` stanza, journal scraping is
+defined in a `journal` stanza:
+
+```yaml
+scrape_configs:
+  - job_name: journal
+    journal:
+      json: false
+      max_age: 12h
+      path: /var/log/journal
+      matches: _TRANSPORT=kernel
+      labels:
+        job: systemd-journal
+    relabel_configs:
+      - source_labels: ['__journal__systemd_unit']
+        target_label: 'unit'
+```
+
+All fields defined in the `journal` section are optional, and are just provided
+here for reference. The `max_age` field ensures that no older entry than the
+time specified will be sent to Loki; this circumvents "entry too old" errors.
+The `path` field tells Promtail where to read journal entries from. The labels
+map defines a constant list of labels to add to every journal entry that Promtail
+reads. The `matches` field adds journal filters. If multiple filters are specified
+matching different fields, the log entries are filtered by both, if two filters
+apply to the same field, then they are automatically matched as alternatives.
+
+When the `json` field is set to `true`, messages from the journal will be
+passed through the pipeline as JSON, keeping all of the original fields from the
+journal entry. This is useful when you don't want to index some fields but you
+still want to know what values they contained.
+
+By default, Promtail reads from the journal by looking in the `/var/log/journal`
+and `/run/log/journal` paths. If running Promtail inside of a Docker container,
+the path appropriate to your distribution should be bind mounted inside of
+Promtail along with binding `/etc/machine-id`. Bind mounting `/etc/machine-id`
+to the path of the same name is required for the journal reader to know which
+specific journal to read from. For example:
+
+```bash
+docker run \
+  -v /var/log/journal/:/var/log/journal/ \
+  -v /run/log/journal/:/run/log/journal/ \
+  -v /etc/machine-id:/etc/machine-id \
+  grafana/promtail:latest \
+  -config.file=/path/to/config/file.yaml
+```
+
+When Promtail reads from the journal, it brings in all fields prefixed with
+`__journal_` as internal labels. Like in the example above, the `_SYSTEMD_UNIT`
+field from the journal was transformed into a label called `unit` through
+`relabel_configs`. See [Relabeling](#relabeling) for more information, also look at [the systemd man pages](https://www.freedesktop.org/software/systemd/man/systemd.journal-fields.html) for a list of fields exposed by the journal.
+
+Here's an example where the `SYSTEMD_UNIT`, `HOSTNAME`, and `SYSLOG_IDENTIFIER` are relabeled for use in Loki.
+
+Keep in mind that labels prefixed with `__` will be dropped, so relabeling is required to keep these labels.
+
+```yaml
+- job_name: systemd-journal
+  journal:
+    labels:
+      cluster: ops-tools1
+      job: default/systemd-journal
+    path: /var/log/journal
+  relabel_configs:
+  - source_labels:
+    - __journal__systemd_unit
+    target_label: systemd_unit
+  - source_labels:
+    - __journal__hostname
+    target_label: nodename
+  - source_labels:
+    - __journal_syslog_identifier
+    target_label: syslog_identifier
+```
+
+## Kafka
+
+Promtail supports reading message from Kafka using a consumer group.
+The Kafka targets can be configured using the `kafka` stanza:
+
+```yaml
+scrape_configs:
+- job_name: kafka
+  kafka:
+    brokers:
+    - my-kafka-0.org:50705
+    - my-kafka-1.org:50705
+    topics:
+    - ^promtail.*
+    - some_fixed_topic
+    labels:
+      job: kafka
+  relabel_configs:
+      - action: replace
+        source_labels:
+          - __meta_kafka_topic
+        target_label: topic
+      - action: replace
+        source_labels:
+          - __meta_kafka_partition
+        target_label: partition
+      - action: replace
+        source_labels:
+          - __meta_kafka_group_id
+        target_label: group
+      - action: replace
+        source_labels:
+          - __meta_kafka_message_key
+        target_label: message_key
+```
+
+Only the `brokers` and `topics` are required.
+Read the [configuration]({{< relref "./configuration#kafka" >}}) section for more information.
+
+## Relabeling
+
+Each `scrape_configs` entry can contain a `relabel_configs` stanza.
+`relabel_configs` is a list of operations to transform the labels from discovery
+into another form.
+
+A single entry in `relabel_configs` can also reject targets by doing an `action:
+drop` if a label value matches a specified regex. When a target is dropped, the
+owning `scrape_config` will not process logs from that particular source.
+Other `scrape_configs` without the drop action reading from the same target
+may still use and forward logs from it to Loki.
+
+A common use case of `relabel_configs` is to transform an internal label such
+as `__meta_kubernetes_*` into an intermediate internal label such as
+`__service__`. The intermediate internal label may then be dropped based on
+value or transformed to a final external label, such as `__job__`.
+
+### Examples
+
+- Drop the target if a label (`__service__` in the example) is empty:
+```yaml
+  - action: drop
+    regex: ''
+    source_labels:
+    - __service__
+```
+- Drop the target if any of the `source_labels` contain a value:
+```yaml
+  - action: drop
+    regex: .+
+    separator: ''
+    source_labels:
+    - __meta_kubernetes_pod_label_name
+    - __meta_kubernetes_pod_label_app
+```
+- Persist an internal label by renaming it so it will be sent to Loki:
+```yaml
+  - action: replace
+    source_labels:
+    - __meta_kubernetes_namespace
+    target_label: namespace
+```
+- Persist all Kubernetes pod labels by mapping them, like by mapping
+    `__meta_kube__meta_kubernetes_pod_label_foo` to `foo`.
+```yaml
+  - action: labelmap
+    regex: __meta_kubernetes_pod_label_(.+)
+```
+
+Additional reading:
+
+ - [Julien Pivotto's slides from PromConf Munich, 2017](https://www.slideshare.net/roidelapluie/taking-advantage-of-prometheus-relabeling-109483749)
+
 ## Syslog Receiver
 
 Promtail supports receiving [IETF Syslog (RFC5424)](https://tools.ietf.org/html/rfc5424)
@@ -355,246 +580,35 @@ For sending messages via UDP:
 *.* action(type="omfwd" protocol="udp" target="<promtail_host>" port="<promtail_port>" Template="RSYSLOG_SyslogProtocol23Format")
 ```
 
-## Azure Event Hubs
+## Windows Event Log
 
-Promtail supports reading messages from Azure Event Hubs.
-Targets can be configured using the `azure_event_hubs` stanza:
+On Windows Promtail supports reading from the event log.
+Windows event targets can be configured using the `windows_events` stanza:
 
-```yaml
-- job_name: azure_event_hubs
-  azure_event_hubs:
-    group_id: "mygroup"
-    fully_qualified_namespace: my-namespace.servicebus.windows.net:9093
-    connection_string: "my-connection-string"
-    event_hubs:
-      - event-hub-name
-    labels:
-      job: azure_event_hub
-  relabel_configs:
-    - action: replace
-      source_labels:
-        - __azure_event_hubs_category
-      target_label: category
-```
-
-Only `fully_qualified_namespace`, `connection_string` and `event_hubs` are required fields.
-Read the [configuration]({{< relref "./configuration#azure-event-hubs" >}}) section for more information.
-
-## Kafka
-
-Promtail supports reading message from Kafka using a consumer group.
-The Kafka targets can be configured using the `kafka` stanza:
 
 ```yaml
 scrape_configs:
-- job_name: kafka
-  kafka:
-    brokers:
-    - my-kafka-0.org:50705
-    - my-kafka-1.org:50705
-    topics:
-    - ^promtail.*
-    - some_fixed_topic
+- job_name: windows
+  windows_events:
+    use_incoming_timestamp: false
+    bookmark_path: "./bookmark.xml"
+    eventlog_name: "Application"
+    xpath_query: '*'
     labels:
-      job: kafka
+      job: windows
   relabel_configs:
-      - action: replace
-        source_labels:
-          - __meta_kafka_topic
-        target_label: topic
-      - action: replace
-        source_labels:
-          - __meta_kafka_partition
-        target_label: partition
-      - action: replace
-        source_labels:
-          - __meta_kafka_group_id
-        target_label: group
-      - action: replace
-        source_labels:
-          - __meta_kafka_message_key
-        target_label: message_key
+    - source_labels: ['computer']
+      target_label: 'host'
 ```
 
-Only the `brokers` and `topics` are required.
-Read the [configuration]({{< relref "./configuration#kafka" >}}) section for more information.
+When Promtail receives an event it will attach the `channel` and `computer` labels
+and serialize the event in json.
+You can relabel default labels via [Relabeling](#relabeling) if required.
 
+Providing a path to a bookmark is mandatory, it will be used to persist the last event processed and allow
+resuming the target without skipping logs.
 
-## GELF
+Read the [configuration]({{< relref "./configuration#windows_events" >}}) section for more information.
 
-Promtail supports listening message using the [GELF](https://docs.graylog.org/docs/gelf) UDP protocol.
-The GELF targets can be configured using the `gelf` stanza:
-
-```yaml
-scrape_configs:
-- job_name: gelf
-  gelf:
-    listen_address: "0.0.0.0:12201"
-    use_incoming_timestamp: true
-    labels:
-      job: gelf
-  relabel_configs:
-      - action: replace
-        source_labels:
-          - __gelf_message_host
-        target_label: host
-      - action: replace
-        source_labels:
-          - __gelf_message_level
-        target_label: level
-      - action: replace
-        source_labels:
-          - __gelf_message_facility
-        target_label: facility
-```
-
-## Cloudflare
-
-Promtail supports pulling HTTP log messages from Cloudflare using the [Logpull API](https://developers.cloudflare.com/logs/logpull).
-The Cloudflare targets can be configured with a `cloudflare` block:
-
-```yaml
-scrape_configs:
-- job_name: cloudflare
-  cloudflare:
-    api_token: REDACTED
-    zone_id: REDACTED
-    fields_type: all
-    labels:
-      job: cloudflare-foo.com
-```
-
-Only `api_token` and `zone_id` are required.
-Refer to the [Cloudfare]({{< relref "./configuration#cloudflare" >}}) configuration section for details.
-
-## Heroku Drain
-Promtail supports receiving logs from a Heroku application by using a [Heroku HTTPS Drain](https://devcenter.heroku.com/articles/log-drains#https-drains).
-Configuration is specified in a`heroku_drain` block within the Promtail `scrape_config` configuration.
-
-```yaml
-- job_name: heroku_drain
-    heroku_drain:
-      server:
-        http_listen_address: 0.0.0.0
-        http_listen_port: 8080
-      labels:
-        job: heroku_drain_docs
-      use_incoming_timestamp: true
-    relabel_configs:
-      - source_labels: ['__heroku_drain_host']
-        target_label: 'host'
-      - source_labels: ['__heroku_drain_app']
-        target_label: 'source'
-      - source_labels: ['__heroku_drain_proc']
-        target_label: 'proc'
-      - source_labels: ['__heroku_drain_log_id']
-        target_label: 'log_id'
-```
-Within the `scrape_configs` configuration for a Heroku Drain target, the `job_name` must be a Prometheus-compatible [metric name](https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels).
-
-The [server]({{< relref "./configuration#server" >}}) section configures the HTTP server created for receiving logs.
-`labels` defines a static set of label values added to each received log entry. `use_incoming_timestamp` can be used to pass
-the timestamp received from Heroku.
-
-Before using a `heroku_drain` target, Heroku should be configured with the URL where the Promtail instance will be listening.
-Follow the steps in [Heroku HTTPS Drain docs](https://devcenter.heroku.com/articles/log-drains#https-drains) for using the Heroku CLI
-with a command like the following:
-
-```
-heroku drains:add [http|https]://HOSTNAME:8080/heroku/api/v1/drain -a HEROKU_APP_NAME
-```
-
-### Getting the Heroku application name
-
-Note that the `__heroku_drain_app` label will contain the source of the log line, either `app` or `heroku` and not the name of the heroku application.
-
-The easiest way to provide the actual application name is to include a query parameter when creating the heroku drain and then relabel that parameter in your scraping config, for example:
-
-```
-heroku drains:add [http|https]://HOSTNAME:8080/heroku/api/v1/drain?app_name=HEROKU_APP_NAME -a HEROKU_APP_NAME
-
-```
-
-And then in a relabel_config:
-
-```yaml
-    relabel_configs:
-      - source_labels: ['__heroku_drain_param_app_name']
-        target_label: 'app'
-```
-
-It also supports `relabeling` and `pipeline` stages just like other targets.
-
-When Promtail receives Heroku Drain logs, various internal labels are made available for [relabeling](#relabeling):
-- `__heroku_drain_host`
-- `__heroku_drain_app`
-- `__heroku_drain_proc`
-- `__heroku_drain_log_id`
-In the example above, the `project_id` label from a GCP resource was transformed into a label called `project` through `relabel_configs`.
-
-## Relabeling
-
-Each `scrape_configs` entry can contain a `relabel_configs` stanza.
-`relabel_configs` is a list of operations to transform the labels from discovery
-into another form.
-
-A single entry in `relabel_configs` can also reject targets by doing an `action:
-drop` if a label value matches a specified regex. When a target is dropped, the
-owning `scrape_config` will not process logs from that particular source.
-Other `scrape_configs` without the drop action reading from the same target
-may still use and forward logs from it to Loki.
-
-A common use case of `relabel_configs` is to transform an internal label such
-as `__meta_kubernetes_*` into an intermediate internal label such as
-`__service__`. The intermediate internal label may then be dropped based on
-value or transformed to a final external label, such as `__job__`.
-
-### Examples
-
-- Drop the target if a label (`__service__` in the example) is empty:
-```yaml
-  - action: drop
-    regex: ''
-    source_labels:
-    - __service__
-```
-- Drop the target if any of the `source_labels` contain a value:
-```yaml
-  - action: drop
-    regex: .+
-    separator: ''
-    source_labels:
-    - __meta_kubernetes_pod_label_name
-    - __meta_kubernetes_pod_label_app
-```
-- Persist an internal label by renaming it so it will be sent to Loki:
-```yaml
-  - action: replace
-    source_labels:
-    - __meta_kubernetes_namespace
-    target_label: namespace
-```
-- Persist all Kubernetes pod labels by mapping them, like by mapping
-    `__meta_kube__meta_kubernetes_pod_label_foo` to `foo`.
-```yaml
-  - action: labelmap
-    regex: __meta_kubernetes_pod_label_(.+)
-```
-
-Additional reading:
-
- - [Julien Pivotto's slides from PromConf Munich, 2017](https://www.slideshare.net/roidelapluie/taking-advantage-of-prometheus-relabeling-109483749)
-
-## HTTP client options
-
-Promtail uses the Prometheus HTTP client implementation for all calls to Loki.
-Therefore it can be configured using the `clients` stanza, where one or more
-connections to Loki can be established:
-
-```yaml
-clients:
-  - [ <client_option> ]
-```
-
-Refer to [`client_config`]({{< relref "./configuration#clients" >}}) from the Promtail
-Configuration reference for all available options.
+See the [eventlogmessage]({{< relref "./stages/eventlogmessage" >}}) stage for extracting
+data from the `message`.


### PR DESCRIPTION
**What this PR does / why we need it**:
Replaces @Alex3k PR #9058 which has gone quite stale (file has moved, new content has been added).

Adds a mini table of contents at the beginning of the page with links to headings.
Rearranges the headings so that they are in alphabetical order.

**Special notes for your reviewer**:
Content below line 27 is unchanged and previously published, it has only been moved in the file.