### PR TITLE
chore: avoid some allocations in tsdb while reading posting offset table

### DIFF
--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/index.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/index.go
@@ -1347,44 +1347,37 @@ func newReader(b ByteSlice, c io.Closer) (*Reader, error) {
 		// Earlier V1 formats don't have a sorted postings offset table, so
 		// load the whole offset table into memory.
 		r.postingsV1 = map[string]map[string]uint64{}
-		if err := ReadOffsetTable(r.b, r.toc.PostingsTable, func(key []string, off uint64, _ int) error {
-			if len(key) != 2 {
-				return errors.Errorf("unexpected key length for posting table %d", len(key))
+		if err := ReadOffsetTable(r.b, r.toc.PostingsTable, func(name, value []byte, off uint64, _ int) error {
+			if _, ok := r.postingsV1[string(name)]; !ok {
+				r.postingsV1[string(name)] = map[string]uint64{}
+				r.postings[string(name)] = nil // Used to get a list of labelnames in places.
 			}
-			if _, ok := r.postingsV1[key[0]]; !ok {
-				r.postingsV1[key[0]] = map[string]uint64{}
-				r.postings[key[0]] = nil // Used to get a list of labelnames in places.
-			}
-			r.postingsV1[key[0]][key[1]] = off
+			r.postingsV1[string(name)][string(value)] = off
 			return nil
 		}); err != nil {
 			return nil, errors.Wrap(err, "read postings table")
 		}
 	} else {
-		var lastKey []string
+		var lastName, lastValue []byte
 		lastOff := 0
 		valueCount := 0
 		// For the postings offset table we keep every label name but only every nth
 		// label value (plus the first and last one), to save memory.
-		if err := ReadOffsetTable(r.b, r.toc.PostingsTable, func(key []string, _ uint64, off int) error {
-			if len(key) != 2 {
-				return errors.Errorf("unexpected key length for posting table %d", len(key))
-			}
-			if _, ok := r.postings[key[0]]; !ok {
+		if err := ReadOffsetTable(r.b, r.toc.PostingsTable, func(name, value []byte, _ uint64, off int) error {
+			if _, ok := r.postings[string(name)]; !ok {
 				// Next label name.
-				r.postings[key[0]] = []postingOffset{}
-				if lastKey != nil {
+				r.postings[string(name)] = []postingOffset{}
+				if lastName != nil {
 					// Always include last value for each label name.
-					r.postings[lastKey[0]] = append(r.postings[lastKey[0]], postingOffset{value: lastKey[1], off: lastOff})
+					r.postings[string(lastName)] = append(r.postings[string(lastName)], postingOffset{value: string(lastValue), off: lastOff})
 				}
-				lastKey = nil
 				valueCount = 0
 			}
 			if valueCount%symbolFactor == 0 {
-				r.postings[key[0]] = append(r.postings[key[0]], postingOffset{value: key[1], off: off})
-				lastKey = nil
+				r.postings[string(name)] = append(r.postings[string(name)], postingOffset{value: string(value), off: off})
+				lastName, lastValue = nil, nil
 			} else {
-				lastKey = key
+				lastName, lastValue = name, value
 				lastOff = off
 			}
 			valueCount++
@@ -1392,8 +1385,8 @@ func newReader(b ByteSlice, c io.Closer) (*Reader, error) {
 		}); err != nil {
 			return nil, errors.Wrap(err, "read postings table")
 		}
-		if lastKey != nil {
-			r.postings[lastKey[0]] = append(r.postings[lastKey[0]], postingOffset{value: lastKey[1], off: lastOff})
+		if lastName != nil {
+			r.postings[string(lastName)] = append(r.postings[string(lastName)], postingOffset{value: string(lastValue), off: lastOff})
 		}
 		// Trim any extra space in the slices.
 		for k, v := range r.postings {
@@ -1443,15 +1436,12 @@ type Range struct {
 // for all postings lists.
 func (r *Reader) PostingsRanges() (map[labels.Label]Range, error) {
 	m := map[labels.Label]Range{}
-	if err := ReadOffsetTable(r.b, r.toc.PostingsTable, func(key []string, off uint64, _ int) error {
-		if len(key) != 2 {
-			return errors.Errorf("unexpected key length for posting table %d", len(key))
-		}
+	if err := ReadOffsetTable(r.b, r.toc.PostingsTable, func(name, value []byte, off uint64, _ int) error {
 		d := encoding.DecWrap(tsdb_enc.NewDecbufAt(r.b, int(off), castagnoliTable))
 		if d.Err() != nil {
 			return d.Err()
 		}
-		m[labels.Label{Name: key[0], Value: key[1]}] = Range{
+		m[labels.Label{Name: string(name), Value: string(value)}] = Range{
 			Start: int64(off) + 4,
 			End:   int64(off) + 4 + int64(d.Len()),
 		}
@@ -1606,27 +1596,24 @@ func (s symbolsIter) Err() error { return s.err }
 
 // ReadOffsetTable reads an offset table and at the given position calls f for each
 // found entry. If f returns an error it stops decoding and returns the received error.
-func ReadOffsetTable(bs ByteSlice, off uint64, f func([]string, uint64, int) error) error {
+func ReadOffsetTable(bs ByteSlice, off uint64, f func(name, value []byte, postingsOffset uint64, labelOffset int) error) error {
 	d := encoding.DecWrap(tsdb_enc.NewDecbufAt(bs, int(off), castagnoliTable))
 	startLen := d.Len()
 	cnt := d.Be32()
 
 	for d.Err() == nil && d.Len() > 0 && cnt > 0 {
 		offsetPos := startLen - d.Len()
-		keyCount := d.Uvarint()
-		// The Postings offset table takes only 2 keys per entry (name and value of label),
-		// and the LabelIndices offset table takes only 1 key per entry (a label name).
-		// Hence setting the size to max of both, i.e. 2.
-		keys := make([]string, 0, 2)
-
-		for i := 0; i < keyCount; i++ {
-			keys = append(keys, d.UvarintStr())
+		if keyCount := d.Uvarint(); keyCount != 2 {
+			return fmt.Errorf("unexpected number of keys for postings offset table %d", keyCount)
 		}
+
+		name := d.UvarintBytes()
+		value := d.UvarintBytes()
 		o := d.Uvarint64()
 		if d.Err() != nil {
 			break
 		}
-		if err := f(keys, o, offsetPos); err != nil {
+		if err := f(name, value, o, offsetPos); err != nil {
 			return err
 		}
 		cnt--

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/index_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/index_test.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"hash/crc32"
+	"io"
 	"math"
 	"math/rand"
 	"os"
@@ -198,28 +199,30 @@ func TestIndexRW_Postings(t *testing.T) {
 	require.NoError(t, p.Err())
 
 	// The label indices are no longer used, so test them by hand here.
-	labelIndices := map[string][]string{}
-	require.NoError(t, ReadOffsetTable(ir.b, ir.toc.LabelIndicesTable, func(key []string, off uint64, _ int) error {
-		if len(key) != 1 {
-			return errors.Errorf("unexpected key length for label indices table %d", len(key))
-		}
+	labelValuesOffsets := map[string]uint64{}
+	d := tsdb_enc.NewDecbufAt(ir.b, int(ir.toc.LabelIndicesTable), castagnoliTable)
+	cnt := d.Be32()
 
+	for d.Err() == nil && d.Len() > 0 && cnt > 0 {
+		require.Equal(t, 1, d.Uvarint(), "Unexpected number of keys for label indices table")
+		lbl := d.UvarintStr()
+		off := d.Uvarint64()
+		labelValuesOffsets[lbl] = off
+		cnt--
+	}
+	require.NoError(t, d.Err())
+
+	labelIndices := map[string][]string{}
+	for lbl, off := range labelValuesOffsets {
 		d := tsdb_enc.NewDecbufAt(ir.b, int(off), castagnoliTable)
-		vals := []string{}
-		nc := d.Be32int()
-		if nc != 1 {
-			return errors.Errorf("unexpected number of label indices table names %d", nc)
-		}
-		for i := d.Be32(); i > 0; i-- {
+		require.Equal(t, 1, d.Be32int(), "Unexpected number of label indices table names")
+		for i := d.Be32(); i > 0 && d.Err() == nil; i-- {
 			v, err := ir.lookupSymbol(d.Be32())
-			if err != nil {
-				return err
-			}
-			vals = append(vals, v)
+			require.NoError(t, err)
+			labelIndices[lbl] = append(labelIndices[lbl], v)
 		}
-		labelIndices[key[0]] = vals
-		return d.Err()
-	}))
+		require.NoError(t, d.Err())
+	}
 	require.Equal(t, map[string][]string{
 		"a": {"1"},
 		"b": {"1", "2", "3", "4"},
@@ -938,5 +941,73 @@ func TestChunkSamples_getChunkSampleForQueryStarting(t *testing.T) {
 			require.NotNil(t, chunkSample)
 			require.Equal(t, tc.chunkSamples.chunks[tc.expectedChunkSampleIdx], *chunkSample)
 		})
+	}
+}
+
+func BenchmarkInitReader_ReadOffsetTable(b *testing.B) {
+	dir := b.TempDir()
+	idxFile := filepath.Join(dir, IndexFilename)
+
+	lbls, err := labels.ReadLabels(filepath.Join("..", "testdata", "20kseries.json"), 1000)
+	require.NoError(b, err)
+
+	// Sort labels as the index writer expects series in sorted order by fingerprint.
+	sort.Slice(lbls, func(i, j int) bool {
+		return lbls[i].Hash() < lbls[j].Hash()
+	})
+
+	symbols := map[string]struct{}{}
+	for _, lset := range lbls {
+		for _, l := range lset {
+			symbols[l.Name] = struct{}{}
+			symbols[l.Value] = struct{}{}
+		}
+	}
+
+	var input indexWriterSeriesSlice
+
+	// Generate ChunkMetas for every label set.
+	for _, lset := range lbls {
+		input = append(input, &indexWriterSeries{
+			labels: lset,
+			chunks: []ChunkMeta{
+				{
+					MinTime:  0,
+					MaxTime:  1,
+					Checksum: rand.Uint32(),
+				},
+			},
+		})
+	}
+
+	iw, err := NewWriter(context.Background(), FormatV3, idxFile)
+	require.NoError(b, err)
+
+	var syms []string
+	for s := range symbols {
+		syms = append(syms, s)
+	}
+	sort.Strings(syms)
+	for _, s := range syms {
+		require.NoError(b, iw.AddSymbol(s))
+	}
+
+	for i, s := range input {
+		err = iw.AddSeries(storage.SeriesRef(i), s.labels, model.Fingerprint(s.labels.Hash()), s.chunks...)
+		require.NoError(b, err)
+	}
+
+	err = iw.Close()
+	require.NoError(b, err)
+
+	bs, err := os.ReadFile(idxFile)
+	require.NoError(b, err)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		r, err := newReader(RealByteSlice(bs), io.NopCloser(nil))
+		require.NoError(b, err)
+		require.NoError(b, r.Close())
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
While looking at top memory allocations in some of the index-gateways, I encountered unwanted allocations from TSDB while reading the posting offset table. There is an optimization in tsdb to hold only 1/32 label values from the Postings Offset Table as strings to avoid having all the data in memory. However, we are [converting all the label values to a string using `UvarintStr` instead of `UvarintBytes`](https://github.com/grafana/loki/blob/1d6f8d51fcfd1c806159e17bce978ea39ee5936c/pkg/storage/stores/shipper/indexshipper/tsdb/index/index.go#L1623), resulting in an unwanted allocation.

Below is the screen capture of the `inuse_space` profile showing the allocations.
<img width="1484" alt="Screenshot 2024-09-11 at 1 22 31 PM" src="https://github.com/user-attachments/assets/e80e6020-dc56-4601-b4b0-b2f125e33dda">

Looking at the tsdb code in Prometheus, where most of the tsdb code comes from, [it seems to be using `UvarintStr` while reading labels from the posting offset table](https://github.com/prometheus/prometheus/blob/0f760f63dd5137ad406e0bc9f08676898e04ac97/tsdb/index/index.go#L1469-L1470).

Here is the benchmark result showing the performance of loading tsdb before and after the change:
```
benchmark                                  old ns/op     new ns/op     delta
BenchmarkInitReader_ReadOffsetTable-10     209807        106483        -49.25%
BenchmarkInitReader_ReadOffsetTable-10     214618        106651        -50.31%
BenchmarkInitReader_ReadOffsetTable-10     216551        107335        -50.43%
BenchmarkInitReader_ReadOffsetTable-10     205202        106941        -47.89%
BenchmarkInitReader_ReadOffsetTable-10     204962        106462        -48.06%

benchmark                                  old allocs     new allocs     delta
BenchmarkInitReader_ReadOffsetTable-10     4425           492            -88.88%
BenchmarkInitReader_ReadOffsetTable-10     4425           492            -88.88%
BenchmarkInitReader_ReadOffsetTable-10     4425           492            -88.88%
BenchmarkInitReader_ReadOffsetTable-10     4425           492            -88.88%
BenchmarkInitReader_ReadOffsetTable-10     4425           492            -88.88%

benchmark                                  old bytes     new bytes     delta
BenchmarkInitReader_ReadOffsetTable-10     158422        30440         -80.79%
BenchmarkInitReader_ReadOffsetTable-10     158417        30432         -80.79%
BenchmarkInitReader_ReadOffsetTable-10     158415        30434         -80.79%
BenchmarkInitReader_ReadOffsetTable-10     158425        30437         -80.79%
BenchmarkInitReader_ReadOffsetTable-10     158425        30446         -80.78%
```