### PR TITLE
Avoid reading block files into memory

### DIFF
--- a/pkg/bloomcompactor/chunkcompactor.go
+++ b/pkg/bloomcompactor/chunkcompactor.go
@@ -174,7 +174,7 @@ func compactNewChunks(
 	}
 
 	// Build and upload bloomBlock to storage
-	block, err := buildBlockFromBlooms(ctx, logger, builder, blooms, job)
+	block, err := buildBlockFromBlooms(ctx, logger, builder, v1.NewSliceIter(blooms), job)
 	if err != nil {
 		level.Error(logger).Log("msg", "building bloomBlocks", "err", err)
 		return bloomshipper.Block{}, err

--- a/pkg/bloomcompactor/chunkcompactor_test.go
+++ b/pkg/bloomcompactor/chunkcompactor_test.go
@@ -147,6 +147,6 @@ func (pbb *mockPersistentBlockBuilder) BuildFrom(_ v1.Iterator[v1.SeriesWithBloo
 	return 0, nil
 }
 
-func (pbb *mockPersistentBlockBuilder) Data() (io.ReadCloser, error) {
+func (pbb *mockPersistentBlockBuilder) Data() (io.ReadSeekCloser, error) {
 	return nil, nil
 }

--- a/pkg/bloomcompactor/chunkcompactor_test.go
+++ b/pkg/bloomcompactor/chunkcompactor_test.go
@@ -125,18 +125,90 @@ func TestChunkCompactor_CompactNewChunks(t *testing.T) {
 	require.Equal(t, indexPath, compactedBlock.IndexPath)
 }
 
+func TestLazyBloomBuilder(t *testing.T) {
+	label := labels.FromStrings("foo", "bar")
+	fp1 := model.Fingerprint(100)
+	fp2 := model.Fingerprint(999)
+	fp3 := model.Fingerprint(200)
+
+	chunkRef1 := index.ChunkMeta{
+		Checksum: 1,
+		MinTime:  1,
+		MaxTime:  99,
+	}
+
+	chunkRef2 := index.ChunkMeta{
+		Checksum: 2,
+		MinTime:  10,
+		MaxTime:  999,
+	}
+
+	seriesMetas := []seriesMeta{
+		{
+			seriesFP:  fp1,
+			seriesLbs: label,
+			chunkRefs: []index.ChunkMeta{chunkRef1},
+		},
+		{
+			seriesFP:  fp2,
+			seriesLbs: label,
+			chunkRefs: []index.ChunkMeta{chunkRef1, chunkRef2},
+		},
+		{
+			seriesFP:  fp3,
+			seriesLbs: label,
+			chunkRefs: []index.ChunkMeta{chunkRef1, chunkRef1, chunkRef2},
+		},
+	}
+
+	job := NewJob(userID, table, indexPath, seriesMetas)
+
+	mbt := &mockBloomTokenizer{}
+	mcc := &mockChunkClient{}
+
+	it := newLazyBloomBuilder(context.Background(), job, mcc, mbt, fpRate)
+
+	// first seriesMeta has 1 chunks
+	require.True(t, it.Next())
+	require.Equal(t, 1, mcc.requestCount)
+	require.Equal(t, 1, mcc.chunkCount)
+	require.Equal(t, fp1, it.At().Series.Fingerprint)
+
+	// first seriesMeta has 2 chunks
+	require.True(t, it.Next())
+	require.Equal(t, 2, mcc.requestCount)
+	require.Equal(t, 3, mcc.chunkCount)
+	require.Equal(t, fp2, it.At().Series.Fingerprint)
+
+	// first seriesMeta has 3 chunks
+	require.True(t, it.Next())
+	require.Equal(t, 3, mcc.requestCount)
+	require.Equal(t, 6, mcc.chunkCount)
+	require.Equal(t, fp3, it.At().Series.Fingerprint)
+
+	// interator is done
+	require.False(t, it.Next())
+	require.Error(t, io.EOF, it.Err())
+	require.Equal(t, v1.SeriesWithBloom{}, it.At())
+}
+
 type mockBloomTokenizer struct {
 	chunks []chunk.Chunk
 }
 
 func (mbt *mockBloomTokenizer) PopulateSeriesWithBloom(_ *v1.SeriesWithBloom, c []chunk.Chunk) error {
-	mbt.chunks = c
+	mbt.chunks = append(mbt.chunks, c...)
 	return nil
 }
 
-type mockChunkClient struct{}
+type mockChunkClient struct {
+	requestCount int
+	chunkCount   int
+}
 
-func (mcc *mockChunkClient) GetChunks(_ context.Context, _ []chunk.Chunk) ([]chunk.Chunk, error) {
+func (mcc *mockChunkClient) GetChunks(_ context.Context, chks []chunk.Chunk) ([]chunk.Chunk, error) {
+	mcc.requestCount++
+	mcc.chunkCount += len(chks)
 	return nil, nil
 }
 

--- a/pkg/storage/stores/shipper/bloomshipper/block_downloader.go
+++ b/pkg/storage/stores/shipper/bloomshipper/block_downloader.go
@@ -181,7 +181,7 @@ type blockWithQuerier struct {
 }
 
 // extract the files into directory and returns absolute path to this directory.
-func (d *blockDownloader) extractBlock(block *Block, ts time.Time) (string, error) {
+func (d *blockDownloader) extractBlock(block *LazyBlock, ts time.Time) (string, error) {
 	workingDirectoryPath := filepath.Join(d.workingDirectory, block.BlockPath, strconv.FormatInt(ts.UnixMilli(), 10))
 	err := os.MkdirAll(workingDirectoryPath, os.ModePerm)
 	if err != nil {
@@ -213,7 +213,7 @@ func (d *blockDownloader) stop() {
 	d.wg.Wait()
 }
 
-func writeDataToTempFile(workingDirectoryPath string, block *Block) (string, error) {
+func writeDataToTempFile(workingDirectoryPath string, block *LazyBlock) (string, error) {
 	defer block.Data.Close()
 	archivePath := filepath.Join(workingDirectoryPath, block.BlockPath[strings.LastIndex(block.BlockPath, delimiter)+1:])
 

--- a/pkg/storage/stores/shipper/bloomshipper/client.go
+++ b/pkg/storage/stores/shipper/bloomshipper/client.go
@@ -191,10 +191,11 @@ func findPeriod(configs []config.PeriodConfig, timestamp int64) (config.DayTime,
 	}
 	return config.DayTime{}, fmt.Errorf("can not find period for timestamp %d", timestamp)
 }
+
 func (b *BloomClient) DeleteMeta(ctx context.Context, meta Meta) error {
 	periodFrom, err := findPeriod(b.periodicConfigs, meta.StartTimestamp)
 	if err != nil {
-		return fmt.Errorf("error updloading meta file: %w", err)
+		return err
 	}
 	key := createMetaObjectKey(meta.MetaRef.Ref)
 	return b.periodicObjectClients[periodFrom].DeleteObject(ctx, key)

--- a/pkg/storage/stores/shipper/bloomshipper/client.go
+++ b/pkg/storage/stores/shipper/bloomshipper/client.go
@@ -279,13 +279,9 @@ func (b *BloomClient) downloadMeta(ctx context.Context, metaRef MetaRef, client 
 	if err != nil {
 		return Meta{}, fmt.Errorf("error downloading meta file %s : %w", metaRef.FilePath, err)
 	}
-	defer func() { _ = reader.Close() }()
+	defer reader.Close()
 
-	buf, err := io.ReadAll(reader)
-	if err != nil {
-		return Meta{}, fmt.Errorf("error reading meta file %s: %w", metaRef.FilePath, err)
-	}
-	err = json.Unmarshal(buf, &meta)
+	err = json.NewDecoder(reader).Decode(&meta)
 	if err != nil {
 		return Meta{}, fmt.Errorf("error unmarshalling content of meta file %s: %w", metaRef.FilePath, err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Bloom blocks in the wild likely exceed the memory resources of a compactor. Therefore we need to make sure that we don't copy block data into memory, but rather write to and read from disk.