### PR TITLE
docs: remove duplicate buckets

### DIFF
--- a/docs/sources/setup/install/helm/install-monolithic/_index.md
+++ b/docs/sources/setup/install/helm/install-monolithic/_index.md
@@ -80,7 +80,6 @@ If you set the `singleBinary.replicas` value to 2 or more, this chart configures
             object_store: filesystem
             schema: v13
         storage:
-          bucketNames:
           type: 's3'
           bucketNames:
             chunks: loki-chunks

--- a/docs/sources/setup/install/helm/install-monolithic/_index.md
+++ b/docs/sources/setup/install/helm/install-monolithic/_index.md
@@ -81,9 +81,6 @@ If you set the `singleBinary.replicas` value to 2 or more, this chart configures
             schema: v13
         storage:
           bucketNames:
-            chunks: loki-chunks
-            ruler: loki-ruler
-            admin: loki-admin
           type: 's3'
           bucketNames:
             chunks: loki-chunks


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes issue reported via docs @ grafana email.

completes backport of #12641 that was started in #13025 but missed this part of the content.



