### PR TITLE
refactor(blooms): Build new metas and blocks

### DIFF
--- a/pkg/bloombuild/builder/batch.go
+++ b/pkg/bloombuild/builder/batch.go
@@ -1,0 +1,356 @@
+package builder
+
+import (
+	"context"
+	"io"
+	"math"
+	"time"
+
+	"github.com/grafana/dskit/multierror"
+	"golang.org/x/exp/slices"
+
+	"github.com/grafana/loki/v3/pkg/chunkenc"
+	"github.com/grafana/loki/v3/pkg/logproto"
+	logql_log "github.com/grafana/loki/v3/pkg/logql/log"
+	v1 "github.com/grafana/loki/v3/pkg/storage/bloom/v1"
+	"github.com/grafana/loki/v3/pkg/storage/chunk"
+	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/bloomshipper"
+)
+
+type Fetcher[A, B any] interface {
+	Fetch(ctx context.Context, inputs []A) ([]B, error)
+}
+
+type FetchFunc[A, B any] func(ctx context.Context, inputs []A) ([]B, error)
+
+func (f FetchFunc[A, B]) Fetch(ctx context.Context, inputs []A) ([]B, error) {
+	return f(ctx, inputs)
+}
+
+// batchedLoader implements `v1.Iterator[C]` in batches
+type batchedLoader[A, B, C any] struct {
+	metrics   *Metrics
+	batchSize int
+	ctx       context.Context
+	fetchers  []Fetcher[A, B]
+	work      [][]A
+
+	mapper func(B) (C, error)
+	cur    C
+	batch  []B
+	err    error
+}
+
+const batchedLoaderDefaultBatchSize = 50
+
+func newBatchedLoader[A, B, C any](
+	ctx context.Context,
+	fetchers []Fetcher[A, B],
+	inputs [][]A,
+	mapper func(B) (C, error),
+	batchSize int,
+) *batchedLoader[A, B, C] {
+	return &batchedLoader[A, B, C]{
+		batchSize: max(batchSize, 1),
+		ctx:       ctx,
+		fetchers:  fetchers,
+		work:      inputs,
+		mapper:    mapper,
+	}
+}
+
+func (b *batchedLoader[A, B, C]) Next() bool {
+
+	// iterate work until we have non-zero length batch
+	for len(b.batch) == 0 {
+
+		// empty batch + no work remaining = we're done
+		if len(b.work) == 0 {
+			return false
+		}
+
+		// setup next batch
+		next := b.work[0]
+		batchSize := min(b.batchSize, len(next))
+		toFetch := next[:batchSize]
+		fetcher := b.fetchers[0]
+
+		// update work
+		b.work[0] = b.work[0][batchSize:]
+		if len(b.work[0]) == 0 {
+			// if we've exhausted work from this set of inputs,
+			// set pointer to next set of inputs
+			// and their respective fetcher
+			b.work = b.work[1:]
+			b.fetchers = b.fetchers[1:]
+		}
+
+		// there was no work in this batch; continue (should not happen)
+		if len(toFetch) == 0 {
+			continue
+		}
+
+		b.batch, b.err = fetcher.Fetch(b.ctx, toFetch)
+		// error fetching, short-circuit iteration
+		if b.err != nil {
+			return false
+		}
+	}
+
+	return b.prepNext()
+}
+
+func (b *batchedLoader[_, B, C]) prepNext() bool {
+	b.cur, b.err = b.mapper(b.batch[0])
+	b.batch = b.batch[1:]
+	return b.err == nil
+}
+
+func (b *batchedLoader[_, _, C]) At() C {
+	return b.cur
+}
+
+func (b *batchedLoader[_, _, _]) Err() error {
+	return b.err
+}
+
+// to ensure memory is bounded while loading chunks
+// TODO(owen-d): testware
+func newBatchedChunkLoader(
+	ctx context.Context,
+	fetchers []Fetcher[chunk.Chunk, chunk.Chunk],
+	inputs [][]chunk.Chunk,
+	metrics *Metrics,
+	batchSize int,
+) *batchedLoader[chunk.Chunk, chunk.Chunk, v1.ChunkRefWithIter] {
+
+	mapper := func(c chunk.Chunk) (v1.ChunkRefWithIter, error) {
+		chk := c.Data.(*chunkenc.Facade).LokiChunk()
+		metrics.chunkSize.Observe(float64(chk.UncompressedSize()))
+		itr, err := chk.Iterator(
+			ctx,
+			time.Unix(0, 0),
+			time.Unix(0, math.MaxInt64),
+			logproto.FORWARD,
+			logql_log.NewNoopPipeline().ForStream(nil),
+		)
+
+		if err != nil {
+			return v1.ChunkRefWithIter{}, err
+		}
+
+		return v1.ChunkRefWithIter{
+			Ref: v1.ChunkRef{
+				From:     c.From,
+				Through:  c.Through,
+				Checksum: c.Checksum,
+			},
+			Itr: itr,
+		}, nil
+	}
+	return newBatchedLoader(ctx, fetchers, inputs, mapper, batchSize)
+}
+
+func newBatchedBlockLoader(
+	ctx context.Context,
+	fetcher Fetcher[bloomshipper.BlockRef, *bloomshipper.CloseableBlockQuerier],
+	blocks []bloomshipper.BlockRef,
+	batchSize int,
+) *batchedLoader[bloomshipper.BlockRef, *bloomshipper.CloseableBlockQuerier, *bloomshipper.CloseableBlockQuerier] {
+
+	fetchers := []Fetcher[bloomshipper.BlockRef, *bloomshipper.CloseableBlockQuerier]{fetcher}
+	inputs := [][]bloomshipper.BlockRef{blocks}
+	mapper := func(a *bloomshipper.CloseableBlockQuerier) (*bloomshipper.CloseableBlockQuerier, error) {
+		return a, nil
+	}
+
+	return newBatchedLoader(ctx, fetchers, inputs, mapper, batchSize)
+}
+
+// compiler checks
+var _ v1.Iterator[*v1.SeriesWithBloom] = &blockLoadingIter{}
+var _ v1.CloseableIterator[*v1.SeriesWithBloom] = &blockLoadingIter{}
+var _ v1.ResettableIterator[*v1.SeriesWithBloom] = &blockLoadingIter{}
+
+// TODO(chaudum): testware
+func newBlockLoadingIter(ctx context.Context, blocks []bloomshipper.BlockRef, fetcher FetchFunc[bloomshipper.BlockRef, *bloomshipper.CloseableBlockQuerier], batchSize int) *blockLoadingIter {
+
+	return &blockLoadingIter{
+		ctx:       ctx,
+		fetcher:   fetcher,
+		inputs:    blocks,
+		batchSize: batchSize,
+		loaded:    make(map[io.Closer]struct{}),
+	}
+}
+
+type blockLoadingIter struct {
+	// constructor arguments
+	ctx         context.Context
+	fetcher     Fetcher[bloomshipper.BlockRef, *bloomshipper.CloseableBlockQuerier]
+	inputs      []bloomshipper.BlockRef
+	overlapping v1.Iterator[[]bloomshipper.BlockRef]
+	batchSize   int
+	// optional arguments
+	filter func(*bloomshipper.CloseableBlockQuerier) bool
+	// internals
+	initialized bool
+	err         error
+	iter        v1.Iterator[*v1.SeriesWithBloom]
+	loader      *batchedLoader[bloomshipper.BlockRef, *bloomshipper.CloseableBlockQuerier, *bloomshipper.CloseableBlockQuerier]
+	loaded      map[io.Closer]struct{}
+}
+
+// At implements v1.Iterator.
+func (i *blockLoadingIter) At() *v1.SeriesWithBloom {
+	if !i.initialized {
+		panic("iterator not initialized")
+	}
+	return i.iter.At()
+}
+
+// Err implements v1.Iterator.
+func (i *blockLoadingIter) Err() error {
+	if !i.initialized {
+		panic("iterator not initialized")
+	}
+	if i.err != nil {
+		return i.err
+	}
+	return i.iter.Err()
+}
+
+func (i *blockLoadingIter) init() {
+	if i.initialized {
+		return
+	}
+
+	// group overlapping blocks
+	i.overlapping = overlappingBlocksIter(i.inputs)
+
+	// set initial iter
+	i.iter = v1.NewEmptyIter[*v1.SeriesWithBloom]()
+
+	// set "match all" filter function if not present
+	if i.filter == nil {
+		i.filter = func(cbq *bloomshipper.CloseableBlockQuerier) bool { return true }
+	}
+
+	// done
+	i.initialized = true
+}
+
+// load next populates the underlying iter via relevant batches
+// and returns the result of iter.Next()
+func (i *blockLoadingIter) loadNext() bool {
+	for i.overlapping.Next() {
+		blockRefs := i.overlapping.At()
+
+		loader := newBatchedBlockLoader(i.ctx, i.fetcher, blockRefs, i.batchSize)
+		filtered := v1.NewFilterIter[*bloomshipper.CloseableBlockQuerier](loader, i.filter)
+
+		iters := make([]v1.PeekingIterator[*v1.SeriesWithBloom], 0, len(blockRefs))
+		for filtered.Next() {
+			bq := filtered.At()
+			i.loaded[bq] = struct{}{}
+			iter, err := bq.SeriesIter()
+			if err != nil {
+				i.err = err
+				i.iter = v1.NewEmptyIter[*v1.SeriesWithBloom]()
+				return false
+			}
+			iters = append(iters, iter)
+		}
+
+		if err := filtered.Err(); err != nil {
+			i.err = err
+			i.iter = v1.NewEmptyIter[*v1.SeriesWithBloom]()
+			return false
+		}
+
+		// edge case: we've filtered out all blocks in the batch; check next batch
+		if len(iters) == 0 {
+			continue
+		}
+
+		// Turn the list of blocks into a single iterator that returns the next series
+		mergedBlocks := v1.NewHeapIterForSeriesWithBloom(iters...)
+		// two overlapping blocks can conceivably have the same series, so we need to dedupe,
+		// preferring the one with the most chunks already indexed since we'll have
+		// to add fewer chunks to the bloom
+		i.iter = v1.NewDedupingIter[*v1.SeriesWithBloom, *v1.SeriesWithBloom](
+			func(a, b *v1.SeriesWithBloom) bool {
+				return a.Series.Fingerprint == b.Series.Fingerprint
+			},
+			v1.Identity[*v1.SeriesWithBloom],
+			func(a, b *v1.SeriesWithBloom) *v1.SeriesWithBloom {
+				if len(a.Series.Chunks) > len(b.Series.Chunks) {
+					return a
+				}
+				return b
+			},
+			v1.NewPeekingIter(mergedBlocks),
+		)
+		return i.iter.Next()
+	}
+
+	i.iter = v1.NewEmptyIter[*v1.SeriesWithBloom]()
+	i.err = i.overlapping.Err()
+	return false
+}
+
+// Next implements v1.Iterator.
+func (i *blockLoadingIter) Next() bool {
+	i.init()
+	return i.iter.Next() || i.loadNext()
+}
+
+// Close implements v1.CloseableIterator.
+func (i *blockLoadingIter) Close() error {
+	var err multierror.MultiError
+	for k := range i.loaded {
+		err.Add(k.Close())
+	}
+	return err.Err()
+}
+
+// Reset implements v1.ResettableIterator.
+// TODO(chaudum) Cache already fetched blocks to to avoid the overhead of
+// creating the reader.
+func (i *blockLoadingIter) Reset() error {
+	if !i.initialized {
+		return nil
+	}
+	// close loaded queriers
+	err := i.Close()
+	i.initialized = false
+	clear(i.loaded)
+	return err
+}
+
+func (i *blockLoadingIter) Filter(filter func(*bloomshipper.CloseableBlockQuerier) bool) {
+	if i.initialized {
+		panic("iterator already initialized")
+	}
+	i.filter = filter
+}
+
+func overlappingBlocksIter(inputs []bloomshipper.BlockRef) v1.Iterator[[]bloomshipper.BlockRef] {
+	// can we assume sorted blocks?
+	peekIter := v1.NewPeekingIter(v1.NewSliceIter(inputs))
+
+	return v1.NewDedupingIter[bloomshipper.BlockRef, []bloomshipper.BlockRef](
+		func(a bloomshipper.BlockRef, b []bloomshipper.BlockRef) bool {
+			minFp := b[0].Bounds.Min
+			maxFp := slices.MaxFunc(b, func(a, b bloomshipper.BlockRef) int { return int(a.Bounds.Max - b.Bounds.Max) }).Bounds.Max
+			return a.Bounds.Overlaps(v1.NewBounds(minFp, maxFp))
+		},
+		func(a bloomshipper.BlockRef) []bloomshipper.BlockRef {
+			return []bloomshipper.BlockRef{a}
+		},
+		func(a bloomshipper.BlockRef, b []bloomshipper.BlockRef) []bloomshipper.BlockRef {
+			return append(b, a)
+		},
+		peekIter,
+	)
+}

