### PR TITLE
chore: fix backports to work with conventional commits

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -23,4 +23,4 @@ jobs:
           metricsWriteAPIKey: ${{secrets.GRAFANA_MISC_STATS_API_KEY}}
           token: ${{secrets.GH_BOT_ACCESS_TOKEN}}
           labelsToAdd: "backport"
-          title: "[{{base}}] {{originalTitle}}"
+          title: "chore: [{{base}}] {{originalTitle}}"


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the titles of backport PRs to work with conventional commits