### PR TITLE
chore(storage/bloom/v1): update comments on bloom test

### DIFF
--- a/pkg/storage/bloom/v1/bloom_tester.go
+++ b/pkg/storage/bloom/v1/bloom_tester.go
@@ -387,12 +387,12 @@ func (sm stringMatcherTest) Matches(bloom filter.Checker) bool {
 	)
 
 	if !bloom.Test(rawKey) {
-		// The structured metadata key wasn't indexed. We pass the bloom test
-		// since we can only filter data out if the key was indexed but the value
-		// wasn't.
+		// The structured metadata key wasn't indexed. However, sm.matcher might be
+		// checking against a label which *does* exist, so we can't safely filter
+		// out this chunk.
 		//
 		// TODO(rfratto): The negative test here is a bit confusing, and the key
-		// presence test should likely be done higher up.
+		// presence test should likely be done higher up within FuseQuerier.
 		return true
 	}
 
@@ -408,12 +408,12 @@ func (sm stringMatcherTest) MatchesWithPrefixBuf(bloom filter.Checker, buf []byt
 	)
 
 	if !bloom.Test(prefixedKey) {
-		// The structured metadata key wasn't indexed for a prefix. We pass the
-		// bloom test since we can only filter data out if the key was indexed but
-		// the value wasn't.
+		// The structured metadata key wasn't indexed for a prefix. However,
+		// sm.matcher might be checking against a label which *does* exist, so we
+		// can't safely filter out this chunk.
 		//
 		// TODO(rfratto): The negative test here is a bit confusing, and the key
-		// presence test should likely be done higher up.
+		// presence test should likely be done higher up within FuseQuerier.
 		return true
 	}
 

--- a/pkg/storage/bloom/v1/bloom_tester_test.go
+++ b/pkg/storage/bloom/v1/bloom_tester_test.go
@@ -169,6 +169,11 @@ func TestLabelMatchersToBloomTest(t *testing.T) {
 			match: true,
 		},
 		{
+			name:  "ignore non-indexed key with empty value",
+			query: `{app="fake"} | noexist=""`,
+			match: true,
+		},
+		{
 			name:  "ignore unsupported operator",
 			query: `{app="fake"} | trace_id=~".*noexist.*"`,
 			match: true,


### PR DESCRIPTION
**What this PR does / why we need it**:
Update comments on bloom test to make it clearer why we can't filter out chunks for which a key was not found in the bloom.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
