### PR TITLE
Add trivy filesystem scanning

### DIFF
--- a/.github/workflows/snyk-pr-comment.yml
+++ b/.github/workflows/snyk-pr-comment.yml
@@ -39,6 +39,8 @@ jobs:
           if [[ $(wc -l < snyk.txt) -gt 1 ]]; then exit 0; fi
           exit 1
 
+          echo "\nTo see more details on these vulnerabilities, and how/where to fix them, please run `make scan-vulnerabilities` on your branch. If these were not introduced by your PR, please considering fixing them in `main` via a subsequent PR. Thanks!" >> snyk.txt
+
       - name: Comment on PR with Snyk scan results
         uses: mshick/add-pr-comment@v2
         if: ${{ steps.should-comment.outcome == 'success' }}

--- a/.github/workflows/snyk-pr-comment.yml
+++ b/.github/workflows/snyk-pr-comment.yml
@@ -36,10 +36,12 @@ jobs:
         continue-on-error: true
         id: should-comment
         run: |
-          if [[ $(wc -l < snyk.txt) -gt 1 ]]; then exit 0; fi
-          exit 1
+          if [[ $(wc -l < snyk.txt) -gt 1 ]]; then
+            echo "\nTo see more details on these vulnerabilities, and how/where to fix them, please run `make scan-vulnerabilities` on your branch. If these were not introduced by your PR, please considering fixing them in `main` via a subsequent PR. Thanks!" >> snyk.txt
+            exit 0;
+          fi
 
-          echo "\nTo see more details on these vulnerabilities, and how/where to fix them, please run `make scan-vulnerabilities` on your branch. If these were not introduced by your PR, please considering fixing them in `main` via a subsequent PR. Thanks!" >> snyk.txt
+          exit 1
 
       - name: Comment on PR with Snyk scan results
         uses: mshick/add-pr-comment@v2

--- a/.github/workflows/trivy-pr-comment.yml
+++ b/.github/workflows/trivy-pr-comment.yml
@@ -52,10 +52,12 @@ jobs:
         continue-on-error: true
         id: should-comment
         run: |
-          if [[ $(wc -l < trivy.txt) -gt 1 ]]; then exit 0; fi
-          exit 1
+          if [[ $(wc -l < trivy.txt) -gt 1 ]]; then
+            echo "\nTo see more details on these vulnerabilities, and how/where to fix them, please run `make scan-vulnerabilities` on your branch. If these were not introduced by your PR, please considering fixing them in `main` via a subsequent PR. Thanks!" >> trivy.txt
+            exit 0;
+          fi
 
-          echo "\nTo see more details on these vulnerabilities, and how/where to fix them, please run `make scan-vulnerabilities` on your branch. If these were not introduced by your PR, please considering fixing them in `main` via a subsequent PR. Thanks!" >> trivy.txt
+          exit 1
 
       - name: Comment on PR with Trivy scan results
         uses: mshick/add-pr-comment@v2

--- a/.github/workflows/trivy-pr-comment.yml
+++ b/.github/workflows/trivy-pr-comment.yml
@@ -55,6 +55,8 @@ jobs:
           if [[ $(wc -l < trivy.txt) -gt 1 ]]; then exit 0; fi
           exit 1
 
+          echo "\nTo see more details on these vulnerabilities, and how/where to fix them, please run `make scan-vulnerabilities` on your branch. If these were not introduced by your PR, please considering fixing them in `main` via a subsequent PR. Thanks!" >> trivy.txt
+
       - name: Comment on PR with Trivy scan results
         uses: mshick/add-pr-comment@v2
         if: ${{ steps.should-comment.outcome == 'success' }}

--- a/.github/workflows/trivy-pr-comment.yml
+++ b/.github/workflows/trivy-pr-comment.yml
@@ -19,12 +19,21 @@ jobs:
           make loki-image
           echo "IMAGE_TAG=${IMAGE_TAG}" >> $GITHUB_ENV
 
-      - name: Run Trivy vulnerability scanner
+      - name: Run Trivy image scanner
         uses: aquasecurity/trivy-action@master
         with:
           image-ref: "docker.io/grafana/loki:${{ env.IMAGE_TAG }}"
           format: "json"
-          output: "trivy.json"
+          output: "trivy-image.json"
+          severity: "CRITICAL,HIGH"
+
+      - name: Run Trivy fs scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: "fs"
+          scan-ref: "go.mod"
+          format: "json"
+          output: "trivy-fs.json"
           severity: "CRITICAL,HIGH"
 
       - name: Prepare Trivy Message
@@ -35,7 +44,9 @@ jobs:
         uses: sergeysova/jq-action@v2
         continue-on-error: true
         with:
-          cmd: jq -r '.Results[] | select(.Vulnerabilities != null) | .Vulnerabilities[] | "* **\(.Severity)** [\(.Title)](\(.PrimaryURL)) in `\(.PkgName)` v\(.InstalledVersion). Fixed in v\(.FixedVersion)"' trivy.json >> trivy.txt
+          cmd: |
+            jq -r '.Results[] | select(.Vulnerabilities != null) | .Target as $target | .Type as $type | .Vulnerabilities[] | "* **\(.Severity)**, Target: \($target), Type: \($type) [\(.Title)](\(.PrimaryURL)) in `\(.PkgName)` v\(.InstalledVersion). Fixed in v\(.FixedVersion)"' trivy-image.json >> trivy.txt
+            jq -r '.Results[] | select(.Vulnerabilities != null) | .Target as $target | .Type as $type | .Vulnerabilities[] | "* **\(.Severity)**, Target: \($target), Type: \($type) [\(.Title)](\(.PrimaryURL)) in `\(.PkgName)` v\(.InstalledVersion). Fixed in v\(.FixedVersion)"' trivy-fs.json >> trivy.text
 
       - name: Determine whether to comment
         continue-on-error: true

--- a/Makefile
+++ b/Makefile
@@ -838,6 +838,7 @@ dev-k3d-down:
 .PHONY: trivy
 trivy: loki-image
 	trivy i $(IMAGE_PREFIX)/loki:$(IMAGE_TAG)
+	trivy fs go.mod
 
 # Synk is also used to scan for vulnerabilities, and detects things that trivy might miss
 .PHONY: snyk


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds trivy filesystem scanning to our Makefile and PR pipelines. This will scan the `go.mod` file for vulnerabilities in dependencies, which are sometimes missed by just scanning the image.

PS @dannykopping this also adds the changes to the vulnerabilities output we talked about that should make it easier to identify a) where the vulnerability is (ie. docker image / os dep vs go.mod dep), and b) what version the dependency needs to be updated to in order to fix it.
