### PR TITLE
Blooms/align compactor to shipper

### DIFF
--- a/pkg/bloomgateway/util_test.go
+++ b/pkg/bloomgateway/util_test.go
@@ -2,7 +2,6 @@ package bloomgateway
 
 import (
 	"context"
-	"fmt"
 	"math/rand"
 	"testing"
 	"time"
@@ -343,8 +342,7 @@ func createBlocks(t *testing.T, tenant string, n int, from, through model.Time, 
 			EndTimestamp:   through,
 		}
 		block := bloomshipper.BlockRef{
-			Ref:       ref,
-			BlockPath: fmt.Sprintf("block-%d", i),
+			Ref: ref,
 		}
 		meta := bloomshipper.Meta{
 			MetaRef: bloomshipper.MetaRef{
@@ -458,7 +456,6 @@ func createBlockRefsFromBlockData(t *testing.T, tenant string, data []bloomshipp
 				EndTimestamp:   0,
 				Checksum:       0,
 			},
-			BlockPath: fmt.Sprintf("block-%d", i),
 		})
 	}
 	return res

--- a/pkg/bloomgateway/util_test.go
+++ b/pkg/bloomgateway/util_test.go
@@ -344,7 +344,6 @@ func createBlocks(t *testing.T, tenant string, n int, from, through model.Time, 
 		}
 		block := bloomshipper.BlockRef{
 			Ref:       ref,
-			IndexPath: "index.tsdb.gz",
 			BlockPath: fmt.Sprintf("block-%d", i),
 		}
 		meta := bloomshipper.Meta{
@@ -459,7 +458,6 @@ func createBlockRefsFromBlockData(t *testing.T, tenant string, data []bloomshipp
 				EndTimestamp:   0,
 				Checksum:       0,
 			},
-			IndexPath: fmt.Sprintf("index-%d", i),
 			BlockPath: fmt.Sprintf("block-%d", i),
 		})
 	}

--- a/pkg/storage/stores/shipper/bloomshipper/block_downloader_test.go
+++ b/pkg/storage/stores/shipper/bloomshipper/block_downloader_test.go
@@ -391,6 +391,7 @@ func Test_blockDownloader_extractBlock(t *testing.T) {
 	}
 
 	err = extractBlock(block.Data, workingDir, nil)
+	require.NoError(t, err)
 
 	require.FileExists(t, filepath.Join(workingDir, v1.BloomFileName))
 	require.FileExists(t, filepath.Join(workingDir, v1.SeriesFileName))

--- a/pkg/storage/stores/shipper/bloomshipper/block_downloader_test.go
+++ b/pkg/storage/stores/shipper/bloomshipper/block_downloader_test.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -15,6 +14,7 @@ import (
 	"github.com/go-kit/log"
 	"github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
 
@@ -42,12 +42,12 @@ func Test_blockDownloader_downloadBlocks(t *testing.T) {
 	}, blockClient, overrides, log.NewNopLogger(), prometheus.DefaultRegisterer)
 	require.NoError(t, err)
 	blocksCh, errorsCh := downloader.downloadBlocks(context.Background(), "fake", blockReferences)
-	downloadedBlocks := make(map[string]any, len(blockReferences))
+	downloadedBlocks := make(map[BlockRef]any, len(blockReferences))
 	done := make(chan bool)
 	go func() {
 		for i := 0; i < 20; i++ {
 			block := <-blocksCh
-			downloadedBlocks[block.BlockPath] = nil
+			downloadedBlocks[block.BlockRef] = nil
 		}
 		done <- true
 	}()
