### PR TITLE
fix(gateway client): exit with nil pointer dereference panic when using ring mode

### DIFF
--- a/pkg/indexgateway/client.go
+++ b/pkg/indexgateway/client.go
@@ -210,7 +210,9 @@ func (s *GatewayClient) Stop() {
 	if err != nil {
 		level.Error(s.logger).Log("msg", "failed to stop index gateway connection pool", "err", err)
 	}
-	s.dnsProvider.Stop()
+	if s.cfg.Mode == SimpleMode {
+		s.dnsProvider.Stop()
+	}
 }
 
 func (s *GatewayClient) QueryPages(ctx context.Context, queries []index.Query, callback index.QueryPagesCallback) error {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes gateway client return with nil pointer panic when using ring mode for ruler service.
`clients.dnsProvider` will only be init when using `simple mode` here:
https://github.com/grafana/loki/blob/183406570411a5ad5ceaf32bf07451b8fce608c1/pkg/indexgateway/client.go#L184
  Service like `ruler` using `ring mode`  will run into panic `nil pointer reference` during restarting or exiting:


**Which issue(s) this PR fixes**:
Fix #13437

**Special notes for your reviewer**:


**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
