### PR TITLE
Experiment: Modify Drain algorithm for better patterns

### DIFF
--- a/pkg/pattern/drain/drain.go
+++ b/pkg/pattern/drain/drain.go
@@ -130,7 +130,7 @@ func DefaultConfig() *Config {
 		//  > message are more likely to be constants. Specifically, Drain
 		//  > selects the next internal node by the tokens in the beginning
 		//  > positions of the log message
-		LogClusterDepth: 100,
+		LogClusterDepth: 10,
 		// SimTh is basically a ratio of matching/total in the cluster.
 		// Cluster tokens: "foo <*> bar fred"
 		//       Log line: "foo bar baz qux"
@@ -139,7 +139,7 @@ func DefaultConfig() *Config {
 		// Both SimTh and MaxClusterDepth impact branching factor: the greater
 		// MaxClusterDepth and SimTh, the less the chance that there will be
 		// "similar" clusters, but the greater the footprint.
-		SimTh:       0.6,
+		SimTh:       0.5,
 		MaxChildren: 100,
 		ParamString: `<_>`,
 		MaxClusters: 300,
@@ -234,7 +234,7 @@ func RemoveNamedVariablesAndConcat(in []string) string {
 			in[i] = "<_>"
 		}
 	}
-	return strings.Join(in, " ")
+	return strings.Join(in, "")
 }
 
 func tokenizePattern(content, param string) []string {

--- a/pkg/pattern/drain/drain.go
+++ b/pkg/pattern/drain/drain.go
@@ -228,6 +228,15 @@ func (d *Drain) TrainPattern(content string, samples []*logproto.PatternSample) 
 	return matchCluster
 }
 
+func RemoveNamedVariablesAndConcat(in []string) string {
+	for i, x := range in {
+		if strings.HasPrefix(x, "<") && strings.HasSuffix(x, ">") {
+			in[i] = "<_>"
+		}
+	}
+	return strings.Join(in, " ")
+}
+
 func tokenizePattern(content, param string) []string {
 	return deduplicatePlaceholders(strings.Split(content, " "), param)
 }

--- a/pkg/pattern/drain/drain.go
+++ b/pkg/pattern/drain/drain.go
@@ -226,22 +226,17 @@ func (d *Drain) train(tokens []string, stringer func([]string) string, ts int64)
 	return matchCluster
 }
 
