### PR TITLE
chore: Log level detection improvements

### DIFF
--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -1619,14 +1619,14 @@ func Test_detectLogLevelFromLogEntry(t *testing.T) {
 		{
 			name: "json log line with an error",
 			entry: logproto.Entry{
-				Line: `{"foo":"bar","level":"error"}`,
+				Line: `{"foo":"bar",msg:"message with keyword error but it should not get picked up",level":"critical"}`,
 			},
-			expectedLogLevel: logLevelError,
+			expectedLogLevel: logLevelCritical,
 		},
 		{
 			name: "logfmt log line with a warn",
 			entry: logproto.Entry{
-				Line: `foo=bar level=warn`,
+				Line: `foo=bar msg="message with keyword error but it should not get picked up" level=warn`,
 			},
 			expectedLogLevel: logLevelWarn,
 		},

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -1637,3 +1637,22 @@ func Test_detectLogLevelFromLogEntry(t *testing.T) {
 		})
 	}
 }
+
+func Benchmark_extractLogLevelFromLogLine(b *testing.B) {
+	// looks scary, but it is some random text of about 1000 chars from charset a-zA-Z0-9
+	logLine := "dGzJ6rKk Zj U04SWEqEK4Uwho8 DpNyLz0 Nfs61HJ fz5iKVigg 44 kabOz7ghviGmVONriAdz4lA 7Kis1OTvZGT3 " +
+		"ZB6ioK4fgJLbzm AuIcbnDZKx3rZ aeZJQzRb3zhrn vok8Efav6cbyzbRUQ PYsEdQxCpdCDcGNsKG FVwe61 nhF06t9hXSNySEWa " +
+		"gBAXP1J8oEL grep1LfeKjA23ntszKA A772vNyxjQF SjWfJypwI7scxk oLlqRzrDl ostO4CCwx01wDB7Utk0 64A7p5eQDITE6zc3 " +
+		"rGL DrPnD K2oj Vro2JEvI2YScstnMx SVu H o GUl8fxZJJ1HY0 C  QOA HNJr5XtsCNRrLi 0w C0Pd8XWbVZyQkSlsRm zFw1lW  " +
+		"c8j6JFQuQnnB EyL20z0 2Duo0dvynnAGD 45ut2Z Jrz8Nd7Pmg 5oQ09r9vnmy U2 mKHO5uBfndPnbjbr  mzOvQs9bM1 9e " +
+		"yvNSfcbPyhuWvB VKJt2kp8IoTVc XCe Uva5mp9NrGh3TEbjQu1 C  Zvdk uPr7St2m kwwMRcS9eC aS6ZuL48eoQUiKo VBPd4m49ymr " +
+		"eQZ0fbjWpj6qA A6rYs4E 58dqh9ntu8baziDJ4c 1q6aVEig YrMXTF hahrlt 6hKVHfZLFZ V 9hEVN0WKgcpu6L zLxo6YC57 XQyfAGpFM " +
+		"Wm3 S7if5qCXPzvuMZ2 gNHdst Z39s9uNc58QBDeYRW umyIF BDqEdqhE tAs2gidkqee3aux8b NLDb7 ZZLekc0cQZ GUKQuBg2pL2y1S " +
+		"RJtBuW ABOqQHLSlNuUw ZlM2nGS2 jwA7cXEOJhY 3oPv4gGAz  Uqdre16MF92C06jOH dayqTCK8XmIilT uvgywFSfNadYvRDQa " +
+		"iUbswJNcwqcr6huw LAGrZS8NGlqqzcD2wFU rm Uqcrh3TKLUCkfkwLm  5CIQbxMCUz boBrEHxvCBrUo YJoF2iyif4xq3q yk "
+
+	for i := 0; i < b.N; i++ {
+		level := extractLogLevelFromLogLine(logLine)
+		require.Equal(b, logLevelInfo, level)
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
1. Add a benchmark for log-level detection code.
2. Check for log levels in standard logging formats before doing a broader search. This change has sped up the code to detect log formats from the logline based on the benchmark:
```
benchmark                                   old ns/op     new ns/op     delta
Benchmark_extractLogLevelFromLogLine-10     3427          3013          -12.08%
Benchmark_extractLogLevelFromLogLine-10     3443          3008          -12.63%
Benchmark_extractLogLevelFromLogLine-10     3498          3007          -14.04%
Benchmark_extractLogLevelFromLogLine-10     3496          3010          -13.90%
Benchmark_extractLogLevelFromLogLine-10     3504          3015          -13.96%

benchmark                                   old allocs     new allocs     delta
Benchmark_extractLogLevelFromLogLine-10     1              1              +0.00%
Benchmark_extractLogLevelFromLogLine-10     1              1              +0.00%
Benchmark_extractLogLevelFromLogLine-10     1              1              +0.00%
Benchmark_extractLogLevelFromLogLine-10     1              1              +0.00%
Benchmark_extractLogLevelFromLogLine-10     1              1              +0.00%

benchmark                                   old bytes     new bytes     delta
Benchmark_extractLogLevelFromLogLine-10     16            16            +0.00%
Benchmark_extractLogLevelFromLogLine-10     16            16            +0.00%
Benchmark_extractLogLevelFromLogLine-10     16            16            +0.00%
Benchmark_extractLogLevelFromLogLine-10     16            16            +0.00%
Benchmark_extractLogLevelFromLogLine-10     16            16            +0.00%
```

**Checklist**
- [x] Tests updated
