### PR TITLE
chore(logging): Add entry's timestamp when rejected with `too far behind`

### DIFF
--- a/pkg/chunkenc/interface.go
+++ b/pkg/chunkenc/interface.go
@@ -24,6 +24,10 @@ var (
 )
 
 type errTooFarBehind struct {
+	// original timestmap of the entry itself.
+	entryTs time.Time
+
+	// cutoff is the oldest acceptable timstamp of the `stream` that entry belongs to.
 	cutoff time.Time
 }
 
@@ -32,12 +36,12 @@ func IsErrTooFarBehind(err error) bool {
 	return ok
 }
 
-func ErrTooFarBehind(cutoff time.Time) error {
-	return &errTooFarBehind{cutoff: cutoff}
+func ErrTooFarBehind(entryTs, cutoff time.Time) error {
+	return &errTooFarBehind{entryTs: entryTs, cutoff: cutoff}
 }
 
 func (m *errTooFarBehind) Error() string {
-	return "entry too far behind, oldest acceptable timestamp is: " + m.cutoff.Format(time.RFC3339)
+	return fmt.Sprintf("entry too far behind, entry timestamp is: %s, oldest acceptable timestamp is: %s", m.entryTs.Format(time.RFC3339), m.cutoff.Format(time.RFC3339))
 }
 
 func IsOutOfOrderErr(err error) bool {

--- a/pkg/chunkenc/interface_test.go
+++ b/pkg/chunkenc/interface_test.go
@@ -31,7 +31,9 @@ func TestParseEncoding(t *testing.T) {
 }
 
 func TestIsOutOfOrderErr(t *testing.T) {
-	for _, err := range []error{ErrOutOfOrder, ErrTooFarBehind(time.Now())} {
+	now := time.Now()
+
+	for _, err := range []error{ErrOutOfOrder, ErrTooFarBehind(now, now)} {
 		require.Equal(t, true, IsOutOfOrderErr(err))
 	}
 }

--- a/pkg/ingester/stream.go
+++ b/pkg/ingester/stream.go
@@ -394,7 +394,7 @@ func (s *stream) validateEntries(entries []logproto.Entry, isReplay, rateLimitWh
 		// The validity window for unordered writes is the highest timestamp present minus 1/2 * max-chunk-age.
 		cutoff := highestTs.Add(-s.cfg.MaxChunkAge / 2)
 		if !isReplay && s.unorderedWrites && !highestTs.IsZero() && cutoff.After(entries[i].Timestamp) {
-			failedEntriesWithError = append(failedEntriesWithError, entryWithError{&entries[i], chunkenc.ErrTooFarBehind(cutoff)})
+			failedEntriesWithError = append(failedEntriesWithError, entryWithError{&entries[i], chunkenc.ErrTooFarBehind(entries[i].Timestamp, cutoff)})
 			s.writeFailures.Log(s.tenant, fmt.Errorf("%w for stream %s", failedEntriesWithError[len(failedEntriesWithError)-1].e, s.labels))
 			outOfOrderSamples++
 			outOfOrderBytes += lineBytes

--- a/pkg/ingester/stream_test.go
+++ b/pkg/ingester/stream_test.go
@@ -84,8 +84,9 @@ func TestMaxReturnedStreamsErrors(t *testing.T) {
 			var expected bytes.Buffer
 			for i := 0; i < tc.expectErrs; i++ {
 				fmt.Fprintf(&expected,
-					"entry with timestamp %s ignored, reason: 'entry too far behind, oldest acceptable timestamp is: %s',\n",
+					"entry with timestamp %s ignored, reason: 'entry too far behind, entry timestamp is: %s, oldest acceptable timestamp is: %s',\n",
 					time.Unix(int64(i), 0).String(),
+					newLines[i].Timestamp.Format(time.RFC3339),
 					time.Unix(int64(numLogs), 0).Format(time.RFC3339),
 				)
 			}


### PR DESCRIPTION
Ingester uses `max_sample_age/2` to reject out-of-order ingestion in Loki. More details about how it works are [here ](https://grafana.com/blog/2021/12/03/new-feature-in-loki-2.4-no-more-ordering-constraint/?pg=blog&plcmt=body-txt)and [here](https://grafana.com/blog/2024/01/04/the-concise-guide-to-loki-how-to-work-with-out-of-order-and-older-logs/).

But when it is rejected, currently we print log line like this on ingester.

```
entry too far behind, oldest acceptable timestamp is: 2024-05-07T10:25:30Z
```

Problem is it doesn't print the original timestamp of the log entry itself. So hard to interpret sometime.

This PR fixes it. Now it looks something like this.

```
entry too far behind, entry timestamp is: 2024-05-05T10:25:30Z, oldest acceptable timestamp is: 2024-05-07T10:25:30Z
```

Also, another thing, now it is consistent with how Loki return the error to the client when it rejects it.

```
entry with timestamp 2024-05-06 15:58:50 +0000 UTC ignored, reason: 'entry too far behind, oldest acceptable timestamp is: 2024-05-07T10:25:30Z',
```

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
