### PR TITLE
fix: mixins / loki-resources-overview panel layout

### DIFF
--- a/production/loki-mixin-compiled-ssd/dashboards/loki-resources-overview.json
+++ b/production/loki-mixin-compiled-ssd/dashboards/loki-resources-overview.json
@@ -314,6 +314,12 @@
                      },
                      "overrides": [ ]
                   },
+                  "gridPos": {
+                     "h": 7,
+                     "w": 6,
+                     "x": 0,
+                     "y": 9
+                  },
                   "id": 4,
                   "links": [ ],
                   "options": {
@@ -402,6 +408,12 @@
                            ]
                         }
                      ]
+                  },
+                  "gridPos": {
+                     "h": 7,
+                     "w": 8,
+                     "x": 0,
+                     "y": 9
                   },
                   "id": 5,
                   "links": [ ],
@@ -504,6 +516,12 @@
                         }
                      ]
                   },
+                  "gridPos": {
+                     "h": 7,
+                     "w": 8,
+                     "x": 8,
+                     "y": 9
+                  },
                   "id": 6,
                   "links": [ ],
                   "options": {
@@ -566,6 +584,12 @@
                      },
                      "overrides": [ ]
                   },
+                  "gridPos": {
+                     "h": 7,
+                     "w": 6,
+                     "x": 18,
+                     "y": 9
+                  },
                   "id": 7,
                   "links": [ ],
                   "options": {
@@ -616,6 +640,12 @@
                      },
                      "overrides": [ ]
                   },
+                  "gridPos": {
+                     "h": 7,
+                     "w": 8,
+                     "x": 0,
+                     "y": 16
+                  },
                   "id": 8,
                   "links": [ ],
                   "options": {
@@ -663,6 +693,12 @@
                      },
                      "overrides": [ ]
                   },
+                  "gridPos": {
+                     "h": 7,
+                     "w": 8,
+                     "x": 8,
+                     "y": 16
+                  },
                   "id": 9,
                   "links": [ ],
                   "options": {
@@ -709,6 +745,12 @@
                         "unit": "percentunit"
                      },
                      "overrides": [ ]
+                  },
+                  "gridPos": {
+                     "h": 7,
+                     "w": 8,
+                     "x": 16,
+                     "y": 16
                   },
                   "id": 10,
                   "links": [ ],
@@ -807,6 +849,12 @@
                            ]
                         }
                      ]
+                  },
+                  "gridPos": {
+                     "h": 7,
+                     "w": 8,
+                     "x": 0,
+                     "y": 24
                   },
                   "id": 11,
                   "links": [ ],
@@ -909,6 +957,12 @@
                         }
                      ]
                   },
+                  "gridPos": {
+                     "h": 7,
+                     "w": 8,
+                     "x": 8,
+                     "y": 24
+                  },
                   "id": 12,
                   "links": [ ],
                   "options": {
@@ -971,6 +1025,12 @@
                      },
                      "overrides": [ ]
                   },
+                  "gridPos": {
+                     "h": 7,
+                     "w": 8,
+                     "x": 16,
+                     "y": 24
+                  },
                   "id": 13,
                   "links": [ ],
                   "options": {
@@ -1021,6 +1081,12 @@
                      },
                      "overrides": [ ]
                   },
+                  "gridPos": {
+                     "h": 7,
+                     "w": 8,
+                     "x": 0,
+                     "y": 31
+                  },
                   "id": 14,
                   "links": [ ],
                   "options": {
@@ -1068,6 +1134,12 @@
                      },
                      "overrides": [ ]
                   },
+                  "gridPos": {
+                     "h": 7,
+                     "w": 8,
+                     "x": 8,
+                     "y": 31
+                  },
                   "id": 15,
                   "links": [ ],
                   "options": {
@@ -1114,6 +1186,12 @@
                         "unit": "percentunit"
                      },
                      "overrides": [ ]
