### PR TITLE
feat: add loki_ingester_rf1_segment_age_seconds metric

### DIFF
--- a/pkg/ingester-rf1/flush.go
+++ b/pkg/ingester-rf1/flush.go
@@ -99,7 +99,7 @@ func (i *Ingester) flushSegment(ctx context.Context, j int, w *wal.SegmentWriter
 	start := time.Now()
 
 	i.metrics.flushesTotal.Add(1)
-	defer i.metrics.flushDuration.Observe(time.Since(start).Seconds())
+	defer func() { i.metrics.flushDuration.Observe(time.Since(start).Seconds()) }()
 
 	buf := i.flushBuffers[j]
 	defer buf.Reset()

--- a/pkg/ingester-rf1/ingester.go
+++ b/pkg/ingester-rf1/ingester.go
@@ -244,7 +244,7 @@ func New(cfg Config, clientConfig client.Config,
 		MaxAge:         cfg.MaxSegmentAge,
 		MaxSegments:    int64(cfg.MaxSegments),
 		MaxSegmentSize: int64(cfg.MaxSegmentSize),
-	}, wal.NewMetrics(registerer))
+	}, wal.NewManagerMetrics(registerer))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ingester-rf1/metrics.go
+++ b/pkg/ingester-rf1/metrics.go
@@ -1,9 +1,10 @@
 package ingesterrf1
 
 import (
-	"github.com/grafana/loki/v3/pkg/storage/wal"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	"github.com/grafana/loki/v3/pkg/storage/wal"
 )
 
 type ingesterMetrics struct {

--- a/pkg/ingester-rf1/metrics.go
+++ b/pkg/ingester-rf1/metrics.go
@@ -1,20 +1,38 @@
 package ingesterrf1
 
 import (
+	"github.com/grafana/loki/v3/pkg/storage/wal"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
-type flushMetrics struct {
+type ingesterMetrics struct {
+	autoForgetUnhealthyIngestersTotal prometheus.Counter
+	limiterEnabled                    prometheus.Gauge
+	// Shutdown marker for ingester scale down.
+	shutdownMarker     prometheus.Gauge
 	flushesTotal       prometheus.Counter
 	flushFailuresTotal prometheus.Counter
 	flushQueues        prometheus.Gauge
 	flushDuration      prometheus.Histogram
-	flushSizeBytes     prometheus.Histogram
+	flushSize          prometheus.Histogram
+	segmentMetrics     *wal.SegmentMetrics
 }
 
-func newFlushMetrics(r prometheus.Registerer) *flushMetrics {
-	return &flushMetrics{
+func newIngesterMetrics(r prometheus.Registerer) *ingesterMetrics {
+	return &ingesterMetrics{
+		autoForgetUnhealthyIngestersTotal: promauto.With(r).NewCounter(prometheus.CounterOpts{
+			Name: "loki_ingester_rf1_autoforget_unhealthy_ingesters_total",
+			Help: "Total number of ingesters automatically forgotten.",
+		}),
+		limiterEnabled: promauto.With(r).NewGauge(prometheus.GaugeOpts{
+			Name: "loki_ingester_rf1_limiter_enabled",
+			Help: "1 if the limiter is enabled, otherwise 0.",
+		}),
+		shutdownMarker: promauto.With(r).NewGauge(prometheus.GaugeOpts{
+			Name: "loki_ingester_rf1_shutdown_marker",
+			Help: "1 if prepare shutdown has been called, 0 otherwise.",
+		}),
 		flushesTotal: promauto.With(r).NewCounter(prometheus.CounterOpts{
 			Name: "loki_ingester_rf1_flushes_total",
 			Help: "The total number of flushes.",
@@ -33,37 +51,12 @@ func newFlushMetrics(r prometheus.Registerer) *flushMetrics {
 			Buckets:                     prometheus.ExponentialBuckets(0.001, 4, 8),
 			NativeHistogramBucketFactor: 1.1,
 		}),
-		flushSizeBytes: promauto.With(r).NewHistogram(prometheus.HistogramOpts{
+		flushSize: promauto.With(r).NewHistogram(prometheus.HistogramOpts{
 			Name:                        "loki_ingester_rf1_flush_size_bytes",
 			Help:                        "The flush size (as written to object storage).",
 			Buckets:                     prometheus.ExponentialBuckets(100, 10, 8),
 			NativeHistogramBucketFactor: 1.1,
 		}),
-	}
-}
-
-type ingesterMetrics struct {
-	autoForgetUnhealthyIngestersTotal prometheus.Counter
-	limiterEnabled                    prometheus.Gauge
-	// Shutdown marker for ingester scale down.
-	shutdownMarker prometheus.Gauge
-	*flushMetrics
-}
-
-func newIngesterMetrics(r prometheus.Registerer) *ingesterMetrics {
-	return &ingesterMetrics{
-		autoForgetUnhealthyIngestersTotal: promauto.With(r).NewCounter(prometheus.CounterOpts{
-			Name: "loki_ingester_rf1_autoforget_unhealthy_ingesters_total",
-			Help: "Total number of ingesters automatically forgotten.",
-		}),
-		limiterEnabled: promauto.With(r).NewGauge(prometheus.GaugeOpts{
-			Name: "loki_ingester_rf1_limiter_enabled",
-			Help: "1 if the limiter is enabled, otherwise 0.",
-		}),
-		shutdownMarker: promauto.With(r).NewGauge(prometheus.GaugeOpts{
-			Name: "loki_ingester_rf1_shutdown_marker",
-			Help: "1 if prepare shutdown has been called, 0 otherwise.",
-		}),
-		flushMetrics: newFlushMetrics(r),
+		segmentMetrics: wal.NewSegmentMetrics(r),
 	}
 }

--- a/pkg/storage/wal/manager_test.go
+++ b/pkg/storage/wal/manager_test.go
@@ -20,7 +20,7 @@ func TestManager_Append(t *testing.T) {
 		MaxAge:         30 * time.Second,
 		MaxSegments:    1,
 		MaxSegmentSize: 1024, // 1KB
-	}, NewMetrics(nil))
+	}, NewManagerMetrics(nil))
 	require.NoError(t, err)
 
 	// Append some data.
@@ -59,7 +59,7 @@ func TestManager_AppendFailed(t *testing.T) {
 		MaxAge:         30 * time.Second,
 		MaxSegments:    1,
 		MaxSegmentSize: 1024, // 1KB
-	}, NewMetrics(nil))
+	}, NewManagerMetrics(nil))
 	require.NoError(t, err)
 
 	// Append some data.
@@ -92,7 +92,7 @@ func TestManager_AppendFailedWALClosed(t *testing.T) {
 		MaxAge:         30 * time.Second,
 		MaxSegments:    10,
 		MaxSegmentSize: 1024, // 1KB
-	}, NewMetrics(nil))
+	}, NewManagerMetrics(nil))
 	require.NoError(t, err)
 
 	// Append some data.
