### PR TITLE
chore: adding retries to stats calls in our limits and sharding middlewares.

### DIFF
--- a/pkg/querier/queryrange/limits_test.go
+++ b/pkg/querier/queryrange/limits_test.go
@@ -697,8 +697,8 @@ func Test_MaxQuerySize(t *testing.T) {
 			ctx := user.InjectOrgID(context.Background(), "foo")
 
 			middlewares := []base.Middleware{
-				NewQuerySizeLimiterMiddleware(schemas, testEngineOpts, util_log.Logger, tc.limits, queryStatsHandler),
-				NewQuerierSizeLimiterMiddleware(schemas, testEngineOpts, util_log.Logger, tc.limits, querierStatsHandler),
+				NewQuerySizeLimiterMiddleware(schemas, testEngineOpts, util_log.Logger, tc.limits, 0, queryStatsHandler),
+				NewQuerierSizeLimiterMiddleware(schemas, testEngineOpts, util_log.Logger, tc.limits, 0, querierStatsHandler),
 			}
 
 			_, err := base.MergeMiddlewares(middlewares...).Wrap(promHandler).Do(ctx, lokiReq)
@@ -742,11 +742,11 @@ func Test_MaxQuerySize_MaxLookBackPeriod(t *testing.T) {
 	}{
 		{
 			desc:       "QuerySizeLimiter",
-			middleware: NewQuerySizeLimiterMiddleware(testSchemasTSDB, engineOpts, util_log.Logger, lim, statsHandler),
+			middleware: NewQuerySizeLimiterMiddleware(testSchemasTSDB, engineOpts, util_log.Logger, lim, 0, statsHandler),
 		},
 		{
 			desc:       "QuerierSizeLimiter",
-			middleware: NewQuerierSizeLimiterMiddleware(testSchemasTSDB, engineOpts, util_log.Logger, lim, statsHandler),
+			middleware: NewQuerierSizeLimiterMiddleware(testSchemasTSDB, engineOpts, util_log.Logger, lim, 0, statsHandler),
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {

--- a/pkg/querier/queryrange/queryrangebase/retry.go
+++ b/pkg/querier/queryrange/queryrangebase/retry.go
@@ -42,7 +42,7 @@ type retry struct {
 // NewRetryMiddleware returns a middleware that retries requests if they
 // fail with 500 or a non-HTTP error.
 func NewRetryMiddleware(log log.Logger, maxRetries int, metrics *RetryMiddlewareMetrics, metricsNamespace string) Middleware {
-	if metrics == nil {
+	if metrics == nil && metricsNamespace != "" {
 		metrics = NewRetryMiddlewareMetrics(nil, metricsNamespace)
 	}
 
@@ -58,7 +58,9 @@ func NewRetryMiddleware(log log.Logger, maxRetries int, metrics *RetryMiddleware
 
 func (r retry) Do(ctx context.Context, req Request) (Response, error) {
 	tries := 0
-	defer func() { r.metrics.retriesCount.Observe(float64(tries)) }()
+	if r.metrics != nil {
+		defer func() { r.metrics.retriesCount.Observe(float64(tries)) }()
+	}
 
 	var lastErr error
 

--- a/pkg/querier/queryrange/querysharding_test.go
+++ b/pkg/querier/queryrange/querysharding_test.go
@@ -174,6 +174,7 @@ func Test_astMapper(t *testing.T) {
 		fakeLimits{maxSeries: math.MaxInt32, maxQueryParallelism: 1, queryTimeout: time.Second},
 		0,
 		[]string{},
+		0,
 	)
 
 	req := defaultReq()
@@ -319,6 +320,7 @@ func Test_astMapper_QuerySizeLimits(t *testing.T) {
 				},
 				0,
 				[]string{},
+				0,
 			)
 
 			req := defaultReq()
@@ -358,6 +360,7 @@ func Test_ShardingByPass(t *testing.T) {
 		fakeLimits{maxSeries: math.MaxInt32, maxQueryParallelism: 1},
 		0,
 		[]string{},
+		0,
 	)
 
 	req := defaultReq()
@@ -440,6 +443,7 @@ func Test_InstantSharding(t *testing.T) {
 		0,
 		nil,
 		[]string{},
+		0,
 	)
 	response, err := sharding.Wrap(queryrangebase.HandlerFunc(func(c context.Context, r queryrangebase.Request) (queryrangebase.Response, error) {
 		lock.Lock()
@@ -724,6 +728,7 @@ func TestShardingAcrossConfigs_ASTMapper(t *testing.T) {
 				fakeLimits{maxSeries: math.MaxInt32, maxQueryParallelism: 1, queryTimeout: time.Second},
 				0,
 				[]string{},
+				0,
 			)
 
 			// currently all the tests call `defaultReq()` which creates an instance of the type LokiRequest
@@ -859,6 +864,7 @@ func Test_ASTMapper_MaxLookBackPeriod(t *testing.T) {
 		fakeLimits{maxSeries: math.MaxInt32, tsdbMaxQueryParallelism: 1, queryTimeout: time.Second},
 		0,
 		[]string{},
+		0,
 	)
 
 	q := `{cluster="dev-us-central-0"}`

--- a/pkg/querier/queryrange/roundtrip.go
+++ b/pkg/querier/queryrange/roundtrip.go
@@ -290,7 +290,7 @@ func NewDetectedLabelsTripperware(cfg Config, opts logql.EngineOpts, logger log.
 		queryRangeMiddleware := []base.Middleware{
 			StatsCollectorMiddleware(),
 			NewLimitsMiddleware(l),
-			NewQuerySizeLimiterMiddleware(schema.Configs, opts, logger, l, statsHandler),
+			NewQuerySizeLimiterMiddleware(schema.Configs, opts, logger, l, cfg.MaxRetries, statsHandler),
 			base.InstrumentMiddleware("split_by_interval", metrics.InstrumentMiddlewareMetrics),
 			SplitByIntervalMiddleware(schema.Configs, limits, merger, splitter, metrics.SplitByMetrics),
 		}
@@ -298,7 +298,7 @@ func NewDetectedLabelsTripperware(cfg Config, opts logql.EngineOpts, logger log.
 		// The sharding middleware takes care of enforcing this limit for both shardable and non-shardable queries.
 		// If we are not using sharding, we enforce the limit by adding this middleware after time splitting.
 		queryRangeMiddleware = append(queryRangeMiddleware,
-			NewQuerierSizeLimiterMiddleware(schema.Configs, opts, logger, l, statsHandler),
+			NewQuerierSizeLimiterMiddleware(schema.Configs, opts, logger, l, cfg.MaxRetries, statsHandler),
 		)
 
 		if cfg.MaxRetries > 0 {
@@ -558,7 +558,7 @@ func NewLogFilterTripperware(cfg Config, engineOpts logql.EngineOpts, log log.Lo
 			QueryMetricsMiddleware(metrics.QueryMetrics),
 			StatsCollectorMiddleware(),
 			NewLimitsMiddleware(limits),
-			NewQuerySizeLimiterMiddleware(schema.Configs, engineOpts, log, limits, statsHandler),
+			NewQuerySizeLimiterMiddleware(schema.Configs, engineOpts, log, limits, cfg.MaxRetries, statsHandler),
 			base.InstrumentMiddleware("split_by_interval", metrics.InstrumentMiddlewareMetrics),
 			SplitByIntervalMiddleware(schema.Configs, limits, merger, newDefaultSplitter(limits, iqo), metrics.SplitByMetrics),
 		}
@@ -593,13 +593,14 @@ func NewLogFilterTripperware(cfg Config, engineOpts logql.EngineOpts, log log.Lo
 					0, // 0 is unlimited shards
 					statsHandler,
 					cfg.ShardAggregations,
+					cfg.MaxRetries,
 				),
 			)
 		} else {
 			// The sharding middleware takes care of enforcing this limit for both shardable and non-shardable queries.
 			// If we are not using sharding, we enforce the limit by adding this middleware after time splitting.
 			queryRangeMiddleware = append(queryRangeMiddleware,
-				NewQuerierSizeLimiterMiddleware(schema.Configs, engineOpts, log, limits, statsHandler),
+				NewQuerierSizeLimiterMiddleware(schema.Configs, engineOpts, log, limits, cfg.MaxRetries, statsHandler),
 			)
 		}
 
@@ -850,7 +851,7 @@ func NewMetricTripperware(cfg Config, engineOpts logql.EngineOpts, log log.Logge
 
 		queryRangeMiddleware = append(
 			queryRangeMiddleware,
-			NewQuerySizeLimiterMiddleware(schema.Configs, engineOpts, log, limits, statsHandler),
+			NewQuerySizeLimiterMiddleware(schema.Configs, engineOpts, log, limits, cfg.MaxRetries, statsHandler),
 			base.InstrumentMiddleware("split_by_interval", metrics.InstrumentMiddlewareMetrics),
 			SplitByIntervalMiddleware(schema.Configs, limits, merger, newMetricQuerySplitter(limits, iqo), metrics.SplitByMetrics),
 		)
@@ -875,13 +876,14 @@ func NewMetricTripperware(cfg Config, engineOpts logql.EngineOpts, log log.Logge
 					0, // 0 is unlimited shards
 					statsHandler,
 					cfg.ShardAggregations,
+					cfg.MaxRetries,
 				),
 			)
 		} else {
 			// The sharding middleware takes care of enforcing this limit for both shardable and non-shardable queries.
 			// If we are not using sharding, we enforce the limit by adding this middleware after time splitting.
 			queryRangeMiddleware = append(queryRangeMiddleware,
-				NewQuerierSizeLimiterMiddleware(schema.Configs, engineOpts, log, limits, statsHandler),
+				NewQuerierSizeLimiterMiddleware(schema.Configs, engineOpts, log, limits, cfg.MaxRetries, statsHandler),
 			)
 		}
 
@@ -959,7 +961,7 @@ func NewInstantMetricTripperware(
 		queryRangeMiddleware := []base.Middleware{
 			StatsCollectorMiddleware(),
 			NewLimitsMiddleware(limits),
-			NewQuerySizeLimiterMiddleware(schema.Configs, engineOpts, log, limits, statsHandler),
+			NewQuerySizeLimiterMiddleware(schema.Configs, engineOpts, log, limits, cfg.MaxRetries, statsHandler),
 			NewSplitByRangeMiddleware(log, engineOpts, limits, cfg.InstantMetricQuerySplitAlign, metrics.MiddlewareMapperMetrics.rangeMapper),
 		}
 
@@ -983,6 +985,7 @@ func NewInstantMetricTripperware(
 					0, // 0 is unlimited shards
 					statsHandler,
 					cfg.ShardAggregations,
+					cfg.MaxRetries,
 				),
 			)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

Some time back we introduced the concept of sending "stats" queries to the scheduler for the queriers to process and return to the frontend for use in query planning (determining shard counts and limits on queries)

This happens before the retry middleware which is inserted as essentially the last middleware, this makes sure we only retry the smallest query unit and not large parts of the query splitting.

The downside is that there are no retries on these stats calls which can lead to 5xx errors for normal behaviors.

Unfortunately changing the location of the retry middleware such that these would be retried would also result in us retrying much larger parts of a query like an entire split_by_time and all of it's shards.  This is maybe ok, but has a different set of tradeoffs.

In this PR instead I chose to use the retry middleware but only specifically around the stats handler call, this has the downside of being kind of strange pattern and maybe not the best implementation, but it has the upside of being a relatively small change to fix an immediate problem without introducing or having to reason about the complexities of retrying entire split_by_time segments.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
