### PR TITLE
feat: allow for tracking of the max label names seen per tenant

### DIFF
--- a/pkg/distributor/limits.go
+++ b/pkg/distributor/limits.go
@@ -16,6 +16,7 @@ type Limits interface {
 	MaxLabelNamesPerSeries(userID string) int
 	MaxLabelNameLength(userID string) int
 	MaxLabelValueLength(userID string) int
+	TrackMaxLabelNames(userID string) bool
 
 	CreationGracePeriod(userID string) time.Duration
 	RejectOldSamples(userID string) bool

--- a/pkg/distributor/validator.go
+++ b/pkg/distributor/validator.go
@@ -41,6 +41,7 @@ type validationContext struct {
 	maxLabelNamesPerSeries int
 	maxLabelNameLength     int
 	maxLabelValueLength    int
+	trackMaxLabelNames     bool
 
 	incrementDuplicateTimestamps bool
 	discoverServiceName          []string
@@ -62,6 +63,7 @@ func (v Validator) getValidationContextForTime(now time.Time, userID string) val
 		maxLineSize:                  v.MaxLineSize(userID),
 		maxLineSizeTruncate:          v.MaxLineSizeTruncate(userID),
 		maxLabelNamesPerSeries:       v.MaxLabelNamesPerSeries(userID),
+		trackMaxLabelNames:           v.TrackMaxLabelNames(userID),
 		maxLabelNameLength:           v.MaxLabelNameLength(userID),
 		maxLabelValueLength:          v.MaxLabelValueLength(userID),
 		incrementDuplicateTimestamps: v.IncrementDuplicateTimestamps(userID),

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -75,6 +75,7 @@ type Limits struct {
 	MaxLabelNameLength          int              `yaml:"max_label_name_length" json:"max_label_name_length"`
 	MaxLabelValueLength         int              `yaml:"max_label_value_length" json:"max_label_value_length"`
 	MaxLabelNamesPerSeries      int              `yaml:"max_label_names_per_series" json:"max_label_names_per_series"`
+	TrackMaxLabelNames          bool             `yaml:"track_max_label_names" json:"track_max_label_names"`
 	RejectOldSamples            bool             `yaml:"reject_old_samples" json:"reject_old_samples"`
 	RejectOldSamplesMaxAge      model.Duration   `yaml:"reject_old_samples_max_age" json:"reject_old_samples_max_age"`
 	CreationGracePeriod         model.Duration   `yaml:"creation_grace_period" json:"creation_grace_period"`
@@ -561,6 +562,11 @@ func (o *Overrides) MaxLabelValueLength(userID string) int {
 // MaxLabelNamesPerSeries returns maximum number of label/value pairs timeseries.
 func (o *Overrides) MaxLabelNamesPerSeries(userID string) int {
 	return o.getOverridesForUser(userID).MaxLabelNamesPerSeries
+}
+
+// TrackMaxLabelNames returns maximum number of label names seen when accepting push requests.
+func (o *Overrides) TrackMaxLabelNames(userID string) bool {
+	return o.getOverridesForUser(userID).TrackMaxLabelNames
 }
 
 // RejectOldSamples returns true when we should reject samples older than certain

--- a/pkg/validation/validate.go
+++ b/pkg/validation/validate.go
@@ -128,3 +128,13 @@ var LineLengthHist = promauto.NewHistogram(prometheus.HistogramOpts{
 	Help:      "The total number of bytes per line.",
 	Buckets:   prometheus.ExponentialBuckets(1, 8, 8), // 1B -> 16MB
 })
+
+// DiscardedSamples is a metric of the number of discarded samples, by reason.
+var MaxLabelNamesPerTenant = promauto.NewGaugeVec(
+	prometheus.GaugeOpts{
+		Namespace: constants.Loki,
+		Name:      "max_label_names",
+		Help:      "The maximum number of labels seen on all streams for a tenant.",
+	},
+	[]string{"tenant"},
+)


### PR DESCRIPTION
Here we're allowing for a metric to track the max label names seen per tenant on each distributor via the validation code path. This would be useful in cases when `max_label_names_per_series` has been set above the default, and we want to confirm whether any series will be discarded when the limit/override is removed or lowered.