### PR TITLE
test: Fix deadlock in table_manager relating to Stop/SyncTables

### DIFF
--- a/pkg/storage/stores/shipper/indexshipper/downloads/table_manager.go
+++ b/pkg/storage/stores/shipper/indexshipper/downloads/table_manager.go
@@ -153,10 +153,9 @@ func (tm *tableManager) loop() {
 
 func (tm *tableManager) Stop() {
 	tm.cancel()
-
+	tm.wg.Wait()
 	tm.tablesMtx.Lock()
 	defer tm.tablesMtx.Unlock()
-	tm.wg.Wait()
 
 	for _, table := range tm.tables {
 		table.Close()


### PR DESCRIPTION
**What this PR does / why we need it**:
Before fix:
```
go test -race -count=100 -run TestStore_SyncStopInteraction  -timeout 10s
panic: test timed out after 10s
running tests:
	TestStore_SyncStopInteraction (10s)

goroutine 713 [running]:
testing.(*M).startAlarm.func1()
	/opt/homebrew/Cellar/go/1.21.6/libexec/src/testing/testing.go:2259 +0x1e0
created by time.goFunc
	/opt/homebrew/Cellar/go/1.21.6/libexec/src/time/sleep.go:176 +0x48

goroutine 1 [chan receive]:
testing.(*T).Run(0xc0012fab60, {0x104ce7f79, 0x1d}, 0x106f59258)
	/opt/homebrew/Cellar/go/1.21.6/libexec/src/testing/testing.go:1649 +0x608
testing.runTests.func1(0x0?)
	/opt/homebrew/Cellar/go/1.21.6/libexec/src/testing/testing.go:2054 +0x84
testing.tRunner(0xc0012fab60, 0xc001ca7ae8)
	/opt/homebrew/Cellar/go/1.21.6/libexec/src/testing/testing.go:1595 +0x1b4
testing.runTests(0xc0008701e0?, {0x1082fa8c0, 0x22, 0x22}, {0xc000c55b58?, 0x102a04d90?, 0x108310b60?})
	/opt/homebrew/Cellar/go/1.21.6/libexec/src/testing/testing.go:2052 +0x6e8
testing.(*M).Run(0xc0008701e0)
	/opt/homebrew/Cellar/go/1.21.6/libexec/src/testing/testing.go:1925 +0x9f0
main.main()
	_testmain.go:127 +0x298

goroutine 19 [select]:
github.com/baidubce/bce-sdk-go/util/log.NewLogger.func1()
	/Users/progers/dev/src/github.com/grafana/loki/vendor/github.com/baidubce/bce-sdk-go/util/log/logger.go:375 +0xec
created by github.com/baidubce/bce-sdk-go/util/log.NewLogger in goroutine 1
	/Users/progers/dev/src/github.com/grafana/loki/vendor/github.com/baidubce/bce-sdk-go/util/log/logger.go:368 +0x254

goroutine 5 [select]:
go.opencensus.io/stats/view.(*worker).start(0xc0006d1300)
	/Users/progers/dev/src/github.com/grafana/loki/vendor/go.opencensus.io/stats/view/worker.go:292 +0x128
created by go.opencensus.io/stats/view.init.0 in goroutine 1
	/Users/progers/dev/src/github.com/grafana/loki/vendor/go.opencensus.io/stats/view/worker.go:34 +0xf4

goroutine 90 [chan receive]:
github.com/grafana/loki/v3/pkg/storage/chunk/fetcher.(*Fetcher).worker(0xc00039b680)
	/Users/progers/dev/src/github.com/grafana/loki/pkg/storage/chunk/fetcher/fetcher.go:104 +0x284
created by github.com/grafana/loki/v3/pkg/storage/chunk/fetcher.New in goroutine 1
	/Users/progers/dev/src/github.com/grafana/loki/pkg/storage/chunk/fetcher/fetcher.go:86 +0x248

goroutine 92 [chan receive]:
github.com/grafana/loki/v3/pkg/storage/chunk/fetcher.(*Fetcher).worker(0xc00039b680)
	/Users/progers/dev/src/github.com/grafana/loki/pkg/storage/chunk/fetcher/fetcher.go:104 +0x284
created by github.com/grafana/loki/v3/pkg/storage/chunk/fetcher.New in goroutine 1
	/Users/progers/dev/src/github.com/grafana/loki/pkg/storage/chunk/fetcher/fetcher.go:86 +0x248

goroutine 91 [chan receive]:
github.com/grafana/loki/v3/pkg/storage/chunk/fetcher.(*Fetcher).worker(0xc00039b680)
	/Users/progers/dev/src/github.com/grafana/loki/pkg/storage/chunk/fetcher/fetcher.go:104 +0x284
created by github.com/grafana/loki/v3/pkg/storage/chunk/fetcher.New in goroutine 1
	/Users/progers/dev/src/github.com/grafana/loki/pkg/storage/chunk/fetcher/fetcher.go:86 +0x248

goroutine 93 [chan receive]:
github.com/grafana/loki/v3/pkg/storage/chunk/fetcher.(*Fetcher).worker(0xc00039b680)
	/Users/progers/dev/src/github.com/grafana/loki/pkg/storage/chunk/fetcher/fetcher.go:104 +0x284
created by github.com/grafana/loki/v3/pkg/storage/chunk/fetcher.New in goroutine 1
	/Users/progers/dev/src/github.com/grafana/loki/pkg/storage/chunk/fetcher/fetcher.go:86 +0x248

goroutine 94 [chan receive]:
github.com/grafana/loki/v3/pkg/storage/chunk/fetcher.(*Fetcher).worker(0xc00039b680)
	/Users/progers/dev/src/github.com/grafana/loki/pkg/storage/chunk/fetcher/fetcher.go:104 +0x284
created by github.com/grafana/loki/v3/pkg/storage/chunk/fetcher.New in goroutine 1
	/Users/progers/dev/src/github.com/grafana/loki/pkg/storage/chunk/fetcher/fetcher.go:86 +0x248

goroutine 95 [chan receive]:
github.com/grafana/loki/v3/pkg/storage/chunk/fetcher.(*Fetcher).worker(0xc00039b680)
	/Users/progers/dev/src/github.com/grafana/loki/pkg/storage/chunk/fetcher/fetcher.go:104 +0x284
created by github.com/grafana/loki/v3/pkg/storage/chunk/fetcher.New in goroutine 1
	/Users/progers/dev/src/github.com/grafana/loki/pkg/storage/chunk/fetcher/fetcher.go:86 +0x248

goroutine 96 [chan receive]:
github.com/grafana/loki/v3/pkg/storage/chunk/fetcher.(*Fetcher).worker(0xc00039b680)
	/Users/progers/dev/src/github.com/grafana/loki/pkg/storage/chunk/fetcher/fetcher.go:104 +0x284
created by github.com/grafana/loki/v3/pkg/storage/chunk/fetcher.New in goroutine 1
	/Users/progers/dev/src/github.com/grafana/loki/pkg/storage/chunk/fetcher/fetcher.go:86 +0x248

goroutine 97 [chan receive]:
github.com/grafana/loki/v3/pkg/storage/chunk/fetcher.(*Fetcher).worker(0xc00039b680)
	/Users/progers/dev/src/github.com/grafana/loki/pkg/storage/chunk/fetcher/fetcher.go:104 +0x284
created by github.com/grafana/loki/v3/pkg/storage/chunk/fetcher.New in goroutine 1
	/Users/progers/dev/src/github.com/grafana/loki/pkg/storage/chunk/fetcher/fetcher.go:86 +0x248

goroutine 130 [chan receive]:
github.com/grafana/loki/v3/pkg/storage/chunk/fetcher.(*Fetcher).worker(0xc00039b680)
	/Users/progers/dev/src/github.com/grafana/loki/pkg/storage/chunk/fetcher/fetcher.go:104 +0x284
created by github.com/grafana/loki/v3/pkg/storage/chunk/fetcher.New in goroutine 1
	/Users/progers/dev/src/github.com/grafana/loki/pkg/storage/chunk/fetcher/fetcher.go:86 +0x248

goroutine 131 [chan receive]:
github.com/grafana/loki/v3/pkg/storage/chunk/fetcher.(*Fetcher).worker(0xc00039b680)
	/Users/progers/dev/src/github.com/grafana/loki/pkg/storage/chunk/fetcher/fetcher.go:104 +0x284
created by github.com/grafana/loki/v3/pkg/storage/chunk/fetcher.New in goroutine 1
	/Users/progers/dev/src/github.com/grafana/loki/pkg/storage/chunk/fetcher/fetcher.go:86 +0x248

goroutine 132 [chan receive]:
github.com/grafana/loki/v3/pkg/storage/chunk/fetcher.(*Fetcher).worker(0xc00039b680)
	/Users/progers/dev/src/github.com/grafana/loki/pkg/storage/chunk/fetcher/fetcher.go:104 +0x284
created by github.com/grafana/loki/v3/pkg/storage/chunk/fetcher.New in goroutine 1
	/Users/progers/dev/src/github.com/grafana/loki/pkg/storage/chunk/fetcher/fetcher.go:86 +0x248

goroutine 133 [chan receive]:
github.com/grafana/loki/v3/pkg/storage/chunk/fetcher.(*Fetcher).worker(0xc00039b680)
	/Users/progers/dev/src/github.com/grafana/loki/pkg/storage/chunk/fetcher/fetcher.go:104 +0x284
created by github.com/grafana/loki/v3/pkg/storage/chunk/fetcher.New in goroutine 1
	/Users/progers/dev/src/github.com/grafana/loki/pkg/storage/chunk/fetcher/fetcher.go:86 +0x248

goroutine 134 [chan receive]:
github.com/grafana/loki/v3/pkg/storage/chunk/fetcher.(*Fetcher).worker(0xc00039b680)
	/Users/progers/dev/src/github.com/grafana/loki/pkg/storage/chunk/fetcher/fetcher.go:104 +0x284
created by github.com/grafana/loki/v3/pkg/storage/chunk/fetcher.New in goroutine 1
	/Users/progers/dev/src/github.com/grafana/loki/pkg/storage/chunk/fetcher/fetcher.go:86 +0x248

goroutine 135 [chan receive]:
github.com/grafana/loki/v3/pkg/storage/chunk/fetcher.(*Fetcher).worker(0xc00039b680)
	/Users/progers/dev/src/github.com/grafana/loki/pkg/storage/chunk/fetcher/fetcher.go:104 +0x284
created by github.com/grafana/loki/v3/pkg/storage/chunk/fetcher.New in goroutine 1
	/Users/progers/dev/src/github.com/grafana/loki/pkg/storage/chunk/fetcher/fetcher.go:86 +0x248

goroutine 136 [chan receive]:
github.com/grafana/loki/v3/pkg/storage/chunk/fetcher.(*Fetcher).worker(0xc00039b680)
	/Users/progers/dev/src/github.com/grafana/loki/pkg/storage/chunk/fetcher/fetcher.go:104 +0x284
created by github.com/grafana/loki/v3/pkg/storage/chunk/fetcher.New in goroutine 1
	/Users/progers/dev/src/github.com/grafana/loki/pkg/storage/chunk/fetcher/fetcher.go:86 +0x248

goroutine 137 [chan receive]:
github.com/grafana/loki/v3/pkg/storage/chunk/fetcher.(*Fetcher).worker(0xc00039b680)
	/Users/progers/dev/src/github.com/grafana/loki/pkg/storage/chunk/fetcher/fetcher.go:104 +0x284
created by github.com/grafana/loki/v3/pkg/storage/chunk/fetcher.New in goroutine 1
	/Users/progers/dev/src/github.com/grafana/loki/pkg/storage/chunk/fetcher/fetcher.go:86 +0x248

goroutine 138 [select]:
github.com/grafana/loki/v3/pkg/storage/chunk/client/local.(*BoltIndexClient).loop(0xc00004fbd0)
	/Users/progers/dev/src/github.com/grafana/loki/pkg/storage/chunk/client/local/boltdb_index_client.go:82 +0x178
created by github.com/grafana/loki/v3/pkg/storage/chunk/client/local.NewBoltDBIndexClient in goroutine 1
	/Users/progers/dev/src/github.com/grafana/loki/pkg/storage/chunk/client/local/boltdb_index_client.go:71 +0x1d0

goroutine 665 [semacquire]:
sync.runtime_Semacquire(0xc000713780?)
	/opt/homebrew/Cellar/go/1.21.6/libexec/src/runtime/sema.go:62 +0x2c
sync.(*WaitGroup).Wait(0xc000713778)
	/opt/homebrew/Cellar/go/1.21.6/libexec/src/sync/waitgroup.go:116 +0x7c
github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/downloads.(*tableManager).Stop(0xc0007136c0)
	/Users/progers/dev/src/github.com/grafana/loki/pkg/storage/stores/shipper/indexshipper/downloads/table_manager.go:159 +0xa4
github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper.(*indexShipper).stop(0xc0006c4000)
	/Users/progers/dev/src/github.com/grafana/loki/pkg/storage/stores/shipper/indexshipper/shipper.go:252 +0x98
sync.(*Once).doSlow(0xc0006c4240, 0xc001331918)
	/opt/homebrew/Cellar/go/1.21.6/libexec/src/sync/once.go:74 +0xb4
sync.(*Once).Do(0xc0006c4240, 0x102a62708?)
	/opt/homebrew/Cellar/go/1.21.6/libexec/src/sync/once.go:65 +0x44
github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper.(*indexShipper).Stop(0xc0006c4000)
	/Users/progers/dev/src/github.com/grafana/loki/pkg/storage/stores/shipper/indexshipper/shipper.go:243 +0x5c
github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb.(*store).Stop-fm.(*store).Stop.func1()
	/Users/progers/dev/src/github.com/grafana/loki/pkg/storage/stores/shipper/indexshipper/tsdb/store.go:148 +0x200
sync.(*Once).doSlow(0xc0001d58a0, 0xc001331ac8)
	/opt/homebrew/Cellar/go/1.21.6/libexec/src/sync/once.go:74 +0xb4
sync.(*Once).Do(0xc0001d58a0, 0xc0001d57c0?)
	/opt/homebrew/Cellar/go/1.21.6/libexec/src/sync/once.go:65 +0x44
github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb.(*store).Stop(...)
	/Users/progers/dev/src/github.com/grafana/loki/pkg/storage/stores/shipper/indexshipper/tsdb/store.go:142
github.com/grafana/loki/v3/pkg/storage.(*LokiStore).storeForPeriod.func2()
	/Users/progers/dev/src/github.com/grafana/loki/pkg/storage/store.go:313 +0xa8
github.com/grafana/loki/v3/pkg/storage/stores.(*storeEntry).Stop(0xc00084c340)
	/Users/progers/dev/src/github.com/grafana/loki/pkg/storage/stores/composite_store_entry.go:201 +0x5c
github.com/grafana/loki/v3/pkg/storage/stores.CompositeStore.Stop(...)
	/Users/progers/dev/src/github.com/grafana/loki/pkg/storage/stores/composite_store.go:306
github.com/grafana/loki/v3/pkg/storage.TestStore_SyncStopInteraction(0xc0012fad00)
	/Users/progers/dev/src/github.com/grafana/loki/pkg/storage/store_test.go:2003 +0xb74
testing.tRunner(0xc0012fad00, 0x106f59258)
	/opt/homebrew/Cellar/go/1.21.6/libexec/src/testing/testing.go:1595 +0x1b4
created by testing.(*T).Run in goroutine 1
	/opt/homebrew/Cellar/go/1.21.6/libexec/src/testing/testing.go:1648 +0x5ec

goroutine 747 [sync.RWMutex.RLock]:
sync.runtime_SemacquireRWMutexR(0xc000713740?, 0x0?, 0x0?)
	/opt/homebrew/Cellar/go/1.21.6/libexec/src/runtime/sema.go:82 +0x28
sync.(*RWMutex).RLock(0xc000713730)
	/opt/homebrew/Cellar/go/1.21.6/libexec/src/sync/rwmutex.go:71 +0x60
github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/downloads.(*tableManager).syncTables(0xc0007136c0, {0x106f85608, 0xc0001d5900})
	/Users/progers/dev/src/github.com/grafana/loki/pkg/storage/stores/shipper/indexshipper/downloads/table_manager.go:214 +0x4c
github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/downloads.(*tableManager).loop(0xc0007136c0)
	/Users/progers/dev/src/github.com/grafana/loki/pkg/storage/stores/shipper/indexshipper/downloads/table_manager.go:133 +0x4a8
created by github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/downloads.NewTableManager in goroutine 665
	/Users/progers/dev/src/github.com/grafana/loki/pkg/storage/stores/shipper/indexshipper/downloads/table_manager.go:114 +0x408
exit status 2
FAIL	github.com/grafana/loki/v3/pkg/storage	10.856s

```
After fix:
```
go test -race -count=100 -run TestStore_SyncStopInteraction  -timeout 10s
PASS
ok  	github.com/grafana/loki/v3/pkg/storage	2.668s
```
**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
