### PR TITLE
ci: add test-integration make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -302,8 +302,7 @@ lint:
 ########
 
 test: all ## run the unit tests
-	$(GOTEST) -covermode=atomic -coverprofile=coverage.txt -p=4 ./... | tee test_results.txt
-	cd tools/lambda-promtail/ && $(GOTEST) -covermode=atomic -coverprofile=lambda-promtail-coverage.txt -p=4 ./... | tee lambda_promtail_test_results.txt
+	$(GOTEST) -covermode=atomic -coverprofile=coverage.txt -p=4 ./... | sed "s:$$: ${DRONE_STEP_NAME} ${DRONE_SOURCE_BRANCH}:" | tee test_results.txt
 
 test-integration:
 	$(GOTEST) -count=1 -v -tags=integration -timeout 10m ./integration

--- a/Makefile
+++ b/Makefile
@@ -301,8 +301,12 @@ lint:
 # Test #
 ########
 
-test: all
-	$(GOTEST) -covermode=atomic -coverprofile=coverage.txt -p=4 ./... | sed "s:$$: ${DRONE_STEP_NAME} ${DRONE_SOURCE_BRANCH}:" | tee test_results.txt
+test: all ## run the unit tests
+	$(GOTEST) -covermode=atomic -coverprofile=coverage.txt -p=4 ./... | tee test_results.txt
+	cd tools/lambda-promtail/ && $(GOTEST) -covermode=atomic -coverprofile=lambda-promtail-coverage.txt -p=4 ./... | tee lambda_promtail_test_results.txt
+
+test-integration:
+	$(GOTEST) -count=1 -v -tags=integration -timeout 10m ./integration
 
 compare-coverage:
 	./tools/diff_coverage.sh $(old) $(new) $(packages)

--- a/integration/loki_micro_services_delete_test.go
+++ b/integration/loki_micro_services_delete_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package integration
 
 import (

--- a/integration/loki_micro_services_test.go
+++ b/integration/loki_micro_services_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package integration
 
 import (

--- a/integration/loki_simple_scalable_test.go
+++ b/integration/loki_simple_scalable_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package integration
 
 import (

--- a/integration/loki_single_binary_test.go
+++ b/integration/loki_single_binary_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package integration
 
 import (

--- a/integration/multi_tenant_queries_test.go
+++ b/integration/multi_tenant_queries_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package integration
 
 import (

--- a/integration/parse_metrics.go
+++ b/integration/parse_metrics.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package integration
 
 import (

--- a/integration/parse_metrics_test.go
+++ b/integration/parse_metrics_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package integration
 
 import (

--- a/integration/per_request_limits_test.go
+++ b/integration/per_request_limits_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package integration
 
 import (

--- a/integration/shared_test.go
+++ b/integration/shared_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package integration
 
 import (


### PR DESCRIPTION
**What this PR does / why we need it**:

When I updated the release pipeline it brought in the `integration` check, this adds the necessary makefile target and go build tags.
