### PR TITLE
ci: pin to loki-2.9.x release tag

### DIFF
--- a/.github/jsonnetfile.json
+++ b/.github/jsonnetfile.json
@@ -8,7 +8,7 @@
           "subdir": "workflows"
         }
       },
-      "version": "v1.11.5"
+      "version": "loki-2.9.x"
     }
   ],
   "legacyImports": true

--- a/.github/jsonnetfile.lock.json
+++ b/.github/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "workflows"
         }
       },
-      "version": "09374df9ca39fa58ec93d9e3fad4da1593186039",
-      "sum": "eMlN1tvu1jxKTdWvNfmXESn7JI+Wfu2C1wCabo7P2VQ="
+      "version": "5a1ae264353c2a87132780efc4fa548769ef53c7",
+      "sum": "ehDGacNILjqjRolJv4FyRroujA9uXtng/aJYNQmN4Zs="
     }
   ],
   "legacyImports": false

--- a/.github/release-workflows.jsonnet
+++ b/.github/release-workflows.jsonnet
@@ -16,7 +16,7 @@ local imageJobs = {
   logstash: build.image('logstash-output-loki', 'clients/cmd/logstash', platform=['linux/amd64']),
   logcli: build.image('logcli', 'cmd/logcli'),
   'loki-canary': build.image('loki-canary', 'cmd/loki-canary'),
-  'loki-operator': build.image('loki-operator', 'operator', context='release/operator', platform=['linux/amd64']),
+  'loki-canary-boringcrypto': build.image('loki-canary-boringcrypto', 'cmd/loki-canary-boringcrypto'),
   promtail: build.image('promtail', 'clients/cmd/promtail'),
   querytee: build.image('loki-query-tee', 'cmd/querytee', platform=['linux/amd64']),
 };
