### PR TITLE
feat: Boilerplate for new bloom build planner and worker components.

### DIFF
--- a/pkg/bloombuild/bloomplanner/config.go
+++ b/pkg/bloombuild/bloomplanner/config.go
@@ -1,0 +1,21 @@
+package bloomplanner
+
+import "flag"
+
+// Config configures the bloom-planner component.
+type Config struct {
+	// TODO: Add config
+}
+
+// RegisterFlagsWithPrefix registers flags for the bloom-planner configuration.
+func (cfg *Config) RegisterFlagsWithPrefix(flagsPrefix string, f *flag.FlagSet) {
+	// TODO: Register flags with flagsPrefix
+}
+
+func (cfg *Config) Validate() error {
+	return nil
+}
+
+type Limits interface {
+	// TODO: Add limits
+}

--- a/pkg/bloombuild/bloomplanner/metrics.go
+++ b/pkg/bloombuild/bloomplanner/metrics.go
@@ -1,0 +1,26 @@
+package bloomplanner
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+const (
+	metricsNamespace = "loki"
+	metricsSubsystem = "bloomplanner"
+)
+
+type Metrics struct {
+	running prometheus.Gauge
+}
+
+func NewMetrics(r prometheus.Registerer) *Metrics {
+	return &Metrics{
+		running: promauto.With(r).NewGauge(prometheus.GaugeOpts{
+			Namespace: metricsNamespace,
+			Subsystem: metricsSubsystem,
+			Name:      "running",
+			Help:      "Value will be 1 if planner is currently running on this instance",
+		}),
+	}
+}

