### PR TITLE
feat(bloom-gw): Add `metrics.go` style log line to bloom gateway `FilterChunks` call

### DIFF
--- a/pkg/bloomgateway/bloomgateway.go
+++ b/pkg/bloomgateway/bloomgateway.go
@@ -288,7 +288,7 @@ func (g *Gateway) FilterChunkRefs(ctx context.Context, req *logproto.FilterChunk
 		go g.consumeTask(ctx, task, tasksCh)
 	}
 
-	sp.Log("enqueue_duration", time.Since(queueStart).String())
+	sp.Log("msg", "enqueued tasks", "duration", time.Since(queueStart).String())
 
 	remaining := len(tasks)
 
@@ -335,9 +335,14 @@ func (g *Gateway) FilterChunkRefs(ctx context.Context, req *logproto.FilterChunk
 	g.metrics.requestedChunks.Observe(float64(preFilterChunks))
 	g.metrics.filteredChunks.Observe(float64(preFilterChunks - postFilterChunks))
 
-	level.Info(sp).Log(
-		"msg", "return filtered chunk refs",
-	)
+	stats.Status = "success"
+	stats.SeriesRequested = preFilterSeries
+	stats.SeriesFiltered = preFilterSeries - postFilterSeries
+	stats.ChunksRequested = preFilterChunks
+	stats.ChunksFiltered = preFilterChunks - postFilterChunks
+
+	sp.Log("msg", "return filtered chunk refs")
+
 	return &logproto.FilterChunkRefResponse{ChunkRefs: filtered}, nil
 }
 

