### PR TITLE
Use TSDB index prefix on blooms directory

### DIFF
--- a/pkg/bloomcompactor/bloomcompactor.go
+++ b/pkg/bloomcompactor/bloomcompactor.go
@@ -342,7 +342,7 @@ type dayRangeIterator struct {
 }
 
 func newDayRangeIterator(min, max config.DayTime, schemaCfg config.SchemaConfig) *dayRangeIterator {
-	return &dayRangeIterator{min: min, max: max, cur: min.Dec()}
+	return &dayRangeIterator{min: min, max: max, cur: min.Dec(), schemaCfg: schemaCfg}
 }
 
 func (r *dayRangeIterator) Next() bool {

--- a/pkg/bloomcompactor/tsdb.go
+++ b/pkg/bloomcompactor/tsdb.go
@@ -26,12 +26,11 @@ const (
 )
 
 type TSDBStore interface {
-	UsersForPeriod(ctx context.Context, table config.DayTime, period config.PeriodConfig) ([]string, error)
-	ResolveTSDBs(ctx context.Context, table config.DayTime, period config.PeriodConfig, tenant string) ([]tsdb.SingleTenantTSDBIdentifier, error)
+	UsersForPeriod(ctx context.Context, table config.DayTable) ([]string, error)
+	ResolveTSDBs(ctx context.Context, table config.DayTable, tenant string) ([]tsdb.SingleTenantTSDBIdentifier, error)
 	LoadTSDB(
 		ctx context.Context,
-		table config.DayTime,
-		period config.PeriodConfig,
+		table config.DayTable,
 		tenant string,
 		id tsdb.Identifier,
 		bounds v1.FingerprintBounds,
@@ -50,13 +49,13 @@ func NewBloomTSDBStore(storage storage.Client) *BloomTSDBStore {
 	}
 }
 
-func (b *BloomTSDBStore) UsersForPeriod(ctx context.Context, table config.DayTime, period config.PeriodConfig) ([]string, error) {
-	_, users, err := b.storage.ListFiles(ctx, table.AddrWithPreffix(&period), true) // bypass cache for ease of testing
+func (b *BloomTSDBStore) UsersForPeriod(ctx context.Context, table config.DayTable) ([]string, error) {
+	_, users, err := b.storage.ListFiles(ctx, table.Addr(), true) // bypass cache for ease of testing
 	return users, err
 }
 
-func (b *BloomTSDBStore) ResolveTSDBs(ctx context.Context, table config.DayTime, period config.PeriodConfig, tenant string) ([]tsdb.SingleTenantTSDBIdentifier, error) {
-	indices, err := b.storage.ListUserFiles(ctx, table.AddrWithPreffix(&period), tenant, true) // bypass cache for ease of testing
+func (b *BloomTSDBStore) ResolveTSDBs(ctx context.Context, table config.DayTable, tenant string) ([]tsdb.SingleTenantTSDBIdentifier, error) {
+	indices, err := b.storage.ListUserFiles(ctx, table.Addr(), tenant, true) // bypass cache for ease of testing
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to list user files")
 	}
@@ -81,15 +80,14 @@ func (b *BloomTSDBStore) ResolveTSDBs(ctx context.Context, table config.DayTime,
 
 func (b *BloomTSDBStore) LoadTSDB(
 	ctx context.Context,
-	table config.DayTime,
-	period config.PeriodConfig,
+	table config.DayTable,
 	tenant string,
 	id tsdb.Identifier,
 	bounds v1.FingerprintBounds,
 ) (v1.CloseableIterator[*v1.Series], error) {
 	withCompression := id.Name() + gzipExtension
 
-	data, err := b.storage.GetUserFile(ctx, table.AddrWithPreffix(&period), tenant, withCompression)
+	data, err := b.storage.GetUserFile(ctx, table.Addr(), tenant, withCompression)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get file")
 	}
@@ -274,36 +272,35 @@ func (s *TSDBStores) storeForPeriod(table config.DayTime) (TSDBStore, error) {
 	)
 }
 
-func (s *TSDBStores) UsersForPeriod(ctx context.Context, table config.DayTime, period config.PeriodConfig) ([]string, error) {
-	store, err := s.storeForPeriod(table)
+func (s *TSDBStores) UsersForPeriod(ctx context.Context, table config.DayTable) ([]string, error) {
+	store, err := s.storeForPeriod(table.DayTime)
 	if err != nil {
 		return nil, err
 	}
 
-	return store.UsersForPeriod(ctx, table, period)
+	return store.UsersForPeriod(ctx, table)
 }
 
-func (s *TSDBStores) ResolveTSDBs(ctx context.Context, table config.DayTime, period config.PeriodConfig, tenant string) ([]tsdb.SingleTenantTSDBIdentifier, error) {
-	store, err := s.storeForPeriod(table)
+func (s *TSDBStores) ResolveTSDBs(ctx context.Context, table config.DayTable, tenant string) ([]tsdb.SingleTenantTSDBIdentifier, error) {
+	store, err := s.storeForPeriod(table.DayTime)
 	if err != nil {
 		return nil, err
 	}
 
-	return store.ResolveTSDBs(ctx, table, period, tenant)
+	return store.ResolveTSDBs(ctx, table, tenant)
 }
 
 func (s *TSDBStores) LoadTSDB(
 	ctx context.Context,
-	table config.DayTime,
-	period config.PeriodConfig,
+	table config.DayTable,
 	tenant string,
 	id tsdb.Identifier,
 	bounds v1.FingerprintBounds,
 ) (v1.CloseableIterator[*v1.Series], error) {
-	store, err := s.storeForPeriod(table)
+	store, err := s.storeForPeriod(table.DayTime)
 	if err != nil {
 		return nil, err
 	}
 
-	return store.LoadTSDB(ctx, table, period, tenant, id, bounds)
+	return store.LoadTSDB(ctx, table, tenant, id, bounds)
 }

--- a/pkg/bloomgateway/util_test.go
+++ b/pkg/bloomgateway/util_test.go
@@ -311,7 +311,7 @@ func createBlocks(t *testing.T, tenant string, n int, from, through model.Time, 
 		}
 		ref := bloomshipper.Ref{
 			TenantID:       tenant,
-			TableName:      config.NewDayTime(truncateDay(from)).Addr(),
+			TableName:      config.NewDayTable(config.NewDayTime(truncateDay(from)), "").Addr(),
 			Bounds:         v1.NewBounds(fromFp, throughFp),
 			StartTimestamp: from,
 			EndTimestamp:   through,

--- a/pkg/storage/config/schema_config.go
+++ b/pkg/storage/config/schema_config.go
@@ -201,7 +201,7 @@ func (cfg *PeriodConfig) GetIndexTableNumberRange(schemaEndDate DayTime) TableRa
 }
 
 func (cfg *PeriodConfig) GetFullTableName(t model.Time) string {
-	return NewDayTime(t).TableWithPrefix(cfg)
+	return NewDayTime(t).AddrWithPreffix(cfg)
 }
 
 func NewDayTime(d model.Time) DayTime {
@@ -244,7 +244,7 @@ func (d DayTime) Addr() string {
 		d.ModelTime().Time().UnixNano()/int64(ObjectStorageIndexRequiredPeriod))
 }
 
-func (d DayTime) TableWithPrefix(cfg *PeriodConfig) string {
+func (d DayTime) AddrWithPreffix(cfg *PeriodConfig) string {
 	return fmt.Sprintf("%s%d",
 		cfg.IndexTables.Prefix,
 		d.ModelTime().Time().UnixNano()/int64(ObjectStorageIndexRequiredPeriod))

--- a/pkg/storage/config/schema_config.go
+++ b/pkg/storage/config/schema_config.go
@@ -262,6 +262,10 @@ type DayTable struct {
 	Prefix string
 }
 
+func (d DayTable) String() string {
+	return d.Addr()
+}
+
 func NewDayTable(d DayTime, prefix string) DayTable {
 	return DayTable{
 		DayTime: d,

--- a/pkg/storage/config/schema_config.go
+++ b/pkg/storage/config/schema_config.go
@@ -200,10 +200,6 @@ func (cfg *PeriodConfig) GetIndexTableNumberRange(schemaEndDate DayTime) TableRa
 	}
 }
 
-func (cfg *PeriodConfig) GetFullTableName(t model.Time) string {
-	return NewDayTime(t).AddrWithPreffix(cfg)
-}
-
 func NewDayTime(d model.Time) DayTime {
 	return DayTime{d}
 }
@@ -237,19 +233,6 @@ func (d DayTime) String() string {
 	return d.Time.Time().UTC().Format("2006-01-02")
 }
 
-// Addr returns the unix day offset as a string, which is used
-// as the address for the index table in storage.
-func (d DayTime) Addr() string {
-	return fmt.Sprintf("%d",
-		d.ModelTime().Time().UnixNano()/int64(ObjectStorageIndexRequiredPeriod))
-}
-
-func (d DayTime) AddrWithPreffix(cfg *PeriodConfig) string {
-	return fmt.Sprintf("%s%d",
-		cfg.IndexTables.Prefix,
-		d.ModelTime().Time().UnixNano()/int64(ObjectStorageIndexRequiredPeriod))
-}
-
 func (d DayTime) Inc() DayTime {
 	return DayTime{d.Add(ObjectStorageIndexRequiredPeriod)}
 }
@@ -272,6 +255,26 @@ func (d DayTime) ModelTime() model.Time {
 
 func (d DayTime) Bounds() (model.Time, model.Time) {
 	return d.Time, d.Inc().Time
+}
+
+type DayTable struct {
+	DayTime
+	Prefix string
+}
+
+func NewDayTable(d DayTime, prefix string) DayTable {
+	return DayTable{
+		DayTime: d,
+		Prefix:  prefix,
+	}
+}
+
+// Addr returns the prefix (if any) and the unix day offset as a string, which is used
+// as the address for the index table in storage.
+func (d DayTable) Addr() string {
+	return fmt.Sprintf("%s%d",
+		d.Prefix,
+		d.ModelTime().Time().UnixNano()/int64(ObjectStorageIndexRequiredPeriod))
 }
 
 // SchemaConfig contains the config for our chunk index schemas


### PR DESCRIPTION
**What this PR does / why we need it**:
Before this PR, bloom blocks and metas were written to `bloom/<day>/<tenant>...`, but the gateway expects it to be at `bloom/<index prefix>_<day>/<tenant>`. This PR adds the index prefix to the path. 

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