+                  },
+                  "gridPos": {
+                     "h": 7,
+                     "w": 8,
+                     "x": 16,
+                     "y": 31
                   },
                   "id": 16,
                   "links": [ ],

--- a/production/loki-mixin-compiled-ssd/dashboards/loki-resources-overview.json
+++ b/production/loki-mixin-compiled-ssd/dashboards/loki-resources-overview.json
@@ -314,12 +314,6 @@
                      },
                      "overrides": [ ]
                   },
-                  "gridPos": {
-                     "h": 7,
-                     "w": 6,
-                     "x": 0,
-                     "y": 9
-                  },
                   "id": 4,
                   "links": [ ],
                   "options": {
@@ -331,7 +325,7 @@
                         "sort": "none"
                      }
                   },
-                  "span": 1,
+                  "span": 3,
                   "targets": [
                      {
                         "expr": "sum by(pod) (loki_write_memory_streams{cluster=~\"$cluster\", job=~\"($namespace)/(loki.*|enterprise-logs)-write\"})",
@@ -409,12 +403,6 @@
                         }
                      ]
                   },
-                  "gridPos": {
-                     "h": 7,
-                     "w": 8,
-                     "x": 0,
-                     "y": 9
-                  },
                   "id": 5,
                   "links": [ ],
                   "options": {
@@ -426,7 +414,7 @@
                         "sort": "none"
                      }
                   },
-                  "span": 1,
+                  "span": 3,
                   "targets": [
                      {
                         "expr": "sum by(pod) (rate(container_cpu_usage_seconds_total{cluster=~\"$cluster\", namespace=~\"$namespace\", container=\"loki\", pod=~\"(loki.*|enterprise-logs)-write.*\"}[$__rate_interval]))",
@@ -516,12 +504,6 @@
                         }
                      ]
                   },
-                  "gridPos": {
-                     "h": 7,
-                     "w": 8,
-                     "x": 8,
-                     "y": 9
-                  },
                   "id": 6,
                   "links": [ ],
                   "options": {
@@ -533,7 +515,7 @@
                         "sort": "none"
                      }
                   },
-                  "span": 1,
+                  "span": 3,
                   "targets": [
                      {
                         "expr": "max by(pod) (container_memory_working_set_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", container=\"loki\", pod=~\"(loki.*|enterprise-logs)-write.*\"})",
@@ -584,12 +566,6 @@
                      },
                      "overrides": [ ]
                   },
-                  "gridPos": {
-                     "h": 7,
-                     "w": 6,
-                     "x": 18,
-                     "y": 9
-                  },
                   "id": 7,
                   "links": [ ],
                   "options": {
@@ -601,7 +577,7 @@
                         "sort": "none"
                      }
                   },
-                  "span": 1,
+                  "span": 3,
                   "targets": [
                      {
                         "expr": "sum by(pod) (go_memstats_heap_inuse_bytes{cluster=~\"$cluster\", job=~\"($namespace)/(loki.*|enterprise-logs)-write\"})",
@@ -615,7 +591,19 @@
                      "sort": 2
                   },
                   "type": "timeseries"
-               },
+               }
+            ],
+            "repeat": null,
+            "repeatIteration": null,
+            "repeatRowId": null,
+            "showTitle": true,
+            "title": "Write path",
+            "titleSize": "h6"
+         },
+         {
+            "collapse": false,
+            "height": "250px",
+            "panels": [
                {
                   "datasource": "$datasource",
                   "fieldConfig": {
@@ -640,12 +628,6 @@
                      },
                      "overrides": [ ]
                   },
-                  "gridPos": {
-                     "h": 7,
-                     "w": 8,
-                     "x": 0,
-                     "y": 16
-                  },
                   "id": 8,
                   "links": [ ],
                   "options": {
@@ -657,7 +639,7 @@
                         "sort": "none"
                      }
                   },
-                  "span": 1,
+                  "span": 4,
                   "targets": [
                      {
                         "expr": "sum by(instance, pod, device) (rate(node_disk_written_bytes_total[$__rate_interval])) + ignoring(pod) group_right() (label_replace(count by(instance, pod, device) (container_fs_writes_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", container=\"loki\", pod=~\"(loki.*|enterprise-logs)-write.*\", device!~\".*sda.*\"}), \"device\", \"$1\", \"device\", \"/dev/(.*)\") * 0)\n",
@@ -693,12 +675,6 @@
                      },
                      "overrides": [ ]
                   },
-                  "gridPos": {
-                     "h": 7,
-                     "w": 8,
-                     "x": 8,
-                     "y": 16
-                  },
                   "id": 9,
                   "links": [ ],
                   "options": {
@@ -710,7 +686,7 @@
                         "sort": "none"
                      }
                   },
