### PR TITLE
fix: data race in seriesIterator, use atomic int

### DIFF
--- a/pkg/iter/sample_iterator.go
+++ b/pkg/iter/sample_iterator.go
@@ -3,6 +3,7 @@ package iter
 import (
 	"container/heap"
 	"context"
+	"go.uber.org/atomic"
 	"io"
 	"sync"
 
@@ -521,7 +522,7 @@ func NewSampleQueryResponseIterator(resp *logproto.SampleQueryResponse) SampleIt
 }
 
 type seriesIterator struct {
-	i      int
+	i      *atomic.Int32
 	series logproto.Series
 }
 
@@ -567,14 +568,14 @@ func NewMultiSeriesIterator(series []logproto.Series) SampleIterator {
 // NewSeriesIterator iterates over sample in a series.
 func NewSeriesIterator(series logproto.Series) SampleIterator {
 	return &seriesIterator{
-		i:      -1,
+		i:      atomic.NewInt32(-1),
 		series: series,
 	}
 }
 
 func (i *seriesIterator) Next() bool {
-	i.i++
-	return i.i < len(i.series.Samples)
+	i.i.Inc()
+	return int(i.i.Load()) < len(i.series.Samples)
 }
 
 func (i *seriesIterator) Error() error {
@@ -590,7 +591,7 @@ func (i *seriesIterator) StreamHash() uint64 {
 }
 
 func (i *seriesIterator) Sample() logproto.Sample {
-	return i.series.Samples[i.i]
+	return i.series.Samples[i.i.Load()]
 }
 
 func (i *seriesIterator) Close() error {


### PR DESCRIPTION
Before the fix
```
go test --race ./pkg/logql/...
?   	github.com/grafana/loki/pkg/logql/vector	[no test files]
==================
WARNING: DATA RACE
Read at 0x00c0009d4bc0 by goroutine 340:
  github.com/grafana/loki/pkg/iter.(*seriesIterator).Next()
      /Users/poyzannur/workspace/loki/pkg/iter/sample_iterator.go:576 +0x2c
  github.com/grafana/loki/pkg/iter.(*sortSampleIterator).init()
      /Users/poyzannur/workspace/loki/pkg/iter/sample_iterator.go:387 +0xec
  github.com/grafana/loki/pkg/iter.(*sortSampleIterator).Next()
      /Users/poyzannur/workspace/loki/pkg/iter/sample_iterator.go:405 +0x2c
  github.com/grafana/loki/pkg/iter.NewPeekingSampleIterator()
      /Users/poyzannur/workspace/loki/pkg/iter/sample_iterator.go:45 +0x78
  github.com/grafana/loki/pkg/logql.(*DefaultEvaluator).NewStepEvaluator()
      /Users/poyzannur/workspace/loki/pkg/logql/evaluator.go:272 +0x6f0
  github.com/grafana/loki/pkg/logql.newBinOpStepEvaluator.func1()
      /Users/poyzannur/workspace/loki/pkg/logql/evaluator.go:698 +0xa8
  golang.org/x/sync/errgroup.(*Group).Go.func1()
      /Users/poyzannur/workspace/loki/vendor/golang.org/x/sync/errgroup/errgroup.go:75 +0x6c

Previous write at 0x00c0009d4bc0 by goroutine 341:
  github.com/grafana/loki/pkg/iter.(*seriesIterator).Next()
      /Users/poyzannur/workspace/loki/pkg/iter/sample_iterator.go:576 +0x3c
  github.com/grafana/loki/pkg/iter.(*sortSampleIterator).init()
      /Users/poyzannur/workspace/loki/pkg/iter/sample_iterator.go:387 +0xec
  github.com/grafana/loki/pkg/iter.(*sortSampleIterator).Next()
      /Users/poyzannur/workspace/loki/pkg/iter/sample_iterator.go:405 +0x2c
  github.com/grafana/loki/pkg/iter.NewPeekingSampleIterator()
      /Users/poyzannur/workspace/loki/pkg/iter/sample_iterator.go:45 +0x78
  github.com/grafana/loki/pkg/logql.(*DefaultEvaluator).NewStepEvaluator()
      /Users/poyzannur/workspace/loki/pkg/logql/evaluator.go:272 +0x6f0
  github.com/grafana/loki/pkg/logql.newBinOpStepEvaluator.func2()
      /Users/poyzannur/workspace/loki/pkg/logql/evaluator.go:706 +0xb4
  golang.org/x/sync/errgroup.(*Group).Go.func1()
      /Users/poyzannur/workspace/loki/vendor/golang.org/x/sync/errgroup/errgroup.go:75 +0x6c

Goroutine 340 (running) created at:
  golang.org/x/sync/errgroup.(*Group).Go()
      /Users/poyzannur/workspace/loki/vendor/golang.org/x/sync/errgroup/errgroup.go:72 +0x10c
  github.com/grafana/loki/pkg/logql.newBinOpStepEvaluator()
      /Users/poyzannur/workspace/loki/pkg/logql/evaluator.go:696 +0x598
  github.com/grafana/loki/pkg/logql.(*DefaultEvaluator).NewStepEvaluator()
      /Users/poyzannur/workspace/loki/pkg/logql/evaluator.go:274 +0x798
  github.com/grafana/loki/pkg/logql.(*query).evalSample()
      /Users/poyzannur/workspace/loki/pkg/logql/engine.go:348 +0x21c
  github.com/grafana/loki/pkg/logql.(*query).Eval()
      /Users/poyzannur/workspace/loki/pkg/logql/engine.go:285 +0x4d4
  github.com/grafana/loki/pkg/logql.(*query).Exec()
      /Users/poyzannur/workspace/loki/pkg/logql/engine.go:252 +0x118c
  github.com/grafana/loki/pkg/logql.TestStepEvaluator_Error.func1()
      /Users/poyzannur/workspace/loki/pkg/logql/engine_test.go:2448 +0x4b0
  testing.tRunner()
      /opt/homebrew/opt/go/libexec/src/testing/testing.go:1595 +0x194
  testing.(*T).Run.func1()
      /opt/homebrew/opt/go/libexec/src/testing/testing.go:1648 +0x40

Goroutine 341 (finished) created at:
  golang.org/x/sync/errgroup.(*Group).Go()
      /Users/poyzannur/workspace/loki/vendor/golang.org/x/sync/errgroup/errgroup.go:72 +0x10c
  github.com/grafana/loki/pkg/logql.newBinOpStepEvaluator()
      /Users/poyzannur/workspace/loki/pkg/logql/evaluator.go:704 +0x738
  github.com/grafana/loki/pkg/logql.(*DefaultEvaluator).NewStepEvaluator()
      /Users/poyzannur/workspace/loki/pkg/logql/evaluator.go:274 +0x798
  github.com/grafana/loki/pkg/logql.(*query).evalSample()
      /Users/poyzannur/workspace/loki/pkg/logql/engine.go:348 +0x21c
  github.com/grafana/loki/pkg/logql.(*query).Eval()
      /Users/poyzannur/workspace/loki/pkg/logql/engine.go:285 +0x4d4
  github.com/grafana/loki/pkg/logql.(*query).Exec()
      /Users/poyzannur/workspace/loki/pkg/logql/engine.go:252 +0x118c
  github.com/grafana/loki/pkg/logql.TestStepEvaluator_Error.func1()
      /Users/poyzannur/workspace/loki/pkg/logql/engine_test.go:2448 +0x4b0
  testing.tRunner()
      /opt/homebrew/opt/go/libexec/src/testing/testing.go:1595 +0x194
  testing.(*T).Run.func1()
      /opt/homebrew/opt/go/libexec/src/testing/testing.go:1648 +0x40
==================
--- FAIL: TestStepEvaluator_Error (0.00s)
    --- FAIL: TestStepEvaluator_Error/binOpStepEvaluator (0.00s)
        testing.go:1465: race detected during execution of test
    testing.go:1465: race detected during execution of test
FAIL
FAIL	github.com/grafana/loki/pkg/logql	129.372s
ok  	github.com/grafana/loki/pkg/logql/log	(cached)
ok  	github.com/grafana/loki/pkg/logql/log/jsonexpr	(cached)
ok  	github.com/grafana/loki/pkg/logql/log/logfmt	(cached)
ok  	github.com/grafana/loki/pkg/logql/log/pattern	(cached)
ok  	github.com/grafana/loki/pkg/logql/sketch	(cached)
ok  	github.com/grafana/loki/pkg/logql/syntax	(cached)
```

After the fix
```
go test --race ./pkg/logql/...                   
?   	github.com/grafana/loki/pkg/logql/vector	[no test files]
ok  	github.com/grafana/loki/pkg/logql	(cached)
ok  	github.com/grafana/loki/pkg/logql/log	(cached)
ok  	github.com/grafana/loki/pkg/logql/log/jsonexpr	(cached)
ok  	github.com/grafana/loki/pkg/logql/log/logfmt	(cached)
ok  	github.com/grafana/loki/pkg/logql/log/pattern	(cached)
ok  	github.com/grafana/loki/pkg/logql/sketch	(cached)
ok  	github.com/grafana/loki/pkg/logql/syntax	(cached)

```
