### PR TITLE
Jsonnet: Fix and update loki-mixin panels

### DIFF
--- a/production/helm/loki/src/dashboards/loki-logs.json
+++ b/production/helm/loki/src/dashboards/loki-logs.json
@@ -78,7 +78,7 @@
                "sort": 0,
                "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
                "buckets": null,
                "mode": "time",
@@ -165,7 +165,7 @@
                "sort": 0,
                "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
                "buckets": null,
                "mode": "time",
@@ -251,7 +251,7 @@
                "sort": 0,
                "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
                "buckets": null,
                "mode": "time",
@@ -337,7 +337,7 @@
                "sort": 0,
                "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
                "buckets": null,
                "mode": "time",
@@ -423,7 +423,7 @@
                "sort": 0,
                "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
                "buckets": null,
                "mode": "time",
@@ -509,7 +509,7 @@
                "sort": 0,
                "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
                "buckets": null,
                "mode": "time",
@@ -596,7 +596,7 @@
                "sort": 0,
                "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
                "buckets": null,
                "mode": "time",
@@ -683,7 +683,7 @@
                "sort": 0,
                "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
                "buckets": null,
                "mode": "time",
@@ -788,7 +788,7 @@
                "sort": 2,
                "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
                "buckets": null,
                "mode": "time",

--- a/production/loki-mixin-compiled-ssd/dashboards/loki-logs.json
+++ b/production/loki-mixin-compiled-ssd/dashboards/loki-logs.json
@@ -77,7 +77,7 @@
                "sort": 0,
                "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
                "buckets": null,
                "mode": "time",
@@ -164,7 +164,7 @@
                "sort": 0,
                "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
                "buckets": null,
                "mode": "time",
@@ -250,7 +250,7 @@
                "sort": 0,
                "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
                "buckets": null,
                "mode": "time",
@@ -336,7 +336,7 @@
                "sort": 0,
                "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
                "buckets": null,
                "mode": "time",
@@ -422,7 +422,7 @@
                "sort": 0,
                "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
                "buckets": null,
                "mode": "time",
@@ -508,7 +508,7 @@
                "sort": 0,
                "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
                "buckets": null,
                "mode": "time",
@@ -595,7 +595,7 @@
                "sort": 0,
                "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
                "buckets": null,
                "mode": "time",
@@ -682,7 +682,7 @@
                "sort": 0,
                "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
                "buckets": null,
                "mode": "time",
@@ -787,7 +787,7 @@
                "sort": 2,
                "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
                "buckets": null,
                "mode": "time",

--- a/production/loki-mixin-compiled-ssd/dashboards/loki-operational.json
+++ b/production/loki-mixin-compiled-ssd/dashboards/loki-operational.json
@@ -102,7 +102,7 @@
                "sort": 0,
                "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
                "buckets": null,
                "mode": "time",
@@ -198,7 +198,7 @@
                "sort": 0,
                "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
                "buckets": null,
                "mode": "time",
@@ -293,7 +293,7 @@
                "sort": 0,
                "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
                "buckets": null,
                "mode": "time",
@@ -389,7 +389,7 @@
                "sort": 0,
                "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
                "buckets": null,
                "mode": "time",
@@ -485,7 +485,7 @@
                "sort": 2,
                "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
                "buckets": null,
                "mode": "time",
@@ -591,7 +591,7 @@
                "sort": 0,
                "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
                "buckets": null,
                "mode": "time",
@@ -697,7 +697,7 @@
                "sort": 0,
                "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
                "buckets": null,
                "mode": "time",
@@ -794,7 +794,7 @@
                "sort": 0,
                "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
                "buckets": null,
                "mode": "time",
@@ -903,7 +903,7 @@
                "sort": 0,
                "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
                "buckets": null,
                "mode": "time",
@@ -1000,7 +1000,7 @@
                "sort": 0,
                "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
                "buckets": null,
                "mode": "time",
@@ -1109,7 +1109,7 @@
                "sort": 0,
                "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
                "buckets": null,
                "mode": "time",
