### PR TITLE
chore(blooms): Remove excessive logging in fused querier

### DIFF
--- a/pkg/storage/bloom/v1/bloom_tokenizer.go
+++ b/pkg/storage/bloom/v1/bloom_tokenizer.go
@@ -112,7 +112,7 @@ func (bt *BloomTokenizer) Populate(blooms v2iter.SizedIterator[*Bloom], chks v2i
 		// We noticed some blooms are empty on the resulting blocks.
 		// We have the feeling that the empty blooms may be reused from old blocks.
 		// Here we log an error if we find an empty bloom.
-		if bloom.Count() == 0 {
+		if bloom.IsEmpty() {
 			level.Warn(bt.logger).Log("msg", "found existing empty bloom")
 		}
 	} else {
@@ -149,7 +149,7 @@ func (bt *BloomTokenizer) Populate(blooms v2iter.SizedIterator[*Bloom], chks v2i
 	}
 
 	// TODO(salvacorts): Delete this once we solve the correctness bug
-	if bloom.Count() == 0 {
+	if bloom.IsEmpty() {
 		level.Warn(bt.logger).Log("msg", "resulting bloom is empty")
 	}
 

--- a/pkg/storage/bloom/v1/filter/scalable.go
+++ b/pkg/storage/bloom/v1/filter/scalable.go
@@ -116,6 +116,10 @@ func (s *ScalableBloomFilter) Count() (ct int) {
 	return
 }
 
+func (s *ScalableBloomFilter) IsEmpty() bool {
+	return s.Count() == 0
+}
+
 // FillRatio returns the average ratio of set bits across every filter.
 func (s *ScalableBloomFilter) FillRatio() float64 {
 	var sum, count float64

--- a/pkg/storage/bloom/v1/fuse.go
+++ b/pkg/storage/bloom/v1/fuse.go
@@ -305,14 +305,18 @@ func (fq *FusedQuerier) runSeries(_ Schema, series *SeriesWithMeta, reqs []Reque
 		// Test each bloom individually
 		bloom := fq.bq.blooms.At()
 
-		// TODO(owen-d): this is a stopgap to avoid filtering broken blooms until we find their cause.
+		// This is a stopgap to avoid filtering on empty blooms.
 		// In the case we don't have any data in the bloom, don't filter any chunks.
-		if bloom.ScalableBloomFilter.Count() == 0 {
-			level.Warn(fq.logger).Log(
-				"msg", "Found bloom with no data",
-				"offset_page", offset.Page,
-				"offset_bytes", offset.ByteOffset,
-			)
+		// Empty blooms are generated from chunks that do not have entries with structured metadata.
+		if bloom.IsEmpty() {
+			// To debug empty blooms, uncomment the following block. Note that this may produce *a lot* of logs.
+			// swb := fq.bq.At()
+			// level.Debug(fq.logger).Log(
+			// 	"msg", "empty bloom",
+			// 	"series", swb.Fingerprint,
+			// 	"offset_page", offset.Page,
+			// 	"offset_bytes", offset.ByteOffset,
+			// )
 
 			for j := range reqs {
 				for k := range inputs[j].InBlooms {


### PR DESCRIPTION
**What this PR does / why we need it**:

The FusedQuerier emits a large amount of log lines at level `WARN` if a bloom is empty. Since the introduction of structured metadata blooms, this happens every time a series does not have structured metadata in any of its entries.

![screenshot_20240917_165025](https://github.com/user-attachments/assets/71ac7edc-c442-4f1a-804d-45e489983628)

**Special notes for your reviewer**:

In the future, an optimisation could be to not write blooms for series at all, if they contain no data.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
