### PR TITLE
fix: remove limit middleware for `detected_labels`

### DIFF
--- a/pkg/querier/queryrange/roundtrip.go
+++ b/pkg/querier/queryrange/roundtrip.go
@@ -253,12 +253,10 @@ func NewMiddleware(
 
 	detectedLabelsTripperware, err := NewDetectedLabelsTripperware(
 		cfg,
-		engineOpts,
 		log,
 		limits,
 		schema,
 		metrics,
-		indexStatsTripperware,
 		metricsNamespace,
 		codec, limits, iqo)
 	if err != nil {
@@ -282,24 +280,16 @@ func NewMiddleware(
 	}), StopperWrapper{resultsCache, statsCache, volumeCache}, nil
 }
 
-func NewDetectedLabelsTripperware(cfg Config, opts logql.EngineOpts, logger log.Logger, l Limits, schema config.SchemaConfig, metrics *Metrics, mw base.Middleware, namespace string, merger base.Merger, limits Limits, iqo util.IngesterQueryOptions) (base.Middleware, error) {
+func NewDetectedLabelsTripperware(cfg Config, logger log.Logger, l Limits, schema config.SchemaConfig, metrics *Metrics, namespace string, merger base.Merger, limits Limits, iqo util.IngesterQueryOptions) (base.Middleware, error) {
 	return base.MiddlewareFunc(func(next base.Handler) base.Handler {
-		statsHandler := mw.Wrap(next)
 		splitter := newDefaultSplitter(limits, iqo)
 
 		queryRangeMiddleware := []base.Middleware{
 			StatsCollectorMiddleware(),
 			NewLimitsMiddleware(l),
-			NewQuerySizeLimiterMiddleware(schema.Configs, opts, logger, l, statsHandler),
 			base.InstrumentMiddleware("split_by_interval", metrics.InstrumentMiddlewareMetrics),
 			SplitByIntervalMiddleware(schema.Configs, limits, merger, splitter, metrics.SplitByMetrics),
 		}
-
-		// The sharding middleware takes care of enforcing this limit for both shardable and non-shardable queries.
-		// If we are not using sharding, we enforce the limit by adding this middleware after time splitting.
-		queryRangeMiddleware = append(queryRangeMiddleware,
-			NewQuerierSizeLimiterMiddleware(schema.Configs, opts, logger, l, statsHandler),
-		)
 
 		if cfg.MaxRetries > 0 {
 			queryRangeMiddleware = append(


### PR DESCRIPTION
**What this PR does / why we need it**:

Similar to https://github.com/grafana/loki/pull/13423 the `detected_labels` endpoint does not need the limit middleware. `DetectedLabels` is an index only query and thus should be fine to execute without limits.

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
