### PR TITLE
docs: Don't allow running new and old querier worker grpc clients

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -2237,19 +2237,19 @@ The `frontend_worker` configures the worker - running within the Loki querier - 
 [id: <string> | default = ""]
 
 # Configures the querier gRPC client used to communicate with the
-# query-frontend. Can't be used in conjunction with 'grpc_client_config'.
+# query-frontend. This can't be used in conjunction with 'grpc_client_config'.
 # The CLI flags prefix for this block configuration is:
 # querier.frontend-grpc-client
 [query_frontend_grpc_client: <grpc_client>]
 
 # Configures the querier gRPC client used to communicate with the query-frontend
-# and with the query-scheduler. Can't be used in conjunction with
+# and with the query-scheduler. This can't be used in conjunction with
 # 'query_frontend_grpc_client' or 'query_scheduler_grpc_client'.
 # The CLI flags prefix for this block configuration is: querier.frontend-client
 [grpc_client_config: <grpc_client>]
 
 # Configures the querier gRPC client used to communicate with the
-# query-scheduler. Can't be used in conjunction with 'grpc_client_config'.
+# query-scheduler. This can't be used in conjunction with 'grpc_client_config'.
 # The CLI flags prefix for this block configuration is:
 # querier.scheduler-grpc-client
 [query_scheduler_grpc_client: <grpc_client>]

--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -2237,19 +2237,19 @@ The `frontend_worker` configures the worker - running within the Loki querier - 
 [id: <string> | default = ""]
 
 # Configures the querier gRPC client used to communicate with the
-# query-frontend. Shouldn't be used in conjunction with 'grpc_client_config'.
+# query-frontend. Can't be used in conjunction with 'grpc_client_config'.
 # The CLI flags prefix for this block configuration is:
 # querier.frontend-grpc-client
 [query_frontend_grpc_client: <grpc_client>]
 
 # Configures the querier gRPC client used to communicate with the query-frontend
-# and with the query-scheduler if 'query_scheduler_grpc_client' isn't defined.
-# This shouldn't be used if 'query_frontend_grpc_client' is defined.
+# and with the query-scheduler. Can't be used in conjunction with
+# 'query_frontend_grpc_client' or 'query_scheduler_grpc_client'.
 # The CLI flags prefix for this block configuration is: querier.frontend-client
 [grpc_client_config: <grpc_client>]
 
 # Configures the querier gRPC client used to communicate with the
-# query-scheduler. If not defined, 'grpc_client_config' is used instead.
+# query-scheduler. Can't be used in conjunction with 'grpc_client_config'.
 # The CLI flags prefix for this block configuration is:
 # querier.scheduler-grpc-client
 [query_scheduler_grpc_client: <grpc_client>]

