### PR TITLE
chore(promtail): Update Promtail base image to Debian 12.5

### DIFF
--- a/clients/cmd/promtail/Dockerfile
+++ b/clients/cmd/promtail/Dockerfile
@@ -1,21 +1,15 @@
-FROM golang:1.21.9-bullseye as build
+FROM golang:1.21.9-bookworm as build
 
 COPY . /src/loki
 WORKDIR /src/loki
-# Backports repo required to get a libsystemd version 246 or newer which is required to handle journal +ZSTD compression
-RUN echo "deb http://deb.debian.org/debian bullseye-backports main" >> /etc/apt/sources.list
-RUN apt-get update && apt-get install -t bullseye-backports -qy libsystemd-dev
+RUN apt-get update && apt-get install -qy libsystemd-dev
 RUN make clean && make BUILD_IN_CONTAINER=false PROMTAIL_JOURNAL_ENABLED=true promtail
 
 # Promtail requires debian as the base image to support systemd journal reading
-FROM debian:bullseye-slim
+FROM debian:12.5-slim
 # tzdata required for the timestamp stage to work
-# Backports repo required to get a libsystemd version 246 or newer which is required to handle journal +ZSTD compression
-RUN echo "deb http://deb.debian.org/debian bullseye-backports main" >> /etc/apt/sources.list
 RUN apt-get update && \
-  apt-get install -qy \
-  tzdata ca-certificates
-RUN apt-get install -t bullseye-backports -qy libsystemd-dev && \
+  apt-get install -qy tzdata ca-certificates libsystemd-dev && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 COPY --from=build /src/loki/clients/cmd/promtail/promtail /usr/bin/promtail
 COPY clients/cmd/promtail/promtail-docker-config.yaml /etc/promtail/config.yml

--- a/clients/cmd/promtail/Dockerfile.arm32
+++ b/clients/cmd/promtail/Dockerfile.arm32
@@ -1,21 +1,15 @@
-FROM golang:1.21.9-bullseye as build
+FROM golang:1.21.9-bookworm as build
 
 COPY . /src/loki
 WORKDIR /src/loki
-# Backports repo required to get a libsystemd version 246 or newer which is required to handle journal +ZSTD compression
-RUN echo "deb http://deb.debian.org/debian bullseye-backports main" >> /etc/apt/sources.list
-RUN apt-get update && apt-get install -t bullseye-backports -qy libsystemd-dev
+RUN apt-get update && apt-get install -qy libsystemd-dev
 RUN make clean && make BUILD_IN_CONTAINER=false PROMTAIL_JOURNAL_ENABLED=true promtail
 
 # Promtail requires debian as the base image to support systemd journal reading
-FROM debian:bullseye-slim
+FROM debian:12.5-slim
 # tzdata required for the timestamp stage to work
-# Backports repo required to get a libsystemd version 246 or newer which is required to handle journal +ZSTD compression
-RUN echo "deb http://deb.debian.org/debian bullseye-backports main" >> /etc/apt/sources.list
 RUN apt-get update && \
-  apt-get install -qy \
-  tzdata ca-certificates
-RUN apt-get install -t bullseye-backports -qy libsystemd-dev && \
+  apt-get install -qy tzdata ca-certificates libsystemd-dev && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 COPY --from=build /src/loki/clients/cmd/promtail/promtail /usr/bin/promtail
 COPY clients/cmd/promtail/promtail-local-config.yaml /etc/promtail/local-config.yaml

--- a/clients/cmd/promtail/Dockerfile.cross
+++ b/clients/cmd/promtail/Dockerfile.cross
@@ -13,11 +13,10 @@ WORKDIR /src/loki
 RUN make clean && GOARCH=$(cat /goarch) GOARM=$(cat /goarm) make BUILD_IN_CONTAINER=false PROMTAIL_JOURNAL_ENABLED=true promtail
 
 # Promtail requires debian as the base image to support systemd journal reading
-FROM debian:stretch-slim
+FROM debian:12.5-slim
 # tzdata required for the timestamp stage to work
 RUN apt-get update && \
-  apt-get install -qy \
-  tzdata ca-certificates libsystemd-dev && \
+  apt-get install -qy tzdata ca-certificates libsystemd-dev && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 COPY --from=build /src/loki/clients/cmd/promtail/promtail /usr/bin/promtail
 COPY clients/cmd/promtail/promtail-local-config.yaml /etc/promtail/local-config.yaml


### PR DESCRIPTION
**What this PR does / why we need it**:

Debian 11 (Bullseye) has been superseded by Debian 12 (Bookworm).

**Which issue(s) this PR fixes**:

Ref https://github.com/grafana/loki/issues/838#issuecomment-2056942205

**Special notes for your reviewer**:

```console
$ trivy image -q grafana/promtail:chaudum-promtail-base-image-6336f56

grafana/promtail:chaudum-promtail-base-image-6336f56 (debian 12.5)

Total: 100 (UNKNOWN: 0, LOW: 67, MEDIUM: 23, HIGH: 9, CRITICAL: 1)
```

The 1 CRITICAL is a "will_not_fix":

![screenshot_20240418_155745](https://github.com/grafana/loki/assets/281260/1dfd111f-beaf-424d-b88e-751db00fe709)


**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
