### PR TITLE
chore: [release-2.9.x] feat: Add ingester_chunks_flush_failures_total (#12925)

### DIFF
--- a/.github/release-workflows.jsonnet
+++ b/.github/release-workflows.jsonnet
@@ -2,11 +2,7 @@ local lokiRelease = import 'workflows/main.jsonnet';
 local build = lokiRelease.build;
 local job = lokiRelease.job;
 
-local releaseLibRef = std.filter(
-  function(dep) dep.source.git.remote == 'https://github.com/grafana/loki-release.git',
-  (import 'jsonnetfile.json').dependencies
-)[0].version;
-
+local releaseLibRef = "release-1.12.x";
 local checkTemplate = 'grafana/loki-release/.github/workflows/check.yml@%s' % releaseLibRef;
 
 local imageJobs = {

--- a/.github/release-workflows.jsonnet
+++ b/.github/release-workflows.jsonnet
@@ -2,7 +2,7 @@ local lokiRelease = import 'workflows/main.jsonnet';
 local build = lokiRelease.build;
 local job = lokiRelease.job;
 
-local releaseLibRef = "release-1.12.x";
+local releaseLibRef = 'loki-2.9.x';
 local checkTemplate = 'grafana/loki-release/.github/workflows/check.yml@%s' % releaseLibRef;
 
 local imageJobs = {

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,10 +1,10 @@
 "jobs":
   "check":
-    "uses": "grafana/loki-release/.github/workflows/check.yml@release-1.12.x"
+    "uses": "grafana/loki-release/.github/workflows/check.yml@loki-2.9.x"
     "with":
       "build_image": "grafana/loki-build-image:0.30.1"
       "golang_ci_lint_version": "v1.51.2"
-      "release_lib_ref": "release-1.12.x"
+      "release_lib_ref": "loki-2.9.x"
       "skip_validation": false
       "use_github_app_token": true
 "name": "check"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,10 +1,10 @@
 "jobs":
   "check":
-    "uses": "grafana/loki-release/.github/workflows/check.yml@loki-2.9.x"
+    "uses": "grafana/loki-release/.github/workflows/check.yml@release-1.12.x"
     "with":
-      "build_image": "grafana/loki-build-image:0.33.1"
-      "golang_ci_lint_version": "v1.55.1"
-      "release_lib_ref": "loki-2.9.x"
+      "build_image": "grafana/loki-build-image:0.30.1"
+      "golang_ci_lint_version": "v1.51.2"
+      "release_lib_ref": "release-1.12.x"
       "skip_validation": false
       "use_github_app_token": true
 "name": "check"

--- a/.github/workflows/minor-release-pr.yml
+++ b/.github/workflows/minor-release-pr.yml
@@ -5,18 +5,18 @@ env:
   CHANGELOG_PATH: "CHANGELOG.md"
   DOCKER_USERNAME: "grafana"
   IMAGE_PREFIX: "grafana"
-  RELEASE_LIB_REF: "release-1.12.x"
+  RELEASE_LIB_REF: "loki-2.9.x"
   RELEASE_REPO: "grafana/loki"
   SKIP_VALIDATION: false
   USE_GITHUB_APP_TOKEN: true
   VERSIONING_STRATEGY: "always-bump-minor"
 jobs:
   check:
-    uses: "grafana/loki-release/.github/workflows/check.yml@release-1.12.x"
+    uses: "grafana/loki-release/.github/workflows/check.yml@loki-2.9.x"
     with:
       build_image: "grafana/loki-build-image:0.30.1"
       golang_ci_lint_version: "v1.51.2"
-      release_lib_ref: "release-1.12.x"
+      release_lib_ref: "loki-2.9.x"
       skip_validation: false
       use_github_app_token: true
   create-release-pr:

--- a/.github/workflows/minor-release-pr.yml
+++ b/.github/workflows/minor-release-pr.yml
@@ -5,18 +5,18 @@ env:
   CHANGELOG_PATH: "CHANGELOG.md"
   DOCKER_USERNAME: "grafana"
   IMAGE_PREFIX: "grafana"
-  RELEASE_LIB_REF: "loki-2.9.x"
+  RELEASE_LIB_REF: "release-1.12.x"
   RELEASE_REPO: "grafana/loki"
   SKIP_VALIDATION: false
   USE_GITHUB_APP_TOKEN: true
   VERSIONING_STRATEGY: "always-bump-minor"
 jobs:
   check:
-    uses: "grafana/loki-release/.github/workflows/check.yml@loki-2.9.x"
+    uses: "grafana/loki-release/.github/workflows/check.yml@release-1.12.x"
     with:
-      build_image: "grafana/loki-build-image:0.33.1"
-      golang_ci_lint_version: "v1.55.1"
-      release_lib_ref: "loki-2.9.x"
+      build_image: "grafana/loki-build-image:0.30.1"
+      golang_ci_lint_version: "v1.51.2"
+      release_lib_ref: "release-1.12.x"
       skip_validation: false
       use_github_app_token: true
   create-release-pr:
@@ -89,7 +89,7 @@ jobs:
           --target-branch "${{ steps.extract_branch.outputs.branch }}" \
           --token "${{ steps.github_app_token.outputs.token }}" \
           --versioning-strategy "${{ env.VERSIONING_STRATEGY }}"
-
+        
       working-directory: "lib"
   dist:
     needs:
@@ -136,7 +136,7 @@ jobs:
           --env SKIP_ARM \
           --volume .:/src/loki \
           --workdir /src/loki \
-          --entrypoint /bin/sh "grafana/loki-build-image:0.33.1"
+          --entrypoint /bin/sh "grafana/loki-build-image:0.30.1"
           git config --global --add safe.directory /src/loki
           echo "${NFPM_SIGNING_KEY}" > $NFPM_SIGNING_KEY_FILE
           make dist packages
@@ -181,7 +181,7 @@ jobs:
       name: "parse image platform"
       run: |
         mkdir -p images
-
+        
         platform="$(echo "${{ matrix.platform}}" |  sed  "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -243,7 +243,7 @@ jobs:
       name: "parse image platform"
       run: |
         mkdir -p images
-
+        
         platform="$(echo "${{ matrix.platform}}" |  sed  "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -305,7 +305,7 @@ jobs:
       name: "parse image platform"
       run: |
         mkdir -p images
-
+        
         platform="$(echo "${{ matrix.platform}}" |  sed  "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -369,7 +369,7 @@ jobs:
       name: "parse image platform"
       run: |
         mkdir -p images
-
+        
         platform="$(echo "${{ matrix.platform}}" |  sed  "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -431,7 +431,7 @@ jobs:
       name: "parse image platform"
       run: |
         mkdir -p images
-
+        
         platform="$(echo "${{ matrix.platform}}" |  sed  "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -495,7 +495,7 @@ jobs:
       name: "parse image platform"
       run: |
         mkdir -p images
-
+        
         platform="$(echo "${{ matrix.platform}}" |  sed  "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -559,7 +559,7 @@ jobs:
       name: "parse image platform"
       run: |
         mkdir -p images
-
+        
         platform="$(echo "${{ matrix.platform}}" |  sed  "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -623,7 +623,7 @@ jobs:
       name: "parse image platform"
       run: |
         mkdir -p images
-
+        
         platform="$(echo "${{ matrix.platform}}" |  sed  "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -687,7 +687,7 @@ jobs:
       name: "parse image platform"
       run: |
         mkdir -p images
-
+        
         platform="$(echo "${{ matrix.platform}}" |  sed  "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -778,16 +778,16 @@ jobs:
           --target-branch "${{ steps.extract_branch.outputs.branch }}" \
           --token "${{ steps.github_app_token.outputs.token }}" \
           --versioning-strategy "${{ env.VERSIONING_STRATEGY }}"
-
+        
         cat release.json
-
-        if [[ `jq length release.json` -gt 1 ]]; then
+        
+        if [[ `jq length release.json` -gt 1 ]]; then 
           echo 'release-please would create more than 1 PR, so cannot determine correct version'
           echo "pr_created=false" >> $GITHUB_OUTPUT
           exit 1
         fi
-
-        if [[ `jq length release.json` -eq 0 ]]; then
+        
+        if [[ `jq length release.json` -eq 0 ]]; then 
           echo "pr_created=false" >> $GITHUB_OUTPUT
         else
           version="$(npm run --silent get-version)"

--- a/.github/workflows/patch-release-pr.yml
+++ b/.github/workflows/patch-release-pr.yml
@@ -5,18 +5,18 @@ env:
   CHANGELOG_PATH: "CHANGELOG.md"
   DOCKER_USERNAME: "grafana"
   IMAGE_PREFIX: "grafana"
-  RELEASE_LIB_REF: "release-1.12.x"
+  RELEASE_LIB_REF: "loki-2.9.x"
   RELEASE_REPO: "grafana/loki"
   SKIP_VALIDATION: false
   USE_GITHUB_APP_TOKEN: true
   VERSIONING_STRATEGY: "always-bump-patch"
 jobs:
   check:
-    uses: "grafana/loki-release/.github/workflows/check.yml@release-1.12.x"
+    uses: "grafana/loki-release/.github/workflows/check.yml@loki-2.9.x"
     with:
       build_image: "grafana/loki-build-image:0.30.1"
       golang_ci_lint_version: "v1.51.2"
-      release_lib_ref: "release-1.12.x"
+      release_lib_ref: "loki-2.9.x"
       skip_validation: false
       use_github_app_token: true
   create-release-pr:

--- a/.github/workflows/patch-release-pr.yml
+++ b/.github/workflows/patch-release-pr.yml
@@ -5,18 +5,18 @@ env:
   CHANGELOG_PATH: "CHANGELOG.md"
   DOCKER_USERNAME: "grafana"
   IMAGE_PREFIX: "grafana"
-  RELEASE_LIB_REF: "loki-2.9.x"
+  RELEASE_LIB_REF: "release-1.12.x"
   RELEASE_REPO: "grafana/loki"
   SKIP_VALIDATION: false
   USE_GITHUB_APP_TOKEN: true
   VERSIONING_STRATEGY: "always-bump-patch"
 jobs:
   check:
-    uses: "grafana/loki-release/.github/workflows/check.yml@loki-2.9.x"
+    uses: "grafana/loki-release/.github/workflows/check.yml@release-1.12.x"
     with:
-      build_image: "grafana/loki-build-image:0.33.1"
-      golang_ci_lint_version: "v1.55.1"
-      release_lib_ref: "loki-2.9.x"
+      build_image: "grafana/loki-build-image:0.30.1"
+      golang_ci_lint_version: "v1.51.2"
+      release_lib_ref: "release-1.12.x"
       skip_validation: false
       use_github_app_token: true
   create-release-pr:
@@ -89,7 +89,7 @@ jobs:
           --target-branch "${{ steps.extract_branch.outputs.branch }}" \
           --token "${{ steps.github_app_token.outputs.token }}" \
           --versioning-strategy "${{ env.VERSIONING_STRATEGY }}"
-
+        
       working-directory: "lib"
   dist:
     needs:
@@ -136,7 +136,7 @@ jobs:
           --env SKIP_ARM \
           --volume .:/src/loki \
           --workdir /src/loki \
-          --entrypoint /bin/sh "grafana/loki-build-image:0.33.1"
+          --entrypoint /bin/sh "grafana/loki-build-image:0.30.1"
           git config --global --add safe.directory /src/loki
           echo "${NFPM_SIGNING_KEY}" > $NFPM_SIGNING_KEY_FILE
           make dist packages
@@ -181,7 +181,7 @@ jobs:
       name: "parse image platform"
       run: |
         mkdir -p images
-
+        
         platform="$(echo "${{ matrix.platform}}" |  sed  "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -243,7 +243,7 @@ jobs:
       name: "parse image platform"
       run: |
         mkdir -p images
-
+        
         platform="$(echo "${{ matrix.platform}}" |  sed  "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -305,7 +305,7 @@ jobs:
       name: "parse image platform"
       run: |
         mkdir -p images
-
+        
         platform="$(echo "${{ matrix.platform}}" |  sed  "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -369,7 +369,7 @@ jobs:
       name: "parse image platform"
       run: |
         mkdir -p images
-
+        
         platform="$(echo "${{ matrix.platform}}" |  sed  "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -431,7 +431,7 @@ jobs:
       name: "parse image platform"
       run: |
         mkdir -p images
-
+        
         platform="$(echo "${{ matrix.platform}}" |  sed  "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -495,7 +495,7 @@ jobs:
       name: "parse image platform"
       run: |
         mkdir -p images
-
+        
         platform="$(echo "${{ matrix.platform}}" |  sed  "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -559,7 +559,7 @@ jobs:
       name: "parse image platform"
       run: |
         mkdir -p images
-
+        
         platform="$(echo "${{ matrix.platform}}" |  sed  "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -623,7 +623,7 @@ jobs:
       name: "parse image platform"
       run: |
         mkdir -p images
-
+        
         platform="$(echo "${{ matrix.platform}}" |  sed  "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -687,7 +687,7 @@ jobs:
       name: "parse image platform"
       run: |
         mkdir -p images
-
+        
         platform="$(echo "${{ matrix.platform}}" |  sed  "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -778,16 +778,16 @@ jobs:
           --target-branch "${{ steps.extract_branch.outputs.branch }}" \
           --token "${{ steps.github_app_token.outputs.token }}" \
           --versioning-strategy "${{ env.VERSIONING_STRATEGY }}"
-
+        
         cat release.json
-
-        if [[ `jq length release.json` -gt 1 ]]; then
+        
+        if [[ `jq length release.json` -gt 1 ]]; then 
           echo 'release-please would create more than 1 PR, so cannot determine correct version'
           echo "pr_created=false" >> $GITHUB_OUTPUT
           exit 1
         fi
-
-        if [[ `jq length release.json` -eq 0 ]]; then
+        
+        if [[ `jq length release.json` -eq 0 ]]; then 
           echo "pr_created=false" >> $GITHUB_OUTPUT
         else
           version="$(npm run --silent get-version)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ concurrency:
 env:
   IMAGE_PREFIX: "grafana"
   PUBLISH_TO_GCS: false
-  RELEASE_LIB_REF: "release-1.12.x"
+  RELEASE_LIB_REF: "loki-2.9.x"
   RELEASE_REPO: "grafana/loki"
   USE_GITHUB_APP_TOKEN: false
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ concurrency:
 env:
   IMAGE_PREFIX: "grafana"
   PUBLISH_TO_GCS: false
-  RELEASE_LIB_REF: "loki-2.9.x"
+  RELEASE_LIB_REF: "release-1.12.x"
   RELEASE_REPO: "grafana/loki"
   USE_GITHUB_APP_TOKEN: false
 jobs:

--- a/pkg/ingester/flush.go
+++ b/pkg/ingester/flush.go
@@ -363,6 +363,7 @@ func (i *Ingester) encodeChunk(ctx context.Context, ch *chunk.Chunk, desc *chunk
 // chunk to have another opportunity to be flushed.
 func (i *Ingester) flushChunk(ctx context.Context, ch *chunk.Chunk) error {
 	if err := i.store.Put(ctx, []chunk.Chunk{*ch}); err != nil {
+		i.metrics.chunksFlushFailures.Inc()
 		return fmt.Errorf("store put chunk: %w", err)
 	}
 	i.metrics.flushedChunksStats.Inc(1)

--- a/pkg/ingester/metrics.go
+++ b/pkg/ingester/metrics.go
@@ -46,6 +46,7 @@ type ingesterMetrics struct {
 	chunkSizePerTenant            *prometheus.CounterVec
 	chunkAge                      prometheus.Histogram
 	chunkEncodeTime               prometheus.Histogram
+	chunksFlushFailures           prometheus.Counter
 	chunksFlushedPerReason        *prometheus.CounterVec
 	chunkLifespan                 prometheus.Histogram
 	flushedChunksStats            *analytics.Counter
@@ -228,6 +229,11 @@ func newIngesterMetrics(r prometheus.Registerer) *ingesterMetrics {
 			Help:      "Distribution of chunk encode times.",
 			// 10ms to 10s.
 			Buckets: prometheus.ExponentialBuckets(0.01, 4, 6),
+		}),
+		chunksFlushFailures: promauto.With(r).NewCounter(prometheus.CounterOpts{
+			Namespace: constants.Loki,
+			Name:      "ingester_chunks_flush_failures_total",
+			Help:      "Total number of flush failures.",
 		}),
 		chunksFlushedPerReason: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
 			Namespace: "loki",

--- a/pkg/ingester/metrics.go
+++ b/pkg/ingester/metrics.go
@@ -231,7 +231,7 @@ func newIngesterMetrics(r prometheus.Registerer) *ingesterMetrics {
 			Buckets: prometheus.ExponentialBuckets(0.01, 4, 6),
 		}),
 		chunksFlushFailures: promauto.With(r).NewCounter(prometheus.CounterOpts{
-			Namespace: constants.Loki,
+			Namespace: "loki",
 			Name:      "ingester_chunks_flush_failures_total",
 			Help:      "Total number of flush failures.",
 		}),


### PR DESCRIPTION
**What this PR does / why we need it**:

Backports https://github.com/grafana/loki/pull/12925 to 2.9.x.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
