### PR TITLE
chore: make error labels injectable via 'Add'

### DIFF
--- a/pkg/logql/log/labels.go
+++ b/pkg/logql/log/labels.go
@@ -363,6 +363,17 @@ func (b *LabelsBuilder) Add(category LabelCategory, labels ...labels.Label) *Lab
 		if b.BaseHas(name) {
 			name = fmt.Sprintf("%s%s", name, duplicateSuffix)
 		}
+
+		if name == logqlmodel.ErrorLabel {
+			b.err = l.Value
+			continue
+		}
+
+		if name == logqlmodel.ErrorDetailsLabel {
+			b.errDetails = l.Value
+			continue
+		}
+
 		b.Set(category, name, l.Value)
 	}
 	return b

--- a/pkg/logql/log/labels_test.go
+++ b/pkg/logql/log/labels_test.go
@@ -68,6 +68,31 @@ func TestLabelsBuilder_LabelsError(t *testing.T) {
 	require.Equal(t, labels.FromStrings("already", "in"), lbs)
 }
 
+func TestLabelsBuilder_LabelsErrorFromAdd(t *testing.T) {
+	lbs := labels.FromStrings("already", "in")
+	b := NewBaseLabelsBuilder().ForLabels(lbs, lbs.Hash())
+	b.Reset()
+
+	// This works for any category
+	b.Add(StructuredMetadataLabel, labels.FromStrings(logqlmodel.ErrorLabel, "test error", logqlmodel.ErrorDetailsLabel, "test details")...)
+	lbsWithErr := b.LabelsResult()
+
+	expectedLbs := labels.FromStrings(
+		logqlmodel.ErrorLabel, "test error",
+		logqlmodel.ErrorDetailsLabel, "test details",
+		"already", "in",
+	)
+	require.Equal(t, expectedLbs, lbsWithErr.Labels())
+	require.Equal(t, expectedLbs.String(), lbsWithErr.String())
+	require.Equal(t, expectedLbs.Hash(), lbsWithErr.Hash())
+	require.Equal(t, labels.FromStrings("already", "in"), lbsWithErr.Stream())
+	require.Nil(t, lbsWithErr.StructuredMetadata())
+	require.Equal(t, labels.FromStrings(logqlmodel.ErrorLabel, "test error", logqlmodel.ErrorDetailsLabel, "test details"), lbsWithErr.Parsed())
+
+	// make sure the original labels is unchanged.
+	require.Equal(t, labels.FromStrings("already", "in"), lbs)
+}
+
 func TestLabelsBuilder_IntoMap(t *testing.T) {
 	strs := []string{
 		"namespace", "loki",


### PR DESCRIPTION
To control the error flow at the pipeline-level, this PR makes it so label errors can be injected into a line via `Add` in the label builder.