### PR TITLE
fix: Fix multi_tenant querier for detected labels

### DIFF
--- a/pkg/querier/multi_tenant_querier.go
+++ b/pkg/querier/multi_tenant_querier.go
@@ -297,9 +297,7 @@ func (q *MultiTenantQuerier) DetectedLabels(ctx context.Context, req *logproto.D
 
 	return &logproto.DetectedLabelsResponse{
 		DetectedLabels: []*logproto.DetectedLabel{
-			{Label: "cluster"},
-			{Label: "namespace"},
-			{Label: "instance"},
+			{Label: "multi_tenant_querier_not_implemented"},
 		},
 	}, nil
 }

--- a/pkg/querier/multi_tenant_querier.go
+++ b/pkg/querier/multi_tenant_querier.go
@@ -284,7 +284,7 @@ func (q *MultiTenantQuerier) DetectedFields(ctx context.Context, req *logproto.D
 
 func (q *MultiTenantQuerier) DetectedLabels(ctx context.Context, req *logproto.DetectedLabelsRequest) (*logproto.DetectedLabelsResponse, error) {
 	// TODO(shantanu)
-	tenantIDs, err := tenant.TenantID(ctx)
+	tenantIDs, err := tenant.TenantIDs(ctx)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Quick fix to multi tenant querier detected labels to fix dev environment
Also returns a default label to avoid confusion
