### PR TITLE
chore: Optimize WAL segment writes to object storage

### DIFF
--- a/pkg/ingester-rf1/ingester.go
+++ b/pkg/ingester-rf1/ingester.go
@@ -219,6 +219,7 @@ type Ingester struct {
 	// pick a queue.
 	flushQueues     []*util.PriorityQueue
 	flushQueuesDone sync.WaitGroup
+	nextFlushQueue  int
 
 	flushCtx *flushCtx
 
@@ -297,6 +298,7 @@ func New(cfg Config, clientConfig client.Config,
 			newCtxAvailable: make(chan struct{}),
 			segmentWriter:   segmentWriter,
 		},
+		nextFlushQueue: 0,
 	}
 
 	// TODO: change flush on shutdown
@@ -590,7 +592,8 @@ func (i *Ingester) doFlushTick() {
 	// TODO: use multiple flush queues if required
 	// Don't write empty segments if there is nothing to write.
 	if currentFlushCtx.segmentWriter.InputSize() > 0 {
-		i.flushQueues[0].Enqueue(currentFlushCtx)
+		i.flushQueues[i.nextFlushQueue].Enqueue(currentFlushCtx)
+		i.nextFlushQueue++
 	}
 }
 

--- a/pkg/ingester-rf1/ingester.go
+++ b/pkg/ingester-rf1/ingester.go
@@ -593,7 +593,7 @@ func (i *Ingester) doFlushTick() {
 	// Don't write empty segments if there is nothing to write.
 	if currentFlushCtx.segmentWriter.InputSize() > 0 {
 		i.flushQueues[i.nextFlushQueue].Enqueue(currentFlushCtx)
-		i.nextFlushQueue++
+		i.nextFlushQueue = (i.nextFlushQueue + 1) % len(i.flushQueues)
 	}
 }
 

--- a/pkg/ingester-rf1/objstore/storage.go
+++ b/pkg/ingester-rf1/objstore/storage.go
@@ -31,6 +31,10 @@ func New(
 	storageConfig storage.Config,
 	clientMetrics storage.ClientMetrics,
 ) (*Multi, error) {
+	if storageConfig.GCSConfig.ChunkBufferSize == 0 {
+		storageConfig.GCSConfig.ChunkBufferSize = 1 * 1024 * 1024 // 1MB
+	}
+
 	store := &Multi{
 		storageConfig: storageConfig,
 	}

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -636,6 +636,7 @@ func (t *Loki) initIngesterRF1() (_ services.Service, err error) {
 
 	logger := log.With(util_log.Logger, "component", "ingester-rf1")
 	t.Cfg.IngesterRF1.LifecyclerConfig.ListenPort = t.Cfg.Server.GRPCListenPort
+	t.Cfg.StorageConfig.GCSConfig.ChunkBufferSize = 1024 * 1024 // Hardcoded to 1MB because the RF1 WAL segments use an unbuffered writer to GCS, and that results in a lot of small packets with this set to the default of 0.
 
 	if t.Cfg.IngesterRF1.ShutdownMarkerPath == "" && t.Cfg.Common.PathPrefix != "" {
 		t.Cfg.IngesterRF1.ShutdownMarkerPath = t.Cfg.Common.PathPrefix

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -636,7 +636,6 @@ func (t *Loki) initIngesterRF1() (_ services.Service, err error) {
 
 	logger := log.With(util_log.Logger, "component", "ingester-rf1")
 	t.Cfg.IngesterRF1.LifecyclerConfig.ListenPort = t.Cfg.Server.GRPCListenPort
-	t.Cfg.StorageConfig.GCSConfig.ChunkBufferSize = 1024 * 1024 // Hardcoded to 1MB because the RF1 WAL segments use an unbuffered writer to GCS, and that results in a lot of small packets with this set to the default of 0.
 
 	if t.Cfg.IngesterRF1.ShutdownMarkerPath == "" && t.Cfg.Common.PathPrefix != "" {
 		t.Cfg.IngesterRF1.ShutdownMarkerPath = t.Cfg.Common.PathPrefix
@@ -765,6 +764,10 @@ func (t *Loki) initTableManager() (services.Service, error) {
 }
 
 func (t *Loki) initStore() (services.Service, error) {
+	if t.Cfg.isTarget(IngesterRF1) && t.Cfg.StorageConfig.GCSConfig.ChunkBufferSize == 0 {
+		t.Cfg.StorageConfig.GCSConfig.ChunkBufferSize = 1024 * 1024
+	}
+
 	// Set configs pertaining to object storage based indices
 	if config.UsingObjectStorageIndex(t.Cfg.SchemaConfig.Configs) {
 		t.updateConfigForShipperStore()

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -764,10 +764,6 @@ func (t *Loki) initTableManager() (services.Service, error) {
 }
 
 func (t *Loki) initStore() (services.Service, error) {
-	if t.Cfg.isTarget(IngesterRF1) && t.Cfg.StorageConfig.GCSConfig.ChunkBufferSize == 0 {
-		t.Cfg.StorageConfig.GCSConfig.ChunkBufferSize = 1024 * 1024
-	}
-
 	// Set configs pertaining to object storage based indices
 	if config.UsingObjectStorageIndex(t.Cfg.SchemaConfig.Configs) {
 		t.updateConfigForShipperStore()


### PR DESCRIPTION
**What this PR does / why we need it**:
Two optimisations:
* Use multiple flush threads for object storage
* Use buffered writer for putting data in the pipe.
* The buffered writer is needed to avoid sending data to object storage with small packets, as writing from the WAL segment happens in small bursts.