### PR TITLE
chore(blooms): honors bloom_compactor_enabled for tenants

### DIFF
--- a/docs/sources/configure/_index.md
+++ b/docs/sources/configure/_index.md
@@ -3183,18 +3183,9 @@ shard_streams:
 # CLI flag: -bloom-compactor.shard-size
 [bloom_compactor_shard_size: <int> | default = 1]
 
-# The maximum age of a table before it is compacted. Do not compact tables older
-# than the the configured time. Default to 7 days. 0s means no limit.
-# CLI flag: -bloom-compactor.max-table-age
-[bloom_compactor_max_table_age: <duration> | default = 168h]
-
 # Whether to compact chunks into bloom filters.
 # CLI flag: -bloom-compactor.enable-compaction
 [bloom_compactor_enable_compaction: <boolean> | default = false]
-
-# The batch size of the chunks the bloom-compactor downloads at once.
-# CLI flag: -bloom-compactor.chunks-batch-size
-[bloom_compactor_chunks_batch_size: <int> | default = 100]
 
 # Length of the n-grams created when computing blooms from log lines.
 # CLI flag: -bloom-compactor.ngram-length

--- a/docs/sources/configure/_index.md
+++ b/docs/sources/configure/_index.md
@@ -3181,7 +3181,7 @@ shard_streams:
 # The shard size defines how many bloom compactors should be used by a tenant
 # when computing blooms. If it's set to 0, shuffle sharding is disabled.
 # CLI flag: -bloom-compactor.shard-size
-[bloom_compactor_shard_size: <int> | default = 1]
+[bloom_compactor_shard_size: <int> | default = 0]
 
 # Whether to compact chunks into bloom filters.
 # CLI flag: -bloom-compactor.enable-compaction

--- a/pkg/bloomcompactor/bloomcompactor.go
+++ b/pkg/bloomcompactor/bloomcompactor.go
@@ -176,13 +176,18 @@ type tenantTableRange struct {
 	queueTime, startTime, endTime time.Time
 }
 
