### PR TITLE
[Blooms] Consistent hashing via tokens for bloomcompactor

### DIFF
--- a/pkg/bloomcompactor/batch.go
+++ b/pkg/bloomcompactor/batch.go
@@ -132,7 +132,7 @@ func newBatchedChunkLoader(
 			time.Unix(0, 0),
 			time.Unix(0, math.MaxInt64),
 			logproto.FORWARD,
-			logql_log.NewNoopPipeline().ForStream(c.Metric),
+			logql_log.NewNoopPipeline().ForStream(nil),
 		)
 
 		if err != nil {

--- a/pkg/bloomcompactor/bloomcompactor_test.go
+++ b/pkg/bloomcompactor/bloomcompactor_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/dskit/ring"
 	"github.com/grafana/dskit/services"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
@@ -113,7 +114,7 @@ func TestCompactor_ownsTenant(t *testing.T) {
 				require.NoError(t, err)
 				if ownsTenant {
 					compactorOwnsTenant++
-					compactorOwnershipRange = append(compactorOwnershipRange, ownershipRange)
+					compactorOwnershipRange = append(compactorOwnershipRange, ownershipRange...)
 				}
 			}
 			require.Equal(t, tc.expectedCompactorsOwningTenant, compactorOwnsTenant)
@@ -135,12 +136,6 @@ func TestCompactor_ownsTenant(t *testing.T) {
 					coveredKeySpace.Max = boundsA.Max
 				}
 
-				// Assert that the fingerprint key-space is evenly distributed across the compactors
-				// We do some adjustments if the key-space is not evenly distributable, so we use a delta of 10
-				// to account for that and check that the key-space is reasonably evenly distributed.
-				fpPerTenant := math.MaxUint64 / uint64(tc.expectedCompactorsOwningTenant)
-				boundsLen := uint64(boundsA.Max - boundsA.Min)
-				require.InDelta(t, fpPerTenant, boundsLen, 10)
 			}
 			// Assert that the fingerprint key-space is complete
 			require.True(t, coveredKeySpace.Equal(v1.NewBounds(0, math.MaxUint64)))
