### PR TITLE
Clone filterer of label filter

### DIFF
--- a/pkg/logql/log/label_filter.go
+++ b/pkg/logql/log/label_filter.go
@@ -366,7 +366,7 @@ func NewStringLabelFilter(m *labels.Matcher) LabelFilterer {
 
 	return &LineFilterLabelFilter{
 		Matcher: m,
-		filter:  f,
+		Filter:  f,
 	}
 }
 
@@ -383,12 +383,12 @@ func (s *StringLabelFilter) RequiredLabelNames() []string {
 // LineFilterLabelFilter filters the desired label using an optimized line filter
 type LineFilterLabelFilter struct {
 	*labels.Matcher
-	filter Filterer
+	Filter Filterer
 }
 
 // overrides the matcher.String() function in case there is a regexpFilter
 func (s *LineFilterLabelFilter) String() string {
-	if unwrappedFilter, ok := s.filter.(regexpFilter); ok {
+	if unwrappedFilter, ok := s.Filter.(regexpFilter); ok {
 		rStr := unwrappedFilter.String()
 		str := fmt.Sprintf("%s%s`%s`", s.Matcher.Name, s.Matcher.Type, rStr)
 		return str
@@ -398,7 +398,7 @@ func (s *LineFilterLabelFilter) String() string {
 
 func (s *LineFilterLabelFilter) Process(_ int64, line []byte, lbs *LabelsBuilder) ([]byte, bool) {
 	v := labelValue(s.Name, lbs)
-	return line, s.filter.Filter(unsafeGetBytes(v))
+	return line, s.Filter.Filter(unsafeGetBytes(v))
 }
 
 func (s *LineFilterLabelFilter) isLabelFilterer() {}

--- a/pkg/logql/syntax/clone.go
+++ b/pkg/logql/syntax/clone.go
@@ -230,7 +230,9 @@ func cloneLabelFilterer(filter log.LabelFilterer) log.LabelFilterer {
 		}
 		return copied
 	case *log.LineFilterLabelFilter:
-		copied := &log.LineFilterLabelFilter{}
+		copied := &log.LineFilterLabelFilter{
+			Filter: concrete.Filter,
+		}
 		if concrete.Matcher != nil {
 			copied.Matcher = mustNewMatcher(concrete.Type, concrete.Name, concrete.Value)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
The `LineFilterLabelFilter.Filterer` wasn't cloned which resulted in nil pointer panics.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
