### PR TITLE
feat(rf1): Add query path for the metastore

### DIFF
--- a/pkg/ingester-rf1/metastore/metastore_state_list_blocks_for_query.go
+++ b/pkg/ingester-rf1/metastore/metastore_state_list_blocks_for_query.go
@@ -5,9 +5,10 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/grafana/loki/v3/pkg/ingester-rf1/metastore/metastorepb"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	"github.com/grafana/loki/v3/pkg/ingester-rf1/metastore/metastorepb"
 )
 
 func (m *Metastore) ListBlocksForQuery(

--- a/pkg/ingester-rf1/metastore/metastore_state_list_blocks_for_query.go
+++ b/pkg/ingester-rf1/metastore/metastore_state_list_blocks_for_query.go
@@ -1,0 +1,78 @@
+package metastore
+
+import (
+	"context"
+	"slices"
+	"strings"
+
+	"github.com/grafana/loki/v3/pkg/ingester-rf1/metastore/metastorepb"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func (m *Metastore) ListBlocksForQuery(
+	ctx context.Context,
+	request *metastorepb.ListBlocksForQueryRequest,
+) (
+	*metastorepb.ListBlocksForQueryResponse, error,
+) {
+	return m.state.listBlocksForQuery(ctx, request)
+}
+
+func (m *metastoreState) listBlocksForQuery(
+	_ context.Context,
+	request *metastorepb.ListBlocksForQueryRequest,
+) (
+	*metastorepb.ListBlocksForQueryResponse, error,
+) {
+	if len(request.TenantId) == 0 {
+		return nil, status.Error(codes.InvalidArgument, "tenant_id is required")
+	}
+
+	if request.StartTime > request.EndTime {
+		return nil, status.Error(codes.InvalidArgument, "start_time must be less than or equal to end_time")
+	}
+	var resp metastorepb.ListBlocksForQueryResponse
+	m.segmentsMutex.Lock()
+	defer m.segmentsMutex.Unlock()
+
+	for _, segment := range m.segments {
+		for _, tenants := range segment.TenantStreams {
+			if tenants.TenantId == request.TenantId && inRange(segment.MinTime, segment.MaxTime, request.StartTime, request.EndTime) {
+				resp.Blocks = append(resp.Blocks, cloneBlockForQuery(segment))
+				break
+			}
+		}
+	}
+	slices.SortFunc(resp.Blocks, func(a, b *metastorepb.BlockMeta) int {
+		return strings.Compare(a.Id, b.Id)
+	})
+	return &resp, nil
+}
+
+func inRange(blockStart, blockEnd, queryStart, queryEnd int64) bool {
+	return blockStart <= queryEnd && blockEnd >= queryStart
+}
+
+func cloneBlockForQuery(b *metastorepb.BlockMeta) *metastorepb.BlockMeta {
+	res := &metastorepb.BlockMeta{
+		Id:              b.Id,
+		MinTime:         b.MinTime,
+		MaxTime:         b.MaxTime,
+		CompactionLevel: b.CompactionLevel,
+		FormatVersion:   b.FormatVersion,
+		IndexRef: metastorepb.DataRef{
+			Offset: b.IndexRef.Offset,
+			Length: b.IndexRef.Length,
+		},
+		TenantStreams: make([]*metastorepb.TenantStreams, 0, len(b.TenantStreams)),
+	}
+	for _, svc := range b.TenantStreams {
+		res.TenantStreams = append(res.TenantStreams, &metastorepb.TenantStreams{
+			TenantId: svc.TenantId,
+			MinTime:  svc.MinTime,
+			MaxTime:  svc.MaxTime,
+		})
+	}
+	return res
+}

--- a/pkg/ingester-rf1/metastore/metastore_state_list_blocks_for_query_test.go
+++ b/pkg/ingester-rf1/metastore/metastore_state_list_blocks_for_query_test.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"testing"
 
-	metastorepb "github.com/grafana/loki/v3/pkg/ingester-rf1/metastore/metastorepb"
 	"github.com/stretchr/testify/require"
+
+	metastorepb "github.com/grafana/loki/v3/pkg/ingester-rf1/metastore/metastorepb"
 )
 
 func TestMetastore_ListBlocksForQuery(t *testing.T) {

--- a/pkg/ingester-rf1/metastore/metastore_state_list_blocks_for_query_test.go
+++ b/pkg/ingester-rf1/metastore/metastore_state_list_blocks_for_query_test.go
@@ -1,0 +1,127 @@
+package metastore
+
+import (
+	"context"
+	"testing"
+
+	metastorepb "github.com/grafana/loki/v3/pkg/ingester-rf1/metastore/metastorepb"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMetastore_ListBlocksForQuery(t *testing.T) {
+	block1, block2, block3 := &metastorepb.BlockMeta{
+		Id:      "block1",
+		MinTime: 0,
+		MaxTime: 100,
+		TenantStreams: []*metastorepb.TenantStreams{
+			{
+				TenantId: "tenant1",
+				MinTime:  0,
+				MaxTime:  50,
+			},
+		},
+	}, &metastorepb.BlockMeta{
+		Id:      "block2",
+		MinTime: 100,
+		MaxTime: 200,
+		TenantStreams: []*metastorepb.TenantStreams{
+			{
+				TenantId: "tenant1",
+				MinTime:  100,
+				MaxTime:  150,
+			},
+		},
+	}, &metastorepb.BlockMeta{
+		Id:      "block3",
+		MinTime: 200,
+		MaxTime: 300,
+		TenantStreams: []*metastorepb.TenantStreams{
+			{
+				TenantId: "tenant2",
+				MinTime:  200,
+				MaxTime:  250,
+			},
+			{
+				TenantId: "tenant1",
+				MinTime:  200,
+				MaxTime:  250,
+			},
+		},
+	}
+	m := &Metastore{
+		state: &metastoreState{
+			segments: map[string]*metastorepb.BlockMeta{
+				"block1": block1,
+				"block2": block2,
+				"block3": block3,
+			},
+		},
+	}
+
+	tests := []struct {
+		name             string
+		request          *metastorepb.ListBlocksForQueryRequest
+		expectedResponse *metastorepb.ListBlocksForQueryResponse
+	}{
+		{
+			name: "Matching tenant and time range",
+			request: &metastorepb.ListBlocksForQueryRequest{
+				TenantId:  "tenant1",
+				StartTime: 0,
+				EndTime:   100,
+			},
+			expectedResponse: &metastorepb.ListBlocksForQueryResponse{
+				Blocks: []*metastorepb.BlockMeta{
+					block1,
+					block2,
+				},
+			},
+		},
+		{
+			name: "Matching tenant but partial time range",
+			request: &metastorepb.ListBlocksForQueryRequest{
+				TenantId:  "tenant1",
+				StartTime: 50,
+				EndTime:   150,
+			},
+			expectedResponse: &metastorepb.ListBlocksForQueryResponse{
+				Blocks: []*metastorepb.BlockMeta{
+					block1,
+					block2,
+				},
+			},
+		},
+		{
+			name: "Non-matching tenant",
+			request: &metastorepb.ListBlocksForQueryRequest{
+				TenantId:  "tenant3",
+				StartTime: 0,
+				EndTime:   100,
+			},
+			expectedResponse: &metastorepb.ListBlocksForQueryResponse{},
+		},
+		{
+			name: "Matching one tenant but not the other",
+			request: &metastorepb.ListBlocksForQueryRequest{
+				TenantId:  "tenant1",
+				StartTime: 100,
+				EndTime:   550,
+			},
+			expectedResponse: &metastorepb.ListBlocksForQueryResponse{
+				Blocks: []*metastorepb.BlockMeta{
+					block1,
+					block2,
+					block3,
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			resp, err := m.ListBlocksForQuery(context.Background(), test.request)
+			require.NoError(t, err)
+			require.Equal(t, test.expectedResponse, resp)
+		})
+	}
+}

--- a/pkg/ingester-rf1/metastore/metastorepb/metastore.pb.go
+++ b/pkg/ingester-rf1/metastore/metastorepb/metastore.pb.go
@@ -310,12 +310,116 @@ func (m *TenantStreams) GetMaxTime() int64 {
 	return 0
 }
 
+type ListBlocksForQueryRequest struct {
+	TenantId  string `protobuf:"bytes,1,opt,name=tenant_id,json=tenantId,proto3" json:"tenant_id,omitempty"`
+	StartTime int64  `protobuf:"varint,2,opt,name=start_time,json=startTime,proto3" json:"start_time,omitempty"`
+	EndTime   int64  `protobuf:"varint,3,opt,name=end_time,json=endTime,proto3" json:"end_time,omitempty"`
+}
+
+func (m *ListBlocksForQueryRequest) Reset()      { *m = ListBlocksForQueryRequest{} }
+func (*ListBlocksForQueryRequest) ProtoMessage() {}
+func (*ListBlocksForQueryRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_43ce85359599db4e, []int{5}
+}
+func (m *ListBlocksForQueryRequest) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *ListBlocksForQueryRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_ListBlocksForQueryRequest.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *ListBlocksForQueryRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ListBlocksForQueryRequest.Merge(m, src)
+}
+func (m *ListBlocksForQueryRequest) XXX_Size() int {
+	return m.Size()
+}
+func (m *ListBlocksForQueryRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_ListBlocksForQueryRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_ListBlocksForQueryRequest proto.InternalMessageInfo
+
+func (m *ListBlocksForQueryRequest) GetTenantId() string {
+	if m != nil {
+		return m.TenantId
+	}
+	return ""
+}
+
+func (m *ListBlocksForQueryRequest) GetStartTime() int64 {
+	if m != nil {
+		return m.StartTime
+	}
+	return 0
+}
+
+func (m *ListBlocksForQueryRequest) GetEndTime() int64 {
+	if m != nil {
+		return m.EndTime
+	}
+	return 0
+}
+
+type ListBlocksForQueryResponse struct {
+	Blocks []*BlockMeta `protobuf:"bytes,1,rep,name=blocks,proto3" json:"blocks,omitempty"`
+}
+
+func (m *ListBlocksForQueryResponse) Reset()      { *m = ListBlocksForQueryResponse{} }
+func (*ListBlocksForQueryResponse) ProtoMessage() {}
+func (*ListBlocksForQueryResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_43ce85359599db4e, []int{6}
+}
+func (m *ListBlocksForQueryResponse) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *ListBlocksForQueryResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_ListBlocksForQueryResponse.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *ListBlocksForQueryResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ListBlocksForQueryResponse.Merge(m, src)
+}
+func (m *ListBlocksForQueryResponse) XXX_Size() int {
+	return m.Size()
+}
+func (m *ListBlocksForQueryResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_ListBlocksForQueryResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_ListBlocksForQueryResponse proto.InternalMessageInfo
+
+func (m *ListBlocksForQueryResponse) GetBlocks() []*BlockMeta {
+	if m != nil {
+		return m.Blocks
+	}
+	return nil
+}
+
 func init() {
 	proto.RegisterType((*AddBlockRequest)(nil), "metastorepb.AddBlockRequest")
 	proto.RegisterType((*AddBlockResponse)(nil), "metastorepb.AddBlockResponse")
 	proto.RegisterType((*BlockMeta)(nil), "metastorepb.BlockMeta")
 	proto.RegisterType((*DataRef)(nil), "metastorepb.DataRef")
 	proto.RegisterType((*TenantStreams)(nil), "metastorepb.TenantStreams")
+	proto.RegisterType((*ListBlocksForQueryRequest)(nil), "metastorepb.ListBlocksForQueryRequest")
+	proto.RegisterType((*ListBlocksForQueryResponse)(nil), "metastorepb.ListBlocksForQueryResponse")
 }
 
 func init() {
@@ -323,37 +427,42 @@ func init() {
 }
 
 var fileDescriptor_43ce85359599db4e = []byte{
-	// 471 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x9c, 0x52, 0xcf, 0x8a, 0xd3, 0x40,
-	0x18, 0xcf, 0xb4, 0xb5, 0x4d, 0xa7, 0xb4, 0x5b, 0x86, 0x65, 0x89, 0x55, 0xc7, 0x10, 0x10, 0x22,
-	0x68, 0x8b, 0x55, 0x16, 0x3c, 0xc9, 0x16, 0x2f, 0x0b, 0xee, 0x65, 0x76, 0xf1, 0x26, 0x65, 0xda,
-	0x7c, 0x89, 0xc3, 0x36, 0x33, 0x31, 0x19, 0x4b, 0x8f, 0x3e, 0x82, 0x4f, 0xe0, 0xd9, 0x47, 0xd9,
-	0x63, 0x8f, 0x7b, 0x12, 0x9b, 0x5e, 0x3c, 0xee, 0x23, 0x48, 0x27, 0xd9, 0x6d, 0x2b, 0x78, 0xd9,
-	0xdb, 0xf7, 0xfb, 0x93, 0x1f, 0xf9, 0x7d, 0xf3, 0xe1, 0xe3, 0xe4, 0x32, 0x1a, 0x08, 0x19, 0x41,
-	0xa6, 0x21, 0x7d, 0x99, 0x86, 0xaf, 0x06, 0x31, 0x68, 0x9e, 0x69, 0x95, 0xc2, 0x76, 0x4a, 0x26,
-	0xdb, 0xb9, 0x9f, 0xa4, 0x4a, 0x2b, 0xd2, 0xda, 0x11, 0x7b, 0x87, 0x91, 0x8a, 0x94, 0xe1, 0x07,
-	0x9b, 0xa9, 0xb0, 0x78, 0xef, 0xf0, 0xc1, 0x49, 0x10, 0x8c, 0x66, 0x6a, 0x7a, 0xc9, 0xe0, 0xcb,
-	0x57, 0xc8, 0x34, 0x79, 0x81, 0x1f, 0x4c, 0x36, 0xd8, 0x41, 0x2e, 0xf2, 0x5b, 0xc3, 0xa3, 0xfe,
-	0x4e, 0x4a, 0xdf, 0x38, 0xcf, 0x40, 0x73, 0x56, 0x98, 0x3c, 0x82, 0xbb, 0xdb, 0x80, 0x2c, 0x51,
-	0x32, 0x03, 0xef, 0x47, 0x05, 0x37, 0xef, 0x8c, 0xe4, 0x19, 0xee, 0x84, 0x2a, 0x8d, 0xb9, 0x1e,
-	0xcf, 0x21, 0xcd, 0x84, 0x92, 0x26, 0xb8, 0xc6, 0xda, 0x05, 0xfb, 0xb1, 0x20, 0x49, 0x07, 0x57,
-	0x44, 0xe0, 0x54, 0x5c, 0xe4, 0x37, 0x59, 0x45, 0x04, 0xe4, 0x21, 0xb6, 0x63, 0x21, 0xc7, 0x5a,
-	0xc4, 0xe0, 0x54, 0x5d, 0xe4, 0x57, 0x59, 0x23, 0x16, 0xf2, 0x42, 0xc4, 0x60, 0x24, 0xbe, 0x28,
-	0xa4, 0x5a, 0x29, 0xf1, 0x85, 0x91, 0x9e, 0xe3, 0xee, 0x54, 0xc5, 0x09, 0x9f, 0x6a, 0xa1, 0xe4,
-	0x78, 0x06, 0x73, 0x98, 0x39, 0x75, 0x17, 0xf9, 0x6d, 0x76, 0xb0, 0xe5, 0x3f, 0x6c, 0x68, 0x72,
-	0x8c, 0x6d, 0x21, 0x03, 0x58, 0x30, 0x08, 0x9d, 0x86, 0xa9, 0x7a, 0xb8, 0x57, 0xf5, 0x3d, 0xd7,
-	0x9c, 0x41, 0x38, 0xaa, 0x5d, 0xfd, 0x7a, 0x6a, 0xb1, 0x3b, 0x2f, 0x39, 0xc1, 0x1d, 0x0d, 0x92,
-	0x4b, 0x3d, 0xce, 0x74, 0x0a, 0x3c, 0xce, 0x1c, 0xdb, 0xad, 0xfa, 0xad, 0x61, 0x6f, 0xef, 0xeb,
-	0x0b, 0x63, 0x39, 0x2f, 0x1c, 0xac, 0xad, 0x77, 0xa1, 0xf7, 0x16, 0x37, 0xca, 0x74, 0x72, 0x84,
-	0xeb, 0x2a, 0x0c, 0x33, 0xd0, 0x66, 0x2b, 0x55, 0x56, 0xa2, 0x0d, 0x3f, 0x03, 0x19, 0xe9, 0xcf,
-	0x66, 0x25, 0x55, 0x56, 0x22, 0x6f, 0x82, 0xdb, 0x7b, 0xd1, 0xe4, 0x11, 0x6e, 0x96, 0xbf, 0x23,
-	0x02, 0x93, 0xd1, 0x64, 0x76, 0x41, 0x9c, 0xde, 0x73, 0x89, 0xc3, 0x4f, 0xb8, 0x7b, 0x76, 0x5b,
-	0xe5, 0x1c, 0xd2, 0xb9, 0x98, 0x02, 0x39, 0xc5, 0xf6, 0xed, 0x3b, 0x93, 0xc7, 0x7b, 0x4d, 0xff,
-	0xb9, 0x9f, 0xde, 0x93, 0xff, 0xa8, 0xe5, 0x71, 0x58, 0xa3, 0x37, 0xcb, 0x15, 0xb5, 0xae, 0x57,
-	0xd4, 0xba, 0x59, 0x51, 0xf4, 0x2d, 0xa7, 0xe8, 0x67, 0x4e, 0xd1, 0x55, 0x4e, 0xd1, 0x32, 0xa7,
-	0xe8, 0x77, 0x4e, 0xd1, 0x9f, 0x9c, 0x5a, 0x37, 0x39, 0x45, 0xdf, 0xd7, 0xd4, 0x5a, 0xae, 0xa9,
-	0x75, 0xbd, 0xa6, 0xd6, 0xa4, 0x6e, 0x0e, 0xf6, 0xf5, 0xdf, 0x00, 0x00, 0x00, 0xff, 0xff, 0x62,
-	0x2d, 0xad, 0xa0, 0x0d, 0x03, 0x00, 0x00,
+	// 558 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x9c, 0x53, 0xc1, 0x6e, 0x13, 0x3b,
+	0x14, 0x1d, 0x27, 0x7d, 0x69, 0xe2, 0x2a, 0x6d, 0x65, 0x55, 0xd5, 0x34, 0x8f, 0x9a, 0x68, 0x24,
+	0x20, 0x48, 0x90, 0x8a, 0x82, 0x2a, 0xb1, 0x42, 0x8d, 0x10, 0x52, 0xa5, 0x74, 0x81, 0x5b, 0xb1,
+	0x8d, 0x26, 0x99, 0x3b, 0x83, 0xd5, 0x8c, 0x1d, 0x6c, 0x37, 0x0a, 0x3b, 0x3e, 0x81, 0x2f, 0x60,
+	0xcd, 0x97, 0xa0, 0x2e, 0xb3, 0xec, 0x0a, 0x91, 0xc9, 0x86, 0x65, 0x3f, 0x01, 0xc5, 0x33, 0x69,
+	0x32, 0x40, 0x40, 0x62, 0xe7, 0x7b, 0xce, 0x99, 0x73, 0xaf, 0xef, 0x1c, 0xe3, 0xa3, 0xc1, 0x45,
+	0x74, 0xc0, 0x45, 0x04, 0xda, 0x80, 0x7a, 0xac, 0xc2, 0x27, 0x07, 0x31, 0x18, 0x5f, 0x1b, 0xa9,
+	0x60, 0x71, 0x1a, 0x74, 0x17, 0xe7, 0xe6, 0x40, 0x49, 0x23, 0xc9, 0xc6, 0x12, 0x59, 0xdb, 0x89,
+	0x64, 0x24, 0x2d, 0x7e, 0x30, 0x3b, 0xa5, 0x12, 0xef, 0x05, 0xde, 0x3a, 0x0e, 0x82, 0x56, 0x5f,
+	0xf6, 0x2e, 0x18, 0xbc, 0xbb, 0x04, 0x6d, 0xc8, 0x23, 0xfc, 0x5f, 0x77, 0x56, 0xbb, 0xa8, 0x8e,
+	0x1a, 0x1b, 0x87, 0xbb, 0xcd, 0x25, 0x97, 0xa6, 0x55, 0x9e, 0x82, 0xf1, 0x59, 0x2a, 0xf2, 0x08,
+	0xde, 0x5e, 0x18, 0xe8, 0x81, 0x14, 0x1a, 0xbc, 0x4f, 0x05, 0x5c, 0xb9, 0x15, 0x92, 0x7b, 0x78,
+	0x33, 0x94, 0x2a, 0xf6, 0x4d, 0x67, 0x08, 0x4a, 0x73, 0x29, 0xac, 0xf1, 0x1a, 0xab, 0xa6, 0xe8,
+	0x9b, 0x14, 0x24, 0x9b, 0xb8, 0xc0, 0x03, 0xb7, 0x50, 0x47, 0x8d, 0x0a, 0x2b, 0xf0, 0x80, 0xec,
+	0xe1, 0x72, 0xcc, 0x45, 0xc7, 0xf0, 0x18, 0xdc, 0x62, 0x1d, 0x35, 0x8a, 0x6c, 0x3d, 0xe6, 0xe2,
+	0x9c, 0xc7, 0x60, 0x29, 0x7f, 0x94, 0x52, 0x6b, 0x19, 0xe5, 0x8f, 0x2c, 0xf5, 0x10, 0x6f, 0xf7,
+	0x64, 0x3c, 0xf0, 0x7b, 0x86, 0x4b, 0xd1, 0xe9, 0xc3, 0x10, 0xfa, 0x6e, 0xa9, 0x8e, 0x1a, 0x55,
+	0xb6, 0xb5, 0xc0, 0xdb, 0x33, 0x98, 0x1c, 0xe1, 0x32, 0x17, 0x01, 0x8c, 0x18, 0x84, 0xee, 0xba,
+	0xbd, 0xea, 0x4e, 0xee, 0xaa, 0x2f, 0x7d, 0xe3, 0x33, 0x08, 0x5b, 0x6b, 0x57, 0x5f, 0xef, 0x3a,
+	0xec, 0x56, 0x4b, 0x8e, 0xf1, 0xa6, 0x01, 0xe1, 0x0b, 0xd3, 0xd1, 0x46, 0x81, 0x1f, 0x6b, 0xb7,
+	0x5c, 0x2f, 0x36, 0x36, 0x0e, 0x6b, 0xb9, 0xaf, 0xcf, 0xad, 0xe4, 0x2c, 0x55, 0xb0, 0xaa, 0x59,
+	0x2e, 0xbd, 0xe7, 0x78, 0x3d, 0x73, 0x27, 0xbb, 0xb8, 0x24, 0xc3, 0x50, 0x83, 0xb1, 0x5b, 0x29,
+	0xb2, 0xac, 0x9a, 0xe1, 0x7d, 0x10, 0x91, 0x79, 0x6b, 0x57, 0x52, 0x64, 0x59, 0xe5, 0x75, 0x71,
+	0x35, 0x67, 0x4d, 0xfe, 0xc7, 0x95, 0x6c, 0x1c, 0x1e, 0x58, 0x8f, 0x0a, 0x2b, 0xa7, 0xc0, 0xc9,
+	0x3f, 0x2e, 0xd1, 0x53, 0x78, 0xaf, 0xcd, 0xb5, 0xb1, 0xbf, 0x50, 0xbf, 0x92, 0xea, 0xf5, 0x25,
+	0xa8, 0xf7, 0xf3, 0x78, 0xfc, 0xb1, 0xdf, 0x3e, 0xc6, 0xda, 0xf8, 0xca, 0xa4, 0xb6, 0xe9, 0xe4,
+	0x15, 0x8b, 0xcc, 0x7b, 0x82, 0x08, 0x72, 0xe3, 0x80, 0x08, 0x6c, 0xcf, 0x36, 0xae, 0xfd, 0xae,
+	0x67, 0x9a, 0x28, 0xd2, 0xc4, 0x25, 0x1b, 0x37, 0xed, 0x22, 0xbb, 0xeb, 0x55, 0xa1, 0xcc, 0x54,
+	0x87, 0x5f, 0x10, 0xde, 0x3e, 0x9d, 0x2b, 0xce, 0x40, 0x0d, 0x79, 0x0f, 0xc8, 0x09, 0x2e, 0xcf,
+	0xa3, 0x4a, 0xee, 0xe4, 0x0c, 0x7e, 0x7a, 0x02, 0xb5, 0xfd, 0x15, 0x6c, 0x96, 0x6f, 0x87, 0x44,
+	0x98, 0xfc, 0x3a, 0x2d, 0xb9, 0x9f, 0xfb, 0x6c, 0xe5, 0x0a, 0x6b, 0x0f, 0xfe, 0xaa, 0x9b, 0x37,
+	0x6a, 0x3d, 0x1b, 0x4f, 0xa8, 0x73, 0x3d, 0xa1, 0xce, 0xcd, 0x84, 0xa2, 0x0f, 0x09, 0x45, 0x9f,
+	0x13, 0x8a, 0xae, 0x12, 0x8a, 0xc6, 0x09, 0x45, 0xdf, 0x12, 0x8a, 0xbe, 0x27, 0xd4, 0xb9, 0x49,
+	0x28, 0xfa, 0x38, 0xa5, 0xce, 0x78, 0x4a, 0x9d, 0xeb, 0x29, 0x75, 0xba, 0x25, 0xfb, 0xb8, 0x9f,
+	0xfe, 0x08, 0x00, 0x00, 0xff, 0xff, 0xfa, 0xbc, 0xd9, 0xf7, 0x39, 0x04, 0x00, 0x00,
 }
 
 func (this *AddBlockRequest) Equal(that interface{}) bool {
@@ -505,6 +614,65 @@ func (this *TenantStreams) Equal(that interface{}) bool {
 	}
 	return true
 }
+func (this *ListBlocksForQueryRequest) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*ListBlocksForQueryRequest)
+	if !ok {
+		that2, ok := that.(ListBlocksForQueryRequest)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if this.TenantId != that1.TenantId {
+		return false
+	}
+	if this.StartTime != that1.StartTime {
+		return false
+	}
+	if this.EndTime != that1.EndTime {
+		return false
+	}
+	return true
+}
+func (this *ListBlocksForQueryResponse) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*ListBlocksForQueryResponse)
+	if !ok {
+		that2, ok := that.(ListBlocksForQueryResponse)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if len(this.Blocks) != len(that1.Blocks) {
+		return false
+	}
+	for i := range this.Blocks {
+		if !this.Blocks[i].Equal(that1.Blocks[i]) {
+			return false
+		}
+	}
+	return true
+}
 func (this *AddBlockRequest) GoString() string {
 	if this == nil {
 		return "nil"
@@ -567,6 +735,30 @@ func (this *TenantStreams) GoString() string {
 	s = append(s, "}")
 	return strings.Join(s, "")
 }
+func (this *ListBlocksForQueryRequest) GoString() string {
+	if this == nil {
+		return "nil"
+	}
+	s := make([]string, 0, 7)
+	s = append(s, "&metastorepb.ListBlocksForQueryRequest{")
+	s = append(s, "TenantId: "+fmt.Sprintf("%#v", this.TenantId)+",\n")
+	s = append(s, "StartTime: "+fmt.Sprintf("%#v", this.StartTime)+",\n")
+	s = append(s, "EndTime: "+fmt.Sprintf("%#v", this.EndTime)+",\n")
+	s = append(s, "}")
+	return strings.Join(s, "")
+}
+func (this *ListBlocksForQueryResponse) GoString() string {
+	if this == nil {
+		return "nil"
+	}
+	s := make([]string, 0, 5)
+	s = append(s, "&metastorepb.ListBlocksForQueryResponse{")
+	if this.Blocks != nil {
+		s = append(s, "Blocks: "+fmt.Sprintf("%#v", this.Blocks)+",\n")
+	}
+	s = append(s, "}")
+	return strings.Join(s, "")
+}
 func valueToGoStringMetastore(v interface{}, typ string) string {
 	rv := reflect.ValueOf(v)
 	if rv.IsNil() {
@@ -589,6 +781,7 @@ const _ = grpc.SupportPackageIsVersion4
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
 type MetastoreServiceClient interface {
 	AddBlock(ctx context.Context, in *AddBlockRequest, opts ...grpc.CallOption) (*AddBlockResponse, error)
+	ListBlocksForQuery(ctx context.Context, in *ListBlocksForQueryRequest, opts ...grpc.CallOption) (*ListBlocksForQueryResponse, error)
 }
 
 type metastoreServiceClient struct {
@@ -608,9 +801,19 @@ func (c *metastoreServiceClient) AddBlock(ctx context.Context, in *AddBlockReque
 	return out, nil
 }
 
+func (c *metastoreServiceClient) ListBlocksForQuery(ctx context.Context, in *ListBlocksForQueryRequest, opts ...grpc.CallOption) (*ListBlocksForQueryResponse, error) {
+	out := new(ListBlocksForQueryResponse)
+	err := c.cc.Invoke(ctx, "/metastorepb.MetastoreService/ListBlocksForQuery", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // MetastoreServiceServer is the server API for MetastoreService service.
 type MetastoreServiceServer interface {
 	AddBlock(context.Context, *AddBlockRequest) (*AddBlockResponse, error)
+	ListBlocksForQuery(context.Context, *ListBlocksForQueryRequest) (*ListBlocksForQueryResponse, error)
 }
 
 // UnimplementedMetastoreServiceServer can be embedded to have forward compatible implementations.
@@ -619,6 +822,9 @@ type UnimplementedMetastoreServiceServer struct {
 
 func (*UnimplementedMetastoreServiceServer) AddBlock(ctx context.Context, req *AddBlockRequest) (*AddBlockResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method AddBlock not implemented")
+}
+func (*UnimplementedMetastoreServiceServer) ListBlocksForQuery(ctx context.Context, req *ListBlocksForQueryRequest) (*ListBlocksForQueryResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ListBlocksForQuery not implemented")
 }
 
 func RegisterMetastoreServiceServer(s *grpc.Server, srv MetastoreServiceServer) {
@@ -643,6 +849,24 @@ func _MetastoreService_AddBlock_Handler(srv interface{}, ctx context.Context, de
 	return interceptor(ctx, in, info, handler)
 }
 
+func _MetastoreService_ListBlocksForQuery_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListBlocksForQueryRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(MetastoreServiceServer).ListBlocksForQuery(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/metastorepb.MetastoreService/ListBlocksForQuery",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(MetastoreServiceServer).ListBlocksForQuery(ctx, req.(*ListBlocksForQueryRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 var _MetastoreService_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "metastorepb.MetastoreService",
 	HandlerType: (*MetastoreServiceServer)(nil),
@@ -650,6 +874,10 @@ var _MetastoreService_serviceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "AddBlock",
 			Handler:    _MetastoreService_AddBlock_Handler,
+		},
+		{
+			MethodName: "ListBlocksForQuery",
+			Handler:    _MetastoreService_ListBlocksForQuery_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
@@ -861,6 +1089,83 @@ func (m *TenantStreams) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+func (m *ListBlocksForQueryRequest) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *ListBlocksForQueryRequest) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *ListBlocksForQueryRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.EndTime != 0 {
+		i = encodeVarintMetastore(dAtA, i, uint64(m.EndTime))
+		i--
+		dAtA[i] = 0x18
+	}
+	if m.StartTime != 0 {
+		i = encodeVarintMetastore(dAtA, i, uint64(m.StartTime))
+		i--
+		dAtA[i] = 0x10
+	}
+	if len(m.TenantId) > 0 {
+		i -= len(m.TenantId)
+		copy(dAtA[i:], m.TenantId)
+		i = encodeVarintMetastore(dAtA, i, uint64(len(m.TenantId)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *ListBlocksForQueryResponse) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *ListBlocksForQueryResponse) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *ListBlocksForQueryResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.Blocks) > 0 {
+		for iNdEx := len(m.Blocks) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Blocks[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintMetastore(dAtA, i, uint64(size))
+			}
+			i--
+			dAtA[i] = 0xa
+		}
+	}
+	return len(dAtA) - i, nil
+}
+
 func encodeVarintMetastore(dAtA []byte, offset int, v uint64) int {
 	offset -= sovMetastore(v)
 	base := offset
@@ -961,6 +1266,40 @@ func (m *TenantStreams) Size() (n int) {
 	return n
 }
 
+func (m *ListBlocksForQueryRequest) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.TenantId)
+	if l > 0 {
+		n += 1 + l + sovMetastore(uint64(l))
+	}
+	if m.StartTime != 0 {
+		n += 1 + sovMetastore(uint64(m.StartTime))
+	}
+	if m.EndTime != 0 {
+		n += 1 + sovMetastore(uint64(m.EndTime))
+	}
+	return n
+}
+
+func (m *ListBlocksForQueryResponse) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if len(m.Blocks) > 0 {
+		for _, e := range m.Blocks {
+			l = e.Size()
+			n += 1 + l + sovMetastore(uint64(l))
+		}
+	}
+	return n
+}
+
 func sovMetastore(x uint64) (n int) {
 	return (math_bits.Len64(x|1) + 6) / 7
 }
@@ -1026,6 +1365,33 @@ func (this *TenantStreams) String() string {
 		`TenantId:` + fmt.Sprintf("%v", this.TenantId) + `,`,
 		`MinTime:` + fmt.Sprintf("%v", this.MinTime) + `,`,
 		`MaxTime:` + fmt.Sprintf("%v", this.MaxTime) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *ListBlocksForQueryRequest) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&ListBlocksForQueryRequest{`,
+		`TenantId:` + fmt.Sprintf("%v", this.TenantId) + `,`,
+		`StartTime:` + fmt.Sprintf("%v", this.StartTime) + `,`,
+		`EndTime:` + fmt.Sprintf("%v", this.EndTime) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *ListBlocksForQueryResponse) String() string {
+	if this == nil {
+		return "nil"
+	}
+	repeatedStringForBlocks := "[]*BlockMeta{"
+	for _, f := range this.Blocks {
+		repeatedStringForBlocks += strings.Replace(f.String(), "BlockMeta", "BlockMeta", 1) + ","
+	}
+	repeatedStringForBlocks += "}"
+	s := strings.Join([]string{`&ListBlocksForQueryResponse{`,
+		`Blocks:` + repeatedStringForBlocks + `,`,
 		`}`,
 	}, "")
 	return s
@@ -1598,6 +1964,216 @@ func (m *TenantStreams) Unmarshal(dAtA []byte) error {
 					break
 				}
 			}
+		default:
+			iNdEx = preIndex
+			skippy, err := skipMetastore(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthMetastore
+			}
+			if (iNdEx + skippy) < 0 {
+				return ErrInvalidLengthMetastore
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *ListBlocksForQueryRequest) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowMetastore
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: ListBlocksForQueryRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: ListBlocksForQueryRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field TenantId", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowMetastore
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthMetastore
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthMetastore
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.TenantId = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field StartTime", wireType)
+			}
+			m.StartTime = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowMetastore
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.StartTime |= int64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 3:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field EndTime", wireType)
+			}
+			m.EndTime = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowMetastore
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.EndTime |= int64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		default:
+			iNdEx = preIndex
+			skippy, err := skipMetastore(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthMetastore
+			}
+			if (iNdEx + skippy) < 0 {
+				return ErrInvalidLengthMetastore
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *ListBlocksForQueryResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowMetastore
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: ListBlocksForQueryResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: ListBlocksForQueryResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Blocks", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowMetastore
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthMetastore
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthMetastore
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Blocks = append(m.Blocks, &BlockMeta{})
+			if err := m.Blocks[len(m.Blocks)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := skipMetastore(dAtA[iNdEx:])

--- a/pkg/ingester-rf1/metastore/metastorepb/metastore.proto
+++ b/pkg/ingester-rf1/metastore/metastorepb/metastore.proto
@@ -6,6 +6,7 @@ import "gogoproto/gogo.proto";
 
 service MetastoreService {
   rpc AddBlock(AddBlockRequest) returns (AddBlockResponse) {}
+  rpc ListBlocksForQuery(ListBlocksForQueryRequest) returns (ListBlocksForQueryResponse) {}
 }
 
 message AddBlockRequest {
@@ -37,4 +38,15 @@ message TenantStreams {
   int64 min_time = 3;
   int64 max_time = 4;
   //todo offset in the block.
+}
+
+
+message ListBlocksForQueryRequest {
+  string tenant_id = 1;
+  int64 start_time = 2;
+  int64 end_time = 3;
+}
+
+message ListBlocksForQueryResponse {
+  repeated BlockMeta blocks = 1;
 }

--- a/pkg/ingester-rf1/metastore/metastorepb/metastore.proto
+++ b/pkg/ingester-rf1/metastore/metastorepb/metastore.proto
@@ -40,7 +40,6 @@ message TenantStreams {
   //todo offset in the block.
 }
 
-
 message ListBlocksForQueryRequest {
   string tenant_id = 1;
   int64 start_time = 2;


### PR DESCRIPTION
**What this PR does / why we need it**:

This adds a new RPC to query wal segment meta for a given range and tenant.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
