### PR TITLE
perf(bloom-gw): Dequeue single task in bloom gateway worker

### DIFF
--- a/pkg/bloomgateway/worker.go
+++ b/pkg/bloomgateway/worker.go
@@ -63,15 +63,14 @@ func (w *worker) starting(_ context.Context) error {
 	return nil
 }
 
-func (w *worker) running(_ context.Context) error {
+func (w *worker) running(ctx context.Context) error {
 	idx := queue.StartIndexWithLocalQueue
 
 	p := newProcessor(w.id, w.cfg.queryConcurrency, w.store, w.logger, w.metrics)
 
 	for st := w.State(); st == services.Running || st == services.Stopping; {
-		taskCtx := context.Background()
 		start := time.Now()
-		item, newIdx, err := w.queue.Dequeue(taskCtx, idx, w.id)
+		item, newIdx, err := w.queue.Dequeue(ctx, idx, w.id)
 		w.metrics.dequeueDuration.WithLabelValues(w.id).Observe(time.Since(start).Seconds())
 		if err != nil {
 			// We only return an error if the queue is stopped and dequeuing did not yield any items

--- a/pkg/storage/stores/shipper/bloomshipper/fetcher.go
+++ b/pkg/storage/stores/shipper/bloomshipper/fetcher.go
@@ -226,7 +226,7 @@ func (f *Fetcher) FetchBlocks(ctx context.Context, refs []BlockRef, opts ...Fetc
 			f.metrics.downloadQueueSize.Observe(float64(len(f.q.queue)))
 			start := time.Now()
 			f.q.enqueue(downloadRequest[BlockRef, BlockDirectory]{
-				ctx:     ctx,
+				ctx:     context.Background(),
 				item:    refs[i],
 				key:     key,
 				idx:     i,


### PR DESCRIPTION
Simplifies task execution. A single slow task that requires a lot of bloom checks may slow down all other tasks executed within the same multiplexed execution.

While the idea of multiplexing requests/tasks was to reduce file i/o as well as memory consumption, it turned out that the downside of slowing down individual requests does not benefits.

**More observations and metrics are needed to verify this assumption, but initial tests showed a significant decrease in p99 latency for bloom gateway requests.**