### PR TITLE
fix: Properly reset wal segment writer

### DIFF
--- a/pkg/storage/wal/segment.go
+++ b/pkg/storage/wal/segment.go
@@ -62,6 +62,12 @@ type streamSegment struct {
 }
 
 func (s *streamSegment) Reset() {
+	for i := range s.entries {
+		s.entries[i] = nil
+	}
+	s.lbls = nil
+	s.tenantID = ""
+	s.maxt = 0
 	s.entries = s.entries[:0]
 }
 
@@ -102,7 +108,6 @@ func (b *SegmentWriter) getOrCreateStream(id streamID, lbls labels.Labels) *stre
 		lbls = labels.NewBuilder(lbls).Set(tenantLabel, id.tenant).Labels()
 	}
 	s = streamSegmentPool.Get().(*streamSegment)
-	s.Reset()
 	s.lbls = lbls
 	s.tenantID = id.tenant
 	b.streams[id] = s
@@ -265,6 +270,7 @@ func (b *SegmentWriter) WriteTo(w io.Writer) (int64, error) {
 func (b *SegmentWriter) Reset() {
 	for _, s := range b.streams {
 		s := s
+		s.Reset()
 		streamSegmentPool.Put(s)
 	}
 	b.streams = make(map[streamID]*streamSegment, 64)


### PR DESCRIPTION
**What this PR does / why we need it**:

We recently discover that we were holding on entries and stream labels. This fixes the reset of wal segment writer.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
