### PR TITLE
Fix backend target in docker compose

### DIFF
--- a/production/docker/config/loki.yaml
+++ b/production/docker/config/loki.yaml
@@ -76,10 +76,24 @@ ruler:
 
 schema_config:
   configs:
+  - from: 2020-08-01
+    store: boltdb-shipper
+    object_store: s3
+    schema: v11
+    index:
+      prefix: index_
+      period: 24h
   - from: 2023-07-11
     store: tsdb
     object_store: s3
-    schema: v13
+    schema: v12
+    index:
+      prefix: index_
+      period: 24h
+  - from: 2024-01-10
+    store: tsdb
+    object_store: s3
+    schema: v12
     index:
       prefix: index_
       period: 24h

--- a/production/docker/config/loki.yaml
+++ b/production/docker/config/loki.yaml
@@ -9,19 +9,20 @@ server:
 
 common:
   path_prefix: /loki
-  storage:
-    s3:
-      endpoint: minio:9000
-      insecure: true
-      bucketnames: loki-data
-      access_key_id: loki
-      secret_access_key: supersecret
-      s3forcepathstyle: true
-  compactor_address: http://loki-write:3100
+  compactor_address: http://loki-backend:3100
   replication_factor: 3
 
+storage_config:
+  aws:
+    endpoint: minio:9000
+    insecure: true
+    bucketnames: loki-data
+    access_key_id: loki
+    secret_access_key: supersecret
+    s3forcepathstyle: true
+
 memberlist:
-  join_members: ["loki-read", "loki-write"]
+  join_members: ["loki-read", "loki-write", "loki-backend"]
   dead_node_reclaim_time: 30s
   gossip_to_dead_nodes_time: 15s
   left_ingesters_timeout: 30s
@@ -54,6 +55,10 @@ ruler:
   enable_sharding: true  
   wal:
     dir: /loki/ruler-wal
+  evaluation:
+    mode: remote
+    query_frontend:
+      address: dns:///loki-read:9095
   storage:
     type: local
     local:
@@ -71,17 +76,10 @@ ruler:
 
 schema_config:
   configs:
-  - from: 2020-08-01
-    store: boltdb-shipper
-    object_store: s3
-    schema: v11
-    index:
-      prefix: index_
-      period: 24h
   - from: 2023-07-11
     store: tsdb
     object_store: s3
-    schema: v12
+    schema: v13
     index:
       prefix: index_
       period: 24h

--- a/production/docker/config/prometheus.yaml
+++ b/production/docker/config/prometheus.yaml
@@ -11,6 +11,7 @@ scrape_configs:
       - names:
           - loki-read
           - loki-write
+          - loki-backend
         type: A
         port: 3100
   - job_name: 'promtail'

--- a/production/docker/docker-compose.yaml
+++ b/production/docker/docker-compose.yaml
@@ -89,7 +89,7 @@ services:
       - |
         mkdir -p /data/loki-data && \
         mkdir -p /data/loki-ruler &&
-        minio server /data
+        minio server --address "0.0.0.0:9000" --console-address "0.0.0.0:9001" /data
     environment:
       - MINIO_ROOT_USER=loki
       - MINIO_ROOT_PASSWORD=supersecret
@@ -97,6 +97,7 @@ services:
       - MINIO_UPDATE=off
     ports:
       - "9000:9000"
+      - "9001:9001"
     volumes:
       - ./.data/minio:/data
     networks:
@@ -116,7 +117,6 @@ services:
     image: *lokiImage
     volumes:
       - ./config:/etc/loki/
-      - ./rules:/loki/rules:ro
     # only needed for interactive debugging with dlv
     # cap_add:
     #   - SYS_PTRACE
@@ -127,7 +127,7 @@ services:
       - "7946"
       # uncomment to use interactive debugging
       # - "40000-40002:40000" # makes the replicas available on ports 40000, 40001, 40002
-    command: "-config.file=/etc/loki/loki.yaml -target=read"
+    command: "-config.file=/etc/loki/loki.yaml -target=read -legacy-read-mode=false"
     networks:
       - loki
     restart: always
@@ -161,6 +161,7 @@ services:
     image: *lokiImage
     volumes:
       - ./config:/etc/loki/
+      - ./rules:/loki/rules:ro
     # only needed for interactive debugging with dlv
     # cap_add:
     #   - SYS_PTRACE


### PR DESCRIPTION
**What this PR does / why we need it**:
At https://github.com/grafana/loki/pull/9899 added the new `backend` SSD target to the docker compose we ship at `production/docker`. Later on, https://github.com/grafana/loki/pull/8836 removed it since the current stable version of Loki was 2.7.3 and `backend` was introduced with 2.8 (RC at the time of this PR).

The backend target is now GA, this PR enables it back in our provided docker compose.

Additionally, the following improvements/updates are made:
- Move storage config from `common.storage.s3` to `storage.aws`
- Remove schema period using boltdb-shipper
- Update tsdb schema to latest (v13)
- Expose minio web console