### PR TITLE
feat: Add metrics to WAL Manager

### DIFF
--- a/pkg/ingester-rf1/ingester.go
+++ b/pkg/ingester-rf1/ingester.go
@@ -257,7 +257,7 @@ func New(cfg Config, clientConfig client.Config,
 		MaxAge:         wal.DefaultMaxAge,
 		MaxSegments:    wal.DefaultMaxSegments,
 		MaxSegmentSize: wal.DefaultMaxSegmentSize,
-	})
+	}, wal.NewMetrics(registerer))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/wal/manager_test.go
+++ b/pkg/storage/wal/manager_test.go
@@ -16,7 +16,7 @@ func TestManager_Append(t *testing.T) {
 	m, err := NewManager(Config{
 		MaxSegments:    1,
 		MaxSegmentSize: 1024, // 1KB
-	})
+	}, NewMetrics(nil))
 	require.NoError(t, err)
 
 	// Append some data.
@@ -96,7 +96,7 @@ func TestManager_Append_ErrFull(t *testing.T) {
 	m, err := NewManager(Config{
 		MaxSegments:    10,
 		MaxSegmentSize: 1024, // 1KB
-	})
+	}, NewMetrics(nil))
 	require.NoError(t, err)
 
 	// Should be able to write to all 10 segments of 1KB each.
@@ -140,7 +140,7 @@ func TestManager_NextPending(t *testing.T) {
 		MaxAge:         DefaultMaxAge,
 		MaxSegments:    1,
 		MaxSegmentSize: 1024, // 1KB
-	})
+	}, NewMetrics(nil))
 	require.NoError(t, err)
 
 	// There should be no items as no data has been written.
@@ -195,7 +195,7 @@ func TestManager_Put(t *testing.T) {
 	m, err := NewManager(Config{
 		MaxSegments:    10,
 		MaxSegmentSize: 1024, // 1KB
-	})
+	}, NewMetrics(nil))
 	require.NoError(t, err)
 
 	// There should be 10 available segments, and 0 pending.


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit adds the following gauges to the WAL Manager:

  - `wal_segments_available`
    The number of WAL segments accepting writes

  - `wal_segments_pending`
    The number of WAL segments waiting to be flushed

  - `wal_segments_flushing`
    The number of WAL segments being flushed

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
