### PR TITLE
labels/line formatter pooling panic fix

### DIFF
--- a/pkg/logql/log/fmt_test.go
+++ b/pkg/logql/log/fmt_test.go
@@ -925,7 +925,7 @@ func TestInvalidUnixTimes(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestMapPool(t *testing.T) {
+func TestMapPoolPanic(_ *testing.T) {
 	wg := sync.WaitGroup{}
 	wg.Add(1)
 	wgFinished := sync.WaitGroup{}

--- a/pkg/logql/log/fmt_test.go
+++ b/pkg/logql/log/fmt_test.go
@@ -932,7 +932,9 @@ func TestMapPoolPanic(_ *testing.T) {
 
 	ls := labels.FromStrings("cluster", "us-central-0")
 	builder := NewBaseLabelsBuilder().ForLabels(ls, ls.Hash())
-	a := newMustLineFormatter(`[1m{{if .level }}{{alignRight 5 .level}}{{else if .severity}}{{alignRight 5 .severity}}{{end}}[0m [90m[{{alignRight 10 .resources_service_instance_id}}{{if .attributes_thread_name}}/{{alignRight 20 .attributes_thread_name}}{{else if eq "java" .resources_telemetry_sdk_language }}                    {{end}}][0m [36m{{if .instrumentation_scope_name }}{{alignRight 40 .instrumentation_scope_name}}{{end}}[0m {{.body}} {{if .traceid}} [37m[3m[traceid={{.traceid}}]{{end}}`)
+	// this specific line format was part of the query that first alerted us to the panic caused by map pooling in the label/line formatter Process functions
+	tmpl := `[1m{{if .level }}{{alignRight 5 .level}}{{else if .severity}}{{alignRight 5 .severity}}{{end}}[0m [90m[{{alignRight 10 .resources_service_instance_id}}{{if .attributes_thread_name}}/{{alignRight 20 .attributes_thread_name}}{{else if eq "java" .resources_telemetry_sdk_language }}                    {{end}}][0m [36m{{if .instrumentation_scope_name }}{{alignRight 40 .instrumentation_scope_name}}{{end}}[0m {{.body}} {{if .traceid}} [37m[3m[traceid={{.traceid}}]{{end}}`
+	a := newMustLineFormatter(tmpl)
 	a.Process(0,
 		[]byte("logger=sqlstore.metrics traceID=XXXXXXXXXXXXXXXXXXXXXXXXXXXX t=2024-01-04T23:58:47.696779826Z level=debug msg=\"query finished\" status=success elapsedtime=1.523571ms sql=\"some SQL query\" error=null"),
 		builder,
@@ -942,7 +944,7 @@ func TestMapPoolPanic(_ *testing.T) {
 		wgFinished.Add(1)
 		go func() {
 			wg.Wait()
-			a := newMustLineFormatter(`[1m{{if .level }}{{alignRight 5 .level}}{{else if .severity}}{{alignRight 5 .severity}}{{end}}[0m [90m[{{alignRight 10 .resources_service_instance_id}}{{if .attributes_thread_name}}/{{alignRight 20 .attributes_thread_name}}{{else if eq "java" .resources_telemetry_sdk_language }}                    {{end}}][0m [36m{{if .instrumentation_scope_name }}{{alignRight 40 .instrumentation_scope_name}}{{end}}[0m {{.body}} {{if .traceid}} [37m[3m[traceid={{.traceid}}]{{end}}`)
+			a := newMustLineFormatter(tmpl)
 			a.Process(0,
 				[]byte("logger=sqlstore.metrics traceID=XXXXXXXXXXXXXXXXXXXXXXXXXXXX t=2024-01-04T23:58:47.696779826Z level=debug msg=\"query finished\" status=success elapsedtime=1.523571ms sql=\"some SQL query\" error=null"),
 				builder,

--- a/pkg/logql/log/fmt_test.go
+++ b/pkg/logql/log/fmt_test.go
@@ -2,6 +2,7 @@ package log
 
 import (
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -922,4 +923,47 @@ func TestInvalidUnixTimes(t *testing.T) {
 
 	_, err = unixToTime("464")
 	require.Error(t, err)
+}
+
+func TestMapPool(t *testing.T) {
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	wgFinished := sync.WaitGroup{}
+
+	ls := labels.FromStrings("cluster", "us-central-0")
+	builder := NewBaseLabelsBuilder().ForLabels(ls, ls.Hash())
+	a := newMustLineFormatter(`[1m{{if .level }}{{alignRight 5 .level}}{{else if .severity}}{{alignRight 5 .severity}}{{end}}[0m [90m[{{alignRight 10 .resources_service_instance_id}}{{if .attributes_thread_name}}/{{alignRight 20 .attributes_thread_name}}{{else if eq "java" .resources_telemetry_sdk_language }}                    {{end}}][0m [36m{{if .instrumentation_scope_name }}{{alignRight 40 .instrumentation_scope_name}}{{end}}[0m {{.body}} {{if .traceid}} [37m[3m[traceid={{.traceid}}]{{end}}`)
+	a.Process(0,
+		[]byte("logger=sqlstore.metrics traceID=XXXXXXXXXXXXXXXXXXXXXXXXXXXX t=2024-01-04T23:58:47.696779826Z level=debug msg=\"query finished\" status=success elapsedtime=1.523571ms sql=\"some SQL query\" error=null"),
+		builder,
+	)
+
+	for i := 0; i < 100; i++ {
+		wgFinished.Add(1)
+		go func() {
+			wg.Wait()
+			a := newMustLineFormatter(`[1m{{if .level }}{{alignRight 5 .level}}{{else if .severity}}{{alignRight 5 .severity}}{{end}}[0m [90m[{{alignRight 10 .resources_service_instance_id}}{{if .attributes_thread_name}}/{{alignRight 20 .attributes_thread_name}}{{else if eq "java" .resources_telemetry_sdk_language }}                    {{end}}][0m [36m{{if .instrumentation_scope_name }}{{alignRight 40 .instrumentation_scope_name}}{{end}}[0m {{.body}} {{if .traceid}} [37m[3m[traceid={{.traceid}}]{{end}}`)
+			a.Process(0,
+				[]byte("logger=sqlstore.metrics traceID=XXXXXXXXXXXXXXXXXXXXXXXXXXXX t=2024-01-04T23:58:47.696779826Z level=debug msg=\"query finished\" status=success elapsedtime=1.523571ms sql=\"some SQL query\" error=null"),
+				builder,
+			)
+			wgFinished.Done()
+		}()
+	}
+	for i := 0; i < 100; i++ {
+		wgFinished.Add(1)
+		j := i
+		go func() {
+			wg.Wait()
+			m := smp.Get()
+			for k, v := range m {
+				m[k] = fmt.Sprintf("%s%d", v, j)
+			}
+			smp.Put(m)
+			wgFinished.Done()
+
+		}()
+	}
+	wg.Done()
+	wgFinished.Wait()
 }

--- a/pkg/logql/log/labels.go
+++ b/pkg/logql/log/labels.go
@@ -506,7 +506,6 @@ func (b *LabelsBuilder) Map() map[string]string {
 	// todo should we also cache maps since limited by the result ?
 	// Maps also don't create a copy of the labels.
 	res := smp.Get()
-	clear(res)
 	for _, l := range b.buf {
 		res[l.Name] = l.Value
 	}

--- a/pkg/logql/log/labels.go
+++ b/pkg/logql/log/labels.go
@@ -495,12 +495,12 @@ func (b *LabelsBuilder) IntoMap(m map[string]string) {
 	}
 }
 
-func (b *LabelsBuilder) Map() map[string]string {
+func (b *LabelsBuilder) Map() (map[string]string, bool) {
 	if !b.hasDel() && !b.hasAdd() && !b.HasErr() {
 		if b.baseMap == nil {
 			b.baseMap = b.base.Map()
 		}
-		return b.baseMap
+		return b.baseMap, false
 	}
 	b.buf = b.UnsortedLabels(b.buf)
 	// todo should we also cache maps since limited by the result ?
@@ -509,7 +509,7 @@ func (b *LabelsBuilder) Map() map[string]string {
 	for _, l := range b.buf {
 		res[l.Name] = l.Value
 	}
-	return res
+	return res, true
 }
 
 // LabelsResult returns the LabelsResult from the builder.


### PR DESCRIPTION
Big thanks to @slim-bean, even after ~1 day of trying to find a cause here I didn't track down this issue, that I was returning something to the pool that hadn't actually been retrieved from the pool.

The test here in the 2nd commit will fail if you pass the `-race` flag without the fix from the 3rd commit.