### PR TITLE
Map ring token keyspace (uint32) into fingerprint keyspace (uint64)

### DIFF
--- a/pkg/bloomgateway/client.go
+++ b/pkg/bloomgateway/client.go
@@ -329,6 +329,7 @@ func serverAddressesWithTokenRanges(subRing ring.ReadRing, instances []ring.Inst
 
 	if len(servers) > 0 && servers[len(servers)-1].Max < math.MaxUint64 {
 		// append the instance for the range between the maxFp and MaxUint64
+		// TODO(owen-d): support wrapping around keyspace for token ranges
 		servers = append(servers, addrsWithBounds{
 			id:    servers[0].id,
 			addrs: servers[0].addrs,

--- a/pkg/bloomgateway/client.go
+++ b/pkg/bloomgateway/client.go
@@ -35,9 +35,9 @@ import (
 	"github.com/grafana/loki/pkg/util/constants"
 )
 
-// Number of bits to shift to the left to tranform a token value from the ring
+// Number of bits to shift to the left to transform a token value from the ring
 // (uint32) into a value in the keyspace of fingerprints (uint64).
-const uint32_uint64 = 32
+const bitsTokenToFingerprint = 32
 
 var (
 	// BlocksOwnerRead is the operation used to check the authoritative owners of a block
@@ -323,7 +323,7 @@ func serverAddressesWithTokenRanges(subRing ring.ReadRing, instances []ring.Inst
 			return nil, errors.Wrap(err, "bloom gateway get ring")
 		}
 
-		bounds := mapTokenRangeToFingerprintRange(it.At().TokenRange, uint32_uint64)
+		bounds := mapTokenRangeToFingerprintRange(it.At().TokenRange, bitsTokenToFingerprint)
 		servers = append(servers, addrsWithBounds{
 			id:                it.At().Instance.Id,
 			addrs:             rs.GetAddresses(),
@@ -332,12 +332,12 @@ func serverAddressesWithTokenRanges(subRing ring.ReadRing, instances []ring.Inst
 	}
 
 	if len(servers) > 0 && servers[len(servers)-1].Max < math.MaxUint64 {
-		// append the instance for the token range between the greates token and MaxUint64
+		// append the instance for the range between the maxFp and MaxUint64
 		servers = append(servers, addrsWithBounds{
 			id:    servers[0].id,
 			addrs: servers[0].addrs,
 			FingerprintBounds: v1.NewBounds(
-				model.Fingerprint(servers[len(servers)-1].Max+1),
+				servers[len(servers)-1].Max+1,
 				model.Fingerprint(math.MaxUint64),
 			),
 		})

--- a/pkg/bloomgateway/client_test.go
+++ b/pkg/bloomgateway/client_test.go
@@ -181,8 +181,8 @@ func BenchmarkPartitionFingerprintsByAddresses(b *testing.B) {
 			id:    fmt.Sprintf("instance-%x", i),
 			addrs: []string{fmt.Sprintf("%d", i)},
 			FingerprintBounds: v1.NewBounds(
-				model.Fingerprint(i)<<uint32_uint64,
-				model.Fingerprint(i+tokenStep)<<uint32_uint64,
+				model.Fingerprint(i)<<bitsTokenToFingerprint,
+				model.Fingerprint(i+tokenStep)<<bitsTokenToFingerprint,
 			),
 		})
 	}

--- a/pkg/bloomutils/ring.go
+++ b/pkg/bloomutils/ring.go
@@ -44,8 +44,12 @@ func (r Range[T]) Cmp(t T) v1.BoundsCheck {
 	return v1.Overlap
 }
 
+func NewRange[T constraints.Unsigned](min, max T) Range[T] {
+	return Range[T]{Min: min, Max: max}
+}
+
 func NewTokenRange(min, max uint32) Range[uint32] {
-	return Range[uint32]{min, max}
+	return Range[uint32]{Min: min, Max: max}
 }
 
 type InstanceWithTokenRange struct {


### PR DESCRIPTION
**What this PR does / why we need it**:

In order to compare the keyspace from the bloom gateway's ring with the fingerprints, they need to use the same keyspace.

The ring, however, uses tokens within a `uint32` keyspace, whereas the fingerprints use a `uint64` keyspace.
Therefore the ranges from the ring tokens need to be mapped into the `uint64` keyspace. This is done bit-shifting the Min value 32 bits to the left and the Max value 32 bits to the left plus adding `(1<<32)-1` to "fill" the remaining values up to the next Min value.

The structs used to combined ring instance information and token/fingerprint ranges are yet to be simplified. However, this is not goal of this PR.