### PR TITLE
refactor: Replace TenantConfig method with interface.

### DIFF
--- a/pkg/distributor/writefailures/manager_test.go
+++ b/pkg/distributor/writefailures/manager_test.go
@@ -20,18 +20,20 @@ func TestWriteFailuresLogging(t *testing.T) {
 		buf := bytes.NewBuffer(nil)
 		logger := log.NewLogfmtLogger(buf)
 
-		f := func(tenantID string) *runtime.Config {
-			if tenantID == "good-tenant" {
-				return &runtime.Config{
-					LimitedLogPushErrors: true,
+		f := &providerMock{
+			tenantConfig: func(tenantID string) *runtime.Config {
+				if tenantID == "good-tenant" {
+					return &runtime.Config{
+						LimitedLogPushErrors: true,
+					}
 				}
-			}
-			if tenantID == "bad-tenant" {
-				return &runtime.Config{
-					LimitedLogPushErrors: false,
+				if tenantID == "bad-tenant" {
+					return &runtime.Config{
+						LimitedLogPushErrors: false,
+					}
 				}
-			}
-			return &runtime.Config{}
+				return &runtime.Config{}
+			},
 		}
 
 		runtimeCfg, err := runtime.NewTenantConfigs(f)
@@ -55,12 +57,14 @@ func TestWriteFailuresRateLimiting(t *testing.T) {
 	buf := bytes.NewBuffer(nil)
 	logger := log.NewLogfmtLogger(buf)
 
-	f := func(tenantID string) *runtime.Config {
-		return &runtime.Config{
-			LimitedLogPushErrors: true,
-		}
+	provider := &providerMock{
+		tenantConfig: func(tenantID string) *runtime.Config {
+			return &runtime.Config{
+				LimitedLogPushErrors: true,
+			}
+		},
 	}
-	runtimeCfg, err := runtime.NewTenantConfigs(f)
+	runtimeCfg, err := runtime.NewTenantConfigs(provider)
 	require.NoError(t, err)
 
 	t.Run("with zero rate limiting", func(t *testing.T) {
@@ -126,7 +130,7 @@ func TestWriteFailuresRateLimiting(t *testing.T) {
 	})
 
 	t.Run("limit is per-tenant", func(t *testing.T) {
-		runtimeCfg, err := runtime.NewTenantConfigs(f)
+		runtimeCfg, err := runtime.NewTenantConfigs(provider)
 		require.NoError(t, err)
 		manager := NewManager(logger, prometheus.NewRegistry(), Cfg{LogRate: flagext.ByteSize(1000)}, runtimeCfg, "ingester")
 
@@ -160,4 +164,16 @@ func TestWriteFailuresRateLimiting(t *testing.T) {
 		require.Contains(t, content, "1y")
 		require.Contains(t, content, "3z")
 	})
+}
+
+type providerMock struct {
+	tenantConfig func(string) *runtime.Config
+}
+
+func (m *providerMock) TenantConfig(userID string) *runtime.Config {
+	return m.tenantConfig(userID)
+}
+
+func (m *providerMock) DefaultConfig() *runtime.Config {
+	return runtime.EmptyConfig
 }

--- a/pkg/distributor/writefailures/manager_test.go
+++ b/pkg/distributor/writefailures/manager_test.go
@@ -173,7 +173,3 @@ type providerMock struct {
 func (m *providerMock) TenantConfig(userID string) *runtime.Config {
 	return m.tenantConfig(userID)
 }
-
-func (m *providerMock) DefaultConfig() *runtime.Config {
-	return runtime.EmptyConfig
-}

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -306,7 +306,7 @@ func (t *Loki) initOverridesExporter() (services.Service, error) {
 }
 
 func (t *Loki) initTenantConfigs() (_ services.Service, err error) {
-	t.tenantConfigs, err = runtime.NewTenantConfigs(tenantConfigFromRuntimeConfig(t.runtimeConfig))
+	t.tenantConfigs, err = runtime.NewTenantConfigs(newTenantConfigProvider(t.runtimeConfig))
 	// tenantConfigs are not a service, since they don't have any operational state.
 	return nil, err
 }

--- a/pkg/loki/runtime_config.go
+++ b/pkg/loki/runtime_config.go
@@ -94,6 +94,7 @@ func newTenantConfigProvider(c *runtimeconfig.Manager) runtime.TenantConfigProvi
 	return &tenantConfigProvider{c: c}
 }
 
+// TenantConfig returns the user config or default config if none was defined.
 func (t *tenantConfigProvider) TenantConfig(userID string) *runtime.Config {
 	if t.c == nil {
 		return nil
@@ -106,19 +107,6 @@ func (t *tenantConfigProvider) TenantConfig(userID string) *runtime.Config {
 	if tenantCfg, ok := cfg.TenantConfig[userID]; ok {
 		return tenantCfg
 	}
-	return nil
-}
-
-func (t *tenantConfigProvider) DefaultConfig() *runtime.Config {
-	if t.c == nil {
-		return nil
-	}
-
-	cfg, ok := t.c.GetConfig().(*runtimeConfigValues)
-	if !ok || cfg == nil {
-		return nil
-	}
-
 	return cfg.DefaultConfig
 }
 

--- a/pkg/loki/runtime_config.go
+++ b/pkg/loki/runtime_config.go
@@ -55,6 +55,7 @@ func loadRuntimeConfig(r io.Reader) (interface{}, error) {
 	return overrides, nil
 }
 
+// tenantLimitsFromRuntimeConfig implements validation.Limits
 type tenantLimitsFromRuntimeConfig struct {
 	c *runtimeconfig.Manager
 }
@@ -85,20 +86,40 @@ func newtenantLimitsFromRuntimeConfig(c *runtimeconfig.Manager) validation.Tenan
 	return &tenantLimitsFromRuntimeConfig{c: c}
 }
 
-func tenantConfigFromRuntimeConfig(c *runtimeconfig.Manager) runtime.TenantConfig {
-	if c == nil {
+type tenantConfigProvider struct {
+	c *runtimeconfig.Manager
+}
+
+func newTenantConfigProvider(c *runtimeconfig.Manager) runtime.TenantConfigProvider {
+	return &tenantConfigProvider{c: c}
+}
+
+func (t *tenantConfigProvider) TenantConfig(userID string) *runtime.Config {
+	if t.c == nil {
 		return nil
 	}
-	return func(userID string) *runtime.Config {
-		cfg, ok := c.GetConfig().(*runtimeConfigValues)
-		if !ok || cfg == nil {
-			return nil
-		}
-		if tenantCfg, ok := cfg.TenantConfig[userID]; ok {
-			return tenantCfg
-		}
-		return cfg.DefaultConfig
+
+	cfg, ok := t.c.GetConfig().(*runtimeConfigValues)
+	if !ok || cfg == nil {
+		return nil
 	}
+	if tenantCfg, ok := cfg.TenantConfig[userID]; ok {
+		return tenantCfg
+	}
+	return nil
+}
+
+func (t *tenantConfigProvider) DefaultConfig() *runtime.Config {
+	if t.c == nil {
+		return nil
+	}
+
+	cfg, ok := t.c.GetConfig().(*runtimeConfigValues)
+	if !ok || cfg == nil {
+		return nil
+	}
+
+	return cfg.DefaultConfig
 }
 
 func multiClientRuntimeConfigChannel(manager *runtimeconfig.Manager) func() <-chan kv.MultiRuntimeConfig {

--- a/pkg/loki/runtime_config_test.go
+++ b/pkg/loki/runtime_config_test.go
@@ -98,9 +98,9 @@ configs:
         log_push_request: true
 `)
 
-	user1 := runtimeGetter("1")
-	user2 := runtimeGetter("2")
-	user3 := runtimeGetter("3")
+	user1 := runtimeGetter.TenantConfig("1")
+	user2 := runtimeGetter.TenantConfig("2")
+	user3 := runtimeGetter.TenantConfig("3")
 
 	require.Equal(t, false, user1.LogPushRequest)
 	require.Equal(t, false, user1.LimitedLogPushErrors)
@@ -110,7 +110,7 @@ configs:
 	require.Equal(t, true, user3.LogPushRequest)
 }
 
-func newTestRuntimeconfig(t *testing.T, yaml string) runtime.TenantConfig {
+func newTestRuntimeconfig(t *testing.T, yaml string) runtime.TenantConfigProvider {
 	t.Helper()
 	f, err := os.CreateTemp(t.TempDir(), "bar")
 	require.NoError(t, err)
@@ -140,7 +140,7 @@ func newTestRuntimeconfig(t *testing.T, yaml string) runtime.TenantConfig {
 		require.NoError(t, runtimeConfig.AwaitTerminated(context.Background()))
 	}()
 
-	return tenantConfigFromRuntimeConfig(runtimeConfig)
+	return newTenantConfigProvider(runtimeConfig)
 }
 
 func newTestOverrides(t *testing.T, yaml string) *validation.Overrides {

--- a/pkg/runtime/config.go
+++ b/pkg/runtime/config.go
@@ -14,7 +14,6 @@ var EmptyConfig = &Config{}
 // TenantConfigProvider serves a tenant or default config.
 type TenantConfigProvider interface {
 	TenantConfig(userID string) *Config
-	DefaultConfig() *Config
 }
 
 // TenantConfigs periodically fetch a set of per-user configs, and provides convenience


### PR DESCRIPTION
**What this PR does / why we need it**:
This change allows the retrieval of the `TenantConfig` or the `DefaultConfig`. It also defines an interface instead of a tenant config function which makes it a little easier to grok the code.

Eventually this will enable us to introduce GEL specific configurations.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
