### PR TITLE
chore(storage/bloom/v1): add ExtractTestableLabelMatchers

### DIFF
--- a/pkg/logql/syntax/visit.go
+++ b/pkg/logql/syntax/visit.go
@@ -95,7 +95,7 @@ func (v *DepthFirstTraversal) VisitDropLabels(e *DropLabelsExpr) {
 	if e == nil {
 		return
 	}
-	if v.VisitDecolorizeFn != nil {
+	if v.VisitDropLabelsFn != nil {
 		v.VisitDropLabelsFn(v, e)
 	}
 }

--- a/pkg/storage/bloom/v1/ast_extractor.go
+++ b/pkg/storage/bloom/v1/ast_extractor.go
@@ -1,0 +1,125 @@
+package v1
+
+import (
+	"github.com/prometheus/prometheus/model/labels"
+
+	"github.com/grafana/loki/v3/pkg/logql/log"
+	"github.com/grafana/loki/v3/pkg/logql/syntax"
+)
+
+// LabelMatcher represents bloom tests for key-value pairs, mapped from
+// LabelFilterExprs from the AST.
+type LabelMatcher interface{ isLabelMatcher() }
+
+// UnsupportedLabelMatcher represents a label matcher which could not be
+// mapped. Bloom tests for UnsupportedLabelMatchers must always pass.
+type UnsupportedLabelMatcher struct{}
+
+// PlainLabelMatcher represents a direct key-value matcher. Bloom tests
+// must only pass if the key-value pair exists in the bloom.
+type PlainLabelMatcher struct{ Key, Value string }
+
+// OrLabelMatcher represents a logical OR test. Bloom tests must only pass if
+// one of the Left or Right label matcher bloom tests pass.
+type OrLabelMatcher struct{ Left, Right LabelMatcher }
+
+// AndLabelMatcher represents a logical AND test. Bloom tests must only pass
+// if both of the Left and Right label matcher bloom tests pass.
+type AndLabelMatcher struct{ Left, Right LabelMatcher }
+
+// ExtractTestableLabelMatchers extracts label matchers from the label filters
+// in an expression. The resulting label matchers can then be used for testing
+// against bloom filters. Only label matchers before the first parse stage are
+// included.
+//
+// Unsupported LabelFilterExprs map to an UnsupportedLabelMatcher, for which
+// bloom tests should always pass.
+func ExtractTestableLabelMatchers(expr syntax.Expr) []LabelMatcher {
+	var (
+		exprs           []*syntax.LabelFilterExpr
+		foundParseStage bool
+	)
+
+	visitor := &syntax.DepthFirstTraversal{
+		VisitLabelFilterFn: func(v syntax.RootVisitor, e *syntax.LabelFilterExpr) {
+			if !foundParseStage {
+				exprs = append(exprs, e)
+			}
+		},
+
+		// TODO(rfratto): Find a way to generically represent or test for an
+		// expression that modifies extracted labels (parsers, keep, drop, etc.).
+		//
+		// As the AST is now, we can't prove at compile time that the list of
+		// visitors below is complete. For example, if a new parser stage
+		// expression is added without updating this list, blooms can silently
+		// misbehave.
+
+		VisitLogfmtParserFn:           func(v syntax.RootVisitor, e *syntax.LogfmtParserExpr) { foundParseStage = true },
+		VisitLabelParserFn:            func(v syntax.RootVisitor, e *syntax.LabelParserExpr) { foundParseStage = true },
+		VisitJSONExpressionParserFn:   func(v syntax.RootVisitor, e *syntax.JSONExpressionParser) { foundParseStage = true },
+		VisitLogfmtExpressionParserFn: func(v syntax.RootVisitor, e *syntax.LogfmtExpressionParser) { foundParseStage = true },
+		VisitLabelFmtFn:               func(v syntax.RootVisitor, e *syntax.LabelFmtExpr) { foundParseStage = true },
+		VisitKeepLabelFn:              func(v syntax.RootVisitor, e *syntax.KeepLabelsExpr) { foundParseStage = true },
+		VisitDropLabelsFn:             func(v syntax.RootVisitor, e *syntax.DropLabelsExpr) { foundParseStage = true },
+	}
+	expr.Accept(visitor)
+
+	return buildLabelMatchers(exprs)
+}
+
+func buildLabelMatchers(exprs []*syntax.LabelFilterExpr) []LabelMatcher {
+	matchers := make([]LabelMatcher, 0, len(exprs))
+	for _, expr := range exprs {
+		matchers = append(matchers, buildLabelMatcher(expr.LabelFilterer))
+	}
+	return matchers
+}
+
+func buildLabelMatcher(filter log.LabelFilterer) LabelMatcher {
+	switch filter := filter.(type) {
+
+	case *log.LineFilterLabelFilter:
+		if filter.Type != labels.MatchEqual {
+			return UnsupportedLabelMatcher{}
+		}
+
+		return PlainLabelMatcher{
+			Key:   filter.Name,
+			Value: filter.Value,
+		}
+
+	case *log.StringLabelFilter:
+		if filter.Type != labels.MatchEqual {
+			return UnsupportedLabelMatcher{}
+		}
+
+		return PlainLabelMatcher{
+			Key:   filter.Name,
+			Value: filter.Value,
+		}
+
+	case *log.BinaryLabelFilter:
+		var (
+			left  = buildLabelMatcher(filter.Left)
+			right = buildLabelMatcher(filter.Right)
+		)
+
+		if filter.And {
+			return AndLabelMatcher{Left: left, Right: right}
+		}
+		return OrLabelMatcher{Left: left, Right: right}
+
+	default:
+		return UnsupportedLabelMatcher{}
+	}
+}
+
+//
+// Implement marker types:
+//
+
+func (UnsupportedLabelMatcher) isLabelMatcher() {}
+func (PlainLabelMatcher) isLabelMatcher()       {}
+func (OrLabelMatcher) isLabelMatcher()          {}
+func (AndLabelMatcher) isLabelMatcher()         {}

--- a/pkg/storage/bloom/v1/ast_extractor_test.go
+++ b/pkg/storage/bloom/v1/ast_extractor_test.go
@@ -1,0 +1,97 @@
+package v1_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/logql/syntax"
+	v1 "github.com/grafana/loki/v3/pkg/storage/bloom/v1"
+)
+
+func TestExtractLabelMatchers(t *testing.T) {
+	tt := []struct {
+		name   string
+		input  string
+		expect []v1.LabelMatcher
+	}{
+		{
+			name:  "basic label matcher",
+			input: `{app="foo"} | key="value"`,
+			expect: []v1.LabelMatcher{
+				v1.PlainLabelMatcher{Key: "key", Value: "value"},
+			},
+		},
+
+		{
+			name:  "or label matcher",
+			input: `{app="foo"} | key1="value1" or key2="value2"`,
+			expect: []v1.LabelMatcher{
+				v1.OrLabelMatcher{
+					Left:  v1.PlainLabelMatcher{Key: "key1", Value: "value1"},
+					Right: v1.PlainLabelMatcher{Key: "key2", Value: "value2"},
+				},
+			},
+		},
+
+		{
+			name:  "and label matcher",
+			input: `{app="foo"} | key1="value1" and key2="value2"`,
+			expect: []v1.LabelMatcher{
+				v1.AndLabelMatcher{
+					Left:  v1.PlainLabelMatcher{Key: "key1", Value: "value1"},
+					Right: v1.PlainLabelMatcher{Key: "key2", Value: "value2"},
+				},
+			},
+		},
+
+		{
+			name:  "multiple label matchers",
+			input: `{app="foo"} | key1="value1" | key2="value2"`,
+			expect: []v1.LabelMatcher{
+				v1.PlainLabelMatcher{Key: "key1", Value: "value1"},
+				v1.PlainLabelMatcher{Key: "key2", Value: "value2"},
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			expr, err := syntax.ParseExpr(tc.input)
+			require.NoError(t, err)
+			require.Equal(t, tc.expect, v1.ExtractTestableLabelMatchers(expr))
+		})
+	}
+}
+
+func TestExtractLabelMatchers_IgnoreAfterParse(t *testing.T) {
+	tt := []struct {
+		name string
+		expr string
+	}{
+		{"after json parser", `json`},
+		{"after logfmt parser", `logfmt`},
+		{"after pattern parser", `pattern "<msg>"`},
+		{"after regexp parser", `regexp "(?P<message>.*)"`},
+		{"after unpack parser", `unpack`},
+		{"after label_format", `label_format foo="bar"`},
+		{"after drop labels stage", `drop foo`},
+		{"after keep labels stage", `keep foo`},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			fullInput := fmt.Sprintf(`{app="foo"} | key1="value1" | %s | key2="value2"`, tc.expr)
+			expect := []v1.LabelMatcher{
+				v1.PlainLabelMatcher{Key: "key1", Value: "value1"},
+				// key2="value2" should be ignored following tc.expr
+			}
+
+			expr, err := syntax.ParseExpr(fullInput)
+			require.NoError(t, err)
+
+			require.Equal(t, expect, v1.ExtractTestableLabelMatchers(expr), "key2=value2 should be ignored with query %s", fullInput)
+		})
+	}
+}

--- a/pkg/storage/bloom/v1/ast_extractor_test.go
+++ b/pkg/storage/bloom/v1/ast_extractor_test.go
@@ -54,6 +54,14 @@ func TestExtractLabelMatchers(t *testing.T) {
 				v1.PlainLabelMatcher{Key: "key2", Value: "value2"},
 			},
 		},
+
+		{
+			name:  "unsupported label matchers",
+			input: `{app="foo"} | key1=~"value1"`,
+			expect: []v1.LabelMatcher{
+				v1.UnsupportedLabelMatcher{},
+			},
+		},
 	}
 
 	for _, tc := range tt {


### PR DESCRIPTION
**What this PR does / why we need it**:

ExtractTestableLabelMatchers examines a LogQL expression and extracts any label filters that can be used for bloom testing. This will eventually be used for the new structured metadata blooms. 

The returned value is a higher level type for separation of concerns and easier testing.

This commit also fixes a bug where DropLabelsExpr was not implemented properly.

**Which issue(s) this PR fixes**:
N/A 

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
