### PR TITLE
feat: Allows to wrap distributor Tee

### DIFF
--- a/pkg/distributor/tee.go
+++ b/pkg/distributor/tee.go
@@ -4,3 +4,24 @@ package distributor
 type Tee interface {
 	Duplicate(tenant string, streams []KeyedStream)
 }
+
+// WrapTee wraps a new Tee around an existing Tee.
+func WrapTee(existing, new Tee) Tee {
+	if existing == nil {
+		return new
+	}
+	if multi, ok := existing.(*multiTee); ok {
+		return &multiTee{append(multi.tees, new)}
+	}
+	return &multiTee{tees: []Tee{existing, new}}
+}
+
+type multiTee struct {
+	tees []Tee
+}
+
+func (m *multiTee) Duplicate(tenant string, streams []KeyedStream) {
+	for _, tee := range m.tees {
+		tee.Duplicate(tenant, streams)
+	}
+}

--- a/pkg/distributor/tee_test.go
+++ b/pkg/distributor/tee_test.go
@@ -3,8 +3,9 @@ package distributor
 import (
 	"testing"
 
-	"github.com/grafana/loki/pkg/push"
 	"github.com/stretchr/testify/mock"
+
+	"github.com/grafana/loki/pkg/push"
 )
 
 type mockedTee struct {

--- a/pkg/distributor/tee_test.go
+++ b/pkg/distributor/tee_test.go
@@ -1,0 +1,43 @@
+package distributor
+
+import (
+	"testing"
+
+	"github.com/grafana/loki/pkg/push"
+	"github.com/stretchr/testify/mock"
+)
+
+type mockedTee struct {
+	mock.Mock
+}
+
+func (m *mockedTee) Duplicate(tenant string, streams []KeyedStream) {
+	m.Called(tenant, streams)
+}
+
+func TestWrapTee(t *testing.T) {
+	tee1 := new(mockedTee)
+	tee2 := new(mockedTee)
+	tee3 := new(mockedTee)
+	streams := []KeyedStream{
+		{
+			HashKey: 1,
+			Stream:  push.Stream{},
+		},
+	}
+	tee1.On("Duplicate", "1", streams).Once()
+	tee1.On("Duplicate", "2", streams).Once()
+	tee2.On("Duplicate", "2", streams).Once()
+	tee1.On("Duplicate", "3", streams).Once()
+	tee2.On("Duplicate", "3", streams).Once()
+	tee3.On("Duplicate", "3", streams).Once()
+
+	wrappedTee := WrapTee(nil, tee1)
+	wrappedTee.Duplicate("1", streams)
+
+	wrappedTee = WrapTee(wrappedTee, tee2)
+	wrappedTee.Duplicate("2", streams)
+
+	wrappedTee = WrapTee(wrappedTee, tee3)
+	wrappedTee.Duplicate("3", streams)
+}

--- a/pkg/distributor/tee_test.go
+++ b/pkg/distributor/tee_test.go
@@ -40,4 +40,8 @@ func TestWrapTee(t *testing.T) {
 
 	wrappedTee = WrapTee(wrappedTee, tee3)
 	wrappedTee.Duplicate("3", streams)
+
+	tee1.AssertExpectations(t)
+	tee2.AssertExpectations(t)
+	tee3.AssertExpectations(t)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This is going to be useful when we we want to tee to multiple destination and avoid the original Tee being replaced.

cc @MasslessParticle 



**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
