### PR TITLE
fix: Fix for how the loop sync is done

### DIFF
--- a/pkg/storage/stores/shipper/indexshipper/downloads/table_manager.go
+++ b/pkg/storage/stores/shipper/indexshipper/downloads/table_manager.go
@@ -111,14 +111,13 @@ func NewTableManager(cfg Config, openIndexFileFunc index.OpenIndexFileFunc, inde
 		return nil, err
 	}
 
+	// Increment the WaitGroup counter here before starting the goroutine
+	tm.wg.Add(1)
 	go tm.loop()
 	return tm, nil
 }
 
 func (tm *tableManager) loop() {
-	tm.tablesMtx.Lock()
-	tm.wg.Add(1)
-	tm.tablesMtx.Unlock()
 	defer tm.wg.Done()
 
 	syncTicker := time.NewTicker(tm.cfg.SyncInterval)


### PR DESCRIPTION
**What this PR does / why we need it**:
Before fix:
```
go test -race -count=10 . -timeout 30s
==================
WARNING: DATA RACE
Write at 0x00c000213030 by goroutine 493:
  runtime.racewrite()
      <autogenerated>:1 +0x10
  github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/downloads.(*tableManager).Stop()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/storage/stores/shipper/indexshipper/downloads/table_manager.go:156 +0x50
  github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/downloads.buildTestTableManager.func2()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/storage/stores/shipper/indexshipper/downloads/table_manager_test.go:68 +0x3c
  runtime.deferreturn()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/runtime/panic.go:602 +0x5c
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40

Previous read at 0x00c000213030 by goroutine 494:
  runtime.raceread()
      <autogenerated>:1 +0x10
  github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/downloads.(*tableManager).loop()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/storage/stores/shipper/indexshipper/downloads/table_manager.go:120 +0x50
  github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/downloads.NewTableManager.gowrap1()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/storage/stores/shipper/indexshipper/downloads/table_manager.go:114 +0x34

Goroutine 493 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x5e4
  testing.runTests.func1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:2161 +0x80
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.runTests()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:2159 +0x6e0
  testing.(*M).Run()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:2027 +0xb74
  main.main()
      _testmain.go:69 +0x294

Goroutine 494 (finished) created at:
  github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/downloads.NewTableManager()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/storage/stores/shipper/indexshipper/downloads/table_manager.go:114 +0x400
  github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/downloads.buildTestTableManager()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/storage/stores/shipper/indexshipper/downloads/table_manager_test.go:62 +0x2fc
  github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/downloads.TestTableManager_cleanupCache()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/storage/stores/shipper/indexshipper/downloads/table_manager_test.go:103 +0x44
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x40
==================
--- FAIL: TestTableManager_cleanupCache (0.00s)
    testing.go:1398: race detected during execution of test
FAIL
FAIL	github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/downloads	21.587s
FAIL

```
After fix:
```
 go test -race -count=10 . -timeout 30s
ok  	github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/downloads	22.217s
progers@Pauls-MacBook-Pro downloads % 
```
**Which issue(s) this PR fixes**:
Relates to https://github.com/grafana/loki/issues/8586

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
