### PR TITLE
chore: Update examples to use v13 schema, along with related defaults

### DIFF
--- a/cmd/loki/loki-docker-config.yaml
+++ b/cmd/loki/loki-docker-config.yaml
@@ -20,7 +20,7 @@ schema_config:
     - from: 2020-10-24
       store: tsdb
       object_store: filesystem
-      schema: v12
+      schema: v13
       index:
         prefix: index_
         period: 24h

--- a/cmd/loki/loki-local-config.yaml
+++ b/cmd/loki/loki-local-config.yaml
@@ -28,7 +28,7 @@ schema_config:
     - from: 2020-10-24
       store: tsdb
       object_store: filesystem
-      schema: v12
+      schema: v13
       index:
         prefix: index_
         period: 24h

--- a/cmd/loki/loki-local-experimental-config.yaml
+++ b/cmd/loki/loki-local-experimental-config.yaml
@@ -28,7 +28,7 @@ schema_config:
     - from: 2020-10-24
       store: tsdb
       object_store: filesystem
-      schema: v12
+      schema: v13
       index:
         prefix: index_
         period: 24h

--- a/cmd/loki/loki-local-with-memcached.yaml
+++ b/cmd/loki/loki-local-with-memcached.yaml
@@ -76,7 +76,7 @@ schema_config:
     - from: 2020-10-24
       store: tsdb
       object_store: filesystem
-      schema: v12
+      schema: v13
       index:
         prefix: index_
         period: 24h

--- a/docs/sources/configure/_index.md
+++ b/docs/sources/configure/_index.md
@@ -4753,7 +4753,7 @@ The `period_config` block configures what index schemas should be used for from 
 # gcp-columnkey, bigtable, bigtable-hashed, cassandra, grpc.
 [object_store: <string> | default = ""]
 
-# The schema version to use, current recommended schema is v12.
+# The schema version to use, current recommended schema is v13.
 [schema: <string> | default = ""]
 
 # Configures how the index is updated and stored.

--- a/docs/sources/configure/_index.md
+++ b/docs/sources/configure/_index.md
@@ -4753,7 +4753,7 @@ The `period_config` block configures what index schemas should be used for from 
 # gcp-columnkey, bigtable, bigtable-hashed, cassandra, grpc.
 [object_store: <string> | default = ""]
 
-# The schema version to use, current recommended schema is v13.
+# The schema version to use, current recommended schema is v12.
 [schema: <string> | default = ""]
 
 # Configures how the index is updated and stored.

--- a/docs/sources/configure/examples/configuration-examples.md
+++ b/docs/sources/configure/examples/configuration-examples.md
@@ -30,7 +30,7 @@ schema_config:
   - from: 2020-05-15
     store: tsdb
     object_store: filesystem
-    schema: v12
+    schema: v13
     index:
       prefix: index_
       period: 24h
@@ -71,7 +71,7 @@ schema_config:
   - from: 2020-05-15
     store: tsdb
     object_store: s3
-    schema: v12
+    schema: v13
     index:
       prefix: index_
       period: 24h
@@ -127,7 +127,7 @@ schema_config:
   - from: 2020-05-15
     store: tsdb
     object_store: gcs
-    schema: v12
+    schema: v13
     index:
       prefix: index_
       period: 24h
@@ -154,7 +154,7 @@ schema_config:
     - from: 2020-05-15
       store: tsdb
       object_store: bos
-      schema: v12
+      schema: v13
       index:
         prefix: index_
         period: 24h
@@ -203,12 +203,12 @@ schema_config:
         period: 24h
         prefix: index_
 
-  # Starting from 2023-6-15 Loki should store indexes on TSDB with the v12 schema
+  # Starting from 2023-6-15 Loki should store indexes on TSDB with the v13 schema
   # using daily periodic tables and chunks on AWS S3.
   - from: "2023-06-15"
     store: tsdb
     object_store: s3
-    schema: v12
+    schema: v13
     index:
         period: 24h
         prefix: index_
@@ -227,7 +227,7 @@ schema_config:
   - from: 2020-05-15
     store: tsdb
     object_store: alibabacloud
-    schema: v12
+    schema: v13
     index:
       prefix: index_
       period: 24h
@@ -297,7 +297,7 @@ schema_config:
     - from: 2020-10-01
       store: tsdb
       object_store: cos
-      schema: v12
+      schema: v13
       index:
         period: 24h
         prefix: index_
@@ -327,7 +327,7 @@ schema_config:
     - from: 2020-10-01
       store: tsdb
       object_store: cos
-      schema: v12
+      schema: v13
       index:
         period: 24h
         prefix: index_
@@ -364,7 +364,7 @@ schema_config:
     - from: 2020-10-01
       store: tsdb
       object_store: cos
-      schema: v12
+      schema: v13
       index:
         period: 24h
         prefix: index_