--- a/pkg/bloombuild/builder/batch_test.go
+++ b/pkg/bloombuild/builder/batch_test.go
@@ -1,0 +1,210 @@
+package builder
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	v1 "github.com/grafana/loki/v3/pkg/storage/bloom/v1"
+	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/bloomshipper"
+)
+
+func TestBatchedLoader(t *testing.T) {
+	t.Parallel()
+
+	errMapper := func(i int) (int, error) {
+		return 0, errors.New("bzzt")
+	}
+	successMapper := func(i int) (int, error) {
+		return i, nil
+	}
+
+	expired, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	for _, tc := range []struct {
+		desc      string
+		ctx       context.Context
+		batchSize int
+		mapper    func(int) (int, error)
+		err       bool
+		inputs    [][]int
+		exp       []int
+	}{
+		{
+			desc:      "OneBatch",
+			ctx:       context.Background(),
+			batchSize: 2,
+			mapper:    successMapper,
+			err:       false,
+			inputs:    [][]int{{0, 1}},
+			exp:       []int{0, 1},
+		},
+		{
+			desc:      "ZeroBatchSizeStillWorks",
+			ctx:       context.Background(),
+			batchSize: 0,
+			mapper:    successMapper,
+			err:       false,
+			inputs:    [][]int{{0, 1}},
+			exp:       []int{0, 1},
+		},
+		{
+			desc:      "OneBatchLessThanFull",
+			ctx:       context.Background(),
+			batchSize: 2,
+			mapper:    successMapper,
+			err:       false,
+			inputs:    [][]int{{0}},
+			exp:       []int{0},
+		},
+		{
+			desc:      "TwoBatches",
+			ctx:       context.Background(),
+			batchSize: 2,
+			mapper:    successMapper,
+			err:       false,
+			inputs:    [][]int{{0, 1, 2, 3}},
+			exp:       []int{0, 1, 2, 3},
+		},
+		{
+			desc:      "MultipleBatchesMultipleLoaders",
+			ctx:       context.Background(),
+			batchSize: 2,
+			mapper:    successMapper,
+			err:       false,
+			inputs:    [][]int{{0, 1}, {2}, {3, 4, 5}},
+			exp:       []int{0, 1, 2, 3, 4, 5},
+		},
+		{
+			desc:      "HandlesEmptyInputs",
+			ctx:       context.Background(),
+			batchSize: 2,
+			mapper:    successMapper,
+			err:       false,
+			inputs:    [][]int{{0, 1, 2, 3}, nil, {4}},
+			exp:       []int{0, 1, 2, 3, 4},
+		},
+		{
+			desc:      "Timeout",
+			ctx:       expired,
+			batchSize: 2,
+			mapper:    successMapper,
+			err:       true,
+			inputs:    [][]int{{0}},
+		},
+		{
+			desc:      "MappingFailure",
+			ctx:       context.Background(),
+			batchSize: 2,
+			mapper:    errMapper,
+			err:       true,
+			inputs:    [][]int{{0}},
+		},
+	} {
+		tc := tc
+		t.Run(tc.desc, func(t *testing.T) {
+			fetchers := make([]Fetcher[int, int], 0, len(tc.inputs))
+			for range tc.inputs {
+				fetchers = append(
+					fetchers,
+					FetchFunc[int, int](func(ctx context.Context, xs []int) ([]int, error) {
+						if ctx.Err() != nil {
+							return nil, ctx.Err()
+						}
+						return xs, nil
+					}),
+				)
+			}
+
+			loader := newBatchedLoader[int, int, int](
+				tc.ctx,
+				fetchers,
+				tc.inputs,
+				tc.mapper,
+				tc.batchSize,
+			)
+
+			got, err := v1.Collect[int](loader)
+			if tc.err {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.exp, got)
+
+		})
+	}
+}
+
+func TestOverlappingBlocksIter(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		desc string
+		inp  []bloomshipper.BlockRef
+		exp  int // expected groups
+	}{
+		{
+			desc: "Empty",
+			inp:  []bloomshipper.BlockRef{},
+			exp:  0,
+		},
+		{
+			desc: "NonOverlapping",
+			inp: []bloomshipper.BlockRef{
+				genBlockRef(0x0000, 0x00ff),
+				genBlockRef(0x0100, 0x01ff),
+				genBlockRef(0x0200, 0x02ff),
+			},
+			exp: 3,
+		},
+		{
+			desc: "AllOverlapping",
+			inp: []bloomshipper.BlockRef{
+				genBlockRef(0x0000, 0x02ff), // |-----------|
+				genBlockRef(0x0100, 0x01ff), //     |---|
+				genBlockRef(0x0200, 0x02ff), //         |---|
+			},
+			exp: 1,
+		},
+		{
+			desc: "PartialOverlapping",
+			inp: []bloomshipper.BlockRef{
+				genBlockRef(0x0000, 0x01ff), // group 1  |-------|
+				genBlockRef(0x0100, 0x02ff), // group 1      |-------|
+				genBlockRef(0x0200, 0x03ff), // group 1          |-------|
+				genBlockRef(0x0200, 0x02ff), // group 1          |---|
+			},
+			exp: 1,
+		},
+		{
+			desc: "PartialOverlapping",
+			inp: []bloomshipper.BlockRef{
+				genBlockRef(0x0000, 0x01ff), // group 1  |-------|
+				genBlockRef(0x0100, 0x02ff), // group 1      |-------|
+				genBlockRef(0x0100, 0x01ff), // group 1      |---|
+				genBlockRef(0x0300, 0x03ff), // group 2              |---|
+				genBlockRef(0x0310, 0x03ff), // group 2                |-|
+			},
+			exp: 2,
+		},
+	} {
+		tc := tc
+		t.Run(tc.desc, func(t *testing.T) {
+			it := overlappingBlocksIter(tc.inp)
+			var overlapping [][]bloomshipper.BlockRef
+			var i int
+			for it.Next() && it.Err() == nil {
+				require.NotNil(t, it.At())
+				overlapping = append(overlapping, it.At())
+				for _, r := range it.At() {
+					t.Log(i, r)
+				}
+				i++
+			}
+			require.Equal(t, tc.exp, len(overlapping))
+		})
+	}
+}

--- a/pkg/bloombuild/builder/builder.go
+++ b/pkg/bloombuild/builder/builder.go
@@ -283,12 +283,7 @@ func (b *Builder) processTask(
 		)
 
 		level.Debug(logger).Log("msg", "generating blocks", "overlapping_blocks", len(gap.Blocks))
-
 		newBlocks := gen.Generate(ctx)
-		if err != nil {
-			level.Error(logger).Log("msg", "failed to generate bloom", "err", err)
-			return nil, fmt.Errorf("failed to generate bloom: %w", err)
-		}
 
 		for newBlocks.Next() && newBlocks.Err() == nil {
 			blockCt++

--- a/pkg/bloombuild/builder/builder.go
+++ b/pkg/bloombuild/builder/builder.go
@@ -1,8 +1,10 @@
 package builder
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/go-kit/log"
@@ -13,7 +15,15 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/grpc"
 
+	"github.com/grafana/loki/v3/pkg/bloombuild/common"
 	"github.com/grafana/loki/v3/pkg/bloombuild/protos"
+	"github.com/grafana/loki/v3/pkg/chunkenc"
+	"github.com/grafana/loki/v3/pkg/storage"
+	v1 "github.com/grafana/loki/v3/pkg/storage/bloom/v1"
+	"github.com/grafana/loki/v3/pkg/storage/config"
+	"github.com/grafana/loki/v3/pkg/storage/stores"
+	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/bloomshipper"
+	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb"
 	utillog "github.com/grafana/loki/v3/pkg/util/log"
 )
 
