### PR TITLE
fix: support multi-zone ingesters when converting global to local limits for streams in limiter.go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -50,7 +50,7 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/websocket v1.5.0
 	github.com/grafana/cloudflare-go v0.0.0-20230110200409-c627cf6792f2
-	github.com/grafana/dskit v0.0.0-20240528015923-27d7d41066d3
+	github.com/grafana/dskit v0.0.0-20240626184720-35810fdf1c6d
 	github.com/grafana/go-gelf/v2 v2.0.1
 	github.com/grafana/gomemcache v0.0.0-20240229205252-cd6a66d6fb56
 	github.com/grafana/regexp v0.0.0-20221122212121-6b5c0a4cb7fd

--- a/go.sum
+++ b/go.sum
@@ -1017,8 +1017,8 @@ github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWm
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grafana/cloudflare-go v0.0.0-20230110200409-c627cf6792f2 h1:qhugDMdQ4Vp68H0tp/0iN17DM2ehRo1rLEdOFe/gB8I=
 github.com/grafana/cloudflare-go v0.0.0-20230110200409-c627cf6792f2/go.mod h1:w/aiO1POVIeXUQyl0VQSZjl5OAGDTL5aX+4v0RA1tcw=
-github.com/grafana/dskit v0.0.0-20240528015923-27d7d41066d3 h1:k8vINlI4w+RYc37NRwQlRe/IHYoEbu6KAe2XdGDeV1U=
-github.com/grafana/dskit v0.0.0-20240528015923-27d7d41066d3/go.mod h1:HvSf3uf8Ps2vPpzHeAFyZTdUcbVr+Rxpq1xcx7J/muc=
+github.com/grafana/dskit v0.0.0-20240626184720-35810fdf1c6d h1:CD8PWWX+9lYdgeMquSofmLErvCtk7jb+3/W/SH6oo/k=
+github.com/grafana/dskit v0.0.0-20240626184720-35810fdf1c6d/go.mod h1:HvSf3uf8Ps2vPpzHeAFyZTdUcbVr+Rxpq1xcx7J/muc=
 github.com/grafana/go-gelf/v2 v2.0.1 h1:BOChP0h/jLeD+7F9mL7tq10xVkDG15he3T1zHuQaWak=
 github.com/grafana/go-gelf/v2 v2.0.1/go.mod h1:lexHie0xzYGwCgiRGcvZ723bSNyNI8ZRD4s0CLobh90=
 github.com/grafana/gocql v0.0.0-20200605141915-ba5dc39ece85 h1:xLuzPoOzdfNb/RF/IENCw+oLVdZB4G21VPhkHBgwSHY=

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -1568,6 +1568,10 @@ func (r *readRingMock) ZonesCount() int {
 	return 1
 }
 
+func (r *readRingMock) HealthyInstancesInZoneCount() int {
+	return len(r.replicationSet.Instances)
+}
+
 func (r *readRingMock) Subring(_ uint32, _ int) ring.ReadRing {
 	return r
 }

