### PR TITLE
Add log duplication (tee-ing) in the Distributor

### DIFF
--- a/pkg/distributor/tee.go
+++ b/pkg/distributor/tee.go
@@ -1,0 +1,6 @@
+package distributor
+
+// Tee imlpementations can duplicate the log streams to another endpoint.
+type Tee interface {
+	Duplicate([]KeyedStream)
+}

--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -323,6 +323,7 @@ type Loki struct {
 	clientMetrics       storage.ClientMetrics
 	deleteClientMetrics *deletion.DeleteRequestClientMetrics
 
+	Tee                distributor.Tee
 	HTTPAuthMiddleware middleware.Interface
 
 	Codec   Codec

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -319,6 +319,7 @@ func (t *Loki) initDistributor() (services.Service, error) {
 		t.Overrides,
 		prometheus.DefaultRegisterer,
 		t.Cfg.MetricsNamespace,
+		t.Tee,
 		logger,
 	)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

This allows us to inject a `Tee` in the `Distributor` that can duplicate all of the incoming log stream, before they are replicated.

**Which issue(s) this PR fixes**:
No issue

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
