### PR TITLE
fix: Use Pod Disruption Template in all Template Files.

### DIFF
--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -3,7 +3,7 @@ name: loki
 description: Helm chart for Grafana Loki and Grafana Enterprise Logs supporting both simple, scalable and distributed modes.
 type: application
 appVersion: 3.0.0
-version: 6.6.4
+version: 6.6.5
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/production/helm/loki/templates/backend/poddisruptionbudget-backend.yaml
+++ b/production/helm/loki/templates/backend/poddisruptionbudget-backend.yaml
@@ -1,6 +1,6 @@
 {{- $isSimpleScalable := eq (include "loki.deployment.isScalable" .) "true" -}}
 {{- if and $isSimpleScalable (gt (int .Values.backend.replicas) 1) (not .Values.read.legacyReadTarget ) }}
-apiVersion: policy/v1
+apiVersion: {{ include "loki.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "loki.backendFullname" . }}

--- a/production/helm/loki/templates/gateway/poddisruptionbudget-gateway.yaml
+++ b/production/helm/loki/templates/gateway/poddisruptionbudget-gateway.yaml
@@ -3,7 +3,7 @@
   (and (not .Values.gateway.autoscaling.enabled) (gt (int .Values.gateway.replicas) 1)) 
   (and .Values.gateway.autoscaling.enabled (gt (int .Values.gateway.autoscaling.minReplicas) 1))
 }}
-apiVersion: policy/v1
+apiVersion: {{ include "loki.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "loki.gatewayFullname" . }}

--- a/production/helm/loki/templates/read/poddisruptionbudget-read.yaml
+++ b/production/helm/loki/templates/read/poddisruptionbudget-read.yaml
@@ -1,6 +1,6 @@
 {{- $isSimpleScalable := eq (include "loki.deployment.isScalable" .) "true" -}}
 {{- if and $isSimpleScalable (gt (int .Values.read.replicas) 1) }}
-apiVersion: policy/v1
+apiVersion: {{ include "loki.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "loki.readFullname" . }}

--- a/production/helm/loki/templates/single-binary/pdb.yaml
+++ b/production/helm/loki/templates/single-binary/pdb.yaml
@@ -1,7 +1,7 @@
 {{- $isSingleBinary := eq (include "loki.deployment.isSingleBinary" .) "true" -}}
 {{- if and .Values.podDisruptionBudget $isSingleBinary -}}
 ---
-apiVersion: policy/v1
+apiVersion: {{ include "loki.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "loki.fullname" . }}

--- a/production/helm/loki/templates/write/poddisruptionbudget-write.yaml
+++ b/production/helm/loki/templates/write/poddisruptionbudget-write.yaml
@@ -1,6 +1,6 @@
 {{- $isSimpleScalable := eq (include "loki.deployment.isScalable" .) "true" -}}
 {{- if and $isSimpleScalable (gt (int .Values.write.replicas) 1) }}
-apiVersion: policy/v1
+apiVersion: {{ include "loki.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "loki.writeFullname" . }}


### PR DESCRIPTION
Fixes an issue where the Loki helm chart will fail to install on older versions of Kubernetes still using the v1beta1 version of PodDisruptionBudget. Some files were hardcoded to use policy/v1 endpoint while others correctly used the template. This PR updates all files to use the correct template.

**Which issue(s) this PR fixes**:
Fixes #13387 

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ N/A ] Documentation added
- [ N/A ] Tests updated
- [ X ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [N/A] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ X ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ N/A ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
