### PR TITLE
fix: scheduler discovery service may collid with other loki install

### DIFF
--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -13,6 +13,10 @@ Entries should include a reference to the pull request that introduced the chang
 
 [//]: # (<AUTOMATED_UPDATES_LOCATOR> : do not remove this line. This locator is used by the CI pipeline to automatically create a changelog entry for each new Loki release. Add other chart versions and respective changelog entries bellow this line.)
 
+## 5.41.3
+
+- [BUGFIX] Fix query-scheduler service name conflict
+
 ## 5.41.2
 
 - [FEATURE] Add ciliumnetworkpolicies.

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -3,7 +3,7 @@ name: loki
 description: Helm chart for Grafana Loki in simple, scalable mode
 type: application
 appVersion: 2.9.3
-version: 5.41.2
+version: 5.41.3
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -1,6 +1,6 @@
 # loki
 
-![Version: 5.41.2](https://img.shields.io/badge/Version-5.41.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.9.3](https://img.shields.io/badge/AppVersion-2.9.3-informational?style=flat-square)
+![Version: 5.41.3](https://img.shields.io/badge/Version-5.41.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.9.3](https://img.shields.io/badge/AppVersion-2.9.3-informational?style=flat-square)
 
 Helm chart for Grafana Loki in simple, scalable mode
 

--- a/production/helm/loki/templates/_helpers.tpl
+++ b/production/helm/loki/templates/_helpers.tpl
@@ -878,7 +878,8 @@ enableServiceLinks: false
 {{- $isSimpleScalable := eq (include "loki.deployment.isScalable" .) "true" -}}
 {{- $schedulerAddress := ""}}
 {{- if and $isSimpleScalable (not .Values.read.legacyReadTarget ) -}}
-{{- $schedulerAddress = printf "query-scheduler-discovery.%s.svc.%s.:9095" .Release.Namespace .Values.global.clusterDomain -}}
+{{- $backendHost := include "loki.backendFullname" .}}
+{{- $schedulerAddress = printf "%s-scheduler-discovery.%s.svc.%s.:9095" $backendHost .Release.Namespace .Values.global.clusterDomain -}}
 {{- end -}}
 {{- printf "%s" $schedulerAddress }}
 {{- end }}

--- a/production/helm/loki/templates/backend/query-scheduler-discovery.yaml
+++ b/production/helm/loki/templates/backend/query-scheduler-discovery.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: query-scheduler-discovery
+  name: {{ include "loki.backendFullname" . }}-scheduler-discovery
   labels:
     {{- include "loki.backendSelectorLabels" . | nindent 4 }}
     prometheus.io/service-monitor: "false"


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes a resource conflict which may occurs if you intend to install multiple instances of loki in a same namespace.

**Which issue(s) this PR fixes**:
Fixes conflict introduced in #9477 

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [ ] ~Tests updated~
- [x] `CHANGELOG.md` updated
  - [x] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [] ~Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`~
- [x] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
