### PR TITLE
fix(downstreamer leak): Use buffered channel to prevent goroutine leak

### DIFF
--- a/pkg/querier/queryrange/downstreamer.go
+++ b/pkg/querier/queryrange/downstreamer.go
@@ -162,7 +162,7 @@ func (in instance) For(
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	ch := make(chan logql.Resp)
+	ch := make(chan logql.Resp, len(queries)+1)
 
 	// ForEachJob blocks until all are done. However, we want to process the
 	// results as they come in. That's why we start everything in another

--- a/pkg/querier/queryrange/downstreamer_test.go
+++ b/pkg/querier/queryrange/downstreamer_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
+	"go.uber.org/goleak"
 
 	"github.com/grafana/loki/v3/pkg/logproto"
 	"github.com/grafana/loki/v3/pkg/logql"
@@ -221,6 +222,11 @@ func ensureParallelism(t *testing.T, in *instance, n int) {
 }
 
 func TestInstanceFor(t *testing.T) {
+	// Verify that no leaks exists after the test execution
+	defer goleak.VerifyNone(t,
+		goleak.IgnoreCurrent(),
+	)
+
 	mkIn := func() *instance {
 		return DownstreamHandler{
 			limits: fakeLimits{},


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix goroutine leak due to request errors on downstreamer.go

**Which issue(s) this PR fixes**:
Fixes #13735

**Special notes for your reviewer**:
Quick fix using a buffered channel.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
