### PR TITLE
Bloom Gateway: Extract processing logic from bloom worker into separate struct

### DIFF
--- a/pkg/bloomcompactor/bloomcompactor.go
+++ b/pkg/bloomcompactor/bloomcompactor.go
@@ -498,11 +498,9 @@ func (c *Compactor) runCompact(ctx context.Context, logger log.Logger, job Job, 
 		return err
 	}
 	metaSearchParams := bloomshipper.MetaSearchParams{
-		TenantID:       job.tenantID,
-		MinFingerprint: job.minFp,
-		MaxFingerprint: job.maxFp,
-		StartTimestamp: job.from,
-		EndTimestamp:   job.through,
+		TenantID: job.tenantID,
+		Keyspace: bloomshipper.Keyspace{Min: job.minFp, Max: job.maxFp},
+		Interval: bloomshipper.Interval{Start: job.from, End: job.through},
 	}
 	var metas []bloomshipper.Meta
 	//TODO  Configure pool for these to avoid allocations

--- a/pkg/bloomgateway/processor.go
+++ b/pkg/bloomgateway/processor.go
@@ -6,9 +6,10 @@ import (
 	"sort"
 
 	"github.com/go-kit/log"
+	"github.com/prometheus/common/model"
+
 	v1 "github.com/grafana/loki/pkg/storage/bloom/v1"
 	"github.com/grafana/loki/pkg/storage/stores/shipper/bloomshipper"
-	"github.com/prometheus/common/model"
 )
 
 type tasksForBlock struct {

--- a/pkg/bloomgateway/processor.go
+++ b/pkg/bloomgateway/processor.go
@@ -1,0 +1,168 @@
+package bloomgateway
+
+import (
+	"context"
+	"math"
+	"sort"
+
+	"github.com/go-kit/log"
+	v1 "github.com/grafana/loki/pkg/storage/bloom/v1"
+	"github.com/grafana/loki/pkg/storage/stores/shipper/bloomshipper"
+	"github.com/prometheus/common/model"
+)
+
+type tasksForBlock struct {
+	blockRef bloomshipper.BlockRef
+	tasks    []Task
+}
+
+type metaLoader interface {
+	LoadMetas(context.Context, bloomshipper.MetaSearchParams) ([]bloomshipper.Meta, error)
+}
+
+type blockLoader interface {
+	LoadBlocks(context.Context, []bloomshipper.BlockRef) (v1.Iterator[bloomshipper.BlockQuerierWithFingerprintRange], error)
+}
+
+type store interface {
+	blockLoader
+	metaLoader
+}
+
+type processor struct {
+	store  store
+	logger log.Logger
+}
+
+func (p *processor) run(ctx context.Context, tasks []Task) error {
+	for ts, tasks := range group(tasks, func(t Task) model.Time { return t.day }) {
+		interval := bloomshipper.Interval{
+			Start: ts,
+			End:   ts.Add(Day),
+		}
+		tenant := tasks[0].Tenant
+		err := p.do(ctx, tenant, interval, []bloomshipper.Keyspace{{Min: 0, Max: math.MaxUint64}}, tasks)
+		if err != nil {
+			for _, task := range tasks {
+				task.CloseWithError(err)
+			}
+			return err
+		}
+		for _, task := range tasks {
+			task.Close()
+		}
+	}
+	return nil
+}
+
+func (p *processor) do(ctx context.Context, tenant string, interval bloomshipper.Interval, keyspaces []bloomshipper.Keyspace, tasks []Task) error {
+	minFpRange, maxFpRange := getFirstLast(keyspaces)
+	metaSearch := bloomshipper.MetaSearchParams{
+		TenantID: tenant,
+		Interval: interval,
+		Keyspace: bloomshipper.Keyspace{Min: minFpRange.Min, Max: maxFpRange.Max},
+	}
+	metas, err := p.store.LoadMetas(ctx, metaSearch)
+	if err != nil {
+		return err
+	}
+	blocksRefs := bloomshipper.BlocksForMetas(metas, interval, keyspaces)
+	return p.process(ctx, partition(tasks, blocksRefs))
+}
+
+func (p *processor) process(ctx context.Context, data []tasksForBlock) error {
+	refs := make([]bloomshipper.BlockRef, len(data))
+	for _, block := range data {
+		refs = append(refs, block.blockRef)
+	}
+
+	blockIter, err := p.store.LoadBlocks(ctx, refs)
+	if err != nil {
+		return err
+	}
+
+outer:
+	for blockIter.Next() {
+		bq := blockIter.At()
+		for i, block := range data {
+			if block.blockRef.MinFingerprint == uint64(bq.MinFp) && block.blockRef.MaxFingerprint == uint64(bq.MaxFp) {
+				err := p.processBlock(ctx, bq.BlockQuerier, block.tasks)
+				if err != nil {
+					return err
+				}
+				data = append(data[:i], data[i+1:]...)
+				continue outer
+			}
+		}
+	}
+	return nil
+}
+
+func (p *processor) processBlock(_ context.Context, blockQuerier *v1.BlockQuerier, tasks []Task) error {
+	schema, err := blockQuerier.Schema()
+	if err != nil {
+		return err
+	}
+
+	tokenizer := v1.NewNGramTokenizer(schema.NGramLen(), 0)
+	iters := make([]v1.PeekingIterator[v1.Request], 0, len(tasks))
+	for _, task := range tasks {
+		it := v1.NewPeekingIter(task.RequestIter(tokenizer))
+		iters = append(iters, it)
+	}
+
+	fq := blockQuerier.Fuse(iters)
+	return fq.Run()
+}
+
+// getFirstLast returns the first and last item of a fingerprint slice
+// It assumes an ascending sorted list of fingerprints.
+func getFirstLast[T any](s []T) (T, T) {
+	var zero T
+	if len(s) == 0 {
+		return zero, zero
+	}
+	return s[0], s[len(s)-1]
+}
+
+func group[K comparable, V any, S ~[]V](s S, f func(v V) K) map[K]S {
+	m := make(map[K]S)
+	for _, elem := range s {
+		m[f(elem)] = append(m[f(elem)], elem)
+	}
+	return m
+}
+
+func partition(tasks []Task, blocks []bloomshipper.BlockRef) []tasksForBlock {
+	result := make([]tasksForBlock, 0, len(blocks))
+
+	for _, block := range blocks {
+		bounded := tasksForBlock{
+			blockRef: block,
+		}
+
+		for _, task := range tasks {
+			refs := task.series
+			min := sort.Search(len(refs), func(i int) bool {
+				return block.Cmp(refs[i].Fingerprint) > v1.Before
+			})
+
+			max := sort.Search(len(refs), func(i int) bool {
+				return block.Cmp(refs[i].Fingerprint) == v1.After
+			})
+
+			// All fingerprints fall outside of the consumer's range
+			if min == len(refs) || max == 0 {
+				continue
+			}
+
+			bounded.tasks = append(bounded.tasks, task.Copy(refs[min:max]))
+		}
+
+		if len(bounded.tasks) > 0 {
+			result = append(result, bounded)
+		}
+
+	}
+	return result
+}

--- a/pkg/bloomgateway/processor_test.go
+++ b/pkg/bloomgateway/processor_test.go
@@ -7,12 +7,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/grafana/loki/pkg/logql/syntax"
-	v1 "github.com/grafana/loki/pkg/storage/bloom/v1"
-	"github.com/grafana/loki/pkg/storage/stores/shipper/bloomshipper"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
+
+	"github.com/grafana/loki/pkg/logql/syntax"
+	v1 "github.com/grafana/loki/pkg/storage/bloom/v1"
+	"github.com/grafana/loki/pkg/storage/stores/shipper/bloomshipper"
 )
 
 var _ store = &dummyStore{}

