### PR TITLE
feat: convert WalSegmentWriter to io.ReadSeeker

### DIFF
--- a/pkg/storage/wal/segment.go
+++ b/pkg/storage/wal/segment.go
@@ -279,16 +279,18 @@ func NewEncodedSegmentReader(encodedContent *bytes.Buffer) *EncodedSegmentReader
 	}
 }
 
-func (e EncodedSegmentReader) Read(p []byte) (n int, err error) {
+func (e *EncodedSegmentReader) Read(p []byte) (n int, err error) {
 	return e.delegate.Read(p)
 }
 
-func (e EncodedSegmentReader) Seek(offset int64, whence int) (int64, error) {
+func (e *EncodedSegmentReader) Seek(offset int64, whence int) (int64, error) {
 	return e.delegate.Seek(offset, whence)
 }
 
-func (e EncodedSegmentReader) Close() error {
+func (e *EncodedSegmentReader) Close() error {
 	encodedWalSegmentBufferPool.Put(e.encodedContent)
+	e.encodedContent = nil
+	e.delegate = nil
 	return nil
 }
 

--- a/pkg/storage/wal/segment.go
+++ b/pkg/storage/wal/segment.go
@@ -19,6 +19,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/storage/wal/chunks"
 	"github.com/grafana/loki/v3/pkg/storage/wal/index"
 	"github.com/grafana/loki/v3/pkg/util/encoding"
+	"github.com/grafana/loki/v3/pkg/util/pool"
 )
 
 // LOKW is the magic number for the Loki WAL format.
@@ -32,6 +33,8 @@ var (
 			}
 		},
 	}
