### PR TITLE
fix: Bugfixes for detected  labels API

### DIFF
--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -1389,7 +1389,7 @@ func (i *Ingester) GetDetectedLabels(ctx context.Context, req *logproto.Detected
 	}
 	var matchers []*labels.Matcher
 	if req.Query != "" {
-		matchers, err := syntax.ParseMatchers(req.Query, true)
+		matchers, err = syntax.ParseMatchers(req.Query, true)
 		if err != nil {
 			return nil, err
 		}
@@ -1403,7 +1403,7 @@ func (i *Ingester) GetDetectedLabels(ctx context.Context, req *logproto.Detected
 	}
 	result := make(map[string]*logproto.UniqueLabelValues)
 	for label, values := range labelMap {
-		uniqueValues := make([]string, len(values))
+		var uniqueValues []string
 		for v := range values {
 			uniqueValues = append(uniqueValues, v)
 		}

--- a/pkg/ingester/instance.go
+++ b/pkg/ingester/instance.go
@@ -564,8 +564,6 @@ func (i *instance) Label(ctx context.Context, req *logproto.LabelRequest, matche
 	}
 
 	labels := util.NewUniqueStrings(0)
-	// (shantanu) can create a map here to store label names::values and count the unique values
-	// just return a string to int map
 	err := i.forMatchingStreams(ctx, *req.Start, matchers, nil, func(s *stream) error {
 		for _, label := range s.labels {
 			if req.Values && label.Name == req.Name {

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -915,7 +915,7 @@ func (q *SingleTenantQuerier) DetectedLabels(ctx context.Context, req *logproto.
 
 	g, ctx := errgroup.WithContext(ctx)
 	ingesterQueryInterval, _ := q.buildQueryIntervals(*req.Start, *req.End)
-	if !q.cfg.QueryStoreOnly {
+	if !q.cfg.QueryStoreOnly && ingesterQueryInterval != nil {
 		g.Go(func() error {
 			var err error
 			splitReq := *req
@@ -930,6 +930,12 @@ func (q *SingleTenantQuerier) DetectedLabels(ctx context.Context, req *logproto.
 
 	if err := g.Wait(); err != nil {
 		return nil, err
+	}
+
+	if ingesterLabels == nil {
+		return &logproto.DetectedLabelsResponse{
+			DetectedLabels: []*logproto.DetectedLabel{},
+		}, nil
 	}
 
 	for label, values := range ingesterLabels.Labels {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes bug in the detected labels API. 

- Query does not work as matches are not recognized
- Blank value increases the cardinality by 1
- Dedupe does not work properly
- panics if ingester labels are nil
