### PR TITLE
chore(blooms)!: Introduce a new block schema (V3)

### DIFF
--- a/pkg/bloomgateway/processor.go
+++ b/pkg/bloomgateway/processor.go
@@ -145,8 +145,8 @@ func (p *processor) processBlock(_ context.Context, bq *bloomshipper.CloseableBl
 		return err
 	}
 
-	// We require V3 schema
-	if !schema.IsCurrentSchema() {
+	// We require V3+ schema
+	if schema.Version() < v1.V3 {
 		return v1.ErrUnsupportedSchemaVersion
 	}
 

--- a/pkg/bloomgateway/processor.go
+++ b/pkg/bloomgateway/processor.go
@@ -145,6 +145,11 @@ func (p *processor) processBlock(_ context.Context, bq *bloomshipper.CloseableBl
 		return err
 	}
 
+	// We require V3 schema
+	if !schema.IsCurrentSchema() {
+		return v1.ErrUnsupportedSchemaVersion
+	}
+
 	tokenizer := v1.NewNGramTokenizer(schema.NGramLen(), schema.NGramSkip())
 	iters := make([]iter.PeekIterator[v1.Request], 0, len(tasks))
 

--- a/pkg/storage/bloom/v1/archive_test.go
+++ b/pkg/storage/bloom/v1/archive_test.go
@@ -23,7 +23,7 @@ func TestArchive(t *testing.T) {
 	builder, err := NewBlockBuilder(
 		BlockOptions{
 			Schema: Schema{
-				version:  DefaultSchemaVersion,
+				version:  CurrentSchemaVersion,
 				encoding: chunkenc.EncSnappy,
 			},
 			SeriesPageSize: 100,

--- a/pkg/storage/bloom/v1/bloom.go
+++ b/pkg/storage/bloom/v1/bloom.go
@@ -23,6 +23,13 @@ type Bloom struct {
 	filter.ScalableBloomFilter
 }
 
+func NewBloom() *Bloom {
+	return &Bloom{
+		// TODO parameterise SBF options. fp_rate
+		ScalableBloomFilter: *filter.NewScalableBloomFilter(1024, 0.01, 0.8),
+	}
+}
+
 func (b *Bloom) Encode(enc *encoding.Encbuf) error {
 	// divide by 8 b/c bloom capacity is measured in bits, but we want bytes
 	buf := bytes.NewBuffer(make([]byte, 0, int(b.Capacity()/8)))

--- a/pkg/storage/bloom/v1/bloom_builder.go
+++ b/pkg/storage/bloom/v1/bloom_builder.go
@@ -46,6 +46,8 @@ func (b *BloomBlockBuilder) Append(bloom *Bloom) (BloomOffset, error) {
 		}
 	}
 
+	// version := b.opts.Schema.version
+
 	b.scratch.Reset()
 	if err := bloom.Encode(b.scratch); err != nil {
 		return BloomOffset{}, errors.Wrap(err, "encoding bloom")

--- a/pkg/storage/bloom/v1/bloom_builder.go
+++ b/pkg/storage/bloom/v1/bloom_builder.go
@@ -46,8 +46,6 @@ func (b *BloomBlockBuilder) Append(bloom *Bloom) (BloomOffset, error) {
 		}
 	}
 
-	// version := b.opts.Schema.version
-
 	b.scratch.Reset()
 	if err := bloom.Encode(b.scratch); err != nil {
 		return BloomOffset{}, errors.Wrap(err, "encoding bloom")

--- a/pkg/storage/bloom/v1/bloom_tokenizer.go
+++ b/pkg/storage/bloom/v1/bloom_tokenizer.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/grafana/loki/v3/pkg/iter"
 	v2iter "github.com/grafana/loki/v3/pkg/iter/v2"
-	"github.com/grafana/loki/v3/pkg/logproto"
 	"github.com/grafana/loki/v3/pkg/storage/bloom/v1/filter"
 	"github.com/grafana/loki/v3/pkg/util/encoding"
 
@@ -139,7 +138,7 @@ func (bt *BloomTokenizer) Populate(
 
 	for chks.Next() {
 		chk := chks.At()
-		itr := newPeekingEntryIterAdapter(chk.Itr)
+		itr := v2iter.NewPeekIter(chk.Itr)
 
 		for {
 			full, newBytes := bt.addChunkToBloom(
@@ -287,20 +286,4 @@ outer:
 	bt.metrics.sourceBytesAdded.Add(float64(chunkBytes))
 
 	return full, chunkBytes
-}
-
-type entryIterAdapter struct {
-	iter.EntryIterator
-}
-
-func (a entryIterAdapter) At() logproto.Entry {
-	return a.EntryIterator.At()
-}
-
-func (a entryIterAdapter) Err() error {
-	return a.EntryIterator.Err()
-}
-
-func newPeekingEntryIterAdapter(itr iter.EntryIterator) *v2iter.PeekIter[logproto.Entry] {
-	return v2iter.NewPeekIter[logproto.Entry](entryIterAdapter{itr})
 }

--- a/pkg/storage/bloom/v1/bloom_tokenizer.go
+++ b/pkg/storage/bloom/v1/bloom_tokenizer.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/grafana/loki/v3/pkg/iter"
 	v2iter "github.com/grafana/loki/v3/pkg/iter/v2"
-	"github.com/grafana/loki/v3/pkg/storage/bloom/v1/filter"
 	"github.com/grafana/loki/v3/pkg/util/encoding"
 
 	"github.com/grafana/loki/pkg/push"

--- a/pkg/storage/bloom/v1/bloom_tokenizer.go
+++ b/pkg/storage/bloom/v1/bloom_tokenizer.go
@@ -91,13 +91,6 @@ func estimatedCount(m uint, p float64) uint {
 	return uint(-float64(m) * math.Log(1-p))
 }
 
-func (bt *BloomTokenizer) newBloom() *Bloom {
-	return &Bloom{
-		// TODO parameterise SBF options. fp_rate
-		ScalableBloomFilter: *filter.NewScalableBloomFilter(1024, 0.01, 0.8),
-	}
-}
-
 // Populates a bloom filter(s) with the tokens from the given chunks.
 // Called once per series
 func (bt *BloomTokenizer) Populate(
@@ -131,7 +124,7 @@ func (bt *BloomTokenizer) Populate(
 			)
 		}
 	} else {
-		bloom = bt.newBloom()
+		bloom = NewBloom()
 	}
 
 	var bytesAdded int
@@ -155,7 +148,7 @@ func (bt *BloomTokenizer) Populate(
 
 				// start a new bloom + reset bytesAdded counter
 				bytesAdded = 0
-				bloom = bt.newBloom()
+				bloom = NewBloom()
 
 				// cache _MUST_ be cleared when a new bloom is created to ensure that all tokens from
 				// each line are indexed into at least one bloom

--- a/pkg/storage/bloom/v1/builder.go
+++ b/pkg/storage/bloom/v1/builder.go
@@ -66,6 +66,18 @@ func (b BlockOptions) Encode(enc *encoding.Encbuf) {
 	enc.PutBE64(b.BlockSize)
 }
 
+// func NewDefaultBlockOptions(maxBlockSizeBytes, maxBloomSizeBytes uint64) BlockOptions {
+// 	opts := NewBlockOptionsFromSchema(Schema{
+// 		version:     DefaultSchemaVersion,
+// 		encoding:    chunkenc.EncNone,
+// 		nGramLength: 0,
+// 		nGramSkip:   0,
+// 	})
+// 	opts.BlockSize = maxBlockSizeBytes
+// 	opts.UnencodedBlockOptions.MaxBloomSizeBytes = maxBloomSizeBytes
+// 	return opts
+// }
+
 func NewBlockOptions(enc chunkenc.Encoding, nGramLength, nGramSkip, maxBlockSizeBytes, maxBloomSizeBytes uint64) BlockOptions {
 	opts := NewBlockOptionsFromSchema(Schema{
 		version:     DefaultSchemaVersion,
@@ -289,7 +301,7 @@ func (mb *MergeBuilder) processNextSeries(
 		bytesAdded += bloom.SourceBytesAdded
 	}
 
-	done, err := builder.AddSeries(*nextInStore, offsets)
+	done, err := builder.AddSeries(*nextInStore, offsets, []Field{Field("__line__")})
 	if err != nil {
 		return nil, bytesAdded, 0, false, false, errors.Wrap(err, "committing series")
 	}

--- a/pkg/storage/bloom/v1/builder.go
+++ b/pkg/storage/bloom/v1/builder.go
@@ -66,18 +66,6 @@ func (b BlockOptions) Encode(enc *encoding.Encbuf) {
 	enc.PutBE64(b.BlockSize)
 }
 
-// func NewDefaultBlockOptions(maxBlockSizeBytes, maxBloomSizeBytes uint64) BlockOptions {
-// 	opts := NewBlockOptionsFromSchema(Schema{
-// 		version:     DefaultSchemaVersion,
-// 		encoding:    chunkenc.EncNone,
-// 		nGramLength: 0,
-// 		nGramSkip:   0,
-// 	})
-// 	opts.BlockSize = maxBlockSizeBytes
-// 	opts.UnencodedBlockOptions.MaxBloomSizeBytes = maxBloomSizeBytes
-// 	return opts
-// }
-
 func NewBlockOptions(enc chunkenc.Encoding, nGramLength, nGramSkip, maxBlockSizeBytes, maxBloomSizeBytes uint64) BlockOptions {
 	opts := NewBlockOptionsFromSchema(Schema{
 		version:     CurrentSchemaVersion,

--- a/pkg/storage/bloom/v1/builder.go
+++ b/pkg/storage/bloom/v1/builder.go
@@ -80,7 +80,7 @@ func (b BlockOptions) Encode(enc *encoding.Encbuf) {
 
 func NewBlockOptions(enc chunkenc.Encoding, nGramLength, nGramSkip, maxBlockSizeBytes, maxBloomSizeBytes uint64) BlockOptions {
 	opts := NewBlockOptionsFromSchema(Schema{
-		version:     DefaultSchemaVersion,
+		version:     CurrentSchemaVersion,
 		encoding:    enc,
 		nGramLength: nGramLength,
 		nGramSkip:   nGramSkip,

--- a/pkg/storage/bloom/v1/builder.go
+++ b/pkg/storage/bloom/v1/builder.go
@@ -301,7 +301,12 @@ func (mb *MergeBuilder) processNextSeries(
 		bytesAdded += bloom.SourceBytesAdded
 	}
 
-	done, err := builder.AddSeries(*nextInStore, offsets, []Field{Field("__line__")})
+	// TODO(chaudum): Use the indexed fields from bloom creation, however,
+	// currently we still build blooms from log lines.
+	fields := NewSet[Field](1)
+	fields.Add("__line__")
+
+	done, err := builder.AddSeries(*nextInStore, offsets, fields)
 	if err != nil {
 		return nil, bytesAdded, 0, false, false, errors.Wrap(err, "committing series")
 	}

--- a/pkg/storage/bloom/v1/builder_test.go
+++ b/pkg/storage/bloom/v1/builder_test.go
@@ -24,11 +24,11 @@ var blockEncodings = []chunkenc.Encoding{
 	chunkenc.EncZstd,
 }
 
-func TestBlockOptionsRoundTrip(t *testing.T) {
+func TestBlockOptions_RoundTrip(t *testing.T) {
 	t.Parallel()
 	opts := BlockOptions{
 		Schema: Schema{
-			version:     V1,
+			version:     DefaultSchemaVersion,
 			encoding:    chunkenc.EncSnappy,
 			nGramLength: 10,
 			nGramSkip:   2,
@@ -548,9 +548,8 @@ func TestMergeBuilder_Roundtrip(t *testing.T) {
 	builder, err := NewBlockBuilder(blockOpts, writer)
 	require.Nil(t, err)
 
-	checksum, _, err := mb.Build(builder)
+	_, _, err = mb.Build(builder)
 	require.Nil(t, err)
-	require.Equal(t, uint32(0x2a6cdba6), checksum)
 
 	// ensure the new block contains one copy of all the data
 	// by comparing it against an iterator over the source data

--- a/pkg/storage/bloom/v1/builder_test.go
+++ b/pkg/storage/bloom/v1/builder_test.go
@@ -550,6 +550,9 @@ func TestMergeBuilder_Roundtrip(t *testing.T) {
 
 	_, _, err = mb.Build(builder)
 	require.Nil(t, err)
+	// checksum changes as soon as the contents of the block or the encoding change
+	// once the block format is stable, calculate the checksum and assert its correctness
+	// require.Equal(t, uint32(0x2a6cdba6), checksum)
 
 	// ensure the new block contains one copy of all the data
 	// by comparing it against an iterator over the source data

--- a/pkg/storage/bloom/v1/builder_test.go
+++ b/pkg/storage/bloom/v1/builder_test.go
@@ -28,7 +28,7 @@ func TestBlockOptions_RoundTrip(t *testing.T) {
 	t.Parallel()
 	opts := BlockOptions{
 		Schema: Schema{
-			version:     DefaultSchemaVersion,
+			version:     CurrentSchemaVersion,
 			encoding:    chunkenc.EncSnappy,
 			nGramLength: 10,
 			nGramSkip:   2,
@@ -89,7 +89,7 @@ func TestBlockBuilder_RoundTrip(t *testing.T) {
 			t.Run(desc, func(t *testing.T) {
 				blockOpts := BlockOptions{
 					Schema: Schema{
-						version:     DefaultSchemaVersion,
+						version:     CurrentSchemaVersion,
 						encoding:    enc,
 						nGramLength: 10,
 						nGramSkip:   2,
@@ -210,7 +210,7 @@ func TestMergeBuilder(t *testing.T) {
 	data, _ := MkBasicSeriesWithBlooms(numSeries, 0, 0xffff, 0, 10000)
 	blockOpts := BlockOptions{
 		Schema: Schema{
-			version:  DefaultSchemaVersion,
+			version:  CurrentSchemaVersion,
 			encoding: chunkenc.EncSnappy,
 		},
 		SeriesPageSize: 100,
@@ -306,7 +306,7 @@ func TestMergeBuilderFingerprintCollision(t *testing.T) {
 
 	blockOpts := BlockOptions{
 		Schema: Schema{
-			version:  DefaultSchemaVersion,
+			version:  CurrentSchemaVersion,
 			encoding: chunkenc.EncSnappy,
 		},
 		SeriesPageSize: 100,
@@ -399,7 +399,7 @@ func TestBlockReset(t *testing.T) {
 	reader := NewByteReader(indexBuf, bloomsBuf)
 
 	schema := Schema{
-		version:     DefaultSchemaVersion,
+		version:     CurrentSchemaVersion,
 		encoding:    chunkenc.EncSnappy,
 		nGramLength: 10,
 		nGramSkip:   2,
@@ -457,7 +457,7 @@ func TestMergeBuilder_Roundtrip(t *testing.T) {
 
 	blockOpts := BlockOptions{
 		Schema: Schema{
-			version:     DefaultSchemaVersion,
+			version:     CurrentSchemaVersion,
 			encoding:    chunkenc.EncSnappy, // test with different encodings?
 			nGramLength: 4,                  // needs to match values from MkBasicSeriesWithBlooms
 			nGramSkip:   0,                  // needs to match values from MkBasicSeriesWithBlooms

--- a/pkg/storage/bloom/v1/fuse.go
+++ b/pkg/storage/bloom/v1/fuse.go
@@ -253,7 +253,7 @@ func (fq *FusedQuerier) Run() error {
 	return nil
 }
 
-func (fq *FusedQuerier) runSeries(schema Schema, series *SeriesWithOffsets, reqs []Request) {
+func (fq *FusedQuerier) runSeries(schema Schema, series *SeriesWithMeta, reqs []Request) {
 	// For a given chunk|series to be removed, it must fail to match all blooms.
 	// Because iterating/loading blooms can be expensive, we iterate blooms one at a time, collecting
 	// the removals (failures) for each (bloom, chunk) pair.

--- a/pkg/storage/bloom/v1/fuse_test.go
+++ b/pkg/storage/bloom/v1/fuse_test.go
@@ -58,7 +58,7 @@ func TestFusedQuerier(t *testing.T) {
 	builder, err := NewBlockBuilder(
 		BlockOptions{
 			Schema: Schema{
-				version:  DefaultSchemaVersion,
+				version:  CurrentSchemaVersion,
 				encoding: chunkenc.EncSnappy,
 			},
 			SeriesPageSize: 100,
@@ -152,7 +152,7 @@ func TestFuseMultiPage(t *testing.T) {
 	builder, err := NewBlockBuilder(
 		BlockOptions{
 			Schema: Schema{
-				version:     DefaultSchemaVersion,
+				version:     CurrentSchemaVersion,
 				encoding:    chunkenc.EncSnappy,
 				nGramLength: 3, // we test trigrams
 				nGramSkip:   0,
@@ -308,7 +308,7 @@ func TestLazyBloomIter_Seek_ResetError(t *testing.T) {
 	builder, err := NewBlockBuilder(
 		BlockOptions{
 			Schema: Schema{
-				version:  DefaultSchemaVersion,
+				version:  CurrentSchemaVersion,
 				encoding: chunkenc.EncSnappy,
 			},
 			SeriesPageSize: 100,
@@ -366,7 +366,7 @@ func TestFusedQuerierSkipsEmptyBlooms(t *testing.T) {
 	builder, err := NewBlockBuilder(
 		BlockOptions{
 			Schema: Schema{
-				version:  DefaultSchemaVersion,
+				version:  CurrentSchemaVersion,
 				encoding: chunkenc.EncNone,
 			},
 			SeriesPageSize: 100,
@@ -430,7 +430,7 @@ func setupBlockForBenchmark(b *testing.B) (*BlockQuerier, [][]Request, []chan Ou
 	builder, err := NewBlockBuilder(
 		BlockOptions{
 			Schema: Schema{
-				version:  DefaultSchemaVersion,
+				version:  CurrentSchemaVersion,
 				encoding: chunkenc.EncSnappy,
 			},
 			SeriesPageSize: 256 << 10, // 256k

--- a/pkg/storage/bloom/v1/index.go
+++ b/pkg/storage/bloom/v1/index.go
@@ -292,8 +292,6 @@ type Meta struct {
 	Offsets []BloomOffset
 }
 
-// SeriesWithMeta is a series with a a variable number of bloom offsets.
-// Used in v2+ to store blooms for larger series in parts
 type SeriesWithMeta struct {
 	Series
 	Meta

--- a/pkg/storage/bloom/v1/index.go
+++ b/pkg/storage/bloom/v1/index.go
@@ -341,7 +341,7 @@ func (s *SeriesWithMeta) Decode(
 	previousOffset BloomOffset,
 ) (model.Fingerprint, BloomOffset, error) {
 	if version < V3 {
-		return 0, BloomOffset{}, errUnsupportedSchemaVersion
+		return 0, BloomOffset{}, ErrUnsupportedSchemaVersion
 	}
 
 	s.Fingerprint = previousFp + model.Fingerprint(dec.Uvarint64())

--- a/pkg/storage/bloom/v1/index_querier.go
+++ b/pkg/storage/bloom/v1/index_querier.go
@@ -10,7 +10,7 @@ import (
 )
 
 type SeriesIterator interface {
-	iter.Iterator[*SeriesWithOffset]
+	iter.Iterator[*SeriesWithMeta]
 	Reset()
 }
 
@@ -138,7 +138,7 @@ func (it *LazySeriesIter) next() bool {
 	return false
 }
 
-func (it *LazySeriesIter) At() *SeriesWithOffsets {
+func (it *LazySeriesIter) At() *SeriesWithMeta {
 	return it.curPage.At()
 }
 

--- a/pkg/storage/bloom/v1/index_test.go
+++ b/pkg/storage/bloom/v1/index_test.go
@@ -52,10 +52,7 @@ func TestSeriesEncoding_V3(t *testing.T) {
 				{Page: 1, ByteOffset: 2},
 				{Page: 2, ByteOffset: 1},
 			},
-			Fields: []Field{
-				Field("foo"),
-				Field("bar"),
-			},
+			Fields: NewSetFromLiteral[Field]("foo", "bar"),
 		},
 	}
 

--- a/pkg/storage/bloom/v1/schema.go
+++ b/pkg/storage/bloom/v1/schema.go
@@ -1,0 +1,123 @@
+package v1
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/grafana/loki/v3/pkg/chunkenc"
+	"github.com/grafana/loki/v3/pkg/util/encoding"
+	"github.com/pkg/errors"
+)
+
+type Version byte
+
+func (v Version) String() string {
+	return fmt.Sprintf("v%d", v)
+}
+
+const (
+	// Add new versions below
+	V1 Version = iota
+	// V2 supports single series blooms encoded over multiple pages
+	// to accommodate larger single series
+	V2
+	// V2 indicated schema for indexed structured metadata
+	V3
+
+	DefaultSchemaVersion = V3
+)
+
+var (
+	SupportedVersions = []Version{V3}
+
+	errInvalidSchemaVerunkion   = errors.New("invalid schema version")
+	errUnsupportedSchemaVersion = errors.New("unsupported schema version")
+)
+
+type Schema struct {
+	version                Version
+	encoding               chunkenc.Encoding
+	nGramLength, nGramSkip uint64
+}
+
+func NewSchema() Schema {
+	return Schema{
+		version:     DefaultSchemaVersion,
+		encoding:    chunkenc.EncNone,
+		nGramLength: 0,
+		nGramSkip:   0,
+	}
+}
+
+func (s Schema) String() string {
+	return fmt.Sprintf("%s,encoding=%s,ngram=%d,skip=%d", s.version, s.encoding, s.nGramLength, s.nGramSkip)
+}
+
+func (s Schema) Compatible(other Schema) bool {
+	return s == other
+}
+
+func (s Schema) NGramLen() int {
+	return int(s.nGramLength)
+}
+
+func (s Schema) NGramSkip() int {
+	return int(s.nGramSkip)
+}
+
+// byte length
+func (s Schema) Len() int {
+	// magic number + version + encoding + ngram length + ngram skip
+	return 4 + 1 + 1 + 8 + 8
+}
+
+func (s *Schema) DecompressorPool() chunkenc.ReaderPool {
+	return chunkenc.GetReaderPool(s.encoding)
+}
+
+func (s *Schema) CompressorPool() chunkenc.WriterPool {
+	return chunkenc.GetWriterPool(s.encoding)
+}
+
+func (s *Schema) Encode(enc *encoding.Encbuf) {
+	enc.Reset()
+	enc.PutBE32(magicNumber)
+	enc.PutByte(byte(s.version))
+	enc.PutByte(byte(s.encoding))
+	enc.PutBE64(s.nGramLength)
+	enc.PutBE64(s.nGramSkip)
+
+}
+
+func (s *Schema) DecodeFrom(r io.ReadSeeker) error {
+	// TODO(owen-d): improve allocations
+	schemaBytes := make([]byte, s.Len())
+	_, err := io.ReadFull(r, schemaBytes)
+	if err != nil {
+		return errors.Wrap(err, "reading schema")
+	}
+
+	dec := encoding.DecWith(schemaBytes)
+	return s.Decode(&dec)
+}
+
+func (s *Schema) Decode(dec *encoding.Decbuf) error {
+	number := dec.Be32()
+	if number != magicNumber {
+		return errors.Errorf("invalid magic number. expected %x, got  %x", magicNumber, number)
+	}
+	s.version = Version(dec.Byte())
+	if s.version != V3 {
+		return errors.Errorf("invalid version. expected %d, got %d", 3, s.version)
+	}
+
+	s.encoding = chunkenc.Encoding(dec.Byte())
+	if _, err := chunkenc.ParseEncoding(s.encoding.String()); err != nil {
+		return errors.Wrap(err, "parsing encoding")
+	}
+
+	s.nGramLength = dec.Be64()
+	s.nGramSkip = dec.Be64()
+
+	return dec.Err()
+}

--- a/pkg/storage/bloom/v1/schema.go
+++ b/pkg/storage/bloom/v1/schema.go
@@ -17,6 +17,8 @@ func (v Version) String() string {
 }
 
 const (
+	magicNumber = uint32(0xCA7CAFE5)
+
 	// Add new versions below
 	V1 Version = iota
 	// V2 supports single series blooms encoded over multiple pages
@@ -58,8 +60,8 @@ func (s Schema) Compatible(other Schema) bool {
 	return s == other
 }
 
-func (s Schema) IsCurrentSchema() bool {
-	return s.version == CurrentSchemaVersion
+func (s Schema) Version() Version {
+	return s.version
 }
 
 func (s Schema) NGramLen() int {

--- a/pkg/storage/bloom/v1/schema.go
+++ b/pkg/storage/bloom/v1/schema.go
@@ -24,7 +24,7 @@ const (
 	// V2 indicated schema for indexed structured metadata
 	V3
 
-	DefaultSchemaVersion = V3
+	CurrentSchemaVersion = V3
 )
 
 var (
@@ -42,7 +42,7 @@ type Schema struct {
 
 func NewSchema() Schema {
 	return Schema{
-		version:     DefaultSchemaVersion,
+		version:     CurrentSchemaVersion,
 		encoding:    chunkenc.EncNone,
 		nGramLength: 0,
 		nGramSkip:   0,
@@ -58,7 +58,7 @@ func (s Schema) Compatible(other Schema) bool {
 }
 
 func (s Schema) IsCurrentSchema() bool {
-	return s.version == DefaultSchemaVersion
+	return s.version == CurrentSchemaVersion
 }
 
 func (s Schema) NGramLen() int {

--- a/pkg/storage/bloom/v1/schema.go
+++ b/pkg/storage/bloom/v1/schema.go
@@ -30,8 +30,8 @@ const (
 var (
 	SupportedVersions = []Version{V3}
 
-	errInvalidSchemaVerunkion   = errors.New("invalid schema version")
-	errUnsupportedSchemaVersion = errors.New("unsupported schema version")
+	ErrInvalidSchemaVersion     = errors.New("invalid schema version")
+	ErrUnsupportedSchemaVersion = errors.New("unsupported schema version")
 )
 
 type Schema struct {
@@ -55,6 +55,10 @@ func (s Schema) String() string {
 
 func (s Schema) Compatible(other Schema) bool {
 	return s == other
+}
+
+func (s Schema) IsCurrentSchema() bool {
+	return s.version == DefaultSchemaVersion
 }
 
 func (s Schema) NGramLen() int {

--- a/pkg/storage/bloom/v1/schema.go
+++ b/pkg/storage/bloom/v1/schema.go
@@ -4,9 +4,10 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/pkg/errors"
+
 	"github.com/grafana/loki/v3/pkg/chunkenc"
 	"github.com/grafana/loki/v3/pkg/util/encoding"
-	"github.com/pkg/errors"
 )
 
 type Version byte

--- a/pkg/storage/bloom/v1/test_util.go
+++ b/pkg/storage/bloom/v1/test_util.go
@@ -28,7 +28,7 @@ func MakeBlock(t testing.TB, nth int, fromFp, throughFp model.Fingerprint, fromT
 	builder, err := NewBlockBuilder(
 		BlockOptions{
 			Schema: Schema{
-				version:     DefaultSchemaVersion,
+				version:     CurrentSchemaVersion,
 				encoding:    chunkenc.EncSnappy,
 				nGramLength: 4, // see DefaultNGramLength in bloom_tokenizer_test.go
 				nGramSkip:   0, // see DefaultNGramSkip in bloom_tokenizer_test.go

--- a/pkg/storage/bloom/v1/util.go
+++ b/pkg/storage/bloom/v1/util.go
@@ -1,7 +1,6 @@
 package v1
 
 import (
-	"fmt"
 	"hash"
 	"hash/crc32"
 	"io"
@@ -10,23 +9,8 @@ import (
 	"github.com/grafana/loki/v3/pkg/util/mempool"
 )
 
-type Version byte
-
-func (v Version) String() string {
-	return fmt.Sprintf("v%d", v)
-}
-
 const (
 	magicNumber = uint32(0xCA7CAFE5)
-	// Add new versions below
-	V1 Version = iota
-	// V2 supports single series blooms encoded over multiple pages
-	// to accommodate larger single series
-	V2
-)
-
-const (
-	DefaultSchemaVersion = V2
 )
 
 var (

--- a/pkg/storage/bloom/v1/util.go
+++ b/pkg/storage/bloom/v1/util.go
@@ -9,10 +9,6 @@ import (
 	"github.com/grafana/loki/v3/pkg/util/mempool"
 )
 
-const (
-	magicNumber = uint32(0xCA7CAFE5)
-)
-
 var (
 	castagnoliTable = crc32.MakeTable(crc32.Castagnoli)
 

--- a/pkg/storage/bloom/v1/util.go
+++ b/pkg/storage/bloom/v1/util.go
@@ -67,3 +67,45 @@ func PointerSlice[T any](xs []T) []*T {
 	}
 	return out
 }
+
+type Set[V comparable] struct {
+	internal map[V]struct{}
+}
+
+func NewSet[V comparable](size int) Set[V] {
+	return Set[V]{make(map[V]struct{}, size)}
+}
+
+func NewSetFromLiteral[V comparable](v ...V) Set[V] {
+	set := NewSet[V](len(v))
+	for _, elem := range v {
+		set.Add(elem)
+	}
+	return set
+}
+
+func (s Set[V]) Add(v V) bool {
+	_, ok := s.internal[v]
+	if !ok {
+		s.internal[v] = struct{}{}
+	}
+	return !ok
+}
+
+func (s Set[V]) Len() int {
+	return len(s.internal)
+}
+
+func (s Set[V]) Items() []V {
+	set := make([]V, 0, s.Len())
+	for k := range s.internal {
+		set = append(set, k)
+	}
+	return set
+}
+
+func (s Set[V]) Union(other Set[V]) {
+	for _, v := range other.Items() {
+		s.Add(v)
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

A new schema version V3 for bloom blocks that is incompatible with old schemas.
It simplifies some parts of the code and makes the schema more extensible, laying the groundwork for indexing structured metadata fields into bloom filters.

:warning: **This PR breaks the bloom filter functionality!** Until the read path is implemented, bloom blocks created with the new schema cannot be queries in the bloom gateways.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
