### PR TITLE
otlp: fix otlp service.name check when no resource attributes are defined

### DIFF
--- a/pkg/loghttp/push/otlp.go
+++ b/pkg/loghttp/push/otlp.go
@@ -114,7 +114,7 @@ func otlpToLokiPushRequest(ld plog.Logs, userID string, tenantsRetention Tenants
 		res := rls.At(i).Resource()
 		resAttrs := res.Attributes()
 
-		if v, _ := resAttrs.Get(attrServiceName); v.AsString() == "" {
+		if v, ok := resAttrs.Get(attrServiceName); !ok || v.AsString() == "" {
 			resAttrs.PutStr(attrServiceName, "unknown_service")
 		}
 		resourceAttributesAsStructuredMetadata := make(push.LabelsAdapter, 0, resAttrs.Len())


### PR DESCRIPTION
**What this PR does / why we need it**:
When no resource attributes are defined, check for `service.name` resource attributes fail with `nil pointer dereference`. This PR fixes the issue by checking the bool returned by the `Get` method on resource attributes.

**Checklist**
- [x] Tests updated