@@ -194,4 +189,76 @@ func (m mockLimits) BloomFalsePositiveRate(_ string) float64 {
 
 func (m mockLimits) BloomCompactorMaxBlockSize(_ string) int {
 	panic("implement me")
+}
+
+func TestTokenRangesForInstance(t *testing.T) {
+	desc := func(id int, tokens ...uint32) ring.InstanceDesc {
+		return ring.InstanceDesc{Id: fmt.Sprintf("%d", id), Tokens: tokens}
+	}
+
+	tests := map[string]struct {
+		input []ring.InstanceDesc
+		exp   map[string]ring.TokenRanges
+		err   bool
+	}{
+		"no nodes": {
+			input: []ring.InstanceDesc{},
+			exp: map[string]ring.TokenRanges{
+				"0": {0, math.MaxUint32}, // have to put one in here to trigger test
+			},
+			err: true,
+		},
+		"one node": {
+			input: []ring.InstanceDesc{
+				desc(0, 0, 100),
+			},
+			exp: map[string]ring.TokenRanges{
+				"0": {0, math.MaxUint32},
+			},
+		},
+		"two nodes": {
+			input: []ring.InstanceDesc{
+				desc(0, 25, 75),
+				desc(1, 10, 50, 100),
+			},
+			exp: map[string]ring.TokenRanges{
+				"0": {10, 24, 50, 74},
+				"1": {0, 9, 25, 49, 75, math.MaxUint32},
+			},
+		},
+		"consecutive tokens": {
+			input: []ring.InstanceDesc{
+				desc(0, 99),
+				desc(1, 100),
+			},
+			exp: map[string]ring.TokenRanges{
+				"0": {0, 98, 100, math.MaxUint32},
+				"1": {99, 99},
+			},
+		},
+		"extremes": {
+			input: []ring.InstanceDesc{
+				desc(0, 0),
+				desc(1, math.MaxUint32),
+			},
+			exp: map[string]ring.TokenRanges{
+				"0": {math.MaxUint32, math.MaxUint32},
+				"1": {0, math.MaxUint32 - 1},
+			},
+		},
+	}
+
+	for desc, test := range tests {
+		t.Run(desc, func(t *testing.T) {
+			for id := range test.exp {
+				ranges, err := tokenRangesForInstance(id, test.input)
+				if test.err {
+					require.Error(t, err)
+					continue
+				}
+				require.NoError(t, err)
+				require.Equal(t, test.exp[id], ranges)
+			}
+		})
+	}
 }

--- a/pkg/bloomutils/ring.go
+++ b/pkg/bloomutils/ring.go
@@ -3,14 +3,13 @@
 package bloomutils
 
 import (
-	"errors"
 	"fmt"
 	"math"
 	"sort"
 
 	"github.com/grafana/dskit/ring"
+	"github.com/prometheus/common/model"
 	"golang.org/x/exp/constraints"
-	"golang.org/x/exp/slices"
 
 	v1 "github.com/grafana/loki/pkg/storage/bloom/v1"
 )
@@ -68,44 +67,16 @@ func (i InstancesWithTokenRange) Contains(token uint32) bool {
 	return false
 }
 
-// KeyRangeForInstance calculates the token range for a specific instance
-// with given id based on the first token in the ring.
-// This assumes that each instance in the ring is configured with only a single
-// token.
-func KeyRangeForInstance[T constraints.Unsigned](id string, instances []ring.InstanceDesc, keyspace Range[T]) (Range[T], error) {
-
-	// Sort instances -- they may not be sorted
-	// because they're usually accessed by looking up the tokens (which are sorted)
-	sort.Slice(instances, func(i, j int) bool {
-		return instances[i].Tokens[0] < instances[j].Tokens[0]
-	})
-
-	idx := slices.IndexFunc(instances, func(inst ring.InstanceDesc) bool {
-		return inst.Id == id
-	})
-
-	// instance with Id == id not found
-	if idx == -1 {
-		return Range[T]{}, ring.ErrInstanceNotFound
+// TODO(owen-d): use https://github.com/grafana/loki/pull/11975 after merge
+func KeyspacesFromTokenRanges(tokenRanges ring.TokenRanges) []v1.FingerprintBounds {
+	keyspaces := make([]v1.FingerprintBounds, 0, len(tokenRanges)/2)
+	for i := 0; i < len(tokenRanges)-1; i += 2 {
+		keyspaces = append(keyspaces, v1.FingerprintBounds{
+			Min: model.Fingerprint(tokenRanges[i]) << 32,
+			Max: model.Fingerprint(tokenRanges[i+1])<<32 | model.Fingerprint(math.MaxUint32),
+		})
 	}
-
-	diff := keyspace.Max - keyspace.Min
-	i := T(idx)
-	n := T(len(instances))
-
-	if diff < n {
-		return Range[T]{}, errors.New("keyspace is smaller than amount of instances")
-	}
-
-	step := diff / n
-	min := step * i
-	max := step*i + step - 1
-	if i == n-1 {
-		// extend the last token tange to MaxUint32
-		max = (keyspace.Max - keyspace.Min)
-	}
-
-	return Range[T]{min, max}, nil
+	return keyspaces
 }
 
 // NewInstanceSortMergeIterator creates an iterator that yields instanceWithToken elements

--- a/pkg/bloomutils/ring_test.go
+++ b/pkg/bloomutils/ring_test.go
@@ -6,8 +6,9 @@ import (
 	"testing"
 
 	"github.com/grafana/dskit/ring"
-	v1 "github.com/grafana/loki/pkg/storage/bloom/v1"
 	"github.com/stretchr/testify/require"
+
+	v1 "github.com/grafana/loki/pkg/storage/bloom/v1"
 )
 
 func TestBloomGatewayClient_InstanceSortMergeIterator(t *testing.T) {

--- a/pkg/bloomutils/ring_test.go
+++ b/pkg/bloomutils/ring_test.go
@@ -1,10 +1,12 @@
 package bloomutils
 
 import (
+	"fmt"
 	"math"
 	"testing"
 
 	"github.com/grafana/dskit/ring"
+	v1 "github.com/grafana/loki/pkg/storage/bloom/v1"
 	"github.com/stretchr/testify/require"
 )
 
@@ -40,45 +42,34 @@ func uint64Range(min, max uint64) Range[uint64] {
 	return Range[uint64]{min, max}
 }
 
-func TestBloomGatewayClient_KeyRangeForInstance(t *testing.T) {
-	for name, tc := range map[string]struct {
-		id       string
-		input    []ring.InstanceDesc
-		expected Range[uint64]
+func TestKeyspacesFromTokenRanges(t *testing.T) {
+	for i, tc := range []struct {
+		tokenRanges ring.TokenRanges
+		exp         []v1.FingerprintBounds
 	}{
-		"first instance includes 0 token": {
-			id: "3",
-			input: []ring.InstanceDesc{
-				{Id: "1", Tokens: []uint32{3}},
-				{Id: "2", Tokens: []uint32{5}},
-				{Id: "3", Tokens: []uint32{1}},
+		{
+			tokenRanges: ring.TokenRanges{
+				0, math.MaxUint32 / 2,
+				math.MaxUint32/2 + 1, math.MaxUint32,
 			},
-			expected: uint64Range(0, math.MaxUint64/3-1),
+			exp: []v1.FingerprintBounds{
+				v1.NewBounds(0, math.MaxUint64/2),
+				v1.NewBounds(math.MaxUint64/2+1, math.MaxUint64),
+			},
 		},
-		"middle instance": {
-			id: "1",
-			input: []ring.InstanceDesc{
-				{Id: "1", Tokens: []uint32{3}},
-				{Id: "2", Tokens: []uint32{5}},
-				{Id: "3", Tokens: []uint32{1}},
+		{
+			tokenRanges: ring.TokenRanges{
+				0, math.MaxUint8,
+				math.MaxUint16, math.MaxUint16 << 1,
 			},
-			expected: uint64Range(math.MaxUint64/3, math.MaxUint64/3*2-1),
-		},
-		"last instance includes MaxUint32 token": {
-			id: "2",
-			input: []ring.InstanceDesc{
-				{Id: "1", Tokens: []uint32{3}},
-				{Id: "2", Tokens: []uint32{5}},
-				{Id: "3", Tokens: []uint32{1}},
+			exp: []v1.FingerprintBounds{
+				v1.NewBounds(0, 0xff00000000|math.MaxUint32),
+				v1.NewBounds(math.MaxUint16<<32, math.MaxUint16<<33|math.MaxUint32),
 			},
-			expected: uint64Range(math.MaxUint64/3*2, math.MaxUint64),
 		},
 	} {
-		tc := tc
-		t.Run(name, func(t *testing.T) {
-			result, err := KeyRangeForInstance(tc.id, tc.input, Uint64Range)
-			require.NoError(t, err)
-			require.Equal(t, tc.expected, result)
+		t.Run(fmt.Sprint(i), func(t *testing.T) {
+			require.Equal(t, tc.exp, KeyspacesFromTokenRanges(tc.tokenRanges))
 		})
 	}
 }

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -1446,7 +1446,9 @@ func (t *Loki) initBloomCompactorRing() (services.Service, error) {
 	// is LegacyMode needed?
 	// legacyReadMode := t.Cfg.LegacyReadTarget && t.isModuleActive(Read)
 
-	rm, err := lokiring.NewRingManager(bloomCompactorRingKey, lokiring.ServerMode, t.Cfg.BloomCompactor.Ring, 1, 1, util_log.Logger, prometheus.DefaultRegisterer)
+	// TODO(owen-d): configurable num tokens, just use lifecycler config?
+	numTokens := 10
+	rm, err := lokiring.NewRingManager(bloomCompactorRingKey, lokiring.ServerMode, t.Cfg.BloomCompactor.Ring, 1, numTokens, util_log.Logger, prometheus.DefaultRegisterer)
 
 	if err != nil {
 		return nil, gerrors.Wrap(err, "error initializing bloom-compactor ring manager")


### PR DESCRIPTION
Moves bloom ring ownership back to a traditional consistent hashing mode via tokens. Copies/adapts some dskit ring code where necessary because `<ReadRing>.GetTokenRangesForInstance()` does not currently support non zone-aware topologies.

This should also break up the bloom compactor's unit of work by making metas for smaller ranges which are now roughly `(keyspace_range / num_replicas / tokens_per_replica)`. With the currently hardcoded `10` tokens per replica, we'll build about 10 times more metas than prior.

Also includes a small change to minimize metric construction during chunk iteration where it's not needed, although this may need some more extensive refactoring for more performance benefits later.