### PR TITLE
chore: Remove redundant comments

### DIFF
--- a/pkg/storage/wal/manager.go
+++ b/pkg/storage/wal/manager.go
@@ -102,21 +102,14 @@ type Manager struct {
 	cfg       Config
 	metrics   *ManagerMetrics
 	available *list.List
-
-	// pending is a list of segments that are waiting to be flushed. Once
-	// flushed, the segment is reset and moved to the back of the available
-	// list to accept writes again.
-	pending *list.List
-
+	pending   *list.List
 	// firstAppend is the time of the first append to the segment at the
 	// front of the available list. It is used to know when the segment has
 	// exceeded the maximum age and should be moved to the pending list.
 	// It is reset each time this happens.
 	firstAppend time.Time
-
-	closed bool
-	mu     sync.Mutex
-
+	closed      bool
+	mu          sync.Mutex
 	// Used in tests.
 	clock quartz.Clock
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes redundant comments for `pending` variable since it's explained above in the comments for `Manager` struct.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