@@ -24,44 +24,49 @@ local imageJobs = {
 local buildImage = 'grafana/loki-build-image:0.30.1';
 local golangCiLintVersion = 'v1.51.2';
 
+local imageBuildTimeoutMin = 40;
+local imagePrefix = 'grafana';
+
 {
   'patch-release-pr.yml': std.manifestYamlDoc(
     lokiRelease.releasePRWorkflow(
-      imageJobs=imageJobs,
-      buildImage=buildImage,
       branches=['release-[0-9]+.[0-9]+.x'],
+      buildImage=buildImage,
       checkTemplate=checkTemplate,
       golangCiLintVersion=golangCiLintVersion,
-      imagePrefix='grafana',
+      imageBuildTimeoutMin=imageBuildTimeoutMin,
+      imageJobs=imageJobs,
+      imagePrefix=imagePrefix,
       releaseLibRef=releaseLibRef,
       releaseRepo='grafana/loki',
       skipArm=false,
       skipValidation=false,
-      versioningStrategy='always-bump-patch',
       useGitHubAppToken=true,
+      versioningStrategy='always-bump-patch',
     ), false, false
   ),
   'minor-release-pr.yml': std.manifestYamlDoc(
     lokiRelease.releasePRWorkflow(
-      imageJobs=imageJobs,
-      buildImage=buildImage,
       branches=['k[0-9]+'],
+      buildImage=buildImage,
       checkTemplate=checkTemplate,
       golangCiLintVersion=golangCiLintVersion,
-      imagePrefix='grafana',
+      imageBuildTimeoutMin=imageBuildTimeoutMin,
+      imageJobs=imageJobs,
+      imagePrefix=imagePrefix,
       releaseLibRef=releaseLibRef,
       releaseRepo='grafana/loki',
       skipArm=false,
       skipValidation=false,
-      versioningStrategy='always-bump-minor',
       useGitHubAppToken=true,
+      versioningStrategy='always-bump-minor',
     ), false, false
   ),
   'release.yml': std.manifestYamlDoc(
     lokiRelease.releaseWorkflow(
       branches=['release-[0-9]+.[0-9]+.x', 'k[0-9]+'],
       getDockerCredsFromVault=true,
-      imagePrefix='grafana',
+      imagePrefix=imagePrefix,
       releaseLibRef=releaseLibRef,
       releaseRepo='grafana/loki',
       useGitHubAppToken=false,

--- a/.github/vendor/github.com/grafana/loki-release/workflows/common.libsonnet
+++ b/.github/vendor/github.com/grafana/loki-release/workflows/common.libsonnet
@@ -61,8 +61,8 @@
     withEnv: function(env) {
       env: env,
     },
-    withSecrets: function(env) {
-      secrets: env,
+    withSecrets: function(secrets) {
+      secrets: secrets,
     },
   },
 
@@ -142,4 +142,19 @@
                 echo "token=${{ secrets.GH_TOKEN }}" >> $GITHUB_OUTPUT
               fi
             |||),
+
+  validationJob: function(useGCR=false)
+    $.job.new()
+    + $.job.withContainer({
+      image: '${{ inputs.build_image }}',
+    } + if useGCR then {
+      credentials: {
+        username: '_json_key',
+        password: '${{ secrets.GCS_SERVICE_ACCOUNT_KEY }}',
+      },
+    } else {})
+    + $.job.withEnv({
+      BUILD_IN_CONTAINER: false,
+      SKIP_VALIDATION: '${{ inputs.skip_validation }}',
+    }),
 }

--- a/.github/vendor/github.com/grafana/loki-release/workflows/main.jsonnet
+++ b/.github/vendor/github.com/grafana/loki-release/workflows/main.jsonnet
@@ -5,20 +5,25 @@
   build: import 'build.libsonnet',
   release: import 'release.libsonnet',
   validate: import 'validate.libsonnet',
+  validateGel: import 'validate-gel.libsonnet',
   releasePRWorkflow: function(
     branches=['release-[0-9]+.[0-9]+.x', 'k[0-9]+'],
     buildImage='grafana/loki-build-image:0.33.0',
+    changelogPath='CHANGELOG.md',
     checkTemplate='./.github/workflows/check.yml',
+    distMakeTargets=['dist', 'packages'],
     dockerUsername='grafana',
     golangCiLintVersion='v1.55.1',
+    imageBuildTimeoutMin=25,
     imageJobs={},
     imagePrefix='grafana',
     releaseLibRef='main',
     releaseRepo='grafana/loki-release',
     skipArm=false,
     skipValidation=false,
-    versioningStrategy='always-bump-patch',
     useGitHubAppToken=true,
+    useGCR=false,
+    versioningStrategy='always-bump-patch',
                     ) {
     name: 'create release PR',
     on: {
@@ -35,13 +40,15 @@
       group: 'create-release-pr-${{ github.sha }}',
     },
     env: {
-      RELEASE_REPO: releaseRepo,
+      BUILD_TIMEOUT: imageBuildTimeoutMin,
+      CHANGELOG_PATH: changelogPath,
       DOCKER_USERNAME: dockerUsername,
       IMAGE_PREFIX: imagePrefix,
-      SKIP_VALIDATION: skipValidation,
-      VERSIONING_STRATEGY: versioningStrategy,
       RELEASE_LIB_REF: releaseLibRef,
+      RELEASE_REPO: releaseRepo,
+      SKIP_VALIDATION: skipValidation,
       USE_GITHUB_APP_TOKEN: useGitHubAppToken,
+      VERSIONING_STRATEGY: versioningStrategy,
     },
     local validationSteps = ['check'],
     jobs: {
@@ -52,9 +59,12 @@
                golang_ci_lint_version: golangCiLintVersion,
                release_lib_ref: releaseLibRef,
                use_github_app_token: useGitHubAppToken,
-             }),
+             })
+             + if useGCR then $.job.withSecrets({
+               GCS_SERVICE_ACCOUNT_KEY: '${{ secrets.GCS_SERVICE_ACCOUNT_KEY }}',
+             }) else {},
       version: $.build.version + $.common.job.withNeeds(validationSteps),
-      dist: $.build.dist(buildImage, skipArm) + $.common.job.withNeeds(['version']),
+      dist: $.build.dist(buildImage, skipArm, useGCR, distMakeTargets) + $.common.job.withNeeds(['version']),
     } + std.mapWithKey(function(name, job) job + $.common.job.withNeeds(['version']), imageJobs) + {
       local buildImageSteps = ['dist'] + std.objectFields(imageJobs),
       'create-release-pr': $.release.createReleasePR + $.common.job.withNeeds(buildImageSteps),
@@ -62,9 +72,11 @@
   },
   releaseWorkflow: function(
     branches=['release-[0-9].[0-9].x', 'k[0-9]*'],
-    dockerUsername='grafana',
+    dockerUsername='grafanabot',
     getDockerCredsFromVault=false,
     imagePrefix='grafana',
+    publishBucket='',
+    publishToGCS=false,
     releaseLibRef='main',
     releaseRepo='grafana/loki-release',
     useGitHubAppToken=true,
@@ -84,10 +96,15 @@
       group: 'create-release-${{ github.sha }}',
     },
     env: {
-      RELEASE_REPO: releaseRepo,
       IMAGE_PREFIX: imagePrefix,
       RELEASE_LIB_REF: releaseLibRef,
+      RELEASE_REPO: releaseRepo,
       USE_GITHUB_APP_TOKEN: useGitHubAppToken,
+    } + if publishToGCS then {
+      PUBLISH_BUCKET: publishBucket,
+      PUBLISH_TO_GCS: true,
+    } else {
+      PUBLISH_TO_GCS: false,
     },
     jobs: {
       shouldRelease: $.release.shouldRelease,
@@ -146,5 +163,62 @@
       USE_GITHUB_APP_TOKEN: '${{ inputs.use_github_app_token }}',
     },
     jobs: $.validate,
