### PR TITLE
refactor: Simplify fingerprint partitioning in bloom gateway client

### DIFF
--- a/pkg/bloomcompactor/bloomcompactor.go
+++ b/pkg/bloomcompactor/bloomcompactor.go
@@ -2,10 +2,6 @@ package bloomcompactor
 
 import (
 	"context"
-	"fmt"
-	"math"
-	"slices"
-	"sort"
 	"sync"
 	"time"
 
@@ -212,105 +208,13 @@ func (c *Compactor) ownsTenant(tenant string) ([]v1.FingerprintBounds, bool, err
 		return nil, false, errors.Wrap(err, "getting ring healthy instances")
 	}
 
-	ranges, err := tokenRangesForInstance(c.cfg.Ring.InstanceID, rs.Instances)
+	ranges, err := bloomutils.TokenRangesForInstance(c.cfg.Ring.InstanceID, rs.Instances)
 	if err != nil {
 		return nil, false, errors.Wrap(err, "getting token ranges for instance")
 	}
 
 	keyspaces := bloomutils.KeyspacesFromTokenRanges(ranges)
 	return keyspaces, true, nil
-}
-
-func tokenRangesForInstance(id string, instances []ring.InstanceDesc) (ranges ring.TokenRanges, err error) {
-	var ownedTokens map[uint32]struct{}
-
-	// lifted from grafana/dskit/ring/model.go <*Desc>.GetTokens()
-	toks := make([][]uint32, 0, len(instances))
-	for _, instance := range instances {
-		if instance.Id == id {
-			ranges = make(ring.TokenRanges, 0, 2*(len(instance.Tokens)+1))
-			ownedTokens = make(map[uint32]struct{}, len(instance.Tokens))
-			for _, tok := range instance.Tokens {
-				ownedTokens[tok] = struct{}{}
-			}
-		}
-
-		// Tokens may not be sorted for an older version which, so we enforce sorting here.
-		tokens := instance.Tokens
-		if !sort.IsSorted(ring.Tokens(tokens)) {
-			sort.Sort(ring.Tokens(tokens))
-		}
-
-		toks = append(toks, tokens)
-	}
-
-	if cap(ranges) == 0 {
-		return nil, fmt.Errorf("instance %s not found", id)
-	}
-
-	allTokens := ring.MergeTokens(toks)
-	if len(allTokens) == 0 {
-		return nil, errors.New("no tokens in the ring")
-	}
-
-	// mostly lifted from grafana/dskit/ring/token_range.go <*Ring>.GetTokenRangesForInstance()
-
-	// non-zero value means we're now looking for start of the range. Zero value means we're looking for next end of range (ie. token owned by this instance).
-	rangeEnd := uint32(0)
-
-	// if this instance claimed the first token, it owns the wrap-around range, which we'll break into two separate ranges
-	firstToken := allTokens[0]
-	_, ownsFirstToken := ownedTokens[firstToken]
-
-	if ownsFirstToken {
-		// we'll start by looking for the beginning of the range that ends with math.MaxUint32
-		rangeEnd = math.MaxUint32
-	}
-
-	// walk the ring backwards, alternating looking for ends and starts of ranges
-	for i := len(allTokens) - 1; i > 0; i-- {
-		token := allTokens[i]
-		_, owned := ownedTokens[token]
-
-		if rangeEnd == 0 {
-			// we're looking for the end of the next range
-			if owned {
-				rangeEnd = token - 1
-			}
-		} else {
-			// we have a range end, and are looking for the start of the range
-			if !owned {
-				ranges = append(ranges, rangeEnd, token)
-				rangeEnd = 0
-			}
-		}
-	}
-
-	// finally look at the first token again
-	// - if we have a range end, check if we claimed token 0
-	//   - if we don't, we have our start
-	//   - if we do, the start is 0
-	// - if we don't have a range end, check if we claimed token 0
-	//   - if we don't, do nothing
-	//   - if we do, add the range of [0, token-1]
-	//     - BUT, if the token itself is 0, do nothing, because we don't own the tokens themselves (we should be covered by the already added range that ends with MaxUint32)
-
-	if rangeEnd == 0 {
-		if ownsFirstToken && firstToken != 0 {
-			ranges = append(ranges, firstToken-1, 0)
-		}
-	} else {
-		if ownsFirstToken {
-			ranges = append(ranges, rangeEnd, 0)
-		} else {
-			ranges = append(ranges, rangeEnd, firstToken)
-		}
-	}
-
-	// Ensure returned ranges are sorted.
-	slices.Sort(ranges)
-
-	return ranges, nil
 }
 
 // runs a single round of compaction for all relevant tenants and tables

--- a/pkg/bloomcompactor/bloomcompactor_test.go
+++ b/pkg/bloomcompactor/bloomcompactor_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/loki/pkg/bloomutils"
 	v1 "github.com/grafana/loki/pkg/storage/bloom/v1"
 	util_log "github.com/grafana/loki/pkg/util/log"
 	lokiring "github.com/grafana/loki/pkg/util/ring"
