### PR TITLE
fix: Memcached persistence

### DIFF
--- a/docs/sources/setup/install/helm/reference.md
+++ b/docs/sources/setup/install/helm/reference.md
@@ -2039,7 +2039,7 @@ null
 		<tr>
 			<td>chunksCache.persistence.storageSize</td>
 			<td>string</td>
-			<td>Size of persistent disk</td>
+			<td>Size of persistent disk, must be in G or Gi</td>
 			<td><pre lang="json">
 "10G"
 </pre>
@@ -6545,7 +6545,12 @@ false
 			<td>object</td>
 			<td>The SecurityContext override for memcached pods</td>
 			<td><pre lang="json">
-{}
+{
+  "fsGroup": 11211,
+  "runAsGroup": 11211,
+  "runAsNonRoot": true,
+  "runAsUser": 11211
+}
 </pre>
 </td>
 		</tr>
@@ -9584,7 +9589,7 @@ null
 		<tr>
 			<td>resultsCache.persistence.storageSize</td>
 			<td>string</td>
-			<td>Size of persistent disk</td>
+			<td>Size of persistent disk, must be in G or Gi</td>
 			<td><pre lang="json">
 "10G"
 </pre>

--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -13,6 +13,10 @@ Entries should include a reference to the pull request that introduced the chang
 
 [//]: # (<AUTOMATED_UPDATES_LOCATOR> : do not remove this line. This locator is used by the CI pipeline to automatically create a changelog entry for each new Loki release. Add other chart versions and respective changelog entries bellow this line.)
 
+## 6.14.1
+
+- [BUGFIX] Fixed Memcached persistence options.
+
 ## 6.14.0
 
 - [FEATURE] Add additional service annotations for components in distributed mode

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -3,7 +3,7 @@ name: loki
 description: Helm chart for Grafana Loki and Grafana Enterprise Logs supporting both simple, scalable and distributed modes.
 type: application
 appVersion: 3.1.1
-version: 6.14.0
+version: 6.14.1
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -1,6 +1,6 @@
 # loki
 
-![Version: 6.14.0](https://img.shields.io/badge/Version-6.14.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.1.1](https://img.shields.io/badge/AppVersion-3.1.1-informational?style=flat-square)
+![Version: 6.14.1](https://img.shields.io/badge/Version-6.14.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.1.1](https://img.shields.io/badge/AppVersion-3.1.1-informational?style=flat-square)
 
 Helm chart for Grafana Loki and Grafana Enterprise Logs supporting both simple, scalable and distributed modes.
 

--- a/production/helm/loki/templates/memcached/_memcached-statefulset.tpl
+++ b/production/helm/loki/templates/memcached/_memcached-statefulset.tpl
@@ -102,9 +102,11 @@ spec:
           ports:
             - containerPort: {{ .port }}
               name: client
+          {{- /* Calculate storage size as round(.persistence.storageSize * 0.9). But with integer built-in operators. */}}
+          {{- $persistenceSize := (div (mul (trimSuffix "Gi" .persistence.storageSize | trimSuffix "G") 9) 10 ) }}
           args:
             - -m {{ .allocatedMemory }}
-            - --extended=modern,track_sizes{{ if .persistence.enabled }},ext_path={{ .persistence.mountPath }}/file:{{ .persistence.storageSize }}{{ end }}{{ with .extraExtendedOptions }},{{ . }}{{ end }}
+            - --extended=modern,track_sizes{{ if .persistence.enabled }},ext_path={{ .persistence.mountPath }}/file:{{ $persistenceSize }}G,ext_wbuf_size=16{{ end }}{{ with .extraExtendedOptions }},{{ . }}{{ end }}
             - -I {{ .maxItemMemory }}m
             - -c {{ .connectionLimit }}
             - -v

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -2962,7 +2962,11 @@ memcached:
     # -- Memcached Docker image pull policy
     pullPolicy: IfNotPresent
   # -- The SecurityContext override for memcached pods
-  podSecurityContext: {}
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 11211
+    runAsGroup: 11211
+    fsGroup: 11211
   # -- The name of the PriorityClass for memcached pods
   priorityClassName: null
   # -- The SecurityContext for memcached containers
@@ -3085,7 +3089,7 @@ resultsCache:
   persistence:
     # -- Enable creating PVCs for the results-cache
     enabled: false
-    # -- Size of persistent disk
+    # -- Size of persistent disk, must be in G or Gi
     storageSize: 10G
     # -- Storage class to be used.
     # If defined, storageClassName: <storageClass>.
@@ -3187,7 +3191,7 @@ chunksCache:
   persistence:
     # -- Enable creating PVCs for the chunks-cache
     enabled: false
-    # -- Size of persistent disk
+    # -- Size of persistent disk, must be in G or Gi
     storageSize: 10G
     # -- Storage class to be used.
     # If defined, storageClassName: <storageClass>.


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes the usage of persistence on Memcached:
 - Memcached must create a file smaller than disk size
 - `ext_wbuf_size` must be bigger than max item size and be divisible by `wbuf_size` which is 64 by default
 - Add pod permissions to access local volume

**Which issue(s) this PR fixes**:
Fixes #14028
Related #13619 

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
