### PR TITLE
fix: fix parsing of default per tenant otlp config

### DIFF
--- a/integration/cluster/cluster.go
+++ b/integration/cluster/cluster.go
@@ -68,6 +68,9 @@ limits_config:
       attributes_config:
         - action: index_label
           attributes: ["service.name"]
+    log_attributes:
+      - action: drop
+        attributes: [email]
 
 storage_config:
   named_stores:
@@ -430,6 +433,7 @@ func (c *Component) run() error {
 		return err
 	}
 
+	config.LimitsConfig.SetGlobalOTLPConfig(config.Distributor.OTLPConfig)
 	var err error
 	c.loki, err = loki.New(config.Config)
 	if err != nil {

--- a/integration/loki_micro_services_test.go
+++ b/integration/loki_micro_services_test.go
@@ -739,7 +739,7 @@ func TestOTLPLogsIngestQuery(t *testing.T) {
 
 	t.Run("ingest-logs", func(t *testing.T) {
 		// ingest some log lines
-		require.NoError(t, cliDistributor.PushOTLPLogLine("lineA", now.Add(-45*time.Minute), map[string]any{"trace_id": 1, "user_id": "2"}))
+		require.NoError(t, cliDistributor.PushOTLPLogLine("lineA", now.Add(-45*time.Minute), map[string]any{"trace_id": 1, "user_id": "2", "email": "foo@bar.com"}))
 		require.NoError(t, cliDistributor.PushOTLPLogLine("lineB", now.Add(-45*time.Minute), nil))
 
 		require.NoError(t, cliDistributor.PushOTLPLogLine("lineC", now, map[string]any{"order.ids": []any{5, 6}}))

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -403,7 +403,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 // SetGlobalOTLPConfig set GlobalOTLPConfig which is used while unmarshaling per-tenant otlp config to use the default list of resource attributes picked as index labels.
 func (l *Limits) SetGlobalOTLPConfig(cfg push.GlobalOTLPConfig) {
 	l.GlobalOTLPConfig = cfg
-	l.OTLPConfig = push.DefaultOTLPConfig(cfg)
+	l.OTLPConfig.ApplyGlobalOTLPConfig(cfg)
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.


### PR DESCRIPTION
**What this PR does / why we need it**:
There was a mistake I made in setting the default per tenant otlp config parsed from the overall Loki config, which causes Loki to ignore it. The per tenant otlp config set in overrides works as expected.
This PR fixes the issue and updates the otlp integration test to validate the change.

**Which issue(s) this PR fixes**:
Fixes #12780 

**Checklist**
- [x] Tests updated