### PR TITLE
Extend BloomStore with `Client(model.Time)` function

### DIFF
--- a/pkg/bloomgateway/processor_test.go
+++ b/pkg/bloomgateway/processor_test.go
@@ -42,8 +42,12 @@ func (s *dummyStore) FetchBlocks(_ context.Context, _ []bloomshipper.BlockRef) (
 	panic("don't call me")
 }
 
-func (s *dummyStore) Fetcher(_ model.Time) *bloomshipper.Fetcher {
-	return nil
+func (s *dummyStore) Fetcher(_ model.Time) (*bloomshipper.Fetcher, error) {
+	return nil, nil
+}
+
+func (s *dummyStore) Client(_ model.Time) (bloomshipper.Client, error) {
+	return nil, nil
 }
 
 func (s *dummyStore) Stop() {

--- a/pkg/storage/stores/shipper/bloomshipper/store.go
+++ b/pkg/storage/stores/shipper/bloomshipper/store.go
@@ -17,12 +17,16 @@ import (
 	"github.com/grafana/loki/pkg/storage/config"
 )
 
+var (
+	errNoStore = errors.New("no store found for time")
+)
+
 type Store interface {
 	ResolveMetas(ctx context.Context, params MetaSearchParams) ([][]MetaRef, []*Fetcher, error)
 	FetchMetas(ctx context.Context, params MetaSearchParams) ([]Meta, error)
 	FetchBlocks(ctx context.Context, refs []BlockRef) ([]BlockDirectory, error)
-	Fetcher(ts model.Time) *Fetcher
-	Client(ts model.Time) Client
+	Fetcher(ts model.Time) (*Fetcher, error)
+	Client(ts model.Time) (Client, error)
 	Stop()
 }
 
@@ -112,13 +116,13 @@ func (b *bloomStoreEntry) FetchBlocks(ctx context.Context, refs []BlockRef) ([]B
 }
 
 // Fetcher implements Store.
-func (b *bloomStoreEntry) Fetcher(_ model.Time) *Fetcher {
-	return b.fetcher
+func (b *bloomStoreEntry) Fetcher(_ model.Time) (*Fetcher, error) {
+	return b.fetcher, nil
 }
 
 // Client implements Store.
-func (b *bloomStoreEntry) Client(_ model.Time) Client {
-	return b.bloomClient
+func (b *bloomStoreEntry) Client(_ model.Time) (Client, error) {
+	return b.bloomClient, nil
 }
 
 // Stop implements Store.
@@ -224,19 +228,19 @@ func (b *BloomStore) Block(ref BlockRef) (loc Location) {
 }
 
 // Fetcher implements Store.
-func (b *BloomStore) Fetcher(ts model.Time) *Fetcher {
+func (b *BloomStore) Fetcher(ts model.Time) (*Fetcher, error) {
 	if store := b.getStore(ts); store != nil {
 		return store.Fetcher(ts)
 	}
-	return nil
+	return nil, errNoStore
 }
 
 // Client implements Store.
-func (b *BloomStore) Client(ts model.Time) Client {
+func (b *BloomStore) Client(ts model.Time) (Client, error) {
 	if store := b.getStore(ts); store != nil {
 		return store.Client(ts)
 	}
-	return nil
+	return nil, errNoStore
 }
 
 // ResolveMetas implements Store.
@@ -307,7 +311,7 @@ func (b *BloomStore) FetchBlocks(ctx context.Context, blocks []BlockRef) ([]Bloc
 
 		if len(res) > 0 {
 			refs = append(refs, res)
-			fetchers = append(fetchers, s.Fetcher(s.start))
+			fetchers = append(fetchers, s.fetcher)
 		}
 	}
 
@@ -343,6 +347,7 @@ func (b *BloomStore) getStore(ts model.Time) *bloomStoreEntry {
 		return b.stores[j]
 	}
 
+	// should in theory never happen
 	return nil
 }
 

--- a/pkg/storage/stores/shipper/bloomshipper/store.go
+++ b/pkg/storage/stores/shipper/bloomshipper/store.go
@@ -22,6 +22,7 @@ type Store interface {
 	FetchMetas(ctx context.Context, params MetaSearchParams) ([]Meta, error)
 	FetchBlocks(ctx context.Context, refs []BlockRef) ([]BlockDirectory, error)
 	Fetcher(ts model.Time) *Fetcher
+	Client(ts model.Time) Client
 	Stop()
 }
 
@@ -113,6 +114,11 @@ func (b *bloomStoreEntry) FetchBlocks(ctx context.Context, refs []BlockRef) ([]B
 // Fetcher implements Store.
 func (b *bloomStoreEntry) Fetcher(_ model.Time) *Fetcher {
 	return b.fetcher
+}
+
+// Client implements Store.
+func (b *bloomStoreEntry) Client(_ model.Time) Client {
+	return b.bloomClient
 }
 
 // Stop implements Store.
@@ -221,6 +227,14 @@ func (b *BloomStore) Block(ref BlockRef) (loc Location) {
 func (b *BloomStore) Fetcher(ts model.Time) *Fetcher {
 	if store := b.getStore(ts); store != nil {
 		return store.Fetcher(ts)
+	}
+	return nil
+}
+
+// Client implements Store.
+func (b *BloomStore) Client(ts model.Time) Client {
+	if store := b.getStore(ts); store != nil {
+		return store.Client(ts)
 	}
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

For certain operations, we want direct access to the `BloomClient`. Since every schema period has its own client, the `Client()` function accepts a `model.Timestamp` for which the client should be returned.

The function may return an error, if no client for the given time could be found.