### PR TITLE
feat: Enable log volume endpoint by default in helm

### DIFF
--- a/docs/sources/setup/install/helm/reference.md
+++ b/docs/sources/setup/install/helm/reference.md
@@ -5250,7 +5250,8 @@ null
     "query_timeout": "300s",
     "reject_old_samples": true,
     "reject_old_samples_max_age": "168h",
-    "split_queries_by_interval": "15m"
+    "split_queries_by_interval": "15m",
+    "volume_enabled": true
   },
   "memberlistConfig": {},
   "memcached": {
@@ -5594,7 +5595,8 @@ null
   "query_timeout": "300s",
   "reject_old_samples": true,
   "reject_old_samples_max_age": "168h",
-  "split_queries_by_interval": "15m"
+  "split_queries_by_interval": "15m",
+  "volume_enabled": true
 }
 </pre>
 </td>

--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -13,6 +13,10 @@ Entries should include a reference to the pull request that introduced the chang
 
 [//]: # (<AUTOMATED_UPDATES_LOCATOR> : do not remove this line. This locator is used by the CI pipeline to automatically create a changelog entry for each new Loki release. Add other chart versions and respective changelog entries bellow this line.)
 
+## 6.2.4
+
+- [ENHANCEMENT] Activate the volume endpoint by default.
+
 ## 6.2.3
 
 - [ENHANCEMENT] Allow minio address to be overridden.

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -3,7 +3,7 @@ name: loki
 description: Helm chart for Grafana Loki in simple, scalable mode
 type: application
 appVersion: 3.0.0
-version: 6.2.3
+version: 6.2.4
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -1,6 +1,6 @@
 # loki
 
-![Version: 6.2.3](https://img.shields.io/badge/Version-6.2.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.0.0](https://img.shields.io/badge/AppVersion-3.0.0-informational?style=flat-square)
+![Version: 6.2.4](https://img.shields.io/badge/Version-6.2.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.0.0](https://img.shields.io/badge/AppVersion-3.0.0-informational?style=flat-square)
 
 Helm chart for Grafana Loki in simple, scalable mode
 

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -1907,8 +1907,7 @@ distributor:
   # -- Node selector for distributor pods
   nodeSelector: {}
   # -- Tolerations for distributor pods
-  tolerations:
-    []
+  tolerations: []
     # -- Adds the appProtocol field to the distributor service. This allows distributor to work with istio protocol selection.
   appProtocol:
     # -- Set the optional grpc service protocol. Ex: "grpc", "http2" or "https"
@@ -2775,8 +2774,7 @@ ruler:
   appProtocol:
     grpc: ""
   # -- Directories containing rules files
-  directories:
-    {}
+  directories: {}
     # tenant_foo:
     #   rules1.txt: |
     #     groups:

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -304,6 +304,7 @@ loki:
     max_cache_freshness_per_query: 10m
     split_queries_by_interval: 15m
     query_timeout: 300s
+    volume_enabled: true
   # -- Provides a reloadable runtime configuration file for some specific configuration
   runtimeConfig: {}
   # -- Check https://grafana.com/docs/loki/latest/configuration/#common_config for more info on how to provide a common configuration
@@ -1906,7 +1907,8 @@ distributor:
   # -- Node selector for distributor pods
   nodeSelector: {}
   # -- Tolerations for distributor pods
-  tolerations: []
+  tolerations:
+    []
     # -- Adds the appProtocol field to the distributor service. This allows distributor to work with istio protocol selection.
   appProtocol:
     # -- Set the optional grpc service protocol. Ex: "grpc", "http2" or "https"
@@ -2773,7 +2775,8 @@ ruler:
   appProtocol:
     grpc: ""
   # -- Directories containing rules files
-  directories: {}
+  directories:
+    {}
     # tenant_foo:
     #   rules1.txt: |
     #     groups:


### PR DESCRIPTION
**What this PR does / why we need it**:

Set volume API on by default in helm this is going to be a better experience and has been there for a while.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
