### PR TITLE
chore: Use pool of bytes.Buffer instead of io.Pipe

### DIFF
--- a/pkg/ingester-rf1/ingester.go
+++ b/pkg/ingester-rf1/ingester.go
@@ -1,6 +1,7 @@
 package ingesterrf1
 
 import (
+	"bytes"
 	"context"
 	"flag"
 	"fmt"
@@ -205,6 +206,7 @@ type Ingester struct {
 
 	// One queue per flush thread.  Fingerprint is used to
 	// pick a queue.
+	flushBuffers     sync.Pool
 	flushWorkersDone sync.WaitGroup
 
 	wal *wal.Manager
@@ -272,6 +274,7 @@ func New(cfg Config, clientConfig client.Config,
 		instances:        map[string]*instance{},
 		store:            storage,
 		periodicConfigs:  periodConfigs,
+		flushBuffers:     sync.Pool{New: func() any { return new(bytes.Buffer) }},
 		flushWorkersDone: sync.WaitGroup{},
 		tailersQuit:      make(chan struct{}),
 		metrics:          metrics,

--- a/pkg/ingester-rf1/ingester.go
+++ b/pkg/ingester-rf1/ingester.go
@@ -206,7 +206,7 @@ type Ingester struct {
 
 	// One queue per flush thread.  Fingerprint is used to
 	// pick a queue.
-	flushBuffers     sync.Pool
+	flushBuffers     []*bytes.Buffer
 	flushWorkersDone sync.WaitGroup
 
 	wal *wal.Manager
@@ -274,7 +274,6 @@ func New(cfg Config, clientConfig client.Config,
 		instances:        map[string]*instance{},
 		store:            storage,
 		periodicConfigs:  periodConfigs,
-		flushBuffers:     sync.Pool{New: func() any { return new(bytes.Buffer) }},
 		flushWorkersDone: sync.WaitGroup{},
 		tailersQuit:      make(chan struct{}),
 		metrics:          metrics,

--- a/pkg/storage/wal/segment.go
+++ b/pkg/storage/wal/segment.go
@@ -299,32 +299,6 @@ func (b *SegmentWriter) Reset() {
 	b.inputSize.Store(0)
 }
 
-type EncodedSegmentReader struct {
-	*io.PipeReader
-	*io.PipeWriter
-}
-
-func (e *EncodedSegmentReader) Close() error {
-	err := e.PipeWriter.Close()
-	if err != nil {
-		return err
-	}
-	err = e.PipeReader.Close()
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func (b *SegmentWriter) Reader() io.ReadCloser {
-	pr, pw := io.Pipe()
-	go func() {
-		_, err := b.WriteTo(pw)
-		pw.CloseWithError(err)
-	}()
-	return &EncodedSegmentReader{PipeReader: pr, PipeWriter: pw}
-}
-
 // InputSize returns the total size of the input data written to the writer.
 // It doesn't account for timestamps and labels.
 func (b *SegmentWriter) InputSize() int64 {

--- a/pkg/storage/wal/segment_test.go
+++ b/pkg/storage/wal/segment_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io"
 	"sort"
 	"sync"
 	"testing"
@@ -508,21 +507,6 @@ func BenchmarkWrites(b *testing.B) {
 			n, err := writer.WriteTo(dst)
 			require.NoError(b, err)
 			require.EqualValues(b, encodedLength, n)
-		}
-	})
-
-	bytesBuf := make([]byte, encodedLength)
-	b.Run("Reader", func(b *testing.B) {
-		b.ResetTimer()
-		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
-			var err error
-			reader := writer.Reader()
-
-			n, err := io.ReadFull(reader, bytesBuf)
-			require.NoError(b, err)
-			require.EqualValues(b, encodedLength, n)
-			require.NoError(b, reader.Close())
 		}
 	})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR uses a pool of `bytes.Buffer` instead of `io.Pipe`.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
