### PR TITLE
fix: not owned stream count

### DIFF
--- a/pkg/ingester/limiter_test.go
+++ b/pkg/ingester/limiter_test.go
@@ -24,7 +24,7 @@ func TestStreamCountLimiter_AssertNewStreamAllowed(t *testing.T) {
 		expected                error
 		useOwnedStreamService   bool
 		fixedLimit              int32
-		ownedStreamCount        int64
+		ownedStreamCount        int
 	}{
 		"both local and global limit are disabled": {
 			maxLocalStreamsPerUser:  0,
@@ -147,7 +147,7 @@ func TestStreamCountLimiter_AssertNewStreamAllowed(t *testing.T) {
 
 			ownedStreamSvc := &ownedStreamService{
 				fixedLimit:       atomic.NewInt32(testData.fixedLimit),
-				ownedStreamCount: atomic.NewInt64(testData.ownedStreamCount),
+				ownedStreamCount: testData.ownedStreamCount,
 			}
 			limiter := NewLimiter(limits, NilMetrics, ring, testData.ringReplicationFactor)
 			defaultCountSupplier := func() int {


### PR DESCRIPTION
**What this PR does / why we need it**:

added an additional field to track the count of not-owned streams count, otherwise when recalculating job updates ownedStreamCount and not-owned streams are actually flushed, and the counter will contain the wrong value because it's decremented every time the stream is flushed.

