### PR TITLE
fix: Optimize regular initialization

### DIFF
--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -60,7 +60,6 @@ var (
 	idRegexp = regexp.MustCompile(idPattern)
 )
 
-
 type interval struct {
 	start, end time.Time
 }

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -50,9 +50,16 @@ const (
 	// before checking if a new entry is available (to avoid spinning the CPU in a continuous
 	// check loop)
 	tailerWaitEntryThrottle = time.Second / 2
+
+	idPattern = `^(?:(?:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})|(?:(?:\{)?[0-9a-fA-F]{8}(?:-?[0-9a-fA-F]{4}){3}-?[0-9a-fA-F]{12}(?:\})?)|(\d+(?:\.\d+)?))$`
 )
 
-var nowFunc = func() time.Time { return time.Now() }
+var (
+	nowFunc = func() time.Time { return time.Now() }
+
+	idRegexp = regexp.MustCompile(idPattern)
+)
+
 
 type interval struct {
 	start, end time.Time
@@ -1046,12 +1053,8 @@ func (q *SingleTenantQuerier) isLabelRelevant(label string, values []string, sta
 
 // containsAllIDTypes filters out all UUID, GUID and numeric types. Returns false if even one value is not of the type
 func containsAllIDTypes(values []string) bool {
-	pattern := `^(?:(?:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})|(?:(?:\{)?[0-9a-fA-F]{8}(?:-?[0-9a-fA-F]{4}){3}-?[0-9a-fA-F]{12}(?:\})?)|(\d+(?:\.\d+)?))$`
-
-	re := regexp.MustCompile(pattern)
-
 	for _, v := range values {
-		if !re.MatchString(v) {
+		if !idRegexp.MatchString(v) {
 			return false
 		}
 	}

--- a/pkg/querier/querier_test.go
+++ b/pkg/querier/querier_test.go
@@ -1425,6 +1425,35 @@ func TestQuerier_isLabelRelevant(t *testing.T) {
 	}
 }
 
+func TestQuerier_containsAllIDTypes(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		values   []string
+		expected bool
+	}{
+		{
+			name:    "all uuidv4 values are valid",
+			values:   []string{"751e8ee6-b377-4b2e-b7b5-5508fbe980ef", "6b7e2663-8ecb-42e1-8bdc-0c5de70185b3", "2e1e67ff-be4f-47b8-aee1-5d67ff1ddabf", "c95b2d62-74ed-4ed7-a8a1-eb72fc67946e"},
+			expected: true,
+		},
+		{
+			name:    "one uuidv4 values are invalid",
+			values:   []string{"57808f62-f117-4a22-84a0-bc3282c7f1061", "5076e837-cd8d-4dd7-95ff-fecb087dccf6", "2e2a6554-1744-4399-b89a-88ae79c27096", "d3c31248-ec0c-4bc4-b11c-8fb1cfb42e62"},
+			expected: false,
+		},
+		{
+			name:    "all uuidv4 values are invalid",
+			values:   []string{"w", "x", "y", "z"},
+			expected: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, containsAllIDTypes(tc.values))
+		})
+
+	}
+}
+
 func TestQuerier_DetectedLabels(t *testing.T) {
 	manyValues := []string{}
 	now := time.Now()

--- a/pkg/querier/querier_test.go
+++ b/pkg/querier/querier_test.go
@@ -1432,17 +1432,17 @@ func TestQuerier_containsAllIDTypes(t *testing.T) {
 		expected bool
 	}{
 		{
-			name:    "all uuidv4 values are valid",
+			name:     "all uuidv4 values are valid",
 			values:   []string{"751e8ee6-b377-4b2e-b7b5-5508fbe980ef", "6b7e2663-8ecb-42e1-8bdc-0c5de70185b3", "2e1e67ff-be4f-47b8-aee1-5d67ff1ddabf", "c95b2d62-74ed-4ed7-a8a1-eb72fc67946e"},
 			expected: true,
 		},
 		{
-			name:    "one uuidv4 values are invalid",
-			values:   []string{"57808f62-f117-4a22-84a0-bc3282c7f1061", "5076e837-cd8d-4dd7-95ff-fecb087dccf6", "2e2a6554-1744-4399-b89a-88ae79c27096", "d3c31248-ec0c-4bc4-b11c-8fb1cfb42e62"},
+			name:     "one uuidv4 values are invalid",
+			values:   []string{"w", "5076e837-cd8d-4dd7-95ff-fecb087dccf6", "2e2a6554-1744-4399-b89a-88ae79c27096", "d3c31248-ec0c-4bc4-b11c-8fb1cfb42e62"},
 			expected: false,
 		},
 		{
-			name:    "all uuidv4 values are invalid",
+			name:     "all uuidv4 values are invalid",
 			values:   []string{"w", "x", "y", "z"},
 			expected: false,
 		},

--- a/pkg/ruler/base/notifier.go
+++ b/pkg/ruler/base/notifier.go
@@ -25,7 +25,11 @@ import (
 
 // TODO: Instead of using the same metrics for all notifiers,
 // should we have separate metrics for each discovery.NewManager?
-var sdMetrics map[string]discovery.DiscovererMetrics
+var (
+	sdMetrics map[string]discovery.DiscovererMetrics
+
+	srvDNSregexp = regexp.MustCompile(`^_.+._.+`)
+)
 
 func init() {
 	var err error
@@ -112,7 +116,6 @@ func buildNotifierConfig(amConfig *ruler_config.AlertManagerConfig, externalLabe
 	amURLs := strings.Split(amConfig.AlertmanagerURL, ",")
 	validURLs := make([]*url.URL, 0, len(amURLs))
 
-	srvDNSregexp := regexp.MustCompile(`^_.+._.+`)
 	for _, h := range amURLs {
 		url, err := url.Parse(h)
 		if err != nil {

--- a/pkg/storage/chunk/cache/resultscache/pipelinewrapper_keygen.go
+++ b/pkg/storage/chunk/cache/resultscache/pipelinewrapper_keygen.go
@@ -2,6 +2,7 @@ package resultscache
 
 import (
 	"context"
+
 	"github.com/grafana/loki/v3/pkg/util/httpreq"
 )
 

--- a/pkg/storage/chunk/cache/resultscache/pipelinewrapper_keygen_test.go
+++ b/pkg/storage/chunk/cache/resultscache/pipelinewrapper_keygen_test.go
@@ -2,9 +2,11 @@ package resultscache
 
 import (
 	"context"
-	"github.com/grafana/loki/v3/pkg/util/httpreq"
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/util/httpreq"
 )
 
 func TestPipelineWrapperKeygen(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:
every time function **buildNotifierConfig** and **containsAllIDTypes** execute, these regexp are initialized. which situation reduce the performance. 

**Which issue(s) this PR fixes**:
no issue

**Special notes for your reviewer**:

