### PR TITLE
feat: Add support for Helm namespaceOverride

### DIFF
--- a/docs/sources/setup/install/helm/reference.md
+++ b/docs/sources/setup/install/helm/reference.md
@@ -2896,7 +2896,7 @@ null
 			<td><pre lang="json">
 {
   "name": "self-monitoring",
-  "secretNamespace": "{{ .Release.Namespace }}"
+  "secretNamespace": "{{ include "loki.namespace" . }}"
 }
 </pre>
 </td>
@@ -2915,7 +2915,7 @@ null
 			<td>string</td>
 			<td>Namespace to create additional tenant token secret in. Useful if your Grafana instance is in a separate namespace. Token will still be created in the canary namespace.</td>
 			<td><pre lang="json">
-"{{ .Release.Namespace }}"
+"{{ include "loki.namespace" . }}"
 </pre>
 </td>
 		</tr>

--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -13,6 +13,11 @@ Entries should include a reference to the pull request that introduced the chang
 
 [//]: # (<AUTOMATED_UPDATES_LOCATOR> : do not remove this line. This locator is used by the CI pipeline to automatically create a changelog entry for each new Loki release. Add other chart versions and respective changelog entries bellow this line.)
 
+
+## 5.47.0
+
+- [ENHANCEMENT] Added support for namespace overriding when installing in a multi-chart(dependency) setup.
+
 ## 5.47.0
 
 - [CHANGE] Changed version of Loki to 2.9.6

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -3,7 +3,7 @@ name: loki
 description: Helm chart for Grafana Loki in simple, scalable mode
 type: application
 appVersion: 2.9.6
-version: 5.47.0
+version: 5.48.0
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -1,6 +1,6 @@
 # loki
 
-![Version: 5.47.0](https://img.shields.io/badge/Version-5.47.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.9.6](https://img.shields.io/badge/AppVersion-2.9.6-informational?style=flat-square)
+![Version: 5.48.0](https://img.shields.io/badge/Version-5.48.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.9.6](https://img.shields.io/badge/AppVersion-2.9.6-informational?style=flat-square)
 
 Helm chart for Grafana Loki in simple, scalable mode
 

--- a/production/helm/loki/templates/backend/poddisruptionbudget-backend.yaml
+++ b/production/helm/loki/templates/backend/poddisruptionbudget-backend.yaml
@@ -4,7 +4,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "loki.backendFullname" . }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.backendLabels" . | nindent 4 }}
 spec:

--- a/production/helm/loki/templates/backend/query-scheduler-discovery.yaml
+++ b/production/helm/loki/templates/backend/query-scheduler-discovery.yaml
@@ -5,7 +5,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: query-scheduler-discovery
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.backendSelectorLabels" . | nindent 4 }}
     prometheus.io/service-monitor: "false"

--- a/production/helm/loki/templates/backend/service-backend-headless.yaml
+++ b/production/helm/loki/templates/backend/service-backend-headless.yaml
@@ -5,7 +5,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "loki.backendFullname" . }}-headless
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.backendSelectorLabels" . | nindent 4 }}
     {{- with .Values.loki.serviceLabels }}

--- a/production/helm/loki/templates/backend/service-backend.yaml
+++ b/production/helm/loki/templates/backend/service-backend.yaml
@@ -5,7 +5,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "loki.backendFullname" . }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.backendLabels" . | nindent 4 }}
     {{- with .Values.loki.serviceLabels }}

--- a/production/helm/loki/templates/backend/statefulset-backend.yaml
+++ b/production/helm/loki/templates/backend/statefulset-backend.yaml
@@ -5,7 +5,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "loki.backendFullname" . }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.backendLabels" . | nindent 4 }}
     app.kubernetes.io/part-of: memberlist

--- a/production/helm/loki/templates/ciliumnetworkpolicy.yaml
+++ b/production/helm/loki/templates/ciliumnetworkpolicy.yaml
@@ -4,7 +4,7 @@ apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
   name: {{ include "loki.name" . }}-namespace-only
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.labels" . | nindent 4 }}
 spec:
@@ -21,7 +21,7 @@ apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
   name: {{ include "loki.name" . }}-egress-dns
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.labels" . | nindent 4 }}
 spec:
@@ -41,7 +41,7 @@ apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
   name: {{ include "loki.name" . }}-ingress
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.labels" . | nindent 4 }}
 spec:
