### PR TITLE
docs: Close admonition shortcode

### DIFF
--- a/docs/sources/operations/storage/retention.md
+++ b/docs/sources/operations/storage/retention.md
@@ -199,6 +199,7 @@ The retention period must be a multiple of the index and chunks table
 `period`, configured in the [`period_config`](https://grafana.com/docs/loki/<LOKI_VERSION>/configure/#period_config) block.
 See the [Table Manager](https://grafana.com/docs/loki/<LOKI_VERSION>/operations/storage/table-manager/#retention) documentation for
 more information.
+{{% /admonition %}}
 
 {{% admonition type="note" %}}
 To avoid querying of data beyond the retention period,


### PR DESCRIPTION
**What this PR does / why we need it**:

Reported via Slack, this missing close tag on the admonition is currently breaking the website build.

This issue does not appear in `main`, and I have no idea how it got into the 3.0 branch, as this file has not been touched in the past three weeks.