--- a/docs/sources/configure/examples/yaml/1-Local-Configuration-Example.yaml
+++ b/docs/sources/configure/examples/yaml/1-Local-Configuration-Example.yaml
@@ -19,7 +19,7 @@ schema_config:
   - from: 2020-05-15
     store: tsdb
     object_store: filesystem
-    schema: v12
+    schema: v13
     index:
       prefix: index_
       period: 24h

--- a/docs/sources/configure/examples/yaml/11-COS-HMAC-Example.yaml
+++ b/docs/sources/configure/examples/yaml/11-COS-HMAC-Example.yaml
@@ -5,7 +5,7 @@ schema_config:
     - from: 2020-10-01
       store: tsdb
       object_store: cos
-      schema: v12
+      schema: v13
       index:
         period: 24h
         prefix: index_

--- a/docs/sources/configure/examples/yaml/12-COS-APIKey-Example.yaml
+++ b/docs/sources/configure/examples/yaml/12-COS-APIKey-Example.yaml
@@ -5,7 +5,7 @@ schema_config:
     - from: 2020-10-01
       store: tsdb
       object_store: cos
-      schema: v12
+      schema: v13
       index:
         period: 24h
         prefix: index_

--- a/docs/sources/configure/examples/yaml/13-COS-Trusted-Profile-Example.yaml
+++ b/docs/sources/configure/examples/yaml/13-COS-Trusted-Profile-Example.yaml
@@ -11,7 +11,7 @@ schema_config:
     - from: 2020-10-01
       store: tsdb
       object_store: cos
-      schema: v12
+      schema: v13
       index:
         period: 24h
         prefix: index_

--- a/docs/sources/configure/examples/yaml/16-(Deprecated)-Cassandra-Snippet.yaml
+++ b/docs/sources/configure/examples/yaml/16-(Deprecated)-Cassandra-Snippet.yaml
@@ -6,7 +6,7 @@ schema_config:
   - from: 2020-05-15
     store: cassandra
     object_store: filesystem
-    schema: v13
+    schema: v12
     index:
       prefix: cassandra_table
       period: 168h

--- a/docs/sources/configure/examples/yaml/16-(Deprecated)-Cassandra-Snippet.yaml
+++ b/docs/sources/configure/examples/yaml/16-(Deprecated)-Cassandra-Snippet.yaml
@@ -6,7 +6,7 @@ schema_config:
   - from: 2020-05-15
     store: cassandra
     object_store: filesystem
-    schema: v12
+    schema: v13
     index:
       prefix: cassandra_table
       period: 168h

--- a/docs/sources/configure/examples/yaml/2-S3-Cluster-Example.yaml
+++ b/docs/sources/configure/examples/yaml/2-S3-Cluster-Example.yaml
@@ -20,7 +20,7 @@ schema_config:
   - from: 2020-05-15
     store: tsdb
     object_store: s3
-    schema: v12
+    schema: v13
     index:
       prefix: index_
       period: 24h

--- a/docs/sources/configure/examples/yaml/4-GCS-Example.yaml
+++ b/docs/sources/configure/examples/yaml/4-GCS-Example.yaml
@@ -19,7 +19,7 @@ schema_config:
   - from: 2020-05-15
     store: tsdb
     object_store: gcs
-    schema: v12
+    schema: v13
     index:
       prefix: index_
       period: 24h

--- a/docs/sources/configure/examples/yaml/5-BOS-Example.yaml
+++ b/docs/sources/configure/examples/yaml/5-BOS-Example.yaml
@@ -6,7 +6,7 @@ schema_config:
     - from: 2020-05-15
       store: tsdb
       object_store: bos
-      schema: v12
+      schema: v13
       index:
         prefix: index_
         period: 24h

--- a/docs/sources/configure/examples/yaml/7-Schema-Migration-Snippet.yaml
+++ b/docs/sources/configure/examples/yaml/7-Schema-Migration-Snippet.yaml
@@ -11,12 +11,12 @@ schema_config:
         period: 24h
         prefix: index_
 
-  # Starting from 2023-6-15 Loki should store indexes on TSDB with the v12 schema
+  # Starting from 2023-6-15 Loki should store indexes on TSDB with the v13 schema
   # using daily periodic tables and chunks on AWS S3.
   - from: "2023-06-15"
     store: tsdb
     object_store: s3
-    schema: v12
+    schema: v13
     index:
         period: 24h
         prefix: index_

--- a/docs/sources/configure/examples/yaml/8-alibaba-cloud-storage-Snippet.yaml
+++ b/docs/sources/configure/examples/yaml/8-alibaba-cloud-storage-Snippet.yaml
@@ -5,7 +5,7 @@ schema_config:
   - from: 2020-05-15
     store: tsdb
     object_store: alibabacloud
