### PR TITLE
chore(ci/cd): Unblock CI

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   main:
+    if: github.repository == 'grafana/loki'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Actions
@@ -21,6 +22,6 @@ jobs:
         uses: ./actions/backport
         with:
           metricsWriteAPIKey: ${{secrets.GRAFANA_MISC_STATS_API_KEY}}
-          token: ${{secrets.GH_BOT_ACCESS_TOKEN}}
+          token: ${{secrets.GH_TOKEN}}
           labelsToAdd: "backport"
           title: "chore: [{{base}}] {{originalTitle}}"

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -22,6 +22,6 @@ jobs:
         uses: ./actions/backport
         with:
           metricsWriteAPIKey: ${{secrets.GRAFANA_MISC_STATS_API_KEY}}
-          token: ${{secrets.GH_TOKEN}}
+          token: ${{secrets.GITHUB_TOKEN}}
           labelsToAdd: "backport"
           title: "chore: [{{base}}] {{originalTitle}}"


### PR DESCRIPTION
Using the same workflow configuration as [grafana/pyroscope](https://github.com/grafana/pyroscope).

https://github.com/grafana/pyroscope/blob/c85a30aefa7574a1ed81e3bee8ade2745e664aef/.github/workflows/backport.yml

**Special notes for your reviewer**:

While this will make the CI check for "Backport PR Creator" succeed, the actual backporting may still fail.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