@@ -1215,7 +1215,7 @@
                "sort": 0,
                "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
                "buckets": null,
                "mode": "time",
@@ -1312,7 +1312,7 @@
                "sort": 0,
                "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
                "buckets": null,
                "mode": "time",
@@ -1420,7 +1420,7 @@
                "sort": 0,
                "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
                "buckets": null,
                "mode": "time",
@@ -1517,7 +1517,7 @@
                "sort": 0,
                "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
                "buckets": null,
                "mode": "time",
@@ -1618,7 +1618,7 @@
                      "sort": 0,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -1815,7 +1815,7 @@
                      "sort": 2,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -1907,7 +1907,7 @@
                      "sort": 2,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -1999,7 +1999,7 @@
                      "sort": 2,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -2116,7 +2116,7 @@
                      "sort": 2,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -2205,7 +2205,7 @@
                      "sort": 2,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -2294,7 +2294,7 @@
                      "sort": 2,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -2383,7 +2383,7 @@
                      "sort": 2,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -2490,7 +2490,7 @@
                      "sort": 0,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -2581,7 +2581,7 @@
                      "sort": 0,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -2697,7 +2697,7 @@
                      "sort": 0,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -2850,7 +2850,7 @@
                      "sort": 0,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -3022,7 +3022,7 @@
                      "sort": 2,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -3114,7 +3114,7 @@
                      "sort": 2,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -3206,7 +3206,7 @@
                      "sort": 2,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -3323,7 +3323,7 @@
                      "sort": 2,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -3443,7 +3443,7 @@
                      "sort": 2,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -3535,7 +3535,7 @@
                      "sort": 2,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -3655,7 +3655,7 @@
                      "sort": 2,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -3747,7 +3747,7 @@
                      "sort": 2,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -3861,7 +3861,7 @@
                      "sort": 2,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -3964,7 +3964,7 @@
                      "sort": 2,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -4067,7 +4067,7 @@
                      "sort": 2,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -4165,7 +4165,7 @@
                      "sort": 2,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -4255,7 +4255,7 @@
                      "sort": 2,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -4345,7 +4345,7 @@
                      "sort": 2,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -4435,7 +4435,7 @@
                      "sort": 2,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -4525,7 +4525,7 @@
                      "sort": 2,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -4645,7 +4645,7 @@
                      "sort": 2,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -4737,7 +4737,7 @@
                      "sort": 2,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -4839,7 +4839,7 @@
                      "sort": 0,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -4925,7 +4925,7 @@
                      "sort": 0,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -5011,7 +5011,7 @@
                      "sort": 0,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -5097,7 +5097,7 @@
                      "sort": 0,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -5194,7 +5194,7 @@
                      "sort": 0,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -5297,7 +5297,7 @@
                      "sort": 2,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -5388,7 +5388,7 @@
                      "sort": 2,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -5507,7 +5507,7 @@
                      "sort": 2,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -5598,7 +5598,7 @@
                      "sort": 2,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -5717,7 +5717,7 @@
                      "sort": 2,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -5808,7 +5808,7 @@
                      "sort": 2,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -5927,7 +5927,7 @@
                      "sort": 2,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -6018,7 +6018,7 @@
                      "sort": 2,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",

--- a/production/loki-mixin-compiled-ssd/dashboards/loki-reads.json
+++ b/production/loki-mixin-compiled-ssd/dashboards/loki-reads.json
@@ -217,9 +217,9 @@
                               "group": "A",
                               "mode": "normal"
                            }
-                        }
-                     },
-                     "unit": "s"
+                        },
+                        "unit": "s"
+                     }
                   },
                   "fill": 1,
                   "id": 3,
@@ -493,9 +493,9 @@
                               "group": "A",
                               "mode": "normal"
                            }
-                        }
-                     },
-                     "unit": "s"
+                        },
+                        "unit": "s"
+                     }
                   },
                   "fill": 1,
                   "id": 6,

