### PR TITLE
fix(blooms): Do not fail requests when fetching metas from cache fails

### DIFF
--- a/pkg/storage/chunk/cache/mock.go
+++ b/pkg/storage/chunk/cache/mock.go
@@ -13,16 +13,27 @@ type MockCache interface {
 	GetInternal() map[string][]byte
 	KeysRequested() int
 	GetKeys() []string
+	SetErr(error, error)
 }
 
 type mockCache struct {
 	numKeyUpdates int
 	keysRequested int
 	sync.Mutex
-	cache map[string][]byte
+	cache    map[string][]byte
+	storeErr error // optional error that is returned when calling Store()
+	fetchErr error // optional error that is returned when calling Fetch()
+}
+
+func (m *mockCache) SetErr(storeErr, fetchErr error) {
+	m.storeErr, m.fetchErr = storeErr, fetchErr
 }
 
 func (m *mockCache) Store(_ context.Context, keys []string, bufs [][]byte) error {
+	if m.storeErr != nil {
+		return m.storeErr
+	}
+
 	m.Lock()
 	defer m.Unlock()
 	for i := range keys {
@@ -33,6 +44,10 @@ func (m *mockCache) Store(_ context.Context, keys []string, bufs [][]byte) error
 }
 
 func (m *mockCache) Fetch(_ context.Context, keys []string) (found []string, bufs [][]byte, missing []string, err error) {
+	if m.fetchErr != nil {
+		return nil, nil, nil, m.fetchErr
+	}
+
 	m.Lock()
 	defer m.Unlock()
 	for _, key := range keys {

--- a/pkg/storage/stores/shipper/bloomshipper/fetcher.go
+++ b/pkg/storage/stores/shipper/bloomshipper/fetcher.go
@@ -129,7 +129,8 @@ func (f *Fetcher) FetchMetas(ctx context.Context, refs []MetaRef) ([]Meta, error
 	}
 	cacheHits, cacheBufs, _, err := f.metasCache.Fetch(ctx, keys)
 	if err != nil {
-		return nil, err
+		level.Error(f.logger).Log("msg", "failed to fetch metas from cache", "err", err)
+		return nil, nil
 	}
 
 	fromCache, missing, err := f.processMetasCacheResponse(ctx, refs, cacheHits, cacheBufs)


### PR DESCRIPTION
**What this PR does / why we need it**:

The bloom shipper uses metas to resolve available blocks. Metas are fetched from cache, and if not available from object storage.
If fetching metas from cache fails, e.g. timeout, the request should not fail, but proceed as if no metas were available.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
