### PR TITLE
Fixing broken links

### DIFF
--- a/docs/sources/release-notes/cadence.md
+++ b/docs/sources/release-notes/cadence.md
@@ -8,7 +8,7 @@ weight: 1
 
 ## Stable Releases
 
-Loki releases (this includes [Promtail](https://grafana.com/docs/loki/latest/send-data/promtail/), [Loki Canary](https://grafana.com/docs/loki/latest/operations/loki-canary/), etc) use the following
+Loki releases (this includes [Promtail](https://grafana.com/docs/loki/<LOKI_VERSION>/send-data/promtail/), [Loki Canary](https://grafana.com/docs/loki/<LOKI_VERSION>/operations/loki-canary/), etc) use the following
 naming scheme: `MAJOR`.`MINOR`.`PATCH`.
 
 - `MAJOR` (roughly once a year): these releases include large new features and possible backwards-compatibility breaks.
@@ -18,14 +18,14 @@ naming scheme: `MAJOR`.`MINOR`.`PATCH`.
 {{% admonition type="note" %}}
 While our naming scheme resembles [Semantic Versioning](https://semver.org/), at this time we do not strictly follow its
 guidelines to the letter. Our goal is to provide regular releases that are as stable as possible, and we take backwards-compatibility
-seriously. As with any software, always read the [release notes](https://grafana.com/docs/loki/latest/release-notes/) and the [upgrade guide](https://grafana.com/docs/loki/latest/setup/upgrade/) whenever
+seriously. As with any software, always read the [release notes](https://grafana.com/docs/loki/<LOKI_VERSION>/release-notes/) and the [upgrade guide](https://grafana.com/docs/loki/<LOKI_VERSION>/setup/upgrade/) whenever
 choosing a new version of Loki to install.
 {{% /admonition %}}
 
 New releases are based of a [weekly release](#weekly-releases) which we have vetted for stability over a number of weeks.
 
 We strongly recommend keeping up-to-date with patch releases as they are released. We post updates of new releases in the `#loki` channel
-of our [Slack community](https://grafana.com/docs/loki/latest/community/getting-in-touch/).
+of our [Slack community](https://grafana.com/docs/loki/<LOKI_VERSION>/community/getting-in-touch/).
 
 You can find all of our releases [on GitHub](https://github.com/grafana/loki/releases) and on [Docker Hub](https://hub.docker.com/r/grafana/loki).
 

--- a/docs/sources/release-notes/cadence.md
+++ b/docs/sources/release-notes/cadence.md
@@ -8,7 +8,7 @@ weight: 1
 
 ## Stable Releases
 
-Loki releases (this includes [Promtail](/clients/promtail), [Loki Canary](/operations/loki-canary/), etc) use the following
+Loki releases (this includes [Promtail](https://grafana.com/docs/loki/latest/send-data/promtail/), [Loki Canary](https://grafana.com/docs/loki/latest/operations/loki-canary/), etc) use the following
 naming scheme: `MAJOR`.`MINOR`.`PATCH`.
 
 - `MAJOR` (roughly once a year): these releases include large new features and possible backwards-compatibility breaks.
@@ -18,14 +18,14 @@ naming scheme: `MAJOR`.`MINOR`.`PATCH`.
 {{% admonition type="note" %}}
 While our naming scheme resembles [Semantic Versioning](https://semver.org/), at this time we do not strictly follow its
 guidelines to the letter. Our goal is to provide regular releases that are as stable as possible, and we take backwards-compatibility
-seriously. As with any software, always read the [release notes](/release-notes) and the [upgrade guide](/upgrading) whenever
+seriously. As with any software, always read the [release notes](https://grafana.com/docs/loki/latest/release-notes/) and the [upgrade guide](https://grafana.com/docs/loki/latest/setup/upgrade/) whenever
 choosing a new version of Loki to install.
 {{% /admonition %}}
 
 New releases are based of a [weekly release](#weekly-releases) which we have vetted for stability over a number of weeks.
 
 We strongly recommend keeping up-to-date with patch releases as they are released. We post updates of new releases in the `#loki` channel
-of our [Slack community](/community/getting-in-touch).
+of our [Slack community](https://grafana.com/docs/loki/latest/community/getting-in-touch/).
 
 You can find all of our releases [on GitHub](https://github.com/grafana/loki/releases) and on [Docker Hub](https://hub.docker.com/r/grafana/loki).
 

--- a/docs/sources/release-notes/cadence.md
+++ b/docs/sources/release-notes/cadence.md
@@ -8,7 +8,7 @@ weight: 1
 
 ## Stable Releases
 
-Loki releases (this includes [Promtail](https://grafana.com/docs/loki/<LOKI_VERSION>/send-data/promtail/), [Loki Canary](https://grafana.com/docs/loki/<LOKI_VERSION>/operations/loki-canary/), etc) use the following
+Loki releases (this includes [Promtail](https://grafana.com/docs/loki/<LOKI_VERSION>/send-data/promtail/), [Loki Canary](https://grafana.com/docs/loki/<LOKI_VERSION>/operations/loki-canary/), etc.) use the following
 naming scheme: `MAJOR`.`MINOR`.`PATCH`.
 
 - `MAJOR` (roughly once a year): these releases include large new features and possible backwards-compatibility breaks.


### PR DESCRIPTION
Replaces #11923.  For some reason I can't push updates to that PR, so opening a new one.

Which issue(s) this PR fixes:
Fixes broken links in https://grafana.com/docs/loki/latest/release-notes/cadence/
