### PR TITLE
feat(helm): Helm support OpenStack application credentials for Swift storage

### DIFF
--- a/docs/sources/setup/install/helm/reference.md
+++ b/docs/sources/setup/install/helm/reference.md
@@ -6090,6 +6090,9 @@ null
     "signatureVersion": null
   },
   "swift": {
+    "application_credential_id": null,
+    "application_credential_name": null,
+    "application_credential_secret": null,
     "auth_url": null,
     "auth_version": null,
     "connect_timeout": null,

--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -19,6 +19,9 @@ Entries should include a reference to the pull request that introduced the chang
 - [FIX] Do not create bloom planner, bloom builder, bloom gateway Deployment/Statefulset if their replica count is 0.
 - [FIX] Configure (ephemeral) storage for bloom builder working directory
 - [ENHANCEMENT] Automatically configure bloom planner address for bloom builders and bloom gateway addresses for bloom gateway clients.
+## 6.12.1
+
+- [ENHANCEMENT] Add support for OpenStack application credentials when using Swift for storage
 
 ## 6.12.0
 

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -3,7 +3,7 @@ name: loki
 description: Helm chart for Grafana Loki and Grafana Enterprise Logs supporting both simple, scalable and distributed modes.
 type: application
 appVersion: 3.1.1
-version: 6.13.0
+version: 6.13.1
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -1,6 +1,6 @@
 # loki
 
-![Version: 6.13.0](https://img.shields.io/badge/Version-6.13.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.1.1](https://img.shields.io/badge/AppVersion-3.1.1-informational?style=flat-square)
+![Version: 6.13.1](https://img.shields.io/badge/Version-6.13.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.1.1](https://img.shields.io/badge/AppVersion-3.1.1-informational?style=flat-square)
 
 Helm chart for Grafana Loki and Grafana Enterprise Logs supporting both simple, scalable and distributed modes.
 

--- a/production/helm/loki/templates/_helpers.tpl
+++ b/production/helm/loki/templates/_helpers.tpl
@@ -377,6 +377,15 @@ azure:
 {{- else if eq .Values.loki.storage.type "swift" -}}
 {{- with .Values.loki.storage.swift }}
 swift:
+  {{- with .application_credential_id }}
+  application_credential_id: {{ . }}
+  {{- end }}
+  {{- with .application_credential_name }}
+  application_credential_name: {{ . }}
+  {{- end }}
+  {{- with .application_credential_secret }}
+  application_credential_secret: {{ . }}
+  {{- end }}
   {{- with .auth_version }}
   auth_version: {{ . }}
   {{- end }}
@@ -384,7 +393,9 @@ swift:
   {{- with .internal }}
   internal: {{ . }}
   {{- end }}
-  username: {{ .username }}
+  {{- with .username }}
+  username: {{ . }}
+  {{- end }}
   user_domain_name: {{ .user_domain_name }}
   {{- with .user_domain_id }}
   user_domain_id: {{ . }}
@@ -392,7 +403,9 @@ swift:
   {{- with .user_id }}
   user_id: {{ . }}
   {{- end }}
-  password: {{ .password }}
+  {{- with .password }}
+  password: {{ . }}
+  {{- end }}
   {{- with .domain_id }}
   domain_id: {{ . }}
   {{- end }}
@@ -461,6 +474,15 @@ storage:
   {{- with .Values.loki.storage.swift }}
   backend: "swift"
   swift:
+    {{- with .application_credential_id }}
+    application_credential_id: {{ . }}
+    {{- end }}
+    {{- with .application_credential_name }}
+    application_credential_name: {{ . }}
+    {{- end }}
+    {{- with .application_credential_secret }}
+    application_credential_secret: {{ . }}
+    {{- end }}
     {{- with .auth_version }}
     auth_version: {{ . }}
     {{- end }}
@@ -468,7 +490,9 @@ storage:
     {{- with .internal }}
     internal: {{ . }}
     {{- end }}
-    username: {{ .username }}
+    {{- with .username }}
+    username: {{ . }}
+    {{- end }}
     user_domain_name: {{ .user_domain_name }}
     {{- with .user_domain_id }}
     user_domain_id: {{ . }}
@@ -476,7 +500,9 @@ storage:
     {{- with .user_id }}
     user_id: {{ . }}
     {{- end }}
-    password: {{ .password }}
+    {{- with .password }}
+    password: {{ . }}
+    {{- end }}
     {{- with .domain_id }}
     domain_id: {{ . }}
     {{- end }}

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -354,6 +354,9 @@ loki:
       requestTimeout: null
       endpointSuffix: null
     swift:
+      application_credential_id: null
+      application_credential_name: null
+      application_credential_secret: null
       auth_version: null
       auth_url: null
       internal: null


### PR DESCRIPTION
**What this PR does / why we need it**:

Support application credentials for authentication with OpenStack.

**Which issue(s) this PR fixes**:

#14034 

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
