### PR TITLE
perf(blooms): mempool no longer zeroes out buffers unnecessarily

### DIFF
--- a/pkg/util/mempool/pool.go
+++ b/pkg/util/mempool/pool.go
@@ -64,15 +64,6 @@ func (s *slab) get(size int) ([]byte, error) {
 		return nil, errSlabExhausted
 	}
 
-	// Taken from https://github.com/ortuman/nuke/blob/main/monotonic_arena.go#L37-L48
-	// This piece of code will be translated into a runtime.memclrNoHeapPointers
-	// invocation by the compiler, which is an assembler optimized implementation.
-	// Architecture specific code can be found at src/runtime/memclr_$GOARCH.s
-	// in Go source (since https://codereview.appspot.com/137880043).
-	for i := range buf {
-		buf[i] = 0
-	}
-
 	return buf[:size], nil
 }
 

--- a/pkg/util/mempool/pool_test.go
+++ b/pkg/util/mempool/pool_test.go
@@ -7,8 +7,9 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/grafana/loki/v3/pkg/util/flagext"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/util/flagext"
 )
 
 func TestMemPool(t *testing.T) {

--- a/pkg/util/mempool/pool_test.go
+++ b/pkg/util/mempool/pool_test.go
@@ -45,24 +45,6 @@ func TestMemPool(t *testing.T) {
 		require.Equal(t, 512, cap(res))
 	})
 
-	t.Run("buffer is cleared when returned", func(t *testing.T) {
-		pool := New("test", []Bucket{
-			{Size: 1, Capacity: 64},
-		}, nil)
-		res, err := pool.Get(8)
-		require.NoError(t, err)
-		require.Equal(t, 8, len(res))
-		source := []byte{0, 1, 2, 3, 4, 5, 6, 7}
-		copy(res, source)
-
-		pool.Put(res)
-
-		res, err = pool.Get(8)
-		require.NoError(t, err)
-		require.Equal(t, 8, len(res))
-		require.Equal(t, make([]byte, 8), res)
-	})
-
 	t.Run("pool returns error when no buffer is available", func(t *testing.T) {
 		pool := New("test", []Bucket{
 			{Size: 1, Capacity: 64},


### PR DESCRIPTION

Dramatically improves the speed of mempool usage. I noticed some code in the mempool which iterated over buffers on every `get()` call. Guessing this to be expensive, I added a few benchmarks -- this is one of those rare `-100%` speed improvements. The reason this is safe because only the length of the provided `[]byte` is important -- NOT it's contents. I verified this everywhere it was used (I knew this was the expected contract already), added some benchmarks, and we saw a great improvement.

```
goos: darwin
goarch: arm64
pkg: github.com/grafana/loki/v3/pkg/util/mempool
              │   /tmp/old.txt   │             /tmp/new.txt             │
              │      sec/op      │   sec/op     vs base                 │
Slab/1KB-10         121.35n ± 1%   33.80n ± 1%   -72.15% (p=0.000 n=10)
Slab/1MB-10       11222.00n ± 2%   33.82n ± 0%   -99.70% (p=0.000 n=10)
Slab/128MB-10   1420680.00n ± 2%   33.75n ± 0%  -100.00% (p=0.000 n=10)
geomean              12.46µ        33.79n        -99.73%

              │ /tmp/old.txt │            /tmp/new.txt             │
              │     B/op     │    B/op     vs base                 │
Slab/1KB-10     0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Slab/1MB-10     0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Slab/128MB-10   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                    ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

              │ /tmp/old.txt │            /tmp/new.txt             │
              │  allocs/op   │ allocs/op   vs base                 │
Slab/1KB-10     0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Slab/1MB-10     0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Slab/128MB-10   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                    ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```