### PR TITLE
added the capability to configure Loki without needing to rebuild the…

### DIFF
--- a/operator/internal/handlers/lokistack_create_or_update.go
+++ b/operator/internal/handlers/lokistack_create_or_update.go
@@ -59,6 +59,8 @@ func CreateOrUpdateLokiStack(
 		gwImg = manifests.DefaultLokiStackGatewayImage
 	}
 
+	cfgBase64 := os.Getenv(manifests.EnvRelatedLokiConfig)
+
 	objStore, err := storage.BuildOptions(ctx, k, &stack, fg)
 	if err != nil {
 		return err
@@ -110,6 +112,7 @@ func CreateOrUpdateLokiStack(
 		Timeouts:               timeoutConfig,
 		Tenants:                tenants,
 		OpenShiftOptions:       ocpOptions,
+		ConfigLokiBase64:       cfgBase64,
 	}
 
 	ll.Info("begin building manifests")

--- a/operator/internal/manifests/config.go
+++ b/operator/internal/manifests/config.go
@@ -2,9 +2,11 @@ package manifests
 
 import (
 	"crypto/sha1"
+	"encoding/base64"
 	"fmt"
 	"strings"
 
+	"github.com/ViaQ/logerr/v2/kverrors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -22,7 +24,12 @@ func LokiConfigMap(opt Options) (*corev1.ConfigMap, string, error) {
 		}
 	}
 
-	c, rc, err := config.Build(cfg)
+	lokiConfig, err := base64.StdEncoding.DecodeString(opt.ConfigLokiBase64)
+	if err != nil {
+		return nil, "", kverrors.Wrap(err, "failed to decode configuration from base64")
+	}
+
+	c, rc, err := config.Build(lokiConfig, cfg)
 	if err != nil {
 		return nil, "", err
 	}

--- a/operator/internal/manifests/internal/config/build.go
+++ b/operator/internal/manifests/internal/config/build.go
@@ -35,10 +35,20 @@ var (
 )
 
 // Build builds a loki stack configuration files
-func Build(opts Options) ([]byte, []byte, error) {
+func Build(lokiCustomConfigYAMLTmplStr []byte, opts Options) ([]byte, []byte, error) {
+	var configYAMLTmpl *template.Template
+	if len(lokiCustomConfigYAMLTmplStr) > 0 {
+		tmpl, err := template.New("loki-config.yaml").Parse(string(lokiCustomConfigYAMLTmplStr))
+		if err != nil {
+			return nil, nil, kverrors.Wrap(err, "failed to create loki configuration YAML template")
+		}
+		configYAMLTmpl = tmpl
+	} else {
+		configYAMLTmpl = lokiConfigYAMLTmpl
+	}
 	// Build loki config yaml
 	w := bytes.NewBuffer(nil)
-	err := lokiConfigYAMLTmpl.Execute(w, opts)
+	err := configYAMLTmpl.Execute(w, opts)
 	if err != nil {
 		return nil, nil, kverrors.Wrap(err, "failed to create loki configuration")
 	}

--- a/operator/internal/manifests/internal/config/build_test.go
+++ b/operator/internal/manifests/internal/config/build_test.go
@@ -264,7 +264,7 @@ overrides:
 			WriteTimeout: 10 * time.Minute,
 		},
 	}
-	cfg, rCfg, err := Build(opts)
+	cfg, rCfg, err := Build([]byte{}, opts)
 	require.NoError(t, err)
 	require.YAMLEq(t, expCfg, string(cfg))
 	require.YAMLEq(t, expRCfg, string(rCfg))
@@ -596,7 +596,7 @@ overrides:
 			WriteTimeout: 10 * time.Minute,
 		},
 	}
-	cfg, rCfg, err := Build(opts)
+	cfg, rCfg, err := Build([]byte{}, opts)
 	require.NoError(t, err)
 	require.YAMLEq(t, expCfg, string(cfg))
 	require.YAMLEq(t, expRCfg, string(rCfg))
