### PR TITLE
Skip optimization for DownstreamSampleExpr

### DIFF
--- a/pkg/logql/optimize.go
+++ b/pkg/logql/optimize.go
@@ -8,7 +8,7 @@ func optimizeSampleExpr(expr syntax.SampleExpr) (syntax.SampleExpr, error) {
 	// we skip sharding AST for now, it's not easy to clone them since they are not part of the language.
 	expr.Walk(func(e syntax.Expr) {
 		switch e.(type) {
-		case *ConcatSampleExpr, *DownstreamSampleExpr, *QuantileSketchEvalExpr, *QuantileSketchMergeExpr:
+		case *ConcatSampleExpr, DownstreamSampleExpr, *QuantileSketchEvalExpr, *QuantileSketchMergeExpr:
 			skip = true
 			return
 		}

--- a/pkg/logql/shardmapper.go
+++ b/pkg/logql/shardmapper.go
@@ -128,7 +128,7 @@ func (m ShardMapper) mapBinOpExpr(e *syntax.BinOpExpr, r *downstreamRecorder) (*
 	if err != nil {
 		return nil, 0, err
 	}
-	if isNoOp(e.SampleExpr, rhsMapped) && !isLiteralOrVector(rhsMapped) {
+	if isNoOp(e.RHS, rhsMapped) && !isLiteralOrVector(rhsMapped) {
 		// TODO: check if literal or vector
 		rhsMapped = DownstreamSampleExpr{
 			shard:      nil,

--- a/pkg/logql/shardmapper_test.go
+++ b/pkg/logql/shardmapper_test.go
@@ -1446,16 +1446,84 @@ func TestMapping(t *testing.T) {
 				},
 			},
 		},
+		{
+			in: `quantile_over_time(0.99, {a="foo"} | unwrap bytes [1s]) by (a, b) > 1`,
+			expr: &syntax.BinOpExpr{
+				SampleExpr: DownstreamSampleExpr{
+					SampleExpr: &syntax.RangeAggregationExpr{
+						Operation: syntax.OpRangeTypeQuantile,
+						Params:    float64p(0.99),
+						Left: &syntax.LogRange{
+							Left: &syntax.MatchersExpr{
+								Mts: []*labels.Matcher{mustNewMatcher(labels.MatchEqual, "a", "foo")},
+							},
+							Unwrap: &syntax.UnwrapExpr{
+								Identifier: "bytes",
+							},
+							Interval: 1 * time.Second,
+						},
+						Grouping: &syntax.Grouping{
+							Groups: []string{"a", "b"},
+						},
+					},
+				},
+				RHS: &syntax.LiteralExpr{
+					Val: 1,
+				},
+				Op: syntax.OpTypeGT,
+				Opts: &syntax.BinOpOptions{
+					ReturnBool:     false,
+					VectorMatching: &syntax.VectorMatching{},
+				},
+			},
+		},
+		{
+			in: `1 < quantile_over_time(0.99, {a="foo"} | unwrap bytes [1s]) by (a, b)`,
+			expr: &syntax.BinOpExpr{
+				SampleExpr: &syntax.LiteralExpr{
+					Val: 1,
+				},
+				RHS: DownstreamSampleExpr{
+					SampleExpr: &syntax.RangeAggregationExpr{
+						Operation: syntax.OpRangeTypeQuantile,
+						Params:    float64p(0.99),
+						Left: &syntax.LogRange{
+							Left: &syntax.MatchersExpr{
+								Mts: []*labels.Matcher{mustNewMatcher(labels.MatchEqual, "a", "foo")},
+							},
+							Unwrap: &syntax.UnwrapExpr{
+								Identifier: "bytes",
+							},
+							Interval: 1 * time.Second,
+						},
+						Grouping: &syntax.Grouping{
+							Groups: []string{"a", "b"},
+						},
+					},
+				},
+				Op: syntax.OpTypeLT,
+				Opts: &syntax.BinOpOptions{
+					ReturnBool:     false,
+					VectorMatching: &syntax.VectorMatching{},
+				},
+			},
+		},
 	} {
 		t.Run(tc.in, func(t *testing.T) {
 			ast, err := syntax.ParseExpr(tc.in)
 			require.Equal(t, tc.err, err)
 
 			mapped, _, err := m.Map(ast, nilShardMetrics.downstreamRecorder())
+			switch e := mapped.(type) {
+			case syntax.SampleExpr:
+				optimized, err := optimizeSampleExpr(e)
+				require.NoError(t, err)
+				require.Equal(t, mapped.String(), optimized.String())
+			}
 
 			require.Equal(t, tc.err, err)
-			require.Equal(t, mapped.String(), tc.expr.String())
-			require.Equal(t, mapped, tc.expr)
+			require.Equal(t, tc.expr.String(), mapped.String())
+			require.Equal(t, tc.expr, mapped)
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This fixes a four year old bug. The `optimizeSampleExpr` was switching on the wrong `DownstreamSampleExpr` type.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
