### PR TITLE
fix(blooms): Fix a regression introduced with #12774

### DIFF
--- a/pkg/bloomgateway/resolver.go
+++ b/pkg/bloomgateway/resolver.go
@@ -110,14 +110,14 @@ func unassignedSeries(mapped []blockWithSeries, series []*logproto.GroupedChunkR
 		})
 
 		maxIdx := sort.Search(len(skipped), func(i int) bool {
-			return skipped[i].Fingerprint >= maxFp.Fingerprint
+			return skipped[i].Fingerprint > maxFp.Fingerprint
 		})
 
 		if minIdx == len(skipped) || maxIdx == 0 || minIdx == maxIdx {
 			continue
 		}
 
-		skipped = append(skipped[0:minIdx], skipped[maxIdx+1:]...)
+		skipped = append(skipped[0:minIdx], skipped[maxIdx:]...)
 	}
 
 	return skipped

--- a/pkg/bloomgateway/resolver_test.go
+++ b/pkg/bloomgateway/resolver_test.go
@@ -242,12 +242,34 @@ func TestBlockResolver_UnassignedSeries(t *testing.T) {
 				{Fingerprint: 0xe0},
 			},
 		},
+		{
+			desc: "block overlapping single remaining series",
+			mapped: []blockWithSeries{
+				{
+					series: []*logproto.GroupedChunkRefs{
+						{Fingerprint: 0x00},
+						{Fingerprint: 0x20},
+						{Fingerprint: 0x40},
+						{Fingerprint: 0x60},
+						{Fingerprint: 0x80},
+						{Fingerprint: 0xa0},
+						{Fingerprint: 0xc0},
+					},
+				},
+				{
+					series: []*logproto.GroupedChunkRefs{
+						{Fingerprint: 0xe0},
+					},
+				},
+			},
+			expected: []*logproto.GroupedChunkRefs{},
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			result := unassignedSeries(tc.mapped, series)
-			require.Equal(t, result, tc.expected)
+			require.Equal(t, tc.expected, result)
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes a regression introduced with #12774 where series where wrongly identified as "skipped" even though there were part of blocks.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
