### PR TITLE
ci: revert release to using classic PAT

### DIFF
--- a/.github/release-workflows.jsonnet
+++ b/.github/release-workflows.jsonnet
@@ -30,6 +30,7 @@ local imageJobs = {
       skipArm=false,
       skipValidation=false,
       versioningStrategy='always-bump-patch',
+      useGitHubAppToken=true,
     ), false, false
   ),
   'minor-release-pr.yml': std.manifestYamlDoc(
@@ -45,6 +46,7 @@ local imageJobs = {
       skipArm=false,
       skipValidation=false,
       versioningStrategy='always-bump-minor',
+      useGitHubAppToken=true,
     ), false, false
   ),
   'release.yml': std.manifestYamlDoc(
@@ -54,6 +56,7 @@ local imageJobs = {
       imagePrefix='grafana',
       releaseLibRef=releaseLibRef,
       releaseRepo='grafana/loki',
+      useGitHubAppToken=false,
     ), false, false
   ),
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ env:
   IMAGE_PREFIX: "grafana"
   RELEASE_LIB_REF: "release-1.11.x"
   RELEASE_REPO: "grafana/loki"
-  USE_GITHUB_APP_TOKEN: true
+  USE_GITHUB_APP_TOKEN: false
 jobs:
   createRelease:
     if: "${{ fromJSON(needs.shouldRelease.outputs.shouldRelease) }}"


### PR DESCRIPTION
**What this PR does / why we need it**:

revert release pipeline to using grafanabot classic PAT