### PR TITLE
feat: Bring back bloom components to backend target in SSD

### DIFF
--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -663,7 +663,7 @@ func (t *Loki) setupModuleManager() error {
 
 		Read:    {QueryFrontend, Querier},
 		Write:   {Ingester, Distributor},
-		Backend: {QueryScheduler, Ruler, Compactor, IndexGateway},
+		Backend: {QueryScheduler, Ruler, Compactor, IndexGateway, BloomGateway, BloomCompactor},
 
 		All: {QueryScheduler, QueryFrontend, Querier, Ingester, Distributor, Ruler, Compactor},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR brings back (from https://github.com/grafana/loki/pull/12381) the bloom compactor and bloom gateways to the backend target of the SSD mode.
The flags that enable the compactor and the gateways, as well as actual per-tenant filtering are disabled by default so a user of SSD shouldn't actually use blooms unless they manually enabled them. These flags are:
- `bloom-compactor.enabled`
- `bloom-gateway.enabled`
- per tenant `bloom_gateway_enable_filtering` and `bloom_compactor_enable_compaction`

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
