### PR TITLE
perf: Avoid looking up unnecessary TSDB symbols during Volume API

### DIFF
--- a/pkg/ingester/instance_test.go
+++ b/pkg/ingester/instance_test.go
@@ -1177,7 +1177,7 @@ func TestInstance_Volume(t *testing.T) {
 
 			volumes, err := instance.GetVolume(context.Background(), &logproto.VolumeRequest{
 				From:        0,
-				Through:     1.1 * 1e3, // milliseconds
+				Through:     1.1 * 1e3, //milliseconds
 				Matchers:    "{}",
 				Limit:       5,
 				AggregateBy: seriesvolume.Series,
@@ -1196,7 +1196,7 @@ func TestInstance_Volume(t *testing.T) {
 			instance := prepareInstance(t)
 			volumes, err := instance.GetVolume(context.Background(), &logproto.VolumeRequest{
 				From:        0,
-				Through:     1.1 * 1e3, // milliseconds
+				Through:     1.1 * 1e3, //milliseconds
 				Matchers:    `{log_stream="dispatcher"}`,
 				Limit:       5,
 				AggregateBy: seriesvolume.Series,
@@ -1212,7 +1212,7 @@ func TestInstance_Volume(t *testing.T) {
 			instance := prepareInstance(t)
 			volumes, err := instance.GetVolume(context.Background(), &logproto.VolumeRequest{
 				From:        5,
-				Through:     1.1 * 1e3, // milliseconds
+				Through:     1.1 * 1e3, //milliseconds
 				Matchers:    "{}",
 				Limit:       5,
 				AggregateBy: seriesvolume.Series,
@@ -1246,7 +1246,7 @@ func TestInstance_Volume(t *testing.T) {
 				instance := prepareInstance(t)
 				volumes, err := instance.GetVolume(context.Background(), &logproto.VolumeRequest{
 					From:         0,
-					Through:      1.1 * 1e3, // milliseconds
+					Through:      1.1 * 1e3, //milliseconds
 					Matchers:     `{}`,
 					Limit:        5,
 					TargetLabels: []string{"log_stream"},
@@ -1264,7 +1264,7 @@ func TestInstance_Volume(t *testing.T) {
 				instance := prepareInstance(t)
 				volumes, err := instance.GetVolume(context.Background(), &logproto.VolumeRequest{
 					From:         0,
-					Through:      1.1 * 1e3, // milliseconds
+					Through:      1.1 * 1e3, //milliseconds
 					Matchers:     `{log_stream="dispatcher"}`,
 					Limit:        5,
 					TargetLabels: []string{"host"},
@@ -1281,7 +1281,7 @@ func TestInstance_Volume(t *testing.T) {
 				instance := prepareInstance(t)
 				volumes, err := instance.GetVolume(context.Background(), &logproto.VolumeRequest{
 					From:         0,
-					Through:      1.1 * 1e3, // milliseconds
+					Through:      1.1 * 1e3, //milliseconds
 					Matchers:     `{log_stream=~".+"}`,
 					Limit:        5,
 					TargetLabels: []string{"host", "job"},
@@ -1301,7 +1301,7 @@ func TestInstance_Volume(t *testing.T) {
 			instance := prepareInstance(t)
 			volumes, err := instance.GetVolume(context.Background(), &logproto.VolumeRequest{
 				From:        0,
-				Through:     1.1 * 1e3, // milliseconds
+				Through:     1.1 * 1e3, //milliseconds
 				Matchers:    "{}",
 				Limit:       5,
 				AggregateBy: seriesvolume.Labels,
@@ -1321,7 +1321,7 @@ func TestInstance_Volume(t *testing.T) {
 			instance := prepareInstance(t)
 			volumes, err := instance.GetVolume(context.Background(), &logproto.VolumeRequest{
 				From:        0,
-				Through:     1.1 * 1e3, // milliseconds
+				Through:     1.1 * 1e3, //milliseconds
 				Matchers:    `{log_stream="worker"}`,
 				Limit:       5,
 				AggregateBy: seriesvolume.Labels,
@@ -1342,7 +1342,7 @@ func TestInstance_Volume(t *testing.T) {
 			instance := prepareInstance(t)
 			volumes, err := instance.GetVolume(context.Background(), &logproto.VolumeRequest{
 				From:        5,
-				Through:     1.1 * 1e3, // milliseconds
+				Through:     1.1 * 1e3, //milliseconds
 				Matchers:    "{}",
 				Limit:       5,
 				AggregateBy: seriesvolume.Labels,
@@ -1377,7 +1377,7 @@ func TestInstance_Volume(t *testing.T) {
 				instance := prepareInstance(t)
 				volumes, err := instance.GetVolume(context.Background(), &logproto.VolumeRequest{
 					From:         0,
-					Through:      1.1 * 1e3, // milliseconds
+					Through:      1.1 * 1e3, //milliseconds
 					Matchers:     `{}`,
 					Limit:        5,
 					TargetLabels: []string{"host"},
@@ -1394,7 +1394,7 @@ func TestInstance_Volume(t *testing.T) {
 				instance := prepareInstance(t)
 				volumes, err := instance.GetVolume(context.Background(), &logproto.VolumeRequest{
 					From:         0,
-					Through:      1.1 * 1e3, // milliseconds
+					Through:      1.1 * 1e3, //milliseconds
 					Matchers:     `{log_stream="dispatcher"}`,
 					Limit:        5,
 					TargetLabels: []string{"host"},
@@ -1411,7 +1411,7 @@ func TestInstance_Volume(t *testing.T) {
 				instance := prepareInstance(t)
 				volumes, err := instance.GetVolume(context.Background(), &logproto.VolumeRequest{
 					From:         0,
-					Through:      1.1 * 1e3, // milliseconds
+					Through:      1.1 * 1e3, //milliseconds
 					Matchers:     `{log_stream=~".+"}`,
 					Limit:        5,
 					TargetLabels: []string{"host", "job"},

--- a/pkg/ingester/instance_test.go
+++ b/pkg/ingester/instance_test.go
@@ -658,6 +658,10 @@ func (t *testFilter) ShouldFilter(lbs labels.Labels) bool {
 	return lbs.Get("log_stream") == "dispatcher"
 }
 
+func (t *testFilter) RequiredLabelNames() []string {
+	return []string{"log_stream"}
+}
+
 func Test_ChunkFilter(t *testing.T) {
 	instance := defaultInstance(t)
 	instance.chunkFilter = &testFilter{}
@@ -1173,7 +1177,7 @@ func TestInstance_Volume(t *testing.T) {
 
 			volumes, err := instance.GetVolume(context.Background(), &logproto.VolumeRequest{
 				From:        0,
-				Through:     1.1 * 1e3, //milliseconds
+				Through:     1.1 * 1e3, // milliseconds
 				Matchers:    "{}",
 				Limit:       5,
 				AggregateBy: seriesvolume.Series,
@@ -1192,7 +1196,7 @@ func TestInstance_Volume(t *testing.T) {
 			instance := prepareInstance(t)
 			volumes, err := instance.GetVolume(context.Background(), &logproto.VolumeRequest{
 				From:        0,
-				Through:     1.1 * 1e3, //milliseconds
+				Through:     1.1 * 1e3, // milliseconds
 				Matchers:    `{log_stream="dispatcher"}`,
 				Limit:       5,
 				AggregateBy: seriesvolume.Series,
@@ -1208,7 +1212,7 @@ func TestInstance_Volume(t *testing.T) {
 			instance := prepareInstance(t)
 			volumes, err := instance.GetVolume(context.Background(), &logproto.VolumeRequest{
 				From:        5,
-				Through:     1.1 * 1e3, //milliseconds
+				Through:     1.1 * 1e3, // milliseconds
 				Matchers:    "{}",
 				Limit:       5,
 				AggregateBy: seriesvolume.Series,
@@ -1242,7 +1246,7 @@ func TestInstance_Volume(t *testing.T) {
 				instance := prepareInstance(t)
 				volumes, err := instance.GetVolume(context.Background(), &logproto.VolumeRequest{
 					From:         0,
-					Through:      1.1 * 1e3, //milliseconds
+					Through:      1.1 * 1e3, // milliseconds
 					Matchers:     `{}`,
 					Limit:        5,
 					TargetLabels: []string{"log_stream"},
@@ -1260,7 +1264,7 @@ func TestInstance_Volume(t *testing.T) {
 				instance := prepareInstance(t)
 				volumes, err := instance.GetVolume(context.Background(), &logproto.VolumeRequest{
 					From:         0,
-					Through:      1.1 * 1e3, //milliseconds
+					Through:      1.1 * 1e3, // milliseconds
 					Matchers:     `{log_stream="dispatcher"}`,
 					Limit:        5,
 					TargetLabels: []string{"host"},
@@ -1277,7 +1281,7 @@ func TestInstance_Volume(t *testing.T) {
 				instance := prepareInstance(t)
 				volumes, err := instance.GetVolume(context.Background(), &logproto.VolumeRequest{
 					From:         0,
-					Through:      1.1 * 1e3, //milliseconds
+					Through:      1.1 * 1e3, // milliseconds
 					Matchers:     `{log_stream=~".+"}`,
 					Limit:        5,
 					TargetLabels: []string{"host", "job"},
@@ -1297,7 +1301,7 @@ func TestInstance_Volume(t *testing.T) {
 			instance := prepareInstance(t)
 			volumes, err := instance.GetVolume(context.Background(), &logproto.VolumeRequest{
 				From:        0,
-				Through:     1.1 * 1e3, //milliseconds
+				Through:     1.1 * 1e3, // milliseconds
 				Matchers:    "{}",
 				Limit:       5,
 				AggregateBy: seriesvolume.Labels,
@@ -1317,7 +1321,7 @@ func TestInstance_Volume(t *testing.T) {
 			instance := prepareInstance(t)
 			volumes, err := instance.GetVolume(context.Background(), &logproto.VolumeRequest{
 				From:        0,
-				Through:     1.1 * 1e3, //milliseconds
+				Through:     1.1 * 1e3, // milliseconds
 				Matchers:    `{log_stream="worker"}`,
 				Limit:       5,
 				AggregateBy: seriesvolume.Labels,
@@ -1338,7 +1342,7 @@ func TestInstance_Volume(t *testing.T) {
 			instance := prepareInstance(t)
 			volumes, err := instance.GetVolume(context.Background(), &logproto.VolumeRequest{
 				From:        5,
-				Through:     1.1 * 1e3, //milliseconds
+				Through:     1.1 * 1e3, // milliseconds
 				Matchers:    "{}",
 				Limit:       5,
 				AggregateBy: seriesvolume.Labels,
@@ -1373,7 +1377,7 @@ func TestInstance_Volume(t *testing.T) {
 				instance := prepareInstance(t)
 				volumes, err := instance.GetVolume(context.Background(), &logproto.VolumeRequest{
 					From:         0,
-					Through:      1.1 * 1e3, //milliseconds
+					Through:      1.1 * 1e3, // milliseconds
 					Matchers:     `{}`,
 					Limit:        5,
 					TargetLabels: []string{"host"},
@@ -1390,7 +1394,7 @@ func TestInstance_Volume(t *testing.T) {
 				instance := prepareInstance(t)
 				volumes, err := instance.GetVolume(context.Background(), &logproto.VolumeRequest{
 					From:         0,
-					Through:      1.1 * 1e3, //milliseconds
+					Through:      1.1 * 1e3, // milliseconds
 					Matchers:     `{log_stream="dispatcher"}`,
 					Limit:        5,
 					TargetLabels: []string{"host"},
@@ -1407,7 +1411,7 @@ func TestInstance_Volume(t *testing.T) {
 				instance := prepareInstance(t)
 				volumes, err := instance.GetVolume(context.Background(), &logproto.VolumeRequest{
 					From:         0,
-					Through:      1.1 * 1e3, //milliseconds
+					Through:      1.1 * 1e3, // milliseconds
 					Matchers:     `{log_stream=~".+"}`,
 					Limit:        5,
 					TargetLabels: []string{"host", "job"},

--- a/pkg/storage/chunk/interface.go
+++ b/pkg/storage/chunk/interface.go
@@ -67,4 +67,5 @@ type RequestChunkFilterer interface {
 // Filterer filters chunks based on the metric.
 type Filterer interface {
 	ShouldFilter(metric labels.Labels) bool
+	RequiredLabelNames() []string
 }

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -219,7 +219,8 @@ func getLocalStore(path string, cm ClientMetrics) Store {
 					PeriodicTableConfig: config.PeriodicTableConfig{
 						Prefix: "index_",
 						Period: time.Hour * 168,
-					}},
+					},
+				},
 				RowShards: 16,
 			},
 		},
@@ -866,6 +867,10 @@ func (f fakeChunkFilterer) ShouldFilter(metric labels.Labels) bool {
 	return metric.Get("foo") == "bazz"
 }
 
+func (f fakeChunkFilterer) RequiredLabelNames() []string {
+	return []string{"foo"}
+}
+
 func Test_ChunkFilterer(t *testing.T) {
 	s := &LokiStore{
 		Store: storeFixture,
@@ -921,7 +926,6 @@ func Test_PipelineWrapper(t *testing.T) {
 	s.SetPipelineWrapper(wrapper)
 	ctx = user.InjectOrgID(context.Background(), "test-user")
 	logit, err := s.SelectLogs(ctx, logql.SelectLogParams{QueryRequest: newQuery("{foo=~\"ba.*\"}", from, from.Add(1*time.Hour), []astmapper.ShardAnnotation{{Shard: 1, Of: 5}}, nil)})
-
 	if err != nil {
 		t.Errorf("store.SelectLogs() error = %v", err)
 		return
@@ -952,7 +956,6 @@ func Test_PipelineWrapper_disabled(t *testing.T) {
 	ctx = user.InjectOrgID(context.Background(), "test-user")
 	ctx = httpreq.InjectHeader(ctx, httpreq.LokiDisablePipelineWrappersHeader, "true")
 	logit, err := s.SelectLogs(ctx, logql.SelectLogParams{QueryRequest: newQuery("{foo=~\"ba.*\"}", from, from.Add(1*time.Hour), []astmapper.ShardAnnotation{{Shard: 1, Of: 5}}, nil)})
-
 	if err != nil {
 		t.Errorf("store.SelectLogs() error = %v", err)
 		return
@@ -1292,7 +1295,8 @@ func TestStore_indexPrefixChange(t *testing.T) {
 			PeriodicTableConfig: config.PeriodicTableConfig{
 				Prefix: "index_",
 				Period: time.Hour * 24,
-			}},
+			},
+		},
 	}
 
 	schemaConfig := config.SchemaConfig{
@@ -1366,7 +1370,8 @@ func TestStore_indexPrefixChange(t *testing.T) {
 			PeriodicTableConfig: config.PeriodicTableConfig{
 				Prefix: "index_tsdb_",
 				Period: time.Hour * 24,
-			}},
+			},
+		},
 		RowShards: 2,
 	}
 	schemaConfig.Configs = append(schemaConfig.Configs, periodConfig2)
@@ -1471,7 +1476,8 @@ func TestStore_MultiPeriod(t *testing.T) {
 					PeriodicTableConfig: config.PeriodicTableConfig{
 						Prefix: "index_",
 						Period: time.Hour * 24,
-					}},
+					},
+				},
 			}
 
 			periodConfigV11 := config.PeriodConfig{
@@ -1483,7 +1489,8 @@ func TestStore_MultiPeriod(t *testing.T) {
 					PeriodicTableConfig: config.PeriodicTableConfig{
 						Prefix: "index_",
 						Period: time.Hour * 24,
-					}},
+					},
+				},
 				RowShards: 2,
 			}
 
@@ -1562,7 +1569,6 @@ func TestStore_MultiPeriod(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func mustParseLabels(s string) []logproto.SeriesIdentifier_LabelsEntry {
@@ -1829,7 +1835,8 @@ func TestStore_BoltdbTsdbSameIndexPrefix(t *testing.T) {
 					PeriodicTableConfig: config.PeriodicTableConfig{
 						Prefix: "index_",
 						Period: time.Hour * 24,
-					}},
+					},
+				},
 				RowShards: 2,
 			},
 			{
@@ -1842,7 +1849,8 @@ func TestStore_BoltdbTsdbSameIndexPrefix(t *testing.T) {
 					PeriodicTableConfig: config.PeriodicTableConfig{
 						Prefix: "index_",
 						Period: time.Hour * 24,
-					}},
+					},
+				},
 			},
 		},
 	}
@@ -1980,7 +1988,8 @@ func TestStore_SyncStopInteraction(t *testing.T) {
 					PeriodicTableConfig: config.PeriodicTableConfig{
 						Prefix: "index_",
 						Period: time.Hour * 24,
-					}},
+					},
+				},
 				RowShards: 2,
 			},
 			{
@@ -1993,7 +2002,8 @@ func TestStore_SyncStopInteraction(t *testing.T) {
 					PeriodicTableConfig: config.PeriodicTableConfig{
 						Prefix: "index_",
 						Period: time.Hour * 24,
-					}},
+					},
+				},
 			},
 		},
 	}

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -219,8 +219,7 @@ func getLocalStore(path string, cm ClientMetrics) Store {
 					PeriodicTableConfig: config.PeriodicTableConfig{
 						Prefix: "index_",
 						Period: time.Hour * 168,
-					},
-				},
+					}},
 				RowShards: 16,
 			},
 		},
@@ -926,6 +925,7 @@ func Test_PipelineWrapper(t *testing.T) {
 	s.SetPipelineWrapper(wrapper)
 	ctx = user.InjectOrgID(context.Background(), "test-user")
 	logit, err := s.SelectLogs(ctx, logql.SelectLogParams{QueryRequest: newQuery("{foo=~\"ba.*\"}", from, from.Add(1*time.Hour), []astmapper.ShardAnnotation{{Shard: 1, Of: 5}}, nil)})
+
 	if err != nil {
 		t.Errorf("store.SelectLogs() error = %v", err)
 		return
@@ -956,6 +956,7 @@ func Test_PipelineWrapper_disabled(t *testing.T) {
 	ctx = user.InjectOrgID(context.Background(), "test-user")
 	ctx = httpreq.InjectHeader(ctx, httpreq.LokiDisablePipelineWrappersHeader, "true")
 	logit, err := s.SelectLogs(ctx, logql.SelectLogParams{QueryRequest: newQuery("{foo=~\"ba.*\"}", from, from.Add(1*time.Hour), []astmapper.ShardAnnotation{{Shard: 1, Of: 5}}, nil)})
+
 	if err != nil {
 		t.Errorf("store.SelectLogs() error = %v", err)
 		return
@@ -1295,8 +1296,7 @@ func TestStore_indexPrefixChange(t *testing.T) {
 			PeriodicTableConfig: config.PeriodicTableConfig{
 				Prefix: "index_",
 				Period: time.Hour * 24,
-			},
-		},
+			}},
 	}
 
 	schemaConfig := config.SchemaConfig{
@@ -1370,8 +1370,7 @@ func TestStore_indexPrefixChange(t *testing.T) {
 			PeriodicTableConfig: config.PeriodicTableConfig{
 				Prefix: "index_tsdb_",
 				Period: time.Hour * 24,
-			},
-		},
+			}},
 		RowShards: 2,
 	}
 	schemaConfig.Configs = append(schemaConfig.Configs, periodConfig2)
@@ -1476,8 +1475,7 @@ func TestStore_MultiPeriod(t *testing.T) {
 					PeriodicTableConfig: config.PeriodicTableConfig{
 						Prefix: "index_",
 						Period: time.Hour * 24,
-					},
-				},
+					}},
 			}
 
 			periodConfigV11 := config.PeriodConfig{
@@ -1489,8 +1487,7 @@ func TestStore_MultiPeriod(t *testing.T) {
 					PeriodicTableConfig: config.PeriodicTableConfig{
 						Prefix: "index_",
 						Period: time.Hour * 24,
-					},
-				},
+					}},
 				RowShards: 2,
 			}
 
@@ -1569,6 +1566,7 @@ func TestStore_MultiPeriod(t *testing.T) {
 			}
 		})
 	}
+
 }
 
 func mustParseLabels(s string) []logproto.SeriesIdentifier_LabelsEntry {
@@ -1835,8 +1833,7 @@ func TestStore_BoltdbTsdbSameIndexPrefix(t *testing.T) {
 					PeriodicTableConfig: config.PeriodicTableConfig{
 						Prefix: "index_",
 						Period: time.Hour * 24,
-					},
-				},
+					}},
 				RowShards: 2,
 			},
 			{
@@ -1849,8 +1846,7 @@ func TestStore_BoltdbTsdbSameIndexPrefix(t *testing.T) {
 					PeriodicTableConfig: config.PeriodicTableConfig{
 						Prefix: "index_",
 						Period: time.Hour * 24,
-					},
-				},
+					}},
 			},
 		},
 	}
@@ -1988,8 +1984,7 @@ func TestStore_SyncStopInteraction(t *testing.T) {
 					PeriodicTableConfig: config.PeriodicTableConfig{
 						Prefix: "index_",
 						Period: time.Hour * 24,
-					},
-				},
+					}},
 				RowShards: 2,
 			},
 			{
@@ -2002,8 +1997,7 @@ func TestStore_SyncStopInteraction(t *testing.T) {
 					PeriodicTableConfig: config.PeriodicTableConfig{
 						Prefix: "index_",
 						Period: time.Hour * 24,
-					},
-				},
+					}},
 			},
 		},
 	}

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/index.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/index.go
@@ -2234,7 +2234,7 @@ func (dec *Decoder) prepSeries(b []byte, lbls *labels.Labels, chks *[]ChunkMeta)
 // prepSeriesBy returns series labels and chunks for a series and only returning selected `by` label names.
 // If `by` is empty, it returns all labels for the series.
 func (dec *Decoder) prepSeriesBy(b []byte, lbls *labels.Labels, chks *[]ChunkMeta, by map[string]struct{}) (*encoding.Decbuf, uint64, error) {
-	if len(by) == 0 {
+	if by == nil {
 		return dec.prepSeries(b, lbls, chks)
 	}
 	*lbls = (*lbls)[:0]

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/index.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/index.go
@@ -1832,7 +1832,7 @@ func (r *Reader) Series(id storage.SeriesRef, from int64, through int64, lbls *l
 	return fprint, nil
 }
 
-func (r *Reader) ChunkStats(id storage.SeriesRef, from, through int64, lbls *labels.Labels) (uint64, ChunkStats, error) {
+func (r *Reader) ChunkStats(id storage.SeriesRef, from, through int64, lbls *labels.Labels, by map[string]struct{}) (uint64, ChunkStats, error) {
 	offset := id
 	// In version 2+ series IDs are no longer exact references but series are 16-byte padded
 	// and the ID is the multiple of 16 of the actual position.
@@ -1844,7 +1844,7 @@ func (r *Reader) ChunkStats(id storage.SeriesRef, from, through int64, lbls *lab
 		return 0, ChunkStats{}, d.Err()
 	}
 
-	return r.dec.ChunkStats(r.version, d.Get(), id, from, through, lbls)
+	return r.dec.ChunkStats(r.version, d.Get(), id, from, through, lbls, by)
 }
 
 func (r *Reader) Postings(name string, fpFilter FingerprintFilter, values ...string) (Postings, error) {
@@ -2216,7 +2216,7 @@ func (dec *Decoder) prepSeries(b []byte, lbls *labels.Labels, chks *[]ChunkMeta)
 		if d.Err() != nil {
 			return nil, 0, errors.Wrap(d.Err(), "read series label offsets")
 		}
-
+		// todo(cyriltovena): we could cache this by user requests spanning multiple prepSeries calls.
 		ln, err := dec.LookupSymbol(lno)
 		if err != nil {
 			return nil, 0, errors.Wrap(err, "lookup label name")
@@ -2231,8 +2231,50 @@ func (dec *Decoder) prepSeries(b []byte, lbls *labels.Labels, chks *[]ChunkMeta)
 	return &d, fprint, nil
 }
 
-func (dec *Decoder) ChunkStats(version int, b []byte, seriesRef storage.SeriesRef, from, through int64, lbls *labels.Labels) (uint64, ChunkStats, error) {
-	d, fp, err := dec.prepSeries(b, lbls, nil)
+// prepSeriesBy returns series labels and chunks for a series and only returning selected `by` label names.
+// If `by` is empty, it returns all labels for the series.
+func (dec *Decoder) prepSeriesBy(b []byte, lbls *labels.Labels, chks *[]ChunkMeta, by map[string]struct{}) (*encoding.Decbuf, uint64, error) {
+	if len(by) == 0 {
+		return dec.prepSeries(b, lbls, chks)
+	}
+	*lbls = (*lbls)[:0]
+	if chks != nil {
+		*chks = (*chks)[:0]
+	}
+
+	d := encoding.DecWrap(tsdb_enc.Decbuf{B: b})
+
+	fprint := d.Be64()
+	k := d.Uvarint()
+
+	for i := 0; i < k; i++ {
+		lno := uint32(d.Uvarint())
+		lvo := uint32(d.Uvarint())
+
+		if d.Err() != nil {
+			return nil, 0, errors.Wrap(d.Err(), "read series label offsets")
+		}
+		// todo(cyriltovena): we could cache this by user requests spanning multiple prepSeries calls.
+		ln, err := dec.LookupSymbol(lno)
+		if err != nil {
+			return nil, 0, errors.Wrap(err, "lookup label name")
+		}
+		if _, ok := by[ln]; !ok {
+			continue
+		}
+
+		lv, err := dec.LookupSymbol(lvo)
+		if err != nil {
+			return nil, 0, errors.Wrap(err, "lookup label value")
+		}
+
+		*lbls = append(*lbls, labels.Label{Name: ln, Value: lv})
+	}
+	return &d, fprint, nil
+}
+
+func (dec *Decoder) ChunkStats(version int, b []byte, seriesRef storage.SeriesRef, from, through int64, lbls *labels.Labels, by map[string]struct{}) (uint64, ChunkStats, error) {
+	d, fp, err := dec.prepSeriesBy(b, lbls, nil, by)
 	if err != nil {
 		return 0, ChunkStats{}, err
 	}

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/querier.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/querier.go
@@ -69,7 +69,7 @@ type IndexReader interface {
 	Series(ref storage.SeriesRef, from int64, through int64, lset *labels.Labels, chks *[]index.ChunkMeta) (uint64, error)
 
 	// ChunkStats returns the stats for the chunks in the given series.
-	ChunkStats(ref storage.SeriesRef, from, through int64, lset *labels.Labels) (uint64, index.ChunkStats, error)
+	ChunkStats(ref storage.SeriesRef, from, through int64, lset *labels.Labels, by map[string]struct{}) (uint64, index.ChunkStats, error)
 
 	// LabelNames returns all the unique label names present in the index in sorted order.
 	LabelNames(matchers ...*labels.Matcher) ([]string, error)

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/single_file_index.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/single_file_index.go
@@ -292,8 +292,7 @@ func (i *TSDBIndex) Stats(ctx context.Context, _ string, from, through model.Tim
 		var filterer chunk.Filterer
 		by := make(map[string]struct{})
 		if i.chunkFilter != nil {
-			filterer = i.chunkFilter.ForRequest(ctx)
-			if filterer != nil {
+			if filterer = i.chunkFilter.ForRequest(ctx); filterer != nil {
 				for _, k := range filterer.RequiredLabelNames() {
 					by[k] = struct{}{}
 				}
@@ -373,8 +372,10 @@ func (i *TSDBIndex) Volume(
 
 		// If we are aggregating by series, we need to include all labels in the series required for filtering chunks.
 		if i.chunkFilter != nil {
-			for _, k := range i.chunkFilter.ForRequest(ctx).RequiredLabelNames() {
-				by[k] = struct{}{}
+			if filterer := i.chunkFilter.ForRequest(ctx); filterer != nil {
+				for _, k := range filterer.RequiredLabelNames() {
+					by[k] = struct{}{}
+				}
 			}
 		}
 	}

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/single_file_index.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/single_file_index.go
@@ -293,8 +293,10 @@ func (i *TSDBIndex) Stats(ctx context.Context, _ string, from, through model.Tim
 		by := make(map[string]struct{})
 		if i.chunkFilter != nil {
 			filterer = i.chunkFilter.ForRequest(ctx)
-			for _, k := range i.chunkFilter.ForRequest(ctx).RequiredLabelNames() {
-				by[k] = struct{}{}
+			if filterer != nil {
+				for _, k := range filterer.RequiredLabelNames() {
+					by[k] = struct{}{}
+				}
 			}
 		}
 		for p.Next() {
@@ -366,9 +368,6 @@ func (i *TSDBIndex) Volume(
 	if !includeAll && (aggregateBySeries || len(targetLabels) > 0) {
 		by = make(map[string]struct{}, len(labelsToMatch))
 		for k := range labelsToMatch {
-			by[k] = struct{}{}
-		}
-		for _, k := range targetLabels {
 			by[k] = struct{}{}
 		}
 

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/single_file_index_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/single_file_index_test.go
@@ -2,6 +2,7 @@ package tsdb
 
 import (
 	"context"
+	"fmt"
 	"math/rand"
 	"sort"
 	"testing"
@@ -140,7 +141,6 @@ func TestSingleIdx(t *testing.T) {
 					End:         10,
 					Checksum:    3,
 				}}, shardedRefs)
-
 			})
 
 			t.Run("Series", func(t *testing.T) {
@@ -202,10 +202,8 @@ func TestSingleIdx(t *testing.T) {
 				require.Nil(t, err)
 				require.Equal(t, []string{"bar"}, vs)
 			})
-
 		})
 	}
-
 }
 
 func BenchmarkTSDBIndex_GetChunkRefs(b *testing.B) {
@@ -743,8 +741,48 @@ func TestTSDBIndex_Volume(t *testing.T) {
 					Limit: 10,
 				}, acc.Volumes())
 			})
+			// todo(cyriltovena): tests with chunk filterer
 		})
 	})
+}
+
+func BenchmarkTSDBIndex_Volume(b *testing.B) {
+	var series []LoadableSeries
+	for i := 0; i < 1000; i++ {
+		series = append(series, LoadableSeries{
+			Labels: mustParseLabels(fmt.Sprintf(`{foo="bar", fizz="fizz%d", buzz="buzz%d",bar="bar%d", bozz="bozz%d"}`, i, i, i, i)),
+			Chunks: []index.ChunkMeta{
+				{
+					MinTime:  0,
+					MaxTime:  10,
+					Checksum: uint32(i),
+					KB:       10,
+					Entries:  10,
+				},
+				{
+					MinTime:  10,
+					MaxTime:  20,
+					Checksum: uint32(i),
+					KB:       10,
+					Entries:  10,
+				},
+			},
+		})
+	}
+	ctx := context.Background()
+	from := model.Earliest
+	through := model.Latest
+	// Create the TSDB index
+	tempDir := b.TempDir()
+	tsdbIndex := BuildIndex(b, tempDir, series)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		acc := seriesvolume.NewAccumulator(10, 10)
+		err := tsdbIndex.Volume(ctx, "fake", from, through, acc, nil, nil, nil, seriesvolume.Series, labels.MustNewMatcher(labels.MatchRegexp, "foo", ".+"))
+		require.NoError(b, err)
+	}
 }
 
 type filterAll struct{}
@@ -757,4 +795,8 @@ type filterAllFilterer struct{}
 
 func (f *filterAllFilterer) ShouldFilter(_ labels.Labels) bool {
 	return true
+}
+
+func (f *filterAllFilterer) RequiredLabelNames() []string {
+	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This avoid loading all symbols for stats queries when not needed.

```
❯ benchstat before.txt after.txt
name                 old time/op    new time/op    delta
TSDBIndex_Volume-16    1.10ms ± 2%    0.40ms ± 4%  -63.24%  (p=0.008 n=5+5)

name                 old alloc/op   new alloc/op   delta
TSDBIndex_Volume-16    84.8kB ± 0%    52.7kB ± 0%     ~     (p=0.079 n=4+5)

name                 old allocs/op  new allocs/op  delta
TSDBIndex_Volume-16     5.07k ± 0%     1.07k ± 0%  -78.95%  (p=0.008 n=5+5)

````
**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
