### PR TITLE
ci: update drone image version to 0.33.2

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -376,7 +376,7 @@ local manifest_ecr(apps, archs) = pipeline('manifest-ecr') {
   ],
 };
 
-local build_image_tag = '0.33.1';
+local build_image_tag = '0.33.2';
 [
   pipeline('loki-build-image-' + arch) {
     workspace: {

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -17,7 +17,7 @@ steps:
       from_secret: docker_password
     repo: grafana/loki-build-image
     tags:
-    - 0.33.1-amd64
+    - 0.33.2-amd64
     username:
       from_secret: docker_username
   when:
@@ -54,7 +54,7 @@ steps:
       from_secret: docker_password
     repo: grafana/loki-build-image
     tags:
-    - 0.33.1-arm64
+    - 0.33.2-arm64
     username:
       from_secret: docker_username
   when:
@@ -86,7 +86,7 @@ steps:
     password:
       from_secret: docker_password
     spec: .drone/docker-manifest-build-image.tmpl
-    target: loki-build-image:0.33.1
+    target: loki-build-image:0.33.2
     username:
       from_secret: docker_username
   when:
@@ -1306,8 +1306,3 @@ get:
   path: infra/data/ci/packages-publish/gpg
 kind: secret
 name: gpg_private_key
----
-kind: signature
-hmac: e0940674c7a2b5ae47c6509b0bc97dc594a054e5b881fd1962b81837d6b1dee6
-
-...

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -1306,3 +1306,8 @@ get:
   path: infra/data/ci/packages-publish/gpg
 kind: secret
 name: gpg_private_key
+---
+kind: signature
+hmac: 9bf822bf90b378304512cc3e1363d3ba9a3050b2fe3a0c8eb03dcd68ad80355b
+
+...

--- a/loki-build-image/README.md
+++ b/loki-build-image/README.md
@@ -2,6 +2,10 @@
 
 ## Versions
 
+### 0.33.2
+
+- Update to go 1.22.2
+
 ### 0.33.1-golangci.1.51.2
 
 - Update to Go version 1.21.9 but restore golangci-lint to v1.51.2


### PR DESCRIPTION
follow up to https://github.com/grafana/loki/pull/12706 where I forgot to bump the image version