### PR TITLE
docs: Add Explore Logs to Release Notes

### DIFF
--- a/docs/sources/release-notes/v3-1.md
+++ b/docs/sources/release-notes/v3-1.md
@@ -22,6 +22,8 @@ Key features in Loki 3.1.0 include the following:
 
 - **lokitool:** Add `lokitool` to replace `cortextool`. ([#12166](https://github.com/grafana/loki/issues/12166)) ([7b7d3d4](https://github.com/grafana/loki/commit/7b7d3d4cd2c979c778d3741156f0d765a9e531b2)). Introduce `index audit` to `lokitool` ([#13008](https://github.com/grafana/loki/issues/13008)) ([47f0236](https://github.com/grafana/loki/commit/47f0236ea8f33a67a0a1abf6e6d6b3582661c4ba)).
 
+- **Explore Logs:** Explore Logs, which lets you explore your Loki data without writing LogQL queries, is now available in public preview. If you are a Grafana Cloud user, you can access Explore Logs in the Grafana Cloud main navigation menu. If you are not a Grafana Cloud user, you can install the [Explore Logs plugin](https://grafana.com/docs/grafana-cloud/visualizations/simplified-exploration/logs/access/).  For more information, refer to the [Explore Logs documentation](https://grafana.com/docs/grafana-cloud/visualizations/simplified-exploration/logs/).
+
 - **Docs:** Added a video to the Getting Started demo and updated for Grafana Alloy. Added an interactive sandbox to the Loki Quickstart tutorial. Updated the documentation for the SSD and microservices deployment modes using the Helm charts.  Documented the new meta-monitoring Helm chart.
 
 Other improvements include the following:


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates the Loki Release Notes to mention Explore Logs now that it is public preview.