### PR TITLE
fix: backport #13485 to k210

### DIFF
--- a/pkg/logql/engine.go
+++ b/pkg/logql/engine.go
@@ -378,11 +378,10 @@ func (q *query) evalSample(ctx context.Context, expr syntax.SampleExpr) (promql_
 			return nil, fmt.Errorf("unsupported result type: %T", r)
 		}
 	}
-	return nil, nil
+	return nil, errors.New("unexpected empty result")
 }
 
 func (q *query) JoinSampleVector(next bool, r StepResult, stepEvaluator StepEvaluator, maxSeries int) (promql_parser.Value, error) {
-
 	seriesIndex := map[uint64]*promql.Series{}
 
 	vec := promql.Vector{}


### PR DESCRIPTION
backports bugfix for when first/last over time had empty vectors, the fix is the removal of:
```
if len(vec) == 0 {
	return e.hasNext(), ts, SampleVector(vec)
}
```