### PR TITLE
docs: Update HTTP API docs for  limit

### DIFF
--- a/docs/sources/reference/loki-http-api.md
+++ b/docs/sources/reference/loki-http-api.md
@@ -251,7 +251,7 @@ The JSON object must be set immediately after the log line. Here is an example o
 
 In microservices mode, `/loki/api/v1/push` is exposed by the distributor.
 
-If [`block_ingestion_until`]({{< relref "../configure/#limits_config" >}}) is configured and push requests are blocked, the endpoint will return the status code configured in `block_ingestion_status_code` (`260` by default)
+If [[block_ingestion_until]({{< relref "../configure#limits_config" >}})) is configured and push requests are blocked, the endpoint will return the status code configured in `block_ingestion_status_code` (`260` by default)
 along with an error message. If the configured status code is `200`, no error message will be returned.
 
 ### Examples

--- a/docs/sources/reference/loki-http-api.md
+++ b/docs/sources/reference/loki-http-api.md
@@ -251,6 +251,9 @@ The JSON object must be set immediately after the log line. Here is an example o
 
 In microservices mode, `/loki/api/v1/push` is exposed by the distributor.
 
+If [`block_ingestion_until`]({{< relref "../configure/#limits_config" >}}) is configured and push requests are blocked, the endpoint will return the status code configured in `block_ingestion_status_code` (`260` by default)
+along with an error message. If the configured status code is `200`, no error message will be returned.
+
 ### Examples
 
 The following cURL command pushes a stream with the label "foo=bar2" and a single log line "fizzbuzz" using JSON encoding:

--- a/docs/sources/reference/loki-http-api.md
+++ b/docs/sources/reference/loki-http-api.md
@@ -251,7 +251,7 @@ The JSON object must be set immediately after the log line. Here is an example o
 
 In microservices mode, `/loki/api/v1/push` is exposed by the distributor.
 
-If [[block_ingestion_until]({{< relref "../configure#limits_config" >}})) is configured and push requests are blocked, the endpoint will return the status code configured in `block_ingestion_status_code` (`260` by default)
+If [`block_ingestion_until`](/docs/loki/<LOKI_VERSION>/configuration/#limits_config) is configured and push requests are blocked, the endpoint will return the status code configured in `block_ingestion_status_code` (`260` by default)
 along with an error message. If the configured status code is `200`, no error message will be returned.
 
 ### Examples


### PR DESCRIPTION
**What this PR does / why we need it**:
Followup for https://github.com/grafana/loki/pull/13958

In this PR we update the HTTP API docs.

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
