### PR TITLE
feat: parameterise the MaximumEventAgeInSeconds, LogGroupName, and IAMRoleName for lambda-promtail CloudFormation template

### DIFF
--- a/tools/lambda-promtail/template.yaml
+++ b/tools/lambda-promtail/template.yaml
@@ -85,10 +85,10 @@ Resources:
           Statement:
           - Effect: Allow
             Action:
-              - logs:CreateLogGroup
-              - logs:CreateLogStream
-              - logs:PutLogEvents
-              - logs:PutSubscriptionFilter
+            - logs:CreateLogGroup
+            - logs:CreateLogStream
+            - logs:PutLogEvents
+            - logs:PutSubscriptionFilter
             Resource: arn:aws:logs:*:*:*
       RoleName: !Ref IAMRoleName
   LambdaPromtailFunction:

--- a/tools/lambda-promtail/template.yaml
+++ b/tools/lambda-promtail/template.yaml
@@ -71,25 +71,25 @@ Resources:
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:
-          - Effect: Allow
-            Principal:
-              Service:
-                - lambda.amazonaws.com
-            Action:
-              - sts:AssumeRole
+        - Effect: Allow
+          Principal:
+            Service:
+            - lambda.amazonaws.com
+          Action:
+          - sts:AssumeRole
       Description: "Lambda Promtail Role"
       Policies:
-        - PolicyName: logs
-          PolicyDocument:
-            Version: '2012-10-17'
-            Statement:
-              - Effect: Allow
-                Action:
-                  - logs:CreateLogGroup
-                  - logs:CreateLogStream
-                  - logs:PutLogEvents
-                  - logs:PutSubscriptionFilter
-                Resource: arn:aws:logs:*:*:*
+      - PolicyName: logs
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action:
+              - logs:CreateLogGroup
+              - logs:CreateLogStream
+              - logs:PutLogEvents
+              - logs:PutSubscriptionFilter
+            Resource: arn:aws:logs:*:*:*
       RoleName: !Ref IAMRoleName
   LambdaPromtailFunction:
     Type: AWS::Lambda::Function

--- a/tools/lambda-promtail/template.yaml
+++ b/tools/lambda-promtail/template.yaml
@@ -13,6 +13,10 @@ Parameters:
     Description: The maximum of concurrent executions you want to reserve for the function.
     Type: Number
     Default: 2
+  MaximumEventAgeInSeconds:
+    Description: The maximum age of a request that Lambda sends to a function for processing.
+    Type: Number
+    Default: 21600
   Username:
     Description: The basic auth username, necessary if writing directly to Grafana Cloud Loki.
     Type: String
@@ -51,6 +55,14 @@ Parameters:
     Description: Determines whether to verify the TLS certificate
     Type: String
     Default: "false"
+  LogGroupName:
+    Description: Name of the CloudWatch Log Group to subscribe from.
+    Type: String
+    Default: "/aws/lambda/some-lamda-log-group"
+  IAMRoleName:
+    Description: Name of the LambdaPromtailRole IAM Role.
+    Type: String
+    Default: "iam_for_lambda"
 
 Resources:
   LambdaPromtailRole:
@@ -59,26 +71,26 @@ Resources:
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:
-        - Effect: Allow
-          Principal:
-            Service:
-            - lambda.amazonaws.com
-          Action:
-          - sts:AssumeRole
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - sts:AssumeRole
       Description: "Lambda Promtail Role"
       Policies:
-      - PolicyName: logs
-        PolicyDocument:
-          Version: '2012-10-17'
-          Statement:
-          - Effect: Allow
-            Action:
-            - logs:CreateLogGroup
-            - logs:CreateLogStream
-            - logs:PutLogEvents
-            - logs:PutSubscriptionFilter
-            Resource: arn:aws:logs:*:*:*
-      RoleName: iam_for_lambda
+        - PolicyName: logs
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                  - logs:PutSubscriptionFilter
+                Resource: arn:aws:logs:*:*:*
+      RoleName: !Ref IAMRoleName
   LambdaPromtailFunction:
     Type: AWS::Lambda::Function
     Properties:
@@ -119,6 +131,7 @@ Resources:
     Properties:
       FunctionName: !Ref LambdaPromtailFunction
       MaximumRetryAttempts: 2
+      MaximumEventAgeInSeconds: !Ref MaximumEventAgeInSeconds
       Qualifier: !GetAtt LambdaPromtailVersion.Version
   # Copy this block and modify as required to create Subscription Filters for
   # additional CloudWatch Log Groups.
@@ -128,7 +141,7 @@ Resources:
     Properties:
       DestinationArn: !GetAtt LambdaPromtailFunction.Arn
       FilterPattern: ""
-      LogGroupName: "/aws/lambda/some-lamda-log-group"
+      LogGroupName: !Ref LogGroupName
 
 Outputs:
   LambdaPromtailFunction:


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

It adds the parameter for specifying `MaximumEventAgeInSeconds` for the lambda-promtail's EventInvokeConfig template.

**Why do we need this?**

Without specifying this, the default value is `21600` which is 6 hours. We have been facing a problem where our lambda-promtail gets throttled and cannot process cloudwatch logs fast enough.

This has an effect as the more throttled it is, the more delay the event got processed, and eventually the old messages will  be too old for Loki, causing even more failure to the Lambda processing

```
server returned HTTP status 400 Bad Request (400): entry with timestamp 2024-04-22 08:10:31.966 +0000 UTC ignored, reason: 'entry too far behind, oldest acceptable timestamp is: 2024-04-22T08:21:38Z',: errorString
```


![image](https://github.com/grafana/loki/assets/16816820/f4ae747b-c52d-4d1e-a5b4-8d91de066149)


![image](https://github.com/grafana/loki/assets/16816820/9ccc29c6-bb4f-461b-bd2b-8ce586595050)

Once we got to this point, the only way to mitigate this is to discard the old events, and the only way to do it is to change the `MaximumEventAgeInSeconds`

![image](https://github.com/grafana/loki/assets/16816820/aabd677e-73a2-4a35-8440-77b723d91b17)


As the current template does not allow this, we are making this PR so we can benefit from upstream fix.

**Test**

Using this version of the `lambda-promtail.yaml` and put 100 seconds as `MaximumEventAgeInSeconds`

![image](https://github.com/grafana/loki/assets/16816820/a747f4a9-4f15-471d-a333-739dd2c6482b)


Checking the configuration of the new version, it's updated as it should

![image](https://github.com/grafana/loki/assets/16816820/bc93e98d-e688-44d6-bc8c-2a39e5374b9b)


**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
