### PR TITLE
docs: update release notes for 2.9.7

### DIFF
--- a/docs/sources/release-notes/v2-9.md
+++ b/docs/sources/release-notes/v2-9.md
@@ -11,19 +11,19 @@ Grafana Labs is excited to announce the release of Loki 2.9.0 Here's a summary o
 
 - **Structured metadata**: The [Structured Metadata](https://grafana.com/docs/loki/<LOKI_VERSION>/get-started/labels/structured-metadata/) feature, which was introduced as experimental in release 2.9.0, is generally available as of release 2.9.4.
 
--  **Query Language Improvements**: Several improvements to the query language that speed up line parsing and regex matching. [PR #8646](https://github.com/grafana/loki/pull/8646), [PR #8659](https://github.com/grafana/loki/pull/8659), [PR #8724](https://github.com/grafana/loki/pull/8724), [PR #8734](https://github.com/grafana/loki/pull/8734), [PR #8739](https://github.com/grafana/loki/pull/8739), [PR #8763](https://github.com/grafana/loki/pull/8763), [PR #8890](https://github.com/grafana/loki/pull/8890), [PR #8914](https://github.com/grafana/loki/pull/8914)
+- **Query Language Improvements**: Several improvements to the query language that speed up line parsing and regex matching. [PR #8646](https://github.com/grafana/loki/pull/8646), [PR #8659](https://github.com/grafana/loki/pull/8659), [PR #8724](https://github.com/grafana/loki/pull/8724), [PR #8734](https://github.com/grafana/loki/pull/8734), [PR #8739](https://github.com/grafana/loki/pull/8739), [PR #8763](https://github.com/grafana/loki/pull/8763), [PR #8890](https://github.com/grafana/loki/pull/8890), [PR #8914](https://github.com/grafana/loki/pull/8914)
 
--  **Remote rule evaluation**: Rule evaluation can now be handled by queriers to improve speed. [PR #8744](https://github.com/grafana/loki/pull/8744) [PR #8848](https://github.com/grafana/loki/pull/8848)
+- **Remote rule evaluation**: Rule evaluation can now be handled by queriers to improve speed. [PR #8744](https://github.com/grafana/loki/pull/8744) [PR #8848](https://github.com/grafana/loki/pull/8848)
 
--  **Multi-store Index support**: Loki now supports reading/writing indexes to multiple object stores which enables the use of different storage buckets across periods for storing index. [PR #7754](https://github.com/grafana/loki/pull/7754), [PR #7447](https://github.com/grafana/loki/pull/7447)
+- **Multi-store Index support**: Loki now supports reading/writing indexes to multiple object stores which enables the use of different storage buckets across periods for storing index. [PR #7754](https://github.com/grafana/loki/pull/7754), [PR #7447](https://github.com/grafana/loki/pull/7447)
 
--  **New volume and volume_range endpoints**: Two new endoints, `index/volume` and `index/volume_range`, have been added to Loki. They return aggregate volume information from the TSDB index for all streams matching a provided stream selector. This feature was introduced via multiple PRs, including [PR #9988](https://github.com/grafana/loki/pull/9988), [PR #9966](https://github.com/grafana/loki/pull/9966), [PR #9833](https://github.com/grafana/loki/pull/9833), [PR #9832](https://github.com/grafana/loki/pull/9832), [PR #9776](https://github.com/grafana/loki/pull/9776), [PR #9762](https://github.com/grafana/loki/pull/9762), [PR #9704](https://github.com/grafana/loki/pull/9704), [PR #10248](https://github.com/grafana/loki/pull/10248), [PR #10099](https://github.com/grafana/loki/pull/10099), [PR #10076](https://github.com/grafana/loki/pull/10076), [PR #10047](https://github.com/grafana/loki/pull/10047) and [PR #10045](https://github.com/grafana/loki/pull/10045)
+- **New volume and volume_range endpoints**: Two new endoints, `index/volume` and `index/volume_range`, have been added to Loki. They return aggregate volume information from the TSDB index for all streams matching a provided stream selector. This feature was introduced via multiple PRs, including [PR #9988](https://github.com/grafana/loki/pull/9988), [PR #9966](https://github.com/grafana/loki/pull/9966), [PR #9833](https://github.com/grafana/loki/pull/9833), [PR #9832](https://github.com/grafana/loki/pull/9832), [PR #9776](https://github.com/grafana/loki/pull/9776), [PR #9762](https://github.com/grafana/loki/pull/9762), [PR #9704](https://github.com/grafana/loki/pull/9704), [PR #10248](https://github.com/grafana/loki/pull/10248), [PR #10099](https://github.com/grafana/loki/pull/10099), [PR #10076](https://github.com/grafana/loki/pull/10076), [PR #10047](https://github.com/grafana/loki/pull/10047) and [PR #10045](https://github.com/grafana/loki/pull/10045)
 
--  **New Storage Client**: Add support for IBM cloud object storage as storage client. [PR #8826](https://github.com/grafana/loki/pull/8826)
+- **New Storage Client**: Add support for IBM cloud object storage as storage client. [PR #8826](https://github.com/grafana/loki/pull/8826)
 
--  **Block queries by hash**: Queries can now be blocked by a query hash. [PR #8953](https://github.com/grafana/loki/pull/8953)
+- **Block queries by hash**: Queries can now be blocked by a query hash. [PR #8953](https://github.com/grafana/loki/pull/8953)
 
--  **logfmt stage improvements**: logfmt parser now performs non-strict parsing by default which helps scan semi-structured log lines. [PR #9626](https://github.com/grafana/loki/pull/9626)
+- **logfmt stage improvements**: logfmt parser now performs non-strict parsing by default which helps scan semi-structured log lines. [PR #9626](https://github.com/grafana/loki/pull/9626)
 
 - **Deprecations**
   - Legacy index and chunk stores that are not "single store" (such as `tsdb`, `boltdb-shipper`) are deprecated. These storage backends are Cassandra (`cassandra`), DynamoDB (`aws`, `aws-dynamo`), BigTable (`bigtable`, `bigtable-hashed`), GCP (`gcp`, `gcp-columnkey`), and gRPC (`grpc`). See https://grafana.com/docs/loki/<LOKI_VERSION>/configure/storage.md for more information.
@@ -34,17 +34,21 @@ Grafana Labs is excited to announce the release of Loki 2.9.0 Here's a summary o
 
 ## Bug fixes
 
+### 2.9.7 (2024-04-10)
+
+- Bump go to 1.21.9 and build image to 0.33.1 (#12542) (efc4d2f)
+
 ### 2.9.6 (2024-03-21)
 
-* Fixed Promtail failures connecting to local Loki installation ([#12184](https://github.com/grafana/loki/issues/12184)) ([8585e35](https://github.com/grafana/loki/commit/8585e3537375c0deb11462d7256f5da23228f5e1)).
-* Fixed an issue when using IPv6 where IPv6 addresses were not properly joined with ports. Use `net.JoinHostPort` to support IPv6 addresses. ([#10650](https://github.com/grafana/loki/issues/10650)) ([#11870](https://github.com/grafana/loki/issues/11870)) ([7def3b4](https://github.com/grafana/loki/commit/7def3b4e774252e13ba154ca13f72816a84da7dd)).
-* Updated google.golang.org/protobuf to v1.33.0 ([#12269](https://github.com/grafana/loki/issues/12269)) ([#12287](https://github.com/grafana/loki/issues/12287)) ([3186520](https://github.com/grafana/loki/commit/318652035059fdaa40405f263fc9e37b4d38b157)).
+- Fixed Promtail failures connecting to local Loki installation ([#12184](https://github.com/grafana/loki/issues/12184)) ([8585e35](https://github.com/grafana/loki/commit/8585e3537375c0deb11462d7256f5da23228f5e1)).
+- Fixed an issue when using IPv6 where IPv6 addresses were not properly joined with ports. Use `net.JoinHostPort` to support IPv6 addresses. ([#10650](https://github.com/grafana/loki/issues/10650)) ([#11870](https://github.com/grafana/loki/issues/11870)) ([7def3b4](https://github.com/grafana/loki/commit/7def3b4e774252e13ba154ca13f72816a84da7dd)).
+- Updated google.golang.org/protobuf to v1.33.0 ([#12269](https://github.com/grafana/loki/issues/12269)) ([#12287](https://github.com/grafana/loki/issues/12287)) ([3186520](https://github.com/grafana/loki/commit/318652035059fdaa40405f263fc9e37b4d38b157)).
 
 For a full list of all changes and fixes, refer to the [CHANGELOG](https://github.com/grafana/loki/blob/release-2.9.x/CHANGELOG.md).
 
 ### 2.9.5 (2024-02-28)
 
-* Bumped base images and Go dependencies to address CVEs ([#12092](https://github.com/grafana/loki/issues/12092)) ([eee3598](https://github.com/grafana/loki/commit/eee35983f38fe04543b169ffa8ece76c23c4217b)).
+- Bumped base images and Go dependencies to address CVEs ([#12092](https://github.com/grafana/loki/issues/12092)) ([eee3598](https://github.com/grafana/loki/commit/eee35983f38fe04543b169ffa8ece76c23c4217b)).
 
 For a full list of all changes and fixes, refer to the [CHANGELOG](https://github.com/grafana/loki/blob/release-2.9.x/CHANGELOG.md).
 
@@ -61,21 +65,21 @@ For a full list of all changes and fixes, refer to the [CHANGELOG](https://githu
 
 ### 2.9.3 (2023-12-11)
 
-* Upgraded otelhttp from 0.40.0 -> 0.44.0 and base alpine image from 3.18.3 -> 3.18.5 to fix a few CVES (CVE-2023-45142, CVE-2022-21698, CVE-2023-5363).
-* Fixed querying ingester for label values with a matcher (previously didn't respect the matcher).
-* Ensured all lifecycler cfgs ref a valid IPv6 addr and port combination.
+- Upgraded otelhttp from 0.40.0 -> 0.44.0 and base alpine image from 3.18.3 -> 3.18.5 to fix a few CVES (CVE-2023-45142, CVE-2022-21698, CVE-2023-5363).
+- Fixed querying ingester for label values with a matcher (previously didn't respect the matcher).
+- Ensured all lifecycler cfgs ref a valid IPv6 addr and port combination.
 
 For a full list of all changes and fixes, refer to the [CHANGELOG](https://github.com/grafana/loki/blob/release-2.9.x/CHANGELOG.md).
 
 ### 2.9.2 (2023-10-16)
 
-* Upgraded go to v1.21.3, golang.org/x/net to v0.17.0 and grpc-go to v1.56.3 to patch CVE-2023-39325 / CVE-2023-44487
+- Upgraded go to v1.21.3, golang.org/x/net to v0.17.0 and grpc-go to v1.56.3 to patch CVE-2023-39325 / CVE-2023-44487
 
 For a full list of all changes and fixes, refer to the [CHANGELOG](https://github.com/grafana/loki/blob/release-2.9.x/CHANGELOG.md).
 
 ### 2.9.1 (2023-09-14)
 
-* Updated Docker base images to mitigate security vulnerability CVE-2022-48174
-* Fixed bugs in indexshipper (`tsdb`, `boltdb-shipper`) that could result in not showing all ingested logs in query results.
+- Updated Docker base images to mitigate security vulnerability CVE-2022-48174
+- Fixed bugs in indexshipper (`tsdb`, `boltdb-shipper`) that could result in not showing all ingested logs in query results.
 
 For a full list of all changes and fixes, refer to the [CHANGELOG](https://github.com/grafana/loki/blob/release-2.9.x/CHANGELOG.md).


### PR DESCRIPTION
**What this PR does / why we need it**:
 Updates the Release Notes for the 2.9.7 Release and fixes some bullet formatting.