### PR TITLE
chore: replace pkg/errors with errors

### DIFF
--- a/pkg/ingester/index/multi.go
+++ b/pkg/ingester/index/multi.go
@@ -1,9 +1,9 @@
 package index
 
 import (
+	"fmt"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 
@@ -39,7 +39,7 @@ func NewMultiInvertedIndex(periods []config.PeriodConfig, indexShards uint32) (*
 			if bitPrefixed == nil {
 				bitPrefixed, err = NewBitPrefixWithShards(indexShards)
 				if err != nil {
-					return nil, errors.Wrapf(err, "creating tsdb inverted index for period starting %v", pd.From)
+					return nil, fmt.Errorf("creating tsdb inverted index for period starting %v: %w", pd.From, err)
 				}
 			}
 			periodIndices = append(periodIndices, periodIndex{

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -2,6 +2,7 @@ package ingester
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"math/rand"
@@ -29,7 +30,6 @@ import (
 	"github.com/grafana/dskit/services"
 	"github.com/grafana/dskit/tenant"
 	"github.com/opentracing/opentracing-go"
-	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
@@ -543,7 +543,7 @@ func (i *Ingester) starting(ctx context.Context) error {
 	shutdownMarkerPath := path.Join(i.cfg.ShutdownMarkerPath, shutdownMarkerFilename)
 	shutdownMarker, err := shutdownMarkerExists(shutdownMarkerPath)
 	if err != nil {
-		return errors.Wrap(err, "failed to check ingester shutdown marker")
+		return fmt.Errorf("failed to check ingester shutdown marker: %w", err)
 	}
 
 	if shutdownMarker {

--- a/pkg/ingester/instance.go
+++ b/pkg/ingester/instance.go
@@ -2,6 +2,7 @@ package ingester
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"net/http"
@@ -15,7 +16,6 @@ import (
 	"github.com/grafana/dskit/ring"
 	"github.com/grafana/dskit/tenant"
 	"github.com/opentracing/opentracing-go"
-	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/common/model"

--- a/pkg/ingester/instance_test.go
+++ b/pkg/ingester/instance_test.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/grafana/dskit/backoff"
 	"github.com/grafana/dskit/flagext"
-	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
@@ -53,7 +52,7 @@ func defaultConfig() *Config {
 		OwnedStreamsCheckInterval: 1 * time.Second,
 	}
 	if err := cfg.Validate(); err != nil {
-		panic(errors.Wrap(err, "error building default test config"))
+		panic(fmt.Errorf("error building default test config: %w", err))
 	}
 	return &cfg
 }

--- a/pkg/ingester/recovery_test.go
+++ b/pkg/ingester/recovery_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/user"
-	"github.com/pkg/errors"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/tsdb/chunks"
 	"github.com/prometheus/prometheus/tsdb/record"
@@ -142,7 +141,7 @@ func (r *MemRecoverer) SetStream(_ context.Context, userID string, series record
 	}
 
 	if _, exists := user[series.Ref]; exists {
-		return errors.Errorf("stream (%d) already exists for user (%s)", series.Ref, userID)
+		return fmt.Errorf("stream (%d) already exists for user (%s)", series.Ref, userID)
 	}
 
 	user[series.Ref] = make([]logproto.Entry, 0)
@@ -156,12 +155,12 @@ func (r *MemRecoverer) Push(userID string, entries wal.RefEntries) error {
 
 	user, ok := r.users[userID]
 	if !ok {
-		return errors.Errorf("unexpected user access (%s)", userID)
+		return fmt.Errorf("unexpected user access (%s)", userID)
 	}
 
 	stream, ok := user[entries.Ref]
 	if !ok {
-		return errors.Errorf("unexpected stream access")
+		return fmt.Errorf("unexpected stream access")
 	}
 
 	r.seriesCt += len(entries.Entries)

--- a/pkg/ingester/stream.go
+++ b/pkg/ingester/stream.go
@@ -3,6 +3,7 @@ package ingester
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"sync"
@@ -13,7 +14,6 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/httpgrpc"
 	"github.com/opentracing/opentracing-go"
-	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 

--- a/pkg/ingester/wal.go
+++ b/pkg/ingester/wal.go
@@ -2,11 +2,11 @@ package ingester
 
 import (
 	"flag"
+	"fmt"
 	"sync"
 	"time"
 
 	"github.com/go-kit/log/level"
-	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/tsdb/wlog"
 
@@ -33,7 +33,7 @@ type WALConfig struct {
 
 func (cfg *WALConfig) Validate() error {
 	if cfg.Enabled && cfg.CheckpointDuration < 1 {
-		return errors.Errorf("invalid checkpoint duration: %v", cfg.CheckpointDuration)
+		return fmt.Errorf("invalid checkpoint duration: %v", cfg.CheckpointDuration)
 	}
 	return nil
 }

--- a/pkg/ingester/wal/encoding.go
+++ b/pkg/ingester/wal/encoding.go
@@ -1,9 +1,10 @@
 package wal
 
 import (
+	"errors"
+	"fmt"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/prometheus/prometheus/tsdb/chunks"
 	"github.com/prometheus/prometheus/tsdb/record"
 
@@ -198,18 +199,18 @@ func DecodeEntries(b []byte, version RecordType, rec *Record) error {
 		}
 
 		if dec.Err() != nil {
-			return errors.Wrapf(dec.Err(), "entry decode error after %d RefEntries", nEntries-rem)
+			return fmt.Errorf("entry decode error after %d RefEntries: %w", nEntries-rem, dec.Err())
 		}
 
 		rec.RefEntries = append(rec.RefEntries, refEntries)
 	}
 
 	if dec.Err() != nil {
-		return errors.Wrap(dec.Err(), "refEntry decode error")
+		return fmt.Errorf("refEntry decode error: %w", dec.Err())
 	}
 
 	if len(dec.B) > 0 {
-		return errors.Errorf("unexpected %d bytes left in entry", len(dec.B))
+		return fmt.Errorf("unexpected %d bytes left in entry", len(dec.B))
 	}
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Replaces use of `pkg/errors` with `errors` in Ingester.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
