### PR TITLE
Blooms/block metadata

### DIFF
--- a/pkg/storage/bloom/v1/builder_test.go
+++ b/pkg/storage/bloom/v1/builder_test.go
@@ -358,7 +358,7 @@ func TestMergeBuilder_Roundtrip(t *testing.T) {
 
 	checksum, err := mb.Build(builder)
 	require.Nil(t, err)
-	require.Equal(t, uint32(0x2ec4fd6a), checksum)
+	require.Equal(t, uint32(0xe306ec6e), checksum)
 
 	// ensure the new block contains one copy of all the data
 	// by comparing it against an iterator over the source data

--- a/pkg/storage/bloom/v1/builder_test.go
+++ b/pkg/storage/bloom/v1/builder_test.go
@@ -9,7 +9,31 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/loki/pkg/chunkenc"
+	"github.com/grafana/loki/pkg/util/encoding"
 )
+
+func TestBlockOptionsRoundTrip(t *testing.T) {
+	opts := BlockOptions{
+		Schema: Schema{
+			version:     V1,
+			encoding:    chunkenc.EncSnappy,
+			nGramLength: 10,
+			nGramSkip:   2,
+		},
+		SeriesPageSize: 100,
+		BloomPageSize:  10 << 10,
+		BlockSize:      10 << 20,
+	}
+
+	var enc encoding.Encbuf
+	opts.Encode(&enc)
+
+	var got BlockOptions
+	err := got.DecodeFrom(bytes.NewReader(enc.Get()))
+	require.Nil(t, err)
+
+	require.Equal(t, opts, got)
+}
 
 func TestBlockBuilderRoundTrip(t *testing.T) {
 	numSeries := 100

--- a/pkg/storage/bloom/v1/index.go
+++ b/pkg/storage/bloom/v1/index.go
@@ -89,19 +89,14 @@ func (s *Schema) Decode(dec *encoding.Decbuf) error {
 // Block index is a set of series pages along with
 // the headers for each page
 type BlockIndex struct {
-	schema      Schema
+	opts BlockOptions
+
 	pageHeaders []SeriesPageHeaderWithOffset // headers for each series page
 }
 
-func NewBlockIndex(encoding chunkenc.Encoding) BlockIndex {
-	return BlockIndex{
-		schema: Schema{version: DefaultSchemaVersion, encoding: encoding},
-	}
-}
-
 func (b *BlockIndex) DecodeHeaders(r io.ReadSeeker) error {
-	if err := b.schema.DecodeFrom(r); err != nil {
-		return errors.Wrap(err, "decoding schema")
+	if err := b.opts.DecodeFrom(r); err != nil {
+		return errors.Wrap(err, "decoding block options")
 	}
 
 	var (
@@ -167,7 +162,7 @@ func (b *BlockIndex) NewSeriesPageDecoder(r io.ReadSeeker, header SeriesPageHead
 		return nil, errors.Wrap(err, "checksumming series page")
 	}
 
-	decompressor, err := b.schema.DecompressorPool().GetReader(bytes.NewReader(dec.Get()))
+	decompressor, err := b.opts.Schema.DecompressorPool().GetReader(bytes.NewReader(dec.Get()))
 	if err != nil {
 		return nil, errors.Wrap(err, "getting decompressor")
 	}

--- a/pkg/storage/bloom/v1/index_querier.go
+++ b/pkg/storage/bloom/v1/index_querier.go
@@ -49,7 +49,7 @@ func (it *LazySeriesIter) Seek(fp model.Fingerprint) error {
 	// first potentially relevant page
 	desiredPage := sort.Search(len(it.b.index.pageHeaders), func(i int) bool {
 		header := it.b.index.pageHeaders[i]
-		return header.ThroughFp >= fp
+		return header.Bounds.Max >= fp
 	})
 
 	switch {


### PR DESCRIPTION


A few updates to the bloom library:
* Uses `FingerprintBounds` in series headers
* Encodes `BlockOptions` in the series file so we can later read the target page & block sizes the block was generated with in addition to the schema.
* Introduces `BlockMetadata` struct and loads it correctly from blocks. This struct will be used to convert to the `BlockRef`s from the `bloomshipper` pkg and used in the bloom compactor + bloom gateway
* Integrates checksums better into block building and XORs the headers metadata from each file (blooms, series) together to generate a final checksum for the block (a combination of both files).