### PR TITLE
fix(blooms): skip empty blooms on reads

### DIFF
--- a/pkg/storage/bloom/v1/filter/scalable.go
+++ b/pkg/storage/bloom/v1/filter/scalable.go
@@ -110,6 +110,13 @@ func (s *ScalableBloomFilter) K() uint {
 	return s.filters[len(s.filters)-1].K()
 }
 
+func (s *ScalableBloomFilter) Count() (ct int) {
+	for _, filter := range s.filters {
+		ct += int(filter.Count())
+	}
+	return
+}
+
 // FillRatio returns the average ratio of set bits across every filter.
 func (s *ScalableBloomFilter) FillRatio() float64 {
 	var sum, count float64

--- a/pkg/storage/bloom/v1/fuse.go
+++ b/pkg/storage/bloom/v1/fuse.go
@@ -300,6 +300,13 @@ func (fq *FusedQuerier) runSeries(schema Schema, series *SeriesWithOffsets, reqs
 		// Test each bloom individually
 		bloom := fq.bq.blooms.At()
 		for j, req := range reqs {
+			// TODO(owen-d): this is a stopgap to avoid filtering broken blooms until we find their cause.
+			// In the case we don't have any data in the bloom, don't filter any chunks.
+			if bloom.ScalableBloomFilter.Count() == 0 {
+				for k := range inputs[j].InBlooms {
+					inputs[j].found[k] = true
+				}
+			}
 
 			// shortcut: series level removal
 			// we can skip testing chunk keys individually if the bloom doesn't match


### PR DESCRIPTION
Read path safeguard to prevent filtering chunks associated with empty blooms while we work on finding the underlying cause of empty blooms in compaction.