### PR TITLE
fix(blooms): dont break iterator conventions

### DIFF
--- a/pkg/storage/bloom/v1/block.go
+++ b/pkg/storage/bloom/v1/block.go
@@ -144,7 +144,7 @@ func (bq *BlockQuerier) Seek(fp model.Fingerprint) error {
 func (bq *BlockQuerier) Next() bool {
 	for bq.series.Next() {
 		series := bq.series.At()
-		if ok := bq.blooms.LoadOffset(series.Offset); !ok {
+		if skip := bq.blooms.LoadOffset(series.Offset); skip {
 			// can't seek to the desired bloom, likely because the page was too large to load
 			// so we skip this series and move on to the next
 			continue

--- a/pkg/storage/bloom/v1/block.go
+++ b/pkg/storage/bloom/v1/block.go
@@ -144,14 +144,12 @@ func (bq *BlockQuerier) Seek(fp model.Fingerprint) error {
 func (bq *BlockQuerier) Next() bool {
 	for bq.series.Next() {
 		series := bq.series.At()
-		bq.blooms.Seek(series.Offset)
+		if ok := bq.blooms.LoadOffset(series.Offset); !ok {
+			// can't seek to the desired bloom, likely because the page was too large to load
+			// so we skip this series and move on to the next
+			continue
+		}
 		if !bq.blooms.Next() {
-			// skip blocks that are too large
-			if errors.Is(bq.blooms.Err(), ErrPageTooLarge) {
-				// fmt.Printf("skipping bloom page: %s (%d)\n", series.Fingerprint, series.Chunks.Len())
-				bq.blooms.err = nil
-				continue
-			}
 			return false
 		}
 		bloom := bq.blooms.At()
@@ -174,71 +172,4 @@ func (bq *BlockQuerier) Err() error {
 	}
 
 	return bq.blooms.Err()
-}
-
-// CheckChunksForSeries checks if the given chunks pass a set of searches in the given bloom block.
-// It returns the list of chunks which will need to be downloaded for a query based on the initial list
-// passed as the `chks` argument. Chunks will be removed from the result set if they are indexed in the bloom
-// and fail to pass all the searches.
-func (bq *BlockQuerier) CheckChunksForSeries(fp model.Fingerprint, chks ChunkRefs, searches [][]byte) (ChunkRefs, error) {
-	schema, err := bq.Schema()
-	if err != nil {
-		return chks, fmt.Errorf("getting schema: %w", err)
-	}
-
-	if err := bq.Seek(fp); err != nil {
-		return chks, errors.Wrapf(err, "seeking to series for fp: %v", fp)
-	}
-
-	if !bq.series.Next() {
-		return chks, nil
-	}
-
-	series := bq.series.At()
-	if series.Fingerprint != fp {
-		return chks, nil
-	}
-
-	bq.blooms.Seek(series.Offset)
-	if !bq.blooms.Next() {
-		return chks, fmt.Errorf("seeking to bloom for fp: %v", fp)
-	}
-
-	bloom := bq.blooms.At()
-
-	// First, see if the search passes the series level bloom before checking for chunks individually
-	for _, search := range searches {
-		if !bloom.Test(search) {
-			// the entire series bloom didn't pass one of the searches,
-			// so we can skip checking chunks individually.
-			// We still return all chunks that are not included in the bloom
-			// as they may still have the data
-			return chks.Unless(series.Chunks), nil
-		}
-	}
-
-	// TODO(salvacorts): pool tokenBuf
-	var tokenBuf []byte
-	var prefixLen int
-
-	// Check chunks individually now
-	mustCheck, inBlooms := chks.Compare(series.Chunks, true)
-
-outer:
-	for _, chk := range inBlooms {
-		// Get buf to concatenate the chunk and search token
-		tokenBuf, prefixLen = prefixedToken(schema.NGramLen(), chk, tokenBuf)
-		for _, search := range searches {
-			tokenBuf = append(tokenBuf[:prefixLen], search...)
-
-			if !bloom.Test(tokenBuf) {
-				// chunk didn't pass the search, continue to the next chunk
-				continue outer
-			}
-		}
-		// chunk passed all searches, add to the list of chunks to download
-		mustCheck = append(mustCheck, chk)
-
-	}
-	return mustCheck, nil
 }

--- a/pkg/storage/bloom/v1/bloom.go
+++ b/pkg/storage/bloom/v1/bloom.go
@@ -275,11 +275,13 @@ func (b *BloomBlock) DecodeHeaders(r io.ReadSeeker) (uint32, error) {
 	return checksum, nil
 }
 
-func (b *BloomBlock) BloomPageDecoder(r io.ReadSeeker, pageIdx int, maxPageSize int, metrics *Metrics) (res *BloomPageDecoder, err error) {
+// BloomPageDecoder returns a decoder for the given page index.
+// It may skip the page if it's too large.
+func (b *BloomBlock) BloomPageDecoder(r io.ReadSeeker, pageIdx int, maxPageSize int, metrics *Metrics) (res *BloomPageDecoder, skip bool, err error) {
 	if pageIdx < 0 || pageIdx >= len(b.pageHeaders) {
 		metrics.pagesSkipped.WithLabelValues(pageTypeBloom, skipReasonOOB).Inc()
 		metrics.bytesSkipped.WithLabelValues(pageTypeBloom, skipReasonOOB).Add(float64(b.pageHeaders[pageIdx].DecompressedLen))
-		return nil, fmt.Errorf("invalid page (%d) for bloom page decoding", pageIdx)
+		return nil, false, fmt.Errorf("invalid page (%d) for bloom page decoding", pageIdx)
 	}
 
 	page := b.pageHeaders[pageIdx]
@@ -288,13 +290,13 @@ func (b *BloomBlock) BloomPageDecoder(r io.ReadSeeker, pageIdx int, maxPageSize 
 	if page.Len > maxPageSize {
 		metrics.pagesSkipped.WithLabelValues(pageTypeBloom, skipReasonTooLarge).Inc()
 		metrics.bytesSkipped.WithLabelValues(pageTypeBloom, skipReasonTooLarge).Add(float64(page.DecompressedLen))
-		return nil, ErrPageTooLarge
+		return nil, true, ErrPageTooLarge
 	}
 
 	if _, err = r.Seek(int64(page.Offset), io.SeekStart); err != nil {
 		metrics.pagesSkipped.WithLabelValues(pageTypeBloom, skipReasonErr).Inc()
 		metrics.bytesSkipped.WithLabelValues(pageTypeBloom, skipReasonErr).Add(float64(page.DecompressedLen))
-		return nil, errors.Wrap(err, "seeking to bloom page")
+		return nil, false, errors.Wrap(err, "seeking to bloom page")
 	}
 
 	if b.schema.encoding == chunkenc.EncNone {
@@ -306,10 +308,10 @@ func (b *BloomBlock) BloomPageDecoder(r io.ReadSeeker, pageIdx int, maxPageSize 
 	if err != nil {
 		metrics.pagesSkipped.WithLabelValues(pageTypeBloom, skipReasonErr).Inc()
 		metrics.bytesSkipped.WithLabelValues(pageTypeBloom, skipReasonErr).Add(float64(page.DecompressedLen))
-		return nil, errors.Wrap(err, "decoding bloom page")
+		return nil, false, errors.Wrap(err, "decoding bloom page")
 	}
 
 	metrics.pagesRead.WithLabelValues(pageTypeBloom).Inc()
 	metrics.bytesRead.WithLabelValues(pageTypeBloom).Add(float64(page.DecompressedLen))
-	return res, nil
+	return res, false, nil
 }

--- a/pkg/storage/bloom/v1/fuse.go
+++ b/pkg/storage/bloom/v1/fuse.go
@@ -99,11 +99,12 @@ func (fq *FusedQuerier) Run() error {
 		}
 
 		// Now that we've found the series, we need to find the unpack the bloom
-		ok := fq.bq.blooms.LoadOffset(series.Offset)
-		if !ok {
+		skip := fq.bq.blooms.LoadOffset(series.Offset)
+		if skip {
 			// could not seek to the desired bloom,
 			// likely because the page was too large to load
 			fq.noRemovals(nextBatch, fp)
+			continue
 		}
 
 		if !fq.bq.blooms.Next() {

--- a/pkg/storage/bloom/v1/fuse_test.go
+++ b/pkg/storage/bloom/v1/fuse_test.go
@@ -229,10 +229,10 @@ func TestLazyBloomIter_Seek_ResetError(t *testing.T) {
 			seekable = false
 		}
 		if !seekable {
-			require.False(t, querier.blooms.LoadOffset(series.Offset))
+			require.True(t, querier.blooms.LoadOffset(series.Offset))
 			continue
 		}
-		require.True(t, querier.blooms.LoadOffset(series.Offset))
+		require.False(t, querier.blooms.LoadOffset(series.Offset))
 		require.True(t, querier.blooms.Next())
 		require.NoError(t, querier.blooms.Err())
 	}


### PR DESCRIPTION
Followup to https://github.com/grafana/loki/pull/12806 which exposes skipped pages more explicitly than as an error.
* refactors skip logic for bloom pages that are too large
* s/Seek/LoadOffset/ for LazyBloomIter
* removes unused code
