### PR TITLE
chore: remove experimental flags from features and configs which are no longer so.

### DIFF
--- a/docs/sources/configure/_index.md
+++ b/docs/sources/configure/_index.md
@@ -726,15 +726,13 @@ rate_store:
   # CLI flag: -distributor.rate-store.debug
   [debug: <boolean> | default = false]
 
-# Experimental. Customize the logging of write failures.
+# Customize the logging of write failures.
 write_failures_logging:
-  # Experimental and subject to change. Log volume allowed (per second).
-  # Default: 1KB.
+  # Log volume allowed (per second). Default: 1KB.
   # CLI flag: -distributor.write-failures-logging.rate
   [rate: <int> | default = 1KB]
 
-  # Experimental and subject to change. Whether a insight=true key should be
-  # logged or not. Default: false.
+  # Whether a insight=true key should be logged or not. Default: false.
   # CLI flag: -distributor.write-failures-logging.add-insights-label
   [add_insights_label: <boolean> | default = false]
 
@@ -2633,7 +2631,7 @@ The `compactor` block configures the compactor component, which compacts index s
 # CLI flag: -compactor.apply-retention-interval
 [apply_retention_interval: <duration> | default = 0s]
 
-# (Experimental) Activate custom (per-stream,per-tenant) retention.
+# Activate custom (per-stream,per-tenant) retention.
 # CLI flag: -compactor.retention-enabled
 [retention_enabled: <boolean> | default = false]
 

--- a/docs/sources/send-data/otel/_index.md
+++ b/docs/sources/send-data/otel/_index.md
@@ -15,8 +15,6 @@ For ingesting logs to Loki using the OpenTelemetry Collector, you must use the [
 ## Loki configuration
 
 When logs are ingested by Loki using an OpenTelemetry protocol (OTLP) ingestion endpoint, some of the data is stored as [Structured Metadata]({{< relref "../../get-started/labels/structured-metadata" >}}).
-Since Structured Metadata is still an experimental feature, Loki by default rejects any writes using that feature.
-To start ingesting logs in OpenTelemetry format, you need to enable `allow_structured_metadata` per tenant configuration (in the `limits_config`).
 
 ## Configure the OpenTelemetry Collector to write logs into Loki
 

--- a/docs/sources/send-data/promtail/stages/structured_metadata.md
+++ b/docs/sources/send-data/promtail/stages/structured_metadata.md
@@ -5,10 +5,6 @@ description: The 'structured_metadata' Promtail pipeline stage
 
 # structured_metadata
 
-{{% admonition type="warning" %}}
-Structured metadata is an experimental feature and is subject to change in future releases of Grafana Loki.
-{{% /admonition %}}
-
 The `structured_metadata` stage is an action stage that takes data from the extracted map and
 modifies the [structured metadata]({{< relref "../../../get-started/labels/structured-metadata" >}}) that is sent to Loki with the log entry.
 

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -96,7 +96,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.DurationVar(&cfg.CompactionInterval, "compactor.compaction-interval", 10*time.Minute, "Interval at which to re-run the compaction operation.")
 	f.DurationVar(&cfg.ApplyRetentionInterval, "compactor.apply-retention-interval", 0, "Interval at which to apply/enforce retention. 0 means run at same interval as compaction. If non-zero, it should always be a multiple of compaction interval.")
 	f.DurationVar(&cfg.RetentionDeleteDelay, "compactor.retention-delete-delay", 2*time.Hour, "Delay after which chunks will be fully deleted during retention.")
-	f.BoolVar(&cfg.RetentionEnabled, "compactor.retention-enabled", false, "(Experimental) Activate custom (per-stream,per-tenant) retention.")
+	f.BoolVar(&cfg.RetentionEnabled, "compactor.retention-enabled", false, "Activate custom (per-stream,per-tenant) retention.")
 	f.IntVar(&cfg.RetentionDeleteWorkCount, "compactor.retention-delete-worker-count", 150, "The total amount of worker to use to delete chunks.")
 	f.StringVar(&cfg.DeleteRequestStore, "compactor.delete-request-store", "", "Store used for managing delete requests.")
 	f.StringVar(&cfg.DeleteRequestStoreKeyPrefix, "compactor.delete-request-store.key-prefix", "index/", "Path prefix for storing delete requests.")

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -85,7 +85,7 @@ type Config struct {
 	RateStore RateStoreConfig `yaml:"rate_store"`
 
 	// WriteFailuresLoggingCfg customizes write failures logging behavior.
-	WriteFailuresLogging writefailures.Cfg `yaml:"write_failures_logging" doc:"description=Experimental. Customize the logging of write failures."`
+	WriteFailuresLogging writefailures.Cfg `yaml:"write_failures_logging" doc:"description=Customize the logging of write failures."`
 
 	OTLPConfig push.GlobalOTLPConfig `yaml:"otlp_config"`
 }

--- a/pkg/distributor/writefailures/cfg.go
+++ b/pkg/distributor/writefailures/cfg.go
@@ -7,15 +7,15 @@ import (
 )
 
 type Cfg struct {
-	LogRate flagext.ByteSize `yaml:"rate" category:"experimental"`
+	LogRate flagext.ByteSize `yaml:"rate"`
 
-	AddInsightsLabel bool `yaml:"add_insights_label" category:"experimental"`
+	AddInsightsLabel bool `yaml:"add_insights_label"`
 }
 
 // RegisterFlags registers distributor-related flags.
 func (cfg *Cfg) RegisterFlagsWithPrefix(prefix string, fs *flag.FlagSet) {
 	_ = cfg.LogRate.Set("1KB")
-	fs.Var(&cfg.LogRate, prefix+".rate", "Experimental and subject to change. Log volume allowed (per second). Default: 1KB.")
+	fs.Var(&cfg.LogRate, prefix+".rate", "Log volume allowed (per second). Default: 1KB.")
 
-	fs.BoolVar(&cfg.AddInsightsLabel, prefix+".add-insights-label", false, "Experimental and subject to change. Whether a insight=true key should be logged or not. Default: false.")
+	fs.BoolVar(&cfg.AddInsightsLabel, prefix+".add-insights-label", false, "Whether a insight=true key should be logged or not. Default: false.")
 }

--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -112,7 +112,7 @@ type Config struct {
 
 	Common common.Config `yaml:"common,omitempty"`
 
-	ShutdownDelay time.Duration `yaml:"shutdown_delay" category:"experimental"`
+	ShutdownDelay time.Duration `yaml:"shutdown_delay"`
 
 	MetricsNamespace string `yaml:"metrics_namespace"`
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

I revisited things marked as experimental and updates several things which no longer need be considered experimental for Loki 3.0

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
