### PR TITLE
Update patch versions in docs and YAML files to v2.8.8

### DIFF
--- a/docs/sources/clients/docker-driver/_index.md
+++ b/docs/sources/clients/docker-driver/_index.md
@@ -28,7 +28,7 @@ The Docker plugin must be installed on each Docker host that will be running con
 Run the following command to install the plugin, updating the release version if needed:
 
 ```bash
-docker plugin install grafana/loki-docker-driver:2.8.5 --alias loki --grant-all-permissions
+docker plugin install grafana/loki-docker-driver:2.8.8 --alias loki --grant-all-permissions
 ```
 
 To check installed plugins, use the `docker plugin ls` command. Plugins that
@@ -49,7 +49,7 @@ re-enabling and restarting Docker:
 
 ```bash
 docker plugin disable loki --force
-docker plugin upgrade loki grafana/loki-docker-driver:2.8.5 --grant-all-permissions
+docker plugin upgrade loki grafana/loki-docker-driver:2.8.8 --grant-all-permissions
 docker plugin enable loki
 systemctl restart docker
 ```

--- a/docs/sources/installation/docker.md
+++ b/docs/sources/installation/docker.md
@@ -22,10 +22,10 @@ The configuration acquired with these installation instructions run Loki as a si
 Copy and paste the commands below into your command line.
 
 ```bash
-wget https://raw.githubusercontent.com/grafana/loki/v2.8.0/cmd/loki/loki-local-config.yaml -O loki-config.yaml
-docker run --name loki -d -v $(pwd):/mnt/config -p 3100:3100 grafana/loki:2.8.0 -config.file=/mnt/config/loki-config.yaml
-wget https://raw.githubusercontent.com/grafana/loki/v2.8.0/clients/cmd/promtail/promtail-docker-config.yaml -O promtail-config.yaml
-docker run --name promtail -d -v $(pwd):/mnt/config -v /var/log:/var/log --link loki grafana/promtail:2.8.0 -config.file=/mnt/config/promtail-config.yaml
+wget https://raw.githubusercontent.com/grafana/loki/v2.8.8/cmd/loki/loki-local-config.yaml -O loki-config.yaml
+docker run --name loki -d -v $(pwd):/mnt/config -p 3100:3100 grafana/loki:2.8.8 -config.file=/mnt/config/loki-config.yaml
+wget https://raw.githubusercontent.com/grafana/loki/v2.8.8/clients/cmd/promtail/promtail-docker-config.yaml -O promtail-config.yaml
+docker run --name promtail -d -v $(pwd):/mnt/config -v /var/log:/var/log --link loki grafana/promtail:2.8.8 -config.file=/mnt/config/promtail-config.yaml
 ```
 
 When finished, `loki-config.yaml` and `promtail-config.yaml` are downloaded in the directory you chose. Docker containers are running Loki and Promtail using those config files.
@@ -40,10 +40,10 @@ Copy and paste the commands below into your terminal. Note that you will need to
 
 ```bash
 cd "<local-path>"
-wget https://raw.githubusercontent.com/grafana/loki/v2.8.0/cmd/loki/loki-local-config.yaml -O loki-config.yaml
-docker run --name loki -v <local-path>:/mnt/config -p 3100:3100 grafana/loki:2.8.0 --config.file=/mnt/config/loki-config.yaml
-wget https://raw.githubusercontent.com/grafana/loki/v2.8.0/clients/cmd/promtail/promtail-docker-config.yaml -O promtail-config.yaml
-docker run -v <local-path>:/mnt/config -v /var/log:/var/log --link loki grafana/promtail:2.8.0 --config.file=/mnt/config/promtail-config.yaml
+wget https://raw.githubusercontent.com/grafana/loki/v2.8.8/cmd/loki/loki-local-config.yaml -O loki-config.yaml
+docker run --name loki -v <local-path>:/mnt/config -p 3100:3100 grafana/loki:2.8.8 --config.file=/mnt/config/loki-config.yaml
+wget https://raw.githubusercontent.com/grafana/loki/v2.8.8/clients/cmd/promtail/promtail-docker-config.yaml -O promtail-config.yaml
+docker run -v <local-path>:/mnt/config -v /var/log:/var/log --link loki grafana/promtail:2.8.8 --config.file=/mnt/config/promtail-config.yaml
 ```
 
 When finished, `loki-config.yaml` and `promtail-config.yaml` are downloaded in the directory you chose. Docker containers are running Loki and Promtail using those config files.
@@ -55,6 +55,6 @@ Navigate to http://localhost:3100/metrics to view the output.
 Run the following commands in your command line. They work for Windows or Linux systems.
 
 ```bash
-wget https://raw.githubusercontent.com/grafana/loki/v2.8.0/production/docker-compose.yaml -O docker-compose.yaml
+wget https://raw.githubusercontent.com/grafana/loki/v2.8.8/production/docker-compose.yaml -O docker-compose.yaml
 docker-compose -f docker-compose.yaml up
 ```

--- a/examples/getting-started/docker-compose.yaml
+++ b/examples/getting-started/docker-compose.yaml
@@ -6,7 +6,7 @@ networks:
 
 services:
   read:
-    image: grafana/loki:2.8.5
+    image: grafana/loki:2.8.8
     command: "-config.file=/etc/loki/config.yaml -target=read"
     ports:
       - 3101:3100
@@ -27,7 +27,7 @@ services:
           - loki
 
   write:
-    image: grafana/loki:2.8.5
+    image: grafana/loki:2.8.8
     command: "-config.file=/etc/loki/config.yaml -target=write"
     ports:
       - 3102:3100
@@ -46,7 +46,7 @@ services:
       <<: *loki-dns
 
   promtail:
