### PR TITLE
Always set matcher in label filter deserialization.

### DIFF
--- a/pkg/logql/syntax/serialize.go
+++ b/pkg/logql/syntax/serialize.go
@@ -623,9 +623,7 @@ func decodeLabelFilter(iter *jsoniter.Iterator) log.LabelFilterer {
 			}
 
 			var matcher *labels.Matcher
-			if name != "" && value != "" {
-				matcher = labels.MustNewMatcher(t, name, value)
-			}
+			matcher = labels.MustNewMatcher(t, name, value)
 
 			filter = log.NewStringLabelFilter(matcher)
 

--- a/pkg/logql/syntax/serialize_test.go
+++ b/pkg/logql/syntax/serialize_test.go
@@ -12,46 +12,44 @@ func TestJSONSerializationRoundTrip(t *testing.T) {
 	tests := map[string]struct {
 		query string
 	}{
-		/*
-			"simple matchers": {
-				query: `{env="prod", app=~"loki.*"}`,
-			},
-			"simple aggregation": {
-				query: `count_over_time({env="prod", app=~"loki.*"}[5m])`,
-			},
-			"simple aggregation with unwrap": {
-				query: `sum_over_time({env="prod", app=~"loki.*"} | unwrap bytes[5m])`,
-			},
-			"bin op": {
-				query: `(count_over_time({env="prod", app=~"loki.*"}[5m]) >= 0)`,
-			},
-			"label filter": {
-				query: `{app="foo"} |= "bar" | json | ( latency>=250ms or ( status_code<500 , status_code>200 ) )`,
-			},
-			"regexp": {
-				query: `{env="prod", app=~"loki.*"} |~ ".*foo.*"`,
-			},
-			"vector matching": {
-				query: `(sum by (cluster)(rate({foo="bar"}[5m])) / ignoring (cluster)  count(rate({foo="bar"}[5m])))`,
-			},
-			"sum over or vector": {
-				query: `(sum(count_over_time({foo="bar"}[5m])) or vector(1.000000))`,
-			},
-			"label replace": {
-				query: `label_replace(vector(0.000000),"foo","bar","","")`,
-			},
-			"filters with bytes": {
-				query: `{app="foo"} |= "bar" | json | ( status_code <500 or ( status_code>200 , size>=2.5KiB ) )`,
-			},
-			"post filter": {
-				query: `quantile_over_time(0.99998,{app="foo"} |= "bar" | json | latency >= 250ms or ( status_code < 500 and status_code > 200)
-					| line_format "blip{{ .foo }}blop {{.status_code}}" | label_format foo=bar,status_code="buzz{{.bar}}" | unwrap foo
-					| __error__ !~".+"[5m]) by (namespace,instance)`,
-			},
-			"multiple post filters": {
-				query: `rate({app="foo"} | json | unwrap foo | latency >= 250ms or bytes > 42B or ( status_code < 500 and status_code > 200) or source = ip("") and user = "me" [1m])`,
-			},
-		*/
+		"simple matchers": {
+			query: `{env="prod", app=~"loki.*"}`,
+		},
+		"simple aggregation": {
+			query: `count_over_time({env="prod", app=~"loki.*"}[5m])`,
+		},
+		"simple aggregation with unwrap": {
+			query: `sum_over_time({env="prod", app=~"loki.*"} | unwrap bytes[5m])`,
+		},
+		"bin op": {
+			query: `(count_over_time({env="prod", app=~"loki.*"}[5m]) >= 0)`,
+		},
+		"label filter": {
+			query: `{app="foo"} |= "bar" | json | ( latency>=250ms or ( status_code<500 , status_code>200 ) )`,
+		},
+		"regexp": {
+			query: `{env="prod", app=~"loki.*"} |~ ".*foo.*"`,
+		},
+		"vector matching": {
+			query: `(sum by (cluster)(rate({foo="bar"}[5m])) / ignoring (cluster)  count(rate({foo="bar"}[5m])))`,
+		},
+		"sum over or vector": {
+			query: `(sum(count_over_time({foo="bar"}[5m])) or vector(1.000000))`,
+		},
+		"label replace": {
+			query: `label_replace(vector(0.000000),"foo","bar","","")`,
+		},
+		"filters with bytes": {
+			query: `{app="foo"} |= "bar" | json | ( status_code <500 or ( status_code>200 , size>=2.5KiB ) )`,
+		},
+		"post filter": {
+			query: `quantile_over_time(0.99998,{app="foo"} |= "bar" | json | latency >= 250ms or ( status_code < 500 and status_code > 200)
+				| line_format "blip{{ .foo }}blop {{.status_code}}" | label_format foo=bar,status_code="buzz{{.bar}}" | unwrap foo
+				| __error__ !~".+"[5m]) by (namespace,instance)`,
+		},
+		"multiple post filters": {
+			query: `rate({app="foo"} | json | unwrap foo | latency >= 250ms or bytes > 42B or ( status_code < 500 and status_code > 200) or source = ip("") and user = "me" [1m])`,
+		},
 		"empty label filter string": {
 			query: `rate({app="foo"} |= "bar" | json | unwrap latency | path!="" [5m])`,
 		},

--- a/pkg/logql/syntax/serialize_test.go
+++ b/pkg/logql/syntax/serialize_test.go
@@ -12,43 +12,48 @@ func TestJSONSerializationRoundTrip(t *testing.T) {
 	tests := map[string]struct {
 		query string
 	}{
-		"simple matchers": {
-			query: `{env="prod", app=~"loki.*"}`,
-		},
-		"simple aggregation": {
-			query: `count_over_time({env="prod", app=~"loki.*"}[5m])`,
-		},
-		"simple aggregation with unwrap": {
-			query: `sum_over_time({env="prod", app=~"loki.*"} | unwrap bytes[5m])`,
-		},
-		"bin op": {
-			query: `(count_over_time({env="prod", app=~"loki.*"}[5m]) >= 0)`,
-		},
-		"label filter": {
-			query: `{app="foo"} |= "bar" | json | ( latency>=250ms or ( status_code<500 , status_code>200 ) )`,
-		},
-		"regexp": {
-			query: `{env="prod", app=~"loki.*"} |~ ".*foo.*"`,
-		},
-		"vector matching": {
-			query: `(sum by (cluster)(rate({foo="bar"}[5m])) / ignoring (cluster)  count(rate({foo="bar"}[5m])))`,
-		},
-		"sum over or vector": {
-			query: `(sum(count_over_time({foo="bar"}[5m])) or vector(1.000000))`,
-		},
-		"label replace": {
-			query: `label_replace(vector(0.000000),"foo","bar","","")`,
-		},
-		"filters with bytes": {
-			query: `{app="foo"} |= "bar" | json | ( status_code <500 or ( status_code>200 , size>=2.5KiB ) )`,
-		},
-		"post filter": {
-			query: `quantile_over_time(0.99998,{app="foo"} |= "bar" | json | latency >= 250ms or ( status_code < 500 and status_code > 200)
-				| line_format "blip{{ .foo }}blop {{.status_code}}" | label_format foo=bar,status_code="buzz{{.bar}}" | unwrap foo
-				| __error__ !~".+"[5m]) by (namespace,instance)`,
-		},
-		"multiple post filters": {
-			query: `rate({app="foo"} | json | unwrap foo | latency >= 250ms or bytes > 42B or ( status_code < 500 and status_code > 200) or source = ip("") and user = "me" [1m])`,
+		/*
+			"simple matchers": {
+				query: `{env="prod", app=~"loki.*"}`,
+			},
+			"simple aggregation": {
+				query: `count_over_time({env="prod", app=~"loki.*"}[5m])`,
+			},
+			"simple aggregation with unwrap": {
+				query: `sum_over_time({env="prod", app=~"loki.*"} | unwrap bytes[5m])`,
+			},
+			"bin op": {
+				query: `(count_over_time({env="prod", app=~"loki.*"}[5m]) >= 0)`,
+			},
+			"label filter": {
+				query: `{app="foo"} |= "bar" | json | ( latency>=250ms or ( status_code<500 , status_code>200 ) )`,
+			},
+			"regexp": {
+				query: `{env="prod", app=~"loki.*"} |~ ".*foo.*"`,
+			},
+			"vector matching": {
+				query: `(sum by (cluster)(rate({foo="bar"}[5m])) / ignoring (cluster)  count(rate({foo="bar"}[5m])))`,
+			},
+			"sum over or vector": {
+				query: `(sum(count_over_time({foo="bar"}[5m])) or vector(1.000000))`,
+			},
+			"label replace": {
+				query: `label_replace(vector(0.000000),"foo","bar","","")`,
+			},
+			"filters with bytes": {
+				query: `{app="foo"} |= "bar" | json | ( status_code <500 or ( status_code>200 , size>=2.5KiB ) )`,
+			},
+			"post filter": {
+				query: `quantile_over_time(0.99998,{app="foo"} |= "bar" | json | latency >= 250ms or ( status_code < 500 and status_code > 200)
+					| line_format "blip{{ .foo }}blop {{.status_code}}" | label_format foo=bar,status_code="buzz{{.bar}}" | unwrap foo
+					| __error__ !~".+"[5m]) by (namespace,instance)`,
+			},
+			"multiple post filters": {
+				query: `rate({app="foo"} | json | unwrap foo | latency >= 250ms or bytes > 42B or ( status_code < 500 and status_code > 200) or source = ip("") and user = "me" [1m])`,
+			},
+		*/
+		"empty label filter string": {
+			query: `rate({app="foo"} |= "bar" | json | unwrap latency | path!="" [5m])`,
 		},
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Originally we would not set the matcher of a label filter if the name or value was empty. However , `post != ""` is a valid filter expression with an empty value.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
