### PR TITLE
Spans: Stop emitting `GetChunks` and `IndexClient.GetChunkRefs`

### DIFF
--- a/pkg/storage/stores/composite_store_entry.go
+++ b/pkg/storage/stores/composite_store_entry.go
@@ -46,18 +46,8 @@ func (c *storeEntry) GetChunks(ctx context.Context, userID string, from, through
 	if ctx.Err() != nil {
 		return nil, nil, ctx.Err()
 	}
-	sp, ctx := opentracing.StartSpanFromContext(ctx, "GetChunks")
-	defer sp.Finish()
-	log := spanlogger.FromContext(ctx)
-	defer log.Span.Finish()
 
 	shortcut, err := c.validateQueryTimeRange(ctx, userID, &from, &through)
-	level.Debug(log).Log(
-		"shortcut", shortcut,
-		"from", from.Time(),
-		"through", through.Time(),
-		"err", err,
-	)
 	if err != nil {
 		return nil, nil, err
 	} else if shortcut {


### PR DESCRIPTION
**What this PR does / why we need it**:
Modify our code to not emit the `GetChunks` and the `IndexClient.GetChunkRefs` spans.
We don't worse our observability by getting rid of them because their data is redundant with parent spans. Example:
- If an specific index-gateway or ingester struggles, the parent span `/logproto.Querier/GetChunkIDs` will report it just fine
- If an specific query causes trouble the `query.Exec` span will show the query name, the `start` and `end`, etc. Also, its children will show the slower parts of the query (in case we have a weak link)

**Which issue(s) this PR fixes**:
N/A