### PR TITLE
fix(workflows): don't run metric collector on forks

### DIFF
--- a/.github/workflows/metrics-collector.yml
+++ b/.github/workflows/metrics-collector.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   main:
+    if: github.owner == "grafana"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Actions


### PR DESCRIPTION
**What this PR does / why we need it**:

After a recent fork sync metrics-collector action started spamming with unsuccessful runs, but since its only used for github issue triage in the playground, there is no need for it to run on forks?

![image](https://github.com/grafana/loki/assets/74900682/73db0742-caea-4e21-a402-f7777232bee0)
```

Run ./actions/metrics-collector
/home/runner/work/loki/loki/actions/node_modules/@actions/core/lib/core.js:106
        throw new Error(`Input required and not supplied: ${name}`);
        ^

Error: Input required and not supplied: token
    at Object.getInput (/home/runner/work/loki/loki/actions/node_modules/@actions/core/lib/core.js:106:15)
    at getRequiredInput (/home/runner/work/loki/loki/actions/common/utils.js:40:41)
    at new ActionBase (/home/runner/work/loki/loki/actions/common/Action.js:16:51)
    at new Action (/home/runner/work/loki/loki/actions/common/Action.js:103:9)
    at new MetricsCollector (/home/runner/work/loki/loki/actions/metrics-collector/index.js:8:9)
    at Object.<anonymous> (/home/runner/work/loki/loki/actions/metrics-collector/index.js:56:1)
    at Module._compile (node:internal/modules/cjs/loader:1198:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1252:10)
    at Module.load (node:internal/modules/cjs/loader:1076:32)
    at Function.Module._load (node:internal/modules/cjs/loader:911:12)
```

Since there were no changes in action itself I assume something changed with repo action settings

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