--- a/pkg/bloomgateway/processor_test.go
+++ b/pkg/bloomgateway/processor_test.go
@@ -1,0 +1,99 @@
+package bloomgateway
+
+import (
+	"context"
+	"math/rand"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/grafana/loki/pkg/logql/syntax"
+	v1 "github.com/grafana/loki/pkg/storage/bloom/v1"
+	"github.com/grafana/loki/pkg/storage/stores/shipper/bloomshipper"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
+)
+
+var _ store = &dummyStore{}
+
+type dummyStore struct {
+	metas     []bloomshipper.Meta
+	blocks    []bloomshipper.BlockRef
+	querieres []bloomshipper.BlockQuerierWithFingerprintRange
+}
+
+func (s *dummyStore) LoadMetas(_ context.Context, _ bloomshipper.MetaSearchParams) ([]bloomshipper.Meta, error) {
+	//TODO(chaudum) Filter metas based on search params
+	return s.metas, nil
+}
+
+func (s *dummyStore) LoadBlocks(_ context.Context, refs []bloomshipper.BlockRef) (v1.Iterator[bloomshipper.BlockQuerierWithFingerprintRange], error) {
+	result := make([]bloomshipper.BlockQuerierWithFingerprintRange, len(s.querieres))
+
+	for _, ref := range refs {
+		for _, bq := range s.querieres {
+			if ref.MinFingerprint == uint64(bq.MinFp) && ref.MaxFingerprint == uint64(bq.MaxFp) {
+				result = append(result, bq)
+			}
+		}
+	}
+
+	rand.Shuffle(len(result), func(i, j int) {
+		result[i], result[j] = result[j], result[i]
+	})
+
+	return v1.NewSliceIter(result), nil
+}
+
+func TestProcessor(t *testing.T) {
+	ctx := context.Background()
+	tenant := "fake"
+	now := mktime("2024-01-27 12:00")
+
+	t.Run("dummy", func(t *testing.T) {
+		blocks, metas, queriers, data := createBlocks(t, tenant, 10, now.Add(-1*time.Hour), now, 0x0000, 0x1000)
+		p := &processor{
+			store: &dummyStore{
+				querieres: queriers,
+				metas:     metas,
+				blocks:    blocks,
+			},
+		}
+
+		chunkRefs := createQueryInputFromBlockData(t, tenant, data, 10)
+		swb := seriesWithBounds{
+			series: groupRefs(t, chunkRefs),
+			bounds: model.Interval{
+				Start: now.Add(-1 * time.Hour),
+				End:   now,
+			},
+			day: truncateDay(now),
+		}
+		filters := []syntax.LineFilter{
+			{Ty: 0, Match: "no match"},
+		}
+
+		t.Log("series", len(swb.series))
+		task, _ := NewTask(ctx, "fake", swb, filters)
+		tasks := []Task{task}
+
+		results := atomic.NewInt64(0)
+		var wg sync.WaitGroup
+		for i := range tasks {
+			wg.Add(1)
+			go func(ta Task) {
+				defer wg.Done()
+				for range ta.resCh {
+					results.Inc()
+				}
+				t.Log("done", results.Load())
+			}(tasks[i])
+		}
+
+		err := p.run(ctx, tasks)
+		wg.Wait()
+		require.NoError(t, err)
+		require.Equal(t, int64(len(swb.series)), results.Load())
+	})
+}

