### PR TITLE
fix(blooms): Correctly skip block page in case it exceeds the max page size for querying

### DIFF
--- a/pkg/storage/bloom/v1/bloom.go
+++ b/pkg/storage/bloom/v1/bloom.go
@@ -18,7 +18,7 @@ import (
 // Figure out a decent maximum page size that we can process.
 // TODO(chaudum): Make max page size configurable
 var maxPageSize = 32 << 20 // 32MB
-var errPageTooLarge = "bloom page too large to process: N=%d Offset=%d Len=%d DecompressedLen=%d"
+var ErrPageTooLarge = errors.Errorf("bloom page too large: size limit is %.1fMiB", float64(maxPageSize)/float64(1<<20))
 
 type Bloom struct {
 	filter.ScalableBloomFilter
@@ -253,9 +253,10 @@ func (b *BloomBlock) BloomPageDecoder(r io.ReadSeeker, pageIdx int) (*BloomPageD
 	}
 
 	page := b.pageHeaders[pageIdx]
+	// fmt.Printf("pageIdx=%d page=%+v size=%.2fMiB\n", pageIdx, page, float64(page.Len)/float64(1<<20))
 
 	if page.Len > maxPageSize {
-		return nil, fmt.Errorf(errPageTooLarge, page.N, page.Offset, page.Len, page.DecompressedLen)
+		return nil, ErrPageTooLarge
 	}
 
 	if _, err := r.Seek(int64(page.Offset), io.SeekStart); err != nil {

--- a/tools/bloom/inspector/main.go
+++ b/tools/bloom/inspector/main.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	v1 "github.com/grafana/loki/pkg/storage/bloom/v1"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run main.go BLOCK_DIRECTORY")
+		os.Exit(2)
+	}
+
+	path := os.Args[1]
+	fmt.Printf("Block directory: %s\n", path)
+
+	r := v1.NewDirectoryBlockReader(path)
+	b := v1.NewBlock(r)
+	q := v1.NewBlockQuerier(b)
+
+	md, err := q.Metadata()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("Metadata: %+v\n", md)
+
+	for q.Next() {
+		swb := q.At()
+		fmt.Printf("%s (%d)\n", swb.Series.Fingerprint, swb.Series.Chunks.Len())
+	}
+	if q.Err() != nil {
+		fmt.Printf("error: %s\n", q.Err())
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously a bloom page that was too big caused the rest of the block to be skipped.
