### PR TITLE
chore: replace remaining references to ExtractTestableLineFilters

### DIFF
--- a/pkg/bloomgateway/querier.go
+++ b/pkg/bloomgateway/querier.go
@@ -103,7 +103,7 @@ func convertToShortRef(ref *logproto.ChunkRef) *logproto.ShortRef {
 
 func (bq *BloomQuerier) FilterChunkRefs(ctx context.Context, tenant string, from, through model.Time, chunkRefs []*logproto.ChunkRef, queryPlan plan.QueryPlan) ([]*logproto.ChunkRef, error) {
 	// Shortcut that does not require any filtering
-	if !bq.limits.BloomGatewayEnabled(tenant) || len(chunkRefs) == 0 || len(v1.ExtractTestableLineFilters(queryPlan.AST)) == 0 {
+	if !bq.limits.BloomGatewayEnabled(tenant) || len(chunkRefs) == 0 || len(v1.ExtractTestableLabelMatchers(queryPlan.AST)) == 0 {
 		return chunkRefs, nil
 	}
 

--- a/pkg/bloomgateway/querier_test.go
+++ b/pkg/bloomgateway/querier_test.go
@@ -93,7 +93,7 @@ func TestBloomQuerier(t *testing.T) {
 		through := model.Now()
 		from := through.Add(-12 * time.Hour)
 		chunkRefs := []*logproto.ChunkRef{}
-		expr, err := syntax.ParseExpr(`{foo="bar"} |= "uuid"`)
+		expr, err := syntax.ParseExpr(`{foo="bar"} | trace_id="exists"`)
 		require.NoError(t, err)
 		res, err := bq.FilterChunkRefs(ctx, tenant, from, through, chunkRefs, plan.QueryPlan{AST: expr})
 		require.NoError(t, err)
@@ -113,7 +113,7 @@ func TestBloomQuerier(t *testing.T) {
 			{Fingerprint: 1000, UserID: tenant, From: from, Through: through, Checksum: 2},
 			{Fingerprint: 2000, UserID: tenant, From: from, Through: through, Checksum: 3},
 		}
-		expr, err := syntax.ParseExpr(`{foo="bar"} |= "uuid"`)
+		expr, err := syntax.ParseExpr(`{foo="bar"} | trace_id="exists"`)
 		require.NoError(t, err)
 		res, err := bq.FilterChunkRefs(ctx, tenant, from, through, chunkRefs, plan.QueryPlan{AST: expr})
 		require.Error(t, err)
@@ -132,7 +132,7 @@ func TestBloomQuerier(t *testing.T) {
 			{Fingerprint: 2000, UserID: tenant, From: mktime("2024-04-16 23:30"), Through: mktime("2024-04-17 00:30"), Checksum: 2}, // day 1
 			{Fingerprint: 3000, UserID: tenant, From: mktime("2024-04-17 00:30"), Through: mktime("2024-04-17 01:30"), Checksum: 3}, // day 2
 		}
-		expr, err := syntax.ParseExpr(`{foo="bar"} |= "uuid"`)
+		expr, err := syntax.ParseExpr(`{foo="bar"} | trace_id="exists"`)
 		require.NoError(t, err)
 		res, err := bq.FilterChunkRefs(ctx, tenant, from, through, chunkRefs, plan.QueryPlan{AST: expr})
 		require.NoError(t, err)

--- a/pkg/indexgateway/gateway.go
+++ b/pkg/indexgateway/gateway.go
@@ -248,7 +248,7 @@ func (g *Gateway) GetChunkRef(ctx context.Context, req *logproto.GetChunkRefRequ
 
 	// Extract LineFiltersExpr from the plan. If there is none, we can short-circuit and return before making a req
 	// to the bloom-gateway (through the g.bloomQuerier)
-	if len(v1.ExtractTestableLineFilters(req.Plan.AST)) == 0 {
+	if len(v1.ExtractTestableLabelMatchers(req.Plan.AST)) == 0 {
 		return result, nil
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The bloomgateway and indexgateway still had logic checking for line filters instead of label matcher expressions.


**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