--- a/production/loki-mixin-compiled/dashboards/loki-logs.json
+++ b/production/loki-mixin-compiled/dashboards/loki-logs.json
@@ -77,7 +77,7 @@
                "sort": 0,
                "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
                "buckets": null,
                "mode": "time",
@@ -164,7 +164,7 @@
                "sort": 0,
                "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
                "buckets": null,
                "mode": "time",
@@ -250,7 +250,7 @@
                "sort": 0,
                "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
                "buckets": null,
                "mode": "time",
@@ -336,7 +336,7 @@
                "sort": 0,
                "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
                "buckets": null,
                "mode": "time",
@@ -422,7 +422,7 @@
                "sort": 0,
                "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
                "buckets": null,
                "mode": "time",
@@ -508,7 +508,7 @@
                "sort": 0,
                "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
                "buckets": null,
                "mode": "time",
@@ -595,7 +595,7 @@
                "sort": 0,
                "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
                "buckets": null,
                "mode": "time",
@@ -682,7 +682,7 @@
                "sort": 0,
                "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
                "buckets": null,
                "mode": "time",
@@ -787,7 +787,7 @@
                "sort": 2,
                "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
                "buckets": null,
                "mode": "time",

--- a/production/loki-mixin-compiled/dashboards/loki-operational.json
+++ b/production/loki-mixin-compiled/dashboards/loki-operational.json
@@ -102,7 +102,7 @@
                "sort": 0,
                "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
                "buckets": null,
                "mode": "time",
@@ -198,7 +198,7 @@
                "sort": 0,
                "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
                "buckets": null,
                "mode": "time",
@@ -294,7 +294,7 @@
                "sort": 2,
                "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
                "buckets": null,
                "mode": "time",
@@ -389,7 +389,7 @@
                "sort": 0,
                "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
                "buckets": null,
                "mode": "time",
@@ -485,7 +485,7 @@
                "sort": 0,
                "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
                "buckets": null,
                "mode": "time",
@@ -581,7 +581,7 @@
                "sort": 2,
                "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
                "buckets": null,
                "mode": "time",
@@ -687,7 +687,7 @@
                "sort": 0,
                "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
                "buckets": null,
                "mode": "time",
@@ -793,7 +793,7 @@
                "sort": 0,
                "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
                "buckets": null,
                "mode": "time",
@@ -890,7 +890,7 @@
                "sort": 0,
                "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
                "buckets": null,
                "mode": "time",
@@ -999,7 +999,7 @@
                "sort": 0,
                "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
                "buckets": null,
                "mode": "time",
@@ -1096,7 +1096,7 @@
                "sort": 0,
                "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
                "buckets": null,
                "mode": "time",
@@ -1205,7 +1205,7 @@
                "sort": 0,
                "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
                "buckets": null,
                "mode": "time",
@@ -1311,7 +1311,7 @@
                "sort": 0,
                "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
                "buckets": null,
                "mode": "time",
@@ -1408,7 +1408,7 @@
                "sort": 0,
                "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
                "buckets": null,
                "mode": "time",
@@ -1516,7 +1516,7 @@
                "sort": 0,
                "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
                "buckets": null,
                "mode": "time",
@@ -1613,7 +1613,7 @@
                "sort": 0,
                "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
                "buckets": null,
                "mode": "time",
