### PR TITLE
Fix configuration for bloom filter deployment

### DIFF
--- a/production/ksonnet/loki/bloom-gateway.libsonnet
+++ b/production/ksonnet/loki/bloom-gateway.libsonnet
@@ -31,12 +31,14 @@
           bloom_gateway+: {
             enabled: true,
             worker_concurrency: 8,
-            replication_factor: 3,
+            ring: {
+              replication_factor: 3,
+            },
             client: {
               cache_results: false,
             },
           },
-          storage+: {
+          storage_config+: {
             bloom_shipper+: {
               working_directory: '/data/blooms',
               blocks_downloading_queue: {


### PR DESCRIPTION
**What this PR does / why we need it**:

* The config block for storage is named `storage_config`, not `storage`.
* The replication factor for the bloom gateway is part of the `ring` config.
