### PR TITLE
feat(blooms): Add in-memory LRU cache for meta files

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -5280,6 +5280,26 @@ bloom_shipper:
   # component.
   # The CLI flags prefix for this block configuration is: bloom.metas-cache
   [metas_cache: <cache_config>]
+
+  metas_lru_cache:
+    # In-memory LRU cache for bloom metas. Whether embedded cache is enabled.
+    # CLI flag: -bloom.metas-lru-cache.enabled
+    [enabled: <boolean> | default = false]
+
+    # In-memory LRU cache for bloom metas. Maximum memory size of the cache in
+    # MB.
+    # CLI flag: -bloom.metas-lru-cache.max-size-mb
+    [max_size_mb: <int> | default = 100]
+
+    # In-memory LRU cache for bloom metas. Maximum number of entries in the
+    # cache.
+    # CLI flag: -bloom.metas-lru-cache.max-size-items
+    [max_size_items: <int> | default = 0]
+
+    # In-memory LRU cache for bloom metas. The time to live for items in the
+    # cache before they get purged.
+    # CLI flag: -bloom.metas-lru-cache.ttl
+    [ttl: <duration> | default = 1h]
 ```
 
 ### swift_storage_config

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -733,7 +733,7 @@ func (t *Loki) initBloomStore() (services.Service, error) {
 		lruCfg := cache.EmbeddedCacheConfig{
 			Enabled:       true,
 			MaxSizeMB:     256,
-			MaxSizeItems:  10000,
+			MaxSizeItems:  128000,
 			TTL:           10 * time.Minute,
 			PurgeInterval: 1 * time.Minute,
 		}

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -730,13 +730,10 @@ func (t *Loki) initBloomStore() (services.Service, error) {
 	if cache.IsCacheConfigured(bsCfg.MetasCache) {
 		metasCache, err = cache.New(bsCfg.MetasCache, reg, logger, stats.BloomMetasCache, constants.Loki)
 
-		lruCfg := cache.EmbeddedCacheConfig{
-			Enabled:       true,
-			MaxSizeMB:     256,
-			MaxSizeItems:  128000,
-			TTL:           10 * time.Minute,
-			PurgeInterval: 1 * time.Minute,
-		}
+		// always enable LRU cache
+		lruCfg := bsCfg.MetasLRUCache
+		lruCfg.Enabled = true
+		lruCfg.PurgeInterval = 1 * time.Minute
 		lruCache := cache.NewEmbeddedCache("inmemory-metas-lru", lruCfg, reg, logger, stats.BloomMetasCache)
 
 		metasCache = cache.NewTiered([]cache.Cache{lruCache, metasCache})

--- a/pkg/storage/stores/shipper/bloomshipper/config/config.go
+++ b/pkg/storage/stores/shipper/bloomshipper/config/config.go
@@ -12,11 +12,12 @@ import (
 )
 
 type Config struct {
-	WorkingDirectory    flagext.StringSliceCSV `yaml:"working_directory"`
-	MaxQueryPageSize    flagext.Bytes          `yaml:"max_query_page_size"`
-	DownloadParallelism int                    `yaml:"download_parallelism"`
-	BlocksCache         BlocksCacheConfig      `yaml:"blocks_cache"`
-	MetasCache          cache.Config           `yaml:"metas_cache"`
+	WorkingDirectory    flagext.StringSliceCSV    `yaml:"working_directory"`
+	MaxQueryPageSize    flagext.Bytes             `yaml:"max_query_page_size"`
+	DownloadParallelism int                       `yaml:"download_parallelism"`
+	BlocksCache         BlocksCacheConfig         `yaml:"blocks_cache"`
+	MetasCache          cache.Config              `yaml:"metas_cache"`
+	MetasLRUCache       cache.EmbeddedCacheConfig `yaml:"metas_lru_cache"`
 
 	// This will always be set to true when flags are registered.
 	// In tests, where config is created as literal, it can be set manually.
@@ -32,6 +33,7 @@ func (c *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.IntVar(&c.DownloadParallelism, prefix+"download-parallelism", 8, "The amount of maximum concurrent bloom blocks downloads. Usually set to 2x number of CPU cores.")
 	c.BlocksCache.RegisterFlagsWithPrefixAndDefaults(prefix+"blocks-cache.", "Cache for bloom blocks. ", f, 24*time.Hour)
 	c.MetasCache.RegisterFlagsWithPrefix(prefix+"metas-cache.", "Cache for bloom metas. ", f)
+	c.MetasLRUCache.RegisterFlagsWithPrefix(prefix+"metas-lru-cache.", "In-memory LRU cache for bloom metas. ", f)
 
 	// always cache LIST operations
 	c.CacheListOps = true


### PR DESCRIPTION
**What this PR does / why we need it**:

The in-memory LRU cache helps to reduce the amount of operations against memcached (or other configured cache backend).


**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
