### PR TITLE
docs: update storage topic to include azure

### DIFF
--- a/docs/sources/setup/install/helm/configure-storage/_index.md
+++ b/docs/sources/setup/install/helm/configure-storage/_index.md
@@ -20,9 +20,9 @@ This guide assumes Loki will be installed in one of the modes above and that a `
 
 **To use a managed object store:**
 
-1. Set the `type` of `storage` in `values.yaml` to `gcs` or `s3`.
+1. In the `values.yaml` file, set the value for `storage.type` to `azure`, `gcs` or `s3`.
 
-2. Configure the storage client under `loki.storage.gcs` or `loki.storage.s3`.
+2. Configure the storage client under `loki.storage.azure`, `loki.storage.gcs` or `loki.storage.s3`.
 
 
 **To install Minio alongside Loki:**

--- a/docs/sources/setup/install/helm/configure-storage/_index.md
+++ b/docs/sources/setup/install/helm/configure-storage/_index.md
@@ -20,9 +20,9 @@ This guide assumes Loki will be installed in one of the modes above and that a `
 
 **To use a managed object store:**
 
-1. In the `values.yaml` file, set the value for `storage.type` to `azure`, `gcs` or `s3`.
+1. In the `values.yaml` file, set the value for `storage.type` to `azure`, `gcs`, or `s3`.
 
-2. Configure the storage client under `loki.storage.azure`, `loki.storage.gcs` or `loki.storage.s3`.
+1. Configure the storage client under `loki.storage.azure`, `loki.storage.gcs`, or `loki.storage.s3`.
 
 
 **To install Minio alongside Loki:**
@@ -41,7 +41,7 @@ This guide assumes Loki will be installed in one of the modes above and that a `
 1. Provision an IAM role, policy and S3 bucket as described in [Storage]({{< relref "../../../../storage#aws-deployment-s3-single-store" >}}).
    - If the Terraform module was used note the annotation emitted by `terraform output -raw annotation`.
 
-2. Add the IAM role annotation to the service account in `values.yaml`:
+1. Add the IAM role annotation to the service account in `values.yaml`:
 
    ```
    serviceAccount:
@@ -49,7 +49,7 @@ This guide assumes Loki will be installed in one of the modes above and that a `
        "eks.amazonaws.com/role-arn": "arn:aws:iam::<account id>:role/<role name>"
    ```
 
-3. Configure the storage:
+1. Configure the storage:
 
    ```
    loki:


### PR DESCRIPTION
Someone recently pointed out on Slack that the Configure Storage topic does not mention Azure.  Updating to include Azure and revising the first step for clarity.