### PR TITLE
operator: Improve messages for errors in storage secret

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Main
 
+- [11824](https://github.com/grafana/loki/pull/11824) **xperimental**: Improve messages for errors in storage secret
 - [11524](https://github.com/grafana/loki/pull/11524) **JoaoBraveCoding**, **periklis**: Add OpenShift cloud credentials support for AWS STS
 - [11513](https://github.com/grafana/loki/pull/11513) **btaani**: Add a custom metric that collects Lokistacks requiring a schema upgrade
 - [11718](https://github.com/grafana/loki/pull/11718) **periklis**: Upgrade k8s.io, sigs.k8s.io and openshift deps

--- a/operator/internal/handlers/internal/storage/secrets.go
+++ b/operator/internal/handlers/internal/storage/secrets.go
@@ -3,10 +3,10 @@ package storage
 import (
 	"context"
 	"crypto/sha1"
+	"errors"
 	"fmt"
 	"sort"
 
-	"github.com/ViaQ/logerr/v2/kverrors"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -18,7 +18,17 @@ import (
 	"github.com/grafana/loki/operator/internal/status"
 )
 
-var hashSeparator = []byte(",")
+var (
+	hashSeparator = []byte(",")
+
+	errSecretUnknownType     = errors.New("unknown secret type")
+	errMissingSecretField    = errors.New("missing secret field")
+	errSecretFieldNotAllowed = errors.New("secret field not allowed")
+	errSecretUnknownSSEType  = errors.New("unsupported SSE type (supported: SSE-KMS, SSE-S3)")
+	errSecretHashError       = errors.New("error calculating hash for secret")
+
+	errS3NoAuth = errors.New("missing secret fields for static or sts authentication")
+)
 
 func getSecrets(ctx context.Context, k k8s.Client, stack *lokiv1.LokiStack, fg configv1.FeatureGates) (*corev1.Secret, *corev1.Secret, error) {
 	var (
@@ -35,7 +45,7 @@ func getSecrets(ctx context.Context, k k8s.Client, stack *lokiv1.LokiStack, fg c
 				Requeue: false,
 			}
 		}
-		return nil, nil, kverrors.Wrap(err, "failed to lookup lokistack storage secret", "name", key)
+		return nil, nil, fmt.Errorf("failed to lookup lokistack storage secret: %w", err)
 	}
 
 	if fg.OpenShift.ManagedAuthEnv {
@@ -57,7 +67,7 @@ func getSecrets(ctx context.Context, k k8s.Client, stack *lokiv1.LokiStack, fg c
 					Requeue: true,
 				}
 			}
-			return nil, nil, kverrors.Wrap(err, "failed to lookup OpenShift CCO managed authentication credentials secret", "name", stack)
+			return nil, nil, fmt.Errorf("failed to lookup OpenShift CCO managed authentication credentials secret: %w", err)
 		}
 
 		return &storageSecret, &managedAuthSecret, nil
@@ -71,7 +81,7 @@ func getSecrets(ctx context.Context, k k8s.Client, stack *lokiv1.LokiStack, fg c
 func extractSecrets(secretType lokiv1.ObjectStorageSecretType, objStore, managedAuth *corev1.Secret, fg configv1.FeatureGates) (storage.Options, error) {
 	hash, err := hashSecretData(objStore)
 	if err != nil {
-		return storage.Options{}, kverrors.Wrap(err, "error calculating hash for secret", "type", secretType)
+		return storage.Options{}, errSecretHashError
 	}
 
 	storageOpts := storage.Options{
@@ -84,7 +94,7 @@ func extractSecrets(secretType lokiv1.ObjectStorageSecretType, objStore, managed
 		var managedAuthHash string
 		managedAuthHash, err = hashSecretData(managedAuth)
 		if err != nil {
-			return storage.Options{}, kverrors.Wrap(err, "error calculating hash for secret", "type", client.ObjectKeyFromObject(managedAuth))
+			return storage.Options{}, errSecretHashError
 		}
 
 		storageOpts.OpenShift = storage.OpenShiftOptions{
@@ -107,7 +117,7 @@ func extractSecrets(secretType lokiv1.ObjectStorageSecretType, objStore, managed
 	case lokiv1.ObjectStorageSecretAlibabaCloud:
 		storageOpts.AlibabaCloud, err = extractAlibabaCloudConfigSecret(objStore)
 	default:
-		return storage.Options{}, kverrors.New("unknown secret type", "type", secretType)
+		return storage.Options{}, fmt.Errorf("%w: %s", errSecretUnknownType, secretType)
 	}
 
 	if err != nil {
@@ -149,19 +159,19 @@ func extractAzureConfigSecret(s *corev1.Secret) (*storage.AzureStorageConfig, er
 	// Extract and validate mandatory fields
 	env := s.Data[storage.KeyAzureEnvironmentName]
 	if len(env) == 0 {
-		return nil, kverrors.New("missing secret field", "field", storage.KeyAzureEnvironmentName)
+		return nil, fmt.Errorf("%w: %s", errMissingSecretField, storage.KeyAzureEnvironmentName)
 	}
 	container := s.Data[storage.KeyAzureStorageContainerName]
 	if len(container) == 0 {
-		return nil, kverrors.New("missing secret field", "field", storage.KeyAzureStorageContainerName)
+		return nil, fmt.Errorf("%w: %s", errMissingSecretField, storage.KeyAzureStorageContainerName)
 	}
 	name := s.Data[storage.KeyAzureStorageAccountName]
 	if len(name) == 0 {
-		return nil, kverrors.New("missing secret field", "field", storage.KeyAzureStorageAccountName)
+		return nil, fmt.Errorf("%w: %s", errMissingSecretField, storage.KeyAzureStorageAccountName)
 	}
 	key := s.Data[storage.KeyAzureStorageAccountKey]
 	if len(key) == 0 {
-		return nil, kverrors.New("missing secret field", "field", storage.KeyAzureStorageAccountKey)
+		return nil, fmt.Errorf("%w: %s", errMissingSecretField, storage.KeyAzureStorageAccountKey)
 	}
 
 	// Extract and validate optional fields
@@ -178,13 +188,13 @@ func extractGCSConfigSecret(s *corev1.Secret) (*storage.GCSStorageConfig, error)
 	// Extract and validate mandatory fields
 	bucket := s.Data[storage.KeyGCPStorageBucketName]
 	if len(bucket) == 0 {
-		return nil, kverrors.New("missing secret field", "field", storage.KeyGCPStorageBucketName)
+		return nil, fmt.Errorf("%w: %s", errMissingSecretField, storage.KeyGCPStorageBucketName)
 	}
 
 	// Check if google authentication credentials is provided
 	keyJSON := s.Data[storage.KeyGCPServiceAccountKeyFilename]
 	if len(keyJSON) == 0 {
-		return nil, kverrors.New("missing google authentication credentials", "field", storage.KeyGCPServiceAccountKeyFilename)
+		return nil, fmt.Errorf("%w: %s", errMissingSecretField, storage.KeyGCPServiceAccountKeyFilename)
 	}
 
 	return &storage.GCSStorageConfig{
@@ -196,7 +206,7 @@ func extractS3ConfigSecret(s *corev1.Secret, fg configv1.FeatureGates) (*storage
 	// Extract and validate mandatory fields
 	buckets := s.Data[storage.KeyAWSBucketNames]
 	if len(buckets) == 0 {
-		return nil, kverrors.New("missing secret field", "field", storage.KeyAWSBucketNames)
+		return nil, fmt.Errorf("%w: %s", errMissingSecretField, storage.KeyAWSBucketNames)
 	}
 
 	var (
@@ -233,14 +243,14 @@ func extractS3ConfigSecret(s *corev1.Secret, fg configv1.FeatureGates) (*storage
 		cfg.Audience = storage.AWSOpenShiftAudience
 		// Do not allow users overriding the role arn provided on Loki Operator installation
 		if len(roleArn) != 0 {
-			return nil, kverrors.New("extra secret field set", "field", storage.KeyAWSRoleArn)
+			return nil, fmt.Errorf("%w: %s", errSecretFieldNotAllowed, storage.KeyAWSRoleArn)
 		}
 		if len(audience) != 0 {
-			return nil, kverrors.New("extra secret field set", "field", storage.KeyAWSAudience)
+			return nil, fmt.Errorf("%w: %s", errSecretFieldNotAllowed, storage.KeyAWSAudience)
 		}
 		// In the STS case region is not an optional field
 		if len(region) == 0 {
-			return nil, kverrors.New("missing secret field", "field", storage.KeyAWSRegion)
+			return nil, fmt.Errorf("%w: %s", errMissingSecretField, storage.KeyAWSRegion)
 		}
 
 		return cfg, nil
@@ -248,13 +258,13 @@ func extractS3ConfigSecret(s *corev1.Secret, fg configv1.FeatureGates) (*storage
 		cfg.Endpoint = string(endpoint)
 
 		if len(endpoint) == 0 {
-			return nil, kverrors.New("missing secret field", "field", storage.KeyAWSEndpoint)
+			return nil, fmt.Errorf("%w: %s", errMissingSecretField, storage.KeyAWSEndpoint)
 		}
 		if len(id) == 0 {
-			return nil, kverrors.New("missing secret field", "field", storage.KeyAWSAccessKeyID)
+			return nil, fmt.Errorf("%w: %s", errMissingSecretField, storage.KeyAWSAccessKeyID)
 		}
 		if len(secret) == 0 {
-			return nil, kverrors.New("missing secret field", "field", storage.KeyAWSAccessKeySecret)
+			return nil, fmt.Errorf("%w: %s", errMissingSecretField, storage.KeyAWSAccessKeySecret)
 		}
 
 		return cfg, nil
@@ -264,11 +274,11 @@ func extractS3ConfigSecret(s *corev1.Secret, fg configv1.FeatureGates) (*storage
 
 		// In the STS case region is not an optional field
 		if len(region) == 0 {
-			return nil, kverrors.New("missing secret field", "field", storage.KeyAWSRegion)
+			return nil, fmt.Errorf("%w: %s", errMissingSecretField, storage.KeyAWSRegion)
 		}
 		return cfg, nil
 	default:
-		return nil, kverrors.New("missing secret fields for static or sts authentication")
+		return nil, errS3NoAuth
 	}
 }
 
@@ -283,7 +293,7 @@ func extractS3SSEConfig(d map[string][]byte) (storage.S3SSEConfig, error) {
 		kmsEncryptionCtx = string(d[storage.KeyAWSSseKmsEncryptionContext])
 		kmsKeyId = string(d[storage.KeyAWSSseKmsKeyID])
 		if kmsKeyId == "" {
-			return storage.S3SSEConfig{}, kverrors.New("missing secret field", "field", storage.KeyAWSSseKmsKeyID)
+			return storage.S3SSEConfig{}, fmt.Errorf("%w: %s", errMissingSecretField, storage.KeyAWSSseKmsKeyID)
 		}
 
 	case storage.SSES3Type:
@@ -291,13 +301,13 @@ func extractS3SSEConfig(d map[string][]byte) (storage.S3SSEConfig, error) {
 		return storage.S3SSEConfig{}, nil
 
 	default:
-		return storage.S3SSEConfig{}, kverrors.New("unsupported secret field value (Supported: SSE-KMS, SSE-S3)", "field", storage.KeyAWSSSEType, "value", sseType)
+		return storage.S3SSEConfig{}, fmt.Errorf("%w: %s", errSecretUnknownSSEType, sseType)
 	}
 
 	return storage.S3SSEConfig{
 		Type:                 sseType,
-		KMSKeyID:             string(kmsKeyId),
-		KMSEncryptionContext: string(kmsEncryptionCtx),
+		KMSKeyID:             kmsKeyId,
+		KMSEncryptionContext: kmsEncryptionCtx,
 	}, nil
 }
 
@@ -305,39 +315,39 @@ func extractSwiftConfigSecret(s *corev1.Secret) (*storage.SwiftStorageConfig, er
 	// Extract and validate mandatory fields
 	url := s.Data[storage.KeySwiftAuthURL]
 	if len(url) == 0 {
-		return nil, kverrors.New("missing secret field", "field", storage.KeySwiftAuthURL)
+		return nil, fmt.Errorf("%w: %s", errMissingSecretField, storage.KeySwiftAuthURL)
 	}
 	username := s.Data[storage.KeySwiftUsername]
 	if len(username) == 0 {
-		return nil, kverrors.New("missing secret field", "field", storage.KeySwiftUsername)
+		return nil, fmt.Errorf("%w: %s", errMissingSecretField, storage.KeySwiftUsername)
 	}
 	userDomainName := s.Data[storage.KeySwiftUserDomainName]
 	if len(userDomainName) == 0 {
-		return nil, kverrors.New("missing secret field", "field", storage.KeySwiftUserDomainName)
+		return nil, fmt.Errorf("%w: %s", errMissingSecretField, storage.KeySwiftUserDomainName)
 	}
 	userDomainID := s.Data[storage.KeySwiftUserDomainID]
 	if len(userDomainID) == 0 {
-		return nil, kverrors.New("missing secret field", "field", storage.KeySwiftUserDomainID)
+		return nil, fmt.Errorf("%w: %s", errMissingSecretField, storage.KeySwiftUserDomainID)
 	}
 	userID := s.Data[storage.KeySwiftUserID]
 	if len(userID) == 0 {
-		return nil, kverrors.New("missing secret field", "field", storage.KeySwiftUserID)
+		return nil, fmt.Errorf("%w: %s", errMissingSecretField, storage.KeySwiftUserID)
 	}
 	password := s.Data[storage.KeySwiftPassword]
 	if len(password) == 0 {
-		return nil, kverrors.New("missing secret field", "field", storage.KeySwiftPassword)
+		return nil, fmt.Errorf("%w: %s", errMissingSecretField, storage.KeySwiftPassword)
 	}
 	domainID := s.Data[storage.KeySwiftDomainID]
 	if len(domainID) == 0 {
-		return nil, kverrors.New("missing secret field", "field", storage.KeySwiftDomainID)
+		return nil, fmt.Errorf("%w: %s", errMissingSecretField, storage.KeySwiftDomainID)
 	}
 	domainName := s.Data[storage.KeySwiftDomainName]
 	if len(domainName) == 0 {
-		return nil, kverrors.New("missing secret field", "field", storage.KeySwiftDomainName)
+		return nil, fmt.Errorf("%w: %s", errMissingSecretField, storage.KeySwiftDomainName)
 	}
 	containerName := s.Data[storage.KeySwiftContainerName]
 	if len(containerName) == 0 {
-		return nil, kverrors.New("missing secret field", "field", storage.KeySwiftContainerName)
+		return nil, fmt.Errorf("%w: %s", errMissingSecretField, storage.KeySwiftContainerName)
 	}
 
 	// Extract and validate optional fields
@@ -367,19 +377,19 @@ func extractAlibabaCloudConfigSecret(s *corev1.Secret) (*storage.AlibabaCloudSto
 	// Extract and validate mandatory fields
 	endpoint := s.Data[storage.KeyAlibabaCloudEndpoint]
 	if len(endpoint) == 0 {
-		return nil, kverrors.New("missing secret field", "field", storage.KeyAlibabaCloudEndpoint)
+		return nil, fmt.Errorf("%w: %s", errMissingSecretField, storage.KeyAlibabaCloudEndpoint)
 	}
 	bucket := s.Data[storage.KeyAlibabaCloudBucket]
 	if len(bucket) == 0 {
-		return nil, kverrors.New("missing secret field", "field", storage.KeyAlibabaCloudBucket)
+		return nil, fmt.Errorf("%w: %s", errMissingSecretField, storage.KeyAlibabaCloudBucket)
 	}
 	id := s.Data[storage.KeyAlibabaCloudAccessKeyID]
 	if len(id) == 0 {
-		return nil, kverrors.New("missing secret field", "field", storage.KeyAlibabaCloudAccessKeyID)
+		return nil, fmt.Errorf("%w: %s", errMissingSecretField, storage.KeyAlibabaCloudAccessKeyID)
 	}
 	secret := s.Data[storage.KeyAlibabaCloudSecretAccessKey]
 	if len(secret) == 0 {
-		return nil, kverrors.New("missing secret field", "field", storage.KeyAlibabaCloudSecretAccessKey)
+		return nil, fmt.Errorf("%w: %s", errMissingSecretField, storage.KeyAlibabaCloudSecretAccessKey)
 	}
 
 	return &storage.AlibabaCloudStorageConfig{

--- a/operator/internal/handlers/internal/storage/secrets.go
+++ b/operator/internal/handlers/internal/storage/secrets.go
@@ -22,7 +22,7 @@ var (
 	hashSeparator = []byte(",")
 
 	errSecretUnknownType     = errors.New("unknown secret type")
-	errMissingSecretField    = errors.New("missing secret field")
+	errSecretMissingField    = errors.New("missing secret field")
 	errSecretFieldNotAllowed = errors.New("secret field not allowed")
 	errSecretUnknownSSEType  = errors.New("unsupported SSE type (supported: SSE-KMS, SSE-S3)")
 	errSecretHashError       = errors.New("error calculating hash for secret")
@@ -159,19 +159,19 @@ func extractAzureConfigSecret(s *corev1.Secret) (*storage.AzureStorageConfig, er
 	// Extract and validate mandatory fields
 	env := s.Data[storage.KeyAzureEnvironmentName]
 	if len(env) == 0 {
-		return nil, fmt.Errorf("%w: %s", errMissingSecretField, storage.KeyAzureEnvironmentName)
+		return nil, fmt.Errorf("%w: %s", errSecretMissingField, storage.KeyAzureEnvironmentName)
 	}
 	container := s.Data[storage.KeyAzureStorageContainerName]
 	if len(container) == 0 {
-		return nil, fmt.Errorf("%w: %s", errMissingSecretField, storage.KeyAzureStorageContainerName)
+		return nil, fmt.Errorf("%w: %s", errSecretMissingField, storage.KeyAzureStorageContainerName)
 	}
 	name := s.Data[storage.KeyAzureStorageAccountName]
 	if len(name) == 0 {
-		return nil, fmt.Errorf("%w: %s", errMissingSecretField, storage.KeyAzureStorageAccountName)
+		return nil, fmt.Errorf("%w: %s", errSecretMissingField, storage.KeyAzureStorageAccountName)
 	}
 	key := s.Data[storage.KeyAzureStorageAccountKey]
 	if len(key) == 0 {
-		return nil, fmt.Errorf("%w: %s", errMissingSecretField, storage.KeyAzureStorageAccountKey)
+		return nil, fmt.Errorf("%w: %s", errSecretMissingField, storage.KeyAzureStorageAccountKey)
 	}
 
 	// Extract and validate optional fields
@@ -188,13 +188,13 @@ func extractGCSConfigSecret(s *corev1.Secret) (*storage.GCSStorageConfig, error)
 	// Extract and validate mandatory fields
 	bucket := s.Data[storage.KeyGCPStorageBucketName]
 	if len(bucket) == 0 {
-		return nil, fmt.Errorf("%w: %s", errMissingSecretField, storage.KeyGCPStorageBucketName)
+		return nil, fmt.Errorf("%w: %s", errSecretMissingField, storage.KeyGCPStorageBucketName)
 	}
 
 	// Check if google authentication credentials is provided
 	keyJSON := s.Data[storage.KeyGCPServiceAccountKeyFilename]
 	if len(keyJSON) == 0 {
-		return nil, fmt.Errorf("%w: %s", errMissingSecretField, storage.KeyGCPServiceAccountKeyFilename)
+		return nil, fmt.Errorf("%w: %s", errSecretMissingField, storage.KeyGCPServiceAccountKeyFilename)
 	}
 
 	return &storage.GCSStorageConfig{
@@ -206,7 +206,7 @@ func extractS3ConfigSecret(s *corev1.Secret, fg configv1.FeatureGates) (*storage
 	// Extract and validate mandatory fields
 	buckets := s.Data[storage.KeyAWSBucketNames]
 	if len(buckets) == 0 {
-		return nil, fmt.Errorf("%w: %s", errMissingSecretField, storage.KeyAWSBucketNames)
+		return nil, fmt.Errorf("%w: %s", errSecretMissingField, storage.KeyAWSBucketNames)
 	}
 
 	var (
@@ -250,7 +250,7 @@ func extractS3ConfigSecret(s *corev1.Secret, fg configv1.FeatureGates) (*storage
 		}
 		// In the STS case region is not an optional field
 		if len(region) == 0 {
-			return nil, fmt.Errorf("%w: %s", errMissingSecretField, storage.KeyAWSRegion)
+			return nil, fmt.Errorf("%w: %s", errSecretMissingField, storage.KeyAWSRegion)
 		}
 
 		return cfg, nil
@@ -258,13 +258,13 @@ func extractS3ConfigSecret(s *corev1.Secret, fg configv1.FeatureGates) (*storage
 		cfg.Endpoint = string(endpoint)
 
 		if len(endpoint) == 0 {
-			return nil, fmt.Errorf("%w: %s", errMissingSecretField, storage.KeyAWSEndpoint)
+			return nil, fmt.Errorf("%w: %s", errSecretMissingField, storage.KeyAWSEndpoint)
 		}
 		if len(id) == 0 {
-			return nil, fmt.Errorf("%w: %s", errMissingSecretField, storage.KeyAWSAccessKeyID)
+			return nil, fmt.Errorf("%w: %s", errSecretMissingField, storage.KeyAWSAccessKeyID)
 		}
 		if len(secret) == 0 {
-			return nil, fmt.Errorf("%w: %s", errMissingSecretField, storage.KeyAWSAccessKeySecret)
+			return nil, fmt.Errorf("%w: %s", errSecretMissingField, storage.KeyAWSAccessKeySecret)
 		}
 
 		return cfg, nil
@@ -274,7 +274,7 @@ func extractS3ConfigSecret(s *corev1.Secret, fg configv1.FeatureGates) (*storage
 
 		// In the STS case region is not an optional field
 		if len(region) == 0 {
-			return nil, fmt.Errorf("%w: %s", errMissingSecretField, storage.KeyAWSRegion)
+			return nil, fmt.Errorf("%w: %s", errSecretMissingField, storage.KeyAWSRegion)
 		}
 		return cfg, nil
 	default:
@@ -293,7 +293,7 @@ func extractS3SSEConfig(d map[string][]byte) (storage.S3SSEConfig, error) {
 		kmsEncryptionCtx = string(d[storage.KeyAWSSseKmsEncryptionContext])
 		kmsKeyId = string(d[storage.KeyAWSSseKmsKeyID])
 		if kmsKeyId == "" {
-			return storage.S3SSEConfig{}, fmt.Errorf("%w: %s", errMissingSecretField, storage.KeyAWSSseKmsKeyID)
+			return storage.S3SSEConfig{}, fmt.Errorf("%w: %s", errSecretMissingField, storage.KeyAWSSseKmsKeyID)
 		}
 
 	case storage.SSES3Type:
@@ -315,39 +315,39 @@ func extractSwiftConfigSecret(s *corev1.Secret) (*storage.SwiftStorageConfig, er
 	// Extract and validate mandatory fields
 	url := s.Data[storage.KeySwiftAuthURL]
 	if len(url) == 0 {
-		return nil, fmt.Errorf("%w: %s", errMissingSecretField, storage.KeySwiftAuthURL)
+		return nil, fmt.Errorf("%w: %s", errSecretMissingField, storage.KeySwiftAuthURL)
 	}
 	username := s.Data[storage.KeySwiftUsername]
 	if len(username) == 0 {
-		return nil, fmt.Errorf("%w: %s", errMissingSecretField, storage.KeySwiftUsername)
+		return nil, fmt.Errorf("%w: %s", errSecretMissingField, storage.KeySwiftUsername)
 	}
 	userDomainName := s.Data[storage.KeySwiftUserDomainName]
 	if len(userDomainName) == 0 {
-		return nil, fmt.Errorf("%w: %s", errMissingSecretField, storage.KeySwiftUserDomainName)
+		return nil, fmt.Errorf("%w: %s", errSecretMissingField, storage.KeySwiftUserDomainName)
 	}
 	userDomainID := s.Data[storage.KeySwiftUserDomainID]
 	if len(userDomainID) == 0 {
-		return nil, fmt.Errorf("%w: %s", errMissingSecretField, storage.KeySwiftUserDomainID)
+		return nil, fmt.Errorf("%w: %s", errSecretMissingField, storage.KeySwiftUserDomainID)
 	}
 	userID := s.Data[storage.KeySwiftUserID]
 	if len(userID) == 0 {
-		return nil, fmt.Errorf("%w: %s", errMissingSecretField, storage.KeySwiftUserID)
+		return nil, fmt.Errorf("%w: %s", errSecretMissingField, storage.KeySwiftUserID)
 	}
 	password := s.Data[storage.KeySwiftPassword]
 	if len(password) == 0 {
-		return nil, fmt.Errorf("%w: %s", errMissingSecretField, storage.KeySwiftPassword)
+		return nil, fmt.Errorf("%w: %s", errSecretMissingField, storage.KeySwiftPassword)
 	}
 	domainID := s.Data[storage.KeySwiftDomainID]
 	if len(domainID) == 0 {
-		return nil, fmt.Errorf("%w: %s", errMissingSecretField, storage.KeySwiftDomainID)
+		return nil, fmt.Errorf("%w: %s", errSecretMissingField, storage.KeySwiftDomainID)
 	}
 	domainName := s.Data[storage.KeySwiftDomainName]
 	if len(domainName) == 0 {
-		return nil, fmt.Errorf("%w: %s", errMissingSecretField, storage.KeySwiftDomainName)
+		return nil, fmt.Errorf("%w: %s", errSecretMissingField, storage.KeySwiftDomainName)
 	}
 	containerName := s.Data[storage.KeySwiftContainerName]
 	if len(containerName) == 0 {
-		return nil, fmt.Errorf("%w: %s", errMissingSecretField, storage.KeySwiftContainerName)
+		return nil, fmt.Errorf("%w: %s", errSecretMissingField, storage.KeySwiftContainerName)
 	}
 
 	// Extract and validate optional fields
@@ -377,19 +377,19 @@ func extractAlibabaCloudConfigSecret(s *corev1.Secret) (*storage.AlibabaCloudSto
 	// Extract and validate mandatory fields
 	endpoint := s.Data[storage.KeyAlibabaCloudEndpoint]
 	if len(endpoint) == 0 {
-		return nil, fmt.Errorf("%w: %s", errMissingSecretField, storage.KeyAlibabaCloudEndpoint)
+		return nil, fmt.Errorf("%w: %s", errSecretMissingField, storage.KeyAlibabaCloudEndpoint)
 	}
 	bucket := s.Data[storage.KeyAlibabaCloudBucket]
 	if len(bucket) == 0 {
-		return nil, fmt.Errorf("%w: %s", errMissingSecretField, storage.KeyAlibabaCloudBucket)
+		return nil, fmt.Errorf("%w: %s", errSecretMissingField, storage.KeyAlibabaCloudBucket)
 	}
 	id := s.Data[storage.KeyAlibabaCloudAccessKeyID]
 	if len(id) == 0 {
-		return nil, fmt.Errorf("%w: %s", errMissingSecretField, storage.KeyAlibabaCloudAccessKeyID)
+		return nil, fmt.Errorf("%w: %s", errSecretMissingField, storage.KeyAlibabaCloudAccessKeyID)
 	}
 	secret := s.Data[storage.KeyAlibabaCloudSecretAccessKey]
 	if len(secret) == 0 {
-		return nil, fmt.Errorf("%w: %s", errMissingSecretField, storage.KeyAlibabaCloudSecretAccessKey)
+		return nil, fmt.Errorf("%w: %s", errSecretMissingField, storage.KeyAlibabaCloudSecretAccessKey)
 	}
 
 	return &storage.AlibabaCloudStorageConfig{

--- a/operator/internal/handlers/internal/storage/storage_test.go
+++ b/operator/internal/handlers/internal/storage/storage_test.go
@@ -293,7 +293,7 @@ func TestBuildOptions_WhenInvalidSecret_SetDegraded(t *testing.T) {
 	}
 
 	degradedErr := &status.DegradedError{
-		Message: "Invalid object storage secret contents: missing secret field",
+		Message: "Invalid object storage secret contents: missing secret field: bucketnames",
 		Reason:  lokiv1.ReasonInvalidObjectStorageSecret,
 		Requeue: false,
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

The `kverrors` library we currently use to emit errors found in the storage secret is not well suited for this task, because the `Error()` output does not contain the structured metadata which makes many error messages ambiguous. As we use these error messages in the status of the LokiStack this is not helpful for the user.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

This has been extracted from #11802. That PR needs to be updated again when this is merged.

**Checklist**

- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Tests updated
- [x] `CHANGELOG.md` updated
