### PR TITLE
Support sharding of binary operation for non shardable side.

### DIFF
--- a/pkg/logql/downstream.go
+++ b/pkg/logql/downstream.go
@@ -285,11 +285,11 @@ func (ev DownstreamEvaluator) Downstream(ctx context.Context, queries []Downstre
 type errorQuerier struct{}
 
 func (errorQuerier) SelectLogs(_ context.Context, _ SelectLogParams) (iter.EntryIterator, error) {
-	return nil, errors.New("unimplemented")
+	return nil, errors.New("unimplemented SelectLogs")
 }
 
 func (errorQuerier) SelectSamples(_ context.Context, _ SelectSampleParams) (iter.SampleIterator, error) {
-	return nil, errors.New("unimplemented")
+	return nil, errors.New("unimplemented SelectSamples")
 }
 
 func NewDownstreamEvaluator(downstreamer Downstreamer) *DownstreamEvaluator {

--- a/pkg/logql/downstream.go
+++ b/pkg/logql/downstream.go
@@ -285,11 +285,11 @@ func (ev DownstreamEvaluator) Downstream(ctx context.Context, queries []Downstre
 type errorQuerier struct{}
 
 func (errorQuerier) SelectLogs(_ context.Context, _ SelectLogParams) (iter.EntryIterator, error) {
-	return nil, errors.New("unimplemented SelectLogs")
+	return nil, errors.New("SelectLogs unimplemented: the query-frontend cannot evaluate an expression that selects logs. this is likely a bug in the query engine. please contact your system operator")
 }
 
 func (errorQuerier) SelectSamples(_ context.Context, _ SelectSampleParams) (iter.SampleIterator, error) {
-	return nil, errors.New("unimplemented SelectSamples")
+	return nil, errors.New("SelectSamples unimplemented: the query-frontend cannot evaluate an expression that selects samples. this is likely a bug in the query engine. please contact your system operator")
 }
 
 func NewDownstreamEvaluator(downstreamer Downstreamer) *DownstreamEvaluator {

--- a/pkg/logql/downstream_test.go
+++ b/pkg/logql/downstream_test.go
@@ -56,9 +56,11 @@ func TestMappingEquivalence(t *testing.T) {
 		{`avg_over_time({a=~".+"} | logfmt | unwrap value [1s]) by (a)`, true},
 		{`quantile_over_time(0.99, {a=~".+"} | logfmt | unwrap value [1s])`, true},
 		{
-			`quantile_over_time(0.99, {a=~".+"} | logfmt | unwrap value [1s]) by (a) > 1
-			 and
-			 avg(rate({a=~".+"}[1s])) by (a)`,
+			`
+			  (quantile_over_time(0.99,{a=~".+"} | logfmt | unwrap value[1s]) by (a) > 1)
+			and
+			  avg by (a)(rate({a=~".+"}[1s]))
+			`,
 			false,
 		},
 		// topk prefers already-seen values in tiebreakers. Since the test data generates

--- a/pkg/logql/downstream_test.go
+++ b/pkg/logql/downstream_test.go
@@ -55,6 +55,12 @@ func TestMappingEquivalence(t *testing.T) {
 		{`avg_over_time({a=~".+"} | logfmt | unwrap value [1s])`, false},
 		{`avg_over_time({a=~".+"} | logfmt | unwrap value [1s]) by (a)`, true},
 		{`quantile_over_time(0.99, {a=~".+"} | logfmt | unwrap value [1s])`, true},
+		{
+			`quantile_over_time(0.99, {a=~".+"} | logfmt | unwrap value [1s]) by (a) > 1
+			 and
+			 avg(rate({a=~".+"}[1s])) by (a)`,
+			false,
+		},
 		// topk prefers already-seen values in tiebreakers. Since the test data generates
 		// the same log lines for each series & the resulting promql.Vectors aren't deterministically
 		// sorted by labels, we don't expect this to pass.

--- a/pkg/logql/downstream_test.go
+++ b/pkg/logql/downstream_test.go
@@ -57,9 +57,9 @@ func TestMappingEquivalence(t *testing.T) {
 		{`quantile_over_time(0.99, {a=~".+"} | logfmt | unwrap value [1s])`, true},
 		{
 			`
-			  (quantile_over_time(0.99,{a=~".+"} | logfmt | unwrap value[1s]) by (a) > 1)
+			  (quantile_over_time(0.99, {a=~".+"} | logfmt | unwrap value [1s]) by (a) > 1)
 			and
-			  avg by (a)(rate({a=~".+"}[1s]))
+			  avg by (a) (rate({a=~".+"}[1s]))
 			`,
 			false,
 		},

--- a/pkg/logql/shardmapper.go
+++ b/pkg/logql/shardmapper.go
@@ -97,6 +97,7 @@ func (m ShardMapper) Map(expr syntax.Expr, r *downstreamRecorder) (syntax.Expr, 
 	case *syntax.RangeAggregationExpr:
 		return m.mapRangeAggregationExpr(e, r)
 	case *syntax.BinOpExpr:
+		// TODO: extract into method
 		var err error
 		var lhsMapped, rhsMapped syntax.Expr
 		var lhsBytesPerShard, rhsBytesPerShard uint64
@@ -111,7 +112,7 @@ func (m ShardMapper) Map(expr syntax.Expr, r *downstreamRecorder) (syntax.Expr, 
 				return nil, 0, badASTMapping(lhsMapped)
 			}
 		} else {
-			lhsMapped = &DownstreamSampleExpr{
+			lhsMapped = DownstreamSampleExpr{
 				shard:      nil,
 				SampleExpr: e.SampleExpr,
 			}
@@ -127,7 +128,7 @@ func (m ShardMapper) Map(expr syntax.Expr, r *downstreamRecorder) (syntax.Expr, 
 				return nil, 0, badASTMapping(rhsMapped)
 			}
 		} else {
-			rhsMapped = &DownstreamSampleExpr{
+			rhsMapped = DownstreamSampleExpr{
 				shard:      nil,
 				SampleExpr: e.RHS,
 			}

--- a/pkg/logql/shardmapper.go
+++ b/pkg/logql/shardmapper.go
@@ -97,9 +97,16 @@ func (m ShardMapper) Map(expr syntax.Expr, r *downstreamRecorder) (syntax.Expr, 
 	case *syntax.RangeAggregationExpr:
 		return m.mapRangeAggregationExpr(e, r)
 	case *syntax.BinOpExpr:
-		lhsMapped, lhsBytesPerShard, err := m.Map(e.SampleExpr, r)
-		if err != nil {
-			return nil, 0, err
+		if e.SampleExpr.Shardable() {
+			lhsMapped, lhsBytesPerShard, err := m.Map(e.SampleExpr, r)
+			if err != nil {
+				return nil, 0, err
+			}
+		} else {
+			lhsMapped := DownstreamSampleExpr{
+				shard: nil,
+				SampleExpr: e.SampleExpr,
+			}
 		}
 		rhsMapped, rhsBytesPerShard, err := m.Map(e.RHS, r)
 		if err != nil {

--- a/pkg/logql/shardmapper_test.go
+++ b/pkg/logql/shardmapper_test.go
@@ -1361,26 +1361,88 @@ func TestMapping(t *testing.T) {
 		},
 		{
 			in: `
-			  (quantile_over_time(0.99,{a=~".+"} | logfmt | unwrap value[1s]) by (a) > 1)
+			  quantile_over_time(0.99, {a="foo"} | unwrap bytes [1s]) by (b)
 			and
-			  avg by (a)(rate({a=~".+"}[1s]))
+			  sum by (b) (rate({a="bar"}[1s]))
 			`,
 			expr: &syntax.BinOpExpr{
-				SampleExpr: &syntax.RangeAggregationExpr{
-					Operation: syntax.OpRangeTypeQuantile,
-					Params:    float64p(0.8),
-					Left: &syntax.LogRange{
-						Left: &syntax.MatchersExpr{
-							Mts: []*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")},
+				SampleExpr: DownstreamSampleExpr{
+					SampleExpr: &syntax.RangeAggregationExpr{
+						Operation: syntax.OpRangeTypeQuantile,
+						Params:    float64p(0.99),
+						Left: &syntax.LogRange{
+							Left: &syntax.MatchersExpr{
+								Mts: []*labels.Matcher{mustNewMatcher(labels.MatchEqual, "a", "foo")},
+							},
+							Unwrap: &syntax.UnwrapExpr{
+								Identifier: "bytes",
+							},
+							Interval: 1 * time.Second,
 						},
-						Unwrap: &syntax.UnwrapExpr{
-							Identifier: "bytes",
+						Grouping: &syntax.Grouping{
+							Groups: []string{"b"},
 						},
-						Interval: 5 * time.Minute,
+					},
+				},
+				RHS: &syntax.VectorAggregationExpr{
+					Left: &ConcatSampleExpr{
+						DownstreamSampleExpr: DownstreamSampleExpr{
+							shard: &astmapper.ShardAnnotation{
+								Shard: 0,
+								Of:    2,
+							},
+							SampleExpr: &syntax.VectorAggregationExpr{
+								Left: &syntax.RangeAggregationExpr{
+									Left: &syntax.LogRange{
+										Left: &syntax.MatchersExpr{
+											Mts: []*labels.Matcher{mustNewMatcher(labels.MatchEqual, "a", "bar")},
+										},
+										Interval: 1 * time.Second,
+									},
+									Operation: syntax.OpRangeTypeRate,
+								},
+								Grouping: &syntax.Grouping{
+									Groups: []string{"b"},
+								},
+								Params:    0,
+								Operation: syntax.OpTypeSum,
+							},
+						},
+						next: &ConcatSampleExpr{
+							DownstreamSampleExpr: DownstreamSampleExpr{
+								shard: &astmapper.ShardAnnotation{
+									Shard: 1,
+									Of:    2,
+								},
+								SampleExpr: &syntax.VectorAggregationExpr{
+									Left: &syntax.RangeAggregationExpr{
+										Left: &syntax.LogRange{
+											Left: &syntax.MatchersExpr{
+												Mts: []*labels.Matcher{mustNewMatcher(labels.MatchEqual, "a", "bar")},
+											},
+											Interval: 1 * time.Second,
+										},
+										Operation: syntax.OpRangeTypeRate,
+									},
+									Grouping: &syntax.Grouping{
+										Groups: []string{"b"},
+									},
+									Params:    0,
+									Operation: syntax.OpTypeSum,
+								},
+							},
+							next: nil,
+						},
 					},
 					Grouping: &syntax.Grouping{
-						Groups: []string{"cluster"},
+						Groups: []string{"b"},
 					},
+					Operation: syntax.OpTypeSum,
+				},
+				Op: syntax.OpTypeAnd,
+				Opts: &syntax.BinOpOptions{
+					ReturnBool:     false,
+					VectorMatching: &syntax.VectorMatching{},
 				},
 			},
 		},
@@ -1392,8 +1454,8 @@ func TestMapping(t *testing.T) {
 			mapped, _, err := m.Map(ast, nilShardMetrics.downstreamRecorder())
 
 			require.Equal(t, tc.err, err)
-			require.Equal(t, tc.expr.String(), mapped.String())
-			require.Equal(t, tc.expr, mapped)
+			require.Equal(t, mapped.String(), tc.expr.String())
+			require.Equal(t, mapped, tc.expr)
 		})
 	}
 }

--- a/pkg/logql/shardmapper_test.go
+++ b/pkg/logql/shardmapper_test.go
@@ -1359,6 +1359,31 @@ func TestMapping(t *testing.T) {
 				},
 			},
 		},
+		{
+			in: `
+			  (quantile_over_time(0.99,{a=~".+"} | logfmt | unwrap value[1s]) by (a) > 1)
+			and
+			  avg by (a)(rate({a=~".+"}[1s]))
+			`,
+			expr: &syntax.BinOpExpr{
+				SampleExpr: &syntax.RangeAggregationExpr{
+					Operation: syntax.OpRangeTypeQuantile,
+					Params:    float64p(0.8),
+					Left: &syntax.LogRange{
+						Left: &syntax.MatchersExpr{
+							Mts: []*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")},
+						},
+						Unwrap: &syntax.UnwrapExpr{
+							Identifier: "bytes",
+						},
+						Interval: 5 * time.Minute,
+					},
+					Grouping: &syntax.Grouping{
+						Groups: []string{"cluster"},
+					},
+				},
+			},
+		},
 	} {
 		t.Run(tc.in, func(t *testing.T) {
 			ast, err := syntax.ParseExpr(tc.in)

--- a/tools/dev/loki-boltdb-storage-s3/config/loki.yaml
+++ b/tools/dev/loki-boltdb-storage-s3/config/loki.yaml
@@ -67,7 +67,6 @@ ingester_client:
     remote_timeout: 1s
 limits_config:
     cardinality_limit: 100000
-    enforce_metric_name: false
     ingestion_burst_size_mb: 5
     ingestion_rate_mb: 2
     ingestion_rate_strategy: global


### PR DESCRIPTION
**What this PR does / why we need it**:
Sharding of a binary operation with one unshardable side has been broken for quite some time.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
