### PR TITLE
fix: Fix panic on requesting out-of-order Pattern samples

### DIFF
--- a/pkg/pattern/drain/chunk.go
+++ b/pkg/pattern/drain/chunk.go
@@ -51,7 +51,7 @@ func (c Chunk) ForRange(start, end, step model.Time) []logproto.PatternSample {
 	}
 	first := c.Samples[0].Timestamp
 	last := c.Samples[len(c.Samples)-1].Timestamp
-	if start >= end || first >= end || last < start {
+	if last < first || start >= end || first >= end || last < start {
 		return nil
 	}
 	var lo int
@@ -114,6 +114,11 @@ func (c *Chunks) Add(ts model.Time) {
 		Timestamp: t,
 		Value:     1,
 	})
+	if len(last.Samples) > 1 && last.Samples[len(last.Samples)-2].Timestamp > t {
+		sort.SliceStable(last.Samples, func(i, j int) bool {
+			return last.Samples[i].Timestamp < last.Samples[j].Timestamp
+		})
+	}
 }
 
 func (c Chunks) Iterator(pattern string, from, through, step model.Time) iter.Iterator {

--- a/pkg/pattern/drain/chunk_test.go
+++ b/pkg/pattern/drain/chunk_test.go
@@ -21,6 +21,10 @@ func TestAdd(t *testing.T) {
 	cks.Add(model.TimeFromUnixNano(time.Hour.Nanoseconds()) + TimeResolution + 1)
 	require.Equal(t, 2, len(cks))
 	require.Equal(t, 1, len(cks[1].Samples))
+	cks.Add(model.TimeFromUnixNano(time.Hour.Nanoseconds()) - TimeResolution)
+	require.Equal(t, 2, len(cks))
+	require.Equal(t, 2, len(cks[1].Samples))
+	require.Lessf(t, cks[1].Samples[0].Timestamp, cks[1].Samples[1].Timestamp, "Samples should be sorted if inserted out of order")
 }
 
 func TestIterator(t *testing.T) {
@@ -52,6 +56,7 @@ func TestForRange(t *testing.T) {
 		c        *Chunk
 		start    model.Time
 		end      model.Time
+		step     model.Time
 		expected []logproto.PatternSample
 	}{
 		{
@@ -179,6 +184,16 @@ func TestForRange(t *testing.T) {
 				{Timestamp: 2, Value: 0},
 				{Timestamp: 4, Value: 10},
 			},
+		},
+		{
+			name: "Out-of-order samples generate nil result",
+			c: &Chunk{Samples: []logproto.PatternSample{
+				{Timestamp: 5, Value: 2},
+				{Timestamp: 3, Value: 2},
+			}},
+			start:    4,
+			end:      6,
+			expected: nil,
 		},
 	}
 

--- a/pkg/pattern/drain/chunk_test.go
+++ b/pkg/pattern/drain/chunk_test.go
@@ -23,8 +23,7 @@ func TestAdd(t *testing.T) {
 	require.Equal(t, 1, len(cks[1].Samples))
 	cks.Add(model.TimeFromUnixNano(time.Hour.Nanoseconds()) - TimeResolution)
 	require.Equal(t, 2, len(cks))
-	require.Equal(t, 2, len(cks[1].Samples))
-	require.Lessf(t, cks[1].Samples[0].Timestamp, cks[1].Samples[1].Timestamp, "Samples should be sorted if inserted out of order")
+	require.Equalf(t, 1, len(cks[1].Samples), "Older samples should not be added if they arrive out of order")
 }
 
 func TestIterator(t *testing.T) {
@@ -192,6 +191,18 @@ func TestForRange(t *testing.T) {
 				{Timestamp: 3, Value: 2},
 			}},
 			start:    4,
+			end:      6,
+			expected: nil,
+		},
+		{
+			name: "Internally out-of-order samples generate nil result",
+			c: &Chunk{Samples: []logproto.PatternSample{
+				{Timestamp: 1, Value: 2},
+				{Timestamp: 5, Value: 2},
+				{Timestamp: 3, Value: 2},
+				{Timestamp: 7, Value: 2},
+			}},
+			start:    2,
 			end:      6,
 			expected: nil,
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a panic that can occur when samples are out-of-order in the Pattern chunks.
This happens because the calculated slice length can be negative if the timestamp at `hi-1` is less than the timestamp at `lo` due to subtracting `currentStep` (generated from timestamp@`lo`) from the timestamp@`hi-1`.
```go
	currentStep := truncateTimestamp(c.Samples[lo].Timestamp, step)
	aggregatedSamples := make([]logproto.PatternSample, 0, ((c.Samples[hi-1].Timestamp-currentStep)/step)+1)
```

**Implementation Notes**
- I opted to return nil if the timestamps are out-of-order which may be incorrect behaviour (but does solve the panic).
- The samples should never be out of order now since I added a sort to the `Add` method.
- An alternative is to simply reject samples that are older than the latest during `Add` - let me know if you prefer this approach.