### PR TITLE
ci: Fix promtail windows test github action

### DIFF
--- a/.github/workflows/promtail-windows-test.yml
+++ b/.github/workflows/promtail-windows-test.yml
@@ -1,8 +1,8 @@
 name: Promtail Windows Test
 on:
-  pull_request:
-  tags: ['v[0-9].[0-9]+.[0-9]+']
-  branches: [main, k*]
+  push:
+    tags: ['v[0-9].[0-9]+.[0-9]+']
+    branches: [main, k*]
 jobs:
   build:
     runs-on: windows-latest

--- a/.github/workflows/promtail-windows-test.yml
+++ b/.github/workflows/promtail-windows-test.yml
@@ -1,8 +1,10 @@
 name: Promtail Windows Test
 on:
+  pull_request:
+    branches: ["main", "k*", "release-[0-9]+.[0-9]+.x"]
   push:
     tags: ['v[0-9].[0-9]+.[0-9]+']
-    branches: [main, k*]
+    branches: ["main", "k*", "release-[0-9]+.[0-9]+.x"]
 jobs:
   build:
     runs-on: windows-latest


### PR DESCRIPTION
**What this PR does / why we need it**:

This is failing with a message:

```
[Error](https://github.com/grafana/loki/actions/runs/8738514835/workflow)
Invalid type for `on`
```

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
