### PR TITLE
chore(deps): update alpine docker tag from v3.20.2 to v3.20.3 for loki [security]

### DIFF
--- a/clients/cmd/docker-driver/Dockerfile
+++ b/clients/cmd/docker-driver/Dockerfile
@@ -9,7 +9,7 @@ COPY . /src/loki
 WORKDIR /src/loki
 RUN make clean && make BUILD_IN_CONTAINER=false clients/cmd/docker-driver/docker-driver
 
-FROM alpine:3.20.2
+FROM alpine:3.20.3
 RUN apk add --update --no-cache ca-certificates tzdata
 COPY --from=build /src/loki/clients/cmd/docker-driver/docker-driver /bin/docker-driver
 WORKDIR /bin/

--- a/clients/cmd/promtail/Dockerfile.debug
+++ b/clients/cmd/promtail/Dockerfile.debug
@@ -9,7 +9,7 @@ WORKDIR /src/loki
 RUN make clean && make BUILD_IN_CONTAINER=false PROMTAIL_JOURNAL_ENABLED=true promtail-debug
 
 
-FROM       alpine:3.20.2
+FROM       alpine:3.20.3
 RUN        apk add --update --no-cache ca-certificates tzdata
 COPY       --from=build /src/loki/clients/cmd/promtail/promtail-debug /usr/bin/promtail-debug
 COPY       --from=build /usr/bin/dlv /usr/bin/dlv

--- a/loki-build-image/Dockerfile
+++ b/loki-build-image/Dockerfile
@@ -15,7 +15,7 @@ RUN BIN=$([ "$TARGETARCH" = "arm64" ] && echo "helm-docs_Linux_arm64" || echo "h
     curl -L "https://github.com/norwoodj/helm-docs/releases/download/v1.11.2/$BIN.tar.gz" | tar zx && \
     install -t /usr/local/bin helm-docs
 
-FROM alpine:3.20.2 AS lychee
+FROM alpine:3.20.3 AS lychee
 ARG TARGETARCH
 ARG LYCHEE_VER="0.7.0"
 RUN apk add --no-cache curl && \
@@ -24,18 +24,18 @@ RUN apk add --no-cache curl && \
     mv /tmp/lychee /usr/bin/lychee && \
     rm -rf "/tmp/linux-$TARGETARCH" /tmp/lychee-$LYCHEE_VER.tgz
 
-FROM alpine:3.20.2 AS golangci
+FROM alpine:3.20.3 AS golangci
 RUN apk add --no-cache curl && \
     cd / && \
     curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.55.1
 
-FROM alpine:3.20.2 AS buf
+FROM alpine:3.20.3 AS buf
 ARG TARGETOS
 RUN apk add --no-cache curl && \
     curl -sSL "https://github.com/bufbuild/buf/releases/download/v1.4.0/buf-$TARGETOS-$(uname -m)" -o "/usr/bin/buf" && \
     chmod +x "/usr/bin/buf"
 
-FROM alpine:3.20.2 AS docker
+FROM alpine:3.20.3 AS docker
 RUN apk add --no-cache docker-cli docker-cli-buildx
 
 FROM golang:${GO_VERSION}-bookworm AS drone

--- a/tools/dev/loki-tsdb-storage-s3/dev.dockerfile
+++ b/tools/dev/loki-tsdb-storage-s3/dev.dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.22.6
 ENV CGO_ENABLED=0
 RUN go install github.com/go-delve/delve/cmd/dlv@v1.22.1
 
-FROM alpine:3.20.2
+FROM alpine:3.20.3
 
 RUN     mkdir /loki
 WORKDIR /loki


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently Loki using Alpine Minor-Version `3.20.2`. This Docker base image containing a vulnerability CVE-2024-6119 inside the OS-package `openssl` (Severity: HIGH). Alpine released a Minor-Version `3.20.3` to fix this vulnerability - Details: 
* https://alpinelinux.org/posts/Alpine-3.17.10-3.18.9-3.19.4-3.20.3-released.html
* https://security.alpinelinux.org/vuln/CVE-2024-6119

This PR will bump the `alpine` image-tag to `3.20.3` used by Loki.

**Which issue(s) this PR fixes**:
Fixes #14140

**Special notes for your reviewer**:
I'm not fully sure regarding changing the file `loki-build-image/Dockerfile`. The last PR regarding an Alpine-Update did not change this file, but currently this file also referenced a dedicated Alpine version tag.