### PR TITLE
fix(helm): Removed duplicate bucketNames from documentation and fixed key name `deploymentMode`

### DIFF
--- a/docs/sources/setup/install/helm/install-monolithic/_index.md
+++ b/docs/sources/setup/install/helm/install-monolithic/_index.md
@@ -77,7 +77,7 @@ If you set the `singleBinary.replicas` value to 2 or more, this chart configures
             index:
               prefix: loki_index_
               period: 24h
-            object_store: filesystem
+            object_store: s3
             schema: v13
         storage:
           type: 's3'

--- a/docs/sources/setup/install/helm/install-monolithic/_index.md
+++ b/docs/sources/setup/install/helm/install-monolithic/_index.md
@@ -80,10 +80,6 @@ If you set the `singleBinary.replicas` value to 2 or more, this chart configures
             object_store: filesystem
             schema: v13
         storage:
-          bucketNames:
-            chunks: loki-chunks
-            ruler: loki-ruler
-            admin: loki-admin
           type: 's3'
           bucketNames:
             chunks: loki-chunks

--- a/docs/sources/setup/install/helm/install-monolithic/_index.md
+++ b/docs/sources/setup/install/helm/install-monolithic/_index.md
@@ -39,7 +39,7 @@ If you set the `singleBinary.replicas` value to 2 or more, this chart configures
     - If running a single replica of Loki, configure the `filesystem` storage:
 
       ```yaml
-      mode: SingleBinary
+      deploymentMode: SingleBinary
       loki:
         commonConfig:
           replication_factor: 1

--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -13,6 +13,10 @@ Entries should include a reference to the pull request that introduced the chang
 
 [//]: # (<AUTOMATED_UPDATES_LOCATOR> : do not remove this line. This locator is used by the CI pipeline to automatically create a changelog entry for each new Loki release. Add other chart versions and respective changelog entries bellow this line.)
 
+## 6.2.1
+
+- [BUGFIX] Removed duplicate bucketNames from documentation and fixed key name `deploymentMode`
+
 ## 6.2.0
 
 - [FEATURE] Add a headless service to the bloom gateway component.

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -3,7 +3,7 @@ name: loki
 description: Helm chart for Grafana Loki in simple, scalable mode
 type: application
 appVersion: 3.0.0
-version: 6.2.0
+version: 6.2.1
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -1,6 +1,6 @@
 # loki
 
-![Version: 6.2.0](https://img.shields.io/badge/Version-6.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.0.0](https://img.shields.io/badge/AppVersion-3.0.0-informational?style=flat-square)
+![Version: 6.2.1](https://img.shields.io/badge/Version-6.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.0.0](https://img.shields.io/badge/AppVersion-3.0.0-informational?style=flat-square)
 
 Helm chart for Grafana Loki in simple, scalable mode
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes documentation for Helm deployments to not have duplicate values and utilize correct `deploymentMode` key name.

**Which issue(s) this PR fixes**:
Fixes [#12610](https://github.com/grafana/loki/issues/12610)

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [X] Documentation added
- [X] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