--- a/pkg/bloomgateway/util_test.go
+++ b/pkg/bloomgateway/util_test.go
@@ -1,6 +1,9 @@
 package bloomgateway
 
 import (
+	"context"
+	"fmt"
+	"math/rand"
 	"testing"
 	"time"
 
@@ -8,8 +11,28 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/loki/pkg/logproto"
+	v1 "github.com/grafana/loki/pkg/storage/bloom/v1"
+	"github.com/grafana/loki/pkg/storage/config"
 	"github.com/grafana/loki/pkg/storage/stores/shipper/bloomshipper"
 )
+
+func parseDayTime(s string) config.DayTime {
+	t, err := time.Parse("2006-01-02", s)
+	if err != nil {
+		panic(err)
+	}
+	return config.DayTime{
+		Time: model.TimeFromUnix(t.Unix()),
+	}
+}
+
+func mktime(s string) model.Time {
+	ts, err := time.Parse("2006-01-02 15:04", s)
+	if err != nil {
+		panic(err)
+	}
+	return model.TimeFromUnix(ts.Unix())
+}
 
 func TestGetFromThrough(t *testing.T) {
 	chunks := []*logproto.ShortRef{
@@ -272,4 +295,179 @@ func TestPartitionRequest(t *testing.T) {
 		})
 	}
 
