### PR TITLE
chore: Round-robin flush queues for RF=1 segments

### DIFF
--- a/pkg/ingester-rf1/ingester.go
+++ b/pkg/ingester-rf1/ingester.go
@@ -219,6 +219,7 @@ type Ingester struct {
 	// pick a queue.
 	flushQueues     []*util.PriorityQueue
 	flushQueuesDone sync.WaitGroup
+	nextFlushQueue  int
 
 	flushCtx *flushCtx
 
@@ -297,6 +298,7 @@ func New(cfg Config, clientConfig client.Config,
 			newCtxAvailable: make(chan struct{}),
 			segmentWriter:   segmentWriter,
 		},
+		nextFlushQueue: 0,
 	}
 
 	// TODO: change flush on shutdown
@@ -590,7 +592,8 @@ func (i *Ingester) doFlushTick() {
 	// TODO: use multiple flush queues if required
 	// Don't write empty segments if there is nothing to write.
 	if currentFlushCtx.segmentWriter.InputSize() > 0 {
-		i.flushQueues[0].Enqueue(currentFlushCtx)
+		i.flushQueues[i.nextFlushQueue].Enqueue(currentFlushCtx)
+		i.nextFlushQueue++
 	}
 }
 

--- a/pkg/ingester-rf1/ingester.go
+++ b/pkg/ingester-rf1/ingester.go
@@ -593,7 +593,7 @@ func (i *Ingester) doFlushTick() {
 	// Don't write empty segments if there is nothing to write.
 	if currentFlushCtx.segmentWriter.InputSize() > 0 {
 		i.flushQueues[i.nextFlushQueue].Enqueue(currentFlushCtx)
-		i.nextFlushQueue++
+		i.nextFlushQueue = (i.nextFlushQueue + 1) % len(i.flushQueues)
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
* We current just assign every flush to the first flush queue, which is a bottleneck
* This assigns flushes round-robin to each flush queue so we use them all evenly, and each queue gets maximum time to actually do the flush before the next segment is assigned.
  * Existing ingester assigns randomly using the stream fingerprint, but we don't have that here.
* Default setting is to use 32 flush queues so this should be plenty.
