### PR TITLE
Add `name` labels and modify runtime cfg name

### DIFF
--- a/production/helm/loki/templates/admin-api/_helpers.yaml
+++ b/production/helm/loki/templates/admin-api/_helpers.yaml
@@ -12,6 +12,7 @@ adminApi common labels
 {{ include "loki.labels" . }}
 app.kubernetes.io/component: admin-api
 target: admin-api
+name: admin-api
 {{- end }}
 
 {{/*
@@ -21,4 +22,5 @@ adminApi selector labels
 {{ include "loki.selectorLabels" . }}
 app.kubernetes.io/component: admin-api
 target: admin-api
+name: admin-api
 {{- end }}

--- a/production/helm/loki/templates/backend/_helpers-backend.tpl
+++ b/production/helm/loki/templates/backend/_helpers-backend.tpl
@@ -11,6 +11,7 @@ backend common labels
 {{- define "loki.backendLabels" -}}
 {{ include "loki.labels" . }}
 app.kubernetes.io/component: backend
+name: backend
 {{- end }}
 
 {{/*
@@ -19,6 +20,7 @@ backend selector labels
 {{- define "loki.backendSelectorLabels" -}}
 {{ include "loki.selectorLabels" . }}
 app.kubernetes.io/component: backend
+name: backend
 {{- end }}
 
 {{/*

--- a/production/helm/loki/templates/compactor/_helpers-compactor.tpl
+++ b/production/helm/loki/templates/compactor/_helpers-compactor.tpl
@@ -11,6 +11,7 @@ compactor common labels
 {{- define "loki.compactorLabels" -}}
 {{ include "loki.labels" . }}
 app.kubernetes.io/component: compactor
+name: compactor
 {{- end }}
 
 {{/*
@@ -19,6 +20,7 @@ compactor selector labels
 {{- define "loki.compactorSelectorLabels" -}}
 {{ include "loki.selectorLabels" . }}
 app.kubernetes.io/component: compactor
+name: compactor
 {{- end }}
 
 {{/*

--- a/production/helm/loki/templates/distributor/_helpers-distributor.tpl
+++ b/production/helm/loki/templates/distributor/_helpers-distributor.tpl
@@ -11,6 +11,7 @@ distributor common labels
 {{- define "loki.distributorLabels" -}}
 {{ include "loki.labels" . }}
 app.kubernetes.io/component: distributor
+name: distributor
 {{- end }}
 
 {{/*
@@ -19,6 +20,7 @@ distributor selector labels
 {{- define "loki.distributorSelectorLabels" -}}
 {{ include "loki.selectorLabels" . }}
 app.kubernetes.io/component: distributor
+name: distributor
 {{- end }}
 
 {{/*

--- a/production/helm/loki/templates/gateway/_helpers-gateway.tpl
+++ b/production/helm/loki/templates/gateway/_helpers-gateway.tpl
@@ -11,6 +11,7 @@ gateway common labels
 {{- define "loki.gatewayLabels" -}}
 {{ include "loki.labels" . }}
 app.kubernetes.io/component: gateway
+name: gateway
 {{- end }}
 
 {{/*
@@ -19,6 +20,7 @@ gateway selector labels
 {{- define "loki.gatewaySelectorLabels" -}}
 {{ include "loki.selectorLabels" . }}
 app.kubernetes.io/component: gateway
+name: gateway
 {{- end }}
 
 {{/*

--- a/production/helm/loki/templates/index-gateway/_helpers-index-gateway.tpl
+++ b/production/helm/loki/templates/index-gateway/_helpers-index-gateway.tpl
@@ -11,6 +11,7 @@ index-gateway common labels
 {{- define "loki.indexGatewayLabels" -}}
 {{ include "loki.labels" . }}
 app.kubernetes.io/component: index-gateway
+name: index-gateway
 {{- end }}
 
 {{/*
@@ -19,6 +20,7 @@ index-gateway selector labels
 {{- define "loki.indexGatewaySelectorLabels" -}}
 {{ include "loki.selectorLabels" . }}
 app.kubernetes.io/component: index-gateway
+name: index-gateway
 {{- end }}
 
 {{/*

--- a/production/helm/loki/templates/index-gateway/statefulset-index-gateway.yaml
+++ b/production/helm/loki/templates/index-gateway/statefulset-index-gateway.yaml
@@ -140,7 +140,7 @@ spec:
           {{- include "loki.configVolume" . | nindent 10 }}
         - name: runtime-config
           configMap:
-            name: {{ template "loki.fullname" . }}-runtime
+            name: {{ template "loki.name" . }}-runtime
         {{- if .Values.enterprise.enabled }}
         - name: license
           secret:

--- a/production/helm/loki/templates/ingester/statefulset-ingester-zone-a.yaml
+++ b/production/helm/loki/templates/ingester/statefulset-ingester-zone-a.yaml
@@ -184,7 +184,7 @@ spec:
           {{- include "loki.configVolume" . | nindent 10 }}
         - name: runtime-config
           configMap:
-            name: {{ template "loki.fullname" . }}-runtime
+            name: {{ template "loki.name" . }}-runtime
         {{- if .Values.enterprise.enabled }}
         - name: license
           secret:

--- a/production/helm/loki/templates/ingester/statefulset-ingester-zone-b.yaml
+++ b/production/helm/loki/templates/ingester/statefulset-ingester-zone-b.yaml
@@ -184,7 +184,7 @@ spec:
           {{- include "loki.configVolume" . | nindent 10 }}
         - name: runtime-config
           configMap:
-            name: {{ template "loki.fullname" . }}-runtime
+            name: {{ template "loki.name" . }}-runtime
         {{- if .Values.enterprise.enabled }}
         - name: license
           secret:

--- a/production/helm/loki/templates/ingester/statefulset-ingester-zone-c.yaml
+++ b/production/helm/loki/templates/ingester/statefulset-ingester-zone-c.yaml
@@ -184,7 +184,7 @@ spec:
           {{- include "loki.configVolume" . | nindent 10 }}
         - name: runtime-config
           configMap:
-            name: {{ template "loki.fullname" . }}-runtime
+            name: {{ template "loki.name" . }}-runtime
         {{- if .Values.enterprise.enabled }}
         - name: license
           secret:

--- a/production/helm/loki/templates/loki-canary/_helpers.tpl
+++ b/production/helm/loki/templates/loki-canary/_helpers.tpl
@@ -11,6 +11,7 @@ canary common labels
 {{- define "loki-canary.labels" -}}
 {{ include "loki.labels" . }}
 app.kubernetes.io/component: canary
+name: canary
 {{- end }}
 
 {{/*
@@ -19,6 +20,7 @@ canary selector labels
 {{- define "loki-canary.selectorLabels" -}}
 {{ include "loki.selectorLabels" . }}
 app.kubernetes.io/component: canary
+name: canary
 {{- end }}
 
 {{/*

--- a/production/helm/loki/templates/querier/_helpers-querier.tpl
+++ b/production/helm/loki/templates/querier/_helpers-querier.tpl
@@ -11,6 +11,7 @@ querier common labels
 {{- define "loki.querierLabels" -}}
 {{ include "loki.labels" . }}
 app.kubernetes.io/component: querier
+name: querier
 {{- end }}
 
 {{/*
@@ -19,6 +20,7 @@ querier selector labels
 {{- define "loki.querierSelectorLabels" -}}
 {{ include "loki.selectorLabels" . }}
 app.kubernetes.io/component: querier
+name: querier
 {{- end }}
 
 {{/*

--- a/production/helm/loki/templates/query-frontend/_helpers-query-frontend.tpl
+++ b/production/helm/loki/templates/query-frontend/_helpers-query-frontend.tpl
@@ -11,6 +11,7 @@ query-frontend common labels
 {{- define "loki.queryFrontendLabels" -}}
 {{ include "loki.labels" . }}
 app.kubernetes.io/component: query-frontend
+name: query-frontend
 {{- end }}
 
 {{/*
@@ -19,6 +20,7 @@ query-frontend selector labels
 {{- define "loki.queryFrontendSelectorLabels" -}}
 {{ include "loki.selectorLabels" . }}
 app.kubernetes.io/component: query-frontend
+name: query-frontend
 {{- end }}
 
 {{/*

--- a/production/helm/loki/templates/query-frontend/deployment-query-frontend.yaml
+++ b/production/helm/loki/templates/query-frontend/deployment-query-frontend.yaml
@@ -126,7 +126,7 @@ spec:
           {{- include "loki.configVolume" . | nindent 10 }}
         - name: runtime-config
           configMap:
-            name: {{ template "loki.fullname" . }}-runtime
+            name: {{ template "loki.name" . }}-runtime
         {{- if .Values.enterprise.enabled }}
         - name: license
           secret:

--- a/production/helm/loki/templates/query-scheduler/_helpers-query-scheduler.tpl
+++ b/production/helm/loki/templates/query-scheduler/_helpers-query-scheduler.tpl
@@ -11,6 +11,7 @@ query-scheduler common labels
 {{- define "loki.querySchedulerLabels" -}}
 {{ include "loki.labels" . }}
 app.kubernetes.io/component: query-scheduler
+name: query-scheduler
 {{- end }}
 
 {{/*
@@ -19,6 +20,7 @@ query-scheduler selector labels
 {{- define "loki.querySchedulerSelectorLabels" -}}
 {{ include "loki.selectorLabels" . }}
 app.kubernetes.io/component: query-scheduler
+name: query-scheduler
 {{- end }}
 
 {{/*

--- a/production/helm/loki/templates/read/_helpers-read.tpl
+++ b/production/helm/loki/templates/read/_helpers-read.tpl
@@ -11,6 +11,7 @@ read common labels
 {{- define "loki.readLabels" -}}
 {{ include "loki.labels" . }}
 app.kubernetes.io/component: read
+name: read
 {{- end }}
 
 {{/*
@@ -19,6 +20,7 @@ read selector labels
 {{- define "loki.readSelectorLabels" -}}
 {{ include "loki.selectorLabels" . }}
 app.kubernetes.io/component: read
+name: read
 {{- end }}
 
 {{/*

--- a/production/helm/loki/templates/ruler/_helpers-ruler.tpl
+++ b/production/helm/loki/templates/ruler/_helpers-ruler.tpl
@@ -11,6 +11,7 @@ ruler common labels
 {{- define "loki.rulerLabels" -}}
 {{ include "loki.labels" . }}
 app.kubernetes.io/component: ruler
+name: ruler
 {{- end }}
 
 {{/*
@@ -19,6 +20,7 @@ ruler selector labels
 {{- define "loki.rulerSelectorLabels" -}}
 {{ include "loki.selectorLabels" . }}
 app.kubernetes.io/component: ruler
+name: ruler
 {{- end }}
 
 {{/*

--- a/production/helm/loki/templates/ruler/statefulset-ruler.yaml
+++ b/production/helm/loki/templates/ruler/statefulset-ruler.yaml
@@ -133,7 +133,7 @@ spec:
           {{- include "loki.configVolume" . | nindent 10 }}
         - name: runtime-config
           configMap:
-            name: {{ template "loki.fullname" . }}-runtime
+            name: {{ template "loki.name" . }}-runtime
         {{- if .Values.enterprise.enabled }}
         - name: license
           secret:

--- a/production/helm/loki/templates/single-binary/_helpers-single-binary.tpl
+++ b/production/helm/loki/templates/single-binary/_helpers-single-binary.tpl
@@ -4,6 +4,7 @@ singleBinary common labels
 {{- define "loki.singleBinaryLabels" -}}
 {{ include "loki.labels" . }}
 app.kubernetes.io/component: single-binary
+name: single-binary
 {{- end }}
 
 
@@ -11,6 +12,7 @@ app.kubernetes.io/component: single-binary
 {{- define "loki.singleBinarySelectorLabels" -}}
 {{ include "loki.selectorLabels" . }}
 app.kubernetes.io/component: single-binary
+name: single-binary
 {{- end }}
 
 {{/*

--- a/production/helm/loki/templates/write/_helpers-write.tpl
+++ b/production/helm/loki/templates/write/_helpers-write.tpl
@@ -11,6 +11,7 @@ write common labels
 {{- define "loki.writeLabels" -}}
 {{ include "loki.labels" . }}
 app.kubernetes.io/component: write
+name: write
 {{- end }}
 
 {{/*
@@ -19,6 +20,7 @@ write selector labels
 {{- define "loki.writeSelectorLabels" -}}
 {{ include "loki.selectorLabels" . }}
 app.kubernetes.io/component: write
+name: write
 {{- end }}
 
 {{/*


### PR DESCRIPTION
**What this PR does / why we need it**:
* Adds `name` label to all components (ingesters already have this)
* Modify the runtime config to not use `fullName` (the other components only use `name`)

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
