### PR TITLE
chore(deps): Bump golang to 1.21.9

### DIFF
--- a/clients/cmd/fluent-bit/Dockerfile
+++ b/clients/cmd/fluent-bit/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22.0-bullseye AS builder
+FROM golang:1.22.2-bullseye AS builder
 
 COPY . /src
 

--- a/clients/cmd/promtail/Dockerfile
+++ b/clients/cmd/promtail/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.3-bullseye as build
+FROM golang:1.21.9-bullseye as build
 
 COPY . /src/loki
 WORKDIR /src/loki

--- a/clients/cmd/promtail/Dockerfile.arm32
+++ b/clients/cmd/promtail/Dockerfile.arm32
@@ -1,4 +1,4 @@
-FROM golang:1.21.2-bullseye as build
+FROM golang:1.21.9-bullseye as build
 
 COPY . /src/loki
 WORKDIR /src/loki

--- a/clients/cmd/promtail/Dockerfile.cross
+++ b/clients/cmd/promtail/Dockerfile.cross
@@ -2,7 +2,7 @@ ARG BUILD_IMAGE=grafana/loki-build-image:0.33.1
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/promtail -f clients/cmd/promtail/Dockerfile .
-FROM golang:1.21.2-alpine as goenv
+FROM golang:1.21.9-alpine as goenv
 RUN go env GOARCH > /goarch && \
   go env GOARM > /goarm
 

--- a/cmd/logcli/Dockerfile
+++ b/cmd/logcli/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.3 as build
+FROM golang:1.21.9 as build
 
 COPY . /src/loki
 WORKDIR /src/loki

--- a/cmd/logql-analyzer/Dockerfile
+++ b/cmd/logql-analyzer/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.3 as build
+FROM golang:1.21.9 as build
 
 COPY . /src/loki
 WORKDIR /src/loki

--- a/cmd/loki-canary-boringcrypto/Dockerfile
+++ b/cmd/loki-canary-boringcrypto/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.3 as build
+FROM golang:1.21.9 as build
 
 COPY . /src/loki
 WORKDIR /src/loki

--- a/cmd/loki-canary/Dockerfile
+++ b/cmd/loki-canary/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.3 as build
+FROM golang:1.21.9 as build
 
 COPY . /src/loki
 WORKDIR /src/loki

--- a/cmd/loki-canary/Dockerfile.cross
+++ b/cmd/loki-canary/Dockerfile.cross
@@ -2,7 +2,7 @@ ARG BUILD_IMAGE=grafana/loki-build-image:0.33.1
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/promtail -f cmd/promtail/Dockerfile .
-FROM golang:1.21.2-alpine as goenv
+FROM golang:1.21.9-alpine as goenv
 RUN go env GOARCH > /goarch && \
   go env GOARM > /goarm
 

--- a/cmd/loki/Dockerfile
+++ b/cmd/loki/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.3 as build
+FROM golang:1.21.9 as build
 
 COPY . /src/loki
 WORKDIR /src/loki

--- a/cmd/loki/Dockerfile.cross
+++ b/cmd/loki/Dockerfile.cross
@@ -2,7 +2,7 @@ ARG BUILD_IMAGE=grafana/loki-build-image:0.33.1
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/loki -f cmd/loki/Dockerfile .
-FROM golang:1.21.2-alpine as goenv
+FROM golang:1.21.9-alpine as goenv
 RUN go env GOARCH > /goarch && \
     go env GOARM > /goarm
 

--- a/cmd/loki/Dockerfile.debug
+++ b/cmd/loki/Dockerfile.debug
@@ -3,7 +3,7 @@ ARG BUILD_IMAGE=grafana/loki-build-image:0.33.1
 # This file is intended to be called from the root like so:
 # docker build -t grafana/loki -f cmd/loki/Dockerfile.debug .
 
-FROM golang:1.21.2-alpine as goenv
+FROM golang:1.21.9-alpine as goenv
 RUN go env GOARCH > /goarch && \
     go env GOARM > /goarm && \
     go install github.com/go-delve/delve/cmd/dlv@latest

--- a/cmd/migrate/Dockerfile
+++ b/cmd/migrate/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.3 as build
+FROM golang:1.21.9 as build
 COPY . /src/loki
 WORKDIR /src/loki
 RUN make clean && make BUILD_IN_CONTAINER=false migrate

--- a/cmd/querytee/Dockerfile
+++ b/cmd/querytee/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.3 as build
+FROM golang:1.21.9 as build
 
 COPY . /src/loki
 WORKDIR /src/loki

--- a/cmd/querytee/Dockerfile.cross
+++ b/cmd/querytee/Dockerfile.cross
@@ -2,7 +2,7 @@ ARG BUILD_IMAGE=grafana/loki-build-image:0.33.1
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/promtail -f cmd/promtail/Dockerfile .
-FROM golang:1.21.2-alpine as goenv
+FROM golang:1.21.9-alpine as goenv
 RUN go env GOARCH > /goarch && \
   go env GOARM > /goarm
 

--- a/tools/dev/loki-tsdb-storage-s3/dev.dockerfile
+++ b/tools/dev/loki-tsdb-storage-s3/dev.dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.3
+FROM golang:1.21.9
 ENV CGO_ENABLED=0
 RUN go install github.com/go-delve/delve/cmd/dlv@v1.22.1
 

--- a/tools/lambda-promtail/Dockerfile
+++ b/tools/lambda-promtail/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22.2-alpine AS build-image
+FROM golang:1.21.9-alpine AS build-image
 
 COPY tools/lambda-promtail /src/lambda-promtail
 WORKDIR /src/lambda-promtail

--- a/tools/tsdb/bloom-tester/Dockerfile
+++ b/tools/tsdb/bloom-tester/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.3 as build
+FROM golang:1.21.9 as build
 ENV BUILD_IN_CONTAINER=false
 
 COPY . /src/bloom-tester


### PR DESCRIPTION
**What this PR does / why we need it**:
Addresses several CVEs:
- CVE-2023-45288 - https://github.com/golang/go/issues/65051 (fixed in Go 1.21.9)
- CVE-2024-24783 and Go issue https://go.dev/issue/65390. (fixed in Go 1.21.8)
- CVE-2023-45290 and Go issue https://go.dev/issue/65383. (fixed in Go 1.21.8)
- CVE-2023-45289 and Go issue https://go.dev/issue/65065. (fixed in Go 1.21.8)
- CVE-2024-24785 and Go issue https://go.dev/issue/65697. (fixed in Go 1.21.8)
- CVE-2024-24784 and Go issue https://go.dev/issue/65083. (fixed in Go 1.21.8 / Probably not affected)
- CVE-2023-39326 and Go issue https://go.dev/issue/64433. (fixed in Go 1.21.5)
- CVE-2023-45285 and Go issue https://go.dev/issue/63845. (fixed in Go 1.21.5 / Not affected)
- CVE-2023-45283 and Go issue https://go.dev/issue/64028. (fixed in Go 1.21.5 / Probably not affected)
- CVE-2023-45283 and Go issue https://go.dev/issue/63713. (fixed in Go 1.21.4 / Not affected)
- CVE-2023-45284 and Go issue https://go.dev/issue/63713. (fixed in Go 1.21.4 / Not affected)

Replaces:
- #12460 for CVE-2023-45288

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
