### PR TITLE
chore(helm-chart): added SSE config into AWS storage config

### DIFF
--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -13,6 +13,10 @@ Entries should include a reference to the pull request that introduced the chang
 
 [//]: # (<AUTOMATED_UPDATES_LOCATOR> : do not remove this line. This locator is used by the CI pipeline to automatically create a changelog entry for each new Loki release. Add other chart versions and respective changelog entries bellow this line.)
 
+## 6.7.4
+
+- [ENHANCEMENT] Allow configuring the SSE section under AWS S3 storage config.
+
 ## 6.7.3
 
 - [BUGFIX] Removed Helm test binary

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -3,7 +3,7 @@ name: loki
 description: Helm chart for Grafana Loki and Grafana Enterprise Logs supporting both simple, scalable and distributed modes.
 type: application
 appVersion: 3.1.0
-version: 6.7.3
+version: 6.7.4
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -1,6 +1,6 @@
 # loki
 
-![Version: 6.7.3](https://img.shields.io/badge/Version-6.7.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.1.0](https://img.shields.io/badge/AppVersion-3.1.0-informational?style=flat-square)
+![Version: 6.7.4](https://img.shields.io/badge/Version-6.7.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.1.0](https://img.shields.io/badge/AppVersion-3.1.0-informational?style=flat-square)
 
 Helm chart for Grafana Loki and Grafana Enterprise Logs supporting both simple, scalable and distributed modes.
 

--- a/production/helm/loki/templates/_helpers.tpl
+++ b/production/helm/loki/templates/_helpers.tpl
@@ -239,30 +239,15 @@ s3:
   insecure: {{ .insecure }}
   {{- with .http_config}}
   http_config:
-    {{- with .idle_conn_timeout }}
-    idle_conn_timeout: {{ . }}
-    {{- end}}
-    {{- with .response_header_timeout }}
-    response_header_timeout: {{ . }}
-    {{- end}}
-    {{- with .insecure_skip_verify }}
-    insecure_skip_verify: {{ . }}
-    {{- end}}
-    {{- with .ca_file}}
-    ca_file: {{ . }}
-    {{- end}}
+{{ toYaml . | indent 4 }}
   {{- end }}
   {{- with .backoff_config}}
   backoff_config:
-    {{- with .min_period }}
-    min_period: {{ . }}
-    {{- end}}
-    {{- with .max_period }}
-    max_period: {{ . }}
-    {{- end}}
-    {{- with .max_retries }}
-    max_retries: {{ . }}
-    {{- end}}
+{{ toYaml . | indent 4 }}
+  {{- end }}
+  {{- with .sse }}
+  sse:
+{{ toYaml . | indent 4 }}
   {{- end }}
 {{- end -}}
 
@@ -308,35 +293,7 @@ alibabacloud:
 {{- else if eq .Values.loki.storage.type "swift" -}}
 {{- with .Values.loki.storage.swift }}
 swift:
-  {{- with .auth_version }}
-  auth_version: {{ . }}
-  {{- end }}
-  auth_url: {{ .auth_url }}
-  {{- with .internal }}
-  internal: {{ . }}
-  {{- end }}
-  username: {{ .username }}
-  user_domain_name: {{ .user_domain_name }}
-  {{- with .user_domain_id }}
-  user_domain_id: {{ . }}
-  {{- end }}
-  {{- with .user_id }}
-  user_id: {{ . }}
-  {{- end }}
-  password: {{ .password }}
-  {{- with .domain_id }}
-  domain_id: {{ . }}
-  {{- end }}
-  domain_name: {{ .domain_name }}
-  project_id: {{ .project_id }}
-  project_name: {{ .project_name }}
-  project_domain_id: {{ .project_domain_id }}
-  project_domain_name: {{ .project_domain_name }}
-  region_name: {{ .region_name }}
-  container_name: {{ .container_name }}
-  max_retries: {{ .max_retries | default 3 }}
-  connect_timeout: {{ .connect_timeout | default "10s" }}
-  request_timeout: {{ .request_timeout | default "5s" }}
+{{ toYaml . | indent 2 }}
 {{- end -}}
 {{- else -}}
 {{- with .Values.loki.storage.filesystem }}


### PR DESCRIPTION
**What this PR does / why we need it**:
made the template flexible to avoid copying each field separately.
previously we missed SSE section for AWS config, and it was required to add each field into s3 manually.sse config.


**Special notes for your reviewer**:
### Example of AWS config : 
![image](https://github.com/user-attachments/assets/97f96d81-065b-4291-8159-ff3b3a8e0c1b)


### Example of Swift config: 
###### I decided to refactor [swift_storage_config](https://grafana.com/docs/loki/latest/configure/#swift_storage_config) because the fields of Loki config and the fields in `values.yaml` are the same, as well as the default values.
![image](https://github.com/user-attachments/assets/cbb37e8c-41e6-4909-8f33-cfaf19f6b38c)


**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
