### PR TITLE
chore: update path for local config in production readme

### DIFF
--- a/clients/cmd/promtail/promtail-local-config.yaml
+++ b/clients/cmd/promtail/promtail-local-config.yaml
@@ -1,9 +1,13 @@
 server:
   http_listen_port: 9080
   grpc_listen_port: 0
+  log_level: debug
 
 positions:
   filename: /tmp/positions.yaml
+  sync_period: 10s
+target_config:
+  sync_period: 10s
 
 clients:
   - url: http://localhost:3100/loki/api/v1/push

--- a/clients/cmd/promtail/promtail-local-config.yaml
+++ b/clients/cmd/promtail/promtail-local-config.yaml
@@ -1,13 +1,9 @@
 server:
   http_listen_port: 9080
   grpc_listen_port: 0
-  log_level: debug
 
 positions:
   filename: /tmp/positions.yaml
-  sync_period: 10s
-target_config:
-  sync_period: 10s
 
 clients:
   - url: http://localhost:3100/loki/api/v1/push

--- a/production/README.md
+++ b/production/README.md
@@ -83,7 +83,7 @@ First, see the [build from source](../README.md) section of the root readme.
 Once Promtail is built, to run Promtail, use the following command:
 
 ```bash
-$ ./promtail -config.file=./cmd/promtail/promtail-local-config.yaml
+$ ./promtail -config.file=./clients/cmd/promtail/promtail-local-config.yaml
 ...
 ```
 


### PR DESCRIPTION
**What this PR does / why we need it**:

:wave:, According to [Build and run from source](https://github.com/grafana/loki/tree/main/production#build-and-run-from-source) `promtail` should start without issues when only config file is passed (without passing any additional flags). However, because of the missing fields in the `promtail-local-config.yaml` file, it fails.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
