### PR TITLE
docs: update otlp ingestion with correct endpoint and add endpoint to reference api docs

### DIFF
--- a/docs/sources/reference/loki-http-api.md
+++ b/docs/sources/reference/loki-http-api.md
@@ -24,6 +24,7 @@ Authorization needs to be done separately, for example, using an open-source loa
 These endpoints are exposed by the `distributor`, `write`, and `all` components:
 
 - [`POST /loki/api/v1/push`](#ingest-logs)
+- [`POST /otlp/v1/logs`](#ingest-logs-using-otlp)
 
 A [list of clients]({{< relref "../send-data" >}}) can be found in the clients documentation.
 
@@ -259,6 +260,16 @@ curl -H "Content-Type: application/json" \
   -s -X POST "http://localhost:3100/loki/api/v1/push" \
   --data-raw '{"streams": [{ "stream": { "foo": "bar2" }, "values": [ [ "1570818238000000000", "fizzbuzz" ] ] }]}'
 ```
+
+## Ingest logs using OTLP
+
+```bash
+POST /otlp/v1/logs
+```
+
+`/otlp/v1/logs` lets the OpenTelemetry Collector send logs to Loki using `otlphttp` procotol.
+
+For information on how to configure Loki, refer to the [OTel Collector topic](https://grafana.com/docs/loki/<LOKI_VERSION>/send-data/otel/).
 
 ## Query logs at a single point in time
 

--- a/docs/sources/send-data/otel/_index.md
+++ b/docs/sources/send-data/otel/_index.md
@@ -30,7 +30,7 @@ You need to make the following changes to the [OpenTelemetry Collector config](h
 ```yaml
 exporters:
   otlphttp:
-    endpoint: http://<loki-addr>:3100/otlp
+    endpoint: http://<loki-addr>:3100/otlp/v1/logs
 ```
 
 And enable it in `service.pipelines`:
@@ -57,7 +57,7 @@ exporters:
   otlphttp:
     auth:
       authenticator: basicauth/otlp
-    endpoint: http://<loki-addr>:3100/otlp
+    endpoint: http://<loki-addr>:3100/otlp/v1/logs
 
 service:
   extensions: [basicauth/otlp]


### PR DESCRIPTION
**What this PR does / why we need it**:
This PRs fixes some parts of the documentation about the otlp ingestion endpoints. 

The original documentation created on PR #11026 gives a great explanation and how to use it, but it was missing the complete endpoint and it was driving me crazy that I was receiving a 404 when trying to push data from otel collector to loki.

So I found this #12709 and things were clearer and after using this endpoint on my otel collector exporter, it worked like it was supposed to.

I also took the liberty to add in the HTTP API Reference documentation, since it's a good place to also check for all endpoints

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
