### PR TITLE
refactor(blooms): Bloom building integration test

### DIFF
--- a/integration/bloom_building_test.go
+++ b/integration/bloom_building_test.go
@@ -5,8 +5,18 @@ package integration
 import (
 	"context"
 	"fmt"
+	"testing"
+	"time"
+
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/flagext"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/integration/client"
+	"github.com/grafana/loki/v3/integration/cluster"
 	"github.com/grafana/loki/v3/pkg/storage"
 	v1 "github.com/grafana/loki/v3/pkg/storage/bloom/v1"
 	"github.com/grafana/loki/v3/pkg/storage/chunk/cache"
@@ -16,16 +26,6 @@ import (
 	bloomshipperconfig "github.com/grafana/loki/v3/pkg/storage/stores/shipper/bloomshipper/config"
 	"github.com/grafana/loki/v3/pkg/storage/types"
 	"github.com/grafana/loki/v3/pkg/util/mempool"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/common/model"
-	"github.com/prometheus/prometheus/model/labels"
-	"testing"
-	"time"
-
-	"github.com/stretchr/testify/require"
-
-	"github.com/grafana/loki/v3/integration/client"
-	"github.com/grafana/loki/v3/integration/cluster"
 )
 
 func TestBloomBuilding(t *testing.T) {

--- a/integration/bloom_building_test.go
+++ b/integration/bloom_building_test.go
@@ -1,0 +1,286 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/flagext"
+	"github.com/grafana/loki/v3/pkg/storage"
+	v1 "github.com/grafana/loki/v3/pkg/storage/bloom/v1"
+	"github.com/grafana/loki/v3/pkg/storage/chunk/cache"
+	"github.com/grafana/loki/v3/pkg/storage/chunk/client/local"
+	"github.com/grafana/loki/v3/pkg/storage/config"
+	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/bloomshipper"
+	bloomshipperconfig "github.com/grafana/loki/v3/pkg/storage/stores/shipper/bloomshipper/config"
+	"github.com/grafana/loki/v3/pkg/storage/types"
+	"github.com/grafana/loki/v3/pkg/util/mempool"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/integration/client"
+	"github.com/grafana/loki/v3/integration/cluster"
+)
+
+func TestBloomBuilding(t *testing.T) {
+	const (
+		nSeries        = 10 //1000
+		nLogsPerSeries = 50
+	)
+
+	clu := cluster.New(level.DebugValue(), cluster.SchemaWithTSDB, func(c *cluster.Cluster) {
+		c.SetSchemaVer("v13")
+	})
+	defer func() {
+		require.NoError(t, clu.Cleanup())
+	}()
+
+	// First run distributor and ingester and write some data across many series.
+	tDistributor := clu.AddComponent(
+		"distributor",
+		"-target=distributor",
+	)
+	tIngester := clu.AddComponent(
+		"ingester",
+		"-target=ingester",
+		"-ingester.flush-on-shutdown=true",
+	)
+	require.NoError(t, clu.Run())
+
+	tenantID := "fake"
+	now := time.Now()
+	cliDistributor := client.New(tenantID, "", tDistributor.HTTPURL())
+	cliIngester := client.New(tenantID, "", tIngester.HTTPURL())
+	cliIngester.Now = now
+
+	// We now ingest some logs across many series.
+	series := make([]labels.Labels, 0, nSeries)
+	for i := 0; i < nSeries; i++ {
+		lbs := labels.FromStrings("job", fmt.Sprintf("job-%d", i))
+		series = append(series, lbs)
+
+		for j := 0; j < nLogsPerSeries; j++ {
+			require.NoError(t, cliDistributor.PushLogLine(fmt.Sprintf("log line %d", j), now, nil, lbs.Map()))
+		}
+	}
+
+	// restart ingester which should flush the chunks and index
+	require.NoError(t, tIngester.Restart())
+
+	// Start compactor and wait for compaction to finish.
+	start := recordStartTime()
+	tCompactor := clu.AddComponent(
+		"compactor",
+		"-target=compactor",
+		"-compactor.compaction-interval=10m",
+		"-compactor.run-once=true",
+	)
+	require.NoError(t, clu.Run())
+
+	// Wait for compaction to finish.
+	cliCompactor := client.New(tenantID, "", tCompactor.HTTPURL())
+	checkCompactionFinished(t, cliCompactor, start)
+
+	// Now create the bloom planner and builders
+	start = recordStartTime()
+	tBloomPlanner := clu.AddComponent(
+		"bloom-planner",
+		"-target=bloom-planner",
+		"-bloom-build.enabled=true",
+		"-bloom-build.enable=true",
+		"-bloom-build.planner.interval=10m",
+		"-bloom-build.planner.min-table-offset=0",
+	)
+	require.NoError(t, clu.Run())
+	tBloomBuilder := clu.AddComponent(
+		"bloom-builder",
+		"-target=bloom-builder",
+		"-bloom-build.enabled=true",
+		"-bloom-build.enable=true",
+		"-bloom-build.builder.planner-address="+tBloomPlanner.GRPCURL(),
+	)
+	require.NoError(t, clu.Run())
+
+	// Wait for bloom build to finish
+	cliPlanner := client.New(tenantID, "", tBloomPlanner.HTTPURL())
+	checkBloomBuildFinished(t, cliPlanner, start)
+
+	// Create bloom client to fetch metas and blocks.
+	bloomStore := createBloomStore(t, tBloomPlanner.ClusterSharedPath())
+
+	// Check that all series pushed are present in the metas and blocks.
+	checkSeriesInBlooms(t, now, tenantID, bloomStore, series)
+
+	// Push some more logs so TSDBs need to be updated.
+	for i := 0; i < nSeries; i++ {
+		lbs := labels.FromStrings("job", fmt.Sprintf("job-new-%d", i))
+		series = append(series, lbs)
+
+		for j := 0; j < nLogsPerSeries; j++ {
+			require.NoError(t, cliDistributor.PushLogLine(fmt.Sprintf("log line %d", j), now, nil, lbs.Map()))
+		}
+	}
+
+	// restart ingester which should flush the chunks and index
+	require.NoError(t, tIngester.Restart())
+
+	// Restart compactor and wait for compaction to finish so TSDBs are updated.
+	start = recordStartTime()
+	require.NoError(t, tCompactor.Restart())
+	cliCompactor = client.New(tenantID, "", tCompactor.HTTPURL())
+	checkCompactionFinished(t, cliCompactor, start)
+
+	// Restart bloom planner to trigger bloom build
+	start = recordStartTime()
+	require.NoError(t, tBloomPlanner.Restart())
+
+	// TODO(salvacorts): Implement retry on builder so we don't need to restart it.
+	tBloomBuilder.AddFlags("-bloom-build.builder.planner-address=" + tBloomPlanner.GRPCURL())
+	require.NoError(t, tBloomBuilder.Restart())
+
+	// Wait for bloom build to finish
+	cliPlanner = client.New(tenantID, "", tBloomPlanner.HTTPURL())
+	checkBloomBuildFinished(t, cliPlanner, start)
+
+	// Check that all series (both previous and new ones) pushed are present in the metas and blocks.
+	// This check ensures up to 1 meta per series, which tests deletion of old metas.
+	checkSeriesInBlooms(t, now, tenantID, bloomStore, series)
+}
+
+func recordStartTime() time.Time {
+	start := time.Now()
+	time.Sleep(1 * time.Second) // Gauge seconds has second precision, so we need to wait a bit.
+	return start
+}
+
+func checkCompactionFinished(t *testing.T, cliCompactor *client.Client, start time.Time) {
+	require.Eventually(t, func() bool {
+		metrics, err := cliCompactor.Metrics()
+		require.NoError(t, err)
+
+		metricName := "loki_boltdb_shipper_compact_tables_operation_last_successful_run_timestamp_seconds"
+		val, _, err := extractMetric(metricName, metrics)
+		require.NoError(t, err)
+
+		lastRun := time.Unix(int64(val), 0)
+		return lastRun.After(start)
+	}, 30*time.Second, 1*time.Second)
+}
+
+func checkBloomBuildFinished(t *testing.T, cliPlanner *client.Client, start time.Time) {
+	require.Eventually(t, func() bool {
+		metrics, err := cliPlanner.Metrics()
+		require.NoError(t, err)
+
+		metricName := "loki_bloomplanner_build_last_successful_run_timestamp_seconds"
+		val, _, err := extractMetric(metricName, metrics)
+		require.NoError(t, err)
+
+		lastRun := time.Unix(int64(val), 0)
+		return lastRun.After(start)
+	}, 30*time.Second, 1*time.Second)
+}
+
+func createBloomStore(t *testing.T, sharedPath string) *bloomshipper.BloomStore {
+	logger := log.NewNopLogger()
+	//logger := log.NewLogfmtLogger(os.Stdout)
+
+	schemaCfg := config.SchemaConfig{
+		Configs: []config.PeriodConfig{
+			{
+				From: parseDayTime("2023-09-01"),
+				IndexTables: config.IndexPeriodicTableConfig{
+					PeriodicTableConfig: config.PeriodicTableConfig{
+						Prefix: "index_tsdb_",
+						Period: 24 * time.Hour,
+					},
+				},
+				IndexType:  types.TSDBType,
+				ObjectType: types.StorageTypeFileSystem,
+				Schema:     "v13",
+				RowShards:  16,
+			},
+		},
+	}
+	storageCfg := storage.Config{
+		BloomShipperConfig: bloomshipperconfig.Config{
+			WorkingDirectory:    []string{sharedPath + "/bloom-store-test"},
+			DownloadParallelism: 1,
+			BlocksCache: bloomshipperconfig.BlocksCacheConfig{
+				SoftLimit: flagext.Bytes(10 << 20),
+				HardLimit: flagext.Bytes(20 << 20),
+				TTL:       time.Hour,
+			},
+		},
+		FSConfig: local.FSConfig{
+			Directory: sharedPath + "/fs-store-1",
+		},
+	}
+
+	reg := prometheus.NewPedanticRegistry()
+	metasCache := cache.NewNoopCache()
+	blocksCache := bloomshipper.NewFsBlocksCache(storageCfg.BloomShipperConfig.BlocksCache, reg, logger)
+
+	store, err := bloomshipper.NewBloomStore(schemaCfg.Configs, storageCfg, storage.ClientMetrics{}, metasCache, blocksCache, &mempool.SimpleHeapAllocator{}, reg, logger)
+	require.NoError(t, err)
+
+	return store
+}
+
+func checkSeriesInBlooms(
+	t *testing.T,
+	now time.Time,
+	tenantID string,
+	bloomStore *bloomshipper.BloomStore,
+	series []labels.Labels,
+) {
+	for _, lbs := range series {
+		seriesFP := model.Fingerprint(lbs.Hash())
+
+		metas, err := bloomStore.FetchMetas(context.Background(), bloomshipper.MetaSearchParams{
+			TenantID: tenantID,
+			Interval: bloomshipper.NewInterval(model.TimeFromUnix(now.Add(-24*time.Hour).Unix()), model.TimeFromUnix(now.Unix())),
+			Keyspace: v1.NewBounds(seriesFP, seriesFP),
+		})
+		require.NoError(t, err)
+
+		// Only one meta should be present.
+		require.Len(t, metas, 1)
+
+		var relevantBlocks []bloomshipper.BlockRef
+		for _, block := range metas[0].Blocks {
+			if block.Cmp(uint64(seriesFP)) != v1.Overlap {
+				continue
+			}
+			relevantBlocks = append(relevantBlocks, block)
+		}
+
+		// Only one block should be relevant.
+		require.Len(t, relevantBlocks, 1)
+
+		queriers, err := bloomStore.FetchBlocks(context.Background(), relevantBlocks)
+		require.NoError(t, err)
+		require.Len(t, queriers, 1)
+		querier := queriers[0]
+
+		require.NoError(t, querier.Seek(seriesFP))
+		require.Equal(t, seriesFP, querier.At().Series.Fingerprint)
+	}
+}
+
+func parseDayTime(s string) config.DayTime {
+	t, err := time.Parse("2006-01-02", s)
+	if err != nil {
+		panic(err)
+	}
+	return config.DayTime{
+		Time: model.TimeFromUnix(t.Unix()),
+	}
+}

--- a/pkg/bloombuild/builder/builder.go
+++ b/pkg/bloombuild/builder/builder.go
@@ -11,9 +11,12 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/google/uuid"
 	"github.com/grafana/dskit/services"
+	"github.com/grafana/dskit/user"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/grafana/loki/v3/pkg/bloombuild/common"
 	"github.com/grafana/loki/v3/pkg/bloombuild/protos"
@@ -84,16 +87,25 @@ func (b *Builder) starting(_ context.Context) error {
 }
 
 func (b *Builder) stopping(_ error) error {
+	defer b.metrics.running.Set(0)
+
 	if b.client != nil {
+		// The gRPC server we use from dskit expects the orgID to be injected into the context when auth is enabled
+		// We won't actually use the orgID anywhere in this service, but we need to inject it to satisfy the server.
+		ctx, err := user.InjectIntoGRPCRequest(user.InjectOrgID(context.Background(), "fake"))
+		if err != nil {
+			level.Error(b.logger).Log("msg", "failed to inject orgID into context", "err", err)
+			return nil
+		}
+
 		req := &protos.NotifyBuilderShutdownRequest{
 			BuilderID: b.ID,
 		}
-		if _, err := b.client.NotifyBuilderShutdown(context.Background(), req); err != nil {
+		if _, err := b.client.NotifyBuilderShutdown(ctx, req); err != nil {
 			level.Error(b.logger).Log("msg", "failed to notify planner about builder shutdown", "err", err)
 		}
 	}
 
-	b.metrics.running.Set(0)
 	return nil
 }
 
@@ -110,6 +122,13 @@ func (b *Builder) running(ctx context.Context) error {
 	}
 
 	b.client = protos.NewPlannerForBuilderClient(conn)
+
+	// The gRPC server we use from dskit expects the orgID to be injected into the context when auth is enabled
+	// We won't actually use the orgID anywhere in this service, but we need to inject it to satisfy the server.
+	ctx, err = user.InjectIntoGRPCRequest(user.InjectOrgID(ctx, "fake"))
+	if err != nil {
+		return fmt.Errorf("failed to inject orgID into context: %w", err)
+	}
 
 	c, err := b.client.BuilderLoop(ctx)
 	if err != nil {
@@ -135,7 +154,7 @@ func (b *Builder) builderLoop(c protos.PlannerForBuilder_BuilderLoopClient) erro
 		// will be canceled and the loop will exit.
 		protoTask, err := c.Recv()
 		if err != nil {
-			if errors.Is(c.Context().Err(), context.Canceled) {
+			if status.Code(err) == codes.Canceled {
 				level.Debug(b.logger).Log("msg", "builder loop context canceled")
 				return nil
 			}

--- a/pkg/bloombuild/planner/metrics.go
+++ b/pkg/bloombuild/planner/metrics.go
@@ -28,9 +28,10 @@ type Metrics struct {
 	taskLost          prometheus.Counter
 	tasksFailed       prometheus.Counter
 
-	buildStarted   prometheus.Counter
-	buildCompleted *prometheus.CounterVec
-	buildTime      *prometheus.HistogramVec
+	buildStarted     prometheus.Counter
+	buildCompleted   *prometheus.CounterVec
+	buildTime        *prometheus.HistogramVec
+	buildLastSuccess prometheus.Gauge
 
 	blocksDeleted prometheus.Counter
 	metasDeleted  prometheus.Counter
@@ -111,6 +112,12 @@ func NewMetrics(
 			Help:      "Time spent during a builds cycle.",
 			Buckets:   prometheus.DefBuckets,
 		}, []string{"status"}),
+		buildLastSuccess: promauto.With(r).NewGauge(prometheus.GaugeOpts{
+			Namespace: metricsNamespace,
+			Subsystem: metricsSubsystem,
+			Name:      "build_last_successful_run_timestamp_seconds",
+			Help:      "Unix timestamp of the last successful build cycle.",
+		}),
 
 		blocksDeleted: promauto.With(r).NewCounter(prometheus.CounterOpts{
 			Namespace: metricsNamespace,

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -40,6 +40,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/analytics"
 	"github.com/grafana/loki/v3/pkg/bloombuild/builder"
 	"github.com/grafana/loki/v3/pkg/bloombuild/planner"
+	bloomprotos "github.com/grafana/loki/v3/pkg/bloombuild/protos"
 	"github.com/grafana/loki/v3/pkg/bloomgateway"
 	"github.com/grafana/loki/v3/pkg/compactor"
 	compactorclient "github.com/grafana/loki/v3/pkg/compactor/client"
@@ -714,9 +715,9 @@ func (t *Loki) initStore() (services.Service, error) {
 }
 
 func (t *Loki) initBloomStore() (services.Service, error) {
-	// BloomStore is a dependency of IndexGateway, even when the BloomGateway is not enabled.
-	// Do not instantiate store and do not create a service.
-	if !t.Cfg.BloomGateway.Enabled {
+	// BloomStore is a dependency of IndexGateway and Bloom Planner & Builder.
+	// Do not instantiate store and do not create a service if neither ar enabled.
+	if !t.Cfg.BloomGateway.Enabled && !t.Cfg.BloomBuild.Enabled {
 		return nil, nil
 	}
 
@@ -1584,7 +1585,7 @@ func (t *Loki) initBloomPlanner() (services.Service, error) {
 
 	logger := log.With(util_log.Logger, "component", "bloom-planner")
 
-	return planner.New(
+	p, err := planner.New(
 		t.Cfg.BloomBuild.Planner,
 		t.Overrides,
 		t.Cfg.SchemaConfig,
@@ -1594,6 +1595,12 @@ func (t *Loki) initBloomPlanner() (services.Service, error) {
 		logger,
 		prometheus.DefaultRegisterer,
 	)
+	if err != nil {
+		return nil, err
+	}
+
+	bloomprotos.RegisterPlannerForBuilderServer(t.Server.GRPC, p)
+	return p, nil
 }
 
 func (t *Loki) initBloomBuilder() (services.Service, error) {
@@ -1601,7 +1608,7 @@ func (t *Loki) initBloomBuilder() (services.Service, error) {
 		return nil, nil
 	}
 
-	logger := log.With(util_log.Logger, "component", "bloom-worker")
+	logger := log.With(util_log.Logger, "component", "bloom-builder")
 
 	return builder.New(
 		t.Cfg.BloomBuild.Builder,


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds an integration test for bloom building and outdated metas and blocks deletion. it also fixes some issues discovered while testing.

**Special notes for your reviewer**:
- The test currently uses sleeps to wait for compaction and bloom build to finish. I tried looking at the metrics ([see commit diff][1]) but these are not refreshed after a component restart. I think this happens because we reuse the prometheus defualt register across components and restarts.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)

[1]: https://github.com/grafana/loki/pull/13296/commits/aab6e813a6de31d8abb583f18d9276b368cd3962