--- a/pkg/bloomgateway/bloomgateway.go
+++ b/pkg/bloomgateway/bloomgateway.go
@@ -56,7 +56,6 @@ import (
 	"go.uber.org/atomic"
 
 	"github.com/grafana/loki/pkg/logproto"
-	"github.com/grafana/loki/pkg/logql/syntax"
 	"github.com/grafana/loki/pkg/queue"
 	v1 "github.com/grafana/loki/pkg/storage/bloom/v1"
 	"github.com/grafana/loki/pkg/storage/stores/shipper/bloomshipper"
@@ -262,15 +261,6 @@ func (g *Gateway) FilterChunkRefs(ctx context.Context, req *logproto.FilterChunk
 
 		// TODO(owen-d): include capacity in constructor?
 		task.responses = responsesPool.Get(len(seriesForDay.series))
-
-		level.Debug(sp).Log(
-			"msg", "created task for day",
-			"task", task.ID,
-			"day", seriesForDay.day,
-			"interval", seriesForDay.interval.String(),
-			"nSeries", len(seriesForDay.series),
-			"filters", JoinFunc(filters, ";", func(e syntax.LineFilterExpr) string { return e.String() }),
-		)
 		tasks = append(tasks, task)
 	}
 

--- a/pkg/bloomgateway/bloomgateway_test.go
+++ b/pkg/bloomgateway/bloomgateway_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
-	"os"
 	"sync"
 	"testing"
 	"time"
@@ -139,7 +138,7 @@ func TestBloomGateway_StartStopService(t *testing.T) {
 func TestBloomGateway_FilterChunkRefs(t *testing.T) {
 	tenantID := "test"
 
-	logger := log.NewLogfmtLogger(os.Stderr)
+	logger := log.NewNopLogger()
 	reg := prometheus.NewRegistry()
 
 	kvStore, closer := consul.NewInMemoryClient(ring.GetCodec(), logger, reg)

--- a/pkg/bloomgateway/bloomgateway_test.go
+++ b/pkg/bloomgateway/bloomgateway_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"os"
 	"sync"
 	"testing"
 	"time"
@@ -138,7 +139,7 @@ func TestBloomGateway_StartStopService(t *testing.T) {
 func TestBloomGateway_FilterChunkRefs(t *testing.T) {
 	tenantID := "test"
 
-	logger := log.NewNopLogger()
+	logger := log.NewLogfmtLogger(os.Stderr)
 	reg := prometheus.NewRegistry()
 
 	kvStore, closer := consul.NewInMemoryClient(ring.GetCodec(), logger, reg)

--- a/pkg/bloomgateway/processor.go
+++ b/pkg/bloomgateway/processor.go
@@ -80,7 +80,7 @@ func (p *processor) processTasks(ctx context.Context, tenant string, day config.
 	level.Debug(p.logger).Log("msg", "fetched metas", "count", len(metas), "duration", duration, "err", err)
 
 	for _, t := range tasks {
-		FromContext(t.ctx).AddFetchTime(duration)
+		FromContext(t.ctx).AddMetasFetchTime(duration)
 	}
 
 	if err != nil {
@@ -112,7 +112,7 @@ func (p *processor) processTasks(ctx context.Context, tenant string, day config.
 	level.Debug(p.logger).Log("msg", "fetched blocks", "count", len(refs), "duration", duration, "err", err)
 
 	for _, t := range tasks {
-		FromContext(t.ctx).AddFetchTime(duration)
+		FromContext(t.ctx).AddBlocksFetchTime(duration)
 	}
 
 	if err != nil {

--- a/pkg/bloomgateway/processor.go
+++ b/pkg/bloomgateway/processor.go
@@ -45,7 +45,7 @@ func (p *processor) runWithBounds(ctx context.Context, tasks []Task, bounds v1.M
 		"msg", "process tasks with bounds",
 		"tenant", tenant,
 		"tasks", len(tasks),
-		"bounds", JoinFunc(bounds, ",", func(e v1.FingerprintBounds) string { return e.String() }),
+		"bounds", len(bounds),
 	)
 
 	for ts, tasks := range group(tasks, func(t Task) config.DayTime { return t.table }) {
@@ -140,13 +140,6 @@ func (p *processor) processBlocks(ctx context.Context, bqs []*bloomshipper.Close
 		}
 
 		block := data[i]
-		level.Debug(p.logger).Log(
-			"msg", "process block with tasks",
-			"job", i+1,
-			"of_jobs", len(bqs),
-			"block", block.ref,
-			"num_tasks", len(block.tasks),
-		)
 
 		if !block.ref.Bounds.Equal(bq.Bounds) {
 			return errors.Errorf("block and querier bounds differ: %s vs %s", block.ref.Bounds, bq.Bounds)

--- a/pkg/bloomgateway/stats.go
+++ b/pkg/bloomgateway/stats.go
@@ -7,7 +7,10 @@ import (
 )
 
 type Stats struct {
-	QueueTime, FetchTime, ProcessingTime, PostProcessingTime time.Duration
+	Status                                                           string
+	NumTasks, NumFilters                                             int
+	ChunksRequested, ChunksFiltered, SeriesRequested, SeriesFiltered int
+	QueueTime, FetchTime, ProcessingTime, PostProcessingTime         time.Duration
 }
 
 type statsKey int
@@ -16,7 +19,9 @@ var ctxKey = statsKey(0)
 
 // ContextWithEmptyStats returns a context with empty stats.
 func ContextWithEmptyStats(ctx context.Context) (*Stats, context.Context) {
-	stats := &Stats{}
+	stats := &Stats{
+		Status: "unknown",
+	}
 	ctx = context.WithValue(ctx, ctxKey, stats)
 	return stats, ctx
 }
@@ -36,6 +41,13 @@ func (s *Stats) KVArgs() []any {
 		return []any{}
 	}
 	return []any{
+		"msg", "bloomgateway.FilterChunkRefs",
+		"status", s.Status,
+		"tasks", s.NumTasks,
+		"series_requested", s.SeriesRequested,
+		"series_filtered", s.SeriesFiltered,
+		"chunks_requested", s.ChunksRequested,
+		"chunks_filtered", s.ChunksFiltered,
 		"queue_time", s.QueueTime,
 		"fetch_time", s.FetchTime,
 		"processing_time", s.ProcessingTime,

--- a/pkg/bloomgateway/stats.go
+++ b/pkg/bloomgateway/stats.go
@@ -2,15 +2,16 @@ package bloomgateway
 
 import (
 	"context"
-	"sync/atomic" //lint:ignore faillint
 	"time"
+
+	"go.uber.org/atomic"
 )
 
 type Stats struct {
 	Status                                                                         string
 	NumTasks, NumFilters                                                           int
 	ChunksRequested, ChunksFiltered, SeriesRequested, SeriesFiltered               int
-	QueueTime, MetasFetchTime, BlocksFetchTime, ProcessingTime, PostProcessingTime time.Duration
+	QueueTime, MetasFetchTime, BlocksFetchTime, ProcessingTime, PostProcessingTime atomic.Duration
 }
 
 type statsKey int
@@ -45,11 +46,11 @@ func (s *Stats) KVArgs() []any {
 		"series_filtered", s.SeriesFiltered,
 		"chunks_requested", s.ChunksRequested,
 		"chunks_filtered", s.ChunksFiltered,
-		"queue_time", s.QueueTime,
-		"metas_fetch_time", s.MetasFetchTime,
-		"blocks_fetch_time", s.BlocksFetchTime,
-		"processing_time", s.ProcessingTime,
-		"post_processing_time", s.PostProcessingTime,
+		"queue_time", s.QueueTime.Load(),
+		"metas_fetch_time", s.MetasFetchTime.Load(),
+		"blocks_fetch_time", s.BlocksFetchTime.Load(),
+		"processing_time", s.ProcessingTime.Load(),
+		"post_processing_time", s.PostProcessingTime.Load(),
 	}
 }
 
@@ -57,33 +58,33 @@ func (s *Stats) AddQueueTime(t time.Duration) {
 	if s == nil {
 		return
 	}
-	atomic.AddInt64((*int64)(&s.QueueTime), int64(t))
+	s.QueueTime.Add(t)
 }
 
 func (s *Stats) AddMetasFetchTime(t time.Duration) {
 	if s == nil {
 		return
 	}
-	atomic.AddInt64((*int64)(&s.MetasFetchTime), int64(t))
+	s.MetasFetchTime.Add(t)
 }
 
 func (s *Stats) AddBlocksFetchTime(t time.Duration) {
 	if s == nil {
 		return
 	}
-	atomic.AddInt64((*int64)(&s.BlocksFetchTime), int64(t))
+	s.BlocksFetchTime.Add(t)
 }
 
 func (s *Stats) AddProcessingTime(t time.Duration) {
 	if s == nil {
 		return
 	}
-	atomic.AddInt64((*int64)(&s.ProcessingTime), int64(t))
+	s.ProcessingTime.Add(t)
 }
 
 func (s *Stats) AddPostProcessingTime(t time.Duration) {
 	if s == nil {
 		return
 	}
-	atomic.AddInt64((*int64)(&s.PostProcessingTime), int64(t))
+	s.PostProcessingTime.Add(t)
 }

--- a/pkg/bloomgateway/stats.go
+++ b/pkg/bloomgateway/stats.go
@@ -2,7 +2,7 @@ package bloomgateway
 
 import (
 	"context"
-	"sync/atomic" //lint:ignore faillint we can't use go.uber.org/atomic with a protobuf struct without wrapping it.
+	"sync/atomic" //lint:ignore
 	"time"
 )
 
@@ -19,9 +19,7 @@ var ctxKey = statsKey(0)
 
 // ContextWithEmptyStats returns a context with empty stats.
 func ContextWithEmptyStats(ctx context.Context) (*Stats, context.Context) {
-	stats := &Stats{
-		Status: "unknown",
-	}
+	stats := &Stats{Status: "unknown"}
 	ctx = context.WithValue(ctx, ctxKey, stats)
 	return stats, ctx
 }
@@ -41,7 +39,6 @@ func (s *Stats) KVArgs() []any {
 		return []any{}
 	}
 	return []any{
-		"msg", "bloomgateway.FilterChunkRefs",
 		"status", s.Status,
 		"tasks", s.NumTasks,
 		"series_requested", s.SeriesRequested,

--- a/pkg/bloomgateway/stats.go
+++ b/pkg/bloomgateway/stats.go
@@ -7,10 +7,10 @@ import (
 )
 
 type Stats struct {
-	Status                                                           string
-	NumTasks, NumFilters                                             int
-	ChunksRequested, ChunksFiltered, SeriesRequested, SeriesFiltered int
-	QueueTime, FetchTime, ProcessingTime, PostProcessingTime         time.Duration
+	Status                                                                         string
+	NumTasks, NumFilters                                                           int
+	ChunksRequested, ChunksFiltered, SeriesRequested, SeriesFiltered               int
+	QueueTime, MetasFetchTime, BlocksFetchTime, ProcessingTime, PostProcessingTime time.Duration
 }
 
 type statsKey int
@@ -49,7 +49,8 @@ func (s *Stats) KVArgs() []any {
 		"chunks_requested", s.ChunksRequested,
 		"chunks_filtered", s.ChunksFiltered,
 		"queue_time", s.QueueTime,
-		"fetch_time", s.FetchTime,
+		"metas_fetch_time", s.MetasFetchTime,
+		"blocks_fetch_time", s.BlocksFetchTime,
 		"processing_time", s.ProcessingTime,
 		"post_processing_time", s.PostProcessingTime,
 	}
@@ -62,11 +63,18 @@ func (s *Stats) AddQueueTime(t time.Duration) {
 	atomic.AddInt64((*int64)(&s.QueueTime), int64(t))
 }
 
-func (s *Stats) AddFetchTime(t time.Duration) {
+func (s *Stats) AddMetasFetchTime(t time.Duration) {
 	if s == nil {
 		return
 	}
-	atomic.AddInt64((*int64)(&s.FetchTime), int64(t))
+	atomic.AddInt64((*int64)(&s.MetasFetchTime), int64(t))
+}
+
+func (s *Stats) AddBlocksFetchTime(t time.Duration) {
+	if s == nil {
+		return
+	}
+	atomic.AddInt64((*int64)(&s.BlocksFetchTime), int64(t))
 }
 
 func (s *Stats) AddProcessingTime(t time.Duration) {

--- a/pkg/bloomgateway/stats.go
+++ b/pkg/bloomgateway/stats.go
@@ -2,7 +2,7 @@ package bloomgateway
 
 import (
 	"context"
-	"sync/atomic" //lint:ignore
+	"sync/atomic" //lint:ignore faillint
 	"time"
 )
 

--- a/pkg/bloomgateway/stats.go
+++ b/pkg/bloomgateway/stats.go
@@ -1,0 +1,72 @@
+package bloomgateway
+
+import (
+	"context"
+	"sync/atomic" //lint:ignore faillint we can't use go.uber.org/atomic with a protobuf struct without wrapping it.
+	"time"
+)
+
+type Stats struct {
+	QueueTime, FetchTime, ProcessingTime, PostProcessingTime time.Duration
+}
+
+type statsKey int
+
+var ctxKey = statsKey(0)
+
+// ContextWithEmptyStats returns a context with empty stats.
+func ContextWithEmptyStats(ctx context.Context) (*Stats, context.Context) {
+	stats := &Stats{}
+	ctx = context.WithValue(ctx, ctxKey, stats)
+	return stats, ctx
+}
+
+// FromContext gets the Stats out of the Context. Returns nil if stats have not
+// been initialised in the context.
+func FromContext(ctx context.Context) *Stats {
+	o := ctx.Value(ctxKey)
+	if o == nil {
+		return nil
+	}
+	return o.(*Stats)
+}
+
+func (s *Stats) KVArgs() []any {
+	if s == nil {
+		return []any{}
+	}
+	return []any{
+		"queue_time", s.QueueTime,
+		"fetch_time", s.FetchTime,
+		"processing_time", s.ProcessingTime,
+		"post_processing_time", s.PostProcessingTime,
+	}
+}
+
+func (s *Stats) AddQueueTime(t time.Duration) {
+	if s == nil {
+		return
+	}
+	atomic.AddInt64((*int64)(&s.QueueTime), int64(t))
+}
+
+func (s *Stats) AddFetchTime(t time.Duration) {
+	if s == nil {
+		return
+	}
+	atomic.AddInt64((*int64)(&s.FetchTime), int64(t))
+}
+
+func (s *Stats) AddProcessingTime(t time.Duration) {
+	if s == nil {
+		return
+	}
+	atomic.AddInt64((*int64)(&s.ProcessingTime), int64(t))
+}
+
+func (s *Stats) AddPostProcessingTime(t time.Duration) {
+	if s == nil {
+		return
+	}
+	atomic.AddInt64((*int64)(&s.PostProcessingTime), int64(t))
+}

--- a/pkg/bloomgateway/worker.go
+++ b/pkg/bloomgateway/worker.go
@@ -103,6 +103,7 @@ func (w *worker) running(_ context.Context) error {
 			level.Debug(w.logger).Log("msg", "dequeued task", "task", task.ID)
 			_ = w.pending.Dec()
 			w.metrics.queueDuration.WithLabelValues(w.id).Observe(time.Since(task.enqueueTime).Seconds())
+			FromContext(task.ctx).AddQueueTime(time.Since(task.enqueueTime))
 			tasks = append(tasks, task)
 
 			first, last := getFirstLast(task.series)


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds a "metrics.go" style log line to the bloom gateway that contains latencies for queueing, processing, post-processing, as well as number of chunks/series requested/filtered.

This log line should give operators a better understanding where time is spent for individual requests.

Example log line:

```
ts=2024-03-26T13:16:11.869619964Z caller=spanlogger.go:109 component=bloom-gateway tenant=XXX method=bloomgateway.FilterChunkRefs user=XXX traceID=6239d49e1e88f88645bd7f1f6f1b85c8 level=info status=success tasks=1 series_requested=35 series_filtered=31 chunks_requested=103 chunks_filtered=93 queue_time=4.108128936s metas_fetch_time=22.040408ms blocks_fetch_time=1.284575ms processing_time=30.215863002s post_processing_time=16.084µs
```