### PR TITLE
Use correct header name in docs for query fairness in scheduler

### DIFF
--- a/docs/sources/operations/query-fairness/_index.md
+++ b/docs/sources/operations/query-fairness/_index.md
@@ -115,7 +115,7 @@ you would usually want to avoid this scenario and control yourself where the hea
 
 When using Grafana as the Loki user interface, you can, for example, create multiple data sources
 with the same tenant, but with a different additional HTTP header
-`X-Loki-Scope-Actor` and restrict which Grafana user can use which data source.
+`X-Loki-Actor-Path` and restrict which Grafana user can use which data source.
 
 Alternatively, if you have a proxy for authentication in front of Loki, you can
 pass the (hashed) user from the authentication as downstream header to Loki.


### PR DESCRIPTION
**What this PR does / why we need it**:

The rest of the doc mentions the correct header name.