### PR TITLE
Helm: Fix http port name

### DIFF
--- a/production/helm/loki/templates/compactor/deployment-compactor.yaml
+++ b/production/helm/loki/templates/compactor/deployment-compactor.yaml
@@ -73,7 +73,7 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
           ports:
-            - name: http
+            - name: http-metrics
               containerPort: 3100
               protocol: TCP
             - name: grpc

--- a/production/helm/loki/templates/compactor/service-compactor.yaml
+++ b/production/helm/loki/templates/compactor/service-compactor.yaml
@@ -18,9 +18,9 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-    - name: http
+    - name: http-metrics
       port: 3100
-      targetPort: http
+      targetPort: http-metrics
       protocol: TCP
     - name: grpc
       port: 9095

--- a/production/helm/loki/templates/compactor/statefulset-compactor.yaml
+++ b/production/helm/loki/templates/compactor/statefulset-compactor.yaml
@@ -87,7 +87,7 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
           ports:
-            - name: http
+            - name: http-metrics
               containerPort: 3100
               protocol: TCP
             - name: grpc

--- a/production/helm/loki/templates/distributor/deployment-distributor.yaml
+++ b/production/helm/loki/templates/distributor/deployment-distributor.yaml
@@ -72,7 +72,7 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
           ports:
-            - name: http
+            - name: http-metrics
               containerPort: 3100
               protocol: TCP
             - name: grpc

--- a/production/helm/loki/templates/distributor/service-distributor.yaml
+++ b/production/helm/loki/templates/distributor/service-distributor.yaml
@@ -17,7 +17,7 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-    - name: http
+    - name: http-metrics
       port: 3100
       targetPort: http
       protocol: TCP

--- a/production/helm/loki/templates/gateway/deployment-gateway.yaml
+++ b/production/helm/loki/templates/gateway/deployment-gateway.yaml
@@ -61,7 +61,7 @@ spec:
           image: {{ include "loki.gatewayImage" . }}
           imagePullPolicy: {{ .Values.gateway.image.pullPolicy }}
           ports:
-            - name: http
+            - name: http-metrics
               containerPort: 8080
               protocol: TCP
           {{- with .Values.gateway.extraEnv }}

--- a/production/helm/loki/templates/gateway/service-gateway.yaml
+++ b/production/helm/loki/templates/gateway/service-gateway.yaml
@@ -28,9 +28,9 @@ spec:
   loadBalancerIP: {{ .Values.gateway.service.loadBalancerIP }}
   {{- end }}
   ports:
-    - name: http
+    - name: http-metrics
       port: {{ .Values.gateway.service.port }}
-      targetPort: http
+      targetPort: http-metrics
       {{- if and (eq "NodePort" .Values.gateway.service.type) .Values.gateway.service.nodePort }}
       nodePort: {{ .Values.gateway.service.nodePort }}
       {{- end }}

--- a/production/helm/loki/templates/index-gateway/service-index-gateway-headless.yaml
+++ b/production/helm/loki/templates/index-gateway/service-index-gateway-headless.yaml
@@ -11,9 +11,9 @@ spec:
   type: ClusterIP
   clusterIP: None
   ports:
-    - name: http
+    - name: http-metrics
       port: 3100
-      targetPort: http
+      targetPort: http-metrics
       protocol: TCP
     - name: grpc
       port: 9095

--- a/production/helm/loki/templates/index-gateway/service-index-gateway.yaml
+++ b/production/helm/loki/templates/index-gateway/service-index-gateway.yaml
@@ -16,9 +16,9 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-    - name: http
+    - name: http-metrics
       port: 3100
-      targetPort: http
+      targetPort: http-metrics
       protocol: TCP
     - name: grpc
       port: 9095

--- a/production/helm/loki/templates/index-gateway/statefulset-index-gateway.yaml
+++ b/production/helm/loki/templates/index-gateway/statefulset-index-gateway.yaml
@@ -79,7 +79,7 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
           ports:
-            - name: http
+            - name: http-metrics
               containerPort: 3100
               protocol: TCP
             - name: grpc

--- a/production/helm/loki/templates/ingester/deployment-ingester.yaml
+++ b/production/helm/loki/templates/ingester/deployment-ingester.yaml
@@ -82,7 +82,7 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
           ports:
-            - name: http
+            - name: http-metrics
               containerPort: 3100
               protocol: TCP
             - name: grpc

--- a/production/helm/loki/templates/ingester/service-ingester-headless.yaml
+++ b/production/helm/loki/templates/ingester/service-ingester-headless.yaml
@@ -16,9 +16,9 @@ spec:
   type: ClusterIP
   clusterIP: None
   ports:
-    - name: http
+    - name: http-metrics
       port: 3100
-      targetPort: http
+      targetPort: http-metrics
       protocol: TCP
     - name: grpc
       port: 9095

--- a/production/helm/loki/templates/ingester/service-ingester.yaml
+++ b/production/helm/loki/templates/ingester/service-ingester.yaml
@@ -17,9 +17,9 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-    - name: http
+    - name: http-metrics
       port: 3100
-      targetPort: http
+      targetPort: http-metrics
       protocol: TCP
     - name: grpc
       port: 9095

