### PR TITLE
chore: Improve performance of structured metadata

### DIFF
--- a/pkg/chunkenc/memchunk.go
+++ b/pkg/chunkenc/memchunk.go
@@ -1359,7 +1359,7 @@ func (si *bufferedIterator) Next() bool {
 		}
 	}
 
-	ts, line, structuredMetadata, ok := si.moveNext(si.currStructuredMetadata)
+	ts, line, structuredMetadata, ok := si.moveNext()
 	if !ok {
 		si.Close()
 		return false
@@ -1372,7 +1372,7 @@ func (si *bufferedIterator) Next() bool {
 }
 
 // moveNext moves the buffer to the next entry
-func (si *bufferedIterator) moveNext(structuredMetadata labels.Labels) (int64, []byte, labels.Labels, bool) {
+func (si *bufferedIterator) moveNext() (int64, []byte, labels.Labels, bool) {
 	var decompressedBytes int64
 	var decompressedStructuredMetadataBytes int64
 	var ts int64
@@ -1555,7 +1555,7 @@ func (si *bufferedIterator) moveNext(structuredMetadata labels.Labels) (int64, [
 	si.stats.AddDecompressedStructuredMetadataBytes(decompressedStructuredMetadataBytes)
 	si.stats.AddDecompressedBytes(decompressedBytes + decompressedStructuredMetadataBytes)
 
-	return ts, si.buf[:lineSize], si.symbolizer.Lookup(si.symbolsBuf[:nSymbols], structuredMetadata), true
+	return ts, si.buf[:lineSize], si.symbolizer.Lookup(si.symbolsBuf[:nSymbols], si.currStructuredMetadata), true
 }
 
 func (si *bufferedIterator) Err() error { return si.err }

--- a/pkg/chunkenc/memchunk.go
+++ b/pkg/chunkenc/memchunk.go
@@ -1568,7 +1568,6 @@ func (si *bufferedIterator) Close() error {
 	return si.err
 }
 
-// nolint:staticcheck
 func (si *bufferedIterator) close() {
 	if si.reader != nil {
 		si.pool.PutReader(si.reader)
@@ -1586,7 +1585,7 @@ func (si *bufferedIterator) close() {
 	}
 
 	if si.currStructuredMetadata != nil {
-		structuredMetadataPool.Put(si.currStructuredMetadata)
+		structuredMetadataPool.Put(si.currStructuredMetadata) // nolint:staticcheck
 		si.currStructuredMetadata = nil
 	}
 

--- a/pkg/chunkenc/memchunk.go
+++ b/pkg/chunkenc/memchunk.go
@@ -1568,6 +1568,7 @@ func (si *bufferedIterator) Close() error {
 	return si.err
 }
 
+// nolint:staticcheck
 func (si *bufferedIterator) close() {
 	if si.reader != nil {
 		si.pool.PutReader(si.reader)
@@ -1585,7 +1586,6 @@ func (si *bufferedIterator) close() {
 	}
 
 	if si.currStructuredMetadata != nil {
-		// nolint:staticcheck
 		structuredMetadataPool.Put(si.currStructuredMetadata)
 		si.currStructuredMetadata = nil
 	}

--- a/pkg/chunkenc/memchunk_test.go
+++ b/pkg/chunkenc/memchunk_test.go
@@ -99,7 +99,6 @@ func TestBlocksInclusive(t *testing.T) {
 			require.Equal(t, 1, blocks[0].Entries())
 		}
 	}
-
 }
 
 func TestBlock(t *testing.T) {
@@ -387,7 +386,6 @@ func TestRoundtripV2(t *testing.T) {
 				assertLines(loaded)
 			})
 		}
-
 	}
 }
 
@@ -886,9 +884,11 @@ func (nomatchPipeline) BaseLabels() log.LabelsResult { return log.EmptyLabelsRes
 func (nomatchPipeline) Process(_ int64, line []byte, _ ...labels.Label) ([]byte, log.LabelsResult, bool) {
 	return line, nil, false
 }
+
 func (nomatchPipeline) ProcessString(_ int64, line string, _ ...labels.Label) (string, log.LabelsResult, bool) {
 	return line, nil, false
 }
+
 func (nomatchPipeline) ReferencedStructuredMetadata() bool {
 	return false
 }
@@ -947,16 +947,31 @@ func BenchmarkRead(b *testing.B) {
 	}
 }
 
+type noopTestPipeline struct{}
+
+func (noopTestPipeline) BaseLabels() log.LabelsResult { return log.EmptyLabelsResult }
+func (noopTestPipeline) Process(_ int64, line []byte, _ ...labels.Label) ([]byte, log.LabelsResult, bool) {
+	return line, nil, false
+}
+
+func (noopTestPipeline) ProcessString(_ int64, line string, _ ...labels.Label) (string, log.LabelsResult, bool) {
+	return line, nil, false
+}
+
+func (noopTestPipeline) ReferencedStructuredMetadata() bool {
+	return false
+}
+
 func BenchmarkBackwardIterator(b *testing.B) {
 	for _, bs := range testBlockSizes {
 		b.Run(humanize.Bytes(uint64(bs)), func(b *testing.B) {
 			b.ReportAllocs()
-			c := NewMemChunk(ChunkFormatV3, EncSnappy, DefaultTestHeadBlockFmt, bs, testTargetSize)
+			c := NewMemChunk(ChunkFormatV4, EncSnappy, DefaultTestHeadBlockFmt, bs, testTargetSize)
 			_ = fillChunk(c)
 			b.ResetTimer()
 			for n := 0; n < b.N; n++ {
-				noopStreamPipeline := log.NewNoopPipeline().ForStream(labels.Labels{})
-				iterator, err := c.Iterator(context.Background(), time.Unix(0, 0), time.Now(), logproto.BACKWARD, noopStreamPipeline)
+				noop := noopTestPipeline{}
+				iterator, err := c.Iterator(context.Background(), time.Unix(0, 0), time.Now(), logproto.BACKWARD, noop)
 				if err != nil {
 					panic(err)
 				}
@@ -1754,7 +1769,6 @@ func TestMemChunk_SpaceFor(t *testing.T) {
 					require.Equal(t, expect, chk.SpaceFor(&tc.entry))
 				})
 			}
-
 		})
 	}
 }

--- a/pkg/chunkenc/symbols.go
+++ b/pkg/chunkenc/symbols.go
@@ -15,6 +15,12 @@ import (
 	"github.com/grafana/loki/v3/pkg/util"
 )
 
+var structuredMetadataPool = sync.Pool{
+	New: func() interface{} {
+		return make(labels.Labels, 0, 8)
+	},
+}
+
 // symbol holds reference to a label name and value pair
 type symbol struct {
 	Name, Value uint32
@@ -90,18 +96,20 @@ func (s *symbolizer) add(lbl string) uint32 {
 }
 
 // Lookup coverts and returns labels pairs for the given symbols
-func (s *symbolizer) Lookup(syms symbols) labels.Labels {
+func (s *symbolizer) Lookup(syms symbols, buf labels.Labels) labels.Labels {
 	if len(syms) == 0 {
 		return nil
 	}
-	lbls := make([]labels.Label, len(syms))
+	if buf == nil {
+		buf = structuredMetadataPool.Get().(labels.Labels)
+	}
+	buf = buf[:0]
 
-	for i, symbol := range syms {
-		lbls[i].Name = s.lookup(symbol.Name)
-		lbls[i].Value = s.lookup(symbol.Value)
+	for _, symbol := range syms {
+		buf = append(buf, labels.Label{Name: s.lookup(symbol.Name), Value: s.lookup(symbol.Value)})
 	}
 
-	return lbls
+	return buf
 }
 
 func (s *symbolizer) lookup(idx uint32) string {

--- a/pkg/chunkenc/symbols_test.go
+++ b/pkg/chunkenc/symbols_test.go
@@ -131,7 +131,7 @@ func TestSymbolizer(t *testing.T) {
 				for i, labels := range tc.labelsToAdd {
 					symbols := s.Add(labels)
 					require.Equal(t, tc.expectedSymbols[i], symbols)
-					require.Equal(t, labels, s.Lookup(symbols))
+					require.Equal(t, labels, s.Lookup(symbols, nil))
 				}
 
 				// Test that Lookup returns empty labels if no symbols are provided.
@@ -141,7 +141,7 @@ func TestSymbolizer(t *testing.T) {
 							Name:  0,
 							Value: 0,
 						},
-					})
+					}, nil)
 					require.Equal(t, "", ret[0].Name)
 					require.Equal(t, "", ret[0].Value)
 				}
@@ -157,7 +157,7 @@ func TestSymbolizer(t *testing.T) {
 
 				loaded := symbolizerFromCheckpoint(buf.Bytes())
 				for i, symbols := range tc.expectedSymbols {
-					require.Equal(t, tc.labelsToAdd[i], loaded.Lookup(symbols))
+					require.Equal(t, tc.labelsToAdd[i], loaded.Lookup(symbols, nil))
 				}
 
 				buf.Reset()
@@ -167,7 +167,7 @@ func TestSymbolizer(t *testing.T) {
 				loaded, err = symbolizerFromEnc(buf.Bytes(), GetReaderPool(encoding))
 				require.NoError(t, err)
 				for i, symbols := range tc.expectedSymbols {
-					require.Equal(t, tc.labelsToAdd[i], loaded.Lookup(symbols))
+					require.Equal(t, tc.labelsToAdd[i], loaded.Lookup(symbols, nil))
 				}
 			})
 		}

--- a/pkg/chunkenc/unordered.go
+++ b/pkg/chunkenc/unordered.go
@@ -244,7 +244,6 @@ func (hb *unorderedHeadBlock) forEntries(
 	return nil
 }
 
-// nolint:staticcheck
 func (hb *unorderedHeadBlock) Iterator(ctx context.Context, direction logproto.Direction, mint, maxt int64, pipeline log.StreamPipeline) iter.EntryIterator {
 	// We are doing a copy everytime, this is because b.entries could change completely,
 	// the alternate would be that we allocate a new b.entries everytime we cut a block,
@@ -299,14 +298,13 @@ func (hb *unorderedHeadBlock) Iterator(ctx context.Context, direction logproto.D
 
 	return iter.EntryIteratorWithClose(iter.NewStreamsIterator(streamsResult, direction), func() error {
 		if structuredMetadata != nil {
-			structuredMetadataPool.Put(structuredMetadata)
+			structuredMetadataPool.Put(structuredMetadata) // nolint:staticcheck
 		}
 		return nil
 	})
 }
 
 // nolint:unused
-// nolint:staticcheck
 func (hb *unorderedHeadBlock) SampleIterator(
 	ctx context.Context,
 	mint,
@@ -367,7 +365,7 @@ func (hb *unorderedHeadBlock) SampleIterator(
 			SamplesPool.Put(s.Samples)
 		}
 		if structuredMetadata != nil {
-			structuredMetadataPool.Put(structuredMetadata)
+			structuredMetadataPool.Put(structuredMetadata) // nolint:staticcheck
 		}
 		return nil
 	})

--- a/pkg/chunkenc/unordered.go
+++ b/pkg/chunkenc/unordered.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
-
 	"io"
 	"math"
 	"time"
@@ -252,13 +251,15 @@ func (hb *unorderedHeadBlock) Iterator(ctx context.Context, direction logproto.D
 	// cutting of blocks.
 	streams := map[string]*logproto.Stream{}
 	baseHash := pipeline.BaseLabels().Hash()
+	var structuredMetadata labels.Labels
 	_ = hb.forEntries(
 		ctx,
 		direction,
 		mint,
 		maxt,
 		func(statsCtx *stats.Context, ts int64, line string, structuredMetadataSymbols symbols) error {
-			newLine, parsedLbs, matches := pipeline.ProcessString(ts, line, hb.symbolizer.Lookup(structuredMetadataSymbols)...)
+			structuredMetadata = hb.symbolizer.Lookup(structuredMetadataSymbols, structuredMetadata)
+			newLine, parsedLbs, matches := pipeline.ProcessString(ts, line, structuredMetadata...)
 			if !matches {
 				return nil
 			}
@@ -294,7 +295,13 @@ func (hb *unorderedHeadBlock) Iterator(ctx context.Context, direction logproto.D
 	for _, stream := range streams {
 		streamsResult = append(streamsResult, *stream)
 	}
-	return iter.NewStreamsIterator(streamsResult, direction)
+
+	return iter.EntryIteratorWithClose(iter.NewStreamsIterator(streamsResult, direction), func() error {
+		if structuredMetadata != nil {
+			structuredMetadataPool.Put(structuredMetadata)
+		}
+		return nil
+	})
 }
 
 // nolint:unused
@@ -306,13 +313,15 @@ func (hb *unorderedHeadBlock) SampleIterator(
 ) iter.SampleIterator {
 	series := map[string]*logproto.Series{}
 	baseHash := extractor.BaseLabels().Hash()
+	var structuredMetadata labels.Labels
 	_ = hb.forEntries(
 		ctx,
 		logproto.FORWARD,
 		mint,
 		maxt,
 		func(statsCtx *stats.Context, ts int64, line string, structuredMetadataSymbols symbols) error {
-			value, parsedLabels, ok := extractor.ProcessString(ts, line, hb.symbolizer.Lookup(structuredMetadataSymbols)...)
+			structuredMetadata = hb.symbolizer.Lookup(structuredMetadataSymbols, structuredMetadata)
+			value, parsedLabels, ok := extractor.ProcessString(ts, line, structuredMetadata...)
 			if !ok {
 				return nil
 			}
@@ -354,6 +363,10 @@ func (hb *unorderedHeadBlock) SampleIterator(
 	return iter.SampleIteratorWithClose(iter.NewMultiSeriesIterator(seriesRes), func() error {
 		for _, s := range series {
 			SamplesPool.Put(s.Samples)
+		}
+		if structuredMetadata != nil {
+			// nolint:staticcheck
+			structuredMetadataPool.Put(structuredMetadata)
 		}
 		return nil
 	})
@@ -445,7 +458,7 @@ func (hb *unorderedHeadBlock) Convert(version HeadBlockFmt, symbolizer *symboliz
 		0,
 		math.MaxInt64,
 		func(_ *stats.Context, ts int64, line string, structuredMetadataSymbols symbols) error {
-			_, err := out.Append(ts, line, hb.symbolizer.Lookup(structuredMetadataSymbols))
+			_, err := out.Append(ts, line, hb.symbolizer.Lookup(structuredMetadataSymbols, nil))
 			return err
 		},
 	)
@@ -585,8 +598,7 @@ func (hb *unorderedHeadBlock) LoadBytes(b []byte) error {
 				}
 			}
 		}
-
-		if _, err := hb.Append(ts, line, hb.symbolizer.Lookup(structuredMetadataSymbols)); err != nil {
+		if _, err := hb.Append(ts, line, hb.symbolizer.Lookup(structuredMetadataSymbols, nil)); err != nil {
 			return err
 		}
 	}

--- a/pkg/chunkenc/unordered.go
+++ b/pkg/chunkenc/unordered.go
@@ -244,6 +244,7 @@ func (hb *unorderedHeadBlock) forEntries(
 	return nil
 }
 
+// nolint:staticcheck
 func (hb *unorderedHeadBlock) Iterator(ctx context.Context, direction logproto.Direction, mint, maxt int64, pipeline log.StreamPipeline) iter.EntryIterator {
 	// We are doing a copy everytime, this is because b.entries could change completely,
 	// the alternate would be that we allocate a new b.entries everytime we cut a block,
@@ -305,6 +306,7 @@ func (hb *unorderedHeadBlock) Iterator(ctx context.Context, direction logproto.D
 }
 
 // nolint:unused
+// nolint:staticcheck
 func (hb *unorderedHeadBlock) SampleIterator(
 	ctx context.Context,
 	mint,
@@ -365,7 +367,6 @@ func (hb *unorderedHeadBlock) SampleIterator(
 			SamplesPool.Put(s.Samples)
 		}
 		if structuredMetadata != nil {
-			// nolint:staticcheck
 			structuredMetadataPool.Put(structuredMetadata)
 		}
 		return nil

--- a/pkg/chunkenc/util_test.go
+++ b/pkg/chunkenc/util_test.go
@@ -53,6 +53,13 @@ func fillChunkClose(c Chunk, close bool) int64 {
 	entry := &logproto.Entry{
 		Timestamp: time.Unix(0, 0),
 		Line:      testdata.LogString(i),
+		StructuredMetadata: []logproto.LabelAdapter{
+			{Name: "foo", Value: "bar"},
+			{Name: "baz", Value: "buzz"},
+			{Name: "qux", Value: "quux"},
+			{Name: "corge", Value: "grault"},
+			{Name: "garply", Value: "waldo"},
+		},
 	}
 	for c.SpaceFor(entry) {
 		_, err := c.Append(entry)


### PR DESCRIPTION
**What this PR does / why we need it**:

I realized queries with structured metadata where a bit slow and turns out we do a lot allocations in fact a slice of labels for each log line.

Improving this pretty impressive result:

```
❯ benchstat before.txt after.txt
name                        old time/op    new time/op    delta
BackwardIterator/66_kB-16     26.6ms ±11%    20.7ms ±11%  -22.12%  (p=0.008 n=5+5)
BackwardIterator/262_kB-16    21.8ms ±14%    19.3ms ± 8%  -11.75%  (p=0.016 n=5+5)
BackwardIterator/524_kB-16    16.7ms ± 6%    18.5ms ±19%     ~     (p=0.421 n=5+5)

name                        old alloc/op   new alloc/op   delta
BackwardIterator/66_kB-16     8.91MB ± 0%    1.02MB ± 0%  -88.53%  (p=0.008 n=5+5)
BackwardIterator/262_kB-16    7.34MB ± 0%    0.33MB ± 2%  -95.49%  (p=0.008 n=5+5)
BackwardIterator/524_kB-16    5.88MB ± 0%    0.13MB ± 3%  -97.77%  (p=0.008 n=5+5)

name                        old allocs/op  new allocs/op  delta
BackwardIterator/66_kB-16      51.5k ± 0%      2.8k ± 0%  -94.64%  (p=0.000 n=5+4)
BackwardIterator/262_kB-16     44.0k ± 0%      0.6k ± 0%  -98.60%  (p=0.008 n=5+5)
BackwardIterator/524_kB-16     36.0k ± 0%      0.3k ± 0%  -99.29%  (p=0.008 n=5+5)
```

cc @sandeepsukhani do you see anything wrong ?

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
