### PR TITLE
fix: remove retries on the stats handlers because they already retry

### DIFF
--- a/pkg/querier/queryrange/roundtrip.go
+++ b/pkg/querier/queryrange/roundtrip.go
@@ -285,11 +285,6 @@ func NewMiddleware(
 func NewDetectedLabelsTripperware(cfg Config, opts logql.EngineOpts, logger log.Logger, l Limits, schema config.SchemaConfig, metrics *Metrics, mw base.Middleware, namespace string, merger base.Merger, limits Limits, iqo util.IngesterQueryOptions) (base.Middleware, error) {
 	return base.MiddlewareFunc(func(next base.Handler) base.Handler {
 		statsHandler := mw.Wrap(next)
-		if cfg.MaxRetries > 0 {
-			tr := base.InstrumentMiddleware("retry", metrics.InstrumentMiddlewareMetrics)
-			rm := base.NewRetryMiddleware(logger, cfg.MaxRetries, metrics.RetryMiddlewareMetrics, namespace)
-			statsHandler = queryrangebase.MergeMiddlewares(tr, rm).Wrap(statsHandler)
-		}
 		splitter := newDefaultSplitter(limits, iqo)
 
 		queryRangeMiddleware := []base.Middleware{
@@ -562,7 +557,6 @@ func NewLogFilterTripperware(cfg Config, engineOpts logql.EngineOpts, log log.Lo
 		if cfg.MaxRetries > 0 {
 			tr := base.InstrumentMiddleware("retry", metrics.InstrumentMiddlewareMetrics)
 			rm := base.NewRetryMiddleware(log, cfg.MaxRetries, metrics.RetryMiddlewareMetrics, metricsNamespace)
-			statsHandler = queryrangebase.MergeMiddlewares(tr, rm).Wrap(statsHandler)
 			retryNextHandler = queryrangebase.MergeMiddlewares(tr, rm).Wrap(next)
 		}
 
@@ -635,7 +629,6 @@ func NewLimitedTripperware(cfg Config, engineOpts logql.EngineOpts, log log.Logg
 		if cfg.MaxRetries > 0 {
 			tr := base.InstrumentMiddleware("retry", metrics.InstrumentMiddlewareMetrics)
 			rm := base.NewRetryMiddleware(log, cfg.MaxRetries, metrics.RetryMiddlewareMetrics, metricsNamespace)
-			statsHandler = queryrangebase.MergeMiddlewares(tr, rm).Wrap(statsHandler)
 			retryNextHandler = queryrangebase.MergeMiddlewares(tr, rm).Wrap(next)
 		}
 
@@ -879,7 +872,6 @@ func NewMetricTripperware(cfg Config, engineOpts logql.EngineOpts, log log.Logge
 		if cfg.MaxRetries > 0 {
 			tr := base.InstrumentMiddleware("retry", metrics.InstrumentMiddlewareMetrics)
 			rm := base.NewRetryMiddleware(log, cfg.MaxRetries, metrics.RetryMiddlewareMetrics, metricsNamespace)
-			statsHandler = queryrangebase.MergeMiddlewares(tr, rm).Wrap(statsHandler)
 			retryNextHandler = queryrangebase.MergeMiddlewares(tr, rm).Wrap(next)
 		}
 
@@ -1009,7 +1001,6 @@ func NewInstantMetricTripperware(
 		if cfg.MaxRetries > 0 {
 			tr := base.InstrumentMiddleware("retry", metrics.InstrumentMiddlewareMetrics)
 			rm := base.NewRetryMiddleware(log, cfg.MaxRetries, metrics.RetryMiddlewareMetrics, metricsNamespace)
-			statsHandler = queryrangebase.MergeMiddlewares(tr, rm).Wrap(statsHandler)
 			retryNextHandler = queryrangebase.MergeMiddlewares(tr, rm).Wrap(next)
 		}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

https://github.com/grafana/loki/pull/13584 added retries to the stats handlers because I had seen some 5xx errors on stats functions not being retried.  it was pointed out we already have retries on the statshandler, the tripperware used here already includes it.

Instead it seems the 5xx's that were not retried were fixed in https://github.com/grafana/loki/pull/13592 so this PR removes the duplicate retry 

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
