### PR TITLE
chore: Add readiness check to query-scheduler + increase mem

### DIFF
--- a/production/ksonnet/loki/query-scheduler.libsonnet
+++ b/production/ksonnet/loki/query-scheduler.libsonnet
@@ -1,4 +1,5 @@
 local k = import 'ksonnet-util/kausal.libsonnet';
+local loki = import 'github.com/grafana/loki/production/ksonnet/loki/loki.libsonnet';
 
 {
   local max_outstanding = if $._config.queryFrontend.sharded_queries_enabled then 1024 else 256,
@@ -40,9 +41,10 @@ local k = import 'ksonnet-util/kausal.libsonnet';
     container.withPorts($.query_scheduler_ports) +
     container.withArgsMixin(k.util.mapToFlags($.query_scheduler_args)) +
     $.jaeger_mixin +
-    k.util.resourcesRequests('2', '600Mi') +
-    k.util.resourcesLimits(null, '1200Mi') +
-    container.withEnvMixin($._config.commonEnvs)
+    k.util.resourcesRequests('2', '800Mi') +
+    k.util.resourcesLimits(null, '1600Mi') +
+    container.withEnvMixin($._config.commonEnvs) +
+    loki.util.readinessProbe
   else {},
 
   local deployment = k.apps.v1.deployment,

--- a/production/ksonnet/loki/query-scheduler.libsonnet
+++ b/production/ksonnet/loki/query-scheduler.libsonnet
@@ -1,5 +1,5 @@
-local k = import 'ksonnet-util/kausal.libsonnet';
 local loki = import 'github.com/grafana/loki/production/ksonnet/loki/loki.libsonnet';
+local k = import 'ksonnet-util/kausal.libsonnet';
 
 {
   local max_outstanding = if $._config.queryFrontend.sharded_queries_enabled then 1024 else 256,


### PR DESCRIPTION
**What this PR does / why we need it**:
* Increase the default memory request & limit for the query-scheduler
* Set up a readiness probe to check the query-scheduler is ready before sending traffic to it & triggering termination of another pod.