### PR TITLE
[bloom-gateway] blocks cache refilling

### DIFF
--- a/docs/sources/configure/_index.md
+++ b/docs/sources/configure/_index.md
@@ -2348,6 +2348,11 @@ bloom_shipper:
     # directory is force deleted.
     # CLI flag: -blocks-cache.remove-directory-graceful-period
     [remove_directory_graceful_period: <duration> | default = 5m]
+
+    # If enabled, all the blocks existing in the working directory will be put
+    # back into the cache during start-up.
+    # CLI flag: -blocks-cache.refill-cache-from-disk
+    [refill_cache_from_disk: <boolean> | default = true]
 ```
 
 ### chunk_store_config

--- a/pkg/storage/stores/shipper/bloomshipper/block_downloader.go
+++ b/pkg/storage/stores/shipper/bloomshipper/block_downloader.go
@@ -193,6 +193,10 @@ func (s *cacheDownloadingStrategy) refillCacheFromDisk(ctx context.Context) erro
 		level.Warn(s.logger).Log("msg", "bloom blocks cache refilling is disabled, consider enabling this option to avoid disk overfilling.")
 		return nil
 	}
+	if _, err := os.Stat(s.workingDirectory); os.IsNotExist(err) {
+		level.Warn(s.logger).Log("msg", "working directory does not exists, skipping cache refilling")
+		return nil
+	}
 	err := filepath.Walk(s.workingDirectory, func(path string, info fs.FileInfo, err error) error {
 		//find `bloom` file
 		if err != nil || info.IsDir() || !strings.HasSuffix(path, v1.BloomFileName) {

--- a/pkg/storage/stores/shipper/bloomshipper/block_downloader_test.go
+++ b/pkg/storage/stores/shipper/bloomshipper/block_downloader_test.go
@@ -92,7 +92,8 @@ func Test_blockDownloader_cacheRefilledAfterRestart(t *testing.T) {
 			overrides, err := validation.NewOverrides(validation.Limits{BloomGatewayBlocksDownloadingParallelism: 20}, nil)
 			require.NoError(t, err)
 			workingDirectory := t.TempDir()
-
+			// it's needed to assert the case when working directory is not created yet
+			workingDirectory = filepath.Join(workingDirectory, "non-existent-sub-folder")
 			blockReferences, blockClient := createFakeBlocks(t, blocksCount)
 			workersCount := 10
 

--- a/pkg/storage/stores/shipper/bloomshipper/client.go
+++ b/pkg/storage/stores/shipper/bloomshipper/client.go
@@ -171,10 +171,10 @@ func (b *BloomClient) PutMeta(ctx context.Context, meta Meta) error {
 	return b.periodicObjectClients[periodFrom].PutObject(ctx, key, bytes.NewReader(data))
 }
 
-func createBlockObjectKey(meta Ref) string {
-	blockParentFolder := fmt.Sprintf("%x-%x", meta.MinFingerprint, meta.MaxFingerprint)
-	filename := fmt.Sprintf("%d-%d-%x", meta.StartTimestamp, meta.EndTimestamp, meta.Checksum)
-	return strings.Join([]string{rootFolder, meta.TableName, meta.TenantID, bloomsFolder, blockParentFolder, filename}, delimiter)
+func createBlockObjectKey(block Ref) string {
+	blockParentFolder := fmt.Sprintf("%x-%x", block.MinFingerprint, block.MaxFingerprint)
+	filename := fmt.Sprintf("%d-%d-%x", block.StartTimestamp, block.EndTimestamp, block.Checksum)
+	return strings.Join([]string{rootFolder, block.TableName, block.TenantID, bloomsFolder, blockParentFolder, filename}, delimiter)
 }
 
 func createMetaObjectKey(meta Ref) string {

--- a/pkg/storage/stores/shipper/bloomshipper/compress_utils.go
+++ b/pkg/storage/stores/shipper/bloomshipper/compress_utils.go
@@ -77,5 +77,6 @@ func extractArchive(archivePath string, workingDirectoryPath string) error {
 	if err != nil {
 		return fmt.Errorf("error opening archive file %s: %w", archivePath, err)
 	}
+	defer file.Close()
 	return v1.UnTarGz(workingDirectoryPath, file)
 }

--- a/pkg/storage/stores/shipper/bloomshipper/config/config.go
+++ b/pkg/storage/stores/shipper/bloomshipper/config/config.go
@@ -19,12 +19,14 @@ type Config struct {
 type BlocksCacheConfig struct {
 	EmbeddedCacheConfig           cache.EmbeddedCacheConfig `yaml:",inline"`
 	RemoveDirectoryGracefulPeriod time.Duration             `yaml:"remove_directory_graceful_period"`
+	RefillCacheFromDisk           bool                      `yaml:"refill_cache_from_disk"`
 }
 
 func (c *BlocksCacheConfig) RegisterFlagsWithPrefixAndDefaults(prefix string, f *flag.FlagSet) {
 	c.EmbeddedCacheConfig.RegisterFlagsWithPrefixAndDefaults(prefix, "", f, 0)
 	f.DurationVar(&c.RemoveDirectoryGracefulPeriod, prefix+"remove-directory-graceful-period", 5*time.Minute,
 		"During this period the process waits until the directory becomes not used and only after this it will be deleted. If the timeout is reached, the directory is force deleted.")
+	f.BoolVar(&c.RefillCacheFromDisk, prefix+"refill-cache-from-disk", true, "If enabled, all the blocks existing in the working directory will be put back into the cache during start-up.")
 }
 
 type DownloadingQueueConfig struct {


### PR DESCRIPTION
I added bloom blocks cache refilling to load all extracted blocks from the working directory and put them back into the cache on start-up.

**What this PR does / why we need it**: This change is needed to prevent disk overfilling because the blocks are left abandoned after the restart and Loki has to download all the blocks again but it downloads it into the new folders because we use a timestamp in folders name.

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
