### PR TITLE
chore: better align struct fields for ingesters

### DIFF
--- a/pkg/ingester-rf1/flush.go
+++ b/pkg/ingester-rf1/flush.go
@@ -77,8 +77,8 @@ func (i *Ingester) FlushHandler(w http.ResponseWriter, _ *http.Request) {
 }
 
 type flushOp struct {
-	from      model.Time
 	userID    string
+	from      model.Time
 	fp        model.Fingerprint
 	immediate bool
 }

--- a/pkg/ingester-rf1/instance.go
+++ b/pkg/ingester-rf1/instance.go
@@ -54,21 +54,16 @@ var (
 )
 
 type instance struct {
-	cfg *Config
+	streamsCreatedTotal prometheus.Counter
+	streamsRemovedTotal prometheus.Counter
 
-	buf     []byte // buffer used to compute fps.
+	customStreamsTracker push.UsageTracker
+	cfg                  *Config
+
 	streams *streamsMap
 
 	index  *index.Multi
 	mapper *FpMapper // using of mapper no longer needs mutex because reading from streams is lock-free
-
-	instanceID string
-
-	streamsCreatedTotal prometheus.Counter
-	streamsRemovedTotal prometheus.Counter
-
-	// tailers   map[uint32]*tailer
-	tailerMtx sync.RWMutex
 
 	limiter            *Limiter
 	streamCountLimiter *streamCountLimiter
@@ -84,7 +79,12 @@ type instance struct {
 
 	schemaconfig *config.SchemaConfig
 
-	customStreamsTracker push.UsageTracker
+	instanceID string
+
+	buf []byte // buffer used to compute fps.
+
+	// tailers   map[uint32]*tailer
+	tailerMtx sync.RWMutex
 }
 
 func (i *instance) Push(ctx context.Context, req *logproto.PushRequest, flushCtx *flushCtx) error {

--- a/pkg/ingester-rf1/limiter.go
+++ b/pkg/ingester-rf1/limiter.go
@@ -34,10 +34,11 @@ type Limits interface {
 // Limiter implements primitives to get the maximum number of streams
 // an ingester can handle for a specific tenant
 type Limiter struct {
-	limits            Limits
-	ring              RingCount
+	limits  Limits
+	ring    RingCount
+	metrics *ingesterMetrics
+
 	replicationFactor int
-	metrics           *ingesterMetrics
 
 	mtx      sync.RWMutex
 	disabled bool
@@ -128,10 +129,10 @@ func (l *Limiter) convertGlobalToLocalLimit(globalLimit int) int {
 type supplier[T any] func() T
 
 type streamCountLimiter struct {
-	tenantID                   string
 	limiter                    *Limiter
 	defaultStreamCountSupplier supplier[int]
 	ownedStreamSvc             *ownedStreamService
+	tenantID                   string
 }
 
 var noopFixedLimitSupplier = func() int {
@@ -187,11 +188,11 @@ func (l *Limiter) RateLimit(tenant string) validation.RateLimit {
 }
 
 type StreamRateLimiter struct {
-	recheckPeriod time.Duration
 	recheckAt     time.Time
 	strategy      RateLimiterStrategy
-	tenant        string
 	lim           *rate.Limiter
+	tenant        string
+	recheckPeriod time.Duration
 }
 
 func NewStreamRateLimiter(strategy RateLimiterStrategy, tenant string, recheckPeriod time.Duration) *StreamRateLimiter {

--- a/pkg/ingester-rf1/mapper.go
+++ b/pkg/ingester-rf1/mapper.go
@@ -21,10 +21,6 @@ var separatorString = string([]byte{model.SeparatorByte})
 // FpMapper is used to map fingerprints in order to work around fingerprint
 // collisions.
 type FpMapper struct {
-	// highestMappedFP has to be aligned for atomic operations.
-	highestMappedFP atomic.Uint64
-
-	mtx sync.RWMutex // Protects mappings.
 	// maps original fingerprints to a map of string representations of
 	// metrics to the truly unique fingerprint.
 	mappings map[model.Fingerprint]map[string]model.Fingerprint
@@ -32,6 +28,10 @@ type FpMapper struct {
 	// Returns existing labels for given fingerprint, if any.
 	// Equality check relies on labels.Labels being sorted.
 	fpToLabels func(fingerprint model.Fingerprint) labels.Labels
+	// highestMappedFP has to be aligned for atomic operations.
+	highestMappedFP atomic.Uint64
+
+	mtx sync.RWMutex // Protects mappings.
 }
 
 // NewFPMapper returns an fpMapper ready to use.

--- a/pkg/ingester-rf1/owned_streams.go
+++ b/pkg/ingester-rf1/owned_streams.go
@@ -10,9 +10,10 @@ import (
 type ownedStreamService struct {
 	services.Service
 
+	limiter    *Limiter
+	fixedLimit *atomic.Int32
+
 	tenantID            string
-	limiter             *Limiter
-	fixedLimit          *atomic.Int32
 	ownedStreamCount    int
 	notOwnedStreamCount int
 	lock                sync.RWMutex

--- a/pkg/ingester-rf1/stream_rate_calculator.go
+++ b/pkg/ingester-rf1/stream_rate_calculator.go
@@ -24,13 +24,14 @@ type stripeLock struct {
 }
 
 type StreamRateCalculator struct {
-	size     int
-	samples  []map[string]map[uint64]logproto.StreamRate
-	locks    []stripeLock
 	stopchan chan struct{}
 
-	rateLock sync.RWMutex
+	samples  []map[string]map[uint64]logproto.StreamRate
+	locks    []stripeLock
 	allRates []logproto.StreamRate
+	size     int
+
+	rateLock sync.RWMutex
 }
 
 func NewStreamRateCalculator() *StreamRateCalculator {

--- a/pkg/ingester-rf1/streams_map.go
+++ b/pkg/ingester-rf1/streams_map.go
@@ -8,10 +8,10 @@ import (
 )
 
 type streamsMap struct {
-	consistencyMtx sync.RWMutex // Keep read/write consistency between other fields
-	streams        *sync.Map    // map[string]*stream
-	streamsByFP    *sync.Map    // map[model.Fingerprint]*stream
+	streams        *sync.Map // map[string]*stream
+	streamsByFP    *sync.Map // map[model.Fingerprint]*stream
 	streamsCounter *atomic.Int64
+	consistencyMtx sync.RWMutex // Keep read/write consistency between other fields
 }
 
 func newStreamsMap() *streamsMap {

--- a/pkg/ingester/checkpoint.go
+++ b/pkg/ingester/checkpoint.go
@@ -191,11 +191,11 @@ type streamInstance struct {
 }
 
 type streamIterator struct {
+	current   Series
+	err       error
 	instances []streamInstance
 
-	current Series
-	buffer  []chunkWithBuffer
-	err     error
+	buffer []chunkWithBuffer
 }
 
 // newStreamsIterator returns a new stream iterators that iterates over one instance at a time, then
@@ -303,14 +303,14 @@ type walLogger interface {
 }
 
 type WALCheckpointWriter struct {
-	metrics    *ingesterMetrics
-	segmentWAL *wlog.WL
-
 	checkpointWAL walLogger
-	lastSegment   int    // name of the last segment guaranteed to be covered by the checkpoint
-	final         string // filename to atomically rotate upon completion
-	bufSize       int
-	recs          [][]byte
+	metrics       *ingesterMetrics
+	segmentWAL    *wlog.WL
+
+	final       string // filename to atomically rotate upon completion
+	recs        [][]byte
+	lastSegment int // name of the last segment guaranteed to be covered by the checkpoint
+	bufSize     int
 }
 
 func (w *WALCheckpointWriter) Advance() (bool, error) {
@@ -517,12 +517,12 @@ func (w *WALCheckpointWriter) Close(abort bool) error {
 }
 
 type Checkpointer struct {
-	dur     time.Duration
 	iter    SeriesIter
 	writer  CheckpointWriter
 	metrics *ingesterMetrics
 
 	quit <-chan struct{}
+	dur  time.Duration
 }
 
 func NewCheckpointer(dur time.Duration, iter SeriesIter, writer CheckpointWriter, metrics *ingesterMetrics, quit <-chan struct{}) *Checkpointer {

--- a/pkg/ingester/instance.go
+++ b/pkg/ingester/instance.go
@@ -88,21 +88,24 @@ var (
 )
 
 type instance struct {
-	cfg *Config
+	streamsCreatedTotal prometheus.Counter
+	streamsRemovedTotal prometheus.Counter
 
-	buf     []byte // buffer used to compute fps.
+	wal WAL
+
+	chunkFilter      chunk.RequestChunkFilterer
+	pipelineWrapper  log.PipelineWrapper
+	extractorWrapper log.SampleExtractorWrapper
+
+	customStreamsTracker push.UsageTracker
+	cfg                  *Config
+
 	streams *streamsMap
 
 	index  *index.Multi
 	mapper *FpMapper // using of mapper no longer needs mutex because reading from streams is lock-free
 
-	instanceID string
-
-	streamsCreatedTotal prometheus.Counter
-	streamsRemovedTotal prometheus.Counter
-
-	tailers   map[uint32]*tailer
-	tailerMtx sync.RWMutex
+	tailers map[uint32]*tailer
 
 	limiter            *Limiter
 	streamCountLimiter *streamCountLimiter
@@ -110,24 +113,22 @@ type instance struct {
 
 	configs *runtime.TenantConfigs
 
-	wal WAL
-
 	// Denotes whether the ingester should flush on shutdown.
 	// Currently only used by the WAL to signal when the disk is full.
 	flushOnShutdownSwitch *OnceSwitch
 
 	metrics *ingesterMetrics
 
-	chunkFilter          chunk.RequestChunkFilterer
-	pipelineWrapper      log.PipelineWrapper
-	extractorWrapper     log.SampleExtractorWrapper
 	streamRateCalculator *StreamRateCalculator
 
 	writeFailures *writefailures.Manager
 
 	schemaconfig *config.SchemaConfig
 
-	customStreamsTracker push.UsageTracker
+	instanceID string
+
+	buf       []byte // buffer used to compute fps.
+	tailerMtx sync.RWMutex
 }
 
 func newInstance(

--- a/pkg/ingester/limiter.go
+++ b/pkg/ingester/limiter.go
@@ -36,10 +36,11 @@ type Limits interface {
 // Limiter implements primitives to get the maximum number of streams
 // an ingester can handle for a specific tenant
 type Limiter struct {
-	limits            Limits
-	ring              RingCount
+	limits  Limits
+	ring    RingCount
+	metrics *ingesterMetrics
+
 	replicationFactor int
-	metrics           *ingesterMetrics
 
 	mtx      sync.RWMutex
 	disabled bool
@@ -139,10 +140,10 @@ func calculateLimitForMultipleZones(globalLimit, zonesCount int, l *Limiter) int
 type supplier[T any] func() T
 
 type streamCountLimiter struct {
-	tenantID                   string
 	limiter                    *Limiter
 	defaultStreamCountSupplier supplier[int]
 	ownedStreamSvc             *ownedStreamService
+	tenantID                   string
 }
 
 var noopFixedLimitSupplier = func() int {
@@ -198,11 +199,11 @@ func (l *Limiter) RateLimit(tenant string) validation.RateLimit {
 }
 
 type StreamRateLimiter struct {
-	recheckPeriod time.Duration
 	recheckAt     time.Time
 	strategy      RateLimiterStrategy
-	tenant        string
 	lim           *rate.Limiter
+	tenant        string
+	recheckPeriod time.Duration
 }
 
 func NewStreamRateLimiter(strategy RateLimiterStrategy, tenant string, recheckPeriod time.Duration) *StreamRateLimiter {

--- a/pkg/ingester/mapper.go
+++ b/pkg/ingester/mapper.go
@@ -21,10 +21,6 @@ var separatorString = string([]byte{model.SeparatorByte})
 // FpMapper is used to map fingerprints in order to work around fingerprint
 // collisions.
 type FpMapper struct {
-	// highestMappedFP has to be aligned for atomic operations.
-	highestMappedFP atomic.Uint64
-
-	mtx sync.RWMutex // Protects mappings.
 	// maps original fingerprints to a map of string representations of
 	// metrics to the truly unique fingerprint.
 	mappings map[model.Fingerprint]map[string]model.Fingerprint
@@ -32,6 +28,10 @@ type FpMapper struct {
 	// Returns existing labels for given fingerprint, if any.
 	// Equality check relies on labels.Labels being sorted.
 	fpToLabels func(fingerprint model.Fingerprint) labels.Labels
+	// highestMappedFP has to be aligned for atomic operations.
+	highestMappedFP atomic.Uint64
+
+	mtx sync.RWMutex // Protects mappings.
 }
 
 // NewFPMapper returns an fpMapper ready to use.

--- a/pkg/ingester/owned_streams.go
+++ b/pkg/ingester/owned_streams.go
@@ -18,12 +18,12 @@ var notOwnedStreamsMetric = promauto.NewGauge(prometheus.GaugeOpts{
 })
 
 type ownedStreamService struct {
-	tenantID         string
 	limiter          *Limiter
 	fixedLimit       *atomic.Int32
+	notOwnedStreams  map[model.Fingerprint]any
+	tenantID         string
 	ownedStreamCount int
 	lock             sync.RWMutex
-	notOwnedStreams  map[model.Fingerprint]any
 }
 
 func newOwnedStreamService(tenantID string, limiter *Limiter) *ownedStreamService {

--- a/pkg/ingester/recalculate_owned_streams.go
+++ b/pkg/ingester/recalculate_owned_streams.go
@@ -15,11 +15,12 @@ type recalculateOwnedStreams struct {
 
 	logger log.Logger
 
+	ingestersRing ring.ReadRing
+
 	instancesSupplier func() []*instance
+	ticker            *time.Ticker
 	ingesterID        string
 	previousRing      ring.ReplicationSet
-	ingestersRing     ring.ReadRing
-	ticker            *time.Ticker
 }
 
 func newRecalculateOwnedStreams(instancesSupplier func() []*instance, ingesterID string, ring ring.ReadRing, ringPollInterval time.Duration, logger log.Logger) *recalculateOwnedStreams {

--- a/pkg/ingester/recovery.go
+++ b/pkg/ingester/recovery.go
@@ -58,11 +58,11 @@ type Recoverer interface {
 }
 
 type ingesterRecoverer struct {
-	// basically map[userID]map[fingerprint]*stream
-	users  sync.Map
-	ing    *Ingester
 	logger log.Logger
+	ing    *Ingester
 	done   chan struct{}
+	// basically map[userID]map[fingerprint]*stream
+	users sync.Map
 }
 
 func newIngesterRecoverer(i *Ingester) *ingesterRecoverer {
@@ -345,8 +345,8 @@ func RecoverCheckpoint(reader WALReader, recoverer Recoverer) error {
 }
 
 type recoveryInput struct {
-	userID string
 	data   interface{}
+	userID string
 }
 
 // recoverGeneric enables reusing the ability to recover from WALs of different types

--- a/pkg/ingester/replay_controller.go
+++ b/pkg/ingester/replay_controller.go
@@ -40,6 +40,10 @@ type Flusher interface {
 
 // replayController handles coordinating backpressure between WAL replays and chunk flushing.
 type replayController struct {
+	flusher Flusher
+	metrics *ingesterMetrics
+	cond    *sync.Cond
+	cfg     WALConfig
 	// Note, this has to be defined first to make sure it is aligned properly for 32bit ARM OS
 	// From https://golang.org/pkg/sync/atomic/#pkg-note-BUG:
 	// > On ARM, 386, and 32-bit MIPS, it is the caller's responsibility to arrange for
@@ -47,11 +51,7 @@ type replayController struct {
 	// > variable or in an allocated struct, array, or slice can be relied upon to
 	// > be 64-bit aligned.
 	currentBytes atomic.Int64
-	cfg          WALConfig
-	metrics      *ingesterMetrics
-	cond         *sync.Cond
 	isFlushing   atomic.Bool
-	flusher      Flusher
 }
 
 // flusher is expected to reduce pressure via calling Sub

--- a/pkg/ingester/stream_rate_calculator.go
+++ b/pkg/ingester/stream_rate_calculator.go
@@ -24,13 +24,14 @@ type stripeLock struct {
 }
 
 type StreamRateCalculator struct {
-	size     int
-	samples  []map[string]map[uint64]logproto.StreamRate
-	locks    []stripeLock
 	stopchan chan struct{}
 
-	rateLock sync.RWMutex
+	samples  []map[string]map[uint64]logproto.StreamRate
+	locks    []stripeLock
 	allRates []logproto.StreamRate
+	size     int
+
+	rateLock sync.RWMutex
 }
 
 func NewStreamRateCalculator() *StreamRateCalculator {

--- a/pkg/ingester/streams_map.go
+++ b/pkg/ingester/streams_map.go
@@ -8,10 +8,10 @@ import (
 )
 
 type streamsMap struct {
-	consistencyMtx sync.RWMutex // Keep read/write consistency between other fields
-	streams        *sync.Map    // map[string]*stream
-	streamsByFP    *sync.Map    // map[model.Fingerprint]*stream
+	streams        *sync.Map // map[string]*stream
+	streamsByFP    *sync.Map // map[model.Fingerprint]*stream
 	streamsCounter *atomic.Int64
+	consistencyMtx sync.RWMutex // Keep read/write consistency between other fields
 }
 
 func newStreamsMap() *streamsMap {

--- a/pkg/ingester/wal.go
+++ b/pkg/ingester/wal.go
@@ -24,11 +24,11 @@ const walSegmentSize = wlog.DefaultSegmentSize * 4
 const defaultCeiling = 4 << 30 // 4GB
 
 type WALConfig struct {
-	Enabled             bool             `yaml:"enabled"`
 	Dir                 string           `yaml:"dir"`
 	CheckpointDuration  time.Duration    `yaml:"checkpoint_duration"`
-	FlushOnShutdown     bool             `yaml:"flush_on_shutdown"`
 	ReplayMemoryCeiling flagext.ByteSize `yaml:"replay_memory_ceiling"`
+	Enabled             bool             `yaml:"enabled"`
+	FlushOnShutdown     bool             `yaml:"flush_on_shutdown"`
 }
 
 func (cfg *WALConfig) Validate() error {
@@ -66,13 +66,14 @@ func (noopWAL) Log(*wal.Record) error { return nil }
 func (noopWAL) Stop() error           { return nil }
 
 type walWrapper struct {
-	cfg        WALConfig
-	wal        *wlog.WL
-	metrics    *ingesterMetrics
 	seriesIter SeriesIter
 
+	wal     *wlog.WL
+	metrics *ingesterMetrics
+	quit    chan struct{}
+	cfg     WALConfig
+
 	wait sync.WaitGroup
-	quit chan struct{}
 }
 
 // newWAL creates a WAL object. If the WAL is disabled, then the returned WAL is a no-op WAL.

--- a/pkg/pattern/flush.go
+++ b/pkg/pattern/flush.go
@@ -38,8 +38,8 @@ func (i *Ingester) flush(mayRemoveStreams bool) {
 }
 
 type flushOp struct {
-	from      model.Time
 	userID    string
+	from      model.Time
 	fp        model.Fingerprint
 	immediate bool
 }

--- a/pkg/pattern/ingester_querier.go
+++ b/pkg/pattern/ingester_querier.go
@@ -201,8 +201,8 @@ func (q *IngesterQuerier) forAllIngesters(ctx context.Context, f func(context.Co
 }
 
 type ResponseFromIngesters struct {
-	addr     string
 	response interface{}
+	addr     string
 }
 
 func (q *IngesterQuerier) forGivenIngesters(ctx context.Context, replicationSet ring.ReplicationSet, f func(context.Context, logproto.PatternClient) (interface{}, error)) ([]ResponseFromIngesters, error) {

--- a/pkg/pattern/instance.go
+++ b/pkg/pattern/instance.go
@@ -30,16 +30,16 @@ const indexShards = 32
 
 // instance is a tenant instance of the pattern ingester.
 type instance struct {
-	instanceID     string
-	buf            []byte             // buffer used to compute fps.
+	logger         log.Logger
 	mapper         *ingester.FpMapper // using of mapper no longer needs mutex because reading from streams is lock-free
 	streams        *streamsMap
 	index          *index.BitPrefixInvertedIndex
-	logger         log.Logger
 	metrics        *ingesterMetrics
 	chunkMetrics   *metric.ChunkMetrics
-	aggregationCfg metric.AggregationConfig
 	drainCfg       *drain.Config
+	instanceID     string
+	buf            []byte // buffer used to compute fps.
+	aggregationCfg metric.AggregationConfig
 }
 
 func newInstance(instanceID string, logger log.Logger, metrics *ingesterMetrics, chunkMetrics *metric.ChunkMetrics, drainCfg *drain.Config, aggCfg metric.AggregationConfig) (*instance, error) {

--- a/pkg/pattern/stream.go
+++ b/pkg/pattern/stream.go
@@ -28,21 +28,22 @@ import (
 )
 
 type stream struct {
-	fp           model.Fingerprint
-	labels       labels.Labels
-	labelsString string
-	labelHash    uint64
-	patterns     *drain.Drain
-	mtx          sync.Mutex
-
-	cfg    metric.AggregationConfig
-	chunks *metric.Chunks
-
 	evaluator metric.SampleEvaluatorFactory
+
+	logger   log.Logger
+	patterns *drain.Drain
+	chunks   *metric.Chunks
+
+	labelsString string
+	labels       labels.Labels
+	fp           model.Fingerprint
+	labelHash    uint64
 
 	lastTs int64
 
-	logger log.Logger
+	mtx sync.Mutex
+
+	cfg metric.AggregationConfig
 }
 
 func newStream(

--- a/pkg/pattern/streams_map.go
+++ b/pkg/pattern/streams_map.go
@@ -8,10 +8,10 @@ import (
 )
 
 type streamsMap struct {
-	consistencyMtx sync.RWMutex // Keep read/write consistency between other fields
-	streams        *sync.Map    // map[string]*stream
-	streamsByFP    *sync.Map    // map[model.Fingerprint]*stream
+	streams        *sync.Map // map[string]*stream
+	streamsByFP    *sync.Map // map[model.Fingerprint]*stream
 	streamsCounter *atomic.Int64
+	consistencyMtx sync.RWMutex // Keep read/write consistency between other fields
 }
 
 func newStreamsMap() *streamsMap {


### PR DESCRIPTION
**What this PR does / why we need it**:

This should help reduce memory usage. For now I've only done it for ingesters but we might want to look at the query path too.


```
betteralign -apply  ./pkg/ingester
/Users/cyril/work/loki/pkg/ingester/checkpoint.go:193:21: 16 bytes saved: struct with 208 pointer bytes could be 192
/Users/cyril/work/loki/pkg/ingester/checkpoint.go:305:26: 16 bytes saved: struct with 72 pointer bytes could be 56
/Users/cyril/work/loki/pkg/ingester/checkpoint.go:519:19: 8 bytes saved: struct with 56 pointer bytes could be 48
/Users/cyril/work/loki/pkg/ingester/flush.go:90:14: 8 bytes saved: struct with 16 pointer bytes could be 8
/Users/cyril/work/loki/pkg/ingester/ingester.go:84:13: 16 bytes saved: struct of size 960 could be 944
/Users/cyril/work/loki/pkg/ingester/ingester.go:214:15: 8 bytes saved: struct of size 1728 could be 1720
/Users/cyril/work/loki/pkg/ingester/instance.go:90:15: 40 bytes saved: struct with 288 pointer bytes could be 248
/Users/cyril/work/loki/pkg/ingester/limiter.go:38:14: 8 bytes saved: struct with 48 pointer bytes could be 40
/Users/cyril/work/loki/pkg/ingester/limiter.go:141:25: 8 bytes saved: struct with 40 pointer bytes could be 32
/Users/cyril/work/loki/pkg/ingester/limiter.go:200:24: 16 bytes saved: struct with 72 pointer bytes could be 56
/Users/cyril/work/loki/pkg/ingester/mapper.go:23:15: 32 bytes saved: struct with 48 pointer bytes could be 16
/Users/cyril/work/loki/pkg/ingester/owned_streams.go:20:25: 40 bytes saved: struct with 72 pointer bytes could be 32
/Users/cyril/work/loki/pkg/ingester/recalculate_owned_streams.go:13:30: 40 bytes saved: struct with 128 pointer bytes could be 88
/Users/cyril/work/loki/pkg/ingester/recovery.go:60:24: 8 bytes saved: struct with 64 pointer bytes could be 56
/Users/cyril/work/loki/pkg/ingester/recovery.go:347:20: 8 bytes saved: struct with 32 pointer bytes could be 24
/Users/cyril/work/loki/pkg/ingester/replay_controller.go:42:23: 48 bytes saved: struct with 96 pointer bytes could be 48
/Users/cyril/work/loki/pkg/ingester/stream.go:40:13: 8 bytes saved: struct of size 296 could be 288
/Users/cyril/work/loki/pkg/ingester/stream.go:87:16: 16 bytes saved: struct with 80 pointer bytes could be 64
/Users/cyril/work/loki/pkg/ingester/stream_rate_calculator.go:26:27: 32 bytes saved: struct with 96 pointer bytes could be 64
/Users/cyril/work/loki/pkg/ingester/streams_map.go:10:17: 24 bytes saved: struct with 48 pointer bytes could be 24
/Users/cyril/work/loki/pkg/ingester/tailer.go:31:18: 8 bytes saved: struct with 56 pointer bytes could be 48
/Users/cyril/work/loki/pkg/ingester/tailer.go:36:13: 8 bytes saved: struct of size 200 could be 192
/Users/cyril/work/loki/pkg/ingester/wal.go:26:16: 8 bytes saved: struct of size 48 could be 40
/Users/cyril/work/loki/pkg/ingester/wal.go:68:17: 48 bytes saved: struct with 104 pointer bytes could be 56
```

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
