### PR TITLE
Documentation: Add composer example + configs for MAC M-series with podman

### DIFF
--- a/examples/getting-started/MAC_M-Series/README.md
+++ b/examples/getting-started/MAC_M-Series/README.md
@@ -1,0 +1,59 @@
+# Getting Started on a MAC M-Series (arm64-based)
+
+- Install 'brew'
+```
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+```
+
+- Install dependencies
+```
+brew install podman
+brew install podman-compose
+brew install git
+```
+
+- Validate installation and binary paths
+```
+podman-compose --version
+```
+
+- Create a Directory that you will map to the podman machine
+```
+mkdir ~/LOKI
+cd ~/LOKI
+```
+
+- Copy the following files from this directory to ~/LOKI:
+
+  * alloy-local-config.yaml
+  * docker-compose.yaml
+  * loki-config.yaml
+
+
+- Build flog as there is no arm-based image
+```
+cd ~/Downloads
+git clone https://github.com/mingrammer/flog.git
+cd flog
+podman machine init -v ~/LOKI:/var/home/core/LOKI
+podman machine start
+podman build -t localhost/mingrammer/flog:latest .
+podman image ls
+cd ~/LOKI
+```
+
+- Bring the infrastructure up
+```
+podman-compose up -d
+sleep 10 && podman ps
+```
+
+- Wait for the indrastructure is up and running and responding with 'ready'
+```
+$ curl http://localhost:3101/ready
+ready
+$ curl http://localhost:3102/ready
+ready
+```
+
+- Open the portal in your favourite browser and follow https://grafana.com/docs/loki/latest/get-started/quick-start/#viewing-your-logs-in-grafana

--- a/examples/getting-started/MAC_M-Series/alloy-local-config.yaml
+++ b/examples/getting-started/MAC_M-Series/alloy-local-config.yaml
@@ -1,0 +1,30 @@
+discovery.docker "flog_scrape" {
+	host             = "unix:///var/run/docker.sock"
+	refresh_interval = "5s"
+}
+
+discovery.relabel "flog_scrape" {
+	targets = []
+
+	rule {
+		source_labels = ["__meta_docker_container_name"]
+		regex         = "/(.*)"
+		target_label  = "container"
+	}
+}
+
+loki.source.docker "flog_scrape" {
+	host             = "unix:///var/run/docker.sock"
+	targets          = discovery.docker.flog_scrape.targets
+	forward_to       = [loki.write.default.receiver]
+	relabel_rules    = discovery.relabel.flog_scrape.rules
+	refresh_interval = "5s"
+}
+
+loki.write "default" {
+	endpoint {
+		url       = "http://gateway:3100/loki/api/v1/push"
+		tenant_id = "tenant1"
+	}
+	external_labels = {}
+}

