### PR TITLE
Fixed permission issue on tmp folder when deploying loki components with operator.

### DIFF
--- a/cmd/loki/Dockerfile
+++ b/cmd/loki/Dockerfile
@@ -15,7 +15,7 @@ RUN addgroup -g 10001 -S loki && \
     adduser -u 10001 -S loki -G loki
 RUN mkdir -p /loki/rules && \
     mkdir -p /loki/rules-temp && \
-    chown -R loki:loki /etc/loki /loki
+    chown -R loki:loki /etc/loki /loki /tmp
 
 USER 10001
 EXPOSE 3100


### PR DESCRIPTION
**What this PR does / why we need it**:

Added Dockerfile command to change owner from root to loki on the tmp folder. This is needed for all StatefulSet (like ingester, compactor, index-gateway and ruler) components. Related to #11631.

**Which issue(s) this PR fixes**:
Fixes #11631

**Special notes for your reviewer**:

Added chown command to change owner from root to loki.

**Checklist**
- [ X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