-                  "span": 1,
+                  "span": 4,
                   "targets": [
                      {
                         "expr": "sum by(instance, pod, device) (rate(node_disk_read_bytes_total[$__rate_interval])) + ignoring(pod) group_right() (label_replace(count by(instance, pod, device) (container_fs_writes_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", container=\"loki\", pod=~\"(loki.*|enterprise-logs)-write.*\", device!~\".*sda.*\"}), \"device\", \"$1\", \"device\", \"/dev/(.*)\") * 0)\n",
@@ -746,12 +722,6 @@
                      },
                      "overrides": [ ]
                   },
-                  "gridPos": {
-                     "h": 7,
-                     "w": 8,
-                     "x": 16,
-                     "y": 16
-                  },
                   "id": 10,
                   "links": [ ],
                   "options": {
@@ -763,7 +733,7 @@
                         "sort": "none"
                      }
                   },
-                  "span": 1,
+                  "span": 4,
                   "targets": [
                      {
                         "expr": "max by(persistentvolumeclaim) (kubelet_volume_stats_used_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", persistentvolumeclaim=~\".*(loki.*|enterprise-logs)-write.*\"} / kubelet_volume_stats_capacity_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", persistentvolumeclaim=~\".*(loki.*|enterprise-logs)-write.*\"})",
@@ -780,7 +750,7 @@
             "repeatIteration": null,
             "repeatRowId": null,
             "showTitle": true,
-            "title": "Write path",
+            "title": "",
             "titleSize": "h6"
          },
          {
@@ -850,12 +820,6 @@
                         }
                      ]
                   },
-                  "gridPos": {
-                     "h": 7,
-                     "w": 8,
-                     "x": 0,
-                     "y": 24
-                  },
                   "id": 11,
                   "links": [ ],
                   "options": {
@@ -867,7 +831,7 @@
                         "sort": "none"
                      }
                   },
-                  "span": 2,
+                  "span": 4,
                   "targets": [
                      {
                         "expr": "sum by(pod) (rate(container_cpu_usage_seconds_total{cluster=~\"$cluster\", namespace=~\"$namespace\", container=\"loki\", pod=~\"(loki.*|enterprise-logs)-backend.*\"}[$__rate_interval]))",
@@ -957,12 +921,6 @@
                         }
                      ]
                   },
-                  "gridPos": {
-                     "h": 7,
-                     "w": 8,
-                     "x": 8,
-                     "y": 24
-                  },
                   "id": 12,
                   "links": [ ],
                   "options": {
@@ -974,7 +932,7 @@
                         "sort": "none"
                      }
                   },
-                  "span": 2,
+                  "span": 4,
                   "targets": [
                      {
                         "expr": "max by(pod) (container_memory_working_set_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", container=\"loki\", pod=~\"(loki.*|enterprise-logs)-backend.*\"})",
@@ -1025,12 +983,6 @@
                      },
                      "overrides": [ ]
                   },
-                  "gridPos": {
-                     "h": 7,
-                     "w": 8,
-                     "x": 16,
-                     "y": 24
-                  },
                   "id": 13,
                   "links": [ ],
                   "options": {
@@ -1042,7 +994,7 @@
                         "sort": "none"
                      }
                   },
