### PR TITLE
fix: change log level since this is a known case

### DIFF
--- a/pkg/querier/queryrange/limits.go
+++ b/pkg/querier/queryrange/limits.go
@@ -345,7 +345,7 @@ func (q *querySizeLimiter) Do(ctx context.Context, r queryrangebase.Request) (qu
 	// Only support TSDB
 	schemaCfg, err := q.getSchemaCfg(r)
 	if err != nil {
-		level.Error(log).Log("msg", "failed to get schema config, not applying querySizeLimit", "err", err)
+		level.Warn(log).Log("msg", "failed to get schema config, not applying querySizeLimit", "err", err)
 		return q.next.Do(ctx, r)
 	}
 	if schemaCfg.IndexType != types.TSDBType {


### PR DESCRIPTION
**What this PR does / why we need it**:

Change the level of a log message. This can happen when spanning multiple schemas and should not be logged as an error.

**Which issue(s) this PR fixes**:
Fixes #10771