### PR TITLE
skips publishing images on PRs

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -177,16 +177,6 @@ local promtail_win() = pipeline('promtail-windows') {
 
 local querytee() = pipeline('querytee-amd64') + arch_image('amd64', 'main') {
   steps+: [
-    // dry run for everything that is not tag or main
-    docker('amd64', 'querytee') {
-      depends_on: ['image-tag'],
-      when: onPRs,
-      settings+: {
-        dry_run: true,
-        repo: 'grafana/loki-query-tee',
-      },
-    },
-  ] + [
     // publish for tag or main
     docker('amd64', 'querytee') {
       depends_on: ['image-tag'],
@@ -201,16 +191,6 @@ local querytee() = pipeline('querytee-amd64') + arch_image('amd64', 'main') {
 
 local fluentbit(arch) = pipeline('fluent-bit-' + arch) + arch_image(arch) {
   steps+: [
-    // dry run for everything that is not tag or main
-    clients_docker(arch, 'fluent-bit') {
-      depends_on: ['image-tag'],
-      when: onPRs,
-      settings+: {
-        dry_run: true,
-        repo: 'grafana/fluent-bit-plugin-loki',
-      },
-    },
-  ] + [
     // publish for tag or main
     clients_docker(arch, 'fluent-bit') {
       depends_on: ['image-tag'],
@@ -225,16 +205,6 @@ local fluentbit(arch) = pipeline('fluent-bit-' + arch) + arch_image(arch) {
 
 local fluentd() = pipeline('fluentd-amd64') + arch_image('amd64', 'main') {
   steps+: [
-    // dry run for everything that is not tag or main
-    clients_docker('amd64', 'fluentd') {
-      depends_on: ['image-tag'],
-      when: onPRs,
-      settings+: {
-        dry_run: true,
-        repo: 'grafana/fluent-plugin-loki',
-      },
-    },
-  ] + [
     // publish for tag or main
     clients_docker('amd64', 'fluentd') {
       depends_on: ['image-tag'],
@@ -249,16 +219,6 @@ local fluentd() = pipeline('fluentd-amd64') + arch_image('amd64', 'main') {
 
 local logstash() = pipeline('logstash-amd64') + arch_image('amd64', 'main') {
   steps+: [
-    // dry run for everything that is not tag or main
-    clients_docker('amd64', 'logstash') {
-      depends_on: ['image-tag'],
-      when: onPRs,
-      settings+: {
-        dry_run: true,
-        repo: 'grafana/logstash-output-loki',
-      },
-    },
-  ] + [
     // publish for tag or main
     clients_docker('amd64', 'logstash') {
       depends_on: ['image-tag'],
@@ -273,15 +233,6 @@ local logstash() = pipeline('logstash-amd64') + arch_image('amd64', 'main') {
 
 local promtail(arch) = pipeline('promtail-' + arch) + arch_image(arch) {
   steps+: [
-    // dry run for everything that is not tag or main
-    clients_docker(arch, 'promtail') {
-      depends_on: ['image-tag'],
-      when: onPRs,
-      settings+: {
-        dry_run: true,
-      },
-    },
-  ] + [
     // publish for tag or main
     clients_docker(arch, 'promtail') {
       depends_on: ['image-tag'],
@@ -341,16 +292,6 @@ local lokioperator(arch) = pipeline('lokioperator-' + arch) + arch_image(arch) {
 
 local logql_analyzer() = pipeline('logql-analyzer') + arch_image('amd64') {
   steps+: [
-    // dry run for everything that is not tag or main
-    docker('amd64', 'logql-analyzer') {
-      depends_on: ['image-tag'],
-      when: onPRs,
-      settings+: {
-        dry_run: true,
-        repo: 'grafana/logql-analyzer',
-      },
-    },
-  ] + [
     // publish for tag or main
     docker('amd64', 'logql-analyzer') {
       depends_on: ['image-tag'],
@@ -365,16 +306,6 @@ local logql_analyzer() = pipeline('logql-analyzer') + arch_image('amd64') {
 
 local multiarch_image(arch) = pipeline('docker-' + arch) + arch_image(arch) {
   steps+: [
-    // dry run for everything that is not tag or main
-    docker(arch, app) {
-      depends_on: ['image-tag'],
-      when: onPRs,
-      settings+: {
-        dry_run: true,
-      },
-    }
-    for app in apps
-  ] + [
     // publish for tag or main
     docker(arch, app) {
       depends_on: ['image-tag'],

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -361,66 +361,6 @@ steps:
 - depends_on:
   - image-tag
   image: plugins/docker
-  name: build-loki-image
-  settings:
-    dockerfile: cmd/loki/Dockerfile
-    dry_run: true
-    password:
-      from_secret: docker_password
-    repo: grafana/loki
-    username:
-      from_secret: docker_username
-  when:
-    event:
-    - pull_request
-- depends_on:
-  - image-tag
-  image: plugins/docker
-  name: build-loki-canary-image
-  settings:
-    dockerfile: cmd/loki-canary/Dockerfile
-    dry_run: true
-    password:
-      from_secret: docker_password
-    repo: grafana/loki-canary
-    username:
-      from_secret: docker_username
-  when:
-    event:
-    - pull_request
-- depends_on:
-  - image-tag
-  image: plugins/docker
-  name: build-loki-canary-boringcrypto-image
-  settings:
-    dockerfile: cmd/loki-canary-boringcrypto/Dockerfile
-    dry_run: true
-    password:
-      from_secret: docker_password
-    repo: grafana/loki-canary-boringcrypto
-    username:
-      from_secret: docker_username
-  when:
-    event:
-    - pull_request
-- depends_on:
-  - image-tag
-  image: plugins/docker
-  name: build-logcli-image
-  settings:
-    dockerfile: cmd/logcli/Dockerfile
-    dry_run: true
-    password:
-      from_secret: docker_password
-    repo: grafana/logcli
-    username:
-      from_secret: docker_username
-  when:
-    event:
-    - pull_request
-- depends_on:
-  - image-tag
-  image: plugins/docker
   name: publish-loki-image
   settings:
     dockerfile: cmd/loki/Dockerfile
@@ -503,66 +443,6 @@ steps:
   - echo $(./tools/image-tag)-arm64 > .tags
   image: alpine
   name: image-tag
-- depends_on:
-  - image-tag
-  image: plugins/docker
-  name: build-loki-image
-  settings:
-    dockerfile: cmd/loki/Dockerfile
-    dry_run: true
-    password:
-      from_secret: docker_password
-    repo: grafana/loki
-    username:
-      from_secret: docker_username
-  when:
-    event:
-    - pull_request
-- depends_on:
-  - image-tag
-  image: plugins/docker
-  name: build-loki-canary-image
-  settings:
-    dockerfile: cmd/loki-canary/Dockerfile
-    dry_run: true
-    password:
-      from_secret: docker_password
-    repo: grafana/loki-canary
-    username:
-      from_secret: docker_username
-  when:
-    event:
-    - pull_request
-- depends_on:
-  - image-tag
-  image: plugins/docker
-  name: build-loki-canary-boringcrypto-image
-  settings:
-    dockerfile: cmd/loki-canary-boringcrypto/Dockerfile
-    dry_run: true
-    password:
-      from_secret: docker_password
-    repo: grafana/loki-canary-boringcrypto
-    username:
-      from_secret: docker_username
-  when:
-    event:
-    - pull_request
-- depends_on:
-  - image-tag
-  image: plugins/docker
-  name: build-logcli-image
-  settings:
-    dockerfile: cmd/logcli/Dockerfile
-    dry_run: true
-    password:
-      from_secret: docker_password
-    repo: grafana/logcli
-    username:
-      from_secret: docker_username
-  when:
-    event:
-    - pull_request
 - depends_on:
   - image-tag
   image: plugins/docker
@@ -651,66 +531,6 @@ steps:
 - depends_on:
   - image-tag
   image: plugins/docker:linux-arm
-  name: build-loki-image
-  settings:
-    dockerfile: cmd/loki/Dockerfile
-    dry_run: true
-    password:
-      from_secret: docker_password
-    repo: grafana/loki
-    username:
-      from_secret: docker_username
-  when:
-    event:
-    - pull_request
-- depends_on:
-  - image-tag
-  image: plugins/docker:linux-arm
-  name: build-loki-canary-image
-  settings:
-    dockerfile: cmd/loki-canary/Dockerfile
-    dry_run: true
-    password:
-      from_secret: docker_password
-    repo: grafana/loki-canary
-    username:
-      from_secret: docker_username
-  when:
-    event:
-    - pull_request
-- depends_on:
-  - image-tag
-  image: plugins/docker:linux-arm
-  name: build-loki-canary-boringcrypto-image
-  settings:
-    dockerfile: cmd/loki-canary-boringcrypto/Dockerfile
-    dry_run: true
-    password:
-      from_secret: docker_password
-    repo: grafana/loki-canary-boringcrypto
-    username:
-      from_secret: docker_username
-  when:
-    event:
-    - pull_request
-- depends_on:
-  - image-tag
-  image: plugins/docker:linux-arm
-  name: build-logcli-image
-  settings:
-    dockerfile: cmd/logcli/Dockerfile
-    dry_run: true
-    password:
-      from_secret: docker_password
-    repo: grafana/logcli
-    username:
-      from_secret: docker_username
-  when:
-    event:
-    - pull_request
-- depends_on:
-  - image-tag
-  image: plugins/docker:linux-arm
   name: publish-loki-image
   settings:
     dockerfile: cmd/loki/Dockerfile
@@ -796,21 +616,6 @@ steps:
 - depends_on:
   - image-tag
   image: plugins/docker
-  name: build-promtail-image
-  settings:
-    dockerfile: clients/cmd/promtail/Dockerfile
-    dry_run: true
-    password:
-      from_secret: docker_password
-    repo: grafana/promtail
-    username:
-      from_secret: docker_username
-  when:
-    event:
-    - pull_request
-- depends_on:
-  - image-tag
-  image: plugins/docker
   name: publish-promtail-image
   settings:
     dockerfile: clients/cmd/promtail/Dockerfile
@@ -848,21 +653,6 @@ steps:
 - depends_on:
   - image-tag
   image: plugins/docker
-  name: build-promtail-image
-  settings:
-    dockerfile: clients/cmd/promtail/Dockerfile
-    dry_run: true
-    password:
-      from_secret: docker_password
-    repo: grafana/promtail
-    username:
-      from_secret: docker_username
-  when:
-    event:
-    - pull_request
-- depends_on:
-  - image-tag
-  image: plugins/docker
   name: publish-promtail-image
   settings:
     dockerfile: clients/cmd/promtail/Dockerfile
@@ -897,21 +687,6 @@ steps:
   - echo $(./tools/image-tag)-arm > .tags
   image: alpine
   name: image-tag
-- depends_on:
-  - image-tag
-  image: plugins/docker:linux-arm
-  name: build-promtail-image
-  settings:
-    dockerfile: clients/cmd/promtail/Dockerfile.arm32
-    dry_run: true
-    password:
-      from_secret: docker_password
-    repo: grafana/promtail
-    username:
-      from_secret: docker_username
-  when:
-    event:
-    - pull_request
 - depends_on:
   - image-tag
   image: plugins/docker:linux-arm
@@ -1120,21 +895,6 @@ steps:
 - depends_on:
   - image-tag
   image: plugins/docker
-  name: build-fluent-bit-image
-  settings:
-    dockerfile: clients/cmd/fluent-bit/Dockerfile
-    dry_run: true
-    password:
-      from_secret: docker_password
-    repo: grafana/fluent-bit-plugin-loki
-    username:
-      from_secret: docker_username
-  when:
-    event:
-    - pull_request
-- depends_on:
-  - image-tag
-  image: plugins/docker
   name: publish-fluent-bit-image
   settings:
     dockerfile: clients/cmd/fluent-bit/Dockerfile
@@ -1172,21 +932,6 @@ steps:
 - depends_on:
   - image-tag
   image: plugins/docker
-  name: build-fluent-bit-image
-  settings:
-    dockerfile: clients/cmd/fluent-bit/Dockerfile
-    dry_run: true
-    password:
-      from_secret: docker_password
-    repo: grafana/fluent-bit-plugin-loki
-    username:
-      from_secret: docker_username
-  when:
-    event:
-    - pull_request
-- depends_on:
-  - image-tag
-  image: plugins/docker
   name: publish-fluent-bit-image
   settings:
     dockerfile: clients/cmd/fluent-bit/Dockerfile
@@ -1221,21 +966,6 @@ steps:
   - echo $(./tools/image-tag)-arm > .tags
   image: alpine
   name: image-tag
-- depends_on:
-  - image-tag
-  image: plugins/docker:linux-arm
-  name: build-fluent-bit-image
-  settings:
-    dockerfile: clients/cmd/fluent-bit/Dockerfile
-    dry_run: true
-    password:
-      from_secret: docker_password
-    repo: grafana/fluent-bit-plugin-loki
-    username:
-      from_secret: docker_username
-  when:
-    event:
-    - pull_request
 - depends_on:
   - image-tag
   image: plugins/docker:linux-arm
@@ -1277,21 +1007,6 @@ steps:
 - depends_on:
   - image-tag
   image: plugins/docker
-  name: build-fluentd-image
-  settings:
-    dockerfile: clients/cmd/fluentd/Dockerfile
-    dry_run: true
-    password:
-      from_secret: docker_password
-    repo: grafana/fluent-plugin-loki
-    username:
-      from_secret: docker_username
-  when:
-    event:
-    - pull_request
-- depends_on:
-  - image-tag
-  image: plugins/docker
   name: publish-fluentd-image
   settings:
     dockerfile: clients/cmd/fluentd/Dockerfile
@@ -1330,21 +1045,6 @@ steps:
 - depends_on:
   - image-tag
   image: plugins/docker
-  name: build-logstash-image
-  settings:
-    dockerfile: clients/cmd/logstash/Dockerfile
-    dry_run: true
-    password:
-      from_secret: docker_password
-    repo: grafana/logstash-output-loki
-    username:
-      from_secret: docker_username
-  when:
-    event:
-    - pull_request
-- depends_on:
-  - image-tag
-  image: plugins/docker
   name: publish-logstash-image
   settings:
     dockerfile: clients/cmd/logstash/Dockerfile
@@ -1380,21 +1080,6 @@ steps:
   - echo ",main" >> .tags
   image: alpine
   name: image-tag
-- depends_on:
-  - image-tag
-  image: plugins/docker
-  name: build-querytee-image
-  settings:
-    dockerfile: cmd/querytee/Dockerfile
-    dry_run: true
-    password:
-      from_secret: docker_password
-    repo: grafana/loki-query-tee
-    username:
-      from_secret: docker_username
-  when:
-    event:
-    - pull_request
 - depends_on:
   - image-tag
   image: plugins/docker
@@ -1659,21 +1344,6 @@ steps:
   - echo $(./tools/image-tag)-amd64 > .tags
   image: alpine
   name: image-tag
-- depends_on:
-  - image-tag
-  image: plugins/docker
-  name: build-logql-analyzer-image
-  settings:
-    dockerfile: cmd/logql-analyzer/Dockerfile
-    dry_run: true
-    password:
-      from_secret: docker_password
-    repo: grafana/logql-analyzer
-    username:
-      from_secret: docker_username
-  when:
-    event:
-    - pull_request
 - depends_on:
   - image-tag
   image: plugins/docker
@@ -2072,6 +1742,6 @@ kind: secret
 name: gpg_private_key
 ---
 kind: signature
-hmac: 51861919f0ba5370a152bdb9267828c742f2042819fb01388c6d23bf44e3cbb7
+hmac: 407e26c6abea4941598787a4dd59bb3bec044edf7e816365543c62d46bf52f2c
 
 ...


### PR DESCRIPTION
We only need to publish images on `main` -- there's no need to publish PR builds and they can cause us to be rate limited much more easily, increase build times, etc.