### PR TITLE
chore: [release-2.9.x] Bump go to 1.21.9 and build image to 0.33.1 

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "image": "grafana/loki-build-image:33.1",
+  "image": "grafana/loki-build-image:0.33.1",
   "containerEnv": {
     "BUILD_IN_CONTAINER": "false"
   },

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "image": "grafana/loki-build-image:0.29.0",
+  "image": "grafana/loki-build-image:33.1",
   "containerEnv": {
     "BUILD_IN_CONTAINER": "false"
   },

--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -498,7 +498,7 @@ local manifest_ecr(apps, archs) = pipeline('manifest-ecr') {
 
 [
   pipeline('loki-build-image') {
-    local build_image_tag = '0.33.1-golangci.1.51.2',
+    local build_image_tag = '0.33.1',
     workspace: {
       base: '/src',
       path: 'loki',

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -10,7 +10,7 @@ steps:
     dry_run: true
     repo: grafana/loki-build-image
     tags:
-    - 0.33.1-golangci.1.51.2
+    - 0.33.1
   when:
     event:
     - pull_request
@@ -26,7 +26,7 @@ steps:
       from_secret: docker_password
     repo: grafana/loki-build-image
     tags:
-    - 0.33.1-golangci.1.51.2
+    - 0.33.1
     username:
       from_secret: docker_username
   when:
@@ -93,14 +93,14 @@ steps:
   depends_on:
   - clone
   environment: {}
-  image: grafana/loki-build-image:0.30.1
+  image: grafana/loki-build-image:0.33.1
   name: check-drone-drift
 - commands:
   - make BUILD_IN_CONTAINER=false check-generated-files
   depends_on:
   - clone
   environment: {}
-  image: grafana/loki-build-image:0.30.1
+  image: grafana/loki-build-image:0.33.1
   name: check-generated-files
 - commands:
   - cd ..
@@ -110,7 +110,7 @@ steps:
   depends_on:
   - clone
   environment: {}
-  image: grafana/loki-build-image:0.30.1
+  image: grafana/loki-build-image:0.33.1
   name: clone-target-branch
   when:
     event:
@@ -121,14 +121,14 @@ steps:
   - clone-target-branch
   - check-generated-files
   environment: {}
-  image: grafana/loki-build-image:0.30.1
+  image: grafana/loki-build-image:0.33.1
   name: test
 - commands:
   - cd ../loki-target-branch && BUILD_IN_CONTAINER=false make test
   depends_on:
   - clone-target-branch
   environment: {}
-  image: grafana/loki-build-image:0.30.1
+  image: grafana/loki-build-image:0.33.1
   name: test-target-branch
   when:
     event:
@@ -141,7 +141,7 @@ steps:
   - test
   - test-target-branch
   environment: {}
-  image: grafana/loki-build-image:0.30.1
+  image: grafana/loki-build-image:0.33.1
   name: compare-coverage
   when:
     event:
@@ -159,7 +159,7 @@ steps:
     TOKEN:
       from_secret: github_token
     USER: grafanabot
-  image: grafana/loki-build-image:0.30.1
+  image: grafana/loki-build-image:0.33.1
   name: report-coverage
   when:
     event:
@@ -169,7 +169,7 @@ steps:
   depends_on:
   - check-generated-files
   environment: {}
-  image: grafana/loki-build-image:0.30.1
+  image: grafana/loki-build-image:0.33.1
   name: lint
 - commands:
   - make BUILD_IN_CONTAINER=false check-mod
@@ -177,7 +177,7 @@ steps:
   - test
   - lint
   environment: {}
-  image: grafana/loki-build-image:0.30.1
+  image: grafana/loki-build-image:0.33.1
   name: check-mod
 - commands:
   - apk add make bash && make lint-scripts
@@ -188,21 +188,21 @@ steps:
   depends_on:
   - check-generated-files
   environment: {}
-  image: grafana/loki-build-image:0.30.1
+  image: grafana/loki-build-image:0.33.1
   name: loki
 - commands:
   - make BUILD_IN_CONTAINER=false check-doc
   depends_on:
   - loki
   environment: {}
-  image: grafana/loki-build-image:0.30.1
+  image: grafana/loki-build-image:0.33.1
   name: check-doc
 - commands:
   - make BUILD_IN_CONTAINER=false check-format GIT_TARGET_BRANCH="$DRONE_TARGET_BRANCH"
   depends_on:
   - loki
   environment: {}
-  image: grafana/loki-build-image:0.30.1
+  image: grafana/loki-build-image:0.33.1
   name: check-format
   when:
     event:
@@ -212,14 +212,14 @@ steps:
   depends_on:
   - loki
   environment: {}
-  image: grafana/loki-build-image:0.30.1
+  image: grafana/loki-build-image:0.33.1
   name: validate-example-configs
 - commands:
   - make BUILD_IN_CONTAINER=false check-example-config-doc
   depends_on:
   - clone
   environment: {}
-  image: grafana/loki-build-image:0.30.1
+  image: grafana/loki-build-image:0.33.1
   name: check-example-config-doc
 - commands:
   - mkdir -p /hugo/content/docs/loki/latest
@@ -252,7 +252,7 @@ steps:
   depends_on:
   - clone
   environment: {}
-  image: grafana/loki-build-image:0.30.1
+  image: grafana/loki-build-image:0.33.1
   name: loki-mixin-check
   when:
     event:
@@ -277,7 +277,7 @@ steps:
   depends_on:
   - clone
   environment: {}
-  image: grafana/loki-build-image:0.30.1
+  image: grafana/loki-build-image:0.33.1
   name: documentation-helm-reference-check
 trigger:
   ref:
@@ -1683,7 +1683,7 @@ steps:
     NFPM_SIGNING_KEY:
       from_secret: gpg_private_key
     NFPM_SIGNING_KEY_FILE: /drone/src/private-key.key
-  image: grafana/loki-build-image:0.30.1
+  image: grafana/loki-build-image:0.33.1
   name: write-key
 - commands:
   - make BUILD_IN_CONTAINER=false packages
@@ -1691,7 +1691,7 @@ steps:
     NFPM_PASSPHRASE:
       from_secret: gpg_passphrase
     NFPM_SIGNING_KEY_FILE: /drone/src/private-key.key
-  image: grafana/loki-build-image:0.30.1
+  image: grafana/loki-build-image:0.33.1
   name: test packaging
 - commands:
   - ./tools/packaging/verify-deb-install.sh
@@ -1717,7 +1717,7 @@ steps:
     NFPM_PASSPHRASE:
       from_secret: gpg_passphrase
     NFPM_SIGNING_KEY_FILE: /drone/src/private-key.key
-  image: grafana/loki-build-image:0.30.1
+  image: grafana/loki-build-image:0.33.1
   name: publish
   when:
     event:
@@ -1752,7 +1752,7 @@ steps:
       from_secret: docker_password
     DOCKER_USERNAME:
       from_secret: docker_username
-  image: grafana/loki-build-image:0.30.1
+  image: grafana/loki-build-image:0.33.1
   name: build and push
   privileged: true
   volumes:
@@ -2017,6 +2017,6 @@ kind: secret
 name: gpg_private_key
 ---
 kind: signature
-hmac: 016d84867476782105e34f5165893b0fbb62e393be4cf5436c199f6e339d79d7
+hmac: d8b8157778d7af50fed6a3495772371184d2df57c6940516be68ecdf8cdf5de4
 
 ...

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,7 +2,7 @@
   "check":
     "uses": "grafana/loki-release/.github/workflows/check.yml@loki-2.9.x"
     "with":
-      "build_image": "grafana/loki-build-image:0.30.1"
+      "build_image": "grafana/loki-build-image:0.33.1"
       "golang_ci_lint_version": "v1.51.2"
       "release_lib_ref": "loki-2.9.x"
       "skip_validation": false

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,7 +2,7 @@
   "check":
     "uses": "grafana/loki-release/.github/workflows/check.yml@loki-2.9.x"
     "with":
-      "build_image": "grafana/loki-build-image:0.30.1"
+      "build_image": "grafana/loki-build-image:33.1"
       "golang_ci_lint_version": "v1.51.2"
       "release_lib_ref": "loki-2.9.x"
       "skip_validation": false

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -3,7 +3,7 @@
     "uses": "grafana/loki-release/.github/workflows/check.yml@loki-2.9.x"
     "with":
       "build_image": "grafana/loki-build-image:0.33.1"
-      "golang_ci_lint_version": "v1.51.2"
+      "golang_ci_lint_version": "v1.55.1"
       "release_lib_ref": "loki-2.9.x"
       "skip_validation": false
       "use_github_app_token": true

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,7 +2,7 @@
   "check":
     "uses": "grafana/loki-release/.github/workflows/check.yml@loki-2.9.x"
     "with":
-      "build_image": "grafana/loki-build-image:33.1"
+      "build_image": "grafana/loki-build-image:0.33.1"
       "golang_ci_lint_version": "v1.51.2"
       "release_lib_ref": "loki-2.9.x"
       "skip_validation": false

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,7 +2,7 @@
   "check":
     "uses": "grafana/loki-release/.github/workflows/check.yml@loki-2.9.x"
     "with":
-      "build_image": "grafana/loki-build-image:0.33.1"
+      "build_image": "grafana/loki-build-image:0.30.1"
       "golang_ci_lint_version": "v1.51.2"
       "release_lib_ref": "loki-2.9.x"
       "skip_validation": false

--- a/.github/workflows/minor-release-pr.yml
+++ b/.github/workflows/minor-release-pr.yml
@@ -14,7 +14,7 @@ jobs:
   check:
     uses: "grafana/loki-release/.github/workflows/check.yml@loki-2.9.x"
     with:
-      build_image: "grafana/loki-build-image:33.1"
+      build_image: "grafana/loki-build-image:0.33.1"
       golang_ci_lint_version: "v1.51.2"
       release_lib_ref: "loki-2.9.x"
       skip_validation: false
@@ -89,7 +89,7 @@ jobs:
           --target-branch "${{ steps.extract_branch.outputs.branch }}" \
           --token "${{ steps.github_app_token.outputs.token }}" \
           --versioning-strategy "${{ env.VERSIONING_STRATEGY }}"
-        
+
       working-directory: "lib"
   dist:
     needs:
@@ -136,7 +136,7 @@ jobs:
           --env SKIP_ARM \
           --volume .:/src/loki \
           --workdir /src/loki \
-          --entrypoint /bin/sh "grafana/loki-build-image:33.1"
+          --entrypoint /bin/sh "grafana/loki-build-image:0.33.1"
           git config --global --add safe.directory /src/loki
           echo "${NFPM_SIGNING_KEY}" > $NFPM_SIGNING_KEY_FILE
           make dist packages
@@ -181,7 +181,7 @@ jobs:
       name: "parse image platform"
       run: |
         mkdir -p images
-        
+
         platform="$(echo "${{ matrix.platform}}" |  sed  "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -243,7 +243,7 @@ jobs:
       name: "parse image platform"
       run: |
         mkdir -p images
-        
+
         platform="$(echo "${{ matrix.platform}}" |  sed  "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -305,7 +305,7 @@ jobs:
       name: "parse image platform"
       run: |
         mkdir -p images
-        
+
         platform="$(echo "${{ matrix.platform}}" |  sed  "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -369,7 +369,7 @@ jobs:
       name: "parse image platform"
       run: |
         mkdir -p images
-        
+
         platform="$(echo "${{ matrix.platform}}" |  sed  "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -431,7 +431,7 @@ jobs:
       name: "parse image platform"
       run: |
         mkdir -p images
-        
+
         platform="$(echo "${{ matrix.platform}}" |  sed  "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -495,7 +495,7 @@ jobs:
       name: "parse image platform"
       run: |
         mkdir -p images
-        
+
         platform="$(echo "${{ matrix.platform}}" |  sed  "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -559,7 +559,7 @@ jobs:
       name: "parse image platform"
       run: |
         mkdir -p images
-        
+
         platform="$(echo "${{ matrix.platform}}" |  sed  "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -623,7 +623,7 @@ jobs:
       name: "parse image platform"
       run: |
         mkdir -p images
-        
+
         platform="$(echo "${{ matrix.platform}}" |  sed  "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -687,7 +687,7 @@ jobs:
       name: "parse image platform"
       run: |
         mkdir -p images
-        
+
         platform="$(echo "${{ matrix.platform}}" |  sed  "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -778,16 +778,16 @@ jobs:
           --target-branch "${{ steps.extract_branch.outputs.branch }}" \
           --token "${{ steps.github_app_token.outputs.token }}" \
           --versioning-strategy "${{ env.VERSIONING_STRATEGY }}"
-        
+
         cat release.json
-        
-        if [[ `jq length release.json` -gt 1 ]]; then 
+
+        if [[ `jq length release.json` -gt 1 ]]; then
           echo 'release-please would create more than 1 PR, so cannot determine correct version'
           echo "pr_created=false" >> $GITHUB_OUTPUT
           exit 1
         fi
-        
-        if [[ `jq length release.json` -eq 0 ]]; then 
+
+        if [[ `jq length release.json` -eq 0 ]]; then
           echo "pr_created=false" >> $GITHUB_OUTPUT
         else
           version="$(npm run --silent get-version)"

--- a/.github/workflows/minor-release-pr.yml
+++ b/.github/workflows/minor-release-pr.yml
@@ -15,7 +15,7 @@ jobs:
     uses: "grafana/loki-release/.github/workflows/check.yml@loki-2.9.x"
     with:
       build_image: "grafana/loki-build-image:0.33.1"
-      golang_ci_lint_version: "v1.51.2"
+      golang_ci_lint_version: "v1.55.1"
       release_lib_ref: "loki-2.9.x"
       skip_validation: false
       use_github_app_token: true

--- a/.github/workflows/minor-release-pr.yml
+++ b/.github/workflows/minor-release-pr.yml
@@ -14,7 +14,7 @@ jobs:
   check:
     uses: "grafana/loki-release/.github/workflows/check.yml@loki-2.9.x"
     with:
-      build_image: "grafana/loki-build-image:0.30.1"
+      build_image: "grafana/loki-build-image:33.1"
       golang_ci_lint_version: "v1.51.2"
       release_lib_ref: "loki-2.9.x"
       skip_validation: false
@@ -136,7 +136,7 @@ jobs:
           --env SKIP_ARM \
           --volume .:/src/loki \
           --workdir /src/loki \
-          --entrypoint /bin/sh "grafana/loki-build-image:0.30.1"
+          --entrypoint /bin/sh "grafana/loki-build-image:33.1"
           git config --global --add safe.directory /src/loki
           echo "${NFPM_SIGNING_KEY}" > $NFPM_SIGNING_KEY_FILE
           make dist packages

--- a/.github/workflows/patch-release-pr.yml
+++ b/.github/workflows/patch-release-pr.yml
@@ -136,7 +136,7 @@ jobs:
           --env SKIP_ARM \
           --volume .:/src/loki \
           --workdir /src/loki \
-          --entrypoint /bin/sh "grafana/loki-build-image:33.1"
+          --entrypoint /bin/sh "grafana/loki-build-image:0.33.1"
           git config --global --add safe.directory /src/loki
           echo "${NFPM_SIGNING_KEY}" > $NFPM_SIGNING_KEY_FILE
           make dist packages

--- a/.github/workflows/patch-release-pr.yml
+++ b/.github/workflows/patch-release-pr.yml
@@ -15,7 +15,7 @@ jobs:
     uses: "grafana/loki-release/.github/workflows/check.yml@loki-2.9.x"
     with:
       build_image: "grafana/loki-build-image:0.33.1"
-      golang_ci_lint_version: "v1.51.2"
+      golang_ci_lint_version: "v1.55.1"
       release_lib_ref: "loki-2.9.x"
       skip_validation: false
       use_github_app_token: true

--- a/.github/workflows/patch-release-pr.yml
+++ b/.github/workflows/patch-release-pr.yml
@@ -14,7 +14,7 @@ jobs:
   check:
     uses: "grafana/loki-release/.github/workflows/check.yml@loki-2.9.x"
     with:
-      build_image: "grafana/loki-build-image:0.30.1"
+      build_image: "grafana/loki-build-image:33.1"
       golang_ci_lint_version: "v1.51.2"
       release_lib_ref: "loki-2.9.x"
       skip_validation: false
@@ -136,7 +136,7 @@ jobs:
           --env SKIP_ARM \
           --volume .:/src/loki \
           --workdir /src/loki \
-          --entrypoint /bin/sh "grafana/loki-build-image:0.30.1"
+          --entrypoint /bin/sh "grafana/loki-build-image:33.1"
           git config --global --add safe.directory /src/loki
           echo "${NFPM_SIGNING_KEY}" > $NFPM_SIGNING_KEY_FILE
           make dist packages

--- a/.github/workflows/patch-release-pr.yml
+++ b/.github/workflows/patch-release-pr.yml
@@ -14,7 +14,7 @@ jobs:
   check:
     uses: "grafana/loki-release/.github/workflows/check.yml@loki-2.9.x"
     with:
-      build_image: "grafana/loki-build-image:33.1"
+      build_image: "grafana/loki-build-image:0.33.1"
       golang_ci_lint_version: "v1.51.2"
       release_lib_ref: "loki-2.9.x"
       skip_validation: false
@@ -89,7 +89,7 @@ jobs:
           --target-branch "${{ steps.extract_branch.outputs.branch }}" \
           --token "${{ steps.github_app_token.outputs.token }}" \
           --versioning-strategy "${{ env.VERSIONING_STRATEGY }}"
-        
+
       working-directory: "lib"
   dist:
     needs:
@@ -181,7 +181,7 @@ jobs:
       name: "parse image platform"
       run: |
         mkdir -p images
-        
+
         platform="$(echo "${{ matrix.platform}}" |  sed  "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -243,7 +243,7 @@ jobs:
       name: "parse image platform"
       run: |
         mkdir -p images
-        
+
         platform="$(echo "${{ matrix.platform}}" |  sed  "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -305,7 +305,7 @@ jobs:
       name: "parse image platform"
       run: |
         mkdir -p images
-        
+
         platform="$(echo "${{ matrix.platform}}" |  sed  "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -369,7 +369,7 @@ jobs:
       name: "parse image platform"
       run: |
         mkdir -p images
-        
+
         platform="$(echo "${{ matrix.platform}}" |  sed  "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -431,7 +431,7 @@ jobs:
       name: "parse image platform"
       run: |
         mkdir -p images
-        
+
         platform="$(echo "${{ matrix.platform}}" |  sed  "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -495,7 +495,7 @@ jobs:
       name: "parse image platform"
       run: |
         mkdir -p images
-        
+
         platform="$(echo "${{ matrix.platform}}" |  sed  "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -559,7 +559,7 @@ jobs:
       name: "parse image platform"
       run: |
         mkdir -p images
-        
+
         platform="$(echo "${{ matrix.platform}}" |  sed  "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -623,7 +623,7 @@ jobs:
       name: "parse image platform"
       run: |
         mkdir -p images
-        
+
         platform="$(echo "${{ matrix.platform}}" |  sed  "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -687,7 +687,7 @@ jobs:
       name: "parse image platform"
       run: |
         mkdir -p images
-        
+
         platform="$(echo "${{ matrix.platform}}" |  sed  "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -778,16 +778,16 @@ jobs:
           --target-branch "${{ steps.extract_branch.outputs.branch }}" \
           --token "${{ steps.github_app_token.outputs.token }}" \
           --versioning-strategy "${{ env.VERSIONING_STRATEGY }}"
-        
+
         cat release.json
-        
-        if [[ `jq length release.json` -gt 1 ]]; then 
+
+        if [[ `jq length release.json` -gt 1 ]]; then
           echo 'release-please would create more than 1 PR, so cannot determine correct version'
           echo "pr_created=false" >> $GITHUB_OUTPUT
           exit 1
         fi
-        
-        if [[ `jq length release.json` -eq 0 ]]; then 
+
+        if [[ `jq length release.json` -eq 0 ]]; then
           echo "pr_created=false" >> $GITHUB_OUTPUT
         else
           version="$(npm run --silent get-version)"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -88,5 +88,11 @@ issues:
     - Error return value of .*log\.Logger\)\.Log\x60 is not checked
     - Error return value of .*.Log.* is not checked
     - Error return value of `` is not checked
+  exclude-rules:
+    - path: pkg/scheduler/scheduler.go
+      text: 'SA1019: msg.GetHttpRequest is deprecated: Do not use'
+    - path: '(.+)_test\.go'
+      linters:
+        - goconst
 
   fix: true

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ DOCKER_IMAGE_DIRS := $(patsubst %/Dockerfile,%,$(DOCKERFILES))
 BUILD_IN_CONTAINER ?= true
 
 # ensure you run `make drone` after changing this
-BUILD_IMAGE_VERSION := 0.30.1
+BUILD_IMAGE_VERSION := 0.33.1
 
 # Docker image info
 IMAGE_PREFIX ?= grafana

--- a/clients/cmd/docker-driver/Dockerfile
+++ b/clients/cmd/docker-driver/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:33.1
+ARG BUILD_IMAGE=grafana/loki-build-image:0.33.1
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/loki -f cmd/loki/Dockerfile .

--- a/clients/cmd/docker-driver/Dockerfile
+++ b/clients/cmd/docker-driver/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.29.3
+ARG BUILD_IMAGE=grafana/loki-build-image:33.1
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/loki -f cmd/loki/Dockerfile .

--- a/clients/cmd/fluent-bit/Dockerfile
+++ b/clients/cmd/fluent-bit/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.3-bullseye AS builder
+FROM golang:1.21.9-bullseye AS builder
 
 COPY . /src
 

--- a/clients/cmd/promtail/Dockerfile
+++ b/clients/cmd/promtail/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.3-bullseye as build
+FROM golang:1.21.9-bullseye as build
 
 COPY . /src/loki
 WORKDIR /src/loki

--- a/clients/cmd/promtail/Dockerfile.cross
+++ b/clients/cmd/promtail/Dockerfile.cross
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.29.3
+ARG BUILD_IMAGE=grafana/loki-build-image:0.33.1
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/promtail -f clients/cmd/promtail/Dockerfile .

--- a/clients/cmd/promtail/Dockerfile.debug
+++ b/clients/cmd/promtail/Dockerfile.debug
@@ -2,7 +2,7 @@
 # This file is intended to be called from the root like so:
 # docker build -t grafana/promtail -f clients/cmd/promtail/Dockerfile.debug .
 
-FROM grafana/loki-build-image:33.1 as build
+FROM grafana/loki-build-image:0.33.1 as build
 ARG GOARCH="amd64"
 COPY . /src/loki
 WORKDIR /src/loki

--- a/clients/cmd/promtail/Dockerfile.debug
+++ b/clients/cmd/promtail/Dockerfile.debug
@@ -2,7 +2,7 @@
 # This file is intended to be called from the root like so:
 # docker build -t grafana/promtail -f clients/cmd/promtail/Dockerfile.debug .
 
-FROM grafana/loki-build-image:0.29.3 as build
+FROM grafana/loki-build-image:33.1 as build
 ARG GOARCH="amd64"
 COPY . /src/loki
 WORKDIR /src/loki

--- a/clients/pkg/logentry/stages/metrics.go
+++ b/clients/pkg/logentry/stages/metrics.go
@@ -179,6 +179,7 @@ func (m *metricStage) Name() string {
 }
 
 // recordCounter will update a counter metric
+// nolint:goconst
 func (m *metricStage) recordCounter(name string, counter *metric.Counters, labels model.LabelSet, v interface{}) {
 	// If value matching is defined, make sure value matches.
 	if counter.Cfg.Value != nil {

--- a/cmd/logcli/Dockerfile
+++ b/cmd/logcli/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.3 as build
+FROM golang:1.21.9 as build
 
 COPY . /src/loki
 WORKDIR /src/loki

--- a/cmd/logql-analyzer/Dockerfile
+++ b/cmd/logql-analyzer/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.3 as build
+FROM golang:1.21.9 as build
 
 COPY . /src/loki
 WORKDIR /src/loki

--- a/cmd/loki-canary-boringcrypto/Dockerfile
+++ b/cmd/loki-canary-boringcrypto/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.3 as build
+FROM golang:1.21.9 as build
 
 COPY . /src/loki
 WORKDIR /src/loki

--- a/cmd/loki-canary/Dockerfile
+++ b/cmd/loki-canary/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.3 as build
+FROM golang:1.21.9 as build
 
 COPY . /src/loki
 WORKDIR /src/loki

--- a/cmd/loki-canary/Dockerfile.cross
+++ b/cmd/loki-canary/Dockerfile.cross
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.29.3
+ARG BUILD_IMAGE=grafana/loki-build-image:0.33.1
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/promtail -f cmd/promtail/Dockerfile .

--- a/cmd/loki/Dockerfile
+++ b/cmd/loki/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.3 as build
+FROM golang:1.21.9 as build
 
 COPY . /src/loki
 WORKDIR /src/loki

--- a/cmd/loki/Dockerfile.cross
+++ b/cmd/loki/Dockerfile.cross
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.29.3
+ARG BUILD_IMAGE=grafana/loki-build-image:0.33.1
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/loki -f cmd/loki/Dockerfile .

--- a/cmd/loki/Dockerfile.debug
+++ b/cmd/loki/Dockerfile.debug
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.29.3
+ARG BUILD_IMAGE=grafana/loki-build-image:0.33.1
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/loki -f cmd/loki/Dockerfile.debug .

--- a/cmd/migrate/Dockerfile
+++ b/cmd/migrate/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.3 as build
+FROM golang:1.21.9 as build
 COPY . /src/loki
 WORKDIR /src/loki
 RUN make clean && make BUILD_IN_CONTAINER=false migrate

--- a/cmd/querytee/Dockerfile
+++ b/cmd/querytee/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.3 as build
+FROM golang:1.21.9 as build
 
 COPY . /src/loki
 WORKDIR /src/loki

--- a/cmd/querytee/Dockerfile.cross
+++ b/cmd/querytee/Dockerfile.cross
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.29.3
+ARG BUILD_IMAGE=grafana/loki-build-image:0.33.1
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/promtail -f cmd/promtail/Dockerfile .

--- a/operator/Dockerfile.cross
+++ b/operator/Dockerfile.cross
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.29.3
+ARG BUILD_IMAGE=grafana/loki-build-image:0.33.1
 
 FROM golang:1.20.6-alpine as goenv
 RUN go env GOARCH > /goarch && \

--- a/pkg/logcli/client/client.go
+++ b/pkg/logcli/client/client.go
@@ -324,6 +324,7 @@ func (c *DefaultClient) doRequest(path, query string, quiet bool, out interface{
 	return json.NewDecoder(resp.Body).Decode(out)
 }
 
+// nolint:goconst
 func (c *DefaultClient) getHTTPRequestHeader() (http.Header, error) {
 	h := make(http.Header)
 

--- a/pkg/logcli/query/part_file.go
+++ b/pkg/logcli/query/part_file.go
@@ -36,7 +36,7 @@ func (f *PartFile) Exists() (bool, error) {
 	} else if errors.Is(err, os.ErrNotExist) {
 		// File does not exist.
 		return false, nil
-	} else {
+	} else { // nolint:revive
 		// Unclear if file exists or not, we cannot stat it.
 		return false, fmt.Errorf("failed to check if part file exists: %s: %s", f.finalName, err)
 	}

--- a/pkg/logql/evaluator.go
+++ b/pkg/logql/evaluator.go
@@ -698,9 +698,8 @@ func matchingSignature(sample promql.Sample, opts *syntax.BinOpOptions) uint64 {
 		return sample.Metric.Hash()
 	} else if opts.VectorMatching.On {
 		return labels.NewBuilder(sample.Metric).Keep(opts.VectorMatching.MatchingLabels...).Labels().Hash()
-	} else {
-		return labels.NewBuilder(sample.Metric).Del(opts.VectorMatching.MatchingLabels...).Labels().Hash()
 	}
+	return labels.NewBuilder(sample.Metric).Del(opts.VectorMatching.MatchingLabels...).Labels().Hash()
 }
 
 func vectorBinop(op string, opts *syntax.BinOpOptions, lhs, rhs promql.Vector, lsigs, rsigs []uint64) (promql.Vector, error) {

--- a/pkg/querier/http.go
+++ b/pkg/querier/http.go
@@ -316,10 +316,9 @@ func (q *QuerierAPI) TailHandler(w http.ResponseWriter, r *http.Request) {
 					break
 				} else if tailer.stopped {
 					return
-				} else {
-					level.Error(logger).Log("msg", "Unexpected error from client", "err", err)
-					break
 				}
+				level.Error(logger).Log("msg", "Unexpected error from client", "err", err)
+				break
 			}
 		}
 		doneChan <- struct{}{}

--- a/pkg/querier/queryrange/querysharding.go
+++ b/pkg/querier/queryrange/querysharding.go
@@ -333,8 +333,6 @@ func (confs ShardingConfigs) ValidRange(start, end int64) (config.PeriodConfig, 
 		} else if end < int64(confs[i+1].From.Time) {
 			// The request is entirely scoped into this shard config
 			return conf, nil
-		} else {
-			continue
 		}
 	}
 

--- a/tools/doc-generator/writer.go
+++ b/tools/doc-generator/writer.go
@@ -37,6 +37,7 @@ func (w *specWriter) writeConfigBlock(b *parse.ConfigBlock, indent int) {
 	}
 }
 
+// nolint:goconst
 func (w *specWriter) writeConfigEntry(e *parse.ConfigEntry, indent int) {
 	if e.Kind == parse.KindBlock {
 		// If the block is a root block it will have its dedicated section in the doc,

--- a/tools/lambda-promtail/Dockerfile
+++ b/tools/lambda-promtail/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.3-alpine AS build-image
+FROM golang:1.21.9-alpine AS build-image
 
 COPY tools/lambda-promtail /src/lambda-promtail
 WORKDIR /src/lambda-promtail


### PR DESCRIPTION
**What this PR does / why we need it**:

Use the new build image to address https://pkg.go.dev/vuln/GO-2024-2687.
Some changes had to be made to satisfy the linter. 

Fixes https://github.com/grafana/loki-private/issues/940

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
