### PR TITLE
 Allow to change loki read and write service components in helm configuration

### DIFF
--- a/docs/sources/setup/install/helm/reference.md
+++ b/docs/sources/setup/install/helm/reference.md
@@ -3494,18 +3494,36 @@ null
 		<tr>
 			<td>read.service.annotations</td>
 			<td>object</td>
-			<td>Annotations for read Service</td>
+			<td>Annotations for the read service</td>
 			<td><pre lang="json">
 {}
 </pre>
 </td>
 		</tr>
 		<tr>
+			<td>read.service.clusterIP</td>
+			<td>string</td>
+			<td>ClusterIP of the read service</td>
+			<td><pre lang="json">
+null
+</pre>
+</td>
+		</tr>
+		<tr>
 			<td>read.service.labels</td>
 			<td>object</td>
-			<td>Additional labels for read Service</td>
+			<td>Additional labels for read service</td>
 			<td><pre lang="json">
 {}
+</pre>
+</td>
+		</tr>
+		<tr>
+			<td>read.service.type</td>
+			<td>string</td>
+			<td>Type of the read service</td>
+			<td><pre lang="json">
+"ClusterIP"
 </pre>
 </td>
 		</tr>
@@ -4803,18 +4821,36 @@ null
 		<tr>
 			<td>write.service.annotations</td>
 			<td>object</td>
-			<td>Annotations for write Service</td>
+			<td>Annotations for the write service</td>
 			<td><pre lang="json">
 {}
 </pre>
 </td>
 		</tr>
 		<tr>
+			<td>write.service.clusterIP</td>
+			<td>string</td>
+			<td>ClusterIP of the write service</td>
+			<td><pre lang="json">
+null
+</pre>
+</td>
+		</tr>
+		<tr>
 			<td>write.service.labels</td>
 			<td>object</td>
-			<td>Additional labels for write Service</td>
+			<td>Additional labels for write service</td>
 			<td><pre lang="json">
 {}
+</pre>
+</td>
+		</tr>
+		<tr>
+			<td>write.service.type</td>
+			<td>string</td>
+			<td>Type of the write service</td>
+			<td><pre lang="json">
+"ClusterIP"
 </pre>
 </td>
 		</tr>

--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -13,6 +13,10 @@ Entries should include a reference to the pull request that introduced the chang
 
 [//]: # (<AUTOMATED_UPDATES_LOCATOR> : do not remove this line. This locator is used by the CI pipeline to automatically create a changelog entry for each new Loki release. Add other chart versions and respective changelog entries bellow this line.)
 
+## 5.41.5
+
+- [ENHANCEMENT] Allow to change loki read and write service components configuration
+
 ## 5.41.4
 
 - [CHANGE] Use `/ingester/shutdown?terminate=false` for write `preStop` hook

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -3,7 +3,7 @@ name: loki
 description: Helm chart for Grafana Loki in simple, scalable mode
 type: application
 appVersion: 2.9.3
-version: 5.41.4
+version: 5.41.5
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -1,6 +1,6 @@
 # loki
 
-![Version: 5.41.4](https://img.shields.io/badge/Version-5.41.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.9.3](https://img.shields.io/badge/AppVersion-2.9.3-informational?style=flat-square)
+![Version: 5.41.5](https://img.shields.io/badge/Version-5.41.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.9.3](https://img.shields.io/badge/AppVersion-2.9.3-informational?style=flat-square)
 
 Helm chart for Grafana Loki in simple, scalable mode
 

--- a/production/helm/loki/templates/read/service-read.yaml
+++ b/production/helm/loki/templates/read/service-read.yaml
@@ -21,8 +21,15 @@ metadata:
     {{- with .Values.read.service.annotations }}
     {{- toYaml . | nindent 4}}
     {{- end }}
+  {{- with .Values.read.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
-  type: ClusterIP
+  type: {{ .Values.read.service.type }}
+  {{- with .Values.read.service.clusterIP }}
+  clusterIP: {{ . }}
+  {{- end }}
   ports:
     - name: http-metrics
       port: 3100

--- a/production/helm/loki/templates/write/service-write.yaml
+++ b/production/helm/loki/templates/write/service-write.yaml
@@ -21,8 +21,15 @@ metadata:
     {{- with .Values.write.service.annotations }}
     {{- toYaml . | nindent 4}}
     {{- end }}
+  {{- with .Values.write.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
-  type: ClusterIP
+  type: {{ .Values.write.service.type }}
+  {{- with .Values.write.service.clusterIP }}
+  clusterIP: {{ . }}
+  {{- end }}
   ports:
     - name: http-metrics
       port: 3100

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -780,11 +780,16 @@ write:
   podLabels: {}
   # -- Additional selector labels for each `write` pod
   selectorLabels: {}
+  # Write service configuration
   service:
-    # -- Annotations for write Service
-    annotations: {}
-    # -- Additional labels for write Service
+    # -- Type of the write service
+    type: ClusterIP
+    # -- ClusterIP of the write service
+    clusterIP: null
+    # -- Additional labels for write service
     labels: {}
+    # -- Annotations for the write service
+    annotations: {}
   # -- Comma-separated list of Loki modules to load for the write
   targetModule: "write"
   # -- Additional CLI args for the write
@@ -967,11 +972,16 @@ read:
   podLabels: {}
   # -- Additional selector labels for each `read` pod
   selectorLabels: {}
+  # Read service configuration
   service:
-    # -- Annotations for read Service
-    annotations: {}
-    # -- Additional labels for read Service
+    # -- Type of the read service
+    type: ClusterIP
+    # -- ClusterIP of the read service
+    clusterIP: null
+    # -- Additional labels for read service
     labels: {}
+    # -- Annotations for the read service
+    annotations: {}
   # -- Comma-separated list of Loki modules to load for the read
   targetModule: "read"
   # -- Whether or not to use the 2 target type simple scalable mode (read, write) or the


### PR DESCRIPTION
**What this PR does / why we need it**:
When deploying to AWS EKS, services must be of type `NodePort` if `ingressClassName: alb`. By adding the ability to specify service type for the loki `read` and `write` services, EKS users can now use the chart without the loki gateway.
This PR also adds the ability to specify a `clusterIP` if service type is defined as `ClusterIP`.
This PR also adds the ability to specify annotations for each service.

**Which issue(s) this PR fixes**:
No issue, but this PR is based upon https://github.com/grafana/loki/pull/9077, which was created earlier in 2023 but OP never followed up.

**Special notes for your reviewer**:
Previous defaults were added explicitly in values.yaml to maintain backwards compatibility.

I also had to add `.PHONY: sources/setup/install/helm/reference.md` in the Makefile in order to be able to run `make sources/setup/install/helm/reference.md`, otherwise make would interpret the input as a file to check and would return `make: 'sources/setup/install/helm/reference.md' is up to date`. How is that makefile supposed to be used?
I reviewed the contributing guidelines, including the [section about contributing to docs](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md#contribute-to-documentation), but it doesn't mention helm: I tried running `make docs` but it only builds the hugo docs website (btw I also had to add `:z` to all volume mounts because I'm running podman on a OS with selinux).

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [X] Documentation added
- [ ] Tests updated
- [X] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [X] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)