### PR TITLE
fix(packaging): Require online network in systemd unit file for Loki and Promtail

### DIFF
--- a/tools/packaging/loki.service
+++ b/tools/packaging/loki.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Loki service
-After=network.target
+After=network-online.target
+Wants=network-online.target
 
 [Service]
 Type=simple

--- a/tools/packaging/promtail.service
+++ b/tools/packaging/promtail.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Promtail service
-After=network.target
+After=network-online.target
+Wants=network-online.target
 
 [Service]
 Type=simple


### PR DESCRIPTION
### What this PR does / why we need it:

From https://systemd.io/NETWORK_ONLINE/:

**How do I make sure that my service starts after the network is really online?**

That depends on your setup and the services you plan to run after it (see above). If you need to delay you service after network connectivity has been established, include

```systemd
After=network-online.target
Wants=network-online.target
```

in the `.service` file.

This will delay boot until the network management software says the network is “up”. For details, see the next question.

### Which issue(s) this PR fixes:

Closes #12724 

### Checklist

- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
