### PR TITLE
Bloom Gateway: Make tasks cancelable

### DIFF
--- a/pkg/bloomgateway/bloomgateway.go
+++ b/pkg/bloomgateway/bloomgateway.go
@@ -411,9 +411,6 @@ outer:
 func consumeTask(ctx context.Context, task Task, tasksCh chan<- Task, logger log.Logger) {
 	logger = log.With(logger, "task", task.ID)
 
-	task.responses = responsesPool.Get(len(task.series))
-	defer responsesPool.Put(task.responses)
-
 	for res := range task.resCh {
 		select {
 		case <-ctx.Done():

--- a/pkg/bloomgateway/bloomgateway.go
+++ b/pkg/bloomgateway/bloomgateway.go
@@ -330,17 +330,17 @@ func (g *Gateway) FilterChunkRefs(ctx context.Context, req *logproto.FilterChunk
 	})
 
 	var numSeries int
-	seriesWithBloomsPerDay := partitionRequest(req)
+	seriesByDay := partitionRequest(req)
 
 	// no tasks --> empty response
-	if len(seriesWithBloomsPerDay) == 0 {
+	if len(seriesByDay) == 0 {
 		return &logproto.FilterChunkRefResponse{
 			ChunkRefs: []*logproto.GroupedChunkRefs{},
 		}, nil
 	}
 
-	tasks := make([]Task, 0, len(seriesWithBloomsPerDay))
-	for _, seriesWithBounds := range seriesWithBloomsPerDay {
+	tasks := make([]Task, 0, len(seriesByDay))
+	for _, seriesWithBounds := range seriesByDay {
 		task, err := NewTask(ctx, tenantID, seriesWithBounds, req.Filters)
 		if err != nil {
 			return nil, err

--- a/pkg/bloomgateway/bloomgateway_test.go
+++ b/pkg/bloomgateway/bloomgateway_test.go
@@ -183,6 +183,52 @@ func TestBloomGateway_FilterChunkRefs(t *testing.T) {
 		MaxOutstandingPerTenant: 1024,
 	}
 
+	t.Run("request cancellation does not result in channel locking", func(t *testing.T) {
+		reg := prometheus.NewRegistry()
+		gw, err := New(cfg, schemaCfg, storageCfg, limits, ss, cm, logger, reg)
+		require.NoError(t, err)
+
+		now := mktime("2024-01-25 10:00")
+
+		bqs, data := createBlockQueriers(t, 10, now.Add(-24*time.Hour), now, 0, 1024)
+		mockStore := newMockBloomStore(bqs)
+		mockStore.delay = 100 * time.Millisecond // delay for each block
+		gw.bloomShipper = mockStore
+
+		err = gw.initServices()
+		require.NoError(t, err)
+
+		err = services.StartAndAwaitRunning(context.Background(), gw)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			err = services.StopAndAwaitTerminated(context.Background(), gw)
+			require.NoError(t, err)
+		})
+
+		chunkRefs := createQueryInputFromBlockData(t, tenantID, data, 100)
+
+		// saturate workers
+		// then send additional request
+		for i := 0; i < gw.cfg.WorkerConcurrency+1; i++ {
+			req := &logproto.FilterChunkRefRequest{
+				From:    now.Add(-24 * time.Hour),
+				Through: now,
+				Refs:    groupRefs(t, chunkRefs),
+				Filters: []syntax.LineFilter{
+					{Ty: labels.MatchEqual, Match: "does not match"},
+				},
+			}
+
+			ctx, cancelFn := context.WithTimeout(context.Background(), 200*time.Millisecond)
+			ctx = user.InjectOrgID(ctx, tenantID)
+			t.Cleanup(cancelFn)
+
+			res, err := gw.FilterChunkRefs(ctx, req)
+			require.ErrorContainsf(t, err, context.DeadlineExceeded.Error(), "%+v", res)
+		}
+
+	})
+
 	t.Run("returns unfiltered chunk refs if no filters provided", func(t *testing.T) {
 		reg := prometheus.NewRegistry()
 		gw, err := New(cfg, schemaCfg, storageCfg, limits, ss, cm, logger, reg)
@@ -428,12 +474,17 @@ func newMockBloomStore(bqs []bloomshipper.BlockQuerierWithFingerprintRange) *moc
 
 type mockBloomStore struct {
 	bqs []bloomshipper.BlockQuerierWithFingerprintRange
+	// mock how long it takes to serve block queriers
+	delay time.Duration
+	// mock response error when serving block queriers in ForEach
+	err error
 }
 
 var _ bloomshipper.Interface = &mockBloomStore{}
 
 // GetBlockRefs implements bloomshipper.Interface
 func (s *mockBloomStore) GetBlockRefs(_ context.Context, tenant string, _ bloomshipper.Interval) ([]bloomshipper.BlockRef, error) {
+	time.Sleep(s.delay)
 	blocks := make([]bloomshipper.BlockRef, 0, len(s.bqs))
 	for i := range s.bqs {
 		blocks = append(blocks, bloomshipper.BlockRef{
@@ -452,6 +503,11 @@ func (s *mockBloomStore) Stop() {}
 
 // Fetch implements bloomshipper.Interface
 func (s *mockBloomStore) Fetch(_ context.Context, _ string, _ []bloomshipper.BlockRef, callback bloomshipper.ForEachBlockCallback) error {
+	if s.err != nil {
+		time.Sleep(s.delay)
+		return s.err
+	}
+
 	shuffled := make([]bloomshipper.BlockQuerierWithFingerprintRange, len(s.bqs))
 	_ = copy(shuffled, s.bqs)
 
@@ -461,7 +517,11 @@ func (s *mockBloomStore) Fetch(_ context.Context, _ string, _ []bloomshipper.Blo
 
 	for _, bq := range shuffled {
 		// ignore errors in the mock
-		_ = callback(bq.BlockQuerier, uint64(bq.MinFp), uint64(bq.MaxFp))
+		time.Sleep(s.delay)
+		err := callback(bq.BlockQuerier, uint64(bq.MinFp), uint64(bq.MaxFp))
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/pkg/bloomgateway/bloomgateway_test.go
+++ b/pkg/bloomgateway/bloomgateway_test.go
@@ -236,9 +236,9 @@ func TestBloomGateway_FilterChunkRefs(t *testing.T) {
 
 		now := mktime("2024-01-25 10:00")
 
-		bqs, data := createBlockQueriers(t, 10, now.Add(-24*time.Hour), now, 0, 1024)
+		bqs, data := createBlockQueriers(t, 50, now.Add(-24*time.Hour), now, 0, 1024)
 		mockStore := newMockBloomStore(bqs)
-		mockStore.delay = 100 * time.Millisecond // delay for each block
+		mockStore.delay = 50 * time.Millisecond // delay for each block - 50x50=2500ms
 		gw.bloomShipper = mockStore
 
 		err = gw.initServices()
@@ -265,7 +265,7 @@ func TestBloomGateway_FilterChunkRefs(t *testing.T) {
 				},
 			}
 
-			ctx, cancelFn := context.WithTimeout(context.Background(), 200*time.Millisecond)
+			ctx, cancelFn := context.WithTimeout(context.Background(), 500*time.Millisecond)
 			ctx = user.InjectOrgID(ctx, tenantID)
 			t.Cleanup(cancelFn)
 

--- a/pkg/bloomgateway/multiplexing.go
+++ b/pkg/bloomgateway/multiplexing.go
@@ -1,6 +1,9 @@
 package bloomgateway
 
 import (
+	"context"
+	"math/rand"
+	"sync"
 	"time"
 
 	"github.com/oklog/ulid"
@@ -15,8 +18,27 @@ const (
 	Day = 24 * time.Hour
 )
 
+var (
+	entropy = rand.New(rand.NewSource(time.Now().UnixNano()))
+)
+
 type tokenSettings struct {
 	nGramLen int
+}
+
+type wrappedError struct {
+	mu  sync.Mutex
+	err error
+}
+
+func (e *wrappedError) Error() string {
+	return e.err.Error()
+}
+
+func (e *wrappedError) Set(err error) {
+	e.mu.Lock()
+	e.err = err
+	e.mu.Unlock()
 }
 
 // Task is the data structure that is enqueued to the internal queue and dequeued by query workers
@@ -26,10 +48,16 @@ type Task struct {
 	// Tenant is the tenant ID
 	Tenant string
 
-	// ErrCh is a send-only channel to write an error to
-	ErrCh chan error
-	// ResCh is a send-only channel to write partial responses to
-	ResCh chan v1.Output
+	// channel to write partial responses to
+	resCh chan v1.Output
+	// channel to notify listener that the task is done
+	done chan struct{}
+
+	// the last error of the task
+	// needs to be a pointer so multiple copies of the task can modify its value
+	err *wrappedError
+	// the respones received from the block queriers
+	responses []v1.Output
 
 	// series of the original request
 	series []*logproto.GroupedChunkRefs
@@ -37,6 +65,8 @@ type Task struct {
 	filters []syntax.LineFilter
 	// from..through date of the task's chunks
 	bounds model.Interval
+	// the context from the request
+	ctx context.Context
 
 	// TODO(chaudum): Investigate how to remove that.
 	day model.Time
@@ -45,23 +75,23 @@ type Task struct {
 // NewTask returns a new Task that can be enqueued to the task queue.
 // In addition, it returns a result and an error channel, as well
 // as an error if the instantiation fails.
-func NewTask(tenantID string, refs seriesWithBounds, filters []syntax.LineFilter) (Task, error) {
-	key, err := ulid.New(ulid.Now(), nil)
+func NewTask(ctx context.Context, tenantID string, refs seriesWithBounds, filters []syntax.LineFilter) (Task, error) {
+	key, err := ulid.New(ulid.Now(), entropy)
 	if err != nil {
 		return Task{}, err
 	}
-	errCh := make(chan error, 1)
-	resCh := make(chan v1.Output, len(refs.series))
 
 	task := Task{
 		ID:      key,
 		Tenant:  tenantID,
-		ErrCh:   errCh,
-		ResCh:   resCh,
+		err:     new(wrappedError),
+		resCh:   make(chan v1.Output),
 		filters: filters,
 		series:  refs.series,
 		bounds:  refs.bounds,
 		day:     refs.day,
+		ctx:     ctx,
+		done:    make(chan struct{}),
 	}
 	return task, nil
 }
@@ -70,17 +100,37 @@ func (t Task) Bounds() (model.Time, model.Time) {
 	return t.bounds.Start, t.bounds.End
 }
 
+func (t Task) Done() <-chan struct{} {
+	return t.done
+}
+
+func (t Task) Err() error {
+	return t.err.err
+}
+
+func (t Task) Close() {
+	close(t.resCh)
+	close(t.done)
+}
+
+func (t Task) CloseWithError(err error) {
+	t.err.Set(err)
+	t.Close()
+}
+
 // Copy returns a copy of the existing task but with a new slice of grouped chunk refs
 func (t Task) Copy(series []*logproto.GroupedChunkRefs) Task {
+	// do not copy ID to distinguish it as copied task
 	return Task{
-		ID:      ulid.ULID{}, // create emty ID to distinguish it as copied task
 		Tenant:  t.Tenant,
-		ErrCh:   t.ErrCh,
-		ResCh:   t.ResCh,
+		err:     t.err,
+		resCh:   t.resCh,
 		filters: t.filters,
 		series:  series,
 		bounds:  t.bounds,
 		day:     t.day,
+		ctx:     t.ctx,
+		done:    make(chan struct{}),
 	}
 }
 
@@ -88,7 +138,7 @@ func (t Task) RequestIter(tokenizer *v1.NGramTokenizer) v1.Iterator[v1.Request] 
 	return &requestIterator{
 		series:   v1.NewSliceIter(t.series),
 		searches: convertToSearches(t.filters, tokenizer),
-		channel:  t.ResCh,
+		channel:  t.resCh,
 		curr:     v1.Request{},
 	}
 }
@@ -104,7 +154,6 @@ type requestIterator struct {
 
 // At implements v1.Iterator.
 func (it *requestIterator) At() v1.Request {
-
 	return it.curr
 }
 

--- a/pkg/bloomgateway/multiplexing.go
+++ b/pkg/bloomgateway/multiplexing.go
@@ -82,16 +82,17 @@ func NewTask(ctx context.Context, tenantID string, refs seriesWithBounds, filter
 	}
 
 	task := Task{
-		ID:      key,
-		Tenant:  tenantID,
-		err:     new(wrappedError),
-		resCh:   make(chan v1.Output),
-		filters: filters,
-		series:  refs.series,
-		bounds:  refs.bounds,
-		day:     refs.day,
-		ctx:     ctx,
-		done:    make(chan struct{}),
+		ID:        key,
+		Tenant:    tenantID,
+		err:       new(wrappedError),
+		resCh:     make(chan v1.Output),
+		filters:   filters,
+		series:    refs.series,
+		bounds:    refs.bounds,
+		day:       refs.day,
+		ctx:       ctx,
+		done:      make(chan struct{}),
+		responses: make([]v1.Output, 0, len(refs.series)),
 	}
 	return task, nil
 }
@@ -122,15 +123,16 @@ func (t Task) CloseWithError(err error) {
 func (t Task) Copy(series []*logproto.GroupedChunkRefs) Task {
 	// do not copy ID to distinguish it as copied task
 	return Task{
-		Tenant:  t.Tenant,
-		err:     t.err,
-		resCh:   t.resCh,
-		filters: t.filters,
-		series:  series,
-		bounds:  t.bounds,
-		day:     t.day,
-		ctx:     t.ctx,
-		done:    make(chan struct{}),
+		Tenant:    t.Tenant,
+		err:       t.err,
+		resCh:     t.resCh,
+		filters:   t.filters,
+		series:    series,
+		bounds:    t.bounds,
+		day:       t.day,
+		ctx:       t.ctx,
+		done:      make(chan struct{}),
+		responses: make([]v1.Output, 0, len(series)),
 	}
 }
 

--- a/pkg/bloomgateway/multiplexing_test.go
+++ b/pkg/bloomgateway/multiplexing_test.go
@@ -1,6 +1,7 @@
 package bloomgateway
 
 import (
+	"context"
 	"math"
 	"testing"
 	"time"
@@ -29,7 +30,7 @@ func TestTask(t *testing.T) {
 			},
 		}
 		swb := partitionRequest(req)[0]
-		task, err := NewTask("tenant", swb, nil)
+		task, err := NewTask(context.Background(), "tenant", swb, nil)
 		require.NoError(t, err)
 		from, through := task.Bounds()
 		require.Equal(t, ts.Add(-1*time.Hour), from)
@@ -43,7 +44,7 @@ func createTasksForRequests(t *testing.T, tenant string, requests ...*logproto.F
 	tasks := make([]Task, 0, len(requests))
 	for _, r := range requests {
 		for _, swb := range partitionRequest(r) {
-			task, err := NewTask(tenant, swb, nil)
+			task, err := NewTask(context.Background(), tenant, swb, nil)
 			require.NoError(t, err)
 			tasks = append(tasks, task)
 		}
@@ -61,7 +62,7 @@ func TestTask_RequestIterator(t *testing.T) {
 			bounds: model.Interval{Start: 0, End: math.MaxInt64},
 			series: []*logproto.GroupedChunkRefs{},
 		}
-		task, _ := NewTask(tenant, swb, []syntax.LineFilter{})
+		task, _ := NewTask(context.Background(), tenant, swb, []syntax.LineFilter{})
 		it := task.RequestIter(tokenizer)
 		// nothing to iterate over
 		require.False(t, it.Next())

--- a/pkg/bloomgateway/worker.go
+++ b/pkg/bloomgateway/worker.go
@@ -108,90 +108,72 @@ func (w *worker) starting(_ context.Context) error {
 func (w *worker) running(ctx context.Context) error {
 	idx := queue.StartIndexWithLocalQueue
 
-	for {
-		select {
-
-		case <-ctx.Done():
-			return ctx.Err()
-
-		default:
-			taskCtx := context.Background()
-			dequeueStart := time.Now()
-			items, newIdx, err := w.queue.DequeueMany(taskCtx, idx, w.id, w.cfg.maxItems, w.cfg.maxWaitTime)
-			w.metrics.dequeueWaitTime.WithLabelValues(w.id).Observe(time.Since(dequeueStart).Seconds())
-			if err != nil {
-				// We only return an error if the queue is stopped and dequeuing did not yield any items
-				if err == queue.ErrStopped && len(items) == 0 {
-					return err
-				}
-				w.metrics.dequeueErrors.WithLabelValues(w.id).Inc()
-				level.Error(w.logger).Log("msg", "failed to dequeue tasks", "err", err, "items", len(items))
+	for st := w.State(); st == services.Running || st == services.Stopping; {
+		taskCtx := context.Background()
+		dequeueStart := time.Now()
+		items, newIdx, err := w.queue.DequeueMany(taskCtx, idx, w.id, w.cfg.maxItems, w.cfg.maxWaitTime)
+		w.metrics.dequeueWaitTime.WithLabelValues(w.id).Observe(time.Since(dequeueStart).Seconds())
+		if err != nil {
+			// We only return an error if the queue is stopped and dequeuing did not yield any items
+			if err == queue.ErrStopped && len(items) == 0 {
+				return err
 			}
-			idx = newIdx
+			w.metrics.dequeueErrors.WithLabelValues(w.id).Inc()
+			level.Error(w.logger).Log("msg", "failed to dequeue tasks", "err", err, "items", len(items))
+		}
+		idx = newIdx
 
-			if len(items) == 0 {
+		if len(items) == 0 {
+			w.queue.ReleaseRequests(items)
+			continue
+		}
+		w.metrics.dequeuedTasks.WithLabelValues(w.id).Add(float64(len(items)))
+
+		tasksPerDay := make(map[model.Time][]Task)
+
+		for _, item := range items {
+			task, ok := item.(Task)
+			if !ok {
+				// This really should never happen, because only the bloom gateway itself can enqueue tasks.
 				w.queue.ReleaseRequests(items)
+				return errors.Errorf("failed to cast dequeued item to Task: %v", item)
+			}
+			level.Debug(w.logger).Log("msg", "dequeued task", "task", task.ID)
+			w.pending.Delete(task.ID)
+
+			tasksPerDay[task.day] = append(tasksPerDay[task.day], task)
+		}
+
+		for day, tasks := range tasksPerDay {
+			// interval is [Start, End)
+			interval := bloomshipper.Interval{
+				Start: day,          // inclusive
+				End:   day.Add(Day), // non-inclusive
+			}
+
+			logger := log.With(w.logger, "day", day.Time(), "tenant", tasks[0].Tenant)
+			level.Debug(logger).Log("msg", "process tasks", "tasks", len(tasks))
+
+			storeFetchStart := time.Now()
+			blockRefs, err := w.shipper.GetBlockRefs(taskCtx, tasks[0].Tenant, interval)
+			w.metrics.storeAccessLatency.WithLabelValues(w.id, "GetBlockRefs").Observe(time.Since(storeFetchStart).Seconds())
+			if err != nil {
+				for _, t := range tasks {
+					t.CloseWithError(err)
+				}
+				// continue with tasks of next day
 				continue
 			}
-			w.metrics.dequeuedTasks.WithLabelValues(w.id).Add(float64(len(items)))
-
-			tasksPerDay := make(map[model.Time][]Task)
-
-			for _, item := range items {
-				task, ok := item.(Task)
-				if !ok {
-					// This really should never happen, because only the bloom gateway itself can enqueue tasks.
-					w.queue.ReleaseRequests(items)
-					return errors.Errorf("failed to cast dequeued item to Task: %v", item)
+			// No blocks found.
+			// Since there are no blocks for the given tasks, we need to return the
+			// unfiltered list of chunk refs.
+			if len(blockRefs) == 0 {
+				level.Warn(logger).Log("msg", "no blocks found")
+				for _, t := range tasks {
+					t.Close()
 				}
-				level.Debug(w.logger).Log("msg", "dequeued task", "task", task.ID)
-				w.pending.Delete(task.ID)
-
-				tasksPerDay[task.day] = append(tasksPerDay[task.day], task)
-			}
-
-			for day, tasks := range tasksPerDay {
-				// interval is [Start, End)
-				interval := bloomshipper.Interval{
-					Start: day,          // inclusive
-					End:   day.Add(Day), // non-inclusive
-				}
-
-				logger := log.With(w.logger, "day", day.Time(), "tenant", tasks[0].Tenant)
-				level.Debug(logger).Log("msg", "process tasks", "tasks", len(tasks))
-
-				storeFetchStart := time.Now()
-				blockRefs, err := w.shipper.GetBlockRefs(taskCtx, tasks[0].Tenant, interval)
-				w.metrics.storeAccessLatency.WithLabelValues(w.id, "GetBlockRefs").Observe(time.Since(storeFetchStart).Seconds())
-				if err != nil {
-					for _, t := range tasks {
-						t.CloseWithError(err)
-					}
-					// continue with tasks of next day
-					continue
-				}
-				// No blocks found.
-				// Since there are no blocks for the given tasks, we need to return the
-				// unfiltered list of chunk refs.
-				if len(blockRefs) == 0 {
-					level.Warn(logger).Log("msg", "no blocks found")
-					for _, t := range tasks {
-						t.Close()
-					}
-					// continue with tasks of next day
-					continue
-				}
-
-				// Remove tasks that are already cancelled
-				tasks = slices.DeleteFunc(tasks, func(t Task) bool {
-					if res := t.ctx.Err(); res != nil {
-						t.CloseWithError(res)
-						return true
-					}
-					return false
-				})
-				// no tasks to process
 				// continue with tasks of next day
+
 				if len(tasks) == 0 {
 					continue
 				}
@@ -218,10 +200,47 @@ func (w *worker) running(ctx context.Context) error {
 				}
 			}
 
-			// return dequeued items back to the pool
-			w.queue.ReleaseRequests(items)
+			// Remove tasks that are already cancelled
+			tasks = slices.DeleteFunc(tasks, func(t Task) bool {
+				if res := t.ctx.Err(); res != nil {
+					t.CloseWithError(res)
+					return true
+				}
+				return false
+			})
+			// no tasks to process
+			// continue with tasks of next day
+			if len(tasks) == 0 {
+				continue
+			}
+
+			tasksForBlocks := partitionFingerprintRange(tasks, blockRefs)
+			blockRefs = blockRefs[:0]
+			for _, b := range tasksForBlocks {
+				blockRefs = append(blockRefs, b.blockRef)
+			}
+
+			err = w.processBlocksWithCallback(taskCtx, tasks[0].Tenant, blockRefs, tasksForBlocks)
+			if err != nil {
+				for _, t := range tasks {
+					t.CloseWithError(err)
+				}
+				// continue with tasks of next day
+				continue
+			}
+
+			// all tasks for this day are done.
+			// close them to notify the request handler
+			for _, task := range tasks {
+				task.Close()
+			}
 		}
+
+		// return dequeued items back to the pool
+		w.queue.ReleaseRequests(items)
 	}
+
+	return nil
 }
 
 func (w *worker) stopping(err error) error {

--- a/pkg/bloomgateway/worker.go
+++ b/pkg/bloomgateway/worker.go
@@ -145,6 +145,21 @@ func (w *worker) running(_ context.Context) error {
 		}
 
 		for day, tasks := range tasksPerDay {
+
+			// Remove tasks that are already cancelled
+			tasks = slices.DeleteFunc(tasks, func(t Task) bool {
+				if res := t.ctx.Err(); res != nil {
+					t.CloseWithError(res)
+					return true
+				}
+				return false
+			})
+			// no tasks to process
+			// continue with tasks of next day
+			if len(tasks) == 0 {
+				continue
+			}
+
 			// interval is [Start, End)
 			interval := bloomshipper.Interval{
 				Start: day,          // inclusive

--- a/pkg/bloomgateway/worker.go
+++ b/pkg/bloomgateway/worker.go
@@ -286,7 +286,3 @@ func (w *worker) processBlock(blockQuerier *v1.BlockQuerier, tasks []Task) error
 	w.metrics.bloomQueryLatency.WithLabelValues(w.id, "success").Observe(duration)
 	return nil
 }
-
-func toModelTime(t time.Time) model.Time {
-	return model.TimeFromUnixNano(t.UnixNano())
-}

--- a/pkg/bloomgateway/worker.go
+++ b/pkg/bloomgateway/worker.go
@@ -105,7 +105,7 @@ func (w *worker) starting(_ context.Context) error {
 	return nil
 }
 
-func (w *worker) running(ctx context.Context) error {
+func (w *worker) running(_ context.Context) error {
 	idx := queue.StartIndexWithLocalQueue
 
 	for st := w.State(); st == services.Running || st == services.Stopping; {

--- a/pkg/bloomgateway/worker.go
+++ b/pkg/bloomgateway/worker.go
@@ -179,6 +179,10 @@ func (w *worker) running(_ context.Context) error {
 				// continue with tasks of next day
 				continue
 			}
+			if len(tasks) == 0 {
+				continue
+			}
+
 			// No blocks found.
 			// Since there are no blocks for the given tasks, we need to return the
 			// unfiltered list of chunk refs.
@@ -188,31 +192,7 @@ func (w *worker) running(_ context.Context) error {
 					t.Close()
 				}
 				// continue with tasks of next day
-
-				if len(tasks) == 0 {
-					continue
-				}
-
-				tasksForBlocks := partitionFingerprintRange(tasks, blockRefs)
-				blockRefs = blockRefs[:0]
-				for _, b := range tasksForBlocks {
-					blockRefs = append(blockRefs, b.blockRef)
-				}
-
-				err = w.processBlocksWithCallback(taskCtx, tasks[0].Tenant, blockRefs, tasksForBlocks)
-				if err != nil {
-					for _, t := range tasks {
-						t.CloseWithError(err)
-					}
-					// continue with tasks of next day
-					continue
-				}
-
-				// all tasks for this day are done.
-				// close them to notify the request handler
-				for _, task := range tasks {
-					task.Close()
-				}
+				continue
 			}
 
 			// Remove tasks that are already cancelled


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR refactors the bloom gateway workers so that tasks that have been enqueued by requests do not end up locking the results channel and therefore the worker, in case the request was cancelled (`context cancelled`) or timed out (`context deadline exceeded`).
It also handles errors from the shipper in a way that they are returned to the waiting request asap so it can return and does not need to wait for all tasks to finish.

This PR also fixes the worker shutdown in a way that it now gracefully stops and continues to work off the remaining tasks from the queue.