### PR TITLE
ci: make renovate commits come in as fixes

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -30,5 +30,7 @@
     "prConcurrentLimit": 10,
     "rebaseWhen": "conflicted",
     "branchPrefix": "deps-update/",
-    "postUpdateOptions": ["gomodTidy"]
+    "postUpdateOptions": ["gomodTidy"],
+    "semanticCommitType": "fix",
+    "semanticCommitScope": "deps"
   }


### PR DESCRIPTION
**What this PR does / why we need it**:

We often release patches that are just dependency updates. If we want those updates reflected in the changelog, renovate needs to use `fix` commit types.