### PR TITLE
fix(bloom-gateway): Close all block queriers in case of error

### DIFF
--- a/pkg/bloomgateway/processor.go
+++ b/pkg/bloomgateway/processor.go
@@ -97,13 +97,21 @@ func (p *processor) processBlocks(ctx context.Context, data []blockWithTasks) er
 		return err
 	}
 
+	defer func() {
+		for i := range bqs {
+			if bqs[i] == nil {
+				continue
+			}
+			bqs[i].Close()
+		}
+	}()
+
 	return concurrency.ForEachJob(ctx, len(bqs), p.concurrency, func(ctx context.Context, i int) error {
 		bq := bqs[i]
 		if bq == nil {
 			// TODO(chaudum): Add metric for skipped blocks
 			return nil
 		}
-		defer bq.Close()
 
 		block := data[i]
 		level.Debug(p.logger).Log(


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes the logic for closing block queriers retrieved from the `p.store.FetchBlocks()` call in case of an error.

Since `concurrency.ForEach()` returns on first errors, it happened that the remaining block queriers did not get closed.