@@ -251,7 +252,7 @@ func TestTokenRangesForInstance(t *testing.T) {
 	for desc, test := range tests {
 		t.Run(desc, func(t *testing.T) {
 			for id := range test.exp {
-				ranges, err := tokenRangesForInstance(id, test.input)
+				ranges, err := bloomutils.TokenRangesForInstance(id, test.input)
 				if test.err {
 					require.Error(t, err)
 					continue

--- a/pkg/bloomgateway/client.go
+++ b/pkg/bloomgateway/client.go
@@ -235,23 +235,23 @@ func (c *GatewayClient) FilterChunks(ctx context.Context, tenant string, from, t
 		return nil, errors.Wrap(err, "bloom gateway get healthy instances")
 	}
 
-	servers, err := serverAddressesWithTokenRanges(subRing, rs.Instances)
+	servers, err := replicationSetsWithBounds(subRing, rs.Instances)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "bloom gateway get replication sets")
 	}
-	streamsByInst := groupFingerprintsByServer(groups, servers)
+	servers = partitionByReplicationSet(groups, servers)
 
 	filteredChunkRefs := groupedChunksRefPool.Get(len(groups))
 	defer groupedChunksRefPool.Put(filteredChunkRefs)
 
-	for _, item := range streamsByInst {
+	for _, rs := range servers {
 		// randomize order of addresses so we don't hotspot the first server in the list
-		addrs := shuffleAddrs(item.instance.addrs)
+		addrs := shuffleAddrs(rs.rs.GetAddresses())
 		err := c.doForAddrs(addrs, func(client logproto.BloomGatewayClient) error {
 			req := &logproto.FilterChunkRefRequest{
 				From:    from,
 				Through: through,
-				Refs:    item.fingerprints,
+				Refs:    rs.groups,
 				Filters: filters,
 			}
 			resp, err := client.FilterChunkRefs(ctx, req)
@@ -291,11 +291,6 @@ func (c *GatewayClient) doForAddrs(addrs []string, fn func(logproto.BloomGateway
 	return err
 }
 
-func groupFingerprintsByServer(groups []*logproto.GroupedChunkRefs, servers []addrsWithBounds) []instanceWithFingerprints {
-	boundedFingerprints := partitionFingerprintsByAddresses(groups, servers)
-	return groupByInstance(boundedFingerprints)
-}
-
 func mapTokenRangeToFingerprintRange(r bloomutils.Range[uint32]) v1.FingerprintBounds {
 	minFp := uint64(r.Min) << 32
 	maxFp := uint64(r.Max) << 32
@@ -305,117 +300,77 @@ func mapTokenRangeToFingerprintRange(r bloomutils.Range[uint32]) v1.FingerprintB
 	)
 }
 
-func serverAddressesWithTokenRanges(subRing ring.ReadRing, instances []ring.InstanceDesc) ([]addrsWithBounds, error) {
+type rsWithRanges struct {
+	rs     ring.ReplicationSet
+	ranges []v1.FingerprintBounds
+	groups []*logproto.GroupedChunkRefs
+}
+
+func replicationSetsWithBounds(subRing ring.ReadRing, instances []ring.InstanceDesc) ([]rsWithRanges, error) {
 	bufDescs, bufHosts, bufZones := ring.MakeBuffersForGet()
 
-	servers := make([]addrsWithBounds, 0, len(instances))
-	it := bloomutils.NewInstanceSortMergeIterator(instances)
-
-	for it.Next() {
-		// We can use on of the tokens from the token range
-		// to obtain all addresses for that token.
-		rs, err := subRing.Get(it.At().TokenRange.Max, BlocksOwnerRead, bufDescs, bufHosts, bufZones)
+	servers := make([]rsWithRanges, 0, len(instances))
+	for _, inst := range instances {
+		tr, err := subRing.GetTokenRangesForInstance(inst.Id)
+		fmt.Println(inst.Id, tr)
 		if err != nil {
 			return nil, errors.Wrap(err, "bloom gateway get ring")
 		}
 
-		bounds := mapTokenRangeToFingerprintRange(it.At().TokenRange)
-		servers = append(servers, addrsWithBounds{
-			id:                it.At().Instance.Id,
-			addrs:             rs.GetAddresses(),
-			FingerprintBounds: bounds,
-		})
-	}
+		rs, err := subRing.Get(tr[0], BlocksOwnerRead, bufDescs, bufHosts, bufZones)
+		if err != nil {
+			return nil, errors.Wrap(err, "bloom gateway get ring")
+		}
 
-	if len(servers) > 0 && servers[len(servers)-1].Max < math.MaxUint64 {
-		// append the instance for the range between the maxFp and MaxUint64
-		// TODO(owen-d): support wrapping around keyspace for token ranges
-		servers = append(servers, addrsWithBounds{
-			id:    servers[0].id,
-			addrs: servers[0].addrs,
-			FingerprintBounds: v1.NewBounds(
-				servers[len(servers)-1].Max+1,
-				model.Fingerprint(math.MaxUint64),
-			),
+		bounds := make([]v1.FingerprintBounds, 0, len(tr)/2)
+		for i := 0; i < len(tr); i += 2 {
+			b := v1.NewBounds(
+				model.Fingerprint(uint64(tr[i])<<32),
+				model.Fingerprint(uint64(tr[i+1])<<32|math.MaxUint32),
+			)
+			bounds = append(bounds, b)
+		}
+
+		servers = append(servers, rsWithRanges{
+			rs:     rs,
+			ranges: bounds,
 		})
 	}
 	return servers, nil
 }
 
-type addrsWithBounds struct {
-	v1.FingerprintBounds
-	id    string
-	addrs []string
-}
+func partitionByReplicationSet(fingerprints []*logproto.GroupedChunkRefs, rs []rsWithRanges) (result []rsWithRanges) {
+	for _, inst := range rs {
+		for _, bounds := range inst.ranges {
+			min, _ := slices.BinarySearchFunc(fingerprints, bounds, func(g *logproto.GroupedChunkRefs, b v1.FingerprintBounds) int {
+				if g.Fingerprint < uint64(b.Min) {
+					return -1
+				} else if g.Fingerprint > uint64(b.Min) {
+					return 1
+				}
+				return 0
+			})
 
-type instanceWithFingerprints struct {
-	instance     addrsWithBounds
-	fingerprints []*logproto.GroupedChunkRefs
-}
+			max, _ := slices.BinarySearchFunc(fingerprints, bounds, func(g *logproto.GroupedChunkRefs, b v1.FingerprintBounds) int {
+				if g.Fingerprint <= uint64(b.Max) {
+					return -1
+				} else if g.Fingerprint > uint64(b.Max) {
+					return 1
+				}
+				return 0
+			})
 
-func partitionFingerprintsByAddresses(fingerprints []*logproto.GroupedChunkRefs, addresses []addrsWithBounds) (result []instanceWithFingerprints) {
-	for _, instance := range addresses {
-		min, _ := slices.BinarySearchFunc(fingerprints, instance.FingerprintBounds, func(g *logproto.GroupedChunkRefs, b v1.FingerprintBounds) int {
-			if g.Fingerprint < uint64(b.Min) {
-				return -1
-			} else if g.Fingerprint > uint64(b.Min) {
-				return 1
+			// fingerprint is out of boundaries
+			if min == len(fingerprints) || max == 0 {
+				continue
 			}
-			return 0
-		})
 
-		max, _ := slices.BinarySearchFunc(fingerprints, instance.FingerprintBounds, func(g *logproto.GroupedChunkRefs, b v1.FingerprintBounds) int {
-			if g.Fingerprint <= uint64(b.Max) {
-				return -1
-			} else if g.Fingerprint > uint64(b.Max) {
-				return 1
-			}
-			return 0
-		})
-
-		// fingerprint is out of boundaries
-		if min == len(fingerprints) || max == 0 {
-			continue
+			inst.groups = append(inst.groups, fingerprints[min:max]...)
 		}
 
-		result = append(result, instanceWithFingerprints{instance: instance, fingerprints: fingerprints[min:max]})
-	}
-
-	return result
-}
-
-// groupByInstance groups fingerprints by server instance
-func groupByInstance(boundedFingerprints []instanceWithFingerprints) []instanceWithFingerprints {
-	if len(boundedFingerprints) == 0 {
-		return []instanceWithFingerprints{}
-	}
-
-	result := make([]instanceWithFingerprints, 0, len(boundedFingerprints))
-	pos := make(map[string]int, len(boundedFingerprints))
-
-	for _, cur := range boundedFingerprints {
-		if len(cur.fingerprints) == 0 {
-			continue
+		if len(inst.groups) > 0 {
+			result = append(result, inst)
 		}
-		// Copy fingerprint slice, otherwise we mutate the original
-		// TODO(chaudum): Use SlicePool
-		tmp := make([]*logproto.GroupedChunkRefs, len(cur.fingerprints))
-		_ = copy(tmp, cur.fingerprints)
-
-		idx, ok := pos[cur.instance.id]
-		if ok {
-			result[idx].fingerprints = append(result[idx].fingerprints, tmp...)
-			continue
-		}
-
-		pos[cur.instance.id] = len(result)
-		result = append(result, instanceWithFingerprints{
-			instance: addrsWithBounds{
-				id:    cur.instance.id,
-				addrs: cur.instance.addrs,
-			},
-			fingerprints: tmp,
-		})
 	}
 
 	return result

--- a/pkg/bloomgateway/client.go
+++ b/pkg/bloomgateway/client.go
@@ -312,7 +312,6 @@ func replicationSetsWithBounds(subRing ring.ReadRing, instances []ring.InstanceD
 	servers := make([]rsWithRanges, 0, len(instances))
 	for _, inst := range instances {
 		tr, err := subRing.GetTokenRangesForInstance(inst.Id)
-		fmt.Println(inst.Id, tr)
 		if err != nil {
 			return nil, errors.Wrap(err, "bloom gateway get ring")
 		}

--- a/pkg/bloomgateway/client_test.go
+++ b/pkg/bloomgateway/client_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"sort"
 	"testing"
 	"time"
 
@@ -20,6 +19,15 @@ import (
 	v1 "github.com/grafana/loki/pkg/storage/bloom/v1"
 	"github.com/grafana/loki/pkg/validation"
 )
+
+func rs(id int, tokens ...uint32) ring.ReplicationSet {
+	inst := ring.InstanceDesc{
+		Id:     fmt.Sprintf("instance-%d", id),
+		Addr:   fmt.Sprintf("10.0.0.%d", id),
+		Tokens: tokens,
+	}
+	return ring.ReplicationSet{Instances: []ring.InstanceDesc{inst}}
+}
 
 func TestBloomGatewayClient(t *testing.T) {
 	logger := log.NewNopLogger()
@@ -40,7 +48,68 @@ func TestBloomGatewayClient(t *testing.T) {
 	})
 }
 
-func TestBloomGatewayClient_PartitionFingerprintsByAddresses(t *testing.T) {
+func TestBloomGatewayClient_ReplicationSetsWithBounds(t *testing.T) {
+	testCases := map[string]struct {
+		instances []ring.InstanceDesc
+		expected  []rsWithRanges
+	}{
+		"single instance covers full range": {
+			instances: []ring.InstanceDesc{
+				{Id: "instance-1", Addr: "10.0.0.1", Tokens: []uint32{(1 << 31)}}, // 0x80000000
+			},
+			expected: []rsWithRanges{
+				{rs: rs(1, (1 << 31)), ranges: []v1.FingerprintBounds{
+					v1.NewBounds(0, math.MaxUint64),
+				}},
+			},
+		},
+		"one token per instance": {
+			instances: []ring.InstanceDesc{
+				{Id: "instance-1", Addr: "10.0.0.1", Tokens: []uint32{(1 << 30) * 1}}, // 0x40000000
+				{Id: "instance-2", Addr: "10.0.0.2", Tokens: []uint32{(1 << 30) * 2}}, // 0x80000000
+				{Id: "instance-3", Addr: "10.0.0.3", Tokens: []uint32{(1 << 30) * 3}}, // 0xc0000000
+			},
+			expected: []rsWithRanges{
+				{rs: rs(1, (1<<30)*1), ranges: []v1.FingerprintBounds{
+					v1.NewBounds(0, 4611686018427387903),
+					v1.NewBounds(13835058055282163712, 18446744073709551615),
+				}},
+				{rs: rs(2, (1<<30)*2), ranges: []v1.FingerprintBounds{
+					v1.NewBounds(4611686018427387904, 9223372036854775807),
+				}},
+				{rs: rs(3, (1<<30)*3), ranges: []v1.FingerprintBounds{
+					v1.NewBounds(9223372036854775808, 13835058055282163711),
+				}},
+			},
+		},
+		"extreme tokens in ring": {
+			instances: []ring.InstanceDesc{
+				{Id: "instance-1", Addr: "10.0.0.1", Tokens: []uint32{0}},
+				{Id: "instance-2", Addr: "10.0.0.2", Tokens: []uint32{math.MaxUint32}},
+			},
+			expected: []rsWithRanges{
+				{rs: rs(1, 0), ranges: []v1.FingerprintBounds{
+					v1.NewBounds(math.MaxUint64-math.MaxUint32, math.MaxUint64),
+				}},
+				{rs: rs(2, math.MaxUint32), ranges: []v1.FingerprintBounds{
+					v1.NewBounds(0, math.MaxUint64-math.MaxUint32-1),
+				}},
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			subRing := newMockRing(t, tc.instances)
+			res, err := replicationSetsWithBounds(subRing, tc.instances)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, res)
+		})
+	}
+}
+
+func TestBloomGatewayClient_PartitionByReplicationSet(t *testing.T) {
 	// Create 10 fingerprints [0, 2, 4, ... 18]
 	groups := make([]*logproto.GroupedChunkRefs, 0, 10)
 	for i := 0; i < 20; i += 2 {
@@ -50,129 +119,77 @@ func TestBloomGatewayClient_PartitionFingerprintsByAddresses(t *testing.T) {
 	// instance token ranges do not overlap
 	t.Run("non-overlapping", func(t *testing.T) {
 
-		servers := []addrsWithBounds{
-			{id: "instance-1", addrs: []string{"10.0.0.1"}, FingerprintBounds: v1.NewBounds(0, 4)},
-			{id: "instance-2", addrs: []string{"10.0.0.2"}, FingerprintBounds: v1.NewBounds(5, 9)},
-			{id: "instance-3", addrs: []string{"10.0.0.3"}, FingerprintBounds: v1.NewBounds(10, 14)},
-			{id: "instance-2", addrs: []string{"10.0.0.2"}, FingerprintBounds: v1.NewBounds(15, 19)},
+		servers := []rsWithRanges{
+			{rs: rs(1), ranges: []v1.FingerprintBounds{v1.NewBounds(0, 4)}},
+			{rs: rs(2), ranges: []v1.FingerprintBounds{v1.NewBounds(5, 9), v1.NewBounds(15, 19)}},
+			{rs: rs(3), ranges: []v1.FingerprintBounds{v1.NewBounds(10, 14)}},
 		}
 
 		// partition fingerprints
 
-		expected := []instanceWithFingerprints{
+		expected := [][]*logproto.GroupedChunkRefs{
 			{
-				instance: servers[0],
-				fingerprints: []*logproto.GroupedChunkRefs{
-					{Fingerprint: 0},
-					{Fingerprint: 2},
-					{Fingerprint: 4},
-				},
+				{Fingerprint: 0},
+				{Fingerprint: 2},
+				{Fingerprint: 4},
 			},
 			{
-				instance: servers[1],
-				fingerprints: []*logproto.GroupedChunkRefs{
-					{Fingerprint: 6},
-					{Fingerprint: 8},
-				},
+				{Fingerprint: 6},
+				{Fingerprint: 8},
+				{Fingerprint: 16},
+				{Fingerprint: 18},
 			},
 			{
-				instance: servers[2],
-				fingerprints: []*logproto.GroupedChunkRefs{
-					{Fingerprint: 10},
-					{Fingerprint: 12},
-					{Fingerprint: 14},
-				},
-			},
-			{
-				instance: servers[3],
-				fingerprints: []*logproto.GroupedChunkRefs{
-					{Fingerprint: 16},
-					{Fingerprint: 18},
-				},
+				{Fingerprint: 10},
+				{Fingerprint: 12},
+				{Fingerprint: 14},
 			},
 		}
 
-		bounded := partitionFingerprintsByAddresses(groups, servers)
-		require.Equal(t, expected, bounded)
-
-		// group fingerprints by instance
-
-		expected = []instanceWithFingerprints{
-			{
-				instance: addrsWithBounds{id: "instance-1", addrs: []string{"10.0.0.1"}},
-				fingerprints: []*logproto.GroupedChunkRefs{
-					{Fingerprint: 0},
-					{Fingerprint: 2},
-					{Fingerprint: 4},
-				},
-			},
-			{
-				instance: addrsWithBounds{id: "instance-2", addrs: []string{"10.0.0.2"}},
-				fingerprints: []*logproto.GroupedChunkRefs{
-					{Fingerprint: 6},
-					{Fingerprint: 8},
-					{Fingerprint: 16},
-					{Fingerprint: 18},
-				},
-			},
-			{
-				instance: addrsWithBounds{id: "instance-3", addrs: []string{"10.0.0.3"}},
-				fingerprints: []*logproto.GroupedChunkRefs{
-					{Fingerprint: 10},
-					{Fingerprint: 12},
-					{Fingerprint: 14},
-				},
-			},
+		partitioned := partitionByReplicationSet(groups, servers)
+		for i := range partitioned {
+			require.Equal(t, expected[i], partitioned[i].groups)
 		}
-		result := groupByInstance(bounded)
-		require.Equal(t, expected, result)
 	})
 
-	// instance token ranges overlap
+	// instance token ranges overlap -- this should not happen in a real ring, though
 	t.Run("overlapping", func(t *testing.T) {
-		servers := []addrsWithBounds{
-			{id: "instance-1", addrs: []string{"10.0.0.1"}, FingerprintBounds: v1.NewBounds(0, 9)},
-			{id: "instance-2", addrs: []string{"10.0.0.2"}, FingerprintBounds: v1.NewBounds(5, 14)},
-			{id: "instance-3", addrs: []string{"10.0.0.3"}, FingerprintBounds: v1.NewBounds(10, 19)},
+		servers := []rsWithRanges{
+			{rs: rs(1), ranges: []v1.FingerprintBounds{v1.NewBounds(0, 9)}},
+			{rs: rs(2), ranges: []v1.FingerprintBounds{v1.NewBounds(5, 14)}},
+			{rs: rs(3), ranges: []v1.FingerprintBounds{v1.NewBounds(10, 19)}},
 		}
 
 		// partition fingerprints
 
-		expected := []instanceWithFingerprints{
+		expected := [][]*logproto.GroupedChunkRefs{
 			{
-				instance: servers[0],
-				fingerprints: []*logproto.GroupedChunkRefs{
-					{Fingerprint: 0},
-					{Fingerprint: 2},
-					{Fingerprint: 4},
-					{Fingerprint: 6},
-					{Fingerprint: 8},
-				},
+				{Fingerprint: 0},
+				{Fingerprint: 2},
+				{Fingerprint: 4},
+				{Fingerprint: 6},
+				{Fingerprint: 8},
 			},
 			{
-				instance: servers[1],
-				fingerprints: []*logproto.GroupedChunkRefs{
-					{Fingerprint: 6},
-					{Fingerprint: 8},
-					{Fingerprint: 10},
-					{Fingerprint: 12},
-					{Fingerprint: 14},
-				},
+				{Fingerprint: 6},
+				{Fingerprint: 8},
+				{Fingerprint: 10},
+				{Fingerprint: 12},
+				{Fingerprint: 14},
 			},
 			{
-				instance: servers[2],
-				fingerprints: []*logproto.GroupedChunkRefs{
-					{Fingerprint: 10},
-					{Fingerprint: 12},
-					{Fingerprint: 14},
-					{Fingerprint: 16},
-					{Fingerprint: 18},
-				},
+				{Fingerprint: 10},
+				{Fingerprint: 12},
+				{Fingerprint: 14},
+				{Fingerprint: 16},
+				{Fingerprint: 18},
 			},
 		}
 
-		bounded := partitionFingerprintsByAddresses(groups, servers)
-		require.Equal(t, expected, bounded)
+		partitioned := partitionByReplicationSet(groups, servers)
+		for i := range partitioned {
+			require.Equal(t, expected[i], partitioned[i].groups)
+		}
 	})
 }
 
@@ -187,22 +204,20 @@ func BenchmarkPartitionFingerprintsByAddresses(b *testing.B) {
 
 	numServers := 100
 	tokenStep := math.MaxUint32 / uint32(numServers)
-	servers := make([]addrsWithBounds, 0, numServers)
+	servers := make([]rsWithRanges, 0, numServers)
 	for i := uint32(0); i < math.MaxUint32-tokenStep; i += tokenStep {
-		servers = append(servers, addrsWithBounds{
-			id:    fmt.Sprintf("instance-%x", i),
-			addrs: []string{fmt.Sprintf("%d", i)},
-			FingerprintBounds: v1.NewBounds(
-				model.Fingerprint(i)<<32,
-				model.Fingerprint(i+tokenStep)<<32,
-			),
+		servers = append(servers, rsWithRanges{
+			rs: rs(int(i)),
+			ranges: []v1.FingerprintBounds{
+				v1.NewBounds(model.Fingerprint(i)<<32, model.Fingerprint(i+tokenStep)<<32),
+			},
 		})
 	}
 
 	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		_ = partitionFingerprintsByAddresses(groups, servers)
+		_ = partitionByReplicationSet(groups, servers)
 	}
 }
 
@@ -229,194 +244,17 @@ func TestBloomGatewayClient_MapTokenRangeToFingerprintRange(t *testing.T) {
 	}
 }
 
-func TestBloomGatewayClient_ServerAddressesWithTokenRanges(t *testing.T) {
-	testCases := map[string]struct {
-		instances []ring.InstanceDesc
-		expected  []addrsWithBounds
-	}{
-		"one token per instance, no gaps between fingerprint ranges": {
-			instances: []ring.InstanceDesc{
-				{Id: "instance-1", Addr: "10.0.0.1", Tokens: []uint32{(1 << 30) * 1}}, // 0x40000000
-				{Id: "instance-2", Addr: "10.0.0.2", Tokens: []uint32{(1 << 30) * 2}}, // 0x80000000
-				{Id: "instance-3", Addr: "10.0.0.3", Tokens: []uint32{(1 << 30) * 3}}, // 0xc0000000
-			},
-			expected: []addrsWithBounds{
-				{id: "instance-1", addrs: []string{"10.0.0.1"}, FingerprintBounds: v1.NewBounds(0, 4611686022722355199)},
-				{id: "instance-2", addrs: []string{"10.0.0.2"}, FingerprintBounds: v1.NewBounds(4611686022722355200, 9223372041149743103)},
-				{id: "instance-3", addrs: []string{"10.0.0.3"}, FingerprintBounds: v1.NewBounds(9223372041149743104, 13835058059577131007)},
-				{id: "instance-1", addrs: []string{"10.0.0.1"}, FingerprintBounds: v1.NewBounds(13835058059577131008, 18446744073709551615)},
-			},
-		},
-		"MinUint32 and MaxUint32 are actual tokens in the ring": {
-			instances: []ring.InstanceDesc{
-				{Id: "instance-1", Addr: "10.0.0.1", Tokens: []uint32{0}},
-				{Id: "instance-2", Addr: "10.0.0.2", Tokens: []uint32{math.MaxUint32}},
-			},
-			expected: []addrsWithBounds{
-				{id: "instance-1", addrs: []string{"10.0.0.1"}, FingerprintBounds: v1.NewBounds(0, (1<<32)-1)},
-				{id: "instance-2", addrs: []string{"10.0.0.2"}, FingerprintBounds: v1.NewBounds((1 << 32), math.MaxUint64)},
-			},
-		},
-	}
-
-	for name, tc := range testCases {
-		tc := tc
-		t.Run(name, func(t *testing.T) {
-			subRing := newMockRing(tc.instances)
-			res, err := serverAddressesWithTokenRanges(subRing, tc.instances)
-			require.NoError(t, err)
-			require.Equal(t, tc.expected, res)
-		})
-	}
-
-}
-
-func TestBloomGatewayClient_GroupFingerprintsByServer(t *testing.T) {
-	instances := []ring.InstanceDesc{
-		{Id: "instance-1", Addr: "10.0.0.1", Tokens: []uint32{0x1fffffff, 0x7fffffff}},
-		{Id: "instance-2", Addr: "10.0.0.2", Tokens: []uint32{0x3fffffff, 0x9fffffff}},
-		{Id: "instance-3", Addr: "10.0.0.3", Tokens: []uint32{0x5fffffff, 0xbfffffff}},
-	}
-
-	subRing := newMockRing(instances)
-	servers, err := serverAddressesWithTokenRanges(subRing, instances)
-	require.NoError(t, err)
-
-	// for _, s := range servers {
-	// 	t.Log(s, v1.NewBounds(model.Fingerprint(s.fpRange.Min), model.Fingerprint(s.fpRange.Max)))
-	// }
-	/**
-	    {instance-1 [10.0.0.1] {         0  536870911} {                   0  2305843004918726656}} 0000000000000000-1fffffff00000000
-	    {instance-2 [10.0.0.2] { 536870912 1073741823} { 2305843009213693952  4611686014132420608}} 2000000000000000-3fffffff00000000
-	    {instance-3 [10.0.0.3] {1073741824 1610612735} { 4611686018427387904  6917529023346114560}} 4000000000000000-5fffffff00000000
-	    {instance-1 [10.0.0.1] {1610612736 2147483647} { 6917529027641081856  9223372032559808512}} 6000000000000000-7fffffff00000000
-	    {instance-2 [10.0.0.2] {2147483648 2684354559} { 9223372036854775808 11529215041773502464}} 8000000000000000-9fffffff00000000
-	    {instance-3 [10.0.0.3] {2684354560 3221225471} {11529215046068469760 13835058050987196416}} a000000000000000-bfffffff00000000
-	    {instance-1 [10.0.0.1] {3221225472 4294967295} {13835058055282163712 18446744073709551615}} c000000000000000-ffffffffffffffff
-		**/
-
-	testCases := []struct {
-		name     string
-		chunks   []*logproto.GroupedChunkRefs
-		expected []instanceWithFingerprints
-	}{
-		{
-			name:     "empty input yields empty result",
-			chunks:   []*logproto.GroupedChunkRefs{},
-			expected: []instanceWithFingerprints{},
-		},
-		{
-			name: "fingerprints within a single token range are grouped",
-			chunks: []*logproto.GroupedChunkRefs{
-				{Fingerprint: 0x5000000000000001},
-				{Fingerprint: 0x5000000000000010},
-				{Fingerprint: 0x5000000000000100},
-			},
-			expected: []instanceWithFingerprints{
-				{
-					instance: addrsWithBounds{
-						id:    "instance-3",
-						addrs: []string{"10.0.0.3"},
-					},
-					fingerprints: []*logproto.GroupedChunkRefs{
-						{Fingerprint: 0x5000000000000001},
-						{Fingerprint: 0x5000000000000010},
-						{Fingerprint: 0x5000000000000100},
-					},
-				},
-			},
-		},
-		{
-			name: "fingerprints within multiple token ranges of a single instance are grouped",
-			chunks: []*logproto.GroupedChunkRefs{
-				{Fingerprint: 0x1000000000000000},
-				{Fingerprint: 0x7000000000000000},
-				{Fingerprint: 0xd000000000000000},
-			},
-			expected: []instanceWithFingerprints{
-				{
-					instance: addrsWithBounds{
-						id:    "instance-1",
-						addrs: []string{"10.0.0.1"},
-					},
-					fingerprints: []*logproto.GroupedChunkRefs{
-						{Fingerprint: 0x1000000000000000},
-						{Fingerprint: 0x7000000000000000},
-						{Fingerprint: 0xd000000000000000},
-					},
-				},
-			},
-		},
-		{
-			name: "fingerprints with token ranges of multiple instances are grouped",
-			chunks: []*logproto.GroupedChunkRefs{
-				{Fingerprint: 0x1000000000000000},
-				{Fingerprint: 0x3000000000000000},
-				{Fingerprint: 0x5000000000000000},
-				{Fingerprint: 0x7000000000000000},
-				{Fingerprint: 0x9000000000000000},
-				{Fingerprint: 0xb000000000000000},
-				{Fingerprint: 0xd000000000000000},
-				{Fingerprint: 0xf000000000000000},
-			},
-			expected: []instanceWithFingerprints{
-				{
-					instance: addrsWithBounds{
-						id:    "instance-1",
-						addrs: []string{"10.0.0.1"},
-					},
-					fingerprints: []*logproto.GroupedChunkRefs{
-						{Fingerprint: 0x1000000000000000},
-						{Fingerprint: 0x7000000000000000},
-						{Fingerprint: 0xd000000000000000},
-						{Fingerprint: 0xf000000000000000},
-					},
-				},
-				{
-					instance: addrsWithBounds{
-						id:    "instance-2",
-						addrs: []string{"10.0.0.2"},
-					},
-					fingerprints: []*logproto.GroupedChunkRefs{
-						{Fingerprint: 0x3000000000000000},
-						{Fingerprint: 0x9000000000000000},
-					},
-				},
-				{
-					instance: addrsWithBounds{
-						id:    "instance-3",
-						addrs: []string{"10.0.0.3"},
-					},
-					fingerprints: []*logproto.GroupedChunkRefs{
-						{Fingerprint: 0x5000000000000000},
-						{Fingerprint: 0xb000000000000000},
-					},
-				},
-			},
-		},
-	}
-
-	for _, tc := range testCases {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
-			// sort chunks here, to be able to write more human readable test input
-			sort.Slice(tc.chunks, func(i, j int) bool {
-				return tc.chunks[i].Fingerprint < tc.chunks[j].Fingerprint
-			})
-			res := groupFingerprintsByServer(tc.chunks, servers)
-			require.Equal(t, tc.expected, res)
-		})
-	}
-}
-
 // make sure mockRing implements the ring.ReadRing interface
 var _ ring.ReadRing = &mockRing{}
 
-func newMockRing(instances []ring.InstanceDesc) *mockRing {
-	it := bloomutils.NewInstanceSortMergeIterator(instances)
-	ranges := make([]bloomutils.InstanceWithTokenRange, 0)
-	for it.Next() {
-		ranges = append(ranges, it.At())
+func newMockRing(t *testing.T, instances []ring.InstanceDesc) *mockRing {
+	ranges := make([]ring.TokenRanges, 0)
+	for i := range instances {
+		tr, err := bloomutils.TokenRangesForInstance(instances[i].Id, instances)
+		if err != nil {
+			t.Fatal(err)
+		}
+		ranges = append(ranges, tr)
 	}
 	return &mockRing{
 		instances: instances,
@@ -426,21 +264,17 @@ func newMockRing(instances []ring.InstanceDesc) *mockRing {
 
 type mockRing struct {
 	instances []ring.InstanceDesc
-	ranges    []bloomutils.InstanceWithTokenRange
+	ranges    []ring.TokenRanges
 }
 
 // Get implements ring.ReadRing.
-func (r *mockRing) Get(key uint32, _ ring.Operation, _ []ring.InstanceDesc, _ []string, _ []string) (ring.ReplicationSet, error) {
-	idx, _ := sort.Find(len(r.ranges), func(i int) int {
-		if r.ranges[i].TokenRange.Max < key {
-			return 1
+func (r *mockRing) Get(key uint32, _ ring.Operation, _ []ring.InstanceDesc, _ []string, _ []string) (rs ring.ReplicationSet, err error) {
+	for i := range r.ranges {
+		if r.ranges[i].IncludesKey(key) {
+			rs.Instances = append(rs.Instances, r.instances[i])
 		}
-		if r.ranges[i].TokenRange.Max > key {
-			return -1
-		}
-		return 0
-	})
-	return ring.ReplicationSet{Instances: []ring.InstanceDesc{r.ranges[idx].Instance}}, nil
+	}
+	return
 }
 
 // GetAllHealthy implements ring.ReadRing.
@@ -490,7 +324,6 @@ func (*mockRing) CleanupShuffleShardCache(_ string) {
 	panic("unimplemented")
 }
 
-func (r *mockRing) GetTokenRangesForInstance(_ string) (ring.TokenRanges, error) {
-	tr := ring.TokenRanges{0, math.MaxUint32}
-	return tr, nil
+func (r *mockRing) GetTokenRangesForInstance(id string) (ring.TokenRanges, error) {
+	return bloomutils.TokenRangesForInstance(id, r.instances)
 }

--- a/pkg/bloomutils/ring_test.go
+++ b/pkg/bloomutils/ring_test.go
@@ -11,34 +11,6 @@ import (
 	v1 "github.com/grafana/loki/pkg/storage/bloom/v1"
 )
 
-func TestBloomGatewayClient_InstanceSortMergeIterator(t *testing.T) {
-	//          | 0 1 2 3 4 5 6 7 8 9 |
-	// ---------+---------------------+
-	// ID 1     |        ***o    ***o |
-	// ID 2     |    ***o    ***o     |
-	// ID 3     | **o                 |
-	input := []ring.InstanceDesc{
-		{Id: "1", Tokens: []uint32{5, 9}},
-		{Id: "2", Tokens: []uint32{3, 7}},
-		{Id: "3", Tokens: []uint32{1}},
-	}
-	expected := []InstanceWithTokenRange{
-		{Instance: input[2], TokenRange: NewTokenRange(0, 1)},
-		{Instance: input[1], TokenRange: NewTokenRange(2, 3)},
-		{Instance: input[0], TokenRange: NewTokenRange(4, 5)},
-		{Instance: input[1], TokenRange: NewTokenRange(6, 7)},
-		{Instance: input[0], TokenRange: NewTokenRange(8, 9)},
-	}
-
-	var i int
-	it := NewInstanceSortMergeIterator(input)
-	for it.Next() {
-		t.Log(expected[i], it.At())
-		require.Equal(t, expected[i], it.At())
-		i++
-	}
-}
-
 func uint64Range(min, max uint64) Range[uint64] {
 	return Range[uint64]{min, max}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Use the recently introduced `tokenRangesForInstance()` function to determine the the ranges for each replication set.

For this purpose, the function moves into the `bloomutils` packages.

This PR eliminates the structs `addrsWithBounds` and `instanceWithFingerprints` (which had somewhat similar usage) and unifies them into `rsWithRanges` that holds both the fingerprint ranges and the assigned GroupedChunkRefs.