### PR TITLE
fix: show 200 status code for successful queries

### DIFF
--- a/cmd/loki/loki-local-config.yaml
+++ b/cmd/loki/loki-local-config.yaml
@@ -18,9 +18,6 @@ common:
     kvstore:
       store: inmemory
 
-ingester_rf1:
-  enabled: false
-
 query_range:
   results_cache:
     cache:

--- a/pkg/logql/engine.go
+++ b/pkg/logql/engine.go
@@ -265,10 +265,10 @@ func (q *query) Exec(ctx context.Context) (logqlmodel.Result, error) {
 	statResult := statsCtx.Result(time.Since(start), queueTime, q.resultLength(data))
 	sp.LogKV(statResult.KVList()...)
 
-  status := http.StatusOK
-  if err != nil {
-	  status, _ = server.ClientHTTPStatusAndError(err)
-  }
+	status := http.StatusOK
+	if err != nil {
+		status, _ = server.ClientHTTPStatusAndError(err)
+	}
 
 	if q.record {
 		RecordRangeAndInstantQueryMetrics(ctx, q.logger, q.params, strconv.Itoa(status), statResult, data)

--- a/pkg/logql/engine.go
+++ b/pkg/logql/engine.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"net/http"
 	"sort"
 	"strconv"
 	"strings"
@@ -264,7 +265,10 @@ func (q *query) Exec(ctx context.Context) (logqlmodel.Result, error) {
 	statResult := statsCtx.Result(time.Since(start), queueTime, q.resultLength(data))
 	sp.LogKV(statResult.KVList()...)
 
-	status, _ := server.ClientHTTPStatusAndError(err)
+  status := http.StatusOK
+  if err != nil {
+	  status, _ = server.ClientHTTPStatusAndError(err)
+  }
 
 	if q.record {
 		RecordRangeAndInstantQueryMetrics(ctx, q.logger, q.params, strconv.Itoa(status), statResult, data)


### PR DESCRIPTION
**What this PR does / why we need it**:

[This change](https://github.com/grafana/loki/pull/10956/files#diff-cee1265b2b7d985c9e33bebaa2299074a017697246ec6c7ada151ccf2f45b499R246) in #10956 broke the status code reporting in the `metrics.go` line from our queriers. In the case where error was `nil`, it produces a 500. Previously, when [error was nil, it produced a 200](https://github.com/grafana/loki/pull/10956/files#diff-71063175d4d67c35bfdd623b3609a70c6667416c640196d78931e0f2f5c0af0eL99).

This PR fixes that behavior, reporting a 200 status unless there is a problem.