### PR TITLE
feat(blooms): Add series & chunks per block metrics

### DIFF
--- a/pkg/storage/bloom/v1/metrics.go
+++ b/pkg/storage/bloom/v1/metrics.go
@@ -20,6 +20,8 @@ type Metrics struct {
 	insertsTotal        *prometheus.CounterVec
 	sourceBytesAdded    prometheus.Counter
 	blockSize           prometheus.Histogram
+	seriesPerBlock      prometheus.Histogram
+	chunksPerBlock      prometheus.Histogram
 	blockFlushReason    *prometheus.CounterVec
 
 	// reads
@@ -119,6 +121,18 @@ func NewMetrics(r prometheus.Registerer) *Metrics {
 			Name:      "bloom_block_size",
 			Help:      "Size of the bloom block in bytes",
 			Buckets:   prometheus.ExponentialBucketsRange(1<<20, 1<<30, 8),
+		}),
+		seriesPerBlock: promauto.With(r).NewHistogram(prometheus.HistogramOpts{
+			Namespace: constants.Loki,
+			Name:      "bloom_series_per_block",
+			Help:      "Number of series per block",
+			Buckets:   prometheus.ExponentialBuckets(1, 2, 9), // 2 --> 256
+		}),
+		chunksPerBlock: promauto.With(r).NewHistogram(prometheus.HistogramOpts{
+			Namespace: constants.Loki,
+			Name:      "bloom_chunks_per_block",
+			Help:      "Number of chunks per block",
+			Buckets:   prometheus.ExponentialBuckets(1, 2, 15), // 2 --> 16384
 		}),
 		blockFlushReason: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
 			Namespace: constants.Loki,


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds metrics to track the series per blocks and chunks per block at build time.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
