### PR TITLE
feat: Use prefixed WAL storage path in Object Storage

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -75,7 +75,7 @@ require (
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f
 	github.com/ncw/swift v1.0.53
 	github.com/oklog/run v1.1.0
-	github.com/oklog/ulid v1.3.1 // indirect
+	github.com/oklog/ulid v1.3.1
 	github.com/opentracing-contrib/go-grpc v0.0.0-20210225150812-73cb765af46e
 	github.com/opentracing-contrib/go-stdlib v1.0.0
 	github.com/opentracing/opentracing-go v1.2.0

--- a/pkg/storage/chunk/client/object_client.go
+++ b/pkg/storage/chunk/client/object_client.go
@@ -87,7 +87,6 @@ type client struct {
 	keyEncoder          KeyEncoder
 	getChunkMaxParallel int
 	schema              config.SchemaConfig
-	entropy             io.Reader
 }
 
 // NewClient wraps the provided ObjectClient with a chunk.Client implementation

--- a/pkg/storage/chunk/client/object_client.go
+++ b/pkg/storage/chunk/client/object_client.go
@@ -3,9 +3,9 @@ package client
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
 	"encoding/base64"
 	"io"
-	"math/rand"
 	"strings"
 	"time"
 
@@ -101,7 +101,6 @@ func NewClientWithMaxParallel(store ObjectClient, encoder KeyEncoder, maxParalle
 		keyEncoder:          encoder,
 		getChunkMaxParallel: maxParallel,
 		schema:              schema,
-		entropy:             rand.New(rand.NewSource(time.Now().UnixNano())),
 	}
 }
 
@@ -119,8 +118,8 @@ func (o *client) PutWal(ctx context.Context, segment *wal.SegmentWriter) error {
 		_ = reader.Close()
 	}(reader)
 
-	newUlid := ulid.MustNew(ulid.Timestamp(time.Now()), o.entropy)
-	return o.store.PutObject(ctx, "loki-v2/wal/anon/"+newUlid.String(), bytes.NewReader(buffer.Bytes()))
+	newUlid := ulid.MustNew(ulid.Timestamp(time.Now()), rand.Reader)
+	return o.store.PutObject(ctx, "loki-v2/wal/anon/"+newUlid.String(), reader)
 }
 
 // PutChunks stores the provided chunks in the configured backend. If multiple errors are


### PR DESCRIPTION
**What this PR does / why we need it**:
- Sets the name for the stored WAL segment to be a ULID with a prefix used only by this ingester.
- This will need more work as the entropy source is not concurrent safe & will probably collide with another instance of the ingester, but I wanted to namespace the object path before trying this code against a real object store to avoid polluting it.

**Which issue(s) this PR fixes**:
Partial implements https://github.com/grafana/loki-private/issues/1020