### PR TITLE
fix: Add containerSecurityContext to Loki backend statefulset sidercar container

### DIFF
--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -13,6 +13,10 @@ Entries should include a reference to the pull request that introduced the chang
 
 [//]: # (<AUTOMATED_UPDATES_LOCATOR> : do not remove this line. This locator is used by the CI pipeline to automatically create a changelog entry for each new Loki release. Add other chart versions and respective changelog entries bellow this line.)
 
+## 6.15.0
+
+- [BUGFIX] Add containerSecurityContext to Loki helm chart backend statefulset sidercar container
+
 ## 6.14.0
 
 - [FEATURE] Add additional service annotations for components in distributed mode

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -3,7 +3,7 @@ name: loki
 description: Helm chart for Grafana Loki and Grafana Enterprise Logs supporting both simple, scalable and distributed modes.
 type: application
 appVersion: 3.1.1
-version: 6.14.0
+version: 6.15.0
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -1,6 +1,6 @@
 # loki
 
-![Version: 6.14.0](https://img.shields.io/badge/Version-6.14.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.1.1](https://img.shields.io/badge/AppVersion-3.1.1-informational?style=flat-square)
+![Version: 6.15.0](https://img.shields.io/badge/Version-6.15.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.1.1](https://img.shields.io/badge/AppVersion-3.1.1-informational?style=flat-square)
 
 Helm chart for Grafana Loki and Grafana Enterprise Logs supporting both simple, scalable and distributed modes.
 

--- a/production/helm/loki/templates/backend/statefulset-backend.yaml
+++ b/production/helm/loki/templates/backend/statefulset-backend.yaml
@@ -133,6 +133,10 @@ spec:
             - name: LOG_LEVEL
               value: "{{ .Values.sidecar.rules.logLevel }}"
             {{- end }}
+          {{- if .Values.sidecar.containerSecurityContext }}
+          containerSecurityContext:
+          {{- toYaml .Values.sidecar.containerSecurityContext | nindent 12 }}
+          {{- end }}
           {{- if .Values.sidecar.livenessProbe }}
           livenessProbe:
           {{- toYaml .Values.sidecar.livenessProbe | nindent 12 }}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is to add containerSecurityContext to Loki backend statefulset sidercar container.
In statefulset-backend.yaml, the spec for container sidecar does not include containerSecurityContext. This has caused deployment to fail because it ignores containerSecurityContext specified in values.yaml for the sidecar container, resulting in failing the Kubernetes policy engine (in our case kyverno) validation check.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:
None

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
