### PR TITLE
fix(blooms): Delete outdated metas during planning

### DIFF
--- a/pkg/bloombuild/planner/metrics.go
+++ b/pkg/bloombuild/planner/metrics.go
@@ -15,6 +15,9 @@ const (
 
 	statusSuccess = "success"
 	statusFailure = "failure"
+
+	phasePlanning = "planning"
+	phaseBuilding = "building"
 )
 
 type Metrics struct {
@@ -33,8 +36,8 @@ type Metrics struct {
 	buildTime        *prometheus.HistogramVec
 	buildLastSuccess prometheus.Gauge
 
-	blocksDeleted prometheus.Counter
-	metasDeleted  prometheus.Counter
+	blocksDeleted *prometheus.CounterVec
+	metasDeleted  *prometheus.CounterVec
 
 	tenantsDiscovered    prometheus.Counter
 	tenantTasksPlanned   *prometheus.GaugeVec
@@ -127,18 +130,18 @@ func NewMetrics(
 			Help:      "Unix timestamp of the last successful build cycle.",
 		}),
 
-		blocksDeleted: promauto.With(r).NewCounter(prometheus.CounterOpts{
+		blocksDeleted: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
 			Namespace: metricsNamespace,
 			Subsystem: metricsSubsystem,
 			Name:      "blocks_deleted_total",
 			Help:      "Number of blocks deleted",
-		}),
-		metasDeleted: promauto.With(r).NewCounter(prometheus.CounterOpts{
+		}, []string{"phase"}),
+		metasDeleted: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
 			Namespace: metricsNamespace,
 			Subsystem: metricsSubsystem,
 			Name:      "metas_deleted_total",
 			Help:      "Number of metas deleted",
-		}),
+		}, []string{"phase"}),
 
 		tenantsDiscovered: promauto.With(r).NewCounter(prometheus.CounterOpts{
 			Namespace: metricsNamespace,

--- a/pkg/bloombuild/planner/planner.go
+++ b/pkg/bloombuild/planner/planner.go
@@ -357,9 +357,6 @@ func (p *Planner) computeTasks(
 			level.Error(logger).Log("msg", "failed to find outdated gaps", "err", err)
 			continue
 		}
-		if len(gaps) == 0 {
-			continue
-		}
 
 		for _, gap := range gaps {
 			tasks = append(tasks, protos.NewTask(table, tenant, ownershipRange, gap.tsdb, gap.gaps))
@@ -448,11 +445,18 @@ func (p *Planner) deleteOutdatedMetas(
 
 	upToDate, outdated := outdatedMetas(metas)
 	if len(outdated) == 0 {
-		level.Debug(logger).Log("msg", "no outdated metas found")
+		level.Debug(logger).Log(
+			"msg", "no outdated metas found",
+			"upToDate", len(upToDate),
+		)
 		return upToDate, nil
 	}
 
-	level.Debug(logger).Log("msg", "found outdated metas", "outdated", len(outdated))
+	level.Debug(logger).Log(
+		"msg", "found outdated metas",
+		"outdated", len(outdated),
+		"upToDate", len(upToDate),
+	)
 
 	client, err := p.bloomStore.Client(table.ModelTime())
 	if err != nil {

--- a/pkg/bloombuild/planner/planner_test.go
+++ b/pkg/bloombuild/planner/planner_test.go
@@ -884,7 +884,7 @@ func Test_deleteOutdatedMetas(t *testing.T) {
 			removeLocFromMetasSources(metas)
 			require.ElementsMatch(t, tc.originalMetas, metas)
 
-			upToDate, err := planner.deleteOutdatedMetas(context.Background(), testTable, "fakeTenant", tc.originalMetas, phasePlanning)
+			upToDate, err := planner.deleteOutdatedMetasAndBlocks(context.Background(), testTable, "fakeTenant", tc.originalMetas, phasePlanning)
 			require.NoError(t, err)
 			require.ElementsMatch(t, tc.expectedUpToDateMetas, upToDate)
 

--- a/pkg/bloombuild/planner/versioned_range.go
+++ b/pkg/bloombuild/planner/versioned_range.go
@@ -261,5 +261,11 @@ func outdatedMetas(metas []bloomshipper.Meta) ([]bloomshipper.Meta, []bloomshipp
 		upToDate = append(upToDate, meta)
 	}
 
+	// We previously sorted the input metas by their TSDB source TS, therefore, they may not be sorted by FP anymore.
+	// We need to re-sort them by their FP to match the original order.
+	sort.Slice(upToDate, func(i, j int) bool {
+		return upToDate[i].Bounds.Less(upToDate[j].Bounds)
+	})
+
 	return upToDate, outdated
 }

--- a/pkg/bloombuild/planner/versioned_range.go
+++ b/pkg/bloombuild/planner/versioned_range.go
@@ -210,8 +210,9 @@ func (t tsdbTokenRange) reassemble(from int) tsdbTokenRange {
 	return t[:len(t)-(reassembleTo-from)]
 }
 
-func outdatedMetas(metas []bloomshipper.Meta) []bloomshipper.Meta {
+func outdatedMetas(metas []bloomshipper.Meta) ([]bloomshipper.Meta, []bloomshipper.Meta) {
 	var outdated []bloomshipper.Meta
+	var upToDate []bloomshipper.Meta
 
 	// Sort metas descending by most recent source when checking
 	// for outdated metas (older metas are discarded if they don't change the range).
@@ -254,8 +255,11 @@ func outdatedMetas(metas []bloomshipper.Meta) []bloomshipper.Meta {
 		tokenRange, added = tokenRange.Add(version, meta.Bounds)
 		if !added {
 			outdated = append(outdated, meta)
+			continue
 		}
+
+		upToDate = append(upToDate, meta)
 	}
 
-	return outdated
+	return upToDate, outdated
 }

--- a/pkg/bloombuild/planner/versioned_range_test.go
+++ b/pkg/bloombuild/planner/versioned_range_test.go
@@ -252,21 +252,25 @@ func Test_OutdatedMetas(t *testing.T) {
 	}
 
 	for _, tc := range []struct {
-		desc  string
-		metas []bloomshipper.Meta
-		exp   []bloomshipper.Meta
+		desc        string
+		metas       []bloomshipper.Meta
+		expOutdated []bloomshipper.Meta
+		expUpToDate []bloomshipper.Meta
 	}{
 		{
-			desc:  "no metas",
-			metas: nil,
-			exp:   nil,
+			desc:        "no metas",
+			metas:       nil,
+			expOutdated: nil,
 		},
 		{
 			desc: "single meta",
 			metas: []bloomshipper.Meta{
 				gen(v1.NewBounds(0, 10), 0),
 			},
-			exp: nil,
+			expOutdated: nil,
+			expUpToDate: []bloomshipper.Meta{
+				gen(v1.NewBounds(0, 10), 0),
+			},
 		},
 		{
 			desc: "single outdated meta",
@@ -274,8 +278,11 @@ func Test_OutdatedMetas(t *testing.T) {
 				gen(v1.NewBounds(0, 10), 0),
 				gen(v1.NewBounds(0, 10), 1),
 			},
-			exp: []bloomshipper.Meta{
+			expOutdated: []bloomshipper.Meta{
 				gen(v1.NewBounds(0, 10), 0),
+			},
+			expUpToDate: []bloomshipper.Meta{
+				gen(v1.NewBounds(0, 10), 1),
 			},
 		},
 		{
@@ -285,9 +292,12 @@ func Test_OutdatedMetas(t *testing.T) {
 				gen(v1.NewBounds(6, 10), 0),
 				gen(v1.NewBounds(0, 10), 1),
 			},
-			exp: []bloomshipper.Meta{
+			expOutdated: []bloomshipper.Meta{
 				gen(v1.NewBounds(6, 10), 0),
 				gen(v1.NewBounds(0, 5), 0),
+			},
+			expUpToDate: []bloomshipper.Meta{
+				gen(v1.NewBounds(0, 10), 1),
 			},
 		},
 		{
@@ -297,9 +307,12 @@ func Test_OutdatedMetas(t *testing.T) {
 				gen(v1.NewBounds(6, 10), 0),
 				gen(v1.NewBounds(0, 10), 1),
 			},
-			exp: []bloomshipper.Meta{
+			expOutdated: []bloomshipper.Meta{
 				gen(v1.NewBounds(6, 10), 0),
 				gen(v1.NewBounds(0, 5), 0),
+			},
+			expUpToDate: []bloomshipper.Meta{
+				gen(v1.NewBounds(0, 10), 1),
 			},
 		},
 		{
@@ -309,14 +322,19 @@ func Test_OutdatedMetas(t *testing.T) {
 				gen(v1.NewBounds(0, 10), 1), // only part of the range is outdated, must keep
 				gen(v1.NewBounds(8, 10), 2),
 			},
-			exp: []bloomshipper.Meta{
+			expOutdated: []bloomshipper.Meta{
 				gen(v1.NewBounds(0, 5), 0),
+			},
+			expUpToDate: []bloomshipper.Meta{
+				gen(v1.NewBounds(0, 10), 1),
+				gen(v1.NewBounds(8, 10), 2),
 			},
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
-			outdated := outdatedMetas(tc.metas)
-			require.Equal(t, tc.exp, outdated)
+			upToDate, outdated := outdatedMetas(tc.metas)
+			require.ElementsMatch(t, tc.expOutdated, outdated)
+			require.ElementsMatch(t, tc.expUpToDate, upToDate)
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
If a planner crashes before receiving all tasks for a given tenant-table combination, it will not delete the outdated metas and blocks. This PR fixes this by also deleting outdated metas during the planning phase. Thereafter, gaps will be computed only with the metas that are up to date.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
