### PR TITLE
Helm chart: add persistence.annotation option for the singleBinary mode

### DIFF
--- a/production/helm/loki/templates/single-binary/statefulset.yaml
+++ b/production/helm/loki/templates/single-binary/statefulset.yaml
@@ -180,6 +180,10 @@ spec:
       kind: PersistentVolumeClaim
       metadata:
         name: storage
+        {{- with .Values.singleBinary.persistence.annotations }}
+        annotations:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
       spec:
         accessModes:
           - ReadWriteOnce

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -1236,6 +1236,8 @@ singleBinary:
     storageClass: null
     # -- Selector for persistent disk
     selector: null
+    # -- Annotations for the PVC
+    # annotations: []
 # Use either this ingress or the gateway, but not both at once.
 # If you enable this, make sure to disable the gateway.
 # You'll need to supply authn configuration for your ingress controller.


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds an options to the helm chart to add annotations to the created PVC.

This is needed in some kind of PVC to define how they work. For example in an [NFS mount using the k8s NFS provider](https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner) you define what path to mount like this:

```
annotations:
  "nfs.io/storage-path": "/monitoring/loki"
```

Without that it would always mount the root of the NFS.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
