### PR TITLE
perf(blooms): Recycle bloom page buffers

### DIFF
--- a/pkg/storage/bloom/v1/bloom.go
+++ b/pkg/storage/bloom/v1/bloom.go
@@ -86,7 +86,7 @@ func LazyDecodeBloomPage(r io.Reader, pool chunkenc.ReaderPool, page BloomPageHe
 	}
 	defer pool.PutReader(decompressor)
 
-	b := make([]byte, page.DecompressedLen)
+	b := BlockPool.Get(page.DecompressedLen)[:page.DecompressedLen]
 
 	if _, err = io.ReadFull(decompressor, b); err != nil {
 		return nil, errors.Wrap(err, "decompressing bloom page")
@@ -97,6 +97,10 @@ func LazyDecodeBloomPage(r io.Reader, pool chunkenc.ReaderPool, page BloomPageHe
 	return decoder, nil
 }
 
+// NewBloomPageDecoder returns a decoder for a bloom page.
+// If the byte slice passed in the constructor is from the BlockPool pool, then
+// the caller needs to ensure that Close() is called to put the slice back to
+// its pool.
 func NewBloomPageDecoder(data []byte) *BloomPageDecoder {
 	// last 8 bytes are the number of blooms in this page
 	dec := encoding.DecWith(data[len(data)-8:])
@@ -117,11 +121,6 @@ func NewBloomPageDecoder(data []byte) *BloomPageDecoder {
 }
 
 // Decoder is a seekable, reset-able iterator
-// TODO(owen-d): use buffer pools. The reason we don't currently
-// do this is because the `data` slice currently escapes the decoder
-// via the returned bloom, so we can't know when it's safe to return it to the pool.
-// This happens via `data ([]byte) -> dec (*encoding.Decbuf) -> bloom (Bloom)` where
-// the final Bloom has a reference to the data slice.
 // We could optimize this by encoding the mode (read, write) into our structs
 // and doing copy-on-write shenannigans, but I'm avoiding this for now.
 type BloomPageDecoder struct {
@@ -165,6 +164,14 @@ func (d *BloomPageDecoder) At() *Bloom {
 
 func (d *BloomPageDecoder) Err() error {
 	return d.err
+}
+
+// Close needs to ca
+func (d *BloomPageDecoder) Close() {
+	d.err = nil
+	d.cur = nil
+	d.dec.B = d.data[:0]
+	BlockPool.Put(d.data)
 }
 
 type BloomPageHeader struct {

--- a/pkg/storage/bloom/v1/bloom.go
+++ b/pkg/storage/bloom/v1/bloom.go
@@ -169,7 +169,8 @@ func (d *BloomPageDecoder) Err() error {
 func (d *BloomPageDecoder) Close() {
 	d.err = nil
 	d.cur = nil
-	d.dec.B = d.data[:0]
+	d.data = nil
+	d.dec.B = nil
 	BlockPool.Put(d.data)
 }
 

--- a/pkg/storage/bloom/v1/bloom.go
+++ b/pkg/storage/bloom/v1/bloom.go
@@ -166,7 +166,6 @@ func (d *BloomPageDecoder) Err() error {
 	return d.err
 }
 
-// Close needs to ca
 func (d *BloomPageDecoder) Close() {
 	d.err = nil
 	d.cur = nil

--- a/pkg/storage/bloom/v1/bloom.go
+++ b/pkg/storage/bloom/v1/bloom.go
@@ -169,9 +169,9 @@ func (d *BloomPageDecoder) Err() error {
 func (d *BloomPageDecoder) Close() {
 	d.err = nil
 	d.cur = nil
+	BlockPool.Put(d.data)
 	d.data = nil
 	d.dec.B = nil
-	BlockPool.Put(d.data)
 }
 
 type BloomPageHeader struct {

--- a/pkg/storage/bloom/v1/util.go
+++ b/pkg/storage/bloom/v1/util.go
@@ -32,10 +32,10 @@ var (
 		},
 	}
 
-	// 1KB -> 8MB
+	// 4KB -> 64MB
 	BlockPool = BytePool{
 		pool: pool.New(
-			1<<10, 1<<24, 4,
+			4<<10, 64<<20, 4,
 			func(size int) interface{} {
 				return make([]byte, size)
 			}),


### PR DESCRIPTION
**What this PR does / why we need it**:

When reading a bloom page into memory, a new byte slice with the size of the decoded page was allocated.

![screenshot_20240319_084201](https://github.com/grafana/loki/assets/281260/9a5fcdb1-f4ae-48dd-9f4a-fb3d97db055a)

This PR changes bloom page decoder to use a byte slice from the `BlockPool`. The caller (`LazyBloomIter` of the block querier) is responsible for closing the page whenever a new one is loaded, so the byte slice is put back to its pool. 

![screenshot_20240319_084736](https://github.com/grafana/loki/assets/281260/91696520-9551-4f5a-819b-19349dd18b5f)

Note that the screeshots are from different time ranges and therefore differ in absolute numbers for allocated memory. However the second screenshot shows that there are no more direct allocations in `github.com/grafana/loki/pkg/storage/bloom/v1.LazyDecodeBloomPage` any more.


Additionally, this PR changes the max bucket of the `BlockPool` byte slice pool to 64MB so that pages bigger than 16MB are correctly put back to the pool, since [slices exceeding the capacity of the largest bucket are not put back](https://github.com/grafana/loki/blob/main/vendor/github.com/prometheus/prometheus/util/pool/pool.go#L74-L87).

