### PR TITLE
chore: Improve test coverage of WAL Manager

### DIFF
--- a/pkg/storage/wal/manager_test.go
+++ b/pkg/storage/wal/manager_test.go
@@ -283,7 +283,7 @@ func TestManager_Put(t *testing.T) {
 	}, NewMetrics(nil))
 	require.NoError(t, err)
 
-	// There should be 10 available and 0 pending segments.
+	// There should be 1 available and 0 pending segments.
 	require.Equal(t, 1, m.available.Len())
 	require.Equal(t, 0, m.pending.Len())
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request improves the test coverage of the WAL Manager.

```
go test ./... -run TestManager -v
=== RUN   TestManager_Append
--- PASS: TestManager_Append (0.00s)
=== RUN   TestManager_AppendFailed
--- PASS: TestManager_AppendFailed (0.00s)
=== RUN   TestManager_AppendMaxAge
--- PASS: TestManager_AppendMaxAge (0.10s)
=== RUN   TestManager_AppendMaxSize
--- PASS: TestManager_AppendMaxSize (0.00s)
=== RUN   TestManager_AppendWALFull
--- PASS: TestManager_AppendWALFull (0.00s)
=== RUN   TestManager_NextPending
--- PASS: TestManager_NextPending (0.00s)
=== RUN   TestManager_NexPendingMaxAge
--- PASS: TestManager_NexPendingMaxAge (0.10s)
=== RUN   TestManager_Put
--- PASS: TestManager_Put (0.00s)
=== RUN   TestManager_Metrics
--- PASS: TestManager_Metrics (0.00s)
```

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
