### PR TITLE
fix: avoid wiping out delete request list cache in queriers when compactor is down

### DIFF
--- a/pkg/compactor/deletion/delete_requests_client.go
+++ b/pkg/compactor/deletion/delete_requests_client.go
@@ -98,22 +98,25 @@ func (c *deleteRequestsClient) updateLoop() {
 	for {
 		select {
 		case <-t.C:
-			c.updateCache()
+			if err := c.updateCache(); err != nil {
+				if err != nil {
+					level.Error(log.Logger).Log("msg", "error reloading cached delete requests", "err", err)
+				}
+			}
 		case <-c.stopChan:
 			return
 		}
 	}
 }
 
-func (c *deleteRequestsClient) updateCache() {
+func (c *deleteRequestsClient) updateCache() error {
 	userIDs := c.currentUserIDs()
 
 	newCache := make(map[string][]DeleteRequest)
 	for _, userID := range userIDs {
 		deleteReq, err := c.compactorClient.GetAllDeleteRequestsForUser(context.Background(), userID)
 		if err != nil {
-			level.Error(log.Logger).Log("msg", "error getting delete requests from the store", "err", err)
-			continue
+			return err
 		}
 		newCache[userID] = deleteReq
 	}
@@ -121,6 +124,8 @@ func (c *deleteRequestsClient) updateCache() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.cache = newCache
+
+	return nil
 }
 
 func (c *deleteRequestsClient) currentUserIDs() []string {

--- a/pkg/compactor/deletion/delete_requests_client.go
+++ b/pkg/compactor/deletion/delete_requests_client.go
@@ -99,9 +99,7 @@ func (c *deleteRequestsClient) updateLoop() {
 		select {
 		case <-t.C:
 			if err := c.updateCache(); err != nil {
-				if err != nil {
-					level.Error(log.Logger).Log("msg", "error reloading cached delete requests", "err", err)
-				}
+				level.Error(log.Logger).Log("msg", "error reloading cached delete requests", "err", err)
 			}
 		case <-c.stopChan:
 			return

--- a/pkg/compactor/deletion/delete_requests_client_test.go
+++ b/pkg/compactor/deletion/delete_requests_client_test.go
@@ -2,6 +2,7 @@ package deletion
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -63,6 +64,14 @@ func TestGetCacheGenNumberForUser(t *testing.T) {
 		require.Nil(t, err)
 		require.Equal(t, "different", deleteRequests[0].RequestID)
 
+		// failure in compactor calls should not wipe the cache
+		compactorClient.SetErr(fmt.Errorf("fail compactor calls"))
+		time.Sleep(200 * time.Millisecond)
+
+		deleteRequests, err = client.GetAllDeleteRequestsForUser(context.Background(), "userID")
+		require.Nil(t, err)
+		require.Equal(t, "different", deleteRequests[0].RequestID)
+
 		client.Stop()
 	})
 }
@@ -71,6 +80,7 @@ type mockCompactorClient struct {
 	mx          sync.Mutex
 	delRequests []DeleteRequest
 	cacheGenNum string
+	err         error
 }
 
 func (m *mockCompactorClient) SetDeleteRequests(d []DeleteRequest) {
@@ -80,12 +90,19 @@ func (m *mockCompactorClient) SetDeleteRequests(d []DeleteRequest) {
 }
 
 func (m *mockCompactorClient) GetAllDeleteRequestsForUser(_ context.Context, _ string) ([]DeleteRequest, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
 	m.mx.Lock()
 	defer m.mx.Unlock()
 	return m.delRequests, nil
 }
 
 func (m *mockCompactorClient) GetCacheGenerationNumber(_ context.Context, _ string) (string, error) {
+	if m.err != nil {
+		return "", m.err
+	}
+
 	return m.cacheGenNum, nil
 }
 
@@ -94,3 +111,7 @@ func (m *mockCompactorClient) Name() string {
 }
 
 func (m *mockCompactorClient) Stop() {}
+
+func (m *mockCompactorClient) SetErr(err error) {
+	m.err = err
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
For query time filtering of data requested for deletion, we load a list of delete requests from the compactor at query time.
The list of delete requests is cached with the queriers to avoid going to compactor during each Loki query.
We update this list every 5 minutes for all the tenants whose delete request lists have been cached.
However, when the compactor is down, we inadvertently wipe out the cache, causing us to break the queries while the compactor is down.

This PR fixes the issue by not updating the cache when we are failing list calls to the compactor.

**Checklist**
- [x] Tests updated