### PR TITLE
chore: helm: Add headless service to bloom-gateway

### DIFF
--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -13,8 +13,17 @@ Entries should include a reference to the pull request that introduced the chang
 
 [//]: # (<AUTOMATED_UPDATES_LOCATOR> : do not remove this line. This locator is used by the CI pipeline to automatically create a changelog entry for each new Loki release. Add other chart versions and respective changelog entries bellow this line.)
 
+## 6.2.0
+
+- [FEATURE] Add a headless service to the bloom gateway component.
+
+## 6.1.0
+
+- [CHANGE] Only default bucket names in helm when using minio.
+
 ## 6.0.0
 
+- [FEATURE] added a new `Distributed` mode of deployment.
 - [CHANGE] the lokiCanary section was moved from under monitoring to be under the root of the file.
 - [CHANGE] the definitions for topologySpreadConstraints and podAffinity were converted from string templates to objects. Also removed the soft constraint on zone.
 - [CHANGE] the externalConfigSecretName was replaced with more generic configs

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -3,7 +3,7 @@ name: loki
 description: Helm chart for Grafana Loki in simple, scalable mode
 type: application
 appVersion: 3.0.0
-version: 6.1.0
+version: 6.2.0
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -1,6 +1,6 @@
 # loki
 
-![Version: 6.1.0](https://img.shields.io/badge/Version-6.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.0.0](https://img.shields.io/badge/AppVersion-3.0.0-informational?style=flat-square)
+![Version: 6.2.0](https://img.shields.io/badge/Version-6.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.0.0](https://img.shields.io/badge/AppVersion-3.0.0-informational?style=flat-square)
 
 Helm chart for Grafana Loki in simple, scalable mode
 

--- a/production/helm/loki/templates/bloom-gateway/service-bloom-gateway-headless.yaml
+++ b/production/helm/loki/templates/bloom-gateway/service-bloom-gateway-headless.yaml
@@ -1,0 +1,36 @@
+{{- $isDistributed := eq (include "loki.deployment.isDistributed" .) "true" -}}
+{{- if $isDistributed -}}
+{{- if (gt (int .Values.bloomGateway.replicas) 0) -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "loki.bloomGatewayFullname" . }}-headless
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "loki.bloomGatewaySelectorLabels" . | nindent 4 }}
+    {{- with .Values.bloomGateway.serviceLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.loki.serviceAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: http-metrics
+      port: 3100
+      targetPort: http-metrics
+      protocol: TCP
+    - name: grpc
+      port: 9095
+      targetPort: grpc
+      protocol: TCP
+      {{- if .Values.bloomGateway.appProtocol.grpc }}
+      appProtocol: {{ .Values.bloomGateway.appProtocol.grpc }}
+      {{- end }}
+  selector:
+    {{- include "loki.bloomGatewaySelectorLabels" . | nindent 4 }}
+{{- end -}}
+{{- end -}}


### PR DESCRIPTION
**What this PR does / why we need it**:
Add a headless service to bloom-gateway.
you can then configure the bloom-gateway client to use it the following way:
```
bloom_gateway:
  client:
    addresses: dnssrv+_bloom-gateway-grpc._tcp.bloom-gateway-headless.my-namespace.svc.cluster.local.
```