### PR TITLE
(chore) BloomStore: Clean up `FetchBlocks()`

### DIFF
--- a/pkg/storage/stores/shipper/bloomshipper/store.go
+++ b/pkg/storage/stores/shipper/bloomshipper/store.go
@@ -107,7 +107,7 @@ func (b *bloomStoreEntry) FetchMetas(ctx context.Context, params MetaSearchParam
 
 // FetchBlocks implements Store.
 func (b *bloomStoreEntry) FetchBlocks(ctx context.Context, refs []BlockRef) ([]BlockDirectory, error) {
-	return b.fetcher.FetchBlocksWithQueue(ctx, refs)
+	return b.fetcher.FetchBlocks(ctx, refs)
 }
 
 // Fetcher implements Store.
@@ -299,7 +299,7 @@ func (b *BloomStore) FetchBlocks(ctx context.Context, blocks []BlockRef) ([]Bloc
 
 	results := make([]BlockDirectory, 0, len(blocks))
 	for i := range fetchers {
-		res, err := fetchers[i].FetchBlocksWithQueue(ctx, refs[i])
+		res, err := fetchers[i].FetchBlocks(ctx, refs[i])
 		results = append(results, res...)
 		if err != nil {
 			return results, err


### PR DESCRIPTION
**What this PR does / why we need it**:

* Removes `FetchBlocksWithQueue` and replace it with `FetchBlocks`
* Operate on single `BlockRef` when loading a block directory from cache/fs/storage.