### PR TITLE
fix: ingester/helm zoneAwareness

### DIFF
--- a/production/helm/loki/templates/ingester/hpa.yaml
+++ b/production/helm/loki/templates/ingester/hpa.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
-    kind: Statefulset
+    kind: StatefulSet
     name: {{ include "loki.ingesterFullname" . }}
   minReplicas: {{ .Values.ingester.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.ingester.autoscaling.maxReplicas }}

--- a/production/helm/loki/templates/ingester/statefulset-ingester.yaml
+++ b/production/helm/loki/templates/ingester/statefulset-ingester.yaml
@@ -87,7 +87,6 @@ spec:
           {{- end }}
           args:
             - -config.file=/etc/loki/config/config.yaml
-            - -ingester.ring.instance-availability-zone=zone-default
             - -target=ingester
             {{- with .Values.ingester.extraArgs }}
             {{- toYaml . | nindent 12 }}


### PR DESCRIPTION
- -ingester.ring.instance-availability-zone=zone-default

**What this PR does / why we need it**:
`flag provided but not defined: -ingester.ring.instance-availability-zone`
```
flag provided but not defined: -ingester.ring.instance-availability-zone
Run with -help to get list of available parameters
```
**Which issue(s) this PR fixes**:
Fixes #<issue number>
#13250 
https://github.com/grafana/loki/issues/13250
**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
