### PR TITLE
chore(ci): fix failing arm builds

### DIFF
--- a/pkg/ingester-kafka/kafka/kafka_tee.go
+++ b/pkg/ingester-kafka/kafka/kafka_tee.go
@@ -101,7 +101,7 @@ func NewTee(
 		// When a Produce request to Kafka fail, the client will retry up until the RecordDeliveryTimeout is reached.
 		// Once the timeout is reached, the Produce request will fail and all other buffered requests in the client
 		// (for the same partition) will fail too. See kgo.RecordDeliveryTimeout() documentation for more info.
-		kgo.RecordRetries(math.MaxInt64),
+		kgo.RecordRetries(math.MaxInt),
 		kgo.RecordDeliveryTimeout(time.Minute),
 		kgo.ProduceRequestTimeout(time.Minute),
 		kgo.RequestTimeoutOverhead(time.Minute),


### PR DESCRIPTION
**What this PR does / why we need it**:
`GOOS=linux GOARCH=arm make loki` fails on main
https://github.com/grafana/loki/actions/runs/10658934585/job/29540918814

**Which issue(s) this PR fixes**:

Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
