### PR TITLE
docs: backport release notes to 2.9 branch

### DIFF
--- a/docs/sources/release-notes/v2-9.md
+++ b/docs/sources/release-notes/v2-9.md
@@ -34,29 +34,38 @@ Grafana Labs is excited to announce the release of Loki 2.9.0 Here's a summary o
  
 ## Bug fixes
 
+### 2.9.5 (2024-02-28)
+
+* Bump base images and Go dependencies to address CVEs ([#12092](https://github.com/grafana/loki/issues/12092)) ([eee3598](https://github.com/grafana/loki/commit/eee35983f38fe04543b169ffa8ece76c23c4217b)).
+
+For a full list of all changes and fixes, refer to the [CHANGELOG](https://github.com/grafana/loki/blob/release-2.9.x/CHANGELOG.md).
+
 ### 2.9.4 (2024-01-24)
 
-* Fixed a couple of data races that can cause panics due to concurrent read-write access of tenant configs.
-* Fixed a bug in the log results cache.
-* Fixed the cache to atomically check background cache size limit correctly.
-* Fixed the discrepancy between the semantics of logs and metrics queries.
-* Fixed promtail default scrape config causing CPU and memory load
-* Update `golang.org/x/crypto` to `v0.18.0`
+- Fixed a couple of data races that can cause panics due to concurrent read-write access of tenant configs.
+- Fixed a bug in the log results cache.
+- Fixed the cache to atomically check background cache size limit correctly.
+- Fixed the discrepancy between the semantics of logs and metrics queries.
+- Fixed promtail default scrape config causing CPU and memory load.
+- Update golang.org/x/crypto to v0.18.0.
+
+For a full list of all changes and fixes, refer to the [CHANGELOG](https://github.com/grafana/loki/blob/release-2.9.x/CHANGELOG.md).
 
 ### 2.9.3 (2023-12-11)
 
 * Upgrade otelhttp from 0.40.0 -> 0.44.0 and base alpine image from 3.18.3 -> 3.18.5 to fix a few CVES (CVE-2023-45142, CVE-2022-21698, CVE-2023-5363).
 * Fix querying ingester for label values with a matcher (previously didn't respect the matcher).
-* Ensure all lifecycler cfgs ref a valid IPv6 addr and port combination
+* Ensure all lifecycler cfgs ref a valid IPv6 addr and port combination.
+
+For a full list of all changes and fixes, refer to the [CHANGELOG](https://github.com/grafana/loki/blob/release-2.9.x/CHANGELOG.md).
 
 ### 2.9.2 (2023-10-16)
 
 * Upgrade go to v1.21.3, golang.org/x/net to v0.17.0 and grpc-go to v1.56.3 to patch CVE-2023-39325 / CVE-2023-44487
 
-For a full list of all changes and fixes, look at the [CHANGELOG](https://github.com/grafana/loki/blob/release-2.9.x/CHANGELOG.md).
+For a full list of all changes and fixes, refer to the [CHANGELOG](https://github.com/grafana/loki/blob/release-2.9.x/CHANGELOG.md).
 
 ### 2.9.1 (2023-09-14)
 
 * Update Docker base images to mitigate security vulnerability CVE-2022-48174
 * Fix bugs in indexshipper (`tsdb`, `boltdb-shipper`) that could result in not showing all ingested logs in query results.
-


### PR DESCRIPTION
**What this PR does / why we need it**:

Backports #12349 to the 2.9 release branch.