-func (d *Drain) prune() {
-	// Traverse the tree (the whole tree?!) and combine any branches that have similar clusters
-	// i.e. a branch with <HEX> and <NUM> or <NUM>ac<<NUM> should be aggregated to <HEX> as the most accurate.
-	// This may mean some branches are not reachable? Will see if this is a big deal
-
+func (d *Drain) String() string {
+	return d.tree("", d.rootNode, 0)
 }
 
-func (d *Drain) String() {
-	d.print("", d.rootNode, 0)
-}
-
-func (d *Drain) print(key string, root *Node, depth int) {
-	fmt.Printf("%s%s [%d]\n", strings.Repeat("-", depth), key, len(root.clusterIDs))
+func (d *Drain) tree(key string, root *Node, depth int) string {
+	builder := strings.Builder{}
+	builder.WriteString(fmt.Sprintf("%s%s [%d clusters]\n", strings.Repeat("-", depth), key, len(root.clusterIDs)))
 	for _, child := range maps.Keys(root.keyToChildNode) {
-		d.print(child, root.keyToChildNode[child], depth+1)
+		builder.WriteString(d.tree(child, root.keyToChildNode[child], depth+1))
 	}
+	return builder.String()
 }
 
 func (d *Drain) TrainPattern(content string, samples []*logproto.PatternSample) *LogCluster {

--- a/pkg/pattern/drain/drain.go
+++ b/pkg/pattern/drain/drain.go
@@ -130,7 +130,7 @@ func DefaultConfig() *Config {
 		//  > message are more likely to be constants. Specifically, Drain
 		//  > selects the next internal node by the tokens in the beginning
 		//  > positions of the log message
-		LogClusterDepth: 8,
+		LogClusterDepth: 100,
 		// SimTh is basically a ratio of matching/total in the cluster.
 		// Cluster tokens: "foo <*> bar fred"
 		//       Log line: "foo bar baz qux"
@@ -139,7 +139,7 @@ func DefaultConfig() *Config {
 		// Both SimTh and MaxClusterDepth impact branching factor: the greater
 		// MaxClusterDepth and SimTh, the less the chance that there will be
 		// "similar" clusters, but the greater the footprint.
-		SimTh:       0.3,
+		SimTh:       0.6,
 		MaxChildren: 100,
 		ParamString: `<_>`,
 		MaxClusters: 300,

--- a/pkg/pattern/drain/drain_test.go
+++ b/pkg/pattern/drain/drain_test.go
@@ -21,7 +21,7 @@ func TestDrain_TrainExtractsPatterns(t *testing.T) {
 		{
 			// High variation leads to many patterns including some that are too generic (many tokens matched) and some that are too specific (too few matchers)
 			name:      "Generate patterns on high variation logfmt logs",
-			drain:     New(DefaultConfig()),
+			drain:     New(DefaultConfig(), "logfmt"),
 			inputFile: "testdata/agent-logfmt.txt",
 			patterns: []string{
 				"ts=2024-04-16T15:10:43.192290389Z caller=filetargetmanager.go:361 level=info component=logs logs_config=default msg=\"Adding target\" key=\"/var/log/pods/*19a1cce8-5f04-46e0-a124-292b0dd9b343/testcoordinator/*.log:{batch_kubernetes_io_controller_uid=\\\"25ec5edf-f78e-468b-b6f3-3b9685f0cc8f\\\", batch_kubernetes_io_job_name=\\\"testcoordinator-job-2665838\\\", container=\\\"testcoordinator\\\", controller_uid=\\\"25ec5edf-f78e-468b-b6f3-3b9685f0cc8f\\\", job=\\\"k6-cloud/testcoordinator\\\", job_name=\\\"testcoordinator-job-2665838\\\", name=\\\"testcoordinator\\\", namespace=\\\"k6-cloud\\\", pod=\\\"testcoordinator-job-2665838-9g8ds\\\"}\"",
@@ -43,7 +43,7 @@ func TestDrain_TrainExtractsPatterns(t *testing.T) {
 		{
 			// Lower variation leads to fewer patterns including some with limited value (single lines, no matchers)
 			name:      "Generate patterns on low variation logfmt logs",
-			drain:     New(DefaultConfig()),
+			drain:     New(DefaultConfig(), "logfmt"),
 			inputFile: "testdata/ingester-logfmt.txt",
 			patterns: []string{
 				"<_> caller=head.go:216 level=debug tenant=987678 msg=\"profile is empty after delta computation\" metricName=memory",
@@ -54,7 +54,7 @@ func TestDrain_TrainExtractsPatterns(t *testing.T) {
 		{
 			// Lower variation logs in json leads to a high number of patterns with very few matchers
 			name:      "Generate patterns on json formatted logs",
-			drain:     New(DefaultConfig()),
+			drain:     New(DefaultConfig(), "adaptive"),
 			inputFile: "testdata/drone-json.txt",
 			patterns: []string{
 				"<_> capacity <_>",
@@ -96,7 +96,7 @@ func TestDrain_TrainExtractsPatterns(t *testing.T) {
 		},
 		{
 			name:      "Patterns for distributor logs",
-			drain:     New(DefaultConfig()),
+			drain:     New(DefaultConfig(), "logfmt"),
 			inputFile: "testdata/distributor-logfmt.txt",
 			patterns: []string{
 				`<_> caller=http.go:194 level=debug <_> <_> msg="POST <_> <_> <_>`,
@@ -104,7 +104,7 @@ func TestDrain_TrainExtractsPatterns(t *testing.T) {
 		},
 		{
 			name:      "Patterns for journald logs",
-			drain:     New(DefaultConfig()),
+			drain:     New(DefaultConfig(), "adaptive"),
 			inputFile: "testdata/journald.txt",
 			patterns: []string{
 				"2024-05-07T11:59:43.484606Z INFO ExtHandler ExtHandler Downloading agent manifest",
@@ -195,7 +195,7 @@ func TestDrain_TrainExtractsPatterns(t *testing.T) {
 		},
 		{
 			name:      "Patterns for kafka logs",
-			drain:     New(DefaultConfig()),
+			drain:     New(DefaultConfig(), "adaptive"),
 			inputFile: "testdata/kafka.txt",
 			patterns: []string{
 				`[2024-05-07 <_> INFO [LocalLog partition=mimir-dev-09-aggregations-offsets-0, dir=/bitnami/kafka/data] Deleting segment files <_> size=948, <_> <_> (kafka.log.LocalLog$)`,
@@ -219,7 +219,7 @@ func TestDrain_TrainExtractsPatterns(t *testing.T) {
 		},
 		{
 			name:      "Patterns for kubernetes logs",
-			drain:     New(DefaultConfig()),
+			drain:     New(DefaultConfig(), "adaptive"),
 			inputFile: "testdata/kubernetes.txt",
 			patterns: []string{
 				"I0507 12:04:17.596484       1 highnodeutilization.go:107] \"Criteria for a node below target utilization\" CPU=50 Mem=50 Pods=100",
@@ -252,7 +252,7 @@ func TestDrain_TrainExtractsPatterns(t *testing.T) {
 		},
 		{
 			name:      "Patterns for vault logs",
-			drain:     New(DefaultConfig()),
+			drain:     New(DefaultConfig(), "adaptive"),
 			inputFile: "testdata/vault.txt",
 			patterns: []string{
 				"<_> [INFO]  expiration: revoked lease: <_>",
@@ -260,7 +260,7 @@ func TestDrain_TrainExtractsPatterns(t *testing.T) {
 		},
 		{
 			name:      "Patterns for calico logs",
-			drain:     New(DefaultConfig()),
+			drain:     New(DefaultConfig(), "adaptive"),
 			inputFile: "testdata/calico.txt",
 			patterns: []string{
 				`2024-05-08 <_> [DEBUG][216945] felix/table.go 870: Found forward-reference <_> ipVersion=0x4 <_> <_> [0:0]" table="nat"`,
@@ -384,7 +384,7 @@ func TestDrain_TrainGeneratesMatchablePatterns(t *testing.T) {
 	}{
 		{
 			name:  `should match each line against a pattern`,
-			drain: New(DefaultConfig()),
+			drain: New(DefaultConfig(), "adaptive"),
 			inputLines: []string{
 				"test test test",
 				"test test test",
@@ -394,7 +394,7 @@ func TestDrain_TrainGeneratesMatchablePatterns(t *testing.T) {
 		},
 		{
 			name:  `should also match newlines`,
-			drain: New(DefaultConfig()),
+			drain: New(DefaultConfig(), "adaptive"),
 			inputLines: []string{
 				`test test test
 `,
@@ -433,7 +433,7 @@ func TestDrain_TrainGeneratesPatternsMatchableByLokiPatternFilter(t *testing.T) 
 	}{
 		{
 			name:  `should extract patterns that all lines match`,
-			drain: New(DefaultConfig()),
+			drain: New(DefaultConfig(), "adaptive"),
 			inputLines: []string{
 				"test 1 test",
 				"test 2 test",
@@ -443,7 +443,7 @@ func TestDrain_TrainGeneratesPatternsMatchableByLokiPatternFilter(t *testing.T) 
 		},
 		{
 			name:  `should extract patterns that match if line ends with newlines`,
-			drain: New(DefaultConfig()),
+			drain: New(DefaultConfig(), "adaptive"),
 			inputLines: []string{
 				`test 1 test
 `,
@@ -457,7 +457,7 @@ func TestDrain_TrainGeneratesPatternsMatchableByLokiPatternFilter(t *testing.T) 
 		},
 		{
 			name:  `should extract patterns that match if line ends with empty space`,
-			drain: New(DefaultConfig()),
+			drain: New(DefaultConfig(), "adaptive"),
 			inputLines: []string{
 				`test 1 test			`,
 				`test 2 test			`,
@@ -467,7 +467,7 @@ func TestDrain_TrainGeneratesPatternsMatchableByLokiPatternFilter(t *testing.T) 
 		},
 		{
 			name:  `should extract patterns that match if line starts with empty space`,
-			drain: New(DefaultConfig()),
+			drain: New(DefaultConfig(), "adaptive"),
 			inputLines: []string{
 				`			test 1 test`,
 				`			test 2 test`,

--- a/pkg/pattern/drain/log_cluster.go
+++ b/pkg/pattern/drain/log_cluster.go
@@ -20,9 +20,13 @@ type LogCluster struct {
 
 func (c *LogCluster) String() string {
 	if c.Stringer != nil {
-		return c.Stringer(c.Tokens)
+		return stripReplacements(c.Stringer(c.Tokens))
 	}
-	return strings.Join(c.Tokens, " ")
+	return stripReplacements(strings.Join(c.Tokens, " "))
+}
+
+func stripReplacements(in string) string {
+	return strings.NewReplacer("<HEX>", "<_>", "<NUM>", "<_>", "<TIMESTAMP>", "<_>", "<DURATION>", "<_>", "<BYTESIZE>", "<_>", "<IP>", "<_>", "<UUID>", "<_>").Replace(in)
 }
 
 func (c *LogCluster) append(ts model.Time) {

--- a/pkg/pattern/drain/tokenizers.go
+++ b/pkg/pattern/drain/tokenizers.go
@@ -23,15 +23,15 @@ type adaptiveLogsTokenizer struct{}
 func (a *adaptiveLogsTokenizer) Marshal(in string) []string {
 	preprocessedTokens := tokenization.PreprocessAndTokenizeWithOpts([]byte(in), tokenization.TokenizerOpts{
 		UseSingleTokenForQuotes:   true,
-		IncludeDelimitersInTokens: false,
-		PreprocessNumbers:         true,
+		IncludeDelimitersInTokens: true,
+		PreprocessNumbers:         false,
 	})
 	return preprocessedTokens
 }
 
 func (a *adaptiveLogsTokenizer) Unmarshal(tokens []string) string {
 	// Not easy to unmarshal back to a pattern string for the UI: This works some of the time.
-	return strings.Join(tokens, " ")
+	return strings.Join(tokens, "")
 }
 
 // A tokenizer which tweaks the Adaptive one above to make it more suitable for Explore app.

--- a/pkg/pattern/drain/tokenizers.go
+++ b/pkg/pattern/drain/tokenizers.go
@@ -1,0 +1,137 @@
+package drain
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	"github.com/go-logfmt/logfmt"
+
+	"github.com/grafana/loki/v3/pkg/pattern/tokenization"
+)
+
+type Tokenizer interface {
+	Marshal(string) []string
+	Unmarshal([]string) string
+}
+
+// Tokenizers using the Adaptive logs tokenizer and replacer.
+// This tokenizes multi-word quotes as single tokens.
+// It replaces as much as possible with constants before passing to Drain (e.g. <NUM>, <DURATION>, <TIMESTAMP>, <HEX>)
+type adaptiveLogsTokenizer struct{}
+
+func (a *adaptiveLogsTokenizer) Marshal(in string) []string {
+	preprocessedTokens := tokenization.PreprocessAndTokenizeWithOpts([]byte(in), tokenization.TokenizerOpts{
+		UseSingleTokenForQuotes:   true,
+		IncludeDelimitersInTokens: false,
+		PreprocessNumbers:         true,
+	})
+	return preprocessedTokens
+}
+
+func (a *adaptiveLogsTokenizer) Unmarshal(tokens []string) string {
+	// Not easy to unmarshal back to a pattern string for the UI: This works some of the time.
+	return strings.Join(tokens, " ")
+}
+
+// A tokenizer which tweaks the Adaptive one above to make it more suitable for Explore app.
+// It tokenizes inside quotes, includes delimiters in the response in order to reconstruct the string, and ignores a few more generic replacement placeholders (e.g. does not use <NUM> or <HEX>)
+type limitedReplacementsTokenizer struct{}
+
+func (a *limitedReplacementsTokenizer) Marshal(in string) []string {
+	preprocessedTokens := tokenization.PreprocessAndTokenizeWithOpts([]byte(in), tokenization.TokenizerOpts{
+		UseSingleTokenForQuotes:   false,
+		IncludeDelimitersInTokens: true,
+		PreprocessNumbers:         false,
+	})
+	return preprocessedTokens
+}
+
+func (a *limitedReplacementsTokenizer) Unmarshal(tokens []string) string {
+	return strings.Join(tokens, "")
+}
+
+// Preprocesses the string to replace some terms with placeholders, except a few common ones (e.g. does not use <NUM> or <HEX>)
+// Uses a simple approach to tokenizing: Use space or comma, depending on which is more frequently used in this log line.
+type spaceOrCommaTokenizer struct {
+	delimiter string
+}
+
+func (a *spaceOrCommaTokenizer) Marshal(in string) []string {
+	preprocessedContent := string(tokenization.Preprocess([]byte(in), false, false))
+
+	if a.delimiter == "" {
+		spaces := strings.Count(preprocessedContent, " ")
+		commas := strings.Count(preprocessedContent, ",")
+		a.delimiter = " "
+		if commas > spaces {
+			a.delimiter = ","
+		}
+	}
+
+	return strings.Split(preprocessedContent, a.delimiter)
+}
+func (a *spaceOrCommaTokenizer) Unmarshal(tokens []string) string {
+	return strings.Join(tokens, a.delimiter)
+}
+
+type logfmtTokenizer struct {
+	tokenizeInsideQuotes bool
+}
+
+func (a *logfmtTokenizer) Marshal(in string) []string {
+	tokens := []string{}
+	processed := tokenization.Preprocess([]byte(in), false, false)
+	decoder := logfmt.NewDecoder(bytes.NewReader(processed))
+	for decoder.ScanRecord() {
+		for decoder.ScanKeyval() {
+			k := decoder.Key()
+			v := decoder.Value()
+			equals := "="
+			if v == nil {
+				equals = ""
+			}
+			tokens = append(tokens, fmt.Sprintf("%s%s", k, equals))
+			if v == nil {
+				continue
+			}
+			if a.tokenizeInsideQuotes {
+				tokens = append(tokens, strings.Split(string(v), " ")...)
+			} else {
+				tokens = append(tokens, string(v))
+			}
+		}
+	}
+
+	return tokens
+}
+
+func (a *logfmtTokenizer) Unmarshal(tokens []string) string {
+	var output strings.Builder
+	var quoted strings.Builder
+	var quotedTokens int
+
+	for _, token := range tokens {
+		if strings.HasSuffix(token, "=") {
+			quotedOutput := quoted.String()
+			if quotedTokens > 1 {
+				output.WriteString(fmt.Sprintf("%q ", strings.TrimSuffix(quotedOutput, " ")))
+			} else {
+				output.WriteString(fmt.Sprintf("%s", quotedOutput))
+			}
+			quoted.Reset()
+			quotedTokens = 0
+			output.WriteString(token)
+		} else {
+			quoted.WriteString(token + " ")
+			quotedTokens++
+		}
+	}
+	quotedOutput := strings.TrimSuffix(quoted.String(), " ")
+	if quotedTokens > 1 {
+		output.WriteString(fmt.Sprintf("%q", strings.TrimSuffix(quotedOutput, " ")))
+	} else {
+		output.WriteString(fmt.Sprintf("%s", quotedOutput))
+	}
+	return output.String()
+}

--- a/pkg/pattern/ingester_querier.go
+++ b/pkg/pattern/ingester_querier.go
@@ -67,7 +67,7 @@ func (q *IngesterQuerier) Patterns(ctx context.Context, req *logproto.QueryPatte
 }
 
 func prunePatterns(resp *logproto.QueryPatternsResponse, minClusterSize int) *logproto.QueryPatternsResponse {
-	d := drain.New(drain.DefaultConfig())
+	d := drain.New(drain.DefaultConfig(), "")
 	for _, p := range resp.Series {
 		d.TrainPattern(p.Pattern, p.Samples)
 	}

--- a/pkg/pattern/stream.go
+++ b/pkg/pattern/stream.go
@@ -2,12 +2,14 @@ package pattern
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/grafana/loki/v3/pkg/logproto"
 	"github.com/grafana/loki/v3/pkg/pattern/drain"
 	"github.com/grafana/loki/v3/pkg/pattern/iter"
+	"github.com/grafana/loki/v3/pkg/pattern/tokenization"
 
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
@@ -49,7 +51,9 @@ func (s *stream) Push(
 			continue
 		}
 		s.lastTs = entry.Timestamp.UnixNano()
-		s.patterns.Train(entry.Line, entry.Timestamp.UnixNano())
+		preprocessedContent := tokenization.Preprocess([]byte(entry.Line))
+		preprocessedTokens := strings.Split(string(preprocessedContent), " ")
+		s.patterns.TrainTokens(preprocessedTokens, drain.RemoveNamedVariablesAndConcat, entry.Timestamp.UnixNano())
 	}
 	return nil
 }

--- a/pkg/pattern/stream.go
+++ b/pkg/pattern/stream.go
@@ -2,7 +2,6 @@ package pattern
 
 import (
 	"context"
-	"strings"
 	"sync"
 	"time"
 
@@ -51,9 +50,9 @@ func (s *stream) Push(
 			continue
 		}
 		s.lastTs = entry.Timestamp.UnixNano()
-		preprocessedContent := tokenization.Preprocess([]byte(entry.Line))
-		preprocessedTokens := strings.Split(string(preprocessedContent), " ")
-		s.patterns.TrainTokens(preprocessedTokens, drain.RemoveNamedVariablesAndConcat, entry.Timestamp.UnixNano())
+		preprocessedContent := tokenization.PreprocessAndTokenize([]byte(entry.Line))
+		//preprocessedTokens := strings.Split(string(preprocessedContent), " ")
+		s.patterns.TrainTokens(preprocessedContent, drain.RemoveNamedVariablesAndConcat, entry.Timestamp.UnixNano())
 	}
 	return nil
 }

--- a/pkg/pattern/tokenization/replacer.go
+++ b/pkg/pattern/tokenization/replacer.go
@@ -57,6 +57,8 @@ type replacer struct {
 	// A somewhat hacky solution that allows us to preserve specific numeric
 	// values we care about, like status and status_code.
 	preserveNextNumbers bool
+
+	replaceNumbers bool
 }
 
 // commit advances the current position marker to the lookahead position, i.e.
@@ -350,12 +352,18 @@ func (r *replacer) advance() (c byte, advanced bool) {
 }
 
 func (r *replacer) emitNumber() {
+	if !r.replaceNumbers {
+		return
+	}
 	r.commit()
 	r.dest = append(r.dest, placeholderNumber...)
 	r.consumeUpToCurrent()
 }
 
 func (r *replacer) emitNumberOrCopyText(hasMinusPrefix bool) {
+	if !r.replaceNumbers {
+		return
+	}
 	r.commit()
 	if !r.preserveNextNumbers {
 		r.dest = append(r.dest, placeholderNumber...)

--- a/pkg/pattern/tokenization/tokenization.go
+++ b/pkg/pattern/tokenization/tokenization.go
@@ -27,6 +27,8 @@ type tokenizer struct {
 	// allocate new memory.
 	line   string
 	tokens []string
+
+	tokeniseWholeQuotes bool
 }
 
 func (t *tokenizer) countOrSaveToken(endTokenPos, skip int) {
@@ -75,14 +77,14 @@ func (t *tokenizer) handleNextToken() bool {
 		// character is also part of the current token. The only special case
 		// here is if the current character is a matching quote, that means
 		// we'll no longer be quoted.
-		case curQuotePos >= 0:
+		case t.tokeniseWholeQuotes && curQuotePos >= 0:
 			if c == curQuoteChar { // end quote
 				curQuotePos = -1
 			}
 
 		// If we encounter a qoute character and we were not already in a quoted
 		// part of the line, mark that we are now in a quote from that type.
-		case c == '"' || c == '\'' || c == '`':
+		case t.tokeniseWholeQuotes && (c == '"' || c == '\'' || c == '`'):
 			curQuoteChar = c
 			curQuotePos = p
 


### PR DESCRIPTION
## This PR is a draft: I'm not proposing to merge this unless we are happy with the approach

**What this PR does / why we need it**:
- This is an experimental change to the Drain algorithm in an attempt to generate *"better"* patterns.
  - Seems to generate **less generic** patterns but also **avoids very specific** patterns so there is a nicer middleground.
- It uses what I describe as "lazy preprocessing" to utilise the existing pre-processing code to categorise tokens on-the-fly.
- Truncates all tokens to 50 characters to remove really long tokens (pod names etc.) and increase chance of matching.
- It generates a much better parse tree as we end up with branches for different types (\<HEX\>, \<NUM\>, \<IP\>) while still allowing actual values if there is only one to show which aids readability. (e.g. if logs only contain `log.go:48` we retain that instead of `log.go:<NUM>`)
- Makes use of multiple tokenization strategies: "logfmt" tokenizer will attempt to parse logfmt logs, "adaptive" with use the tokenizer already in the repo which works better on unstructured/json logs.

Several caveats apply:
- The code is not optimised and is generally more CPU intensive than before. Parse tree is flatter which might compensate for this a bit.
- Picking which tokenizer to use isn't great - I can clean this up if this direction is promising.

Examples:
Old:
```
"<_> caller=http.go:194 level=debug <_> <_> msg=\"POST <_> <_> <_>"
```

New
```
"ts=<_> caller=http.go:194 level=debug traceID=<_> orgID=<_> msg=\"POST /push.v1.PusherService/Push (200) <_>\"",
"ts=<_> caller=http.go:194 level=debug traceID=<_> orgID=<_> msg=\"POST /ingest?aggregationType=sum&from=17146522271076410<_> (200) <_>\"",
"ts=<_> caller=http.go:194 level=debug traceID=<_> orgID=<_> msg=\"POST /push.v1.PusherService/Push (<_>) <_>\"",
"ts=<_> caller=http.go:194 level=debug traceID=<_> orgID=<_> msg=\"POST /pyroscope/ingest?aggregationType=sum&from=1714652<_> (200) <_>\"",
"ts=<_> caller=http.go:194 level=debug traceID=<_> orgID=<_> msg=\"POST /ingest?aggregationType=&from=1714652227232613927&<_> (200) <_>\"",
"ts=<_> caller=http.go:194 level=debug traceID=<_> orgID=<_> msg=\"POST /ingest?aggregationType=average&from=1714652227232<_> (200) <_>\""
```

This is available in image: `grafana/enterprise-logs:custom-k201-21e25369a1bf-3e6ea71e3efd` for testing further.