### PR TITLE
ci: remove branch regex from doc publishing task

### DIFF
--- a/.github/workflows/publish-technical-documentation-release.yml
+++ b/.github/workflows/publish-technical-documentation-release.yml
@@ -2,8 +2,6 @@ name: "publish-technical-documentation-release"
 
 on:
   push:
-    branches:
-      - "release-*"
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
     paths:
@@ -33,7 +31,6 @@ jobs:
         with:
           ref_name: "${{ github.ref_name }}"
           release_tag_regexp: "^v(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$"
-          release_branch_regexp: "^release-(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.x$"
 
       - name: "Determine technical documentation version"
         if: "steps.has-matching-release-tag.outputs.bool == 'true'"


### PR DESCRIPTION
**What this PR does / why we need it**:

This should allow us to publish based on tag only (from any branch) which will allow us to release minors from k branches while still releasing patches from `release-*` branches.
