### PR TITLE
chore(deps): lamba-promtail, move back to al2, update krb5-libs

### DIFF
--- a/tools/lambda-promtail/Dockerfile
+++ b/tools/lambda-promtail/Dockerfile
@@ -14,6 +14,8 @@ RUN go mod download
 RUN go build -o /main -tags lambda.norpc -ldflags="-s -w" lambda-promtail/*.go
 # copy artifacts to a clean image
 FROM public.ecr.aws/lambda/provided:al2023
-RUN dnf -y upgrade openssl-libs ca-certificates
+# dnf doesn't run with the current build image, but these are 
+# currently up to date in the al2023 image - 2024.08.20
+#RUN dnf -y upgrade openssl-libs ca-certificates
 COPY --from=build-image /main /main
 ENTRYPOINT [ "/main" ]

--- a/tools/lambda-promtail/Dockerfile
+++ b/tools/lambda-promtail/Dockerfile
@@ -13,9 +13,7 @@ RUN ls -al
 RUN go mod download
 RUN go build -o /main -tags lambda.norpc -ldflags="-s -w" lambda-promtail/*.go
 # copy artifacts to a clean image
-FROM public.ecr.aws/lambda/provided:al2023
-# dnf doesn't run with the current build image, but these are 
-# currently up to date in the al2023 image - 2024.08.20
-#RUN dnf -y upgrade openssl-libs ca-certificates
+FROM public.ecr.aws/lambda/provided:al2
+RUN yum -y update openssl-libs ca-certificates krb5-libs
 COPY --from=build-image /main /main
 ENTRYPOINT [ "/main" ]


### PR DESCRIPTION
**What this PR does / why we need it**:
Previous [PR](https://github.com/grafana/loki/pull/13938) updated to AmazonLinux 2023. This does not currently build in the pipeline on amd64 platforms.  This PR puts us back to AL2, and updates `krb5-libs`

**Which issue(s) this PR fixes**:
Fixes build issue on amd64 platforms, updates AL2 image to have a newer `krb5-libs`

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
