### PR TITLE
chore(bloom-gw): Process blocks in parallel

### DIFF
--- a/pkg/bloomgateway/bloomgateway.go
+++ b/pkg/bloomgateway/bloomgateway.go
@@ -348,14 +348,11 @@ func (g *Gateway) FilterChunkRefs(ctx context.Context, req *logproto.FilterChunk
 // Once the tasks is closed, it will send the task with the results from the
 // block querier to the supplied task channel.
 func (g *Gateway) consumeTask(ctx context.Context, task Task, tasksCh chan<- Task) {
-	logger := log.With(g.logger, "task", task.ID)
-
 	for res := range task.resCh {
 		select {
 		case <-ctx.Done():
-			level.Debug(logger).Log("msg", "drop partial result", "fp_int", uint64(res.Fp), "fp_hex", res.Fp, "chunks_to_remove", res.Removals.Len())
+			// do nothing
 		default:
-			level.Debug(logger).Log("msg", "accept partial result", "fp_int", uint64(res.Fp), "fp_hex", res.Fp, "chunks_to_remove", res.Removals.Len())
 			task.responses = append(task.responses, res)
 		}
 	}

--- a/pkg/bloomgateway/multiplexing.go
+++ b/pkg/bloomgateway/multiplexing.go
@@ -87,17 +87,16 @@ func NewTask(ctx context.Context, tenantID string, refs seriesWithInterval, filt
 	}
 
 	task := Task{
-		ID:        key,
-		Tenant:    tenantID,
-		err:       new(wrappedError),
-		resCh:     make(chan v1.Output),
-		filters:   filters,
-		series:    refs.series,
-		interval:  refs.interval,
-		table:     refs.day,
-		ctx:       ctx,
-		done:      make(chan struct{}),
-		responses: make([]v1.Output, 0, len(refs.series)),
+		ID:       key,
+		Tenant:   tenantID,
+		err:      new(wrappedError),
+		resCh:    make(chan v1.Output),
+		filters:  filters,
+		series:   refs.series,
+		interval: refs.interval,
+		table:    refs.day,
+		ctx:      ctx,
+		done:     make(chan struct{}),
 	}
 	return task, nil
 }
@@ -130,16 +129,15 @@ func (t Task) CloseWithError(err error) {
 func (t Task) Copy(series []*logproto.GroupedChunkRefs) Task {
 	// do not copy ID to distinguish it as copied task
 	return Task{
-		Tenant:    t.Tenant,
-		err:       t.err,
-		resCh:     t.resCh,
-		filters:   t.filters,
-		series:    series,
-		interval:  t.interval,
-		table:     t.table,
-		ctx:       t.ctx,
-		done:      make(chan struct{}),
-		responses: make([]v1.Output, 0, len(series)),
+		Tenant:   t.Tenant,
+		err:      t.err,
+		resCh:    t.resCh,
+		filters:  t.filters,
+		series:   series,
+		interval: t.interval,
+		table:    t.table,
+		ctx:      t.ctx,
+		done:     make(chan struct{}),
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

While processing a single block is rather fast, processing a lot of blocks sequentially can lead to problem that single slowly processed blocks lead to high tail latency.

Example trace:
![screenshot_20240313_225517](https://github.com/grafana/loki/assets/281260/472deb6d-5a7a-4e99-8f50-0daa9f661a68)
