### PR TITLE
docs: Update 3.0 Release Notes

### DIFF
--- a/docs/sources/release-notes/_index.md
+++ b/docs/sources/release-notes/_index.md
@@ -8,12 +8,13 @@ weight: 100
 Release notes for Loki are in the CHANGELOG for the release and
 listed here by version number.
 
-- [V2.9 release notes]({{< relref "./v2-9" >}})
-- [V2.8 release notes]({{< relref "./v2-8" >}})
-- [V2.7 release notes]({{< relref "./v2-7" >}})
-- [V2.6 release notes]({{< relref "./v2-6" >}})
-- [V2.5 release notes]({{< relref "./v2-5" >}})
-- [V2.4 release notes]({{< relref "./v2-4" >}})
-- [V2.3 release notes]({{< relref "./v2-3" >}})
+- [V3.0 release notes](https://grafana.com/docs/loki/<LOKI_VERSION>/release-notes/v3.0/)
+- [V2.9 release notes](https://grafana.com/docs/loki/<LOKI_VERSION>/release-notes/v2-9/)
+- [V2.8 release notes](https://grafana.com/docs/loki/<LOKI_VERSION>/release-notes/v2-8/)
+- [V2.7 release notes](https://grafana.com/docs/loki/<LOKI_VERSION>/release-notes/v2-7/)
+- [V2.6 release notes](https://grafana.com/docs/loki/<LOKI_VERSION>/release-notes/v2-6/)
+- [V2.5 release notes](https://grafana.com/docs/loki/<LOKI_VERSION>/release-notes/v2-5/)
+- [V2.4 release notes](https://grafana.com/docs/loki/<LOKI_VERSION>/release-notes/v2-4/)
+- [V2.3 release notes](https://grafana.com/docs/loki/<LOKI_VERSION>/release-notes/v2-3/)
 
-The details about our release cadence are documented [here]({{< relref "./cadence" >}}).
+The details about our release cadence are documented [here](https://grafana.com/docs/loki/<LOKI_VERSION>/release-notes/cadence/).

--- a/docs/sources/release-notes/v3.0.md
+++ b/docs/sources/release-notes/v3.0.md
@@ -1,6 +1,6 @@
 ---
 title: v3.0
-description:  Version 3.0 release notes.
+description: Version 3.0 release notes.
 weight: 30
 ---
 
@@ -8,9 +8,13 @@ weight: 30
 
 Grafana Labs and the Loki team are excited to announce the release of Loki 3.0. Here's a summary of new enhancements and important fixes.
 
-For a full list of all changes and fixes, refer to the [CHANGELOG](https://github.com/grafana/loki/blob/release-3.0.0-rc1/CHANGELOG.md).
+For a full list of all changes and fixes, refer to the [CHANGELOG](https://github.com/grafana/loki/blob/release-3.0.x/CHANGELOG.md).
 
 ## Features and enhancements
+
+{{< admonition type="note" >}}
+Note that Loki 3.0 defaults to using the v13 schema. All of the latest features are built against TSDB and the v13 Schema. This version of the schema is compatible with both Loki 2.9.x and Loki 3.0. The main change is to add support for Structured Metadata which is used by the new OTLP native endpoint.
+{{< /admonition >}}
 
 Key features in Loki 3.0.0 include the following:
 
@@ -20,13 +24,19 @@ Key features in Loki 3.0.0 include the following:
 
 - **Helm charts**: A major upgrade to the Loki helm chart introduces support for `Distributed` mode (also known as [microservices](https://grafana.com/docs/loki/<LOKI_VERSION>/get-started/deployment-modes/#microservices-mode) mode), includes memcached by default, and includes several updates to configurations to improve Loki operations.
 
-- **Lambda/Promtail:** support dropping labels ([#10755](https://github.com/grafana/loki/issues/10755)) ([ec54c72](https://github.com/grafana/loki/commit/ec54c723ebbeeda88000dde188d539ecfe05dad8)).
+- **Pattern match filter**: LogQL now supports two new pattern match filter operators. You can match any word with just one control character and it is simpler and 10x faster than using regex.
 
-- **Docs improvements**: All the Getting Started topics have been revised, including a new [Quickstart](https://grafana.com/docs/loki/<LOKI_VERSION>/get-started/quick-start/) to help new users get up and running with Loki faster.The Storage, Configuration Reference, and API documentation have been updated to reflect deprecated and removed code, configuration options, and API endpoints.
+- **Caching updates**: This release includes multiple updates to caching to improve performance, add new configuration options and support for new features, deprecate features no longer needed, and add automatic background checks.
+
+- **Lambda/Promtail:** Support dropping labels ([#10755](https://github.com/grafana/loki/issues/10755)) ([ec54c72](https://github.com/grafana/loki/commit/ec54c723ebbeeda88000dde188d539ecfe05dad8)).
+
+- **Profiling integration**: Added profiling integrations to tracing instrumentation to allow getting a profile for a single request.
+
+- **Docs improvements**: All the Getting Started topics have been revised, including a new [Quickstart](https://grafana.com/docs/loki/<LOKI_VERSION>/get-started/quick-start/) to help new users get up and running with Loki faster. The Storage, Configuration Reference, and API documentation have been updated to reflect deprecated and removed code, configuration options, and API endpoints.
 
 ## Deprecations
 
-One of the focuses of Loki 3.0 was cleaning up unused code and old features that had been previously deprecated but not removed. Loki 3.0 removes a number of previous deprecations and introduces some new deprecations.  Some of the main areas with changes include:
+One of the focuses of Loki 3.0 was cleaning up unused code and old features that had been previously deprecated but not removed. Loki 3.0 removes a number of previous deprecations and introduces some new deprecations. Some of the main areas with changes include:
 
 - [Deprecated storage options](https://grafana.com/docs/loki/<LOKI_VERSION>/storage/) including the deprecation of the BoltDB store.
 
@@ -38,24 +48,35 @@ To learn more about breaking changes in this release, refer to the [Upgrade guid
 
 ## Upgrade Considerations
 
-The path from 2.9 to 3.0 includes several breaking changes.  For important upgrade guidance, refer to the [Upgrade Guide](https://grafana.com/docs/loki/<LOKI_VERSION>/setup/upgrade/) and the separate [Helm Upgrade Guide](https://grafana.com/docs/loki/<LOKI_VERSION>/setup/upgrade/upgrade-to-6x/).
+The path from 2.9 to 3.0 includes several breaking changes. For important upgrade guidance, refer to the [Upgrade Guide](https://grafana.com/docs/loki/<LOKI_VERSION>/setup/upgrade/) and the separate [Helm Upgrade Guide](https://grafana.com/docs/loki/<LOKI_VERSION>/setup/upgrade/upgrade-to-6x/).
 
 ## Bug fixes
 
 ### 3.0.0 (2024-04-08)
-- All lifecycler cfgs ref a valid IPv6 addr and port combination ([#11121](https://github.com/grafana/loki/issues/11121)) ([6385b19](https://github.com/grafana/loki/commit/6385b195739bd7d4e9706faddd0de663d8e5331a))
-- **deps:** update github.com/c2h5oh/datasize digest to 859f65c (main) ([#10820](https://github.com/grafana/loki/issues/10820)) ([c66ffd1](https://github.com/grafana/loki/commit/c66ffd125cd89f5845a75a1751186fa46d003f70))
-- **deps:** update github.com/docker/go-plugins-helpers digest to 6eecb7b (main) ([#10826](https://github.com/grafana/loki/issues/10826)) ([fb9c496](https://github.com/grafana/loki/commit/fb9c496b21be62f56866ae0f92440085e7860a2a))
-- **deps:** update github.com/grafana/gomemcache digest to 6947259 (main) ([#10836](https://github.com/grafana/loki/issues/10836)) ([2327789](https://github.com/grafana/loki/commit/2327789b5506d0ccc00d931195da17a2d47bf236))
-- **deps:** update github.com/grafana/loki/pkg/push digest to 583aa28 (main) ([#10842](https://github.com/grafana/loki/issues/10842)) ([02d9418](https://github.com/grafana/loki/commit/02d9418270f4e615c1f78b0def635da7c0572ca4))
-- **deps:** update github.com/grafana/loki/pkg/push digest to cfc4f0e (main) ([#10946](https://github.com/grafana/loki/issues/10946)) ([d27c4d2](https://github.com/grafana/loki/commit/d27c4d297dc6cce93ada98f16b962380ec933c6a))
-- **deps:** update github.com/grafana/loki/pkg/push digest to e523809 (main) ([#11107](https://github.com/grafana/loki/issues/11107)) ([09cb9ae](https://github.com/grafana/loki/commit/09cb9ae76f4aef7dea477961c0c5424d7243bf2a))
-- **deps:** update github.com/joncrlsn/dque digest to c2ef48c (main) ([#10947](https://github.com/grafana/loki/issues/10947)) ([1fe4885](https://github.com/grafana/loki/commit/1fe48858ae15b33646eedb85b05d6773a8bc5020))
-- **deps:** update module google.golang.org/grpc [security] (main) ([#11031](https://github.com/grafana/loki/issues/11031)) ([0695424](https://github.com/grafana/loki/commit/0695424f7dd62435df3a9981276b40f3c5ef5641))
-- **helm:** bump nginx-unprivilege to fix CVE ([#10754](https://github.com/grafana/loki/issues/10754)) ([dbf7dd4](https://github.com/grafana/loki/commit/dbf7dd4bac112a538a59907a8c6092504e7f4a91))
-- **Parse JSON String arrays properly so string elements can be retrieved**: [PR #11921](https://github.com/grafana/loki/pull/11921)]
-- **promtail:** correctly parse list of drop stage sources from YAML ([#10848](https://github.com/grafana/loki/issues/10848)) ([f51ee84](https://github.com/grafana/loki/commit/f51ee849b03c5f6b79f3e93cb7fd7811636bede2))
-- **promtail:** prevent panic due to duplicate metric registration after reloaded ([#10798](https://github.com/grafana/loki/issues/10798)) ([47e2c58](https://github.com/grafana/loki/commit/47e2c5884f443667e64764f3fc3948f8f11abbb8))
-- respect query matcher in ingester when getting label values ([#10375](https://github.com/grafana/loki/issues/10375)) ([85e2e52](https://github.com/grafana/loki/commit/85e2e52279ecac6dc111d5c113c54d6054d2c922))
-- Sidecar configuration for Backend ([#10603](https://github.com/grafana/loki/issues/10603)) ([c29ba97](https://github.com/grafana/loki/commit/c29ba973a0b5b7b59613d210b741d5a547ea0e83))
-- **tools/lambda-promtail:** Do not evaluate empty string for drop_labels ([#11074](https://github.com/grafana/loki/issues/11074)) ([94169a0](https://github.com/grafana/loki/commit/94169a0e6b5bf96426ad21e40f9583b721f35d6c))
+
+- All lifecycler configurations reference a valid IPv6 address and port combination ([#11121](https://github.com/grafana/loki/issues/11121)) ([6385b19](https://github.com/grafana/loki/commit/6385b195739bd7d4e9706faddd0de663d8e5331a)).
+- **deps:** Update github.com/c2h5oh/datasize digest to 859f65c (main) ([#10820](https://github.com/grafana/loki/issues/10820)) ([c66ffd1](https://github.com/grafana/loki/commit/c66ffd125cd89f5845a75a1751186fa46d003f70)).
+- **deps:** Update github.com/docker/go-plugins-helpers digest to 6eecb7b (main) ([#10826](https://github.com/grafana/loki/issues/10826)) ([fb9c496](https://github.com/grafana/loki/commit/fb9c496b21be62f56866ae0f92440085e7860a2a)).
+- **deps:** Update github.com/grafana/gomemcache digest to 6947259 (main) ([#10836](https://github.com/grafana/loki/issues/10836)) ([2327789](https://github.com/grafana/loki/commit/2327789b5506d0ccc00d931195da17a2d47bf236)).
+- **deps:** Update github.com/grafana/loki/pkg/push digest to 583aa28 (main) ([#10842](https://github.com/grafana/loki/issues/10842)) ([02d9418](https://github.com/grafana/loki/commit/02d9418270f4e615c1f78b0def635da7c0572ca4)).
+- **deps:** Update github.com/grafana/loki/pkg/push digest to cfc4f0e (main) ([#10946](https://github.com/grafana/loki/issues/10946)) ([d27c4d2](https://github.com/grafana/loki/commit/d27c4d297dc6cce93ada98f16b962380ec933c6a)).
+- **deps:** Update github.com/grafana/loki/pkg/push digest to e523809 (main) ([#11107](https://github.com/grafana/loki/issues/11107)) ([09cb9ae](https://github.com/grafana/loki/commit/09cb9ae76f4aef7dea477961c0c5424d7243bf2a)).
+- **deps:** Update github.com/joncrlsn/dque digest to c2ef48c (main) ([#10947](https://github.com/grafana/loki/issues/10947)) ([1fe4885](https://github.com/grafana/loki/commit/1fe48858ae15b33646eedb85b05d6773a8bc5020)).
+- **deps:** Update module google.golang.org/grpc [security] (main) ([#11031](https://github.com/grafana/loki/issues/11031)) ([0695424](https://github.com/grafana/loki/commit/0695424f7dd62435df3a9981276b40f3c5ef5641)).
+- **helm:** Bump nginx-unprivilege to fix CVE ([#10754](https://github.com/grafana/loki/issues/10754)) ([dbf7dd4](https://github.com/grafana/loki/commit/dbf7dd4bac112a538a59907a8c6092504e7f4a91)).
+- **helm:** Sidecar configuration for Backend ([#10603](https://github.com/grafana/loki/issues/10603)) ([c29ba97](https://github.com/grafana/loki/commit/c29ba973a0b5b7b59613d210b741d5a547ea0e83)).
+- **lambda-promtail** Fix panic in lambda-promtail due to mishandling of empty DROP_LABELS env var. ([#11074](https://github.com/grafana/loki/pull/11074)).
+- **loki:** Respect query matcher in ingester when getting label values ([#10375](https://github.com/grafana/loki/issues/10375)) ([85e2e52](https://github.com/grafana/loki/commit/85e2e52279ecac6dc111d5c113c54d6054d2c922)).
+- **loki** Generate tsdb_shipper storage_config even if using_boltdb_shipper is false ([#11195](https://github.com/grafana/loki/pull/11195)).
+- **loki** Do not reflect label names in request metrics' "route" label. ([11551](https://github.com/grafana/loki/pull/11551)).
+- **loki** Fix duplicate logs from docker containers. ([#11563](https://github.com/grafana/loki/pull/11563)).
+- **loki** Ruler: Fixed a panic that can be caused by concurrent read-write access of tenant configs when there are a large amount of rules. ([#11601](https://github.com/grafana/loki/pull/11601)).
+- **loki** Fixed regression adding newlines to HTTP error response bodies which may break client integrations. ([#11606](https://github.com/grafana/loki/pull/11606)).
+- **loki** Log results cache: compose empty response based on the request being served to avoid returning incorrect limit or direction. ([#11657](https://github.com/grafana/loki/pull/11657)).
+- **loki** Fix semantics of label parsing logic of metrics and logs queries. Both only parse the first label if multiple extractions into the same label are requested. ([#11587](https://github.com/grafana/loki/pull/11587)).
+- **loki** Background Cache: Fixes a bug that is causing the background queue size to be incremented twice for each enqueued item. ([#11776](https://github.com/grafana/loki/pull/11776)).
+- **loki**: Parsing: String array elements were not being parsed correctly in JSON processing ([#11921](https://github.com/grafana/loki/pull/11921)).
+- **promtail:** Correctly parse list of drop stage sources from YAML ([#10848](https://github.com/grafana/loki/issues/10848)) ([f51ee84](https://github.com/grafana/loki/commit/f51ee849b03c5f6b79f3e93cb7fd7811636bede2)).
+- **promtail:** Prevent panic due to duplicate metric registration after reloaded ([#10798](https://github.com/grafana/loki/issues/10798)) ([47e2c58](https://github.com/grafana/loki/commit/47e2c5884f443667e64764f3fc3948f8f11abbb8)).
+- **promtail**: Fix Promtail excludepath not evaluated on newly added files. ([#9831](https://github.com/grafana/loki/pull/9831)).
+- **tools/lambda-promtail:** Do not evaluate empty string for drop_labels ([#11074](https://github.com/grafana/loki/issues/11074)) ([94169a0](https://github.com/grafana/loki/commit/94169a0e6b5bf96426ad21e40f9583b721f35d6c)).

--- a/docs/sources/release-notes/v3.0.md
+++ b/docs/sources/release-notes/v3.0.md
@@ -13,7 +13,7 @@ For a full list of all changes and fixes, refer to the [CHANGELOG](https://githu
 ## Features and enhancements
 
 {{< admonition type="note" >}}
-Note that Loki 3.0 defaults to using the v13 schema. All of the latest features are built against TSDB and the v13 Schema. This version of the schema is compatible with both Loki 2.9.x and Loki 3.0. The main change is to add support for Structured Metadata which is used by the new OTLP native endpoint.
+Note that Loki 3.0 defaults to using the v13 schema. All of the latest features are built against TSDB and the v13 Schema. This version of the schema is compatible with both Loki 2.9.x and Loki 3.0. The main change is to add support for Structured Metadata which is used by the new OTLP native endpoint and is enabled by default.
 {{< /admonition >}}
 
 Key features in Loki 3.0.0 include the following:
@@ -24,7 +24,7 @@ Key features in Loki 3.0.0 include the following:
 
 - **Helm charts**: A major upgrade to the Loki helm chart introduces support for `Distributed` mode (also known as [microservices](https://grafana.com/docs/loki/<LOKI_VERSION>/get-started/deployment-modes/#microservices-mode) mode), includes memcached by default, and includes several updates to configurations to improve Loki operations.
 
-- **Pattern match filter**: LogQL now supports two new pattern match filter operators. You can match any word with just one control character and it is simpler and 10x faster than using regex.
+- **Pattern match filter**: LogQL now supports two new [pattern match filter operators](https://grafana.com/docs/loki/<LOKI_VERSION>/query/#pattern-match-filter-operators). You can match any word with just one control character and it is simpler and 10x faster than using regex.
 
 - **Caching updates**: This release includes multiple updates to caching to improve performance, add new configuration options and support for new features, deprecate features no longer needed, and add automatic background checks.
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates the Loki 3.0 Release Notes based on the updated CHANGELOG (#12544).
Adds a few additional feature callouts.
Updates the list of Fixed Issues.
Adds 3.0 release notes to the Release Notes landing page.