+  },
+  checkGel: {
+    name: 'check',
+    on: {
+      workflow_call: {
+        inputs: {
+          build_image: {
+            description: 'loki build image to use',
+            required: true,
+            type: 'string',
+          },
+          skip_validation: {
+            default: false,
+            description: 'skip validation steps',
+            required: false,
+            type: 'boolean',
+          },
+          golang_ci_lint_version: {
+            default: 'v1.55.1',
+            description: 'version of golangci-lint to use',
+            required: false,
+            type: 'string',
+          },
+          release_lib_ref: {
+            default: 'main',
+            description: 'git ref of release library to use',
+            required: false,
+            type: 'string',
+          },
+          use_github_app_token: {
+            default: true,
+            description: 'whether to use the GitHub App token for GH_TOKEN secret',
+            required: false,
+            type: 'boolean',
+          },
+        },
+        secrets: {
+          GCS_SERVICE_ACCOUNT_KEY: {
+            description: 'GCS service account key',
+            required: true,
+          },
+        },
+      },
+    },
+    permissions: {
+      contents: 'write',
+      'pull-requests': 'write',
+      'id-token': 'write',
+    },
+    concurrency: {
+      group: 'check-${{ github.sha }}',
+    },
+    env: {
+      RELEASE_LIB_REF: '${{ inputs.release_lib_ref }}',
+      USE_GITHUB_APP_TOKEN: '${{ inputs.use_github_app_token }}',
+    },
+    jobs: $.validateGel,
   },
 }

--- a/.github/vendor/github.com/grafana/loki-release/workflows/workflows.jsonnet
+++ b/.github/vendor/github.com/grafana/loki-release/workflows/workflows.jsonnet
@@ -8,7 +8,7 @@ local build = lokiRelease.build;
       },
       branches=['release-[0-9]+.[0-9]+.x'],
       imagePrefix='trevorwhitney075',
-      releaseLibRef='release-1.11.x',
+      releaseLibRef='release-1.12.x',
       releaseRepo='grafana/loki-release',
       skipValidation=false,
       versioningStrategy='always-bump-patch',
@@ -17,15 +17,17 @@ local build = lokiRelease.build;
   '.github/workflows/release.yml': std.manifestYamlDoc(
     lokiRelease.releaseWorkflow(
       branches=['release-[0-9]+.[0-9]+.x'],
-      dockerUsername='trevorwhitney075',
-      getDockerCredsFromVault=false,
+      getDockerCredsFromVault=true,
       imagePrefix='trevorwhitney075',
-      releaseLibRef='release-1.11.x',
+      releaseLibRef='release-1.12.x',
       releaseRepo='grafana/loki-release',
       useGitHubAppToken=false,
     ), false, false
   ),
   '.github/workflows/check.yml': std.manifestYamlDoc(
     lokiRelease.check
+  ),
+  '.github/workflows/gel-check.yml': std.manifestYamlDoc(
+    lokiRelease.checkGel
   ),
 }

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,10 +1,10 @@
 "jobs":
   "check":
-    "uses": "grafana/loki-release/.github/workflows/check.yml@v1.11.5"
+    "uses": "grafana/loki-release/.github/workflows/check.yml@loki-2.9.x"
     "with":
       "build_image": "grafana/loki-build-image:0.30.1"
       "golang_ci_lint_version": "v1.51.2"
-      "release_lib_ref": "v1.11.5"
+      "release_lib_ref": "loki-2.9.x"
       "skip_validation": false
       "use_github_app_token": true
 "name": "check"

--- a/.github/workflows/minor-release-pr.yml
+++ b/.github/workflows/minor-release-pr.yml
@@ -1,20 +1,22 @@
 concurrency:
   group: "create-release-pr-${{ github.sha }}"
 env:
+  BUILD_TIMEOUT: 40
+  CHANGELOG_PATH: "CHANGELOG.md"
   DOCKER_USERNAME: "grafana"
   IMAGE_PREFIX: "grafana"
-  RELEASE_LIB_REF: "v1.11.5"
+  RELEASE_LIB_REF: "loki-2.9.x"
   RELEASE_REPO: "grafana/loki"
   SKIP_VALIDATION: false
   USE_GITHUB_APP_TOKEN: true
   VERSIONING_STRATEGY: "always-bump-minor"
 jobs:
   check:
