### PR TITLE
quantile sharding: switch to ddsketch sparse constructor and remove quantile vector pooling in Join function

### DIFF
--- a/pkg/logql/quantile_over_time_sketch.go
+++ b/pkg/logql/quantile_over_time_sketch.go
@@ -284,7 +284,8 @@ func JoinQuantileSketchVector(next bool, r StepResult, stepEvaluator StepEvaluat
 	}
 
 	// The result is released to the pool when the matrix is serialized.
-	result := quantileVectorPool.Get(stepCount)
+	//result := quantileVectorPool.Get(stepCount)
+	result := ProbabilisticQuantileMatrix{}
 
 	for next {
 		result = append(result, vec)
@@ -295,7 +296,7 @@ func JoinQuantileSketchVector(next bool, r StepResult, stepEvaluator StepEvaluat
 		}
 	}
 
-	return ProbabilisticQuantileMatrix(result), stepEvaluator.Error()
+	return result, stepEvaluator.Error()
 }
 
 // QuantileSketchMatrixStepEvaluator steps through a matrix of quantile sketch

--- a/pkg/logql/quantile_over_time_sketch.go
+++ b/pkg/logql/quantile_over_time_sketch.go
@@ -236,28 +236,20 @@ func probabilisticQuantileSampleFromProto(proto *logproto.QuantileSketchSample) 
 
 type quantileSketchBatchRangeVectorIterator struct {
 	*batchRangeVectorIterator
-	at []ProbabilisticQuantileSample
 }
 
 func (r *quantileSketchBatchRangeVectorIterator) At() (int64, StepResult) {
-	/*
-		if r.at == nil {
-			r.at = make([]ProbabilisticQuantileSample, 0, len(r.window))
-		}
-		clear(r.at)
-	*/
-	r.at = r.at[:0]
-	r.at = make([]ProbabilisticQuantileSample, 0, len(r.window))
+	at := make([]ProbabilisticQuantileSample, 0, len(r.window))
 	// convert ts from nano to milli seconds as the iterator work with nanoseconds
 	ts := r.current/1e+6 + r.offset/1e+6
 	for _, series := range r.window {
-		r.at = append(r.at, ProbabilisticQuantileSample{
+		at = append(at, ProbabilisticQuantileSample{
 			F:      r.agg(series.Floats),
 			T:      ts,
 			Metric: series.Metric,
 		})
 	}
-	return ts, ProbabilisticQuantileVector(r.at)
+	return ts, ProbabilisticQuantileVector(at)
 }
 
 func (r *quantileSketchBatchRangeVectorIterator) agg(samples []promql.FPoint) sketch.QuantileSketch {

--- a/pkg/logql/quantile_over_time_sketch_test.go
+++ b/pkg/logql/quantile_over_time_sketch_test.go
@@ -136,9 +136,9 @@ func BenchmarkJoinQuantileSketchVector(b *testing.B) {
 			iter: iter,
 		}
 		_, _, r := ev.Next()
-		_, err := JoinQuantileSketchVector(true, r.QuantileSketchVec(), ev, params)
+		m, err := JoinQuantileSketchVector(true, r.QuantileSketchVec(), ev, params)
 		require.NoError(b, err)
-		//r.(ProbabilisticQuantileMatrix).Release()
+		m.(ProbabilisticQuantileMatrix).Release()
 	}
 }
 

--- a/pkg/logql/sketch/quantile.go
+++ b/pkg/logql/sketch/quantile.go
@@ -47,7 +47,7 @@ const relativeAccuracy = 0.01
 var ddsketchPool = sync.Pool{
 	New: func() any {
 		m, _ := mapping.NewCubicallyInterpolatedMapping(relativeAccuracy)
-		return ddsketch.NewDDSketchFromStoreProvider(m, store.DefaultProvider)
+		return ddsketch.NewDDSketchFromStoreProvider(m, store.SparseStoreConstructor)
 	},
 }
 


### PR DESCRIPTION
This should reduce our memory usage for our quantile sketches by about half, at least in our current situation we'll OOM after ~160-170 minutes instead of ~90 :cry: 