### PR TITLE
fix(bloomstore): Keep synchronous state between cache and fs on entry eviction

### DIFF
--- a/pkg/storage/chunk/cache/embeddedcache_test.go
+++ b/pkg/storage/chunk/cache/embeddedcache_test.go
@@ -48,10 +48,9 @@ func TestEmbeddedCacheEviction(t *testing.T) {
 
 	for _, test := range tests {
 		removedEntriesCount := atomic.NewInt64(0)
-		onEntryRemoved := func(key string, value []byte) {
+		c := NewTypedEmbeddedCache[string, []byte](test.name, test.cfg, nil, log.NewNopLogger(), "test", sizeOf, func(_ *Entry[string, []byte]) {
 			removedEntriesCount.Inc()
-		}
-		c := NewTypedEmbeddedCache[string, []byte](test.name, test.cfg, nil, log.NewNopLogger(), "test", sizeOf, onEntryRemoved)
+		})
 		ctx := context.Background()
 
 		// Check put / get works
@@ -187,10 +186,9 @@ func TestEmbeddedCacheExpiry(t *testing.T) {
 	}
 
 	removedEntriesCount := atomic.NewInt64(0)
-	onEntryRemoved := func(key string, value []byte) {
+	c := NewTypedEmbeddedCache[string, []byte]("cache_exprity_test", cfg, nil, log.NewNopLogger(), "test", sizeOf, func(_ *Entry[string, []byte]) {
 		removedEntriesCount.Inc()
-	}
-	c := NewTypedEmbeddedCache[string, []byte]("cache_exprity_test", cfg, nil, log.NewNopLogger(), "test", sizeOf, onEntryRemoved)
+	})
 	ctx := context.Background()
 
 	err := c.Store(ctx, []string{key1, key2, key3, key4}, [][]byte{data1, data2, data3, data4})

--- a/pkg/storage/stores/shipper/bloomshipper/cache.go
+++ b/pkg/storage/stores/shipper/bloomshipper/cache.go
@@ -2,7 +2,6 @@ package bloomshipper
 
 import (
 	"context"
-	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -46,10 +45,11 @@ func NewBlocksCache(cfg cache.EmbeddedCacheConfig, reg prometheus.Registerer, lo
 		reg,
 		logger,
 		stats.BloomBlocksCache,
-		calculateBlockDirectorySize,
+		directorySize,
 		func(_ string, value BlockDirectory) {
-			value.removeDirectoryAsync()
-		})
+			removeBlockDirectory(value)
+		},
+	)
 }
 
 func LoadBlocksDirIntoCache(path string, c cache.TypedCache[string, BlockDirectory], logger log.Logger) error {
@@ -99,9 +99,9 @@ func NewBlockDirectory(ref BlockRef, path string, logger log.Logger) BlockDirect
 		BlockRef:                    ref,
 		Path:                        path,
 		refCount:                    atomic.NewInt32(0),
-		removeDirectoryTimeout:      time.Minute,
+		removeDirectoryTimeout:      5 * time.Second,
+		activeQueriersCheckInterval: 100 * time.Millisecond,
 		logger:                      logger,
-		activeQueriersCheckInterval: defaultActiveQueriersCheckInterval,
 	}
 	if err := bd.resolveSize(); err != nil {
 		panic(err)
@@ -114,13 +114,15 @@ func NewBlockDirectory(ref BlockRef, path string, logger log.Logger) BlockDirect
 type BlockDirectory struct {
 	BlockRef
 	Path                        string
-	removeDirectoryTimeout      time.Duration
 	refCount                    *atomic.Int32
-	logger                      log.Logger
+	removeDirectoryTimeout      time.Duration
 	activeQueriersCheckInterval time.Duration
 	size                        int64
+	logger                      log.Logger
 }
 
+// Convenience function to create a new block from a directory.
+// Must not be called outside of BlockQuerier().
 func (b BlockDirectory) Block() *v1.Block {
 	return v1.NewBlock(v1.NewDirectoryBlockReader(b.Path))
 }
@@ -129,10 +131,12 @@ func (b BlockDirectory) Size() int64 {
 	return b.size
 }
 
+// Acquire increases the ref counter on the directory.
 func (b BlockDirectory) Acquire() {
 	_ = b.refCount.Inc()
 }
 
+// Release decreases the ref counter on the directory.
 func (b BlockDirectory) Release() error {
 	_ = b.refCount.Dec()
 	return nil
@@ -165,39 +169,37 @@ func (b BlockDirectory) BlockQuerier() *CloseableBlockQuerier {
 	}
 }
 
-const defaultActiveQueriersCheckInterval = 100 * time.Millisecond
-
-func (b *BlockDirectory) removeDirectoryAsync() {
-	go func() {
-		timeout := time.After(b.removeDirectoryTimeout)
-		ticker := time.NewTicker(b.activeQueriersCheckInterval)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-ticker.C:
-				if b.refCount.Load() == 0 {
-					err := deleteFolder(b.Path)
-					if err == nil {
-						return
-					}
-					level.Error(b.logger).Log("msg", "error deleting block directory", "err", err)
-				}
-			case <-timeout:
-				level.Warn(b.logger).Log("msg", "force deleting block folder after timeout", "timeout", b.removeDirectoryTimeout)
-				err := deleteFolder(b.Path)
-				if err == nil {
-					return
-				}
-				level.Error(b.logger).Log("msg", "error force deleting block directory", "err", err)
-			}
-		}
-	}()
+func directorySize(entry *cache.Entry[string, BlockDirectory]) uint64 {
+	return uint64(entry.Value.Size())
 }
 
