### PR TITLE
fix: Remove lost character in ciliumnetworkpolicy.yaml

### DIFF
--- a/production/helm/loki/templates/ciliumnetworkpolicy.yaml
+++ b/production/helm/loki/templates/ciliumnetworkpolicy.yaml
@@ -149,7 +149,7 @@ spec:
       {{- range $port := .Values.networkPolicy.externalStorage.ports }} 
       - port: "{{ $port }}"
         protocol: TCP
-      {{- end }}à
+      {{- end }}
   {{- if .Values.networkPolicy.externalStorage.cidrs }}
     {{- range $cidr := .Values.networkPolicy.externalStorage.cidrs }}
     toCIDR:


### PR DESCRIPTION
**What this PR does / why we need it**: Random character breaks Loki helm chart when enabling CiliumNetworkPolicies

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
