### PR TITLE
fix: Expand matching for additional variations

### DIFF
--- a/pkg/storage/chunk/client/gcp/gcs_object_client.go
+++ b/pkg/storage/chunk/client/gcp/gcs_object_client.go
@@ -272,7 +272,7 @@ func (s *GCSObjectClient) IsStorageTimeoutErr(err error) bool {
 	if isContextErr(err) {
 		// Go 1.23 changed the type of the error returned by the http client when a timeout occurs
 		// while waiting for headers.  This is a server side timeout.
-		return strings.Contains(err.Error(), "Client.Timeout exceeded while awaiting header")
+		return strings.Contains(err.Error(), "Client.Timeout")
 	}
 
 	// connection misconfiguration, or writing on a closed connection


### PR DESCRIPTION
**What this PR does / why we need it**:
Additional flavors, as seen [here](https://github.com/golang/go/blob/606b8ff5eff5e83e92b5b7466f9682115c1a6883/src/net/http/client.go#L968)

**Which issue(s) this PR fixes**:
Follow on to https://github.com/grafana/loki/pull/14217

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
