### PR TITLE
Update patch version in docs and yaml files for v2.9.4

### DIFF
--- a/docs/sources/get-started/deployment-modes.md
+++ b/docs/sources/get-started/deployment-modes.md
@@ -78,7 +78,7 @@ For release 2.9 the components are:
 TIP: You can see the complete list of targets for your version of Loki by running Loki with the flag `-list-targets`, for example:
 
 ```bash
-docker run docker.io/grafana/loki:2.9.2 -config.file=/etc/loki/local-config.yaml -list-targets
+docker run docker.io/grafana/loki:2.9.4 -config.file=/etc/loki/local-config.yaml -list-targets
 ```
 ![Microservices mode diagram](../microservices-mode.png "Microservices mode")
 

--- a/docs/sources/operations/loki-canary/_index.md
+++ b/docs/sources/operations/loki-canary/_index.md
@@ -132,7 +132,7 @@ Loki Canary is also provided as a Docker container image:
 
 ```bash
 # change tag to the most recent release
-$ docker pull grafana/loki-canary:2.0.0
+$ docker pull grafana/loki-canary:2.9.4
 ```
 
 ### Kubernetes

--- a/docs/sources/send-data/docker-driver/_index.md
+++ b/docs/sources/send-data/docker-driver/_index.md
@@ -29,7 +29,7 @@ The Docker plugin must be installed on each Docker host that will be running con
 Run the following command to install the plugin, updating the release version if needed:
 
 ```bash
-docker plugin install grafana/loki-docker-driver:2.9.1 --alias loki --grant-all-permissions
+docker plugin install grafana/loki-docker-driver:2.9.4 --alias loki --grant-all-permissions
 ```
 
 To check installed plugins, use the `docker plugin ls` command. Plugins that
@@ -50,7 +50,7 @@ re-enabling and restarting Docker:
 
 ```bash
 docker plugin disable loki --force
-docker plugin upgrade loki grafana/loki-docker-driver:2.9.1 --grant-all-permissions
+docker plugin upgrade loki grafana/loki-docker-driver:2.9.4 --grant-all-permissions
 docker plugin enable loki
 systemctl restart docker
 ```

--- a/docs/sources/send-data/promtail/installation.md
+++ b/docs/sources/send-data/promtail/installation.md
@@ -21,7 +21,7 @@ Every Grafana Loki release includes binaries for Promtail which can be found on 
 
 ```bash
 # modify tag to most recent version
-docker pull grafana/promtail:2.0.0
+docker pull grafana/promtail:2.9.4
 ```
 
 ## Install using Helm

--- a/docs/sources/setup/install/docker.md
+++ b/docs/sources/setup/install/docker.md
@@ -25,10 +25,10 @@ The configuration acquired with these installation instructions run Loki as a si
 Copy and paste the commands below into your command line.
 
 ```bash
-wget https://raw.githubusercontent.com/grafana/loki/v2.9.1/cmd/loki/loki-local-config.yaml -O loki-config.yaml
-docker run --name loki -d -v $(pwd):/mnt/config -p 3100:3100 grafana/loki:2.9.1 -config.file=/mnt/config/loki-config.yaml
-wget https://raw.githubusercontent.com/grafana/loki/v2.9.1/clients/cmd/promtail/promtail-docker-config.yaml -O promtail-config.yaml
-docker run --name promtail -d -v $(pwd):/mnt/config -v /var/log:/var/log --link loki grafana/promtail:2.9.1 -config.file=/mnt/config/promtail-config.yaml
+wget https://raw.githubusercontent.com/grafana/loki/v2.9.4/cmd/loki/loki-local-config.yaml -O loki-config.yaml
+docker run --name loki -d -v $(pwd):/mnt/config -p 3100:3100 grafana/loki:2.9.4 -config.file=/mnt/config/loki-config.yaml
+wget https://raw.githubusercontent.com/grafana/loki/v2.9.4/clients/cmd/promtail/promtail-docker-config.yaml -O promtail-config.yaml
+docker run --name promtail -d -v $(pwd):/mnt/config -v /var/log:/var/log --link loki grafana/promtail:2.9.4 -config.file=/mnt/config/promtail-config.yaml
 ```
 
 When finished, `loki-config.yaml` and `promtail-config.yaml` are downloaded in the directory you chose. Docker containers are running Loki and Promtail using those config files.
