### PR TITLE
fix(blooms): Not filters should always match

### DIFF
--- a/pkg/storage/bloom/v1/bloom_tester_test.go
+++ b/pkg/storage/bloom/v1/bloom_tester_test.go
@@ -47,16 +47,16 @@ func TestFiltersToBloomTests(t *testing.T) {
 			expectMatch: false,
 		},
 		{
-			name:        "notEq match",
+			name:        "notEq doesnt exist",
 			query:       `{app="fake"} != "nope"`,
 			bloom:       fakeBloom{"foo", "bar"},
 			expectMatch: true,
 		},
 		{
-			name:        "notEq no match",
+			name:        "notEq exists",
 			query:       `{app="fake"} != "foo"`,
 			bloom:       fakeBloom{"foo", "bar"},
-			expectMatch: false,
+			expectMatch: true, // Still should match because it's NotEQ
 		},
 		{
 			name:        "or filter both match",
@@ -89,22 +89,22 @@ func TestFiltersToBloomTests(t *testing.T) {
 			expectMatch: true,
 		},
 		{
-			name:        "Not or filter right no match",
+			name:        "NotEq OR filter right exists",
 			query:       `{app="fake"} != "nope" or "bar"`,
 			bloom:       fakeBloom{"foo", "bar"},
-			expectMatch: false,
+			expectMatch: true, // Still should match because it's NotEQ
 		},
 		{
-			name:        "Not or filter left no match",
+			name:        "Not OR filter left exists",
 			query:       `{app="fake"} != "foo" or "nope"`,
 			bloom:       fakeBloom{"foo", "bar"},
-			expectMatch: false,
+			expectMatch: true, // Still should match because it's NotEQ
 		},
 		{
-			name:        "Not or filter no match",
+			name:        "NotEq OR filter both exists",
 			query:       `{app="fake"} != "foo" or "bar"`,
 			bloom:       fakeBloom{"foo", "bar"},
-			expectMatch: false,
+			expectMatch: true, // Still should match because it's NotEQ
 		},
 		{
 			name:        "complex filter match",
@@ -125,10 +125,10 @@ func TestFiltersToBloomTests(t *testing.T) {
 			expectMatch: true,
 		},
 		{
-			name:        "regex match none",
+			name:        "regex match all notEq",
 			query:       `{app="fake"} !~ ".*"`,
 			bloom:       fakeBloom{"foo", "bar"},
-			expectMatch: false,
+			expectMatch: true, // Still should match,
 		},
 		{
 			name:        "regex match",
@@ -138,9 +138,15 @@ func TestFiltersToBloomTests(t *testing.T) {
 		},
 		{
 			name:        "regex no match",
-			query:       `{app="fake"} !~ "nope|.*foo.*"`,
+			query:       `{app="fake"} |~ ".*not.*"`,
 			bloom:       fakeBloom{"foo", "bar"},
 			expectMatch: false,
+		},
+		{
+			name:        "regex notEq right exists",
+			query:       `{app="fake"} !~ "nope|.*foo.*"`,
+			bloom:       fakeBloom{"foo", "bar"},
+			expectMatch: true, // Still should match because it's NotEQ
 		},
 		{
 			name:        "complex regex match",
@@ -149,10 +155,10 @@ func TestFiltersToBloomTests(t *testing.T) {
 			expectMatch: true,
 		},
 		{
-			name:        "complex regex no match",
+			name:        "complex regex with notEq exists",
 			query:       `{app="fake"} |~ "(nope|.*not.*|.*foo.*)" or "(no|ba)" !~ "noz.*"`,
 			bloom:       fakeBloom{"foo", "bar", "baz", "fuzz", "noz"},
-			expectMatch: false,
+			expectMatch: true, // Still should match because it's NotEQ
 		},
 		{
 			name:        "line filter after line format",


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a bug from https://github.com/grafana/loki/pull/12035. We cannot test `MatchNotEqual` and `MatchNotRegexp` filters against blooms.

Blooms are probabilistic filters so we cannot safely assume that we can skip chunks for which the blooms return that the string we are filtering out might exist.

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
