### PR TITLE
Cache: correctly check background cache size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 * [11539](https://github.com/grafana/loki/pull/11539) **kaviraj,ashwanthgoli** Support caching /series and /labels query results
 * [11545](https://github.com/grafana/loki/pull/11545) **dannykopping** Force correct memcached timeout when fetching chunks.
 * [11589](https://github.com/grafana/loki/pull/11589) **ashwanthgoli** Results Cache: Adds `query_length_served` cache stat to measure the length of the query served from cache.
+* [11654](https://github.com/grafana/loki/pull/11654) **dannykopping** Cache: atomically check background cache size limit correctly. 
 
 ##### Fixes
 * [11074](https://github.com/grafana/loki/pull/11074) **hainenber** Fix panic in lambda-promtail due to mishandling of empty DROP_LABELS env var.

--- a/pkg/storage/chunk/cache/background.go
+++ b/pkg/storage/chunk/cache/background.go
@@ -148,8 +148,13 @@ func (c *backgroundCache) Store(ctx context.Context, keys []string, bufs [][]byt
 		}
 
 		size := bgWrite.size()
-		newSize := c.size.Load() + int64(size)
+		// prospectively add new size
+		c.size.Add(int64(size))
+
+		newSize := c.size.Load()
 		if newSize > int64(c.sizeLimit) {
+			// subtract it since we've exceeded the limit
+			c.size.Add(-int64(size))
 			c.failStore(ctx, size, num, "queue at byte size limit")
 			return nil
 		}

--- a/pkg/storage/chunk/cache/background.go
+++ b/pkg/storage/chunk/cache/background.go
@@ -149,12 +149,10 @@ func (c *backgroundCache) Store(ctx context.Context, keys []string, bufs [][]byt
 
 		size := bgWrite.size()
 		// prospectively add new size
-		c.size.Add(int64(size))
-
-		newSize := c.size.Load()
+		newSize := c.size.Add(int64(size))
 		if newSize > int64(c.sizeLimit) {
 			// subtract it since we've exceeded the limit
-			c.size.Add(-int64(size))
+			c.size.Sub(int64(size))
 			c.failStore(ctx, size, num, "queue at byte size limit")
 			return nil
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
The size check was not being performed atomically, which led to flakiness in the `TestBackgroundSizeLimit` test.
