### PR TITLE
Update publishing workflows

### DIFF
--- a/.github/workflows/doc-validator.yml
+++ b/.github/workflows/doc-validator.yml
@@ -7,10 +7,10 @@ jobs:
   doc-validator:
     runs-on: "ubuntu-latest"
     container:
-      image: "grafana/doc-validator:v4.0.0"
+      image: "grafana/doc-validator:v5.0.0"
     steps:
       - name: "Checkout code"
-        uses: "actions/checkout@v3"
+        uses: "actions/checkout@v4"
         with:
           fetch-depth: 0
       - name: "Run doc-validator"

--- a/.github/workflows/publish-technical-documentation-next.yml
+++ b/.github/workflows/publish-technical-documentation-next.yml
@@ -8,24 +8,12 @@ on:
       - "docs/sources/**"
   workflow_dispatch:
 jobs:
-  test:
-    runs-on: "ubuntu-latest"
-    steps:
-      - name: "Check out code"
-        uses: "actions/checkout@v3"
-      - name: "Build website"
-        # -e HUGO_REFLINKSERRORLEVEL=ERROR prevents merging broken refs with the downside
-        # that no refs to external content can be used as these refs will not resolve in the
-        # docs-base image.
-        run: |
-          docker run -v ${PWD}/docs/sources:/hugo/content/docs/loki/next -e HUGO_REFLINKSERRORLEVEL=ERROR --rm grafana/docs-base:latest /bin/bash -c 'make hugo'
-
   sync:
     runs-on: "ubuntu-latest"
     needs: "test"
     steps:
       - name: "Check out code"
-        uses: "actions/checkout@v3"
+        uses: "actions/checkout@v4"
 
       - name: "Clone website-sync Action"
         # WEBSITE_SYNC_TOKEN is a fine-grained GitHub Personal Access Token that expires.

--- a/.github/workflows/publish-technical-documentation-release.yml
+++ b/.github/workflows/publish-technical-documentation-release.yml
@@ -10,30 +10,17 @@ on:
       - "docs/sources/**"
   workflow_dispatch:
 jobs:
-  test:
-    runs-on: "ubuntu-latest"
-    steps:
-      - name: "Check out code"
-        uses: "actions/checkout@v3"
-      - name:
-          "Build website"
-          # -e HUGO_REFLINKSERRORLEVEL=ERROR prevents merging broken refs with the downside
-          # that no refs to external content can be used as these refs will not resolve in the
-          # docs-base image.
-        run: |
-          docker run -v ${PWD}/docs/sources:/hugo/content/docs/loki/release -e HUGO_REFLINKSERRORLEVEL=ERROR --rm grafana/docs-base:latest /bin/bash -c 'make hugo'
-
   sync:
     runs-on: "ubuntu-latest"
     needs: "test"
     steps:
       - name: "Checkout code and tags"
-        uses: "actions/checkout@v3"
+        uses: "actions/checkout@v4"
         with:
           fetch-depth: 0
 
       - name: "Checkout Actions library"
-        uses: "actions/checkout@v3"
+        uses: "actions/checkout@v4"
         with:
           repository: "grafana/grafana-github-actions"
           path: "./actions"


### PR DESCRIPTION
- Don't block publishing on `relref` Hugo build errors.

  The use of the shortcode is deprecated in favor of the guidance in https://grafana.com/docs/writers-toolkit/write/links/#link-to-grafanacom-pages.
  Additionally, the repository CI isn't checking this so the failure is only caught after merging a PR and not before.

- Update the checkout action version.

Also:

- [Update doc-validator workflow to latest release](https://github.com/grafana/loki/commit/8a634eadb35210c9a32e32a355103b3ec04df21b) 

  Add support for `ref` URIs documented in https://grafana.com/docs/writers-toolkit/write/links/#link-from-source-content-thats-used-in-multiple-projects.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>

**Which issue(s) this PR fixes**:
Fixes publishing workflows being blocked on `relref` Hugo build errors