### PR TITLE
fix: Do not filter out chunks for store when `From==Through` and `From==start` 

### DIFF
--- a/pkg/storage/stores/composite_store.go
+++ b/pkg/storage/stores/composite_store.go
@@ -172,8 +172,8 @@ func (c CompositeStore) GetChunks(
 ) ([][]chunk.Chunk, []*fetcher.Fetcher, error) {
 	chunkIDs := [][]chunk.Chunk{}
 	fetchers := []*fetcher.Fetcher{}
-	err := c.forStores(ctx, from, through, func(innerCtx context.Context, from, through model.Time, store Store) error {
-		ids, fetcher, err := store.GetChunks(innerCtx, userID, from, through, predicate, storeChunksOverride)
+	err := c.forStores(ctx, from, through, func(innerCtx context.Context, innerFrom, innerThrough model.Time, store Store) error {
+		ids, fetcher, err := store.GetChunks(innerCtx, userID, innerFrom, innerThrough, predicate, storeChunksOverride)
 		if err != nil {
 			return err
 		}

--- a/pkg/storage/stores/composite_store_entry.go
+++ b/pkg/storage/stores/composite_store_entry.go
@@ -92,8 +92,8 @@ func filterForTimeRange(refs []*logproto.ChunkRef, from, through model.Time) []c
 	for _, ref := range refs {
 		// Only include chunks where the query start time (from) is < the chunk end time (ref.Through)
 		// and the query end time (through) is >= the chunk start time (ref.From)
-		// A special case also exists where a chunk can contain a single log line which results in ref.From being equal to ref.Through, but only include this chunk if this log line timestamp is in the timerange of the query
-		if (through >= ref.From && from < ref.Through) || (ref.From == ref.Through && (ref.From >= from && ref.From < through) {
+		// A special case also exists where a chunk can contain a single log line which results in ref.From being equal to ref.Through, and that is equal to the from time.
+		if (through >= ref.From && from < ref.Through) || (ref.From == from && ref.Through == from) {
 			filtered = append(filtered, chunk.Chunk{
 				ChunkRef: *ref,
 			})

--- a/pkg/storage/stores/composite_store_entry.go
+++ b/pkg/storage/stores/composite_store_entry.go
@@ -90,7 +90,10 @@ func (c *storeEntry) GetChunks(
 func filterForTimeRange(refs []*logproto.ChunkRef, from, through model.Time) []chunk.Chunk {
 	filtered := make([]chunk.Chunk, 0, len(refs))
 	for _, ref := range refs {
-		if (through >= ref.From && from < ref.Through) || (ref.From == from && ref.Through == from) {
+		// Only include chunks where the query start time (from) is < the chunk end time (ref.Through)
+		// and the query end time (through) is >= the chunk start time (ref.From)
+		// A special case also exists where a chunk can contain a single log line which results in ref.From being equal to ref.Through, but only include this chunk if this log line timestamp is in the timerange of the query
+		if (through >= ref.From && from < ref.Through) || (ref.From == ref.Through && (ref.From >= from && ref.From < through) {
 			filtered = append(filtered, chunk.Chunk{
 				ChunkRef: *ref,
 			})

--- a/pkg/storage/stores/composite_store_entry.go
+++ b/pkg/storage/stores/composite_store_entry.go
@@ -90,7 +90,7 @@ func (c *storeEntry) GetChunks(
 func filterForTimeRange(refs []*logproto.ChunkRef, from, through model.Time) []chunk.Chunk {
 	filtered := make([]chunk.Chunk, 0, len(refs))
 	for _, ref := range refs {
-		if through >= ref.From && from < ref.Through {
+		if (through >= ref.From && from < ref.Through) || (ref.From == from && ref.Through == from) {
 			filtered = append(filtered, chunk.Chunk{
 				ChunkRef: *ref,
 			})

--- a/pkg/storage/stores/composite_store_test.go
+++ b/pkg/storage/stores/composite_store_test.go
@@ -421,6 +421,23 @@ func TestFilterForTimeRange(t *testing.T) {
 			through: 7,
 			exp:     mkChks(5, 7),
 		},
+		{
+			desc: "ref with from == through",
+			input: []*logproto.ChunkRef{
+				{From: 1, Through: 1}, // outside
+				{From: 2, Through: 2}, // ref.From == from == ref.Through
+				{From: 3, Through: 3}, // inside
+				{From: 4, Through: 4}, // ref.From == through == ref.Through
+				{From: 5, Through: 5}, // outside
+			},
+			from:    2,
+			through: 4,
+			exp: []chunk.Chunk{
+				{ChunkRef: logproto.ChunkRef{From: 2, Through: 2}},
+				{ChunkRef: logproto.ChunkRef{From: 3, Through: 3}},
+				{ChunkRef: logproto.ChunkRef{From: 4, Through: 4}},
+			},
+		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
 			got := filterForTimeRange(tc.input, tc.from, tc.through)


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes a bug where chunks are incorrectly filtered out when their `From` timestamp is equal to their `Through` timestamp (which happens when there is a single log line) and the `From` timestamp is equal to the `from` time of the of the request.

How to reproduce:

1. Insert a single log line with a timestamp exactly at point of an hour
2. Flush ingester
3. Query log line with a split interval of 1h

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

* In a query range, the `From` is inclusive and the `Through` is exclusive
* In a ChunkRef, both `From` and `Through` are inclusive, because `Through` represents the timestamp of the last log line in the chunk.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
