### PR TITLE
fix: Correctly encode step when translating proto to http internally

### DIFF
--- a/pkg/logproto/compat.go
+++ b/pkg/logproto/compat.go
@@ -506,6 +506,33 @@ func (m *ShardsRequest) LogToSpan(sp opentracing.Span) {
 	sp.LogFields(fields...)
 }
 
+func (m *DetectedFieldsRequest) GetCachingOptions() (res definitions.CachingOptions) { return }
+
+func (m *DetectedFieldsRequest) WithStartEnd(start, end time.Time) definitions.Request {
+	clone := *m
+	clone.Start = start
+	clone.End = end
+	return &clone
+}
+
+func (m *DetectedFieldsRequest) WithQuery(query string) definitions.Request {
+	clone := *m
+	clone.Query = query
+	return &clone
+}
+
+func (m *DetectedFieldsRequest) LogToSpan(sp opentracing.Span) {
+	fields := []otlog.Field{
+		otlog.String("query", m.GetQuery()),
+		otlog.String("start", m.Start.String()),
+		otlog.String("end", m.End.String()),
+		otlog.String("step", time.Duration(m.Step).String()),
+		otlog.String("field_limit", fmt.Sprintf("%d", m.FieldLimit)),
+		otlog.String("line_limit", fmt.Sprintf("%d", m.LineLimit)),
+	}
+	sp.LogFields(fields...)
+}
+
 func (m *QueryPatternsRequest) GetCachingOptions() (res definitions.CachingOptions) { return }
 
 func (m *QueryPatternsRequest) WithStartEnd(start, end time.Time) definitions.Request {
@@ -531,6 +558,36 @@ func (m *QueryPatternsRequest) LogToSpan(sp opentracing.Span) {
 		otlog.String("start", m.Start.String()),
 		otlog.String("end", m.End.String()),
 		otlog.String("step", time.Duration(m.Step).String()),
+	}
+	sp.LogFields(fields...)
+}
+
+func (m *DetectedLabelsRequest) GetStep() int64 { return 0 }
+
+func (m *DetectedLabelsRequest) GetCachingOptions() (res definitions.CachingOptions) { return }
+
+func (m *DetectedLabelsRequest) WithStartEnd(start, end time.Time) definitions.Request {
+	clone := *m
+	clone.Start = start
+	clone.End = end
+	return &clone
+}
+
+func (m *DetectedLabelsRequest) WithQuery(query string) definitions.Request {
+	clone := *m
+	clone.Query = query
+	return &clone
+}
+
+func (m *DetectedLabelsRequest) WithStartEndForCache(start, end time.Time) resultscache.Request {
+	return m.WithStartEnd(start, end).(resultscache.Request)
+}
+
+func (m *DetectedLabelsRequest) LogToSpan(sp opentracing.Span) {
+	fields := []otlog.Field{
+		otlog.String("query", m.GetQuery()),
+		otlog.String("start", m.Start.String()),
+		otlog.String("end", m.End.String()),
 	}
 	sp.LogFields(fields...)
 }

--- a/pkg/querier/queryrange/codec.go
+++ b/pkg/querier/queryrange/codec.go
@@ -919,7 +919,10 @@ func (c Codec) EncodeRequest(ctx context.Context, r queryrangebase.Request) (*ht
 			"end":         []string{fmt.Sprintf("%d", request.End.UnixNano())},
 			"line_limit":  []string{fmt.Sprintf("%d", request.GetLineLimit())},
 			"field_limit": []string{fmt.Sprintf("%d", request.GetFieldLimit())},
-			"step":        []string{fmt.Sprintf("%d", request.GetStep())},
+		}
+
+		if request.Step != 0 {
+			params["step"] = []string{fmt.Sprintf("%f", float64(request.Step)/float64(1e3))}
 		}
 
 		u := &url.URL{
@@ -940,7 +943,10 @@ func (c Codec) EncodeRequest(ctx context.Context, r queryrangebase.Request) (*ht
 			"query": []string{request.GetQuery()},
 			"start": []string{fmt.Sprintf("%d", request.Start.UnixNano())},
 			"end":   []string{fmt.Sprintf("%d", request.End.UnixNano())},
-			"step":  []string{fmt.Sprintf("%d", request.GetStep())},
+		}
+
+		if request.Step != 0 {
+			params["step"] = []string{fmt.Sprintf("%f", float64(request.Step)/float64(1e3))}
 		}
 
 		u := &url.URL{

--- a/pkg/querier/queryrange/codec_test.go
+++ b/pkg/querier/queryrange/codec_test.go
@@ -10,7 +10,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strconv"
-	strings "strings"
+	"strings"
 	"testing"
 	"time"
 
@@ -201,6 +201,57 @@ func Test_codec_EncodeDecodeRequest(t *testing.T) {
 			Limit:       100,
 			Step:        30 * 1e3, // step is expected in ms; default is 0 or no step
 			AggregateBy: "series",
+		}, false},
+		{"detected_fields", func() (*http.Request, error) {
+			return DefaultCodec.EncodeRequest(ctx, &DetectedFieldsRequest{
+				logproto.DetectedFieldsRequest{
+					Query:      `{foo="bar"}`,
+					Start:      start,
+					End:        end,
+					Step:       30 * 1e3, // step is expected in ms; default is 0 or no step
+					LineLimit:  100,
+					FieldLimit: 100,
+				},
+				"/loki/api/v1/detected_fields",
+			})
+		}, &DetectedFieldsRequest{
+			logproto.DetectedFieldsRequest{
+				Query:      `{foo="bar"}`,
+				Start:      start,
+				End:        end,
+				Step:       30 * 1e3, // step is expected in ms; default is 0 or no step
+				LineLimit:  100,
+				FieldLimit: 100,
+			},
+			"/loki/api/v1/detected_fields",
+		}, false},
+		{"patterns", func() (*http.Request, error) {
+			return DefaultCodec.EncodeRequest(ctx, &logproto.QueryPatternsRequest{
+				Start: start,
+				End:   end,
+				Step:  30 * 1e3, // step is expected in ms
+			})
+		}, &logproto.QueryPatternsRequest{
+			Start: start,
+			End:   end,
+			Step:  30 * 1e3, // step is expected in ms; default is 0 or no step
+		}, false},
+		{"detected_labels", func() (*http.Request, error) {
+			return DefaultCodec.EncodeRequest(ctx, &DetectedLabelsRequest{
+				"/loki/api/v1/detected_labels",
+				logproto.DetectedLabelsRequest{
+					Query: `{foo="bar"}`,
+					Start: start,
+					End:   end,
+				},
+			})
+		}, &DetectedLabelsRequest{
+			"/loki/api/v1/detected_labels",
+			logproto.DetectedLabelsRequest{
+				Query: `{foo="bar"}`,
+				Start: start,
+				End:   end,
+			},
 		}, false},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes the encoding from a proto to a http request for QueryPatterns & DetectedFields & DetectedLabels
- The step parameter is represented internally as a int64 number of milliseconds but the HTTP API expects either a duration string or a int number of seconds. 
- When using HTTP between internal components, we were adding step to a query string as-is so the step parameter in milliseconds was being treated as seconds, hence the API eventually returned  one big aggregated datapoint instead of many smaller ones.
- This only shows up when **not** using `frontend: protobuf` so it was tough to reproduce locally. With protobuf encoding, everything worked as expected.
- The same bug was affecting DetectedFields too but we just didn't notice it yet.

Fixes https://github.com/grafana/loki/issues/13155
