### PR TITLE
Bump build image

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "image": "grafana/loki-build-image:0.31.3",
+  "image": "grafana/loki-build-image:0.33.0",
   "containerEnv": {
     "BUILD_IN_CONTAINER": "false"
   },

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "image": "grafana/loki-build-image:0.29.0",
+  "image": "grafana/loki-build-image:0.31.3",
   "containerEnv": {
     "BUILD_IN_CONTAINER": "false"
   },

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -182,14 +182,14 @@ steps:
   depends_on:
   - clone
   environment: {}
-  image: grafana/loki-build-image:0.31.2
+  image: grafana/loki-build-image:0.33.0
   name: check-drone-drift
 - commands:
   - make BUILD_IN_CONTAINER=false check-generated-files
   depends_on:
   - clone
   environment: {}
-  image: grafana/loki-build-image:0.31.2
+  image: grafana/loki-build-image:0.33.0
   name: check-generated-files
 - commands:
   - cd ..
@@ -199,7 +199,7 @@ steps:
   depends_on:
   - clone
   environment: {}
-  image: grafana/loki-build-image:0.31.2
+  image: grafana/loki-build-image:0.33.0
   name: clone-target-branch
   when:
     event:
@@ -210,14 +210,14 @@ steps:
   - clone-target-branch
   - check-generated-files
   environment: {}
-  image: grafana/loki-build-image:0.31.2
+  image: grafana/loki-build-image:0.33.0
   name: test
 - commands:
   - cd ../loki-target-branch && BUILD_IN_CONTAINER=false make test
   depends_on:
   - clone-target-branch
   environment: {}
-  image: grafana/loki-build-image:0.31.2
+  image: grafana/loki-build-image:0.33.0
   name: test-target-branch
   when:
     event:
@@ -230,7 +230,7 @@ steps:
   - test
   - test-target-branch
   environment: {}
-  image: grafana/loki-build-image:0.31.2
+  image: grafana/loki-build-image:0.33.0
   name: compare-coverage
   when:
     event:
@@ -248,7 +248,7 @@ steps:
     TOKEN:
       from_secret: github_token
     USER: grafanabot
-  image: grafana/loki-build-image:0.31.2
+  image: grafana/loki-build-image:0.33.0
   name: report-coverage
   when:
     event:
@@ -258,7 +258,7 @@ steps:
   depends_on:
   - check-generated-files
   environment: {}
-  image: grafana/loki-build-image:0.31.2
+  image: grafana/loki-build-image:0.33.0
   name: lint
 - commands:
   - make BUILD_IN_CONTAINER=false check-mod
@@ -266,7 +266,7 @@ steps:
   - test
   - lint
   environment: {}
-  image: grafana/loki-build-image:0.31.2
+  image: grafana/loki-build-image:0.33.0
   name: check-mod
 - commands:
   - apk add make bash && make lint-scripts
@@ -277,21 +277,21 @@ steps:
   depends_on:
   - check-generated-files
   environment: {}
-  image: grafana/loki-build-image:0.31.2
+  image: grafana/loki-build-image:0.33.0
   name: loki
 - commands:
   - make BUILD_IN_CONTAINER=false check-doc
   depends_on:
   - loki
   environment: {}
-  image: grafana/loki-build-image:0.31.2
+  image: grafana/loki-build-image:0.33.0
   name: check-doc
 - commands:
   - make BUILD_IN_CONTAINER=false check-format GIT_TARGET_BRANCH="$DRONE_TARGET_BRANCH"
   depends_on:
   - loki
   environment: {}
-  image: grafana/loki-build-image:0.31.2
+  image: grafana/loki-build-image:0.33.0
   name: check-format
   when:
     event:
@@ -301,14 +301,14 @@ steps:
   depends_on:
   - loki
   environment: {}
-  image: grafana/loki-build-image:0.31.2
+  image: grafana/loki-build-image:0.33.0
   name: validate-example-configs
 - commands:
   - make BUILD_IN_CONTAINER=false check-example-config-doc
   depends_on:
   - clone
   environment: {}
