### PR TITLE
fix(helm): properly forward queries to ruler

### DIFF
--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -13,6 +13,10 @@ Entries should include a reference to the pull request that introduced the chang
 
 [//]: # (<AUTOMATED_UPDATES_LOCATOR> : do not remove this line. This locator is used by the CI pipeline to automatically create a changelog entry for each new Loki release. Add other chart versions and respective changelog entries bellow this line.)
 
+## 6.3.5
+
+- [BUGFIX] Properly forward queries to ruler
+
 ## 6.3.4
 
 - [BUGFIX] Add missing OTLP endpoint to nginx config

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -3,7 +3,7 @@ name: loki
 description: Helm chart for Grafana Loki in simple, scalable mode
 type: application
 appVersion: 3.0.0
-version: 6.3.4
+version: 6.3.5
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/production/helm/loki/templates/_helpers.tpl
+++ b/production/helm/loki/templates/_helpers.tpl
@@ -544,6 +544,7 @@ Ingress service paths for scalable deployment
 {{- define "loki.ingress.scalableServicePaths" -}}
 {{- include "loki.ingress.servicePath" (dict "ctx" . "svcName" "read" "paths" .Values.ingress.paths.read )}}
 {{- include "loki.ingress.servicePath" (dict "ctx" . "svcName" "write" "paths" .Values.ingress.paths.write )}}
+{{- include "loki.ingress.servicePath" (dict "ctx" . "svcName" "backend" "paths" .Values.ingress.paths.backend )}}
 {{- end -}}
 
 {{/*

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -1146,6 +1146,7 @@ ingress:
       - /api/prom/tail
       - /loki/api/v1/tail
       - /loki/api
+    backend:
       - /api/prom/rules
       - /loki/api/v1/rules
       - /prometheus/api/v1/rules


### PR DESCRIPTION
**What this PR does / why we need it**:
When using Ingress instead of gateway with simple scalable mode, ruler paths are currently redirected to reader instead of backend.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
