### PR TITLE
chore(blooms): misc fixes

### DIFF
--- a/docs/sources/configure/_index.md
+++ b/docs/sources/configure/_index.md
@@ -1915,11 +1915,6 @@ client:
   # bloom-gateway-client.grpc
   [grpc_client_config: <grpc_client>]
 
-  # Flag to control whether requests sent to the gateway should be logged or
-  # not.
-  # CLI flag: -bloom-gateway-client.log-gateway-requests
-  [log_gateway_requests: <boolean> | default = false]
-
   results_cache:
     # The cache block configures the cache backend.
     # The CLI flags prefix for this block configuration is:
@@ -2370,7 +2365,7 @@ bloom_shipper:
   blocks_downloading_queue:
     # The count of parallel workers that download Bloom Blocks.
     # CLI flag: -bloom.shipper.blocks-downloading-queue.workers-count
-    [workers_count: <int> | default = 100]
+    [workers_count: <int> | default = 16]
 
     # Maximum number of task in queue per tenant per bloom-gateway. Enqueuing
     # the tasks above this limit will fail an error.

--- a/pkg/bloomgateway/cache.go
+++ b/pkg/bloomgateway/cache.go
@@ -46,6 +46,7 @@ func newCacheKeyGen(limits CacheLimits) keyGen {
 	return keyGen{limits}
 }
 
+// TODO(owen-d): need to implement our own key-generation which accounts for fingerprint ranges requested.
 func (k keyGen) GenerateCacheKey(ctx context.Context, tenant string, r resultscache.Request) string {
 	return resultscache.ConstSplitter(k.BloomGatewayCacheKeyInterval(tenant)).GenerateCacheKey(ctx, tenant, r)
 }

--- a/pkg/bloomgateway/stats.go
+++ b/pkg/bloomgateway/stats.go
@@ -53,6 +53,7 @@ func (s *Stats) KVArgs() []any {
 	filterRatio := float64(s.ChunksFiltered) / float64(max(s.ChunksRequested, 1))
 
 	return []any{
+		"msg", "stats-report",
 		"status", s.Status,
 		"tasks", s.NumTasks,
 		"series_requested", s.SeriesRequested,

--- a/pkg/storage/stores/shipper/bloomshipper/config/config.go
+++ b/pkg/storage/stores/shipper/bloomshipper/config/config.go
@@ -26,7 +26,7 @@ type DownloadingQueueConfig struct {
 }
 
 func (cfg *DownloadingQueueConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
-	f.IntVar(&cfg.WorkersCount, prefix+"workers-count", 100, "The count of parallel workers that download Bloom Blocks.")
+	f.IntVar(&cfg.WorkersCount, prefix+"workers-count", 16, "The count of parallel workers that download Bloom Blocks.")
 	f.IntVar(&cfg.MaxTasksEnqueuedPerTenant, prefix+"max_tasks_enqueued_per_tenant", 10_000, "Maximum number of task in queue per tenant per bloom-gateway. Enqueuing the tasks above this limit will fail an error.")
 }
 


### PR DESCRIPTION
unbounds bloom-gw-client concurrency

removes unused log_gateway_requests param

adds note wrt bloom-gw results cache keygen issue

add msg field to stats log

sets bloomshipper workers-count to 16 default
