### PR TITLE
builder baseMap concurrent write fix lock

### DIFF
--- a/pkg/logql/log/fmt.go
+++ b/pkg/logql/log/fmt.go
@@ -221,8 +221,8 @@ func (lf *LineFormatter) Process(ts int64, line []byte, lbs *LabelsBuilder) ([]b
 	lf.currentLine = line
 	lf.currentTs = ts
 
-	// map now is taking from a pool
-	m := lbs.Map()
+	m := smp.Get()
+	lbs.IntoMap(m)
 	defer smp.Put(m)
 	if err := lf.Template.Execute(lf.buf, m); err != nil {
 		lbs.SetErr(errTemplateFormat)

--- a/pkg/logql/log/fmt_test.go
+++ b/pkg/logql/log/fmt_test.go
@@ -948,8 +948,4 @@ func TestMapPool(t *testing.T) {
 	}
 	wg.Done()
 	time.Sleep(2 * time.Second)
-
-	//require.Equal(t, tt.want, newMustLineFormatter(tt.fmt).RequiredLabelNames())
-	//})
-	//}
 }

--- a/pkg/logql/log/fmt_test.go
+++ b/pkg/logql/log/fmt_test.go
@@ -2,6 +2,7 @@ package log
 
 import (
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -922,4 +923,33 @@ func TestInvalidUnixTimes(t *testing.T) {
 
 	_, err = unixToTime("464")
 	require.Error(t, err)
+}
+
+func TestMapPool(t *testing.T) {
+	//for _, tt := range tests {
+	//	t.Run(tt.fmt, func(t *testing.T) {
+	ls := labels.FromStrings("cluster", "us-central-0")
+	builder := NewBaseLabelsBuilder().ForLabels(ls, ls.Hash())
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	for i := 0; i < 100; i++ {
+		go func() {
+			wg.Wait()
+			a := newMustLineFormatter(`[1m{{if .level }}{{alignRight 5 .level}}{{else if .severity}}{{alignRight 5 .severity}}{{end}}[0m [90m[{{alignRight 10 .resources_service_instance_id}}{{if .attributes_thread_name}}/{{alignRight 20 .attributes_thread_name}}{{else if eq "java" .resources_telemetry_sdk_language }}                    {{end}}][0m [36m{{if .instrumentation_scope_name }}{{alignRight 40 .instrumentation_scope_name}}{{end}}[0m {{.body}} {{if .traceid}} [37m[3m[traceid={{.traceid}}]{{end}}`)
+			for j := 0; j < 100; j++ {
+				a.Process(0,
+					[]byte("logger=sqlstore.metrics traceID=XXXXXXXXXXXXXXXXXXXXXXXXXXXX t=2024-01-04T23:58:47.696779826Z level=debug msg=\"query finished\" status=success elapsedtime=1.523571ms sql=\"some SQL query\" error=null"),
+					builder,
+				)
+			}
+
+		}()
+
+	}
+	wg.Done()
+	time.Sleep(2 * time.Second)
+
+	//require.Equal(t, tt.want, newMustLineFormatter(tt.fmt).RequiredLabelNames())
+	//})
+	//}
 }

--- a/pkg/logql/log/labels.go
+++ b/pkg/logql/log/labels.go
@@ -480,11 +480,17 @@ var smp = newStringMapPool()
 // properly clear the map if it is going to be reused
 func (b *LabelsBuilder) IntoMap(m map[string]string) {
 	if !b.hasDel() && !b.hasAdd() && !b.HasErr() {
+		b.mapLock.RLock()
 		if b.baseMap == nil {
+			b.mapLock.RUnlock()
+			b.mapLock.Lock()
 			b.baseMap = b.base.Map()
+			b.mapLock.Unlock()
 			for k, v := range b.baseMap {
 				m[k] = v
 			}
+		} else {
+			b.mapLock.RUnlock()
 		}
 		return
 	}


### PR DESCRIPTION
It looks like with either sufficiently large line formats, or line formats that have some kind of operation that results in two line formats being executed concurrently (somehow, I do not understand how), it's possible for us to end up with a concurrent write as part of `LineFormatter.Process` calls. 

This AFAICT existed before https://github.com/grafana/loki/pull/11484 but a query was executed in one of our environments today that made us think the panic was from those changes. I suspect the baseMap usage is the underlying cause, and can confirm by deploying the changes from here into one of our environments tomorrow and running the same query I saw today that caused the panic. 