### PR TITLE
Update paths in cloud config topics

### DIFF
--- a/docs/sources/send-data/promtail/cloud/ec2/_index.md
+++ b/docs/sources/send-data/promtail/cloud/ec2/_index.md
@@ -287,5 +287,5 @@ Let's head back to Grafana and verify that your Promtail logs are available in G
 [live tailing]: https://grafana.com/docs/grafana/latest/features/datasources/loki/#live-tailing
 [systemd]: ../../../installation/helm#run-promtail-with-systemd-journal-support
 [journald]: https://www.freedesktop.org/software/systemd/man/systemd-journald.service.html
-[final config]: https://github.com/grafana/loki/blob/main/docs/sources/clients/aws/ec2/promtail-ec2-final.yaml
+[final config]: https://github.com/grafana/loki/blob/main/docs/sources/send-data/promtail/cloud/ec2/promtail-ec2-final.yaml
 [relabeling]: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config

--- a/docs/sources/send-data/promtail/cloud/ecs/_index.md
+++ b/docs/sources/send-data/promtail/cloud/ecs/_index.md
@@ -39,7 +39,7 @@ We will also need an [IAM Role to run containers][ecs iam] with, let's create a 
 > You might already have this `ecsTaskExecutionRole` role in your AWS account if that's the case you can skip this step.
 
 ```bash
-curl https://raw.githubusercontent.com/grafana/loki/main/docs/sources/clients/aws/ecs/ecs-role.json > ecs-role.json
+curl https://raw.githubusercontent.com/grafana/loki/main/docs/sources/send-data/promtail/cloud/ecs/ecs-role.json > ecs-role.json
 aws iam create-role --role-name ecsTaskExecutionRole  --assume-role-policy-document file://ecs-role.json
 
 {

--- a/docs/sources/send-data/promtail/cloud/eks/_index.md
+++ b/docs/sources/send-data/promtail/cloud/eks/_index.md
@@ -233,7 +233,7 @@ helm upgrade  promtail loki/promtail -n monitoring -f values.yaml
 And deploy the `eventrouter` using:
 
 ```bash
-kubectl create -f https://raw.githubusercontent.com/grafana/loki/main/docs/sources/clients/aws/eks/eventrouter.yaml
+kubectl create -f https://raw.githubusercontent.com/grafana/loki/main/docs/sources/send-data/promtail/cloud/eks/eventrouter.yaml
 ```
 You should see output similar to the following:
 ```bash


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates links to path for a couple of example files that were missed in the information architecture moves.

**Which issue(s) this PR fixes**:
Fixes #11617 

(This is in addition to the updates in https://github.com/grafana/loki/pull/11568)

