### PR TITLE
fix(break): helm: Fix how we set imagePullSecrets for enterprise-gateway and admin-api.

### DIFF
--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -13,6 +13,10 @@ Entries should include a reference to the pull request that introduced the chang
 
 [//]: # (<AUTOMATED_UPDATES_LOCATOR> : do not remove this line. This locator is used by the CI pipeline to automatically create a changelog entry for each new Loki release. Add other chart versions and respective changelog entries bellow this line.)
 
+## 6.8.0
+
+- [BUGFIX] Fixed how we set imagePullSecrets for the admin-api and enterprise-gateway
+
 ## 6.7.4
 
 - [ENHANCEMENT] Allow configuring the SSE section under AWS S3 storage config.

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -3,7 +3,7 @@ name: loki
 description: Helm chart for Grafana Loki and Grafana Enterprise Logs supporting both simple, scalable and distributed modes.
 type: application
 appVersion: 3.1.0
-version: 6.7.4
+version: 6.8.0
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -1,6 +1,6 @@
 # loki
 
-![Version: 6.7.4](https://img.shields.io/badge/Version-6.7.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.1.0](https://img.shields.io/badge/AppVersion-3.1.0-informational?style=flat-square)
+![Version: 6.8.0](https://img.shields.io/badge/Version-6.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.1.0](https://img.shields.io/badge/AppVersion-3.1.0-informational?style=flat-square)
 
 Helm chart for Grafana Loki and Grafana Enterprise Logs supporting both simple, scalable and distributed modes.
 

--- a/production/helm/loki/templates/admin-api/deployment-admin-api.yaml
+++ b/production/helm/loki/templates/admin-api/deployment-admin-api.yaml
@@ -65,11 +65,9 @@ spec:
               mountPath: {{ .Values.minio.configPathmc }}certs
           {{ end }}
         {{- end }}
-      {{- if .Values.imagePullSecrets }}
+      {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
-      {{- range .Values.imagePullSecrets }}
-        - name: {{ . }}
-      {{- end }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.adminApi.hostAliases }}
       hostAliases:

--- a/production/helm/loki/templates/gateway/deployment-gateway-enterprise.yaml
+++ b/production/helm/loki/templates/gateway/deployment-gateway-enterprise.yaml
@@ -46,11 +46,9 @@ spec:
         {{- toYaml .Values.enterpriseGateway.podSecurityContext | nindent 8 }}
       initContainers:
         {{- toYaml .Values.enterpriseGateway.initContainers | nindent 8 }}
-      {{- if .Values.imagePullSecrets }}
+      {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
-      {{- range .Values.imagePullSecrets }}
-        - name: {{ . }}
-      {{- end }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.enterpriseGateway.hostAliases }}
       hostAliases:


### PR DESCRIPTION
**What this PR does / why we need it**:
On this PR I'm changing how we set `imagePullSecrets` for the `admin-api` and for the `enterprise-gateway`.
Those two components expect `.Values.imagePullSecrets` to be in the following format:

```yaml
- mySecret1
- mySecret2
```

But all other components expect it to be in the following format instead:
```yaml
- name: mySecret1
- name: mySecret2
```

This can be considered a breaking change but simultaneously, it was impossible to set this correctly for both, `admin-api+enterprise-gateway` vs all other components. 

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