@@ -77,7 +77,7 @@ apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
   name: {{ include "loki.name" . }}-ingress-metrics
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.labels" . | nindent 4 }}
 spec:
@@ -109,7 +109,7 @@ apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
   name: {{ include "loki.name" . }}-egress-alertmanager
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.labels" . | nindent 4 }}
 spec:
@@ -136,7 +136,7 @@ apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
   name: {{ include "loki.name" . }}-egress-external-storage
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.labels" . | nindent 4 }}
 spec:
@@ -215,7 +215,7 @@ apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
   name: {{ include "loki.name" . }}-egress-discovery
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.labels" . | nindent 4 }}
 spec:

--- a/production/helm/loki/templates/config.yaml
+++ b/production/helm/loki/templates/config.yaml
@@ -7,7 +7,7 @@ kind: ConfigMap
 {{- end }}
 metadata:
   name: {{ tpl .Values.loki.externalConfigSecretName . }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.labels" . | nindent 4 }}
 {{- if eq .Values.loki.configStorageType "Secret" }}

--- a/production/helm/loki/templates/gateway/configmap-gateway.yaml
+++ b/production/helm/loki/templates/gateway/configmap-gateway.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "loki.gatewayFullname" . }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.gatewayLabels" . | nindent 4 }}
 data:

--- a/production/helm/loki/templates/gateway/deployment-gateway.yaml
+++ b/production/helm/loki/templates/gateway/deployment-gateway.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "loki.gatewayFullname" . }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.gatewayLabels" . | nindent 4 }}
   {{- if or (not (empty .Values.loki.annotations)) (not (empty .Values.backend.annotations))}}

--- a/production/helm/loki/templates/gateway/hpa.yaml
+++ b/production/helm/loki/templates/gateway/hpa.yaml
@@ -8,7 +8,7 @@ apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "loki.gatewayFullname" . }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.gatewayLabels" . | nindent 4 }}
 spec:

--- a/production/helm/loki/templates/gateway/ingress-gateway.yaml
+++ b/production/helm/loki/templates/gateway/ingress-gateway.yaml
@@ -7,7 +7,7 @@ apiVersion: {{ include "loki.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ include "loki.gatewayFullname" . }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.gatewayLabels" . | nindent 4 }}
     {{- range $labelKey, $labelValue := .Values.gateway.ingress.labels }}

--- a/production/helm/loki/templates/gateway/poddisruptionbudget-gateway.yaml
+++ b/production/helm/loki/templates/gateway/poddisruptionbudget-gateway.yaml
@@ -7,7 +7,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "loki.gatewayFullname" . }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.gatewayLabels" . | nindent 4 }}
 spec:

--- a/production/helm/loki/templates/gateway/secret-gateway.yaml
+++ b/production/helm/loki/templates/gateway/secret-gateway.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "loki.gatewayFullname" $ }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.gatewayLabels" $ | nindent 4 }}
 stringData:

--- a/production/helm/loki/templates/gateway/service-gateway.yaml
+++ b/production/helm/loki/templates/gateway/service-gateway.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "loki.gatewayFullname" . }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.gatewayLabels" . | nindent 4 }}
     {{- with .Values.loki.serviceLabels }}

--- a/production/helm/loki/templates/ingress.yaml
+++ b/production/helm/loki/templates/ingress.yaml
@@ -4,7 +4,7 @@ apiVersion: {{ include "loki.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ include "loki.fullname" . }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.labels" . | nindent 4 }}
     {{- with .Values.ingress.labels }}

--- a/production/helm/loki/templates/loki-canary/daemonset.yaml
+++ b/production/helm/loki/templates/loki-canary/daemonset.yaml
@@ -5,7 +5,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ include "loki-canary.fullname" $ }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ default $.Release.Namespace $.Values.namespaceOverride | trunc 63 | trimSuffix "-" }}
   labels:
     {{- include "loki-canary.labels" $ | nindent 4 }}
 spec:

--- a/production/helm/loki/templates/loki-canary/service.yaml
+++ b/production/helm/loki/templates/loki-canary/service.yaml
@@ -5,7 +5,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "loki-canary.fullname" $ }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ default $.Release.Namespace $.Values.namespaceOverride | trunc 63 | trimSuffix "-" }}
   labels:
     {{- include "loki-canary.labels" $ | nindent 4 }}
     {{- with $.Values.loki.serviceLabels }}

