### PR TITLE
chore: Optimize line_tokenizer for better performance

### DIFF
--- a/pkg/pattern/drain/line_tokenizer.go
+++ b/pkg/pattern/drain/line_tokenizer.go
@@ -38,7 +38,7 @@ func newPunctuationTokenizer() *punctuationTokenizer {
 }
 
 func (p *punctuationTokenizer) Tokenize(line string) ([]string, interface{}) {
-	tokens := make([]string, len(line))                  // Maximum size is every character is punctuation
+	tokens := make([]string, 0, 64)                      // Maximum size is every character is punctuation
 	spacesAfter := make([]int, strings.Count(line, " ")) // Could be a bitmap, but it's not worth it for a few bytes.
 
 	start := 0
@@ -51,14 +51,14 @@ func (p *punctuationTokenizer) Tokenize(line string) ([]string, interface{}) {
 		included := char < 128 && p.includeDelimiters[char] != 0
 		if char == ' ' || included || unicode.IsPunct(char) {
 			if i > start {
-				tokens[nextTokenIdx] = line[start:i]
+				tokens = append(tokens, line[start:i])
 				nextTokenIdx++
 			}
 			if char == ' ' {
 				spacesAfter[nextSpaceIdx] = nextTokenIdx - 1
 				nextSpaceIdx++
 			} else {
-				tokens[nextTokenIdx] = line[i : i+1]
+				tokens = append(tokens, line[i:i+1])
 				nextTokenIdx++
 			}
 			start = i + 1
@@ -66,7 +66,7 @@ func (p *punctuationTokenizer) Tokenize(line string) ([]string, interface{}) {
 	}
 
 	if start < len(line) {
-		tokens[nextTokenIdx] = line[start:]
+		tokens = append(tokens, line[start:])
 		nextTokenIdx++
 	}
 


### PR DESCRIPTION
The line_tokenizer code has been optimized to improve performance. The `make` function for the `tokens` slice has been modified to use a capacity of 64 instead of the length of the line. 

Hopefully this helps keep allocation under control.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
