### PR TITLE
fix(helm): Fix unneeded command argument in ingester statefulset

### DIFF
--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -13,6 +13,10 @@ Entries should include a reference to the pull request that introduced the chang
 
 [//]: # (<AUTOMATED_UPDATES_LOCATOR> : do not remove this line. This locator is used by the CI pipeline to automatically create a changelog entry for each new Loki release. Add other chart versions and respective changelog entries bellow this line.)
 
+## 6.3.5
+
+- [BUGFIX] Remove unexisting command argument `ingester.ring.instance-availability-zone` in ingester statfulset
+
 ## 6.3.4
 
 - [BUGFIX] Add missing OTLP endpoint to nginx config

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -3,7 +3,7 @@ name: loki
 description: Helm chart for Grafana Loki in simple, scalable mode
 type: application
 appVersion: 3.0.0
-version: 6.3.4
+version: 6.3.5
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/production/helm/loki/templates/ingester/statefulset-ingester.yaml
+++ b/production/helm/loki/templates/ingester/statefulset-ingester.yaml
@@ -87,7 +87,6 @@ spec:
           {{- end }}
           args:
             - -config.file=/etc/loki/config/config.yaml
-            - -ingester.ring.instance-availability-zone=zone-default
             - -target=ingester
             {{- with .Values.ingester.extraArgs }}
             {{- toYaml . | nindent 12 }}


### PR DESCRIPTION
**What this PR does / why we need it**:

When running Loki in distributed mode and without zone aware replication, the statefulset template sets `ingester.ring.instance-availability-zone` argument but it not specified in the Loki configuration flags.

This results in ingester pods crashing at startup with the following message: 
```
flag provided but not defined: -ingester.ring.instance-availability-zone
Run with -help to get list of available parameters
```

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [X] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
