### PR TITLE
feat: Allow promtail to skip or stop tailing watching files/folders that contain a file with promtail_ignore in the title. 

### DIFF
--- a/clients/pkg/promtail/targets/file/filetarget.go
+++ b/clients/pkg/promtail/targets/file/filetarget.go
@@ -262,7 +262,9 @@ func (t *FileTarget) sync() error {
 			}
 		}
 	}
-
+	
+	matches = removeFilesInIgnoredDirectories(matches)
+	
 	if len(matches) == 0 {
 		level.Debug(t.logger).Log("msg", "no files matched requested path, nothing will be tailed", "path", t.path, "pathExclude", t.pathExclude)
 	}
@@ -319,6 +321,17 @@ func (t *FileTarget) sync() error {
 	t.stopTailingAndRemovePosition(toStopTailing)
 
 	return nil
+}
+
+// given a list of files return the list of files minus those in directories with ignore files
+func removeFilesInIgnoredDirectories(matches []string ) []string {
+	for j := 0; j < len(matches); j++ {
+		if d,err := doublestar.Glob(filepath.Join(filepath.Dir(matches[j]), "*promtail_ignore*")); len(d) > 0 {
+			// exclude this specific match
+				matches = append(matches[:j], matches[j+1:]...)
+		}
+	return matches
+
 }
 
 func (t *FileTarget) startWatching(dirs map[string]struct{}) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Allow promtail to skip or stop tailing watching files/folders that contain a file with promtail_ignore in the title. 
promtail works poorly with transient log files (like airflow dag logs) because it tries to watch an ever growing list of files folders which will likely never change again. 

This allows you to stop promtail watching those files/folders on the fly



**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)

Initial PR to see if there is any views towards it, can work on tests later
