### PR TITLE
fix(bloomstore): Fix race conditions

### DIFF
--- a/pkg/storage/stores/shipper/bloomshipper/blockscache.go
+++ b/pkg/storage/stores/shipper/bloomshipper/blockscache.go
@@ -291,8 +291,8 @@ func (c *BlocksCache) Get(ctx context.Context, key string) (BlockDirectory, bool
 		return BlockDirectory{}, false
 	}
 
-	c.lock.RLock()
-	defer c.lock.RUnlock()
+	c.lock.Lock()
+	defer c.lock.Unlock()
 
 	entry := c.get(key)
 	if entry == nil {

--- a/pkg/storage/stores/shipper/bloomshipper/blockscache.go
+++ b/pkg/storage/stores/shipper/bloomshipper/blockscache.go
@@ -455,3 +455,9 @@ func (c *BlocksCache) evictExpiredItems(ttl time.Duration) {
 		}
 	}
 }
+
+func (c *BlocksCache) len() (int, bool) {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return c.lru.Len(), c.lru.Len() == len(c.entries)
+}

--- a/pkg/storage/stores/shipper/bloomshipper/blockscache_test.go
+++ b/pkg/storage/stores/shipper/bloomshipper/blockscache_test.go
@@ -123,7 +123,9 @@ func TestBlocksCache_PutAndGet(t *testing.T) {
 	_, found = cache.Get(ctx, "a")
 	require.True(t, found)
 
-	require.Equal(t, 3, cache.lru.Len())
+	l, ok := cache.len()
+	require.True(t, ok)
+	require.Equal(t, 3, l)
 
 	// check LRU order
 	elem := cache.lru.Front()
@@ -187,8 +189,9 @@ func TestBlocksCache_TTLEviction(t *testing.T) {
 	_, found = cache.Get(ctx, "b")
 	require.True(t, found)
 
-	require.Equal(t, 1, cache.lru.Len())
-	require.Equal(t, 1, len(cache.entries))
+	l, ok := cache.len()
+	require.True(t, ok)
+	require.Equal(t, 1, l)
 }
 
 func TestBlocksCache_LRUEviction(t *testing.T) {
@@ -224,8 +227,9 @@ func TestBlocksCache_LRUEviction(t *testing.T) {
 
 	time.Sleep(time.Second)
 
-	require.Equal(t, 3, cache.lru.Len())
-	require.Equal(t, 3, len(cache.entries))
+	l, ok := cache.len()
+	require.True(t, ok)
+	require.Equal(t, 3, l)
 
 	// key "b" was evicted because it was the oldest
 	// and it had no ref counts


### PR DESCRIPTION
**What this PR does / why we need it**:

* Use lock for writing when doing a Get()

  This is necessary, because a Get() operation alters the linked list `c.lru` to move the requested item to the front of the list.

* Fix races in blocks cache tests
