### PR TITLE
fix: Invalidate caches when pipeline wrappers are disabled

### DIFF
--- a/pkg/storage/chunk/cache/resultscache/cache.go
+++ b/pkg/storage/chunk/cache/resultscache/cache.go
@@ -87,7 +87,7 @@ func NewResultsCache(
 		next:                 next,
 		cache:                c,
 		limits:               limits,
-		keyGen:               keyGen,
+		keyGen:               NewPipelineWrapperKeygen(keyGen),
 		cacheGenNumberLoader: cacheGenNumberLoader,
 		retentionEnabled:     retentionEnabled,
 		extractor:            extractor,

--- a/pkg/storage/chunk/cache/resultscache/pipelinewrapper_keygen.go
+++ b/pkg/storage/chunk/cache/resultscache/pipelinewrapper_keygen.go
@@ -1,0 +1,23 @@
+package resultscache
+
+import (
+	"context"
+	"github.com/grafana/loki/v3/pkg/util/httpreq"
+)
+
+type PipelineWrapperKeyGenerator struct {
+	inner KeyGenerator
+}
+
+func NewPipelineWrapperKeygen(inner KeyGenerator) KeyGenerator {
+	return &PipelineWrapperKeyGenerator{inner: inner}
+}
+
+func (kg *PipelineWrapperKeyGenerator) GenerateCacheKey(ctx context.Context, userID string, r Request) string {
+	innerKey := kg.inner.GenerateCacheKey(ctx, userID, r)
+
+	if httpreq.ExtractHeader(ctx, httpreq.LokiDisablePipelineWrappersHeader) == "true" {
+		return "pipeline-disabled:" + innerKey
+	}
+	return innerKey
+}

--- a/pkg/storage/chunk/cache/resultscache/pipelinewrapper_keygen_test.go
+++ b/pkg/storage/chunk/cache/resultscache/pipelinewrapper_keygen_test.go
@@ -1,0 +1,32 @@
+package resultscache
+
+import (
+	"context"
+	"github.com/grafana/loki/v3/pkg/util/httpreq"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestPipelineWrapperKeygen(t *testing.T) {
+	kg := &stubKeygen{key: "cache-key"}
+	keygen := NewPipelineWrapperKeygen(kg)
+
+	t.Run("it does nothing if pipeline wrappers aren't disabled", func(t *testing.T) {
+		key := keygen.GenerateCacheKey(context.Background(), "", nil)
+		require.Equal(t, "cache-key", key)
+	})
+
+	t.Run("it changes the key when pipeline wrappers are disabled", func(t *testing.T) {
+		ctx := httpreq.InjectHeader(context.Background(), httpreq.LokiDisablePipelineWrappersHeader, "true")
+		key := keygen.GenerateCacheKey(ctx, "", nil)
+		require.Equal(t, "pipeline-disabled:cache-key", key)
+	})
+}
+
+type stubKeygen struct {
+	key string
+}
+
+func (k *stubKeygen) GenerateCacheKey(_ context.Context, _ string, _ Request) string {
+	return k.key
+}


### PR DESCRIPTION
Pipeline wrappers can be disabled at the request level. When they are, the results of queries change so caches need to be invalidated.

This PR introduces a new key generator that changes the key when pipeline wrappers are disabled.