### PR TITLE
chore: refactor line filter MatchType

### DIFF
--- a/pkg/loghttp/params.go
+++ b/pkg/loghttp/params.go
@@ -11,9 +11,9 @@ import (
 	"github.com/c2h5oh/datasize"
 	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
-	"github.com/prometheus/prometheus/model/labels"
 
 	"github.com/grafana/loki/pkg/logproto"
+	"github.com/grafana/loki/pkg/logql/log"
 	"github.com/grafana/loki/pkg/logql/syntax"
 )
 
@@ -193,7 +193,7 @@ func parseRegexQuery(httpRequest *http.Request) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		newExpr, err := syntax.AddFilterExpr(expr, labels.MatchRegexp, "", regexp)
+		newExpr, err := syntax.AddFilterExpr(expr, log.LineMatchRegexp, "", regexp)
 		if err != nil {
 			return "", err
 		}

--- a/pkg/logql/log/filter.go
+++ b/pkg/logql/log/filter.go
@@ -14,6 +14,32 @@ import (
 	"github.com/grafana/loki/pkg/util"
 )
 
+// LineMatchType is an enum for line matching types.
+type LineMatchType int
+
+// Possible LineMatchTypes.
+const (
+	LineMatchEqual LineMatchType = iota
+	LineMatchNotEqual
+	LineMatchRegexp
+	LineMatchNotRegexp
+)
+
+func (t LineMatchType) String() string {
+	switch t {
+	case LineMatchEqual:
+		return "|="
+	case LineMatchNotEqual:
+		return "!="
+	case LineMatchRegexp:
+		return "|~"
+	case LineMatchNotRegexp:
+		return "!~"
+	default:
+		return ""
+	}
+}
+
 // Checker is an interface that matches against the input line or regexp.
 type Checker interface {
 	Test(line []byte, caseInsensitive bool, equal bool) bool
@@ -517,15 +543,15 @@ func (f containsAllFilter) Matches(test Checker) bool {
 }
 
 // NewFilter creates a new line filter from a match string and type.
-func NewFilter(match string, mt labels.MatchType) (Filterer, error) {
+func NewFilter(match string, mt LineMatchType) (Filterer, error) {
 	switch mt {
-	case labels.MatchRegexp:
+	case LineMatchRegexp:
 		return parseRegexpFilter(match, true, false)
-	case labels.MatchNotRegexp:
+	case LineMatchNotRegexp:
 		return parseRegexpFilter(match, false, false)
-	case labels.MatchEqual:
+	case LineMatchEqual:
 		return newContainsFilter([]byte(match), false), nil
-	case labels.MatchNotEqual:
+	case LineMatchNotEqual:
 		return NewNotFilter(newContainsFilter([]byte(match), false)), nil
 	default:
 		return nil, fmt.Errorf("unknown matcher: %v", match)

--- a/pkg/logql/log/ip.go
+++ b/pkg/logql/log/ip.go
@@ -6,7 +6,6 @@ import (
 	"net/netip"
 	"unicode"
 
-	"github.com/prometheus/prometheus/model/labels"
 	"go4.org/netipx"
 )
 
@@ -27,14 +26,14 @@ type IPMatcher interface{}
 
 type IPLineFilter struct {
 	ip *ipFilter
-	ty labels.MatchType
+	ty LineMatchType
 }
 
 // NewIPLineFilter is used to construct ip filter as a `LineFilter`
-func NewIPLineFilter(pattern string, ty labels.MatchType) (*IPLineFilter, error) {
+func NewIPLineFilter(pattern string, ty LineMatchType) (*IPLineFilter, error) {
 	// check if `ty` supported in ip matcher.
 	switch ty {
-	case labels.MatchEqual, labels.MatchNotEqual:
+	case LineMatchEqual, LineMatchNotEqual:
 	default:
 		return nil, ErrIPFilterInvalidOperation
 	}
@@ -69,8 +68,8 @@ func (f *IPLineFilter) RequiredLabelNames() []string {
 	return []string{} // empty for line filter
 }
 
-func (f *IPLineFilter) filterTy(line []byte, ty labels.MatchType) bool {
-	if ty == labels.MatchNotEqual {
+func (f *IPLineFilter) filterTy(line []byte, ty LineMatchType) bool {
+	if ty == LineMatchNotEqual {
 		return !f.ip.filter(line)
 	}
 	return f.ip.filter(line)

--- a/pkg/logql/log/ip_test.go
+++ b/pkg/logql/log/ip_test.go
@@ -189,7 +189,7 @@ func Test_IPLineFilterTy(t *testing.T) {
 	cases := []struct {
 		name          string
 		pat           string
-		ty            labels.MatchType
+		ty            LineMatchType
 		line          []byte
 		expectedMatch bool
 
@@ -199,21 +199,21 @@ func Test_IPLineFilterTy(t *testing.T) {
 		{
 			name:          "equal operator",
 			pat:           "192.168.0.1",
-			ty:            labels.MatchEqual,
+			ty:            LineMatchEqual,
 			line:          []byte("192.168.0.1"),
 			expectedMatch: true,
 		},
 		{
 			name:          "not equal operator",
 			pat:           "192.168.0.2",
-			ty:            labels.MatchNotEqual,
+			ty:            LineMatchNotEqual,
 			line:          []byte("192.168.0.1"), // match because !=ip("192.168.0.2")
 			expectedMatch: true,
 		},
 		{
 			name: "regex not equal",
 			pat:  "192.168.0.2",
-			ty:   labels.MatchNotRegexp, // not supported
+			ty:   LineMatchNotRegexp, // not supported
 			line: []byte("192.168.0.1"),
 			fail: true,
 			err:  ErrIPFilterInvalidOperation,
@@ -221,7 +221,7 @@ func Test_IPLineFilterTy(t *testing.T) {
 		{
 			name: "regex equal",
 			pat:  "192.168.0.2",
-			ty:   labels.MatchRegexp, // not supported
+			ty:   LineMatchRegexp, // not supported
 			line: []byte("192.168.0.1"),
 			fail: true,
 			err:  ErrIPFilterInvalidOperation,

--- a/pkg/logql/log/metrics_extraction_test.go
+++ b/pkg/logql/log/metrics_extraction_test.go
@@ -346,7 +346,7 @@ func TestNewLineSampleExtractor(t *testing.T) {
 	require.Equal(t, 1., f)
 	assertLabelResult(t, lbs, l)
 
-	stage := mustFilter(NewFilter("foo", labels.MatchEqual)).ToStage()
+	stage := mustFilter(NewFilter("foo", LineMatchEqual)).ToStage()
 	se, err = NewLineSampleExtractor(BytesExtractor, []Stage{stage}, []string{"namespace"}, false, false)
 	require.NoError(t, err)
 
@@ -404,7 +404,7 @@ func TestNewLineSampleExtractorWithStructuredMetadata(t *testing.T) {
 	se, err = NewLineSampleExtractor(BytesExtractor, []Stage{
 		NewStringLabelFilter(labels.MustNewMatcher(labels.MatchEqual, "foo", "bar")),
 		NewStringLabelFilter(labels.MustNewMatcher(labels.MatchEqual, "user", "bob")),
-		mustFilter(NewFilter("foo", labels.MatchEqual)).ToStage(),
+		mustFilter(NewFilter("foo", LineMatchEqual)).ToStage(),
 	}, []string{"foo"}, false, false)
 	require.NoError(t, err)
 

--- a/pkg/logql/log/pipeline_test.go
+++ b/pkg/logql/log/pipeline_test.go
@@ -240,7 +240,7 @@ func newPipelineFilter(start, end int64, lbls, structuredMetadata labels.Labels,
 		stages = append(stages, s)
 	})
 
-	stages = append(stages, mustFilter(NewFilter(filter, labels.MatchEqual)).ToStage())
+	stages = append(stages, mustFilter(NewFilter(filter, LineMatchEqual)).ToStage())
 
 	return PipelineFilter{start, end, matchers, NewPipeline(stages)}
 }
@@ -527,7 +527,7 @@ func Benchmark_Pipeline(b *testing.B) {
 	b.ReportAllocs()
 
 	stages := []Stage{
-		mustFilter(NewFilter("metrics.go", labels.MatchEqual)).ToStage(),
+		mustFilter(NewFilter("metrics.go", LineMatchEqual)).ToStage(),
 		NewLogfmtParser(false, false),
 		NewAndLabelFilter(
 			NewDurationLabelFilter(LabelFilterGreaterThan, "duration", 10*time.Millisecond),
@@ -611,7 +611,7 @@ func jsonBenchmark(b *testing.B, parser Stage) {
 	b.ReportAllocs()
 
 	p := NewPipeline([]Stage{
-		mustFilter(NewFilter("metrics.go", labels.MatchEqual)).ToStage(),
+		mustFilter(NewFilter("metrics.go", LineMatchEqual)).ToStage(),
 		parser,
 	})
 	line := []byte(`{"ts":"2020-12-27T09:15:54.333026285Z","error":"action could not be completed", "context":{"file": "metrics.go"}}`)
@@ -643,7 +643,7 @@ func invalidJSONBenchmark(b *testing.B, parser Stage) {
 	b.ReportAllocs()
 
 	p := NewPipeline([]Stage{
-		mustFilter(NewFilter("invalid json", labels.MatchEqual)).ToStage(),
+		mustFilter(NewFilter("invalid json", LineMatchEqual)).ToStage(),
 		parser,
 	})
 	line := []byte(`invalid json`)
@@ -696,7 +696,7 @@ func logfmtBenchmark(b *testing.B, parser Stage) {
 	b.ReportAllocs()
 
 	p := NewPipeline([]Stage{
-		mustFilter(NewFilter("ts", labels.MatchEqual)).ToStage(),
+		mustFilter(NewFilter("ts", LineMatchEqual)).ToStage(),
 		parser,
 	})
 

--- a/pkg/logql/shardmapper_test.go
+++ b/pkg/logql/shardmapper_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/loki/pkg/logql/log"
 	"github.com/grafana/loki/pkg/logql/syntax"
 	"github.com/grafana/loki/pkg/logqlmodel"
 	"github.com/grafana/loki/pkg/querier/astmapper"
@@ -529,7 +530,7 @@ func TestMapping(t *testing.T) {
 						MultiStages: syntax.MultiStageExpr{
 							&syntax.LineFilterExpr{
 								LineFilter: syntax.LineFilter{
-									Ty:    labels.MatchEqual,
+									Ty:    log.LineMatchEqual,
 									Match: "error",
 									Op:    "",
 								},
@@ -550,7 +551,7 @@ func TestMapping(t *testing.T) {
 							MultiStages: syntax.MultiStageExpr{
 								&syntax.LineFilterExpr{
 									LineFilter: syntax.LineFilter{
-										Ty:    labels.MatchEqual,
+										Ty:    log.LineMatchEqual,
 										Match: "error",
 										Op:    "",
 									},

--- a/pkg/logql/syntax/ast.go
+++ b/pkg/logql/syntax/ast.go
@@ -329,7 +329,7 @@ func (e *PipelineExpr) HasFilter() bool {
 }
 
 type LineFilter struct {
-	Ty    labels.MatchType
+	Ty    log.LineMatchType
 	Match string
 	Op    string
 }
@@ -342,7 +342,7 @@ type LineFilterExpr struct {
 	implicit
 }
 
-func newLineFilterExpr(ty labels.MatchType, op, match string) *LineFilterExpr {
+func newLineFilterExpr(ty log.LineMatchType, op, match string) *LineFilterExpr {
 	return &LineFilterExpr{
 		LineFilter: LineFilter{
 			Ty:    ty,
@@ -355,7 +355,7 @@ func newLineFilterExpr(ty labels.MatchType, op, match string) *LineFilterExpr {
 func newOrLineFilter(left, right *LineFilterExpr) *LineFilterExpr {
 	right.Ty = left.Ty
 
-	if left.Ty == labels.MatchEqual || left.Ty == labels.MatchRegexp {
+	if left.Ty == log.LineMatchEqual || left.Ty == log.LineMatchRegexp {
 		left.Or = right
 		right.IsOrChild = true
 		return left
@@ -389,7 +389,7 @@ func (e *LineFilterExpr) Accept(v RootVisitor) {
 }
 
 // AddFilterExpr adds a filter expression to a logselector expression.
-func AddFilterExpr(expr LogSelectorExpr, ty labels.MatchType, op, match string) (LogSelectorExpr, error) {
+func AddFilterExpr(expr LogSelectorExpr, ty log.LineMatchType, op, match string) (LogSelectorExpr, error) {
 	filter := newLineFilterExpr(ty, op, match)
 	switch e := expr.(type) {
 	case *MatchersExpr:
@@ -412,16 +412,7 @@ func (e *LineFilterExpr) String() string {
 	}
 
 	if !e.IsOrChild { // Only write the type when we're not chaining "or" filters
-		switch e.Ty {
-		case labels.MatchRegexp:
-			sb.WriteString("|~")
-		case labels.MatchNotRegexp:
-			sb.WriteString("!~")
-		case labels.MatchEqual:
-			sb.WriteString("|=")
-		case labels.MatchNotEqual:
-			sb.WriteString("!=")
-		}
+		sb.WriteString(e.Ty.String())
 		sb.WriteString(" ")
 	}
 

--- a/pkg/logql/syntax/ast_test.go
+++ b/pkg/logql/syntax/ast_test.go
@@ -449,16 +449,16 @@ func Test_FilterMatcher(t *testing.T) {
 
 func TestOrLineFilterTypes(t *testing.T) {
 	for _, tt := range []struct {
-		ty labels.MatchType
+		ty log.LineMatchType
 	}{
-		{labels.MatchEqual},
-		{labels.MatchNotEqual},
-		{labels.MatchRegexp},
-		{labels.MatchNotRegexp},
+		{log.LineMatchEqual},
+		{log.LineMatchNotEqual},
+		{log.LineMatchRegexp},
+		{log.LineMatchNotRegexp},
 	} {
 		t.Run("right inherits left's type", func(t *testing.T) {
 			left := &LineFilterExpr{LineFilter: LineFilter{Ty: tt.ty, Match: "something"}}
-			right := &LineFilterExpr{LineFilter: LineFilter{Ty: labels.MatchEqual, Match: "something"}}
+			right := &LineFilterExpr{LineFilter: LineFilter{Ty: log.LineMatchEqual, Match: "something"}}
 
 			_ = newOrLineFilter(left, right)
 			require.Equal(t, tt.ty, right.Ty)

--- a/pkg/logql/syntax/expr.y
+++ b/pkg/logql/syntax/expr.y
@@ -11,7 +11,7 @@ import (
 
 %union{
   Expr                    Expr
-  Filter                  labels.MatchType
+  Filter                  log.LineMatchType
   Grouping                *Grouping
   Labels                  []string
   LogExpr                 LogSelectorExpr
@@ -239,10 +239,10 @@ labelReplaceExpr:
     ;
 
 filter:
-      PIPE_MATCH                       { $$ = labels.MatchRegexp }
-    | PIPE_EXACT                       { $$ = labels.MatchEqual }
-    | NRE                              { $$ = labels.MatchNotRegexp }
-    | NEQ                              { $$ = labels.MatchNotEqual }
+      PIPE_MATCH                       { $$ = log.LineMatchRegexp }
+    | PIPE_EXACT                       { $$ = log.LineMatchEqual }
+    | NRE                              { $$ = log.LineMatchNotRegexp }
+    | NEQ                              { $$ = log.LineMatchNotEqual }
     ;
 
 selector:
@@ -287,9 +287,9 @@ filterOp:
   ;
 
 orFilter:
-    STRING                                              { $$ = newLineFilterExpr(labels.MatchEqual, "", $1) }
-  | filterOp OPEN_PARENTHESIS STRING CLOSE_PARENTHESIS	{ $$ = newLineFilterExpr(labels.MatchEqual, $1, $3) }
-  | STRING OR orFilter                                  { $$ = newOrLineFilter(newLineFilterExpr(labels.MatchEqual, "", $1), $3) }
+    STRING                                              { $$ = newLineFilterExpr(log.LineMatchEqual, "", $1) }
+  | filterOp OPEN_PARENTHESIS STRING CLOSE_PARENTHESIS	{ $$ = newLineFilterExpr(log.LineMatchEqual, $1, $3) }
+  | STRING OR orFilter                                  { $$ = newOrLineFilter(newLineFilterExpr(log.LineMatchEqual, "", $1), $3) }
   ;
 
 lineFilter:

--- a/pkg/logql/syntax/expr.y.go
+++ b/pkg/logql/syntax/expr.y.go
@@ -4,7 +4,6 @@ package syntax
 
 import __yyfmt__ "fmt"
 
-
 import (
 	"github.com/grafana/loki/pkg/logql/log"
 	"github.com/prometheus/prometheus/model/labels"
@@ -14,7 +13,7 @@ import (
 type exprSymType struct {
 	yys                   int
 	Expr                  Expr
-	Filter                labels.MatchType
+	Filter                log.LineMatchType
 	Grouping              *Grouping
 	Labels                []string
 	LogExpr               LogSelectorExpr
@@ -265,7 +264,6 @@ var exprStatenames = [...]string{}
 const exprEofCode = 1
 const exprErrCode = 2
 const exprInitialStackSize = 16
-
 
 var exprExca = [...]int{
 	-1, 1,
@@ -553,7 +551,6 @@ var exprErrorMessages = [...]struct {
 	token int
 	msg   string
 }{}
-
 
 /*	parser for yacc output	*/
 
@@ -1162,22 +1159,22 @@ exprdefault:
 	case 57:
 		exprDollar = exprS[exprpt-1 : exprpt+1]
 		{
-			exprVAL.Filter = labels.MatchRegexp
+			exprVAL.Filter = log.LineMatchRegexp
 		}
 	case 58:
 		exprDollar = exprS[exprpt-1 : exprpt+1]
 		{
-			exprVAL.Filter = labels.MatchEqual
+			exprVAL.Filter = log.LineMatchEqual
 		}
 	case 59:
 		exprDollar = exprS[exprpt-1 : exprpt+1]
 		{
-			exprVAL.Filter = labels.MatchNotRegexp
+			exprVAL.Filter = log.LineMatchNotRegexp
 		}
 	case 60:
 		exprDollar = exprS[exprpt-1 : exprpt+1]
 		{
-			exprVAL.Filter = labels.MatchNotEqual
+			exprVAL.Filter = log.LineMatchNotEqual
 		}
 	case 61:
 		exprDollar = exprS[exprpt-3 : exprpt+1]
@@ -1296,17 +1293,17 @@ exprdefault:
 	case 84:
 		exprDollar = exprS[exprpt-1 : exprpt+1]
 		{
-			exprVAL.OrFilter = newLineFilterExpr(labels.MatchEqual, "", exprDollar[1].str)
+			exprVAL.OrFilter = newLineFilterExpr(log.LineMatchEqual, "", exprDollar[1].str)
 		}
 	case 85:
 		exprDollar = exprS[exprpt-4 : exprpt+1]
 		{
-			exprVAL.OrFilter = newLineFilterExpr(labels.MatchEqual, exprDollar[1].FilterOp, exprDollar[3].str)
+			exprVAL.OrFilter = newLineFilterExpr(log.LineMatchEqual, exprDollar[1].FilterOp, exprDollar[3].str)
 		}
 	case 86:
 		exprDollar = exprS[exprpt-3 : exprpt+1]
 		{
-			exprVAL.OrFilter = newOrLineFilter(newLineFilterExpr(labels.MatchEqual, "", exprDollar[1].str), exprDollar[3].OrFilter)
+			exprVAL.OrFilter = newOrLineFilter(newLineFilterExpr(log.LineMatchEqual, "", exprDollar[1].str), exprDollar[3].OrFilter)
 		}
 	case 87:
 		exprDollar = exprS[exprpt-2 : exprpt+1]

--- a/pkg/logql/syntax/linefilter.go
+++ b/pkg/logql/syntax/linefilter.go
@@ -1,8 +1,7 @@
 package syntax
 
 import (
-	"github.com/prometheus/prometheus/model/labels"
-
+	"github.com/grafana/loki/pkg/logql/log"
 	"github.com/grafana/loki/pkg/util/encoding"
 )
 
@@ -40,7 +39,7 @@ func (lf LineFilter) MarshalTo(b []byte) (int, error) {
 
 func (lf *LineFilter) Unmarshal(b []byte) error {
 	buf := encoding.DecWith(b)
-	lf.Ty = labels.MatchType(buf.Uvarint())
+	lf.Ty = log.LineMatchType(buf.Uvarint())
 	lf.Match = buf.UvarintStr()
 	lf.Op = buf.UvarintStr()
 	return nil

--- a/pkg/logql/syntax/linefilter_test.go
+++ b/pkg/logql/syntax/linefilter_test.go
@@ -4,18 +4,19 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/pkg/logql/log"
 )
 
 func TestLineFilterSerialization(t *testing.T) {
 	for i, orig := range []LineFilter{
 		{},
-		{Ty: labels.MatchEqual, Match: "match"},
-		{Ty: labels.MatchEqual, Match: "match", Op: "OR"},
-		{Ty: labels.MatchNotEqual, Match: "not match"},
-		{Ty: labels.MatchNotEqual, Match: "not match", Op: "OR"},
-		{Ty: labels.MatchRegexp, Op: "OR"},
+		{Ty: log.LineMatchEqual, Match: "match"},
+		{Ty: log.LineMatchEqual, Match: "match", Op: "OR"},
+		{Ty: log.LineMatchNotEqual, Match: "not match"},
+		{Ty: log.LineMatchNotEqual, Match: "not match", Op: "OR"},
+		{Ty: log.LineMatchRegexp, Op: "OR"},
 	} {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
 			b := make([]byte, orig.Size())

--- a/pkg/logql/syntax/parser_test.go
+++ b/pkg/logql/syntax/parser_test.go
@@ -30,7 +30,7 @@ var ParseTestCases = []struct {
 			Left: &LogRange{
 				Left: &PipelineExpr{
 					MultiStages: MultiStageExpr{
-						newLineFilterExpr(labels.MatchRegexp, "", "error\\"),
+						newLineFilterExpr(log.LineMatchRegexp, "", "error\\"),
 					},
 					Left: &MatchersExpr{
 						Mts: []*labels.Matcher{
@@ -60,7 +60,7 @@ var ParseTestCases = []struct {
 				Left: newPipelineExpr(
 					newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "foo", Value: "bar"}}),
 					MultiStageExpr{
-						newLineFilterExpr(labels.MatchEqual, "", "error"),
+						newLineFilterExpr(log.LineMatchEqual, "", "error"),
 					},
 				),
 				Interval: 12 * time.Hour,
@@ -75,7 +75,7 @@ var ParseTestCases = []struct {
 			Left: &LogRange{
 				Left: newPipelineExpr(
 					newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "foo", Value: "bar"}}),
-					MultiStageExpr{newLineFilterExpr(labels.MatchEqual, "", "error")},
+					MultiStageExpr{newLineFilterExpr(log.LineMatchEqual, "", "error")},
 				),
 				Interval: 12 * time.Hour,
 			},
@@ -392,8 +392,8 @@ var ParseTestCases = []struct {
 			newMatcherExpr([]*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")}),
 			MultiStageExpr{
 				newNestedLineFilterExpr(
-					newLineFilterExpr(labels.MatchEqual, "", "baz"),
-					newLineFilterExpr(labels.MatchEqual, OpFilterIP, "123.123.123.123"),
+					newLineFilterExpr(log.LineMatchEqual, "", "baz"),
+					newLineFilterExpr(log.LineMatchEqual, OpFilterIP, "123.123.123.123"),
 				),
 			},
 		),
@@ -404,7 +404,7 @@ var ParseTestCases = []struct {
 			newMatcherExpr([]*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar"), mustNewMatcher(labels.MatchEqual, "ip", "foo")}),
 			MultiStageExpr{
 				newLogfmtParserExpr(nil),
-				newLineFilterExpr(labels.MatchEqual, OpFilterIP, "127.0.0.1"),
+				newLineFilterExpr(log.LineMatchEqual, OpFilterIP, "127.0.0.1"),
 				newLabelFilterExpr(log.NewStringLabelFilter(mustNewMatcher(labels.MatchEqual, "ip", "2.3.4.5"))),
 				newLabelFilterExpr(log.NewStringLabelFilter(mustNewMatcher(labels.MatchEqual, "ip", "abc"))),
 				newLabelFilterExpr(log.NewIPLabelFilter("4.5.6.7", "ipaddr", log.LabelFilterEqual)),
@@ -417,7 +417,7 @@ var ParseTestCases = []struct {
 		exp: newPipelineExpr(
 			newMatcherExpr([]*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")}),
 			MultiStageExpr{
-				newLineFilterExpr(labels.MatchEqual, OpFilterIP, "123.123.123.123"),
+				newLineFilterExpr(log.LineMatchEqual, OpFilterIP, "123.123.123.123"),
 			},
 		),
 	},
@@ -427,8 +427,8 @@ var ParseTestCases = []struct {
 			newMatcherExpr([]*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")}),
 			MultiStageExpr{
 				newNestedLineFilterExpr(
-					newLineFilterExpr(labels.MatchEqual, OpFilterIP, "123.123.123.123"),
-					newLineFilterExpr(labels.MatchEqual, "", "baz"),
+					newLineFilterExpr(log.LineMatchEqual, OpFilterIP, "123.123.123.123"),
+					newLineFilterExpr(log.LineMatchEqual, "", "baz"),
 				),
 			},
 		),
@@ -440,10 +440,10 @@ var ParseTestCases = []struct {
 			MultiStageExpr{
 				newNestedLineFilterExpr(
 					newNestedLineFilterExpr(
-						newLineFilterExpr(labels.MatchEqual, OpFilterIP, "123.123.123.123"),
-						newLineFilterExpr(labels.MatchEqual, "", "baz"),
+						newLineFilterExpr(log.LineMatchEqual, OpFilterIP, "123.123.123.123"),
+						newLineFilterExpr(log.LineMatchEqual, "", "baz"),
 					),
-					newLineFilterExpr(labels.MatchEqual, OpFilterIP, "123.123.123.123"),
+					newLineFilterExpr(log.LineMatchEqual, OpFilterIP, "123.123.123.123"),
 				),
 			},
 		),
@@ -454,8 +454,8 @@ var ParseTestCases = []struct {
 			newMatcherExpr([]*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")}),
 			MultiStageExpr{
 				newNestedLineFilterExpr(
-					newLineFilterExpr(labels.MatchEqual, "", "baz"),
-					newLineFilterExpr(labels.MatchEqual, OpFilterIP, "123.123.123.123"),
+					newLineFilterExpr(log.LineMatchEqual, "", "baz"),
+					newLineFilterExpr(log.LineMatchEqual, OpFilterIP, "123.123.123.123"),
 				),
 			},
 		),
@@ -465,7 +465,7 @@ var ParseTestCases = []struct {
 		exp: newPipelineExpr(
 			newMatcherExpr([]*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")}),
 			MultiStageExpr{
-				newLineFilterExpr(labels.MatchNotEqual, OpFilterIP, "123.123.123.123"),
+				newLineFilterExpr(log.LineMatchNotEqual, OpFilterIP, "123.123.123.123"),
 			},
 		),
 	},
@@ -475,8 +475,8 @@ var ParseTestCases = []struct {
 			newMatcherExpr([]*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")}),
 			MultiStageExpr{
 				newNestedLineFilterExpr(
-					newLineFilterExpr(labels.MatchNotEqual, OpFilterIP, "123.123.123.123"),
-					newLineFilterExpr(labels.MatchEqual, "", "baz"),
+					newLineFilterExpr(log.LineMatchNotEqual, OpFilterIP, "123.123.123.123"),
+					newLineFilterExpr(log.LineMatchEqual, "", "baz"),
 				),
 			},
 		),
@@ -488,10 +488,10 @@ var ParseTestCases = []struct {
 			MultiStageExpr{
 				newNestedLineFilterExpr(
 					newNestedLineFilterExpr(
-						newLineFilterExpr(labels.MatchNotEqual, OpFilterIP, "123.123.123.123"),
-						newLineFilterExpr(labels.MatchEqual, "", "baz"),
+						newLineFilterExpr(log.LineMatchNotEqual, OpFilterIP, "123.123.123.123"),
+						newLineFilterExpr(log.LineMatchEqual, "", "baz"),
 					),
-					newLineFilterExpr(labels.MatchNotEqual, OpFilterIP, "123.123.123.123"),
+					newLineFilterExpr(log.LineMatchNotEqual, OpFilterIP, "123.123.123.123"),
 				),
 			},
 		),
@@ -662,7 +662,7 @@ var ParseTestCases = []struct {
 		in: `{foo="bar"} |= "baz"`,
 		exp: newPipelineExpr(
 			newMatcherExpr([]*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")}),
-			MultiStageExpr{newLineFilterExpr(labels.MatchEqual, "", "baz")},
+			MultiStageExpr{newLineFilterExpr(log.LineMatchEqual, "", "baz")},
 		),
 	},
 	{
@@ -673,12 +673,12 @@ var ParseTestCases = []struct {
 				newNestedLineFilterExpr(
 					newNestedLineFilterExpr(
 						newNestedLineFilterExpr(
-							newLineFilterExpr(labels.MatchEqual, "", "baz"),
-							newLineFilterExpr(labels.MatchRegexp, "", "blip"),
+							newLineFilterExpr(log.LineMatchEqual, "", "baz"),
+							newLineFilterExpr(log.LineMatchRegexp, "", "blip"),
 						),
-						newLineFilterExpr(labels.MatchNotEqual, "", "flip"),
+						newLineFilterExpr(log.LineMatchNotEqual, "", "flip"),
 					),
-					newLineFilterExpr(labels.MatchNotRegexp, "", "flap"),
+					newLineFilterExpr(log.LineMatchNotRegexp, "", "flap"),
 				),
 			},
 		),
@@ -693,12 +693,12 @@ var ParseTestCases = []struct {
 						newNestedLineFilterExpr(
 							newNestedLineFilterExpr(
 								newNestedLineFilterExpr(
-									newLineFilterExpr(labels.MatchEqual, "", "baz"),
-									newLineFilterExpr(labels.MatchRegexp, "", "blip"),
+									newLineFilterExpr(log.LineMatchEqual, "", "baz"),
+									newLineFilterExpr(log.LineMatchRegexp, "", "blip"),
 								),
-								newLineFilterExpr(labels.MatchNotEqual, "", "flip"),
+								newLineFilterExpr(log.LineMatchNotEqual, "", "flip"),
 							),
-							newLineFilterExpr(labels.MatchNotRegexp, "", "flap"),
+							newLineFilterExpr(log.LineMatchNotRegexp, "", "flap"),
 						),
 					},
 				),
@@ -715,12 +715,12 @@ var ParseTestCases = []struct {
 						newNestedLineFilterExpr(
 							newNestedLineFilterExpr(
 								newNestedLineFilterExpr(
-									newLineFilterExpr(labels.MatchEqual, "", "baz"),
-									newLineFilterExpr(labels.MatchRegexp, "", "blip"),
+									newLineFilterExpr(log.LineMatchEqual, "", "baz"),
+									newLineFilterExpr(log.LineMatchRegexp, "", "blip"),
 								),
-								newLineFilterExpr(labels.MatchNotEqual, "", "flip"),
+								newLineFilterExpr(log.LineMatchNotEqual, "", "flip"),
 							),
-							newLineFilterExpr(labels.MatchNotRegexp, "", "flap"),
+							newLineFilterExpr(log.LineMatchNotRegexp, "", "flap"),
 						),
 					},
 				),
@@ -737,12 +737,12 @@ var ParseTestCases = []struct {
 						newNestedLineFilterExpr(
 							newNestedLineFilterExpr(
 								newNestedLineFilterExpr(
-									newLineFilterExpr(labels.MatchEqual, "", "baz"),
-									newLineFilterExpr(labels.MatchRegexp, "", "blip"),
+									newLineFilterExpr(log.LineMatchEqual, "", "baz"),
+									newLineFilterExpr(log.LineMatchRegexp, "", "blip"),
 								),
-								newLineFilterExpr(labels.MatchNotEqual, "", "flip"),
+								newLineFilterExpr(log.LineMatchNotEqual, "", "flip"),
 							),
-							newLineFilterExpr(labels.MatchNotRegexp, "", "flap"),
+							newLineFilterExpr(log.LineMatchNotRegexp, "", "flap"),
 						),
 						newLabelParserExpr(OpParserTypeUnpack, ""),
 					},
@@ -769,12 +769,12 @@ var ParseTestCases = []struct {
 							newNestedLineFilterExpr(
 								newNestedLineFilterExpr(
 									newNestedLineFilterExpr(
-										newLineFilterExpr(labels.MatchEqual, "", "baz"),
-										newLineFilterExpr(labels.MatchRegexp, "", "blip"),
+										newLineFilterExpr(log.LineMatchEqual, "", "baz"),
+										newLineFilterExpr(log.LineMatchRegexp, "", "blip"),
 									),
-									newLineFilterExpr(labels.MatchNotEqual, "", "flip"),
+									newLineFilterExpr(log.LineMatchNotEqual, "", "flip"),
 								),
-								newLineFilterExpr(labels.MatchNotRegexp, "", "flap"),
+								newLineFilterExpr(log.LineMatchNotRegexp, "", "flap"),
 							),
 						},
 					),
@@ -796,12 +796,12 @@ var ParseTestCases = []struct {
 						newNestedLineFilterExpr(
 							newNestedLineFilterExpr(
 								newNestedLineFilterExpr(
-									newLineFilterExpr(labels.MatchEqual, "", "baz"),
-									newLineFilterExpr(labels.MatchRegexp, "", "blip"),
+									newLineFilterExpr(log.LineMatchEqual, "", "baz"),
+									newLineFilterExpr(log.LineMatchRegexp, "", "blip"),
 								),
-								newLineFilterExpr(labels.MatchNotEqual, "", "flip"),
+								newLineFilterExpr(log.LineMatchNotEqual, "", "flip"),
 							),
-							newLineFilterExpr(labels.MatchNotRegexp, "", "flap"),
+							newLineFilterExpr(log.LineMatchNotRegexp, "", "flap"),
 						),
 					},
 				),
@@ -824,12 +824,12 @@ var ParseTestCases = []struct {
 						newNestedLineFilterExpr(
 							newNestedLineFilterExpr(
 								newNestedLineFilterExpr(
-									newLineFilterExpr(labels.MatchEqual, "", "baz"),
-									newLineFilterExpr(labels.MatchRegexp, "", "blip"),
+									newLineFilterExpr(log.LineMatchEqual, "", "baz"),
+									newLineFilterExpr(log.LineMatchRegexp, "", "blip"),
 								),
-								newLineFilterExpr(labels.MatchNotEqual, "", "flip"),
+								newLineFilterExpr(log.LineMatchNotEqual, "", "flip"),
 							),
-							newLineFilterExpr(labels.MatchNotRegexp, "", "flap"),
+							newLineFilterExpr(log.LineMatchNotRegexp, "", "flap"),
 						),
 					},
 				),
@@ -852,12 +852,12 @@ var ParseTestCases = []struct {
 						newNestedLineFilterExpr(
 							newNestedLineFilterExpr(
 								newNestedLineFilterExpr(
-									newLineFilterExpr(labels.MatchEqual, "", "baz"),
-									newLineFilterExpr(labels.MatchRegexp, "", "blip"),
+									newLineFilterExpr(log.LineMatchEqual, "", "baz"),
+									newLineFilterExpr(log.LineMatchRegexp, "", "blip"),
 								),
-								newLineFilterExpr(labels.MatchNotEqual, "", "flip"),
+								newLineFilterExpr(log.LineMatchNotEqual, "", "flip"),
 							),
-							newLineFilterExpr(labels.MatchNotRegexp, "", "flap"),
+							newLineFilterExpr(log.LineMatchNotRegexp, "", "flap"),
 						),
 					},
 				),
@@ -882,12 +882,12 @@ var ParseTestCases = []struct {
 								newNestedLineFilterExpr(
 									newNestedLineFilterExpr(
 										newNestedLineFilterExpr(
-											newLineFilterExpr(labels.MatchEqual, "", "baz"),
-											newLineFilterExpr(labels.MatchRegexp, "", "blip"),
+											newLineFilterExpr(log.LineMatchEqual, "", "baz"),
+											newLineFilterExpr(log.LineMatchRegexp, "", "blip"),
 										),
-										newLineFilterExpr(labels.MatchNotEqual, "", "flip"),
+										newLineFilterExpr(log.LineMatchNotEqual, "", "flip"),
 									),
-									newLineFilterExpr(labels.MatchNotRegexp, "", "flap"),
+									newLineFilterExpr(log.LineMatchNotRegexp, "", "flap"),
 								),
 							},
 						),
@@ -913,12 +913,12 @@ var ParseTestCases = []struct {
 						newNestedLineFilterExpr(
 							newNestedLineFilterExpr(
 								newNestedLineFilterExpr(
-									newLineFilterExpr(labels.MatchEqual, "", "baz"),
-									newLineFilterExpr(labels.MatchRegexp, "", "blip"),
+									newLineFilterExpr(log.LineMatchEqual, "", "baz"),
+									newLineFilterExpr(log.LineMatchRegexp, "", "blip"),
 								),
-								newLineFilterExpr(labels.MatchNotEqual, "", "flip"),
+								newLineFilterExpr(log.LineMatchNotEqual, "", "flip"),
 							),
-							newLineFilterExpr(labels.MatchNotRegexp, "", "flap"),
+							newLineFilterExpr(log.LineMatchNotRegexp, "", "flap"),
 						),
 					},
 				),
@@ -935,12 +935,12 @@ var ParseTestCases = []struct {
 						newNestedLineFilterExpr(
 							newNestedLineFilterExpr(
 								newNestedLineFilterExpr(
-									newLineFilterExpr(labels.MatchEqual, "", "baz"),
-									newLineFilterExpr(labels.MatchRegexp, "", "blip"),
+									newLineFilterExpr(log.LineMatchEqual, "", "baz"),
+									newLineFilterExpr(log.LineMatchRegexp, "", "blip"),
 								),
-								newLineFilterExpr(labels.MatchNotEqual, "", "flip"),
+								newLineFilterExpr(log.LineMatchNotEqual, "", "flip"),
 							),
-							newLineFilterExpr(labels.MatchNotRegexp, "", "flap"),
+							newLineFilterExpr(log.LineMatchNotRegexp, "", "flap"),
 						),
 					},
 				),
@@ -963,12 +963,12 @@ var ParseTestCases = []struct {
 						newNestedLineFilterExpr(
 							newNestedLineFilterExpr(
 								newNestedLineFilterExpr(
-									newLineFilterExpr(labels.MatchEqual, "", "baz"),
-									newLineFilterExpr(labels.MatchRegexp, "", "blip"),
+									newLineFilterExpr(log.LineMatchEqual, "", "baz"),
+									newLineFilterExpr(log.LineMatchRegexp, "", "blip"),
 								),
-								newLineFilterExpr(labels.MatchNotEqual, "", "flip"),
+								newLineFilterExpr(log.LineMatchNotEqual, "", "flip"),
 							),
-							newLineFilterExpr(labels.MatchNotRegexp, "", "flap"),
+							newLineFilterExpr(log.LineMatchNotRegexp, "", "flap"),
 						),
 					},
 				),
@@ -993,12 +993,12 @@ var ParseTestCases = []struct {
 								newNestedLineFilterExpr(
 									newNestedLineFilterExpr(
 										newNestedLineFilterExpr(
-											newLineFilterExpr(labels.MatchEqual, "", "baz"),
-											newLineFilterExpr(labels.MatchRegexp, "", "blip"),
+											newLineFilterExpr(log.LineMatchEqual, "", "baz"),
+											newLineFilterExpr(log.LineMatchRegexp, "", "blip"),
 										),
-										newLineFilterExpr(labels.MatchNotEqual, "", "flip"),
+										newLineFilterExpr(log.LineMatchNotEqual, "", "flip"),
 									),
-									newLineFilterExpr(labels.MatchNotRegexp, "", "flap"),
+									newLineFilterExpr(log.LineMatchNotRegexp, "", "flap"),
 								),
 							},
 						),
@@ -1257,7 +1257,7 @@ var ParseTestCases = []struct {
 								mustNewMatcher(labels.MatchEqual, "namespace", "tns"),
 							}),
 							MultiStageExpr{
-								newLineFilterExpr(labels.MatchEqual, "", "level=error"),
+								newLineFilterExpr(log.LineMatchEqual, "", "level=error"),
 							}),
 						Interval: 5 * time.Minute,
 					}, OpRangeTypeCount, nil, nil),
@@ -1291,7 +1291,7 @@ var ParseTestCases = []struct {
 								mustNewMatcher(labels.MatchEqual, "namespace", "tns"),
 							}),
 							MultiStageExpr{
-								newLineFilterExpr(labels.MatchEqual, "", "level=error"),
+								newLineFilterExpr(log.LineMatchEqual, "", "level=error"),
 							}),
 						Interval: 5 * time.Minute,
 					}, OpRangeTypeCount, nil, nil),
@@ -1368,7 +1368,7 @@ var ParseTestCases = []struct {
 		exp: &PipelineExpr{
 			Left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}),
 			MultiStages: MultiStageExpr{
-				newLineFilterExpr(labels.MatchEqual, "", "bar"),
+				newLineFilterExpr(log.LineMatchEqual, "", "bar"),
 				newLabelParserExpr(OpParserTypeJSON, ""),
 				&LabelFilterExpr{
 					LabelFilterer: log.NewOrLabelFilter(
@@ -1387,7 +1387,7 @@ var ParseTestCases = []struct {
 		exp: &PipelineExpr{
 			Left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}),
 			MultiStages: MultiStageExpr{
-				newLineFilterExpr(labels.MatchEqual, "", "bar"),
+				newLineFilterExpr(log.LineMatchEqual, "", "bar"),
 				newLabelParserExpr(OpParserTypeUnpack, ""),
 				newLabelParserExpr(OpParserTypeJSON, ""),
 				&LabelFilterExpr{
@@ -1407,7 +1407,7 @@ var ParseTestCases = []struct {
 		exp: &PipelineExpr{
 			Left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}),
 			MultiStages: MultiStageExpr{
-				newLineFilterExpr(labels.MatchEqual, "", "bar"),
+				newLineFilterExpr(log.LineMatchEqual, "", "bar"),
 				newLabelParserExpr(OpParserTypeJSON, ""),
 				&LabelFilterExpr{
 					LabelFilterer: log.NewAndLabelFilter(
@@ -1426,7 +1426,7 @@ var ParseTestCases = []struct {
 		exp: &PipelineExpr{
 			Left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}),
 			MultiStages: MultiStageExpr{
-				newLineFilterExpr(labels.MatchEqual, "", "bar"),
+				newLineFilterExpr(log.LineMatchEqual, "", "bar"),
 				newLabelParserExpr(OpParserTypePattern, "<foo> bar <buzz>"),
 				&LabelFilterExpr{
 					LabelFilterer: log.NewAndLabelFilter(
@@ -1445,7 +1445,7 @@ var ParseTestCases = []struct {
 		exp: &PipelineExpr{
 			Left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}),
 			MultiStages: MultiStageExpr{
-				newLineFilterExpr(labels.MatchEqual, "", "bar"),
+				newLineFilterExpr(log.LineMatchEqual, "", "bar"),
 				newLabelParserExpr(OpParserTypeJSON, ""),
 				&LabelFilterExpr{
 					LabelFilterer: log.NewOrLabelFilter(
@@ -1464,7 +1464,7 @@ var ParseTestCases = []struct {
 		exp: &PipelineExpr{
 			Left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}),
 			MultiStages: MultiStageExpr{
-				newLineFilterExpr(labels.MatchEqual, "", "bar"),
+				newLineFilterExpr(log.LineMatchEqual, "", "bar"),
 				newLabelParserExpr(OpParserTypeJSON, ""),
 				&LabelFilterExpr{
 					LabelFilterer: log.NewAndLabelFilter(
@@ -1483,7 +1483,7 @@ var ParseTestCases = []struct {
 		exp: &PipelineExpr{
 			Left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}),
 			MultiStages: MultiStageExpr{
-				newLineFilterExpr(labels.MatchEqual, "", "bar"),
+				newLineFilterExpr(log.LineMatchEqual, "", "bar"),
 				newLabelParserExpr(OpParserTypeJSON, ""),
 				&LabelFilterExpr{
 					LabelFilterer: log.NewOrLabelFilter(
@@ -1503,7 +1503,7 @@ var ParseTestCases = []struct {
 		exp: &PipelineExpr{
 			Left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}),
 			MultiStages: MultiStageExpr{
-				newLineFilterExpr(labels.MatchEqual, "", "bar"),
+				newLineFilterExpr(log.LineMatchEqual, "", "bar"),
 				newLabelParserExpr(OpParserTypeJSON, ""),
 				&LabelFilterExpr{
 					LabelFilterer: log.NewOrLabelFilter(
@@ -1534,7 +1534,7 @@ var ParseTestCases = []struct {
 		exp: &PipelineExpr{
 			Left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}),
 			MultiStages: MultiStageExpr{
-				newLineFilterExpr(labels.MatchEqual, "", "bar"),
+				newLineFilterExpr(log.LineMatchEqual, "", "bar"),
 				newLineFmtExpr("blip{{ .foo }}blop"),
 			},
 		},
@@ -1545,7 +1545,7 @@ var ParseTestCases = []struct {
 		exp: &PipelineExpr{
 			Left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}),
 			MultiStages: MultiStageExpr{
-				newLineFilterExpr(labels.MatchEqual, "", "bar"),
+				newLineFilterExpr(log.LineMatchEqual, "", "bar"),
 				newLabelParserExpr(OpParserTypeJSON, ""),
 				&LabelFilterExpr{
 					LabelFilterer: log.NewOrLabelFilter(
@@ -1566,7 +1566,7 @@ var ParseTestCases = []struct {
 		exp: &PipelineExpr{
 			Left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}),
 			MultiStages: MultiStageExpr{
-				newLineFilterExpr(labels.MatchEqual, "", "bar"),
+				newLineFilterExpr(log.LineMatchEqual, "", "bar"),
 				newLabelParserExpr(OpParserTypeJSON, ""),
 				&LabelFilterExpr{
 					LabelFilterer: log.NewOrLabelFilter(
@@ -1592,7 +1592,7 @@ var ParseTestCases = []struct {
 			newLogRange(&PipelineExpr{
 				Left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}),
 				MultiStages: MultiStageExpr{
-					newLineFilterExpr(labels.MatchEqual, "", "bar"),
+					newLineFilterExpr(log.LineMatchEqual, "", "bar"),
 					newLabelParserExpr(OpParserTypeJSON, ""),
 					&LabelFilterExpr{
 						LabelFilterer: log.NewOrLabelFilter(
@@ -1638,7 +1638,7 @@ var ParseTestCases = []struct {
 		exp: &PipelineExpr{
 			Left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}),
 			MultiStages: MultiStageExpr{
-				newLineFilterExpr(labels.MatchEqual, "", "bar"),
+				newLineFilterExpr(log.LineMatchEqual, "", "bar"),
 				newLabelParserExpr(OpParserTypeJSON, ""),
 				&LabelFilterExpr{
 					LabelFilterer: log.NewOrLabelFilter(
@@ -1659,7 +1659,7 @@ var ParseTestCases = []struct {
 			newLogRange(&PipelineExpr{
 				Left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}),
 				MultiStages: MultiStageExpr{
-					newLineFilterExpr(labels.MatchEqual, "", "bar"),
+					newLineFilterExpr(log.LineMatchEqual, "", "bar"),
 					newLabelParserExpr(OpParserTypeJSON, ""),
 					&LabelFilterExpr{
 						LabelFilterer: log.NewOrLabelFilter(
@@ -1690,7 +1690,7 @@ var ParseTestCases = []struct {
 			newLogRange(&PipelineExpr{
 				Left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}),
 				MultiStages: MultiStageExpr{
-					newLineFilterExpr(labels.MatchEqual, "", "bar"),
+					newLineFilterExpr(log.LineMatchEqual, "", "bar"),
 					newLabelParserExpr(OpParserTypeJSON, ""),
 					&LabelFilterExpr{
 						LabelFilterer: log.NewOrLabelFilter(
@@ -1720,7 +1720,7 @@ var ParseTestCases = []struct {
 			newLogRange(&PipelineExpr{
 				Left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "namespace", Value: "tns"}}),
 				MultiStages: MultiStageExpr{
-					newLineFilterExpr(labels.MatchEqual, "", "level=error"),
+					newLineFilterExpr(log.LineMatchEqual, "", "level=error"),
 					newLabelParserExpr(OpParserTypeJSON, ""),
 					&LabelFilterExpr{
 						LabelFilterer: log.NewAndLabelFilter(
@@ -1742,7 +1742,7 @@ var ParseTestCases = []struct {
 			newLogRange(&PipelineExpr{
 				Left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "namespace", Value: "tns"}}),
 				MultiStages: MultiStageExpr{
-					newLineFilterExpr(labels.MatchEqual, "", "level=error"),
+					newLineFilterExpr(log.LineMatchEqual, "", "level=error"),
 					newLabelParserExpr(OpParserTypeJSON, ""),
 					&LabelFilterExpr{
 						LabelFilterer: log.NewAndLabelFilter(
@@ -1764,7 +1764,7 @@ var ParseTestCases = []struct {
 			newLogRange(&PipelineExpr{
 				Left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "namespace", Value: "tns"}}),
 				MultiStages: MultiStageExpr{
-					newLineFilterExpr(labels.MatchEqual, "", "level=error"),
+					newLineFilterExpr(log.LineMatchEqual, "", "level=error"),
 					newLabelParserExpr(OpParserTypeJSON, ""),
 					&LabelFilterExpr{
 						LabelFilterer: log.NewAndLabelFilter(
@@ -1786,7 +1786,7 @@ var ParseTestCases = []struct {
 			newLogRange(&PipelineExpr{
 				Left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "namespace", Value: "tns"}}),
 				MultiStages: MultiStageExpr{
-					newLineFilterExpr(labels.MatchEqual, "", "level=error"),
+					newLineFilterExpr(log.LineMatchEqual, "", "level=error"),
 					newLabelParserExpr(OpParserTypeJSON, ""),
 					&LabelFilterExpr{
 						LabelFilterer: log.NewAndLabelFilter(
@@ -1808,7 +1808,7 @@ var ParseTestCases = []struct {
 			newLogRange(&PipelineExpr{
 				Left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}),
 				MultiStages: MultiStageExpr{
-					newLineFilterExpr(labels.MatchEqual, "", "bar"),
+					newLineFilterExpr(log.LineMatchEqual, "", "bar"),
 				},
 			},
 				5*time.Minute,
@@ -1890,7 +1890,7 @@ var ParseTestCases = []struct {
 			newLogRange(&PipelineExpr{
 				Left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}),
 				MultiStages: MultiStageExpr{
-					newLineFilterExpr(labels.MatchEqual, "", "bar"),
+					newLineFilterExpr(log.LineMatchEqual, "", "bar"),
 					newLabelParserExpr(OpParserTypeJSON, ""),
 					&LabelFilterExpr{
 						LabelFilterer: log.NewOrLabelFilter(
@@ -1921,7 +1921,7 @@ var ParseTestCases = []struct {
 			newLogRange(&PipelineExpr{
 				Left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}),
 				MultiStages: MultiStageExpr{
-					newLineFilterExpr(labels.MatchEqual, "", "bar"),
+					newLineFilterExpr(log.LineMatchEqual, "", "bar"),
 					newLabelParserExpr(OpParserTypeJSON, ""),
 					&LabelFilterExpr{
 						LabelFilterer: log.NewOrLabelFilter(
@@ -1952,7 +1952,7 @@ var ParseTestCases = []struct {
 			newLogRange(&PipelineExpr{
 				Left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}),
 				MultiStages: MultiStageExpr{
-					newLineFilterExpr(labels.MatchEqual, "", "bar"),
+					newLineFilterExpr(log.LineMatchEqual, "", "bar"),
 					newLabelParserExpr(OpParserTypeJSON, ""),
 					&LabelFilterExpr{
 						LabelFilterer: log.NewOrLabelFilter(
@@ -1983,7 +1983,7 @@ var ParseTestCases = []struct {
 			newLogRange(&PipelineExpr{
 				Left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}),
 				MultiStages: MultiStageExpr{
-					newLineFilterExpr(labels.MatchEqual, "", "bar"),
+					newLineFilterExpr(log.LineMatchEqual, "", "bar"),
 					newLabelParserExpr(OpParserTypeJSON, ""),
 					&LabelFilterExpr{
 						LabelFilterer: log.NewOrLabelFilter(
@@ -2018,7 +2018,7 @@ var ParseTestCases = []struct {
 				newLogRange(&PipelineExpr{
 					Left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}),
 					MultiStages: MultiStageExpr{
-						newLineFilterExpr(labels.MatchEqual, "", "bar"),
+						newLineFilterExpr(log.LineMatchEqual, "", "bar"),
 						newLabelParserExpr(OpParserTypeJSON, ""),
 						&LabelFilterExpr{
 							LabelFilterer: log.NewOrLabelFilter(
@@ -2057,7 +2057,7 @@ var ParseTestCases = []struct {
 				newLogRange(&PipelineExpr{
 					Left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}),
 					MultiStages: MultiStageExpr{
-						newLineFilterExpr(labels.MatchEqual, "", "bar"),
+						newLineFilterExpr(log.LineMatchEqual, "", "bar"),
 						newLabelParserExpr(OpParserTypeJSON, ""),
 						&LabelFilterExpr{
 							LabelFilterer: log.NewOrLabelFilter(
@@ -2096,7 +2096,7 @@ var ParseTestCases = []struct {
 				newLogRange(&PipelineExpr{
 					Left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}),
 					MultiStages: MultiStageExpr{
-						newLineFilterExpr(labels.MatchEqual, "", "bar"),
+						newLineFilterExpr(log.LineMatchEqual, "", "bar"),
 						newLabelParserExpr(OpParserTypeJSON, ""),
 						&LabelFilterExpr{
 							LabelFilterer: log.NewOrLabelFilter(
@@ -2135,7 +2135,7 @@ var ParseTestCases = []struct {
 				newLogRange(&PipelineExpr{
 					Left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}),
 					MultiStages: MultiStageExpr{
-						newLineFilterExpr(labels.MatchEqual, "", "bar"),
+						newLineFilterExpr(log.LineMatchEqual, "", "bar"),
 						newLabelParserExpr(OpParserTypeJSON, ""),
 						&LabelFilterExpr{
 							LabelFilterer: log.NewOrLabelFilter(
@@ -2174,7 +2174,7 @@ var ParseTestCases = []struct {
 				newLogRange(&PipelineExpr{
 					Left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}),
 					MultiStages: MultiStageExpr{
-						newLineFilterExpr(labels.MatchEqual, "", "bar"),
+						newLineFilterExpr(log.LineMatchEqual, "", "bar"),
 						newLabelParserExpr(OpParserTypeJSON, ""),
 						&LabelFilterExpr{
 							LabelFilterer: log.NewOrLabelFilter(
@@ -2213,7 +2213,7 @@ var ParseTestCases = []struct {
 				newLogRange(&PipelineExpr{
 					Left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}),
 					MultiStages: MultiStageExpr{
-						newLineFilterExpr(labels.MatchEqual, "", "bar"),
+						newLineFilterExpr(log.LineMatchEqual, "", "bar"),
 						newLabelParserExpr(OpParserTypeJSON, ""),
 						&LabelFilterExpr{
 							LabelFilterer: log.NewOrLabelFilter(
@@ -2263,7 +2263,7 @@ var ParseTestCases = []struct {
 					newLogRange(&PipelineExpr{
 						Left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}),
 						MultiStages: MultiStageExpr{
-							newLineFilterExpr(labels.MatchEqual, "", "bar"),
+							newLineFilterExpr(log.LineMatchEqual, "", "bar"),
 							newLabelParserExpr(OpParserTypeJSON, ""),
 							&LabelFilterExpr{
 								LabelFilterer: log.NewOrLabelFilter(
@@ -2295,7 +2295,7 @@ var ParseTestCases = []struct {
 					newLogRange(&PipelineExpr{
 						Left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}),
 						MultiStages: MultiStageExpr{
-							newLineFilterExpr(labels.MatchEqual, "", "bar"),
+							newLineFilterExpr(log.LineMatchEqual, "", "bar"),
 							newLabelParserExpr(OpParserTypeJSON, ""),
 							&LabelFilterExpr{
 								LabelFilterer: log.NewOrLabelFilter(
@@ -2344,7 +2344,7 @@ var ParseTestCases = []struct {
 					newLogRange(&PipelineExpr{
 						Left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}),
 						MultiStages: MultiStageExpr{
-							newLineFilterExpr(labels.MatchEqual, "", "bar"),
+							newLineFilterExpr(log.LineMatchEqual, "", "bar"),
 							newLabelParserExpr(OpParserTypeJSON, ""),
 							&LabelFilterExpr{
 								LabelFilterer: log.NewOrLabelFilter(
@@ -2376,7 +2376,7 @@ var ParseTestCases = []struct {
 					newLogRange(&PipelineExpr{
 						Left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}),
 						MultiStages: MultiStageExpr{
-							newLineFilterExpr(labels.MatchEqual, "", "bar"),
+							newLineFilterExpr(log.LineMatchEqual, "", "bar"),
 							newLabelParserExpr(OpParserTypeJSON, ""),
 							&LabelFilterExpr{
 								LabelFilterer: log.NewOrLabelFilter(
@@ -2425,7 +2425,7 @@ var ParseTestCases = []struct {
 					newLogRange(&PipelineExpr{
 						Left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}),
 						MultiStages: MultiStageExpr{
-							newLineFilterExpr(labels.MatchEqual, "", "bar"),
+							newLineFilterExpr(log.LineMatchEqual, "", "bar"),
 							newLabelParserExpr(OpParserTypeJSON, ""),
 							&LabelFilterExpr{
 								LabelFilterer: log.NewOrLabelFilter(
@@ -2457,7 +2457,7 @@ var ParseTestCases = []struct {
 					newLogRange(&PipelineExpr{
 						Left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}),
 						MultiStages: MultiStageExpr{
-							newLineFilterExpr(labels.MatchEqual, "", "bar"),
+							newLineFilterExpr(log.LineMatchEqual, "", "bar"),
 							newLabelParserExpr(OpParserTypeJSON, ""),
 							&LabelFilterExpr{
 								LabelFilterer: log.NewOrLabelFilter(
@@ -2506,7 +2506,7 @@ var ParseTestCases = []struct {
 					newLogRange(&PipelineExpr{
 						Left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}),
 						MultiStages: MultiStageExpr{
-							newLineFilterExpr(labels.MatchEqual, "", "bar"),
+							newLineFilterExpr(log.LineMatchEqual, "", "bar"),
 							newLabelParserExpr(OpParserTypeJSON, ""),
 							&LabelFilterExpr{
 								LabelFilterer: log.NewOrLabelFilter(
@@ -2538,7 +2538,7 @@ var ParseTestCases = []struct {
 					newLogRange(&PipelineExpr{
 						Left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}),
 						MultiStages: MultiStageExpr{
-							newLineFilterExpr(labels.MatchEqual, "", "bar"),
+							newLineFilterExpr(log.LineMatchEqual, "", "bar"),
 							newLabelParserExpr(OpParserTypeJSON, ""),
 							&LabelFilterExpr{
 								LabelFilterer: log.NewOrLabelFilter(
@@ -2655,7 +2655,7 @@ var ParseTestCases = []struct {
 						newLogRange(&PipelineExpr{
 							Left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}),
 							MultiStages: MultiStageExpr{
-								newLineFilterExpr(labels.MatchEqual, "", "bar"),
+								newLineFilterExpr(log.LineMatchEqual, "", "bar"),
 								newLabelParserExpr(OpParserTypeJSON, ""),
 								&LabelFilterExpr{
 									LabelFilterer: log.NewOrLabelFilter(
@@ -2687,7 +2687,7 @@ var ParseTestCases = []struct {
 						newLogRange(&PipelineExpr{
 							Left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}),
 							MultiStages: MultiStageExpr{
-								newLineFilterExpr(labels.MatchEqual, "", "bar"),
+								newLineFilterExpr(log.LineMatchEqual, "", "bar"),
 								newLabelParserExpr(OpParserTypeJSON, ""),
 								&LabelFilterExpr{
 									LabelFilterer: log.NewOrLabelFilter(
@@ -2932,7 +2932,7 @@ var ParseTestCases = []struct {
 		exp: &PipelineExpr{
 			Left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}),
 			MultiStages: MultiStageExpr{
-				newLineFilterExpr(labels.MatchEqual, "", "bar"),
+				newLineFilterExpr(log.LineMatchEqual, "", "bar"),
 				newLabelParserExpr(OpParserTypeJSON, ""),
 			},
 		},
@@ -2963,7 +2963,7 @@ var ParseTestCases = []struct {
 		exp: &PipelineExpr{
 			Left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}),
 			MultiStages: MultiStageExpr{
-				newLineFilterExpr(labels.MatchEqual, "", "#"),
+				newLineFilterExpr(log.LineMatchEqual, "", "#"),
 			},
 		},
 	},
@@ -3147,23 +3147,23 @@ var ParseTestCases = []struct {
 					Left: newOrLineFilter(
 						&LineFilterExpr{
 							LineFilter: LineFilter{
-								Ty:    labels.MatchEqual,
+								Ty:    log.LineMatchEqual,
 								Match: "foo",
 							},
 						},
 						&LineFilterExpr{
 							LineFilter: LineFilter{
-								Ty:    labels.MatchEqual,
+								Ty:    log.LineMatchEqual,
 								Match: "bar",
 							},
 						}),
 					LineFilter: LineFilter{
-						Ty:    labels.MatchEqual,
+						Ty:    log.LineMatchEqual,
 						Match: "buzz",
 					},
 					Or: &LineFilterExpr{
 						LineFilter: LineFilter{
-							Ty:    labels.MatchEqual,
+							Ty:    log.LineMatchEqual,
 							Match: "fizz",
 						},
 						IsOrChild: true,

--- a/pkg/querier/queryrange/roundtrip.go
+++ b/pkg/querier/queryrange/roundtrip.go
@@ -15,10 +15,10 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
-	"github.com/prometheus/prometheus/model/labels"
 
 	"github.com/grafana/loki/pkg/logproto"
 	"github.com/grafana/loki/pkg/logql"
+	logqllog "github.com/grafana/loki/pkg/logql/log"
 	"github.com/grafana/loki/pkg/logql/syntax"
 	"github.com/grafana/loki/pkg/logqlmodel/stats"
 	base "github.com/grafana/loki/pkg/querier/queryrange/queryrangebase"
@@ -374,7 +374,7 @@ func (r roundTripper) Do(ctx context.Context, req base.Request) (base.Response, 
 func transformRegexQuery(req *http.Request, expr syntax.LogSelectorExpr) (syntax.LogSelectorExpr, error) {
 	regexp := req.Form.Get("regexp")
 	if regexp != "" {
-		filterExpr, err := syntax.AddFilterExpr(expr, labels.MatchRegexp, "", regexp)
+		filterExpr, err := syntax.AddFilterExpr(expr, logqllog.LineMatchRegexp, "", regexp)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/storage/bloom/v1/bloom_tester.go
+++ b/pkg/storage/bloom/v1/bloom_tester.go
@@ -3,7 +3,6 @@ package v1
 import (
 	"github.com/grafana/regexp"
 	regexpsyntax "github.com/grafana/regexp/syntax"
-	"github.com/prometheus/prometheus/model/labels"
 
 	"github.com/grafana/loki/pkg/logql/log"
 	"github.com/grafana/loki/pkg/logql/syntax"
@@ -90,16 +89,16 @@ func FiltersToBloomTest(b NGramBuilder, filters ...syntax.LineFilterExpr) BloomT
 
 func simpleFilterToBloomTest(b NGramBuilder, filter syntax.LineFilter) BloomTest {
 	switch filter.Ty {
-	case labels.MatchNotEqual, labels.MatchNotRegexp:
+	case log.LineMatchNotEqual, log.LineMatchNotRegexp:
 		// We cannot test _negated_ filters with a bloom filter since blooms are probabilistic
 		// filters that can only tell us if a string _might_ exist.
 		// For example, for `!= "foo"`, the bloom filter might tell us that the string "foo" might exist
 		// but because we are not sure, we cannot discard that chunk because it might actually not be there.
 		// Therefore, we return a test that always returns true.
 		return MatchAll
-	case labels.MatchEqual:
+	case log.LineMatchEqual:
 		return newStringTest(b, filter.Match)
-	case labels.MatchRegexp:
+	case log.LineMatchRegexp:
 		reg, err := regexpsyntax.Parse(filter.Match, regexpsyntax.Perl)
 		if err != nil {
 			// TODO: log error


### PR DESCRIPTION
The PR replaces `labels.MatchType` (prometheus) used in the line filters with a new type `LineMatchType`, specific to the case.

The main reason for this change is that the use of `labels.MatchType` does not allow for the extension of the line filter operators list, which is required for issue #12347.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
