### PR TITLE
Bloom gateway: Wire up cache config with implementation

### DIFF
--- a/docs/sources/configure/_index.md
+++ b/docs/sources/configure/_index.md
@@ -2327,27 +2327,26 @@ bloom_shipper:
     [max_tasks_enqueued_per_tenant: <int> | default = 10000]
 
   blocks_cache:
-    # Whether embedded cache is enabled.
-    # CLI flag: -blocks-cache.enabled
+    # Cache for bloom blocks. Whether embedded cache is enabled.
+    # CLI flag: -bloom.blocks-cache.enabled
     [enabled: <boolean> | default = false]
 
-    # Maximum memory size of the cache in MB.
-    # CLI flag: -blocks-cache.max-size-mb
+    # Cache for bloom blocks. Maximum memory size of the cache in MB.
+    # CLI flag: -bloom.blocks-cache.max-size-mb
     [max_size_mb: <int> | default = 100]
 
-    # Maximum number of entries in the cache.
-    # CLI flag: -blocks-cache.max-size-items
+    # Cache for bloom blocks. Maximum number of entries in the cache.
+    # CLI flag: -bloom.blocks-cache.max-size-items
     [max_size_items: <int> | default = 0]
 
-    # The time to live for items in the cache before they get purged.
-    # CLI flag: -blocks-cache.ttl
-    [ttl: <duration> | default = 0s]
+    # Cache for bloom blocks. The time to live for items in the cache before
+    # they get purged.
+    # CLI flag: -bloom.blocks-cache.ttl
+    [ttl: <duration> | default = 24h]
 
