### PR TITLE
feat: Implement labels & series endpoints for RF1 queriers

### DIFF
--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -1855,9 +1855,6 @@ func (t *Loki) initMetastore() (services.Service, error) {
 	if !t.Cfg.IngesterRF1.Enabled {
 		return nil, nil
 	}
-	if t.Cfg.isTarget(All) {
-		t.Cfg.MetastoreClient.MetastoreAddress = fmt.Sprintf("localhost:%d", t.Cfg.Server.GRPCListenPort)
-	}
 	m, err := metastore.New(t.Cfg.Metastore, log.With(util_log.Logger, "component", "metastore"), prometheus.DefaultRegisterer, t.health)
 	if err != nil {
 		return nil, err
@@ -1871,6 +1868,9 @@ func (t *Loki) initMetastore() (services.Service, error) {
 func (t *Loki) initMetastoreClient() (services.Service, error) {
 	if !t.Cfg.IngesterRF1.Enabled && !t.Cfg.QuerierRF1.Enabled {
 		return nil, nil
+	}
+	if t.Cfg.isTarget(All) {
+		t.Cfg.MetastoreClient.MetastoreAddress = fmt.Sprintf("localhost:%d", t.Cfg.Server.GRPCListenPort)
 	}
 	mc, err := metastoreclient.New(t.Cfg.MetastoreClient, prometheus.DefaultRegisterer)
 	if err != nil {

--- a/pkg/querier-rf1/wal/querier.go
+++ b/pkg/querier-rf1/wal/querier.go
@@ -4,15 +4,11 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"net/http"
 	"sort"
 	"sync"
 	"time"
 
-	"github.com/go-kit/kit/log/level"
-	"github.com/grafana/dskit/httpgrpc"
 	"github.com/opentracing/opentracing-go"
-	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
@@ -31,8 +27,6 @@ import (
 	"github.com/grafana/loki/v3/pkg/storage/wal/chunks"
 	"github.com/grafana/loki/v3/pkg/storage/wal/index"
 	"github.com/grafana/loki/v3/pkg/util"
-	"github.com/grafana/loki/v3/pkg/util/spanlogger"
-	util_validation "github.com/grafana/loki/v3/pkg/util/validation"
 )
 
 // TODO: Replace with the querier.Querier interface once we have support for all the methods.
@@ -394,28 +388,4 @@ func (q *Querier) forIndices(ctx context.Context, req *metastorepb.ListBlocksFor
 		})
 	}
 	return g.Wait()
-}
-
-func validateQueryTimeRangeLimits(ctx context.Context, userID string, limits querier.TimeRangeLimits, from, through time.Time) (time.Time, time.Time, error) {
-	now := nowFunc()
-	// Clamp the time range based on the max query lookback.
-	maxQueryLookback := limits.MaxQueryLookback(ctx, userID)
-	if maxQueryLookback > 0 && from.Before(now.Add(-maxQueryLookback)) {
-		origStartTime := from
-		from = now.Add(-maxQueryLookback)
-
-		level.Debug(spanlogger.FromContext(ctx)).Log(
-			"msg", "the start time of the query has been manipulated because of the 'max query lookback' setting",
-			"original", origStartTime,
-			"updated", from)
-
-	}
-	maxQueryLength := limits.MaxQueryLength(ctx, userID)
-	if maxQueryLength > 0 && (through).Sub(from) > maxQueryLength {
-		return time.Time{}, time.Time{}, httpgrpc.Errorf(http.StatusBadRequest, util_validation.ErrQueryTooLong, (through).Sub(from), model.Duration(maxQueryLength))
-	}
-	if through.Before(from) {
-		return time.Time{}, time.Time{}, httpgrpc.Errorf(http.StatusBadRequest, util_validation.ErrQueryTooOld, model.Duration(maxQueryLookback))
-	}
-	return from, through, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
* Implements the series & labels endpoints on the RF-1 querier via reading the segment indexes.

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/loki-private/issues/1065