-func deleteFolder(folderPath string) error {
-	err := os.RemoveAll(folderPath)
-	if err != nil {
-		return fmt.Errorf("error deleting bloom block directory: %w", err)
+const defaultActiveQueriersCheckInterval = 100 * time.Millisecond
+
+// removeBlockDirectory is called by the cache when an item is evicted
+// The cache key and the cache value are passed to this function.
+// The function needs to be synchronous, because otherwise we could get a cache
+// race condition where the item is already evicted from the cache, but the
+// underlying directory isn't.
+func removeBlockDirectory(b BlockDirectory) {
+	timeout := time.After(b.removeDirectoryTimeout)
+	ticker := time.NewTicker(b.activeQueriersCheckInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			if b.refCount.Load() == 0 {
+				if err := os.RemoveAll(b.Path); err != nil {
+					level.Error(b.logger).Log("msg", "error deleting block directory", "err", err)
+				}
+				return
+			}
+		case <-timeout:
+			level.Warn(b.logger).Log("msg", "force deleting block folder after timeout", "timeout", b.removeDirectoryTimeout)
+			if err := os.RemoveAll(b.Path); err != nil {
+				level.Error(b.logger).Log("msg", "error force deleting block directory", "err", err)
+			}
+			return
+		}
 	}
-	return nil
 }

--- a/pkg/storage/stores/shipper/bloomshipper/cache.go
+++ b/pkg/storage/stores/shipper/bloomshipper/cache.go
@@ -46,9 +46,7 @@ func NewBlocksCache(cfg cache.EmbeddedCacheConfig, reg prometheus.Registerer, lo
 		logger,
 		stats.BloomBlocksCache,
 		directorySize,
-		func(_ string, value BlockDirectory) {
-			removeBlockDirectory(value)
-		},
+		removeBlockDirectory,
 	)
 }
 
@@ -180,7 +178,9 @@ const defaultActiveQueriersCheckInterval = 100 * time.Millisecond
 // The function needs to be synchronous, because otherwise we could get a cache
 // race condition where the item is already evicted from the cache, but the
 // underlying directory isn't.
-func removeBlockDirectory(b BlockDirectory) {
+func removeBlockDirectory(entry *cache.Entry[string, BlockDirectory]) {
+	b := entry.Value
+
 	timeout := time.After(b.removeDirectoryTimeout)
 	ticker := time.NewTicker(b.activeQueriersCheckInterval)
 	defer ticker.Stop()

--- a/pkg/storage/stores/shipper/bloomshipper/cache_test.go
+++ b/pkg/storage/stores/shipper/bloomshipper/cache_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
+	"github.com/grafana/loki/pkg/storage/chunk/cache"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
 
@@ -91,7 +92,11 @@ func TestBlockDirectory_Cleanup(t *testing.T) {
 			// acquire directory
 			blockDir.refCount.Inc()
 			// start cleanup goroutine
-			blockDir.removeDirectoryAsync()
+			e := &cache.Entry[string, BlockDirectory]{
+				Key:   blockDir.Path,
+				Value: blockDir,
+			}
+			go removeBlockDirectory(e)
 
 			if tc.releaseQuerier {
 				// release directory

--- a/pkg/storage/stores/shipper/bloomshipper/compress_utils_test.go
+++ b/pkg/storage/stores/shipper/bloomshipper/compress_utils_test.go
@@ -2,6 +2,7 @@ package bloomshipper
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -13,9 +14,18 @@ import (
 	v1 "github.com/grafana/loki/pkg/storage/bloom/v1"
 )
 
-func directoryDoesNotExist(path string) bool {
-	_, err := os.Lstat(path)
-	return err != nil
+func DirExists(path string) bool {
+	info, err := os.Lstat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false
+		}
+		panic(fmt.Sprintf("error running os.Lstat(%q): %s", path, err))
+	}
+	if !info.IsDir() {
+		panic(fmt.Sprintf("%q is not a directory", path))
+	}
+	return true
 }
 
 const testArchiveFileName = "test-block-archive"


### PR DESCRIPTION
**What this PR does / why we need it**:

`removeBlockDirectory` is called by the cache when an item is evicted.

The cache entry is passed to this function. The function needs to evict/invalidate the entry synchronously, otherwise we could get a cache race condition where the item is already evicted from the cache, but the underlying directory isn't.

However, instead of removing the directory immediately, the function only renames it, so existing readers can still access the files. The actual cleanup of the directory happens asynchronously once the readers count is zero.

