### PR TITLE
feat: add FOLDER_ANNOTATATION logic for loki helm chart sidecar, making multi-tenant alerting easier

### DIFF
--- a/production/helm/loki/templates/backend/statefulset-backend.yaml
+++ b/production/helm/loki/templates/backend/statefulset-backend.yaml
@@ -103,6 +103,10 @@ spec:
             {{- end }}
             - name: FOLDER
               value: "{{ .Values.sidecar.rules.folder }}"
+            {{- if .Values.sidecar.rules.folderAnnotation }}
+            - name: FOLDER_ANNOTATION
+              value: "{{ .Values.sidecar.rules.folderAnnotation }}"
+            {{- end }}
             - name: RESOURCE
               value: {{ quote .Values.sidecar.rules.resource }}
             {{- if .Values.sidecar.enableUniqueFilenames }}

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -3175,6 +3175,10 @@ sidecar:
     labelValue: ""
     # -- Folder into which the rules will be placed.
     folder: /rules
+    # -- The annotation overwriting the folder value.
+    # The annotation value can be either an absolute or a relative path. Relative paths will be relative to FOLDER.
+    # Useful for multi-tenancy setups.
+    folderAnnotation: null
     # -- Comma separated list of namespaces. If specified, the sidecar will search for config-maps/secrets inside these namespaces.
     # Otherwise the namespace in which the sidecar is running will be used.
     # It's also possible to specify 'ALL' to search in all namespaces.


### PR DESCRIPTION
**What this PR does / why we need it**:
The sidecar container is super convenient for adding (alerting) rules to loki.

However, as things stand, all files are mounted into the same directory, with no convenient way to separate them by tenant.

Luckily, the [sidecar image](https://github.com/kiwigrid/k8s-sidecar) already has a built-in environment variable for this, `FOLDER_ANNOTATION`. This PR implements the environment variable into the pod definition, in a manner consistent with other env variables.

**Which issue(s) this PR fixes**:
Fixes #13049

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
