### PR TITLE
test: Update azure-storage-blob-go to include a data race fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -342,7 +342,7 @@ require (
 
 replace github.com/Azure/azure-sdk-for-go => github.com/Azure/azure-sdk-for-go v36.2.0+incompatible
 
-replace github.com/Azure/azure-storage-blob-go => github.com/MasslessParticle/azure-storage-blob-go v0.14.1-0.20220216145902-b5e698eff68e
+replace github.com/Azure/azure-storage-blob-go => github.com/MasslessParticle/azure-storage-blob-go v0.14.1-0.20240322194317-344980fda573
 
 replace github.com/hashicorp/consul => github.com/hashicorp/consul v1.14.5
 

--- a/go.sum
+++ b/go.sum
@@ -250,8 +250,6 @@ github.com/IBM/go-sdk-core/v5 v5.13.1/go.mod h1:pVkN7IGmsSdmR1ZCU4E/cLcCclqRKMYg
 github.com/IBM/ibm-cos-sdk-go v1.10.0 h1:/2VIev2/jBei39OqU2+nSZQnoWJ+KtkiSAIDkqsd7uU=
 github.com/IBM/ibm-cos-sdk-go v1.10.0/go.mod h1:C8KRTRaoD3CWPPBOa6FCOpdh0ZMlUjKAAA4i3F+Q/sc=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
-github.com/MasslessParticle/azure-storage-blob-go v0.14.1-0.20220216145902-b5e698eff68e h1:HisBR+gQKIwJqDe1iNVqUDk+GTRE2IZAbl+fLoDKNBs=
-github.com/MasslessParticle/azure-storage-blob-go v0.14.1-0.20220216145902-b5e698eff68e/go.mod h1:SMqIBi+SuiQH32bvyjngEewEeXoPfKMgWlBDaYf6fck=
 github.com/MasslessParticle/azure-storage-blob-go v0.14.1-0.20240322194317-344980fda573 h1:DCPjdUAi+jcGnL7iN+A7uNY8xG584oMRuisYh/VE21E=
 github.com/MasslessParticle/azure-storage-blob-go v0.14.1-0.20240322194317-344980fda573/go.mod h1:SMqIBi+SuiQH32bvyjngEewEeXoPfKMgWlBDaYf6fck=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=

--- a/go.sum
+++ b/go.sum
@@ -252,6 +252,8 @@ github.com/IBM/ibm-cos-sdk-go v1.10.0/go.mod h1:C8KRTRaoD3CWPPBOa6FCOpdh0ZMlUjKA
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/MasslessParticle/azure-storage-blob-go v0.14.1-0.20220216145902-b5e698eff68e h1:HisBR+gQKIwJqDe1iNVqUDk+GTRE2IZAbl+fLoDKNBs=
 github.com/MasslessParticle/azure-storage-blob-go v0.14.1-0.20220216145902-b5e698eff68e/go.mod h1:SMqIBi+SuiQH32bvyjngEewEeXoPfKMgWlBDaYf6fck=
+github.com/MasslessParticle/azure-storage-blob-go v0.14.1-0.20240322194317-344980fda573 h1:DCPjdUAi+jcGnL7iN+A7uNY8xG584oMRuisYh/VE21E=
+github.com/MasslessParticle/azure-storage-blob-go v0.14.1-0.20240322194317-344980fda573/go.mod h1:SMqIBi+SuiQH32bvyjngEewEeXoPfKMgWlBDaYf6fck=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver/v3 v3.2.0 h1:3MEsd0SM6jqZojhjLWWeBY+Kcjy9i6MQAeY7YgDP83g=

--- a/vendor/github.com/Azure/azure-storage-blob-go/azblob/chunkwriting.go
+++ b/vendor/github.com/Azure/azure-storage-blob-go/azblob/chunkwriting.go
@@ -188,8 +188,11 @@ func (c *copier) close() error {
 // waitForFinish waits for all writes to complete while combining errors from errCh
 func (c *copier) waitForFinish() error {
 	var err error
+	var mu sync.Mutex
 	done := make(chan struct{})
+	mu.Lock()
 	go func() {
+		defer mu.Unlock()
 		// when write latencies are long, several errors might have occurred
 		// drain them all as we wait for writes to complete.
 		err = c.drainErrs(done)
@@ -197,6 +200,9 @@ func (c *copier) waitForFinish() error {
 
 	c.wg.Wait()
 	close(done)
+
+	mu.Lock()
+	defer mu.Unlock()
 	return err
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -104,7 +104,7 @@ github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/internal/shared
 github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/pageblob
 github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/sas
 github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/service
-# github.com/Azure/azure-storage-blob-go v0.14.0 => github.com/MasslessParticle/azure-storage-blob-go v0.14.1-0.20220216145902-b5e698eff68e
+# github.com/Azure/azure-storage-blob-go v0.14.0 => github.com/MasslessParticle/azure-storage-blob-go v0.14.1-0.20240322194317-344980fda573
 ## explicit; go 1.15
 github.com/Azure/azure-storage-blob-go/azblob
 # github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1
@@ -2260,7 +2260,7 @@ sigs.k8s.io/structured-merge-diff/v4/value
 ## explicit; go 1.12
 sigs.k8s.io/yaml
 # github.com/Azure/azure-sdk-for-go => github.com/Azure/azure-sdk-for-go v36.2.0+incompatible
-# github.com/Azure/azure-storage-blob-go => github.com/MasslessParticle/azure-storage-blob-go v0.14.1-0.20220216145902-b5e698eff68e
+# github.com/Azure/azure-storage-blob-go => github.com/MasslessParticle/azure-storage-blob-go v0.14.1-0.20240322194317-344980fda573
 # github.com/hashicorp/consul => github.com/hashicorp/consul v1.14.5
 # github.com/gocql/gocql => github.com/grafana/gocql v0.0.0-20200605141915-ba5dc39ece85
 # github.com/hashicorp/memberlist => github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe


### PR DESCRIPTION
**What this PR does / why we need it**:
Pulls in a data race fix for the azure-storage-blob library.  External fork PR fix is: https://github.com/MasslessParticle/azure-storage-blob-go/pull/1

Before fix:
```
go test -race -count=1 .
==================
WARNING: DATA RACE
Write at 0x00c00061f5d0 by goroutine 46:
  github.com/Azure/azure-storage-blob-go/azblob.(*copier).waitForFinish.func1()
      /Users/progers/dev/src/github.com/grafana/loki/vendor/github.com/Azure/azure-storage-blob-go/azblob/chunkwriting.go:195 +0x50

Previous read at 0x00c00061f5d0 by goroutine 37:
  github.com/Azure/azure-storage-blob-go/azblob.(*copier).waitForFinish()
      /Users/progers/dev/src/github.com/grafana/loki/vendor/github.com/Azure/azure-storage-blob-go/azblob/chunkwriting.go:200 +0x168
  github.com/Azure/azure-storage-blob-go/azblob.(*copier).close()
      /Users/progers/dev/src/github.com/grafana/loki/vendor/github.com/Azure/azure-storage-blob-go/azblob/chunkwriting.go:179 +0x30
  github.com/Azure/azure-storage-blob-go/azblob.copyFromReader()
      /Users/progers/dev/src/github.com/grafana/loki/vendor/github.com/Azure/azure-storage-blob-go/azblob/chunkwriting.go:64 +0x360
  github.com/Azure/azure-storage-blob-go/azblob.UploadStreamToBlockBlob()
      /Users/progers/dev/src/github.com/grafana/loki/vendor/github.com/Azure/azure-storage-blob-go/azblob/highlevel.go:553 +0x104
  github.com/grafana/loki/pkg/storage/chunk/client/azure.(*BlobStorage).PutObject.func1()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/storage/chunk/client/azure/blob_storage_client.go:290 +0x200
  github.com/grafana/loki/pkg/util/instrument.TimeRequest()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/util/instrument/instrument.go:20 +0xac
  github.com/grafana/loki/pkg/storage/chunk/client/azure.(*BlobStorage).PutObject()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/storage/chunk/client/azure/blob_storage_client.go:282 +0x134
  github.com/grafana/loki/pkg/storage/chunk/client/azure.Test_Hedging.func1()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/storage/chunk/client/azure/blob_storage_client_test.go:99 +0x154
  github.com/grafana/loki/pkg/storage/chunk/client/azure.Test_Hedging.func4()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/storage/chunk/client/azure/blob_storage_client_test.go:148 +0x278
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.21.6/libexec/src/testing/testing.go:1595 +0x1b0
  testing.(*T).Run.func1()
      /opt/homebrew/Cellar/go/1.21.6/libexec/src/testing/testing.go:1648 +0x40

Goroutine 46 (running) created at:
  github.com/Azure/azure-storage-blob-go/azblob.(*copier).waitForFinish()
      /Users/progers/dev/src/github.com/grafana/loki/vendor/github.com/Azure/azure-storage-blob-go/azblob/chunkwriting.go:192 +0x148
  github.com/Azure/azure-storage-blob-go/azblob.(*copier).close()
      /Users/progers/dev/src/github.com/grafana/loki/vendor/github.com/Azure/azure-storage-blob-go/azblob/chunkwriting.go:179 +0x30
  github.com/Azure/azure-storage-blob-go/azblob.copyFromReader()
      /Users/progers/dev/src/github.com/grafana/loki/vendor/github.com/Azure/azure-storage-blob-go/azblob/chunkwriting.go:64 +0x360
  github.com/Azure/azure-storage-blob-go/azblob.UploadStreamToBlockBlob()
      /Users/progers/dev/src/github.com/grafana/loki/vendor/github.com/Azure/azure-storage-blob-go/azblob/highlevel.go:553 +0x104
  github.com/grafana/loki/pkg/storage/chunk/client/azure.(*BlobStorage).PutObject.func1()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/storage/chunk/client/azure/blob_storage_client.go:290 +0x200
  github.com/grafana/loki/pkg/util/instrument.TimeRequest()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/util/instrument/instrument.go:20 +0xac
  github.com/grafana/loki/pkg/storage/chunk/client/azure.(*BlobStorage).PutObject()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/storage/chunk/client/azure/blob_storage_client.go:282 +0x134
  github.com/grafana/loki/pkg/storage/chunk/client/azure.Test_Hedging.func1()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/storage/chunk/client/azure/blob_storage_client_test.go:99 +0x154
  github.com/grafana/loki/pkg/storage/chunk/client/azure.Test_Hedging.func4()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/storage/chunk/client/azure/blob_storage_client_test.go:148 +0x278
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.21.6/libexec/src/testing/testing.go:1595 +0x1b0
  testing.(*T).Run.func1()
      /opt/homebrew/Cellar/go/1.21.6/libexec/src/testing/testing.go:1648 +0x40

Goroutine 37 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.21.6/libexec/src/testing/testing.go:1648 +0x5e8
  github.com/grafana/loki/pkg/storage/chunk/client/azure.Test_Hedging()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/storage/chunk/client/azure/blob_storage_client_test.go:122 +0x190
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.21.6/libexec/src/testing/testing.go:1595 +0x1b0
  testing.(*T).Run.func1()
      /opt/homebrew/Cellar/go/1.21.6/libexec/src/testing/testing.go:1648 +0x40
==================
--- FAIL: Test_Hedging (0.26s)
    --- FAIL: Test_Hedging/delete/put/list_are_not_hedged (0.16s)
        testing.go:1465: race detected during execution of test
    testing.go:1465: race detected during execution of test
FAIL
FAIL	github.com/grafana/loki/pkg/storage/chunk/client/azure	0.742s
FAIL
```
After fix:
```
go test -race -count=10 .
ok  	github.com/grafana/loki/pkg/storage/chunk/client/azure	4.177s

```
**Which issue(s) this PR fixes**:
Relates to: https://github.com/grafana/loki/issues/8586

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
