### PR TITLE
chore: Remove client header interceptors from metastore client

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -115,8 +115,8 @@ Pass the `-config.expand-env` flag at the command line to enable this way of set
 [querier: <querier>]
 
 querier_rf1:
-  # Enable the RF1 querier. If set, replaces the usual querier with a RF-1
-  # querier when using 'ALL' target.
+  # Enable the RF1 querier. If set, replaces the usual querier with an RF-1
+  # querier.
   # CLI flag: -querier-rf1.enabled
   [enabled: <boolean> | default = false]
 

--- a/pkg/ingester-rf1/metastore/client/client.go
+++ b/pkg/ingester-rf1/metastore/client/client.go
@@ -13,7 +13,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/grpc"
 
-	metastorepb "github.com/grafana/loki/v3/pkg/ingester-rf1/metastore/metastorepb"
+	"github.com/grafana/loki/v3/pkg/ingester-rf1/metastore/metastorepb"
 	"github.com/grafana/loki/v3/pkg/util/constants"
 )
 
@@ -106,12 +106,10 @@ const grpcServiceConfig = `{
 func instrumentation(latency *prometheus.HistogramVec) ([]grpc.UnaryClientInterceptor, []grpc.StreamClientInterceptor) {
 	var unaryInterceptors []grpc.UnaryClientInterceptor
 	unaryInterceptors = append(unaryInterceptors, otgrpc.OpenTracingClientInterceptor(opentracing.GlobalTracer()))
-	unaryInterceptors = append(unaryInterceptors, middleware.ClientUserHeaderInterceptor)
 	unaryInterceptors = append(unaryInterceptors, middleware.UnaryClientInstrumentInterceptor(latency))
 
 	var streamInterceptors []grpc.StreamClientInterceptor
 	streamInterceptors = append(streamInterceptors, otgrpc.OpenTracingStreamClientInterceptor(opentracing.GlobalTracer()))
-	streamInterceptors = append(streamInterceptors, middleware.StreamClientUserHeaderInterceptor)
 	streamInterceptors = append(streamInterceptors, middleware.StreamClientInstrumentInterceptor(latency))
 
 	return unaryInterceptors, streamInterceptors

--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -722,7 +722,7 @@ func (t *Loki) setupModuleManager() error {
 		TenantConfigs:            {RuntimeConfig},
 		Distributor:              {Ring, Server, Overrides, TenantConfigs, PatternRingClient, IngesterRF1RingClient, Analytics},
 		Store:                    {Overrides, IndexGatewayRing},
-		IngesterRF1:              {Store, Server, MemberlistKV, TenantConfigs, MetastoreClient, Analytics, Metastore},
+		IngesterRF1:              {Store, Server, MemberlistKV, TenantConfigs, MetastoreClient, Analytics},
 		Ingester:                 {Store, Server, MemberlistKV, TenantConfigs, Analytics},
 		Querier:                  {Store, Ring, Server, IngesterQuerier, PatternRingClient, Overrides, Analytics, CacheGenerationLoader, QuerySchedulerRing},
 		QueryFrontendTripperware: {Server, Overrides, TenantConfigs},
@@ -752,7 +752,7 @@ func (t *Loki) setupModuleManager() error {
 		Write:   {Ingester, IngesterRF1, Distributor, PatternIngester},
 		Backend: {QueryScheduler, Ruler, Compactor, IndexGateway, BloomGateway, BloomCompactor},
 
-		All: {QueryScheduler, QueryFrontend, Querier, Ingester, IngesterRF1, PatternIngester, Distributor, Ruler, Compactor},
+		All: {QueryScheduler, QueryFrontend, Querier, Ingester, IngesterRF1, PatternIngester, Distributor, Ruler, Compactor, Metastore},
 	}
 
 	if t.Cfg.Querier.PerRequestLimitsEnabled {

--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -722,7 +722,7 @@ func (t *Loki) setupModuleManager() error {
 		TenantConfigs:            {RuntimeConfig},
 		Distributor:              {Ring, Server, Overrides, TenantConfigs, PatternRingClient, IngesterRF1RingClient, Analytics},
 		Store:                    {Overrides, IndexGatewayRing},
-		IngesterRF1:              {Store, Server, MemberlistKV, TenantConfigs, MetastoreClient, Analytics},
+		IngesterRF1:              {Store, Server, MemberlistKV, TenantConfigs, MetastoreClient, Analytics, Metastore},
 		Ingester:                 {Store, Server, MemberlistKV, TenantConfigs, Analytics},
 		Querier:                  {Store, Ring, Server, IngesterQuerier, PatternRingClient, Overrides, Analytics, CacheGenerationLoader, QuerySchedulerRing},
 		QueryFrontendTripperware: {Server, Overrides, TenantConfigs},

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -1814,6 +1814,12 @@ func (t *Loki) initAnalytics() (services.Service, error) {
 }
 
 func (t *Loki) initMetastore() (services.Service, error) {
+	if !t.Cfg.IngesterRF1.Enabled {
+		return nil, nil
+	}
+	if t.Cfg.isTarget(All) {
+		t.Cfg.MetastoreClient.MetastoreAddress = fmt.Sprintf("localhost:%s", t.Cfg.Server.GRPCListenAddress)
+	}
 	m, err := metastore.New(t.Cfg.Metastore, log.With(util_log.Logger, "component", "metastore"), prometheus.DefaultRegisterer, t.health)
 	if err != nil {
 		return nil, err

--- a/pkg/querier-rf1/querier.go
+++ b/pkg/querier-rf1/querier.go
@@ -57,7 +57,7 @@ type Config struct {
 // RegisterFlags register flags.
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	cfg.Engine.RegisterFlagsWithPrefix("querier-rf1", f)
-	f.BoolVar(&cfg.Enabled, "querier-rf1.enabled", false, "Enable the RF1 querier. If set, replaces the usual querier with a RF-1 querier when using 'ALL' target.")
+	f.BoolVar(&cfg.Enabled, "querier-rf1.enabled", false, "Enable the RF1 querier. If set, replaces the usual querier with an RF-1 querier.")
 	f.DurationVar(&cfg.ExtraQueryDelay, "querier-rf1.extra-query-delay", 0, "Time to wait before sending more than the minimum successful query requests.")
 	f.IntVar(&cfg.MaxConcurrent, "querier-rf1.max-concurrent", 4, "The maximum number of queries that can be simultaneously processed by the querier.")
 	f.BoolVar(&cfg.PerRequestLimitsEnabled, "querier-rf1.per-request-limits-enabled", false, "When true, querier limits sent via a header are enforced.")


### PR DESCRIPTION
**What this PR does / why we need it**:
* Removes the client header interceptors from the metastore client
* Starts the metastore with the All target as long as ingester-rf1 is enabled.
* Under "All" target, sets the metastore address to be the local grpc port because the cmd/loki/loki-local-config.yml specifies a different port for some reason.
