### PR TITLE
ast left cycular reference result in oom

### DIFF
--- a/pkg/logql/syntax/ast.go
+++ b/pkg/logql/syntax/ast.go
@@ -185,16 +185,22 @@ func (m MultiStageExpr) reorderStages() []StageExpr {
 func combineFilters(in []*LineFilterExpr) StageExpr {
 	result := in[len(in)-1]
 	for i := len(in) - 2; i >= 0; i-- {
-		leafNode(result).Left = in[i]
+		leaf := leafNode(result, in[i])
+		if leaf != nil {
+			leaf = in[i]
+		}
 	}
 
 	return result
 }
 
-func leafNode(in *LineFilterExpr) *LineFilterExpr {
+func leafNode(in *LineFilterExpr, child *LineFilterExpr) *LineFilterExpr {
 	current := in
 	//nolint:revive
 	for ; current.Left != nil; current = current.Left {
+		if current == child {
+			return nil
+		}
 	}
 	return current
 }

--- a/pkg/logql/syntax/ast_test.go
+++ b/pkg/logql/syntax/ast_test.go
@@ -1076,3 +1076,24 @@ func TestGroupingString(t *testing.T) {
 	}
 	require.Equal(t, " without ()", g.String())
 }
+
+func TestCombineFilters(t *testing.T) {
+	in := []*LineFilterExpr{
+		{LineFilter: LineFilter{Ty: log.LineMatchEqual, Match: "test1"}},
+		{LineFilter: LineFilter{Ty: log.LineMatchEqual, Match: "tes2"}},
+	}
+
+	var combineFilter StageExpr
+	for i := 0; i < 2; i++ {
+		combineFilter = combineFilters(in)
+	}
+
+	current := combineFilter.(*LineFilterExpr)
+	i := 0
+	for ; current.Left != nil; current = current.Left {
+		i++
+		if i > 2 {
+			t.Fatalf("left num isn't a correct number")
+		}
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #13277
it a AST circular reference problem.
https://github.com/grafana/loki/blob/main/pkg/ingester/ingester.go#L962
https://github.com/grafana/loki/blob/main/pkg/ingester/ingester.go#L978

these two func execute pipeline func use the same AST tree. which result in circular reference at below line code.
https://github.com/grafana/loki/blob/main/pkg/logql/syntax/ast.go#L188

actually. if the **Pipeline** func execute more than twice. it result in dead loop.

i fix it.  if the root contain a child which is same as the node will be inserted.  the node won't be inserted. 