-  image: grafana/loki-build-image:0.31.2
+  image: grafana/loki-build-image:0.33.0
   name: check-example-config-doc
 - commands:
   - mkdir -p /hugo/content/docs/loki/latest
@@ -341,7 +341,7 @@ steps:
   depends_on:
   - clone
   environment: {}
-  image: grafana/loki-build-image:0.31.2
+  image: grafana/loki-build-image:0.33.0
   name: loki-mixin-check
   when:
     event:
@@ -366,7 +366,7 @@ steps:
   depends_on:
   - clone
   environment: {}
-  image: grafana/loki-build-image:0.31.2
+  image: grafana/loki-build-image:0.33.0
   name: documentation-helm-reference-check
 trigger:
   ref:
@@ -1772,7 +1772,7 @@ steps:
     NFPM_SIGNING_KEY:
       from_secret: gpg_private_key
     NFPM_SIGNING_KEY_FILE: /drone/src/private-key.key
-  image: grafana/loki-build-image:0.31.2
+  image: grafana/loki-build-image:0.33.0
   name: write-key
 - commands:
   - make BUILD_IN_CONTAINER=false packages
@@ -1780,7 +1780,7 @@ steps:
     NFPM_PASSPHRASE:
       from_secret: gpg_passphrase
     NFPM_SIGNING_KEY_FILE: /drone/src/private-key.key
-  image: grafana/loki-build-image:0.31.2
+  image: grafana/loki-build-image:0.33.0
   name: test packaging
 - commands:
   - ./tools/packaging/verify-deb-install.sh
@@ -1806,7 +1806,7 @@ steps:
     NFPM_PASSPHRASE:
       from_secret: gpg_passphrase
     NFPM_SIGNING_KEY_FILE: /drone/src/private-key.key
-  image: grafana/loki-build-image:0.31.2
+  image: grafana/loki-build-image:0.33.0
   name: publish
   when:
     event:
@@ -1841,7 +1841,7 @@ steps:
       from_secret: docker_password
     DOCKER_USERNAME:
       from_secret: docker_username
-  image: grafana/loki-build-image:0.31.2
+  image: grafana/loki-build-image:0.33.0
   name: build and push
   privileged: true
   volumes:
@@ -2106,6 +2106,6 @@ kind: secret
 name: gpg_private_key
 ---
 kind: signature
-hmac: 8ae9cff1a379503d0b568f727d9c12bcb486a5e8d1fc3271deea32f07939baf1
+hmac: f77bf60db54dd4ae7fd08a312e00237e310d542e7e63980ad02dedecda703c76
 
 ...

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -6,7 +6,7 @@ jobs:
     env:
       BUILD_IN_CONTAINER: false 
     container:
-      image: grafana/loki-build-image:0.32.0
+      image: grafana/loki-build-image:0.31.3
     steps:
       - uses: actions/checkout@v4
       - run: git config --global --add safe.directory "$GITHUB_WORKSPACE"

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -6,7 +6,7 @@ jobs:
     env:
       BUILD_IN_CONTAINER: false 
     container:
-      image: grafana/loki-build-image:0.31.3
+      image: grafana/loki-build-image:0.33.0
     steps:
       - uses: actions/checkout@v4
       - run: git config --global --add safe.directory "$GITHUB_WORKSPACE"

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ DOCKER_IMAGE_DIRS := $(patsubst %/Dockerfile,%,$(DOCKERFILES))
 BUILD_IN_CONTAINER ?= true
 
 # ensure you run `make drone` after changing this
-BUILD_IMAGE_VERSION ?= 0.31.2
+BUILD_IMAGE_VERSION ?= 0.31.3
 
 # Docker image info
 IMAGE_PREFIX ?= grafana

--- a/Makefile
+++ b/Makefile
@@ -836,14 +836,16 @@ dev-k3d-down:
 
 # Trivy is used to scan images for vulnerabilities
 .PHONY: trivy
