### PR TITLE
fix(helm) Add capability to ignore the gateway service by the serviceMonitor

### DIFF
--- a/production/helm/loki/templates/gateway/service-gateway.yaml
+++ b/production/helm/loki/templates/gateway/service-gateway.yaml
@@ -12,6 +12,9 @@ metadata:
     {{- with .Values.gateway.service.labels }}
     {{- toYaml . | nindent 4}}
     {{- end }}
+    {{- if .Values.gateway.excludeFromServiceMonitor }}
+    prometheus.io/scrape: "false"
+    {{- end }}
   annotations:
     {{- with .Values.loki.serviceAnnotations }}
     {{- toYaml . | nindent 4}}

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -975,6 +975,9 @@ gateway:
     annotations: {}
     # -- Labels for gateway service
     labels: {}
+    # -- Adds the label prometheus.io/service-monitor: "false" to the gateway service so that it's excluded from the loki serviceMonitor
+    # The nginx does not export metrics per default and would be reported as down if monitoring.serviceMonitor.enabled is true.
+    excludeFromServiceMonitor: false
   # Gateway ingress configuration
   ingress:
     # -- Specifies whether an ingress for the gateway should be created


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR sets per default the label `prometheus.io/scrape=false` to the gateway service. 

This causes the gateway service not to be treated as a Prometheus scrape target and fixes alerts that the target is down and can't be scraped. This is useful because the nginx does not provide any metrics in the default configuration. 

Users could either add the label manually or we set it per default. With this PR I would pitch the 2nd option so that users don't have to investigate the alerts caused by a default loki deployment via helm.

**Which issue(s) this PR fixes**:
Could not find any related issue and experienced the issue by myself when switching from the loki-distributed to the loki chart. 

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
