### PR TITLE
Restore previous behaviour of no trailing newlines in HTTP error response bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 * [11195](https://github.com/grafana/loki/pull/11195) **canuteson** Generate tsdb_shipper storage_config even if using_boltdb_shipper is false
 * [11551](https://github.com/grafana/loki/pull/11551) **dannykopping** Do not reflect label names in request metrics' "route" label.
 * [11601](https://github.com/grafana/loki/pull/11601) **dannykopping** Ruler: Fixed a panic that can be caused by concurrent read-write access of tenant configs when there are a large amount of rules.
+* [11606](https://github.com/grafana/loki/pull/11606) **dannykopping** Fixed regression adding newlines to HTTP error response bodies which may break client integrations.
 
 ##### Changes
 

--- a/pkg/querier/http_test.go
+++ b/pkg/querier/http_test.go
@@ -45,7 +45,7 @@ func TestTailHandler(t *testing.T) {
 
 	handler.ServeHTTP(rr, req)
 	require.Equal(t, http.StatusBadRequest, rr.Code)
-	require.Equal(t, "multiple org IDs present\n", rr.Body.String())
+	require.Equal(t, "multiple org IDs present", rr.Body.String())
 }
 
 type slowConnectionSimulator struct {

--- a/pkg/querier/queryrange/serialize_test.go
+++ b/pkg/querier/queryrange/serialize_test.go
@@ -104,7 +104,7 @@ func TestResponseFormat(t *testing.T) {
 			url:             "/loki/wrong/path",
 			response:        nil,
 			expectedCode:    http.StatusNotFound,
-			expectedRespone: "unknown request path: /loki/wrong/path\n",
+			expectedRespone: "unknown request path: /loki/wrong/path",
 		},
 	} {
 		t.Run(fmt.Sprintf("%s returns the expected format", tc.url), func(t *testing.T) {

--- a/pkg/util/server/error.go
+++ b/pkg/util/server/error.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/grafana/dskit/httpgrpc"
@@ -29,7 +30,10 @@ const (
 // WriteError write a go error with the correct status code.
 func WriteError(err error, w http.ResponseWriter) {
 	status, cerr := ClientHTTPStatusAndError(err)
-	http.Error(w, cerr.Error(), status)
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.WriteHeader(status)
+	fmt.Fprint(w, cerr.Error())
 }
 
 // ClientHTTPStatusAndError returns error and http status that is "safe" to return to client without

--- a/pkg/util/server/error_test.go
+++ b/pkg/util/server/error_test.go
@@ -56,7 +56,7 @@ func Test_writeError(t *testing.T) {
 			require.Equal(t, tt.expectedStatus, rec.Result().StatusCode)
 			b, err := io.ReadAll(rec.Result().Body)
 			require.NoError(t, err)
-			require.Equal(t, tt.msg, string(b[:len(b)-1]))
+			require.EqualValues(t, tt.msg, b)
 		})
 
 		t.Run(tt.name+"-roundtrip", func(t *testing.T) {
@@ -68,7 +68,7 @@ func Test_writeError(t *testing.T) {
 			require.Equal(t, tt.expectedStatus, rec.Result().StatusCode)
 			b, err := io.ReadAll(rec.Result().Body)
 			require.NoError(t, err)
-			require.Equal(t, tt.msg, string(b[:len(b)-1]))
+			require.EqualValues(t, tt.msg, b)
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
#11487 introduced a regression which added trailing newlines to HTTP error response bodies, which may affect client integrations.

This regression hasn't made it into the 2.9.x or 2.8.x releases yet so no backporting is necessary.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
