### PR TITLE
Bloom checksum work

### DIFF
--- a/pkg/storage/bloom/v1/bloom.go
+++ b/pkg/storage/bloom/v1/bloom.go
@@ -143,6 +143,7 @@ func (d *BloomPageDecoder) Err() error {
 
 type BloomPageHeader struct {
 	N, Offset, Len, DecompressedLen int
+	Hash                            uint32
 }
 
 func (h *BloomPageHeader) Encode(enc *encoding.Encbuf) {
@@ -150,6 +151,7 @@ func (h *BloomPageHeader) Encode(enc *encoding.Encbuf) {
 	enc.PutUvarint(h.Offset)
 	enc.PutUvarint(h.Len)
 	enc.PutUvarint(h.DecompressedLen)
+	enc.PutBE32(h.Hash)
 }
 
 func (h *BloomPageHeader) Decode(dec *encoding.Decbuf) error {
@@ -157,6 +159,7 @@ func (h *BloomPageHeader) Decode(dec *encoding.Decbuf) error {
 	h.Offset = dec.Uvarint()
 	h.Len = dec.Uvarint()
 	h.DecompressedLen = dec.Uvarint()
+	h.Hash = dec.Be32()
 	return dec.Err()
 }
 

--- a/pkg/storage/bloom/v1/builder.go
+++ b/pkg/storage/bloom/v1/builder.go
@@ -99,7 +99,7 @@ func writeInt32(h hash.Hash32, value int32) {
 func writeUInt64(h hash.Hash32, value uint64) {
 	// Convert int32 to little-endian byte slice
 	bytes := make([]byte, 8)
-	binary.BigEndian.PutUint64(bytes, uint64(value))
+	binary.BigEndian.PutUint64(bytes, value)
 	h.Write(bytes)
 }
 

--- a/pkg/storage/bloom/v1/builder.go
+++ b/pkg/storage/bloom/v1/builder.go
@@ -233,6 +233,7 @@ func (b *BloomBlockBuilder) flushPage() error {
 		Offset:          b.offset,
 		Len:             compressedLen,
 		DecompressedLen: decompressedLen,
+		Hash:            crc32Hash.Sum32(),
 	}
 	b.pages = append(b.pages, header)
 	b.offset += compressedLen

--- a/pkg/storage/bloom/v1/builder_test.go
+++ b/pkg/storage/bloom/v1/builder_test.go
@@ -564,7 +564,7 @@ func TestMergeBuilder_Roundtrip(t *testing.T) {
 
 	checksum, err := mb.Build(builder)
 	require.Nil(t, err)
-	require.Equal(t, uint32(0x779633b5), checksum)
+	require.Equal(t, uint32(0xd47103f5), checksum)
 
 	// ensure the new block contains one copy of all the data
 	// by comparing it against an iterator over the source data

--- a/pkg/storage/bloom/v1/builder_test.go
+++ b/pkg/storage/bloom/v1/builder_test.go
@@ -242,6 +242,75 @@ func TestBlockReset(t *testing.T) {
 	require.Equal(t, rounds[0], rounds[1])
 }
 
+func TestBlockChecksums(t *testing.T) {
+	testCases := []struct {
+		name         string
+		fingerprint1 model.Fingerprint
+		fingerprint2 model.Fingerprint
+		timestamp1   model.Time
+		timestamp2   model.Time
+		expectEqual  bool
+	}{
+		{"DifferentFPsSameTs", 0x0000, 0x1111, 0, 0, false},
+		{"SameFPsDifferentTs", 0xffff, 0xffff, 0, 123400, false},
+		{"DifferentFPsDifferentTs", 0x0000, 0x11aa, 0, 10000, false},
+		{"SameFPsSameTs", 0xffff, 0xffff, 0, 0, true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			tmpDir2 := t.TempDir()
+			writer := NewDirectoryBlockWriter(tmpDir)
+			writer2 := NewDirectoryBlockWriter(tmpDir2)
+
+			schema := Schema{
+				version:     DefaultSchemaVersion,
+				encoding:    chunkenc.EncSnappy,
+				nGramLength: 10,
+				nGramSkip:   2,
+			}
+
+			builder, err := NewBlockBuilder(
+				BlockOptions{
+					schema:         schema,
+					SeriesPageSize: 100,
+					BloomPageSize:  10 << 10,
+				},
+				writer,
+			)
+			require.Nil(t, err)
+
+			builder2, err := NewBlockBuilder(
+				BlockOptions{
+					schema:         schema,
+					SeriesPageSize: 100,
+					BloomPageSize:  10 << 10,
+				},
+				writer2,
+			)
+			require.Nil(t, err)
+
+			data1, _ := mkBasicSeriesWithBlooms(4, 100, 0, tc.fingerprint1, tc.timestamp1, 10000)
+			data2, _ := mkBasicSeriesWithBlooms(4, 100, 0, tc.fingerprint2, tc.timestamp2, 10000)
+
+			itr1 := NewSliceIter[SeriesWithBloom](data1)
+			checksum1, err := builder.BuildFrom(itr1)
+			require.NoError(t, err)
+
+			itr2 := NewSliceIter[SeriesWithBloom](data2)
+			checksum2, err := builder2.BuildFrom(itr2)
+			require.NoError(t, err)
+
+			if tc.expectEqual {
+				require.Equal(t, checksum1, checksum2, "checksums should be equal")
+			} else {
+				require.NotEqual(t, checksum1, checksum2, "checksums should not be equal")
+			}
+		})
+	}
+}
+
 // This test is a basic roundtrip test for the merge builder.
 // It creates one set of blocks with the same (duplicate) data, and another set of blocks with
 // disjoint data. It then merges the two sets of blocks and ensures that the merged blocks contain

--- a/pkg/storage/bloom/v1/builder_test.go
+++ b/pkg/storage/bloom/v1/builder_test.go
@@ -564,7 +564,7 @@ func TestMergeBuilder_Roundtrip(t *testing.T) {
 
 	checksum, err := mb.Build(builder)
 	require.Nil(t, err)
-	require.Equal(t, uint32(0xd47103f5), checksum)
+	require.Equal(t, uint32(0x248b4c2d), checksum)
 
 	// ensure the new block contains one copy of all the data
 	// by comparing it against an iterator over the source data


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously, MergeBuilder.Build() used a checksum of the bloom page headers.  This PR does multiple things in relation to checksums, including:
- Augmenting the bloom page header to have a checksum of the data of the bloom page (in order to capture the actual content of the blooms).  As a result, a bloom page with a single bloom should now differ from another bloom page with a single bloom, unless the contents of the two blooms are exactly equal.
- Add checksum calculations for the block options
- Return the checksums when Close()ing the series data
- Augmenting the checksum calculations to include the checksum of the bloom pages, the series pages, and the block options

This will render existing bloom data invalid.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
