### PR TITLE
fix: don't shard `quantile_over_time` if it's not the top level aggregation for a query

### DIFF
--- a/pkg/logql/shardmapper.go
+++ b/pkg/logql/shardmapper.go
@@ -89,13 +89,13 @@ func (m ShardMapper) Map(expr syntax.Expr, r *downstreamRecorder, topLevel bool)
 	case *syntax.MatchersExpr, *syntax.PipelineExpr:
 		return m.mapLogSelectorExpr(e.(syntax.LogSelectorExpr), r)
 	case *syntax.VectorAggregationExpr:
-		return m.mapVectorAggregationExpr(e, r, false)
+		return m.mapVectorAggregationExpr(e, r, topLevel)
 	case *syntax.LabelReplaceExpr:
 		return m.mapLabelReplaceExpr(e, r, topLevel)
 	case *syntax.RangeAggregationExpr:
 		return m.mapRangeAggregationExpr(e, r, topLevel)
 	case *syntax.BinOpExpr:
-		return m.mapBinOpExpr(e, r, true)
+		return m.mapBinOpExpr(e, r, topLevel)
 	default:
 		return nil, 0, errors.Errorf("unexpected expr type (%T) for ASTMapper type (%T) ", expr, m)
 	}

--- a/pkg/logql/shardmapper_test.go
+++ b/pkg/logql/shardmapper_test.go
@@ -118,9 +118,18 @@ func TestMappingStrings(t *testing.T) {
 		in  string
 		out string
 	}{
-		{ // We shouldn't shard max if the inner operation is a quantile_over_time.
+		// NOTE (callum):These two queries containing quantile_over_time should result in
+		// the same unsharded of the max and not the inner quantile regardless of whether
+		// quantile sharding is turned on. This should be the case even if the inner quantile
+		// does not contain a grouping until we decide whether to do the further optimization
+		// of sharding the inner quantile.
+		{
 			in:  `max by (status)(quantile_over_time(0.70, {a=~".+"} | logfmt | unwrap value [1s]))`,
 			out: `maxby(status)(quantile_over_time(0.7,{a=~".+"}|logfmt|unwrapvalue[1s]))`,
+		},
+		{
+			in:  `max by (status)(quantile_over_time(0.70, {a=~".+"} | logfmt | unwrap value [1s]) by (baz))`,
+			out: `maxby(status)(quantile_over_time(0.7,{a=~".+"}|logfmt|unwrapvalue[1s])by(baz))`,
 		},
 		{
 			in: `{foo="bar"}`,
@@ -367,10 +376,6 @@ func TestMappingStrings(t *testing.T) {
 				)
 			)`,
 		},
-		{ // This should result in the same downstream sharding of the max and not the inner quantile regardless of whether quantile sharding is turned on.
-			in:  `max by (status)(quantile_over_time(0.70, {a=~".+"} | logfmt | unwrap value [1s]))`,
-			out: `maxby(status)(downstream<maxby(status)(quantile_over_time(0.7,{a=~".+"}|logfmt|unwrapvalue[1s])),shard=0_of_2>++downstream<maxby(status)(quantile_over_time(0.7,{a=~".+"}|logfmt|unwrapvalue[1s])),shard=1_of_2>)`,
-		},
 		// should be noop if VectorExpr
 		{
 			in:  `vector(0)`,
@@ -428,28 +433,44 @@ func TestMappingStrings(t *testing.T) {
 // Test that mapping of queries for operation types that have probabilistic
 // sharding options, but whose sharding is turned off, are not sharded on those operations.
 func TestMappingStrings_NoProbabilisticSharding(t *testing.T) {
-	m := NewShardMapper(ConstantShards(2), nilShardMetrics, []string{})
 	for _, tc := range []struct {
 		in  string
 		out string
 	}{
-		{ // This should result in the same downstream sharding of the max and not the inner quantile regardless of whether quantile sharding is turned on.
-			in:  `max by (status)(quantile_over_time(0.70, {a=~".+"} | logfmt | unwrap value [1s]))`,
-			out: `maxby(status)(downstream<maxby(status)(quantile_over_time(0.7,{a=~".+"}|logfmt|unwrapvalue[1s])),shard=0_of_2>++downstream<maxby(status)(quantile_over_time(0.7,{a=~".+"}|logfmt|unwrapvalue[1s])),shard=1_of_2>)`,
+		// NOTE (callum):These two queries containing quantile_over_time should result in
+		// the same unsharded of the max and not the inner quantile regardless of whether
+		// quantile sharding is turned on. This should be the case even if the inner quantile
+		// does not contain a grouping until we decide whether to do the further optimization
+		// of sharding the inner quantile.
+		{
+			in:  `max by (status)(quantile_over_time(0.70, {a=~".+"} | logfmt | unwrap value [1s]) by (baz))`,
+			out: `maxby(status)(quantile_over_time(0.7,{a=~".+"}|logfmt|unwrapvalue[1s])by(baz))`,
 		},
 		{
-			in:  `quantile_over_time(0.70, {a=~".+"} | logfmt | unwrap value [1s])`,
-			out: `quantile_over_time(0.7,{a=~".+"}|logfmt|unwrapvalue[1s])`,
+			in:  `max by (status)(quantile_over_time(0.70, {a=~".+"} | logfmt | unwrap value [1s]))`,
+			out: `maxby(status)(quantile_over_time(0.7,{a=~".+"}|logfmt|unwrapvalue[1s]))`,
 		},
 	} {
 		t.Run(tc.in, func(t *testing.T) {
+			shardedMapper := NewShardMapper(ConstantShards(2), nilShardMetrics, []string{ShardQuantileOverTime})
+
 			ast, err := syntax.ParseExpr(tc.in)
 			require.Nil(t, err)
 
-			mapped, _, err := m.Map(ast, nilShardMetrics.downstreamRecorder())
+			sharded, _, err := shardedMapper.Map(ast, nilShardMetrics.downstreamRecorder(), true)
 			require.Nil(t, err)
 
-			require.Equal(t, removeWhiteSpace(tc.out), removeWhiteSpace(mapped.String()))
+			require.Equal(t, removeWhiteSpace(tc.out), removeWhiteSpace(sharded.String()))
+
+			unshardedMapper := NewShardMapper(ConstantShards(2), nilShardMetrics, []string{})
+
+			ast, err = syntax.ParseExpr(tc.in)
+			require.Nil(t, err)
+
+			unsharded, _, err := unshardedMapper.Map(ast, nilShardMetrics.downstreamRecorder(), true)
+			require.Nil(t, err)
+
+			require.Equal(t, removeWhiteSpace(tc.out), removeWhiteSpace(unsharded.String()))
 		})
 	}
 }
@@ -1374,6 +1395,22 @@ func TestMapping(t *testing.T) {
 							next: nil,
 						},
 					},
+				},
+			},
+		},
+		{
+			in: `quantile_over_time(0.8, {foo="bar"} | unwrap bytes [5m])`,
+			expr: &syntax.RangeAggregationExpr{
+				Operation: syntax.OpRangeTypeQuantile,
+				Params:    float64p(0.8),
+				Left: &syntax.LogRange{
+					Left: &syntax.MatchersExpr{
+						Mts: []*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")},
+					},
+					Unwrap: &syntax.UnwrapExpr{
+						Identifier: "bytes",
+					},
+					Interval: 5 * time.Minute,
 				},
 			},
 		},

--- a/pkg/logql/shardmapper_test.go
+++ b/pkg/logql/shardmapper_test.go
@@ -118,6 +118,10 @@ func TestMappingStrings(t *testing.T) {
 		in  string
 		out string
 	}{
+		{ // We shouldn't shard max if the inner operation is a quantile_over_time.
+			in:  `max by (status)(quantile_over_time(0.70, {a=~".+"} | logfmt | unwrap value [1s]))`,
+			out: `maxby(status)(quantile_over_time(0.7,{a=~".+"}|logfmt|unwrapvalue[1s]))`,
+		},
 		{
 			in: `{foo="bar"}`,
 			out: `downstream<{foo="bar"}, shard=0_of_2>
@@ -413,7 +417,7 @@ func TestMappingStrings(t *testing.T) {
 			ast, err := syntax.ParseExpr(tc.in)
 			require.Nil(t, err)
 
-			mapped, _, err := m.Map(ast, nilShardMetrics.downstreamRecorder())
+			mapped, _, err := m.Map(ast, nilShardMetrics.downstreamRecorder(), true)
 			require.Nil(t, err)
 
 			require.Equal(t, removeWhiteSpace(tc.out), removeWhiteSpace(mapped.String()))
@@ -1546,7 +1550,7 @@ func TestMapping(t *testing.T) {
 			ast, err := syntax.ParseExpr(tc.in)
 			require.Equal(t, tc.err, err)
 
-			mapped, _, err := m.Map(ast, nilShardMetrics.downstreamRecorder())
+			mapped, _, err := m.Map(ast, nilShardMetrics.downstreamRecorder(), true)
 			switch e := mapped.(type) {
 			case syntax.SampleExpr:
 				optimized, err := optimizeSampleExpr(e)

--- a/pkg/logql/syntax/ast.go
+++ b/pkg/logql/syntax/ast.go
@@ -1338,6 +1338,10 @@ func (e *RangeAggregationExpr) String() string {
 
 // impl SampleExpr
 func (e *RangeAggregationExpr) Shardable(topLevel bool) bool {
+	// Here we are blocking sharding of quantile operations if they are not
+	// the top level aggregation in a query, such as max(quantile_over_time(...)).
+	// The sharding here will be blocked even if the feature flag in the shardmapper
+	// to enable sharding of quantile queries is enabled.
 	if e.Operation == OpRangeTypeQuantile && !topLevel {
 		return false
 	}

--- a/pkg/logql/syntax/ast.go
+++ b/pkg/logql/syntax/ast.go
@@ -25,8 +25,8 @@ import (
 //
 //sumtype:decl
 type Expr interface {
-	logQLExpr()      // ensure it's not implemented accidentally
-	Shardable() bool // A recursive check on the AST to see if it's shardable.
+	logQLExpr()                   // ensure it's not implemented accidentally
+	Shardable(topLevel bool) bool // A recursive check on the AST to see if it's shardable.
 	Walkable
 	fmt.Stringer
 	AcceptVisitor
@@ -231,7 +231,7 @@ func (e *MatchersExpr) AppendMatchers(m []*labels.Matcher) {
 	e.Mts = append(e.Mts, m...)
 }
 
-func (e *MatchersExpr) Shardable() bool { return true }
+func (e *MatchersExpr) Shardable(_ bool) bool { return true }
 
 func (e *MatchersExpr) Walk(f WalkFn) { f(e) }
 
@@ -273,9 +273,9 @@ func newPipelineExpr(left *MatchersExpr, pipeline MultiStageExpr) LogSelectorExp
 
 func (e *PipelineExpr) isLogSelectorExpr() {}
 
-func (e *PipelineExpr) Shardable() bool {
+func (e *PipelineExpr) Shardable(topLevel bool) bool {
 	for _, p := range e.MultiStages {
-		if !p.Shardable() {
+		if !p.Shardable(topLevel) {
 			return false
 		}
 	}
@@ -402,7 +402,7 @@ func AddFilterExpr(expr LogSelectorExpr, ty labels.MatchType, op, match string) 
 	}
 }
 
-func (e *LineFilterExpr) Shardable() bool { return true }
+func (e *LineFilterExpr) Shardable(_ bool) bool { return true }
 
 func (e *LineFilterExpr) String() string {
 	var sb strings.Builder
@@ -534,7 +534,7 @@ func newLogfmtParserExpr(flags []string) *LogfmtParserExpr {
 
 func (*LogfmtParserExpr) isStageExpr() {}
 
-func (e *LogfmtParserExpr) Shardable() bool { return true }
+func (e *LogfmtParserExpr) Shardable(_ bool) bool { return true }
 
 func (e *LogfmtParserExpr) Walk(f WalkFn) { f(e) }
 
@@ -591,7 +591,7 @@ func newLabelParserExpr(op, param string) *LabelParserExpr {
 
 func (*LabelParserExpr) isStageExpr() {}
 
-func (e *LabelParserExpr) Shardable() bool { return true }
+func (e *LabelParserExpr) Shardable(_ bool) bool { return true }
 
 func (e *LabelParserExpr) Walk(f WalkFn) { f(e) }
 
@@ -640,7 +640,7 @@ func newLabelFilterExpr(filterer log.LabelFilterer) *LabelFilterExpr {
 
 func (*LabelFilterExpr) isStageExpr() {}
 
-func (e *LabelFilterExpr) Shardable() bool { return true }
+func (e *LabelFilterExpr) Shardable(_ bool) bool { return true }
 
 func (e *LabelFilterExpr) Walk(f WalkFn) { f(e) }
 
@@ -681,7 +681,7 @@ func newDecolorizeExpr() *DecolorizeExpr {
 
 func (*DecolorizeExpr) isStageExpr() {}
 
-func (e *DecolorizeExpr) Shardable() bool { return true }
+func (e *DecolorizeExpr) Shardable(_ bool) bool { return true }
 
 func (e *DecolorizeExpr) Stage() (log.Stage, error) {
 	return log.NewDecolorizer()
@@ -704,7 +704,7 @@ func newDropLabelsExpr(dropLabels []log.DropLabel) *DropLabelsExpr {
 
 func (*DropLabelsExpr) isStageExpr() {}
 
-func (e *DropLabelsExpr) Shardable() bool { return true }
+func (e *DropLabelsExpr) Shardable(_ bool) bool { return true }
 
 func (e *DropLabelsExpr) Stage() (log.Stage, error) {
 	return log.NewDropLabels(e.dropLabels), nil
@@ -746,7 +746,7 @@ func newKeepLabelsExpr(keepLabels []log.KeepLabel) *KeepLabelsExpr {
 
 func (*KeepLabelsExpr) isStageExpr() {}
 
-func (e *KeepLabelsExpr) Shardable() bool { return true }
+func (e *KeepLabelsExpr) Shardable(_ bool) bool { return true }
 
 func (e *KeepLabelsExpr) Stage() (log.Stage, error) {
 	return log.NewKeepLabels(e.keepLabels), nil
@@ -781,7 +781,7 @@ func (e *KeepLabelsExpr) Accept(v RootVisitor) { v.VisitKeepLabel(e) }
 
 func (*LineFmtExpr) isStageExpr() {}
 
-func (e *LineFmtExpr) Shardable() bool { return true }
+func (e *LineFmtExpr) Shardable(_ bool) bool { return true }
 
 func (e *LineFmtExpr) Walk(f WalkFn) { f(e) }
 
@@ -808,7 +808,7 @@ func newLabelFmtExpr(fmts []log.LabelFmt) *LabelFmtExpr {
 
 func (*LabelFmtExpr) isStageExpr() {}
 
-func (e *LabelFmtExpr) Shardable() bool {
+func (e *LabelFmtExpr) Shardable(_ bool) bool {
 	// While LabelFmt is shardable in certain cases, it is not always,
 	// but this is left to the shardmapper to determine
 	return true
@@ -856,7 +856,7 @@ func newJSONExpressionParser(expressions []log.LabelExtractionExpr) *JSONExpress
 
 func (*JSONExpressionParser) isStageExpr() {}
 
-func (j *JSONExpressionParser) Shardable() bool { return true }
+func (j *JSONExpressionParser) Shardable(_ bool) bool { return true }
 
 func (j *JSONExpressionParser) Walk(f WalkFn) { f(j) }
 
@@ -912,7 +912,7 @@ func newLogfmtExpressionParser(expressions []log.LabelExtractionExpr, flags []st
 
 func (*LogfmtExpressionParser) isStageExpr() {}
 
-func (l *LogfmtExpressionParser) Shardable() bool { return true }
+func (l *LogfmtExpressionParser) Shardable(_ bool) bool { return true }
 
 func (l *LogfmtExpressionParser) Walk(f WalkFn) { f(l) }
 
@@ -1033,7 +1033,7 @@ func (r LogRange) String() string {
 	return sb.String()
 }
 
-func (r *LogRange) Shardable() bool { return r.Left.Shardable() }
+func (r *LogRange) Shardable(topLevel bool) bool { return r.Left.Shardable(topLevel) }
 
 func (r *LogRange) Walk(f WalkFn) {
 	f(r)
@@ -1337,8 +1337,11 @@ func (e *RangeAggregationExpr) String() string {
 }
 
 // impl SampleExpr
-func (e *RangeAggregationExpr) Shardable() bool {
-	return shardableOps[e.Operation] && e.Left.Shardable()
+func (e *RangeAggregationExpr) Shardable(topLevel bool) bool {
+	if e.Operation == OpRangeTypeQuantile && !topLevel {
+		return false
+	}
+	return shardableOps[e.Operation] && e.Left.Shardable(topLevel)
 }
 
 func (e *RangeAggregationExpr) Walk(f WalkFn) {
@@ -1496,8 +1499,8 @@ func (e *VectorAggregationExpr) String() string {
 }
 
 // impl SampleExpr
-func (e *VectorAggregationExpr) Shardable() bool {
-	if !shardableOps[e.Operation] || !e.Left.Shardable() {
+func (e *VectorAggregationExpr) Shardable(topLevel bool) bool {
+	if !shardableOps[e.Operation] || !e.Left.Shardable(topLevel) {
 		return false
 	}
 
@@ -1524,7 +1527,7 @@ func (e *VectorAggregationExpr) Shardable() bool {
 		// `max( max(sum(rate(shard1))) ++ max(sum(rate(shard2))) ... etc)`
 		// because it’s only taking the maximum from each shard,
 		// but we actually need to sum all the shards then put the max on top
-		if _, ok := e.Left.(*RangeAggregationExpr); ok {
+		if _, ok := e.Left.(*RangeAggregationExpr); ok && e.Left.Shardable(false) {
 			return true
 		}
 		return false
@@ -1654,7 +1657,7 @@ func (e *BinOpExpr) String() string {
 }
 
 // impl SampleExpr
-func (e *BinOpExpr) Shardable() bool {
+func (e *BinOpExpr) Shardable(topLevel bool) bool {
 	if e.Opts != nil && e.Opts.VectorMatching != nil {
 		matching := e.Opts.VectorMatching
 		// prohibit sharding when we're changing the label groupings,
@@ -1666,7 +1669,7 @@ func (e *BinOpExpr) Shardable() bool {
 			return false
 		}
 	}
-	return shardableOps[e.Op] && e.SampleExpr.Shardable() && e.RHS.Shardable()
+	return shardableOps[e.Op] && e.SampleExpr.Shardable(topLevel) && e.RHS.Shardable(topLevel)
 }
 
 func (e *BinOpExpr) Walk(f WalkFn) {
@@ -2006,7 +2009,7 @@ func (e *LiteralExpr) isSampleExpr()                           {}
 func (e *LiteralExpr) isLogSelectorExpr()                      {}
 func (e *LiteralExpr) Selector() (LogSelectorExpr, error)      { return e, e.err }
 func (e *LiteralExpr) HasFilter() bool                         { return false }
-func (e *LiteralExpr) Shardable() bool                         { return true }
+func (e *LiteralExpr) Shardable(_ bool) bool                   { return true }
 func (e *LiteralExpr) Walk(f WalkFn)                           { f(e) }
 func (e *LiteralExpr) Accept(v RootVisitor)                    { v.VisitLiteral(e) }
 func (e *LiteralExpr) Pipeline() (log.Pipeline, error)         { return log.NewNoopPipeline(), nil }
@@ -2093,7 +2096,7 @@ func (e *LabelReplaceExpr) Extractor() (SampleExtractor, error) {
 	return e.Left.Extractor()
 }
 
-func (e *LabelReplaceExpr) Shardable() bool {
+func (e *LabelReplaceExpr) Shardable(_ bool) bool {
 	return false
 }
 
@@ -2233,7 +2236,7 @@ func (e *VectorExpr) Value() (float64, error) {
 
 func (e *VectorExpr) Selector() (LogSelectorExpr, error)      { return e, e.err }
 func (e *VectorExpr) HasFilter() bool                         { return false }
-func (e *VectorExpr) Shardable() bool                         { return false }
+func (e *VectorExpr) Shardable(_ bool) bool                   { return false }
 func (e *VectorExpr) Walk(f WalkFn)                           { f(e) }
 func (e *VectorExpr) Accept(v RootVisitor)                    { v.VisitVector(e) }
 func (e *VectorExpr) Pipeline() (log.Pipeline, error)         { return log.NewNoopPipeline(), nil }


### PR DESCRIPTION
This PR adds the addition of a `top bool` parameter to mapping functions as well as the `Shardable` function for the Expression interface. This allows us to know whether the expression/operation we're currently deciding whether or not to shard is the top level aggregation for the entire query or not.

Currently we want to use this to signal that `quantile_over_time` is unshardable when it's not the top level query aggregation. This also results in something like `max by (x) (quantile_over_time...)` or  `max by (x) (quantile_over_time... by (y))` being unshardable instead of resulting in a query sharded on the `max`. We can also extend this to other probabilistic sharding operation types in the future, such as `topk`.

In the future we could allow sharding of the inner quantile resulting in pattern
```
maxby(foo)(quantileSketchEval<quantileSketchMerge<downstream<__quantile_sketch_over_time__(...)by(baz),shard=1_of_2>++downstream<__quantile_sketch_over_time__(...)by(baz),shard=0_of_2>>>)
```

but for now this is the safest path forward and unblocks shipping of a stable release + other important features.