### PR TITLE
Jsonnet: Change by-pod source code to reuse the `latency` util function

### DIFF
--- a/production/loki-mixin/dashboards/loki-reads.libsonnet
+++ b/production/loki-mixin/dashboards/loki-reads.libsonnet
@@ -10,37 +10,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
 
     local p99LatencyByPod(metric, selectorStr) =
       $.panel('Per Pod Latency (p99)') +
-      {
-        targets: [
-          {
-            expr:
-              |||
-                histogram_quantile(0.99,
-                  sum(
-                   rate(%s%s[$__rate_interval])
-                   ) by (pod, le)
-                 )
-              ||| % [metric, selectorStr],
-            instant: false,
-            legendFormat: '__auto',
-            range: true,
-            refId: 'A',
-          },
-        ],
-        fieldConfig+: {
-          defaults+: {
-            custom+: {
-              fillOpacity: 50,
-              showPoints: 'never',
-              stacking: {
-                group: 'A',
-                mode: 'normal',
-              },
-            },
-            unit: 's',
-          },
-        },
-      },
+      $.latencyPanel(metric, selectorStr),
 
     'loki-reads.json': {
                          local cfg = self,
@@ -96,11 +66,9 @@ local utils = import 'mixin-utils/utils.libsonnet';
                          )
                          .addPanel(
                            p99LatencyByPod(
-                             'loki_request_duration_seconds_bucket',
+                             'loki_request_duration_seconds',
                              $.toPrometheusSelector(
-                               dashboards['loki-reads.json'].clusterMatchers +
-                               dashboards['loki-reads.json'].matchers.cortexgateway +
-                               [utils.selector.re('route', http_routes)]
+                               dashboards['loki-reads.json'].clusterMatchers + dashboards['loki-reads.json'].matchers.cortexgateway + [utils.selector.re('route', http_routes)]
                              ),
                            )
                          )
@@ -121,7 +89,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
                          )
                          .addPanel(
                            p99LatencyByPod(
-                             'loki_request_duration_seconds_bucket',
+                             'loki_request_duration_seconds',
                              $.toPrometheusSelector(
                                dashboards['loki-reads.json'].clusterMatchers +
                                dashboards['loki-reads.json'].matchers.queryFrontend +
@@ -147,7 +115,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
                          )
                          .addPanel(
                            p99LatencyByPod(
-                             'loki_request_duration_seconds_bucket',
+                             'loki_request_duration_seconds',
                              $.toPrometheusSelector(
                                dashboards['loki-reads.json'].clusterMatchers +
                                dashboards['loki-reads.json'].matchers.querier +
@@ -173,7 +141,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
                          )
                          .addPanel(
                            p99LatencyByPod(
-                             'loki_request_duration_seconds_bucket',
+                             'loki_request_duration_seconds',
                              $.toPrometheusSelector(
                                dashboards['loki-reads.json'].clusterMatchers +
                                dashboards['loki-reads.json'].matchers.ingester +
@@ -200,7 +168,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
                          )
                          .addPanel(
                            p99LatencyByPod(
-                             'loki_request_duration_seconds_bucket',
+                             'loki_request_duration_seconds',
                              $.toPrometheusSelector(
                                dashboards['loki-reads.json'].clusterMatchers +
                                dashboards['loki-reads.json'].matchers.ingesterZoneAware +
@@ -222,7 +190,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
                          )
                          .addPanel(
                            p99LatencyByPod(
-                             'loki_index_request_duration_seconds_bucket',
+                             'loki_index_request_duration_seconds',
                              '{%s operation!="index_chunk"}' % dashboards['loki-reads.json'].querierSelector
                            )
                          )
@@ -254,7 +222,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
                          )
                          .addPanel(
                            p99LatencyByPod(
-                             'loki_boltdb_shipper_request_duration_seconds_bucket',
+                             'loki_boltdb_shipper_request_duration_seconds',
                              '{%s operation="Shipper.Query"}' % dashboards['loki-reads.json'].querierOrIndexGatewaySelector
                            )
                          )


### PR DESCRIPTION
**What this PR does / why we need it**:
Modify our implementation of `p99LatencyByPod` to reuse the `latencyPanel` util function.
I tested the change using grizzly.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
