### PR TITLE
chore(blooms): use the right iter reference in blockLoadingIter.loadNext

### DIFF
--- a/pkg/bloomcompactor/batch.go
+++ b/pkg/bloomcompactor/batch.go
@@ -251,7 +251,7 @@ func (i *blockLoadingIter) loadNext() bool {
 
 		iters := make([]v1.PeekingIterator[*v1.SeriesWithBloom], 0, len(blockRefs))
 		for filtered.Next() {
-			bq := loader.At()
+			bq := filtered.At()
 			i.loaded[bq] = struct{}{}
 			iter, err := bq.SeriesIter()
 			if err != nil {


### PR DESCRIPTION
I was investigating an issue from this code path and saw we use the non-filter iter's `At()` method. Fixes this to be more semantically correct although it shouldn't change behavior.