### PR TITLE
fix: correct _extracted logic in detected fields

### DIFF
--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -1318,13 +1318,12 @@ func getStructuredMetadata(entry push.Entry) map[string][]string {
 }
 
 func parseEntry(entry push.Entry, lbls *logql_log.LabelsBuilder) (map[string][]string, []string) {
-	logFmtParser := logql_log.NewLogfmtParser(false, false)
-
 	origParsed := getParsedLabels(entry)
 	parsed := make(map[string][]string, len(origParsed))
 
 	for lbl, values := range origParsed {
-		if lbl == logqlmodel.ErrorLabel || lbl == logqlmodel.ErrorDetailsLabel || lbl == logqlmodel.PreserveErrorLabel {
+		if lbl == logqlmodel.ErrorLabel || lbl == logqlmodel.ErrorDetailsLabel ||
+			lbl == logqlmodel.PreserveErrorLabel {
 			continue
 		}
 
@@ -1336,8 +1335,10 @@ func parseEntry(entry push.Entry, lbls *logql_log.LabelsBuilder) (map[string][]s
 	jsonParser := logql_log.NewJSONParser()
 	_, jsonSuccess := jsonParser.Process(0, []byte(line), lbls)
 	if !jsonSuccess || lbls.HasErr() {
-		parser = "logfmt"
 		lbls.Reset()
+
+		logFmtParser := logql_log.NewLogfmtParser(false, false)
+		parser = "logfmt"
 		_, logfmtSuccess := logFmtParser.Process(0, []byte(line), lbls)
 		if !logfmtSuccess || lbls.HasErr() {
 			return parsed, nil
@@ -1369,7 +1370,8 @@ func parseEntry(entry push.Entry, lbls *logql_log.LabelsBuilder) (map[string][]s
 
 	result := make(map[string][]string, len(parsedLabels))
 	for lbl, values := range parsedLabels {
-		if lbl == logqlmodel.ErrorLabel || lbl == logqlmodel.ErrorDetailsLabel || lbl == logqlmodel.PreserveErrorLabel {
+		if lbl == logqlmodel.ErrorLabel || lbl == logqlmodel.ErrorDetailsLabel ||
+			lbl == logqlmodel.PreserveErrorLabel {
 			continue
 		}
 		vals := make([]string, 0, len(values))

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -1332,14 +1332,14 @@ func parseEntry(entry push.Entry, lbls *logql_log.LabelsBuilder) (map[string][]s
 	}
 
 	line := entry.Line
-	parser := "logfmt"
-	_, logfmtSuccess := logFmtParser.Process(0, []byte(line), lbls)
-	if !logfmtSuccess || lbls.HasErr() {
-		parser = "json"
-		jsonParser := logql_log.NewJSONParser()
+	parser := "json"
+	jsonParser := logql_log.NewJSONParser()
+	_, jsonSuccess := jsonParser.Process(0, []byte(line), lbls)
+	if !jsonSuccess || lbls.HasErr() {
+		parser = "logfmt"
 		lbls.Reset()
-		_, jsonSuccess := jsonParser.Process(0, []byte(line), lbls)
-		if !jsonSuccess || lbls.HasErr() {
+		_, logfmtSuccess := logFmtParser.Process(0, []byte(line), lbls)
+		if !logfmtSuccess || lbls.HasErr() {
 			return parsed, nil
 		}
 	}

--- a/pkg/querier/querier_mock_test.go
+++ b/pkg/querier/querier_mock_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/grafana/loki/v3/pkg/logql/log"
+	"github.com/grafana/loki/v3/pkg/logql/syntax"
 
 	"github.com/grafana/loki/pkg/push"
 
@@ -16,6 +17,7 @@ import (
 	"github.com/grafana/dskit/grpcclient"
 	"github.com/grafana/dskit/ring"
 	ring_client "github.com/grafana/dskit/ring/client"
+	logql_log "github.com/grafana/loki/v3/pkg/logql/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
@@ -578,27 +580,41 @@ func mockLogfmtStream(from int, quantity int) logproto.Stream {
 	return mockLogfmtStreamWithLabels(from, quantity, `{type="test", name="foo"}`)
 }
 
-func mockLogfmtStreamWithLabels(_ int, quantity int, labels string) logproto.Stream {
+func mockLogfmtStreamWithLabels(_ int, quantity int, lbls string) logproto.Stream {
 	entries := make([]logproto.Entry, 0, quantity)
+	streamLabels, err := syntax.ParseLabels(lbls)
+	if err != nil {
+		streamLabels = labels.EmptyLabels()
+	}
+
+	lblBuilder := logql_log.NewBaseLabelsBuilder().ForLabels(streamLabels, streamLabels.Hash())
+	logFmtParser := logql_log.NewLogfmtParser(false, false)
 
 	// used for detected fields queries which are always BACKWARD
 	for i := quantity; i > 0; i-- {
-		entries = append(entries, logproto.Entry{
+		line := fmt.Sprintf(
+			`message="line %d" count=%d fake=true bytes=%dMB duration=%dms percent=%f even=%t name=bar`,
+			i,
+			i,
+			(i * 10),
+			(i * 256),
+			float32(i*10.0),
+			(i%2 == 0))
+
+		entry := logproto.Entry{
 			Timestamp: time.Unix(int64(i), 0),
-			Line: fmt.Sprintf(
-				`message="line %d" count=%d fake=true bytes=%dMB duration=%dms percent=%f even=%t name=bar`,
-				i,
-				i,
-				(i * 10),
-				(i * 256),
-				float32(i*10.0),
-				(i%2 == 0)),
-		})
+			Line:      line,
+		}
+		_, logfmtSuccess := logFmtParser.Process(0, []byte(line), lblBuilder)
+		if logfmtSuccess {
+			entry.Parsed = logproto.FromLabelsToLabelAdapters(lblBuilder.LabelsResult().Parsed())
+		}
+		entries = append(entries, entry)
 	}
 
 	return logproto.Stream{
 		Entries: entries,
-		Labels:  labels,
+		Labels:  lblBuilder.LabelsResult().String(),
 	}
 }
 
@@ -609,7 +625,7 @@ func mockLogfmtStreamWithStructuredMetadata(from int, quantity int) logproto.Str
 func mockLogfmtStreamWithLabelsAndStructuredMetadata(
 	from int,
 	quantity int,
-	labels string,
+	lbls string,
 ) logproto.Stream {
 	var entries []logproto.Entry
 	metadata := push.LabelsAdapter{
@@ -626,15 +642,29 @@ func mockLogfmtStreamWithLabelsAndStructuredMetadata(
 		})
 	}
 
+	streamLabels, err := syntax.ParseLabels(lbls)
+	if err != nil {
+		streamLabels = labels.EmptyLabels()
+	}
+
+	lblBuilder := logql_log.NewBaseLabelsBuilder().ForLabels(streamLabels, streamLabels.Hash())
+	logFmtParser := logql_log.NewLogfmtParser(false, false)
+
 	for i := quantity; i > 0; i-- {
-		entries = append(entries, logproto.Entry{
+		line := fmt.Sprintf(`message="line %d" count=%d fake=true`, i, i)
+		entry := logproto.Entry{
 			Timestamp:          time.Unix(int64(i), 0),
-			Line:               fmt.Sprintf(`message="line %d" count=%d fake=true`, i, i),
+			Line:               line,
 			StructuredMetadata: metadata,
-		})
+		}
+		_, logfmtSuccess := logFmtParser.Process(0, []byte(line), lblBuilder)
+		if logfmtSuccess {
+			entry.Parsed = logproto.FromLabelsToLabelAdapters(lblBuilder.LabelsResult().Parsed())
+		}
+		entries = append(entries, entry)
 	}
 	return logproto.Stream{
-		Labels:  labels,
+		Labels:  lbls,
 		Entries: entries,
 	}
 }

--- a/pkg/querier/querier_test.go
+++ b/pkg/querier/querier_test.go
@@ -2134,7 +2134,7 @@ func Test_parseDetectedFeilds(t *testing.T) {
 			},
 		}
 
-		nginxJsonLines := []push.Entry{
+		nginxJSONLines := []push.Entry{
 			{Timestamp: now, Line: `{"host":"100.117.38.203", "user-identifier":"nader3722", "datetime":"05/Sep/2024:16:13:56 +0000", "method": "PATCH", "request": "/api/loki/v1/push", "protocol":"HTTP/2.0", "status":200, "bytes":9664, "referer": "https://www.seniorbleeding-edge.net/exploit/robust/whiteboard"}`, StructuredMetadata: debugDetectedFieldMetadata},
 			{Timestamp: now, Line: `{"host":"66.134.9.30", "user-identifier":"-", "datetime":"05/Sep/2024:16:13:55 +0000", "method": "DELETE", "request": "/api/mimir/v1/push", "protocol":"HTTP/1.1", "status":200, "bytes":18688, "referer": "https://www.districtiterate.biz/synergistic/next-generation/extend"}`, StructuredMetadata: debugDetectedFieldMetadata},
 			{Timestamp: now, Line: `{"host":"66.134.9.30", "user-identifier":"-", "datetime":"05/Sep/2024:16:13:55 +0000", "method": "GET", "request": "/api/loki/v1/label/names", "protocol":"HTTP/1.1", "status":200, "bytes":9314, "referer": "https://www.dynamicimplement.info/enterprise/distributed/incentivize/strategic"}`, StructuredMetadata: debugDetectedFieldMetadata},

--- a/pkg/querier/querier_test.go
+++ b/pkg/querier/querier_test.go
@@ -21,8 +21,9 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/loki/pkg/push"
 	util_log "github.com/grafana/loki/v3/pkg/util/log"
+
+	"github.com/grafana/loki/pkg/push"
 
 	"github.com/grafana/loki/v3/pkg/compactor/deletion"
 	"github.com/grafana/loki/v3/pkg/ingester/client"
@@ -2146,7 +2147,7 @@ func Test_parseDetectedFeilds(t *testing.T) {
 
 		nginxStream := push.Stream{
 			Labels:  nginxLbls,
-			Entries: nginxJsonLines,
+			Entries: nginxJSONLines,
 			Hash:    nginxMetric.Hash(),
 		}
 
@@ -2272,7 +2273,7 @@ func Test_parseDetectedFeilds(t *testing.T) {
 
 			nginxStream := push.Stream{
 				Labels:  nginxLbls,
-				Entries: nginxJsonLines,
+				Entries: nginxJSONLines,
 				Hash:    nginxMetric.Hash(),
 			}
 
@@ -2433,7 +2434,7 @@ func Test_parseDetectedFeilds(t *testing.T) {
 			}
 		}
 
-		nginxJsonLines := []push.Entry{
+		nginxJSONLines := []push.Entry{
 			{
 				Timestamp:          now,
 				Line:               `{"host":"100.117.38.203", "user-identifier":"nader3722", "datetime":"05/Sep/2024:16:13:56 +0000", "method": "PATCH", "request": "/api/loki/v1/push", "protocol":"HTTP/2.0", "status":200, "bytes":9664, "referer": "https://www.seniorbleeding-edge.net/exploit/robust/whiteboard"}`,
@@ -2460,7 +2461,7 @@ func Test_parseDetectedFeilds(t *testing.T) {
 
 		nginxStream := push.Stream{
 			Labels:  nginxLbls,
-			Entries: nginxJsonLines,
+			Entries: nginxJSONLines,
 			Hash:    nginxMetric.Hash(),
 		}
 
@@ -2586,7 +2587,7 @@ func Test_parseDetectedFeilds(t *testing.T) {
 
 			nginxStream := push.Stream{
 				Labels:  nginxLbls,
-				Entries: nginxJsonLines,
+				Entries: nginxJSONLines,
 				Hash:    nginxMetric.Hash(),
 			}
 

--- a/pkg/querier/querier_test.go
+++ b/pkg/querier/querier_test.go
@@ -16,10 +16,12 @@ import (
 	ring_client "github.com/grafana/dskit/ring/client"
 	"github.com/grafana/dskit/user"
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/loki/pkg/push"
 	util_log "github.com/grafana/loki/v3/pkg/util/log"
 
 	"github.com/grafana/loki/v3/pkg/compactor/deletion"
@@ -27,6 +29,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/logproto"
 	"github.com/grafana/loki/v3/pkg/logql"
 	"github.com/grafana/loki/v3/pkg/logql/syntax"
+	"github.com/grafana/loki/v3/pkg/logqlmodel"
 	"github.com/grafana/loki/v3/pkg/querier/plan"
 	"github.com/grafana/loki/v3/pkg/storage"
 	"github.com/grafana/loki/v3/pkg/util/constants"
@@ -2094,5 +2097,573 @@ func Test_getParsersFromExpr(t *testing.T) {
 		expr, err := syntax.ParseLogSelector(exprStr, true)
 		require.NoError(t, err)
 		assert.Equal(t, []string{"logfmt", "json"}, getParsersFromExpr(expr))
+	})
+}
+
+func Test_parseDetectedFeilds(t *testing.T) {
+	now := time.Now()
+
+	t.Run("when no parsers are supplied", func(t *testing.T) {
+		infoDetectdFiledMetadata := []push.LabelAdapter{
+			{
+				Name:  "detected_level",
+				Value: "info",
+			},
+		}
+
+		rulerLines := []push.Entry{
+			{Timestamp: now, Line: "ts=2024-09-05T15:36:38.757788067Z caller=grpc_logging.go:66 tenant=2419 level=info method=/cortex.Ingester/Push duration=19.098s msg=gRPC", StructuredMetadata: infoDetectdFiledMetadata},
+			{Timestamp: now, Line: "ts=2024-09-05T15:36:38.698375619Z caller=grpc_logging.go:66 tenant=29 level=info method=/cortex.Ingester/Push duration=5.471s msg=gRPC", StructuredMetadata: infoDetectdFiledMetadata},
+			{Timestamp: now, Line: "ts=2024-09-05T15:36:38.629424175Z caller=grpc_logging.go:66 tenant=2919 level=info method=/cortex.Ingester/Push duration=29.234s msg=gRPC", StructuredMetadata: infoDetectdFiledMetadata},
+		}
+
+		rulerLbls := `{cluster="us-east-1", namespace="mimir-dev", pod="mimir-ruler-nfb37", service_name="mimir-ruler"}`
+		rulerMetric, err := parser.ParseMetric(rulerLbls)
+		require.NoError(t, err)
+
+		rulerStream := push.Stream{
+			Labels:  rulerLbls,
+			Entries: rulerLines,
+			Hash:    rulerMetric.Hash(),
+		}
+
+		debugDetectedFieldMetadata := []push.LabelAdapter{
+			{
+				Name:  "detected_level",
+				Value: "debug",
+			},
+		}
+
+		nginxJsonLines := []push.Entry{
+			{Timestamp: now, Line: `{"host":"100.117.38.203", "user-identifier":"nader3722", "datetime":"05/Sep/2024:16:13:56 +0000", "method": "PATCH", "request": "/api/loki/v1/push", "protocol":"HTTP/2.0", "status":200, "bytes":9664, "referer": "https://www.seniorbleeding-edge.net/exploit/robust/whiteboard"}`, StructuredMetadata: debugDetectedFieldMetadata},
+			{Timestamp: now, Line: `{"host":"66.134.9.30", "user-identifier":"-", "datetime":"05/Sep/2024:16:13:55 +0000", "method": "DELETE", "request": "/api/mimir/v1/push", "protocol":"HTTP/1.1", "status":200, "bytes":18688, "referer": "https://www.districtiterate.biz/synergistic/next-generation/extend"}`, StructuredMetadata: debugDetectedFieldMetadata},
+			{Timestamp: now, Line: `{"host":"66.134.9.30", "user-identifier":"-", "datetime":"05/Sep/2024:16:13:55 +0000", "method": "GET", "request": "/api/loki/v1/label/names", "protocol":"HTTP/1.1", "status":200, "bytes":9314, "referer": "https://www.dynamicimplement.info/enterprise/distributed/incentivize/strategic"}`, StructuredMetadata: debugDetectedFieldMetadata},
+		}
+
+		nginxLbls := `{ cluster="eu-west-1", level="debug", namespace="gateway", pod="nginx-json-oghco", service_name="nginx-json" }`
+		nginxMetric, err := parser.ParseMetric(nginxLbls)
+		require.NoError(t, err)
+
+		nginxStream := push.Stream{
+			Labels:  nginxLbls,
+			Entries: nginxJsonLines,
+			Hash:    nginxMetric.Hash(),
+		}
+
+		t.Run("detect logfmt fields when with no supplied parsers", func(t *testing.T) {
+			df := parseDetectedFields(uint32(15), logqlmodel.Streams([]push.Stream{rulerStream}))
+			for _, expected := range []string{"ts", "caller", "tenant", "level", "method", "duration", "msg"} {
+				require.Contains(t, df, expected)
+				parsers := df[expected].parsers
+
+				require.Len(t, parsers, 1)
+				require.Equal(t, "logfmt", parsers[0])
+			}
+
+			// no parsers for structed metadata
+			for _, expected := range []string{"detected_level"} {
+				require.Contains(t, df, expected)
+				parsers := df[expected].parsers
+
+				require.Len(t, parsers, 0)
+			}
+		})
+
+		t.Run("detect json fields when with no supplied parsers", func(t *testing.T) {
+			df := parseDetectedFields(uint32(15), logqlmodel.Streams([]push.Stream{nginxStream}))
+			for _, expected := range []string{"host", "user_identifier", "datetime", "method", "request", "protocol", "status", "bytes", "referer"} {
+				require.Contains(t, df, expected)
+				parsers := df[expected].parsers
+
+				require.Len(t, parsers, 1)
+				require.Equal(t, "json", parsers[0])
+			}
+
+			// no parsers for structed metadata
+			for _, expected := range []string{"detected_level"} {
+				require.Contains(t, df, expected)
+				parsers := df[expected].parsers
+
+				require.Len(t, parsers, 0)
+			}
+		})
+
+		t.Run("detect mixed fields when with no supplied parsers", func(t *testing.T) {
+			df := parseDetectedFields(uint32(20), logqlmodel.Streams([]push.Stream{rulerStream, nginxStream}))
+
+			for _, expected := range []string{"ts", "caller", "tenant", "level", "duration", "msg"} {
+				require.Contains(t, df, expected)
+				parsers := df[expected].parsers
+
+				require.Len(t, parsers, 1, "expected only logfmt parser for %s", expected)
+				require.Equal(t, "logfmt", parsers[0], "expected only logfmt parser for %s", expected)
+			}
+
+			for _, expected := range []string{"host", "user_identifier", "datetime", "request", "protocol", "status", "bytes", "referer"} {
+				require.Contains(t, df, expected)
+				parsers := df[expected].parsers
+
+				require.Len(t, parsers, 1, "expected only json parser for %s", expected)
+				require.Equal(t, "json", parsers[0], "expected only json parser for %s", expected)
+			}
+
+			// multiple parsers for fields that exist in both streams
+			for _, expected := range []string{"method"} {
+				require.Contains(t, df, expected)
+				parsers := df[expected].parsers
+
+				require.Len(t, parsers, 2, "expected logfmt and json parser for %s", expected)
+				require.Contains(t, parsers, "logfmt", "expected logfmt parser for %s", expected)
+				require.Contains(t, parsers, "json", "expected json parser for %s", expected)
+			}
+
+			// no parsers for structed metadata
+			for _, expected := range []string{"detected_level"} {
+				require.Contains(t, df, expected)
+				parsers := df[expected].parsers
+
+				require.Len(t, parsers, 0)
+			}
+		})
+
+		t.Run("correctly applies _extracted for a single stream", func(t *testing.T) {
+			rulerLbls := `{cluster="us-east-1", namespace="mimir-dev", pod="mimir-ruler-nfb37", service_name="mimir-ruler", tenant="42", caller="inside-the-house"}`
+			rulerMetric, err := parser.ParseMetric(rulerLbls)
+			require.NoError(t, err)
+
+			rulerStream := push.Stream{
+				Labels:  rulerLbls,
+				Entries: rulerLines,
+				Hash:    rulerMetric.Hash(),
+			}
+
+			df := parseDetectedFields(uint32(15), logqlmodel.Streams([]push.Stream{rulerStream}))
+			for _, expected := range []string{"ts", "caller_extracted", "tenant_extracted", "level", "method", "duration", "msg"} {
+				require.Contains(t, df, expected)
+				parsers := df[expected].parsers
+
+				require.Len(t, parsers, 1)
+				require.Equal(t, "logfmt", parsers[0])
+			}
+
+			// no parsers for structed metadata
+			for _, expected := range []string{"detected_level"} {
+				require.Contains(t, df, expected)
+				parsers := df[expected].parsers
+
+				require.Len(t, parsers, 0)
+			}
+		})
+
+		t.Run("correctly applies _extracted for multiple streams", func(t *testing.T) {
+			rulerLbls := `{cluster="us-east-1", namespace="mimir-dev", pod="mimir-ruler-nfb37", service_name="mimir-ruler", tenant="42", caller="inside-the-house"}`
+			rulerMetric, err := parser.ParseMetric(rulerLbls)
+			require.NoError(t, err)
+
+			rulerStream := push.Stream{
+				Labels:  rulerLbls,
+				Entries: rulerLines,
+				Hash:    rulerMetric.Hash(),
+			}
+
+			nginxLbls := `{ cluster="eu-west-1", level="debug", namespace="gateway", pod="nginx-json-oghco", service_name="nginx-json", host="localhost"}`
+			nginxMetric, err := parser.ParseMetric(nginxLbls)
+			require.NoError(t, err)
+
+			nginxStream := push.Stream{
+				Labels:  nginxLbls,
+				Entries: nginxJsonLines,
+				Hash:    nginxMetric.Hash(),
+			}
+
+			df := parseDetectedFields(uint32(20), logqlmodel.Streams([]push.Stream{rulerStream, nginxStream}))
+			for _, expected := range []string{"ts", "caller_extracted", "tenant_extracted", "level", "duration", "msg"} {
+				require.Contains(t, df, expected)
+				parsers := df[expected].parsers
+
+				require.Len(t, parsers, 1)
+				require.Equal(t, "logfmt", parsers[0])
+			}
+
+			for _, expected := range []string{"host_extracted", "user_identifier", "datetime", "request", "protocol", "status", "bytes", "referer"} {
+				require.Contains(t, df, expected)
+				parsers := df[expected].parsers
+
+				require.Len(t, parsers, 1, "expected only json parser for %s", expected)
+				require.Equal(t, "json", parsers[0], "expected only json parser for %s", expected)
+			}
+
+			// multiple parsers for fields that exist in both streams
+			for _, expected := range []string{"method"} {
+				require.Contains(t, df, expected)
+				parsers := df[expected].parsers
+
+				require.Len(t, parsers, 2, "expected logfmt and json parser for %s", expected)
+				require.Contains(t, parsers, "logfmt", "expected logfmt parser for %s", expected)
+				require.Contains(t, parsers, "json", "expected json parser for %s", expected)
+			}
+
+			// no parsers for structed metadata
+			for _, expected := range []string{"detected_level"} {
+				require.Contains(t, df, expected)
+				parsers := df[expected].parsers
+
+				require.Len(t, parsers, 0)
+			}
+		})
+	})
+
+	t.Run("when parsers are supplied", func(t *testing.T) {
+		infoDetectdFiledMetadata := []push.LabelAdapter{
+			{
+				Name:  "detected_level",
+				Value: "info",
+			},
+		}
+
+		parsedRulerFields := func(ts, tenant, duration string) []push.LabelAdapter {
+			return []push.LabelAdapter{
+				{
+					Name:  "ts",
+					Value: ts,
+				},
+				{
+					Name:  "caller",
+					Value: "grpc_logging.go:66",
+				},
+				{
+					Name:  "tenant",
+					Value: tenant,
+				},
+				{
+					Name:  "level",
+					Value: "info",
+				},
+				{
+					Name:  "method",
+					Value: "/cortex.Ingester/Push",
+				},
+				{
+					Name:  "duration",
+					Value: duration,
+				},
+				{
+					Name:  "msg",
+					Value: "gRPC",
+				},
+			}
+		}
+
+		rulerLines := []push.Entry{
+			{
+				Timestamp:          now,
+				Line:               "ts=2024-09-05T15:36:38.757788067Z caller=grpc_logging.go:66 tenant=2419 level=info method=/cortex.Ingester/Push duration=19.098s msg=gRPC",
+				StructuredMetadata: infoDetectdFiledMetadata,
+				Parsed:             parsedRulerFields("2024-09-05T15:36:38.757788067Z", "2419", "19.098s"),
+			},
+			{
+				Timestamp:          now,
+				Line:               "ts=2024-09-05T15:36:38.698375619Z caller=grpc_logging.go:66 tenant=29 level=info method=/cortex.Ingester/Push duration=5.471s msg=gRPC",
+				StructuredMetadata: infoDetectdFiledMetadata,
+				Parsed:             parsedRulerFields("2024-09-05T15:36:38.698375619Z", "29", "5.471s"),
+			},
+			{
+				Timestamp:          now,
+				Line:               "ts=2024-09-05T15:36:38.629424175Z caller=grpc_logging.go:66 tenant=2919 level=info method=/cortex.Ingester/Push duration=29.234s msg=gRPC",
+				StructuredMetadata: infoDetectdFiledMetadata,
+				Parsed:             parsedRulerFields("2024-09-05T15:36:38.629424175Z", "2919", "29.234s"),
+			},
+		}
+
+		rulerLbls := `{cluster="us-east-1", namespace="mimir-dev", pod="mimir-ruler-nfb37", service_name="mimir-ruler"}`
+		rulerMetric, err := parser.ParseMetric(rulerLbls)
+		require.NoError(t, err)
+
+		rulerStream := push.Stream{
+			Labels:  rulerLbls,
+			Entries: rulerLines,
+			Hash:    rulerMetric.Hash(),
+		}
+
+		debugDetectedFieldMetadata := []push.LabelAdapter{
+			{
+				Name:  "detected_level",
+				Value: "debug",
+			},
+		}
+
+		parsedNginxFields := func(host, userIdentifier, datetime, method, request, protocol, status, bytes, referer string) []push.LabelAdapter {
+			return []push.LabelAdapter{
+				{
+					Name:  "host",
+					Value: host,
+				},
+				{
+					Name:  "user_identifier",
+					Value: userIdentifier,
+				},
+				{
+					Name:  "datetime",
+					Value: datetime,
+				},
+				{
+					Name:  "method",
+					Value: method,
+				},
+				{
+					Name:  "request",
+					Value: request,
+				},
+				{
+					Name:  "protocol",
+					Value: protocol,
+				},
+				{
+					Name:  "status",
+					Value: status,
+				},
+				{
+					Name:  "bytes",
+					Value: bytes,
+				},
+				{
+					Name:  "referer",
+					Value: referer,
+				},
+			}
+		}
+
+		nginxJsonLines := []push.Entry{
+			{
+				Timestamp:          now,
+				Line:               `{"host":"100.117.38.203", "user-identifier":"nader3722", "datetime":"05/Sep/2024:16:13:56 +0000", "method": "PATCH", "request": "/api/loki/v1/push", "protocol":"HTTP/2.0", "status":200, "bytes":9664, "referer": "https://www.seniorbleeding-edge.net/exploit/robust/whiteboard"}`,
+				StructuredMetadata: debugDetectedFieldMetadata,
+				Parsed:             parsedNginxFields("100.117.38.203", "nadre3722", "05/Sep/2024:16:13:56 +0000", "PATCH", "/api/loki/v1/push", "HTTP/2.0", "200", "9664", "https://www.seniorbleeding-edge.net/exploit/robust/whiteboard"),
+			},
+			{
+				Timestamp:          now,
+				Line:               `{"host":"66.134.9.30", "user-identifier":"-", "datetime":"05/Sep/2024:16:13:55 +0000", "method": "DELETE", "request": "/api/mimir/v1/push", "protocol":"HTTP/1.1", "status":200, "bytes":18688, "referer": "https://www.districtiterate.biz/synergistic/next-generation/extend"}`,
+				StructuredMetadata: debugDetectedFieldMetadata,
+				Parsed:             parsedNginxFields("66.134.9.30", "-", "05/Sep/2024:16:13:55 +0000", "DELETE", "/api/mimir/v1/push", "HTTP/1.1", "200", "18688", "https://www.districtiterate.biz/synergistic/next-generation/extend"),
+			},
+			{
+				Timestamp:          now,
+				Line:               `{"host":"66.134.9.30", "user-identifier":"-", "datetime":"05/Sep/2024:16:13:55 +0000", "method": "GET", "request": "/api/loki/v1/label/names", "protocol":"HTTP/1.1", "status":200, "bytes":9314, "referer": "https://www.dynamicimplement.info/enterprise/distributed/incentivize/strategic"}`,
+				StructuredMetadata: debugDetectedFieldMetadata,
+				Parsed:             parsedNginxFields("66.134.9.30", "-", "05/Sep/2024:16:13:55 +0000", "GET", "/api/loki/v1/label/names", "HTTP/1.1", "200", "9314", "https://www.dynamicimplement.info/enterprise/distributed/incentivize/strategic"),
+			},
+		}
+
+		nginxLbls := `{ cluster="eu-west-1", level="debug", namespace="gateway", pod="nginx-json-oghco", service_name="nginx-json" }`
+		nginxMetric, err := parser.ParseMetric(nginxLbls)
+		require.NoError(t, err)
+
+		nginxStream := push.Stream{
+			Labels:  nginxLbls,
+			Entries: nginxJsonLines,
+			Hash:    nginxMetric.Hash(),
+		}
+
+		t.Run("detect logfmt fields", func(t *testing.T) {
+			df := parseDetectedFields(uint32(15), logqlmodel.Streams([]push.Stream{rulerStream}))
+			for _, expected := range []string{"ts", "caller", "tenant", "level", "method", "duration", "msg"} {
+				require.Contains(t, df, expected)
+				parsers := df[expected].parsers
+
+				require.Len(t, parsers, 1)
+				require.Equal(t, "logfmt", parsers[0])
+			}
+
+			// no parsers for structed metadata
+			for _, expected := range []string{"detected_level"} {
+				require.Contains(t, df, expected)
+				parsers := df[expected].parsers
+
+				require.Len(t, parsers, 0)
+			}
+		})
+
+		t.Run("detect json fields", func(t *testing.T) {
+			df := parseDetectedFields(uint32(15), logqlmodel.Streams([]push.Stream{nginxStream}))
+			for _, expected := range []string{"host", "user_identifier", "datetime", "method", "request", "protocol", "status", "bytes", "referer"} {
+				require.Contains(t, df, expected)
+				parsers := df[expected].parsers
+
+				require.Len(t, parsers, 1)
+				require.Equal(t, "json", parsers[0])
+			}
+
+			// no parsers for structed metadata
+			for _, expected := range []string{"detected_level"} {
+				require.Contains(t, df, expected)
+				parsers := df[expected].parsers
+
+				require.Len(t, parsers, 0)
+			}
+		})
+
+		t.Run("detect mixed fields", func(t *testing.T) {
+			df := parseDetectedFields(uint32(20), logqlmodel.Streams([]push.Stream{rulerStream, nginxStream}))
+
+			for _, expected := range []string{"ts", "caller", "tenant", "level", "duration", "msg"} {
+				require.Contains(t, df, expected)
+				parsers := df[expected].parsers
+
+				require.Len(t, parsers, 1, "expected only logfmt parser for %s", expected)
+				require.Equal(t, "logfmt", parsers[0], "expected only logfmt parser for %s", expected)
+			}
+
+			for _, expected := range []string{"host", "user_identifier", "datetime", "request", "protocol", "status", "bytes", "referer"} {
+				require.Contains(t, df, expected)
+				parsers := df[expected].parsers
+
+				require.Len(t, parsers, 1, "expected only json parser for %s", expected)
+				require.Equal(t, "json", parsers[0], "expected only json parser for %s", expected)
+			}
+
+			// multiple parsers for fields that exist in both streams
+			for _, expected := range []string{"method"} {
+				require.Contains(t, df, expected)
+				parsers := df[expected].parsers
+
+				require.Len(t, parsers, 2, "expected logfmt and json parser for %s", expected)
+				require.Contains(t, parsers, "logfmt", "expected logfmt parser for %s", expected)
+				require.Contains(t, parsers, "json", "expected json parser for %s", expected)
+			}
+
+			// no parsers for structed metadata
+			for _, expected := range []string{"detected_level"} {
+				require.Contains(t, df, expected)
+				parsers := df[expected].parsers
+
+				require.Len(t, parsers, 0)
+			}
+		})
+
+		t.Run("correctly applies _extracted for a single stream", func(t *testing.T) {
+			rulerLbls := `{cluster="us-east-1", namespace="mimir-dev", pod="mimir-ruler-nfb37", service_name="mimir-ruler", tenant="42", caller="inside-the-house"}`
+			rulerMetric, err := parser.ParseMetric(rulerLbls)
+			require.NoError(t, err)
+
+			rulerStream := push.Stream{
+				Labels:  rulerLbls,
+				Entries: rulerLines,
+				Hash:    rulerMetric.Hash(),
+			}
+
+			df := parseDetectedFields(uint32(15), logqlmodel.Streams([]push.Stream{rulerStream}))
+			for _, expected := range []string{"ts", "caller_extracted", "tenant_extracted", "level", "method", "duration", "msg"} {
+				require.Contains(t, df, expected)
+				parsers := df[expected].parsers
+
+				require.Len(t, parsers, 1)
+				require.Equal(t, "logfmt", parsers[0])
+			}
+
+			// no parsers for structed metadata
+			for _, expected := range []string{"detected_level"} {
+				require.Contains(t, df, expected)
+				parsers := df[expected].parsers
+
+				require.Len(t, parsers, 0)
+			}
+		})
+
+		t.Run("correctly applies _extracted for multiple streams", func(t *testing.T) {
+			rulerLbls := `{cluster="us-east-1", namespace="mimir-dev", pod="mimir-ruler-nfb37", service_name="mimir-ruler", tenant="42", caller="inside-the-house"}`
+			rulerMetric, err := parser.ParseMetric(rulerLbls)
+			require.NoError(t, err)
+
+			rulerStream := push.Stream{
+				Labels:  rulerLbls,
+				Entries: rulerLines,
+				Hash:    rulerMetric.Hash(),
+			}
+
+			nginxLbls := `{ cluster="eu-west-1", level="debug", namespace="gateway", pod="nginx-json-oghco", service_name="nginx-json", host="localhost"}`
+			nginxMetric, err := parser.ParseMetric(nginxLbls)
+			require.NoError(t, err)
+
+			nginxStream := push.Stream{
+				Labels:  nginxLbls,
+				Entries: nginxJsonLines,
+				Hash:    nginxMetric.Hash(),
+			}
+
+			df := parseDetectedFields(uint32(20), logqlmodel.Streams([]push.Stream{rulerStream, nginxStream}))
+			for _, expected := range []string{"ts", "caller_extracted", "tenant_extracted", "level", "duration", "msg"} {
+				require.Contains(t, df, expected)
+				parsers := df[expected].parsers
+
+				require.Len(t, parsers, 1)
+				require.Equal(t, "logfmt", parsers[0])
+			}
+
+			for _, expected := range []string{"host_extracted", "user_identifier", "datetime", "request", "protocol", "status", "bytes", "referer"} {
+				require.Contains(t, df, expected)
+				parsers := df[expected].parsers
+
+				require.Len(t, parsers, 1, "expected only json parser for %s", expected)
+				require.Equal(t, "json", parsers[0], "expected only json parser for %s", expected)
+			}
+
+			// multiple parsers for fields that exist in both streams
+			for _, expected := range []string{"method"} {
+				require.Contains(t, df, expected)
+				parsers := df[expected].parsers
+
+				require.Len(t, parsers, 2, "expected logfmt and json parser for %s", expected)
+				require.Contains(t, parsers, "logfmt", "expected logfmt parser for %s", expected)
+				require.Contains(t, parsers, "json", "expected json parser for %s", expected)
+			}
+
+			// no parsers for structed metadata
+			for _, expected := range []string{"detected_level"} {
+				require.Contains(t, df, expected)
+				parsers := df[expected].parsers
+
+				require.Len(t, parsers, 0)
+			}
+		})
+	})
+
+	t.Run("handles level in all the places", func(t *testing.T) {
+		rulerLbls := `{cluster="us-east-1", namespace="mimir-dev", pod="mimir-ruler-nfb37", service_name="mimir-ruler", tenant="42", caller="inside-the-house", level="debug"}`
+		rulerMetric, err := parser.ParseMetric(rulerLbls)
+		require.NoError(t, err)
+
+		rulerStream := push.Stream{
+			Labels: rulerLbls,
+			Entries: []push.Entry{
+				{
+					Timestamp: now,
+					Line:      "ts=2024-09-05T15:36:38.757788067Z caller=grpc_logging.go:66 tenant=2419 level=info method=/cortex.Ingester/Push duration=19.098s msg=gRPC",
+					StructuredMetadata: []push.LabelAdapter{
+						{
+							Name:  "detected_level",
+							Value: "debug",
+						},
+					},
+					Parsed: []push.LabelAdapter{
+						{
+							Name:  "level",
+							Value: "info",
+						},
+					},
+				},
+			},
+			Hash: rulerMetric.Hash(),
+		}
+
+		df := parseDetectedFields(uint32(20), logqlmodel.Streams([]push.Stream{rulerStream, rulerStream}))
+
+		detectedLevelField := df["detected_level"]
+		require.Len(t, detectedLevelField.parsers, 0)
+		require.Equal(t, uint64(1), detectedLevelField.sketch.Estimate())
+
+		levelField := df["level_extracted"]
+		require.Len(t, levelField.parsers, 1)
+		require.Contains(t, levelField.parsers, "logfmt")
+		require.Equal(t, uint64(1), levelField.sketch.Estimate())
 	})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Explore logs passes multiple parsers in the query to `detected_fields`, which has resulted in a whole bunch of unknown edge cases. This fixes:

1. making sure `_extracted` is correctly applied when the incoming stream labels already have extracted fields because of the formatters included in the query
2. Returning the `Parsed` values on the entry being parsed if not additional parsed values are found
3. Correctly apply `logfmt` and `json` parsers to already parsed fields
4. Drop special error labels from detected fields response

**Which issue(s) this PR fixes**:
Fixes #14063

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
