### PR TITLE
chore: do not shard log queries with empty filter

### DIFF
--- a/pkg/logql/syntax/ast.go
+++ b/pkg/logql/syntax/ast.go
@@ -322,8 +322,8 @@ func (e *PipelineExpr) HasFilter() bool {
 		case *LabelFilterExpr:
 			return true
 		case *LineFilterExpr:
-			// return false if all line filters are empty
-			if v.Match != "" {
+			// ignore empty matchers as they match everything
+			if !((v.Ty == log.LineMatchEqual || v.Ty == log.LineMatchRegexp) && v.Match == "") {
 				return true
 			}
 		default:

--- a/pkg/logql/syntax/ast.go
+++ b/pkg/logql/syntax/ast.go
@@ -317,19 +317,15 @@ func (e *PipelineExpr) Pipeline() (log.Pipeline, error) {
 
 // HasFilter returns true if the pipeline contains stage that can filter out lines.
 func (e *PipelineExpr) HasFilter() bool {
-	if len(e.MultiStages) == 1 {
-		switch s := e.MultiStages[0].(type) {
-		case *LineFilterExpr:
-			if s.Match == "" {
-				return false
-			}
-		}
-	}
-
 	for _, p := range e.MultiStages {
-		switch p.(type) {
-		case *LineFilterExpr, *LabelFilterExpr:
+		switch v := p.(type) {
+		case *LabelFilterExpr:
 			return true
+		case *LineFilterExpr:
+			// return false if all line filters are empty
+			if v.Match != "" {
+				return true
+			}
 		default:
 			continue
 		}

--- a/pkg/logql/syntax/ast.go
+++ b/pkg/logql/syntax/ast.go
@@ -317,6 +317,15 @@ func (e *PipelineExpr) Pipeline() (log.Pipeline, error) {
 
 // HasFilter returns true if the pipeline contains stage that can filter out lines.
 func (e *PipelineExpr) HasFilter() bool {
+	if len(e.MultiStages) == 1 {
+		switch s := e.MultiStages[0].(type) {
+		case *LineFilterExpr:
+			if s.Match == "" {
+				return false
+			}
+		}
+	}
+
 	for _, p := range e.MultiStages {
 		switch p.(type) {
 		case *LineFilterExpr, *LabelFilterExpr:

--- a/pkg/logql/syntax/ast_test.go
+++ b/pkg/logql/syntax/ast_test.go
@@ -1039,6 +1039,19 @@ func TestParseLargeQuery(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestLogSelectorExprHasFilter(t *testing.T) {
+	for query, hasFilter := range map[string]bool{
+		`{foo="bar"} |= ""`:                  false,
+		`{foo="bar"} |= "notempty"`:          true,
+		`{foo="bar"} |= "" |= "notempty"`:    true,
+		`{foo="bar"} | lbl="notempty"`:       true,
+		`{foo="bar"} |= "" | lbl="notempty"`: true,
+	} {
+		expr, _ := ParseExpr(query)
+		require.Equal(t, hasFilter, expr.(LogSelectorExpr).HasFilter())
+	}
+}
+
 func TestGroupingString(t *testing.T) {
 	g := Grouping{
 		Groups:  []string{"a", "b"},

--- a/pkg/logql/syntax/ast_test.go
+++ b/pkg/logql/syntax/ast_test.go
@@ -1043,12 +1043,15 @@ func TestLogSelectorExprHasFilter(t *testing.T) {
 	for query, hasFilter := range map[string]bool{
 		`{foo="bar"} |= ""`:                  false,
 		`{foo="bar"} |= "" |= ""`:            false,
+		`{foo="bar"} |~ ""`:                  false,
 		`{foo="bar"} |= "notempty"`:          true,
 		`{foo="bar"} |= "" |= "notempty"`:    true,
+		`{foo="bar"} != ""`:                  true,
 		`{foo="bar"} | lbl="notempty"`:       true,
 		`{foo="bar"} |= "" | lbl="notempty"`: true,
 	} {
-		expr, _ := ParseExpr(query)
+		expr, err := ParseExpr(query)
+		require.NoError(t, err)
 		require.Equal(t, hasFilter, expr.(LogSelectorExpr).HasFilter())
 	}
 }

--- a/pkg/logql/syntax/ast_test.go
+++ b/pkg/logql/syntax/ast_test.go
@@ -1042,6 +1042,7 @@ func TestParseLargeQuery(t *testing.T) {
 func TestLogSelectorExprHasFilter(t *testing.T) {
 	for query, hasFilter := range map[string]bool{
 		`{foo="bar"} |= ""`:                  false,
+		`{foo="bar"} |= "" |= ""`:            false,
 		`{foo="bar"} |= "notempty"`:          true,
 		`{foo="bar"} |= "" |= "notempty"`:    true,
 		`{foo="bar"} | lbl="notempty"`:       true,


### PR DESCRIPTION
**What this PR does / why we need it**:

Log filter queries are sharded unlike limited queries. But line filters with empty matchers `|= ""`, `|~ ""` match everything, so we can treat them as limited queries and not shard them to reduce all the parallel work and return early.

This pr updates `HasFilter()` to return false if the pipeline only contains empty line filter matchers. As a result these queries would now get [routed](https://github.com/grafana/loki/blob/7231e82f868a876d1d920ce34818d7b34dd7c477/pkg/querier/queryrange/roundtrip.go#L416) to limited tripperware(which does not shard queries) 

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