--- a/pkg/ingester/limiter.go
+++ b/pkg/ingester/limiter.go
@@ -131,7 +131,7 @@ func calculateLimitForSingleZone(globalLimit int, l *Limiter) int {
 func calculateLimitForMultipleZones(globalLimit, zonesCount int, l *Limiter) int {
 	ingestersInZone := l.ring.HealthyInstancesInZoneCount()
 	if ingestersInZone > 0 {
-		return int(float64(globalLimit) * float64(l.replicationFactor) * float64(zonesCount) / float64(ingestersInZone))
+		return int((float64(globalLimit) * float64(l.replicationFactor)) / float64(zonesCount) / float64(ingestersInZone))
 	}
 	return 0
 }

--- a/pkg/ingester/limiter_test.go
+++ b/pkg/ingester/limiter_test.go
@@ -214,6 +214,14 @@ func (m *ringCountMock) HealthyInstancesCount() int {
 	return m.count
 }
 
+func (m *ringCountMock) ZonesCount() int {
+	return 1
+}
+
+func (m *ringCountMock) HealthyInstancesInZoneCount() int {
+	return m.count
+}
+
 // Assert some of the weirder (bug?) behavior of golang.org/x/time/rate
 func TestGoLimiter(t *testing.T) {
 	for _, tc := range []struct {

--- a/pkg/ingester/limiter_test.go
+++ b/pkg/ingester/limiter_test.go
@@ -293,9 +293,9 @@ func TestConvertGlobalToLocalLimit(t *testing.T) {
 	}{
 		{"GlobalLimitZero", 0, 1, 1, 1, 3, 0},
 		{"SingleZoneMultipleIngesters", 100, 1, 10, 10, 3, 30},
-		{"MultipleZones", 200, 3, 0, 10, 3, 180},
-		{"MultipleZonesNoIngesters", 200, 2, 0, 0, 3, 0},
-		{"MultipleZonesNoIngestersInZone", 200, 3, 10, 0, 3, 0},
+		{"MultipleZones", 200, 3, 30, 10, 3, 20},
+		{"MultipleZonesNoHealthyIngesters", 200, 2, 0, 0, 3, 0},
+		{"MultipleZonesNoHealthyIngestersInZone", 200, 3, 10, 0, 3, 0},
 	}
 
 	for _, tc := range tests {

--- a/pkg/ingester/limiter_test.go
+++ b/pkg/ingester/limiter_test.go
@@ -292,8 +292,8 @@ func TestConvertGlobalToLocalLimit(t *testing.T) {
 		expectedLocalLimit          int
 	}{
 		{"GlobalLimitZero", 0, 1, 1, 1, 3, 0},
-		{"SingleZoneMultipleIngesters", 100, 1, 10, 10, 3, 10},
-		{"MultipleZones", 200, 2, 0, 10, 3, 40},
+		{"SingleZoneMultipleIngesters", 100, 1, 10, 10, 3, 30},
+		{"MultipleZones", 200, 3, 0, 10, 3, 180},
 		{"MultipleZonesNoIngesters", 200, 2, 0, 0, 3, 0},
 		{"MultipleZonesNoIngestersInZone", 200, 3, 10, 0, 3, 0},
 	}

--- a/vendor/github.com/grafana/dskit/grpcutil/dns_resolver.go
+++ b/vendor/github.com/grafana/dskit/grpcutil/dns_resolver.go
@@ -208,7 +208,7 @@ func (w *dnsWatcher) lookupSRV() map[string]*Update {
 		for _, a := range addrs {
 			a, ok := formatIP(a)
 			if !ok {
-				level.Error(w.logger).Log("failed IP parsing", "err", err)
+				level.Error(w.logger).Log("msg", "failed IP parsing", "err", err)
 				continue
 			}
 			addr := a + ":" + strconv.Itoa(int(s.Port))

--- a/vendor/github.com/grafana/dskit/grpcutil/health_check.go
+++ b/vendor/github.com/grafana/dskit/grpcutil/health_check.go
@@ -16,7 +16,7 @@ type Check func(ctx context.Context) bool
 
 // WithManager returns a new Check that tests if the managed services are healthy.
 func WithManager(manager *services.Manager) Check {
-	return func(ctx context.Context) bool {
+	return func(context.Context) bool {
 		states := manager.ServicesByState()
 
 		// Given this is a health check endpoint for the whole instance, we should consider
@@ -33,7 +33,7 @@ func WithManager(manager *services.Manager) Check {
 
 // WithShutdownRequested returns a new Check that returns false when shutting down.
 func WithShutdownRequested(requested *atomic.Bool) Check {
-	return func(ctx context.Context) bool {
+	return func(context.Context) bool {
 		return !requested.Load()
 	}
 }

--- a/vendor/github.com/grafana/dskit/httpgrpc/httpgrpc.go
+++ b/vendor/github.com/grafana/dskit/httpgrpc/httpgrpc.go
@@ -116,8 +116,14 @@ func Errorf(code int, tmpl string, args ...interface{}) error {
 	})
 }
 
-// ErrorFromHTTPResponse converts an HTTP response into a grpc error
+// ErrorFromHTTPResponse converts an HTTP response into a grpc error, and uses HTTP response body as an error message.
+// Note that if HTTP response body contains non-utf8 string, then returned error cannot be marshalled by protobuf.
 func ErrorFromHTTPResponse(resp *HTTPResponse) error {
+	return ErrorFromHTTPResponseWithMessage(resp, string(resp.Body))
+}
+
+// ErrorFromHTTPResponseWithMessage converts an HTTP response into a grpc error, and uses supplied message for Error message.
+func ErrorFromHTTPResponseWithMessage(resp *HTTPResponse, msg string) error {
 	a, err := types.MarshalAny(resp)
 	if err != nil {
 		return err
@@ -125,7 +131,7 @@ func ErrorFromHTTPResponse(resp *HTTPResponse) error {
 
 	return status.ErrorProto(&spb.Status{
 		Code:    resp.Code,
-		Message: string(resp.Body),
+		Message: msg,
 		Details: []*types.Any{a},
 	})
 }

--- a/vendor/github.com/grafana/dskit/httpgrpc/server/server.go
+++ b/vendor/github.com/grafana/dskit/httpgrpc/server/server.go
@@ -26,11 +26,21 @@ import (
 )
 
 var (
-	// DoNotLogErrorHeaderKey is a header key used for marking non-loggable errors. More precisely, if an HTTP response
+	// DoNotLogErrorHeaderKey is a header name used for marking non-loggable errors. More precisely, if an HTTP response
 	// has a status code 5xx, and contains a header with key DoNotLogErrorHeaderKey and any values, the generated error
 	// will be marked as non-loggable.
 	DoNotLogErrorHeaderKey = http.CanonicalHeaderKey("X-DoNotLogError")
+
+	// ErrorMessageHeaderKey is a header name for header that contains error message that should be used when Server.Handle
+	// (httpgrpc.HTTP/Handle implementation) decides to return the response as an error, using status.ErrorProto.
+	// Normally Server.Handle would use entire response body as a error message, but Message field of rcp.Status object
+	// is a string, and if body contains non-utf8 bytes, marshalling of this object will fail.
+	ErrorMessageHeaderKey = http.CanonicalHeaderKey("X-ErrorMessage")
 )
+
+type contextType int
+
+const handledByHttpgrpcServer contextType = 0
 
 type Option func(*Server)
 
@@ -59,6 +69,8 @@ func NewServer(handler http.Handler, opts ...Option) *Server {
 
 // Handle implements HTTPServer.
 func (s Server) Handle(ctx context.Context, r *httpgrpc.HTTPRequest) (*httpgrpc.HTTPResponse, error) {
+	ctx = context.WithValue(ctx, handledByHttpgrpcServer, true)
+
 	req, err := httpgrpc.ToHTTPRequest(ctx, r)
 	if err != nil {
 		return nil, err
@@ -74,13 +86,24 @@ func (s Server) Handle(ctx context.Context, r *httpgrpc.HTTPRequest) (*httpgrpc.
 		header.Del(DoNotLogErrorHeaderKey) // remove before converting to httpgrpc resp
 	}
 
+	errorMessageFromHeader := ""
+	if msg, ok := header[ErrorMessageHeaderKey]; ok {
+		errorMessageFromHeader = msg[0]
+		header.Del(ErrorMessageHeaderKey) // remove before converting to httpgrpc resp
+	}
+
 	resp := &httpgrpc.HTTPResponse{
 		Code:    int32(recorder.Code),
 		Headers: httpgrpc.FromHeader(header),
 		Body:    recorder.Body.Bytes(),
 	}
 	if s.shouldReturnError(resp) {
-		err := httpgrpc.ErrorFromHTTPResponse(resp)
+		var err error
+		if errorMessageFromHeader != "" {
+			err = httpgrpc.ErrorFromHTTPResponseWithMessage(resp, errorMessageFromHeader)
+		} else {
+			err = httpgrpc.ErrorFromHTTPResponse(resp)
+		}
 		if doNotLogError {
 			err = middleware.DoNotLogError{Err: err}
 		}
@@ -205,4 +228,14 @@ func (c *Client) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+}
+
+// IsHandledByHttpgrpcServer returns true if context is associated with HTTP request that was initiated by
+// Server.Handle, which is an implementation of httpgrpc.HTTP/Handle gRPC method.
+func IsHandledByHttpgrpcServer(ctx context.Context) bool {
+	val := ctx.Value(handledByHttpgrpcServer)
+	if v, ok := val.(bool); ok {
+		return v
+	}
+	return false
 }

--- a/vendor/github.com/grafana/dskit/kv/consul/client.go
+++ b/vendor/github.com/grafana/dskit/kv/consul/client.go
@@ -116,7 +116,7 @@ func (c *Client) Put(ctx context.Context, key string, value interface{}) error {
 		return err
 	}
 
-	return instrument.CollectedRequest(ctx, "Put", c.consulMetrics.consulRequestDuration, instrument.ErrorCode, func(ctx context.Context) error {
+	return instrument.CollectedRequest(ctx, "Put", c.consulMetrics.consulRequestDuration, instrument.ErrorCode, func(context.Context) error {
 		_, err := c.kv.Put(&consul.KVPair{
 			Key:   key,
 			Value: bytes,
@@ -376,16 +376,18 @@ func checkLastIndex(index, metaLastIndex uint64) (newIndex uint64, skip bool) {
 		// Don't just keep using index=0.
 		// After blocking request, returned index must be at least 1.
 		return 1, false
-	} else if metaLastIndex < index {
+	}
+	if metaLastIndex < index {
 		// Index reset.
 		return 0, false
-	} else if index == metaLastIndex {
+	}
+	if index == metaLastIndex {
 		// Skip if the index is the same as last time, because the key value is
 		// guaranteed to be the same as last time
 		return metaLastIndex, true
-	} else {
-		return metaLastIndex, false
 	}
+
+	return metaLastIndex, false
 }
 
 func (c *Client) createRateLimiter() *rate.Limiter {

--- a/vendor/github.com/grafana/dskit/kv/etcd/mock.go
+++ b/vendor/github.com/grafana/dskit/kv/etcd/mock.go
@@ -234,15 +234,17 @@ func (m *mockKV) Do(_ context.Context, op clientv3.Op) (clientv3.OpResponse, err
 func (m *mockKV) doInternal(op clientv3.Op) (clientv3.OpResponse, error) {
 	if op.IsGet() {
 		return m.doGet(op)
-	} else if op.IsPut() {
-		return m.doPut(op)
-	} else if op.IsDelete() {
-		return m.doDelete(op)
-	} else if op.IsTxn() {
-		return m.doTxn(op)
-	} else {
-		panic(fmt.Sprintf("unsupported operation: %+v", op))
 	}
+	if op.IsPut() {
+		return m.doPut(op)
+	}
+	if op.IsDelete() {
+		return m.doDelete(op)
+	}
+	if op.IsTxn() {
+		return m.doTxn(op)
+	}
+	panic(fmt.Sprintf("unsupported operation: %+v", op))
 }
 
 func (m *mockKV) doGet(op clientv3.Op) (clientv3.OpResponse, error) {

--- a/vendor/github.com/grafana/dskit/kv/memberlist/memberlist_client.go
+++ b/vendor/github.com/grafana/dskit/kv/memberlist/memberlist_client.go
@@ -1171,7 +1171,7 @@ func (m *KV) queueBroadcast(key string, content []string, version uint, message 
 		content: content,
 		version: version,
 		msg:     message,
-		finished: func(b ringBroadcast) {
+		finished: func(ringBroadcast) {
 			m.totalSizeOfBroadcastMessagesInQueue.Sub(float64(l))
 		},
 		logger: m.logger,

--- a/vendor/github.com/grafana/dskit/kv/multi.go
+++ b/vendor/github.com/grafana/dskit/kv/multi.go
@@ -350,7 +350,7 @@ func (m *MultiClient) writeToSecondary(ctx context.Context, primary kvclient, ke
 		}
 
 		m.mirrorWritesCounter.Inc()
-		err := kvc.client.CAS(ctx, key, func(in interface{}) (out interface{}, retry bool, err error) {
+		err := kvc.client.CAS(ctx, key, func(interface{}) (out interface{}, retry bool, err error) {
 			// try once
 			return newValue, false, nil
 		})

--- a/vendor/github.com/grafana/dskit/middleware/logging.go
+++ b/vendor/github.com/grafana/dskit/middleware/logging.go
@@ -56,9 +56,11 @@ func NewLogMiddleware(log log.Logger, logRequestHeaders bool, logRequestAtInfoLe
 // logWithRequest information from the request and context as fields.
 func (l Log) logWithRequest(r *http.Request) log.Logger {
 	localLog := l.Log
-	traceID, ok := tracing.ExtractTraceID(r.Context())
+	traceID, ok := tracing.ExtractSampledTraceID(r.Context())
 	if ok {
 		localLog = log.With(localLog, "trace_id", traceID)
+	} else if traceID != "" {
+		localLog = log.With(localLog, "trace_id_unsampled", traceID)
 	}
 
 	if l.SourceIPs != nil {

--- a/vendor/github.com/grafana/dskit/services/failure_watcher.go
+++ b/vendor/github.com/grafana/dskit/services/failure_watcher.go
@@ -35,7 +35,7 @@ func (w *FailureWatcher) WatchService(service Service) {
 		panic(errFailureWatcherNotInitialized)
 	}
 
-	service.AddListener(NewListener(nil, nil, nil, nil, func(from State, failure error) {
+	service.AddListener(NewListener(nil, nil, nil, nil, func(_ State, failure error) {
 		w.ch <- errors.Wrapf(failure, "service %s failed", DescribeService(service))
 	}))
 }

--- a/vendor/github.com/grafana/dskit/spanprofiler/tracer.go
+++ b/vendor/github.com/grafana/dskit/spanprofiler/tracer.go
@@ -41,6 +41,9 @@ func (t *tracer) StartSpan(operationName string, opts ...opentracing.StartSpanOp
 	if !ok {
 		return span
 	}
+	if !spanCtx.IsSampled() {
+		return span
+	}
 	// pprof labels are attached only once, at the span root level.
 	if !isRootSpan(opts...) {
 		return span

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -927,7 +927,7 @@ github.com/gorilla/websocket
 # github.com/grafana/cloudflare-go v0.0.0-20230110200409-c627cf6792f2
 ## explicit; go 1.17
 github.com/grafana/cloudflare-go
-# github.com/grafana/dskit v0.0.0-20240528015923-27d7d41066d3
+# github.com/grafana/dskit v0.0.0-20240626184720-35810fdf1c6d
 ## explicit; go 1.20
 github.com/grafana/dskit/aws
 github.com/grafana/dskit/backoff


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the calculation for stream limits to support multi-zone ingester deployments while maintaining the old logic for single-zone deployments.

re:
- https://github.com/grafana/loki/pull/13006
- https://github.com/grafana/loki/pull/13103
- https://github.com/grafana/loki/pull/13254
- https://github.com/grafana/loki/pull/13030
- https://github.com/grafana/loki/pull/13231
- https://github.com/grafana/loki/pull/13314

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

Requires https://github.com/grafana/dskit/pull/526 to be merged and the version of dskit used by Loki to be updated to support `HealthyInstancesInZoneCount()`

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