-    uses: "grafana/loki-release/.github/workflows/check.yml@v1.11.5"
+    uses: "grafana/loki-release/.github/workflows/check.yml@loki-2.9.x"
     with:
       build_image: "grafana/loki-build-image:0.30.1"
       golang_ci_lint_version: "v1.51.2"
-      release_lib_ref: "v1.11.5"
+      release_lib_ref: "loki-2.9.x"
       skip_validation: false
       use_github_app_token: true
   create-release-pr:
@@ -26,7 +28,7 @@ jobs:
     - "logstash"
     - "loki"
     - "loki-canary"
-    - "loki-operator"
+    - "loki-canary-boringcrypto"
     - "promtail"
     - "querytee"
     runs-on: "ubuntu-latest"
@@ -74,6 +76,7 @@ jobs:
       run: |
         npm install
         npm exec -- release-please release-pr \
+          --changelog-path "${CHANGELOG_PATH}" \
           --consider-all-branches \
           --group-pull-request-title-pattern "chore\${scope}: release\${component} \${version}" \
           --label "backport main,autorelease: pending,product-approved" \
@@ -102,6 +105,10 @@ jobs:
       uses: "google-github-actions/auth@v2"
       with:
         credentials_json: "${{ secrets.GCS_SERVICE_ACCOUNT_KEY }}"
+    - name: "Set up Cloud SDK"
+      uses: "google-github-actions/setup-gcloud@v2"
+      with:
+        version: ">= 452.0.0"
     - id: "get-secrets"
       name: "get nfpm signing keys"
       uses: "grafana/shared-workflows/actions/get-vault-secrets@main"
@@ -179,11 +186,14 @@ jobs:
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
       working-directory: "release"
-    - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
+    - env:
+        IMAGE_TAG: "${{ needs.version.outputs.version }}"
+      if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
       name: "Build and export"
-      timeout-minutes: 25
+      timeout-minutes: "${{ fromJSON(env.BUILD_TIMEOUT) }}"
       uses: "docker/build-push-action@v5"
       with:
+        build-args: "IMAGE_TAG=${{ needs.version.outputs.version }}"
         context: "release"
         file: "release/clients/cmd/fluent-bit/Dockerfile"
         outputs: "type=docker,dest=release/images/fluent-bit-plugin-loki-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
@@ -238,11 +248,14 @@ jobs:
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
       working-directory: "release"
-    - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
+    - env:
+        IMAGE_TAG: "${{ needs.version.outputs.version }}"
+      if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
       name: "Build and export"
-      timeout-minutes: 25
+      timeout-minutes: "${{ fromJSON(env.BUILD_TIMEOUT) }}"
       uses: "docker/build-push-action@v5"
       with:
+        build-args: "IMAGE_TAG=${{ needs.version.outputs.version }}"
         context: "release"
         file: "release/clients/cmd/fluentd/Dockerfile"
         outputs: "type=docker,dest=release/images/fluent-plugin-loki-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
@@ -297,11 +310,14 @@ jobs:
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
       working-directory: "release"
-    - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
+    - env:
+        IMAGE_TAG: "${{ needs.version.outputs.version }}"
+      if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
       name: "Build and export"
-      timeout-minutes: 25
+      timeout-minutes: "${{ fromJSON(env.BUILD_TIMEOUT) }}"
       uses: "docker/build-push-action@v5"
       with:
+        build-args: "IMAGE_TAG=${{ needs.version.outputs.version }}"
         context: "release"
         file: "release/cmd/logcli/Dockerfile"
         outputs: "type=docker,dest=release/images/logcli-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
@@ -358,11 +374,14 @@ jobs:
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
       working-directory: "release"
-    - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
+    - env:
+        IMAGE_TAG: "${{ needs.version.outputs.version }}"
+      if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
       name: "Build and export"
-      timeout-minutes: 25
+      timeout-minutes: "${{ fromJSON(env.BUILD_TIMEOUT) }}"
       uses: "docker/build-push-action@v5"
       with:
+        build-args: "IMAGE_TAG=${{ needs.version.outputs.version }}"
         context: "release"
         file: "release/clients/cmd/logstash/Dockerfile"
         outputs: "type=docker,dest=release/images/logstash-output-loki-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
@@ -417,11 +436,14 @@ jobs:
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
       working-directory: "release"
-    - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
+    - env:
+        IMAGE_TAG: "${{ needs.version.outputs.version }}"
+      if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
       name: "Build and export"
-      timeout-minutes: 25
+      timeout-minutes: "${{ fromJSON(env.BUILD_TIMEOUT) }}"
       uses: "docker/build-push-action@v5"
       with:
+        build-args: "IMAGE_TAG=${{ needs.version.outputs.version }}"
         context: "release"
         file: "release/cmd/loki/Dockerfile"
         outputs: "type=docker,dest=release/images/loki-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