@@ -1714,7 +1714,7 @@
                      "sort": 0,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -1911,7 +1911,7 @@
                      "sort": 2,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -2003,7 +2003,7 @@
                      "sort": 2,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -2095,7 +2095,7 @@
                      "sort": 2,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -2212,7 +2212,7 @@
                      "sort": 2,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -2301,7 +2301,7 @@
                      "sort": 2,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -2390,7 +2390,7 @@
                      "sort": 2,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -2479,7 +2479,7 @@
                      "sort": 2,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -2584,7 +2584,7 @@
                      "sort": 2,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -2676,7 +2676,7 @@
                      "sort": 2,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -2768,7 +2768,7 @@
                      "sort": 2,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -2885,7 +2885,7 @@
                      "sort": 2,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -2992,7 +2992,7 @@
                      "sort": 0,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -3083,7 +3083,7 @@
                      "sort": 0,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -3199,7 +3199,7 @@
                      "sort": 0,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -3352,7 +3352,7 @@
                      "sort": 0,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -3524,7 +3524,7 @@
                      "sort": 2,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -3616,7 +3616,7 @@
                      "sort": 2,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -3708,7 +3708,7 @@
                      "sort": 2,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -3825,7 +3825,7 @@
                      "sort": 2,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -3945,7 +3945,7 @@
                      "sort": 2,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -4037,7 +4037,7 @@
                      "sort": 2,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -4157,7 +4157,7 @@
                      "sort": 2,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -4249,7 +4249,7 @@
                      "sort": 2,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -4363,7 +4363,7 @@
                      "sort": 2,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -4466,7 +4466,7 @@
                      "sort": 2,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -4569,7 +4569,7 @@
                      "sort": 2,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -4667,7 +4667,7 @@
                      "sort": 2,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -4757,7 +4757,7 @@
                      "sort": 2,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -4847,7 +4847,7 @@
                      "sort": 2,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -4937,7 +4937,7 @@
                      "sort": 2,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -5027,7 +5027,7 @@
                      "sort": 2,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -5147,7 +5147,7 @@
                      "sort": 2,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -5239,7 +5239,7 @@
                      "sort": 2,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -5341,7 +5341,7 @@
                      "sort": 0,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -5427,7 +5427,7 @@
                      "sort": 0,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -5513,7 +5513,7 @@
                      "sort": 0,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -5599,7 +5599,7 @@
                      "sort": 0,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -5696,7 +5696,7 @@
                      "sort": 0,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -5799,7 +5799,7 @@
                      "sort": 2,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -5890,7 +5890,7 @@
                      "sort": 2,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -6009,7 +6009,7 @@
                      "sort": 2,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -6100,7 +6100,7 @@
                      "sort": 2,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -6219,7 +6219,7 @@
                      "sort": 2,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -6310,7 +6310,7 @@
                      "sort": 2,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -6429,7 +6429,7 @@
                      "sort": 2,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",
@@ -6520,7 +6520,7 @@
                      "sort": 2,
                      "value_type": "individual"
                   },
-                  "type": "graph",
+                  "type": "timeseries",
                   "xaxis": {
                      "buckets": null,
                      "mode": "time",

--- a/production/loki-mixin-compiled/dashboards/loki-reads.json
+++ b/production/loki-mixin-compiled/dashboards/loki-reads.json
@@ -217,9 +217,9 @@
                               "group": "A",
                               "mode": "normal"
                            }
-                        }
-                     },
-                     "unit": "s"
+                        },
+                        "unit": "s"
+                     }
                   },
                   "fill": 1,
                   "id": 3,
@@ -493,9 +493,9 @@
                               "group": "A",
                               "mode": "normal"
                            }
-                        }
-                     },
-                     "unit": "s"
+                        },
+                        "unit": "s"
+                     }
                   },
                   "fill": 1,
                   "id": 6,
@@ -769,9 +769,9 @@
                               "group": "A",
                               "mode": "normal"
                            }
-                        }
-                     },
-                     "unit": "s"
+                        },
+                        "unit": "s"
+                     }
                   },
                   "fill": 1,
                   "id": 9,
@@ -1045,9 +1045,9 @@
                               "group": "A",
                               "mode": "normal"
                            }
-                        }
-                     },
-                     "unit": "s"
+                        },
+                        "unit": "s"
+                     }
                   },
                   "fill": 1,
                   "id": 12,
@@ -1321,9 +1321,9 @@
                               "group": "A",
                               "mode": "normal"
                            }
-                        }
-                     },
-                     "unit": "s"
+                        },
+                        "unit": "s"
+                     }
                   },
                   "fill": 1,
                   "id": 15,
@@ -1597,9 +1597,9 @@
                               "group": "A",
                               "mode": "normal"
                            }
