### PR TITLE
feat: Store structured metadata with patterns

### DIFF
--- a/pkg/pattern/drain/chunk_test.go
+++ b/pkg/pattern/drain/chunk_test.go
@@ -5,30 +5,33 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/loki/pkg/push"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/loki/v3/pkg/logproto"
 )
 
+var metadata = push.LabelsAdapter{}
+
 func TestAdd(t *testing.T) {
 	cks := Chunks{}
-	cks.Add(TimeResolution + 1)
-	cks.Add(TimeResolution + 2)
-	cks.Add(2*TimeResolution + 1)
+	cks.Add(TimeResolution+1, metadata)
+	cks.Add(TimeResolution+2, metadata)
+	cks.Add(2*TimeResolution+1, metadata)
 	require.Equal(t, 1, len(cks))
 	require.Equal(t, 2, len(cks[0].Samples))
-	cks.Add(model.TimeFromUnixNano(time.Hour.Nanoseconds()) + TimeResolution + 1)
+	cks.Add(model.TimeFromUnixNano(time.Hour.Nanoseconds())+TimeResolution+1, metadata)
 	require.Equal(t, 2, len(cks))
 	require.Equal(t, 1, len(cks[1].Samples))
 }
 
 func TestIterator(t *testing.T) {
 	cks := Chunks{}
-	cks.Add(TimeResolution + 1)
-	cks.Add(TimeResolution + 2)
-	cks.Add(2*TimeResolution + 1)
-	cks.Add(model.TimeFromUnixNano(time.Hour.Nanoseconds()) + TimeResolution + 1)
+	cks.Add(TimeResolution+1, metadata)
+	cks.Add(TimeResolution+2, metadata)
+	cks.Add(2*TimeResolution+1, metadata)
+	cks.Add(model.TimeFromUnixNano(time.Hour.Nanoseconds())+TimeResolution+1, metadata)
 
 	it := cks.Iterator("test", model.Time(0), model.Time(time.Hour.Nanoseconds()), TimeResolution)
 	require.NotNil(t, it)

--- a/pkg/pattern/drain/drain_test.go
+++ b/pkg/pattern/drain/drain_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/grafana/loki/pkg/push"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/loki/v3/pkg/logql/log/pattern"
@@ -106,7 +107,7 @@ func TestDrain_TrainExtractsPatterns(t *testing.T) {
 			scanner := bufio.NewScanner(file)
 			for scanner.Scan() {
 				line := scanner.Text()
-				tt.drain.Train(line, 0)
+				tt.drain.Train(line, 0, push.LabelsAdapter{})
 			}
 
 			var output []string
@@ -152,7 +153,7 @@ func TestDrain_TrainGeneratesMatchablePatterns(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			for _, line := range tt.inputLines {
-				tt.drain.Train(line, 0)
+				tt.drain.Train(line, 0, push.LabelsAdapter{})
 			}
 			t.Log("Learned clusters", tt.drain.Clusters())
 
@@ -217,7 +218,7 @@ func TestDrain_TrainGeneratesPatternsMatchableByLokiPatternFilter(t *testing.T) 
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			for _, line := range tt.inputLines {
-				tt.drain.Train(line, 0)
+				tt.drain.Train(line, 0, push.LabelsAdapter{})
 			}
 			require.Equal(t, 1, len(tt.drain.Clusters()))
 			cluster := tt.drain.Clusters()[0]

--- a/pkg/pattern/drain/log_cluster.go
+++ b/pkg/pattern/drain/log_cluster.go
@@ -4,9 +4,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/grafana/loki/pkg/push"
 	"github.com/prometheus/common/model"
 
 	"github.com/grafana/loki/v3/pkg/logproto"
+	"github.com/grafana/loki/v3/pkg/logql/log"
 	"github.com/grafana/loki/v3/pkg/pattern/iter"
 )
 
@@ -25,9 +27,9 @@ func (c *LogCluster) String() string {
 	return strings.Join(c.Tokens, " ")
 }
 
-func (c *LogCluster) append(ts model.Time) {
+func (c *LogCluster) append(ts model.Time, metadata push.LabelsAdapter) {
 	c.Size++
-	c.Chunks.Add(ts)
+	c.Chunks.Add(ts, metadata)
 }
 
 func (c *LogCluster) merge(samples []*logproto.PatternSample) {
@@ -35,8 +37,8 @@ func (c *LogCluster) merge(samples []*logproto.PatternSample) {
 	c.Chunks.merge(samples)
 }
 
-func (c *LogCluster) Iterator(from, through, step model.Time) iter.Iterator {
-	return c.Chunks.Iterator(c.String(), from, through, step)
+func (c *LogCluster) Iterator(from, through, step model.Time, labelFilters log.StreamPipeline) iter.Iterator {
+	return c.Chunks.Iterator(c.String(), from, through, step, labelFilters)
 }
 
 func (c *LogCluster) Samples() []*logproto.PatternSample {


### PR DESCRIPTION
**What this PR does / why we need it**:
- Adds structured metadata from the incoming log stream to the Pattern chunks. 
- Enables the the use of label filters in the Pattern API Query string so filters like `| detected_level="debug"` can be applied to patterns returned by the API.
- No other LogQL queries are supported.

I'm definitely not confident this is the right way to implement this feature, hence leaving this PR in draft mode until I get some early feedback.
It also needs some more tests so I'll follow up with some more commits over the next few days before making undrafting this PR.
