### PR TITLE
fix: add logging to empty bloom

### DIFF
--- a/pkg/bloomgateway/processor.go
+++ b/pkg/bloomgateway/processor.go
@@ -167,7 +167,8 @@ func (p *processor) processBlock(_ context.Context, bq *bloomshipper.CloseableBl
 		iters = append(iters, it)
 	}
 
-	fq := blockQuerier.Fuse(iters, p.logger)
+	logger := log.With(p.logger, "block", bq.BlockRef.String())
+	fq := blockQuerier.Fuse(iters, logger)
 
 	start := time.Now()
 	err = fq.Run()

--- a/pkg/storage/bloom/v1/fuse.go
+++ b/pkg/storage/bloom/v1/fuse.go
@@ -299,15 +299,24 @@ func (fq *FusedQuerier) runSeries(schema Schema, series *SeriesWithOffsets, reqs
 
 		// Test each bloom individually
 		bloom := fq.bq.blooms.At()
-		for j, req := range reqs {
-			// TODO(owen-d): this is a stopgap to avoid filtering broken blooms until we find their cause.
-			// In the case we don't have any data in the bloom, don't filter any chunks.
-			if bloom.ScalableBloomFilter.Count() == 0 {
+
+		// TODO(owen-d): this is a stopgap to avoid filtering broken blooms until we find their cause.
+		// In the case we don't have any data in the bloom, don't filter any chunks.
+		if bloom.ScalableBloomFilter.Count() == 0 {
+			level.Warn(fq.logger).Log(
+				"Found bloom with no data",
+				"offset_page", offset.Page,
+				"offset_bytes", offset.ByteOffset,
+			)
+
+			for j := range reqs {
 				for k := range inputs[j].InBlooms {
 					inputs[j].found[k] = true
 				}
 			}
+		}
 
+		for j, req := range reqs {
 			// shortcut: series level removal
 			// we can skip testing chunk keys individually if the bloom doesn't match
 			// the query.

--- a/pkg/storage/bloom/v1/fuse.go
+++ b/pkg/storage/bloom/v1/fuse.go
@@ -304,7 +304,7 @@ func (fq *FusedQuerier) runSeries(schema Schema, series *SeriesWithOffsets, reqs
 		// In the case we don't have any data in the bloom, don't filter any chunks.
 		if bloom.ScalableBloomFilter.Count() == 0 {
 			level.Warn(fq.logger).Log(
-				"Found bloom with no data",
+				"msg", "Found bloom with no data",
 				"offset_page", offset.Page,
 				"offset_bytes", offset.ByteOffset,
 			)


### PR DESCRIPTION
**What this PR does / why we need it**:
Follow up for https://github.com/grafana/loki/pull/13500/files to log the empty blooms with their block and offset.

I also moved the bloom empty check outside the reqs loop.

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
