### PR TITLE
operator: Fixes Ruler RBAC to allow it to send alerts to UWM AM

### DIFF
--- a/operator/bundle/community-openshift/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/community-openshift/manifests/loki-operator.clusterserviceversion.yaml
@@ -150,7 +150,7 @@ metadata:
     categories: OpenShift Optional, Logging & Tracing
     certified: "false"
     containerImage: docker.io/grafana/loki-operator:0.5.0
-    createdAt: "2023-12-12T09:22:19Z"
+    createdAt: "2024-01-09T15:56:31Z"
     description: The Community Loki Operator provides Kubernetes native deployment
       and management of Loki and related logging components.
     features.operators.openshift.io/disconnected: "true"
@@ -1420,10 +1420,6 @@ spec:
     spec:
       clusterPermissions:
       - rules:
-        - nonResourceURLs:
-          - /api/v2/alerts
-          verbs:
-          - create
         - apiGroups:
           - ""
           resources:
@@ -1591,6 +1587,18 @@ spec:
           - alertmanagers
           verbs:
           - patch
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - alertmanagers/api
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
         - apiGroups:
           - monitoring.coreos.com
           resources:

--- a/operator/bundle/community-openshift/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/community-openshift/manifests/loki-operator.clusterserviceversion.yaml
@@ -150,7 +150,7 @@ metadata:
     categories: OpenShift Optional, Logging & Tracing
     certified: "false"
     containerImage: docker.io/grafana/loki-operator:0.5.0
-    createdAt: "2024-01-09T15:56:31Z"
+    createdAt: "2024-01-10T18:25:00Z"
     description: The Community Loki Operator provides Kubernetes native deployment
       and management of Loki and related logging components.
     features.operators.openshift.io/disconnected: "true"
@@ -1420,6 +1420,10 @@ spec:
     spec:
       clusterPermissions:
       - rules:
+        - nonResourceURLs:
+          - /api/v2/alerts
+          verbs:
+          - create
         - apiGroups:
           - ""
           resources:
@@ -1593,12 +1597,6 @@ spec:
           - alertmanagers/api
           verbs:
           - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
         - apiGroups:
           - monitoring.coreos.com
           resources:

--- a/operator/bundle/community/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/community/manifests/loki-operator.clusterserviceversion.yaml
@@ -150,7 +150,7 @@ metadata:
     categories: OpenShift Optional, Logging & Tracing
     certified: "false"
     containerImage: docker.io/grafana/loki-operator:0.5.0
-    createdAt: "2023-12-12T09:22:17Z"
+    createdAt: "2024-01-09T15:56:30Z"
     description: The Community Loki Operator provides Kubernetes native deployment
       and management of Loki and related logging components.
     operators.operatorframework.io/builder: operator-sdk-unknown
@@ -1400,10 +1400,6 @@ spec:
     spec:
       clusterPermissions:
       - rules:
-        - nonResourceURLs:
-          - /api/v2/alerts
-          verbs:
-          - create
         - apiGroups:
           - ""
           resources:
@@ -1571,6 +1567,18 @@ spec:
           - alertmanagers
           verbs:
           - patch
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - alertmanagers/api
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
         - apiGroups:
           - monitoring.coreos.com
           resources:

--- a/operator/bundle/community/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/community/manifests/loki-operator.clusterserviceversion.yaml
@@ -150,7 +150,7 @@ metadata:
     categories: OpenShift Optional, Logging & Tracing
     certified: "false"
     containerImage: docker.io/grafana/loki-operator:0.5.0
-    createdAt: "2024-01-09T15:56:30Z"
+    createdAt: "2024-01-10T18:24:59Z"
     description: The Community Loki Operator provides Kubernetes native deployment
       and management of Loki and related logging components.
     operators.operatorframework.io/builder: operator-sdk-unknown
@@ -1400,6 +1400,10 @@ spec:
     spec:
       clusterPermissions:
       - rules:
+        - nonResourceURLs:
+          - /api/v2/alerts
+          verbs:
+          - create
         - apiGroups:
           - ""
           resources:
@@ -1573,12 +1577,6 @@ spec:
           - alertmanagers/api
           verbs:
           - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
         - apiGroups:
           - monitoring.coreos.com
           resources:

--- a/operator/bundle/openshift/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/openshift/manifests/loki-operator.clusterserviceversion.yaml
@@ -150,7 +150,7 @@ metadata:
     categories: OpenShift Optional, Logging & Tracing
     certified: "false"
     containerImage: quay.io/openshift-logging/loki-operator:0.1.0
-    createdAt: "2024-01-09T15:56:33Z"
+    createdAt: "2024-01-10T18:25:02Z"
     description: |
       The Loki Operator for OCP provides a means for configuring and managing a Loki stack for cluster logging.
       ## Prerequisites and Requirements
@@ -1405,6 +1405,10 @@ spec:
     spec:
       clusterPermissions:
       - rules:
+        - nonResourceURLs:
+          - /api/v2/alerts
+          verbs:
+          - create
         - apiGroups:
           - ""
           resources:
@@ -1578,12 +1582,6 @@ spec:
           - alertmanagers/api
           verbs:
           - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
         - apiGroups:
           - monitoring.coreos.com
           resources:

