### PR TITLE
fix(blooms): ensure tokenizer cache is reset between series

### DIFF
--- a/pkg/storage/bloom/v1/bloom_tokenizer.go
+++ b/pkg/storage/bloom/v1/bloom_tokenizer.go
@@ -97,11 +97,14 @@ func (bt *BloomTokenizer) newBloom() *Bloom {
 	}
 }
 
+// Populates a bloom filter(s) with the tokens from the given chunks.
+// Called once per series
 func (bt *BloomTokenizer) Populate(
 	blooms SizedIterator[*Bloom],
 	chks Iterator[ChunkRefWithIter],
 	ch chan *BloomCreation,
 ) {
+	clear(bt.cache) // MUST always clear the cache before starting a new series
 	var next bool
 
 	// All but the last bloom are considered full -- send back unaltered


### PR DESCRIPTION
Fixes bug where ngrams were not added to blooms b/c they had been added previously to a potentially different series. This caused blooms to fail membership tests incorrectly.