### PR TITLE
chore: Enable `limited_log_push_errors` by default

### DIFF
--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -68,6 +68,16 @@ import (
 	"github.com/grafana/loki/v3/pkg/validation"
 )
 
+type CustomRuntime struct {
+	RuntimeConfig runtimeconfig.Config `yaml:",inline"`
+	Defaults      runtime.Config       `yaml:"defaults,omitempty"`
+}
+
+func (c *CustomRuntime) RegisterFlags(f *flag.FlagSet) {
+	c.RuntimeConfig.RegisterFlags(f)
+	f.BoolVar(&c.Defaults.LimitedLogPushErrors, "runtime-config.default.limited-log-push-errors", true, "Whether failed pushes are logged by default or not.")
+}
+
 // Config is the root config for Loki.
 type Config struct {
 	Target       flagext.StringSliceCSV `yaml:"target,omitempty"`
@@ -99,9 +109,9 @@ type Config struct {
 	TableManager        index.TableManagerConfig   `yaml:"table_manager,omitempty"`
 	MemberlistKV        memberlist.KVConfig        `yaml:"memberlist"`
 
-	RuntimeConfig runtimeconfig.Config `yaml:"runtime_config,omitempty"`
-	Tracing       tracing.Config       `yaml:"tracing"`
-	Analytics     analytics.Config     `yaml:"analytics"`
+	RuntimeConfig CustomRuntime    `yaml:"runtime_config,omitempty"`
+	Tracing       tracing.Config   `yaml:"tracing"`
+	Analytics     analytics.Config `yaml:"analytics"`
 
 	LegacyReadTarget bool `yaml:"legacy_read_target,omitempty" doc:"hidden|deprecated"`
 

--- a/pkg/loki/runtime_config.go
+++ b/pkg/loki/runtime_config.go
@@ -42,7 +42,11 @@ func (r runtimeConfigValues) validate() error {
 }
 
 func loadRuntimeConfig(r io.Reader) (interface{}, error) {
-	overrides := &runtimeConfigValues{}
+	overrides := &runtimeConfigValues{
+		DefaultConfig: &runtime.Config{
+			LimitedLogPushErrors: true,
+		},
+	}
 
 	decoder := yaml.NewDecoder(r)
 	decoder.SetStrict(true)

--- a/pkg/loki/runtime_config.go
+++ b/pkg/loki/runtime_config.go
@@ -14,6 +14,8 @@ import (
 	"github.com/grafana/loki/v3/pkg/validation"
 )
 
+var defaultRuntimeCfg *runtime.Config
+
 // runtimeConfigValues are values that can be reloaded from configuration file while Loki is running.
 // Reloading is done by runtimeconfig.Manager, which also keeps the currently loaded config.
 // These values are then pushed to the components that are interested in them.
@@ -25,6 +27,10 @@ type runtimeConfigValues struct {
 	DefaultConfig *runtime.Config `yaml:"default"`
 
 	Multi kv.MultiRuntimeConfig `yaml:"multi_kv_config"`
+}
+
+func SetDefaultRuntimeForYAMLUnmarshalling(cfg runtime.Config) {
+	defaultRuntimeCfg = &cfg
 }
 
 func (r runtimeConfigValues) validate() error {

--- a/pkg/loki/runtime_config.go
+++ b/pkg/loki/runtime_config.go
@@ -49,9 +49,7 @@ func (r runtimeConfigValues) validate() error {
 
 func loadRuntimeConfig(r io.Reader) (interface{}, error) {
 	overrides := &runtimeConfigValues{
-		DefaultConfig: &runtime.Config{
-			LimitedLogPushErrors: true,
-		},
+		DefaultConfig: defaultRuntimeCfg,
 	}
 
 	decoder := yaml.NewDecoder(r)

--- a/pkg/loki/runtime_config_test.go
+++ b/pkg/loki/runtime_config_test.go
@@ -84,6 +84,29 @@ overrides:
 	require.Equal(t, "invalid override for tenant 29: retention period must be >= 24h was 5h", err.Error())
 }
 
+func Test_DefaultValuesWithoutDefaultSectionHelp(t *testing.T) {
+	runtimeGetter := newTestRuntimeconfig(t,
+		`
+configs:
+    "1":
+        log_push_request: false
+        limited_log_push_errors: false
+    "2":
+        log_push_request: true
+`)
+
+	user1 := runtimeGetter.TenantConfig("1")
+	user2 := runtimeGetter.TenantConfig("2")
+	user3 := runtimeGetter.TenantConfig("3")
+
+	require.Equal(t, false, user1.LogPushRequest)
+	require.Equal(t, false, user1.LimitedLogPushErrors)
+	require.Equal(t, false, user2.LimitedLogPushErrors)
+	require.Equal(t, true, user2.LogPushRequest)
+	require.Equal(t, true, user3.LimitedLogPushErrors)
+	require.Equal(t, false, user3.LogPushRequest)
+}
+
 func Test_DefaultConfig(t *testing.T) {
 	runtimeGetter := newTestRuntimeconfig(t,
 		`


### PR DESCRIPTION
**What this PR does / why we need it**:
Make `limited_log_push_errors` enabled by default on Loki 3.0. It can still be disabled for all tenants by changing the `default` section on the runtime config file.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
