### PR TITLE
fix(helm): Various fixes and enhancements for bloom components

### DIFF
--- a/docs/sources/setup/install/helm/reference.md
+++ b/docs/sources/setup/install/helm/reference.md
@@ -6146,6 +6146,9 @@ null
 			<td>Additional storage config</td>
 			<td><pre lang="json">
 {
+  "bloom_shipper": {
+    "working_directory": "/var/loki/data/bloomshipper"
+  },
   "boltdb_shipper": {
     "index_gateway_client": {
       "server_address": "{{ include \"loki.indexGatewayAddress\" . }}"

--- a/docs/sources/setup/install/helm/reference.md
+++ b/docs/sources/setup/install/helm/reference.md
@@ -1109,8 +1109,6 @@ null
     ],
     "enableStatefulSetAutoDeletePVC": false,
     "enabled": false,
-    "size": "10Gi",
-    "storageClass": null,
     "whenDeleted": "Retain",
     "whenScaled": "Retain"
   },
@@ -1299,6 +1297,15 @@ null
 </td>
 		</tr>
 		<tr>
+			<td>bloomGateway.persistence.claims[0].size</td>
+			<td>string</td>
+			<td>Size of persistent disk</td>
+			<td><pre lang="json">
+"10Gi"
+</pre>
+</td>
+		</tr>
+		<tr>
 			<td>bloomGateway.persistence.enableStatefulSetAutoDeletePVC</td>
 			<td>bool</td>
 			<td>Enable StatefulSetAutoDeletePVC feature</td>
@@ -1313,24 +1320,6 @@ false
 			<td>Enable creating PVCs for the bloom-gateway</td>
 			<td><pre lang="json">
 false
-</pre>
-</td>
-		</tr>
-		<tr>
-			<td>bloomGateway.persistence.size</td>
-			<td>string</td>
-			<td>Size of persistent disk</td>
-			<td><pre lang="json">
-"10Gi"
-</pre>
-</td>
-		</tr>
-		<tr>
-			<td>bloomGateway.persistence.storageClass</td>
-			<td>string</td>
-			<td>Storage class to be used. If defined, storageClassName: <storageClass>. If set to "-", storageClassName: "", which disables dynamic provisioning. If empty or set to null, no storageClassName spec is set, choosing the default provisioner (gp2 on AWS, standard on GKE, AWS, and OpenStack).</td>
-			<td><pre lang="json">
-null
 </pre>
 </td>
 		</tr>
@@ -1492,11 +1481,15 @@ null
   "nodeSelector": {},
   "persistence": {
     "annotations": {},
-    "claims": [],
+    "claims": [
+      {
+        "name": "data",
+        "size": "10Gi",
+        "storageClass": null
+      }
+    ],
     "enableStatefulSetAutoDeletePVC": false,
     "enabled": false,
-    "size": "10Gi",
-    "storageClass": null,
     "whenDeleted": "Retain",
     "whenScaled": "Retain"
   },
@@ -1680,7 +1673,16 @@ null
 			<td>list</td>
 			<td>List of the bloom-planner PVCs</td>
 			<td><pre lang="list">
-[]
+
+</pre>
+</td>
+		</tr>
+		<tr>
+			<td>bloomPlanner.persistence.claims[0].size</td>
+			<td>string</td>
+			<td>Size of persistent disk</td>
+			<td><pre lang="json">
+"10Gi"
 </pre>
 </td>
 		</tr>
@@ -1699,24 +1701,6 @@ false
 			<td>Enable creating PVCs for the bloom-planner</td>
 			<td><pre lang="json">
 false
-</pre>
-</td>
-		</tr>
-		<tr>
-			<td>bloomPlanner.persistence.size</td>
-			<td>string</td>
-			<td>Size of persistent disk</td>
-			<td><pre lang="json">
-"10Gi"
-</pre>
-</td>
-		</tr>
-		<tr>
-			<td>bloomPlanner.persistence.storageClass</td>
-			<td>string</td>
-			<td>Storage class to be used. If defined, storageClassName: <storageClass>. If set to "-", storageClassName: "", which disables dynamic provisioning. If empty or set to null, no storageClassName spec is set, choosing the default provisioner (gp2 on AWS, standard on GKE, AWS, and OpenStack).</td>
-			<td><pre lang="json">
-null
 </pre>
 </td>
 		</tr>

--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -16,6 +16,7 @@ Entries should include a reference to the pull request that introduced the chang
 ## 6.13.0
 
 - [CHANGE] Correctly wrap ClusterRoleBinding around `rbac/namespaced` conditional.
+- [FIX] Configure (emphemeral) storage for bloom builder working directory
 - [ENHANCEMENT] Automatically configure bloom planner address for bloom builders and bloom gateway addresses for bloom gateway clients.
 
 ## 6.12.0

--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -16,6 +16,7 @@ Entries should include a reference to the pull request that introduced the chang
 ## 6.13.0
 
 - [CHANGE] Correctly wrap ClusterRoleBinding around `rbac/namespaced` conditional.
+- [ENHANCEMENT] Automatically configure bloom planner address for bloom builders and bloom gateway addresses for bloom gateway clients.
 
 ## 6.12.0
 

--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -17,7 +17,7 @@ Entries should include a reference to the pull request that introduced the chang
 
 - [CHANGE] Correctly wrap ClusterRoleBinding around `rbac/namespaced` conditional.
 - [FIX] Do not create bloom planner, bloom builder, bloom gateway Deployment/Statefulset if their replica count is 0.
-- [FIX] Configure (emphemeral) storage for bloom builder working directory
+- [FIX] Configure (ephemeral) storage for bloom builder working directory
 - [ENHANCEMENT] Automatically configure bloom planner address for bloom builders and bloom gateway addresses for bloom gateway clients.
 
 ## 6.12.0

--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -16,6 +16,7 @@ Entries should include a reference to the pull request that introduced the chang
 ## 6.13.0
 
 - [CHANGE] Correctly wrap ClusterRoleBinding around `rbac/namespaced` conditional.
+- [FIX] Do not create bloom planner, bloom builder, bloom gateway Deployment/Statefulset if their replica count is 0.
 - [FIX] Configure (emphemeral) storage for bloom builder working directory
 - [ENHANCEMENT] Automatically configure bloom planner address for bloom builders and bloom gateway addresses for bloom gateway clients.
 

--- a/production/helm/loki/templates/_helpers.tpl
+++ b/production/helm/loki/templates/_helpers.tpl
@@ -1047,6 +1047,34 @@ enableServiceLinks: false
 {{- printf "%s" $idxGatewayAddress }}
 {{- end }}
 
+{{/* Determine bloom-planner address */}}
+{{- define "loki.bloomPlannerAddress" -}}
+{{- $bloomPlannerAddress := ""}}
+{{- $isDistributed := eq (include "loki.deployment.isDistributed" .) "true" -}}
+{{- $isScalable := eq (include "loki.deployment.isScalable" .) "true" -}}
+{{- if $isDistributed -}}
+{{- $bloomPlannerAddress = printf "%s-headless.%s.svc.%s:%s" (include "loki.bloomPlannerFullname" .) .Release.Namespace .Values.global.clusterDomain (.Values.loki.server.grpc_listen_port | toString) -}}
+{{- end -}}
+{{- if $isScalable -}}
+{{- $bloomPlannerAddress = printf "%s-headless.%s.svc.%s:%s" (include "loki.backendFullname" .) .Release.Namespace .Values.global.clusterDomain (.Values.loki.server.grpc_listen_port | toString) -}}
+{{- end -}}
+{{- printf "%s" $bloomPlannerAddress}}
+{{- end }}
+
+{{/* Determine bloom-gateway address */}}
+{{- define "loki.bloomGatewayAddresses" -}}
+{{- $bloomGatewayAddresses := ""}}
+{{- $isDistributed := eq (include "loki.deployment.isDistributed" .) "true" -}}
+{{- $isScalable := eq (include "loki.deployment.isScalable" .) "true" -}}
+{{- if $isDistributed -}}
+{{- $bloomGatewayAddresses = printf "dnssrvnoa+_grpc._tcp.%s-headless.%s.svc.%s" (include "loki.bloomGatewayFullname" .) .Release.Namespace .Values.global.clusterDomain -}}
+{{- end -}}
+{{- if $isScalable -}}
+{{- $bloomGatewayAddresses = printf "dnssrvnoa+_grpc._tcp.%s-headless.%s.svc.%s" (include "loki.backendFullname" .) .Release.Namespace .Values.global.clusterDomain -}}
+{{- end -}}
+{{- printf "%s" $bloomGatewayAddresses}}
+{{- end }}
+
 {{- define "loki.config.checksum" -}}
 checksum/config: {{ include (print .Template.BasePath "/config.yaml") . | sha256sum }}
 {{- end -}}

--- a/production/helm/loki/templates/bloom-builder/deployment-bloom-builder.yaml
+++ b/production/helm/loki/templates/bloom-builder/deployment-bloom-builder.yaml
@@ -1,5 +1,5 @@
 {{- $isDistributed := eq (include "loki.deployment.isDistributed" .) "true" -}}
-{{- if $isDistributed -}}
+{{- if (and $isDistributed (gt (int .Values.bloomPlanner.replicas) 0)) -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/production/helm/loki/templates/bloom-builder/deployment-bloom-builder.yaml
+++ b/production/helm/loki/templates/bloom-builder/deployment-bloom-builder.yaml
@@ -101,6 +101,10 @@ spec:
             - name: license
               mountPath: /etc/loki/license
             {{- end }}
+            - name: temp
+              mountPath: /tmp
+            - name: data
+              mountPath: /var/loki
             {{- with .Values.bloomBuilder.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -136,6 +140,10 @@ spec:
             secretName: enterprise-logs-license
           {{- end }}
         {{- end }}
+        - name: temp
+          emptyDir: {}
+        - name: data
+          emptyDir: {}
         {{- with .Values.bloomBuilder.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/production/helm/loki/templates/bloom-builder/service-bloom-builder-headless.yaml
+++ b/production/helm/loki/templates/bloom-builder/service-bloom-builder-headless.yaml
@@ -1,5 +1,5 @@
 {{- $isDistributed := eq (include "loki.deployment.isDistributed" .) "true" -}}
-{{- if $isDistributed -}}
+{{- if (and $isDistributed (or (gt (int .Values.bloomBuilder.replicas) 0)) .Values.bloomBuilder.autoscaling.enabled) -}}
 apiVersion: v1
 kind: Service
 metadata:

--- a/production/helm/loki/templates/bloom-builder/service-bloom-builder.yaml
+++ b/production/helm/loki/templates/bloom-builder/service-bloom-builder.yaml
@@ -1,5 +1,5 @@
 {{- $isDistributed := eq (include "loki.deployment.isDistributed" .) "true" -}}
-{{- if $isDistributed -}}
+{{- if (and $isDistributed (gt (int .Values.bloomBuilder.replicas) 0)) -}}
 apiVersion: v1
 kind: Service
 metadata:

--- a/production/helm/loki/templates/bloom-gateway/statefulset-bloom-gateway.yaml
+++ b/production/helm/loki/templates/bloom-gateway/statefulset-bloom-gateway.yaml
@@ -1,6 +1,5 @@
 {{- $isDistributed := eq (include "loki.deployment.isDistributed" .) "true" -}}
-{{- if $isDistributed }}
-{{- if (gt (int .Values.bloomGateway.replicas) 0) -}}
+{{- if (and $isDistributed (gt (int .Values.bloomGateway.replicas) 0)) -}}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -179,5 +178,4 @@ spec:
             storage: {{ .size | quote }}
   {{- end }}
   {{- end }}
-{{- end -}}
 {{- end -}}

--- a/production/helm/loki/templates/bloom-planner/service-bloom-planner-headless.yaml
+++ b/production/helm/loki/templates/bloom-planner/service-bloom-planner-headless.yaml
@@ -1,6 +1,5 @@
 {{- $isDistributed := eq (include "loki.deployment.isDistributed" .) "true" -}}
-{{- if $isDistributed -}}
-{{- if (gt (int .Values.bloomPlanner.replicas) 0) -}}
+{{- if (and $isDistributed (gt (int .Values.bloomPlanner.replicas) 0)) -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -32,5 +31,4 @@ spec:
       {{- end }}
   selector:
     {{- include "loki.bloomPlannerSelectorLabels" . | nindent 4 }}
-{{- end -}}
 {{- end -}}

--- a/production/helm/loki/templates/bloom-planner/statefulset-bloom-planner.yaml
+++ b/production/helm/loki/templates/bloom-planner/statefulset-bloom-planner.yaml
@@ -1,6 +1,5 @@
 {{- $isDistributed := eq (include "loki.deployment.isDistributed" .) "true" -}}
-{{- if $isDistributed }}
-{{- if (gt (int .Values.bloomPlanner.replicas) 0) -}}
+{{- if (and $isDistributed (gt (int .Values.bloomPlanner.replicas) 0)) -}}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -179,5 +178,4 @@ spec:
             storage: {{ .size | quote }}
   {{- end }}
   {{- end }}
-{{- end -}}
 {{- end -}}

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -2463,20 +2463,13 @@ bloomGateway:
   persistence:
     # -- Enable creating PVCs for the bloom-gateway
     enabled: false
-    # -- Size of persistent disk
-    size: 10Gi
-    # -- Storage class to be used.
-    # If defined, storageClassName: <storageClass>.
-    # If set to "-", storageClassName: "", which disables dynamic provisioning.
-    # If empty or set to null, no storageClassName spec is
-    # set, choosing the default provisioner (gp2 on AWS, standard on GKE, AWS, and OpenStack).
-    storageClass: null
     # -- Annotations for bloom-gateway PVCs
     annotations: {}
     # -- List of the bloom-gateway PVCs
     # @notationType -- list
     claims:
       - name: data
+        # -- Size of persistent disk
         size: 10Gi
         #   -- Storage class to be used.
         #   If defined, storageClassName: <storageClass>.
@@ -2484,8 +2477,6 @@ bloomGateway:
         #   If empty or set to null, no storageClassName spec is
         #   set, choosing the default provisioner (gp2 on AWS, standard on GKE, AWS, and OpenStack).
         storageClass: null
-        # - name: wal
-        #   size: 150Gi
     # -- Enable StatefulSetAutoDeletePVC feature
     enableStatefulSetAutoDeletePVC: false
     whenDeleted: Retain
@@ -2569,19 +2560,20 @@ bloomPlanner:
   persistence:
     # -- Enable creating PVCs for the bloom-planner
     enabled: false
-    # -- Size of persistent disk
-    size: 10Gi
-    # -- Storage class to be used.
-    # If defined, storageClassName: <storageClass>.
-    # If set to "-", storageClassName: "", which disables dynamic provisioning.
-    # If empty or set to null, no storageClassName spec is
-    # set, choosing the default provisioner (gp2 on AWS, standard on GKE, AWS, and OpenStack).
-    storageClass: null
     # -- Annotations for bloom-planner PVCs
     annotations: {}
     # -- List of the bloom-planner PVCs
     # @notationType -- list
-    claims: []
+    claims:
+      - name: data
+        # -- Size of persistent disk
+        size: 10Gi
+        #   -- Storage class to be used.
+        #   If defined, storageClassName: <storageClass>.
+        #   If set to "-", storageClassName: "", which disables dynamic provisioning.
+        #   If empty or set to null, no storageClassName spec is
+        #   set, choosing the default provisioner (gp2 on AWS, standard on GKE, AWS, and OpenStack).
+        storageClass: null
     # -- Enable StatefulSetAutoDeletePVC feature
     enableStatefulSetAutoDeletePVC: false
     whenDeleted: Retain

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -279,6 +279,16 @@ loki:
 
     tracing:
       enabled: {{ .Values.loki.tracing.enabled }}
+
+    {{- with .Values.loki.bloom_build }}
+    bloom_build:
+      {{- tpl (. | toYaml) $ | nindent 4 }}
+    {{- end }}
+
+    {{- with .Values.loki.bloom_gateway }}
+    bloom_gateway:
+      {{- tpl (. | toYaml) $ | nindent 4 }}
+    {{- end }}
   # Should authentication be enabled
   auth_enabled: true
   # -- memberlist configuration (overrides embedded default)
@@ -410,6 +420,8 @@ loki:
     tsdb_shipper:
       index_gateway_client:
         server_address: '{{ include "loki.indexGatewayAddress" . }}'
+    bloom_shipper:
+      working_directory: /var/loki/data/bloomshipper
     hedging:
       at: "250ms"
       max_per_second: 20
@@ -442,8 +454,12 @@ loki:
     enabled: false
   bloom_build:
     enabled: false
+    builder:
+      planner_address: '{{ include "loki.bloomPlannerAddress" . }}'
   bloom_gateway:
     enabled: false
+    client:
+      addresses: '{{ include "loki.bloomGatewayAddresses" . }}'
 ######################################################################################################################
 #
 # Enterprise Loki Configs


### PR DESCRIPTION
**What this PR does / why we need it**:

* Fix: Do not create bloom Deployment/Statefulset if replicas=0 (fixes https://github.com/grafana/loki/issues/14090)
* Fix: Configure PV claims for bloom gateway and bloom builder correctly (fixes https://github.com/grafana/loki/issues/14082)
* Fix: Configure emphemeral storage for bloom builder working directory (fixes https://github.com/grafana/loki/issues/14084)
* Add required configuration for bloom builder and bloom gateway

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
