### PR TITLE
feat(helm): canary can be set as a deployment

### DIFF
--- a/docs/sources/setup/install/helm/reference.md
+++ b/docs/sources/setup/install/helm/reference.md
@@ -6213,6 +6213,20 @@ false
 </td>
 		</tr>
 		<tr>
+			<td>lokiCanary.deployment</td>
+			<td>object</td>
+			<td>Used when `mode=deployment`</td>
+			<td><pre lang="json">
+{
+  "replicaCount": 3,
+  "strategy": {
+    "type": "RollingUpdate"
+  }
+}
+</pre>
+</td>
+		</tr>
+		<tr>
 			<td>lokiCanary.dnsConfig</td>
 			<td>object</td>
 			<td>DNS config for canary pods</td>
@@ -6341,6 +6355,15 @@ null
 			<td>The name of the label to look for at loki when doing the checks.</td>
 			<td><pre lang="json">
 "pod"
+</pre>
+</td>
+		</tr>
+		<tr>
+			<td>lokiCanary.mode</td>
+			<td>string</td>
+			<td>Mode can be either `daemonset` or `deployment`</td>
+			<td><pre lang="json">
+"daemonset"
 </pre>
 </td>
 		</tr>

--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -13,6 +13,10 @@ Entries should include a reference to the pull request that introduced the chang
 
 [//]: # (<AUTOMATED_UPDATES_LOCATOR> : do not remove this line. This locator is used by the CI pipeline to automatically create a changelog entry for each new Loki release. Add other chart versions and respective changelog entries bellow this line.)
 
+## 6.13.0
+
+- [ENHANCEMENT] Option to create canay as deployment or daemonset
+
 ## 6.12.0
 
 - [ENHANCEMENT] Replace Bloom Compactor component with Bloom Planner and Bloom Builder. These are the new components to build bloom blocks.
@@ -62,9 +66,6 @@ Entries should include a reference to the pull request that introduced the chang
 ## 6.7.0
 
 - [CHANGE] Changed version of Grafana Enterprise Logs to 3.1.0
-## 6.7.0
-
-- [ENHANCEMENT] Option to create canay as deployment or daemonset
 
 ## 6.6.6
 

--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -62,6 +62,9 @@ Entries should include a reference to the pull request that introduced the chang
 ## 6.7.0
 
 - [CHANGE] Changed version of Grafana Enterprise Logs to 3.1.0
+## 6.7.0
+
+- [ENHANCEMENT] Option to create canay as deployment or daemonset
 
 ## 6.6.6
 

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -3,7 +3,7 @@ name: loki
 description: Helm chart for Grafana Loki and Grafana Enterprise Logs supporting both simple, scalable and distributed modes.
 type: application
 appVersion: 3.1.1
-version: 6.12.0
+version: 6.13.0
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -1,6 +1,6 @@
 # loki
 
-![Version: 6.13.0](https://img.shields.io/badge/Version-6.12.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.1.1](https://img.shields.io/badge/AppVersion-3.1.1-informational?style=flat-square)
+![Version: 6.13.0](https://img.shields.io/badge/Version-6.13.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.1.1](https://img.shields.io/badge/AppVersion-3.1.1-informational?style=flat-square)
 
 Helm chart for Grafana Loki and Grafana Enterprise Logs supporting both simple, scalable and distributed modes.
 

--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -1,6 +1,6 @@
 # loki
 
-![Version: 6.12.0](https://img.shields.io/badge/Version-6.12.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.1.1](https://img.shields.io/badge/AppVersion-3.1.1-informational?style=flat-square)
+![Version: 6.13.0](https://img.shields.io/badge/Version-6.12.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.1.1](https://img.shields.io/badge/AppVersion-3.1.1-informational?style=flat-square)
 
 Helm chart for Grafana Loki and Grafana Enterprise Logs supporting both simple, scalable and distributed modes.
 

--- a/production/helm/loki/templates/loki-canary/_pod.tpl
+++ b/production/helm/loki/templates/loki-canary/_pod.tpl
@@ -1,0 +1,107 @@
+{{/*
+Pod template used in Daemonset and Deployment
+*/}}
+{{- define "canary.podTemplate" -}}
+metadata:
+  {{- with $.Values.lokiCanary.annotations }}
+  annotations:
+    {{- toYaml . | nindent 8 }}
+  {{- end }}
+  labels:
+    {{- include "loki-canary.selectorLabels" $ | nindent 4 }}
+    {{- with $.Values.lokiCanary.podLabels }}
+    {{- toYaml . | nindent 8 }}
+    {{- end }}
+spec:
+  serviceAccountName: {{ include "loki-canary.fullname" $ }}
+  {{- with $.Values.imagePullSecrets }}
+  imagePullSecrets:
+    {{- toYaml . | nindent 8 }}
+  {{- end }}
+  {{- include "loki-canary.priorityClassName" $ | nindent 2 }}
+  securityContext:
+    {{- toYaml $.Values.loki.podSecurityContext | nindent 4 }}
+  containers:
+    - name: loki-canary
+      image: {{ include "loki-canary.image" $ }}
+      imagePullPolicy: {{ $.Values.loki.image.pullPolicy }}
+      args:
+        - -addr={{- include "loki.host" $ }}
+        - -labelname={{ $.Values.lokiCanary.labelname }}
+        - -labelvalue=$(POD_NAME)
+        {{- if $.Values.enterprise.enabled }}
+        - -user=$(USER)
+        - -tenant-id=$(USER)
+        - -pass=$(PASS)
+        {{- else if $.Values.loki.auth_enabled }}
+        - -user={{ $.Values.monitoring.selfMonitoring.tenant.name }}
+        - -tenant-id={{ $.Values.monitoring.selfMonitoring.tenant.name }}
+        - -pass={{ $.Values.monitoring.selfMonitoring.tenant.password }}
+        {{- end }}
+        {{- if $.Values.lokiCanary.push }}
+        - -push=true
+        {{- end }}
+        {{- with $.Values.lokiCanary.extraArgs }}
+        {{- toYaml . | nindent 12 }}
+        {{- end }}
+      securityContext:
+        {{- toYaml $.Values.loki.containerSecurityContext | nindent 8 }}
+      volumeMounts:
+        {{- with $.Values.lokiCanary.extraVolumeMounts }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      ports:
+        - name: http-metrics
+          containerPort: 3500
+          protocol: TCP
+      env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        {{ if $.Values.enterprise.enabled }}
+        - name: USER
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "enterprise-logs.selfMonitoringTenantSecret" $ }}
+              key: username
+        - name: PASS
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "enterprise-logs.selfMonitoringTenantSecret" $ }}
+              key: password
+        {{- end -}}
+        {{- with $.Values.lokiCanary.extraEnv }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with $.Values.lokiCanary.extraEnvFrom }}
+      envFrom:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      readinessProbe:
+        httpGet:
+          path: /metrics
+          port: http-metrics
+        initialDelaySeconds: 15
+        timeoutSeconds: 1
+      {{- with $.Values.lokiCanary.resources}}
+      resources:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  {{- with $.Values.lokiCanary.dnsConfig }}
+  dnsConfig:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $.Values.lokiCanary.nodeSelector }}
+  nodeSelector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $.Values.lokiCanary.tolerations }}
+  tolerations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  volumes:
+  {{- with $.Values.lokiCanary.extraVolumes }}
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/production/helm/loki/templates/loki-canary/deployment.yaml
+++ b/production/helm/loki/templates/loki-canary/deployment.yaml
@@ -1,20 +1,21 @@
 {{- with .Values.lokiCanary -}}
