### PR TITLE
chore: use native histogram for metastore_request_duration_seconds

### DIFF
--- a/pkg/ingester-rf1/metastore/client/client.go
+++ b/pkg/ingester-rf1/metastore/client/client.go
@@ -14,7 +14,6 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/grafana/loki/v3/pkg/ingester-rf1/metastore/metastorepb"
-	"github.com/grafana/loki/v3/pkg/util/constants"
 )
 
 type Config struct {
@@ -58,8 +57,7 @@ func (c *Client) Service() services.Service { return c.service }
 
 func dial(cfg Config, r prometheus.Registerer) (*grpc.ClientConn, error) {
 	latency := prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Namespace:                   constants.Loki,
-		Name:                        "metastore_request_duration_seconds",
+		Name:                        "loki_metastore_request_duration_seconds",
 		Help:                        "Time (in seconds) spent serving requests when using the metastore",
 		Buckets:                     instrument.DefBuckets,
 		NativeHistogramBucketFactor: 1.1,

--- a/pkg/ingester-rf1/metastore/client/client.go
+++ b/pkg/ingester-rf1/metastore/client/client.go
@@ -58,10 +58,11 @@ func (c *Client) Service() services.Service { return c.service }
 
 func dial(cfg Config, r prometheus.Registerer) (*grpc.ClientConn, error) {
 	latency := prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Namespace: constants.Loki,
-		Name:      "metastore_request_duration_seconds",
-		Help:      "Time (in seconds) spent serving requests when using the metastore",
-		Buckets:   instrument.DefBuckets,
+		Namespace:                   constants.Loki,
+		Name:                        "metastore_request_duration_seconds",
+		Help:                        "Time (in seconds) spent serving requests when using the metastore",
+		Buckets:                     instrument.DefBuckets,
+		NativeHistogramBucketFactor: 1.1,
 	}, []string{"operation", "status_code"})
 	if r != nil {
 		err := r.Register(latency)

--- a/pkg/ingester-rf1/metastore/client/client.go
+++ b/pkg/ingester-rf1/metastore/client/client.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/grafana/dskit/grpcclient"
-	"github.com/grafana/dskit/instrument"
 	"github.com/grafana/dskit/middleware"
 	"github.com/grafana/dskit/services"
 	"github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc"
@@ -59,7 +58,7 @@ func dial(cfg Config, r prometheus.Registerer) (*grpc.ClientConn, error) {
 	latency := prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name:                        "loki_metastore_request_duration_seconds",
 		Help:                        "Time (in seconds) spent serving requests when using the metastore",
-		Buckets:                     instrument.DefBuckets,
+		Buckets:                     prometheus.ExponentialBuckets(0.001, 4, 8),
 		NativeHistogramBucketFactor: 1.1,
 	}, []string{"operation", "status_code"})
 	if r != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

Use native histograms for the `metastore_request_duration_seconds` metric.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
