### PR TITLE
fix: correct selector of the `loki-headless` Service in the SingleBinary mode

### DIFF
--- a/production/helm/loki/templates/single-binary/service-headless.yaml
+++ b/production/helm/loki/templates/single-binary/service-headless.yaml
@@ -31,5 +31,8 @@ spec:
       targetPort: http-metrics
       protocol: TCP
   selector:
-    {{- include "loki.selectorLabels" . | nindent 4 }}
+    {{- include "loki.singleBinarySelectorLabels" . | nindent 4 }}
+    {{- with .Values.singleBinary.selectorLabels }}
+      {{- tpl (toYaml .) $ | nindent 4 }}
+    {{- end }}
 {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes selector of the `loki-headless` Service in the SingleBinary mode.

**Which issue(s) this PR fixes**:
Fixes #13752

**Special notes for your reviewer**:
The selector has been made identical to the one in the `loki` Service.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