-trivy: loki-image
+trivy: loki-image build-image
 	trivy i $(IMAGE_PREFIX)/loki:$(IMAGE_TAG)
+	trivy i $(IMAGE_PREFIX)/loki-build-image:$(BUILD_IMAGE_VERSION)
 	trivy fs go.mod
 
 # Synk is also used to scan for vulnerabilities, and detects things that trivy might miss
 .PHONY: snyk
-snyk: loki-image
+snyk: loki-image build-image
 	snyk container test $(IMAGE_PREFIX)/loki:$(IMAGE_TAG)
+	snyk container test $(IMAGE_PREFIX)/loki-build-image:$(BUILD_IMAGE_VERSION)
 	snyk code test
 
 .PHONY: scan-vulnerabilities

--- a/Makefile
+++ b/Makefile
@@ -838,14 +838,14 @@ dev-k3d-down:
 .PHONY: trivy
 trivy: loki-image build-image
 	trivy i $(IMAGE_PREFIX)/loki:$(IMAGE_TAG)
-	trivy i $(IMAGE_PREFIX)/loki-build-image:$(BUILD_IMAGE_VERSION)
+	trivy i $(IMAGE_PREFIX)/loki-build-image:$(IMAGE_TAG)
 	trivy fs go.mod
 
 # Synk is also used to scan for vulnerabilities, and detects things that trivy might miss
 .PHONY: snyk
 snyk: loki-image build-image
-	snyk container test $(IMAGE_PREFIX)/loki:$(IMAGE_TAG)
-	snyk container test $(IMAGE_PREFIX)/loki-build-image:$(BUILD_IMAGE_VERSION)
+	snyk container test $(IMAGE_PREFIX)/loki:$(IMAGE_TAG) --file=cmd/loki/Dockerfile
+	snyk container test $(IMAGE_PREFIX)/loki-build-image:$(IMAGE_TAG) --file=loki-build-image/Dockerfile
 	snyk code test
 
 .PHONY: scan-vulnerabilities

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ DOCKER_IMAGE_DIRS := $(patsubst %/Dockerfile,%,$(DOCKERFILES))
 BUILD_IN_CONTAINER ?= true
 
 # ensure you run `make drone` after changing this
-BUILD_IMAGE_VERSION ?= 0.31.3
+BUILD_IMAGE_VERSION ?= 0.33.0
 
 # Docker image info
 IMAGE_PREFIX ?= grafana

--- a/clients/cmd/docker-driver/Dockerfile
+++ b/clients/cmd/docker-driver/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.31.3
+ARG BUILD_IMAGE=grafana/loki-build-image:0.33.0
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/loki -f cmd/loki/Dockerfile .

--- a/clients/cmd/docker-driver/Dockerfile
+++ b/clients/cmd/docker-driver/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.31.2
+ARG BUILD_IMAGE=grafana/loki-build-image:0.31.3
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/loki -f cmd/loki/Dockerfile .

--- a/clients/cmd/docker-driver/Dockerfile
+++ b/clients/cmd/docker-driver/Dockerfile
@@ -9,7 +9,7 @@ COPY . /src/loki
 WORKDIR /src/loki
 RUN make clean && make BUILD_IN_CONTAINER=false clients/cmd/docker-driver/docker-driver
 
-FROM alpine:3.18.4
+FROM alpine:3.18.5
 RUN apk add --update --no-cache ca-certificates tzdata
 COPY --from=build /src/loki/clients/cmd/docker-driver/docker-driver /bin/docker-driver
 WORKDIR /bin/

--- a/clients/cmd/promtail/Dockerfile.cross
+++ b/clients/cmd/promtail/Dockerfile.cross
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.31.3
+ARG BUILD_IMAGE=grafana/loki-build-image:0.33.0
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/promtail -f clients/cmd/promtail/Dockerfile .

