### PR TITLE
fix(operator): Keep credentialMode in status when updating schemas

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Main
 
+- [12212](https://github.com/grafana/loki/pull/12212) **xperimental**: Keep credentialMode in status when updating schemas
 - [12165](https://github.com/grafana/loki/pull/12165) **JoaoBraveCoding**: Change attribute value used for CCO-based credential mode
 - [12157](https://github.com/grafana/loki/pull/12157) **periklis**: Fix managed auth features annotation for community-openshift bundle
 - [12104](https://github.com/grafana/loki/pull/12104) **periklis**: Upgrade build and runtime dependencies

--- a/operator/internal/status/storage.go
+++ b/operator/internal/status/storage.go
@@ -21,9 +21,6 @@ func SetStorageSchemaStatus(ctx context.Context, k k8s.Client, req ctrl.Request,
 		return kverrors.Wrap(err, "failed to lookup lokistack", "name", req.NamespacedName)
 	}
 
-	s.Status.Storage = lokiv1.LokiStackStorageStatus{
-		Schemas: schemas,
-	}
-
+	s.Status.Storage.Schemas = schemas
 	return k.Status().Update(ctx, &s)
 }

--- a/operator/internal/status/storage_test.go
+++ b/operator/internal/status/storage_test.go
@@ -66,6 +66,7 @@ func TestSetStorageSchemaStatus_WhenStorageStatusExists_OverwriteStorageStatus(t
 		},
 		Status: lokiv1.LokiStackStatus{
 			Storage: lokiv1.LokiStackStorageStatus{
+				CredentialMode: lokiv1.CredentialModeStatic,
 				Schemas: []lokiv1.ObjectStorageSchema{
 					{
 						Version:       lokiv1.ObjectStorageSchemaV11,
@@ -94,14 +95,17 @@ func TestSetStorageSchemaStatus_WhenStorageStatusExists_OverwriteStorageStatus(t
 		},
 	}
 
-	expected := []lokiv1.ObjectStorageSchema{
-		{
-			Version:       lokiv1.ObjectStorageSchemaV11,
-			EffectiveDate: "2020-10-11",
-		},
-		{
-			Version:       lokiv1.ObjectStorageSchemaV12,
-			EffectiveDate: "2021-10-11",
+	expected := lokiv1.LokiStackStorageStatus{
+		CredentialMode: lokiv1.CredentialModeStatic,
+		Schemas: []lokiv1.ObjectStorageSchema{
+			{
+				Version:       lokiv1.ObjectStorageSchemaV11,
+				EffectiveDate: "2020-10-11",
+			},
+			{
+				Version:       lokiv1.ObjectStorageSchemaV12,
+				EffectiveDate: "2021-10-11",
+			},
 		},
 	}
 
@@ -115,7 +119,7 @@ func TestSetStorageSchemaStatus_WhenStorageStatusExists_OverwriteStorageStatus(t
 
 	sw.UpdateStub = func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
 		stack := obj.(*lokiv1.LokiStack)
-		require.Equal(t, expected, stack.Status.Storage.Schemas)
+		require.Equal(t, expected, stack.Status.Storage)
 		return nil
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

I noticed that the `credentialMode` in `.status.storage` of LokiStack disappears sometimes when the operator is reconciling the LokiStack. This PR fixes this by only setting the storage schema list instead of the whole storage status during the intermediate update.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Tests updated
- [x] `CHANGELOG.md` updated
