### PR TITLE
fix(blooms): Fix findGaps when ownership goes to MaxUInt64 and that is covered by existing meta

### DIFF
--- a/pkg/bloomcompactor/controller.go
+++ b/pkg/bloomcompactor/controller.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"math"
 	"sort"
 	"sync"
 
@@ -735,7 +736,11 @@ func findGaps(ownershipRange v1.FingerprintBounds, metas []v1.FingerprintBounds)
 
 		searchRange := ownershipRange.Slice(leftBound, clippedMeta.Max)
 		// update the left bound for the next iteration
-		leftBound = min(clippedMeta.Max+1, ownershipRange.Max+1)
+		// We do the max to prevent the max bound to overflow from MaxUInt64 to 0
+		leftBound = min(
+			max(clippedMeta.Max+1, clippedMeta.Max),
+			max(ownershipRange.Max+1, ownershipRange.Max),
+		)
 
 		// since we've already ensured that the meta is within the ownership range,
 		// we know the xor will be of length zero (when the meta is equal to the ownership range)
@@ -750,8 +755,11 @@ func findGaps(ownershipRange v1.FingerprintBounds, metas []v1.FingerprintBounds)
 		gaps = append(gaps, xors[0])
 	}
 
-	if leftBound <= ownershipRange.Max {
-		// There is a gap between the last meta and the end of the ownership range.
+	// If the leftBound is less than the ownership range max, and it's smaller than MaxUInt64,
+	// There is a gap between the last meta and the end of the ownership range.
+	// Note: we check `leftBound < math.MaxUint64` since in the loop above we clamp the
+	// leftBound to MaxUint64 to prevent an overflow to 0: `max(clippedMeta.Max+1, clippedMeta.Max)`
+	if leftBound < math.MaxUint64 && leftBound <= ownershipRange.Max {
 		gaps = append(gaps, v1.NewBounds(leftBound, ownershipRange.Max))
 	}
 

--- a/pkg/bloomcompactor/controller_test.go
+++ b/pkg/bloomcompactor/controller_test.go
@@ -2,6 +2,7 @@ package bloomcompactor
 
 import (
 	"fmt"
+	"math"
 	"testing"
 	"time"
 
@@ -101,6 +102,27 @@ func Test_findGaps(t *testing.T) {
 			metas: []v1.FingerprintBounds{
 				v1.NewBounds(3, 5),
 				v1.NewBounds(6, 7),
+			},
+		},
+		{
+			desc:           "full ownership range with single meta",
+			err:            false,
+			exp:            nil,
+			ownershipRange: v1.NewBounds(0, math.MaxUint64),
+			metas: []v1.FingerprintBounds{
+				v1.NewBounds(0, math.MaxUint64),
+			},
+		},
+		{
+			desc:           "full ownership range with multiple metas",
+			err:            false,
+			exp:            nil,
+			ownershipRange: v1.NewBounds(0, math.MaxUint64),
+			// Three metas covering the whole 0 - MaxUint64
+			metas: []v1.FingerprintBounds{
+				v1.NewBounds(0, math.MaxUint64/3),
+				v1.NewBounds(math.MaxUint64/3+1, math.MaxUint64/2),
+				v1.NewBounds(math.MaxUint64/2+1, math.MaxUint64),
 			},
 		},
 	} {


### PR DESCRIPTION
**What this PR does / why we need it**:

If a meta and ownership tange covers till the end of the FP key-space (MaxUInt64), the current implementation of `findGaps` overflows and the keyspace covered by that meta is misreported as a gap:
https://github.com/grafana/loki/blob/4c88be0ef2310406206c02d7747bf73b51c95bda/pkg/bloomcompactor/controller.go#L738

In more detail:
https://github.com/grafana/loki/blob/4c88be0ef2310406206c02d7747bf73b51c95bda/pkg/bloomcompactor/controller.go#L738-L756

If we only have one meta spanning the whole keyspace:
- `leftBound = min(clippedMeta.Max+1, ownershipRange.Max+1)` Here clippedMeta.Max is MaxUint64 so +1 makes this 0
- `if len(xors) == 0 {` is true so we end the loop
- `if leftBound <= ownershipRange.Max {` since `leftBound` is 0 we get inside here and add the gap.

This PR fixes this by taking care of the overflows.

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/loki/issues/12499

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
