### PR TITLE
operator: React to changes in ConfigMap used for storage CA

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Main
 
+- [11624](https://github.com/grafana/loki/pull/11624) **xperimental**: React to changes in ConfigMap used for storage CA
 - [11533](https://github.com/grafana/loki/pull/11533) **periklis**: Add serviceaccount per LokiStack resource
 - [11158](https://github.com/grafana/loki/pull/11158) **btaani**: operator: Add warning for old schema configuration
 - [11473](https://github.com/grafana/loki/pull/11473) **JoaoBraveCoding**: Adds structured metadata dashboards

--- a/operator/controllers/loki/lokistack_controller.go
+++ b/operator/controllers/loki/lokistack_controller.go
@@ -324,7 +324,7 @@ func (r *LokiStackReconciler) enqueueForStorageCA() handler.EventHandler {
 	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []reconcile.Request {
 		lokiStacks := &lokiv1.LokiStackList{}
 		if err := r.Client.List(ctx, lokiStacks, client.InNamespace(obj.GetNamespace())); err != nil {
-			r.Log.Error(err, "Error getting LokiStack resources in event handler")
+			r.Log.Error(err, "Error listing LokiStack resources for storage CA update")
 			return nil
 		}
 

--- a/operator/controllers/loki/lokistack_controller.go
+++ b/operator/controllers/loki/lokistack_controller.go
@@ -94,12 +94,7 @@ var (
 	})
 	createUpdateOrDeletePred = builder.WithPredicates(predicate.Funcs{
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			if e.ObjectOld.GetGeneration() == 0 && len(e.ObjectOld.GetAnnotations()) == 0 {
-				return e.ObjectOld.GetResourceVersion() != e.ObjectNew.GetResourceVersion()
-			}
-
-			return e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration() ||
-				cmp.Diff(e.ObjectOld.GetAnnotations(), e.ObjectNew.GetAnnotations()) != ""
+			return e.ObjectOld.GetResourceVersion() != e.ObjectNew.GetResourceVersion()
 		},
 		CreateFunc:  func(e event.CreateEvent) bool { return true },
 		DeleteFunc:  func(e event.DeleteEvent) bool { return true },

--- a/operator/controllers/loki/lokistack_controller_test.go
+++ b/operator/controllers/loki/lokistack_controller_test.go
@@ -203,8 +203,8 @@ func TestLokiStackController_RegisterWatchedResources(t *testing.T) {
 	table := []test{
 		{
 			src:               &openshiftconfigv1.APIServer{},
-			index:             2,
-			watchesCallsCount: 3,
+			index:             3,
+			watchesCallsCount: 4,
 			featureGates: configv1.FeatureGates{
 				OpenShift: configv1.OpenShiftFeatureGates{
 					ClusterTLSPolicy: true,
@@ -214,8 +214,8 @@ func TestLokiStackController_RegisterWatchedResources(t *testing.T) {
 		},
 		{
 			src:               &openshiftconfigv1.Proxy{},
-			index:             2,
-			watchesCallsCount: 3,
+			index:             3,
+			watchesCallsCount: 4,
 			featureGates: configv1.FeatureGates{
 				OpenShift: configv1.OpenShiftFeatureGates{
 					ClusterProxy: true,
@@ -226,14 +226,21 @@ func TestLokiStackController_RegisterWatchedResources(t *testing.T) {
 		{
 			src:               &corev1.Service{},
 			index:             0,
-			watchesCallsCount: 2,
+			watchesCallsCount: 3,
 			featureGates:      configv1.FeatureGates{},
 			pred:              createUpdateOrDeletePred,
 		},
 		{
 			src:               &corev1.Secret{},
 			index:             1,
-			watchesCallsCount: 2,
+			watchesCallsCount: 3,
+			featureGates:      configv1.FeatureGates{},
+			pred:              createUpdateOrDeletePred,
+		},
+		{
+			src:               &corev1.ConfigMap{},
+			index:             2,
+			watchesCallsCount: 3,
 			featureGates:      configv1.FeatureGates{},
 			pred:              createUpdateOrDeletePred,
 		},

--- a/operator/internal/handlers/internal/storage/ca_configmap.go
+++ b/operator/internal/handlers/internal/storage/ca_configmap.go
@@ -7,12 +7,18 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+type caKeyError string
+
+func (e caKeyError) Error() string {
+	return fmt.Sprintf("key not present or data empty: %s", string(e))
+}
+
 // CheckCAConfigMap checks if the given CA configMap has an non-empty entry for the key used as CA certificate.
 // If the key is present it will return a hash of the current key name and contents.
 func CheckCAConfigMap(cm *corev1.ConfigMap, key string) (string, error) {
 	data := cm.Data[key]
 	if data == "" {
-		return "", fmt.Errorf("key not present or data empty: %s", key)
+		return "", caKeyError(key)
 	}
 
 	h := sha1.New()

--- a/operator/internal/handlers/internal/storage/ca_configmap.go
+++ b/operator/internal/handlers/internal/storage/ca_configmap.go
@@ -1,9 +1,32 @@
 package storage
 
-import corev1 "k8s.io/api/core/v1"
+import (
+	"crypto/sha1"
+	"fmt"
 
-// IsValidCAConfigMap checks if the given CA configMap has an
-// non-empty entry for the key
-func IsValidCAConfigMap(cm *corev1.ConfigMap, key string) bool {
-	return cm.Data[key] != ""
+	corev1 "k8s.io/api/core/v1"
+)
+
+// CheckCAConfigMap checks if the given CA configMap has an non-empty entry for the key used as CA certificate.
+// If the key is present it will return a hash of the current key name and contents.
+func CheckCAConfigMap(cm *corev1.ConfigMap, key string) (string, error) {
+	data := cm.Data[key]
+	if data == "" {
+		return "", fmt.Errorf("key not present or data empty: %s", key)
+	}
+
+	h := sha1.New()
+	if _, err := h.Write([]byte(key)); err != nil {
+		return "", err
+	}
+
+	if _, err := h.Write(hashSeparator); err != nil {
+		return "", err
+	}
+
+	if _, err := h.Write([]byte(data)); err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("%x", h.Sum(nil)), nil
 }

--- a/operator/internal/handlers/lokistack_create_or_update.go
+++ b/operator/internal/handlers/lokistack_create_or_update.go
@@ -133,7 +133,8 @@ func CreateOrUpdateLokiStack(
 			caKey = tlsConfig.CAKey
 		}
 
-		caHash, err := storage.CheckCAConfigMap(&cm, caKey)
+		var caHash string
+		caHash, err = storage.CheckCAConfigMap(&cm, caKey)
 		if err != nil {
 			return &status.DegradedError{
 				Message: fmt.Sprintf("Invalid object storage CA configmap contents: %s", err),

--- a/operator/internal/handlers/lokistack_create_or_update.go
+++ b/operator/internal/handlers/lokistack_create_or_update.go
@@ -133,14 +133,16 @@ func CreateOrUpdateLokiStack(
 			caKey = tlsConfig.CAKey
 		}
 
-		if !storage.IsValidCAConfigMap(&cm, caKey) {
+		caHash, err := storage.CheckCAConfigMap(&cm, caKey)
+		if err != nil {
 			return &status.DegradedError{
-				Message: "Invalid object storage CA configmap contents: missing key or no contents",
+				Message: fmt.Sprintf("Invalid object storage CA configmap contents: %s", err),
 				Reason:  lokiv1.ReasonInvalidObjectStorageCAConfigMap,
 				Requeue: false,
 			}
 		}
 
+		objStore.SecretSHA1 = fmt.Sprintf("%s;%s", objStore.SecretSHA1, caHash)
 		objStore.TLS = &storageoptions.TLSConfig{CA: cm.Name, Key: caKey}
 	}
 

--- a/operator/internal/handlers/lokistack_create_or_update_test.go
+++ b/operator/internal/handlers/lokistack_create_or_update_test.go
@@ -997,7 +997,7 @@ func TestCreateOrUpdateLokiStack_WhenInvalidCAConfigMap_SetDegraded(t *testing.T
 	}
 
 	degradedErr := &status.DegradedError{
-		Message: "Invalid object storage CA configmap contents: missing key or no contents",
+		Message: "Invalid object storage CA configmap contents: key not present or data empty: service-ca.crt",
 		Reason:  lokiv1.ReasonInvalidObjectStorageCAConfigMap,
 		Requeue: false,
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

The operator allows to set a custom CA used for accessing S3-based object storage using the `spec.storage.tls.caName` key. While the operator already produces an error when the ConfigMap referenced by that key does not exist or does not contain data, it does not automatically react to changes to the ConfigMap. This PR fixes that by watching for changes to ConfigMap resources.

**Which issue(s) this PR fixes**:

[LOG-4897](https://issues.redhat.com/browse/LOG-4897)

**Special notes for your reviewer**:

-  [This commit](https://github.com/grafana/loki/commit/92611216e8edb7721e83119f73c4606436d04661) of the PR contains a change to the predicate used for checking if a ConfigMap resource has changed. The old implementation used `metadata.generation` which is not used on ConfigMap resources. This PR changes this to use the `metadata.resourceVersion` instead which is available on all resources. The same code is also used for Service and Secret resource types.

**Checklist**

- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Tests updated
- [x] `CHANGELOG.md` updated
