### PR TITLE
quantile sharding; fix bug related to # of steps (instant query mem usage) and use CollapsingLowestDense store for ddsketch

### DIFF
--- a/pkg/logql/engine.go
+++ b/pkg/logql/engine.go
@@ -363,7 +363,7 @@ func (q *query) evalSample(ctx context.Context, expr syntax.SampleExpr) (promql_
 			maxSeries := validation.SmallestPositiveIntPerTenant(tenantIDs, maxSeriesCapture)
 			return q.JoinSampleVector(next, ts, vec, stepEvaluator, maxSeries)
 		case ProbabilisticQuantileVector:
-			return JoinQuantileSketchVector(next, vec, stepEvaluator, q.params)
+			return MergeQuantileSketchVector(next, vec, stepEvaluator, q.params)
 		default:
 			return nil, fmt.Errorf("unsupported result type: %T", r)
 		}

--- a/pkg/logql/quantile_over_time_sketch.go
+++ b/pkg/logql/quantile_over_time_sketch.go
@@ -269,6 +269,10 @@ func JoinQuantileSketchVector(next bool, r StepResult, stepEvaluator StepEvaluat
 		return nil, stepEvaluator.Error()
 	}
 
+	if GetRangeType(params) == InstantType {
+		return ProbabilisticQuantileMatrix{vec}, nil
+	}
+
 	stepCount := int(math.Ceil(float64(params.End().Sub(params.Start()).Nanoseconds()) / float64(params.Step().Nanoseconds())))
 	if stepCount <= 0 {
 		stepCount = 1
@@ -282,11 +286,6 @@ func JoinQuantileSketchVector(next bool, r StepResult, stepEvaluator StepEvaluat
 		vec = r.QuantileSketchVec()
 		if stepEvaluator.Error() != nil {
 			return nil, stepEvaluator.Error()
-		}
-		// Don't continue to evaluate more steps if we already filled the
-		// # of steps we should have based on start/end and step params.
-		if len(result) == stepCount {
-			break
 		}
 	}
 

--- a/pkg/logql/quantile_over_time_sketch.go
+++ b/pkg/logql/quantile_over_time_sketch.go
@@ -283,6 +283,11 @@ func JoinQuantileSketchVector(next bool, r StepResult, stepEvaluator StepEvaluat
 		if stepEvaluator.Error() != nil {
 			return nil, stepEvaluator.Error()
 		}
+		// Don't continue to evaluate more steps if we already filled the
+		// # of steps we should have based on start/end and step params.
+		if len(result) == stepCount {
+			break
+		}
 	}
 
 	return result, stepEvaluator.Error()

--- a/pkg/logql/quantile_over_time_sketch.go
+++ b/pkg/logql/quantile_over_time_sketch.go
@@ -262,8 +262,8 @@ func (r *quantileSketchBatchRangeVectorIterator) agg(samples []promql.FPoint) sk
 	return s
 }
 
