### PR TITLE
chore: Final batch of linting cleanup for Go 1.23 and newer golangci

### DIFF
--- a/pkg/kafka/ingester/consumer.go
+++ b/pkg/kafka/ingester/consumer.go
@@ -249,7 +249,7 @@ func (c *consumer) flush(ctx context.Context) error {
 	wal.ReportSegmentStats(stats, c.metrics.segmentMetrics)
 
 	id := ulid.MustNew(ulid.Timestamp(time.Now()), rand.Reader).String()
-	if err := c.storage.PutObject(ctx, fmt.Sprintf(wal.Dir+id), c.flushBuf); err != nil {
+	if err := c.storage.PutObject(ctx, wal.Dir+id, c.flushBuf); err != nil {
 		return fmt.Errorf("failed to put object to object storage: %w", err)
 	}
 

--- a/pkg/kafka/ingester/partition_reader_test.go
+++ b/pkg/kafka/ingester/partition_reader_test.go
@@ -56,7 +56,7 @@ func TestPartitionReader_BasicFunctionality(t *testing.T) {
 	_, kafkaCfg := testkafka.CreateCluster(t, 1, "test-topic")
 	consumer := newMockConsumer()
 
-	consumerFactory := func(committer Committer) (Consumer, error) {
+	consumerFactory := func(_ Committer) (Consumer, error) {
 		return consumer, nil
 	}
 

--- a/pkg/logql/log/pipeline.go
+++ b/pkg/logql/log/pipeline.go
@@ -2,7 +2,6 @@ package log
 
 import (
 	"context"
-	"reflect"
 	"sync"
 	"unsafe"
 
@@ -383,11 +382,7 @@ func ReduceStages(stages []Stage) Stage {
 }
 
 func unsafeGetBytes(s string) []byte {
-	var buf []byte
-	p := unsafe.Pointer(&buf)
-	*(*string)(p) = s
-	(*reflect.SliceHeader)(p).Cap = len(s)
-	return buf
+	return unsafe.Slice(unsafe.StringData(s), len(s))
 }
 
 func unsafeGetString(buf []byte) string {

--- a/pkg/logql/log/pipeline_test.go
+++ b/pkg/logql/log/pipeline_test.go
@@ -546,6 +546,42 @@ func TestKeepLabelsPipeline(t *testing.T) {
 
 }
 
+func TestUnsafeGetBytes(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  []byte
+	}{
+		{
+			name:  "empty string",
+			input: "",
+			want:  nil,
+		},
+		{
+			name:  "simple string",
+			input: "hello",
+			want:  []byte{'h', 'e', 'l', 'l', 'o'},
+		},
+		{
+			name:  "string with spaces",
+			input: "hello world",
+			want:  []byte{'h', 'e', 'l', 'l', 'o', ' ', 'w', 'o', 'r', 'l', 'd'},
+		},
+		{
+			name:  "string with special characters",
+			input: "hello\nworld\t!",
+			want:  []byte{'h', 'e', 'l', 'l', 'o', '\n', 'w', 'o', 'r', 'l', 'd', '\t', '!'},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := unsafeGetBytes(tt.input)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func Benchmark_Pipeline(b *testing.B) {
 	b.ReportAllocs()
 

--- a/pkg/logql/sketch/topk.go
+++ b/pkg/logql/sketch/topk.go
@@ -2,7 +2,6 @@ package sketch
 
 import (
 	"container/heap"
-	"reflect"
 	"sort"
 	"unsafe"
 
@@ -210,14 +209,8 @@ func (t *Topk) updateBF(removed, added string) {
 	}
 }
 
-// todo: is there a way to save more bytes/allocs via a pool?
 func unsafeGetBytes(s string) []byte {
-	if s == "" {
-		return nil // or []byte{}
-	}
-	return (*[0x7fff0000]byte)(unsafe.Pointer(
-		(*reflect.StringHeader)(unsafe.Pointer(&s)).Data),
-	)[:len(s):len(s)]
+	return unsafe.Slice(unsafe.StringData(s), len(s))
 }
 
 // Observe is our sketch event observation function, which is a bit more complex than the original count min sketch + heap TopK

--- a/pkg/storage/bloom/v1/builder_test.go
+++ b/pkg/storage/bloom/v1/builder_test.go
@@ -356,7 +356,7 @@ func TestMergeBuilderFingerprintCollision(t *testing.T) {
 	}
 
 	// We're not testing the ability to extend a bloom in this test
-	pop := func(s *Series, _ iter.SizedIterator[*Bloom], _ ChunkRefs, ch chan *BloomCreation) {
+	pop := func(_ *Series, _ iter.SizedIterator[*Bloom], _ ChunkRefs, ch chan *BloomCreation) {
 		bloom := NewBloom()
 		stats := indexingInfo{
 			sourceBytes:   int(bloom.Capacity()) / 8,

--- a/pkg/storage/chunk/chunk.go
+++ b/pkg/storage/chunk/chunk.go
@@ -5,7 +5,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"hash/crc32"
-	"reflect"
 	"strconv"
 	"strings"
 	"sync"
@@ -215,11 +214,7 @@ func readOneHexPart(hex []byte) (part []byte, i int) {
 }
 
 func unsafeGetBytes(s string) []byte {
-	var buf []byte
-	p := unsafe.Pointer(&buf)
-	*(*string)(p) = s
-	(*reflect.SliceHeader)(p).Cap = len(s)
-	return buf
+	return unsafe.Slice(unsafe.StringData(s), len(s))
 }
 
 func unsafeGetString(buf []byte) string {


### PR DESCRIPTION
**What this PR does / why we need it**:
Go 1.23 prefers a newer version of golangci, which causes linting issues with the Loki codebase.  This PR is to address those issues.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [X] Tests updated
- [X] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
