### PR TITLE
chore(kafka): Refactor configurations and remove old modules

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -167,264 +167,6 @@ querier_rf1:
 # itself to a key value store.
 [ingester: <ingester>]
 
-ingester_rf1:
-  # Whether the ingester is enabled.
-  # CLI flag: -ingester-rf1.enabled
-  [enabled: <boolean> | default = false]
-
-  # Configures how the lifecycle of the ingester will operate and where it will
-  # register for discovery.
-  lifecycler:
-    ring:
-      kvstore:
-        # Backend storage to use for the ring. Supported values are: consul,
-        # etcd, inmemory, memberlist, multi.
-        # CLI flag: -ingester-rf1.store
-        [store: <string> | default = "consul"]
-
-        # The prefix for the keys in the store. Should end with a /.
-        # CLI flag: -ingester-rf1.prefix
-        [prefix: <string> | default = "collectors/"]
-
-        # Configuration for a Consul client. Only applies if the selected
-        # kvstore is consul.
-        # The CLI flags prefix for this block configuration is:
-        # ingester-rf1.consul
-        [consul: <consul>]
-
-        # Configuration for an ETCD v3 client. Only applies if the selected
-        # kvstore is etcd.
-        # The CLI flags prefix for this block configuration is:
-        # ingester-rf1.etcd
-        [etcd: <etcd>]
-
-        multi:
-          # Primary backend storage used by multi-client.
-          # CLI flag: -ingester-rf1.multi.primary
-          [primary: <string> | default = ""]
-
-          # Secondary backend storage used by multi-client.
-          # CLI flag: -ingester-rf1.multi.secondary
-          [secondary: <string> | default = ""]
-
-          # Mirror writes to secondary store.
-          # CLI flag: -ingester-rf1.multi.mirror-enabled
-          [mirror_enabled: <boolean> | default = false]
-
-          # Timeout for storing value to secondary store.
-          # CLI flag: -ingester-rf1.multi.mirror-timeout
-          [mirror_timeout: <duration> | default = 2s]
-
-      # The heartbeat timeout after which ingesters are skipped for
-      # reads/writes. 0 = never (timeout disabled).
-      # CLI flag: -ingester-rf1.ring.heartbeat-timeout
-      [heartbeat_timeout: <duration> | default = 1m]
-
-      # The number of ingesters to write to and read from.
-      # CLI flag: -ingester-rf1.distributor.replication-factor
-      [replication_factor: <int> | default = 3]
-
-      # True to enable the zone-awareness and replicate ingested samples across
-      # different availability zones.
-      # CLI flag: -ingester-rf1.distributor.zone-awareness-enabled
-      [zone_awareness_enabled: <boolean> | default = false]
-
-      # Comma-separated list of zones to exclude from the ring. Instances in
-      # excluded zones will be filtered out from the ring.
-      # CLI flag: -ingester-rf1.distributor.excluded-zones
-      [excluded_zones: <string> | default = ""]
-
-    # Number of tokens for each ingester.
-    # CLI flag: -ingester-rf1.num-tokens
-    [num_tokens: <int> | default = 128]
-
-    # Period at which to heartbeat to consul. 0 = disabled.
-    # CLI flag: -ingester-rf1.heartbeat-period
-    [heartbeat_period: <duration> | default = 5s]
-
-    # Heartbeat timeout after which instance is assumed to be unhealthy. 0 =
-    # disabled.
-    # CLI flag: -ingester-rf1.heartbeat-timeout
-    [heartbeat_timeout: <duration> | default = 1m]
-
-    # Observe tokens after generating to resolve collisions. Useful when using
-    # gossiping ring.
-    # CLI flag: -ingester-rf1.observe-period
-    [observe_period: <duration> | default = 0s]
-
-    # Period to wait for a claim from another member; will join automatically
-    # after this.
-    # CLI flag: -ingester-rf1.join-after
-    [join_after: <duration> | default = 0s]
-
-    # Minimum duration to wait after the internal readiness checks have passed
-    # but before succeeding the readiness endpoint. This is used to slowdown
-    # deployment controllers (eg. Kubernetes) after an instance is ready and
-    # before they proceed with a rolling update, to give the rest of the cluster
-    # instances enough time to receive ring updates.
-    # CLI flag: -ingester-rf1.min-ready-duration
-    [min_ready_duration: <duration> | default = 15s]
-
-    # Name of network interface to read address from.
-    # CLI flag: -ingester-rf1.lifecycler.interface
-    [interface_names: <list of strings> | default = [<private network interfaces>]]
-
-    # Enable IPv6 support. Required to make use of IP addresses from IPv6
-    # interfaces.
-    # CLI flag: -ingester-rf1.enable-inet6
-    [enable_inet6: <boolean> | default = false]
-
-    # Duration to sleep for before exiting, to ensure metrics are scraped.
-    # CLI flag: -ingester-rf1.final-sleep
-    [final_sleep: <duration> | default = 0s]
-
-    # File path where tokens are stored. If empty, tokens are not stored at
-    # shutdown and restored at startup.
-    # CLI flag: -ingester-rf1.tokens-file-path
-    [tokens_file_path: <string> | default = ""]
-
-    # The availability zone where this instance is running.
-    # CLI flag: -ingester-rf1.availability-zone
-    [availability_zone: <string> | default = ""]
-
-    # Unregister from the ring upon clean shutdown. It can be useful to disable
-    # for rolling restarts with consistent naming in conjunction with
-    # -distributor.extend-writes=false.
-    # CLI flag: -ingester-rf1.unregister-on-shutdown
-    [unregister_on_shutdown: <boolean> | default = true]
-
-    # When enabled the readiness probe succeeds only after all instances are
-    # ACTIVE and healthy in the ring, otherwise only the instance itself is
-    # checked. This option should be disabled if in your cluster multiple
-    # instances can be rolled out simultaneously, otherwise rolling updates may
-    # be slowed down.
-    # CLI flag: -ingester-rf1.readiness-check-ring-health
-    [readiness_check_ring_health: <boolean> | default = true]
-
-    # IP address to advertise in the ring.
-    # CLI flag: -ingester-rf1.lifecycler.addr
-    [address: <string> | default = ""]
-
-    # port to advertise in consul (defaults to server.grpc-listen-port).
-    # CLI flag: -ingester-rf1.lifecycler.port
-    [port: <int> | default = 0]
-
-    # ID to register in the ring.
-    # CLI flag: -ingester-rf1.lifecycler.ID
-    [id: <string> | default = "<hostname>"]
-
-  # The maximum age of a segment before it should be flushed. Increasing this
-  # value allows more time for a segment to grow to max-segment-size, but may
-  # increase latency if the write volume is too small.
-  # CLI flag: -ingester-rf1.max-segment-age
-  [max_segment_age: <duration> | default = 500ms]
-
-  # The maximum size of a segment before it should be flushed. It is not a
-  # strict limit, and segments can exceed the maximum size when individual
-  # appends are larger than the remaining capacity.
-  # CLI flag: -ingester-rf1.max-segment-size
-  [max_segment_size: <int> | default = 8388608]
-
-  # The maximum number of segments to buffer in-memory. Increasing this value
-  # allows for large bursts of writes to be buffered in memory, but may increase
-  # latency if the write volume exceeds the rate at which segments can be
-  # flushed.
-  # CLI flag: -ingester-rf1.max-segments
-  [max_segments: <int> | default = 10]
-
-  # How many flushes can happen concurrently from each stream.
-  # CLI flag: -ingester-rf1.concurrent-flushes
-  [concurrent_flushes: <int> | default = 32]
-
-  # How often should the ingester see if there are any blocks to flush. The
-  # first flush check is delayed by a random time up to 0.8x the flush check
-  # period. Additionally, there is +/- 1% jitter added to the interval.
-  # CLI flag: -ingester-rf1.flush-check-period
-  [flush_check_period: <duration> | default = 500ms]
-
-  flush_op_backoff:
-    # Minimum backoff period when a flush fails. Each concurrent flush has its
-    # own backoff, see `ingester.concurrent-flushes`.
-    # CLI flag: -ingester-rf1.flush-op-backoff-min-period
-    [min_period: <duration> | default = 100ms]
-
-    # Maximum backoff period when a flush fails. Each concurrent flush has its
-    # own backoff, see `ingester.concurrent-flushes`.
-    # CLI flag: -ingester-rf1.flush-op-backoff-max-period
-    [max_period: <duration> | default = 1m]
-
-    # Maximum retries for failed flushes.
-    # CLI flag: -ingester-rf1.flush-op-backoff-retries
-    [max_retries: <int> | default = 10]
-
-  # The timeout for an individual flush. Will be retried up to
-  # `flush-op-backoff-retries` times.
-  # CLI flag: -ingester-rf1.flush-op-timeout
-  [flush_op_timeout: <duration> | default = 10s]
-
-  # Forget about ingesters having heartbeat timestamps older than
-  # `ring.kvstore.heartbeat_timeout`. This is equivalent to clicking on the
-  # `/ring` `forget` button in the UI: the ingester is removed from the ring.
-  # This is a useful setting when you are sure that an unhealthy node won't
-  # return. An example is when not using stateful sets or the equivalent. Use
-  # `memberlist.rejoin_interval` > 0 to handle network partition cases when
-  # using a memberlist.
-  # CLI flag: -ingester-rf1.autoforget-unhealthy
-  [autoforget_unhealthy: <boolean> | default = false]
-
-  # The maximum number of errors a stream will report to the user when a push
-  # fails. 0 to make unlimited.
-  # CLI flag: -ingester-rf1.max-ignored-stream-errors
-  [max_returned_stream_errors: <int> | default = 10]
-
-  # Shard factor used in the ingesters for the in process reverse index. This
-  # MUST be evenly divisible by ALL schema shard factors or Loki will not start.
-  # CLI flag: -ingester-rf1.index-shards
-  [index_shards: <int> | default = 32]
-
-  # Maximum number of dropped streams to keep in memory during tailing.
-  # CLI flag: -ingester-rf1.tailer.max-dropped-streams
-  [max_dropped_streams: <int> | default = 10]
-
-  # Path where the shutdown marker file is stored. If not set and
-  # common.path_prefix is set then common.path_prefix will be used.
-  # CLI flag: -ingester-rf1.shutdown-marker-path
-  [shutdown_marker_path: <string> | default = ""]
-
-  # Interval at which the ingester ownedStreamService checks for changes in the
-  # ring to recalculate owned streams.
-  # CLI flag: -ingester-rf1.owned-streams-check-interval
-  [owned_streams_check_interval: <duration> | default = 30s]
-
-  # How long stream metadata is retained in memory after it was last seen.
-  # CLI flag: -ingester-rf1.stream-retain-period
-  [stream_retain_period: <duration> | default = 5m]
-
-  # Configures how the pattern ingester will connect to the ingesters.
-  client_config:
-    # Configures how connections are pooled.
-    pool_config:
-      # How frequently to clean up clients for ingesters that have gone away.
-      # CLI flag: -ingester-rf1.client-cleanup-period
-      [client_cleanup_period: <duration> | default = 15s]
-
-      # Run a health check on each ingester client during periodic cleanup.
-      # CLI flag: -ingester-rf1.health-check-ingesters
-      [health_check_ingesters: <boolean> | default = true]
-
-      # Timeout for the health check.
-      # CLI flag: -ingester-rf1.remote-timeout
-      [remote_timeout: <duration> | default = 1s]
-
-    # The remote request timeout on the client side.
-    # CLI flag: -ingester-rf1.client.timeout
-    [remote_timeout: <duration> | default = 5s]
-
-    # Configures how the gRPC connection to ingesters work as a client.
-    # The CLI flags prefix for this block configuration is:
-    # pattern-ingester.client
-    [grpc_client_config: <grpc_client>]
-
 pattern_ingester:
   # Whether the pattern ingester is enabled.
   # CLI flag: -pattern-ingester.enabled