--- a/pkg/loki/config_wrapper.go
+++ b/pkg/loki/config_wrapper.go
@@ -693,8 +693,13 @@ func applyCommonQuerierWorkerGRPCConfig(cfg, defaults *ConfigWrapper) error {
 	usingNewSchedulerCfg := !reflect.DeepEqual(cfg.Worker.QuerySchedulerGRPCClientConfig, defaults.Worker.QuerySchedulerGRPCClientConfig)
 	usingOldFrontendCfg := !reflect.DeepEqual(cfg.Worker.OldQueryFrontendGRPCClientConfig, defaults.Worker.OldQueryFrontendGRPCClientConfig)
 
-	if usingOldFrontendCfg && (usingNewFrontendCfg || usingNewSchedulerCfg) {
-		return fmt.Errorf("both `grpc_client_config` and (`query_frontend_grpc_client` or `query_scheduler_grpc_client`) are set at the same time. Please use only `query_frontend_grpc_client` and `query_scheduler_grpc_client`")
+	if usingOldFrontendCfg {
+		if usingNewFrontendCfg || usingNewSchedulerCfg {
+			return fmt.Errorf("both `grpc_client_config` and (`query_frontend_grpc_client` or `query_scheduler_grpc_client`) are set at the same time. Please use only `query_frontend_grpc_client` and `query_scheduler_grpc_client`")
+		}
+		cfg.Worker.NewQueryFrontendGRPCClientConfig = cfg.Worker.OldQueryFrontendGRPCClientConfig
+		cfg.Worker.QuerySchedulerGRPCClientConfig = cfg.Worker.OldQueryFrontendGRPCClientConfig
 	}
+
 	return nil
 }

--- a/pkg/querier/worker/worker.go
+++ b/pkg/querier/worker/worker.go
@@ -30,10 +30,10 @@ type Config struct {
 
 	QuerierID string `yaml:"id"`
 
-	NewQueryFrontendGRPCClientConfig grpcclient.Config `yaml:"query_frontend_grpc_client" doc:"description=Configures the querier gRPC client used to communicate with the query-frontend. Shouldn't be used in conjunction with 'grpc_client_config'."`
-	OldQueryFrontendGRPCClientConfig grpcclient.Config `yaml:"grpc_client_config" doc:"description=Configures the querier gRPC client used to communicate with the query-frontend and with the query-scheduler if 'query_scheduler_grpc_client' isn't defined. This shouldn't be used if 'query_frontend_grpc_client' is defined."`
+	NewQueryFrontendGRPCClientConfig grpcclient.Config `yaml:"query_frontend_grpc_client" doc:"description=Configures the querier gRPC client used to communicate with the query-frontend. Can't be used in conjunction with 'grpc_client_config'."`
+	OldQueryFrontendGRPCClientConfig grpcclient.Config `yaml:"grpc_client_config" doc:"description=Configures the querier gRPC client used to communicate with the query-frontend and with the query-scheduler. Can't be used in conjunction with 'query_frontend_grpc_client' or 'query_scheduler_grpc_client'."`
 
-	QuerySchedulerGRPCClientConfig grpcclient.Config `yaml:"query_scheduler_grpc_client" doc:"description=Configures the querier gRPC client used to communicate with the query-scheduler. If not defined, 'grpc_client_config' is used instead."`
+	QuerySchedulerGRPCClientConfig grpcclient.Config `yaml:"query_scheduler_grpc_client" doc:"description=Configures the querier gRPC client used to communicate with the query-scheduler. Can't be used in conjunction with 'grpc_client_config'."`
 }
 
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {

--- a/pkg/querier/worker/worker.go
+++ b/pkg/querier/worker/worker.go
@@ -30,10 +30,10 @@ type Config struct {
 
 	QuerierID string `yaml:"id"`
 
-	NewQueryFrontendGRPCClientConfig grpcclient.Config `yaml:"query_frontend_grpc_client" doc:"description=Configures the querier gRPC client used to communicate with the query-frontend. Can't be used in conjunction with 'grpc_client_config'."`
-	OldQueryFrontendGRPCClientConfig grpcclient.Config `yaml:"grpc_client_config" doc:"description=Configures the querier gRPC client used to communicate with the query-frontend and with the query-scheduler. Can't be used in conjunction with 'query_frontend_grpc_client' or 'query_scheduler_grpc_client'."`
+	NewQueryFrontendGRPCClientConfig grpcclient.Config `yaml:"query_frontend_grpc_client" doc:"description=Configures the querier gRPC client used to communicate with the query-frontend. This can't be used in conjunction with 'grpc_client_config'."`
+	OldQueryFrontendGRPCClientConfig grpcclient.Config `yaml:"grpc_client_config" doc:"description=Configures the querier gRPC client used to communicate with the query-frontend and with the query-scheduler. This can't be used in conjunction with 'query_frontend_grpc_client' or 'query_scheduler_grpc_client'."`
 
-	QuerySchedulerGRPCClientConfig grpcclient.Config `yaml:"query_scheduler_grpc_client" doc:"description=Configures the querier gRPC client used to communicate with the query-scheduler. Can't be used in conjunction with 'grpc_client_config'."`
+	QuerySchedulerGRPCClientConfig grpcclient.Config `yaml:"query_scheduler_grpc_client" doc:"description=Configures the querier gRPC client used to communicate with the query-scheduler. This can't be used in conjunction with 'grpc_client_config'."`
 }
 
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Make new and old ways of configuring querier workers grpc clients mutually exclusive. Otherwise we'll never migrate to the new configs.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
