### PR TITLE
fix(retry): fix retries when using protobuf encoding

### DIFF
--- a/pkg/querier/queryrange/queryrangebase/retry.go
+++ b/pkg/querier/queryrange/queryrangebase/retry.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"github.com/gogo/status"
 	"github.com/grafana/dskit/backoff"
-	"github.com/grafana/dskit/httpgrpc"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
@@ -89,8 +89,8 @@ func (r retry) Do(ctx context.Context, req Request) (Response, error) {
 		}
 
 		// Retry if we get a HTTP 500 or a non-HTTP error.
-		httpResp, ok := httpgrpc.HTTPResponseFromError(err)
-		if !ok || httpResp.Code/100 == 5 {
+		status, ok := status.FromError(err)
+		if !ok || status.Code()/100 == 5 {
 			lastErr = err
 			level.Error(util_log.WithContext(ctx, r.log)).Log(
 				"msg", "error processing request",


### PR DESCRIPTION
**What this PR does / why we need it**:
`retry.go` expects the Details field of grpc status to be populated which it then uses to read the http response code, it fallbacks to retrying if this field is not set.

But with protobuf encoding Details is not populated and loki retries 4xxs. I do not think it is necessary to set this. 

`httpgrpc.HTTPResponseFromError` gets the Status from the error and [additionally tries to decode the http response](https://github.com/grafana/loki/blob/76a764bdca863734176ea5db714da0817d8a4151/vendor/github.com/grafana/dskit/httpgrpc/httpgrpc.go#L141) from Details field. But all `retry.go` needs is the Code from Status field which would be set for both encoding formats, so replacing this call with `status.FromError()` which only pulls out the Status from error should fix the retry behaviour.

**references:**
- Query response status with protobuf encoding is populated here https://github.com/grafana/loki/blob/76a764bdca863734176ea5db714da0817d8a4151/pkg/querier/worker/util.go#L142
- Status from Query response is decoded here. Details are not populated https://github.com/grafana/loki/blob/76a764bdca863734176ea5db714da0817d8a4151/pkg/querier/queryrange/marshal.go#L208
- http encoding populates the Details field here along with Status.Code
https://github.com/grafana/loki/blob/76a764bdca863734176ea5db714da0817d8a4151/pkg/querier/queryrange/codec.go#L667


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
