### PR TITLE
fix(blooms): Remove backoff from notify planner

### DIFF
--- a/pkg/bloombuild/builder/batch.go
+++ b/pkg/bloombuild/builder/batch.go
@@ -303,6 +303,12 @@ func (i *blockLoadingIter) loadNext() bool {
 // Next implements v1.Iterator.
 func (i *blockLoadingIter) Next() bool {
 	i.init()
+
+	if i.ctx.Err() != nil {
+		i.err = i.ctx.Err()
+		return false
+	}
+
 	return i.iter.Next() || i.loadNext()
 }
 

--- a/pkg/bloombuild/builder/builder.go
+++ b/pkg/bloombuild/builder/builder.go
@@ -262,22 +262,10 @@ func (b *Builder) notifyTaskCompletedToPlanner(
 		CreatedMetas: metas,
 	}
 
-	// We have a retry mechanism upper in the stack, but we add another one here
-	// to try our best to avoid losing the task result.
-	retries := backoff.New(c.Context(), b.cfg.BackoffConfig)
-	for retries.Ongoing() {
-		if err := c.Send(&protos.BuilderToPlanner{
-			BuilderID: b.ID,
-			Result:    *result.ToProtoTaskResult(),
-		}); err == nil {
-			break
-		}
-
-		level.Error(logger).Log("msg", "failed to acknowledge task completion to planner. Retrying", "err", err)
-		retries.Wait()
-	}
-
-	if err := retries.Err(); err != nil {
+	if err := c.Send(&protos.BuilderToPlanner{
+		BuilderID: b.ID,
+		Result:    *result.ToProtoTaskResult(),
+	}); err != nil {
 		return fmt.Errorf("failed to acknowledge task completion to planner: %w", err)
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
In https://github.com/grafana/loki/pull/13306 we implemented a backoff mechanism to retry connecting to the builder. We added a backoff to connect to the builder to receive tasks, and another one to send back the results.

In this PR we remove the backoff to send back the result. I ran some experiments and:
- The context of the connection is not canceled when the connection to the planner is lost.
   - This is fine as the blocks and metas are pushed to the store and later planning cycles will take them into account.
- When the connection is broken to the planner, regardless of the backoff, it will always fail
- In (the unlikely) case that the planner is throttling CPU, gRPC already has some internal default retry mechanism for the Send and Receive operations.  

We can revisit this if we decide to make the planner tolerant to restarts and make it able to pick it up where it failed.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