--- a/production/helm/loki/templates/loki-canary/serviceaccount.yaml
+++ b/production/helm/loki/templates/loki-canary/serviceaccount.yaml
@@ -5,7 +5,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "loki-canary.fullname" $ }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ default $.Release.Namespace $.Values.namespaceOverride | trunc 63 | trimSuffix "-" }}
   labels:
     {{- include "loki-canary.labels" $ | nindent 4 }}
   {{- with .annotations }}

--- a/production/helm/loki/templates/monitoring/dashboards/configmap-1.yaml
+++ b/production/helm/loki/templates/monitoring/dashboards/configmap-1.yaml
@@ -5,7 +5,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "loki.dashboardsName" $ }}-1
-  namespace: {{ .namespace | default $.Release.Namespace }}
+  namespace: {{ .namespace | default $.Release.Namespace $.Values.namespaceOverride | trunc 63 | trimSuffix "-" }}
   labels:
     {{- include "loki.labels" $ | nindent 4 }}
     {{- with .labels }}

--- a/production/helm/loki/templates/monitoring/dashboards/configmap-2.yaml
+++ b/production/helm/loki/templates/monitoring/dashboards/configmap-2.yaml
@@ -5,7 +5,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "loki.dashboardsName" $ }}-2
-  namespace: {{ .namespace | default $.Release.Namespace }}
+  namespace: {{ .namespace | default $.Release.Namespace $.Values.namespaceOverride | trunc 63 | trimSuffix "-" }}
   labels:
     {{- include "loki.labels" $ | nindent 4 }}
     {{- with .labels }}

--- a/production/helm/loki/templates/monitoring/grafana-agent.yaml
+++ b/production/helm/loki/templates/monitoring/grafana-agent.yaml
@@ -4,7 +4,7 @@ apiVersion: monitoring.grafana.com/v1alpha1
 kind: GrafanaAgent
 metadata:
   name: {{ include "loki.fullname" $ }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ default $.Release.Namespace $.Values.namespaceOverride | trunc 63 | trimSuffix "-" }}
   labels:
     {{- include "loki.labels" $ | nindent 4 }}
     {{- with .labels }}
@@ -45,7 +45,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "loki.fullname" $ }}-grafana-agent
-  namespace: {{ .namespace | default $.Release.Namespace }}
+  namespace: {{ .namespace | default $.Release.Namespace $.Values.namespaceOverride | trunc 63 | trimSuffix "-" }}
 
 ---
 
@@ -95,6 +95,6 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ include "loki.fullname" $ }}-grafana-agent
-  namespace: {{ .namespace | default $.Release.Namespace }}
+  namespace: {{ .namespace | default $.Release.Namespace $.Values.namespaceOverride | trunc 63 | trimSuffix "-" }}
 {{- end}}
 {{- end}}