-                        }
-                     },
-                     "unit": "s"
+                        },
+                        "unit": "s"
+                     }
                   },
                   "fill": 1,
                   "id": 18,

--- a/production/loki-mixin/dashboards/dashboard-loki-logs.json
+++ b/production/loki-mixin/dashboards/dashboard-loki-logs.json
@@ -79,7 +79,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "type": "graph",
+      "type": "timeseries",
       "xaxis": {
         "buckets": null,
         "mode": "time",
@@ -166,7 +166,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "type": "graph",
+      "type": "timeseries",
       "xaxis": {
         "buckets": null,
         "mode": "time",
@@ -252,7 +252,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "type": "graph",
+      "type": "timeseries",
       "xaxis": {
         "buckets": null,
         "mode": "time",
@@ -338,7 +338,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "type": "graph",
+      "type": "timeseries",
       "xaxis": {
         "buckets": null,
         "mode": "time",
@@ -424,7 +424,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "type": "graph",
+      "type": "timeseries",
       "xaxis": {
         "buckets": null,
         "mode": "time",
@@ -510,7 +510,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "type": "graph",
+      "type": "timeseries",
       "xaxis": {
         "buckets": null,
         "mode": "time",
@@ -597,7 +597,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "type": "graph",
+      "type": "timeseries",
       "xaxis": {
         "buckets": null,
         "mode": "time",
@@ -684,7 +684,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "type": "graph",
+      "type": "timeseries",
       "xaxis": {
         "buckets": null,
         "mode": "time",
@@ -789,7 +789,7 @@
         "sort": 2,
         "value_type": "individual"
       },
-      "type": "graph",
+      "type": "timeseries",
       "xaxis": {
         "buckets": null,
         "mode": "time",

--- a/production/loki-mixin/dashboards/dashboard-loki-operational.json
+++ b/production/loki-mixin/dashboards/dashboard-loki-operational.json
@@ -105,7 +105,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "type": "graph",
+      "type": "timeseries",
       "xaxis": {
         "buckets": null,
         "mode": "time",
@@ -200,7 +200,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "type": "graph",
+      "type": "timeseries",
       "xaxis": {
         "buckets": null,
         "mode": "time",
@@ -295,7 +295,7 @@
         "sort": 2,
         "value_type": "individual"
       },
-      "type": "graph",
+      "type": "timeseries",
       "xaxis": {
         "buckets": null,
         "mode": "time",
@@ -389,7 +389,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "type": "graph",
+      "type": "timeseries",
       "xaxis": {
         "buckets": null,
         "mode": "time",
@@ -484,7 +484,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "type": "graph",
+      "type": "timeseries",
       "xaxis": {
         "buckets": null,
         "mode": "time",
@@ -579,7 +579,7 @@
         "sort": 2,
         "value_type": "individual"
       },
-      "type": "graph",
+      "type": "timeseries",
       "xaxis": {
         "buckets": null,
         "mode": "time",
@@ -684,7 +684,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "type": "graph",
+      "type": "timeseries",
       "xaxis": {
         "buckets": null,
         "mode": "time",
@@ -789,7 +789,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "type": "graph",
+      "type": "timeseries",
       "xaxis": {
         "buckets": null,
         "mode": "time",
@@ -885,7 +885,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "type": "graph",
+      "type": "timeseries",
       "xaxis": {
         "buckets": null,
         "mode": "time",
@@ -993,7 +993,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "type": "graph",
+      "type": "timeseries",
       "xaxis": {
         "buckets": null,
         "mode": "time",
@@ -1089,7 +1089,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "type": "graph",
+      "type": "timeseries",
       "xaxis": {
         "buckets": null,
         "mode": "time",
@@ -1197,7 +1197,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "type": "graph",
+      "type": "timeseries",
       "xaxis": {
         "buckets": null,
         "mode": "time",
@@ -1302,7 +1302,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "type": "graph",
+      "type": "timeseries",
       "xaxis": {
         "buckets": null,
         "mode": "time",
@@ -1398,7 +1398,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "type": "graph",
+      "type": "timeseries",
       "xaxis": {
         "buckets": null,
         "mode": "time",
@@ -1505,7 +1505,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "type": "graph",
+      "type": "timeseries",
       "xaxis": {
         "buckets": null,
         "mode": "time",
@@ -1601,7 +1601,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "type": "graph",
+      "type": "timeseries",
       "xaxis": {
         "buckets": null,
         "mode": "time",
@@ -1701,7 +1701,7 @@
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -1895,7 +1895,7 @@
             "sort": 2,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -1986,7 +1986,7 @@
             "sort": 2,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -2077,7 +2077,7 @@
             "sort": 2,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -2192,7 +2192,7 @@
             "sort": 2,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -2280,7 +2280,7 @@
             "sort": 2,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -2368,7 +2368,7 @@
             "sort": 2,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -2456,7 +2456,7 @@
             "sort": 2,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -2559,7 +2559,7 @@
             "sort": 2,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -2650,7 +2650,7 @@
             "sort": 2,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -2741,7 +2741,7 @@
             "sort": 2,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -2856,7 +2856,7 @@
             "sort": 2,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -2961,7 +2961,7 @@
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -3051,7 +3051,7 @@
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -3165,7 +3165,7 @@
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -3316,7 +3316,7 @@
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -3485,7 +3485,7 @@
             "sort": 2,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -3576,7 +3576,7 @@
             "sort": 2,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -3667,7 +3667,7 @@
             "sort": 2,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -3782,7 +3782,7 @@
             "sort": 2,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -3900,7 +3900,7 @@
             "sort": 2,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -3991,7 +3991,7 @@
             "sort": 2,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -4109,7 +4109,7 @@
             "sort": 2,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -4200,7 +4200,7 @@
             "sort": 2,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -4312,7 +4312,7 @@
             "sort": 2,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -4414,7 +4414,7 @@
             "sort": 2,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -4516,7 +4516,7 @@
             "sort": 2,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -4613,7 +4613,7 @@
             "sort": 2,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -4702,7 +4702,7 @@
             "sort": 2,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -4791,7 +4791,7 @@
             "sort": 2,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -4880,7 +4880,7 @@
             "sort": 2,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -4969,7 +4969,7 @@
             "sort": 2,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -5087,7 +5087,7 @@
             "sort": 2,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -5178,7 +5178,7 @@
             "sort": 2,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -5278,7 +5278,7 @@
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -5363,7 +5363,7 @@
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -5448,7 +5448,7 @@
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -5533,7 +5533,7 @@
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -5629,7 +5629,7 @@
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -5731,7 +5731,7 @@
             "sort": 2,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -5821,7 +5821,7 @@
             "sort": 2,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -5938,7 +5938,7 @@
             "sort": 2,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -6028,7 +6028,7 @@
             "sort": 2,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -6145,7 +6145,7 @@
             "sort": 2,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -6235,7 +6235,7 @@
             "sort": 2,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -6352,7 +6352,7 @@
             "sort": 2,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -6442,7 +6442,7 @@
             "sort": 2,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -6559,7 +6559,7 @@
             "sort": 2,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -6649,7 +6649,7 @@
             "sort": 2,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",

--- a/production/loki-mixin/dashboards/loki-reads.libsonnet
+++ b/production/loki-mixin/dashboards/loki-reads.libsonnet
@@ -37,8 +37,8 @@ local utils = import 'mixin-utils/utils.libsonnet';
                 mode: 'normal',
               },
             },
+            unit: 's',
           },
-          unit: 's',
         },
       },
 


### PR DESCRIPTION
**What this PR does / why we need it**:
* Update our legacy panels (Loki/Logs and Loki/Operation) do use `"type": "timeseries"` instead of `"type": "graph"`. The graph type is deprecated on recent Grafana versions. I tested the changes with Grizzly and it worked fine.
* Fix our p99 panel unit. I previously made it to be `s` instead of `short` but when replicating the change on our source code I put the change at the wrong identation level. This time I made sure to test the change with Grizzly.