### PR TITLE
fix: use nanosecond precision for timestamp in compacted tsdb index file names

### DIFF
--- a/pkg/storage/stores/shipper/indexshipper/tsdb/identifier.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/identifier.go
@@ -79,7 +79,7 @@ func (i SingleTenantTSDBIdentifier) Hash(h hash.Hash32) (err error) {
 func (i SingleTenantTSDBIdentifier) str() string {
 	return fmt.Sprintf(
 		"%d-%s-%d-%d-%x.tsdb",
-		i.TS.Unix(),
+		i.TS.UnixNano(),
 		compactedFileUploader,
 		i.From,
 		i.Through,
@@ -109,7 +109,7 @@ func ParseSingleTenantTSDBPath(p string) (id SingleTenantTSDBIdentifier, ok bool
 		return
 	}
 
-	ts, err := strconv.Atoi(elems[0])
+	ts, err := strconv.ParseInt(elems[0], 10, 64)
 	if err != nil {
 		return
 	}
@@ -133,8 +133,14 @@ func ParseSingleTenantTSDBPath(p string) (id SingleTenantTSDBIdentifier, ok bool
 		return
 	}
 
+	var parsedTS time.Time
+	if len(elems[0]) <= 10 {
+		parsedTS = time.Unix(ts, 0)
+	} else {
+		parsedTS = time.Unix(0, ts)
+	}
 	return SingleTenantTSDBIdentifier{
-		TS:       time.Unix(int64(ts), 0),
+		TS:       parsedTS,
 		From:     model.Time(from),
 		Through:  model.Time(through),
 		Checksum: uint32(checksum),

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/identifier_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/identifier_test.go
@@ -28,6 +28,17 @@ func TestParseSingleTenantTSDBPath(t *testing.T) {
 			ok: true,
 		},
 		{
+			desc:  "simple_works_with_nanosecond",
+			input: "1712534400000000000-compactor-1-10-ff.tsdb",
+			id: SingleTenantTSDBIdentifier{
+				TS:       time.Unix(0, 1712534400000000000),
+				From:     1,
+				Through:  10,
+				Checksum: 255,
+			},
+			ok: true,
+		},
+		{
 			desc:  "uint32_max_checksum_works",
 			input: fmt.Sprintf("1-compactor-1-10-%x.tsdb", math.MaxUint32),
 			id: SingleTenantTSDBIdentifier{


### PR DESCRIPTION
**What this PR does / why we need it**:
Do the same changes as PR #11277, i.e., have a creation timestamp in compacted index files with nanosecond precision instead of seconds. I had only made that change for `boltdb-shipper` and skipped changing `tsdb` since `tsdb` index file names have checksums in them. However, as seen in issue #12500, we can hit the bug if compaction happens twice in the same unix second, and it ends up having the same contents in the compacted index(hence the same checksum as well).

**Which issue(s) this PR fixes**:
Fixes #12500 

**Checklist**
- [x] Tests updated