### PR TITLE
chore: pass shard count to injected pipelines and extractors

### DIFF
--- a/pkg/ingester/instance.go
+++ b/pkg/ingester/instance.go
@@ -437,12 +437,13 @@ func (i *instance) Query(ctx context.Context, req logql.SelectLogParams) (iter.E
 	}
 
 	if i.pipelineWrapper != nil {
+		shards := logql.ParseShardCount(req.GetShards())
 		userID, err := tenant.TenantID(ctx)
 		if err != nil {
 			return nil, err
 		}
 
-		pipeline = i.pipelineWrapper.Wrap(ctx, pipeline, expr.String(), userID)
+		pipeline = i.pipelineWrapper.Wrap(ctx, pipeline, expr.String(), userID, shards)
 	}
 
 	stats := stats.FromContext(ctx)
@@ -491,12 +492,13 @@ func (i *instance) QuerySample(ctx context.Context, req logql.SelectSampleParams
 	}
 
 	if i.extractorWrapper != nil {
+		shards := logql.ParseShardCount(req.GetShards())
 		userID, err := tenant.TenantID(ctx)
 		if err != nil {
 			return nil, err
 		}
 
-		extractor = i.extractorWrapper.Wrap(ctx, extractor, expr.String(), userID)
+		extractor = i.extractorWrapper.Wrap(ctx, extractor, expr.String(), userID, shards)
 	}
 
 	stats := stats.FromContext(ctx)

