### PR TITLE
chore(jsonnet): Add backend component to loki-simple-scalable jsonnet

### DIFF
--- a/production/ksonnet/loki-simple-scalable/backend.libsonnet
+++ b/production/ksonnet/loki-simple-scalable/backend.libsonnet
@@ -1,0 +1,57 @@
+local k = import 'ksonnet-util/kausal.libsonnet';
+
+{
+  local container = k.core.v1.container,
+  local pvc = k.core.v1.persistentVolumeClaim,
+  local statefulSet = k.apps.v1.statefulSet,
+  local volumeMount = k.core.v1.volumeMount,
+  local service = k.core.v1.service,
+
+  _config+:: {
+    backend_replicas: 1,
+  },
+
+  // The backends
+  backend_pvc::
+    pvc.new('backend-data') +
+    pvc.mixin.spec.resources.withRequests({ storage: '10Gi' }) +
+    pvc.mixin.spec.withAccessModes(['ReadWriteOnce']) +
+    pvc.mixin.spec.withStorageClassName('fast'),
+
+  backend_args::
+    $._config.commonArgs {
+      target: 'backend',
+    },
+
+  backend_container::
+    container.new('backend', $._images.loki) +
+    container.withPorts($.util.defaultPorts) +
+    container.withArgsMixin(k.util.mapToFlags($.backend_args)) +
+    container.withVolumeMountsMixin([volumeMount.new('backend-data', '/data')]) +
+    container.mixin.readinessProbe.httpGet.withPath('/ready') +
+    container.mixin.readinessProbe.httpGet.withPort($._config.http_listen_port) +
+    container.mixin.readinessProbe.withInitialDelaySeconds(15) +
+    container.mixin.readinessProbe.withTimeoutSeconds(1),
+
+  backend_statefulset:
+    statefulSet.new('backend', $._config.backend_replicas, [$.backend_container], $.backend_pvc) +
+    statefulSet.mixin.spec.withServiceName('backend') +
+    statefulSet.mixin.metadata.withLabels({ app: $._config.headless_service_name, name: 'backend' }) +
+    statefulSet.mixin.spec.selector.withMatchLabels({ name: 'backend' }) +
+    statefulSet.mixin.spec.template.metadata.withLabels({ name: 'backend', app: $._config.headless_service_name }) +
+    $._config.config_hash_mixin +
+    k.util.configVolumeMount('loki', '/etc/loki') +
+    k.util.antiAffinity +
+    statefulSet.mixin.spec.updateStrategy.withType('RollingUpdate') +
+    statefulSet.mixin.spec.template.spec.securityContext.withFsGroup(10001) +  // 10001 is the group ID assigned to Loki in the Dockerfile
+    statefulSet.mixin.spec.template.spec.withTerminationGracePeriodSeconds(4800) +
+    statefulSet.mixin.spec.withPodManagementPolicy('Parallel'),
+
+  backend_service:
+    k.util.serviceFor($.backend_statefulset) +
+    service.mixin.spec.withType('ClusterIP') +
+    service.mixin.spec.withPorts([
+      k.core.v1.servicePort.newNamed('backend-http-metrics', 80, 'http-metrics'),
+      k.core.v1.servicePort.newNamed('backend-grpc', 9095, 'grpc'),
+    ]),
+}

--- a/production/ksonnet/loki-simple-scalable/loki.libsonnet
+++ b/production/ksonnet/loki-simple-scalable/loki.libsonnet
@@ -5,4 +5,5 @@
 // Loki services
 (import 'read.libsonnet') +
 (import 'write.libsonnet') +
+(import 'backend.libsonnet') +
 (import 'headless.libsonnet')


### PR DESCRIPTION
**What this PR does / why we need it**:

Here we add a `backend` target to the `loki-simple-scalable` jsonnet deployment method.  Without this change, the deployment does not come up successfully on the read path, since the backend is a required component.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
