### PR TITLE
fix: Remove Hardcoded Bucket Name from EventBridge Example CloudFormation Template

### DIFF
--- a/tools/lambda-promtail/template-eventbridge.yaml
+++ b/tools/lambda-promtail/template-eventbridge.yaml
@@ -88,7 +88,7 @@ Resources:
               - Effect: Allow
                 Action:
                   - s3:GetObject
-                Resource: arn:aws:s3:::thepalbi-lambda-lb-access-logs/*
+                Resource: !Sub 'arn:aws:s3:::${EventSourceS3Bucket}/*'
       RoleName: iam_for_lambda
   LambdaPromtailFunction:
     Type: AWS::Lambda::Function


### PR DESCRIPTION
**What this PR does / why we need it**:

The current CloudFormation template for EventBridge includes a hardcoded S3 bucket name. This changes that so it uses the S3 bucket name from the input parameters.

**Which issue(s) this PR fixes**:
The EventBridge example template doesn't work properly without it.

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
