### PR TITLE
fix(blooms): Suppress error from resolving server addresses for blocks

### DIFF
--- a/pkg/bloomgateway/client_test.go
+++ b/pkg/bloomgateway/client_test.go
@@ -130,6 +130,3 @@ func TestGatewayClient_MergeChunkSets(t *testing.T) {
 	result := mergeChunkSets(inp1, inp2)
 	require.Equal(t, expected, result)
 }
-
-func TestGatewayClient_FilterChunks(t *testing.T) {
-}

--- a/pkg/bloomgateway/client_test.go
+++ b/pkg/bloomgateway/client_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/flagext"
+	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
@@ -16,9 +17,16 @@ import (
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/bloomshipper"
 )
 
+type errorMockPool struct {
+	*JumpHashClientPool
+}
+
+func (p *errorMockPool) Addr(_ string) (string, error) {
+	return "", errors.New("no server found")
+}
+
 func TestBloomGatewayClient(t *testing.T) {
 	logger := log.NewNopLogger()
-	reg := prometheus.NewRegistry()
 
 	limits := newLimits()
 
@@ -26,6 +34,7 @@ func TestBloomGatewayClient(t *testing.T) {
 	flagext.DefaultValues(&cfg)
 
 	t.Run("FilterChunks returns response", func(t *testing.T) {
+		reg := prometheus.NewRegistry()
 		c, err := NewClient(cfg, limits, reg, logger, nil, false)
 		require.NoError(t, err)
 		expr, err := syntax.ParseExpr(`{foo="bar"}`)
@@ -33,6 +42,33 @@ func TestBloomGatewayClient(t *testing.T) {
 		res, err := c.FilterChunks(context.Background(), "tenant", bloomshipper.NewInterval(0, 0), nil, plan.QueryPlan{AST: expr})
 		require.NoError(t, err)
 		require.Equal(t, 0, len(res))
+	})
+
+	t.Run("pool error is suppressed and returns full list of chunks", func(t *testing.T) {
+		reg := prometheus.NewRegistry()
+		c, err := NewClient(cfg, limits, reg, logger, nil, false)
+		require.NoError(t, err)
+		c.pool = &errorMockPool{}
+
+		expected := []*logproto.GroupedChunkRefs{
+			{Fingerprint: 0x00, Refs: []*logproto.ShortRef{shortRef(0, 1, 1)}},
+			{Fingerprint: 0x9f, Refs: []*logproto.ShortRef{shortRef(0, 1, 2)}},
+			{Fingerprint: 0xa0, Refs: []*logproto.ShortRef{shortRef(0, 1, 3)}},
+			{Fingerprint: 0xff, Refs: []*logproto.ShortRef{shortRef(0, 1, 4)}},
+		}
+
+		blocks := []blockWithSeries{
+			{block: mkBlockRef(0x00, 0x9f), series: expected[0:2]},
+			{block: mkBlockRef(0xa0, 0xff), series: expected[2:4]},
+		}
+		expr, err := syntax.ParseExpr(`{foo="bar"}`)
+		require.NoError(t, err)
+
+		res, err := c.FilterChunks(context.Background(), "tenant", bloomshipper.NewInterval(0, 0), blocks, plan.QueryPlan{AST: expr})
+		require.NoError(t, err)
+		require.Equal(t, 4, len(res))
+
+		require.Equal(t, expected, res)
 	})
 }
 
@@ -93,4 +129,7 @@ func TestGatewayClient_MergeChunkSets(t *testing.T) {
 
 	result := mergeChunkSets(inp1, inp2)
 	require.Equal(t, expected, result)
+}
+
+func TestGatewayClient_FilterChunks(t *testing.T) {
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Instead of returning the error, `FilterChunks` returns the full, unfiltered list of chunks.

This makes sure that queries do not fail if no bloom gateway instances are available.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
