### PR TITLE
docs: Update release notes for 2.9.8 (#12881)

### DIFF
--- a/docs/sources/release-notes/v2-9.md
+++ b/docs/sources/release-notes/v2-9.md
@@ -34,6 +34,14 @@ Grafana Labs is excited to announce the release of Loki 2.9.0 Here's a summary o
 
 ## Bug fixes
 
+### 2.9.8 (2024-05-03)
+
+- **deps:** update module golang.org/x/net to v0.23.0 [security] (release-2.9.x) ([#12865](https://github.com/grafana/loki/issues/12865)) ([94e0029](https://github.com/grafana/loki/commit/94e00299ec9b36ad97c147641566b6922268c54e)).
+
+### 2.9.7 (2024-04-10)
+
+- Bump go to 1.21.9 and build image to 0.33.1 (#12542) (efc4d2f)
+
 ### 2.9.6 (2024-03-21)
 
 * Fixed Promtail failures connecting to local Loki installation ([#12184](https://github.com/grafana/loki/issues/12184)) ([8585e35](https://github.com/grafana/loki/commit/8585e3537375c0deb11462d7256f5da23228f5e1)).


### PR DESCRIPTION
(cherry picked from commit a21c1077deecfb6b7a68a2ba6e472cafc2a2eca3)

Backport #12881 to the 3.0 branch.