### PR TITLE
perf: Prune unused pattern branches

### DIFF
--- a/pkg/pattern/drain/drain.go
+++ b/pkg/pattern/drain/drain.go
@@ -284,6 +284,27 @@ func (d *Drain) PatternString(c *LogCluster) string {
 	return s
 }
 
+func (d *Drain) Prune() {
+	d.pruneTree(d.rootNode)
+}
+
+func (d *Drain) pruneTree(node *Node) int {
+	for key, child := range node.keyToChildNode {
+		if d.pruneTree(child) == 0 {
+			delete(node.keyToChildNode, key)
+		}
+	}
+
+	validClusterIds := 0
+	for _, clusterID := range node.clusterIDs {
+		cluster := d.idToCluster.Get(clusterID)
+		if cluster != nil {
+			validClusterIds++
+		}
+	}
+	return len(node.keyToChildNode) + validClusterIds
+}
+
 func (d *Drain) Delete(cluster *LogCluster) {
 	d.idToCluster.cache.Remove(cluster.id)
 }

--- a/pkg/pattern/stream.go
+++ b/pkg/pattern/stream.go
@@ -275,6 +275,8 @@ func (s *stream) prune(olderThan time.Duration) bool {
 			s.patterns.Delete(cluster)
 		}
 	}
+	// Clear empty branches after deleting chunks & clusters
+	s.patterns.Prune()
 
 	chunksPruned := true
 	if s.chunks != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a Prune command to Drain to clear branches with no associated log clusters.

* We use an LRU cache to limit the number of patterns we match against
* But when we delete a pattern due to age, we don't delete it's corresponding branches in the drain tree.
* This PR adds a step to traverse the tree and delete any nodes that don't have children or log clusters attached.
* It is run periodically, at the same time as we run the current logcluster prune process but it could probably be reduced in frequency.