### PR TITLE
chore: update base image used for the lambda-promtail image

### DIFF
--- a/tools/lambda-promtail/Dockerfile
+++ b/tools/lambda-promtail/Dockerfile
@@ -1,21 +1,10 @@
-FROM golang:1.21.3-alpine AS build-image
-
-COPY tools/lambda-promtail /src/lambda-promtail
-WORKDIR /src/lambda-promtail
-
-RUN go version
-
-RUN apk update && apk upgrade && \
-    apk add --no-cache bash git
-
-RUN go mod download
-RUN go build -o ./main -tags lambda.norpc -ldflags="-s -w" lambda-promtail/*.go
-
-
-FROM alpine:3.18.5
-
-WORKDIR /app
-
-COPY --from=build-image /src/lambda-promtail/main ./
-
-ENTRYPOINT ["/app/main"]
+FROM public.ecr.aws/lambda/provided:al2 as build-image
+RUN yum install -y golang
+RUN go env -w GOPROXY=direct
+ADD . .
+RUN go build -o /main -tags lambda.norpc -ldflags="-s -w" lambda-promtail/*.go
+RUN ls -al
+# copy artifacts to a clean image
+FROM public.ecr.aws/lambda/provided:al2
+COPY --from=build-image /main /main
+ENTRYPOINT [ "/main" ]       


### PR DESCRIPTION
This is required because AWS has stopped supporting the official Go 1.x runtime, documented [here](https://aws.amazon.com/blogs/compute/migrating-aws-lambda-functions-from-the-go1-x-runtime-to-the-custom-runtime-on-amazon-linux-2/). So now we need to use this Lambda specific base image.