### PR TITLE
Fix bloom-compactor duplicate metric panics

### DIFF
--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -1414,6 +1414,10 @@ func (t *Loki) initBloomCompactor() (services.Service, error) {
 
 	shuffleSharding := bloomcompactor.NewShuffleShardingStrategy(t.bloomCompactorRingManager.Ring, t.bloomCompactorRingManager.RingLifecycler, t.Overrides)
 
+	if config.UsingObjectStorageIndex(t.Cfg.SchemaConfig.Configs) {
+		t.updateConfigForShipperStore()
+	}
+
 	compactor, err := bloomcompactor.New(
 		t.Cfg.BloomCompactor,
 		t.Cfg.StorageConfig,

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -699,7 +699,7 @@ func (t *Loki) updateConfigForShipperStore() {
 		t.Cfg.StorageConfig.TSDBShipperConfig.Mode = indexshipper.ModeWriteOnly
 		t.Cfg.StorageConfig.TSDBShipperConfig.IngesterDBRetainPeriod = shipperQuerierIndexUpdateDelay(t.Cfg.StorageConfig.IndexCacheValidity, t.Cfg.StorageConfig.TSDBShipperConfig.ResyncInterval)
 
-	case t.Cfg.isModuleEnabled(Querier), t.Cfg.isModuleEnabled(Ruler), t.Cfg.isModuleEnabled(Read), t.Cfg.isModuleEnabled(Backend), t.isModuleActive(IndexGateway):
+	case t.Cfg.isModuleEnabled(Querier), t.Cfg.isModuleEnabled(Ruler), t.Cfg.isModuleEnabled(Read), t.Cfg.isModuleEnabled(Backend), t.Cfg.isModuleEnabled(BloomCompactor), t.isModuleActive(IndexGateway):
 		// We do not want query to do any updates to index
 		t.Cfg.StorageConfig.BoltDBShipperConfig.Mode = indexshipper.ModeReadOnly
 		t.Cfg.StorageConfig.TSDBShipperConfig.Mode = indexshipper.ModeReadOnly


### PR DESCRIPTION
**What this PR does / why we need it**:
Bloom-compactor fails start up for duplicate metrics panics. This happens when you have multiple peridodConfigs with TSDB, because  when indexshipper is started in RW mode, which only allows for a single shipper instance.

Instead it should be started in RO mode. 

```
2023-12-20 08:06:53.229	/src/enterprise-logs/vendor/github.com/grafana/loki/pkg/bloomcompactor/bloomcompactor.go:134 +0x84a
2023-12-20 08:06:53.229	github.com/grafana/loki/pkg/bloomcompactor.New({{{{0xc000a6ae30, 0xa}, {0x2e3be4d, 0xb}, {{...}, {...}, {...}, _}, {_, _}}, ...}, ...}, ...)
2023-12-20 08:06:53.229	/src/enterprise-logs/vendor/github.com/grafana/loki/pkg/storage/stores/shipper/indexshipper/shipper.go:155 +0x230
2023-12-20 08:06:53.229	github.com/grafana/loki/pkg/storage/stores/shipper/indexshipper.NewIndexShipper({_, _}, {{0xc00077ba80, 0x10}, {0xc00077baa0, 0x10}, 0x4e94914f0000, 0x45d964b800, 0x0, {{0x0, ...}, ...}, ...}, ...)
2023-12-20 08:06:53.229	/src/enterprise-logs/vendor/github.com/grafana/loki/pkg/storage/stores/shipper/indexshipper/shipper.go:174 +0x1bf
2023-12-20 08:06:53.229	github.com/grafana/loki/pkg/storage/stores/shipper/indexshipper.(*indexShipper).init(0xc001fd1d40, {0x2e2f03e?, 0x2?}, {0x366db20?, 0xc00201a000?}, {0x7f1ba4f99508, 0xc000d23530}, 0xc00077baa0?, {0x4c86, 0x18daea1d7f, ...}, ...)
2023-12-20 08:06:53.229	/src/enterprise-logs/vendor/github.com/grafana/loki/pkg/storage/stores/shipper/indexshipper/uploads/table_manager.go:47 +0xf4
.....
2023-12-20 08:06:53.229	github.com/prometheus/client_golang/prometheus.(*wrappingRegisterer).MustRegister(0xc002003260, {0xc001d0fed0?, 0x1, 0x0?})
2023-12-20 08:06:53.229	goroutine 1 [running]:
2023-12-20 08:06:53.229	
2023-12-20 08:06:53.229	panic: duplicate metrics collector registration attempted
```