### PR TITLE
docs: [style] quickstart as one word

### DIFF
--- a/docs/sources/get-started/_index.md
+++ b/docs/sources/get-started/_index.md
@@ -32,14 +32,12 @@ To collect logs and view your log data generally involves the following steps:
 
 **Next steps:** Learn more about Loki’s query language, [LogQL](https://grafana.com/docs/loki/latest/query/).
 
-
 ## Example Grafana Agent configuration file to ship Kubernetes Pod logs to Loki
 
 To deploy Grafana Agent to collect Pod logs from your Kubernetes cluster and ship them to Loki, you an use the Grafana Agent Helm chart, and a `values.yaml` file.
 
 1. Install Loki with the [Helm chart](https://grafana.com/docs/loki/latest/setup/install/helm/install-scalable/).
 1. Deploy the Grafana Agent, using the [Grafana Agent Helm chart](https://grafana.com/docs/agent/latest/flow/setup/install/kubernetes/) and this example `values.yaml` file updating the value for `forward_to = [loki.write.endpoint.receiver]`:
-
 
 ```yaml
 agent:
@@ -101,14 +99,15 @@ agent:
       }
 
 ```
-  
 
 1. Then install Grafana Agent in your Kubernetes cluster using:
 
     ```bash
     helm upgrade -f values.yaml agent grafana/grafana-agent 
     ```
+
 This sample file is configured to:
+
 - Install Grafana Agent to discover Pod logs.
 - Add `container` and `pod` labels to the logs.
 - Push the logs to your Loki cluster using the tenant ID `cloud`.

--- a/docs/sources/get-started/quick-start.md
+++ b/docs/sources/get-started/quick-start.md
@@ -1,11 +1,11 @@
 ---
-title: Quick start to run Loki locally
-menuTitle: Loki quick start
+title: Quickstart to run Loki locally
+menuTitle: Loki quickstart
 weight: 550
 description: How to create and use a simple local Loki cluster for testing and evaluation purposes.
 ---
 
-# Quick start to run Loki locally
+# Quickstart to run Loki locally
 
 If you want to experiment with Loki, you can run Loki locally using the Docker Compose file that ships with Loki. It runs Loki in a [monolithic deployment](https://grafana.com/docs/loki/latest/get-started/deployment-modes/#monolithic-mode) mode and includes a sample application to generate logs.
 
@@ -24,11 +24,12 @@ The Docker Compose configuration instantiates the following components, each in 
 ## Installing Loki and collecting sample logs
 
 Prerequisites
+
 - [Docker](https://docs.docker.com/install)
 - [Docker Compose](https://docs.docker.com/compose/install)
 
 {{% admonition type="note" %}}
-This quick start assumes you are running Linux.
+This quickstart assumes you are running Linux.
 {{% /admonition %}}
 
 **To install Loki locally, follow these steps:**
@@ -57,6 +58,7 @@ This quick start assumes you are running Linux.
     ```
 
     You should see something similar to the following:
+
     ```bash
     ✔ Network evaluate-loki_loki          Created      0.1s 
     ✔ Container evaluate-loki-minio-1     Started      0.6s 
@@ -99,30 +101,37 @@ Once you have collected logs, you will want to view them.  You can view your log
     Here are some basic sample queries to get you started using LogQL.  Note that these queries assume that you followed the instructions to create a directory called `evaluate-loki`. If you installed in a different directory, you’ll need to modify these queries to match your installation directory.  After copying any of these queries into the query editor, click **Run Query** (4) to execute the query.
 
     1. View all the log lines which have the container label "flog":
+
         ```bash
         {container="evaluate-loki-flog-1"}
         ```
+
         In Loki, this is called a log stream. Loki uses [labels](https://grafana.com/docs/loki/latest/get-started/labels/) as metadata to describe log streams.  Loki queries always start with a label selector.  In the query above, the label selector is `container`.
 
     1. To view all the log lines which have the container label "grafana":
+
         ```bash
         {container="evaluate-loki-grafana-1"}
         ```
 
     1. Find all the log lines in the container=flog stream that contain the string "status":
+
         ```bash
         {container="evaluate-loki-flog-1"} |= `status`
         ```
 
     1. Find all the log lines in the container=flog stream where the JSON field "status" is "404":
+
         ```bash
         {container="evaluate-loki-flog-1"} | json | status=`404`
         ```
 
     1. Calculate the number of logs per second where the JSON field "status" is "404":
+
         ```bash
         sum by(container) (rate({container="evaluate-loki-flog-1"} | json | status=`404` [$__auto]))        
         ```
+
     The final query above is a metric query which returns a time series. This will trigger Grafana to draw a graph of the results.  You can change the type of graph for a different view of the data.  Click **Bars** to view a bar graph of the data.
 
 1. Click the **Builder** tab (3) to return to Builder mode in the query editor.
@@ -134,30 +143,37 @@ Once you have collected logs, you will want to view them.  You can view your log
 For a thorough introduction to LogQL, refer to the [LogQL reference](https://grafana.com/docs/loki/latest/query/).
 
 ## Sample queries (code view)
+
 Here are some more sample queries that you can run using the Flog sample data.
 
 To see all the log lines that flog has generated, enter the LogQL query:
+
 ```bash
 {container="evaluate-loki-flog-1"}|= ``
 ```
-The flog app generates log lines for simulated HTTP requests. 
+
+The flog app generates log lines for simulated HTTP requests.
 
 To see all `GET` log lines, enter the LogQL query:
+
 ```bash
 {container="evaluate-loki-flog-1"} |= "GET"
 ```
 
 To see all `POST` methods, enter the LogQL query:
+
 ```bash
 {container="evaluate-loki-flog-1"} |= "POST"
 ```
 
 To see every log line with a 401 status (unauthorized error), enter the LogQL query:
+
 ```bash
 {container="evaluate-loki-flog-1"} | json | status="401"
 ```
 
 To see every log line that does not contain the value 401:
+
 ```bash
 {container="evaluate-loki-flog-1"} != "401"
 ```


### PR DESCRIPTION
**What this PR does / why we need it**:

Update to conform to today's Style Roundtable decision to write "quickstart" as a single word.
Added/removed lines to address Vale linter errors while I was in there.