### PR TITLE
feat: Delete WAL objects on truncate

### DIFF
--- a/pkg/ingester-rf1/ingester.go
+++ b/pkg/ingester-rf1/ingester.go
@@ -145,6 +145,8 @@ type Wrapper interface {
 
 // Storage is the store interface we need on the ingester.
 type Storage interface {
+	IsObjectNotFoundErr(err error) bool
+	DeleteObject(ctx context.Context, objectKey string) error
 	PutObject(ctx context.Context, objectKey string, object io.Reader) error
 	Stop()
 }

--- a/pkg/ingester-rf1/metastore/metastore_hack.go
+++ b/pkg/ingester-rf1/metastore/metastore_hack.go
@@ -1,14 +1,20 @@
 package metastore
 
 import (
+	"context"
+	"fmt"
+	"path"
 	"time"
 
 	"github.com/go-kit/log/level"
 	"github.com/hashicorp/raft"
 	"github.com/oklog/ulid"
+	"go.etcd.io/bbolt"
 	"google.golang.org/protobuf/types/known/anypb"
 
+	"github.com/grafana/loki/v3/pkg/ingester-rf1/metastore/metastorepb"
 	"github.com/grafana/loki/v3/pkg/ingester-rf1/metastore/raftlogpb"
+	"github.com/grafana/loki/v3/pkg/storage/wal"
 )
 
 // FIXME(kolesnikovae):
@@ -60,10 +66,10 @@ func (m *metastoreState) applyTruncate(request *raftlogpb.TruncateCommand) (*any
 		_ = level.Error(m.logger).Log("msg", "failed to get metadata bucket", "err", err)
 		return nil, err
 	}
-	for k, segment := range m.segments {
-		if ulid.MustParse(segment.Id).Time() < request.Timestamp {
-			if err = bucket.Delete([]byte(segment.Id)); err != nil {
-				_ = level.Error(m.logger).Log("msg", "failed to delete stale segments", "err", err)
+	for k, v := range m.segments {
+		if ulid.MustParse(v.Id).Time() < request.Timestamp {
+			if err = m.deleteSegment(context.TODO(), bucket, v); err != nil {
+				_ = level.Error(m.logger).Log("msg", "failed to delete segment", "id", v.Id, "err", err)
 				continue
 			}
 			delete(m.segments, k)
@@ -71,4 +77,16 @@ func (m *metastoreState) applyTruncate(request *raftlogpb.TruncateCommand) (*any
 		}
 	}
 	return &anypb.Any{}, nil
+}
+
+func (m *metastoreState) deleteSegment(ctx context.Context, bucket *bbolt.Bucket, segment *metastorepb.BlockMeta) error {
+	ctx, cancelFunc := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancelFunc()
+	if err := m.store.DeleteObject(ctx, path.Join(wal.Dir, segment.Id)); err != nil && !m.store.IsObjectNotFoundErr(err) {
+		return fmt.Errorf("failed to delete segment from object store: %w", err)
+	}
+	if err := bucket.Delete([]byte(segment.Id)); err != nil {
+		return fmt.Errorf("failed to delete segment from boltdb: %w", err)
+	}
+	return nil
 }

--- a/pkg/ingester-rf1/metastore/metastore_state.go
+++ b/pkg/ingester-rf1/metastore/metastore_state.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"go.etcd.io/bbolt"
 
+	ingesterrf1 "github.com/grafana/loki/v3/pkg/ingester-rf1"
 	metastorepb "github.com/grafana/loki/v3/pkg/ingester-rf1/metastore/metastorepb"
 )
 
@@ -18,14 +19,16 @@ type metastoreState struct {
 	segmentsMutex sync.Mutex
 	segments      map[string]*metastorepb.BlockMeta
 
-	db *boltdb
+	db    *boltdb
+	store ingesterrf1.Storage
 }
 
-func newMetastoreState(logger log.Logger, db *boltdb) *metastoreState {
+func newMetastoreState(logger log.Logger, db *boltdb, store ingesterrf1.Storage) *metastoreState {
 	return &metastoreState{
 		logger:   logger,
 		segments: make(map[string]*metastorepb.BlockMeta),
 		db:       db,
+		store:    store,
 	}
 }
 

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -1825,7 +1825,7 @@ func (t *Loki) initMetastore() (services.Service, error) {
 	if t.Cfg.isTarget(All) {
 		t.Cfg.MetastoreClient.MetastoreAddress = fmt.Sprintf("localhost:%d", t.Cfg.Server.GRPCListenPort)
 	}
-	m, err := metastore.New(t.Cfg.Metastore, log.With(util_log.Logger, "component", "metastore"), prometheus.DefaultRegisterer, t.health)
+	m, err := metastore.New(t.Cfg.Metastore, t.Cfg.SchemaConfig.Configs, t.Cfg.StorageConfig, t.ClientMetrics, log.With(util_log.Logger, "component", "metastore"), prometheus.DefaultRegisterer, t.health)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Until we have a working compactor, we should delete objects from the WAL when truncated from the metastore. This complements, but does not replace the lifecycle rules on the bucket.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
