### PR TITLE
fix: promtail parser for azureeventhubs message without time field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### Bug Fixes
 
 * **deps:** bumped dependencies versions to resolve CVEs ([#13789](https://github.com/grafana/loki/issues/13789)) ([34206cd](https://github.com/grafana/loki/commit/34206cd2d6290566034710ae6c2d08af8804bc91))
-
+* **promtail:** fix parser for azureeventhubs message without time field ([#14218](https://github.com/grafana/loki/pull/14218))
 
 ## [3.1.0](https://github.com/grafana/loki/compare/v3.0.0...v3.1.0) (2024-07-02)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Bug Fixes
+
+* **promtail:** fix parser for azureeventhubs message without time field ([#14218](https://github.com/grafana/loki/pull/14218))
+
 ## [3.1.1](https://github.com/grafana/loki/compare/v3.1.0...v3.1.1) (2024-08-08)
 
 
@@ -11,7 +17,6 @@
 ### Bug Fixes
 
 * **deps:** bumped dependencies versions to resolve CVEs ([#13789](https://github.com/grafana/loki/issues/13789)) ([34206cd](https://github.com/grafana/loki/commit/34206cd2d6290566034710ae6c2d08af8804bc91))
-* **promtail:** fix parser for azureeventhubs message without time field ([#14218](https://github.com/grafana/loki/pull/14218))
 
 ## [3.1.0](https://github.com/grafana/loki/compare/v3.0.0...v3.1.0) (2024-07-02)
 

--- a/clients/pkg/promtail/targets/azureeventhubs/parser.go
+++ b/clients/pkg/promtail/targets/azureeventhubs/parser.go
@@ -8,13 +8,11 @@ import (
 	"time"
 
 	"github.com/Shopify/sarama"
+	"github.com/grafana/loki/v3/clients/pkg/promtail/api"
+	"github.com/grafana/loki/v3/pkg/logproto"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/relabel"
-
-	"github.com/grafana/loki/v3/clients/pkg/promtail/api"
-
-	"github.com/grafana/loki/v3/pkg/logproto"
 )
 
 type azureMonitorResourceLogs struct {
@@ -33,7 +31,9 @@ func (l azureMonitorResourceLogs) validate() error {
 // azureMonitorResourceLog used to unmarshal common schema for Azure resource logs
 // https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/resource-logs-schema
 type azureMonitorResourceLog struct {
-	Time          string `json:"time"`
+	Time string `json:"time"`
+	// Some logs have `time` field, some have `timeStamp` field : https://github.com/grafana/loki/issues/14176
+	TimeStamp     string `json:"timeStamp"`
 	Category      string `json:"category"`
 	ResourceID    string `json:"resourceId"`
 	OperationName string `json:"operationName"`
@@ -41,7 +41,7 @@ type azureMonitorResourceLog struct {
 
 // validate check if fields marked as required by schema for Azure resource log are not empty
 func (l azureMonitorResourceLog) validate() error {
-	valid := len(l.Time) != 0 &&
+	valid := l.isTimeOrTimeStampFieldSet() &&
 		len(l.Category) != 0 &&
 		len(l.ResourceID) != 0 &&
 		len(l.OperationName) != 0
@@ -51,6 +51,34 @@ func (l azureMonitorResourceLog) validate() error {
 	}
 
 	return nil
+}
+
+func (l azureMonitorResourceLog) isTimeOrTimeStampFieldSet() bool {
+	return len(l.Time) != 0 || len(l.TimeStamp) != 0
+}
+
+// getTime returns time from `time` or `timeStamp` field. If both fields are set, `time` is used. If both fields are empty, error is returned.
+func (l azureMonitorResourceLog) getTime() (time.Time, error) {
+	var t time.Time
+	var err error
+
+	if len(l.Time) == 0 && len(l.TimeStamp) == 0 {
+		return t, errors.New("time and timeStamp fields are empty")
+	}
+
+	if len(l.TimeStamp) != 0 {
+		t, err = time.Parse(time.RFC3339, l.TimeStamp)
+	}
+
+	if len(l.Time) != 0 {
+		t, err = time.Parse(time.RFC3339, l.Time)
+	}
+
+	if err != nil {
+		return t, err
+	}
+
+	return t.UTC(), nil
 }
 
 type messageParser struct {
@@ -153,11 +181,11 @@ func (e *messageParser) parseRecord(record []byte, labelSet model.LabelSet, rela
 }
 
 func (e *messageParser) getTime(messageTime time.Time, useIncomingTimestamp bool, logRecord *azureMonitorResourceLog) time.Time {
-	if !useIncomingTimestamp || logRecord.Time == "" {
+	if !useIncomingTimestamp || !logRecord.isTimeOrTimeStampFieldSet() {
 		return messageTime
 	}
 
-	recordTime, err := time.Parse(time.RFC3339, logRecord.Time)
+	recordTime, err := logRecord.getTime()
 	if err != nil {
 		return messageTime
 	}

--- a/clients/pkg/promtail/targets/azureeventhubs/parser.go
+++ b/clients/pkg/promtail/targets/azureeventhubs/parser.go
@@ -8,11 +8,12 @@ import (
 	"time"
 
 	"github.com/Shopify/sarama"
-	"github.com/grafana/loki/v3/clients/pkg/promtail/api"
-	"github.com/grafana/loki/v3/pkg/logproto"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/relabel"
+
+	"github.com/grafana/loki/v3/clients/pkg/promtail/api"
+	"github.com/grafana/loki/v3/pkg/logproto"
 )
 
 type azureMonitorResourceLogs struct {

--- a/clients/pkg/promtail/targets/azureeventhubs/parser.go
+++ b/clients/pkg/promtail/targets/azureeventhubs/parser.go
@@ -69,14 +69,16 @@ func (l azureMonitorResourceLog) getTime() (time.Time, error) {
 
 	if len(l.TimeStamp) != 0 {
 		t, err = time.Parse(time.RFC3339, l.TimeStamp)
+		if err != nil {
+			return t, err
+		}
 	}
 
 	if len(l.Time) != 0 {
 		t, err = time.Parse(time.RFC3339, l.Time)
-	}
-
-	if err != nil {
-		return t, err
+		if err != nil {
+			return t, err
+		}
 	}
 
 	return t.UTC(), nil

--- a/clients/pkg/promtail/targets/azureeventhubs/parser.go
+++ b/clients/pkg/promtail/targets/azureeventhubs/parser.go
@@ -60,26 +60,23 @@ func (l azureMonitorResourceLog) isTimeOrTimeStampFieldSet() bool {
 
 // getTime returns time from `time` or `timeStamp` field. If both fields are set, `time` is used. If both fields are empty, error is returned.
 func (l azureMonitorResourceLog) getTime() (time.Time, error) {
-	var t time.Time
-	var err error
-
 	if len(l.Time) == 0 && len(l.TimeStamp) == 0 {
 		return t, errors.New("time and timeStamp fields are empty")
 	}
-
-	if len(l.TimeStamp) != 0 {
-		t, err = time.Parse(time.RFC3339, l.TimeStamp)
-		if err != nil {
-			return t, err
-		}
-	}
-
+	
 	if len(l.Time) != 0 {
-		t, err = time.Parse(time.RFC3339, l.Time)
+		t, err := time.Parse(time.RFC3339, l.Time)
 		if err != nil {
 			return t, err
 		}
+		
+		return t.UTC(), nil
 	}
+
+        t, err := time.Parse(time.RFC3339, l.TimeStamp)
+        if err != nil {
+	        return t, err
+        }
 
 	return t.UTC(), nil
 }

--- a/clients/pkg/promtail/targets/azureeventhubs/parser.go
+++ b/clients/pkg/promtail/targets/azureeventhubs/parser.go
@@ -61,22 +61,23 @@ func (l azureMonitorResourceLog) isTimeOrTimeStampFieldSet() bool {
 // getTime returns time from `time` or `timeStamp` field. If both fields are set, `time` is used. If both fields are empty, error is returned.
 func (l azureMonitorResourceLog) getTime() (time.Time, error) {
 	if len(l.Time) == 0 && len(l.TimeStamp) == 0 {
+		var t time.Time
 		return t, errors.New("time and timeStamp fields are empty")
 	}
-	
+
 	if len(l.Time) != 0 {
 		t, err := time.Parse(time.RFC3339, l.Time)
 		if err != nil {
 			return t, err
 		}
-		
+
 		return t.UTC(), nil
 	}
 
-        t, err := time.Parse(time.RFC3339, l.TimeStamp)
-        if err != nil {
-	        return t, err
-        }
+	t, err := time.Parse(time.RFC3339, l.TimeStamp)
+	if err != nil {
+		return t, err
+	}
 
 	return t.UTC(), nil
 }

--- a/clients/pkg/promtail/targets/azureeventhubs/parser_test.go
+++ b/clients/pkg/promtail/targets/azureeventhubs/parser_test.go
@@ -253,3 +253,23 @@ func readFile(t *testing.T, filename string) []byte {
 	assert.NoError(t, err)
 	return data
 }
+
+func Test_parseMessage_message_without_time_with_time_stamp(t *testing.T) {
+	messageParser := &messageParser{
+		disallowCustomMessages: true,
+	}
+
+	message := &sarama.ConsumerMessage{
+		Value:     readFile(t, "testdata/message_without_time_with_time_stamp.json"),
+		Timestamp: time.Date(2023, time.March, 17, 8, 44, 02, 0, time.UTC),
+	}
+
+	entries, err := messageParser.Parse(message, nil, nil, true)
+	assert.NoError(t, err)
+	assert.Len(t, entries, 1)
+
+	expectedLine1 := "{\n      \"timeStamp\": \"2024-09-18T00:45:09+00:00\",\n      \"resourceId\": \"/RESOURCE_ID\",\n      \"operationName\": \"ApplicationGatewayAccess\",\n      \"category\": \"ApplicationGatewayAccessLog\"\n    }"
+	assert.Equal(t, expectedLine1, entries[0].Line)
+
+	assert.Equal(t, time.Date(2024, time.September, 18, 00, 45, 9, 0, time.UTC), entries[0].Timestamp)
+}

--- a/clients/pkg/promtail/targets/azureeventhubs/parser_test.go
+++ b/clients/pkg/promtail/targets/azureeventhubs/parser_test.go
@@ -273,3 +273,17 @@ func Test_parseMessage_message_without_time_with_time_stamp(t *testing.T) {
 
 	assert.Equal(t, time.Date(2024, time.September, 18, 00, 45, 9, 0, time.UTC), entries[0].Timestamp)
 }
+
+func Test_parseMessage_message_without_time_and_time_stamp(t *testing.T) {
+	messageParser := &messageParser{
+		disallowCustomMessages: true,
+	}
+
+	message := &sarama.ConsumerMessage{
+		Value:     readFile(t, "testdata/message_without_time_and_time_stamp.json"),
+		Timestamp: time.Date(2023, time.March, 17, 8, 44, 02, 0, time.UTC),
+	}
+
+	_, err := messageParser.Parse(message, nil, nil, true)
+	assert.EqualError(t, err, "required field or fields is empty")
+}

--- a/clients/pkg/promtail/targets/azureeventhubs/testdata/message_without_time_and_time_stamp.json
+++ b/clients/pkg/promtail/targets/azureeventhubs/testdata/message_without_time_and_time_stamp.json
@@ -1,0 +1,9 @@
+{
+  "records": [
+    {
+      "resourceId": "/RESOURCE_ID",
+      "operationName": "ApplicationGatewayAccess",
+      "category": "ApplicationGatewayAccessLog"
+    }
+  ]
+}

--- a/clients/pkg/promtail/targets/azureeventhubs/testdata/message_without_time_with_time_stamp.json
+++ b/clients/pkg/promtail/targets/azureeventhubs/testdata/message_without_time_with_time_stamp.json
@@ -1,0 +1,10 @@
+{
+  "records": [
+    {
+      "timeStamp": "2024-09-18T00:45:09+00:00",
+      "resourceId": "/RESOURCE_ID",
+      "operationName": "ApplicationGatewayAccess",
+      "category": "ApplicationGatewayAccessLog"
+    }
+  ]
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

The promtail parser for azureeventhubs ignores records that doesn't contain the `time` field. 

- This change accepts such records if they contain the `timeStamp` field instead.
- For the parsed time, the location is set to the `UTC`

**Which issue(s) this PR fixes**:
Fixes: 

- https://github.com/grafana/loki/issues/14176

**Special notes for your reviewer**:


**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
