### PR TITLE
Bloom shipper: Restructure bloom store

### DIFF
--- a/pkg/bloomcompactor/bloomcompactor.go
+++ b/pkg/bloomcompactor/bloomcompactor.go
@@ -510,9 +510,17 @@ func (c *Compactor) runCompact(ctx context.Context, logger log.Logger, job Job, 
 	//TODO  Configure pool for these to avoid allocations
 	var activeBloomBlocksRefs []bloomshipper.BlockRef
 
-	metas, err := c.bloomShipperClient.SearchMetas(ctx, metaSearchParams)
+	metaRefs, fetchers, err := c.bloomShipperClient.ResolveMetas(ctx, metaSearchParams)
 	if err != nil {
 		return err
+	}
+
+	for i := range fetchers {
+		res, err := fetchers[i].FetchMetas(ctx, metaRefs[i])
+		if err != nil {
+			return err
+		}
+		metas = append(metas, res...)
 	}
 
 	// TODO This logic currently is NOT concerned with cutting blocks upon topology changes to bloom-compactors.

--- a/pkg/bloomgateway/bloomgateway.go
+++ b/pkg/bloomgateway/bloomgateway.go
@@ -42,6 +42,7 @@ package bloomgateway
 import (
 	"context"
 	"fmt"
+	"io"
 	"sort"
 	"sync"
 	"time"
@@ -59,6 +60,7 @@ import (
 	"github.com/grafana/loki/pkg/queue"
 	"github.com/grafana/loki/pkg/storage"
 	v1 "github.com/grafana/loki/pkg/storage/bloom/v1"
+	"github.com/grafana/loki/pkg/storage/chunk/cache"
 	"github.com/grafana/loki/pkg/storage/config"
 	"github.com/grafana/loki/pkg/storage/stores/shipper/bloomshipper"
 	"github.com/grafana/loki/pkg/util"
@@ -209,12 +211,15 @@ func New(cfg Config, schemaCfg config.SchemaConfig, storageCfg storage.Config, o
 	g.queue = queue.NewRequestQueue(cfg.MaxOutstandingPerTenant, time.Minute, &fixedQueueLimits{0}, g.queueMetrics)
 	g.activeUsers = util.NewActiveUsersCleanupWithDefaultValues(g.queueMetrics.Cleanup)
 
-	client, err := bloomshipper.NewBloomClient(schemaCfg.Configs, storageCfg, cm)
+	// TODO(chaudum): Plug in cache
+	var metasCache cache.Cache
+	var blocksCache *cache.EmbeddedCache[string, io.ReadCloser]
+	store, err := bloomshipper.NewBloomStore(schemaCfg.Configs, storageCfg, cm, metasCache, blocksCache, logger)
 	if err != nil {
 		return nil, err
 	}
 
-	bloomShipper, err := bloomshipper.NewShipper(client, storageCfg.BloomShipperConfig, overrides, logger, reg)
+	bloomShipper, err := bloomshipper.NewShipper(store, storageCfg.BloomShipperConfig, overrides, logger, reg)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/bloomgateway/processor.go
+++ b/pkg/bloomgateway/processor.go
@@ -17,17 +17,13 @@ type tasksForBlock struct {
 	tasks    []Task
 }
 
-type metaLoader interface {
-	LoadMetas(context.Context, bloomshipper.MetaSearchParams) ([]bloomshipper.Meta, error)
-}
-
 type blockLoader interface {
 	LoadBlocks(context.Context, []bloomshipper.BlockRef) (v1.Iterator[bloomshipper.BlockQuerierWithFingerprintRange], error)
 }
 
 type store interface {
 	blockLoader
-	metaLoader
+	bloomshipper.Store
 }
 
 type processor struct {
@@ -63,7 +59,7 @@ func (p *processor) processTasks(ctx context.Context, tenant string, interval bl
 		Interval: interval,
 		Keyspace: bloomshipper.Keyspace{Min: minFpRange.Min, Max: maxFpRange.Max},
 	}
-	metas, err := p.store.LoadMetas(ctx, metaSearch)
+	metas, err := p.store.SearchMetas(ctx, metaSearch)
 	if err != nil {
 		return err
 	}

--- a/pkg/bloomgateway/processor.go
+++ b/pkg/bloomgateway/processor.go
@@ -59,7 +59,7 @@ func (p *processor) processTasks(ctx context.Context, tenant string, interval bl
 		Interval: interval,
 		Keyspace: bloomshipper.Keyspace{Min: minFpRange.Min, Max: maxFpRange.Max},
 	}
-	metas, err := p.store.SearchMetas(ctx, metaSearch)
+	metas, err := p.store.FetchMetas(ctx, metaSearch)
 	if err != nil {
 		return err
 	}

--- a/pkg/bloomgateway/processor_test.go
+++ b/pkg/bloomgateway/processor_test.go
@@ -24,9 +24,16 @@ type dummyStore struct {
 	querieres []bloomshipper.BlockQuerierWithFingerprintRange
 }
 
-func (s *dummyStore) LoadMetas(_ context.Context, _ bloomshipper.MetaSearchParams) ([]bloomshipper.Meta, error) {
+func (s *dummyStore) SearchMetas(_ context.Context, _ bloomshipper.MetaSearchParams) ([]bloomshipper.Meta, error) {
 	//TODO(chaudum) Filter metas based on search params
 	return s.metas, nil
+}
+
+func (s *dummyStore) Fetcher(_ model.Time) *bloomshipper.Fetcher {
+	return nil
+}
+
+func (s *dummyStore) Stop() {
 }
 
 func (s *dummyStore) LoadBlocks(_ context.Context, refs []bloomshipper.BlockRef) (v1.Iterator[bloomshipper.BlockQuerierWithFingerprintRange], error) {

--- a/pkg/bloomgateway/processor_test.go
+++ b/pkg/bloomgateway/processor_test.go
@@ -24,7 +24,16 @@ type dummyStore struct {
 	querieres []bloomshipper.BlockQuerierWithFingerprintRange
 }
 
-func (s *dummyStore) SearchMetas(_ context.Context, _ bloomshipper.MetaSearchParams) ([]bloomshipper.Meta, error) {
+func (s *dummyStore) ResolveMetas(_ context.Context, _ bloomshipper.MetaSearchParams) ([][]bloomshipper.MetaRef, []*bloomshipper.Fetcher, error) {
+	//TODO(chaudum) Filter metas based on search params
+	refs := make([]bloomshipper.MetaRef, 0, len(s.metas))
+	for _, meta := range s.metas {
+		refs = append(refs, meta.MetaRef)
+	}
+	return [][]bloomshipper.MetaRef{refs}, []*bloomshipper.Fetcher{nil}, nil
+}
+
+func (s *dummyStore) FetchMetas(_ context.Context, _ bloomshipper.MetaSearchParams) ([]bloomshipper.Meta, error) {
 	//TODO(chaudum) Filter metas based on search params
 	return s.metas, nil
 }

--- a/pkg/storage/stores/shipper/bloomshipper/client.go
+++ b/pkg/storage/stores/shipper/bloomshipper/client.go
@@ -9,7 +9,6 @@ import (
 	"path"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/concurrency"
@@ -18,7 +17,6 @@ import (
 	v1 "github.com/grafana/loki/pkg/storage/bloom/v1"
 	"github.com/grafana/loki/pkg/storage/chunk/client"
 	"github.com/grafana/loki/pkg/storage/config"
-	"github.com/grafana/loki/pkg/util/math"
 )
 
 const (

--- a/pkg/storage/stores/shipper/bloomshipper/client.go
+++ b/pkg/storage/stores/shipper/bloomshipper/client.go
@@ -6,15 +6,15 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"path/filepath"
+	"path"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/go-kit/log"
 	"github.com/grafana/dskit/concurrency"
 	"github.com/prometheus/common/model"
 
-	"github.com/grafana/loki/pkg/storage"
 	v1 "github.com/grafana/loki/pkg/storage/bloom/v1"
 	"github.com/grafana/loki/pkg/storage/chunk/client"
 	"github.com/grafana/loki/pkg/storage/config"
@@ -75,7 +75,7 @@ type MetaSearchParams struct {
 type MetaClient interface {
 	// Returns all metas that are within MinFingerprint-MaxFingerprint fingerprint range
 	// and intersect time period from StartTimestamp to EndTimestamp.
-	GetMetas(ctx context.Context, params MetaSearchParams) ([]Meta, error)
+	GetMetas(ctx context.Context, metas []MetaRef) ([]Meta, error)
 	PutMeta(ctx context.Context, meta Meta) error
 	DeleteMeta(ctx context.Context, meta Meta) error
 }
@@ -91,7 +91,7 @@ type Block struct {
 }
 
 type BlockClient interface {
-	GetBlock(ctx context.Context, reference BlockRef) (LazyBlock, error)
+	GetBlock(ctx context.Context, ref BlockRef) (LazyBlock, error)
 	PutBlocks(ctx context.Context, blocks []Block) ([]Block, error)
 	DeleteBlocks(ctx context.Context, blocks []BlockRef) error
 }
@@ -102,84 +102,40 @@ type Client interface {
 	Stop()
 }
 
-// todo add logger
-func NewBloomClient(periodicConfigs []config.PeriodConfig, storageConfig storage.Config, clientMetrics storage.ClientMetrics) (*BloomClient, error) {
-	periodicObjectClients := make(map[config.DayTime]client.ObjectClient)
-	for _, periodicConfig := range periodicConfigs {
-		objectClient, err := storage.NewObjectClient(periodicConfig.ObjectType, storageConfig, clientMetrics)
-		if err != nil {
-			return nil, fmt.Errorf("error creating object client '%s': %w", periodicConfig.ObjectType, err)
-		}
-		periodicObjectClients[periodicConfig.From] = objectClient
-	}
+var _ Client = &BloomClient{}
+
+type BloomClient struct {
+	concurrency int
+	client      client.ObjectClient
+	logger      log.Logger
+}
+
+func NewBloomClient(client client.ObjectClient, logger log.Logger) (*BloomClient, error) {
 	return &BloomClient{
-		periodicConfigs:       periodicConfigs,
-		storageConfig:         storageConfig,
-		periodicObjectClients: periodicObjectClients,
+		concurrency: 100, // make configurable?
+		client:      client,
+		logger:      logger,
 	}, nil
 }
 
-type BloomClient struct {
-	periodicConfigs       []config.PeriodConfig
-	storageConfig         storage.Config
-	periodicObjectClients map[config.DayTime]client.ObjectClient
-}
-
-func (b *BloomClient) GetMetas(ctx context.Context, params MetaSearchParams) ([]Meta, error) {
-	tablesByPeriod := tablesByPeriod(b.periodicConfigs, params.Interval.Start, params.Interval.End)
-
-	var metas []Meta
-	for periodFrom, tables := range tablesByPeriod {
-		periodClient := b.periodicObjectClients[periodFrom]
-		for _, table := range tables {
-			prefix := filepath.Join(rootFolder, table, params.TenantID, metasFolder)
-			list, _, err := periodClient.List(ctx, prefix, "")
-			if err != nil {
-				return nil, fmt.Errorf("error listing metas under prefix [%s]: %w", prefix, err)
-			}
-			for _, object := range list {
-				metaRef, err := createMetaRef(object.Key, params.TenantID, table)
-
-				if err != nil {
-					return nil, err
-				}
-				if metaRef.MaxFingerprint < uint64(params.Keyspace.Min) || uint64(params.Keyspace.Max) < metaRef.MinFingerprint ||
-					metaRef.EndTimestamp.Before(params.Interval.Start) || metaRef.StartTimestamp.After(params.Interval.End) {
-					continue
-				}
-				meta, err := b.downloadMeta(ctx, metaRef, periodClient)
-				if err != nil {
-					return nil, err
-				}
-				metas = append(metas, meta)
-			}
-		}
-	}
-	return metas, nil
-}
-
 func (b *BloomClient) PutMeta(ctx context.Context, meta Meta) error {
-	periodFrom, err := findPeriod(b.periodicConfigs, meta.StartTimestamp)
-	if err != nil {
-		return fmt.Errorf("error updloading meta file: %w", err)
-	}
 	data, err := json.Marshal(meta)
 	if err != nil {
 		return fmt.Errorf("can not marshal the meta to json: %w", err)
 	}
-	key := createMetaObjectKey(meta.MetaRef.Ref)
-	return b.periodicObjectClients[periodFrom].PutObject(ctx, key, bytes.NewReader(data))
+	key := externalMetaKey(meta.MetaRef)
+	return b.client.PutObject(ctx, key, bytes.NewReader(data))
 }
 
-func createBlockObjectKey(meta Ref) string {
-	blockParentFolder := fmt.Sprintf("%x-%x", meta.MinFingerprint, meta.MaxFingerprint)
-	filename := fmt.Sprintf("%d-%d-%x", meta.StartTimestamp, meta.EndTimestamp, meta.Checksum)
-	return strings.Join([]string{rootFolder, meta.TableName, meta.TenantID, bloomsFolder, blockParentFolder, filename}, delimiter)
+func externalBlockKey(ref BlockRef) string {
+	blockParentFolder := fmt.Sprintf("%x-%x", ref.MinFingerprint, ref.MaxFingerprint)
+	filename := fmt.Sprintf("%d-%d-%x", ref.StartTimestamp, ref.EndTimestamp, ref.Checksum)
+	return path.Join(rootFolder, ref.TableName, ref.TenantID, bloomsFolder, blockParentFolder, filename)
 }
 
-func createMetaObjectKey(meta Ref) string {
-	filename := fmt.Sprintf("%x-%x-%d-%d-%x", meta.MinFingerprint, meta.MaxFingerprint, meta.StartTimestamp, meta.EndTimestamp, meta.Checksum)
-	return strings.Join([]string{rootFolder, meta.TableName, meta.TenantID, metasFolder, filename}, delimiter)
+func externalMetaKey(ref MetaRef) string {
+	filename := fmt.Sprintf("%x-%x-%d-%d-%x", ref.MinFingerprint, ref.MaxFingerprint, ref.StartTimestamp, ref.EndTimestamp, ref.Checksum)
+	return path.Join(rootFolder, ref.TableName, ref.TenantID, metasFolder, filename)
 }
 
 func findPeriod(configs []config.PeriodConfig, ts model.Time) (config.DayTime, error) {
@@ -193,22 +149,13 @@ func findPeriod(configs []config.PeriodConfig, ts model.Time) (config.DayTime, e
 }
 
 func (b *BloomClient) DeleteMeta(ctx context.Context, meta Meta) error {
-	periodFrom, err := findPeriod(b.periodicConfigs, meta.StartTimestamp)
-	if err != nil {
-		return err
-	}
-	key := createMetaObjectKey(meta.MetaRef.Ref)
-	return b.periodicObjectClients[periodFrom].DeleteObject(ctx, key)
+	key := externalMetaKey(meta.MetaRef)
+	return b.client.DeleteObject(ctx, key)
 }
 
 // GetBlock downloads the blocks from objectStorage and returns the downloaded block
 func (b *BloomClient) GetBlock(ctx context.Context, reference BlockRef) (LazyBlock, error) {
-	period, err := findPeriod(b.periodicConfigs, reference.StartTimestamp)
-	if err != nil {
-		return LazyBlock{}, fmt.Errorf("error while period lookup: %w", err)
-	}
-	objectClient := b.periodicObjectClients[period]
-	readCloser, _, err := objectClient.GetObject(ctx, createBlockObjectKey(reference.Ref))
+	readCloser, _, err := b.client.GetObject(ctx, externalBlockKey(reference))
 	if err != nil {
 		return LazyBlock{}, fmt.Errorf("error while fetching object from storage: %w", err)
 	}
@@ -220,26 +167,21 @@ func (b *BloomClient) GetBlock(ctx context.Context, reference BlockRef) (LazyBlo
 
 func (b *BloomClient) PutBlocks(ctx context.Context, blocks []Block) ([]Block, error) {
 	results := make([]Block, len(blocks))
-	//todo move concurrency to the config
-	err := concurrency.ForEachJob(ctx, len(blocks), 100, func(ctx context.Context, idx int) error {
+	err := concurrency.ForEachJob(ctx, len(blocks), b.concurrency, func(ctx context.Context, idx int) error {
 		block := blocks[idx]
 		defer func(Data io.ReadCloser) {
 			_ = Data.Close()
 		}(block.Data)
 
-		period, err := findPeriod(b.periodicConfigs, block.StartTimestamp)
-		if err != nil {
-			return fmt.Errorf("error uploading block file: %w", err)
-		}
-		key := createBlockObjectKey(block.Ref)
-		objectClient := b.periodicObjectClients[period]
+		var err error
 
+		key := externalBlockKey(block.BlockRef)
 		_, err = block.Data.Seek(0, 0)
 		if err != nil {
 			return fmt.Errorf("error uploading block file: %w", err)
 		}
 
-		err = objectClient.PutObject(ctx, key, block.Data)
+		err = b.client.PutObject(ctx, key, block.Data)
 		if err != nil {
 			return fmt.Errorf("error uploading block file: %w", err)
 		}
@@ -251,16 +193,10 @@ func (b *BloomClient) PutBlocks(ctx context.Context, blocks []Block) ([]Block, e
 }
 
 func (b *BloomClient) DeleteBlocks(ctx context.Context, references []BlockRef) error {
-	//todo move concurrency to the config
-	return concurrency.ForEachJob(ctx, len(references), 100, func(ctx context.Context, idx int) error {
+	return concurrency.ForEachJob(ctx, len(references), b.concurrency, func(ctx context.Context, idx int) error {
 		ref := references[idx]
-		period, err := findPeriod(b.periodicConfigs, ref.StartTimestamp)
-		if err != nil {
-			return fmt.Errorf("error deleting block file: %w", err)
-		}
-		key := createBlockObjectKey(ref.Ref)
-		objectClient := b.periodicObjectClients[period]
-		err = objectClient.DeleteObject(ctx, key)
+		key := externalBlockKey(ref)
+		err := b.client.DeleteObject(ctx, key)
 		if err != nil {
 			return fmt.Errorf("error deleting block file: %w", err)
 		}
@@ -269,24 +205,35 @@ func (b *BloomClient) DeleteBlocks(ctx context.Context, references []BlockRef) e
 }
 
 func (b *BloomClient) Stop() {
-	for _, objectClient := range b.periodicObjectClients {
-		objectClient.Stop()
-	}
+	b.client.Stop()
 }
 
-func (b *BloomClient) downloadMeta(ctx context.Context, metaRef MetaRef, client client.ObjectClient) (Meta, error) {
+func (b *BloomClient) GetMetas(ctx context.Context, refs []MetaRef) ([]Meta, error) {
+	results := make([]Meta, len(refs))
+	err := concurrency.ForEachJob(ctx, len(refs), b.concurrency, func(ctx context.Context, idx int) error {
+		meta, err := b.getMeta(ctx, refs[idx])
+		if err != nil {
+			return err
+		}
+		results[idx] = meta
+		return nil
+	})
+	return results, err
+}
+
+func (b *BloomClient) getMeta(ctx context.Context, ref MetaRef) (Meta, error) {
 	meta := Meta{
-		MetaRef: metaRef,
+		MetaRef: ref,
 	}
-	reader, _, err := client.GetObject(ctx, metaRef.FilePath)
+	reader, _, err := b.client.GetObject(ctx, ref.FilePath)
 	if err != nil {
-		return Meta{}, fmt.Errorf("error downloading meta file %s : %w", metaRef.FilePath, err)
+		return Meta{}, fmt.Errorf("error downloading meta file %s : %w", ref.FilePath, err)
 	}
 	defer reader.Close()
 
 	err = json.NewDecoder(reader).Decode(&meta)
 	if err != nil {
-		return Meta{}, fmt.Errorf("error unmarshalling content of meta file %s: %w", metaRef.FilePath, err)
+		return Meta{}, fmt.Errorf("error unmarshalling content of meta file %s: %w", ref.FilePath, err)
 	}
 	return meta, nil
 }
@@ -332,32 +279,11 @@ func createMetaRef(objectKey string, tenantID string, tableName string) (MetaRef
 	}, nil
 }
 
-func tablesByPeriod(periodicConfigs []config.PeriodConfig, start, end model.Time) map[config.DayTime][]string {
-	result := make(map[config.DayTime][]string)
-	for i := len(periodicConfigs) - 1; i >= 0; i-- {
-		periodConfig := periodicConfigs[i]
-		if end.Before(periodConfig.From.Time) {
-			continue
-		}
-		owningPeriodStartTs := math.Max64(periodConfig.From.Unix(), start.Unix())
-		owningPeriodEndTs := end.Unix()
-		if i != len(periodicConfigs)-1 {
-			nextPeriodConfig := periodicConfigs[i+1]
-			owningPeriodEndTs = math.Min64(nextPeriodConfig.From.Add(-1*time.Second).Unix(), owningPeriodEndTs)
-		}
-		result[periodConfig.From] = tablesForRange(periodicConfigs[i], owningPeriodStartTs, owningPeriodEndTs)
-		if !start.Before(periodConfig.From.Time) {
-			break
-		}
-	}
-	return result
-}
-
-func tablesForRange(periodConfig config.PeriodConfig, from, to int64) []string {
+func tablesForRange(periodConfig config.PeriodConfig, from, to model.Time) []string {
 	interval := periodConfig.IndexTables.Period
 	step := int64(interval.Seconds())
-	lower := from / step
-	upper := to / step
+	lower := from.Unix() / step
+	upper := to.Unix() / step
 	tables := make([]string, 0, 1+upper-lower)
 	prefix := periodConfig.IndexTables.Prefix
 	for i := lower; i <= upper; i++ {

--- a/pkg/storage/stores/shipper/bloomshipper/client.go
+++ b/pkg/storage/stores/shipper/bloomshipper/client.go
@@ -100,6 +100,7 @@ type Client interface {
 	Stop()
 }
 
+// Compiler check to ensure BloomClient implements the Client interface
 var _ Client = &BloomClient{}
 
 type BloomClient struct {

--- a/pkg/storage/stores/shipper/bloomshipper/client_test.go
+++ b/pkg/storage/stores/shipper/bloomshipper/client_test.go
@@ -14,11 +14,13 @@ import (
 	"time"
 
 	awsio "github.com/aws/smithy-go/io"
+	"github.com/go-kit/log"
 	"github.com/google/uuid"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/loki/pkg/storage"
+	"github.com/grafana/loki/pkg/storage/chunk/cache"
 	"github.com/grafana/loki/pkg/storage/config"
 )
 
@@ -47,10 +49,10 @@ func parseDayTime(s string) config.DayTime {
 }
 
 func Test_BloomClient_GetMetas(t *testing.T) {
-	shipper := createClient(t)
+	store := createStore(t)
 
 	var expected []Meta
-	folder1 := shipper.storageConfig.NamedStores.Filesystem["folder-1"].Directory
+	folder1 := store.storageConfig.NamedStores.Filesystem["folder-1"].Directory
 	// must not be present in results because it is outside of time range
 	createMetaInStorage(t, folder1, "first-period-19621", "tenantA", 0, 100, fixedDay.Add(-7*day))
 	// must be present in the results
@@ -60,7 +62,7 @@ func Test_BloomClient_GetMetas(t *testing.T) {
 	// must be present in the results
 	expected = append(expected, createMetaInStorage(t, folder1, "first-period-19621", "tenantA", 101, 200, fixedDay.Add(-6*day)))
 
-	folder2 := shipper.storageConfig.NamedStores.Filesystem["folder-2"].Directory
+	folder2 := store.storageConfig.NamedStores.Filesystem["folder-2"].Directory
 	// must not be present in results because it's out of the time range
 	createMetaInStorage(t, folder2, "second-period-19626", "tenantA", 0, 100, fixedDay.Add(-1*day))
 	// must be present in the results
@@ -68,12 +70,13 @@ func Test_BloomClient_GetMetas(t *testing.T) {
 	// must not be present in results because it belongs to another tenant
 	createMetaInStorage(t, folder2, "second-period-19624", "tenantB", 0, 100, fixedDay.Add(-3*day))
 
-	actual, err := shipper.GetMetas(context.Background(), MetaSearchParams{
+	actual, err := store.SearchMetas(context.Background(), MetaSearchParams{
 		TenantID: "tenantA",
 		Keyspace: Keyspace{Min: 50, Max: 150},
 		Interval: Interval{Start: fixedDay.Add(-6 * day), End: fixedDay.Add(-1*day - 1*time.Hour)},
 	})
 	require.NoError(t, err)
+	require.Equal(t, len(expected), len(actual))
 	require.ElementsMatch(t, expected, actual)
 }
 
@@ -112,7 +115,7 @@ func Test_BloomClient_PutMeta(t *testing.T) {
 	}
 	for name, data := range tests {
 		t.Run(name, func(t *testing.T) {
-			bloomClient := createClient(t)
+			bloomClient := createStore(t)
 
 			err := bloomClient.PutMeta(context.Background(), data.source)
 			require.NoError(t, err)
@@ -168,7 +171,7 @@ func Test_BloomClient_DeleteMeta(t *testing.T) {
 	}
 	for name, data := range tests {
 		t.Run(name, func(t *testing.T) {
-			bloomClient := createClient(t)
+			bloomClient := createStore(t)
 			directory := bloomClient.storageConfig.NamedStores.Filesystem[data.expectedStorage].Directory
 			file := filepath.Join(directory, data.expectedFilePath)
 			err := os.MkdirAll(file[:strings.LastIndex(file, delimiter)], 0755)
@@ -186,7 +189,7 @@ func Test_BloomClient_DeleteMeta(t *testing.T) {
 }
 
 func Test_BloomClient_GetBlocks(t *testing.T) {
-	bloomClient := createClient(t)
+	bloomClient := createStore(t)
 	fsNamedStores := bloomClient.storageConfig.NamedStores.Filesystem
 	firstBlockPath := "bloom/first-period-19621/tenantA/blooms/eeee-ffff/1695272400000-1695276000000-1"
 	firstBlockFullPath := filepath.Join(fsNamedStores["folder-1"].Directory, firstBlockPath)
@@ -236,7 +239,7 @@ func Test_BloomClient_GetBlocks(t *testing.T) {
 }
 
 func Test_BloomClient_PutBlocks(t *testing.T) {
-	bloomClient := createClient(t)
+	bloomClient := createStore(t)
 	blockForFirstFolderData := "data1"
 	blockForFirstFolder := Block{
 		BlockRef: BlockRef{
@@ -313,7 +316,7 @@ func Test_BloomClient_PutBlocks(t *testing.T) {
 }
 
 func Test_BloomClient_DeleteBlocks(t *testing.T) {
-	bloomClient := createClient(t)
+	bloomClient := createStore(t)
 	fsNamedStores := bloomClient.storageConfig.NamedStores.Filesystem
 	block1Path := filepath.Join(fsNamedStores["folder-1"].Directory, "bloom/first-period-19621/tenantA/blooms/eeee-ffff/1695272400000-1695276000000-1")
 	createBlockFile(t, block1Path)
@@ -361,56 +364,6 @@ func createBlockFile(t *testing.T, path string) string {
 	err = os.WriteFile(path, []byte(fileContent), 0700)
 	require.NoError(t, err)
 	return fileContent
-}
-
-func Test_TablesByPeriod(t *testing.T) {
-	configs := createPeriodConfigs()
-	firstPeriodFrom := configs[0].From
-	secondPeriodFrom := configs[1].From
-	tests := map[string]struct {
-		from, to               model.Time
-		expectedTablesByPeriod map[config.DayTime][]string
-	}{
-		"expected 1 table": {
-			from: model.TimeFromUnix(time.Date(2023, time.September, 20, 0, 0, 0, 0, time.UTC).Unix()),
-			to:   model.TimeFromUnix(time.Date(2023, time.September, 20, 23, 59, 59, 0, time.UTC).Unix()),
-			expectedTablesByPeriod: map[config.DayTime][]string{
-				firstPeriodFrom: {"first-period-19620"}},
-		},
-		"expected tables for both periods": {
-			from: model.TimeFromUnix(time.Date(2023, time.September, 21, 0, 0, 0, 0, time.UTC).Unix()),
-			to:   model.TimeFromUnix(time.Date(2023, time.September, 25, 23, 59, 59, 0, time.UTC).Unix()),
-			expectedTablesByPeriod: map[config.DayTime][]string{
-				firstPeriodFrom:  {"first-period-19621", "first-period-19622", "first-period-19623"},
-				secondPeriodFrom: {"second-period-19624", "second-period-19625"},
-			},
-		},
-		"expected tables for the second period": {
-			from: model.TimeFromUnix(time.Date(2023, time.September, 24, 0, 0, 0, 0, time.UTC).Unix()),
-			to:   model.TimeFromUnix(time.Date(2023, time.September, 25, 1, 0, 0, 0, time.UTC).Unix()),
-			expectedTablesByPeriod: map[config.DayTime][]string{
-				secondPeriodFrom: {"second-period-19624", "second-period-19625"},
-			},
-		},
-		"expected only one table from the second period": {
-			from: model.TimeFromUnix(time.Date(2023, time.September, 25, 0, 0, 0, 0, time.UTC).Unix()),
-			to:   model.TimeFromUnix(time.Date(2023, time.September, 25, 1, 0, 0, 0, time.UTC).Unix()),
-			expectedTablesByPeriod: map[config.DayTime][]string{
-				secondPeriodFrom: {"second-period-19625"},
-			},
-		},
-	}
-	for name, data := range tests {
-		t.Run(name, func(t *testing.T) {
-			result := tablesByPeriod(configs, data.from, data.to)
-			for periodFrom, expectedTables := range data.expectedTablesByPeriod {
-				actualTables, exists := result[periodFrom]
-				require.Truef(t, exists, "tables for %s period must be provided but was not in the result: %+v", periodFrom.String(), result)
-				require.ElementsMatchf(t, expectedTables, actualTables, "tables mismatch for period %s", periodFrom.String())
-			}
-			require.Len(t, result, len(data.expectedTablesByPeriod))
-		})
-	}
 }
 
 func Test_createMetaRef(t *testing.T) {
@@ -490,7 +443,7 @@ func Test_createMetaRef(t *testing.T) {
 	}
 }
 
-func createClient(t *testing.T) *BloomClient {
+func createStore(t *testing.T) *BloomStore {
 	periodicConfigs := createPeriodConfigs()
 	namedStores := storage.NamedStores{
 		Filesystem: map[string]storage.NamedFSConfig{
@@ -503,9 +456,9 @@ func createClient(t *testing.T) *BloomClient {
 
 	metrics := storage.NewClientMetrics()
 	t.Cleanup(metrics.Unregister)
-	bloomClient, err := NewBloomClient(periodicConfigs, storageConfig, metrics)
+	store, err := NewBloomStore(periodicConfigs, storageConfig, metrics, cache.NewNoopCache(), nil, log.NewNopLogger())
 	require.NoError(t, err)
-	return bloomClient
+	return store
 }
 
 func createPeriodConfigs() []config.PeriodConfig {

--- a/pkg/storage/stores/shipper/bloomshipper/fetcher.go
+++ b/pkg/storage/stores/shipper/bloomshipper/fetcher.go
@@ -79,7 +79,9 @@ func (f *Fetcher) processCacheResponse(ctx context.Context, refs []MetaRef, keys
 	var lastErr error
 	for i, ref := range refs {
 		if raw, ok := found[externalMetaKey(ref)]; ok {
-			meta := Meta{}
+			meta := Meta{
+				MetaRef: ref,
+			}
 			lastErr = json.Unmarshal(raw, &meta)
 			metas = append(metas, meta)
 		} else {

--- a/pkg/storage/stores/shipper/bloomshipper/fetcher.go
+++ b/pkg/storage/stores/shipper/bloomshipper/fetcher.go
@@ -11,6 +11,7 @@ import (
 	"github.com/grafana/loki/pkg/storage/chunk/cache"
 )
 
+// TODO(chaudum): Add metric for cache hits/misses, and bytes stored/retrieved
 type metrics struct{}
 
 type fetcher interface {

--- a/pkg/storage/stores/shipper/bloomshipper/fetcher.go
+++ b/pkg/storage/stores/shipper/bloomshipper/fetcher.go
@@ -15,6 +15,7 @@ type metrics struct{}
 
 type fetcher interface {
 	FetchMetas(ctx context.Context, refs []MetaRef) ([]Meta, error)
+	// TODO(chaudum): Integrate block fetching
 	// FetchBlocks(ctx context.Context, refs []BlockRef) ([]Block, error)
 }
 
@@ -106,6 +107,8 @@ func (f *Fetcher) writeBackMetas(ctx context.Context, metas []Meta) error {
 	return f.metasCache.Store(ctx, keys, data)
 }
 
+// TODO(chaudum): Integrate block fetching
+
 // func (f *Fetcher) FetchBlocks(ctx context.Context, refs []BlockRef) (v1.Iterator[Block], error) {
 // 	if ctx.Err() != nil {
 // 		return nil, errors.Wrap(ctx.Err(), "fetch Blocks")
@@ -145,30 +148,30 @@ func (f *Fetcher) writeBackMetas(ctx context.Context, metas []Meta) error {
 // 	return f.blocksCache.Store(ctx, keys, data)
 // }
 
-type ChannelIter[T any] struct {
-	ch  <-chan T
-	cur T
-}
+// type ChannelIter[T any] struct {
+// 	ch  <-chan T
+// 	cur T
+// }
 
-func NewChannelIter[T any](ch <-chan T) *ChannelIter[T] {
-	return &ChannelIter[T]{
-		ch: ch,
-	}
-}
+// func NewChannelIter[T any](ch <-chan T) *ChannelIter[T] {
+// 	return &ChannelIter[T]{
+// 		ch: ch,
+// 	}
+// }
 
-func (it *ChannelIter[T]) Next() bool {
-	el, ok := <-it.ch
-	if ok {
-		it.cur = el
-		return true
-	}
-	return false
-}
+// func (it *ChannelIter[T]) Next() bool {
+// 	el, ok := <-it.ch
+// 	if ok {
+// 		it.cur = el
+// 		return true
+// 	}
+// 	return false
+// }
 
-func (it *ChannelIter[T]) At() T {
-	return it.cur
-}
+// func (it *ChannelIter[T]) At() T {
+// 	return it.cur
+// }
 
-func (it *ChannelIter[T]) Err() error {
-	return nil
-}
+// func (it *ChannelIter[T]) Err() error {
+// 	return nil
+// }

--- a/pkg/storage/stores/shipper/bloomshipper/fetcher.go
+++ b/pkg/storage/stores/shipper/bloomshipper/fetcher.go
@@ -67,7 +67,7 @@ func (f *Fetcher) FetchMetas(ctx context.Context, refs []MetaRef) ([]Meta, error
 	return append(fromCache, fromStorage...), err
 }
 
-func (f *Fetcher) processCacheResponse(ctx context.Context, refs []MetaRef, keys []string, bufs [][]byte) ([]Meta, []MetaRef, error) {
+func (f *Fetcher) processCacheResponse(_ context.Context, refs []MetaRef, keys []string, bufs [][]byte) ([]Meta, []MetaRef, error) {
 
 	found := make(map[string][]byte, len(refs))
 	for i, k := range keys {

--- a/pkg/storage/stores/shipper/bloomshipper/fetcher.go
+++ b/pkg/storage/stores/shipper/bloomshipper/fetcher.go
@@ -1,0 +1,172 @@
+package bloomshipper
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+
+	"github.com/go-kit/log"
+	"github.com/pkg/errors"
+
+	"github.com/grafana/loki/pkg/storage/chunk/cache"
+)
+
+type metrics struct{}
+
+type fetcher interface {
+	FetchMetas(ctx context.Context, refs []MetaRef) ([]Meta, error)
+	// FetchBlocks(ctx context.Context, refs []BlockRef) ([]Block, error)
+}
+
+type Fetcher struct {
+	client Client
+
+	metasCache  cache.Cache
+	blocksCache *cache.EmbeddedCache[string, io.ReadCloser]
+
+	metrics *metrics
+	logger  log.Logger
+}
+
+func NewFetcher(client Client, metasCache cache.Cache, blocksCache *cache.EmbeddedCache[string, io.ReadCloser], logger log.Logger) (*Fetcher, error) {
+	return &Fetcher{
+		client:      client,
+		metasCache:  metasCache,
+		blocksCache: blocksCache,
+		logger:      logger,
+	}, nil
+}
+
+func (f *Fetcher) FetchMetas(ctx context.Context, refs []MetaRef) ([]Meta, error) {
+	if ctx.Err() != nil {
+		return nil, errors.Wrap(ctx.Err(), "fetch Metas")
+	}
+
+	keys := make([]string, 0, len(refs))
+	for _, ref := range refs {
+		keys = append(keys, externalMetaKey(ref))
+	}
+	cacheHits, cacheBufs, _, err := f.metasCache.Fetch(ctx, keys)
+	if err != nil {
+		return nil, err
+	}
+
+	fromCache, missing, err := f.processCacheResponse(ctx, refs, cacheHits, cacheBufs)
+	if err != nil {
+		return nil, err
+	}
+
+	fromStorage, err := f.client.GetMetas(ctx, missing)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO(chaudum): Make async
+	err = f.writeBackMetas(ctx, fromStorage)
+	return append(fromCache, fromStorage...), err
+}
+
+func (f *Fetcher) processCacheResponse(ctx context.Context, refs []MetaRef, keys []string, bufs [][]byte) ([]Meta, []MetaRef, error) {
+
+	found := make(map[string][]byte, len(refs))
+	for i, k := range keys {
+		found[k] = bufs[i]
+	}
+
+	metas := make([]Meta, 0, len(found))
+	missing := make([]MetaRef, 0, len(refs)-len(keys))
+
+	var lastErr error
+	for i, ref := range refs {
+		if raw, ok := found[externalMetaKey(ref)]; ok {
+			meta := Meta{}
+			lastErr = json.Unmarshal(raw, &meta)
+			metas = append(metas, meta)
+		} else {
+			missing = append(missing, refs[i])
+		}
+	}
+
+	return metas, missing, lastErr
+}
+
+func (f *Fetcher) writeBackMetas(ctx context.Context, metas []Meta) error {
+	var err error
+	keys := make([]string, len(metas))
+	data := make([][]byte, len(metas))
+	for i := range metas {
+		keys[i] = externalMetaKey(metas[i].MetaRef)
+		data[i], err = json.Marshal(metas[i])
+	}
+	if err != nil {
+		return err
+	}
+	return f.metasCache.Store(ctx, keys, data)
+}
+
+// func (f *Fetcher) FetchBlocks(ctx context.Context, refs []BlockRef) (v1.Iterator[Block], error) {
+// 	if ctx.Err() != nil {
+// 		return nil, errors.Wrap(ctx.Err(), "fetch Blocks")
+// 	}
+
+// 	keys := make([]string, 0, len(refs))
+// 	for _, ref := range refs {
+// 		keys = append(keys, externalBlockKey(ref))
+// 	}
+// 	found, blocksFromCache, missing, err := f.blocksCache.Fetch(ctx, keys)
+// 	if err != nil {
+// 		return nil, err
+// 	}
+
+// 	if len(missing) > 0 {
+// 		for _, key := range missing {
+// 			for i, ref := range refs {
+// 				if key == externalBlockKey(ref) {
+// 					refs = append(refs[:i], refs[i+1:]...)
+// 					i--
+// 				}
+// 			}
+// 		}
+
+// 		blocksFromStorage, err := f.client.GetBlock(ctx, refs)
+// 		if err != nil {
+// 			return nil, err
+// 		}
+// 	}
+
+// 	return nil, nil
+// }
+
+// func (f *Fetcher) writeBackBlocks(ctx context.Context, blocks []Block) error {
+// 	keys := make([]string, 0, len(blocks))
+// 	data := make([]io.ReadCloser, 0, len(blocks))
+// 	return f.blocksCache.Store(ctx, keys, data)
+// }
+
+type ChannelIter[T any] struct {
+	ch  <-chan T
+	cur T
+}
+
+func NewChannelIter[T any](ch <-chan T) *ChannelIter[T] {
+	return &ChannelIter[T]{
+		ch: ch,
+	}
+}
+
+func (it *ChannelIter[T]) Next() bool {
+	el, ok := <-it.ch
+	if ok {
+		it.cur = el
+		return true
+	}
+	return false
+}
+
+func (it *ChannelIter[T]) At() T {
+	return it.cur
+}
+
+func (it *ChannelIter[T]) Err() error {
+	return nil
+}

--- a/pkg/storage/stores/shipper/bloomshipper/fetcher_test.go
+++ b/pkg/storage/stores/shipper/bloomshipper/fetcher_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/grafana/loki/pkg/storage/config"
 )
 
-func makeMetas(t *testing.T, schemaCfg config.SchemaConfig, ts model.Time, dir string, keyspaces []Keyspace) []Meta {
+func makeMetas(t *testing.T, schemaCfg config.SchemaConfig, ts model.Time, keyspaces []Keyspace) []Meta {
 	t.Helper()
 
 	metas := make([]Meta, len(keyspaces))
@@ -76,23 +76,23 @@ func TestMetasFetcher(t *testing.T) {
 		{
 			name:  "all metas found in cache",
 			store: []Meta{},
-			start: makeMetas(t, schemaCfg, now, dir, []Keyspace{{0x0000, 0xffff}}),
-			end:   makeMetas(t, schemaCfg, now, dir, []Keyspace{{0x0000, 0xffff}}),
-			fetch: makeMetas(t, schemaCfg, now, dir, []Keyspace{{0x0000, 0xffff}}),
+			start: makeMetas(t, schemaCfg, now, []Keyspace{{0x0000, 0xffff}}),
+			end:   makeMetas(t, schemaCfg, now, []Keyspace{{0x0000, 0xffff}}),
+			fetch: makeMetas(t, schemaCfg, now, []Keyspace{{0x0000, 0xffff}}),
 		},
 		{
 			name:  "no metas found in cache",
-			store: makeMetas(t, schemaCfg, now, dir, []Keyspace{{0x0000, 0xffff}}),
+			store: makeMetas(t, schemaCfg, now, []Keyspace{{0x0000, 0xffff}}),
 			start: []Meta{},
-			end:   makeMetas(t, schemaCfg, now, dir, []Keyspace{{0x0000, 0xffff}}),
-			fetch: makeMetas(t, schemaCfg, now, dir, []Keyspace{{0x0000, 0xffff}}),
+			end:   makeMetas(t, schemaCfg, now, []Keyspace{{0x0000, 0xffff}}),
+			fetch: makeMetas(t, schemaCfg, now, []Keyspace{{0x0000, 0xffff}}),
 		},
 		{
 			name:  "some metas found in cache",
-			store: makeMetas(t, schemaCfg, now, dir, []Keyspace{{0x0000, 0xffff}, {0x10000, 0x1ffff}}),
-			start: makeMetas(t, schemaCfg, now, dir, []Keyspace{{0x0000, 0xffff}}),
-			end:   makeMetas(t, schemaCfg, now, dir, []Keyspace{{0x0000, 0xffff}, {0x10000, 0x1ffff}}),
-			fetch: makeMetas(t, schemaCfg, now, dir, []Keyspace{{0x0000, 0xffff}, {0x10000, 0x1ffff}}),
+			store: makeMetas(t, schemaCfg, now, []Keyspace{{0x0000, 0xffff}, {0x10000, 0x1ffff}}),
+			start: makeMetas(t, schemaCfg, now, []Keyspace{{0x0000, 0xffff}}),
+			end:   makeMetas(t, schemaCfg, now, []Keyspace{{0x0000, 0xffff}, {0x10000, 0x1ffff}}),
+			fetch: makeMetas(t, schemaCfg, now, []Keyspace{{0x0000, 0xffff}, {0x10000, 0x1ffff}}),
 		},
 	}
 

--- a/pkg/storage/stores/shipper/bloomshipper/fetcher_test.go
+++ b/pkg/storage/stores/shipper/bloomshipper/fetcher_test.go
@@ -1,0 +1,176 @@
+package bloomshipper
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/pkg/storage/chunk/cache"
+	"github.com/grafana/loki/pkg/storage/chunk/client/local"
+	"github.com/grafana/loki/pkg/storage/config"
+)
+
+func makeMetas(t *testing.T, schemaCfg config.SchemaConfig, ts model.Time, dir string, keyspaces []Keyspace) []Meta {
+	t.Helper()
+
+	metas := make([]Meta, len(keyspaces))
+	for i, keyspace := range keyspaces {
+		metas[i] = Meta{
+			MetaRef: MetaRef{
+				Ref: Ref{
+					TenantID:       "fake",
+					TableName:      fmt.Sprintf("%s%d", schemaCfg.Configs[0].IndexTables.Prefix, 0),
+					MinFingerprint: uint64(keyspace.Min),
+					MaxFingerprint: uint64(keyspace.Max),
+					StartTimestamp: ts,
+					EndTimestamp:   ts,
+				},
+			},
+			Tombstones: []BlockRef{},
+			Blocks:     []BlockRef{},
+		}
+		metas[i].FilePath = externalMetaKey(metas[i].MetaRef)
+	}
+	return metas
+}
+
+func TestMetasFetcher(t *testing.T) {
+	dir := t.TempDir()
+	logger := log.NewNopLogger()
+	now := model.Now()
+
+	schemaCfg := config.SchemaConfig{
+		Configs: []config.PeriodConfig{
+			{
+				From:       config.DayTime{Time: 0},
+				IndexType:  "tsdb",
+				ObjectType: "filesystem",
+				Schema:     "v13",
+				IndexTables: config.IndexPeriodicTableConfig{
+					PathPrefix: "index/",
+					PeriodicTableConfig: config.PeriodicTableConfig{
+						Prefix: "table_",
+						Period: 24 * time.Hour,
+					},
+				},
+				ChunkTables: config.PeriodicTableConfig{},
+				RowShards:   16,
+			},
+		},
+	}
+
+	tests := []struct {
+		name  string
+		store []Meta // initial store state
+		start []Meta // initial cache state
+		end   []Meta // final cache state
+		fetch []Meta // metas to fetch
+	}{
+		{
+			name:  "all metas found in cache",
+			store: []Meta{},
+			start: makeMetas(t, schemaCfg, now, dir, []Keyspace{{0x0000, 0xffff}}),
+			end:   makeMetas(t, schemaCfg, now, dir, []Keyspace{{0x0000, 0xffff}}),
+			fetch: makeMetas(t, schemaCfg, now, dir, []Keyspace{{0x0000, 0xffff}}),
+		},
+		{
+			name:  "no metas found in cache",
+			store: makeMetas(t, schemaCfg, now, dir, []Keyspace{{0x0000, 0xffff}}),
+			start: []Meta{},
+			end:   makeMetas(t, schemaCfg, now, dir, []Keyspace{{0x0000, 0xffff}}),
+			fetch: makeMetas(t, schemaCfg, now, dir, []Keyspace{{0x0000, 0xffff}}),
+		},
+		{
+			name:  "some metas found in cache",
+			store: makeMetas(t, schemaCfg, now, dir, []Keyspace{{0x0000, 0xffff}, {0x10000, 0x1ffff}}),
+			start: makeMetas(t, schemaCfg, now, dir, []Keyspace{{0x0000, 0xffff}}),
+			end:   makeMetas(t, schemaCfg, now, dir, []Keyspace{{0x0000, 0xffff}, {0x10000, 0x1ffff}}),
+			fetch: makeMetas(t, schemaCfg, now, dir, []Keyspace{{0x0000, 0xffff}, {0x10000, 0x1ffff}}),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			metasCache := cache.NewMockCache()
+
+			oc, err := local.NewFSObjectClient(local.FSConfig{Directory: dir})
+			require.NoError(t, err)
+
+			c, err := NewBloomClient(oc, logger)
+			require.NoError(t, err)
+
+			fetcher, err := NewFetcher(c, metasCache, nil, logger)
+			require.NoError(t, err)
+
+			// prepare metas cache
+			keys := make([]string, 0, len(test.start))
+			metas := make([][]byte, 0, len(test.start))
+			for _, meta := range test.start {
+				b, err := json.Marshal(meta)
+				require.NoError(t, err)
+				metas = append(metas, b)
+				t.Log(string(b))
+
+				k := externalMetaKey(meta.MetaRef)
+				keys = append(keys, k)
+			}
+			require.NoError(t, metasCache.Store(ctx, keys, metas))
+
+			// prepare store
+			for _, meta := range test.store {
+				meta.FilePath = path.Join(dir, meta.FilePath)
+				err := c.PutMeta(ctx, meta)
+				require.NoError(t, err)
+			}
+
+			actual, err := fetcher.FetchMetas(ctx, metaRefs(test.fetch))
+			require.NoError(t, err)
+			require.ElementsMatch(t, test.fetch, actual)
+
+			requireCachedMetas(t, test.end, metasCache.GetInternal())
+		})
+	}
+}
+
+func metasFromCache(data map[string][]byte) []Meta {
+	metas := make([]Meta, 0, len(data))
+	for k, v := range data {
+		meta := Meta{
+			MetaRef: MetaRef{
+				FilePath: k,
+			},
+		}
+		_ = json.Unmarshal(v, &meta)
+		metas = append(metas, meta)
+	}
+	return metas
+}
+
+func metaRefs(metas []Meta) []MetaRef {
+	refs := make([]MetaRef, 0, len(metas))
+	for _, meta := range metas {
+		refs = append(refs, meta.MetaRef)
+	}
+	return refs
+}
+
+func requireEqualMetas(t *testing.T, expected []Meta, actual []MetaRef) {
+	require.Equal(t, len(expected), len(actual))
+	require.ElementsMatch(t, metaRefs(expected), actual)
+}
+
+func requireCachedMetas(t *testing.T, expected []Meta, actual map[string][]byte) {
+	require.Equal(t, len(expected), len(actual))
+	for _, meta := range expected {
+		_, contains := actual[meta.MetaRef.FilePath]
+		require.True(t, contains)
+	}
+}

--- a/pkg/storage/stores/shipper/bloomshipper/shipper.go
+++ b/pkg/storage/stores/shipper/bloomshipper/shipper.go
@@ -59,7 +59,7 @@ type Interface interface {
 }
 
 type Shipper struct {
-	client          Client
+	store           Store
 	config          config.Config
 	logger          log.Logger
 	blockDownloader *blockDownloader
@@ -69,14 +69,20 @@ type Limits interface {
 	BloomGatewayBlocksDownloadingParallelism(tenantID string) int
 }
 
-func NewShipper(client Client, config config.Config, limits Limits, logger log.Logger, reg prometheus.Registerer) (*Shipper, error) {
+// TODO(chaudum): resolve and rip out
+type StoreAndClient interface {
+	Store
+	Client
+}
+
+func NewShipper(client StoreAndClient, config config.Config, limits Limits, logger log.Logger, reg prometheus.Registerer) (*Shipper, error) {
 	logger = log.With(logger, "component", "bloom-shipper")
 	downloader, err := newBlockDownloader(config, client, limits, logger, reg)
 	if err != nil {
 		return nil, fmt.Errorf("error creating block downloader: %w", err)
 	}
 	return &Shipper{
-		client:          client,
+		store:           client,
 		config:          config,
 		logger:          logger,
 		blockDownloader: downloader,
@@ -138,7 +144,7 @@ func runCallback(callback ForEachBlockCallback, block blockWithQuerier) error {
 }
 
 func (s *Shipper) Stop() {
-	s.client.Stop()
+	s.store.Stop()
 	s.blockDownloader.stop()
 }
 
@@ -154,7 +160,7 @@ func getFirstLast[T any](s []T) (T, T) {
 
 func (s *Shipper) getActiveBlockRefs(ctx context.Context, tenantID string, interval Interval, keyspaces []Keyspace) ([]BlockRef, error) {
 	minFpRange, maxFpRange := getFirstLast(keyspaces)
-	metas, err := s.client.GetMetas(ctx, MetaSearchParams{
+	metas, err := s.store.SearchMetas(ctx, MetaSearchParams{
 		TenantID: tenantID,
 		Keyspace: Keyspace{Min: minFpRange.Min, Max: maxFpRange.Max},
 		Interval: interval,

--- a/pkg/storage/stores/shipper/bloomshipper/shipper.go
+++ b/pkg/storage/stores/shipper/bloomshipper/shipper.go
@@ -160,7 +160,7 @@ func getFirstLast[T any](s []T) (T, T) {
 
 func (s *Shipper) getActiveBlockRefs(ctx context.Context, tenantID string, interval Interval, keyspaces []Keyspace) ([]BlockRef, error) {
 	minFpRange, maxFpRange := getFirstLast(keyspaces)
-	metas, err := s.store.SearchMetas(ctx, MetaSearchParams{
+	metas, err := s.store.FetchMetas(ctx, MetaSearchParams{
 		TenantID: tenantID,
 		Keyspace: Keyspace{Min: minFpRange.Min, Max: maxFpRange.Max},
 		Interval: interval,

--- a/pkg/storage/stores/shipper/bloomshipper/store.go
+++ b/pkg/storage/stores/shipper/bloomshipper/store.go
@@ -1,0 +1,356 @@
+package bloomshipper
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"path/filepath"
+	"sort"
+
+	"github.com/go-kit/log"
+	"github.com/pkg/errors"
+	"github.com/prometheus/common/model"
+
+	"github.com/grafana/loki/pkg/storage"
+	"github.com/grafana/loki/pkg/storage/chunk/cache"
+	"github.com/grafana/loki/pkg/storage/chunk/client"
+	"github.com/grafana/loki/pkg/storage/config"
+)
+
+type Store interface {
+	SearchMetas(ctx context.Context, params MetaSearchParams) ([]Meta, error)
+	Fetcher(ts model.Time) *Fetcher
+	Stop()
+}
+
+var _ Client = &bloomStoreEntry{}
+var _ Store = &bloomStoreEntry{}
+
+type bloomStoreEntry struct {
+	start        model.Time
+	cfg          config.PeriodConfig
+	objectClient client.ObjectClient
+	bloomClient  Client
+	fetcher      *Fetcher
+}
+
+// SearchMetas implements store.
+func (b *bloomStoreEntry) SearchMetas(ctx context.Context, params MetaSearchParams) ([]Meta, error) {
+	var refs []MetaRef
+	tables := tablesForRange(b.cfg, params.Interval.Start, params.Interval.End)
+	for _, table := range tables {
+		prefix := filepath.Join(rootFolder, table, params.TenantID, metasFolder)
+		list, _, err := b.objectClient.List(ctx, prefix, "")
+		if err != nil {
+			return nil, fmt.Errorf("error listing metas under prefix [%s]: %w", prefix, err)
+		}
+		for _, object := range list {
+			metaRef, err := createMetaRef(object.Key, params.TenantID, table)
+
+			if err != nil {
+				return nil, err
+			}
+			if metaRef.MaxFingerprint < uint64(params.Keyspace.Min) || uint64(params.Keyspace.Max) < metaRef.MinFingerprint ||
+				metaRef.EndTimestamp.Before(params.Interval.Start) || metaRef.StartTimestamp.After(params.Interval.End) {
+				continue
+			}
+			refs = append(refs, metaRef)
+		}
+	}
+	return b.fetcher.FetchMetas(ctx, refs)
+}
+
+// SearchMetas implements store.
+func (b *bloomStoreEntry) Fetcher(_ model.Time) *Fetcher {
+	return b.fetcher
+}
+
+// DeleteBlocks implements Client.
+func (b *bloomStoreEntry) DeleteBlocks(ctx context.Context, refs []BlockRef) error {
+	return b.bloomClient.DeleteBlocks(ctx, refs)
+}
+
+// DeleteMeta implements Client.
+func (b *bloomStoreEntry) DeleteMeta(ctx context.Context, meta Meta) error {
+	return b.bloomClient.DeleteMeta(ctx, meta)
+}
+
+// GetBlock implements Client.
+func (b *bloomStoreEntry) GetBlock(ctx context.Context, ref BlockRef) (LazyBlock, error) {
+	return b.bloomClient.GetBlock(ctx, ref)
+}
+
+// GetMetas implements Client.
+func (b *bloomStoreEntry) GetMetas(ctx context.Context, refs []MetaRef) ([]Meta, error) {
+	return b.bloomClient.GetMetas(ctx, refs)
+}
+
+// PutBlocks implements Client.
+func (b *bloomStoreEntry) PutBlocks(ctx context.Context, blocks []Block) ([]Block, error) {
+	return b.bloomClient.PutBlocks(ctx, blocks)
+}
+
+// PutMeta implements Client.
+func (b *bloomStoreEntry) PutMeta(ctx context.Context, meta Meta) error {
+	return b.bloomClient.PutMeta(ctx, meta)
+}
+
+// Stop implements Client.
+func (b bloomStoreEntry) Stop() {
+	b.bloomClient.Stop()
+}
+
+var _ Client = &BloomStore{}
+var _ Store = &BloomStore{}
+
+type BloomStore struct {
+	stores        []*bloomStoreEntry
+	storageConfig storage.Config
+}
+
+func NewBloomStore(
+	periodicConfigs []config.PeriodConfig,
+	storageConfig storage.Config,
+	clientMetrics storage.ClientMetrics,
+	metasCache cache.Cache,
+	blocksCache *cache.EmbeddedCache[string, io.ReadCloser],
+	logger log.Logger,
+) (*BloomStore, error) {
+	store := &BloomStore{
+		storageConfig: storageConfig,
+	}
+
+	if metasCache == nil {
+		metasCache = cache.NewNoopCache()
+	}
+
+	// sort by From time
+	sort.Slice(periodicConfigs, func(i, j int) bool {
+		return periodicConfigs[i].From.Time.Before(periodicConfigs[i].From.Time)
+	})
+
+	for _, periodicConfig := range periodicConfigs {
+		objectClient, err := storage.NewObjectClient(periodicConfig.ObjectType, storageConfig, clientMetrics)
+		if err != nil {
+			return nil, errors.Wrapf(err, "creating object client for period %s", periodicConfig.From)
+		}
+		bloomClient, err := NewBloomClient(objectClient, logger)
+		if err != nil {
+			return nil, errors.Wrapf(err, "creating bloom client for period %s", periodicConfig.From)
+		}
+		fetcher, err := NewFetcher(bloomClient, metasCache, blocksCache, logger)
+		if err != nil {
+			return nil, errors.Wrapf(err, "creating fetcher for period %s", periodicConfig.From)
+		}
+
+		store.stores = append(store.stores, &bloomStoreEntry{
+			start:        periodicConfig.From.Time,
+			cfg:          periodicConfig,
+			objectClient: objectClient,
+			bloomClient:  bloomClient,
+			fetcher:      fetcher,
+		})
+	}
+
+	return store, nil
+}
+
+// SearchMetas implements store.
+func (c *BloomStore) Fetcher(ts model.Time) *Fetcher {
+	if store := c.getStore(ts); store != nil {
+		return store.Fetcher(ts)
+	}
+	return nil
+}
+
+// SearchMetas implements store.
+func (b *BloomStore) SearchMetas(ctx context.Context, params MetaSearchParams) ([]Meta, error) {
+	var result []Meta
+	err := b.forStores(ctx, params.Interval, func(innerCtx context.Context, interval Interval, store Store) error {
+		newParams := params
+		newParams.Interval = interval
+		metas, err := store.SearchMetas(innerCtx, newParams)
+		if err != nil {
+			return err
+		}
+		result = append(result, metas...)
+		return nil
+	})
+	return result, err
+}
+
+// DeleteBlocks implements Client.
+func (b *BloomStore) DeleteBlocks(ctx context.Context, blocks []BlockRef) error {
+	for _, ref := range blocks {
+		err := b.storeDo(
+			ref.StartTimestamp,
+			func(s *bloomStoreEntry) error {
+				return s.DeleteBlocks(ctx, []BlockRef{ref})
+			},
+		)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// DeleteMeta implements Client.
+func (b *BloomStore) DeleteMeta(ctx context.Context, meta Meta) error {
+	return b.storeDo(meta.StartTimestamp, func(s *bloomStoreEntry) error {
+		return s.DeleteMeta(ctx, meta)
+	})
+}
+
+// GetBlock implements Client.
+func (b *BloomStore) GetBlock(ctx context.Context, ref BlockRef) (LazyBlock, error) {
+	var block LazyBlock
+	var err error
+	err = b.storeDo(ref.StartTimestamp, func(s *bloomStoreEntry) error {
+		block, err = s.GetBlock(ctx, ref)
+		return err
+	})
+	return block, err
+}
+
+// GetMetas implements Client.
+func (b *BloomStore) GetMetas(ctx context.Context, metas []MetaRef) ([]Meta, error) {
+	var refs [][]MetaRef
+	var fetchers []*Fetcher
+
+	for i := len(b.stores) - 1; i >= 0; i-- {
+		s := b.stores[i]
+		from, through := s.start, model.Latest
+		if i < len(b.stores)-1 {
+			through = b.stores[i+1].start
+		}
+
+		var res []MetaRef
+		for _, meta := range metas {
+			if meta.StartTimestamp >= from && meta.StartTimestamp < through {
+				res = append(res, meta)
+			}
+		}
+
+		if len(res) > 0 {
+			refs = append(refs, res)
+			fetchers = append(fetchers, s.Fetcher(s.start))
+		}
+	}
+
+	results := make([]Meta, 0, len(metas))
+	for i := range fetchers {
+		res, err := fetchers[i].FetchMetas(ctx, refs[i])
+		results = append(results, res...)
+		if err != nil {
+			return results, err
+		}
+	}
+
+	return results, nil
+}
+
+// PutBlocks implements Client.
+func (b *BloomStore) PutBlocks(ctx context.Context, blocks []Block) ([]Block, error) {
+	results := make([]Block, 0, len(blocks))
+	for _, ref := range blocks {
+		err := b.storeDo(
+			ref.StartTimestamp,
+			func(s *bloomStoreEntry) error {
+				res, err := s.PutBlocks(ctx, []Block{ref})
+				results = append(results, res...)
+				return err
+			},
+		)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return results, nil
+}
+
+// PutMeta implements Client.
+func (b *BloomStore) PutMeta(ctx context.Context, meta Meta) error {
+	return b.storeDo(meta.StartTimestamp, func(s *bloomStoreEntry) error {
+		return s.PutMeta(ctx, meta)
+	})
+}
+
+// Stop implements Client.
+func (b *BloomStore) Stop() {
+	for _, s := range b.stores {
+		s.Stop()
+	}
+}
+
+func (c *BloomStore) getStore(ts model.Time) *bloomStoreEntry {
+	// find the schema with the lowest start _after_ tm
+	j := sort.Search(len(c.stores), func(j int) bool {
+		return c.stores[j].start > ts
+	})
+
+	// reduce it by 1 because we want a schema with start <= tm
+	j--
+
+	if 0 <= j && j < len(c.stores) {
+		return c.stores[j]
+	}
+
+	return nil
+}
+
+func (c *BloomStore) storeDo(ts model.Time, f func(s *bloomStoreEntry) error) error {
+	if store := c.getStore(ts); store != nil {
+		return f(store)
+	}
+	return nil
+}
+
+func (c *BloomStore) forStores(ctx context.Context, interval Interval, f func(innerCtx context.Context, interval Interval, store Store) error) error {
+	if len(c.stores) == 0 {
+		return nil
+	}
+
+	from, through := interval.Start, interval.End
+
+	// first, find the schema with the highest start _before or at_ from
+	i := sort.Search(len(c.stores), func(i int) bool {
+		return c.stores[i].start > from
+	})
+	if i > 0 {
+		i--
+	} else {
+		// This could happen if we get passed a sample from before 1970.
+		i = 0
+		from = c.stores[0].start
+	}
+
+	// next, find the schema with the lowest start _after_ through
+	j := sort.Search(len(c.stores), func(j int) bool {
+		return c.stores[j].start > through
+	})
+
+	min := func(a, b model.Time) model.Time {
+		if a < b {
+			return a
+		}
+		return b
+	}
+
+	start := from
+	for ; i < j; i++ {
+		nextSchemaStarts := model.Latest
+		if i+1 < len(c.stores) {
+			nextSchemaStarts = c.stores[i+1].start
+		}
+
+		end := min(through, nextSchemaStarts-1)
+		err := f(ctx, Interval{start, end}, c.stores[i])
+		if err != nil {
+			return err
+		}
+
+		start = nextSchemaStarts
+	}
+	return nil
+}

--- a/pkg/storage/stores/shipper/bloomshipper/store.go
+++ b/pkg/storage/stores/shipper/bloomshipper/store.go
@@ -23,7 +23,10 @@ type Store interface {
 	Stop()
 }
 
+// Compiler check to ensure bloomStoreEntry implements the Client interface
 var _ Client = &bloomStoreEntry{}
+
+// Compiler check to ensure bloomStoreEntry implements the Store interface
 var _ Store = &bloomStoreEntry{}
 
 type bloomStoreEntry struct {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR changes the structure of how the bloom client

* The `BloomStore` is the top component interface which implements the `Store` and the `Client` interfaces. The store holds a store entry for each schema period.
* The `bloomStoreEntry` implements the `Store` and `Client` interfaces. It holds a bloom client for a single schema period. Additionally, the store entry also exposes a fetcher for metas (and in the future for blocks), which is responsible for getting data from cache or storage (if not available in cache).
* The `BloomClient` implement the `Client` interface. The bloom client uses an object client for the schema period of the bloom client.
* The `Fetcher` can fetch and cache metas.

This structure is very similar to what we use for the chunk store.

**Note**

Before implementing `FetchBlocks()` in the `BloomStore`, I want to implement the new `FingerprintBounds` type also in the shipper and bloom gateway code to be consistent across components, as well as to make use of the new utilities exposed by them.

The store implementation probably needs some specific test cases around using the correct store entry for different schema period configs. The code however is mostly taken from the chunk store implementation.