### PR TITLE
refactor(blooms): Add queue to bloom planner and enqueue tasks

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -351,6 +351,10 @@ bloom_build:
     # CLI flag: -bloom-build.planner.max-table-offset
     [max_table_offset: <int> | default = 2]
 
+    # Maximum number of tasks to queue per tenant.
+    # CLI flag: -bloom-build.planner.max-tasks-per-tenant
+    [max_queued_tasks_per_tenant: <int> | default = 30000]
+
   builder:
 
 # Experimental: The bloom_gateway block configures the Loki bloom gateway
@@ -3408,6 +3412,11 @@ shard_streams:
 # creation.
 # CLI flag: -bloom-build.split-keyspace-by
 [bloom_split_series_keyspace_by: <int> | default = 256]
+
+# Experimental. Maximum number of builders to use when building blooms. 0 allows
+# unlimited builders.
+# CLI flag: -bloom-build.max-builders
+[bloom_build_max_builders: <int> | default = 0]
 
 # Experimental. Length of the n-grams created when computing blooms from log
 # lines.

--- a/pkg/bloombuild/planner/metrics.go
+++ b/pkg/bloombuild/planner/metrics.go
@@ -1,8 +1,12 @@
 package planner
 
 import (
+	"time"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	"github.com/grafana/loki/v3/pkg/queue"
 )
 
 const (
@@ -16,6 +20,11 @@ const (
 type Metrics struct {
 	running prometheus.Gauge
 
+	// Extra Queue metrics
+	connectedBuilders prometheus.GaugeFunc
+	queueDuration     prometheus.Histogram
+	inflightRequests  prometheus.Summary
+
 	buildStarted   prometheus.Counter
 	buildCompleted *prometheus.CounterVec
 	buildTime      *prometheus.HistogramVec
@@ -23,13 +32,38 @@ type Metrics struct {
 	tenantsDiscovered prometheus.Counter
 }
 
-func NewMetrics(r prometheus.Registerer) *Metrics {
+func NewMetrics(
+	r prometheus.Registerer,
+	getConnectedBuilders func() float64,
+) *Metrics {
 	return &Metrics{
 		running: promauto.With(r).NewGauge(prometheus.GaugeOpts{
 			Namespace: metricsNamespace,
 			Subsystem: metricsSubsystem,
 			Name:      "running",
 			Help:      "Value will be 1 if bloom planner is currently running on this instance",
+		}),
+		connectedBuilders: promauto.With(r).NewGaugeFunc(prometheus.GaugeOpts{
+			Namespace: metricsNamespace,
+			Subsystem: metricsSubsystem,
+			Name:      "connected_builders",
+			Help:      "Number of builders currently connected to the planner.",
+		}, getConnectedBuilders),
+		queueDuration: promauto.With(r).NewHistogram(prometheus.HistogramOpts{
+			Namespace: metricsNamespace,
+			Subsystem: metricsSubsystem,
+			Name:      "queue_duration_seconds",
+			Help:      "Time spend by tasks in queue before getting picked up by a builder.",
+			Buckets:   prometheus.DefBuckets,
+		}),
+		inflightRequests: promauto.With(r).NewSummary(prometheus.SummaryOpts{
+			Namespace:  metricsNamespace,
+			Subsystem:  metricsSubsystem,
+			Name:       "inflight_tasks",
+			Help:       "Number of inflight tasks (either queued or processing) sampled at a regular interval. Quantile buckets keep track of inflight tasks over the last 60s.",
+			Objectives: map[float64]float64{0.5: 0.05, 0.75: 0.02, 0.8: 0.02, 0.9: 0.01, 0.95: 0.01, 0.99: 0.001},
+			MaxAge:     time.Minute,
+			AgeBuckets: 6,
 		}),
 
 		buildStarted: promauto.With(r).NewCounter(prometheus.CounterOpts{
@@ -59,4 +93,8 @@ func NewMetrics(r prometheus.Registerer) *Metrics {
 			Help:      "Number of tenants discovered during the current build iteration",
 		}),
 	}
+}
+
+func NewQueueMetrics(r prometheus.Registerer) *queue.Metrics {
+	return queue.NewMetrics(r, metricsNamespace, metricsSubsystem)
 }

--- a/pkg/bloombuild/planner/task.go
+++ b/pkg/bloombuild/planner/task.go
@@ -1,6 +1,9 @@
 package planner
 
 import (
+	"context"
+	"time"
+
 	v1 "github.com/grafana/loki/v3/pkg/storage/bloom/v1"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/bloomshipper"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb"
@@ -19,4 +22,8 @@ type Task struct {
 	OwnershipBounds v1.FingerprintBounds
 	tsdb            tsdb.SingleTenantTSDBIdentifier
 	gaps            []GapWithBlocks
+
+	// Tracking
+	queueTime time.Time
+	ctx       context.Context
 }

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -207,6 +207,7 @@ type Limits struct {
 
 	BloomCreationEnabled       bool `yaml:"bloom_creation_enabled" json:"bloom_creation_enabled" category:"experimental"`
 	BloomSplitSeriesKeyspaceBy int  `yaml:"bloom_split_series_keyspace_by" json:"bloom_split_series_keyspace_by" category:"experimental"`
+	BloomBuildMaxBuilders      int  `yaml:"bloom_build_max_builders" json:"bloom_build_max_builders" category:"experimental"`
 
 	BloomNGramLength       int     `yaml:"bloom_ngram_length" json:"bloom_ngram_length" category:"experimental"`
 	BloomNGramSkip         int     `yaml:"bloom_ngram_skip" json:"bloom_ngram_skip" category:"experimental"`
@@ -385,6 +386,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 
 	f.BoolVar(&l.BloomCreationEnabled, "bloom-build.enable", false, "Experimental. Whether to create blooms for the tenant.")
 	f.IntVar(&l.BloomSplitSeriesKeyspaceBy, "bloom-build.split-keyspace-by", 256, "Experimental. Number of splits to create for the series keyspace when building blooms. The series keyspace is split into this many parts to parallelize bloom creation.")
+	f.IntVar(&l.BloomBuildMaxBuilders, "bloom-build.max-builders", 0, "Experimental. Maximum number of builders to use when building blooms. 0 allows unlimited builders.")
 
 	_ = l.BloomCompactorMaxBloomSize.Set(defaultBloomCompactorMaxBloomSize)
 	f.Var(&l.BloomCompactorMaxBloomSize, "bloom-compactor.max-bloom-size",
@@ -985,6 +987,10 @@ func (o *Overrides) BloomCreationEnabled(userID string) bool {
 
 func (o *Overrides) BloomSplitSeriesKeyspaceBy(userID string) int {
 	return o.getOverridesForUser(userID).BloomSplitSeriesKeyspaceBy
+}
+
+func (o *Overrides) BloomBuildMaxBuilders(userID string) int {
+	return o.getOverridesForUser(userID).BloomBuildMaxBuilders
 }
 
 func (o *Overrides) BloomNGramLength(userID string) int {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR:
- Adds a queue to the bloom planner as well as enqueue tasks.
- Expose new metrics to track the state of the queue.

Tested it locally. Looks like tasks are enqueued successfully:

```
level=info ts=2024-05-21T14:10:42.128586309Z caller=planner.go:182 component=bloom-planner msg="planning completed" tasks=256
```
![image](https://github.com/grafana/loki/assets/8354290/12590549-af6f-4c10-9276-bdf52ce5c834)


**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
