### PR TITLE
chore: Remove unused quantile merge step evaluator.

### DIFF
--- a/pkg/logql/quantile_over_time_sketch.go
+++ b/pkg/logql/quantile_over_time_sketch.go
@@ -20,8 +20,10 @@ const (
 	QuantileSketchMatrixType = "QuantileSketchMatrix"
 )
 
-type ProbabilisticQuantileVector []ProbabilisticQuantileSample
-type ProbabilisticQuantileMatrix []ProbabilisticQuantileVector
+type (
+	ProbabilisticQuantileVector []ProbabilisticQuantileSample
+	ProbabilisticQuantileMatrix []ProbabilisticQuantileVector
+)
 
 var streamHashPool = sync.Pool{
 	New: func() interface{} { return make(map[uint64]int) },
@@ -177,7 +179,8 @@ func (e *QuantileSketchStepEvaluator) Explain(parent Node) {
 
 func newQuantileSketchIterator(
 	it iter.PeekingSampleIterator,
-	selRange, step, start, end, offset int64) RangeVectorIterator {
+	selRange, step, start, end, offset int64,
+) RangeVectorIterator {
 	inner := &batchRangeVectorIterator{
 		iter:     it,
 		step:     step,
@@ -341,70 +344,6 @@ func (*QuantileSketchMatrixStepEvaluator) Error() error { return nil }
 
 func (*QuantileSketchMatrixStepEvaluator) Explain(parent Node) {
 	parent.Child("QuantileSketchMatrix")
-}
-
-// QuantileSketchMergeStepEvaluator merges multiple quantile sketches into one for each
-// step.
-type QuantileSketchMergeStepEvaluator struct {
-	evaluators []StepEvaluator
-	err        error
-}
-
-func NewQuantileSketchMergeStepEvaluator(evaluators []StepEvaluator) *QuantileSketchMergeStepEvaluator {
-	return &QuantileSketchMergeStepEvaluator{
-		evaluators: evaluators,
-		err:        nil,
-	}
-}
-
-func (e *QuantileSketchMergeStepEvaluator) Next() (bool, int64, StepResult) {
-	ok, ts, r := e.evaluators[0].Next()
-	var cur ProbabilisticQuantileVector
-	if ok {
-		cur = r.QuantileSketchVec()
-	}
-
-	if len(e.evaluators) == 1 {
-		return ok, ts, cur
-	}
-
-	for _, eval := range e.evaluators[1:] {
-		ok, nextTs, vec := eval.Next()
-		if ok {
-			if cur == nil {
-				cur = vec.QuantileSketchVec()
-			} else {
-				if ts != nextTs {
-					e.err = fmt.Errorf("timestamps of sketches differ: %d!=%d", ts, nextTs)
-					return false, 0, nil
-				}
-
-				_, e.err = cur.Merge(vec.QuantileSketchVec())
-				if e.err != nil {
-					return false, 0, nil
-				}
-			}
-		}
-	}
-
-	return ok, ts, cur
-}
-
-func (*QuantileSketchMergeStepEvaluator) Close() error { return nil }
-
-func (e *QuantileSketchMergeStepEvaluator) Error() error { return e.err }
-
-func (e *QuantileSketchMergeStepEvaluator) Explain(parent Node) {
-	b := parent.Child("QuantileSketchMerge")
-	if len(e.evaluators) < MaxChildrenDisplay {
-		for _, child := range e.evaluators {
-			child.Explain(b)
-		}
-	} else {
-		e.evaluators[0].Explain(b)
-		b.Child("...")
-		e.evaluators[len(e.evaluators)-1].Explain(b)
-	}
 }
 
 // QuantileSketchVectorStepEvaluator evaluates a quantile sketch into a


### PR DESCRIPTION
**What this PR does / why we need it**:
The `QuantileSketchMergeStepEvaluator` was replace by an accumulator. So I'm removing it here.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
