### PR TITLE
jsonnet: fix unicode quotes in jsonnet to avoid tools failing to parse it properly

### DIFF
--- a/production/ksonnet/loki/gateway.libsonnet
+++ b/production/ksonnet/loki/gateway.libsonnet
@@ -48,7 +48,7 @@ local k = import 'ksonnet-util/kausal.libsonnet';
 
           server {
             listen               80;
-            auth_basic           “Prometheus”;
+            auth_basic           "Prometheus";
             auth_basic_user_file /etc/nginx/secrets/.htpasswd;
             proxy_set_header     X-Scope-OrgID %(gateway_tenant_id)s;
 


### PR DESCRIPTION
**What this PR does / why we need it**:
We have a linter in place in our internal deployment tooling to catch the usage of Unicode quotes because it has caused some issues due to shells/tooling not recognizing them. The linter has caught one such instance in the jsonnet in the Loki repo, which is fixed in this PR.