--- a/clients/cmd/promtail/Dockerfile.cross
+++ b/clients/cmd/promtail/Dockerfile.cross
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.29.3
+ARG BUILD_IMAGE=grafana/loki-build-image:0.31.3
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/promtail -f clients/cmd/promtail/Dockerfile .

--- a/clients/cmd/promtail/Dockerfile.debug
+++ b/clients/cmd/promtail/Dockerfile.debug
@@ -2,7 +2,7 @@
 # This file is intended to be called from the root like so:
 # docker build -t grafana/promtail -f clients/cmd/promtail/Dockerfile.debug .
 
-FROM grafana/loki-build-image:0.29.3 as build
+FROM grafana/loki-build-image:0.31.3 as build
 ARG GOARCH="amd64"
 COPY . /src/loki
 WORKDIR /src/loki

--- a/clients/cmd/promtail/Dockerfile.debug
+++ b/clients/cmd/promtail/Dockerfile.debug
@@ -2,7 +2,7 @@
 # This file is intended to be called from the root like so:
 # docker build -t grafana/promtail -f clients/cmd/promtail/Dockerfile.debug .
 
-FROM grafana/loki-build-image:0.31.3 as build
+FROM grafana/loki-build-image:0.33.0 as build
 ARG GOARCH="amd64"
 COPY . /src/loki
 WORKDIR /src/loki

--- a/clients/cmd/promtail/Dockerfile.debug
+++ b/clients/cmd/promtail/Dockerfile.debug
@@ -9,7 +9,7 @@ WORKDIR /src/loki
 RUN make clean && make BUILD_IN_CONTAINER=false PROMTAIL_JOURNAL_ENABLED=true promtail-debug
 
 
-FROM       alpine:3.18.4
+FROM       alpine:3.18.5
 RUN        apk add --update --no-cache ca-certificates tzdata
 COPY       --from=build /src/loki/clients/cmd/promtail/promtail-debug /usr/bin/promtail-debug
 COPY       --from=build /usr/bin/dlv /usr/bin/dlv

--- a/cmd/logcli/Dockerfile
+++ b/cmd/logcli/Dockerfile
@@ -4,7 +4,7 @@ COPY . /src/loki
 WORKDIR /src/loki
 RUN make clean && make BUILD_IN_CONTAINER=false logcli
 
-FROM alpine:3.18.4
+FROM alpine:3.18.5
 
 RUN apk add --no-cache ca-certificates
 

--- a/cmd/logql-analyzer/Dockerfile
+++ b/cmd/logql-analyzer/Dockerfile
@@ -4,7 +4,7 @@ COPY . /src/loki
 WORKDIR /src/loki
 RUN make clean && CGO_ENABLED=0 go build ./cmd/logql-analyzer/
 
-FROM alpine:3.18.4
+FROM alpine:3.18.5
 
 RUN apk add --no-cache ca-certificates
 

--- a/cmd/loki-canary-boringcrypto/Dockerfile
+++ b/cmd/loki-canary-boringcrypto/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /src/loki
 RUN go env GOARCH > /goarch
 RUN make clean && make GOARCH=$(cat /goarch) BUILD_IN_CONTAINER=true GOEXPERIMENT=boringcrypto loki-canary-boringcrypto
 
-FROM alpine:3.18.4
+FROM alpine:3.18.5
 RUN apk add --update --no-cache ca-certificates
 RUN apk add --no-cache libc6-compat
 COPY --from=build /src/loki/cmd/loki-canary-boringcrypto/loki-canary-boringcrypto /usr/bin/loki-canary

--- a/cmd/loki-canary/Dockerfile
+++ b/cmd/loki-canary/Dockerfile
@@ -4,7 +4,7 @@ COPY . /src/loki
 WORKDIR /src/loki
 RUN make clean && make BUILD_IN_CONTAINER=false loki-canary
 
-FROM alpine:3.18.4
+FROM alpine:3.18.5
 RUN apk add --update --no-cache ca-certificates
 COPY --from=build /src/loki/cmd/loki-canary/loki-canary /usr/bin/loki-canary
 ENTRYPOINT [ "/usr/bin/loki-canary" ]

