### PR TITLE
fix: add metadata resource and source attrs to stats

### DIFF
--- a/pkg/loghttp/push/otlp.go
+++ b/pkg/loghttp/push/otlp.go
@@ -147,8 +147,10 @@ func otlpToLokiPushRequest(ld plog.Logs, userID string, tenantsRetention Tenants
 		}
 
 		resourceAttributesAsStructuredMetadataSize := labelsSize(resourceAttributesAsStructuredMetadata)
-		stats.StructuredMetadataBytes[tenantsRetention.RetentionPeriodFor(userID, lbs)] += int64(resourceAttributesAsStructuredMetadataSize)
-		stats.ResourceAndSourceMetadataLabels[tenantsRetention.RetentionPeriodFor(userID, lbs)] = append(stats.ResourceAndSourceMetadataLabels[tenantsRetention.RetentionPeriodFor(userID, lbs)], resourceAttributesAsStructuredMetadata...)
+		retentionPeriodForUser := tenantsRetention.RetentionPeriodFor(userID, lbs)
+
+		stats.StructuredMetadataBytes[retentionPeriodForUser] += int64(resourceAttributesAsStructuredMetadataSize)
+		stats.ResourceAndSourceMetadataLabels[retentionPeriodForUser] = append(stats.ResourceAndSourceMetadataLabels[retentionPeriodForUser], resourceAttributesAsStructuredMetadata...)
 
 		for j := 0; j < sls.Len(); j++ {
 			scope := sls.At(j).Scope()
@@ -198,8 +200,8 @@ func otlpToLokiPushRequest(ld plog.Logs, userID string, tenantsRetention Tenants
 			}
 
 			scopeAttributesAsStructuredMetadataSize := labelsSize(scopeAttributesAsStructuredMetadata)
-			stats.StructuredMetadataBytes[tenantsRetention.RetentionPeriodFor(userID, lbs)] += int64(scopeAttributesAsStructuredMetadataSize)
-			stats.ResourceAndSourceMetadataLabels[tenantsRetention.RetentionPeriodFor(userID, lbs)] = append(stats.ResourceAndSourceMetadataLabels[tenantsRetention.RetentionPeriodFor(userID, lbs)], scopeAttributesAsStructuredMetadata...)
+			stats.StructuredMetadataBytes[retentionPeriodForUser] += int64(scopeAttributesAsStructuredMetadataSize)
+			stats.ResourceAndSourceMetadataLabels[retentionPeriodForUser] = append(stats.ResourceAndSourceMetadataLabels[retentionPeriodForUser], scopeAttributesAsStructuredMetadata...)
 			for k := 0; k < logs.Len(); k++ {
 				log := logs.At(k)
 
@@ -220,12 +222,12 @@ func otlpToLokiPushRequest(ld plog.Logs, userID string, tenantsRetention Tenants
 				pushRequestsByStream[labelsStr] = stream
 
 				metadataSize := int64(labelsSize(entry.StructuredMetadata) - resourceAttributesAsStructuredMetadataSize - scopeAttributesAsStructuredMetadataSize)
-				stats.StructuredMetadataBytes[tenantsRetention.RetentionPeriodFor(userID, lbs)] += metadataSize
-				stats.LogLinesBytes[tenantsRetention.RetentionPeriodFor(userID, lbs)] += int64(len(entry.Line))
+				stats.StructuredMetadataBytes[retentionPeriodForUser] += metadataSize
+				stats.LogLinesBytes[retentionPeriodForUser] += int64(len(entry.Line))
 
 				if tracker != nil {
-					tracker.ReceivedBytesAdd(userID, tenantsRetention.RetentionPeriodFor(userID, lbs), lbs, float64(len(entry.Line)))
-					tracker.ReceivedBytesAdd(userID, tenantsRetention.RetentionPeriodFor(userID, lbs), lbs, float64(metadataSize))
+					tracker.ReceivedBytesAdd(userID, retentionPeriodForUser, lbs, float64(len(entry.Line)))
+					tracker.ReceivedBytesAdd(userID, retentionPeriodForUser, lbs, float64(metadataSize))
 				}
 
 				stats.NumLines++

--- a/pkg/loghttp/push/otlp.go
+++ b/pkg/loghttp/push/otlp.go
@@ -30,8 +30,9 @@ const (
 
 func newPushStats() *Stats {
 	return &Stats{
-		LogLinesBytes:           map[time.Duration]int64{},
-		StructuredMetadataBytes: map[time.Duration]int64{},
+		LogLinesBytes:                   map[time.Duration]int64{},
+		StructuredMetadataBytes:         map[time.Duration]int64{},
+		ResourceAndSourceMetadataLabels: map[time.Duration]push.LabelsAdapter{},
 	}
 }
 
@@ -147,6 +148,7 @@ func otlpToLokiPushRequest(ld plog.Logs, userID string, tenantsRetention Tenants
 
 		resourceAttributesAsStructuredMetadataSize := labelsSize(resourceAttributesAsStructuredMetadata)
 		stats.StructuredMetadataBytes[tenantsRetention.RetentionPeriodFor(userID, lbs)] += int64(resourceAttributesAsStructuredMetadataSize)
+		stats.ResourceAndSourceMetadataLabels[tenantsRetention.RetentionPeriodFor(userID, lbs)] = append(stats.ResourceAndSourceMetadataLabels[tenantsRetention.RetentionPeriodFor(userID, lbs)], resourceAttributesAsStructuredMetadata...)
 
 		for j := 0; j < sls.Len(); j++ {
 			scope := sls.At(j).Scope()
@@ -197,6 +199,7 @@ func otlpToLokiPushRequest(ld plog.Logs, userID string, tenantsRetention Tenants
 
 			scopeAttributesAsStructuredMetadataSize := labelsSize(scopeAttributesAsStructuredMetadata)
 			stats.StructuredMetadataBytes[tenantsRetention.RetentionPeriodFor(userID, lbs)] += int64(scopeAttributesAsStructuredMetadataSize)
+			stats.ResourceAndSourceMetadataLabels[tenantsRetention.RetentionPeriodFor(userID, lbs)] = append(stats.ResourceAndSourceMetadataLabels[tenantsRetention.RetentionPeriodFor(userID, lbs)], scopeAttributesAsStructuredMetadata...)
 			for k := 0; k < logs.Len(); k++ {
 				log := logs.At(k)
 

--- a/pkg/loghttp/push/otlp_test.go
+++ b/pkg/loghttp/push/otlp_test.go
@@ -79,6 +79,9 @@ func TestOTLPToLokiPushRequest(t *testing.T) {
 				StructuredMetadataBytes: map[time.Duration]int64{
 					time.Hour: 0,
 				},
+				ResourceAndSourceMetadataLabels: map[time.Duration]push.LabelsAdapter{
+					time.Hour: nil,
+				},
 				StreamLabelsSize:         21,
 				MostRecentEntryTimestamp: now,
 			},
@@ -114,6 +117,9 @@ func TestOTLPToLokiPushRequest(t *testing.T) {
 				},
 				StructuredMetadataBytes: map[time.Duration]int64{
 					time.Hour: 0,
+				},
+				ResourceAndSourceMetadataLabels: map[time.Duration]push.LabelsAdapter{
+					time.Hour: nil,
 				},
 				StreamLabelsSize:         27,
 				MostRecentEntryTimestamp: now,
@@ -151,6 +157,9 @@ func TestOTLPToLokiPushRequest(t *testing.T) {
 				},
 				StructuredMetadataBytes: map[time.Duration]int64{
 					time.Hour: 0,
+				},
+				ResourceAndSourceMetadataLabels: map[time.Duration]push.LabelsAdapter{
+					time.Hour: nil,
 				},
 				StreamLabelsSize:         47,
 				MostRecentEntryTimestamp: now,
@@ -252,6 +261,13 @@ func TestOTLPToLokiPushRequest(t *testing.T) {
 				StructuredMetadataBytes: map[time.Duration]int64{
 					time.Hour: 37,
 				},
+				ResourceAndSourceMetadataLabels: map[time.Duration]push.LabelsAdapter{
+					time.Hour: []push.LabelAdapter{
+						{Name: "service_image", Value: "loki"},
+						{Name: "op", Value: "buzz"},
+						{Name: "scope_name", Value: "fizz"},
+					},
+				},
 				StreamLabelsSize:         21,
 				MostRecentEntryTimestamp: now,
 			},
@@ -335,6 +351,13 @@ func TestOTLPToLokiPushRequest(t *testing.T) {
 				},
 				StructuredMetadataBytes: map[time.Duration]int64{
 					time.Hour: 97,
+				},
+				ResourceAndSourceMetadataLabels: map[time.Duration]push.LabelsAdapter{
+					time.Hour: []push.LabelAdapter{
+						{Name: "resource_nested_foo", Value: "bar"},
+						{Name: "scope_nested_foo", Value: "bar"},
+						{Name: "scope_name", Value: "fizz"},
+					},
 				},
 				StreamLabelsSize:         21,
 				MostRecentEntryTimestamp: now,
@@ -478,6 +501,14 @@ func TestOTLPToLokiPushRequest(t *testing.T) {
 				},
 				StructuredMetadataBytes: map[time.Duration]int64{
 					time.Hour: 113,
+				},
+				ResourceAndSourceMetadataLabels: map[time.Duration]push.LabelsAdapter{
+					time.Hour: []push.LabelAdapter{
+						{Name: "pod_ip", Value: "10.200.200.200"},
+						{Name: "resource_nested_foo", Value: "bar"},
+						{Name: "scope_nested_foo", Value: "bar"},
+						{Name: "scope_name", Value: "fizz"},
+					},
 				},
 				StreamLabelsSize:         42,
 				MostRecentEntryTimestamp: now,

--- a/pkg/loghttp/push/push.go
+++ b/pkg/loghttp/push/push.go
@@ -5,6 +5,7 @@ import (
 	"compress/gzip"
 	"fmt"
 	"github.com/go-kit/log/level"
+	"github.com/grafana/loki/pkg/push"
 	"io"
 	"math"
 	"mime"
@@ -73,16 +74,17 @@ type RequestParser func(userID string, r *http.Request, tenantsRetention Tenants
 type RequestParserWrapper func(inner RequestParser) RequestParser
 
 type Stats struct {
-	Errs                     []error
-	NumLines                 int64
-	LogLinesBytes            map[time.Duration]int64
-	StructuredMetadataBytes  map[time.Duration]int64
-	StreamLabelsSize         int64
-	MostRecentEntryTimestamp time.Time
-	ContentType              string
-	ContentEncoding          string
-	BodySize                 int64
+	Errs                            []error
+	NumLines                        int64
+	LogLinesBytes                   map[time.Duration]int64
+	StructuredMetadataBytes         map[time.Duration]int64
+	ResourceAndSourceMetadataLabels map[time.Duration]push.LabelsAdapter
+	StreamLabelsSize                int64
+	MostRecentEntryTimestamp        time.Time
+	ContentType                     string
+	ContentEncoding                 string
 
+	BodySize int64
 	// Extra is a place for a wrapped perser to record any interesting stats as key-value pairs to be logged
 	Extra []any
 }


### PR DESCRIPTION
Adding OTLP resource and source labels to the stats allows them to be accounted for by a wrapping parser