### PR TITLE
fix: allow any level for aggregated metrics

### DIFF
--- a/pkg/pattern/instance.go
+++ b/pkg/pattern/instance.go
@@ -9,7 +9,6 @@ import (
 	"sync"
 
 	"github.com/go-kit/log"
-	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/httpgrpc"
 	"github.com/grafana/dskit/multierror"
 	"github.com/grafana/dskit/ring"
@@ -264,20 +263,11 @@ func (i *instance) Observe(stream string, entries []logproto.Entry) {
 		streamMetrics, ok := i.aggMetricsByStreamAndLevel[stream]
 
 		if !ok {
-			streamMetrics = make(map[string]*aggregatedMetrics, len(constants.LogLevels))
-			for _, l := range constants.LogLevels {
-				streamMetrics[l] = &aggregatedMetrics{}
-			}
+			streamMetrics = map[string]*aggregatedMetrics{}
 		}
 
 		if _, ok := streamMetrics[lvl]; !ok {
-			level.Warn(i.logger).Log(
-				"msg", "unknown log level while observing stream",
-				"level", lvl,
-				"stream", stream,
-			)
-
-			lvl = constants.LogLevelUnknown
+			streamMetrics[lvl] = &aggregatedMetrics{}
 		}
 
 		streamMetrics[lvl].bytes += uint64(len(entry.Line))


### PR DESCRIPTION
**What this PR does / why we need it**:

It was a mistake to assume that level values would match one of the defined constant options, and not worth the performance gain of pre-allocating the map to eliminate all the other options.

This change supports any level for aggregated metrics.

**Which issue(s) this PR fixes**:
Fixes #14213

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
