### PR TITLE
feat: include the stream we failed to create in the stream limit error message

### DIFF
--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -405,11 +405,14 @@ func TestIngesterStreamLimitExceeded(t *testing.T) {
 	require.NoError(t, err)
 
 	req.Streams[0].Labels = `{foo="bar",bar="baz2"}`
+	// The labels in error messages are sorted lexicographically and cleaned up via Push -> ParseLabels.
+	expectedLabels, _ := syntax.ParseLabels(req.Streams[0].Labels)
 
 	_, err = i.Push(ctx, &req)
 	if resp, ok := httpgrpc.HTTPResponseFromError(err); !ok || resp.Code != http.StatusTooManyRequests {
 		t.Fatalf("expected error about exceeding metrics per user, got %v", err)
 	}
+	require.Contains(t, err.Error(), expectedLabels.String())
 }
 
 type mockStore struct {

--- a/pkg/ingester/instance.go
+++ b/pkg/ingester/instance.go
@@ -303,7 +303,7 @@ func (i *instance) createStream(ctx context.Context, pushReqStream logproto.Stre
 		if i.customStreamsTracker != nil {
 			i.customStreamsTracker.DiscardedBytesAdd(ctx, i.instanceID, validation.StreamLimit, labels, float64(bytes))
 		}
-		return nil, httpgrpc.Errorf(http.StatusTooManyRequests, validation.StreamLimitErrorMsg, i.instanceID)
+		return nil, httpgrpc.Errorf(http.StatusTooManyRequests, validation.StreamLimitErrorMsg, labels, i.instanceID)
 	}
 
 	fp := i.getHashForLabels(labels)

--- a/pkg/validation/validate.go
+++ b/pkg/validation/validate.go
@@ -28,7 +28,7 @@ const (
 	// StreamLimit is a reason for discarding lines when we can't create a new stream
 	// because the limit of active streams has been reached.
 	StreamLimit         = "stream_limit"
-	StreamLimitErrorMsg = "Maximum active stream limit exceeded, reduce the number of active streams (reduce labels or reduce label values), or contact your Loki administrator to see if the limit can be increased, user: '%s'"
+	StreamLimitErrorMsg = "Maximum active stream limit exceeded when trying to create stream %s, reduce the number of active streams (reduce labels or reduce label values), or contact your Loki administrator to see if the limit can be increased, user: '%s'"
 	// StreamRateLimit is a reason for discarding lines when the streams own rate limit is hit
 	// rather than the overall ingestion rate limit.
 	StreamRateLimit = "per_stream_rate_limit"


### PR DESCRIPTION
This has come up a few times with end users/support, it can be difficult to know what to do if you receive the StreamLimit error as it doesn't contain any additional information. Logging of the labels isn't a big improvement, but hopefully it will at least point people in the right direction.