### PR TITLE
docs: fix otlp guide - collector config example

### DIFF
--- a/docs/sources/send-data/otel/_index.md
+++ b/docs/sources/send-data/otel/_index.md
@@ -33,7 +33,7 @@ And enable it in `service.pipelines`:
 ```yaml
 service:
   pipelines:
-    metrics:
+    logs:
       receivers: [...]
       processors: [...]
       exporters: [..., otlphttp]
@@ -57,7 +57,7 @@ exporters:
 service:
   extensions: [basicauth/otlp]
   pipelines:
-    metrics:
+    logs:
       receivers: [...]
       processors: [...]
       exporters: [..., otlphttp]


### PR DESCRIPTION
**What this PR does / why we need it**:
- relates #5346

The current documentation seems to work, but the naming may cause confusion.
And not match [Collector docs](https://opentelemetry.io/docs/collector/) usage.

For example, consider the case where using loki and mimir

```yaml
service:
  pipelines:
    # its mimir
    metrics_:
      receivers: [otlp]
      processors: [batch]
      exporters: [otlphttp/mimir]
    # its loki❓
    metrics:
      receivers: [otlp]
      processors: [batch]
      exporters: [otlphttp/loki]
```

Perhaps following is the common naming:

```yaml
service:
  pipelines:
    # its mimir✅
    metrics_:
      receivers: [otlp]
      processors: [batch]
      exporters: [otlphttp/mimir]
    # its loki✅
    logs:
      receivers: [otlp]
      processors: [batch]
      exporters: [otlphttp/loki]
```

**Which issue(s) this PR fixes**:
- none.

**Special notes for your reviewer**:
- none.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
