### PR TITLE
docs: Reorganize Query Templates page

### DIFF
--- a/docs/sources/query/template_functions.md
+++ b/docs/sources/query/template_functions.md
@@ -1,31 +1,31 @@
 ---
-title: Template functions
-menuTItle:  
-description: Describes functions that are supported by the Go text template.
-aliases: 
+title: LogQL template functions
+menuTItle:  Template functions
+description: Describes query functions that are supported by the Go text template.
+aliases:
 - ../logql/template_functions/
 weight: 30
 ---
 
-# Template functions
+# LogQL template functions
 
+The Go templating language is embedded in the Loki query language, LogQL.
 The [text template](https://golang.org/pkg/text/template) format used in `| line_format` and `| label_format` support the usage of functions.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 In the examples below we use backticks to quote the template strings. This is because some template strings contain double quotes, and using backticks lets us avoid escaping the double quotes.
 If you are using a different quoting style, you may need to escape the double quotes.
-{{% /admonition %}}
+{{< /admonition >}}
 
-All labels are added as variables in the template engine. They can be referenced using they label name prefixed by a `.`(e.g `.label_name`). For example the following template will output the value of the path label:
+For more information, refer to the [Go template documentation](https://pkg.go.dev/text/template).
 
-```template
-`{{ .path }}`
-```
+Additionally you can also access the log line using the `__line__` function and the timestamp using the `__timestamp__` function.
 
-Additionally you can also access the log line using the [`__line__`](#__line__) function and the timestamp using the [`__timestamp__`](#__timestamp__) function.
+## Template pipeline syntax
+
+A pipeline is a possibly chained sequence of "commands". A command is a simple value (argument) or a function or method call, possibly with multiple arguments. A pipeline may be "chained" by separating a sequence of commands with pipeline characters '|'. In a chained pipeline, the result of each command is passed as the last argument of the following command. The output of the final command in the pipeline is the value of the pipeline.
 
 You can take advantage of [pipeline](https://golang.org/pkg/text/template/#hdr-Pipelines) to join together multiple functions.
-In a chained pipeline, the result of each command is passed as the last argument of the following command.
 
 Example:
 
@@ -40,12 +40,24 @@ Example:
 ```template
 `{{ if and (contains "he" "hello") (contains "llo" "hello") }} yes {{end}}`
 `{{ if or (contains "he" "hello") (contains("llo" "hello") }} yes {{end}}`
-`{{ if contains "ErrTimeout" .err }} timeout {{else if contains "he" "hello"}} yes {{else}} no {{end}}`
+`{{ if contains .err "ErrTimeout" }} timeout {{else if contains "he" "hello"}} yes {{else}} no {{end}}`
 ```
 
-## __line__
+## Built-in variables for Log line properties
 
-This function returns the current log line.
+These variables provide a way of referencing something from the log line when writing a template expression.
+
+### .label_name
+
+All labels from the Log line are added as variables in the template engine. They can be referenced using the label name prefixed by a `.`(for example,`.label_name`). For example the following template will output the value of the `path` label:
+
+```template
+`{{ .path }}`
+```
+
+### __line__
+
+The `__line__` function returns the current log line.
 
 Signature: `line() string`
 
@@ -56,9 +68,9 @@ Examples:
 `{{ __line__ }}`
 ```
 
-## __timestamp__
+### __timestamp__
 
-This function returns the current log lines timestamp.
+The `__timestamp__` function returns the current log line's timestamp.
 
 Signature: `timestamp() time.Time`
 
@@ -68,27 +80,266 @@ Signature: `timestamp() time.Time`
 `{{ __timestamp__ | unixEpoch }}`
 ```
 
-See the blog: [Parsing and formatting date/time in Go](https://www.pauladamsmith.com/blog/2011/05/go_time.html) for more information.
+For more information, refer to the blog [Parsing and formatting date/time in Go](https://www.pauladamsmith.com/blog/2011/05/go_time.html).
 
-## regexReplaceAll and regexReplaceAllLiteral
+## Date and time
 
-`regexReplaceAll` returns a copy of the input string, replacing matches of the Regexp with the replacement string replacement. Inside string replacement, $ signs are interpreted as in Expand, so for instance $1 represents the text of the first sub-match. See the golang [Regexp.replaceAll documentation](https://golang.org/pkg/regexp/#Regexp.ReplaceAll) for more examples.
+You can use the following functions to manipulate dates and times when building LogQL queries.
 
-Example:
+### date
 
-```template
-`{{ regexReplaceAll "(a*)bc" .some_label "${1}a" }}`
-```
+Returns a textual representation of the time value formatted according to the provided [golang datetime layout](https://pkg.go.dev/time#pkg-constants).
 
-`regexReplaceAllLiteral` function returns a copy of the input string and replaces matches of the Regexp with the replacement string replacement. The replacement string is substituted directly, without using Expand.
+Signature: `date(fmt string, date interface{}) string`
 
 Example:
 
 ```template
-`{{ regexReplaceAllLiteral "(ts=)" .timestamp "timestamp=" }}`
+`{{ date "2006-01-02" now }}`
 ```
 
-## lower
+### duration
+
+An alias for `duration_seconds`
+
+Examples:
+
+```template
+`{{ .foo | duration }}`
+`{{ duration .foo }}`
+```
+
+### duration_seconds
+
+Convert a humanized time duration to seconds using [time.ParseDuration](https://pkg.go.dev/time#ParseDuration)
+
+Signature: `duration_seconds(string) float64`
+
+Examples:
+
+```template
+`{{ .foo | duration_seconds }}`
+`{{ duration_seconds .foo }}`
+```
+
+### now
+
+Returns the current time in the local timezone of the Loki server.
+
+Signature: `Now() time.Time`
+
+Example:
+
+```template
+`{{ now }}`
+```
+
+### toDate
+
+Parses a formatted string and returns the time value it represents using the local timezone of the server running Loki.
+
+For more consistency between Loki installations, it's recommended to use `toDateInZone`
+
+The format string must use the exact date as defined in the [golang datetime layout](https://pkg.go.dev/time#pkg-constants)
+
+Signature: `toDate(fmt, str string) time.Time`
+
+Examples:
+
+```template
+`{{ toDate "2006-01-02" "2021-11-02" }}`
+`{{ .foo | toDate "2006-01-02T15:04:05.999999999Z" }}`
+```
+
+### toDateInZone
+
+Parses a formatted string and returns the time value it represents in the provided timezone.
+
+The format string must use the exact date as defined in the [golang datetime layout](https://pkg.go.dev/time#pkg-constants)
+
+The timezone value can be `Local`, `UTC`, or any of the IANA Time Zone database values
+
+Signature: `toDateInZone(fmt, zone, str string) time.Time`
+
+Examples:
+
+```template
+`{{ toDateInZone "2006-01-02" "UTC" "2021-11-02" }}`
+`{{ .foo | toDateInZone "2006-01-02T15:04:05.999999999Z" "UTC" }}`
+```
+
+### unixEpoch
+
+Returns the number of seconds elapsed since January 1, 1970 UTC.
+
+Signature: `unixEpoch(date time.Time) string`
+
+Examples:
+
+```template
+`{{ unixEpoch now }}`
+`{{ .foo | toDateInZone "2006-01-02T15:04:05.999999999Z" "UTC" | unixEpoch }}`
+```
+
+Example of a query to filter Loki querier jobs which create time is 1 day before:
+
+```logql
+{job="loki/querier"} | label_format nowEpoch=`{{(unixEpoch now)}}`,createDateEpoch=`{{unixEpoch (toDate "2006-01-02" .createDate)}}` | label_format dateTimeDiff=`{{sub .nowEpoch .createDateEpoch}}` | dateTimeDiff > 86400
+```
+
+### unixEpochMillis
+
+Returns the number of milliseconds elapsed since January 1, 1970 UTC.
+
+Signature: `unixEpochMillis(date time.Time) string`
+
+Examples:
+
+```template
+`{{ unixEpochMillis now }}`
+`{{ .foo | toDateInZone "2006-01-02T15:04:05.999999999Z" "UTC" | unixEpochMillis }}`
+```
+
+### unixEpochNanos
+
+Returns the number of nanoseconds elapsed since January 1, 1970 UTC.
+
+Signature: `unixEpochNanos(date time.Time) string`
+
+Examples:
+
+```template
+`{{ unixEpochNanos now }}`
+`{{ .foo | toDateInZone "2006-01-02T15:04:05.999999999Z" "UTC" | unixEpochNanos }}`
+```
+
+### unixToTime
+
+Converts the string epoch to the time value it represents. Epoch times in days, seconds, milliseconds, microseconds and nanoseconds are supported.
+
+Signature: `unixToTime(epoch string) time.Time`
+
+Examples:
+
+Consider the following log line `{"from": "1679577215","to":"1679587215","message":"some message"}`. To print the `from` field as human readable add the following at the end of the LogQL query:
+
+```logql
+... | json | line_format `from="{{date "2006-01-02" (unixToTime .from)}}"`
+```
+
+## String manipulation
+
+You can use the following templates to manipulate strings when building LogQL Queries.
+
+### alignLeft
+
+Use this function to format a string to a fixed with, aligning the content to the left.
+
+Signature: `alignLeft(count int, src string) string`
+
+Examples:
+
+```template
+`{{ alignLeft 5 "hello world"}}` // output: "hello"
+`{{ alignLeft 5 "hi"}}`          // output: "hi   "
+```
+
+### alignRight
+
+Use this function to format a string to a fixed with, aligning the content to the right.
+
+Signature: `alignRight(count int, src string) string`
+
+Examples:
+
+```template
+`{{ alignRight 5 "hello world"}}` // output: "world"
+`{{ alignRight 5 "hi"}}`          // output: "   hi"
+```
+
+### b64enc
+
+Base64 encode a string.
+
+Signature: `b64enc(string) string`
+
+Examples:
+
+```template
+`{{ .foo | b64enc }}`
+`{{ b64enc  .foo }}`
+```
+
+### b64dec
+
+Base64 decode a string.
+
+Signature: `b64dec(string) string`
+
+Examples:
+
+```template
+`{{ .foo | b64dec }}`
+`{{ b64dec  .foo }}`
+```
+
+### bytes
+
+Convert a humanized byte string to bytes using go-humanize. Durations can be turned into strings such as "3 days ago", numbers
+representing sizes like 82854982 into useful strings like, "83 MB" or
+"79 MiB"
+
+Signature: `bytes(string) string`
+
+Examples:
+
+```template
+`{{ .foo | bytes }}`
+`{{ bytes .foo }}`
+```
+
+### default
+
+Enables outputting a default value if the source string is otherwise empty. If the 'src' parameter is not empty, this function returns the value of 'src'. Useful for JSON fields that can be missing, like HTTP headers in a log line that aren't required, as in the following example:
+
+```json
+{job="access_log"} | json | line_format `{{.http_request_headers_x_forwarded_for | default "-"}}`
+```
+
+Signature: `default(d string, src string) string`
+
+Examples:
+
+```template
+`{{ default "-" "" }}` // output: -
+`{{ default "-" "foo" }}` // output: foo
+```
+
+Example of a query to print a `-` if the `http_request_headers_x_forwarded_for` label is empty:
+
+```logql
+{job="access_log"} | json | line_format `{{.http_request_headers_x_forwarded_for | default "-"}}`
+```
+
+### fromJson
+
+Decodes a JSON document into a structure. If the input cannot be decoded as JSON the function will return an empty string.
+
+Signature: `fromJson(v string) interface{}`
+
+Example:
+
+```template
+`{{fromJson "{\"foo\": 55}"}}`
+```
+
+Example of a query to print a newline per queries stored as a json array in the log line:
+
+```logql
+{job="loki/querier"} |= "finish in prometheus" | logfmt | line_format `{{ range $q := fromJson .queries }} {{ $q.query }} {{ end }}`
+```
+
+### lower
 
 Use this function to convert to lower case.
 
@@ -103,69 +354,68 @@ Examples:
 
 The last example will return `hello`.
 
-## upper
+### indent
 
-Use this function to convert to upper case.
+The indent function indents every line in a given string to the specified indent width. This is useful when aligning multi-line strings.
 
-Signature: `upper(string) string`
+Signature: `indent(spaces int,src string) string`
+
+Example:
+
+```template
+`{{ indent 4 .query }}`
+```
+
+This indents each line contained in the `.query` by four (4) spaces.
+
+### nindent
+
+The nindent function is the same as the indent function, but prepends a new line to the beginning of the string.
+
+Signature: `nindent(spaces int,src string) string`
+
+Example:
+
+```template
+`{{ nindent 4 .query }}`
+```
+
+This will indent every line of text by 4 space characters and add a new line to the beginning.
+
+### repeat
+
+Use this function to repeat a string multiple times.
+
+Signature: `repeat(c int,value string) string`
+
+Example:
+
+```template
+`{{ repeat 3 "hello" }}` // output: hellohellohello
+```
+
+### printf
+
+Use this function to format a string in a custom way. For more information about the syntax, refer to the [Go documentation](https://pkg.go.dev/fmt).
+
+Signature: `printf(format string, a ...interface{})`
 
 Examples:
 
 ```template
-`{ .request_method | upper }}`
-`{{ upper  "hello"}}`
+`{{ printf "The IP address was %s" .remote_addr }}` // output: The IP address was 129.168.1.1
+
+`{{ printf "%-40.40s" .request_uri}} {{printf "%-5.5s" .request_method}}`
+// output: 
+// /a/509965767/alternative-to-my-mtg.html  GET
+// /id/609259548/hpr.html                   GET
 ```
-
-This results in `HELLO`.
-
-## title
-
-Convert to title case.
-
-Signature: `title(string) string`
-
-Examples:
 
 ```template
-`{{.request_method | title}}`
-`{{ title "hello world"}}`
+line_format "\"|\" {{printf \"%15.15s\" .ClientHost}} \"|\""
 ```
 
-The last example will return `Hello World`.
-
-## trunc
-
-Truncate a string and add no suffix.
-
-Signature: `trunc(count int,value string) string`
-
-Examples:
-
-```template
-`{{ .path | trunc 2 }}`
-`{{ trunc 5 "hello world"}}`   // output: hello
-`{{ trunc -5 "hello world"}}`  // output: world
-```
-
-## substr
-
-Get a substring from a string.
-
-Signature: `substr(start int,end int,value string) string`
-
-If start is < 0, this calls value[:end].
-If start is >= 0 and end < 0 or end bigger than s length, this calls value[start:]
-Otherwise, this calls value[start, end].
-
-Examples:
-
-```template
-`{{ .path | substr 2 5 }}`
-`{{ substr 0 5 "hello world"}}`  // output: hello
-`{{ substr 6 11 "hello world"}}` // output: world
-```
-
-## replace
+### replace
 
 This function performs simple string replacement.
 
@@ -186,7 +436,40 @@ Examples:
 
 The last example will return `world world`.
 
-## trim
+### substr
+
+Get a substring from a string.
+
+Signature: `substr(start int,end int,value string) string`
+
+If start is < 0, this calls value[:end].
+If start is >= 0 and end < 0 or end bigger than s length, this calls value[start:]
+Otherwise, this calls value[start, end].
+
+Examples:
+
+```template
+`{{ .path | substr 2 5 }}`
+`{{ substr 0 5 "hello world"}}`  // output: hello
+`{{ substr 6 11 "hello world"}}` // output: world
+```
+
+### title
+
+Convert to title case.
+
+Signature: `title(string) string`
+
+Examples:
+
+```template
+`{{.request_method | title}}`
+`{{ title "hello world"}}`
+```
+
+The last example will return `Hello World`.
+
+### trim
 
 The trim function removes space from either side of a string.
 
@@ -199,7 +482,7 @@ Examples:
 `{{ trim "   hello    " }}` // output: hello
 ```
 
-## trimAll
+### trimAll
 
 Use this function to remove given characters from the front or back of a string.
 
@@ -212,20 +495,7 @@ Examples:
 `{{ trimAll "$" "$5.00" }}` // output: 5.00
 ```
 
-## trimSuffix
-
-Use this function to trim just the suffix from a string.
-
-Signature: `trimSuffix(suffix string, src string) string`
-
-Examples:
-
-```template
-`{{  .path | trimSuffix "/" }}`
-`{{ trimSuffix "-" "hello-" }}` // output: hello
-```
-
-## trimPrefix
+### trimPrefix
 
 Use this function to trim just the prefix from a string.
 
@@ -238,73 +508,79 @@ Examples:
 `{{ trimPrefix "-" "-hello" }}` // output: hello
 ```
 
-## alignLeft
+### trimSuffix
 
-Use this function to format a string to a fixed with, aligning the content to the left.
+Use this function to trim just the suffix from a string.
 
-Signature: `alignLeft(count int, src string) string`
-
-Examples:
-
-```template
-`{{ alignLeft 5 "hello world"}}` // output: "hello"
-`{{ alignLeft 5 "hi"}}`          // output: "hi   "
-```
-
-## alignRight
-
-Use this function to format a string to a fixed with, aligning the content to the right.
-
-Signature: `alignRight(count int, src string) string`
+Signature: `trimSuffix(suffix string, src string) string`
 
 Examples:
 
 ```template
-`{{ alignRight 5 "hello world"}}` // output: "world"
-`{{ alignRight 5 "hi"}}`          // output: "   hi"
+`{{  .path | trimSuffix "/" }}`
+`{{ trimSuffix "-" "hello-" }}` // output: hello
 ```
 
-## indent
+### trunc
 
-The indent function indents every line in a given string to the specified indent width. This is useful when aligning multi-line strings.
+Truncate a string and add no suffix.
 
-Signature: `indent(spaces int,src string) string`
+Signature: `trunc(count int,value string) string`
 
-Example:
+Examples:
 
 ```template
-`{{ indent 4 .query }}`
+`{{ .path | trunc 2 }}`
+`{{ trunc 5 "hello world"}}`   // output: hello
+`{{ trunc -5 "hello world"}}`  // output: world
 ```
 
-This indents each line contained in the `.query` by four (4) spaces.
+### upper
 
-## nindent
+Use this function to convert to upper case.
 
-The nindent function is the same as the indent function, but prepends a new line to the beginning of the string.
+Signature: `upper(string) string`
 
-Signature: `nindent(spaces int,src string) string`
-
-Example:
+Examples:
 
 ```template
-`{{ nindent 4 .query }}`
+`{ .request_method | upper }}`
+`{{ upper  "hello"}}`
 ```
 
-This will indent every line of text by 4 space characters and add a new line to the beginning.
+This results in `HELLO`.
 
-## repeat
+### urlencode
 
-Use this function to repeat a string multiple times.
+Use this function to [urlencode](https://en.wikipedia.org/wiki/URL_encoding) a string.
 
-Signature: `repeat(c int,value string) string`
+Signature: `urlencode(string) string`
 
-Example:
+Examples:
 
 ```template
-`{{ repeat 3 "hello" }}` // output: hellohellohello
+`{{ .request_url | urlencode }}`
+`{{ urlencode  .request_url}}`
 ```
 
-## contains
+### urldecode
+
+Use this function to [urldecode](https://en.wikipedia.org/wiki/URL_encoding) a string.
+
+Signature: `urldecode(string) string`
+
+Examples:
+
+```template
+`{{ .request_url | urldecode }}`
+`{{ urldecode  .request_url}}`
+```
+
+## Logical functions
+
+You can use the following logical functions to compare strings when building a template expression.
+
+### contains
 
 Use this function to test to see if one string is contained inside of another.
 
@@ -317,7 +593,7 @@ Examples:
 `{{ if contains "he" "hello" }} yes {{end}}`
 ```
 
-## eq
+### eq
 
 Use this function to test to see if one string has exact matching inside of another.
 
@@ -330,7 +606,7 @@ Examples:
 `{{ if eq "hello" "hello" }} yes {{end}}`
 ```
 
-## hasPrefix and hasSuffix
+### hasPrefix and hasSuffix
 
 The `hasPrefix` and `hasSuffix` functions test whether a string has a given prefix or suffix.
 
@@ -346,7 +622,11 @@ Examples:
 `{{ if hasPrefix "he" "hello" }} yes {{end}}`
 ```
 
-## add
+## Mathematical functions
+
+You can use the following mathematical functions when writing template expressions.
+
+### add
 
 Sum numbers. Supports multiple numbers
 
@@ -358,45 +638,9 @@ Example:
 `{{ add 3 2 5 }}` // output: 10
 ```
 
-## sub
+### addf
 
-Subtract numbers.
-
-Signature: `func(a, b interface{}) int64`
-
-Example:
-
-```template
-`{{ sub 5 2 }}` // output: 3
-```
-
-## mul
-
-Multiply numbers. Supports multiple numbers.
-
-Signature: `func(a interface{}, v ...interface{}) int64`
-
-Example:
-
-```template
-`{{ mul 5 2 3}}` // output: 30
-```
-
-## div
-
-Integer divide numbers.
-
-Signature: `func(a, b interface{}) int64`
-
-Example:
-
-```template
-`{{ div 10 2}}` // output: 5
-```
-
-## addf
-
-Sum numbers. Supports multiple numbers.
+Sum floating point numbers. Supports multiple numbers.
 
 Signature: `func(i ...interface{}) float64`
 
@@ -406,103 +650,7 @@ Example:
 `{{ addf 3.5 2 5 }}` // output: 10.5
 ```
 
-## subf
-
-Subtract numbers. Supports multiple numbers.
-
-Signature: `func(a interface{}, v ...interface{}) float64`
-
-Example:
-
-```template
-`{{ subf  5.5 2 1.5 }}` // output: 2
-```
-
-## mulf
-
-Multiply numbers. Supports multiple numbers
-
-Signature: `func(a interface{}, v ...interface{}) float64`
-
-Example:
-
-```template
-`{{ mulf 5.5 2 2.5 }}` // output: 27.5
-```
-
-## divf
-
-Divide numbers. Supports multiple numbers.
-
-Signature: `func(a interface{}, v ...interface{}) float64`
-
-Example:
-
-```template
-`{{ divf 10 2 4}}` // output: 1.25
-```
-
-## mod
-
-Modulo wit mod.
-
-Signature: `func(a, b interface{}) int64`
-
-Example:
-
-```template
-`{{ mod 10 3}}` // output: 1
-```
-
-## max
-
-Return the largest of a series of integers:
-
-Signature: `max(a interface{}, i ...interface{}) int64`
-
-Example:
-
-```template
-`{{ max 1 2 3 }}` //output 3
-```
-
-## min
-
-Return the smallest of a series of integers.
-
-Signature: `min(a interface{}, i ...interface{}) int64`
-
-Example:
-
-```template
-`{{ min 1 2 3 }}`//output 1
-```
-
-## maxf
-
-Return the largest of a series of floats:
-
-Signature: `maxf(a interface{}, i ...interface{}) float64`
-
-Example:
-
-```template
-`{{ maxf 1 2.5 3 }}` //output 3
-```
-
-## minf
-
-Return the smallest of a series of floats.
-
-Signature: `minf(a interface{}, i ...interface{}) float64`
-
-Example:
-
-```template
-`{{ minf 1 2.5 3 }}` //output 1.5
-```
-
-## ceil
+### ceil
 
 Returns the greatest float value greater than or equal to input value
 
@@ -514,9 +662,45 @@ Example:
 `{{ ceil 123.001 }}` //output 124.0
 ```
 
-## floor
+### div
 
-Returns the greatest float value less than or equal to input value
+Divide two integers.
+
+Signature: `func(a, b interface{}) int64`
+
+Example:
+
+```template
+`{{ div 10 2}}` // output: 5
+```
+
+### divf
+
+Divide floating point numbers. Supports multiple numbers.
+
+Signature: `func(a interface{}, v ...interface{}) float64`
+
+Example:
+
+```template
+`{{ divf 10 2 4}}` // output: 1.25
+```
+
+### float64
+
+Convert a string to a float64.
+
+Signature: `toFloat64(v interface{}) float64`
+
+Example:
+
+```template
+`{{ "3.5" | float64 }}` //output 3.5
+```
+
+### floor
+
+Returns the greatest float value less than or equal to input value.
 
 Signature: `floor(a interface{}) float64`
 
@@ -526,7 +710,103 @@ Example:
 `{{ floor 123.9999 }}` //output 123.0
 ```
 
-## round
+### int
+
+Convert value to an integer.
+
+Signature: `toInt(v interface{}) int`
+
+Example:
+
+```template
+`{{ "3" | int }}` //output 3
+```
+
+### max
+
+Return the largest of a series of integers:
+
+Signature: `max(a interface{}, i ...interface{}) int64`
+
+Example:
+
+```template
+`{{ max 1 2 3 }}` //output 3
+```
+
+### maxf
+
+Return the largest of a series of floats:
+
+Signature: `maxf(a interface{}, i ...interface{}) float64`
+
+Example:
+
+```template
+`{{ maxf 1 2.5 3 }}` //output 3
+```
+
+### min
+
+Return the smallest of a series of integers.
+
+Signature: `min(a interface{}, i ...interface{}) int64`
+
+Example:
+
+```template
+`{{ min 1 2 3 }}`//output 1
+```
+
+### minf
+
+Return the smallest of a series of floats.
+
+Signature: `minf(a interface{}, i ...interface{}) float64`
+
+Example:
+
+```template
+`{{ minf 1 2.5 3 }}` //output 1.5
+```
+
+### mul
+
+Multiply numbers. Supports multiple numbers.
+
+Signature: `mul(a interface{}, v ...interface{}) int64`
+
+Example:
+
+```template
+`{{ mul 5 2 3}}` // output: 30
+```
+
+### mulf
+
+Multiply floating numbers. Supports multiple numbers
+
+Signature: `mulf(a interface{}, v ...interface{}) float64`
+
+Example:
+
+```template
+`{{ mulf 5.5 2 2.5 }}` // output: 27.5
+```
+
+### mod
+
+Returns the remainder when number 'a' is divided by number 'b'.
+
+Signature: `mod(a, b interface{}) int64`
+
+Example:
+
+```template
+`{{ mod 10 3}}` // output: 1
+```
+
+### round
 
 Returns a float value with the remainder rounded to the given number of digits after the decimal point.
 
@@ -548,182 +828,35 @@ Example:
 
 With default `roundOn` of `.5` the above value would be `123.88571`
 
-## int
+### sub
 
-Convert value to an int.
+Subtract one number from another.
 
-Signature: `toInt(v interface{}) int`
-
-Example:
-
-```template
-`{{ "3" | int }}` //output 3
-```
-
-## float64
-
-Convert to a float64.
-
-Signature: `toFloat64(v interface{}) float64`
+Signature: `func(a, b interface{}) int64`
 
 Example:
 
 ```template
-`{{ "3.5" | float64 }}` //output 3.5
+`{{ sub 5 2 }}` // output: 3
 ```
 
-## fromJson
+### subf
 
-Decodes a JSON document into a structure. If the input cannot be decoded as JSON the function will return an empty string.
+Subtract floating numbers. Supports multiple numbers.
 
-Signature: `fromJson(v string) interface{}`
+Signature: `func(a interface{}, v ...interface{}) float64`
 
 Example:
 
 ```template
-`{{fromJson "{\"foo\": 55}"}}`
+`{{ subf  5.5 2 1.5 }}` // output: 2
 ```
 
-Example of a query to print a newline per queries stored as a json array in the log line:
+## Regular expression functions
 
-```logql
-{job="loki/querier"} |= "finish in prometheus" | logfmt | line_format `{{ range $q := fromJson .queries }} {{ $q.query }} {{ end }}`
-```
+You can use the following functions to perform regular expressions in a template expression.
 
-## now
-
-Returns the current time in the local timezone of the Loki server.
-
-Signature: `Now() time.Time`
-
-Example:
-
-```template
-`{{ now }}`
-```
-
-## toDate
-
-Parses a formatted string and returns the time value it represents using the local timezone of the server running Loki.
-
-For more consistency between Loki installations, it's recommended to use `toDateInZone`
-
-The format string must use the exact date as defined in the [golang datetime layout](https://pkg.go.dev/time#pkg-constants)
-
-Signature: `toDate(fmt, str string) time.Time`
-
-Examples: 
-
-```template
-`{{ toDate "2006-01-02" "2021-11-02" }}`
-`{{ .foo | toDate "2006-01-02T15:04:05.999999999Z" }}`
-```
-
-## toDateInZone
-
-Parses a formatted string and returns the time value it represents in the provided timezone.
-
-The format string must use the exact date as defined in the [golang datetime layout](https://pkg.go.dev/time#pkg-constants)
-
-The timezone value can be `Local`, `UTC`, or any of the IANA Time Zone database values
-
-Signature: `toDateInZone(fmt, zone, str string) time.Time`
-
-Examples:
-
-```template
-`{{ toDateInZone "2006-01-02" "UTC" "2021-11-02" }}`
-`{{ .foo | toDateInZone "2006-01-02T15:04:05.999999999Z" "UTC" }}`
-```
-
-## date
-
-Returns a textual representation of the time value formatted according to the provided [golang datetime layout](https://pkg.go.dev/time#pkg-constants).
-
-Signature: `date(fmt string, date interface{}) string`
-
-Example:
-
-```template
-`{{ date "2006-01-02" now }}`
-```
-
-## unixEpoch
-
-Returns the number of seconds elapsed since January 1, 1970 UTC.
-
-Signature: `unixEpoch(date time.Time) string`
-
-Examples:
-
-```template
-`{{ unixEpoch now }}`
-`{{ .foo | toDateInZone "2006-01-02T15:04:05.999999999Z" "UTC" | unixEpoch }}`
-```
-
-Example of a query to filter Loki querier jobs which create time is 1 day before:
-```logql
-{job="loki/querier"} | label_format nowEpoch=`{{(unixEpoch now)}}`,createDateEpoch=`{{unixEpoch (toDate "2006-01-02" .createDate)}}` | label_format dateTimeDiff=`{{sub .nowEpoch .createDateEpoch}}` | dateTimeDiff > 86400
-```
-
-## unixEpochMillis
-
-Returns the number of milliseconds elapsed since January 1, 1970 UTC.
-
-Signature: `unixEpochMillis(date time.Time) string`
-
-Examples:
-
-```template
-`{{ unixEpochMillis now }}`
-`{{ .foo | toDateInZone "2006-01-02T15:04:05.999999999Z" "UTC" | unixEpochMillis }}`
-```
-
-## unixEpochNanos
-
-Returns the number of nanoseconds elapsed since January 1, 1970 UTC.
-
-Signature: `unixEpochNanos(date time.Time) string`
-
-Examples:
-
-```template
-`{{ unixEpochNanos now }}`
-`{{ .foo | toDateInZone "2006-01-02T15:04:05.999999999Z" "UTC" | unixEpochNanos }}`
-```
-
-## unixToTime
-
-Converts the string epoch to the time value it represents. Epoch times in days, seconds, milliseconds, microseconds and nanoseconds are supported.
-
-Signature: `unixToTime(epoch string) time.Time`
-
-Examples:
-
-Consider the following log line `{"from": "1679577215","to":"1679587215","message":"some message"}`. To print the `from` field as human readable add the following at the end of the LogQL query:
-```logql
-... | json | line_format `from="{{date "2006-01-02" (unixToTime .from)}}"`
-```
-
-## default
-
-Checks whether the string(`src`) is set, and returns default(`d`) if not set.
-
-Signature: `default(d string, src string) string`
-
-Examples:
-
-```template
-`{{ default "-" "" }}` // output: -
-`{{ default "-" "foo" }}` // output: foo
-```
-
-Example of a query to print a `-` if the `http_request_headers_x_forwarded_for` label is empty:
-```logql
-{job="access_log"} | json | line_format `{{.http_request_headers_x_forwarded_for | default "-"}}`
-```
-
-## count
+### count
 
 Counts occurrences of the regex (`regex`) in (`src`).
 
@@ -737,95 +870,30 @@ Examples:
 ```
 
 Example of a query to print how many times XYZ occurs in a line:
+
 ```logql
 {job="xyzlog"} | line_format `{{ __line__ | count "XYZ"}}`
 ```
 
-## urlencode
+### regexReplaceAll and regexReplaceAllLiteral
 
-Use this function to [urlencode](https://en.wikipedia.org/wiki/URL_encoding) a string.
+`regexReplaceAll` returns a copy of the input string, replacing matches of the Regexp with the replacement string replacement. Inside string replacement, $ signs are interpreted as in Expand, so for instance $1 represents the text of the first sub-match. See the golang [Regexp.replaceAll documentation](https://golang.org/pkg/regexp/#Regexp.ReplaceAll) for more examples.
 
-Signature: `urlencode(string) string`
+Signature: regexReplaceAll(regex string, src string, replacement string)
+(source)
 
-Examples:
+Example:
 
 ```template
-`{{ .request_url | urlencode }}`
-`{{ urlencode  .request_url}}`
+`{{ regexReplaceAll "(a*)bc" .some_label "${1}a" }}`
 ```
 
-## urldecode
+`regexReplaceAllLiteral` function returns a copy of the input string and replaces matches of the Regexp with the replacement string replacement. The replacement string is substituted directly, without using Expand.
 
-Use this function to [urldecode](https://en.wikipedia.org/wiki/URL_encoding) a string.
+Signature: regexReplaceAllLiteral(regex string, src string, replacement string)
 
-Signature: `urldecode(string) string`
-
-Examples:
+Example:
 
 ```template
-`{{ .request_url | urldecode }}`
-`{{ urldecode  .request_url}}`
-```
-
-## b64enc
-
-Base64 encode a string.
-
-Signature: `b64enc(string) string`
-
-Examples:
-
-```template
-`{{ .foo | b64enc }}`
-`{{ b64enc  .foo }}`
-```
-
-## b64dec
-
-Base64 decode a string.
-
-Signature: `b64dec(string) string`
-
-Examples:
-
-```template
-`{{ .foo | b64dec }}`
-`{{ b64dec  .foo }}`
-```
-
-## bytes
-
-Convert a humanized byte string to bytes using [go-humanize](https://pkg.go.dev/github.com/dustin/go-humanize#ParseBytes)
-
-Signature: `bytes(string) string`
-
-Examples:
-
-```template
-`{{ .foo | bytes }}`
-`{{ bytes .foo }}`
-```
-
-## duration
-
-An alias for `duration_seconds`
-
-Examples:
-
-```template
-`{{ .foo | duration }}`
-`{{ duration .foo }}`
-```
-
-## duration_seconds
-
-Convert a humanized time duration to seconds using [time.ParseDuration](https://pkg.go.dev/time#ParseDuration)
-
-Signature: `duration_seconds(string) float64`
-
-Examples:
-
-```template
-`{{ .foo | duration_seconds }}`
-`{{ duration_seconds .foo }}`
+`{{ regexReplaceAllLiteral "(ts=)" .timestamp "timestamp=" }}`
 ```

--- a/docs/sources/query/template_functions.md
+++ b/docs/sources/query/template_functions.md
@@ -43,7 +43,7 @@ Example:
 `{{ if contains .err "ErrTimeout" }} timeout {{else if contains "he" "hello"}} yes {{else}} no {{end}}`
 ```
 
-## Built-in variables for Log line properties
+## Built-in variables for log line properties
 
 These variables provide a way of referencing something from the log line when writing a template expression.
 
@@ -57,7 +57,7 @@ All labels from the Log line are added as variables in the template engine. They
 
 ### __line__
 
-The `__line__` function returns the current log line.
+The `__line__` function returns the original log line without any modifications.
 
 Signature: `line() string`
 
@@ -302,7 +302,7 @@ Examples:
 
 Enables outputting a default value if the source string is otherwise empty. If the 'src' parameter is not empty, this function returns the value of 'src'. Useful for JSON fields that can be missing, like HTTP headers in a log line that aren't required, as in the following example:
 
-```json
+```logql
 {job="access_log"} | json | line_format `{{.http_request_headers_x_forwarded_for | default "-"}}`
 ```
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Reorganizes the content on the [Query Template Functions](https://grafana.com/docs/loki/latest/query/template_functions/) page into logical categories, and alphabetizes the templates within those categories.  Also adds documentation for `printf` which was previously undocumented.
 Note that the text and examples for the functions has not been updated in this PR.  This is just moving things around to make them easier to find.