### PR TITLE
BloomStore: Change signature of `FetchBlocks()` to return `[]*CloseableBlockQuerier`

### DIFF
--- a/pkg/bloomcompactor/controller.go
+++ b/pkg/bloomcompactor/controller.go
@@ -184,7 +184,7 @@ func (s *SimpleBloomController) do(ctx context.Context) error {
 
 }
 
-func (s *SimpleBloomController) loadWorkForGap(ctx context.Context, id tsdb.Identifier, gap gapWithBlocks) (v1.CloseableIterator[*v1.Series], []*bloomshipper.ClosableBlockQuerier, error) {
+func (s *SimpleBloomController) loadWorkForGap(ctx context.Context, id tsdb.Identifier, gap gapWithBlocks) (v1.CloseableIterator[*v1.Series], []*bloomshipper.CloseableBlockQuerier, error) {
 	// load a series iterator for the gap
 	seriesItr, err := s.tsdbStore.LoadTSDB(id, gap.bounds)
 	if err != nil {
@@ -195,7 +195,7 @@ func (s *SimpleBloomController) loadWorkForGap(ctx context.Context, id tsdb.Iden
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "failed to get blocks")
 	}
-	results := make([]*bloomshipper.ClosableBlockQuerier, 0, len(blocks))
+	results := make([]*bloomshipper.CloseableBlockQuerier, 0, len(blocks))
 	for _, block := range blocks {
 		results = append(results, block.BlockQuerier())
 	}

--- a/pkg/bloomcompactor/controller.go
+++ b/pkg/bloomcompactor/controller.go
@@ -195,12 +195,8 @@ func (s *SimpleBloomController) loadWorkForGap(ctx context.Context, id tsdb.Iden
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "failed to get blocks")
 	}
-	results := make([]*bloomshipper.CloseableBlockQuerier, 0, len(blocks))
-	for _, block := range blocks {
-		results = append(results, block.BlockQuerier())
-	}
 
-	return seriesItr, results, nil
+	return seriesItr, blocks, nil
 }
 
 type gapWithBlocks struct {

--- a/pkg/bloomcompactor/spec.go
+++ b/pkg/bloomcompactor/spec.go
@@ -74,7 +74,7 @@ type SimpleBloomGenerator struct {
 	chunkLoader ChunkLoader
 	// TODO(owen-d): blocks need not be all downloaded prior. Consider implementing
 	// as an iterator of iterators, where each iterator is a batch of overlapping blocks.
-	blocks []*bloomshipper.ClosableBlockQuerier
+	blocks []*bloomshipper.CloseableBlockQuerier
 
 	// options to build blocks with
 	opts v1.BlockOptions
@@ -95,7 +95,7 @@ func NewSimpleBloomGenerator(
 	opts v1.BlockOptions,
 	store v1.Iterator[*v1.Series],
 	chunkLoader ChunkLoader,
-	blocks []*bloomshipper.ClosableBlockQuerier,
+	blocks []*bloomshipper.CloseableBlockQuerier,
 	readWriterFn func() (v1.BlockWriter, v1.BlockReader),
 	metrics *Metrics,
 	logger log.Logger,
@@ -136,7 +136,7 @@ func (s *SimpleBloomGenerator) Generate(ctx context.Context) (skippedBlocks []v1
 
 	var closeErrors multierror.MultiError
 	blocksMatchingSchema := make([]v1.PeekingIterator[*v1.SeriesWithBloom], 0, len(s.blocks))
-	toClose := make([]*bloomshipper.ClosableBlockQuerier, 0, len(s.blocks))
+	toClose := make([]*bloomshipper.CloseableBlockQuerier, 0, len(s.blocks))
 	// Close all remaining blocks on exit
 	defer func() {
 		for _, block := range toClose {

--- a/pkg/bloomcompactor/spec_test.go
+++ b/pkg/bloomcompactor/spec_test.go
@@ -64,9 +64,9 @@ func (dummyChunkLoader) Load(_ context.Context, series *v1.Series) (*ChunkItersB
 }
 
 func dummyBloomGen(opts v1.BlockOptions, store v1.Iterator[*v1.Series], blocks []*v1.Block) *SimpleBloomGenerator {
-	bqs := make([]*bloomshipper.ClosableBlockQuerier, 0, len(blocks))
+	bqs := make([]*bloomshipper.CloseableBlockQuerier, 0, len(blocks))
 	for _, b := range blocks {
-		bqs = append(bqs, &bloomshipper.ClosableBlockQuerier{
+		bqs = append(bqs, &bloomshipper.CloseableBlockQuerier{
 			BlockQuerier: v1.NewBlockQuerier(b),
 		})
 	}

--- a/pkg/bloomgateway/processor_test.go
+++ b/pkg/bloomgateway/processor_test.go
@@ -20,7 +20,7 @@ var _ bloomshipper.Store = &dummyStore{}
 type dummyStore struct {
 	metas     []bloomshipper.Meta
 	blocks    []bloomshipper.BlockRef
-	querieres []*bloomshipper.ClosableBlockQuerier
+	querieres []*bloomshipper.CloseableBlockQuerier
 }
 
 func (s *dummyStore) ResolveMetas(_ context.Context, _ bloomshipper.MetaSearchParams) ([][]bloomshipper.MetaRef, []*bloomshipper.Fetcher, error) {
@@ -48,8 +48,8 @@ func (s *dummyStore) Client(_ model.Time) (bloomshipper.Client, error) {
 func (s *dummyStore) Stop() {
 }
 
-func (s *dummyStore) FetchBlocks(_ context.Context, refs []bloomshipper.BlockRef) ([]*bloomshipper.ClosableBlockQuerier, error) {
-	result := make([]*bloomshipper.ClosableBlockQuerier, 0, len(s.querieres))
+func (s *dummyStore) FetchBlocks(_ context.Context, refs []bloomshipper.BlockRef) ([]*bloomshipper.CloseableBlockQuerier, error) {
+	result := make([]*bloomshipper.CloseableBlockQuerier, 0, len(s.querieres))
 
 	for _, ref := range refs {
 		for _, bq := range s.querieres {

--- a/pkg/bloomgateway/processor_test.go
+++ b/pkg/bloomgateway/processor_test.go
@@ -12,16 +12,15 @@ import (
 	"go.uber.org/atomic"
 
 	"github.com/grafana/loki/pkg/logql/syntax"
-	v1 "github.com/grafana/loki/pkg/storage/bloom/v1"
 	"github.com/grafana/loki/pkg/storage/stores/shipper/bloomshipper"
 )
 
-var _ store = &dummyStore{}
+var _ bloomshipper.Store = &dummyStore{}
 
 type dummyStore struct {
 	metas     []bloomshipper.Meta
 	blocks    []bloomshipper.BlockRef
-	querieres []bloomshipper.BlockQuerierWithFingerprintRange
+	querieres []*bloomshipper.ClosableBlockQuerier
 }
 
 func (s *dummyStore) ResolveMetas(_ context.Context, _ bloomshipper.MetaSearchParams) ([][]bloomshipper.MetaRef, []*bloomshipper.Fetcher, error) {
@@ -38,10 +37,6 @@ func (s *dummyStore) FetchMetas(_ context.Context, _ bloomshipper.MetaSearchPara
 	return s.metas, nil
 }
 
-func (s *dummyStore) FetchBlocks(_ context.Context, _ []bloomshipper.BlockRef) ([]bloomshipper.BlockDirectory, error) {
-	panic("don't call me")
-}
-
 func (s *dummyStore) Fetcher(_ model.Time) (*bloomshipper.Fetcher, error) {
 	return nil, nil
 }
@@ -53,12 +48,12 @@ func (s *dummyStore) Client(_ model.Time) (bloomshipper.Client, error) {
 func (s *dummyStore) Stop() {
 }
 
-func (s *dummyStore) LoadBlocks(_ context.Context, refs []bloomshipper.BlockRef) (v1.Iterator[bloomshipper.BlockQuerierWithFingerprintRange], error) {
-	result := make([]bloomshipper.BlockQuerierWithFingerprintRange, len(s.querieres))
+func (s *dummyStore) FetchBlocks(_ context.Context, refs []bloomshipper.BlockRef) ([]*bloomshipper.ClosableBlockQuerier, error) {
+	result := make([]*bloomshipper.ClosableBlockQuerier, 0, len(s.querieres))
 
 	for _, ref := range refs {
 		for _, bq := range s.querieres {
-			if ref.Bounds.Equal(bq.FingerprintBounds) {
+			if ref.Bounds.Equal(bq.Bounds) {
 				result = append(result, bq)
 			}
 		}
@@ -68,7 +63,7 @@ func (s *dummyStore) LoadBlocks(_ context.Context, refs []bloomshipper.BlockRef)
 		result[i], result[j] = result[j], result[i]
 	})
 
-	return v1.NewSliceIter(result), nil
+	return result, nil
 }
 
 func TestProcessor(t *testing.T) {

--- a/pkg/bloomgateway/util_test.go
+++ b/pkg/bloomgateway/util_test.go
@@ -295,10 +295,10 @@ func TestPartitionRequest(t *testing.T) {
 
 }
 
-func createBlockQueriers(t *testing.T, numBlocks int, from, through model.Time, minFp, maxFp model.Fingerprint) ([]*bloomshipper.ClosableBlockQuerier, [][]v1.SeriesWithBloom) {
+func createBlockQueriers(t *testing.T, numBlocks int, from, through model.Time, minFp, maxFp model.Fingerprint) ([]*bloomshipper.CloseableBlockQuerier, [][]v1.SeriesWithBloom) {
 	t.Helper()
 	step := (maxFp - minFp) / model.Fingerprint(numBlocks)
-	bqs := make([]*bloomshipper.ClosableBlockQuerier, 0, numBlocks)
+	bqs := make([]*bloomshipper.CloseableBlockQuerier, 0, numBlocks)
 	series := make([][]v1.SeriesWithBloom, 0, numBlocks)
 	for i := 0; i < numBlocks; i++ {
 		fromFp := minFp + (step * model.Fingerprint(i))
@@ -308,7 +308,7 @@ func createBlockQueriers(t *testing.T, numBlocks int, from, through model.Time, 
 			throughFp = maxFp
 		}
 		blockQuerier, data := v1.MakeBlockQuerier(t, fromFp, throughFp, from, through)
-		bq := &bloomshipper.ClosableBlockQuerier{
+		bq := &bloomshipper.CloseableBlockQuerier{
 			BlockQuerier: blockQuerier,
 			BlockRef: bloomshipper.BlockRef{
 				Ref: bloomshipper.Ref{
@@ -324,12 +324,12 @@ func createBlockQueriers(t *testing.T, numBlocks int, from, through model.Time, 
 	return bqs, series
 }
 
-func createBlocks(t *testing.T, tenant string, n int, from, through model.Time, minFp, maxFp model.Fingerprint) ([]bloomshipper.BlockRef, []bloomshipper.Meta, []*bloomshipper.ClosableBlockQuerier, [][]v1.SeriesWithBloom) {
+func createBlocks(t *testing.T, tenant string, n int, from, through model.Time, minFp, maxFp model.Fingerprint) ([]bloomshipper.BlockRef, []bloomshipper.Meta, []*bloomshipper.CloseableBlockQuerier, [][]v1.SeriesWithBloom) {
 	t.Helper()
 
 	blocks := make([]bloomshipper.BlockRef, 0, n)
 	metas := make([]bloomshipper.Meta, 0, n)
-	queriers := make([]*bloomshipper.ClosableBlockQuerier, 0, n)
+	queriers := make([]*bloomshipper.CloseableBlockQuerier, 0, n)
 	series := make([][]v1.SeriesWithBloom, 0, n)
 
 	step := (maxFp - minFp) / model.Fingerprint(n)
@@ -358,7 +358,7 @@ func createBlocks(t *testing.T, tenant string, n int, from, through model.Time, 
 			Blocks:     []bloomshipper.BlockRef{block},
 		}
 		blockQuerier, data := v1.MakeBlockQuerier(t, fromFp, throughFp, from, through)
-		querier := &bloomshipper.ClosableBlockQuerier{
+		querier := &bloomshipper.CloseableBlockQuerier{
 			BlockQuerier: blockQuerier,
 			BlockRef:     block,
 		}
@@ -370,12 +370,12 @@ func createBlocks(t *testing.T, tenant string, n int, from, through model.Time, 
 	return blocks, metas, queriers, series
 }
 
-func newMockBloomStore(bqs []*bloomshipper.ClosableBlockQuerier) *mockBloomStore {
+func newMockBloomStore(bqs []*bloomshipper.CloseableBlockQuerier) *mockBloomStore {
 	return &mockBloomStore{bqs: bqs}
 }
 
 type mockBloomStore struct {
-	bqs []*bloomshipper.ClosableBlockQuerier
+	bqs []*bloomshipper.CloseableBlockQuerier
 	// mock how long it takes to serve block queriers
 	delay time.Duration
 	// mock response error when serving block queriers in ForEach
@@ -404,7 +404,7 @@ func (s *mockBloomStore) ForEach(_ context.Context, _ string, _ []bloomshipper.B
 		return s.err
 	}
 
-	shuffled := make([]*bloomshipper.ClosableBlockQuerier, len(s.bqs))
+	shuffled := make([]*bloomshipper.CloseableBlockQuerier, len(s.bqs))
 	_ = copy(shuffled, s.bqs)
 
 	rand.Shuffle(len(shuffled), func(i, j int) {
@@ -444,7 +444,7 @@ func createQueryInputFromBlockData(t *testing.T, tenant string, data [][]v1.Seri
 	return res
 }
 
-func createBlockRefsFromBlockData(t *testing.T, tenant string, data []*bloomshipper.ClosableBlockQuerier) []bloomshipper.BlockRef {
+func createBlockRefsFromBlockData(t *testing.T, tenant string, data []*bloomshipper.CloseableBlockQuerier) []bloomshipper.BlockRef {
 	t.Helper()
 	res := make([]bloomshipper.BlockRef, 0)
 	for i := range data {

--- a/pkg/bloomgateway/util_test.go
+++ b/pkg/bloomgateway/util_test.go
@@ -385,7 +385,7 @@ type mockBloomStore struct {
 var _ bloomshipper.Interface = &mockBloomStore{}
 
 // GetBlockRefs implements bloomshipper.Interface
-func (s *mockBloomStore) GetBlockRefs(_ context.Context, tenant string, _ bloomshipper.Interval) ([]bloomshipper.BlockRef, error) {
+func (s *mockBloomStore) GetBlockRefs(_ context.Context, _ string, _ bloomshipper.Interval) ([]bloomshipper.BlockRef, error) {
 	time.Sleep(s.delay)
 	blocks := make([]bloomshipper.BlockRef, 0, len(s.bqs))
 	for i := range s.bqs {

--- a/pkg/bloomgateway/util_test.go
+++ b/pkg/bloomgateway/util_test.go
@@ -295,10 +295,10 @@ func TestPartitionRequest(t *testing.T) {
 
 }
 
-func createBlockQueriers(t *testing.T, numBlocks int, from, through model.Time, minFp, maxFp model.Fingerprint) ([]bloomshipper.BlockQuerierWithFingerprintRange, [][]v1.SeriesWithBloom) {
+func createBlockQueriers(t *testing.T, numBlocks int, from, through model.Time, minFp, maxFp model.Fingerprint) ([]*bloomshipper.ClosableBlockQuerier, [][]v1.SeriesWithBloom) {
 	t.Helper()
 	step := (maxFp - minFp) / model.Fingerprint(numBlocks)
-	bqs := make([]bloomshipper.BlockQuerierWithFingerprintRange, 0, numBlocks)
+	bqs := make([]*bloomshipper.ClosableBlockQuerier, 0, numBlocks)
 	series := make([][]v1.SeriesWithBloom, 0, numBlocks)
 	for i := 0; i < numBlocks; i++ {
 		fromFp := minFp + (step * model.Fingerprint(i))
@@ -308,9 +308,15 @@ func createBlockQueriers(t *testing.T, numBlocks int, from, through model.Time, 
 			throughFp = maxFp
 		}
 		blockQuerier, data := v1.MakeBlockQuerier(t, fromFp, throughFp, from, through)
-		bq := bloomshipper.BlockQuerierWithFingerprintRange{
-			BlockQuerier:      blockQuerier,
-			FingerprintBounds: v1.NewBounds(fromFp, throughFp),
+		bq := &bloomshipper.ClosableBlockQuerier{
+			BlockQuerier: blockQuerier,
+			BlockRef: bloomshipper.BlockRef{
+				Ref: bloomshipper.Ref{
+					Bounds:         v1.NewBounds(fromFp, throughFp),
+					StartTimestamp: from,
+					EndTimestamp:   through,
+				},
+			},
 		}
 		bqs = append(bqs, bq)
 		series = append(series, data)
@@ -318,12 +324,12 @@ func createBlockQueriers(t *testing.T, numBlocks int, from, through model.Time, 
 	return bqs, series
 }
 
-func createBlocks(t *testing.T, tenant string, n int, from, through model.Time, minFp, maxFp model.Fingerprint) ([]bloomshipper.BlockRef, []bloomshipper.Meta, []bloomshipper.BlockQuerierWithFingerprintRange, [][]v1.SeriesWithBloom) {
+func createBlocks(t *testing.T, tenant string, n int, from, through model.Time, minFp, maxFp model.Fingerprint) ([]bloomshipper.BlockRef, []bloomshipper.Meta, []*bloomshipper.ClosableBlockQuerier, [][]v1.SeriesWithBloom) {
 	t.Helper()
 
 	blocks := make([]bloomshipper.BlockRef, 0, n)
 	metas := make([]bloomshipper.Meta, 0, n)
-	queriers := make([]bloomshipper.BlockQuerierWithFingerprintRange, 0, n)
+	queriers := make([]*bloomshipper.ClosableBlockQuerier, 0, n)
 	series := make([][]v1.SeriesWithBloom, 0, n)
 
 	step := (maxFp - minFp) / model.Fingerprint(n)
@@ -352,9 +358,9 @@ func createBlocks(t *testing.T, tenant string, n int, from, through model.Time, 
 			Blocks:     []bloomshipper.BlockRef{block},
 		}
 		blockQuerier, data := v1.MakeBlockQuerier(t, fromFp, throughFp, from, through)
-		querier := bloomshipper.BlockQuerierWithFingerprintRange{
-			BlockQuerier:      blockQuerier,
-			FingerprintBounds: v1.NewBounds(fromFp, throughFp),
+		querier := &bloomshipper.ClosableBlockQuerier{
+			BlockQuerier: blockQuerier,
+			BlockRef:     block,
 		}
 		queriers = append(queriers, querier)
 		metas = append(metas, meta)
@@ -364,12 +370,12 @@ func createBlocks(t *testing.T, tenant string, n int, from, through model.Time, 
 	return blocks, metas, queriers, series
 }
 
-func newMockBloomStore(bqs []bloomshipper.BlockQuerierWithFingerprintRange) *mockBloomStore {
+func newMockBloomStore(bqs []*bloomshipper.ClosableBlockQuerier) *mockBloomStore {
 	return &mockBloomStore{bqs: bqs}
 }
 
 type mockBloomStore struct {
-	bqs []bloomshipper.BlockQuerierWithFingerprintRange
+	bqs []*bloomshipper.ClosableBlockQuerier
 	// mock how long it takes to serve block queriers
 	delay time.Duration
 	// mock response error when serving block queriers in ForEach
@@ -383,12 +389,7 @@ func (s *mockBloomStore) GetBlockRefs(_ context.Context, tenant string, _ blooms
 	time.Sleep(s.delay)
 	blocks := make([]bloomshipper.BlockRef, 0, len(s.bqs))
 	for i := range s.bqs {
-		blocks = append(blocks, bloomshipper.BlockRef{
-			Ref: bloomshipper.Ref{
-				Bounds:   v1.NewBounds(s.bqs[i].Min, s.bqs[i].Max),
-				TenantID: tenant,
-			},
-		})
+		blocks = append(blocks, s.bqs[i].BlockRef)
 	}
 	return blocks, nil
 }
@@ -403,7 +404,7 @@ func (s *mockBloomStore) ForEach(_ context.Context, _ string, _ []bloomshipper.B
 		return s.err
 	}
 
-	shuffled := make([]bloomshipper.BlockQuerierWithFingerprintRange, len(s.bqs))
+	shuffled := make([]*bloomshipper.ClosableBlockQuerier, len(s.bqs))
 	_ = copy(shuffled, s.bqs)
 
 	rand.Shuffle(len(shuffled), func(i, j int) {
@@ -413,7 +414,7 @@ func (s *mockBloomStore) ForEach(_ context.Context, _ string, _ []bloomshipper.B
 	for _, bq := range shuffled {
 		// ignore errors in the mock
 		time.Sleep(s.delay)
-		err := callback(bq.BlockQuerier, bq.FingerprintBounds)
+		err := callback(bq.BlockQuerier, bq.Bounds)
 		if err != nil {
 			return err
 		}
@@ -443,7 +444,7 @@ func createQueryInputFromBlockData(t *testing.T, tenant string, data [][]v1.Seri
 	return res
 }
 
-func createBlockRefsFromBlockData(t *testing.T, tenant string, data []bloomshipper.BlockQuerierWithFingerprintRange) []bloomshipper.BlockRef {
+func createBlockRefsFromBlockData(t *testing.T, tenant string, data []*bloomshipper.ClosableBlockQuerier) []bloomshipper.BlockRef {
 	t.Helper()
 	res := make([]bloomshipper.BlockRef, 0)
 	for i := range data {
@@ -451,7 +452,7 @@ func createBlockRefsFromBlockData(t *testing.T, tenant string, data []bloomshipp
 			Ref: bloomshipper.Ref{
 				TenantID:       tenant,
 				TableName:      "",
-				Bounds:         v1.NewBounds(data[i].Min, data[i].Max),
+				Bounds:         v1.NewBounds(data[i].Bounds.Min, data[i].Bounds.Max),
 				StartTimestamp: 0,
 				EndTimestamp:   0,
 				Checksum:       0,

--- a/pkg/storage/stores/shipper/bloomshipper/cache.go
+++ b/pkg/storage/stores/shipper/bloomshipper/cache.go
@@ -17,13 +17,13 @@ import (
 	"github.com/grafana/loki/pkg/storage/stores/shipper/bloomshipper/config"
 )
 
-type ClosableBlockQuerier struct {
+type CloseableBlockQuerier struct {
 	BlockRef
 	*v1.BlockQuerier
 	close func() error
 }
 
-func (c *ClosableBlockQuerier) Close() error {
+func (c *CloseableBlockQuerier) Close() error {
 	if c.close != nil {
 		return c.close()
 	}
@@ -88,9 +88,9 @@ func (b BlockDirectory) Release() error {
 // BlockQuerier returns a new block querier from the directory.
 // It increments the counter of active queriers for this directory.
 // The counter is decreased when the returned querier is closed.
-func (b BlockDirectory) BlockQuerier() *ClosableBlockQuerier {
+func (b BlockDirectory) BlockQuerier() *CloseableBlockQuerier {
 	b.Acquire()
-	return &ClosableBlockQuerier{
+	return &CloseableBlockQuerier{
 		BlockQuerier: v1.NewBlockQuerier(b.Block()),
 		BlockRef:     b.BlockRef,
 		close:        b.Release,

--- a/pkg/storage/stores/shipper/bloomshipper/fetcher.go
+++ b/pkg/storage/stores/shipper/bloomshipper/fetcher.go
@@ -21,7 +21,7 @@ type metrics struct{}
 
 type fetcher interface {
 	FetchMetas(ctx context.Context, refs []MetaRef) ([]Meta, error)
-	FetchBlocks(ctx context.Context, refs []BlockRef) ([]*ClosableBlockQuerier, error)
+	FetchBlocks(ctx context.Context, refs []BlockRef) ([]*CloseableBlockQuerier, error)
 	Close()
 }
 
@@ -124,7 +124,7 @@ func (f *Fetcher) writeBackMetas(ctx context.Context, metas []Meta) error {
 	return f.metasCache.Store(ctx, keys, data)
 }
 
-func (f *Fetcher) FetchBlocks(ctx context.Context, refs []BlockRef) ([]*ClosableBlockQuerier, error) {
+func (f *Fetcher) FetchBlocks(ctx context.Context, refs []BlockRef) ([]*CloseableBlockQuerier, error) {
 	n := len(refs)
 
 	responses := make(chan downloadResponse[BlockDirectory], n)
@@ -140,7 +140,7 @@ func (f *Fetcher) FetchBlocks(ctx context.Context, refs []BlockRef) ([]*Closable
 		})
 	}
 
-	results := make([]*ClosableBlockQuerier, n)
+	results := make([]*CloseableBlockQuerier, n)
 	for i := 0; i < n; i++ {
 		select {
 		case err := <-errors:

--- a/pkg/storage/stores/shipper/bloomshipper/fetcher.go
+++ b/pkg/storage/stores/shipper/bloomshipper/fetcher.go
@@ -21,7 +21,7 @@ type metrics struct{}
 
 type fetcher interface {
 	FetchMetas(ctx context.Context, refs []MetaRef) ([]Meta, error)
-	FetchBlocks(ctx context.Context, refs []BlockRef) ([]BlockDirectory, error)
+	FetchBlocks(ctx context.Context, refs []BlockRef) ([]*ClosableBlockQuerier, error)
 	Close()
 }
 
@@ -124,7 +124,7 @@ func (f *Fetcher) writeBackMetas(ctx context.Context, metas []Meta) error {
 	return f.metasCache.Store(ctx, keys, data)
 }
 
-func (f *Fetcher) FetchBlocks(ctx context.Context, refs []BlockRef) ([]BlockDirectory, error) {
+func (f *Fetcher) FetchBlocks(ctx context.Context, refs []BlockRef) ([]*ClosableBlockQuerier, error) {
 	n := len(refs)
 
 	responses := make(chan downloadResponse[BlockDirectory], n)
@@ -140,13 +140,13 @@ func (f *Fetcher) FetchBlocks(ctx context.Context, refs []BlockRef) ([]BlockDire
 		})
 	}
 
-	results := make([]BlockDirectory, len(refs))
+	results := make([]*ClosableBlockQuerier, n)
 	for i := 0; i < n; i++ {
 		select {
 		case err := <-errors:
 			return results, err
 		case res := <-responses:
-			results[res.idx] = res.item
+			results[res.idx] = res.item.BlockQuerier()
 		}
 	}
 

--- a/pkg/storage/stores/shipper/bloomshipper/shipper.go
+++ b/pkg/storage/stores/shipper/bloomshipper/shipper.go
@@ -14,11 +14,6 @@ import (
 	"github.com/grafana/loki/pkg/storage/stores/shipper/bloomshipper/config"
 )
 
-type BlockQuerierWithFingerprintRange struct {
-	*v1.BlockQuerier
-	v1.FingerprintBounds
-}
-
 type ForEachBlockCallback func(bq *v1.BlockQuerier, bounds v1.FingerprintBounds) error
 
 type Interface interface {
@@ -58,34 +53,26 @@ func (s *Shipper) GetBlockRefs(ctx context.Context, tenantID string, interval In
 	return blockRefs, nil
 }
 
-func (s *Shipper) ForEach(ctx context.Context, _ string, blocks []BlockRef, callback ForEachBlockCallback) error {
-	blockDirs, err := s.store.FetchBlocks(ctx, blocks)
+func (s *Shipper) ForEach(ctx context.Context, _ string, refs []BlockRef, callback ForEachBlockCallback) error {
+	bqs, err := s.store.FetchBlocks(ctx, refs)
+
 	if err != nil {
 		return err
 	}
 
-	if len(blockDirs) != len(blocks) {
-		return fmt.Errorf("number of responses (%d) does not match number of requests (%d)", len(blockDirs), len(blocks))
+	if len(bqs) != len(refs) {
+		return fmt.Errorf("number of respones (%d) does not match number of requests (%d)", len(bqs), len(refs))
 	}
 
-	for i := range blocks {
-		if blockDirs[i].BlockRef != blocks[i] {
-			return fmt.Errorf("invalid order of responses: expected: %v, got: %v", blocks[i], blockDirs[i].BlockRef)
-		}
-		err := runCallback(callback, blockDirs[i].BlockQuerier(), blockDirs[i].BlockRef.Bounds)
+	for i := range bqs {
+		err := callback(bqs[i].BlockQuerier, bqs[i].Bounds)
+		// close querier to decrement ref count
+		bqs[i].Close()
 		if err != nil {
 			return err
 		}
 	}
 	return nil
-}
-
-func runCallback(callback ForEachBlockCallback, bq *ClosableBlockQuerier, bounds v1.FingerprintBounds) error {
-	defer func(b *ClosableBlockQuerier) {
-		_ = b.Close()
-	}(bq)
-
-	return callback(bq.BlockQuerier, bounds)
 }
 
 func (s *Shipper) Stop() {

--- a/pkg/storage/stores/shipper/bloomshipper/shipper.go
+++ b/pkg/storage/stores/shipper/bloomshipper/shipper.go
@@ -61,7 +61,7 @@ func (s *Shipper) ForEach(ctx context.Context, _ string, refs []BlockRef, callba
 	}
 
 	if len(bqs) != len(refs) {
-		return fmt.Errorf("number of respones (%d) does not match number of requests (%d)", len(bqs), len(refs))
+		return fmt.Errorf("number of response (%d) does not match number of requests (%d)", len(bqs), len(refs))
 	}
 
 	for i := range bqs {

--- a/pkg/storage/stores/shipper/bloomshipper/store.go
+++ b/pkg/storage/stores/shipper/bloomshipper/store.go
@@ -25,7 +25,7 @@ var (
 type Store interface {
 	ResolveMetas(ctx context.Context, params MetaSearchParams) ([][]MetaRef, []*Fetcher, error)
 	FetchMetas(ctx context.Context, params MetaSearchParams) ([]Meta, error)
-	FetchBlocks(ctx context.Context, refs []BlockRef) ([]*ClosableBlockQuerier, error)
+	FetchBlocks(ctx context.Context, refs []BlockRef) ([]*CloseableBlockQuerier, error)
 	Fetcher(ts model.Time) (*Fetcher, error)
 	Client(ts model.Time) (Client, error)
 	Stop()
@@ -112,7 +112,7 @@ func (b *bloomStoreEntry) FetchMetas(ctx context.Context, params MetaSearchParam
 }
 
 // FetchBlocks implements Store.
-func (b *bloomStoreEntry) FetchBlocks(ctx context.Context, refs []BlockRef) ([]*ClosableBlockQuerier, error) {
+func (b *bloomStoreEntry) FetchBlocks(ctx context.Context, refs []BlockRef) ([]*CloseableBlockQuerier, error) {
 	return b.fetcher.FetchBlocks(ctx, refs)
 }
 
@@ -291,7 +291,7 @@ func (b *BloomStore) FetchMetas(ctx context.Context, params MetaSearchParams) ([
 }
 
 // FetchBlocks implements Store.
-func (b *BloomStore) FetchBlocks(ctx context.Context, blocks []BlockRef) ([]*ClosableBlockQuerier, error) {
+func (b *BloomStore) FetchBlocks(ctx context.Context, blocks []BlockRef) ([]*CloseableBlockQuerier, error) {
 
 	var refs [][]BlockRef
 	var fetchers []*Fetcher
@@ -316,7 +316,7 @@ func (b *BloomStore) FetchBlocks(ctx context.Context, blocks []BlockRef) ([]*Clo
 		}
 	}
 
-	results := make([]*ClosableBlockQuerier, 0, len(blocks))
+	results := make([]*CloseableBlockQuerier, 0, len(blocks))
 	for i := range fetchers {
 		res, err := fetchers[i].FetchBlocks(ctx, refs[i])
 		results = append(results, res...)
@@ -326,7 +326,7 @@ func (b *BloomStore) FetchBlocks(ctx context.Context, blocks []BlockRef) ([]*Clo
 	}
 
 	// sort responses (results []*CloseableBlockQuerier) based on requests (blocks []BlockRef)
-	slices.SortFunc(results, func(a, b *ClosableBlockQuerier) int {
+	slices.SortFunc(results, func(a, b *CloseableBlockQuerier) int {
 		ia, ib := slices.Index(blocks, a.BlockRef), slices.Index(blocks, b.BlockRef)
 		if ia < ib {
 			return -1

--- a/pkg/storage/stores/shipper/bloomshipper/store_test.go
+++ b/pkg/storage/stores/shipper/bloomshipper/store_test.go
@@ -248,19 +248,19 @@ func TestBloomStore_FetchBlocks(t *testing.T) {
 	ctx := context.Background()
 
 	// first call fetches two blocks from cache
-	blockDirs, err := store.FetchBlocks(ctx, []BlockRef{b1.BlockRef, b3.BlockRef})
+	bqs, err := store.FetchBlocks(ctx, []BlockRef{b1.BlockRef, b3.BlockRef})
 	require.NoError(t, err)
-	require.Len(t, blockDirs, 2)
+	require.Len(t, bqs, 2)
 
-	require.ElementsMatch(t, []BlockRef{b1.BlockRef, b3.BlockRef}, []BlockRef{blockDirs[0].BlockRef, blockDirs[1].BlockRef})
+	require.Equal(t, []BlockRef{b1.BlockRef, b3.BlockRef}, []BlockRef{bqs[0].BlockRef, bqs[1].BlockRef})
 
 	// second call fetches two blocks from cache and two from storage
-	blockDirs, err = store.FetchBlocks(ctx, []BlockRef{b1.BlockRef, b2.BlockRef, b3.BlockRef, b4.BlockRef})
+	bqs, err = store.FetchBlocks(ctx, []BlockRef{b1.BlockRef, b2.BlockRef, b3.BlockRef, b4.BlockRef})
 	require.NoError(t, err)
-	require.Len(t, blockDirs, 4)
+	require.Len(t, bqs, 4)
 
 	require.Equal(t,
 		[]BlockRef{b1.BlockRef, b2.BlockRef, b3.BlockRef, b4.BlockRef},
-		[]BlockRef{blockDirs[0].BlockRef, blockDirs[1].BlockRef, blockDirs[2].BlockRef, blockDirs[3].BlockRef},
+		[]BlockRef{bqs[0].BlockRef, bqs[1].BlockRef, bqs[2].BlockRef, bqs[3].BlockRef},
 	)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

In order to encapsulate the reference counting on the `BlockDirectory`, the `BloomStore` now returns a slice of `*CloseableBlockQuerier` instead of the directory itself.

The caller is responsible for closing the returned querier in order to release the reader resource and decrement the ref counter.

The PR also renames `ClosableBlockQuerier` to `CloseableBlockQuerier`.