### PR TITLE
Add mutex for t.stopped to prevent data races

### DIFF
--- a/pkg/querier/http.go
+++ b/pkg/querier/http.go
@@ -199,7 +199,7 @@ func (q *QuerierAPI) TailHandler(w http.ResponseWriter, r *http.Request) {
 					}
 					level.Error(logger).Log("msg", "Error from client", "err", err)
 					break
-				} else if tailer.stopped {
+				} else if tailer.stopped.Load() {
 					return
 				}
 

--- a/pkg/querier/tail.go
+++ b/pkg/querier/tail.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"fmt"
 	"sync"
-	"sync/atomic"
 	"time"
+
+	"go.uber.org/atomic"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"

--- a/pkg/querier/tail_test.go
+++ b/pkg/querier/tail_test.go
@@ -389,7 +389,7 @@ func readFromTailer(tailer *Tailer, maxEntries int) ([]*loghttp.TailResponse, er
 	timeoutTicker := time.NewTicker(timeout)
 	defer timeoutTicker.Stop()
 
-	for !tailer.stopped && entriesCount < maxEntries {
+	for !tailer.stopped.Load() && entriesCount < maxEntries {
 		select {
 		case <-timeoutTicker.C:
 			return nil, errors.New("timeout expired while reading responses from Tailer")


### PR DESCRIPTION
**What this PR does / why we need it**:
This addresses the data race present on the `t.stopped` variable in `tail.go`.

```
==================
WARNING: DATA RACE
Write at 0x00c00098b198 by goroutine 568:
  github.com/grafana/loki/pkg/querier.(*Tailer).close()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/querier/tail.go:272 +0x104
  github.com/grafana/loki/pkg/querier.TestTailer.func7.2()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/querier/tail_test.go:169 +0x34
  runtime.deferreturn()
      /opt/homebrew/Cellar/go/1.21.6/libexec/src/runtime/panic.go:477 +0x34
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.21.6/libexec/src/testing/testing.go:1595 +0x1b0
  testing.(*T).Run.func1()
      /opt/homebrew/Cellar/go/1.21.6/libexec/src/testing/testing.go:1648 +0x40

Previous read at 0x00c00098b198 by goroutine 569:
  github.com/grafana/loki/pkg/querier.(*Tailer).loop()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/querier/tail.go:88 +0x13c
  github.com/grafana/loki/pkg/querier.newTailer.func1()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/querier/tail.go:342 +0x34

Goroutine 568 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.21.6/libexec/src/testing/testing.go:1648 +0x5e8
  github.com/grafana/loki/pkg/querier.TestTailer()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/querier/tail_test.go:158 +0x10dc
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.21.6/libexec/src/testing/testing.go:1595 +0x1b0
  testing.(*T).Run.func1()
      /opt/homebrew/Cellar/go/1.21.6/libexec/src/testing/testing.go:1648 +0x40

Goroutine 569 (running) created at:
  github.com/grafana/loki/pkg/querier.newTailer()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/querier/tail.go:342 +0x300
  github.com/grafana/loki/pkg/querier.TestTailer.func7()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/querier/tail_test.go:168 +0x138
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.21.6/libexec/src/testing/testing.go:1595 +0x1b0
  testing.(*T).Run.func1()
      /opt/homebrew/Cellar/go/1.21.6/libexec/src/testing/testing.go:1648 +0x40
==================
```


**Which issue(s) this PR fixes**:
Relates to: https://github.com/grafana/loki/issues/8586

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
