### PR TITLE
fix: `codec` not initialized in downstream roundtripper

### DIFF
--- a/pkg/lokifrontend/frontend/config.go
+++ b/pkg/lokifrontend/frontend/config.go
@@ -43,7 +43,7 @@ func InitFrontend(cfg CombinedFrontendConfig, ring ring.ReadRing, limits v1.Limi
 	switch {
 	case cfg.DownstreamURL != "":
 		// If the user has specified a downstream Prometheus, then we should use that.
-		rt, err := NewDownstreamRoundTripper(cfg.DownstreamURL, http.DefaultTransport)
+		rt, err := NewDownstreamRoundTripper(cfg.DownstreamURL, http.DefaultTransport, codec)
 		return rt, nil, nil, err
 	case cfg.FrontendV2.SchedulerAddress != "" || ring != nil:
 		// If query-scheduler address is configured, use Frontend.

--- a/pkg/lokifrontend/frontend/downstream_roundtripper.go
+++ b/pkg/lokifrontend/frontend/downstream_roundtripper.go
@@ -20,13 +20,13 @@ type downstreamRoundTripper struct {
 	codec         queryrangebase.Codec
 }
 
-func NewDownstreamRoundTripper(downstreamURL string, transport http.RoundTripper) (queryrangebase.Handler, error) {
+func NewDownstreamRoundTripper(downstreamURL string, transport http.RoundTripper, codec queryrangebase.Codec) (queryrangebase.Handler, error) {
 	u, err := url.Parse(downstreamURL)
 	if err != nil {
 		return nil, err
 	}
 
-	return &downstreamRoundTripper{downstreamURL: u, transport: transport}, nil
+	return &downstreamRoundTripper{downstreamURL: u, transport: transport, codec: codec}, nil
 }
 
 func (d downstreamRoundTripper) Do(ctx context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Looks like part of [this PR](https://github.com/grafana/loki/pull/10688) introduced this bug. Root cause is `codec` is `nil` (never initialized) and panics during downstream `Do`.

Above patch, converted QueryFrontend tripperware into middleware but failed to pass the right `codec` to downstream roundtripper.

This PR passes the codec during `InitFrontend`. 

**Which issue(s) this PR fixes**:
Fixes #12842 

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
