### PR TITLE
docs: Update Release Notes page wweights

### DIFF
--- a/docs/sources/release-notes/v2-9.md
+++ b/docs/sources/release-notes/v2-9.md
@@ -1,7 +1,7 @@
 ---
 title: V2.9
 description: Version 2.9 release notes
-weight: 55
+weight: 50
 ---
 
 # V2.9


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes the page weights so that Release Notes versions 2.8 and 2.9 appear in the correct order.
![PageWeights](https://github.com/grafana/loki/assets/4106682/72f1470d-4383-4b25-8646-5a329b95dc97)
