### PR TITLE
docs: Attempt to fix whatever broke the docs builds

### DIFF
--- a/docs/sources/get-started/labels/structured-metadata.md
+++ b/docs/sources/get-started/labels/structured-metadata.md
@@ -6,7 +6,7 @@ description: Describes how to enable structure metadata for logs and how to quer
 # What is structured metadata
 
 {{% admonition type="warning" %}}
-Structured metadata was added to chunk format V4 which is used if the schema version is greater or equal to `13`. (See [Schema Config]({{< relref "../../storage#schema-config" >}}) for more details about schema versions. )
+Structured metadata was added to chunk format V4 which is used if the schema version is greater or equal to `13`. See [Schema Config](https://grafana.com/docs/loki/latest/configure/storage/#schema-config) for more details about schema versions.
 {{% /admonition %}}
 
 Selecting proper, low cardinality labels is critical to operating and querying Loki effectively. Some metadata, especially infrastructure related metadata, can be difficult to embed in log lines, and is too high cardinality to effectively store as indexed labels (and therefore reducing performance of the index).
@@ -29,12 +29,12 @@ It is an antipattern to extract information that already exists in your log line
 ## Attaching structured metadata to log lines
 
 You have the option to attach structured metadata to log lines in the push payload along with each log line and the timestamp.
-For more information on how to push logs to Loki via the HTTP endpoint, refer to the [HTTP API documentation]({{< relref "../../reference/api#ingest-logs" >}}).
+For more information on how to push logs to Loki via the HTTP endpoint, refer to the [HTTP API documentation](https://grafana.com/docs/loki/latest/reference/api/#ingest-logs).
 
 Alternatively, you can use the Grafana Agent or Promtail to extract and attach structured metadata to your log lines.
-See the [Promtail: Structured metadata stage]({{< relref "../../send-data/promtail/stages/structured_metadata" >}}) for more information.
+See the [Promtail: Structured metadata stage](https://grafana.com/docs/loki/latest/send-data/promtail/stages/structured_metadata/) for more information.
 
-With Loki version 1.2.0, support for structured metadata has been added to the Logstash output plugin. For more information, see [logstash]({{< relref "../../send-data/logstash/_index.md" >}}).
+With Loki version 1.2.0, support for structured metadata has been added to the Logstash output plugin. For more information, see [logstash](https://grafana.com/docs/loki/latest/send-data/logstash/).
 
 {{% admonition type="warning" %}}
 There are defaults for how much structured metadata can be attached per log line.
@@ -52,7 +52,7 @@ There are defaults for how much structured metadata can be attached per log line
 ## Querying structured metadata
 
 Structured metadata is extracted automatically for each returned log line and added to the labels returned for the query.
-You can use labels of structured metadata to filter log line using a [label filter expression]({{< relref "../../query/log_queries#label-filter-expression" >}}).
+You can use labels of structured metadata to filter log line using a [label filter expression](https://grafana.com/docs/loki/latest/query/log_queries/#label-filter-expression).
 
 For example, if you have a label `pod` attached to some of your log lines as structured metadata, you can filter log lines using:
 
@@ -66,7 +66,7 @@ Of course, you can filter by multiple labels of structured metadata at the same 
 {job="example"} | pod="myservice-abc1234-56789" | trace_id="0242ac120002"
 ```
 
-Note that since structured metadata is extracted automatically to the results labels, some metric queries might return an error like `maximum of series (50000) reached for a single query`. You can use the [Keep]({{< relref "../../query/log_queries#keep-labels-expression" >}}) and [Drop]({{< relref "../../query/log_queries#drop-labels-expression" >}}) stages to filter out labels that you don't need.
+Note that since structured metadata is extracted automatically to the results labels, some metric queries might return an error like `maximum of series (50000) reached for a single query`. You can use the [Keep](https://grafana.com/docs/loki/latest/query/log_queries/#keep-labels-expression) and [Drop](https://grafana.com/docs/loki/latest/query/log_queries/#drop-labels-expression) stages to filter out labels that you don't need.
 For example:
 
 ```logql

--- a/docs/sources/operations/storage/retention.md
+++ b/docs/sources/operations/storage/retention.md
@@ -16,7 +16,7 @@ If you have a lifecycle policy configured on the object store, please ensure tha
 Granular retention policies to apply retention at per tenant or per stream level are also supported by the Compactor.
 
 {{% admonition type="note" %}}
-The Compactor does not support retention on [legacy index types]({{< relref "../../storage#index-storage" >}}). Please use the [Table Manager]({{< relref "./table-manager" >}}) when using legacy index types.
+The Compactor does not support retention on [legacy index types](https://grafana.com/docs/loki/latest/configure/storage/#index-storage). Please use the [Table Manager](https://grafana.com/docs/loki/latest/operations/storage/table-manager/) when using legacy index types.
 Both the Table manager and legacy index types are deprecated and may be removed in future major versions of Loki.
 {{% /admonition %}}
 
@@ -50,7 +50,7 @@ Chunks cannot be deleted immediately for the following reasons:
 
 Marker files should be stored on a persistent disk to ensure that the chunks pending for deletion are processed even if the Compactor process restarts.
 {{% admonition type="note" %}}
-We recommend running Compactor as a stateful deployment (StatefulSet when using Kubernetes) with a persistent storage for storing marker files.
+Grafana Labs recommends running Compactor as a stateful deployment (StatefulSet when using Kubernetes) with a persistent storage for storing marker files.
 {{% /admonition %}}
 
 ### Retention Configuration
@@ -100,7 +100,7 @@ Retention is only available if the index period is 24h. Single store TSDB and si
 
 #### Configuring the retention period
 
-Retention period is configured within the [`limits_config`]({{< relref "../../configure#limits_config" >}}) configuration section.
+Retention period is configured within the [`limits_config`](https://grafana.com/docs/loki/latest/configure/#limits_config) configuration section.
 
 There are two ways of setting retention policies:
 
@@ -129,7 +129,7 @@ limits_config:
 You can only use label matchers in the `selector` field of a `retention_stream` definition. Arbitrary LogQL expressions are not supported.
 {{% /admonition %}}
 
-Per tenant retention can be defined by configuring [runtime overrides]({{< relref "../../configure#runtime-configuration-file" >}}). For example:
+Per tenant retention can be defined by configuring [runtime overrides](https://grafana.com/docs/loki/latest/configure/#runtime-configuration-file). For example:
 
 ```yaml
 overrides:
@@ -181,13 +181,13 @@ The example configurations defined above will result in the following retention 
 
 ## Table Manager (deprecated)
 
-Retention through the [Table Manager]({{< relref "./table-manager" >}}) is
+Retention through the [Table Manager](https://grafana.com/docs/loki/latest/operations/storage/table-manager/) is
 achieved by relying on the object store TTL feature, and will work for both
-[boltdb-shipper]({{< relref "./boltdb-shipper" >}}) store and chunk/index stores.
+[boltdb-shipper](https://grafana.com/docs/loki/latest/operations/storage/boltdb-shipper/) store and chunk/index stores.
 
 In order to enable the retention support, the Table Manager needs to be
 configured to enable deletions and a retention period. Please refer to the
-[`table_manager`]({{< relref "../../configure#table_manager" >}})
+[`table_manager`](https://grafana.com/docs/loki/latest/configure/#table_manager)
 section of the Loki configuration reference for all available options.
 Alternatively, the `table-manager.retention-period` and
 `table-manager.retention-deletes-enabled` command line flags can be used. The
@@ -196,15 +196,13 @@ can be parsed using the Prometheus common model [ParseDuration](https://pkg.go.d
 
 {{% admonition type="warning" %}}
 The retention period must be a multiple of the index and chunks table
-`period`, configured in the [`period_config`]({{< relref "../../configure#period_config" >}})
-block. See the [Table Manager]({{< relref "./table-manager#retention" >}}) documentation for
+`period`, configured in the [`period_config`](https://grafana.com/docs/loki/latest/configure/#period_config) block.
+See the [Table Manager](https://grafana.com/docs/loki/latest/operations/storage/table-manager/#retention) documentation for
 more information.
 {{% /admonition %}}
 
 {{% admonition type="note" %}}
-To avoid querying of data beyond the retention period,
-`max_query_lookback` config in [`limits_config`]({{< relref "../../configure#limits_config" >}}) must be set to a value less than or equal to
-what is set in `table_manager.retention_period`.
+To avoid querying of data beyond the retention period,`max_query_lookback` config in [`limits_config`](https://grafana.com/docs/loki/latest/configure/#limits_config) must be set to a value less than or equal to what is set in `table_manager.retention_period`.
 {{% /admonition %}}
 
 When using S3 or GCS, the bucket storing the chunks needs to have the expiry
@@ -225,7 +223,7 @@ intact; you will still be able to see related labels but will be unable to
 retrieve the deleted log content.
 
 For further details on the Table Manager internals, refer to the
-[Table Manager]({{< relref "./table-manager" >}}) documentation.
+[Table Manager](https://grafana.com/docs/loki/latest/operations/storage/table-manager/) documentation.
 
 
 ## Example Configuration


### PR DESCRIPTION
**What this PR does / why we need it**:
 Something in PR #12478 broke the docs publication workflow.  The error messages on the action aren't particularly helpful, but these are the two files that were throwing errors when I attempted a local build. My current assumption is that there were either typos in the XREFs or broken links in that PR, so I've replaced all the relrefs in these two files with full URLs, which are now supported.