### PR TITLE
fix: fix setting of info log level when trying to detect level from log lines

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -919,7 +919,7 @@ func extractLogLevelFromLogLine(log string) string {
 			return logLevelDebug
 		}
 		if strings.Contains(log, `:"info"`) || strings.Contains(log, `:"INFO"`) {
-			return logLevelDebug
+			return logLevelInfo
 		}
 	}
 
@@ -940,7 +940,7 @@ func extractLogLevelFromLogLine(log string) string {
 			return logLevelDebug
 		}
 		if strings.Contains(log, "=info") || strings.Contains(log, "=INFO") {
-			return logLevelDebug
+			return logLevelInfo
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
I made a mistake while setting log level for info logs with logfmt/json format. This PR fixes it. 