### PR TITLE
Helm: fix ciliumNetworkPolicy template in the chart

### DIFF
--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -14,6 +14,10 @@ Entries should include a reference to the pull request that introduced the chang
 [//]: # (<AUTOMATED_UPDATES_LOCATOR> : do not remove this line. This locator is used by the CI pipeline to automatically create a changelog entry for each new Loki release. Add other chart versions and respective changelog entries bellow this line.)
 
 
+## 5.43.1
+
+- [BUGFIX] Fix `toPorts` fields in the `ciliumnetworkpolicy` template
+
 ## 5.43.0
 
 - [ENHANCEMENT] Allow the definition of resources for GrafanaAgent pods

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -3,7 +3,7 @@ name: loki
 description: Helm chart for Grafana Loki in simple, scalable mode
 type: application
 appVersion: 2.9.4
-version: 5.43.0
+version: 5.43.1
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -1,6 +1,6 @@
 # loki
 
-![Version: 5.43.0](https://img.shields.io/badge/Version-5.43.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.9.4](https://img.shields.io/badge/AppVersion-2.9.4-informational?style=flat-square)
+![Version: 5.43.1](https://img.shields.io/badge/Version-5.43.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.9.4](https://img.shields.io/badge/AppVersion-2.9.4-informational?style=flat-square)
 
 Helm chart for Grafana Loki in simple, scalable mode
 

--- a/production/helm/loki/templates/ciliumnetworkpolicy.yaml
+++ b/production/helm/loki/templates/ciliumnetworkpolicy.yaml
@@ -60,8 +60,9 @@ spec:
       {{- include "loki.selectorLabels" . | nindent 6 }}
   ingress:
   - toPorts:
-    - port: http
-      protocol: TCP
+    - ports: 
+      - port: http
+        protocol: TCP
   {{- if .Values.networkPolicy.ingress.namespaceSelector }}
     fromEndpoints:
     - matchLabels:
@@ -85,8 +86,9 @@ spec:
       {{- include "loki.selectorLabels" . | nindent 6 }}
   ingress:
   - toPorts:
-    - port: http-metrics
-      protocol: TCP
+    - ports: 
+      - port: http-metrics
+        protocol: TCP
   {{- if .Values.networkPolicy.metrics.cidrs }}
     {{- range $cidr := .Values.networkPolicy.metrics.cidrs }}
     toCIDR:
@@ -116,8 +118,9 @@ spec:
       {{- include "loki.backendSelectorLabels" . | nindent 6 }}
   egress:
   - toPorts:
-    - port: {{ .Values.networkPolicy.alertmanager.port }}
-      protocol: TCP
+    - ports: 
+      - port: "{{ .Values.networkPolicy.alertmanager.port }}"
+        protocol: TCP
   {{- if .Values.networkPolicy.alertmanager.namespaceSelector }}
     toEndpoints:
     - matchLabels:
@@ -142,10 +145,11 @@ spec:
       {{- include "loki.selectorLabels" . | nindent 6 }}
   egress:
   - toPorts:
-    {{- range $port := .Values.networkPolicy.externalStorage.ports }}
-    - port: {{ $port }}
-      protocol: TCP
-    {{- end }}
+    - ports:
+      {{- range $port := .Values.networkPolicy.externalStorage.ports }} 
+      - port: "{{ $port }}"
+        protocol: TCP
+      {{- end }}à
   {{- if .Values.networkPolicy.externalStorage.cidrs }}
     {{- range $cidr := .Values.networkPolicy.externalStorage.cidrs }}
     toCIDR:
@@ -171,8 +175,9 @@ spec:
       {{- include "loki.selectorLabels" . | nindent 6 }}
   egress:
   - toPorts:
-    - port: {{ .Values.networkPolicy.discovery.port }}
-      protocol: TCP
+    - ports: 
+      - port: "{{ .Values.networkPolicy.discovery.port }}"
+        protocol: TCP
   {{- if .Values.networkPolicy.discovery.namespaceSelector }}
     toEndpoints:
     - matchLabels:


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes the `ciliumnetworkpolicy` template file in the chart because in its current state, the ciliumNetworkPolicies are wrong. The `toPorts` field was not written properly and this was leading to network issues when deployed.

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
