### PR TITLE
chore(blooms): Remove unnecessary sorting of fingerprints

### DIFF
--- a/pkg/bloomgateway/bloomgateway.go
+++ b/pkg/bloomgateway/bloomgateway.go
@@ -257,13 +257,6 @@ func (g *Gateway) FilterChunkRefs(ctx context.Context, req *logproto.FilterChunk
 		}, nil
 	}
 
-	// Sort ChunkRefs by fingerprint in ascending order
-	// TODO(owen-d): pretty sure this should already be sorted.
-	// verify & then check with IsSorted() -> remove
-	sort.Slice(req.Refs, func(i, j int) bool {
-		return req.Refs[i].Fingerprint < req.Refs[j].Fingerprint
-	})
-
 	var numSeries int
 	seriesByDay := partitionRequest(req)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The fingerprints are already sorted in the bloom querier before sending the request of the grouped fingerprints to the bloom gateway.

https://github.com/grafana/loki/blob/main/pkg/bloomgateway/querier.go#L119-L123