### PR TITLE
docs: add missing aliases for moved pages

### DIFF
--- a/docs/sources/configure/storage.md
+++ b/docs/sources/configure/storage.md
@@ -1,10 +1,8 @@
 ---
-aliases:
-  - ../storage/ # /docs/loki/latest/storage/
 title: Storage
 description: Describes Loki storage.
-alias:
-  - /docs/loki/latest/storage/
+aliases:
+  - ../storage/ # /docs/loki/latest/storage/
 weight: 475
 ---
 # Storage

--- a/docs/sources/configure/storage.md
+++ b/docs/sources/configure/storage.md
@@ -123,7 +123,7 @@ DynamoDB is susceptible to rate limiting, particularly due to overconsuming what
 
 ### BoltDB (deprecated)
 
-BoltDB is an embedded database on disk. It is not replicated and thus cannot be used for high availability or clustered Loki deployments, but is commonly paired with a `filesystem` chunk store for proof of concept deployments, trying out Loki, and development. The [boltdb-shipper]({{< relref "../operations/storage/boltdb-shipper" >}}) aims to support clustered deployments using `boltdb` as an index.
+BoltDB is an embedded database on disk. It is not replicated and thus cannot be used for high availability or clustered Loki deployments, but is commonly paired with a `filesystem` chunk store for proof of concept deployments, trying out Loki, and development. The [boltdb-shipper](https://grafana.com/docs/loki/<LOKI_VERSION>/operations/storage/boltdb-shipper/) aims to support clustered deployments using `boltdb` as an index.
 
 {{< collapse title="Title of hidden content" >}}
 This storage type for indexes is deprecated and may be removed in future major versions of Loki.
@@ -168,7 +168,7 @@ table_manager:
   retention_period: 2520h
 ```
 
-For more information, see the [table manager]({{< relref "../operations/storage/table-manager" >}}) documentation.
+For more information, see the [table manager](https://grafana.com/docs/loki/<LOKI_VERSION>/operations/storage/tsdb/) documentation.
 
 ### Provisioning
 
@@ -187,13 +187,13 @@ table_manager:
     inactive_read_throughput: <int> | Default = 300
 ```
 
-Note, there are a few other DynamoDB provisioning options including DynamoDB autoscaling and on-demand capacity. See the [provisioning configuration]({{< relref "../configure#table_manager" >}}) in the `table_manager` block documentation for more information.
+Note, there are a few other DynamoDB provisioning options including DynamoDB autoscaling and on-demand capacity. See the [provisioning configuration](https://grafana.com/docs/loki/<LOKI_VERSION>/configure/#table_manager) in the `table_manager` block documentation for more information.
 
 ## Upgrading Schemas
 
 When a new schema is released and you want to gain the advantages it provides, you can! Loki can transparently query and merge data from across schema boundaries so there is no disruption of service and upgrading is easy.
 
-First, you'll want to create a new [period_config]({{< relref "../configure#period_config" >}}) entry in your [schema_config]({{< relref "../configure#schema_config" >}}). The important thing to remember here is to set this at some point in the _future_ and then roll out the config file changes to Loki. This allows the table manager to create the required table in advance of writes and ensures that existing data isn't queried as if it adheres to the new schema.
+First, you'll want to create a new [period_config](https://grafana.com/docs/loki/<LOKI_VERSION>/configure/#period_config) entry in your [schema_config](https://grafana.com/docs/loki/<LOKI_VERSION>/configure/#schema_config). The important thing to remember here is to set this at some point in the _future_ and then roll out the config file changes to Loki. This allows the table manager to create the required table in advance of writes and ensures that existing data isn't queried as if it adheres to the new schema.
 
 As an example, let's say it's 2023-07-14 and we want to start using the `v13` schema on the 20th:
 ```yaml
@@ -223,7 +223,7 @@ With the exception of the `filesystem` chunk store, Loki will not delete old chu
 
 We're interested in adding targeted deletion in future Loki releases (think tenant or stream level granularity) and may include other strategies as well.
 
-For more information, see the [retention configuration]({{< relref "../operations/storage/retention" >}}) documentation.
+For more information, see the [retention configuration](https://grafana.com/docs/loki/<LOKI_VERSION>/operations/storage/retention/) documentation.
 
 
 ## Examples

--- a/docs/sources/configure/storage.md
+++ b/docs/sources/configure/storage.md
@@ -3,6 +3,8 @@ aliases:
   - ../storage/ # /docs/loki/latest/storage/
 title: Storage
 description: Describes Loki storage.
+alias:
+  - /docs/loki/latest/storage/
 weight: 475
 ---
 # Storage

--- a/docs/sources/reference/loki-http-api.md
+++ b/docs/sources/reference/loki-http-api.md
@@ -2,7 +2,8 @@
 title: Loki HTTP API
 description: Provides a reference page for the Loki HTTP API endpoints for data ingestion, data retrieval, and cluster management.
 aliases:
-  - /docs/loki/latest/reference/api/
+  - ../api/ # /docs/loki/latest/api/
+  - ./api/ # /docs/loki/latest/reference/api/
 weight: 500
 ---
 

--- a/docs/sources/reference/loki-http-api.md
+++ b/docs/sources/reference/loki-http-api.md
@@ -2,7 +2,7 @@
 title: Loki HTTP API
 description: Provides a reference page for the Loki HTTP API endpoints for data ingestion, data retrieval, and cluster management.
 aliases:
-- ../api/
+  - /docs/loki/latest/reference/api/
 weight: 500
 ---
 


### PR DESCRIPTION
**What this PR does / why we need it**:
I realized that I'd moved/renamed these pages and not included the aliases for redirects.