### PR TITLE
perf(mempool): Replace `sync.Mutex` with `sync.Once`

### DIFF
--- a/pkg/util/mempool/pool_test.go
+++ b/pkg/util/mempool/pool_test.go
@@ -124,7 +124,6 @@ func BenchmarkSlab(b *testing.B) {
 	} {
 		b.Run(flagext.ByteSize(uint64(sz)).String(), func(b *testing.B) {
 			slab := newSlab(sz, 1, newMetrics(nil, "test"))
-			slab.init()
 			b.ResetTimer()
 
 			for i := 0; i < b.N; i++ {


### PR DESCRIPTION
**What this PR does / why we need it**:

`sync.Once` uses an atomic integer as gate instead of a Mutex.

```
goos: linux
goarch: amd64
pkg: github.com/grafana/loki/v3/pkg/util/mempool
cpu: 11th Gen Intel(R) Core(TM) i7-1185G7 @ 3.00GHz
             │  bench.old  │             bench.new              │
             │   sec/op    │   sec/op     vs base               │
Slab/1KB-8     138.5n ± 2%   125.1n ± 2%  -9.71% (p=0.000 n=10)
Slab/1MB-8     140.5n ± 3%   128.1n ± 2%  -8.83% (p=0.000 n=10)
Slab/128MB-8   143.0n ± 3%   130.4n ± 3%  -8.81% (p=0.000 n=10)
geomean        140.7n        127.8n       -9.12%
```

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
