### PR TITLE
fix(blooms): Fix `partitionSeriesByDay` function

### DIFF
--- a/pkg/bloomgateway/bloomgateway.go
+++ b/pkg/bloomgateway/bloomgateway.go
@@ -270,7 +270,7 @@ func (g *Gateway) FilterChunkRefs(ctx context.Context, req *logproto.FilterChunk
 		"series_requested", len(req.Refs),
 	)
 
-	if len(seriesByDay) != 1 {
+	if len(seriesByDay) > 1 {
 		stats.Status = labelFailure
 		return nil, errors.New("request time range must span exactly one day")
 	}

--- a/pkg/bloomgateway/util_test.go
+++ b/pkg/bloomgateway/util_test.go
@@ -166,10 +166,46 @@ func TestPartitionRequest(t *testing.T) {
 		exp []seriesWithInterval
 	}{
 
-		"empty": {
+		"no series": {
 			inp: &logproto.FilterChunkRefRequest{
-				From:    ts.Add(-24 * time.Hour),
-				Through: ts,
+				From:    ts.Add(-12 * time.Hour),
+				Through: ts.Add(12 * time.Hour),
+				Refs:    []*logproto.GroupedChunkRefs{},
+			},
+			exp: []seriesWithInterval{},
+		},
+
+		"no chunks for series": {
+			inp: &logproto.FilterChunkRefRequest{
+				From:    ts.Add(-12 * time.Hour),
+				Through: ts.Add(12 * time.Hour),
+				Refs: []*logproto.GroupedChunkRefs{
+					{
+						Fingerprint: 0x00,
+						Refs:        []*logproto.ShortRef{},
+					},
+					{
+						Fingerprint: 0x10,
+						Refs:        []*logproto.ShortRef{},
+					},
+				},
+			},
+			exp: []seriesWithInterval{},
+		},
+
+		"chunks before and after requested day": {
+			inp: &logproto.FilterChunkRefRequest{
+				From:    ts.Add(-2 * time.Hour),
+				Through: ts.Add(2 * time.Hour),
+				Refs: []*logproto.GroupedChunkRefs{
+					{
+						Fingerprint: 0x00,
+						Refs: []*logproto.ShortRef{
+							{From: ts.Add(-13 * time.Hour), Through: ts.Add(-12 * time.Hour)},
+							{From: ts.Add(13 * time.Hour), Through: ts.Add(14 * time.Hour)},
+						},
+					},
+				},
 			},
 			exp: []seriesWithInterval{},
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:

The function `partitionSeriesByDay` could yield empty when chunks were outside of the requested time range.
    
This would result in requests for a time range that does not contain any
chunks for a series to filter. These requests would return errors, because a subsequent `partitionSeriesByDay` for would remove that day resulting in no task.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
