### PR TITLE
fix(operator): Watch for CredentialsRequests on CCOAuthEnv only

### DIFF
--- a/operator/controllers/loki/lokistack_controller.go
+++ b/operator/controllers/loki/lokistack_controller.go
@@ -221,9 +221,11 @@ func (r *LokiStackReconciler) buildController(bld k8s.Builder) error {
 	}
 
 	if r.FeatureGates.OpenShift.Enabled {
-		bld = bld.
-			Owns(&routev1.Route{}, updateOrDeleteOnlyPred).
-			Owns(&cloudcredentialv1.CredentialsRequest{}, updateOrDeleteOnlyPred)
+		bld = bld.Owns(&routev1.Route{}, updateOrDeleteOnlyPred)
+
+		if r.FeatureGates.OpenShift.TokenCCOAuthEnv {
+			bld = bld.Owns(&cloudcredentialv1.CredentialsRequest{}, updateOrDeleteOnlyPred)
+		}
 
 		if r.FeatureGates.OpenShift.ClusterTLSPolicy {
 			bld = bld.Watches(&openshiftconfigv1.APIServer{}, r.enqueueAllLokiStacksHandler(), updateOrDeleteOnlyPred)

--- a/operator/controllers/loki/lokistack_controller_test.go
+++ b/operator/controllers/loki/lokistack_controller_test.go
@@ -161,7 +161,7 @@ func TestLokiStackController_RegisterOwnedResourcesForUpdateOrDeleteOnly(t *test
 		{
 			obj:           &routev1.Route{},
 			index:         10,
-			ownCallsCount: 12,
+			ownCallsCount: 11,
 			featureGates: configv1.FeatureGates{
 				OpenShift: configv1.OpenShiftFeatureGates{
 					Enabled: true,
@@ -175,7 +175,8 @@ func TestLokiStackController_RegisterOwnedResourcesForUpdateOrDeleteOnly(t *test
 			ownCallsCount: 12,
 			featureGates: configv1.FeatureGates{
 				OpenShift: configv1.OpenShiftFeatureGates{
-					Enabled: true,
+					Enabled:         true,
+					TokenCCOAuthEnv: true,
 				},
 			},
 			pred: updateOrDeleteOnlyPred,


### PR DESCRIPTION
**What this PR does / why we need it**:
Registers the controller watcher for `CredentialRequest` only when `CCOAuthEnv: true` OpenShift environments. Resolves issue:

```
{"_ts":"2024-04-24T16:02:28.027229225Z","_level":"0","_component":"loki-operator_controller-runtime_source_EventHandler","_message":"failed to get informer from cache","_error":{"msg":"failed to get API group resources: unable to retrieve the complete list of server APIs: cloudcredential.openshift.io/v1: the server could not find the requested resource"}}
```

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