+}
+
+func createBlockQueriers(t *testing.T, numBlocks int, from, through model.Time, minFp, maxFp model.Fingerprint) ([]bloomshipper.BlockQuerierWithFingerprintRange, [][]v1.SeriesWithBloom) {
+	t.Helper()
+	step := (maxFp - minFp) / model.Fingerprint(numBlocks)
+	bqs := make([]bloomshipper.BlockQuerierWithFingerprintRange, 0, numBlocks)
+	series := make([][]v1.SeriesWithBloom, 0, numBlocks)
+	for i := 0; i < numBlocks; i++ {
+		fromFp := minFp + (step * model.Fingerprint(i))
+		throughFp := fromFp + step - 1
+		// last block needs to include maxFp
+		if i == numBlocks-1 {
+			throughFp = maxFp
+		}
+		blockQuerier, data := v1.MakeBlockQuerier(t, fromFp, throughFp, from, through)
+		bq := bloomshipper.BlockQuerierWithFingerprintRange{
+			BlockQuerier: blockQuerier,
+			MinFp:        fromFp,
+			MaxFp:        throughFp,
+		}
+		bqs = append(bqs, bq)
+		series = append(series, data)
+	}
+	return bqs, series
+}
+
+func createBlocks(t *testing.T, tenant string, n int, from, through model.Time, minFp, maxFp model.Fingerprint) ([]bloomshipper.BlockRef, []bloomshipper.Meta, []bloomshipper.BlockQuerierWithFingerprintRange, [][]v1.SeriesWithBloom) {
+	t.Helper()
+
+	blocks := make([]bloomshipper.BlockRef, 0, n)
+	metas := make([]bloomshipper.Meta, 0, n)
+	queriers := make([]bloomshipper.BlockQuerierWithFingerprintRange, 0, n)
+	series := make([][]v1.SeriesWithBloom, 0, n)
+
+	step := (maxFp - minFp) / model.Fingerprint(n)
+	for i := 0; i < n; i++ {
+		fromFp := minFp + (step * model.Fingerprint(i))
+		throughFp := fromFp + step - 1
+		// last block needs to include maxFp
+		if i == n-1 {
+			throughFp = maxFp
+		}
+		ref := bloomshipper.Ref{
+			TenantID:       tenant,
+			TableName:      "table_0",
+			MinFingerprint: uint64(fromFp),
+			MaxFingerprint: uint64(throughFp),
+			StartTimestamp: from,
+			EndTimestamp:   through,
+		}
+		block := bloomshipper.BlockRef{
+			Ref:       ref,
+			IndexPath: "index.tsdb.gz",
+			BlockPath: fmt.Sprintf("block-%d", i),
+		}
+		meta := bloomshipper.Meta{
+			MetaRef: bloomshipper.MetaRef{
+				Ref: ref,
+			},
+			Tombstones: []bloomshipper.BlockRef{},
+			Blocks:     []bloomshipper.BlockRef{block},
+		}
+		blockQuerier, data := v1.MakeBlockQuerier(t, fromFp, throughFp, from, through)
+		querier := bloomshipper.BlockQuerierWithFingerprintRange{
+			BlockQuerier: blockQuerier,
+			MinFp:        fromFp,
+			MaxFp:        throughFp,
+		}
+		queriers = append(queriers, querier)
+		metas = append(metas, meta)
+		blocks = append(blocks, block)
+		series = append(series, data)
+	}
+	return blocks, metas, queriers, series
+}
+
+func newMockBloomStore(bqs []bloomshipper.BlockQuerierWithFingerprintRange) *mockBloomStore {
+	return &mockBloomStore{bqs: bqs}
+}
+
+type mockBloomStore struct {
+	bqs []bloomshipper.BlockQuerierWithFingerprintRange
+	// mock how long it takes to serve block queriers
+	delay time.Duration
+	// mock response error when serving block queriers in ForEach
+	err error
+}
+
+var _ bloomshipper.Interface = &mockBloomStore{}
+
+// GetBlockRefs implements bloomshipper.Interface
+func (s *mockBloomStore) GetBlockRefs(_ context.Context, tenant string, _ bloomshipper.Interval) ([]bloomshipper.BlockRef, error) {
+	time.Sleep(s.delay)
+	blocks := make([]bloomshipper.BlockRef, 0, len(s.bqs))
+	for i := range s.bqs {
+		blocks = append(blocks, bloomshipper.BlockRef{
+			Ref: bloomshipper.Ref{
+				MinFingerprint: uint64(s.bqs[i].MinFp),
+				MaxFingerprint: uint64(s.bqs[i].MaxFp),
+				TenantID:       tenant,
+			},
+		})
+	}
+	return blocks, nil
+}
+
+// Stop implements bloomshipper.Interface
+func (s *mockBloomStore) Stop() {}
+
+// Fetch implements bloomshipper.Interface
+func (s *mockBloomStore) Fetch(_ context.Context, _ string, _ []bloomshipper.BlockRef, callback bloomshipper.ForEachBlockCallback) error {
+	if s.err != nil {
+		time.Sleep(s.delay)
+		return s.err
+	}
+
+	shuffled := make([]bloomshipper.BlockQuerierWithFingerprintRange, len(s.bqs))
+	_ = copy(shuffled, s.bqs)
+
+	rand.Shuffle(len(shuffled), func(i, j int) {
+		shuffled[i], shuffled[j] = shuffled[j], shuffled[i]
+	})
+
+	for _, bq := range shuffled {
+		// ignore errors in the mock
+		time.Sleep(s.delay)
+		err := callback(bq.BlockQuerier, uint64(bq.MinFp), uint64(bq.MaxFp))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func createQueryInputFromBlockData(t *testing.T, tenant string, data [][]v1.SeriesWithBloom, nthSeries int) []*logproto.ChunkRef {
+	t.Helper()
+	n := 0
+	res := make([]*logproto.ChunkRef, 0)
+	for i := range data {
+		for j := range data[i] {
+			if n%nthSeries == 0 {
+				chk := data[i][j].Series.Chunks[0]
+				res = append(res, &logproto.ChunkRef{
+					Fingerprint: uint64(data[i][j].Series.Fingerprint),
+					UserID:      tenant,
+					From:        chk.Start,
+					Through:     chk.End,
+					Checksum:    chk.Checksum,
+				})
+			}
+			n++
+		}
+	}
+	return res
+}
+
+func createBlockRefsFromBlockData(t *testing.T, tenant string, data []bloomshipper.BlockQuerierWithFingerprintRange) []bloomshipper.BlockRef {
+	t.Helper()
+	res := make([]bloomshipper.BlockRef, 0)
+	for i := range data {
+		res = append(res, bloomshipper.BlockRef{
+			Ref: bloomshipper.Ref{
+				TenantID:       tenant,
+				TableName:      "",
+				MinFingerprint: uint64(data[i].MinFp),
+				MaxFingerprint: uint64(data[i].MaxFp),
+				StartTimestamp: 0,
+				EndTimestamp:   0,
+				Checksum:       0,
+			},
+			IndexPath: fmt.Sprintf("index-%d", i),
+			BlockPath: fmt.Sprintf("block-%d", i),
+		})
+	}
+	return res
 }

--- a/pkg/storage/stores/shipper/bloomshipper/client.go
+++ b/pkg/storage/stores/shipper/bloomshipper/client.go
@@ -67,9 +67,9 @@ type Meta struct {
 }
 
 type MetaSearchParams struct {
-	TenantID                       string
-	MinFingerprint, MaxFingerprint model.Fingerprint
-	StartTimestamp, EndTimestamp   model.Time
+	TenantID string
+	Interval Interval
+	Keyspace Keyspace
 }
 
 type MetaClient interface {
@@ -126,7 +126,7 @@ type BloomClient struct {
 }
 
 func (b *BloomClient) GetMetas(ctx context.Context, params MetaSearchParams) ([]Meta, error) {
-	tablesByPeriod := tablesByPeriod(b.periodicConfigs, params.StartTimestamp, params.EndTimestamp)
+	tablesByPeriod := tablesByPeriod(b.periodicConfigs, params.Interval.Start, params.Interval.End)
 
 	var metas []Meta
 	for periodFrom, tables := range tablesByPeriod {
@@ -143,8 +143,8 @@ func (b *BloomClient) GetMetas(ctx context.Context, params MetaSearchParams) ([]
 				if err != nil {
 					return nil, err
 				}
-				if metaRef.MaxFingerprint < uint64(params.MinFingerprint) || uint64(params.MaxFingerprint) < metaRef.MinFingerprint ||
-					metaRef.EndTimestamp.Before(params.StartTimestamp) || metaRef.StartTimestamp.After(params.EndTimestamp) {
+				if metaRef.MaxFingerprint < uint64(params.Keyspace.Min) || uint64(params.Keyspace.Max) < metaRef.MinFingerprint ||
+					metaRef.EndTimestamp.Before(params.Interval.Start) || metaRef.StartTimestamp.After(params.Interval.End) {
 					continue
 				}
 				meta, err := b.downloadMeta(ctx, metaRef, periodClient)

--- a/pkg/storage/stores/shipper/bloomshipper/client_test.go
+++ b/pkg/storage/stores/shipper/bloomshipper/client_test.go
@@ -69,11 +69,9 @@ func Test_BloomClient_GetMetas(t *testing.T) {
 	createMetaInStorage(t, folder2, "second-period-19624", "tenantB", 0, 100, fixedDay.Add(-3*day))
 
 	actual, err := shipper.GetMetas(context.Background(), MetaSearchParams{
-		TenantID:       "tenantA",
-		MinFingerprint: 50,
-		MaxFingerprint: 150,
-		StartTimestamp: fixedDay.Add(-6 * day),
-		EndTimestamp:   fixedDay.Add(-1*day - 1*time.Hour),
+		TenantID: "tenantA",
+		Keyspace: Keyspace{Min: 50, Max: 150},
+		Interval: Interval{Start: fixedDay.Add(-6 * day), End: fixedDay.Add(-1*day - 1*time.Hour)},
 	})
 	require.NoError(t, err)
 	require.ElementsMatch(t, expected, actual)

--- a/pkg/storage/stores/shipper/bloomshipper/shipper_test.go
+++ b/pkg/storage/stores/shipper/bloomshipper/shipper_test.go
@@ -44,12 +44,11 @@ func Test_Shipper_findBlocks(t *testing.T) {
 
 		ts := model.Now()
 
-		shipper := &Shipper{}
 		interval := Interval{
 			Start: ts.Add(-2 * time.Hour),
 			End:   ts.Add(-1 * time.Hour),
 		}
-		blocks := shipper.findBlocks(metas, interval, []fpRange{{100, 200}})
+		blocks := BlocksForMetas(metas, interval, []Keyspace{{Min: 100, Max: 200}})
 
 		expectedBlockRefs := []BlockRef{
 			createMatchingBlockRef("block2"),
@@ -101,9 +100,8 @@ func Test_Shipper_findBlocks(t *testing.T) {
 	}
 	for name, data := range tests {
 		t.Run(name, func(t *testing.T) {
-			shipper := &Shipper{}
 			ref := createBlockRef("fake-block", data.minFingerprint, data.maxFingerprint, data.startTimestamp, data.endTimestamp)
-			blocks := shipper.findBlocks([]Meta{{Blocks: []BlockRef{ref}}}, interval(300, 400), []fpRange{{100, 200}})
+			blocks := BlocksForMetas([]Meta{{Blocks: []BlockRef{ref}}}, interval(300, 400), []Keyspace{{Min: 100, Max: 200}})
 			if data.filtered {
 				require.Empty(t, blocks)
 				return
@@ -120,67 +118,67 @@ func TestIsOutsideRange(t *testing.T) {
 
 	t.Run("is outside if startTs > through", func(t *testing.T) {
 		b := createBlockRef("block", 0, math.MaxUint64, startTs, endTs)
-		isOutside := isOutsideRange(b, interval(0, 900), []fpRange{})
+		isOutside := isOutsideRange(b, interval(0, 900), []Keyspace{})
 		require.True(t, isOutside)
 	})
 
 	t.Run("is outside if startTs == through ", func(t *testing.T) {
 		b := createBlockRef("block", 0, math.MaxUint64, startTs, endTs)
-		isOutside := isOutsideRange(b, interval(900, 1000), []fpRange{})
+		isOutside := isOutsideRange(b, interval(900, 1000), []Keyspace{})
 		require.True(t, isOutside)
 	})
 
 	t.Run("is outside if endTs < from", func(t *testing.T) {
 		b := createBlockRef("block", 0, math.MaxUint64, startTs, endTs)
-		isOutside := isOutsideRange(b, interval(2100, 3000), []fpRange{})
+		isOutside := isOutsideRange(b, interval(2100, 3000), []Keyspace{})
 		require.True(t, isOutside)
 	})
 
 	t.Run("is outside if endFp < first fingerprint", func(t *testing.T) {
 		b := createBlockRef("block", 0, 90, startTs, endTs)
-		isOutside := isOutsideRange(b, interval(startTs, endTs), []fpRange{{100, 199}})
+		isOutside := isOutsideRange(b, interval(startTs, endTs), []Keyspace{{100, 199}})
 		require.True(t, isOutside)
 	})
 
 	t.Run("is outside if startFp > last fingerprint", func(t *testing.T) {
 		b := createBlockRef("block", 200, math.MaxUint64, startTs, endTs)
-		isOutside := isOutsideRange(b, interval(startTs, endTs), []fpRange{{0, 49}, {100, 149}})
+		isOutside := isOutsideRange(b, interval(startTs, endTs), []Keyspace{{0, 49}, {100, 149}})
 		require.True(t, isOutside)
 	})
 
 	t.Run("is outside if within gaps in fingerprints", func(t *testing.T) {
 		b := createBlockRef("block", 100, 199, startTs, endTs)
-		isOutside := isOutsideRange(b, interval(startTs, endTs), []fpRange{{0, 99}, {200, 299}})
+		isOutside := isOutsideRange(b, interval(startTs, endTs), []Keyspace{{0, 99}, {200, 299}})
 		require.True(t, isOutside)
 	})
 
 	t.Run("is not outside if within fingerprints 1", func(t *testing.T) {
 		b := createBlockRef("block", 10, 90, startTs, endTs)
-		isOutside := isOutsideRange(b, interval(startTs, endTs), []fpRange{{0, 99}, {200, 299}})
+		isOutside := isOutsideRange(b, interval(startTs, endTs), []Keyspace{{0, 99}, {200, 299}})
 		require.False(t, isOutside)
 	})
 
 	t.Run("is not outside if within fingerprints 2", func(t *testing.T) {
 		b := createBlockRef("block", 210, 290, startTs, endTs)
-		isOutside := isOutsideRange(b, interval(startTs, endTs), []fpRange{{0, 99}, {200, 299}})
+		isOutside := isOutsideRange(b, interval(startTs, endTs), []Keyspace{{0, 99}, {200, 299}})
 		require.False(t, isOutside)
 	})
 
 	t.Run("is not outside if spans across multiple fingerprint ranges", func(t *testing.T) {
 		b := createBlockRef("block", 50, 250, startTs, endTs)
-		isOutside := isOutsideRange(b, interval(startTs, endTs), []fpRange{{0, 99}, {200, 299}})
+		isOutside := isOutsideRange(b, interval(startTs, endTs), []Keyspace{{0, 99}, {200, 299}})
 		require.False(t, isOutside)
 	})
 
 	t.Run("is not outside if fingerprint range and time range are larger than block", func(t *testing.T) {
 		b := createBlockRef("block", math.MaxUint64/3, math.MaxUint64/3*2, startTs, endTs)
-		isOutside := isOutsideRange(b, interval(0, 3000), []fpRange{{0, math.MaxUint64}})
+		isOutside := isOutsideRange(b, interval(0, 3000), []Keyspace{{0, math.MaxUint64}})
 		require.False(t, isOutside)
 	})
 
 	t.Run("is not outside if block fingerprint range is bigger that search keyspace", func(t *testing.T) {
 		b := createBlockRef("block", 0x0000, 0xffff, model.Earliest, model.Latest)
-		isOutside := isOutsideRange(b, interval(startTs, endTs), []fpRange{{0x0100, 0xff00}})
+		isOutside := isOutsideRange(b, interval(startTs, endTs), []Keyspace{{0x0100, 0xff00}})
 		require.False(t, isOutside)
 	})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

The processor executes a set of tasks.
It cleanly separates I/O from logic and therefore is more testable than the current worker implementation.

https://github.com/grafana/loki/blob/9602214abf5f0b016f1cad90e921d1e4d969856c/pkg/bloomgateway/processor.go#L33-L36
    
**Note**:

~~Only commit https://github.com/grafana/loki/pull/11812/commits/cd28931055a38827f3a8a739fe2a64c165b3fc89 is relevant. The rest of the commits are part of different PRs (#11792 and #11809), which need to be merged first.~~

The processor is not used yet in the worker.

**Certain parts must be refactored when #11810 is merged.**