### PR TITLE
test: split unit and integrations suites to parallelize

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -23,6 +23,7 @@ run:
     - linux
     - cgo
     - promtail_journal_enabled
+    - integration
 
   # which dirs to skip: they won't be analyzed;
   # can use regexp here: generated.*, regexp is applied on full path;

--- a/Makefile
+++ b/Makefile
@@ -325,8 +325,12 @@ lint: ## run linters
 ########
 
 test: all ## run the unit tests
-	$(GOTEST) -covermode=atomic -coverprofile=coverage.txt -p=4 ./... | sed "s:$$: ${DRONE_STEP_NAME} ${DRONE_SOURCE_BRANCH}:" | tee test_results.txt
-	cd tools/lambda-promtail/ && $(GOTEST) -covermode=atomic -coverprofile=lambda-promtail-coverage.txt -p=4 ./... | sed "s:$$: ${DRONE_STEP_NAME} ${DRONE_SOURCE_BRANCH}:" | tee lambda_promtail_test_results.txt
+	$(GOTEST) -covermode=atomic -coverprofile=coverage.txt -p=4 ./... | tee test_results.txt
+	cd tools/lambda-promtail/ && $(GOTEST) -covermode=atomic -coverprofile=lambda-promtail-coverage.txt -p=4 ./... | tee lambda_promtail_test_results.txt
+
+test-integration:
+	$(GOTEST) -count=1 -v -tags=integration -timeout 10m ./integration
+
 compare-coverage:
 	./tools/diff_coverage.sh $(old) $(new) $(packages)
 

--- a/integration/loki_micro_services_delete_test.go
+++ b/integration/loki_micro_services_delete_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package integration
 
 import (

--- a/integration/loki_micro_services_test.go
+++ b/integration/loki_micro_services_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 package integration
 
 import (

--- a/integration/loki_rule_eval_test.go
+++ b/integration/loki_rule_eval_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 package integration
 
 import (

--- a/integration/loki_simple_scalable_test.go
+++ b/integration/loki_simple_scalable_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 package integration
 
 import (

--- a/integration/loki_single_binary_test.go
+++ b/integration/loki_single_binary_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 package integration
 
 import (

--- a/integration/multi_tenant_queries_test.go
+++ b/integration/multi_tenant_queries_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 package integration
 
 import (

--- a/integration/parse_metrics.go
+++ b/integration/parse_metrics.go
@@ -1,3 +1,4 @@
+//go:build integration
 package integration
 
 import (

--- a/integration/parse_metrics_test.go
+++ b/integration/parse_metrics_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 package integration
 
 import (

--- a/integration/per_request_limits_test.go
+++ b/integration/per_request_limits_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 package integration
 
 import (

--- a/integration/shared_test.go
+++ b/integration/shared_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package integration
 
 import (


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR separates the unit and integration test suites so they can be parallelized in CI for faster builds.