### PR TITLE
Refactor Distributor.Push() to be able to Tee log streams.

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -272,9 +272,14 @@ func (d *Distributor) stopping(_ error) error {
 	return services.StopManagerAndAwaitStopped(context.Background(), d.subservices)
 }
 
+type KeyedStream struct {
+	HashKey uint32
+	Stream  logproto.Stream
+}
+
 // TODO taken from Cortex, see if we can refactor out an usable interface.
 type streamTracker struct {
-	stream      logproto.Stream
+	KeyedStream
 	minSuccess  int
 	maxFailures int
 	succeeded   atomic.Int32
@@ -305,8 +310,7 @@ func (d *Distributor) Push(ctx context.Context, req *logproto.PushRequest) (*log
 	// First we flatten out the request into a list of samples.
 	// We use the heuristic of 1 sample per TS to size the array.
 	// We also work out the hash value at the same time.
-	streams := make([]streamTracker, 0, len(req.Streams))
-	keys := make([]uint32, 0, len(req.Streams))
+	streams := make([]KeyedStream, 0, len(req.Streams))
 	validatedLineSize := 0
 	validatedLineCount := 0
 
@@ -379,12 +383,12 @@ func (d *Distributor) Push(ctx context.Context, req *logproto.PushRequest) (*log
 
 			shardStreamsCfg := d.validator.Limits.ShardStreams(tenantID)
 			if shardStreamsCfg.Enabled {
-				derivedKeys, derivedStreams := d.shardStream(stream, pushSize, tenantID)
-				keys = append(keys, derivedKeys...)
-				streams = append(streams, derivedStreams...)
+				streams = append(streams, d.shardStream(stream, pushSize, tenantID)...)
 			} else {
-				keys = append(keys, lokiring.TokenFor(tenantID, stream.Labels))
-				streams = append(streams, streamTracker{stream: stream})
+				streams = append(streams, KeyedStream{
+					HashKey: lokiring.TokenFor(tenantID, stream.Labels),
+					Stream:  stream,
+				})
 			}
 		}
 	}()
@@ -413,6 +417,7 @@ func (d *Distributor) Push(ctx context.Context, req *logproto.PushRequest) (*log
 	const maxExpectedReplicationSet = 5 // typical replication factor 3 plus one for inactive plus one for luck
 	var descs [maxExpectedReplicationSet]ring.InstanceDesc
 
+	streamTrackers := make([]streamTracker, len(streams))
 	streamsByIngester := map[string][]*streamTracker{}
 	ingesterDescs := map[string]ring.InstanceDesc{}
 
@@ -425,16 +430,19 @@ func (d *Distributor) Push(ctx context.Context, req *logproto.PushRequest) (*log
 			}()
 		}
 
-		for i, key := range keys {
-			replicationSet, err := d.ingestersRing.Get(key, ring.WriteNoExtend, descs[:0], nil, nil)
+		for i, stream := range streams {
+			replicationSet, err := d.ingestersRing.Get(stream.HashKey, ring.WriteNoExtend, descs[:0], nil, nil)
 			if err != nil {
 				return err
 			}
 
-			streams[i].minSuccess = len(replicationSet.Instances) - replicationSet.MaxErrors
-			streams[i].maxFailures = replicationSet.MaxErrors
+			streamTrackers[i] = streamTracker{
+				KeyedStream: stream,
+				minSuccess:  len(replicationSet.Instances) - replicationSet.MaxErrors,
+				maxFailures: replicationSet.MaxErrors,
+			}
 			for _, ingester := range replicationSet.Instances {
-				streamsByIngester[ingester.Addr] = append(streamsByIngester[ingester.Addr], &streams[i])
+				streamsByIngester[ingester.Addr] = append(streamsByIngester[ingester.Addr], &streamTrackers[i])
 				ingesterDescs[ingester.Addr] = ingester
 			}
 		}
@@ -475,13 +483,13 @@ func (d *Distributor) Push(ctx context.Context, req *logproto.PushRequest) (*log
 // streams and their associated keys for hashing to ingesters.
 //
 // The number of shards is limited by the number of entries.
-func (d *Distributor) shardStream(stream logproto.Stream, pushSize int, tenantID string) ([]uint32, []streamTracker) {
+func (d *Distributor) shardStream(stream logproto.Stream, pushSize int, tenantID string) []KeyedStream {
 	shardStreamsCfg := d.validator.Limits.ShardStreams(tenantID)
 	logger := log.With(util_log.WithUserID(tenantID, d.logger), "stream", stream.Labels)
 	shardCount := d.shardCountFor(logger, &stream, pushSize, tenantID, shardStreamsCfg)
 
 	if shardCount <= 1 {
-		return []uint32{lokiring.TokenFor(tenantID, stream.Labels)}, []streamTracker{{stream: stream}}
+		return []KeyedStream{{HashKey: lokiring.TokenFor(tenantID, stream.Labels), Stream: stream}}
 	}
 
 	d.streamShardCount.Inc()
@@ -492,31 +500,30 @@ func (d *Distributor) shardStream(stream logproto.Stream, pushSize int, tenantID
 	return d.divideEntriesBetweenShards(tenantID, shardCount, shardStreamsCfg, stream)
 }
 
-func (d *Distributor) divideEntriesBetweenShards(tenantID string, totalShards int, shardStreamsCfg *shardstreams.Config, stream logproto.Stream) ([]uint32, []streamTracker) {
-	derivedKeys, derivedStreams := d.createShards(stream, totalShards, tenantID, shardStreamsCfg)
+func (d *Distributor) divideEntriesBetweenShards(tenantID string, totalShards int, shardStreamsCfg *shardstreams.Config, stream logproto.Stream) []KeyedStream {
+	derivedStreams := d.createShards(stream, totalShards, tenantID, shardStreamsCfg)
 
 	for i := 0; i < len(stream.Entries); i++ {
 		streamIndex := i % len(derivedStreams)
-		entries := append(derivedStreams[streamIndex].stream.Entries, stream.Entries[i])
-		derivedStreams[streamIndex].stream.Entries = entries
+		entries := append(derivedStreams[streamIndex].Stream.Entries, stream.Entries[i])
+		derivedStreams[streamIndex].Stream.Entries = entries
 	}
 
-	return derivedKeys, derivedStreams
+	return derivedStreams
 }
 
-func (d *Distributor) createShards(stream logproto.Stream, totalShards int, tenantID string, shardStreamsCfg *shardstreams.Config) ([]uint32, []streamTracker) {
+func (d *Distributor) createShards(stream logproto.Stream, totalShards int, tenantID string, shardStreamsCfg *shardstreams.Config) []KeyedStream {
 	var (
 		streamLabels   = labelTemplate(stream.Labels, d.logger)
 		streamPattern  = streamLabels.String()
-		derivedKeys    = make([]uint32, 0, totalShards)
-		derivedStreams = make([]streamTracker, 0, totalShards)
+		derivedStreams = make([]KeyedStream, 0, totalShards)
 
 		streamCount = streamCount(totalShards, stream)
 	)
 
 	if totalShards <= 0 {
 		level.Error(d.logger).Log("msg", "attempt to create shard with zeroed total shards", "org_id", tenantID, "stream", stream.Labels, "entries_len", len(stream.Entries))
-		return derivedKeys, derivedStreams
+		return derivedStreams
 	}
 
 	entriesPerShard := int(math.Ceil(float64(len(stream.Entries)) / float64(totalShards)))
@@ -525,8 +532,10 @@ func (d *Distributor) createShards(stream logproto.Stream, totalShards int, tena
 		shardNum := (startShard + i) % totalShards
 		shard := d.createShard(streamLabels, streamPattern, shardNum, entriesPerShard)
 
-		derivedKeys = append(derivedKeys, lokiring.TokenFor(tenantID, shard.Labels))
-		derivedStreams = append(derivedStreams, streamTracker{stream: shard})
+		derivedStreams = append(derivedStreams, KeyedStream{
+			HashKey: lokiring.TokenFor(tenantID, shard.Labels),
+			Stream:  shard,
+		})
 
 		if shardStreamsCfg.LoggingEnabled {
 			level.Info(d.logger).Log("msg", "stream derived from sharding", "src-stream", stream.Labels, "derived-stream", shard.Labels)
@@ -534,7 +543,7 @@ func (d *Distributor) createShards(stream logproto.Stream, totalShards int, tena
 	}
 	d.shardTracker.SetLastShardNum(tenantID, stream.Hash, startShard+streamCount)
 
-	return derivedKeys, derivedStreams
+	return derivedStreams
 }
 
 func streamCount(totalShards int, stream logproto.Stream) int {
@@ -649,7 +658,7 @@ func (d *Distributor) sendStreamsErr(ctx context.Context, ingester ring.Instance
 		Streams: make([]logproto.Stream, len(streams)),
 	}
 	for i, s := range streams {
-		req.Streams[i] = s.stream
+		req.Streams[i] = s.Stream
 	}
 
 	_, err = c.(logproto.PusherClient).Push(ctx, req)

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -616,16 +616,16 @@ func TestStreamShard(t *testing.T) {
 				shardTracker:     NewShardTracker(),
 			}
 
-			_, derivedStreams := d.shardStream(baseStream, tc.streamSize, "fake")
+			derivedStreams := d.shardStream(baseStream, tc.streamSize, "fake")
 			require.Len(t, derivedStreams, tc.wantDerivedStreamSize)
 
 			for _, s := range derivedStreams {
 				// Generate sorted labels
-				lbls, err := syntax.ParseLabels(s.stream.Labels)
+				lbls, err := syntax.ParseLabels(s.Stream.Labels)
 				require.NoError(t, err)
 
-				require.Equal(t, lbls.Hash(), s.stream.Hash)
-				require.Equal(t, lbls.String(), s.stream.Labels)
+				require.Equal(t, lbls.Hash(), s.Stream.Hash)
+				require.Equal(t, lbls.String(), s.Stream.Labels)
 			}
 		})
 	}
@@ -661,23 +661,23 @@ func TestStreamShardAcrossCalls(t *testing.T) {
 			shardTracker:     NewShardTracker(),
 		}
 
-		_, derivedStreams := d.shardStream(baseStream, streamRate, "fake")
+		derivedStreams := d.shardStream(baseStream, streamRate, "fake")
 		require.Len(t, derivedStreams, 2)
 
 		for i, s := range derivedStreams {
-			require.Len(t, s.stream.Entries, 1)
-			lbls, err := syntax.ParseLabels(s.stream.Labels)
+			require.Len(t, s.Stream.Entries, 1)
+			lbls, err := syntax.ParseLabels(s.Stream.Labels)
 			require.NoError(t, err)
 
 			require.Equal(t, lbls[0].Value, fmt.Sprint(i))
 		}
 
-		_, derivedStreams = d.shardStream(baseStream, streamRate, "fake")
+		derivedStreams = d.shardStream(baseStream, streamRate, "fake")
 		require.Len(t, derivedStreams, 2)
 
 		for i, s := range derivedStreams {
-			require.Len(t, s.stream.Entries, 1)
-			lbls, err := syntax.ParseLabels(s.stream.Labels)
+			require.Len(t, s.Stream.Entries, 1)
+			lbls, err := syntax.ParseLabels(s.Stream.Labels)
 			require.NoError(t, err)
 
 			require.Equal(t, lbls[0].Value, fmt.Sprint(i+2))


### PR DESCRIPTION
**What this PR does / why we need it**:

This allows us to duplicate (i.e. "tee") some of the log streams from the `Distributor` by introducing an optional interface in a follow-up PR.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
See inline comments

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