-func (c *Compactor) tenants(ctx context.Context, table config.DayTable) (*v1.SliceIter[string], error) {
+func (c *Compactor) tenants(ctx context.Context, table config.DayTable) (*v1.FilterIter[string], error) {
 	tenants, err := c.tsdbStore.UsersForPeriod(ctx, table)
 	if err != nil {
 		return nil, errors.Wrap(err, "getting tenants")
 	}
 
-	return v1.NewSliceIter(tenants), nil
+	return v1.NewFilterIter(
+		v1.NewSliceIter(tenants),
+		func(tenant string) bool {
+			return c.limits.BloomCompactorEnabled(tenant)
+		},
+	), nil
 }
 
 // ownsTenant returns the ownership range for the tenant, if the compactor owns the tenant, and an error.

--- a/pkg/bloomcompactor/bloomcompactor_test.go
+++ b/pkg/bloomcompactor/bloomcompactor_test.go
@@ -166,14 +166,6 @@ func (m mockLimits) BloomCompactorShardSize(_ string) int {
 	return m.shardSize
 }
 
-func (m mockLimits) BloomCompactorChunksBatchSize(_ string) int {
-	panic("implement me")
-}
-
-func (m mockLimits) BloomCompactorMaxTableAge(_ string) time.Duration {
-	panic("implement me")
-}
-
 func (m mockLimits) BloomCompactorEnabled(_ string) bool {
 	panic("implement me")
 }

--- a/pkg/bloomcompactor/bloomcompactor_test.go
+++ b/pkg/bloomcompactor/bloomcompactor_test.go
@@ -167,7 +167,7 @@ func (m mockLimits) BloomCompactorShardSize(_ string) int {
 }
 
 func (m mockLimits) BloomCompactorEnabled(_ string) bool {
-	panic("implement me")
+	return true
 }
 
 func (m mockLimits) BloomNGramLength(_ string) int {

--- a/pkg/bloomcompactor/config.go
+++ b/pkg/bloomcompactor/config.go
@@ -71,8 +71,6 @@ func (cfg *RingConfig) RegisterFlagsWithPrefix(flagsPrefix, storePrefix string, 
 type Limits interface {
 	downloads.Limits
 	BloomCompactorShardSize(tenantID string) int
-	BloomCompactorChunksBatchSize(userID string) int
-	BloomCompactorMaxTableAge(tenantID string) time.Duration
 	BloomCompactorEnabled(tenantID string) bool
 	BloomNGramLength(tenantID string) int
 	BloomNGramSkip(tenantID string) int

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -330,7 +330,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&l.BloomGatewayShardSize, "bloom-gateway.shard-size", 0, "The shard size defines how many bloom gateways should be used by a tenant for querying.")
 	f.BoolVar(&l.BloomGatewayEnabled, "bloom-gateway.enable-filtering", false, "Whether to use the bloom gateway component in the read path to filter chunks.")
 
-	f.IntVar(&l.BloomCompactorShardSize, "bloom-compactor.shard-size", 1, "The shard size defines how many bloom compactors should be used by a tenant when computing blooms. If it's set to 0, shuffle sharding is disabled.")
+	f.IntVar(&l.BloomCompactorShardSize, "bloom-compactor.shard-size", 0, "The shard size defines how many bloom compactors should be used by a tenant when computing blooms. If it's set to 0, shuffle sharding is disabled.")
 	f.BoolVar(&l.BloomCompactorEnabled, "bloom-compactor.enable-compaction", false, "Whether to compact chunks into bloom filters.")
 	f.IntVar(&l.BloomNGramLength, "bloom-compactor.ngram-length", 4, "Length of the n-grams created when computing blooms from log lines.")
 	f.IntVar(&l.BloomNGramSkip, "bloom-compactor.ngram-skip", 1, "Skip factor for the n-grams created when computing blooms from log lines.")

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -192,9 +192,7 @@ type Limits struct {
 	BloomGatewayEnabled   bool `yaml:"bloom_gateway_enable_filtering" json:"bloom_gateway_enable_filtering"`
 
 	BloomCompactorShardSize                  int              `yaml:"bloom_compactor_shard_size" json:"bloom_compactor_shard_size"`
-	BloomCompactorMaxTableAge                time.Duration    `yaml:"bloom_compactor_max_table_age" json:"bloom_compactor_max_table_age"`
 	BloomCompactorEnabled                    bool             `yaml:"bloom_compactor_enable_compaction" json:"bloom_compactor_enable_compaction"`
-	BloomCompactorChunksBatchSize            int              `yaml:"bloom_compactor_chunks_batch_size" json:"bloom_compactor_chunks_batch_size"`
 	BloomNGramLength                         int              `yaml:"bloom_ngram_length" json:"bloom_ngram_length"`
 	BloomNGramSkip                           int              `yaml:"bloom_ngram_skip" json:"bloom_ngram_skip"`
 	BloomFalsePositiveRate                   float64          `yaml:"bloom_false_positive_rate" json:"bloom_false_positive_rate"`
@@ -333,9 +331,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&l.BloomGatewayEnabled, "bloom-gateway.enable-filtering", false, "Whether to use the bloom gateway component in the read path to filter chunks.")
 
 	f.IntVar(&l.BloomCompactorShardSize, "bloom-compactor.shard-size", 1, "The shard size defines how many bloom compactors should be used by a tenant when computing blooms. If it's set to 0, shuffle sharding is disabled.")
-	f.DurationVar(&l.BloomCompactorMaxTableAge, "bloom-compactor.max-table-age", 7*24*time.Hour, "The maximum age of a table before it is compacted. Do not compact tables older than the the configured time. Default to 7 days. 0s means no limit.")
 	f.BoolVar(&l.BloomCompactorEnabled, "bloom-compactor.enable-compaction", false, "Whether to compact chunks into bloom filters.")
-	f.IntVar(&l.BloomCompactorChunksBatchSize, "bloom-compactor.chunks-batch-size", 100, "The batch size of the chunks the bloom-compactor downloads at once.")
 	f.IntVar(&l.BloomNGramLength, "bloom-compactor.ngram-length", 4, "Length of the n-grams created when computing blooms from log lines.")
 	f.IntVar(&l.BloomNGramSkip, "bloom-compactor.ngram-skip", 1, "Skip factor for the n-grams created when computing blooms from log lines.")
 	f.Float64Var(&l.BloomFalsePositiveRate, "bloom-compactor.false-positive-rate", 0.01, "Scalable Bloom Filter desired false-positive rate.")
@@ -888,16 +884,8 @@ func (o *Overrides) BloomGatewayEnabled(userID string) bool {
 	return o.getOverridesForUser(userID).BloomGatewayEnabled
 }
 
-func (o *Overrides) BloomCompactorChunksBatchSize(userID string) int {
-	return o.getOverridesForUser(userID).BloomCompactorChunksBatchSize
-}
-
 func (o *Overrides) BloomCompactorShardSize(userID string) int {
 	return o.getOverridesForUser(userID).BloomCompactorShardSize
-}
-
-func (o *Overrides) BloomCompactorMaxTableAge(userID string) time.Duration {
-	return o.getOverridesForUser(userID).BloomCompactorMaxTableAge
 }
 
 func (o *Overrides) BloomCompactorEnabled(userID string) bool {


### PR DESCRIPTION
Also remove unused bloom tenant overrides + disables shuffle sharding by default