-    image: grafana/promtail:2.8.5
+    image: grafana/promtail:2.8.8
     volumes:
       - ./promtail-local-config.yaml:/etc/promtail/config.yaml:ro
       - /var/run/docker.sock:/var/run/docker.sock

--- a/production/docker-compose.yaml
+++ b/production/docker-compose.yaml
@@ -5,7 +5,7 @@ networks:
 
 services:
   loki:
-    image: grafana/loki:2.8.5
+    image: grafana/loki:2.8.8
     ports:
       - "3100:3100"
     command: -config.file=/etc/loki/local-config.yaml
@@ -13,7 +13,7 @@ services:
       - loki
 
   promtail:
-    image: grafana/promtail:2.8.5
+    image: grafana/promtail:2.8.8
     volumes:
       - /var/log:/var/log
     command: -config.file=/etc/promtail/config.yml

--- a/production/docker/docker-compose.yaml
+++ b/production/docker/docker-compose.yaml
@@ -16,7 +16,7 @@ services:
   # Loki would not have permissions to create the directories.
   # Therefore the init container changes permissions of the mounted directory.
   init:
-    image: grafana/loki:2.8.5
+    image: grafana/loki:2.8.8
     user: root
     entrypoint:
       - "chown"
@@ -72,7 +72,7 @@ services:
       - ./loki/:/var/log/
 
   promtail:
-    image: grafana/promtail:2.8.5
+    image: grafana/promtail:2.8.8
     volumes:
       - ./loki/:/var/log/
       - ./config:/etc/promtail/
@@ -114,7 +114,7 @@ services:
       - loki
 
   loki-read:
-    image: grafana/loki:2.8.5
+    image: grafana/loki:2.8.8
     volumes:
       - ./config:/etc/loki/
     ports:
@@ -136,7 +136,7 @@ services:
     # only needed for interactive debugging with dlv
 
   loki-write:
-    image: grafana/loki:2.8.5
+    image: grafana/loki:2.8.8
     volumes:
       - ./config:/etc/loki/
     ports:

--- a/production/ksonnet/loki-canary/config.libsonnet
+++ b/production/ksonnet/loki-canary/config.libsonnet
@@ -1,5 +1,5 @@
 {
   _images+:: {
-    loki_canary: 'grafana/loki-canary:2.8.5',
+    loki_canary: 'grafana/loki-canary:2.8.8',
   },
 }

--- a/production/ksonnet/loki/images.libsonnet
+++ b/production/ksonnet/loki/images.libsonnet
@@ -4,7 +4,7 @@
     memcached: 'memcached:1.5.17-alpine',
     memcachedExporter: 'prom/memcached-exporter:v0.6.0',
 
-    loki: 'grafana/loki:2.8.5',
+    loki: 'grafana/loki:2.8.8',
 
     distributor:: self.loki,
     ingester:: self.loki,

--- a/production/ksonnet/promtail/config.libsonnet
+++ b/production/ksonnet/promtail/config.libsonnet
@@ -1,6 +1,6 @@
 {
   _images+:: {
-    promtail: 'grafana/promtail:2.8.5',
+    promtail: 'grafana/promtail:2.8.8',
   },
 
   _config+:: {

--- a/tools/release_update_tags.sh
+++ b/tools/release_update_tags.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -euo pipefail
+
+OLD_VERSION=${LOKI_OLD_VERSION:-}
+NEW_VERSION=${LOKI_NEW_VERSION:-}
+
+if [[ -z "${OLD_VERSION}" ]]
+then
+    OLD_VERSION="[0-9]+\.[0-9]+\.[0-9]+"
+fi
+
+if [[ -z "${NEW_VERSION}" ]]
+then
+    read -rp "Enter new release version (eg 2.9.2): " NEW_VERSION
+fi
+
+
+LOKI_DOCKER_DRIVER_TAG="grafana\/loki-docker-driver:"
+LOKI_DOCUMENTS_TAG="loki\/v"
+LOKI_DOCKER_TAG="grafana\/loki:"
+LOKI_PROMTAIL_DOCKER_TAG="grafana\/promtail:"
+LOKI_CANARY_DOCKER_TAG="grafana\/loki-canary:"
+LOKI_LOGCLI_DOCKER_TAG="grafana\/logcli:"
+
+echo "Updating version references to ${NEW_VERSION}"
+
+# grep -Iq is to ignore non-binary files.
+find . -type f -not -path "./.git/*" -not -path "./vendor/*" -not -path "./operator/*" -not -path "./CHANGELOG.md" -not -path "./docs/sources/setup/upgrade/*" -exec grep -Iq . {} \; -print0\
+    | xargs -0 sed -i '' -E \
+	    -e "s/(${LOKI_DOCKER_DRIVER_TAG})(${OLD_VERSION})/\1${NEW_VERSION}/g" \
+	    -e "s/(${LOKI_DOCUMENTS_TAG})(${OLD_VERSION})/\1${NEW_VERSION}/g" \
+	    -e "s/(${LOKI_DOCKER_TAG})(${OLD_VERSION})/\1${NEW_VERSION}/g" \
+	    -e "s/(${LOKI_PROMTAIL_DOCKER_TAG})(${OLD_VERSION})/\1${NEW_VERSION}/g" \
+	    -e "s/(${LOKI_CANARY_DOCKER_TAG})(${OLD_VERSION})/\1${NEW_VERSION}/g" \
+	    -e "s/(${LOKI_LOGCLI_DOCKER_TAG})(${OLD_VERSION})/\1${NEW_VERSION}/g" \


### PR DESCRIPTION
**What this PR does / why we need it**:

This fixes the docs and some config examples to use the latest patch version. This hadn't been done for a while, so I also added the script to do it from https://github.com/grafana/loki/pull/10646

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
