### PR TITLE
fix: Init internal server log along with loki's server instance

### DIFF
--- a/cmd/loki/main.go
+++ b/cmd/loki/main.go
@@ -60,6 +60,10 @@ func main() {
 	serverCfg := &config.Server
 	serverCfg.Log = util_log.InitLogger(serverCfg, prometheus.DefaultRegisterer, false)
 
+	if config.InternalServer.Enable {
+		config.InternalServer.Log = serverCfg.Log
+	}
+
 	// Validate the config once both the config file has been loaded
 	// and CLI flags parsed.
 	if err := config.Validate(); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently Loki's internal server instance is running by default in a `panic: nil pointer dereference` because along all the updates for 3.0.0, we missed to initialize this server properly:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x84a4ff]

goroutine 1 [running]:
github.com/go-kit/log/level.NewFilter(...)
	/src/loki/vendor/github.com/go-kit/log/level/level.go:43
github.com/grafana/dskit/log.NewGoKitWithLevel({{0x0?, 0xc00192c208?}, 0x0?}, {0x0, 0x0})
	/src/loki/vendor/github.com/grafana/dskit/log/gokit.go:34 +0x21f
github.com/grafana/dskit/server.newServer({{0x0, 0x0}, 0x0, {0x2a68ab9, 0x3}, {0x0, 0x0}, 0xc1d, 0x0, {0x0, ...}, ...}, ...)
	/src/loki/vendor/github.com/grafana/dskit/server/server.go:254 +0x67
github.com/grafana/dskit/server.New({{0x0, 0x0}, 0x0, {0x2a68ab9, 0x3}, {0x0, 0x0}, 0xc1d, 0x0, {0x0, ...}, ...})
	/src/loki/vendor/github.com/grafana/dskit/server/server.go:241 +0x5f
github.com/grafana/loki/v3/pkg/loki.(*Loki).initInternalServer(0xc000d46000)
	/src/loki/pkg/loki/modules.go:213 +0xb8
github.com/grafana/dskit/modules.(*Manager).initModule(0xc000150e40, {0x7ffdd3022ccb, 0xd}, 0x1?, 0xc0008f88d0?)
	/src/loki/vendor/github.com/grafana/dskit/modules/modules.go:136 +0x1f7
github.com/grafana/dskit/modules.(*Manager).InitModuleServices(0x0?, {0xc000e8dca0, 0x1, 0xc0008e8660?})
	/src/loki/vendor/github.com/grafana/dskit/modules/modules.go:108 +0xd8
github.com/grafana/loki/v3/pkg/loki.(*Loki).Run(0xc000d46000, {0x0?, {0x4?, 0x3?, 0x4912940?}})
	/src/loki/pkg/loki/loki.go:453 +0x9d
main.main()
	/src/loki/cmd/loki/main.go:122 +0x113b
```

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

The internal server in Loki is mainly used in mTLS setups on Kubernetes where we want to allow TLS-secured Readiness/Liveness-Checks without client certificates. Usually k8s readiness/liveness checks do not support mTLS.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
