### PR TITLE
feat: Convert line filter expressions to a set of bloom tests

### DIFF
--- a/pkg/storage/bloom/v1/bloom_tester.go
+++ b/pkg/storage/bloom/v1/bloom_tester.go
@@ -1,9 +1,10 @@
 package v1
 
 import (
+	"github.com/prometheus/prometheus/model/labels"
+
 	"github.com/grafana/loki/pkg/logql/syntax"
 	"github.com/grafana/loki/pkg/storage/bloom/v1/filter"
-	"github.com/prometheus/prometheus/model/labels"
 )
 
 type BloomTest interface {

--- a/pkg/storage/bloom/v1/bloom_tester.go
+++ b/pkg/storage/bloom/v1/bloom_tester.go
@@ -1,0 +1,167 @@
+package v1
+
+import (
+	"github.com/grafana/loki/pkg/logql/syntax"
+	"github.com/grafana/loki/pkg/storage/bloom/v1/filter"
+	"github.com/prometheus/prometheus/model/labels"
+)
+
+type BloomTest interface {
+	Test(bloom filter.Checker) bool
+	TestWithPrefixBuf(bloom filter.Checker, buf []byte, prefixLen int) bool
+}
+
+type BloomTests []BloomTest
+
+func (b BloomTests) Test(bloom filter.Checker) bool {
+	for _, test := range b {
+		if !test.Test(bloom) {
+			return false
+		}
+	}
+	return true
+}
+
+func (b BloomTests) TestWithPrefixBuf(bloom filter.Checker, buf []byte, prefixLen int) bool {
+	for _, test := range b {
+		if !test.TestWithPrefixBuf(bloom, buf, prefixLen) {
+			return false
+		}
+	}
+	return true
+}
+
+func FiltersToBloomTest(b NGramBuilder, filters ...syntax.LineFilterExpr) BloomTest {
+	tests := make(BloomTests, 0, len(filters))
+	for _, f := range filters {
+		if f.Left != nil {
+			tests = append(tests, FiltersToBloomTest(b, *f.Left))
+		}
+		if f.Or != nil {
+			left := FiltersToBloomTest(b, *f.Or)
+			right := simpleFilterToBloomTest(b, f.LineFilter)
+			tests = append(tests, newOrTest(left, right))
+			continue
+		}
+
+		tests = append(tests, simpleFilterToBloomTest(b, f.LineFilter))
+	}
+	return tests
+}
+
+func simpleFilterToBloomTest(b NGramBuilder, filter syntax.LineFilter) BloomTest {
+	switch filter.Ty {
+	case labels.MatchEqual, labels.MatchNotEqual:
+		var test BloomTest = newStringTest(b, filter.Match)
+		if filter.Ty == labels.MatchNotEqual {
+			test = newNotTest(test)
+		}
+		return test
+	case labels.MatchRegexp, labels.MatchNotRegexp:
+		// TODO(salvacorts): Simplify regex similarly to how it's done at pkg/logql/log/filter.go (`simplify` function)
+		// 					 Ideally we want to extract the simplify logic into pkg/util/regex.go
+		return NoopTest
+	default:
+		return NoopTest
+	}
+}
+
+type noopTest struct{}
+
+var NoopTest = noopTest{}
+
+func (n noopTest) Test(_ filter.Checker) bool {
+	return true
+}
+
+func (n noopTest) TestWithPrefixBuf(_ filter.Checker, _ []byte, _ int) bool {
+	return true
+}
+
+// NGramBuilder is an interface for tokenizing strings into ngrams
+// Extracting this interface allows us to test the bloom filter without having to use the actual tokenizer
+// TODO: This should be moved to tokenizer.go
+type NGramBuilder interface {
+	Build(input string) (ngrams [][]byte)
+}
+
+type nGramTokenizerWrapper struct {
+	NGramTokenizer
+}
+
+func NewNGramBuilder(t NGramTokenizer) NGramBuilder {
+	return nGramTokenizerWrapper{NGramTokenizer: t}
+}
+
+func (n nGramTokenizerWrapper) Build(input string) (ngrams [][]byte) {
+	// TODO: preallocate ngrams
+	it := n.Tokens(input)
+	for it.Next() {
+		ngram := make([]byte, n.N)
+		copy(ngram, it.At())
+		ngrams = append(ngrams, ngram)
+	}
+	return
+}
+
+type stringTest struct {
+	ngrams [][]byte
+}
+
+func newStringTest(b NGramBuilder, search string) stringTest {
+	return stringTest{ngrams: b.Build(search)}
+}
+
+func (b stringTest) Test(bloom filter.Checker) bool {
+	for _, ngram := range b.ngrams {
+		if !bloom.Test(ngram) {
+			return false
+		}
+	}
+	return true
+}
+
+func (b stringTest) TestWithPrefixBuf(bloom filter.Checker, buf []byte, prefixLen int) bool {
+	for _, ngram := range b.ngrams {
+		buf = append(buf[:prefixLen], ngram...)
+		if !bloom.Test(buf) {
+			return false
+		}
+	}
+	return true
+}
+
+type notTest struct {
+	BloomTest
+}
+
+func newNotTest(test BloomTest) BloomTest {
+	return notTest{BloomTest: test}
+}
+
+func (b notTest) Test(bloom filter.Checker) bool {
+	return !b.BloomTest.Test(bloom)
+}
+
+func (b notTest) TestWithPrefixBuf(bloom filter.Checker, buf []byte, prefixLen int) bool {
+	return !b.BloomTest.TestWithPrefixBuf(bloom, buf, prefixLen)
+}
+
+type orTest struct {
+	left, right BloomTest
+}
+
+func newOrTest(left, right BloomTest) orTest {
+	return orTest{
+		left:  left,
+		right: right,
+	}
+}
+
+func (o orTest) Test(bloom filter.Checker) bool {
+	return o.left.Test(bloom) || o.right.Test(bloom)
+}
+
+func (o orTest) TestWithPrefixBuf(bloom filter.Checker, buf []byte, prefixLen int) bool {
+	return o.left.TestWithPrefixBuf(bloom, buf, prefixLen) || o.right.TestWithPrefixBuf(bloom, buf, prefixLen)
+}

--- a/pkg/storage/bloom/v1/bloom_tester_test.go
+++ b/pkg/storage/bloom/v1/bloom_tester_test.go
@@ -1,0 +1,153 @@
+package v1
+
+import (
+	"github.com/grafana/loki/pkg/logql/syntax"
+	"github.com/grafana/loki/pkg/storage/bloom/v1/filter"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestFiltersToBloomTests(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		query       string
+		bloom       filter.Checker
+		expectMatch bool
+	}{
+		{
+			name:        "No filters",
+			query:       `{app="fake"}`,
+			bloom:       fakeBloom{"foo", "bar"},
+			expectMatch: true,
+		},
+		{
+			name:        "Single filter",
+			query:       `{app="fake"} |= "foo"`,
+			bloom:       fakeBloom{"foo", "bar"},
+			expectMatch: true,
+		},
+		{
+			name:        "Single filter no match",
+			query:       `{app="fake"} |= "nope"`,
+			bloom:       fakeBloom{"foo", "bar"},
+			expectMatch: false,
+		},
+		{
+			name:        "two filters",
+			query:       `{app="fake"} |= "foo" |= "bar"`,
+			bloom:       fakeBloom{"foo", "bar"},
+			expectMatch: true,
+		},
+		{
+			name:        "two filters no match",
+			query:       `{app="fake"} |= "foo" |= "nope"`,
+			bloom:       fakeBloom{"foo", "bar"},
+			expectMatch: false,
+		},
+		{
+			name:        "notEq match",
+			query:       `{app="fake"} != "nope"`,
+			bloom:       fakeBloom{"foo", "bar"},
+			expectMatch: true,
+		},
+		{
+			name:        "notEq no match",
+			query:       `{app="fake"} != "foo"`,
+			bloom:       fakeBloom{"foo", "bar"},
+			expectMatch: false,
+		},
+		{
+			name:        "or filter both match",
+			query:       `{app="fake"} |= "foo" or "bar"`,
+			bloom:       fakeBloom{"foo", "bar"},
+			expectMatch: true,
+		},
+		{
+			name:        "or filter one right match",
+			query:       `{app="fake"} |= "nope" or "foo"`,
+			bloom:       fakeBloom{"foo", "bar"},
+			expectMatch: true,
+		},
+		{
+			name:        "or filter one left match",
+			query:       `{app="fake"} |= "foo" or "nope"`,
+			bloom:       fakeBloom{"foo", "bar"},
+			expectMatch: true,
+		},
+		{
+			name:        "or filter no match",
+			query:       `{app="fake"} |= "no" or "nope"`,
+			bloom:       fakeBloom{"foo", "bar"},
+			expectMatch: false,
+		},
+		{
+			name:        "Not or filter match",
+			query:       `{app="fake"} != "nope" or "no"`,
+			bloom:       fakeBloom{"foo", "bar"},
+			expectMatch: true,
+		},
+		{
+			name:        "Not or filter right no match",
+			query:       `{app="fake"} != "nope" or "bar"`,
+			bloom:       fakeBloom{"foo", "bar"},
+			expectMatch: false,
+		},
+		{
+			name:        "Not or filter left no match",
+			query:       `{app="fake"} != "foo" or "nope"`,
+			bloom:       fakeBloom{"foo", "bar"},
+			expectMatch: false,
+		},
+		{
+			name:        "Not or filter no match",
+			query:       `{app="fake"} != "foo" or "bar"`,
+			bloom:       fakeBloom{"foo", "bar"},
+			expectMatch: false,
+		},
+		{
+			name:        "complex filter match",
+			query:       `{app="fake"} |= "foo" |= "bar" or "baz" |= "fuzz" or "not" != "nope" != "no" or "none"`,
+			bloom:       fakeBloom{"foo", "bar", "baz", "fuzz"},
+			expectMatch: true,
+		},
+		// TODO: test regexes
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			expr, err := syntax.ParseExpr(tc.query)
+			assert.NoError(t, err)
+			filters := extractLineFilters(expr)
+
+			bloomTests := FiltersToBloomTest(fakeNgramBuilder{}, filters...)
+
+			assert.Equal(t, tc.expectMatch, bloomTests.Test(tc.bloom))
+		})
+	}
+}
+
+func extractLineFilters(expr syntax.Expr) (lineFilters []syntax.LineFilterExpr) {
+	visitor := &syntax.DepthFirstTraversal{
+		VisitLineFilterFn: func(v syntax.RootVisitor, e *syntax.LineFilterExpr) {
+			lineFilters = append(lineFilters, *e)
+		},
+	}
+	expr.Accept(visitor)
+	return lineFilters
+}
+
+type fakeNgramBuilder struct{}
+
+func (f fakeNgramBuilder) Build(input string) [][]byte {
+	return [][]byte{[]byte(input)}
+}
+
+type fakeBloom []string
+
+func (f fakeBloom) Test(data []byte) bool {
+	str := string(data)
+	for _, match := range f {
+		if str == match {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/storage/bloom/v1/bloom_tester_test.go
+++ b/pkg/storage/bloom/v1/bloom_tester_test.go
@@ -1,10 +1,12 @@
 package v1
 
 import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
 	"github.com/grafana/loki/pkg/logql/syntax"
 	"github.com/grafana/loki/pkg/storage/bloom/v1/filter"
-	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestFiltersToBloomTests(t *testing.T) {

--- a/pkg/storage/bloom/v1/bloom_tester_test.go
+++ b/pkg/storage/bloom/v1/bloom_tester_test.go
@@ -117,23 +117,13 @@ func TestFiltersToBloomTests(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			expr, err := syntax.ParseExpr(tc.query)
 			assert.NoError(t, err)
-			filters := extractLineFilters(expr)
+			filters := syntax.ExtractLineFilters(expr)
 
 			bloomTests := FiltersToBloomTest(fakeNgramBuilder{}, filters...)
 
-			assert.Equal(t, tc.expectMatch, bloomTests.Test(tc.bloom))
+			assert.Equal(t, tc.expectMatch, bloomTests.Matches(tc.bloom))
 		})
 	}
-}
-
-func extractLineFilters(expr syntax.Expr) (lineFilters []syntax.LineFilterExpr) {
-	visitor := &syntax.DepthFirstTraversal{
-		VisitLineFilterFn: func(v syntax.RootVisitor, e *syntax.LineFilterExpr) {
-			lineFilters = append(lineFilters, *e)
-		},
-	}
-	expr.Accept(visitor)
-	return lineFilters
 }
 
 type fakeNgramBuilder struct{}

--- a/pkg/storage/bloom/v1/bloom_tester_test.go
+++ b/pkg/storage/bloom/v1/bloom_tester_test.go
@@ -138,8 +138,8 @@ func extractLineFilters(expr syntax.Expr) (lineFilters []syntax.LineFilterExpr) 
 
 type fakeNgramBuilder struct{}
 
-func (f fakeNgramBuilder) Build(input string) [][]byte {
-	return [][]byte{[]byte(input)}
+func (f fakeNgramBuilder) Tokens(line string) Iterator[[]byte] {
+	return NewSliceIter[[]byte]([][]byte{[]byte(line)})
 }
 
 type fakeBloom []string

--- a/pkg/storage/bloom/v1/fuse.go
+++ b/pkg/storage/bloom/v1/fuse.go
@@ -8,7 +8,7 @@ import (
 type Request struct {
 	Fp       model.Fingerprint
 	Chks     ChunkRefs
-	Searches [][]byte
+	Search   BloomTest
 	Response chan<- Output
 }
 
@@ -103,22 +103,19 @@ func (fq *FusedQuerier) Run() error {
 
 		bloom := fq.bq.blooms.At()
 		// test every input against this chunk
-	inputLoop:
 		for _, input := range nextBatch {
 			_, inBlooms := input.Chks.Compare(series.Chunks, true)
 
 			// First, see if the search passes the series level bloom before checking for chunks individually
-			for _, search := range input.Searches {
-				if !bloom.Test(search) {
-					// We return all the chunks that were the intersection of the query
-					// because they for sure do not match the search and don't
-					// need to be downloaded
-					input.Response <- Output{
-						Fp:       fp,
-						Removals: inBlooms,
-					}
-					continue inputLoop
+			if !input.Search.Test(bloom) {
+				// We return all the chunks that were the intersection of the query
+				// because they for sure do not match the search and don't
+				// need to be downloaded
+				input.Response <- Output{
+					Fp:       fp,
+					Removals: inBlooms,
 				}
+				continue
 			}
 
 			// TODO(owen-d): pool
@@ -128,17 +125,12 @@ func (fq *FusedQuerier) Run() error {
 			var tokenBuf []byte
 			var prefixLen int
 
-		chunkLoop:
 			for _, chk := range inBlooms {
 				// Get buf to concatenate the chunk and search token
 				tokenBuf, prefixLen = prefixedToken(schema.NGramLen(), chk, tokenBuf)
-				for _, search := range input.Searches {
-					tokenBuf = append(tokenBuf[:prefixLen], search...)
-
-					if !bloom.Test(tokenBuf) {
-						removals = append(removals, chk)
-						continue chunkLoop
-					}
+				if !input.Search.TestWithPrefixBuf(bloom, tokenBuf, prefixLen) {
+					removals = append(removals, chk)
+					continue
 				}
 				// Otherwise, the chunk passed all the searches
 			}

--- a/pkg/storage/bloom/v1/fuse.go
+++ b/pkg/storage/bloom/v1/fuse.go
@@ -107,7 +107,7 @@ func (fq *FusedQuerier) Run() error {
 			_, inBlooms := input.Chks.Compare(series.Chunks, true)
 
 			// First, see if the search passes the series level bloom before checking for chunks individually
-			if !input.Search.Test(bloom) {
+			if !input.Search.Matches(bloom) {
 				// We return all the chunks that were the intersection of the query
 				// because they for sure do not match the search and don't
 				// need to be downloaded
@@ -128,7 +128,7 @@ func (fq *FusedQuerier) Run() error {
 			for _, chk := range inBlooms {
 				// Get buf to concatenate the chunk and search token
 				tokenBuf, prefixLen = prefixedToken(schema.NGramLen(), chk, tokenBuf)
-				if !input.Search.TestWithPrefixBuf(bloom, tokenBuf, prefixLen) {
+				if !input.Search.MatchesWithPrefixBuf(bloom, tokenBuf, prefixLen) {
 					removals = append(removals, chk)
 					continue
 				}

--- a/pkg/storage/bloom/v1/fuse_test.go
+++ b/pkg/storage/bloom/v1/fuse_test.go
@@ -20,6 +20,7 @@ func TestFusedQuerier(t *testing.T) {
 	reader := NewByteReader(indexBuf, bloomsBuf)
 	numSeries := 1000
 	data, keys := MkBasicSeriesWithBlooms(numSeries, 0, 0x0000, 0xffff, 0, 10000)
+	_ = keys
 
 	builder, err := NewBlockBuilder(
 		BlockOptions{
@@ -54,7 +55,7 @@ func TestFusedQuerier(t *testing.T) {
 				Fp:       data[idx].Series.Fingerprint,
 				Chks:     data[idx].Series.Chunks,
 				Response: ch,
-				Searches: keys[idx],
+				//Searches: keys[idx],
 			})
 		}
 		inputs = append(inputs, reqs)

--- a/pkg/storage/bloom/v1/fuse_test.go
+++ b/pkg/storage/bloom/v1/fuse_test.go
@@ -12,6 +12,16 @@ import (
 	"github.com/grafana/loki/pkg/chunkenc"
 )
 
+func keysToBloomTest(keys [][]byte) BloomTest {
+	var tokenizer fakeNgramBuilder
+	tests := make(BloomTests, 0, len(keys))
+	for _, key := range keys {
+		tests = append(tests, newStringTest(tokenizer, string(key)))
+	}
+
+	return tests
+}
+
 func TestFusedQuerier(t *testing.T) {
 	// references for linking in memory reader+writer
 	indexBuf := bytes.NewBuffer(nil)
@@ -54,7 +64,7 @@ func TestFusedQuerier(t *testing.T) {
 				Fp:       data[idx].Series.Fingerprint,
 				Chks:     data[idx].Series.Chunks,
 				Response: ch,
-				Searches: keys[idx],
+				Search:   keysToBloomTest(keys[idx]),
 			})
 		}
 		inputs = append(inputs, reqs)

--- a/pkg/storage/bloom/v1/fuse_test.go
+++ b/pkg/storage/bloom/v1/fuse_test.go
@@ -20,7 +20,6 @@ func TestFusedQuerier(t *testing.T) {
 	reader := NewByteReader(indexBuf, bloomsBuf)
 	numSeries := 1000
 	data, keys := MkBasicSeriesWithBlooms(numSeries, 0, 0x0000, 0xffff, 0, 10000)
-	_ = keys
 
 	builder, err := NewBlockBuilder(
 		BlockOptions{
@@ -55,7 +54,7 @@ func TestFusedQuerier(t *testing.T) {
 				Fp:       data[idx].Series.Fingerprint,
 				Chks:     data[idx].Series.Chunks,
 				Response: ch,
-				//Searches: keys[idx],
+				Searches: keys[idx],
 			})
 		}
 		inputs = append(inputs, reqs)

--- a/pkg/storage/bloom/v1/tokenizer.go
+++ b/pkg/storage/bloom/v1/tokenizer.go
@@ -42,8 +42,8 @@ func NewNGramTokenizer(n, skip int) *NGramTokenizer {
 
 // The Token iterator uses shared buffers for performance. The []byte returned by At()
 // is not safe for use after subsequent calls to Next()
-func (t *NGramTokenizer) Tokens(line string) NGramTokenIter {
-	return NGramTokenIter{
+func (t *NGramTokenizer) Tokens(line string) Iterator[[]byte] {
+	return &NGramTokenIter{
 		n:    t.N,
 		skip: t.Skip,
 
@@ -97,17 +97,17 @@ type PrefixedTokenIter struct {
 	buf       []byte
 	prefixLen int
 
-	NGramTokenIter
+	Iterator[[]byte]
 }
 
 func (t *PrefixedTokenIter) At() []byte {
-	return append(t.buf[:t.prefixLen], t.NGramTokenIter.At()...)
+	return append(t.buf[:t.prefixLen], t.Iterator.At()...)
 }
 
-func NewPrefixedTokenIter(buf []byte, prefixLn int, iter NGramTokenIter) *PrefixedTokenIter {
+func NewPrefixedTokenIter(buf []byte, prefixLn int, iter Iterator[[]byte]) *PrefixedTokenIter {
 	return &PrefixedTokenIter{
-		buf:            buf,
-		prefixLen:      prefixLn,
-		NGramTokenIter: iter,
+		buf:       buf,
+		prefixLen: prefixLn,
+		Iterator:  iter,
 	}
 }

--- a/pkg/storage/bloom/v1/tokenizer.go
+++ b/pkg/storage/bloom/v1/tokenizer.go
@@ -40,6 +40,7 @@ func NewNGramTokenizer(n, skip int) *NGramTokenizer {
 	return t
 }
 
+// Token implementsthe NGramBuilder interface
 // The Token iterator uses shared buffers for performance. The []byte returned by At()
 // is not safe for use after subsequent calls to Next()
 func (t *NGramTokenizer) Tokens(line string) Iterator[[]byte] {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR introduces:
- A new interface `BloomTest` with two test methods that take a bloom as an argument and returns a boolean. True if the test passes with the given bloom.
- A new function `FiltersToBloomTest` that given a set of `LineFilterExpr`, it returns a `BloomTest`.

~The logic in this PR is not yet used anywhere since we need to do some refactoring to be able to use it. These refactorings will be done on a set of follow-up PRs:~
~1. Pass `syntax.LineFilterExpr` instead of `syntax.LineFilter` with `logproto.FilterChunkRefRequest`~
~2. Create BloomTest from the line filters passed along through `logproto.FilterChunkRefRequest` and modify the fused querier to use the resulting `BloomTest`.~
3. Map regex line filters to `BloomTest` when possible. The logic would be pretty similar to what's done in the `simplify` function at [pkg/logql/log/filter.go](https://github.com/grafana/loki/blob/60edfe0006b0adf6041b7ac437b8c47d66d1ead6/pkg/logql/log/filter.go#L470-L496). We can probably extract the simplification logic into [pkg/util/regex.go].(https://github.com/grafana/loki/blob/5a08a6bcb9ecc816328cb7859bbdcc7cf9d004c5/pkg/util/regex.go)

**Special notes for your reviewer**:
- As explained in the bullets above, regexes are not yet tested. all regex filter expressions are mapped to Noop tests which always return true.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
