### PR TITLE
fix: errors reported by the race detector

### DIFF
--- a/pkg/analytics/reporter.go
+++ b/pkg/analytics/reporter.go
@@ -262,7 +262,7 @@ func (rep *Reporter) running(ctx context.Context) error {
 		}
 		return nil
 	}
-	rep.startCPUPercentCollection(ctx)
+	rep.startCPUPercentCollection(ctx, time.Minute)
 	// check every minute if we should report.
 	ticker := time.NewTicker(reportCheckInterval)
 	defer ticker.Stop()
@@ -317,13 +317,13 @@ func (rep *Reporter) reportUsage(ctx context.Context, interval time.Time) error 
 	return errs.Err()
 }
 
+const cpuUsageKey = "cpu_usage"
+
 var (
-	cpuUsageKey           = "cpu_usage"
-	cpuUsage              = NewFloat(cpuUsageKey)
-	cpuCollectionInterval = time.Minute
+	cpuUsage = NewFloat(cpuUsageKey)
 )
 
-func (rep *Reporter) startCPUPercentCollection(ctx context.Context) {
+func (rep *Reporter) startCPUPercentCollection(ctx context.Context, cpuCollectionInterval time.Duration) {
 	proc, err := process.NewProcess(int32(os.Getpid()))
 	if err != nil {
 		level.Debug(rep.logger).Log("msg", "failed to get process", "err", err)

--- a/pkg/analytics/reporter_test.go
+++ b/pkg/analytics/reporter_test.go
@@ -159,14 +159,13 @@ func TestWrongKV(t *testing.T) {
 }
 
 func TestStartCPUCollection(t *testing.T) {
-	cpuCollectionInterval = 1 * time.Second
 	r, err := NewReporter(Config{Leader: true, Enabled: true}, kv.Config{
 		Store: "inmemory",
 	}, nil, log.NewLogfmtLogger(os.Stdout), prometheus.NewPedanticRegistry())
 	require.NoError(t, err)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	r.startCPUPercentCollection(ctx)
+	r.startCPUPercentCollection(ctx, 1*time.Second)
 	require.Eventually(t, func() bool {
 		return cpuUsage.Value() > 0
 	}, 5*time.Second, 1*time.Second)

--- a/pkg/bloombuild/planner/planner_test.go
+++ b/pkg/bloombuild/planner/planner_test.go
@@ -517,7 +517,7 @@ func Test_BuilderLoop(t *testing.T) {
 			resultsCh := make(chan *protos.TaskResult, nTasks)
 			tasks := createTasks(nTasks, resultsCh)
 			for _, task := range tasks {
-				err = planner.enqueueTask(task)
+				err := planner.enqueueTask(task)
 				require.NoError(t, err)
 			}
 
@@ -527,10 +527,10 @@ func Test_BuilderLoop(t *testing.T) {
 				builder := newMockBuilder(fmt.Sprintf("builder-%d", i))
 				builders = append(builders, builder)
 
-				go func() {
-					err = planner.BuilderLoop(builder)
-					require.ErrorIs(t, err, tc.expectedBuilderLoopError)
-				}()
+				go func(expectedBuilderLoopError error) {
+					err := planner.BuilderLoop(builder)
+					require.ErrorIs(t, err, expectedBuilderLoopError)
+				}(tc.expectedBuilderLoopError)
 			}
 
 			// Eventually, all tasks should be sent to builders
@@ -558,7 +558,7 @@ func Test_BuilderLoop(t *testing.T) {
 
 				// Enqueue tasks again
 				for _, task := range tasks {
-					err = planner.enqueueTask(task)
+					err := planner.enqueueTask(task)
 					require.NoError(t, err)
 				}
 

--- a/pkg/bloombuild/planner/planner_test.go
+++ b/pkg/bloombuild/planner/planner_test.go
@@ -809,6 +809,7 @@ func Test_processTenantTaskResults(t *testing.T) {
 }
 
 type fakeBuilder struct {
+	mx          sync.Mutex
 	id          string
 	tasks       []*protos.Task
 	currTaskIdx int
@@ -833,6 +834,8 @@ func newMockBuilder(id string) *fakeBuilder {
 }
 
 func (f *fakeBuilder) ReceivedTasks() []*protos.Task {
+	f.mx.Lock()
+	defer f.mx.Unlock()
 	return f.tasks
 }
 
@@ -873,6 +876,8 @@ func (f *fakeBuilder) Send(req *protos.PlannerToBuilder) error {
 		return err
 	}
 
+	f.mx.Lock()
+	defer f.mx.Unlock()
 	f.tasks = append(f.tasks, task)
 	f.currTaskIdx++
 	return nil

--- a/pkg/bloombuild/planner/planner_test.go
+++ b/pkg/bloombuild/planner/planner_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
 	"google.golang.org/grpc"
 
 	"github.com/grafana/loki/v3/pkg/bloombuild/protos"
@@ -809,15 +810,15 @@ func Test_processTenantTaskResults(t *testing.T) {
 }
 
 type fakeBuilder struct {
-	mx          sync.Mutex
+	mx          sync.Mutex // Protects tasks and currTaskIdx.
 	id          string
 	tasks       []*protos.Task
 	currTaskIdx int
 	grpc.ServerStream
 
-	returnError    bool
-	returnErrorMsg bool
-	wait           bool
+	returnError    atomic.Bool
+	returnErrorMsg atomic.Bool
+	wait           atomic.Bool
 	ctx            context.Context
 	ctxCancel      context.CancelFunc
 }
@@ -840,15 +841,15 @@ func (f *fakeBuilder) ReceivedTasks() []*protos.Task {
 }
 
 func (f *fakeBuilder) SetReturnError(b bool) {
-	f.returnError = b
+	f.returnError.Store(b)
 }
 
 func (f *fakeBuilder) SetReturnErrorMsg(b bool) {
-	f.returnErrorMsg = b
+	f.returnErrorMsg.Store(b)
 }
 
 func (f *fakeBuilder) SetWait(b bool) {
-	f.wait = b
+	f.wait.Store(b)
 }
 
 func (f *fakeBuilder) CancelContext(b bool) {
@@ -891,12 +892,12 @@ func (f *fakeBuilder) Recv() (*protos.BuilderToPlanner, error) {
 		}, nil
 	}
 
-	if f.returnError {
+	if f.returnError.Load() {
 		return nil, fmt.Errorf("fake error from %s", f.id)
 	}
 
 	// Wait until `wait` is false
-	for f.wait {
+	for f.wait.Load() {
 		time.Sleep(time.Second)
 	}
 
@@ -906,10 +907,12 @@ func (f *fakeBuilder) Recv() (*protos.BuilderToPlanner, error) {
 	}
 
 	var errMsg string
-	if f.returnErrorMsg {
+	if f.returnErrorMsg.Load() {
 		errMsg = fmt.Sprintf("fake error from %s", f.id)
 	}
 
+	f.mx.Lock()
+	defer f.mx.Unlock()
 	return &protos.BuilderToPlanner{
 		BuilderID: f.id,
 		Result: protos.ProtoTaskResult{

--- a/pkg/bloombuild/planner/task.go
+++ b/pkg/bloombuild/planner/task.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"time"
 
+	"go.uber.org/atomic"
+
 	"github.com/grafana/loki/v3/pkg/bloombuild/protos"
 )
 
@@ -13,7 +15,7 @@ type QueueTask struct {
 	resultsChannel chan *protos.TaskResult
 
 	// Tracking
-	timesEnqueued int
+	timesEnqueued atomic.Int64
 	queueTime     time.Time
 	ctx           context.Context
 }

--- a/pkg/bloomgateway/bloomgateway_test.go
+++ b/pkg/bloomgateway/bloomgateway_test.go
@@ -140,8 +140,8 @@ func TestBloomGateway_FilterChunkRefs(t *testing.T) {
 	t.Run("request fails when providing invalid block", func(t *testing.T) {
 		now := mktime("2023-10-03 10:00")
 
-		_, metas, queriers, data := createBlocks(t, tenantID, 10, now.Add(-1*time.Hour), now, 0x0000, 0x0fff)
-		mockStore := newMockBloomStore(queriers, metas)
+		refs, metas, queriers, data := createBlocks(t, tenantID, 10, now.Add(-1*time.Hour), now, 0x0000, 0x0fff)
+		mockStore := newMockBloomStore(refs, queriers, metas)
 
 		reg := prometheus.NewRegistry()
 		gw, err := New(cfg, mockStore, logger, reg)
@@ -176,7 +176,7 @@ func TestBloomGateway_FilterChunkRefs(t *testing.T) {
 		now := mktime("2023-10-03 10:00")
 
 		refs, metas, queriers, data := createBlocks(t, tenantID, 10, now.Add(-1*time.Hour), now, 0x0000, 0x0fff)
-		mockStore := newMockBloomStore(queriers, metas)
+		mockStore := newMockBloomStore(refs, queriers, metas)
 		mockStore.err = errors.New("request failed")
 
 		reg := prometheus.NewRegistry()
@@ -220,7 +220,7 @@ func TestBloomGateway_FilterChunkRefs(t *testing.T) {
 
 		// replace store implementation and re-initialize workers and sub-services
 		refs, metas, queriers, data := createBlocks(t, tenantID, 10, now.Add(-1*time.Hour), now, 0x0000, 0x0fff)
-		mockStore := newMockBloomStore(queriers, metas)
+		mockStore := newMockBloomStore(refs, queriers, metas)
 		mockStore.delay = 2000 * time.Millisecond
 
 		reg := prometheus.NewRegistry()
@@ -263,7 +263,7 @@ func TestBloomGateway_FilterChunkRefs(t *testing.T) {
 		now := mktime("2023-10-03 10:00")
 
 		reg := prometheus.NewRegistry()
-		gw, err := New(cfg, newMockBloomStore(nil, nil), logger, reg)
+		gw, err := New(cfg, newMockBloomStore(nil, nil, nil), logger, reg)
 		require.NoError(t, err)
 
 		err = services.StartAndAwaitRunning(context.Background(), gw)
@@ -309,7 +309,7 @@ func TestBloomGateway_FilterChunkRefs(t *testing.T) {
 		now := mktime("2023-10-03 10:00")
 
 		reg := prometheus.NewRegistry()
-		gw, err := New(cfg, newMockBloomStore(nil, nil), logger, reg)
+		gw, err := New(cfg, newMockBloomStore(nil, nil, nil), logger, reg)
 		require.NoError(t, err)
 
 		err = services.StartAndAwaitRunning(context.Background(), gw)
@@ -363,7 +363,7 @@ func TestBloomGateway_FilterChunkRefs(t *testing.T) {
 		refs, metas, queriers, data := createBlocks(t, tenantID, 10, now.Add(-1*time.Hour), now, 0x0000, 0x0fff)
 
 		reg := prometheus.NewRegistry()
-		store := newMockBloomStore(queriers, metas)
+		store := newMockBloomStore(refs, queriers, metas)
 
 		gw, err := New(cfg, store, logger, reg)
 		require.NoError(t, err)

--- a/pkg/bloomgateway/util_test.go
+++ b/pkg/bloomgateway/util_test.go
@@ -392,12 +392,12 @@ func TestPartitionRequest(t *testing.T) {
 	}
 }
 
-func createBlocks(t *testing.T, tenant string, n int, from, through model.Time, minFp, maxFp model.Fingerprint) ([]bloomshipper.BlockRef, []bloomshipper.Meta, []*bloomshipper.CloseableBlockQuerier, [][]v1.SeriesWithBlooms) {
+func createBlocks(t *testing.T, tenant string, n int, from, through model.Time, minFp, maxFp model.Fingerprint) ([]bloomshipper.BlockRef, []bloomshipper.Meta, []*v1.Block, [][]v1.SeriesWithBlooms) {
 	t.Helper()
 
 	blockRefs := make([]bloomshipper.BlockRef, 0, n)
 	metas := make([]bloomshipper.Meta, 0, n)
-	queriers := make([]*bloomshipper.CloseableBlockQuerier, 0, n)
+	blocks := make([]*v1.Block, 0, n)
 	series := make([][]v1.SeriesWithBlooms, 0, n)
 
 	step := (maxFp - minFp) / model.Fingerprint(n)
@@ -432,16 +432,12 @@ func createBlocks(t *testing.T, tenant string, n int, from, through model.Time, 
 		// 		t.Log(i, j, string(keys[i][j]))
 		// 	}
 		// }
-		querier := &bloomshipper.CloseableBlockQuerier{
-			BlockQuerier: v1.NewBlockQuerier(block, false, v1.DefaultMaxPageSize),
-			BlockRef:     blockRef,
-		}
-		queriers = append(queriers, querier)
+		blocks = append(blocks, block)
 		metas = append(metas, meta)
 		blockRefs = append(blockRefs, blockRef)
 		series = append(series, data)
 	}
-	return blockRefs, metas, queriers, series
+	return blockRefs, metas, blocks, series
 }
 
 func createQueryInputFromBlockData(t *testing.T, tenant string, data [][]v1.SeriesWithBlooms, nthSeries int) []*logproto.ChunkRef {

--- a/pkg/chunkenc/memchunk_test.go
+++ b/pkg/chunkenc/memchunk_test.go
@@ -470,7 +470,7 @@ func TestSerialization(t *testing.T) {
 					}
 					require.NoError(t, it.Error())
 
-					countExtractor = func() log.StreamSampleExtractor {
+					extractor := func() log.StreamSampleExtractor {
 						ex, err := log.NewLineSampleExtractor(log.CountExtractor, nil, nil, false, false)
 						if err != nil {
 							panic(err)
@@ -478,7 +478,7 @@ func TestSerialization(t *testing.T) {
 						return ex.ForStream(labels.Labels{})
 					}()
 
-					sampleIt := bc.SampleIterator(context.Background(), time.Unix(0, 0), time.Unix(0, math.MaxInt64), countExtractor)
+					sampleIt := bc.SampleIterator(context.Background(), time.Unix(0, 0), time.Unix(0, math.MaxInt64), extractor)
 					for i := 0; i < numSamples; i++ {
 						require.True(t, sampleIt.Next(), i)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Race conditions lead to hard-to-understand bugs in production.
While nearly all the code touched by this PR is for tests or diagnostics, it is a great help to run the race detector regularly, to avoid new races being added in production.

All tests now pass on my local machine with `-race`, apart from:
 * `TestOwnsRetention/multiple_compactors`, which fails with "Condition never satisfied"

`TestGenerateDataSize` is extremely slow under the race detector, taking ~10 minutes on my machine.  Perhaps it should use smaller payloads?

**Which issue(s) this PR fixes**:
Fixes #8586

**Special notes for your reviewer**:
This PR is broken down into individual commits; it will be easier to review one at a time.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- NA Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- NA Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- NA For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- NA If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
