### PR TITLE
docs: More Alloy updates

### DIFF
--- a/docs/sources/get-started/_index.md
+++ b/docs/sources/get-started/_index.md
@@ -23,8 +23,8 @@ To collect logs and view your log data generally involves the following steps:
    - [Storage options](https://grafana.com/docs/loki/<LOKI_VERSION>/operations/storage/)
    - [Configuration reference](https://grafana.com/docs/loki/<LOKI_VERSION>/configure/)
    - There are [examples](https://grafana.com/docs/loki/<LOKI_VERSION>/configure/examples/) for specific Object Storage providers that you can modify.
-1. Deploy the [Grafana Agent](https://grafana.com/docs/agent/latest/flow/) to collect logs from your applications.
-    1. On Kubernetes, deploy the Grafana Agent using the Helm chart. Configure Grafana Agent to scrape logs from your Kubernetes cluster, and add your Loki endpoint details. See the following section for an example Grafana Agent Flow configuration file.
+1. Deploy [Grafana Alloy](https://grafana.com/docs/alloy/latest/) to collect logs from your applications.
+    1. On Kubernetes, deploy the Grafana Flow using the Helm chart. Configure Grafana Alloy to scrape logs from your Kubernetes cluster, and add your Loki endpoint details. See the following section for an example Grafana Alloy configuration file.
     1. Add [labels](https://grafana.com/docs/loki/<LOKI_VERSION>/get-started/labels/) to your logs following our [best practices](https://grafana.com/docs/loki/<LOKI_VERSION>/get-started/labels/bp-labels/). Most Loki users start by adding labels which describe where the logs are coming from (region, cluster, environment, etc.).
 1. Deploy [Grafana](https://grafana.com/docs/grafana/latest/setup-grafana/) or [Grafana Cloud](https://grafana.com/docs/grafana-cloud/quickstart/) and configure a [Loki datasource](https://grafana.com/docs/grafana/latest/datasources/loki/configure-loki-data-source/).
 1. Select the [Explore feature](https://grafana.com/docs/grafana/latest/explore/) in the Grafana main menu. To [view logs in Explore](https://grafana.com/docs/grafana/latest/explore/logs-integration/):
@@ -34,14 +34,56 @@ To collect logs and view your log data generally involves the following steps:
 
 **Next steps:** Learn more about Loki’s query language, [LogQL](https://grafana.com/docs/loki/<LOKI_VERSION>/query/).
 
-## Example Grafana Agent configuration file to ship Kubernetes Pod logs to Loki
+## Example Grafana Alloy and Agent configuration files to ship Kubernetes Pod logs to Loki
 
-To deploy Grafana Agent to collect Pod logs from your Kubernetes cluster and ship them to Loki, you an use the Grafana Agent Helm chart, and a `values.yaml` file.
+To deploy Grafana Alloy or Agent to collect Pod logs from your Kubernetes cluster and ship them to Loki, you an use a Helm chart, and a `values.yaml` file.
+
+This sample `values.yaml` file is configured to:
+
+- Install Grafana Agent to discover Pod logs.
+- Add `container` and `pod` labels to the logs.
+- Push the logs to your Loki cluster using the tenant ID `cloud`.
 
 1. Install Loki with the [Helm chart](https://grafana.com/docs/loki/<LOKI_VERSION>/setup/install/helm/install-scalable/).
-1. Deploy the Grafana Agent, using the [Grafana Agent Helm chart](https://grafana.com/docs/agent/latest/flow/setup/install/kubernetes/) and this example `values.yaml` file updating the value for `forward_to = [loki.write.endpoint.receiver]`:
 
-```yaml
+1. Deploy either Grafana Alloy or the Grafana Agent, using the Helm chart:
+    - [Grafana Alloy Helm chart](https://grafana.com/docs/alloy/latest/get-started/install/kubernetes/)
+    - [Grafana Agent Helm chart](https://grafana.com/docs/agent/latest/flow/setup/install/kubernetes/)
+
+1. Create a `values.yaml` file, based on the following example, making sure to update the value for `forward_to = [loki.write.endpoint.receiver]`:
+
+    {{< code >}}
+
+```yaml-alloy
+alloy:
+  mounts:
+    varlog: true
+  configMap:
+    content: |
+      logging {
+        level  = "info"
+        format = "logfmt"
+      }
+
+      discovery.kubernetes "pods" {
+        role = "pod"
+      }
+
+      loki.source.kubernetes "pods" {
+        targets    = discovery.kubernetes.pods.targets
+        forward_to = [loki.write.endpoint.receiver]
+      }
+
+      loki.write "endpoint" {
+        endpoint {
+            url = "http://loki-gateway.default.svc.cluster.local:80/loki/api/v1/push"
+            tenant_id = "local"
+        }
+      }
+
+```
+
+```yaml-static-agent
 agent:
   mounts:
     varlog: true
@@ -99,17 +141,20 @@ agent:
             tenant_id = "cloud"
         }
       }
+```
+
+    {{< /code >}}
+
+1. Then install Alloy or the Agent in your Kubernetes cluster using:
+
+    {{< code >}}
+
+```alloy
+helm install alloy grafana/alloy -f ./values.yml    
 
 ```
 
-1. Then install Grafana Agent in your Kubernetes cluster using:
-
-    ```bash
-    helm upgrade -f values.yaml agent grafana/grafana-agent 
-    ```
-
-This sample file is configured to:
-
-- Install Grafana Agent to discover Pod logs.
-- Add `container` and `pod` labels to the logs.
-- Push the logs to your Loki cluster using the tenant ID `cloud`.
+```agent
+helm upgrade -f values.yaml agent grafana/grafana-agent 
+```
+    {{< /code >}}

--- a/docs/sources/setup/install/helm/install-scalable/_index.md
+++ b/docs/sources/setup/install/helm/install-scalable/_index.md
@@ -294,5 +294,5 @@ bloomGateway:
 To configure other storage providers, refer to the [Helm Chart Reference]({{< relref "../reference" >}}).
 
 ## Next Steps 
-* Configure an agent to [send log data to Loki](/docs/loki/<LOKI_VERSION>/send-data/).
+* Configure a client to [send log data to Loki](/docs/loki/<LOKI_VERSION>/send-data/).
 * Monitor the Loki deployment using the [Meta Monitoring Healm chart](/docs/loki/<LOKI_VERSION>/setup/install/helm/monitor-and-alert/)


### PR DESCRIPTION
**What this PR does / why we need it**:

Continuation of work started in #13056 and #13056.

Still working through updating all the Grafana Agent references to Grafana Alloy.

**Which issue(s) this PR fixes**:

Addresses https://github.com/grafana/alloy/issues/884 but cannot complete work until the Loki Helm chart is updated to install Alloy.

**Special notes for your reviewer**:
Since we still support Grafana Agent, I didn't want to delete the configuration example (yet).  The `code` shortcode creates tabs in the Hugo generated output.
![CODE_Shortcode](https://github.com/grafana/loki/assets/4106682/87976dbb-b11f-4a0a-9f9c-9a31370031e1)

References to "Grafana Agent" were left in the upgrade and migration topics, since it is appropriate there.