### PR TITLE
fix: image tag from env and pin release to v1.11.5

### DIFF
--- a/.github/jsonnetfile.json
+++ b/.github/jsonnetfile.json
@@ -8,7 +8,7 @@
           "subdir": "workflows"
         }
       },
-      "version": "release-1.11.x"
+      "version": "v1.11.5"
     }
   ],
   "legacyImports": true

--- a/.github/jsonnetfile.lock.json
+++ b/.github/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "workflows"
         }
       },
-      "version": "e5f369532d30a4f83e3abdd1f58bd52a4871a419",
-      "sum": "n2lxvnkcGKkH7iTFRRBzjPGZGOaMNZvFhdr2abEqhs0="
+      "version": "09374df9ca39fa58ec93d9e3fad4da1593186039",
+      "sum": "eMlN1tvu1jxKTdWvNfmXESn7JI+Wfu2C1wCabo7P2VQ="
     }
   ],
   "legacyImports": false

--- a/.github/release-workflows.jsonnet
+++ b/.github/release-workflows.jsonnet
@@ -1,7 +1,11 @@
 local lokiRelease = import 'workflows/main.jsonnet';
 local build = lokiRelease.build;
 
-local releaseLibRef = 'release-1.11.x';
+local releaseLibRef = std.filter(
+  function(dep) dep.source.git.remote == 'https://github.com/grafana/loki-release.git',
+  (import 'jsonnetfile.json').dependencies
+)[0].version;
+
 local checkTemplate = 'grafana/loki-release/.github/workflows/check.yml@%s' % releaseLibRef;
 
 local imageJobs = {

--- a/.github/vendor/github.com/grafana/loki-release/workflows/main.jsonnet
+++ b/.github/vendor/github.com/grafana/loki-release/workflows/main.jsonnet
@@ -75,7 +75,11 @@
         branches: branches,
       },
     },
-    permissions: 'write-all',
+    permissions: {
+      contents: 'write',
+      'pull-requests': 'write',
+      'id-token': 'write',
+    },
     concurrency: {
       group: 'create-release-${{ github.sha }}',
     },

--- a/.github/workflows/minor-release-pr.yml
+++ b/.github/workflows/minor-release-pr.yml
@@ -3,18 +3,18 @@ concurrency:
 env:
   DOCKER_USERNAME: "grafana"
   IMAGE_PREFIX: "grafana"
-  RELEASE_LIB_REF: "release-1.11.x"
+  RELEASE_LIB_REF: "v1.11.5"
   RELEASE_REPO: "grafana/loki"
   SKIP_VALIDATION: false
   USE_GITHUB_APP_TOKEN: true
   VERSIONING_STRATEGY: "always-bump-minor"
 jobs:
   check:
-    uses: "grafana/loki-release/.github/workflows/check.yml@release-1.11.x"
+    uses: "grafana/loki-release/.github/workflows/check.yml@v1.11.5"
     with:
       build_image: "grafana/loki-build-image:0.29.3-go1.20.10"
       golang_ci_lint_version: "v1.51.2"
-      release_lib_ref: "release-1.11.x"
+      release_lib_ref: "v1.11.5"
       skip_validation: false
       use_github_app_token: true
   create-release-pr:

--- a/.github/workflows/patch-release-pr.yml
+++ b/.github/workflows/patch-release-pr.yml
@@ -3,18 +3,18 @@ concurrency:
 env:
   DOCKER_USERNAME: "grafana"
   IMAGE_PREFIX: "grafana"
-  RELEASE_LIB_REF: "release-1.11.x"
+  RELEASE_LIB_REF: "v1.11.5"
   RELEASE_REPO: "grafana/loki"
   SKIP_VALIDATION: false
   USE_GITHUB_APP_TOKEN: true
   VERSIONING_STRATEGY: "always-bump-patch"
 jobs:
   check:
-    uses: "grafana/loki-release/.github/workflows/check.yml@release-1.11.x"
+    uses: "grafana/loki-release/.github/workflows/check.yml@v1.11.5"
     with:
       build_image: "grafana/loki-build-image:0.29.3-go1.20.10"
       golang_ci_lint_version: "v1.51.2"
-      release_lib_ref: "release-1.11.x"
+      release_lib_ref: "v1.11.5"
       skip_validation: false
       use_github_app_token: true
   create-release-pr:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ concurrency:
   group: "create-release-${{ github.sha }}"
 env:
   IMAGE_PREFIX: "grafana"
-  RELEASE_LIB_REF: "release-1.11.x"
+  RELEASE_LIB_REF: "v1.11.5"
   RELEASE_REPO: "grafana/loki"
   USE_GITHUB_APP_TOKEN: true
 jobs:
@@ -201,4 +201,7 @@ name: "create release"
     branches:
     - "release-[0-9]+.[0-9]+.x"
     - "k[0-9]+"
-permissions: "write-all"
+permissions:
+  contents: "write"
+  id-token: "write"
+  pull-requests: "write"

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ BUILD_IMAGE_VERSION := 0.29.3-go1.20.10
 # Docker image info
 IMAGE_PREFIX ?= grafana
 
-IMAGE_TAG := $(shell ./tools/image-tag)
+IMAGE_TAG ?= $(shell ./tools/image-tag)
 
 # Version info for binaries
 GIT_REVISION := $(shell git rev-parse --short HEAD)


### PR DESCRIPTION
**What this PR does / why we need it**:

This pins the release workflow to `v1.11.5`, which rolls back some overzealous permissions, and fixes the `Makefile` to accept `IMAGE_TAG` from the env so the binaries version information is correct.