### PR TITLE
fix: Add value to helm chart to configure single binary service type

### DIFF
--- a/docs/sources/setup/install/helm/reference.md
+++ b/docs/sources/setup/install/helm/reference.md
@@ -10043,6 +10043,14 @@ null
 </td>
 		</tr>
 		<tr>
+			<td>singleBinary.service.type</td>
+			<td>string</td>
+			<td>Type to use for single binary Service</td>
+			<td><pre lang="json">
+"ClusterIP"
+</pre>
+		</tr>
+		<tr>
 			<td>singleBinary.targetModule</td>
 			<td>string</td>
 			<td>Comma-separated list of Loki modules to load for the single binary</td>

--- a/pkg/bloombuild/planner/task.go
+++ b/pkg/bloombuild/planner/task.go
@@ -9,7 +9,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb"
 )
 
-// TODO: Extract this definiton to a proto file at pkg/bloombuild/protos/protos.proto
+// TODO: Extract this definition to a proto file at pkg/bloombuild/protos/protos.proto
 
 type GapWithBlocks struct {
 	bounds v1.FingerprintBounds

--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -16,6 +16,7 @@ Entries should include a reference to the pull request that introduced the chang
 ## 6.6.1
 
 - [BUGFIX] Fix query scheduler http-metrics targetPort
+- [BUGFIX] Added helm chart value `singleBinary.service.type` to allow configuration of the single binary Service type
 
 ## 6.6.0
 
@@ -23,7 +24,7 @@ Entries should include a reference to the pull request that introduced the chang
 
 ## 6.5.2
 
-- [BUGFIX] Fixed Ingress routing for all deployment modes.  
+- [BUGFIX] Fixed Ingress routing for all deployment modes.
 
 ## 6.5.0
 

--- a/production/helm/loki/templates/single-binary/service.yaml
+++ b/production/helm/loki/templates/single-binary/service.yaml
@@ -22,7 +22,7 @@ metadata:
     {{- toYaml . | nindent 4}}
     {{- end }}
 spec:
-  type: ClusterIP
+  type: {{ .Values.singleBinary.service.type }}
   ports:
     - name: http-metrics
       port: {{ .Values.loki.server.http_listen_port }}

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -1244,6 +1244,8 @@ singleBinary:
     annotations: {}
     # -- Additional labels for single binary Service
     labels: {}
+    # -- Type for single binary Service
+    type: ClusterIP
   # -- Comma-separated list of Loki modules to load for the single binary
   targetModule: "all"
   # -- Labels for single binary service


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows the single binary Service type to be configured via values.yaml. In the case of an Ingress that relies on NodePort Services, the Ingress will not be able to reconcile, which can cause problems for other workloads sharing the Ingress group.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
