### PR TITLE
chore: Add metastore client as dep for rf1 querier & ignore auth for ListBlocks

### DIFF
--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -724,7 +724,7 @@ func (t *Loki) setupModuleManager() error {
 		Store:                    {Overrides, IndexGatewayRing},
 		IngesterRF1:              {Store, Server, MemberlistKV, TenantConfigs, MetastoreClient, Analytics},
 		Ingester:                 {Store, Server, MemberlistKV, TenantConfigs, Analytics},
-		Querier:                  {Store, Ring, Server, IngesterQuerier, PatternRingClient, Overrides, Analytics, CacheGenerationLoader, QuerySchedulerRing},
+		Querier:                  {Store, Ring, Server, IngesterQuerier, PatternRingClient, MetastoreClient, Overrides, Analytics, CacheGenerationLoader, QuerySchedulerRing},
 		QueryFrontendTripperware: {Server, Overrides, TenantConfigs},
 		QueryFrontend:            {QueryFrontendTripperware, Analytics, CacheGenerationLoader, QuerySchedulerRing},
 		QueryScheduler:           {Server, Overrides, MemberlistKV, Analytics, QuerySchedulerRing},

--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -418,6 +418,7 @@ func (t *Loki) setupAuthMiddleware() {
 			"/grpc.health.v1.Health/Check",
 			"/grpc.health.v1.Health/Watch",
 			"/metastorepb.MetastoreService/AddBlock",
+			"/metastorepb.MetastoreService/ListBlocksForQuery",
 			"/logproto.StreamData/GetStreamRates",
 			"/frontend.Frontend/Process",
 			"/frontend.Frontend/NotifyClientShutdown",

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -1835,7 +1835,7 @@ func (t *Loki) initMetastore() (services.Service, error) {
 }
 
 func (t *Loki) initMetastoreClient() (services.Service, error) {
-	if !t.Cfg.IngesterRF1.Enabled {
+	if !t.Cfg.IngesterRF1.Enabled && !t.Cfg.QuerierRF1.Enabled {
 		return nil, nil
 	}
 	mc, err := metastoreclient.New(t.Cfg.MetastoreClient, prometheus.DefaultRegisterer)

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -1835,6 +1835,9 @@ func (t *Loki) initMetastore() (services.Service, error) {
 }
 
 func (t *Loki) initMetastoreClient() (services.Service, error) {
+	if !t.Cfg.IngesterRF1.Enabled {
+		return nil, nil
+	}
 	mc, err := metastoreclient.New(t.Cfg.MetastoreClient, prometheus.DefaultRegisterer)
 	if err != nil {
 		return nil, err

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -1829,6 +1829,7 @@ func (t *Loki) initMetastore() (services.Service, error) {
 	if err != nil {
 		return nil, err
 	}
+	// Service methods have tenant auth disabled in the fakeauth.SetupAuthMiddleware call since this is a shared service
 	metastorepb.RegisterMetastoreServiceServer(t.Server.GRPC, m)
 
 	return m, nil


### PR DESCRIPTION
**What this PR does / why we need it**:
* Add the metastore client as a dep to the querier if RF1 is enabled
* This enables the metastore client in standalone querier.
* Also add the ListBlocks to the unauthed method list so querier can call it