### PR TITLE
[Blooms] Stateless archiving

### DIFF
--- a/pkg/storage/bloom/v1/archive.go
+++ b/pkg/storage/bloom/v1/archive.go
@@ -11,9 +11,16 @@ import (
 	"github.com/grafana/loki/pkg/chunkenc"
 )
 
-func TarGz(dst io.Writer, src *DirectoryBlockReader) error {
-	if err := src.Init(); err != nil {
-		return errors.Wrap(err, "error initializing directory block reader")
+type TarEntry struct {
+	Name string
+	Size int64
+	Body io.ReadSeeker
+}
+
+func TarGz(dst io.Writer, reader BlockReader) error {
+	itr, err := reader.TarEntries()
+	if err != nil {
+		return errors.Wrap(err, "error getting tar entries")
 	}
 
 	gzipper := chunkenc.GetWriterPool(chunkenc.EncGZIP).GetWriter(dst)
@@ -22,27 +29,24 @@ func TarGz(dst io.Writer, src *DirectoryBlockReader) error {
 	tarballer := tar.NewWriter(gzipper)
 	defer tarballer.Close()
 
-	for _, f := range []*os.File{src.index, src.blooms} {
-		info, err := f.Stat()
-		if err != nil {
-			return errors.Wrapf(err, "error stat'ing file %s", f.Name())
+	for itr.Next() {
+		entry := itr.At()
+		hdr := &tar.Header{
+			Name: entry.Name,
+			Mode: 0600,
+			Size: entry.Size,
 		}
 
-		header, err := tar.FileInfoHeader(info, f.Name())
-		if err != nil {
-			return errors.Wrapf(err, "error creating tar header for file %s", f.Name())
+		if err := tarballer.WriteHeader(hdr); err != nil {
+			return errors.Wrapf(err, "error writing tar header for file %s", entry.Name)
 		}
 
-		if err := tarballer.WriteHeader(header); err != nil {
-			return errors.Wrapf(err, "error writing tar header for file %s", f.Name())
+		if _, err := io.Copy(tarballer, entry.Body); err != nil {
+			return errors.Wrapf(err, "error writing file %s to tarball", entry.Name)
 		}
-
-		if _, err := io.Copy(tarballer, f); err != nil {
-			return errors.Wrapf(err, "error writing file %s to tarball", f.Name())
-		}
-
 	}
-	return nil
+
+	return itr.Err()
 }
 
 func UnTarGz(dst string, r io.Reader) error {

--- a/pkg/storage/bloom/v1/archive_test.go
+++ b/pkg/storage/bloom/v1/archive_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestArchive(t *testing.T) {
+	t.Parallel()
 	// for writing files to two dirs for comparison and ensuring they're equal
 	dir1 := t.TempDir()
 	dir2 := t.TempDir()

--- a/pkg/storage/bloom/v1/block_writer.go
+++ b/pkg/storage/bloom/v1/block_writer.go
@@ -12,6 +12,7 @@ import (
 )
 
 const (
+	FileMode       = 0644
 	BloomFileName  = "bloom"
 	SeriesFileName = "series"
 )

--- a/pkg/storage/bloom/v1/bloom_tokenizer_test.go
+++ b/pkg/storage/bloom/v1/bloom_tokenizer_test.go
@@ -33,6 +33,7 @@ var (
 )
 
 func TestPrefixedKeyCreation(t *testing.T) {
+	t.Parallel()
 	var ones uint64 = 0xffffffffffffffff
 
 	ref := ChunkRef{
@@ -76,6 +77,7 @@ func TestPrefixedKeyCreation(t *testing.T) {
 }
 
 func TestSetLineTokenizer(t *testing.T) {
+	t.Parallel()
 	bt := NewBloomTokenizer(DefaultNGramLength, DefaultNGramSkip, metrics)
 
 	// Validate defaults
@@ -89,6 +91,7 @@ func TestSetLineTokenizer(t *testing.T) {
 }
 
 func TestTokenizerPopulate(t *testing.T) {
+	t.Parallel()
 	var testLine = "this is a log line"
 	bt := NewBloomTokenizer(DefaultNGramLength, DefaultNGramSkip, metrics)
 

--- a/pkg/storage/bloom/v1/bounds_test.go
+++ b/pkg/storage/bloom/v1/bounds_test.go
@@ -8,29 +8,34 @@ import (
 )
 
 func Test_ParseFingerprint(t *testing.T) {
+	t.Parallel()
 	fp, err := model.ParseFingerprint("7d0")
 	assert.NoError(t, err)
 	assert.Equal(t, model.Fingerprint(2000), fp)
 }
 
 func Test_FingerprintBounds_String(t *testing.T) {
+	t.Parallel()
 	bounds := NewBounds(10, 2000)
 	assert.Equal(t, "000000000000000a-00000000000007d0", bounds.String())
 }
 
 func Test_ParseBoundsFromAddr(t *testing.T) {
+	t.Parallel()
 	bounds, err := ParseBoundsFromAddr("a-7d0")
 	assert.NoError(t, err)
 	assert.Equal(t, NewBounds(10, 2000), bounds)
 }
 
 func Test_ParseBoundsFromParts(t *testing.T) {
+	t.Parallel()
 	bounds, err := ParseBoundsFromParts("a", "7d0")
 	assert.NoError(t, err)
 	assert.Equal(t, NewBounds(10, 2000), bounds)
 }
 
 func Test_FingerprintBounds_Cmp(t *testing.T) {
+	t.Parallel()
 	bounds := NewBounds(10, 20)
 	assert.Equal(t, Before, bounds.Cmp(0))
 	assert.Equal(t, Overlap, bounds.Cmp(10))
@@ -40,6 +45,7 @@ func Test_FingerprintBounds_Cmp(t *testing.T) {
 }
 
 func Test_FingerprintBounds_Overlap(t *testing.T) {
+	t.Parallel()
 	bounds := NewBounds(10, 20)
 	assert.True(t, bounds.Overlaps(FingerprintBounds{Min: 5, Max: 15}))
 	assert.True(t, bounds.Overlaps(FingerprintBounds{Min: 15, Max: 25}))
@@ -50,6 +56,7 @@ func Test_FingerprintBounds_Overlap(t *testing.T) {
 }
 
 func Test_FingerprintBounds_Within(t *testing.T) {
+	t.Parallel()
 	target := NewBounds(10, 20)
 	assert.False(t, NewBounds(1, 9).Within(target))
 	assert.False(t, NewBounds(21, 30).Within(target))
@@ -61,6 +68,7 @@ func Test_FingerprintBounds_Within(t *testing.T) {
 }
 
 func Test_FingerprintBounds_Intersection(t *testing.T) {
+	t.Parallel()
 	target := NewBounds(10, 20)
 	assert.Nil(t, NewBounds(1, 9).Intersection(target))
 	assert.Nil(t, NewBounds(21, 30).Intersection(target))
@@ -72,6 +80,7 @@ func Test_FingerprintBounds_Intersection(t *testing.T) {
 }
 
 func Test_FingerprintBounds_Union(t *testing.T) {
+	t.Parallel()
 	target := NewBounds(10, 20)
 	assert.Equal(t, []FingerprintBounds{
 		{Min: 1, Max: 9},
@@ -90,6 +99,7 @@ func Test_FingerprintBounds_Union(t *testing.T) {
 }
 
 func Test_FingerprintBounds_Xor(t *testing.T) {
+	t.Parallel()
 	target := NewBounds(10, 20)
 	assert.Equal(t, []FingerprintBounds{
 		{Min: 1, Max: 9},

--- a/pkg/storage/bloom/v1/builder_test.go
+++ b/pkg/storage/bloom/v1/builder_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestBlockOptionsRoundTrip(t *testing.T) {
+	t.Parallel()
 	opts := BlockOptions{
 		Schema: Schema{
 			version:     V1,
@@ -123,6 +124,7 @@ func TestBlockBuilderRoundTrip(t *testing.T) {
 }
 
 func TestMergeBuilder(t *testing.T) {
+	t.Parallel()
 
 	nBlocks := 10
 	numSeries := 100
@@ -209,6 +211,7 @@ func TestMergeBuilder(t *testing.T) {
 }
 
 func TestBlockReset(t *testing.T) {
+	t.Parallel()
 	numSeries := 100
 	numKeysPerSeries := 10000
 	data, _ := MkBasicSeriesWithBlooms(numSeries, numKeysPerSeries, 1, 0xffff, 0, 10000)
@@ -260,6 +263,7 @@ func TestBlockReset(t *testing.T) {
 // disjoint data. It then merges the two sets of blocks and ensures that the merged blocks contain
 // one copy of the first set (duplicate data) and one copy of the second set (disjoint data).
 func TestMergeBuilder_Roundtrip(t *testing.T) {
+	t.Parallel()
 	numSeries := 100
 	numKeysPerSeries := 100
 	minTs, maxTs := model.Time(0), model.Time(10000)

--- a/pkg/storage/bloom/v1/dedupe_test.go
+++ b/pkg/storage/bloom/v1/dedupe_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestMergeDedupeIter(t *testing.T) {
+	t.Parallel()
 	var (
 		numSeries        = 100
 		numKeysPerSeries = 10000

--- a/pkg/storage/bloom/v1/fuse_test.go
+++ b/pkg/storage/bloom/v1/fuse_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestFusedQuerier(t *testing.T) {
+	t.Parallel()
 	// references for linking in memory reader+writer
 	indexBuf := bytes.NewBuffer(nil)
 	bloomsBuf := bytes.NewBuffer(nil)

--- a/pkg/storage/bloom/v1/index_test.go
+++ b/pkg/storage/bloom/v1/index_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestBloomOffsetEncoding(t *testing.T) {
+	t.Parallel()
 	src := BloomOffset{Page: 1, ByteOffset: 2}
 	enc := &encoding.Encbuf{}
 	src.Encode(enc, BloomOffset{})
@@ -22,6 +23,7 @@ func TestBloomOffsetEncoding(t *testing.T) {
 }
 
 func TestSeriesEncoding(t *testing.T) {
+	t.Parallel()
 	src := SeriesWithOffset{
 		Series: Series{
 			Fingerprint: model.Fingerprint(1),
@@ -54,6 +56,7 @@ func TestSeriesEncoding(t *testing.T) {
 }
 
 func TestChunkRefCompare(t *testing.T) {
+	t.Parallel()
 	for _, tc := range []struct {
 		desc                              string
 		left, right, exclusive, inclusive ChunkRefs

--- a/pkg/storage/bloom/v1/iter_test.go
+++ b/pkg/storage/bloom/v1/iter_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestSliceIterWithIndex(t *testing.T) {
+	t.Parallel()
 	t.Run("SliceIterWithIndex implements PeekingIterator interface", func(t *testing.T) {
 		xs := []string{"a", "b", "c"}
 		it := NewSliceIterWithIndex(xs, 123)

--- a/pkg/storage/bloom/v1/merge_test.go
+++ b/pkg/storage/bloom/v1/merge_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestMergeBlockQuerier_NonOverlapping(t *testing.T) {
+	t.Parallel()
 	var (
 		numSeries        = 100
 		numKeysPerSeries = 10000
@@ -34,6 +35,7 @@ func TestMergeBlockQuerier_NonOverlapping(t *testing.T) {
 }
 
 func TestMergeBlockQuerier_Duplicate(t *testing.T) {
+	t.Parallel()
 	var (
 		numSeries        = 100
 		numKeysPerSeries = 10000
@@ -64,6 +66,8 @@ func TestMergeBlockQuerier_Duplicate(t *testing.T) {
 }
 
 func TestMergeBlockQuerier_Overlapping(t *testing.T) {
+	t.Parallel()
+
 	var (
 		numSeries        = 100
 		numKeysPerSeries = 10000

--- a/pkg/storage/bloom/v1/reader.go
+++ b/pkg/storage/bloom/v1/reader.go
@@ -12,6 +12,7 @@ import (
 type BlockReader interface {
 	Index() (io.ReadSeeker, error)
 	Blooms() (io.ReadSeeker, error)
+	TarEntries() (Iterator[TarEntry], error)
 }
 
 // In memory reader
@@ -29,6 +30,33 @@ func (r *ByteReader) Index() (io.ReadSeeker, error) {
 
 func (r *ByteReader) Blooms() (io.ReadSeeker, error) {
 	return bytes.NewReader(r.blooms.Bytes()), nil
+}
+
+func (r *ByteReader) TarEntries() (Iterator[TarEntry], error) {
+	indexLn := r.index.Len()
+	index, err := r.Index()
+	if err != nil {
+		return nil, err
+	}
+	bloomLn := r.blooms.Len()
+	blooms, err := r.Blooms()
+	if err != nil {
+		return nil, err
+	}
+	entries := []TarEntry{
+		{
+			Name: SeriesFileName,
+			Size: int64(indexLn),
+			Body: index,
+		},
+		{
+			Name: BloomFileName,
+			Size: int64(bloomLn),
+			Body: blooms,
+		},
+	}
+
+	return NewSliceIter[TarEntry](entries), err
 }
 
 // File reader
@@ -80,4 +108,37 @@ func (r *DirectoryBlockReader) Blooms() (io.ReadSeeker, error) {
 		}
 	}
 	return r.blooms, nil
+}
+
+func (r *DirectoryBlockReader) TarEntries() (Iterator[TarEntry], error) {
+	if !r.initialized {
+		if err := r.Init(); err != nil {
+			return nil, err
+		}
+	}
+
+	idxInfo, err := r.index.Stat()
+	if err != nil {
+		return nil, errors.Wrap(err, "error stat'ing series file")
+	}
+
+	bloomInfo, err := r.blooms.Stat()
+	if err != nil {
+		return nil, errors.Wrap(err, "error stat'ing bloom file")
+	}
+
+	entries := []TarEntry{
+		{
+			Name: SeriesFileName,
+			Size: idxInfo.Size(),
+			Body: r.index,
+		},
+		{
+			Name: BloomFileName,
+			Size: bloomInfo.Size(),
+			Body: r.blooms,
+		},
+	}
+
+	return NewSliceIter[TarEntry](entries), nil
 }

--- a/pkg/storage/bloom/v1/tokenizer_test.go
+++ b/pkg/storage/bloom/v1/tokenizer_test.go
@@ -9,6 +9,7 @@ import (
 const BigFile = "../../../logql/sketch/testdata/war_peace.txt"
 
 func TestNGramIterator(t *testing.T) {
+	t.Parallel()
 	var (
 		three      = NewNGramTokenizer(3, 0)
 		threeSkip1 = NewNGramTokenizer(3, 1)
@@ -72,6 +73,7 @@ func TestNGramIterator(t *testing.T) {
 }
 
 func TestPrefixedIterator(t *testing.T) {
+	t.Parallel()
 	var (
 		three = NewNGramTokenizer(3, 0)
 	)

--- a/pkg/storage/bloom/v1/util_test.go
+++ b/pkg/storage/bloom/v1/util_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestPeekingIterator(t *testing.T) {
+	t.Parallel()
 	data := []int{1, 2, 3, 4, 5}
 	itr := NewPeekingIter[int](NewSliceIter[int](data))
 


### PR DESCRIPTION
Moves the archival code to an interface based approach, removing the explicit fs dependency. We can now implement with in-memory solutions. Also refactors to use a tar-file iterator and marks tests as parallelizable.