### PR TITLE
feat(canary): Add test to check query results with and without cache.

### DIFF
--- a/clients/cmd/promtail/promtail-local-config.yaml
+++ b/clients/cmd/promtail/promtail-local-config.yaml
@@ -16,3 +16,4 @@ scrape_configs:
     labels:
       job: varlogs
       __path__: /var/log/*log
+      stream: stdout

--- a/cmd/loki-canary/main.go
+++ b/cmd/loki-canary/main.go
@@ -79,6 +79,10 @@ func main() {
 	metricTestQueryRange := flag.Duration("metric-test-range", 24*time.Hour, "The range value [24h] used in the metric test instant-query."+
 		" Note: this value is truncated to the running time of the canary until this value is reached")
 
+	cacheTestInterval := flag.Duration("cache-test-interval", 15*time.Minute, "The interval the cache test query should be run")
+	cacheTestQueryRange := flag.Duration("cache-test-range", 24*time.Hour, "The range value [24h] used in the cache test instant-query.")
+	cacheTestQueryNow := flag.Duration("cache-test-now", 1*time.Hour, "duration how far back from current time the execustion time (--now) should be set for running this query in the cache test instant-query.")
+
 	spotCheckInterval := flag.Duration("spot-check-interval", 15*time.Minute, "Interval that a single result will be kept from sent entries and spot-checked against Loki, "+
 		"e.g. 15min default one entry every 15 min will be saved and then queried again every 15min until spot-check-max is reached")
 	spotCheckMax := flag.Duration("spot-check-max", 4*time.Hour, "How far back to check a spot check entry before dropping it")
@@ -189,7 +193,7 @@ func main() {
 			_, _ = fmt.Fprintf(os.Stderr, "Unable to create reader for Loki querier, check config: %s", err)
 			os.Exit(1)
 		}
-		c.comparator = comparator.NewComparator(os.Stderr, *wait, *maxWait, *pruneInterval, *spotCheckInterval, *spotCheckMax, *spotCheckQueryRate, *spotCheckWait, *metricTestInterval, *metricTestQueryRange, *interval, *buckets, sentChan, receivedChan, c.reader, true)
+		c.comparator = comparator.NewComparator(os.Stderr, *wait, *maxWait, *pruneInterval, *spotCheckInterval, *spotCheckMax, *spotCheckQueryRate, *spotCheckWait, *metricTestInterval, *metricTestQueryRange, *cacheTestInterval, *cacheTestQueryRange, *cacheTestQueryNow, *interval, *buckets, sentChan, receivedChan, c.reader, true)
 	}
 
 	startCanary()

--- a/cmd/loki-canary/main.go
+++ b/cmd/loki-canary/main.go
@@ -81,7 +81,7 @@ func main() {
 
 	cacheTestInterval := flag.Duration("cache-test-interval", 15*time.Minute, "The interval the cache test query should be run")
 	cacheTestQueryRange := flag.Duration("cache-test-range", 24*time.Hour, "The range value [24h] used in the cache test instant-query.")
-	cacheTestQueryNow := flag.Duration("cache-test-now", 1*time.Hour, "duration how far back from current time the execustion time (--now) should be set for running this query in the cache test instant-query.")
+	cacheTestQueryNow := flag.Duration("cache-test-now", 1*time.Hour, "duration how far back from current time the execution time (--now) should be set for running this query in the cache test instant-query.")
 
 	spotCheckInterval := flag.Duration("spot-check-interval", 15*time.Minute, "Interval that a single result will be kept from sent entries and spot-checked against Loki, "+
 		"e.g. 15min default one entry every 15 min will be saved and then queried again every 15min until spot-check-max is reached")

--- a/pkg/canary/comparator/comparator.go
+++ b/pkg/canary/comparator/comparator.go
@@ -350,9 +350,9 @@ func (c *Comparator) cacheTest(currTime time.Time) {
 	queryStartTime := currTime.Add(-c.cacheTestNow)
 
 	// We cannot query for range before the pod even started.
-	if queryStartTime.Add(-c.cacheTestRange).Before(c.startTime) {
+	if queryStartTime.Before(c.startTime) {
 		// we wait.
-		fmt.Fprintf(c.w, "cacheTest not run. still waiting for query start time to past the process start time. ")
+		fmt.Fprintf(c.w, "cacheTest not run. still waiting for query start range(%s) to past the process start time(%s).\n", queryStartTime, c.startTime)
 		return
 	}
 

--- a/pkg/canary/comparator/comparator.go
+++ b/pkg/canary/comparator/comparator.go
@@ -132,9 +132,8 @@ type Comparator struct {
 	metricTestRunning   bool
 	cacheTestInterval   time.Duration
 	cacheTestRange      time.Duration
-	// how far back from current time the execustion time (--now) should be set for running this query.
-	cacheTestNow time.Duration
-
+	// how far back from current time the execution time (--now) should be set for running this query.
+	cacheTestNow     time.Duration
 	cacheTestRunning bool
 	writeInterval    time.Duration
 	confirmAsync     bool
@@ -378,7 +377,7 @@ func (c *Comparator) cacheTest(currTime time.Time) {
 	queryResultsTotal.WithLabelValues("success").Inc()
 	if math.Abs(countNocache-countCache) > floatDiffTolerance {
 		queryResultsDiff.Inc()
-		fmt.Fprintf(c.w, "found a diff in instant query results time: %s, result_with_cache: %v, result_without_cache: %v", queryStartTime, countCache, countNocache)
+		fmt.Fprintf(c.w, "found a diff in instant query results time: %s, result_with_cache: %v, result_without_cache: %v\n", queryStartTime, countCache, countNocache)
 	}
 }
 

--- a/pkg/canary/comparator/comparator.go
+++ b/pkg/canary/comparator/comparator.go
@@ -378,6 +378,7 @@ func (c *Comparator) cacheTest(currTime time.Time) {
 	queryResultsTotal.WithLabelValues("success").Inc()
 	if math.Abs(countNocache-countCache) > floatDiffTolerance {
 		queryResultsDiff.Inc()
+		fmt.Fprintf(c.w, "found a diff in instant query results time: %s, result_with_cache: %v, result_without_cache: %v", queryStartTime, countCache, countNocache)
 	}
 }
 

--- a/pkg/canary/comparator/comparator_test.go
+++ b/pkg/canary/comparator/comparator_test.go
@@ -19,7 +19,7 @@ func TestComparatorEntryReceivedOutOfOrder(t *testing.T) {
 	duplicateEntries = &mockCounter{}
 
 	actual := &bytes.Buffer{}
-	c := NewComparator(actual, 1*time.Hour, 1*time.Hour, 1*time.Hour, 15*time.Minute, 4*time.Hour, 4*time.Hour, 0, 1*time.Minute, 0, 0, 1, make(chan time.Time), make(chan time.Time), nil, false)
+	c := NewComparator(actual, 1*time.Hour, 1*time.Hour, 1*time.Hour, 15*time.Minute, 4*time.Hour, 4*time.Hour, 0, 1*time.Minute, 0, 1*time.Hour, 0, 1, make(chan time.Time), make(chan time.Time), nil, false)
 
 	t1 := time.Now()
 	t2 := t1.Add(1 * time.Second)
@@ -60,7 +60,7 @@ func TestComparatorEntryReceivedNotExpected(t *testing.T) {
 	duplicateEntries = &mockCounter{}
 
 	actual := &bytes.Buffer{}
-	c := NewComparator(actual, 1*time.Hour, 1*time.Hour, 1*time.Hour, 15*time.Minute, 4*time.Hour, 4*time.Hour, 0, 1*time.Minute, 0, 0, 1, make(chan time.Time), make(chan time.Time), nil, false)
+	c := NewComparator(actual, 1*time.Hour, 1*time.Hour, 1*time.Hour, 15*time.Minute, 4*time.Hour, 4*time.Hour, 0, 1*time.Minute, 0, 1*time.Hour, 0, 1, make(chan time.Time), make(chan time.Time), nil, false)
 
 	t1 := time.Now()
 	t2 := t1.Add(1 * time.Second)
@@ -101,7 +101,7 @@ func TestComparatorEntryReceivedDuplicate(t *testing.T) {
 	duplicateEntries = &mockCounter{}
 
 	actual := &bytes.Buffer{}
-	c := NewComparator(actual, 1*time.Hour, 1*time.Hour, 1*time.Hour, 15*time.Minute, 4*time.Hour, 4*time.Hour, 0, 1*time.Minute, 0, 0, 1, make(chan time.Time), make(chan time.Time), nil, false)
+	c := NewComparator(actual, 1*time.Hour, 1*time.Hour, 1*time.Hour, 15*time.Minute, 4*time.Hour, 4*time.Hour, 0, 1*time.Minute, 0, 1*time.Hour, 0, 1, make(chan time.Time), make(chan time.Time), nil, false)
 
 	t1 := time.Unix(0, 0)
 	t2 := t1.Add(1 * time.Second)
@@ -159,7 +159,7 @@ func TestEntryNeverReceived(t *testing.T) {
 	wait := 60 * time.Second
 	maxWait := 300 * time.Second
 	//We set the prune interval timer to a huge value here so that it never runs, instead we call pruneEntries manually below
-	c := NewComparator(actual, wait, maxWait, 50*time.Hour, 15*time.Minute, 4*time.Hour, 4*time.Hour, 0, 1*time.Minute, 0, 0, 1, make(chan time.Time), make(chan time.Time), mr, false)
+	c := NewComparator(actual, wait, maxWait, 50*time.Hour, 15*time.Minute, 4*time.Hour, 4*time.Hour, 0, 1*time.Minute, 0, 1*time.Hour, 0, 1, make(chan time.Time), make(chan time.Time), mr, false)
 
 	c.entrySent(t1)
 	c.entrySent(t2)
@@ -232,7 +232,7 @@ func TestConcurrentConfirmMissing(t *testing.T) {
 	wait := 30 * time.Millisecond
 	maxWait := 30 * time.Millisecond
 
-	c := NewComparator(output, wait, maxWait, 50*time.Hour, 15*time.Minute, 4*time.Hour, 4*time.Hour, 0, 1*time.Minute, 0, 0, 1, make(chan time.Time), make(chan time.Time), mr, false)
+	c := NewComparator(output, wait, maxWait, 50*time.Hour, 15*time.Minute, 4*time.Hour, 4*time.Hour, 0, 1*time.Minute, 0, 1*time.Hour, 0, 1, make(chan time.Time), make(chan time.Time), mr, false)
 
 	for _, t := range found {
 		tCopy := t
@@ -263,7 +263,7 @@ func TestPruneAckdEntires(t *testing.T) {
 	wait := 30 * time.Millisecond
 	maxWait := 30 * time.Millisecond
 	//We set the prune interval timer to a huge value here so that it never runs, instead we call pruneEntries manually below
-	c := NewComparator(actual, wait, maxWait, 50*time.Hour, 15*time.Minute, 4*time.Hour, 4*time.Hour, 0, 1*time.Minute, 0, 0, 1, make(chan time.Time), make(chan time.Time), nil, false)
+	c := NewComparator(actual, wait, maxWait, 50*time.Hour, 15*time.Minute, 4*time.Hour, 4*time.Hour, 0, 1*time.Minute, 0, 1*time.Hour, 0, 1, make(chan time.Time), make(chan time.Time), nil, false)
 
 	t1 := time.Unix(0, 0)
 	t2 := t1.Add(1 * time.Millisecond)
@@ -320,7 +320,7 @@ func TestSpotCheck(t *testing.T) {
 	spotCheck := 10 * time.Millisecond
 	spotCheckMax := 20 * time.Millisecond
 	//We set the prune interval timer to a huge value here so that it never runs, instead we call spotCheckEntries manually below
-	c := NewComparator(actual, 1*time.Hour, 1*time.Hour, 50*time.Hour, spotCheck, spotCheckMax, 4*time.Hour, 3*time.Millisecond, 1*time.Minute, 0, 0, 1, make(chan time.Time), make(chan time.Time), mr, false)
+	c := NewComparator(actual, 1*time.Hour, 1*time.Hour, 50*time.Hour, spotCheck, spotCheckMax, 4*time.Hour, 3*time.Millisecond, 1*time.Minute, 0, 1*time.Hour, 0, 1, make(chan time.Time), make(chan time.Time), mr, false)
 
 	// Send all the entries
 	for i := range entries {
@@ -360,6 +360,41 @@ func TestSpotCheck(t *testing.T) {
 	prometheus.Unregister(responseLatency)
 }
 
+func TestCacheTest(t *testing.T) {
+	actual := &bytes.Buffer{}
+	mr := &mockReader{}
+	cacheTestInterval := 500 * time.Millisecond
+	now := time.Now()
+
+	c := NewComparator(actual, 1*time.Hour, 1*time.Hour, 50*time.Hour, 0, 0, 4*time.Hour, 0, 10*time.Minute, 0, cacheTestInterval, 1*time.Hour, 1, make(chan time.Time), make(chan time.Time), mr, false)
+	// Force the start time to a known value
+	c.startTime = time.Unix(10, 0)
+
+	queryresultsdiff = &mockCounter{}
+	mr.countOverTime = 2.3
+	mr.noCacheCountOvertime = mr.countOverTime // same value for both with and without cache
+	c.cacheTest(now)
+	assert.Equal(t, 0, queryresultsdiff.(*mockCounter).count)
+
+	queryresultsdiff = &mockCounter{} // reset counter
+	mr.countOverTime = 2.3            // value not important
+	mr.noCacheCountOvertime = 2.5     // different than `countOverTime` value.
+	c.cacheTest(now)
+	assert.Equal(t, 1, queryresultsdiff.(*mockCounter).count)
+
+	queryresultsdiff = &mockCounter{}    // reset counter
+	mr.countOverTime = 2.3               // value not important
+	mr.noCacheCountOvertime = 2.30000005 // different than `countOverTime` value but withing tolerance
+	c.cacheTest(now)
+	assert.Equal(t, 0, queryresultsdiff.(*mockCounter).count)
+
+	// This avoids a panic on subsequent test execution,
+	// seems ugly but was easy, and multiple instantiations
+	// of the comparator should be an error
+	prometheus.Unregister(responseLatency)
+
+}
+
 func TestMetricTest(t *testing.T) {
 	metricTestActual = &mockGauge{}
 	metricTestExpected = &mockGauge{}
@@ -371,7 +406,7 @@ func TestMetricTest(t *testing.T) {
 	mr := &mockReader{}
 	metricTestRange := 30 * time.Second
 	//We set the prune interval timer to a huge value here so that it never runs, instead we call spotCheckEntries manually below
-	c := NewComparator(actual, 1*time.Hour, 1*time.Hour, 50*time.Hour, 0, 0, 4*time.Hour, 0, 10*time.Minute, metricTestRange, writeInterval, 1, make(chan time.Time), make(chan time.Time), mr, false)
+	c := NewComparator(actual, 1*time.Hour, 1*time.Hour, 50*time.Hour, 0, 0, 4*time.Hour, 0, 10*time.Minute, metricTestRange, 1*time.Hour, writeInterval, 1, make(chan time.Time), make(chan time.Time), mr, false)
 	// Force the start time to a known value
 	c.startTime = time.Unix(10, 0)
 
@@ -507,13 +542,20 @@ type mockReader struct {
 	resp          []time.Time
 	countOverTime float64
 	queryRange    string
+
+	// return this value if called without cache.
+	noCacheCountOvertime float64
 }
 
 func (r *mockReader) Query(_ time.Time, _ time.Time) ([]time.Time, error) {
 	return r.resp, nil
 }
 
-func (r *mockReader) QueryCountOverTime(queryRange string) (float64, error) {
+func (r *mockReader) QueryCountOverTime(queryRange string, _ time.Time, cache bool) (float64, error) {
 	r.queryRange = queryRange
-	return r.countOverTime, nil
+	res := r.countOverTime
+	if !cache {
+		res = r.noCacheCountOvertime
+	}
+	return res, nil
 }

--- a/pkg/canary/comparator/comparator_test.go
+++ b/pkg/canary/comparator/comparator_test.go
@@ -394,7 +394,6 @@ func TestCacheTest(t *testing.T) {
 	// seems ugly but was easy, and multiple instantiations
 	// of the comparator should be an error
 	prometheus.Unregister(responseLatency)
-
 }
 
 func TestMetricTest(t *testing.T) {

--- a/pkg/canary/comparator/comparator_test.go
+++ b/pkg/canary/comparator/comparator_test.go
@@ -19,7 +19,7 @@ func TestComparatorEntryReceivedOutOfOrder(t *testing.T) {
 	duplicateEntries = &mockCounter{}
 
 	actual := &bytes.Buffer{}
-	c := NewComparator(actual, 1*time.Hour, 1*time.Hour, 1*time.Hour, 15*time.Minute, 4*time.Hour, 4*time.Hour, 0, 1*time.Minute, 0, 1*time.Hour, 0, 1, make(chan time.Time), make(chan time.Time), nil, false)
+	c := NewComparator(actual, 1*time.Hour, 1*time.Hour, 1*time.Hour, 15*time.Minute, 4*time.Hour, 4*time.Hour, 0, 1*time.Minute, 0, 1*time.Hour, 3*time.Hour, 30*time.Minute, 0, 1, make(chan time.Time), make(chan time.Time), nil, false)
 
 	t1 := time.Now()
 	t2 := t1.Add(1 * time.Second)
@@ -60,7 +60,7 @@ func TestComparatorEntryReceivedNotExpected(t *testing.T) {
 	duplicateEntries = &mockCounter{}
 
 	actual := &bytes.Buffer{}
-	c := NewComparator(actual, 1*time.Hour, 1*time.Hour, 1*time.Hour, 15*time.Minute, 4*time.Hour, 4*time.Hour, 0, 1*time.Minute, 0, 1*time.Hour, 0, 1, make(chan time.Time), make(chan time.Time), nil, false)
+	c := NewComparator(actual, 1*time.Hour, 1*time.Hour, 1*time.Hour, 15*time.Minute, 4*time.Hour, 4*time.Hour, 0, 1*time.Minute, 0, 1*time.Hour, 3*time.Hour, 30*time.Minute, 0, 1, make(chan time.Time), make(chan time.Time), nil, false)
 
 	t1 := time.Now()
 	t2 := t1.Add(1 * time.Second)
@@ -101,7 +101,7 @@ func TestComparatorEntryReceivedDuplicate(t *testing.T) {
 	duplicateEntries = &mockCounter{}
 
 	actual := &bytes.Buffer{}
-	c := NewComparator(actual, 1*time.Hour, 1*time.Hour, 1*time.Hour, 15*time.Minute, 4*time.Hour, 4*time.Hour, 0, 1*time.Minute, 0, 1*time.Hour, 0, 1, make(chan time.Time), make(chan time.Time), nil, false)
+	c := NewComparator(actual, 1*time.Hour, 1*time.Hour, 1*time.Hour, 15*time.Minute, 4*time.Hour, 4*time.Hour, 0, 1*time.Minute, 0, 1*time.Hour, 3*time.Hour, 30*time.Minute, 0, 1, make(chan time.Time), make(chan time.Time), nil, false)
 
 	t1 := time.Unix(0, 0)
 	t2 := t1.Add(1 * time.Second)
@@ -159,7 +159,7 @@ func TestEntryNeverReceived(t *testing.T) {
 	wait := 60 * time.Second
 	maxWait := 300 * time.Second
 	//We set the prune interval timer to a huge value here so that it never runs, instead we call pruneEntries manually below
-	c := NewComparator(actual, wait, maxWait, 50*time.Hour, 15*time.Minute, 4*time.Hour, 4*time.Hour, 0, 1*time.Minute, 0, 1*time.Hour, 0, 1, make(chan time.Time), make(chan time.Time), mr, false)
+	c := NewComparator(actual, wait, maxWait, 50*time.Hour, 15*time.Minute, 4*time.Hour, 4*time.Hour, 0, 1*time.Minute, 0, 1*time.Hour, 3*time.Hour, 30*time.Minute, 0, 1, make(chan time.Time), make(chan time.Time), mr, false)
 
 	c.entrySent(t1)
 	c.entrySent(t2)
@@ -232,7 +232,7 @@ func TestConcurrentConfirmMissing(t *testing.T) {
 	wait := 30 * time.Millisecond
 	maxWait := 30 * time.Millisecond
 
-	c := NewComparator(output, wait, maxWait, 50*time.Hour, 15*time.Minute, 4*time.Hour, 4*time.Hour, 0, 1*time.Minute, 0, 1*time.Hour, 0, 1, make(chan time.Time), make(chan time.Time), mr, false)
+	c := NewComparator(output, wait, maxWait, 50*time.Hour, 15*time.Minute, 4*time.Hour, 4*time.Hour, 0, 1*time.Minute, 0, 1*time.Hour, 3*time.Hour, 30*time.Minute, 0, 1, make(chan time.Time), make(chan time.Time), mr, false)
 
 	for _, t := range found {
 		tCopy := t
@@ -263,7 +263,7 @@ func TestPruneAckdEntires(t *testing.T) {
 	wait := 30 * time.Millisecond
 	maxWait := 30 * time.Millisecond
 	//We set the prune interval timer to a huge value here so that it never runs, instead we call pruneEntries manually below
-	c := NewComparator(actual, wait, maxWait, 50*time.Hour, 15*time.Minute, 4*time.Hour, 4*time.Hour, 0, 1*time.Minute, 0, 1*time.Hour, 0, 1, make(chan time.Time), make(chan time.Time), nil, false)
+	c := NewComparator(actual, wait, maxWait, 50*time.Hour, 15*time.Minute, 4*time.Hour, 4*time.Hour, 0, 1*time.Minute, 0, 1*time.Hour, 3*time.Hour, 30*time.Minute, 0, 1, make(chan time.Time), make(chan time.Time), nil, false)
 
 	t1 := time.Unix(0, 0)
 	t2 := t1.Add(1 * time.Millisecond)
@@ -320,7 +320,7 @@ func TestSpotCheck(t *testing.T) {
 	spotCheck := 10 * time.Millisecond
 	spotCheckMax := 20 * time.Millisecond
 	//We set the prune interval timer to a huge value here so that it never runs, instead we call spotCheckEntries manually below
-	c := NewComparator(actual, 1*time.Hour, 1*time.Hour, 50*time.Hour, spotCheck, spotCheckMax, 4*time.Hour, 3*time.Millisecond, 1*time.Minute, 0, 1*time.Hour, 0, 1, make(chan time.Time), make(chan time.Time), mr, false)
+	c := NewComparator(actual, 1*time.Hour, 1*time.Hour, 50*time.Hour, spotCheck, spotCheckMax, 4*time.Hour, 3*time.Millisecond, 1*time.Minute, 0, 1*time.Hour, 3*time.Hour, 30*time.Minute, 0, 1, make(chan time.Time), make(chan time.Time), mr, false)
 
 	// Send all the entries
 	for i := range entries {
@@ -363,10 +363,12 @@ func TestSpotCheck(t *testing.T) {
 func TestCacheTest(t *testing.T) {
 	actual := &bytes.Buffer{}
 	mr := &mockReader{}
-	cacheTestInterval := 500 * time.Millisecond
 	now := time.Now()
+	cacheTestInterval := 500 * time.Millisecond
+	cacheTestRange := 30 * time.Second
+	cacheTestNow := 2 * time.Second
 
-	c := NewComparator(actual, 1*time.Hour, 1*time.Hour, 50*time.Hour, 0, 0, 4*time.Hour, 0, 10*time.Minute, 0, cacheTestInterval, 1*time.Hour, 1, make(chan time.Time), make(chan time.Time), mr, false)
+	c := NewComparator(actual, 1*time.Hour, 1*time.Hour, 50*time.Hour, 0, 0, 4*time.Hour, 0, 10*time.Minute, 0, cacheTestInterval, cacheTestRange, cacheTestNow, 1*time.Hour, 1, make(chan time.Time), make(chan time.Time), mr, false)
 	// Force the start time to a known value
 	c.startTime = time.Unix(10, 0)
 
@@ -406,7 +408,7 @@ func TestMetricTest(t *testing.T) {
 	mr := &mockReader{}
 	metricTestRange := 30 * time.Second
 	//We set the prune interval timer to a huge value here so that it never runs, instead we call spotCheckEntries manually below
-	c := NewComparator(actual, 1*time.Hour, 1*time.Hour, 50*time.Hour, 0, 0, 4*time.Hour, 0, 10*time.Minute, metricTestRange, 1*time.Hour, writeInterval, 1, make(chan time.Time), make(chan time.Time), mr, false)
+	c := NewComparator(actual, 1*time.Hour, 1*time.Hour, 50*time.Hour, 0, 0, 4*time.Hour, 0, 10*time.Minute, metricTestRange, 1*time.Hour, 3*time.Hour, 30*time.Minute, writeInterval, 1, make(chan time.Time), make(chan time.Time), mr, false)
 	// Force the start time to a known value
 	c.startTime = time.Unix(10, 0)
 

--- a/pkg/canary/comparator/comparator_test.go
+++ b/pkg/canary/comparator/comparator_test.go
@@ -372,23 +372,23 @@ func TestCacheTest(t *testing.T) {
 	// Force the start time to a known value
 	c.startTime = time.Unix(10, 0)
 
-	queryresultsdiff = &mockCounter{}
+	queryResultsDiff = &mockCounter{}
 	mr.countOverTime = 2.3
 	mr.noCacheCountOvertime = mr.countOverTime // same value for both with and without cache
 	c.cacheTest(now)
-	assert.Equal(t, 0, queryresultsdiff.(*mockCounter).count)
+	assert.Equal(t, 0, queryResultsDiff.(*mockCounter).count)
 
-	queryresultsdiff = &mockCounter{} // reset counter
+	queryResultsDiff = &mockCounter{} // reset counter
 	mr.countOverTime = 2.3            // value not important
 	mr.noCacheCountOvertime = 2.5     // different than `countOverTime` value.
 	c.cacheTest(now)
-	assert.Equal(t, 1, queryresultsdiff.(*mockCounter).count)
+	assert.Equal(t, 1, queryResultsDiff.(*mockCounter).count)
 
-	queryresultsdiff = &mockCounter{}    // reset counter
+	queryResultsDiff = &mockCounter{}    // reset counter
 	mr.countOverTime = 2.3               // value not important
 	mr.noCacheCountOvertime = 2.30000005 // different than `countOverTime` value but withing tolerance
 	c.cacheTest(now)
-	assert.Equal(t, 0, queryresultsdiff.(*mockCounter).count)
+	assert.Equal(t, 0, queryResultsDiff.(*mockCounter).count)
 
 	// This avoids a panic on subsequent test execution,
 	// seems ugly but was easy, and multiple instantiations
@@ -488,6 +488,42 @@ func (m *mockCounter) Add(float64) {
 }
 
 func (m *mockCounter) Inc() {
+	m.cLck.Lock()
+	defer m.cLck.Unlock()
+	m.count++
+}
+
+type mockCounterVec struct {
+	mockCounter
+	labels []string
+}
+
+func (m *mockCounterVec) WithLabelValues(lvs ...string) prometheus.Counter {
+	m.labels = lvs
+	return &m.mockCounter
+}
+
+func (m *mockCounterVec) Desc() *prometheus.Desc {
+	panic("implement me")
+}
+
+func (m *mockCounterVec) Write(*io_prometheus_client.Metric) error {
+	panic("implement me")
+}
+
+func (m *mockCounterVec) Describe(chan<- *prometheus.Desc) {
+	panic("implement me")
+}
+
+func (m *mockCounterVec) Collect(chan<- prometheus.Metric) {
+	panic("implement me")
+}
+
+func (m *mockCounterVec) Add(float64) {
+	panic("implement me")
+}
+
+func (m *mockCounterVec) Inc() {
 	m.cLck.Lock()
 	defer m.cLck.Unlock()
 	m.count++

--- a/pkg/canary/reader/reader.go
+++ b/pkg/canary/reader/reader.go
@@ -45,7 +45,7 @@ var (
 
 type LokiReader interface {
 	Query(start time.Time, end time.Time) ([]time.Time, error)
-	QueryCountOverTime(queryRange string) (float64, error)
+	QueryCountOverTime(queryRange string, now time.Time, cache bool) (float64, error)
 }
 
 type Reader struct {
@@ -180,7 +180,7 @@ func (r *Reader) Stop() {
 
 // QueryCountOverTime will ask Loki for a count of logs over the provided range e.g. 5m
 // QueryCountOverTime blocks if a previous query has failed until the appropriate backoff time has been reached.
-func (r *Reader) QueryCountOverTime(queryRange string) (float64, error) {
+func (r *Reader) QueryCountOverTime(queryRange string, now time.Time, cache bool) (float64, error) {
 	r.backoffMtx.RLock()
 	next := r.nextQuery
 	r.backoffMtx.RUnlock()
@@ -201,10 +201,10 @@ func (r *Reader) QueryCountOverTime(queryRange string) (float64, error) {
 		Host:   r.addr,
 		Path:   "/loki/api/v1/query",
 		RawQuery: "query=" + url.QueryEscape(fmt.Sprintf("count_over_time({%v=\"%v\",%v=\"%v\"}[%s])", r.sName, r.sValue, r.lName, r.lVal, queryRange)) +
-			fmt.Sprintf("&time=%d", time.Now().UnixNano()) +
+			fmt.Sprintf("&time=%d", now.UnixNano()) +
 			"&limit=1000",
 	}
-	fmt.Fprintf(r.w, "Querying loki for metric count with query: %v\n", u.String())
+	fmt.Fprintf(r.w, "Querying loki for metric count with query: %v, cache: %v\n", u.String(), cache)
 
 	ctx, cancel := context.WithTimeout(context.Background(), r.queryTimeout)
 	defer cancel()
@@ -221,6 +221,9 @@ func (r *Reader) QueryCountOverTime(queryRange string) (float64, error) {
 		req.Header.Set("X-Scope-OrgID", r.tenantID)
 	}
 	req.Header.Set("User-Agent", userAgent)
+	if !cache {
+		req.Header.Set("Cache-Control", "no-cache")
+	}
 
 	resp, err := r.httpClient.Do(req)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Recently, we added support for `Cache-Control` header for loki. 

This PR uses it to test if same query for same data returns same results with and without results cache.

Easy to catch any bug in results cache if there are any differences.

NOTE: This currently does `count_over_time` instant query for the cache test. In future we can extend it for range queries as well.

This PR introduces to additional metrics for `loki-canary` to track any differences in this test.
```
loki_canary_cache_test_query_results_total{status=~"success|fail"}
loki_canary_cache_test_query_results_diff_total
```

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

This is one of the step to gain more confidence on recently added "results cache" support for instant query.

Manually ingested logs with older timestamps to create discrepancy with results cache. And counters seems to be working fine.

```
# HELP loki_canary_cache_test_query_results_diff_total counts number of times the query results was different with and without cache 
# TYPE loki_canary_cache_test_query_results_diff_total counter
loki_canary_cache_test_query_results_diff_total 16
# HELP loki_canary_cache_test_query_results_total counts number of times the query results test requests are done 
# TYPE loki_canary_cache_test_query_results_total counter
loki_canary_cache_test_query_results_total{status="success"} 23
```

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
