### PR TITLE
Revert "bugfix(memcached): Make `memcached` batch fetch truely context aware"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@
 
 ##### Enhancements
 
-* [11363](https://github.com/grafana/loki/pull/11363) **kavirajk**: bugfix(memcached): Make memcached batch fetch truely context aware.
 * [11319](https://github.com/grafana/loki/pull/11319) **someStrangerFromTheAbyss**: Helm: Add extraContainers to the write pods.
 * [11243](https://github.com/grafana/loki/pull/11243) **kavirajk**: Inflight-logging: Add extra metadata to inflight requests logging.
 * [11110](https://github.com/grafana/loki/pull/11003) **MichelHollands**: Change the default of the `metrics-namespace` flag to 'loki'.

--- a/pkg/storage/chunk/cache/memcached_client_test.go
+++ b/pkg/storage/chunk/cache/memcached_client_test.go
@@ -9,8 +9,6 @@ import (
 type mockMemcache struct {
 	sync.RWMutex
 	contents map[string][]byte
-
-	keysFetchedCount int
 }
 
 func newMockMemcache() *mockMemcache {
@@ -22,7 +20,6 @@ func newMockMemcache() *mockMemcache {
 func (m *mockMemcache) GetMulti(keys []string, _ ...memcache.Option) (map[string]*memcache.Item, error) {
 	m.RLock()
 	defer m.RUnlock()
-	m.keysFetchedCount += len(keys)
 	result := map[string]*memcache.Item{}
 	for _, k := range keys {
 		if c, ok := m.contents[k]; ok {

--- a/pkg/storage/chunk/cache/memcached_test.go
+++ b/pkg/storage/chunk/cache/memcached_test.go
@@ -4,10 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strconv"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/go-kit/log"
 	"github.com/grafana/gomemcache/memcache"
@@ -19,178 +17,44 @@ import (
 )
 
 func TestMemcached_fetchKeysBatched(t *testing.T) {
-	// This test checks for three things
+	// This test checks for two things
 	// 1. `c.inputCh` is closed when `c.Stop()` is triggered
 	// 2. Once `c.inputCh` is closed, no one should be writing to `c.inputCh` (thus shouldn't panic with "send to closed channel")
-	// 3. Once the `ctx` is cancelled or timeout, it should stop fetching the keys.
 
-	t.Run("inputCh is closed without panics when Stop() is triggered", func(t *testing.T) {
-		client := newMockMemcache()
-		m := cache.NewMemcached(cache.MemcachedConfig{
-			BatchSize:   10,
-			Parallelism: 5,
-		}, client, "test", nil, log.NewNopLogger(), "test")
+	client := newMockMemcache()
+	m := cache.NewMemcached(cache.MemcachedConfig{
+		BatchSize:   10,
+		Parallelism: 5,
+	}, client, "test", nil, log.NewNopLogger(), "test")
 
-		var (
-			wg   sync.WaitGroup
-			wait = make(chan struct{}) // chan to make goroutine wait till `m.Stop()` is called.
-			ctx  = context.Background()
-		)
+	var (
+		wg      sync.WaitGroup
+		stopped = make(chan struct{}) // chan to make goroutine wait till `m.Stop()` is called.
+		ctx     = context.Background()
+	)
 
-		wg.Add(1)
+	wg.Add(1)
 
-		// This goroutine is going to do some real "work" (writing to `c.inputCh`). We then do `m.Stop()` closing `c.inputCh`. We assert there shouldn't be any panics.
-		go func() {
-			defer wg.Done()
-			<-wait
-			assert.NotPanics(t, func() {
-				keys := []string{"1", "2"}
-				bufs := [][]byte{[]byte("1"), []byte("2")}
-				err := m.Store(ctx, keys, bufs)
-				require.NoError(t, err)
+	// This goroutine is going to do some real "work" (writing to `c.inputCh`). We then do `m.Stop()` closing `c.inputCh`. We assert there shouldn't be any panics.
+	go func() {
+		defer wg.Done()
+		<-stopped
+		assert.NotPanics(t, func() {
+			keys := []string{"1", "2"}
+			bufs := [][]byte{[]byte("1"), []byte("2")}
+			err := m.Store(ctx, keys, bufs)
+			require.NoError(t, err)
 
-				_, _, _, err = m.Fetch(ctx, keys) // will try to write to `intputChan` and shouldn't panic
-				require.NoError(t, err)
+			_, _, _, err = m.Fetch(ctx, keys) // will try to write to `intputChan` and shouldn't panic
+			require.NoError(t, err)
 
-			})
-		}()
+		})
+	}()
 
-		m.Stop()
-		close(wait)
+	m.Stop()
+	close(stopped)
 
-		wg.Wait()
-
-	})
-
-	t.Run("stop fetching when context cancelled", func(t *testing.T) {
-		client := newMockMemcache()
-		m := cache.NewMemcached(cache.MemcachedConfig{
-			BatchSize:   10,
-			Parallelism: 5,
-		}, client, "test", nil, log.NewNopLogger(), "test")
-
-		var (
-			wg             sync.WaitGroup
-			wait           = make(chan struct{})
-			ctx, ctxCancel = context.WithCancel(context.Background())
-		)
-
-		wg.Add(1)
-
-		// This goroutine is going to do some real "work" (writing to `c.inputCh`). We then cancel passed context closing `c.inputCh`.
-		// We assert there shouldn't be any panics and it stopped fetching keys.
-		go func() {
-			defer wg.Done()
-			assert.NotPanics(t, func() {
-				keys := []string{"1", "2"}
-				bufs := [][]byte{[]byte("1"), []byte("2")}
-				err := m.Store(ctx, keys, bufs)
-				require.NoError(t, err)
-				<-wait                            // wait before fetching
-				_, _, _, err = m.Fetch(ctx, keys) // will try to write to `intputChan` and shouldn't panic
-				require.ErrorIs(t, err, context.Canceled)
-			})
-		}()
-
-		ctxCancel() // cancel even before single fetch is done.
-		close(wait) // start the fetching
-		wg.Wait()
-		require.Equal(t, 0, client.keysFetchedCount) // client.GetMulti shouldn't have called because context is cancelled before.
-		m.Stop()                                     // cancelation and Stop() should be able to work.
-
-	})
-
-	t.Run("stop fetching in-between, when context cancelled", func(t *testing.T) {
-		client := newMockMemcache()
-		m := cache.NewMemcached(cache.MemcachedConfig{
-			BatchSize:   2, // Less batch size to create interleving between each batch
-			Parallelism: 3, // means it starts 3 go routines to fetch whatever number of keys we give, fetching 2 keys in each fetch.
-		}, client, "test", nil, log.NewNopLogger(), "test")
-
-		var (
-			wg              sync.WaitGroup
-			wait            = make(chan struct{})
-			ctx, ctxCancel  = context.WithCancel(context.Background())
-			numKeys         = 1500
-			waitBeforeFetch = 100 * time.Millisecond
-			delayFetch      = make(chan struct{})
-		)
-
-		m.SetTestFetchDelay(delayFetch)
-		wg.Add(1)
-
-		// This goroutine is going to do some real "work" (writing to `c.inputCh`). We then cancel passed context closing `c.inputCh`.
-		// We assert there shouldn't be any panics and it stopped fetching keys.
-		go func() {
-			defer wg.Done()
-			assert.NotPanics(t, func() {
-				// these many keys, because we have
-				// BatchSize: 2 and Paralleslism: 3
-				// it starts 3 go routines to fetch 15 keys in total, fetching 2 keys in each fetch.
-				keys, values := genKeysValues(numKeys)
-				err := m.Store(ctx, keys, values)
-				require.NoError(t, err)
-				<-wait                            // wait before fetching
-				_, _, _, err = m.Fetch(ctx, keys) // will try to write to `intputChan` and shouldn't panic
-				require.ErrorIs(t, err, context.Canceled)
-			})
-		}()
-
-		close(wait) // start the fetching
-
-		go func() {
-			// this waits for at least one batch fetch and cancel after fetching begins
-			time.Sleep(waitBeforeFetch)
-			close(delayFetch) // should have fetched **at least** one batch after closing this.
-			ctxCancel()
-		}()
-
-		wg.Wait()
-		require.NotEqual(t, client.keysFetchedCount, 0)   // should have fetched some keys.
-		require.Less(t, client.keysFetchedCount, numKeys) // but not all the keys because ctx cancelled in-between.
-		m.Stop()
-
-	})
-
-	t.Run("stop fetching when context timeout", func(t *testing.T) {
-		cancelTimeout := 100 * time.Millisecond
-
-		client := newMockMemcache()
-		m := cache.NewMemcached(cache.MemcachedConfig{
-			BatchSize:   10,
-			Parallelism: 5,
-		}, client, "test", nil, log.NewNopLogger(), "test")
-
-		var (
-			wg             sync.WaitGroup
-			wait           = make(chan struct{})
-			ctx, ctxCancel = context.WithTimeout(context.Background(), cancelTimeout)
-		)
-		wg.Add(1)
-
-		// This goroutine is going to do some real "work" (writing to `c.inputCh`). We then wait till context timeout happens closing `c.inputCh`.
-		// We assert there shouldn't be any panics and it stopped fetching keys.
-		go func() {
-			defer wg.Done()
-			assert.NotPanics(t, func() {
-				keys := []string{"1", "2"}
-				bufs := [][]byte{[]byte("1"), []byte("2")}
-				err := m.Store(ctx, keys, bufs)
-				require.NoError(t, err)
-				<-wait                            // wait before fetching
-				_, _, _, err = m.Fetch(ctx, keys) // will try to write to `intputChan` and shouldn't panic
-				require.ErrorIs(t, err, context.DeadlineExceeded)
-			})
-		}()
-
-		time.Sleep(cancelTimeout + (5 * time.Millisecond)) // wait till context timeout
-		close(wait)                                        // start the fetching
-		wg.Wait()
-		require.Equal(t, 0, client.keysFetchedCount) // client.GetMulti shouldn't have called because context is timedout before.
-		m.Stop()                                     // cancelation and Stop() should be able to work.
-		ctxCancel()                                  // finally cancel context for cleanup sake
-
-	})
+	wg.Wait()
 }
 
 func TestMemcached(t *testing.T) {
@@ -336,18 +200,4 @@ func testMemcacheFailing(t *testing.T, memcache *cache.Memcached) {
 			require.True(t, ok, "key missing %s", key)
 		}
 	}
-}
-
-// generate `n` keys values with numerical value from 1-n (inclusive)
-func genKeysValues(n int) ([]string, [][]byte) {
-	keys := make([]string, 0, n)
-	values := make([][]byte, 0, n)
-
-	for i := 0; i < n; i++ {
-		s := strconv.Itoa(i + 1)
-		keys = append(keys, s)
-		values = append(values, []byte(s))
-	}
-
-	return keys, values
 }


### PR DESCRIPTION
Reverts grafana/loki#11363

This PR was causing some issue. Spend some time testing on some internal cell. Still couldn't track down the issue yet. Reverting to make `main` stable for now.