### PR TITLE
fix(blooms): Improve error wrap to make ignoreNotFound work when fetching blocks

### DIFF
--- a/pkg/storage/stores/shipper/bloomshipper/client.go
+++ b/pkg/storage/stores/shipper/bloomshipper/client.go
@@ -316,7 +316,7 @@ func (b *BloomClient) GetBlock(ctx context.Context, ref BlockRef) (BlockDirector
 
 	rc, _, err := b.client.GetObject(ctx, key)
 	if err != nil {
-		return BlockDirectory{}, fmt.Errorf("failed to get block file %s: %w", key, err)
+		return BlockDirectory{}, errors.Wrap(err, fmt.Sprintf("failed to get block file %s", key))
 	}
 	defer rc.Close()
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix an issue where the `options.ignoreNotFound` of the fetcher is not effective. 

The root cause of this issue is that the error returned by `fmt.Errorf()` in `BloomClient` loses the underlying cause. As a result, `S3ObjectClient.IsObjectNotFoundErr()` fails to determine if the underlying cause of the returned error is of type `awserr.Error`.

https://github.com/grafana/loki/blob/2dfc13bb73c73c6c8cfb57c23ce832f902d8a43e/pkg/storage/chunk/client/aws/s3_storage_client.go#L498C1-L504C2


**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
