### PR TITLE
Tokenize line filters on a per-block basis

### DIFF
--- a/pkg/bloomgateway/bloomgateway.go
+++ b/pkg/bloomgateway/bloomgateway.go
@@ -142,9 +142,8 @@ func makePendingTasks(n int) *pendingTasks {
 type Gateway struct {
 	services.Service
 
-	cfg       Config
-	logger    log.Logger
-	overrides Limits
+	cfg    Config
+	logger log.Logger
 
 	metrics       *metrics
 	workerMetrics *workerMetrics
@@ -187,7 +186,6 @@ func New(cfg Config, schemaCfg config.SchemaConfig, storageCfg storage.Config, o
 		},
 		workerMetrics: newWorkerMetrics(reg, constants.Loki, metricsSubsystem),
 		queueMetrics:  queue.NewMetrics(reg, constants.Loki, metricsSubsystem),
-		overrides:     overrides,
 	}
 
 	g.queue = queue.NewRequestQueue(cfg.MaxOutstandingPerTenant, time.Minute, &fixedQueueLimits{100}, g.queueMetrics)
@@ -300,9 +298,6 @@ func (g *Gateway) FilterChunkRefs(ctx context.Context, req *logproto.FilterChunk
 	})
 
 	task, resCh, errCh, err := NewTask(tenantID, req)
-	task.tokenSettings = tokenSettings{
-		nGramLen: g.overrides.BloomNGramLength(tenantID),
-	}
 
 	if err != nil {
 		return nil, err

--- a/pkg/bloomgateway/config.go
+++ b/pkg/bloomgateway/config.go
@@ -37,13 +37,8 @@ func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	cfg.Client.RegisterFlags(f)
 }
 
-type NGramSettings interface {
-	BloomNGramLength(tenantID string) int
-}
-
 type Limits interface {
 	CacheLimits
-	NGramSettings
 	BloomGatewayShardSize(tenantID string) int
 	BloomGatewayEnabled(tenantID string) bool
 	BloomGatewayBlocksDownloadingParallelism(tenantID string) int

--- a/pkg/bloomgateway/multiplexing_test.go
+++ b/pkg/bloomgateway/multiplexing_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/grafana/loki/pkg/logproto"
 	"github.com/grafana/loki/pkg/logql/syntax"
+	v1 "github.com/grafana/loki/pkg/storage/bloom/v1"
 )
 
 func TestTask(t *testing.T) {
@@ -32,6 +33,7 @@ func TestTaskMergeIterator(t *testing.T) {
 	ts := model.TimeFromUnix(1699523810)
 	day := getDayTime(ts)
 	tenant := "fake"
+	tokenizer := v1.NewNGramTokenizer(4, 0)
 
 	t.Run("empty requests result in empty iterator", func(t *testing.T) {
 		r1 := &logproto.FilterChunkRefRequest{
@@ -58,7 +60,7 @@ func TestTaskMergeIterator(t *testing.T) {
 		t3, _, _, err := NewTask(tenant, r3)
 		require.NoError(t, err)
 
-		it := newTaskMergeIterator(day, t1, t2, t3)
+		it := newTaskMergeIterator(day, tokenizer, t1, t2, t3)
 		// nothing to iterate over
 		require.False(t, it.Next())
 	})
@@ -103,7 +105,7 @@ func TestTaskMergeIterator(t *testing.T) {
 		t3, _, _, err := NewTask(tenant, r3)
 		require.NoError(t, err)
 
-		it := newTaskMergeIterator(day, t1, t2, t3)
+		it := newTaskMergeIterator(day, tokenizer, t1, t2, t3)
 
 		// first item
 		require.True(t, it.Next())

--- a/pkg/bloomgateway/util.go
+++ b/pkg/bloomgateway/util.go
@@ -38,18 +38,13 @@ func getFromThrough(refs []*logproto.ShortRef) (model.Time, model.Time) {
 
 // convertToSearches converts a list of line filter expressions to a list of
 // byte slices that can be used with the bloom filters.
-// TODO(chaudum): Tokenize filter strings
-func convertToSearches(cfg tokenSettings, filters []syntax.LineFilter) [][]byte {
-	// never use a skip factor for search n-grams
-	t := v1.NewNGramTokenizer(cfg.nGramLen, 0)
-	// Can we assume an avg filter string length of 12 chars?
-	// Then the capacity would be (len(filterString) - (nGramLen-1)) * numFilters
-	searches := make([][]byte, 0, (13-cfg.nGramLen)*len(filters))
+func convertToSearches(filters []syntax.LineFilter, t *v1.NGramTokenizer) [][]byte {
+	searches := make([][]byte, 0, (13-t.N)*len(filters))
 	for _, f := range filters {
 		if f.Ty == labels.MatchEqual {
 			it := t.Tokens(f.Match)
 			for it.Next() {
-				key := make([]byte, cfg.nGramLen)
+				key := make([]byte, t.N)
 				_ = copy(key, it.At())
 				searches = append(searches, key)
 			}

--- a/pkg/storage/bloom/v1/index.go
+++ b/pkg/storage/bloom/v1/index.go
@@ -74,6 +74,10 @@ func (s *Schema) Decode(dec *encoding.Decbuf) error {
 	return dec.Err()
 }
 
+func (s Schema) NGramLen() int {
+	return int(s.nGramLength)
+}
+
 // Block index is a set of series pages along with
 // the headers for each page
 type BlockIndex struct {

--- a/pkg/storage/bloom/v1/test_util.go
+++ b/pkg/storage/bloom/v1/test_util.go
@@ -26,8 +26,10 @@ func MakeBlockQuerier(t testing.TB, fromFp, throughFp model.Fingerprint, fromTs,
 	builder, err := NewBlockBuilder(
 		BlockOptions{
 			schema: Schema{
-				version:  DefaultSchemaVersion,
-				encoding: chunkenc.EncSnappy,
+				version:     DefaultSchemaVersion,
+				encoding:    chunkenc.EncSnappy,
+				nGramLength: 4, // see DefaultNGramLength in bloom_tokenizer_test.go
+				nGramSkip:   0, // see DefaultNGramSkip in bloom_tokenizer_test.go
 			},
 			SeriesPageSize: 100,
 			BloomPageSize:  10 << 10,


### PR DESCRIPTION
**What this PR does / why we need it**:

So far, the line filters from the user query have been tokenized to n-grams based on the per-tenant setting.
However, since the setting can change over time, block may be written with different n-gram sizes.

This PR adds the ability to read the n-gram length from the block schema at query time and tokenizes the line filters from the input just ahead of searching the block.


**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
