### PR TITLE
chore: Add podDistruption to idx-gws

### DIFF
--- a/production/ksonnet/loki/index-gateway.libsonnet
+++ b/production/ksonnet/loki/index-gateway.libsonnet
@@ -68,14 +68,14 @@
   else {},
 
 
-  index_gateway_pdb:  if $._config.use_index_gateway then
-      podDisruptionBudget.new('index-gateway-pdb') +
-      podDisruptionBudget.mixin.metadata.withLabels({ name: 'index-gateway-pdb' }) +
-      podDisruptionBudget.mixin.spec.selector.withMatchLabels({
-        name: $.index_gateway_statefulset.metadata.name,
-      }) +
-      podDisruptionBudget.mixin.spec.withMaxUnavailable(1)
-   else {},
+  index_gateway_pdb: if $._config.use_index_gateway then
+    podDisruptionBudget.new('index-gateway-pdb') +
+    podDisruptionBudget.mixin.metadata.withLabels({ name: 'index-gateway-pdb' }) +
+    podDisruptionBudget.mixin.spec.selector.withMatchLabels({
+      name: $.index_gateway_statefulset.metadata.name,
+    }) +
+    podDisruptionBudget.mixin.spec.withMaxUnavailable(1)
+  else {},
 
   index_gateway_service: if $._config.use_index_gateway then
     k.util.serviceFor($.index_gateway_statefulset, $._config.service_ignored_labels)


### PR DESCRIPTION
**What this PR does / why we need it**:
Increases reliability of index-gws by adding podDisruptionBudget

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:
This is preferred over pod priority in k8 documentation. 
Loki already has this on helm config. 