### PR TITLE
Bloom Compactor: Fix panic at startup if multiple TSDB period configs are defined

### DIFF
--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -699,7 +699,7 @@ func (t *Loki) updateConfigForShipperStore() {
 		t.Cfg.StorageConfig.TSDBShipperConfig.Mode = indexshipper.ModeWriteOnly
 		t.Cfg.StorageConfig.TSDBShipperConfig.IngesterDBRetainPeriod = shipperQuerierIndexUpdateDelay(t.Cfg.StorageConfig.IndexCacheValidity, t.Cfg.StorageConfig.TSDBShipperConfig.ResyncInterval)
 
-	case t.Cfg.isModuleEnabled(Querier), t.Cfg.isModuleEnabled(Ruler), t.Cfg.isModuleEnabled(Read), t.Cfg.isModuleEnabled(Backend), t.isModuleActive(IndexGateway):
+	case t.Cfg.isModuleEnabled(Querier), t.Cfg.isModuleEnabled(Ruler), t.Cfg.isModuleEnabled(Read), t.Cfg.isModuleEnabled(Backend), t.isModuleActive(IndexGateway), t.isModuleActive(BloomCompactor):
 		// We do not want query to do any updates to index
 		t.Cfg.StorageConfig.BoltDBShipperConfig.Mode = indexshipper.ModeReadOnly
 		t.Cfg.StorageConfig.TSDBShipperConfig.Mode = indexshipper.ModeReadOnly
@@ -1410,6 +1410,8 @@ func (t *Loki) initIndexGatewayInterceptors() (services.Service, error) {
 }
 
 func (t *Loki) initBloomCompactor() (services.Service, error) {
+	t.updateConfigForShipperStore()
+
 	logger := log.With(util_log.Logger, "component", "bloom-compactor")
 
 	shuffleSharding := bloomcompactor.NewShuffleShardingStrategy(t.bloomCompactorRingManager.Ring, t.bloomCompactorRingManager.RingLifecycler, t.Overrides)


### PR DESCRIPTION
### Bloom Compactor: Fix duplicate metrics registration

If there are multiple period configs with TSDB, then each shipper
instance needs to register their metrics with a unique static label set,
otherwise, the bloom compactor would panic at startup due to duplicate
metric registration attempt.

### Bloom compactor: Start indexshipper in RO mode

We don't want/need to upload any index files in the bloom compactor, but
we only download files.