### PR TITLE
feat: Add metrics for Ingester RF-1

### DIFF
--- a/pkg/ingester-rf1/flush.go
+++ b/pkg/ingester-rf1/flush.go
@@ -41,7 +41,7 @@ const (
 func (i *Ingester) InitFlushQueues() {
 	i.flushQueuesDone.Add(i.cfg.ConcurrentFlushes)
 	for j := 0; j < i.cfg.ConcurrentFlushes; j++ {
-		i.flushQueues[j] = util.NewPriorityQueue(i.metrics.flushQueueLength)
+		i.flushQueues[j] = util.NewPriorityQueue(i.metrics.flushQueues)
 		go i.flushLoop(j)
 	}
 }
@@ -107,14 +107,15 @@ func (i *Ingester) flushLoop(j int) {
 		start := time.Now()
 
 		// We'll use this to log the size of the segment that was flushed.
-		n := humanize.Bytes(uint64(op.it.Writer.InputSize()))
+		n := op.it.Writer.InputSize()
+		humanized := humanize.Bytes(uint64(n))
 
 		err := i.flushOp(l, op)
 		d := time.Since(start)
 		if err != nil {
-			level.Error(l).Log("msg", "failed to flush", "size", n, "duration", d, "err", err)
+			level.Error(l).Log("msg", "failed to flush", "size", humanized, "duration", d, "err", err)
 		} else {
-			level.Debug(l).Log("msg", "flushed", "size", n, "duration", d)
+			level.Debug(l).Log("msg", "flushed", "size", humanized, "duration", d)
 		}
 
 		op.it.Result.SetDone(err)
@@ -146,14 +147,21 @@ func (i *Ingester) flushOp(l log.Logger, op *flushOp) error {
 func (i *Ingester) flushSegment(ctx context.Context, ch *wal.SegmentWriter) error {
 	reader := ch.Reader()
 	defer runutil.CloseWithLogOnErr(util_log.Logger, reader, "flushSegment")
-
 	newUlid := ulid.MustNew(ulid.Timestamp(time.Now()), rand.Reader)
 
+	start := time.Now()
+	defer func() {
+		i.metrics.flushDuration.Observe(time.Since(start).Seconds())
+	}()
+
+	// TODO: observe flush size, not just segment size
+	i.metrics.segmentSize.Observe(float64(ch.InputSize()) / 1024 / 1024)
+
+	i.metrics.flushesTotal.Add(1)
 	if err := i.store.PutObject(ctx, fmt.Sprintf("loki-v2/wal/anon/"+newUlid.String()), reader); err != nil {
-		i.metrics.chunksFlushFailures.Inc()
+		i.metrics.flushFailuresTotal.Inc()
 		return fmt.Errorf("store put chunk: %w", err)
 	}
-	i.metrics.flushedChunksStats.Inc(1)
-	// TODO: report some flush metrics
+
 	return nil
 }

--- a/pkg/ingester-rf1/flush.go
+++ b/pkg/ingester-rf1/flush.go
@@ -155,7 +155,7 @@ func (i *Ingester) flushSegment(ctx context.Context, ch *wal.SegmentWriter) erro
 	}()
 
 	// TODO: observe flush size, not just segment size
-	i.metrics.segmentSize.Observe(float64(ch.InputSize()) / 1024 / 1024)
+	i.metrics.segmentSize.Observe(float64(ch.InputSize()))
 
 	i.metrics.flushesTotal.Add(1)
 	if err := i.store.PutObject(ctx, fmt.Sprintf("loki-v2/wal/anon/"+newUlid.String()), reader); err != nil {

--- a/pkg/ingester-rf1/ingester.go
+++ b/pkg/ingester-rf1/ingester.go
@@ -251,7 +251,7 @@ func New(cfg Config, clientConfig client.Config,
 	}
 	compressionStats.Set(cfg.ChunkEncoding)
 	targetSizeStats.Set(int64(cfg.TargetChunkSize))
-	metrics := newIngesterMetrics(registerer, metricsNamespace)
+	metrics := newIngesterMetrics(registerer)
 
 	walManager, err := wal.NewManager(wal.Config{
 		MaxAge:         wal.DefaultMaxAge,

--- a/pkg/ingester-rf1/metrics.go
+++ b/pkg/ingester-rf1/metrics.go
@@ -25,9 +25,10 @@ func newIngesterMetrics(r prometheus.Registerer, metricsNamespace string) *inges
 			Help: "Total number of ingesters automatically forgotten",
 		}),
 		flushDuration: promauto.With(r).NewHistogram(prometheus.HistogramOpts{
-			Name:    "loki_ingester_rf1_flush_duration",
-			Help:    "The flush duration (in seconds)",
-			Buckets: []float64{0.1, 0.2, 0.5, 1, 2.5, 5, 7.5, 10},
+			Name:                        "loki_ingester_rf1_flush_duration_seconds",
+			Help:                        "The flush duration (in seconds)",
+			Buckets:                     prometheus.ExponentialBuckets(0.001, 4, 8),
+			NativeHistogramBucketFactor: 1.1,
 		}),
 		flushFailuresTotal: promauto.With(r).NewCounter(prometheus.CounterOpts{
 			Name: "loki_ingester_rf1_flush_failures_total",
@@ -42,18 +43,20 @@ func newIngesterMetrics(r prometheus.Registerer, metricsNamespace string) *inges
 			Help: "The total number of flush queues.",
 		}),
 		flushSize: promauto.With(r).NewHistogram(prometheus.HistogramOpts{
-			Name:    "loki_ingester_rf1_flush_size_megabytes",
-			Help:    "The flush size (as written to object storage).",
-			Buckets: []float64{0.1, 0.5, 1, 2.5, 5, 7.5, 10},
+			Name:                        "loki_ingester_rf1_flush_size_bytes",
+			Help:                        "The flush size (as written to object storage).",
+			Buckets:                     prometheus.ExponentialBuckets(100, 10, 8),
+			NativeHistogramBucketFactor: 1.1,
 		}),
 		limiterEnabled: promauto.With(r).NewGauge(prometheus.GaugeOpts{
 			Name: "loki_ingester_rf1_limiter_enabled",
 			Help: "1 if the limiter is enabled, otherwise 0.",
 		}),
 		segmentSize: promauto.With(r).NewHistogram(prometheus.HistogramOpts{
-			Name:    "loki_ingester_rf1_segment_size_megabytes",
-			Help:    "The segment size (uncompressed in memory).",
-			Buckets: []float64{0.1, 0.5, 1, 2.5, 5, 7.5, 10},
+			Name:                        "loki_ingester_rf1_segment_size_bytes",
+			Help:                        "The segment size (uncompressed in memory).",
+			Buckets:                     prometheus.ExponentialBuckets(100, 10, 8),
+			NativeHistogramBucketFactor: 1.1,
 		}),
 		shutdownMarker: promauto.With(r).NewGauge(prometheus.GaugeOpts{
 			Name: "loki_ingester_rf1_shutdown_marker",

--- a/pkg/ingester-rf1/metrics.go
+++ b/pkg/ingester-rf1/metrics.go
@@ -3,55 +3,61 @@ package ingesterrf1
 import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-
-	"github.com/grafana/loki/v3/pkg/analytics"
-	"github.com/grafana/loki/v3/pkg/util/constants"
 )
 
 type ingesterMetrics struct {
-	limiterEnabled                    prometheus.Gauge
 	autoForgetUnhealthyIngestersTotal prometheus.Counter
-	chunksFlushFailures               prometheus.Counter
-	chunksFlushedPerReason            *prometheus.CounterVec
-	flushedChunksStats                *analytics.Counter
-	flushQueueLength                  prometheus.Gauge
-
-	// Shutdown marker for ingester scale down
+	flushDuration                     prometheus.Histogram
+	flushFailuresTotal                prometheus.Counter
+	flushesTotal                      prometheus.Counter
+	flushQueues                       prometheus.Gauge
+	flushSize                         prometheus.Histogram
+	limiterEnabled                    prometheus.Gauge
+	segmentSize                       prometheus.Histogram
+	// Shutdown marker for ingester scale down.
 	shutdownMarker prometheus.Gauge
 }
 
 func newIngesterMetrics(r prometheus.Registerer, metricsNamespace string) *ingesterMetrics {
 	return &ingesterMetrics{
-		limiterEnabled: promauto.With(r).NewGauge(prometheus.GaugeOpts{
-			Name: "loki_ingester_rf1_limiter_enabled",
-			Help: "Whether the ingester's limiter is enabled",
-		}),
 		autoForgetUnhealthyIngestersTotal: promauto.With(r).NewCounter(prometheus.CounterOpts{
 			Name: "loki_ingester_rf1_autoforget_unhealthy_ingesters_total",
 			Help: "Total number of ingesters automatically forgotten",
 		}),
-		chunksFlushFailures: promauto.With(r).NewCounter(prometheus.CounterOpts{
-			Namespace: constants.Loki,
-			Name:      "ingester_rf1_chunks_flush_failures_total",
-			Help:      "Total number of flush failures.",
+		flushDuration: promauto.With(r).NewHistogram(prometheus.HistogramOpts{
+			Name:    "loki_ingester_rf1_flush_duration",
+			Help:    "The flush duration (in seconds)",
+			Buckets: []float64{0.1, 0.2, 0.5, 1, 2.5, 5, 7.5, 10},
 		}),
-		chunksFlushedPerReason: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
-			Namespace: constants.Loki,
-			Name:      "ingester_rf1_chunks_flushed_total",
-			Help:      "Total flushed chunks per reason.",
-		}, []string{"reason"}),
-		flushedChunksStats: analytics.NewCounter("ingester_rf1_flushed_chunks"),
-		flushQueueLength: promauto.With(r).NewGauge(prometheus.GaugeOpts{
-			Namespace: metricsNamespace,
-			Subsystem: "ingester_rf1",
-			Name:      "flush_queue_length",
-			Help:      "The total number of series pending in the flush queue.",
+		flushFailuresTotal: promauto.With(r).NewCounter(prometheus.CounterOpts{
+			Name: "loki_ingester_rf1_flush_failures_total",
+			Help: "The total number of failed flushes.",
+		}),
+		flushesTotal: promauto.With(r).NewCounter(prometheus.CounterOpts{
+			Name: "loki_ingester_rf1_flushes_total",
+			Help: "The total number of flushes.",
+		}),
+		flushQueues: promauto.With(r).NewGauge(prometheus.GaugeOpts{
+			Name: "loki_ingester_rf1_flush_queues",
+			Help: "The total number of flush queues.",
+		}),
+		flushSize: promauto.With(r).NewHistogram(prometheus.HistogramOpts{
+			Name:    "loki_ingester_rf1_flush_size_megabytes",
+			Help:    "The flush size (as written to object storage).",
+			Buckets: []float64{0.1, 0.5, 1, 2.5, 5, 7.5, 10},
+		}),
+		limiterEnabled: promauto.With(r).NewGauge(prometheus.GaugeOpts{
+			Name: "loki_ingester_rf1_limiter_enabled",
+			Help: "1 if the limiter is enabled, otherwise 0.",
+		}),
+		segmentSize: promauto.With(r).NewHistogram(prometheus.HistogramOpts{
+			Name:    "loki_ingester_rf1_segment_size_megabytes",
+			Help:    "The segment size (uncompressed in memory).",
+			Buckets: []float64{0.1, 0.5, 1, 2.5, 5, 7.5, 10},
 		}),
 		shutdownMarker: promauto.With(r).NewGauge(prometheus.GaugeOpts{
-			Namespace: constants.Loki,
-			Subsystem: "ingester_rf1",
-			Name:      "shutdown_marker",
-			Help:      "1 if prepare shutdown has been called, 0 otherwise",
+			Name: "loki_ingester_rf1_shutdown_marker",
+			Help: "1 if prepare shutdown has been called, 0 otherwise",
 		}),
 	}
 }

--- a/pkg/ingester-rf1/metrics.go
+++ b/pkg/ingester-rf1/metrics.go
@@ -5,62 +5,65 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
-type ingesterMetrics struct {
-	autoForgetUnhealthyIngestersTotal prometheus.Counter
-	flushDuration                     prometheus.Histogram
-	flushFailuresTotal                prometheus.Counter
-	flushesTotal                      prometheus.Counter
-	flushQueues                       prometheus.Gauge
-	flushSize                         prometheus.Histogram
-	limiterEnabled                    prometheus.Gauge
-	segmentSize                       prometheus.Histogram
-	// Shutdown marker for ingester scale down.
-	shutdownMarker prometheus.Gauge
+type flushMetrics struct {
+	flushesTotal       prometheus.Counter
+	flushFailuresTotal prometheus.Counter
+	flushQueues        prometheus.Gauge
+	flushDuration      prometheus.Histogram
+	flushSizeBytes     prometheus.Histogram
 }
 
-func newIngesterMetrics(r prometheus.Registerer, metricsNamespace string) *ingesterMetrics {
-	return &ingesterMetrics{
-		autoForgetUnhealthyIngestersTotal: promauto.With(r).NewCounter(prometheus.CounterOpts{
-			Name: "loki_ingester_rf1_autoforget_unhealthy_ingesters_total",
-			Help: "Total number of ingesters automatically forgotten",
-		}),
-		flushDuration: promauto.With(r).NewHistogram(prometheus.HistogramOpts{
-			Name:                        "loki_ingester_rf1_flush_duration_seconds",
-			Help:                        "The flush duration (in seconds)",
-			Buckets:                     prometheus.ExponentialBuckets(0.001, 4, 8),
-			NativeHistogramBucketFactor: 1.1,
+func newFlushMetrics(r prometheus.Registerer) *flushMetrics {
+	return &flushMetrics{
+		flushesTotal: promauto.With(r).NewCounter(prometheus.CounterOpts{
+			Name: "loki_ingester_rf1_flushes_total",
+			Help: "The total number of flushes.",
 		}),
 		flushFailuresTotal: promauto.With(r).NewCounter(prometheus.CounterOpts{
 			Name: "loki_ingester_rf1_flush_failures_total",
 			Help: "The total number of failed flushes.",
 		}),
-		flushesTotal: promauto.With(r).NewCounter(prometheus.CounterOpts{
-			Name: "loki_ingester_rf1_flushes_total",
-			Help: "The total number of flushes.",
-		}),
 		flushQueues: promauto.With(r).NewGauge(prometheus.GaugeOpts{
 			Name: "loki_ingester_rf1_flush_queues",
 			Help: "The total number of flush queues.",
 		}),
-		flushSize: promauto.With(r).NewHistogram(prometheus.HistogramOpts{
+		flushDuration: promauto.With(r).NewHistogram(prometheus.HistogramOpts{
+			Name:                        "loki_ingester_rf1_flush_duration_seconds",
+			Help:                        "The flush duration (in seconds).",
+			Buckets:                     prometheus.ExponentialBuckets(0.001, 4, 8),
+			NativeHistogramBucketFactor: 1.1,
+		}),
+		flushSizeBytes: promauto.With(r).NewHistogram(prometheus.HistogramOpts{
 			Name:                        "loki_ingester_rf1_flush_size_bytes",
 			Help:                        "The flush size (as written to object storage).",
 			Buckets:                     prometheus.ExponentialBuckets(100, 10, 8),
 			NativeHistogramBucketFactor: 1.1,
 		}),
+	}
+}
+
+type ingesterMetrics struct {
+	autoForgetUnhealthyIngestersTotal prometheus.Counter
+	limiterEnabled                    prometheus.Gauge
+	// Shutdown marker for ingester scale down.
+	shutdownMarker prometheus.Gauge
+	*flushMetrics
+}
+
+func newIngesterMetrics(r prometheus.Registerer) *ingesterMetrics {
+	return &ingesterMetrics{
+		autoForgetUnhealthyIngestersTotal: promauto.With(r).NewCounter(prometheus.CounterOpts{
+			Name: "loki_ingester_rf1_autoforget_unhealthy_ingesters_total",
+			Help: "Total number of ingesters automatically forgotten.",
+		}),
 		limiterEnabled: promauto.With(r).NewGauge(prometheus.GaugeOpts{
 			Name: "loki_ingester_rf1_limiter_enabled",
 			Help: "1 if the limiter is enabled, otherwise 0.",
 		}),
-		segmentSize: promauto.With(r).NewHistogram(prometheus.HistogramOpts{
-			Name:                        "loki_ingester_rf1_segment_size_bytes",
-			Help:                        "The segment size (uncompressed in memory).",
-			Buckets:                     prometheus.ExponentialBuckets(100, 10, 8),
-			NativeHistogramBucketFactor: 1.1,
-		}),
 		shutdownMarker: promauto.With(r).NewGauge(prometheus.GaugeOpts{
 			Name: "loki_ingester_rf1_shutdown_marker",
-			Help: "1 if prepare shutdown has been called, 0 otherwise",
+			Help: "1 if prepare shutdown has been called, 0 otherwise.",
 		}),
+		flushMetrics: newFlushMetrics(r),
 	}
 }

--- a/pkg/storage/wal/metrics.go
+++ b/pkg/storage/wal/metrics.go
@@ -1,0 +1,77 @@
+package wal
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+type ManagerMetrics struct {
+	NumAvailable prometheus.Gauge
+	NumPending   prometheus.Gauge
+	NumFlushing  prometheus.Gauge
+}
+
+func NewManagerMetrics(r prometheus.Registerer) *ManagerMetrics {
+	return &ManagerMetrics{
+		NumAvailable: promauto.With(r).NewGauge(prometheus.GaugeOpts{
+			Name: "wal_segments_available",
+			Help: "The number of WAL segments accepting writes.",
+		}),
+		NumPending: promauto.With(r).NewGauge(prometheus.GaugeOpts{
+			Name: "wal_segments_pending",
+			Help: "The number of WAL segments waiting to be flushed.",
+		}),
+		NumFlushing: promauto.With(r).NewGauge(prometheus.GaugeOpts{
+			Name: "wal_segments_flushing",
+			Help: "The number of WAL segments being flushed.",
+		}),
+	}
+}
+
+type SegmentMetrics struct {
+	outputSizeBytes prometheus.Histogram
+	inputSizeBytes  prometheus.Histogram
+	streams         prometheus.Histogram
+	tenants         prometheus.Histogram
+}
+
+func NewSegmentMetrics(r prometheus.Registerer) *SegmentMetrics {
+	return &SegmentMetrics{
+		outputSizeBytes: promauto.With(r).NewHistogram(prometheus.HistogramOpts{
+			Name:                        "loki_ingester_rf1_segment_output_size_bytes",
+			Help:                        "The segment size as written to disk (compressed).",
+			Buckets:                     prometheus.ExponentialBuckets(100, 10, 8),
+			NativeHistogramBucketFactor: 1.1,
+		}),
+		inputSizeBytes: promauto.With(r).NewHistogram(prometheus.HistogramOpts{
+			Name:                        "loki_ingester_rf1_segment_input_size_bytes",
+			Help:                        "The segment size (uncompressed).",
+			Buckets:                     prometheus.ExponentialBuckets(100, 10, 8),
+			NativeHistogramBucketFactor: 1.1,
+		}),
+		streams: promauto.With(r).NewHistogram(prometheus.HistogramOpts{
+			Name:                        "loki_ingester_rf1_per_segment_streams",
+			Help:                        "The number of streams per segment.",
+			Buckets:                     prometheus.ExponentialBuckets(1, 2, 10),
+			NativeHistogramBucketFactor: 1.1,
+		}),
+		tenants: promauto.With(r).NewHistogram(prometheus.HistogramOpts{
+			Name:                        "loki_ingester_rf1_per_segment_tenants",
+			Help:                        "The number of tenants per segment.",
+			Buckets:                     prometheus.ExponentialBuckets(1, 2, 10),
+			NativeHistogramBucketFactor: 1.1,
+		}),
+	}
+}
+
+type Metrics struct {
+	SegmentMetrics *SegmentMetrics
+	ManagerMetrics *ManagerMetrics
+}
+
+func NewMetrics(r prometheus.Registerer) *Metrics {
+	return &Metrics{
+		ManagerMetrics: NewManagerMetrics(r),
+		SegmentMetrics: NewSegmentMetrics(r),
+	}
+}

--- a/pkg/storage/wal/segment.go
+++ b/pkg/storage/wal/segment.go
@@ -147,6 +147,8 @@ func (b *SegmentWriter) Append(tenantID, labelsString string, lbls labels.Labels
 	}
 }
 
+// Observe updates metrics for the writer. If called before WriteTo then the
+// output size histogram will observe 0.
 func (b *SegmentWriter) Observe() {
 	b.consistencyMtx.Lock()
 	defer b.consistencyMtx.Unlock()

--- a/pkg/storage/wal/segment.go
+++ b/pkg/storage/wal/segment.go
@@ -46,8 +46,10 @@ type streamID struct {
 }
 
 type SegmentWriter struct {
+	metrics        *SegmentMetrics
 	streams        map[streamID]*streamSegment
 	buf1           encoding.Encbuf
+	outputSize     atomic.Int64
 	inputSize      atomic.Int64
 	idxWriter      *index.Writer
 	consistencyMtx *sync.RWMutex
@@ -76,12 +78,13 @@ func (s *streamSegment) WriteTo(w io.Writer) (n int64, err error) {
 }
 
 // NewWalSegmentWriter creates a new WalSegmentWriter.
-func NewWalSegmentWriter() (*SegmentWriter, error) {
+func NewWalSegmentWriter(m *SegmentMetrics) (*SegmentWriter, error) {
 	idxWriter, err := index.NewWriter()
 	if err != nil {
 		return nil, err
 	}
 	return &SegmentWriter{
+		metrics:        m,
 		streams:        make(map[streamID]*streamSegment, 64),
 		buf1:           encoding.EncWith(make([]byte, 0, 4)),
 		idxWriter:      idxWriter,
@@ -142,6 +145,20 @@ func (b *SegmentWriter) Append(tenantID, labelsString string, lbls labels.Labels
 		copy(s.entries[idx+1:], s.entries[idx:])
 		s.entries[idx] = e
 	}
+}
+
+func (b *SegmentWriter) Observe() {
+	b.consistencyMtx.Lock()
+	defer b.consistencyMtx.Unlock()
+
+	b.metrics.streams.Observe(float64(len(b.streams)))
+	tenants := make(map[string]struct{}, len(b.streams))
+	for _, s := range b.streams {
+		tenants[s.tenantID] = struct{}{}
+	}
+	b.metrics.tenants.Observe(float64(len(tenants)))
+	b.metrics.inputSizeBytes.Observe(float64(b.inputSize.Load()))
+	b.metrics.outputSizeBytes.Observe(float64(b.outputSize.Load()))
 }
 
 func (b *SegmentWriter) WriteTo(w io.Writer) (int64, error) {
@@ -261,6 +278,8 @@ func (b *SegmentWriter) WriteTo(w io.Writer) (int64, error) {
 		return total, err
 	}
 	total += int64(n)
+
+	b.outputSize.Store(total)
 
 	return total, nil
 }

--- a/pkg/storage/wal/segment_test.go
+++ b/pkg/storage/wal/segment_test.go
@@ -105,7 +105,7 @@ func TestWalSegmentWriter_Append(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			// Create a new WalSegmentWriter
-			w, err := NewWalSegmentWriter()
+			w, err := NewWalSegmentWriter(NewSegmentMetrics(nil))
 			require.NoError(t, err)
 			// Append the entries
 			for _, batch := range tt.batches {
@@ -168,7 +168,7 @@ func BenchmarkConcurrentAppends(t *testing.B) {
 	t.ResetTimer()
 	for i := 0; i < t.N; i++ {
 		var err error
-		w, err = NewWalSegmentWriter()
+		w, err = NewWalSegmentWriter(NewSegmentMetrics(nil))
 		require.NoError(t, err)
 
 		for _, lbl := range lbls {
@@ -197,7 +197,7 @@ func TestConcurrentAppends(t *testing.T) {
 	}
 	dst := bytes.NewBuffer(nil)
 
-	w, err := NewWalSegmentWriter()
+	w, err := NewWalSegmentWriter(NewSegmentMetrics(nil))
 	require.NoError(t, err)
 	var wg sync.WaitGroup
 	workChan := make(chan *appendArgs, 100)
@@ -289,7 +289,7 @@ func TestConcurrentAppends(t *testing.T) {
 }
 
 func TestMultiTenantWrite(t *testing.T) {
-	w, err := NewWalSegmentWriter()
+	w, err := NewWalSegmentWriter(NewSegmentMetrics(nil))
 	require.NoError(t, err)
 	dst := bytes.NewBuffer(nil)
 
@@ -359,7 +359,7 @@ func TestCompression(t *testing.T) {
 }
 
 func testCompression(t *testing.T, maxInputSize int64) {
-	w, err := NewWalSegmentWriter()
+	w, err := NewWalSegmentWriter(NewSegmentMetrics(nil))
 	require.NoError(t, err)
 	dst := bytes.NewBuffer(nil)
 	files := testdata.Files()
@@ -416,7 +416,7 @@ func testCompression(t *testing.T, maxInputSize int64) {
 }
 
 func TestReset(t *testing.T) {
-	w, err := NewWalSegmentWriter()
+	w, err := NewWalSegmentWriter(NewSegmentMetrics(nil))
 	require.NoError(t, err)
 	dst := bytes.NewBuffer(nil)
 
@@ -490,7 +490,7 @@ func BenchmarkWrites(b *testing.B) {
 
 	dst := bytes.NewBuffer(make([]byte, 0, inputSize))
 
-	writer, err := NewWalSegmentWriter()
+	writer, err := NewWalSegmentWriter(NewSegmentMetrics(nil))
 	require.NoError(b, err)
 
 	for _, d := range data {


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull requests adds a number of initial metrics for Ingester RF-1.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