-                  "span": 2,
+                  "span": 4,
                   "targets": [
                      {
                         "expr": "sum by(pod) (go_memstats_heap_inuse_bytes{cluster=~\"$cluster\", job=~\"($namespace)/(loki.*|enterprise-logs)-backend\"})",
@@ -1056,7 +1008,19 @@
                      "sort": 2
                   },
                   "type": "timeseries"
-               },
+               }
+            ],
+            "repeat": null,
+            "repeatIteration": null,
+            "repeatRowId": null,
+            "showTitle": true,
+            "title": "Backend path",
+            "titleSize": "h6"
+         },
+         {
+            "collapse": false,
+            "height": "250px",
+            "panels": [
                {
                   "datasource": "$datasource",
                   "fieldConfig": {
@@ -1081,12 +1045,6 @@
                      },
                      "overrides": [ ]
                   },
-                  "gridPos": {
-                     "h": 7,
-                     "w": 8,
-                     "x": 0,
-                     "y": 31
-                  },
                   "id": 14,
                   "links": [ ],
                   "options": {
@@ -1098,7 +1056,7 @@
                         "sort": "none"
                      }
                   },
-                  "span": 2,
+                  "span": 4,
                   "targets": [
                      {
                         "expr": "sum by(instance, pod, device) (rate(node_disk_written_bytes_total[$__rate_interval])) + ignoring(pod) group_right() (label_replace(count by(instance, pod, device) (container_fs_writes_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", container=\"loki\", pod=~\"(loki.*|enterprise-logs)-backend.*\", device!~\".*sda.*\"}), \"device\", \"$1\", \"device\", \"/dev/(.*)\") * 0)\n",
@@ -1134,12 +1092,6 @@
                      },
                      "overrides": [ ]
                   },
-                  "gridPos": {
-                     "h": 7,
-                     "w": 8,
-                     "x": 8,
-                     "y": 31
-                  },
                   "id": 15,
                   "links": [ ],
                   "options": {
@@ -1151,7 +1103,7 @@
                         "sort": "none"
                      }
                   },
-                  "span": 2,
+                  "span": 4,
                   "targets": [
                      {
                         "expr": "sum by(instance, pod, device) (rate(node_disk_read_bytes_total[$__rate_interval])) + ignoring(pod) group_right() (label_replace(count by(instance, pod, device) (container_fs_writes_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", container=\"loki\", pod=~\"(loki.*|enterprise-logs)-backend.*\", device!~\".*sda.*\"}), \"device\", \"$1\", \"device\", \"/dev/(.*)\") * 0)\n",
@@ -1187,12 +1139,6 @@
                      },
                      "overrides": [ ]
                   },
-                  "gridPos": {
-                     "h": 7,
-                     "w": 8,
-                     "x": 16,
-                     "y": 31
-                  },
                   "id": 16,
                   "links": [ ],
                   "options": {
@@ -1204,7 +1150,7 @@
                         "sort": "none"
                      }
                   },
-                  "span": 2,
+                  "span": 4,
                   "targets": [
                      {
                         "expr": "max by(persistentvolumeclaim) (kubelet_volume_stats_used_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", persistentvolumeclaim=~\".*(loki.*|enterprise-logs)-backend.*\"} / kubelet_volume_stats_capacity_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", persistentvolumeclaim=~\".*(loki.*|enterprise-logs)-backend.*\"})",
@@ -1221,7 +1167,7 @@
             "repeatIteration": null,
             "repeatRowId": null,
             "showTitle": true,
-            "title": "Backend path",
+            "title": "",
             "titleSize": "h6"
          }
       ],

