### PR TITLE
chore: Use boltdb Batch API for metastore writes

### DIFF
--- a/pkg/ingester-rf1/metastore/metastore_state_add_block.go
+++ b/pkg/ingester-rf1/metastore/metastore_state_add_block.go
@@ -7,7 +7,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"go.etcd.io/bbolt"
 
-	metastorepb "github.com/grafana/loki/v3/pkg/ingester-rf1/metastore/metastorepb"
+	"github.com/grafana/loki/v3/pkg/ingester-rf1/metastore/metastorepb"
 )
 
 func (m *Metastore) AddBlock(_ context.Context, req *metastorepb.AddBlockRequest) (*metastorepb.AddBlockResponse, error) {
@@ -29,7 +29,7 @@ func (m *metastoreState) applyAddBlock(request *metastorepb.AddBlockRequest) (*m
 	if err != nil {
 		return nil, err
 	}
-	err = m.db.boltdb.Update(func(tx *bbolt.Tx) error {
+	err = m.db.boltdb.Batch(func(tx *bbolt.Tx) error {
 		return updateBlockMetadataBucket(tx, func(bucket *bbolt.Bucket) error {
 			return bucket.Put([]byte(request.Block.Id), value)
 		})

--- a/pkg/ingester-rf1/metastore/metastore_state_test.go
+++ b/pkg/ingester-rf1/metastore/metastore_state_test.go
@@ -1,0 +1,60 @@
+package metastore
+
+import (
+	"crypto/rand"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/oklog/ulid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/ingester-rf1/metastore/metastorepb"
+	util_log "github.com/grafana/loki/v3/pkg/util/log"
+)
+
+func Benchmark_metastoreState_applyAddBlock(t *testing.B) {
+	anHourAgo := ulid.Timestamp(time.Now())
+	workers := 1000
+	workChan := make(chan struct{}, workers)
+	wg := sync.WaitGroup{}
+	m := &metastoreState{
+		logger:        util_log.Logger,
+		segmentsMutex: sync.Mutex{},
+		segments:      make(map[string]*metastorepb.BlockMeta),
+		db: &boltdb{
+			logger: util_log.Logger,
+			config: Config{
+				DataDir: t.TempDir(),
+				Raft: RaftConfig{
+					Dir: t.TempDir(),
+				},
+			},
+		},
+	}
+
+	err := m.db.open(false)
+	require.NoError(t, err)
+
+	// Start workers
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			for range workChan {
+				m.applyAddBlock(&metastorepb.AddBlockRequest{
+					Block: &metastorepb.BlockMeta{
+						Id: ulid.MustNew(anHourAgo, rand.Reader).String(),
+					},
+				})
+			}
+			wg.Done()
+		}()
+	}
+
+	t.ResetTimer()
+	for i := 0; i < t.N; i++ {
+		workChan <- struct{}{}
+	}
+	close(workChan)
+	wg.Wait()
+}

--- a/pkg/ingester-rf1/metastore/metastore_state_test.go
+++ b/pkg/ingester-rf1/metastore/metastore_state_test.go
@@ -41,11 +41,12 @@ func Benchmark_metastoreState_applyAddBlock(t *testing.B) {
 		wg.Add(1)
 		go func() {
 			for range workChan {
-				m.applyAddBlock(&metastorepb.AddBlockRequest{
+				_, err = m.applyAddBlock(&metastorepb.AddBlockRequest{
 					Block: &metastorepb.BlockMeta{
 						Id: ulid.MustNew(anHourAgo, rand.Reader).String(),
 					},
 				})
+				require.NoError(t, err)
 			}
 			wg.Done()
 		}()


### PR DESCRIPTION
**What this PR does / why we need it**:
* Boltdb performs quite slowly when using `Update` as every call will result in a flush to disk
* Switching to batch allows calls from multiple goroutines (API calls) to be batched together into a single flush to disk which increase performance significantly.
* Default parameters for batching are max 1000 pending writes or every 10ms so each write still returns within a reasonable time.
* The benchmark scales roughly linearly up to 1000 workers: ~150 ops/sec to >80,000 ops/sec

```
goos: darwin
goarch: arm64
pkg: github.com/grafana/loki/v3/pkg/ingester-rf1/metastore
                                 │  before.txt   │              after.txt              │
                                 │    sec/op     │   sec/op     vs base                │
_metastoreState_applyAddBlock-14   8255.60µ ± 2%   15.84µ ± 2%  -99.81% (p=0.000 n=10)
```