@@ -478,11 +500,14 @@ jobs:
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
       working-directory: "release"
-    - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
+    - env:
+        IMAGE_TAG: "${{ needs.version.outputs.version }}"
+      if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
       name: "Build and export"
-      timeout-minutes: 25
+      timeout-minutes: "${{ fromJSON(env.BUILD_TIMEOUT) }}"
       uses: "docker/build-push-action@v5"
       with:
+        build-args: "IMAGE_TAG=${{ needs.version.outputs.version }}"
         context: "release"
         file: "release/cmd/loki-canary/Dockerfile"
         outputs: "type=docker,dest=release/images/loki-canary-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
@@ -502,7 +527,7 @@ jobs:
         - "linux/amd64"
         - "linux/arm64"
         - "linux/arm"
-  loki-operator:
+  loki-canary-boringcrypto:
     needs:
     - "version"
     runs-on: "ubuntu-latest"
@@ -539,28 +564,33 @@ jobs:
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
       working-directory: "release"
-    - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
+    - env:
+        IMAGE_TAG: "${{ needs.version.outputs.version }}"
+      if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
       name: "Build and export"
-      timeout-minutes: 25
+      timeout-minutes: "${{ fromJSON(env.BUILD_TIMEOUT) }}"
       uses: "docker/build-push-action@v5"
       with:
-        context: "release/operator"
-        file: "release/operator/Dockerfile"
-        outputs: "type=docker,dest=release/images/loki-operator-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
+        build-args: "IMAGE_TAG=${{ needs.version.outputs.version }}"
+        context: "release"
+        file: "release/cmd/loki-canary-boringcrypto/Dockerfile"
+        outputs: "type=docker,dest=release/images/loki-canary-boringcrypto-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
         platforms: "${{ matrix.platform }}"
-        tags: "${{ env.IMAGE_PREFIX }}/loki-operator:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
+        tags: "${{ env.IMAGE_PREFIX }}/loki-canary-boringcrypto:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
     - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
       name: "upload artifacts"
       uses: "google-github-actions/upload-cloud-storage@v2"
       with:
         destination: "loki-build-artifacts/${{ github.sha }}/images"
-        path: "release/images/loki-operator-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
+        path: "release/images/loki-canary-boringcrypto-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
         process_gcloudignore: false
     strategy:
       fail-fast: true
       matrix:
         platform:
         - "linux/amd64"
+        - "linux/arm64"
+        - "linux/arm"
   promtail:
     needs:
     - "version"
@@ -598,11 +628,14 @@ jobs:
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
       working-directory: "release"
-    - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
+    - env:
+        IMAGE_TAG: "${{ needs.version.outputs.version }}"
+      if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
       name: "Build and export"
-      timeout-minutes: 25
+      timeout-minutes: "${{ fromJSON(env.BUILD_TIMEOUT) }}"
       uses: "docker/build-push-action@v5"
       with:
+        build-args: "IMAGE_TAG=${{ needs.version.outputs.version }}"
         context: "release"
         file: "release/clients/cmd/promtail/Dockerfile"
         outputs: "type=docker,dest=release/images/promtail-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
@@ -659,11 +692,14 @@ jobs:
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
       working-directory: "release"
-    - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
+    - env:
+        IMAGE_TAG: "${{ needs.version.outputs.version }}"
+      if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
       name: "Build and export"
-      timeout-minutes: 25
+      timeout-minutes: "${{ fromJSON(env.BUILD_TIMEOUT) }}"
       uses: "docker/build-push-action@v5"
       with:
+        build-args: "IMAGE_TAG=${{ needs.version.outputs.version }}"
         context: "release"
         file: "release/cmd/querytee/Dockerfile"
         outputs: "type=docker,dest=release/images/loki-query-tee-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"

--- a/.github/workflows/patch-release-pr.yml
+++ b/.github/workflows/patch-release-pr.yml
@@ -1,20 +1,22 @@
 concurrency:
   group: "create-release-pr-${{ github.sha }}"
 env:
+  BUILD_TIMEOUT: 40
+  CHANGELOG_PATH: "CHANGELOG.md"
   DOCKER_USERNAME: "grafana"
   IMAGE_PREFIX: "grafana"
-  RELEASE_LIB_REF: "v1.11.5"
+  RELEASE_LIB_REF: "loki-2.9.x"
   RELEASE_REPO: "grafana/loki"
   SKIP_VALIDATION: false
   USE_GITHUB_APP_TOKEN: true
   VERSIONING_STRATEGY: "always-bump-patch"
 jobs:
   check:
-    uses: "grafana/loki-release/.github/workflows/check.yml@v1.11.5"
+    uses: "grafana/loki-release/.github/workflows/check.yml@loki-2.9.x"
     with:
       build_image: "grafana/loki-build-image:0.30.1"
       golang_ci_lint_version: "v1.51.2"
