### PR TITLE
docs: Update minio generic secret create command

### DIFF
--- a/docs/sources/setup/install/helm/monitor-and-alert/with-local-monitoring.md
+++ b/docs/sources/setup/install/helm/monitor-and-alert/with-local-monitoring.md
@@ -65,8 +65,8 @@ Local mode by default will also enable Minio, which will act as the object stora
 
 ```bash
 kubectl create secret generic minio -n meta \
- --from-literal=<INSERT USERNAME OF CHOICE> \
- --from-literal=<INSERT PASSWORD OF CHOICE>
+ --from-literal=rootUser=<INSERT USERNAME OF CHOICE> \
+ --from-literal=rootPassword=<INSERT PASSWORD OF CHOICE>
 ```
 {{< admonition type="note" >}}
 Username and password must have a minimum of 8 characters.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR corrects the command in the documentation to ensure it follows the correct format for Kubernetes generic secrets. The secret creation now uses the key=value format, preventing errors when running the command. This change is necessary to avoid confusion and ensure the documentation reflects the proper usage.

**Which issue(s) this PR fixes**:
Not directly associated with any current issue tickets.

**Special notes for your reviewer**:
N/A

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