@@ -675,7 +675,7 @@ func TestBuild_ConfigAndRuntimeConfig_CreateLokiConfigFailed(t *testing.T) {
 		},
 		Shippers: []string{"boltdb"},
 	}
-	cfg, rCfg, err := Build(opts)
+	cfg, rCfg, err := Build([]byte{}, opts)
 	require.Error(t, err)
 	require.Empty(t, cfg)
 	require.Empty(t, rCfg)
@@ -1033,7 +1033,7 @@ overrides:
 			WriteTimeout: 10 * time.Minute,
 		},
 	}
-	cfg, rCfg, err := Build(opts)
+	cfg, rCfg, err := Build([]byte{}, opts)
 	require.NoError(t, err)
 	require.YAMLEq(t, expCfg, string(cfg))
 	require.YAMLEq(t, expRCfg, string(rCfg))
@@ -1392,7 +1392,7 @@ overrides:
 			WriteTimeout: 10 * time.Minute,
 		},
 	}
-	cfg, rCfg, err := Build(opts)
+	cfg, rCfg, err := Build([]byte{}, opts)
 	require.NoError(t, err)
 	require.YAMLEq(t, expCfg, string(cfg))
 	require.YAMLEq(t, expRCfg, string(rCfg))
@@ -1781,7 +1781,7 @@ overrides:
 			WriteTimeout: 10 * time.Minute,
 		},
 	}
-	cfg, rCfg, err := Build(opts)
+	cfg, rCfg, err := Build([]byte{}, opts)
 	require.NoError(t, err)
 	require.YAMLEq(t, expCfg, string(cfg))
 	require.YAMLEq(t, expRCfg, string(rCfg))
@@ -2119,7 +2119,7 @@ overrides:
 			WriteTimeout: 10 * time.Minute,
 		},
 	}
-	cfg, rCfg, err := Build(opts)
+	cfg, rCfg, err := Build([]byte{}, opts)
 	require.NoError(t, err)
 	require.YAMLEq(t, expCfg, string(cfg))
 	require.YAMLEq(t, expRCfg, string(rCfg))
@@ -2538,7 +2538,7 @@ overrides:
 			WriteTimeout: 10 * time.Minute,
 		},
 	}
-	cfg, rCfg, err := Build(opts)
+	cfg, rCfg, err := Build([]byte{}, opts)
 	require.NoError(t, err)
 	require.YAMLEq(t, expCfg, string(cfg))
 	require.YAMLEq(t, expRCfg, string(rCfg))
@@ -2884,7 +2884,7 @@ overrides:
 			WriteTimeout: 10 * time.Minute,
 		},
 	}
-	cfg, rCfg, err := Build(opts)
+	cfg, rCfg, err := Build([]byte{}, opts)
 	require.NoError(t, err)
 	require.YAMLEq(t, expCfg, string(cfg))
 	require.YAMLEq(t, expRCfg, string(rCfg))
@@ -3380,7 +3380,7 @@ overrides:
 			WriteTimeout: 10 * time.Minute,
 		},
 	}
-	cfg, rCfg, err := Build(opts)
+	cfg, rCfg, err := Build([]byte{}, opts)
 	require.NoError(t, err)
 	require.YAMLEq(t, expCfg, string(cfg))
 	require.YAMLEq(t, expRCfg, string(rCfg))
@@ -3640,7 +3640,7 @@ overrides:
 			WriteTimeout: 10 * time.Minute,
 		},
 	}
-	cfg, rCfg, err := Build(opts)
+	cfg, rCfg, err := Build([]byte{}, opts)
 	require.NoError(t, err)
 	require.YAMLEq(t, expCfg, string(cfg))
 	require.YAMLEq(t, expRCfg, string(rCfg))
@@ -3902,7 +3902,7 @@ overrides:
 			WriteTimeout: 10 * time.Minute,
 		},
 	}
-	cfg, rCfg, err := Build(opts)
+	cfg, rCfg, err := Build([]byte{}, opts)
 	require.NoError(t, err)
 	require.YAMLEq(t, expCfg, string(cfg))
 	require.YAMLEq(t, expRCfg, string(rCfg))
