### PR TITLE
Add e2e tests for bloom filtering

### DIFF
--- a/integration/client/client.go
+++ b/integration/client/client.go
@@ -480,9 +480,11 @@ type Header struct {
 }
 
 // RunRangeQuery runs a 7d query and returns an error if anything went wrong
+// This function is kept to keep backwards copatibility of existing tests.
+// Better use (*Client).RunRangeQueryWithStartEnd()
 func (c *Client) RunRangeQuery(ctx context.Context, query string, extraHeaders ...Header) (*Response, error) {
-	start := c.Now.Add(-7 * 24 * time.Hour)
 	end := c.Now.Add(-1 * time.Second)
+	start := c.Now.Add(-7 * 24 * time.Hour)
 	return c.RunRangeQueryWithStartEnd(ctx, query, start, end, extraHeaders...)
 }
 

--- a/integration/client/client.go
+++ b/integration/client/client.go
@@ -483,7 +483,7 @@ type Header struct {
 // This function is kept to keep backwards copatibility of existing tests.
 // Better use (*Client).RunRangeQueryWithStartEnd()
 func (c *Client) RunRangeQuery(ctx context.Context, query string, extraHeaders ...Header) (*Response, error) {
-	end := c.Now.Add(-1 * time.Second)
+	end := c.Now.Add(time.Second)
 	start := c.Now.Add(-7 * 24 * time.Hour)
 	return c.RunRangeQueryWithStartEnd(ctx, query, start, end, extraHeaders...)
 }
@@ -499,22 +499,6 @@ func (c *Client) RunRangeQueryWithStartEnd(ctx context.Context, query string, st
 	}
 
 	return c.parseResponse(buf, statusCode)
-}
-
-func (c *Client) rangeQueryURL(query string, start, end time.Time) string {
-	v := url.Values{}
-	v.Set("query", query)
-	v.Set("start", formatTS(start))
-	v.Set("end", formatTS(end))
-
-	u, err := url.Parse(c.baseURL)
-	if err != nil {
-		panic(err)
-	}
-	u.Path = "/loki/api/v1/query_range"
-	u.RawQuery = v.Encode()
-
-	return u.String()
 }
 
 // RunQuery runs a query and returns an error if anything went wrong
@@ -578,6 +562,22 @@ func (c *Client) parseResponse(buf []byte, statusCode int) (*Response, error) {
 	}
 
 	return &lokiResp, nil
