### PR TITLE
chore: [release-3.1.x] fix(ci): add cleanup step into job `dist`

### DIFF
--- a/.github/jsonnetfile.json
+++ b/.github/jsonnetfile.json
@@ -8,7 +8,7 @@
           "subdir": "workflows"
         }
       },
-      "version": "124c4d996f9625478a79f1884465e29ea082d224"
+      "version": "87cb5090c36b5332e7f21b5c59e136962d5f4f56"
     }
   ],
   "legacyImports": true

--- a/.github/jsonnetfile.lock.json
+++ b/.github/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "workflows"
         }
       },
-      "version": "124c4d996f9625478a79f1884465e29ea082d224",
-      "sum": "8wrJURq48ZBAtZcReO1W7AiXmvUyLqb932Q9sXyfFVo="
+      "version": "87cb5090c36b5332e7f21b5c59e136962d5f4f56",
+      "sum": "kVlVZPpPz8d/D6UGK9Hto+NeGy7z8NvGygcB1QboxWw="
     }
   ],
   "legacyImports": false

--- a/.github/vendor/github.com/grafana/loki-release/workflows/build.libsonnet
+++ b/.github/vendor/github.com/grafana/loki-release/workflows/build.libsonnet
@@ -176,6 +176,7 @@ local releaseLibStep = common.releaseLibStep;
   dist: function(buildImage, skipArm=true, useGCR=false, makeTargets=['dist', 'packages'])
     job.new()
     + job.withSteps([
+      common.cleanUpBuildCache,
       common.fetchReleaseRepo,
       common.googleAuth,
       common.setupGoogleCloudSdk,

--- a/.github/vendor/github.com/grafana/loki-release/workflows/common.libsonnet
+++ b/.github/vendor/github.com/grafana/loki-release/workflows/common.libsonnet
@@ -75,6 +75,10 @@
   checkout:
     $.step.new('checkout', 'actions/checkout@v4'),
 
+  cleanUpBuildCache:
+    $.step.new('clean up build tools cache')
+    + $.step.withRun('rm -rf /opt/hostedtoolcache'),
+
   fetchReleaseRepo:
     $.step.new('pull code to release', 'actions/checkout@v4')
     + $.step.with({

--- a/.github/vendor/github.com/grafana/loki-release/workflows/release.libsonnet
+++ b/.github/vendor/github.com/grafana/loki-release/workflows/release.libsonnet
@@ -176,7 +176,7 @@ local pullRequestFooter = 'Merging this PR will release the [artifacts](https://
         step.new('download images')
         + step.withRun(|||
           echo "downloading images to $(pwd)/images"
-          gsutil cp -r gs://loki-build-artifacts/${{ needs.createRelease.outputs.sha }}/images .
+          gsutil cp -r gs://${BUILD_ARTIFACTS_BUCKET}/${{ needs.createRelease.outputs.sha }}/images .
         |||),
         step.new('publish docker images', './lib/actions/push-images')
         + step.with({

--- a/.github/workflows/minor-release-pr.yml
+++ b/.github/workflows/minor-release-pr.yml
@@ -101,6 +101,8 @@ jobs:
       version: "${{ needs.version.outputs.version }}"
     runs-on: "ubuntu-latest"
     steps:
+    - name: "clean up build tools cache"
+      run: "rm -rf /opt/hostedtoolcache"
     - name: "pull code to release"
       uses: "actions/checkout@v4"
       with:

--- a/.github/workflows/patch-release-pr.yml
+++ b/.github/workflows/patch-release-pr.yml
@@ -101,6 +101,8 @@ jobs:
       version: "${{ needs.version.outputs.version }}"
     runs-on: "ubuntu-latest"
     steps:
+    - name: "clean up build tools cache"
+      run: "rm -rf /opt/hostedtoolcache"
     - name: "pull code to release"
       uses: "actions/checkout@v4"
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,7 +138,7 @@ jobs:
     - name: "download images"
       run: |
         echo "downloading images to $(pwd)/images"
-        gsutil cp -r gs://loki-build-artifacts/${{ needs.createRelease.outputs.sha }}/images .
+        gsutil cp -r gs://${BUILD_ARTIFACTS_BUCKET}/${{ needs.createRelease.outputs.sha }}/images .
     - name: "publish docker images"
       uses: "./lib/actions/push-images"
       with:


### PR DESCRIPTION
Backport 217f928f52b3d3fad414a01502c37d143cabf567 from #13801

---

**What this PR does / why we need it**:
updated release workflows to clean up the cache before running job `dist`. it's needed because it's failing with error: `no space left on device`

**Special notes for your reviewer**:
https://github.com/grafana/loki/actions/runs/10299080044/job/28508736330

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
