### PR TITLE
feat: allow configuration of ingester statefulset updateStrategy

### DIFF
--- a/docs/sources/setup/install/helm/reference.md
+++ b/docs/sources/setup/install/helm/reference.md
@@ -4489,6 +4489,12 @@ null
       "whenUnsatisfiable": "ScheduleAnyway"
     }
   ],
+  "updateStrategy": {
+    "rollingUpdate": {
+      "partition": 0
+    },
+    "type": "RollingUpdate"
+  },
   "zoneAwareReplication": {
     "enabled": true,
     "maxUnavailablePct": 33,
@@ -4497,6 +4503,9 @@ null
       "excludeDefaultZone": false,
       "readPath": false,
       "writePath": false
+    },
+    "updateStrategy": {
+      "type": "OnDelete"
     },
     "zoneA": {
       "annotations": {},
@@ -4893,6 +4902,20 @@ Defaults to allow skew no more than 1 node
 </td>
 		</tr>
 		<tr>
+			<td>ingester.updateStrategy</td>
+			<td>object</td>
+			<td>Governs how statefulsets will be rolled out. Ignored if zoneAwareReplication is enabled</td>
+			<td><pre lang="json">
+{
+  "rollingUpdate": {
+    "partition": 0
+  },
+  "type": "RollingUpdate"
+}
+</pre>
+</td>
+		</tr>
+		<tr>
 			<td>ingester.zoneAwareReplication</td>
 			<td>object</td>
 			<td>Enabling zone awareness on ingesters will create 3 statefulests where all writes will send a replica to each zone. This is primarily intended to accelerate rollout operations by allowing for multiple ingesters within a single zone to be shutdown and restart simultaneously (the remaining 2 zones will be guaranteed to have at least one copy of the data). Note: This can be used to run Loki over multiple cloud provider availability zones however this is not currently recommended as Loki is not optimized for this and cross zone network traffic costs can become extremely high extremely quickly. Even with zone awareness enabled, it is recommended to run Loki in a single availability zone.</td>
@@ -4905,6 +4928,9 @@ Defaults to allow skew no more than 1 node
     "excludeDefaultZone": false,
     "readPath": false,
     "writePath": false
+  },
+  "updateStrategy": {
+    "type": "OnDelete"
   },
   "zoneA": {
     "annotations": {},
@@ -4956,6 +4982,17 @@ true
   "excludeDefaultZone": false,
   "readPath": false,
   "writePath": false
+}
+</pre>
+</td>
+		</tr>
+		<tr>
+			<td>ingester.zoneAwareReplication.updateStrategy</td>
+			<td>object</td>
+			<td>Governs how the zone-aware statefulsets will be rolled out</td>
+			<td><pre lang="json">
+{
+  "type": "OnDelete"
 }
 </pre>
 </td>

--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -13,6 +13,10 @@ Entries should include a reference to the pull request that introduced the chang
 
 [//]: # (<AUTOMATED_UPDATES_LOCATOR> : do not remove this line. This locator is used by the CI pipeline to automatically create a changelog entry for each new Loki release. Add other chart versions and respective changelog entries bellow this line.)
 
+## 6.7.0
+
+- [ENHANCEMENT] Allow configuring the `updateStrategy` for ingester StatefulSets
+
 ## 6.6.3
 
 - [BUGFIX] Fix indentation of `query_range` Helm chart values

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -3,7 +3,7 @@ name: loki
 description: Helm chart for Grafana Loki and Grafana Enterprise Logs supporting both simple, scalable and distributed modes.
 type: application
 appVersion: 3.0.0
-version: 6.6.3
+version: 6.7.0
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -1,6 +1,6 @@
 # loki
 
-![Version: 6.6.3](https://img.shields.io/badge/Version-6.6.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.0.0](https://img.shields.io/badge/AppVersion-3.0.0-informational?style=flat-square)
+![Version: 6.7.0](https://img.shields.io/badge/Version-6.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.0.0](https://img.shields.io/badge/AppVersion-3.0.0-informational?style=flat-square)
 
 Helm chart for Grafana Loki and Grafana Enterprise Logs supporting both simple, scalable and distributed modes.
 

--- a/production/helm/loki/templates/ingester/statefulset-ingester-zone-a.yaml
+++ b/production/helm/loki/templates/ingester/statefulset-ingester-zone-a.yaml
@@ -41,7 +41,7 @@ spec:
       name: ingester-zone-a
       rollout-group: ingester
   updateStrategy:
-    type: OnDelete
+    {{- toYaml .Values.ingester.zoneAwareReplication.updateStrategy | nindent 4 }}
   template:
     metadata:
       annotations:

--- a/production/helm/loki/templates/ingester/statefulset-ingester-zone-b.yaml
+++ b/production/helm/loki/templates/ingester/statefulset-ingester-zone-b.yaml
@@ -41,7 +41,7 @@ spec:
       name: ingester-zone-b
       rollout-group: ingester
   updateStrategy:
-    type: OnDelete
+    {{- toYaml .Values.ingester.zoneAwareReplication.updateStrategy | nindent 4 }}
   template:
     metadata:
       annotations:

--- a/production/helm/loki/templates/ingester/statefulset-ingester-zone-c.yaml
+++ b/production/helm/loki/templates/ingester/statefulset-ingester-zone-c.yaml
@@ -41,7 +41,7 @@ spec:
       name: ingester-zone-c
       rollout-group: ingester
   updateStrategy:
-    type: OnDelete
+    {{- toYaml .Values.ingester.zoneAwareReplication.updateStrategy | nindent 4 }}
   template:
     metadata:
       annotations:

--- a/production/helm/loki/templates/ingester/statefulset-ingester.yaml
+++ b/production/helm/loki/templates/ingester/statefulset-ingester.yaml
@@ -18,8 +18,7 @@ spec:
 {{- end }}
   podManagementPolicy: Parallel
   updateStrategy:
-    rollingUpdate:
-      partition: 0
+    {{- toYaml .Values.ingester.updateStrategy | nindent 4 }}
   serviceName: {{ include "loki.ingesterFullname" . }}-headless
   revisionHistoryLimit: {{ .Values.loki.revisionHistoryLimit }}
   {{- if and (semverCompare ">= 1.23-0" .Capabilities.KubeVersion.Version) (.Values.ingester.persistence.enableStatefulSetAutoDeletePVC)  }}

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -1756,6 +1756,11 @@ ingester:
   readinessProbe: {}
   # -- liveness probe settings for ingester pods. If empty use `loki.livenessProbe`
   livenessProbe: {}
+  # -- Governs how statefulsets will be rolled out. Ignored if zoneAwareReplication is enabled
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      partition: 0
   persistence:
     # -- Enable creating PVCs which is required when using boltdb-shipper
     enabled: false
@@ -1822,6 +1827,9 @@ ingester:
       annotations: {}
       # -- Specific annotations to add to zone C pods
       podAnnotations: {}
+    # -- Governs how the zone-aware statefulsets will be rolled out
+    updateStrategy:
+      type: OnDelete
     # -- The migration block allows migrating non zone aware ingesters to zone aware ingesters.
     migration:
       enabled: false


### PR DESCRIPTION
**What this PR does / why we need it**: allows the `updateStrategy` to be configured for ingester statefulsets. This is useful in case we are not using the rollout operator.

**Which issue(s) this PR fixes**:
No issue (I can create one if needed)

**Special notes for your reviewer**: I don't expect any breaking changes, the behaviour should be the same as before but with optional configuration from the `values.yaml`.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
