### PR TITLE
docs: hide the sizing calculator until updated

### DIFF
--- a/docs/sources/setup/_index.md
+++ b/docs/sources/setup/_index.md
@@ -7,7 +7,6 @@ weight: 300
 
 # Setup Loki
 
-- Estimate the initial [size]({{< relref "./size" >}}) for your Loki cluster.
 - [Install]({{< relref "./install" >}}) Loki.
 - [Migrate]({{< relref "./migrate" >}}) from one Loki implementation to another.
 - [Upgrade]({{< relref "./upgrade" >}}) from one Loki version to a newer version.

--- a/docs/sources/setup/install/_index.md
+++ b/docs/sources/setup/install/_index.md
@@ -17,10 +17,6 @@ There are several methods of installing Loki and Promtail:
 - [Install and run locally]({{< relref "./local" >}})
 - [Install from source]({{< relref "./install-from-source" >}})
 
-The [Sizing Tool]({{< relref "../size" >}}) can be used to determine the proper cluster sizing
-given an expected ingestion rate and query performance.  It targets the Helm
-installation on Kubernetes.
-
 ## General process
 
 In order to run Loki, you must:

--- a/docs/sources/setup/size/_index.md
+++ b/docs/sources/setup/size/_index.md
@@ -6,7 +6,7 @@ aliases:
   - ../installation/sizing/
   - ../installation/helm/generate
 weight: 100
-keywords: []
+draft: true
 ---
 
 <link rel="stylesheet" href="../../query/analyzer/style.css">


### PR DESCRIPTION
**What this PR does / why we need it**:

The sizing calculator needs to be updated, hiding until that happens.