### PR TITLE
perf(blooms): removes pendingTasks impl with an atomic.Int64

### DIFF
--- a/pkg/bloomgateway/client.go
+++ b/pkg/bloomgateway/client.go
@@ -295,6 +295,7 @@ func (c *GatewayClient) FilterChunks(ctx context.Context, tenant string, from, t
 // doForAddrs sequetially calls the provided callback function fn for each
 // address in given slice addrs until the callback function does not return an
 // error.
+// TODO(owen-d): parallelism
 func (c *GatewayClient) doForAddrs(addrs []string, fn func(logproto.BloomGatewayClient) error) error {
 	var err error
 	var poolClient ringclient.PoolClient
@@ -340,6 +341,8 @@ func replicationSetsWithBounds(subRing ring.ReadRing, instances []ring.InstanceD
 			return nil, errors.Wrap(err, "bloom gateway get ring")
 		}
 
+		// NB(owen-d): this will send requests to the wrong nodes if RF>1 since it only checks the
+		// first token when assigning replicasets
 		rs, err := subRing.Get(tr[0], BlocksOwnerRead, bufDescs, bufHosts, bufZones)
 		if err != nil {
 			return nil, errors.Wrap(err, "bloom gateway get ring")

--- a/pkg/bloomgateway/worker.go
+++ b/pkg/bloomgateway/worker.go
@@ -9,6 +9,7 @@ import (
 	"github.com/grafana/dskit/services"
 	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
+	"go.uber.org/atomic"
 
 	"github.com/grafana/loki/pkg/queue"
 	v1 "github.com/grafana/loki/pkg/storage/bloom/v1"
@@ -36,12 +37,12 @@ type worker struct {
 	cfg     workerConfig
 	queue   *queue.RequestQueue
 	store   bloomshipper.Store
-	pending *pendingTasks
+	pending *atomic.Int64
 	logger  log.Logger
 	metrics *workerMetrics
 }
 
-func newWorker(id string, cfg workerConfig, queue *queue.RequestQueue, store bloomshipper.Store, pending *pendingTasks, logger log.Logger, metrics *workerMetrics) *worker {
+func newWorker(id string, cfg workerConfig, queue *queue.RequestQueue, store bloomshipper.Store, pending *atomic.Int64, logger log.Logger, metrics *workerMetrics) *worker {
 	w := &worker{
 		id:      id,
 		cfg:     cfg,
@@ -97,7 +98,7 @@ func (w *worker) running(_ context.Context) error {
 				return errors.Errorf("failed to cast dequeued item to Task: %v", item)
 			}
 			level.Debug(w.logger).Log("msg", "dequeued task", "task", task.ID)
-			w.pending.Delete(task.ID)
+			_ = w.pending.Dec()
 			w.metrics.queueDuration.WithLabelValues(w.id).Observe(time.Since(task.enqueueTime).Seconds())
 			tasks = append(tasks, task)
 


### PR DESCRIPTION
* pendingTasks only checks the length of outstanding reqs, so instead replace it with a simpler & performant `atomic.Int64`
* Also adds some comments/todos