### PR TITLE
chore: [release-2.9.x]: feat: Add backoff to flush op

### DIFF
--- a/docs/sources/configure/_index.md
+++ b/docs/sources/configure/_index.md
@@ -1442,7 +1442,23 @@ lifecycler:
 # CLI flag: -ingester.flush-check-period
 [flush_check_period: <duration> | default = 30s]
 
-# The timeout before a flush is cancelled.
+flush_op_backoff:
+  # Minimum backoff period when a flush fails. Each concurrent flush has its own
+  # backoff, see `ingester.concurrent-flushes`.
+  # CLI flag: -ingester.flush-op-backoff-min-period
+  [min_period: <duration> | default = 10s]
+
+  # Maximum backoff period when a flush fails. Each concurrent flush has its own
+  # backoff, see `ingester.concurrent-flushes`.
+  # CLI flag: -ingester.flush-op-backoff-max-period
+  [max_period: <duration> | default = 1m]
+
+  # Maximum retries for failed flushes.
+  # CLI flag: -ingester.flush-op-backoff-retries
+  [max_retries: <int> | default = 10]
+
+# The timeout for an individual flush. Will be retried up to
+# `flush-op-backoff-retries` times.
 # CLI flag: -ingester.flush-op-timeout
 [flush_op_timeout: <duration> | default = 10m]
 

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/dskit/backoff"
 	"github.com/grafana/dskit/flagext"
 	"github.com/grafana/dskit/httpgrpc"
 	"github.com/grafana/dskit/middleware"
