### PR TITLE
chore: Rename `HeapIterator` to `MergeEntryIterator`

### DIFF
--- a/pkg/iter/entry_iterator_test.go
+++ b/pkg/iter/entry_iterator_test.go
@@ -162,16 +162,16 @@ func TestIteratorMultipleLabels(t *testing.T) {
 func TestMergeIteratorPrefetch(t *testing.T) {
 	t.Parallel()
 
-	type tester func(t *testing.T, i HeapIterator)
+	type tester func(t *testing.T, i MergeEntryIterator)
 
 	tests := map[string]tester{
-		"prefetch on IsEmpty() when called as first method": func(t *testing.T, i HeapIterator) {
+		"prefetch on IsEmpty() when called as first method": func(t *testing.T, i MergeEntryIterator) {
 			assert.Equal(t, false, i.IsEmpty())
 		},
-		"prefetch on Peek() when called as first method": func(t *testing.T, i HeapIterator) {
+		"prefetch on Peek() when called as first method": func(t *testing.T, i MergeEntryIterator) {
 			assert.Equal(t, time.Unix(0, 0), i.Peek())
 		},
-		"prefetch on Next() when called as first method": func(t *testing.T, i HeapIterator) {
+		"prefetch on Next() when called as first method": func(t *testing.T, i MergeEntryIterator) {
 			assert.True(t, i.Next())
 			assert.Equal(t, logproto.Entry{Timestamp: time.Unix(0, 0), Line: "0"}, i.At())
 		},

--- a/pkg/querier/tail.go
+++ b/pkg/querier/tail.go
@@ -38,7 +38,7 @@ const (
 // Tailer manages complete lifecycle of a tail request
 type Tailer struct {
 	// openStreamIterator is for streams already open
-	openStreamIterator iter.HeapIterator
+	openStreamIterator iter.MergeEntryIterator
 	streamMtx          sync.Mutex // for synchronizing access to openStreamIterator
 
 	currEntry  logproto.Entry

--- a/pkg/storage/batch.go
+++ b/pkg/storage/batch.go
@@ -421,7 +421,7 @@ func (it *logBatchIterator) buildIterators(chks map[model.Fingerprint][][]*LazyC
 	for _, chunks := range chks {
 		if len(chunks) != 0 && len(chunks[0]) != 0 {
 			streamPipeline := it.pipeline.ForStream(labels.NewBuilder(chunks[0][0].Chunk.Metric).Del(labels.MetricName).Labels())
-			iterator, err := it.buildHeapIterator(chunks, from, through, streamPipeline, nextChunk)
+			iterator, err := it.buildMergeIterator(chunks, from, through, streamPipeline, nextChunk)
 			if err != nil {
 				return nil, err
 			}
@@ -433,7 +433,7 @@ func (it *logBatchIterator) buildIterators(chks map[model.Fingerprint][][]*LazyC
 	return result, nil
 }
 
-func (it *logBatchIterator) buildHeapIterator(chks [][]*LazyChunk, from, through time.Time, streamPipeline log.StreamPipeline, nextChunk *LazyChunk) (iter.EntryIterator, error) {
+func (it *logBatchIterator) buildMergeIterator(chks [][]*LazyChunk, from, through time.Time, streamPipeline log.StreamPipeline, nextChunk *LazyChunk) (iter.EntryIterator, error) {
 	result := make([]iter.EntryIterator, 0, len(chks))
 
 	for i := range chks {

--- a/pkg/storage/batch_test.go
+++ b/pkg/storage/batch_test.go
@@ -1649,9 +1649,9 @@ func TestBuildHeapIterator(t *testing.T) {
 				ctx:      ctx,
 				pipeline: log.NewNoopPipeline(),
 			}
-			it, err := b.buildHeapIterator(tc.input, from, from.Add(6*time.Millisecond), b.pipeline.ForStream(labels.Labels{labels.Label{Name: "foo", Value: "bar"}}), nil)
+			it, err := b.buildMergeIterator(tc.input, from, from.Add(6*time.Millisecond), b.pipeline.ForStream(labels.Labels{labels.Label{Name: "foo", Value: "bar"}}), nil)
 			if err != nil {
-				t.Errorf("buildHeapIterator error = %v", err)
+				t.Errorf("buildMergeIterator error = %v", err)
 				return
 			}
 			req := newQuery("{foo=\"bar\"}", from, from.Add(6*time.Millisecond), nil, nil)


### PR DESCRIPTION
**What this PR does / why we need it**:

The name of the iterator leaked its implementation, and additionally that was not even correct any more, since the implementation has changed.

**Special notes for your reviewer**:

Stumbled across this iterator and was confused about its name.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
