### PR TITLE
fix: fix a bug where AppendRequest with no entries triggers flush

### DIFF
--- a/pkg/storage/wal/manager.go
+++ b/pkg/storage/wal/manager.go
@@ -156,7 +156,7 @@ func (m *Manager) Append(r AppendRequest) (*AppendResult, error) {
 	s.w.Append(r.TenantID, r.LabelsStr, r.Labels, r.Entries, m.clock.Now())
 	// If the segment exceeded the maximum age or the maximum size, move s to
 	// the closed list to be flushed.
-	if m.clock.Since(s.w.firstAppend) >= m.cfg.MaxAge || s.w.InputSize() >= m.cfg.MaxSegmentSize {
+	if s.w.Age(m.clock.Now()) >= m.cfg.MaxAge || s.w.InputSize() >= m.cfg.MaxSegmentSize {
 		m.move(el, s)
 	}
 	return s.r, nil
@@ -224,7 +224,7 @@ func (m *Manager) move(el *list.Element, s *segment) {
 func (m *Manager) moveFrontIfExpired() bool {
 	if el := m.available.Front(); el != nil {
 		s := el.Value.(*segment)
-		if !s.w.firstAppend.IsZero() && m.clock.Since(s.w.firstAppend) >= m.cfg.MaxAge {
+		if s.w.Age(m.clock.Now()) >= m.cfg.MaxAge {
 			m.move(el, s)
 			return true
 		}

--- a/pkg/storage/wal/segment.go
+++ b/pkg/storage/wal/segment.go
@@ -140,6 +140,9 @@ func NewWalSegmentWriter() (*SegmentWriter, error) {
 
 // Age returns the age of the segment.
 func (b *SegmentWriter) Age(now time.Time) time.Duration {
+	if b.firstAppend.IsZero() {
+		return 0
+	}
 	return now.Sub(b.firstAppend)
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit fixes a bug where an `AppendRequest` with no entries triggers a flush. This is because the code expects a successful `Append` to `SegmentWriter` to set the `firstAppend` timestamp. This is an alternative fix to #13665.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
