### PR TITLE
Bloom Shipper: Fix bug in block boundary check

### DIFF
--- a/pkg/bloomgateway/bloomgateway_test.go
+++ b/pkg/bloomgateway/bloomgateway_test.go
@@ -433,7 +433,7 @@ type mockBloomStore struct {
 var _ bloomshipper.Interface = &mockBloomStore{}
 
 // GetBlockRefs implements bloomshipper.Interface
-func (s *mockBloomStore) GetBlockRefs(_ context.Context, tenant string, _, _ model.Time) ([]bloomshipper.BlockRef, error) {
+func (s *mockBloomStore) GetBlockRefs(_ context.Context, tenant string, _ bloomshipper.Interval) ([]bloomshipper.BlockRef, error) {
 	blocks := make([]bloomshipper.BlockRef, 0, len(s.bqs))
 	for i := range s.bqs {
 		blocks = append(blocks, bloomshipper.BlockRef{

--- a/pkg/storage/stores/shipper/bloomshipper/shipper.go
+++ b/pkg/storage/stores/shipper/bloomshipper/shipper.go
@@ -15,6 +15,24 @@ import (
 	"github.com/grafana/loki/pkg/storage/stores/shipper/bloomshipper/config"
 )
 
+type Interval struct {
+	Start model.Time
+	End   model.Time
+}
+
+func (i Interval) String() string {
+	return fmt.Sprintf("[%s, %s)", i.Start.Time(), i.End.Time())
+}
+
+func (i Interval) Cmp(other model.Time) v1.BoundsCheck {
+	if other.Before(i.Start) {
+		return v1.Before
+	} else if other.After(i.End) || other.Equal(i.End) {
+		return v1.After
+	}
+	return v1.Overlap
+}
+
 type fpRange [2]uint64
 
 func (r fpRange) minFp() uint64 {
@@ -33,7 +51,7 @@ type BlockQuerierWithFingerprintRange struct {
 type ForEachBlockCallback func(bq *v1.BlockQuerier, minFp, maxFp uint64) error
 
 type Interface interface {
-	GetBlockRefs(ctx context.Context, tenant string, from, through model.Time) ([]BlockRef, error)
+	GetBlockRefs(ctx context.Context, tenant string, interval Interval) ([]BlockRef, error)
 	Fetch(ctx context.Context, tenant string, blocks []BlockRef, callback ForEachBlockCallback) error
 	Stop()
 }
@@ -63,10 +81,12 @@ func NewShipper(client Client, config config.Config, limits Limits, logger log.L
 	}, nil
 }
 
-func (s *Shipper) GetBlockRefs(ctx context.Context, tenantID string, from, through model.Time) ([]BlockRef, error) {
-	level.Debug(s.logger).Log("msg", "GetBlockRefs", "tenant", tenantID, "from", from, "through", through)
+func (s *Shipper) GetBlockRefs(ctx context.Context, tenantID string, interval Interval) ([]BlockRef, error) {
+	level.Debug(s.logger).Log("msg", "GetBlockRefs", "tenant", tenantID, "[", interval.Start, "", interval.End)
 
-	blockRefs, err := s.getActiveBlockRefs(ctx, tenantID, from, through, []fpRange{{0, math.MaxUint64}})
+	// TODO(chaudum): The bloom gateway should not fetch blocks for the complete key space
+	keyspaces := []fpRange{{0, math.MaxUint64}}
+	blockRefs, err := s.getActiveBlockRefs(ctx, tenantID, interval, keyspaces)
 	if err != nil {
 		return nil, fmt.Errorf("error fetching active block references : %w", err)
 	}
@@ -130,20 +150,20 @@ func getFirstLast[T any](s []T) (T, T) {
 	return s[0], s[len(s)-1]
 }
 
-func (s *Shipper) getActiveBlockRefs(ctx context.Context, tenantID string, from, through model.Time, fingerprints []fpRange) ([]BlockRef, error) {
-	minFpRange, maxFpRange := getFirstLast(fingerprints)
+func (s *Shipper) getActiveBlockRefs(ctx context.Context, tenantID string, interval Interval, keyspaces []fpRange) ([]BlockRef, error) {
+	minFpRange, maxFpRange := getFirstLast(keyspaces)
 	metas, err := s.client.GetMetas(ctx, MetaSearchParams{
 		TenantID:       tenantID,
 		MinFingerprint: model.Fingerprint(minFpRange.minFp()),
 		MaxFingerprint: model.Fingerprint(maxFpRange.maxFp()),
-		StartTimestamp: from,
-		EndTimestamp:   through,
+		StartTimestamp: interval.Start,
+		EndTimestamp:   interval.End,
 	})
 	if err != nil {
 		return []BlockRef{}, fmt.Errorf("error fetching meta.json files: %w", err)
 	}
 	level.Debug(s.logger).Log("msg", "dowloaded metas", "count", len(metas))
-	activeBlocks := s.findBlocks(metas, from, through, fingerprints)
+	activeBlocks := s.findBlocks(metas, interval, keyspaces)
 	slices.SortStableFunc(activeBlocks, func(a, b BlockRef) int {
 		if a.MinFingerprint < b.MinFingerprint {
 			return -1
@@ -157,20 +177,22 @@ func (s *Shipper) getActiveBlockRefs(ctx context.Context, tenantID string, from,
 	return activeBlocks, nil
 }
 
-func (s *Shipper) findBlocks(metas []Meta, startTimestamp, endTimestamp model.Time, fingerprints []fpRange) []BlockRef {
-	outdatedBlocks := make(map[string]interface{})
+func (s *Shipper) findBlocks(metas []Meta, interval Interval, keyspaces []fpRange) []BlockRef {
+	tombstones := make(map[string]interface{})
 	for _, meta := range metas {
 		for _, tombstone := range meta.Tombstones {
-			outdatedBlocks[tombstone.BlockPath] = nil
+			tombstones[tombstone.BlockPath] = nil
 		}
 	}
 	blocksSet := make(map[string]BlockRef)
 	for _, meta := range metas {
 		for _, block := range meta.Blocks {
-			if _, contains := outdatedBlocks[block.BlockPath]; contains {
+			if _, contains := tombstones[block.BlockPath]; contains {
+				// skip tombstoned blocks
 				continue
 			}
-			if isOutsideRange(&block, startTimestamp, endTimestamp, fingerprints) {
+			if isOutsideRange(&block, interval, keyspaces) {
+				// skip block that are outside of interval or keyspaces
 				continue
 			}
 			blocksSet[block.BlockPath] = block
@@ -186,21 +208,21 @@ func (s *Shipper) findBlocks(metas []Meta, startTimestamp, endTimestamp model.Ti
 // isOutsideRange tests if a given BlockRef b is outside of search boundaries
 // defined by min/max timestamp and min/max fingerprint.
 // Fingerprint ranges must be sorted in ascending order.
-func isOutsideRange(b *BlockRef, startTimestamp, endTimestamp model.Time, fingerprints []fpRange) bool {
-	// First, check time range
-	if b.EndTimestamp < startTimestamp || b.StartTimestamp > endTimestamp {
+func isOutsideRange(b *BlockRef, interval Interval, keyspaces []fpRange) bool {
+	// check time interval
+	if interval.Cmp(b.EndTimestamp) == v1.Before || interval.Cmp(b.StartTimestamp) == v1.After {
 		return true
 	}
 
 	// Then, check if outside of min/max of fingerprint slice
-	minFpRange, maxFpRange := getFirstLast(fingerprints)
+	minFpRange, maxFpRange := getFirstLast(keyspaces)
 	if b.MaxFingerprint < minFpRange.minFp() || b.MinFingerprint > maxFpRange.maxFp() {
 		return true
 	}
 
 	prev := fpRange{0, 0}
-	for i := 0; i < len(fingerprints); i++ {
-		fpr := fingerprints[i]
+	for i := 0; i < len(keyspaces); i++ {
+		fpr := keyspaces[i]
 		if b.MinFingerprint > prev.maxFp() && b.MaxFingerprint < fpr.minFp() {
 			return true
 		}

--- a/pkg/storage/stores/shipper/bloomshipper/shipper_test.go
+++ b/pkg/storage/stores/shipper/bloomshipper/shipper_test.go
@@ -10,6 +10,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func interval(start, end model.Time) Interval {
+	return Interval{Start: start, End: end}
+}
+
 func Test_Shipper_findBlocks(t *testing.T) {
 	t.Run("expected block that are specified in tombstones to be filtered out", func(t *testing.T) {
 		metas := []Meta{
@@ -40,8 +44,14 @@ func Test_Shipper_findBlocks(t *testing.T) {
 			},
 		}
 
+		ts := model.Now()
+
 		shipper := &Shipper{}
-		blocks := shipper.findBlocks(metas, model.Now().Add(-2*time.Hour), model.Now().Add(-1*time.Hour), []fpRange{{100, 200}})
+		interval := Interval{
+			Start: ts.Add(-2 * time.Hour),
+			End:   ts.Add(-1 * time.Hour),
+		}
+		blocks := shipper.findBlocks(metas, interval, []fpRange{{100, 200}})
 
 		expectedBlockRefs := []BlockRef{
 			createMatchingBlockRef("block2"),
@@ -95,7 +105,7 @@ func Test_Shipper_findBlocks(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			shipper := &Shipper{}
 			ref := createBlockRef("fake-block", data.minFingerprint, data.maxFingerprint, data.startTimestamp, data.endTimestamp)
-			blocks := shipper.findBlocks([]Meta{{Blocks: []BlockRef{ref}}}, 300, 400, []fpRange{{100, 200}})
+			blocks := shipper.findBlocks([]Meta{{Blocks: []BlockRef{ref}}}, interval(300, 400), []fpRange{{100, 200}})
 			if data.filtered {
 				require.Empty(t, blocks)
 				return
@@ -112,55 +122,61 @@ func TestIsOutsideRange(t *testing.T) {
 
 	t.Run("is outside if startTs > through", func(t *testing.T) {
 		b := createBlockRef("block", 0, math.MaxUint64, startTs, endTs)
-		isOutside := isOutsideRange(&b, 0, 900, []fpRange{})
+		isOutside := isOutsideRange(&b, interval(0, 900), []fpRange{})
+		require.True(t, isOutside)
+	})
+
+	t.Run("is outside if startTs == through ", func(t *testing.T) {
+		b := createBlockRef("block", 0, math.MaxUint64, startTs, endTs)
+		isOutside := isOutsideRange(&b, interval(900, 1000), []fpRange{})
 		require.True(t, isOutside)
 	})
 
 	t.Run("is outside if endTs < from", func(t *testing.T) {
 		b := createBlockRef("block", 0, math.MaxUint64, startTs, endTs)
-		isOutside := isOutsideRange(&b, 2100, 3000, []fpRange{})
+		isOutside := isOutsideRange(&b, interval(2100, 3000), []fpRange{})
 		require.True(t, isOutside)
 	})
 
 	t.Run("is outside if endFp < first fingerprint", func(t *testing.T) {
 		b := createBlockRef("block", 0, 90, startTs, endTs)
-		isOutside := isOutsideRange(&b, startTs, endTs, []fpRange{{100, 199}})
+		isOutside := isOutsideRange(&b, interval(startTs, endTs), []fpRange{{100, 199}})
 		require.True(t, isOutside)
 	})
 
 	t.Run("is outside if startFp > last fingerprint", func(t *testing.T) {
 		b := createBlockRef("block", 200, math.MaxUint64, startTs, endTs)
-		isOutside := isOutsideRange(&b, startTs, endTs, []fpRange{{0, 49}, {100, 149}})
+		isOutside := isOutsideRange(&b, interval(startTs, endTs), []fpRange{{0, 49}, {100, 149}})
 		require.True(t, isOutside)
 	})
 
 	t.Run("is outside if within gaps in fingerprints", func(t *testing.T) {
 		b := createBlockRef("block", 100, 199, startTs, endTs)
-		isOutside := isOutsideRange(&b, startTs, endTs, []fpRange{{0, 99}, {200, 299}})
+		isOutside := isOutsideRange(&b, interval(startTs, endTs), []fpRange{{0, 99}, {200, 299}})
 		require.True(t, isOutside)
 	})
 
 	t.Run("is not outside if within fingerprints 1", func(t *testing.T) {
 		b := createBlockRef("block", 10, 90, startTs, endTs)
-		isOutside := isOutsideRange(&b, startTs, endTs, []fpRange{{0, 99}, {200, 299}})
+		isOutside := isOutsideRange(&b, interval(startTs, endTs), []fpRange{{0, 99}, {200, 299}})
 		require.False(t, isOutside)
 	})
 
 	t.Run("is not outside if within fingerprints 2", func(t *testing.T) {
 		b := createBlockRef("block", 210, 290, startTs, endTs)
-		isOutside := isOutsideRange(&b, startTs, endTs, []fpRange{{0, 99}, {200, 299}})
+		isOutside := isOutsideRange(&b, interval(startTs, endTs), []fpRange{{0, 99}, {200, 299}})
 		require.False(t, isOutside)
 	})
 
 	t.Run("is not outside if spans across multiple fingerprint ranges", func(t *testing.T) {
 		b := createBlockRef("block", 50, 250, startTs, endTs)
-		isOutside := isOutsideRange(&b, startTs, endTs, []fpRange{{0, 99}, {200, 299}})
+		isOutside := isOutsideRange(&b, interval(startTs, endTs), []fpRange{{0, 99}, {200, 299}})
 		require.False(t, isOutside)
 	})
 
 	t.Run("is not outside if fingerprint range and time range are larger than block", func(t *testing.T) {
 		b := createBlockRef("block", math.MaxUint64/3, math.MaxUint64/3*2, startTs, endTs)
-		isOutside := isOutsideRange(&b, 0, 3000, []fpRange{{0, math.MaxUint64}})
+		isOutside := isOutsideRange(&b, interval(0, 3000), []fpRange{{0, math.MaxUint64}})
 		require.False(t, isOutside)
 	})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

The check `isOutsideRange()` returned incorrect results, because the end timestamp of the search interval is not inclusive.