@@ -446,14 +188,12 @@ pattern_ingester:
 
         # Configuration for a Consul client. Only applies if the selected
         # kvstore is consul.
-        # The CLI flags prefix for this block configuration is:
-        # pattern-ingester.consul
+        # The CLI flags prefix for this block configuration is: pattern-ingester
         [consul: <consul>]
 
         # Configuration for an ETCD v3 client. Only applies if the selected
         # kvstore is etcd.
-        # The CLI flags prefix for this block configuration is:
-        # pattern-ingester.etcd
+        # The CLI flags prefix for this block configuration is: pattern-ingester
         [etcd: <etcd>]
 
         multi:
@@ -1081,227 +821,6 @@ kafka_config:
   # This limit is per Kafka client. 0 to disable the limit.
   # CLI flag: -kafka.producer-max-buffered-bytes
   [producer_max_buffered_bytes: <int> | default = 1073741824]
-
-kafka_ingester:
-  # Whether the kafka ingester is enabled.
-  # CLI flag: -kafka-ingester.enabled
-  [enabled: <boolean> | default = false]
-
-  # Configures how the lifecycle of the ingester will operate and where it will
-  # register for discovery.
-  lifecycler:
-    ring:
-      kvstore:
-        # Backend storage to use for the ring. Supported values are: consul,
-        # etcd, inmemory, memberlist, multi.
-        # CLI flag: -kafka-ingesterstore
-        [store: <string> | default = "consul"]
-
-        # The prefix for the keys in the store. Should end with a /.
-        # CLI flag: -kafka-ingesterprefix
-        [prefix: <string> | default = "collectors/"]
-
-        # Configuration for a Consul client. Only applies if the selected
-        # kvstore is consul.
-        # The CLI flags prefix for this block configuration is:
-        # kafka-ingesterconsul
-        [consul: <consul>]
-
-        # Configuration for an ETCD v3 client. Only applies if the selected
-        # kvstore is etcd.
-        # The CLI flags prefix for this block configuration is:
-        # kafka-ingesteretcd
-        [etcd: <etcd>]
-
-        multi:
-          # Primary backend storage used by multi-client.
-          # CLI flag: -kafka-ingestermulti.primary
-          [primary: <string> | default = ""]
-
-          # Secondary backend storage used by multi-client.
-          # CLI flag: -kafka-ingestermulti.secondary
-          [secondary: <string> | default = ""]
-
-          # Mirror writes to secondary store.
-          # CLI flag: -kafka-ingestermulti.mirror-enabled
-          [mirror_enabled: <boolean> | default = false]
-
-          # Timeout for storing value to secondary store.
-          # CLI flag: -kafka-ingestermulti.mirror-timeout
-          [mirror_timeout: <duration> | default = 2s]
-
-      # The heartbeat timeout after which ingesters are skipped for
-      # reads/writes. 0 = never (timeout disabled).
-      # CLI flag: -kafka-ingesterring.heartbeat-timeout
-      [heartbeat_timeout: <duration> | default = 1m]
-
-      # The number of ingesters to write to and read from.
-      # CLI flag: -kafka-ingesterdistributor.replication-factor
-      [replication_factor: <int> | default = 3]
-
-      # True to enable the zone-awareness and replicate ingested samples across
-      # different availability zones.
-      # CLI flag: -kafka-ingesterdistributor.zone-awareness-enabled
-      [zone_awareness_enabled: <boolean> | default = false]
-
-      # Comma-separated list of zones to exclude from the ring. Instances in
-      # excluded zones will be filtered out from the ring.
-      # CLI flag: -kafka-ingesterdistributor.excluded-zones
-      [excluded_zones: <string> | default = ""]
-
-    # Number of tokens for each ingester.
-    # CLI flag: -kafka-ingesternum-tokens
-    [num_tokens: <int> | default = 128]
-
-    # Period at which to heartbeat to consul. 0 = disabled.
-    # CLI flag: -kafka-ingesterheartbeat-period
-    [heartbeat_period: <duration> | default = 5s]
-
-    # Heartbeat timeout after which instance is assumed to be unhealthy. 0 =
-    # disabled.
-    # CLI flag: -kafka-ingesterheartbeat-timeout
-    [heartbeat_timeout: <duration> | default = 1m]
-
-    # Observe tokens after generating to resolve collisions. Useful when using
-    # gossiping ring.
-    # CLI flag: -kafka-ingesterobserve-period
-    [observe_period: <duration> | default = 0s]
-
-    # Period to wait for a claim from another member; will join automatically
-    # after this.
-    # CLI flag: -kafka-ingesterjoin-after
-    [join_after: <duration> | default = 0s]
-
-    # Minimum duration to wait after the internal readiness checks have passed
-    # but before succeeding the readiness endpoint. This is used to slowdown
-    # deployment controllers (eg. Kubernetes) after an instance is ready and
-    # before they proceed with a rolling update, to give the rest of the cluster
-    # instances enough time to receive ring updates.
-    # CLI flag: -kafka-ingestermin-ready-duration
-    [min_ready_duration: <duration> | default = 15s]
-
-    # Name of network interface to read address from.
-    # CLI flag: -kafka-ingesterlifecycler.interface
-    [interface_names: <list of strings> | default = [<private network interfaces>]]
-
-    # Enable IPv6 support. Required to make use of IP addresses from IPv6
-    # interfaces.
-    # CLI flag: -kafka-ingesterenable-inet6
-    [enable_inet6: <boolean> | default = false]
-
-    # Duration to sleep for before exiting, to ensure metrics are scraped.
-    # CLI flag: -kafka-ingesterfinal-sleep
-    [final_sleep: <duration> | default = 0s]
-
-    # File path where tokens are stored. If empty, tokens are not stored at
-    # shutdown and restored at startup.
-    # CLI flag: -kafka-ingestertokens-file-path
-    [tokens_file_path: <string> | default = ""]
-
-    # The availability zone where this instance is running.
-    # CLI flag: -kafka-ingesteravailability-zone
-    [availability_zone: <string> | default = ""]
-
-    # Unregister from the ring upon clean shutdown. It can be useful to disable
-    # for rolling restarts with consistent naming in conjunction with
-    # -distributor.extend-writes=false.
-    # CLI flag: -kafka-ingesterunregister-on-shutdown
-    [unregister_on_shutdown: <boolean> | default = true]
-
-    # When enabled the readiness probe succeeds only after all instances are
-    # ACTIVE and healthy in the ring, otherwise only the instance itself is
-    # checked. This option should be disabled if in your cluster multiple
-    # instances can be rolled out simultaneously, otherwise rolling updates may
-    # be slowed down.
-    # CLI flag: -kafka-ingesterreadiness-check-ring-health
-    [readiness_check_ring_health: <boolean> | default = true]
-
-    # IP address to advertise in the ring.
-    # CLI flag: -kafka-ingesterlifecycler.addr
-    [address: <string> | default = ""]
-
-    # port to advertise in consul (defaults to server.grpc-listen-port).
-    # CLI flag: -kafka-ingesterlifecycler.port
-    [port: <int> | default = 0]
-
-    # ID to register in the ring.
-    # CLI flag: -kafka-ingesterlifecycler.ID
-    [id: <string> | default = "<hostname>"]
-
-  # Path where the shutdown marker file is stored. If not set and
-  # common.path_prefix is set then common.path_prefix will be used.
-  # CLI flag: -kafka-ingester.shutdown-marker-path
-  [shutdown_marker_path: <string> | default = ""]
-
-  # The interval at which the ingester will flush and commit offsets to Kafka.
-  # If not set, the default flush interval will be used.
-  # CLI flag: -kafka-ingester.flush-interval
-  [flush_interval: <duration> | default = 15s]
-
-  # The size at which the ingester will flush and commit offsets to Kafka. If
-  # not set, the default flush size will be used.
-  # CLI flag: -kafka-ingester.flush-size
-  [flush_size: <int> | default = 314572800]
-
-  partition_ring:
-    # The key-value store used to share the hash ring across multiple instances.
-    # This option needs be set on ingesters, distributors, queriers, and rulers
-    # when running in microservices mode.
-    kvstore:
-      # Backend storage to use for the ring. Supported values are: consul, etcd,
-      # inmemory, memberlist, multi.
-      # CLI flag: -ingester.partition-ring.store
-      [store: <string> | default = "memberlist"]
-
-      # The prefix for the keys in the store. Should end with a /.
-      # CLI flag: -ingester.partition-ring.prefix
-      [prefix: <string> | default = "collectors/"]
-
-      # Configuration for a Consul client. Only applies if the selected kvstore
-      # is consul.
-      # The CLI flags prefix for this block configuration is:
-      # ingester.partition-ring.consul
-      [consul: <consul>]
-
-      # Configuration for an ETCD v3 client. Only applies if the selected
-      # kvstore is etcd.
-      # The CLI flags prefix for this block configuration is:
-      # ingester.partition-ring.etcd
-      [etcd: <etcd>]
-
-      multi:
-        # Primary backend storage used by multi-client.
-        # CLI flag: -ingester.partition-ring.multi.primary
-        [primary: <string> | default = ""]
-
-        # Secondary backend storage used by multi-client.
-        # CLI flag: -ingester.partition-ring.multi.secondary
-        [secondary: <string> | default = ""]
-
-        # Mirror writes to secondary store.
-        # CLI flag: -ingester.partition-ring.multi.mirror-enabled
-        [mirror_enabled: <boolean> | default = false]
-
-        # Timeout for storing value to secondary store.
-        # CLI flag: -ingester.partition-ring.multi.mirror-timeout
-        [mirror_timeout: <duration> | default = 2s]
-
-    # Minimum number of owners to wait before a PENDING partition gets switched
-    # to ACTIVE.
-    # CLI flag: -ingester.partition-ring.min-partition-owners-count
-    [min_partition_owners_count: <int> | default = 1]
-
-    # How long the minimum number of owners are enforced before a PENDING
-    # partition gets switched to ACTIVE.
-    # CLI flag: -ingester.partition-ring.min-partition-owners-duration
-    [min_partition_owners_duration: <duration> | default = 10s]
-
-    # How long to wait before an INACTIVE partition is eligible for deletion.
-    # The partition is deleted only if it has been in INACTIVE state for at
-    # least the configured duration and it has no owners registered. A value of
-    # 0 disables partitions deletion.
-    # CLI flag: -ingester.partition-ring.delete-inactive-partition-after
-    [delete_inactive_partition_after: <duration> | default = 13h]
 
 # Configuration for 'runtime config' module, responsible for reloading runtime
 # configuration file.
