### PR TITLE
chore(blooms): Some boom gateway cleanups

### DIFF
--- a/pkg/bloomgateway/bloomgateway.go
+++ b/pkg/bloomgateway/bloomgateway.go
@@ -63,7 +63,6 @@ import (
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/bloomshipper"
 	"github.com/grafana/loki/v3/pkg/util"
 	"github.com/grafana/loki/v3/pkg/util/constants"
-	util_log "github.com/grafana/loki/v3/pkg/util/log"
 	utillog "github.com/grafana/loki/v3/pkg/util/log"
 	"github.com/grafana/loki/v3/pkg/util/spanlogger"
 )
@@ -209,7 +208,7 @@ func (g *Gateway) FilterChunkRefs(ctx context.Context, req *logproto.FilterChunk
 	stats, ctx := ContextWithEmptyStats(ctx)
 	logger := spanlogger.FromContextWithFallback(
 		ctx,
-		util_log.WithContext(ctx, g.logger),
+		utillog.WithContext(ctx, g.logger),
 	)
 
 	defer func() {
@@ -340,7 +339,7 @@ func (g *Gateway) FilterChunkRefs(ctx context.Context, req *logproto.FilterChunk
 		}
 	}
 
-	combinedRecorder.Report(util_log.WithContext(ctx, g.logger), g.bloomStore.BloomMetrics())
+	combinedRecorder.Report(utillog.WithContext(ctx, g.logger), g.bloomStore.BloomMetrics())
 	sp.LogKV("msg", "received all responses")
 
 	start := time.Now()

--- a/pkg/bloomgateway/bloomgateway.go
+++ b/pkg/bloomgateway/bloomgateway.go
@@ -1,43 +1,7 @@
 /*
-Bloom Gateway package
-
 The bloom gateway is a component that can be run as a standalone microserivce
 target and provides capabilities for filtering ChunkRefs based on a given list
 of line filter expressions.
-
-			     Querier   Query Frontend
-			        |           |
-			................................... service boundary
-			        |           |
-			        +----+------+
-			             |
-			     indexgateway.Gateway
-			             |
-			   bloomgateway.BloomQuerier
-			             |
-			   bloomgateway.GatewayClient
-			             |
-			  logproto.BloomGatewayClient
-			             |
-			................................... service boundary
-			             |
-			      bloomgateway.Gateway
-			             |
-		       queue.RequestQueue
-			             |
-		       bloomgateway.Worker
-			             |
-		     bloomgateway.Processor
-			             |
-	         bloomshipper.Store
-			             |
-	         bloomshipper.Client
-			             |
-			        ObjectClient
-			             |
-			................................... service boundary
-			             |
-		         object storage
 */
 package bloomgateway
 

--- a/pkg/bloomgateway/bloomgateway.go
+++ b/pkg/bloomgateway/bloomgateway.go
@@ -31,8 +31,6 @@ import (
 	"github.com/grafana/loki/v3/pkg/util/spanlogger"
 )
 
-var errGatewayUnhealthy = errors.New("bloom-gateway is unhealthy in the ring")
-
 const (
 	metricsSubsystem        = "bloom_gateway"
 	querierMetricsSubsystem = "bloom_gateway_querier"

--- a/pkg/bloomgateway/bloomgateway.go
+++ b/pkg/bloomgateway/bloomgateway.go
@@ -222,9 +222,6 @@ func (g *Gateway) FilterChunkRefs(ctx context.Context, req *logproto.FilterChunk
 		}, nil
 	}
 
-	// TODO(chaudum): I intentionally keep the logic for handling multiple tasks,
-	// so that the PR does not explode in size. This should be cleaned up at some point.
-
 	seriesByDay := partitionRequest(req)
 	stats.NumTasks = len(seriesByDay)
 
@@ -240,14 +237,13 @@ func (g *Gateway) FilterChunkRefs(ctx context.Context, req *logproto.FilterChunk
 		return nil, errors.New("request time range must span exactly one day")
 	}
 
-	tasks := make([]Task, 0, len(seriesByDay))
-	responses := make([][]v1.Output, 0, len(seriesByDay))
-	for _, seriesForDay := range seriesByDay {
-		task := newTask(ctx, tenantID, seriesForDay, filters, blocks)
-		// TODO(owen-d): include capacity in constructor?
-		task.responses = responsesPool.Get(len(seriesForDay.series))
-		tasks = append(tasks, task)
-	}
+	series := seriesByDay[0]
+	task := newTask(ctx, tenantID, series, filters, blocks)
+
+	// TODO(owen-d): include capacity in constructor?
+	task.responses = responsesPool.Get(len(series.series))
+	// free up the responses
+	defer responsesPool.Put(task.responses)
 
 	g.activeUsers.UpdateUserTimestamp(tenantID, time.Now())
 
@@ -258,61 +254,40 @@ func (g *Gateway) FilterChunkRefs(ctx context.Context, req *logproto.FilterChunk
 		preFilterChunks += len(series.Refs)
 	}
 
-	// Ideally we could use an unbuffered channel here, but since we return the
-	// request on the first error, there can be cases where the request context
-	// is not done yet and the consumeTask() function wants to send to the
-	// tasksCh, but nobody reads from it any more.
-	queueStart := time.Now()
-	tasksCh := make(chan Task, len(tasks))
-	for _, task := range tasks {
-		task := task
-		task.enqueueTime = time.Now()
+	tasksCh := make(chan Task, 1)
 
-		// TODO(owen-d): gracefully handle full queues
-		if err := g.queue.Enqueue(tenantID, nil, task, func() {
-			// When enqueuing, we also add the task to the pending tasks
-			_ = g.pendingTasks.Inc()
-		}); err != nil {
-			stats.Status = labelFailure
-			return nil, errors.Wrap(err, "failed to enqueue task")
-		}
-		// TODO(owen-d): use `concurrency` lib, bound parallelism
-		go g.consumeTask(ctx, task, tasksCh)
+	// TODO(owen-d): gracefully handle full queues
+	task.enqueueTime = time.Now()
+	if err := g.queue.Enqueue(tenantID, nil, task, func() {
+		// When enqueuing, we also add the task to the pending tasks
+		_ = g.pendingTasks.Inc()
+	}); err != nil {
+		stats.Status = labelFailure
+		return nil, errors.Wrap(err, "failed to enqueue task")
 	}
-
-	sp.LogKV("msg", "enqueued tasks", "duration", time.Since(queueStart).String())
-
-	remaining := len(tasks)
+	// TODO(owen-d): use `concurrency` lib, bound parallelism
+	go g.consumeTask(ctx, task, tasksCh)
 
 	combinedRecorder := v1.NewBloomRecorder(ctx, "combined")
-	for remaining > 0 {
-		select {
-		case <-ctx.Done():
-			stats.Status = "cancel"
-			return nil, errors.Wrap(ctx.Err(), "request failed")
-		case task := <-tasksCh:
-			if task.Err() != nil {
-				stats.Status = labelFailure
-				return nil, errors.Wrap(task.Err(), "request failed")
-			}
-			responses = append(responses, task.responses)
-			combinedRecorder.Merge(task.recorder)
-			remaining--
+
+	select {
+	case <-ctx.Done():
+		stats.Status = "cancel"
+		return nil, errors.Wrap(ctx.Err(), "request failed")
+	case task = <-tasksCh:
+		if task.Err() != nil {
+			stats.Status = labelFailure
+			return nil, errors.Wrap(task.Err(), "request failed")
 		}
+		combinedRecorder.Merge(task.recorder)
 	}
 
 	combinedRecorder.Report(utillog.WithContext(ctx, g.logger), g.bloomStore.BloomMetrics())
-	sp.LogKV("msg", "received all responses")
 
 	start := time.Now()
-	filtered := filterChunkRefs(req, responses)
+	filtered := filterChunkRefs(req, task.responses)
 	duration := time.Since(start)
 	stats.AddPostProcessingTime(duration)
-
-	// free up the responses
-	for _, resp := range responses {
-		responsesPool.Put(resp)
-	}
 
 	var postFilterSeries, postFilterChunks int
 	postFilterSeries = len(filtered)
@@ -365,35 +340,13 @@ func (g *Gateway) consumeTask(ctx context.Context, task Task, tasksCh chan<- Tas
 	}
 }
 
-// merges a list of responses via a heap. The same fingerprints and chunks can be present in multiple responses.
-// Individual responses do not need to be be ordered beforehand.
-func orderedResponsesByFP(responses [][]v1.Output) v1.Iterator[v1.Output] {
-	if len(responses) == 0 {
-		return v1.NewEmptyIter[v1.Output]()
-	}
-	if len(responses) == 1 {
-		sort.Slice(responses[0], func(i, j int) bool { return responses[0][i].Fp < responses[0][j].Fp })
-		return v1.NewSliceIter(responses[0])
-	}
-
-	itrs := make([]v1.PeekingIterator[v1.Output], 0, len(responses))
-	for _, r := range responses {
-		sort.Slice(r, func(i, j int) bool { return r[i].Fp < r[j].Fp })
-		itrs = append(itrs, v1.NewPeekingIter(v1.NewSliceIter(r)))
-	}
-	return v1.NewHeapIterator[v1.Output](
-		func(o1, o2 v1.Output) bool { return o1.Fp < o2.Fp },
-		itrs...,
-	)
-}
-
 // TODO(owen-d): improve perf. This can be faster with a more specialized impl
 // NB(owen-d): `req` is mutated in place for performance, but `responses` is not
 // Removals of the outputs must be sorted.
-func filterChunkRefs(
-	req *logproto.FilterChunkRefRequest,
-	responses [][]v1.Output,
-) []*logproto.GroupedChunkRefs {
+func filterChunkRefs(req *logproto.FilterChunkRefRequest, responses []v1.Output) []*logproto.GroupedChunkRefs {
+	// sort responses by fingerprint
+	sort.Slice(responses, func(i, j int) bool { return responses[i].Fp < responses[j].Fp })
+
 	res := make([]*logproto.GroupedChunkRefs, 0, len(req.Refs))
 
 	// dedupe outputs, merging the same series.
@@ -442,7 +395,7 @@ func filterChunkRefs(
 			res.Removals = chks
 			return res
 		},
-		v1.NewPeekingIter(orderedResponsesByFP(responses)),
+		v1.NewPeekingIter(v1.NewSliceIter(responses)),
 	)
 
 	// Iterate through the requested and filtered series/chunks,

--- a/pkg/bloomgateway/util.go
+++ b/pkg/bloomgateway/util.go
@@ -28,12 +28,7 @@ func getFromThrough(refs []*logproto.ShortRef) (model.Time, model.Time) {
 	}
 
 	maxItem := slices.MaxFunc(refs, func(a, b *logproto.ShortRef) int {
-		if a.Through > b.Through {
-			return 1
-		} else if a.Through < b.Through {
-			return -1
-		}
-		return 0
+		return int(a.Through) - int(b.Through)
 	})
 
 	return refs[0].From, maxItem.Through

--- a/pkg/bloomgateway/util.go
+++ b/pkg/bloomgateway/util.go
@@ -35,11 +35,10 @@ func getFromThrough(refs []*logproto.ShortRef) (model.Time, model.Time) {
 }
 
 // convertToChunkRefs converts a []*logproto.ShortRef into v1.ChunkRefs
-// TODO(chaudum): Avoid conversion by transferring v1.ChunkRefs in gRPC request.
 func convertToChunkRefs(refs []*logproto.ShortRef) v1.ChunkRefs {
 	result := make(v1.ChunkRefs, 0, len(refs))
-	for _, ref := range refs {
-		result = append(result, v1.ChunkRef{From: ref.From, Through: ref.Through, Checksum: ref.Checksum})
+	for i := range refs {
+		result = append(result, v1.ChunkRef(*refs[i]))
 	}
 	return result
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

* Cleanup logic for processing multiple days
  in single `FilterChunkRefs` request in the bloom gateway. The handler
  already returned an error if the requested chunk refs spanned across
  multiple days, but the logic for processing multiple days/tasks was
  still in place. This commit simplifies the logic to only process a
  single task per request.

* Remove unused package global variable

* Remove bloomgateway package comment

* Remove duplicate imports

* Avoid conversion from *logproto.ShortRef to v1.ChunkRef
  and istead cast the value of the pointer

* Simplify `getFromThrough()` function


**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
