### PR TITLE
chore(blooms): records more bloom iteration stats

### DIFF
--- a/pkg/bloomgateway/bloomgateway.go
+++ b/pkg/bloomgateway/bloomgateway.go
@@ -89,7 +89,7 @@ type Gateway struct {
 
 	queue       *queue.RequestQueue
 	activeUsers *util.ActiveUsersCleanupService
-	bloomStore  bloomshipper.Store
+	bloomStore  bloomshipper.StoreWithMetrics
 
 	pendingTasks *atomic.Int64
 
@@ -111,7 +111,7 @@ func (l *fixedQueueLimits) MaxConsumers(_ string, _ int) int {
 }
 
 // New returns a new instance of the Bloom Gateway.
-func New(cfg Config, store bloomshipper.Store, logger log.Logger, reg prometheus.Registerer) (*Gateway, error) {
+func New(cfg Config, store bloomshipper.StoreWithMetrics, logger log.Logger, reg prometheus.Registerer) (*Gateway, error) {
 	utillog.WarnExperimentalUse("Bloom Gateway", logger)
 	g := &Gateway{
 		cfg:     cfg,
@@ -340,7 +340,7 @@ func (g *Gateway) FilterChunkRefs(ctx context.Context, req *logproto.FilterChunk
 		}
 	}
 
-	combinedRecorder.Log(util_log.WithContext(ctx, g.logger))
+	combinedRecorder.Report(util_log.WithContext(ctx, g.logger), g.bloomStore.BloomMetrics())
 	sp.LogKV("msg", "received all responses")
 
 	start := time.Now()

--- a/pkg/bloomgateway/processor.go
+++ b/pkg/bloomgateway/processor.go
@@ -144,7 +144,7 @@ func (p *processor) processBlocks(ctx context.Context, bqs []*bloomshipper.Close
 	})
 }
 
-func (p *processor) processBlock(ctx context.Context, blockQuerier *v1.BlockQuerier, tasks []Task) error {
+func (p *processor) processBlock(_ context.Context, blockQuerier *v1.BlockQuerier, tasks []Task) error {
 	schema, err := blockQuerier.Schema()
 	if err != nil {
 		return err

--- a/pkg/bloomgateway/processor.go
+++ b/pkg/bloomgateway/processor.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 
 	"github.com/grafana/dskit/concurrency"
@@ -145,7 +144,7 @@ func (p *processor) processBlocks(ctx context.Context, bqs []*bloomshipper.Close
 	})
 }
 
-func (p *processor) processBlock(_ context.Context, blockQuerier *v1.BlockQuerier, tasks []Task) error {
+func (p *processor) processBlock(ctx context.Context, blockQuerier *v1.BlockQuerier, tasks []Task) error {
 	schema, err := blockQuerier.Schema()
 	if err != nil {
 		return err
@@ -155,11 +154,15 @@ func (p *processor) processBlock(_ context.Context, blockQuerier *v1.BlockQuerie
 	iters := make([]v1.PeekingIterator[v1.Request], 0, len(tasks))
 
 	for _, task := range tasks {
-		if sp := opentracing.SpanFromContext(task.ctx); sp != nil {
-			md, _ := blockQuerier.Metadata()
-			blk := bloomshipper.BlockRefFrom(task.tenant, task.table.String(), md)
-			sp.LogKV("process block", blk.String(), "series", len(task.series))
-		}
+		// NB(owen-d): can be helpful for debugging, but is noisy
+		// and don't feel like threading this through a configuration
+
+		// if sp := opentracing.SpanFromContext(task.ctx); sp != nil {
+		// 	md, _ := blockQuerier.Metadata()
+		// 	blk := bloomshipper.BlockRefFrom(task.tenant, task.table.String(), md)
+		// 	blockID := blk.String()
+		// 	sp.LogKV("process block", blockID, "series", len(task.series))
+		// }
 
 		it := v1.NewPeekingIter(task.RequestIter(tokenizer))
 		iters = append(iters, it)

--- a/pkg/bloomgateway/processor_test.go
+++ b/pkg/bloomgateway/processor_test.go
@@ -15,6 +15,7 @@ import (
 	"go.uber.org/atomic"
 
 	"github.com/grafana/loki/v3/pkg/logql/syntax"
+	v1 "github.com/grafana/loki/v3/pkg/storage/bloom/v1"
 	"github.com/grafana/loki/v3/pkg/storage/chunk/client"
 	"github.com/grafana/loki/v3/pkg/storage/config"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/bloomshipper"
@@ -38,6 +39,10 @@ type dummyStore struct {
 	delay time.Duration
 	// mock response error when serving block queriers in ForEach
 	err error
+}
+
+func (s *dummyStore) BloomMetrics() *v1.Metrics {
+	return v1.NewMetrics(nil)
 }
 
 func (s *dummyStore) ResolveMetas(_ context.Context, _ bloomshipper.MetaSearchParams) ([][]bloomshipper.MetaRef, []*bloomshipper.Fetcher, error) {

--- a/pkg/storage/bloom/v1/fuse.go
+++ b/pkg/storage/bloom/v1/fuse.go
@@ -1,10 +1,14 @@
 package v1
 
 import (
+	"context"
+
 	"github.com/efficientgo/core/errors"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"github.com/grafana/loki/v3/pkg/util/spanlogger"
 	"github.com/prometheus/common/model"
+	"go.uber.org/atomic"
 )
 
 type Request struct {
@@ -12,6 +16,76 @@ type Request struct {
 	Chks     ChunkRefs
 	Search   BloomTest
 	Response chan<- Output
+	Recorder *BloomRecorder
+}
+
+// BloomRecorder records the results of a bloom search
+func NewBloomRecorder(ctx context.Context, id string) *BloomRecorder {
+	return &BloomRecorder{
+		ctx:            ctx,
+		id:             id,
+		seriesFound:    atomic.NewInt64(0),
+		chunksFound:    atomic.NewInt64(0),
+		seriesSkipped:  atomic.NewInt64(0),
+		chunksSkipped:  atomic.NewInt64(0),
+		seriesMissed:   atomic.NewInt64(0),
+		chunksMissed:   atomic.NewInt64(0),
+		chunksFiltered: atomic.NewInt64(0),
+	}
+}
+
+type BloomRecorder struct {
+	ctx context.Context
+	id  string
+	// exists in the bloom+queried
+	seriesFound, chunksFound *atomic.Int64
+	// exists in bloom+skipped
+	seriesSkipped, chunksSkipped *atomic.Int64
+	// not found in bloom
+	seriesMissed, chunksMissed *atomic.Int64
+	// filtered out
+	chunksFiltered *atomic.Int64
+}
+
+func (r *BloomRecorder) Merge(other *BloomRecorder) {
+	r.seriesFound.Add(other.seriesFound.Load())
+	r.chunksFound.Add(other.chunksFound.Load())
+	r.seriesSkipped.Add(other.seriesSkipped.Load())
+	r.chunksSkipped.Add(other.chunksSkipped.Load())
+	r.seriesMissed.Add(other.seriesMissed.Load())
+	r.chunksMissed.Add(other.chunksMissed.Load())
+	r.chunksFiltered.Add(other.chunksFiltered.Load())
+}
+
+func (r *BloomRecorder) Log(logger log.Logger) {
+	logger = spanlogger.FromContextWithFallback(r.ctx, logger)
+	level.Debug(logger).Log(
+		"recorder_msg", "bloom search results",
+		"recorder_id", r.id,
+
+		"recorder_series_requested", r.seriesFound.Load()+r.seriesSkipped.Load()+r.seriesMissed.Load(),
+		"recorder_series_found", r.seriesFound.Load(),
+		"recorder_series_skipped", r.seriesSkipped.Load(),
+		"recorder_series_missed", r.seriesMissed.Load(),
+
+		"recorder_chunks_requested", r.chunksFound.Load()+r.chunksSkipped.Load()+r.chunksMissed.Load(),
+		"recorder_chunks_found", r.chunksFound.Load(),
+		"recorder_chunks_skipped", r.chunksSkipped.Load(),
+		"recorder_chunks_missed", r.chunksMissed.Load(),
+		"recorder_chunks_filtered", r.chunksFiltered.Load(),
+	)
+}
+
+func (r *BloomRecorder) record(
+	seriesFound, chunksFound, seriesSkipped, chunksSkipped, seriesMissed, chunksMissed, chunksFiltered int,
+) {
+	r.seriesFound.Add(int64(seriesFound))
+	r.chunksFound.Add(int64(chunksFound))
+	r.seriesSkipped.Add(int64(seriesSkipped))
+	r.chunksSkipped.Add(int64(chunksSkipped))
+	r.seriesMissed.Add(int64(seriesMissed))
+	r.chunksMissed.Add(int64(chunksMissed))
+	r.chunksFiltered.Add(int64(chunksFiltered))
 }
 
 // Output represents a chunk that failed to pass all searches
@@ -59,8 +133,50 @@ func NewFusedQuerier(bq *BlockQuerier, inputs []PeekingIterator[Request], logger
 	}
 }
 
-func (fq *FusedQuerier) noRemovals(batch []Request, fp model.Fingerprint) {
+func (fq *FusedQuerier) recordMissingFp(
+	batch []Request,
+	fp model.Fingerprint,
+) {
+	fq.noRemovals(batch, fp, func(input Request) {
+		input.Recorder.record(
+			0, 0, // found
+			0, 0, // skipped
+			1, len(input.Chks), // missed
+			0, // chunks filtered
+		)
+	})
+}
+
+func (fq *FusedQuerier) recordSkippedFp(
+	batch []Request,
+	fp model.Fingerprint,
+) {
+	fq.noRemovals(batch, fp, func(input Request) {
+		input.Recorder.record(
+			0, 0, // found
+			1, len(input.Chks), // skipped
+			0, 0, // missed
+			0, // chunks filtered
+		)
+	})
+}
+
+func (fq *FusedQuerier) noRemovals(
+	batch []Request,
+	fp model.Fingerprint,
+	fn func(Request),
+) {
 	for _, input := range batch {
+		if fp != input.Fp {
+			// should not happen, but log just in case
+			level.Error(fq.logger).Log(
+				"msg", "fingerprint mismatch",
+				"expected", fp,
+				"actual", input.Fp,
+				"block", "TODO",
+			)
+		}
+		fn(input)
 		input.Response <- Output{
 			Fp:       fp,
 			Removals: nil,
@@ -94,7 +210,7 @@ func (fq *FusedQuerier) Run() error {
 		if series.Fingerprint != fp {
 			// fingerprint not found, can't remove chunks
 			level.Debug(fq.logger).Log("msg", "fingerprint not found", "fp", series.Fingerprint, "err", fq.bq.series.Err())
-			fq.noRemovals(nextBatch, fp)
+			fq.recordMissingFp(nextBatch, fp)
 			continue
 		}
 
@@ -103,51 +219,49 @@ func (fq *FusedQuerier) Run() error {
 		if skip {
 			// could not seek to the desired bloom,
 			// likely because the page was too large to load
-			fq.noRemovals(nextBatch, fp)
+			fq.recordSkippedFp(nextBatch, fp)
 			continue
 		}
 
 		if !fq.bq.blooms.Next() {
 			// fingerprint not found, can't remove chunks
 			level.Debug(fq.logger).Log("msg", "fingerprint not found", "fp", series.Fingerprint, "err", fq.bq.blooms.Err())
-			fq.noRemovals(nextBatch, fp)
+			fq.recordMissingFp(nextBatch, fp)
 			continue
 		}
 
 		bloom := fq.bq.blooms.At()
 		// test every input against this chunk
 		for _, input := range nextBatch {
-			_, inBlooms := input.Chks.Compare(series.Chunks, true)
+			missing, inBlooms := input.Chks.Compare(series.Chunks, true)
+
+			var (
+				// TODO(owen-d): pool
+				removals ChunkRefs
+				// TODO(salvacorts): pool tokenBuf
+				tokenBuf  []byte
+				prefixLen int
+			)
 
 			// First, see if the search passes the series level bloom before checking for chunks individually
-			if !input.Search.Matches(bloom) {
-				// We return all the chunks that were the intersection of the query
-				// because they for sure do not match the search and don't
-				// need to be downloaded
-				input.Response <- Output{
-					Fp:       fp,
-					Removals: inBlooms,
+			if matchedSeries := input.Search.Matches(bloom); !matchedSeries {
+				removals = inBlooms
+			} else {
+				for _, chk := range inBlooms {
+					// Get buf to concatenate the chunk and search token
+					tokenBuf, prefixLen = prefixedToken(schema.NGramLen(), chk, tokenBuf)
+					if !input.Search.MatchesWithPrefixBuf(bloom, tokenBuf, prefixLen) {
+						removals = append(removals, chk)
+					}
 				}
-				continue
 			}
 
-			// TODO(owen-d): pool
-			var removals ChunkRefs
-
-			// TODO(salvacorts): pool tokenBuf
-			var tokenBuf []byte
-			var prefixLen int
-
-			for _, chk := range inBlooms {
-				// Get buf to concatenate the chunk and search token
-				tokenBuf, prefixLen = prefixedToken(schema.NGramLen(), chk, tokenBuf)
-				if !input.Search.MatchesWithPrefixBuf(bloom, tokenBuf, prefixLen) {
-					removals = append(removals, chk)
-					continue
-				}
-				// Otherwise, the chunk passed all the searches
-			}
-
+			input.Recorder.record(
+				1, len(inBlooms), // found
+				0, 0, // skipped
+				0, len(missing), // missed
+				len(removals), // filtered
+			)
 			input.Response <- Output{
 				Fp:       fp,
 				Removals: removals,

--- a/pkg/storage/bloom/v1/fuse.go
+++ b/pkg/storage/bloom/v1/fuse.go
@@ -6,9 +6,10 @@ import (
 	"github.com/efficientgo/core/errors"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/grafana/loki/v3/pkg/util/spanlogger"
 	"github.com/prometheus/common/model"
 	"go.uber.org/atomic"
+
+	"github.com/grafana/loki/v3/pkg/util/spanlogger"
 )
 
 type Request struct {

--- a/pkg/storage/bloom/v1/fuse_test.go
+++ b/pkg/storage/bloom/v1/fuse_test.go
@@ -89,6 +89,7 @@ func TestFusedQuerier(t *testing.T) {
 		for j := 0; j < n; j++ {
 			idx := numSeries/nReqs*i + j
 			reqs = append(reqs, Request{
+				Recorder: NewBloomRecorder(context.Background(), "unknown"),
 				Fp:       data[idx].Series.Fingerprint,
 				Chks:     data[idx].Series.Chunks,
 				Response: ch,
@@ -282,6 +283,7 @@ func setupBlockForBenchmark(b *testing.B) (*BlockQuerier, [][]Request, []chan Ou
 				idx = numSeries - 1
 			}
 			reqs = append(reqs, Request{
+				Recorder: NewBloomRecorder(context.Background(), "unknown"),
 				Fp:       data[idx].Series.Fingerprint,
 				Chks:     data[idx].Series.Chunks,
 				Response: ch,

--- a/pkg/storage/bloom/v1/metrics.go
+++ b/pkg/storage/bloom/v1/metrics.go
@@ -28,6 +28,9 @@ type Metrics struct {
 	pagesSkipped *prometheus.CounterVec
 	bytesRead    *prometheus.CounterVec
 	bytesSkipped *prometheus.CounterVec
+
+	recorderSeries *prometheus.CounterVec
+	recorderChunks *prometheus.CounterVec
 }
 
 const (
@@ -52,6 +55,12 @@ const (
 
 	bloomCreationTypeIndexed = "indexed"
 	bloomCreationTypeSkipped = "skipped"
+
+	recorderRequested = "requested"
+	recorderFound     = "found"
+	recorderSkipped   = "skipped"
+	recorderMissed    = "missed"
+	recorderFiltered  = "filtered"
 )
 
 func NewMetrics(r prometheus.Registerer) *Metrics {
@@ -148,5 +157,16 @@ func NewMetrics(r prometheus.Registerer) *Metrics {
 			Name:      "bloom_bytes_skipped_total",
 			Help:      "Number of bytes skipped during query iteration",
 		}, []string{"type", "reason"}),
+
+		recorderSeries: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
+			Namespace: constants.Loki,
+			Name:      "bloom_recorder_series_total",
+			Help:      "Number of series reported by the bloom query recorder. Type can be requested (total), found (existed in blooms), skipped (due to page too large configurations, etc), missed (not found in blooms)",
+		}, []string{"type"}),
+		recorderChunks: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
+			Namespace: constants.Loki,
+			Name:      "bloom_recorder_chunks_total",
+			Help:      "Number of chunks reported by the bloom query recorder. Type can be requested (total), found (existed in blooms), skipped (due to page too large configurations, etc), missed (not found in blooms), filtered (filtered out)",
+		}, []string{"type"}),
 	}
 }


### PR DESCRIPTION
This gives us more granular information on why data was added/passed filters/skipped. Also cleans up a bit of bloom-gw code. Gives info like 
<img width="397" alt="image" src="https://github.com/grafana/loki/assets/8173478/72e43842-8687-44c5-b29e-d4ccba3bc180">

