### PR TITLE
fix(blooms): Reset error on LazyBloomIter.Seek

### DIFF
--- a/pkg/storage/bloom/v1/bloom_querier.go
+++ b/pkg/storage/bloom/v1/bloom_querier.go
@@ -45,6 +45,9 @@ func (it *LazyBloomIter) ensureInit() {
 func (it *LazyBloomIter) Seek(offset BloomOffset) {
 	it.ensureInit()
 
+	// reset error from any previous seek/next
+	it.err = nil
+
 	// if we need a different page or the current page hasn't been loaded,
 	// load the desired page
 	if it.curPageIndex != offset.Page || it.curPage == nil {

--- a/pkg/storage/bloom/v1/bloom_querier.go
+++ b/pkg/storage/bloom/v1/bloom_querier.go
@@ -45,8 +45,10 @@ func (it *LazyBloomIter) ensureInit() {
 func (it *LazyBloomIter) Seek(offset BloomOffset) {
 	it.ensureInit()
 
-	// reset error from any previous seek/next
-	it.err = nil
+	// reset error from any previous seek/next that yield pages too large
+	if errors.Is(it.err, ErrPageTooLarge) {
+		it.err = nil
+	}
 
 	// if we need a different page or the current page hasn't been loaded,
 	// load the desired page


### PR DESCRIPTION
**What this PR does / why we need it**:

We are skipping all pages after any of the pages on a given block have failed due to being too big:
1. `Seek` a page that is too big. `it.err` is set here  https://github.com/grafana/loki/blob/feb210b4c4250fee622661ce349aa6843c20a394/pkg/storage/bloom/v1/bloom_querier.go#L66-L68

2. then `it.Next` return `false` in this check https://github.com/grafana/loki/blob/feb210b4c4250fee622661ce349aa6843c20a394/pkg/storage/bloom/v1/bloom_querier.go#L87-L89.

3. `Seek` another page that should be valid. Decoding of the new page succeeds but `Seek` won’t reset `it.err`. Therefore, the call to `it.Next` return `false` again.

This PR fixes this by resetting `it.err` on every `Seek`.

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
