### PR TITLE
Fix test utility function `MkBasicSeriesWithBlooms`

### DIFF
--- a/pkg/bloomgateway/bloomgateway_test.go
+++ b/pkg/bloomgateway/bloomgateway_test.go
@@ -3,6 +3,7 @@ package bloomgateway
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"os"
 	"testing"
 	"time"
@@ -183,7 +184,7 @@ func TestBloomGateway_FilterChunkRefs(t *testing.T) {
 			require.NoError(t, err)
 		})
 
-		chunkRefs := createQueryInputFromBlockData(t, tenantID, data, 10)
+		chunkRefs := createQueryInputFromBlockData(t, tenantID, data, 100)
 
 		// saturate workers
 		// then send additional request
@@ -359,7 +360,7 @@ func TestBloomGateway_FilterChunkRefs(t *testing.T) {
 			require.NoError(t, err)
 		})
 
-		chunkRefs := createQueryInputFromBlockData(t, tenantID, data, 100)
+		chunkRefs := createQueryInputFromBlockData(t, tenantID, data, 10)
 
 		t.Run("no match - return empty response", func(t *testing.T) {
 			inputChunkRefs := groupRefs(t, chunkRefs)
@@ -383,27 +384,37 @@ func TestBloomGateway_FilterChunkRefs(t *testing.T) {
 
 		t.Run("match - return filtered", func(t *testing.T) {
 			inputChunkRefs := groupRefs(t, chunkRefs)
-			// hack to get indexed key for a specific series
-			// the indexed key range for a series is defined as
-			// i * keysPerSeries ... i * keysPerSeries + keysPerSeries - 1
-			// where i is the nth series in a block
-			// fortunately, i is also used as Checksum for the single chunk of a series
-			// see mkBasicSeriesWithBlooms() in pkg/storage/bloom/v1/test_util.go
-			key := inputChunkRefs[0].Refs[0].Checksum*1000 + 500
+			// Hack to get search string for a specific series
+			// see MkBasicSeriesWithBlooms() in pkg/storage/bloom/v1/test_util.go
+			// each series has 1 chunk
+			// each chunk has multiple strings, from int(fp) to int(nextFp)-1
+			x := rand.Intn(len(inputChunkRefs))
+			fp := inputChunkRefs[x].Fingerprint
+			chks := inputChunkRefs[x].Refs
+			line := fmt.Sprintf("%04x", int(fp)+0) // first line
+
+			t.Log("x=", x, "fp=", fp, "line=", line)
 
 			req := &logproto.FilterChunkRefRequest{
 				From:    now.Add(-8 * time.Hour),
 				Through: now,
 				Refs:    inputChunkRefs,
 				Filters: []syntax.LineFilter{
-					{Ty: labels.MatchEqual, Match: fmt.Sprintf("series %d", key)},
+					{Ty: labels.MatchEqual, Match: line},
 				},
 			}
 			ctx := user.InjectOrgID(context.Background(), tenantID)
 			res, err := gw.FilterChunkRefs(ctx, req)
 			require.NoError(t, err)
+
 			expectedResponse := &logproto.FilterChunkRefResponse{
-				ChunkRefs: inputChunkRefs[:1],
+				ChunkRefs: []*logproto.GroupedChunkRefs{
+					{
+						Fingerprint: fp,
+						Refs:        chks,
+						Tenant:      tenantID,
+					},
+				},
 			}
 			require.Equal(t, expectedResponse, res)
 		})

--- a/pkg/bloomgateway/bloomgateway_test.go
+++ b/pkg/bloomgateway/bloomgateway_test.go
@@ -391,7 +391,7 @@ func TestBloomGateway_FilterChunkRefs(t *testing.T) {
 			x := rand.Intn(len(inputChunkRefs))
 			fp := inputChunkRefs[x].Fingerprint
 			chks := inputChunkRefs[x].Refs
-			line := fmt.Sprintf("%04x", int(fp)+0) // first line
+			line := fmt.Sprintf("%04x:%04x", int(fp), 0) // first line
 
 			t.Log("x=", x, "fp=", fp, "line=", line)
 

--- a/pkg/bloomgateway/util_test.go
+++ b/pkg/bloomgateway/util_test.go
@@ -293,39 +293,10 @@ func TestPartitionRequest(t *testing.T) {
 
 }
 
-func createBlockQueriers(t *testing.T, numBlocks int, from, through model.Time, minFp, maxFp model.Fingerprint) ([]*bloomshipper.CloseableBlockQuerier, [][]v1.SeriesWithBloom) {
-	t.Helper()
-	step := (maxFp - minFp) / model.Fingerprint(numBlocks)
-	bqs := make([]*bloomshipper.CloseableBlockQuerier, 0, numBlocks)
-	series := make([][]v1.SeriesWithBloom, 0, numBlocks)
-	for i := 0; i < numBlocks; i++ {
-		fromFp := minFp + (step * model.Fingerprint(i))
-		throughFp := fromFp + step - 1
-		// last block needs to include maxFp
-		if i == numBlocks-1 {
-			throughFp = maxFp
-		}
-		blockQuerier, data := v1.MakeBlockQuerier(t, fromFp, throughFp, from, through)
-		bq := &bloomshipper.CloseableBlockQuerier{
-			BlockQuerier: blockQuerier,
-			BlockRef: bloomshipper.BlockRef{
-				Ref: bloomshipper.Ref{
-					Bounds:         v1.NewBounds(fromFp, throughFp),
-					StartTimestamp: from,
-					EndTimestamp:   through,
-				},
-			},
-		}
-		bqs = append(bqs, bq)
-		series = append(series, data)
-	}
-	return bqs, series
-}
-
 func createBlocks(t *testing.T, tenant string, n int, from, through model.Time, minFp, maxFp model.Fingerprint) ([]bloomshipper.BlockRef, []bloomshipper.Meta, []*bloomshipper.CloseableBlockQuerier, [][]v1.SeriesWithBloom) {
 	t.Helper()
 
-	blocks := make([]bloomshipper.BlockRef, 0, n)
+	blockRefs := make([]bloomshipper.BlockRef, 0, n)
 	metas := make([]bloomshipper.Meta, 0, n)
 	queriers := make([]*bloomshipper.CloseableBlockQuerier, 0, n)
 	series := make([][]v1.SeriesWithBloom, 0, n)
@@ -345,7 +316,7 @@ func createBlocks(t *testing.T, tenant string, n int, from, through model.Time, 
 			StartTimestamp: from,
 			EndTimestamp:   through,
 		}
-		block := bloomshipper.BlockRef{
+		blockRef := bloomshipper.BlockRef{
 			Ref: ref,
 		}
 		meta := bloomshipper.Meta{
@@ -353,19 +324,26 @@ func createBlocks(t *testing.T, tenant string, n int, from, through model.Time, 
 				Ref: ref,
 			},
 			Tombstones: []bloomshipper.BlockRef{},
-			Blocks:     []bloomshipper.BlockRef{block},
+			Blocks:     []bloomshipper.BlockRef{blockRef},
 		}
-		blockQuerier, data := v1.MakeBlockQuerier(t, fromFp, throughFp, from, through)
+		block, data, _ := v1.MakeBlock(t, n, fromFp, throughFp, from, through)
+		// Printing fingerprints and the log lines of its chunks comes handy for debugging...
+		// for i := range keys {
+		// 	t.Log(data[i].Series.Fingerprint)
+		// 	for j := range keys[i] {
+		// 		t.Log(i, j, string(keys[i][j]))
+		// 	}
+		// }
 		querier := &bloomshipper.CloseableBlockQuerier{
-			BlockQuerier: blockQuerier,
-			BlockRef:     block,
+			BlockQuerier: v1.NewBlockQuerier(block),
+			BlockRef:     blockRef,
 		}
 		queriers = append(queriers, querier)
 		metas = append(metas, meta)
-		blocks = append(blocks, block)
+		blockRefs = append(blockRefs, blockRef)
 		series = append(series, data)
 	}
-	return blocks, metas, queriers, series
+	return blockRefs, metas, queriers, series
 }
 
 func createQueryInputFromBlockData(t *testing.T, tenant string, data [][]v1.SeriesWithBloom, nthSeries int) []*logproto.ChunkRef {

--- a/pkg/storage/bloom/v1/archive_test.go
+++ b/pkg/storage/bloom/v1/archive_test.go
@@ -18,7 +18,7 @@ func TestArchive(t *testing.T) {
 
 	numSeries := 100
 	numKeysPerSeries := 10000
-	data, _ := MkBasicSeriesWithBlooms(numSeries, numKeysPerSeries, 0, 0xffff, 0, 10000)
+	data, _ := MkBasicSeriesWithBlooms(numSeries, numKeysPerSeries, 0x0000, 0xffff, 0, 10000)
 
 	builder, err := NewBlockBuilder(
 		BlockOptions{

--- a/pkg/storage/bloom/v1/builder_test.go
+++ b/pkg/storage/bloom/v1/builder_test.go
@@ -362,7 +362,7 @@ func TestMergeBuilder_Roundtrip(t *testing.T) {
 
 	checksum, err := mb.Build(builder)
 	require.Nil(t, err)
-	require.Equal(t, uint32(0xe306ec6e), checksum)
+	require.Equal(t, uint32(0x30712486), checksum)
 
 	// ensure the new block contains one copy of all the data
 	// by comparing it against an iterator over the source data

--- a/pkg/storage/bloom/v1/fuse_test.go
+++ b/pkg/storage/bloom/v1/fuse_test.go
@@ -19,15 +19,8 @@ func TestFusedQuerier(t *testing.T) {
 	bloomsBuf := bytes.NewBuffer(nil)
 	writer := NewMemoryBlockWriter(indexBuf, bloomsBuf)
 	reader := NewByteReader(indexBuf, bloomsBuf)
-	numSeries := 100
-	numKeysPerSeries := 10000
-	data, keys := MkBasicSeriesWithBlooms(numSeries, numKeysPerSeries, 0x0000, 0xffff, 0, 10000)
-
-	// for i := range keys {
-	// 	for j := range keys[i] {
-	// 		fmt.Println(i, j, string(keys[i][j]))
-	// 	}
-	// }
+	numSeries := 1000
+	data, keys := MkBasicSeriesWithBlooms(numSeries, 0, 0x0000, 0xffff, 0, 10000)
 
 	builder, err := NewBlockBuilder(
 		BlockOptions{
@@ -54,7 +47,7 @@ func TestFusedQuerier(t *testing.T) {
 	for i := 0; i < nReqs; i++ {
 		ch := make(chan Output)
 		var reqs []Request
-		// find nth series for each
+		// find n series for each
 		for j := 0; j < n; j++ {
 			idx := numSeries/nReqs*i + j
 			reqs = append(reqs, Request{

--- a/pkg/storage/bloom/v1/fuse_test.go
+++ b/pkg/storage/bloom/v1/fuse_test.go
@@ -23,6 +23,12 @@ func TestFusedQuerier(t *testing.T) {
 	numKeysPerSeries := 10000
 	data, keys := MkBasicSeriesWithBlooms(numSeries, numKeysPerSeries, 0x0000, 0xffff, 0, 10000)
 
+	// for i := range keys {
+	// 	for j := range keys[i] {
+	// 		fmt.Println(i, j, string(keys[i][j]))
+	// 	}
+	// }
+
 	builder, err := NewBlockBuilder(
 		BlockOptions{
 			Schema: Schema{

--- a/pkg/storage/bloom/v1/fuse_test.go
+++ b/pkg/storage/bloom/v1/fuse_test.go
@@ -21,7 +21,7 @@ func TestFusedQuerier(t *testing.T) {
 	reader := NewByteReader(indexBuf, bloomsBuf)
 	numSeries := 100
 	numKeysPerSeries := 10000
-	data, keys := MkBasicSeriesWithBlooms(numSeries, numKeysPerSeries, 0, 0xffff, 0, 10000)
+	data, keys := MkBasicSeriesWithBlooms(numSeries, numKeysPerSeries, 0x0000, 0xffff, 0, 10000)
 
 	builder, err := NewBlockBuilder(
 		BlockOptions{
@@ -41,14 +41,15 @@ func TestFusedQuerier(t *testing.T) {
 	block := NewBlock(reader)
 	querier := NewBlockQuerier(block)
 
-	nReqs := 10
+	n := 2
+	nReqs := numSeries / n
 	var inputs [][]Request
 	var resChans []chan Output
 	for i := 0; i < nReqs; i++ {
 		ch := make(chan Output)
 		var reqs []Request
-		// find 2 series for each
-		for j := 0; j < 2; j++ {
+		// find nth series for each
+		for j := 0; j < n; j++ {
 			idx := numSeries/nReqs*i + j
 			reqs = append(reqs, Request{
 				Fp:       data[idx].Series.Fingerprint,

--- a/pkg/storage/bloom/v1/test_util.go
+++ b/pkg/storage/bloom/v1/test_util.go
@@ -45,7 +45,7 @@ func MakeBlock(t testing.TB, nth int, fromFp, throughFp model.Fingerprint, fromT
 	return block, data, keys
 }
 
-func MkBasicSeriesWithBlooms(nSeries, keysPerSeries int, fromFp, throughFp model.Fingerprint, fromTs, throughTs model.Time) (seriesList []SeriesWithBloom, keysList [][][]byte) {
+func MkBasicSeriesWithBlooms(nSeries, _ int, fromFp, throughFp model.Fingerprint, fromTs, throughTs model.Time) (seriesList []SeriesWithBloom, keysList [][][]byte) {
 	const nGramLen = 4
 	seriesList = make([]SeriesWithBloom, 0, nSeries)
 	keysList = make([][][]byte, 0, nSeries)
@@ -69,8 +69,8 @@ func MkBasicSeriesWithBlooms(nSeries, keysPerSeries int, fromFp, throughFp model
 		var bloom Bloom
 		bloom.ScalableBloomFilter = *filter.NewScalableBloomFilter(1024, 0.01, 0.8)
 
-		keys := make([][]byte, 0, keysPerSeries)
-		for j := 0; j < keysPerSeries; j++ {
+		keys := make([][]byte, 0, int(step))
+		for j := 0; j < int(step); j++ {
 			line := fmt.Sprintf("%04x", int(series.Fingerprint)+j)
 			it := tokenizer.Tokens(line)
 			for it.Next() {

--- a/pkg/storage/bloom/v1/test_util.go
+++ b/pkg/storage/bloom/v1/test_util.go
@@ -72,12 +72,16 @@ func MkBasicSeriesWithBlooms(nSeries, keysPerSeries int, fromFp, throughFp model
 
 		keys := make([][]byte, 0, keysPerSeries)
 		for j := 0; j < keysPerSeries; j++ {
-			it := tokenizer.Tokens(fmt.Sprintf("series %d", i*keysPerSeries+j))
+			line := fmt.Sprintf("%04x", int(series.Fingerprint)+j)
+			it := tokenizer.Tokens(line)
 			for it.Next() {
 				key := it.At()
 				// series-level key
 				bloom.Add(key)
-				keys = append(keys, key)
+
+				dst := make([]byte, len(key))
+				_ = copy(dst, key)
+				keys = append(keys, dst)
 
 				// chunk-level key
 				for _, chk := range series.Chunks {


### PR DESCRIPTION
**What this PR does / why we need it**:

The utility correctly populated the blooms, but returned incorrect values for `keys`, which are the indexed keys of a bloom.

The values need to be copied when appending to the result slice.

https://github.com/grafana/loki/pull/11909/files#diff-8aa1bba39beb779ea35f85fa9309b10d08637a2f6527f9fd4b26f59db79802e8L80


Additionally, the source for the tokenizer changed to be avoid duplicate keys that are present in all blooms.