### PR TITLE
chore: allow make docs to be run in container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -801,7 +801,13 @@ check-format: format
 # Documentation related commands
 
 doc: ## Generates the config file documentation
+ifeq ($(BUILD_IN_CONTAINER),true)
+	$(SUDO) docker run $(RM) $(TTY) -i \
+		-v $(shell pwd):/src/loki$(MOUNT_FLAGS) \
+		$(IMAGE_PREFIX)/loki-build-image:$(BUILD_IMAGE_VERSION) $@;
+else
 	go run ./tools/doc-generator $(DOC_FLAGS_TEMPLATE) > $(DOC_FLAGS)
+endif
 
 docs: doc
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Making docs appears to be sensitive to the go version (different versions cause the ciphers to change), so this allows the `make docs` target to be run with `BUILD_IN_CONTAINER=true` so everyone can use the same version.