### PR TITLE
chore(blooms): bloom_client records cache locality score

### DIFF
--- a/pkg/bloomgateway/client_test.go
+++ b/pkg/bloomgateway/client_test.go
@@ -48,7 +48,7 @@ func TestBloomGatewayClient(t *testing.T) {
 		require.NoError(t, err)
 		res, err := c.FilterChunks(context.Background(), "tenant", model.Now(), model.Now(), nil, plan.QueryPlan{AST: expr})
 		require.NoError(t, err)
-		require.Equal(t, []*logproto.GroupedChunkRefs{}, res)
+		require.Equal(t, 0, len(res))
 	})
 }
 

--- a/pkg/bloomgateway/metrics.go
+++ b/pkg/bloomgateway/metrics.go
@@ -3,6 +3,7 @@ package bloomgateway
 import (
 	"time"
 
+	"github.com/grafana/loki/v3/pkg/util/constants"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
@@ -10,6 +11,22 @@ import (
 type metrics struct {
 	*workerMetrics
 	*serverMetrics
+}
+
+type clientMetrics struct {
+	cacheLocalityScore prometheus.Histogram
+}
+
+func newClientMetrics(registerer prometheus.Registerer) *clientMetrics {
+	return &clientMetrics{
+		cacheLocalityScore: promauto.With(registerer).NewHistogram(prometheus.HistogramOpts{
+			Namespace: constants.Loki,
+			Subsystem: "bloom_gateway_client",
+			Name:      "cache_locality_score",
+			Help:      "Cache locality score of the bloom filter, as measured by % of keyspace touched / % of bloom_gws required",
+			Buckets:   prometheus.ExponentialBucketsRange(1, 100, 8),
+		}),
+	}
 }
 
 type serverMetrics struct {

--- a/pkg/bloomgateway/metrics.go
+++ b/pkg/bloomgateway/metrics.go
@@ -25,7 +25,7 @@ func newClientMetrics(registerer prometheus.Registerer) *clientMetrics {
 			Subsystem: "bloom_gateway_client",
 			Name:      "cache_locality_score",
 			Help:      "Cache locality score of the bloom filter, as measured by % of keyspace touched / % of bloom_gws required",
-			Buckets:   prometheus.ExponentialBucketsRange(1, 100, 8),
+			Buckets:   prometheus.LinearBuckets(0.01, 0.2, 5),
 		}),
 	}
 }

--- a/pkg/bloomgateway/metrics.go
+++ b/pkg/bloomgateway/metrics.go
@@ -3,9 +3,10 @@ package bloomgateway
 import (
 	"time"
 
-	"github.com/grafana/loki/v3/pkg/util/constants"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	"github.com/grafana/loki/v3/pkg/util/constants"
 )
 
 type metrics struct {


### PR DESCRIPTION
This is a helpful way to measure how effectively we distribute filter queries to bloom-gws. Should mostly converge to 1 once we start using jump-hash instead of the ring for these, but it'll give us a good way to measure that improvement.