### PR TITLE
fix: Use elements match in gapsBetweenTSDBsAndMetas test

### DIFF
--- a/pkg/bloombuild/planner/planner_test.go
+++ b/pkg/bloombuild/planner/planner_test.go
@@ -163,7 +163,7 @@ func Test_gapsBetweenTSDBsAndMetas(t *testing.T) {
 				require.Error(t, err)
 				return
 			}
-			require.Equal(t, tc.exp, gaps)
+			require.ElementsMatch(t, tc.exp, gaps)
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This test was sometimes failing with:

```
Error:      	Not equal: 
        	            	expected: []planner.tsdbGaps{planner.tsdbGaps{tsdbIdentifier:tsdb.SingleTenantTSDBIdentifier{exportTSInSecs:false, TS:time.Time{wall:0x0, ext:62135596800, loc:(*time.Location)(0x3baad[20](https://github.com/grafana/loki/actions/runs/10176790602/job/28150967362#step:5:21))}, From:0, Through:0, Checksum:0x0}, tsdb:common.ClosableForSeries(nil), gaps:[]v1.FingerprintBounds{v1.FingerprintBounds{Min:0x6, Max:0xa}}}, planner.tsdbGaps{tsdbIdentifier:tsdb.SingleTenantTSDBIdentifier{exportTSInSecs:false, TS:time.Time{wall:0x0, ext:62135596801, loc:(*time.Location)(0x3baad20)}, From:0, Through:0, Checksum:0x0}, tsdb:common.ClosableForSeries(nil), gaps:[]v1.FingerprintBounds{v1.FingerprintBounds{Min:0x9, Max:0xa}}}}
        	            	actual  : []planner.tsdbGaps{planner.tsdbGaps{tsdbIdentifier:tsdb.SingleTenantTSDBIdentifier{exportTSInSecs:false, TS:time.Time{wall:0x0, ext:62135596801, loc:(*time.Location)(0x3baad20)}, From:0, Through:0, Checksum:0x0}, tsdb:common.ClosableForSeries(nil), gaps:[]v1.FingerprintBounds{v1.FingerprintBounds{Min:0x9, Max:0xa}}}, planner.tsdbGaps{tsdbIdentifier:tsdb.SingleTenantTSDBIdentifier{exportTSInSecs:false, TS:time.Time{wall:0x0, ext:6[21](https://github.com/grafana/loki/actions/runs/10176790602/job/28150967362#step:5:22)35596800, loc:(*time.Location)(0x3baad20)}, From:0, Through:0, Checksum:0x0}, tsdb:common.ClosableForSeries(nil), gaps:[]v1.FingerprintBounds{v1.FingerprintBounds{Min:0x6, Max:0xa}}}}
```

Note that the content of both slices is the same but with a different order.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
