### PR TITLE
chore: move timestamps into SegmentWriter

### DIFF
--- a/pkg/storage/wal/manager_test.go
+++ b/pkg/storage/wal/manager_test.go
@@ -311,7 +311,7 @@ func TestManager_NextPendingAge(t *testing.T) {
 	s, err := m.NextPending()
 	require.NoError(t, err)
 	require.NotNil(t, s)
-	require.Equal(t, 100*time.Millisecond, s.Age())
+	require.Equal(t, 100*time.Millisecond, s.Writer.Age(s.Moved))
 	m.Put(s)
 
 	// Append 1KB of data using two separate append requests, 1ms apart.
@@ -342,7 +342,7 @@ func TestManager_NextPendingAge(t *testing.T) {
 	s, err = m.NextPending()
 	require.NoError(t, err)
 	require.NotNil(t, s)
-	require.Equal(t, time.Millisecond, s.Age())
+	require.Equal(t, time.Millisecond, s.Writer.Age(s.Moved))
 }
 
 func TestManager_NextPendingMaxAgeExceeded(t *testing.T) {

--- a/pkg/storage/wal/segment_test.go
+++ b/pkg/storage/wal/segment_test.go
@@ -112,7 +112,7 @@ func TestWalSegmentWriter_Append(t *testing.T) {
 				for _, stream := range batch {
 					labels, err := syntax.ParseLabels(stream.labels)
 					require.NoError(t, err)
-					w.Append(stream.tenant, stream.labels, labels, stream.entries)
+					w.Append(stream.tenant, stream.labels, labels, stream.entries, time.Now())
 				}
 			}
 			require.NotEmpty(t, tt.expected, "expected entries are empty")
@@ -150,7 +150,7 @@ func TestMultiTenantWrite(t *testing.T) {
 			for i := 0; i < 10; i++ {
 				w.Append(tenant, lblString, lbl, []*push.Entry{
 					{Timestamp: time.Unix(0, int64(i)), Line: fmt.Sprintf("log line %d", i)},
-				})
+				}, time.Now())
 			}
 		}
 	}
@@ -225,7 +225,7 @@ func testCompression(t *testing.T, maxInputSize int64) {
 			inputSize += int64(len(line))
 			w.Append("tenant", lbl.String(), lbl, []*push.Entry{
 				{Timestamp: time.Unix(0, int64(i*1e9)), Line: string(line)},
-			})
+			}, time.Now())
 		}
 	}
 
@@ -267,7 +267,7 @@ func TestReset(t *testing.T) {
 		{Timestamp: time.Unix(0, 0), Line: "Entry 1"},
 		{Timestamp: time.Unix(1, 0), Line: "Entry 2"},
 		{Timestamp: time.Unix(2, 0), Line: "Entry 3"},
-	})
+	}, time.Now())
 
 	n, err := w.WriteTo(dst)
 	require.NoError(t, err)
@@ -280,7 +280,7 @@ func TestReset(t *testing.T) {
 		{Timestamp: time.Unix(0, 0), Line: "Entry 1"},
 		{Timestamp: time.Unix(1, 0), Line: "Entry 2"},
 		{Timestamp: time.Unix(2, 0), Line: "Entry 3"},
-	})
+	}, time.Now())
 
 	n, err = w.WriteTo(copyBuffer)
 	require.NoError(t, err)
@@ -300,13 +300,13 @@ func Test_Meta(t *testing.T) {
 		{Timestamp: time.Unix(1, 0), Line: "Entry 1"},
 		{Timestamp: time.Unix(2, 0), Line: "Entry 2"},
 		{Timestamp: time.Unix(3, 0), Line: "Entry 3"},
-	})
+	}, time.Now())
 	lbls = labels.FromStrings("container", "bar", "namespace", "dev")
 	w.Append("tenanta", lbls.String(), lbls, []*push.Entry{
 		{Timestamp: time.Unix(2, 0), Line: "Entry 1"},
 		{Timestamp: time.Unix(3, 0), Line: "Entry 2"},
 		{Timestamp: time.Unix(4, 0), Line: "Entry 3"},
-	})
+	}, time.Now())
 	_, err = w.WriteTo(buff)
 	require.NoError(t, err)
 	meta := w.Meta("bar")
@@ -385,7 +385,7 @@ func BenchmarkWrites(b *testing.B) {
 	require.NoError(b, err)
 
 	for _, d := range data {
-		writer.Append(d.tenant, d.labels, d.lbls, d.entries)
+		writer.Append(d.tenant, d.labels, d.lbls, d.entries, time.Now())
 	}
 
 	encodedLength, err := writer.WriteTo(dst)


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit starts to move some of the timestamp fields out of the WAL Manager and into `SegmentWriter`. The purpose of this is so we can increment all the metrics and have all the stats in the same place. I will think about how to move `moved` next. 

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
