### PR TITLE
ci: temporarily disable the workflow for the PRs where PRs branch is from

### DIFF
--- a/.github/workflows/helm-loki-ci.yml
+++ b/.github/workflows/helm-loki-ci.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   publish-diff:
+    # temporarily disable the workflow for the PRs where PRs branch is from fork.
+    if: github.event.pull_request.head.repo.full_name == github.repository
     name: Publish Rendered Helm Chart Diff
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
**What this PR does / why we need it**:
temporarily disable the workflow for the PRs where PRs branch is from a fork. 
It's needed because right now the CI is failing due to an error: 
![image](https://github.com/user-attachments/assets/a26f94ed-356e-4b7e-b415-98c7f0e83e4c)
see: https://github.com/grafana/loki/pull/12870#issuecomment-2357153631
