### PR TITLE
(chore) Bloom gateway: Improve fingerprint partitioning in client

### DIFF
--- a/pkg/bloomgateway/client.go
+++ b/pkg/bloomgateway/client.go
@@ -326,11 +326,6 @@ func serverAddressesWithTokenRanges(subRing ring.ReadRing, instances []ring.Inst
 	return servers, nil
 }
 
-type instanceWithToken struct {
-	instance ring.InstanceDesc
-	token    uint32
-}
-
 type addrsWithTokenRange struct {
 	id         string
 	addrs      []string

--- a/pkg/bloomgateway/client.go
+++ b/pkg/bloomgateway/client.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"math"
 	"math/rand"
-	"sort"
 	"sync"
 
 	"github.com/go-kit/log"
@@ -20,6 +19,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/common/model"
+	"golang.org/x/exp/slices"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health/grpc_health_v1"
 
@@ -343,13 +343,22 @@ type instanceWithFingerprints struct {
 
 func partitionFingerprintsByAddresses(fingerprints []*logproto.GroupedChunkRefs, addresses []addrsWithTokenRange) (result []instanceWithFingerprints) {
 	for _, instance := range addresses {
-
-		min := sort.Search(len(fingerprints), func(i int) bool {
-			return instance.cmp(uint32(fingerprints[i].Fingerprint)) > v1.Before
+		min, _ := slices.BinarySearchFunc(fingerprints, instance.tokenRange, func(g *logproto.GroupedChunkRefs, r bloomutils.Range[uint32]) int {
+			if uint32(g.Fingerprint) < r.Min {
+				return -1
+			} else if uint32(g.Fingerprint) > r.Min {
+				return 1
+			}
+			return 0
 		})
 
-		max := sort.Search(len(fingerprints), func(i int) bool {
-			return instance.cmp(uint32(fingerprints[i].Fingerprint)) == v1.After
+		max, _ := slices.BinarySearchFunc(fingerprints, instance.tokenRange, func(g *logproto.GroupedChunkRefs, r bloomutils.Range[uint32]) int {
+			if uint32(g.Fingerprint) <= r.Max {
+				return -1
+			} else if uint32(g.Fingerprint) > r.Max {
+				return 1
+			}
+			return 0
 		})
 
 		// fingerprint is out of boundaries

--- a/pkg/bloomutils/ring.go
+++ b/pkg/bloomutils/ring.go
@@ -20,7 +20,7 @@ var (
 	Uint64Range = Range[uint64]{Min: 0, Max: math.MaxUint64}
 )
 
-type Range[T constraints.Integer] struct {
+type Range[T constraints.Unsigned] struct {
 	Min, Max T
 }
 
@@ -72,7 +72,7 @@ func (i InstancesWithTokenRange) Contains(token uint32) bool {
 // with given id based on the first token in the ring.
 // This assumes that each instance in the ring is configured with only a single
 // token.
-func KeyRangeForInstance[T constraints.Integer](id string, instances []ring.InstanceDesc, keyspace Range[T]) (Range[T], error) {
+func KeyRangeForInstance[T constraints.Unsigned](id string, instances []ring.InstanceDesc, keyspace Range[T]) (Range[T], error) {
 
 	// Sort instances -- they may not be sorted
 	// because they're usually accessed by looking up the tokens (which are sorted)


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR re-implements the fingerprint partitioning on the bloom gateway client using `slices.BinarySearchFunc`.

Benchmark results from `sort.Search` (old) vs. `slices.BinarySearchFunc` (new):

```
$ benchstat old.txt new.txt
goos: linux
goarch: amd64
pkg: github.com/grafana/loki/pkg/bloomgateway
cpu: 11th Gen Intel(R) Core(TM) i7-1185G7 @ 3.00GHz
                                   │   old.txt    │              new.txt               │
                                   │    sec/op    │   sec/op     vs base               │
PartitionFingerprintsByAddresses-8   18.75µ ± 70%   16.94µ ± 2%  -9.68% (p=0.000 n=10)

                                   │   old.txt    │             new.txt              │
                                   │     B/op     │     B/op      vs base            │
PartitionFingerprintsByAddresses-8   18.69Ki ± 0%   18.69Ki ± 0%  ~ (p=1.000 n=10) ¹
¹ all samples are equal

                                   │  old.txt   │            new.txt             │
                                   │ allocs/op  │ allocs/op   vs base            │
PartitionFingerprintsByAddresses-8   8.000 ± 0%   8.000 ± 0%  ~ (p=1.000 n=10) ¹
¹ all samples are equal
```