--- a/pkg/ingester/instance_test.go
+++ b/pkg/ingester/instance_test.go
@@ -697,6 +697,7 @@ func Test_PipelineWrapper(t *testing.T) {
 				Start:     time.Unix(0, 0),
 				End:       time.Unix(0, 100000000),
 				Direction: logproto.BACKWARD,
+				Shards:    []string{astmapper.ShardAnnotation{Shard: 0, Of: 1}.String()},
 				Plan: &plan.QueryPlan{
 					AST: syntax.MustParseExpr(`{job="3"}`),
 				},
@@ -713,19 +714,22 @@ func Test_PipelineWrapper(t *testing.T) {
 
 	require.Equal(t, "test-user", wrapper.tenant)
 	require.Equal(t, `{job="3"}`, wrapper.query)
+	require.Equal(t, 1, wrapper.shards)
 	require.Equal(t, 10, wrapper.pipeline.sp.called) // we've passed every log line through the wrapper
 }
 
 type testPipelineWrapper struct {
 	query    string
 	tenant   string
+	shards   int
 	pipeline *mockPipeline
 }
 
-func (t *testPipelineWrapper) Wrap(_ context.Context, pipeline log.Pipeline, query, tenant string) log.Pipeline {
+func (t *testPipelineWrapper) Wrap(_ context.Context, pipeline log.Pipeline, query, tenant string, shard int) log.Pipeline {
 	t.tenant = tenant
 	t.query = query
 	t.pipeline.wrappedExtractor = pipeline
+	t.shards = shard
 	return t.pipeline
 }
 
@@ -787,6 +791,7 @@ func Test_ExtractorWrapper(t *testing.T) {
 				Selector: `sum(count_over_time({job="3"}[1m]))`,
 				Start:    time.Unix(0, 0),
 				End:      time.Unix(0, 100000000),
+				Shards:   []string{astmapper.ShardAnnotation{Shard: 0, Of: 1}.String()},
 				Plan: &plan.QueryPlan{
 					AST: syntax.MustParseExpr(`sum(count_over_time({job="3"}[1m]))`),
 				},
@@ -802,19 +807,22 @@ func Test_ExtractorWrapper(t *testing.T) {
 	}
 
 	require.Equal(t, `sum(count_over_time({job="3"}[1m]))`, wrapper.query)
+	require.Equal(t, 1, wrapper.shards)
 	require.Equal(t, 10, wrapper.extractor.sp.called) // we've passed every log line through the wrapper
 }
 
 type testExtractorWrapper struct {
 	query     string
 	tenant    string
+	shards    int
 	extractor *mockExtractor
 }
 
-func (t *testExtractorWrapper) Wrap(_ context.Context, extractor log.SampleExtractor, query, tenant string) log.SampleExtractor {
+func (t *testExtractorWrapper) Wrap(_ context.Context, extractor log.SampleExtractor, query, tenant string, shard int) log.SampleExtractor {
 	t.tenant = tenant
 	t.query = query
 	t.extractor.wrappedExtractor = extractor
+	t.shards = shard
 	return t.extractor
 }
 

--- a/pkg/logql/downstream.go
+++ b/pkg/logql/downstream.go
@@ -329,6 +329,23 @@ func ParseShards(strs []string) (Shards, error) {
 	return shards, nil
 }
 
+func ParseShardCount(strs []string) int {
+	if len(strs) == 0 {
+		return 0
+	}
+
+	for _, str := range strs {
+		shard, err := astmapper.ParseShard(str)
+		if err != nil {
+			continue
+		}
+
+		return shard.Of
+	}
+
+	return 0
+}
+
 type Downstreamable interface {
 	Downstreamer(context.Context) Downstreamer
 }

--- a/pkg/logql/downstream_test.go
+++ b/pkg/logql/downstream_test.go
@@ -741,6 +741,11 @@ func TestParseShardCount(t *testing.T) {
 		expected int
 	}{
 		{
+			name:     "empty shards",
+			shards:   []string{},
+			expected: 0,
+		},
+		{
 			name:     "single shard",
 			shards:   []string{"0_of_3"},
 			expected: 3,

--- a/pkg/logql/downstream_test.go
+++ b/pkg/logql/downstream_test.go
@@ -733,3 +733,37 @@ and
     10`
 	assert.Equal(t, expected, got)
 }
+
+func TestParseShardCount(t *testing.T) {
+	for _, st := range []struct {
+		name     string
+		shards   []string
+		expected int
+	}{
+		{
+			name:     "single shard",
+			shards:   []string{"0_of_3"},
+			expected: 3,
+		},
+		{
+			name:     "single shard with error",
+			shards:   []string{"0_of_"},
+			expected: 0,
+		},
+		{
+			name:     "multiple shards",
+			shards:   []string{"0_of_3", "0_of_4"},
+			expected: 3,
+		},
+		{
+			name:     "multiple shards with errors",
+			shards:   []string{"_of_3", "0_of_4"},
+			expected: 4,
+		},
+	} {
+		t.Run(st.name, func(t *testing.T) {
+			require.Equal(t, st.expected, ParseShardCount(st.shards))
+		})
+
+	}
+}

--- a/pkg/logql/log/metrics_extraction.go
+++ b/pkg/logql/log/metrics_extraction.go
@@ -43,7 +43,7 @@ type StreamSampleExtractor interface {
 // SampleExtractorWrapper takes an extractor, wraps it is some desired functionality
 // and returns a new pipeline
 type SampleExtractorWrapper interface {
-	Wrap(ctx context.Context, extractor SampleExtractor, query, tenant string) SampleExtractor
+	Wrap(ctx context.Context, extractor SampleExtractor, query, tenant string, shards int) SampleExtractor
 }
 
 type lineSampleExtractor struct {

--- a/pkg/logql/log/pipeline.go
+++ b/pkg/logql/log/pipeline.go
@@ -40,7 +40,7 @@ type Stage interface {
 // PipelineWrapper takes a pipeline, wraps it is some desired functionality and
 // returns a new pipeline
 type PipelineWrapper interface {
-	Wrap(ctx context.Context, pipeline Pipeline, query, tenant string) Pipeline
+	Wrap(ctx context.Context, pipeline Pipeline, query, tenant string, shards int) Pipeline
 }
 
 // NewNoopPipeline creates a pipelines that does not process anything and returns log streams as is.

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -508,12 +508,13 @@ func (s *LokiStore) SelectLogs(ctx context.Context, req logql.SelectLogParams) (
 	}
 
 	if s.pipelineWrapper != nil {
+		shards := logql.ParseShardCount(req.GetShards())
 		userID, err := tenant.TenantID(ctx)
 		if err != nil {
 			return nil, err
 		}
 
-		pipeline = s.pipelineWrapper.Wrap(ctx, pipeline, expr.String(), userID)
+		pipeline = s.pipelineWrapper.Wrap(ctx, pipeline, expr.String(), userID, shards)
 	}
 
 	var chunkFilterer chunk.Filterer
@@ -555,12 +556,13 @@ func (s *LokiStore) SelectSamples(ctx context.Context, req logql.SelectSamplePar
 	}
 
 	if s.extractorWrapper != nil {
+		shards := logql.ParseShardCount(req.GetShards())
 		userID, err := tenant.TenantID(ctx)
 		if err != nil {
 			return nil, err
 		}
 
-		extractor = s.extractorWrapper.Wrap(ctx, extractor, expr.String(), userID)
+		extractor = s.extractorWrapper.Wrap(ctx, extractor, expr.String(), userID, shards)
 	}
 
 	var chunkFilterer chunk.Filterer

--- a/pkg/storage/util_test.go
+++ b/pkg/storage/util_test.go
@@ -146,7 +146,7 @@ func newQuery(query string, start, end time.Time, shards []astmapper.ShardAnnota
 	return req
 }
 
-func newSampleQuery(query string, start, end time.Time, deletes []*logproto.Delete) *logproto.SampleQueryRequest {
+func newSampleQuery(query string, start, end time.Time, shards []astmapper.ShardAnnotation, deletes []*logproto.Delete) *logproto.SampleQueryRequest {
 	req := &logproto.SampleQueryRequest{
 		Selector: query,
 		Start:    start,
@@ -155,6 +155,9 @@ func newSampleQuery(query string, start, end time.Time, deletes []*logproto.Dele
 		Plan: &plan.QueryPlan{
 			AST: syntax.MustParseExpr(query),
 		},
+	}
+	for _, shard := range shards {
+		req.Shards = append(req.Shards, shard.String())
 	}
 	return req
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This pr enables passing shard count information to pipeline and extractor wrappers.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