--- a/production/loki-mixin/dashboards/loki-resources-overview.libsonnet
+++ b/production/loki-mixin/dashboards/loki-resources-overview.libsonnet
@@ -41,16 +41,46 @@
           ) +
           {
             tooltip: { sort: 2 },  // Sort descending.
-          },
+            gridPos: {
+              h: 7,
+              w: 6,
+              x: 0,
+              y: 9,
+            },
+          }
         )
         .addPanel(
-          $.CPUUsagePanel('CPU', write_pod_matcher),
+          $.CPUUsagePanel('CPU', write_pod_matcher) +
+          {
+            gridPos: {
+              h: 7,
+              w: 8,
+              x: 0,
+              y: 9,
+            },
+          }
         )
         .addPanel(
-          $.memoryWorkingSetPanel('Memory (workingset)', write_pod_matcher),
+          $.memoryWorkingSetPanel('Memory (workingset)', write_pod_matcher) +
+          {
+            gridPos: {
+              h: 7,
+              w: 8,
+              x: 8,
+              y: 9,
+            },
+          }
         )
         .addPanel(
-          $.goHeapInUsePanel('Memory (go heap inuse)', write_job_matcher),
+          $.goHeapInUsePanel('Memory (go heap inuse)', write_job_matcher) +
+          {
+            gridPos: {
+              h: 7,
+              w: 6,
+              x: 18,
+              y: 9,
+            },
+          }
         )
         .addPanel(
           $.newQueryPanel('Disk Writes', 'Bps') +
@@ -58,7 +88,15 @@
             'sum by(%s, %s, device) (rate(node_disk_written_bytes_total[$__rate_interval])) + %s' % [$._config.per_node_label, $._config.per_instance_label, $.filterNodeDisk(write_pod_matcher)],
             '{{%s}} - {{device}}' % $._config.per_instance_label
           ) +
-          $.withStacking,
+          $.withStacking +
+          {
+            gridPos: {
+              h: 7,
+              w: 8,
+              x: 0,
+              y: 16,
+            },
+          }
         )
         .addPanel(
           $.newQueryPanel('Disk Reads', 'Bps') +
@@ -66,22 +104,62 @@
             'sum by(%s, %s, device) (rate(node_disk_read_bytes_total[$__rate_interval])) + %s' % [$._config.per_node_label, $._config.per_instance_label, $.filterNodeDisk(write_pod_matcher)],
             '{{%s}} - {{device}}' % $._config.per_instance_label
           ) +
-          $.withStacking,
+          $.withStacking +
+          {
+            gridPos: {
+              h: 7,
+              w: 8,
+              x: 8,
+              y: 16,
+            },
+          }
         )
         .addPanel(
-          $.containerDiskSpaceUtilizationPanel('Disk Space Utilization', write_job_matcher),
+          $.containerDiskSpaceUtilizationPanel('Disk Space Utilization', write_job_matcher) +
+          {
+            gridPos: {
+              h: 7,
+              w: 8,
+              x: 16,
+              y: 16,
+            },
+          }
         )
       )
       .addRow(
         $.row('Backend path')
         .addPanel(
-          $.CPUUsagePanel('CPU', backend_pod_matcher),
+          $.CPUUsagePanel('CPU', backend_pod_matcher) +
+          {
+            gridPos: {
+              h: 7,
+              w: 8,
+              x: 0,
+              y: 24,
+            },
+          }
         )
         .addPanel(
-          $.memoryWorkingSetPanel('Memory (workingset)', backend_pod_matcher),
+          $.memoryWorkingSetPanel('Memory (workingset)', backend_pod_matcher) +
+          {
+            gridPos: {
+              h: 7,
+              w: 8,
+              x: 8,
+              y: 24,
+            },
+          }
         )
         .addPanel(
-          $.goHeapInUsePanel('Memory (go heap inuse)', backend_job_matcher),
+          $.goHeapInUsePanel('Memory (go heap inuse)', backend_job_matcher) +
+          {
+            gridPos: {
+              h: 7,
+              w: 8,
+              x: 16,
+              y: 24,
+            },
+          }
         )
         .addPanel(
           $.newQueryPanel('Disk Writes', 'Bps') +
@@ -89,7 +167,15 @@
             'sum by(%s, %s, device) (rate(node_disk_written_bytes_total[$__rate_interval])) + %s' % [$._config.per_node_label, $._config.per_instance_label, $.filterNodeDisk(backend_pod_matcher)],
             '{{%s}} - {{device}}' % $._config.per_instance_label
           ) +
-          $.withStacking,
+          $.withStacking +
+          {
+            gridPos: {
+              h: 7,
+              w: 8,
+              x: 0,
+              y: 31,
+            },
+          }
         )
         .addPanel(
           $.newQueryPanel('Disk Reads', 'Bps') +
@@ -97,10 +183,26 @@
             'sum by(%s, %s, device) (rate(node_disk_read_bytes_total[$__rate_interval])) + %s' % [$._config.per_node_label, $._config.per_instance_label, $.filterNodeDisk(backend_pod_matcher)],
             '{{%s}} - {{device}}' % $._config.per_instance_label
           ) +
