### PR TITLE
chore(bloom-gw): Parallelise bloom gateway queries

### DIFF
--- a/pkg/bloomgateway/client.go
+++ b/pkg/bloomgateway/client.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/concurrency"
 	"github.com/grafana/dskit/grpcclient"
 	"github.com/grafana/dskit/instrument"
 	"github.com/grafana/dskit/ring"
@@ -54,6 +55,9 @@ var (
 			}
 		},
 	}
+
+	// NB(chaudum): Should probably be configurable, but I don't want yet another user setting.
+	maxQueryParallelism = 10
 )
 
 type ringGetBuffers struct {
@@ -251,10 +255,11 @@ func (c *GatewayClient) FilterChunks(ctx context.Context, tenant string, from, t
 	}
 	servers = partitionByReplicationSet(groups, servers)
 
-	filteredChunkRefs := groupedChunksRefPool.Get(len(groups))
-	defer groupedChunksRefPool.Put(filteredChunkRefs)
+	results := make([][]*logproto.GroupedChunkRefs, len(servers))
+	count := 0
+	err = concurrency.ForEachJob(ctx, len(servers), maxQueryParallelism, func(ctx context.Context, i int) error {
+		rs := servers[i]
 
-	for i, rs := range servers {
 		// randomize order of addresses so we don't hotspot the first server in the list
 		addrs := shuffleAddrs(rs.rs.GetAddresses())
 		level.Info(c.logger).Log(
@@ -271,7 +276,8 @@ func (c *GatewayClient) FilterChunks(ctx context.Context, tenant string, from, t
 			"plan", plan.String(),
 			"plan_hash", plan.Hash(),
 		)
-		err := c.doForAddrs(addrs, func(client logproto.BloomGatewayClient) error {
+
+		return c.doForAddrs(addrs, func(client logproto.BloomGatewayClient) error {
 			req := &logproto.FilterChunkRefRequest{
 				From:    from,
 				Through: through,
@@ -282,14 +288,24 @@ func (c *GatewayClient) FilterChunks(ctx context.Context, tenant string, from, t
 			if err != nil {
 				return err
 			}
-			filteredChunkRefs = append(filteredChunkRefs, resp.ChunkRefs...)
+			results[i] = resp.ChunkRefs
+			count += len(resp.ChunkRefs)
 			return nil
 		})
-		if err != nil {
-			return nil, err
-		}
+	})
+
+	if err != nil {
+		return nil, err
 	}
-	return filteredChunkRefs, nil
+	return flatten(results, count), nil
+}
+
+func flatten(input [][]*logproto.GroupedChunkRefs, n int) []*logproto.GroupedChunkRefs {
+	result := make([]*logproto.GroupedChunkRefs, 0, n)
+	for _, res := range input {
+		result = append(result, res...)
+	}
+	return result
 }
 
 // doForAddrs sequetially calls the provided callback function fn for each


### PR DESCRIPTION
**What this PR does / why we need it**:

* Using `concurrency` lib to perform requests from a single index gateway
to multiple other bloom gateways concurrently.

* The bloom gateway client must not use slices from the grouped chunk refs
pool for storing the results from the requests, because when it is put
back to the pool when the function returns, it may be re-used by other
function calls, modifying the contents of the slice.