### PR TITLE
fix: Read full buffer from storage when fetching a range

### DIFF
--- a/pkg/querier-rf1/wal/chunks.go
+++ b/pkg/querier-rf1/wal/chunks.go
@@ -2,7 +2,6 @@ package wal
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"sort"
@@ -316,8 +315,8 @@ func readChunkData(ctx context.Context, storage BlockStorage, chunk ChunkData) (
 	defer reader.Close()
 
 	data := make([]byte, size)
-	_, err = reader.Read(data)
-	if err != nil && !errors.Is(err, io.EOF) {
+	_, err = io.ReadFull(reader, data)
+	if err != nil {
 		return nil, fmt.Errorf("could not read socket for %s: %w", chunk.id, err)
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes an issue in RF-1 queries where we didn't read the full object storage response because it wasn't available yet.
* io.ReadFull handles EOF errors so we no longer need to check for them. We'll get unexpected EOF if something goes wrong.