### PR TITLE
chore(lint-error): remove unused `stepCount` in `engine.go`

### DIFF
--- a/pkg/logql/engine.go
+++ b/pkg/logql/engine.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"math"
 	"sort"
 	"strconv"
 	"strings"
@@ -442,11 +441,6 @@ func (q *query) JoinSampleVector(next bool, r StepResult, stepEvaluator StepEval
 			sort.Slice(vec, func(i, j int) bool { return labels.Compare(vec[i].Metric, vec[j].Metric) < 0 })
 		}
 		return vec, nil
-	}
-
-	stepCount := int(math.Ceil(float64(q.params.End().Sub(q.params.Start()).Nanoseconds()) / float64(q.params.Step().Nanoseconds())))
-	if stepCount <= 0 {
-		stepCount = 1
 	}
 
 	for next {


### PR DESCRIPTION
**What this PR does / why we need it**:
[Recent PR](https://github.com/grafana/loki/pull/13578) removed the usage `stepCount`. But not the assignment, causing some CI checks to fail

This may block any PRs to merge 
```
INFO [runner] linters took 59.237147569s with stages: goanalysis_metalinter: 58.68919861s
pkg/logql/engine.go:449:3: ineffectual assignment to stepCount (ineffassign)
		stepCount = 1
		^
```

This PR removes the unused `stepCount`

**Which issue(s) this PR fixes**:
Fixes #NA

**Special notes for your reviewer**:
Blocks PR to be merged. e.g: https://github.com/grafana/loki/pull/11132

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
