### PR TITLE
chore(blooms): Replace extracting line filters with extracting label filters

### DIFF
--- a/pkg/indexgateway/gateway.go
+++ b/pkg/indexgateway/gateway.go
@@ -246,8 +246,9 @@ func (g *Gateway) GetChunkRef(ctx context.Context, req *logproto.GetChunkRefRequ
 		return result, nil
 	}
 
-	// Extract LineFiltersExpr from the plan. If there is none, we can short-circuit and return before making a req
-	// to the bloom-gateway (through the g.bloomQuerier)
+	// Extract testable LabelFilters from the plan. If there is none, we can
+	// short-circuit and return before making a req to the bloom-gateway (through
+	// the g.bloomQuerier)
 	if len(v1.ExtractTestableLabelMatchers(req.Plan.AST)) == 0 {
 		return result, nil
 	}
@@ -464,7 +465,7 @@ func (g *Gateway) boundedShards(
 	filtered := refs
 
 	// 2) filter via blooms if enabled
-	filters := syntax.ExtractLineFilters(p.Plan().AST)
+	filters := v1.ExtractTestableLabelMatchers(p.Plan().AST)
 	if g.bloomQuerier != nil && len(filters) > 0 {
 		xs, err := g.bloomQuerier.FilterChunkRefs(ctx, instanceID, req.From, req.Through, refs, p.Plan())
 		if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

Replace the logic for extracting line filters with extracting label filters on the bloom gateway client, because otherwise the bloom gateway server would receive requests with no label matchers.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
