### PR TITLE
chore(blooms): increase blockpool by factor-of-2

### DIFF
--- a/pkg/storage/bloom/v1/util.go
+++ b/pkg/storage/bloom/v1/util.go
@@ -35,7 +35,7 @@ var (
 	// 4KB -> 128MB
 	BlockPool = BytePool{
 		pool: pool.New(
-			4<<10, 128<<20, 4,
+			4<<10, 128<<20, 2,
 			func(size int) interface{} {
 				return make([]byte, size)
 			}),


### PR DESCRIPTION
A smaller first step compared to https://github.com/grafana/loki/pull/12362, this PR decreases the steps to try and avoid provisioning too much capacity in bloom pages.