### PR TITLE
docs: Update Release Notes for 2.9.10

### DIFF
--- a/docs/sources/release-notes/v2-9.md
+++ b/docs/sources/release-notes/v2-9.md
@@ -5,7 +5,9 @@ weight: 50
 ---
 
 # V2.9
-Grafana Labs is excited to announce the release of Loki 2.9.0 Here's a summary of new enhancements and important fixes:
+Grafana Labs is excited to announce the release of Loki 2.9.0 Here's a summary of new enhancements and important fixes.
+
+For a full list of all changes and fixes, refer to the [CHANGELOG](https://github.com/grafana/loki/blob/release-2.9.x/CHANGELOG.md).
 
 ## Features and enhancements
 
@@ -33,6 +35,15 @@ Grafana Labs is excited to announce the release of Loki 2.9.0 Here's a summary o
   - For the full list of deprecations, see CHANGELOG.md
 
 ## Bug fixes
+
+### 2.9.10 (2026-08-09)
+
+- Update dependencies versions to remove CVE ([#13835](https://github.com/grafana/loki/pull/13835)) ([567bef2](https://github.com/grafana/loki/commit/567bef286376663407c54f5da07fa00963ba5485)).
+
+### 2.9.9 (2024 -07-04)
+
+- **Ingester:** Add `ingester_chunks_flush_failures_total` [12925](https://github.com/grafana/loki/pull/12925).
+- **Ingester:** Add backoff to flush op [13140](https://github.com/grafana/loki/pull/13140).
 
 ### 2.9.8 (2024-05-03)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Update the Release Notes for 2.9.9 and 2.9.10 releases.

https://github.com/grafana/loki/releases/tag/v2.9.9 

https://github.com/grafana/loki/releases/tag/v2.9.10