### PR TITLE
feat: new stream count limiter

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -2974,6 +2974,11 @@ The `limits_config` block configures global and per-tenant limits in Loki. The v
 # CLI flag: -validation.discover-log-levels
 [discover_log_levels: <boolean> | default = true]
 
+# When true, the ingester takes into account only the streams that belongs to
+# this instance according to the ring while applying the stream limit.
+# CLI flag: -ingester.use-owned-stream-count
+[use_owned_stream_count: <boolean> | default = false]
+
 # Maximum number of active streams per user, per ingester. 0 to disable.
 # CLI flag: -ingester.max-streams-per-user
 [max_streams_per_user: <int> | default = 0]

--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -2974,8 +2974,8 @@ The `limits_config` block configures global and per-tenant limits in Loki. The v
 # CLI flag: -validation.discover-log-levels
 [discover_log_levels: <boolean> | default = true]
 
-# When true, the ingester takes into account only the streams that belongs to
-# this instance according to the ring while applying the stream limit.
+# When true an ingester takes into account only the streams that it owns
+# according to the ring while applying the stream limit.
 # CLI flag: -ingester.use-owned-stream-count
 [use_owned_stream_count: <boolean> | default = false]
 

--- a/pkg/ingester/instance.go
+++ b/pkg/ingester/instance.go
@@ -104,7 +104,10 @@ type instance struct {
 	tailers   map[uint32]*tailer
 	tailerMtx sync.RWMutex
 
-	limiter *Limiter
+	limiter            *Limiter
+	streamCountLimiter *streamCountLimiter
+	ownedStreamsSvc    *ownedStreamService
+
 	configs *runtime.TenantConfigs
 
 	wal WAL
@@ -147,11 +150,12 @@ func newInstance(
 	if err != nil {
 		return nil, err
 	}
-
+	streams := newStreamsMap()
+	ownedStreamsSvc := newOwnedStreamService(instanceID, limiter)
 	c := config.SchemaConfig{Configs: periodConfigs}
 	i := &instance{
 		cfg:        cfg,
-		streams:    newStreamsMap(),
+		streams:    streams,
 		buf:        make([]byte, 0, 1024),
 		index:      invertedIndex,
 		instanceID: instanceID,
@@ -159,9 +163,11 @@ func newInstance(
 		streamsCreatedTotal: streamsCreatedTotal.WithLabelValues(instanceID),
 		streamsRemovedTotal: streamsRemovedTotal.WithLabelValues(instanceID),
 
-		tailers: map[uint32]*tailer{},
-		limiter: limiter,
-		configs: configs,
+		tailers:            map[uint32]*tailer{},
+		limiter:            limiter,
+		streamCountLimiter: newStreamCountLimiter(instanceID, streams.Len, limiter, ownedStreamsSvc),
+		ownedStreamsSvc:    ownedStreamsSvc,
+		configs:            configs,
 
 		wal:                   wal,
 		metrics:               metrics,
@@ -286,29 +292,11 @@ func (i *instance) createStream(ctx context.Context, pushReqStream logproto.Stre
 	}
 
 	if record != nil {
-		err = i.limiter.AssertMaxStreamsPerUser(i.instanceID, i.streams.Len())
+		err = i.streamCountLimiter.AssertNewStreamAllowed(i.instanceID)
 	}
 
 	if err != nil {
-		if i.configs.LogStreamCreation(i.instanceID) {
-			level.Debug(util_log.Logger).Log(
-				"msg", "failed to create stream, exceeded limit",
-				"org_id", i.instanceID,
-				"err", err,
-				"stream", pushReqStream.Labels,
-			)
-		}
-
-		validation.DiscardedSamples.WithLabelValues(validation.StreamLimit, i.instanceID).Add(float64(len(pushReqStream.Entries)))
-		bytes := 0
-		for _, e := range pushReqStream.Entries {
-			bytes += len(e.Line)
-		}
-		validation.DiscardedBytes.WithLabelValues(validation.StreamLimit, i.instanceID).Add(float64(bytes))
-		if i.customStreamsTracker != nil {
-			i.customStreamsTracker.DiscardedBytesAdd(ctx, i.instanceID, validation.StreamLimit, labels, float64(bytes))
-		}
-		return nil, httpgrpc.Errorf(http.StatusTooManyRequests, validation.StreamLimitErrorMsg, labels, i.instanceID)
+		return i.onStreamCreationError(ctx, pushReqStream, err, labels)
 	}
 
 	fp := i.getHashForLabels(labels)
@@ -333,21 +321,47 @@ func (i *instance) createStream(ctx context.Context, pushReqStream logproto.Stre
 		i.metrics.recoveredStreamsTotal.Inc()
 	}
 
+	i.onStreamCreated(s)
+
+	return s, nil
+}
+
+func (i *instance) onStreamCreationError(ctx context.Context, pushReqStream logproto.Stream, err error, labels labels.Labels) (*stream, error) {
+	if i.configs.LogStreamCreation(i.instanceID) {
+		level.Debug(util_log.Logger).Log(
+			"msg", "failed to create stream, exceeded limit",
+			"org_id", i.instanceID,
+			"err", err,
+			"stream", pushReqStream.Labels,
+		)
+	}
+
+	validation.DiscardedSamples.WithLabelValues(validation.StreamLimit, i.instanceID).Add(float64(len(pushReqStream.Entries)))
+	bytes := 0
+	for _, e := range pushReqStream.Entries {
+		bytes += len(e.Line)
+	}
+	validation.DiscardedBytes.WithLabelValues(validation.StreamLimit, i.instanceID).Add(float64(bytes))
+	if i.customStreamsTracker != nil {
+		i.customStreamsTracker.DiscardedBytesAdd(ctx, i.instanceID, validation.StreamLimit, labels, float64(bytes))
+	}
+	return nil, httpgrpc.Errorf(http.StatusTooManyRequests, validation.StreamLimitErrorMsg, labels, i.instanceID)
+}
+
+func (i *instance) onStreamCreated(s *stream) {
 	memoryStreams.WithLabelValues(i.instanceID).Inc()
 	memoryStreamsLabelsBytes.Add(float64(len(s.labels.String())))
 	i.streamsCreatedTotal.Inc()
 	i.addTailersToNewStream(s)
 	streamsCountStats.Add(1)
-
+	i.ownedStreamsSvc.incOwnedStreamCount()
 	if i.configs.LogStreamCreation(i.instanceID) {
 		level.Debug(util_log.Logger).Log(
 			"msg", "successfully created stream",
 			"org_id", i.instanceID,
-			"stream", pushReqStream.Labels,
+			"stream", s.labels.String(),
 		)
 	}
-
-	return s, nil
 }
 
 func (i *instance) createStreamByFP(ls labels.Labels, fp model.Fingerprint) (*stream, error) {
@@ -407,6 +421,7 @@ func (i *instance) removeStream(s *stream) {
 		memoryStreams.WithLabelValues(i.instanceID).Dec()
 		memoryStreamsLabelsBytes.Sub(float64(len(s.labels.String())))
 		streamsCountStats.Add(-1)
+		i.ownedStreamsSvc.decOwnedStreamCount()
 	}
 }
 

--- a/pkg/ingester/owned_streams.go
+++ b/pkg/ingester/owned_streams.go
@@ -1,0 +1,44 @@
+package ingester
+
+import "go.uber.org/atomic"
+
+type ownedStreamService struct {
+	tenantID   string
+	limiter    *Limiter
+	fixedLimit *atomic.Int32
+
+	//todo: implement job to recalculate it
+	ownedStreamCount *atomic.Int64
+}
+
+func newOwnedStreamService(tenantID string, limiter *Limiter) *ownedStreamService {
+	svc := &ownedStreamService{
+		tenantID:         tenantID,
+		limiter:          limiter,
+		ownedStreamCount: atomic.NewInt64(0),
+		fixedLimit:       atomic.NewInt32(0),
+	}
+	svc.updateFixedLimit()
+	return svc
+}
+
+func (s *ownedStreamService) getOwnedStreamCount() int {
+	return int(s.ownedStreamCount.Load())
+}
+
+func (s *ownedStreamService) updateFixedLimit() {
+	limit, _, _, _ := s.limiter.GetStreamCountLimit(s.tenantID)
+	s.fixedLimit.Store(int32(limit))
+}
+
+func (s *ownedStreamService) getFixedLimit() int {
+	return int(s.fixedLimit.Load())
+}
+
+func (s *ownedStreamService) incOwnedStreamCount() {
+	s.ownedStreamCount.Inc()
+}
+
+func (s *ownedStreamService) decOwnedStreamCount() {
+	s.ownedStreamCount.Dec()
+}

--- a/pkg/ingester/owned_streams_test.go
+++ b/pkg/ingester/owned_streams_test.go
@@ -3,8 +3,9 @@ package ingester
 import (
 	"testing"
 
-	"github.com/grafana/loki/v3/pkg/validation"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/validation"
 )
 
 func Test_OwnedStreamService(t *testing.T) {

--- a/pkg/ingester/owned_streams_test.go
+++ b/pkg/ingester/owned_streams_test.go
@@ -1,0 +1,35 @@
+package ingester
+
+import (
+	"testing"
+
+	"github.com/grafana/loki/v3/pkg/validation"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_OwnedStreamService(t *testing.T) {
+	limits, err := validation.NewOverrides(validation.Limits{
+		MaxGlobalStreamsPerUser: 100,
+	}, nil)
+	require.NoError(t, err)
+	// Mock the ring
+	ring := &ringCountMock{count: 30}
+	limiter := NewLimiter(limits, NilMetrics, ring, 3)
+
+	service := newOwnedStreamService("test", limiter)
+	require.Equal(t, 0, service.getOwnedStreamCount())
+	require.Equal(t, 10, service.getFixedLimit(), "fixed limit must be initialised during the instantiation")
+
+	limits.DefaultLimits().MaxGlobalStreamsPerUser = 1000
+	require.Equal(t, 10, service.getFixedLimit(), "fixed list must not be changed until update is triggered")
+
+	service.updateFixedLimit()
+	require.Equal(t, 100, service.getFixedLimit())
+
+	service.incOwnedStreamCount()
+	service.incOwnedStreamCount()
+	require.Equal(t, 2, service.getOwnedStreamCount())
+
+	service.decOwnedStreamCount()
+	require.Equal(t, 1, service.getOwnedStreamCount())
+}

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -85,6 +85,7 @@ type Limits struct {
 	DiscoverLogLevels           bool             `yaml:"discover_log_levels" json:"discover_log_levels"`
 
 	// Ingester enforced limits.
+	UseOwnedStreamCount     bool             `yaml:"use_owned_stream_count" json:"use_owned_stream_count"`
 	MaxLocalStreamsPerUser  int              `yaml:"max_streams_per_user" json:"max_streams_per_user"`
 	MaxGlobalStreamsPerUser int              `yaml:"max_global_streams_per_user" json:"max_global_streams_per_user"`
 	UnorderedWrites         bool             `yaml:"unordered_writes" json:"unordered_writes"`
@@ -269,6 +270,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.Var(&l.CreationGracePeriod, "validation.create-grace-period", "Duration which table will be created/deleted before/after it's needed; we won't accept sample from before this time.")
 	f.IntVar(&l.MaxEntriesLimitPerQuery, "validation.max-entries-limit", 5000, "Maximum number of log entries that will be returned for a query.")
 
+	f.BoolVar(&l.UseOwnedStreamCount, "ingester.use-owned-stream-count", false, "When true, the ingester takes into account only the streams that belongs to this instance according to the ring while applying the stream limit.")
 	f.IntVar(&l.MaxLocalStreamsPerUser, "ingester.max-streams-per-user", 0, "Maximum number of active streams per user, per ingester. 0 to disable.")
 	f.IntVar(&l.MaxGlobalStreamsPerUser, "ingester.max-global-streams-per-user", 5000, "Maximum number of active streams per user, across the cluster. 0 to disable. When the global limit is enabled, each ingester is configured with a dynamic local limit based on the replication factor and the current number of healthy ingesters, and is kept updated whenever the number of ingesters change.")
 
@@ -584,6 +586,10 @@ func (o *Overrides) RejectOldSamplesMaxAge(userID string) time.Duration {
 // we should accept samples.
 func (o *Overrides) CreationGracePeriod(userID string) time.Duration {
 	return time.Duration(o.getOverridesForUser(userID).CreationGracePeriod)
+}
+
+func (o *Overrides) UseOwnedStreamCount(userID string) bool {
+	return o.getOverridesForUser(userID).UseOwnedStreamCount
 }
 
 // MaxLocalStreamsPerUser returns the maximum number of streams a user is allowed to store

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -270,7 +270,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.Var(&l.CreationGracePeriod, "validation.create-grace-period", "Duration which table will be created/deleted before/after it's needed; we won't accept sample from before this time.")
 	f.IntVar(&l.MaxEntriesLimitPerQuery, "validation.max-entries-limit", 5000, "Maximum number of log entries that will be returned for a query.")
 
-	f.BoolVar(&l.UseOwnedStreamCount, "ingester.use-owned-stream-count", false, "When true, the ingester takes into account only the streams that belongs to this instance according to the ring while applying the stream limit.")
+	f.BoolVar(&l.UseOwnedStreamCount, "ingester.use-owned-stream-count", false, "When true an ingester takes into account only the streams that it owns according to the ring while applying the stream limit.")
 	f.IntVar(&l.MaxLocalStreamsPerUser, "ingester.max-streams-per-user", 0, "Maximum number of active streams per user, per ingester. 0 to disable.")
 	f.IntVar(&l.MaxGlobalStreamsPerUser, "ingester.max-global-streams-per-user", 5000, "Maximum number of active streams per user, across the cluster. 0 to disable. When the global limit is enabled, each ingester is configured with a dynamic local limit based on the replication factor and the current number of healthy ingesters, and is kept updated whenever the number of ingesters change.")
 


### PR DESCRIPTION
**What this PR does / why we need it**:
implemented a new stream count limiter that uses the values from ownedStreamService if the feature flag is enabled. This functionality is needed to take into account only the owned streams while asserting the limit.


**Special notes for your reviewer**:
- until the feature flag is enabled, these changes should not affect the users
- previously we had a RWLock near the value in the limiter, and that lock was used to disable all the limit while recovering the WAL. However, this lock is not needed because when we replay the WAL we do not assert if we reached the stream count limit: https://github.com/grafana/loki/blob/main/pkg/ingester/instance.go#L288-L290 (record is nil while replaying the WAL). So, I removed this RWLock to simplify the implementation.


**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
