### PR TITLE
Note the helm chart and docs do not agree

### DIFF
--- a/docs/sources/get-started/deployment-modes.md
+++ b/docs/sources/get-started/deployment-modes.md
@@ -33,7 +33,7 @@ The three execution paths in simple scalable mode are each activated by appendin
 - `-target=write` - The write target is stateful and is controlled by a Kubernetes StatefulSet. It contains the following components:
 -- Distributor
 -- Ingester
-- `-target=read` - The read target is stateless and can be run as a Kubernetes Deployment that can be scaled automatically (N.B. In the official helm chart it is currently deployed as a stateful set). It contains the following components:
+- `-target=read` - The read target is stateless and can be run as a Kubernetes Deployment that can be scaled automatically (Note that in the official helm chart it is currently deployed as a stateful set). It contains the following components:
 -- Query front end
 -- Queriers
 - `-target=backend` - The backend target is stateful, and is controlled by a Kubernetes StatefulSet. Contains the following components:

--- a/docs/sources/get-started/deployment-modes.md
+++ b/docs/sources/get-started/deployment-modes.md
@@ -33,7 +33,7 @@ The three execution paths in simple scalable mode are each activated by appendin
 - `-target=write` - The write target is stateful and is controlled by a Kubernetes StatefulSet. It contains the following components:
 -- Distributor
 -- Ingester
-- `-target=read` - The read target is stateless and can be run as a Kubernetes Deployment that can be scaled automatically. It contains the following components:
+- `-target=read` - The read target is stateless and can be run as a Kubernetes Deployment that can be scaled automatically (N.B. In the official helm chart it is currently deployed as a stateful set). It contains the following components:
 -- Query front end
 -- Queriers
 - `-target=backend` - The backend target is stateful, and is controlled by a Kubernetes StatefulSet. Contains the following components:


### PR DESCRIPTION
**What this PR does / why we need it**: Docs do not match the code in the helm chart - where the read deployment is made as a statefulset with ReadWriteOnce disks (https://github.com/grafana/loki/blob/main/production/helm/loki/templates/read/statefulset-read.yaml). I suspect the docs are correct that it's possible - but given it's the official helm chart - the deviation should be noted.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