@@ -23,24 +33,45 @@ type Builder struct {
 	ID string
 
 	cfg     Config
+	limits  Limits
 	metrics *Metrics
 	logger  log.Logger
+
+	tsdbStore   common.TSDBStore
+	bloomStore  bloomshipper.Store
+	chunkLoader ChunkLoader
 
 	client protos.PlannerForBuilderClient
 }
 
 func New(
 	cfg Config,
+	limits Limits,
+	schemaCfg config.SchemaConfig,
+	storeCfg storage.Config,
+	storageMetrics storage.ClientMetrics,
+	fetcherProvider stores.ChunkFetcherProvider,
+	bloomStore bloomshipper.Store,
 	logger log.Logger,
 	r prometheus.Registerer,
 ) (*Builder, error) {
 	utillog.WarnExperimentalUse("Bloom Builder", logger)
 
+	tsdbStore, err := common.NewTSDBStores(schemaCfg, storeCfg, storageMetrics, logger)
+	if err != nil {
+		return nil, fmt.Errorf("error creating TSDB store: %w", err)
+	}
+
+	metrics := NewMetrics(r, v1.NewMetrics(r))
 	b := &Builder{
-		ID:      uuid.NewString(),
-		cfg:     cfg,
-		metrics: NewMetrics(r),
-		logger:  logger,
+		ID:          uuid.NewString(),
+		cfg:         cfg,
+		limits:      limits,
+		metrics:     metrics,
+		tsdbStore:   tsdbStore,
+		bloomStore:  bloomStore,
+		chunkLoader: NewStoreChunkLoader(fetcherProvider, metrics),
+		logger:      logger,
 	}
 
 	b.Service = services.NewBasicService(b.starting, b.running, b.stopping)
@@ -116,7 +147,8 @@ func (b *Builder) builderLoop(c protos.PlannerForBuilder_BuilderLoopClient) erro
 		start := time.Now()
 		status := statusSuccess
 
-		err = b.processTask(c.Context(), protoTask.Task)
+		// TODO: Use the returned created meta refs to delete old metas and blocks
+		_, err = b.processTask(c.Context(), protoTask.Task)
 		if err != nil {
 			status = statusFailure
 			level.Error(b.logger).Log("msg", "failed to process task", "err", err)
@@ -151,15 +183,228 @@ func (b *Builder) notifyTaskCompletedToPlanner(c protos.PlannerForBuilder_Builde
 	return nil
 }
 
-func (b *Builder) processTask(_ context.Context, protoTask *protos.ProtoTask) error {
+// processTask generates the blooms blocks and metas and uploads them to the object storage.
+// Now that we have the gaps, we will generate a bloom block for each gap.
+// We can accelerate this by using existing blocks which may already contain
+// needed chunks in their blooms, for instance after a new TSDB version is generated
+// but contains many of the same chunk references from the previous version.
+// To do this, we'll need to take the metas we've already resolved and find blocks
+// overlapping the ownership ranges we've identified as needing updates.
+// With these in hand, we can download the old blocks and use them to
+// accelerate bloom generation for the new blocks.
+func (b *Builder) processTask(
+	ctx context.Context,
+	protoTask *protos.ProtoTask,
+) ([]bloomshipper.Meta, error) {
 	task, err := protos.FromProtoTask(protoTask)
 	if err != nil {
-		return fmt.Errorf("failed to convert proto task to task: %w", err)
+		return nil, fmt.Errorf("failed to convert proto task to task: %w", err)
 	}
 
-	level.Debug(b.logger).Log("msg", "received task", "task", task.ID)
+	client, err := b.bloomStore.Client(task.Table.ModelTime())
+	if err != nil {
+		level.Error(b.logger).Log("msg", "failed to get client", "err", err)
+		return nil, fmt.Errorf("failed to get client: %w", err)
+	}
 
-	// TODO: Implement task processing
+	tenant := task.Tenant
+	logger := log.With(
+		b.logger,
+		"tenant", tenant,
+		"task", task.ID,
+		"tsdb", task.TSDB.Name(),
+	)
+	level.Debug(logger).Log("msg", "received task")
 
-	return nil
+	blockEnc, err := chunkenc.ParseEncoding(b.limits.BloomBlockEncoding(task.Tenant))
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse block encoding: %w", err)
+	}
+
+	var (
+		blockCt      int
+		nGramSize    = uint64(b.limits.BloomNGramLength(tenant))
+		nGramSkip    = uint64(b.limits.BloomNGramSkip(tenant))
+		maxBlockSize = uint64(b.limits.BloomCompactorMaxBlockSize(tenant))
+		maxBloomSize = uint64(b.limits.BloomCompactorMaxBloomSize(tenant))
+		blockOpts    = v1.NewBlockOptions(blockEnc, nGramSize, nGramSkip, maxBlockSize, maxBloomSize)
+		created      []bloomshipper.Meta
+		totalSeries  int
+		bytesAdded   int
+	)
+
+	for i := range task.Gaps {
+		gap := task.Gaps[i]
+		logger := log.With(logger, "gap", gap.Bounds.String())
+
+		meta := bloomshipper.Meta{
+			MetaRef: bloomshipper.MetaRef{
+				Ref: bloomshipper.Ref{
+					TenantID:  tenant,
+					TableName: task.Table.Addr(),
+					Bounds:    gap.Bounds,
+				},
+			},
+			Sources: []tsdb.SingleTenantTSDBIdentifier{task.TSDB},
+		}
+
+		// Fetch blocks that aren't up to date but are in the desired fingerprint range
+		// to try and accelerate bloom creation.
+		level.Debug(logger).Log("msg", "loading series and blocks for gap", "blocks", len(gap.Blocks))
+		seriesItr, blocksIter, err := b.loadWorkForGap(ctx, task.Table, tenant, task.TSDB, gap)
+		if err != nil {
+			level.Error(logger).Log("msg", "failed to get series and blocks", "err", err)
+			return nil, fmt.Errorf("failed to get series and blocks: %w", err)
+		}
+
+		// TODO(owen-d): more elegant error handling than sync.OnceFunc
+		closeBlocksIter := sync.OnceFunc(func() {
+			if err := blocksIter.Close(); err != nil {
+				level.Error(logger).Log("msg", "failed to close blocks iterator", "err", err)
+			}
+		})
+		defer closeBlocksIter()
+
+		// Blocks are built consuming the series iterator. For observability, we wrap the series iterator
+		// with a counter iterator to count the number of times Next() is called on it.
+		// This is used to observe the number of series that are being processed.
+		seriesItrWithCounter := v1.NewCounterIter[*v1.Series](seriesItr)
+
+		gen := NewSimpleBloomGenerator(
+			tenant,
+			blockOpts,
+			seriesItrWithCounter,
+			b.chunkLoader,
+			blocksIter,
+			b.rwFn,
+			nil, // TODO(salvacorts): Pass reporter or remove when we address tracking
+			b.metrics,
+			logger,
+		)
+
+		level.Debug(logger).Log("msg", "generating blocks", "overlapping_blocks", len(gap.Blocks))
+
+		newBlocks := gen.Generate(ctx)
+		if err != nil {
+			level.Error(logger).Log("msg", "failed to generate bloom", "err", err)
+			return nil, fmt.Errorf("failed to generate bloom: %w", err)
+		}
+
+		for newBlocks.Next() && newBlocks.Err() == nil {
+			blockCt++
+			blk := newBlocks.At()
+
+			built, err := bloomshipper.BlockFrom(tenant, task.Table.Addr(), blk)
+			if err != nil {
+				level.Error(logger).Log("msg", "failed to build block", "err", err)
+				return nil, fmt.Errorf("failed to build block: %w", err)
+			}
+
+			logger := log.With(logger, "block", built.BlockRef.String())
+
+			if err := client.PutBlock(
+				ctx,
+				built,
+			); err != nil {
+				level.Error(logger).Log("msg", "failed to write block", "err", err)
+				return nil, fmt.Errorf("failed to write block: %w", err)
+			}
+			b.metrics.blocksCreated.Inc()
+
+			totalGapKeyspace := gap.Bounds.Max - gap.Bounds.Min
+			progress := built.Bounds.Max - gap.Bounds.Min
+			pct := float64(progress) / float64(totalGapKeyspace) * 100
+			level.Debug(logger).Log("msg", "uploaded block", "progress_pct", fmt.Sprintf("%.2f", pct))
+
+			meta.Blocks = append(meta.Blocks, built.BlockRef)
+		}
+
+		if err := newBlocks.Err(); err != nil {
+			level.Error(logger).Log("msg", "failed to generate bloom", "err", err)
+			return nil, fmt.Errorf("failed to generate bloom: %w", err)
+		}
+
+		closeBlocksIter()
+		bytesAdded += newBlocks.Bytes()
+		totalSeries += seriesItrWithCounter.Count()
+		b.metrics.blocksReused.Add(float64(len(gap.Blocks)))
+
+		// Write the new meta
+		// TODO(owen-d): put total size in log, total time in metrics+log
+		ref, err := bloomshipper.MetaRefFrom(tenant, task.Table.Addr(), gap.Bounds, meta.Sources, meta.Blocks)
+		if err != nil {
+			level.Error(logger).Log("msg", "failed to checksum meta", "err", err)
+			return nil, fmt.Errorf("failed to checksum meta: %w", err)
+		}
+		meta.MetaRef = ref
+
+		logger = log.With(logger, "meta", meta.MetaRef.String())
+
+		if err := client.PutMeta(ctx, meta); err != nil {
+			level.Error(logger).Log("msg", "failed to write meta", "err", err)
+			return nil, fmt.Errorf("failed to write meta: %w", err)
+		}
+
+		b.metrics.metasCreated.Inc()
+		level.Debug(logger).Log("msg", "uploaded meta")
+		created = append(created, meta)
+	}
+
+	b.metrics.seriesPerTask.Observe(float64(totalSeries))
+	b.metrics.bytesPerTask.Observe(float64(bytesAdded))
+	level.Debug(logger).Log(
+		"msg", "finished bloom generation",
+		"blocks", blockCt,
+		"series", totalSeries,
+		"bytes_added", bytesAdded,
+	)
+
+	return created, nil
+}
+
+func (b *Builder) loadWorkForGap(
+	ctx context.Context,
+	table config.DayTable,
+	tenant string,
+	id tsdb.Identifier,
+	gap protos.GapWithBlocks,
+) (v1.Iterator[*v1.Series], v1.CloseableResettableIterator[*v1.SeriesWithBloom], error) {
+	// load a series iterator for the gap
+	seriesItr, err := b.tsdbStore.LoadTSDB(ctx, table, tenant, id, gap.Bounds)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "failed to load tsdb")
+	}
+
+	// load a blocks iterator for the gap
+	fetcher, err := b.bloomStore.Fetcher(table.ModelTime())
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "failed to get fetcher")
+	}
+
+	// NB(owen-d): we filter out nil blocks here to avoid panics in the bloom generator since the fetcher
+	// input->output length and indexing in its contract
+	// NB(chaudum): Do we want to fetch in strict mode and fail instead?
+	f := FetchFunc[bloomshipper.BlockRef, *bloomshipper.CloseableBlockQuerier](func(ctx context.Context, refs []bloomshipper.BlockRef) ([]*bloomshipper.CloseableBlockQuerier, error) {
+		blks, err := fetcher.FetchBlocks(ctx, refs, bloomshipper.WithFetchAsync(false), bloomshipper.WithIgnoreNotFound(true))
+		if err != nil {
+			return nil, err
+		}
+		exists := make([]*bloomshipper.CloseableBlockQuerier, 0, len(blks))
+		for _, blk := range blks {
+			if blk != nil {
+				exists = append(exists, blk)
+			}
+		}
+		return exists, nil
+	})
+	blocksIter := newBlockLoadingIter(ctx, gap.Blocks, f, 10)
+
+	return seriesItr, blocksIter, nil
+}
+
+// TODO(owen-d): pool, evaluate if memory-only is the best choice
+func (b *Builder) rwFn() (v1.BlockWriter, v1.BlockReader) {
+	indexBuf := bytes.NewBuffer(nil)
+	bloomsBuf := bytes.NewBuffer(nil)
+	return v1.NewMemoryBlockWriter(indexBuf, bloomsBuf), v1.NewByteReader(indexBuf, bloomsBuf)
 }