-{{- if and .enabled (eq .mode "daemonset") -}}
+{{- if and .enabled (eq .mode "deployment") -}}
 ---
 apiVersion: apps/v1
-kind: DaemonSet
+kind: Deployment
 metadata:
   name: {{ include "loki-canary.fullname" $ }}
   namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "loki-canary.labels" $ | nindent 4 }}
 spec:
+  replicas: {{ .deployment.replicaCount  }}
   selector:
     matchLabels:
       {{- include "loki-canary.selectorLabels" $ | nindent 6 }}
-  {{- with .updateStrategy }}
-  updateStrategy:
-    {{- toYaml . | nindent 4 }}
+  {{- with .deployment.strategy }}
+  strategy:
+    {{- toYaml . | trim | nindent 4 }}
   {{- end }}
   template:
     {{- include "canary.podTemplate" $ | nindent 4 }}

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -630,6 +630,13 @@ test:
 # that it's working correctly
 lokiCanary:
   enabled: true
+  # -- Mode can be either `daemonset` or `deployment`
+  mode: daemonset
+  # -- Used when `mode=deployment`
+  deployment:
+    replicaCount: 3
+    strategy:
+      type: RollingUpdate
   # -- If true, the canary will send directly to Loki via the address configured for verification --
   # -- If false, it will write to stdout and an Agent will be needed to scrape and send the logs --
   push: true


### PR DESCRIPTION
**What this PR does / why we need it**:

By default, canary was created as a daemonset. Meaning write path was tested for each node of the cluster.
However, when you have one loki on a cluster, but the clients sending logs run on some other clusters, it does not make much sense anymore to have that many canary pods.
So, if you just want to test the write path works, a deployment with a few canary pods is enough.

This PR adds the option to deploy canary pods as a deployment instead of a daemonset.

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
