### PR TITLE
fix(blooms): Remove unused arg

### DIFF
--- a/pkg/bloombuild/builder/builder.go
+++ b/pkg/bloombuild/builder/builder.go
@@ -69,7 +69,7 @@ func New(
 		return nil, fmt.Errorf("error creating TSDB store: %w", err)
 	}
 
-	metrics := NewMetrics(r, bloomStore.BloomMetrics())
+	metrics := NewMetrics(r)
 	b := &Builder{
 		ID:          builderID,
 		cfg:         cfg,

--- a/pkg/bloombuild/builder/metrics.go
+++ b/pkg/bloombuild/builder/metrics.go
@@ -3,8 +3,6 @@ package builder
 import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-
-	v1 "github.com/grafana/loki/v3/pkg/storage/bloom/v1"
 )
 
 const (
@@ -32,7 +30,7 @@ type Metrics struct {
 	chunkSize prometheus.Histogram
 }
 
-func NewMetrics(r prometheus.Registerer, bloomMetrics *v1.Metrics) *Metrics {
+func NewMetrics(r prometheus.Registerer) *Metrics {
 	return &Metrics{
 		running: promauto.With(r).NewGauge(prometheus.GaugeOpts{
 			Namespace: metricsNamespace,


### PR DESCRIPTION
**What this PR does / why we need it**:
Folow-up PR for https://github.com/grafana/loki/pull/13341 fixing this check:

https://github.com/grafana/loki/actions/runs/9696539224/job/26758688527
![image](https://github.com/grafana/loki/assets/8354290/f57fcd67-398c-41a9-8943-315688ff2cac)


**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
