### PR TITLE
helm: added missing namespace to query-scheduler-discovery service

### DIFF
--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -13,6 +13,10 @@ Entries should include a reference to the pull request that introduced the chang
 
 [//]: # (<AUTOMATED_UPDATES_LOCATOR> : do not remove this line. This locator is used by the CI pipeline to automatically create a changelog entry for each new Loki release. Add other chart versions and respective changelog entries bellow this line.)
 
+## 5.41.6
+
+- [BUGFIX] Added missing namespace to query-scheduler-discovery service when deploying loki in a specific namespace.
+
 ## 5.41.5
 
 - [BUGFIX] Added "swift" type object storage to resolve Loki HELM Chart error.

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -3,7 +3,7 @@ name: loki
 description: Helm chart for Grafana Loki in simple, scalable mode
 type: application
 appVersion: 2.9.3
-version: 5.41.5
+version: 5.41.6
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -1,6 +1,6 @@
 # loki
 
-![Version: 5.41.5](https://img.shields.io/badge/Version-5.41.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.9.3](https://img.shields.io/badge/AppVersion-2.9.3-informational?style=flat-square)
+![Version: 5.41.6](https://img.shields.io/badge/Version-5.41.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.9.3](https://img.shields.io/badge/AppVersion-2.9.3-informational?style=flat-square)
 
 Helm chart for Grafana Loki in simple, scalable mode
 

--- a/production/helm/loki/templates/backend/query-scheduler-discovery.yaml
+++ b/production/helm/loki/templates/backend/query-scheduler-discovery.yaml
@@ -5,6 +5,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: query-scheduler-discovery
+  namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "loki.backendSelectorLabels" . | nindent 4 }}
     prometheus.io/service-monitor: "false"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the namespace attribute to the query-scheduler-service descriptor because it is needed when deploying loki in non-default namespace

**Which issue(s) this PR fixes**:
Fixes #10048 

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] `CHANGELOG.md` updated
  - [x] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)

I hope I did everything right with the changelog, chat and readme updates since this my first PR, please tell me if something needs fixing.