### PR TITLE
Extend `TestPartitionFingerprintRange` test case

### DIFF
--- a/pkg/bloomgateway/util.go
+++ b/pkg/bloomgateway/util.go
@@ -73,16 +73,6 @@ func convertToChunkRefs(refs []*logproto.ShortRef) v1.ChunkRefs {
 	return result
 }
 
-// getFirstLast returns the first and last item of a fingerprint slice
-// It assumes an ascending sorted list of fingerprints.
-func getFirstLast[T any](s []T) (T, T) {
-	var zero T
-	if len(s) == 0 {
-		return zero, zero
-	}
-	return s[0], s[len(s)-1]
-}
-
 type boundedTasks struct {
 	blockRef bloomshipper.BlockRef
 	tasks    []Task

--- a/pkg/bloomgateway/util_test.go
+++ b/pkg/bloomgateway/util_test.go
@@ -37,38 +37,68 @@ func mkBlockRef(minFp, maxFp uint64) bloomshipper.BlockRef {
 }
 
 func TestPartitionFingerprintRange(t *testing.T) {
-	seriesPerBound := 100
-	bounds := []bloomshipper.BlockRef{
-		mkBlockRef(0, 99),
-		mkBlockRef(100, 199),
-		mkBlockRef(200, 299),
-		mkBlockRef(300, 399), // one out of bounds block
-	}
-
-	nTasks := 4
-	nSeries := 300
-	tasks := make([]Task, nTasks)
-	for i := 0; i < nSeries; i++ {
-		if tasks[i%4].Request == nil {
-			tasks[i%4].Request = &logproto.FilterChunkRefRequest{}
+	t.Run("consecutive block ranges", func(t *testing.T) {
+		bounds := []bloomshipper.BlockRef{
+			mkBlockRef(0, 99),    // out of bounds block
+			mkBlockRef(100, 199), // contains partially [150..199]
+			mkBlockRef(200, 299), // contains fully [200..299]
+			mkBlockRef(300, 399), // contains partially [300..349]
+			mkBlockRef(400, 499), // out of bounds block
 		}
-		tasks[i%4].Request.Refs = append(tasks[i%nTasks].Request.Refs, &logproto.GroupedChunkRefs{Fingerprint: uint64(i)})
-	}
 
-	results := partitionFingerprintRange(tasks, bounds)
-	require.Equal(t, 3, len(results)) // ensure we only return bounds in range
-	for _, res := range results {
-		// ensure we have the right number of tasks per bound
-		for i := 0; i < nTasks; i++ {
-			require.Equal(t, seriesPerBound/nTasks, len(res.tasks[i].Request.Refs))
+		nTasks := 5
+		nSeries := 200
+		startFp := 150
+
+		tasks := make([]Task, nTasks)
+		for i := startFp; i < startFp+nSeries; i++ {
+			if tasks[i%nTasks].Request == nil {
+				tasks[i%nTasks].Request = &logproto.FilterChunkRefRequest{}
+			}
+			tasks[i%nTasks].Request.Refs = append(tasks[i%nTasks].Request.Refs, &logproto.GroupedChunkRefs{Fingerprint: uint64(i)})
 		}
-	}
 
-	// ensure bound membership
-	for i := 0; i < nSeries; i++ {
-		require.Equal(t,
-			&logproto.GroupedChunkRefs{Fingerprint: uint64(i)},
-			results[i/seriesPerBound].tasks[i%nTasks].Request.Refs[i%seriesPerBound/nTasks],
-		)
-	}
+		results := partitionFingerprintRange(tasks, bounds)
+		require.Equal(t, 3, len(results)) // ensure we only return bounds in range
+
+		actualFingerprints := make([]*logproto.GroupedChunkRefs, 0, nSeries)
+		expectedTaskRefs := []int{10, 20, 10}
+		for i, res := range results {
+			// ensure we have the right number of tasks per bound
+			require.Len(t, res.tasks, 5)
+			for _, task := range res.tasks {
+				require.Equal(t, expectedTaskRefs[i], len(task.Request.Refs))
+				actualFingerprints = append(actualFingerprints, task.Request.Refs...)
+			}
+		}
+
+		// ensure bound membership
+		expectedFingerprints := make([]*logproto.GroupedChunkRefs, nSeries)
+		for i := 0; i < nSeries; i++ {
+			expectedFingerprints[i] = &logproto.GroupedChunkRefs{Fingerprint: uint64(startFp + i)}
+		}
+
+		require.ElementsMatch(t, expectedFingerprints, actualFingerprints)
+	})
+
+	t.Run("inconsecutive block ranges", func(t *testing.T) {
+		bounds := []bloomshipper.BlockRef{
+			mkBlockRef(0, 89),
+			mkBlockRef(100, 189),
+			mkBlockRef(200, 289),
+		}
+
+		task := Task{Request: &logproto.FilterChunkRefRequest{}}
+		for i := 0; i < 300; i++ {
+			task.Request.Refs = append(task.Request.Refs, &logproto.GroupedChunkRefs{Fingerprint: uint64(i)})
+		}
+
+		results := partitionFingerprintRange([]Task{task}, bounds)
+		require.Equal(t, 3, len(results)) // ensure we only return bounds in range
+		for _, res := range results {
+			// ensure we have the right number of tasks per bound
+			require.Len(t, res.tasks, 1)
+			require.Len(t, res.tasks[0].Request.Refs, 90)
+		}
+	})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

The test cases now also cover partially out of bounds blocks as well as inconsecutive block ranges.