### PR TITLE
fix(tsdb): correctly use bit prefix calculation in tsdb shard matching

### DIFF
--- a/pkg/logql/shards.go
+++ b/pkg/logql/shards.go
@@ -159,7 +159,7 @@ func (s *Shard) Match(fp model.Fingerprint) bool {
 		return v1.BoundsFromProto(s.Bounded.Bounds).Match(fp)
 	}
 
-	return s.PowerOfTwo.Match(fp)
+	return s.PowerOfTwo.TSDB().Match(fp)
 }
 
 func (s *Shard) GetFromThrough() (model.Fingerprint, model.Fingerprint) {


### PR DESCRIPTION
I unwittingly introduced a bug in https://github.com/grafana/loki/pull/12208 by using the old `astmapper` shard's `Match` calculation, which caused us to incorrectly calculate shard inclusion in TSDB. This PR fixes that and I'll look into another to preclude reintroducing this type of error.