### PR TITLE
fix(deps): bump grafana/pyroscope-go to v0.1.8 for go1.23

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -271,7 +271,7 @@ require (
 	github.com/googleapis/enterprise-certificate-proxy v0.3.2 // indirect
 	github.com/googleapis/gax-go/v2 v2.12.5 // indirect
 	github.com/gophercloud/gophercloud v1.13.0 // indirect
-	github.com/grafana/pyroscope-go/godeltaprof v0.1.6 // indirect
+	github.com/grafana/pyroscope-go/godeltaprof v0.1.8 // indirect
 	github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1056,8 +1056,8 @@ github.com/grafana/jsonparser v0.0.0-20240425183733-ea80629e1a32 h1:NznuPwItog+r
 github.com/grafana/jsonparser v0.0.0-20240425183733-ea80629e1a32/go.mod h1:796sq+UcONnSlzA3RtlBZ+b/hrerkZXiEmO8oMjyRwY=
 github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe h1:yIXAAbLswn7VNWBIvM71O2QsgfgW9fRXZNR0DXe6pDU=
 github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOnAH9VT3Sh9MUE=
-github.com/grafana/pyroscope-go/godeltaprof v0.1.6 h1:nEdZ8louGAplSvIJi1HVp7kWvFvdiiYg3COLlTwJiFo=
-github.com/grafana/pyroscope-go/godeltaprof v0.1.6/go.mod h1:Tk376Nbldo4Cha9RgiU7ik8WKFkNpfds98aUzS8omLE=
+github.com/grafana/pyroscope-go/godeltaprof v0.1.8 h1:iwOtYXeeVSAeYefJNaxDytgjKtUuKQbJqgAIjlnicKg=
+github.com/grafana/pyroscope-go/godeltaprof v0.1.8/go.mod h1:2+l7K7twW49Ct4wFluZD3tZ6e0SjanjcUUBPVD/UuGU=
 github.com/grafana/regexp v0.0.0-20240518133315-a468a5bfb3bc h1:GN2Lv3MGO7AS6PrRoT6yV5+wkrOpcszoIsO4+4ds248=
 github.com/grafana/regexp v0.0.0-20240518133315-a468a5bfb3bc/go.mod h1:+JKpmjMGhpgPL+rXZ5nsZieVzvarn86asRlBg4uNGnk=
 github.com/grafana/tail v0.0.0-20230510142333-77b18831edf0 h1:bjh0PVYSVVFxzINqPFYJmAmJNrWPgnVjuSdYJGHmtFU=
@@ -1306,7 +1306,6 @@ github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+o
 github.com/klauspost/compress v1.9.5/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
 github.com/klauspost/compress v1.11.0/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/klauspost/compress v1.13.6/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
-github.com/klauspost/compress v1.17.3/go.mod h1:/dCuZOvVtNoHsyb+cuJD3itjs3NbnF6KH9zAO4BDxPM=
 github.com/klauspost/compress v1.17.9 h1:6KIumPrER1LHsvBVuDa0r5xaG0Es51mhhB9BQB2qeMA=
 github.com/klauspost/compress v1.17.9/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=
 github.com/klauspost/cpuid v1.2.0/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=

--- a/vendor/github.com/grafana/pyroscope-go/godeltaprof/README.md
+++ b/vendor/github.com/grafana/pyroscope-go/godeltaprof/README.md
@@ -91,8 +91,11 @@ CPU profiles: [BenchmarkOG](https://flamegraph.com/share/a8f68312-98c7-11ee-a502
 
 # upstreaming
 
-TODO(korniltsev): create golang issue and ask if godeltaprof is something that could be considered merging to upstream golang repo
-in some way(maybe not as is, maybe with different APIs)
+In the perfect world, this functionality exists in golang runtime/stdlib and we don't need godeltaprof library at all.
+
+See golang proposals:
+https://github.com/golang/go/issues/57765
+https://github.com/golang/go/issues/67942
 
 
 

--- a/vendor/github.com/grafana/pyroscope-go/godeltaprof/heap.go
+++ b/vendor/github.com/grafana/pyroscope-go/godeltaprof/heap.go
@@ -28,28 +28,28 @@ import (
 //	...
 //	err := hp.Profile(someWriter)
 type HeapProfiler struct {
-	impl  pprof.DeltaHeapProfiler
-	mutex sync.Mutex
+	impl    pprof.DeltaHeapProfiler
+	mutex   sync.Mutex
+	options pprof.ProfileBuilderOptions
 }
 
 func NewHeapProfiler() *HeapProfiler {
 	return &HeapProfiler{
-		impl: pprof.DeltaHeapProfiler{
-			Options: pprof.ProfileBuilderOptions{
-				GenericsFrames: true,
-				LazyMapping:    true,
-			},
+		impl: pprof.DeltaHeapProfiler{},
+		options: pprof.ProfileBuilderOptions{
+			GenericsFrames: true,
+			LazyMapping:    true,
 		}}
 }
 
 func NewHeapProfilerWithOptions(options ProfileOptions) *HeapProfiler {
 	return &HeapProfiler{
-		impl: pprof.DeltaHeapProfiler{
-			Options: pprof.ProfileBuilderOptions{
-				GenericsFrames: options.GenericsFrames,
-				LazyMapping:    options.LazyMappings,
-			},
-		}}
+		impl: pprof.DeltaHeapProfiler{},
+		options: pprof.ProfileBuilderOptions{
+			GenericsFrames: options.GenericsFrames,
+			LazyMapping:    options.LazyMappings,
+		},
+	}
 }
 
 func (d *HeapProfiler) Profile(w io.Writer) error {
@@ -76,6 +76,7 @@ func (d *HeapProfiler) Profile(w io.Writer) error {
 		}
 		// Profile grew; try again.
 	}
-
-	return d.impl.WriteHeapProto(w, p, int64(runtime.MemProfileRate), "")
+	rate := int64(runtime.MemProfileRate)
+	b := pprof.NewProfileBuilder(w, &d.options, pprof.HeapProfileConfig(rate))
+	return d.impl.WriteHeapProto(b, p, rate)
 }

--- a/vendor/github.com/grafana/pyroscope-go/godeltaprof/http/pprof/pprof.go
+++ b/vendor/github.com/grafana/pyroscope-go/godeltaprof/http/pprof/pprof.go
@@ -21,9 +21,10 @@ type deltaProfiler interface {
 }
 
 func init() {
-	http.HandleFunc("/debug/pprof/delta_heap", Heap)
-	http.HandleFunc("/debug/pprof/delta_block", Block)
-	http.HandleFunc("/debug/pprof/delta_mutex", Mutex)
+	prefix := routePrefix()
+	http.HandleFunc(prefix+"/debug/pprof/delta_heap", Heap)
+	http.HandleFunc(prefix+"/debug/pprof/delta_block", Block)
+	http.HandleFunc(prefix+"/debug/pprof/delta_mutex", Mutex)
 }
 
 func Heap(w http.ResponseWriter, r *http.Request) {

--- a/vendor/github.com/grafana/pyroscope-go/godeltaprof/http/pprof/pprof_go21.go
+++ b/vendor/github.com/grafana/pyroscope-go/godeltaprof/http/pprof/pprof_go21.go
@@ -1,0 +1,7 @@
+//go:build !go1.22
+
+package pprof
+
+func routePrefix() string {
+	return ""
+}

--- a/vendor/github.com/grafana/pyroscope-go/godeltaprof/http/pprof/pprof_go22.go
+++ b/vendor/github.com/grafana/pyroscope-go/godeltaprof/http/pprof/pprof_go22.go
@@ -1,0 +1,10 @@
+//go:build go1.22
+
+package pprof
+
+func routePrefix() string {
+	// As of go 1.23 we will panic if we don't prefix with "GET "
+	// https://github.com/golang/go/blob/9fcffc53593c5cd103630d0d24ef8bd91e17246d/src/net/http/pprof/pprof.go#L98-L97
+	// https://github.com/golang/go/commit/9fcffc53593c5cd103630d0d24ef8bd91e17246d
+	return "GET "
+}

--- a/vendor/github.com/grafana/pyroscope-go/godeltaprof/internal/pprof/builder.go
+++ b/vendor/github.com/grafana/pyroscope-go/godeltaprof/internal/pprof/builder.go
@@ -1,0 +1,18 @@
+package pprof
+
+type ProfileBuilder interface {
+	LocsForStack(stk []uintptr) (newLocs []uint64)
+	Sample(values []int64, locs []uint64, blockSize int64)
+	Build()
+}
+
+type ProfileConfig struct {
+	PeriodType        ValueType
+	Period            int64
+	SampleType        []ValueType
+	DefaultSampleType string
+}
+
+type ValueType struct {
+	Typ, Unit string
+}

--- a/vendor/github.com/grafana/pyroscope-go/godeltaprof/internal/pprof/map.go
+++ b/vendor/github.com/grafana/pyroscope-go/godeltaprof/internal/pprof/map.go
@@ -8,30 +8,23 @@ import "unsafe"
 
 // A profMap is a map from (stack, tag) to mapEntry.
 // It grows without bound, but that's assumed to be OK.
-type profMap struct {
-	hash    map[uintptr]*profMapEntry
-	all     *profMapEntry
-	last    *profMapEntry
-	free    []profMapEntry
+type profMap[PREV any, ACC any] struct {
+	hash    map[uintptr]*profMapEntry[PREV, ACC]
+	free    []profMapEntry[PREV, ACC]
 	freeStk []uintptr
 }
 
-type count struct {
-	// alloc_objects, alloc_bytes for heap
-	// mutex_count, mutex_duration for mutex
-	v1, v2 int64
-}
-
 // A profMapEntry is a single entry in the profMap.
-type profMapEntry struct {
-	nextHash *profMapEntry // next in hash list
-	nextAll  *profMapEntry // next in list of all entries
+// todo use unsafe.Pointer + len for stk ?
+type profMapEntry[PREV any, ACC any] struct {
+	nextHash *profMapEntry[PREV, ACC] // next in hash list
 	stk      []uintptr
 	tag      uintptr
-	count    count
+	prev     PREV
+	acc      ACC
 }
 
-func (m *profMap) Lookup(stk []uintptr, tag uintptr) *profMapEntry {
+func (m *profMap[PREV, ACC]) Lookup(stk []uintptr, tag uintptr) *profMapEntry[PREV, ACC] {
 	// Compute hash of (stk, tag).
 	h := uintptr(0)
 	for _, x := range stk {
@@ -42,7 +35,7 @@ func (m *profMap) Lookup(stk []uintptr, tag uintptr) *profMapEntry {
 	h += uintptr(tag) * 41
 
 	// Find entry if present.
-	var last *profMapEntry
+	var last *profMapEntry[PREV, ACC]
 Search:
 	for e := m.hash[h]; e != nil; last, e = e, e.nextHash {
 		if len(e.stk) != len(stk) || e.tag != tag {
@@ -64,7 +57,7 @@ Search:
 
 	// Add new entry.
 	if len(m.free) < 1 {
-		m.free = make([]profMapEntry, 128)
+		m.free = make([]profMapEntry[PREV, ACC], 128)
 	}
 	e := &m.free[0]
 	m.free = m.free[1:]
@@ -82,15 +75,8 @@ Search:
 		e.stk[j] = uintptr(stk[j])
 	}
 	if m.hash == nil {
-		m.hash = make(map[uintptr]*profMapEntry)
+		m.hash = make(map[uintptr]*profMapEntry[PREV, ACC])
 	}
 	m.hash[h] = e
-	if m.all == nil {
-		m.all = e
-		m.last = e
-	} else {
-		m.last.nextAll = e
-		m.last = e
-	}
 	return e
 }

--- a/vendor/github.com/grafana/pyroscope-go/godeltaprof/internal/pprof/stub.go
+++ b/vendor/github.com/grafana/pyroscope-go/godeltaprof/internal/pprof/stub.go
@@ -1,16 +1,4 @@
-//go:build go1.16 && !go1.23
-// +build go1.16,!go1.23
-
 package pprof
-
-// unsafe is required for go:linkname
-import _ "unsafe"
-
-//go:linkname runtime_expandFinalInlineFrame runtime/pprof.runtime_expandFinalInlineFrame
-func runtime_expandFinalInlineFrame(stk []uintptr) []uintptr
-
-//go:linkname runtime_cyclesPerSecond runtime/pprof.runtime_cyclesPerSecond
-func runtime_cyclesPerSecond() int64
 
 func Runtime_cyclesPerSecond() int64 {
 	return runtime_cyclesPerSecond()

--- a/vendor/github.com/grafana/pyroscope-go/godeltaprof/internal/pprof/stub_go22.go
+++ b/vendor/github.com/grafana/pyroscope-go/godeltaprof/internal/pprof/stub_go22.go
@@ -1,5 +1,5 @@
-//go:build go1.21
-// +build go1.21
+//go:build go1.21 && !go1.23
+// +build go1.21,!go1.23
 
 package pprof
 
@@ -19,3 +19,9 @@ func runtime_FrameStartLine(f *runtime.Frame) int
 //go:noescape
 //go:linkname runtime_FrameSymbolName runtime/pprof.runtime_FrameSymbolName
 func runtime_FrameSymbolName(f *runtime.Frame) string
+
+//go:linkname runtime_expandFinalInlineFrame runtime/pprof.runtime_expandFinalInlineFrame
+func runtime_expandFinalInlineFrame(stk []uintptr) []uintptr
+
+//go:linkname runtime_cyclesPerSecond runtime/pprof.runtime_cyclesPerSecond
+func runtime_cyclesPerSecond() int64

--- a/vendor/github.com/grafana/pyroscope-go/godeltaprof/internal/pprof/stub_go23.go
+++ b/vendor/github.com/grafana/pyroscope-go/godeltaprof/internal/pprof/stub_go23.go
@@ -1,5 +1,5 @@
-//go:build go1.16 && !go1.21
-// +build go1.16,!go1.21
+//go:build go1.23
+// +build go1.23
 
 package pprof
 
@@ -9,14 +9,16 @@ import (
 )
 
 // runtime_FrameStartLine is defined in runtime/symtab.go.
-func runtime_FrameStartLine(f *runtime.Frame) int {
-	return 0
-}
+//
+//go:noescape
+//go:linkname runtime_FrameStartLine runtime/pprof.runtime_FrameStartLine
+func runtime_FrameStartLine(f *runtime.Frame) int
 
 // runtime_FrameSymbolName is defined in runtime/symtab.go.
-func runtime_FrameSymbolName(f *runtime.Frame) string {
-	return f.Function
-}
+//
+//go:noescape
+//go:linkname runtime_FrameSymbolName runtime/pprof.runtime_FrameSymbolName
+func runtime_FrameSymbolName(f *runtime.Frame) string
 
 //go:linkname runtime_expandFinalInlineFrame runtime/pprof.runtime_expandFinalInlineFrame
 func runtime_expandFinalInlineFrame(stk []uintptr) []uintptr

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1029,8 +1029,8 @@ github.com/grafana/jsonparser
 # github.com/grafana/loki/pkg/push v0.0.0-20231124142027-e52380921608 => ./pkg/push
 ## explicit; go 1.19
 github.com/grafana/loki/pkg/push
-# github.com/grafana/pyroscope-go/godeltaprof v0.1.6
-## explicit; go 1.16
+# github.com/grafana/pyroscope-go/godeltaprof v0.1.8
+## explicit; go 1.18
 github.com/grafana/pyroscope-go/godeltaprof
 github.com/grafana/pyroscope-go/godeltaprof/http/pprof
 github.com/grafana/pyroscope-go/godeltaprof/internal/pprof


### PR DESCRIPTION
**What this PR does / why we need it**:

Bumping `grafana/pyroscope-go` to fix errors in `./cmd/loki` being compiled by go 1.23


**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
 
Related:

https://github.com/Homebrew/homebrew-core/pull/175310