### PR TITLE
fix: Defer closing iterator after sending batches to client

### DIFF
--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -926,8 +926,6 @@ func (i *Ingester) Query(req *logproto.QueryRequest, queryServer logproto.Querie
 		it = iter.NewMergeEntryIterator(ctx, []iter.EntryIterator{it, storeItr}, req.Direction)
 	}
 
-	defer util.LogErrorWithContext(ctx, "closing iterator", it.Close)
-
 	// sendBatches uses -1 to specify no limit.
 	batchLimit := int32(req.Limit)
 	if batchLimit == 0 {
@@ -990,8 +988,6 @@ func (i *Ingester) QuerySample(req *logproto.SampleQueryRequest, queryServer log
 
 		it = iter.NewMergeSampleIterator(ctx, []iter.SampleIterator{it, storeItr})
 	}
-
-	defer util.LogErrorWithContext(ctx, "closing iterator", it.Close)
 
 	return sendSampleBatches(ctx, it, queryServer)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Due to deferring the closing too early, the `MergeEntryIterator` and `MergeSampleIterator` could be pre-maturely closed before the results were sent back to the client.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

This fix must also be forward-ported to `main`.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
