### PR TITLE
test: Fix race condition in LogQL test

### DIFF
--- a/pkg/iter/sample_iterator.go
+++ b/pkg/iter/sample_iterator.go
@@ -574,8 +574,8 @@ func NewSeriesIterator(series logproto.Series) SampleIterator {
 }
 
 func (i *seriesIterator) Next() bool {
-	tmp := i.i.Add(1)
-	return int(tmp) < len(i.series.Samples)
+	i.i.Inc()
+	return int(i.i.Load()) < len(i.series.Samples)
 }
 
 func (i *seriesIterator) Error() error {

--- a/pkg/iter/sample_iterator.go
+++ b/pkg/iter/sample_iterator.go
@@ -3,7 +3,6 @@ package iter
 import (
 	"container/heap"
 	"context"
-	"go.uber.org/atomic"
 	"io"
 	"sync"
 
@@ -522,7 +521,7 @@ func NewSampleQueryResponseIterator(resp *logproto.SampleQueryResponse) SampleIt
 }
 
 type seriesIterator struct {
-	i      *atomic.Int32
+	i      int
 	series logproto.Series
 }
 
@@ -568,14 +567,14 @@ func NewMultiSeriesIterator(series []logproto.Series) SampleIterator {
 // NewSeriesIterator iterates over sample in a series.
 func NewSeriesIterator(series logproto.Series) SampleIterator {
 	return &seriesIterator{
-		i:      atomic.NewInt32(-1),
+		i:      -1,
 		series: series,
 	}
 }
 
 func (i *seriesIterator) Next() bool {
-	i.i.Inc()
-	return int(i.i.Load()) < len(i.series.Samples)
+	i.i++
+	return i.i < len(i.series.Samples)
 }
 
 func (i *seriesIterator) Error() error {
@@ -591,7 +590,7 @@ func (i *seriesIterator) StreamHash() uint64 {
 }
 
 func (i *seriesIterator) Sample() logproto.Sample {
-	return i.series.Samples[i.i.Load()]
+	return i.series.Samples[i.i]
 }
 
 func (i *seriesIterator) Close() error {


### PR DESCRIPTION
**What this PR does / why we need it**:  
Fix a race condition in LogQL test.
The iterators used in `TestStepEvaluator_Error` were shared across goroutines, leading to a warning from the race detector. Instead, return a new data structure each time.

Also revert #12223 and #12225 which were a previous change to remove the warning, but negatively impact performance.

```
goos: darwin
goarch: arm64
pkg: github.com/grafana/loki/pkg/logql
                                            │ before.txt  │             after.txt             │
                                            │   sec/op    │   sec/op     vs base              │
_RangeVectorIteratorCompare/streaming_agg-8   4.791µ ± 1%   4.793µ ± 3%       ~ (p=0.937 n=6)
_RangeVectorIteratorCompare/batch_agg-8       6.760µ ± 2%   6.589µ ± 1%  -2.53% (p=0.009 n=6)
_RangeVectorIterator-8                        4.855µ ± 1%   4.758µ ± 2%       ~ (p=0.121 n=6)
geomean                                       5.397µ        5.316µ       -1.50%

                                            │  before.txt  │             after.txt              │
                                            │     B/op     │     B/op      vs base              │
_RangeVectorIteratorCompare/streaming_agg-8   3.872Ki ± 0%   3.856Ki ± 0%  -0.40% (p=0.002 n=6)
_RangeVectorIteratorCompare/batch_agg-8       33.99Ki ± 0%   33.97Ki ± 0%  -0.06% (p=0.002 n=6)
_RangeVectorIterator-8                        3.880Ki ± 0%   3.856Ki ± 0%  -0.60% (p=0.002 n=6)
geomean                                       7.993Ki        7.965Ki       -0.35%

                                            │ before.txt │            after.txt             │
                                            │ allocs/op  │ allocs/op   vs base              │
_RangeVectorIteratorCompare/streaming_agg-8   65.00 ± 0%   63.00 ± 0%  -3.08% (p=0.002 n=6)
_RangeVectorIteratorCompare/batch_agg-8       39.00 ± 0%   37.00 ± 0%  -5.13% (p=0.002 n=6)
_RangeVectorIterator-8                        66.00 ± 0%   64.00 ± 0%  -3.03% (p=0.002 n=6)
geomean                                       55.10        53.04       -3.75%
```

**Which issue(s) this PR fixes**:
Part of #8586 

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- NA Documentation added
- [x] Tests updated
- NA `CHANGELOG.md` updated
