### PR TITLE
fix(otlp): use severity_text for detecting log level

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -70,7 +70,8 @@ var (
 var allowedLabelsForLevel = map[string]struct{}{
 	"level": {}, "LEVEL": {}, "Level": {},
 	"severity": {}, "SEVERITY": {}, "Severity": {},
-	"lvl": {}, "LVL": {}, "Lvl": {},
+	"severity_text": {},
+	"lvl":           {}, "LVL": {}, "Lvl": {},
 }
 
 // Config for a Distributor.


### PR DESCRIPTION
**What this PR does / why we need it**:
OTel data model uses `severity_text` for reporting log level. Loki's OTLP endpoint also [parses it as structured metadata](https://github.com/grafana/loki/blob/d4cf05a6a0119f9f4062628579cfcbe17cf678a4/pkg/loghttp/push/otlp.go#L299), but the log level detection feature does not look up this field. This pr updates the look-up list to include `severity_text`


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
