### PR TITLE
fix: data race in unit test

### DIFF
--- a/pkg/compactor/deletion/delete_requests_client_test.go
+++ b/pkg/compactor/deletion/delete_requests_client_test.go
@@ -90,11 +90,11 @@ func (m *mockCompactorClient) SetDeleteRequests(d []DeleteRequest) {
 }
 
 func (m *mockCompactorClient) GetAllDeleteRequestsForUser(_ context.Context, _ string) ([]DeleteRequest, error) {
+	m.mx.Lock()
+	defer m.mx.Unlock()
 	if m.err != nil {
 		return nil, m.err
 	}
-	m.mx.Lock()
-	defer m.mx.Unlock()
 	return m.delRequests, nil
 }
 
@@ -113,5 +113,7 @@ func (m *mockCompactorClient) Name() string {
 func (m *mockCompactorClient) Stop() {}
 
 func (m *mockCompactorClient) SetErr(err error) {
+	m.mx.Lock()
+	defer m.mx.Unlock()
 	m.err = err
 }


### PR DESCRIPTION
Before the fix
```
 go test --race ./pkg/compactor/...
?   	github.com/grafana/loki/pkg/compactor/client	[no test files]
?   	github.com/grafana/loki/pkg/compactor/client/grpc	[no test files]
ok  	github.com/grafana/loki/pkg/compactor	(cached)
==================
WARNING: DATA RACE
Read at 0x00c000946070 by goroutine 149:
  github.com/grafana/loki/pkg/compactor/deletion.(*mockCompactorClient).GetAllDeleteRequestsForUser()
      /Users/poyzannur/workspace/loki/pkg/compactor/deletion/delete_requests_client_test.go:93 +0x44
  github.com/grafana/loki/pkg/compactor/deletion.(*deleteRequestsClient).updateCache()
      /Users/poyzannur/workspace/loki/pkg/compactor/deletion/delete_requests_client.go:115 +0xe8
  github.com/grafana/loki/pkg/compactor/deletion.(*deleteRequestsClient).updateLoop()
      /Users/poyzannur/workspace/loki/pkg/compactor/deletion/delete_requests_client.go:101 +0x10c
  github.com/grafana/loki/pkg/compactor/deletion.NewDeleteRequestsClient.func1()
      /Users/poyzannur/workspace/loki/pkg/compactor/deletion/delete_requests_client.go:60 +0x34

Previous write at 0x00c000946070 by goroutine 148:
  github.com/grafana/loki/pkg/compactor/deletion.(*mockCompactorClient).SetErr()
      /Users/poyzannur/workspace/loki/pkg/compactor/deletion/delete_requests_client_test.go:116 +0x494
  github.com/grafana/loki/pkg/compactor/deletion.TestGetCacheGenNumberForUser.func2()
      /Users/poyzannur/workspace/loki/pkg/compactor/deletion/delete_requests_client_test.go:68 +0x464
  testing.tRunner()
      /opt/homebrew/opt/go/libexec/src/testing/testing.go:1595 +0x194
  testing.(*T).Run.func1()
      /opt/homebrew/opt/go/libexec/src/testing/testing.go:1648 +0x40

Goroutine 149 (running) created at:
  github.com/grafana/loki/pkg/compactor/deletion.NewDeleteRequestsClient()
      /Users/poyzannur/workspace/loki/pkg/compactor/deletion/delete_requests_client.go:60 +0x2a8
  github.com/grafana/loki/pkg/compactor/deletion.TestGetCacheGenNumberForUser.func2()
      /Users/poyzannur/workspace/loki/pkg/compactor/deletion/delete_requests_client_test.go:44 +0x144
  testing.tRunner()
      /opt/homebrew/opt/go/libexec/src/testing/testing.go:1595 +0x194
  testing.(*T).Run.func1()
      /opt/homebrew/opt/go/libexec/src/testing/testing.go:1648 +0x40

Goroutine 148 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/opt/go/libexec/src/testing/testing.go:1648 +0x5d8
  github.com/grafana/loki/pkg/compactor/deletion.TestGetCacheGenNumberForUser()
      /Users/poyzannur/workspace/loki/pkg/compactor/deletion/delete_requests_client_test.go:36 +0x12c
  testing.tRunner()
      /opt/homebrew/opt/go/libexec/src/testing/testing.go:1595 +0x194
  testing.(*T).Run.func1()
      /opt/homebrew/opt/go/libexec/src/testing/testing.go:1648 +0x40
==================
--- FAIL: TestGetCacheGenNumberForUser (0.40s)
    --- FAIL: TestGetCacheGenNumberForUser/it_caches_the_results (0.40s)
        testing.go:1465: race detected during execution of test
    testing.go:1465: race detected during execution of test
/var/folders/sn/7r_bccw12tb9gzfqxg0c6ch80000gn/T/TestDeleteRequestsStore884019854/001
/var/folders/sn/7r_bccw12tb9gzfqxg0c6ch80000gn/T/TestBatchCreateGetit_adds_the_requests_with_different_sequence_numbers_but_the_same_request_id,_status,_and_creation_time1771388142/001
/var/folders/sn/7r_bccw12tb9gzfqxg0c6ch80000gn/T/TestBatchCreateGetreturns_all_the_requests_that_share_a_request_id3753367018/001
/var/folders/sn/7r_bccw12tb9gzfqxg0c6ch80000gn/T/TestBatchCreateGetupdates_a_single_request_with_a_new_status3550616609/001
/var/folders/sn/7r_bccw12tb9gzfqxg0c6ch80000gn/T/TestBatchCreateGetdeletes_several_delete_requests2988262926/001
FAIL
FAIL	github.com/grafana/loki/pkg/compactor/deletion	2.144s
ok  	github.com/grafana/loki/pkg/compactor/deletionmode	(cached)
ok  	github.com/grafana/loki/pkg/compactor/generationnumber	(cached)
ok  	github.com/grafana/loki/pkg/compactor/retention	(cached)

```

After the fix
```
 go test --race ./pkg/compactor/...
?   	github.com/grafana/loki/pkg/compactor/client	[no test files]
?   	github.com/grafana/loki/pkg/compactor/client/grpc	[no test files]
ok  	github.com/grafana/loki/pkg/compactor	(cached)
ok  	github.com/grafana/loki/pkg/compactor/deletion	(cached)
ok  	github.com/grafana/loki/pkg/compactor/deletionmode	(cached)
ok  	github.com/grafana/loki/pkg/compactor/generationnumber	(cached)
ok  	github.com/grafana/loki/pkg/compactor/retention	(cached)
```