### PR TITLE
fix: loki-operational.libsonnet

### DIFF
--- a/production/loki-mixin/dashboards/loki-operational.libsonnet
+++ b/production/loki-mixin/dashboards/loki-operational.libsonnet
@@ -88,8 +88,8 @@ local utils = import 'mixin-utils/utils.libsonnet';
                                      'cluster="$cluster"',
                                      $._config.per_cluster_label + '="$cluster"'
                                    ),
-                                   'cluster_',
-                                   $._config.per_cluster_label + '_'
+                                   'cluster_job',
+                                   $._config.per_cluster_label + '_job'
                                  )
                                  else
                                    std.strReplace(


### PR DESCRIPTION
This PR fixes the  loki-operational.libsonnet mixin in case the value of per_cluster_label starts with cluster_.

For historical reasons, we named the cluster label cluster_id so generation actually replaces all cluster_id with cluster_id_id in this dashboard because the replace is incorrect

**What this PR does / why we need it**:

This PR fixes the loki operational dashboard when the cluster label starts with cluster_

**Which issue(s) this PR fixes**:

Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
