### PR TITLE
fix: Make meta monitoring dashboards work with micro services chart

### DIFF
--- a/production/loki-mixin-compiled/dashboards/loki-reads-resources.json
+++ b/production/loki-mixin-compiled/dashboards/loki-reads-resources.json
@@ -266,7 +266,7 @@
                   "span": 4,
                   "targets": [
                      {
-                        "expr": "sum by(pod) (go_memstats_heap_inuse_bytes{cluster=~\"$cluster\", job=~\"($namespace)/query-frontend\"})",
+                        "expr": "sum by(pod) (go_memstats_heap_inuse_bytes{cluster=~\"$cluster\", job=~\"($namespace)/.*query-frontend\"})",
                         "format": "time_series",
                         "legendFormat": "{{pod}}",
                         "legendLink": null
@@ -530,7 +530,7 @@
                   "span": 4,
                   "targets": [
                      {
-                        "expr": "sum by(pod) (go_memstats_heap_inuse_bytes{cluster=~\"$cluster\", job=~\"($namespace)/query-scheduler\"})",
+                        "expr": "sum by(pod) (go_memstats_heap_inuse_bytes{cluster=~\"$cluster\", job=~\"($namespace)/.*query-scheduler\"})",
                         "format": "time_series",
                         "legendFormat": "{{pod}}",
                         "legendLink": null
@@ -794,7 +794,7 @@
                   },
                   "targets": [
                      {
-                        "expr": "sum by(pod) (go_memstats_heap_inuse_bytes{cluster=~\"$cluster\", job=~\"($namespace)/querier\"})",
+                        "expr": "sum by(pod) (go_memstats_heap_inuse_bytes{cluster=~\"$cluster\", job=~\"($namespace)/.*querier\"})",
                         "format": "time_series",
                         "legendFormat": "{{pod}}",
                         "legendLink": null
@@ -1606,7 +1606,7 @@
                   },
                   "targets": [
                      {
-                        "expr": "sum by(pod) (go_memstats_heap_inuse_bytes{cluster=~\"$cluster\", job=~\"($namespace)/bloom-gateway\"})",
+                        "expr": "sum by(pod) (go_memstats_heap_inuse_bytes{cluster=~\"$cluster\", job=~\"($namespace)/.*bloom-gateway\"})",
                         "format": "time_series",
                         "legendFormat": "{{pod}}",
                         "legendLink": null

--- a/production/loki-mixin-compiled/dashboards/loki-writes-resources.json
+++ b/production/loki-mixin-compiled/dashboards/loki-writes-resources.json
@@ -266,7 +266,7 @@
                   "span": 4,
                   "targets": [
                      {
-                        "expr": "sum by(pod) (go_memstats_heap_inuse_bytes{cluster=~\"$cluster\", job=~\"($namespace)/distributor\"})",
+                        "expr": "sum by(pod) (go_memstats_heap_inuse_bytes{cluster=~\"$cluster\", job=~\"($namespace)/.*distributor\"})",
                         "format": "time_series",
                         "legendFormat": "{{pod}}",
                         "legendLink": null

--- a/production/loki-mixin/dashboards/loki-reads-resources.libsonnet
+++ b/production/loki-mixin/dashboards/loki-reads-resources.libsonnet
@@ -3,17 +3,17 @@ local utils = import 'mixin-utils/utils.libsonnet';
 
 (import 'dashboard-utils.libsonnet') {
   local index_gateway_pod_matcher = if $._config.meta_monitoring.enabled
-  then 'container=~"loki|index-gateway", pod=~"(index-gateway.*|%s-read.*|loki-single-binary)"' % $._config.ssd.pod_prefix_matcher
+  then 'container=~"loki|index-gateway", pod=~"(.*index-gateway.*|%s-read.*|loki-single-binary)"' % $._config.ssd.pod_prefix_matcher
   else if $._config.ssd.enabled then 'container="loki", pod=~"%s-read.*"' % $._config.ssd.pod_prefix_matcher else 'container="index-gateway"',
   local index_gateway_job_matcher = if $._config.meta_monitoring.enabled
-  then '(index-gateway.*|%s-read.*|loki-single-binary)' % $._config.ssd.pod_prefix_matcher
+  then '(.*index-gateway.*|%s-read.*|loki-single-binary)' % $._config.ssd.pod_prefix_matcher
   else if $._config.ssd.enabled then '%s-read' % $._config.ssd.pod_prefix_matcher else 'index-gateway',
 
   local ingester_pod_matcher = if $._config.meta_monitoring.enabled
-  then 'container=~"loki|ingester", pod=~"(ingester.*|%s-write.*|loki-single-binary)"' % $._config.ssd.pod_prefix_matcher
+  then 'container=~"loki|ingester", pod=~"(.*ingester.*|%s-write.*|loki-single-binary)"' % $._config.ssd.pod_prefix_matcher
   else if $._config.ssd.enabled then 'container="loki", pod=~"%s-write.*"' % $._config.ssd.pod_prefix_matcher else 'container="ingester"',
   local ingester_job_matcher = if $._config.meta_monitoring.enabled
-  then '(ingester.+|%s-write|loki-single-binary)' % $._config.ssd.pod_prefix_matcher
+  then '(.*ingester.*|%s-write|loki-single-binary)' % $._config.ssd.pod_prefix_matcher
   else if $._config.ssd.enabled then '%s-write' % $._config.ssd.pod_prefix_matcher else 'ingester.+',
 
   grafanaDashboards+::
@@ -46,7 +46,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
             $.containerMemoryWorkingSetPanel('Memory (workingset)', 'query-frontend'),
           )
           .addPanel(
-            $.goHeapInUsePanel('Memory (go heap inuse)', 'query-frontend'),
+            $.goHeapInUsePanel('Memory (go heap inuse)', '.*query-frontend'),
           )
         )
         .addRowIf(
@@ -59,7 +59,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
             $.containerMemoryWorkingSetPanel('Memory (workingset)', 'query-scheduler'),
           )
           .addPanel(
-            $.goHeapInUsePanel('Memory (go heap inuse)', 'query-scheduler'),
+            $.goHeapInUsePanel('Memory (go heap inuse)', '.*query-scheduler'),
           )
         )
         .addRowIf(
@@ -72,7 +72,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
             $.containerMemoryWorkingSetPanel('Memory (workingset)', 'querier'),
           )
           .addPanel(
-            $.goHeapInUsePanel('Memory (go heap inuse)', 'querier'),
+            $.goHeapInUsePanel('Memory (go heap inuse)', '.*querier'),
           )
           .addPanel(
             $.newQueryPanel('Disk Writes', 'Bps') +
@@ -135,7 +135,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
             $.containerMemoryWorkingSetPanel('Memory (workingset)', 'bloom-gateway'),
           )
           .addPanel(
-            $.goHeapInUsePanel('Memory (go heap inuse)', 'bloom-gateway'),
+            $.goHeapInUsePanel('Memory (go heap inuse)', '.*bloom-gateway'),
           )
           .addPanel(
             $.newQueryPanel('Disk Writes', 'Bps') +

--- a/production/loki-mixin/dashboards/loki-writes-resources.libsonnet
+++ b/production/loki-mixin/dashboards/loki-writes-resources.libsonnet
@@ -11,7 +11,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
 
   grafanaDashboards+::
     {
-      'distributorloki-writes-resources.json':
+      'loki-writes-resources.json':
         ($.dashboard('Loki / Writes Resources', uid='writes-resources'))
         .addCluster()
         .addNamespace()

--- a/production/loki-mixin/dashboards/loki-writes-resources.libsonnet
+++ b/production/loki-mixin/dashboards/loki-writes-resources.libsonnet
@@ -39,7 +39,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
             $.containerMemoryWorkingSetPanel('Memory (workingset)', 'distributor'),
           )
           .addPanel(
-            $.goHeapInUsePanel('Memory (go heap inuse)',  '.*distributor'),
+            $.goHeapInUsePanel('Memory (go heap inuse)', '.*distributor'),
           )
         )
         .addRow(

--- a/production/loki-mixin/dashboards/loki-writes-resources.libsonnet
+++ b/production/loki-mixin/dashboards/loki-writes-resources.libsonnet
@@ -3,15 +3,15 @@ local utils = import 'mixin-utils/utils.libsonnet';
 
 (import 'dashboard-utils.libsonnet') {
   local ingester_pod_matcher = if $._config.meta_monitoring.enabled
-  then 'container=~"loki|ingester", pod=~"(ingester.*|%s-write.*|loki-single-binary)"' % $._config.ssd.pod_prefix_matcher
+  then 'container=~"loki|ingester", pod=~"(.*ingester.*|%s-write.*|loki-single-binary)"' % $._config.ssd.pod_prefix_matcher
   else if $._config.ssd.enabled then 'container="loki", pod=~"%s-write.*"' % $._config.ssd.pod_prefix_matcher else 'container="ingester"',
   local ingester_job_matcher = if $._config.meta_monitoring.enabled
-  then '(ingester.*|%s-write|loki-single-binary)' % $._config.ssd.pod_prefix_matcher
+  then '(.*ingester.*|%s-write|loki-single-binary)' % $._config.ssd.pod_prefix_matcher
   else if $._config.ssd.enabled then '%s-write' % $._config.ssd.pod_prefix_matcher else 'ingester.*',
 
   grafanaDashboards+::
     {
-      'loki-writes-resources.json':
+      'distributorloki-writes-resources.json':
         ($.dashboard('Loki / Writes Resources', uid='writes-resources'))
         .addCluster()
         .addNamespace()
@@ -39,7 +39,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
             $.containerMemoryWorkingSetPanel('Memory (workingset)', 'distributor'),
           )
           .addPanel(
-            $.goHeapInUsePanel('Memory (go heap inuse)', 'distributor'),
+            $.goHeapInUsePanel('Memory (go heap inuse)',  '.*distributor'),
           )
         )
         .addRow(


### PR DESCRIPTION
**What this PR does / why we need it**:

The micro services helm chart adds the namespace name to the pods and job. This PR updates the read and writes resources dashboards to handle this in the meta-monitoring chart. In this last chart the job label is consistent irregardless of the deployment mode. So some small changes were needed as well.

Tested by generating the dashboards and checking they work in loki-dev-013 (As this is single binary it doesn't show much there as there is no way to split CPU usage etc) and 014.

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