-      release_lib_ref: "v1.11.5"
+      release_lib_ref: "loki-2.9.x"
       skip_validation: false
       use_github_app_token: true
   create-release-pr:
@@ -26,7 +28,7 @@ jobs:
     - "logstash"
     - "loki"
     - "loki-canary"
-    - "loki-operator"
+    - "loki-canary-boringcrypto"
     - "promtail"
     - "querytee"
     runs-on: "ubuntu-latest"
@@ -74,6 +76,7 @@ jobs:
       run: |
         npm install
         npm exec -- release-please release-pr \
+          --changelog-path "${CHANGELOG_PATH}" \
           --consider-all-branches \
           --group-pull-request-title-pattern "chore\${scope}: release\${component} \${version}" \
           --label "backport main,autorelease: pending,product-approved" \
@@ -102,6 +105,10 @@ jobs:
       uses: "google-github-actions/auth@v2"
       with:
         credentials_json: "${{ secrets.GCS_SERVICE_ACCOUNT_KEY }}"
+    - name: "Set up Cloud SDK"
+      uses: "google-github-actions/setup-gcloud@v2"
+      with:
+        version: ">= 452.0.0"
     - id: "get-secrets"
       name: "get nfpm signing keys"
       uses: "grafana/shared-workflows/actions/get-vault-secrets@main"
@@ -179,11 +186,14 @@ jobs:
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
       working-directory: "release"
-    - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
+    - env:
+        IMAGE_TAG: "${{ needs.version.outputs.version }}"
+      if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
       name: "Build and export"
-      timeout-minutes: 25
+      timeout-minutes: "${{ fromJSON(env.BUILD_TIMEOUT) }}"
       uses: "docker/build-push-action@v5"
       with:
+        build-args: "IMAGE_TAG=${{ needs.version.outputs.version }}"
         context: "release"
         file: "release/clients/cmd/fluent-bit/Dockerfile"
         outputs: "type=docker,dest=release/images/fluent-bit-plugin-loki-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
@@ -238,11 +248,14 @@ jobs:
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
       working-directory: "release"
-    - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
+    - env:
+        IMAGE_TAG: "${{ needs.version.outputs.version }}"
+      if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
       name: "Build and export"
-      timeout-minutes: 25
+      timeout-minutes: "${{ fromJSON(env.BUILD_TIMEOUT) }}"
       uses: "docker/build-push-action@v5"
       with:
+        build-args: "IMAGE_TAG=${{ needs.version.outputs.version }}"
         context: "release"
         file: "release/clients/cmd/fluentd/Dockerfile"
         outputs: "type=docker,dest=release/images/fluent-plugin-loki-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
@@ -297,11 +310,14 @@ jobs:
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
       working-directory: "release"
-    - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
+    - env:
+        IMAGE_TAG: "${{ needs.version.outputs.version }}"
+      if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
       name: "Build and export"
-      timeout-minutes: 25
+      timeout-minutes: "${{ fromJSON(env.BUILD_TIMEOUT) }}"
       uses: "docker/build-push-action@v5"
       with:
+        build-args: "IMAGE_TAG=${{ needs.version.outputs.version }}"
         context: "release"
         file: "release/cmd/logcli/Dockerfile"
         outputs: "type=docker,dest=release/images/logcli-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
@@ -358,11 +374,14 @@ jobs:
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
       working-directory: "release"
-    - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
+    - env:
+        IMAGE_TAG: "${{ needs.version.outputs.version }}"
+      if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
       name: "Build and export"
-      timeout-minutes: 25
+      timeout-minutes: "${{ fromJSON(env.BUILD_TIMEOUT) }}"
       uses: "docker/build-push-action@v5"
       with:
+        build-args: "IMAGE_TAG=${{ needs.version.outputs.version }}"
         context: "release"
         file: "release/clients/cmd/logstash/Dockerfile"
         outputs: "type=docker,dest=release/images/logstash-output-loki-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
@@ -417,11 +436,14 @@ jobs:
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
       working-directory: "release"
-    - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
+    - env:
+        IMAGE_TAG: "${{ needs.version.outputs.version }}"
+      if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
       name: "Build and export"
-      timeout-minutes: 25
+      timeout-minutes: "${{ fromJSON(env.BUILD_TIMEOUT) }}"
       uses: "docker/build-push-action@v5"
       with:
+        build-args: "IMAGE_TAG=${{ needs.version.outputs.version }}"
         context: "release"
         file: "release/cmd/loki/Dockerfile"
         outputs: "type=docker,dest=release/images/loki-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
@@ -478,11 +500,14 @@ jobs:
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
       working-directory: "release"
