### PR TITLE
chore(jsonnet)!: convert read statefulset into deployment for loki-simple-scalable

### DIFF
--- a/production/ksonnet/loki-simple-scalable/read.libsonnet
+++ b/production/ksonnet/loki-simple-scalable/read.libsonnet
@@ -2,20 +2,13 @@ local k = import 'ksonnet-util/kausal.libsonnet';
 
 {
   local container = k.core.v1.container,
-  local pvc = k.core.v1.persistentVolumeClaim,
-  local statefulSet = k.apps.v1.statefulSet,
+  local deployment = k.apps.v1.deployment,
   local volumeMount = k.core.v1.volumeMount,
   local service = k.core.v1.service,
 
   _config+:: {
     read_replicas: 3,
   },
-
-  // Use PVC for queriers instead of node disk.
-  read_pvc::
-    pvc.new('read-data') +
-    pvc.mixin.spec.resources.withRequests({ storage: '10Gi' }) +
-    pvc.mixin.spec.withAccessModes(['ReadWriteOnce']),
 
   read_args::
     $._config.commonArgs {
@@ -26,28 +19,24 @@ local k = import 'ksonnet-util/kausal.libsonnet';
     container.new('read', $._images.read) +
     container.withPorts($.util.defaultPorts) +
     container.withArgsMixin(k.util.mapToFlags($.read_args)) +
-    container.withVolumeMountsMixin([volumeMount.new('read-data', '/data')]) +
     container.mixin.readinessProbe.httpGet.withPath('/ready') +
     container.mixin.readinessProbe.httpGet.withPort($._config.http_listen_port) +
     container.mixin.readinessProbe.withInitialDelaySeconds(15) +
     container.mixin.readinessProbe.withTimeoutSeconds(1),
 
-  read_statefulset:
-    statefulSet.new('read', $._config.read_replicas, [$.read_container], $.read_pvc) +
-    statefulSet.mixin.spec.withServiceName('read') +
-    statefulSet.mixin.metadata.withLabels({ app: $._config.headless_service_name, name: 'read' }) +
-    statefulSet.mixin.spec.selector.withMatchLabels({ name: 'read' }) +
-    statefulSet.mixin.spec.template.metadata.withLabels({ name: 'read', app: $._config.headless_service_name }) +
+  read_deployment:
+    deployment.new('read', $._config.read_replicas, [$.read_container]) +
+    deployment.mixin.metadata.withLabels({ app: $._config.headless_service_name, name: 'read' }) +
+    deployment.mixin.spec.selector.withMatchLabels({ name: 'read' }) +
+    deployment.mixin.spec.template.metadata.withLabels({ name: 'read', app: $._config.headless_service_name }) +
     $._config.config_hash_mixin +
     k.util.configVolumeMount('loki', '/etc/loki') +
     k.util.antiAffinity +
-    statefulSet.mixin.spec.updateStrategy.withType('RollingUpdate') +
-    statefulSet.mixin.spec.template.spec.securityContext.withFsGroup(10001) +  // 10001 is the group ID assigned to Loki in the Dockerfile
-    statefulSet.mixin.spec.template.spec.withTerminationGracePeriodSeconds(4800) +
-    statefulSet.mixin.spec.withPodManagementPolicy('Parallel'),
+    deployment.mixin.spec.template.spec.securityContext.withFsGroup(10001) +  // 10001 is the group ID assigned to Loki in the Dockerfile
+    deployment.mixin.spec.template.spec.withTerminationGracePeriodSeconds(4800),
 
   read_service:
-    k.util.serviceFor($.read_statefulset) +
+    k.util.serviceFor($.read_deployment) +
     service.mixin.spec.withType('ClusterIP') +
     service.mixin.spec.withPorts([
       k.core.v1.servicePort.newNamed('read-http-metrics', 80, 'http-metrics'),


### PR DESCRIPTION
**What this PR does / why we need it**:

Here we change the `read` statefulset into a deployment.  The stateful nature of the `read` component has moved to the `backend` component, and so here we make the converstion and allow easier scalability of the read path.

**BREAKING CHANGE** Users will need to clean up the old `statefulset`, `pvc` and `pv` resources that were created for the `read` component.  `tk prune` can help.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
