### PR TITLE
fix(spans): corrects early-close for a few spans

### DIFF
--- a/pkg/querier/queryrange/limits.go
+++ b/pkg/querier/queryrange/limits.go
@@ -341,7 +341,6 @@ func (q *querySizeLimiter) guessLimitName() string {
 
 func (q *querySizeLimiter) Do(ctx context.Context, r queryrangebase.Request) (queryrangebase.Response, error) {
 	log := spanlogger.FromContext(ctx)
-	defer log.Finish()
 
 	// Only support TSDB
 	schemaCfg, err := q.getSchemaCfg(r)

--- a/pkg/querier/queryrange/shard_resolver.go
+++ b/pkg/querier/queryrange/shard_resolver.go
@@ -222,7 +222,6 @@ func (r *dynamicShardResolver) ShardingRanges(expr syntax.Expr, targetBytesPerSh
 	error,
 ) {
 	log := spanlogger.FromContext(r.ctx)
-	defer log.Finish()
 
 	adjustedFrom := r.from
 


### PR DESCRIPTION
* Since we're not creating new spans in a few places, we shouldn't finish them from subroutines
* some minor span logging
