### PR TITLE
docs: fix formatting in structured metadata topic

### DIFF
--- a/docs/sources/get-started/labels/structured-metadata.md
+++ b/docs/sources/get-started/labels/structured-metadata.md
@@ -21,8 +21,8 @@ Structured metadata can also be used to query commonly needed metadata from log 
 
 You should only use structured metadata in the following situations:
 
-    • If you are ingesting data in OpenTelemetry format, using the Grafana Agent or an OpenTelemetry Collector. Structured metadata was designed to support native ingestion of OpenTelemetry data.
-    • If you have high cardinality metadata that should not be used as a label and does not exist in the log line.  Some examples might include `process_id` or `thread_id` or Kubernetes pod names.
+- If you are ingesting data in OpenTelemetry format, using the Grafana Agent or an OpenTelemetry Collector. Structured metadata was designed to support native ingestion of OpenTelemetry data.
+- If you have high cardinality metadata that should not be used as a label and does not exist in the log line.  Some examples might include `process_id` or `thread_id` or Kubernetes pod names.
  
 It is an antipattern to extract information that already exists in your log lines and put it into structured metadata.
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes bullets that were formatted as a code block due to a copy/paste error.