### PR TITLE
fixes seek in bloom blocks to correctly return the first fp >= target_fp

### DIFF
--- a/pkg/storage/bloom/v1/builder_test.go
+++ b/pkg/storage/bloom/v1/builder_test.go
@@ -235,7 +235,8 @@ func TestBlockReset(t *testing.T) {
 			rounds[i] = append(rounds[i], querier.At().Series.Fingerprint)
 		}
 
-		querier.Seek(0) // reset at end
+		err = querier.Seek(0) // reset at end
+		require.Nil(t, err)
 	}
 
 	require.Equal(t, rounds[0], rounds[1])

--- a/pkg/storage/bloom/v1/builder_test.go
+++ b/pkg/storage/bloom/v1/builder_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/loki/pkg/chunkenc"
@@ -192,4 +193,50 @@ func TestMergeBuilder(t *testing.T) {
 		NewSliceIter[*SeriesWithBloom](PointerSlice(data)),
 		querier,
 	)
+}
+
+func TestBlockReset(t *testing.T) {
+	numSeries := 100
+	numKeysPerSeries := 10000
+	data, _ := mkBasicSeriesWithBlooms(numSeries, numKeysPerSeries, 1, 0xffff, 0, 10000)
+
+	indexBuf := bytes.NewBuffer(nil)
+	bloomsBuf := bytes.NewBuffer(nil)
+	writer := NewMemoryBlockWriter(indexBuf, bloomsBuf)
+	reader := NewByteReader(indexBuf, bloomsBuf)
+
+	schema := Schema{
+		version:     DefaultSchemaVersion,
+		encoding:    chunkenc.EncSnappy,
+		nGramLength: 10,
+		nGramSkip:   2,
+	}
+
+	builder, err := NewBlockBuilder(
+		BlockOptions{
+			schema:         schema,
+			SeriesPageSize: 100,
+			BloomPageSize:  10 << 10,
+		},
+		writer,
+	)
+
+	require.Nil(t, err)
+	itr := NewSliceIter[SeriesWithBloom](data)
+	_, err = builder.BuildFrom(itr)
+	require.Nil(t, err)
+	block := NewBlock(reader)
+	querier := NewBlockQuerier(block)
+
+	rounds := make([][]model.Fingerprint, 2)
+
+	for i := 0; i < len(rounds); i++ {
+		for querier.Next() {
+			rounds[i] = append(rounds[i], querier.At().Series.Fingerprint)
+		}
+
+		querier.Seek(0) // reset at end
+	}
+
+	require.Equal(t, rounds[0], rounds[1])
 }

--- a/pkg/storage/bloom/v1/index.go
+++ b/pkg/storage/bloom/v1/index.go
@@ -297,8 +297,9 @@ func (d *SeriesPageDecoder) Next() bool {
 }
 
 func (d *SeriesPageDecoder) Seek(fp model.Fingerprint) {
-	if fp > d.header.ThroughFp || fp < d.header.FromFp {
-		// shortcut: we know the fingerprint is not in this page
+	if fp > d.header.ThroughFp {
+		// shortcut: we know the fingerprint is too large so nothing in this page
+		// will match the seek call, which returns the first found fingerprint >= fp.
 		// so masquerade the index as if we've already iterated through
 		d.i = d.header.NumSeries
 	}

--- a/pkg/storage/bloom/v1/index_querier.go
+++ b/pkg/storage/bloom/v1/index_querier.go
@@ -55,7 +55,7 @@ func (it *LazySeriesIter) Seek(fp model.Fingerprint) error {
 	page := it.b.index.pageHeaders[desiredPage]
 
 	switch {
-	case desiredPage == len(it.b.index.pageHeaders), page.FromFp > fp:
+	case desiredPage == len(it.b.index.pageHeaders):
 		// no overlap exists, either because no page was found with a throughFP >= fp
 		// or because the first page that was found has a fromFP > fp,
 		// meaning successive pages would also have a fromFP > fp


### PR DESCRIPTION
While debugging some unrelated code, I found that `Seek` was improperly implemented. It should return the first value greater or equal than the target. Previously it would cause iterators to return different values when reset.