### PR TITLE
feat: Update doc-validator version

### DIFF
--- a/.github/workflows/doc-validator.yml
+++ b/.github/workflows/doc-validator.yml
@@ -7,7 +7,7 @@ jobs:
   doc-validator:
     runs-on: "ubuntu-latest"
     container:
-      image: "grafana/doc-validator:v5.0.0"
+      image: "grafana/doc-validator:v5.1.0"
     steps:
       - name: "Checkout code"
         uses: "actions/checkout@v4"


### PR DESCRIPTION
https://github.com/grafana/technical-documentation/releases/tag/doc-validator%2Fv5.1.0

**What this PR does / why we need it**:

Includes the fix for large GitHub diffs reported in https://github.com/reviewdog/reviewdog/issues/1696.

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/loki/actions/runs/9974973142/job/27563623135?pr=13550