@@ -2255,14 +1774,12 @@ ring:
 
     # Configuration for a Consul client. Only applies if the selected kvstore is
     # consul.
-    # The CLI flags prefix for this block configuration is:
-    # common.storage.ring.consul
+    # The CLI flags prefix for this block configuration is: common.storage.ring
     [consul: <consul>]
 
     # Configuration for an ETCD v3 client. Only applies if the selected kvstore
     # is etcd.
-    # The CLI flags prefix for this block configuration is:
-    # common.storage.ring.etcd
+    # The CLI flags prefix for this block configuration is: common.storage.ring
     [etcd: <etcd>]
 
     multi:
@@ -2436,13 +1953,12 @@ compactor_ring:
 
     # Configuration for a Consul client. Only applies if the selected kvstore is
     # consul.
-    # The CLI flags prefix for this block configuration is:
-    # compactor.ring.consul
+    # The CLI flags prefix for this block configuration is: compactor.ring
     [consul: <consul>]
 
     # Configuration for an ETCD v3 client. Only applies if the selected kvstore
     # is etcd.
-    # The CLI flags prefix for this block configuration is: compactor.ring.etcd
+    # The CLI flags prefix for this block configuration is: compactor.ring
     [etcd: <etcd>]
 
     multi:
@@ -2521,48 +2037,45 @@ compactor_ring:
 
 Configuration for a Consul client. Only applies if the selected kvstore is `consul`. The supported CLI flags `<prefix>` used to reference this configuration block are:
 
-- `common.storage.ring.consul`
-- `compactor.ring.consul`
-- `consul`
-- `distributor.ring.consul`
-- `index-gateway.ring.consul`
-- `ingester-rf1.consul`
-- `ingester.partition-ring.consul`
-- `kafka-ingesterconsul`
-- `pattern-ingester.consul`
-- `query-scheduler.ring.consul`
-- `ruler.ring.consul`
+- `common.storage.ring`
+- `compactor.ring`
+- `distributor.ring`
+- `index-gateway.ring`
+- `ingester.partition-ring`
+- `pattern-ingester`
+- `query-scheduler.ring`
+- `ruler.ring`
 
 &nbsp;
 
 ```yaml
 # Hostname and port of Consul.
-# CLI flag: -<prefix>.hostname
+# CLI flag: -<prefix>.consul.hostname
 [host: <string> | default = "localhost:8500"]
 
 # ACL Token used to interact with Consul.
-# CLI flag: -<prefix>.acl-token
+# CLI flag: -<prefix>.consul.acl-token
 [acl_token: <string> | default = ""]
 
 # HTTP timeout when talking to Consul
-# CLI flag: -<prefix>.client-timeout
+# CLI flag: -<prefix>.consul.client-timeout
 [http_client_timeout: <duration> | default = 20s]
 
 # Enable consistent reads to Consul.
-# CLI flag: -<prefix>.consistent-reads
+# CLI flag: -<prefix>.consul.consistent-reads
 [consistent_reads: <boolean> | default = false]
 
 # Rate limit when watching key or prefix in Consul, in requests per second. 0
 # disables the rate limit.
-# CLI flag: -<prefix>.watch-rate-limit
+# CLI flag: -<prefix>.consul.watch-rate-limit
 [watch_rate_limit: <float> | default = 1]
 
 # Burst size used in rate limit. Values less than 1 are treated as 1.
-# CLI flag: -<prefix>.watch-burst-size
+# CLI flag: -<prefix>.consul.watch-burst-size
 [watch_burst_size: <int> | default = 1]
 
 # Maximum duration to wait before retrying a Compare And Swap (CAS) operation.
-# CLI flag: -<prefix>.cas-retry-delay
+# CLI flag: -<prefix>.consul.cas-retry-delay
 [cas_retry_delay: <duration> | default = 1s]
 ```
 
@@ -2667,14 +2180,12 @@ ring:
 
     # Configuration for a Consul client. Only applies if the selected kvstore is
     # consul.
-    # The CLI flags prefix for this block configuration is:
-    # distributor.ring.consul
+    # The CLI flags prefix for this block configuration is: distributor.ring
     [consul: <consul>]
 
     # Configuration for an ETCD v3 client. Only applies if the selected kvstore
     # is etcd.
-    # The CLI flags prefix for this block configuration is:
-    # distributor.ring.etcd
+    # The CLI flags prefix for this block configuration is: distributor.ring
     [etcd: <etcd>]
 
     multi:
@@ -2746,58 +2257,55 @@ otlp_config:
 
 Configuration for an ETCD v3 client. Only applies if the selected kvstore is `etcd`. The supported CLI flags `<prefix>` used to reference this configuration block are:
 
-- `common.storage.ring.etcd`
-- `compactor.ring.etcd`
-- `distributor.ring.etcd`
-- `etcd`
-- `index-gateway.ring.etcd`
-- `ingester-rf1.etcd`
-- `ingester.partition-ring.etcd`
-- `kafka-ingesteretcd`
-- `pattern-ingester.etcd`
-- `query-scheduler.ring.etcd`
-- `ruler.ring.etcd`
+- `common.storage.ring`
+- `compactor.ring`
+- `distributor.ring`
+- `index-gateway.ring`
+- `ingester.partition-ring`
+- `pattern-ingester`
+- `query-scheduler.ring`
+- `ruler.ring`
 
 &nbsp;
 
 ```yaml
 # The etcd endpoints to connect to.
-# CLI flag: -<prefix>.endpoints
+# CLI flag: -<prefix>.etcd.endpoints
 [endpoints: <list of strings> | default = []]
 
 # The dial timeout for the etcd connection.
-# CLI flag: -<prefix>.dial-timeout
+# CLI flag: -<prefix>.etcd.dial-timeout
 [dial_timeout: <duration> | default = 10s]
 
 # The maximum number of retries to do for failed ops.
-# CLI flag: -<prefix>.max-retries
+# CLI flag: -<prefix>.etcd.max-retries
 [max_retries: <int> | default = 10]
 
 # Enable TLS.
-# CLI flag: -<prefix>.tls-enabled
+# CLI flag: -<prefix>.etcd.tls-enabled
 [tls_enabled: <boolean> | default = false]
 
 # Path to the client certificate, which will be used for authenticating with the
 # server. Also requires the key path to be configured.
-# CLI flag: -<prefix>.tls-cert-path
+# CLI flag: -<prefix>.etcd.tls-cert-path
 [tls_cert_path: <string> | default = ""]
 
 # Path to the key for the client certificate. Also requires the client
 # certificate to be configured.
-# CLI flag: -<prefix>.tls-key-path
+# CLI flag: -<prefix>.etcd.tls-key-path
 [tls_key_path: <string> | default = ""]
 
 # Path to the CA certificates to validate server certificate against. If not
 # set, the host's root CA certificates are used.
-# CLI flag: -<prefix>.tls-ca-path
+# CLI flag: -<prefix>.etcd.tls-ca-path
 [tls_ca_path: <string> | default = ""]
 
 # Override the expected name on the server certificate.
-# CLI flag: -<prefix>.tls-server-name
+# CLI flag: -<prefix>.etcd.tls-server-name
 [tls_server_name: <string> | default = ""]
 
 # Skip validating server certificate.
-# CLI flag: -<prefix>.tls-insecure-skip-verify
+# CLI flag: -<prefix>.etcd.tls-insecure-skip-verify
 [tls_insecure_skip_verify: <boolean> | default = false]
 
 # Override the default cipher suite list (separated by commas). Allowed values:
@@ -2830,20 +2338,20 @@ Configuration for an ETCD v3 client. Only applies if the selected kvstore is `et
 # - TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA
 # - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256
 # - TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
