### PR TITLE
feat: add warnings to metadata context directly

### DIFF
--- a/pkg/logqlmodel/metadata/context.go
+++ b/pkg/logqlmodel/metadata/context.go
@@ -77,6 +77,12 @@ func (c *Context) Headers() []*definitions.PrometheusResponseHeader {
 	return headers
 }
 
+func (c *Context) AddWarning(warning string) {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+
+	c.warnings[warning] = struct{}{}
+}
 func (c *Context) Warnings() []string {
 	c.mtx.Lock()
 	defer c.mtx.Unlock()


### PR DESCRIPTION
Looking up a context key can be surprisingly expensive. This PR makes it so we can add warnings to the `*metadata.Context` directly
