### PR TITLE
chore: log the query from the request when we're unable to get a result from the results cache

### DIFF
--- a/pkg/querier/queryrange/queryrangebase/results_cache.go
+++ b/pkg/querier/queryrange/queryrangebase/results_cache.go
@@ -224,7 +224,7 @@ func (s resultsCache) shouldCacheResponse(ctx context.Context, req Request, r Re
 	s.metrics.versionComparisons.Inc()
 
 	if len(genNumbersFromResp) == 0 && genNumberFromCtx != "" {
-		level.Debug(logger).Log("msg", fmt.Sprintf("we found results cache gen number %s set in store but none in headers", genNumberFromCtx))
+		level.Debug(logger).Log("msg", fmt.Sprintf("we found results cache gen number %s set in store but none in headers", genNumberFromCtx), "query", req.GetQuery())
 
 		// NB(owen-d):
 		// If the queriers aren't returning cache numbers, something is likely broken
@@ -235,7 +235,7 @@ func (s resultsCache) shouldCacheResponse(ctx context.Context, req Request, r Re
 
 	for _, gen := range genNumbersFromResp {
 		if gen != genNumberFromCtx {
-			level.Debug(logger).Log("msg", fmt.Sprintf("inconsistency in results cache gen numbers %s (GEN-FROM-RESPONSE) != %s (GEN-FROM-STORE), not caching the response", gen, genNumberFromCtx))
+			level.Debug(logger).Log("msg", fmt.Sprintf("inconsistency in results cache gen numbers %s (GEN-FROM-RESPONSE) != %s (GEN-FROM-STORE), not caching the response", gen, genNumberFromCtx), "query", req.GetQuery())
 			s.metrics.versionComparisonFailures.WithLabelValues(reasonMismatch).Inc()
 			return false
 		}


### PR DESCRIPTION
We noticed when attempting to track down a potential sharding bug that we'd hit some path that caused the query frontends to not receive any cache gen headers back from queriers. We're still unsure what caused this, but along the way we noticed some amount of missing instrumentation or missing details in existing instrumentation that would have been useful along the way.

One of these is the lack of logging of the query itself when we log that we failed to receive headers from the queriers, or if the querier cache gen # and QF cache gen # mismatch.