### PR TITLE
fix(blooms): fixup bloom testing

### DIFF
--- a/pkg/bloomgateway/processor.go
+++ b/pkg/bloomgateway/processor.go
@@ -168,7 +168,7 @@ func (p *processor) processBlock(_ context.Context, blockQuerier *v1.BlockQuerie
 		return err
 	}
 
-	tokenizer := v1.NewNGramTokenizer(schema.NGramLen(), 0)
+	tokenizer := v1.NewNGramTokenizer(schema.NGramLen(), schema.NGramSkip())
 	iters := make([]v1.PeekingIterator[v1.Request], 0, len(tasks))
 
 	for _, task := range tasks {

--- a/pkg/storage/bloom/v1/bloom_tester.go
+++ b/pkg/storage/bloom/v1/bloom_tester.go
@@ -4,7 +4,6 @@ import (
 	"unicode/utf8"
 
 	"github.com/grafana/regexp"
-	regexpsyntax "github.com/grafana/regexp/syntax"
 
 	"github.com/grafana/loki/v3/pkg/logql/log"
 	"github.com/grafana/loki/v3/pkg/logql/log/pattern"
@@ -103,22 +102,7 @@ func simpleFilterToBloomTest(b NGramBuilder, filter syntax.LineFilter) BloomTest
 	case log.LineMatchEqual:
 		return newStringTest(b, filter.Match)
 	case log.LineMatchRegexp:
-		// return MatchAll
-		reg, err := regexpsyntax.Parse(filter.Match, regexpsyntax.Perl)
-		if err != nil {
-			// TODO: log error
-			return MatchAll
-		}
-		reg = reg.Simplify()
-
-		simplifier := log.NewRegexSimplifier(newStringFilterFunc(b), newStringFilterFunc(b))
-		matcher, ok := simplifier.Simplify(reg, false)
-		if !ok {
-			// If the regex simplifier fails, we default to MatchAll
-			return MatchAll
-		}
-
-		return matcherFilterWrapper{filter: matcher}
+		return MatchAll
 	case log.LineMatchPattern:
 		return newPatternTest(b, filter.Match)
 	default:

--- a/pkg/storage/bloom/v1/bloom_tester.go
+++ b/pkg/storage/bloom/v1/bloom_tester.go
@@ -70,6 +70,7 @@ func ExtractTestableLineFilters(expr syntax.Expr) []syntax.LineFilterExpr {
 // Use ExtractTestableLineFilters to extract testable line filters from an expression.
 // TODO(owen-d): limits the number of bloom lookups run.
 // An arbitrarily high number can overconsume cpu and is a DoS vector.
+// TODO(owen-d): use for loop not recursion to protect callstack
 func FiltersToBloomTest(b NGramBuilder, filters ...syntax.LineFilterExpr) BloomTest {
 	tests := make(BloomTests, 0, len(filters))
 	for _, f := range filters {

--- a/pkg/storage/bloom/v1/bloom_tester_test.go
+++ b/pkg/storage/bloom/v1/bloom_tester_test.go
@@ -3,226 +3,245 @@ package v1
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/loki/v3/pkg/logql/syntax"
-	"github.com/grafana/loki/v3/pkg/storage/bloom/v1/filter"
 )
 
-func TestFiltersToBloomTests(t *testing.T) {
-	for _, tc := range []struct {
-		name        string
-		query       string
-		bloom       filter.Checker
-		expectMatch bool
-	}{
-		{
-			name:        "No filters",
-			query:       `{app="fake"}`,
-			bloom:       fakeBloom{"foo", "bar"},
-			expectMatch: true,
-		},
-		{
-			name:        "Single filter",
-			query:       `{app="fake"} |= "foo"`,
-			bloom:       fakeBloom{"foo", "bar"},
-			expectMatch: true,
-		},
-		{
-			name:        "Single filter no match",
-			query:       `{app="fake"} |= "nope"`,
-			bloom:       fakeBloom{"foo", "bar"},
-			expectMatch: false,
-		},
-		{
-			name:        "two filters",
-			query:       `{app="fake"} |= "foo" |= "bar"`,
-			bloom:       fakeBloom{"foo", "bar"},
-			expectMatch: true,
-		},
-		{
-			name:        "two filters no match",
-			query:       `{app="fake"} |= "foo" |= "nope"`,
-			bloom:       fakeBloom{"foo", "bar"},
-			expectMatch: false,
-		},
-		{
-			name:        "notEq doesnt exist",
-			query:       `{app="fake"} != "nope"`,
-			bloom:       fakeBloom{"foo", "bar"},
-			expectMatch: true,
-		},
-		{
-			name:        "notEq exists",
-			query:       `{app="fake"} != "foo"`,
-			bloom:       fakeBloom{"foo", "bar"},
-			expectMatch: true, // Still should match because it's NotEQ
-		},
-		{
-			name:        "or filter both match",
-			query:       `{app="fake"} |= "foo" or "bar"`,
-			bloom:       fakeBloom{"foo", "bar"},
-			expectMatch: true,
-		},
-		{
-			name:        "or filter one right match",
-			query:       `{app="fake"} |= "nope" or "foo"`,
-			bloom:       fakeBloom{"foo", "bar"},
-			expectMatch: true,
-		},
-		{
-			name:        "or filter one left match",
-			query:       `{app="fake"} |= "foo" or "nope"`,
-			bloom:       fakeBloom{"foo", "bar"},
-			expectMatch: true,
-		},
-		{
-			name:        "or filter no match",
-			query:       `{app="fake"} |= "no" or "nope"`,
-			bloom:       fakeBloom{"foo", "bar"},
-			expectMatch: false,
-		},
-		{
-			name:        "Not or filter match",
-			query:       `{app="fake"} != "nope" or "no"`,
-			bloom:       fakeBloom{"foo", "bar"},
-			expectMatch: true,
-		},
-		{
-			name:        "NotEq OR filter right exists",
-			query:       `{app="fake"} != "nope" or "bar"`,
-			bloom:       fakeBloom{"foo", "bar"},
-			expectMatch: true, // Still should match because it's NotEQ
-		},
-		{
-			name:        "Not OR filter left exists",
-			query:       `{app="fake"} != "foo" or "nope"`,
-			bloom:       fakeBloom{"foo", "bar"},
-			expectMatch: true, // Still should match because it's NotEQ
-		},
-		{
-			name:        "NotEq OR filter both exists",
-			query:       `{app="fake"} != "foo" or "bar"`,
-			bloom:       fakeBloom{"foo", "bar"},
-			expectMatch: true, // Still should match because it's NotEQ
-		},
-		{
-			name:        "complex filter match",
-			query:       `{app="fake"} |= "foo" |= "bar" or "baz" |= "fuzz" or "not" != "nope" != "no" or "none"`,
-			bloom:       fakeBloom{"foo", "bar", "baz", "fuzz"},
-			expectMatch: true,
-		},
-		{
-			name:        "regex match all star",
-			query:       `{app="fake"} |~ ".*"`,
-			bloom:       fakeBloom{"foo", "bar"},
-			expectMatch: true,
-		},
-		{
-			name:        "regex match all plus",
-			query:       `{app="fake"} |~ ".+"`,
-			bloom:       fakeBloom{"foo", "bar"},
-			expectMatch: true,
-		},
-		{
-			name:        "regex match all notEq",
-			query:       `{app="fake"} !~ ".*"`,
-			bloom:       fakeBloom{"foo", "bar"},
-			expectMatch: true, // Still should match,
-		},
-		{
-			name:        "regex match",
-			query:       `{app="fake"} |~ "nope|.*foo.*"`,
-			bloom:       fakeBloom{"foo", "bar"},
-			expectMatch: true,
-		},
-		{
-			name:        "regex no match",
-			query:       `{app="fake"} |~ ".*not.*"`,
-			bloom:       fakeBloom{"foo", "bar"},
-			expectMatch: false,
-		},
-		{
-			name:        "regex notEq right exists",
-			query:       `{app="fake"} !~ "nope|.*foo.*"`,
-			bloom:       fakeBloom{"foo", "bar"},
-			expectMatch: true, // Still should match because it's NotEQ
-		},
-		{
-			name:        "complex regex match",
-			query:       `{app="fake"} |~ "(nope|.*not.*|.*foo.*)" or "(no|ba)" !~ "noz.*" or "(nope|not)"`,
-			bloom:       fakeBloom{"foo", "bar", "baz", "fuzz"},
-			expectMatch: true,
-		},
-		{
-			name:        "complex regex with notEq exists",
-			query:       `{app="fake"} |~ "(nope|.*not.*|.*foo.*)" or "(no|ba)" !~ "noz.*"`,
-			bloom:       fakeBloom{"foo", "bar", "baz", "fuzz", "noz"},
-			expectMatch: true, // Still should match because it's NotEQ
-		},
-		{
-			name:        "line filter after line format",
-			query:       `{app="fake"} |= "foo" | line_format "thisNewTextShouldMatch" |= "thisNewTextShouldMatch"`,
-			bloom:       fakeBloom{"foo"},
-			expectMatch: true,
-		},
-		{
-			name:        "pattern match exists",
-			query:       `{app="fake"} |> "<_>foo<bar>"`,
-			bloom:       fakeBloom{"foo", "bar"},
-			expectMatch: true,
-		},
-		{
-			name:        "pattern match does not exist",
-			query:       `{app="fake"} |> "<_>foo<bar>"`,
-			bloom:       fakeBloom{"bar", "baz"},
-			expectMatch: false,
-		},
-		{
-			name:        "pattern not match exists",
-			query:       `{app="fake"} !> "<_>foo<bar>"`,
-			bloom:       fakeBloom{"foo", "bar"},
-			expectMatch: true,
-		},
-		{
-			name:        "pattern not match does not exist",
-			query:       `{app="fake"} !> "<_>foo<bar>"`,
-			bloom:       fakeBloom{"bar", "baz"},
-			expectMatch: true,
-		},
-		{
-			name:        "pattern all",
-			query:       `{app="fake"} |> "<_>"`,
-			bloom:       fakeBloom{"bar", "baz"},
-			expectMatch: true,
-		},
-		{
-			name:        "pattern empty",
-			query:       `{app="fake"} |> ""`,
-			bloom:       fakeBloom{"bar", "baz"},
-			expectMatch: true,
-		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			expr, err := syntax.ParseExpr(tc.query)
-			assert.NoError(t, err)
-			filters := ExtractTestableLineFilters(expr)
+// func TestFiltersToBloomTests(t *testing.T) {
+// 	for _, tc := range []struct {
+// 		name        string
+// 		query       string
+// 		bloom       filter.Checker
+// 		expectMatch bool
+// 	}{
+// 		{
+// 			name:        "No filters",
+// 			query:       `{app="fake"}`,
+// 			bloom:       fakeBloom{"foo", "bar"},
+// 			expectMatch: true,
+// 		},
+// 		{
+// 			name:        "Single filter",
+// 			query:       `{app="fake"} |= "foo"`,
+// 			bloom:       fakeBloom{"foo", "bar"},
+// 			expectMatch: true,
+// 		},
+// 		{
+// 			name:        "Single filter no match",
+// 			query:       `{app="fake"} |= "nope"`,
+// 			bloom:       fakeBloom{"foo", "bar"},
+// 			expectMatch: false,
+// 		},
+// 		{
+// 			name:        "two filters",
+// 			query:       `{app="fake"} |= "foo" |= "bar"`,
+// 			bloom:       fakeBloom{"foo", "bar"},
+// 			expectMatch: true,
+// 		},
+// 		{
+// 			name:        "two filters no match",
+// 			query:       `{app="fake"} |= "foo" |= "nope"`,
+// 			bloom:       fakeBloom{"foo", "bar"},
+// 			expectMatch: false,
+// 		},
+// 		{
+// 			name:        "notEq doesnt exist",
+// 			query:       `{app="fake"} != "nope"`,
+// 			bloom:       fakeBloom{"foo", "bar"},
+// 			expectMatch: true,
+// 		},
+// 		{
+// 			name:        "notEq exists",
+// 			query:       `{app="fake"} != "foo"`,
+// 			bloom:       fakeBloom{"foo", "bar"},
+// 			expectMatch: true, // Still should match because it's NotEQ
+// 		},
+// 		{
+// 			name:        "or filter both match",
+// 			query:       `{app="fake"} |= "foo" or "bar"`,
+// 			bloom:       fakeBloom{"foo", "bar"},
+// 			expectMatch: true,
+// 		},
+// 		{
+// 			name:        "or filter one right match",
+// 			query:       `{app="fake"} |= "nope" or "foo"`,
+// 			bloom:       fakeBloom{"foo", "bar"},
+// 			expectMatch: true,
+// 		},
+// 		{
+// 			name:        "or filter one left match",
+// 			query:       `{app="fake"} |= "foo" or "nope"`,
+// 			bloom:       fakeBloom{"foo", "bar"},
+// 			expectMatch: true,
+// 		},
+// 		{
+// 			name:        "or filter no match",
+// 			query:       `{app="fake"} |= "no" or "nope"`,
+// 			bloom:       fakeBloom{"foo", "bar"},
+// 			expectMatch: false,
+// 		},
+// 		{
+// 			name:        "Not or filter match",
+// 			query:       `{app="fake"} != "nope" or "no"`,
+// 			bloom:       fakeBloom{"foo", "bar"},
+// 			expectMatch: true,
+// 		},
+// 		{
+// 			name:        "NotEq OR filter right exists",
+// 			query:       `{app="fake"} != "nope" or "bar"`,
+// 			bloom:       fakeBloom{"foo", "bar"},
+// 			expectMatch: true, // Still should match because it's NotEQ
+// 		},
+// 		{
+// 			name:        "Not OR filter left exists",
+// 			query:       `{app="fake"} != "foo" or "nope"`,
+// 			bloom:       fakeBloom{"foo", "bar"},
+// 			expectMatch: true, // Still should match because it's NotEQ
+// 		},
+// 		{
+// 			name:        "NotEq OR filter both exists",
+// 			query:       `{app="fake"} != "foo" or "bar"`,
+// 			bloom:       fakeBloom{"foo", "bar"},
+// 			expectMatch: true, // Still should match because it's NotEQ
+// 		},
+// 		{
+// 			name:        "complex filter match",
+// 			query:       `{app="fake"} |= "foo" |= "bar" or "baz" |= "fuzz" or "not" != "nope" != "no" or "none"`,
+// 			bloom:       fakeBloom{"foo", "bar", "baz", "fuzz"},
+// 			expectMatch: true,
+// 		},
+// 		{
+// 			name:        "regex match all star",
+// 			query:       `{app="fake"} |~ ".*"`,
+// 			bloom:       fakeBloom{"foo", "bar"},
+// 			expectMatch: true,
+// 		},
+// 		{
+// 			name:        "regex match all plus",
+// 			query:       `{app="fake"} |~ ".+"`,
+// 			bloom:       fakeBloom{"foo", "bar"},
+// 			expectMatch: true,
+// 		},
+// 		{
+// 			name:        "regex match all notEq",
+// 			query:       `{app="fake"} !~ ".*"`,
+// 			bloom:       fakeBloom{"foo", "bar"},
+// 			expectMatch: true, // Still should match,
+// 		},
+// 		{
+// 			name:        "regex match",
+// 			query:       `{app="fake"} |~ "nope|.*foo.*"`,
+// 			bloom:       fakeBloom{"foo", "bar"},
+// 			expectMatch: true,
+// 		},
+// 		{
+// 			name:        "regex no match",
+// 			query:       `{app="fake"} |~ ".*not.*"`,
+// 			bloom:       fakeBloom{"foo", "bar"},
+// 			expectMatch: false,
+// 		},
+// 		{
+// 			name:        "regex notEq right exists",
+// 			query:       `{app="fake"} !~ "nope|.*foo.*"`,
+// 			bloom:       fakeBloom{"foo", "bar"},
+// 			expectMatch: true, // Still should match because it's NotEQ
+// 		},
+// 		{
+// 			name:        "complex regex match",
+// 			query:       `{app="fake"} |~ "(nope|.*not.*|.*foo.*)" or "(no|ba)" !~ "noz.*" or "(nope|not)"`,
+// 			bloom:       fakeBloom{"foo", "bar", "baz", "fuzz"},
+// 			expectMatch: true,
+// 		},
+// 		{
+// 			name:        "complex regex with notEq exists",
+// 			query:       `{app="fake"} |~ "(nope|.*not.*|.*foo.*)" or "(no|ba)" !~ "noz.*"`,
+// 			bloom:       fakeBloom{"foo", "bar", "baz", "fuzz", "noz"},
+// 			expectMatch: true, // Still should match because it's NotEQ
+// 		},
+// 		{
+// 			name:        "line filter after line format",
+// 			query:       `{app="fake"} |= "foo" | line_format "thisNewTextShouldMatch" |= "thisNewTextShouldMatch"`,
+// 			bloom:       fakeBloom{"foo"},
+// 			expectMatch: true,
+// 		},
+// 		{
+// 			name:        "pattern match exists",
+// 			query:       `{app="fake"} |> "<_>foo<bar>"`,
+// 			bloom:       fakeBloom{"foo", "bar"},
+// 			expectMatch: true,
+// 		},
+// 		{
+// 			name:        "pattern match does not exist",
+// 			query:       `{app="fake"} |> "<_>foo<bar>"`,
+// 			bloom:       fakeBloom{"bar", "baz"},
+// 			expectMatch: false,
+// 		},
+// 		{
+// 			name:        "pattern not match exists",
+// 			query:       `{app="fake"} !> "<_>foo<bar>"`,
+// 			bloom:       fakeBloom{"foo", "bar"},
+// 			expectMatch: true,
+// 		},
+// 		{
+// 			name:        "pattern not match does not exist",
+// 			query:       `{app="fake"} !> "<_>foo<bar>"`,
+// 			bloom:       fakeBloom{"bar", "baz"},
+// 			expectMatch: true,
+// 		},
+// 		{
+// 			name:        "pattern all",
+// 			query:       `{app="fake"} |> "<_>"`,
+// 			bloom:       fakeBloom{"bar", "baz"},
+// 			expectMatch: true,
+// 		},
+// 		{
+// 			name:        "pattern empty",
+// 			query:       `{app="fake"} |> ""`,
+// 			bloom:       fakeBloom{"bar", "baz"},
+// 			expectMatch: true,
+// 		},
+// 	} {
+// 		t.Run(tc.name, func(t *testing.T) {
+// 			expr, err := syntax.ParseExpr(tc.query)
+// 			assert.NoError(t, err)
+// 			filters := ExtractTestableLineFilters(expr)
 
-			bloomTests := FiltersToBloomTest(fakeNgramBuilder{}, filters...)
-			assert.Equal(t, tc.expectMatch, bloomTests.Matches(tc.bloom))
-		})
+// 			bloomTests := FiltersToBloomTest(fakeNgramBuilder{}, filters...)
+// 			assert.Equal(t, tc.expectMatch, bloomTests.Matches(tc.bloom))
+// 		})
+// 	}
+// }
+
+// type fakeNgramBuilder struct{}
+
+// func (f fakeNgramBuilder) Tokens(line string) Iterator[[]byte] {
+// 	return NewSliceIter[[]byte]([][]byte{[]byte(line)})
+// }
+
+// type fakeBloom []string
+
+// func (f fakeBloom) Test(data []byte) bool {
+// 	str := string(data)
+// 	for _, match := range f {
+// 		if str == match {
+// 			return true
+// 		}
+// 	}
+// 	return false
+// }
+
+type fakeBloom2 []string
+
+func newFakeBloom2(tokenizer *NGramTokenizer, line string) (res fakeBloom2) {
+	toks := tokenizer.Tokens(line)
+	for toks.Next() {
+		res = append(res, string(toks.At()))
 	}
+	return
 }
 
-type fakeNgramBuilder struct{}
-
-func (f fakeNgramBuilder) Tokens(line string) Iterator[[]byte] {
-	return NewSliceIter[[]byte]([][]byte{[]byte(line)})
-}
-
-type fakeBloom []string
-
-func (f fakeBloom) Test(data []byte) bool {
+func (f fakeBloom2) Test(data []byte) bool {
 	str := string(data)
 	for _, match := range f {
 		if str == match {
@@ -230,4 +249,104 @@ func (f fakeBloom) Test(data []byte) bool {
 		}
 	}
 	return false
+}
+
+func TestIdk(t *testing.T) {
+	// All tested on 4skip1
+	n := 4
+	skip := 1
+	tokenizer := NewNGramTokenizer(n, skip)
+
+	for _, tc := range []struct {
+		desc    string
+		line    string
+		query   string
+		match   bool
+		enabled bool
+	}{
+		{
+			desc:  "filter too short always match",
+			line:  "foobar",
+			query: `{app="fake"} |= "z"`,
+			match: true,
+		},
+		{
+			desc:  "simple matcher",
+			line:  "foobar",
+			query: `{app="fake"} |= "oobar"`,
+			match: true,
+		},
+		{
+			desc:  "longer sequence",
+			line:  "abcdefghijklmnopqrstuvwxyz",
+			query: `{app="fake"} |= "nopqrstuvwxyz"`,
+			match: true,
+		},
+		{
+			desc:  "longer sequence nomatch",
+			line:  "abcdefghijklmnopqrstuvwxyz",
+			query: `{app="fake"} |= "nopqrstuvwxyzzz"`,
+			match: false,
+		},
+		{
+			desc:  "pattern simple",
+			line:  "abcdefghijklmnopqrstuvwxyz",
+			query: `{app="fake"} |> "<_>lmnopq<_>"`,
+			match: true,
+		},
+		{
+			desc:  "pattern too short matches",
+			line:  "abcdefghijklmnopqrstuvwxyz",
+			query: `{app="fake"} |> "<_>zzz<_>"`,
+			match: true,
+		},
+		{
+			desc:  "pattern mix long success and short",
+			line:  "abcdefghijklmnopqrstuvwxyz",
+			query: `{app="fake"} |> "<_>lmnop<_>zzz<_>"`,
+			match: true,
+		},
+		{
+			desc:  "pattern mix long fail and short",
+			line:  "abcdefghijklmnopqrstuvwxyz",
+			query: `{app="fake"} |> "<_>zzzzz<_>zzz<_>"`,
+			match: false,
+		},
+		{
+			desc:  "regexp simple",
+			line:  "foobarbaz",
+			query: `{app="fake"} |~ "(foo|bar)bazz"`,
+			match: true,
+		},
+		{
+			desc:  "regexp simple",
+			line:  "foobarbaz",
+			query: `{app="fake"} |~ "(foo|bar)baz"`,
+			match: true,
+		},
+		{
+			desc:  "regexp nomatch",
+			line:  "foobarbaz",
+			query: `{app="fake"} |~ "(foo|bar)bazzz"`,
+			match: false,
+		},
+	} {
+
+		// shortcut to enable specific tests
+		tc.enabled = true
+		if !tc.enabled {
+			continue
+		}
+		t.Run(tc.desc, func(t *testing.T) {
+			bloom := newFakeBloom2(tokenizer, tc.line)
+			expr, err := syntax.ParseExpr(tc.query)
+			require.NoError(t, err)
+			filters := ExtractTestableLineFilters(expr)
+			bloomTests := FiltersToBloomTest(tokenizer, filters...)
+			matched := bloomTests.Matches(bloom)
+
+			require.Equal(t, tc.match, matched)
+
+		})
+	}
 }

--- a/pkg/storage/bloom/v1/bloom_tester_test.go
+++ b/pkg/storage/bloom/v1/bloom_tester_test.go
@@ -313,22 +313,10 @@ func TestIdk(t *testing.T) {
 			match: false,
 		},
 		{
-			desc:  "regexp simple",
+			desc:  "regexp disabled",
 			line:  "foobarbaz",
-			query: `{app="fake"} |~ "(foo|bar)bazz"`,
+			query: `{app="fake"} |~ "(aaaaa|bbbbb)bazz"`,
 			match: true,
-		},
-		{
-			desc:  "regexp simple",
-			line:  "foobarbaz",
-			query: `{app="fake"} |~ "(foo|bar)baz"`,
-			match: true,
-		},
-		{
-			desc:  "regexp nomatch",
-			line:  "foobarbaz",
-			query: `{app="fake"} |~ "(foo|bar)bazzz"`,
-			match: false,
 		},
 	} {
 

--- a/pkg/storage/bloom/v1/bloom_tester_test.go
+++ b/pkg/storage/bloom/v1/bloom_tester_test.go
@@ -8,232 +8,11 @@ import (
 	"github.com/grafana/loki/v3/pkg/logql/syntax"
 )
 
-// func TestFiltersToBloomTests(t *testing.T) {
-// 	for _, tc := range []struct {
-// 		name        string
-// 		query       string
-// 		bloom       filter.Checker
-// 		expectMatch bool
-// 	}{
-// 		{
-// 			name:        "No filters",
-// 			query:       `{app="fake"}`,
-// 			bloom:       fakeBloom{"foo", "bar"},
-// 			expectMatch: true,
-// 		},
-// 		{
-// 			name:        "Single filter",
-// 			query:       `{app="fake"} |= "foo"`,
-// 			bloom:       fakeBloom{"foo", "bar"},
-// 			expectMatch: true,
-// 		},
-// 		{
-// 			name:        "Single filter no match",
-// 			query:       `{app="fake"} |= "nope"`,
-// 			bloom:       fakeBloom{"foo", "bar"},
-// 			expectMatch: false,
-// 		},
-// 		{
-// 			name:        "two filters",
-// 			query:       `{app="fake"} |= "foo" |= "bar"`,
-// 			bloom:       fakeBloom{"foo", "bar"},
-// 			expectMatch: true,
-// 		},
-// 		{
-// 			name:        "two filters no match",
-// 			query:       `{app="fake"} |= "foo" |= "nope"`,
-// 			bloom:       fakeBloom{"foo", "bar"},
-// 			expectMatch: false,
-// 		},
-// 		{
-// 			name:        "notEq doesnt exist",
-// 			query:       `{app="fake"} != "nope"`,
-// 			bloom:       fakeBloom{"foo", "bar"},
-// 			expectMatch: true,
-// 		},
-// 		{
-// 			name:        "notEq exists",
-// 			query:       `{app="fake"} != "foo"`,
-// 			bloom:       fakeBloom{"foo", "bar"},
-// 			expectMatch: true, // Still should match because it's NotEQ
-// 		},
-// 		{
-// 			name:        "or filter both match",
-// 			query:       `{app="fake"} |= "foo" or "bar"`,
-// 			bloom:       fakeBloom{"foo", "bar"},
-// 			expectMatch: true,
-// 		},
-// 		{
-// 			name:        "or filter one right match",
-// 			query:       `{app="fake"} |= "nope" or "foo"`,
-// 			bloom:       fakeBloom{"foo", "bar"},
-// 			expectMatch: true,
-// 		},
-// 		{
-// 			name:        "or filter one left match",
-// 			query:       `{app="fake"} |= "foo" or "nope"`,
-// 			bloom:       fakeBloom{"foo", "bar"},
-// 			expectMatch: true,
-// 		},
-// 		{
-// 			name:        "or filter no match",
-// 			query:       `{app="fake"} |= "no" or "nope"`,
-// 			bloom:       fakeBloom{"foo", "bar"},
-// 			expectMatch: false,
-// 		},
-// 		{
-// 			name:        "Not or filter match",
-// 			query:       `{app="fake"} != "nope" or "no"`,
-// 			bloom:       fakeBloom{"foo", "bar"},
-// 			expectMatch: true,
-// 		},
-// 		{
-// 			name:        "NotEq OR filter right exists",
-// 			query:       `{app="fake"} != "nope" or "bar"`,
-// 			bloom:       fakeBloom{"foo", "bar"},
-// 			expectMatch: true, // Still should match because it's NotEQ
-// 		},
-// 		{
-// 			name:        "Not OR filter left exists",
-// 			query:       `{app="fake"} != "foo" or "nope"`,
-// 			bloom:       fakeBloom{"foo", "bar"},
-// 			expectMatch: true, // Still should match because it's NotEQ
-// 		},
-// 		{
-// 			name:        "NotEq OR filter both exists",
-// 			query:       `{app="fake"} != "foo" or "bar"`,
-// 			bloom:       fakeBloom{"foo", "bar"},
-// 			expectMatch: true, // Still should match because it's NotEQ
-// 		},
-// 		{
-// 			name:        "complex filter match",
-// 			query:       `{app="fake"} |= "foo" |= "bar" or "baz" |= "fuzz" or "not" != "nope" != "no" or "none"`,
-// 			bloom:       fakeBloom{"foo", "bar", "baz", "fuzz"},
-// 			expectMatch: true,
-// 		},
-// 		{
-// 			name:        "regex match all star",
-// 			query:       `{app="fake"} |~ ".*"`,
-// 			bloom:       fakeBloom{"foo", "bar"},
-// 			expectMatch: true,
-// 		},
-// 		{
-// 			name:        "regex match all plus",
-// 			query:       `{app="fake"} |~ ".+"`,
-// 			bloom:       fakeBloom{"foo", "bar"},
-// 			expectMatch: true,
-// 		},
-// 		{
-// 			name:        "regex match all notEq",
-// 			query:       `{app="fake"} !~ ".*"`,
-// 			bloom:       fakeBloom{"foo", "bar"},
-// 			expectMatch: true, // Still should match,
-// 		},
-// 		{
-// 			name:        "regex match",
-// 			query:       `{app="fake"} |~ "nope|.*foo.*"`,
-// 			bloom:       fakeBloom{"foo", "bar"},
-// 			expectMatch: true,
-// 		},
-// 		{
-// 			name:        "regex no match",
-// 			query:       `{app="fake"} |~ ".*not.*"`,
-// 			bloom:       fakeBloom{"foo", "bar"},
-// 			expectMatch: false,
-// 		},
-// 		{
-// 			name:        "regex notEq right exists",
-// 			query:       `{app="fake"} !~ "nope|.*foo.*"`,
-// 			bloom:       fakeBloom{"foo", "bar"},
-// 			expectMatch: true, // Still should match because it's NotEQ
-// 		},
-// 		{
-// 			name:        "complex regex match",
-// 			query:       `{app="fake"} |~ "(nope|.*not.*|.*foo.*)" or "(no|ba)" !~ "noz.*" or "(nope|not)"`,
-// 			bloom:       fakeBloom{"foo", "bar", "baz", "fuzz"},
-// 			expectMatch: true,
-// 		},
-// 		{
-// 			name:        "complex regex with notEq exists",
-// 			query:       `{app="fake"} |~ "(nope|.*not.*|.*foo.*)" or "(no|ba)" !~ "noz.*"`,
-// 			bloom:       fakeBloom{"foo", "bar", "baz", "fuzz", "noz"},
-// 			expectMatch: true, // Still should match because it's NotEQ
-// 		},
-// 		{
-// 			name:        "line filter after line format",
-// 			query:       `{app="fake"} |= "foo" | line_format "thisNewTextShouldMatch" |= "thisNewTextShouldMatch"`,
-// 			bloom:       fakeBloom{"foo"},
-// 			expectMatch: true,
-// 		},
-// 		{
-// 			name:        "pattern match exists",
-// 			query:       `{app="fake"} |> "<_>foo<bar>"`,
-// 			bloom:       fakeBloom{"foo", "bar"},
-// 			expectMatch: true,
-// 		},
-// 		{
-// 			name:        "pattern match does not exist",
-// 			query:       `{app="fake"} |> "<_>foo<bar>"`,
-// 			bloom:       fakeBloom{"bar", "baz"},
-// 			expectMatch: false,
-// 		},
-// 		{
-// 			name:        "pattern not match exists",
-// 			query:       `{app="fake"} !> "<_>foo<bar>"`,
-// 			bloom:       fakeBloom{"foo", "bar"},
-// 			expectMatch: true,
-// 		},
-// 		{
-// 			name:        "pattern not match does not exist",
-// 			query:       `{app="fake"} !> "<_>foo<bar>"`,
-// 			bloom:       fakeBloom{"bar", "baz"},
-// 			expectMatch: true,
-// 		},
-// 		{
-// 			name:        "pattern all",
-// 			query:       `{app="fake"} |> "<_>"`,
-// 			bloom:       fakeBloom{"bar", "baz"},
-// 			expectMatch: true,
-// 		},
-// 		{
-// 			name:        "pattern empty",
-// 			query:       `{app="fake"} |> ""`,
-// 			bloom:       fakeBloom{"bar", "baz"},
-// 			expectMatch: true,
-// 		},
-// 	} {
-// 		t.Run(tc.name, func(t *testing.T) {
-// 			expr, err := syntax.ParseExpr(tc.query)
-// 			assert.NoError(t, err)
-// 			filters := ExtractTestableLineFilters(expr)
+type fakeBloom []string
 
-// 			bloomTests := FiltersToBloomTest(fakeNgramBuilder{}, filters...)
-// 			assert.Equal(t, tc.expectMatch, bloomTests.Matches(tc.bloom))
-// 		})
-// 	}
-// }
-
-// type fakeNgramBuilder struct{}
-
-// func (f fakeNgramBuilder) Tokens(line string) Iterator[[]byte] {
-// 	return NewSliceIter[[]byte]([][]byte{[]byte(line)})
-// }
-
-// type fakeBloom []string
-
-// func (f fakeBloom) Test(data []byte) bool {
-// 	str := string(data)
-// 	for _, match := range f {
-// 		if str == match {
-// 			return true
-// 		}
-// 	}
-// 	return false
-// }
-
-type fakeBloom2 []string
-
-func newFakeBloom2(tokenizer *NGramTokenizer, line string) (res fakeBloom2) {
+// fakeBloom is a fake bloom filter that matches tokens exactly.
+// It uses a tokenizer to build the tokens for a line
+func newFakeBloom(tokenizer *NGramTokenizer, line string) (res fakeBloom) {
 	toks := tokenizer.Tokens(line)
 	for toks.Next() {
 		res = append(res, string(toks.At()))
@@ -241,7 +20,7 @@ func newFakeBloom2(tokenizer *NGramTokenizer, line string) (res fakeBloom2) {
 	return
 }
 
-func (f fakeBloom2) Test(data []byte) bool {
+func (f fakeBloom) Test(data []byte) bool {
 	str := string(data)
 	for _, match := range f {
 		if str == match {
@@ -251,7 +30,7 @@ func (f fakeBloom2) Test(data []byte) bool {
 	return false
 }
 
-func TestIdk(t *testing.T) {
+func TestBloomQueryingLogic(t *testing.T) {
 	// All tested on 4skip1
 	n := 4
 	skip := 1
@@ -326,7 +105,7 @@ func TestIdk(t *testing.T) {
 			continue
 		}
 		t.Run(tc.desc, func(t *testing.T) {
-			bloom := newFakeBloom2(tokenizer, tc.line)
+			bloom := newFakeBloom(tokenizer, tc.line)
 			expr, err := syntax.ParseExpr(tc.query)
 			require.NoError(t, err)
 			filters := ExtractTestableLineFilters(expr)

--- a/pkg/storage/bloom/v1/bloom_tokenizer.go
+++ b/pkg/storage/bloom/v1/bloom_tokenizer.go
@@ -48,12 +48,12 @@ func NewBloomTokenizer(nGramLen, nGramSkip int, metrics *Metrics) *BloomTokenize
 	}
 }
 
-func (bt *BloomTokenizer) GetNGramLength() uint64 {
-	return uint64(bt.lineTokenizer.N)
+func (bt *BloomTokenizer) N() uint64 {
+	return uint64(bt.lineTokenizer.N())
 }
 
-func (bt *BloomTokenizer) GetNGramSkip() uint64 {
-	return uint64(bt.lineTokenizer.Skip)
+func (bt *BloomTokenizer) SkipFactor() uint64 {
+	return uint64(bt.lineTokenizer.SkipFactor())
 }
 
 func clearCache(cache map[string]interface{}) {
@@ -115,7 +115,7 @@ func (bt *BloomTokenizer) Populate(swb *SeriesWithBloom, chks Iterator[ChunkRefW
 			chk                    = chks.At()
 			itr                    = chk.Itr
 		)
-		tokenBuf, prefixLn = prefixedToken(bt.lineTokenizer.N, chk.Ref, tokenBuf)
+		tokenBuf, prefixLn = prefixedToken(bt.lineTokenizer.N(), chk.Ref, tokenBuf)
 
 		// Iterate over lines in the chunk
 		for itr.Next() && itr.Error() == nil {

--- a/pkg/storage/bloom/v1/bloom_tokenizer_test.go
+++ b/pkg/storage/bloom/v1/bloom_tokenizer_test.go
@@ -82,13 +82,13 @@ func TestSetLineTokenizer(t *testing.T) {
 	bt := NewBloomTokenizer(DefaultNGramLength, DefaultNGramSkip, metrics)
 
 	// Validate defaults
-	require.Equal(t, bt.lineTokenizer.N, DefaultNGramLength)
-	require.Equal(t, bt.lineTokenizer.Skip, DefaultNGramSkip)
+	require.Equal(t, bt.lineTokenizer.N(), DefaultNGramLength)
+	require.Equal(t, bt.lineTokenizer.SkipFactor(), DefaultNGramSkip)
 
 	// Set new tokenizer, and validate against that
 	bt.lineTokenizer = NewNGramTokenizer(6, 7)
-	require.Equal(t, bt.lineTokenizer.N, 6)
-	require.Equal(t, bt.lineTokenizer.Skip, 7)
+	require.Equal(t, bt.lineTokenizer.N(), 6)
+	require.Equal(t, bt.lineTokenizer.SkipFactor(), 7)
 }
 
 func TestTokenizerPopulate(t *testing.T) {

--- a/pkg/storage/bloom/v1/fuse_test.go
+++ b/pkg/storage/bloom/v1/fuse_test.go
@@ -13,6 +13,18 @@ import (
 	"github.com/grafana/loki/v3/pkg/chunkenc"
 )
 
+// TODO(owen-d): this is unhinged from the data it represents. I'm leaving this solely so I don't
+// have to refactor tests here in order to fix this elsewhere, but it can/should be fixed --
+// the skip & n len are hardcoded based on data that's passed to it elsewhere.
+type fakeNgramBuilder struct{}
+
+func (f fakeNgramBuilder) N() int          { return 4 }
+func (f fakeNgramBuilder) SkipFactor() int { return 0 }
+
+func (f fakeNgramBuilder) Tokens(line string) Iterator[[]byte] {
+	return NewSliceIter[[]byte]([][]byte{[]byte(line)})
+}
+
 func keysToBloomTest(keys [][]byte) BloomTest {
 	var tokenizer fakeNgramBuilder
 	tests := make(BloomTests, 0, len(keys))

--- a/pkg/storage/bloom/v1/tokenizer.go
+++ b/pkg/storage/bloom/v1/tokenizer.go
@@ -20,9 +20,17 @@ func reassemble(buf []rune, ln, pos int, result []byte) []byte {
 
 // Iterable variants (more performant, less space)
 type NGramTokenizer struct {
-	N, Skip int
+	n, skip int
 	buffer  []rune // circular buffer used for ngram generation
 	res     []byte // buffer used for token generation
+}
+
+func (t *NGramTokenizer) N() int {
+	return t.n
+}
+
+func (t *NGramTokenizer) SkipFactor() int {
+	return t.skip
 }
 
 /*
@@ -31,8 +39,8 @@ These will be utilized for the bloom filters to allow for fuzzy searching.
 */
 func NewNGramTokenizer(n, skip int) *NGramTokenizer {
 	t := &NGramTokenizer{
-		N:      n,
-		Skip:   skip,
+		n:      n,
+		skip:   skip,
 		buffer: make([]rune, n+skip),
 		res:    make([]byte, 0, n*MaxRuneLen), // maximum 4 bytes per rune
 	}
@@ -45,8 +53,8 @@ func NewNGramTokenizer(n, skip int) *NGramTokenizer {
 // is not safe for use after subsequent calls to Next()
 func (t *NGramTokenizer) Tokens(line string) Iterator[[]byte] {
 	return &NGramTokenIter{
-		n:    t.N,
-		skip: t.Skip,
+		n:    t.N(),
+		skip: t.SkipFactor(),
 
 		line: line,
 

--- a/pkg/storage/bloom/v1/tokenizer_test.go
+++ b/pkg/storage/bloom/v1/tokenizer_test.go
@@ -190,7 +190,7 @@ func BenchmarkTokens(b *testing.B) {
 				{
 					desc: "v2",
 					f: func() func() {
-						buf, prefixLn := prefixedToken(v2Three.N, ChunkRef{}, nil)
+						buf, prefixLn := prefixedToken(v2Three.N(), ChunkRef{}, nil)
 						return func() {
 							itr := NewPrefixedTokenIter(buf, prefixLn, v2Three.Tokens(lorem))
 							for itr.Next() {
@@ -207,7 +207,7 @@ func BenchmarkTokens(b *testing.B) {
 				{
 					desc: "v2",
 					f: func() func() {
-						buf, prefixLn := prefixedToken(v2Three.N, ChunkRef{}, nil)
+						buf, prefixLn := prefixedToken(v2Three.N(), ChunkRef{}, nil)
 						return func() {
 							itr := NewPrefixedTokenIter(buf, prefixLn, v2ThreeSkip1.Tokens(lorem))
 							for itr.Next() {

--- a/tools/tsdb/bloom-tester/readlib.go
+++ b/tools/tsdb/bloom-tester/readlib.go
@@ -204,7 +204,7 @@ func analyzeRead(metrics *Metrics, sampler Sampler, shipper indexshipper.IndexSh
 										bloomTokenizer.SetLineTokenizer(experiment.tokenizer)
 										for gotIdx := range got { // for every chunk
 											for _, queryExperiment := range queryExperiments { // for each search string
-												if len(queryExperiment.searchString) >= experiment.tokenizer.N+experiment.tokenizer.Skip {
+												if len(queryExperiment.searchString) >= experiment.tokenizer.N()+experiment.tokenizer.SkipFactor() {
 
 													foundInChunk := false
 													foundInSbf := false

--- a/tools/tsdb/bloom-tester/tokenizer.go
+++ b/tools/tsdb/bloom-tester/tokenizer.go
@@ -70,11 +70,11 @@ func (bt *BloomTokenizer) SetLineTokenizer(t *v1.NGramTokenizer) {
 }
 
 func (bt *BloomTokenizer) GetNGramLength() uint64 {
-	return uint64(bt.lineTokenizer.N)
+	return uint64(bt.lineTokenizer.N())
 }
 
 func (bt *BloomTokenizer) GetNGramSkip() uint64 {
-	return uint64(bt.lineTokenizer.Skip)
+	return uint64(bt.lineTokenizer.SkipFactor())
 }
 
 func newMetrics(r prometheus.Registerer, namespace, subsystem string) *metrics {
@@ -146,7 +146,7 @@ func (bt *BloomTokenizer) PopulateSeriesWithBloom(seriesWithBloom *v1.SeriesWith
 
 	for idx := range chunks {
 		lc := chunks[idx].Data.(*chunkenc.Facade).LokiChunk()
-		tokenBuf, prefixLn := prefixedToken(bt.lineTokenizer.N, chunks[idx].ChunkRef)
+		tokenBuf, prefixLn := prefixedToken(bt.lineTokenizer.N(), chunks[idx].ChunkRef)
 		chunkTotalUncompressedSize += lc.UncompressedSize()
 
 		itr, err := lc.Iterator(


### PR DESCRIPTION
I found some problems with how we were testing bloom filter ngram membership which caused us to exclude chunks we shouldn't. This PR has a few fixes:

* Handle skip factors in bloom membership
* Improved testing (previous tests didn't test a lot of the actual logic, were complex, etc)
* removes regexps from bloom testing because the current impls were provably incorrect and I don't have time to fix these now (followup for later)
