### PR TITLE
fix: correct use of atomic int

### DIFF
--- a/pkg/iter/sample_iterator.go
+++ b/pkg/iter/sample_iterator.go
@@ -574,8 +574,8 @@ func NewSeriesIterator(series logproto.Series) SampleIterator {
 }
 
 func (i *seriesIterator) Next() bool {
-	i.i.Inc()
-	return int(i.i.Load()) < len(i.series.Samples)
+	tmp := i.i.Add(1)
+	return int(tmp) < len(i.series.Samples)
 }
 
 func (i *seriesIterator) Error() error {


### PR DESCRIPTION
Fix for the wrong use of atomic int use in https://github.com/grafana/loki/pull/12223
Thanks @na-- for catching it.