### PR TITLE
fix(sharding): apply offset to both `from` and `through` in shard request

### DIFF
--- a/pkg/querier/queryrange/shard_resolver.go
+++ b/pkg/querier/queryrange/shard_resolver.go
@@ -225,8 +225,10 @@ func (r *dynamicShardResolver) ShardingRanges(expr syntax.Expr, targetBytesPerSh
 ) {
 	log := spanlogger.FromContext(r.ctx)
 
-	adjustedFrom := r.from
-	adjustedThrough := r.through
+	var (
+		adjustedFrom    = r.from
+		adjustedThrough model.Time
+	)
 
 	// NB(owen-d): there should only ever be 1 matcher group passed
 	// to this call as we call it separately for different legs
@@ -252,6 +254,7 @@ func (r *dynamicShardResolver) ShardingRanges(expr syntax.Expr, targetBytesPerSh
 			adjustedFrom = r.from.Add(-diff)
 		}
 
+		// use the latest adjustedThrough
 		if r.through.Add(-grp.Offset).After(adjustedThrough) {
 			adjustedThrough = r.through.Add(-grp.Offset)
 		}

--- a/pkg/querier/queryrange/shard_resolver.go
+++ b/pkg/querier/queryrange/shard_resolver.go
@@ -260,6 +260,11 @@ func (r *dynamicShardResolver) ShardingRanges(expr syntax.Expr, targetBytesPerSh
 		}
 	}
 
+	// handle the case where there are no matchers
+	if adjustedThrough == 0 {
+		adjustedThrough = r.through
+	}
+
 	exprStr := expr.String()
 	// try to get shards for the given expression
 	// if it fails, fallback to linearshards based on stats

--- a/pkg/querier/queryrange/shard_resolver.go
+++ b/pkg/querier/queryrange/shard_resolver.go
@@ -226,6 +226,7 @@ func (r *dynamicShardResolver) ShardingRanges(expr syntax.Expr, targetBytesPerSh
 	log := spanlogger.FromContext(r.ctx)
 
 	adjustedFrom := r.from
+	adjustedThrough := r.through
 
 	// NB(owen-d): there should only ever be 1 matcher group passed
 	// to this call as we call it separately for different legs
@@ -236,17 +237,23 @@ func (r *dynamicShardResolver) ShardingRanges(expr syntax.Expr, targetBytesPerSh
 	}
 
 	for _, grp := range grps {
-		diff := grp.Interval + grp.Offset
+		diff := grp.Interval
 
 		// For instant queries, when start == end,
 		// we have a default lookback which we add here
-		if grp.Interval == 0 {
-			diff = diff + r.defaultLookback
+		if diff == 0 {
+			diff = r.defaultLookback
 		}
+
+		diff += grp.Offset
 
 		// use the oldest adjustedFrom
 		if r.from.Add(-diff).Before(adjustedFrom) {
 			adjustedFrom = r.from.Add(-diff)
+		}
+
+		if r.through.Add(-grp.Offset).After(adjustedThrough) {
+			adjustedThrough = r.through.Add(-grp.Offset)
 		}
 	}
 
@@ -256,7 +263,7 @@ func (r *dynamicShardResolver) ShardingRanges(expr syntax.Expr, targetBytesPerSh
 	// use the retry handler here to retry transient errors
 	resp, err := r.retryNextHandler.Do(r.ctx, &logproto.ShardsRequest{
 		From:                adjustedFrom,
-		Through:             r.through,
+		Through:             adjustedThrough,
 		Query:               expr.String(),
 		TargetBytesPerShard: targetBytesPerShard,
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:

We are applying offset only on `From` which results in the shard resolver to incorrectly get shards over a long range `from-offset-interval -> through` for large offsets causing the query to fail with the following error. This pr applies offset on `Through` as well for the bounded sharding strategy. power of two strategy is already applying [it](https://github.com/grafana/loki/blob/f1a83801df696a9884241e0792c5aa04c830b307/pkg/querier/queryrange/shard_resolver.go#L105)

```
shard query is too large to execute on a single querier
```

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
