### PR TITLE
fix(helm): Check for `rbac.namespaced` condition before creating roles

### DIFF
--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -13,6 +13,10 @@ Entries should include a reference to the pull request that introduced the chang
 
 [//]: # (<AUTOMATED_UPDATES_LOCATOR> : do not remove this line. This locator is used by the CI pipeline to automatically create a changelog entry for each new Loki release. Add other chart versions and respective changelog entries bellow this line.)
 
+## 6.13.0
+
+- [CHANGE] Correctly wrap ClusterRoleBinding around `rbac/namespaced` conditional.
+
 ## 6.12.0
 
 - [ENHANCEMENT] Replace Bloom Compactor component with Bloom Planner and Bloom Builder. These are the new components to build bloom blocks.

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -3,7 +3,7 @@ name: loki
 description: Helm chart for Grafana Loki and Grafana Enterprise Logs supporting both simple, scalable and distributed modes.
 type: application
 appVersion: 3.1.1
-version: 6.12.0
+version: 6.13.0
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -1,6 +1,6 @@
 # loki
 
-![Version: 6.12.0](https://img.shields.io/badge/Version-6.12.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.1.1](https://img.shields.io/badge/AppVersion-3.1.1-informational?style=flat-square)
+![Version: 6.13.0](https://img.shields.io/badge/Version-6.13.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.1.1](https://img.shields.io/badge/AppVersion-3.1.1-informational?style=flat-square)
 
 Helm chart for Grafana Loki and Grafana Enterprise Logs supporting both simple, scalable and distributed modes.
 

--- a/production/helm/loki/templates/provisioner/role-provisioner.yaml
+++ b/production/helm/loki/templates/provisioner/role-provisioner.yaml
@@ -1,4 +1,4 @@
-{{ if and .Values.enterprise.provisioner.enabled .Values.enterprise.enabled }}
+{{ if and .Values.enterprise.provisioner.enabled .Values.enterprise.enabled (not .Values.rbac.namespaced)}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/production/helm/loki/templates/provisioner/role-provisioner.yaml
+++ b/production/helm/loki/templates/provisioner/role-provisioner.yaml
@@ -1,4 +1,4 @@
-{{ if and .Values.enterprise.provisioner.enabled .Values.enterprise.enabled (not .Values.rbac.namespaced)}}
+{{ if and (and .Values.enterprise.provisioner.enabled .Values.enterprise.enabled) (not .Values.rbac.namespaced)}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/production/helm/loki/templates/provisioner/rolebinding-provisioner.yaml
+++ b/production/helm/loki/templates/provisioner/rolebinding-provisioner.yaml
@@ -1,4 +1,4 @@
-{{ if and .Values.enterprise.provisioner.enabled .Values.enterprise.enabled }}
+{{ if and .Values.enterprise.provisioner.enabled .Values.enterprise.enabled (not .Values.rbac.namespaced)}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/production/helm/loki/templates/provisioner/rolebinding-provisioner.yaml
+++ b/production/helm/loki/templates/provisioner/rolebinding-provisioner.yaml
@@ -1,4 +1,4 @@
-{{ if and .Values.enterprise.provisioner.enabled .Values.enterprise.enabled (not .Values.rbac.namespaced)}}
+{{ if and (and .Values.enterprise.provisioner.enabled .Values.enterprise.enabled) (not .Values.rbac.namespaced)}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/production/helm/loki/templates/tokengen/clusterrole-tokengen.yaml
+++ b/production/helm/loki/templates/tokengen/clusterrole-tokengen.yaml
@@ -1,4 +1,4 @@
-{{ if and .Values.enterprise.tokengen.enabled .Values.enterprise.enabled }}
+{{ if and .Values.enterprise.tokengen.enabled .Values.enterprise.enabled (not .Values.rbac.namespaced)}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/production/helm/loki/templates/tokengen/clusterrole-tokengen.yaml
+++ b/production/helm/loki/templates/tokengen/clusterrole-tokengen.yaml
@@ -1,4 +1,4 @@
-{{ if and .Values.enterprise.tokengen.enabled .Values.enterprise.enabled (not .Values.rbac.namespaced)}}
+{{ if and (and .Values.enterprise.tokengen.enabled .Values.enterprise.enabled) (not .Values.rbac.namespaced)}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/production/helm/loki/templates/tokengen/clusterrolebinding-tokengen.yaml
+++ b/production/helm/loki/templates/tokengen/clusterrolebinding-tokengen.yaml
@@ -1,4 +1,4 @@
-{{ if and .Values.enterprise.tokengen.enabled .Values.enterprise.enabled }}
+{{ if and .Values.enterprise.tokengen.enabled .Values.enterprise.enabled (not .Values.rbac.namespaced)}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/production/helm/loki/templates/tokengen/clusterrolebinding-tokengen.yaml
+++ b/production/helm/loki/templates/tokengen/clusterrolebinding-tokengen.yaml
@@ -1,4 +1,4 @@
-{{ if and .Values.enterprise.tokengen.enabled .Values.enterprise.enabled (not .Values.rbac.namespaced)}}
+{{ if and (and .Values.enterprise.tokengen.enabled .Values.enterprise.enabled) (not .Values.rbac.namespaced)}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
**What this PR does / why we need it**:
Modify the tokengen and provisioner to check for `rbac.namespaced` before creating the role, as we do with the `backend` component. This is a fix as we were expected to do this check. 

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
