### PR TITLE
docs: Update supported and deprecated type in Manage > Storage

### DIFF
--- a/docs/sources/operations/storage/_index.md
+++ b/docs/sources/operations/storage/_index.md
@@ -9,16 +9,16 @@ You can read a high level overview of Loki storage [here](https://grafana.com/do
 
 Grafana Loki needs to store two different types of data: **chunks** and **indexes**.
 
+When using Accelerated Search (experimental), then a third data type is used: **bloom blocks**.
+
 Loki receives logs in separate streams, where each stream is uniquely identified
 by its tenant ID and its set of labels. As log entries from a stream arrive,
-they are compressed as "chunks" and saved in the chunks store. See [chunk
+they are compressed as **chunks** and saved in the chunks store. See [chunk
 format](#chunk-format) for how chunks are stored internally.
 
 The **index** stores each stream's label set and links them to the individual
-chunks.
-
-Refer to Loki's [configuration](https://grafana.com/docs/loki/<LOKI_VERSION>/configure/) for details on
-how to configure the storage and the index.
+chunks. Refer to Loki's [configuration](https://grafana.com/docs/loki/<LOKI_VERSION>/configure/) for
+details on how to configure the storage and the index.
 
 For more information:
 
@@ -26,36 +26,36 @@ For more information:
 - [Retention](https://grafana.com/docs/loki/<LOKI_VERSION>/operations/storage/retention/)
 - [Logs Deletion](https://grafana.com/docs/loki/<LOKI_VERSION>/operations/storage/logs-deletion/)
 
-## Supported Stores
+## Store Types
 
-The following are supported for the index:
+### ✅ Supported index stores
 
-- [TSDB](https://grafana.com/docs/loki/<LOKI_VERSION>/operations/storage/tsdb/) index store which stores TSDB index files in the object store. This is the recommended index store for Loki 2.8 and newer.
-- [Single Store (boltdb-shipper)](https://grafana.com/docs/loki/<LOKI_VERSION>/operations/storage/boltdb-shipper/) index store which stores boltdb index files in the object store. 
-- [Amazon DynamoDB](https://aws.amazon.com/dynamodb)
-- [Google Bigtable](https://cloud.google.com/bigtable)
-- [Apache Cassandra](https://cassandra.apache.org)
-- [BoltDB](https://github.com/boltdb/bolt) (doesn't work when clustering Loki)
+- [Single Store TSDB](https://grafana.com/docs/loki/<LOKI_VERSION>/operations/storage/tsdb/) index store which stores TSDB index files in the object store.
+  **This is the recommended index store for Loki 2.8 and newer.**
+- [Single Store BoltDB (boltdb-shipper)](https://grafana.com/docs/loki/<LOKI_VERSION>/operations/storage/boltdb-shipper/) index store which stores boltdb index files in the object store.
 
-The following are deprecated for the index and will be removed in a future release:
+### ❌ Deprecated index stores
 
 - [Amazon DynamoDB](https://aws.amazon.com/dynamodb). Support for this is deprecated and will be removed in a future release.
 - [Google Bigtable](https://cloud.google.com/bigtable). Support for this is deprecated and will be removed in a future release.
 - [Apache Cassandra](https://cassandra.apache.org). Support for this is deprecated and will be removed in a future release.
+- [BoltDB](https://github.com/boltdb/bolt) (doesn't work when clustering Loki)
 
-The following are supported and recommended for the chunks:
+### ✅ Supported and recommended chunks stores
 
-- [Amazon S3](https://aws.amazon.com/s3)
-- [Google Cloud Storage](https://cloud.google.com/storage/)
+- [Amazon Simple Storage Storage (S3)](https://aws.amazon.com/s3)
+- [Google Cloud Storage (GCS)](https://cloud.google.com/storage/)
+- [Microsoft Azure Blob Storage](https://azure.microsoft.com/en-us/products/storage/blobs)
+- [IBM Cloud Object Storage (COS)](https://www.ibm.com/cloud/object-storage)
+- [Baidu Object Storage (BOS)](https://cloud.baidu.com/product/bos.html)
+- [Alibaba Object Storage Service (OSS)](https://www.alibabacloud.com/product/object-storage-service)
+
+### ⚠️ Supported chunks stores, not typically recommended for production use
+
 - [Filesystem]({{< relref "./filesystem" >}}) (please read more about the filesystem to understand the pros/cons before using with production data)
-- [Baidu Object Storage](https://cloud.baidu.com/product/bos.html)
-- [IBM Cloud Object Storage](https://www.ibm.com/cloud/object-storage)
+- S3 API compatible storage, such as [MinIO](https://min.io/)
 
-The following are supported for the chunks, but not typically recommended for production use:
-
-- [Filesystem]({{< relref "./filesystem" >}}) (please read more about the filesystem to understand the pros/cons before using with production data)
-
-The following are deprecated for the chunks and will be removed in a future release:
+### ❌ Deprecated chunks stores
 
 - [Amazon DynamoDB](https://aws.amazon.com/dynamodb). Support for this is deprecated and will be removed in a future release.
 - [Google Bigtable](https://cloud.google.com/bigtable). Support for this is deprecated and will be removed in a future release.


### PR DESCRIPTION
**What this PR does / why we need it**:

Make distinction between supported and deprecated store types more visible on this page, similar to what's listed under `Configure > Storage`.

Also updated the list of supported object store backends.