### PR TITLE
docs: fix mal formed link

### DIFF
--- a/docs/sources/send-data/promtail/installation.md
+++ b/docs/sources/send-data/promtail/installation.md
@@ -19,7 +19,7 @@ Every Grafana Loki release includes binaries for Promtail which can be found on 
 
 ## Install using APT or RPM package manager
 
-See the instructions [here](https://grafana.com/docs/loki//setup/install/local/#install-using-apt-or-rpm-package-manager). 
+See the instructions [here](https://grafana.com/docs/loki/setup/install/local/#install-using-apt-or-rpm-package-manager). 
 
 ## Install using Docker 
 


### PR DESCRIPTION
**What this PR does / why we need it**:

fix a malformed link identified in the weekly broken link report.

Note - Introduced by #11502, not backported.
Not found in 2.9 branch
Found in 3.0 branch.