@@ -660,57 +661,119 @@ func TestIngester_asyncStoreMaxLookBack(t *testing.T) {
 
 func TestValidate(t *testing.T) {
 	for i, tc := range []struct {
-		in       Config
-		err      bool
-		expected Config
+		in          Config
+		expected    Config
+		expectedErr string
 	}{
 		{
 			in: Config{
-				MaxChunkAge:   time.Minute,
 				ChunkEncoding: chunkenc.EncGZIP.String(),
-				IndexShards:   index.DefaultIndexShards,
+				FlushOpBackoff: backoff.Config{
+					MinBackoff: 100 * time.Millisecond,
+					MaxBackoff: 10 * time.Second,
+					MaxRetries: 1,
+				},
+				FlushOpTimeout: 15 * time.Second,
+				IndexShards:    index.DefaultIndexShards,
+				MaxChunkAge:    time.Minute,
 			},
 			expected: Config{
-				MaxChunkAge:    time.Minute,
-				ChunkEncoding:  chunkenc.EncGZIP.String(),
-				parsedEncoding: chunkenc.EncGZIP,
+				ChunkEncoding: chunkenc.EncGZIP.String(),
+				FlushOpBackoff: backoff.Config{
+					MinBackoff: 100 * time.Millisecond,
+					MaxBackoff: 10 * time.Second,
+					MaxRetries: 1,
+				},
+				FlushOpTimeout: 15 * time.Second,
 				IndexShards:    index.DefaultIndexShards,
+				MaxChunkAge:    time.Minute,
+				parsedEncoding: chunkenc.EncGZIP,
 			},
 		},
 		{
 			in: Config{
 				ChunkEncoding: chunkenc.EncSnappy.String(),
-				IndexShards:   index.DefaultIndexShards,
-			},
-			expected: Config{
-				ChunkEncoding:  chunkenc.EncSnappy.String(),
-				parsedEncoding: chunkenc.EncSnappy,
+				FlushOpBackoff: backoff.Config{
+					MinBackoff: 100 * time.Millisecond,
+					MaxBackoff: 10 * time.Second,
+					MaxRetries: 1,
+				},
+				FlushOpTimeout: 15 * time.Second,
 				IndexShards:    index.DefaultIndexShards,
 			},
+			expected: Config{
+				ChunkEncoding: chunkenc.EncSnappy.String(),
+				FlushOpBackoff: backoff.Config{
+					MinBackoff: 100 * time.Millisecond,
+					MaxBackoff: 10 * time.Second,
+					MaxRetries: 1,
+				},
+				FlushOpTimeout: 15 * time.Second,
+				IndexShards:    index.DefaultIndexShards,
+				parsedEncoding: chunkenc.EncSnappy,
+			},
 		},
 		{
 			in: Config{
-				IndexShards:   index.DefaultIndexShards,
 				ChunkEncoding: "bad-enc",
+				FlushOpBackoff: backoff.Config{
+					MinBackoff: 100 * time.Millisecond,
+					MaxBackoff: 10 * time.Second,
+					MaxRetries: 1,
+				},
+				FlushOpTimeout: 15 * time.Second,
+				IndexShards:    index.DefaultIndexShards,
 			},
-			err: true,
+			expectedErr: "invalid encoding: bad-enc, supported: none, gzip, lz4-64k, snappy, lz4-256k, lz4-1M, lz4, flate, zstd",
 		},
 		{
 			in: Config{
-				MaxChunkAge:   time.Minute,
 				ChunkEncoding: chunkenc.EncGZIP.String(),
+				FlushOpBackoff: backoff.Config{
+					MinBackoff: 100 * time.Millisecond,
+					MaxBackoff: 10 * time.Second,
+				},
+				FlushOpTimeout: 15 * time.Second,
+				IndexShards:    index.DefaultIndexShards,
+				MaxChunkAge:    time.Minute,
 			},
-			err: true,
+			expectedErr: "invalid flush op max retries: 0",
+		},
+		{
+			in: Config{
+				ChunkEncoding: chunkenc.EncGZIP.String(),
+				FlushOpBackoff: backoff.Config{
+					MinBackoff: 100 * time.Millisecond,
+					MaxBackoff: 10 * time.Second,
+					MaxRetries: 1,
+				},
+				IndexShards: index.DefaultIndexShards,
+				MaxChunkAge: time.Minute,
+			},
+			expectedErr: "invalid flush op timeout: 0s",
+		},
+		{
+			in: Config{
+				ChunkEncoding: chunkenc.EncGZIP.String(),
+				FlushOpBackoff: backoff.Config{
+					MinBackoff: 100 * time.Millisecond,
+					MaxBackoff: 10 * time.Second,
+					MaxRetries: 1,
+				},
+				FlushOpTimeout: 15 * time.Second,
+				MaxChunkAge:    time.Minute,
+			},
+			expectedErr: "invalid ingester index shard factor: 0",
 		},
 	} {
 		t.Run(fmt.Sprint(i), func(t *testing.T) {
 			err := tc.in.Validate()
-			if tc.err {
-				require.NotNil(t, err)
-				return
+			if tc.expectedErr != "" {
+				require.EqualError(t, err, tc.expectedErr)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.expected, tc.in)
 			}
-			require.Nil(t, err)
-			require.Equal(t, tc.expected, tc.in)
 		})
 	}
 }

--- a/pkg/ingester/instance_test.go
+++ b/pkg/ingester/instance_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/dskit/backoff"
 	"github.com/grafana/dskit/flagext"
 	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
@@ -30,9 +31,15 @@ import (
 
 func defaultConfig() *Config {
 	cfg := Config{
-		BlockSize:     512,
-		ChunkEncoding: "gzip",
-		IndexShards:   32,
+		BlockSize:      512,
+		ChunkEncoding:  "gzip",
+		IndexShards:    32,
+		FlushOpTimeout: 15 * time.Second,
+		FlushOpBackoff: backoff.Config{
+			MinBackoff: 100 * time.Millisecond,
+			MaxBackoff: 10 * time.Second,
+			MaxRetries: 1,
+		},
 	}
 	if err := cfg.Validate(); err != nil {
 		panic(errors.Wrap(err, "error building default test config"))


### PR DESCRIPTION
**What this PR does / why we need it**:

Backports https://github.com/grafana/loki/pull/13140 to 2.9.x.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
