### PR TITLE
fix: Lint issues after merge to main

### DIFF
--- a/integration/bloom_building_test.go
+++ b/integration/bloom_building_test.go
@@ -99,16 +99,14 @@ func TestBloomBuilding(t *testing.T) {
 	require.NoError(t, clu.Run())
 
 	// Add several builders
-	builders := make([]*cluster.Component, 0, nBuilders)
 	for i := 0; i < nBuilders; i++ {
-		builder := clu.AddComponent(
+		clu.AddComponent(
 			"bloom-builder",
 			"-target=bloom-builder",
 			"-bloom-build.enabled=true",
 			"-bloom-build.enable=true",
 			"-bloom-build.builder.planner-address="+tBloomPlanner.GRPCURL(),
 		)
-		builders = append(builders, builder)
 	}
 	require.NoError(t, clu.Run())
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Followup PR for https://github.com/grafana/loki/pull/13308 fixing a lint issue that broke main.
```
INFO [runner] linters took 28.358598988s with stages: goanalysis_metalinter: 28.013548731s 
integration/bloom_building_test.go:111:14: SA4010: this result of append is never used, except maybe in other appends (staticcheck)
		builders = append(builders, builder)
```

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
