### PR TITLE
chore(storage/bloom/v1): filter out chunks where the queried key was not indexed

### DIFF
--- a/pkg/storage/bloom/v1/bloom_tester.go
+++ b/pkg/storage/bloom/v1/bloom_tester.go
@@ -387,13 +387,11 @@ func (sm stringMatcherTest) Matches(bloom filter.Checker) bool {
 	)
 
 	if !bloom.Test(rawKey) {
-		// The structured metadata key wasn't indexed. We pass the bloom test
-		// since we can only filter data out if the key was indexed but the value
-		// wasn't.
-		//
-		// TODO(rfratto): The negative test here is a bit confusing, and the key
-		// presence test should likely be done higher up.
-		return true
+		// The structured metadata key wasn't indexed, so we can safely filter out
+		// this data. Given that Matches is only called when a bloom exists, and
+		// blooms can't have false negatives, we can be confident that neither the
+		// key nor the key-value pair was indexed.
+		return false
 	}
 
 	return bloom.Test(rawCombined)
@@ -408,13 +406,11 @@ func (sm stringMatcherTest) MatchesWithPrefixBuf(bloom filter.Checker, buf []byt
 	)
 
 	if !bloom.Test(prefixedKey) {
-		// The structured metadata key wasn't indexed for a prefix. We pass the
-		// bloom test since we can only filter data out if the key was indexed but
-		// the value wasn't.
-		//
-		// TODO(rfratto): The negative test here is a bit confusing, and the key
-		// presence test should likely be done higher up.
-		return true
+		// The structured metadata key wasn't indexed, so we can safely filter out
+		// this data. Given that Matches is only called when a bloom exists, and
+		// blooms can't have false negatives, we can be confident that neither the
+		// key nor the key-value pair was indexed.
+		return false
 	}
 
 	return bloom.Test(prefixedCombined)

--- a/pkg/storage/bloom/v1/bloom_tester_test.go
+++ b/pkg/storage/bloom/v1/bloom_tester_test.go
@@ -166,7 +166,7 @@ func TestLabelMatchersToBloomTest(t *testing.T) {
 		{
 			name:  "ignore non-indexed key",
 			query: `{app="fake"} | noexist="noexist"`,
-			match: true,
+			match: false,
 		},
 		{
 			name:  "ignore unsupported operator",


### PR DESCRIPTION
**What this PR does / why we need it**:
Previously, this logic assumed that once we're running the bloom test, any key that was not indexed may still be in the chunk but not in the bloom. However, as long as the bloom exists, we can be confident that if the key does not exist, the key will not be found anywhere in that chunk.

This change will allow filtering out chunks where the queried structured metadata key is not found. 

**Which issue(s) this PR fixes**:
N/A 

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
