### PR TITLE
fix: Propagate headers/warnings/stats from quantile downstreams

### DIFF
--- a/pkg/logql/accumulator_test.go
+++ b/pkg/logql/accumulator_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/logproto"
 	"github.com/grafana/loki/v3/pkg/logql/sketch"
 	"github.com/grafana/loki/v3/pkg/logqlmodel"
+	"github.com/grafana/loki/v3/pkg/logqlmodel/stats"
 	"github.com/grafana/loki/v3/pkg/querier/queryrange/queryrangebase/definitions"
 )
 
@@ -163,7 +164,7 @@ func TestQuantileSketchDownstreamAccumulatorSimple(t *testing.T) {
 
 	require.Equal(t, res.Headers[0].Name, "HeaderA")
 	require.Equal(t, res.Warnings, []string{"warning"})
-	require.NotNil(t, res.Statistics)
+	require.Equal(t, int64(33), res.Statistics.Summary.Shards)
 }
 
 func BenchmarkAccumulator(b *testing.B) {
@@ -235,6 +236,9 @@ func newStreamResults() []logqlmodel.Result {
 
 func newQuantileSketchResults() []logqlmodel.Result {
 	results := make([]logqlmodel.Result, 100)
+	statistics := stats.Result{
+		Summary: stats.Summary{Shards: 33},
+	}
 
 	for r := range results {
 		vectors := make([]ProbabilisticQuantileVector, 10)
@@ -248,7 +252,7 @@ func newQuantileSketchResults() []logqlmodel.Result {
 				}
 			}
 		}
-		results[r] = logqlmodel.Result{Data: ProbabilisticQuantileMatrix(vectors), Headers: []*definitions.PrometheusResponseHeader{{Name: "HeaderA", Values: []string{"ValueA"}}}, Warnings: []string{"warning"}}
+		results[r] = logqlmodel.Result{Data: ProbabilisticQuantileMatrix(vectors), Headers: []*definitions.PrometheusResponseHeader{{Name: "HeaderA", Values: []string{"ValueA"}}}, Warnings: []string{"warning"}, Statistics: statistics}
 	}
 
 	return results

--- a/pkg/logql/accumulator_test.go
+++ b/pkg/logql/accumulator_test.go
@@ -162,6 +162,8 @@ func TestQuantileSketchDownstreamAccumulatorSimple(t *testing.T) {
 	require.Equal(t, 10, len(got), "correct number of vectors")
 
 	require.Equal(t, res.Headers[0].Name, "HeaderA")
+	require.Equal(t, res.Warnings, []string{"warning"})
+	require.NotNil(t, res.Statistics)
 }
 
 func BenchmarkAccumulator(b *testing.B) {
@@ -246,7 +248,7 @@ func newQuantileSketchResults() []logqlmodel.Result {
 				}
 			}
 		}
-		results[r] = logqlmodel.Result{Data: ProbabilisticQuantileMatrix(vectors), Headers: []*definitions.PrometheusResponseHeader{{Name: "HeaderA", Values: []string{"ValueA"}}}}
+		results[r] = logqlmodel.Result{Data: ProbabilisticQuantileMatrix(vectors), Headers: []*definitions.PrometheusResponseHeader{{Name: "HeaderA", Values: []string{"ValueA"}}}, Warnings: []string{"warning"}}
 	}
 
 	return results


### PR DESCRIPTION
**What this PR does / why we need it**:
Passes headers from Downstreams back to the caller
* This caused a bug where the cache header was injected in downstreams after sharding, but wasn't passed back up to the query frontend, so the results were never cached.
* I copied the implementation from the StreamAccumulator in the same file - so this also passes back warnings & statistics if they are present.
* I added a test to confirm.

While debugging, I added a Span for when the `CacheGenHeader` is added, and you can see the span is triggered, and the header injected, in the Downstream call but never passed all the way up to the ResultsCache.Do because of this bug:
![image](https://github.com/user-attachments/assets/9a4cfa56-98f8-47f4-b445-7d19e97ef487)


Trace from my local instance showing that 3/4 intervals now hit the cache:
![image](https://github.com/user-attachments/assets/417c6eda-10ee-4fde-852f-f54221abadc5)