### PR TITLE
Docs: Fix link to `ecs-task.json` file in ECS instructions

### DIFF
--- a/docs/sources/send-data/promtail/cloud/ecs/_index.md
+++ b/docs/sources/send-data/promtail/cloud/ecs/_index.md
@@ -88,13 +88,13 @@ Our [task definition][task] will be made of two containers, the [Firelens][Firel
 Let's download the task definition, we'll go through the most important parts.
 
 ```bash
-curl https://raw.githubusercontent.com/grafana/loki/main/docs/sources/clients/aws/ecs/ecs-task.json > ecs-task.json
+curl https://raw.githubusercontent.com/grafana/loki/main/docs/sources/send-data/promtail/cloud/ecs/ecs-task.json > ecs-task.json
 ```
 
 ```json
  {
     "essential": true,
-    "image": "grafana/fluent-bit-plugin-loki:2.0.0-amd64",
+    "image": "grafana/fluent-bit-plugin-loki:2.9.3-amd64",
     "name": "log_router",
     "firelensConfiguration": {
         "type": "fluentbit",

--- a/docs/sources/send-data/promtail/cloud/ecs/ecs-task.json
+++ b/docs/sources/send-data/promtail/cloud/ecs/ecs-task.json
@@ -2,7 +2,7 @@
     "containerDefinitions": [
         {
             "essential": true,
-            "image": "grafana/fluent-bit-plugin-loki:1.6.0-amd64",
+            "image": "grafana/fluent-bit-plugin-loki:2.9.3-amd64",
             "name": "log_router",
             "firelensConfiguration": {
                 "type": "fluentbit",


### PR DESCRIPTION
Also updated the Docker image to match the latest version

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
