### PR TITLE
docs: remove redundant backticks from http api documentation

### DIFF
--- a/docs/sources/reference/loki-http-api.md
+++ b/docs/sources/reference/loki-http-api.md
@@ -798,7 +798,7 @@ gave this response:
 ## Query log statistics
 
 ```bash
-GET `/loki/api/v1/index/stats`
+GET /loki/api/v1/index/stats
 ```
 
 The `/loki/api/v1/index/stats` endpoint can be used to query the index for the number of `streams`, `chunks`, `entries`, and `bytes` that a query resolves to.


### PR DESCRIPTION
This is the only place in documentation with backticks used in code samples. See 
<img width="810" alt="image" src="https://github.com/grafana/loki/assets/30407135/2f2991e0-bae9-4886-bc27-d57625c1166b">

**versus** 

<img width="828" alt="image" src="https://github.com/grafana/loki/assets/30407135/baf8cf08-8d9e-4bcb-a97b-5dd72ed3848a">
<img width="834" alt="image" src="https://github.com/grafana/loki/assets/30407135/5769e0a4-7790-41c5-8e01-6bc2ce6299ab">