--- a/pkg/bloombuild/bloomplanner/planner.go
+++ b/pkg/bloombuild/bloomplanner/planner.go
@@ -1,0 +1,48 @@
+package bloomplanner
+
+import (
+	"context"
+	"github.com/go-kit/log"
+	"github.com/grafana/dskit/services"
+	utillog "github.com/grafana/loki/v3/pkg/util/log"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type Planner struct {
+	services.Service
+
+	cfg     Config
+	metrics *Metrics
+	logger  log.Logger
+}
+
+func New(
+	cfg Config,
+	logger log.Logger,
+	r prometheus.Registerer,
+) (*Planner, error) {
+	utillog.WarnExperimentalUse("Bloom Build Planner", logger)
+
+	p := &Planner{
+		cfg:     cfg,
+		metrics: NewMetrics(r),
+		logger:  logger,
+	}
+
+	p.Service = services.NewBasicService(p.starting, p.running, p.stopping)
+	return p, nil
+}
+
+func (p *Planner) starting(_ context.Context) (err error) {
+	p.metrics.running.Set(1)
+	return err
+}
+
+func (p *Planner) stopping(_ error) error {
+	p.metrics.running.Set(0)
+	return nil
+}
+
+func (p *Planner) running(_ context.Context) error {
+	return nil
+}

--- a/pkg/bloombuild/bloomworker/builder.go
+++ b/pkg/bloombuild/bloomworker/builder.go
@@ -1,4 +1,4 @@
-package bloomplanner
+package bloomworker
 
 import (
 	"context"
@@ -10,7 +10,7 @@ import (
 	utillog "github.com/grafana/loki/v3/pkg/util/log"
 )
 
-type Planner struct {
+type Worker struct {
 	services.Service
 
 	cfg     Config
@@ -22,29 +22,29 @@ func New(
 	cfg Config,
 	logger log.Logger,
 	r prometheus.Registerer,
-) (*Planner, error) {
-	utillog.WarnExperimentalUse("Bloom Build Planner", logger)
+) (*Worker, error) {
+	utillog.WarnExperimentalUse("Bloom Builder", logger)
 
-	p := &Planner{
+	w := &Worker{
 		cfg:     cfg,
 		metrics: NewMetrics(r),
 		logger:  logger,
 	}
 
-	p.Service = services.NewBasicService(p.starting, p.running, p.stopping)
-	return p, nil
+	w.Service = services.NewBasicService(w.starting, w.running, w.stopping)
+	return w, nil
 }
 
-func (p *Planner) starting(_ context.Context) (err error) {
-	p.metrics.running.Set(1)
+func (w *Worker) starting(_ context.Context) (err error) {
+	w.metrics.running.Set(1)
 	return err
 }
 
-func (p *Planner) stopping(_ error) error {
-	p.metrics.running.Set(0)
+func (w *Worker) stopping(_ error) error {
+	w.metrics.running.Set(0)
 	return nil
 }
 
-func (p *Planner) running(_ context.Context) error {
+func (w *Worker) running(_ context.Context) error {
 	return nil
 }

--- a/pkg/bloombuild/bloomworker/config.go
+++ b/pkg/bloombuild/bloomworker/config.go
@@ -1,0 +1,21 @@
+package bloomworker
+
+import "flag"
+
+// Config configures the bloom-planner component.
+type Config struct {
+	// TODO: Add config
+}
+
+// RegisterFlagsWithPrefix registers flags for the bloom-planner configuration.
+func (cfg *Config) RegisterFlagsWithPrefix(flagsPrefix string, f *flag.FlagSet) {
+	// TODO: Register flags with flagsPrefix
+}
+
+func (cfg *Config) Validate() error {
+	return nil
+}
+
+type Limits interface {
+	// TODO: Add limits
+}

--- a/pkg/bloombuild/bloomworker/metrics.go
+++ b/pkg/bloombuild/bloomworker/metrics.go
@@ -1,4 +1,4 @@
-package bloomplanner
+package bloomworker
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
@@ -7,7 +7,7 @@ import (
 
 const (
 	metricsNamespace = "loki"
-	metricsSubsystem = "bloomplanner"
+	metricsSubsystem = "bloombuilder"
 )
 
 type Metrics struct {
@@ -20,7 +20,7 @@ func NewMetrics(r prometheus.Registerer) *Metrics {
 			Namespace: metricsNamespace,
 			Subsystem: metricsSubsystem,
 			Name:      "running",
-			Help:      "Value will be 1 if bloom build planner is currently running on this instance",
+			Help:      "Value will be 1 if the bloom builder is currently running on this instance",
 		}),
 	}
 }

--- a/pkg/bloombuild/config.go
+++ b/pkg/bloombuild/config.go
@@ -1,0 +1,32 @@
+package bloombuild
+
+import (
+	"flag"
+	"fmt"
+	bloomplanner "github.com/grafana/loki/v3/pkg/bloombuild/planner"
+)
+
+// Config configures the bloom-planner component.
+type Config struct {
+	Enabled bool `yaml:"enabled"`
+
+	Planner bloomplanner.Config `yaml:"planner"`
+}
+
+// RegisterFlags registers flags for the bloom building configuration.
+func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
+	f.BoolVar(&cfg.Enabled, "bloom-build.enabled", false, "Flag to enable or disable the usage of the bloom-build-planner and bloom-builder components.")
+	cfg.Planner.RegisterFlagsWithPrefix("bloom-build.enabled.planner", f)
+}
+
+func (cfg *Config) Validate() error {
+	if !cfg.Enabled {
+		return nil
+	}
+
+	if err := cfg.Planner.Validate(); err != nil {
+		return fmt.Errorf("invalid bloom planner configuration: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/bloombuild/config.go
+++ b/pkg/bloombuild/config.go
@@ -3,7 +3,9 @@ package bloombuild
 import (
 	"flag"
 	"fmt"
-	bloomplanner "github.com/grafana/loki/v3/pkg/bloombuild/planner"
+
+	"github.com/grafana/loki/v3/pkg/bloombuild/bloomplanner"
+	"github.com/grafana/loki/v3/pkg/bloombuild/bloomworker"
 )
 
 // Config configures the bloom-planner component.
@@ -11,12 +13,14 @@ type Config struct {
 	Enabled bool `yaml:"enabled"`
 
 	Planner bloomplanner.Config `yaml:"planner"`
+	Worker  bloomworker.Config  `yaml:"worker"`
 }
 
 // RegisterFlags registers flags for the bloom building configuration.
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&cfg.Enabled, "bloom-build.enabled", false, "Flag to enable or disable the usage of the bloom-build-planner and bloom-builder components.")
-	cfg.Planner.RegisterFlagsWithPrefix("bloom-build.enabled.planner", f)
+	cfg.Planner.RegisterFlagsWithPrefix("bloom-build.planner", f)
+	cfg.Worker.RegisterFlagsWithPrefix("bloom-build.worker", f)
 }
 
 func (cfg *Config) Validate() error {
@@ -26,6 +30,10 @@ func (cfg *Config) Validate() error {
 
 	if err := cfg.Planner.Validate(); err != nil {
 		return fmt.Errorf("invalid bloom planner configuration: %w", err)
+	}
+
+	if err := cfg.Worker.Validate(); err != nil {
+		return fmt.Errorf("invalid bloom worker configuration: %w", err)
 	}
 
 	return nil

--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -653,6 +653,7 @@ func (t *Loki) setupModuleManager() error {
 	mm.RegisterModule(BloomCompactor, t.initBloomCompactor)
 	mm.RegisterModule(BloomCompactorRing, t.initBloomCompactorRing, modules.UserInvisibleModule)
 	mm.RegisterModule(BloomBuildPlanner, t.initBloomBuildPlanner)
+	mm.RegisterModule(BloomBuildWorker, t.initBloomBuildWorker)
 	mm.RegisterModule(IndexGateway, t.initIndexGateway)
 	mm.RegisterModule(IndexGatewayRing, t.initIndexGatewayRing, modules.UserInvisibleModule)
 	mm.RegisterModule(IndexGatewayInterceptors, t.initIndexGatewayInterceptors, modules.UserInvisibleModule)
@@ -691,6 +692,7 @@ func (t *Loki) setupModuleManager() error {
 		BloomGateway:             {Server, BloomStore, Analytics},
 		BloomCompactor:           {Server, BloomStore, BloomCompactorRing, Analytics, Store},
 		BloomBuildPlanner:        {Server, BloomStore, Analytics, Store},
+		BloomBuildWorker:         {Server, BloomStore, Analytics, Store},
 		PatternIngester:          {Server, MemberlistKV, Analytics},
 		PatternRingClient:        {Server, MemberlistKV, Analytics},
 		IngesterQuerier:          {Ring},

--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -31,6 +31,7 @@ import (
 	"google.golang.org/grpc/health/grpc_health_v1"
 
 	"github.com/grafana/loki/v3/pkg/analytics"
+	"github.com/grafana/loki/v3/pkg/bloombuild"
 	"github.com/grafana/loki/v3/pkg/bloomcompactor"
 	"github.com/grafana/loki/v3/pkg/bloomgateway"
 	"github.com/grafana/loki/v3/pkg/compactor"
@@ -90,6 +91,7 @@ type Config struct {
 	Pattern             pattern.Config             `yaml:"pattern_ingester,omitempty"`
 	IndexGateway        indexgateway.Config        `yaml:"index_gateway"`
 	BloomCompactor      bloomcompactor.Config      `yaml:"bloom_compactor,omitempty" category:"experimental"`
+	BloomBuild          bloombuild.Config          `yaml:"bloom_build,omitempty" category:"experimental"`
 	BloomGateway        bloomgateway.Config        `yaml:"bloom_gateway,omitempty" category:"experimental"`
 	StorageConfig       storage.Config             `yaml:"storage_config,omitempty"`
 	ChunkStoreConfig    config.ChunkStoreConfig    `yaml:"chunk_store_config,omitempty"`
@@ -173,6 +175,7 @@ func (c *Config) RegisterFlags(f *flag.FlagSet) {
 	c.Tracing.RegisterFlags(f)
 	c.CompactorConfig.RegisterFlags(f)
 	c.BloomCompactor.RegisterFlags(f)
+	c.BloomBuild.RegisterFlags(f)
 	c.QueryScheduler.RegisterFlags(f)
 	c.Analytics.RegisterFlags(f)
 	c.OperationalConfig.RegisterFlags(f)
@@ -649,6 +652,7 @@ func (t *Loki) setupModuleManager() error {
 	mm.RegisterModule(BloomStore, t.initBloomStore)
 	mm.RegisterModule(BloomCompactor, t.initBloomCompactor)
 	mm.RegisterModule(BloomCompactorRing, t.initBloomCompactorRing, modules.UserInvisibleModule)
+	mm.RegisterModule(BloomBuildPlanner, t.initBloomBuildPlanner)
 	mm.RegisterModule(IndexGateway, t.initIndexGateway)
 	mm.RegisterModule(IndexGatewayRing, t.initIndexGatewayRing, modules.UserInvisibleModule)
 	mm.RegisterModule(IndexGatewayInterceptors, t.initIndexGatewayInterceptors, modules.UserInvisibleModule)
@@ -686,6 +690,7 @@ func (t *Loki) setupModuleManager() error {
 		IndexGateway:             {Server, Store, BloomStore, IndexGatewayRing, IndexGatewayInterceptors, Analytics},
 		BloomGateway:             {Server, BloomStore, Analytics},
 		BloomCompactor:           {Server, BloomStore, BloomCompactorRing, Analytics, Store},
+		BloomBuildPlanner:        {Server, BloomStore, Analytics, Store},
 		PatternIngester:          {Server, MemberlistKV, Analytics},
 		PatternRingClient:        {Server, MemberlistKV, Analytics},
 		IngesterQuerier:          {Ring},


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the boilerplate for the two new bloom building components: the planner and the worker.
We don't add any functionality yet. 

**Special notes for your reviewer**:
- Let's discuss the naming of the components.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
