### PR TITLE
chore: Remove size and duration logs now we have metrics

### DIFF
--- a/pkg/ingester-rf1/flush.go
+++ b/pkg/ingester-rf1/flush.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/dustin/go-humanize"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/backoff"
@@ -84,18 +83,9 @@ func (i *Ingester) flushWorker(j int) {
 			continue
 		}
 
-		start := time.Now()
-
-		// We'll use this to log the size of the segment that was flushed.
-		n := it.Writer.InputSize()
-		humanized := humanize.Bytes(uint64(n))
-
 		err = i.flushItem(l, j, it)
-		d := time.Since(start)
 		if err != nil {
-			level.Error(l).Log("msg", "failed to flush", "size", humanized, "duration", d, "err", err)
-		} else {
-			level.Debug(l).Log("msg", "flushed", "size", humanized, "duration", d)
+			level.Error(l).Log("msg", "failed to flush", "err", err)
 		}
 
 		it.Result.SetDone(err)


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes size and duration logs now we have metrics.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
