### PR TITLE
chore(blooms): Various fixes in blooms read path

### DIFF
--- a/pkg/bloomgateway/bloomgateway.go
+++ b/pkg/bloomgateway/bloomgateway.go
@@ -72,8 +72,9 @@ import (
 var errGatewayUnhealthy = errors.New("bloom-gateway is unhealthy in the ring")
 
 const (
-	pendingTasksInitialCap = 1024
-	metricsSubsystem       = "bloom_gateway"
+	pendingTasksInitialCap  = 1024
+	metricsSubsystem        = "bloom_gateway"
+	querierMetricsSubsystem = "bloom_gateway_querier"
 )
 
 var (

--- a/pkg/bloomgateway/client.go
+++ b/pkg/bloomgateway/client.go
@@ -311,7 +311,7 @@ func replicationSetsWithBounds(subRing ring.ReadRing, instances []ring.InstanceD
 
 	servers := make([]rsWithRanges, 0, len(instances))
 	for _, inst := range instances {
-		tr, err := subRing.GetTokenRangesForInstance(inst.Id)
+		tr, err := bloomutils.TokenRangesForInstance(inst.Id, instances)
 		if err != nil {
 			return nil, errors.Wrap(err, "bloom gateway get ring")
 		}

--- a/pkg/bloomgateway/querier.go
+++ b/pkg/bloomgateway/querier.go
@@ -61,7 +61,7 @@ type BloomQuerier struct {
 func NewQuerier(c Client, r prometheus.Registerer, logger log.Logger) *BloomQuerier {
 	return &BloomQuerier{
 		c:       c,
-		metrics: newQuerierMetrics(r, constants.Loki, "bloom_gateway_querier"),
+		metrics: newQuerierMetrics(r, constants.Loki, querierMetricsSubsystem),
 		logger:  logger,
 	}
 }

--- a/pkg/bloomgateway/querier.go
+++ b/pkg/bloomgateway/querier.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/grafana/loki/pkg/logproto"
 	"github.com/grafana/loki/pkg/logql/syntax"
+	"github.com/grafana/loki/pkg/util/constants"
 )
 
 type querierMetrics struct {
@@ -57,8 +58,12 @@ type BloomQuerier struct {
 	metrics *querierMetrics
 }
 
-func NewQuerier(c Client, logger log.Logger) *BloomQuerier {
-	return &BloomQuerier{c: c, logger: logger}
+func NewQuerier(c Client, r prometheus.Registerer, logger log.Logger) *BloomQuerier {
+	return &BloomQuerier{
+		c:       c,
+		metrics: newQuerierMetrics(r, constants.Loki, "bloom_gateway_querier"),
+		logger:  logger,
+	}
 }
 
 func convertToShortRef(ref *logproto.ChunkRef) *logproto.ShortRef {

--- a/pkg/bloomgateway/querier_test.go
+++ b/pkg/bloomgateway/querier_test.go
@@ -32,7 +32,7 @@ func TestBloomQuerier(t *testing.T) {
 
 	t.Run("client not called when filters are empty", func(t *testing.T) {
 		c := &noopClient{}
-		bq := NewQuerier(c, logger)
+		bq := NewQuerier(c, nil, logger)
 
 		ctx := context.Background()
 		through := model.Now()
@@ -51,7 +51,7 @@ func TestBloomQuerier(t *testing.T) {
 
 	t.Run("client not called when chunkRefs are empty", func(t *testing.T) {
 		c := &noopClient{}
-		bq := NewQuerier(c, logger)
+		bq := NewQuerier(c, nil, logger)
 
 		ctx := context.Background()
 		through := model.Now()
@@ -68,7 +68,7 @@ func TestBloomQuerier(t *testing.T) {
 
 	t.Run("querier propagates error from client", func(t *testing.T) {
 		c := &noopClient{err: errors.New("something went wrong")}
-		bq := NewQuerier(c, logger)
+		bq := NewQuerier(c, nil, logger)
 
 		ctx := context.Background()
 		through := model.Now()

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -1354,7 +1354,7 @@ func (t *Loki) initIndexGateway() (services.Service, error) {
 		if err != nil {
 			return nil, err
 		}
-		bloomQuerier = bloomgateway.NewQuerier(bloomGatewayClient, logger)
+		bloomQuerier = bloomgateway.NewQuerier(bloomGatewayClient, prometheus.DefaultRegisterer, logger)
 	}
 
 	gateway, err := indexgateway.NewIndexGateway(t.Cfg.IndexGateway, logger, prometheus.DefaultRegisterer, t.Store, indexClients, bloomQuerier)


### PR DESCRIPTION
**What this PR does / why we need it**:

* Wire up bloom querier metrics to fix nil pointer panic
* Use `bloomutils.TokenRangesForInstance` instead of `subRing.GetTokenRangesForInstance` to avoid `zone not set` error