-    - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
+    - env:
+        IMAGE_TAG: "${{ needs.version.outputs.version }}"
+      if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
       name: "Build and export"
-      timeout-minutes: 25
+      timeout-minutes: "${{ fromJSON(env.BUILD_TIMEOUT) }}"
       uses: "docker/build-push-action@v5"
       with:
+        build-args: "IMAGE_TAG=${{ needs.version.outputs.version }}"
         context: "release"
         file: "release/cmd/loki-canary/Dockerfile"
         outputs: "type=docker,dest=release/images/loki-canary-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
@@ -502,7 +527,7 @@ jobs:
         - "linux/amd64"
         - "linux/arm64"
         - "linux/arm"
-  loki-operator:
+  loki-canary-boringcrypto:
     needs:
     - "version"
     runs-on: "ubuntu-latest"
@@ -539,28 +564,33 @@ jobs:
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
       working-directory: "release"
-    - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
+    - env:
+        IMAGE_TAG: "${{ needs.version.outputs.version }}"
+      if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
       name: "Build and export"
-      timeout-minutes: 25
+      timeout-minutes: "${{ fromJSON(env.BUILD_TIMEOUT) }}"
       uses: "docker/build-push-action@v5"
       with:
-        context: "release/operator"
-        file: "release/operator/Dockerfile"
-        outputs: "type=docker,dest=release/images/loki-operator-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
+        build-args: "IMAGE_TAG=${{ needs.version.outputs.version }}"
+        context: "release"
+        file: "release/cmd/loki-canary-boringcrypto/Dockerfile"
+        outputs: "type=docker,dest=release/images/loki-canary-boringcrypto-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
         platforms: "${{ matrix.platform }}"
-        tags: "${{ env.IMAGE_PREFIX }}/loki-operator:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
+        tags: "${{ env.IMAGE_PREFIX }}/loki-canary-boringcrypto:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
     - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
       name: "upload artifacts"
       uses: "google-github-actions/upload-cloud-storage@v2"
       with:
         destination: "loki-build-artifacts/${{ github.sha }}/images"
-        path: "release/images/loki-operator-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
+        path: "release/images/loki-canary-boringcrypto-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
         process_gcloudignore: false
     strategy:
       fail-fast: true
       matrix:
         platform:
         - "linux/amd64"
+        - "linux/arm64"
+        - "linux/arm"
   promtail:
     needs:
     - "version"
@@ -598,11 +628,14 @@ jobs:
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
       working-directory: "release"
-    - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
+    - env:
+        IMAGE_TAG: "${{ needs.version.outputs.version }}"
+      if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
       name: "Build and export"
-      timeout-minutes: 25
+      timeout-minutes: "${{ fromJSON(env.BUILD_TIMEOUT) }}"
       uses: "docker/build-push-action@v5"
       with:
+        build-args: "IMAGE_TAG=${{ needs.version.outputs.version }}"
         context: "release"
         file: "release/clients/cmd/promtail/Dockerfile"
         outputs: "type=docker,dest=release/images/promtail-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
@@ -659,11 +692,14 @@ jobs:
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
       working-directory: "release"
-    - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
+    - env:
+        IMAGE_TAG: "${{ needs.version.outputs.version }}"
+      if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
       name: "Build and export"
-      timeout-minutes: 25
+      timeout-minutes: "${{ fromJSON(env.BUILD_TIMEOUT) }}"
       uses: "docker/build-push-action@v5"
       with:
+        build-args: "IMAGE_TAG=${{ needs.version.outputs.version }}"
         context: "release"
         file: "release/cmd/querytee/Dockerfile"
         outputs: "type=docker,dest=release/images/loki-query-tee-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,8 @@ concurrency:
   group: "create-release-${{ github.sha }}"
 env:
   IMAGE_PREFIX: "grafana"
-  RELEASE_LIB_REF: "v1.11.5"
+  PUBLISH_TO_GCS: false
+  RELEASE_LIB_REF: "loki-2.9.x"
   RELEASE_REPO: "grafana/loki"
   USE_GITHUB_APP_TOKEN: false
 jobs:
@@ -13,6 +14,7 @@ jobs:
     outputs:
       draft: "${{ steps.check_release.outputs.draft }}"
       exists: "${{ steps.check_release.outputs.exists }}"
+      isLatest: "${{ needs.shouldRelease.outputs.isLatest }}"
       name: "${{ needs.shouldRelease.outputs.name }}"
       sha: "${{ needs.shouldRelease.outputs.sha }}"
     runs-on: "ubuntu-latest"
@@ -89,7 +91,8 @@ jobs:
           --release-type simple \
           --repo-url "${{ env.RELEASE_REPO }}" \
           --target-branch "${{ needs.shouldRelease.outputs.branch }}" \
