### PR TITLE
fix(loki/production/docker-compose): upgrade loki and grafana production image tags to 3.1.1

### DIFF
--- a/production/docker-compose.yaml
+++ b/production/docker-compose.yaml
@@ -5,7 +5,7 @@ networks:
 
 services:
   loki:
-    image: grafana/loki:2.9.2
+    image: grafana/loki:3.1.1
     ports:
       - "3100:3100"
     command: -config.file=/etc/loki/local-config.yaml
@@ -13,7 +13,7 @@ services:
       - loki
 
   promtail:
-    image: grafana/promtail:2.9.2
+    image: grafana/promtail:3.1.1
     volumes:
       - /var/log:/var/log
     command: -config.file=/etc/promtail/config.yml


### PR DESCRIPTION
**What this PR does / why we need it**: Because this is on the v3.1.x release branch and it still has v2.x.x image tags in the docker-compose.yml. This should also be reflected by updating the link for docker-compose.yaml in the documentation at https://grafana.com/docs/loki/latest/setup/install/docker/#install-with-docker-compose

**Which issue(s) this PR fixes**: No issue created

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
