### PR TITLE
Fix index gateway startup if bloom gateway is enabled

### DIFF
--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -693,6 +693,11 @@ func (t *Loki) setupModuleManager() error {
 		deps[QueryFrontend] = append(deps[QueryFrontend], QueryScheduler)
 	}
 
+	// Add bloom gateway ring in client mode to IndexGateway service dependencies if bloom filtering is enabled.
+	if t.Cfg.isModuleEnabled(IndexGateway) && t.Cfg.BloomGateway.Enabled {
+		deps[IndexGateway] = append(deps[IndexGateway], BloomGatewayRing)
+	}
+
 	//TODO(poyzannur) not sure this is needed for BloomCompactor
 	if t.Cfg.LegacyReadTarget {
 		deps[Read] = append(deps[Read], QueryScheduler, Ruler, Compactor, IndexGateway, BloomGateway, BloomCompactor)


### PR DESCRIPTION
**What this PR does / why we need it**:

The index gateways discovers the bloom gateways by using the bloom gateway ring.
In order to initialize the ring before the index gateway, it needs to be added as dependency of the index gateway.

The dependency is conditional, because we don't want the ring to be initialized even though the bloom gateway is not used.

**Special notes for your reviewer**:

This regression was introduced with https://github.com/grafana/loki/pull/11537
