### PR TITLE
chore(blooms): Use `bloomshipper.Interval` instead of `model.Interval`

### DIFF
--- a/pkg/bloomgateway/bloomgateway.go
+++ b/pkg/bloomgateway/bloomgateway.go
@@ -306,13 +306,14 @@ func (g *Gateway) FilterChunkRefs(ctx context.Context, req *logproto.FilterChunk
 
 	filters := syntax.ExtractLineFilters(req.Plan.AST)
 	tasks := make([]Task, 0, len(seriesByDay))
-	for _, seriesWithBounds := range seriesByDay {
-		task, err := NewTask(ctx, tenantID, seriesWithBounds, filters)
+	for _, seriesForDay := range seriesByDay {
+		task, err := NewTask(ctx, tenantID, seriesForDay, filters)
 		if err != nil {
 			return nil, err
 		}
+		level.Debug(g.logger).Log("msg", "creating task for day", "day", seriesForDay.day, "interval", seriesForDay.interval.String(), "task", task.ID)
 		tasks = append(tasks, task)
-		numSeries += len(seriesWithBounds.series)
+		numSeries += len(seriesForDay.series)
 	}
 
 	g.activeUsers.UpdateUserTimestamp(tenantID, time.Now())

--- a/pkg/bloomgateway/multiplexing.go
+++ b/pkg/bloomgateway/multiplexing.go
@@ -13,6 +13,7 @@ import (
 	"github.com/grafana/loki/pkg/logql/syntax"
 	v1 "github.com/grafana/loki/pkg/storage/bloom/v1"
 	"github.com/grafana/loki/pkg/storage/config"
+	"github.com/grafana/loki/pkg/storage/stores/shipper/bloomshipper"
 )
 
 const (
@@ -65,7 +66,7 @@ type Task struct {
 	// filters of the original request
 	filters []syntax.LineFilterExpr
 	// from..through date of the task's chunks
-	bounds model.Interval
+	interval bloomshipper.Interval
 	// the context from the request
 	ctx context.Context
 
@@ -76,7 +77,7 @@ type Task struct {
 // NewTask returns a new Task that can be enqueued to the task queue.
 // In addition, it returns a result and an error channel, as well
 // as an error if the instantiation fails.
-func NewTask(ctx context.Context, tenantID string, refs seriesWithBounds, filters []syntax.LineFilterExpr) (Task, error) {
+func NewTask(ctx context.Context, tenantID string, refs seriesWithInterval, filters []syntax.LineFilterExpr) (Task, error) {
 	key, err := ulid.New(ulid.Now(), entropy)
 	if err != nil {
 		return Task{}, err
@@ -89,8 +90,8 @@ func NewTask(ctx context.Context, tenantID string, refs seriesWithBounds, filter
 		resCh:     make(chan v1.Output),
 		filters:   filters,
 		series:    refs.series,
-		bounds:    refs.bounds,
-		table:     refs.table,
+		interval:  refs.interval,
+		table:     refs.day,
 		ctx:       ctx,
 		done:      make(chan struct{}),
 		responses: make([]v1.Output, 0, len(refs.series)),
@@ -98,8 +99,10 @@ func NewTask(ctx context.Context, tenantID string, refs seriesWithBounds, filter
 	return task, nil
 }
 
+// Bounds implements Bounded
+// see pkg/storage/stores/shipper/indexshipper/tsdb.Bounded
 func (t Task) Bounds() (model.Time, model.Time) {
-	return t.bounds.Start, t.bounds.End
+	return t.interval.Start, t.interval.End
 }
 
 func (t Task) Done() <-chan struct{} {
@@ -129,7 +132,7 @@ func (t Task) Copy(series []*logproto.GroupedChunkRefs) Task {
 		resCh:     t.resCh,
 		filters:   t.filters,
 		series:    series,
-		bounds:    t.bounds,
+		interval:  t.interval,
 		table:     t.table,
 		ctx:       t.ctx,
 		done:      make(chan struct{}),

--- a/pkg/bloomgateway/multiplexing_test.go
+++ b/pkg/bloomgateway/multiplexing_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/grafana/loki/pkg/logproto"
 	"github.com/grafana/loki/pkg/logql/syntax"
 	v1 "github.com/grafana/loki/pkg/storage/bloom/v1"
+	"github.com/grafana/loki/pkg/storage/stores/shipper/bloomshipper"
 )
 
 func TestTask(t *testing.T) {
@@ -59,7 +60,7 @@ func TestTask_RequestIterator(t *testing.T) {
 
 	t.Run("empty request yields empty iterator", func(t *testing.T) {
 		swb := seriesWithInterval{
-			interval: model.Interval{Start: 0, End: math.MaxInt64},
+			interval: bloomshipper.Interval{Start: 0, End: math.MaxInt64},
 			series:   []*logproto.GroupedChunkRefs{},
 		}
 		task, _ := NewTask(context.Background(), tenant, swb, []syntax.LineFilterExpr{})

--- a/pkg/bloomgateway/multiplexing_test.go
+++ b/pkg/bloomgateway/multiplexing_test.go
@@ -58,9 +58,9 @@ func TestTask_RequestIterator(t *testing.T) {
 	tokenizer := v1.NewNGramTokenizer(4, 0)
 
 	t.Run("empty request yields empty iterator", func(t *testing.T) {
-		swb := seriesWithBounds{
-			bounds: model.Interval{Start: 0, End: math.MaxInt64},
-			series: []*logproto.GroupedChunkRefs{},
+		swb := seriesWithInterval{
+			interval: model.Interval{Start: 0, End: math.MaxInt64},
+			series:   []*logproto.GroupedChunkRefs{},
 		}
 		task, _ := NewTask(context.Background(), tenant, swb, []syntax.LineFilterExpr{})
 		it := task.RequestIter(tokenizer)

--- a/pkg/bloomgateway/processor_test.go
+++ b/pkg/bloomgateway/processor_test.go
@@ -104,13 +104,13 @@ func TestProcessor(t *testing.T) {
 		p := newProcessor("worker", mockStore, log.NewNopLogger(), metrics)
 
 		chunkRefs := createQueryInputFromBlockData(t, tenant, data, 10)
-		swb := seriesWithBounds{
+		swb := seriesWithInterval{
 			series: groupRefs(t, chunkRefs),
-			bounds: model.Interval{
+			interval: model.Interval{
 				Start: now.Add(-1 * time.Hour),
 				End:   now,
 			},
-			table: config.NewDayTime(truncateDay(now)),
+			day: config.NewDayTime(truncateDay(now)),
 		}
 		filters := []syntax.LineFilterExpr{
 			{
@@ -153,13 +153,13 @@ func TestProcessor(t *testing.T) {
 		p := newProcessor("worker", mockStore, log.NewNopLogger(), metrics)
 
 		chunkRefs := createQueryInputFromBlockData(t, tenant, data, 10)
-		swb := seriesWithBounds{
+		swb := seriesWithInterval{
 			series: groupRefs(t, chunkRefs),
-			bounds: model.Interval{
+			interval: model.Interval{
 				Start: now.Add(-1 * time.Hour),
 				End:   now,
 			},
-			table: config.NewDayTime(truncateDay(now)),
+			day: config.NewDayTime(truncateDay(now)),
 		}
 		filters := []syntax.LineFilterExpr{
 			{

--- a/pkg/bloomgateway/processor_test.go
+++ b/pkg/bloomgateway/processor_test.go
@@ -106,7 +106,7 @@ func TestProcessor(t *testing.T) {
 		chunkRefs := createQueryInputFromBlockData(t, tenant, data, 10)
 		swb := seriesWithInterval{
 			series: groupRefs(t, chunkRefs),
-			interval: model.Interval{
+			interval: bloomshipper.Interval{
 				Start: now.Add(-1 * time.Hour),
 				End:   now,
 			},
@@ -155,7 +155,7 @@ func TestProcessor(t *testing.T) {
 		chunkRefs := createQueryInputFromBlockData(t, tenant, data, 10)
 		swb := seriesWithInterval{
 			series: groupRefs(t, chunkRefs),
-			interval: model.Interval{
+			interval: bloomshipper.Interval{
 				Start: now.Add(-1 * time.Hour),
 				End:   now,
 			},

--- a/pkg/bloomgateway/util.go
+++ b/pkg/bloomgateway/util.go
@@ -128,14 +128,14 @@ func partitionTasks(tasks []Task, blocks []bloomshipper.BlockRef) []blockWithTas
 	return result
 }
 
-type seriesWithBounds struct {
-	bounds model.Interval
-	table  config.DayTime
-	series []*logproto.GroupedChunkRefs
+type seriesWithInterval struct {
+	day      config.DayTime
+	series   []*logproto.GroupedChunkRefs
+	interval bloomshipper.Interval
 }
 
-func partitionRequest(req *logproto.FilterChunkRefRequest) []seriesWithBounds {
-	result := make([]seriesWithBounds, 0)
+func partitionRequest(req *logproto.FilterChunkRefRequest) []seriesWithInterval {
+	result := make([]seriesWithInterval, 0)
 
 	fromDay, throughDay := truncateDay(req.From), truncateDay(req.Through)
 
@@ -177,12 +177,12 @@ func partitionRequest(req *logproto.FilterChunkRefRequest) []seriesWithBounds {
 		}
 
 		if len(res) > 0 {
-			result = append(result, seriesWithBounds{
-				bounds: model.Interval{
+			result = append(result, seriesWithInterval{
+				interval: bloomshipper.Interval{
 					Start: minTs,
 					End:   maxTs,
 				},
-				table:  config.NewDayTime(day),
+				day:    config.NewDayTime(day),
 				series: res,
 			})
 		}

--- a/pkg/bloomgateway/util_test.go
+++ b/pkg/bloomgateway/util_test.go
@@ -143,7 +143,7 @@ func TestPartitionRequest(t *testing.T) {
 
 	testCases := map[string]struct {
 		inp *logproto.FilterChunkRefRequest
-		exp []seriesWithBounds
+		exp []seriesWithInterval
 	}{
 
 		"empty": {
@@ -151,7 +151,7 @@ func TestPartitionRequest(t *testing.T) {
 				From:    ts.Add(-24 * time.Hour),
 				Through: ts,
 			},
-			exp: []seriesWithBounds{},
+			exp: []seriesWithInterval{},
 		},
 
 		"all chunks within single day": {
@@ -173,10 +173,10 @@ func TestPartitionRequest(t *testing.T) {
 					},
 				},
 			},
-			exp: []seriesWithBounds{
+			exp: []seriesWithInterval{
 				{
-					bounds: model.Interval{Start: ts.Add(-60 * time.Minute), End: ts.Add(-45 * time.Minute)},
-					table:  config.NewDayTime(mktime("2024-01-24 00:00")),
+					interval: bloomshipper.Interval{Start: ts.Add(-60 * time.Minute), End: ts.Add(-45 * time.Minute)},
+					day:      config.NewDayTime(mktime("2024-01-24 00:00")),
 					series: []*logproto.GroupedChunkRefs{
 						{
 							Fingerprint: 0x00,
@@ -214,10 +214,10 @@ func TestPartitionRequest(t *testing.T) {
 					},
 				},
 			},
-			exp: []seriesWithBounds{
+			exp: []seriesWithInterval{
 				{
-					bounds: model.Interval{Start: ts.Add(-23 * time.Hour), End: ts.Add(-22 * time.Hour)},
-					table:  config.NewDayTime(mktime("2024-01-23 00:00")),
+					interval: bloomshipper.Interval{Start: ts.Add(-23 * time.Hour), End: ts.Add(-22 * time.Hour)},
+					day:      config.NewDayTime(mktime("2024-01-23 00:00")),
 					series: []*logproto.GroupedChunkRefs{
 						{
 							Fingerprint: 0x00,
@@ -228,8 +228,8 @@ func TestPartitionRequest(t *testing.T) {
 					},
 				},
 				{
-					bounds: model.Interval{Start: ts.Add(-2 * time.Hour), End: ts.Add(-1 * time.Hour)},
-					table:  config.NewDayTime(mktime("2024-01-24 00:00")),
+					interval: bloomshipper.Interval{Start: ts.Add(-2 * time.Hour), End: ts.Add(-1 * time.Hour)},
+					day:      config.NewDayTime(mktime("2024-01-24 00:00")),
 					series: []*logproto.GroupedChunkRefs{
 						{
 							Fingerprint: 0x01,
@@ -255,10 +255,10 @@ func TestPartitionRequest(t *testing.T) {
 					},
 				},
 			},
-			exp: []seriesWithBounds{
+			exp: []seriesWithInterval{
 				{
-					bounds: model.Interval{Start: ts.Add(-13 * time.Hour), End: ts.Add(-11 * time.Hour)},
-					table:  config.NewDayTime(mktime("2024-01-23 00:00")),
+					interval: bloomshipper.Interval{Start: ts.Add(-13 * time.Hour), End: ts.Add(-11 * time.Hour)},
+					day:      config.NewDayTime(mktime("2024-01-23 00:00")),
 					series: []*logproto.GroupedChunkRefs{
 						{
 							Fingerprint: 0x00,
@@ -269,8 +269,8 @@ func TestPartitionRequest(t *testing.T) {
 					},
 				},
 				{
-					bounds: model.Interval{Start: ts.Add(-13 * time.Hour), End: ts.Add(-11 * time.Hour)},
-					table:  config.NewDayTime(mktime("2024-01-24 00:00")),
+					interval: bloomshipper.Interval{Start: ts.Add(-13 * time.Hour), End: ts.Add(-11 * time.Hour)},
+					day:      config.NewDayTime(mktime("2024-01-24 00:00")),
 					series: []*logproto.GroupedChunkRefs{
 						{
 							Fingerprint: 0x00,

--- a/pkg/storage/bloom/v1/bloom_tokenizer.go
+++ b/pkg/storage/bloom/v1/bloom_tokenizer.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/grafana/dskit/multierror"
+
 	"github.com/grafana/loki/pkg/iter"
 
 	"github.com/grafana/loki/pkg/util/encoding"

--- a/pkg/storage/stores/shipper/bloomshipper/cache_test.go
+++ b/pkg/storage/stores/shipper/bloomshipper/cache_test.go
@@ -9,9 +9,10 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
-	"github.com/grafana/loki/pkg/logqlmodel/stats"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
+
+	"github.com/grafana/loki/pkg/logqlmodel/stats"
 )
 
 type mockCache[K comparable, V any] struct {

--- a/pkg/storage/stores/shipper/bloomshipper/resolver_test.go
+++ b/pkg/storage/stores/shipper/bloomshipper/resolver_test.go
@@ -3,8 +3,9 @@ package bloomshipper
 import (
 	"testing"
 
-	v1 "github.com/grafana/loki/pkg/storage/bloom/v1"
 	"github.com/stretchr/testify/require"
+
+	v1 "github.com/grafana/loki/pkg/storage/bloom/v1"
 )
 
 func TestResolver_ParseMetaKey(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Just a minor cleanup.