### PR TITLE
fix(log-to-span): timestamp.Time should be called with milliseconds

### DIFF
--- a/pkg/querier/queryrange/codec.go
+++ b/pkg/querier/queryrange/codec.go
@@ -312,8 +312,8 @@ func (r *DetectedLabelsRequest) WithQuery(query string) queryrangebase.Request {
 
 func (r *DetectedLabelsRequest) LogToSpan(sp opentracing.Span) {
 	sp.LogFields(
-		otlog.String("start", timestamp.Time(r.GetStart().UnixNano()).String()),
-		otlog.String("end", timestamp.Time(r.GetEnd().UnixNano()).String()),
+		otlog.String("start", timestamp.Time(r.GetStart().UnixMilli()).String()),
+		otlog.String("end", timestamp.Time(r.GetEnd().UnixMilli()).String()),
 	)
 }
 
@@ -2359,8 +2359,8 @@ func (r *DetectedFieldsRequest) WithQuery(query string) queryrangebase.Request {
 
 func (r *DetectedFieldsRequest) LogToSpan(sp opentracing.Span) {
 	sp.LogFields(
-		otlog.String("start", timestamp.Time(r.GetStart().UnixNano()).String()),
-		otlog.String("end", timestamp.Time(r.GetEnd().UnixNano()).String()),
+		otlog.String("start", timestamp.Time(r.GetStart().UnixMilli()).String()),
+		otlog.String("end", timestamp.Time(r.GetEnd().UnixMilli()).String()),
 		otlog.String("query", r.GetQuery()),
 		otlog.Int64("step (ms)", r.GetStep()),
 		otlog.Int64("line_limit", int64(r.GetLineLimit())),


### PR DESCRIPTION
**What this PR does / why we need it**:

This was throwing weird dates in the span's events:
![image](https://github.com/user-attachments/assets/8c5a83d0-47a4-43b8-b94e-978478748f35)

https://pkg.go.dev/github.com/prometheus/prometheus/model/timestamp#Time is supposed to be called with milliseconds.