### PR TITLE
fix(operator): Update Grafana example configuration

### DIFF
--- a/operator/docs/user-guides/forwarding_logs_to_gateway.md
+++ b/operator/docs/user-guides/forwarding_logs_to_gateway.md
@@ -16,7 +16,7 @@ toc: true
 
 This document will describe how to send application, infrastructure, audit and network logs to the LokiStack Gateway as different tenants using Promtail or Fluentd. The built-in gateway provides secure access to the distributor (and query-frontend) via consulting an OAuth/OIDC endpoint for the request subject.
 
-__Please read the [hacking guide](./hack_loki_operator.md) before proceeding with the following instructions.__
+__Please read the [hacking guide](../operator/hack_loki_operator.md) before proceeding with the following instructions.__
 
 _Note: While this document will only give instructions for two methods of log forwarding into the gateway, the examples given in the Promtail and Fluentd sections can be extrapolated to other log forwarders._
 

--- a/operator/docs/user-guides/forwarding_logs_without_gateway.md
+++ b/operator/docs/user-guides/forwarding_logs_without_gateway.md
@@ -15,7 +15,7 @@ toc: true
 
 This document describes how to send application, infrastructure, and audit logs to the Loki Distributor as different tenants using Fluentd or Vector.
 
-__Please read the [hacking guide](./hack_loki_operator.md) before proceeding with the following instructions.__
+__Please read the [hacking guide](../operator/hack_loki_operator.md) before proceeding with the following instructions.__
 
 _Note:_ This document only applies to OpenShift-based deployments.
 

--- a/operator/docs/user-guides/howto_connect_grafana.md
+++ b/operator/docs/user-guides/howto_connect_grafana.md
@@ -42,7 +42,7 @@ If your LokiStack deployment has the gateway enabled, use one of the first two o
 
 The preferred option for accessing the data stored in Loki managed by loki-operator when running on OpenShift with the default OpenShift tenancy model is to go through the LokiStack gateway and do proper authentication against the authentication service included in OpenShift.
 
-An example configuration authenticating to the gateway in this manner is available in  [`addon_grafana_gateway_ocp_oauth.yaml`](../../hack/addon_grafana_gateway_ocp_oauth.yaml).
+An example configuration authenticating to the gateway in this manner is available in  [`addon_grafana_gateway_ocp_oauth.yaml`](https://raw.githubusercontent.com/grafana/loki/main/operator/hack/addon_grafana_gateway_ocp_oauth.yaml).
 
 The configuration uses `oauth-proxy` to authenticate the user to the Grafana instance and forwards the token through Grafana to LokiStack's gateway service. This enables the configuration to fully take advantage of the tenancy model, so that users can only see the logs of their applications and only admins can view infrastructure and audit logs.
 
@@ -54,7 +54,7 @@ Similar to the above configuration this variant makes use of `oauth-proxy` to au
 
 As this configuration does not provide any tenancy it should only be used for testing or debugging a LokiStack. It does not completely bypass authentication though, so no public access of the data stored in Loki is possible.
 
-An example configuration using this technique is available in [`addon_grafana_gateway_ocp.yaml`](../hack/addon_grafana_gateway_ocp.yaml).
+An example configuration using this technique is available in [`addon_grafana_gateway_ocp.yaml`](https://raw.githubusercontent.com/grafana/loki/main/operator/hack/addon_grafana_gateway_ocp.yaml).
 
 ### Accessing the Query-Frontend Directly
 

--- a/operator/hack/addon_grafana_gateway_ocp.yaml
+++ b/operator/hack/addon_grafana_gateway_ocp.yaml
@@ -7,30 +7,6 @@ metadata:
   namespace: openshift-logging
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: logging-logs-reader
-rules:
-- apiGroups:
-  - loki.grafana.com
-  resourceNames:
-  - logs
-  resources:
-  - application
-  - infrastructure
-  - audit
-  verbs:
-  - get
-  - create
-- apiGroups:
-  - ""
-  resources:
-  - namespaces
-  verbs:
-  - get
-  - list
----
-apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: logging-grafana-auth-delegator
@@ -46,11 +22,37 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: logging-grafana-logs-reader
+  name: logging-grafana-logs-reader-application
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: logging-logs-reader
+  name: cluster-logging-application-view
+subjects:
+- kind: ServiceAccount
+  name: grafana
+  namespace: openshift-logging
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: logging-grafana-logs-reader-infrastructure
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-logging-infrastructure-view
+subjects:
+- kind: ServiceAccount
+  name: grafana
+  namespace: openshift-logging
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: logging-grafana-logs-reader-audit
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-logging-audit-view
 subjects:
 - kind: ServiceAccount
   name: grafana
@@ -103,7 +105,7 @@ data:
       - name: Loki (Infrastructure)
         type: loki
         access: proxy
-        url: https://${GATEWAY_ADDRESS}/api/logs/v1/application/
+        url: https://${GATEWAY_ADDRESS}/api/logs/v1/infrastructure/
         jsonData:
           tlsAuthWithCACert: true
           httpHeaderName1: Authorization
@@ -113,7 +115,7 @@ data:
       - name: Loki (Audit)
         type: loki
         access: proxy
-        url: https://${GATEWAY_ADDRESS}/api/logs/v1/application/
+        url: https://${GATEWAY_ADDRESS}/api/logs/v1/audit/
         jsonData:
           tlsAuthWithCACert: true
           httpHeaderName1: Authorization
@@ -194,7 +196,7 @@ spec:
           value: /var/lib/provisioning
         - name: GF_SECURITY_ADMIN_USER
           value: kube:admin
-        image: docker.io/grafana/grafana:8.5.6
+        image: docker.io/grafana/grafana:8.5.27
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/operator/hack/addon_grafana_gateway_ocp_oauth.yaml
+++ b/operator/hack/addon_grafana_gateway_ocp_oauth.yaml
@@ -7,20 +7,6 @@ metadata:
   namespace: openshift-logging
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: logging-application-logs-reader
-rules:
-- apiGroups:
-  - loki.grafana.com
-  resourceNames:
-  - logs
-  resources:
-  - application
-  verbs:
-  - get
----
-apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: logging-grafana-auth-delegator
@@ -32,19 +18,6 @@ subjects:
 - kind: ServiceAccount
   name: grafana
   namespace: openshift-logging
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: logging-users-application-logs-reader
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: logging-application-logs-reader
-subjects:
-- apiGroup: rbac.authorization.k8s.io
-  kind: Group
-  name: system:authenticated
 ---
 apiVersion: v1
 data:
@@ -167,7 +140,7 @@ spec:
           value: lokistack-dev-gateway-http.openshift-logging.svc:8080
         - name: GF_SECURITY_ADMIN_USER
           value: kube:admin
-        image: docker.io/grafana/grafana:8.5.6
+        image: docker.io/grafana/grafana:8.5.27
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3


### PR DESCRIPTION
**What this PR does / why we need it**:

The repository contains some manifests for showing how to connect Grafana to LokiStack. These have not been updated to reflect the state after "fine-grained logs access" was implemented and contain resources that conflict with what is deployed by the cluster-logging-operator.

This PR updates the existing examples to work with the current state of Loki Operator. This does not include updating the manifests for a newer Grafana release. It also fixes some links in the documentation used for the Loki Operator website.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
