### PR TITLE
Replace min/max token with `TokenRange` in bloom ring utilities

### DIFF
--- a/pkg/bloomcompactor/bloomcompactor.go
+++ b/pkg/bloomcompactor/bloomcompactor.go
@@ -2,6 +2,7 @@ package bloomcompactor
 
 import (
 	"context"
+	"math"
 	"sync"
 	"time"
 
@@ -201,11 +202,11 @@ func (c *Compactor) ownsTenant(tenant string) (v1.FingerprintBounds, bool, error
 
 	}
 
-	ownershipBounds, err := bloomutils.GetInstanceWithTokenRange(c.cfg.Ring.InstanceID, rs.Instances)
+	keyRange, err := bloomutils.KeyRangeForInstance(c.cfg.Ring.InstanceID, rs.Instances, bloomutils.Range[uint64]{Min: 0, Max: math.MaxUint64})
 	if err != nil {
 		return v1.FingerprintBounds{}, false, errors.Wrap(err, "getting instance token range")
 	}
-	return ownershipBounds, true, nil
+	return v1.NewBounds(model.Fingerprint(keyRange.Min), model.Fingerprint(keyRange.Max)), true, nil
 }
 
 // runs a single round of compaction for all relevant tenants and tables

--- a/pkg/bloomcompactor/bloomcompactor.go
+++ b/pkg/bloomcompactor/bloomcompactor.go
@@ -2,7 +2,6 @@ package bloomcompactor
 
 import (
 	"context"
-	"math"
 	"sync"
 	"time"
 

--- a/pkg/bloomcompactor/bloomcompactor.go
+++ b/pkg/bloomcompactor/bloomcompactor.go
@@ -202,7 +202,7 @@ func (c *Compactor) ownsTenant(tenant string) (v1.FingerprintBounds, bool, error
 
 	}
 
-	keyRange, err := bloomutils.KeyRangeForInstance(c.cfg.Ring.InstanceID, rs.Instances, bloomutils.Range[uint64]{Min: 0, Max: math.MaxUint64})
+	keyRange, err := bloomutils.KeyRangeForInstance(c.cfg.Ring.InstanceID, rs.Instances, bloomutils.Uint64Range)
 	if err != nil {
 		return v1.FingerprintBounds{}, false, errors.Wrap(err, "getting instance token range")
 	}

--- a/pkg/bloomgateway/client_test.go
+++ b/pkg/bloomgateway/client_test.go
@@ -19,6 +19,9 @@ import (
 	"github.com/grafana/loki/pkg/validation"
 )
 
+// short constructor
+var newTr = bloomutils.NewTokenRange
+
 func TestBloomGatewayClient(t *testing.T) {
 	logger := log.NewNopLogger()
 	reg := prometheus.NewRegistry()
@@ -53,10 +56,10 @@ func TestBloomGatewayClient_PartitionFingerprintsByAddresses(t *testing.T) {
 			{Fingerprint: 401}, // out of bounds, will be dismissed
 		}
 		servers := []addrsWithTokenRange{
-			{id: "instance-1", addrs: []string{"10.0.0.1"}, minToken: 0, maxToken: 100},
-			{id: "instance-2", addrs: []string{"10.0.0.2"}, minToken: 101, maxToken: 200},
-			{id: "instance-3", addrs: []string{"10.0.0.3"}, minToken: 201, maxToken: 300},
-			{id: "instance-2", addrs: []string{"10.0.0.2"}, minToken: 301, maxToken: 400},
+			{id: "instance-1", addrs: []string{"10.0.0.1"}, tokenRange: newTr(0, 100)},
+			{id: "instance-2", addrs: []string{"10.0.0.2"}, tokenRange: newTr(101, 200)},
+			{id: "instance-3", addrs: []string{"10.0.0.3"}, tokenRange: newTr(201, 300)},
+			{id: "instance-2", addrs: []string{"10.0.0.2"}, tokenRange: newTr(301, 400)},
 		}
 
 		// partition fingerprints
@@ -135,9 +138,9 @@ func TestBloomGatewayClient_PartitionFingerprintsByAddresses(t *testing.T) {
 			{Fingerprint: 350},
 		}
 		servers := []addrsWithTokenRange{
-			{id: "instance-1", addrs: []string{"10.0.0.1"}, minToken: 0, maxToken: 200},
-			{id: "instance-2", addrs: []string{"10.0.0.2"}, minToken: 100, maxToken: 300},
-			{id: "instance-3", addrs: []string{"10.0.0.3"}, minToken: 200, maxToken: 400},
+			{id: "instance-1", addrs: []string{"10.0.0.1"}, tokenRange: newTr(0, 200)},
+			{id: "instance-2", addrs: []string{"10.0.0.2"}, tokenRange: newTr(100, 300)},
+			{id: "instance-3", addrs: []string{"10.0.0.3"}, tokenRange: newTr(200, 400)},
 		}
 
 		// partition fingerprints
@@ -174,10 +177,10 @@ func TestBloomGatewayClient_ServerAddressesWithTokenRanges(t *testing.T) {
 				{Id: "instance-3", Addr: "10.0.0.3", Tokens: []uint32{math.MaxUint32 / 6 * 5}},
 			},
 			expected: []addrsWithTokenRange{
-				{id: "instance-1", addrs: []string{"10.0.0.1"}, minToken: 0, maxToken: math.MaxUint32 / 6 * 1},
-				{id: "instance-2", addrs: []string{"10.0.0.2"}, minToken: math.MaxUint32/6*1 + 1, maxToken: math.MaxUint32 / 6 * 3},
-				{id: "instance-3", addrs: []string{"10.0.0.3"}, minToken: math.MaxUint32/6*3 + 1, maxToken: math.MaxUint32 / 6 * 5},
-				{id: "instance-1", addrs: []string{"10.0.0.1"}, minToken: math.MaxUint32/6*5 + 1, maxToken: math.MaxUint32},
+				{id: "instance-1", addrs: []string{"10.0.0.1"}, tokenRange: newTr(0, math.MaxUint32/6*1)},
+				{id: "instance-2", addrs: []string{"10.0.0.2"}, tokenRange: newTr(math.MaxUint32/6*1+1, math.MaxUint32/6*3)},
+				{id: "instance-3", addrs: []string{"10.0.0.3"}, tokenRange: newTr(math.MaxUint32/6*3+1, math.MaxUint32/6*5)},
+				{id: "instance-1", addrs: []string{"10.0.0.1"}, tokenRange: newTr(math.MaxUint32/6*5+1, math.MaxUint32)},
 			},
 		},
 		"MinUint32 and MaxUint32 are tokens in the ring": {
@@ -186,10 +189,10 @@ func TestBloomGatewayClient_ServerAddressesWithTokenRanges(t *testing.T) {
 				{Id: "instance-2", Addr: "10.0.0.2", Tokens: []uint32{math.MaxUint32 / 3 * 1, math.MaxUint32}},
 			},
 			expected: []addrsWithTokenRange{
-				{id: "instance-1", addrs: []string{"10.0.0.1"}, minToken: 0, maxToken: 0},
-				{id: "instance-2", addrs: []string{"10.0.0.2"}, minToken: 1, maxToken: math.MaxUint32 / 3},
-				{id: "instance-1", addrs: []string{"10.0.0.1"}, minToken: math.MaxUint32/3*1 + 1, maxToken: math.MaxUint32 / 3 * 2},
-				{id: "instance-2", addrs: []string{"10.0.0.2"}, minToken: math.MaxUint32/3*2 + 1, maxToken: math.MaxUint32},
+				{id: "instance-1", addrs: []string{"10.0.0.1"}, tokenRange: newTr(0, 0)},
+				{id: "instance-2", addrs: []string{"10.0.0.2"}, tokenRange: newTr(1, math.MaxUint32/3)},
+				{id: "instance-1", addrs: []string{"10.0.0.1"}, tokenRange: newTr(math.MaxUint32/3*1+1, math.MaxUint32/3*2)},
+				{id: "instance-2", addrs: []string{"10.0.0.2"}, tokenRange: newTr(math.MaxUint32/3*2+1, math.MaxUint32)},
 			},
 		},
 	}
