### PR TITLE
docs: Replace instances of k6.io/docs with grafana.com/docs/k6

### DIFF
--- a/docs/sources/send-data/k6/_index.md
+++ b/docs/sources/send-data/k6/_index.md
@@ -9,8 +9,8 @@ weight:  900
 
 # Using k6 for load testing
 
-Grafana [k6](https://k6.io) is a modern load-testing tool.
-Its clean and approachable scripting [API](https://k6.io/docs/javascript-api/)
+Grafana [k6](https://grafana.com/oss/k6/) is a modern load-testing tool.
+Its clean and approachable scripting [API](https://grafana.com/docs/k6/latest/javascript-api/)
 works locally or in the cloud.
 Its configuration makes it flexible.
 
@@ -55,7 +55,7 @@ Use the custom-built k6 binary in the same way as a non-custom k6 binary:
 ```
 
 `test.js` is a Javascript load test.
-Refer to the [k6 documentation](https://k6.io/docs/) to get started.
+Refer to the [k6 documentation](https://grafana.com/docs/k6/latest/) to get started.
 
 ### Scripting API
 
@@ -75,7 +75,7 @@ Classes of this module are:
 | `Client` | client for writing and reading logs from Loki |
 
 `Config` and `Client` must be called on the k6 init context (see
-[Test life cycle](https://k6.io/docs/using-k6/test-life-cycle/)) outside of the
+[Test life cycle](https://grafana.com/docs/k6/latest/using-k6/test-lifecycle/)) outside of the
 default function so the client is only configured once and shared between all
 VU iterations.
 

--- a/docs/sources/send-data/k6/query-scenario.md
+++ b/docs/sources/send-data/k6/query-scenario.md
@@ -96,7 +96,7 @@ export default () => {
 ## Metrics
 
 The extension collects metrics that are printed in the
-[end-of-test summary](https://k6.io/docs/results-visualization/end-of-test-summary/) in addition to the built-in metrics.
+[end-of-test summary](https://grafana.com/docs/k6/latest/results-output/end-of-test/) in addition to the built-in metrics.
 These metrics are collected only for instant and range queries.
 
 | name                              | description                                  |

--- a/docs/sources/send-data/k6/write-scenario.md
+++ b/docs/sources/send-data/k6/write-scenario.md
@@ -59,17 +59,17 @@ These parameters can be adjusted in the load test:
 
 * The way to run k6
 
-    k6 supports three [execution modes](https://k6.io/docs/get-started/running-k6/#execution-modes) to run a test: local, distributed, and cloud.
+    k6 supports three [execution modes](https://grafana.com/docs/k6/latest/get-started/running-k6/#execution-modes) to run a test: local, distributed, and cloud.
     Whereas running your k6 load test from a single (local
     or remote) machine is easy to set up and fine for smaller Loki clusters,
     the single machine does not load test large Loki installations,
     because it cannot create the data to saturate the write path.
-    For larger tests, consider [these optimizations](https://k6.io/docs/testing-guides/running-large-tests/), or run them in [Grafana Cloud k6](/products/cloud/k6) or a Kubernetes cluster with the [k6 Operator](https://github.com/grafana/k6-operator).
+    For larger tests, consider [these optimizations](https://grafana.com/docs/k6/latest/testing-guides/running-large-tests/), or run them in [Grafana Cloud k6](/products/cloud/k6) or a Kubernetes cluster with the [k6 Operator](https://github.com/grafana/k6-operator).
 
 ## Metrics
 
 The extension collects two metrics that are printed in the
-[end-of-test summary](https://k6.io/docs/results-visualization/end-of-test-summary/) in addition to the built-in metrics.
+[end-of-test summary](https://grafana.com/docs/k6/latest/results-output/end-of-test/) in addition to the built-in metrics.
 
 | name | description |
 | ---- | ----------- |
@@ -80,7 +80,7 @@ The extension collects two metrics that are printed in the
 
 An HTTP request that successfully pushes logs to Loki
 responds with status `204 No Content`.
-The status code should be checked explicitly with a [k6 check](https://k6.io/docs/javascript-api/k6/check-val-sets-tags/).
+The status code should be checked explicitly with a [k6 check](https://grafana.com/docs/k6/latest/javascript-api/k6/check/).
 
 
 ## Javascript example


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR updates all the links to k6.io/docs to grafana.com/docs/k6. This is part of the SEO work we're doing to try to make the Grafana version of the k6 docs to start to show up higher in search results.

I found these links by searching the website repository. Ideally, we'd update these links for all versions (v1.4.x to v1.7.x, and v2.5.x to v3.0.x).

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
