### PR TITLE
perf(blooms): Allocate encoding buffers with target size

### DIFF
--- a/pkg/storage/bloom/v1/builder.go
+++ b/pkg/storage/bloom/v1/builder.go
@@ -94,8 +94,9 @@ type PageWriter struct {
 }
 
 func NewPageWriter(targetSize int) PageWriter {
+	enc := encoding.EncWith(make([]byte, 0, targetSize))
 	return PageWriter{
-		enc:        &encoding.Encbuf{},
+		enc:        &enc,
 		targetSize: targetSize,
 	}
 }
@@ -128,7 +129,7 @@ func (w *PageWriter) writePage(writer io.Writer, pool chunkenc.WriterPool, crc32
 	w.enc.PutBE64(uint64(w.n))
 	decompressedLen := w.enc.Len()
 
-	buf := &bytes.Buffer{}
+	buf := bytes.NewBuffer(make([]byte, 0, w.enc.Len()))
 	compressor := pool.GetWriter(buf)
 	defer pool.PutWriter(compressor)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Avoid costly `growSlice` function.

Profile from one of the bloom compactors:

![screenshot_20240712_153429](https://github.com/user-attachments/assets/dd03c977-c705-41b8-a22b-9a38c4aa352f)


**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
