### PR TITLE
docs: Adding upgrade link page to Operations

### DIFF
--- a/docs/sources/operations/upgrade.md
+++ b/docs/sources/operations/upgrade.md
@@ -6,6 +6,6 @@ weight:
 
 # Upgrade
 
-- [Upgrade]({{< relref "https://grafana.com/docs/loki/latest/setup/upgrade/" >}}) from one Loki version to a newer version.
+- [Upgrade](https://grafana.com/docs/loki/latest/setup/upgrade/) from one Loki version to a newer version.
 
-- [Upgrade Helm]({{< relref "https://grafana.com/docs/loki/latest/setup/upgrade/" >}}) from Helm v2.x to Helm v3,x.
+- [Upgrade Helm](https://grafana.com/docs/loki/latest/setup/upgrade/) from Helm v2.x to Helm v3,x.

--- a/docs/sources/operations/upgrade.md
+++ b/docs/sources/operations/upgrade.md
@@ -1,0 +1,11 @@
+---
+title: Upgrade
+description: Links to Loki upgrade documentation.
+weight: 
+---
+
+# Upgrade
+
+- [Upgrade]({{< relref "https://grafana.com/docs/loki/latest/setup/upgrade/" >}}) from one Loki version to a newer version.
+
+- [Upgrade Helm]({{< relref "https://grafana.com/docs/loki/latest/setup/upgrade/" >}}) from Helm v2.x to Helm v3,x.

--- a/docs/sources/operations/upgrade.md
+++ b/docs/sources/operations/upgrade.md
@@ -8,4 +8,4 @@ weight:
 
 - [Upgrade](https://grafana.com/docs/loki/latest/setup/upgrade/) from one Loki version to a newer version.
 
-- [Upgrade Helm](https://grafana.com/docs/loki/latest/setup/upgrade/) from Helm v2.x to Helm v3,x.
+- [Upgrade Helm](https://grafana.com/docs/loki/latest/setup/upgrade/) from Helm v2.x to Helm v3.x.


### PR DESCRIPTION
**What this PR does / why we need it**:
@slim-bean keeps looking for the Upgrade content under Operations/Manage,

Adding a page to link to the upgrade docs (which are under Setup) to increase findability.