### PR TITLE
fix(query sharding): Generalize avg -> sum/count sharding using existing binop mapper

### DIFF
--- a/pkg/logql/shardmapper.go
+++ b/pkg/logql/shardmapper.go
@@ -240,33 +240,21 @@ func (m ShardMapper) mapVectorAggregationExpr(expr *syntax.VectorAggregationExpr
 
 		case syntax.OpTypeAvg:
 			// avg(x) -> sum(x)/count(x), which is parallelizable
-			lhs, lhsBytesPerShard, err := m.mapVectorAggregationExpr(&syntax.VectorAggregationExpr{
-				Left:      expr.Left,
-				Grouping:  expr.Grouping,
-				Operation: syntax.OpTypeSum,
-			}, r, false)
-			if err != nil {
-				return nil, 0, err
+			binOp := &syntax.BinOpExpr{
+				SampleExpr: &syntax.VectorAggregationExpr{
+					Left:      expr.Left,
+					Grouping:  expr.Grouping,
+					Operation: syntax.OpTypeSum,
+				},
+				RHS: &syntax.VectorAggregationExpr{
+					Left:      expr.Left,
+					Grouping:  expr.Grouping,
+					Operation: syntax.OpTypeCount,
+				},
+				Op: syntax.OpTypeDiv,
 			}
 
-			rhs, rhsBytesPerShard, err := m.mapVectorAggregationExpr(&syntax.VectorAggregationExpr{
-				Left:      expr.Left,
-				Grouping:  expr.Grouping,
-				Operation: syntax.OpTypeCount,
-			}, r, false)
-			if err != nil {
-				return nil, 0, err
-			}
-
-			// We take the maximum bytes per shard of both sides of the operation
-			bytesPerShard := uint64(max(int(lhsBytesPerShard), int(rhsBytesPerShard)))
-
-			return &syntax.BinOpExpr{
-				SampleExpr: lhs,
-				RHS:        rhs,
-				Op:         syntax.OpTypeDiv,
-			}, bytesPerShard, nil
-
+			return m.mapBinOpExpr(binOp, r, topLevel)
 		case syntax.OpTypeCount:
 			if syntax.ReducesLabels(expr.Left) {
 				// skip sharding optimizations at this level. If labels are reduced,

--- a/pkg/logql/shardmapper_test.go
+++ b/pkg/logql/shardmapper_test.go
@@ -232,6 +232,19 @@ func TestMappingStrings(t *testing.T) {
 			)`,
 		},
 		{
+			// produced by sum/count --> (sumby(foo_extracted)(downstream<sumby(foo_extracted)(quantile_over_time(0.95,{foo=\"baz\"}|logfmt|unwrapfoo_extracted|__error__=\"\"[5m])),shard=0_of_2>++downstream<sumby(foo_extracted)(quantile_over_time(0.95,{foo=\"baz\"}|logfmt|unwrapfoo_extracted|__error__=\"\"[5m])),shard=1_of_2>)/sumby(foo_extracted)(downstream<countby(foo_extracted)(quantile_over_time(0.95,{foo=\"baz\"}|logfmt|unwrapfoo_extracted|__error__=\"\"[5m])),shard=0_of_2>++downstream<countby(foo_extracted)(quantile_over_time(0.95,{foo=\"baz\"}|logfmt|unwrapfoo_extracted|__error__=\"\"[5m])),shard=1_of_2>))
+			in: `avg by(foo_extracted) (quantile_over_time(0.95, {foo="baz"} | logfmt | unwrap foo_extracted | __error__="" [5m]))`,
+			out: `(
+               sum by (foo_extracted) (
+                   downstream<sumby(foo_extracted)(quantile_over_time(0.95,{foo="baz"}|logfmt|unwrapfoo_extracted|__error__=""[5m])),shard=0_of_2>++downstream<sumby(foo_extracted)(quantile_over_time(0.95,{foo="baz"}|logfmt|unwrapfoo_extracted|__error__=""[5m])),shard=1_of_2>
+               )
+               / 
+               sum by (foo_extracted) (
+                   downstream<countby(foo_extracted)(quantile_over_time(0.95,{foo="baz"}|logfmt|unwrapfoo_extracted|__error__=""[5m])),shard=0_of_2>++downstream<countby(foo_extracted)(quantile_over_time(0.95,{foo="baz"}|logfmt|unwrapfoo_extracted|__error__=""[5m])),shard=1_of_2>
+               )
+            )`,
+		},
+		{
 			in: `count(rate({foo="bar"} | json | keep foo [5m]))`,
 			out: `count(
 				sum without()(
@@ -283,12 +296,12 @@ func TestMappingStrings(t *testing.T) {
 		},
 		{
 			in: `sum without (a) (
-		  			label_replace(
-		    			sum without (b) (
-		      				rate({foo="bar"}[5m])
-		    			),
-		    			"baz", "buz", "foo", "(.*)"
-		  			)
+		 			label_replace(
+		   			sum without (b) (
+		     				rate({foo="bar"}[5m])
+		   			),
+		   			"baz", "buz", "foo", "(.*)"
+		 			)
 				)`,
 			out: `sum without(a) (
 					label_replace(


### PR DESCRIPTION
We make `avg` queries shardable by converting them into `sum/count` queries. The conversion didn't handle all possible mappings and sometimes results in the error `SelectSamples unimplemented: the query-frontend cannot evaluate an expression that selects samples. this is likely a bug in the query engine. please contact your system operator`. This happens even when inputting the native `sum/count` query would succeed. For example:

`avg by(foo_extracted) (quantile_over_time(0.95, {foo="baz"} | logfmt | unwrap foo_extracted | __error__=`` [$__auto]))` fails but `sum by(foo_extracted) (quantile_over_time(0.95, {foo="baz"} | logfmt | unwrap foo_extracted | __error__=`` [$__auto])) / count by(foo_extracted) (quantile_over_time(0.95, {foo="baz"} | logfmt | unwrap foo_extracted | __error__=`` [$__auto]))` succeeds.

This happens because our handling of top-level binary-operations is pretty sophisticated but the conversion from `avg -> sum/count` was only a piece of that. This PR removes the one-off mapping of binops in the `avg -> sum/count` case and replaces it with a bin op that is handed by our normal `mapBinOp` logic.
