### PR TITLE
refactor(singlebinary): move from trigger to helpers

### DIFF
--- a/production/helm/loki/templates/_helpers.tpl
+++ b/production/helm/loki/templates/_helpers.tpl
@@ -31,6 +31,13 @@ singleBinary fullname
 {{- end -}}
 
 {{/*
+Return true if deployment mode is SingleBinary
+*/}}
+{{- define "loki.deployment.isSingleBinary" -}}
+  {{- eq .Values.deploymentMode "SingleBinary" }}
+{{- end -}}
+
+{{/*
 Resource name template
 Params:
   ctx = . context

--- a/production/helm/loki/templates/backend/clusterrole.yaml
+++ b/production/helm/loki/templates/backend/clusterrole.yaml
@@ -1,5 +1,5 @@
 {{- $isSimpleScalable := eq (include "loki.deployment.isScalable" .) "true" -}}
-{{- if and $isSimpleScalable (not .Values.rbac.namespaced) (not .Values.rbac.useExistingRole) }}
+{{- if and $isSimpleScalable (not .Values.rbac.namespaced) (not .Values.rbac.useExistingRole) (not (include "loki.deployment.isSingleBinary" .)) }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/production/helm/loki/templates/backend/clusterrolebinding.yaml
+++ b/production/helm/loki/templates/backend/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- $isSimpleScalable := eq (include "loki.deployment.isScalable" .) "true" -}}
-{{- if and $isSimpleScalable (not .Values.rbac.namespaced) }}
+{{- if and $isSimpleScalable (not .Values.rbac.namespaced) (not (include "loki.deployment.isSingleBinary" .)) }}
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/production/helm/loki/templates/backend/hpa.yaml
+++ b/production/helm/loki/templates/backend/hpa.yaml
@@ -1,6 +1,6 @@
 {{- $isSimpleScalable := eq (include "loki.deployment.isScalable" .) "true" -}}
 {{- $autoscalingv2 := .Capabilities.APIVersions.Has "autoscaling/v2" -}}
-{{- if and $isSimpleScalable (not .Values.read.legacyReadTarget ) ( .Values.backend.autoscaling.enabled ) }}
+{{- if and $isSimpleScalable (not .Values.read.legacyReadTarget ) ( .Values.backend.autoscaling.enabled ) (not (include "loki.deployment.isSingleBinary" .)) }}
 {{- if $autoscalingv2 }}
 apiVersion: autoscaling/v2
 {{- else }}

--- a/production/helm/loki/templates/backend/poddisruptionbudget-backend.yaml
+++ b/production/helm/loki/templates/backend/poddisruptionbudget-backend.yaml
@@ -1,5 +1,5 @@
 {{- $isSimpleScalable := eq (include "loki.deployment.isScalable" .) "true" -}}
-{{- if and $isSimpleScalable (gt (int .Values.backend.replicas) 1) (not .Values.read.legacyReadTarget ) }}
+{{- if and $isSimpleScalable (gt (int .Values.backend.replicas) 1) (not .Values.read.legacyReadTarget ) (not (include "loki.deployment.isSingleBinary" .)) }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:

--- a/production/helm/loki/templates/backend/query-scheduler-discovery.yaml
+++ b/production/helm/loki/templates/backend/query-scheduler-discovery.yaml
@@ -1,5 +1,5 @@
 {{- $isSimpleScalable := eq (include "loki.deployment.isScalable" .) "true" -}}
-{{- if and $isSimpleScalable (not .Values.read.legacyReadTarget ) }}
+{{- if and $isSimpleScalable (not .Values.read.legacyReadTarget ) (not (include "loki.deployment.isSingleBinary" .)) }}
 ---
 apiVersion: v1
 kind: Service

--- a/production/helm/loki/templates/backend/service-backend-headless.yaml
+++ b/production/helm/loki/templates/backend/service-backend-headless.yaml
@@ -1,5 +1,5 @@
 {{- $isSimpleScalable := eq (include "loki.deployment.isScalable" .) "true" -}}
-{{- if and $isSimpleScalable (not .Values.read.legacyReadTarget ) }}
+{{- if and $isSimpleScalable (not .Values.read.legacyReadTarget ) (not (include "loki.deployment.isSingleBinary" .)) }}
 ---
 apiVersion: v1
 kind: Service

--- a/production/helm/loki/templates/backend/service-backend.yaml
+++ b/production/helm/loki/templates/backend/service-backend.yaml
@@ -1,5 +1,5 @@
 {{- $isSimpleScalable := eq (include "loki.deployment.isScalable" .) "true" -}}
-{{- if and $isSimpleScalable (not .Values.read.legacyReadTarget ) }}
+{{- if and $isSimpleScalable (not .Values.read.legacyReadTarget ) (not (include "loki.deployment.isSingleBinary" .)) }}
 ---
 apiVersion: v1
 kind: Service

--- a/production/helm/loki/templates/backend/statefulset-backend.yaml
+++ b/production/helm/loki/templates/backend/statefulset-backend.yaml
@@ -19,12 +19,8 @@ metadata:
     {{- end }}
   {{- end }}
 spec:
-{{- if not .Values.write.autoscaling.enabled }}
-  {{- if eq .Values.deploymentMode "SingleBinary" }}
-  replicas: 0
-  {{- else }}
-  replicas: {{ .Values.write.replicas }}
-  {{- end }}
+{{- if not .Values.backend.autoscaling.enabled }}
+  replicas: {{ .Values.backend.replicas }}
 {{- end }}
   podManagementPolicy: {{ .Values.backend.podManagementPolicy }}
   updateStrategy:

--- a/production/helm/loki/templates/backend/statefulset-backend.yaml
+++ b/production/helm/loki/templates/backend/statefulset-backend.yaml
@@ -1,5 +1,5 @@
 {{- $isSimpleScalable := eq (include "loki.deployment.isScalable" .) "true" -}}
-{{- if and $isSimpleScalable (not .Values.read.legacyReadTarget ) }}
+{{- if and $isSimpleScalable (not .Values.read.legacyReadTarget ) (not (include "loki.deployment.isSingleBinary" .)) }}
 ---
 apiVersion: apps/v1
 kind: StatefulSet

--- a/production/helm/loki/templates/read/statefulset-read.yaml
+++ b/production/helm/loki/templates/read/statefulset-read.yaml
@@ -20,11 +20,7 @@ metadata:
   {{- end }}
 spec:
 {{- if not .Values.write.autoscaling.enabled }}
-  {{- if eq .Values.deploymentMode "SingleBinary" }}
   replicas: 0
-  {{- else }}
-  replicas: {{ .Values.write.replicas }}
-  {{- end }}
 {{- end }}
   podManagementPolicy: {{ .Values.read.podManagementPolicy }}
   updateStrategy:

--- a/production/helm/loki/templates/write/statefulset-write.yaml
+++ b/production/helm/loki/templates/write/statefulset-write.yaml
@@ -20,11 +20,7 @@ metadata:
   {{- end }}
 spec:
 {{- if not .Values.write.autoscaling.enabled }}
-  {{- if eq .Values.deploymentMode "SingleBinary" }}
   replicas: 0
-  {{- else }}
-  replicas: {{ .Values.write.replicas }}
-  {{- end }}
 {{- end }}
   podManagementPolicy: {{ .Values.write.podManagementPolicy }}
   updateStrategy:


### PR DESCRIPTION
**What this PR does / why we need it**:

This pr extrapolates the logic of the singlebinary inside the helpersfile and the use that to condition the existance of the various components instead of putting replicas to 0

**Which issue(s) this PR fixes**:
[Continues/Refactor this PR](https://github.com/grafana/loki/pull/12590)

**Special notes for your reviewer**:


**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
