### PR TITLE
Deprecate and flip -legacy-read-mode to false by default

### DIFF
--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -101,7 +101,7 @@ type Config struct {
 	Tracing       tracing.Config       `yaml:"tracing"`
 	Analytics     analytics.Config     `yaml:"analytics"`
 
-	LegacyReadTarget bool `yaml:"legacy_read_target,omitempty" doc:"hidden"`
+	LegacyReadTarget bool `yaml:"legacy_read_target,omitempty" doc:"hidden|deprecated"`
 
 	Common common.Config `yaml:"common,omitempty"`
 
@@ -136,9 +136,8 @@ func (c *Config) RegisterFlags(f *flag.FlagSet) {
 			"It will, however, distort metrics, because it is counted as live memory. ",
 	)
 
-	//TODO(trevorwhitney): flip this to false with Loki 3.0
-	f.BoolVar(&c.LegacyReadTarget, "legacy-read-mode", true, "Set to false to disable the legacy read mode and use new scalable mode with 3rd backend target. "+
-		"The default will be flipped to false in the next Loki release.")
+	f.BoolVar(&c.LegacyReadTarget, "legacy-read-mode", false, "Deprecated. Set to true to enable the legacy read mode running the components from the backend target. "+
+		"This setting is deprecated and will be removed in the next minor release.")
 
 	f.DurationVar(&c.ShutdownDelay, "shutdown-delay", 0, "How long to wait between SIGTERM and shutdown. After receiving SIGTERM, Loki will report 503 Service Unavailable status via /ready endpoint.")
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR addresses a pending TODO to flip the value of the `-legacy-read-mode` to false by default. We also deprecate it as we plan to remove it after Loki 3.0.
