### PR TITLE
fix(helm): add bloom compactor service object

### DIFF
--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -13,6 +13,10 @@ Entries should include a reference to the pull request that introduced the chang
 
 [//]: # (<AUTOMATED_UPDATES_LOCATOR> : do not remove this line. This locator is used by the CI pipeline to automatically create a changelog entry for each new Loki release. Add other chart versions and respective changelog entries bellow this line.)
 
+## 6.3.6
+
+- [BUGFIX] Add service object for bloom compactor in distributed mode
+
 ## 6.3.4
 
 - [BUGFIX] Add missing OTLP endpoint to nginx config

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -3,7 +3,7 @@ name: loki
 description: Helm chart for Grafana Loki in simple, scalable mode
 type: application
 appVersion: 3.0.0
-version: 6.3.4
+version: 6.3.6
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -1,6 +1,6 @@
 # loki
 
-![Version: 6.3.4](https://img.shields.io/badge/Version-6.3.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.0.0](https://img.shields.io/badge/AppVersion-3.0.0-informational?style=flat-square)
+![Version: 6.3.6](https://img.shields.io/badge/Version-6.3.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.0.0](https://img.shields.io/badge/AppVersion-3.0.0-informational?style=flat-square)
 
 Helm chart for Grafana Loki in simple, scalable mode
 

--- a/production/helm/loki/templates/bloom-compactor/service-bloom-compactor-headless.yaml
+++ b/production/helm/loki/templates/bloom-compactor/service-bloom-compactor-headless.yaml
@@ -1,0 +1,36 @@
+{{- $isDistributed := eq (include "loki.deployment.isDistributed" .) "true" -}}
+{{- if $isDistributed -}}
+{{- if (gt (int .Values.bloomCompactor.replicas) 0) -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "loki.bloomCompactorFullname" . }}-headless
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "loki.bloomCompactorSelectorLabels" . | nindent 4 }}
+    {{- with .Values.bloomCompactor.serviceLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.loki.serviceAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: http-metrics
+      port: 3100
+      targetPort: http-metrics
+      protocol: TCP
+    - name: grpc
+      port: 9095
+      targetPort: grpc
+      protocol: TCP
+      {{- if .Values.bloomCompactor.appProtocol.grpc }}
+      appProtocol: {{ .Values.bloomCompactor.appProtocol.grpc }}
+      {{- end }}
+  selector:
+    {{- include "loki.bloomCompactorSelectorLabels" . | nindent 4 }}
+{{- end -}}
+{{- end -}}


### PR DESCRIPTION
**What this PR does / why we need it**:
Bloom compactor in distributed mode was missing service object, which caused serviceMonitor to not catch it during monitoring discovery.

Simple fix, all values was already present in values.yaml.

Not sure on version since i already bumped chart to 6.3.5 in another PR, so i set it to 6.3.6

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
