### PR TITLE
fix(ruler): pass noop analyseRules to rules manager

### DIFF
--- a/pkg/ruler/compat.go
+++ b/pkg/ruler/compat.go
@@ -349,12 +349,11 @@ func (exprAdapter) PromQLExpr()                           {}
 func (exprAdapter) Type() parser.ValueType                { return parser.ValueType("unimplemented") }
 func (exprAdapter) Pretty(_ int) string                   { return "" }
 
-type noopRuleDependencyController struct {
-}
+type noopRuleDependencyController struct{}
 
 // Prometheus rules manager calls AnalyseRules to determine the dependents and dependencies of a rule
 // which it then uses to decide if a rule within a group is eligible for concurrent execution.
 // AnalyseRules is a noop for Loki since there is no dependency relation between rules.
-func (*noopRuleDependencyController) AnalyseRules(rules []rules.Rule) {
+func (*noopRuleDependencyController) AnalyseRules([]rules.Rule) {
 	// Do nothing
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Prometheus rules manager calls [AnalyseRules](https://github.com/grafana/loki/blob/30ce8a4963902073bc7f5d371170d80db7793c01/vendor/github.com/prometheus/prometheus/rules/manager.go#L429) to determine the dependents and dependencies of a rule which it then uses to decide if a rule within a group is eligible for [concurrent execution](https://github.com/grafana/loki/blob/30ce8a4963902073bc7f5d371170d80db7793c01/vendor/github.com/prometheus/prometheus/rules/group.go#L582).

this pr pass a noop implementation since there is no dependency relation between rules in Loki and uses sequential rule execution.


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:
if concurrent execution is enabled in the future, `RuleDependencyController` implementation might need an update to set the [dependents](https://github.com/grafana/loki/blob/30ce8a4963902073bc7f5d371170d80db7793c01/vendor/github.com/prometheus/prometheus/rules/rule.go#L66) and [dependencies](https://github.com/grafana/loki/blob/30ce8a4963902073bc7f5d371170d80db7793c01/vendor/github.com/prometheus/prometheus/rules/rule.go#L74) to false for the rules in a group


**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
