### PR TITLE
chore(blooms): Populate blocks cache on startup

### DIFF
--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -673,6 +673,8 @@ func (t *Loki) initBloomStore() (services.Service, error) {
 	var blocksCache cache.TypedCache[string, bloomshipper.BlockDirectory]
 	if bsCfg.BlocksCache.IsEnabled() {
 		blocksCache = bloomshipper.NewBlocksCache(bsCfg.BlocksCache, reg, logger)
+		err = bloomshipper.LoadBlocksDirIntoCache(t.Cfg.StorageConfig.BloomShipperConfig.WorkingDirectory, blocksCache, logger)
+		level.Warn(logger).Log("msg", "failed to preload blocks cache", "err", err)
 	}
 
 	t.BloomStore, err = bloomshipper.NewBloomStore(t.Cfg.SchemaConfig.Configs, t.Cfg.StorageConfig, t.clientMetrics, metasCache, blocksCache, logger)

--- a/pkg/storage/stores/shipper/bloomshipper/cache_test.go
+++ b/pkg/storage/stores/shipper/bloomshipper/cache_test.go
@@ -1,13 +1,60 @@
 package bloomshipper
 
 import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/go-kit/log"
+	"github.com/grafana/loki/pkg/logqlmodel/stats"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
 )
+
+type mockCache[K comparable, V any] struct {
+	sync.Mutex
+	cache map[K]V
+}
+
+func (m *mockCache[K, V]) Store(_ context.Context, keys []K, values []V) error {
+	m.Lock()
+	defer m.Unlock()
+	for i := range keys {
+		m.cache[keys[i]] = values[i]
+	}
+	return nil
+}
+
+func (m *mockCache[K, V]) Fetch(_ context.Context, keys []K) (found []K, values []V, missing []K, err error) {
+	m.Lock()
+	defer m.Unlock()
+	for _, key := range keys {
+		buf, ok := m.cache[key]
+		if ok {
+			found = append(found, key)
+			values = append(values, buf)
+		} else {
+			missing = append(missing, key)
+		}
+	}
+	return
+}
+
+func (m *mockCache[K, V]) Stop() {
+}
+
+func (m *mockCache[K, V]) GetCacheType() stats.CacheType {
+	return "mock"
+}
+
+func newTypedMockCache[K comparable, V any]() *mockCache[K, V] {
+	return &mockCache[K, V]{
+		cache: make(map[K]V),
+	}
+}
 
 func TestBlockDirectory_Cleanup(t *testing.T) {
 	checkInterval := 50 * time.Millisecond
@@ -64,4 +111,39 @@ func Test_ClosableBlockQuerier(t *testing.T) {
 	require.Equal(t, int32(1), blockDir.refCount.Load())
 	require.NoError(t, querier.Close())
 	require.Equal(t, int32(0), blockDir.refCount.Load())
+}
+
+func Test_LoadBlocksDirIntoCache(t *testing.T) {
+	logger := log.NewNopLogger()
+	wd := t.TempDir()
+
+	// plain file
+	fp, _ := os.Create(filepath.Join(wd, "regular-file.tar.gz"))
+	fp.Close()
+
+	// invalid directory
+	_ = os.MkdirAll(filepath.Join(wd, "not/a/valid/blockdir"), 0o755)
+
+	// empty block directory
+	fn1 := "bloom/table_1/tenant/blocks/0000000000000000-000000000000ffff/0-3600000-abcd"
+	_ = os.MkdirAll(filepath.Join(wd, fn1), 0o755)
+
+	// valid block directory
+	fn2 := "bloom/table_2/tenant/blocks/0000000000010000-000000000001ffff/0-3600000-abcd"
+	_ = os.MkdirAll(filepath.Join(wd, fn2), 0o755)
+	fp, _ = os.Create(filepath.Join(wd, fn2, "bloom"))
+	fp.Close()
+	fp, _ = os.Create(filepath.Join(wd, fn2, "series"))
+	fp.Close()
+
+	c := newTypedMockCache[string, BlockDirectory]()
+	err := LoadBlocksDirIntoCache(wd, c, logger)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, len(c.cache))
+
+	key := filepath.Join(wd, fn2) + ".tar.gz"
+	blockDir, found := c.cache[key]
+	require.True(t, found)
+	require.Equal(t, filepath.Join(wd, fn2), blockDir.Path)
 }