-// JoinQuantileSketchVector joins the results from stepEvaluator into a ProbabilisticQuantileMatrix.
-func JoinQuantileSketchVector(next bool, r StepResult, stepEvaluator StepEvaluator, params Params) (promql_parser.Value, error) {
+// MergeQuantileSketchVector joins the results from stepEvaluator into a ProbabilisticQuantileMatrix.
+func MergeQuantileSketchVector(next bool, r StepResult, stepEvaluator StepEvaluator, params Params) (promql_parser.Value, error) {
 	vec := r.QuantileSketchVec()
 	if stepEvaluator.Error() != nil {
 		return nil, stepEvaluator.Error()

--- a/pkg/logql/quantile_over_time_sketch_test.go
+++ b/pkg/logql/quantile_over_time_sketch_test.go
@@ -148,7 +148,9 @@ func BenchmarkQuantileBatchRangeVectorIteratorAt(b *testing.B) {
 	}{
 		{numberSamples: 1},
 		{numberSamples: 1_000},
+		{numberSamples: 10_000},
 		{numberSamples: 100_000},
+		{numberSamples: 1_000_000},
 	} {
 		b.Run(fmt.Sprintf("%d-samples", tc.numberSamples), func(b *testing.B) {
 			r := rand.New(rand.NewSource(42))

--- a/pkg/logql/quantile_over_time_sketch_test.go
+++ b/pkg/logql/quantile_over_time_sketch_test.go
@@ -69,7 +69,7 @@ func TestJoinQuantileSketchVectorError(t *testing.T) {
 	ev := errorStepEvaluator{
 		err: errors.New("could not evaluate"),
 	}
-	_, err := JoinQuantileSketchVector(true, result, ev, LiteralParams{})
+	_, err := MergeQuantileSketchVector(true, result, ev, LiteralParams{})
 	require.ErrorContains(t, err, "could not evaluate")
 }
 
@@ -136,7 +136,7 @@ func BenchmarkJoinQuantileSketchVector(b *testing.B) {
 			iter: iter,
 		}
 		_, _, r := ev.Next()
-		m, err := JoinQuantileSketchVector(true, r.QuantileSketchVec(), ev, params)
+		m, err := MergeQuantileSketchVector(true, r.QuantileSketchVec(), ev, params)
 		require.NoError(b, err)
 		m.(ProbabilisticQuantileMatrix).Release()
 	}

--- a/pkg/logql/sketch/quantile.go
+++ b/pkg/logql/sketch/quantile.go
@@ -47,7 +47,7 @@ const relativeAccuracy = 0.01
 var ddsketchPool = sync.Pool{
 	New: func() any {
 		m, _ := mapping.NewCubicallyInterpolatedMapping(relativeAccuracy)
-		return ddsketch.NewDDSketchFromStoreProvider(m, store.SparseStoreConstructor)
+		return ddsketch.NewDDSketch(m, store.NewCollapsingLowestDenseStore(2048), store.NewCollapsingLowestDenseStore(2048))
 	},
 }
 


### PR DESCRIPTION
**EDIT: I also found the bug that was causing us to OOM when executing instant queries, see the 2nd commit**

This should reduce the memory allocated by the vector iteration by at least 25% but as much as ~80%. The quantile vector iteration accounts for at least 15% of all in use space last time I tested (and during that time queriers we're OOM'ing as a result of quantile sharding). 

However, with the usage of this alternate store type we give up some amount of relative accuracy guarantees for _lower_ quantiles. From their readme:

```
We also provide implementations, returned by LogCollapsingLowestDenseDDSketch(relativeAccuracy, maxNumBins) and LogCollapsingHighestDenseDDSketch(relativeAccuracy, maxNumBins), where the q-quantile will be accurate up to the specified relative error for q that is not too small (or large). Concretely, the q-quantile will be accurate up to the specified relative error as long as it belongs to one of the m bins kept by the sketch. For instance, If the values are time in seconds, maxNumBins = 2048 covers a time range from 80 microseconds to 1 year.
```

Benchmark:
```
goos: linux
goarch: amd64
pkg: github.com/grafana/loki/pkg/logql
cpu: AMD Ryzen 9 5950X 16-Core Processor
                                                      │    base     │                new2                │
                                                      │   sec/op    │   sec/op     vs base               │
QuantileBatchRangeVectorIteratorAt/1-samples-32         153.4n ± 1%   169.8n ± 1%  +10.76% (p=0.002 n=6)
QuantileBatchRangeVectorIteratorAt/1000-samples-32      30.17µ ± 1%   10.63µ ± 1%  -64.76% (p=0.002 n=6)
QuantileBatchRangeVectorIteratorAt/10000-samples-32     281.1µ ± 1%   101.5µ ± 2%  -63.88% (p=0.002 n=6)
QuantileBatchRangeVectorIteratorAt/100000-samples-32    2.355m ± 2%   1.006m ± 2%  -57.26% (p=0.002 n=6)
QuantileBatchRangeVectorIteratorAt/1000000-samples-32   23.50m ± 2%   10.11m ± 1%  -56.99% (p=0.002 n=6)
geomean                                                 148.4µ        71.47µ       -51.84%

                                                      │     base     │                 new2                 │
                                                      │     B/op     │    B/op      vs base                 │
QuantileBatchRangeVectorIteratorAt/1-samples-32          80.00 ±  0%   80.00 ±  0%        ~ (p=1.000 n=6) ¹
QuantileBatchRangeVectorIteratorAt/1000-samples-32      157.00 ±  1%   80.00 ±  0%  -49.04% (p=0.002 n=6)
QuantileBatchRangeVectorIteratorAt/10000-samples-32     155.00 ±  3%   80.00 ±  1%  -48.39% (p=0.002 n=6)
QuantileBatchRangeVectorIteratorAt/100000-samples-32    109.00 ± 76%   83.00 ±  0%  -23.85% (p=0.002 n=6)
QuantileBatchRangeVectorIteratorAt/1000000-samples-32   1082.5 ±  4%   222.0 ± 11%  -79.49% (p=0.002 n=6)
geomean                                                  187.2         98.84        -47.19%
¹ all samples are equal

                                                      │    base    │                new2                 │
                                                      │ allocs/op  │ allocs/op   vs base                 │
QuantileBatchRangeVectorIteratorAt/1-samples-32         3.000 ± 0%   3.000 ± 0%        ~ (p=1.000 n=6) ¹
QuantileBatchRangeVectorIteratorAt/1000-samples-32      6.000 ± 0%   3.000 ± 0%  -50.00% (p=0.002 n=6)
QuantileBatchRangeVectorIteratorAt/10000-samples-32     6.000 ± 0%   3.000 ± 0%  -50.00% (p=0.002 n=6)
QuantileBatchRangeVectorIteratorAt/100000-samples-32    4.000 ± 0%   3.000 ± 0%  -25.00% (p=0.002 n=6)
QuantileBatchRangeVectorIteratorAt/1000000-samples-32   7.000 ± 0%   3.000 ± 0%  -57.14% (p=0.002 n=6)
geomean                                                 4.967        3.000       -39.60%
¹ all samples are equal
```

And profiling
![2024-02-08-180659_2040x719_scrot](https://github.com/grafana/loki/assets/3246492/89770447-8eb1-4914-96d5-b702e06bd6d4)
![2024-02-08-180725_2042x650_scrot](https://github.com/grafana/loki/assets/3246492/3d9cf1c4-6eac-4c31-a3b5-3b38e613b2f9)
