### PR TITLE
fix: do not retain span logger created with index set initialized at query time

### DIFF
--- a/pkg/storage/stores/shipper/indexshipper/downloads/index_set.go
+++ b/pkg/storage/stores/shipper/indexshipper/downloads/index_set.go
@@ -20,7 +20,6 @@ import (
 	"github.com/grafana/loki/v3/pkg/storage/chunk/client/util"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/index"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/storage"
-	util_log "github.com/grafana/loki/v3/pkg/util/log"
 	"github.com/grafana/loki/v3/pkg/util/spanlogger"
 )
 
@@ -32,7 +31,7 @@ const (
 var errIndexListCacheTooStale = fmt.Errorf("index list cache too stale")
 
 type IndexSet interface {
-	Init(forQuerying bool) error
+	Init(forQuerying bool, logger log.Logger) error
 	Close()
 	ForEach(ctx context.Context, callback index.ForEachIndexCallback) error
 	ForEachConcurrent(ctx context.Context, callback index.ForEachIndexCallback) error
@@ -94,13 +93,11 @@ func NewIndexSet(tableName, userID, cacheLocation string, baseIndexSet storage.I
 }
 
 // Init downloads all the db files for the table from object storage.
-func (t *indexSet) Init(forQuerying bool) (err error) {
+func (t *indexSet) Init(forQuerying bool, logger log.Logger) (err error) {
 	// Using background context to avoid cancellation of download when request times out.
 	// We would anyways need the files for serving next requests.
 	ctx := context.Background()
 	ctx, t.cancelFunc = context.WithTimeout(ctx, downloadTimeout)
-
-	logger, ctx := spanlogger.NewWithLogger(ctx, t.logger, "indexSet.Init")
 
 	defer func() {
 		if err != nil {
@@ -186,7 +183,7 @@ func (t *indexSet) ForEach(ctx context.Context, callback index.ForEachIndexCallb
 	}
 	defer t.indexMtx.rUnlock()
 
-	logger := util_log.WithContext(ctx, t.logger)
+	logger := spanlogger.FromContextWithFallback(ctx, t.logger)
 	level.Debug(logger).Log("index-files-count", len(t.index))
 
 	for _, idx := range t.index {
@@ -205,7 +202,7 @@ func (t *indexSet) ForEachConcurrent(ctx context.Context, callback index.ForEach
 	}
 	defer t.indexMtx.rUnlock()
 
-	logger := util_log.WithContext(ctx, t.logger)
+	logger := spanlogger.FromContextWithFallback(ctx, t.logger)
 	level.Debug(logger).Log("index-files-count", len(t.index))
 
 	if len(t.index) == 0 {

--- a/pkg/storage/stores/shipper/indexshipper/downloads/index_set_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/downloads/index_set_test.go
@@ -26,7 +26,7 @@ func buildTestIndexSet(t *testing.T, userID, path string) (*indexSet, stopFunc) 
 		}, util_log.Logger)
 	require.NoError(t, err)
 
-	require.NoError(t, idxSet.Init(false))
+	require.NoError(t, idxSet.Init(false, util_log.Logger))
 
 	return idxSet.(*indexSet), idxSet.Close
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
While investigating the memory usage of index gateways, I came across an instance where the logger was doing too many allocations coming from specifically [here](https://github.com/grafana/loki/blob/bf60455c8e52b87774df9ca90232b4c72d72e46b/pkg/storage/stores/shipper/indexshipper/downloads/index_set.go#L209). It turns out we were creating a span logger at query time and [retaining it with the index set initialized at query time](https://github.com/grafana/loki/blob/2a4d9b37714a3ee39ab398a964dfa5a70e49c64f/pkg/storage/stores/shipper/indexshipper/downloads/table.go#L314). 

<img width="1878" alt="Screenshot 2024-09-02 at 4 24 08 PM" src="https://github.com/user-attachments/assets/68cfaa71-eacb-4017-8ca5-8c6e22648d6b">

This PR fixes the issue by not using span logger while initializing index sets.