### PR TITLE
fix(indexstats): do not collect stats from "IndexStats" lookups for other query types

### DIFF
--- a/pkg/ingester/tailer.go
+++ b/pkg/ingester/tailer.go
@@ -4,8 +4,9 @@ import (
 	"encoding/binary"
 	"hash/fnv"
 	"sync"
-	"sync/atomic"
 	"time"
+
+	"go.uber.org/atomic"
 
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/prometheus/model/labels"


### PR DESCRIPTION
**What this PR does / why we need it**:
`indexStatsTripperware` is used for resolving shards for most query types, but it also includes `StatsCollectorMiddleware` middleware in the chain which is not thread safe. This could result in [data corruption of the collected stats](https://github.com/grafana/loki/blob/main/pkg/querier/queryrange/stats.go#L210) since the subqueries split by time could resolve shards concurrently.

This pr makes changes to only include the stats collection middleware for actual index stats queries, other queries types will not need this. 

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
