### PR TITLE
fix(operator): Fix validating s3 endpoint

### DIFF
--- a/operator/internal/handlers/internal/storage/secrets.go
+++ b/operator/internal/handlers/internal/storage/secrets.go
@@ -484,7 +484,7 @@ func validateS3Endpoint(endpoint string, region string) error {
 			return fmt.Errorf("%w: %s", errSecretMissingField, storage.KeyAWSRegion)
 		}
 
-		validEndpoint := fmt.Sprintf("https://s3.%s%s", region, awsEndpointSuffix)
+		validEndpoint := fmt.Sprintf("%s://s3.%s%s", parsedURL.Scheme, region, awsEndpointSuffix)
 		if endpoint != validEndpoint {
 			return fmt.Errorf("%w: %s", errS3EndpointAWSInvalid, validEndpoint)
 		}

--- a/operator/internal/handlers/internal/storage/secrets_test.go
+++ b/operator/internal/handlers/internal/storage/secrets_test.go
@@ -591,7 +591,7 @@ func TestS3Extract(t *testing.T) {
 					"access_key_secret": []byte("secret"),
 				},
 			},
-			wantError: "endpoint for AWS S3 must include correct region: https://s3.region.amazonaws.com",
+			wantError: "endpoint for AWS S3 must include correct region: http://s3.region.amazonaws.com",
 		},
 	}
 	for _, tst := range table {


### PR DESCRIPTION
**What this PR does / why we need it**:
A minor fix following #12181 where the S3 endpoint was validated based on an `https` only URL. Now it validates both `http` and `https`.

**Which issue(s) this PR fixes**:
Fixes #12181 

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
