### PR TITLE
chore: replace pkg/errors with errors

### DIFF
--- a/pkg/pattern/metric/evaluator.go
+++ b/pkg/pattern/metric/evaluator.go
@@ -6,7 +6,6 @@ import (
 	"sort"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql"
@@ -127,7 +126,7 @@ func (ev *DefaultEvaluatorFactory) NewStepEvaluator(
 		}
 
 		if e.Grouping == nil {
-			return nil, errors.Errorf("aggregation operator '%q' without grouping", e.Operation)
+			return nil, fmt.Errorf("aggregation operator '%q' without grouping", e.Operation)
 		}
 		nextEvaluator, err := evFactory.NewStepEvaluator(ctx, evFactory, e.Left, from, through, step)
 		if err != nil {
@@ -158,7 +157,7 @@ func (ev *DefaultEvaluatorFactory) NewStepEvaluator(
 		)
 		return NewSampleRangeAggEvaluator(loki_iter.NewPeekingSampleIterator(it), e, params, e.Left.Offset)
 	default:
-		return nil, errors.Errorf("unexpected expr type (%T)", e)
+		return nil, fmt.Errorf("unexpected expr type (%T)", e)
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Replaces use of `pkg/errors` with `errors` in Pattern Ingester.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
