### PR TITLE
test: gcs object client test data race

### DIFF
--- a/pkg/storage/chunk/client/gcp/gcs_object_client.go
+++ b/pkg/storage/chunk/client/gcp/gcs_object_client.go
@@ -320,7 +320,8 @@ func gcsTransport(ctx context.Context, scope string, insecure bool, http2 bool, 
 	if insecure {
 		customTransport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 		// When using `insecure` (testing only), we add a fake API key as well to skip credential chain lookups.
-		transportOptions = append(transportOptions, option.WithAPIKey("insecure"))
+		//transportOptions = append(transportOptions, option.WithAPIKey("insecure"))
+		transportOptions = append(transportOptions, option.WithoutAuthentication())
 	}
 	if serviceAccount.String() != "" {
 		transportOptions = append(transportOptions, option.WithCredentialsJSON([]byte(serviceAccount.String())))

--- a/pkg/storage/chunk/client/gcp/gcs_object_client.go
+++ b/pkg/storage/chunk/client/gcp/gcs_object_client.go
@@ -319,8 +319,6 @@ func gcsTransport(ctx context.Context, scope string, insecure bool, http2 bool, 
 	transportOptions := []option.ClientOption{option.WithScopes(scope)}
 	if insecure {
 		customTransport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
-		// When using `insecure` (testing only), we add a fake API key as well to skip credential chain lookups.
-		//transportOptions = append(transportOptions, option.WithAPIKey("insecure"))
 		transportOptions = append(transportOptions, option.WithoutAuthentication())
 	}
 	if serviceAccount.String() != "" {


### PR DESCRIPTION
**What this PR does / why we need it**:

Before fix:
```
==================
WARNING: DATA RACE
Read at 0x00c00080b890 by goroutine 67:
  net/url.(*URL).Query()
      /opt/homebrew/Cellar/go/1.21.6/libexec/src/net/url/url.go:1115 +0x30
  google.golang.org/api/googleapi/transport.(*APIKey).RoundTrip()
      /Users/progers/dev/src/github.com/grafana/loki/vendor/google.golang.org/api/googleapi/transport/apikey.go:40 +0x108
  github.com/grafana/loki/pkg/storage/chunk/client/gcp.instrumentedTransport.RoundTrip()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/storage/chunk/client/gcp/instrumentation.go:76 +0x68
  github.com/grafana/loki/pkg/storage/chunk/client/gcp.(*instrumentedTransport).RoundTrip()
      <autogenerated>:1 +0x64
  github.com/grafana/loki/pkg/storage/chunk/client/hedging.(*limitedHedgingRoundTripper).RoundTrip()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/storage/chunk/client/hedging/hedging.go:144 +0x9c
  github.com/grafana/loki/pkg/storage/chunk/client/hedging.(*winnerTrackingRoundTripper).RoundTrip()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/storage/chunk/client/hedging/hedging.go:157 +0x60
  github.com/cristalhq/hedgedhttp.(*hedgedTransport).RoundTrip.func2()
      /Users/progers/dev/src/github.com/grafana/loki/vendor/github.com/cristalhq/hedgedhttp/hedged.go:211 +0x94
  github.com/cristalhq/hedgedhttp.runInPool.func1()
      /Users/progers/dev/src/github.com/grafana/loki/vendor/github.com/cristalhq/hedgedhttp/hedged.go:305 +0x38

Previous write at 0x00c00080b890 by goroutine 64:
  google.golang.org/api/googleapi/transport.(*APIKey).RoundTrip()
      /Users/progers/dev/src/github.com/grafana/loki/vendor/google.golang.org/api/googleapi/transport/apikey.go:42 +0x164
  github.com/grafana/loki/pkg/storage/chunk/client/gcp.instrumentedTransport.RoundTrip()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/storage/chunk/client/gcp/instrumentation.go:76 +0x68
  github.com/grafana/loki/pkg/storage/chunk/client/gcp.(*instrumentedTransport).RoundTrip()
      <autogenerated>:1 +0x64
  github.com/grafana/loki/pkg/storage/chunk/client/hedging.(*limitedHedgingRoundTripper).RoundTrip()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/storage/chunk/client/hedging/hedging.go:144 +0x9c
  github.com/grafana/loki/pkg/storage/chunk/client/hedging.(*winnerTrackingRoundTripper).RoundTrip()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/storage/chunk/client/hedging/hedging.go:157 +0x60
  github.com/cristalhq/hedgedhttp.(*hedgedTransport).RoundTrip.func2()
      /Users/progers/dev/src/github.com/grafana/loki/vendor/github.com/cristalhq/hedgedhttp/hedged.go:211 +0x94
  github.com/cristalhq/hedgedhttp.runInPool.func1()
      /Users/progers/dev/src/github.com/grafana/loki/vendor/github.com/cristalhq/hedgedhttp/hedged.go:305 +0x38
```

After fix:
```
go test . -race -count=20
ok  	github.com/grafana/loki/pkg/storage/chunk/client/gcp	28.149s
```
**Which issue(s) this PR fixes**:
Relates to: https://github.com/grafana/loki/issues/8586

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