-    schema: v12
+    schema: v13
     index:
       prefix: index_
       period: 24h

--- a/docs/sources/operations/storage/retention.md
+++ b/docs/sources/operations/storage/retention.md
@@ -72,7 +72,7 @@ schema_config:
             period: 24h
             prefix: index_
         object_store: gcs
-        schema: v12
+        schema: v13
         store: tsdb
 storage_config:
     tsdb_shipper:
@@ -238,7 +238,7 @@ schema_config:
   - from: 2018-04-15
     store: tsdb
     object_store: gcs
-    schema: v12
+    schema: v13
     index:
       prefix: loki_index_
       period: 24h

--- a/docs/sources/operations/storage/schema/_index.md
+++ b/docs/sources/operations/storage/schema/_index.md
@@ -23,7 +23,7 @@ Here are items to consider when changing the schema; if schema changes are not d
 
   Be aware of your relation to UTC when using the current date. Make sure that UTC 00:00:00 has not already passed for your current date.
   
-  As an example, assume that the current date is 2022-04-10, and you want to update to the v12 schema, so you restart Loki with 2022-04-11 as the `from` date for the new schema. If you forget to take into account that your timezone is UTC -5:00 and it’s currently 20:00 hours in your local timezone,  that is actually 2022-04-11T01:00:00 UTC. When Loki starts it will see the new schema and begin to write and store objects following that new schema. If you then try to query data that was written between 00:00:00 and 01:00:00 UTC, Loki will use the new schema and the data will be unreadable, because it was created with the previous schema.
+  As an example, assume that the current date is 2022-04-10, and you want to update to the v13 schema, so you restart Loki with 2022-04-11 as the `from` date for the new schema. If you forget to take into account that your timezone is UTC -5:00 and it’s currently 20:00 hours in your local timezone,  that is actually 2022-04-11T01:00:00 UTC. When Loki starts it will see the new schema and begin to write and store objects following that new schema. If you then try to query data that was written between 00:00:00 and 01:00:00 UTC, Loki will use the new schema and the data will be unreadable, because it was created with the previous schema.
 
 - You cannot undo or roll back a schema change.
 
@@ -46,6 +46,6 @@ schema_config:
             period: 24h
             prefix: loki_ops_index_
           object_store: gcs
-          schema: v12
+          schema: v13
           store: tsdb
 ```

--- a/docs/sources/operations/storage/tsdb.md
+++ b/docs/sources/operations/storage/tsdb.md
@@ -29,7 +29,7 @@ schema_config:
         period: 24h
         prefix: index_
       object_store: gcs
-      schema: v12
+      schema: v13
       store: tsdb
 
 storage_config:

--- a/docs/sources/setup/migrate/migrate-to-tsdb/_index.md
+++ b/docs/sources/setup/migrate/migrate-to-tsdb/_index.md
@@ -39,7 +39,7 @@ schema_config:
     - from: 2023-10-20 ①
       store: tsdb ②
       object_store: filesystem ③
-      schema: v12 ④
+      schema: v13 ④
       index:
         prefix: index_
         period: 24h
@@ -51,7 +51,7 @@ schema_config:
 
 ③  This sample configuration uses filesystem as the storage in both the periods. If you want to use a different storage for the TSDB index and chunks, you can specify a different `object_store` in the new period.
 
-④  Update the schema to v12 which is the recommended version at the time of writing. Please refer to the [configure page]({{< relref "../../../configure#period_config" >}}) for the current recommend version.
+④  Update the schema to v13 which is the recommended version at the time of writing. Please refer to the [configure page]({{< relref "../../../configure#period_config" >}}) for the current recommend version.
 
 ### Configure TSDB shipper
 

--- a/docs/sources/storage/_index.md
+++ b/docs/sources/storage/_index.md
@@ -127,7 +127,7 @@ This storage type for indexes is deprecated and may be removed in future major v
 ## Schema Config
 
 Loki aims to be backwards compatible and over the course of its development has had many internal changes that facilitate better and more efficient storage/querying. Loki allows incrementally upgrading to these new storage _schemas_ and can query across them transparently. This makes upgrading a breeze.
-For instance, this is what it looks like when migrating from BoltDB with v11 schema to TSDB with v12 schema starting 2023-07-01:
+For instance, this is what it looks like when migrating from BoltDB with v11 schema to TSDB with v13 schema starting 2023-07-01:
 
 ```yaml
 schema_config:
@@ -142,13 +142,13 @@ schema_config:
     - from: 2023-07-01
       store: tsdb
       object_store: filesystem
