### PR TITLE
feat: improve syntax parser for pattern

### DIFF
--- a/pkg/logql/log/pattern/parser_test.go
+++ b/pkg/logql/log/pattern/parser_test.go
@@ -57,3 +57,14 @@ func Test_Parse(t *testing.T) {
 		require.Equal(t, tc.expected, actual)
 	}
 }
+
+var result expr
+
+func BenchmarkParseExpr(b *testing.B) {
+	var err error
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		result, err = parseExpr(`level=info <_> caller=main.go:107 msg="Starting Grafana Enterprise Traces" version="version=weekly-r138-f1920489, branch=weekly-r138, revision=f1920489"`)
+	}
+	require.NoError(b, err)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Thought we had an issue there, but not really, although we still useful to get 35% less alloc.

```
❯ benchstat before.txt after.txt
name          old time/op    new time/op    delta
ParseExpr-16    8.73µs ± 3%    7.79µs ± 1%  -10.81%  (p=0.008 n=5+5)

name          old alloc/op   new alloc/op   delta
ParseExpr-16    5.07kB ± 0%    3.28kB ± 0%  -35.27%  (p=0.008 n=5+5)

name          old allocs/op  new allocs/op  delta
ParseExpr-16      26.0 ± 0%      25.0 ± 0%   -3.85%  (p=0.008 n=5+5)
```

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
