### PR TITLE
feat(blooms): Make bloom block compression configurable

### DIFF
--- a/docs/sources/configure/_index.md
+++ b/docs/sources/configure/_index.md
@@ -3202,6 +3202,10 @@ shard_streams:
 # CLI flag: -bloom-compactor.false-positive-rate
 [bloom_false_positive_rate: <float> | default = 0.01]
 
+# Compression algorithm for bloom block pages.
+# CLI flag: -bloom-compactor.block-encoding
+[bloom_block_encoding: <string> | default = "none"]
+
 # Maximum number of blocks will be downloaded in parallel by the Bloom Gateway.
 # CLI flag: -bloom-gateway.blocks-downloading-parallelism
 [bloom_gateway_blocks_downloading_parallelism: <int> | default = 50]

--- a/pkg/bloomcompactor/bloomcompactor_test.go
+++ b/pkg/bloomcompactor/bloomcompactor_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/loki/pkg/bloomutils"
+	"github.com/grafana/loki/pkg/chunkenc"
 	v1 "github.com/grafana/loki/pkg/storage/bloom/v1"
 	"github.com/grafana/loki/pkg/storage/config"
 	util_log "github.com/grafana/loki/pkg/util/log"
@@ -178,6 +179,10 @@ func (m mockLimits) BloomNGramSkip(_ string) int {
 
 func (m mockLimits) BloomFalsePositiveRate(_ string) float64 {
 	panic("implement me")
+}
+
+func (m mockLimits) BloomBlockEncoding(_ string) string {
+	return chunkenc.EncNone.String()
 }
 
 func (m mockLimits) BloomCompactorMaxBlockSize(_ string) int {

--- a/pkg/bloomcompactor/config.go
+++ b/pkg/bloomcompactor/config.go
@@ -3,8 +3,9 @@ package bloomcompactor
 import (
 	"flag"
 	"fmt"
-	"github.com/pkg/errors"
 	"time"
+
+	"github.com/pkg/errors"
 
 	"github.com/grafana/loki/pkg/storage/stores/shipper/indexshipper/downloads"
 	"github.com/grafana/loki/pkg/util/ring"
@@ -83,4 +84,5 @@ type Limits interface {
 	BloomNGramSkip(tenantID string) int
 	BloomFalsePositiveRate(tenantID string) float64
 	BloomCompactorMaxBlockSize(tenantID string) int
+	BloomBlockEncoding(tenantID string) string
 }

--- a/pkg/bloomcompactor/spec_test.go
+++ b/pkg/bloomcompactor/spec_test.go
@@ -118,13 +118,13 @@ func TestSimpleBloomGenerator(t *testing.T) {
 	}{
 		{
 			desc:       "SkipsIncompatibleSchemas",
-			fromSchema: v1.NewBlockOptions(3, 0, maxBlockSize),
-			toSchema:   v1.NewBlockOptions(4, 0, maxBlockSize),
+			fromSchema: v1.NewBlockOptions(0, 3, 0, maxBlockSize),
+			toSchema:   v1.NewBlockOptions(0, 4, 0, maxBlockSize),
 		},
 		{
 			desc:       "CombinesBlocks",
-			fromSchema: v1.NewBlockOptions(4, 0, maxBlockSize),
-			toSchema:   v1.NewBlockOptions(4, 0, maxBlockSize),
+			fromSchema: v1.NewBlockOptions(0, 4, 0, maxBlockSize),
+			toSchema:   v1.NewBlockOptions(0, 4, 0, maxBlockSize),
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {

--- a/pkg/bloomcompactor/spec_test.go
+++ b/pkg/bloomcompactor/spec_test.go
@@ -3,12 +3,14 @@ package bloomcompactor
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/go-kit/log"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/loki/pkg/chunkenc"
 	v1 "github.com/grafana/loki/pkg/storage/bloom/v1"
 	"github.com/grafana/loki/pkg/storage/stores/shipper/bloomshipper"
 )
@@ -111,53 +113,56 @@ func dummyBloomGen(t *testing.T, opts v1.BlockOptions, store v1.Iterator[*v1.Ser
 
 func TestSimpleBloomGenerator(t *testing.T) {
 	const maxBlockSize = 100 << 20 // 100MB
-	for _, tc := range []struct {
-		desc                 string
-		fromSchema, toSchema v1.BlockOptions
-		overlapping          bool
-	}{
-		{
-			desc:       "SkipsIncompatibleSchemas",
-			fromSchema: v1.NewBlockOptions(0, 3, 0, maxBlockSize),
-			toSchema:   v1.NewBlockOptions(0, 4, 0, maxBlockSize),
-		},
-		{
-			desc:       "CombinesBlocks",
-			fromSchema: v1.NewBlockOptions(0, 4, 0, maxBlockSize),
-			toSchema:   v1.NewBlockOptions(0, 4, 0, maxBlockSize),
-		},
-	} {
-		t.Run(tc.desc, func(t *testing.T) {
-			sourceBlocks, data, refs := blocksFromSchemaWithRange(t, 2, tc.fromSchema, 0x00000, 0x6ffff)
-			storeItr := v1.NewMapIter[v1.SeriesWithBloom, *v1.Series](
-				v1.NewSliceIter[v1.SeriesWithBloom](data),
-				func(swb v1.SeriesWithBloom) *v1.Series {
-					return swb.Series
-				},
-			)
+	for _, enc := range []chunkenc.Encoding{chunkenc.EncNone, chunkenc.EncGZIP, chunkenc.EncSnappy} {
+		for _, tc := range []struct {
+			desc                 string
+			fromSchema, toSchema v1.BlockOptions
+			overlapping          bool
+		}{
+			{
+				desc:       "SkipsIncompatibleSchemas",
+				fromSchema: v1.NewBlockOptions(enc, 3, 0, maxBlockSize),
+				toSchema:   v1.NewBlockOptions(enc, 4, 0, maxBlockSize),
+			},
+			{
+				desc:       "CombinesBlocks",
+				fromSchema: v1.NewBlockOptions(enc, 4, 0, maxBlockSize),
+				toSchema:   v1.NewBlockOptions(enc, 4, 0, maxBlockSize),
+			},
+		} {
+			t.Run(fmt.Sprintf("%s/%s", tc.desc, enc), func(t *testing.T) {
+				sourceBlocks, data, refs := blocksFromSchemaWithRange(t, 2, tc.fromSchema, 0x00000, 0x6ffff)
+				storeItr := v1.NewMapIter[v1.SeriesWithBloom, *v1.Series](
+					v1.NewSliceIter[v1.SeriesWithBloom](data),
+					func(swb v1.SeriesWithBloom) *v1.Series {
+						return swb.Series
+					},
+				)
 
-			gen := dummyBloomGen(t, tc.toSchema, storeItr, sourceBlocks, refs)
-			results := gen.Generate(context.Background())
+				gen := dummyBloomGen(t, tc.toSchema, storeItr, sourceBlocks, refs)
+				results := gen.Generate(context.Background())
 
-			var outputBlocks []*v1.Block
-			for results.Next() {
-				outputBlocks = append(outputBlocks, results.At())
-			}
-			// require.Equal(t, tc.outputBlocks, len(outputBlocks))
-
-			// Check all the input series are present in the output blocks.
-			expectedRefs := v1.PointerSlice(data)
-			outputRefs := make([]*v1.SeriesWithBloom, 0, len(data))
-			for _, block := range outputBlocks {
-				bq := block.Querier()
-				for bq.Next() {
-					outputRefs = append(outputRefs, bq.At())
+				var outputBlocks []*v1.Block
+				for results.Next() {
+					outputBlocks = append(outputBlocks, results.At())
 				}
-			}
-			require.Equal(t, len(expectedRefs), len(outputRefs))
-			for i := range expectedRefs {
-				require.Equal(t, expectedRefs[i].Series, outputRefs[i].Series)
-			}
-		})
+				// require.Equal(t, tc.outputBlocks, len(outputBlocks))
+
+				// Check all the input series are present in the output blocks.
+				expectedRefs := v1.PointerSlice(data)
+				outputRefs := make([]*v1.SeriesWithBloom, 0, len(data))
+				for _, block := range outputBlocks {
+					bq := block.Querier()
+					for bq.Next() {
+						outputRefs = append(outputRefs, bq.At())
+					}
+				}
+				require.Equal(t, len(expectedRefs), len(outputRefs))
+				for i := range expectedRefs {
+					require.Equal(t, expectedRefs[i].Series, outputRefs[i].Series)
+				}
+			})
+		}
 	}
+
 }

--- a/pkg/storage/bloom/v1/bloom.go
+++ b/pkg/storage/bloom/v1/bloom.go
@@ -198,7 +198,6 @@ type BloomBlock struct {
 	pageHeaders []BloomPageHeader
 }
 
-// Deprecated
 func NewBloomBlock(encoding chunkenc.Encoding) BloomBlock {
 	return BloomBlock{
 		schema: Schema{version: DefaultSchemaVersion, encoding: encoding},

--- a/pkg/storage/bloom/v1/bloom.go
+++ b/pkg/storage/bloom/v1/bloom.go
@@ -198,6 +198,7 @@ type BloomBlock struct {
 	pageHeaders []BloomPageHeader
 }
 
+// Deprecated
 func NewBloomBlock(encoding chunkenc.Encoding) BloomBlock {
 	return BloomBlock{
 		schema: Schema{version: DefaultSchemaVersion, encoding: encoding},

--- a/pkg/storage/bloom/v1/builder.go
+++ b/pkg/storage/bloom/v1/builder.go
@@ -15,7 +15,7 @@ import (
 )
 
 var (
-	DefaultBlockOptions = NewBlockOptions(4, 1, 50<<20) // 50MB
+	DefaultBlockOptions = NewBlockOptions(0, 4, 1, 50<<20) // EncNone, 50MB
 )
 
 type BlockOptions struct {
@@ -70,9 +70,10 @@ type BlockBuilder struct {
 	blooms *BloomBlockBuilder
 }
 
-func NewBlockOptions(NGramLength, NGramSkip, MaxBlockSizeBytes uint64) BlockOptions {
+func NewBlockOptions(enc chunkenc.Encoding, NGramLength, NGramSkip, MaxBlockSizeBytes uint64) BlockOptions {
 	opts := NewBlockOptionsFromSchema(Schema{
 		version:     byte(1),
+		encoding:    enc,
 		nGramLength: NGramLength,
 		nGramSkip:   NGramSkip,
 	})

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -19,6 +19,7 @@ import (
 	"golang.org/x/time/rate"
 	"gopkg.in/yaml.v2"
 
+	"github.com/grafana/loki/pkg/chunkenc"
 	"github.com/grafana/loki/pkg/compactor/deletionmode"
 	"github.com/grafana/loki/pkg/distributor/shardstreams"
 	"github.com/grafana/loki/pkg/loghttp/push"
@@ -196,6 +197,7 @@ type Limits struct {
 	BloomNGramLength                         int              `yaml:"bloom_ngram_length" json:"bloom_ngram_length"`
 	BloomNGramSkip                           int              `yaml:"bloom_ngram_skip" json:"bloom_ngram_skip"`
 	BloomFalsePositiveRate                   float64          `yaml:"bloom_false_positive_rate" json:"bloom_false_positive_rate"`
+	BloomBlockEncoding                       string           `yaml:"bloom_block_encoding" json:"bloom_block_encoding"`
 	BloomGatewayBlocksDownloadingParallelism int              `yaml:"bloom_gateway_blocks_downloading_parallelism" json:"bloom_gateway_blocks_downloading_parallelism"`
 	BloomGatewayCacheKeyInterval             time.Duration    `yaml:"bloom_gateway_cache_key_interval" json:"bloom_gateway_cache_key_interval"`
 	BloomCompactorMaxBlockSize               flagext.ByteSize `yaml:"bloom_compactor_max_block_size" json:"bloom_compactor_max_block_size"`
@@ -336,6 +338,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&l.BloomNGramLength, "bloom-compactor.ngram-length", 4, "Length of the n-grams created when computing blooms from log lines.")
 	f.IntVar(&l.BloomNGramSkip, "bloom-compactor.ngram-skip", 1, "Skip factor for the n-grams created when computing blooms from log lines.")
 	f.Float64Var(&l.BloomFalsePositiveRate, "bloom-compactor.false-positive-rate", 0.01, "Scalable Bloom Filter desired false-positive rate.")
+	f.StringVar(&l.BloomBlockEncoding, "bloom-compactor.block-encoding", "none", "Compression algorithm for bloom block pages.")
 	f.IntVar(&l.BloomGatewayBlocksDownloadingParallelism, "bloom-gateway.blocks-downloading-parallelism", 50, "Maximum number of blocks will be downloaded in parallel by the Bloom Gateway.")
 	f.DurationVar(&l.BloomGatewayCacheKeyInterval, "bloom-gateway.cache-key-interval", 15*time.Minute, "Interval for computing the cache key in the Bloom Gateway.")
 	_ = l.BloomCompactorMaxBlockSize.Set(defaultBloomCompactorMaxBlockSize)
@@ -426,6 +429,10 @@ func (l *Limits) Validate() error {
 	}
 
 	if err := l.OTLPConfig.Validate(); err != nil {
+		return err
+	}
+
+	if _, err := chunkenc.ParseEncoding(l.BloomBlockEncoding); err != nil {
 		return err
 	}
 
@@ -920,6 +927,10 @@ func (o *Overrides) BloomCompactorMaxBlockSize(userID string) int {
 
 func (o *Overrides) BloomFalsePositiveRate(userID string) float64 {
 	return o.getOverridesForUser(userID).BloomFalsePositiveRate
+}
+
+func (o *Overrides) BloomBlockEncoding(userID string) string {
+	return o.getOverridesForUser(userID).BloomBlockEncoding
 }
 
 func (o *Overrides) AllowStructuredMetadata(userID string) bool {

--- a/pkg/validation/limits_test.go
+++ b/pkg/validation/limits_test.go
@@ -2,6 +2,7 @@ package validation
 
 import (
 	"encoding/json"
+	"fmt"
 	"reflect"
 	"testing"
 	"time"
@@ -11,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
 
+	"github.com/grafana/loki/pkg/chunkenc"
 	"github.com/grafana/loki/pkg/compactor/deletionmode"
 	"github.com/grafana/loki/pkg/loghttp/push"
 )
@@ -308,19 +310,39 @@ query_timeout: 5m
 	}
 }
 
-func TestLimitsValidation_deletionMode(t *testing.T) {
+func TestLimitsValidation(t *testing.T) {
 	for _, tc := range []struct {
-		mode     string
+		limits   Limits
 		expected error
 	}{
-		{mode: "disabled", expected: nil},
-		{mode: "filter-only", expected: nil},
-		{mode: "filter-and-delete", expected: nil},
-		{mode: "something-else", expected: deletionmode.ErrUnknownMode},
+		{
+			limits:   Limits{DeletionMode: "disabled", BloomBlockEncoding: "none"},
+			expected: nil,
+		},
+		{
+			limits:   Limits{DeletionMode: "filter-only", BloomBlockEncoding: "none"},
+			expected: nil,
+		},
+		{
+			limits:   Limits{DeletionMode: "filter-and-delete", BloomBlockEncoding: "none"},
+			expected: nil,
+		},
+		{
+			limits:   Limits{DeletionMode: "something-else", BloomBlockEncoding: "none"},
+			expected: deletionmode.ErrUnknownMode,
+		},
+		{
+			limits:   Limits{DeletionMode: "disabled", BloomBlockEncoding: "unknown"},
+			expected: fmt.Errorf("invalid encoding: unknown, supported: %s", chunkenc.SupportedEncoding()),
+		},
 	} {
-		t.Run(tc.mode, func(t *testing.T) {
-			limits := Limits{DeletionMode: tc.mode}
-			require.ErrorIs(t, limits.Validate(), tc.expected)
+		desc := fmt.Sprintf("%s/%s", tc.limits.DeletionMode, tc.limits.BloomBlockEncoding)
+		t.Run(desc, func(t *testing.T) {
+			if tc.expected == nil {
+				require.NoError(t, tc.limits.Validate())
+			} else {
+				require.ErrorContains(t, tc.limits.Validate(), tc.expected.Error())
+			}
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

* Make bloom block compression configurable

  Up to now, no compression was used for bloom pages. This commit adds a
  new runtime setting that allows to specify the compression algorithm
  used when building the bloom blocks.

* Test different block encodings