### PR TITLE
fix: Add copyString function to symbolizer to avoid retaining  memory

### DIFF
--- a/pkg/chunkenc/symbols.go
+++ b/pkg/chunkenc/symbols.go
@@ -78,6 +78,7 @@ func (s *symbolizer) add(lbl string) uint32 {
 
 	idx, ok = s.symbolsMap[lbl]
 	if !ok {
+		lbl = copyString(lbl)
 		idx = uint32(len(s.labels))
 		s.symbolsMap[lbl] = idx
 		s.labels = append(s.labels, lbl)
@@ -85,6 +86,13 @@ func (s *symbolizer) add(lbl string) uint32 {
 	}
 
 	return idx
+}
+
+// copyString returns a copy of the string
+func copyString(s string) string {
+	buf := make([]byte, len(s))
+	copy(buf, s)
+	return string(buf)
 }
 
 // Lookup coverts and returns labels pairs for the given symbols

--- a/pkg/chunkenc/symbols.go
+++ b/pkg/chunkenc/symbols.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"hash"
 	"io"
+	"strings"
 	"sync"
 
 	"github.com/pkg/errors"
@@ -78,7 +79,7 @@ func (s *symbolizer) add(lbl string) uint32 {
 
 	idx, ok = s.symbolsMap[lbl]
 	if !ok {
-		lbl = copyString(lbl)
+		lbl = strings.Clone(lbl)
 		idx = uint32(len(s.labels))
 		s.symbolsMap[lbl] = idx
 		s.labels = append(s.labels, lbl)
@@ -86,13 +87,6 @@ func (s *symbolizer) add(lbl string) uint32 {
 	}
 
 	return idx
-}
-
-// copyString returns a copy of the string
-func copyString(s string) string {
-	buf := make([]byte, len(s))
-	copy(buf, s)
-	return string(buf)
 }
 
 // Lookup coverts and returns labels pairs for the given symbols


### PR DESCRIPTION
**What this PR does / why we need it**:

This was reported by the community that when using structured metadata ingester were leaking memory.

Labels have a special proto Unmarshaller to avoid string copy since it was never interned before it was never causing a problem. But since the addition of structured metadata we now do intern thoses labels and they hold reference of the full GRPC buffer from the push request. 

https://github.com/grafana/loki/blob/main/vendor/github.com/grafana/loki/pkg/push/types.go#L667

To fix the issue I simply copy the string before interning it. We could consider removing this optimisation too, but I'm afraid it will have other impact so going safe for now.

**Which issue(s) this PR fixes**:
Fixes #13123

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