--- a/cmd/loki-canary/Dockerfile.cross
+++ b/cmd/loki-canary/Dockerfile.cross
@@ -12,7 +12,7 @@ COPY . /src/loki
 WORKDIR /src/loki
 RUN make clean && GOARCH=$(cat /goarch) GOARM=$(cat /goarm) make BUILD_IN_CONTAINER=false loki-canary
 
-FROM alpine:3.18.4
+FROM alpine:3.18.5
 RUN apk add --update --no-cache ca-certificates
 COPY --from=build /src/loki/cmd/loki-canary/loki-canary /usr/bin/loki-canary
 ENTRYPOINT [ "/usr/bin/loki-canary" ]

--- a/cmd/loki-canary/Dockerfile.cross
+++ b/cmd/loki-canary/Dockerfile.cross
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.31.3
+ARG BUILD_IMAGE=grafana/loki-build-image:0.33.0
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/promtail -f cmd/promtail/Dockerfile .

--- a/cmd/loki-canary/Dockerfile.cross
+++ b/cmd/loki-canary/Dockerfile.cross
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.29.3
+ARG BUILD_IMAGE=grafana/loki-build-image:0.31.3
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/promtail -f cmd/promtail/Dockerfile .

--- a/cmd/loki/Dockerfile
+++ b/cmd/loki/Dockerfile
@@ -4,7 +4,7 @@ COPY . /src/loki
 WORKDIR /src/loki
 RUN make clean && make BUILD_IN_CONTAINER=false loki
 
-FROM alpine:3.18.4
+FROM alpine:3.18.5
 
 RUN apk add --no-cache ca-certificates libcap
 

--- a/cmd/loki/Dockerfile.cross
+++ b/cmd/loki/Dockerfile.cross
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.31.3
+ARG BUILD_IMAGE=grafana/loki-build-image:0.33.0
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/loki -f cmd/loki/Dockerfile .

--- a/cmd/loki/Dockerfile.cross
+++ b/cmd/loki/Dockerfile.cross
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.29.3
+ARG BUILD_IMAGE=grafana/loki-build-image:0.31.3
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/loki -f cmd/loki/Dockerfile .

--- a/cmd/loki/Dockerfile.cross
+++ b/cmd/loki/Dockerfile.cross
@@ -12,7 +12,7 @@ COPY . /src/loki
 WORKDIR /src/loki
 RUN make clean && GOARCH=$(cat /goarch) GOARM=$(cat /goarm) make BUILD_IN_CONTAINER=false loki
 
-FROM alpine:3.18.4
+FROM alpine:3.18.5
 
 RUN apk add --no-cache ca-certificates
 

--- a/cmd/loki/Dockerfile.debug
+++ b/cmd/loki/Dockerfile.debug
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.29.3
+ARG BUILD_IMAGE=grafana/loki-build-image:0.31.3
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/loki -f cmd/loki/Dockerfile.debug .

--- a/cmd/loki/Dockerfile.debug
+++ b/cmd/loki/Dockerfile.debug
@@ -15,7 +15,7 @@ WORKDIR /src/loki
 RUN make clean && \
     GOARCH=$(cat /goarch) GOARM=$(cat /goarm) make BUILD_IN_CONTAINER=false loki-debug
 
-FROM       alpine:3.18.4
+FROM       alpine:3.18.5
 RUN        apk add --update --no-cache ca-certificates
 COPY       --from=build /src/loki/cmd/loki/loki-debug /usr/bin/loki-debug
 COPY       --from=goenv /go/bin/dlv /usr/bin/dlv

--- a/cmd/loki/Dockerfile.debug
+++ b/cmd/loki/Dockerfile.debug
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.31.3
+ARG BUILD_IMAGE=grafana/loki-build-image:0.33.0
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/loki -f cmd/loki/Dockerfile.debug .

