### PR TITLE
Fluentbit: Wrap errors without throwing away the original error message

### DIFF
--- a/clients/cmd/fluent-bit/config.go
+++ b/clients/cmd/fluent-bit/config.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -67,7 +66,7 @@ func parseConfig(cfg ConfigGetter) (*config, error) {
 	}
 	err := clientURL.Set(url)
 	if err != nil {
-		return nil, errors.New("failed to parse client URL")
+		return nil, fmt.Errorf("failed to parse client URL: %w", err)
 	}
 	res.clientConfig.URL = clientURL
 
@@ -83,7 +82,7 @@ func parseConfig(cfg ConfigGetter) (*config, error) {
 		} else {
 			batchWaitValue, err := time.ParseDuration(batchWait)
 			if err != nil {
-				return nil, fmt.Errorf("failed to parse BatchWait: %s", batchWait)
+				return nil, fmt.Errorf("failed to parse BatchWait %s: %w", batchWait, err)
 			}
 			res.clientConfig.BatchWait = batchWaitValue
 		}
@@ -93,7 +92,7 @@ func parseConfig(cfg ConfigGetter) (*config, error) {
 	if batchSize != "" {
 		batchSizeValue, err := strconv.Atoi(batchSize)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse BatchSize: %s", batchSize)
+			return nil, fmt.Errorf("failed to parse BatchSize %s: %w", batchSize, err)
 		}
 		res.clientConfig.BatchSize = batchSizeValue
 	}
@@ -102,7 +101,7 @@ func parseConfig(cfg ConfigGetter) (*config, error) {
 	if timeout != "" {
 		timeoutValue, err := time.ParseDuration(timeout)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse Timeout: %s", timeout)
+			return nil, fmt.Errorf("failed to parse Timeout %s: %w", timeout, err)
 		}
 		res.clientConfig.Timeout = timeoutValue
 	}
@@ -111,7 +110,7 @@ func parseConfig(cfg ConfigGetter) (*config, error) {
 	if minBackoff != "" {
 		minBackoffValue, err := time.ParseDuration(minBackoff)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse MinBackoff: %s", minBackoff)
+			return nil, fmt.Errorf("failed to parse MinBackoff %s: %w", minBackoff, err)
 		}
 		res.clientConfig.BackoffConfig.MinBackoff = minBackoffValue
 	}
@@ -120,7 +119,7 @@ func parseConfig(cfg ConfigGetter) (*config, error) {
 	if maxBackoff != "" {
 		maxBackoffValue, err := time.ParseDuration(maxBackoff)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse MaxBackoff: %s", maxBackoff)
+			return nil, fmt.Errorf("failed to parse MaxBackoff %s: %w", maxBackoff, err)
 		}
 		res.clientConfig.BackoffConfig.MaxBackoff = maxBackoffValue
 	}
@@ -129,7 +128,7 @@ func parseConfig(cfg ConfigGetter) (*config, error) {
 	if maxRetries != "" {
 		maxRetriesValue, err := strconv.Atoi(maxRetries)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse MaxRetries: %s", maxRetries)
+			return nil, fmt.Errorf("failed to parse MaxRetries %s: %w", maxRetries, err)
 		}
 		res.clientConfig.BackoffConfig.MaxRetries = maxRetriesValue
 	}
@@ -154,7 +153,7 @@ func parseConfig(cfg ConfigGetter) (*config, error) {
 	}
 	var level log.Level
 	if err := level.Set(logLevel); err != nil {
-		return nil, fmt.Errorf("invalid log level: %v", logLevel)
+		return nil, fmt.Errorf("invalid log level %v: %w", logLevel, err)
 	}
 	res.logLevel = level
 
@@ -238,7 +237,7 @@ func parseConfig(cfg ConfigGetter) (*config, error) {
 	if queueSegmentSize != "" {
 		res.bufferConfig.dqueConfig.queueSegmentSize, err = strconv.Atoi(queueSegmentSize)
 		if err != nil {
-			return nil, fmt.Errorf("impossible to convert string to integer DqueSegmentSize: %v", queueSegmentSize)
+			return nil, fmt.Errorf("impossible to convert string to integer DqueSegmentSize %v: %w", queueSegmentSize, err)
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Modify our fluentbit go client to not throw away error messages for invalid configuration values. Instead, wrap them with our existing descriptive messages.