--- a/production/helm/loki/templates/monitoring/logs-instance.yaml
+++ b/production/helm/loki/templates/monitoring/logs-instance.yaml
@@ -4,7 +4,7 @@ apiVersion: monitoring.grafana.com/v1alpha1
 kind: LogsInstance
 metadata:
   name: {{ include "loki.fullname" $ }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ default $.Release.Namespace $.Values.namespaceOverride | trunc 63 | trimSuffix "-" }}
   {{- with .annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/production/helm/loki/templates/monitoring/loki-alerts.yaml
+++ b/production/helm/loki/templates/monitoring/loki-alerts.yaml
@@ -14,7 +14,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   name: {{ include "loki.fullname" $ }}-loki-alerts
-  namespace: {{ .namespace | default $.Release.Namespace }}
+  namespace: {{ .namespace | default (include "loki.namespace" . ) }}
 spec:
   groups:
   {{- include "loki.ruleGroupToYaml" (tpl ($.Files.Get "src/alerts.yaml.tpl") $ | fromYaml).groups | indent 4 }}

--- a/production/helm/loki/templates/monitoring/loki-rules.yaml
+++ b/production/helm/loki/templates/monitoring/loki-rules.yaml
@@ -14,7 +14,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   name: {{ include "loki.fullname" $ }}-loki-rules
-  namespace: {{ .namespace | default $.Release.Namespace }}
+  namespace: {{ .namespace | default (include "loki.namespace" . ) }}
 spec:
   groups:
   {{- include "loki.ruleGroupToYaml" (tpl ($.Files.Get "src/rules.yaml.tpl") $ | fromYaml).groups | indent 4 }}

--- a/production/helm/loki/templates/monitoring/pod-logs.yaml
+++ b/production/helm/loki/templates/monitoring/pod-logs.yaml
@@ -5,7 +5,7 @@ apiVersion: {{ .apiVersion }}
 kind: PodLogs
 metadata:
   name: {{ include "loki.fullname" $ }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ default $.Release.Namespace $.Values.namespaceOverride | trunc 63 | trimSuffix "-" }}
   {{- with .annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -51,7 +51,7 @@ spec:
     {{- end }}
   namespaceSelector:
     matchNames:
-      - {{ $.Release.Namespace }}
+      - {{ default $.Release.Namespace $.Values.namespaceOverride | trunc 63 | trimSuffix "-" }}
   selector:
     matchLabels:
       {{- include "loki.selectorLabels" $ | nindent 6 }}

--- a/production/helm/loki/templates/monitoring/servicemonitor.yaml
+++ b/production/helm/loki/templates/monitoring/servicemonitor.yaml
@@ -5,7 +5,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "loki.fullname" $ }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ default $.Release.Namespace $.Values.namespaceOverride | trunc 63 | trimSuffix "-" }}
   {{- with .annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -40,7 +40,7 @@ spec:
       relabelings:
         - sourceLabels: [job]
           action: replace
-          replacement: "{{ $.Release.Namespace }}/$1"
+          replacement: "{{ default $.Release.Namespace $.Values.namespaceOverride | trunc 63 | trimSuffix "-" }}/$1"
           targetLabel: job
         - action: replace
           replacement: "{{ include "loki.clusterLabel" $ }}"

--- a/production/helm/loki/templates/networkpolicy.yaml
+++ b/production/helm/loki/templates/networkpolicy.yaml
@@ -4,7 +4,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ include "loki.name" . }}-namespace-only
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.labels" . | nindent 4 }}
 spec:
@@ -24,7 +24,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ include "loki.name" . }}-egress-dns
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.labels" . | nindent 4 }}
 spec:
@@ -45,7 +45,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ include "loki.name" . }}-ingress
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.labels" . | nindent 4 }}
 spec:
@@ -83,7 +83,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ include "loki.name" . }}-ingress-metrics
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.labels" . | nindent 4 }}
 spec:
@@ -117,7 +117,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ include "loki.name" . }}-egress-alertmanager
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.labels" . | nindent 4 }}
 spec:
@@ -146,7 +146,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ include "loki.name" . }}-egress-external-storage
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.labels" . | nindent 4 }}
 spec:
@@ -178,7 +178,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ include "loki.name" . }}-egress-discovery
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.labels" . | nindent 4 }}
 spec:

--- a/production/helm/loki/templates/provisioner/job-provisioner.yaml
+++ b/production/helm/loki/templates/provisioner/job-provisioner.yaml
@@ -4,7 +4,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ template "enterprise-logs.provisionerFullname" . }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "enterprise-logs.provisionerLabels" . | nindent 4 }}
     {{- with .Values.enterprise.provisioner.labels }}
@@ -105,7 +105,7 @@ spec:
                   --from-literal=token-write="$(cat /bootstrap/token-write-{{ .name }})" \
                   --from-literal=token-read="$(cat /bootstrap/token-read-{{ .name }})"
               {{- end }}
-              {{- $namespace := $.Release.Namespace }}
+              {{- $namespace := (include "loki.namespace" . ) }}
               {{- with .Values.monitoring.selfMonitoring.tenant }}
               {{- $secretNamespace := tpl .secretNamespace $ }}
               ! test -s /bootstrap/token-self-monitoring || \

--- a/production/helm/loki/templates/provisioner/role-provisioner.yaml
+++ b/production/helm/loki/templates/provisioner/role-provisioner.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ template "enterprise-logs.provisionerFullname" . }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "enterprise-logs.provisionerLabels" . | nindent 4 }}
     {{- with .Values.enterprise.provisioner.labels }}

--- a/production/helm/loki/templates/provisioner/rolebinding-provisioner.yaml
+++ b/production/helm/loki/templates/provisioner/rolebinding-provisioner.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ template "enterprise-logs.provisionerFullname" . }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "enterprise-logs.provisionerLabels" . | nindent 4 }}
     {{- with .Values.enterprise.provisioner.labels }}
@@ -22,5 +22,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "enterprise-logs.provisionerFullname" . }}
-    namespace: {{ $.Release.Namespace }}
+    namespace: {{ include "loki.namespace" . }}
 {{- end }}

