### PR TITLE
fix: Handle EOF when reading from some obj stores

### DIFF
--- a/pkg/querier-rf1/wal/chunks.go
+++ b/pkg/querier-rf1/wal/chunks.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/pkg/errors"
 	"github.com/prometheus/prometheus/model/labels"
 	"golang.org/x/sync/errgroup"
 
@@ -309,14 +310,14 @@ func readChunkData(ctx context.Context, storage BlockStorage, chunk ChunkData) (
 	// together.
 	reader, err := storage.GetObjectRange(ctx, wal.Dir+chunk.id, int64(offset), int64(size))
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "could not get range reader for "+chunk.id)
 	}
 	defer reader.Close()
 
 	data := make([]byte, size)
 	_, err = reader.Read(data)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "could not read socket for "+chunk.id)
 	}
 
 	return data, nil

--- a/pkg/querier-rf1/wal/chunks.go
+++ b/pkg/querier-rf1/wal/chunks.go
@@ -3,6 +3,7 @@ package wal
 import (
 	"context"
 	"fmt"
+	"io"
 	"sort"
 
 	"github.com/pkg/errors"
@@ -316,7 +317,7 @@ func readChunkData(ctx context.Context, storage BlockStorage, chunk ChunkData) (
 
 	data := make([]byte, size)
 	_, err = reader.Read(data)
-	if err != nil {
+	if err != nil && err != io.EOF {
 		return nil, errors.Wrap(err, "could not read socket for "+chunk.id)
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
* Fixes reading from some storage providers that return an EOF when done instead of a nil error.
* This is a valid response, we just didn't handle it properly.