### PR TITLE
fix: remove shared state noParserHints to avoid data race

### DIFF
--- a/pkg/logql/log/labels.go
+++ b/pkg/logql/log/labels.go
@@ -157,7 +157,7 @@ type LabelsBuilder struct {
 // NewBaseLabelsBuilderWithGrouping creates a new base labels builder with grouping to compute results.
 func NewBaseLabelsBuilderWithGrouping(groups []string, parserKeyHints ParserHint, without, noLabels bool) *BaseLabelsBuilder {
 	if parserKeyHints == nil {
-		parserKeyHints = noParserHints
+		parserKeyHints = NoParserHints()
 	}
 
 	const labelsCapacity = 16
@@ -179,7 +179,7 @@ func NewBaseLabelsBuilderWithGrouping(groups []string, parserKeyHints ParserHint
 
 // NewBaseLabelsBuilder creates a new base labels builder.
 func NewBaseLabelsBuilder() *BaseLabelsBuilder {
-	return NewBaseLabelsBuilderWithGrouping(nil, noParserHints, false, false)
+	return NewBaseLabelsBuilderWithGrouping(nil, NoParserHints(), false, false)
 }
 
 // ForLabels creates a labels builder for a given labels set as base.

--- a/pkg/logql/log/parser_hints.go
+++ b/pkg/logql/log/parser_hints.go
@@ -6,7 +6,9 @@ import (
 	"github.com/grafana/loki/pkg/logqlmodel"
 )
 
-var noParserHints = &Hints{}
+func NoParserHints() ParserHint {
+	return &Hints{}
+}
 
 // ParserHint are hints given to LogQL parsers.
 // This is specially useful for parser that extract implicitly all possible label keys.

--- a/pkg/logql/log/parser_test.go
+++ b/pkg/logql/log/parser_test.go
@@ -28,7 +28,7 @@ func Test_jsonParser_Parse(t *testing.T) {
 				"pod_uuid", "foo",
 				"pod_deployment_ref", "foobar",
 			),
-			noParserHints,
+			NoParserHints(),
 		},
 		{
 			"numeric",
@@ -37,7 +37,7 @@ func Test_jsonParser_Parse(t *testing.T) {
 			labels.FromStrings("counter", "1",
 				"price__net_", "5.56909",
 			),
-			noParserHints,
+			NoParserHints(),
 		},
 		{
 			"escaped",
@@ -47,7 +47,7 @@ func Test_jsonParser_Parse(t *testing.T) {
 				"price__net_", "5.56909",
 				"foo", `foo\"bar`,
 			),
-			noParserHints,
+			NoParserHints(),
 		},
 		{
 			"utf8 error rune",
@@ -57,21 +57,21 @@ func Test_jsonParser_Parse(t *testing.T) {
 				"price__net_", "5.56909",
 				"foo", "",
 			),
-			noParserHints,
+			NoParserHints(),
 		},
 		{
 			"skip arrays",
 			[]byte(`{"counter":1, "price": {"net_":["10","20"]}}`),
 			labels.EmptyLabels(),
 			labels.FromStrings("counter", "1"),
-			noParserHints,
+			NoParserHints(),
 		},
 		{
 			"bad key replaced",
 			[]byte(`{"cou-nter":1}`),
 			labels.EmptyLabels(),
 			labels.FromStrings("cou_nter", "1"),
-			noParserHints,
+			NoParserHints(),
 		},
 		{
 			"errors",
@@ -80,7 +80,7 @@ func Test_jsonParser_Parse(t *testing.T) {
 			labels.FromStrings("__error__", "JSONParserErr",
 				"__error_details__", "Value looks like object, but can't find closing '}' symbol",
 			),
-			noParserHints,
+			NoParserHints(),
 		},
 		{
 			"errors hints",
@@ -103,7 +103,7 @@ func Test_jsonParser_Parse(t *testing.T) {
 				"next_err", "false",
 				"pod_deployment_ref", "foobar",
 			),
-			noParserHints,
+			NoParserHints(),
 		},
 	}
 	for _, tt := range tests {
@@ -255,7 +255,7 @@ func TestJSONExpressionParser(t *testing.T) {
 			},
 			labels.EmptyLabels(),
 			labels.FromStrings("app", "foo"),
-			noParserHints,
+			NoParserHints(),
 		},
 		{
 			"alternate syntax",
@@ -265,7 +265,7 @@ func TestJSONExpressionParser(t *testing.T) {
 			},
 			labels.EmptyLabels(),
 			labels.FromStrings("test", "value"),
-			noParserHints,
+			NoParserHints(),
 		},
 		{
 			"multiple fields",
@@ -278,7 +278,7 @@ func TestJSONExpressionParser(t *testing.T) {
 			labels.FromStrings("app", "foo",
 				"namespace", "prod",
 			),
-			noParserHints,
+			NoParserHints(),
 		},
 		{
 			"utf8",
@@ -288,7 +288,7 @@ func TestJSONExpressionParser(t *testing.T) {
 			},
 			labels.EmptyLabels(),
 			labels.FromStrings("utf8", "value"),
-			noParserHints,
+			NoParserHints(),
 		},
 		{
 			"nested field",
@@ -298,7 +298,7 @@ func TestJSONExpressionParser(t *testing.T) {
 			},
 			labels.EmptyLabels(),
 			labels.FromStrings("uuid", "foo"),
-			noParserHints,
+			NoParserHints(),
 		},
 		{
 			"nested field alternate syntax",
@@ -308,7 +308,7 @@ func TestJSONExpressionParser(t *testing.T) {
 			},
 			labels.EmptyLabels(),
 			labels.FromStrings("uuid", "foo"),
-			noParserHints,
+			NoParserHints(),
 		},
 		{
 			"nested field alternate syntax 2",
@@ -318,7 +318,7 @@ func TestJSONExpressionParser(t *testing.T) {
 			},
 			labels.EmptyLabels(),
 			labels.FromStrings("uuid", "foo"),
-			noParserHints,
+			NoParserHints(),
 		},
 		{
 			"nested field alternate syntax 3",
@@ -328,7 +328,7 @@ func TestJSONExpressionParser(t *testing.T) {
 			},
 			labels.EmptyLabels(),
 			labels.FromStrings("uuid", "foo"),
-			noParserHints,
+			NoParserHints(),
 		},
 		{
 			"array element",
@@ -338,7 +338,7 @@ func TestJSONExpressionParser(t *testing.T) {
 			},
 			labels.EmptyLabels(),
 			labels.FromStrings("param", "1"),
-			noParserHints,
+			NoParserHints(),
 		},
 		{
 			"full array",
@@ -348,7 +348,7 @@ func TestJSONExpressionParser(t *testing.T) {
 			},
 			labels.EmptyLabels(),
 			labels.FromStrings("params", "[1,2,3]"),
-			noParserHints,
+			NoParserHints(),
 		},
 		{
 			"full object",
@@ -358,7 +358,7 @@ func TestJSONExpressionParser(t *testing.T) {
 			},
 			labels.EmptyLabels(),
 			labels.FromStrings("deployment", `{"ref":"foobar", "params": [1,2,3]}`),
-			noParserHints,
+			NoParserHints(),
 		},
 		{
 			"expression matching nothing",
@@ -368,7 +368,7 @@ func TestJSONExpressionParser(t *testing.T) {
 			},
 			labels.EmptyLabels(),
 			labels.FromStrings("nope", ""),
-			noParserHints,
+			NoParserHints(),
 		},
 		{
 			"null field",
@@ -379,7 +379,7 @@ func TestJSONExpressionParser(t *testing.T) {
 			labels.EmptyLabels(),
 			labels.FromStrings("nf", ""), // null is coerced to an empty string
 
-			noParserHints,
+			NoParserHints(),
 		},
 		{
 			"boolean field",
@@ -389,7 +389,7 @@ func TestJSONExpressionParser(t *testing.T) {
 			},
 			labels.EmptyLabels(),
 			labels.FromStrings("bool", `false`),
-			noParserHints,
+			NoParserHints(),
 		},
 		{
 			"label override",
@@ -401,7 +401,7 @@ func TestJSONExpressionParser(t *testing.T) {
 			labels.FromStrings("uuid", "bar",
 				"uuid_extracted", "foo",
 			),
-			noParserHints,
+			NoParserHints(),
 		},
 		{
 			"non-matching expression",
@@ -413,7 +413,7 @@ func TestJSONExpressionParser(t *testing.T) {
 			labels.FromStrings("uuid", "bar",
 				"request_size", "",
 			),
-			noParserHints,
+			NoParserHints(),
 		},
 		{
 			"empty line",
@@ -423,7 +423,7 @@ func TestJSONExpressionParser(t *testing.T) {
 			},
 			labels.EmptyLabels(),
 			labels.FromStrings("uuid", ""),
-			noParserHints,
+			NoParserHints(),
 		},
 		{
 			"existing labels are not affected",
@@ -435,7 +435,7 @@ func TestJSONExpressionParser(t *testing.T) {
 			labels.FromStrings("foo", "bar",
 				"uuid", "",
 			),
-			noParserHints,
+			NoParserHints(),
 		},
 		{
 			"invalid JSON line",
@@ -447,7 +447,7 @@ func TestJSONExpressionParser(t *testing.T) {
 			labels.FromStrings("foo", "bar",
 				logqlmodel.ErrorLabel, errJSON,
 			),
-			noParserHints,
+			NoParserHints(),
 		},
 		{
 			"invalid JSON line with hints",
@@ -470,7 +470,7 @@ func TestJSONExpressionParser(t *testing.T) {
 			},
 			labels.FromStrings("foo", "bar"),
 			labels.FromStrings("foo", "bar"),
-			noParserHints,
+			NoParserHints(),
 		},
 		{
 			"nested escaped object",
@@ -482,7 +482,7 @@ func TestJSONExpressionParser(t *testing.T) {
 			labels.FromStrings("foo", "bar",
 				"app", `{ "key": "value", "key2":"value2"}`,
 			),
-			noParserHints,
+			NoParserHints(),
 		},
 	}
 	for _, tt := range tests {
@@ -746,7 +746,7 @@ func TestLogfmtParser_parse(t *testing.T) {
 				"__error__", "LogfmtParserErr",
 				"__error_details__", "logfmt syntax error at pos 8 : unexpected '='",
 			),
-			noParserHints,
+			NoParserHints(),
 		},
 		{
 			"not logfmt with hints",
@@ -766,7 +766,7 @@ func TestLogfmtParser_parse(t *testing.T) {
 			labels.EmptyLabels(),
 			labels.FromStrings("buzz", "foo"),
 			nil,
-			noParserHints,
+			NoParserHints(),
 		},
 		{
 			"key alone logfmt",
@@ -775,7 +775,7 @@ func TestLogfmtParser_parse(t *testing.T) {
 			labels.FromStrings("foo", "bar",
 				"bar", "foo"),
 			nil,
-			noParserHints,
+			NoParserHints(),
 		},
 		{
 			"quoted logfmt",
@@ -785,7 +785,7 @@ func TestLogfmtParser_parse(t *testing.T) {
 				"foobar", "foo bar",
 			),
 			nil,
-			noParserHints,
+			NoParserHints(),
 		},
 		{
 			"escaped control chars in logfmt",
@@ -795,7 +795,7 @@ func TestLogfmtParser_parse(t *testing.T) {
 				"foobar", "foo\nbar\tbaz",
 			),
 			nil,
-			noParserHints,
+			NoParserHints(),
 		},
 		{
 			"literal control chars in logfmt",
@@ -805,7 +805,7 @@ func TestLogfmtParser_parse(t *testing.T) {
 				"foobar", "foo\nbar\tbaz",
 			),
 			nil,
-			noParserHints,
+			NoParserHints(),
 		},
 		{
 			"escaped slash logfmt",
@@ -815,7 +815,7 @@ func TestLogfmtParser_parse(t *testing.T) {
 				"foobar", `foo ba\r baz`,
 			),
 			nil,
-			noParserHints,
+			NoParserHints(),
 		},
 		{
 			"literal newline and escaped slash logfmt",
@@ -825,7 +825,7 @@ func TestLogfmtParser_parse(t *testing.T) {
 				"foobar", "foo bar\nb\\az",
 			),
 			nil,
-			noParserHints,
+			NoParserHints(),
 		},
 		{
 			"double property logfmt",
@@ -836,7 +836,7 @@ func TestLogfmtParser_parse(t *testing.T) {
 				"latency", "10ms",
 			),
 			nil,
-			noParserHints,
+			NoParserHints(),
 		},
 		{
 			"duplicate from line property",
@@ -846,7 +846,7 @@ func TestLogfmtParser_parse(t *testing.T) {
 				"foobar", "10ms",
 			),
 			nil,
-			noParserHints,
+			NoParserHints(),
 		},
 		{
 			"duplicate property",
@@ -857,7 +857,7 @@ func TestLogfmtParser_parse(t *testing.T) {
 				"foobar", "10ms",
 			),
 			nil,
-			noParserHints,
+			NoParserHints(),
 		},
 		{
 			"invalid key names",
@@ -869,7 +869,7 @@ func TestLogfmtParser_parse(t *testing.T) {
 				"test_dash", "foo",
 			),
 			nil,
-			noParserHints,
+			NoParserHints(),
 		},
 		{
 			"nil",
@@ -877,7 +877,7 @@ func TestLogfmtParser_parse(t *testing.T) {
 			labels.FromStrings("foo", "bar"),
 			labels.FromStrings("foo", "bar"),
 			nil,
-			noParserHints,
+			NoParserHints(),
 		},
 		{
 			"empty key",
@@ -892,7 +892,7 @@ func TestLogfmtParser_parse(t *testing.T) {
 				"__error__", "LogfmtParserErr",
 				"__error_details__", "logfmt syntax error at pos 15 : unexpected '='",
 			),
-			noParserHints,
+			NoParserHints(),
 		},
 		{
 			"error rune in key",
@@ -906,7 +906,7 @@ func TestLogfmtParser_parse(t *testing.T) {
 				"__error__", "LogfmtParserErr",
 				"__error_details__", "logfmt syntax error at pos 20 : invalid key",
 			),
-			noParserHints,
+			NoParserHints(),
 		},
 		{
 			"double quote in key",
@@ -920,7 +920,7 @@ func TestLogfmtParser_parse(t *testing.T) {
 				"__error__", "LogfmtParserErr",
 				"__error_details__", `logfmt syntax error at pos 17 : unexpected '"'`,
 			),
-			noParserHints,
+			NoParserHints(),
 		},
 		{
 			"= in value",
@@ -933,7 +933,7 @@ func TestLogfmtParser_parse(t *testing.T) {
 				"__error__", "LogfmtParserErr",
 				"__error_details__", `logfmt syntax error at pos 7 : unexpected '='`,
 			),
-			noParserHints,
+			NoParserHints(),
 		},
 	}
 
@@ -1200,7 +1200,7 @@ func Test_unpackParser_Parse(t *testing.T) {
 				"cluster", "us-central1",
 			),
 			[]byte(`some message`),
-			noParserHints,
+			NoParserHints(),
 		},
 		{
 			"wrong json",
@@ -1210,7 +1210,7 @@ func Test_unpackParser_Parse(t *testing.T) {
 				"__error_details__", "expecting json object(6), but it is not",
 			),
 			[]byte(`"app":"foo","namespace":"prod","_entry":"some message","pod":{"uid":"1"}`),
-			noParserHints,
+			NoParserHints(),
 		},
 		{
 			"empty line",
@@ -1218,7 +1218,7 @@ func Test_unpackParser_Parse(t *testing.T) {
 			labels.FromStrings("cluster", "us-central1"),
 			labels.FromStrings("cluster", "us-central1"),
 			[]byte(``),
-			noParserHints,
+			NoParserHints(),
 		},
 		{
 			"wrong json with hints",
@@ -1240,7 +1240,7 @@ func Test_unpackParser_Parse(t *testing.T) {
 				"cluster", "us-central1",
 			),
 			[]byte(`["foo","bar"]`),
-			noParserHints,
+			NoParserHints(),
 		},
 		{
 			"should rename",
@@ -1254,7 +1254,7 @@ func Test_unpackParser_Parse(t *testing.T) {
 				"cluster", "us-central1",
 			),
 			[]byte(`some message`),
-			noParserHints,
+			NoParserHints(),
 		},
 		{
 			"should not change log and labels if no packed entry",
@@ -1266,7 +1266,7 @@ func Test_unpackParser_Parse(t *testing.T) {
 				"cluster", "us-central1",
 			),
 			[]byte(`{"bar":1,"app":"foo","namespace":"prod","pod":{"uid":"1"}}`),
-			noParserHints,
+			NoParserHints(),
 		},
 		{
 			"non json with escaped quotes",
@@ -1278,7 +1278,7 @@ func Test_unpackParser_Parse(t *testing.T) {
 				"cluster", "us-central1",
 			),
 			[]byte(`I0303 17:49:45.976518    1526 kubelet_getters.go:178] "Pod status updated" pod="openshift-etcd/etcd-ip-10-0-150-50.us-east-2.compute.internal" status=Running`),
-			noParserHints,
+			NoParserHints(),
 		},
 		{
 			"invalid key names",
@@ -1289,7 +1289,7 @@ func Test_unpackParser_Parse(t *testing.T) {
 				"test_dash", "foo",
 			),
 			[]byte(`some message`),
-			noParserHints,
+			NoParserHints(),
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
**What this PR does / why we need it**:

A data race introduced in https://github.com/grafana/loki/pull/11587 was caught  in the [backport to k184](https://github.com/grafana/loki/pull/11668). This removes the shared state of a single global `noParserHints` in favor of creating an empty `Hint` object for each label builder, since the `Hints` is keeping state of `extracted` and `requiredLabels`.