### PR TITLE
fix(blooms): Fully deduplicate chunks from FilterChunkRef responses

### DIFF
--- a/pkg/bloomgateway/bloomgateway.go
+++ b/pkg/bloomgateway/bloomgateway.go
@@ -44,6 +44,7 @@ package bloomgateway
 import (
 	"context"
 	"fmt"
+	"slices"
 	"sort"
 	"time"
 
@@ -383,8 +384,10 @@ func (g *Gateway) consumeTask(ctx context.Context, task Task, tasksCh chan<- Tas
 		case <-ctx.Done():
 			// do nothing
 		default:
-			// chunks may not be sorted
-			sort.Slice(res.Removals, func(i, j int) bool { return res.Removals[i].Less(res.Removals[j]) })
+			// chunks may not always be sorted
+			if !slices.IsSortedFunc(res.Removals, func(a, b v1.ChunkRef) int { return a.Cmp(b) }) {
+				slices.SortFunc(res.Removals, func(a, b v1.ChunkRef) int { return a.Cmp(b) })
+			}
 			task.responses = append(task.responses, res)
 		}
 	}

--- a/pkg/bloomgateway/bloomgateway.go
+++ b/pkg/bloomgateway/bloomgateway.go
@@ -383,6 +383,8 @@ func (g *Gateway) consumeTask(ctx context.Context, task Task, tasksCh chan<- Tas
 		case <-ctx.Done():
 			// do nothing
 		default:
+			// chunks may not be sorted
+			sort.Slice(res.Removals, func(i, j int) bool { return res.Removals[i].Less(res.Removals[j]) })
 			task.responses = append(task.responses, res)
 		}
 	}
@@ -413,7 +415,7 @@ func orderedResponsesByFP(responses [][]v1.Output) v1.Iterator[v1.Output] {
 		itrs = append(itrs, v1.NewPeekingIter(v1.NewSliceIter(r)))
 	}
 	return v1.NewHeapIterator[v1.Output](
-		func(o1, o2 v1.Output) bool { return o1.Fp <= o2.Fp },
+		func(o1, o2 v1.Output) bool { return o1.Fp < o2.Fp },
 		itrs...,
 	)
 }

--- a/pkg/bloomgateway/bloomgateway.go
+++ b/pkg/bloomgateway/bloomgateway.go
@@ -422,6 +422,7 @@ func orderedResponsesByFP(responses [][]v1.Output) v1.Iterator[v1.Output] {
 
 // TODO(owen-d): improve perf. This can be faster with a more specialized impl
 // NB(owen-d): `req` is mutated in place for performance, but `responses` is not
+// Removals of the outputs must be sorted.
 func filterChunkRefs(req *logproto.FilterChunkRefRequest, responses [][]v1.Output) []*logproto.GroupedChunkRefs {
 	res := make([]*logproto.GroupedChunkRefs, 0, len(req.Refs))
 
@@ -435,6 +436,7 @@ func filterChunkRefs(req *logproto.FilterChunkRefRequest, responses [][]v1.Outpu
 		// from
 		v1.Identity[v1.Output],
 		// merge two removal sets for the same series, deduping
+		// requires that the removals of the outputs are sorted
 		func(o1, o2 v1.Output) v1.Output {
 			res := v1.Output{Fp: o1.Fp}
 

--- a/pkg/bloomgateway/bloomgateway_test.go
+++ b/pkg/bloomgateway/bloomgateway_test.go
@@ -640,12 +640,12 @@ func TestFilterChunkRefs(t *testing.T) {
 				{
 					{fp: 0, checksums: []uint32{0, 1}},
 					{fp: 0, checksums: []uint32{0, 1, 2}},
-					{fp: 1, checksums: []uint32{1}},
+					{fp: 1, checksums: []uint32{0, 2}},
 					{fp: 2, checksums: []uint32{1}},
 				},
 			},
 			expected: mkResult([]instruction{
-				{fp: 1, checksums: []uint32{0, 2}},
+				{fp: 1, checksums: []uint32{1}},
 				{fp: 2, checksums: []uint32{0, 2}},
 				{fp: 3, checksums: []uint32{0, 1, 2}},
 			}),
@@ -668,6 +668,27 @@ func TestFilterChunkRefs(t *testing.T) {
 				{fp: 1, checksums: []uint32{0, 1, 2}},
 				{fp: 2, checksums: []uint32{0, 2}},
 				{fp: 3, checksums: []uint32{0, 1, 2}},
+			}),
+		},
+		{
+			desc:  "unordered fingerprints",
+			input: mkInput(4, 3),
+			removals: [][]instruction{
+				{
+					{fp: 3, checksums: []uint32{2}},
+					{fp: 0, checksums: []uint32{1, 2}},
+					{fp: 2, checksums: []uint32{1, 2}},
+				},
+				{
+					{fp: 1, checksums: []uint32{1}},
+					{fp: 2, checksums: []uint32{0, 1}},
+					{fp: 3, checksums: []uint32{0}},
+				},
+			},
+			expected: mkResult([]instruction{
+				{fp: 0, checksums: []uint32{0}},
+				{fp: 1, checksums: []uint32{0, 2}},
+				{fp: 3, checksums: []uint32{1}},
 			}),
 		},
 	} {

--- a/pkg/bloomgateway/cache_test.go
+++ b/pkg/bloomgateway/cache_test.go
@@ -344,7 +344,10 @@ func TestMerge(t *testing.T) {
 			m := newMerger()
 			actual, err := m.MergeResponse(input...)
 			require.NoError(t, err)
-			require.Equal(t, tc.expected, actual)
+
+			resp, ok := actual.(*logproto.FilterChunkRefResponse)
+			require.True(t, ok)
+			require.Equal(t, tc.expected, resp)
 		})
 	}
 }