--- a/production/helm/loki/templates/provisioner/serviceaccount-provisioner.yaml
+++ b/production/helm/loki/templates/provisioner/serviceaccount-provisioner.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "enterprise-logs.provisionerFullname" . }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "enterprise-logs.provisionerLabels" . | nindent 4 }}
     {{- with .Values.enterprise.provisioner.labels }}

--- a/production/helm/loki/templates/read/deployment-read.yaml
+++ b/production/helm/loki/templates/read/deployment-read.yaml
@@ -5,7 +5,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "loki.readFullname" . }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     app.kubernetes.io/part-of: memberlist
     {{- include "loki.readLabels" . | nindent 4 }}

--- a/production/helm/loki/templates/read/poddisruptionbudget-read.yaml
+++ b/production/helm/loki/templates/read/poddisruptionbudget-read.yaml
@@ -4,7 +4,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "loki.readFullname" . }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.readLabels" . | nindent 4 }}
 spec:

--- a/production/helm/loki/templates/read/service-read-headless.yaml
+++ b/production/helm/loki/templates/read/service-read-headless.yaml
@@ -5,7 +5,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "loki.readFullname" . }}-headless
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.readSelectorLabels" . | nindent 4 }}
     {{- with .Values.loki.serviceLabels }}

--- a/production/helm/loki/templates/read/service-read.yaml
+++ b/production/helm/loki/templates/read/service-read.yaml
@@ -5,7 +5,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "loki.readFullname" . }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.readLabels" . | nindent 4 }}
     {{- with .Values.loki.serviceLabels }}

--- a/production/helm/loki/templates/read/statefulset-read.yaml
+++ b/production/helm/loki/templates/read/statefulset-read.yaml
@@ -5,7 +5,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "loki.readFullname" . }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     app.kubernetes.io/part-of: memberlist
     {{- include "loki.readLabels" . | nindent 4 }}

--- a/production/helm/loki/templates/role.yaml
+++ b/production/helm/loki/templates/role.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "loki.name" . }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.labels" . | nindent 4 }}
 {{- if .Values.rbac.pspEnabled }}

--- a/production/helm/loki/templates/rolebinding.yaml
+++ b/production/helm/loki/templates/rolebinding.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "loki.name" . }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.labels" . | nindent 4 }}
 roleRef:
@@ -13,5 +13,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ include "loki.serviceAccountName" . }}
-    namespace: {{ $.Release.Namespace }}
+    namespace: {{ include "loki.namespace" . }}
 {{- end }}

--- a/production/helm/loki/templates/runtime-configmap.yaml
+++ b/production/helm/loki/templates/runtime-configmap.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "loki.name" . }}-runtime
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.labels" . | nindent 4 }}
 data:

--- a/production/helm/loki/templates/secret-license.yaml
+++ b/production/helm/loki/templates/secret-license.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: enterprise-logs-license
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.labels" . | nindent 4 }}
 data:

--- a/production/helm/loki/templates/service-memberlist.yaml
+++ b/production/helm/loki/templates/service-memberlist.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "loki.memberlist" . }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.labels" . | nindent 4 }}
 spec:

--- a/production/helm/loki/templates/serviceaccount.yaml
+++ b/production/helm/loki/templates/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "loki.serviceAccountName" . }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.labels }}

--- a/production/helm/loki/templates/single-binary/pdb.yaml
+++ b/production/helm/loki/templates/single-binary/pdb.yaml
@@ -5,7 +5,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "loki.fullname" . }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.labels" . | nindent 4 }}
 spec:

--- a/production/helm/loki/templates/single-binary/service-headless.yaml
+++ b/production/helm/loki/templates/single-binary/service-headless.yaml
@@ -5,7 +5,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "loki.name" . }}-headless
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.labels" . | nindent 4 }}
     {{- with .Values.loki.serviceLabels }}

--- a/production/helm/loki/templates/single-binary/service.yaml
+++ b/production/helm/loki/templates/single-binary/service.yaml
@@ -5,7 +5,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "loki.singleBinaryFullname" . }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.labels" . | nindent 4 }}
     {{- with .Values.loki.serviceLabels }}

--- a/production/helm/loki/templates/single-binary/statefulset.yaml
+++ b/production/helm/loki/templates/single-binary/statefulset.yaml
@@ -5,7 +5,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "loki.singleBinaryFullname" . }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.singleBinaryLabels" . | nindent 4 }}
     app.kubernetes.io/part-of: memberlist

