### PR TITLE
refactor(blooms): Implement retry in builder

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -378,17 +378,17 @@ bloom_build:
     [planner_address: <string> | default = ""]
 
     backoff_config:
-      # Minimum backoff time
-      # CLI flag: -bloom-build.builder.backoff.min-backoff
-      [min_period: <duration> | default = 1s]
+      # Minimum delay when backing off.
+      # CLI flag: -bloom-build.builder.backoff.backoff-min-period
+      [min_period: <duration> | default = 100ms]
 
-      # Maximum backoff time
-      # CLI flag: -bloom-build.builder.backoff.max-backoff
+      # Maximum delay when backing off.
+      # CLI flag: -bloom-build.builder.backoff.backoff-max-period
       [max_period: <duration> | default = 10s]
 
-      # Maximum number of times to retry an operation
-      # CLI flag: -bloom-build.builder.backoff.max-retries
-      [max_retries: <int> | default = 5]
+      # Number of times to backoff and retry before failing.
+      # CLI flag: -bloom-build.builder.backoff.backoff-retries
+      [max_retries: <int> | default = 10]
 
 # Experimental: The bloom_gateway block configures the Loki bloom gateway
 # server, responsible for serving queries for filtering chunks based on filter

--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -377,6 +377,19 @@ bloom_build:
     # CLI flag: -bloom-build.builder.planner-address
     [planner_address: <string> | default = ""]
 
+    backoff_config:
+      # Minimum backoff time
+      # CLI flag: -bloom-build.builder.backoff.min-backoff
+      [min_period: <duration> | default = 1s]
+
+      # Maximum backoff time
+      # CLI flag: -bloom-build.builder.backoff.max-backoff
+      [max_period: <duration> | default = 10s]
+
+      # Maximum number of times to retry an operation
+      # CLI flag: -bloom-build.builder.backoff.max-retries
+      [max_retries: <int> | default = 5]
+
 # Experimental: The bloom_gateway block configures the Loki bloom gateway
 # server, responsible for serving queries for filtering chunks based on filter
 # expressions.

--- a/pkg/bloombuild/builder/builder_test.go
+++ b/pkg/bloombuild/builder/builder_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
+	"github.com/grafana/dskit/backoff"
 	"github.com/grafana/dskit/flagext"
 	"github.com/grafana/dskit/services"
 	"github.com/prometheus/client_golang/prometheus"
@@ -77,6 +78,11 @@ func Test_BuilderLoop(t *testing.T) {
 	limits := fakeLimits{}
 	cfg := Config{
 		PlannerAddress: server.Addr(),
+		BackoffConfig: backoff.Config{
+			MinBackoff: 1 * time.Second,
+			MaxBackoff: 10 * time.Second,
+			MaxRetries: 5,
+		},
 	}
 	flagext.DefaultValues(&cfg.GrpcConfig)
 

--- a/pkg/bloombuild/builder/config.go
+++ b/pkg/bloombuild/builder/config.go
@@ -3,8 +3,6 @@ package builder
 import (
 	"flag"
 	"fmt"
-	"time"
-
 	"github.com/grafana/dskit/backoff"
 	"github.com/grafana/dskit/grpcclient"
 )
@@ -20,10 +18,7 @@ type Config struct {
 func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.StringVar(&cfg.PlannerAddress, prefix+".planner-address", "", "Hostname (and port) of the bloom planner")
 	cfg.GrpcConfig.RegisterFlagsWithPrefix(prefix+".grpc", f)
-
-	f.DurationVar(&cfg.BackoffConfig.MinBackoff, prefix+".backoff.min-backoff", 1*time.Second, "Minimum backoff time")
-	f.DurationVar(&cfg.BackoffConfig.MaxBackoff, prefix+".backoff.max-backoff", 10*time.Second, "Maximum backoff time")
-	f.IntVar(&cfg.BackoffConfig.MaxRetries, prefix+".backoff.max-retries", 5, "Maximum number of times to retry an operation")
+	cfg.BackoffConfig.RegisterFlagsWithPrefix(prefix+".backoff", f)
 }
 
 func (cfg *Config) Validate() error {

--- a/pkg/bloombuild/builder/config.go
+++ b/pkg/bloombuild/builder/config.go
@@ -21,9 +21,9 @@ func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.StringVar(&cfg.PlannerAddress, prefix+".planner-address", "", "Hostname (and port) of the bloom planner")
 	cfg.GrpcConfig.RegisterFlagsWithPrefix(prefix+".grpc", f)
 
-	f.DurationVar(&cfg.BackoffConfig.MinBackoff, "dynamodb.min-backoff", 1*time.Second, "Minimum backoff time")
-	f.DurationVar(&cfg.BackoffConfig.MaxBackoff, "dynamodb.max-backoff", 10*time.Second, "Maximum backoff time")
-	f.IntVar(&cfg.BackoffConfig.MaxRetries, "dynamodb.max-retries", 5, "Maximum number of times to retry an operation")
+	f.DurationVar(&cfg.BackoffConfig.MinBackoff, prefix+".backoff.min-backoff", 1*time.Second, "Minimum backoff time")
+	f.DurationVar(&cfg.BackoffConfig.MaxBackoff, prefix+".backoff.max-backoff", 10*time.Second, "Maximum backoff time")
+	f.IntVar(&cfg.BackoffConfig.MaxRetries, prefix+".backoff.max-retries", 5, "Maximum number of times to retry an operation")
 }
 
 func (cfg *Config) Validate() error {

--- a/pkg/bloombuild/builder/config.go
+++ b/pkg/bloombuild/builder/config.go
@@ -3,6 +3,7 @@ package builder
 import (
 	"flag"
 	"fmt"
+
 	"github.com/grafana/dskit/backoff"
 	"github.com/grafana/dskit/grpcclient"
 )

--- a/pkg/bloombuild/builder/config.go
+++ b/pkg/bloombuild/builder/config.go
@@ -3,7 +3,9 @@ package builder
 import (
 	"flag"
 	"fmt"
+	"time"
 
+	"github.com/grafana/dskit/backoff"
 	"github.com/grafana/dskit/grpcclient"
 )
 
@@ -11,12 +13,17 @@ import (
 type Config struct {
 	GrpcConfig     grpcclient.Config `yaml:"grpc_config"`
 	PlannerAddress string            `yaml:"planner_address"`
+	BackoffConfig  backoff.Config    `yaml:"backoff_config"`
 }
 
 // RegisterFlagsWithPrefix registers flags for the bloom-planner configuration.
 func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.StringVar(&cfg.PlannerAddress, prefix+".planner-address", "", "Hostname (and port) of the bloom planner")
 	cfg.GrpcConfig.RegisterFlagsWithPrefix(prefix+".grpc", f)
+
+	f.DurationVar(&cfg.BackoffConfig.MinBackoff, "dynamodb.min-backoff", 1*time.Second, "Minimum backoff time")
+	f.DurationVar(&cfg.BackoffConfig.MaxBackoff, "dynamodb.max-backoff", 10*time.Second, "Maximum backoff time")
+	f.IntVar(&cfg.BackoffConfig.MaxRetries, "dynamodb.max-retries", 5, "Maximum number of times to retry an operation")
 }
 
 func (cfg *Config) Validate() error {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR implements a retry with backoff in the bloom builder. We retry to connect to the planner at two levels:
- At the top of the receive and build loop
- When we try to send back the task result to the planner

**Special notes for your reviewer**:
- We do not retry when we send a builder shutdown notification to the planner. Rationale being that this more like a best effort and we don't want to prevent a builder from shutting down.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
