### PR TITLE
correctly set block iter when no overlapping blocks are found

### DIFF
--- a/pkg/bloomcompactor/batch.go
+++ b/pkg/bloomcompactor/batch.go
@@ -285,6 +285,7 @@ func (i *blockLoadingIter) Filter(filter func(*bloomshipper.CloseableBlockQuerie
 func (i *blockLoadingIter) loadNext() bool {
 	// check if there are more overlapping groups to load
 	if !i.overlapping.Next() {
+		i.iter = v1.NewEmptyIter[*v1.SeriesWithBloom]()
 		return false
 	}
 


### PR DESCRIPTION
previously would panic when the previous block list was nil (first iteration)