### PR TITLE
fix:  #13124 test-canary template doesn't respect test.enabled flag 

### DIFF
--- a/production/helm/loki/templates/tests/test-canary.yaml
+++ b/production/helm/loki/templates/tests/test-canary.yaml
@@ -1,5 +1,5 @@
 {{- with .Values.test }}
-{{- if $.Values.lokiCanary.enabled }}
+{{- if and .enabled $.Values.lokiCanary.enabled }}
 ---
 apiVersion: v1
 kind: Pod


### PR DESCRIPTION
**Which issue(s) this PR fixes**:
Fixes  #13124

