### PR TITLE
tests(blooms): Adapt test fixture for generating blooms

### DIFF
--- a/pkg/bloomgateway/bloomgateway_test.go
+++ b/pkg/bloomgateway/bloomgateway_test.go
@@ -403,16 +403,14 @@ func TestBloomGateway_FilterChunkRefs(t *testing.T) {
 			inputChunkRefs := groupRefs(t, chunkRefs)
 			// Hack to get search string for a specific series
 			// see MkBasicSeriesWithBlooms() in pkg/storage/bloom/v1/test_util.go
-			// each series has 1 chunk
-			// each chunk has multiple strings, from int(fp) to int(nextFp)-1
-			x := rand.Intn(len(inputChunkRefs))
-			fp := inputChunkRefs[x].Fingerprint
-			chks := inputChunkRefs[x].Refs
-			line := fmt.Sprintf("%04x:%04x", int(fp), 0) // first line
+			rnd := rand.Intn(len(inputChunkRefs))
+			fp := inputChunkRefs[rnd].Fingerprint
+			chks := inputChunkRefs[rnd].Refs
+			key := fmt.Sprintf("%s:%04x", model.Fingerprint(fp), 0)
 
-			t.Log("x=", x, "fp=", fp, "line=", line)
+			t.Log("rnd=", rnd, "fp=", fp, "key=", key)
 
-			expr, err := syntax.ParseExpr(fmt.Sprintf(`{foo="bar"} |= "%s"`, line))
+			expr, err := syntax.ParseExpr(fmt.Sprintf(`{foo="bar"} | trace_id="%s"`, key))
 			require.NoError(t, err)
 
 			req := &logproto.FilterChunkRefRequest{

--- a/pkg/storage/bloom/v1/fuse_test.go
+++ b/pkg/storage/bloom/v1/fuse_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"math"
 	"sync"
 	"testing"
 
@@ -27,13 +28,14 @@ var BloomPagePool = mempool.New("test", []mempool.Bucket{
 // TODO(owen-d): this is unhinged from the data it represents. I'm leaving this solely so I don't
 // have to refactor tests here in order to fix this elsewhere, but it can/should be fixed --
 // the skip & n len are hardcoded based on data that's passed to it elsewhere.
+// TODO(chaudum): Can be removed once matching with structured metadata is implemented.
 type fakeNgramBuilder struct{}
 
-func (f fakeNgramBuilder) N() int          { return 4 }
+func (f fakeNgramBuilder) N() int          { return math.MaxInt } // do not tokenize
 func (f fakeNgramBuilder) SkipFactor() int { return 0 }
 
-func (f fakeNgramBuilder) Tokens(line string) v2.Iterator[[]byte] {
-	return v2.NewSliceIter[[]byte]([][]byte{[]byte(line)})
+func (f fakeNgramBuilder) Tokens(key string) v2.Iterator[[]byte] {
+	return v2.NewSliceIter[[]byte]([][]byte{[]byte(key)})
 }
 
 func keysToBloomTest(keys [][]byte) BloomTest {

--- a/pkg/storage/bloom/v1/test_util.go
+++ b/pkg/storage/bloom/v1/test_util.go
@@ -9,9 +9,9 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/loki/pkg/push"
 	"github.com/grafana/loki/v3/pkg/chunkenc"
 	iter "github.com/grafana/loki/v3/pkg/iter/v2"
-	"github.com/grafana/loki/v3/pkg/storage/bloom/v1/filter"
 )
 
 // TODO(owen-d): this should probably be in it's own testing-util package
@@ -46,94 +46,73 @@ func MakeBlock(t testing.TB, nth int, fromFp, throughFp model.Fingerprint, fromT
 	return block, data, keys
 }
 
-// This is a helper type used in tests that buffers blooms and can be turned into
-// the commonly used iterator form *SeriesWithBlooms.
-type SeriesWithLiteralBlooms struct {
-	Series *Series
-	Blooms []*Bloom
-}
-
-func (s *SeriesWithLiteralBlooms) SeriesWithBlooms() SeriesWithBlooms {
-	offsets := make([]BloomOffset, 0, len(s.Blooms))
-	for i := range s.Blooms {
+func newSeriesWithBlooms(series Series, blooms []*Bloom) SeriesWithBlooms {
+	offsets := make([]BloomOffset, 0, len(blooms))
+	for i := range blooms {
 		offsets = append(offsets, BloomOffset{Page: i, ByteOffset: 0})
 	}
 	return SeriesWithBlooms{
 		Series: &SeriesWithMeta{
-			Series: *s.Series,
+			Series: series,
 			Meta: Meta{
 				Fields:  NewSetFromLiteral[Field]("trace_id"),
 				Offsets: offsets,
 			},
 		},
-		Blooms: iter.NewSliceIter(s.Blooms),
+		Blooms: iter.NewSliceIter(blooms),
 	}
 }
 
-func MkBasicSeriesWithBlooms(nSeries int, fromFp, throughFp model.Fingerprint, fromTs, throughTs model.Time) (seriesList []SeriesWithBlooms, keysList [][][]byte) {
-	series, keys := MkBasicSeriesWithLiteralBlooms(nSeries, fromFp, throughFp, fromTs, throughTs)
-	mapped := make([]SeriesWithBlooms, 0, len(series))
-	for _, s := range series {
-		v := s.SeriesWithBlooms()
-		mapped = append(mapped, v)
-	}
+func MkBasicSeriesWithBlooms(nSeries int, fromFp, throughFp model.Fingerprint, fromTs, throughTs model.Time) ([]SeriesWithBlooms, [][][]byte) {
+	// return values
+	seriesList := make([]SeriesWithBlooms, 0, nSeries)
+	keysList := make([][][]byte, 0, nSeries)
 
-	return mapped, keys
-}
-
-func MkBasicSeriesWithLiteralBlooms(nSeries int, fromFp, throughFp model.Fingerprint, fromTs, throughTs model.Time) (seriesList []SeriesWithLiteralBlooms, keysList [][][]byte) {
-	const nGramLen = 4
-	seriesList = make([]SeriesWithLiteralBlooms, 0, nSeries)
-	keysList = make([][][]byte, 0, nSeries)
+	numChunksPerSeries := 10
+	numBloomsPerSeries := 2
 
 	step := (throughFp - fromFp) / model.Fingerprint(nSeries)
-	timeDelta := time.Duration(throughTs.Sub(fromTs).Nanoseconds() / int64(nSeries))
+	timeDelta := time.Duration(throughTs.Sub(fromTs).Nanoseconds() / int64(numChunksPerSeries))
 
-	tokenizer := NewNGramTokenizer(nGramLen, 0)
 	for i := 0; i < nSeries; i++ {
 		var series Series
-		series.Fingerprint = fromFp + model.Fingerprint(i)*step
-		from := fromTs.Add(timeDelta * time.Duration(i))
-		series.Chunks = []ChunkRef{
-			{
-				From:     from,
-				Through:  from.Add(timeDelta),
-				Checksum: uint32(i),
-			},
-		}
+		var blooms []*Bloom
 
-		var bloom Bloom
-		bloom.ScalableBloomFilter = *filter.NewScalableBloomFilter(1024, 0.01, 0.8)
+		series.Fingerprint = fromFp + model.Fingerprint(i)*step
+		for from := fromTs; from < throughTs; from = from.Add(timeDelta) {
+			series.Chunks = append(series.Chunks,
+				ChunkRef{
+					From:    from,
+					Through: from.Add(timeDelta),
+				},
+			)
+		}
 
 		keys := make([][]byte, 0, int(step))
-		for _, chk := range series.Chunks {
-			tokenBuf, prefixLen := prefixedToken(nGramLen, chk, nil)
 
-			for j := 0; j < int(step); j++ {
-				line := fmt.Sprintf("%04x:%04x", int(series.Fingerprint), j)
-				it := tokenizer.Tokens(line)
+		chunkBatchSize := (series.Chunks.Len() + numBloomsPerSeries - 1) / numBloomsPerSeries
+		for j := 0; j < numBloomsPerSeries; j++ {
+			bloom := NewBloom()
+
+			batchStart, batchEnd := j*chunkBatchSize, min(series.Chunks.Len(), (j+1)*chunkBatchSize)
+			for x, chk := range series.Chunks[batchStart:batchEnd] {
+				tokenizer := NewStructuredMetadataTokenizer(string(prefixForChunkRef(chk)))
+				kv := push.LabelAdapter{Name: "trace_id", Value: fmt.Sprintf("%s:%04x", series.Fingerprint, j*chunkBatchSize+x)}
+				it := tokenizer.Tokens(kv)
 				for it.Next() {
-					key := it.At()
-					// series-level key
+					key := []byte(it.At())
 					bloom.Add(key)
-
-					// chunk-level key
-					tokenBuf = append(tokenBuf[:prefixLen], key...)
-					bloom.Add(tokenBuf)
-
-					keyCopy := key
-					keys = append(keys, keyCopy)
+					keys = append(keys, key)
 				}
 			}
+			blooms = append(blooms, bloom)
 		}
 
-		seriesList = append(seriesList, SeriesWithLiteralBlooms{
-			Series: &series,
-			Blooms: []*Bloom{&bloom},
-		})
+		seriesList = append(seriesList, newSeriesWithBlooms(series, blooms))
 		keysList = append(keysList, keys)
 	}
-	return
+
+	return seriesList, keysList
 }
 
 func EqualIterators[T any](t *testing.T, test func(a, b T), expected, actual iter.Iterator[T]) {

--- a/pkg/storage/bloom/v1/versioned_builder_test.go
+++ b/pkg/storage/bloom/v1/versioned_builder_test.go
@@ -28,9 +28,9 @@ func smallBlockOpts(v Version, enc chunkenc.Encoding) BlockOptions {
 	}
 }
 
-func setup(v Version) (BlockOptions, []SeriesWithLiteralBlooms, BlockWriter, BlockReader) {
+func setup(v Version) (BlockOptions, []SeriesWithBlooms, BlockWriter, BlockReader) {
 	numSeries := 100
-	data, _ := MkBasicSeriesWithLiteralBlooms(numSeries, 0, 0xffff, 0, 10000)
+	data, _ := MkBasicSeriesWithBlooms(numSeries, 0, 0xffff, 0, 10000)
 	indexBuf := bytes.NewBuffer(nil)
 	bloomsBuf := bytes.NewBuffer(nil)
 	writer := NewMemoryBlockWriter(indexBuf, bloomsBuf)
@@ -39,61 +39,47 @@ func setup(v Version) (BlockOptions, []SeriesWithLiteralBlooms, BlockWriter, Blo
 }
 
 func TestV3Roundtrip(t *testing.T) {
-	opts, data, writer, reader := setup(V3)
+	opts, sourceData, writer, reader := setup(V3)
 
-	data, err := v2.Collect(
-		v2.NewMapIter[SeriesWithLiteralBlooms, SeriesWithLiteralBlooms](
-			v2.NewSliceIter(data),
-			func(swlb SeriesWithLiteralBlooms) SeriesWithLiteralBlooms {
-				return SeriesWithLiteralBlooms{
-					Series: swlb.Series,
-					// hack(owen-d): data currently only creates one bloom per series, but I want to test multiple.
-					// we're not checking the contents here, so ensuring the same bloom is used twice is fine.
-					Blooms: []*Bloom{swlb.Blooms[0], swlb.Blooms[0]},
-				}
-			},
-		),
-	)
-	require.NoError(t, err)
+	// SeriesWithBlooms holds an interator of blooms,
+	// which will be exhausted after being consumed by the block builder
+	// therefore we need a deepcopy of the original data, or - and that's easier to achieve -
+	// we simply create the same data twice.
+	_, unmodifiedData, _, _ := setup(V3)
 
 	b, err := NewBlockBuilderV3(opts, writer)
 	require.NoError(t, err)
 
-	mapped := v2.NewMapIter[SeriesWithLiteralBlooms](
-		v2.NewSliceIter(data),
-		func(s SeriesWithLiteralBlooms) SeriesWithBlooms {
-			return s.SeriesWithBlooms()
-		},
-	)
-
-	_, err = b.BuildFrom(mapped)
+	_, err = b.BuildFrom(v2.NewSliceIter(sourceData))
 	require.NoError(t, err)
 
 	// Ensure Equality
 	block := NewBlock(reader, NewMetrics(nil))
 	querier := NewBlockQuerier(block, &mempool.SimpleHeapAllocator{}, DefaultMaxPageSize).Iter()
 
-	CompareIterators[SeriesWithLiteralBlooms, *SeriesWithBlooms](
+	CompareIterators[SeriesWithBlooms, *SeriesWithBlooms](
 		t,
-		func(t *testing.T, a SeriesWithLiteralBlooms, b *SeriesWithBlooms) {
-			require.Equal(t, *a.Series, b.Series.Series) // ensure series equality
-			bs, err := v2.Collect(b.Blooms)
+		func(t *testing.T, a SeriesWithBlooms, b *SeriesWithBlooms) {
+			require.Equal(t, a.Series.Series.Fingerprint, b.Series.Series.Fingerprint)
+			require.ElementsMatch(t, a.Series.Series.Chunks, b.Series.Series.Chunks)
+			bloomsA, err := v2.Collect(a.Blooms)
+			require.NoError(t, err)
+			bloomsB, err := v2.Collect(b.Blooms)
 			require.NoError(t, err)
 
-			// ensure we only have one bloom in v1
-			require.Equal(t, 2, len(a.Blooms))
-			require.Equal(t, 2, len(bs))
+			require.Equal(t, 2, len(bloomsA))
+			require.Equal(t, 2, len(bloomsB))
 
 			var encA, encB encoding.Encbuf
-			for i := range a.Blooms {
-				require.NoError(t, a.Blooms[i].Encode(&encA))
-				require.NoError(t, bs[i].Encode(&encB))
+			for i := range bloomsA {
+				require.NoError(t, bloomsA[i].Encode(&encA))
+				require.NoError(t, bloomsB[i].Encode(&encB))
 				require.Equal(t, encA.Get(), encB.Get())
 				encA.Reset()
 				encB.Reset()
 			}
 		},
-		v2.NewSliceIter(data),
+		v2.NewSliceIter(unmodifiedData),
 		querier,
 	)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

* Build SeriesWithBlooms with multiple pages
* Do not use n-gram tokenizer to generate indexed keys
* Remove SeriesWithLiteralBlooms data structure

This should lead to higher confidence into our tests.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
