### PR TITLE
Fix for a few data races

### DIFF
--- a/pkg/querier/queryrange/split_by_interval_test.go
+++ b/pkg/querier/queryrange/split_by_interval_test.go
@@ -1852,7 +1852,11 @@ func Test_ExitEarly(t *testing.T) {
 
 	res, err := split.Do(ctx, req)
 
-	require.Equal(t, int(req.Limit), callCt)
+	mtx.Lock()
+	count := callCt
+	mtx.Unlock()
+
+	require.Equal(t, int(req.Limit), count)
 	require.NoError(t, err)
 	require.Equal(t, expected, res)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Two different races addressed in this PR.

```

go test . -race -count=50 -run Test_ExitEarly -v   
=== RUN   Test_ExitEarly
--- PASS: Test_ExitEarly (0.00s)
=== RUN   Test_ExitEarly
==================
WARNING: DATA RACE
Write at 0x00c00064e508 by goroutine 115:
  github.com/grafana/loki/pkg/querier/queryrange.Test_ExitEarly.func1()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/querier/queryrange/split_by_interval_test.go:1779 +0xb4
  github.com/grafana/loki/pkg/querier/queryrange/queryrangebase.HandlerFunc.Do()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/querier/queryrange/queryrangebase/roundtrip.go:80 +0x50
  github.com/grafana/loki/pkg/querier/queryrange.(*seriesLimiter).Do()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/querier/queryrange/limits.go:415 +0x7c
  github.com/grafana/loki/pkg/querier/queryrange.(*splitByInterval).loop()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/querier/queryrange/split_by_interval.go:162 +0x114
  github.com/grafana/loki/pkg/querier/queryrange.(*splitByInterval).Process.func1()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/querier/queryrange/split_by_interval.go:126 +0x70

Previous read at 0x00c00064e508 by goroutine 113:
  github.com/grafana/loki/pkg/querier/queryrange.Test_ExitEarly()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/querier/queryrange/split_by_interval_test.go:1855 +0x940
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.21.6/libexec/src/testing/testing.go:1595 +0x1b0
  testing.(*T).Run.func1()
      /opt/homebrew/Cellar/go/1.21.6/libexec/src/testing/testing.go:1648 +0x40

Goroutine 115 (running) created at:
  github.com/grafana/loki/pkg/querier/queryrange.(*splitByInterval).Process()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/querier/queryrange/split_by_interval.go:126 +0x140
  github.com/grafana/loki/pkg/querier/queryrange.(*splitByInterval).Do()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/querier/queryrange/split_by_interval.go:244 +0xb20
  github.com/grafana/loki/pkg/querier/queryrange.Test_ExitEarly()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/querier/queryrange/split_by_interval_test.go:1853 +0x910
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.21.6/libexec/src/testing/testing.go:1595 +0x1b0
  testing.(*T).Run.func1()
      /opt/homebrew/Cellar/go/1.21.6/libexec/src/testing/testing.go:1648 +0x40

Goroutine 113 (finished) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.21.6/libexec/src/testing/testing.go:1648 +0x5e8
  testing.runTests.func1()
      /opt/homebrew/Cellar/go/1.21.6/libexec/src/testing/testing.go:2054 +0x80
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.21.6/libexec/src/testing/testing.go:1595 +0x1b0
  testing.runTests()
      /opt/homebrew/Cellar/go/1.21.6/libexec/src/testing/testing.go:2052 +0x6e4
  testing.(*M).Run()
      /opt/homebrew/Cellar/go/1.21.6/libexec/src/testing/testing.go:1925 +0x9ec
  main.main()
      _testmain.go:273 +0x294
==================
```
after fix:
```
go test . -race -count=50 -run Test_ExitEarly
PASS
ok  	github.com/grafana/loki/pkg/querier/queryrange	1.778s
```
and

```
go test -count=10 -race . -run earlyExitOnQuorum
==================
WARNING: DATA RACE
Read at 0x00c00073a248 by goroutine 120:
  github.com/grafana/loki/pkg/querier.TestIngesterQuerier_earlyExitOnQuorum.func5.1()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/querier/ingester_querier_test.go:91 +0x128
  github.com/stretchr/testify/mock.(*Mock).MethodCalled()
      /Users/progers/dev/src/github.com/grafana/loki/vendor/github.com/stretchr/testify/mock/mock.go:552 +0xd3c
  github.com/stretchr/testify/mock.(*Mock).Called()
      /Users/progers/dev/src/github.com/grafana/loki/vendor/github.com/stretchr/testify/mock/mock.go:464 +0x140
  github.com/grafana/loki/pkg/querier.(*querierClientMock).Label()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/querier/querier_mock_test.go:69 +0x164
  github.com/grafana/loki/pkg/querier.(*IngesterQuerier).Label.func1()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/querier/ingester_querier.go:145 +0x60
  github.com/grafana/loki/pkg/querier.(*IngesterQuerier).forGivenIngesters.func1()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/querier/ingester_querier.go:91 +0x108
  github.com/grafana/dskit/ring.DoUntilQuorum[go.shape.struct { github.com/grafana/loki/pkg/querier.addr string; github.com/grafana/loki/pkg/querier.response interface {} }].func1()
      /Users/progers/dev/src/github.com/grafana/loki/vendor/github.com/grafana/dskit/ring/replication_set.go:218 +0x4c
  github.com/grafana/dskit/ring.DoUntilQuorumWithoutSuccessfulContextCancellation[go.shape.struct { github.com/grafana/loki/pkg/querier.addr string; github.com/grafana/loki/pkg/querier.response interface {} }].func2()
      /Users/progers/dev/src/github.com/grafana/loki/vendor/github.com/grafana/dskit/ring/replication_set.go:297 +0xdc
  github.com/grafana/dskit/ring.DoUntilQuorumWithoutSuccessfulContextCancellation[go.shape.struct { github.com/grafana/loki/pkg/querier.addr string; github.com/grafana/loki/pkg/querier.response interface {} }].func5()
      /Users/progers/dev/src/github.com/grafana/loki/vendor/github.com/grafana/dskit/ring/replication_set.go:303 +0x44

Previous write at 0x00c00073a248 by goroutine 119:
  github.com/grafana/loki/pkg/querier.TestIngesterQuerier_earlyExitOnQuorum.func5.1()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/querier/ingester_querier_test.go:91 +0x138
  github.com/stretchr/testify/mock.(*Mock).MethodCalled()
      /Users/progers/dev/src/github.com/grafana/loki/vendor/github.com/stretchr/testify/mock/mock.go:552 +0xd3c
  github.com/stretchr/testify/mock.(*Mock).Called()
      /Users/progers/dev/src/github.com/grafana/loki/vendor/github.com/stretchr/testify/mock/mock.go:464 +0x140
  github.com/grafana/loki/pkg/querier.(*querierClientMock).Label()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/querier/querier_mock_test.go:69 +0x164
  github.com/grafana/loki/pkg/querier.(*IngesterQuerier).Label.func1()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/querier/ingester_querier.go:145 +0x60
  github.com/grafana/loki/pkg/querier.(*IngesterQuerier).forGivenIngesters.func1()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/querier/ingester_querier.go:91 +0x108
  github.com/grafana/dskit/ring.DoUntilQuorum[go.shape.struct { github.com/grafana/loki/pkg/querier.addr string; github.com/grafana/loki/pkg/querier.response interface {} }].func1()
      /Users/progers/dev/src/github.com/grafana/loki/vendor/github.com/grafana/dskit/ring/replication_set.go:218 +0x4c
  github.com/grafana/dskit/ring.DoUntilQuorumWithoutSuccessfulContextCancellation[go.shape.struct { github.com/grafana/loki/pkg/querier.addr string; github.com/grafana/loki/pkg/querier.response interface {} }].func2()
      /Users/progers/dev/src/github.com/grafana/loki/vendor/github.com/grafana/dskit/ring/replication_set.go:297 +0xdc
  github.com/grafana/dskit/ring.DoUntilQuorumWithoutSuccessfulContextCancellation[go.shape.struct { github.com/grafana/loki/pkg/querier.addr string; github.com/grafana/loki/pkg/querier.response interface {} }].func5()
      /Users/progers/dev/src/github.com/grafana/loki/vendor/github.com/grafana/dskit/ring/replication_set.go:303 +0x44
```
after fix:
```
go test -count=50 -race . -run earlyExitOnQuorum
ok  	github.com/grafana/loki/pkg/querier	1.905s
```
**Which issue(s) this PR fixes**:
Relates to: https://github.com/grafana/loki/issues/8586

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
