### PR TITLE
fix: congestion_config within common config and AWS S3 support

### DIFF
--- a/pkg/loki/config_wrapper.go
+++ b/pkg/loki/config_wrapper.go
@@ -566,7 +566,15 @@ func applyStorageConfig(cfg, defaults *ConfigWrapper) error {
 		}
 	}
 
+  if configsFound > 1 {
+		return ErrTooManyStorageConfigs
+	}
+
 	if !reflect.DeepEqual(cfg.Common.Storage.CongestionControl, defaults.StorageConfig.CongestionControl) {
+		//run any config func before setting the congestion control func
+		if applyConfig != nil {
+			applyConfig(cfg)
+		}
 		applyConfig = func(r *ConfigWrapper) {
 			r.StorageConfig.CongestionControl = r.Common.Storage.CongestionControl
 		}

--- a/pkg/storage/factory.go
+++ b/pkg/storage/factory.go
@@ -488,6 +488,9 @@ func NewChunkClient(name string, cfg Config, schemaCfg config.SchemaConfig, cc c
 			if err != nil {
 				return nil, err
 			}
+			if cfg.CongestionControl.Enabled {
+				c = cc.Wrap(c)
+			}
 			return client.NewClientWithMaxParallel(c, nil, cfg.MaxParallelGetChunk, schemaCfg), nil
 
 		case types.StorageTypeGCS:


### PR DESCRIPTION
**What this PR does / why we need it**:
Current code does not support
(1) when congestion_control is part “common” config section
(2) AWS S3 storage to use congestion_control config

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/loki/issues/13100

**Special notes for your reviewer**:

**Checklist**
- [/] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [/] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
