### PR TITLE
docs: fix up storage page front matter

### DIFF
--- a/docs/sources/configure/storage.md
+++ b/docs/sources/configure/storage.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - ../storage/ # /docs/loki/latest/storage/
 title: Storage
 description: Describes Loki storage.
 weight: 475

--- a/docs/sources/operations/storage/_index.md
+++ b/docs/sources/operations/storage/_index.md
@@ -2,7 +2,6 @@
 title: Manage storage
 menuTitle: Storage
 description: Describes Loki's storage needs and supported stores.
-weight: 
 ---
 # Manage storage
 


### PR DESCRIPTION
- Remove null weight
- Add alias to redirect page moved in https://github.com/grafana/loki/commit/3634ff4d6497ef369e003cb49fefac0faa0f7359#diff-a237ac9bc307f92382f99ae669a146e1ae9a4b0a34758c9f52a7b53da52946e1.

**What this PR does / why we need it**:

As reported in https://raintank-corp.slack.com/archives/C045X9GRT7S/p1712630378148329.
The page was moved but no redirect was put in place so the Google index is currently broken and so are links from blog posts.

**Special notes for your reviewer**:

Likely needs backport to the Loki 3 release branch.