--- a/operator/bundle/openshift/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/openshift/manifests/loki-operator.clusterserviceversion.yaml
@@ -150,7 +150,7 @@ metadata:
     categories: OpenShift Optional, Logging & Tracing
     certified: "false"
     containerImage: quay.io/openshift-logging/loki-operator:0.1.0
-    createdAt: "2023-12-12T09:22:21Z"
+    createdAt: "2024-01-09T15:56:33Z"
     description: |
       The Loki Operator for OCP provides a means for configuring and managing a Loki stack for cluster logging.
       ## Prerequisites and Requirements
@@ -1405,10 +1405,6 @@ spec:
     spec:
       clusterPermissions:
       - rules:
-        - nonResourceURLs:
-          - /api/v2/alerts
-          verbs:
-          - create
         - apiGroups:
           - ""
           resources:
@@ -1576,6 +1572,18 @@ spec:
           - alertmanagers
           verbs:
           - patch
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - alertmanagers/api
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
         - apiGroups:
           - monitoring.coreos.com
           resources:

--- a/operator/config/rbac/role.yaml
+++ b/operator/config/rbac/role.yaml
@@ -4,6 +4,10 @@ kind: ClusterRole
 metadata:
   name: lokistack-manager
 rules:
+- nonResourceURLs:
+  - /api/v2/alerts
+  verbs:
+  - create
 - apiGroups:
   - ""
   resources:
@@ -177,12 +181,6 @@ rules:
   - alertmanagers/api
   verbs:
   - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
 - apiGroups:
   - monitoring.coreos.com
   resources:

--- a/operator/config/rbac/role.yaml
+++ b/operator/config/rbac/role.yaml
@@ -4,10 +4,6 @@ kind: ClusterRole
 metadata:
   name: lokistack-manager
 rules:
-- nonResourceURLs:
-  - /api/v2/alerts
-  verbs:
-  - create
 - apiGroups:
   - ""
   resources:
@@ -175,6 +171,18 @@ rules:
   - alertmanagers
   verbs:
   - patch
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - alertmanagers/api
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - monitoring.coreos.com
   resources:

--- a/operator/controllers/loki/lokistack_controller.go
+++ b/operator/controllers/loki/lokistack_controller.go
@@ -123,7 +123,8 @@ type LokiStackReconciler struct {
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings;clusterroles;roles;rolebindings,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors;prometheusrules,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups=monitoring.coreos.com,resources=alertmanagers,verbs=patch
-// +kubebuilder:rbac:groups=monitoring.coreos.com,resources=alertmanagers/api,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=monitoring.coreos.com,resources=alertmanagers/api,verbs=create
+// +kubebuilder:rbac:urls=/api/v2/alerts,verbs=create
 // +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;create;update
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses,verbs=get;list;watch;create;update
 // +kubebuilder:rbac:groups=policy,resources=poddisruptionbudgets,verbs=get;list;watch;create;update

--- a/operator/controllers/loki/lokistack_controller.go
+++ b/operator/controllers/loki/lokistack_controller.go
@@ -123,7 +123,7 @@ type LokiStackReconciler struct {
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings;clusterroles;roles;rolebindings,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors;prometheusrules,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups=monitoring.coreos.com,resources=alertmanagers,verbs=patch
-// +kubebuilder:rbac:urls=/api/v2/alerts,verbs=create
+// +kubebuilder:rbac:groups=monitoring.coreos.com,resources=alertmanagers/api,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;create;update
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses,verbs=get;list;watch;create;update
 // +kubebuilder:rbac:groups=policy,resources=poddisruptionbudgets,verbs=get;list;watch;create;update

--- a/operator/internal/manifests/openshift/rbac.go
+++ b/operator/internal/manifests/openshift/rbac.go
@@ -101,11 +101,20 @@ func BuildRulerClusterRole(opts Options) *rbacv1.ClusterRole {
 				},
 			},
 			{
-				NonResourceURLs: []string{
-					"/api/v2/alerts",
+				APIGroups: []string{
+					"monitoring.coreos.com",
+				},
+				Resources: []string{
+					"alertmanagers/api",
 				},
 				Verbs: []string{
+					"get",
+					"list",
+					"watch",
 					"create",
+					"update",
+					"patch",
+					"delete",
 				},
 			},
 		},

--- a/operator/internal/manifests/openshift/rbac.go
+++ b/operator/internal/manifests/openshift/rbac.go
@@ -101,6 +101,14 @@ func BuildRulerClusterRole(opts Options) *rbacv1.ClusterRole {
 				},
 			},
 			{
+				NonResourceURLs: []string{
+					"/api/v2/alerts",
+				},
+				Verbs: []string{
+					"create",
+				},
+			},
+			{
 				APIGroups: []string{
 					"monitoring.coreos.com",
 				},
@@ -108,13 +116,7 @@ func BuildRulerClusterRole(opts Options) *rbacv1.ClusterRole {
 					"alertmanagers/api",
 				},
 				Verbs: []string{
-					"get",
-					"list",
-					"watch",
 					"create",
-					"update",
-					"patch",
-					"delete",
 				},
 			},
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:

Updated RBAC now match the new updated requirements by UWM Alertmanager introduced on https://github.com/openshift/cluster-monitoring-operator/pull/2099

**Which issue(s) this PR fixes**:

Issue https://issues.redhat.com/browse/LOG-4938

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