--- a/cmd/migrate/Dockerfile
+++ b/cmd/migrate/Dockerfile
@@ -3,7 +3,7 @@ COPY . /src/loki
 WORKDIR /src/loki
 RUN make clean && make BUILD_IN_CONTAINER=false migrate
 
-FROM alpine:3.18.4
+FROM alpine:3.18.5
 RUN apk add --update --no-cache ca-certificates
 COPY --from=build /src/loki/cmd/migrate/migrate /usr/bin/migrate
 #ENTRYPOINT [ "/usr/bin/migrate" ]

--- a/cmd/querytee/Dockerfile
+++ b/cmd/querytee/Dockerfile
@@ -4,7 +4,7 @@ COPY . /src/loki
 WORKDIR /src/loki
 RUN make clean && make BUILD_IN_CONTAINER=false loki-querytee
 
-FROM alpine:3.18.4
+FROM alpine:3.18.5
 RUN apk add --update --no-cache ca-certificates
 COPY --from=build /src/loki/cmd/querytee/querytee /usr/bin/querytee
 ENTRYPOINT [ "/usr/bin/querytee" ]

--- a/cmd/querytee/Dockerfile.cross
+++ b/cmd/querytee/Dockerfile.cross
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.31.3
+ARG BUILD_IMAGE=grafana/loki-build-image:0.33.0
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/promtail -f cmd/promtail/Dockerfile .

--- a/cmd/querytee/Dockerfile.cross
+++ b/cmd/querytee/Dockerfile.cross
@@ -12,7 +12,7 @@ COPY . /src/loki
 WORKDIR /src/loki
 RUN make clean && GOARCH=$(cat /goarch) GOARM=$(cat /goarm) make BUILD_IN_CONTAINER=false loki-querytee
 
-FROM alpine:3.18.4
+FROM alpine:3.18.5
 RUN apk add --update --no-cache ca-certificates
 COPY --from=build /src/loki/cmd/querytee/querytee /usr/bin/querytee
 ENTRYPOINT [ "/usr/bin/querytee" ]

--- a/cmd/querytee/Dockerfile.cross
+++ b/cmd/querytee/Dockerfile.cross
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.29.3
+ARG BUILD_IMAGE=grafana/loki-build-image:0.31.3
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/promtail -f cmd/promtail/Dockerfile .

