### PR TITLE
feat(loki): add support for sts endpoint when using s3 buckets

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -1049,6 +1049,11 @@ dynamodb:
 # CLI flag: -s3.endpoint
 [endpoint: <string> | default = ""]
 
+# Accessing S3 resources using temporary, secure credentials provided by AWS
+# Security Token Service.
+# CLI flag: -s3.sts-endpoint
+[sts_endpoint: <string> | default = ""]
+
 # AWS region to use.
 # CLI flag: -s3.region
 [region: <string> | default = ""]
@@ -4964,6 +4969,11 @@ The `s3_storage_config` block configures the connection to Amazon S3 object stor
 # S3 Endpoint to connect to.
 # CLI flag: -<prefix>.storage.s3.endpoint
 [endpoint: <string> | default = ""]
+
+# Accessing S3 resources using temporary, secure credentials provided by AWS
+# Security Token Service.
+# CLI flag: -<prefix>.storage.s3.sts-endpoint
+[sts_endpoint: <string> | default = ""]
 
 # AWS region to use.
 # CLI flag: -<prefix>.storage.s3.region

--- a/pkg/storage/bucket/s3/bucket_client.go
+++ b/pkg/storage/bucket/s3/bucket_client.go
@@ -42,6 +42,7 @@ func newS3Config(cfg Config) (s3.Config, error) {
 		Bucket:          cfg.BucketName,
 		Endpoint:        cfg.Endpoint,
 		Region:          cfg.Region,
+		STSEndpoint:     cfg.STSEndpoint,
 		AccessKey:       cfg.AccessKeyID,
 		SecretKey:       cfg.SecretAccessKey.String(),
 		SessionToken:    cfg.SessionToken.String(),

--- a/pkg/util/http.go
+++ b/pkg/util/http.go
@@ -298,3 +298,12 @@ func FlagFromValues(values url.Values, key string, d bool) bool {
 		return d
 	}
 }
+
+func IsValidURL(endpoint string) bool {
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return false
+	}
+
+	return u.Scheme != "" && u.Host != ""
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR introduces the ability to override the sts endpoint used to authenticate with the AWS sdk / thanos s3 provider. It also provides a path to use STS authentication with minio operator.

As a note for those who try the minio operator STS auth: the AWS SDK adds a trailing slash when calling STS endpoint, which will cause the auth call to fail with 404. An nginx proxy can fix this the following config:
```
    location /sts/platform/ {
      resolver kube-dns.kube-system.svc.cluster.local;

      # Forward the request to the upstream server
      proxy_pass https://<ACTUAL ADDRESS OF THE STS SERVICE FOR MINIO OPERATOR>;
      proxy_set_header Host $host;
      proxy_set_header X-Real-IP $remote_addr;
      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
      proxy_set_header X-Forwarded-Proto $scheme;

      # Preserve the original request method
      proxy_method $request_method;
    }
```


**Which issue(s) this PR fixes**:
Fixes #10751

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`]
(https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