@@ -126,7 +126,7 @@ func TestManager_AppendFailedWALFull(t *testing.T) {
 		MaxAge:         30 * time.Second,
 		MaxSegments:    10,
 		MaxSegmentSize: 1024, // 1KB
-	}, NewMetrics(nil))
+	}, NewManagerMetrics(nil))
 	require.NoError(t, err)
 
 	// Should be able to write 100KB of data, 10KB per segment.
@@ -161,7 +161,7 @@ func TestManager_AppendMaxAgeExceeded(t *testing.T) {
 		MaxAge:         100 * time.Millisecond,
 		MaxSegments:    1,
 		MaxSegmentSize: 8 * 1024 * 1024, // 8MB
-	}, NewMetrics(nil))
+	}, NewManagerMetrics(nil))
 	require.NoError(t, err)
 
 	// Create a mock clock.
@@ -208,7 +208,7 @@ func TestManager_AppendMaxSizeExceeded(t *testing.T) {
 		MaxAge:         30 * time.Second,
 		MaxSegments:    1,
 		MaxSegmentSize: 1024, // 1KB
-	}, NewMetrics(nil))
+	}, NewManagerMetrics(nil))
 	require.NoError(t, err)
 
 	// Append 512B of data.
@@ -250,7 +250,7 @@ func TestManager_NextPending(t *testing.T) {
 		MaxAge:         30 * time.Second,
 		MaxSegments:    1,
 		MaxSegmentSize: 1024, // 1KB
-	}, NewMetrics(nil))
+	}, NewManagerMetrics(nil))
 	require.NoError(t, err)
 
 	// There should be no segments waiting to be flushed as no data has been
@@ -286,7 +286,7 @@ func TestManager_NextPendingAge(t *testing.T) {
 		MaxAge:         100 * time.Millisecond,
 		MaxSegments:    1,
 		MaxSegmentSize: 1024, // 1KB
-	}, NewMetrics(nil))
+	}, NewManagerMetrics(nil))
 	require.NoError(t, err)
 
 	// Create a mock clock.
@@ -311,7 +311,7 @@ func TestManager_NextPendingAge(t *testing.T) {
 	s, err := m.NextPending()
 	require.NoError(t, err)
 	require.NotNil(t, s)
-	require.Equal(t, 100*time.Millisecond, s.Writer.Age(s.Moved))
+	require.Equal(t, 100*time.Millisecond, s.Writer.Age(clock.Now()))
 	m.Put(s)
 
 	// Append 1KB of data using two separate append requests, 1ms apart.
@@ -342,7 +342,7 @@ func TestManager_NextPendingAge(t *testing.T) {
 	s, err = m.NextPending()
 	require.NoError(t, err)
 	require.NotNil(t, s)
-	require.Equal(t, time.Millisecond, s.Writer.Age(s.Moved))
+	require.Equal(t, time.Millisecond, s.Writer.Age(clock.Now()))
 }
 
 func TestManager_NextPendingMaxAgeExceeded(t *testing.T) {
@@ -350,7 +350,7 @@ func TestManager_NextPendingMaxAgeExceeded(t *testing.T) {
 		MaxAge:         100 * time.Millisecond,
 		MaxSegments:    1,
 		MaxSegmentSize: 1024, // 1KB
-	}, NewMetrics(nil))
+	}, NewManagerMetrics(nil))
 	require.NoError(t, err)
 
 	// Create a mock clock.