-# CLI flag: -<prefix>.tls-cipher-suites
+# CLI flag: -<prefix>.etcd.tls-cipher-suites
 [tls_cipher_suites: <string> | default = ""]
 
 # Override the default minimum TLS version. Allowed values: VersionTLS10,
 # VersionTLS11, VersionTLS12, VersionTLS13
-# CLI flag: -<prefix>.tls-min-version
+# CLI flag: -<prefix>.etcd.tls-min-version
 [tls_min_version: <string> | default = ""]
 
 # Etcd username.
-# CLI flag: -<prefix>.username
+# CLI flag: -<prefix>.etcd.username
 [username: <string> | default = ""]
 
 # Etcd password.
-# CLI flag: -<prefix>.password
+# CLI flag: -<prefix>.etcd.password
 [password: <string> | default = ""]
 ```
 
@@ -3042,7 +2550,6 @@ The `grpc_client` block configures the gRPC client used to communicate between a
 - `bloom-gateway-client.grpc`
 - `boltdb.shipper.index-gateway-client.grpc`
 - `frontend.grpc-client-config`
-- `ingester-rf1.client`
 - `ingester.client`
 - `metastore.grpc-client-config`
 - `pattern-ingester.client`
@@ -3220,14 +2727,12 @@ ring:
 
     # Configuration for a Consul client. Only applies if the selected kvstore is
     # consul.
-    # The CLI flags prefix for this block configuration is:
-    # index-gateway.ring.consul
+    # The CLI flags prefix for this block configuration is: index-gateway.ring
     [consul: <consul>]
 
     # Configuration for an ETCD v3 client. Only applies if the selected kvstore
     # is etcd.
-    # The CLI flags prefix for this block configuration is:
-    # index-gateway.ring.etcd
+    # The CLI flags prefix for this block configuration is: index-gateway.ring
     [etcd: <etcd>]
 
     multi:
@@ -3319,12 +2824,10 @@ lifecycler:
 
       # Configuration for a Consul client. Only applies if the selected kvstore
       # is consul.
-      # The CLI flags prefix for this block configuration is: consul
       [consul: <consul>]
 
       # Configuration for an ETCD v3 client. Only applies if the selected
       # kvstore is etcd.
-      # The CLI flags prefix for this block configuration is: etcd
       [etcd: <etcd>]
 
       multi:
@@ -3584,6 +3087,71 @@ wal:
 # ring to recalculate owned streams.
 # CLI flag: -ingester.owned-streams-check-interval
 [owned_streams_check_interval: <duration> | default = 30s]
+
+kafka_ingestion:
+  # Whether the kafka ingester is enabled.
+  # CLI flag: -ingester.kafka-ingestion-enabled
+  [enabled: <boolean> | default = false]
+
+  partition_ring:
+    # The key-value store used to share the hash ring across multiple instances.
+    # This option needs be set on ingesters, distributors, queriers, and rulers
+    # when running in microservices mode.
+    kvstore:
+      # Backend storage to use for the ring. Supported values are: consul, etcd,
+      # inmemory, memberlist, multi.
+      # CLI flag: -ingester.partition-ring.store
+      [store: <string> | default = "memberlist"]
+
+      # The prefix for the keys in the store. Should end with a /.
+      # CLI flag: -ingester.partition-ring.prefix
+      [prefix: <string> | default = "collectors/"]
+
+      # Configuration for a Consul client. Only applies if the selected kvstore
+      # is consul.
+      # The CLI flags prefix for this block configuration is:
+      # ingester.partition-ring
+      [consul: <consul>]
+
+      # Configuration for an ETCD v3 client. Only applies if the selected
+      # kvstore is etcd.
+      # The CLI flags prefix for this block configuration is:
+      # ingester.partition-ring
+      [etcd: <etcd>]
+
+      multi:
+        # Primary backend storage used by multi-client.
+        # CLI flag: -ingester.partition-ring.multi.primary
+        [primary: <string> | default = ""]
+
+        # Secondary backend storage used by multi-client.
+        # CLI flag: -ingester.partition-ring.multi.secondary
+        [secondary: <string> | default = ""]
+
+        # Mirror writes to secondary store.
+        # CLI flag: -ingester.partition-ring.multi.mirror-enabled
+        [mirror_enabled: <boolean> | default = false]
+
+        # Timeout for storing value to secondary store.
+        # CLI flag: -ingester.partition-ring.multi.mirror-timeout
+        [mirror_timeout: <duration> | default = 2s]
+
+    # Minimum number of owners to wait before a PENDING partition gets switched
+    # to ACTIVE.
+    # CLI flag: -ingester.partition-ring.min-partition-owners-count
+    [min_partition_owners_count: <int> | default = 1]
+
+    # How long the minimum number of owners are enforced before a PENDING
+    # partition gets switched to ACTIVE.
+    # CLI flag: -ingester.partition-ring.min-partition-owners-duration
+    [min_partition_owners_duration: <duration> | default = 10s]
+
+    # How long to wait before an INACTIVE partition is eligible for deletion.
+    # The partition is deleted only if it has been in INACTIVE state for at
+    # least the configured duration and it has no owners registered. A value of
+    # 0 disables partitions deletion.
+    # CLI flag: -ingester.partition-ring.delete-inactive-partition-after
+    [delete_inactive_partition_after: <duration> | default = 13h]
 ```
 
 ### ingester_client
@@ -3593,16 +3161,26 @@ The `ingester_client` block configures how the distributor will connect to inges
 ```yaml
 # Configures how connections are pooled.
 pool_config:
-  [client_cleanup_period: <duration>]
+  # How frequently to clean up clients for ingesters that have gone away.
+  # CLI flag: -distributor.client-cleanup-period
+  [client_cleanup_period: <duration> | default = 15s]
 
-  [health_check_ingesters: <boolean>]
+  # Run a health check on each ingester client during periodic cleanup.
+  # CLI flag: -distributor.health-check-ingesters
+  [health_check_ingesters: <boolean> | default = true]
 
-  [remote_timeout: <duration>]
+  # How quickly a dead client will be removed after it has been detected to
+  # disappear. Set this to a value to allow time for a secondary health check to
+  # recover the missing client.
+  # CLI flag: -ingester.client.healthcheck-timeout
+  [remote_timeout: <duration> | default = 1s]
 
-[remote_timeout: <duration>]
+# The remote request timeout on the client side.
+# CLI flag: -ingester.client.timeout
+[remote_timeout: <duration> | default = 5s]
 
 # Configures how the gRPC connection to ingesters work as a client.
-# The CLI flags prefix for this block configuration is: ingester-rf1.client
+# The CLI flags prefix for this block configuration is: ingester.client
 [grpc_client_config: <grpc_client>]
 ```
 
@@ -4799,14 +4377,12 @@ scheduler_ring:
 
     # Configuration for a Consul client. Only applies if the selected kvstore is
     # consul.
-    # The CLI flags prefix for this block configuration is:
-    # query-scheduler.ring.consul
+    # The CLI flags prefix for this block configuration is: query-scheduler.ring
     [consul: <consul>]
 
     # Configuration for an ETCD v3 client. Only applies if the selected kvstore
     # is etcd.
-    # The CLI flags prefix for this block configuration is:
-    # query-scheduler.ring.etcd
+    # The CLI flags prefix for this block configuration is: query-scheduler.ring
     [etcd: <etcd>]
 
     multi:
@@ -5107,12 +4683,12 @@ ring:
 
     # Configuration for a Consul client. Only applies if the selected kvstore is
     # consul.
-    # The CLI flags prefix for this block configuration is: ruler.ring.consul
+    # The CLI flags prefix for this block configuration is: ruler.ring
     [consul: <consul>]
 
     # Configuration for an ETCD v3 client. Only applies if the selected kvstore
     # is etcd.
-    # The CLI flags prefix for this block configuration is: ruler.ring.etcd
+    # The CLI flags prefix for this block configuration is: ruler.ring
     [etcd: <etcd>]
 
     multi:

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -14,6 +14,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/grafana/loki/v3/pkg/kafka"
+	"github.com/grafana/loki/v3/pkg/kafka/partitionring"
 	"github.com/grafana/loki/v3/pkg/loghttp/push"
 	"github.com/grafana/loki/v3/pkg/logqlmodel/metadata"
 	"github.com/grafana/loki/v3/pkg/storage/types"
