### PR TITLE
fix: Add data race protection for the tm.wg var

### DIFF
--- a/pkg/storage/stores/shipper/indexshipper/downloads/table_manager.go
+++ b/pkg/storage/stores/shipper/indexshipper/downloads/table_manager.go
@@ -116,7 +116,9 @@ func NewTableManager(cfg Config, openIndexFileFunc index.OpenIndexFileFunc, inde
 }
 
 func (tm *tableManager) loop() {
+	tm.tablesMtx.Lock()
 	tm.wg.Add(1)
+	tm.tablesMtx.Unlock()
 	defer tm.wg.Done()
 
 	syncTicker := time.NewTicker(tm.cfg.SyncInterval)
@@ -151,10 +153,10 @@ func (tm *tableManager) loop() {
 
 func (tm *tableManager) Stop() {
 	tm.cancel()
-	tm.wg.Wait()
 
 	tm.tablesMtx.Lock()
 	defer tm.tablesMtx.Unlock()
+	tm.wg.Wait()
 
 	for _, table := range tm.tables {
 		table.Close()


### PR DESCRIPTION
**What this PR does / why we need it**:
Moves access to the `table_manager.wg` var behind the existing `tablesMtx` mutex
**Which issue(s) this PR fixes**:
relates to: https://github.com/grafana/loki/issues/8586

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