-    # During this period the process waits until the directory becomes not used
-    # and only after this it will be deleted. If the timeout is reached, the
-    # directory is force deleted.
-    # CLI flag: -blocks-cache.remove-directory-graceful-period
-    [remove_directory_graceful_period: <duration> | default = 5m]
+  # The cache block configures the cache backend.
+  # The CLI flags prefix for this block configuration is: bloom.metas-cache
+  [metas_cache: <cache_config>]
 ```
 
 ### chunk_store_config
@@ -4354,6 +4353,7 @@ The TLS configuration.
 The cache block configures the cache backend. The supported CLI flags `<prefix>` used to reference this configuration block are:
 
 - `bloom-gateway-client.cache`
+- `bloom.metas-cache`
 - `frontend`
 - `frontend.index-stats-results-cache`
 - `frontend.label-results-cache`

--- a/pkg/bloomgateway/bloomgateway.go
+++ b/pkg/bloomgateway/bloomgateway.go
@@ -59,7 +59,6 @@ import (
 	"github.com/grafana/loki/pkg/queue"
 	"github.com/grafana/loki/pkg/storage"
 	v1 "github.com/grafana/loki/pkg/storage/bloom/v1"
-	"github.com/grafana/loki/pkg/storage/chunk/cache"
 	"github.com/grafana/loki/pkg/storage/config"
 	"github.com/grafana/loki/pkg/storage/stores/shipper/bloomshipper"
 	"github.com/grafana/loki/pkg/util"
@@ -211,9 +210,7 @@ func New(cfg Config, schemaCfg config.SchemaConfig, storageCfg storage.Config, o
 	g.activeUsers = util.NewActiveUsersCleanupWithDefaultValues(g.queueMetrics.Cleanup)
 
 	// TODO(chaudum): Plug in cache
-	var metasCache cache.Cache
-	var blocksCache *cache.EmbeddedCache[string, bloomshipper.BlockDirectory]
-	store, err := bloomshipper.NewBloomStore(schemaCfg.Configs, storageCfg, cm, metasCache, blocksCache, logger)
+	store, err := bloomshipper.NewBloomStore(schemaCfg.Configs, storageCfg, cm, nil, nil, logger)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/bloomgateway/bloomgateway.go
+++ b/pkg/bloomgateway/bloomgateway.go
@@ -56,6 +56,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
 	"github.com/grafana/loki/pkg/logproto"
+	"github.com/grafana/loki/pkg/logqlmodel/stats"
 	"github.com/grafana/loki/pkg/queue"
 	"github.com/grafana/loki/pkg/storage"
 	v1 "github.com/grafana/loki/pkg/storage/bloom/v1"
@@ -206,17 +207,27 @@ func New(cfg Config, schemaCfg config.SchemaConfig, storageCfg storage.Config, o
 		workerMetrics: newWorkerMetrics(reg, constants.Loki, metricsSubsystem),
 		queueMetrics:  queue.NewMetrics(reg, constants.Loki, metricsSubsystem),
 	}
+	var err error
 
 	g.queue = queue.NewRequestQueue(cfg.MaxOutstandingPerTenant, time.Minute, &fixedQueueLimits{0}, g.queueMetrics)
 	g.activeUsers = util.NewActiveUsersCleanupWithDefaultValues(g.queueMetrics.Cleanup)
 
-	// TODO(chaudum): Plug in cache
+	var metasCache cache.Cache
+	mcCfg := storageCfg.BloomShipperConfig.MetasCache
+	if cache.IsCacheConfigured(mcCfg) {
+		metasCache, err = cache.New(mcCfg, reg, logger, stats.BloomMetasCache, constants.Loki)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	var blocksCache cache.TypedCache[string, bloomshipper.BlockDirectory]
 	bcCfg := storageCfg.BloomShipperConfig.BlocksCache
-	if bcCfg.EmbeddedCacheConfig.IsEnabled() {
+	if bcCfg.IsEnabled() {
 		blocksCache = bloomshipper.NewBlocksCache(bcCfg, reg, logger)
 	}
-	store, err := bloomshipper.NewBloomStore(schemaCfg.Configs, storageCfg, cm, nil, blocksCache, logger)
+
+	store, err := bloomshipper.NewBloomStore(schemaCfg.Configs, storageCfg, cm, metasCache, blocksCache, logger)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/logqlmodel/stats/context.go
+++ b/pkg/logqlmodel/stats/context.go
@@ -65,6 +65,7 @@ const (
 	LabelResultCache  CacheType = "label-result"  //nolint:staticcheck
 	BloomFilterCache  CacheType = "bloom-filter"  //nolint:staticcheck
 	BloomBlocksCache  CacheType = "bloom-blocks"  //nolint:staticcheck
+	BloomMetasCache   CacheType = "bloom-metas"   //nolint:staticcheck
 )
 
 // NewContext creates a new statistics context

--- a/pkg/logqlmodel/stats/context.go
+++ b/pkg/logqlmodel/stats/context.go
@@ -55,16 +55,16 @@ type Context struct {
 type CacheType string
 
 const (
-	ChunkCache        CacheType = "chunk" //nolint:staticcheck
-	IndexCache                  = "index"
-	ResultCache                 = "result"
-	StatsResultCache            = "stats-result"
-	VolumeResultCache           = "volume-result"
-	WriteDedupeCache            = "write-dedupe"
-	SeriesResultCache           = "series-result"
-	LabelResultCache            = "label-result"
-	BloomFilterCache            = "bloom-filter"
-	BloomBlocksCache            = "bloom-blocks"
+	ChunkCache        CacheType = "chunk"         //nolint:staticcheck
+	IndexCache        CacheType = "index"         //nolint:staticcheck
+	ResultCache       CacheType = "result"        //nolint:staticcheck
+	StatsResultCache  CacheType = "stats-result"  //nolint:staticcheck
+	VolumeResultCache CacheType = "volume-result" //nolint:staticcheck
+	WriteDedupeCache  CacheType = "write-dedupe"  //nolint:staticcheck
+	SeriesResultCache CacheType = "series-result" //nolint:staticcheck
+	LabelResultCache  CacheType = "label-result"  //nolint:staticcheck
+	BloomFilterCache  CacheType = "bloom-filter"  //nolint:staticcheck
+	BloomBlocksCache  CacheType = "bloom-blocks"  //nolint:staticcheck
 )
 
 // NewContext creates a new statistics context

--- a/pkg/storage/stores/shipper/bloomshipper/cache.go
+++ b/pkg/storage/stores/shipper/bloomshipper/cache.go
@@ -30,10 +30,10 @@ func (c *CloseableBlockQuerier) Close() error {
 	return nil
 }
 
-func NewBlocksCache(config config.Config, reg prometheus.Registerer, logger log.Logger) *cache.EmbeddedCache[string, BlockDirectory] {
+func NewBlocksCache(cfg config.BlocksCacheConfig, reg prometheus.Registerer, logger log.Logger) *cache.EmbeddedCache[string, BlockDirectory] {
 	return cache.NewTypedEmbeddedCache[string, BlockDirectory](
 		"bloom-blocks-cache",
-		config.BlocksCache.EmbeddedCacheConfig,
+		cfg.EmbeddedCacheConfig,
 		reg,
 		logger,
 		stats.BloomBlocksCache,

--- a/pkg/storage/stores/shipper/bloomshipper/cache.go
+++ b/pkg/storage/stores/shipper/bloomshipper/cache.go
@@ -14,7 +14,6 @@ import (
 	"github.com/grafana/loki/pkg/logqlmodel/stats"
 	v1 "github.com/grafana/loki/pkg/storage/bloom/v1"
 	"github.com/grafana/loki/pkg/storage/chunk/cache"
-	"github.com/grafana/loki/pkg/storage/stores/shipper/bloomshipper/config"
 )
 
 type CloseableBlockQuerier struct {
@@ -30,10 +29,10 @@ func (c *CloseableBlockQuerier) Close() error {
 	return nil
 }
 
-func NewBlocksCache(cfg config.BlocksCacheConfig, reg prometheus.Registerer, logger log.Logger) *cache.EmbeddedCache[string, BlockDirectory] {
+func NewBlocksCache(cfg cache.EmbeddedCacheConfig, reg prometheus.Registerer, logger log.Logger) *cache.EmbeddedCache[string, BlockDirectory] {
 	return cache.NewTypedEmbeddedCache[string, BlockDirectory](
 		"bloom-blocks-cache",
-		cfg.EmbeddedCacheConfig,
+		cfg,
 		reg,
 		logger,
 		stats.BloomBlocksCache,

--- a/pkg/storage/stores/shipper/bloomshipper/config/config.go
+++ b/pkg/storage/stores/shipper/bloomshipper/config/config.go
@@ -11,20 +11,10 @@ import (
 )
 
 type Config struct {
-	WorkingDirectory       string                 `yaml:"working_directory"`
-	BlocksDownloadingQueue DownloadingQueueConfig `yaml:"blocks_downloading_queue"`
-	BlocksCache            BlocksCacheConfig      `yaml:"blocks_cache"`
-}
-
-type BlocksCacheConfig struct {
-	EmbeddedCacheConfig           cache.EmbeddedCacheConfig `yaml:",inline"`
-	RemoveDirectoryGracefulPeriod time.Duration             `yaml:"remove_directory_graceful_period"`
-}
-
-func (c *BlocksCacheConfig) RegisterFlagsWithPrefixAndDefaults(prefix string, f *flag.FlagSet) {
-	c.EmbeddedCacheConfig.RegisterFlagsWithPrefixAndDefaults(prefix, "", f, 0)
-	f.DurationVar(&c.RemoveDirectoryGracefulPeriod, prefix+"remove-directory-graceful-period", 5*time.Minute,
-		"During this period the process waits until the directory becomes not used and only after this it will be deleted. If the timeout is reached, the directory is force deleted.")
+	WorkingDirectory       string                    `yaml:"working_directory"`
+	BlocksDownloadingQueue DownloadingQueueConfig    `yaml:"blocks_downloading_queue"`
+	BlocksCache            cache.EmbeddedCacheConfig `yaml:"blocks_cache"`
+	MetasCache             cache.Config              `yaml:"metas_cache"`
 }
 
 type DownloadingQueueConfig struct {
@@ -40,7 +30,8 @@ func (cfg *DownloadingQueueConfig) RegisterFlagsWithPrefix(prefix string, f *fla
 func (c *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.StringVar(&c.WorkingDirectory, prefix+"shipper.working-directory", "bloom-shipper", "Working directory to store downloaded Bloom Blocks.")
 	c.BlocksDownloadingQueue.RegisterFlagsWithPrefix(prefix+"shipper.blocks-downloading-queue.", f)
-	c.BlocksCache.RegisterFlagsWithPrefixAndDefaults("blocks-cache.", f)
+	c.BlocksCache.RegisterFlagsWithPrefixAndDefaults(prefix+"blocks-cache.", "Cache for bloom blocks", f, 24*time.Hour)
+	c.MetasCache.RegisterFlagsWithPrefix(prefix+"metas-cache.", "Cache for meta files", f)
 }
 
 func (c *Config) Validate() error {

--- a/pkg/storage/stores/shipper/bloomshipper/config/config.go
+++ b/pkg/storage/stores/shipper/bloomshipper/config/config.go
@@ -30,8 +30,8 @@ func (cfg *DownloadingQueueConfig) RegisterFlagsWithPrefix(prefix string, f *fla
 func (c *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.StringVar(&c.WorkingDirectory, prefix+"shipper.working-directory", "bloom-shipper", "Working directory to store downloaded Bloom Blocks.")
 	c.BlocksDownloadingQueue.RegisterFlagsWithPrefix(prefix+"shipper.blocks-downloading-queue.", f)
-	c.BlocksCache.RegisterFlagsWithPrefixAndDefaults(prefix+"blocks-cache.", "Cache for bloom blocks", f, 24*time.Hour)
-	c.MetasCache.RegisterFlagsWithPrefix(prefix+"metas-cache.", "Cache for meta files", f)
+	c.BlocksCache.RegisterFlagsWithPrefixAndDefaults(prefix+"blocks-cache.", "Cache for bloom blocks. ", f, 24*time.Hour)
+	c.MetasCache.RegisterFlagsWithPrefix(prefix+"metas-cache.", "Cache for bloom metas. ", f)
 }
 
 func (c *Config) Validate() error {

--- a/pkg/storage/stores/shipper/bloomshipper/fetcher.go
+++ b/pkg/storage/stores/shipper/bloomshipper/fetcher.go
@@ -32,7 +32,7 @@ type Fetcher struct {
 	client Client
 
 	metasCache      cache.Cache
-	blocksCache     *cache.EmbeddedCache[string, BlockDirectory]
+	blocksCache     cache.TypedCache[string, BlockDirectory]
 	localFSResolver KeyResolver
 
 	q *downloadQueue[BlockRef, BlockDirectory]
@@ -41,7 +41,7 @@ type Fetcher struct {
 	logger  log.Logger
 }
 
-func NewFetcher(cfg bloomStoreConfig, client Client, metasCache cache.Cache, blocksCache *cache.EmbeddedCache[string, BlockDirectory], logger log.Logger) (*Fetcher, error) {
+func NewFetcher(cfg bloomStoreConfig, client Client, metasCache cache.Cache, blocksCache cache.TypedCache[string, BlockDirectory], logger log.Logger) (*Fetcher, error) {
 	fetcher := &Fetcher{
 		client:          client,
 		metasCache:      metasCache,

--- a/pkg/storage/stores/shipper/bloomshipper/store.go
+++ b/pkg/storage/stores/shipper/bloomshipper/store.go
@@ -146,7 +146,7 @@ func NewBloomStore(
 	storageConfig storage.Config,
 	clientMetrics storage.ClientMetrics,
 	metasCache cache.Cache,
-	blocksCache *cache.EmbeddedCache[string, BlockDirectory],
+	blocksCache cache.TypedCache[string, BlockDirectory],
 	logger log.Logger,
 ) (*BloomStore, error) {
 	store := &BloomStore{
@@ -155,6 +155,10 @@ func NewBloomStore(
 
 	if metasCache == nil {
 		metasCache = cache.NewNoopCache()
+	}
+
+	if blocksCache == nil {
+		blocksCache = cache.NewNoopTypedCache[string, BlockDirectory]()
 	}
 
 	// sort by From time

--- a/pkg/storage/stores/shipper/bloomshipper/store_test.go
+++ b/pkg/storage/stores/shipper/bloomshipper/store_test.go
@@ -52,11 +52,9 @@ func newMockBloomStore(t *testing.T) (*BloomStore, string) {
 			BlocksDownloadingQueue: config.DownloadingQueueConfig{
 				WorkersCount: 1,
 			},
-			BlocksCache: config.BlocksCacheConfig{
-				EmbeddedCacheConfig: cache.EmbeddedCacheConfig{
-					MaxSizeItems: 1000,
-					TTL:          1 * time.Hour,
-				},
+			BlocksCache: cache.EmbeddedCacheConfig{
+				MaxSizeItems: 1000,
+				TTL:          1 * time.Hour,
 			},
 		},
 	}

--- a/pkg/storage/stores/shipper/bloomshipper/store_test.go
+++ b/pkg/storage/stores/shipper/bloomshipper/store_test.go
@@ -66,7 +66,7 @@ func newMockBloomStore(t *testing.T) (*BloomStore, string) {
 	logger := log.NewLogfmtLogger(os.Stderr)
 
 	metasCache := cache.NewMockCache()
-	blocksCache := NewBlocksCache(storageConfig.BloomShipperConfig, prometheus.NewPedanticRegistry(), logger)
+	blocksCache := NewBlocksCache(storageConfig.BloomShipperConfig.BlocksCache, prometheus.NewPedanticRegistry(), logger)
 	store, err := NewBloomStore(periodicConfigs, storageConfig, metrics, metasCache, blocksCache, logger)
 	require.NoError(t, err)
 	t.Cleanup(store.Stop)


### PR DESCRIPTION
**What this PR does / why we need it**:

Until now, the cache configuration in the bloom gateway did not intialize the cache.
This PR wires the config with the actual implementation and passes them to the bloom store.