### PR TITLE
docs: fix URL of eventrouter YAML

### DIFF
--- a/docs/sources/send-data/promtail/cloud/eks/_index.md
+++ b/docs/sources/send-data/promtail/cloud/eks/_index.md
@@ -209,7 +209,7 @@ helm upgrade  promtail loki/promtail -n monitoring -f values.yaml
 And deploy the `eventrouter` using:
 
 ```bash
-kubectl create -f https://raw.githubusercontent.com/grafana/loki/main/docs/sources/clients/aws/eks/eventrouter.yaml
+kubectl create -f https://raw.githubusercontent.com/grafana/loki/main/docs/sources/send-data/promtail/cloud/eks/eventrouter.yaml
 
 serviceaccount/eventrouter created
 clusterrole.rbac.authorization.k8s.io/eventrouter created


### PR DESCRIPTION
Reported to docs@grafana.com

It's already fixed in `main` ("next" documentation).