### PR TITLE
Ruler: catering for another data race in tenant config

### DIFF
--- a/pkg/ruler/registry.go
+++ b/pkg/ruler/registry.go
@@ -179,6 +179,9 @@ func (r *walRegistry) stop() {
 }
 
 func (r *walRegistry) getTenantConfig(tenant string) (instance.Config, error) {
+	r.overridesMu.Lock()
+	defer r.overridesMu.Unlock()
+
 	conf, err := r.config.WAL.Clone()
 	if err != nil {
 		return instance.Config{}, err
@@ -225,9 +228,6 @@ func (r *walRegistry) getTenantConfig(tenant string) (instance.Config, error) {
 }
 
 func (r *walRegistry) getTenantRemoteWriteConfig(tenant string, base RemoteWriteConfig) (*RemoteWriteConfig, error) {
-	r.overridesMu.Lock()
-	defer r.overridesMu.Unlock()
-
 	overrides, err := base.Clone()
 	if err != nil {
 		return nil, fmt.Errorf("error generating tenant remote-write config: %w", err)


### PR DESCRIPTION
Expands on #11601

**What this PR does / why we need it**:
Turns out the previous tests didn't expose all possible causes for data races (another one occurs at https://github.com/grafana/loki/blob/5a55158cc751465846383bc758aa0c169363b292/pkg/ruler/registry.go#L204).
Moving the mutex to the calling function adds more safety.

**Which issue(s) this PR fixes**:
Fixes #11569
