### PR TITLE
chore: New build image for release branches

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -498,7 +498,7 @@ local manifest_ecr(apps, archs) = pipeline('manifest-ecr') {
 
 [
   pipeline('loki-build-image') {
-    local build_image_tag = '0.29.3-golangci.1.51.2',
+    local build_image_tag = '0.33.1-golangci.1.51.2',
     workspace: {
       base: '/src',
       path: 'loki',

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -10,7 +10,7 @@ steps:
     dry_run: true
     repo: grafana/loki-build-image
     tags:
-    - 0.29.3-golangci.1.51.2
+    - 0.33.1-golangci.1.51.2
   when:
     event:
     - pull_request
@@ -26,7 +26,7 @@ steps:
       from_secret: docker_password
     repo: grafana/loki-build-image
     tags:
-    - 0.29.3-golangci.1.51.2
+    - 0.33.1-golangci.1.51.2
     username:
       from_secret: docker_username
   when:

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -2017,6 +2017,6 @@ kind: secret
 name: gpg_private_key
 ---
 kind: signature
-hmac: 2b2de80a1510c1d22832e002c35a198ce84b1fd86cf05490ad0861dc2f51cf7a
+hmac: 016d84867476782105e34f5165893b0fbb62e393be4cf5436c199f6e339d79d7
 
 ...

--- a/loki-build-image/Dockerfile
+++ b/loki-build-image/Dockerfile
@@ -5,7 +5,7 @@
 # See ../docs/sources/maintaining/release-loki-build-image.md
 
 # Install helm (https://helm.sh/) and helm-docs (https://github.com/norwoodj/helm-docs) for generating Helm Chart reference.
-FROM golang:1.20.6-bullseye as helm
+FROM golang:1.20.9-bullseye as helm
 ARG HELM_VER="v3.2.3"
 RUN curl -L -o /tmp/helm-$HELM_VER.tgz https://get.helm.sh/helm-${HELM_VER}-linux-amd64.tar.gz && \
     tar -xz -C /tmp -f /tmp/helm-$HELM_VER.tgz && \
@@ -38,7 +38,7 @@ RUN apk add --no-cache docker-cli
 # TODO this should be fixed to download and extract the specific release binary from github as we do for golangci and helm above
 # however we need a commit which hasn't been released yet: https://github.com/drone/drone-cli/commit/1fad337d74ca0ecf420993d9d2d7229a1c99f054
 # Read the comment below regarding GO111MODULE=on and why it is necessary
-FROM golang:1.20.6-bullseye as drone
+FROM golang:1.20.9-bullseye as drone
 RUN curl -L https://github.com/drone/drone-cli/releases/download/v1.4.0/drone_linux_amd64.tar.gz | tar zx && \
     install -t /usr/local/bin drone
 
@@ -47,33 +47,33 @@ RUN curl -L https://github.com/drone/drone-cli/releases/download/v1.4.0/drone_li
 # Error:
 # github.com/fatih/faillint@v1.5.0 requires golang.org/x/tools@v0.0.0-20200207224406-61798d64f025
 #   (not golang.org/x/tools@v0.0.0-20190918214920-58d531046acd from golang.org/x/tools/cmd/goyacc@58d531046acdc757f177387bc1725bfa79895d69)
-FROM golang:1.20.6-bullseye as faillint
+FROM golang:1.20.9-bullseye as faillint
 RUN GO111MODULE=on go install github.com/fatih/faillint@v1.11.0
 RUN GO111MODULE=on go install golang.org/x/tools/cmd/goimports@v0.7.0
 
-FROM golang:1.20.6-bullseye as delve
+FROM golang:1.20.9-bullseye as delve
 RUN GO111MODULE=on go install github.com/go-delve/delve/cmd/dlv@latest
 
 # Install ghr used to push binaries and template the release
 # This collides with the version of go tools used in the base image, thus we install it in its own image and copy it over.
-FROM golang:1.20.6-bullseye as ghr
+FROM golang:1.20.9-bullseye as ghr
 RUN GO111MODULE=on go install github.com/tcnksm/ghr@9349474
 
 # Install nfpm (https://nfpm.goreleaser.com) for creating .deb and .rpm packages.
-FROM golang:1.20.6-bullseye as nfpm
+FROM golang:1.20.9-bullseye as nfpm
 RUN GO111MODULE=on go install github.com/goreleaser/nfpm/v2/cmd/nfpm@v2.11.3
 
 # Install gotestsum
-FROM golang:1.20.6-bullseye as gotestsum
+FROM golang:1.20.9-bullseye as gotestsum
 RUN GO111MODULE=on go install gotest.tools/gotestsum@v1.8.2
 
 # Install tools used to compile jsonnet.
-FROM golang:1.20.6-bullseye as jsonnet
+FROM golang:1.20.9-bullseye as jsonnet
 RUN GO111MODULE=on go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@v0.4.0
 RUN GO111MODULE=on go install github.com/monitoring-mixins/mixtool/cmd/mixtool@bca3066
 RUN GO111MODULE=on go install github.com/google/go-jsonnet/cmd/jsonnet@v0.18.0
 
-FROM golang:1.20.6-bullseye
+FROM golang:1.20.9-bullseye
 RUN apt-get update && \
     apt-get install -qy \
     musl gnupg ragel \

--- a/loki-build-image/README.md
+++ b/loki-build-image/README.md
@@ -2,6 +2,13 @@
 
 ## Versions
 
+### 0.33.1-golangci.1.51.2
+
+- Update to Go version 1.20.9 but restore golangci-lint to v1.51.2
+
+* This release should only be used for the release branches such as 2.9.x, 2.8.x and 2.7.x. 
+* The current release of the build image uses golangci-lint to v1.53.2 which makes a lot of linter checks mandatory causing a huge amount of fixes See https://github.com/grafana/loki/pull/9601. To avoid the integration problems this build image will be used in those branches.
+
 ### 0.29.3-golangci.1.51.2
 
 - Update to Go version 1.20.6 but restore golangci-lint to v1.51.2


### PR DESCRIPTION
**What this PR does / why we need it**:
Builds a new release image based on `main`'s `0.33.1` but sticks to `golangci-lint@v1.51.2`

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:
Manual backport of:
- #12465

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
