### PR TITLE
fix: helm template error if ingress is enabled

### DIFF
--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -13,6 +13,10 @@ Entries should include a reference to the pull request that introduced the chang
 
 [//]: # (<AUTOMATED_UPDATES_LOCATOR> : do not remove this line. This locator is used by the CI pipeline to automatically create a changelog entry for each new Loki release. Add other chart versions and respective changelog entries bellow this line.)
 
+## 5.44.3
+
+- [BUGFIX] Fix template error: `<.Values.loki.server.http_listen_port>: can't evaluate field Values in type interface {}`
+
 ## 5.44.2
 
 - [BUGFIX] Fix usage of `http_listen_port` and `grpc_listen_port` field in template.

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -3,7 +3,7 @@ name: loki
 description: Helm chart for Grafana Loki in simple, scalable mode
 type: application
 appVersion: 2.9.4
-version: 5.44.2
+version: 5.44.3
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -1,6 +1,6 @@
 # loki
 
-![Version: 5.44.2](https://img.shields.io/badge/Version-5.44.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.9.4](https://img.shields.io/badge/AppVersion-2.9.4-informational?style=flat-square)
+![Version: 5.44.3](https://img.shields.io/badge/Version-5.44.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.9.4](https://img.shields.io/badge/AppVersion-2.9.4-informational?style=flat-square)
 
 Helm chart for Grafana Loki in simple, scalable mode
 

--- a/production/helm/loki/templates/_helpers.tpl
+++ b/production/helm/loki/templates/_helpers.tpl
@@ -562,16 +562,16 @@ Params:
   pathType: Prefix
   {{- end }}
   backend:
-    {{- if $ingressApiIsStable }}
     {{- $serviceName := include "loki.ingress.serviceName" (dict "ctx" $.ctx "svcName" $.svcName) }}
+    {{- if $ingressApiIsStable }}
     service:
       name: {{ $serviceName }}
       port:
-        number: {{ .Values.loki.server.http_listen_port }}
+        number: {{ $.ctx.Values.loki.server.http_listen_port }}
     {{- else }}
     serviceName: {{ $serviceName }}
-    servicePort: {{ .Values.loki.server.http_listen_port }}
-{{- end -}}
+    servicePort: {{ $.ctx.Values.loki.server.http_listen_port }}
+    {{- end -}}
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The current released helm chart produce an error, if ingress is enabled.

```
% helm template . --set singleBinary.replicas=1 --set ingress.enabled=true > /dev/null
Error: template: loki/templates/ingress.yaml:38:14: executing "loki/templates/ingress.yaml" at <include "loki.ingress.servicePaths" $>: error calling include: template: loki/templates/_helpers.tpl:530:4: executing "loki.ingress.servicePaths" at <include "loki.ingress.singleBinaryServicePaths" .>: error calling include: template: loki/templates/_helpers.tpl:546:4: executing "loki.ingress.singleBinaryServicePaths" at <include "loki.ingress.servicePath" (dict "ctx" . "svcName" "singleBinary" "paths" .Values.ingress.paths.singleBinary)>: error calling include: template: loki/templates/_helpers.tpl:570:26: executing "loki.ingress.servicePath" at <.Values.loki.server.http_listen_port>: can't evaluate field Values in type interface {}
```


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
