### PR TITLE
packaging: fix install path for loki.service & promtail.service

### DIFF
--- a/tools/packaging/loki-postinstall.sh
+++ b/tools/packaging/loki-postinstall.sh
@@ -20,7 +20,7 @@ cleanInstall() {
     # even if you want your service to run as non root.
     if [ "${systemd_version}" -lt 231 ]; then
         printf "\033[31m systemd version %s is less then 231, fixing the service file \033[0m\n" "${systemd_version}"
-        sed -i "s/=+/=/g" /etc/systemd/system/loki.service
+        sed -i "s/=+/=/g" /usr/lib/systemd/system/loki.service
     fi
     printf "\033[32m Reload the service unit from disk\033[0m\n"
     systemctl daemon-reload ||:

--- a/tools/packaging/nfpm.jsonnet
+++ b/tools/packaging/nfpm.jsonnet
@@ -20,7 +20,7 @@ local overrides = {
     contents+: [
       {
         src: './tools/packaging/loki.service',
-        dst: '/etc/systemd/system/loki.service',
+        dst: '/usr/lib/systemd/system/loki.service',
       },
       {
         src: './cmd/loki/loki-local-config.yaml',
@@ -42,7 +42,7 @@ local overrides = {
     contents+: [
       {
         src: './tools/packaging/promtail.service',
-        dst: '/etc/systemd/system/promtail.service',
+        dst: '/usr/lib/systemd/system/promtail.service',
       },
       {
         src: './tools/packaging/promtail-minimal-config.yaml',

--- a/tools/packaging/promtail-postinstall.sh
+++ b/tools/packaging/promtail-postinstall.sh
@@ -20,7 +20,7 @@ cleanInstall() {
     # even if you want your service to run as non root.
     if [ "${systemd_version}" -lt 231 ]; then
         printf "\033[31m systemd version %s is less then 231, fixing the service file \033[0m\n" "${systemd_version}"
-        sed -i "s/=+/=/g" /etc/systemd/system/promtail.service
+        sed -i "s/=+/=/g" /usr/lib/systemd/system/promtail.service
     fi
     printf "\033[32m Reload the service unit from disk\033[0m\n"
     systemctl daemon-reload ||:


### PR DESCRIPTION
Small fix in Linux packaging.

There's a convention documented in [man systemd.unit](https://www.freedesktop.org/software/systemd/man/latest/systemd.unit.html#Unit%20File%20Load%20Path):

* `/etc/systemd/system`	System units created by the administrator
* `/usr/lib/systemd/system`	System units installed by the distribution package manager

Typically, if a package ships a systemd `.service` (*especially* in native apt/yum/dnf packages), the unit-file gets installed under `/usr/lib/systemd/system/` — while the `/etc` location is reserved for downstream system vendor.

Grafana got this right:
```
$ dpkg -L grafana-enterprise | grep systemd/system/
/usr/lib/systemd/system/grafana-server.service
```

**Notes for reviewer**:

Doubtful if this is worth a mention in CHANGELOG or any further docs besides this PR.
Please suggest briefly in review if it is.

I also don't expect any breakage in upgrades, dpkg/rpm should handle this just fine.  
(Although the separation of vendor/sysadmin VS packager responsibility can became a bitterly moot topic — especially when packages start reaching under /etc/systemd/system...)

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [x] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