@@ -111,12 +111,12 @@ func Test_blockDownloader_downloadBlock(t *testing.T) {
 			require.NoError(t, err)
 
 			blocksCh, errorsCh := downloader.downloadBlocks(context.Background(), "fake", blockReferences)
-			downloadedBlocks := make(map[string]any, len(blockReferences))
+			downloadedBlocks := make(map[BlockRef]any, len(blockReferences))
 			done := make(chan bool)
 			go func() {
 				for i := 0; i < 20; i++ {
 					block := <-blocksCh
-					downloadedBlocks[block.BlockPath] = nil
+					downloadedBlocks[block.BlockRef] = nil
 				}
 				done <- true
 			}()
@@ -132,12 +132,12 @@ func Test_blockDownloader_downloadBlock(t *testing.T) {
 			require.Equal(t, int32(20), blockClient.getBlockCalls.Load())
 
 			blocksCh, errorsCh = downloader.downloadBlocks(context.Background(), "fake", blockReferences)
-			downloadedBlocks = make(map[string]any, len(blockReferences))
+			downloadedBlocks = make(map[BlockRef]any, len(blockReferences))
 			done = make(chan bool)
 			go func() {
 				for i := 0; i < 20; i++ {
 					block := <-blocksCh
-					downloadedBlocks[block.BlockPath] = nil
+					downloadedBlocks[block.BlockRef] = nil
 				}
 				done <- true
 			}()
@@ -313,7 +313,7 @@ func Test_closableBlockQuerier(t *testing.T) {
 
 // creates fake blocks and returns map[block-path]Block and mockBlockClient
 func createFakeBlocks(t *testing.T, count int) ([]BlockRef, *mockBlockClient) {
-	mockData := make(map[string]blockSupplier, count)
+	mockData := make(map[BlockRef]blockSupplier, count)
 	refs := make([]BlockRef, 0, count)
 	for i := 0; i < count; i++ {
 		archivePath, _, _ := createBlockArchive(t)
@@ -321,9 +321,16 @@ func createFakeBlocks(t *testing.T, count int) ([]BlockRef, *mockBlockClient) {
 		//ensure file can be opened
 		require.NoError(t, err)
 		blockRef := BlockRef{
-			BlockPath: fmt.Sprintf("block-path-%d", i),
+			Ref: Ref{
+				TenantID:       "",
+				TableName:      "",
+				Bounds:         v1.NewBounds(model.Fingerprint(i), model.Fingerprint(i+1)),
+				StartTimestamp: 0,
+				EndTimestamp:   0,
+				Checksum:       0,
+			},
 		}
-		mockData[blockRef.BlockPath] = func() LazyBlock {
+		mockData[blockRef] = func() LazyBlock {
 			file, _ := os.OpenFile(archivePath, os.O_RDONLY, 0700)
 			return LazyBlock{
 				BlockRef: blockRef,
@@ -339,19 +346,20 @@ type blockSupplier func() LazyBlock
 
 type mockBlockClient struct {
 	responseDelay time.Duration
-	mockData      map[string]blockSupplier
+	mockData      map[BlockRef]blockSupplier
 	getBlockCalls atomic.Int32
+	defaultKeyResolver
 }
 
 func (m *mockBlockClient) GetBlock(_ context.Context, reference BlockRef) (LazyBlock, error) {
 	m.getBlockCalls.Inc()
 	time.Sleep(m.responseDelay)
-	supplier, exists := m.mockData[reference.BlockPath]
+	supplier, exists := m.mockData[reference]
 	if exists {
 		return supplier(), nil
 	}
 
-	return LazyBlock{}, fmt.Errorf("block %s is not found in mockData", reference.BlockPath)
+	return LazyBlock{}, fmt.Errorf("block %s is not found in mockData", reference)
 }
 
 func (m *mockBlockClient) PutBlocks(_ context.Context, _ []Block) ([]Block, error) {
@@ -368,26 +376,30 @@ func Test_blockDownloader_extractBlock(t *testing.T) {
 	require.NoError(t, err)
 
 	workingDir := t.TempDir()
-	ts := time.Now().UTC()
 	block := LazyBlock{
-		BlockRef: BlockRef{BlockPath: "first-period-19621/tenantA/metas/ff-fff-1695272400-1695276000-aaa"},
-		Data:     blockFile,
+		BlockRef: BlockRef{
+			Ref: Ref{
+				TenantID:       "",
+				TableName:      "",
+				Bounds:         v1.NewBounds(0, 1),
+				StartTimestamp: 0,
+				EndTimestamp:   0,
+				Checksum:       0,
+			},
+		},
+		Data: blockFile,
 	}
 
-	actualPath, err := extractBlock(&block, ts, workingDir, nil)
+	err = extractBlock(block.Data, workingDir, nil)
 
-	require.NoError(t, err)
-	expectedPath := filepath.Join(workingDir, block.BlockPath, strconv.FormatInt(ts.UnixNano(), 10))
-	require.Equal(t, expectedPath, actualPath,
-		"expected archive to be extracted to working directory under the same path as blockPath and with timestamp suffix")
-	require.FileExists(t, filepath.Join(expectedPath, v1.BloomFileName))
-	require.FileExists(t, filepath.Join(expectedPath, v1.SeriesFileName))
+	require.FileExists(t, filepath.Join(workingDir, v1.BloomFileName))
+	require.FileExists(t, filepath.Join(workingDir, v1.SeriesFileName))
 
-	actualBloomFileContent, err := os.ReadFile(filepath.Join(expectedPath, v1.BloomFileName))
+	actualBloomFileContent, err := os.ReadFile(filepath.Join(workingDir, v1.BloomFileName))
 	require.NoError(t, err)
 	require.Equal(t, bloomFileContent, string(actualBloomFileContent))
 
-	actualSeriesFileContent, err := os.ReadFile(filepath.Join(expectedPath, v1.SeriesFileName))
+	actualSeriesFileContent, err := os.ReadFile(filepath.Join(workingDir, v1.SeriesFileName))
 	require.NoError(t, err)
 	require.Equal(t, seriesFileContent, string(actualSeriesFileContent))
 }

--- a/pkg/storage/stores/shipper/bloomshipper/client.go
+++ b/pkg/storage/stores/shipper/bloomshipper/client.go
@@ -69,7 +69,6 @@ func (r Ref) Interval() Interval {
 
 type BlockRef struct {
 	Ref
-	IndexPath string
 	BlockPath string
 }
 

--- a/pkg/storage/stores/shipper/bloomshipper/client_test.go
+++ b/pkg/storage/stores/shipper/bloomshipper/client_test.go
@@ -205,17 +205,6 @@ func Test_BloomClient_DeleteMeta(t *testing.T) {
 }
 
 func Test_BloomClient_GetBlocks(t *testing.T) {
-	bloomClient := createStore(t)
-	fsNamedStores := bloomClient.storageConfig.NamedStores.Filesystem
-	firstBlockPath := fmt.Sprintf("bloom/first-period-19621/tenantA/blooms/%s/1695272400000-1695276000000-1", v1.NewBounds(0xeeee, 0xffff))
-	firstBlockFullPath := filepath.Join(fsNamedStores["folder-1"].Directory, firstBlockPath)
-	firstBlockData := createBlockFile(t, firstBlockFullPath)
-	secondBlockPath := fmt.Sprintf("bloom/second-period-19624/tenantA/blooms/%s/1695531600000-1695535200000-2", v1.NewBounds(0xaaaa, 0xbbbb))
-	secondBlockFullPath := filepath.Join(fsNamedStores["folder-2"].Directory, secondBlockPath)
-	secondBlockData := createBlockFile(t, secondBlockFullPath)
-	require.FileExists(t, firstBlockFullPath)
-	require.FileExists(t, secondBlockFullPath)
-
 	firstBlockRef := BlockRef{
 		Ref: Ref{
 			TenantID:       "tenantA",
@@ -225,7 +214,6 @@ func Test_BloomClient_GetBlocks(t *testing.T) {
 			EndTimestamp:   Date(2023, time.September, 21, 6, 0, 0),
 			Checksum:       1,
 		},
-		BlockPath: firstBlockPath,
 	}
 	secondBlockRef := BlockRef{
 		Ref: Ref{
@@ -236,8 +224,22 @@ func Test_BloomClient_GetBlocks(t *testing.T) {
 			EndTimestamp:   Date(2023, time.September, 24, 6, 0, 0),
 			Checksum:       2,
 		},
-		BlockPath: secondBlockPath,
 	}
+
+	bloomClient := createStore(t)
+	fsNamedStores := bloomClient.storageConfig.NamedStores.Filesystem
+	firstBlockFullPath := NewPrefixedResolver(
+		fsNamedStores["folder-1"].Directory,
+		defaultKeyResolver{},
+	).Block(firstBlockRef).LocalPath()
+	firstBlockData := createBlockFile(t, firstBlockFullPath)
+	secondBlockFullPath := NewPrefixedResolver(
+		fsNamedStores["folder-2"].Directory,
+		defaultKeyResolver{},
+	).Block(secondBlockRef).LocalPath()
+	secondBlockData := createBlockFile(t, secondBlockFullPath)
+	require.FileExists(t, firstBlockFullPath)
+	require.FileExists(t, secondBlockFullPath)
 
 	downloadedFirstBlock, err := bloomClient.GetBlock(context.Background(), firstBlockRef)
 	require.NoError(t, err)
@@ -254,8 +256,7 @@ func Test_BloomClient_GetBlocks(t *testing.T) {
 
 func Test_BloomClient_PutBlocks(t *testing.T) {
 	bloomClient := createStore(t)
-	blockForFirstFolderData := "data1"
-	blockForFirstFolder := Block{
+	block := Block{
 		BlockRef: BlockRef{
 			Ref: Ref{
 				TenantID:       "tenantA",
@@ -266,111 +267,43 @@ func Test_BloomClient_PutBlocks(t *testing.T) {
 				Checksum:       1,
 			},
 		},
-		Data: awsio.ReadSeekNopCloser{ReadSeeker: bytes.NewReader([]byte(blockForFirstFolderData))},
+		Data: awsio.ReadSeekNopCloser{ReadSeeker: bytes.NewReader([]byte("data"))},
 	}
-
-	blockForSecondFolderData := "data2"
-	blockForSecondFolder := Block{
-		BlockRef: BlockRef{
-			Ref: Ref{
-				TenantID:       "tenantA",
-				TableName:      "second-period-19624",
-				Bounds:         v1.NewBounds(0xaaaa, 0xbbbb),
-				StartTimestamp: Date(2023, time.September, 24, 5, 0, 0),
-				EndTimestamp:   Date(2023, time.September, 24, 6, 0, 0),
-				Checksum:       2,
-			},
-		},
-		Data: awsio.ReadSeekNopCloser{ReadSeeker: bytes.NewReader([]byte(blockForSecondFolderData))},
-	}
-
-	results, err := bloomClient.PutBlocks(context.Background(), []Block{blockForFirstFolder, blockForSecondFolder})
+	_, err := bloomClient.PutBlocks(context.Background(), []Block{block})
 	require.NoError(t, err)
-	require.Len(t, results, 2)
-	firstResultBlock := results[0]
-	path := firstResultBlock.BlockPath
-	require.Equal(t,
-		fmt.Sprintf(
-			"bloom/first-period-19621/tenantA/blooms/%s/1695272400000-1695276000000-1",
-			v1.NewBounds(0xeeee, 0xffff),
-		),
-		path,
-	)
-	require.Equal(t, blockForFirstFolder.TenantID, firstResultBlock.TenantID)
-	require.Equal(t, blockForFirstFolder.TableName, firstResultBlock.TableName)
-	require.Equal(t, blockForFirstFolder.Bounds.Min, firstResultBlock.Bounds.Min)
-	require.Equal(t, blockForFirstFolder.Bounds.Max, firstResultBlock.Bounds.Max)
-	require.Equal(t, blockForFirstFolder.StartTimestamp, firstResultBlock.StartTimestamp)
-	require.Equal(t, blockForFirstFolder.EndTimestamp, firstResultBlock.EndTimestamp)
-	require.Equal(t, blockForFirstFolder.Checksum, firstResultBlock.Checksum)
-	folder1 := bloomClient.storageConfig.NamedStores.Filesystem["folder-1"].Directory
-	savedFilePath := filepath.Join(folder1, path)
-	require.FileExists(t, savedFilePath)
-	savedData, err := os.ReadFile(savedFilePath)
+	got, err := bloomClient.GetBlock(context.Background(), block.BlockRef)
 	require.NoError(t, err)
-	require.Equal(t, blockForFirstFolderData, string(savedData))
-
-	secondResultBlock := results[1]
-	path = secondResultBlock.BlockPath
-	require.Equal(t,
-		fmt.Sprintf(
-			"bloom/second-period-19624/tenantA/blooms/%s/1695531600000-1695535200000-2",
-			v1.NewBounds(0xaaaa, 0xbbbb),
-		),
-		path,
-	)
-	require.Equal(t, blockForSecondFolder.TenantID, secondResultBlock.TenantID)
-	require.Equal(t, blockForSecondFolder.TableName, secondResultBlock.TableName)
-	require.Equal(t, blockForSecondFolder.Bounds.Min, secondResultBlock.Bounds.Min)
-	require.Equal(t, blockForSecondFolder.Bounds.Max, secondResultBlock.Bounds.Max)
-	require.Equal(t, blockForSecondFolder.StartTimestamp, secondResultBlock.StartTimestamp)
-	require.Equal(t, blockForSecondFolder.EndTimestamp, secondResultBlock.EndTimestamp)
-	require.Equal(t, blockForSecondFolder.Checksum, secondResultBlock.Checksum)
-	folder2 := bloomClient.storageConfig.NamedStores.Filesystem["folder-2"].Directory
-
-	savedFilePath = filepath.Join(folder2, path)
-	require.FileExists(t, savedFilePath)
-	savedData, err = os.ReadFile(savedFilePath)
+	require.Equal(t, block.BlockRef, got.BlockRef)
+	data, err := io.ReadAll(got.Data)
 	require.NoError(t, err)
-	require.Equal(t, blockForSecondFolderData, string(savedData))
+	require.Equal(t, "data", string(data))
 }
 
 func Test_BloomClient_DeleteBlocks(t *testing.T) {
-	bloomClient := createStore(t)
-	fsNamedStores := bloomClient.storageConfig.NamedStores.Filesystem
-	block1Path := filepath.Join(fsNamedStores["folder-1"].Directory, "bloom/first-period-19621/tenantA/blooms/000000000000eeee-000000000000ffff/1695272400000-1695276000000-1")
-	createBlockFile(t, block1Path)
-	block2Path := filepath.Join(fsNamedStores["folder-2"].Directory, "bloom/second-period-19624/tenantA/blooms/000000000000aaaa-000000000000bbbb/1695531600000-1695535200000-2")
-	createBlockFile(t, block2Path)
-	require.FileExists(t, block1Path)
-	require.FileExists(t, block2Path)
-
-	blocksToDelete := []BlockRef{
-		{
-			Ref: Ref{
-				TenantID:       "tenantA",
-				TableName:      "second-period-19624",
-				Bounds:         v1.NewBounds(0xaaaa, 0xbbbb),
-				StartTimestamp: Date(2023, time.September, 24, 5, 0, 0),
-				EndTimestamp:   Date(2023, time.September, 24, 6, 0, 0),
-				Checksum:       2,
-			},
-		},
-		{
-			Ref: Ref{
-				TenantID:       "tenantA",
-				TableName:      "first-period-19621",
-				Bounds:         v1.NewBounds(0xeeee, 0xffff),
-				StartTimestamp: Date(2023, time.September, 21, 5, 0, 0),
-				EndTimestamp:   Date(2023, time.September, 21, 6, 0, 0),
-				Checksum:       1,
-			},
+	block := BlockRef{
+		Ref: Ref{
+			TenantID:       "tenantA",
+			TableName:      "first-period-19621",
+			Bounds:         v1.NewBounds(0xeeee, 0xffff),
+			StartTimestamp: Date(2023, time.September, 21, 5, 0, 0),
+			EndTimestamp:   Date(2023, time.September, 21, 6, 0, 0),
+			Checksum:       1,
 		},
 	}
-	err := bloomClient.DeleteBlocks(context.Background(), blocksToDelete)
+
+	bloomClient := createStore(t)
+	fsNamedStores := bloomClient.storageConfig.NamedStores.Filesystem
+	blockFullPath := NewPrefixedResolver(
+		fsNamedStores["folder-1"].Directory,
+		defaultKeyResolver{},
+	).Block(block).LocalPath()
+	_ = createBlockFile(t, blockFullPath)
+	require.FileExists(t, blockFullPath)
+
+	err := bloomClient.DeleteBlocks(context.Background(), []BlockRef{block})
 	require.NoError(t, err)
-	require.NoFileExists(t, block1Path)
-	require.NoFileExists(t, block2Path)
+	require.NoFileExists(t, blockFullPath)
+
 }
 
 func createBlockFile(t *testing.T, path string) string {
@@ -550,7 +483,6 @@ func createMetaEntity(
 					StartTimestamp: startTimestamp,
 					EndTimestamp:   endTimestamp,
 				},
-				BlockPath: uuid.New().String(),
 			},
 		},
 		Blocks: []BlockRef{
@@ -562,7 +494,6 @@ func createMetaEntity(
 					StartTimestamp: startTimestamp,
 					EndTimestamp:   endTimestamp,
 				},
-				BlockPath: uuid.New().String(),
 			},
 		},
 	}

--- a/pkg/storage/stores/shipper/bloomshipper/client_test.go
+++ b/pkg/storage/stores/shipper/bloomshipper/client_test.go
@@ -265,7 +265,6 @@ func Test_BloomClient_PutBlocks(t *testing.T) {
 				EndTimestamp:   Date(2023, time.September, 21, 6, 0, 0),
 				Checksum:       1,
 			},
-			IndexPath: uuid.New().String(),
 		},
 		Data: awsio.ReadSeekNopCloser{ReadSeeker: bytes.NewReader([]byte(blockForFirstFolderData))},
 	}
@@ -281,7 +280,6 @@ func Test_BloomClient_PutBlocks(t *testing.T) {
 				EndTimestamp:   Date(2023, time.September, 24, 6, 0, 0),
 				Checksum:       2,
 			},
-			IndexPath: uuid.New().String(),
 		},
 		Data: awsio.ReadSeekNopCloser{ReadSeeker: bytes.NewReader([]byte(blockForSecondFolderData))},
 	}
@@ -305,7 +303,6 @@ func Test_BloomClient_PutBlocks(t *testing.T) {
 	require.Equal(t, blockForFirstFolder.StartTimestamp, firstResultBlock.StartTimestamp)
 	require.Equal(t, blockForFirstFolder.EndTimestamp, firstResultBlock.EndTimestamp)
 	require.Equal(t, blockForFirstFolder.Checksum, firstResultBlock.Checksum)
-	require.Equal(t, blockForFirstFolder.IndexPath, firstResultBlock.IndexPath)
 	folder1 := bloomClient.storageConfig.NamedStores.Filesystem["folder-1"].Directory
 	savedFilePath := filepath.Join(folder1, path)
 	require.FileExists(t, savedFilePath)
@@ -329,7 +326,6 @@ func Test_BloomClient_PutBlocks(t *testing.T) {
 	require.Equal(t, blockForSecondFolder.StartTimestamp, secondResultBlock.StartTimestamp)
 	require.Equal(t, blockForSecondFolder.EndTimestamp, secondResultBlock.EndTimestamp)
 	require.Equal(t, blockForSecondFolder.Checksum, secondResultBlock.Checksum)
-	require.Equal(t, blockForSecondFolder.IndexPath, secondResultBlock.IndexPath)
 	folder2 := bloomClient.storageConfig.NamedStores.Filesystem["folder-2"].Directory
 
 	savedFilePath = filepath.Join(folder2, path)
@@ -359,7 +355,6 @@ func Test_BloomClient_DeleteBlocks(t *testing.T) {
 				EndTimestamp:   Date(2023, time.September, 24, 6, 0, 0),
 				Checksum:       2,
 			},
-			IndexPath: uuid.New().String(),
 		},
 		{
 			Ref: Ref{
@@ -370,7 +365,6 @@ func Test_BloomClient_DeleteBlocks(t *testing.T) {
 				EndTimestamp:   Date(2023, time.September, 21, 6, 0, 0),
 				Checksum:       1,
 			},
-			IndexPath: uuid.New().String(),
 		},
 	}
 	err := bloomClient.DeleteBlocks(context.Background(), blocksToDelete)
@@ -556,7 +550,6 @@ func createMetaEntity(
 					StartTimestamp: startTimestamp,
 					EndTimestamp:   endTimestamp,
 				},
-				IndexPath: uuid.New().String(),
 				BlockPath: uuid.New().String(),
 			},
 		},
@@ -569,7 +562,6 @@ func createMetaEntity(
 					StartTimestamp: startTimestamp,
 					EndTimestamp:   endTimestamp,
 				},
-				IndexPath: uuid.New().String(),
 				BlockPath: uuid.New().String(),
 			},
 		},

--- a/pkg/storage/stores/shipper/bloomshipper/compress_utils.go
+++ b/pkg/storage/stores/shipper/bloomshipper/compress_utils.go
@@ -32,32 +32,8 @@ func CompressBloomBlock(ref BlockRef, archivePath, localDst string, logger log.L
 	return blockToUpload, nil
 }
 
-func UncompressBloomBlock(block *LazyBlock, workingDirectory string, logger log.Logger) (string, error) {
-	workingDirectoryPath := filepath.Join(workingDirectory, block.BlockPath)
-	err := os.MkdirAll(workingDirectoryPath, os.ModePerm)
-	if err != nil {
-		return "", fmt.Errorf("can not create directory to extract the block: %w", err)
-	}
-	archivePath, err := writeDataToTempFile(workingDirectoryPath, block)
-	if err != nil {
-		return "", fmt.Errorf("error writing data to temp file: %w", err)
-	}
-	level.Info(logger).Log("msg", "extracting archive", "archive", archivePath, "workingDirectory", workingDirectoryPath, "blockPath", block.BlockPath)
-	defer func() {
-		err = os.Remove(archivePath)
-		if err != nil {
-			level.Error(logger).Log("msg", "removing archive file", "err", err, "file", archivePath)
-		}
-	}()
-	err = extractArchive(archivePath, workingDirectoryPath)
-	if err != nil {
-		return "", fmt.Errorf("error extracting archive: %w", err)
-	}
-	return workingDirectoryPath, nil
-}
-
-func writeDataToTempFile(workingDirectoryPath string, block *LazyBlock) (string, error) {
-	defer block.Data.Close()
+func writeDataToTempFile(workingDirectoryPath string, data io.ReadCloser) (string, error) {
+	defer data.Close()
 	archivePath := filepath.Join(workingDirectoryPath, uuid.New().String())
 
 	archiveFile, err := os.Create(archivePath)
@@ -65,7 +41,7 @@ func writeDataToTempFile(workingDirectoryPath string, block *LazyBlock) (string,
 		return "", fmt.Errorf("error creating empty file to store the archiver: %w", err)
 	}
 	defer archiveFile.Close()
-	_, err = io.Copy(archiveFile, block.Data)
+	_, err = io.Copy(archiveFile, data)
 	if err != nil {
 		return "", fmt.Errorf("error writing data to archive file: %w", err)
 	}

--- a/pkg/storage/stores/shipper/bloomshipper/resolver.go
+++ b/pkg/storage/stores/shipper/bloomshipper/resolver.go
@@ -1,0 +1,121 @@
+package bloomshipper
+
+import (
+	"fmt"
+	"path"
+	"path/filepath"
+)
+
+const (
+	BloomPrefix  = "bloom"
+	MetasPrefix  = "metas"
+	BlocksPrefix = "blocks"
+)
+
+// KeyResolver is an interface for resolving keys to locations.
+// This is used to determine where items are stored in object storage _and_ on disk.
+// Using an interface allows us to abstract away platform specifics
+// (e.g. OS path-specifics, object storage difference, etc)
+// TODO(owen-d): implement resolvers that schema-aware, allowing us to change
+// the locations of data across schema boundaries (for instance to upgrade|improve).
+type KeyResolver interface {
+	Meta(MetaRef) Location
+	Block(BlockRef) Location
+}
+
+type defaultKeyResolver struct{}
+
+func (defaultKeyResolver) Meta(ref MetaRef) Location {
+	return simpleLocation{
+		BloomPrefix,
+		fmt.Sprintf("%v", ref.TableName),
+		ref.TenantID,
+		MetasPrefix,
+		fmt.Sprintf("%v-%v", ref.Bounds, ref.Checksum),
+	}
+}
+
+func (defaultKeyResolver) Block(ref BlockRef) Location {
+	return simpleLocation{
+		BloomPrefix,
+		fmt.Sprintf("%v", ref.TableName),
+		ref.TenantID,
+		BlocksPrefix,
+		ref.Bounds.String(),
+		fmt.Sprintf("%d-%d-%x", ref.StartTimestamp, ref.EndTimestamp, ref.Checksum),
+	}
+}
+
+type PrefixedResolver struct {
+	prefix string
+	KeyResolver
+}
+
+func NewPrefixedResolver(prefix string, resolver KeyResolver) KeyResolver {
+	return PrefixedResolver{
+		prefix:      prefix,
+		KeyResolver: resolver,
+	}
+}
+
+func (p PrefixedResolver) Meta(ref MetaRef) Location {
+	return locations{
+		key(p.prefix),
+		p.KeyResolver.Meta(ref),
+	}
+}
+
+func (p PrefixedResolver) Block(ref BlockRef) Location {
+	return locations{
+		key(p.prefix),
+		p.KeyResolver.Block(ref),
+	}
+}
+
+type Location interface {
+	Addr() string      // object storage location
+	LocalPath() string // local path version
+}
+
+// simplest Location implementor, just a string
+type key string
+
+func (k key) Addr() string {
+	return string(k)
+}
+
+func (k key) LocalPath() string {
+	return string(k)
+}
+
+// simpleLocation is a simple implementation of Location combining multiple strings
+type simpleLocation []string
+
+func (xs simpleLocation) LocalPath() string {
+	return filepath.Join(xs...)
+}
+
+func (xs simpleLocation) Addr() string {
+	return path.Join(xs...)
+}
+
+// helper type for combining multiple locations into one
+type locations []Location
+
+func (ls locations) Addr() string {
+	xs := make([]string, 0, len(ls))
+	for _, l := range ls {
+		xs = append(xs, l.Addr())
+	}
+
+	return path.Join(xs...)
+}
+
+func (ls locations) LocalPath() string {
+	xs := make([]string, 0, len(ls))
+	for _, l := range ls {
+		xs = append(xs, l.LocalPath())
+	}
+
+	return filepath.Join(xs...)
+}

--- a/pkg/storage/stores/shipper/bloomshipper/shipper_test.go
+++ b/pkg/storage/stores/shipper/bloomshipper/shipper_test.go
@@ -18,24 +18,24 @@ func Test_Shipper_findBlocks(t *testing.T) {
 			{
 				Blocks: []BlockRef{
 					//this blockRef is marked as deleted in the next meta
-					createMatchingBlockRef("block1"),
-					createMatchingBlockRef("block2"),
+					createMatchingBlockRef(1),
+					createMatchingBlockRef(2),
 				},
 			},
 			{
 				Blocks: []BlockRef{
 					//this blockRef is marked as deleted in the next meta
-					createMatchingBlockRef("block3"),
-					createMatchingBlockRef("block4"),
+					createMatchingBlockRef(3),
+					createMatchingBlockRef(4),
 				},
 			},
 			{
 				Tombstones: []BlockRef{
-					createMatchingBlockRef("block1"),
-					createMatchingBlockRef("block3"),
+					createMatchingBlockRef(1),
+					createMatchingBlockRef(3),
 				},
 				Blocks: []BlockRef{
-					createMatchingBlockRef("block5"),
+					createMatchingBlockRef(5),
 				},
 			},
 		}
@@ -49,9 +49,9 @@ func Test_Shipper_findBlocks(t *testing.T) {
 		blocks := BlocksForMetas(metas, interval, []v1.FingerprintBounds{{Min: 100, Max: 200}})
 
 		expectedBlockRefs := []BlockRef{
-			createMatchingBlockRef("block2"),
-			createMatchingBlockRef("block4"),
-			createMatchingBlockRef("block5"),
+			createMatchingBlockRef(2),
+			createMatchingBlockRef(4),
+			createMatchingBlockRef(5),
 		}
 		require.ElementsMatch(t, expectedBlockRefs, blocks)
 	})
@@ -98,7 +98,7 @@ func Test_Shipper_findBlocks(t *testing.T) {
 	}
 	for name, data := range tests {
 		t.Run(name, func(t *testing.T) {
-			ref := createBlockRef("fake-block", data.minFingerprint, data.maxFingerprint, data.startTimestamp, data.endTimestamp)
+			ref := createBlockRef(data.minFingerprint, data.maxFingerprint, data.startTimestamp, data.endTimestamp)
 			blocks := BlocksForMetas([]Meta{{Blocks: []BlockRef{ref}}}, NewInterval(300, 400), []v1.FingerprintBounds{{Min: 100, Max: 200}})
 			if data.filtered {
 				require.Empty(t, blocks)
@@ -115,78 +115,79 @@ func TestIsOutsideRange(t *testing.T) {
 	endTs := model.Time(2000)
 
 	t.Run("is outside if startTs > through", func(t *testing.T) {
-		b := createBlockRef("block", 0, math.MaxUint64, startTs, endTs)
+		b := createBlockRef(0, math.MaxUint64, startTs, endTs)
 		isOutside := isOutsideRange(b, NewInterval(0, 900), []v1.FingerprintBounds{})
 		require.True(t, isOutside)
 	})
 
 	t.Run("is outside if startTs == through ", func(t *testing.T) {
-		b := createBlockRef("block", 0, math.MaxUint64, startTs, endTs)
+		b := createBlockRef(0, math.MaxUint64, startTs, endTs)
 		isOutside := isOutsideRange(b, NewInterval(900, 1000), []v1.FingerprintBounds{})
 		require.True(t, isOutside)
 	})
 
 	t.Run("is outside if endTs < from", func(t *testing.T) {
-		b := createBlockRef("block", 0, math.MaxUint64, startTs, endTs)
+		b := createBlockRef(0, math.MaxUint64, startTs, endTs)
 		isOutside := isOutsideRange(b, NewInterval(2100, 3000), []v1.FingerprintBounds{})
 		require.True(t, isOutside)
 	})
 
 	t.Run("is outside if endFp < first fingerprint", func(t *testing.T) {
-		b := createBlockRef("block", 0, 90, startTs, endTs)
+		b := createBlockRef(0, 90, startTs, endTs)
 		isOutside := isOutsideRange(b, NewInterval(startTs, endTs), []v1.FingerprintBounds{{Min: 100, Max: 199}})
 		require.True(t, isOutside)
 	})
 
 	t.Run("is outside if startFp > last fingerprint", func(t *testing.T) {
-		b := createBlockRef("block", 200, math.MaxUint64, startTs, endTs)
+		b := createBlockRef(200, math.MaxUint64, startTs, endTs)
 		isOutside := isOutsideRange(b, NewInterval(startTs, endTs), []v1.FingerprintBounds{{Min: 0, Max: 49}, {Min: 100, Max: 149}})
 		require.True(t, isOutside)
 	})
 
 	t.Run("is outside if within gaps in fingerprints", func(t *testing.T) {
-		b := createBlockRef("block", 100, 199, startTs, endTs)
+		b := createBlockRef(100, 199, startTs, endTs)
 		isOutside := isOutsideRange(b, NewInterval(startTs, endTs), []v1.FingerprintBounds{{Min: 0, Max: 99}, {Min: 200, Max: 299}})
 		require.True(t, isOutside)
 	})
 
 	t.Run("is not outside if within fingerprints 1", func(t *testing.T) {
-		b := createBlockRef("block", 10, 90, startTs, endTs)
+		b := createBlockRef(10, 90, startTs, endTs)
 		isOutside := isOutsideRange(b, NewInterval(startTs, endTs), []v1.FingerprintBounds{{Min: 0, Max: 99}, {Min: 200, Max: 299}})
 		require.False(t, isOutside)
 	})
 
 	t.Run("is not outside if within fingerprints 2", func(t *testing.T) {
-		b := createBlockRef("block", 210, 290, startTs, endTs)
+		b := createBlockRef(210, 290, startTs, endTs)
 		isOutside := isOutsideRange(b, NewInterval(startTs, endTs), []v1.FingerprintBounds{{Min: 0, Max: 99}, {Min: 200, Max: 299}})
 		require.False(t, isOutside)
 	})
 
 	t.Run("is not outside if spans across multiple fingerprint ranges", func(t *testing.T) {
-		b := createBlockRef("block", 50, 250, startTs, endTs)
+		b := createBlockRef(50, 250, startTs, endTs)
 		isOutside := isOutsideRange(b, NewInterval(startTs, endTs), []v1.FingerprintBounds{{Min: 0, Max: 99}, {Min: 200, Max: 299}})
 		require.False(t, isOutside)
 	})
 
 	t.Run("is not outside if fingerprint range and time range are larger than block", func(t *testing.T) {
-		b := createBlockRef("block", math.MaxUint64/3, math.MaxUint64/3*2, startTs, endTs)
+		b := createBlockRef(math.MaxUint64/3, math.MaxUint64/3*2, startTs, endTs)
 		isOutside := isOutsideRange(b, NewInterval(0, 3000), []v1.FingerprintBounds{{Min: 0, Max: math.MaxUint64}})
 		require.False(t, isOutside)
 	})
 
 	t.Run("is not outside if block fingerprint range is bigger that search keyspace", func(t *testing.T) {
-		b := createBlockRef("block", 0x0000, 0xffff, model.Earliest, model.Latest)
+		b := createBlockRef(0x0000, 0xffff, model.Earliest, model.Latest)
 		isOutside := isOutsideRange(b, NewInterval(startTs, endTs), []v1.FingerprintBounds{{Min: 0x0100, Max: 0xff00}})
 		require.False(t, isOutside)
 	})
 }
 
-func createMatchingBlockRef(blockPath string) BlockRef {
-	return createBlockRef(blockPath, 0, math.MaxUint64, model.Time(0), model.Time(math.MaxInt64))
+func createMatchingBlockRef(checksum uint32) BlockRef {
+	block := createBlockRef(0, math.MaxUint64, model.Time(0), model.Time(math.MaxInt64))
+	block.Checksum = checksum
+	return block
 }
 
 func createBlockRef(
-	blockPath string,
 	minFingerprint, maxFingerprint uint64,
 	startTimestamp, endTimestamp model.Time,
 ) BlockRef {
@@ -200,7 +201,5 @@ func createBlockRef(
 			EndTimestamp:   endTimestamp,
 			Checksum:       0,
 		},
-		// block path is unique, and it's used to distinguish the blocks so the rest of the fields might be skipped in this test
-		BlockPath: blockPath,
 	}
 }


### PR DESCRIPTION
Does some alignment work between the `bloomcompactor` and the `bloomshipper` pkgs. Notably:

* Uses `bloomshipper.BlockRef` everywhere (removes old bloomshipper struct
* Integrates `v1.FingerprintBounds` in `Ref` struct
* `Location` interface to distinguish local paths vs paths in object storage for certain types (`{Meta,Bloom}Ref`s)
* Introduces `KeyResolver` interface to generate locations from these structs
* Integrates `KeyResolver` into our bloom store. In the future, this will allow us to change key structures across schema boundaries when we want to change|improve them.
* Removes `BlockPath` from `BlockRef` in favor of the new resolving functionality. This is also beneficial because it lets us _calculate_ locations from the pure Ref objects, rather than tie some arbitrary state to them which can change (or not be populated by accident).