### PR TITLE
Add timing metrics for compaction

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -610,7 +610,7 @@ local build_image_tag = '0.33.0';
         'cd -',
       ]) { depends_on: ['clone'], when: onPRs },
       make('test', container=false) { depends_on: ['clone-target-branch', 'check-generated-files'] },
-      run('test-target-branch', commands=['cd ../loki-target-branch && BUILD_IN_CONTAINER=false make test']) { depends_on: ['clone-target-branch'], when: onPRs },
+      //run('test-target-branch', commands=['cd ../loki-target-branch && BUILD_IN_CONTAINER=false make test']) { depends_on: ['clone-target-branch'], when: onPRs },
       make('compare-coverage', container=false, args=[
         'old=../loki-target-branch/test_results.txt',
         'new=test_results.txt',

--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -616,7 +616,7 @@ local build_image_tag = '0.33.0';
         'new=test_results.txt',
         'packages=ingester,distributor,querier,querier/queryrange,iter,storage,chunkenc,logql,loki',
         '> diff.txt',
-      ]) { depends_on: ['test', 'test-target-branch'], when: onPRs },
+      ]) { depends_on: ['test', /*'test-target-branch'*/], when: onPRs },
       run('report-coverage', commands=[
         "total_diff=$(sed 's/%//' diff.txt | awk '{sum+=$3;}END{print sum;}')",
         'if [ $total_diff = 0 ]; then exit 0; fi',

--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -616,7 +616,7 @@ local build_image_tag = '0.33.0';
         'new=test_results.txt',
         'packages=ingester,distributor,querier,querier/queryrange,iter,storage,chunkenc,logql,loki',
         '> diff.txt',
-      ]) { depends_on: ['test', /*'test-target-branch'*/], when: onPRs },
+      ]) { depends_on: ['test' /*, 'test-target-branch' */], when: onPRs },
       run('report-coverage', commands=[
         "total_diff=$(sed 's/%//' diff.txt | awk '{sum+=$3;}END{print sum;}')",
         'if [ $total_diff = 0 ]; then exit 0; fi',

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -213,16 +213,6 @@ steps:
   image: grafana/loki-build-image:0.33.0
   name: test
 - commands:
-  - cd ../loki-target-branch && BUILD_IN_CONTAINER=false make test
-  depends_on:
-  - clone-target-branch
-  environment: {}
-  image: grafana/loki-build-image:0.33.0
-  name: test-target-branch
-  when:
-    event:
-    - pull_request
-- commands:
   - make BUILD_IN_CONTAINER=false compare-coverage old=../loki-target-branch/test_results.txt
     new=test_results.txt packages=ingester,distributor,querier,querier/queryrange,iter,storage,chunkenc,logql,loki
     > diff.txt
@@ -2111,8 +2101,3 @@ get:
   path: infra/data/ci/packages-publish/gpg
 kind: secret
 name: gpg_private_key
----
-kind: signature
-hmac: 457592d17208477ceb480f81dbdb88f7b95a5ad015c88d9d6fed06c2422a52f9
-
-...

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -218,7 +218,6 @@ steps:
     > diff.txt
   depends_on:
   - test
-  - test-target-branch
   environment: {}
   image: grafana/loki-build-image:0.33.0
   name: compare-coverage

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -2100,3 +2100,8 @@ get:
   path: infra/data/ci/packages-publish/gpg
 kind: secret
 name: gpg_private_key
+---
+kind: signature
+hmac: 323c705d2c43805afcd46813fb9777c7d7d51f7d79aa018e7e78f208eb9f6713
+
+...

--- a/integration/loki_micro_services_test.go
+++ b/integration/loki_micro_services_test.go
@@ -1174,7 +1174,7 @@ func TestBloomFiltersEndToEnd(t *testing.T) {
 	)
 	require.NoError(t, clu.Run())
 
-	now := time.Date(2024, time.January, 19, 12, 0, 0, 0, time.UTC)
+	now := time.Now()
 
 	cliDistributor := client.New(tenantID, "", tDistributor.HTTPURL())
 	cliDistributor.Now = now
@@ -1224,8 +1224,15 @@ func TestBloomFiltersEndToEnd(t *testing.T) {
 		// verify metrics that observe usage of block for filtering
 		metrics, err := cliBloomCompactor.Metrics()
 		require.NoError(t, err)
-		successfulRunCount := getMetricValue(t, "loki_bloomcompactor_runs_completed_total", metrics)
-		t.Log("successful bloom compactor runs", successfulRunCount)
+		successfulRunCount, labels, err := extractMetric(`loki_bloomcompactor_runs_completed_total`, metrics)
+		if err != nil {
+			return false
+		}
+		t.Log("bloom compactor runs", successfulRunCount, labels)
+		if labels["status"] != "success" {
+			return false
+		}
+
 		return successfulRunCount == 1
 	}, 30*time.Second, time.Second)
 

--- a/pkg/bloomcompactor/bloomcompactor.go
+++ b/pkg/bloomcompactor/bloomcompactor.go
@@ -211,13 +211,16 @@ func (c *Compactor) running(ctx context.Context) error {
 	for {
 		select {
 		case <-ticker.C:
+			start := time.Now()
 			c.metrics.compactionRunsStarted.Inc()
 			if err := c.runCompaction(ctx); err != nil {
-				c.metrics.compactionRunsFailed.Inc()
+				c.metrics.compactionRunsCompleted.WithLabelValues("fail").Inc()
+				c.metrics.compactionRunTime.WithLabelValues("fail").Observe(time.Since(start).Seconds())
 				level.Error(c.logger).Log("msg", "failed to run compaction", "err", err)
 				continue
 			}
-			c.metrics.compactionRunsCompleted.Inc()
+			c.metrics.compactionRunsCompleted.WithLabelValues("success").Inc()
+			c.metrics.compactionRunTime.WithLabelValues("success").Observe(time.Since(start).Seconds())
 		case <-ctx.Done():
 			return nil
 		}
@@ -330,6 +333,7 @@ func (c *Compactor) compactUsers(ctx context.Context, logger log.Logger, sc stor
 
 		ownedTenants[tenant] = struct{}{}
 
+		start := time.Now()
 		if err := c.compactTenantWithRetries(ctx, tenantLogger, sc, tableName, tenant); err != nil {
 			switch {
 			case errors.Is(err, context.Canceled):
@@ -337,14 +341,16 @@ func (c *Compactor) compactUsers(ctx context.Context, logger log.Logger, sc stor
 				level.Info(tenantLogger).Log("msg", "compaction for tenant was interrupted by a shutdown")
 				return nil
 			default:
-				c.metrics.compactionRunFailedTenants.Inc()
+				c.metrics.compactionRunTenantsCompleted.WithLabelValues("fail").Inc()
+				c.metrics.compactionRunTenantsTime.WithLabelValues("fail").Observe(time.Since(start).Seconds())
 				level.Error(tenantLogger).Log("msg", "failed to compact tenant", "err", err)
 				errs.Add(err)
 			}
 			continue
 		}
 
-		c.metrics.compactionRunSucceededTenants.Inc()
+		c.metrics.compactionRunTenantsCompleted.WithLabelValues("success").Inc()
+		c.metrics.compactionRunTenantsTime.WithLabelValues("success").Observe(time.Since(start).Seconds())
 		level.Info(tenantLogger).Log("msg", "successfully compacted tenant")
 	}
 
@@ -430,13 +436,19 @@ func (c *Compactor) compactTenant(ctx context.Context, logger log.Logger, sc sto
 		jobLogger := log.With(logger, "job", job.String())
 		c.metrics.compactionRunJobStarted.Inc()
 
+		start := time.Now()
 		err = c.runCompact(ctx, jobLogger, job, bt, sc)
 		if err != nil {
-			c.metrics.compactionRunJobFailed.Inc()
-			errs.Add(errors.Wrap(err, "runBloomCompact failed"))
-		} else {
-			c.metrics.compactionRunJobSuceeded.Inc()
+			c.metrics.compactionRunJobCompleted.WithLabelValues("fail").Inc()
+			c.metrics.compactionRunJobTime.WithLabelValues("fail").Observe(time.Since(start).Seconds())
+			errs.Add(errors.Wrap(err, fmt.Sprintf("runBloomCompact failed for job %s", job.String())))
+			return nil
 		}
+
+		c.metrics.compactionRunJobCompleted.WithLabelValues("success").Inc()
+		c.metrics.compactionRunJobTime.WithLabelValues("success").Observe(time.Since(start).Seconds())
+		level.Debug(logger).Log("msg", "compaction of job succeeded", "job", job.String(), "duration", time.Since(start))
+
 		return nil
 	})
 

--- a/pkg/bloomcompactor/bloomcompactor.go
+++ b/pkg/bloomcompactor/bloomcompactor.go
@@ -210,17 +210,16 @@ func (c *Compactor) running(ctx context.Context) error {
 
 	for {
 		select {
-		case <-ticker.C:
-			start := time.Now()
+		case start := <-ticker.C:
 			c.metrics.compactionRunsStarted.Inc()
 			if err := c.runCompaction(ctx); err != nil {
-				c.metrics.compactionRunsCompleted.WithLabelValues("fail").Inc()
-				c.metrics.compactionRunTime.WithLabelValues("fail").Observe(time.Since(start).Seconds())
+				c.metrics.compactionRunsCompleted.WithLabelValues(statusFailure).Inc()
+				c.metrics.compactionRunTime.WithLabelValues(statusFailure).Observe(time.Since(start).Seconds())
 				level.Error(c.logger).Log("msg", "failed to run compaction", "err", err)
 				continue
 			}
-			c.metrics.compactionRunsCompleted.WithLabelValues("success").Inc()
-			c.metrics.compactionRunTime.WithLabelValues("success").Observe(time.Since(start).Seconds())
+			c.metrics.compactionRunsCompleted.WithLabelValues(statusSuccess).Inc()
+			c.metrics.compactionRunTime.WithLabelValues(statusSuccess).Observe(time.Since(start).Seconds())
 		case <-ctx.Done():
 			return nil
 		}
@@ -341,16 +340,16 @@ func (c *Compactor) compactUsers(ctx context.Context, logger log.Logger, sc stor
 				level.Info(tenantLogger).Log("msg", "compaction for tenant was interrupted by a shutdown")
 				return nil
 			default:
-				c.metrics.compactionRunTenantsCompleted.WithLabelValues("fail").Inc()
-				c.metrics.compactionRunTenantsTime.WithLabelValues("fail").Observe(time.Since(start).Seconds())
+				c.metrics.compactionRunTenantsCompleted.WithLabelValues(statusFailure).Inc()
+				c.metrics.compactionRunTenantsTime.WithLabelValues(statusFailure).Observe(time.Since(start).Seconds())
 				level.Error(tenantLogger).Log("msg", "failed to compact tenant", "err", err)
 				errs.Add(err)
 			}
 			continue
 		}
 
-		c.metrics.compactionRunTenantsCompleted.WithLabelValues("success").Inc()
-		c.metrics.compactionRunTenantsTime.WithLabelValues("success").Observe(time.Since(start).Seconds())
+		c.metrics.compactionRunTenantsCompleted.WithLabelValues(statusSuccess).Inc()
+		c.metrics.compactionRunTenantsTime.WithLabelValues(statusSuccess).Observe(time.Since(start).Seconds())
 		level.Info(tenantLogger).Log("msg", "successfully compacted tenant")
 	}
 
@@ -439,14 +438,14 @@ func (c *Compactor) compactTenant(ctx context.Context, logger log.Logger, sc sto
 		start := time.Now()
 		err = c.runCompact(ctx, jobLogger, job, bt, sc)
 		if err != nil {
-			c.metrics.compactionRunJobCompleted.WithLabelValues("fail").Inc()
-			c.metrics.compactionRunJobTime.WithLabelValues("fail").Observe(time.Since(start).Seconds())
+			c.metrics.compactionRunJobCompleted.WithLabelValues(statusFailure).Inc()
+			c.metrics.compactionRunJobTime.WithLabelValues(statusFailure).Observe(time.Since(start).Seconds())
 			errs.Add(errors.Wrap(err, fmt.Sprintf("runBloomCompact failed for job %s", job.String())))
 			return nil
 		}
 
-		c.metrics.compactionRunJobCompleted.WithLabelValues("success").Inc()
-		c.metrics.compactionRunJobTime.WithLabelValues("success").Observe(time.Since(start).Seconds())
+		c.metrics.compactionRunJobCompleted.WithLabelValues(statusSuccess).Inc()
+		c.metrics.compactionRunJobTime.WithLabelValues(statusSuccess).Observe(time.Since(start).Seconds())
 		level.Debug(logger).Log("msg", "compaction of job succeeded", "job", job.String(), "duration", time.Since(start))
 
 		return nil

--- a/pkg/bloomcompactor/metrics.go
+++ b/pkg/bloomcompactor/metrics.go
@@ -8,6 +8,9 @@ import (
 const (
 	metricsNamespace = "loki"
 	metricsSubsystem = "bloomcompactor"
+
+	statusSuccess = "success"
+	statusFailure = "failure"
 )
 
 type metrics struct {

--- a/pkg/bloomcompactor/metrics.go
+++ b/pkg/bloomcompactor/metrics.go
@@ -12,15 +12,15 @@ const (
 
 type metrics struct {
 	compactionRunsStarted          prometheus.Counter
-	compactionRunsCompleted        prometheus.Counter
-	compactionRunsFailed           prometheus.Counter
+	compactionRunsCompleted        *prometheus.CounterVec
+	compactionRunTime              *prometheus.HistogramVec
 	compactionRunDiscoveredTenants prometheus.Counter
 	compactionRunSkippedTenants    prometheus.Counter
-	compactionRunSucceededTenants  prometheus.Counter
-	compactionRunFailedTenants     prometheus.Counter
+	compactionRunTenantsCompleted  *prometheus.CounterVec
+	compactionRunTenantsTime       *prometheus.HistogramVec
 	compactionRunJobStarted        prometheus.Counter
-	compactionRunJobSuceeded       prometheus.Counter
-	compactionRunJobFailed         prometheus.Counter
+	compactionRunJobCompleted      *prometheus.CounterVec
+	compactionRunJobTime           *prometheus.HistogramVec
 	compactionRunInterval          prometheus.Gauge
 	compactorRunning               prometheus.Gauge
 }
@@ -33,18 +33,19 @@ func newMetrics(r prometheus.Registerer) *metrics {
 			Name:      "runs_started_total",
 			Help:      "Total number of compactions started",
 		}),
-		compactionRunsCompleted: promauto.With(r).NewCounter(prometheus.CounterOpts{
+		compactionRunsCompleted: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
 			Namespace: metricsNamespace,
 			Subsystem: metricsSubsystem,
 			Name:      "runs_completed_total",
 			Help:      "Total number of compactions completed successfully",
-		}),
-		compactionRunsFailed: promauto.With(r).NewCounter(prometheus.CounterOpts{
+		}, []string{"status"}),
+		compactionRunTime: promauto.With(r).NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: metricsNamespace,
 			Subsystem: metricsSubsystem,
-			Name:      "runs_failed_total",
-			Help:      "Total number of compaction runs failed",
-		}),
+			Name:      "runs_time_seconds",
+			Help:      "Time spent during a compaction cycle.",
+			Buckets:   prometheus.DefBuckets,
+		}, []string{"status"}),
 		compactionRunDiscoveredTenants: promauto.With(r).NewCounter(prometheus.CounterOpts{
 			Namespace: metricsNamespace,
 			Subsystem: metricsSubsystem,
@@ -57,36 +58,38 @@ func newMetrics(r prometheus.Registerer) *metrics {
 			Name:      "tenants_skipped",
 			Help:      "Number of tenants skipped during the current compaction run",
 		}),
-		compactionRunSucceededTenants: promauto.With(r).NewCounter(prometheus.CounterOpts{
+		compactionRunTenantsCompleted: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
 			Namespace: metricsNamespace,
 			Subsystem: metricsSubsystem,
-			Name:      "tenants_succeeded",
+			Name:      "tenants_completed",
 			Help:      "Number of tenants successfully processed during the current compaction run",
-		}),
-		compactionRunFailedTenants: promauto.With(r).NewCounter(prometheus.CounterOpts{
+		}, []string{"status"}),
+		compactionRunTenantsTime: promauto.With(r).NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: metricsNamespace,
 			Subsystem: metricsSubsystem,
-			Name:      "tenants_failed",
-			Help:      "Number of tenants failed processing during the current compaction run",
-		}),
+			Name:      "tenants_time_seconds",
+			Help:      "Time spent processing tenants.",
+			Buckets:   prometheus.DefBuckets,
+		}, []string{"status"}),
 		compactionRunJobStarted: promauto.With(r).NewCounter(prometheus.CounterOpts{
 			Namespace: metricsNamespace,
 			Subsystem: metricsSubsystem,
 			Name:      "job_started",
 			Help:      "Number of jobs started processing during the current compaction run",
 		}),