--- a/pkg/bloombuild/builder/builder_test.go
+++ b/pkg/bloombuild/builder/builder_test.go
@@ -164,28 +164,23 @@ func (f *fakePlannerServer) NotifyBuilderShutdown(_ context.Context, _ *protos.N
 type fakeLimits struct {
 }
 
-func (f fakeLimits) BloomBlockEncoding(tenantID string) string {
-	//TODO implement me
+func (f fakeLimits) BloomBlockEncoding(_ string) string {
 	panic("implement me")
 }
 
-func (f fakeLimits) BloomNGramLength(tenantID string) int {
-	//TODO implement me
+func (f fakeLimits) BloomNGramLength(_ string) int {
 	panic("implement me")
 }
 
-func (f fakeLimits) BloomNGramSkip(tenantID string) int {
-	//TODO implement me
+func (f fakeLimits) BloomNGramSkip(_ string) int {
 	panic("implement me")
 }
 
-func (f fakeLimits) BloomCompactorMaxBlockSize(tenantID string) int {
-	//TODO implement me
+func (f fakeLimits) BloomCompactorMaxBlockSize(_ string) int {
 	panic("implement me")
 }
 
-func (f fakeLimits) BloomCompactorMaxBloomSize(tenantID string) int {
-	//TODO implement me
+func (f fakeLimits) BloomCompactorMaxBloomSize(_ string) int {
 	panic("implement me")
 }
 

--- a/pkg/bloombuild/builder/config.go
+++ b/pkg/bloombuild/builder/config.go
@@ -32,5 +32,9 @@ func (cfg *Config) Validate() error {
 }
 
 type Limits interface {
-	// TODO: Add limits
+	BloomBlockEncoding(tenantID string) string
+	BloomNGramLength(tenantID string) int
+	BloomNGramSkip(tenantID string) int
+	BloomCompactorMaxBlockSize(tenantID string) int
+	BloomCompactorMaxBloomSize(tenantID string) int
 }

--- a/pkg/bloombuild/builder/spec.go
+++ b/pkg/bloombuild/builder/spec.go
@@ -1,0 +1,321 @@
+package builder
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/pkg/errors"
+	"github.com/prometheus/common/model"
+
+	"github.com/grafana/loki/v3/pkg/logproto"
+	v1 "github.com/grafana/loki/v3/pkg/storage/bloom/v1"
+	"github.com/grafana/loki/v3/pkg/storage/chunk"
+	"github.com/grafana/loki/v3/pkg/storage/chunk/fetcher"
+	"github.com/grafana/loki/v3/pkg/storage/stores"
+	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/bloomshipper"
+	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb"
+)
+
+// inclusive range
+type Keyspace struct {
+	min, max model.Fingerprint
+}
+
+func (k Keyspace) Cmp(other Keyspace) v1.BoundsCheck {
+	if other.max < k.min {
+		return v1.Before
+	} else if other.min > k.max {
+		return v1.After
+	}
+	return v1.Overlap
+}
+
+// Store is likely bound within. This allows specifying impls like ShardedStore<Store>
+// to only request the shard-range needed from the existing store.
+type BloomGenerator interface {
+	Generate(ctx context.Context) (skippedBlocks []v1.BlockMetadata, toClose []io.Closer, results v1.Iterator[*v1.Block], err error)
+}
+
+// Simple implementation of a BloomGenerator.
+type SimpleBloomGenerator struct {
+	userID      string
+	store       v1.Iterator[*v1.Series]
+	chunkLoader ChunkLoader
+	blocksIter  v1.ResettableIterator[*v1.SeriesWithBloom]
+
+	// options to build blocks with
+	opts v1.BlockOptions
+
+	metrics *Metrics
+	logger  log.Logger
+
+	readWriterFn func() (v1.BlockWriter, v1.BlockReader)
+	reporter     func(model.Fingerprint)
+
+	tokenizer *v1.BloomTokenizer
+}
+
+// SimpleBloomGenerator is a foundational implementation of BloomGenerator.
+// It mainly wires up a few different components to generate bloom filters for a set of blocks
+// and handles schema compatibility:
+// Blocks which are incompatible with the schema are skipped and will have their chunks reindexed
+func NewSimpleBloomGenerator(
+	userID string,
+	opts v1.BlockOptions,
+	store v1.Iterator[*v1.Series],
+	chunkLoader ChunkLoader,
+	blocksIter v1.ResettableIterator[*v1.SeriesWithBloom],
+	readWriterFn func() (v1.BlockWriter, v1.BlockReader),
+	reporter func(model.Fingerprint),
+	metrics *Metrics,
+	logger log.Logger,
+) *SimpleBloomGenerator {
+	return &SimpleBloomGenerator{
+		userID:      userID,
+		opts:        opts,
+		store:       store,
+		chunkLoader: chunkLoader,
+		blocksIter:  blocksIter,
+		logger: log.With(
+			logger,
+			"component", "bloom_generator",
+			"org_id", userID,
+		),
+		readWriterFn: readWriterFn,
+		metrics:      metrics,
+		reporter:     reporter,
+
+		tokenizer: v1.NewBloomTokenizer(
+			opts.Schema.NGramLen(),
+			opts.Schema.NGramSkip(),
+			int(opts.UnencodedBlockOptions.MaxBloomSizeBytes),
+			metrics.bloomMetrics,
+		),
+	}
+}
+
+func (s *SimpleBloomGenerator) populator(ctx context.Context) func(series *v1.Series, bloom *v1.Bloom) (int, bool, error) {
+	return func(series *v1.Series, bloom *v1.Bloom) (int, bool, error) {
+		start := time.Now()
+		level.Debug(s.logger).Log(
+			"msg", "populating bloom filter",
+			"stage", "before",
+			"fp", series.Fingerprint,
+			"chunks", len(series.Chunks),
+		)
+		chunkItersWithFP, err := s.chunkLoader.Load(ctx, s.userID, series)
+		if err != nil {
+			return 0, false, errors.Wrapf(err, "failed to load chunks for series: %+v", series)
+		}
+
+		bytesAdded, skip, err := s.tokenizer.Populate(
+			&v1.SeriesWithBloom{
+				Series: series,
+				Bloom:  bloom,
+			},
+			chunkItersWithFP.itr,
+		)
+
+		level.Debug(s.logger).Log(
+			"msg", "populating bloom filter",
+			"stage", "after",
+			"fp", series.Fingerprint,
+			"chunks", len(series.Chunks),
+			"series_bytes", bytesAdded,
+			"duration", time.Since(start),
+			"err", err,
+		)
+
+		if s.reporter != nil {
+			s.reporter(series.Fingerprint)
+		}
+		return bytesAdded, skip, err
+	}
+
+}
+
+func (s *SimpleBloomGenerator) Generate(ctx context.Context) *LazyBlockBuilderIterator {
+	level.Debug(s.logger).Log("msg", "generating bloom filters for blocks", "schema", fmt.Sprintf("%+v", s.opts.Schema))
+
+	series := v1.NewPeekingIter(s.store)
+
+	// TODO: Use interface
+	impl, ok := s.blocksIter.(*blockLoadingIter)
+	if ok {
+		impl.Filter(
+			func(bq *bloomshipper.CloseableBlockQuerier) bool {
+
+				logger := log.With(s.logger, "block", bq.BlockRef)
+				md, err := bq.Metadata()
+				schema := md.Options.Schema
+				if err != nil {
+					level.Warn(logger).Log("msg", "failed to get schema for block", "err", err)
+					bq.Close() // close unused querier
+					return false
+				}
+
+				if !s.opts.Schema.Compatible(schema) {
+					level.Warn(logger).Log("msg", "block schema incompatible with options", "generator_schema", fmt.Sprintf("%+v", s.opts.Schema), "block_schema", fmt.Sprintf("%+v", schema))
+					bq.Close() // close unused querier
+					return false
+				}
+
+				level.Debug(logger).Log("msg", "adding compatible block to bloom generation inputs")
+				return true
+			},
+		)
+	}
+
+	return NewLazyBlockBuilderIterator(ctx, s.opts, s.metrics, s.populator(ctx), s.readWriterFn, series, s.blocksIter)
+}
+
+// LazyBlockBuilderIterator is a lazy iterator over blocks that builds
+// each block by adding series to them until they are full.
+type LazyBlockBuilderIterator struct {
+	ctx          context.Context
+	opts         v1.BlockOptions
+	metrics      *Metrics
+	populate     func(*v1.Series, *v1.Bloom) (int, bool, error)
+	readWriterFn func() (v1.BlockWriter, v1.BlockReader)
+	series       v1.PeekingIterator[*v1.Series]
+	blocks       v1.ResettableIterator[*v1.SeriesWithBloom]
+
+	bytesAdded int
+	curr       *v1.Block
+	err        error
+}
+
+func NewLazyBlockBuilderIterator(
+	ctx context.Context,
+	opts v1.BlockOptions,
+	metrics *Metrics,
+	populate func(*v1.Series, *v1.Bloom) (int, bool, error),
+	readWriterFn func() (v1.BlockWriter, v1.BlockReader),
+	series v1.PeekingIterator[*v1.Series],
+	blocks v1.ResettableIterator[*v1.SeriesWithBloom],
+) *LazyBlockBuilderIterator {
+	return &LazyBlockBuilderIterator{
+		ctx:          ctx,
+		opts:         opts,
+		metrics:      metrics,
+		populate:     populate,
+		readWriterFn: readWriterFn,
+		series:       series,
+		blocks:       blocks,
+	}
+}
+
+func (b *LazyBlockBuilderIterator) Bytes() (bytes int) {
+	return b.bytesAdded
+}
+
+func (b *LazyBlockBuilderIterator) Next() bool {
+	// No more series to process
+	if _, hasNext := b.series.Peek(); !hasNext {
+		return false
+	}
+
+	if err := b.ctx.Err(); err != nil {
+		b.err = errors.Wrap(err, "context canceled")
+		return false
+	}
+
+	if err := b.blocks.Reset(); err != nil {
+		b.err = errors.Wrap(err, "reset blocks iterator")
+		return false
+	}
+
+	mergeBuilder := v1.NewMergeBuilder(b.blocks, b.series, b.populate, b.metrics.bloomMetrics)
+	writer, reader := b.readWriterFn()
+	blockBuilder, err := v1.NewBlockBuilder(b.opts, writer)
+	if err != nil {
+		b.err = errors.Wrap(err, "failed to create bloom block builder")
+		return false
+	}
+	_, sourceBytes, err := mergeBuilder.Build(blockBuilder)
+	b.bytesAdded += sourceBytes
+
+	if err != nil {
+		b.err = errors.Wrap(err, "failed to build bloom block")
+		return false
+	}
+
+	b.curr = v1.NewBlock(reader, b.metrics.bloomMetrics)
+	return true
+}
+
+func (b *LazyBlockBuilderIterator) At() *v1.Block {
+	return b.curr
+}
+
+func (b *LazyBlockBuilderIterator) Err() error {
+	return b.err
+}
+
+// IndexLoader loads an index. This helps us do things like
+// load TSDBs for a specific period excluding multitenant (pre-compacted) indices
+type indexLoader interface {
+	Index() (tsdb.Index, error)
+}
+
+// ChunkItersByFingerprint models the chunks belonging to a fingerprint
+type ChunkItersByFingerprint struct {
+	fp  model.Fingerprint
+	itr v1.Iterator[v1.ChunkRefWithIter]
+}
+
+// ChunkLoader loads chunks from a store
+type ChunkLoader interface {
+	Load(ctx context.Context, userID string, series *v1.Series) (*ChunkItersByFingerprint, error)
+}
+
+// StoreChunkLoader loads chunks from a store
+type StoreChunkLoader struct {
+	fetcherProvider stores.ChunkFetcherProvider
+	metrics         *Metrics
+}
+
+func NewStoreChunkLoader(fetcherProvider stores.ChunkFetcherProvider, metrics *Metrics) *StoreChunkLoader {
+	return &StoreChunkLoader{
+		fetcherProvider: fetcherProvider,
+		metrics:         metrics,
+	}
+}
+
+func (s *StoreChunkLoader) Load(ctx context.Context, userID string, series *v1.Series) (*ChunkItersByFingerprint, error) {
+	// NB(owen-d): This is probably unnecessary as we should only have one fetcher
+	// because we'll only be working on a single index period at a time, but this should protect
+	// us in the case of refactoring/changing this and likely isn't a perf bottleneck.
+	chksByFetcher := make(map[*fetcher.Fetcher][]chunk.Chunk)
+	for _, chk := range series.Chunks {
+		fetcher := s.fetcherProvider.GetChunkFetcher(chk.From)
+		chksByFetcher[fetcher] = append(chksByFetcher[fetcher], chunk.Chunk{
+			ChunkRef: logproto.ChunkRef{
+				Fingerprint: uint64(series.Fingerprint),
+				UserID:      userID,
+				From:        chk.From,
+				Through:     chk.Through,
+				Checksum:    chk.Checksum,
+			},
+		})
+	}
+
+	var (
+		fetchers = make([]Fetcher[chunk.Chunk, chunk.Chunk], 0, len(chksByFetcher))
+		inputs   = make([][]chunk.Chunk, 0, len(chksByFetcher))
+	)
+	for fetcher, chks := range chksByFetcher {
+		fn := FetchFunc[chunk.Chunk, chunk.Chunk](fetcher.FetchChunks)
+		fetchers = append(fetchers, fn)
+		inputs = append(inputs, chks)
+	}
+
+	return &ChunkItersByFingerprint{
+		fp:  series.Fingerprint,
+		itr: newBatchedChunkLoader(ctx, fetchers, inputs, s.metrics, batchedLoaderDefaultBatchSize),
+	}, nil
+}

--- a/pkg/bloombuild/builder/spec_test.go
+++ b/pkg/bloombuild/builder/spec_test.go
@@ -1,0 +1,176 @@
+package builder
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/go-kit/log"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/chunkenc"
+	v1 "github.com/grafana/loki/v3/pkg/storage/bloom/v1"
+	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/bloomshipper"
+)
+
+func blocksFromSchema(t *testing.T, n int, options v1.BlockOptions) (res []*v1.Block, data []v1.SeriesWithBloom, refs []bloomshipper.BlockRef) {
+	return blocksFromSchemaWithRange(t, n, options, 0, 0xffff)
+}
+
+// splits 100 series across `n` non-overlapping blocks.
+// uses options to build blocks with.
+func blocksFromSchemaWithRange(t *testing.T, n int, options v1.BlockOptions, fromFP, throughFp model.Fingerprint) (res []*v1.Block, data []v1.SeriesWithBloom, refs []bloomshipper.BlockRef) {
+	if 100%n != 0 {
+		panic("100 series must be evenly divisible by n")
+	}
+
+	numSeries := 100
+	data, _ = v1.MkBasicSeriesWithBlooms(numSeries, 0, fromFP, throughFp, 0, 10000)
+
+	seriesPerBlock := numSeries / n
+
+	for i := 0; i < n; i++ {
+		// references for linking in memory reader+writer
+		indexBuf := bytes.NewBuffer(nil)
+		bloomsBuf := bytes.NewBuffer(nil)
+		writer := v1.NewMemoryBlockWriter(indexBuf, bloomsBuf)
+		reader := v1.NewByteReader(indexBuf, bloomsBuf)
+
+		builder, err := v1.NewBlockBuilder(
+			options,
+			writer,
+		)
+		require.Nil(t, err)
+
+		minIdx, maxIdx := i*seriesPerBlock, (i+1)*seriesPerBlock
+
+		itr := v1.NewSliceIter[v1.SeriesWithBloom](data[minIdx:maxIdx])
+		_, err = builder.BuildFrom(itr)
+		require.Nil(t, err)
+
+		res = append(res, v1.NewBlock(reader, v1.NewMetrics(nil)))
+		ref := genBlockRef(data[minIdx].Series.Fingerprint, data[maxIdx-1].Series.Fingerprint)
+		t.Log("create block", ref)
+		refs = append(refs, ref)
+	}
+
+	return res, data, refs
+}
+
+// doesn't actually load any chunks
+type dummyChunkLoader struct{}
+
+func (dummyChunkLoader) Load(_ context.Context, _ string, series *v1.Series) (*ChunkItersByFingerprint, error) {
+	return &ChunkItersByFingerprint{
+		fp:  series.Fingerprint,
+		itr: v1.NewEmptyIter[v1.ChunkRefWithIter](),
+	}, nil
+}
+
+func dummyBloomGen(t *testing.T, opts v1.BlockOptions, store v1.Iterator[*v1.Series], blocks []*v1.Block, refs []bloomshipper.BlockRef) *SimpleBloomGenerator {
+	bqs := make([]*bloomshipper.CloseableBlockQuerier, 0, len(blocks))
+	for i, b := range blocks {
+		bqs = append(bqs, &bloomshipper.CloseableBlockQuerier{
+			BlockRef:     refs[i],
+			BlockQuerier: v1.NewBlockQuerier(b, false, v1.DefaultMaxPageSize),
+		})
+	}
+
+	fetcher := func(_ context.Context, refs []bloomshipper.BlockRef) ([]*bloomshipper.CloseableBlockQuerier, error) {
+		res := make([]*bloomshipper.CloseableBlockQuerier, 0, len(refs))
+		for _, ref := range refs {
+			for _, bq := range bqs {
+				if ref.Bounds.Equal(bq.Bounds) {
+					res = append(res, bq)
+				}
+			}
+		}
+		t.Log("req", refs)
+		t.Log("res", res)
+		return res, nil
+	}
+
+	blocksIter := newBlockLoadingIter(context.Background(), refs, FetchFunc[bloomshipper.BlockRef, *bloomshipper.CloseableBlockQuerier](fetcher), 1)
+
+	return NewSimpleBloomGenerator(
+		"fake",
+		opts,
+		store,
+		dummyChunkLoader{},
+		blocksIter,
+		func() (v1.BlockWriter, v1.BlockReader) {
+			indexBuf := bytes.NewBuffer(nil)
+			bloomsBuf := bytes.NewBuffer(nil)
+			return v1.NewMemoryBlockWriter(indexBuf, bloomsBuf), v1.NewByteReader(indexBuf, bloomsBuf)
+		},
+		nil,
+		NewMetrics(nil, nil),
+		log.NewNopLogger(),
+	)
+}
+
+func TestSimpleBloomGenerator(t *testing.T) {
+	const maxBlockSize = 100 << 20 // 100MB
+	for _, enc := range []chunkenc.Encoding{chunkenc.EncNone, chunkenc.EncGZIP, chunkenc.EncSnappy} {
+		for _, tc := range []struct {
+			desc                 string
+			fromSchema, toSchema v1.BlockOptions
+			overlapping          bool
+		}{
+			{
+				desc:       "SkipsIncompatibleSchemas",
+				fromSchema: v1.NewBlockOptions(enc, 3, 0, maxBlockSize, 0),
+				toSchema:   v1.NewBlockOptions(enc, 4, 0, maxBlockSize, 0),
+			},
+			{
+				desc:       "CombinesBlocks",
+				fromSchema: v1.NewBlockOptions(enc, 4, 0, maxBlockSize, 0),
+				toSchema:   v1.NewBlockOptions(enc, 4, 0, maxBlockSize, 0),
+			},
+		} {
+			t.Run(fmt.Sprintf("%s/%s", tc.desc, enc), func(t *testing.T) {
+				sourceBlocks, data, refs := blocksFromSchemaWithRange(t, 2, tc.fromSchema, 0x00000, 0x6ffff)
+				storeItr := v1.NewMapIter[v1.SeriesWithBloom, *v1.Series](
+					v1.NewSliceIter[v1.SeriesWithBloom](data),
+					func(swb v1.SeriesWithBloom) *v1.Series {
+						return swb.Series
+					},
+				)
+
+				gen := dummyBloomGen(t, tc.toSchema, storeItr, sourceBlocks, refs)
+				results := gen.Generate(context.Background())
+
+				var outputBlocks []*v1.Block
+				for results.Next() {
+					outputBlocks = append(outputBlocks, results.At())
+				}
+				// require.Equal(t, tc.outputBlocks, len(outputBlocks))
+
+				// Check all the input series are present in the output blocks.
+				expectedRefs := v1.PointerSlice(data)
+				outputRefs := make([]*v1.SeriesWithBloom, 0, len(data))
+				for _, block := range outputBlocks {
+					bq := v1.NewBlockQuerier(block, false, v1.DefaultMaxPageSize)
+					for bq.Next() {
+						outputRefs = append(outputRefs, bq.At())
+					}
+				}
+				require.Equal(t, len(expectedRefs), len(outputRefs))
+				for i := range expectedRefs {
+					require.Equal(t, expectedRefs[i].Series, outputRefs[i].Series)
+				}
+			})
+		}
+	}
+}
+
+func genBlockRef(min, max model.Fingerprint) bloomshipper.BlockRef {
+	bounds := v1.NewBounds(min, max)
+	return bloomshipper.BlockRef{
+		Ref: bloomshipper.Ref{
+			Bounds: bounds,
+		},
+	}
+}

--- a/pkg/bloombuild/builder/spec_test.go
+++ b/pkg/bloombuild/builder/spec_test.go
@@ -106,7 +106,7 @@ func dummyBloomGen(t *testing.T, opts v1.BlockOptions, store v1.Iterator[*v1.Ser
 			return v1.NewMemoryBlockWriter(indexBuf, bloomsBuf), v1.NewByteReader(indexBuf, bloomsBuf)
 		},
 		nil,
-		NewMetrics(nil, nil),
+		NewMetrics(nil, v1.NewMetrics(nil)),
 		log.NewNopLogger(),
 	)
 }

--- a/pkg/bloombuild/common/tsdb.go
+++ b/pkg/bloombuild/common/tsdb.go
@@ -1,4 +1,4 @@
-package planner
+package common
 
 import (
 	"context"

--- a/pkg/bloombuild/common/tsdb_test.go
+++ b/pkg/bloombuild/common/tsdb_test.go
@@ -1,4 +1,4 @@
-package planner
+package common
 
 import (
 	"context"

--- a/pkg/bloombuild/planner/planner.go
+++ b/pkg/bloombuild/planner/planner.go
@@ -14,6 +14,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 
+	"github.com/grafana/loki/v3/pkg/bloombuild/common"
 	"github.com/grafana/loki/v3/pkg/bloombuild/protos"
 	"github.com/grafana/loki/v3/pkg/queue"
 	"github.com/grafana/loki/v3/pkg/storage"
@@ -37,7 +38,7 @@ type Planner struct {
 	limits    Limits
 	schemaCfg config.SchemaConfig
 
-	tsdbStore  TSDBStore
+	tsdbStore  common.TSDBStore
 	bloomStore bloomshipper.Store
 
 	tasksQueue  *queue.RequestQueue
@@ -61,7 +62,7 @@ func New(
 ) (*Planner, error) {
 	utillog.WarnExperimentalUse("Bloom Planner", logger)
 
-	tsdbStore, err := NewTSDBStores(schemaCfg, storeCfg, storageMetrics, logger)
+	tsdbStore, err := common.NewTSDBStores(schemaCfg, storeCfg, storageMetrics, logger)
 	if err != nil {
 		return nil, fmt.Errorf("error creating TSDB store: %w", err)
 	}
@@ -191,7 +192,7 @@ func (p *Planner) runOne(ctx context.Context) error {
 
 			task := NewTask(
 				ctx, now,
-				protos.NewTask(w.table.Addr(), w.tenant, w.ownershipRange, gap.tsdb, gap.gaps),
+				protos.NewTask(w.table, w.tenant, w.ownershipRange, gap.tsdb, gap.gaps),
 			)
 
 			if err := p.enqueueTask(task); err != nil {

--- a/pkg/bloombuild/planner/planner_test.go
+++ b/pkg/bloombuild/planner/planner_test.go
@@ -393,7 +393,7 @@ func Test_BuilderLoop(t *testing.T) {
 	for i := 0; i < nTasks; i++ {
 		task := NewTask(
 			context.Background(), time.Now(),
-			protos.NewTask("fakeTable", "fakeTenant", v1.NewBounds(0, 10), tsdbID(1), nil),
+			protos.NewTask(config.NewDayTable(config.NewDayTime(0), "fake"), "fakeTenant", v1.NewBounds(0, 10), tsdbID(1), nil),
 		)
 
 		err = planner.enqueueTask(task)

--- a/pkg/bloombuild/protos/types.pb.go
+++ b/pkg/bloombuild/protos/types.pb.go
@@ -80,6 +80,57 @@ func (m *ProtoFingerprintBounds) GetMax() github_com_prometheus_common_model.Fin
 	return 0
 }
 
+type DayTable struct {
+	DayTimestampMS int64  `protobuf:"varint,1,opt,name=dayTimestampMS,proto3" json:"dayTimestampMS,omitempty"`
+	Prefix         string `protobuf:"bytes,2,opt,name=prefix,proto3" json:"prefix,omitempty"`
+}
+
+func (m *DayTable) Reset()      { *m = DayTable{} }
+func (*DayTable) ProtoMessage() {}
+func (*DayTable) Descriptor() ([]byte, []int) {
+	return fileDescriptor_5325fb0610e1e9ae, []int{1}
+}
+func (m *DayTable) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *DayTable) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_DayTable.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *DayTable) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_DayTable.Merge(m, src)
+}
+func (m *DayTable) XXX_Size() int {
+	return m.Size()
+}
+func (m *DayTable) XXX_DiscardUnknown() {
+	xxx_messageInfo_DayTable.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_DayTable proto.InternalMessageInfo
+
+func (m *DayTable) GetDayTimestampMS() int64 {
+	if m != nil {
+		return m.DayTimestampMS
+	}
+	return 0
+}
+
+func (m *DayTable) GetPrefix() string {
+	if m != nil {
+		return m.Prefix
+	}
+	return ""
+}
+
 type ProtoGapWithBlocks struct {
 	Bounds   ProtoFingerprintBounds `protobuf:"bytes,1,opt,name=bounds,proto3" json:"bounds"`
 	BlockRef []string               `protobuf:"bytes,2,rep,name=blockRef,proto3" json:"blockRef,omitempty"`
@@ -88,7 +139,7 @@ type ProtoGapWithBlocks struct {
 func (m *ProtoGapWithBlocks) Reset()      { *m = ProtoGapWithBlocks{} }
 func (*ProtoGapWithBlocks) ProtoMessage() {}
 func (*ProtoGapWithBlocks) Descriptor() ([]byte, []int) {
-	return fileDescriptor_5325fb0610e1e9ae, []int{1}
+	return fileDescriptor_5325fb0610e1e9ae, []int{2}
 }
 func (m *ProtoGapWithBlocks) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -136,7 +187,7 @@ func (m *ProtoGapWithBlocks) GetBlockRef() []string {
 //	instead of unmarshaling them from strings or doing unsafe casts.
 type ProtoTask struct {
 	Id     string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
-	Table  string                 `protobuf:"bytes,2,opt,name=table,proto3" json:"table,omitempty"`
+	Table  DayTable               `protobuf:"bytes,2,opt,name=table,proto3" json:"table"`
 	Tenant string                 `protobuf:"bytes,3,opt,name=tenant,proto3" json:"tenant,omitempty"`
 	Bounds ProtoFingerprintBounds `protobuf:"bytes,4,opt,name=bounds,proto3" json:"bounds"`
 	Tsdb   string                 `protobuf:"bytes,5,opt,name=tsdb,proto3" json:"tsdb,omitempty"`
@@ -146,7 +197,7 @@ type ProtoTask struct {
 func (m *ProtoTask) Reset()      { *m = ProtoTask{} }
 func (*ProtoTask) ProtoMessage() {}
 func (*ProtoTask) Descriptor() ([]byte, []int) {
-	return fileDescriptor_5325fb0610e1e9ae, []int{2}
+	return fileDescriptor_5325fb0610e1e9ae, []int{3}
 }
 func (m *ProtoTask) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -182,11 +233,11 @@ func (m *ProtoTask) GetId() string {
 	return ""
 }
 
-func (m *ProtoTask) GetTable() string {
+func (m *ProtoTask) GetTable() DayTable {
 	if m != nil {
 		return m.Table
 	}
-	return ""
+	return DayTable{}
 }
 
 func (m *ProtoTask) GetTenant() string {
@@ -219,6 +270,7 @@ func (m *ProtoTask) GetGaps() []*ProtoGapWithBlocks {
 
 func init() {
 	proto.RegisterType((*ProtoFingerprintBounds)(nil), "protos.ProtoFingerprintBounds")
+	proto.RegisterType((*DayTable)(nil), "protos.DayTable")
 	proto.RegisterType((*ProtoGapWithBlocks)(nil), "protos.ProtoGapWithBlocks")
 	proto.RegisterType((*ProtoTask)(nil), "protos.ProtoTask")
 }
@@ -226,32 +278,36 @@ func init() {
 func init() { proto.RegisterFile("pkg/bloombuild/protos/types.proto", fileDescriptor_5325fb0610e1e9ae) }
 
 var fileDescriptor_5325fb0610e1e9ae = []byte{
-	// 393 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xa4, 0x92, 0x31, 0xeb, 0x9b, 0x40,
-	0x18, 0xc6, 0x3d, 0xf5, 0x2f, 0xf5, 0x02, 0x19, 0x8e, 0x10, 0x24, 0xc3, 0x99, 0x66, 0xca, 0xa4,
-	0x90, 0x4e, 0x85, 0x4e, 0x0e, 0xe9, 0xd0, 0xa5, 0x48, 0xa1, 0xd0, 0xed, 0x2e, 0x5e, 0xcd, 0x11,
-	0xf5, 0x24, 0x77, 0x82, 0xdd, 0xfa, 0x11, 0xfa, 0x31, 0x3a, 0xf7, 0x53, 0x64, 0xcc, 0x52, 0xc8,
-	0x24, 0x8d, 0x59, 0x4a, 0xa6, 0xcc, 0x9d, 0x8a, 0xa7, 0x94, 0x04, 0x3a, 0xb5, 0xd3, 0xfb, 0x3c,
-	0xaf, 0xbe, 0xbf, 0xf7, 0x79, 0x45, 0xf8, 0xbc, 0xdc, 0xa5, 0x21, 0xcd, 0x84, 0xc8, 0x69, 0xc5,
-	0xb3, 0x24, 0x2c, 0xf7, 0x42, 0x09, 0x19, 0xaa, 0x4f, 0x25, 0x93, 0x81, 0x36, 0xc8, 0xe9, 0x7b,
-	0xb3, 0x49, 0x2a, 0x52, 0xa1, 0x75, 0xd8, 0xa9, 0xfe, 0xe9, 0xe2, 0x1b, 0x80, 0xd3, 0xb7, 0x9d,
-	0x5a, 0xf3, 0x22, 0x65, 0xfb, 0x72, 0xcf, 0x0b, 0x15, 0x89, 0xaa, 0x48, 0x24, 0x7a, 0x03, 0xad,
-	0x9c, 0x17, 0x1e, 0x98, 0x83, 0xa5, 0x1d, 0xbd, 0xbc, 0x36, 0x7e, 0x67, 0x7f, 0x35, 0x7e, 0x90,
-	0x72, 0xb5, 0xad, 0x68, 0xb0, 0x11, 0x79, 0xb7, 0x2f, 0x67, 0x6a, 0xcb, 0x2a, 0x19, 0x6e, 0x44,
-	0x9e, 0x8b, 0x22, 0xcc, 0x45, 0xc2, 0xb2, 0xe0, 0x8e, 0x16, 0x77, 0x63, 0x1a, 0x46, 0x6a, 0xcf,
-	0xbc, 0x83, 0x91, 0xfa, 0x9f, 0x60, 0xa4, 0x5e, 0xd4, 0x10, 0xe9, 0xcc, 0xaf, 0x49, 0xf9, 0x9e,
-	0xab, 0x6d, 0x94, 0x89, 0xcd, 0x4e, 0xa2, 0x35, 0x74, 0xa8, 0x4e, 0xae, 0x23, 0x8f, 0x56, 0xb8,
-	0x3f, 0x51, 0x06, 0x7f, 0xbf, 0x2f, 0x1a, 0x1f, 0x1a, 0xdf, 0xb8, 0x36, 0xfe, 0x30, 0x15, 0x0f,
-	0x15, 0xcd, 0xe0, 0x33, 0xda, 0x11, 0x63, 0xf6, 0xd1, 0x33, 0xe7, 0xd6, 0xd2, 0x8d, 0xff, 0xf8,
-	0xc5, 0x77, 0x00, 0x5d, 0x8d, 0x7b, 0x47, 0xe4, 0x0e, 0x8d, 0xa1, 0xc9, 0x13, 0xbd, 0xcd, 0x8d,
-	0x4d, 0x9e, 0xa0, 0x09, 0x7c, 0x52, 0x84, 0x66, 0x4c, 0x9f, 0xe9, 0xc6, 0xbd, 0x41, 0x53, 0xe8,
-	0x28, 0x56, 0x90, 0x42, 0x79, 0x96, 0x6e, 0x0f, 0xee, 0x2e, 0xaf, 0xfd, 0x5f, 0x79, 0x11, 0xb4,
-	0x95, 0x4c, 0xa8, 0xf7, 0xa4, 0xe9, 0x5a, 0xa3, 0x00, 0xda, 0x29, 0x29, 0xa5, 0xe7, 0xcc, 0xad,
-	0xe5, 0x68, 0x35, 0x7b, 0x20, 0x3f, 0x7c, 0xb5, 0x58, 0xbf, 0x17, 0xbd, 0x3a, 0x9e, 0xb1, 0x71,
-	0x3a, 0x63, 0xe3, 0x76, 0xc6, 0xe0, 0x73, 0x8b, 0xc1, 0xd7, 0x16, 0x83, 0x43, 0x8b, 0xc1, 0xb1,
-	0xc5, 0xe0, 0x47, 0x8b, 0xc1, 0xcf, 0x16, 0x1b, 0xb7, 0x16, 0x83, 0x2f, 0x17, 0x6c, 0x1c, 0x2f,
-	0xd8, 0x38, 0x5d, 0xb0, 0xf1, 0x61, 0xf8, 0xb5, 0x68, 0x5f, 0x5f, 0xfc, 0x0e, 0x00, 0x00, 0xff,
-	0xff, 0x57, 0x05, 0xc7, 0x5d, 0x8e, 0x02, 0x00, 0x00,
+	// 452 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xa4, 0x92, 0x31, 0x8b, 0xdb, 0x30,
+	0x14, 0xc7, 0xad, 0x38, 0x17, 0x2e, 0x0a, 0x0d, 0x45, 0x94, 0xc3, 0x64, 0x50, 0xd2, 0x0c, 0x25,
+	0x93, 0x0d, 0x29, 0x1d, 0x0a, 0x9d, 0x4c, 0xb9, 0x42, 0x4b, 0xa1, 0xa8, 0x81, 0x42, 0x37, 0x39,
+	0xd6, 0x39, 0x22, 0x96, 0x65, 0x22, 0x05, 0x92, 0xad, 0x1f, 0xa1, 0x1f, 0xa3, 0x73, 0x3f, 0xc5,
+	0x8d, 0x19, 0x6f, 0x32, 0x8d, 0xb3, 0x94, 0x9b, 0x6e, 0xea, 0xd0, 0xa9, 0x48, 0xf2, 0x95, 0xa4,
+	0x74, 0x6a, 0xa7, 0xf7, 0xfe, 0xb2, 0xf4, 0x7b, 0xef, 0xff, 0xc7, 0xf0, 0x71, 0xb9, 0xcc, 0xa2,
+	0x24, 0x97, 0x52, 0x24, 0x6b, 0x9e, 0xa7, 0x51, 0xb9, 0x92, 0x5a, 0xaa, 0x48, 0x6f, 0x4b, 0xa6,
+	0x42, 0x2b, 0x50, 0xc7, 0x9d, 0x0d, 0x1e, 0x65, 0x32, 0x93, 0xb6, 0x8f, 0x4c, 0xe7, 0xbe, 0x8e,
+	0xbf, 0x02, 0x78, 0xf1, 0xce, 0x74, 0x97, 0xbc, 0xc8, 0xd8, 0xaa, 0x5c, 0xf1, 0x42, 0xc7, 0x72,
+	0x5d, 0xa4, 0x0a, 0xbd, 0x81, 0xbe, 0xe0, 0x45, 0x00, 0x46, 0x60, 0xd2, 0x8e, 0x9f, 0xdf, 0x56,
+	0x43, 0x23, 0x7f, 0x56, 0xc3, 0x30, 0xe3, 0x7a, 0xb1, 0x4e, 0xc2, 0xb9, 0x14, 0x66, 0x9e, 0x60,
+	0x7a, 0xc1, 0xd6, 0x2a, 0x9a, 0x4b, 0x21, 0x64, 0x11, 0x09, 0x99, 0xb2, 0x3c, 0x3c, 0xa2, 0x11,
+	0xf3, 0xcc, 0xc2, 0xe8, 0x26, 0x68, 0x1d, 0xc1, 0xe8, 0xe6, 0x9f, 0x60, 0x74, 0x33, 0x7e, 0x0d,
+	0xcf, 0x5f, 0xd2, 0xed, 0x8c, 0x26, 0x39, 0x43, 0x4f, 0x60, 0x3f, 0xa5, 0xdb, 0x19, 0x17, 0x4c,
+	0x69, 0x2a, 0xca, 0xb7, 0xef, 0xed, 0xc2, 0x3e, 0xf9, 0xe3, 0x14, 0x5d, 0xc0, 0x4e, 0xb9, 0x62,
+	0x57, 0xdc, 0xed, 0xd0, 0x25, 0x8d, 0x1a, 0x6f, 0x20, 0xb2, 0xfe, 0x5f, 0xd1, 0xf2, 0x03, 0xd7,
+	0x8b, 0x38, 0x97, 0xf3, 0xa5, 0x42, 0x97, 0xb0, 0x93, 0xd8, 0x14, 0x2c, 0xad, 0x37, 0xc5, 0x2e,
+	0x2e, 0x15, 0xfe, 0x3d, 0xab, 0xb8, 0x7f, 0x5d, 0x0d, 0xbd, 0xdb, 0x6a, 0xd8, 0xbc, 0x22, 0x4d,
+	0x45, 0x03, 0x78, 0x9e, 0x18, 0x22, 0x61, 0x57, 0x41, 0x6b, 0xe4, 0x4f, 0xba, 0xe4, 0xb7, 0x1e,
+	0xff, 0x00, 0xb0, 0x6b, 0x71, 0x33, 0xaa, 0x96, 0xa8, 0x0f, 0x5b, 0x3c, 0xb5, 0xd3, 0xba, 0xa4,
+	0xc5, 0x53, 0xf4, 0x0c, 0x9e, 0x69, 0x63, 0xd0, 0xae, 0xdb, 0x9b, 0x3e, 0xbc, 0x5f, 0xe0, 0xde,
+	0x78, 0xfc, 0xa0, 0x19, 0xe9, 0xae, 0x11, 0x57, 0x8c, 0x4d, 0xcd, 0x0a, 0x5a, 0xe8, 0xc0, 0x77,
+	0x36, 0x9d, 0x3a, 0x32, 0xd4, 0xfe, 0x2f, 0x43, 0x08, 0xb6, 0xb5, 0x4a, 0x93, 0xe0, 0xcc, 0xd2,
+	0x6d, 0x8f, 0x42, 0xd8, 0xce, 0x68, 0xa9, 0x82, 0xce, 0xc8, 0x9f, 0xf4, 0xa6, 0x83, 0x13, 0xf2,
+	0x49, 0xac, 0xc4, 0xde, 0x8b, 0x5f, 0xec, 0xf6, 0xd8, 0xbb, 0xd9, 0x63, 0xef, 0x6e, 0x8f, 0xc1,
+	0xa7, 0x1a, 0x83, 0x2f, 0x35, 0x06, 0xd7, 0x35, 0x06, 0xbb, 0x1a, 0x83, 0x6f, 0x35, 0x06, 0xdf,
+	0x6b, 0xec, 0xdd, 0xd5, 0x18, 0x7c, 0x3e, 0x60, 0x6f, 0x77, 0xc0, 0xde, 0xcd, 0x01, 0x7b, 0x1f,
+	0x9b, 0xff, 0x38, 0x71, 0xf5, 0xe9, 0xaf, 0x00, 0x00, 0x00, 0xff, 0xff, 0xfa, 0x37, 0x21, 0xfb,
+	0xfb, 0x02, 0x00, 0x00,
 }
 
 func (this *ProtoFingerprintBounds) Equal(that interface{}) bool {
@@ -277,6 +333,33 @@ func (this *ProtoFingerprintBounds) Equal(that interface{}) bool {
 		return false
 	}
 	if this.Max != that1.Max {
+		return false
+	}
+	return true
+}
+func (this *DayTable) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*DayTable)
+	if !ok {
+		that2, ok := that.(DayTable)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if this.DayTimestampMS != that1.DayTimestampMS {
+		return false
+	}
+	if this.Prefix != that1.Prefix {
 		return false
 	}
 	return true
@@ -335,7 +418,7 @@ func (this *ProtoTask) Equal(that interface{}) bool {
 	if this.Id != that1.Id {
 		return false
 	}
-	if this.Table != that1.Table {
+	if !this.Table.Equal(&that1.Table) {
 		return false
 	}
 	if this.Tenant != that1.Tenant {
@@ -368,6 +451,17 @@ func (this *ProtoFingerprintBounds) GoString() string {
 	s = append(s, "}")
 	return strings.Join(s, "")
 }
+func (this *DayTable) GoString() string {
+	if this == nil {
+		return "nil"
+	}
+	s := make([]string, 0, 6)
+	s = append(s, "&protos.DayTable{")
+	s = append(s, "DayTimestampMS: "+fmt.Sprintf("%#v", this.DayTimestampMS)+",\n")
+	s = append(s, "Prefix: "+fmt.Sprintf("%#v", this.Prefix)+",\n")
+	s = append(s, "}")
+	return strings.Join(s, "")
+}
 func (this *ProtoGapWithBlocks) GoString() string {
 	if this == nil {
 		return "nil"
@@ -386,7 +480,7 @@ func (this *ProtoTask) GoString() string {
 	s := make([]string, 0, 10)
 	s = append(s, "&protos.ProtoTask{")
 	s = append(s, "Id: "+fmt.Sprintf("%#v", this.Id)+",\n")
-	s = append(s, "Table: "+fmt.Sprintf("%#v", this.Table)+",\n")
+	s = append(s, "Table: "+strings.Replace(this.Table.GoString(), `&`, ``, 1)+",\n")
 	s = append(s, "Tenant: "+fmt.Sprintf("%#v", this.Tenant)+",\n")
 	s = append(s, "Bounds: "+strings.Replace(this.Bounds.GoString(), `&`, ``, 1)+",\n")
 	s = append(s, "Tsdb: "+fmt.Sprintf("%#v", this.Tsdb)+",\n")
@@ -431,6 +525,41 @@ func (m *ProtoFingerprintBounds) MarshalToSizedBuffer(dAtA []byte) (int, error) 
 	}
 	if m.Min != 0 {
 		i = encodeVarintTypes(dAtA, i, uint64(m.Min))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *DayTable) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *DayTable) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *DayTable) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.Prefix) > 0 {
+		i -= len(m.Prefix)
+		copy(dAtA[i:], m.Prefix)
+		i = encodeVarintTypes(dAtA, i, uint64(len(m.Prefix)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if m.DayTimestampMS != 0 {
+		i = encodeVarintTypes(dAtA, i, uint64(m.DayTimestampMS))
 		i--
 		dAtA[i] = 0x8
 	}
@@ -537,13 +666,16 @@ func (m *ProtoTask) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 		i--
 		dAtA[i] = 0x1a
 	}
-	if len(m.Table) > 0 {
-		i -= len(m.Table)
-		copy(dAtA[i:], m.Table)
-		i = encodeVarintTypes(dAtA, i, uint64(len(m.Table)))
-		i--
-		dAtA[i] = 0x12
+	{
+		size, err := m.Table.MarshalToSizedBuffer(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = encodeVarintTypes(dAtA, i, uint64(size))
 	}
+	i--
+	dAtA[i] = 0x12
 	if len(m.Id) > 0 {
 		i -= len(m.Id)
 		copy(dAtA[i:], m.Id)
@@ -580,6 +712,22 @@ func (m *ProtoFingerprintBounds) Size() (n int) {
 	return n
 }
 
+func (m *DayTable) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.DayTimestampMS != 0 {
+		n += 1 + sovTypes(uint64(m.DayTimestampMS))
+	}
+	l = len(m.Prefix)
+	if l > 0 {
+		n += 1 + l + sovTypes(uint64(l))
+	}
+	return n
+}
+
 func (m *ProtoGapWithBlocks) Size() (n int) {
 	if m == nil {
 		return 0
@@ -607,10 +755,8 @@ func (m *ProtoTask) Size() (n int) {
 	if l > 0 {
 		n += 1 + l + sovTypes(uint64(l))
 	}
-	l = len(m.Table)
-	if l > 0 {
-		n += 1 + l + sovTypes(uint64(l))
-	}
+	l = m.Table.Size()
+	n += 1 + l + sovTypes(uint64(l))
 	l = len(m.Tenant)
 	if l > 0 {
 		n += 1 + l + sovTypes(uint64(l))
@@ -647,6 +793,17 @@ func (this *ProtoFingerprintBounds) String() string {
 	}, "")
 	return s
 }
+func (this *DayTable) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&DayTable{`,
+		`DayTimestampMS:` + fmt.Sprintf("%v", this.DayTimestampMS) + `,`,
+		`Prefix:` + fmt.Sprintf("%v", this.Prefix) + `,`,
+		`}`,
+	}, "")
+	return s
+}
 func (this *ProtoGapWithBlocks) String() string {
 	if this == nil {
 		return "nil"
@@ -669,7 +826,7 @@ func (this *ProtoTask) String() string {
 	repeatedStringForGaps += "}"
 	s := strings.Join([]string{`&ProtoTask{`,
 		`Id:` + fmt.Sprintf("%v", this.Id) + `,`,
-		`Table:` + fmt.Sprintf("%v", this.Table) + `,`,
+		`Table:` + strings.Replace(strings.Replace(this.Table.String(), "DayTable", "DayTable", 1), `&`, ``, 1) + `,`,
 		`Tenant:` + fmt.Sprintf("%v", this.Tenant) + `,`,
 		`Bounds:` + strings.Replace(strings.Replace(this.Bounds.String(), "ProtoFingerprintBounds", "ProtoFingerprintBounds", 1), `&`, ``, 1) + `,`,
 		`Tsdb:` + fmt.Sprintf("%v", this.Tsdb) + `,`,
@@ -753,6 +910,110 @@ func (m *ProtoFingerprintBounds) Unmarshal(dAtA []byte) error {
 					break
 				}
 			}
+		default:
+			iNdEx = preIndex
+			skippy, err := skipTypes(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthTypes
+			}
+			if (iNdEx + skippy) < 0 {
+				return ErrInvalidLengthTypes
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *DayTable) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowTypes
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: DayTable: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: DayTable: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DayTimestampMS", wireType)
+			}
+			m.DayTimestampMS = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTypes
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.DayTimestampMS |= int64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Prefix", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTypes
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthTypes
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTypes
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Prefix = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := skipTypes(dAtA[iNdEx:])
@@ -960,7 +1221,7 @@ func (m *ProtoTask) Unmarshal(dAtA []byte) error {
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Table", wireType)
 			}
-			var stringLen uint64
+			var msglen int
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
 					return ErrIntOverflowTypes
@@ -970,23 +1231,24 @@ func (m *ProtoTask) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				stringLen |= uint64(b&0x7F) << shift
+				msglen |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
 			}
-			intStringLen := int(stringLen)
-			if intStringLen < 0 {
+			if msglen < 0 {
 				return ErrInvalidLengthTypes
 			}
-			postIndex := iNdEx + intStringLen
+			postIndex := iNdEx + msglen
 			if postIndex < 0 {
 				return ErrInvalidLengthTypes
 			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.Table = string(dAtA[iNdEx:postIndex])
+			if err := m.Table.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
 			iNdEx = postIndex
 		case 3:
 			if wireType != 2 {

--- a/pkg/bloombuild/protos/types.proto
+++ b/pkg/bloombuild/protos/types.proto
@@ -22,6 +22,11 @@ message ProtoFingerprintBounds {
   ];
 }
 
+message DayTable {
+  int64 dayTimestampMS = 1;
+  string prefix = 2;
+}
+
 message ProtoGapWithBlocks {
   ProtoFingerprintBounds bounds = 1 [
     (gogoproto.nullable) = false,
@@ -34,7 +39,10 @@ message ProtoGapWithBlocks {
 //       instead of unmarshaling them from strings or doing unsafe casts.
 message ProtoTask {
   string id = 1;
-  string table = 2;
+  DayTable table = 2 [
+    (gogoproto.nullable) = false,
+    (gogoproto.jsontag) = "table"
+  ];
   string tenant = 3;
   ProtoFingerprintBounds bounds = 4 [
     (gogoproto.nullable) = false,

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -1585,6 +1585,12 @@ func (t *Loki) initBloomBuilder() (services.Service, error) {
 
 	return builder.New(
 		t.Cfg.BloomBuild.Builder,
+		t.Overrides,
+		t.Cfg.SchemaConfig,
+		t.Cfg.StorageConfig,
+		t.ClientMetrics,
+		t.Store,
+		t.BloomStore,
 		logger,
 		prometheus.DefaultRegisterer,
 	)


### PR DESCRIPTION
**What this PR does / why we need it**:
Similarly to https://github.com/grafana/loki/pull/12994, this PR copies logic from the bloom compactor to the new bloom planner component.  We implement pretty much the same logic from the `bloomcompactor.controller.buildGaps` ([source][1]):

1. For each gap inside the received task, load the get series and blocks iters for gap.
    - Same as `bloomcompactor.controller.loadWorkForGap` ([here][2]). We copied `batch.go` and `batch_test.go` from the compactor so we can use `newBlockLoadingIter`.
2. Generate new blocks (see `NewSimpleBloomGenerator` and `gen.Generate`)
    - We copied `spec.go` and `spec_test.go` from the bloom compactor
3. Put blocks to object store
4. Create block refs, and add them to the meta's block slice
5. Create metaRef and add it to the Meta
6. Put the meta to object store
7. Return success/error to planner
    - Note: we do not return the new metas to the planner. We will do it when we implement deletion of outdated blocks and metas.

**Special notes for your reviewer**:
- Most of the logic and tests are copied right away from the bloom compactor implementation.
- This is how I'd review this PR:
   - Skim through the copied files (no changes were made):
        - `batch.go` and `batch_test.go`
        - `spec.go` and `spec_test.go`
   - Focus on `builder.go` specifically `processTask` but beware as stated above that it's also pretty much the same logic as `bloomcompactor.controller.buildGaps` ([source][1]).
- I'll create a separate PR for returning back the new metas to the planner 

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)

[2]: https://github.com/grafana/loki/blob/cb1f5d9fca2908bd31a3c6bef38d49fe084d2939/pkg/bloomcompactor/controller.go#L284
[1]: https://github.com/grafana/loki/blob/cb1f5d9fca2908bd31a3c6bef38d49fe084d2939/pkg/bloomcompactor/controller.go#L324