### PR TITLE
feat(blooms)!: Index structured metadata into blooms

### DIFF
--- a/pkg/storage/bloom/v1/bloom_tokenizer.go
+++ b/pkg/storage/bloom/v1/bloom_tokenizer.go
@@ -173,7 +173,7 @@ func (bt *BloomTokenizer) sendBloom(ch chan<- *BloomCreation, bloom *Bloom, stat
 }
 
 func prefixForChunkRef(chk ChunkRef) []byte {
-	enc := encoding.EncWith(make([]byte, 20))
+	enc := encoding.EncWith(make([]byte, 0, 20))
 	enc.PutBE64(uint64(chk.From))    // 8 bytes
 	enc.PutBE64(uint64(chk.Through)) // 8 bytes
 	enc.PutBE32(chk.Checksum)        // 4 bytes

--- a/pkg/storage/bloom/v1/bloom_tokenizer_test.go
+++ b/pkg/storage/bloom/v1/bloom_tokenizer_test.go
@@ -100,12 +100,15 @@ func TestTokenizerPopulate(t *testing.T) {
 	var testLine = "this is a log line"
 	bt := NewBloomTokenizer(DefaultNGramLength, DefaultNGramSkip, 0, metrics, logger.NewNopLogger())
 
-	sbf := filter.NewScalableBloomFilter(1024, 0.01, 0.8)
-
+	metadata := push.LabelsAdapter{
+		{Name: "pod", Value: "loki-1"},
+		{Name: "trace_id", Value: "3bef3c91643bde73"},
+	}
 	memChunk := chunkenc.NewMemChunk(chunkenc.ChunkFormatV4, chunkenc.EncSnappy, chunkenc.ChunkHeadFormatFor(chunkenc.ChunkFormatV4), 256000, 1500000)
 	_, _ = memChunk.Append(&push.Entry{
-		Timestamp: time.Unix(0, 1),
-		Line:      testLine,
+		Timestamp:          time.Unix(0, 1),
+		Line:               testLine,
+		StructuredMetadata: metadata,
 	})
 	itr, err := memChunk.Iterator(
 		context.Background(),
@@ -116,24 +119,25 @@ func TestTokenizerPopulate(t *testing.T) {
 	)
 	require.Nil(t, err)
 
-	bloom := Bloom{
-		ScalableBloomFilter: *sbf,
-	}
+	ref := ChunkRef{}
 
+	bloom := NewBloom()
 	blooms, err := populateAndConsumeBloom(
 		bt,
-		v2.NewSliceIter([]*Bloom{&bloom}),
-		v2.NewSliceIter([]ChunkRefWithIter{{Ref: ChunkRef{},
-			Itr: itr}}),
+		v2.NewSliceIter([]*Bloom{bloom}),
+		v2.NewSliceIter([]ChunkRefWithIter{{Ref: ref, Itr: itr}}),
 	)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(blooms))
 
-	tokenizer := NewNGramTokenizer(DefaultNGramLength, DefaultNGramSkip)
-	toks := tokenizer.Tokens(testLine)
-	for toks.Next() {
-		token := toks.At()
-		require.True(t, blooms[0].Test(token))
+	tokenizer := NewStructuredMetadataTokenizer(string(prefixForChunkRef(ref)))
+
+	for _, kv := range metadata {
+		tokens := tokenizer.Tokens(kv)
+		for tokens.Next() {
+			token := tokens.At()
+			require.True(t, blooms[0].Test([]byte(token)))
+		}
 	}
 }
 
@@ -141,10 +145,15 @@ func TestBloomTokenizerPopulateWithoutPreexistingBloom(t *testing.T) {
 	var testLine = "this is a log line"
 	bt := NewBloomTokenizer(DefaultNGramLength, DefaultNGramSkip, 0, metrics, logger.NewNopLogger())
 
+	metadata := push.LabelsAdapter{
+		{Name: "pod", Value: "loki-1"},
+		{Name: "trace_id", Value: "3bef3c91643bde73"},
+	}
 	memChunk := chunkenc.NewMemChunk(chunkenc.ChunkFormatV4, chunkenc.EncSnappy, chunkenc.ChunkHeadFormatFor(chunkenc.ChunkFormatV4), 256000, 1500000)
 	_, _ = memChunk.Append(&push.Entry{
-		Timestamp: time.Unix(0, 1),
-		Line:      testLine,
+		Timestamp:          time.Unix(0, 1),
+		Line:               testLine,
+		StructuredMetadata: metadata,
 	})
 	itr, err := memChunk.Iterator(
 		context.Background(),
@@ -155,30 +164,34 @@ func TestBloomTokenizerPopulateWithoutPreexistingBloom(t *testing.T) {
 	)
 	require.Nil(t, err)
 
+	ref := ChunkRef{}
+
 	blooms, err := populateAndConsumeBloom(
 		bt,
 		v2.NewEmptyIter[*Bloom](),
-		v2.NewSliceIter([]ChunkRefWithIter{{Ref: ChunkRef{},
-			Itr: itr}}),
+		v2.NewSliceIter([]ChunkRefWithIter{{Ref: ref, Itr: itr}}),
 	)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(blooms))
 
-	tokenizer := NewNGramTokenizer(DefaultNGramLength, DefaultNGramSkip)
-	toks := tokenizer.Tokens(testLine)
-	for toks.Next() {
-		token := toks.At()
-		require.True(t, blooms[0].Test(token))
-	}
+	tokenizer := NewStructuredMetadataTokenizer(string(prefixForChunkRef(ref)))
 
+	for _, kv := range metadata {
+		tokens := tokenizer.Tokens(kv)
+		for tokens.Next() {
+			token := tokens.At()
+			require.True(t, blooms[0].Test([]byte(token)))
+		}
+	}
 }
 
-func chunkRefItrFromLines(lines ...string) (iter.EntryIterator, error) {
+func chunkRefItrFromMetadata(metadata ...push.LabelsAdapter) (iter.EntryIterator, error) {
 	memChunk := chunkenc.NewMemChunk(chunkenc.ChunkFormatV4, chunkenc.EncSnappy, chunkenc.ChunkHeadFormatFor(chunkenc.ChunkFormatV4), 256000, 1500000)
-	for i, line := range lines {
+	for i, md := range metadata {
 		if _, err := memChunk.Append(&push.Entry{
-			Timestamp: time.Unix(0, int64(i)),
-			Line:      line,
+			Timestamp:          time.Unix(0, int64(i)),
+			Line:               "line content",
+			StructuredMetadata: md,
 		}); err != nil {
 			return nil, err
 		}
@@ -195,7 +208,7 @@ func chunkRefItrFromLines(lines ...string) (iter.EntryIterator, error) {
 }
 
 func randomStr(ln int) string {
-	rng := rand.New(rand.NewSource(0))
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
 	charset := []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_!@#$%^&*() ")
 
 	res := make([]rune, ln)
@@ -206,24 +219,20 @@ func randomStr(ln int) string {
 }
 
 func TestTokenizerPopulateWontExceedMaxSize(t *testing.T) {
-	maxSize := 2048
+	maxSize := 4 << 10
 	bt := NewBloomTokenizer(DefaultNGramLength, DefaultNGramSkip, maxSize, NewMetrics(nil), logger.NewNopLogger())
 	ch := make(chan *BloomCreation)
-	line := randomStr(10e3)
-	itr, err := chunkRefItrFromLines(line)
+
+	metadata := make([]push.LabelsAdapter, 0, 4<<10)
+	for i := 0; i < cap(metadata); i++ {
+		metadata = append(metadata, push.LabelsAdapter{{Name: "trace_id", Value: randomStr(12)}})
+	}
+
+	itr, err := chunkRefItrFromMetadata(metadata...)
 	require.NoError(t, err)
 	go bt.Populate(
-		v2.NewSliceIter([]*Bloom{
-			{
-				*filter.NewScalableBloomFilter(1024, 0.01, 0.8),
-			},
-		}),
-		v2.NewSliceIter([]ChunkRefWithIter{
-			{
-				Ref: ChunkRef{},
-				Itr: itr,
-			},
-		}),
+		v2.NewEmptyIter[*Bloom](),
+		v2.NewSliceIter([]ChunkRefWithIter{{Ref: ChunkRef{}, Itr: itr}}),
 		ch,
 	)
 
@@ -231,10 +240,11 @@ func TestTokenizerPopulateWontExceedMaxSize(t *testing.T) {
 	for created := range ch {
 		ct++
 		capacity := created.Bloom.ScalableBloomFilter.Capacity() / 8
+		t.Log(ct, int(capacity), maxSize)
 		require.Less(t, int(capacity), maxSize)
 	}
 	// ensure we created two bloom filters from this dataset
-	require.Equal(t, 2, ct)
+	require.Greater(t, ct, 2)
 }
 
 func populateAndConsumeBloom(
@@ -292,21 +302,19 @@ func BenchmarkPopulateSeriesWithBloom(b *testing.B) {
 
 func TestTokenizerClearsCacheBetweenPopulateCalls(t *testing.T) {
 	bt := NewBloomTokenizer(DefaultNGramLength, DefaultNGramSkip, 0, NewMetrics(nil), logger.NewNopLogger())
-	line := "foobarbazz"
+	md := push.LabelsAdapter{
+		{Name: "trace_id", Value: "3bef3c91643bde73"},
+	}
 	var blooms []*Bloom
+	ref := ChunkRef{}
 
 	for i := 0; i < 2; i++ {
 		ch := make(chan *BloomCreation)
-		itr, err := chunkRefItrFromLines(line)
+		itr, err := chunkRefItrFromMetadata(md)
 		require.NoError(t, err)
 		go bt.Populate(
 			v2.NewEmptyIter[*Bloom](),
-			v2.NewSliceIter([]ChunkRefWithIter{
-				{
-					Ref: ChunkRef{},
-					Itr: itr,
-				},
-			}),
+			v2.NewSliceIter([]ChunkRefWithIter{{Ref: ref, Itr: itr}}),
 			ch,
 		)
 		var ct int
@@ -319,11 +327,12 @@ func TestTokenizerClearsCacheBetweenPopulateCalls(t *testing.T) {
 
 	}
 
+	tokenizer := NewStructuredMetadataTokenizer(string(prefixForChunkRef(ref)))
 	for _, bloom := range blooms {
-		toks := bt.lineTokenizer.Tokens(line)
+		toks := tokenizer.Tokens(md[0])
 		for toks.Next() {
 			token := toks.At()
-			require.True(t, bloom.Test(token))
+			require.True(t, bloom.Test([]byte(token)))
 		}
 		require.NoError(t, toks.Err())
 	}

--- a/pkg/storage/bloom/v1/builder_test.go
+++ b/pkg/storage/bloom/v1/builder_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/grafana/loki/v3/pkg/chunkenc"
 	iter "github.com/grafana/loki/v3/pkg/iter/v2"
-	"github.com/grafana/loki/v3/pkg/storage/bloom/v1/filter"
 	"github.com/grafana/loki/v3/pkg/util/encoding"
 	"github.com/grafana/loki/v3/pkg/util/mempool"
 )
@@ -248,9 +247,13 @@ func TestMergeBuilder(t *testing.T) {
 	pop := func(_ *Series, srcBlooms iter.SizedIterator[*Bloom], _ ChunkRefs, ch chan *BloomCreation) {
 		for srcBlooms.Next() {
 			bloom := srcBlooms.At()
+			stats := IndexingStats{
+				SourceBytes: int(bloom.Capacity()) / 8,
+				Fields:      NewSetFromLiteral[Field]("__all__"),
+			}
 			ch <- &BloomCreation{
-				Bloom:            bloom,
-				SourceBytesAdded: int(bloom.Capacity()) / 8,
+				Bloom: bloom,
+				Stats: stats,
 			}
 		}
 		close(ch)
@@ -353,11 +356,15 @@ func TestMergeBuilderFingerprintCollision(t *testing.T) {
 	}
 
 	// We're not testing the ability to extend a bloom in this test
-	pop := func(_ *Series, _ iter.SizedIterator[*Bloom], _ ChunkRefs, ch chan *BloomCreation) {
+	pop := func(s *Series, _ iter.SizedIterator[*Bloom], _ ChunkRefs, ch chan *BloomCreation) {
+		bloom := NewBloom()
+		stats := IndexingStats{
+			SourceBytes: int(bloom.Capacity()) / 8,
+			Fields:      NewSetFromLiteral[Field]("__all__"),
+		}
 		ch <- &BloomCreation{
-			Bloom: &Bloom{
-				ScalableBloomFilter: *filter.NewScalableBloomFilter(1024, 0.01, 0.8),
-			},
+			Bloom: bloom,
+			Stats: stats,
 		}
 		close(ch)
 	}
@@ -527,9 +534,13 @@ func TestMergeBuilder_Roundtrip(t *testing.T) {
 	pop := func(_ *Series, srcBlooms iter.SizedIterator[*Bloom], _ ChunkRefs, ch chan *BloomCreation) {
 		for srcBlooms.Next() {
 			bloom := srcBlooms.At()
+			stats := IndexingStats{
+				SourceBytes: int(bloom.Capacity()) / 8,
+				Fields:      NewSetFromLiteral[Field]("__all__"),
+			}
 			ch <- &BloomCreation{
-				Bloom:            bloom,
-				SourceBytesAdded: int(bloom.Capacity()) / 8,
+				Bloom: bloom,
+				Stats: stats,
 			}
 		}
 		close(ch)

--- a/pkg/storage/bloom/v1/builder_test.go
+++ b/pkg/storage/bloom/v1/builder_test.go
@@ -247,13 +247,13 @@ func TestMergeBuilder(t *testing.T) {
 	pop := func(_ *Series, srcBlooms iter.SizedIterator[*Bloom], _ ChunkRefs, ch chan *BloomCreation) {
 		for srcBlooms.Next() {
 			bloom := srcBlooms.At()
-			stats := IndexingStats{
-				SourceBytes: int(bloom.Capacity()) / 8,
-				Fields:      NewSetFromLiteral[Field]("__all__"),
+			stats := indexingInfo{
+				sourceBytes:   int(bloom.Capacity()) / 8,
+				indexedFields: NewSetFromLiteral[Field]("__all__"),
 			}
 			ch <- &BloomCreation{
 				Bloom: bloom,
-				Stats: stats,
+				Info:  stats,
 			}
 		}
 		close(ch)
@@ -358,13 +358,13 @@ func TestMergeBuilderFingerprintCollision(t *testing.T) {
 	// We're not testing the ability to extend a bloom in this test
 	pop := func(s *Series, _ iter.SizedIterator[*Bloom], _ ChunkRefs, ch chan *BloomCreation) {
 		bloom := NewBloom()
-		stats := IndexingStats{
-			SourceBytes: int(bloom.Capacity()) / 8,
-			Fields:      NewSetFromLiteral[Field]("__all__"),
+		stats := indexingInfo{
+			sourceBytes:   int(bloom.Capacity()) / 8,
+			indexedFields: NewSetFromLiteral[Field]("__all__"),
 		}
 		ch <- &BloomCreation{
 			Bloom: bloom,
-			Stats: stats,
+			Info:  stats,
 		}
 		close(ch)
 	}
@@ -534,13 +534,13 @@ func TestMergeBuilder_Roundtrip(t *testing.T) {
 	pop := func(_ *Series, srcBlooms iter.SizedIterator[*Bloom], _ ChunkRefs, ch chan *BloomCreation) {
 		for srcBlooms.Next() {
 			bloom := srcBlooms.At()
-			stats := IndexingStats{
-				SourceBytes: int(bloom.Capacity()) / 8,
-				Fields:      NewSetFromLiteral[Field]("__all__"),
+			stats := indexingInfo{
+				sourceBytes:   int(bloom.Capacity()) / 8,
+				indexedFields: NewSetFromLiteral[Field]("__all__"),
 			}
 			ch <- &BloomCreation{
 				Bloom: bloom,
-				Stats: stats,
+				Info:  stats,
 			}
 		}
 		close(ch)

--- a/pkg/storage/bloom/v1/filter/scalable.go
+++ b/pkg/storage/bloom/v1/filter/scalable.go
@@ -88,10 +88,9 @@ func NewScalableBloomFilter(hint uint, fpRate, r float64) *ScalableBloomFilter {
 	return s
 }
 
-// NewDefaultScalableBloomFilter creates a new Scalable Bloom Filter with the
-// specified target false-positive rate and an optimal tightening ratio.
-func NewDefaultScalableBloomFilter(fpRate float64) *ScalableBloomFilter {
-	return NewScalableBloomFilter(10000, fpRate, 0.8)
+// NewDefaultScalableBloomFilter creates a new Scalable Bloom Filter.
+func NewDefaultScalableBloomFilter() *ScalableBloomFilter {
+	return NewScalableBloomFilter(10e3, 0.1, 0.8)
 }
 
 // Capacity returns the current Scalable Bloom Filter capacity, which is the

--- a/pkg/storage/bloom/v1/filter/scalable_test.go
+++ b/pkg/storage/bloom/v1/filter/scalable_test.go
@@ -20,7 +20,7 @@ import (
 // Ensures that NewDefaultScalableBloomFilter creates a Scalable Bloom Filter
 // with hint = 10000 and r = 0.8.
 func TestNewDefaultScalableBloomFilter(t *testing.T) {
-	f := NewDefaultScalableBloomFilter(0.1)
+	f := NewDefaultScalableBloomFilter()
 
 	if f.fp != 0.1 {
 		t.Errorf("Expected 0.1, got %f", f.fp)

--- a/pkg/storage/bloom/v1/tokenizer.go
+++ b/pkg/storage/bloom/v1/tokenizer.go
@@ -13,29 +13,27 @@ const (
 )
 
 type StructuredMetadataTokenizer struct {
+	// prefix to add to tokens, typically the encoded chunkref
 	prefix string
-	buf    []string
+	tokens []string
 }
 
 func NewStructuredMetadataTokenizer(prefix string) *StructuredMetadataTokenizer {
 	return &StructuredMetadataTokenizer{
 		prefix: prefix,
-		buf:    make([]string, 6),
+		tokens: make([]string, 6),
 	}
 }
 
 // Tokens implements the NGramBuilder interface
 func (t *StructuredMetadataTokenizer) Tokens(kv push.LabelAdapter) iter.Iterator[string] {
 	combined := fmt.Sprintf("%s=%s", kv.Name, kv.Value)
-	t.buf = append(t.buf[:0],
-		kv.Name,
-		t.prefix+kv.Name,
-		kv.Value,
-		t.prefix+kv.Value,
-		combined,
-		t.prefix+combined,
+	t.tokens = append(t.tokens[:0],
+		kv.Name, t.prefix+kv.Name,
+		kv.Value, t.prefix+kv.Value,
+		combined, t.prefix+combined,
 	)
-	return iter.NewSliceIter(t.buf)
+	return iter.NewSliceIter(t.tokens)
 }
 
 func reassemble(buf []rune, ln, pos int, result []byte) []byte {

--- a/pkg/storage/bloom/v1/tokenizer_test.go
+++ b/pkg/storage/bloom/v1/tokenizer_test.go
@@ -4,9 +4,10 @@ import (
 	"testing"
 	"unicode/utf8"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/grafana/loki/pkg/push"
 	v2 "github.com/grafana/loki/v3/pkg/iter/v2"
-	"github.com/stretchr/testify/require"
 )
 
 const BigFile = "../../../logql/sketch/testdata/war_peace.txt"

--- a/pkg/storage/bloom/v1/tokenizer_test.go
+++ b/pkg/storage/bloom/v1/tokenizer_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 	"unicode/utf8"
 
+	"github.com/grafana/loki/pkg/push"
+	v2 "github.com/grafana/loki/v3/pkg/iter/v2"
 	"github.com/stretchr/testify/require"
 )
 
@@ -229,4 +231,16 @@ func BenchmarkTokens(b *testing.B) {
 			}
 		})
 	}
+}
+
+func TestStructuredMetadataTokenizer(t *testing.T) {
+	tokenizer := NewStructuredMetadataTokenizer("chunk")
+
+	metadata := push.LabelAdapter{Name: "pod", Value: "loki-1"}
+	expected := []string{"pod", "chunkpod", "loki-1", "chunkloki-1", "pod=loki-1", "chunkpod=loki-1"}
+
+	tokenIter := tokenizer.Tokens(metadata)
+	got, err := v2.Collect(tokenIter)
+	require.NoError(t, err)
+	require.Equal(t, expected, got)
 }

--- a/pkg/storage/bloom/v1/versioned_builder.go
+++ b/pkg/storage/bloom/v1/versioned_builder.go
@@ -63,6 +63,8 @@ func NewBlockBuilderV3(opts BlockOptions, writer BlockWriter) (*V3Builder, error
 	}, nil
 }
 
+// BuildFrom is only used in tests as helper function to create blocks
+// It does not take indexed fields into account.
 func (b *V3Builder) BuildFrom(itr iter.Iterator[SeriesWithBlooms]) (uint32, error) {
 	for itr.Next() {
 		at := itr.At()
@@ -79,8 +81,7 @@ func (b *V3Builder) BuildFrom(itr iter.Iterator[SeriesWithBlooms]) (uint32, erro
 			return 0, errors.Wrap(err, "iterating blooms")
 		}
 
-		// TODO(chaudum): Use the indexed fields from bloom creation, however,
-		// currently we still build blooms from log lines.
+		// TODO(chaudum): Use the indexed fields from bloom creation.
 		fields := NewSet[Field](1)
 		fields.Add("__line__")
 

--- a/tools/bloom/inspector/main.go
+++ b/tools/bloom/inspector/main.go
@@ -9,29 +9,65 @@ import (
 )
 
 func main() {
-	if len(os.Args) < 2 {
+	if len(os.Args) < 2 || os.Args[1] == "-h" {
 		fmt.Println("Usage: go run main.go BLOCK_DIRECTORY")
 		os.Exit(2)
 	}
 
 	path := os.Args[1]
-	fmt.Printf("Block directory: %s\n", path)
+	fmt.Printf("Block:    %s\n", path)
 
 	r := v1.NewDirectoryBlockReader(path)
 	b := v1.NewBlock(r, v1.NewMetrics(nil))
-	q := v1.NewBlockQuerier(b, &mempool.SimpleHeapAllocator{}, v1.DefaultMaxPageSize)
+	q := v1.NewBlockQuerier(b, &mempool.SimpleHeapAllocator{}, 256<<20)
+	qIter := q.Iter()
 
 	md, err := q.Metadata()
 	if err != nil {
 		panic(err)
 	}
 
-	fmt.Printf("Metadata: %+v\n", md)
+	fmt.Printf("Checksum: 0x%x\n", md.Checksum)
+	fmt.Printf("Series:   %+v\n", md.Series)
+	fmt.Printf("Options:  %+v\n", md.Options)
 
-	for q.Next() {
-		swb := q.At()
-		fmt.Printf("%s (%d)\n", swb.Series.Fingerprint, swb.Series.Chunks.Len())
+	fmt.Println("-----------------------------")
+
+	count := 0
+	for qIter.Next() {
+		swb := qIter.At()
+		series := swb.Series
+		p := 0
+		for swb.Blooms.Next() {
+			bloom := swb.Blooms.At()
+			fmt.Printf(
+				"fp=%s page=%d chunks=%d size=%vB fill=%v count=%v\n",
+				series.Fingerprint,
+				p,
+				series.Chunks.Len(),
+				bloom.Capacity()/8,
+				bloom.FillRatio(),
+				bloom.Count(),
+			)
+			p++
+		}
+		count++
 	}
+	fmt.Printf("Stream count: %4d\n", count)
+
+	// q.Reset()
+
+	// fmt.Println("-----------------------------")
+
+	// count = 0
+	// for q.Next() {
+	// 	swb := q.At()
+	// 	series := swb.Series
+	// 	fmt.Printf("%s (%3d) %v\n", series.Fingerprint, series.Chunks.Len(), swb.Meta.Fields.Items())
+	// 	count++
+	// }
+	// fmt.Printf("Stream count: %4d\n", count)
+
 	if q.Err() != nil {
 		fmt.Printf("error: %s\n", q.Err())
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Instead of indexing ngrams of the log line content, we index the plain values of the structured metadata keys and values.

Resulting tokens are:
* `name`
* `chunkPrefix + name`
* `value`
* `chunkPrefix + value`
* `name + '=' value`
* `chunkPrefix + name + '=' + value`

Indexed fields (metadata name) are also extracted into the series metadata.

⚠️ Indexed metadata values cannot be queried with the bloom gateways yet.

**Special notes for your reviewer**:

This PR does not cleanup unused code used for ngram-tokenization. This is scope for a follow up.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
