### PR TITLE
test: Add synchronization for fakeTailer responses

### DIFF
--- a/pkg/ingester/tailer_test.go
+++ b/pkg/ingester/tailer_test.go
@@ -168,6 +168,7 @@ func (f *fakeTailServer) cloneTailResponse(response logproto.TailResponse) logpr
 	if response.Stream != nil {
 		clone.Stream = &logproto.Stream{}
 		clone.Stream.Labels = response.Stream.Labels
+		clone.Stream.Hash = response.Stream.Hash
 		if response.Stream.Entries != nil {
 			clone.Stream.Entries = make([]logproto.Entry, len(response.Stream.Entries))
 			copy(clone.Stream.Entries, response.Stream.Entries)

--- a/pkg/ingester/tailer_test.go
+++ b/pkg/ingester/tailer_test.go
@@ -163,7 +163,7 @@ func (f *fakeTailServer) Send(response *logproto.TailResponse) error {
 
 func (f *fakeTailServer) Context() context.Context { return context.Background() }
 
-func (f *fakeTailServer) cloneTailResponse(response logproto.TailResponse) logproto.TailResponse {
+func cloneTailResponse(response logproto.TailResponse) logproto.TailResponse {
 	var clone logproto.TailResponse
 	if response.Stream != nil {
 		clone.Stream = &logproto.Stream{}
@@ -187,7 +187,7 @@ func (f *fakeTailServer) GetResponses() []logproto.TailResponse {
 	defer f.responsesMu.Unlock()
 	clonedResponses := make([]logproto.TailResponse, len(f.responses))
 	for i, resp := range f.responses {
-		clonedResponses[i] = f.cloneTailResponse(resp)
+		clonedResponses[i] = cloneTailResponse(resp)
 	}
 	return f.responses
 }

--- a/pkg/ingester/tailer_test.go
+++ b/pkg/ingester/tailer_test.go
@@ -149,10 +149,13 @@ func Test_dropstream(t *testing.T) {
 }
 
 type fakeTailServer struct {
-	responses []logproto.TailResponse
+	responses   []logproto.TailResponse
+	responsesMu sync.Mutex
 }
 
 func (f *fakeTailServer) Send(response *logproto.TailResponse) error {
+	f.responsesMu.Lock()
+	defer f.responsesMu.Unlock()
 	f.responses = append(f.responses, *response)
 	return nil
 
@@ -160,11 +163,37 @@ func (f *fakeTailServer) Send(response *logproto.TailResponse) error {
 
 func (f *fakeTailServer) Context() context.Context { return context.Background() }
 
+func (f *fakeTailServer) cloneTailResponse(response logproto.TailResponse) logproto.TailResponse {
+	var clone logproto.TailResponse
+	if response.Stream != nil {
+		clone.Stream = &logproto.Stream{}
+		clone.Stream.Labels = response.Stream.Labels
+		if response.Stream.Entries != nil {
+			clone.Stream.Entries = make([]logproto.Entry, len(response.Stream.Entries))
+			copy(clone.Stream.Entries, response.Stream.Entries)
+		}
+	}
+	if response.DroppedStreams != nil {
+		clone.DroppedStreams = make([]*logproto.DroppedStream, len(response.DroppedStreams))
+		copy(clone.DroppedStreams, response.DroppedStreams)
+	}
+
+	return clone
+}
+
 func (f *fakeTailServer) GetResponses() []logproto.TailResponse {
+	f.responsesMu.Lock()
+	defer f.responsesMu.Unlock()
+	clonedResponses := make([]logproto.TailResponse, len(f.responses))
+	for i, resp := range f.responses {
+		clonedResponses[i] = f.cloneTailResponse(resp)
+	}
 	return f.responses
 }
 
 func (f *fakeTailServer) Reset() {
+	f.responsesMu.Lock()
+	defer f.responsesMu.Unlock()
 	f.responses = f.responses[:0]
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Data race found.  Before the fix:
```

go test -race -count=10 . -run Test_StructuredMetadata 
==================
WARNING: DATA RACE
Read at 0x00c000c225d0 by goroutine 113:
  github.com/grafana/loki/pkg/ingester.(*fakeTailServer).GetResponses()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/ingester/tailer_test.go:164 +0x30
  github.com/grafana/loki/pkg/ingester.Test_StructuredMetadata.func1.2()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/ingester/tailer_test.go:326 +0x40
  github.com/stretchr/testify/assert.Eventually.func1()
      /Users/progers/dev/src/github.com/grafana/loki/vendor/github.com/stretchr/testify/assert/assertions.go:1852 +0x38

Previous write at 0x00c000c225d0 by goroutine 110:
  github.com/grafana/loki/pkg/ingester.(*fakeTailServer).Send()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/ingester/tailer_test.go:156 +0x138
  github.com/grafana/loki/pkg/ingester.(*tailer).loop()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/ingester/tailer.go:105 +0x214
  github.com/grafana/loki/pkg/ingester.Test_StructuredMetadata.func1.1()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/ingester/tailer_test.go:318 +0x34

Goroutine 113 (running) created at:
  github.com/stretchr/testify/assert.Eventually()
      /Users/progers/dev/src/github.com/grafana/loki/vendor/github.com/stretchr/testify/assert/assertions.go:1852 +0x2b8
  github.com/stretchr/testify/require.Eventually()
      /Users/progers/dev/src/github.com/grafana/loki/vendor/github.com/stretchr/testify/require/require.go:401 +0x90
  github.com/grafana/loki/pkg/ingester.Test_StructuredMetadata.func1()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/ingester/tailer_test.go:325 +0x30c
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.21.6/libexec/src/testing/testing.go:1595 +0x1b0
  testing.(*T).Run.func1()
      /opt/homebrew/Cellar/go/1.21.6/libexec/src/testing/testing.go:1648 +0x40

Goroutine 110 (running) created at:
  github.com/grafana/loki/pkg/ingester.Test_StructuredMetadata.func1()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/ingester/tailer_test.go:317 +0x1e4
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.21.6/libexec/src/testing/testing.go:1595 +0x1b0
  testing.(*T).Run.func1()
      /opt/homebrew/Cellar/go/1.21.6/libexec/src/testing/testing.go:1648 +0x40
==================
```

After the fix:
```

go test -race -count=10 . -run Test_StructuredMetadata
ok  	github.com/grafana/loki/pkg/ingester	21.665s

```
**Which issue(s) this PR fixes**:
Relates to: https://github.com/grafana/loki/issues/8586


**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
