### PR TITLE
(chore) Bloom shipper: Extend `Interval` struct with utility functions

### DIFF
--- a/pkg/bloomgateway/processor.go
+++ b/pkg/bloomgateway/processor.go
@@ -33,10 +33,7 @@ type processor struct {
 
 func (p *processor) run(ctx context.Context, tasks []Task) error {
 	for ts, tasks := range group(tasks, func(t Task) model.Time { return t.day }) {
-		interval := bloomshipper.Interval{
-			Start: ts,
-			End:   ts.Add(Day),
-		}
+		interval := bloomshipper.NewInterval(ts, ts.Add(Day))
 		tenant := tasks[0].Tenant
 		err := p.processTasks(ctx, tenant, interval, []v1.FingerprintBounds{{Min: 0, Max: math.MaxUint64}}, tasks)
 		if err != nil {

--- a/pkg/bloomgateway/worker.go
+++ b/pkg/bloomgateway/worker.go
@@ -160,11 +160,7 @@ func (w *worker) running(_ context.Context) error {
 			}
 
 			// interval is [Start, End)
-			interval := bloomshipper.Interval{
-				Start: day,          // inclusive
-				End:   day.Add(Day), // non-inclusive
-			}
-
+			interval := bloomshipper.NewInterval(day, day.Add(Day))
 			logger := log.With(w.logger, "day", day.Time(), "tenant", tasks[0].Tenant)
 			level.Debug(logger).Log("msg", "process tasks", "tasks", len(tasks))
 

--- a/pkg/storage/bloom/v1/bounds.go
+++ b/pkg/storage/bloom/v1/bounds.go
@@ -30,7 +30,7 @@ func (b FingerprintBounds) Hash(h hash.Hash32) error {
 	enc.PutBE64(uint64(b.Min))
 	enc.PutBE64(uint64(b.Max))
 	_, err := h.Write(enc.Get())
-	return errors.Wrap(err, "writing OwnershipRange")
+	return errors.Wrap(err, "writing FingerprintBounds")
 }
 
 func (b FingerprintBounds) String() string {
@@ -54,6 +54,7 @@ func (b FingerprintBounds) Cmp(fp model.Fingerprint) BoundsCheck {
 	return Overlap
 }
 
+// Overlaps returns whether the bounds (partially) overlap with the target bounds
 func (b FingerprintBounds) Overlaps(target FingerprintBounds) bool {
 	return b.Cmp(target.Min) != After && b.Cmp(target.Max) != Before
 }
@@ -63,7 +64,7 @@ func (b FingerprintBounds) Slice(min, max model.Fingerprint) *FingerprintBounds 
 	return b.Intersection(FingerprintBounds{Min: min, Max: max})
 }
 
-// Returns whether the fingerprint is fully within the target bounds
+// Within returns whether the fingerprint is fully within the target bounds
 func (b FingerprintBounds) Within(target FingerprintBounds) bool {
 	return b.Min >= target.Min && b.Max <= target.Max
 }

--- a/pkg/storage/stores/shipper/bloomshipper/client_test.go
+++ b/pkg/storage/stores/shipper/bloomshipper/client_test.go
@@ -73,8 +73,9 @@ func Test_BloomClient_FetchMetas(t *testing.T) {
 
 	searchParams := MetaSearchParams{
 		TenantID: "tenantA",
+
 		Keyspace: v1.NewBounds(50, 150),
-		Interval: Interval{Start: fixedDay.Add(-6 * day), End: fixedDay.Add(-1*day - 1*time.Hour)},
+		Interval: NewInterval(fixedDay.Add(-6*day), fixedDay.Add(-1*day-1*time.Hour)),
 	}
 
 	fetched, err := store.FetchMetas(context.Background(), searchParams)

--- a/pkg/storage/stores/shipper/bloomshipper/interval.go
+++ b/pkg/storage/stores/shipper/bloomshipper/interval.go
@@ -1,0 +1,59 @@
+package bloomshipper
+
+import (
+	"fmt"
+	"hash"
+
+	"github.com/pkg/errors"
+	"github.com/prometheus/common/model"
+
+	v1 "github.com/grafana/loki/pkg/storage/bloom/v1"
+	"github.com/grafana/loki/pkg/util/encoding"
+)
+
+// Interval defines a time range with start end end time
+// where the start is inclusive, the end is non-inclusive.
+type Interval struct {
+	Start, End model.Time
+}
+
+func NewInterval(start, end model.Time) Interval {
+	return Interval{Start: start, End: end}
+}
+
+func (i Interval) Hash(h hash.Hash32) error {
+	var enc encoding.Encbuf
+	enc.PutBE64(uint64(i.Start))
+	enc.PutBE64(uint64(i.End))
+	_, err := h.Write(enc.Get())
+	return errors.Wrap(err, "writing Interval")
+}
+
+func (i Interval) String() string {
+	// 13 digits are enough until Sat Nov 20 2286 17:46:39 UTC
+	return fmt.Sprintf("%013d-%013d", i.Start, i.End)
+}
+
+func (i Interval) Repr() string {
+	return fmt.Sprintf("[%s, %s)", i.Start.Time().UTC(), i.End.Time().UTC())
+}
+
+// Cmp returns the position of a time relative to the interval
+func (i Interval) Cmp(ts model.Time) v1.BoundsCheck {
+	if ts.Before(i.Start) {
+		return v1.Before
+	} else if ts.After(i.End) || ts.Equal(i.End) {
+		return v1.After
+	}
+	return v1.Overlap
+}
+
+// Overlaps returns whether the interval overlaps (partially) with the target interval
+func (b Interval) Overlaps(target Interval) bool {
+	return b.Cmp(target.Start) != v1.After && b.Cmp(target.End) != v1.Before
+}
+
+// Within returns whether the interval is fully within the target interval
+func (b Interval) Within(target Interval) bool {
+	return b.Start >= target.Start && b.End <= target.End
+}

--- a/pkg/storage/stores/shipper/bloomshipper/interval.go
+++ b/pkg/storage/stores/shipper/bloomshipper/interval.go
@@ -49,11 +49,11 @@ func (i Interval) Cmp(ts model.Time) v1.BoundsCheck {
 }
 
 // Overlaps returns whether the interval overlaps (partially) with the target interval
-func (b Interval) Overlaps(target Interval) bool {
-	return b.Cmp(target.Start) != v1.After && b.Cmp(target.End) != v1.Before
+func (i Interval) Overlaps(target Interval) bool {
+	return i.Cmp(target.Start) != v1.After && i.Cmp(target.End) != v1.Before
 }
 
 // Within returns whether the interval is fully within the target interval
-func (b Interval) Within(target Interval) bool {
-	return b.Start >= target.Start && b.End <= target.End
+func (i Interval) Within(target Interval) bool {
+	return i.Start >= target.Start && i.End <= target.End
 }

--- a/pkg/storage/stores/shipper/bloomshipper/interval_test.go
+++ b/pkg/storage/stores/shipper/bloomshipper/interval_test.go
@@ -1,0 +1,50 @@
+package bloomshipper
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/assert"
+
+	v1 "github.com/grafana/loki/pkg/storage/bloom/v1"
+)
+
+func Test_Interval_String(t *testing.T) {
+	start := model.Time(0)
+	end := model.TimeFromUnix(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC).Unix())
+	interval := NewInterval(start, end)
+	assert.Equal(t, "0000000000000-1704067200000", interval.String())
+	assert.Equal(t, "[1970-01-01 00:00:00 +0000 UTC, 2024-01-01 00:00:00 +0000 UTC)", interval.Repr())
+}
+
+func Test_Interval_Cmp(t *testing.T) {
+	interval := NewInterval(10, 20)
+	assert.Equal(t, v1.Before, interval.Cmp(0))
+	assert.Equal(t, v1.Overlap, interval.Cmp(10))
+	assert.Equal(t, v1.Overlap, interval.Cmp(15))
+	assert.Equal(t, v1.After, interval.Cmp(20)) // End is not inclusive
+	assert.Equal(t, v1.After, interval.Cmp(21))
+}
+
+func Test_Interval_Overlap(t *testing.T) {
+	interval := NewInterval(10, 20)
+	assert.True(t, interval.Overlaps(Interval{Start: 5, End: 15}))
+	assert.True(t, interval.Overlaps(Interval{Start: 15, End: 25}))
+	assert.True(t, interval.Overlaps(Interval{Start: 10, End: 20}))
+	assert.True(t, interval.Overlaps(Interval{Start: 5, End: 25}))
+	assert.False(t, interval.Overlaps(Interval{Start: 1, End: 9}))
+	assert.False(t, interval.Overlaps(Interval{Start: 20, End: 30})) // End is not inclusive
+	assert.False(t, interval.Overlaps(Interval{Start: 25, End: 30}))
+}
+
+func Test_Interval_Within(t *testing.T) {
+	target := NewInterval(10, 20)
+	assert.False(t, NewInterval(1, 9).Within(target))
+	assert.False(t, NewInterval(21, 30).Within(target))
+	assert.True(t, NewInterval(10, 20).Within(target))
+	assert.True(t, NewInterval(14, 15).Within(target))
+	assert.False(t, NewInterval(5, 15).Within(target))
+	assert.False(t, NewInterval(15, 25).Within(target))
+	assert.False(t, NewInterval(5, 25).Within(target))
+}

--- a/pkg/storage/stores/shipper/bloomshipper/shipper.go
+++ b/pkg/storage/stores/shipper/bloomshipper/shipper.go
@@ -8,29 +8,11 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/common/model"
 	"golang.org/x/exp/slices"
 
 	v1 "github.com/grafana/loki/pkg/storage/bloom/v1"
 	"github.com/grafana/loki/pkg/storage/stores/shipper/bloomshipper/config"
 )
-
-type Interval struct {
-	Start, End model.Time
-}
-
-func (i Interval) String() string {
-	return fmt.Sprintf("[%s, %s)", i.Start.Time(), i.End.Time())
-}
-
-func (i Interval) Cmp(other model.Time) v1.BoundsCheck {
-	if other.Before(i.Start) {
-		return v1.Before
-	} else if other.After(i.End) || other.Equal(i.End) {
-		return v1.After
-	}
-	return v1.Overlap
-}
 
 type BlockQuerierWithFingerprintRange struct {
 	*v1.BlockQuerier
@@ -203,14 +185,14 @@ func BlocksForMetas(metas []Meta, interval Interval, keyspaces []v1.FingerprintB
 // isOutsideRange tests if a given BlockRef b is outside of search boundaries
 // defined by min/max timestamp and min/max fingerprint.
 // Fingerprint ranges must be sorted in ascending order.
-func isOutsideRange(b BlockRef, interval Interval, keyspaces []v1.FingerprintBounds) bool {
+func isOutsideRange(b BlockRef, interval Interval, bounds []v1.FingerprintBounds) bool {
 	// check time interval
-	if interval.Cmp(b.EndTimestamp) == v1.Before || interval.Cmp(b.StartTimestamp) == v1.After {
+	if !interval.Overlaps(b.Interval()) {
 		return true
 	}
 
 	// check fingerprint ranges
-	for _, keyspace := range keyspaces {
+	for _, keyspace := range bounds {
 		if keyspace.Within(b.Bounds()) || keyspace.Overlaps(b.Bounds()) {
 			return false
 		}

--- a/pkg/storage/stores/shipper/bloomshipper/store.go
+++ b/pkg/storage/stores/shipper/bloomshipper/store.go
@@ -41,7 +41,7 @@ type bloomStoreEntry struct {
 // ResolveMetas implements store.
 func (b *bloomStoreEntry) ResolveMetas(ctx context.Context, params MetaSearchParams) ([][]MetaRef, []*Fetcher, error) {
 	var refs []MetaRef
-	tables := tablesForRange(b.cfg, params.Interval.Start, params.Interval.End)
+	tables := tablesForRange(b.cfg, params.Interval)
 	for _, table := range tables {
 		prefix := filepath.Join(rootFolder, table, params.TenantID, metasFolder)
 		list, _, err := b.objectClient.List(ctx, prefix, "")
@@ -393,7 +393,7 @@ func (b *BloomStore) forStores(ctx context.Context, interval Interval, f func(in
 		}
 
 		end := min(through, nextSchemaStarts-1)
-		err := f(ctx, Interval{start, end}, b.stores[i])
+		err := f(ctx, NewInterval(start, end), b.stores[i])
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

~~Even though it is mainly used by the bloom shipper and bloom gateway, it should reside next to the FingerprintBounds, which has similar characteristics and utility functions.~~

Update:

I reverted moving the struct, but kept the utility functions.