### PR TITLE
chore(operator): set release-as to avoid commit done in #12348

### DIFF
--- a/operator/release-please-config.json
+++ b/operator/release-please-config.json
@@ -1,5 +1,5 @@
 {
-    "bootstrap-sha": "d298093baa58fd31e1fe73544cea0408eb744710",
+    "bootstrap-sha": "c025fb003a3071130b659fe47ed0edf7c7c0fdb2",
     "bump-minor-pre-major": true,
     "bump-patch-for-minor-pre-major": true,
     "include-component-in-tag": true,
@@ -7,6 +7,7 @@
     "tag-separator": "/",
     "packages": {
         "operator": {
+            "release-as": "0.6.1",
             "component": "operator",
             "release-type": "go",
             "pull-request-title-pattern": "chore(${component}): community release ${version}",


### PR DESCRIPTION


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
