### PR TITLE
fix(helm): fix imagePullSecrets for statefulset-results-cache

### DIFF
--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -13,6 +13,10 @@ Entries should include a reference to the pull request that introduced the chang
 
 [//]: # (<AUTOMATED_UPDATES_LOCATOR> : do not remove this line. This locator is used by the CI pipeline to automatically create a changelog entry for each new Loki release. Add other chart versions and respective changelog entries bellow this line.)
 
+## 6.7.2
+
+- [BUGFIX] Fix imagePullSecrets for statefulset-results-cache
+
 ## 6.7.1
 
 - [CHANGE] Changed version of Loki to 3.1.0

--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -45,6 +45,10 @@ Entries should include a reference to the pull request that introduced the chang
 
 - [BUGFIX] Fix query-frontend (headless) and ruler http-metrics targetPort
 
+## 6.6.2
+
+- [BUGFIX] Fix imagePullSecrets for statefulset-results-cache
+
 ## 6.6.1
 
 - [BUGFIX] Fix query scheduler http-metrics targetPort

--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -45,10 +45,6 @@ Entries should include a reference to the pull request that introduced the chang
 
 - [BUGFIX] Fix query-frontend (headless) and ruler http-metrics targetPort
 
-## 6.6.2
-
-- [BUGFIX] Fix imagePullSecrets for statefulset-results-cache
-
 ## 6.6.1
 
 - [BUGFIX] Fix query scheduler http-metrics targetPort

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -3,7 +3,7 @@ name: loki
 description: Helm chart for Grafana Loki and Grafana Enterprise Logs supporting both simple, scalable and distributed modes.
 type: application
 appVersion: 3.1.0
-version: 6.7.1
+version: 6.7.2
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -1,6 +1,6 @@
 # loki
 
-![Version: 6.7.1](https://img.shields.io/badge/Version-6.7.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.1.0](https://img.shields.io/badge/AppVersion-3.1.0-informational?style=flat-square)
+![Version: 6.7.2](https://img.shields.io/badge/Version-6.7.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.1.0](https://img.shields.io/badge/AppVersion-3.1.0-informational?style=flat-square)
 
 Helm chart for Grafana Loki and Grafana Enterprise Logs supporting both simple, scalable and distributed modes.
 

--- a/production/helm/loki/templates/memcached/_memcached-statefulset.tpl
+++ b/production/helm/loki/templates/memcached/_memcached-statefulset.tpl
@@ -72,7 +72,7 @@ spec:
       terminationGracePeriodSeconds: {{ .terminationGracePeriodSeconds }}
       {{- if $.ctx.Values.imagePullSecrets }}
       imagePullSecrets:
-      {{- range $.ctx.Values.image.pullSecrets }}
+      {{- range $.ctx.Values.imagePullSecrets }}
         - name: {{ . }}
       {{- end }}
       {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:

If you set the `imagePullSecrets` value, you will encounter an error as helm cannot template the statefulset-results-cache.yaml file :

```
helm template loki grafana/loki --version 6.6.1 --set-json imagePullSecrets='["test"]' --set loki.useTestSchema=true --set loki.storage.bucketNames.chunks=chunks

Error: template: loki/templates/results-cache/statefulset-results-cache.yaml:1:4: executing "loki/templates/results-cache/statefulset-results-cache.yaml" at <include "loki.memcached.statefulSet" (dict "ctx" $ "valuesSection" "resultsCache" "component" "results-cache")>: error calling include: template: loki/templates/memcached/_memcached-statefulset.tpl:75:17: executing "loki.memcached.statefulSet" at <$.ctx.Values.image.pullSecrets>: nil pointer evaluating interface {}.pullSecrets
```

This PR fixes this issue, which appears to be caused by a typo between `$.ctx.Values.imagePullSecrets` and `$.ctx.Values.image.pullSecrets` to match the `values.yaml` file

**Which issue(s) this PR fixes**:
Fixes #12632 

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
