### PR TITLE
Correctly check chunks in bloom block querier.

### DIFF
--- a/pkg/storage/bloom/v1/block.go
+++ b/pkg/storage/bloom/v1/block.go
@@ -174,6 +174,11 @@ func (bq *BlockQuerier) Err() error {
 // passed as the `chks` argument. Chunks will be removed from the result set if they are indexed in the bloom
 // and fail to pass all the searches.
 func (bq *BlockQuerier) CheckChunksForSeries(fp model.Fingerprint, chks ChunkRefs, searches [][]byte) (ChunkRefs, error) {
+	schema, err := bq.Schema()
+	if err != nil {
+		return chks, fmt.Errorf("getting schema: %w", err)
+	}
+
 	if err := bq.Seek(fp); err != nil {
 		return chks, errors.Wrapf(err, "seeking to series for fp: %v", fp)
 	}
@@ -205,18 +210,22 @@ func (bq *BlockQuerier) CheckChunksForSeries(fp model.Fingerprint, chks ChunkRef
 		}
 	}
 
-	// TODO(owen-d): pool, memoize chunk search prefix creation
+	// TODO(salvacorts): pool tokenBuf
+	var tokenBuf []byte
+	var prefixLen int
 
 	// Check chunks individually now
 	mustCheck, inBlooms := chks.Compare(series.Chunks, true)
 
 outer:
 	for _, chk := range inBlooms {
+		// Get buf to concatenate the chunk and search token
+		tokenBuf, prefixLen = prefixedToken(schema.NGramLen(), chk, tokenBuf)
 		for _, search := range searches {
-			// TODO(owen-d): meld chunk + search into a single byte slice from the block schema
-			var combined = search
+			tokenBuf = append(tokenBuf[:prefixLen], search...)
 
-			if !bloom.Test(combined) {
+			if !bloom.Test(tokenBuf) {
+				// chunk didn't pass the search, continue to the next chunk
 				continue outer
 			}
 		}

--- a/pkg/storage/bloom/v1/bloom_tokenizer.go
+++ b/pkg/storage/bloom/v1/bloom_tokenizer.go
@@ -61,14 +61,19 @@ func clearCache(cache map[string]interface{}) {
 // of specific ngram length, along with the length of the prefix.
 // It ensures enough capacity for the prefix and the token so additional tokens can be created
 // without allocations by appending them to the prefix length
-func prefixedToken(ngram int, chk ChunkRef) ([]byte, int) {
-	var enc encoding.Encbuf
+// If the buffer is nil or too small, a new one is created. The buffer is returned for reuse.
+func prefixedToken(ngram int, chk ChunkRef, buf []byte) ([]byte, int) {
+	enc := encoding.EncWith(buf)
+	enc.Reset()
 	enc.PutBE64(uint64(chk.Start))
 	enc.PutBE64(uint64(chk.End))
 	enc.PutBE32(chk.Checksum)
 	prefixLn := enc.Len() // record the length of the prefix
 
-	enc.PutBytes(make([]byte, ngram*MaxRuneLen)) // ensure enough capacity for the ngram
+	// If the buffer is too small, ensure enough capacity for the ngram
+	if cap(enc.Get()) < prefixLn+ngram*MaxRuneLen {
+		enc.PutBytes(make([]byte, ngram*MaxRuneLen))
+	}
 
 	// return the underlying byte slice and the length of the prefix
 	return enc.Get(), prefixLn
@@ -86,10 +91,13 @@ func (bt *BloomTokenizer) Populate(swb *SeriesWithBloom, chks Iterator[ChunkRefW
 
 	clearCache(bt.cache)
 
+	var tokenBuf []byte
+	var prefixLn int
+
 	for chks.Err() == nil && chks.Next() {
 		chk := chks.At()
 		itr := chk.Itr
-		tokenBuf, prefixLn := prefixedToken(bt.lineTokenizer.N, chk.Ref)
+		tokenBuf, prefixLn = prefixedToken(bt.lineTokenizer.N, chk.Ref, tokenBuf)
 
 		defer itr.Close()
 

--- a/pkg/storage/bloom/v1/bloom_tokenizer_test.go
+++ b/pkg/storage/bloom/v1/bloom_tokenizer_test.go
@@ -56,7 +56,7 @@ func TestPrefixedKeyCreation(t *testing.T) {
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
-			token, prefixLn := prefixedToken(tc.ngram, ref)
+			token, prefixLn := prefixedToken(tc.ngram, ref, nil)
 			require.Equal(t, 20, prefixLn)
 			require.Equal(t, tc.expLen, len(token))
 			// first 8 bytes should be zeros from `from`

--- a/pkg/storage/bloom/v1/fuse.go
+++ b/pkg/storage/bloom/v1/fuse.go
@@ -135,7 +135,7 @@ func (fq *FusedQuerier) Run() error {
 				for _, search := range input.Searches {
 					tokenBuf = append(tokenBuf[:prefixLen], search...)
 
-					if !bloom.ScalableBloomFilter.Test(tokenBuf) {
+					if !bloom.Test(tokenBuf) {
 						removals = append(removals, chk)
 						continue chunkLoop
 					}

--- a/pkg/storage/bloom/v1/fuse.go
+++ b/pkg/storage/bloom/v1/fuse.go
@@ -56,6 +56,11 @@ func NewFusedQuerier(bq *BlockQuerier, inputs []PeekingIterator[Request]) *Fused
 }
 
 func (fq *FusedQuerier) Run() error {
+	schema, err := fq.bq.Schema()
+	if err != nil {
+		return errors.Wrap(err, "getting schema")
+	}
+
 	for fq.inputs.Next() {
 		// find all queries for the next relevant fingerprint
 		nextBatch := fq.inputs.At()
@@ -119,13 +124,18 @@ func (fq *FusedQuerier) Run() error {
 			// TODO(owen-d): pool
 			var removals ChunkRefs
 
+			// TODO(salvacorts): pool tokenBuf
+			var tokenBuf []byte
+			var prefixLen int
+
 		chunkLoop:
 			for _, chk := range inBlooms {
+				// Get buf to concatenate the chunk and search token
+				tokenBuf, prefixLen = prefixedToken(schema.NGramLen(), chk, tokenBuf)
 				for _, search := range input.Searches {
-					// TODO(owen-d): meld chunk + search into a single byte slice from the block schema
-					var combined = search
+					tokenBuf = append(tokenBuf[:prefixLen], search...)
 
-					if !bloom.ScalableBloomFilter.Test(combined) {
+					if !bloom.ScalableBloomFilter.Test(tokenBuf) {
 						removals = append(removals, chk)
 						continue chunkLoop
 					}

--- a/pkg/storage/bloom/v1/fuse_test.go
+++ b/pkg/storage/bloom/v1/fuse_test.go
@@ -98,7 +98,7 @@ func TestFusedQuerier(t *testing.T) {
 				t,
 				Output{
 					Fp:       req.Fp,
-					Removals: req.Chks,
+					Removals: nil,
 				},
 				resp,
 			)

--- a/pkg/storage/bloom/v1/fuse_test.go
+++ b/pkg/storage/bloom/v1/fuse_test.go
@@ -20,7 +20,7 @@ func TestFusedQuerier(t *testing.T) {
 	reader := NewByteReader(indexBuf, bloomsBuf)
 	numSeries := 100
 	numKeysPerSeries := 10000
-	data, _ := MkBasicSeriesWithBlooms(numSeries, numKeysPerSeries, 0, 0xffff, 0, 10000)
+	data, keys := MkBasicSeriesWithBlooms(numSeries, numKeysPerSeries, 0, 0xffff, 0, 10000)
 
 	builder, err := NewBlockBuilder(
 		BlockOptions{
@@ -53,6 +53,7 @@ func TestFusedQuerier(t *testing.T) {
 				Fp:       data[idx].Series.Fingerprint,
 				Chks:     data[idx].Series.Chunks,
 				Response: ch,
+				Searches: keys[idx],
 			})
 		}
 		inputs = append(inputs, reqs)
@@ -97,7 +98,7 @@ func TestFusedQuerier(t *testing.T) {
 				t,
 				Output{
 					Fp:       req.Fp,
-					Removals: nil,
+					Removals: req.Chks,
 				},
 				resp,
 			)

--- a/pkg/storage/bloom/v1/tokenizer_test.go
+++ b/pkg/storage/bloom/v1/tokenizer_test.go
@@ -171,7 +171,7 @@ func BenchmarkTokens(b *testing.B) {
 				{
 					desc: "v2",
 					f: func() func() {
-						buf, prefixLn := prefixedToken(v2Three.N, ChunkRef{})
+						buf, prefixLn := prefixedToken(v2Three.N, ChunkRef{}, nil)
 						return func() {
 							itr := NewPrefixedTokenIter(buf, prefixLn, v2Three.Tokens(lorem))
 							for itr.Next() {
@@ -188,7 +188,7 @@ func BenchmarkTokens(b *testing.B) {
 				{
 					desc: "v2",
 					f: func() func() {
-						buf, prefixLn := prefixedToken(v2Three.N, ChunkRef{})
+						buf, prefixLn := prefixedToken(v2Three.N, ChunkRef{}, nil)
 						return func() {
 							itr := NewPrefixedTokenIter(buf, prefixLn, v2ThreeSkip1.Tokens(lorem))
 							for itr.Next() {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the block querier to correctly test blooms for chunks. Before this PR, for each chunk we were checking the same set of search terms against the bloom. Therefore, we were not filtering chunks, but only series. This PR uses the chunk ref as a prefix for the search term. 

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