+}
+
+func (c *Client) rangeQueryURL(query string, start, end time.Time) string {
+	v := url.Values{}
+	v.Set("query", query)
+	v.Set("start", formatTS(start))
+	v.Set("end", formatTS(end))
+
+	u, err := url.Parse(c.baseURL)
+	if err != nil {
+		panic(err)
+	}
+	u.Path = "/loki/api/v1/query_range"
+	u.RawQuery = v.Encode()
+
+	return u.String()
 }
 
 func (c *Client) LabelNames(ctx context.Context) ([]string, error) {

--- a/integration/cluster/cluster.go
+++ b/integration/cluster/cluster.go
@@ -100,7 +100,6 @@ ingester:
 
 querier:
   multi_tenant_queries_enabled: true
-  query_ingesters_within: 1s
 
 query_scheduler:
   max_outstanding_requests_per_tenant: 2048

--- a/integration/cluster/cluster.go
+++ b/integration/cluster/cluster.go
@@ -62,6 +62,7 @@ limits_config:
   ingestion_burst_size_mb: 50
   reject_old_samples: false
   allow_structured_metadata: true
+  split_queries_by_interval: 24h
 
 storage_config:
   named_stores:
@@ -101,7 +102,7 @@ ingester:
 
 querier:
   multi_tenant_queries_enabled: true
-  query_ingesters_within: 5s
+  query_ingesters_within: 1s
 
 query_scheduler:
   max_outstanding_requests_per_tenant: 2048

--- a/integration/cluster/cluster.go
+++ b/integration/cluster/cluster.go
@@ -173,7 +173,7 @@ func New(logLevel level.Value, opts ...func(*Cluster)) *Cluster {
 
 	overridesFile := filepath.Join(sharedPath, "loki-overrides.yaml")
 
-	err = os.WriteFile(filepath.Join(sharedPath, "loki-overrides.yaml"), []byte(`overrides:`), 0777)
+	err = os.WriteFile(overridesFile, []byte(`overrides:`), 0777)
 	if err != nil {
 		panic(fmt.Errorf("error creating overrides file: %w", err))
 	}
@@ -420,6 +420,8 @@ func (c *Component) run() error {
 		c.configFile,
 		"-limits.per-user-override-config",
 		c.overridesFile,
+		"-limits.per-user-override-period",
+		"1s",
 	), flagset); err != nil {
 		return err
 	}

--- a/integration/cluster/cluster.go
+++ b/integration/cluster/cluster.go
@@ -167,7 +167,7 @@ func New(logLevel level.Value, opts ...func(*Cluster)) *Cluster {
 	}
 
 	resetMetricRegistry()
-	sharedPath, err := os.MkdirTemp("", "loki-shared-data")
+	sharedPath, err := os.MkdirTemp("", "loki-shared-data-")
 	if err != nil {
 		panic(err.Error())
 	}
@@ -331,12 +331,12 @@ func port(addr string) string {
 func (c *Component) writeConfig() error {
 	var err error
 
-	configFile, err := os.CreateTemp("", "loki-config")
+	configFile, err := os.CreateTemp("", fmt.Sprintf("loki-%s-config-*.yaml", c.name))
 	if err != nil {
 		return fmt.Errorf("error creating config file: %w", err)
 	}
 
-	c.dataPath, err = os.MkdirTemp("", "loki-data")
+	c.dataPath, err = os.MkdirTemp("", fmt.Sprintf("loki-%s-data-", c.name))
 	if err != nil {
 		return fmt.Errorf("error creating data path: %w", err)
 	}

--- a/integration/cluster/cluster.go
+++ b/integration/cluster/cluster.go
@@ -62,7 +62,7 @@ limits_config:
   ingestion_burst_size_mb: 50
   reject_old_samples: false
   allow_structured_metadata: true
-  split_queries_by_interval: 24h
+  split_queries_by_interval: 1h
 
 storage_config:
   named_stores:

--- a/integration/cluster/cluster.go
+++ b/integration/cluster/cluster.go
@@ -43,7 +43,6 @@ server:
   grpc_server_max_recv_msg_size: 110485813
   grpc_server_max_send_msg_size: 110485813
 
-
 common:
   path_prefix: {{.dataPath}}
   storage:
@@ -70,14 +69,26 @@ storage_config:
       store-1:
         directory: {{.sharedDataPath}}/fs-store-1
   boltdb_shipper:
-    active_index_directory: {{.dataPath}}/index
+    active_index_directory: {{.dataPath}}/boltdb-index
     cache_location: {{.dataPath}}/boltdb-cache
+    build_per_tenant_index: true
   tsdb_shipper:
     active_index_directory: {{.dataPath}}/tsdb-index
     cache_location: {{.dataPath}}/tsdb-cache
+  bloom_shipper:
+    working_directory: {{.dataPath}}/bloom-shipper
+    blocks_downloading_queue:
+      workers_count: 1
+
+bloom_gateway:
+  enabled: false
+
+bloom_compactor:
+  enabled: false
+  working_directory: {{.dataPath}}/bloom-compactor
 
 compactor:
-  working_directory: {{.dataPath}}/retention
+  working_directory: {{.dataPath}}/compactor
   retention_enabled: true
   delete_request_store: store-1
 
@@ -90,6 +101,7 @@ ingester:
 
 querier:
   multi_tenant_queries_enabled: true
+  query_ingesters_within: 5s
 
 query_scheduler:
   max_outstanding_requests_per_tenant: 2048

--- a/integration/cluster/cluster.go
+++ b/integration/cluster/cluster.go
@@ -62,7 +62,6 @@ limits_config:
   ingestion_burst_size_mb: 50
   reject_old_samples: false
   allow_structured_metadata: true
-  split_queries_by_interval: 1h
 
 storage_config:
   named_stores:
@@ -72,7 +71,6 @@ storage_config:
   boltdb_shipper:
     active_index_directory: {{.dataPath}}/boltdb-index
     cache_location: {{.dataPath}}/boltdb-cache
-    build_per_tenant_index: true
   tsdb_shipper:
     active_index_directory: {{.dataPath}}/tsdb-index
     cache_location: {{.dataPath}}/tsdb-cache

--- a/pkg/bloomcompactor/bloomcompactor.go
+++ b/pkg/bloomcompactor/bloomcompactor.go
@@ -284,7 +284,7 @@ func (c *Compactor) compactTable(ctx context.Context, logger log.Logger, tableNa
 		return fmt.Errorf("index store client not found for period starting at %s", schemaCfg.From.String())
 	}
 
-	_, tenants, err := sc.index.ListFiles(ctx, tableName, false)
+	_, tenants, err := sc.index.ListFiles(ctx, tableName, true)
 	if err != nil {
 		return fmt.Errorf("failed to list files for table %s: %w", tableName, err)
 	}

--- a/pkg/bloomcompactor/bloomcompactor.go
+++ b/pkg/bloomcompactor/bloomcompactor.go
@@ -51,6 +51,7 @@ import (
 	"github.com/grafana/loki/pkg/storage"
 	v1 "github.com/grafana/loki/pkg/storage/bloom/v1"
 	chunk_client "github.com/grafana/loki/pkg/storage/chunk/client"
+	"github.com/grafana/loki/pkg/storage/chunk/client/local"
 	"github.com/grafana/loki/pkg/storage/config"
 	"github.com/grafana/loki/pkg/storage/stores/shipper/bloomshipper"
 	"github.com/grafana/loki/pkg/storage/stores/shipper/indexshipper"
@@ -166,10 +167,18 @@ func New(
 			return nil, errors.Wrap(err, "create index shipper")
 		}
 
+		// The ObjectClient does not expose the key encoder it uses,
+		// so check the concrete type and set the FSEncoder if needed.
+		var keyEncoder chunk_client.KeyEncoder
+		switch objectClient.(type) {
+		case *local.FSObjectClient:
+			keyEncoder = chunk_client.FSEncoder
+		}
+
 		c.storeClients[periodicConfig.From] = storeClient{
 			object:       objectClient,
 			index:        index_storage.NewIndexStorageClient(objectClient, periodicConfig.IndexTables.PathPrefix),
-			chunk:        chunk_client.NewClient(objectClient, nil, schemaConfig),
+			chunk:        chunk_client.NewClient(objectClient, keyEncoder, schemaConfig),
 			indexShipper: indexShipper,
 		}
 	}

--- a/pkg/bloomgateway/bloomgateway.go
+++ b/pkg/bloomgateway/bloomgateway.go
@@ -180,9 +180,8 @@ func New(cfg Config, schemaCfg config.SchemaConfig, storageCfg storage.Config, o
 		sharding:     shardingStrategy,
 		pendingTasks: makePendingTasks(pendingTasksInitialCap),
 		workerConfig: workerConfig{
-			maxWaitTime:               200 * time.Millisecond,
-			maxItems:                  100,
-			processBlocksSequentially: false,
+			maxWaitTime: 200 * time.Millisecond,
+			maxItems:    100,
 		},
 		workerMetrics: newWorkerMetrics(reg, constants.Loki, metricsSubsystem),
 		queueMetrics:  queue.NewMetrics(reg, constants.Loki, metricsSubsystem),

--- a/pkg/bloomgateway/bloomgateway.go
+++ b/pkg/bloomgateway/bloomgateway.go
@@ -323,7 +323,7 @@ func (g *Gateway) FilterChunkRefs(ctx context.Context, req *logproto.FilterChunk
 		case res := <-resCh:
 			responses = append(responses, res)
 			// log line is helpful for debugging tests
-			// level.Debug(g.logger).Log("msg", "got partial result", "task", task.ID, "tenant", tenantID, "fp", uint64(res.Fp), "chunks", res.Removals.Len(), "progress", fmt.Sprintf("%d/%d", len(responses), requestCount))
+			level.Debug(g.logger).Log("msg", "got partial result", "task", task.ID, "tenant", tenantID, "fp_int", uint64(res.Fp), "fp_hex", res.Fp, "chunks_to_remove", res.Removals.Len(), "progress", fmt.Sprintf("%d/%d", len(responses), requestCount))
 			// wait for all parts of the full response
 			if len(responses) == requestCount {
 				for _, o := range responses {

--- a/pkg/storage/stores/shipper/bloomshipper/client.go
+++ b/pkg/storage/stores/shipper/bloomshipper/client.go
@@ -143,7 +143,7 @@ func (b *BloomClient) GetMetas(ctx context.Context, params MetaSearchParams) ([]
 					return nil, err
 				}
 				if metaRef.MaxFingerprint < uint64(params.MinFingerprint) || uint64(params.MaxFingerprint) < metaRef.MinFingerprint ||
-					metaRef.StartTimestamp.Before(params.StartTimestamp) || metaRef.EndTimestamp.After(params.EndTimestamp) {
+					metaRef.EndTimestamp.Before(params.StartTimestamp) || metaRef.StartTimestamp.After(params.EndTimestamp) {
 					continue
 				}
 				meta, err := b.downloadMeta(ctx, metaRef, periodClient)

--- a/pkg/storage/stores/shipper/bloomshipper/shipper.go
+++ b/pkg/storage/stores/shipper/bloomshipper/shipper.go
@@ -124,6 +124,7 @@ func (s *Shipper) getActiveBlockRefs(ctx context.Context, tenantID string, from,
 	if err != nil {
 		return []BlockRef{}, fmt.Errorf("error fetching meta.json files: %w", err)
 	}
+	level.Debug(s.logger).Log("msg", "dowloaded metas", "count", len(metas))
 	activeBlocks := s.findBlocks(metas, from, through, fingerprints)
 	slices.SortStableFunc(activeBlocks, func(a, b BlockRef) int {
 		if a.MinFingerprint < b.MinFingerprint {
@@ -192,7 +193,7 @@ func isOutsideRange(b *BlockRef, startTimestamp, endTimestamp model.Time, finger
 	// e.g.
 	// fingerprints = [1, 2,          6, 7, 8]
 	// block =              [3, 4, 5]
-	idx := getPosition[[]uint64](fingerprints, b.MinFingerprint)
+	idx := getPosition(fingerprints, b.MinFingerprint)
 	// in case b.MinFingerprint is outside of the fingerprints range, return true
 	// this is already covered in the range check above, but I keep it as a second gate
 	if idx > len(fingerprints)-1 {

--- a/pkg/storage/stores/shipper/bloomshipper/shipper.go
+++ b/pkg/storage/stores/shipper/bloomshipper/shipper.go
@@ -79,23 +79,6 @@ func runCallback(callback ForEachBlockCallback, block blockWithQuerier) error {
 	return nil
 }
 
-// makeFpRanges groups continuous fingerprints into ranges of [2]uint64{minFp, maxFp}
-func makeFpRanges(fingerprints []uint64) [][2]uint64 {
-	panic("makeFpRange() not implemented")
-}
-
-func (s *Shipper) ForEachBlock(ctx context.Context, tenantID string, from, through model.Time, fingerprints []uint64, callback ForEachBlockCallback) error {
-	level.Debug(s.logger).Log("msg", "ForEachBlock", "tenant", tenantID, "from", from, "through", through, "fingerprints", len(fingerprints))
-	fpRanges := makeFpRanges(fingerprints)
-
-	blockRefs, err := s.getActiveBlockRefs(ctx, tenantID, from, through, fpRanges)
-	if err != nil {
-		return fmt.Errorf("error fetching active block references : %w", err)
-	}
-
-	return s.Fetch(ctx, tenantID, blockRefs, callback)
-}
-
 func (s *Shipper) Stop() {
 	s.client.Stop()
 	s.blockDownloader.stop()

--- a/pkg/storage/stores/shipper/bloomshipper/shipper_test.go
+++ b/pkg/storage/stores/shipper/bloomshipper/shipper_test.go
@@ -41,7 +41,7 @@ func Test_Shipper_findBlocks(t *testing.T) {
 		}
 
 		shipper := &Shipper{}
-		blocks := shipper.findBlocks(metas, model.Now().Add(-2*time.Hour), model.Now().Add(-1*time.Hour), [][2]uint64{{100, 200}})
+		blocks := shipper.findBlocks(metas, model.Now().Add(-2*time.Hour), model.Now().Add(-1*time.Hour), []fpRange{{100, 200}})
 
 		expectedBlockRefs := []BlockRef{
 			createMatchingBlockRef("block2"),
@@ -95,7 +95,7 @@ func Test_Shipper_findBlocks(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			shipper := &Shipper{}
 			ref := createBlockRef("fake-block", data.minFingerprint, data.maxFingerprint, data.startTimestamp, data.endTimestamp)
-			blocks := shipper.findBlocks([]Meta{{Blocks: []BlockRef{ref}}}, 300, 400, [][2]uint64{{100, 200}})
+			blocks := shipper.findBlocks([]Meta{{Blocks: []BlockRef{ref}}}, 300, 400, []fpRange{{100, 200}})
 			if data.filtered {
 				require.Empty(t, blocks)
 				return
@@ -112,55 +112,55 @@ func TestIsOutsideRange(t *testing.T) {
 
 	t.Run("is outside if startTs > through", func(t *testing.T) {
 		b := createBlockRef("block", 0, math.MaxUint64, startTs, endTs)
-		isOutside := isOutsideRange(&b, 0, 900, [][2]uint64{})
+		isOutside := isOutsideRange(&b, 0, 900, []fpRange{})
 		require.True(t, isOutside)
 	})
 
 	t.Run("is outside if endTs < from", func(t *testing.T) {
 		b := createBlockRef("block", 0, math.MaxUint64, startTs, endTs)
-		isOutside := isOutsideRange(&b, 2100, 3000, [][2]uint64{})
+		isOutside := isOutsideRange(&b, 2100, 3000, []fpRange{})
 		require.True(t, isOutside)
 	})
 
 	t.Run("is outside if endFp < first fingerprint", func(t *testing.T) {
 		b := createBlockRef("block", 0, 90, startTs, endTs)
-		isOutside := isOutsideRange(&b, startTs, endTs, [][2]uint64{{100, 199}})
+		isOutside := isOutsideRange(&b, startTs, endTs, []fpRange{{100, 199}})
 		require.True(t, isOutside)
 	})
 
 	t.Run("is outside if startFp > last fingerprint", func(t *testing.T) {
 		b := createBlockRef("block", 200, math.MaxUint64, startTs, endTs)
-		isOutside := isOutsideRange(&b, startTs, endTs, [][2]uint64{{0, 49}, {100, 149}})
+		isOutside := isOutsideRange(&b, startTs, endTs, []fpRange{{0, 49}, {100, 149}})
 		require.True(t, isOutside)
 	})
 
 	t.Run("is outside if within gaps in fingerprints", func(t *testing.T) {
 		b := createBlockRef("block", 100, 199, startTs, endTs)
-		isOutside := isOutsideRange(&b, startTs, endTs, [][2]uint64{{0, 99}, {200, 299}})
+		isOutside := isOutsideRange(&b, startTs, endTs, []fpRange{{0, 99}, {200, 299}})
 		require.True(t, isOutside)
 	})
 
 	t.Run("is not outside if within fingerprints 1", func(t *testing.T) {
 		b := createBlockRef("block", 10, 90, startTs, endTs)
-		isOutside := isOutsideRange(&b, startTs, endTs, [][2]uint64{{0, 99}, {200, 299}})
+		isOutside := isOutsideRange(&b, startTs, endTs, []fpRange{{0, 99}, {200, 299}})
 		require.False(t, isOutside)
 	})
 
 	t.Run("is not outside if within fingerprints 2", func(t *testing.T) {
 		b := createBlockRef("block", 210, 290, startTs, endTs)
-		isOutside := isOutsideRange(&b, startTs, endTs, [][2]uint64{{0, 99}, {200, 299}})
+		isOutside := isOutsideRange(&b, startTs, endTs, []fpRange{{0, 99}, {200, 299}})
 		require.False(t, isOutside)
 	})
 
 	t.Run("is not outside if spans across multiple fingerprint ranges", func(t *testing.T) {
 		b := createBlockRef("block", 50, 250, startTs, endTs)
-		isOutside := isOutsideRange(&b, startTs, endTs, [][2]uint64{{0, 99}, {200, 299}})
+		isOutside := isOutsideRange(&b, startTs, endTs, []fpRange{{0, 99}, {200, 299}})
 		require.False(t, isOutside)
 	})
 
 	t.Run("is not outside if fingerprint range and time range are larger than block", func(t *testing.T) {
 		b := createBlockRef("block", math.MaxUint64/3, math.MaxUint64/3*2, startTs, endTs)
-		isOutside := isOutsideRange(&b, 0, 3000, [][2]uint64{{0, math.MaxUint64}})
+		isOutside := isOutsideRange(&b, 0, 3000, []fpRange{{0, math.MaxUint64}})
 		require.False(t, isOutside)
 	})
 }

--- a/pkg/storage/stores/shipper/bloomshipper/shipper_test.go
+++ b/pkg/storage/stores/shipper/bloomshipper/shipper_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 	"testing"
+	"time"
 
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
@@ -40,7 +41,7 @@ func Test_Shipper_findBlocks(t *testing.T) {
 		}
 
 		shipper := &Shipper{}
-		blocks := shipper.findBlocks(metas, 300, 400, []uint64{100, 200})
+		blocks := shipper.findBlocks(metas, model.Now().Add(-2*time.Hour), model.Now().Add(-1*time.Hour), [][2]uint64{{100, 200}})
 
 		expectedBlockRefs := []BlockRef{
 			createMatchingBlockRef("block2"),
@@ -53,8 +54,8 @@ func Test_Shipper_findBlocks(t *testing.T) {
 	tests := map[string]struct {
 		minFingerprint uint64
 		maxFingerprint uint64
-		startTimestamp int64
-		endTimestamp   int64
+		startTimestamp model.Time
+		endTimestamp   model.Time
 		filtered       bool
 	}{
 		"expected block not to be filtered out if minFingerprint and startTimestamp are within range": {
@@ -94,7 +95,7 @@ func Test_Shipper_findBlocks(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			shipper := &Shipper{}
 			ref := createBlockRef("fake-block", data.minFingerprint, data.maxFingerprint, data.startTimestamp, data.endTimestamp)
-			blocks := shipper.findBlocks([]Meta{{Blocks: []BlockRef{ref}}}, 300, 400, []uint64{100, 110, 120, 130, 140, 150, 160, 170, 180, 190, 200})
+			blocks := shipper.findBlocks([]Meta{{Blocks: []BlockRef{ref}}}, 300, 400, [][2]uint64{{100, 200}})
 			if data.filtered {
 				require.Empty(t, blocks)
 				return
@@ -105,94 +106,83 @@ func Test_Shipper_findBlocks(t *testing.T) {
 	}
 }
 
-func TestGetPosition(t *testing.T) {
-	for i, tc := range []struct {
-		s   []int
-		v   int
-		exp int
-	}{
-		{s: []int{}, v: 1, exp: 0},
-		{s: []int{1, 2, 3}, v: 0, exp: 0},
-		{s: []int{1, 2, 3}, v: 2, exp: 1},
-		{s: []int{1, 2, 3}, v: 4, exp: 3},
-		{s: []int{1, 2, 4, 5}, v: 3, exp: 2},
-	} {
-		tc := tc
-		name := fmt.Sprintf("case-%d", i)
-		t.Run(name, func(t *testing.T) {
-			got := getPosition[[]int](tc.s, tc.v)
-			require.Equal(t, tc.exp, got)
-		})
-	}
-}
-
 func TestIsOutsideRange(t *testing.T) {
+	startTs := model.Time(1000)
+	endTs := model.Time(2000)
+
 	t.Run("is outside if startTs > through", func(t *testing.T) {
-		b := createBlockRef("block", 0, math.MaxUint64, 100, 200)
-		isOutside := isOutsideRange(&b, 0, 90, []uint64{})
+		b := createBlockRef("block", 0, math.MaxUint64, startTs, endTs)
+		isOutside := isOutsideRange(&b, 0, 900, [][2]uint64{})
 		require.True(t, isOutside)
 	})
 
 	t.Run("is outside if endTs < from", func(t *testing.T) {
-		b := createBlockRef("block", 0, math.MaxUint64, 100, 200)
-		isOutside := isOutsideRange(&b, 210, 300, []uint64{})
+		b := createBlockRef("block", 0, math.MaxUint64, startTs, endTs)
+		isOutside := isOutsideRange(&b, 2100, 3000, [][2]uint64{})
 		require.True(t, isOutside)
 	})
 
 	t.Run("is outside if endFp < first fingerprint", func(t *testing.T) {
-		b := createBlockRef("block", 0, 90, 100, 200)
-		isOutside := isOutsideRange(&b, 100, 200, []uint64{100, 200})
+		b := createBlockRef("block", 0, 90, startTs, endTs)
+		isOutside := isOutsideRange(&b, startTs, endTs, [][2]uint64{{100, 199}})
 		require.True(t, isOutside)
 	})
 
 	t.Run("is outside if startFp > last fingerprint", func(t *testing.T) {
-		b := createBlockRef("block", 210, math.MaxUint64, 100, 200)
-		isOutside := isOutsideRange(&b, 100, 200, []uint64{100, 200})
+		b := createBlockRef("block", 200, math.MaxUint64, startTs, endTs)
+		isOutside := isOutsideRange(&b, startTs, endTs, [][2]uint64{{0, 49}, {100, 149}})
 		require.True(t, isOutside)
 	})
 
 	t.Run("is outside if within gaps in fingerprints", func(t *testing.T) {
-		b := createBlockRef("block", 100, 200, 100, 200)
-		isOutside := isOutsideRange(&b, 100, 200, []uint64{0, 99, 201, 300})
+		b := createBlockRef("block", 100, 199, startTs, endTs)
+		isOutside := isOutsideRange(&b, startTs, endTs, [][2]uint64{{0, 99}, {200, 299}})
 		require.True(t, isOutside)
 	})
 
 	t.Run("is not outside if within fingerprints 1", func(t *testing.T) {
-		b := createBlockRef("block", 100, 200, 100, 200)
-		isOutside := isOutsideRange(&b, 100, 200, []uint64{0, 100, 200, 300})
+		b := createBlockRef("block", 10, 90, startTs, endTs)
+		isOutside := isOutsideRange(&b, startTs, endTs, [][2]uint64{{0, 99}, {200, 299}})
 		require.False(t, isOutside)
 	})
 
 	t.Run("is not outside if within fingerprints 2", func(t *testing.T) {
-		b := createBlockRef("block", 100, 150, 100, 200)
-		isOutside := isOutsideRange(&b, 100, 200, []uint64{0, 100, 200, 300})
+		b := createBlockRef("block", 210, 290, startTs, endTs)
+		isOutside := isOutsideRange(&b, startTs, endTs, [][2]uint64{{0, 99}, {200, 299}})
 		require.False(t, isOutside)
 	})
 
-	t.Run("is not outside if within fingerprints 3", func(t *testing.T) {
-		b := createBlockRef("block", 150, 200, 100, 200)
-		isOutside := isOutsideRange(&b, 100, 200, []uint64{0, 100, 200, 300})
+	t.Run("is not outside if spans across multiple fingerprint ranges", func(t *testing.T) {
+		b := createBlockRef("block", 50, 250, startTs, endTs)
+		isOutside := isOutsideRange(&b, startTs, endTs, [][2]uint64{{0, 99}, {200, 299}})
+		require.False(t, isOutside)
+	})
+
+	t.Run("is not outside if fingerprint range and time range are larger than block", func(t *testing.T) {
+		b := createBlockRef("block", math.MaxUint64/3, math.MaxUint64/3*2, startTs, endTs)
+		isOutside := isOutsideRange(&b, 0, 3000, [][2]uint64{{0, math.MaxUint64}})
 		require.False(t, isOutside)
 	})
 }
 
 func createMatchingBlockRef(blockPath string) BlockRef {
-	return createBlockRef(blockPath, 0, uint64(math.MaxUint64), 0, math.MaxInt)
+	return createBlockRef(blockPath, 0, math.MaxUint64, model.Time(0), model.Now())
 }
 
 func createBlockRef(
 	blockPath string,
 	minFingerprint, maxFingerprint uint64,
-	startTimestamp, endTimestamp int64,
+	startTimestamp, endTimestamp model.Time,
 ) BlockRef {
+	day := startTimestamp.Unix() / int64(24*time.Hour/time.Second)
 	return BlockRef{
 		Ref: Ref{
 			TenantID:       "fake",
-			TableName:      "16600",
+			TableName:      fmt.Sprintf("%d", day),
 			MinFingerprint: minFingerprint,
 			MaxFingerprint: maxFingerprint,
-			StartTimestamp: model.Time(startTimestamp),
-			EndTimestamp:   model.Time(endTimestamp),
+			StartTimestamp: startTimestamp,
+			EndTimestamp:   endTimestamp,
 			Checksum:       0,
 		},
 		// block path is unique, and it's used to distinguish the blocks so the rest of the fields might be skipped in this test

--- a/pkg/storage/stores/shipper/bloomshipper/store.go
+++ b/pkg/storage/stores/shipper/bloomshipper/store.go
@@ -2,7 +2,6 @@ package bloomshipper
 
 import (
 	"context"
-	"sort"
 	"time"
 
 	"github.com/prometheus/common/model"
@@ -14,7 +13,6 @@ type ForEachBlockCallback func(bq *v1.BlockQuerier, minFp, maxFp uint64) error
 
 type ReadShipper interface {
 	GetBlockRefs(ctx context.Context, tenant string, from, through model.Time) ([]BlockRef, error)
-	ForEachBlock(ctx context.Context, tenant string, from, through model.Time, fingerprints []uint64, callback ForEachBlockCallback) error
 	Fetch(ctx context.Context, tenant string, blocks []BlockRef, callback ForEachBlockCallback) error
 }
 
@@ -30,8 +28,6 @@ type BlockQuerierWithFingerprintRange struct {
 
 type Store interface {
 	GetBlockRefs(ctx context.Context, tenant string, from, through time.Time) ([]BlockRef, error)
-	GetBlockQueriers(ctx context.Context, tenant string, from, through time.Time, fingerprints []uint64) ([]BlockQuerierWithFingerprintRange, error)
-	GetBlockQueriersForBlockRefs(ctx context.Context, tenant string, blocks []BlockRef) ([]BlockQuerierWithFingerprintRange, error)
 	ForEach(ctx context.Context, tenant string, blocks []BlockRef, callback ForEachBlockCallback) error
 	Stop()
 }
@@ -58,40 +54,6 @@ func (bs *BloomStore) GetBlockRefs(ctx context.Context, tenant string, from, thr
 // ForEach implements Store
 func (bs *BloomStore) ForEach(ctx context.Context, tenant string, blocks []BlockRef, callback ForEachBlockCallback) error {
 	return bs.shipper.Fetch(ctx, tenant, blocks, callback)
-}
-
-// GetQueriersForBlocks implements Store
-func (bs *BloomStore) GetBlockQueriersForBlockRefs(ctx context.Context, tenant string, blocks []BlockRef) ([]BlockQuerierWithFingerprintRange, error) {
-	bqs := make([]BlockQuerierWithFingerprintRange, 0, 32)
-	err := bs.shipper.Fetch(ctx, tenant, blocks, func(bq *v1.BlockQuerier, minFp uint64, maxFp uint64) error {
-		bqs = append(bqs, BlockQuerierWithFingerprintRange{
-			BlockQuerier: bq,
-			MinFp:        model.Fingerprint(minFp),
-			MaxFp:        model.Fingerprint(maxFp),
-		})
-		return nil
-	})
-	sort.Slice(bqs, func(i, j int) bool {
-		return bqs[i].MinFp < bqs[j].MinFp
-	})
-	return bqs, err
-}
-
-// BlockQueriers implements Store
-func (bs *BloomStore) GetBlockQueriers(ctx context.Context, tenant string, from, through time.Time, fingerprints []uint64) ([]BlockQuerierWithFingerprintRange, error) {
-	bqs := make([]BlockQuerierWithFingerprintRange, 0, 32)
-	err := bs.shipper.ForEachBlock(ctx, tenant, toModelTime(from), toModelTime(through), fingerprints, func(bq *v1.BlockQuerier, minFp uint64, maxFp uint64) error {
-		bqs = append(bqs, BlockQuerierWithFingerprintRange{
-			BlockQuerier: bq,
-			MinFp:        model.Fingerprint(minFp),
-			MaxFp:        model.Fingerprint(maxFp),
-		})
-		return nil
-	})
-	sort.Slice(bqs, func(i, j int) bool {
-		return bqs[i].MinFp < bqs[j].MinFp
-	})
-	return bqs, err
 }
 
 func toModelTime(t time.Time) model.Time {


### PR DESCRIPTION
**What?**

This PR adds an end-to-end integration test for creating bloom filters and using them in the gateway to filter chunks.

**Why?**

This test helped to identify bugs in the bloom shipper code that would have taken a very long time to discover in other ways, such as deploying to a dev environment or running a long-running docker compose setup.

**Notes**

The following commits of this PR are actual changes to the compactor/gateway code to make e2e test work:

* https://github.com/grafana/loki/pull/11645/commits/2dcc761ba069a377ece1a3a48fa6c6c59039043c
* https://github.com/grafana/loki/pull/11645/commits/84052ddb34c012e12d3e98b86317a6b18bc3d76e
* https://github.com/grafana/loki/pull/11645/commits/3ba44f83c81bb305d3fb08d0141b6f080bde03ea

The bloom gateway code path for processing blocks was cleaned up, because it still contained the unused "sequention processing" path of blocks, which was initially kept to verify the callback based processing works alike:

* https://github.com/grafana/loki/pull/11645/commits/f55d79b84fa6d6118fd66720aa107ba15ef0b862