### PR TITLE
Fix jsonnet config for bloom gateway blocks cache

### DIFF
--- a/production/ksonnet/loki/bloom-gateway.libsonnet
+++ b/production/ksonnet/loki/bloom-gateway.libsonnet
@@ -47,7 +47,7 @@
               blocks_cache: {
                 enabled: true,
                 max_size_mb: error 'set bloom_shipper.blocks_cache.max_size_mb to ~80% of available disk size',
-                ttl: 3600 * 24,  // 24h
+                ttl: '24h',
               },
             },
           },


### PR DESCRIPTION
**What this PR does / why we need it**:

The value is supposed to be a time.Duration value, rather than an int value for seconds.

This changes fixes the rather small cache TTL.