### PR TITLE
Query-frontend: use the same query split interval for generated cache keys

### DIFF
--- a/pkg/querier/queryrange/index_stats_cache.go
+++ b/pkg/querier/queryrange/index_stats_cache.go
@@ -93,6 +93,7 @@ func NewIndexStatsCacheMiddleware(
 	merger queryrangebase.Merger,
 	c cache.Cache,
 	cacheGenNumberLoader queryrangebase.CacheGenNumberLoader,
+	iqo util.IngesterQueryOptions,
 	shouldCache queryrangebase.ShouldCacheFn,
 	parallelismForReq queryrangebase.ParallelismForReqFn,
 	retentionEnabled bool,

--- a/pkg/querier/queryrange/index_stats_cache.go
+++ b/pkg/querier/queryrange/index_stats_cache.go
@@ -103,7 +103,7 @@ func NewIndexStatsCacheMiddleware(
 	return queryrangebase.NewResultsCacheMiddleware(
 		log,
 		c,
-		IndexStatsSplitter{cacheKeyLimits{limits, transformer}},
+		IndexStatsSplitter{cacheKeyLimits{limits, transformer, iqo}},
 		limits,
 		merger,
 		IndexStatsExtractor{},

--- a/pkg/querier/queryrange/index_stats_cache_test.go
+++ b/pkg/querier/queryrange/index_stats_cache_test.go
@@ -37,6 +37,7 @@ func TestIndexStatsCache(t *testing.T) {
 		c,
 		nil,
 		nil,
+		nil,
 		func(_ context.Context, _ []string, _ queryrangebase.Request) int {
 			return 1
 		},
@@ -178,6 +179,7 @@ func TestIndexStatsCache_RecentData(t *testing.T) {
 				WithSplitByLimits(lim, 24*time.Hour),
 				DefaultCodec,
 				c,
+				nil,
 				nil,
 				nil,
 				func(_ context.Context, _ []string, _ queryrangebase.Request) int {

--- a/pkg/querier/queryrange/ingester_query_window.go
+++ b/pkg/querier/queryrange/ingester_query_window.go
@@ -1,0 +1,31 @@
+package queryrange
+
+import (
+	"time"
+
+	"github.com/grafana/loki/pkg/util"
+	"github.com/grafana/loki/pkg/util/validation"
+)
+
+// SplitIntervalForTimeRange returns the correct split interval to use. It accounts for the given upperBound value being
+// within the ingester query window, in which case it returns the ingester query split (unless it's not set, then the default
+// split interval will be used).
+func SplitIntervalForTimeRange(iqo util.IngesterQueryOptions, limits Limits, defaultSplitFn func(string) time.Duration, tenantIDs []string, ref, upperBound time.Time) time.Duration {
+	split := validation.SmallestPositiveNonZeroDurationPerTenant(tenantIDs, defaultSplitFn)
+
+	if iqo != nil {
+		// if the query is within the ingester query window, choose the ingester split duration (if configured), otherwise
+		// revert to the default split duration
+		ingesterQueryWindowStart := ref.Add(-iqo.QueryIngestersWithin())
+
+		// query is (even partially) within the ingester query window
+		if upperBound.After(ingesterQueryWindowStart) {
+			ingesterSplit := validation.MaxDurationOrZeroPerTenant(tenantIDs, limits.IngesterQuerySplitDuration)
+			if !iqo.QueryStoreOnly() && ingesterSplit > 0 {
+				split = ingesterSplit
+			}
+		}
+	}
+
+	return split
+}

--- a/pkg/querier/queryrange/labels_cache.go
+++ b/pkg/querier/queryrange/labels_cache.go
@@ -77,6 +77,7 @@ func NewLabelsCacheMiddleware(
 	merger queryrangebase.Merger,
 	c cache.Cache,
 	cacheGenNumberLoader queryrangebase.CacheGenNumberLoader,
+	iqo util.IngesterQueryOptions,
 	shouldCache queryrangebase.ShouldCacheFn,
 	parallelismForReq queryrangebase.ParallelismForReqFn,
 	retentionEnabled bool,

--- a/pkg/querier/queryrange/labels_cache_test.go
+++ b/pkg/querier/queryrange/labels_cache_test.go
@@ -69,6 +69,7 @@ func TestLabelsCache(t *testing.T) {
 			cache.NewMockCache(),
 			nil,
 			nil,
+			nil,
 			func(_ context.Context, _ []string, _ queryrangebase.Request) int {
 				return 1
 			},

--- a/pkg/querier/queryrange/limits.go
+++ b/pkg/querier/queryrange/limits.go
@@ -30,6 +30,7 @@ import (
 	"github.com/grafana/loki/pkg/storage/chunk/cache/resultscache"
 	"github.com/grafana/loki/pkg/storage/config"
 	"github.com/grafana/loki/pkg/storage/stores/index/stats"
+	"github.com/grafana/loki/pkg/util"
 	util_log "github.com/grafana/loki/pkg/util/log"
 	"github.com/grafana/loki/pkg/util/spanlogger"
 	"github.com/grafana/loki/pkg/util/validation"
@@ -102,10 +103,11 @@ type UserIDTransformer func(context.Context, string) string
 type cacheKeyLimits struct {
 	Limits
 	transformer UserIDTransformer
+	iqo         util.IngesterQueryOptions
 }
 
 func (l cacheKeyLimits) GenerateCacheKey(ctx context.Context, userID string, r resultscache.Request) string {
-	split := l.QuerySplitDuration(userID)
+	split := SplitIntervalForTimeRange(l.iqo, l.Limits, l.QuerySplitDuration, []string{userID}, time.Now().UTC(), r.GetEnd().UTC())
 
 	var currentInterval int64
 	if denominator := int64(split / time.Millisecond); denominator > 0 {

--- a/pkg/querier/queryrange/limits_test.go
+++ b/pkg/querier/queryrange/limits_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"regexp"
 	"sync"
 	"testing"
 	"time"
@@ -22,6 +23,7 @@ import (
 	"github.com/grafana/loki/pkg/querier/plan"
 	base "github.com/grafana/loki/pkg/querier/queryrange/queryrangebase"
 	"github.com/grafana/loki/pkg/storage/config"
+	"github.com/grafana/loki/pkg/util"
 	"github.com/grafana/loki/pkg/util/constants"
 	util_log "github.com/grafana/loki/pkg/util/log"
 	"github.com/grafana/loki/pkg/util/math"
@@ -48,8 +50,91 @@ func TestLimits(t *testing.T) {
 	require.Equal(
 		t,
 		fmt.Sprintf("%s:%s:%d:%d:%d", "a", r.GetQuery(), r.GetStep(), r.GetStart().UnixMilli()/int64(time.Hour/time.Millisecond), int64(time.Hour)),
-		cacheKeyLimits{wrapped, nil}.GenerateCacheKey(context.Background(), "a", r),
+		cacheKeyLimits{wrapped, nil, nil}.GenerateCacheKey(context.Background(), "a", r),
 	)
+}
+
+func TestIngesterQueryWindowCacheKey(t *testing.T) {
+	const (
+		defaultTenant   = "a"
+		alternateTenant = "b"
+		query           = `sum(rate({foo="bar"}[1]))`
+		defaultSplit    = time.Hour
+		ingesterSplit   = 90 * time.Minute
+	)
+
+	var (
+		step                = (15 * time.Second).Milliseconds()
+		ingesterQueryWindow = defaultSplit * 3
+	)
+
+	l := fakeLimits{
+		splitDuration:         map[string]time.Duration{defaultTenant: defaultSplit, alternateTenant: defaultSplit},
+		ingesterSplitDuration: map[string]time.Duration{defaultTenant: ingesterSplit},
+	}
+
+	cases := []struct {
+		name, tenantID string
+		start, end     time.Time
+		expectedSplit  time.Duration
+		iqo            util.IngesterQueryOptions
+	}{
+		{
+			name:          "outside ingester query window",
+			tenantID:      defaultTenant,
+			start:         time.Now().Add(-6 * time.Hour),
+			end:           time.Now().Add(-5 * time.Hour),
+			expectedSplit: defaultSplit,
+		},
+		{
+			name:          "within ingester query window",
+			tenantID:      defaultTenant,
+			start:         time.Now().Add(-6 * time.Hour),
+			end:           time.Now().Add(-ingesterQueryWindow / 2),
+			expectedSplit: ingesterSplit,
+			iqo: ingesterQueryOpts{
+				queryIngestersWithin: ingesterQueryWindow,
+				queryStoreOnly:       false,
+			},
+		},
+		{
+			name:          "within ingester query window, but query store only",
+			tenantID:      defaultTenant,
+			start:         time.Now().Add(-6 * time.Hour),
+			end:           time.Now().Add(-ingesterQueryWindow / 2),
+			expectedSplit: defaultSplit,
+			iqo: ingesterQueryOpts{
+				queryIngestersWithin: ingesterQueryWindow,
+				queryStoreOnly:       true,
+			},
+		},
+		{
+			name:          "within ingester query window, but no ingester split duration configured",
+			tenantID:      alternateTenant,
+			start:         time.Now().Add(-6 * time.Hour),
+			end:           time.Now().Add(-ingesterQueryWindow / 2),
+			expectedSplit: defaultSplit,
+			iqo: ingesterQueryOpts{
+				queryIngestersWithin: ingesterQueryWindow,
+				queryStoreOnly:       false,
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			keyGen := cacheKeyLimits{l, nil, tc.iqo}
+
+			r := &LokiRequest{
+				Query:   query,
+				StartTs: tc.start,
+				EndTs:   tc.end,
+				Step:    step,
+			}
+
+			pattern := regexp.MustCompile(fmt.Sprintf(`%s:%s:%d:(\d+):%d`, tc.tenantID, regexp.QuoteMeta(query), step, tc.expectedSplit))
+			require.Regexp(t, pattern, keyGen.GenerateCacheKey(context.Background(), tc.tenantID, r))
+		})
+	}
 }
 
 func Test_seriesLimiter(t *testing.T) {
@@ -308,7 +393,7 @@ func Test_MaxQueryLookBack_Types(t *testing.T) {
 }
 
 func Test_GenerateCacheKey_NoDivideZero(t *testing.T) {
-	l := cacheKeyLimits{WithSplitByLimits(nil, 0), nil}
+	l := cacheKeyLimits{WithSplitByLimits(nil, 0), nil, nil}
 	start := time.Now()
 	r := &LokiRequest{
 		Query:   "qry",

--- a/pkg/querier/queryrange/series_cache.go
+++ b/pkg/querier/queryrange/series_cache.go
@@ -13,16 +13,20 @@ import (
 	"github.com/grafana/loki/pkg/querier/queryrange/queryrangebase"
 	"github.com/grafana/loki/pkg/storage/chunk/cache"
 	"github.com/grafana/loki/pkg/storage/chunk/cache/resultscache"
+	"github.com/grafana/loki/pkg/util"
 )
 
 type cacheKeySeries struct {
 	Limits
 	transformer UserIDTransformer
+	iqo         util.IngesterQueryOptions
 }
 
 // GenerateCacheKey generates a cache key based on the userID, matchers, split duration and the interval of the request.
 func (i cacheKeySeries) GenerateCacheKey(ctx context.Context, userID string, r resultscache.Request) string {
 	sr := r.(*LokiSeriesRequest)
+
+	// TODO(dannyk): replace with the below once we've confirmed we want to use same split for metadata queries
 	split := i.MetadataQuerySplitDuration(userID)
 
 	var currentInterval int64
@@ -88,7 +92,7 @@ func NewSeriesCacheMiddleware(
 	return queryrangebase.NewResultsCacheMiddleware(
 		logger,
 		c,
-		cacheKeySeries{limits, transformer},
+		cacheKeySeries{limits, transformer, iqo},
 		limits,
 		merger,
 		seriesExtractor{},

--- a/pkg/querier/queryrange/series_cache.go
+++ b/pkg/querier/queryrange/series_cache.go
@@ -78,6 +78,7 @@ func NewSeriesCacheMiddleware(
 	merger queryrangebase.Merger,
 	c cache.Cache,
 	cacheGenNumberLoader queryrangebase.CacheGenNumberLoader,
+	iqo util.IngesterQueryOptions,
 	shouldCache queryrangebase.ShouldCacheFn,
 	parallelismForReq queryrangebase.ParallelismForReqFn,
 	retentionEnabled bool,

--- a/pkg/querier/queryrange/series_cache_test.go
+++ b/pkg/querier/queryrange/series_cache_test.go
@@ -77,6 +77,7 @@ func TestSeriesCache(t *testing.T) {
 			cache.NewMockCache(),
 			nil,
 			nil,
+			nil,
 			func(_ context.Context, _ []string, _ queryrangebase.Request) int {
 				return 1
 			},

--- a/pkg/querier/queryrange/split_by_interval.go
+++ b/pkg/querier/queryrange/split_by_interval.go
@@ -186,6 +186,7 @@ func (h *splitByInterval) Do(ctx context.Context, r queryrangebase.Request) (que
 	case *LokiSeriesRequest, *LabelRequest:
 		interval = validation.MaxDurationOrZeroPerTenant(tenantIDs, h.limits.MetadataQuerySplitDuration)
 	default:
+		// TODO everywhere else we use SmallestPositiveNonZeroDurationPerTenant for this limit; why max here?
 		interval = validation.MaxDurationOrZeroPerTenant(tenantIDs, h.limits.QuerySplitDuration)
 	}
 

--- a/pkg/querier/queryrange/splitters.go
+++ b/pkg/querier/queryrange/splitters.go
@@ -98,7 +98,7 @@ func (s *defaultSplitter) split(execTime time.Time, tenantIDs []string, req quer
 
 	start, end, needsIngesterSplits := ingesterQueryBounds(execTime, s.iqo, req)
 
-	if ingesterQueryInterval := validation.MaxDurationPerTenant(tenantIDs, s.limits.IngesterQuerySplitDuration); ingesterQueryInterval != 0 && needsIngesterSplits {
+	if ingesterQueryInterval := validation.MaxDurationOrZeroPerTenant(tenantIDs, s.limits.IngesterQuerySplitDuration); ingesterQueryInterval != 0 && needsIngesterSplits {
 		// perform splitting using special interval (`split_ingester_queries_by_interval`)
 		util.ForInterval(ingesterQueryInterval, start, end, endTimeInclusive, factory)
 
@@ -212,7 +212,7 @@ func (s *metricQuerySplitter) split(execTime time.Time, tenantIDs []string, r qu
 	start, end, needsIngesterSplits = ingesterQueryBounds(execTime, s.iqo, lokiReq)
 	start, end = s.alignStartEnd(r.GetStep(), start, end)
 
-	if ingesterQueryInterval := validation.MaxDurationPerTenant(tenantIDs, s.limits.IngesterQuerySplitDuration); ingesterQueryInterval != 0 && needsIngesterSplits {
+	if ingesterQueryInterval := validation.MaxDurationOrZeroPerTenant(tenantIDs, s.limits.IngesterQuerySplitDuration); ingesterQueryInterval != 0 && needsIngesterSplits {
 		// perform splitting using special interval (`split_ingester_queries_by_interval`)
 		s.buildMetricSplits(lokiReq.GetStep(), ingesterQueryInterval, start, end, factory)
 

--- a/pkg/querier/queryrange/volume_cache.go
+++ b/pkg/querier/queryrange/volume_cache.go
@@ -101,6 +101,7 @@ func NewVolumeCacheMiddleware(
 	merger queryrangebase.Merger,
 	c cache.Cache,
 	cacheGenNumberLoader queryrangebase.CacheGenNumberLoader,
+	iqo util.IngesterQueryOptions,
 	shouldCache queryrangebase.ShouldCacheFn,
 	parallelismForReq queryrangebase.ParallelismForReqFn,
 	retentionEnabled bool,

--- a/pkg/querier/queryrange/volume_cache.go
+++ b/pkg/querier/queryrange/volume_cache.go
@@ -111,7 +111,7 @@ func NewVolumeCacheMiddleware(
 	return queryrangebase.NewResultsCacheMiddleware(
 		log,
 		c,
-		VolumeSplitter{cacheKeyLimits{limits, transformer}},
+		VolumeSplitter{cacheKeyLimits{limits, transformer, iqo}},
 		limits,
 		merger,
 		VolumeExtractor{},

--- a/pkg/querier/queryrange/volume_cache_test.go
+++ b/pkg/querier/queryrange/volume_cache_test.go
@@ -39,6 +39,7 @@ func TestVolumeCache(t *testing.T) {
 			c,
 			nil,
 			nil,
+			nil,
 			func(_ context.Context, _ []string, _ queryrangebase.Request) int {
 				return 1
 			},
@@ -302,6 +303,7 @@ func TestVolumeCache_RecentData(t *testing.T) {
 				WithSplitByLimits(lim, 24*time.Hour),
 				DefaultCodec,
 				c,
+				nil,
 				nil,
 				nil,
 				func(_ context.Context, _ []string, _ queryrangebase.Request) int {

--- a/pkg/storage/chunk/cache/resultscache/cache.go
+++ b/pkg/storage/chunk/cache/resultscache/cache.go
@@ -50,7 +50,7 @@ type ResultsCache struct {
 	next                 Handler
 	cache                cache.Cache
 	limits               Limits
-	splitter             KeyGenerator
+	keyGen               KeyGenerator
 	cacheGenNumberLoader CacheGenNumberLoader
 	retentionEnabled     bool
 	extractor            Extractor
@@ -86,7 +86,7 @@ func NewResultsCache(
 		next:                 next,
 		cache:                c,
 		limits:               limits,
-		splitter:             keyGen,
+		keyGen:               keyGen,
 		cacheGenNumberLoader: cacheGenNumberLoader,
 		retentionEnabled:     retentionEnabled,
 		extractor:            extractor,
@@ -115,7 +115,7 @@ func (s ResultsCache) Do(ctx context.Context, r Request) (Response, error) {
 	}
 
 	var (
-		key      = s.splitter.GenerateCacheKey(ctx, tenant.JoinTenantIDs(tenantIDs), r)
+		key      = s.keyGen.GenerateCacheKey(ctx, tenant.JoinTenantIDs(tenantIDs), r)
 		extents  []Extent
 		response Response
 	)


### PR DESCRIPTION
**What this PR does / why we need it**:
Follow up from #11535, this PR modifies the results cache implementation to use the same interval for generating cache keys.

**Special notes for your reviewer**:
We need to decide whether we want metadata queries to be split using the same interval or a different one.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