--- a/examples/getting-started/MAC_M-Series/docker-compose.yaml
+++ b/examples/getting-started/MAC_M-Series/docker-compose.yaml
@@ -1,0 +1,222 @@
+---
+version: "4"
+
+networks:
+  loki:
+
+services:
+  read:
+    image: grafana/loki:latest
+    command: "-config.file=/etc/loki/config.yaml -target=read"
+    container_name: evaluate-loki-read-1
+    ports:
+      - 3101:3100
+      - 7946
+      - 9095
+    volumes:
+      -  /var/home/core/LOKI/loki-config.yaml:/etc/loki/config.yaml:rw,Z
+    depends_on:
+      - minio
+    healthcheck:
+      test: [ "CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:3100/ready || exit 1" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - loki
+
+  write:
+    image: grafana/loki:latest
+    command: "-config.file=/etc/loki/config.yaml -target=write"
+    container_name: evaluate-loki-write-1
+    ports:
+      - 3102:3100
+      - 7946
+      - 9095
+    volumes:
+      -  /var/home/core/LOKI/loki-config.yaml:/etc/loki/config.yaml:rw,Z
+    healthcheck:
+      test: [ "CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:3100/ready || exit 1" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    depends_on:
+      - minio
+    networks:
+      - loki
+
+  alloy:
+    image: grafana/alloy:latest
+    container_name: evaluate-loki-alloy-1
+    security_opt:
+      - "label=disable"
+    volumes:
+      -  /var/home/core/LOKI/alloy-local-config.yaml:/etc/alloy/config.alloy:ro,Z
+      - /var/run/user/503/podman/podman.sock:/var/run/docker.sock:rw,Z
+    command:  run --server.http.listen-addr=0.0.0.0:12345 --storage.path=/var/lib/alloy/data /etc/alloy/config.alloy
+    ports:
+      - 12345:12345
+    depends_on:
+      - gateway
+    networks:
+      - loki
+
+  minio:
+    image: minio/minio
+    container_name: evaluate-loki-minio-1
+    entrypoint:
+      - sh
+      - -euc
+      - |
+        mkdir -p /data/loki-data && \
+        mkdir -p /data/loki-ruler && \
+        minio server /data
+    environment:
+      - MINIO_ROOT_USER=loki
+      - MINIO_ROOT_PASSWORD=supersecret
+      - MINIO_PROMETHEUS_AUTH_TYPE=public
+      - MINIO_UPDATE=off
+    ports:
+      - 9000
+    volumes:
+      - minio_vol:/data
+    healthcheck:
+      test: timeout 5s bash -c ':> /dev/tcp/127.0.0.1/9000' || exit 1
+      interval: 15s
+      timeout: 20s
+      retries: 5
+    networks:
+      - loki
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: evaluate-loki-grafana-1
+    environment:
+      - GF_PATHS_PROVISIONING=/etc/grafana/provisioning
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+    depends_on:
+      - gateway
+    entrypoint:
+      - sh
+      - -euc
+      - |
+        mkdir -p /etc/grafana/provisioning/datasources
+        cat <<EOF > /etc/grafana/provisioning/datasources/ds.yaml
+        apiVersion: 1
+        datasources:
+          - name: Loki
+            type: loki
+            access: proxy
+            url: http://gateway:3100
+            jsonData:
+              httpHeaderName1: "X-Scope-OrgID"
+            secureJsonData:
+              httpHeaderValue1: "tenant1"
+        EOF
+        /run.sh
+    ports:
+      - "3000:3000"
+    healthcheck:
+      test: [ "CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:3000/api/health || exit 1" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - loki
+
+  backend:
+    image: grafana/loki:latest
+    container_name: evaluate-loki-backend-1
+    volumes:
+      -  /var/home/core/LOKI/loki-config.yaml:/etc/loki/config.yaml:rw,Z
+    ports:
+      - "3100"
+      - "7946"
+    command: "-config.file=/etc/loki/config.yaml -target=backend -legacy-read-mode=false"
+    depends_on:
+      - gateway
+    networks:
+      - loki
+
+
+  gateway:
+    image: docker.io/ubuntu/nginx
+    container_name: evaluate-loki-gateway-1
+    depends_on:
+      - read
+      - write
+    entrypoint:
+      - sh
+      - -euc
+      - |
+        cat <<EOF > /etc/nginx/nginx.conf
+        user  nginx;
+        worker_processes  5;  ## Default: 1
+
+        events {
+          worker_connections   1000;
+        }
+
+        http {
+          resolver 10.89.0.1;
+
+          server {
+            listen             3100;
+
+            location = / {
+              return 200 'OK';
+              auth_basic off;
+            }
+
+            location = /api/prom/push {
+              proxy_pass       http://write:3100\$$request_uri;
+            }
+
+            location = /api/prom/tail {
+              proxy_pass       http://read:3100\$$request_uri;
+              proxy_set_header Upgrade \$$http_upgrade;
+              proxy_set_header Connection "upgrade";
+            }
+
+            location ~ /api/prom/.* {
+              proxy_pass       http://read:3100\$$request_uri;
+            }
+
+            location = /loki/api/v1/push {
+              proxy_pass       http://write:3100\$$request_uri;
+            }
+
+            location = /loki/api/v1/tail {
+              proxy_pass       http://read:3100\$$request_uri;
+              proxy_set_header Upgrade \$$http_upgrade;
+              proxy_set_header Connection "upgrade";
+            }
+
+            location ~ /loki/api/.* {
+              proxy_pass       http://read:3100\$$request_uri;
+            }
+          }
+        }
+        EOF
+        /docker-entrypoint.sh nginx -g "daemon off;"
+    ports:
+      - "3100:3100"
+    healthcheck:
+      test: ["CMD", "service", "nginx", "status"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - loki
+
+
+  flog:
+    image: localhost/mingrammer/flog
+    container_name: evaluate-loki-flog-1
+    command: -f json -d 200ms -l
+    networks:
+      - loki
+
+volumes:
+  minio_vol: {}

--- a/examples/getting-started/MAC_M-Series/loki-config.yaml
+++ b/examples/getting-started/MAC_M-Series/loki-config.yaml
@@ -1,0 +1,45 @@
+---
+server:
+  http_listen_address: 0.0.0.0
+  http_listen_port: 3100
+
+memberlist:
+  join_members: ["read.dns.podman", "write.dns.podman", "backend.dns.podman"]
+  dead_node_reclaim_time: 30s
+  gossip_to_dead_nodes_time: 15s
+  left_ingesters_timeout: 30s
+  bind_addr: ['0.0.0.0']
+  bind_port: 7946
+  gossip_interval: 2s
+
+schema_config:
+  configs:
+    - from: 2021-08-01
+      store: tsdb
+      object_store: s3
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+common:
+  path_prefix: /loki
+  replication_factor: 1
+  compactor_address: http://backend:3100
+  storage:
+    s3:
+      endpoint: minio:9000
+      insecure: true
+      bucketnames: loki-data
+      access_key_id: loki
+      secret_access_key: supersecret
+      s3forcepathstyle: true
+  ring:
+    kvstore:
+      store: memberlist
+ruler:
+  storage:
+    s3:
+      bucketnames: loki-ruler
+
+compactor:
+  working_directory: /tmp/compactor


### PR DESCRIPTION
**What this PR does / why we need it**:
- Adds an example (with relevant configs) for running Loki on Mac M-series with podman

**Which issue(s) this PR fixes**:
- There is no issue for that

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
