### PR TITLE
refactor(bloomstore): Introduce fetch option for blocks fetcher

### DIFF
--- a/docs/sources/configure/_index.md
+++ b/docs/sources/configure/_index.md
@@ -2349,11 +2349,6 @@ bloom_shipper:
   # CLI flag: -bloom.shipper.working-directory
   [working_directory: <string> | default = "bloom-shipper"]
 
-  # In an eventually consistent system like the bloom components, we usually
-  # want to ignore blocks that are missing in storage.
-  # CLI flag: -bloom.shipper.ignore-missing-blocks
-  [ignore_missing_blocks: <boolean> | default = true]
-
   blocks_downloading_queue:
     # The count of parallel workers that download Bloom Blocks.
     # CLI flag: -bloom.shipper.blocks-downloading-queue.workers-count

--- a/pkg/bloomcompactor/controller.go
+++ b/pkg/bloomcompactor/controller.go
@@ -301,7 +301,7 @@ func (s *SimpleBloomController) loadWorkForGap(
 	// NB(owen-d): we filter out nil blocks here to avoid panics in the bloom generator since the fetcher
 	// input->output length and indexing in its contract
 	f := FetchFunc[bloomshipper.BlockRef, *bloomshipper.CloseableBlockQuerier](func(ctx context.Context, refs []bloomshipper.BlockRef) ([]*bloomshipper.CloseableBlockQuerier, error) {
-		blks, err := fetcher.FetchBlocks(ctx, refs)
+		blks, err := fetcher.FetchBlocks(ctx, refs, bloomshipper.WithFetchAsync(false), bloomshipper.WithIgnoreNotFound(false))
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/bloomcompactor/controller.go
+++ b/pkg/bloomcompactor/controller.go
@@ -300,8 +300,9 @@ func (s *SimpleBloomController) loadWorkForGap(
 
 	// NB(owen-d): we filter out nil blocks here to avoid panics in the bloom generator since the fetcher
 	// input->output length and indexing in its contract
+	// NB(chaudum): Do we want to fetch in strict mode and fail instead?
 	f := FetchFunc[bloomshipper.BlockRef, *bloomshipper.CloseableBlockQuerier](func(ctx context.Context, refs []bloomshipper.BlockRef) ([]*bloomshipper.CloseableBlockQuerier, error) {
-		blks, err := fetcher.FetchBlocks(ctx, refs, bloomshipper.WithFetchAsync(false), bloomshipper.WithIgnoreNotFound(false))
+		blks, err := fetcher.FetchBlocks(ctx, refs, bloomshipper.WithFetchAsync(false), bloomshipper.WithIgnoreNotFound(true))
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/bloomcompactor/tracker.go
+++ b/pkg/bloomcompactor/tracker.go
@@ -5,10 +5,11 @@ import (
 	"math"
 	"sync"
 
-	v1 "github.com/grafana/loki/pkg/storage/bloom/v1"
-	"github.com/grafana/loki/pkg/storage/config"
 	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
+
+	v1 "github.com/grafana/loki/pkg/storage/bloom/v1"
+	"github.com/grafana/loki/pkg/storage/config"
 )
 
 type tableRangeProgress struct {

--- a/pkg/bloomcompactor/tracker_test.go
+++ b/pkg/bloomcompactor/tracker_test.go
@@ -3,10 +3,11 @@ package bloomcompactor
 import (
 	"testing"
 
-	v1 "github.com/grafana/loki/pkg/storage/bloom/v1"
-	"github.com/grafana/loki/pkg/storage/config"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
+
+	v1 "github.com/grafana/loki/pkg/storage/bloom/v1"
+	"github.com/grafana/loki/pkg/storage/config"
 )
 
 func mkTblRange(tenant string, tbl config.DayTime, from, through model.Fingerprint) *tenantTableRange {

--- a/pkg/bloomcompactor/versioned_range.go
+++ b/pkg/bloomcompactor/versioned_range.go
@@ -3,9 +3,10 @@ package bloomcompactor
 import (
 	"sort"
 
+	"github.com/prometheus/common/model"
+
 	v1 "github.com/grafana/loki/pkg/storage/bloom/v1"
 	"github.com/grafana/loki/pkg/storage/stores/shipper/bloomshipper"
-	"github.com/prometheus/common/model"
 )
 
 type tsdbToken struct {
@@ -94,7 +95,7 @@ func (t tsdbTokenRange) Add(version int, bounds v1.FingerprintBounds) (res tsdbT
 		}
 
 		// If we need to update the range, there are 5 cases:
-		// 1. `equal`: the incoming range equals an exising range ()
+		// 1. `equal`: the incoming range equals an existing range ()
 		//      ------        # addition
 		//      ------        # src
 		// 2. `subset`: the incoming range is a subset of an existing range

--- a/pkg/bloomcompactor/versioned_range_test.go
+++ b/pkg/bloomcompactor/versioned_range_test.go
@@ -3,11 +3,12 @@ package bloomcompactor
 import (
 	"testing"
 
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+
 	v1 "github.com/grafana/loki/pkg/storage/bloom/v1"
 	"github.com/grafana/loki/pkg/storage/stores/shipper/bloomshipper"
 	"github.com/grafana/loki/pkg/storage/stores/shipper/indexshipper/tsdb"
-	"github.com/prometheus/common/model"
-	"github.com/stretchr/testify/require"
 )
 
 func Test_TsdbTokenRange(t *testing.T) {

--- a/pkg/bloomgateway/bloomgateway_test.go
+++ b/pkg/bloomgateway/bloomgateway_test.go
@@ -73,6 +73,9 @@ func setupBloomStore(t *testing.T) *bloomshipper.BloomStore {
 	storageCfg := storage.Config{
 		BloomShipperConfig: bloomshipperconfig.Config{
 			WorkingDirectory: t.TempDir(),
+			BlocksDownloadingQueue: bloomshipperconfig.DownloadingQueueConfig{
+				WorkersCount: 1,
+			},
 		},
 		FSConfig: local.FSConfig{
 			Directory: t.TempDir(),

--- a/pkg/bloomgateway/processor.go
+++ b/pkg/bloomgateway/processor.go
@@ -79,7 +79,7 @@ func (p *processor) processBlocks(ctx context.Context, data []blockWithTasks) er
 		refs = append(refs, block.ref)
 	}
 
-	bqs, err := p.store.FetchBlocks(ctx, refs)
+	bqs, err := p.store.FetchBlocks(ctx, refs, bloomshipper.WithFetchAsync(true), bloomshipper.WithIgnoreNotFound(true))
 	if err != nil {
 		return err
 	}

--- a/pkg/bloomgateway/processor.go
+++ b/pkg/bloomgateway/processor.go
@@ -87,6 +87,7 @@ func (p *processor) processBlocks(ctx context.Context, data []blockWithTasks) er
 		return err
 	}
 
+	// TODO(chaudum): use `concurrency` lib with bound parallelism
 	for i, bq := range bqs {
 		block := data[i]
 		if bq == nil {

--- a/pkg/bloomgateway/processor.go
+++ b/pkg/bloomgateway/processor.go
@@ -79,7 +79,10 @@ func (p *processor) processBlocks(ctx context.Context, data []blockWithTasks) er
 		refs = append(refs, block.ref)
 	}
 
+	start := time.Now()
 	bqs, err := p.store.FetchBlocks(ctx, refs, bloomshipper.WithFetchAsync(true), bloomshipper.WithIgnoreNotFound(true))
+	level.Debug(p.logger).Log("msg", "fetch blocks", "count", len(bqs), "duration", time.Since(start), "err", err)
+
 	if err != nil {
 		return err
 	}
@@ -87,7 +90,7 @@ func (p *processor) processBlocks(ctx context.Context, data []blockWithTasks) er
 	for i, bq := range bqs {
 		block := data[i]
 		if bq == nil {
-			level.Warn(p.logger).Log("msg", "skipping not found block", "block", block.ref)
+			// TODO(chaudum): Add metric for skipped blocks
 			continue
 		}
 		level.Debug(p.logger).Log(

--- a/pkg/bloomgateway/processor_test.go
+++ b/pkg/bloomgateway/processor_test.go
@@ -65,7 +65,7 @@ func (s *dummyStore) Client(_ model.Time) (bloomshipper.Client, error) {
 func (s *dummyStore) Stop() {
 }
 
-func (s *dummyStore) FetchBlocks(_ context.Context, refs []bloomshipper.BlockRef) ([]*bloomshipper.CloseableBlockQuerier, error) {
+func (s *dummyStore) FetchBlocks(_ context.Context, refs []bloomshipper.BlockRef, opts ...bloomshipper.FetchOption) ([]*bloomshipper.CloseableBlockQuerier, error) {
 	result := make([]*bloomshipper.CloseableBlockQuerier, 0, len(s.querieres))
 
 	if s.err != nil {

--- a/pkg/bloomgateway/processor_test.go
+++ b/pkg/bloomgateway/processor_test.go
@@ -65,7 +65,7 @@ func (s *dummyStore) Client(_ model.Time) (bloomshipper.Client, error) {
 func (s *dummyStore) Stop() {
 }
 
-func (s *dummyStore) FetchBlocks(_ context.Context, refs []bloomshipper.BlockRef, opts ...bloomshipper.FetchOption) ([]*bloomshipper.CloseableBlockQuerier, error) {
+func (s *dummyStore) FetchBlocks(_ context.Context, refs []bloomshipper.BlockRef, _ ...bloomshipper.FetchOption) ([]*bloomshipper.CloseableBlockQuerier, error) {
 	result := make([]*bloomshipper.CloseableBlockQuerier, 0, len(s.querieres))
 
 	if s.err != nil {

--- a/pkg/loki/modules_test.go
+++ b/pkg/loki/modules_test.go
@@ -368,6 +368,9 @@ func minimalWorkingConfig(t *testing.T, dir, target string, cfgTransformers ...f
 		FSConfig: local.FSConfig{Directory: dir},
 		BloomShipperConfig: bloomshipperconfig.Config{
 			WorkingDirectory: filepath.Join(dir, "blooms"),
+			BlocksDownloadingQueue: bloomshipperconfig.DownloadingQueueConfig{
+				WorkersCount: 1,
+			},
 		},
 		BoltDBShipperConfig: boltdb.IndexCfg{
 			Config: indexshipper.Config{

--- a/pkg/storage/stores/shipper/bloomshipper/config/config.go
+++ b/pkg/storage/stores/shipper/bloomshipper/config/config.go
@@ -12,7 +12,6 @@ import (
 
 type Config struct {
 	WorkingDirectory       string                    `yaml:"working_directory"`
-	IgnoreMissingBlocks    bool                      `yaml:"ignore_missing_blocks"`
 	BlocksDownloadingQueue DownloadingQueueConfig    `yaml:"blocks_downloading_queue"`
 	BlocksCache            cache.EmbeddedCacheConfig `yaml:"blocks_cache"`
 	MetasCache             cache.Config              `yaml:"metas_cache"`
@@ -30,7 +29,6 @@ func (cfg *DownloadingQueueConfig) RegisterFlagsWithPrefix(prefix string, f *fla
 
 func (c *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.StringVar(&c.WorkingDirectory, prefix+"shipper.working-directory", "bloom-shipper", "Working directory to store downloaded Bloom Blocks.")
-	f.BoolVar(&c.IgnoreMissingBlocks, prefix+"shipper.ignore-missing-blocks", true, "In an eventually consistent system like the bloom components, we usually want to ignore blocks that are missing in storage.")
 	c.BlocksDownloadingQueue.RegisterFlagsWithPrefix(prefix+"shipper.blocks-downloading-queue.", f)
 	c.BlocksCache.RegisterFlagsWithPrefixAndDefaults(prefix+"blocks-cache.", "Cache for bloom blocks. ", f, 24*time.Hour)
 	c.MetasCache.RegisterFlagsWithPrefix(prefix+"metas-cache.", "Cache for bloom metas. ", f)

--- a/pkg/storage/stores/shipper/bloomshipper/fetcher_test.go
+++ b/pkg/storage/stores/shipper/bloomshipper/fetcher_test.go
@@ -139,6 +139,124 @@ func TestMetasFetcher(t *testing.T) {
 	}
 }
 
+func TestFetchOptions(t *testing.T) {
+	options := &options{
+		ignoreNotFound: false,
+		fetchAsync:     false,
+	}
+
+	options.apply(WithFetchAsync(true), WithIgnoreNotFound(true))
+
+	require.True(t, options.fetchAsync)
+	require.True(t, options.ignoreNotFound)
+}
+
+func TestFetcher_DownloadQueue(t *testing.T) {
+	t.Run("invalid arguments", func(t *testing.T) {
+		for _, tc := range []struct {
+			size, workers int
+			err           string
+		}{
+			{
+				size: 0, workers: 1, err: "queue size needs to be greater than 0",
+			},
+			{
+				size: 1, workers: 0, err: "queue requires at least 1 worker",
+			},
+		} {
+			tc := tc
+			t.Run(tc.err, func(t *testing.T) {
+				_, err := newDownloadQueue[bool, bool](
+					tc.size,
+					tc.workers,
+					func(ctx context.Context, r downloadRequest[bool, bool]) {},
+					log.NewNopLogger(),
+				)
+				require.ErrorContains(t, err, tc.err)
+			})
+		}
+	})
+
+	t.Run("cancelled context", func(t *testing.T) {
+		ctx := context.Background()
+
+		q, err := newDownloadQueue[bool, bool](
+			100,
+			1,
+			func(_ context.Context, _ downloadRequest[bool, bool]) {},
+			log.NewNopLogger(),
+		)
+		require.NoError(t, err)
+		t.Cleanup(q.close)
+
+		ctx, cancel := context.WithCancel(ctx)
+		cancel()
+
+		resultsCh := make(chan downloadResponse[bool], 1)
+		errorsCh := make(chan error, 1)
+
+		r := downloadRequest[bool, bool]{
+			ctx:     ctx,
+			item:    false,
+			key:     "test",
+			idx:     0,
+			results: resultsCh,
+			errors:  errorsCh,
+		}
+		q.enqueue(r)
+
+		select {
+		case err := <-errorsCh:
+			require.Error(t, err)
+		case res := <-resultsCh:
+			require.False(t, true, "got %+v should have received an error instead", res)
+		}
+
+	})
+
+	t.Run("process function is called with context and request as arguments", func(t *testing.T) {
+		ctx := context.Background()
+
+		q, err := newDownloadQueue[bool, bool](
+			100,
+			1,
+			func(_ context.Context, r downloadRequest[bool, bool]) {
+				r.results <- downloadResponse[bool]{
+					key:  r.key,
+					idx:  r.idx,
+					item: true,
+				}
+			},
+			log.NewNopLogger(),
+		)
+		require.NoError(t, err)
+		t.Cleanup(q.close)
+
+		resultsCh := make(chan downloadResponse[bool], 1)
+		errorsCh := make(chan error, 1)
+
+		r := downloadRequest[bool, bool]{
+			ctx:     ctx,
+			item:    false,
+			key:     "test",
+			idx:     0,
+			results: resultsCh,
+			errors:  errorsCh,
+		}
+		q.enqueue(r)
+
+		select {
+		case err := <-errorsCh:
+			require.False(t, true, "got %+v should have received a response instead", err)
+		case res := <-resultsCh:
+			require.True(t, res.item)
+			require.Equal(t, r.key, res.key)
+			require.Equal(t, r.idx, res.idx)
+		}
+
+	})
+}
+
 func TestFetcher_LoadBlocksFromFS(t *testing.T) {
 	base := t.TempDir()
 	cfg := bloomStoreConfig{workingDir: base, numWorkers: 1}

--- a/pkg/storage/stores/shipper/bloomshipper/fetcher_test.go
+++ b/pkg/storage/stores/shipper/bloomshipper/fetcher_test.go
@@ -312,7 +312,9 @@ func createBlockDir(t *testing.T, path string) {
 }
 
 func TestFetcher_IsBlockDir(t *testing.T) {
-	fetcher, _ := NewFetcher(bloomStoreConfig{}, nil, nil, nil, nil, log.NewNopLogger())
+	cfg := bloomStoreConfig{numWorkers: 1}
+
+	fetcher, _ := NewFetcher(cfg, nil, nil, nil, nil, log.NewNopLogger())
 
 	t.Run("path does not exist", func(t *testing.T) {
 		base := t.TempDir()

--- a/pkg/storage/stores/shipper/bloomshipper/shipper.go
+++ b/pkg/storage/stores/shipper/bloomshipper/shipper.go
@@ -30,7 +30,7 @@ func NewShipper(client Store) *Shipper {
 // ForEach is a convenience function that wraps the store's FetchBlocks function
 // and automatically closes the block querier once the callback was run.
 func (s *Shipper) ForEach(ctx context.Context, refs []BlockRef, callback ForEachBlockCallback) error {
-	bqs, err := s.store.FetchBlocks(ctx, refs)
+	bqs, err := s.store.FetchBlocks(ctx, refs, WithFetchAsync(false))
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/stores/shipper/bloomshipper/store.go
+++ b/pkg/storage/stores/shipper/bloomshipper/store.go
@@ -353,8 +353,6 @@ func (b *BloomStore) FetchBlocks(ctx context.Context, blocks []BlockRef, opts ..
 		results = append(results, res...)
 	}
 
-	level.Debug(b.logger).Log("msg", "fetch blocks", "num_req", len(blocks), "num_resp", len(results))
-
 	// sort responses (results []*CloseableBlockQuerier) based on requests (blocks []BlockRef)
 	sortBlocks(results, blocks)
 

--- a/pkg/storage/stores/shipper/bloomshipper/store.go
+++ b/pkg/storage/stores/shipper/bloomshipper/store.go
@@ -123,7 +123,7 @@ func (b *bloomStoreEntry) FetchMetas(ctx context.Context, params MetaSearchParam
 }
 
 // FetchBlocks implements Store.
-func (b *bloomStoreEntry) FetchBlocks(ctx context.Context, refs []BlockRef, opts ...FetchOption) ([]*CloseableBlockQuerier, error) {
+func (b *bloomStoreEntry) FetchBlocks(ctx context.Context, refs []BlockRef, _ ...FetchOption) ([]*CloseableBlockQuerier, error) {
 	return b.fetcher.FetchBlocks(ctx, refs)
 }
 

--- a/pkg/storage/stores/shipper/bloomshipper/store.go
+++ b/pkg/storage/stores/shipper/bloomshipper/store.go
@@ -29,16 +29,15 @@ var (
 type Store interface {
 	ResolveMetas(ctx context.Context, params MetaSearchParams) ([][]MetaRef, []*Fetcher, error)
 	FetchMetas(ctx context.Context, params MetaSearchParams) ([]Meta, error)
-	FetchBlocks(ctx context.Context, refs []BlockRef) ([]*CloseableBlockQuerier, error)
+	FetchBlocks(ctx context.Context, refs []BlockRef, opts ...FetchOption) ([]*CloseableBlockQuerier, error)
 	Fetcher(ts model.Time) (*Fetcher, error)
 	Client(ts model.Time) (Client, error)
 	Stop()
 }
 
 type bloomStoreConfig struct {
-	workingDir          string
-	numWorkers          int
-	ignoreMissingBlocks bool
+	workingDir string
+	numWorkers int
 }
 
 // Compiler check to ensure bloomStoreEntry implements the Store interface
@@ -124,7 +123,7 @@ func (b *bloomStoreEntry) FetchMetas(ctx context.Context, params MetaSearchParam
 }
 
 // FetchBlocks implements Store.
-func (b *bloomStoreEntry) FetchBlocks(ctx context.Context, refs []BlockRef) ([]*CloseableBlockQuerier, error) {
+func (b *bloomStoreEntry) FetchBlocks(ctx context.Context, refs []BlockRef, opts ...FetchOption) ([]*CloseableBlockQuerier, error) {
 	return b.fetcher.FetchBlocks(ctx, refs)
 }
 
@@ -185,9 +184,8 @@ func NewBloomStore(
 
 	// TODO(chaudum): Remove wrapper
 	cfg := bloomStoreConfig{
-		workingDir:          storageConfig.BloomShipperConfig.WorkingDirectory,
-		numWorkers:          storageConfig.BloomShipperConfig.BlocksDownloadingQueue.WorkersCount,
-		ignoreMissingBlocks: storageConfig.BloomShipperConfig.IgnoreMissingBlocks,
+		workingDir: storageConfig.BloomShipperConfig.WorkingDirectory,
+		numWorkers: storageConfig.BloomShipperConfig.BlocksDownloadingQueue.WorkersCount,
 	}
 
 	if err := util.EnsureDirectory(cfg.workingDir); err != nil {
@@ -317,12 +315,8 @@ func (b *BloomStore) FetchMetas(ctx context.Context, params MetaSearchParams) ([
 	return metas, nil
 }
 
-// FetchBlocks implements Store.
-func (b *BloomStore) FetchBlocks(ctx context.Context, blocks []BlockRef) ([]*CloseableBlockQuerier, error) {
-
-	var refs [][]BlockRef
-	var fetchers []*Fetcher
-
+// partitionBlocksByFetcher returns a slice of BlockRefs for each fetcher
+func (b *BloomStore) partitionBlocksByFetcher(blocks []BlockRef) (refs [][]BlockRef, fetchers []*Fetcher) {
 	for i := len(b.stores) - 1; i >= 0; i-- {
 		s := b.stores[i]
 		from, through := s.start, model.Latest
@@ -343,9 +337,16 @@ func (b *BloomStore) FetchBlocks(ctx context.Context, blocks []BlockRef) ([]*Clo
 		}
 	}
 
+	return refs, fetchers
+}
+
+// FetchBlocks implements Store.
+func (b *BloomStore) FetchBlocks(ctx context.Context, blocks []BlockRef, opts ...FetchOption) ([]*CloseableBlockQuerier, error) {
+	refs, fetchers := b.partitionBlocksByFetcher(blocks)
+
 	results := make([]*CloseableBlockQuerier, 0, len(blocks))
 	for i := range fetchers {
-		res, err := fetchers[i].FetchBlocks(ctx, refs[i])
+		res, err := fetchers[i].FetchBlocks(ctx, refs[i], opts...)
 		if err != nil {
 			return results, err
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

Requests to the bloom gateway should not wait for blocks to be downloaded into cache first, but should operate on readily available blocks.

This PR introduces fetch options for the bloom store that specify how the store should behave when requesting blocks from block refs.

`WithIgnoreMissing`: Ignore errors from blocks that could not be found in object storage, and instead return a `nil` value in the response.
`WithFetchAsync`: Return only the blocks that are available locally in cache and dispatch downloading of blocks to the blocks downloader, that operates in the background, and make them available for subsequent requests.