### PR TITLE
fix: fix a bug where AppendRequest with no entries triggers flush

### DIFF
--- a/pkg/storage/wal/manager.go
+++ b/pkg/storage/wal/manager.go
@@ -153,7 +153,10 @@ func (m *Manager) Append(r AppendRequest) (*AppendResult, error) {
 		return nil, ErrFull
 	}
 	s := el.Value.(*segment)
-	s.w.Append(r.TenantID, r.LabelsStr, r.Labels, r.Entries, m.clock.Now())
+	err := s.w.Append(r.TenantID, r.LabelsStr, r.Labels, r.Entries, m.clock.Now())
+	if err != nil {
+		return nil, err
+	}
 	// If the segment exceeded the maximum age or the maximum size, move s to
 	// the closed list to be flushed.
 	if m.clock.Since(s.w.firstAppend) >= m.cfg.MaxAge || s.w.InputSize() >= m.cfg.MaxSegmentSize {

--- a/pkg/storage/wal/manager_test.go
+++ b/pkg/storage/wal/manager_test.go
@@ -87,6 +87,26 @@ func TestManager_AppendFailed(t *testing.T) {
 	require.EqualError(t, res.Err(), "failed to flush")
 }
 
+func TestManager_AppendFailedNoEntries(t *testing.T) {
+	m, err := NewManager(Config{
+		MaxAge:         30 * time.Second,
+		MaxSegments:    1,
+		MaxSegmentSize: 1024, // 1KB
+	}, NewManagerMetrics(nil))
+	require.NoError(t, err)
+
+	// Append no entries.
+	lbs := labels.Labels{{Name: "a", Value: "b"}}
+	res, err := m.Append(AppendRequest{
+		TenantID:  "1",
+		Labels:    lbs,
+		LabelsStr: lbs.String(),
+		Entries:   []*logproto.Entry{},
+	})
+	require.ErrorIs(t, err, ErrNoEntries)
+	require.Nil(t, res)
+}
+
 func TestManager_AppendFailedWALClosed(t *testing.T) {
 	m, err := NewManager(Config{
 		MaxAge:         30 * time.Second,

--- a/pkg/storage/wal/segment.go
+++ b/pkg/storage/wal/segment.go
@@ -35,7 +35,8 @@ var (
 			}
 		},
 	}
-	tenantLabel = "__loki_tenant__"
+	tenantLabel  = "__loki_tenant__"
+	ErrNoEntries = errors.New("no entries")
 )
 
 func init() {
@@ -164,9 +165,9 @@ func (b *SegmentWriter) getOrCreateStream(id streamID, lbls labels.Labels) *stre
 }
 
 // Labels are passed a string  `{foo="bar",baz="qux"}`  `{foo="foo",baz="foo"}`. labels.Labels => Symbols foo, baz , qux
-func (b *SegmentWriter) Append(tenantID, labelsString string, lbls labels.Labels, entries []*logproto.Entry, now time.Time) {
+func (b *SegmentWriter) Append(tenantID, labelsString string, lbls labels.Labels, entries []*logproto.Entry, now time.Time) error {
 	if len(entries) == 0 {
-		return
+		return ErrNoEntries
 	}
 	if b.firstAppend.IsZero() {
 		b.firstAppend = now
@@ -194,6 +195,7 @@ func (b *SegmentWriter) Append(tenantID, labelsString string, lbls labels.Labels
 		copy(s.entries[idx+1:], s.entries[idx:])
 		s.entries[idx] = e
 	}
+	return nil
 }
 
 func (b *SegmentWriter) Meta(id string) *metastorepb.BlockMeta {

--- a/pkg/storage/wal/segment_test.go
+++ b/pkg/storage/wal/segment_test.go
@@ -112,7 +112,7 @@ func TestWalSegmentWriter_Append(t *testing.T) {
 				for _, stream := range batch {
 					labels, err := syntax.ParseLabels(stream.labels)
 					require.NoError(t, err)
-					w.Append(stream.tenant, stream.labels, labels, stream.entries, time.Now())
+					require.NoError(t, w.Append(stream.tenant, stream.labels, labels, stream.entries, time.Now()))
 				}
 			}
 			require.NotEmpty(t, tt.expected, "expected entries are empty")
@@ -148,9 +148,9 @@ func TestMultiTenantWrite(t *testing.T) {
 		for _, lbl := range lbls {
 			lblString := lbl.String()
 			for i := 0; i < 10; i++ {
-				w.Append(tenant, lblString, lbl, []*push.Entry{
+				require.NoError(t, w.Append(tenant, lblString, lbl, []*push.Entry{
 					{Timestamp: time.Unix(0, int64(i)), Line: fmt.Sprintf("log line %d", i)},
-				}, time.Now())
+				}, time.Now()))
 			}
 		}
 	}
@@ -223,9 +223,9 @@ func testCompression(t *testing.T, maxInputSize int64) {
 				continue
 			}
 			inputSize += int64(len(line))
-			w.Append("tenant", lbl.String(), lbl, []*push.Entry{
+			require.NoError(t, w.Append("tenant", lbl.String(), lbl, []*push.Entry{
 				{Timestamp: time.Unix(0, int64(i*1e9)), Line: string(line)},
-			}, time.Now())
+			}, time.Now()))
 		}
 	}
 
@@ -263,11 +263,11 @@ func TestReset(t *testing.T) {
 	require.NoError(t, err)
 	dst := bytes.NewBuffer(nil)
 
-	w.Append("tenant", "foo", labels.FromStrings("container", "foo", "namespace", "dev"), []*push.Entry{
+	require.NoError(t, w.Append("tenant", "foo", labels.FromStrings("container", "foo", "namespace", "dev"), []*push.Entry{
 		{Timestamp: time.Unix(0, 0), Line: "Entry 1"},
 		{Timestamp: time.Unix(1, 0), Line: "Entry 2"},
 		{Timestamp: time.Unix(2, 0), Line: "Entry 3"},
-	}, time.Now())
+	}, time.Now()))
 
 	n, err := w.WriteTo(dst)
 	require.NoError(t, err)
@@ -276,11 +276,11 @@ func TestReset(t *testing.T) {
 	copyBuffer := bytes.NewBuffer(nil)
 
 	w.Reset()
-	w.Append("tenant", "foo", labels.FromStrings("container", "foo", "namespace", "dev"), []*push.Entry{
+	require.NoError(t, w.Append("tenant", "foo", labels.FromStrings("container", "foo", "namespace", "dev"), []*push.Entry{
 		{Timestamp: time.Unix(0, 0), Line: "Entry 1"},
 		{Timestamp: time.Unix(1, 0), Line: "Entry 2"},
 		{Timestamp: time.Unix(2, 0), Line: "Entry 3"},
-	}, time.Now())
+	}, time.Now()))
 
 	n, err = w.WriteTo(copyBuffer)
 	require.NoError(t, err)
@@ -296,17 +296,17 @@ func Test_Meta(t *testing.T) {
 	require.NoError(t, err)
 
 	lbls := labels.FromStrings("container", "foo", "namespace", "dev")
-	w.Append("tenantb", lbls.String(), lbls, []*push.Entry{
+	require.NoError(t, w.Append("tenantb", lbls.String(), lbls, []*push.Entry{
 		{Timestamp: time.Unix(1, 0), Line: "Entry 1"},
 		{Timestamp: time.Unix(2, 0), Line: "Entry 2"},
 		{Timestamp: time.Unix(3, 0), Line: "Entry 3"},
-	}, time.Now())
+	}, time.Now()))
 	lbls = labels.FromStrings("container", "bar", "namespace", "dev")
-	w.Append("tenanta", lbls.String(), lbls, []*push.Entry{
+	require.NoError(t, w.Append("tenanta", lbls.String(), lbls, []*push.Entry{
 		{Timestamp: time.Unix(2, 0), Line: "Entry 1"},
 		{Timestamp: time.Unix(3, 0), Line: "Entry 2"},
 		{Timestamp: time.Unix(4, 0), Line: "Entry 3"},
-	}, time.Now())
+	}, time.Now()))
 	_, err = w.WriteTo(buff)
 	require.NoError(t, err)
 	meta := w.Meta("bar")
@@ -385,7 +385,7 @@ func BenchmarkWrites(b *testing.B) {
 	require.NoError(b, err)
 
 	for _, d := range data {
-		writer.Append(d.tenant, d.labels, d.lbls, d.entries, time.Now())
+		require.NoError(b, writer.Append(d.tenant, d.labels, d.lbls, d.entries, time.Now()))
 	}
 
 	encodedLength, err := writer.WriteTo(dst)


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit fixes a bug where an `AppendRequest` with no entries triggers a flush. This is because the code expects a successful `Append` to `SegmentWriter` to set the `firstAppend` timestamp.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
