### PR TITLE
refactor!: refactor how we do defaults for runtime overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@
 * [11121](https://github.com/grafana/loki/pull/11121) **periklis** Ensure all lifecycler cfgs ref a valid IPv6 addr and port combination
 * [10650](https://github.com/grafana/loki/pull/10650) **matthewpi** Ensure the frontend uses a valid IPv6 addr and port combination
 * [11665](https://github.com/grafana/loki/pull/11665) **salvacorts** Deprecate and flip `-legacy-read-mode` flag to `false` by default.
+* [12448](https://github.com/grafana/loki/pull/12448/files) **slim-bean** BREAKING CHANGE: refactor how we do defaults for runtime overrides
 
 #### Promtail
 

--- a/cmd/loki/main.go
+++ b/cmd/loki/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/prometheus/common/version"
 
 	"github.com/grafana/loki/v3/pkg/loki"
+	loki_runtime "github.com/grafana/loki/v3/pkg/runtime"
 	"github.com/grafana/loki/v3/pkg/util"
 	_ "github.com/grafana/loki/v3/pkg/util/build"
 	"github.com/grafana/loki/v3/pkg/util/cfg"
@@ -49,6 +50,7 @@ func main() {
 	// call it atleast once, the defaults are set to an empty struct.
 	// We call it with the flag values so that the config file unmarshalling only overrides the values set in the config.
 	validation.SetDefaultLimitsForYAMLUnmarshalling(config.LimitsConfig)
+	loki_runtime.SetDefaultLimitsForYAMLUnmarshalling(config.OperationConfig)
 
 	// Init the logger which will honor the log level set in config.Server
 	if reflect.DeepEqual(&config.Server.LogLevel, &log.Level{}) {

--- a/cmd/loki/main.go
+++ b/cmd/loki/main.go
@@ -50,7 +50,7 @@ func main() {
 	// call it atleast once, the defaults are set to an empty struct.
 	// We call it with the flag values so that the config file unmarshalling only overrides the values set in the config.
 	validation.SetDefaultLimitsForYAMLUnmarshalling(config.LimitsConfig)
-	loki_runtime.SetDefaultLimitsForYAMLUnmarshalling(config.OperationConfig)
+	loki_runtime.SetDefaultLimitsForYAMLUnmarshalling(config.OperationalConfig)
 
 	// Init the logger which will honor the log level set in config.Server
 	if reflect.DeepEqual(&config.Server.LogLevel, &log.Level{}) {

--- a/docs/sources/configure/_index.md
+++ b/docs/sources/configure/_index.md
@@ -3684,7 +3684,7 @@ Configuration for 'runtime config' module, responsible for reloading runtime con
 
 ### operational_config
 
-These are values which allow you to control aspects of Loki's operation, most commonly used for controlling types of higher verbosity logging, the values here can be overridden in the `configs` section of the runtime_config file.
+These are values which allow you to control aspects of Loki's operation, most commonly used for controlling types of higher verbosity logging, the values here can be overridden in the `configs` section of the `runtime_config` file.
 
 ```yaml
 # Log every new stream created by a push request (very verbose, recommend to

--- a/docs/sources/configure/_index.md
+++ b/docs/sources/configure/_index.md
@@ -212,7 +212,7 @@ Pass the `-config.expand-env` flag at the command line to enable this way of set
 
 # These are values which allow you to control aspects of Loki's operation, most
 # commonly used for controlling types of higher verbosity logging, the values
-# here can be overridden in the `configs` section of the runtime_config file.
+# here can be overridden in the `configs` section of the `runtime_config` file.
 [operational_config: <operational_config>]
 
 # Configuration for tracing.

--- a/docs/sources/configure/_index.md
+++ b/docs/sources/configure/_index.md
@@ -210,26 +210,10 @@ Pass the `-config.expand-env` flag at the command line to enable this way of set
 # configuration file.
 [runtime_config: <runtime_config>]
 
-operational_config:
-  # Log every new stream created by a push request (very verbose, recommend to
-  # enable via runtime config only).
-  # CLI flag: -operation-config.log-stream-creation
-  [log_stream_creation: <boolean> | default = false]
-
-  # Log every push request (very verbose, recommend to enable via runtime config
-  # only).
-  # CLI flag: -operation-config.log-push-request
-  [log_push_request: <boolean> | default = false]
-
-  # Log every stream in a push request (very verbose, recommend to enable via
-  # runtime config only).
-  # CLI flag: -operation-config.log-push-request-streams
-  [log_push_request_streams: <boolean> | default = false]
-
-  # Log push errors with a rate limited logger, will show client push errors
-  # without overly spamming logs.
-  # CLI flag: -operation-config.limited-log-push-errors
-  [limited_log_push_errors: <boolean> | default = true]
+# These are values which allow you to control aspects of Loki's operation, most
+# commonly used for controlling types of higher verbosity logging, the values
+# here can be overridden in the `configs` section of the runtime_config file.
+[operational_config: <operational_config>]
 
 # Configuration for tracing.
 [tracing: <tracing>]
@@ -3696,6 +3680,32 @@ Configuration for 'runtime config' module, responsible for reloading runtime con
 # at runtime. Runtime config files will be merged from left to right.
 # CLI flag: -runtime-config.file
 [file: <string> | default = ""]
+```
+
+### operational_config
+
+These are values which allow you to control aspects of Loki's operation, most commonly used for controlling types of higher verbosity logging, the values here can be overridden in the `configs` section of the runtime_config file.
+
+```yaml
+# Log every new stream created by a push request (very verbose, recommend to
+# enable via runtime config only).
+# CLI flag: -operation-config.log-stream-creation
+[log_stream_creation: <boolean> | default = false]
+
+# Log every push request (very verbose, recommend to enable via runtime config
+# only).
+# CLI flag: -operation-config.log-push-request
+[log_push_request: <boolean> | default = false]
+
+# Log every stream in a push request (very verbose, recommend to enable via
+# runtime config only).
+# CLI flag: -operation-config.log-push-request-streams
+[log_push_request_streams: <boolean> | default = false]
+
+# Log push errors with a rate limited logger, will show client push errors
+# without overly spamming logs.
+# CLI flag: -operation-config.limited-log-push-errors
+[limited_log_push_errors: <boolean> | default = true]
 ```
 
 ### tracing

--- a/docs/sources/configure/_index.md
+++ b/docs/sources/configure/_index.md
@@ -186,7 +186,9 @@ Pass the `-config.expand-env` flag at the command line to enable this way of set
 # shards for performance.
 [compactor: <compactor>]
 
-# The limits_config block configures global and per-tenant limits in Loki.
+# The limits_config block configures global and per-tenant limits in Loki. The
+# values here can be overridden in the `overrides` section of the runtime_config
+# file
 [limits_config: <limits_config>]
 
 # The frontend_worker configures the worker - running within the Loki querier -
@@ -2768,7 +2770,7 @@ retention:
 
 ### limits_config
 
-The `limits_config` block configures global and per-tenant limits in Loki.
+The `limits_config` block configures global and per-tenant limits in Loki. The values here can be overridden in the `overrides` section of the runtime_config file
 
 ```yaml
 # Whether the ingestion rate limit should be applied individually to each

--- a/docs/sources/configure/_index.md
+++ b/docs/sources/configure/_index.md
@@ -208,6 +208,27 @@ Pass the `-config.expand-env` flag at the command line to enable this way of set
 # configuration file.
 [runtime_config: <runtime_config>]
 
+operational_config:
+  # Log every new stream created by a push request (very verbose, recommend to
+  # enable via runtime config only).
+  # CLI flag: -operation-config.log-stream-creation
+  [log_stream_creation: <boolean> | default = false]
+
+  # Log every push request (very verbose, recommend to enable via runtime config
+  # only).
+  # CLI flag: -operation-config.log-push-request
+  [log_push_request: <boolean> | default = false]
+
+  # Log every stream in a push request (very verbose, recommend to enable via
+  # runtime config only).
+  # CLI flag: -operation-config.log-push-request-streams
+  [log_push_request_streams: <boolean> | default = false]
+
+  # Log push errors with a rate limited logger, will show client push errors
+  # without overly spamming logs.
+  # CLI flag: -operation-config.limited-log-push-errors
+  [limited_log_push_errors: <boolean> | default = true]
+
 # Configuration for tracing.
 [tracing: <tracing>]
 

--- a/docs/sources/setup/upgrade/_index.md
+++ b/docs/sources/setup/upgrade/_index.md
@@ -40,7 +40,7 @@ The output is incredibly verbose as it shows the entire internal config struct u
 
 #### Removed the `default` section of the runtime overrides config file.
 
-This was introduced in 2.9 and likely not widely used.  This only affects you if you run Loki with a runtime config file AND you had populated the new `default` block added in 2.9
+This was introduced in 2.9 and likely not widely used.  This only affects you if you run Loki with a runtime config file AND you had populated the new `default` block added in 2.9.
 
 The `default` block was removed and instead a top level config now exists in the standard loki config called `operational_config`, you can set default values here for runtime configs.
 

--- a/docs/sources/setup/upgrade/_index.md
+++ b/docs/sources/setup/upgrade/_index.md
@@ -42,7 +42,7 @@ The output is incredibly verbose as it shows the entire internal config struct u
 
 This was introduced in 2.9 and likely not widely used.  This only affects you if you run Loki with a runtime config file AND you had populated the new `default` block added in 2.9.
 
-The `default` block was removed and instead a top level config now exists in the standard loki config called `operational_config`, you can set default values here for runtime configs.
+The `default` block was removed and instead a top level config now exists in the standard Loki config called `operational_config`, you can set default values here for runtime configs.
 
 #### Removed `shared_store` and `shared_store_key_prefix` from shipper configuration
 

--- a/docs/sources/setup/upgrade/_index.md
+++ b/docs/sources/setup/upgrade/_index.md
@@ -38,6 +38,12 @@ The output is incredibly verbose as it shows the entire internal config struct u
 
 ### Loki
 
+#### Removed the `default` section of the runtime overrides config file.
+
+This was introduced in 2.9 and likely not widely used.  This only affects you if you run Loki with a runtime config file AND you had populated the new `default` block added in 2.9
+
+The `default` block was removed and instead a top level config now exists in the standard loki config called `operational_config`, you can set default values here for runtime configs.
+
 #### Removed `shared_store` and `shared_store_key_prefix` from shipper configuration
 
 The following CLI flags and the corresponding YAML settings to configure shared store for TSDB and BoltDB shippers are now removed:

--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -99,10 +99,10 @@ type Config struct {
 	TableManager        index.TableManagerConfig   `yaml:"table_manager,omitempty"`
 	MemberlistKV        memberlist.KVConfig        `yaml:"memberlist"`
 
-	RuntimeConfig   runtimeconfig.Config `yaml:"runtime_config,omitempty"`
-	OperationConfig runtime.Config       `yaml:"operation_config,omitempty"`
-	Tracing         tracing.Config       `yaml:"tracing"`
-	Analytics       analytics.Config     `yaml:"analytics"`
+	RuntimeConfig     runtimeconfig.Config `yaml:"runtime_config,omitempty"`
+	OperationalConfig runtime.Config       `yaml:"operational_config,omitempty"`
+	Tracing           tracing.Config       `yaml:"tracing"`
+	Analytics         analytics.Config     `yaml:"analytics"`
 
 	LegacyReadTarget bool `yaml:"legacy_read_target,omitempty" doc:"hidden|deprecated"`
 
@@ -172,7 +172,7 @@ func (c *Config) RegisterFlags(f *flag.FlagSet) {
 	c.BloomCompactor.RegisterFlags(f)
 	c.QueryScheduler.RegisterFlags(f)
 	c.Analytics.RegisterFlags(f)
-	c.OperationConfig.RegisterFlags(f)
+	c.OperationalConfig.RegisterFlags(f)
 }
 
 func (c *Config) registerServerFlagsWithChangedDefaultValues(fs *flag.FlagSet) {

--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -99,9 +99,10 @@ type Config struct {
 	TableManager        index.TableManagerConfig   `yaml:"table_manager,omitempty"`
 	MemberlistKV        memberlist.KVConfig        `yaml:"memberlist"`
 
-	RuntimeConfig runtimeconfig.Config `yaml:"runtime_config,omitempty"`
-	Tracing       tracing.Config       `yaml:"tracing"`
-	Analytics     analytics.Config     `yaml:"analytics"`
+	RuntimeConfig   runtimeconfig.Config `yaml:"runtime_config,omitempty"`
+	OperationConfig runtime.Config       `yaml:"operation_config,omitempty"`
+	Tracing         tracing.Config       `yaml:"tracing"`
+	Analytics       analytics.Config     `yaml:"analytics"`
 
 	LegacyReadTarget bool `yaml:"legacy_read_target,omitempty" doc:"hidden|deprecated"`
 
@@ -171,6 +172,7 @@ func (c *Config) RegisterFlags(f *flag.FlagSet) {
 	c.BloomCompactor.RegisterFlags(f)
 	c.QueryScheduler.RegisterFlags(f)
 	c.Analytics.RegisterFlags(f)
+	c.OperationConfig.RegisterFlags(f)
 }
 
 func (c *Config) registerServerFlagsWithChangedDefaultValues(fs *flag.FlagSet) {

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -260,7 +260,7 @@ func (t *Loki) initRuntimeConfig() (services.Service, error) {
 
 	// make sure to set default limits before we start loading configuration into memory
 	validation.SetDefaultLimitsForYAMLUnmarshalling(t.Cfg.LimitsConfig)
-	runtime.SetDefaultLimitsForYAMLUnmarshalling(t.Cfg.OperationConfig)
+	runtime.SetDefaultLimitsForYAMLUnmarshalling(t.Cfg.OperationalConfig)
 
 	var err error
 	t.runtimeConfig, err = runtimeconfig.New(t.Cfg.RuntimeConfig, "loki", prometheus.WrapRegistererWithPrefix("loki_", prometheus.DefaultRegisterer), util_log.Logger)

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -260,6 +260,7 @@ func (t *Loki) initRuntimeConfig() (services.Service, error) {
 
 	// make sure to set default limits before we start loading configuration into memory
 	validation.SetDefaultLimitsForYAMLUnmarshalling(t.Cfg.LimitsConfig)
+	runtime.SetDefaultLimitsForYAMLUnmarshalling(t.Cfg.OperationConfig)
 
 	var err error
 	t.runtimeConfig, err = runtimeconfig.New(t.Cfg.RuntimeConfig, "loki", prometheus.WrapRegistererWithPrefix("loki_", prometheus.DefaultRegisterer), util_log.Logger)

--- a/pkg/loki/runtime_config.go
+++ b/pkg/loki/runtime_config.go
@@ -21,9 +21,6 @@ type runtimeConfigValues struct {
 	TenantLimits map[string]*validation.Limits `yaml:"overrides"`
 	TenantConfig map[string]*runtime.Config    `yaml:"configs"`
 
-	// DefaultConfig defines the default runtime configuration. Used if a tenant runtime configuration wasn't given.
-	DefaultConfig *runtime.Config `yaml:"default"`
-
 	Multi kv.MultiRuntimeConfig `yaml:"multi_kv_config"`
 }
 
@@ -107,7 +104,7 @@ func (t *tenantConfigProvider) TenantConfig(userID string) *runtime.Config {
 	if tenantCfg, ok := cfg.TenantConfig[userID]; ok {
 		return tenantCfg
 	}
-	return cfg.DefaultConfig
+	return nil
 }
 
 func multiClientRuntimeConfigChannel(manager *runtimeconfig.Manager) func() <-chan kv.MultiRuntimeConfig {

--- a/pkg/loki/runtime_config_test.go
+++ b/pkg/loki/runtime_config_test.go
@@ -87,9 +87,6 @@ overrides:
 func Test_DefaultConfig(t *testing.T) {
 	runtimeGetter := newTestRuntimeconfig(t,
 		`
-default:
-    log_push_request: true
-    limited_log_push_errors: false
 configs:
     "1":
         log_push_request: false
@@ -98,16 +95,15 @@ configs:
         log_push_request: true
 `)
 
-	user1 := runtimeGetter.TenantConfig("1")
-	user2 := runtimeGetter.TenantConfig("2")
-	user3 := runtimeGetter.TenantConfig("3")
+	tenantConfigs, err := runtime.NewTenantConfigs(runtimeGetter)
+	require.NoError(t, err)
 
-	require.Equal(t, false, user1.LogPushRequest)
-	require.Equal(t, false, user1.LimitedLogPushErrors)
-	require.Equal(t, false, user2.LimitedLogPushErrors)
-	require.Equal(t, true, user2.LogPushRequest)
-	require.Equal(t, false, user3.LimitedLogPushErrors)
-	require.Equal(t, true, user3.LogPushRequest)
+	require.Equal(t, false, tenantConfigs.LogPushRequest("1"))
+	require.Equal(t, false, tenantConfigs.LimitedLogPushErrors("1"))
+	require.Equal(t, false, tenantConfigs.LimitedLogPushErrors("2"))
+	require.Equal(t, true, tenantConfigs.LogPushRequest("2"))
+	require.Equal(t, true, tenantConfigs.LimitedLogPushErrors("3"))
+	require.Equal(t, false, tenantConfigs.LogPushRequest("3"))
 }
 
 func newTestRuntimeconfig(t *testing.T, yaml string) runtime.TenantConfigProvider {
@@ -126,7 +122,10 @@ func newTestRuntimeconfig(t *testing.T, yaml string) runtime.TenantConfigProvide
 	}
 	flagset := flag.NewFlagSet("", flag.PanicOnError)
 	var defaults validation.Limits
+	var operations runtime.Config
 	defaults.RegisterFlags(flagset)
+	operations.RegisterFlags(flagset)
+	runtime.SetDefaultLimitsForYAMLUnmarshalling(operations)
 	require.NoError(t, flagset.Parse(nil))
 
 	reg := prometheus.NewPedanticRegistry()

--- a/pkg/runtime/config.go
+++ b/pkg/runtime/config.go
@@ -1,6 +1,8 @@
 package runtime
 
-import "flag"
+import (
+	"flag"
+)
 
 type Config struct {
 	LogStreamCreation     bool `yaml:"log_stream_creation"`
@@ -44,13 +46,26 @@ type TenantConfigs struct {
 }
 
 // DefaultTenantConfigs creates and returns a new TenantConfigs with the defaults populated.
+// Only useful for testing, the provider will ignore any tenants passed in.
 func DefaultTenantConfigs() *TenantConfigs {
 	return &TenantConfigs{
-		TenantConfigProvider: nil,
+		TenantConfigProvider: &defaultsOnlyConfigProvider{},
 	}
 }
 
-// NewTenantConfig makes a new TenantConfigs
+type defaultsOnlyConfigProvider struct {
+}
+
+// TenantConfig implementation for defaultsOnlyConfigProvider, ignores the tenant input and only returns a default config
+func (t *defaultsOnlyConfigProvider) TenantConfig(_ string) *Config {
+	if defaultConfig == nil {
+		defaultConfig = &Config{}
+		defaultConfig.RegisterFlags(flag.NewFlagSet("", flag.PanicOnError))
+	}
+	return defaultConfig
+}
+
+// NewTenantConfigs makes a new TenantConfigs
 func NewTenantConfigs(configProvider TenantConfigProvider) (*TenantConfigs, error) {
 	return &TenantConfigs{
 		TenantConfigProvider: configProvider,

--- a/pkg/runtime/config.go
+++ b/pkg/runtime/config.go
@@ -15,7 +15,7 @@ type Config struct {
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&cfg.LogStreamCreation, "operation-config.log-stream-creation", false, "Log every new stream created by a push request (very verbose, recommend to enable via runtime config only).")
 	f.BoolVar(&cfg.LogPushRequest, "operation-config.log-push-request", false, "Log every push request (very verbose, recommend to enable via runtime config only).")
-	f.BoolVar(&cfg.LogPushRequestStreams, "operation-config.log-push-request-streams", false, "Log every stream in a pus request (very verbose, recommend to enable via runtime config only).")
+	f.BoolVar(&cfg.LogPushRequestStreams, "operation-config.log-push-request-streams", false, "Log every stream in a push request (very verbose, recommend to enable via runtime config only).")
 	f.BoolVar(&cfg.LimitedLogPushErrors, "operation-config.limited-log-push-errors", true, "Log push errors with a rate limited logger, will show client push errors without overly spamming logs.")
 }
 

--- a/production/ksonnet/loki/overrides.libsonnet
+++ b/production/ksonnet/loki/overrides.libsonnet
@@ -25,14 +25,6 @@ local k = import 'ksonnet-util/kausal.libsonnet';
       //   log_push_request_streams: true,
       // },
     },
-
-    defaultRuntimeConfigs: {
-      // override the default runtime configs. Useful to change a behavior globally across multiple tenants. See pkg/loki/runtime_config.go
-      //
-      // log_stream_creation: true,
-      // log_push_request: true,
-      // log_push_request_streams: true,
-    },
   },
   local configMap = k.core.v1.configMap,
 

--- a/production/ksonnet/loki/overrides.libsonnet
+++ b/production/ksonnet/loki/overrides.libsonnet
@@ -35,7 +35,6 @@ local k = import 'ksonnet-util/kausal.libsonnet';
         {
           overrides: $._config.overrides,
           configs: $._config.runtimeConfigs,
-          default: $._config.defaultRuntimeConfigs,
         }
         + (if std.length($._config.multi_kv_config) > 0 then { multi_kv_config: $._config.multi_kv_config } else {}),
       ),

--- a/tools/doc-generator/parse/root_blocks.go
+++ b/tools/doc-generator/parse/root_blocks.go
@@ -133,7 +133,7 @@ var (
 		{
 			Name:       "limits_config",
 			StructType: []reflect.Type{reflect.TypeOf(validation.Limits{})},
-			Desc:       "The limits_config block configures global and per-tenant limits in Loki.",
+			Desc:       "The limits_config block configures global and per-tenant limits in Loki. The values here can be overridden in the `overrides` section of the runtime_config file",
 		},
 		{
 			Name:       "frontend_worker",
@@ -150,6 +150,11 @@ var (
 			Name:       "runtime_config",
 			StructType: []reflect.Type{reflect.TypeOf(runtimeconfig.Config{})},
 			Desc:       "Configuration for 'runtime config' module, responsible for reloading runtime configuration file.",
+		},
+		{
+			Name:       "operational_config",
+			StructType: []reflect.Type{reflect.TypeOf(runtimeconfig.Config{})},
+			Desc:       "These are values which allow you to control aspects of Loki's operation, most commonly used for controlling types of higher verbosity logging, the values here can be overridden in the `configs` section of the runtime_config file.",
 		},
 		{
 			Name:       "tracing",

--- a/tools/doc-generator/parse/root_blocks.go
+++ b/tools/doc-generator/parse/root_blocks.go
@@ -27,6 +27,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/querier/queryrange"
 	querier_worker "github.com/grafana/loki/v3/pkg/querier/worker"
 	"github.com/grafana/loki/v3/pkg/ruler"
+	"github.com/grafana/loki/v3/pkg/runtime"
 	"github.com/grafana/loki/v3/pkg/scheduler"
 	"github.com/grafana/loki/v3/pkg/storage"
 	"github.com/grafana/loki/v3/pkg/storage/chunk/cache"
@@ -153,7 +154,7 @@ var (
 		},
 		{
 			Name:       "operational_config",
-			StructType: []reflect.Type{reflect.TypeOf(runtimeconfig.Config{})},
+			StructType: []reflect.Type{reflect.TypeOf(runtime.Config{})},
 			Desc:       "These are values which allow you to control aspects of Loki's operation, most commonly used for controlling types of higher verbosity logging, the values here can be overridden in the `configs` section of the runtime_config file.",
 		},
 		{

--- a/tools/doc-generator/parse/root_blocks.go
+++ b/tools/doc-generator/parse/root_blocks.go
@@ -155,7 +155,7 @@ var (
 		{
 			Name:       "operational_config",
 			StructType: []reflect.Type{reflect.TypeOf(runtime.Config{})},
-			Desc:       "These are values which allow you to control aspects of Loki's operation, most commonly used for controlling types of higher verbosity logging, the values here can be overridden in the `configs` section of the runtime_config file.",
+			Desc:       "These are values which allow you to control aspects of Loki's operation, most commonly used for controlling types of higher verbosity logging, the values here can be overridden in the `configs` section of the `runtime_config` file.",
 		},
 		{
 			Name:       "tracing",


### PR DESCRIPTION
**What this PR does / why we need it**:

We introduced a "defaults" section into the runtime overrides for runtime configs, however this prevented us from being able to set a default for these values without providing a runtime config.

we already have a pattern for this we used for limits_config so this PR refactors those defaults to be a first class object in the loki config and follows the same pattern of setting this as defaults.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