-          $.withStacking,
+          $.withStacking +
+          {
+            gridPos: {
+              h: 7,
+              w: 8,
+              x: 8,
+              y: 31,
+            },
+          }
         )
         .addPanel(
-          $.containerDiskSpaceUtilizationPanel('Disk Space Utilization', backend_job_matcher),
+          $.containerDiskSpaceUtilizationPanel('Disk Space Utilization', backend_job_matcher) +
+          {
+            gridPos: {
+              h: 7,
+              w: 8,
+              x: 16,
+              y: 31,
+            },
+          }
         )
       ),
   },

--- a/production/loki-mixin/dashboards/loki-resources-overview.libsonnet
+++ b/production/loki-mixin/dashboards/loki-resources-overview.libsonnet
@@ -41,62 +41,27 @@
           ) +
           {
             tooltip: { sort: 2 },  // Sort descending.
-            gridPos: {
-              h: 7,
-              w: 6,
-              x: 0,
-              y: 9,
-            },
           }
         )
         .addPanel(
-          $.CPUUsagePanel('CPU', write_pod_matcher) +
-          {
-            gridPos: {
-              h: 7,
-              w: 8,
-              x: 0,
-              y: 9,
-            },
-          }
+          $.CPUUsagePanel('CPU', write_pod_matcher),
         )
         .addPanel(
-          $.memoryWorkingSetPanel('Memory (workingset)', write_pod_matcher) +
-          {
-            gridPos: {
-              h: 7,
-              w: 8,
-              x: 8,
-              y: 9,
-            },
-          }
+          $.memoryWorkingSetPanel('Memory (workingset)', write_pod_matcher),
         )
         .addPanel(
-          $.goHeapInUsePanel('Memory (go heap inuse)', write_job_matcher) +
-          {
-            gridPos: {
-              h: 7,
-              w: 6,
-              x: 18,
-              y: 9,
-            },
-          }
+          $.goHeapInUsePanel('Memory (go heap inuse)', write_job_matcher),
         )