@@ -392,7 +392,7 @@ func TestManager_NextPendingWALClosed(t *testing.T) {
 		MaxAge:         30 * time.Second,
 		MaxSegments:    1,
 		MaxSegmentSize: 1024, // 1KB
-	}, NewMetrics(nil))
+	}, NewManagerMetrics(nil))
 	require.NoError(t, err)
 
 	// Append some data.
@@ -435,7 +435,7 @@ func TestManager_Put(t *testing.T) {
 		MaxAge:         30 * time.Second,
 		MaxSegments:    1,
 		MaxSegmentSize: 1024, // 1KB
-	}, NewMetrics(nil))
+	}, NewManagerMetrics(nil))
 	require.NoError(t, err)
 
 	// There should be 1 available and 0 pending segments.
@@ -482,7 +482,7 @@ func TestManager_Metrics(t *testing.T) {
 	m, err := NewManager(Config{
 		MaxSegments:    1,
 		MaxSegmentSize: 1024, // 1KB
-	}, NewMetrics(r))
+	}, NewManagerMetrics(r))
 	require.NoError(t, err)
 
 	metricNames := []string{

--- a/pkg/storage/wal/segment.go
+++ b/pkg/storage/wal/segment.go
@@ -66,7 +66,10 @@ type SegmentWriter struct {
 
 // SegmentStats contains the stats for a SegmentWriter.
 type SegmentStats struct {
-	Age       time.Duration
+	// Age is the time between the first append and the flush.
+	Age time.Duration
+	// Idle is the time between the last append and the flush.
+	Idle      time.Duration
 	Streams   int
 	Tenants   int
 	Size      int64
@@ -83,6 +86,7 @@ func GetSegmentStats(w *SegmentWriter, t time.Time) SegmentStats {
 	}
 	return SegmentStats{
 		Age:       t.Sub(w.firstAppend),
+		Idle:      t.Sub(w.lastAppend),
 		Streams:   len(w.streams),
 		Tenants:   len(tenants),
 		Size:      w.inputSize.Load(),

--- a/pkg/storage/wal/segment_test.go
+++ b/pkg/storage/wal/segment_test.go
@@ -105,7 +105,7 @@ func TestWalSegmentWriter_Append(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			// Create a new WalSegmentWriter
-			w, err := NewWalSegmentWriter(NewSegmentMetrics(nil))
+			w, err := NewWalSegmentWriter()
 			require.NoError(t, err)
 			// Append the entries
 			for _, batch := range tt.batches {
@@ -132,7 +132,7 @@ func TestWalSegmentWriter_Append(t *testing.T) {
 }
 
 func TestMultiTenantWrite(t *testing.T) {
-	w, err := NewWalSegmentWriter(NewSegmentMetrics(nil))
+	w, err := NewWalSegmentWriter()
 	require.NoError(t, err)
 	dst := bytes.NewBuffer(nil)
 
@@ -202,7 +202,7 @@ func TestCompression(t *testing.T) {
 }
 
 func testCompression(t *testing.T, maxInputSize int64) {
-	w, err := NewWalSegmentWriter(NewSegmentMetrics(nil))
+	w, err := NewWalSegmentWriter()
 	require.NoError(t, err)
 	dst := bytes.NewBuffer(nil)
 	files := testdata.Files()
@@ -259,7 +259,7 @@ func testCompression(t *testing.T, maxInputSize int64) {
 }
 
 func TestReset(t *testing.T) {
-	w, err := NewWalSegmentWriter(NewSegmentMetrics(nil))
+	w, err := NewWalSegmentWriter()
 	require.NoError(t, err)
 	dst := bytes.NewBuffer(nil)
 
@@ -290,7 +290,7 @@ func TestReset(t *testing.T) {
 }
 
 func Test_Meta(t *testing.T) {
-	w, err := NewWalSegmentWriter(NewSegmentMetrics(nil))
+	w, err := NewWalSegmentWriter()
 	buff := bytes.NewBuffer(nil)
 
 	require.NoError(t, err)
@@ -381,7 +381,7 @@ func BenchmarkWrites(b *testing.B) {
 
 	dst := bytes.NewBuffer(make([]byte, 0, inputSize))
 
-	writer, err := NewWalSegmentWriter(NewSegmentMetrics(nil))
+	writer, err := NewWalSegmentWriter()
 	require.NoError(b, err)
 
 	for _, d := range data {


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request adds a new metric `loki_ingester_rf1_segment_age_seconds`. It also cleans up a lot of the code that is used to report metrics for segments and adds a new `SegmentsStats` struct to get data from a `SegmentWriter`.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
