### PR TITLE
fix(blooms): Reduce jumps between buckets in blocks pool

### DIFF
--- a/pkg/storage/bloom/v1/index.go
+++ b/pkg/storage/bloom/v1/index.go
@@ -166,8 +166,8 @@ func (b *BlockIndex) NewSeriesPageDecoder(r io.ReadSeeker, header SeriesPageHead
 		return nil, errors.Wrap(err, "seeking to series page")
 	}
 
-	data := BlockPool.Get(header.Len)[:header.Len]
-	defer BlockPool.Put(data)
+	data := seriesPagePool.Get(header.Len)[:header.Len]
+	defer seriesPagePool.Put(data)
 	_, err = io.ReadFull(r, data)
 	if err != nil {
 		return nil, errors.Wrap(err, "reading series page")

--- a/pkg/storage/bloom/v1/util.go
+++ b/pkg/storage/bloom/v1/util.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"sync"
 
-	"github.com/prometheus/prometheus/util/pool"
+	"github.com/grafana/loki/pkg/util/pool"
 )
 
 const (
@@ -32,10 +32,30 @@ var (
 		},
 	}
 
-	// 4KB -> 128MB
-	BlockPool = BytePool{
+	// 1KB -> 1MB, 2x growth
+	seriesPagePool = BytePool{
 		pool: pool.New(
-			4<<10, 128<<20, 4,
+			1<<10, 1<<20, 2,
+			func(size int) interface{} {
+				return make([]byte, size)
+			}),
+	}
+
+	// 1MB -> 128MB
+	BlockPool = BytePool{
+		pool: pool.NewWithSizes(
+			[]int{
+				1 << 20,
+				2 << 20,
+				4 << 20,
+				8 << 20,
+				16 << 20,
+				32 << 20,
+				48 << 20,
+				64 << 20,
+				96 << 20,
+				128 << 20,
+			},
 			func(size int) interface{} {
 				return make([]byte, size)
 			}),

--- a/pkg/util/pool/pool.go
+++ b/pkg/util/pool/pool.go
@@ -1,0 +1,90 @@
+package pool
+
+import (
+	"fmt"
+	"reflect"
+	"sync"
+)
+
+// NOTE this is pretty much a copy of prometheus pool
+
+// Pool is a bucketed pool for variably sized byte slices.
+type Pool struct {
+	buckets []sync.Pool
+	sizes   []int
+	// make is the function used to create an empty slice when none exist yet.
+	make func(int) interface{}
+}
+
+// New returns a new Pool with size buckets for minSize to maxSize
+// increasing by the given factor.
+func New(minSize, maxSize int, factor float64, makeFunc func(int) interface{}) *Pool {
+	if minSize < 1 {
+		panic("invalid minimum pool size")
+	}
+	if maxSize < 1 {
+		panic("invalid maximum pool size")
+	}
+	if factor < 2 {
+		panic("invalid factor")
+	}
+
+	var sizes []int
+
+	for s := minSize; s <= maxSize; s = int(float64(s) * factor) {
+		sizes = append(sizes, s)
+	}
+
+	p := &Pool{
+		buckets: make([]sync.Pool, len(sizes)),
+		sizes:   sizes,
+		make:    makeFunc,
+	}
+
+	return p
+}
+
+func NewWithSizes(sizes []int, makeFunc func(int) interface{}) *Pool {
+	if len(sizes) < 1 {
+		panic("invalid pool sizes")
+	}
+
+	p := &Pool{
+		buckets: make([]sync.Pool, len(sizes)),
+		sizes:   sizes,
+		make:    makeFunc,
+	}
+
+	return p
+}
+
+// Get returns a new byte slices that fits the given size.
+func (p *Pool) Get(sz int) interface{} {
+	for i, bktSize := range p.sizes {
+		if sz > bktSize {
+			continue
+		}
+		b := p.buckets[i].Get()
+		if b == nil {
+			b = p.make(bktSize)
+		}
+		return b
+	}
+	return p.make(sz)
+}
+
+// Put adds a slice to the right bucket in the pool.
+func (p *Pool) Put(s interface{}) {
+	slice := reflect.ValueOf(s)
+
+	if slice.Kind() != reflect.Slice {
+		panic(fmt.Sprintf("%+v is not a slice", slice))
+	}
+	for i, size := range p.sizes {
+		if slice.Cap() > size {
+			continue
+		}
+		p.buckets[i].Put(slice.Slice(0, 0).Interface())
+		return
+	}
+}

--- a/pkg/util/pool/pool_test.go
+++ b/pkg/util/pool/pool_test.go
@@ -1,0 +1,62 @@
+package pool
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestPoolNew(t *testing.T) {
+	testPool := New(1, 8, 2, func(size int) interface{} {
+		return make([]int, size)
+	})
+	cases := []struct {
+		size        int
+		expectedCap int
+	}{
+		{
+			size:        -1,
+			expectedCap: 1,
+		},
+		{
+			size:        3,
+			expectedCap: 4,
+		},
+		{
+			size:        10,
+			expectedCap: 10,
+		},
+	}
+	for _, c := range cases {
+		ret := testPool.Get(c.size)
+		require.Equal(t, c.expectedCap, cap(ret.([]int)))
+		testPool.Put(ret)
+	}
+}
+
+func TestPoolNewWithSizes(t *testing.T) {
+	testPool := NewWithSizes([]int{1, 2, 4, 8}, func(size int) interface{} {
+		return make([]int, size)
+	})
+	cases := []struct {
+		size        int
+		expectedCap int
+	}{
+		{
+			size:        -1,
+			expectedCap: 1,
+		},
+		{
+			size:        3,
+			expectedCap: 4,
+		},
+		{
+			size:        10,
+			expectedCap: 10,
+		},
+	}
+	for _, c := range cases {
+		ret := testPool.Get(c.size)
+		require.Equal(t, c.expectedCap, cap(ret.([]int)))
+		testPool.Put(ret)
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Before this PR the blocks pool would create the following buckets:
- 1KB... 2MB, 8MB, 32MB, 128MB

We often read pages that are bigger than 32MB but considerable smaller than 128 MB, still the pool would allocate buffers of 128 MBs for them:
https://github.com/grafana/loki/blob/c53457feb95a871e7494d22c5e072004874a197c/vendor/github.com/prometheus/prometheus/util/pool/pool.go#L61-L67

In this PR, we copy the pool implementation from prometheus into Loki's pool pkg and add a new method `NewWithSizes` to add sizes that can increase with a factor smaller than 2. That way we can have the following buckets for the blocks pool:
- 1MB, 2MB, 4MB, 8MB, 16MB, 32MB, 48MB, 64MB, 96MB, 128MB.

We run this in dev, and OOMs were gone. The first wave is before these changes. The second wave is with a factor of 2. The last wave is with the custom sizes.

![image](https://github.com/grafana/loki/assets/8354290/1f58f7fe-4a60-4619-8f2c-77c3ab6ee2b2)
![image](https://github.com/grafana/loki/assets/8354290/6853783a-4718-4a3c-88dd-1a04ca8ab4a2)


**Special notes for your reviewer**:
Maybe copying Prometheus' pool impl and extending it is a bit overkill but I think it makes sense to have a way to configure buckets other than with an exponential factor.

Curiously enough, the prometheus pool impl, doesn't handle well when the factor is smaller than 2: it leads to an infinite loop. So in our imp[l we change the precondition to check that the factor is biggerEq to 2.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
