### PR TITLE
docs: Update release notes for 2.9.8

### DIFF
--- a/docs/sources/release-notes/v2-9.md
+++ b/docs/sources/release-notes/v2-9.md
@@ -34,6 +34,10 @@ Grafana Labs is excited to announce the release of Loki 2.9.0 Here's a summary o
 
 ## Bug fixes
 
+### 2.9.8 (2024-05-03)
+
+- **deps:** update module golang.org/x/net to v0.23.0 [security] (release-2.9.x) ([#12865](https://github.com/grafana/loki/issues/12865)) ([94e0029](https://github.com/grafana/loki/commit/94e00299ec9b36ad97c147641566b6922268c54e)).
+
 ### 2.9.7 (2024-04-10)
 
 - Bump go to 1.21.9 and build image to 0.33.1 (#12542) (efc4d2f)


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the Release Notes for version 2.9.8.