### PR TITLE
docs: fix broken links due to Alloy docs reorg

### DIFF
--- a/docs/sources/send-data/alloy/examples/alloy-kafka-logs.md
+++ b/docs/sources/send-data/alloy/examples/alloy-kafka-logs.md
@@ -392,7 +392,7 @@ Head back to where you started from to continue with the Loki documentation: [Lo
 
 For more information on Grafana Alloy, refer to the following resources:
 - [Grafana Alloy getting started examples](https://grafana.com/docs/alloy/latest/tutorials/)
-- [Grafana Alloy common task examples](https://grafana.com/docs/alloy/latest/tasks/)
+- [Grafana Alloy common task examples](https://grafana.com/docs/alloy/latest/collect/)
 - [Grafana Alloy component reference](https://grafana.com/docs/alloy/latest/reference/components/)
 
 ## Complete metrics, logs, traces, and profiling example

--- a/docs/sources/send-data/alloy/examples/alloy-otel-logs.md
+++ b/docs/sources/send-data/alloy/examples/alloy-otel-logs.md
@@ -279,7 +279,7 @@ Head back to where you started from to continue with the Loki documentation: [Lo
 
 For more information on Grafana Alloy, refer to the following resources:
 - [Grafana Alloy getting started examples](https://grafana.com/docs/alloy/latest/tutorials/)
-- [Grafana Alloy common task examples](https://grafana.com/docs/alloy/latest/tasks/)
+- [Grafana Alloy common task examples](https://grafana.com/docs/alloy/latest/collect/)
 - [Grafana Alloy component reference](https://grafana.com/docs/alloy/latest/reference/components/)
 
 ## Complete metrics, logs, traces, and profiling example


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes two broken links reported in the weekly report, due to a reorganization of the Alloy docs.
