### PR TITLE
fix: detected fields incorrect type bug

### DIFF
--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -1118,9 +1118,6 @@ func (q *SingleTenantQuerier) DetectedFields(ctx context.Context, req *logproto.
 
 	detectedFields := parseDetectedFields(ctx, req.FieldLimit, streams)
 
-	// TODO: detected field needs to contain the sketch
-	// make sure response to frontend is GRPC
-	// only want cardinality in JSON
 	fields := make([]*logproto.DetectedField, len(detectedFields))
 	fieldCount := 0
 	for k, v := range detectedFields {
@@ -1141,7 +1138,6 @@ func (q *SingleTenantQuerier) DetectedFields(ctx context.Context, req *logproto.
 		fieldCount++
 	}
 
-	// TODO: detected fields response needs to include the sketch
 	return &logproto.DetectedFieldsResponse{
 		Fields:     fields,
 		FieldLimit: req.GetFieldLimit(),

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -1118,9 +1118,9 @@ func (q *SingleTenantQuerier) DetectedFields(ctx context.Context, req *logproto.
 
 	detectedFields := parseDetectedFields(ctx, req.FieldLimit, streams)
 
-	//TODO: detected field needs to contain the sketch
+	// TODO: detected field needs to contain the sketch
 	// make sure response to frontend is GRPC
-	//only want cardinality in JSON
+	// only want cardinality in JSON
 	fields := make([]*logproto.DetectedField, len(detectedFields))
 	fieldCount := 0
 	for k, v := range detectedFields {
@@ -1141,7 +1141,7 @@ func (q *SingleTenantQuerier) DetectedFields(ctx context.Context, req *logproto.
 		fieldCount++
 	}
 
-	//TODO: detected fields response needs to include the sketch
+	// TODO: detected fields response needs to include the sketch
 	return &logproto.DetectedFieldsResponse{
 		Fields:     fields,
 		FieldLimit: req.GetFieldLimit(),
@@ -1218,7 +1218,6 @@ func parseDetectedFields(ctx context.Context, limit uint32, streams logqlmodel.S
 	fieldCount := uint32(0)
 
 	for _, stream := range streams {
-		detectType := true
 		level.Debug(spanlogger.FromContext(ctx)).Log(
 			"detected_fields", "true",
 			"msg", fmt.Sprintf("looking for detected fields in stream %d with %d lines", stream.Hash, len(stream.Entries)))
@@ -1241,6 +1240,7 @@ func parseDetectedFields(ctx context.Context, limit uint32, streams logqlmodel.S
 					df.parsers = append(df.parsers, *parser)
 				}
 
+				detectType := true
 				for _, v := range vals {
 					parsedFields := detectedFields[k]
 					if detectType {

--- a/pkg/querier/querier_mock_test.go
+++ b/pkg/querier/querier_mock_test.go
@@ -119,7 +119,6 @@ func (c *querierClientMock) GetDetectedLabels(ctx context.Context, in *logproto.
 		return (*logproto.LabelToValuesResponse)(nil), args.Error(1)
 	}
 	return res.(*logproto.LabelToValuesResponse), args.Error(1)
-
 }
 
 func (c *querierClientMock) GetVolume(ctx context.Context, in *logproto.VolumeRequest, opts ...grpc.CallOption) (*logproto.VolumeResponse, error) {
@@ -572,7 +571,14 @@ func mockLogfmtStreamWithLabels(from int, quantity int, labels string) logproto.
 	for i := quantity; i > 0; i-- {
 		entries = append(entries, logproto.Entry{
 			Timestamp: time.Unix(int64(i), 0),
-			Line:      fmt.Sprintf(`message="line %d" count=%d fake=true`, i, i),
+			Line: fmt.Sprintf(
+				`message="line %d" count=%d fake=true bytes=%dMB duration=%dms percent=%f even=%t`,
+				i,
+				i,
+				(i * 10),
+				(i * 256),
+				float32(i*10.0),
+				(i%2 == 0)),
 		})
 	}
 

--- a/pkg/querier/querier_mock_test.go
+++ b/pkg/querier/querier_mock_test.go
@@ -7,8 +7,9 @@ import (
 	"math"
 	"time"
 
-	"github.com/grafana/loki/pkg/push"
 	"github.com/grafana/loki/v3/pkg/logql/log"
+
+	"github.com/grafana/loki/pkg/push"
 
 	"github.com/grafana/loki/v3/pkg/loghttp"
 
@@ -564,7 +565,7 @@ func mockLogfmtStream(from int, quantity int) logproto.Stream {
 	return mockLogfmtStreamWithLabels(from, quantity, `{type="test"}`)
 }
 
-func mockLogfmtStreamWithLabels(from int, quantity int, labels string) logproto.Stream {
+func mockLogfmtStreamWithLabels(_ int, quantity int, labels string) logproto.Stream {
 	entries := make([]logproto.Entry, 0, quantity)
 
 	// used for detected fields queries which are always BACKWARD

--- a/pkg/querier/querier_test.go
+++ b/pkg/querier/querier_test.go
@@ -1718,11 +1718,11 @@ func TestQuerier_DetectedFields(t *testing.T) {
 	t.Run("returns detected fields from queried logs", func(t *testing.T) {
 		store := newStoreMock()
 		store.On("SelectLogs", mock.Anything, mock.Anything).
-			Return(mockLogfmtStreamIterator(1, 2), nil)
+			Return(mockLogfmtStreamIterator(1, 5), nil)
 
 		queryClient := newQueryClientMock()
 		queryClient.On("Recv").
-			Return(mockQueryResponse([]logproto.Stream{mockLogfmtStream(1, 2)}), nil)
+			Return(mockQueryResponse([]logproto.Stream{mockLogfmtStream(1, 5)}), nil)
 
 		ingesterClient := newQuerierClientMock()
 		ingesterClient.On("Query", mock.Anything, mock.Anything, mock.Anything).
@@ -1741,8 +1741,18 @@ func TestQuerier_DetectedFields(t *testing.T) {
 		require.NoError(t, err)
 
 		detectedFields := resp.Fields
-		assert.Len(t, detectedFields, 3)
-		expectedCardinality := map[string]uint64{"message": 2, "count": 2, "fake": 1}
+		// log lines come from querier_mock_test.go
+		// message="line %d" count=%d fake=true bytes=%dMB duration=%dms percent=%f even=%t
+		assert.Len(t, detectedFields, 7)
+		expectedCardinality := map[string]uint64{
+			"message":  5,
+			"count":    5,
+			"fake":     1,
+			"bytes":    5,
+			"duration": 5,
+			"percent":  5,
+			"even":     2,
+		}
 		for _, d := range detectedFields {
 			card := expectedCardinality[d.Label]
 			assert.Equal(t, card, d.Cardinality, "Expected cardinality mismatch for: %s", d.Label)


### PR DESCRIPTION
**What this PR does / why we need it**:

This fixes a bug with the detected fields endpoint that was incorrectly determining the type of some fields. It also adds benchmarks for detected fields.

**Which issue(s) this PR fixes**:
Fixes #13455