@@ -43,10 +43,10 @@ Copy and paste the commands below into your terminal. Note that you will need to
 
 ```bash
 cd "<local-path>"
-wget https://raw.githubusercontent.com/grafana/loki/v2.9.1/cmd/loki/loki-local-config.yaml -O loki-config.yaml
-docker run --name loki -v <local-path>:/mnt/config -p 3100:3100 grafana/loki:2.9.1 --config.file=/mnt/config/loki-config.yaml
-wget https://raw.githubusercontent.com/grafana/loki/v2.9.1/clients/cmd/promtail/promtail-docker-config.yaml -O promtail-config.yaml
-docker run -v <local-path>:/mnt/config -v /var/log:/var/log --link loki grafana/promtail:2.9.1 --config.file=/mnt/config/promtail-config.yaml
+wget https://raw.githubusercontent.com/grafana/loki/v2.9.4/cmd/loki/loki-local-config.yaml -O loki-config.yaml
+docker run --name loki -v <local-path>:/mnt/config -p 3100:3100 grafana/loki:2.9.4 --config.file=/mnt/config/loki-config.yaml
+wget https://raw.githubusercontent.com/grafana/loki/v2.9.4/clients/cmd/promtail/promtail-docker-config.yaml -O promtail-config.yaml
+docker run -v <local-path>:/mnt/config -v /var/log:/var/log --link loki grafana/promtail:2.9.4 --config.file=/mnt/config/promtail-config.yaml
 ```
 
 When finished, `loki-config.yaml` and `promtail-config.yaml` are downloaded in the directory you chose. Docker containers are running Loki and Promtail using those config files.
@@ -58,6 +58,6 @@ Navigate to http://localhost:3100/metrics to view the output.
 Run the following commands in your command line. They work for Windows or Linux systems.
 
 ```bash
-wget https://raw.githubusercontent.com/grafana/loki/v2.9.1/production/docker-compose.yaml -O docker-compose.yaml
+wget https://raw.githubusercontent.com/grafana/loki/v2.9.4/production/docker-compose.yaml -O docker-compose.yaml
 docker-compose -f docker-compose.yaml up
 ```

--- a/docs/sources/setup/install/local.md
+++ b/docs/sources/setup/install/local.md
@@ -37,7 +37,7 @@ The configuration specifies running Loki as a single binary.
    **Note:** Do not download LogCLI or Loki Canary at this time. `LogCLI` allows you to run Loki queries in a command line interface. [Loki Canary]({{< relref "../../operations/loki-canary" >}}) is a tool to audit Loki performance.
 4. Unzip the package contents into the same directory. This is where the two programs will run.
 5. In the command line, change directory (`cd` on most systems) to the directory with Loki and Promtail. Copy and paste the commands below into your command line to download generic configuration files.
