### PR TITLE
deletion: delete chunk overlapping multiple tables when processing oldest table that has it indexed

### DIFF
--- a/pkg/compactor/retention/retention.go
+++ b/pkg/compactor/retention/retention.go
@@ -203,7 +203,7 @@ func markForDelete(
 				// Mark the chunk for deletion only if it is completely deleted, or this is the last table that the chunk is index in.
 				// For a partially deleted chunk, if we delete the source chunk before all the tables which index it are processed then
 				// the retention would fail because it would fail to find it in the storage.
-				if filterFunc == nil || c.Through <= tableInterval.End {
+				if filterFunc == nil || c.From >= tableInterval.Start {
 					if err := marker.Put(c.ChunkID); err != nil {
 						return false, err
 					}

--- a/pkg/compactor/retention/retention_test.go
+++ b/pkg/compactor/retention/retention_test.go
@@ -175,11 +175,16 @@ func Test_Retention(t *testing.T) {
 	}
 }
 
-type noopWriter struct{}
+type noopWriter struct {
+	count int64
+}
 
-func (noopWriter) Put(_ []byte) error { return nil }
-func (noopWriter) Count() int64       { return 0 }
-func (noopWriter) Close() error       { return nil }
+func (n *noopWriter) Put(_ []byte) error {
+	n.count++
+	return nil
+}
+func (n *noopWriter) Count() int64 { return n.count }
+func (n *noopWriter) Close() error { return nil }
 
 func Test_EmptyTable(t *testing.T) {
 	schema := allSchemas[0]
@@ -197,11 +202,11 @@ func Test_EmptyTable(t *testing.T) {
 	tables := store.indexTables()
 	require.Len(t, tables, 1)
 	// Set a very low retention to make sure all chunks are marked for deletion which will create an empty table.
-	empty, _, err := markForDelete(context.Background(), 0, tables[0].name, noopWriter{}, tables[0], NewExpirationChecker(&fakeLimits{perTenant: map[string]retentionLimit{"1": {retentionPeriod: time.Second}, "2": {retentionPeriod: time.Second}}}), nil, util_log.Logger)
+	empty, _, err := markForDelete(context.Background(), 0, tables[0].name, &noopWriter{}, tables[0], NewExpirationChecker(&fakeLimits{perTenant: map[string]retentionLimit{"1": {retentionPeriod: time.Second}, "2": {retentionPeriod: time.Second}}}), nil, util_log.Logger)
 	require.NoError(t, err)
 	require.True(t, empty)
 
-	_, _, err = markForDelete(context.Background(), 0, tables[0].name, noopWriter{}, newTable("test"), NewExpirationChecker(&fakeLimits{}), nil, util_log.Logger)
+	_, _, err = markForDelete(context.Background(), 0, tables[0].name, &noopWriter{}, newTable("test"), NewExpirationChecker(&fakeLimits{}), nil, util_log.Logger)
 	require.Equal(t, err, errNoChunksFound)
 }
 
@@ -632,6 +637,7 @@ func TestMarkForDelete_SeriesCleanup(t *testing.T) {
 		expectedDeletedSeries []map[uint64]struct{}
 		expectedEmpty         []bool
 		expectedModified      []bool
+		numChunksDeleted      []int64
 	}{
 		{
 			name: "no chunk and series deleted",
@@ -651,6 +657,9 @@ func TestMarkForDelete_SeriesCleanup(t *testing.T) {
 			},
 			expectedModified: []bool{
 				false,
+			},
+			numChunksDeleted: []int64{
+				0,
 			},
 		},
 		{
@@ -675,6 +684,9 @@ func TestMarkForDelete_SeriesCleanup(t *testing.T) {
 			expectedModified: []bool{
 				false,
 			},
+			numChunksDeleted: []int64{
+				0,
+			},
 		},
 		{
 			name: "only one chunk in store which gets deleted",
@@ -694,6 +706,9 @@ func TestMarkForDelete_SeriesCleanup(t *testing.T) {
 			},
 			expectedModified: []bool{
 				true,
+			},
+			numChunksDeleted: []int64{
+				1,
 			},
 		},
 		{
@@ -723,6 +738,9 @@ func TestMarkForDelete_SeriesCleanup(t *testing.T) {
 			expectedModified: []bool{
 				true,
 			},
+			numChunksDeleted: []int64{
+				1,
+			},
 		},
 		{
 			name: "one of two chunks deleted",
@@ -746,6 +764,9 @@ func TestMarkForDelete_SeriesCleanup(t *testing.T) {
 			},
 			expectedModified: []bool{
 				true,
+			},
+			numChunksDeleted: []int64{
+				1,
 			},
 		},
 		{
@@ -779,6 +800,9 @@ func TestMarkForDelete_SeriesCleanup(t *testing.T) {
 			expectedModified: []bool{
 				true,
 			},
+			numChunksDeleted: []int64{
+				1,
+			},
 		},
 		{
 			name: "one big chunk partially deleted for yesterdays table without rewrite",
@@ -801,6 +825,9 @@ func TestMarkForDelete_SeriesCleanup(t *testing.T) {
 			},
 			expectedModified: []bool{
 				true, true,
+			},
+			numChunksDeleted: []int64{
+				1, 0,
 			},
 		},
 		{
@@ -825,6 +852,9 @@ func TestMarkForDelete_SeriesCleanup(t *testing.T) {
 			expectedModified: []bool{
 				true, true,
 			},
+			numChunksDeleted: []int64{
+				1, 0,
+			},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -847,10 +877,12 @@ func TestMarkForDelete_SeriesCleanup(t *testing.T) {
 				seriesCleanRecorder := newSeriesCleanRecorder(table)
 
 				cr := newChunkRewriter(store.chunkClient, table.name, table)
-				empty, isModified, err := markForDelete(context.Background(), 0, table.name, noopWriter{}, seriesCleanRecorder, expirationChecker, cr, util_log.Logger)
+				marker := &noopWriter{}
+				empty, isModified, err := markForDelete(context.Background(), 0, table.name, marker, seriesCleanRecorder, expirationChecker, cr, util_log.Logger)
 				require.NoError(t, err)
 				require.Equal(t, tc.expectedEmpty[i], empty)
 				require.Equal(t, tc.expectedModified[i], isModified)
+				require.Equal(t, tc.numChunksDeleted[i], marker.count)
 
 				require.EqualValues(t, tc.expectedDeletedSeries[i], seriesCleanRecorder.deletedSeries[userID])
 			}
@@ -884,7 +916,7 @@ func TestDeleteTimeout(t *testing.T) {
 			context.Background(),
 			tc.timeout,
 			table.name,
-			noopWriter{},
+			&noopWriter{},
 			newSeriesCleanRecorder(table),
 			expirationChecker,
 			newChunkRewriter(store.chunkClient, table.name, table),
@@ -925,7 +957,7 @@ func TestMarkForDelete_DropChunkFromIndex(t *testing.T) {
 	require.Len(t, tables, 8)
 
 	for i, table := range tables {
-		empty, _, err := markForDelete(context.Background(), 0, table.name, noopWriter{}, table,
+		empty, _, err := markForDelete(context.Background(), 0, table.name, &noopWriter{}, table,
 			NewExpirationChecker(fakeLimits{perTenant: map[string]retentionLimit{"1": {retentionPeriod: retentionPeriod}}}), nil, util_log.Logger)
 		require.NoError(t, err)
 		if i == 7 {


### PR DESCRIPTION
**What this PR does / why we need it**:
When a delete request has a line filter and/or is deleting a chunk partially, we create a new chunk from the source chunk and mark the original chunk for deletion. However, when a chunk overlaps multiple tables, we apply heuristics to retain the chunk until all the tables that have it indexed get processed since we need the original chunk to build a new one.

Earlier, we used to process tables from oldest to newest, so the logic to detect if all the tables indexing a chunk are processed was done by seeing if `chunk-end-time` <= `table-end-time`. To put it in simple terms, if the chunk ends in the current table we are processing, it means this is the last table that we are processing, which has the chunk indexed.

However, this does not work anymore since we changed the order of processing tables to process the newest tables first. To get it working back, I have updated the logic to `chunk-start-time` >= `table-start-time`. In simple terms, if the chunk starts in the current table we are processing, it means this is the last table we are processing, which has the chunk indexed.

**Checklist**
- [x] Tests updated