### PR TITLE
chore(image-tags): exclude helm release tags

### DIFF
--- a/tools/image-tag
+++ b/tools/image-tag
@@ -13,7 +13,7 @@ SHA=$(git rev-parse --short=7 HEAD | head -c7)
 # If not a tag, use branch-hash else use tag
 TAG=$((git describe --tags --exact-match 2> /dev/null || echo "") | sed 's/[operator\/]*v//g')
 
-if [ -z "$TAG" ]
+if [ -z "$TAG" ] || [[ "${TAG}" == helm-loki-* ]]
 then
       echo "${BRANCH}"-"${SHA}""${WIP}"
 else


### PR DESCRIPTION
**What this PR does / why we need it**:
Do not use helm release tags for creating image-tag for loki, promtail and other images that are published with merged commits

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
