### PR TITLE
docs: Update release notes for 2.9.6

### DIFF
--- a/docs/sources/release-notes/v2-9.md
+++ b/docs/sources/release-notes/v2-9.md
@@ -34,9 +34,17 @@ Grafana Labs is excited to announce the release of Loki 2.9.0 Here's a summary o
 
 ## Bug fixes
 
+### 2.9.6 (2024-03-21)
+
+* Fixed Promtail failures connecting to local Loki installation ([#12184](https://github.com/grafana/loki/issues/12184)) ([8585e35](https://github.com/grafana/loki/commit/8585e3537375c0deb11462d7256f5da23228f5e1)).
+* Fixed an issue when using IPv6 where IPv6 addresses were not properly joined with ports. Use `net.JoinHostPort` to support IPv6 addresses. ([#10650](https://github.com/grafana/loki/issues/10650)) ([#11870](https://github.com/grafana/loki/issues/11870)) ([7def3b4](https://github.com/grafana/loki/commit/7def3b4e774252e13ba154ca13f72816a84da7dd)).
+* Updated google.golang.org/protobuf to v1.33.0 ([#12269](https://github.com/grafana/loki/issues/12269)) ([#12287](https://github.com/grafana/loki/issues/12287)) ([3186520](https://github.com/grafana/loki/commit/318652035059fdaa40405f263fc9e37b4d38b157)).
+
+For a full list of all changes and fixes, refer to the [CHANGELOG](https://github.com/grafana/loki/blob/release-2.9.x/CHANGELOG.md).
+
 ### 2.9.5 (2024-02-28)
 
-* Bump base images and Go dependencies to address CVEs ([#12092](https://github.com/grafana/loki/issues/12092)) ([eee3598](https://github.com/grafana/loki/commit/eee35983f38fe04543b169ffa8ece76c23c4217b)).
+* Bumped base images and Go dependencies to address CVEs ([#12092](https://github.com/grafana/loki/issues/12092)) ([eee3598](https://github.com/grafana/loki/commit/eee35983f38fe04543b169ffa8ece76c23c4217b)).
 
 For a full list of all changes and fixes, refer to the [CHANGELOG](https://github.com/grafana/loki/blob/release-2.9.x/CHANGELOG.md).
 
@@ -47,25 +55,27 @@ For a full list of all changes and fixes, refer to the [CHANGELOG](https://githu
 - Fixed the cache to atomically check background cache size limit correctly.
 - Fixed the discrepancy between the semantics of logs and metrics queries.
 - Fixed promtail default scrape config causing CPU and memory load.
-- Update golang.org/x/crypto to v0.18.0.
+- Updated golang.org/x/crypto to v0.18.0.
 
 For a full list of all changes and fixes, refer to the [CHANGELOG](https://github.com/grafana/loki/blob/release-2.9.x/CHANGELOG.md).
 
 ### 2.9.3 (2023-12-11)
 
-* Upgrade otelhttp from 0.40.0 -> 0.44.0 and base alpine image from 3.18.3 -> 3.18.5 to fix a few CVES (CVE-2023-45142, CVE-2022-21698, CVE-2023-5363).
-* Fix querying ingester for label values with a matcher (previously didn't respect the matcher).
-* Ensure all lifecycler cfgs ref a valid IPv6 addr and port combination.
+* Upgraded otelhttp from 0.40.0 -> 0.44.0 and base alpine image from 3.18.3 -> 3.18.5 to fix a few CVES (CVE-2023-45142, CVE-2022-21698, CVE-2023-5363).
+* Fixed querying ingester for label values with a matcher (previously didn't respect the matcher).
+* Ensured all lifecycler cfgs ref a valid IPv6 addr and port combination.
 
 For a full list of all changes and fixes, refer to the [CHANGELOG](https://github.com/grafana/loki/blob/release-2.9.x/CHANGELOG.md).
 
 ### 2.9.2 (2023-10-16)
 
-* Upgrade go to v1.21.3, golang.org/x/net to v0.17.0 and grpc-go to v1.56.3 to patch CVE-2023-39325 / CVE-2023-44487
+* Upgraded go to v1.21.3, golang.org/x/net to v0.17.0 and grpc-go to v1.56.3 to patch CVE-2023-39325 / CVE-2023-44487
 
 For a full list of all changes and fixes, refer to the [CHANGELOG](https://github.com/grafana/loki/blob/release-2.9.x/CHANGELOG.md).
 
 ### 2.9.1 (2023-09-14)
 
-* Update Docker base images to mitigate security vulnerability CVE-2022-48174
-* Fix bugs in indexshipper (`tsdb`, `boltdb-shipper`) that could result in not showing all ingested logs in query results.
+* Updated Docker base images to mitigate security vulnerability CVE-2022-48174
+* Fixed bugs in indexshipper (`tsdb`, `boltdb-shipper`) that could result in not showing all ingested logs in query results.
+
+For a full list of all changes and fixes, refer to the [CHANGELOG](https://github.com/grafana/loki/blob/release-2.9.x/CHANGELOG.md).


### PR DESCRIPTION
**What this PR does / why we need it**:
Update the release notes for 2.9.6.