### PR TITLE
chore(blooms): allocator is best effort; uses pool if available otherwise allocs

### DIFF
--- a/pkg/storage/bloom/v1/block.go
+++ b/pkg/storage/bloom/v1/block.go
@@ -136,6 +136,7 @@ func (bq *BlockQuerier) Schema() (Schema, error) {
 }
 
 func (bq *BlockQuerier) Reset() error {
+	bq.blooms.Reset()
 	return bq.LazySeriesIter.Seek(0)
 }
 
@@ -145,10 +146,6 @@ func (bq *BlockQuerier) Err() error {
 	}
 
 	return bq.blooms.Err()
-}
-
-func (bq *BlockQuerier) Close() {
-	bq.blooms.Close()
 }
 
 type BlockQuerierIter struct {
@@ -163,7 +160,11 @@ func (bq *BlockQuerier) Iter() *BlockQuerierIter {
 }
 
 func (b *BlockQuerierIter) Next() bool {
-	return b.LazySeriesIter.Next()
+	next := b.LazySeriesIter.Next()
+	if !next {
+		b.blooms.Reset()
+	}
+	return next
 }
 
 func (b *BlockQuerierIter) At() *SeriesWithBlooms {

--- a/pkg/storage/bloom/v1/bloom.go
+++ b/pkg/storage/bloom/v1/bloom.go
@@ -166,10 +166,12 @@ func (d *BloomPageDecoder) Relinquish(alloc mempool.Allocator) {
 
 	data := d.data
 	d.data = nil
+	d.Reset() // Reset for cleaning up residual references to data via `dec`
 
 	if cap(data) > 0 {
 		_ = alloc.Put(data)
 	}
+
 }
 
 func (d *BloomPageDecoder) Reset() {

--- a/pkg/storage/bloom/v1/bloom.go
+++ b/pkg/storage/bloom/v1/bloom.go
@@ -65,13 +65,10 @@ func (b *Bloom) Decode(dec *encoding.Decbuf) error {
 }
 
 func LazyDecodeBloomPage(r io.Reader, alloc mempool.Allocator, pool chunkenc.ReaderPool, page BloomPageHeader) (*BloomPageDecoder, error) {
-	data, err := alloc.Get(page.Len)
-	if err != nil {
-		return nil, errors.Wrap(err, "allocating buffer")
-	}
+	data := alloc.Get(page.Len)
 	defer alloc.Put(data)
 
-	_, err = io.ReadFull(r, data)
+	_, err := io.ReadFull(r, data)
 	if err != nil {
 		return nil, errors.Wrap(err, "reading bloom page")
 	}
@@ -87,12 +84,9 @@ func LazyDecodeBloomPage(r io.Reader, alloc mempool.Allocator, pool chunkenc.Rea
 	}
 	defer pool.PutReader(decompressor)
 
-	b, err := alloc.Get(page.DecompressedLen)
-	if err != nil {
-		return nil, errors.Wrap(err, "allocating buffer")
-	}
+	b := alloc.Get(page.DecompressedLen)
 
-	if _, err = io.ReadFull(decompressor, b); err != nil {
+	if _, err := io.ReadFull(decompressor, b); err != nil {
 		return nil, errors.Wrap(err, "decompressing bloom page")
 	}
 
@@ -108,12 +102,9 @@ func LazyDecodeBloomPageNoCompression(r io.Reader, alloc mempool.Allocator, page
 		return nil, errors.New("the Len and DecompressedLen of the page do not match")
 	}
 
-	data, err := alloc.Get(page.Len)
-	if err != nil {
-		return nil, errors.Wrap(err, "allocating buffer")
-	}
+	data := alloc.Get(page.Len)
 
-	_, err = io.ReadFull(r, data)
+	_, err := io.ReadFull(r, data)
 	if err != nil {
 		return nil, errors.Wrap(err, "reading bloom page")
 	}

--- a/pkg/storage/bloom/v1/bloom_querier.go
+++ b/pkg/storage/bloom/v1/bloom_querier.go
@@ -162,6 +162,11 @@ func (it *LazyBloomIter) Err() error {
 	}
 }
 
-func (it *LazyBloomIter) Close() {
-	it.curPage.Relinquish(it.alloc)
+func (it *LazyBloomIter) Reset() {
+	it.err = nil
+	it.curPageIndex = 0
+	if it.curPage != nil {
+		it.curPage.Relinquish(it.alloc)
+	}
+	it.curPage = nil
 }

--- a/pkg/storage/bloom/v1/index.go
+++ b/pkg/storage/bloom/v1/index.go
@@ -166,7 +166,7 @@ func (b *BlockIndex) NewSeriesPageDecoder(r io.ReadSeeker, header SeriesPageHead
 		return nil, errors.Wrap(err, "seeking to series page")
 	}
 
-	data, _ := SeriesPagePool.Get(header.Len)
+	data := SeriesPagePool.Get(header.Len)
 	defer SeriesPagePool.Put(data)
 	_, err = io.ReadFull(r, data)
 	if err != nil {

--- a/pkg/storage/stores/shipper/bloomshipper/cache.go
+++ b/pkg/storage/stores/shipper/bloomshipper/cache.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/multierror"
 	"github.com/pkg/errors"
 
 	v1 "github.com/grafana/loki/v3/pkg/storage/bloom/v1"
@@ -23,11 +24,12 @@ type CloseableBlockQuerier struct {
 }
 
 func (c *CloseableBlockQuerier) Close() error {
-	c.BlockQuerier.Close()
+	var err multierror.MultiError
+	err.Add(c.BlockQuerier.Reset())
 	if c.close != nil {
-		return c.close()
+		err.Add(c.close())
 	}
-	return nil
+	return err.Err()
 }
 
 func (c *CloseableBlockQuerier) SeriesIter() (v1.PeekingIterator[*v1.SeriesWithBlooms], error) {

--- a/pkg/util/mempool/allocator.go
+++ b/pkg/util/mempool/allocator.go
@@ -7,15 +7,15 @@ import (
 // Allocator handles byte slices for bloom queriers.
 // It exists to reduce the cost of allocations and allows to re-use already allocated memory.
 type Allocator interface {
-	Get(size int) ([]byte, error)
-	Put([]byte) bool
+	Get(size int) []byte
+	Put([]byte) (returned bool)
 }
 
 // SimpleHeapAllocator allocates a new byte slice every time and does not re-cycle buffers.
 type SimpleHeapAllocator struct{}
 
-func (a *SimpleHeapAllocator) Get(size int) ([]byte, error) {
-	return make([]byte, size), nil
+func (a *SimpleHeapAllocator) Get(size int) []byte {
+	return make([]byte, size)
 }
 
 func (a *SimpleHeapAllocator) Put([]byte) bool {
@@ -38,8 +38,8 @@ func NewBytePoolAllocator(minSize, maxSize int, factor float64) *BytePool {
 }
 
 // Get implements Allocator
-func (p *BytePool) Get(size int) ([]byte, error) {
-	return p.pool.Get(size).([]byte)[:size], nil
+func (p *BytePool) Get(size int) []byte {
+	return p.pool.Get(size).([]byte)[:size]
 }
 
 // Put implements Allocator


### PR DESCRIPTION
Ideally, we'd always return buffers to the pool, but ensuring this in the code is tricky & error prone. Instead, we'll treat allocators as best effort & measure them. This should probabilistically create the reuse we want in lieu of a more perfect solution and allow us to continue using & repopulating pools when we drop pointers.