-          --token "${{ steps.github_app_token.outputs.token }}"
+          --token "${{ steps.github_app_token.outputs.token }}" \
+          --shas-to-tag "${{ needs.shouldRelease.outputs.prNumber }}:${{ needs.shouldRelease.outputs.sha }}"
       working-directory: "lib"
     - env:
         GH_TOKEN: "${{ steps.github_app_token.outputs.token }}"
@@ -98,6 +101,14 @@ jobs:
       run: |
         gh release upload --clobber ${{ needs.shouldRelease.outputs.name }} dist/*
       working-directory: "release"
+    - if: "${{ fromJSON(env.PUBLISH_TO_GCS) }}"
+      name: "release artifacts"
+      uses: "google-github-actions/upload-cloud-storage@v2"
+      with:
+        destination: "${{ env.PUBLISH_BUCKET }}"
+        parent: false
+        path: "release/dist"
+        process_gcloudignore: false
   publishImages:
     needs:
     - "createRelease"
@@ -164,12 +175,14 @@ jobs:
       if: "${{ !fromJSON(needs.createRelease.outputs.exists) || (needs.createRelease.outputs.draft && fromJSON(needs.createRelease.outputs.draft)) }}"
       name: "publish release"
       run: |
-        gh release edit ${{ needs.createRelease.outputs.name }} --draft=false
+        gh release edit ${{ needs.createRelease.outputs.name }} --draft=false --latest=${{ needs.createRelease.outputs.isLatest }}
       working-directory: "release"
   shouldRelease:
     outputs:
       branch: "${{ steps.extract_branch.outputs.branch }}"
+      isLatest: "${{ steps.should_release.outputs.isLatest }}"
       name: "${{ steps.should_release.outputs.name }}"
+      prNumber: "${{ steps.should_release.outputs.prNumber }}"
       sha: "${{ steps.should_release.outputs.sha }}"
       shouldRelease: "${{ steps.should_release.outputs.shouldRelease }}"
     runs-on: "ubuntu-latest"

--- a/Makefile
+++ b/Makefile
@@ -859,4 +859,5 @@ scan-vulnerabilities: trivy snyk
 
 .PHONY: release-workflows
 release-workflows:
+	pushd $(CURDIR)/.github && jb update && popd
 	jsonnet -SJ .github/vendor -m .github/workflows .github/release-workflows.jsonnet

--- a/Makefile
+++ b/Makefile
@@ -325,7 +325,11 @@ lint: ## run linters
 ########
 
 test: all ## run the unit tests
-	$(GOTEST) -covermode=atomic -coverprofile=coverage.txt -p=4 ./... | sed "s:$$: ${DRONE_STEP_NAME} ${DRONE_SOURCE_BRANCH}:" | tee test_results.txt
+	$(GOTEST) -covermode=atomic -coverprofile=coverage.txt -p=4 ./... | tee test_results.txt
+	cd tools/lambda-promtail/ && $(GOTEST) -covermode=atomic -coverprofile=lambda-promtail-coverage.txt -p=4 ./... | tee lambda_promtail_test_results.txt
+
+test-integration:
+	$(GOTEST) -count=1 -v -tags=integration -timeout 10m ./integration
 
 compare-coverage:
 	./tools/diff_coverage.sh $(old) $(new) $(packages)

--- a/integration/loki_micro_services_delete_test.go
+++ b/integration/loki_micro_services_delete_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package integration
 
 import (

--- a/integration/loki_micro_services_test.go
+++ b/integration/loki_micro_services_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package integration
 
 import (

--- a/integration/loki_rule_eval_test.go
+++ b/integration/loki_rule_eval_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package integration
 
 import (

--- a/integration/loki_simple_scalable_test.go
+++ b/integration/loki_simple_scalable_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package integration
 
 import (

--- a/integration/loki_single_binary_test.go
+++ b/integration/loki_single_binary_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package integration
 
 import (

--- a/integration/multi_tenant_queries_test.go
+++ b/integration/multi_tenant_queries_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package integration
 
 import (

--- a/integration/parse_metrics.go
+++ b/integration/parse_metrics.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package integration
 
 import (

--- a/integration/parse_metrics_test.go
+++ b/integration/parse_metrics_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package integration
 
 import (

--- a/integration/per_request_limits_test.go
+++ b/integration/per_request_limits_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package integration
 
 import (

--- a/integration/shared_test.go
+++ b/integration/shared_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package integration
 
 import (


### PR DESCRIPTION
**What this PR does / why we need it**:

Same as https://github.com/grafana/loki/pull/12271 but for 2.9.x releases, pins the release code to the `loki-2.9.x` tag in `grafana/loki-release`.