--- a/production/helm/loki/templates/tests/test-canary.yaml
+++ b/production/helm/loki/templates/tests/test-canary.yaml
@@ -5,7 +5,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: "{{ include "loki.name" $ }}-helm-test"
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ default $.Release.Namespace $.Values.namespaceOverride | trunc 63 | trimSuffix "-" }}
   labels:
     {{- include "loki.helmTestLabels" $ | nindent 4 }}
     {{- with .labels }}

--- a/production/helm/loki/templates/tokengen/clusterrolebinding-tokengen.yaml
+++ b/production/helm/loki/templates/tokengen/clusterrolebinding-tokengen.yaml
@@ -21,5 +21,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "enterprise-logs.tokengenFullname" . }}
-    namespace: {{ $.Release.Namespace }}
+    namespace: {{ include "loki.namespace" . }}
 {{- end }}

--- a/production/helm/loki/templates/tokengen/job-tokengen.yaml
+++ b/production/helm/loki/templates/tokengen/job-tokengen.yaml
@@ -4,7 +4,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ template "enterprise-logs.tokengenFullname" . }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "enterprise-logs.tokengenLabels" . | nindent 4 }}
     {{- with .Values.enterprise.tokengen.labels }}

--- a/production/helm/loki/templates/tokengen/serviceaccount-tokengen.yaml
+++ b/production/helm/loki/templates/tokengen/serviceaccount-tokengen.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "enterprise-logs.tokengenFullname" . }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "enterprise-logs.tokengenLabels" . | nindent 4 }}
     {{- with .Values.enterprise.tokengen.labels }}

--- a/production/helm/loki/templates/write/hpa.yaml
+++ b/production/helm/loki/templates/write/hpa.yaml
@@ -9,7 +9,7 @@ apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "loki.writeFullname" . }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.writeLabels" . | nindent 4 }}
 spec:

--- a/production/helm/loki/templates/write/poddisruptionbudget-write.yaml
+++ b/production/helm/loki/templates/write/poddisruptionbudget-write.yaml
@@ -4,7 +4,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "loki.writeFullname" . }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.writeLabels" . | nindent 4 }}
 spec:

--- a/production/helm/loki/templates/write/service-write-headless.yaml
+++ b/production/helm/loki/templates/write/service-write-headless.yaml
@@ -5,7 +5,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "loki.writeFullname" . }}-headless
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.writeSelectorLabels" . | nindent 4 }}
     {{- with .Values.loki.serviceLabels }}

--- a/production/helm/loki/templates/write/service-write.yaml
+++ b/production/helm/loki/templates/write/service-write.yaml
@@ -5,7 +5,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "loki.writeFullname" . }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.writeLabels" . | nindent 4 }}
     {{- with .Values.loki.serviceLabels }}

--- a/production/helm/loki/templates/write/statefulset-write.yaml
+++ b/production/helm/loki/templates/write/statefulset-write.yaml
@@ -5,7 +5,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "loki.writeFullname" . }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.writeLabels" . | nindent 4 }}
     app.kubernetes.io/part-of: memberlist

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -14,6 +14,8 @@ global:
 nameOverride: null
 # -- Overrides the chart's computed fullname
 fullnameOverride: null
+# -- Overrides the chart's computed fullname
+namespaceOverride: &namespaceOverride null
 # -- Overrides the chart's cluster label
 clusterLabelOverride: null
 # -- Image pull secrets for Docker images
@@ -656,7 +658,7 @@ monitoring:
       name: "self-monitoring"
       # -- Namespace to create additional tenant token secret in. Useful if your Grafana instance
       # is in a separate namespace. Token will still be created in the canary namespace.
-      secretNamespace: "{{ .Release.Namespace }}"
+      secretNamespace: "{{ default .Release.Namespace *namespaceOverride }}"
     # Grafana Agent configuration
     grafanaAgent:
       # -- Controls whether to install the Grafana Agent Operator and its CRDs.


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR introduces support for overriding Helm namespace in multi-chart deployments (via Dependencies). With the new value `namespaceOverride` users can now define arbitrary namespaces, independent from the main release namespace.

**Special notes for your reviewer**:

Due to a Helm limitation, it is not possible to use the helper function inside {{with}} blocks.

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [X] Documentation added
- [X] `CHANGELOG.md` updated
  - [X] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [X] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