@@ -67,6 +69,10 @@ const (
 	RingKey = "ring"
 
 	shutdownMarkerFilename = "shutdown-requested.txt"
+
+	// PartitionRingKey is the key under which we store the partitions ring used by the "ingest storage".
+	PartitionRingKey  = "ingester-partitions"
+	PartitionRingName = "ingester-partitions"
 )
 
 // ErrReadOnly is returned when the ingester is shutting down and a push was
@@ -125,12 +131,15 @@ type Config struct {
 	ShutdownMarkerPath string `yaml:"shutdown_marker_path"`
 
 	OwnedStreamsCheckInterval time.Duration `yaml:"owned_streams_check_interval" doc:"description=Interval at which the ingester ownedStreamService checks for changes in the ring to recalculate owned streams."`
+
+	KafkaIngestion KafkaIngestionConfig `yaml:"kafka_ingestion,omitempty"`
 }
 
 // RegisterFlags registers the flags.
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	cfg.LifecyclerConfig.RegisterFlags(f, util_log.Logger)
 	cfg.WAL.RegisterFlags(f)
+	cfg.KafkaIngestion.RegisterFlags(f)
 
 	f.IntVar(&cfg.ConcurrentFlushes, "ingester.concurrent-flushes", 32, "How many flushes can happen concurrently from each stream.")
 	f.DurationVar(&cfg.FlushCheckPeriod, "ingester.flush-check-period", 30*time.Second, "How often should the ingester see if there are any blocks to flush. The first flush check is delayed by a random time up to 0.8x the flush check period. Additionally, there is +/- 1% jitter added to the interval.")
@@ -180,6 +189,17 @@ func (cfg *Config) Validate() error {
 	}
 
 	return nil
