### PR TITLE
Docs: Adding example in API docs for querying against Grafana Cloud log tenant

### DIFF
--- a/docs/sources/reference/api.md
+++ b/docs/sources/reference/api.md
@@ -404,6 +404,14 @@ curl -u "Tenant1|Tenant2|Tenant3:$API_TOKEN" \
   --data-urlencode 'query=sum(rate({job="varlogs"}[10m])) by (level)' | jq
 ```
 
+
+To query against your hosted log tenant in Grafana Cloud, use the **User** and **URL** values provided in the Loki logging service details of your Grafana Cloud stack. You can find this information in the [Cloud Portal](https://grafana.com/docs/grafana-cloud/account-management/cloud-portal/#your-grafana-cloud-stack). Use an access policy token in your queries for authentication. The password in this example is an access policy token that has been defined in the `API_TOKEN` environment variable:
+```bash
+curl -u "User:$API_TOKEN" \
+  -G -s "<URL-PROVIDED-IN-DATA-SOURCE-SETTINGS>/loki/api/v1/query" \
+  --data-urlencode 'query=sum(rate({job="varlogs"}[10m])) by (level)' | jq
+```
+
 ## Query logs within a range of time
 
 ```

--- a/docs/sources/reference/api.md
+++ b/docs/sources/reference/api.md
@@ -408,7 +408,7 @@ curl -u "Tenant1|Tenant2|Tenant3:$API_TOKEN" \
 To query against your hosted log tenant in Grafana Cloud, use the **User** and **URL** values provided in the Loki logging service details of your Grafana Cloud stack. You can find this information in the [Cloud Portal](https://grafana.com/docs/grafana-cloud/account-management/cloud-portal/#your-grafana-cloud-stack). Use an access policy token in your queries for authentication. The password in this example is an access policy token that has been defined in the `API_TOKEN` environment variable:
 ```bash
 curl -u "User:$API_TOKEN" \
-  -G -s "<URL-PROVIDED-IN-DATA-SOURCE-SETTINGS>/loki/api/v1/query" \
+  -G -s "<URL-PROVIDED-IN-LOKI-DATA-SOURCE-SETTINGS>/loki/api/v1/query" \
   --data-urlencode 'query=sum(rate({job="varlogs"}[10m])) by (level)' | jq
 ```
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds example for querying against Grafana Cloud log tenant to API docs. 


**Which issue(s) this PR fixes**:
Addresses internal doc request that came about via a Support ticket

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
