### PR TITLE
feat: Configure SpreadMinimizingTokenGenerator in ring config

### DIFF
--- a/docs/sources/configure/_index.md
+++ b/docs/sources/configure/_index.md
@@ -719,6 +719,25 @@ scheduler_ring:
   # Enable using a IPv6 instance address.
   # CLI flag: -query-scheduler.ring.instance-enable-ipv6
   [instance_enable_ipv6: <boolean> | default = false]
+
+  # Specifies the strategy used for generating tokens. Supported values are:
+  # random,spread-minimizing.
+  # CLI flag: -query-scheduler.ring.token-generation-strategy
+  [token_generation_strategy: <string> | default = "random"]
+
+  # True to allow this instances registering tokens in the ring only after all
+  # previous instances (with ID lower than the current one) have already been
+  # registered. This configuration option is supported only when the token
+  # generation strategy is set to "spread-minimizing".
+  # CLI flag: -query-scheduler.ring.spread-minimizing-join-ring-in-order
+  [spread_minimizing_join_ring_in_order: <boolean> | default = false]
+
+  # Comma-separated list of zones in which spread minimizing strategy is used
+  # for token generation. This value must include all zones in which the
+  # component is deployed, and must not change over time. This configuration is
+  # used only when `token-generation-strategy` is set to "spread-minimizing".
+  # CLI flag: -query-scheduler.ring.spread-minimizing-zones
+  [spread_minimizing_zones: <string> | default = ""]
 ```
 
 ### frontend
@@ -1783,6 +1802,25 @@ ring:
   # CLI flag: -index-gateway.ring.instance-enable-ipv6
   [instance_enable_ipv6: <boolean> | default = false]
 
+  # Specifies the strategy used for generating tokens. Supported values are:
+  # random,spread-minimizing.
+  # CLI flag: -index-gateway.ring.token-generation-strategy
+  [token_generation_strategy: <string> | default = "random"]
+
+  # True to allow this instances registering tokens in the ring only after all
+  # previous instances (with ID lower than the current one) have already been
+  # registered. This configuration option is supported only when the token
+  # generation strategy is set to "spread-minimizing".
+  # CLI flag: -index-gateway.ring.spread-minimizing-join-ring-in-order
+  [spread_minimizing_join_ring_in_order: <boolean> | default = false]
+
+  # Comma-separated list of zones in which spread minimizing strategy is used
+  # for token generation. This value must include all zones in which the
+  # component is deployed, and must not change over time. This configuration is
+  # used only when `token-generation-strategy` is set to "spread-minimizing".
+  # CLI flag: -index-gateway.ring.spread-minimizing-zones
+  [spread_minimizing_zones: <string> | default = ""]
+
   # Deprecated: How many index gateway instances are assigned to each tenant.
   # Use -index-gateway.shard-size instead. The shard size is also a per-tenant
   # setting.
@@ -1879,6 +1917,25 @@ ring:
   # Enable using a IPv6 instance address.
   # CLI flag: -bloom-gateway.ring.instance-enable-ipv6
   [instance_enable_ipv6: <boolean> | default = false]
+
+  # Specifies the strategy used for generating tokens. Supported values are:
+  # random,spread-minimizing.
+  # CLI flag: -bloom-gateway.ring.token-generation-strategy
+  [token_generation_strategy: <string> | default = "random"]
+
+  # True to allow this instances registering tokens in the ring only after all
+  # previous instances (with ID lower than the current one) have already been
+  # registered. This configuration option is supported only when the token
+  # generation strategy is set to "spread-minimizing".
+  # CLI flag: -bloom-gateway.ring.spread-minimizing-join-ring-in-order
+  [spread_minimizing_join_ring_in_order: <boolean> | default = false]
+
+  # Comma-separated list of zones in which spread minimizing strategy is used
+  # for token generation. This value must include all zones in which the
+  # component is deployed, and must not change over time. This configuration is
+  # used only when `token-generation-strategy` is set to "spread-minimizing".
+  # CLI flag: -bloom-gateway.ring.spread-minimizing-zones
+  [spread_minimizing_zones: <string> | default = ""]
 
   # Factor for data replication.
   # CLI flag: -bloom-gateway.replication-factor
@@ -2562,6 +2619,25 @@ compactor_ring:
   # CLI flag: -compactor.ring.instance-enable-ipv6
   [instance_enable_ipv6: <boolean> | default = false]
 
+  # Specifies the strategy used for generating tokens. Supported values are:
+  # random,spread-minimizing.
+  # CLI flag: -compactor.ring.token-generation-strategy
+  [token_generation_strategy: <string> | default = "random"]
+
+  # True to allow this instances registering tokens in the ring only after all
+  # previous instances (with ID lower than the current one) have already been
+  # registered. This configuration option is supported only when the token
+  # generation strategy is set to "spread-minimizing".
+  # CLI flag: -compactor.ring.spread-minimizing-join-ring-in-order
+  [spread_minimizing_join_ring_in_order: <boolean> | default = false]
+
+  # Comma-separated list of zones in which spread minimizing strategy is used
+  # for token generation. This value must include all zones in which the
+  # component is deployed, and must not change over time. This configuration is
+  # used only when `token-generation-strategy` is set to "spread-minimizing".
+  # CLI flag: -compactor.ring.spread-minimizing-zones
+  [spread_minimizing_zones: <string> | default = ""]
+
 # Number of tables that compactor will try to compact. Newer tables are chosen
 # when this is less than the number of tables available.
 # CLI flag: -compactor.tables-to-compact
@@ -2662,6 +2738,25 @@ ring:
   # Enable using a IPv6 instance address.
   # CLI flag: -bloom-compactor.ring.instance-enable-ipv6
   [instance_enable_ipv6: <boolean> | default = false]
+
+  # Specifies the strategy used for generating tokens. Supported values are:
+  # random,spread-minimizing.
+  # CLI flag: -bloom-compactor.ring.token-generation-strategy
+  [token_generation_strategy: <string> | default = "random"]
+
+  # True to allow this instances registering tokens in the ring only after all
+  # previous instances (with ID lower than the current one) have already been
+  # registered. This configuration option is supported only when the token
+  # generation strategy is set to "spread-minimizing".
+  # CLI flag: -bloom-compactor.ring.spread-minimizing-join-ring-in-order
+  [spread_minimizing_join_ring_in_order: <boolean> | default = false]
+
+  # Comma-separated list of zones in which spread minimizing strategy is used
+  # for token generation. This value must include all zones in which the
+  # component is deployed, and must not change over time. This configuration is
+  # used only when `token-generation-strategy` is set to "spread-minimizing".
+  # CLI flag: -bloom-compactor.ring.spread-minimizing-zones
+  [spread_minimizing_zones: <string> | default = ""]
 
 # Flag to enable or disable the usage of the bloom-compactor component.
 # CLI flag: -bloom-compactor.enabled
@@ -3845,6 +3940,25 @@ ring:
   # Enable using a IPv6 instance address.
   # CLI flag: -common.storage.ring.instance-enable-ipv6
   [instance_enable_ipv6: <boolean> | default = false]
+
+  # Specifies the strategy used for generating tokens. Supported values are:
+  # random,spread-minimizing.
+  # CLI flag: -common.storage.ring.token-generation-strategy
+  [token_generation_strategy: <string> | default = "random"]
+
+  # True to allow this instances registering tokens in the ring only after all
+  # previous instances (with ID lower than the current one) have already been
+  # registered. This configuration option is supported only when the token
+  # generation strategy is set to "spread-minimizing".
+  # CLI flag: -common.storage.ring.spread-minimizing-join-ring-in-order
+  [spread_minimizing_join_ring_in_order: <boolean> | default = false]
+
+  # Comma-separated list of zones in which spread minimizing strategy is used
+  # for token generation. This value must include all zones in which the
+  # component is deployed, and must not change over time. This configuration is
+  # used only when `token-generation-strategy` is set to "spread-minimizing".
+  # CLI flag: -common.storage.ring.spread-minimizing-zones
+  [spread_minimizing_zones: <string> | default = ""]
 
 [instance_interface_names: <list of strings> | default = [<private network interfaces>]]
 

--- a/pkg/loki/config_wrapper.go
+++ b/pkg/loki/config_wrapper.go
@@ -275,6 +275,9 @@ func applyConfigToRings(r, defaults *ConfigWrapper, rc lokiring.RingConfig, merg
 		r.QueryScheduler.SchedulerRing.InstanceZone = rc.InstanceZone
 		r.QueryScheduler.SchedulerRing.ZoneAwarenessEnabled = rc.ZoneAwarenessEnabled
 		r.QueryScheduler.SchedulerRing.KVStore = rc.KVStore
+		r.QueryScheduler.SchedulerRing.TokenGenerationStrategy = rc.TokenGenerationStrategy
+		r.QueryScheduler.SchedulerRing.SpreadMinimizingZones = rc.SpreadMinimizingZones
+		r.QueryScheduler.SchedulerRing.SpreadMinimizingJoinRingInOrder = rc.SpreadMinimizingJoinRingInOrder
 	}
 
 	// Compactor
@@ -288,6 +291,9 @@ func applyConfigToRings(r, defaults *ConfigWrapper, rc lokiring.RingConfig, merg
 		r.CompactorConfig.CompactorRing.InstanceZone = rc.InstanceZone
 		r.CompactorConfig.CompactorRing.ZoneAwarenessEnabled = rc.ZoneAwarenessEnabled
 		r.CompactorConfig.CompactorRing.KVStore = rc.KVStore
+		r.CompactorConfig.CompactorRing.TokenGenerationStrategy = rc.TokenGenerationStrategy
+		r.CompactorConfig.CompactorRing.SpreadMinimizingZones = rc.SpreadMinimizingZones
+		r.CompactorConfig.CompactorRing.SpreadMinimizingJoinRingInOrder = rc.SpreadMinimizingJoinRingInOrder
 	}
 
 	// IndexGateway
@@ -301,6 +307,9 @@ func applyConfigToRings(r, defaults *ConfigWrapper, rc lokiring.RingConfig, merg
 		r.IndexGateway.Ring.InstanceZone = rc.InstanceZone
 		r.IndexGateway.Ring.ZoneAwarenessEnabled = rc.ZoneAwarenessEnabled
 		r.IndexGateway.Ring.KVStore = rc.KVStore
+		r.IndexGateway.Ring.TokenGenerationStrategy = rc.TokenGenerationStrategy
+		r.IndexGateway.Ring.SpreadMinimizingZones = rc.SpreadMinimizingZones
+		r.IndexGateway.Ring.SpreadMinimizingJoinRingInOrder = rc.SpreadMinimizingJoinRingInOrder
 	}
 
 	// BloomCompactor
@@ -314,6 +323,9 @@ func applyConfigToRings(r, defaults *ConfigWrapper, rc lokiring.RingConfig, merg
 		r.BloomCompactor.Ring.InstanceZone = rc.InstanceZone
 		r.BloomCompactor.Ring.ZoneAwarenessEnabled = rc.ZoneAwarenessEnabled
 		r.BloomCompactor.Ring.KVStore = rc.KVStore
+		r.BloomCompactor.Ring.TokenGenerationStrategy = rc.TokenGenerationStrategy
+		r.BloomCompactor.Ring.SpreadMinimizingZones = rc.SpreadMinimizingZones
+		r.BloomCompactor.Ring.SpreadMinimizingJoinRingInOrder = rc.SpreadMinimizingJoinRingInOrder
 	}
 
 	// BloomGateway
@@ -327,6 +339,9 @@ func applyConfigToRings(r, defaults *ConfigWrapper, rc lokiring.RingConfig, merg
 		r.BloomGateway.Ring.InstanceZone = rc.InstanceZone
 		r.BloomGateway.Ring.ZoneAwarenessEnabled = rc.ZoneAwarenessEnabled
 		r.BloomGateway.Ring.KVStore = rc.KVStore
+		r.BloomGateway.Ring.TokenGenerationStrategy = rc.TokenGenerationStrategy
+		r.BloomGateway.Ring.SpreadMinimizingZones = rc.SpreadMinimizingZones
+		r.BloomGateway.Ring.SpreadMinimizingJoinRingInOrder = rc.SpreadMinimizingJoinRingInOrder
 	}
 }
 

--- a/pkg/loki/config_wrapper_test.go
+++ b/pkg/loki/config_wrapper_test.go
@@ -1174,7 +1174,7 @@ func Test_applyIngesterRingConfig(t *testing.T) {
 		assert.Equal(t, 9,
 			reflect.TypeOf(distributor.RingConfig{}).NumField(),
 			fmt.Sprintf(msgf, reflect.TypeOf(distributor.RingConfig{}).String()))
-		assert.Equal(t, 13,
+		assert.Equal(t, 16,
 			reflect.TypeOf(lokiring.RingConfig{}).NumField(),
 			fmt.Sprintf(msgf, reflect.TypeOf(lokiring.RingConfig{}).String()))
 	})

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -1484,6 +1484,8 @@ func (t *Loki) initBloomCompactorRing() (services.Service, error) {
 
 	// TODO(owen-d): configurable num tokens, just use lifecycler config?
 	numTokens := 10
+	t.Cfg.BloomCompactor.Ring.InstanceZone = "none"
+	t.Cfg.BloomCompactor.Ring.SpreadMinimizingZones = []string{"none"}
 	rm, err := lokiring.NewRingManager(bloomCompactorRingKey, lokiring.ServerMode, t.Cfg.BloomCompactor.Ring, 1, numTokens, util_log.Logger, prometheus.DefaultRegisterer)
 
 	if err != nil {

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -1484,8 +1484,6 @@ func (t *Loki) initBloomCompactorRing() (services.Service, error) {
 
 	// TODO(owen-d): configurable num tokens, just use lifecycler config?
 	numTokens := 10
-	t.Cfg.BloomCompactor.Ring.InstanceZone = "none"
-	t.Cfg.BloomCompactor.Ring.SpreadMinimizingZones = []string{"none"}
 	rm, err := lokiring.NewRingManager(bloomCompactorRingKey, lokiring.ServerMode, t.Cfg.BloomCompactor.Ring, 1, numTokens, util_log.Logger, prometheus.DefaultRegisterer)
 
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds support for configuring two token generation startegies for the ring:
- Random: the one we currently use
- Spread-minimizing: strategy that creates tokens based on the id of each instance. 

**Special notes for your reviewer**:
The  Spread-minimizing startegy from dskit expects zone-awareness to be configured. We don't configure it in the bloom-compactors so we are creating one fake zone.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