+}
+
+type KafkaIngestionConfig struct {
+	Enabled             bool                 `yaml:"enabled" doc:"description=Whether the kafka ingester is enabled."`
+	PartitionRingConfig partitionring.Config `yaml:"partition_ring" category:"experimental"`
+	KafkaConfig         kafka.Config         `yaml:"-"`
+}
+
+func (cfg *KafkaIngestionConfig) RegisterFlags(f *flag.FlagSet) {
+	cfg.PartitionRingConfig.RegisterFlagsWithPrefix("ingester.", f)
+	f.BoolVar(&cfg.Enabled, "ingester.kafka-ingestion-enabled", false, "Whether the ingester will consume data from kafka.")
 }
 
 type Wrapper interface {
@@ -785,7 +805,7 @@ func createShutdownMarker(p string) error {
 		return err
 	}
 
-	dir, err := os.OpenFile(path.Dir(p), os.O_RDONLY, 0777)
+	dir, err := os.OpenFile(path.Dir(p), os.O_RDONLY, 0o777)
 	if err != nil {
 		return err
 	}
@@ -802,7 +822,7 @@ func removeShutdownMarker(p string) error {
 		return err
 	}
 
-	dir, err := os.OpenFile(path.Dir(p), os.O_RDONLY, 0777)
+	dir, err := os.OpenFile(path.Dir(p), os.O_RDONLY, 0o777)
 	if err != nil {
 		return err
 	}
@@ -1388,6 +1408,7 @@ func (i *Ingester) Tail(req *logproto.TailRequest, queryServer logproto.Querier_
 	err = server_util.ClientGrpcStatusAndError(err)
 	return err
 }
+
 func (i *Ingester) tail(req *logproto.TailRequest, queryServer logproto.Querier_TailServer) error {
 	select {
 	case <-i.tailersQuit:
@@ -1524,7 +1545,6 @@ func (i *Ingester) getDetectedLabels(ctx context.Context, req *logproto.Detected
 	}
 
 	labelMap, err := instance.LabelsWithValues(ctx, req.Start, matchers...)
-
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -71,7 +71,7 @@ const (
 	shutdownMarkerFilename = "shutdown-requested.txt"
 
 	// PartitionRingKey is the key under which we store the partitions ring used by the "ingest storage".
-	PartitionRingKey  = "ingester-partitions"
+	PartitionRingKey  = "ingester-partitions-key"
 	PartitionRingName = "ingester-partitions"
 )
 

--- a/pkg/kafka/ingester/ingester.go
+++ b/pkg/kafka/ingester/ingester.go
@@ -51,8 +51,8 @@ type Config struct {
 
 // RegisterFlags registers the flags.
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
-	cfg.LifecyclerConfig.RegisterFlagsWithPrefix("kafka-ingester", f, util_log.Logger)
-	cfg.PartitionRingConfig.RegisterFlags(f)
+	cfg.LifecyclerConfig.RegisterFlagsWithPrefix("kafka-ingester.", f, util_log.Logger)
+	cfg.PartitionRingConfig.RegisterFlagsWithPrefix("kafka-ingester.", f)
 	f.StringVar(&cfg.ShutdownMarkerPath, "kafka-ingester.shutdown-marker-path", "", "Path where the shutdown marker file is stored. If not set and common.path_prefix is set then common.path_prefix will be used.")
 	f.BoolVar(&cfg.Enabled, "kafka-ingester.enabled", false, "Whether the Kafka-based ingester path is enabled")
 	f.DurationVar(&cfg.FlushInterval, "kafka-ingester.flush-interval", defaultFlushInterval, "The interval at which the ingester will flush and commit offsets to Kafka. If not set, the default flush interval will be used.")

--- a/pkg/kafka/partitionring/partition_ring.go
+++ b/pkg/kafka/partitionring/partition_ring.go
@@ -25,14 +25,14 @@ type Config struct {
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet
-func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
+func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	// Ring flags
 	cfg.KVStore.Store = "memberlist" // Override default value.
-	cfg.KVStore.RegisterFlagsWithPrefix("ingester.partition-ring.", "collectors/", f)
+	cfg.KVStore.RegisterFlagsWithPrefix(prefix+"partition-ring.", "collectors/", f)
 
-	f.IntVar(&cfg.MinOwnersCount, "ingester.partition-ring.min-partition-owners-count", 1, "Minimum number of owners to wait before a PENDING partition gets switched to ACTIVE.")
-	f.DurationVar(&cfg.MinOwnersDuration, "ingester.partition-ring.min-partition-owners-duration", 10*time.Second, "How long the minimum number of owners are enforced before a PENDING partition gets switched to ACTIVE.")
-	f.DurationVar(&cfg.DeleteInactivePartitionAfter, "ingester.partition-ring.delete-inactive-partition-after", 13*time.Hour, "How long to wait before an INACTIVE partition is eligible for deletion. The partition is deleted only if it has been in INACTIVE state for at least the configured duration and it has no owners registered. A value of 0 disables partitions deletion.")
+	f.IntVar(&cfg.MinOwnersCount, prefix+"partition-ring.min-partition-owners-count", 1, "Minimum number of owners to wait before a PENDING partition gets switched to ACTIVE.")
+	f.DurationVar(&cfg.MinOwnersDuration, prefix+"partition-ring.min-partition-owners-duration", 10*time.Second, "How long the minimum number of owners are enforced before a PENDING partition gets switched to ACTIVE.")
+	f.DurationVar(&cfg.DeleteInactivePartitionAfter, prefix+"partition-ring.delete-inactive-partition-after", 13*time.Hour, "How long to wait before an INACTIVE partition is eligible for deletion. The partition is deleted only if it has been in INACTIVE state for at least the configured duration and it has no owners registered. A value of 0 disables partitions deletion.")
 }
 
 func (cfg *Config) ToLifecyclerConfig(partitionID int32, instanceID string) ring.PartitionInstanceLifecyclerConfig {

--- a/pkg/loki/config_wrapper.go
+++ b/pkg/loki/config_wrapper.go
@@ -247,21 +247,6 @@ func applyConfigToRings(r, defaults *ConfigWrapper, rc lokiring.RingConfig, merg
 	}
 
 	if mergeWithExisting {
-		r.IngesterRF1.LifecyclerConfig.RingConfig.KVStore = rc.KVStore
-		r.IngesterRF1.LifecyclerConfig.HeartbeatPeriod = rc.HeartbeatPeriod
-		r.IngesterRF1.LifecyclerConfig.RingConfig.HeartbeatTimeout = rc.HeartbeatTimeout
-		r.IngesterRF1.LifecyclerConfig.TokensFilePath = rc.TokensFilePath
-		r.IngesterRF1.LifecyclerConfig.RingConfig.ZoneAwarenessEnabled = rc.ZoneAwarenessEnabled
-		r.IngesterRF1.LifecyclerConfig.ID = rc.InstanceID
-		r.IngesterRF1.LifecyclerConfig.InfNames = rc.InstanceInterfaceNames
-		r.IngesterRF1.LifecyclerConfig.Port = rc.InstancePort
-		r.IngesterRF1.LifecyclerConfig.Addr = rc.InstanceAddr
-		r.IngesterRF1.LifecyclerConfig.Zone = rc.InstanceZone
-		r.IngesterRF1.LifecyclerConfig.ListenPort = rc.ListenPort
-		r.IngesterRF1.LifecyclerConfig.ObservePeriod = rc.ObservePeriod
-	}
-
-	if mergeWithExisting {
 		r.Pattern.LifecyclerConfig.RingConfig.KVStore = rc.KVStore
 		r.Pattern.LifecyclerConfig.HeartbeatPeriod = rc.HeartbeatPeriod
 		r.Pattern.LifecyclerConfig.RingConfig.HeartbeatTimeout = rc.HeartbeatTimeout
@@ -274,21 +259,6 @@ func applyConfigToRings(r, defaults *ConfigWrapper, rc lokiring.RingConfig, merg
 		r.Pattern.LifecyclerConfig.Zone = rc.InstanceZone
 		r.Pattern.LifecyclerConfig.ListenPort = rc.ListenPort
 		r.Pattern.LifecyclerConfig.ObservePeriod = rc.ObservePeriod
-	}
-
-	if mergeWithExisting {
-		r.KafkaIngester.LifecyclerConfig.RingConfig.KVStore = rc.KVStore
-		r.KafkaIngester.LifecyclerConfig.HeartbeatPeriod = rc.HeartbeatPeriod
-		r.KafkaIngester.LifecyclerConfig.RingConfig.HeartbeatTimeout = rc.HeartbeatTimeout
-		r.KafkaIngester.LifecyclerConfig.TokensFilePath = rc.TokensFilePath
-		r.KafkaIngester.LifecyclerConfig.RingConfig.ZoneAwarenessEnabled = rc.ZoneAwarenessEnabled
-		r.KafkaIngester.LifecyclerConfig.ID = rc.InstanceID
-		r.KafkaIngester.LifecyclerConfig.InfNames = rc.InstanceInterfaceNames
-		r.KafkaIngester.LifecyclerConfig.Port = rc.InstancePort
-		r.KafkaIngester.LifecyclerConfig.Addr = rc.InstanceAddr
-		r.KafkaIngester.LifecyclerConfig.Zone = rc.InstanceZone
-		r.KafkaIngester.LifecyclerConfig.ListenPort = rc.ListenPort
-		r.KafkaIngester.LifecyclerConfig.ObservePeriod = rc.ObservePeriod
 	}
 
 	// Distributor
@@ -673,7 +643,6 @@ func applyIngesterFinalSleep(cfg *ConfigWrapper) {
 
 func applyIngesterReplicationFactor(cfg *ConfigWrapper) {
 	cfg.Ingester.LifecyclerConfig.RingConfig.ReplicationFactor = cfg.Common.ReplicationFactor
-	cfg.IngesterRF1.LifecyclerConfig.RingConfig.ReplicationFactor = cfg.Common.ReplicationFactor
 }
 
 // applyChunkRetain is used to set chunk retain based on having an index query cache configured

--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -42,7 +42,6 @@ import (
 	ingester_rf1 "github.com/grafana/loki/v3/pkg/ingester-rf1"
 	"github.com/grafana/loki/v3/pkg/ingester-rf1/metastore"
 	metastoreclient "github.com/grafana/loki/v3/pkg/ingester-rf1/metastore/client"
-	"github.com/grafana/loki/v3/pkg/ingester-rf1/metastore/health"
 	ingester_client "github.com/grafana/loki/v3/pkg/ingester/client"
 	"github.com/grafana/loki/v3/pkg/kafka"
 	ingester_kafka "github.com/grafana/loki/v3/pkg/kafka/ingester"
@@ -96,7 +95,6 @@ type Config struct {
 	IngesterClient      ingester_client.Config     `yaml:"ingester_client,omitempty"`
 	IngesterRF1Client   ingester_client.Config     `yaml:"ingester_rf1_client,omitempty"`
 	Ingester            ingester.Config            `yaml:"ingester,omitempty"`
-	IngesterRF1         ingester_rf1.Config        `yaml:"ingester_rf1,omitempty" category:"experimental"`
 	Pattern             pattern.Config             `yaml:"pattern_ingester,omitempty"`
 	IndexGateway        indexgateway.Config        `yaml:"index_gateway"`
 	BloomBuild          bloombuild.Config          `yaml:"bloom_build,omitempty" category:"experimental"`
@@ -114,7 +112,6 @@ type Config struct {
 	Metastore           metastore.Config           `yaml:"metastore,omitempty"`
 	MetastoreClient     metastoreclient.Config     `yaml:"metastore_client"`
 	KafkaConfig         kafka.Config               `yaml:"kafka_config,omitempty" category:"experimental"`
-	KafkaIngester       ingester_kafka.Config      `yaml:"kafka_ingester,omitempty" category:"experimental"`
 
 	RuntimeConfig     runtimeconfig.Config `yaml:"runtime_config,omitempty"`
 	OperationalConfig runtime.Config       `yaml:"operational_config,omitempty"`
@@ -172,9 +169,7 @@ func (c *Config) RegisterFlags(f *flag.FlagSet) {
 	c.CompactorHTTPClient.RegisterFlags(f)
 	c.CompactorGRPCClient.RegisterFlags(f)
 	c.IngesterClient.RegisterFlags(f)
-	// c.IngesterRF1Client.RegisterFlags(f)
 	c.Ingester.RegisterFlags(f)
-	c.IngesterRF1.RegisterFlags(f)
 	c.StorageConfig.RegisterFlags(f)
 	c.IndexGateway.RegisterFlags(f)
 	c.BloomGateway.RegisterFlags(f)
@@ -198,7 +193,6 @@ func (c *Config) RegisterFlags(f *flag.FlagSet) {
 	c.Metastore.RegisterFlags(f)
 	c.MetastoreClient.RegisterFlags(f)
 	c.KafkaConfig.RegisterFlags(f)
-	c.KafkaIngester.RegisterFlags(f)
 }
 
 func (c *Config) registerServerFlagsWithChangedDefaultValues(fs *flag.FlagSet) {
@@ -271,9 +265,6 @@ func (c *Config) Validate() error {
 	if err := c.Ingester.Validate(); err != nil {
 		errs = append(errs, errors.Wrap(err, "CONFIG ERROR: invalid ingester config"))
 	}
-	if err := c.IngesterRF1.Validate(); err != nil {
-		errs = append(errs, errors.Wrap(err, "CONFIG ERROR: invalid ingester config"))
-	}
 	if err := c.LimitsConfig.Validate(); err != nil {
 		errs = append(errs, errors.Wrap(err, "CONFIG ERROR: invalid limits_config config"))
 	}
@@ -304,12 +295,9 @@ func (c *Config) Validate() error {
 	if err := c.Pattern.Validate(); err != nil {
 		errs = append(errs, errors.Wrap(err, "CONFIG ERROR: invalid pattern_ingester config"))
 	}
-	if c.KafkaIngester.Enabled {
+	if c.Ingester.KafkaIngestion.Enabled {
 		if err := c.KafkaConfig.Validate(); err != nil {
 			errs = append(errs, errors.Wrap(err, "CONFIG ERROR: invalid kafka_config config"))
-		}
-		if err := c.KafkaIngester.Validate(); err != nil {
-			errs = append(errs, errors.Wrap(err, "CONFIG ERROR: invalid kafka_ingester config"))
 		}
 	}
 
@@ -399,7 +387,6 @@ type Loki struct {
 	Tee                distributor.Tee
 	PushParserWrapper  push.RequestParserWrapper
 	HTTPAuthMiddleware middleware.Interface
-	health             *health.GRPCHealthService
 
 	Codec   Codec
 	Metrics *server.Metrics
@@ -523,11 +510,7 @@ func (t *Loki) Run(opts RunOpts) error {
 
 	t.Server.HTTP.Path("/log_level").Methods("GET", "POST").Handler(util_log.LevelHandler(&t.Cfg.Server.LogLevel))
 
-	if t.Cfg.isTarget(Metastore) {
-		grpc_health_v1.RegisterHealthServer(t.Server.GRPC, t.health)
-	} else {
-		grpc_health_v1.RegisterHealthServer(t.Server.GRPC, grpcutil.NewHealthCheck(sm))
-	}
+	grpc_health_v1.RegisterHealthServer(t.Server.GRPC, grpcutil.NewHealthCheck(sm))
 
 	// Config endpoint adds a way to see the config and the changes compared to the defaults.
 	t.bindConfigEndpoint(opts)
@@ -694,9 +677,6 @@ func (t *Loki) setupModuleManager() error {
 	mm.RegisterModule(Store, t.initStore, modules.UserInvisibleModule)
 	mm.RegisterModule(Querier, t.initQuerier)
 	mm.RegisterModule(Ingester, t.initIngester)
-	mm.RegisterModule(IngesterRF1, t.initIngesterRF1)
-	mm.RegisterModule(IngesterKafka, t.initKafkaIngester)
-	mm.RegisterModule(IngesterRF1RingClient, t.initIngesterRF1RingClient, modules.UserInvisibleModule)
 	mm.RegisterModule(IngesterQuerier, t.initIngesterQuerier)
 	mm.RegisterModule(IngesterGRPCInterceptors, t.initIngesterGRPCInterceptors, modules.UserInvisibleModule)
 	mm.RegisterModule(QueryFrontendTripperware, t.initQueryFrontendMiddleware, modules.UserInvisibleModule)
@@ -720,8 +700,6 @@ func (t *Loki) setupModuleManager() error {
 	mm.RegisterModule(PatternRingClient, t.initPatternRingClient, modules.UserInvisibleModule)
 	mm.RegisterModule(PatternIngesterTee, t.initPatternIngesterTee, modules.UserInvisibleModule)
 	mm.RegisterModule(PatternIngester, t.initPatternIngester)
-	mm.RegisterModule(Metastore, t.initMetastore)
-	mm.RegisterModule(MetastoreClient, t.initMetastoreClient, modules.UserInvisibleModule)
 	mm.RegisterModule(PartitionRing, t.initPartitionRing, modules.UserInvisibleModule)
 
 	mm.RegisterModule(All, nil)
@@ -736,12 +714,10 @@ func (t *Loki) setupModuleManager() error {
 		Overrides:                {RuntimeConfig},
 		OverridesExporter:        {Overrides, Server},
 		TenantConfigs:            {RuntimeConfig},
-		Distributor:              {Ring, Server, Overrides, TenantConfigs, PatternRingClient, PatternIngesterTee, IngesterRF1RingClient, Analytics, PartitionRing},
+		Distributor:              {Ring, Server, Overrides, TenantConfigs, PatternRingClient, PatternIngesterTee, Analytics, PartitionRing},
 		Store:                    {Overrides, IndexGatewayRing},
-		IngesterRF1:              {Store, Server, MemberlistKV, TenantConfigs, MetastoreClient, Analytics, PartitionRing},
-		IngesterKafka:            {Store, Server, MemberlistKV, TenantConfigs, MetastoreClient, Analytics, PartitionRing},
 		Ingester:                 {Store, Server, MemberlistKV, TenantConfigs, Analytics},
-		Querier:                  {Store, Ring, Server, IngesterQuerier, PatternRingClient, MetastoreClient, Overrides, Analytics, CacheGenerationLoader, QuerySchedulerRing},
+		Querier:                  {Store, Ring, Server, IngesterQuerier, PatternRingClient, Overrides, Analytics, CacheGenerationLoader, QuerySchedulerRing},
 		QueryFrontendTripperware: {Server, Overrides, TenantConfigs},
 		QueryFrontend:            {QueryFrontendTripperware, Analytics, CacheGenerationLoader, QuerySchedulerRing},
 		QueryScheduler:           {Server, Overrides, MemberlistKV, Analytics, QuerySchedulerRing},
@@ -757,8 +733,6 @@ func (t *Loki) setupModuleManager() error {
 		PatternRingClient:        {Server, MemberlistKV, Analytics},
 		PatternIngesterTee:       {Server, MemberlistKV, Analytics, PatternRingClient},
 		PatternIngester:          {Server, MemberlistKV, Analytics, PatternRingClient, PatternIngesterTee},
-		IngesterRF1RingClient:    {Server, MemberlistKV, Analytics},
-		Metastore:                {Server, MetastoreClient},
 		IngesterQuerier:          {Ring},
 		QuerySchedulerRing:       {Overrides, MemberlistKV},
 		IndexGatewayRing:         {Overrides, MemberlistKV},
@@ -766,10 +740,10 @@ func (t *Loki) setupModuleManager() error {
 		MemberlistKV:             {Server},
 
 		Read:    {QueryFrontend, Querier},
-		Write:   {Ingester, IngesterRF1, Distributor, PatternIngester, IngesterKafka},
+		Write:   {Ingester, Distributor, PatternIngester},
 		Backend: {QueryScheduler, Ruler, Compactor, IndexGateway, BloomPlanner, BloomBuilder, BloomGateway},
 
-		All: {QueryScheduler, QueryFrontend, Querier, Ingester, IngesterRF1, PatternIngester, Distributor, Ruler, Compactor, Metastore, IngesterKafka},
+		All: {QueryScheduler, QueryFrontend, Querier, Ingester, PatternIngester, Distributor, Ruler, Compactor},
 	}
 
 	if t.Cfg.Querier.PerRequestLimitsEnabled {

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -47,14 +47,8 @@ import (
 	"github.com/grafana/loki/v3/pkg/distributor"
 	"github.com/grafana/loki/v3/pkg/indexgateway"
 	"github.com/grafana/loki/v3/pkg/ingester"
-	ingester_rf1 "github.com/grafana/loki/v3/pkg/ingester-rf1"
-	"github.com/grafana/loki/v3/pkg/ingester-rf1/metastore"
-	metastoreclient "github.com/grafana/loki/v3/pkg/ingester-rf1/metastore/client"
-	"github.com/grafana/loki/v3/pkg/ingester-rf1/metastore/health"
-	"github.com/grafana/loki/v3/pkg/ingester-rf1/metastore/metastorepb"
 	"github.com/grafana/loki/v3/pkg/ingester-rf1/objstore"
 	ingesterkafka "github.com/grafana/loki/v3/pkg/kafka/ingester"
-	kafka_tee "github.com/grafana/loki/v3/pkg/kafka/tee"
 	"github.com/grafana/loki/v3/pkg/logproto"
 	"github.com/grafana/loki/v3/pkg/logql"
 	"github.com/grafana/loki/v3/pkg/logqlmodel/stats"
@@ -110,9 +104,6 @@ const (
 	Querier                  string = "querier"
 	CacheGenerationLoader    string = "cache-generation-loader"
 	Ingester                 string = "ingester"
-	IngesterRF1              string = "ingester-rf1"
-	IngesterKafka            string = "ingester-kafka"
-	IngesterRF1RingClient    string = "ingester-rf1-ring-client"
 	PatternIngester          string = "pattern-ingester"
 	PatternIngesterTee       string = "pattern-ingester-tee"
 	PatternRingClient        string = "pattern-ring-client"
@@ -145,8 +136,6 @@ const (
 	Backend                  string = "backend"
 	Analytics                string = "analytics"
 	InitCodec                string = "init-codec"
-	Metastore                string = "metastore"
-	MetastoreClient          string = "metastore-client"
 	PartitionRing            string = "partition-ring"
 )
 
@@ -175,8 +164,6 @@ func (t *Loki) initServer() (services.Service, error) {
 	}
 
 	t.Server = serv
-
-	t.health = health.NewGRPCHealthService()
 
 	servicesToWaitFor := func() []services.Service {
 		svs := []services.Service(nil)
@@ -334,21 +321,6 @@ func (t *Loki) initTenantConfigs() (_ services.Service, err error) {
 }
 
 func (t *Loki) initDistributor() (services.Service, error) {
-	if t.Cfg.IngesterRF1.Enabled {
-		rf1Tee, err := ingester_rf1.NewTee(t.Cfg.IngesterRF1, t.IngesterRF1RingClient, t.Cfg.MetricsNamespace, prometheus.DefaultRegisterer, util_log.Logger)
-		if err != nil {
-			return nil, err
-		}
-		t.Tee = distributor.WrapTee(t.Tee, rf1Tee)
-	}
-	if t.Cfg.KafkaIngester.Enabled {
-		kafkaTee, err := kafka_tee.NewTee(t.Cfg.KafkaConfig, t.Cfg.MetricsNamespace, prometheus.DefaultRegisterer, util_log.Logger, t.partitionRing)
-		if err != nil {
-			return nil, err
-		}
-		t.Tee = distributor.WrapTee(t.Tee, kafkaTee)
-	}
-
 	var err error
 	logger := log.With(util_log.Logger, "component", "distributor")
 	t.distributor, err = distributor.New(
@@ -613,6 +585,7 @@ func (t *Loki) initQuerier() (services.Service, error) {
 func (t *Loki) initIngester() (_ services.Service, err error) {
 	logger := log.With(util_log.Logger, "component", "ingester")
 	t.Cfg.Ingester.LifecyclerConfig.ListenPort = t.Cfg.Server.GRPCListenPort
+	t.Cfg.Ingester.KafkaIngestion.KafkaConfig = t.Cfg.KafkaConfig
 
 	if t.Cfg.Ingester.ShutdownMarkerPath == "" && t.Cfg.Common.PathPrefix != "" {
 		t.Cfg.Ingester.ShutdownMarkerPath = t.Cfg.Common.PathPrefix
@@ -647,102 +620,6 @@ func (t *Loki) initIngester() (_ services.Service, err error) {
 		httpMiddleware.Wrap(http.HandlerFunc(t.Ingester.ShutdownHandler)),
 	)
 	return t.Ingester, nil
-}
-
-func (t *Loki) initKafkaIngester() (_ services.Service, err error) {
-	if !t.Cfg.KafkaIngester.Enabled {
-		return nil, nil
-	}
-	t.Cfg.KafkaIngester.KafkaConfig = t.Cfg.KafkaConfig
-	logger := log.With(util_log.Logger, "component", "ingester-kafka")
-	t.Cfg.KafkaIngester.LifecyclerConfig.ListenPort = t.Cfg.Server.GRPCListenPort
-
-	if t.Cfg.KafkaIngester.ShutdownMarkerPath == "" && t.Cfg.Common.PathPrefix != "" {
-		t.Cfg.KafkaIngester.ShutdownMarkerPath = t.Cfg.Common.PathPrefix
-	}
-	if t.Cfg.KafkaIngester.ShutdownMarkerPath == "" {
-		return nil, errors.New("the config setting shutdown marker path is not set. The /ingester/prepare-partition-downscale endpoint won't work")
-	}
-	storage, err := objstore.New(t.Cfg.SchemaConfig.Configs, t.Cfg.StorageConfig, t.ClientMetrics)
-	if err != nil {
-		return nil, err
-	}
-
-	consumerFactory := ingesterkafka.NewConsumerFactory(t.MetastoreClient, storage, t.Cfg.KafkaIngester.FlushInterval, t.Cfg.KafkaIngester.FlushSize, logger, prometheus.DefaultRegisterer)
-	t.kafkaIngester, err = ingesterkafka.New(t.Cfg.KafkaIngester, consumerFactory, logger, t.Cfg.MetricsNamespace, prometheus.DefaultRegisterer)
-	if err != nil {
-		return nil, err
-	}
-
-	httpMiddleware := middleware.Merge(
-		serverutil.RecoveryHTTPMiddleware,
-	)
-	t.Server.HTTP.Methods("POST", "GET", "DELETE").Path("/ingester/prepare-partition-downscale").Handler(
-		httpMiddleware.Wrap(http.HandlerFunc(t.kafkaIngester.PreparePartitionDownscaleHandler)),
-	)
-
-	return t.kafkaIngester, nil
-}
-
-func (t *Loki) initIngesterRF1() (_ services.Service, err error) {
-	if !t.Cfg.IngesterRF1.Enabled {
-		return nil, nil
-	}
-
-	logger := log.With(util_log.Logger, "component", "ingester-rf1")
-	t.Cfg.IngesterRF1.LifecyclerConfig.ListenPort = t.Cfg.Server.GRPCListenPort
-
-	if t.Cfg.IngesterRF1.ShutdownMarkerPath == "" && t.Cfg.Common.PathPrefix != "" {
-		t.Cfg.IngesterRF1.ShutdownMarkerPath = t.Cfg.Common.PathPrefix
-	}
-	if t.Cfg.IngesterRF1.ShutdownMarkerPath == "" {
-		level.Warn(util_log.Logger).Log("msg", "The config setting shutdown marker path is not set. The /ingester/prepare_shutdown endpoint won't work")
-	}
-
-	t.IngesterRF1, err = ingester_rf1.New(t.Cfg.IngesterRF1, t.Cfg.IngesterRF1Client, t.Cfg.SchemaConfig.Configs, t.Cfg.StorageConfig, t.ClientMetrics, t.Overrides, t.tenantConfigs, t.MetastoreClient, prometheus.DefaultRegisterer, t.Cfg.Distributor.WriteFailuresLogging, t.Cfg.MetricsNamespace, logger, t.UsageTracker, t.ring)
-	if err != nil {
-		fmt.Println("Error initializing ingester rf1", err)
-		return
-	}
-
-	if t.Cfg.IngesterRF1.Wrapper != nil {
-		t.IngesterRF1 = t.Cfg.IngesterRF1.Wrapper.Wrap(t.IngesterRF1)
-	}
-
-	fmt.Println("registered GRPC")
-	logproto.RegisterPusherRF1Server(t.Server.GRPC, t.IngesterRF1)
-
-	t.Server.HTTP.Path("/ingester-rf1/ring").Methods("GET", "POST").Handler(t.IngesterRF1)
-
-	if t.Cfg.InternalServer.Enable {
-		t.InternalServer.HTTP.Path("/ingester-rf1/ring").Methods("GET", "POST").Handler(t.IngesterRF1)
-	}
-
-	httpMiddleware := middleware.Merge(
-		serverutil.RecoveryHTTPMiddleware,
-	)
-	t.Server.HTTP.Methods("GET", "POST").Path("/flush").Handler(
-		httpMiddleware.Wrap(http.HandlerFunc(t.IngesterRF1.FlushHandler)),
-	)
-	t.Server.HTTP.Methods("POST", "GET", "DELETE").Path("/ingester-rf1/prepare_shutdown").Handler(
-		httpMiddleware.Wrap(http.HandlerFunc(t.IngesterRF1.PrepareShutdown)),
-	)
-	t.Server.HTTP.Methods("POST", "GET").Path("/ingester-rf1/shutdown").Handler(
-		httpMiddleware.Wrap(http.HandlerFunc(t.IngesterRF1.ShutdownHandler)),
-	)
-	return t.IngesterRF1, nil
-}
-
-func (t *Loki) initIngesterRF1RingClient() (_ services.Service, err error) {
-	if !t.Cfg.IngesterRF1.Enabled {
-		return nil, nil
-	}
-	ringClient, err := ingester_rf1.NewRingClient(t.Cfg.IngesterRF1, t.Cfg.MetricsNamespace, prometheus.DefaultRegisterer, util_log.Logger)
-	if err != nil {
-		return nil, err
-	}
-	t.IngesterRF1RingClient = ringClient
-	return ringClient, nil
 }
 
 func (t *Loki) initPatternIngester() (_ services.Service, err error) {
@@ -995,7 +872,7 @@ func (t *Loki) updateConfigForShipperStore() {
 		t.Cfg.StorageConfig.TSDBShipperConfig.Mode = indexshipper.ModeWriteOnly
 		t.Cfg.StorageConfig.TSDBShipperConfig.IngesterDBRetainPeriod = shipperQuerierIndexUpdateDelay(t.Cfg.StorageConfig.IndexCacheValidity, t.Cfg.StorageConfig.TSDBShipperConfig.ResyncInterval)
 
-	case t.Cfg.isTarget(IngesterRF1), t.Cfg.isTarget(Querier), t.Cfg.isTarget(Ruler), t.Cfg.isTarget(Read), t.Cfg.isTarget(Backend), t.isModuleActive(IndexGateway), t.Cfg.isTarget(BloomPlanner), t.Cfg.isTarget(BloomBuilder):
+	case t.Cfg.isTarget(Querier), t.Cfg.isTarget(Ruler), t.Cfg.isTarget(Read), t.Cfg.isTarget(Backend), t.isModuleActive(IndexGateway), t.Cfg.isTarget(BloomPlanner), t.Cfg.isTarget(BloomBuilder):
 		// We do not want query to do any updates to index
 		t.Cfg.StorageConfig.BoltDBShipperConfig.Mode = indexshipper.ModeReadOnly
 		t.Cfg.StorageConfig.TSDBShipperConfig.Mode = indexshipper.ModeReadOnly
@@ -1501,9 +1378,7 @@ func (t *Loki) initMemberlistKV() (services.Service, error) {
 	t.Cfg.QueryScheduler.SchedulerRing.KVStore.MemberlistKV = t.MemberlistKV.GetMemberlistKV
 	t.Cfg.Ruler.Ring.KVStore.MemberlistKV = t.MemberlistKV.GetMemberlistKV
 	t.Cfg.Pattern.LifecyclerConfig.RingConfig.KVStore.MemberlistKV = t.MemberlistKV.GetMemberlistKV
-	t.Cfg.IngesterRF1.LifecyclerConfig.RingConfig.KVStore.MemberlistKV = t.MemberlistKV.GetMemberlistKV
-	t.Cfg.KafkaIngester.PartitionRingConfig.KVStore.MemberlistKV = t.MemberlistKV.GetMemberlistKV
-	t.Cfg.KafkaIngester.LifecyclerConfig.RingConfig.KVStore.MemberlistKV = t.MemberlistKV.GetMemberlistKV
+	t.Cfg.Ingester.KafkaIngestion.PartitionRingConfig.KVStore.MemberlistKV = t.MemberlistKV.GetMemberlistKV
 	t.Server.HTTP.Handle("/memberlist", t.MemberlistKV)
 
 	if t.Cfg.InternalServer.Enable {
@@ -1871,47 +1746,18 @@ func (t *Loki) initAnalytics() (services.Service, error) {
 	return ur, nil
 }
 
-func (t *Loki) initMetastore() (services.Service, error) {
-	if !t.Cfg.IngesterRF1.Enabled && !t.Cfg.KafkaIngester.Enabled {
-		return nil, nil
-	}
-	if t.Cfg.isTarget(All) {
-		t.Cfg.MetastoreClient.MetastoreAddress = fmt.Sprintf("localhost:%d", t.Cfg.Server.GRPCListenPort)
-	}
-	m, err := metastore.New(t.Cfg.Metastore, log.With(util_log.Logger, "component", "metastore"), prometheus.DefaultRegisterer, t.health)
-	if err != nil {
-		return nil, err
-	}
-	// Service methods have tenant auth disabled in the fakeauth.SetupAuthMiddleware call since this is a shared service
-	metastorepb.RegisterMetastoreServiceServer(t.Server.GRPC, m)
-
-	return m, nil
-}
-
-func (t *Loki) initMetastoreClient() (services.Service, error) {
-	if !t.Cfg.IngesterRF1.Enabled && !t.Cfg.QuerierRF1.Enabled && !t.Cfg.KafkaIngester.Enabled {
-		return nil, nil
-	}
-	mc, err := metastoreclient.New(t.Cfg.MetastoreClient, prometheus.DefaultRegisterer)
-	if err != nil {
-		return nil, err
-	}
-	t.MetastoreClient = mc
-	return mc.Service(), nil
-}
-
 // The Ingest Partition Ring is responsible for watching the available ingesters and assigning partitions to incoming requests.
 func (t *Loki) initPartitionRing() (services.Service, error) {
-	if !t.Cfg.KafkaIngester.Enabled { // TODO: New config flag
+	if !t.Cfg.Ingester.KafkaIngestion.Enabled {
 		return nil, nil
 	}
 
-	kvClient, err := kv.NewClient(t.Cfg.KafkaIngester.PartitionRingConfig.KVStore, ring.GetPartitionRingCodec(), kv.RegistererWithKVName(prometheus.DefaultRegisterer, ingesterkafka.PartitionRingName+"-watcher"), util_log.Logger)
+	kvClient, err := kv.NewClient(t.Cfg.Ingester.KafkaIngestion.PartitionRingConfig.KVStore, ring.GetPartitionRingCodec(), kv.RegistererWithKVName(prometheus.DefaultRegisterer, ingesterkafka.PartitionRingName+"-watcher"), util_log.Logger)
 	if err != nil {
 		return nil, fmt.Errorf("creating KV store for partitions ring watcher: %w", err)
 	}
 
-	t.partitionRingWatcher = ring.NewPartitionRingWatcher(ingesterkafka.PartitionRingName, ingesterkafka.PartitionRingName+"-key", kvClient, util_log.Logger, prometheus.WrapRegistererWithPrefix("loki_", prometheus.DefaultRegisterer))
+	t.partitionRingWatcher = ring.NewPartitionRingWatcher(ingester.PartitionRingName, ingester.PartitionRingName, kvClient, util_log.Logger, prometheus.WrapRegistererWithPrefix("loki_", prometheus.DefaultRegisterer))
 	t.partitionRing = ring.NewPartitionInstanceRing(t.partitionRingWatcher, t.ring, t.Cfg.Ingester.LifecyclerConfig.RingConfig.HeartbeatTimeout)
 
 	// Expose a web page to view the partitions ring state.


### PR DESCRIPTION
**What this PR does / why we need it**:

This refactors kafka configuration and removes old modules registration.

The new kafka configuration is not yet being used by ingester but allow others to start working.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
