### PR TITLE
feat(blooms): Separate page buffer pools for series pages and bloom pages

### DIFF
--- a/pkg/storage/bloom/v1/index.go
+++ b/pkg/storage/bloom/v1/index.go
@@ -166,8 +166,8 @@ func (b *BlockIndex) NewSeriesPageDecoder(r io.ReadSeeker, header SeriesPageHead
 		return nil, errors.Wrap(err, "seeking to series page")
 	}
 
-	data := BlockPool.Get(header.Len)[:header.Len]
-	defer BlockPool.Put(data)
+	data := SeriesPagePool.Get(header.Len)[:header.Len]
+	defer SeriesPagePool.Put(data)
 	_, err = io.ReadFull(r, data)
 	if err != nil {
 		return nil, errors.Wrap(err, "reading series page")

--- a/pkg/storage/bloom/v1/index.go
+++ b/pkg/storage/bloom/v1/index.go
@@ -155,7 +155,7 @@ func (b *BlockIndex) NewSeriesPageDecoder(r io.ReadSeeker, header SeriesPageHead
 	defer func() {
 		if err != nil {
 			metrics.pagesSkipped.WithLabelValues(pageTypeSeries, skipReasonErr).Inc()
-			metrics.bytesSkipped.WithLabelValues(pageTypeSeries).Add(float64(header.DecompressedLen))
+			metrics.bytesSkipped.WithLabelValues(pageTypeSeries, skipReasonErr).Add(float64(header.DecompressedLen))
 		} else {
 			metrics.pagesRead.WithLabelValues(pageTypeSeries).Inc()
 			metrics.bytesRead.WithLabelValues(pageTypeSeries).Add(float64(header.DecompressedLen))

--- a/pkg/storage/bloom/v1/util.go
+++ b/pkg/storage/bloom/v1/util.go
@@ -32,10 +32,21 @@ var (
 		},
 	}
 
-	// 4KB -> 128MB
-	BlockPool = BytePool{
+	// buffer pool for series pages
+	// 1KB 2KB 4KB 8KB 16KB 32KB 64KB 128KB
+	SeriesPagePool = BytePool{
 		pool: pool.New(
-			4<<10, 128<<20, 2,
+			1<<10, 128<<10, 2,
+			func(size int) interface{} {
+				return make([]byte, size)
+			}),
+	}
+
+	// buffer pool for bloom pages
+	// 128KB 256KB 512KB 1MB 2MB 4MB 8MB 16MB 32MB 64MB 128MB
+	BloomPagePool = BytePool{
+		pool: pool.New(
+			128<<10, 128<<20, 2,
 			func(size int) interface{} {
 				return make([]byte, size)
 			}),


### PR DESCRIPTION
**What this PR does / why we need it**:
    
Series pages are much smaller than bloom pages and therefore can make use of a separate buffer pool with different buckets.

**Special notes for your reviewer**:

The second commit fixes a possible panic.
