### PR TITLE
[Blooms] Fix panic when accessing page outside of page bounds

### DIFF
--- a/pkg/storage/bloom/v1/index_querier.go
+++ b/pkg/storage/bloom/v1/index_querier.go
@@ -52,8 +52,6 @@ func (it *LazySeriesIter) Seek(fp model.Fingerprint) error {
 		return header.ThroughFp >= fp
 	})
 
-	page := it.b.index.pageHeaders[desiredPage]
-
 	switch {
 	case desiredPage == len(it.b.index.pageHeaders):
 		// no overlap exists, either because no page was found with a throughFP >= fp
@@ -68,6 +66,7 @@ func (it *LazySeriesIter) Seek(fp model.Fingerprint) error {
 		// on the right page, no action needed
 	default:
 		// need to load a new page
+		page := it.b.index.pageHeaders[desiredPage]
 		r, err := it.b.reader.Index()
 		if err != nil {
 			return errors.Wrap(err, "getting index reader")

--- a/pkg/storage/bloom/v1/index_test.go
+++ b/pkg/storage/bloom/v1/index_test.go
@@ -9,26 +9,6 @@ import (
 	"github.com/grafana/loki/pkg/util/encoding"
 )
 
-// does not include a real bloom offset
-func mkBasicSeries(n int, fromFp, throughFp model.Fingerprint, fromTs, throughTs model.Time) []SeriesWithOffset {
-	var seriesList []SeriesWithOffset
-	for i := 0; i < n; i++ {
-		var series SeriesWithOffset
-		step := (throughFp - fromFp) / (model.Fingerprint(n))
-		series.Fingerprint = fromFp + model.Fingerprint(i)*step
-		timeDelta := fromTs + (throughTs-fromTs)/model.Time(n)*model.Time(i)
-		series.Chunks = []ChunkRef{
-			{
-				Start:    fromTs + timeDelta*model.Time(i),
-				End:      fromTs + timeDelta*model.Time(i),
-				Checksum: uint32(i),
-			},
-		}
-		seriesList = append(seriesList, series)
-	}
-	return seriesList
-}
-
 func TestBloomOffsetEncoding(t *testing.T) {
 	src := BloomOffset{Page: 1, ByteOffset: 2}
 	enc := &encoding.Encbuf{}


### PR DESCRIPTION
Move variable declaration to only access the desired page when it's valid. Also removes an unused (duplicate) test fn.