### PR TITLE
fix(blooms): bloom-gw chunk merging improvements

### DIFF
--- a/pkg/bloomgateway/bloomgateway.go
+++ b/pkg/bloomgateway/bloomgateway.go
@@ -326,7 +326,7 @@ func (g *Gateway) FilterChunkRefs(ctx context.Context, req *logproto.FilterChunk
 		"requested_chunks", preFilterChunks,
 		"filtered_chunks", preFilterChunks-postFilterChunks,
 	)
-	return &logproto.FilterChunkRefResponse{ChunkRefs: req.Refs}, nil
+	return &logproto.FilterChunkRefResponse{ChunkRefs: filtered}, nil
 }
 
 // consumeTask receives v1.Output yielded from the block querier on the task's

--- a/pkg/bloomgateway/bloomgateway.go
+++ b/pkg/bloomgateway/bloomgateway.go
@@ -425,7 +425,14 @@ func (g *Gateway) removeNotMatchingChunks(req *logproto.FilterChunkRefRequest, r
 
 // merges a list of responses via a heap. The same fingerprints and chunks can be present in multiple responses,
 // but each response must be ordered by fingerprint
-func orderedResponsesByFP(responses [][]v1.Output) *v1.HeapIterator[v1.Output] {
+func orderedResponsesByFP(responses [][]v1.Output) v1.Iterator[v1.Output] {
+	if len(responses) == 0 {
+		return v1.NewEmptyIter[v1.Output]()
+	}
+	if len(responses) == 1 {
+		return v1.NewSliceIter(responses[0])
+	}
+
 	itrs := make([]v1.PeekingIterator[v1.Output], 0, len(responses))
 	for _, r := range responses {
 		itrs = append(itrs, v1.NewPeekingIter(v1.NewSliceIter(r)))

--- a/pkg/bloomgateway/bloomgateway_test.go
+++ b/pkg/bloomgateway/bloomgateway_test.go
@@ -686,6 +686,26 @@ func TestFilterChunkRefs(t *testing.T) {
 				{fp: 3, checksums: []uint32{0, 1, 2}},
 			}),
 		},
+		{
+			desc:  "middle duplicates across 2 days",
+			input: mkInput(4, 3),
+			removals: [][]instruction{
+				{
+					{fp: 0, checksums: []uint32{1}},
+					{fp: 2, checksums: []uint32{1}},
+				},
+				{
+					{fp: 0, checksums: []uint32{1}},
+					{fp: 2, checksums: []uint32{1}},
+				},
+			},
+			expected: mkResult([]instruction{
+				{fp: 0, checksums: []uint32{0, 2}},
+				{fp: 1, checksums: []uint32{0, 1, 2}},
+				{fp: 2, checksums: []uint32{0, 2}},
+				{fp: 3, checksums: []uint32{0, 1, 2}},
+			}),
+		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
 			res := filterChunkRefs(tc.input, mkRemovals(tc.removals))

--- a/pkg/bloomgateway/bloomgateway_test.go
+++ b/pkg/bloomgateway/bloomgateway_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"sync"
 	"testing"
 	"time"
 
@@ -16,6 +17,7 @@ import (
 	"github.com/grafana/dskit/user"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/loki/pkg/logproto"
@@ -471,5 +473,284 @@ func TestBloomGateway_RemoveNotMatchingChunks(t *testing.T) {
 		require.Equal(t, 3, n)
 		require.Equal(t, expected, req)
 	})
+
+}
+
+func TestFilterChunkRefsForSeries(t *testing.T) {
+	mkInput := func(xs []uint32) *logproto.GroupedChunkRefs {
+		out := &logproto.GroupedChunkRefs{Refs: make([]*logproto.ShortRef, len(xs))}
+		for i, x := range xs {
+			out.Refs[i] = &logproto.ShortRef{Checksum: x}
+		}
+		return out
+	}
+	mkRemovals := func(xs []uint32) v1.ChunkRefs {
+		out := make(v1.ChunkRefs, len(xs))
+		for i, x := range xs {
+			out[i] = v1.ChunkRef{Checksum: x}
+		}
+		return out
+	}
+
+	for _, tc := range []struct {
+		desc                      string
+		input, removals, expected []uint32
+	}{
+		{
+			desc:     "no matches",
+			input:    []uint32{0, 1},
+			expected: []uint32{0, 1},
+		},
+		{
+			desc:     "remove all",
+			input:    []uint32{0, 1, 2, 3, 4},
+			removals: []uint32{0, 1, 2, 3, 4},
+			expected: []uint32{},
+		},
+		{
+			desc:     "remove every other",
+			input:    []uint32{0, 1, 2, 3, 4},
+			removals: []uint32{0, 2, 4},
+			expected: []uint32{1, 3},
+		},
+		{
+			desc:     "remove middle section",
+			input:    []uint32{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+			removals: []uint32{3, 4, 5},
+			expected: []uint32{0, 1, 2, 6, 7, 8, 9},
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			input := mkInput(tc.input)
+			expected := mkInput(tc.expected)
+
+			filterChunkRefsForSeries(input, mkRemovals(tc.removals))
+
+			require.Equal(t, expected, input)
+		})
+	}
+}
+
+func TestFilterChunkRefs(t *testing.T) {
+	mkInput := func(nSeries, chunksPerSeries int) *logproto.FilterChunkRefRequest {
+		res := &logproto.FilterChunkRefRequest{}
+		refs := make([]*logproto.GroupedChunkRefs, nSeries)
+		for i := range refs {
+			chks := make([]*logproto.ShortRef, chunksPerSeries)
+			for j := range chks {
+				chks[j] = &logproto.ShortRef{Checksum: uint32(j)}
+			}
+			refs[i] = &logproto.GroupedChunkRefs{
+				Fingerprint: uint64(i),
+				Refs:        chks,
+			}
+		}
+		res.Refs = refs
+		return res
+	}
+
+	type instruction struct {
+		fp        uint64
+		checksums []uint32
+	}
+	mkRemovals := func(xs []instruction) []v1.Output {
+		out := make([]v1.Output, len(xs))
+		for i, x := range xs {
+			out[i] = v1.Output{
+				Fp:       model.Fingerprint(x.fp),
+				Removals: make(v1.ChunkRefs, len(x.checksums)),
+			}
+			for j, c := range x.checksums {
+				out[i].Removals[j] = v1.ChunkRef{Checksum: c}
+			}
+		}
+		return out
+	}
+
+	mkResult := func(xs []instruction) *logproto.FilterChunkRefRequest {
+		out := &logproto.FilterChunkRefRequest{Refs: make([]*logproto.GroupedChunkRefs, len(xs))}
+		for i, x := range xs {
+			out.Refs[i] = &logproto.GroupedChunkRefs{
+				Fingerprint: x.fp,
+				Refs:        make([]*logproto.ShortRef, len(x.checksums)),
+			}
+			for j, c := range x.checksums {
+				out.Refs[i].Refs[j] = &logproto.ShortRef{Checksum: c}
+			}
+		}
+		return out
+	}
+
+	for _, tc := range []struct {
+		desc     string
+		input    *logproto.FilterChunkRefRequest
+		removals []instruction
+		expected *logproto.FilterChunkRefRequest
+	}{
+		{
+			desc:     "no removals",
+			input:    mkInput(2, 2),
+			expected: mkInput(2, 2),
+		},
+		{
+			desc:  "remove all",
+			input: mkInput(2, 2),
+			removals: []instruction{
+				{fp: 0, checksums: []uint32{0, 1}},
+				{fp: 1, checksums: []uint32{0, 1}},
+			},
+			expected: mkInput(0, 0),
+		},
+		{
+			desc:  "remove every other series",
+			input: mkInput(4, 2),
+			removals: []instruction{
+				{fp: 0, checksums: []uint32{0, 1}},
+				{fp: 2, checksums: []uint32{0, 1}},
+			},
+			expected: mkResult([]instruction{
+				{fp: 1, checksums: []uint32{0, 1}},
+				{fp: 3, checksums: []uint32{0, 1}},
+			}),
+		},
+		{
+			desc:  "remove the last chunk for each series",
+			input: mkInput(4, 2),
+			removals: []instruction{
+				{fp: 0, checksums: []uint32{1}},
+				{fp: 1, checksums: []uint32{1}},
+				{fp: 2, checksums: []uint32{1}},
+				{fp: 3, checksums: []uint32{1}},
+			},
+			expected: mkResult([]instruction{
+				{fp: 0, checksums: []uint32{0}},
+				{fp: 1, checksums: []uint32{0}},
+				{fp: 2, checksums: []uint32{0}},
+				{fp: 3, checksums: []uint32{0}},
+			}),
+		},
+		{
+			desc:  "remove the middle chunk for every other series",
+			input: mkInput(4, 3),
+			removals: []instruction{
+				{fp: 0, checksums: []uint32{1}},
+				{fp: 2, checksums: []uint32{1}},
+			},
+			expected: mkResult([]instruction{
+				{fp: 0, checksums: []uint32{0, 2}},
+				{fp: 1, checksums: []uint32{0, 1, 2}},
+				{fp: 2, checksums: []uint32{0, 2}},
+				{fp: 3, checksums: []uint32{0, 1, 2}},
+			}),
+		},
+		{
+			desc:  "remove the first chunk of the last series",
+			input: mkInput(4, 3),
+			removals: []instruction{
+				{fp: 3, checksums: []uint32{0}},
+			},
+			expected: mkResult([]instruction{
+				{fp: 0, checksums: []uint32{0, 1, 2}},
+				{fp: 1, checksums: []uint32{0, 1, 2}},
+				{fp: 2, checksums: []uint32{0, 1, 2}},
+				{fp: 3, checksums: []uint32{1, 2}},
+			}),
+		},
+		{
+			desc:  "duplicate removals",
+			input: mkInput(4, 3),
+			removals: []instruction{
+				{fp: 0, checksums: []uint32{0, 1}},
+				{fp: 0, checksums: []uint32{0, 1, 2}},
+				{fp: 1, checksums: []uint32{1}},
+				{fp: 2, checksums: []uint32{1}},
+			},
+			expected: mkResult([]instruction{
+				{fp: 1, checksums: []uint32{0, 2}},
+				{fp: 2, checksums: []uint32{0, 2}},
+				{fp: 3, checksums: []uint32{0, 1, 2}},
+			}),
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			res := filterChunkRefs(tc.input, mkRemovals(tc.removals))
+			require.Equal(t, tc.expected.Refs, res)
+		})
+	}
+
+}
+
+func BenchmarkFilterChunkRefs(b *testing.B) {
+	nSeries := 1024
+	chunksPerSeries := 10
+
+	mkInput := func() *logproto.FilterChunkRefRequest {
+		res := &logproto.FilterChunkRefRequest{}
+
+		refs := make([]*logproto.GroupedChunkRefs, nSeries)
+		for i := range refs {
+			chks := make([]*logproto.ShortRef, chunksPerSeries)
+			for j := range chks {
+				chks[j] = &logproto.ShortRef{Checksum: uint32(j)}
+			}
+			refs[i] = &logproto.GroupedChunkRefs{
+				Fingerprint: uint64(i),
+				Refs:        chks,
+			}
+		}
+		res.Refs = refs
+		return res
+	}
+
+	// responses aren't mutated, so we add a pool to mitigate the alloc
+	// effect on the benchmark
+	var responseP sync.Pool
+	mkOutputs := func() []v1.Output {
+		// remove half the chunks from half the series, so 25% of the volume
+		outputs := make([]v1.Output, nSeries/2)
+		for i := range outputs {
+			output := v1.Output{
+				Fp: model.Fingerprint(i * 2),
+			}
+			for j := 0; j < chunksPerSeries/2; j++ {
+				output.Removals = append(output.Removals, v1.ChunkRef{Checksum: uint32(j * 2)})
+			}
+
+			outputs[i] = output
+		}
+		return outputs
+	}
+	responseP.New = func() interface{} {
+		return mkOutputs()
+	}
+
+	// Add comparison functions here to bench side by side
+	for _, tc := range []struct {
+		desc string
+		f    func(req *logproto.FilterChunkRefRequest, responses []v1.Output)
+	}{
+		{
+			desc: "filterChunkRefs",
+			f:    func(req *logproto.FilterChunkRefRequest, responses []v1.Output) { filterChunkRefs(req, responses) },
+		},
+		{
+			desc: "Gateway.processResponses",
+			f: func(req *logproto.FilterChunkRefRequest, responses []v1.Output) {
+				var g Gateway
+				g.processResponses(req, responses)
+			},
+		},
+	} {
+		b.Run(tc.desc, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				req := mkInput()
+				resps := responseP.Get().([]v1.Output)
+
+				tc.f(req, resps)
+
+				responseP.Put(resps)
+			}
+		})
+	}
 
 }

