### PR TITLE
fix(blooms): Remove blocks not matching any series in task

### DIFF
--- a/pkg/bloomgateway/processor.go
+++ b/pkg/bloomgateway/processor.go
@@ -175,7 +175,7 @@ func (p *processor) processBlock(_ context.Context, blockQuerier *v1.BlockQuerie
 		if sp := opentracing.SpanFromContext(task.ctx); sp != nil {
 			md, _ := blockQuerier.Metadata()
 			blk := bloomshipper.BlockRefFrom(task.Tenant, task.table.String(), md)
-			sp.LogKV("process block", blk.String())
+			sp.LogKV("process block", blk.String(), "series", len(task.series))
 		}
 
 		it := v1.NewPeekingIter(task.RequestIter(tokenizer))

--- a/pkg/bloomgateway/util.go
+++ b/pkg/bloomgateway/util.go
@@ -78,7 +78,7 @@ func partitionTasks(tasks []Task, blocks []bloomshipper.BlockRef) []blockWithTas
 			})
 
 			// All fingerprints fall outside of the consumer's range
-			if min == len(refs) || max == 0 {
+			if min == len(refs) || max == 0 || min == max {
 				continue
 			}
 

--- a/pkg/bloomgateway/util_test.go
+++ b/pkg/bloomgateway/util_test.go
@@ -136,6 +136,26 @@ func TestPartitionTasks(t *testing.T) {
 			require.Len(t, res.tasks[0].series, 90)
 		}
 	})
+
+	t.Run("block series before and after task series", func(t *testing.T) {
+		bounds := []bloomshipper.BlockRef{
+			mkBlockRef(100, 200),
+		}
+
+		tasks := []Task{
+			{
+				series: []*logproto.GroupedChunkRefs{
+					{Fingerprint: 50},
+					{Fingerprint: 75},
+					{Fingerprint: 250},
+					{Fingerprint: 300},
+				},
+			},
+		}
+
+		results := partitionTasks(tasks, bounds)
+		require.Len(t, results, 0)
+	})
 }
 
 func TestPartitionRequest(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

We were downloading way more blocks than series for a given task. This was suspicious since we should download up to one block per requested series. Turns out there was a bug in the `partitionTasks` function where we were not filtering out blocks that didn't match any of the series on a given task.

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
