### PR TITLE
docs: fix broken link

### DIFF
--- a/docs/sources/send-data/promtail/installation.md
+++ b/docs/sources/send-data/promtail/installation.md
@@ -15,13 +15,13 @@ or there is a Helm chart to install it in a Kubernetes cluster.
 ## Install the binary
 
 Every Grafana Loki release includes binaries for Promtail which can be found on the
-[Releases page](https://github.com/grafana/loki/releases) as part of the release assets. 
+[Releases page](https://github.com/grafana/loki/releases) as part of the release assets.
 
 ## Install using APT or RPM package manager
 
-See the instructions [here](https://grafana.com/docs/loki/setup/install/local/#install-using-apt-or-rpm-package-manager). 
+See the instructions [here](https://grafana.com/docs/loki/<LOKI_VERSION>/setup/install/local/#install-using-apt-or-rpm-package-manager).
 
-## Install using Docker 
+## Install using Docker
 
 ```bash
 # modify tag to most recent version
@@ -45,6 +45,7 @@ helm repo update
 ```
 
 Create the configuration file `values.yaml`. The example below illustrates a connection to the locally deployed loki server:
+
 ```yaml
 config:
   # publish data to loki


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes broken link reported via docs @ grafana email.
Section added for 3.0 docs, does not exist in 2.9 docs.

Fixes malformed link that was introduced by #11502 and not fixed in #12677 because I didn't look closely enough at the link.  This time I've tested the link, so it should really be fixed this time.  🙄