+      )
+      .addRow(
+        $.row('')
         .addPanel(
           $.newQueryPanel('Disk Writes', 'Bps') +
           $.queryPanel(
             'sum by(%s, %s, device) (rate(node_disk_written_bytes_total[$__rate_interval])) + %s' % [$._config.per_node_label, $._config.per_instance_label, $.filterNodeDisk(write_pod_matcher)],
             '{{%s}} - {{device}}' % $._config.per_instance_label
           ) +
-          $.withStacking +
-          {
-            gridPos: {
-              h: 7,
-              w: 8,
-              x: 0,
-              y: 16,
-            },
-          }
+          $.withStacking,
         )
         .addPanel(
           $.newQueryPanel('Disk Reads', 'Bps') +
@@ -104,78 +69,33 @@
             'sum by(%s, %s, device) (rate(node_disk_read_bytes_total[$__rate_interval])) + %s' % [$._config.per_node_label, $._config.per_instance_label, $.filterNodeDisk(write_pod_matcher)],
             '{{%s}} - {{device}}' % $._config.per_instance_label
           ) +
-          $.withStacking +
-          {
-            gridPos: {
-              h: 7,
-              w: 8,
-              x: 8,
-              y: 16,
-            },
-          }
+          $.withStacking,
         )
         .addPanel(
-          $.containerDiskSpaceUtilizationPanel('Disk Space Utilization', write_job_matcher) +
-          {
-            gridPos: {
-              h: 7,
-              w: 8,
-              x: 16,
-              y: 16,
-            },
-          }
+          $.containerDiskSpaceUtilizationPanel('Disk Space Utilization', write_job_matcher),
         )
       )
       .addRow(
         $.row('Backend path')
         .addPanel(
-          $.CPUUsagePanel('CPU', backend_pod_matcher) +
-          {
-            gridPos: {
-              h: 7,
-              w: 8,
-              x: 0,
-              y: 24,
-            },
-          }
+          $.CPUUsagePanel('CPU', backend_pod_matcher),
         )
         .addPanel(
-          $.memoryWorkingSetPanel('Memory (workingset)', backend_pod_matcher) +
-          {
-            gridPos: {
-              h: 7,
-              w: 8,
-              x: 8,
-              y: 24,
-            },
-          }
+          $.memoryWorkingSetPanel('Memory (workingset)', backend_pod_matcher),
         )
         .addPanel(
-          $.goHeapInUsePanel('Memory (go heap inuse)', backend_job_matcher) +
-          {
-            gridPos: {
-              h: 7,
-              w: 8,
-              x: 16,
-              y: 24,
-            },
-          }
+          $.goHeapInUsePanel('Memory (go heap inuse)', backend_job_matcher),
         )
+      )
+      .addRow(
+        $.row('')
         .addPanel(
           $.newQueryPanel('Disk Writes', 'Bps') +
           $.queryPanel(
             'sum by(%s, %s, device) (rate(node_disk_written_bytes_total[$__rate_interval])) + %s' % [$._config.per_node_label, $._config.per_instance_label, $.filterNodeDisk(backend_pod_matcher)],
             '{{%s}} - {{device}}' % $._config.per_instance_label
           ) +
-          $.withStacking +
-          {
-            gridPos: {
-              h: 7,
-              w: 8,
-              x: 0,
-              y: 31,
-            },
-          }
+          $.withStacking,
         )
         .addPanel(
           $.newQueryPanel('Disk Reads', 'Bps') +
@@ -183,26 +103,10 @@
             'sum by(%s, %s, device) (rate(node_disk_read_bytes_total[$__rate_interval])) + %s' % [$._config.per_node_label, $._config.per_instance_label, $.filterNodeDisk(backend_pod_matcher)],
             '{{%s}} - {{device}}' % $._config.per_instance_label
           ) +
-          $.withStacking +
-          {
-            gridPos: {
-              h: 7,
-              w: 8,
-              x: 8,
-              y: 31,
-            },
-          }
+          $.withStacking,
         )
         .addPanel(
-          $.containerDiskSpaceUtilizationPanel('Disk Space Utilization', backend_job_matcher) +
-          {
-            gridPos: {
-              h: 7,
-              w: 8,
-              x: 16,
-              y: 31,
-            },
-          }
+          $.containerDiskSpaceUtilizationPanel('Disk Space Utilization', backend_job_matcher),
         )
       ),
   },


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes a layout issue brought up here https://github.com/grafana/loki/pull/13471#issuecomment-2359418045

This now renders as such which is a whole lot better :)

![image](https://github.com/user-attachments/assets/b6842a88-640c-47a4-a9af-f6380e2d55f3)

The multi-row approach was taken from the mimir resource overview dashboards

cc @cstyan 

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
