### PR TITLE
fix(blooms): Extract only line filters before line format expressions

### DIFF
--- a/pkg/bloomgateway/bloomgateway.go
+++ b/pkg/bloomgateway/bloomgateway.go
@@ -218,7 +218,7 @@ func (g *Gateway) FilterChunkRefs(ctx context.Context, req *logproto.FilterChunk
 		return nil, errors.New("from time must not be after through time")
 	}
 
-	filters := syntax.ExtractLineFilters(req.Plan.AST)
+	filters := v1.ExtractTestableLineFilters(req.Plan.AST)
 	g.metrics.receivedFilters.Observe(float64(len(filters)))
 
 	// Shortcut if request does not contain filters

--- a/pkg/bloomgateway/querier.go
+++ b/pkg/bloomgateway/querier.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/grafana/loki/pkg/logproto"
 	"github.com/grafana/loki/pkg/querier/plan"
-	"github.com/grafana/loki/pkg/storage/bloom/v1"
+	v1 "github.com/grafana/loki/pkg/storage/bloom/v1"
 	"github.com/grafana/loki/pkg/util/constants"
 )
 

--- a/pkg/bloomgateway/querier.go
+++ b/pkg/bloomgateway/querier.go
@@ -10,8 +10,8 @@ import (
 	"github.com/prometheus/common/model"
 
 	"github.com/grafana/loki/pkg/logproto"
-	"github.com/grafana/loki/pkg/logql/syntax"
 	"github.com/grafana/loki/pkg/querier/plan"
+	"github.com/grafana/loki/pkg/storage/bloom/v1"
 	"github.com/grafana/loki/pkg/util/constants"
 )
 
