### PR TITLE
fix(detected_fields): always return empty array as `null`

### DIFF
--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -1113,13 +1113,16 @@ func (q *SingleTenantQuerier) DetectedFields(ctx context.Context, req *logproto.
 			level.Warn(q.logger).Log("msg", "failed to marshal hyperloglog sketch", "err", err)
 			continue
 		}
-
+		p := v.parsers
+		if len(p) == 0 {
+			p = nil
+		}
 		fields[fieldCount] = &logproto.DetectedField{
 			Label:       k,
 			Type:        v.fieldType,
 			Cardinality: v.Estimate(),
 			Sketch:      sketch,
-			Parsers:     v.parsers,
+			Parsers:     p,
 		}
 
 		fieldCount++

--- a/pkg/storage/detected/fields.go
+++ b/pkg/storage/detected/fields.go
@@ -44,6 +44,9 @@ func (f *UnmarshaledDetectedField) Merge(df *logproto.DetectedField) error {
 	f.Parsers = append(f.Parsers, df.Parsers...)
 	slices.Sort(f.Parsers)
 	f.Parsers = slices.Compact(f.Parsers)
+	if len(f.Parsers) == 0 {
+		f.Parsers = nil
+	}
 
 	return f.Sketch.Merge(sketch)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

The `detected_fields` API returns an empty `parsers` array when JSON encoding is used and `null` if protobuf is used. This PR always ensures the returned value is `null`.
