### PR TITLE
docs: Update Release Notes for 3.0.1

### DIFF
--- a/docs/sources/release-notes/v3-0.md
+++ b/docs/sources/release-notes/v3-0.md
@@ -54,6 +54,11 @@ The path from 2.9 to 3.0 includes several breaking changes. For important upgrad
 
 ## Bug fixes
 
+### 3.0.1 (2024-08-09)
+
+- **deps:** Bumped dependencies versions to resolve CVEs ([#13833](https://github.com/grafana/loki/pull/13833)) ([e13011d](https://github.com/grafana/loki/commit/e13011d91a77501ca4f659df9cf33f23085d3a35)).
+- Fixed nil pointer dereference in bloomstore initialization ([#12869](https://github.com/grafana/loki/issues/12869)) ([167b468](https://github.com/grafana/loki/commit/167b468598bc70bbed6eed44826d3f9b85e1e0b8)), closes [#12270](https://github.com/grafana/loki/issues/12270).
+
 ### 3.0.0 (2024-04-08)
 
 - All lifecycler configurations reference a valid IPv6 address and port combination ([#11121](https://github.com/grafana/loki/issues/11121)) ([6385b19](https://github.com/grafana/loki/commit/6385b195739bd7d4e9706faddd0de663d8e5331a)).


### PR DESCRIPTION
**What this PR does / why we need it**:

Update the Release Notes for the 3.0.1 release on August 9th

https://github.com/grafana/loki/releases/tag/v3.0.1 