### PR TITLE
feat: enable caching of index stats results, volume results, series results and label results by default

### DIFF
--- a/docs/sources/configure/_index.md
+++ b/docs/sources/configure/_index.md
@@ -866,7 +866,7 @@ results_cache:
 
 # Cache index stats query results.
 # CLI flag: -querier.cache-index-stats-results
-[cache_index_stats_results: <boolean> | default = false]
+[cache_index_stats_results: <boolean> | default = true]
 
 # If a cache config is not specified and cache_index_stats_results is true, the
 # config for the results cache is used.
@@ -883,7 +883,7 @@ index_stats_results_cache:
 
 # Cache volume query results.
 # CLI flag: -querier.cache-volume-results
-[cache_volume_results: <boolean> | default = false]
+[cache_volume_results: <boolean> | default = true]
 
 # If a cache config is not specified and cache_volume_results is true, the
 # config for the results cache is used.
@@ -922,7 +922,7 @@ instant_metric_results_cache:
 
 # Cache series query results.
 # CLI flag: -querier.cache-series-results
-[cache_series_results: <boolean> | default = false]
+[cache_series_results: <boolean> | default = true]
 
 # If series_results_cache is not configured and cache_series_results is true,
 # the config for the results cache is used.
@@ -939,7 +939,7 @@ series_results_cache:
 
 # Cache label query results.
 # CLI flag: -querier.cache-label-results
-[cache_label_results: <boolean> | default = false]
+[cache_label_results: <boolean> | default = true]
 
 # If label_results_cache is not configured and cache_label_results is true, the
 # config for the results cache is used.

--- a/docs/sources/setup/upgrade/_index.md
+++ b/docs/sources/setup/upgrade/_index.md
@@ -186,6 +186,14 @@ Structured Metadata is enabled by default in Loki 3.0, however, it requires your
 
 Automatic stream sharding helps keep the write load of high volume streams balanced across ingesters and helps to avoid hot-spotting. Check out the [operations page](https://grafana.com/docs/loki/latest/operations/automatic-stream-sharding/) for more information
 
+#### More results caching is enabled by default
+
+The TSDB index type has support for caching results for 'stats' and 'volume' queries which are now enabled by default.
+
+'label' and 'series' requests can be cached now too and this is enabled by default.
+
+All of these are cached to the `results_cache` which is configured in the `query_range` config section.  By default, an in memory cache is used.
+
 #### Write dedupe cache is deprecated
 Write dedupe cache is deprecated because it not required by the newer single store indexes ([TSDB]({{< relref "../../operations/storage/tsdb" >}}) and [boltdb-shipper]({{< relref "../../operations/storage/boltdb-shipper" >}})).
 If you using a [legacy index type]({{< relref "../../storage#index-storage" >}}), consider migrating to TSDB (recommended).

--- a/pkg/loki/config_test.go
+++ b/pkg/loki/config_test.go
@@ -69,6 +69,11 @@ func TestCrossComponentValidation(t *testing.T) {
 		tc.base.RegisterFlags(flag.NewFlagSet(tc.desc, 0))
 		// This test predates the newer schema required for structured metadata
 		tc.base.LimitsConfig.AllowStructuredMetadata = false
+		// Several caches will error if not configured, disabled them for this test
+		tc.base.QueryRange.CacheIndexStatsResults = false
+		tc.base.QueryRange.CacheSeriesResults = false
+		tc.base.QueryRange.CacheLabelResults = false
+		tc.base.QueryRange.CacheVolumeResults = false
 		err := tc.base.Validate()
 		if tc.err {
 			require.NotNil(t, err)

--- a/pkg/loki/modules_test.go
+++ b/pkg/loki/modules_test.go
@@ -380,6 +380,12 @@ func minimalWorkingConfig(t *testing.T, dir, target string, cfgTransformers ...f
 		},
 	}
 
+	// Disable some caches otherwise we'll get errors if we don't configure them
+	cfg.QueryRange.CacheLabelResults = false
+	cfg.QueryRange.CacheSeriesResults = false
+	cfg.QueryRange.CacheIndexStatsResults = false
+	cfg.QueryRange.CacheVolumeResults = false
+
 	cfg.SchemaConfig = config.SchemaConfig{
 		Configs: []config.PeriodConfig{
 			{

--- a/pkg/querier/queryrange/roundtrip.go
+++ b/pkg/querier/queryrange/roundtrip.go
@@ -62,16 +62,16 @@ type Config struct {
 // RegisterFlags adds the flags required to configure this flag set.
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	cfg.Config.RegisterFlags(f)
-	f.BoolVar(&cfg.CacheIndexStatsResults, "querier.cache-index-stats-results", false, "Cache index stats query results.")
+	f.BoolVar(&cfg.CacheIndexStatsResults, "querier.cache-index-stats-results", true, "Cache index stats query results.")
 	cfg.StatsCacheConfig.RegisterFlags(f)
-	f.BoolVar(&cfg.CacheVolumeResults, "querier.cache-volume-results", false, "Cache volume query results.")
+	f.BoolVar(&cfg.CacheVolumeResults, "querier.cache-volume-results", true, "Cache volume query results.")
 	cfg.VolumeCacheConfig.RegisterFlags(f)
 	f.BoolVar(&cfg.CacheInstantMetricResults, "querier.cache-instant-metric-results", false, "Cache instant metric query results.")
 	cfg.InstantMetricCacheConfig.RegisterFlags(f)
 	f.BoolVar(&cfg.InstantMetricQuerySplitAlign, "querier.instant-metric-query-split-align", false, "Align the instant metric splits with splityByInterval and query's exec time.")
-	f.BoolVar(&cfg.CacheSeriesResults, "querier.cache-series-results", false, "Cache series query results.")
+	f.BoolVar(&cfg.CacheSeriesResults, "querier.cache-series-results", true, "Cache series query results.")
 	cfg.SeriesCacheConfig.RegisterFlags(f)
-	f.BoolVar(&cfg.CacheLabelResults, "querier.cache-label-results", false, "Cache label query results.")
+	f.BoolVar(&cfg.CacheLabelResults, "querier.cache-label-results", true, "Cache label query results.")
 	cfg.LabelsCacheConfig.RegisterFlags(f)
 }
 


### PR DESCRIPTION

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