@@ -73,7 +73,7 @@ func convertToShortRef(ref *logproto.ChunkRef) *logproto.ShortRef {
 
 func (bq *BloomQuerier) FilterChunkRefs(ctx context.Context, tenant string, from, through model.Time, chunkRefs []*logproto.ChunkRef, queryPlan plan.QueryPlan) ([]*logproto.ChunkRef, error) {
 	// Shortcut that does not require any filtering
-	if len(chunkRefs) == 0 || len(syntax.ExtractLineFilters(queryPlan.AST)) == 0 {
+	if len(chunkRefs) == 0 || len(v1.ExtractTestableLineFilters(queryPlan.AST)) == 0 {
 		return chunkRefs, nil
 	}
 

--- a/pkg/storage/bloom/v1/bloom_tester.go
+++ b/pkg/storage/bloom/v1/bloom_tester.go
@@ -35,6 +35,39 @@ func (b BloomTests) MatchesWithPrefixBuf(bloom filter.Checker, buf []byte, prefi
 	return true
 }
 
+// ExtractTestableLineFilters extracts all line filters from an expression
+// that can be tested against a bloom filter. This will skip any line filters
+// after a line format expression. A line format expression might add content
+// that the query later matches against, which can't be tested with a bloom filter.
+// E.g. For {app="fake"} |= "foo" | line_format "thisNewTextShouldMatch" |= "thisNewTextShouldMatch"
+// this function will return only the line filter for "foo" since the line filter for "thisNewTextShouldMatch"
+// wouldn't match against the bloom filter but should match against the query.
+func ExtractTestableLineFilters(expr syntax.Expr) []syntax.LineFilterExpr {
+	if expr == nil {
+		return nil
+	}
+
+	var filters []syntax.LineFilterExpr
+	var lineFmtFound bool
+	visitor := &syntax.DepthFirstTraversal{
+		VisitLineFilterFn: func(v syntax.RootVisitor, e *syntax.LineFilterExpr) {
+			if e != nil && !lineFmtFound {
+				filters = append(filters, *e)
+			}
+		},
+		VisitLineFmtFn: func(v syntax.RootVisitor, e *syntax.LineFmtExpr) {
+			if e != nil {
+				lineFmtFound = true
+			}
+		},
+	}
+	expr.Accept(visitor)
+	return filters
+}
+
+// FiltersToBloomTest converts a list of line filters to a BloomTest.
+// Note that all the line filters should be testable against a bloom filter.
+// Use ExtractTestableLineFilters to extract testable line filters from an expression.
 // TODO(owen-d): limits the number of bloom lookups run.
 // An arbitrarily high number can overconsume cpu and is a DoS vector.
 func FiltersToBloomTest(b NGramBuilder, filters ...syntax.LineFilterExpr) BloomTest {

--- a/pkg/storage/bloom/v1/bloom_tester_test.go
+++ b/pkg/storage/bloom/v1/bloom_tester_test.go
@@ -154,14 +154,19 @@ func TestFiltersToBloomTests(t *testing.T) {
 			bloom:       fakeBloom{"foo", "bar", "baz", "fuzz", "noz"},
 			expectMatch: false,
 		},
+		{
+			name:        "line filter after line format",
+			query:       `{app="fake"} |= "foo" | line_format "thisNewTextShouldMatch" |= "thisNewTextShouldMatch"`,
+			bloom:       fakeBloom{"foo"},
+			expectMatch: true,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			expr, err := syntax.ParseExpr(tc.query)
 			assert.NoError(t, err)
-			filters := syntax.ExtractLineFilters(expr)
+			filters := ExtractTestableLineFilters(expr)
 
 			bloomTests := FiltersToBloomTest(fakeNgramBuilder{}, filters...)
-
 			assert.Equal(t, tc.expectMatch, bloomTests.Matches(tc.bloom))
 		})
 	}

--- a/pkg/storage/stores/shipper/indexshipper/indexgateway/gateway.go
+++ b/pkg/storage/stores/shipper/indexshipper/indexgateway/gateway.go
@@ -18,7 +18,7 @@ import (
 	"github.com/grafana/loki/pkg/logproto"
 	"github.com/grafana/loki/pkg/logql/syntax"
 	"github.com/grafana/loki/pkg/querier/plan"
-	"github.com/grafana/loki/pkg/storage/bloom/v1"
+	v1 "github.com/grafana/loki/pkg/storage/bloom/v1"
 	"github.com/grafana/loki/pkg/storage/chunk"
 	"github.com/grafana/loki/pkg/storage/config"
 	"github.com/grafana/loki/pkg/storage/stores"

--- a/pkg/storage/stores/shipper/indexshipper/indexgateway/gateway.go
+++ b/pkg/storage/stores/shipper/indexshipper/indexgateway/gateway.go
@@ -18,6 +18,7 @@ import (
 	"github.com/grafana/loki/pkg/logproto"
 	"github.com/grafana/loki/pkg/logql/syntax"
 	"github.com/grafana/loki/pkg/querier/plan"
+	"github.com/grafana/loki/pkg/storage/bloom/v1"
 	"github.com/grafana/loki/pkg/storage/chunk"
 	"github.com/grafana/loki/pkg/storage/config"
 	"github.com/grafana/loki/pkg/storage/stores"
@@ -229,7 +230,7 @@ func (g *Gateway) GetChunkRef(ctx context.Context, req *logproto.GetChunkRefRequ
 
 	// Extract LineFiltersExpr from the plan. If there is none, we can short-circuit and return before making a req
 	// to the bloom-gateway (through the g.bloomQuerier)
-	if len(syntax.ExtractLineFilters(req.Plan.AST)) == 0 {
+	if len(v1.ExtractTestableLineFilters(req.Plan.AST)) == 0 {
 		return result, nil
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes a bug from #12035. Before this PR, we'd extract all line filter expression from a query and build bloom tests out of them. This would potentially break queries with a line filter after a line format expression.

For example, in the query `{app="fake"} |= "foo" | line_format "thisNewTextShouldMatch" |= "thisNewTextShouldMatch"` , the last line filter (` |= "thisNewTextShouldMatch"`) should always match since that text was added with the `line_format` expression before the fillter. Before this PR, the bloom tests would match `thisNewTextShouldMatch` against the blooms and would discard all chunks. As a result, the query would return no data.

In this PR we modify how we extract the line filters form a LogQL expression: we only extract (and thus build bloom tests) for all line filters before a line format expression. In the example above, we'd only build a bloom test for the line filter `|= "foo"`.

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
