### PR TITLE
chore: use quartz in metastore

### DIFF
--- a/pkg/ingester-rf1/metastore/metastore.go
+++ b/pkg/ingester-rf1/metastore/metastore.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/coder/quartz"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/flagext"
@@ -88,6 +89,9 @@ type Metastore struct {
 
 	done chan struct{}
 	wg   sync.WaitGroup
+
+	// Used in tests.
+	clock quartz.Clock
 }
 
 func New(config Config, logger log.Logger, reg prometheus.Registerer, hs health.Service) (*Metastore, error) {
@@ -97,6 +101,7 @@ func New(config Config, logger log.Logger, reg prometheus.Registerer, hs health.
 		reg:    reg,
 		db:     newDB(config, logger),
 		done:   make(chan struct{}),
+		clock:  quartz.NewReal(),
 	}
 	m.leaderhealth = raftleader.NewRaftLeaderHealthObserver(hs, logger)
 	m.state = newMetastoreState(logger, m.db)

--- a/pkg/ingester-rf1/metastore/metastore_hack.go
+++ b/pkg/ingester-rf1/metastore/metastore_hack.go
@@ -29,7 +29,7 @@ func (m *Metastore) cleanupLoop() {
 			if m.raft.State() != raft.Leader {
 				continue
 			}
-			timestamp := uint64(time.Now().Add(-1 * time.Hour).UnixMilli())
+			timestamp := uint64(m.clock.Now().Add(-1 * time.Hour).UnixMilli())
 			req := &raftlogpb.TruncateCommand{Timestamp: timestamp}
 			_, _, err := applyCommand[*raftlogpb.TruncateCommand, *anypb.Any](m.raft, req, m.config.Raft.ApplyTimeout)
 			if err != nil {


### PR DESCRIPTION
This commit updates the metastore to use quartz. This will allow us to mock time in unit tests.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