-   **Note:** Use the corresponding Git refs that match your downloaded Loki version to get the correct configuration file. For example, if you are using Loki version 2.6.1, you need to use the `https://raw.githubusercontent.com/grafana/loki/v2.6.1/cmd/loki/loki-local-config.yaml` URL to download the configuration file that corresponds to the Loki version you aim to run.
+   **Note:** Use the corresponding Git refs that match your downloaded Loki version to get the correct configuration file. For example, if you are using Loki version 2.6.1, you need to use the `https://raw.githubusercontent.com/grafana/loki/v2.9.4/cmd/loki/loki-local-config.yaml` URL to download the configuration file that corresponds to the Loki version you aim to run.
 
     ```
     wget https://raw.githubusercontent.com/grafana/loki/main/cmd/loki/loki-local-config.yaml

--- a/examples/getting-started/docker-compose.yaml
+++ b/examples/getting-started/docker-compose.yaml
@@ -6,7 +6,7 @@ networks:
 
 services:
   read:
-    image: grafana/loki:2.9.0
+    image: grafana/loki:2.9.4
     command: "-config.file=/etc/loki/config.yaml -target=read"
     ports:
       - 3101:3100
@@ -27,7 +27,7 @@ services:
           - loki
 
   write:
-    image: grafana/loki:2.9.0
+    image: grafana/loki:2.9.4
     command: "-config.file=/etc/loki/config.yaml -target=write"
     ports:
       - 3102:3100
@@ -46,7 +46,7 @@ services:
       <<: *loki-dns
 
   promtail:
-    image: grafana/promtail:2.9.0
+    image: grafana/promtail:2.9.4
     volumes:
       - ./promtail-local-config.yaml:/etc/promtail/config.yaml:ro
       - /var/run/docker.sock:/var/run/docker.sock

--- a/production/docker-compose.yaml
+++ b/production/docker-compose.yaml
@@ -5,7 +5,7 @@ networks:
 
 services:
   loki:
-    image: grafana/loki:2.9.0
+    image: grafana/loki:2.9.4
     ports:
       - "3100:3100"
     command: -config.file=/etc/loki/local-config.yaml
@@ -13,7 +13,7 @@ services:
       - loki
 
   promtail:
-    image: grafana/promtail:2.9.0
+    image: grafana/promtail:2.9.4
     volumes:
       - /var/log:/var/log
     command: -config.file=/etc/promtail/config.yml

--- a/production/docker/docker-compose.yaml
+++ b/production/docker/docker-compose.yaml
@@ -14,7 +14,7 @@ services:
   # Loki would not have permissions to create the directories.
   # Therefore the init container changes permissions of the mounted directory.
   init:
-    image: &lokiImage grafana/loki:2.9.0
+    image: &lokiImage grafana/loki:2.9.4
     user: root
     entrypoint:
       - "chown"
@@ -71,7 +71,7 @@ services:
       - ./loki/:/var/log/
 
   promtail:
-    image: grafana/promtail:2.9.0
+    image: grafana/promtail:2.9.4
     volumes:
       - ./loki/:/var/log/
       - ./config:/etc/promtail/

--- a/production/ksonnet/loki-canary/config.libsonnet
+++ b/production/ksonnet/loki-canary/config.libsonnet
@@ -1,5 +1,5 @@
 {
   _images+:: {
-    loki_canary: 'grafana/loki-canary:2.9.0',
+    loki_canary: 'grafana/loki-canary:2.9.4',
   },
 }

--- a/production/ksonnet/loki-simple-scalable/example/main.jsonnet
+++ b/production/ksonnet/loki-simple-scalable/example/main.jsonnet
@@ -8,7 +8,7 @@ local k = import 'ksonnet-util/kausal.libsonnet',
 
 loki {
   _images+:: {
-    loki: 'grafana/loki:2.9.0',
+    loki: 'grafana/loki:2.9.4',
   },
 
   _config+:: {

--- a/production/ksonnet/loki-simple-scalable/images.libsonnet
+++ b/production/ksonnet/loki-simple-scalable/images.libsonnet
@@ -1,6 +1,6 @@
 {
   _images+:: {
-    loki: 'grafana/loki:2.9.0',
+    loki: 'grafana/loki:2.9.4',
 
     read: self.loki,
     write: self.loki,

--- a/production/ksonnet/loki/images.libsonnet
+++ b/production/ksonnet/loki/images.libsonnet
@@ -4,7 +4,7 @@
     memcached: 'memcached:1.5.17-alpine',
     memcachedExporter: 'prom/memcached-exporter:v0.6.0',
 
-    loki: 'grafana/loki:2.9.0',
+    loki: 'grafana/loki:2.9.4',
 
     distributor:: self.loki,
     ingester:: self.loki,

--- a/production/ksonnet/promtail/config.libsonnet
+++ b/production/ksonnet/promtail/config.libsonnet
@@ -1,6 +1,6 @@
 {
   _images+:: {
-    promtail: 'grafana/promtail:2.9.0',
+    promtail: 'grafana/promtail:2.9.4',
   },
 
   _config+:: {

--- a/tools/release_update_tags.sh
+++ b/tools/release_update_tags.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -euo pipefail
+
+OLD_VERSION=${LOKI_OLD_VERSION:-}
+NEW_VERSION=${LOKI_NEW_VERSION:-}
+
+if [[ -z "${OLD_VERSION}" ]]
+then
+OLD_VERSION="[0-9]+\.[0-9]+\.[0-9]+"
+fi
+
+if [[ -z "${NEW_VERSION}" ]]
+then
+read -rp "Enter new release version (eg 2.9.2): " NEW_VERSION
+fi
+
+
+LOKI_DOCKER_DRIVER_TAG="grafana\/loki-docker-driver:"
+LOKI_DOCUMENTS_TAG="loki\/v"
+LOKI_DOCKER_TAG="grafana\/loki:"
+LOKI_PROMTAIL_DOCKER_TAG="grafana\/promtail:"
+LOKI_CANARY_DOCKER_TAG="grafana\/loki-canary:"
+LOKI_LOGCLI_DOCKER_TAG="grafana\/logcli:"
+
+echo "Updating version references to ${NEW_VERSION}"
+
+# grep -Iq is to ignore non-binary files.
+find . -type f -not -path "./.git/*" -not -path "./vendor/*" -not -path "./operator/*" -not -path "./CHANGELOG.md" -not -path "./docs/sources/setup/upgrade/*" -exec grep -Iq . {} \; -print0\
+| xargs -0 sed -i '' -E \
+-e "s/(${LOKI_DOCKER_DRIVER_TAG})(${OLD_VERSION})/\1${NEW_VERSION}/g" \
+-e "s/(${LOKI_DOCUMENTS_TAG})(${OLD_VERSION})/\1${NEW_VERSION}/g" \
+-e "s/(${LOKI_DOCKER_TAG})(${OLD_VERSION})/\1${NEW_VERSION}/g" \
+-e "s/(${LOKI_PROMTAIL_DOCKER_TAG})(${OLD_VERSION})/\1${NEW_VERSION}/g" \
+-e "s/(${LOKI_CANARY_DOCKER_TAG})(${OLD_VERSION})/\1${NEW_VERSION}/g" \
+-e "s/(${LOKI_LOGCLI_DOCKER_TAG})(${OLD_VERSION})/\1${NEW_VERSION}/g"


### PR DESCRIPTION
**What this PR does / why we need it**:
Ran recently introduced tag updater `tools/release_update_tags.sh` (https://github.com/grafana/loki/pull/10646) to update version tags in docs and yaml files
