### PR TITLE
fix(promtail): Fix bug with Promtail config reloading getting stuck indefinitely

### DIFF
--- a/clients/pkg/promtail/targets/file/filetarget.go
+++ b/clients/pkg/promtail/targets/file/filetarget.go
@@ -348,7 +348,6 @@ func (t *FileTarget) startWatching(dirs map[string]struct{}) error {
 			path:      dir,
 			eventType: fileTargetEventWatchStart,
 		}:
-			// continue
 		}
 	}
 	return nil
@@ -368,7 +367,6 @@ func (t *FileTarget) stopWatching(dirs map[string]struct{}) error {
 			path:      dir,
 			eventType: fileTargetEventWatchStop,
 		}:
-			// continue
 		}
 	}
 	return nil

--- a/clients/pkg/promtail/targets/file/filetarget.go
+++ b/clients/pkg/promtail/targets/file/filetarget.go
@@ -25,6 +25,8 @@ const (
 	FilenameLabel = "filename"
 )
 
+var errFileTargetStopped = errors.New("File target is stopped")
+
 // Config describes behavior for Target
 type Config struct {
 	SyncPeriod time.Duration `mapstructure:"sync_period" yaml:"sync_period"`
@@ -223,6 +225,11 @@ func (t *FileTarget) run() {
 			}
 		case <-ticker.C:
 			err := t.sync()
+			if errors.Is(err, errFileTargetStopped) {
+				// This file target has been stopped.
+				// This is normal and there is no need to log an error.
+				return
+			}
 			if err != nil {
 				level.Error(t.logger).Log("msg", "error running sync function", "error", err)
 			}
@@ -291,14 +298,20 @@ func (t *FileTarget) sync() error {
 	t.watchesMutex.Lock()
 	toStartWatching := missing(t.watches, dirs)
 	t.watchesMutex.Unlock()
-	t.startWatching(toStartWatching)
+	err := t.startWatching(toStartWatching)
+	if errors.Is(err, errFileTargetStopped) {
+		return err
+	}
 
 	// Remove any directories which no longer need watching.
 	t.watchesMutex.Lock()
 	toStopWatching := missing(dirs, t.watches)
 	t.watchesMutex.Unlock()
 
-	t.stopWatching(toStopWatching)
+	err = t.stopWatching(toStopWatching)
+	if errors.Is(err, errFileTargetStopped) {
+		return err
+	}
 
 	// fsnotify.Watcher doesn't allow us to see what is currently being watched so we have to track it ourselves.
 	t.watchesMutex.Lock()
@@ -321,32 +334,44 @@ func (t *FileTarget) sync() error {
 	return nil
 }
 
-func (t *FileTarget) startWatching(dirs map[string]struct{}) {
+func (t *FileTarget) startWatching(dirs map[string]struct{}) error {
 	for dir := range dirs {
 		if _, ok := t.getWatch(dir); ok {
 			continue
 		}
 
 		level.Info(t.logger).Log("msg", "watching new directory", "directory", dir)
-		t.targetEventHandler <- fileTargetEvent{
+		select {
+		case <-t.quit:
+			return errFileTargetStopped
+		case t.targetEventHandler <- fileTargetEvent{
 			path:      dir,
 			eventType: fileTargetEventWatchStart,
+		}:
+			// continue
 		}
 	}
+	return nil
 }
 
-func (t *FileTarget) stopWatching(dirs map[string]struct{}) {
+func (t *FileTarget) stopWatching(dirs map[string]struct{}) error {
 	for dir := range dirs {
 		if _, ok := t.getWatch(dir); !ok {
 			continue
 		}
 
 		level.Info(t.logger).Log("msg", "removing directory from watcher", "directory", dir)
-		t.targetEventHandler <- fileTargetEvent{
+		select {
+		case <-t.quit:
+			return errFileTargetStopped
+		case t.targetEventHandler <- fileTargetEvent{
 			path:      dir,
 			eventType: fileTargetEventWatchStop,
+		}:
+			// continue
 		}
 	}
+	return nil
 }
 
 func (t *FileTarget) startTailing(ps []string) {

--- a/clients/pkg/promtail/targets/file/filetarget_test.go
+++ b/clients/pkg/promtail/targets/file/filetarget_test.go
@@ -410,8 +410,11 @@ func TestFileTarget_StopAbruptly(t *testing.T) {
 	// If FileHandler works well, then it will stop waiting for
 	// the blocked fakeHandler and stop cleanly.
 	// This is why this time we don't drain fakeHandler.
-	target.Stop()
-	ps.Stop()
+	requireEventually(t, func() bool {
+		target.Stop()
+		ps.Stop()
+		return true
+	}, "expected FileTarget not to hang")
 
 	require.NoError(t, testutil.GatherAndCompare(registry, bytes.NewBufferString(`
 		# HELP promtail_files_active_total Number of active files.

--- a/clients/pkg/promtail/targets/file/filetarget_test.go
+++ b/clients/pkg/promtail/targets/file/filetarget_test.go
@@ -336,6 +336,90 @@ func TestFileTarget_StopsTailersCleanly_Parallel(t *testing.T) {
 	ps.Stop()
 }
 
+// Make sure that Stop() doesn't hang if FileTarget is waiting on a channel send.
+func TestFileTarget_StopAbruptly(t *testing.T) {
+	w := log.NewSyncWriter(os.Stderr)
+	logger := log.NewLogfmtLogger(w)
+
+	dirName := newTestLogDirectories(t)
+	positionsFileName := filepath.Join(dirName, "positions.yml")
+	logDir1 := filepath.Join(dirName, "log1")
+	logDir2 := filepath.Join(dirName, "log2")
+	logDir3 := filepath.Join(dirName, "log3")
+
+	logfile1 := filepath.Join(logDir1, "test1.log")
+	logfile2 := filepath.Join(logDir2, "test1.log")
+	logfile3 := filepath.Join(logDir3, "test1.log")
+
+	ps, err := positions.New(logger, positions.Config{
+		SyncPeriod:    10 * time.Millisecond,
+		PositionsFile: positionsFileName,
+	})
+	require.NoError(t, err)
+
+	client := fake.New(func() {})
+	defer client.Stop()
+
+	// fakeHandler has to be a buffered channel so that we can call the len() function on it.
+	// We need to call len() to check if the channel is full.
+	fakeHandler := make(chan fileTargetEvent, 1)
+	pathToWatch := filepath.Join(dirName, "**", "*.log")
+	registry := prometheus.NewRegistry()
+	target, err := NewFileTarget(NewMetrics(registry), logger, client, ps, pathToWatch, "", nil, nil, &Config{
+		SyncPeriod: 10 * time.Millisecond,
+	}, DefaultWatchConig, nil, fakeHandler, "", nil)
+	assert.NoError(t, err)
+
+	// Create a directory, still nothing is watched.
+	err = os.MkdirAll(logDir1, 0750)
+	assert.NoError(t, err)
+	_, err = os.Create(logfile1)
+	assert.NoError(t, err)
+
+	// There should be only one WatchStart event in the channel so far.
+	ftEvent := <-fakeHandler
+	require.Equal(t, fileTargetEventWatchStart, ftEvent.eventType)
+
+	requireEventually(t, func() bool {
+		return target.getReadersLen() == 1
+	}, "expected 1 tailer to be created")
+
+	require.NoError(t, testutil.GatherAndCompare(registry, bytes.NewBufferString(`
+		# HELP promtail_files_active_total Number of active files.
+		# TYPE promtail_files_active_total gauge
+		promtail_files_active_total 1
+	`), "promtail_files_active_total"))
+
+	// Create two directories - one more than the buffer of fakeHandler,
+	// so that the file target hands until we call Stop().
+	err = os.MkdirAll(logDir2, 0750)
+	assert.NoError(t, err)
+	_, err = os.Create(logfile2)
+	assert.NoError(t, err)
+
+	err = os.MkdirAll(logDir3, 0750)
+	assert.NoError(t, err)
+	_, err = os.Create(logfile3)
+	assert.NoError(t, err)
+
+	// Wait until the file target is waiting on a channel send due to a full channel buffer.
+	requireEventually(t, func() bool {
+		return len(fakeHandler) == 1
+	}, "expected an event in the fakeHandler channel")
+
+	// If FileHandler works well, then it will stop waiting for
+	// the blocked fakeHandler and stop cleanly.
+	// This is why this time we don't drain fakeHandler.
+	target.Stop()
+	ps.Stop()
+
+	require.NoError(t, testutil.GatherAndCompare(registry, bytes.NewBufferString(`
+		# HELP promtail_files_active_total Number of active files.
+		# TYPE promtail_files_active_total gauge
+		promtail_files_active_total 0
+	`), "promtail_files_active_total"))
+}
+
 func TestFileTargetPathExclusion(t *testing.T) {
 	w := log.NewSyncWriter(os.Stderr)
 	logger := log.NewLogfmtLogger(w)


### PR DESCRIPTION
**What this PR does / why we need it**:

Recently, a memory issue was reported with the Agent Static mode. The memory of the Agent was creeping up steadily, until it eventually OOMs. That Agent was having its config reloaded every 30 seconds.

A goroutine dump indicated that these calls have been taking a long time:
```
goroutine 152484 [chan receive, 1214 minutes]:
github.com/grafana/loki/clients/pkg/promtail/targets/file.(*FileTarget).Stop(...)
	/go/pkg/mod/github.com/grafana/loki@v1.6.2-0.20231004111112-07cbef92268a/clients/pkg/promtail/targets/file/filetarget.go:159

goroutine 152424 [chan send, 1220 minutes]:
github.com/grafana/loki/clients/pkg/promtail/targets/file.(*FileTarget).startWatching(0xc0030ab5f0, 0xc002d9fe48?)
	/go/pkg/mod/github.com/grafana/loki@v1.6.2-0.20231004111112-07cbef92268a/clients/pkg/promtail/targets/file/filetarget.go:314 +0x20a

goroutine 152426 [chan send, 1220 minutes]:
github.com/grafana/loki/clients/pkg/promtail/targets/file.(*FileTarget).startWatching(0xc0030ab6c0, 0xc002e31e48?)
	/go/pkg/mod/github.com/grafana/loki@v1.6.2-0.20231004111112-07cbef92268a/clients/pkg/promtail/targets/file/filetarget.go:314 +0x20a

goroutine 152428 [chan send, 1210 minutes]:
github.com/grafana/loki/clients/pkg/promtail/targets/file.(*FileTarget).stopWatching(0xc0030ab790, 0xc002da1d88?)
	/go/pkg/mod/github.com/grafana/loki@v1.6.2-0.20231004111112-07cbef92268a/clients/pkg/promtail/targets/file/filetarget.go:327 +0x20a
```

What is probably happening is that `FileTargetManager` begins a `Stop()`, but doesn't yet close the `targetEventHandler` channel. As a result, `startWatching` and `stopWatching` seem stuck with sending on the channel. This causes the `sync` call to never complete, which on the other hand means that the `FileTarget`'s `Stop()` function can't complete. 

The memory build up is probably due to lots of calls to the config reload function which never complete.

cc @paul1r who recently committed [similar fixes](https://github.com/grafana/loki/pull/12656).

Should I add a changelog entry? And do you think there is a way to test this? Also, I haven't yet tested with the customer. If you think the code looks ok, we could merge it and verify later that it does fix the customer issue?

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
