### PR TITLE
chore(bloom-gw): Cleanup tracing implementation

### DIFF
--- a/pkg/bloomgateway/processor.go
+++ b/pkg/bloomgateway/processor.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 
 	"github.com/grafana/dskit/concurrency"
@@ -162,22 +161,14 @@ func (p *processor) processBlock(_ context.Context, blockQuerier *v1.BlockQuerie
 	tokenizer := v1.NewNGramTokenizer(schema.NGramLen(), 0)
 	iters := make([]v1.PeekingIterator[v1.Request], 0, len(tasks))
 
-	// collect spans & run single defer to avoid blowing call stack
-	// if there are many tasks
-	spans := make([]opentracing.Span, 0, len(tasks))
-	defer func() {
-		for _, sp := range spans {
-			sp.Finish()
-		}
-	}()
-
 	for _, task := range tasks {
-		// add spans for each task context for this block
-		sp, _ := opentracing.StartSpanFromContext(task.ctx, "bloomgateway.ProcessBlock")
-		spans = append(spans, sp)
-		md, _ := blockQuerier.Metadata()
-		blk := bloomshipper.BlockRefFrom(task.Tenant, task.table.String(), md)
-		sp.LogKV("block", blk.String())
+		// md, _ := blockQuerier.Metadata()
+		// blk := bloomshipper.BlockRefFrom(task.Tenant, task.table.String(), md)
+		//
+		// Why don't we get the span from the task context even though we create it
+		// at the beginning of the request handler?
+		// sp := opentracing.SpanFromContext(task.ctx)
+		// sp.LogKV("process block", blk.String())
 
 		it := v1.NewPeekingIter(task.RequestIter(tokenizer))
 		iters = append(iters, it)
@@ -196,7 +187,9 @@ func (p *processor) processBlock(_ context.Context, blockQuerier *v1.BlockQuerie
 	}
 
 	for _, task := range tasks {
-		FromContext(task.ctx).AddProcessingTime(duration)
+		stats := FromContext(task.ctx)
+		stats.AddProcessingTime(duration)
+		stats.IncProcessedBlocks()
 	}
 
 	return err

--- a/pkg/bloomgateway/processor_test.go
+++ b/pkg/bloomgateway/processor_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
+	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
@@ -88,6 +89,11 @@ func (s *dummyStore) FetchBlocks(_ context.Context, refs []bloomshipper.BlockRef
 
 func TestProcessor(t *testing.T) {
 	ctx := context.Background()
+	// create a span for the request, because the processer annotates the span
+	// with the blocks that have been processed
+	sp, ctx := opentracing.StartSpanFromContext(ctx, "TestProcessor")
+	t.Cleanup(sp.Finish)
+
 	tenant := "fake"
 	now := mktime("2024-01-27 12:00")
 	metrics := newWorkerMetrics(prometheus.NewPedanticRegistry(), constants.Loki, "bloom_gatway")

--- a/pkg/bloomgateway/processor_test.go
+++ b/pkg/bloomgateway/processor_test.go
@@ -89,8 +89,6 @@ func (s *dummyStore) FetchBlocks(_ context.Context, refs []bloomshipper.BlockRef
 
 func TestProcessor(t *testing.T) {
 	ctx := context.Background()
-	// create a span for the request, because the processer annotates the span
-	// with the blocks that have been processed
 	sp, ctx := opentracing.StartSpanFromContext(ctx, "TestProcessor")
 	t.Cleanup(sp.Finish)
 

--- a/pkg/bloomgateway/stats.go
+++ b/pkg/bloomgateway/stats.go
@@ -8,11 +8,15 @@ import (
 )
 
 type Stats struct {
-	Status                                                                         string
-	NumTasks, NumFilters                                                           int
-	ChunksRequested, ChunksFiltered, SeriesRequested, SeriesFiltered               int
-	QueueTime, MetasFetchTime, BlocksFetchTime, ProcessingTime, PostProcessingTime *atomic.Duration
-	ProcessedBlocks                                                                *atomic.Int32
+	Status                              string
+	NumTasks, NumFilters                int
+	ChunksRequested, ChunksFiltered     int
+	SeriesRequested, SeriesFiltered     int
+	QueueTime                           *atomic.Duration
+	MetasFetchTime, BlocksFetchTime     *atomic.Duration
+	ProcessingTime, TotalProcessingTime *atomic.Duration
+	PostProcessingTime                  *atomic.Duration
+	ProcessedBlocks                     *atomic.Int32
 }
 
 type statsKey int
@@ -22,13 +26,14 @@ var ctxKey = statsKey(0)
 // ContextWithEmptyStats returns a context with empty stats.
 func ContextWithEmptyStats(ctx context.Context) (*Stats, context.Context) {
 	stats := &Stats{
-		Status:             "unknown",
-		ProcessedBlocks:    atomic.NewInt32(0),
-		QueueTime:          atomic.NewDuration(0),
-		MetasFetchTime:     atomic.NewDuration(0),
-		BlocksFetchTime:    atomic.NewDuration(0),
-		ProcessingTime:     atomic.NewDuration(0),
-		PostProcessingTime: atomic.NewDuration(0),
+		Status:              "unknown",
+		ProcessedBlocks:     atomic.NewInt32(0),
+		QueueTime:           atomic.NewDuration(0),
+		MetasFetchTime:      atomic.NewDuration(0),
+		BlocksFetchTime:     atomic.NewDuration(0),
+		ProcessingTime:      atomic.NewDuration(0),
+		TotalProcessingTime: atomic.NewDuration(0),
+		PostProcessingTime:  atomic.NewDuration(0),
 	}
 	ctx = context.WithValue(ctx, ctxKey, stats)
 	return stats, ctx
@@ -108,6 +113,13 @@ func (s *Stats) AddProcessingTime(t time.Duration) {
 		return
 	}
 	s.ProcessingTime.Add(t)
+}
+
+func (s *Stats) AddTotalProcessingTime(t time.Duration) {
+	if s == nil {
+		return
+	}
+	s.TotalProcessingTime.Add(t)
 }
 
 func (s *Stats) AddPostProcessingTime(t time.Duration) {

--- a/pkg/bloomgateway/stats.go
+++ b/pkg/bloomgateway/stats.go
@@ -56,6 +56,7 @@ func (s *Stats) KVArgs() []any {
 		"msg", "stats-report",
 		"status", s.Status,
 		"tasks", s.NumTasks,
+		"filters", s.NumFilters,
 		"series_requested", s.SeriesRequested,
 		"series_filtered", s.SeriesFiltered,
 		"chunks_requested", s.ChunksRequested,


### PR DESCRIPTION
**What this PR does / why we need it**:

The huge amount of `bloomgateway.ProcessTask` spans caused problem with Tempo's span limit, resulting in dropped/dangling spans.

Since the processing time is now recorded also in a `metrics.go`-like stats log line, we can remove the spans and only add a log event with the summary to the main span of the request handler.

This PR also unifies the event logging in the index gateway, and adds the real processing time (not aggregated processing time) to the request stats.