-		compactionRunJobSuceeded: promauto.With(r).NewCounter(prometheus.CounterOpts{
+		compactionRunJobCompleted: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
 			Namespace: metricsNamespace,
 			Subsystem: metricsSubsystem,
-			Name:      "job_succeeded",
+			Name:      "job_completed",
 			Help:      "Number of jobs successfully processed during the current compaction run",
-		}),
-		compactionRunJobFailed: promauto.With(r).NewCounter(prometheus.CounterOpts{
+		}, []string{"status"}),
+		compactionRunJobTime: promauto.With(r).NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: metricsNamespace,
 			Subsystem: metricsSubsystem,
-			Name:      "job_failed",
-			Help:      "Number of jobs failed processing during the current compaction run",
-		}),
+			Name:      "job_time_seconds",
+			Help:      "Time spent processing jobs.",
+			Buckets:   prometheus.DefBuckets,
+		}, []string{"status"}),
 		compactionRunInterval: promauto.With(r).NewGauge(prometheus.GaugeOpts{
 			Namespace: metricsNamespace,
 			Subsystem: metricsSubsystem,


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR modifies the metrics of the bloom compactor to:
- Add new histogram metrics to track the time spent to process compaction cycles, tenants and jobs.
- Replace `_succeeded` and `_failed` metrics with a new `_completed` metric with a status label. 

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
