### PR TITLE
fix(blooms): race condition in `BloomPageDecoder`

### DIFF
--- a/pkg/chunkenc/pool.go
+++ b/pkg/chunkenc/pool.go
@@ -349,6 +349,9 @@ func (pool *SnappyPool) GetReader(src io.Reader) (io.Reader, error) {
 
 // PutReader places back in the pool a CompressionReader
 func (pool *SnappyPool) PutReader(reader io.Reader) {
+	r := reader.(*snappy.Reader)
+	// Reset to free reference to the underlying reader
+	r.Reset(nil)
 	pool.readers.Put(reader)
 }
 

--- a/pkg/storage/bloom/v1/bloom_querier.go
+++ b/pkg/storage/bloom/v1/bloom_querier.go
@@ -38,6 +38,12 @@ func (it *LazyBloomIter) Seek(offset BloomOffset) {
 	// if we need a different page or the current page hasn't been loaded,
 	// load the desired page
 	if it.curPageIndex != offset.Page || it.curPage == nil {
+
+		// drop the current page if it exists
+		if it.curPage != nil {
+			it.curPage.Drop()
+		}
+
 		r, err := it.b.reader.Blooms()
 		if err != nil {
 			it.err = errors.Wrap(err, "getting blooms reader")
@@ -97,6 +103,7 @@ func (it *LazyBloomIter) next() bool {
 			}
 			// we've exhausted the current page, progress to next
 			it.curPageIndex++
+			it.curPage.Drop()
 			it.curPage = nil
 			continue
 		}


### PR DESCRIPTION
releases data to correct pools in correct locations + improves SnappyPool to release reader refs prior to putting to Pool
Signed-off-by: Owen Diehl <ow.diehl@gmail.com>