-      schema: v12
+      schema: v13
       index:
         prefix: index_
         period: 24h
 ```
 
-For all data ingested before 2023-07-01, Loki used BoltDB with the v11 schema, and then switched after that point to the more effective TSDB with the v12 schema. This dramatically simplifies upgrading, ensuring it's simple to take advantage of new storage optimizations. These configs should be immutable for as long as you care about retention.
+For all data ingested before 2023-07-01, Loki used BoltDB with the v11 schema, and then switched after that point to the more effective TSDB with the v13 schema. This dramatically simplifies upgrading, ensuring it's simple to take advantage of new storage optimizations. These configs should be immutable for as long as you care about retention.
 
 ## Table Manager (deprecated)
 
@@ -190,7 +190,7 @@ When a new schema is released and you want to gain the advantages it provides, y
 
 First, you'll want to create a new [period_config]({{< relref "../configure#period_config" >}}) entry in your [schema_config]({{< relref "../configure#schema_config" >}}). The important thing to remember here is to set this at some point in the _future_ and then roll out the config file changes to Loki. This allows the table manager to create the required table in advance of writes and ensures that existing data isn't queried as if it adheres to the new schema.
 
-As an example, let's say it's 2023-07-14 and we want to start using the `v12` schema on the 20th:
+As an example, let's say it's 2023-07-14 and we want to start using the `v13` schema on the 20th:
 ```yaml
 schema_config:
   configs:
@@ -204,7 +204,7 @@ schema_config:
     - from: 2023-07-20
       store: tsdb
       object_store: filesystem
-      schema: v12
+      schema: v13
       index:
         prefix: index_
         period: 24h
@@ -243,7 +243,7 @@ schema_config:
     - from: 2020-07-01
       store: tsdb
       object_store: gcs
-      schema: v12
+      schema: v13
       index:
         prefix: index_
         period: 24h
@@ -266,7 +266,7 @@ schema_config:
     - from: 2020-07-01
       store: tsdb
       object_store: aws
-      schema: v12
+      schema: v13
       index:
         prefix: index_
         period: 24h
@@ -352,7 +352,7 @@ schema_config:
       period: 24h
       prefix: index_
     object_store: azure
-    schema: v12
+    schema: v13
     store: tsdb
 storage_config:
   azure:
@@ -388,7 +388,7 @@ schema_config:
       period: 24h
       prefix: index_
     object_store: azure
-    schema: v12
+    schema: v13
     store: tsdb
 storage_config:
   azure:
@@ -420,7 +420,7 @@ schema_config:
         period: 24h
         prefix: loki_index_
       object_store: cos
-      schema: v12
+      schema: v13
       store: tsdb
 
 storage_config:
@@ -489,7 +489,7 @@ schema_config:
     - from: 2020-07-01
       store: tsdb
       object_store: s3
-      schema: v12
+      schema: v13
       index:
         prefix: index_
         period: 24h

--- a/examples/getting-started/loki-config.yaml
+++ b/examples/getting-started/loki-config.yaml
@@ -9,7 +9,7 @@ schema_config:
     - from: 2021-08-01
       store: tsdb
       object_store: s3
-      schema: v12
+      schema: v13
       index:
         prefix: index_
         period: 24h

--- a/production/docker/config/loki.yaml
+++ b/production/docker/config/loki.yaml
@@ -97,6 +97,13 @@ schema_config:
     index:
       prefix: index_
       period: 24h
+  - from: 2024-03-29
+    store: tsdb
+    object_store: s3
+    schema: v13
+    index:
+      prefix: index_
+      period: 24h
 
 
 limits_config:

--- a/production/nomad/loki-distributed/config.yml
+++ b/production/nomad/loki-distributed/config.yml
@@ -72,9 +72,9 @@ frontend_worker:
 schema_config:
   configs:
   - from: 2022-05-15
-    store: boltdb-shipper
+    store: tsdb
     object_store: s3
-    schema: v12
+    schema: v13
     index:
       prefix: index_
       period: 24h

--- a/production/nomad/loki-simple/config.yml
+++ b/production/nomad/loki-simple/config.yml
@@ -27,9 +27,9 @@ ingester:
 schema_config:
   configs:
   - from: 2022-05-15
-    store: boltdb-shipper
+    store: tsdb
     object_store: s3
-    schema: v12
+    schema: v13
     index:
       prefix: index_
       period: 24h

--- a/production/nomad/loki/config.yml
+++ b/production/nomad/loki/config.yml
@@ -27,9 +27,9 @@ ingester:
 schema_config:
   configs:
   - from: 2022-05-15
-    store: boltdb-shipper
+    store: tsdb
     object_store: s3
-    schema: v12
+    schema: v13
     index:
       prefix: index_
       period: 24h


### PR DESCRIPTION
**What this PR does / why we need it**:
Bump examples to use current schema (v12->v13)

**Which issue(s) this PR fixes**:
Relates to: https://github.com/grafana/loki/issues/10266

**Special notes for your reviewer**:

**Checklist**
- [ x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ x] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
