### PR TITLE
chore: add more validation at startup to make sure we have a proper schema, and necessary directories are created

### DIFF
--- a/docs/sources/configure/examples/configuration-examples.md
+++ b/docs/sources/configure/examples/configuration-examples.md
@@ -36,9 +36,6 @@ schema_config:
       period: 24h
 
 storage_config:
-  tsdb_shipper:
-    active_index_directory: /tmp/loki/index
-    cache_location: /tmp/loki/index_cache
   filesystem:
     directory: /tmp/loki/chunks
 

--- a/docs/sources/configure/examples/configuration-examples.md
+++ b/docs/sources/configure/examples/configuration-examples.md
@@ -145,6 +145,8 @@ storage_config:
 
 # This is a partial configuration to deploy Loki backed by Baidu Object Storage (BOS).
 # The index will be shipped to the storage via tsdb-shipper.
+common:
+  path_prefix: /tmp/loki
 
 schema_config:
   configs:
@@ -157,9 +159,6 @@ schema_config:
         period: 24h
 
 storage_config:
-  tsdb_shipper:
-    active_index_directory: /loki/index
-    cache_location: /loki/index_cache
   bos:
     bucket_name: bucket_name_1
     endpoint: bj.bcebos.com
@@ -186,6 +185,9 @@ compactor:
 ## 7-Schema-Migration-Snippet.yaml
 
 ```yaml
+
+common:
+  path_prefix: /tmp/loki
 
 schema_config:
   configs:
@@ -218,6 +220,8 @@ schema_config:
 ```yaml
 
 # This partial configuration uses Alibaba for chunk storage.
+common:
+  path_prefix: /tmp/loki
 
 schema_config:
   configs:
@@ -288,6 +292,8 @@ storage_config:
 ```yaml
 
 # This partial configuration uses IBM Cloud Object Storage (COS) for chunk storage. HMAC will be used for authenticating with COS.
+common:
+  path_prefix: /tmp/loki
 
 schema_config:
   configs:
@@ -300,9 +306,6 @@ schema_config:
         prefix: index_
 
 storage_config:
-  tsdb_shipper:
-    active_index_directory: /loki/index
-    cache_location: /loki/index_cache
   cos:
     bucketnames: <bucket1, bucket2>
     endpoint: <endpoint>
@@ -318,6 +321,8 @@ storage_config:
 ```yaml
 
 # This partial configuration uses IBM Cloud Object Storage (COS) for chunk storage. APIKey will be used for authenticating with COS.
+common:
+  path_prefix: /tmp/loki
 
 schema_config:
   configs:
@@ -330,9 +335,6 @@ schema_config:
         prefix: index_
 
 storage_config:
-  tsdb_shipper:
-    active_index_directory: /loki/index
-    cache_location: /loki/index_cache
   cos:
     bucketnames: <bucket1, bucket2>
     endpoint: <endpoint>
@@ -355,6 +357,8 @@ storage_config:
 # the same trusted profile.
 # In order to use trusted profile authentication we need to follow an additional step to create a trusted profile.
 # For more details about creating a trusted profile, see https://cloud.ibm.com/docs/account?topic=account-create-trusted-profile&interface=ui.
+common:
+  path_prefix: /tmp/loki
 
 schema_config:
   configs:
@@ -367,9 +371,6 @@ schema_config:
         prefix: index_
 
 storage_config:
-  tsdb_shipper:
-    active_index_directory: /loki/index
-    cache_location: /loki/index_cache
   cos:
     bucketnames: <bucket1, bucket2>
     endpoint: <endpoint>

--- a/docs/sources/configure/examples/yaml/1-Local-Configuration-Example.yaml
+++ b/docs/sources/configure/examples/yaml/1-Local-Configuration-Example.yaml
@@ -25,8 +25,5 @@ schema_config:
       period: 24h
 
 storage_config:
-  tsdb_shipper:
-    active_index_directory: /tmp/loki/index
-    cache_location: /tmp/loki/index_cache
   filesystem:
     directory: /tmp/loki/chunks

--- a/docs/sources/configure/examples/yaml/11-COS-HMAC-Example.yaml
+++ b/docs/sources/configure/examples/yaml/11-COS-HMAC-Example.yaml
@@ -1,4 +1,6 @@
 # This partial configuration uses IBM Cloud Object Storage (COS) for chunk storage. HMAC will be used for authenticating with COS.
+common:
+  path_prefix: /tmp/loki
 
 schema_config:
   configs:
@@ -11,9 +13,6 @@ schema_config:
         prefix: index_
 
 storage_config:
-  tsdb_shipper:
-    active_index_directory: /loki/index
-    cache_location: /loki/index_cache
   cos:
     bucketnames: <bucket1, bucket2>
     endpoint: <endpoint>

--- a/docs/sources/configure/examples/yaml/12-COS-APIKey-Example.yaml
+++ b/docs/sources/configure/examples/yaml/12-COS-APIKey-Example.yaml
@@ -1,4 +1,6 @@
 # This partial configuration uses IBM Cloud Object Storage (COS) for chunk storage. APIKey will be used for authenticating with COS.
+common:
+  path_prefix: /tmp/loki
 
 schema_config:
   configs:
@@ -11,9 +13,6 @@ schema_config:
         prefix: index_
 
 storage_config:
-  tsdb_shipper:
-    active_index_directory: /loki/index
-    cache_location: /loki/index_cache
   cos:
     bucketnames: <bucket1, bucket2>
     endpoint: <endpoint>

--- a/docs/sources/configure/examples/yaml/13-COS-Trusted-Profile-Example.yaml
+++ b/docs/sources/configure/examples/yaml/13-COS-Trusted-Profile-Example.yaml
@@ -5,6 +5,8 @@
 # the same trusted profile.
 # In order to use trusted profile authentication we need to follow an additional step to create a trusted profile.
 # For more details about creating a trusted profile, see https://cloud.ibm.com/docs/account?topic=account-create-trusted-profile&interface=ui.
+common:
+  path_prefix: /tmp/loki
 
 schema_config:
   configs:
@@ -17,9 +19,6 @@ schema_config:
         prefix: index_
 
 storage_config:
-  tsdb_shipper:
-    active_index_directory: /loki/index
-    cache_location: /loki/index_cache
   cos:
     bucketnames: <bucket1, bucket2>
     endpoint: <endpoint>

--- a/docs/sources/configure/examples/yaml/5-BOS-Example.yaml
+++ b/docs/sources/configure/examples/yaml/5-BOS-Example.yaml
@@ -1,5 +1,7 @@
 # This is a partial configuration to deploy Loki backed by Baidu Object Storage (BOS).
 # The index will be shipped to the storage via tsdb-shipper.
+common:
+  path_prefix: /tmp/loki
 
 schema_config:
   configs:
@@ -12,9 +14,6 @@ schema_config:
         period: 24h
 
 storage_config:
-  tsdb_shipper:
-    active_index_directory: /loki/index
-    cache_location: /loki/index_cache
   bos:
     bucket_name: bucket_name_1
     endpoint: bj.bcebos.com

--- a/docs/sources/configure/examples/yaml/7-Schema-Migration-Snippet.yaml
+++ b/docs/sources/configure/examples/yaml/7-Schema-Migration-Snippet.yaml
@@ -1,3 +1,6 @@
+common:
+  path_prefix: /tmp/loki
+
 schema_config:
   configs:
     # Starting from 2018-04-15 Loki should store indexes on BoltDB with the v11 schema

--- a/docs/sources/configure/examples/yaml/8-alibaba-cloud-storage-Snippet.yaml
+++ b/docs/sources/configure/examples/yaml/8-alibaba-cloud-storage-Snippet.yaml
@@ -1,4 +1,6 @@
 # This partial configuration uses Alibaba for chunk storage.
+common:
+  path_prefix: /tmp/loki
 
 schema_config:
   configs:

