### PR TITLE
fix(operator): Remove duplicate conditions from status

### DIFF
--- a/operator/internal/status/conditions.go
+++ b/operator/internal/status/conditions.go
@@ -2,36 +2,35 @@ package status
 
 import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+type conditionKey struct {
+	Type   string
+	Reason string
+}
+
 func mergeConditions(old, active []metav1.Condition, now metav1.Time) []metav1.Condition {
+	conditions := map[conditionKey]bool{}
 	merged := make([]metav1.Condition, 0, len(old)+len(active))
-	for len(old) > 0 {
-		c := old[0]
-		found := -1
-		for i, ac := range active {
-			if c.Type == ac.Type && c.Reason == ac.Reason {
-				found = i
-				break
-			}
-		}
-
-		if found != -1 {
-			c = active[found]
-			active = append(active[:found], active[found+1:]...)
-
-			c.Status = metav1.ConditionTrue
-		} else {
-			c.Status = metav1.ConditionFalse
-		}
-
-		c.LastTransitionTime = now
-		merged = append(merged, c)
-		old = old[1:]
-	}
-
 	for _, c := range active {
 		c.Status = metav1.ConditionTrue
 		c.LastTransitionTime = now
+
 		merged = append(merged, c)
+		conditions[conditionKey{Type: c.Type, Reason: c.Reason}] = true
 	}
+
+	for _, c := range old {
+		if conditions[conditionKey{c.Type, c.Reason}] {
+			continue
+		}
+
+		if c.Status != metav1.ConditionFalse {
+			c.LastTransitionTime = now
+			c.Status = metav1.ConditionFalse
+		}
+
+		merged = append(merged, c)
+		conditions[conditionKey{c.Type, c.Reason}] = true
+	}
+
 	return merged
 }

--- a/operator/internal/status/conditions_test.go
+++ b/operator/internal/status/conditions_test.go
@@ -11,7 +11,8 @@ import (
 )
 
 func TestMergeConditions(t *testing.T) {
-	now := metav1.NewTime(time.Unix(0, 0))
+	oldTime := metav1.NewTime(time.Unix(0, 0))
+	now := metav1.NewTime(time.Unix(10, 0))
 	tt := []struct {
 		desc       string
 		old        []metav1.Condition
@@ -37,12 +38,25 @@ func TestMergeConditions(t *testing.T) {
 		{
 			desc: "reset old condition",
 			old: []metav1.Condition{
-				conditionPending,
+				{
+					Type:               conditionPending.Type,
+					Status:             metav1.ConditionTrue,
+					LastTransitionTime: oldTime,
+					Reason:             conditionPending.Reason,
+					Message:            conditionPending.Message,
+				},
 			},
 			active: []metav1.Condition{
 				conditionReady,
 			},
 			wantMerged: []metav1.Condition{
+				{
+					Type:               conditionReady.Type,
+					Status:             metav1.ConditionTrue,
+					LastTransitionTime: now,
+					Reason:             conditionReady.Reason,
+					Message:            conditionReady.Message,
+				},
 				{
 					Type:               conditionPending.Type,
 					Status:             metav1.ConditionFalse,
@@ -50,12 +64,27 @@ func TestMergeConditions(t *testing.T) {
 					Reason:             conditionPending.Reason,
 					Message:            conditionPending.Message,
 				},
+			},
+		},
+		{
+			desc: "keep transition time of old condition",
+			old: []metav1.Condition{
 				{
-					Type:               conditionReady.Type,
-					Status:             metav1.ConditionTrue,
-					LastTransitionTime: now,
-					Reason:             conditionReady.Reason,
-					Message:            conditionReady.Message,
+					Type:               conditionPending.Type,
+					Status:             metav1.ConditionFalse,
+					LastTransitionTime: oldTime,
+					Reason:             conditionPending.Reason,
+					Message:            conditionPending.Message,
+				},
+			},
+			active: []metav1.Condition{},
+			wantMerged: []metav1.Condition{
+				{
+					Type:               conditionPending.Type,
+					Status:             metav1.ConditionFalse,
+					LastTransitionTime: oldTime,
+					Reason:             conditionPending.Reason,
+					Message:            conditionPending.Message,
 				},
 			},
 		},
@@ -72,7 +101,7 @@ func TestMergeConditions(t *testing.T) {
 				{
 					Type:               conditionPending.Type,
 					Status:             metav1.ConditionFalse,
-					LastTransitionTime: now,
+					LastTransitionTime: oldTime,
 					Reason:             conditionPending.Reason,
 					Message:            conditionPending.Message,
 				},
@@ -94,11 +123,54 @@ func TestMergeConditions(t *testing.T) {
 					Message:            conditionReady.Message,
 				},
 				{
+					Type:               string(lokiv1.ConditionWarning),
+					Status:             metav1.ConditionTrue,
+					LastTransitionTime: now,
+					Reason:             "test-warning",
+					Message:            "test-warning-message",
+				},
+				{
 					Type:               conditionPending.Type,
 					Status:             metav1.ConditionFalse,
-					LastTransitionTime: now,
+					LastTransitionTime: oldTime,
 					Reason:             conditionPending.Reason,
 					Message:            conditionPending.Message,
+				},
+			},
+		},
+		{
+			desc: "remove duplicates",
+			old: []metav1.Condition{
+				{
+					Type:               conditionReady.Type,
+					Status:             metav1.ConditionTrue,
+					LastTransitionTime: now,
+					Reason:             conditionReady.Reason,
+					Message:            conditionReady.Message,
+				},
+				{
+					Type:               conditionReady.Type,
+					Status:             metav1.ConditionTrue,
+					LastTransitionTime: now,
+					Reason:             conditionReady.Reason,
+					Message:            conditionReady.Message,
+				},
+			},
+			active: []metav1.Condition{
+				conditionReady,
+				{
+					Type:    string(lokiv1.ConditionWarning),
+					Reason:  "test-warning",
+					Message: "test-warning-message",
+				},
+			},
+			wantMerged: []metav1.Condition{
+				{
+					Type:               conditionReady.Type,
+					Status:             metav1.ConditionTrue,
+					LastTransitionTime: now,
+					Reason:             conditionReady.Reason,
+					Message:            conditionReady.Message,
 				},
 				{
 					Type:               string(lokiv1.ConditionWarning),


### PR DESCRIPTION
**What this PR does / why we need it**:

Some of the code in the operator (for example the metrics) work on the assumption that every combination of "Type" and "Reason" in the Conditions in the LokiStack `.status.conditions` is only present once. The current implementation of the status update function tries to keep this assumption valid, but does not remove duplicate conditions if they already exists (for example, from a previous version of the operator which did not have this assumption yet).

This PR extends the `mergeCondition` function that merges the existing Conditions with the currently active ones, so that it removes duplicate conditions (as defined by having the same combination of "Type & Reason"). In addition it also now keeps the `lastTransitionTime` timestamp untouched when the condition is not part of the "active conditions" and has not been set to "inactive" in this update. This makes it possible to see if conditions have been inactive for a longer time and should improve debugging of LokiStack resources.

**Which issue(s) this PR fixes**:

Fixes [LOG-5696](https://issues.redhat.com/browse/LOG-5696)

**Special notes for your reviewer**:

**Checklist**

- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
