### PR TITLE
fix: quantile sharding; fix bug where sharding would always happen

### DIFF
--- a/pkg/logql/downstream_test.go
+++ b/pkg/logql/downstream_test.go
@@ -97,6 +97,11 @@ func TestMappingEquivalence(t *testing.T) {
 			ctx := user.InjectOrgID(context.Background(), "fake")
 
 			mapper := NewShardMapper(ConstantShards(shards), nilShardMetrics, []string{})
+			// TODO (callum) refactor this test so that we won't need to set every
+			// possible sharding config option to true when we have multiple in the future
+			if tc.approximate {
+				mapper.quantileOverTimeSharding = true
+			}
 			_, _, mapped, err := mapper.Parse(params.GetExpression())
 			require.NoError(t, err)
 

--- a/pkg/logql/shardmapper.go
+++ b/pkg/logql/shardmapper.go
@@ -451,6 +451,10 @@ func (m ShardMapper) mapRangeAggregationExpr(expr *syntax.RangeAggregationExpr, 
 		}, bytesPerShard, nil
 
 	case syntax.OpRangeTypeQuantile:
+		if !m.quantileOverTimeSharding {
+			return noOp(expr, m.shards)
+		}
+
 		potentialConflict := syntax.ReducesLabels(expr)
 		if !potentialConflict && (expr.Grouping == nil || expr.Grouping.Noop()) {
 			return m.mapSampleExpr(expr, r)
@@ -460,7 +464,7 @@ func (m ShardMapper) mapRangeAggregationExpr(expr *syntax.RangeAggregationExpr, 
 		if err != nil {
 			return nil, 0, err
 		}
-		if shards == 0 || !m.quantileOverTimeSharding {
+		if shards == 0 {
 			return noOp(expr, m.shards)
 		}
 


### PR DESCRIPTION
The test in the first commit:
```
{
	in:  `quantile_over_time(0.70, {a=~".+"} | logfmt | unwrap value [1s])`,
	out: `quantile_over_time(0.7,{a=~".+"}|logfmt|unwrapvalue[1s])`,
},
````

Will fail without the change from the 2nd commit.

The fix is relatively simple, before we could return a mapped expression via line 460 if there was no label reduction or grouping operation so instead checking if quantile sharding is enabled should be our very first concern in switch case for quantile operation types.

cc @jeschkies @cyriltovena 