--- a/pkg/bloomgateway/client.go
+++ b/pkg/bloomgateway/client.go
@@ -310,8 +310,13 @@ func mergeSeries(input [][]*logproto.GroupedChunkRefs, buf []*logproto.GroupedCh
 		v1.Identity[*logproto.GroupedChunkRefs],
 		// merge
 		func(a, b *logproto.GroupedChunkRefs) *logproto.GroupedChunkRefs {
-			slices.SortFunc(a.Refs, func(a, b *logproto.ShortRef) int { return a.Cmp(b) })
-			slices.SortFunc(b.Refs, func(a, b *logproto.ShortRef) int { return a.Cmp(b) })
+			// TODO(chaudum): Check if we can assume sorted shortrefs here
+			if !slices.IsSortedFunc(a.Refs, func(a, b *logproto.ShortRef) int { return a.Cmp(b) }) {
+				slices.SortFunc(a.Refs, func(a, b *logproto.ShortRef) int { return a.Cmp(b) })
+			}
+			if !slices.IsSortedFunc(b.Refs, func(a, b *logproto.ShortRef) int { return a.Cmp(b) }) {
+				slices.SortFunc(b.Refs, func(a, b *logproto.ShortRef) int { return a.Cmp(b) })
+			}
 			return &logproto.GroupedChunkRefs{
 				Fingerprint: a.Fingerprint,
 				Tenant:      a.Tenant,

--- a/pkg/bloomgateway/client.go
+++ b/pkg/bloomgateway/client.go
@@ -329,7 +329,6 @@ func mergeSeries(input [][]*logproto.GroupedChunkRefs, buf []*logproto.GroupedCh
 func mergeChunkSets(s1, s2 []*logproto.ShortRef) (result []*logproto.ShortRef) {
 	var i, j int
 	for i < len(s1) && j < len(s2) {
-
 		a, b := s1[i], s2[j]
 
 		if a.Equal(b) {
@@ -342,10 +341,11 @@ func mergeChunkSets(s1, s2 []*logproto.ShortRef) (result []*logproto.ShortRef) {
 		if a.Less(b) {
 			result = append(result, a)
 			i++
-		} else {
-			result = append(result, b)
-			j++
+			continue
 		}
+
+		result = append(result, b)
+		j++
 	}
 
 	if i < len(s1) {

--- a/pkg/bloomgateway/client_test.go
+++ b/pkg/bloomgateway/client_test.go
@@ -71,20 +71,26 @@ func TestGatewayClient_MergeSeries(t *testing.T) {
 	require.Equal(t, expected, result)
 }
 
-func TestGatewayClient_MergeChunks(t *testing.T) {
-	inputs := [][]*logproto.ShortRef{
-		{shortRef(2, 3, 2), shortRef(1, 3, 3)},
-		{shortRef(2, 3, 2), shortRef(1, 3, 3), shortRef(1, 2, 1)},
-		{shortRef(1, 3, 3), shortRef(1, 2, 1)},
-		{shortRef(1, 2, 1)},
+func TestGatewayClient_MergeChunkSets(t *testing.T) {
+	inp1 := []*logproto.ShortRef{
+		shortRef(1, 3, 1),
+		shortRef(2, 3, 2),
+		shortRef(4, 5, 3),
+	}
+	inp2 := []*logproto.ShortRef{
+		shortRef(2, 3, 2),
+		shortRef(3, 4, 4),
+		shortRef(5, 6, 5),
 	}
 
 	expected := []*logproto.ShortRef{
-		shortRef(1, 2, 1),
-		shortRef(1, 3, 3),
+		shortRef(1, 3, 1),
 		shortRef(2, 3, 2),
+		shortRef(3, 4, 4),
+		shortRef(4, 5, 3),
+		shortRef(5, 6, 5),
 	}
 
-	result := mergeChunks(inputs...)
+	result := mergeChunkSets(inp1, inp2)
 	require.Equal(t, expected, result)
 }

--- a/pkg/bloomgateway/client_test.go
+++ b/pkg/bloomgateway/client_test.go
@@ -70,3 +70,21 @@ func TestGatewayClient_MergeSeries(t *testing.T) {
 	result, _ := mergeSeries(inputs, nil)
 	require.Equal(t, expected, result)
 }
+
+func TestGatewayClient_MergeChunks(t *testing.T) {
+	inputs := [][]*logproto.ShortRef{
+		{shortRef(2, 3, 2), shortRef(1, 3, 3)},
+		{shortRef(2, 3, 2), shortRef(1, 3, 3), shortRef(1, 2, 1)},
+		{shortRef(1, 3, 3), shortRef(1, 2, 1)},
+		{shortRef(1, 2, 1)},
+	}
+
+	expected := []*logproto.ShortRef{
+		shortRef(1, 2, 1),
+		shortRef(1, 3, 3),
+		shortRef(2, 3, 2),
+	}
+
+	result := mergeChunks(inputs...)
+	require.Equal(t, expected, result)
+}

--- a/pkg/bloomgateway/querier.go
+++ b/pkg/bloomgateway/querier.go
@@ -100,7 +100,7 @@ func (bq *BloomQuerier) FilterChunkRefs(ctx context.Context, tenant string, from
 	preFilterChunks := len(chunkRefs)
 	preFilterSeries := len(grouped)
 
-	responses := make([][]*logproto.GroupedChunkRefs, 0, 4)
+	responses := make([][]*logproto.GroupedChunkRefs, 0, 2)
 	// We can perform requests sequentially, because most of the time the request
 	// only covers a single day, and if not, it's at most two days.
 	for _, s := range partitionSeriesByDay(from, through, grouped) {

--- a/pkg/bloomgateway/querier.go
+++ b/pkg/bloomgateway/querier.go
@@ -85,14 +85,6 @@ func convertToShortRef(ref *logproto.ChunkRef) *logproto.ShortRef {
 	return &logproto.ShortRef{From: ref.From, Through: ref.Through, Checksum: ref.Checksum}
 }
 
-func sum[S ~[]E, E any](s S, fn func(e E) int) int {
-	var count int
-	for i := range s {
-		count += fn(s[i])
-	}
-	return count
-}
-
 func (bq *BloomQuerier) FilterChunkRefs(ctx context.Context, tenant string, from, through model.Time, chunkRefs []*logproto.ChunkRef, queryPlan plan.QueryPlan) ([]*logproto.ChunkRef, error) {
 	// Shortcut that does not require any filtering
 	if !bq.limits.BloomGatewayEnabled(tenant) || len(chunkRefs) == 0 || len(v1.ExtractTestableLineFilters(queryPlan.AST)) == 0 {
@@ -122,20 +114,6 @@ func (bq *BloomQuerier) FilterChunkRefs(ctx context.Context, tenant string, from
 		if err != nil {
 			return nil, err
 		}
-
-		level.Debug(bq.logger).Log(
-			"msg", "filter series by day",
-			"day", s.day.Time.Time(),
-			"from", s.interval.Start.Time(),
-			"through", s.interval.End.Time(),
-			"series_total", len(s.series),
-			"series_in_blocks", len(blocks),
-			"series_skipped", len(skipped),
-			"series_filtered", len(refs),
-			"chunks_total", sum(s.series, func(e *logproto.GroupedChunkRefs) int { return len(e.Refs) }), // slow
-			"chunks_filtered", sum(refs, func(e *logproto.GroupedChunkRefs) int { return len(e.Refs) }), // slow
-			"chunks_skipped", sum(skipped, func(e *logproto.GroupedChunkRefs) int { return len(e.Refs) }), // slow
-		)
 
 		// add chunk refs from series that were not mapped to any blocks
 		responses = append(responses, refs, skipped)

--- a/pkg/logproto/compat.go
+++ b/pkg/logproto/compat.go
@@ -408,6 +408,65 @@ func (m *FilterChunkRefRequest) WithStartEndForCache(start, end time.Time) resul
 	return &clone
 }
 
+func (a *GroupedChunkRefs) Cmp(b *GroupedChunkRefs) int {
+	if b == nil {
+		if a == nil {
+			return 0
+		}
+		return 1
+	}
+	if a.Fingerprint < b.Fingerprint {
+		return -1
+	}
+	if a.Fingerprint > b.Fingerprint {
+		return 1
+	}
+	return 0
+}
+
+func (a *GroupedChunkRefs) Less(b *GroupedChunkRefs) bool {
+	if b == nil {
+		return a == nil
+	}
+	return a.Fingerprint < b.Fingerprint
+}
+
+// Cmp returns a positive number when a > b, a negative number when a < b, and 0 when a == b
+func (a *ShortRef) Cmp(b *ShortRef) int {
+	if b == nil {
+		if a == nil {
+			return 0
+		}
+		return 1
+	}
+
+	if a.From != b.From {
+		return int(a.From) - int(b.From)
+	}
+
+	if a.Through != b.Through {
+		return int(a.Through) - int(b.Through)
+	}
+
+	return int(a.Checksum) - int(b.Checksum)
+}
+
+func (a *ShortRef) Less(b *ShortRef) bool {
+	if b == nil {
+		return a == nil
+	}
+
+	if a.From != b.From {
+		return a.From < b.From
+	}
+
+	if a.Through != b.Through {
+		return a.Through < b.Through
+	}
+
+	return a.Checksum < b.Checksum
+}
+
 func (m *ShardsRequest) GetCachingOptions() (res definitions.CachingOptions) { return }
 
 func (m *ShardsRequest) GetStart() time.Time {

--- a/pkg/storage/bloom/v1/index.go
+++ b/pkg/storage/bloom/v1/index.go
@@ -425,6 +425,18 @@ func (r *ChunkRef) Less(other ChunkRef) bool {
 	return r.Checksum < other.Checksum
 }
 
+func (r *ChunkRef) Cmp(other ChunkRef) int {
+	if r.From != other.From {
+		return int(other.From) - int(r.From)
+	}
+
+	if r.Through != other.Through {
+		return int(other.Through) - int(r.Through)
+	}
+
+	return int(other.Checksum) - int(r.Checksum)
+}
+
 func (r *ChunkRef) Encode(enc *encoding.Encbuf, previousEnd model.Time) model.Time {
 	// delta encode start time
 	enc.PutVarint64(int64(r.From - previousEnd))

--- a/pkg/storage/bloom/v1/index_test.go
+++ b/pkg/storage/bloom/v1/index_test.go
@@ -55,7 +55,72 @@ func TestSeriesEncoding(t *testing.T) {
 	require.Equal(t, src, dst)
 }
 
-func TestChunkRefCompare(t *testing.T) {
+func TestChunkRefCmpLess(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		desc        string
+		left, right ChunkRef
+		expCmp      int
+		expLess     bool
+	}{
+		{
+			desc:    "From/Through/Checksum are equal",
+			left:    ChunkRef{0, 0, 0},
+			right:   ChunkRef{0, 0, 0},
+			expCmp:  0,
+			expLess: false,
+		},
+		{
+			desc:    "From is before",
+			left:    ChunkRef{0, 1, 0},
+			right:   ChunkRef{1, 1, 0},
+			expCmp:  1,
+			expLess: true,
+		},
+		{
+			desc:    "From is after",
+			left:    ChunkRef{1, 1, 0},
+			right:   ChunkRef{0, 1, 0},
+			expCmp:  -1,
+			expLess: false,
+		},
+		{
+			desc:    "Through is before",
+			left:    ChunkRef{0, 1, 0},
+			right:   ChunkRef{0, 2, 0},
+			expCmp:  1,
+			expLess: true,
+		},
+		{
+			desc:    "Through is after",
+			left:    ChunkRef{0, 2, 0},
+			right:   ChunkRef{0, 1, 0},
+			expCmp:  -1,
+			expLess: false,
+		},
+		{
+			desc:    "Checksum is smaller",
+			left:    ChunkRef{0, 1, 0},
+			right:   ChunkRef{0, 1, 1},
+			expCmp:  1,
+			expLess: true,
+		},
+		{
+			desc:    "Checksum is bigger",
+			left:    ChunkRef{0, 0, 1},
+			right:   ChunkRef{0, 0, 0},
+			expCmp:  -1,
+			expLess: false,
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			require.Equal(t, tc.expCmp, tc.left.Cmp(tc.right))
+			require.Equal(t, tc.expLess, tc.left.Less(tc.right))
+		})
+	}
+}
+
+func TestChunkRefsCompare(t *testing.T) {
 	t.Parallel()
 	for _, tc := range []struct {
 		desc                              string


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR aims for full de-duplication of chunks and series from filter requests from the index gateway to the bloom gateway.

Whenever we merge/de-duplicate slices, the inputs need to be sorted. It appears that the `Removals` (chunks) from the `v1.Output` are not guaranteed to be sorted. 

When comparing ShortRefs, both `From`, `Through`, and `Checksum` need to be used.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
