### PR TITLE
feat: add detected-fields command to logcli

### DIFF
--- a/pkg/logcli/client/file.go
+++ b/pkg/logcli/client/file.go
@@ -190,17 +190,28 @@ func (f *FileClient) GetOrgID() string {
 }
 
 func (f *FileClient) GetStats(_ string, _, _ time.Time, _ bool) (*logproto.IndexStatsResponse, error) {
-	// TODO(trevorwhitney): could we teach logcli to read from an actual index file?
+	// TODO(twhitney): could we teach logcli to read from an actual index file?
 	return nil, ErrNotSupported
 }
 
 func (f *FileClient) GetVolume(_ *volume.Query) (*loghttp.QueryResponse, error) {
-	// TODO(trevorwhitney): could we teach logcli to read from an actual index file?
+	// TODO(twhitney): could we teach logcli to read from an actual index file?
 	return nil, ErrNotSupported
 }
 
 func (f *FileClient) GetVolumeRange(_ *volume.Query) (*loghttp.QueryResponse, error) {
-	// TODO(trevorwhitney): could we teach logcli to read from an actual index file?
+	// TODO(twhitney): could we teach logcli to read from an actual index file?
+	return nil, ErrNotSupported
+}
+
+func (f *FileClient) GetDetectedFields(
+	_ string,
+	_, _ int,
+	_, _ time.Time,
+	_ time.Duration,
+	_ bool,
+) (*loghttp.DetectedFieldsResponse, error) {
+	// TODO(twhitney): could we teach logcli to do this?
 	return nil, ErrNotSupported
 }
 

--- a/pkg/logcli/detected/fields.go
+++ b/pkg/logcli/detected/fields.go
@@ -1,0 +1,46 @@
+package detected
+
+import (
+	"fmt"
+	"log"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/fatih/color"
+	"github.com/grafana/loki/v3/pkg/logcli/client"
+	"github.com/grafana/loki/v3/pkg/loghttp"
+)
+
+type DetectedFieldsQuery struct {
+	QueryString   string
+	Start         time.Time
+	End           time.Time
+	FieldLimit    int
+	LineLimit     int
+	Step          time.Duration
+	Quiet         bool
+	ColoredOutput bool
+}
+
+// DoQuery executes the query and prints out the results
+func (q *DetectedFieldsQuery) Do(c client.Client, statistics bool) {
+	var resp *loghttp.DetectedFieldsResponse
+	var err error
+
+	resp, err = c.GetDetectedFields(q.QueryString, q.FieldLimit, q.LineLimit, q.Start, q.End, q.Step, q.Quiet)
+	if err != nil {
+		log.Fatalf("Error doing request: %+v", err)
+	}
+
+	output := make([]string, len(resp.Fields))
+	for i, field := range resp.Fields {
+		bold := color.New(color.Bold)
+		output[i] = fmt.Sprintf("label: %s\t\t", bold.Sprintf("%s", field.Label)) +
+			fmt.Sprintf("type: %s\t\t", bold.Sprintf("%s", field.Type)) +
+			fmt.Sprintf("cardinality: %s", bold.Sprintf("%d", field.Cardinality))
+	}
+
+	slices.Sort(output)
+	fmt.Println(strings.Join(output, "\n"))
+}

--- a/pkg/loghttp/detected.go
+++ b/pkg/loghttp/detected.go
@@ -1,0 +1,14 @@
+package loghttp
+
+import "github.com/grafana/loki/v3/pkg/logproto"
+
+// LabelResponse represents the http json response to a label query
+type DetectedFieldsResponse struct {
+	Fields   []DetectedField`json:"fields,omitempty"`
+}
+
+type DetectedField struct {
+	Label       string            `json:"label,omitempty"`
+	Type        logproto.DetectedFieldType `json:"type,omitempty"`
+	Cardinality uint64            `json:"cardinality,omitempty"`
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds the `detected_fields` command to logcli.