### PR TITLE
fix(blooms): leaky ref

### DIFF
--- a/pkg/storage/bloom/v1/bloom.go
+++ b/pkg/storage/bloom/v1/bloom.go
@@ -86,7 +86,7 @@ func LazyDecodeBloomPage(r io.Reader, pool chunkenc.ReaderPool, page BloomPageHe
 	}
 	defer pool.PutReader(decompressor)
 
-	b := BlockPool.Get(page.DecompressedLen)[:page.DecompressedLen]
+	b := make([]byte, page.DecompressedLen)
 
 	if _, err = io.ReadFull(decompressor, b); err != nil {
 		return nil, errors.Wrap(err, "decompressing bloom page")
@@ -97,10 +97,6 @@ func LazyDecodeBloomPage(r io.Reader, pool chunkenc.ReaderPool, page BloomPageHe
 	return decoder, nil
 }
 
-// NewBloomPageDecoder returns a decoder for a bloom page.
-// If the byte slice passed in the constructor is from the BlockPool pool, then
-// the caller needs to ensure that Close() is called to put the slice back to
-// its pool.
 func NewBloomPageDecoder(data []byte) *BloomPageDecoder {
 	// last 8 bytes are the number of blooms in this page
 	dec := encoding.DecWith(data[len(data)-8:])
@@ -121,6 +117,11 @@ func NewBloomPageDecoder(data []byte) *BloomPageDecoder {
 }
 
 // Decoder is a seekable, reset-able iterator
+// TODO(owen-d): use buffer pools. The reason we don't currently
+// do this is because the `data` slice currently escapes the decoder
+// via the returned bloom, so we can't know when it's safe to return it to the pool.
+// This happens via `data ([]byte) -> dec (*encoding.Decbuf) -> bloom (Bloom)` where
+// the final Bloom has a reference to the data slice.
 // We could optimize this by encoding the mode (read, write) into our structs
 // and doing copy-on-write shenannigans, but I'm avoiding this for now.
 type BloomPageDecoder struct {
@@ -164,14 +165,6 @@ func (d *BloomPageDecoder) At() *Bloom {
 
 func (d *BloomPageDecoder) Err() error {
 	return d.err
-}
-
-func (d *BloomPageDecoder) Close() {
-	d.err = nil
-	d.cur = nil
-	BlockPool.Put(d.data)
-	d.data = nil
-	d.dec.B = nil
 }
 
 type BloomPageHeader struct {

--- a/pkg/storage/bloom/v1/bloom_querier.go
+++ b/pkg/storage/bloom/v1/bloom_querier.go
@@ -32,13 +32,6 @@ func (it *LazyBloomIter) ensureInit() {
 	}
 }
 
-func (it *LazyBloomIter) setPage(dec *BloomPageDecoder) {
-	if it.curPage != nil {
-		it.curPage.Close()
-	}
-	it.curPage = dec
-}
-
 func (it *LazyBloomIter) Seek(offset BloomOffset) {
 	it.ensureInit()
 
@@ -49,18 +42,17 @@ func (it *LazyBloomIter) Seek(offset BloomOffset) {
 		r, err := it.b.reader.Blooms()
 		if err != nil {
 			it.err = errors.Wrap(err, "getting blooms reader")
-			it.setPage(nil)
 			return
 		}
 		decoder, err := it.b.blooms.BloomPageDecoder(r, offset.Page)
 		if err != nil {
 			it.err = errors.Wrap(err, "loading bloom page")
-			it.setPage(nil)
 			return
 		}
 
 		it.curPageIndex = offset.Page
-		it.setPage(decoder)
+		it.curPage = decoder
+
 	}
 
 	it.curPage.Seek(offset.ByteOffset)
@@ -88,26 +80,25 @@ func (it *LazyBloomIter) next() bool {
 				return false
 			}
 
-			decoder, err := it.b.blooms.BloomPageDecoder(r, it.curPageIndex)
+			it.curPage, err = it.b.blooms.BloomPageDecoder(
+				r,
+				it.curPageIndex,
+			)
 			if err != nil {
 				it.err = err
-				it.setPage(nil)
 				return false
 			}
-			it.setPage(decoder)
 			continue
 		}
 
 		if !it.curPage.Next() {
 			// there was an error
 			if it.curPage.Err() != nil {
-				it.err = it.curPage.Err()
-				it.setPage(nil)
 				return false
 			}
 			// we've exhausted the current page, progress to next
 			it.curPageIndex++
-			it.setPage(nil)
+			it.curPage = nil
 			continue
 		}
 
@@ -115,7 +106,6 @@ func (it *LazyBloomIter) next() bool {
 	}
 
 	// finished last page
-	it.setPage(nil)
 	return false
 }
 

--- a/pkg/storage/bloom/v1/util.go
+++ b/pkg/storage/bloom/v1/util.go
@@ -32,10 +32,10 @@ var (
 		},
 	}
 
-	// 4KB -> 64MB
+	// 1KB -> 8MB
 	BlockPool = BytePool{
 		pool: pool.New(
-			4<<10, 64<<20, 4,
+			1<<10, 1<<24, 4,
 			func(size int) interface{} {
 				return make([]byte, size)
 			}),

--- a/pkg/storage/bloom/v1/util.go
+++ b/pkg/storage/bloom/v1/util.go
@@ -32,10 +32,10 @@ var (
 		},
 	}
 
-	// 1KB -> 8MB
+	// 4KB -> 64MB
 	BlockPool = BytePool{
 		pool: pool.New(
-			1<<10, 1<<24, 4,
+			4<<10, 64<<24, 4,
 			func(size int) interface{} {
 				return make([]byte, size)
 			}),


### PR DESCRIPTION
Reverts https://github.com/grafana/loki/pull/12256 with the exception of the pool sizing deltas. That PR was very similar to the bug which https://github.com/grafana/loki/pull/12050 previously fixed