### PR TITLE
fix: update fixed limit once streams ownership re-checked

### DIFF
--- a/pkg/ingester/recalculate_owned_streams.go
+++ b/pkg/ingester/recalculate_owned_streams.go
@@ -64,6 +64,7 @@ func (s *recalculateOwnedStreams) recalculate() {
 		if err != nil {
 			level.Error(s.logger).Log("msg", "failed to update owned streams", "err", err)
 		}
+		instance.ownedStreamsSvc.updateFixedLimit()
 	}
 }
 

--- a/pkg/ingester/recalculate_owned_streams_test.go
+++ b/pkg/ingester/recalculate_owned_streams_test.go
@@ -83,6 +83,7 @@ func Test_recalculateOwnedStreams_recalculate(t *testing.T) {
 				nil,
 			)
 			require.NoError(t, err)
+			require.Equal(t, 100, tenant.ownedStreamsSvc.getFixedLimit(), "MaxGlobalStreamsPerUser is 100 at this moment")
 			// not owned streams
 			createStream(t, tenant, 49)
 			createStream(t, tenant, 101)
@@ -100,9 +101,14 @@ func Test_recalculateOwnedStreams_recalculate(t *testing.T) {
 			mockTenantsSupplier := &mockTenantsSuplier{tenants: []*instance{tenant}}
 
 			service := newRecalculateOwnedStreams(mockTenantsSupplier.get, "ingester-0", mockRing, 50*time.Millisecond, log.NewNopLogger())
+			//change the limit to assert that fixed limit is updated after the recalculation
+			limits.DefaultLimits().MaxGlobalStreamsPerUser = 50
 
 			service.recalculate()
 
+			if testData.featureEnabled {
+				require.Equal(t, 50, tenant.ownedStreamsSvc.getFixedLimit(), "fixed limit must be updated after recalculation")
+			}
 			require.Equal(t, testData.expectedOwnedStreamCount, tenant.ownedStreamsSvc.ownedStreamCount)
 			require.Equal(t, testData.expectedNotOwnedStreamCount, tenant.ownedStreamsSvc.notOwnedStreamCount)
 		})


### PR DESCRIPTION
**What this PR does / why we need it**:
updated recalculate_owned_streams service to update the fixed limit after checking the streams

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
