### PR TITLE
(Blooms) Add metrics to compactor

### DIFF
--- a/pkg/storage/bloom/v1/util.go
+++ b/pkg/storage/bloom/v1/util.go
@@ -276,3 +276,29 @@ func NewPeekCloseIter[T any](itr CloseableIterator[T]) *PeekCloseIter[T] {
 func (it *PeekCloseIter[T]) Close() error {
 	return it.close()
 }
+
+type CounterIterator[T any] interface {
+	Iterator[T]
+	Count() int
+}
+
+type CounterIter[T any] struct {
+	Iterator[T] // the underlying iterator
+	count       int
+}
+
+func NewCounterIter[T any](itr Iterator[T]) *CounterIter[T] {
+	return &CounterIter[T]{Iterator: itr}
+}
+
+func (it *CounterIter[T]) Next() bool {
+	if it.Iterator.Next() {
+		it.count++
+		return true
+	}
+	return false
+}
+
+func (it *CounterIter[T]) Count() int {
+	return it.count
+}

--- a/pkg/storage/bloom/v1/util_test.go
+++ b/pkg/storage/bloom/v1/util_test.go
@@ -26,3 +26,29 @@ func TestPeekingIterator(t *testing.T) {
 	require.False(t, itr.Next())
 
 }
+
+func TestCounterIter(t *testing.T) {
+	t.Parallel()
+
+	data := []int{1, 2, 3, 4, 5}
+	itr := NewCounterIter[int](NewSliceIter[int](data))
+	peekItr := NewPeekingIter[int](itr)
+
+	// Consume the outer iter and use peek
+	for {
+		if _, ok := peekItr.Peek(); !ok {
+			break
+		}
+		if !peekItr.Next() {
+			break
+		}
+	}
+	// Both iterators should be exhausted
+	require.False(t, itr.Next())
+	require.Nil(t, itr.Err())
+	require.False(t, peekItr.Next())
+	require.Nil(t, peekItr.Err())
+
+	// Assert that the count is correct and peeking hasn't jeopardized the count
+	require.Equal(t, len(data), itr.Count())
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds new metrics to the bloom-compactor:
- `loki_bloomcompactor_compactions_started`: Total number of compactions started
- `loki_bloomcompactor_compactions_completed`: Total number of compactions completed. With `status` (`success`, `failure`).
- `loki_bloomcompactor_compactions_time_seconds`: Time spent during a compaction cycle. With `status` (`success`, `failure`).
- `loki_bloomcompactor_tenants_discovered`: Number of tenants discovered during the current compaction run.
- `loki_bloomcompactor_tenants_skipped`: Number of tenants owned by this instance.
- `loki_bloomcompactor_tenants_skipped`: Number of tenants skipped since they are not owned by this instance.
- `loki_bloomcompactor_tenants_started`: Number of tenants started to process during the current compaction run.
- `loki_bloomcompactor_tenants_completed`: Number of tenants successfully processed during the current compaction run. With `status` (`success`, `failure`).
- `loki_bloomcompactor_tenants_time_seconds`: Time spent processing tenants.
- `loki_bloomcompactor_tenants_series`: Number of series processed per tenant in the owned fingerprint-range.

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