--- a/pkg/bloomgateway/metrics.go
+++ b/pkg/bloomgateway/metrics.go
@@ -14,7 +14,10 @@ type metrics struct {
 
 type serverMetrics struct {
 	inflightRequests prometheus.Summary
-	chunkRemovals    *prometheus.CounterVec
+	requestedSeries  prometheus.Histogram
+	filteredSeries   prometheus.Histogram
+	requestedChunks  prometheus.Histogram
+	filteredChunks   prometheus.Histogram
 }
 
 func newMetrics(registerer prometheus.Registerer, namespace, subsystem string) *metrics {
@@ -35,12 +38,34 @@ func newServerMetrics(registerer prometheus.Registerer, namespace, subsystem str
 			MaxAge:     time.Minute,
 			AgeBuckets: 6,
 		}),
-		chunkRemovals: promauto.With(registerer).NewCounterVec(prometheus.CounterOpts{
+		requestedSeries: promauto.With(registerer).NewHistogram(prometheus.HistogramOpts{
 			Namespace: namespace,
 			Subsystem: subsystem,
-			Name:      "chunk_removals_total",
-			Help:      "Total amount of removals received from the block querier partitioned by state. The state 'accepted' means that the removals are processed, the state 'dropped' means that the removals were received after the task context was done (e.g. client timeout, etc).",
-		}, []string{"state"}),
+			Name:      "requested_series",
+			Help:      "Total amount of series refs sent to bloom-gateway for querying",
+			Buckets:   prometheus.ExponentialBucketsRange(1, 100e3, 10),
+		}),
+		filteredSeries: promauto.With(registerer).NewHistogram(prometheus.HistogramOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "filtered_series",
+			Help:      "Total amount of series refs filtered by bloom-gateway",
+			Buckets:   prometheus.ExponentialBucketsRange(1, 100e3, 10),
+		}),
+		requestedChunks: promauto.With(registerer).NewHistogram(prometheus.HistogramOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "requested_chunks",
+			Help:      "Total amount of chunk refs sent to bloom-gateway for querying",
+			Buckets:   prometheus.ExponentialBucketsRange(1, 100e3, 10),
+		}),
+		filteredChunks: promauto.With(registerer).NewHistogram(prometheus.HistogramOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "filtered_chunks",
+			Help:      "Total amount of chunk refs filtered by bloom-gateway",
+			Buckets:   prometheus.ExponentialBucketsRange(1, 100e3, 10),
+		}),
 	}
 }
 

--- a/pkg/storage/bloom/v1/index.go
+++ b/pkg/storage/bloom/v1/index.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"sort"
 
 	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
@@ -364,6 +365,7 @@ func (s *SeriesWithOffset) Encode(
 	previousFp model.Fingerprint,
 	previousOffset BloomOffset,
 ) (model.Fingerprint, BloomOffset) {
+	sort.Sort(s.Chunks) // ensure order
 	// delta encode fingerprint
 	enc.PutBE64(uint64(s.Fingerprint - previousFp))
 	// delta encode offsets


### PR DESCRIPTION
* histogram metrics for requested vs filtered chunks (aggregate, not per day task)
* benchmarking
* improved `filterChunkRefs` implementation for the bloomcompactor. Both fixes a few mentioned bugs and improves performance.
* testware
* unrelated: ensures we sort chunks prior to committing series to bloom block during construction. This was done elsewhere, but doing it closer to the block itself feels safer.