### PR TITLE
[TSDB][bug] retain previously rotated tsdb heads for one cycle to serve queries

### DIFF
--- a/pkg/storage/stores/shipper/indexshipper/tsdb/head_manager.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/head_manager.go
@@ -144,26 +144,66 @@ func NewHeadManager(name string, logger log.Logger, dir string, metrics *Metrics
 	return m
 }
 
-func (m *HeadManager) loop() {
-	defer m.wg.Done()
-
-	buildPrev := func() error {
-		if m.prev == nil {
-			return nil
-		}
-
-		if err := m.buildTSDBFromHead(m.prevHeads); err != nil {
-			return err
-		}
-
-		// Now that the tsdbManager has the updated TSDBs, we can remove our references
-		m.mtx.Lock()
-		defer m.mtx.Unlock()
-		m.prevHeads = nil
-		m.prev = nil
-
+func (m *HeadManager) buildPrev() error {
+	if m.prev == nil {
 		return nil
 	}
+
+	if err := m.buildTSDBFromHead(m.prevHeads); err != nil {
+		return err
+	}
+
+	// Now that the tsdbManager has the updated TSDBs, we can remove our references
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+	// We nil-out the previous wal to signal that we've built the TSDBs from it successfully.
+	// We don't nil-out the heads because we need to keep the them around
+	// in order to serve queries for the recently rotated out period until
+	// the index-gws|queriers have time to download the new TSDBs
+	m.prev = nil
+
+	return nil
+}
+
+// tick handles one iteration for `loop()`. It builds new heads,
+// cleans up previous heads, and performs rotations.
+func (m *HeadManager) tick(now time.Time) {
+	// retry tsdb build failures from previous run
+	if err := m.buildPrev(); err != nil {
+		level.Error(m.log).Log(
+			"msg", "failed building tsdb head",
+			"period", m.period.PeriodFor(m.prev.initialized),
+			"err", err,
+		)
+		// rotating head without building prev would result in loss of index for that period (until restart)
+		return
+	}
+
+	if activePeriod := m.period.PeriodFor(m.activeHeads.start); m.period.PeriodFor(now) > activePeriod {
+		if err := m.Rotate(now); err != nil {
+			m.metrics.headRotations.WithLabelValues(statusFailure).Inc()
+			level.Error(m.log).Log(
+				"msg", "failed rotating tsdb head",
+				"period", activePeriod,
+				"err", err,
+			)
+			return
+		}
+		m.metrics.headRotations.WithLabelValues(statusSuccess).Inc()
+	}
+
+	// build tsdb from rotated-out period
+	if err := m.buildPrev(); err != nil {
+		level.Error(m.log).Log(
+			"msg", "failed building tsdb head",
+			"period", m.period.PeriodFor(m.prev.initialized),
+			"err", err,
+		)
+	}
+}
+
+func (m *HeadManager) loop() {
+	defer m.wg.Done()
 
 	ticker := time.NewTicker(defaultRotationCheckPeriod)
 	defer ticker.Stop()
@@ -171,39 +211,8 @@ func (m *HeadManager) loop() {
 	for {
 		select {
 		case <-ticker.C:
-			// retry tsdb build failures from previous run
-			if err := buildPrev(); err != nil {
-				level.Error(m.log).Log(
-					"msg", "failed building tsdb head",
-					"period", m.period.PeriodFor(m.prev.initialized),
-					"err", err,
-				)
-				// rotating head without building prev would result in loss of index for that period (until restart)
-				continue
-			}
-
 			now := time.Now()
-			if activePeriod := m.period.PeriodFor(m.activeHeads.start); m.period.PeriodFor(now) > activePeriod {
-				if err := m.Rotate(now); err != nil {
-					m.metrics.headRotations.WithLabelValues(statusFailure).Inc()
-					level.Error(m.log).Log(
-						"msg", "failed rotating tsdb head",
-						"period", activePeriod,
-						"err", err,
-					)
-					continue
-				}
-				m.metrics.headRotations.WithLabelValues(statusSuccess).Inc()
-			}
-
-			// build tsdb from rotated-out period
-			if err := buildPrev(); err != nil {
-				level.Error(m.log).Log(
-					"msg", "failed building tsdb head",
-					"period", m.period.PeriodFor(m.prev.initialized),
-					"err", err,
-				)
-			}
+			m.tick(now)
 		case <-m.cancel:
 			return
 		}

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/head_manager_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/head_manager_test.go
@@ -43,7 +43,7 @@ func newNoopTSDBManager(name, dir string) noopTSDBManager {
 }
 
 func (m noopTSDBManager) BuildFromHead(_ *tenantHeads) error {
-	panic("BuildFromHead not implemented")
+	return nil
 }
 
 func (m noopTSDBManager) BuildFromWALs(_ time.Time, wals []WALIdentifier, _ bool) error {
@@ -251,6 +251,61 @@ func Test_HeadManager_RecoverHead(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, 1, len(grp.wals))
 	require.Nil(t, recoverHead(mgr.name, mgr.dir, mgr.activeHeads, grp.wals, false))
+
+	for _, c := range cases {
+		refs, err := mgr.GetChunkRefs(
+			context.Background(),
+			c.User,
+			0, math.MaxInt64,
+			nil, nil,
+			labels.MustNewMatcher(labels.MatchRegexp, "foo", ".+"),
+		)
+		require.Nil(t, err)
+		require.Equal(t, chunkMetasToChunkRefs(c.User, c.Fingerprint, c.Chunks), refs)
+	}
+
+}
+
+// test head still serves data for the most recently rotated period.
+func Test_HeadManager_QueryAfterRotate(t *testing.T) {
+	now := time.Now()
+	dir := t.TempDir()
+	cases := []struct {
+		Labels      labels.Labels
+		Fingerprint uint64
+		Chunks      []index.ChunkMeta
+		User        string
+	}{
+		{
+			User:        "tenant1",
+			Labels:      mustParseLabels(`{foo="bar", bazz="buzz"}`),
+			Fingerprint: mustParseLabels(`{foo="bar", bazz="buzz"}`).Hash(),
+			Chunks: []index.ChunkMeta{
+				{
+					MinTime:  1,
+					MaxTime:  10,
+					Checksum: 3,
+				},
+			},
+		},
+	}
+
+	storeName := "store_2010-10-10"
+	mgr := NewHeadManager(storeName, log.NewNopLogger(), dir, NewMetrics(nil), newNoopTSDBManager(storeName, dir))
+	// This bit is normally handled by the Start() fn, but we're testing a smaller surface area
+	// so ensure our dirs exist
+	for _, d := range managerRequiredDirs(storeName, dir) {
+		require.Nil(t, util.EnsureDirectory(d))
+	}
+	require.Nil(t, mgr.Rotate(now)) // initialize head (usually done by Start())
+
+	// add data for both tenants
+	for _, tc := range cases {
+		require.Nil(t, mgr.Append(tc.User, tc.Labels, tc.Labels.Hash(), tc.Chunks))
+	}
+
+	nextPeriod := time.Now().Add(time.Duration(mgr.period))
+	mgr.tick(nextPeriod) // synthetic tick to rotate head
 
 	for _, c := range cases {
 		refs, err := mgr.GetChunkRefs(


### PR DESCRIPTION
This PR ensures we retain previous TSDB heads on ingesters for one cycle (15m) in order to serve index queries while waiting for index-gws or queriers to sync it from storage. This bug hadn't surfaced yet (for us) because we've historically used ~6m `chunk-retain` periods which masked this problem (chunks were kept around so we didn't see read gaps). Fixing this bug should allow us to avoid retaining chunks post-flush in ingester memory in TSDB since it doesn't utilize the index-cache (which was the other reason for retaining chunks in memory).

This is very attractive because it allows us to reduce memory pressure in ingesters as well as reduces the data they query since now ingesters will only return the chunk references. This allows queriers to download chunks directly rather than ingesters iterating the chunk data for flushed chunks themselves.

Also does some refactoring to make testing validation easier.