### PR TITLE
fix(bloom-compactor): Correctly disable the bloom-compactor.

### DIFF
--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -658,6 +658,9 @@ func (t *Loki) setupModuleManager() error {
 		Write:   {Ingester, Distributor},
 		Backend: {QueryScheduler, Ruler, Compactor, IndexGateway, BloomGateway, BloomCompactor},
 
+		// TODO(salvacorts): We added the BloomCompactor component to the `all` target to ease testing.
+		//                   We should remove it before releasing the feature since we don’t think any user running
+		//                   the single binary will benefit from the blooms given their scale in terms of ingested data
 		All: {QueryScheduler, QueryFrontend, Querier, Ingester, Distributor, Ruler, Compactor, BloomCompactor},
 	}
 

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -1323,6 +1323,9 @@ func (t *Loki) addCompactorMiddleware(h http.HandlerFunc) http.Handler {
 }
 
 func (t *Loki) initBloomGateway() (services.Service, error) {
+	if !t.Cfg.BloomGateway.Enabled {
+		return nil, nil
+	}
 	logger := log.With(util_log.Logger, "component", "bloom-gateway")
 
 	gateway, err := bloomgateway.New(t.Cfg.BloomGateway, t.BloomStore, logger, prometheus.DefaultRegisterer)
@@ -1334,6 +1337,9 @@ func (t *Loki) initBloomGateway() (services.Service, error) {
 }
 
 func (t *Loki) initBloomGatewayRing() (services.Service, error) {
+	if !t.Cfg.BloomGateway.Enabled {
+		return nil, nil
+	}
 	// Inherit ring listen port from gRPC config
 	t.Cfg.BloomGateway.Ring.ListenPort = t.Cfg.Server.GRPCListenPort
 

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -1467,6 +1467,9 @@ func (t *Loki) initIndexGatewayInterceptors() (services.Service, error) {
 }
 
 func (t *Loki) initBloomCompactor() (services.Service, error) {
+	if !t.Cfg.BloomCompactor.Enabled {
+		return nil, nil
+	}
 	logger := log.With(util_log.Logger, "component", "bloom-compactor")
 
 	shuffleSharding := util_ring.NewTenantShuffleSharding(t.bloomCompactorRingManager.Ring, t.bloomCompactorRingManager.RingLifecycler, t.Overrides.BloomCompactorShardSize)
@@ -1486,6 +1489,9 @@ func (t *Loki) initBloomCompactor() (services.Service, error) {
 }
 
 func (t *Loki) initBloomCompactorRing() (services.Service, error) {
+	if !t.Cfg.BloomCompactor.Enabled {
+		return nil, nil
+	}
 	t.Cfg.BloomCompactor.Ring.ListenPort = t.Cfg.Server.GRPCListenPort
 
 	// is LegacyMode needed?


### PR DESCRIPTION
I was running main on disk for a while and it kept crashing for a while because it was trying to compact bloom.

This ensure we don't actually start services if we don't want to.