--- a/loki-build-image/Dockerfile
+++ b/loki-build-image/Dockerfile
@@ -15,7 +15,7 @@ RUN BIN=$([ "$TARGETARCH" = "arm64" ] && echo "helm-docs_Linux_arm64" || echo "h
     curl -L "https://github.com/norwoodj/helm-docs/releases/download/v1.11.2/$BIN.tar.gz" | tar zx && \
     install -t /usr/local/bin helm-docs
 
-FROM alpine:3.18.4 as lychee
+FROM alpine:3.18.5 as lychee
 ARG TARGETARCH
 ARG LYCHEE_VER="0.7.0"
 RUN apk add --no-cache curl && \
@@ -24,18 +24,18 @@ RUN apk add --no-cache curl && \
     mv /tmp/lychee /usr/bin/lychee && \
     rm -rf "/tmp/linux-$TARGETARCH" /tmp/lychee-$LYCHEE_VER.tgz
 
-FROM alpine:3.18.4 as golangci
+FROM alpine:3.18.5 as golangci
 RUN apk add --no-cache curl && \
     cd / && \
     curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.55.1
 
-FROM alpine:3.18.4 as buf
+FROM alpine:3.18.5 as buf
 ARG TARGETOS
 RUN apk add --no-cache curl && \
     curl -sSL "https://github.com/bufbuild/buf/releases/download/v1.4.0/buf-$TARGETOS-$(uname -m)" -o "/usr/bin/buf" && \
     chmod +x "/usr/bin/buf"
 
-FROM alpine:3.18.4 as docker
+FROM alpine:3.18.5 as docker
 RUN apk add --no-cache docker-cli docker-cli-buildx
 
 FROM golang:1.21.3-bullseye as drone

--- a/loki-build-image/README.md
+++ b/loki-build-image/README.md
@@ -6,7 +6,7 @@
 
 - Update to Alpine 3.18.5
 
-### 0.30.18
+### 0.30.1
 
 - Update to Go version 1.21.3
 

--- a/loki-build-image/README.md
+++ b/loki-build-image/README.md
@@ -2,6 +2,10 @@
 
 ## Versions
 
+### 0.31.3
+
+- Update to Alpine 3.18.5
+
 ### 0.30.18
 
 - Update to Go version 1.21.3

--- a/loki-build-image/README.md
+++ b/loki-build-image/README.md
@@ -2,7 +2,7 @@
 
 ## Versions
 
-### 0.31.3
+### 0.33.0
 
 - Update to Alpine 3.18.5
 

--- a/operator/Dockerfile.cross
+++ b/operator/Dockerfile.cross
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.30.1
+ARG BUILD_IMAGE=grafana/loki-build-image:0.31.3
 
 FROM golang:1.20.10-alpine as goenv
 RUN go env GOARCH > /goarch && \

--- a/operator/Dockerfile.cross
+++ b/operator/Dockerfile.cross
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.31.3
+ARG BUILD_IMAGE=grafana/loki-build-image:0.33.0
 
 FROM golang:1.20.10-alpine as goenv
 RUN go env GOARCH > /goarch && \

--- a/production/helm/loki/src/helm-test/Dockerfile
+++ b/production/helm/loki/src/helm-test/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.4 as build
+FROM golang:1.21.3 as build
 
 # build via Makefile target helm-test-image in root
 # Makefile. Building from this directory will not be

--- a/production/helm/loki/src/helm-test/Dockerfile
+++ b/production/helm/loki/src/helm-test/Dockerfile
@@ -7,7 +7,7 @@ COPY . /src/loki
 WORKDIR /src/loki
 RUN make clean && make BUILD_IN_CONTAINER=false helm-test
 
-FROM alpine:3.18.4
+FROM alpine:3.18.5
 RUN apk add --update --no-cache ca-certificates=20230506-r0
 COPY --from=build /src/loki/production/helm/loki/src/helm-test/helm-test /usr/bin/helm-test
 ENTRYPOINT [ "/usr/bin/helm-test" ]

--- a/tools/dev/loki-boltdb-storage-s3/dev.dockerfile
+++ b/tools/dev/loki-boltdb-storage-s3/dev.dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.20.4
 ENV CGO_ENABLED=0
 RUN go install github.com/go-delve/delve/cmd/dlv@v1.21.1
 
-FROM alpine:3.18.4
+FROM alpine:3.18.5
 
 RUN     mkdir /loki
 WORKDIR /loki

--- a/tools/lambda-promtail/Dockerfile
+++ b/tools/lambda-promtail/Dockerfile
@@ -12,7 +12,7 @@ RUN go mod download
 RUN go build -o ./main -tags lambda.norpc -ldflags="-s -w" lambda-promtail/*.go
 
 
-FROM alpine:3.18.4
+FROM alpine:3.18.5
 
 WORKDIR /app
 

--- a/tools/tsdb/bloom-tester/Dockerfile
+++ b/tools/tsdb/bloom-tester/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /src/bloom-tester
 
 RUN make bloom-tester
 
-FROM alpine:3.18.4
+FROM alpine:3.18.5
 RUN apk add --update --no-cache ca-certificates
 COPY --from=build /src/bloom-tester/tools/tsdb/bloom-tester/bloom-tester /usr/bin/bloom-tester
 ENTRYPOINT [ "/usr/bin/bloom-tester", "--config.file=/etc/loki/config.yaml" ]


### PR DESCRIPTION
**What this PR does / why we need it**:

Bumps alpine in the loki build image and ass the build image to the `scan-vulnerabilities` target to make it easier to scan in the future