### PR TITLE
fix: separates directory creation from permission checks

### DIFF
--- a/pkg/storage/chunk/client/util/util.go
+++ b/pkg/storage/chunk/client/util/util.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 
 	ot "github.com/opentracing/opentracing-go"
@@ -67,15 +68,29 @@ func DoParallelQueries(
 
 // EnsureDirectory makes sure directory is there, if not creates it if not
 func EnsureDirectory(dir string) error {
+	return EnsureDirectoryWithDefaultPermissions(dir, 0o777)
+}
+
+func EnsureDirectoryWithDefaultPermissions(dir string, mode fs.FileMode) error {
 	info, err := os.Stat(dir)
 	if os.IsNotExist(err) {
-		return os.MkdirAll(dir, 0o777)
+		return os.MkdirAll(dir, mode)
 	} else if err == nil && !info.IsDir() {
 		return fmt.Errorf("not a directory: %s", dir)
-	} else if err == nil && info.Mode()&0700 != 0700 {
-		return fmt.Errorf("insufficient permissions: %s %s", dir, info.Mode())
 	}
 	return err
+}
+
+func RequirePermissions(path string, required fs.FileMode) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+
+	if mode := info.Mode(); mode&required != required {
+		return fmt.Errorf("insufficient permissions for path %s: required %s but found %s", path, required.String(), mode.String())
+	}
+	return nil
 }
 
 // ReadCloserWithContextCancelFunc helps with cancelling the context when closing a ReadCloser.

--- a/pkg/storage/chunk/client/util/util_test.go
+++ b/pkg/storage/chunk/client/util/util_test.go
@@ -1,0 +1,30 @@
+package util
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnsureDir(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Directory to be created by EnsureDir
+	dirPath := filepath.Join(tmpDir, "testdir")
+
+	// Ensure the directory does not exist before the test
+	if _, err := os.Stat(dirPath); !os.IsNotExist(err) {
+		t.Fatalf("Directory already exists: %v", err)
+	}
+
+	// create with default permissions
+	require.NoError(t, EnsureDirectoryWithDefaultPermissions(dirPath, 0o640))
+
+	// ensure the directory passes the permission check for more restrictive permissions
+	require.NoError(t, RequirePermissions(dirPath, 0o600))
+
+	// ensure the directory fails the permission check for less restrictive permissions
+	require.Error(t, RequirePermissions(dirPath, 0o660))
+}

--- a/pkg/storage/stores/shipper/bloomshipper/store.go
+++ b/pkg/storage/stores/shipper/bloomshipper/store.go
@@ -324,6 +324,9 @@ func NewBloomStore(
 		if err := util.EnsureDirectory(wd); err != nil {
 			return nil, errors.Wrapf(err, "failed to create working directory for bloom store: '%s'", wd)
 		}
+		if err := util.RequirePermissions(wd, 0o700); err != nil {
+			return nil, errors.Wrapf(err, "insufficient permissions on working directory for bloom store: '%s'", wd)
+		}
 	}
 
 	for _, periodicConfig := range periodicConfigs {


### PR DESCRIPTION
closes https://github.com/grafana/loki/issues/13222
Signed-off-by: Owen Diehl <ow.diehl@gmail.com>

The change from https://github.com/grafana/loki/pull/12019/files cascaded into other usage of `EnsureDirectory` and thus required every place it was called to require at _least_ `0o700` permissions, effectively breaking any read-only mounts.

I've separated creation from permissions testing so they can be applied independently, added some more utilities, and some testware.