### PR TITLE
fix(helm): fixed ingress paths mapping

### DIFF
--- a/docs/sources/setup/install/helm/reference.md
+++ b/docs/sources/setup/install/helm/reference.md
@@ -5086,29 +5086,37 @@ null
   "ingressClassName": "",
   "labels": {},
   "paths": {
-    "read": [
-      "/api/prom/tail",
-      "/loki/api/v1/tail",
-      "/loki/api",
-      "/api/prom/rules",
-      "/loki/api/v1/rules",
-      "/prometheus/api/v1/rules",
-      "/prometheus/api/v1/alerts"
-    ],
-    "singleBinary": [
+    "distributor": [
       "/api/prom/push",
       "/loki/api/v1/push",
+      "/otlp/v1/logs"
+    ],
+    "queryFrontend": [
+      "/api/prom/query",
+      "/api/prom/label",
+      "/api/prom/series",
       "/api/prom/tail",
+      "/loki/api/v1/query",
+      "/loki/api/v1/query_range",
       "/loki/api/v1/tail",
-      "/loki/api",
+      "/loki/api/v1/label",
+      "/loki/api/v1/labels",
+      "/loki/api/v1/series",
+      "/loki/api/v1/index/stats",
+      "/loki/api/v1/index/volume",
+      "/loki/api/v1/index/volume_range",
+      "/loki/api/v1/format_query",
+      "/loki/api/v1/detected_fields",
+      "/loki/api/v1/detected_labels",
+      "/loki/api/v1/patterns"
+    ],
+    "ruler": [
       "/api/prom/rules",
+      "/api/prom/api/v1/rules",
+      "/api/prom/api/v1/alerts",
       "/loki/api/v1/rules",
       "/prometheus/api/v1/rules",
       "/prometheus/api/v1/alerts"
-    ],
-    "write": [
-      "/api/prom/push",
-      "/loki/api/v1/push"
     ]
   },
   "tls": []
@@ -5123,6 +5131,62 @@ null
 			<td><pre lang="json">
 [
   "loki.example.com"
+]
+</pre>
+</td>
+		</tr>
+		<tr>
+			<td>ingress.paths.distributor</td>
+			<td>list</td>
+			<td>Paths that are exposed by Loki Distributor. If deployment mode is Distributed, the requests are forwarded to the service: `{{"loki.distributorFullname"}}`. If deployment mode is SimpleScalable, the requests are forwarded to write k8s service: `{{"loki.writeFullname"}}`. If deployment mode is SingleBinary, the requests are forwarded to the central/single k8s service: `{{"loki.singleBinaryFullname"}}`</td>
+			<td><pre lang="json">
+[
+  "/api/prom/push",
+  "/loki/api/v1/push",
+  "/otlp/v1/logs"
+]
+</pre>
+</td>
+		</tr>
+		<tr>
+			<td>ingress.paths.queryFrontend</td>
+			<td>list</td>
+			<td>Paths that are exposed by Loki Query Frontend. If deployment mode is Distributed, the requests are forwarded to the service: `{{"loki.queryFrontendFullname"}}`. If deployment mode is SimpleScalable, the requests are forwarded to write k8s service: `{{"loki.readFullname"}}`. If deployment mode is SingleBinary, the requests are forwarded to the central/single k8s service: `{{"loki.singleBinaryFullname"}}`</td>
+			<td><pre lang="json">
+[
+  "/api/prom/query",
+  "/api/prom/label",
+  "/api/prom/series",
+  "/api/prom/tail",
+  "/loki/api/v1/query",
+  "/loki/api/v1/query_range",
+  "/loki/api/v1/tail",
+  "/loki/api/v1/label",
+  "/loki/api/v1/labels",
+  "/loki/api/v1/series",
+  "/loki/api/v1/index/stats",
+  "/loki/api/v1/index/volume",
+  "/loki/api/v1/index/volume_range",
+  "/loki/api/v1/format_query",
+  "/loki/api/v1/detected_fields",
+  "/loki/api/v1/detected_labels",
+  "/loki/api/v1/patterns"
+]
+</pre>
+</td>
+		</tr>
+		<tr>
+			<td>ingress.paths.ruler</td>
+			<td>list</td>
+			<td>Paths that are exposed by Loki Ruler. If deployment mode is Distributed, the requests are forwarded to the service: `{{"loki.rulerFullname"}}`. If deployment mode is SimpleScalable, the requests are forwarded to k8s service: `{{"loki.backendFullname"}}`. If deployment mode is SimpleScalable but `read.legacyReadTarget` is `true`, the requests are forwarded to k8s service: `{{"loki.readFullname"}}`. If deployment mode is SingleBinary, the requests are forwarded to the central/single k8s service: `{{"loki.singleBinaryFullname"}}`</td>
+			<td><pre lang="json">
+[
+  "/api/prom/rules",
+  "/api/prom/api/v1/rules",
+  "/api/prom/api/v1/alerts",
+  "/loki/api/v1/rules",
+  "/prometheus/api/v1/rules",
+  "/prometheus/api/v1/alerts"
 ]
 </pre>
 </td>

--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -13,6 +13,10 @@ Entries should include a reference to the pull request that introduced the chang
 
 [//]: # (<AUTOMATED_UPDATES_LOCATOR> : do not remove this line. This locator is used by the CI pipeline to automatically create a changelog entry for each new Loki release. Add other chart versions and respective changelog entries bellow this line.)
 
+## 6.5.2
+
+- [BUGFIX] Fixed Ingress routing for all deployment modes.  
+
 ## 6.5.0
 
 - [CHANGE] Changed version of Grafana Enterprise Logs to v3.0.1

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -3,7 +3,7 @@ name: loki
 description: Helm chart for Grafana Loki and Grafana Enterprise Logs supporting both simple, scalable and distributed modes.
 type: application
 appVersion: 3.0.0
-version: 6.5.1
+version: 6.5.2
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -1,6 +1,6 @@
 # loki
 
-![Version: 6.5.1](https://img.shields.io/badge/Version-6.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.0.0](https://img.shields.io/badge/AppVersion-3.0.0-informational?style=flat-square)
+![Version: 6.5.2](https://img.shields.io/badge/Version-6.5.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.0.0](https://img.shields.io/badge/AppVersion-3.0.0-informational?style=flat-square)
 
 Helm chart for Grafana Loki and Grafana Enterprise Logs supporting both simple, scalable and distributed modes.
 

--- a/production/helm/loki/templates/_helpers.tpl
+++ b/production/helm/loki/templates/_helpers.tpl
@@ -624,11 +624,11 @@ Ingress service paths for distributed deployment
 */}}
 {{- define "loki.ingress.distributedServicePaths" -}}
 {{- $distributorServiceName := include "loki.distributorFullname" . }}
-{{- include "loki.ingress.servicePath" (dict "ctx" . "svcName" $distributorServiceName "paths" .Values.ingress.paths.distributor )}}
+{{- include "loki.ingress.servicePath" (dict "ctx" . "serviceName" $distributorServiceName "paths" .Values.ingress.paths.distributor )}}
 {{- $queryFrontendServiceName := include "loki.queryFrontendFullname" . }}
-{{- include "loki.ingress.servicePath" (dict "ctx" . "svcName" $queryFrontendServiceName "paths" .Values.ingress.paths.queryFrontend )}}
+{{- include "loki.ingress.servicePath" (dict "ctx" . "serviceName" $queryFrontendServiceName "paths" .Values.ingress.paths.queryFrontend )}}
 {{- $rulerServiceName := include "loki.rulerFullname" . }}
-{{- include "loki.ingress.servicePath" (dict "ctx" . "svcName" $rulerServiceName "paths" .Values.ingress.paths.ruler)}}
+{{- include "loki.ingress.servicePath" (dict "ctx" . "serviceName" $rulerServiceName "paths" .Values.ingress.paths.ruler)}}
 {{- end -}}
 
 {{/*

--- a/production/helm/loki/templates/_helpers.tpl
+++ b/production/helm/loki/templates/_helpers.tpl
@@ -693,20 +693,6 @@ Params:
 {{- end -}}
 
 {{/*
-Ingress service name helper function
-Params:
-  ctx = . context
-  svcName = service name without the "loki.fullname" part (ie. read, write)
-*/}}
-{{- define "loki.ingress.serviceName" -}}
-{{- if (eq .svcName "singleBinary") }}
-{{- printf "%s" (include "loki.singleBinaryFullname" .ctx) }}
-{{- else }}
-{{- printf "%s-%s" (include "loki.fullname" .ctx) .svcName }}
-{{- end -}}
-{{- end -}}
-
-{{/*
 Create the service endpoint including port for MinIO.
 */}}
 {{- define "loki.minio" -}}

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -1131,24 +1131,34 @@ ingress:
   labels: {}
   #    blackbox.monitoring.exclude: "true"
   paths:
-    write:
+    distributor:
       - /api/prom/push
       - /loki/api/v1/push
-    read:
+      - /otlp/v1/logs
+    queryFrontend:
+      - /api/prom/query
+      # this path covers labels and labelValues endpoints
+      - /api/prom/label
+      - /api/prom/series
       - /api/prom/tail
+      - /loki/api/v1/query
+      - /loki/api/v1/query_range
       - /loki/api/v1/tail
-      - /loki/api
+      # this path covers labels and labelValues endpoints
+      - /loki/api/v1/label
+      - /loki/api/v1/labels
+      - /loki/api/v1/series
+      - /loki/api/v1/index/stats
+      - /loki/api/v1/index/volume
+      - /loki/api/v1/index/volume_range
+      - /loki/api/v1/format_query
+      - /loki/api/v1/detected_fields
+      - /loki/api/v1/detected_labels
+      - /loki/api/v1/patterns
+    ruler:
       - /api/prom/rules
-      - /loki/api/v1/rules
-      - /prometheus/api/v1/rules
-      - /prometheus/api/v1/alerts
-    singleBinary:
-      - /api/prom/push
-      - /loki/api/v1/push
-      - /api/prom/tail
-      - /loki/api/v1/tail
-      - /loki/api
-      - /api/prom/rules
+      - /api/prom/api/v1/rules
+      - /api/prom/api/v1/alerts
       - /loki/api/v1/rules
       - /prometheus/api/v1/rules
       - /prometheus/api/v1/alerts

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -1131,10 +1131,18 @@ ingress:
   labels: {}
   #    blackbox.monitoring.exclude: "true"
   paths:
+    # -- Paths that are exposed by Loki Distributor.
+    # If deployment mode is Distributed, the requests are forwarded to the service: `{{"loki.distributorFullname"}}`.
+    # If deployment mode is SimpleScalable, the requests are forwarded to write k8s service: `{{"loki.writeFullname"}}`.
+    # If deployment mode is SingleBinary, the requests are forwarded to the central/single k8s service: `{{"loki.singleBinaryFullname"}}`
     distributor:
       - /api/prom/push
       - /loki/api/v1/push
       - /otlp/v1/logs
+    # -- Paths that are exposed by Loki Query Frontend.
+    # If deployment mode is Distributed, the requests are forwarded to the service: `{{"loki.queryFrontendFullname"}}`.
+    # If deployment mode is SimpleScalable, the requests are forwarded to write k8s service: `{{"loki.readFullname"}}`.
+    # If deployment mode is SingleBinary, the requests are forwarded to the central/single k8s service: `{{"loki.singleBinaryFullname"}}`
     queryFrontend:
       - /api/prom/query
       # this path covers labels and labelValues endpoints
@@ -1155,6 +1163,11 @@ ingress:
       - /loki/api/v1/detected_fields
       - /loki/api/v1/detected_labels
       - /loki/api/v1/patterns
+    # -- Paths that are exposed by Loki Ruler.
+    # If deployment mode is Distributed, the requests are forwarded to the service: `{{"loki.rulerFullname"}}`.
+    # If deployment mode is SimpleScalable, the requests are forwarded to k8s service: `{{"loki.backendFullname"}}`.
+    # If deployment mode is SimpleScalable but `read.legacyReadTarget` is `true`, the requests are forwarded to k8s service: `{{"loki.readFullname"}}`.
+    # If deployment mode is SingleBinary, the requests are forwarded to the central/single k8s service: `{{"loki.singleBinaryFullname"}}`
     ruler:
       - /api/prom/rules
       - /api/prom/api/v1/rules


### PR DESCRIPTION
**What this PR does / why we need it**:

fix(helm): added mapping between Loki components and deployment modes to properly configure pure ingress when it's used without gateway/ngingx

**Which issue(s) this PR fixes**:
Fixes #12582

**Special notes for your reviewer**:

Ingress manifest for different modes:

<details><summary>deploymentMode: SingleBinary</summary>
<p>

```yaml

# Source: loki/templates/ingress.yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: chart-name-loki
  namespace: gel
  labels:
    helm.sh/chart: loki-6.5.1
    app.kubernetes.io/name: loki
    app.kubernetes.io/instance: chart-name
    app.kubernetes.io/version: "3.0.0"
    app.kubernetes.io/managed-by: Helm
spec:
  rules:
    - host: "loki.example.com"
      http:
        paths:          
          - path: /api/prom/push
            pathType: Prefix
            backend:
              service:
                name: chart-name-loki
                port:
                  number: 3100
          - path: /loki/api/v1/push
            pathType: Prefix
            backend:
              service:
                name: chart-name-loki
                port:
                  number: 3100
          - path: /otlp/v1/logs
            pathType: Prefix
            backend:
              service:
                name: chart-name-loki
                port:
                  number: 3100
          - path: /api/prom/query
            pathType: Prefix
            backend:
              service:
                name: chart-name-loki
                port:
                  number: 3100
          - path: /api/prom/label
            pathType: Prefix
            backend:
              service:
                name: chart-name-loki
                port:
                  number: 3100
          - path: /api/prom/series
            pathType: Prefix
            backend:
              service:
                name: chart-name-loki
                port:
                  number: 3100
          - path: /api/prom/tail
            pathType: Prefix
            backend:
              service:
                name: chart-name-loki
                port:
                  number: 3100
          - path: /loki/api/v1/query
            pathType: Prefix
            backend:
              service:
                name: chart-name-loki
                port:
                  number: 3100
          - path: /loki/api/v1/query_range
            pathType: Prefix
            backend:
              service:
                name: chart-name-loki
                port:
                  number: 3100
          - path: /loki/api/v1/tail
            pathType: Prefix
            backend:
              service:
                name: chart-name-loki
                port:
                  number: 3100
          - path: /loki/api/v1/label
            pathType: Prefix
            backend:
              service:
                name: chart-name-loki
                port:
                  number: 3100
          - path: /loki/api/v1/labels
            pathType: Prefix
            backend:
              service:
                name: chart-name-loki
                port:
                  number: 3100
          - path: /loki/api/v1/series
            pathType: Prefix
            backend:
              service:
                name: chart-name-loki
                port:
                  number: 3100
          - path: /loki/api/v1/index/stats
            pathType: Prefix
            backend:
              service:
                name: chart-name-loki
                port:
                  number: 3100
          - path: /loki/api/v1/index/volume
            pathType: Prefix
            backend:
              service:
                name: chart-name-loki
                port:
                  number: 3100
          - path: /loki/api/v1/index/volume_range
            pathType: Prefix
            backend:
              service:
                name: chart-name-loki
                port:
                  number: 3100
          - path: /loki/api/v1/format_query
            pathType: Prefix
            backend:
              service:
                name: chart-name-loki
                port:
                  number: 3100
          - path: /loki/api/v1/detected_fields
            pathType: Prefix
            backend:
              service:
                name: chart-name-loki
                port:
                  number: 3100
          - path: /loki/api/v1/detected_labels
            pathType: Prefix
            backend:
              service:
                name: chart-name-loki
                port:
                  number: 3100
          - path: /loki/api/v1/patterns
            pathType: Prefix
            backend:
              service:
                name: chart-name-loki
                port:
                  number: 3100
          - path: /api/prom/rules
            pathType: Prefix
            backend:
              service:
                name: chart-name-loki
                port:
                  number: 3100
          - path: /api/prom/api/v1/rules
            pathType: Prefix
            backend:
              service:
                name: chart-name-loki
                port:
                  number: 3100
          - path: /api/prom/api/v1/alerts
            pathType: Prefix
            backend:
              service:
                name: chart-name-loki
                port:
                  number: 3100
          - path: /loki/api/v1/rules
            pathType: Prefix
            backend:
              service:
                name: chart-name-loki
                port:
                  number: 3100
          - path: /prometheus/api/v1/rules
            pathType: Prefix
            backend:
              service:
                name: chart-name-loki
                port:
                  number: 3100
          - path: /prometheus/api/v1/alerts
            pathType: Prefix
            backend:
              service:
                name: chart-name-loki
                port:
                  number: 3100

```


</p>
</details> 

<details><summary>deploymentMode: SimpleScalable</summary>
<p>

```yaml
---
# Source: loki/templates/ingress.yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: chart-name-loki
  namespace: gel
  labels:
    helm.sh/chart: loki-6.5.1
    app.kubernetes.io/name: loki
    app.kubernetes.io/instance: chart-name
    app.kubernetes.io/version: "3.0.0"
    app.kubernetes.io/managed-by: Helm
spec:
  rules:
    - host: "loki.example.com"
      http:
        paths:          
          - path: /api/prom/query
            pathType: Prefix
            backend:
              service:
                name: loki-read
                port:
                  number: 3100
          - path: /api/prom/label
            pathType: Prefix
            backend:
              service:
                name: loki-read
                port:
                  number: 3100
          - path: /api/prom/series
            pathType: Prefix
            backend:
              service:
                name: loki-read
                port:
                  number: 3100
          - path: /api/prom/tail
            pathType: Prefix
            backend:
              service:
                name: loki-read
                port:
                  number: 3100
          - path: /loki/api/v1/query
            pathType: Prefix
            backend:
              service:
                name: loki-read
                port:
                  number: 3100
          - path: /loki/api/v1/query_range
            pathType: Prefix
            backend:
              service:
                name: loki-read
                port:
                  number: 3100
          - path: /loki/api/v1/tail
            pathType: Prefix
            backend:
              service:
                name: loki-read
                port:
                  number: 3100
          - path: /loki/api/v1/label
            pathType: Prefix
            backend:
              service:
                name: loki-read
                port:
                  number: 3100
          - path: /loki/api/v1/labels
            pathType: Prefix
            backend:
              service:
                name: loki-read
                port:
                  number: 3100
          - path: /loki/api/v1/series
            pathType: Prefix
            backend:
              service:
                name: loki-read
                port:
                  number: 3100
          - path: /loki/api/v1/index/stats
            pathType: Prefix
            backend:
              service:
                name: loki-read
                port:
                  number: 3100
          - path: /loki/api/v1/index/volume
            pathType: Prefix
            backend:
              service:
                name: loki-read
                port:
                  number: 3100
          - path: /loki/api/v1/index/volume_range
            pathType: Prefix
            backend:
              service:
                name: loki-read
                port:
                  number: 3100
          - path: /loki/api/v1/format_query
            pathType: Prefix
            backend:
              service:
                name: loki-read
                port:
                  number: 3100
          - path: /loki/api/v1/detected_fields
            pathType: Prefix
            backend:
              service:
                name: loki-read
                port:
                  number: 3100
          - path: /loki/api/v1/detected_labels
            pathType: Prefix
            backend:
              service:
                name: loki-read
                port:
                  number: 3100
          - path: /loki/api/v1/patterns
            pathType: Prefix
            backend:
              service:
                name: loki-read
                port:
                  number: 3100
          - path: /api/prom/push
            pathType: Prefix
            backend:
              service:
                name: loki-write
                port:
                  number: 3100
          - path: /loki/api/v1/push
            pathType: Prefix
            backend:
              service:
                name: loki-write
                port:
                  number: 3100
          - path: /otlp/v1/logs
            pathType: Prefix
            backend:
              service:
                name: loki-write
                port:
                  number: 3100
          - path: /api/prom/rules
            pathType: Prefix
            backend:
              service:
                name: loki-backend
                port:
                  number: 3100
          - path: /api/prom/api/v1/rules
            pathType: Prefix
            backend:
              service:
                name: loki-backend
                port:
                  number: 3100
          - path: /api/prom/api/v1/alerts
            pathType: Prefix
            backend:
              service:
                name: loki-backend
                port:
                  number: 3100
          - path: /loki/api/v1/rules
            pathType: Prefix
            backend:
              service:
                name: loki-backend
                port:
                  number: 3100
          - path: /prometheus/api/v1/rules
            pathType: Prefix
            backend:
              service:
                name: loki-backend
                port:
                  number: 3100
          - path: /prometheus/api/v1/alerts
            pathType: Prefix
            backend:
              service:
                name: loki-backend
                port:
                  number: 3100

```

</p>
</details> 


<details><summary>deploymentMode: Distributed</summary>
<p>

```yaml
---
# Source: loki/templates/ingress.yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: chart-name-loki
  namespace: gel
  labels:
    helm.sh/chart: loki-6.5.2
    app.kubernetes.io/name: loki
    app.kubernetes.io/instance: chart-name
    app.kubernetes.io/version: "3.0.0"
    app.kubernetes.io/managed-by: Helm
spec:
  rules:
    - host: "loki.example.com"
      http:
        paths:          
          - path: /api/prom/push
            pathType: Prefix
            backend:
              service:
                name: chart-name-loki-distributor
                port:
                  number: 3100
          - path: /loki/api/v1/push
            pathType: Prefix
            backend:
              service:
                name: chart-name-loki-distributor
                port:
                  number: 3100
          - path: /otlp/v1/logs
            pathType: Prefix
            backend:
              service:
                name: chart-name-loki-distributor
                port:
                  number: 3100
          - path: /api/prom/query
            pathType: Prefix
            backend:
              service:
                name: chart-name-loki-query-frontend
                port:
                  number: 3100
          - path: /api/prom/label
            pathType: Prefix
            backend:
              service:
                name: chart-name-loki-query-frontend
                port:
                  number: 3100
          - path: /api/prom/series
            pathType: Prefix
            backend:
              service:
                name: chart-name-loki-query-frontend
                port:
                  number: 3100
          - path: /api/prom/tail
            pathType: Prefix
            backend:
              service:
                name: chart-name-loki-query-frontend
                port:
                  number: 3100
          - path: /loki/api/v1/query
            pathType: Prefix
            backend:
              service:
                name: chart-name-loki-query-frontend
                port:
                  number: 3100
          - path: /loki/api/v1/query_range
            pathType: Prefix
            backend:
              service:
                name: chart-name-loki-query-frontend
                port:
                  number: 3100
          - path: /loki/api/v1/tail
            pathType: Prefix
            backend:
              service:
                name: chart-name-loki-query-frontend
                port:
                  number: 3100
          - path: /loki/api/v1/label
            pathType: Prefix
            backend:
              service:
                name: chart-name-loki-query-frontend
                port:
                  number: 3100
          - path: /loki/api/v1/labels
            pathType: Prefix
            backend:
              service:
                name: chart-name-loki-query-frontend
                port:
                  number: 3100
          - path: /loki/api/v1/series
            pathType: Prefix
            backend:
              service:
                name: chart-name-loki-query-frontend
                port:
                  number: 3100
          - path: /loki/api/v1/index/stats
            pathType: Prefix
            backend:
              service:
                name: chart-name-loki-query-frontend
                port:
                  number: 3100
          - path: /loki/api/v1/index/volume
            pathType: Prefix
            backend:
              service:
                name: chart-name-loki-query-frontend
                port:
                  number: 3100
          - path: /loki/api/v1/index/volume_range
            pathType: Prefix
            backend:
              service:
                name: chart-name-loki-query-frontend
                port:
                  number: 3100
          - path: /loki/api/v1/format_query
            pathType: Prefix
            backend:
              service:
                name: chart-name-loki-query-frontend
                port:
                  number: 3100
          - path: /loki/api/v1/detected_fields
            pathType: Prefix
            backend:
              service:
                name: chart-name-loki-query-frontend
                port:
                  number: 3100
          - path: /loki/api/v1/detected_labels
            pathType: Prefix
            backend:
              service:
                name: chart-name-loki-query-frontend
                port:
                  number: 3100
          - path: /loki/api/v1/patterns
            pathType: Prefix
            backend:
              service:
                name: chart-name-loki-query-frontend
                port:
                  number: 3100
          - path: /api/prom/rules
            pathType: Prefix
            backend:
              service:
                name: chart-name-loki-ruler
                port:
                  number: 3100
          - path: /api/prom/api/v1/rules
            pathType: Prefix
            backend:
              service:
                name: chart-name-loki-ruler
                port:
                  number: 3100
          - path: /api/prom/api/v1/alerts
            pathType: Prefix
            backend:
              service:
                name: chart-name-loki-ruler
                port:
                  number: 3100
          - path: /loki/api/v1/rules
            pathType: Prefix
            backend:
              service:
                name: chart-name-loki-ruler
                port:
                  number: 3100
          - path: /prometheus/api/v1/rules
            pathType: Prefix
            backend:
              service:
                name: chart-name-loki-ruler
                port:
                  number: 3100
          - path: /prometheus/api/v1/alerts
            pathType: Prefix
            backend:
              service:
                name: chart-name-loki-ruler
                port:
                  number: 3100


```

</p>
</details> 


<details><summary>deploymentMode: SimpleScalable && read.legacyReadTarget: true</summary>
<p>

```yaml
---
# Source: loki/templates/ingress.yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: chart-name-loki
  namespace: gel
  labels:
    helm.sh/chart: loki-6.5.1
    app.kubernetes.io/name: loki
    app.kubernetes.io/instance: chart-name
    app.kubernetes.io/version: "3.0.0"
    app.kubernetes.io/managed-by: Helm
spec:
  rules:
    - host: "loki.example.com"
      http:
        paths:          
          - path: /api/prom/query
            pathType: Prefix
            backend:
              service:
                name: loki-read
                port:
                  number: 3100
          - path: /api/prom/label
            pathType: Prefix
            backend:
              service:
                name: loki-read
                port:
                  number: 3100
          - path: /api/prom/series
            pathType: Prefix
            backend:
              service:
                name: loki-read
                port:
                  number: 3100
          - path: /api/prom/tail
            pathType: Prefix
            backend:
              service:
                name: loki-read
                port:
                  number: 3100
          - path: /loki/api/v1/query
            pathType: Prefix
            backend:
              service:
                name: loki-read
                port:
                  number: 3100
          - path: /loki/api/v1/query_range
            pathType: Prefix
            backend:
              service:
                name: loki-read
                port:
                  number: 3100
          - path: /loki/api/v1/tail
            pathType: Prefix
            backend:
              service:
                name: loki-read
                port:
                  number: 3100
          - path: /loki/api/v1/label
            pathType: Prefix
            backend:
              service:
                name: loki-read
                port:
                  number: 3100
          - path: /loki/api/v1/labels
            pathType: Prefix
            backend:
              service:
                name: loki-read
                port:
                  number: 3100
          - path: /loki/api/v1/series
            pathType: Prefix
            backend:
              service:
                name: loki-read
                port:
                  number: 3100
          - path: /loki/api/v1/index/stats
            pathType: Prefix
            backend:
              service:
                name: loki-read
                port:
                  number: 3100
          - path: /loki/api/v1/index/volume
            pathType: Prefix
            backend:
              service:
                name: loki-read
                port:
                  number: 3100
          - path: /loki/api/v1/index/volume_range
            pathType: Prefix
            backend:
              service:
                name: loki-read
                port:
                  number: 3100
          - path: /loki/api/v1/format_query
            pathType: Prefix
            backend:
              service:
                name: loki-read
                port:
                  number: 3100
          - path: /loki/api/v1/detected_fields
            pathType: Prefix
            backend:
              service:
                name: loki-read
                port:
                  number: 3100
          - path: /loki/api/v1/detected_labels
            pathType: Prefix
            backend:
              service:
                name: loki-read
                port:
                  number: 3100
          - path: /loki/api/v1/patterns
            pathType: Prefix
            backend:
              service:
                name: loki-read
                port:
                  number: 3100
          - path: /api/prom/rules
            pathType: Prefix
            backend:
              service:
                name: loki-read
                port:
                  number: 3100
          - path: /api/prom/api/v1/rules
            pathType: Prefix
            backend:
              service:
                name: loki-read
                port:
                  number: 3100
          - path: /api/prom/api/v1/alerts
            pathType: Prefix
            backend:
              service:
                name: loki-read
                port:
                  number: 3100
          - path: /loki/api/v1/rules
            pathType: Prefix
            backend:
              service:
                name: loki-read
                port:
                  number: 3100
          - path: /prometheus/api/v1/rules
            pathType: Prefix
            backend:
              service:
                name: loki-read
                port:
                  number: 3100
          - path: /prometheus/api/v1/alerts
            pathType: Prefix
            backend:
              service:
                name: loki-read
                port:
                  number: 3100
          - path: /api/prom/push
            pathType: Prefix
            backend:
              service:
                name: loki-write
                port:
                  number: 3100
          - path: /loki/api/v1/push
            pathType: Prefix
            backend:
              service:
                name: loki-write
                port:
                  number: 3100
          - path: /otlp/v1/logs
            pathType: Prefix
            backend:
              service:
                name: loki-write
                port:
                  number: 3100

```

</p>
</details> 

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