@@ -215,7 +218,7 @@ func TestBloomGatewayClient_GroupFingerprintsByServer(t *testing.T) {
 
 	it := bloomutils.NewInstanceSortMergeIterator(instances)
 	for it.Next() {
-		t.Log(it.At().MaxToken, it.At().Instance.Addr)
+		t.Log(it.At().TokenRange.Max, it.At().Instance.Addr)
 	}
 
 	testCases := []struct {
@@ -357,10 +360,10 @@ type mockRing struct {
 // Get implements ring.ReadRing.
 func (r *mockRing) Get(key uint32, _ ring.Operation, _ []ring.InstanceDesc, _ []string, _ []string) (ring.ReplicationSet, error) {
 	idx, _ := sort.Find(len(r.ranges), func(i int) int {
-		if r.ranges[i].MaxToken < key {
+		if r.ranges[i].TokenRange.Max < key {
 			return 1
 		}
-		if r.ranges[i].MaxToken > key {
+		if r.ranges[i].TokenRange.Max > key {
 			return -1
 		}
 		return 0

--- a/pkg/bloomutils/ring.go
+++ b/pkg/bloomutils/ring.go
@@ -9,16 +9,13 @@ import (
 
 	"github.com/grafana/dskit/ring"
 	"github.com/prometheus/common/model"
+	"golang.org/x/exp/constraints"
 	"golang.org/x/exp/slices"
 
 	v1 "github.com/grafana/loki/pkg/storage/bloom/v1"
 )
 
-type integer interface {
-	~uint | ~uint32 | ~uint64 | ~int | ~int32 | ~int64
-}
-
-type Range[T integer] struct {
+type Range[T constraints.Integer] struct {
 	Min, Max T
 }
 

--- a/pkg/bloomutils/ring.go
+++ b/pkg/bloomutils/ring.go
@@ -101,35 +101,6 @@ func GetInstanceWithTokenRange(id string, instances []ring.InstanceDesc) (v1.Fin
 	return v1.NewBounds(minToken, maxToken), nil
 }
 
-// GetInstancesWithTokenRanges calculates the token ranges for a specific
-// instance with given id based on all tokens in the ring.
-// If the instances in the ring are configured with a single token, such as the
-// bloom compactor, use GetInstanceWithTokenRange() instead.
-func GetInstancesWithTokenRanges(id string, instances []ring.InstanceDesc) InstancesWithTokenRange {
-	servers := make([]InstanceWithTokenRange, 0, len(instances))
-	it := NewInstanceSortMergeIterator(instances)
-	var firstInst ring.InstanceDesc
-	var lastToken uint32
-	for it.Next() {
-		if firstInst.Id == "" {
-			firstInst = it.At().Instance
-		}
-		if it.At().Instance.Id == id {
-			servers = append(servers, it.At())
-		}
-		lastToken = it.At().TokenRange.Max
-	}
-	// append token range from lastToken+1 to MaxUint32
-	// only if the instance with the first token is the current one
-	if len(servers) > 0 && firstInst.Id == id {
-		servers = append(servers, InstanceWithTokenRange{
-			Instance:   servers[0].Instance,
-			TokenRange: NewTokenRange(lastToken+1, math.MaxUint32),
-		})
-	}
-	return servers
-}
-
 // NewInstanceSortMergeIterator creates an iterator that yields instanceWithToken elements
 // where the token of the elements are sorted in ascending order.
 func NewInstanceSortMergeIterator(instances []ring.InstanceDesc) v1.Iterator[InstanceWithTokenRange] {

--- a/pkg/bloomutils/ring_test.go
+++ b/pkg/bloomutils/ring_test.go
@@ -11,22 +11,22 @@ import (
 )
 
 func TestBloomGatewayClient_SortInstancesByToken(t *testing.T) {
-	//          | 1  2  3  4  5  6  7  8  9  |
-	// ---------+----------------------------+
-	// ID 1     |             *           *  |
-	// ID 2     |       *           *        |
-	// ID 3     | *                          |
+	//          | 0 1 2 3 4 5 6 7 8 9 |
+	// ---------+---------------------+
+	// ID 1     |        ***o    ***o |
+	// ID 2     |    ***o    ***o     |
+	// ID 3     | **o                 |
 	input := []ring.InstanceDesc{
 		{Id: "1", Tokens: []uint32{5, 9}},
 		{Id: "2", Tokens: []uint32{3, 7}},
 		{Id: "3", Tokens: []uint32{1}},
 	}
 	expected := []InstanceWithTokenRange{
-		{Instance: input[2], MinToken: 0, MaxToken: 1},
-		{Instance: input[1], MinToken: 2, MaxToken: 3},
-		{Instance: input[0], MinToken: 4, MaxToken: 5},
-		{Instance: input[1], MinToken: 6, MaxToken: 7},
-		{Instance: input[0], MinToken: 8, MaxToken: 9},
+		{Instance: input[2], TokenRange: NewTokenRange(0, 1)},
+		{Instance: input[1], TokenRange: NewTokenRange(2, 3)},
+		{Instance: input[0], TokenRange: NewTokenRange(4, 5)},
+		{Instance: input[1], TokenRange: NewTokenRange(6, 7)},
+		{Instance: input[0], TokenRange: NewTokenRange(8, 9)},
 	}
 
 	var i int
@@ -46,8 +46,8 @@ func TestBloomGatewayClient_GetInstancesWithTokenRanges(t *testing.T) {
 			{Id: "3", Tokens: []uint32{1}},
 		}
 		expected := InstancesWithTokenRange{
-			{Instance: input[1], MinToken: 2, MaxToken: 3},
-			{Instance: input[1], MinToken: 6, MaxToken: 7},
+			{Instance: input[1], TokenRange: NewTokenRange(2, 3)},
+			{Instance: input[1], TokenRange: NewTokenRange(6, 7)},
 		}
 
 		result := GetInstancesWithTokenRanges("2", input)
@@ -61,8 +61,8 @@ func TestBloomGatewayClient_GetInstancesWithTokenRanges(t *testing.T) {
 			{Id: "3", Tokens: []uint32{1}},
 		}
 		expected := InstancesWithTokenRange{
-			{Instance: input[2], MinToken: 0, MaxToken: 1},
-			{Instance: input[2], MinToken: 10, MaxToken: math.MaxUint32},
+			{Instance: input[2], TokenRange: NewTokenRange(0, 1)},
+			{Instance: input[2], TokenRange: NewTokenRange(10, math.MaxUint32)},
 		}
 
 		result := GetInstancesWithTokenRanges("3", input)

--- a/pkg/bloomutils/ring_test.go
+++ b/pkg/bloomutils/ring_test.go
@@ -38,38 +38,6 @@ func TestBloomGatewayClient_SortInstancesByToken(t *testing.T) {
 	}
 }
 
-func TestBloomGatewayClient_GetInstancesWithTokenRanges(t *testing.T) {
-	t.Run("instance does not own first token in the ring", func(t *testing.T) {
-		input := []ring.InstanceDesc{
-			{Id: "1", Tokens: []uint32{5, 9}},
-			{Id: "2", Tokens: []uint32{3, 7}},
-			{Id: "3", Tokens: []uint32{1}},
-		}
-		expected := InstancesWithTokenRange{
-			{Instance: input[1], TokenRange: NewTokenRange(2, 3)},
-			{Instance: input[1], TokenRange: NewTokenRange(6, 7)},
-		}
-
-		result := GetInstancesWithTokenRanges("2", input)
-		require.Equal(t, expected, result)
-	})
-
-	t.Run("instance owns first token in the ring", func(t *testing.T) {
-		input := []ring.InstanceDesc{
-			{Id: "1", Tokens: []uint32{5, 9}},
-			{Id: "2", Tokens: []uint32{3, 7}},
-			{Id: "3", Tokens: []uint32{1}},
-		}
-		expected := InstancesWithTokenRange{
-			{Instance: input[2], TokenRange: NewTokenRange(0, 1)},
-			{Instance: input[2], TokenRange: NewTokenRange(10, math.MaxUint32)},
-		}
-
-		result := GetInstancesWithTokenRanges("3", input)
-		require.Equal(t, expected, result)
-	})
-}
-
 func TestBloomGatewayClient_GetInstanceWithTokenRange(t *testing.T) {
 	for name, tc := range map[string]struct {
 		id       string

--- a/pkg/bloomutils/ring_test.go
+++ b/pkg/bloomutils/ring_test.go
@@ -10,7 +10,7 @@ import (
 	v1 "github.com/grafana/loki/pkg/storage/bloom/v1"
 )
 
-func TestBloomGatewayClient_SortInstancesByToken(t *testing.T) {
+func TestBloomGatewayClient_InstanceSortMergeIterator(t *testing.T) {
 	//          | 0 1 2 3 4 5 6 7 8 9 |
 	// ---------+---------------------+
 	// ID 1     |        ***o    ***o |
@@ -38,7 +38,7 @@ func TestBloomGatewayClient_SortInstancesByToken(t *testing.T) {
 	}
 }
 
-func TestBloomGatewayClient_GetInstanceWithTokenRange(t *testing.T) {
+func TestBloomGatewayClient_KeyRangeForInstance(t *testing.T) {
 	for name, tc := range map[string]struct {
 		id       string
 		input    []ring.InstanceDesc
@@ -74,7 +74,7 @@ func TestBloomGatewayClient_GetInstanceWithTokenRange(t *testing.T) {
 	} {
 		tc := tc
 		t.Run(name, func(t *testing.T) {
-			result, err := GetInstanceWithTokenRange(tc.id, tc.input)
+			result, err := KeyRangeForInstance(tc.id, tc.input, Uint32Range)
 			require.NoError(t, err)
 			require.Equal(t, tc.expected, result)
 		})

--- a/pkg/bloomutils/ring_test.go
+++ b/pkg/bloomutils/ring_test.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/grafana/dskit/ring"
 	"github.com/stretchr/testify/require"
-
-	v1 "github.com/grafana/loki/pkg/storage/bloom/v1"
 )
 
 func TestBloomGatewayClient_InstanceSortMergeIterator(t *testing.T) {
@@ -38,11 +36,15 @@ func TestBloomGatewayClient_InstanceSortMergeIterator(t *testing.T) {
 	}
 }
 
+func uint64Range(min, max uint64) Range[uint64] {
+	return Range[uint64]{min, max}
+}
+
 func TestBloomGatewayClient_KeyRangeForInstance(t *testing.T) {
 	for name, tc := range map[string]struct {
 		id       string
 		input    []ring.InstanceDesc
-		expected v1.FingerprintBounds
+		expected Range[uint64]
 	}{
 		"first instance includes 0 token": {
 			id: "3",
@@ -51,7 +53,7 @@ func TestBloomGatewayClient_KeyRangeForInstance(t *testing.T) {
 				{Id: "2", Tokens: []uint32{5}},
 				{Id: "3", Tokens: []uint32{1}},
 			},
-			expected: v1.NewBounds(0, math.MaxUint64/3-1),
+			expected: uint64Range(0, math.MaxUint64/3-1),
 		},
 		"middle instance": {
 			id: "1",
@@ -60,7 +62,7 @@ func TestBloomGatewayClient_KeyRangeForInstance(t *testing.T) {
 				{Id: "2", Tokens: []uint32{5}},
 				{Id: "3", Tokens: []uint32{1}},
 			},
-			expected: v1.NewBounds(math.MaxUint64/3, math.MaxUint64/3*2-1),
+			expected: uint64Range(math.MaxUint64/3, math.MaxUint64/3*2-1),
 		},
 		"last instance includes MaxUint32 token": {
 			id: "2",
@@ -69,12 +71,12 @@ func TestBloomGatewayClient_KeyRangeForInstance(t *testing.T) {
 				{Id: "2", Tokens: []uint32{5}},
 				{Id: "3", Tokens: []uint32{1}},
 			},
-			expected: v1.NewBounds(math.MaxUint64/3*2, math.MaxUint64),
+			expected: uint64Range(math.MaxUint64/3*2, math.MaxUint64),
 		},
 	} {
 		tc := tc
 		t.Run(name, func(t *testing.T) {
-			result, err := KeyRangeForInstance(tc.id, tc.input, Uint32Range)
+			result, err := KeyRangeForInstance(tc.id, tc.input, Uint64Range)
 			require.NoError(t, err)
 			require.Equal(t, tc.expected, result)
 		})


### PR DESCRIPTION
This PR replaces min/max token fields with a `TokenRange` field that uses the `Range[uint32]` type.
The `Range[uint32]` uses similar semantics as the `FingerprintBounds` we use for fingerprint ranges.