### PR TITLE
test: Update chunk/cache/mock to have a GetKeys() function 

### DIFF
--- a/pkg/storage/chunk/cache/mock.go
+++ b/pkg/storage/chunk/cache/mock.go
@@ -12,6 +12,7 @@ type MockCache interface {
 	NumKeyUpdates() int
 	GetInternal() map[string][]byte
 	KeysRequested() int
+	GetKeys() []string
 }
 
 type mockCache struct {
@@ -60,6 +61,17 @@ func (m *mockCache) NumKeyUpdates() int {
 
 func (m *mockCache) GetInternal() map[string][]byte {
 	return m.cache
+}
+
+func (m *mockCache) GetKeys() []string {
+	m.Lock()
+	defer m.Unlock()
+
+	keys := make([]string, 0, len(m.cache))
+	for key := range m.cache {
+		keys = append(keys, key)
+	}
+	return keys
 }
 
 func (m *mockCache) KeysRequested() int {

--- a/pkg/storage/chunk/fetcher/fetcher_test.go
+++ b/pkg/storage/chunk/fetcher/fetcher_test.go
@@ -200,11 +200,11 @@ func Test(t *testing.T) {
 			chks, err := f.FetchChunks(context.Background(), test.fetch)
 			assert.NoError(t, err)
 			assertChunks(t, test.fetch, chks)
-			l1actual, err := makeChunksFromMap(c1.GetInternal())
+			l1actual, err := makeChunksFromMapKeys(c1.GetKeys())
 			assert.NoError(t, err)
 			assert.Equal(t, test.l1KeysRequested, c1.KeysRequested())
 			assertChunks(t, test.l1End, l1actual)
-			l2actual, err := makeChunksFromMap(c2.GetInternal())
+			l2actual, err := makeChunksFromMapKeys(c2.GetKeys())
 			assert.NoError(t, err)
 			assert.Equal(t, test.l2KeysRequested, c2.KeysRequested())
 			assertChunks(t, test.l2End, l2actual)
@@ -340,9 +340,9 @@ func makeChunks(now time.Time, tpls ...c) []chunk.Chunk {
 	return chks
 }
 
-func makeChunksFromMap(m map[string][]byte) ([]chunk.Chunk, error) {
-	chks := make([]chunk.Chunk, 0, len(m))
-	for k := range m {
+func makeChunksFromMapKeys(keys []string) ([]chunk.Chunk, error) {
+	chks := make([]chunk.Chunk, 0, len(keys))
+	for _, k := range keys {
 		c, err := chunk.ParseExternalKey("fake", k)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
The new `GetKeys()` function will prevent a data race found.

**What this PR does / why we need it**:

Before the fix:
```
==================
WARNING: DATA RACE
Read at 0x00c000315140 by goroutine 111:
  github.com/grafana/loki/pkg/storage/chunk/fetcher.makeChunksFromMap()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/storage/chunk/fetcher/fetcher_test.go:344 +0x34
  github.com/grafana/loki/pkg/storage/chunk/fetcher.Test.func1()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/storage/chunk/fetcher/fetcher_test.go:207 +0xf7c
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.21.6/libexec/src/testing/testing.go:1595 +0x1b0
  testing.(*T).Run.func1()
      /opt/homebrew/Cellar/go/1.21.6/libexec/src/testing/testing.go:1648 +0x40

Previous write at 0x00c000315140 by goroutine 132:
  runtime.mapaccess2_faststr()
      /opt/homebrew/Cellar/go/1.21.6/libexec/src/runtime/map_faststr.go:108 +0x42c
  github.com/grafana/loki/pkg/storage/chunk/cache.(*mockCache).Store()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/storage/chunk/cache/mock.go:28 +0x1bc
  github.com/grafana/loki/pkg/storage/chunk/fetcher.(*Fetcher).WriteBackCache()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/storage/chunk/fetcher/fetcher.go:318 +0xac4
  github.com/grafana/loki/pkg/storage/chunk/fetcher.(*Fetcher).asyncWriteBackCacheQueueProcessLoop()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/storage/chunk/fetcher/fetcher.go:136 +0x118
  github.com/grafana/loki/pkg/storage/chunk/fetcher.New.func2()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/storage/chunk/fetcher/fetcher.go:115 +0x34

Goroutine 111 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.21.6/libexec/src/testing/testing.go:1648 +0x5e8
  github.com/grafana/loki/pkg/storage/chunk/fetcher.Test()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/storage/chunk/fetcher/fetcher_test.go:156 +0x2990
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.21.6/libexec/src/testing/testing.go:1595 +0x1b0
  testing.(*T).Run.func1()
      /opt/homebrew/Cellar/go/1.21.6/libexec/src/testing/testing.go:1648 +0x40

Goroutine 132 (running) created at:
  github.com/grafana/loki/pkg/storage/chunk/fetcher.New()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/storage/chunk/fetcher/fetcher.go:115 +0x3bc
  github.com/grafana/loki/pkg/storage/chunk/fetcher.Test.func1()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/storage/chunk/fetcher/fetcher_test.go:196 +0xde4
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.21.6/libexec/src/testing/testing.go:1595 +0x1b0
  testing.(*T).Run.func1()
      /opt/homebrew/Cellar/go/1.21.6/libexec/src/testing/testing.go:1648 +0x40
```


After the fix:
```
fetcher % go test . -count=50 -race
ok  	github.com/grafana/loki/pkg/storage/chunk/fetcher	154.566s
```

**Which issue(s) this PR fixes**:
Relates to: https://github.com/grafana/loki/issues/8586

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
