### PR TITLE
docs: specify minimum number of nodes in k8s cluster

### DIFF
--- a/docs/sources/setup/install/helm/install-scalable/_index.md
+++ b/docs/sources/setup/install/helm/install-scalable/_index.md
@@ -33,7 +33,7 @@ It is not recommended to run scalable mode with `filesystem` storage.
 **Prerequisites**
 
 - Helm 3 or above. See [Installing Helm](https://helm.sh/docs/intro/install/).
-- A running Kubernetes cluster.
+- A running Kubernetes cluster (must have at least 3 nodes).
 - (Optional) A Memcached deployment for better query performance. For information on configuring Memcached, refer to [caching section]({{< relref "../../../../operations/caching" >}}).
 
 


### PR DESCRIPTION
Minor update. The Helm chart can't be deployed to a single Node k8s setup due to pod affinity rules in the chart.