### PR TITLE
fix: Fix the lokitool imports

### DIFF
--- a/cmd/lokitool/main.go
+++ b/cmd/lokitool/main.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/prometheus/common/version"
 
-	"github.com/grafana/loki/pkg/tool/commands"
+	"github.com/grafana/loki/v3/pkg/tool/commands"
 )
 
 var (

--- a/pkg/tool/client/rules.go
+++ b/pkg/tool/client/rules.go
@@ -10,7 +10,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
 
-	"github.com/grafana/loki/pkg/tool/rules/rwrulefmt"
+	"github.com/grafana/loki/v3/pkg/tool/rules/rwrulefmt"
 )
 
 // CreateRuleGroup creates a new rule group

--- a/pkg/tool/commands/rules.go
+++ b/pkg/tool/commands/rules.go
@@ -15,10 +15,10 @@ import (
 	"gopkg.in/alecthomas/kingpin.v2"
 	yamlv3 "gopkg.in/yaml.v3"
 
-	"github.com/grafana/loki/pkg/tool/client"
-	"github.com/grafana/loki/pkg/tool/printer"
-	"github.com/grafana/loki/pkg/tool/rules"
-	"github.com/grafana/loki/pkg/tool/rules/rwrulefmt"
+	"github.com/grafana/loki/v3/pkg/tool/client"
+	"github.com/grafana/loki/v3/pkg/tool/printer"
+	"github.com/grafana/loki/v3/pkg/tool/rules"
+	"github.com/grafana/loki/v3/pkg/tool/rules/rwrulefmt"
 )
 
 const (

--- a/pkg/tool/commands/rules_test.go
+++ b/pkg/tool/commands/rules_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v3"
 
-	"github.com/grafana/loki/pkg/tool/rules/rwrulefmt"
+	"github.com/grafana/loki/v3/pkg/tool/rules/rwrulefmt"
 )
 
 func TestCheckDuplicates(t *testing.T) {

--- a/pkg/tool/printer/printer.go
+++ b/pkg/tool/printer/printer.go
@@ -13,8 +13,8 @@ import (
 	"github.com/mitchellh/colorstring"
 	"gopkg.in/yaml.v3"
 
-	"github.com/grafana/loki/pkg/tool/rules"
-	"github.com/grafana/loki/pkg/tool/rules/rwrulefmt"
+	"github.com/grafana/loki/v3/pkg/tool/rules"
+	"github.com/grafana/loki/v3/pkg/tool/rules/rwrulefmt"
 )
 
 // Printer is  used for printing formatted output from the cortextool

--- a/pkg/tool/printer/printer_test.go
+++ b/pkg/tool/printer/printer_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/loki/pkg/tool/rules/rwrulefmt"
+	"github.com/grafana/loki/v3/pkg/tool/rules/rwrulefmt"
 )
 
 func TestPrintRuleSet(t *testing.T) {

--- a/pkg/tool/rules/compare.go
+++ b/pkg/tool/rules/compare.go
@@ -10,7 +10,7 @@ import (
 	"github.com/prometheus/prometheus/model/rulefmt"
 	yaml "gopkg.in/yaml.v3"
 
-	"github.com/grafana/loki/pkg/tool/rules/rwrulefmt"
+	"github.com/grafana/loki/v3/pkg/tool/rules/rwrulefmt"
 )
 
 var (

--- a/pkg/tool/rules/compare_test.go
+++ b/pkg/tool/rules/compare_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/prometheus/prometheus/model/rulefmt"
 	yaml "gopkg.in/yaml.v3"
 
-	"github.com/grafana/loki/pkg/tool/rules/rwrulefmt"
+	"github.com/grafana/loki/v3/pkg/tool/rules/rwrulefmt"
 )
 
 func Test_rulesEqual(t *testing.T) {

--- a/pkg/tool/rules/parser.go
+++ b/pkg/tool/rules/parser.go
@@ -12,7 +12,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	yaml "gopkg.in/yaml.v3"
 
-	"github.com/grafana/loki/pkg/ruler"
+	"github.com/grafana/loki/v3/pkg/ruler"
 )
 
 const (

--- a/pkg/tool/rules/parser_test.go
+++ b/pkg/tool/rules/parser_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/prometheus/prometheus/model/rulefmt"
 
-	"github.com/grafana/loki/pkg/tool/rules/rwrulefmt"
+	"github.com/grafana/loki/v3/pkg/tool/rules/rwrulefmt"
 )
 
 func TestParseFiles(t *testing.T) {

--- a/pkg/tool/rules/rules.go
+++ b/pkg/tool/rules/rules.go
@@ -8,9 +8,9 @@ import (
 	"github.com/prometheus/prometheus/promql/parser"
 	log "github.com/sirupsen/logrus"
 
-	logql "github.com/grafana/loki/pkg/logql/syntax"
+	logql "github.com/grafana/loki/v3/pkg/logql/syntax"
 
-	"github.com/grafana/loki/pkg/tool/rules/rwrulefmt"
+	"github.com/grafana/loki/v3/pkg/tool/rules/rwrulefmt"
 )
 
 // RuleNamespace is used to parse a slightly modified prometheus

--- a/pkg/tool/rules/rules_test.go
+++ b/pkg/tool/rules/rules_test.go
@@ -8,7 +8,7 @@ import (
 	"gopkg.in/yaml.v3"
 	"gotest.tools/assert"
 
-	"github.com/grafana/loki/pkg/tool/rules/rwrulefmt"
+	"github.com/grafana/loki/v3/pkg/tool/rules/rwrulefmt"
 )
 
 func TestAggregateBy(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

The PR that introduced lokitool was not updated to use the new v3 Loki imports. This PR fixes that.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