@@ -4162,7 +4162,7 @@ overrides:
 			WriteTimeout: 10 * time.Minute,
 		},
 	}
-	cfg, rCfg, err := Build(opts)
+	cfg, rCfg, err := Build([]byte{}, opts)
 	require.NoError(t, err)
 	require.YAMLEq(t, expCfg, string(cfg))
 	require.YAMLEq(t, expRCfg, string(rCfg))
@@ -4464,7 +4464,7 @@ overrides:
 			WriteTimeout: 10 * time.Minute,
 		},
 	}
-	cfg, rCfg, err := Build(opts)
+	cfg, rCfg, err := Build([]byte{}, opts)
 	require.NoError(t, err)
 	require.YAMLEq(t, expCfg, string(cfg))
 	require.YAMLEq(t, expRCfg, string(rCfg))
@@ -4763,7 +4763,7 @@ overrides:
 			WriteTimeout: 10 * time.Minute,
 		},
 	}
-	cfg, rCfg, err := Build(opts)
+	cfg, rCfg, err := Build([]byte{}, opts)
 	require.NoError(t, err)
 	require.YAMLEq(t, expCfg, string(cfg))
 	require.YAMLEq(t, expRCfg, string(rCfg))
@@ -5016,7 +5016,7 @@ overrides:
 			WriteTimeout: 10 * time.Minute,
 		},
 	}
-	cfg, rCfg, err := Build(opts)
+	cfg, rCfg, err := Build([]byte{}, opts)
 	require.NoError(t, err)
 	require.YAMLEq(t, expCfg, string(cfg))
 	require.YAMLEq(t, expRCfg, string(rCfg))
@@ -5412,7 +5412,7 @@ analytics:
 			opts.ObjectStorage.Schemas = tc.schemaConfig
 			opts.Shippers = tc.shippers
 
-			cfg, _, err := Build(opts)
+			cfg, _, err := Build([]byte{}, opts)
 			require.NoError(t, err)
 			require.YAMLEq(t, expCfg, string(cfg))
 		})
@@ -5598,7 +5598,7 @@ analytics:
 	opts := defaultOptions()
 	opts.ObjectStorage = objStorageConfig
 
-	cfg, _, err := Build(opts)
+	cfg, _, err := Build([]byte{}, opts)
 	require.NoError(t, err)
 	require.YAMLEq(t, expCfg, string(cfg))
 }

--- a/operator/internal/manifests/options.go
+++ b/operator/internal/manifests/options.go
@@ -20,6 +20,7 @@ type Options struct {
 	Image                  string
 	GatewayImage           string
 	GatewayBaseDomain      string
+	ConfigLokiBase64       string
 	ConfigSHA1             string
 	CertRotationRequiredAt string
 

--- a/operator/internal/manifests/var.go
+++ b/operator/internal/manifests/var.go
@@ -57,6 +57,9 @@ const (
 	EnvRelatedImageLoki = "RELATED_IMAGE_LOKI"
 	// EnvRelatedImageGateway is the environment variable to fetch the Gateway image pullspec.
 	EnvRelatedImageGateway = "RELATED_IMAGE_GATEWAY"
+	// EnvRelatedLokiConfig is the environment variable to override the default configuration of Loki.
+	// The value should be provided in Base64 format.
+	EnvRelatedLokiConfig = "RELATED_CONFIG_LOKI"
 
 	// DefaultContainerImage declares the default fallback for loki image.
 	DefaultContainerImage = "docker.io/grafana/loki:2.9.4"


### PR DESCRIPTION
… operator

**What this PR does / why we need it**:
I added the capability to append template for Loki config without needing to rebuild the operator. In our case, we are developing a private cloud and want to provide logging as a service. This means that multiple user spaces will have clusters deployed with the loki-operator.
Therefore, we cannot rebuild the loki-operator for each such project individually. It's easier for us to create a template with the Loki configuration as an external dependency, which can be provided to the operator at runtime to modify the config-map and manually restart the components.
I understand the best way is to develop resources, but it seems that a quick workaround would also be useful. 

**Special notes for your reviewer**:


**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
