### PR TITLE
fix: Fix bloom deleter PR after merge

### DIFF
--- a/pkg/bloombuild/planner/planner.go
+++ b/pkg/bloombuild/planner/planner.go
@@ -365,10 +365,7 @@ func (p *Planner) processTenantTaskResults(
 	}
 
 	combined := append(originalMetas, newMetas...)
-	outdated, err := outdatedMetas(combined)
-	if err != nil {
-		return fmt.Errorf("failed to find outdated metas: %w", err)
-	}
+	outdated := outdatedMetas(combined)
 	level.Debug(logger).Log("msg", "found outdated metas", "outdated", len(outdated))
 
 	if err := p.deleteOutdatedMetasAndBlocks(ctx, table, tenant, outdated); err != nil {
@@ -476,7 +473,7 @@ func (p *Planner) loadTenantWork(
 
 		// If this is the first this we see this table, initialize the map
 		if tenantTableWork[table] == nil {
-			tenantTableWork[table] = make(map[string][]v1.FingerprintBounds, tenants.Len())
+			tenantTableWork[table] = make(map[string][]v1.FingerprintBounds, tenants.Remaining())
 		}
 
 		for tenants.Next() && tenants.Err() == nil && ctx.Err() == nil {

--- a/pkg/bloombuild/planner/versioned_range_test.go
+++ b/pkg/bloombuild/planner/versioned_range_test.go
@@ -315,8 +315,7 @@ func Test_OutdatedMetas(t *testing.T) {
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
-			outdated, err := outdatedMetas(tc.metas)
-			require.NoError(t, err)
+			outdated := outdatedMetas(tc.metas)
 			require.Equal(t, tc.exp, outdated)
 		})
 	}


### PR DESCRIPTION
Fixes https://github.com/grafana/loki/pull/13153. Reimplemented `outdatedMetas` as it's currently implemented in the bloomcompactor pkg:
https://github.com/grafana/loki/blob/fbe7c559b5ed153fb46a1965c24180011a558b85/pkg/bloomcompactor/versioned_range.go#L213

**nit**: I'm removing the err returned by `outdatedMetas` since it's always nil.

