### PR TITLE
perf: Replace channel check with atomic bool in tailer.send()

### DIFF
--- a/pkg/ingester/tailer.go
+++ b/pkg/ingester/tailer.go
@@ -127,7 +127,7 @@ func (t *tailer) receiveStreamsLoop() {
 		case <-t.closeChan:
 			return
 		case req, ok := <-t.queue:
-			if !ok || t.closed.Load() {
+			if !ok {
 				return
 			}
 
@@ -230,12 +230,7 @@ func isMatching(lbs labels.Labels, matchers []*labels.Matcher) bool {
 }
 
 func (t *tailer) isClosed() bool {
-	select {
-	case <-t.closeChan:
-		return true
-	default:
-		return false
-	}
+	return t.closed.Load()
 }
 
 func (t *tailer) close() {

--- a/pkg/ingester/tailer_test.go
+++ b/pkg/ingester/tailer_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 func TestTailer_RoundTrip(t *testing.T) {
+	t.Parallel()
 	server := &fakeTailServer{}
 
 	lbs := makeRandomLabels()
@@ -66,6 +67,7 @@ func TestTailer_RoundTrip(t *testing.T) {
 }
 
 func TestTailer_sendRaceConditionOnSendWhileClosing(t *testing.T) {
+	t.Parallel()
 	runs := 100
 
 	stream := logproto.Stream{
@@ -103,6 +105,7 @@ func TestTailer_sendRaceConditionOnSendWhileClosing(t *testing.T) {
 }
 
 func Test_dropstream(t *testing.T) {
+	t.Parallel()
 	maxDroppedStreams := 10
 
 	entry := logproto.Entry{Timestamp: time.Now(), Line: "foo"}
@@ -224,6 +227,7 @@ func Test_TailerSendRace(t *testing.T) {
 }
 
 func Test_IsMatching(t *testing.T) {
+	t.Parallel()
 	for _, tt := range []struct {
 		name     string
 		lbs      labels.Labels
@@ -241,6 +245,7 @@ func Test_IsMatching(t *testing.T) {
 }
 
 func Test_StructuredMetadata(t *testing.T) {
+	t.Parallel()
 	lbs := makeRandomLabels()
 
 	for _, tc := range []struct {
@@ -363,4 +368,18 @@ func Test_StructuredMetadata(t *testing.T) {
 			wg.Wait()
 		})
 	}
+}
+
+func Benchmark_tailer_isClosed(t *testing.B) {
+	var server fakeTailServer
+	expr, err := syntax.ParseLogSelector(`{app="foo"}`, true)
+	require.NoError(t, err)
+	tail, err := newTailer("foo", expr, &server, 0)
+	require.NoError(t, err)
+
+	for i := 0; i < t.N; i++ {
+		tail.isClosed()
+	}
+
+	tail.close()
 }

--- a/pkg/ingester/tailer_test.go
+++ b/pkg/ingester/tailer_test.go
@@ -370,7 +370,7 @@ func Test_StructuredMetadata(t *testing.T) {
 	}
 }
 
-func Benchmark_tailer_isClosed(t *testing.B) {
+func Benchmark_isClosed(t *testing.B) {
 	var server fakeTailServer
 	expr, err := syntax.ParseLogSelector(`{app="foo"}`, true)
 	require.NoError(t, err)

--- a/pkg/ingester/tailer_test.go
+++ b/pkg/ingester/tailer_test.go
@@ -377,9 +377,13 @@ func Benchmark_tailer_isClosed(t *testing.B) {
 	tail, err := newTailer("foo", expr, &server, 0)
 	require.NoError(t, err)
 
+	require.Equal(t, false, tail.isClosed())
+
+	t.ResetTimer()
 	for i := 0; i < t.N; i++ {
 		tail.isClosed()
 	}
 
 	tail.close()
+	require.Equal(t, true, tail.isClosed())
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
- @cyriltovena discovered that tailer.isClosed was eating a significant amount of CPU in ops (>20 CPUs worth)
![image](https://github.com/grafana/loki/assets/36448794/2ffec887-bdb1-439a-9906-2aae5a11b828)]
- I replaced the select on the channel to try and reduce the amount of CPU time spent on this particular code path.
- I used an atomic bool for the `send()` but retained the `closeChan` to signal the other parts of the tailer to shut down ASAP, otherwise we'd need to check the bool periodically using (for example) `time.After`.

Benchmark before thte change, using select-default:
```
Benchmark_tailer_isClosed
Benchmark_tailer_isClosed-14    	536670529	         2.220 ns/op
PASS
```

Benchmark after the change, using atomic bool:
```
Benchmark_tailer_isClosed
Benchmark_tailer_isClosed-14    	1000000000	         0.2886 ns/op
PASS
```

So this small change is nearly 10x faster and therefore would save ~18-20 cores worth of CPU time in our ops cluster.