### PR TITLE
chore: allow lint to be run in container locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -315,10 +315,17 @@ publish: packages
 # To run this efficiently on your workstation, run this from the root dir:
 # docker run --rm --tty -i -v $(pwd)/.cache:/go/cache -v $(pwd)/.pkg:/go/pkg -v $(pwd):/src/loki grafana/loki-build-image:0.24.1 lint
 lint: ## run linters
+ifeq ($(BUILD_IN_CONTAINER),true)
+	$(SUDO) docker run  $(RM) $(TTY) -i \
+		-v $(shell go env GOPATH)/pkg:/go/pkg$(MOUNT_FLAGS) \
+		-v $(shell pwd):/src/loki$(MOUNT_FLAGS) \
+		$(IMAGE_PREFIX)/loki-build-image:$(BUILD_IMAGE_VERSION) $@;
+else
 	go version
 	golangci-lint version
 	GO111MODULE=on golangci-lint run -v --timeout 15m
 	faillint -paths "sync/atomic=go.uber.org/atomic" ./...
+endif
 
 ########
 # Test #


### PR DESCRIPTION
keeping golangci-lint versions in sync with various branches is a PIA

**What this PR does / why we need it**:

our `golangci-lint` version varies from release to release and it's a PIA keeping the correct binary in-sync locally, so I'd like to just run it in the respective build container.
