### PR TITLE
chore: treat datasample queries the same as limited queries

### DIFF
--- a/pkg/util/httpreq/tags.go
+++ b/pkg/util/httpreq/tags.go
@@ -40,6 +40,12 @@ func ExtractQueryTagsFromHTTP(req *http.Request) string {
 	return safeQueryTags.ReplaceAllString(tags, "_")
 }
 
+func ExtractQueryTagsFromContext(ctx context.Context) string {
+	// if the cast fails then v will be an empty string
+	v, _ := ctx.Value(QueryTagsHTTPHeader).(string)
+	return v
+}
+
 func InjectQueryTags(ctx context.Context, tags string) context.Context {
 	tags = safeQueryTags.ReplaceAllString(tags, "_")
 	return context.WithValue(ctx, QueryTagsHTTPHeader, tags)


### PR DESCRIPTION
**What this PR does / why we need it**:

datasample queries are use by Grafana for query auto complete as well as "logs sample" on metric queries.

they are generally only helpful if they can return quickly

similar logic here to how we handle "limited" queries (log queries with no label filter)

We shouldn't process these so aggressively in parallel (only do one split by time, at a time) because it's both wasteful and doesn't return a faster result when we only need 10 log lines.

Comparison periods (left with test image, right same time period previous 4 weeks)
![image](https://github.com/user-attachments/assets/ac054631-a31d-42fb-a247-d23feb1277b3)
![image](https://github.com/user-attachments/assets/14271ea7-d540-4e38-b14c-ea8bd0bd90d5)
![image](https://github.com/user-attachments/assets/c262d097-d7ef-43b9-886b-7f4289003461)
![image](https://github.com/user-attachments/assets/146fba21-f3bc-4c02-ae1b-6b51ed83938f)


Will need to see this run for a few more weeks to really confirm if this impact is consistent (maybe it was less querying during the test week), but generally this looks to be a big benefit

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
