### PR TITLE
fix: Defer closing blocks iter after checking error from loadWorkForGap

### DIFF
--- a/pkg/bloomcompactor/controller.go
+++ b/pkg/bloomcompactor/controller.go
@@ -384,6 +384,10 @@ func (s *SimpleBloomController) buildGaps(
 			// to try and accelerate bloom creation
 			level.Debug(logger).Log("msg", "loading series and blocks for gap", "blocks", len(gap.blocks))
 			seriesItr, blocksIter, err := s.loadWorkForGap(ctx, table, tenant, plan.tsdb, gap)
+			if err != nil {
+				level.Error(logger).Log("msg", "failed to get series and blocks", "err", err)
+				return nil, errors.Wrap(err, "failed to get series and blocks")
+			}
 
 			// TODO(owen-d): more elegant error handling than sync.OnceFunc
 			closeBlocksIter := sync.OnceFunc(func() {
@@ -392,11 +396,6 @@ func (s *SimpleBloomController) buildGaps(
 				}
 			})
 			defer closeBlocksIter()
-
-			if err != nil {
-				level.Error(logger).Log("msg", "failed to get series and blocks", "err", err)
-				return nil, errors.Wrap(err, "failed to get series and blocks")
-			}
 
 			// Blocks are built consuming the series iterator. For observability, we wrap the series iterator
 			// with a counter iterator to count the number of times Next() is called on it.


### PR DESCRIPTION
**What this PR does / why we need it**:

Compactors may panic if `SimpleBloomController.loadWorkForGap` returns an error due to setting the defer function that closes the block iterators (`blocksIter`) which is nil before checking and returning on error.

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
