### PR TITLE
Make bloom gateway tasks cancelable (and other fixes)

### DIFF
--- a/integration/loki_micro_services_test.go
+++ b/integration/loki_micro_services_test.go
@@ -1079,7 +1079,7 @@ func TestBloomFiltersEndToEnd(t *testing.T) {
 	tenantID := randStringRunes()
 
 	clu := cluster.New(
-		level.DebugValue(),
+		level.WarnValue(),
 		cluster.SchemaWithTSDB,
 		func(c *cluster.Cluster) { c.SetSchemaVer("v13") },
 	)

--- a/pkg/bloomgateway/bloomgateway.go
+++ b/pkg/bloomgateway/bloomgateway.go
@@ -322,7 +322,7 @@ func (g *Gateway) FilterChunkRefs(ctx context.Context, req *logproto.FilterChunk
 	}
 
 	g.activeUsers.UpdateUserTimestamp(tenantID, time.Now())
-	level.Info(g.logger).Log("msg", "enqueue task", "task", task.ID)
+	level.Info(g.logger).Log("msg", "enqueue task", "task", task.ID, "closed", task.closed)
 	g.queue.Enqueue(tenantID, []string{}, task, func() {
 		// When enqueuing, we also add the task to the pending tasks
 		g.pendingTasks.Add(task.ID, task)

--- a/pkg/bloomgateway/bloomgateway_test.go
+++ b/pkg/bloomgateway/bloomgateway_test.go
@@ -394,6 +394,64 @@ func TestBloomGateway_FilterChunkRefs(t *testing.T) {
 	})
 }
 
+func TestBloomGateway_RemoveNotMatchingChunks(t *testing.T) {
+	t.Run("removing chunks partially", func(t *testing.T) {
+		req := &logproto.FilterChunkRefRequest{
+			Refs: []*logproto.GroupedChunkRefs{
+				{Fingerprint: 0x00, Tenant: "fake", Refs: []*logproto.ShortRef{
+					{Checksum: 0x1},
+					{Checksum: 0x2},
+					{Checksum: 0x3},
+					{Checksum: 0x4},
+					{Checksum: 0x5},
+				}},
+			},
+		}
+		res := v1.Output{
+			Fp: 0x00, Removals: v1.ChunkRefs{
+				{Checksum: 0x2},
+				{Checksum: 0x4},
+			},
+		}
+		expected := &logproto.FilterChunkRefRequest{
+			Refs: []*logproto.GroupedChunkRefs{
+				{Fingerprint: 0x00, Tenant: "fake", Refs: []*logproto.ShortRef{
+					{Checksum: 0x1},
+					{Checksum: 0x3},
+					{Checksum: 0x5},
+				}},
+			},
+		}
+		removeNotMatchingChunks(req, res, log.NewNopLogger())
+		require.Equal(t, expected, req)
+	})
+
+	t.Run("removing all chunks removed fingerprint ref", func(t *testing.T) {
+		req := &logproto.FilterChunkRefRequest{
+			Refs: []*logproto.GroupedChunkRefs{
+				{Fingerprint: 0x00, Tenant: "fake", Refs: []*logproto.ShortRef{
+					{Checksum: 0x1},
+					{Checksum: 0x2},
+					{Checksum: 0x3},
+				}},
+			},
+		}
+		res := v1.Output{
+			Fp: 0x00, Removals: v1.ChunkRefs{
+				{Checksum: 0x1},
+				{Checksum: 0x2},
+				{Checksum: 0x2},
+			},
+		}
+		expected := &logproto.FilterChunkRefRequest{
+			Refs: []*logproto.GroupedChunkRefs{},
+		}
+		removeNotMatchingChunks(req, res, log.NewNopLogger())
+		require.Equal(t, expected, req)
+	})
+
+}
+
 func createBlockQueriers(t *testing.T, numBlocks int, from, through model.Time, minFp, maxFp model.Fingerprint) ([]bloomshipper.BlockQuerierWithFingerprintRange, [][]v1.SeriesWithBloom) {
 	t.Helper()
 	step := (maxFp - minFp) / model.Fingerprint(numBlocks)

--- a/pkg/bloomgateway/bloomgateway_test.go
+++ b/pkg/bloomgateway/bloomgateway_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/grafana/dskit/ring"
 	"github.com/grafana/dskit/services"
 	"github.com/grafana/dskit/user"
+	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
@@ -183,6 +184,58 @@ func TestBloomGateway_FilterChunkRefs(t *testing.T) {
 		WorkerConcurrency:       4,
 		MaxOutstandingPerTenant: 1024,
 	}
+
+	t.Run("shipper error is propagated", func(t *testing.T) {
+		reg := prometheus.NewRegistry()
+		gw, err := New(cfg, schemaCfg, storageCfg, limits, ss, cm, logger, reg)
+		require.NoError(t, err)
+
+		now := mktime("2023-10-03 10:00")
+
+		bqs, data := createBlockQueriers(t, 10, now.Add(-24*time.Hour), now, 0, 1024)
+		mockStore := newMockBloomStore(bqs)
+		mockStore.err = errors.New("failed to fetch block")
+		gw.bloomShipper = mockStore
+
+		err = gw.initServices()
+		require.NoError(t, err)
+
+		err = services.StartAndAwaitRunning(context.Background(), gw)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			err = services.StopAndAwaitTerminated(context.Background(), gw)
+			require.NoError(t, err)
+		})
+
+		chunkRefs := createQueryInputFromBlockData(t, tenantID, data, 100)
+
+		var wg sync.WaitGroup
+		for i := 0; i < 100; i++ {
+			time.Sleep(10 * time.Millisecond)
+			wg.Add(1)
+			go func(idx int) {
+				defer wg.Done()
+				offset := now.Add(time.Duration(idx) * time.Hour)
+				req := &logproto.FilterChunkRefRequest{
+					From:    offset.Add(-24 * time.Hour),
+					Through: offset,
+					Refs:    groupRefs(t, chunkRefs),
+					Filters: []syntax.LineFilter{
+						{Ty: labels.MatchEqual, Match: "does not match"},
+					},
+				}
+
+				ctx, cancelFn := context.WithTimeout(context.Background(), 2000*time.Millisecond)
+				ctx = user.InjectOrgID(ctx, tenantID)
+				t.Cleanup(cancelFn)
+
+				_, err := gw.FilterChunkRefs(ctx, req)
+				require.ErrorContains(t, err, "waiting for results: failed to fetch block")
+			}(i)
+		}
+		// waits 6s
+		wg.Wait()
+	})
 
 	t.Run("request cancellation does not result in channel locking", func(t *testing.T) {
 		reg := prometheus.NewRegistry()

--- a/pkg/bloomgateway/bloomgateway_test.go
+++ b/pkg/bloomgateway/bloomgateway_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -182,6 +183,59 @@ func TestBloomGateway_FilterChunkRefs(t *testing.T) {
 		WorkerConcurrency:       4,
 		MaxOutstandingPerTenant: 1024,
 	}
+
+	t.Run("request cancellation does not result in channel locking", func(t *testing.T) {
+		reg := prometheus.NewRegistry()
+		gw, err := New(cfg, schemaCfg, storageCfg, limits, ss, cm, logger, reg)
+		require.NoError(t, err)
+
+		now := mktime("2023-10-03 10:00")
+
+		bqs, data := createBlockQueriers(t, 10, now.Add(-24*time.Hour), now, 0, 1024)
+		mockStore := newMockBloomStore(bqs)
+		mockStore.delay = 250 * time.Millisecond
+		gw.bloomShipper = mockStore
+
+		err = gw.initServices()
+		require.NoError(t, err)
+
+		err = services.StartAndAwaitRunning(context.Background(), gw)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			err = services.StopAndAwaitTerminated(context.Background(), gw)
+			require.NoError(t, err)
+		})
+
+		chunkRefs := createQueryInputFromBlockData(t, tenantID, data, 100)
+
+		var wg sync.WaitGroup
+		for i := 0; i < 100; i++ {
+			time.Sleep(10 * time.Millisecond)
+			wg.Add(1)
+			go func(idx int) {
+				defer wg.Done()
+				offset := now.Add(time.Duration(idx) * time.Hour)
+				req := &logproto.FilterChunkRefRequest{
+					From:    offset.Add(-24 * time.Hour),
+					Through: offset,
+					Refs:    groupRefs(t, chunkRefs),
+					Filters: []syntax.LineFilter{
+						{Ty: labels.MatchEqual, Match: "does not match"},
+					},
+				}
+
+				ctx, cancelFn := context.WithTimeout(context.Background(), 2000*time.Millisecond)
+				ctx = user.InjectOrgID(ctx, tenantID)
+				t.Cleanup(cancelFn)
+
+				_, err = gw.FilterChunkRefs(ctx, req)
+				require.ErrorContains(t, err, context.DeadlineExceeded.Error())
+			}(i)
+		}
+
+		// waits 6s
+		wg.Wait()
+	})
 
 	t.Run("returns unfiltered chunk refs if no filters provided", func(t *testing.T) {
 		reg := prometheus.NewRegistry()
@@ -370,12 +424,17 @@ func newMockBloomStore(bqs []bloomshipper.BlockQuerierWithFingerprintRange) *moc
 
 type mockBloomStore struct {
 	bqs []bloomshipper.BlockQuerierWithFingerprintRange
+	// mock how long it takes to serve block queriers
+	delay time.Duration
+	// mock response error when serving block queriers in ForEach
+	err error
 }
 
 var _ bloomshipper.Interface = &mockBloomStore{}
 
-// GetBlockRefs implements bloomshipper.Interface
+// GetBlockRefs implements bloomshipper.Store.
 func (s *mockBloomStore) GetBlockRefs(_ context.Context, tenant string, _, _ model.Time) ([]bloomshipper.BlockRef, error) {
+	time.Sleep(s.delay)
 	blocks := make([]bloomshipper.BlockRef, 0, len(s.bqs))
 	for i := range s.bqs {
 		blocks = append(blocks, bloomshipper.BlockRef{
@@ -392,8 +451,13 @@ func (s *mockBloomStore) GetBlockRefs(_ context.Context, tenant string, _, _ mod
 // Stop implements bloomshipper.Interface
 func (s *mockBloomStore) Stop() {}
 
-// Fetch implements bloomshipper.Interface
+// ForEach implements bloomshipper.Store.
 func (s *mockBloomStore) Fetch(_ context.Context, _ string, _ []bloomshipper.BlockRef, callback bloomshipper.ForEachBlockCallback) error {
+	if s.err != nil {
+		time.Sleep(s.delay)
+		return s.err
+	}
+
 	shuffled := make([]bloomshipper.BlockQuerierWithFingerprintRange, len(s.bqs))
 	_ = copy(shuffled, s.bqs)
 
@@ -403,7 +467,11 @@ func (s *mockBloomStore) Fetch(_ context.Context, _ string, _ []bloomshipper.Blo
 
 	for _, bq := range shuffled {
 		// ignore errors in the mock
-		_ = callback(bq.BlockQuerier, uint64(bq.MinFp), uint64(bq.MaxFp))
+		time.Sleep(s.delay)
+		err := callback(bq.BlockQuerier, uint64(bq.MinFp), uint64(bq.MaxFp))
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/pkg/bloomgateway/bloomgateway_test.go
+++ b/pkg/bloomgateway/bloomgateway_test.go
@@ -228,7 +228,7 @@ func TestBloomGateway_FilterChunkRefs(t *testing.T) {
 				ctx = user.InjectOrgID(ctx, tenantID)
 				t.Cleanup(cancelFn)
 
-				_, err = gw.FilterChunkRefs(ctx, req)
+				_, err := gw.FilterChunkRefs(ctx, req)
 				require.ErrorContains(t, err, context.DeadlineExceeded.Error())
 			}(i)
 		}

--- a/pkg/bloomgateway/multiplexing.go
+++ b/pkg/bloomgateway/multiplexing.go
@@ -122,7 +122,7 @@ func NewTask(ctx context.Context, tenantID string, req *logproto.FilterChunkRefR
 // Copy returns a copy of the existing task but with a new slice of chunks
 func (t Task) Copy(refs []*logproto.GroupedChunkRefs) Task {
 	return Task{
-		ID:     t.ID,
+		ID:     ulid.ULID{}, // discard original ID
 		Tenant: t.Tenant,
 		Request: &logproto.FilterChunkRefRequest{
 			From:    t.Request.From,

--- a/pkg/bloomgateway/multiplexing.go
+++ b/pkg/bloomgateway/multiplexing.go
@@ -113,8 +113,7 @@ func NewTask(ctx context.Context, tenantID string, req *logproto.FilterChunkRefR
 		ResCh:    resPipe.Snd(),
 		ctx:      ctx,
 		cancelFn: cancelFn,
-
-		closed: atomic.NewBool(false),
+		closed:   atomic.NewBool(false),
 	}
 
 	return task, resPipe.Rcv(), errPipe.Rcv(), nil

--- a/pkg/bloomgateway/util.go
+++ b/pkg/bloomgateway/util.go
@@ -15,7 +15,7 @@ import (
 )
 
 func getDayTime(ts model.Time) time.Time {
-	return time.Date(ts.Time().Year(), ts.Time().Month(), ts.Time().Day(), 0, 0, 0, 0, time.UTC)
+	return ts.Time().UTC().Truncate(Day)
 }
 
 // getFromThrough assumes a list of ShortRefs sorted by From time

--- a/pkg/bloomgateway/worker.go
+++ b/pkg/bloomgateway/worker.go
@@ -247,15 +247,15 @@ func (w *worker) stopping(err error) error {
 	return nil
 }
 
-func (w *worker) processBlocksWithCallback(ctx context.Context, tenant string, day time.Time, boundedRefs []boundedTasks) error {
-	blockRefs := make([]bloomshipper.BlockRef, 0, len(boundedRefs))
-	for _, b := range boundedRefs {
-		blockRefs = append(blockRefs, b.blockRef)
+func (w *worker) processBlocksWithCallback(ctx context.Context, tenant string, day time.Time, partitionedTasks []boundedTasks) error {
+	blockRefs := make([]bloomshipper.BlockRef, 0, len(partitionedTasks))
+	for _, pt := range partitionedTasks {
+		blockRefs = append(blockRefs, pt.blockRef)
 	}
 	return w.shipper.Fetch(ctx, tenant, blockRefs, func(bq *v1.BlockQuerier, minFp, maxFp uint64) error {
-		for _, b := range boundedRefs {
-			if b.blockRef.MinFingerprint == minFp && b.blockRef.MaxFingerprint == maxFp {
-				return w.processBlock(ctx, bq, day, b.tasks)
+		for _, pt := range partitionedTasks {
+			if pt.blockRef.MinFingerprint == minFp && pt.blockRef.MaxFingerprint == maxFp {
+				return w.processBlock(ctx, bq, day, pt.tasks)
 			}
 		}
 		return fmt.Errorf("no overlapping blocks for range %x-%x", minFp, maxFp)

--- a/pkg/bloomgateway/worker.go
+++ b/pkg/bloomgateway/worker.go
@@ -140,6 +140,11 @@ func (w *worker) running(ctx context.Context) error {
 			tasksByDay := make(map[time.Time][]Task)
 
 			for _, item := range items {
+				if item == nil {
+					// this should never happen, but it's a safety measure
+					w.queue.ReleaseRequests(items)
+					return errors.New("dequeued item is nil")
+				}
 				task, ok := item.(Task)
 				if !ok {
 					// This really should never happen, because only the bloom gateway itself can enqueue tasks.

--- a/pkg/bloomgateway/worker.go
+++ b/pkg/bloomgateway/worker.go
@@ -235,6 +235,7 @@ func (w *worker) running(ctx context.Context) error {
 			// close channels because everything is sent
 			for _, tasks := range tasksPerDay {
 				for _, task := range tasks {
+					level.Debug(w.logger).Log("msg", "close task", "task", task.ID, "closed", task.closed.Load())
 					task.Close()
 				}
 			}

--- a/pkg/bloomgateway/worker.go
+++ b/pkg/bloomgateway/worker.go
@@ -162,13 +162,14 @@ func (w *worker) running(ctx context.Context) error {
 					tasksByDay[fromDay] = append(tasksByDay[fromDay], task)
 				} else {
 					level.Debug(w.logger).Log("msg", "task spans across multiple days", "from", fromDay, "through", throughDay)
-					for i := fromDay; i.Before(throughDay); i = i.Add(24 * time.Hour) {
+					for i := fromDay; i.Before(throughDay); i = i.Add(Day) {
 						tasksByDay[i] = append(tasksByDay[i], task)
 					}
 				}
 			}
 
 			for day, tasks := range tasksByDay {
+
 				// Remove tasks that are already cancelled
 				tasks = slices.DeleteFunc(tasks, func(t Task) bool {
 					return t.Err() != nil

--- a/pkg/bloomgateway/worker.go
+++ b/pkg/bloomgateway/worker.go
@@ -145,7 +145,7 @@ func (w *worker) running(ctx context.Context) error {
 					w.queue.ReleaseRequests(items)
 					return errors.Errorf("failed to cast dequeued item to Task: %v", item)
 				}
-				level.Debug(w.logger).Log("msg", "dequeued task", "task", task.ID)
+				level.Debug(w.logger).Log("msg", "dequeued task", "task", task.ID, "closed", task.closed)
 				w.tasks.Delete(task.ID)
 
 				// check if task was already cancelled while it was waiting in the queue

--- a/pkg/storage/stores/shipper/bloomshipper/block_downloader_test.go
+++ b/pkg/storage/stores/shipper/bloomshipper/block_downloader_test.go
@@ -41,7 +41,7 @@ func Test_blockDownloader_downloadBlocks(t *testing.T) {
 		},
 	}, blockClient, overrides, log.NewNopLogger(), prometheus.DefaultRegisterer)
 	require.NoError(t, err)
-	blocksCh, errorsCh := downloader.downloadBlocks(context.Background(), "fake", blockReferences)
+	blocksCh, errorsCh, _ := downloader.fetch(context.Background(), "fake", blockReferences)
 	downloadedBlocks := make(map[string]any, len(blockReferences))
 	done := make(chan bool)
 	go func() {
@@ -110,7 +110,7 @@ func Test_blockDownloader_downloadBlock(t *testing.T) {
 			t.Cleanup(downloader.stop)
 			require.NoError(t, err)
 
-			blocksCh, errorsCh := downloader.downloadBlocks(context.Background(), "fake", blockReferences)
+			blocksCh, errorsCh, _ := downloader.fetch(context.Background(), "fake", blockReferences)
 			downloadedBlocks := make(map[string]any, len(blockReferences))
 			done := make(chan bool)
 			go func() {
@@ -131,7 +131,7 @@ func Test_blockDownloader_downloadBlock(t *testing.T) {
 			require.Len(t, downloadedBlocks, 20, "all 20 block must be downloaded")
 			require.Equal(t, int32(20), blockClient.getBlockCalls.Load())
 
-			blocksCh, errorsCh = downloader.downloadBlocks(context.Background(), "fake", blockReferences)
+			blocksCh, errorsCh, _ = downloader.fetch(context.Background(), "fake", blockReferences)
 			downloadedBlocks = make(map[string]any, len(blockReferences))
 			done = make(chan bool)
 			go func() {
@@ -203,7 +203,7 @@ func Test_blockDownloader_downloadBlock_deduplication(t *testing.T) {
 				waitGroup.Add(1)
 				go func() {
 					defer waitGroup.Done()
-					blocksCh, errCh := downloader.downloadBlocks(context.Background(), "fake", blockReferences)
+					blocksCh, errCh, _ := downloader.fetch(context.Background(), "fake", blockReferences)
 					var err error
 					select {
 					case <-blocksCh:

--- a/pkg/storage/stores/shipper/bloomshipper/shipper.go
+++ b/pkg/storage/stores/shipper/bloomshipper/shipper.go
@@ -76,7 +76,11 @@ func (s *Shipper) GetBlockRefs(ctx context.Context, tenantID string, from, throu
 func (s *Shipper) Fetch(ctx context.Context, tenantID string, blocks []BlockRef, callback ForEachBlockCallback) error {
 	cancelContext, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
-	blocksChannel, errorsChannel := s.blockDownloader.downloadBlocks(cancelContext, tenantID, blocks)
+
+	resCh, errCh, err := s.blockDownloader.fetch(cancelContext, tenantID, blocks)
+	if err != nil {
+		return err
+	}
 
 	// track how many blocks are still remaning to be downloaded
 	remaining := len(blocks)
@@ -85,10 +89,9 @@ func (s *Shipper) Fetch(ctx context.Context, tenantID string, blocks []BlockRef,
 		select {
 		case <-ctx.Done():
 			return fmt.Errorf("failed to fetch blocks: %w", ctx.Err())
-		case result, sentBeforeClosed := <-blocksChannel:
-			if !sentBeforeClosed {
-				return nil
-			}
+		case err := <-errCh:
+			return fmt.Errorf("failed to fetch blocks: %w", err)
+		case result := <-resCh:
 			err := runCallback(callback, result)
 			if err != nil {
 				return err
@@ -97,8 +100,6 @@ func (s *Shipper) Fetch(ctx context.Context, tenantID string, blocks []BlockRef,
 			if remaining == 0 {
 				return nil
 			}
-		case err := <-errorsChannel:
-			return fmt.Errorf("error downloading blocks : %w", err)
 		}
 	}
 }


### PR DESCRIPTION
**Why we need it**:

A bloom gateway request calling `FilterChunkRefs` that timed out caused a deadlock of the workers, because when the request context is cancelled, the request returned, but the task continued to process until the block querier tried to write to the results channel. That writing was blocked, because the request that was supposed to read from the results channel to gather the result was gone.

**How is is solved**:

The PR introduces two changes:

1) The request context is also passed when creating a new `Task`, which allows to check the cancellation of a request also in the task.
2) The channels of the `Task` are replaced by a "pipe channel", which consists of a sender channel and a receiver channel. The pipe reads from the sender channel until it is closed, and forwards the received item to the receiver channel, but only if the internal context of the pipe isn't closed.
3) In the worker, when dequeuing and processing the tests, the context of tasks is checked for error, to shortcut operations and return errors early.

---

Further smaller changes/fixes:

1) Fix a potential `index out of bounds` panic in the code that removes filtered out chunk refs from th original request.
2) Make sure that the `DequeueMany` call on the task queue returns successive tasks based on their enqueue order.
3) Do not remove cancelled task from task list once they have been partitioned by fingerprint ranged.