### PR TITLE
test: Don't start server until all configured

### DIFF
--- a/pkg/storage/chunk/client/gcp/gcs_object_client_test.go
+++ b/pkg/storage/chunk/client/gcp/gcs_object_client_test.go
@@ -246,7 +246,7 @@ func fakeHTTPRespondingServer(t *testing.T, code int) *httptest.Server {
 }
 
 func fakeSleepingServer(t *testing.T, responseSleep, connectSleep time.Duration, closeOnNew, closeOnActive bool) *httptest.Server {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// sleep on response to mimic server overload
 		time.Sleep(responseSleep)
 	}))
@@ -264,6 +264,6 @@ func fakeSleepingServer(t *testing.T, responseSleep, connectSleep time.Duration,
 		}
 	}
 	t.Cleanup(server.Close)
-
+	server.Start()
 	return server
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Before the fix: 
```
WARNING: DATA RACE
Read at 0x00c0003ae150 by goroutine 151:
  net/http.(*conn).setState()
      /opt/homebrew/Cellar/go/1.21.6/libexec/src/net/http/server.go:1810 +0x120
  net/http.(*Server).Serve()
      /opt/homebrew/Cellar/go/1.21.6/libexec/src/net/http/server.go:3085 +0x594
  net/http/httptest.(*Server).goServe.func1()
      /opt/homebrew/Cellar/go/1.21.6/libexec/src/net/http/httptest/server.go:310 +0xb8

Previous write at 0x00c0003ae150 by goroutine 150:
  github.com/grafana/loki/pkg/storage/chunk/client/gcp.fakeSleepingServer()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/storage/chunk/client/gcp/gcs_object_client_test.go:253 +0x140
  github.com/grafana/loki/pkg/storage/chunk/client/gcp.TestTCPErrs.func1()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/storage/chunk/client/gcp/gcs_object_client_test.go:209 +0xb8
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.21.6/libexec/src/testing/testing.go:1595 +0x1b0
  testing.(*T).Run.func1()
      /opt/homebrew/Cellar/go/1.21.6/libexec/src/testing/testing.go:1648 +0x40

Goroutine 151 (running) created at:
  net/http/httptest.(*Server).goServe()
      /opt/homebrew/Cellar/go/1.21.6/libexec/src/net/http/httptest/server.go:308 +0x98
  net/http/httptest.(*Server).Start()
      /opt/homebrew/Cellar/go/1.21.6/libexec/src/net/http/httptest/server.go:134 +0x31c
  net/http/httptest.NewServer()
      /opt/homebrew/Cellar/go/1.21.6/libexec/src/net/http/httptest/server.go:107 +0x1a0
  github.com/grafana/loki/pkg/storage/chunk/client/gcp.fakeSleepingServer()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/storage/chunk/client/gcp/gcs_object_client_test.go:249 +0x78
  github.com/grafana/loki/pkg/storage/chunk/client/gcp.TestTCPErrs.func1()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/storage/chunk/client/gcp/gcs_object_client_test.go:209 +0xb8
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.21.6/libexec/src/testing/testing.go:1595 +0x1b0
  testing.(*T).Run.func1()
      /opt/homebrew/Cellar/go/1.21.6/libexec/src/testing/testing.go:1648 +0x40

Goroutine 150 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.21.6/libexec/src/testing/testing.go:1648 +0x5e8
  github.com/grafana/loki/pkg/storage/chunk/client/gcp.TestTCPErrs()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/storage/chunk/client/gcp/gcs_object_client_test.go:208 +0x8c
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.21.6/libexec/src/testing/testing.go:1595 +0x1b0
  testing.(*T).Run.func1()
      /opt/homebrew/Cellar/go/1.21.6/libexec/src/testing/testing.go:1648 +0x40
==================
--- FAIL: TestTCPErrs (0.10s)
    --- FAIL: TestTCPErrs/request_took_longer_than_client_timeout,_not_retryable (0.01s)
        testing.go:1465: race detected during execution of test
    testing.go:1465: race detected during execution of test
FAIL
FAIL	github.com/grafana/loki/pkg/storage/chunk/client/gcp	1.754s
FAIL

```

After the fix:
```
go test -race -count=50 . -run TestTCPErrs/request_took_longer_than_client_timeout,_not_retryable
ok  	github.com/grafana/loki/pkg/storage/chunk/client/gcp	2.711s
```

**Which issue(s) this PR fixes**:
Relates to: https://github.com/grafana/loki/issues/8586

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
