### PR TITLE
BREAKING CHANGE(HELM): remove unregister on shutdown argument on zone aware ingesters

### DIFF
--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -13,6 +13,10 @@ Entries should include a reference to the pull request that introduced the chang
 
 [//]: # (<AUTOMATED_UPDATES_LOCATOR> : do not remove this line. This locator is used by the CI pipeline to automatically create a changelog entry for each new Loki release. Add other chart versions and respective changelog entries bellow this line.)
 
+## 6.7.0
+
+- [CHANGE] **BREAKING** Remove `ingester.unregister-on-shutdown=false` for zone aware ingesters in favour of being able to set this via the configuration option `unregister_on_shutdown` (defaults `true`).
+
 ## 6.6.2
 
 - [BUGFIX] Fix query-frontend (headless) and ruler http-metrics targetPort
@@ -27,7 +31,7 @@ Entries should include a reference to the pull request that introduced the chang
 
 ## 6.5.2
 
-- [BUGFIX] Fixed Ingress routing for all deployment modes.  
+- [BUGFIX] Fixed Ingress routing for all deployment modes.
 
 ## 6.5.0
 

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -3,7 +3,7 @@ name: loki
 description: Helm chart for Grafana Loki and Grafana Enterprise Logs supporting both simple, scalable and distributed modes.
 type: application
 appVersion: 3.0.0
-version: 6.6.2
+version: 6.7.0
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -1,6 +1,6 @@
 # loki
 
-![Version: 6.6.1](https://img.shields.io/badge/Version-6.6.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.0.0](https://img.shields.io/badge/AppVersion-3.0.0-informational?style=flat-square)
+![Version: 6.7.0](https://img.shields.io/badge/Version-6.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.0.0](https://img.shields.io/badge/AppVersion-3.0.0-informational?style=flat-square)
 
 Helm chart for Grafana Loki and Grafana Enterprise Logs supporting both simple, scalable and distributed modes.
 

--- a/production/helm/loki/templates/ingester/statefulset-ingester-zone-a.yaml
+++ b/production/helm/loki/templates/ingester/statefulset-ingester-zone-a.yaml
@@ -101,7 +101,6 @@ spec:
           args:
             - -config.file=/etc/loki/config/config.yaml
             - -ingester.availability-zone=zone-a
-            - -ingester.unregister-on-shutdown=false
             - -ingester.tokens-file-path=/var/loki/ring-tokens
             - -target=ingester
             {{- with .Values.ingester.extraArgs }}

--- a/production/helm/loki/templates/ingester/statefulset-ingester-zone-b.yaml
+++ b/production/helm/loki/templates/ingester/statefulset-ingester-zone-b.yaml
@@ -101,7 +101,6 @@ spec:
           args:
             - -config.file=/etc/loki/config/config.yaml
             - -ingester.availability-zone=zone-b
-            - -ingester.unregister-on-shutdown=false
             - -ingester.tokens-file-path=/var/loki/ring-tokens
             - -target=ingester
             {{- with .Values.ingester.extraArgs }}

--- a/production/helm/loki/templates/ingester/statefulset-ingester-zone-c.yaml
+++ b/production/helm/loki/templates/ingester/statefulset-ingester-zone-c.yaml
@@ -101,7 +101,6 @@ spec:
           args:
             - -config.file=/etc/loki/config/config.yaml
             - -ingester.availability-zone=zone-c
-            - -ingester.unregister-on-shutdown=false
             - -ingester.tokens-file-path=/var/loki/ring-tokens
             - -target=ingester
             {{- with .Values.ingester.extraArgs }}


### PR DESCRIPTION
**What this PR does / why we need it**:

Helm templates are abstracted from us (users). Config values should be leading as that's the thing that folks can influence/change. Therefore, removing the hardcoded arg values in favour of being able to set these via the config. Furthermore, the default should be `true`, and I do not see any reason this should be `false` for zone aware ingesters

**Which issue(s) this PR fixes**:
Fixes #13071

**Special notes for your reviewer**:

I made it a breaking change, as we are effectively changing the default value if one uses zone aware ingesters. Users will now default to the configuration default, which is `true` instead of the current `false`. There is not really a way to keep backwards compatibility, but my 2 cents is that it's better to default to the actual intended default. 

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