--- a/pkg/storage/stores/shipper/bloomshipper/fetcher.go
+++ b/pkg/storage/stores/shipper/bloomshipper/fetcher.go
@@ -240,9 +240,13 @@ func (f *Fetcher) loadBlocksFromFS(_ context.Context, refs []BlockRef) ([]BlockD
 var noopClean = func(string) error { return nil }
 
 func (f *Fetcher) isBlockDir(path string) (bool, func(string) error) {
+	return isBlockDir(path, f.logger)
+}
+
+func isBlockDir(path string, logger log.Logger) (bool, func(string) error) {
 	info, err := os.Stat(path)
 	if err != nil && os.IsNotExist(err) {
-		level.Warn(f.logger).Log("msg", "path does not exist", "path", path)
+		level.Warn(logger).Log("msg", "path does not exist", "path", path)
 		return false, noopClean
 	}
 	if !info.IsDir() {
@@ -253,7 +257,7 @@ func (f *Fetcher) isBlockDir(path string) (bool, func(string) error) {
 		filepath.Join(path, v1.SeriesFileName),
 	} {
 		if _, err := os.Stat(file); err != nil && os.IsNotExist(err) {
-			level.Warn(f.logger).Log("msg", "path does not contain required file", "path", path, "file", file)
+			level.Warn(logger).Log("msg", "path does not contain required file", "path", path, "file", file)
 			return false, os.RemoveAll
 		}
 	}

--- a/pkg/storage/stores/shipper/bloomshipper/resolver_test.go
+++ b/pkg/storage/stores/shipper/bloomshipper/resolver_test.go
@@ -1,0 +1,54 @@
+package bloomshipper
+
+import (
+	"testing"
+
+	v1 "github.com/grafana/loki/pkg/storage/bloom/v1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolver_ParseMetaKey(t *testing.T) {
+	r := defaultKeyResolver{}
+	ref := MetaRef{
+		Ref: Ref{
+			TenantID:  "tenant",
+			TableName: "table_1",
+			Bounds:    v1.NewBounds(0x0000, 0xffff),
+			Checksum:  43981,
+		},
+	}
+
+	// encode block ref as string
+	loc := r.Meta(ref)
+	path := loc.LocalPath()
+	require.Equal(t, "bloom/table_1/tenant/metas/0000000000000000-000000000000ffff-abcd.json", path)
+
+	// parse encoded string into block ref
+	parsed, err := r.ParseMetaKey(key(path))
+	require.NoError(t, err)
+	require.Equal(t, ref, parsed)
+}
+
+func TestResolver_ParseBlockKey(t *testing.T) {
+	r := defaultKeyResolver{}
+	ref := BlockRef{
+		Ref: Ref{
+			TenantID:       "tenant",
+			TableName:      "table_1",
+			Bounds:         v1.NewBounds(0x0000, 0xffff),
+			StartTimestamp: 0,
+			EndTimestamp:   3600000,
+			Checksum:       43981,
+		},
+	}
+
+	// encode block ref as string
+	loc := r.Block(ref)
+	path := loc.LocalPath()
+	require.Equal(t, "bloom/table_1/tenant/blocks/0000000000000000-000000000000ffff/0-3600000-abcd.tar.gz", path)
+
+	// parse encoded string into block ref
+	parsed, err := r.ParseBlockKey(key(path))
+	require.NoError(t, err)
+	require.Equal(t, ref, parsed)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

In order to prevent blocks on disk to become orphaned after restarts, we load them into the cache on startup.

The cache takes care of evicting/cleaning items when the max cache size is reached.
