### PR TITLE
chore: log stats around chunks being flushed

### DIFF
--- a/pkg/ingester/flush.go
+++ b/pkg/ingester/flush.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/dustin/go-humanize"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/backoff"
@@ -44,6 +45,60 @@ const (
 	flushReasonFull     = "full"
 	flushReasonSynced   = "synced"
 )
+
+// I don't know if this needs to be private but I only needed it in this package.
+type flushReasonCounter struct {
+	flushReasonIdle     int
+	flushReasonMaxAge   int
+	flushReasonForced   int
+	flushReasonNotOwned int
+	flushReasonFull     int
+	flushReasonSynced   int
+}
+
+func (f *flushReasonCounter) Log() []interface{} {
+	// return counters only if they are non zero
+	var log []interface{}
+	if f.flushReasonIdle > 0 {
+		log = append(log, "idle", f.flushReasonIdle)
+	}
+	if f.flushReasonMaxAge > 0 {
+		log = append(log, "max_age", f.flushReasonMaxAge)
+	}
+	if f.flushReasonForced > 0 {
+		log = append(log, "forced", f.flushReasonForced)
+	}
+	if f.flushReasonNotOwned > 0 {
+		log = append(log, "not_owned", f.flushReasonNotOwned)
+	}
+	if f.flushReasonFull > 0 {
+		log = append(log, "full", f.flushReasonFull)
+	}
+	if f.flushReasonSynced > 0 {
+		log = append(log, "synced", f.flushReasonSynced)
+	}
+	return log
+}
+
+func (f *flushReasonCounter) IncrementForReason(reason string) error {
+	switch reason {
+	case flushReasonIdle:
+		f.flushReasonIdle++
+	case flushReasonMaxAge:
+		f.flushReasonMaxAge++
+	case flushReasonForced:
+		f.flushReasonForced++
+	case flushReasonNotOwned:
+		f.flushReasonNotOwned++
+	case flushReasonFull:
+		f.flushReasonFull++
+	case flushReasonSynced:
+		f.flushReasonSynced++
+	default:
+		return fmt.Errorf("unknown reason: %s", reason)
+	}
+	return nil
+}
 
 // Note: this is called both during the WAL replay (zero or more times)
 // and then after replay as well.
@@ -220,8 +275,33 @@ func (i *Ingester) flushUserSeries(ctx context.Context, userID string, fp model.
 		return nil
 	}
 
+	totalCompressedSize := 0
+	totalUncompressedSize := 0
+	frc := flushReasonCounter{}
+	for _, c := range chunks {
+		totalCompressedSize += c.chunk.CompressedSize()
+		totalUncompressedSize += c.chunk.UncompressedSize()
+		err := frc.IncrementForReason(c.reason)
+		if err != nil {
+			level.Error(i.logger).Log("msg", "error incrementing flush reason", "err", err)
+		}
+	}
+
 	lbs := labels.String()
-	level.Info(i.logger).Log("msg", "flushing stream", "user", userID, "fp", fp, "immediate", immediate, "num_chunks", len(chunks), "labels", lbs)
+	logValues := make([]interface{}, 0, 35)
+	logValues = append(logValues,
+		"msg", "flushing stream",
+		"user", userID,
+		"fp", fp,
+		"immediate", immediate,
+		"num_chunks", len(chunks),
+		"total_comp", humanize.Bytes(uint64(totalCompressedSize)),
+		"avg_comp", humanize.Bytes(uint64(totalCompressedSize/len(chunks))),
+		"total_uncomp", humanize.Bytes(uint64(totalUncompressedSize)),
+		"avg_uncomp", humanize.Bytes(uint64(totalUncompressedSize/len(chunks))))
+	logValues = append(logValues, frc.Log()...)
+	logValues = append(logValues, "labels", lbs)
+	level.Info(i.logger).Log(logValues...)
 
 	ctx = user.InjectOrgID(ctx, userID)
 	ctx, cancelFunc := context.WithTimeout(ctx, i.cfg.FlushOpTimeout)


### PR DESCRIPTION
**What this PR does / why we need it**:

it can be really helpful to get more information on individual streams and chunks flushed.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
