### PR TITLE
fix: Unescape JSON strucutred metadata string values

### DIFF
--- a/pkg/loghttp/push/push_test.go
+++ b/pkg/loghttp/push/push_test.go
@@ -207,6 +207,18 @@ func TestParseRequest(t *testing.T) {
 			expectedLabels:                  labels.FromStrings("foo", "bar2"),
 		},
 		{
+			path:                            `/loki/api/v1/push`,
+			body:                            deflateString(`{"streams": [{ "stream": { "foo": "bar2" }, "values": [ [ "1570818238000000000", "fizzbuzz", {"key": "multi\nline\nvalue"} ] ] }]}`),
+			contentType:                     `application/json; charset=utf-8`,
+			contentEncoding:                 `deflate`,
+			valid:                           true,
+			expectedStructuredMetadataBytes: len("key") + len("multi\nline\nvalue"),
+			expectedBytes:                   len("fizzbuzz") + len("key") + len("multi\nline\nvalue"),
+			expectedLines:                   1,
+			expectedBytesUsageTracker:       map[string]float64{`{foo="bar2"}`: float64(len("fizzbuzz") + len("key") + len("multi\nline\nvalue"))},
+			expectedLabels:                  labels.FromStrings("foo", "bar2"),
+		},
+		{
 			path:                      `/loki/api/v1/push`,
 			body:                      `{"streams": [{ "stream": { "foo": "bar2", "job": "stuff" }, "values": [ [ "1570818238000000000", "fizzbuzz" ] ] }]}`,
 			contentType:               `application/json`,

--- a/pkg/loghttp/query.go
+++ b/pkg/loghttp/query.go
@@ -185,9 +185,13 @@ func unmarshalHTTPToLogProtoEntry(data []byte) (logproto.Entry, error) {
 				if dataType != jsonparser.String {
 					return jsonparser.MalformedStringError
 				}
+				valStr, err := jsonparser.ParseString(val)
+				if err != nil {
+					return err
+				}
 				structuredMetadata = append(structuredMetadata, logproto.LabelAdapter{
 					Name:  string(key),
-					Value: string(val),
+					Value: valStr,
 				})
 				return nil
 			})


### PR DESCRIPTION
In the case of strings, `ObjectEach` strips the quotes but does not unescape them.

**What this PR does / why we need it**:
Fixes #13918

**Which issue(s) this PR fixes**:
Fixes #13918

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [X] Tests updated
- [X] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
