### PR TITLE
Shortcut callback execution if there are 1 or fewer elements

### DIFF
--- a/pkg/storage/stores/shipper/indexshipper/downloads/index_set.go
+++ b/pkg/storage/stores/shipper/indexshipper/downloads/index_set.go
@@ -224,8 +224,8 @@ func (t *indexSet) ForEachConcurrent(ctx context.Context, callback index.ForEach
 		}
 	}
 
-	var g *errgroup.Group
-	g, ctx = errgroup.WithContext(ctx)
+	//nolint:ineffassign,staticcheck
+	g, ctx := errgroup.WithContext(ctx)
 	if t.maxConcurrent == 0 {
 		panic("maxConcurrent cannot be 0, indexSet is being initialized without setting maxConcurrent")
 	}

--- a/pkg/storage/stores/shipper/indexshipper/downloads/index_set.go
+++ b/pkg/storage/stores/shipper/indexshipper/downloads/index_set.go
@@ -209,14 +209,22 @@ func (t *indexSet) ForEachConcurrent(ctx context.Context, callback index.ForEach
 	}
 	defer t.indexMtx.rUnlock()
 
+	logger := util_log.WithContext(ctx, t.logger)
+	level.Debug(logger).Log("index-files-count", len(t.index))
+
+	// shortcut; if there's only one index, there's no need for bounded concurrency
+	if len(t.index) == 1 {
+		for i := range t.index {
+			idx := t.index[i]
+			return callback(t.userID == "", idx)
+		}
+	}
+
 	g, ctx := errgroup.WithContext(ctx)
 	if t.maxConcurrent == 0 {
 		panic("maxConcurrent cannot be 0, indexSet is being initialized without setting maxConcurrent")
 	}
 	g.SetLimit(t.maxConcurrent)
-
-	logger := util_log.WithContext(ctx, t.logger)
-	level.Debug(logger).Log("index-files-count", len(t.index))
 
 	for i := range t.index {
 		idx := t.index[i]

--- a/pkg/storage/stores/shipper/indexshipper/downloads/index_set.go
+++ b/pkg/storage/stores/shipper/indexshipper/downloads/index_set.go
@@ -224,7 +224,8 @@ func (t *indexSet) ForEachConcurrent(ctx context.Context, callback index.ForEach
 		}
 	}
 
-	g, ctx := errgroup.WithContext(ctx)
+	var g *errgroup.Group
+	g, ctx = errgroup.WithContext(ctx)
 	if t.maxConcurrent == 0 {
 		panic("maxConcurrent cannot be 0, indexSet is being initialized without setting maxConcurrent")
 	}

--- a/pkg/storage/stores/shipper/indexshipper/downloads/index_set.go
+++ b/pkg/storage/stores/shipper/indexshipper/downloads/index_set.go
@@ -212,6 +212,10 @@ func (t *indexSet) ForEachConcurrent(ctx context.Context, callback index.ForEach
 	logger := util_log.WithContext(ctx, t.logger)
 	level.Debug(logger).Log("index-files-count", len(t.index))
 
+	if len(t.index) == 0 {
+		return nil
+	}
+
 	// shortcut; if there's only one index, there's no need for bounded concurrency
 	if len(t.index) == 1 {
 		for i := range t.index {

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/multi_file_index.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/multi_file_index.go
@@ -35,6 +35,11 @@ type IndexIter interface {
 type IndexSlice []Index
 
 func (xs IndexSlice) For(ctx context.Context, maxConcurrent int, fn func(context.Context, Index) error) error {
+	// shortcut; if there's only one slice, there's no need for bounded concurrency
+	if len(xs) == 1 {
+		return fn(ctx, xs[0])
+	}
+
 	g, ctx := errgroup.WithContext(ctx)
 	if maxConcurrent == 0 {
 		panic("maxConcurrent cannot be 0, IndexIter is being called with a maxConcurrent of 0")

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/multi_file_index.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/multi_file_index.go
@@ -35,6 +35,10 @@ type IndexIter interface {
 type IndexSlice []Index
 
 func (xs IndexSlice) For(ctx context.Context, maxConcurrent int, fn func(context.Context, Index) error) error {
+	if len(xs) == 0 {
+		return nil
+	}
+
 	// shortcut; if there's only one slice, there's no need for bounded concurrency
 	if len(xs) == 1 {
 		return fn(ctx, xs[0])


### PR DESCRIPTION
**What this PR does / why we need it**:
In the case where we have zero elements, we can exit early; with 1 element there's no need for concurrency.
This will provide a small optimisation and also make our profiles/execution traces easier to read.

We have a fairly significant amount of requests which don't require concurrency:
<img width="1503" alt="image" src="https://github.com/grafana/loki/assets/373762/30d74966-0c87-49fd-8db9-d7ab92999d09">