+	// 512kb - 20 mb
+	encodedWalSegmentBufferPool = pool.NewBuffer(512*1024, 20*1024*1024, 2)
 )
 
 func init() {
@@ -58,6 +61,10 @@ type streamSegment struct {
 
 func (s *streamSegment) Reset() {
 	s.entries = s.entries[:0]
+}
+
+func (s *streamSegment) WriteTo(w io.Writer) (n int64, err error) {
+	return chunks.WriteChunk(w, s.entries, chunks.EncodingSnappy)
 }
 
 // NewWalSegmentWriter creates a new WalSegmentWriter.
@@ -212,6 +219,7 @@ func (b *SegmentWriter) WriteTo(w io.Writer) (int64, error) {
 	// write index len 4b
 	b.buf1.PutBE32int(n)
 	n, err = w.Write(b.buf1.Get())
+	b.buf1.Reset()
 	if err != nil {
 		return total, err
 	}
@@ -234,10 +242,6 @@ func (b *SegmentWriter) WriteTo(w io.Writer) (int64, error) {
 	return total, nil
 }
 
-func (s *streamSegment) WriteTo(w io.Writer) (n int64, err error) {
-	return chunks.WriteChunk(w, s.entries, chunks.EncodingSnappy)
-}
-
 // Reset clears the writer.
 // After calling Reset, the writer can be reused.
 func (b *SegmentWriter) Reset() {
@@ -246,8 +250,46 @@ func (b *SegmentWriter) Reset() {
 		streamSegmentPool.Put(s)
 	}
 	b.streams = make(map[streamID]*streamSegment, 64)
-	b.buf1.Reset()
 	b.inputSize = 0
+}
+
+func (b *SegmentWriter) ToReader() (io.ReadSeekCloser, error) {
+	// snappy compression rate is ~5x , but we can not predict it, so we need to allocate bigger buffer to avoid allocations
+	buffer := encodedWalSegmentBufferPool.Get(int(b.inputSize / 3))
+	_, err := b.WriteTo(buffer)
+	if err != nil {
+		return nil, fmt.Errorf("failed to write segment to create a reader: %w", err)
+	}
+	return NewEncodedSegmentReader(buffer), nil
+}
+
+var (
+	_ io.ReadSeekCloser = &EncodedSegmentReader{}
+)
+
+type EncodedSegmentReader struct {
+	delegate       io.ReadSeeker
+	encodedContent *bytes.Buffer
+}
+
+func NewEncodedSegmentReader(encodedContent *bytes.Buffer) *EncodedSegmentReader {
+	return &EncodedSegmentReader{
+		encodedContent: encodedContent,
+		delegate:       bytes.NewReader(encodedContent.Bytes()),
+	}
+}
+
+func (e EncodedSegmentReader) Read(p []byte) (n int, err error) {
+	return e.delegate.Read(p)
+}
+
+func (e EncodedSegmentReader) Seek(offset int64, whence int) (int64, error) {
+	return e.delegate.Seek(offset, whence)
+}
+
+func (e EncodedSegmentReader) Close() error {
+	encodedWalSegmentBufferPool.Put(e.encodedContent)
+	return nil
 }
 
 // InputSize returns the total size of the input data written to the writer.

--- a/pkg/storage/wal/segment_test.go
+++ b/pkg/storage/wal/segment_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"sort"
-	"sync"
 	"testing"
 	"time"
 
@@ -333,30 +332,38 @@ func BenchmarkWrites(b *testing.B) {
 
 	dst := bytes.NewBuffer(make([]byte, 0, inputSize))
 
-	pool := sync.Pool{
-		New: func() interface{} {
-			writer, err := NewWalSegmentWriter()
-			if err != nil {
-				panic(err)
-			}
-			return writer
-		},
+	writer, err := NewWalSegmentWriter()
+	require.NoError(b, err)
+
+	for _, d := range data {
+		writer.Append(d.tenant, d.labels, d.lbls, d.entries)
 	}
 
-	b.ResetTimer()
-	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		writer := pool.Get().(*SegmentWriter)
+	encodedLength, err := writer.WriteTo(dst)
+	require.NoError(b, err)
 
-		dst.Reset()
-		writer.Reset()
-
-		for _, d := range data {
-			writer.Append(d.tenant, d.labels, d.lbls, d.entries)
+	b.Run("WriteTo", func(b *testing.B) {
+		b.ResetTimer()
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			dst.Reset()
+			n, err := writer.WriteTo(dst)
+			require.NoError(b, err)
+			require.EqualValues(b, encodedLength, n)
 		}
-		n, err := writer.WriteTo(dst)
-		require.NoError(b, err)
-		require.True(b, n > 0)
-		pool.Put(writer)
-	}
+	})
+
+	bytesBuf := make([]byte, inputSize)
+	b.Run("Reader", func(b *testing.B) {
+		b.ResetTimer()
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			reader, err := writer.ToReader()
+			require.NoError(b, err)
+
+			n, err := reader.Read(bytesBuf)
+			require.EqualValues(b, encodedLength, n)
+			require.NoError(b, reader.Close())
+		}
+	})
 }

--- a/pkg/storage/wal/segment_test.go
+++ b/pkg/storage/wal/segment_test.go
@@ -358,10 +358,12 @@ func BenchmarkWrites(b *testing.B) {
 		b.ResetTimer()
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
+			var err error
 			reader, err := writer.ToReader()
 			require.NoError(b, err)
 
 			n, err := reader.Read(bytesBuf)
+			require.NoError(b, err)
 			require.EqualValues(b, encodedLength, n)
 			require.NoError(b, reader.Close())
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
Implemented logic to convert WalSegmentWriter to a reader that implements io.ReadSeekCloser that satisfies the type required by ObjectClient.PutObject() function.

**Special notes for your reviewer**:
Benchmark results:
```
goos: darwin
goarch: arm64
pkg: github.com/grafana/loki/v3/pkg/storage/wal
BenchmarkWrites
BenchmarkWrites/WriteTo
BenchmarkWrites/WriteTo-12         	     330	   3546897 ns/op	   45038 B/op	     229 allocs/op
BenchmarkWrites/Reader
BenchmarkWrites/Reader-12          	     333	   3507544 ns/op	   51875 B/op	     232 allocs/op
PASS
```

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
