### PR TITLE
fix: Read "404" as object not exist

### DIFF
--- a/pkg/storage/chunk/client/aws/s3_storage_client.go
+++ b/pkg/storage/chunk/client/aws/s3_storage_client.go
@@ -501,7 +501,13 @@ func (a *S3ObjectClient) List(ctx context.Context, prefix, delimiter string) ([]
 
 // IsObjectNotFoundErr returns true if error means that object is not found. Relevant to GetObject and DeleteObject operations.
 func (a *S3ObjectClient) IsObjectNotFoundErr(err error) bool {
-	if aerr, ok := errors.Cause(err).(awserr.Error); ok && aerr.Code() == s3.ErrCodeNoSuchKey {
+	aerr, ok := errors.Cause(err).(awserr.Error)
+	if !ok {
+		return false
+	}
+
+	code := aerr.Code()
+	if code == s3.ErrCodeNoSuchKey || code == "NotFound" {
 		return true
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Modify the s3 client to recognize "NotFound" errors when checking if an object error is "NotFound".
I did some tests locally and `Head` calls to objects that doesn't exist gives a "NotFound" instead of "NoSuchKey".

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**: