### PR TITLE
ci: force one time run of helm release for 5.48

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - helm-5.48
     paths:
       - 'production/helm/loki/Chart.yaml'
 


### PR DESCRIPTION
**What this PR does / why we need it**:

We don't normally do old releases of helm, but this is a special case and we need to force a 5.48 release. I tried changing this file just on that branch but it didn't work.