--- a/pkg/bloomcompactor/retention_test.go
+++ b/pkg/bloomcompactor/retention_test.go
@@ -22,6 +22,7 @@ import (
 	storageconfig "github.com/grafana/loki/v3/pkg/storage/config"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/bloomshipper"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/bloomshipper/config"
+	"github.com/grafana/loki/v3/pkg/storage/types"
 	util_log "github.com/grafana/loki/v3/pkg/util/log"
 	lokiring "github.com/grafana/loki/v3/pkg/util/ring"
 	"github.com/grafana/loki/v3/pkg/validation"
@@ -773,7 +774,7 @@ func NewMockBloomStoreWithWorkDir(t *testing.T, workDir string) (*bloomshipper.B
 	schemaCfg := storageconfig.SchemaConfig{
 		Configs: []storageconfig.PeriodConfig{
 			{
-				ObjectType: storageconfig.StorageTypeFileSystem,
+				ObjectType: types.StorageTypeFileSystem,
 				From: storageconfig.DayTime{
 					Time: testTime.Add(-2 * 365 * 24 * time.Hour), // -2 year
 				},
@@ -784,7 +785,7 @@ func NewMockBloomStoreWithWorkDir(t *testing.T, workDir string) (*bloomshipper.B
 					}},
 			},
 			{
-				ObjectType: storageconfig.StorageTypeFileSystem,
+				ObjectType: types.StorageTypeFileSystem,
 				From: storageconfig.DayTime{
 					Time: testTime.Add(-365 * 24 * time.Hour), // -1 year
 				},

--- a/pkg/bloomcompactor/tsdb.go
+++ b/pkg/bloomcompactor/tsdb.go
@@ -22,6 +22,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb/index"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb/sharding"
+	"github.com/grafana/loki/v3/pkg/storage/types"
 )
 
 const (
@@ -185,7 +186,7 @@ func NewTSDBStores(
 	}
 
 	for i, cfg := range schemaCfg.Configs {
-		if cfg.IndexType == config.TSDBType {
+		if cfg.IndexType == types.TSDBType {
 
 			c, err := baseStore.NewObjectClient(cfg.ObjectType, storeCfg, clientMetrics)
 			if err != nil {

--- a/pkg/bloomgateway/bloomgateway_test.go
+++ b/pkg/bloomgateway/bloomgateway_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/storage/config"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/bloomshipper"
 	bloomshipperconfig "github.com/grafana/loki/v3/pkg/storage/stores/shipper/bloomshipper/config"
+	"github.com/grafana/loki/v3/pkg/storage/types"
 	"github.com/grafana/loki/v3/pkg/validation"
 )
 
@@ -58,8 +59,8 @@ func setupBloomStore(t *testing.T) *bloomshipper.BloomStore {
 				Period: 24 * time.Hour,
 			},
 		},
-		IndexType:  config.TSDBType,
-		ObjectType: config.StorageTypeFileSystem,
+		IndexType:  types.TSDBType,
+		ObjectType: types.StorageTypeFileSystem,
 		Schema:     "v13",
 		RowShards:  16,
 	}

--- a/pkg/ingester/index/multi.go
+++ b/pkg/ingester/index/multi.go
@@ -10,6 +10,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/logproto"
 	"github.com/grafana/loki/v3/pkg/logql"
 	"github.com/grafana/loki/v3/pkg/storage/config"
+	"github.com/grafana/loki/v3/pkg/storage/types"
 )
 
 type periodIndex struct {
@@ -34,7 +35,7 @@ func NewMultiInvertedIndex(periods []config.PeriodConfig, indexShards uint32) (*
 
 	for _, pd := range periods {
 		switch pd.IndexType {
-		case config.TSDBType:
+		case types.TSDBType:
 			if bitPrefixed == nil {
 				bitPrefixed, err = NewBitPrefixWithShards(indexShards)
 				if err != nil {

--- a/pkg/ingester/index/multi_test.go
+++ b/pkg/ingester/index/multi_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/logql"
 	"github.com/grafana/loki/v3/pkg/storage/config"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb/index"
+	"github.com/grafana/loki/v3/pkg/storage/types"
 )
 
 func MustParseDayTime(s string) config.DayTime {
@@ -26,19 +27,19 @@ func MustParseDayTime(s string) config.DayTime {
 var testPeriodConfigs = []config.PeriodConfig{
 	{
 		From:      MustParseDayTime("2020-01-01"),
-		IndexType: config.StorageTypeBigTable,
+		IndexType: types.StorageTypeBigTable,
 	},
 	{
 		From:      MustParseDayTime("2021-01-01"),
-		IndexType: config.TSDBType,
+		IndexType: types.TSDBType,
 	},
 	{
 		From:      MustParseDayTime("2022-01-01"),
-		IndexType: config.BoltDBShipperType,
+		IndexType: types.BoltDBShipperType,
 	},
 	{
 		From:      MustParseDayTime("2023-01-01"),
-		IndexType: config.TSDBType,
+		IndexType: types.TSDBType,
 	},
 }
 
@@ -50,7 +51,7 @@ func TestIgnoresInvalidShardFactorWhenTSDBNotPresent(t *testing.T) {
 		[]config.PeriodConfig{
 			{
 				From:      MustParseDayTime("2020-01-01"),
-				IndexType: config.StorageTypeBigTable,
+				IndexType: types.StorageTypeBigTable,
 			},
 		},
 		factor,
@@ -61,11 +62,11 @@ func TestIgnoresInvalidShardFactorWhenTSDBNotPresent(t *testing.T) {
 		[]config.PeriodConfig{
 			{
 				From:      MustParseDayTime("2020-01-01"),
-				IndexType: config.StorageTypeBigTable,
+				IndexType: types.StorageTypeBigTable,
 			},
 			{
 				From:      MustParseDayTime("2021-01-01"),
-				IndexType: config.TSDBType,
+				IndexType: types.TSDBType,
 			},
 		},
 		factor,

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/grafana/loki/v3/pkg/logqlmodel/metadata"
+	"github.com/grafana/loki/v3/pkg/storage/types"
 
 	lokilog "github.com/grafana/loki/v3/pkg/logql/log"
 
@@ -998,13 +999,13 @@ func (i *Ingester) QuerySample(req *logproto.SampleQueryRequest, queryServer log
 func (i *Ingester) asyncStoreMaxLookBack() time.Duration {
 	activePeriodicConfigIndex := config.ActivePeriodConfig(i.periodicConfigs)
 	activePeriodicConfig := i.periodicConfigs[activePeriodicConfigIndex]
-	if activePeriodicConfig.IndexType != config.BoltDBShipperType && activePeriodicConfig.IndexType != config.TSDBType {
+	if activePeriodicConfig.IndexType != types.BoltDBShipperType && activePeriodicConfig.IndexType != types.TSDBType {
 		return 0
 	}
 
 	startTime := activePeriodicConfig.From
-	if activePeriodicConfigIndex != 0 && (i.periodicConfigs[activePeriodicConfigIndex-1].IndexType == config.BoltDBShipperType ||
-		i.periodicConfigs[activePeriodicConfigIndex-1].IndexType == config.TSDBType) {
+	if activePeriodicConfigIndex != 0 && (i.periodicConfigs[activePeriodicConfigIndex-1].IndexType == types.BoltDBShipperType ||
+		i.periodicConfigs[activePeriodicConfigIndex-1].IndexType == types.TSDBType) {
 		startTime = i.periodicConfigs[activePeriodicConfigIndex-1].From
 	}
 

--- a/pkg/ingester/instance_test.go
+++ b/pkg/ingester/instance_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/loki/v3/pkg/storage/types"
 	"github.com/grafana/loki/v3/pkg/util/httpreq"
 
 	"github.com/grafana/dskit/tenant"
@@ -60,7 +61,7 @@ func MustParseDayTime(s string) config.DayTime {
 var defaultPeriodConfigs = []config.PeriodConfig{
 	{
 		From:      MustParseDayTime("1900-01-01"),
-		IndexType: config.StorageTypeBigTable,
+		IndexType: types.StorageTypeBigTable,
 		Schema:    "v13",
 	},
 }

--- a/pkg/logcli/query/query_test.go
+++ b/pkg/logcli/query/query_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/storage"
 	"github.com/grafana/loki/v3/pkg/storage/chunk/client"
 	"github.com/grafana/loki/v3/pkg/storage/chunk/client/local"
-	"github.com/grafana/loki/v3/pkg/storage/config"
+	"github.com/grafana/loki/v3/pkg/storage/types"
 	"github.com/grafana/loki/v3/pkg/util/marshal"
 )
 
@@ -550,7 +550,7 @@ func setupTestEnv(t *testing.T) (string, client.ObjectClient) {
 		},
 	}
 
-	client, err := GetObjectClient(config.StorageTypeFileSystem, conf, cm)
+	client, err := GetObjectClient(types.StorageTypeFileSystem, conf, cm)
 	require.NoError(t, err)
 	require.NotNil(t, client)
 

--- a/pkg/loki/config_compat.go
+++ b/pkg/loki/config_compat.go
@@ -6,26 +6,27 @@ import (
 
 	"github.com/grafana/loki/v3/pkg/ingester/index"
 	frontend "github.com/grafana/loki/v3/pkg/lokifrontend/frontend/v2"
-	"github.com/grafana/loki/v3/pkg/storage/config"
+	"github.com/grafana/loki/v3/pkg/storage/types"
 )
 
-func ValidateConfigCompatibility(c Config) error {
+func ValidateConfigCompatibility(c Config) []error {
+	var errs []error
 	for _, fn := range []func(Config) error{
 		ensureInvertedIndexShardingCompatibility,
 		ensureProtobufEncodingForAggregationSharding,
 	} {
 		if err := fn(c); err != nil {
-			return err
+			errs = append(errs, err)
 		}
 	}
-	return nil
+	return errs
 }
 
 func ensureInvertedIndexShardingCompatibility(c Config) error {
 
 	for i, sc := range c.SchemaConfig.Configs {
 		switch sc.IndexType {
-		case config.TSDBType:
+		case types.TSDBType:
 			if err := index.ValidateBitPrefixShardFactor(uint32(c.Ingester.IndexShards)); err != nil {
 				return err
 			}

--- a/pkg/loki/config_test.go
+++ b/pkg/loki/config_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/grafana/loki/v3/pkg/ingester"
 	"github.com/grafana/loki/v3/pkg/storage/config"
+	"github.com/grafana/loki/v3/pkg/storage/types"
 )
 
 func TestCrossComponentValidation(t *testing.T) {
@@ -27,11 +28,18 @@ func TestCrossComponentValidation(t *testing.T) {
 				SchemaConfig: config.SchemaConfig{
 					Configs: []config.PeriodConfig{
 						{
-							RowShards: 16,
-							Schema:    "v11",
 							From: config.DayTime{
 								Time: model.Now(),
 							},
+							IndexType:  types.TSDBType,
+							ObjectType: types.StorageTypeS3,
+							Schema:     "v11",
+							IndexTables: config.IndexPeriodicTableConfig{
+								PeriodicTableConfig: config.PeriodicTableConfig{
+									Period: 24 * time.Hour,
+								},
+							},
+							RowShards: 16,
 						},
 					},
 				},
@@ -47,17 +55,31 @@ func TestCrossComponentValidation(t *testing.T) {
 				SchemaConfig: config.SchemaConfig{
 					Configs: []config.PeriodConfig{
 						{
-							RowShards: 16,
-							Schema:    "v11",
+							IndexType:  types.BoltDBShipperType,
+							ObjectType: types.StorageTypeS3,
+							RowShards:  16,
+							Schema:     "v11",
 							From: config.DayTime{
 								Time: model.Now().Add(-48 * time.Hour),
 							},
+							IndexTables: config.IndexPeriodicTableConfig{
+								PeriodicTableConfig: config.PeriodicTableConfig{
+									Period: 24 * time.Hour,
+								},
+							},
 						},
 						{
-							RowShards: 17,
-							Schema:    "v11",
+							IndexType:  types.BoltDBShipperType,
+							ObjectType: types.StorageTypeS3,
+							RowShards:  17,
+							Schema:     "v11",
 							From: config.DayTime{
 								Time: model.Now(),
+							},
+							IndexTables: config.IndexPeriodicTableConfig{
+								PeriodicTableConfig: config.PeriodicTableConfig{
+									Period: 24 * time.Hour,
+								},
 							},
 						},
 					},
@@ -74,6 +96,12 @@ func TestCrossComponentValidation(t *testing.T) {
 		tc.base.QueryRange.CacheSeriesResults = false
 		tc.base.QueryRange.CacheLabelResults = false
 		tc.base.QueryRange.CacheVolumeResults = false
+		// Several other validations are required
+		tc.base.CompactorConfig.WorkingDirectory = "tmp"
+		tc.base.StorageConfig.TSDBShipperConfig.ActiveIndexDirectory = "tmp"
+		tc.base.StorageConfig.TSDBShipperConfig.CacheLocation = "tmp"
+		tc.base.StorageConfig.BoltDBShipperConfig.ActiveIndexDirectory = "tmp"
+		tc.base.StorageConfig.BoltDBShipperConfig.CacheLocation = "tmp"
 		err := tc.base.Validate()
 		if tc.err {
 			require.NotNil(t, err)

--- a/pkg/loki/config_wrapper.go
+++ b/pkg/loki/config_wrapper.go
@@ -14,6 +14,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/loki/common"
 	"github.com/grafana/loki/v3/pkg/storage/chunk/cache"
 	"github.com/grafana/loki/v3/pkg/storage/config"
+	"github.com/grafana/loki/v3/pkg/storage/types"
 	"github.com/grafana/loki/v3/pkg/util/cfg"
 	lokiring "github.com/grafana/loki/v3/pkg/util/ring"
 
@@ -140,13 +141,13 @@ func lastConfigFor(configs []config.PeriodConfig, predicate func(config.PeriodCo
 
 func lastBoltdbShipperConfig(configs []config.PeriodConfig) int {
 	return lastConfigFor(configs, func(p config.PeriodConfig) bool {
-		return p.IndexType == config.BoltDBShipperType
+		return p.IndexType == types.BoltDBShipperType
 	})
 }
 
 func lastTSDBConfig(configs []config.PeriodConfig) int {
 	return lastConfigFor(configs, func(p config.PeriodConfig) bool {
-		return p.IndexType == config.TSDBType
+		return p.IndexType == types.TSDBType
 	})
 }
 
@@ -676,7 +677,7 @@ func applyChunkRetain(cfg, defaults *ConfigWrapper) {
 	if !reflect.DeepEqual(cfg.StorageConfig.IndexQueriesCacheConfig, defaults.StorageConfig.IndexQueriesCacheConfig) {
 		// Only apply this change if the active index period is for boltdb-shipper
 		p := config.ActivePeriodConfig(cfg.SchemaConfig.Configs)
-		if cfg.SchemaConfig.Configs[p].IndexType == config.BoltDBShipperType {
+		if cfg.SchemaConfig.Configs[p].IndexType == types.BoltDBShipperType {
 			// Set the retain period to the cache validity plus one minute. One minute is arbitrary but leaves some
 			// buffer to make sure the chunks are there until the index entries expire.
 			cfg.Ingester.RetainPeriod = cfg.StorageConfig.IndexCacheValidity + 1*time.Minute

--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -277,6 +277,7 @@ func (c *Config) Validate() error {
 		errs = append(errs, errors.Wrap(err, "CONFIG ERROR: invalid pattern_ingester config"))
 	}
 
+	errs = append(errs, validateSchemaValues(c)...)
 	errs = append(errs, ValidateConfigCompatibility(*c)...)
 	errs = append(errs, validateBackendAndLegacyReadMode(c)...)
 	errs = append(errs, validateSchemaRequirements(c)...)

--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -262,7 +262,7 @@ func (c *Config) Validate() error {
 		errs = append(errs, errors.Wrap(err, "CONFIG ERROR: invalid compactor config"))
 	}
 	if err := c.ChunkStoreConfig.Validate(); err != nil {
-		errs = append(errs, errors.Wrap(err, "CONFIG ERROR: invalid chunk store config"))
+		errs = append(errs, errors.Wrap(err, "CONFIG ERROR: invalid chunk_store_config config"))
 	}
 	if err := c.QueryRange.Validate(); err != nil {
 		errs = append(errs, errors.Wrap(err, "CONFIG ERROR: invalid query_range config"))

--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -250,7 +250,7 @@ func (c *Config) Validate() error {
 		errs = append(errs, errors.Wrap(err, "CONFIG ERROR: invalid limits_config config"))
 	}
 	if err := c.Worker.Validate(); err != nil {
-		errs = append(errs, errors.Wrap(err, "CONFIG ERROR: invalid frontend-worker config"))
+		errs = append(errs, errors.Wrap(err, "CONFIG ERROR: invalid frontend_worker config"))
 	}
 	if err := c.StorageConfig.BoltDBShipperConfig.Validate(); err != nil {
 		errs = append(errs, errors.Wrap(err, "CONFIG ERROR: invalid boltdb-shipper config"))

--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -229,7 +229,7 @@ func (c *Config) Validate() error {
 		errs = append(errs, errors.Wrap(err, "CONFIG ERROR: invalid storage config"))
 	}
 	if err := c.QueryRange.Validate(); err != nil {
-		errs = append(errs, errors.Wrap(err, "CONFIG ERROR: invalid queryrange config"))
+		errs = append(errs, errors.Wrap(err, "CONFIG ERROR: invalid query_range config"))
 	}
 	if err := c.Querier.Validate(); err != nil {
 		errs = append(errs, errors.Wrap(err, "CONFIG ERROR: invalid querier config"))

--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -226,7 +226,7 @@ func (c *Config) Validate() error {
 		errs = append(errs, errors.Wrap(err, "CONFIG ERROR: invalid schema config"))
 	}
 	if err := c.StorageConfig.Validate(); err != nil {
-		errs = append(errs, errors.Wrap(err, "CONFIG ERROR: invalid storage config"))
+		errs = append(errs, errors.Wrap(err, "CONFIG ERROR: invalid storage_config config"))
 	}
 	if err := c.QueryRange.Validate(); err != nil {
 		errs = append(errs, errors.Wrap(err, "CONFIG ERROR: invalid query_range config"))

--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -253,7 +253,7 @@ func (c *Config) Validate() error {
 		errs = append(errs, errors.Wrap(err, "CONFIG ERROR: invalid frontend_worker config"))
 	}
 	if err := c.StorageConfig.BoltDBShipperConfig.Validate(); err != nil {
-		errs = append(errs, errors.Wrap(err, "CONFIG ERROR: invalid boltdb-shipper config"))
+		errs = append(errs, errors.Wrap(err, "CONFIG ERROR: invalid boltdb_shipper config"))
 	}
 	if err := c.IndexGateway.Validate(); err != nil {
 		errs = append(errs, errors.Wrap(err, "CONFIG ERROR: invalid index_gateway config"))

--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -55,7 +55,6 @@ import (
 	"github.com/grafana/loki/v3/pkg/scheduler"
 	internalserver "github.com/grafana/loki/v3/pkg/server"
 	"github.com/grafana/loki/v3/pkg/storage"
-	"github.com/grafana/loki/v3/pkg/storage/chunk/cache"
 	"github.com/grafana/loki/v3/pkg/storage/config"
 	"github.com/grafana/loki/v3/pkg/storage/stores/series/index"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/bloomshipper"
@@ -221,100 +220,69 @@ func (c *Config) Clone() flagext.Registerer {
 // Validate the config and returns an error if the validation
 // doesn't pass
 func (c *Config) Validate() error {
-	if err := c.SchemaConfig.Validate(); err != nil {
-		return errors.Wrap(err, "invalid schema config")
-	}
-	if err := c.StorageConfig.Validate(); err != nil {
-		return errors.Wrap(err, "invalid storage config")
-	}
-	if err := c.QueryRange.Validate(); err != nil {
-		return errors.Wrap(err, "invalid queryrange config")
-	}
-	if err := c.Querier.Validate(); err != nil {
-		return errors.Wrap(err, "invalid querier config")
-	}
-	if err := c.QueryScheduler.Validate(); err != nil {
-		return errors.Wrap(err, "invalid query_scheduler config")
-	}
-	if err := c.TableManager.Validate(); err != nil {
-		return errors.Wrap(err, "invalid tablemanager config")
-	}
-	if err := c.Ruler.Validate(); err != nil {
-		return errors.Wrap(err, "invalid ruler config")
-	}
-	if err := c.Ingester.Validate(); err != nil {
-		return errors.Wrap(err, "invalid ingester config")
-	}
-	if err := c.LimitsConfig.Validate(); err != nil {
-		return errors.Wrap(err, "invalid limits config")
-	}
-	if err := c.Worker.Validate(); err != nil {
-		return errors.Wrap(err, "invalid frontend-worker config")
-	}
-	if err := c.StorageConfig.BoltDBShipperConfig.Validate(); err != nil {
-		return errors.Wrap(err, "invalid boltdb-shipper config")
-	}
-	if err := c.IndexGateway.Validate(); err != nil {
-		return errors.Wrap(err, "invalid index_gateway config")
-	}
-	if err := c.CompactorConfig.Validate(); err != nil {
-		return errors.Wrap(err, "invalid compactor config")
-	}
-	if err := c.ChunkStoreConfig.Validate(); err != nil {
-		return errors.Wrap(err, "invalid chunk store config")
-	}
-	if err := c.QueryRange.Validate(); err != nil {
-		return errors.Wrap(err, "invalid query_range config")
-	}
-	if err := c.BloomCompactor.Validate(); err != nil {
-		return errors.Wrap(err, "invalid bloom_compactor config")
-	}
-	if err := c.BloomGateway.Validate(); err != nil {
-		return errors.Wrap(err, "invalid bloom_gateway config")
-	}
-
-	if err := c.Pattern.Validate(); err != nil {
-		return errors.Wrap(err, "invalid pattern_ingester config")
-	}
-
-	if err := ValidateConfigCompatibility(*c); err != nil {
-		return err
-	}
-
-	// Honor the legacy scalable deployment topology
-	if c.LegacyReadTarget {
-		if c.isModuleEnabled(Backend) {
-			return fmt.Errorf("invalid target, cannot run backend target with legacy read mode")
-		}
-	}
-
 	var errs []error
 
-	p := config.ActivePeriodConfig(c.SchemaConfig.Configs)
-
-	// If the active index type is not TSDB (which does not use an index cache)
-	// and the index queries cache is configured
-	// and the chunk retain period is less than the validity period of the index cache
-	// throw an error.
-	if c.SchemaConfig.Configs[p].IndexType != config.TSDBType &&
-		cache.IsCacheConfigured(c.StorageConfig.IndexQueriesCacheConfig) &&
-		c.Ingester.RetainPeriod < c.StorageConfig.IndexCacheValidity {
-		errs = append(errs, fmt.Errorf("CONFIG ERROR: the active index is %s which is configured to use an `index_cache_validty` (TTL) of %s, however the chunk_retain_period is %s which is LESS than the `index_cache_validity`. This can lead to query gaps, please configure the `chunk_retain_period` to be greater than the `index_cache_validity`", c.SchemaConfig.Configs[p].IndexType, c.StorageConfig.IndexCacheValidity, c.Ingester.RetainPeriod))
+	if err := c.SchemaConfig.Validate(); err != nil {
+		errs = append(errs, errors.Wrap(err, "CONFIG ERROR: invalid schema config"))
+	}
+	if err := c.StorageConfig.Validate(); err != nil {
+		errs = append(errs, errors.Wrap(err, "CONFIG ERROR: invalid storage config"))
+	}
+	if err := c.QueryRange.Validate(); err != nil {
+		errs = append(errs, errors.Wrap(err, "CONFIG ERROR: invalid queryrange config"))
+	}
+	if err := c.Querier.Validate(); err != nil {
+		errs = append(errs, errors.Wrap(err, "CONFIG ERROR: invalid querier config"))
+	}
+	if err := c.QueryScheduler.Validate(); err != nil {
+		errs = append(errs, errors.Wrap(err, "CONFIG ERROR: invalid query_scheduler config"))
+	}
+	if err := c.TableManager.Validate(); err != nil {
+		errs = append(errs, errors.Wrap(err, "CONFIG ERROR: invalid tablemanager config"))
+	}
+	if err := c.Ruler.Validate(); err != nil {
+		errs = append(errs, errors.Wrap(err, "CONFIG ERROR: invalid ruler config"))
+	}
+	if err := c.Ingester.Validate(); err != nil {
+		errs = append(errs, errors.Wrap(err, "CONFIG ERROR: invalid ingester config"))
+	}
+	if err := c.LimitsConfig.Validate(); err != nil {
+		errs = append(errs, errors.Wrap(err, "CONFIG ERROR: invalid limits config"))
+	}
+	if err := c.Worker.Validate(); err != nil {
+		errs = append(errs, errors.Wrap(err, "CONFIG ERROR: invalid frontend-worker config"))
+	}
+	if err := c.StorageConfig.BoltDBShipperConfig.Validate(); err != nil {
+		errs = append(errs, errors.Wrap(err, "CONFIG ERROR: invalid boltdb-shipper config"))
+	}
+	if err := c.IndexGateway.Validate(); err != nil {
+		errs = append(errs, errors.Wrap(err, "CONFIG ERROR: invalid index_gateway config"))
+	}
+	if err := c.CompactorConfig.Validate(); err != nil {
+		errs = append(errs, errors.Wrap(err, "CONFIG ERROR: invalid compactor config"))
+	}
+	if err := c.ChunkStoreConfig.Validate(); err != nil {
+		errs = append(errs, errors.Wrap(err, "CONFIG ERROR: invalid chunk store config"))
+	}
+	if err := c.QueryRange.Validate(); err != nil {
+		errs = append(errs, errors.Wrap(err, "CONFIG ERROR: invalid query_range config"))
+	}
+	if err := c.BloomCompactor.Validate(); err != nil {
+		errs = append(errs, errors.Wrap(err, "CONFIG ERROR: invalid bloom_compactor config"))
+	}
+	if err := c.BloomGateway.Validate(); err != nil {
+		errs = append(errs, errors.Wrap(err, "CONFIG ERROR: invalid bloom_gateway config"))
+	}
+	if err := c.Pattern.Validate(); err != nil {
+		errs = append(errs, errors.Wrap(err, "CONFIG ERROR: invalid pattern_ingester config"))
 	}
 
-	// Schema version 13 is required to use structured metadata
-	version, err := c.SchemaConfig.Configs[p].VersionAsInt()
-	if err != nil {
-		return err
-	}
-	if c.LimitsConfig.AllowStructuredMetadata && version < 13 {
-		errs = append(errs, fmt.Errorf("CONFIG ERROR: schema v13 is required to store Structured Metadata and use native OTLP ingestion, your schema version is %s. Set `allow_structured_metadata: false` in the `limits_config` section or set the command line argument `-validation.allow-structured-metadata=false` and restart Loki. Then proceed to update to schema v13 or newer before re-enabling this config, search for 'Storage Schema' in the docs for the schema update procedure", c.SchemaConfig.Configs[p].Schema))
-	}
-	// TSDB index is required to use structured metadata
-	if c.LimitsConfig.AllowStructuredMetadata && c.SchemaConfig.Configs[p].IndexType != config.TSDBType {
-		errs = append(errs, fmt.Errorf("CONFIG ERROR: `tsdb` index type is required to store Structured Metadata and use native OTLP ingestion, your index type is `%s` (defined in the `store` parameter of the schema_config). Set `allow_structured_metadata: false` in the `limits_config` section or set the command line argument `-validation.allow-structured-metadata=false` and restart Loki. Then proceed to update the schema to use index type `tsdb` before re-enabling this config, search for 'Storage Schema' in the docs for the schema update procedure", c.SchemaConfig.Configs[p].IndexType))
-	}
+	errs = append(errs, ValidateConfigCompatibility(*c)...)
+	errs = append(errs, validateBackendAndLegacyReadMode(c)...)
+	errs = append(errs, validateSchemaRequirements(c)...)
+	errs = append(errs, validateDirectoriesExist(c)...)
 
+	// The output format isn't great for this, so try to get the operators attention if there are multiple errors
 	if len(errs) > 1 {
 		errs = append([]error{fmt.Errorf("MULTIPLE CONFIG ERRORS FOUND, PLEASE READ CAREFULLY")}, errs...)
 		return stdlib_errors.Join(errs...)

--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -238,7 +238,7 @@ func (c *Config) Validate() error {
 		errs = append(errs, errors.Wrap(err, "CONFIG ERROR: invalid query_scheduler config"))
 	}
 	if err := c.TableManager.Validate(); err != nil {
-		errs = append(errs, errors.Wrap(err, "CONFIG ERROR: invalid tablemanager config"))
+		errs = append(errs, errors.Wrap(err, "CONFIG ERROR: invalid table_manager config"))
 	}
 	if err := c.Ruler.Validate(); err != nil {
 		errs = append(errs, errors.Wrap(err, "CONFIG ERROR: invalid ruler config"))

--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -247,7 +247,7 @@ func (c *Config) Validate() error {
 		errs = append(errs, errors.Wrap(err, "CONFIG ERROR: invalid ingester config"))
 	}
 	if err := c.LimitsConfig.Validate(); err != nil {
-		errs = append(errs, errors.Wrap(err, "CONFIG ERROR: invalid limits config"))
+		errs = append(errs, errors.Wrap(err, "CONFIG ERROR: invalid limits_config config"))
 	}
 	if err := c.Worker.Validate(); err != nil {
 		errs = append(errs, errors.Wrap(err, "CONFIG ERROR: invalid frontend-worker config"))

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -35,6 +35,7 @@ import (
 
 	"github.com/grafana/loki/v3/pkg/bloomcompactor"
 	"github.com/grafana/loki/v3/pkg/logqlmodel/stats"
+	"github.com/grafana/loki/v3/pkg/storage/types"
 
 	"github.com/grafana/loki/v3/pkg/analytics"
 	"github.com/grafana/loki/v3/pkg/bloomgateway"
@@ -807,16 +808,16 @@ func (t *Loki) setupAsyncStore() error {
 
 	shipperConfigIdx := config.ActivePeriodConfig(t.Cfg.SchemaConfig.Configs)
 	iTy := t.Cfg.SchemaConfig.Configs[shipperConfigIdx].IndexType
-	if iTy != config.BoltDBShipperType && iTy != config.TSDBType {
+	if iTy != types.BoltDBShipperType && iTy != types.TSDBType {
 		shipperConfigIdx++
 	}
 
 	// TODO(owen-d): make helper more agnostic between boltdb|tsdb
 	var resyncInterval time.Duration
 	switch t.Cfg.SchemaConfig.Configs[shipperConfigIdx].IndexType {
-	case config.BoltDBShipperType:
+	case types.BoltDBShipperType:
 		resyncInterval = t.Cfg.StorageConfig.BoltDBShipperConfig.ResyncInterval
-	case config.TSDBType:
+	case types.TSDBType:
 		resyncInterval = t.Cfg.StorageConfig.TSDBShipperConfig.ResyncInterval
 	}
 
@@ -1346,8 +1347,8 @@ func (t *Loki) initCompactor() (services.Service, error) {
 		return nil, err
 	}
 
-	t.compactor.RegisterIndexCompactor(config.BoltDBShipperType, boltdbcompactor.NewIndexCompactor())
-	t.compactor.RegisterIndexCompactor(config.TSDBType, tsdb.NewIndexCompactor())
+	t.compactor.RegisterIndexCompactor(types.BoltDBShipperType, boltdbcompactor.NewIndexCompactor())
+	t.compactor.RegisterIndexCompactor(types.TSDBType, tsdb.NewIndexCompactor())
 	t.Server.HTTP.Path("/compactor/ring").Methods("GET", "POST").Handler(t.compactor)
 
 	if t.Cfg.InternalServer.Enable {
@@ -1390,7 +1391,7 @@ func (t *Loki) initIndexGateway() (services.Service, error) {
 	for i, period := range t.Cfg.SchemaConfig.Configs {
 		period := period
 
-		if period.IndexType != config.BoltDBShipperType {
+		if period.IndexType != types.BoltDBShipperType {
 			continue
 		}
 
@@ -1790,7 +1791,7 @@ func (dh ignoreSignalHandler) Stop() {
 
 func schemaHasBoltDBShipperConfig(scfg config.SchemaConfig) bool {
 	for _, cfg := range scfg.Configs {
-		if cfg.IndexType == config.BoltDBShipperType {
+		if cfg.IndexType == types.BoltDBShipperType {
 			return true
 		}
 	}

--- a/pkg/loki/modules_test.go
+++ b/pkg/loki/modules_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/boltdb"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/indexgateway"
+	"github.com/grafana/loki/v3/pkg/storage/types"
 )
 
 func Test_calculateMaxLookBack(t *testing.T) {
@@ -266,7 +267,7 @@ func TestIndexGatewayClientConfig(t *testing.T) {
 
 	t.Run("IndexGateway client is enabled when running querier target", func(t *testing.T) {
 		cfg := minimalWorkingConfig(t, dir, Querier)
-		cfg.SchemaConfig.Configs[0].IndexType = config.BoltDBShipperType
+		cfg.SchemaConfig.Configs[0].IndexType = types.BoltDBShipperType
 		cfg.SchemaConfig.Configs[0].IndexTables.Period = 24 * time.Hour
 		c, err := New(cfg)
 		require.NoError(t, err)
@@ -287,7 +288,7 @@ func TestIndexGatewayClientConfig(t *testing.T) {
 		cfg := minimalWorkingConfig(t, dir, Read, func(cfg *Config) {
 			cfg.LegacyReadTarget = true
 		})
-		cfg.SchemaConfig.Configs[0].IndexType = config.BoltDBShipperType
+		cfg.SchemaConfig.Configs[0].IndexType = types.BoltDBShipperType
 		cfg.SchemaConfig.Configs[0].IndexTables.Period = 24 * time.Hour
 		cfg.CompactorConfig.WorkingDirectory = dir
 		c, err := New(cfg)
@@ -309,7 +310,7 @@ func TestIndexGatewayClientConfig(t *testing.T) {
 		cfg := minimalWorkingConfig(t, dir, Read, func(cfg *Config) {
 			cfg.LegacyReadTarget = false
 		})
-		cfg.SchemaConfig.Configs[0].IndexType = config.BoltDBShipperType
+		cfg.SchemaConfig.Configs[0].IndexType = types.BoltDBShipperType
 		cfg.SchemaConfig.Configs[0].IndexTables.Period = 24 * time.Hour
 		cfg.CompactorConfig.WorkingDirectory = dir
 		c, err := New(cfg)
@@ -331,7 +332,7 @@ func TestIndexGatewayClientConfig(t *testing.T) {
 		cfg := minimalWorkingConfig(t, dir, Backend, func(cfg *Config) {
 			cfg.LegacyReadTarget = false
 		})
-		cfg.SchemaConfig.Configs[0].IndexType = config.BoltDBShipperType
+		cfg.SchemaConfig.Configs[0].IndexType = types.BoltDBShipperType
 		cfg.SchemaConfig.Configs[0].IndexTables.Period = 24 * time.Hour
 		cfg.CompactorConfig.WorkingDirectory = dir
 		c, err := New(cfg)
@@ -389,8 +390,8 @@ func minimalWorkingConfig(t *testing.T, dir, target string, cfgTransformers ...f
 	cfg.SchemaConfig = config.SchemaConfig{
 		Configs: []config.PeriodConfig{
 			{
-				IndexType:  config.BoltDBShipperType,
-				ObjectType: config.StorageTypeFileSystem,
+				IndexType:  types.BoltDBShipperType,
+				ObjectType: types.StorageTypeFileSystem,
 				IndexTables: config.IndexPeriodicTableConfig{
 					PeriodicTableConfig: config.PeriodicTableConfig{
 						Period: time.Hour * 24,
@@ -414,7 +415,7 @@ func minimalWorkingConfig(t *testing.T, dir, target string, cfgTransformers ...f
 	cfg.CompactorConfig.WorkingDirectory = filepath.Join(dir, "compactor")
 
 	cfg.Ruler.Config.Ring.InstanceAddr = localhost
-	cfg.Ruler.Config.StoreConfig.Type = config.StorageTypeLocal
+	cfg.Ruler.Config.StoreConfig.Type = types.StorageTypeLocal
 	cfg.Ruler.Config.StoreConfig.Local.Directory = dir
 
 	cfg.Common.CompactorAddress = "http://localhost:0"

--- a/pkg/loki/validation.go
+++ b/pkg/loki/validation.go
@@ -32,7 +32,7 @@ func validateSchemaRequirements(c *Config) []error {
 	if c.SchemaConfig.Configs[p].IndexType != types.TSDBType &&
 		cache.IsCacheConfigured(c.StorageConfig.IndexQueriesCacheConfig) &&
 		c.Ingester.RetainPeriod < c.StorageConfig.IndexCacheValidity {
-		errs = append(errs, fmt.Errorf("CONFIG ERROR: the active index is %s which is configured to use an `index_cache_validty` (TTL) of %s, however the chunk_retain_period is %s which is LESS than the `index_cache_validity`. This can lead to query gaps, please configure the `chunk_retain_period` to be greater than the `index_cache_validity`", c.SchemaConfig.Configs[p].IndexType, c.StorageConfig.IndexCacheValidity, c.Ingester.RetainPeriod))
+		errs = append(errs, fmt.Errorf("CONFIG ERROR: the active index is %s which is configured to use an `index_cache_validity` (TTL) of %s, however the chunk_retain_period is %s which is LESS than the `index_cache_validity`. This can lead to query gaps, please configure the `chunk_retain_period` to be greater than the `index_cache_validity`", c.SchemaConfig.Configs[p].IndexType, c.StorageConfig.IndexCacheValidity, c.Ingester.RetainPeriod))
 	}
 
 	// Schema version 13 is required to use structured metadata

--- a/pkg/loki/validation.go
+++ b/pkg/loki/validation.go
@@ -1,0 +1,87 @@
+package loki
+
+import (
+	"fmt"
+
+	"github.com/grafana/loki/v3/pkg/storage/chunk/cache"
+	"github.com/grafana/loki/v3/pkg/storage/config"
+	"github.com/grafana/loki/v3/pkg/storage/types"
+)
+
+func validateBackendAndLegacyReadMode(c *Config) []error {
+	var errs []error
+	// Honor the legacy scalable deployment topology
+	if c.LegacyReadTarget {
+		if c.isModuleEnabled(Backend) {
+			errs = append(errs, fmt.Errorf("CONFIG ERROR: invalid target, cannot run backend target with legacy read mode"))
+		}
+	}
+	return errs
+}
+
+func validateSchemaRequirements(c *Config) []error {
+	var errs []error
+	p := config.ActivePeriodConfig(c.SchemaConfig.Configs)
+
+	// If the active index type is not TSDB (which does not use an index cache)
+	// and the index queries cache is configured
+	// and the chunk retain period is less than the validity period of the index cache
+	// throw an error.
+	if c.SchemaConfig.Configs[p].IndexType != types.TSDBType &&
+		cache.IsCacheConfigured(c.StorageConfig.IndexQueriesCacheConfig) &&
+		c.Ingester.RetainPeriod < c.StorageConfig.IndexCacheValidity {
+		errs = append(errs, fmt.Errorf("CONFIG ERROR: the active index is %s which is configured to use an `index_cache_validty` (TTL) of %s, however the chunk_retain_period is %s which is LESS than the `index_cache_validity`. This can lead to query gaps, please configure the `chunk_retain_period` to be greater than the `index_cache_validity`", c.SchemaConfig.Configs[p].IndexType, c.StorageConfig.IndexCacheValidity, c.Ingester.RetainPeriod))
+	}
+
+	// Schema version 13 is required to use structured metadata
+	version, err := c.SchemaConfig.Configs[p].VersionAsInt()
+	if err != nil {
+		errs = append(errs, fmt.Errorf("CONFIG ERROR: invalid schema version at schema position %d", p))
+		// We can't continue if we can't parse the schema version
+		return errs
+	}
+	if c.LimitsConfig.AllowStructuredMetadata && version < 13 {
+		errs = append(errs, fmt.Errorf("CONFIG ERROR: schema v13 is required to store Structured Metadata and use native OTLP ingestion, your schema version is %s. Set `allow_structured_metadata: false` in the `limits_config` section or set the command line argument `-validation.allow-structured-metadata=false` and restart Loki. Then proceed to update to schema v13 or newer before re-enabling this config, search for 'Storage Schema' in the docs for the schema update procedure", c.SchemaConfig.Configs[p].Schema))
+	}
+	// TSDB index is required to use structured metadata
+	if c.LimitsConfig.AllowStructuredMetadata && c.SchemaConfig.Configs[p].IndexType != types.TSDBType {
+		errs = append(errs, fmt.Errorf("CONFIG ERROR: `tsdb` index type is required to store Structured Metadata and use native OTLP ingestion, your index type is `%s` (defined in the `store` parameter of the schema_config). Set `allow_structured_metadata: false` in the `limits_config` section or set the command line argument `-validation.allow-structured-metadata=false` and restart Loki. Then proceed to update the schema to use index type `tsdb` before re-enabling this config, search for 'Storage Schema' in the docs for the schema update procedure", c.SchemaConfig.Configs[p].IndexType))
+	}
+	return errs
+}
+
+func validateDirectoriesExist(c *Config) []error {
+	var errs []error
+	// If TSDB index exists in any index period, make sure the storage locations are configured, when folks upgrade from boltdb-shipper than can hit this and it fails with a confusing stack trace
+	for _, s := range c.SchemaConfig.Configs {
+		if s.IndexType == types.TSDBType {
+			if c.StorageConfig.TSDBShipperConfig.ActiveIndexDirectory == "" {
+				errs = append(errs, fmt.Errorf("CONFIG ERROR: `tsdb` index type is configured in at least one schema period, however, `storage_config`, `tsdb_shipper`, `active_index_directory` is not set, please set this directly or set `path_prefix:` in the `common:` section"))
+			}
+			if c.StorageConfig.TSDBShipperConfig.CacheLocation == "" {
+				errs = append(errs, fmt.Errorf("CONFIG ERROR: `tsdb` index type is configured in at least one schema period, however, `storage_config`, `tsdb_shipper`, `cache_location` is not set, please set this directly or set `path_prefix:` in the `common:` section"))
+			}
+		}
+	}
+
+	// If boltdb-shipper index exists in any index period, make sure the storage locations are configured, when folks upgrade from boltdb-shipper than can hit this and it fails with a confusing stack trace
+	for _, s := range c.SchemaConfig.Configs {
+		if s.IndexType == types.BoltDBShipperType {
+			if c.StorageConfig.BoltDBShipperConfig.ActiveIndexDirectory == "" {
+				errs = append(errs, fmt.Errorf("CONFIG ERROR: `boltdb-shipper` index type is configured in at least one schema period, however, `storage_config`, `boltdb_shipper`, `active_index_directory` is not set, please set this directly or set `path_prefix:` in the `common:` section"))
+			}
+			if c.StorageConfig.BoltDBShipperConfig.CacheLocation == "" {
+				errs = append(errs, fmt.Errorf("CONFIG ERROR: `boltdb-shipper` index type is configured in at least one schema period, however, `storage_config`, `boltdb_shipper`, `cache_location` is not set, please set this directly or set `path_prefix:` in the `common:` section"))
+			}
+		}
+	}
+
+	for _, s := range c.SchemaConfig.Configs {
+		if s.IndexType == types.TSDBType || s.IndexType == types.BoltDBShipperType {
+			if c.CompactorConfig.WorkingDirectory == "" {
+				errs = append(errs, fmt.Errorf("CONFIG ERROR: `compactor:` `working_directory:` is empty, please set a valid directory or set `path_prefix:` in the `common:` section"))
+			}
+		}
+	}
+	return errs
+}

--- a/pkg/querier/queryrange/limits.go
+++ b/pkg/querier/queryrange/limits.go
@@ -30,6 +30,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/storage/chunk/cache/resultscache"
 	"github.com/grafana/loki/v3/pkg/storage/config"
 	"github.com/grafana/loki/v3/pkg/storage/stores/index/stats"
+	"github.com/grafana/loki/v3/pkg/storage/types"
 	"github.com/grafana/loki/v3/pkg/util"
 	util_log "github.com/grafana/loki/v3/pkg/util/log"
 	"github.com/grafana/loki/v3/pkg/util/spanlogger"
@@ -350,7 +351,7 @@ func (q *querySizeLimiter) Do(ctx context.Context, r queryrangebase.Request) (qu
 		level.Error(log).Log("msg", "failed to get schema config, not applying querySizeLimit", "err", err)
 		return q.next.Do(ctx, r)
 	}
-	if schemaCfg.IndexType != config.TSDBType {
+	if schemaCfg.IndexType != types.TSDBType {
 		return q.next.Do(ctx, r)
 	}
 
@@ -605,7 +606,7 @@ func WeightedParallelism(
 	// the active configuration
 	if start.Equal(end) {
 		switch configs[i].IndexType {
-		case config.TSDBType:
+		case types.TSDBType:
 			return l.TSDBMaxQueryParallelism(ctx, user)
 		}
 		return l.MaxQueryParallelism(ctx, user)
@@ -626,7 +627,7 @@ func WeightedParallelism(
 		if i+1 < len(configs) && configs[i+1].From.Time.Before(end) {
 			dur = configs[i+1].From.Time.Sub(from)
 		}
-		if ty := configs[i].IndexType; ty == config.TSDBType {
+		if ty := configs[i].IndexType; ty == types.TSDBType {
 			tsdbDur += dur
 		} else {
 			otherDur += dur

--- a/pkg/querier/queryrange/limits_test.go
+++ b/pkg/querier/queryrange/limits_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/querier/plan"
 	base "github.com/grafana/loki/v3/pkg/querier/queryrange/queryrangebase"
 	"github.com/grafana/loki/v3/pkg/storage/config"
+	"github.com/grafana/loki/v3/pkg/storage/types"
 	"github.com/grafana/loki/v3/pkg/util"
 	"github.com/grafana/loki/v3/pkg/util/constants"
 	util_log "github.com/grafana/loki/v3/pkg/util/log"
@@ -510,7 +511,7 @@ func Test_WeightedParallelism_DivideByZeroError(t *testing.T) {
 				From: config.DayTime{
 					Time: borderTime.Add(-1 * time.Hour),
 				},
-				IndexType: config.TSDBType,
+				IndexType: types.TSDBType,
 			},
 		}
 
@@ -528,7 +529,7 @@ func Test_WeightedParallelism_DivideByZeroError(t *testing.T) {
 				From: config.DayTime{
 					Time: borderTime.Add(-1 * time.Hour),
 				},
-				IndexType: config.TSDBType,
+				IndexType: types.TSDBType,
 			},
 		}
 
@@ -546,7 +547,7 @@ func Test_WeightedParallelism_DivideByZeroError(t *testing.T) {
 				From: config.DayTime{
 					Time: borderTime.Add(-1 * time.Hour),
 				},
-				IndexType: config.TSDBType,
+				IndexType: types.TSDBType,
 			},
 		}
 
@@ -562,12 +563,12 @@ func Test_MaxQuerySize(t *testing.T) {
 		{
 			// BoltDB -> Time -4 days
 			From:      config.DayTime{Time: model.TimeFromUnix(testTime.Add(-96 * time.Hour).Unix())},
-			IndexType: config.BoltDBShipperType,
+			IndexType: types.BoltDBShipperType,
 		},
 		{
 			// TSDB -> Time -2 days
 			From:      config.DayTime{Time: model.TimeFromUnix(testTime.Add(-48 * time.Hour).Unix())},
-			IndexType: config.TSDBType,
+			IndexType: types.TSDBType,
 		},
 	}
 
@@ -586,7 +587,7 @@ func Test_MaxQuerySize(t *testing.T) {
 	}{
 		{
 			desc:       "No TSDB",
-			schema:     config.BoltDBShipperType,
+			schema:     types.BoltDBShipperType,
 			query:      `{app="foo"} |= "foo"`,
 			queryRange: 1 * time.Hour,
 

--- a/pkg/querier/queryrange/querysharding.go
+++ b/pkg/querier/queryrange/querysharding.go
@@ -22,6 +22,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/querier/astmapper"
 	"github.com/grafana/loki/v3/pkg/querier/queryrange/queryrangebase"
 	"github.com/grafana/loki/v3/pkg/storage/config"
+	"github.com/grafana/loki/v3/pkg/storage/types"
 	"github.com/grafana/loki/v3/pkg/util"
 	util_log "github.com/grafana/loki/v3/pkg/util/log"
 	"github.com/grafana/loki/v3/pkg/util/marshal"
@@ -333,7 +334,7 @@ func (splitter *shardSplitter) Do(ctx context.Context, r queryrangebase.Request)
 
 func hasShards(confs ShardingConfigs) bool {
 	for _, conf := range confs {
-		if conf.RowShards > 0 || conf.IndexType == config.TSDBType {
+		if conf.RowShards > 0 || conf.IndexType == types.TSDBType {
 			return true
 		}
 	}
@@ -372,7 +373,7 @@ func (confs ShardingConfigs) GetConf(start, end int64) (config.PeriodConfig, err
 	}
 
 	// query doesn't have shard factor, so don't try to do AST mapping.
-	if conf.RowShards < 2 && conf.IndexType != config.TSDBType {
+	if conf.RowShards < 2 && conf.IndexType != types.TSDBType {
 		return conf, errors.Errorf("shard factor not high enough: [%d]", conf.RowShards)
 	}
 

--- a/pkg/querier/queryrange/querysharding_test.go
+++ b/pkg/querier/queryrange/querysharding_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/querier/queryrange/queryrangebase"
 	"github.com/grafana/loki/v3/pkg/querier/queryrange/queryrangebase/definitions"
 	"github.com/grafana/loki/v3/pkg/storage/config"
+	"github.com/grafana/loki/v3/pkg/storage/types"
 	"github.com/grafana/loki/v3/pkg/util"
 	"github.com/grafana/loki/v3/pkg/util/constants"
 )
@@ -301,7 +302,7 @@ func Test_astMapper_QuerySizeLimits(t *testing.T) {
 				ShardingConfigs{
 					config.PeriodConfig{
 						RowShards: 2,
-						IndexType: config.TSDBType,
+						IndexType: types.TSDBType,
 					},
 				},
 				testEngineOpts,

--- a/pkg/querier/queryrange/shard_resolver.go
+++ b/pkg/querier/queryrange/shard_resolver.go
@@ -25,6 +25,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/storage/config"
 	"github.com/grafana/loki/v3/pkg/storage/stores/index/stats"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb/sharding"
+	"github.com/grafana/loki/v3/pkg/storage/types"
 	"github.com/grafana/loki/v3/pkg/util/spanlogger"
 	"github.com/grafana/loki/v3/pkg/util/validation"
 )
@@ -40,7 +41,7 @@ func shardResolverForConf(
 	statsHandler, next queryrangebase.Handler,
 	limits Limits,
 ) (logql.ShardResolver, bool) {
-	if conf.IndexType == config.TSDBType {
+	if conf.IndexType == types.TSDBType {
 		return &dynamicShardResolver{
 			ctx:             ctx,
 			logger:          logger,

--- a/pkg/storage/config/schema_config.go
+++ b/pkg/storage/config/schema_config.go
@@ -20,34 +20,15 @@ import (
 	"github.com/grafana/loki/v3/pkg/chunkenc"
 	"github.com/grafana/loki/v3/pkg/logproto"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb/index"
+	"github.com/grafana/loki/v3/pkg/storage/types"
+	"github.com/grafana/loki/v3/pkg/util"
 	"github.com/grafana/loki/v3/pkg/util/log"
 )
 
 const (
 	// Supported storage clients
 
-	StorageTypeAlibabaCloud   = "alibabacloud"
-	StorageTypeAWS            = "aws"
-	StorageTypeAWSDynamo      = "aws-dynamo"
-	StorageTypeAzure          = "azure"
-	StorageTypeBOS            = "bos"
-	StorageTypeBoltDB         = "boltdb"
-	StorageTypeCassandra      = "cassandra"
-	StorageTypeInMemory       = "inmemory"
-	StorageTypeBigTable       = "bigtable"
-	StorageTypeBigTableHashed = "bigtable-hashed"
-	StorageTypeFileSystem     = "filesystem"
-	StorageTypeGCP            = "gcp"
-	StorageTypeGCPColumnKey   = "gcp-columnkey"
-	StorageTypeGCS            = "gcs"
-	StorageTypeGrpc           = "grpc-store"
-	StorageTypeLocal          = "local"
-	StorageTypeS3             = "s3"
-	StorageTypeSwift          = "swift"
-	StorageTypeCOS            = "cos"
 	// BoltDBShipperType holds the index type for using boltdb with shipper which keeps flushing them to a shared storage
-	BoltDBShipperType = "boltdb-shipper"
-	TSDBType          = "tsdb"
 
 	// ObjectStorageIndexRequiredPeriod defines the required index period for object storage based index stores like boltdb-shipper and tsdb
 	ObjectStorageIndexRequiredPeriod = 24 * time.Hour
@@ -319,13 +300,13 @@ func (cfg *SchemaConfig) Validate() error {
 	activePCIndex := ActivePeriodConfig((*cfg).Configs)
 
 	// if current index type is boltdb-shipper and there are no upcoming index types then it should be set to 24 hours.
-	if cfg.Configs[activePCIndex].IndexType == BoltDBShipperType &&
+	if cfg.Configs[activePCIndex].IndexType == types.BoltDBShipperType &&
 		cfg.Configs[activePCIndex].IndexTables.Period != ObjectStorageIndexRequiredPeriod && len(cfg.Configs)-1 == activePCIndex {
 		return errCurrentBoltdbShipperNon24Hours
 	}
 
 	// if upcoming index type is boltdb-shipper, it should always be set to 24 hours.
-	if len(cfg.Configs)-1 > activePCIndex && (cfg.Configs[activePCIndex+1].IndexType == BoltDBShipperType &&
+	if len(cfg.Configs)-1 > activePCIndex && (cfg.Configs[activePCIndex+1].IndexType == types.BoltDBShipperType &&
 		cfg.Configs[activePCIndex+1].IndexTables.Period != ObjectStorageIndexRequiredPeriod) {
 		return errUpcomingBoltdbShipperNon24Hours
 	}
@@ -372,7 +353,7 @@ func usingForPeriodConfigs(configs []PeriodConfig, fn func(string) bool) bool {
 
 // IsObjectStorageIndex returns true if the index type is either boltdb-shipper or tsdb.
 func IsObjectStorageIndex(indexType string) bool {
-	return indexType == BoltDBShipperType || indexType == TSDBType
+	return indexType == types.BoltDBShipperType || indexType == types.TSDBType
 }
 
 // UsingObjectStorageIndex returns true if the current or any of the upcoming periods
@@ -471,7 +452,19 @@ func (cfg PeriodConfig) validate() error {
 		return validateError
 	}
 
-	if cfg.IndexType == TSDBType && cfg.IndexTables.Period != ObjectStorageIndexRequiredPeriod {
+	if !util.StringsContain(types.TestingStorageTypes, cfg.IndexType) &&
+		!util.StringsContain(types.SupportedIndexTypes, cfg.IndexType) &&
+		!util.StringsContain(types.DeprecatedIndexTypes, cfg.IndexType) {
+		return fmt.Errorf("unrecognized `store` (index) type `%s`, choose one of: %s", cfg.IndexType, strings.Join(types.SupportedIndexTypes, ", "))
+	}
+
+	if !util.StringsContain(types.TestingStorageTypes, cfg.ObjectType) &&
+		!util.StringsContain(types.SupportedStorageTypes, cfg.ObjectType) &&
+		!util.StringsContain(types.DeprecatedStorageTypes, cfg.ObjectType) {
+		return fmt.Errorf("unrecognized `object_store` type `%s`, choose one of: %s", cfg.ObjectType, strings.Join(types.SupportedStorageTypes, ", "))
+	}
+
+	if cfg.IndexType == types.TSDBType && cfg.IndexTables.Period != ObjectStorageIndexRequiredPeriod {
 		return errTSDBNon24HoursIndexPeriod
 	}
 

--- a/pkg/storage/config/schema_config.go
+++ b/pkg/storage/config/schema_config.go
@@ -21,7 +21,6 @@ import (
 	"github.com/grafana/loki/v3/pkg/logproto"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb/index"
 	"github.com/grafana/loki/v3/pkg/storage/types"
-	"github.com/grafana/loki/v3/pkg/util"
 	"github.com/grafana/loki/v3/pkg/util/log"
 )
 
@@ -450,18 +449,6 @@ func (cfg PeriodConfig) validate() error {
 	validateError := validateChunks(cfg)
 	if validateError != nil {
 		return validateError
-	}
-
-	if !util.StringsContain(types.TestingStorageTypes, cfg.IndexType) &&
-		!util.StringsContain(types.SupportedIndexTypes, cfg.IndexType) &&
-		!util.StringsContain(types.DeprecatedIndexTypes, cfg.IndexType) {
-		return fmt.Errorf("unrecognized `store` (index) type `%s`, choose one of: %s", cfg.IndexType, strings.Join(types.SupportedIndexTypes, ", "))
-	}
-
-	if !util.StringsContain(types.TestingStorageTypes, cfg.ObjectType) &&
-		!util.StringsContain(types.SupportedStorageTypes, cfg.ObjectType) &&
-		!util.StringsContain(types.DeprecatedStorageTypes, cfg.ObjectType) {
-		return fmt.Errorf("unrecognized `object_store` type `%s`, choose one of: %s", cfg.ObjectType, strings.Join(types.SupportedStorageTypes, ", "))
 	}
 
 	if cfg.IndexType == types.TSDBType && cfg.IndexTables.Period != ObjectStorageIndexRequiredPeriod {

--- a/pkg/storage/config/schema_config_test.go
+++ b/pkg/storage/config/schema_config_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/grafana/loki/v3/pkg/logproto"
 	"github.com/grafana/loki/v3/pkg/storage/chunk"
+	"github.com/grafana/loki/v3/pkg/storage/types"
 )
 
 func TestChunkTableFor(t *testing.T) {
@@ -1017,8 +1018,8 @@ func TestGetIndexStoreTableRanges(t *testing.T) {
 		Configs: []PeriodConfig{
 			{
 				From:       DayTime{Time: now.Add(30 * 24 * time.Hour)},
-				IndexType:  BoltDBShipperType,
-				ObjectType: StorageTypeFileSystem,
+				IndexType:  types.BoltDBShipperType,
+				ObjectType: types.StorageTypeFileSystem,
 				Schema:     "v9",
 				IndexTables: IndexPeriodicTableConfig{
 					PeriodicTableConfig: PeriodicTableConfig{
@@ -1028,8 +1029,8 @@ func TestGetIndexStoreTableRanges(t *testing.T) {
 			},
 			{
 				From:       DayTime{Time: now.Add(20 * 24 * time.Hour)},
-				IndexType:  BoltDBShipperType,
-				ObjectType: StorageTypeFileSystem,
+				IndexType:  types.BoltDBShipperType,
+				ObjectType: types.StorageTypeFileSystem,
 				Schema:     "v11",
 				IndexTables: IndexPeriodicTableConfig{
 					PeriodicTableConfig: PeriodicTableConfig{
@@ -1040,8 +1041,8 @@ func TestGetIndexStoreTableRanges(t *testing.T) {
 			},
 			{
 				From:       DayTime{Time: now.Add(15 * 24 * time.Hour)},
-				IndexType:  TSDBType,
-				ObjectType: StorageTypeFileSystem,
+				IndexType:  types.TSDBType,
+				ObjectType: types.StorageTypeFileSystem,
 				Schema:     "v11",
 				IndexTables: IndexPeriodicTableConfig{
 					PeriodicTableConfig: PeriodicTableConfig{
@@ -1052,8 +1053,8 @@ func TestGetIndexStoreTableRanges(t *testing.T) {
 			},
 			{
 				From:       DayTime{Time: now.Add(10 * 24 * time.Hour)},
-				IndexType:  StorageTypeBigTable,
-				ObjectType: StorageTypeFileSystem,
+				IndexType:  types.StorageTypeBigTable,
+				ObjectType: types.StorageTypeFileSystem,
 				Schema:     "v11",
 				IndexTables: IndexPeriodicTableConfig{
 					PeriodicTableConfig: PeriodicTableConfig{
@@ -1064,8 +1065,8 @@ func TestGetIndexStoreTableRanges(t *testing.T) {
 			},
 			{
 				From:       DayTime{Time: now.Add(5 * 24 * time.Hour)},
-				IndexType:  TSDBType,
-				ObjectType: StorageTypeFileSystem,
+				IndexType:  types.TSDBType,
+				ObjectType: types.StorageTypeFileSystem,
 				Schema:     "v11",
 				IndexTables: IndexPeriodicTableConfig{
 					PeriodicTableConfig: PeriodicTableConfig{
@@ -1088,7 +1089,7 @@ func TestGetIndexStoreTableRanges(t *testing.T) {
 			End:          schemaConfig.Configs[2].From.Add(-time.Millisecond).Unix() / int64(schemaConfig.Configs[0].IndexTables.Period/time.Second),
 			PeriodConfig: &schemaConfig.Configs[1],
 		},
-	}, GetIndexStoreTableRanges(BoltDBShipperType, schemaConfig.Configs))
+	}, GetIndexStoreTableRanges(types.BoltDBShipperType, schemaConfig.Configs))
 
 	require.Equal(t, TableRanges{
 		{
@@ -1096,7 +1097,7 @@ func TestGetIndexStoreTableRanges(t *testing.T) {
 			End:          schemaConfig.Configs[4].From.Add(-time.Millisecond).Unix() / int64(schemaConfig.Configs[0].IndexTables.Period/time.Second),
 			PeriodConfig: &schemaConfig.Configs[3],
 		},
-	}, GetIndexStoreTableRanges(StorageTypeBigTable, schemaConfig.Configs))
+	}, GetIndexStoreTableRanges(types.StorageTypeBigTable, schemaConfig.Configs))
 
 	require.Equal(t, TableRanges{
 		{
@@ -1109,7 +1110,7 @@ func TestGetIndexStoreTableRanges(t *testing.T) {
 			End:          model.Time(math.MaxInt64).Unix() / int64(schemaConfig.Configs[0].IndexTables.Period/time.Second),
 			PeriodConfig: &schemaConfig.Configs[4],
 		},
-	}, GetIndexStoreTableRanges(TSDBType, schemaConfig.Configs))
+	}, GetIndexStoreTableRanges(types.TSDBType, schemaConfig.Configs))
 }
 
 const (

--- a/pkg/storage/factory.go
+++ b/pkg/storage/factory.go
@@ -38,6 +38,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/downloads"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/gatewayclient"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/indexgateway"
+	"github.com/grafana/loki/v3/pkg/storage/types"
 	"github.com/grafana/loki/v3/pkg/util"
 	"github.com/grafana/loki/v3/pkg/util/constants"
 )
@@ -46,51 +47,6 @@ var (
 	indexGatewayClient index.Client
 	// singleton for each period
 	boltdbIndexClientsWithShipper = make(map[config.DayTime]*boltdb.IndexClient)
-
-	supportedIndexTypes = []string{
-		config.BoltDBShipperType,
-		config.TSDBType,
-	}
-
-	deprecatedIndexTypes = []string{
-		config.StorageTypeAWS,
-		config.StorageTypeAWSDynamo,
-		config.StorageTypeBigTable,
-		config.StorageTypeBigTableHashed,
-		config.StorageTypeBoltDB,
-		config.StorageTypeCassandra,
-		config.StorageTypeGCP,
-		config.StorageTypeGCPColumnKey,
-		config.StorageTypeGrpc,
-	}
-
-	supportedStorageTypes = []string{
-		// local file system
-		config.StorageTypeFileSystem,
-		// remote object storages
-		config.StorageTypeAWS,
-		config.StorageTypeAlibabaCloud,
-		config.StorageTypeAzure,
-		config.StorageTypeBOS,
-		config.StorageTypeCOS,
-		config.StorageTypeGCS,
-		config.StorageTypeS3,
-		config.StorageTypeSwift,
-	}
-
-	deprecatedStorageTypes = []string{
-		config.StorageTypeAWSDynamo,
-		config.StorageTypeBigTable,
-		config.StorageTypeBigTableHashed,
-		config.StorageTypeCassandra,
-		config.StorageTypeGCP,
-		config.StorageTypeGCPColumnKey,
-		config.StorageTypeGrpc,
-	}
-
-	testingStorageTypes = []string{
-		config.StorageTypeInMemory,
-	}
 )
 
 // ResetBoltDBIndexClientsWithShipper allows to reset the singletons.
@@ -223,10 +179,10 @@ func (ns *NamedStores) populateStoreType() error {
 
 	checkForDuplicates := func(name string) error {
 		switch name {
-		case config.StorageTypeAWS, config.StorageTypeAWSDynamo, config.StorageTypeS3,
-			config.StorageTypeGCP, config.StorageTypeGCPColumnKey, config.StorageTypeBigTable, config.StorageTypeBigTableHashed, config.StorageTypeGCS,
-			config.StorageTypeAzure, config.StorageTypeBOS, config.StorageTypeSwift, config.StorageTypeCassandra,
-			config.StorageTypeFileSystem, config.StorageTypeInMemory, config.StorageTypeGrpc:
+		case types.StorageTypeAWS, types.StorageTypeAWSDynamo, types.StorageTypeS3,
+			types.StorageTypeGCP, types.StorageTypeGCPColumnKey, types.StorageTypeBigTable, types.StorageTypeBigTableHashed, types.StorageTypeGCS,
+			types.StorageTypeAzure, types.StorageTypeBOS, types.StorageTypeSwift, types.StorageTypeCassandra,
+			types.StorageTypeFileSystem, types.StorageTypeInMemory, types.StorageTypeGrpc:
 			return fmt.Errorf("named store %q should not match with the name of a predefined storage type", name)
 		}
 
@@ -241,47 +197,47 @@ func (ns *NamedStores) populateStoreType() error {
 		if err := checkForDuplicates(name); err != nil {
 			return err
 		}
-		ns.storeType[name] = config.StorageTypeAWS
+		ns.storeType[name] = types.StorageTypeAWS
 	}
 
 	for name := range ns.Azure {
 		if err := checkForDuplicates(name); err != nil {
 			return err
 		}
-		ns.storeType[name] = config.StorageTypeAzure
+		ns.storeType[name] = types.StorageTypeAzure
 	}
 	for name := range ns.AlibabaCloud {
 		if err := checkForDuplicates(name); err != nil {
 			return err
 		}
-		ns.storeType[name] = config.StorageTypeAlibabaCloud
+		ns.storeType[name] = types.StorageTypeAlibabaCloud
 	}
 	for name := range ns.BOS {
 		if err := checkForDuplicates(name); err != nil {
 			return err
 		}
-		ns.storeType[name] = config.StorageTypeBOS
+		ns.storeType[name] = types.StorageTypeBOS
 	}
 
 	for name := range ns.Filesystem {
 		if err := checkForDuplicates(name); err != nil {
 			return err
 		}
-		ns.storeType[name] = config.StorageTypeFileSystem
+		ns.storeType[name] = types.StorageTypeFileSystem
 	}
 
 	for name := range ns.GCS {
 		if err := checkForDuplicates(name); err != nil {
 			return err
 		}
-		ns.storeType[name] = config.StorageTypeGCS
+		ns.storeType[name] = types.StorageTypeGCS
 	}
 
 	for name := range ns.Swift {
 		if err := checkForDuplicates(name); err != nil {
 			return err
 		}
-		ns.storeType[name] = config.StorageTypeSwift
+		ns.storeType[name] = types.StorageTypeSwift
 	}
 
 	return nil
@@ -405,16 +361,16 @@ func (cfg *Config) Validate() error {
 func NewIndexClient(periodCfg config.PeriodConfig, tableRange config.TableRange, cfg Config, schemaCfg config.SchemaConfig, limits StoreLimits, cm ClientMetrics, shardingStrategy indexgateway.ShardingStrategy, registerer prometheus.Registerer, logger log.Logger, metricsNamespace string) (index.Client, error) {
 
 	switch true {
-	case util.StringsContain(testingStorageTypes, periodCfg.IndexType):
+	case util.StringsContain(types.TestingStorageTypes, periodCfg.IndexType):
 		switch periodCfg.IndexType {
-		case config.StorageTypeInMemory:
+		case types.StorageTypeInMemory:
 			store := testutils.NewMockStorage()
 			return store, nil
 		}
 
-	case util.StringsContain(supportedIndexTypes, periodCfg.IndexType):
+	case util.StringsContain(types.SupportedIndexTypes, periodCfg.IndexType):
 		switch periodCfg.IndexType {
-		case config.BoltDBShipperType:
+		case types.BoltDBShipperType:
 			if shouldUseIndexGatewayClient(cfg.BoltDBShipperConfig.Config) {
 				if indexGatewayClient != nil {
 					return indexGatewayClient, nil
@@ -450,16 +406,16 @@ func NewIndexClient(periodCfg config.PeriodConfig, tableRange config.TableRange,
 			boltdbIndexClientsWithShipper[periodCfg.From] = indexClient
 			return indexClient, nil
 
-		case config.TSDBType:
+		case types.TSDBType:
 			// TODO(chaudum): Move TSDB index client creation into this code path
 			return nil, fmt.Errorf("code path not supported")
 		}
 
-	case util.StringsContain(deprecatedIndexTypes, periodCfg.IndexType):
+	case util.StringsContain(types.DeprecatedIndexTypes, periodCfg.IndexType):
 		level.Warn(logger).Log("msg", fmt.Sprintf("%s is deprecated. Consider migrating to tsdb", periodCfg.IndexType))
 
 		switch periodCfg.IndexType {
-		case config.StorageTypeAWS, config.StorageTypeAWSDynamo:
+		case types.StorageTypeAWS, types.StorageTypeAWSDynamo:
 			if cfg.AWSStorageConfig.DynamoDB.URL == nil {
 				return nil, fmt.Errorf("Must set -dynamodb.url in aws mode")
 			}
@@ -469,28 +425,28 @@ func NewIndexClient(periodCfg config.PeriodConfig, tableRange config.TableRange,
 			}
 			return aws.NewDynamoDBIndexClient(cfg.AWSStorageConfig.DynamoDBConfig, schemaCfg, registerer)
 
-		case config.StorageTypeGCP:
+		case types.StorageTypeGCP:
 			return gcp.NewStorageClientV1(context.Background(), cfg.GCPStorageConfig, schemaCfg)
 
-		case config.StorageTypeGCPColumnKey, config.StorageTypeBigTable:
+		case types.StorageTypeGCPColumnKey, types.StorageTypeBigTable:
 			return gcp.NewStorageClientColumnKey(context.Background(), cfg.GCPStorageConfig, schemaCfg)
 
-		case config.StorageTypeBigTableHashed:
+		case types.StorageTypeBigTableHashed:
 			cfg.GCPStorageConfig.DistributeKeys = true
 			return gcp.NewStorageClientColumnKey(context.Background(), cfg.GCPStorageConfig, schemaCfg)
 
-		case config.StorageTypeCassandra:
+		case types.StorageTypeCassandra:
 			return cassandra.NewStorageClient(cfg.CassandraStorageConfig, schemaCfg, registerer)
 
-		case config.StorageTypeBoltDB:
+		case types.StorageTypeBoltDB:
 			return local.NewBoltDBIndexClient(cfg.BoltDBConfig)
 
-		case config.StorageTypeGrpc:
+		case types.StorageTypeGrpc:
 			return grpc.NewStorageClient(cfg.GrpcConfig, schemaCfg)
 		}
 	}
 
-	return nil, fmt.Errorf("unrecognized index client type %s, choose one of: %s", periodCfg.IndexType, strings.Join(supportedIndexTypes, ","))
+	return nil, fmt.Errorf("unrecognized index client type %s, choose one of: %s", periodCfg.IndexType, strings.Join(types.SupportedIndexTypes, ","))
 }
 
 // NewChunkClient makes a new chunk.Client of the desired types.
@@ -504,9 +460,9 @@ func NewChunkClient(name string, cfg Config, schemaCfg config.SchemaConfig, cc c
 
 	switch true {
 
-	case util.StringsContain(testingStorageTypes, storeType):
+	case util.StringsContain(types.TestingStorageTypes, storeType):
 		switch storeType {
-		case config.StorageTypeInMemory:
+		case types.StorageTypeInMemory:
 			c, err := NewObjectClient(name, cfg, clientMetrics)
 			if err != nil {
 				return nil, err
@@ -514,23 +470,23 @@ func NewChunkClient(name string, cfg Config, schemaCfg config.SchemaConfig, cc c
 			return client.NewClientWithMaxParallel(c, nil, 1, schemaCfg), nil
 		}
 
-	case util.StringsContain(supportedStorageTypes, storeType):
+	case util.StringsContain(types.SupportedStorageTypes, storeType):
 		switch storeType {
-		case config.StorageTypeFileSystem:
+		case types.StorageTypeFileSystem:
 			c, err := NewObjectClient(name, cfg, clientMetrics)
 			if err != nil {
 				return nil, err
 			}
 			return client.NewClientWithMaxParallel(c, client.FSEncoder, cfg.MaxParallelGetChunk, schemaCfg), nil
 
-		case config.StorageTypeAWS, config.StorageTypeS3, config.StorageTypeAzure, config.StorageTypeBOS, config.StorageTypeSwift, config.StorageTypeCOS, config.StorageTypeAlibabaCloud:
+		case types.StorageTypeAWS, types.StorageTypeS3, types.StorageTypeAzure, types.StorageTypeBOS, types.StorageTypeSwift, types.StorageTypeCOS, types.StorageTypeAlibabaCloud:
 			c, err := NewObjectClient(name, cfg, clientMetrics)
 			if err != nil {
 				return nil, err
 			}
 			return client.NewClientWithMaxParallel(c, nil, cfg.MaxParallelGetChunk, schemaCfg), nil
 
-		case config.StorageTypeGCS:
+		case types.StorageTypeGCS:
 			c, err := NewObjectClient(name, cfg, clientMetrics)
 			if err != nil {
 				return nil, err
@@ -543,11 +499,11 @@ func NewChunkClient(name string, cfg Config, schemaCfg config.SchemaConfig, cc c
 			return client.NewClientWithMaxParallel(c, nil, cfg.MaxParallelGetChunk, schemaCfg), nil
 		}
 
-	case util.StringsContain(deprecatedStorageTypes, storeType):
-		level.Warn(logger).Log("msg", fmt.Sprintf("%s is deprecated. Please use one of the supported object stores: %s", storeType, strings.Join(supportedStorageTypes, ", ")))
+	case util.StringsContain(types.DeprecatedStorageTypes, storeType):
+		level.Warn(logger).Log("msg", fmt.Sprintf("%s is deprecated. Please use one of the supported object stores: %s", storeType, strings.Join(types.SupportedStorageTypes, ", ")))
 
 		switch storeType {
-		case config.StorageTypeAWSDynamo:
+		case types.StorageTypeAWSDynamo:
 			if cfg.AWSStorageConfig.DynamoDB.URL == nil {
 				return nil, fmt.Errorf("Must set -dynamodb.url in aws mode")
 			}
@@ -557,39 +513,39 @@ func NewChunkClient(name string, cfg Config, schemaCfg config.SchemaConfig, cc c
 			}
 			return aws.NewDynamoDBChunkClient(cfg.AWSStorageConfig.DynamoDBConfig, schemaCfg, registerer)
 
-		case config.StorageTypeGCP, config.StorageTypeGCPColumnKey, config.StorageTypeBigTable, config.StorageTypeBigTableHashed:
+		case types.StorageTypeGCP, types.StorageTypeGCPColumnKey, types.StorageTypeBigTable, types.StorageTypeBigTableHashed:
 			return gcp.NewBigtableObjectClient(context.Background(), cfg.GCPStorageConfig, schemaCfg)
 
-		case config.StorageTypeCassandra:
+		case types.StorageTypeCassandra:
 			return cassandra.NewObjectClient(cfg.CassandraStorageConfig, schemaCfg, registerer, cfg.MaxParallelGetChunk)
 
-		case config.StorageTypeGrpc:
+		case types.StorageTypeGrpc:
 			return grpc.NewStorageClient(cfg.GrpcConfig, schemaCfg)
 		}
 	}
 
-	return nil, fmt.Errorf("unrecognized chunk client type %s, choose one of: %s", name, strings.Join(supportedStorageTypes, ", "))
+	return nil, fmt.Errorf("unrecognized chunk client type %s, choose one of: %s", name, strings.Join(types.SupportedStorageTypes, ", "))
 }
 
 // NewTableClient makes a new table client based on the configuration.
 func NewTableClient(name string, periodCfg config.PeriodConfig, cfg Config, cm ClientMetrics, registerer prometheus.Registerer, logger log.Logger) (index.TableClient, error) {
 	switch true {
-	case util.StringsContain(testingStorageTypes, name):
+	case util.StringsContain(types.TestingStorageTypes, name):
 		switch name {
-		case config.StorageTypeInMemory:
+		case types.StorageTypeInMemory:
 			return testutils.NewMockStorage(), nil
 		}
 
-	case util.StringsContain(supportedIndexTypes, name):
+	case util.StringsContain(types.SupportedIndexTypes, name):
 		objectClient, err := NewObjectClient(periodCfg.ObjectType, cfg, cm)
 		if err != nil {
 			return nil, err
 		}
 		return indexshipper.NewTableClient(objectClient, periodCfg.IndexTables.PathPrefix), nil
 
-	case util.StringsContain(deprecatedIndexTypes, name):
+	case util.StringsContain(types.DeprecatedIndexTypes, name):
 		switch name {
-		case config.StorageTypeAWS, config.StorageTypeAWSDynamo:
+		case types.StorageTypeAWS, types.StorageTypeAWSDynamo:
 			if cfg.AWSStorageConfig.DynamoDB.URL == nil {
 				return nil, fmt.Errorf("Must set -dynamodb.url in aws mode")
 			}
@@ -598,18 +554,18 @@ func NewTableClient(name string, periodCfg config.PeriodConfig, cfg Config, cm C
 				level.Warn(logger).Log("msg", "ignoring DynamoDB URL path", "path", path)
 			}
 			return aws.NewDynamoDBTableClient(cfg.AWSStorageConfig.DynamoDBConfig, registerer)
-		case config.StorageTypeGCP, config.StorageTypeGCPColumnKey, config.StorageTypeBigTable, config.StorageTypeBigTableHashed:
+		case types.StorageTypeGCP, types.StorageTypeGCPColumnKey, types.StorageTypeBigTable, types.StorageTypeBigTableHashed:
 			return gcp.NewTableClient(context.Background(), cfg.GCPStorageConfig)
-		case config.StorageTypeCassandra:
+		case types.StorageTypeCassandra:
 			return cassandra.NewTableClient(context.Background(), cfg.CassandraStorageConfig, registerer)
-		case config.StorageTypeBoltDB:
+		case types.StorageTypeBoltDB:
 			return local.NewTableClient(cfg.BoltDBConfig.Directory)
-		case config.StorageTypeGrpc:
+		case types.StorageTypeGrpc:
 			return grpc.NewTableClient(cfg.GrpcConfig)
 		}
 	}
 
-	return nil, fmt.Errorf("unrecognized table client type %s, choose one of: %s", name, strings.Join(supportedIndexTypes, ", "))
+	return nil, fmt.Errorf("unrecognized table client type %s, choose one of: %s", name, strings.Join(types.SupportedIndexTypes, ", "))
 }
 
 // NewBucketClient makes a new bucket client based on the configuration.
@@ -664,10 +620,10 @@ func internalNewObjectClient(name string, cfg Config, clientMetrics ClientMetric
 	}
 
 	switch storeType {
-	case config.StorageTypeInMemory:
+	case types.StorageTypeInMemory:
 		return testutils.NewMockStorage(), nil
 
-	case config.StorageTypeAWS, config.StorageTypeS3:
+	case types.StorageTypeAWS, types.StorageTypeS3:
 		s3Cfg := cfg.AWSStorageConfig.S3Config
 		if namedStore != "" {
 			awsCfg, ok := cfg.NamedStores.AWS[namedStore]
@@ -678,7 +634,7 @@ func internalNewObjectClient(name string, cfg Config, clientMetrics ClientMetric
 		}
 		return aws.NewS3ObjectClient(s3Cfg, cfg.Hedging)
 
-	case config.StorageTypeAlibabaCloud:
+	case types.StorageTypeAlibabaCloud:
 		ossCfg := cfg.AlibabaStorageConfig
 		if namedStore != "" {
 			nsCfg, ok := cfg.NamedStores.AlibabaCloud[namedStore]
@@ -690,7 +646,7 @@ func internalNewObjectClient(name string, cfg Config, clientMetrics ClientMetric
 		}
 		return alibaba.NewOssObjectClient(context.Background(), ossCfg)
 
-	case config.StorageTypeGCS:
+	case types.StorageTypeGCS:
 		gcsCfg := cfg.GCSConfig
 		if namedStore != "" {
 			nsCfg, ok := cfg.NamedStores.GCS[namedStore]
@@ -707,7 +663,7 @@ func internalNewObjectClient(name string, cfg Config, clientMetrics ClientMetric
 		}
 		return gcp.NewGCSObjectClient(context.Background(), gcsCfg, cfg.Hedging)
 
-	case config.StorageTypeAzure:
+	case types.StorageTypeAzure:
 		azureCfg := cfg.AzureStorageConfig
 		if namedStore != "" {
 			nsCfg, ok := cfg.NamedStores.Azure[namedStore]
@@ -718,7 +674,7 @@ func internalNewObjectClient(name string, cfg Config, clientMetrics ClientMetric
 		}
 		return azure.NewBlobStorage(&azureCfg, clientMetrics.AzureMetrics, cfg.Hedging)
 
-	case config.StorageTypeSwift:
+	case types.StorageTypeSwift:
 		swiftCfg := cfg.Swift
 		if namedStore != "" {
 			nsCfg, ok := cfg.NamedStores.Swift[namedStore]
@@ -729,7 +685,7 @@ func internalNewObjectClient(name string, cfg Config, clientMetrics ClientMetric
 		}
 		return openstack.NewSwiftObjectClient(swiftCfg, cfg.Hedging)
 
-	case config.StorageTypeFileSystem:
+	case types.StorageTypeFileSystem:
 		fsCfg := cfg.FSConfig
 		if namedStore != "" {
 			nsCfg, ok := cfg.NamedStores.Filesystem[namedStore]
@@ -740,7 +696,7 @@ func internalNewObjectClient(name string, cfg Config, clientMetrics ClientMetric
 		}
 		return local.NewFSObjectClient(fsCfg)
 
-	case config.StorageTypeBOS:
+	case types.StorageTypeBOS:
 		bosCfg := cfg.BOSStorageConfig
 		if namedStore != "" {
 			nsCfg, ok := cfg.NamedStores.BOS[namedStore]
@@ -752,7 +708,7 @@ func internalNewObjectClient(name string, cfg Config, clientMetrics ClientMetric
 		}
 		return baidubce.NewBOSObjectStorage(&bosCfg)
 
-	case config.StorageTypeCOS:
+	case types.StorageTypeCOS:
 		cosCfg := cfg.COSConfig
 		if namedStore != "" {
 			nsCfg, ok := cfg.NamedStores.COS[namedStore]
@@ -765,6 +721,6 @@ func internalNewObjectClient(name string, cfg Config, clientMetrics ClientMetric
 		return ibmcloud.NewCOSObjectClient(cosCfg, cfg.Hedging)
 
 	default:
-		return nil, fmt.Errorf("Unrecognized storage client %v, choose one of: %v, %v, %v, %v, %v, %v, %v, %v, %v", name, config.StorageTypeAWS, config.StorageTypeS3, config.StorageTypeGCS, config.StorageTypeAzure, config.StorageTypeAlibabaCloud, config.StorageTypeSwift, config.StorageTypeBOS, config.StorageTypeCOS, config.StorageTypeFileSystem)
+		return nil, fmt.Errorf("Unrecognized storage client %v, choose one of: %v, %v, %v, %v, %v, %v, %v, %v, %v", name, types.StorageTypeAWS, types.StorageTypeS3, types.StorageTypeGCS, types.StorageTypeAzure, types.StorageTypeAlibabaCloud, types.StorageTypeSwift, types.StorageTypeBOS, types.StorageTypeCOS, types.StorageTypeFileSystem)
 	}
 }

--- a/pkg/storage/factory.go
+++ b/pkg/storage/factory.go
@@ -265,6 +265,11 @@ func (ns *NamedStores) Validate() error {
 	return ns.populateStoreType()
 }
 
+func (ns *NamedStores) Exists(name string) bool {
+	_, ok := ns.storeType[name]
+	return ok
+}
+
 // Config chooses which storage client to use.
 type Config struct {
 	AlibabaStorageConfig   alibaba.OssConfig         `yaml:"alibabacloud"`

--- a/pkg/storage/factory_test.go
+++ b/pkg/storage/factory_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/storage/config"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/boltdb"
+	"github.com/grafana/loki/v3/pkg/storage/types"
 	"github.com/grafana/loki/v3/pkg/util/constants"
 	util_log "github.com/grafana/loki/v3/pkg/util/log"
 	"github.com/grafana/loki/v3/pkg/validation"
@@ -213,15 +214,15 @@ func TestNamedStores_populateStoreType(t *testing.T) {
 
 		storeType, ok := ns.storeType["store-1"]
 		assert.True(t, ok)
-		assert.Equal(t, config.StorageTypeAWS, storeType)
+		assert.Equal(t, types.StorageTypeAWS, storeType)
 
 		storeType, ok = ns.storeType["store-2"]
 		assert.True(t, ok)
-		assert.Equal(t, config.StorageTypeAWS, storeType)
+		assert.Equal(t, types.StorageTypeAWS, storeType)
 
 		storeType, ok = ns.storeType["store-3"]
 		assert.True(t, ok)
-		assert.Equal(t, config.StorageTypeGCS, storeType)
+		assert.Equal(t, types.StorageTypeGCS, storeType)
 
 		_, ok = ns.storeType["store-4"]
 		assert.False(t, ok)

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"time"
 
+	"github.com/grafana/loki/v3/pkg/storage/types"
 	"github.com/grafana/loki/v3/pkg/util/httpreq"
 
 	lokilog "github.com/grafana/loki/v3/pkg/logql/log"
@@ -276,7 +277,7 @@ func (s *LokiStore) storeForPeriod(p config.PeriodConfig, tableRange config.Tabl
 		}, s.registerer)
 	indexClientLogger := log.With(s.logger, "index-store", fmt.Sprintf("%s-%s", p.IndexType, p.From.String()))
 
-	if p.IndexType == config.TSDBType {
+	if p.IndexType == types.TSDBType {
 		if shouldUseIndexGatewayClient(s.cfg.TSDBShipperConfig) {
 			// inject the index-gateway client into the index store
 			gw, err := gatewayclient.NewGatewayClient(s.cfg.TSDBShipperConfig.IndexGatewayClientConfig, indexClientReg, s.limits, indexClientLogger, s.metricsNamespace)

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/loki/v3/pkg/storage/types"
 	"github.com/grafana/loki/v3/pkg/util/httpreq"
 
 	"github.com/cespare/xxhash/v2"
@@ -212,7 +213,7 @@ func getLocalStore(path string, cm ClientMetrics) Store {
 			{
 				From:       config.DayTime{Time: start},
 				IndexType:  "boltdb",
-				ObjectType: config.StorageTypeFileSystem,
+				ObjectType: types.StorageTypeFileSystem,
 				Schema:     "v13",
 				IndexTables: config.IndexPeriodicTableConfig{
 					PeriodicTableConfig: config.PeriodicTableConfig{
@@ -1282,8 +1283,8 @@ func TestStore_indexPrefixChange(t *testing.T) {
 
 	periodConfig := config.PeriodConfig{
 		From:       config.DayTime{Time: timeToModelTime(firstPeriodDate)},
-		IndexType:  config.TSDBType,
-		ObjectType: config.StorageTypeFileSystem,
+		IndexType:  types.TSDBType,
+		ObjectType: types.StorageTypeFileSystem,
 		Schema:     "v9",
 		IndexTables: config.IndexPeriodicTableConfig{
 			PathPrefix: "index/",
@@ -1356,7 +1357,7 @@ func TestStore_indexPrefixChange(t *testing.T) {
 	// update schema with a new period that uses different index prefix
 	periodConfig2 := config.PeriodConfig{
 		From:       config.DayTime{Time: timeToModelTime(secondPeriodDate)},
-		IndexType:  config.TSDBType,
+		IndexType:  types.TSDBType,
 		ObjectType: "named-store",
 		Schema:     "v11",
 		IndexTables: config.IndexPeriodicTableConfig{
@@ -1435,9 +1436,9 @@ func TestStore_MultiPeriod(t *testing.T) {
 	secondStoreDate := parseDate("2019-01-02")
 
 	for name, indexes := range map[string][]string{
-		"botldb_boltdb": {config.BoltDBShipperType, config.BoltDBShipperType},
-		"botldb_tsdb":   {config.BoltDBShipperType, config.TSDBType},
-		"tsdb_tsdb":     {config.TSDBType, config.TSDBType},
+		"botldb_boltdb": {types.BoltDBShipperType, types.BoltDBShipperType},
+		"botldb_tsdb":   {types.BoltDBShipperType, types.TSDBType},
+		"tsdb_tsdb":     {types.TSDBType, types.TSDBType},
 	} {
 		t.Run(name, func(t *testing.T) {
 			tempDir := t.TempDir()
@@ -1463,7 +1464,7 @@ func TestStore_MultiPeriod(t *testing.T) {
 			periodConfigV9 := config.PeriodConfig{
 				From:       config.DayTime{Time: timeToModelTime(firstStoreDate)},
 				IndexType:  indexes[0],
-				ObjectType: config.StorageTypeFileSystem,
+				ObjectType: types.StorageTypeFileSystem,
 				Schema:     "v9",
 				IndexTables: config.IndexPeriodicTableConfig{
 					PeriodicTableConfig: config.PeriodicTableConfig{
@@ -1820,7 +1821,7 @@ func TestStore_BoltdbTsdbSameIndexPrefix(t *testing.T) {
 			{
 				From:       config.DayTime{Time: timeToModelTime(boltdbShipperStartDate)},
 				IndexType:  "boltdb-shipper",
-				ObjectType: config.StorageTypeFileSystem,
+				ObjectType: types.StorageTypeFileSystem,
 				Schema:     "v12",
 				IndexTables: config.IndexPeriodicTableConfig{
 					PathPrefix: "index/",
@@ -1833,7 +1834,7 @@ func TestStore_BoltdbTsdbSameIndexPrefix(t *testing.T) {
 			{
 				From:       config.DayTime{Time: timeToModelTime(tsdbStartDate)},
 				IndexType:  "tsdb",
-				ObjectType: config.StorageTypeFileSystem,
+				ObjectType: types.StorageTypeFileSystem,
 				Schema:     "v12",
 				IndexTables: config.IndexPeriodicTableConfig{
 					PathPrefix: "index/",

--- a/pkg/storage/stores/shipper/bloomshipper/config/config.go
+++ b/pkg/storage/stores/shipper/bloomshipper/config/config.go
@@ -24,6 +24,7 @@ type Config struct {
 }
 
 func (c *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
+	//FIXME E.Welch, the helm chart does not use the /data dir rather /var so we need to probably consider not defaulting this? not sure what's best to do here.
 	c.WorkingDirectory = []string{"/data/blooms"}
 	f.Var(&c.WorkingDirectory, prefix+"shipper.working-directory", "Working directory to store downloaded bloom blocks. Supports multiple directories, separated by comma.")
 	_ = c.MaxQueryPageSize.Set("64MiB") // default should match the one set in pkg/storage/bloom/v1/bloom.go

--- a/pkg/storage/stores/shipper/bloomshipper/store_test.go
+++ b/pkg/storage/stores/shipper/bloomshipper/store_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/storage/chunk/client/local"
 	storageconfig "github.com/grafana/loki/v3/pkg/storage/config"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/bloomshipper/config"
+	"github.com/grafana/loki/v3/pkg/storage/types"
 )
 
 func newMockBloomStore(t *testing.T) (*BloomStore, string, error) {
@@ -34,7 +35,7 @@ func newMockBloomStore(t *testing.T) (*BloomStore, string, error) {
 func newMockBloomStoreWithWorkDir(t *testing.T, workDir, storeDir string) (*BloomStore, string, error) {
 	periodicConfigs := []storageconfig.PeriodConfig{
 		{
-			ObjectType: storageconfig.StorageTypeFileSystem,
+			ObjectType: types.StorageTypeFileSystem,
 			From:       parseDayTime("2024-01-01"),
 			IndexTables: storageconfig.IndexPeriodicTableConfig{
 				PeriodicTableConfig: storageconfig.PeriodicTableConfig{
@@ -43,7 +44,7 @@ func newMockBloomStoreWithWorkDir(t *testing.T, workDir, storeDir string) (*Bloo
 				}},
 		},
 		{
-			ObjectType: storageconfig.StorageTypeFileSystem,
+			ObjectType: types.StorageTypeFileSystem,
 			From:       parseDayTime("2024-02-01"),
 			IndexTables: storageconfig.IndexPeriodicTableConfig{
 				PeriodicTableConfig: storageconfig.PeriodicTableConfig{

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/head_manager_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/head_manager_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/storage/config"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb/index"
+	"github.com/grafana/loki/v3/pkg/storage/types"
 	"github.com/grafana/loki/v3/pkg/validation"
 )
 
@@ -443,8 +444,8 @@ func TestBuildLegacyWALs(t *testing.T) {
 			Configs: []config.PeriodConfig{
 				{
 					Schema:     "v11",
-					IndexType:  config.TSDBType,
-					ObjectType: config.StorageTypeFileSystem,
+					IndexType:  types.TSDBType,
+					ObjectType: types.StorageTypeFileSystem,
 					IndexTables: config.IndexPeriodicTableConfig{
 						PeriodicTableConfig: config.PeriodicTableConfig{
 							Prefix: "index_",
@@ -454,8 +455,8 @@ func TestBuildLegacyWALs(t *testing.T) {
 				{
 					Schema:     "v11",
 					From:       config.DayTime{Time: timeToModelTime(secondStoreDate)},
-					IndexType:  config.TSDBType,
-					ObjectType: config.StorageTypeFileSystem,
+					IndexType:  types.TSDBType,
+					ObjectType: types.StorageTypeFileSystem,
 					IndexTables: config.IndexPeriodicTableConfig{
 						PeriodicTableConfig: config.PeriodicTableConfig{
 							Prefix: "index_",
@@ -467,8 +468,8 @@ func TestBuildLegacyWALs(t *testing.T) {
 			Configs: []config.PeriodConfig{
 				{
 					Schema:     "v12",
-					IndexType:  config.TSDBType,
-					ObjectType: config.StorageTypeFileSystem,
+					IndexType:  types.TSDBType,
+					ObjectType: types.StorageTypeFileSystem,
 					IndexTables: config.IndexPeriodicTableConfig{
 						PeriodicTableConfig: config.PeriodicTableConfig{
 							Prefix: "index_",
@@ -478,8 +479,8 @@ func TestBuildLegacyWALs(t *testing.T) {
 				{
 					Schema:     "v12",
 					From:       config.DayTime{Time: timeToModelTime(secondStoreDate)},
-					IndexType:  config.TSDBType,
-					ObjectType: config.StorageTypeFileSystem,
+					IndexType:  types.TSDBType,
+					ObjectType: types.StorageTypeFileSystem,
 					IndexTables: config.IndexPeriodicTableConfig{
 						PeriodicTableConfig: config.PeriodicTableConfig{
 							Prefix: "index_",
@@ -491,8 +492,8 @@ func TestBuildLegacyWALs(t *testing.T) {
 			Configs: []config.PeriodConfig{
 				{
 					Schema:     "v13",
-					IndexType:  config.TSDBType,
-					ObjectType: config.StorageTypeFileSystem,
+					IndexType:  types.TSDBType,
+					ObjectType: types.StorageTypeFileSystem,
 					IndexTables: config.IndexPeriodicTableConfig{
 						PeriodicTableConfig: config.PeriodicTableConfig{
 							Prefix: "index_",
@@ -502,8 +503,8 @@ func TestBuildLegacyWALs(t *testing.T) {
 				{
 					Schema:     "v13",
 					From:       config.DayTime{Time: timeToModelTime(secondStoreDate)},
-					IndexType:  config.TSDBType,
-					ObjectType: config.StorageTypeFileSystem,
+					IndexType:  types.TSDBType,
+					ObjectType: types.StorageTypeFileSystem,
 					IndexTables: config.IndexPeriodicTableConfig{
 						PeriodicTableConfig: config.PeriodicTableConfig{
 							Prefix: "index_",

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/manager.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/manager.go
@@ -18,6 +18,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/storage/config"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb/index"
+	"github.com/grafana/loki/v3/pkg/storage/types"
 	util_log "github.com/grafana/loki/v3/pkg/util/log"
 )
 
@@ -276,7 +277,7 @@ func (m *tsdbManager) BuildFromWALs(t time.Time, ids []WALIdentifier, legacy boo
 
 	if legacy {
 		// pass all TSDB tableRanges as the legacy WAL files are not period specific.
-		tableRanges = config.GetIndexStoreTableRanges(config.TSDBType, m.schemaCfg.Configs)
+		tableRanges = config.GetIndexStoreTableRanges(types.TSDBType, m.schemaCfg.Configs)
 
 		// do not ship legacy WAL files.
 		// TSDBs built from these WAL files would get loaded on starting tsdbManager

--- a/pkg/storage/types/types.go
+++ b/pkg/storage/types/types.go
@@ -1,0 +1,71 @@
+package types
+
+var SupportedIndexTypes = []string{
+	BoltDBShipperType,
+	TSDBType,
+}
+
+var DeprecatedIndexTypes = []string{
+	StorageTypeAWS,
+	StorageTypeAWSDynamo,
+	StorageTypeBigTable,
+	StorageTypeBigTableHashed,
+	StorageTypeBoltDB,
+	StorageTypeCassandra,
+	StorageTypeGCP,
+	StorageTypeGCPColumnKey,
+	StorageTypeGrpc,
+}
+
+var SupportedStorageTypes = []string{
+	// local file system
+	StorageTypeFileSystem,
+	// remote object storages
+	StorageTypeAWS,
+	StorageTypeAlibabaCloud,
+	StorageTypeAzure,
+	StorageTypeBOS,
+	StorageTypeCOS,
+	StorageTypeGCS,
+	StorageTypeS3,
+	StorageTypeSwift,
+}
+
+var DeprecatedStorageTypes = []string{
+	StorageTypeAWSDynamo,
+	StorageTypeBigTable,
+	StorageTypeBigTableHashed,
+	StorageTypeCassandra,
+	StorageTypeGCP,
+	StorageTypeGCPColumnKey,
+	StorageTypeGrpc,
+}
+
+var TestingStorageTypes = []string{
+	StorageTypeInMemory,
+}
+
+const (
+	StorageTypeAlibabaCloud   = "alibabacloud"
+	StorageTypeAWS            = "aws"
+	StorageTypeAWSDynamo      = "aws-dynamo"
+	StorageTypeAzure          = "azure"
+	StorageTypeBOS            = "bos"
+	StorageTypeBoltDB         = "boltdb"
+	StorageTypeCassandra      = "cassandra"
+	StorageTypeInMemory       = "inmemory"
+	StorageTypeBigTable       = "bigtable"
+	StorageTypeBigTableHashed = "bigtable-hashed"
+	StorageTypeFileSystem     = "filesystem"
+	StorageTypeGCP            = "gcp"
+	StorageTypeGCPColumnKey   = "gcp-columnkey"
+	StorageTypeGCS            = "gcs"
+	StorageTypeGrpc           = "grpc-store"
+	StorageTypeLocal          = "local"
+	StorageTypeS3             = "s3"
+	StorageTypeSwift          = "swift"
+	StorageTypeCOS            = "cos"
+
+	BoltDBShipperType = "boltdb-shipper"
+	TSDBType          = "tsdb"
+)

--- a/tools/tsdb/helpers/util.go
+++ b/tools/tsdb/helpers/util.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/grafana/loki/v3/pkg/storage/chunk/client"
 	"github.com/grafana/loki/v3/pkg/storage/config"
+	"github.com/grafana/loki/v3/pkg/storage/types"
 )
 
 const (
@@ -54,7 +55,7 @@ func GetPeriodConfigForTableNumber(table string, periodicConfigs []config.Period
 	}
 
 	for i, periodCfg := range periodicConfigs {
-		if periodCfg.IndexType != config.TSDBType {
+		if periodCfg.IndexType != types.TSDBType {
 			continue
 		}
 

--- a/tools/tsdb/migrate-versions/main.go
+++ b/tools/tsdb/migrate-versions/main.go
@@ -26,6 +26,7 @@ import (
 	shipperstorage "github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/storage"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb"
 	tsdbindex "github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb/index"
+	"github.com/grafana/loki/v3/pkg/storage/types"
 	"github.com/grafana/loki/v3/pkg/util/cfg"
 	util_log "github.com/grafana/loki/v3/pkg/util/log"
 )
@@ -80,7 +81,7 @@ func main() {
 	}
 
 	for i, cfg := range lokiCfg.SchemaConfig.Configs {
-		if cfg.IndexType != config.TSDBType {
+		if cfg.IndexType != types.TSDBType {
 			continue
 		}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Had to do a bit more refactoring than I was hoping for this to avoid import cycles.

Mostly this change affects loki.go and refactors how config validation is done so that we can return multiple errors from any validation failures.

It also makes sure we aren't trying to use empty directories in the compactor or indexes (boltdb and tsdb)

It also introduces validation of the index type and object store type in the schema

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
