### PR TITLE
docs: Update simple scalable mode documentation by adding quotes around the schema config timestamps

### DIFF
--- a/docs/sources/setup/install/helm/install-scalable/_index.md
+++ b/docs/sources/setup/install/helm/install-scalable/_index.md
@@ -53,7 +53,7 @@ It is not recommended to run scalable mode with `filesystem` storage. For the pu
      loki:
        schemaConfig:
          configs:
-           - from: 2024-04-01
+           - from: "2024-04-01"
              store: tsdb
              object_store: s3
              schema: v13
@@ -138,7 +138,7 @@ When deploying Loki using S3 Storage **DO NOT** use the default bucket names;  `
 loki:
   schemaConfig:
     configs:
-      - from: 2024-04-01
+      - from: "2024-04-01"
         store: tsdb
         object_store: s3
         schema: v13


### PR DESCRIPTION
**What this PR does / why we need it**:
The `from` field in schema configurations need to be quoted in the Helm values file, otherwise a time portion is added on a Helm install leading to errors. The documentation shows examples without quotes.

**Which issue(s) this PR fixes**:
No recorded issue, this is a minor fix to the documentation that has been added for other deployment modes already.

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [ ] ~~Tests updated~~
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] ~~Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`~~
- [ ] ~~For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)~~
- [ ] ~~If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)~~