--- a/production/helm/loki/templates/ingester/statefulset-ingester.yaml
+++ b/production/helm/loki/templates/ingester/statefulset-ingester.yaml
@@ -92,7 +92,7 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
           ports:
-            - name: http
+            - name: http-metrics
               containerPort: 3100
               protocol: TCP
             - name: grpc

--- a/production/helm/loki/templates/querier/deployment-querier.yaml
+++ b/production/helm/loki/templates/querier/deployment-querier.yaml
@@ -78,7 +78,7 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
           ports:
-            - name: http
+            - name: http-metrics
               containerPort: 3100
               protocol: TCP
             - name: grpc

--- a/production/helm/loki/templates/querier/service-querier-headless.yaml
+++ b/production/helm/loki/templates/querier/service-querier-headless.yaml
@@ -12,9 +12,9 @@ spec:
   type: ClusterIP
   clusterIP: None
   ports:
-    - name: http
+    - name: http-metrics
       port: 3100
-      targetPort: http
+      targetPort: http-metrics
       protocol: TCP
     - name: grpc
       port: 9095

--- a/production/helm/loki/templates/querier/service-querier.yaml
+++ b/production/helm/loki/templates/querier/service-querier.yaml
@@ -17,9 +17,9 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-    - name: http
+    - name: http-metrics
       port: 3100
-      targetPort: http
+      targetPort: http-metrics
       protocol: TCP
     - name: grpc
       port: 9095

--- a/production/helm/loki/templates/querier/statefulset-querier.yaml
+++ b/production/helm/loki/templates/querier/statefulset-querier.yaml
@@ -81,7 +81,7 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
           ports:
-            - name: http
+            - name: http-metrics
               containerPort: 3100
               protocol: TCP
             - name: grpc

--- a/production/helm/loki/templates/query-frontend/deployment-query-frontend.yaml
+++ b/production/helm/loki/templates/query-frontend/deployment-query-frontend.yaml
@@ -71,7 +71,7 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
           ports:
-            - name: http
+            - name: http-metrics
               containerPort: 3100
               protocol: TCP
             - name: grpc
@@ -92,8 +92,6 @@ spec:
             {{- toYaml .Values.loki.containerSecurityContext | nindent 12 }}
           readinessProbe:
             {{- toYaml .Values.loki.readinessProbe | nindent 12 }}
-          livenessProbe:
-            {{- toYaml .Values.loki.livenessProbe | nindent 12 }}
           volumeMounts:
             - name: config
               mountPath: /etc/loki/config

--- a/production/helm/loki/templates/query-frontend/service-query-frontend-headless.yaml
+++ b/production/helm/loki/templates/query-frontend/service-query-frontend-headless.yaml
@@ -20,7 +20,7 @@ spec:
   type: ClusterIP
   publishNotReadyAddresses: true
   ports:
-    - name: http
+    - name: http-metrics
       port: 3100
       targetPort: http
       protocol: TCP

--- a/production/helm/loki/templates/query-frontend/service-query-frontend.yaml
+++ b/production/helm/loki/templates/query-frontend/service-query-frontend.yaml
@@ -18,9 +18,9 @@ spec:
   type: ClusterIP
   publishNotReadyAddresses: true
   ports:
-    - name: http
+    - name: http-metrics
       port: 3100
-      targetPort: http
+      targetPort: http-metrics
       protocol: TCP
     - name: grpc
       port: 9095

--- a/production/helm/loki/templates/query-scheduler/deployment-query-scheduler.yaml
+++ b/production/helm/loki/templates/query-scheduler/deployment-query-scheduler.yaml
@@ -65,7 +65,7 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
           ports:
-            - name: http
+            - name: http-metrics
               containerPort: 3100
               protocol: TCP
             - name: grpc

--- a/production/helm/loki/templates/query-scheduler/service-query-scheduler.yaml
+++ b/production/helm/loki/templates/query-scheduler/service-query-scheduler.yaml
@@ -19,7 +19,7 @@ spec:
   clusterIP: None
   publishNotReadyAddresses: true
   ports:
-    - name: http
+    - name: http-metrics
       port: 3100
       targetPort: http
       protocol: TCP

--- a/production/helm/loki/templates/ruler/deployment-ruler.yaml
+++ b/production/helm/loki/templates/ruler/deployment-ruler.yaml
@@ -73,7 +73,7 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
           ports:
-            - name: http
+            - name: http-metrics
               containerPort: 3100
               protocol: TCP
             - name: grpc

--- a/production/helm/loki/templates/ruler/service-ruler.yaml
+++ b/production/helm/loki/templates/ruler/service-ruler.yaml
@@ -17,7 +17,7 @@ spec:
   type: ClusterIP
   clusterIP: None
   ports:
-    - name: http
+    - name: http-metrics
       port: 3100
       targetPort: http
       protocol: TCP

--- a/production/helm/loki/templates/ruler/statefulset-ruler.yaml
+++ b/production/helm/loki/templates/ruler/statefulset-ruler.yaml
@@ -66,7 +66,7 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
           ports:
-            - name: http
+            - name: http-metrics
               containerPort: 3100
               protocol: TCP
             - name: grpc


### PR DESCRIPTION
**What this PR does / why we need it**:
Components were expecting the port name to be `http` instead of `http-metrics`.

**Which issue(s) this PR fixes**:
N/A
