### PR TITLE
chore: Remove call to deprecated rand.Seed()

### DIFF
--- a/pkg/logql/sketch/topk_slow_test.go
+++ b/pkg/logql/sketch/topk_slow_test.go
@@ -171,7 +171,6 @@ func TestCMSTopk(t *testing.T) {
 					oTotal += int(n)
 				}
 
-				rand.Seed(time.Now().UnixNano())
 				rand.Shuffle(len(events), func(i, j int) { events[i], events[j] = events[j], events[i] })
 
 				for _, e := range events {
@@ -254,7 +253,6 @@ func BenchmarkCMSTopk(b *testing.B) {
 			oTotal += int(n)
 		}
 
-		rand.Seed(time.Now().UnixNano())
 		rand.Shuffle(len(events), func(i, j int) { events[i], events[j] = events[j], events[i] })
 		b.StartTimer()
 
@@ -304,7 +302,6 @@ func TestBFTopK(t *testing.T) {
 		}
 	}
 
-	rand.Seed(time.Now().UnixNano())
 	rand.Shuffle(len(events), func(i, j int) { events[i], events[j] = events[j], events[i] })
 
 	topk, _ := NewSketchBF(100, 27189, 7)

--- a/pkg/logql/sketch/topk_test.go
+++ b/pkg/logql/sketch/topk_test.go
@@ -9,7 +9,6 @@ import (
 	"sort"
 	"strconv"
 	"testing"
-	"time"
 
 	"github.com/alicebob/miniredis/v2/hyperloglog"
 	"github.com/stretchr/testify/assert"
@@ -69,7 +68,6 @@ func TestTopK_Merge(t *testing.T) {
 		}
 	}
 
-	rand.Seed(time.Now().UnixNano()) //nolint:all
 	rand.Shuffle(len(events), func(i, j int) { events[i], events[j] = events[j], events[i] })
 
 	topk1, err := NewCMSTopkForCardinality(nil, k, nStreams)


### PR DESCRIPTION
**What this PR does / why we need it**:
Go 1.24 will be making the call to `rand.Seed()` a no-op.  As of Go 1.20, this call is no longer necessary, as per the [documentation](https://pkg.go.dev/math/rand#Seed).  Specifically, this text:
```
Deprecated: As of Go 1.20 there is no reason to call Seed with a random value. Programs that call Seed with a known value to get a specific sequence of results should use New(NewSource(seed)) to obtain a local random generator.
```
 
**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
