### PR TITLE
fix: Add additional validation for timeout while retrieving headers

### DIFF
--- a/pkg/storage/chunk/client/gcp/gcs_object_client.go
+++ b/pkg/storage/chunk/client/gcp/gcs_object_client.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"strings"
 	"time"
 
 	"cloud.google.com/go/storage"
@@ -269,6 +270,11 @@ func (s *GCSObjectClient) IsStorageTimeoutErr(err error) bool {
 	// TODO(dannyk): move these out to be generic
 	// context errors are all client-side
 	if isContextErr(err) {
+		if strings.Contains(err.Error(), "Client.Timeout exceeded while awaiting header") {
+			// Go 1.23 changed the type of the error returned by the http client when a timeout occurs
+			// while waiting for headers.  This is a server side timeout that can be retried.
+			return true
+		}
 		return false
 	}
 

--- a/pkg/storage/chunk/client/gcp/gcs_object_client.go
+++ b/pkg/storage/chunk/client/gcp/gcs_object_client.go
@@ -271,7 +271,7 @@ func (s *GCSObjectClient) IsStorageTimeoutErr(err error) bool {
 	// context errors are all client-side
 	if isContextErr(err) {
 		// Go 1.23 changed the type of the error returned by the http client when a timeout occurs
-		// while waiting for headers.  This is a server side timeout that can be retried.
+		// while waiting for headers.  This is a server side timeout.
 		return strings.Contains(err.Error(), "Client.Timeout exceeded while awaiting header")
 	}
 

--- a/pkg/storage/chunk/client/gcp/gcs_object_client.go
+++ b/pkg/storage/chunk/client/gcp/gcs_object_client.go
@@ -270,12 +270,9 @@ func (s *GCSObjectClient) IsStorageTimeoutErr(err error) bool {
 	// TODO(dannyk): move these out to be generic
 	// context errors are all client-side
 	if isContextErr(err) {
-		if strings.Contains(err.Error(), "Client.Timeout exceeded while awaiting header") {
-			// Go 1.23 changed the type of the error returned by the http client when a timeout occurs
-			// while waiting for headers.  This is a server side timeout that can be retried.
-			return true
-		}
-		return false
+		// Go 1.23 changed the type of the error returned by the http client when a timeout occurs
+		// while waiting for headers.  This is a server side timeout that can be retried.
+		return strings.Contains(err.Error(), "Client.Timeout exceeded while awaiting header")
 	}
 
 	// connection misconfiguration, or writing on a closed connection


### PR DESCRIPTION
**What this PR does / why we need it**:
Go 1.23 [changed](https://github.com/golang/go/commit/606b8ff5eff5e83e92b5b7466f9682115c1a6883) the type of error being returned in the case of a timeout while waiting for headers, as documented in this [issue](https://github.com/grafana/loki/issues/14206)
**Which issue(s) this PR fixes**:
Fixes #[14206](https://github.com/grafana/loki/issues/14206)

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
