### PR TITLE
fix(mixin): various latency panels in operational dashboard should have ms unit type instead of seconds

### DIFF
--- a/production/loki-mixin-compiled-ssd/dashboards/loki-operational.json
+++ b/production/loki-mixin-compiled-ssd/dashboards/loki-operational.json
@@ -526,7 +526,7 @@
             "fieldConfig": {
                "defaults": {
                   "custom": { },
-                  "unit": "s"
+                  "unit": "ms"
                },
                "overrides": [ ]
             },
@@ -633,7 +633,7 @@
             "fieldConfig": {
                "defaults": {
                   "custom": { },
-                  "unit": "s"
+                  "unit": "ms"
                },
                "overrides": [ ]
             },
@@ -838,7 +838,7 @@
             "fieldConfig": {
                "defaults": {
                   "custom": { },
-                  "unit": "s"
+                  "unit": "ms"
                },
                "overrides": [ ]
             },
@@ -1045,7 +1045,7 @@
             "fieldConfig": {
                "defaults": {
                   "custom": { },
-                  "unit": "s"
+                  "unit": "ms"
                },
                "overrides": [ ]
             },
@@ -1154,7 +1154,7 @@
             "fieldConfig": {
                "defaults": {
                   "custom": { },
-                  "unit": "s"
+                  "unit": "ms"
                },
                "overrides": [ ]
             },
@@ -1360,7 +1360,7 @@
             "fieldConfig": {
                "defaults": {
                   "custom": { },
-                  "unit": "s"
+                  "unit": "ms"
                },
                "overrides": [ ]
             },

--- a/production/loki-mixin-compiled/dashboards/loki-operational.json
+++ b/production/loki-mixin-compiled/dashboards/loki-operational.json
@@ -623,7 +623,7 @@
             "fieldConfig": {
                "defaults": {
                   "custom": { },
-                  "unit": "s"
+                  "unit": "ms"
                },
                "overrides": [ ]
             },
@@ -730,7 +730,7 @@
             "fieldConfig": {
                "defaults": {
                   "custom": { },
-                  "unit": "s"
+                  "unit": "ms"
                },
                "overrides": [ ]
             },
@@ -935,7 +935,7 @@
             "fieldConfig": {
                "defaults": {
                   "custom": { },
-                  "unit": "s"
+                  "unit": "ms"
                },
                "overrides": [ ]
             },
@@ -1142,7 +1142,7 @@
             "fieldConfig": {
                "defaults": {
                   "custom": { },
-                  "unit": "s"
+                  "unit": "ms"
                },
                "overrides": [ ]
             },
@@ -1251,7 +1251,7 @@
             "fieldConfig": {
                "defaults": {
                   "custom": { },
-                  "unit": "s"
+                  "unit": "ms"
                },
                "overrides": [ ]
             },
@@ -1457,7 +1457,7 @@
             "fieldConfig": {
                "defaults": {
                   "custom": { },
-                  "unit": "s"
+                  "unit": "ms"
                },
                "overrides": [ ]
             },

--- a/production/loki-mixin/dashboards/dashboard-loki-operational.json
+++ b/production/loki-mixin/dashboards/dashboard-loki-operational.json
@@ -621,7 +621,7 @@
       "fieldConfig": {
         "defaults": {
           "custom": {},
-          "unit": "s"
+          "unit": "ms"
         },
         "overrides": []
       },
@@ -727,7 +727,7 @@
       "fieldConfig": {
         "defaults": {
           "custom": {},
-          "unit": "s"
+          "unit": "ms"
         },
         "overrides": []
       },
@@ -930,7 +930,7 @@
       "fieldConfig": {
         "defaults": {
           "custom": {},
-          "unit": "s"
+          "unit": "ms"
         },
         "overrides": []
       },
@@ -1135,7 +1135,7 @@
       "fieldConfig": {
         "defaults": {
           "custom": {},
-          "unit": "s"
+          "unit": "ms"
         },
         "overrides": []
       },
@@ -1243,7 +1243,7 @@
       "fieldConfig": {
         "defaults": {
           "custom": {},
-          "unit": "s"
+          "unit": "ms"
         },
         "overrides": []
       },
@@ -1447,7 +1447,7 @@
       "fieldConfig": {
         "defaults": {
           "custom": {},
-          "unit": "s"
+          "unit": "ms"
         },
         "overrides": []
       },


### PR DESCRIPTION
I noticed that these dashboards were showing wildly different latency times than other dashboards/metrics we look at. Changing the unit type on these to be ms instead of s shows the correct latency values.