### PR TITLE
chore: add myself and quentin as codeowners/maintainers of the loki-mixin

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -16,4 +16,9 @@
 CHANGELOG.md
 
 # Mixins
-/production/loki-mixin/ @cstyan @QuentinBisson
+/production/loki-mixin/ @cstyan
+
+# Helm and compiled Mixins
+/production/helm/ @trevorwhitney
+/production/loki-mixin-compiled/ @trevorwhitney
+/production/loki-mixin-compiled-ssh/ @trevorwhitney

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -14,3 +14,6 @@
 
 # No owners - allows sub-maintainers to merge changes.
 CHANGELOG.md
+
+# Mixins
+/production/loki-mixin/ @cstyan @QuentinBisson

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -2,3 +2,4 @@
 
 Some parts of the codebase have other maintainers:
 - `@grafana/docs-logs`, which includes [@knylander-grafana](https://github.com/knylander-grafana) ([Grafana Labs](https://grafana.com/))
+- `@QuentinBisson` is an external contributor who helps maintain the Mixins in `/production/*-mixin/`


### PR DESCRIPTION
Adds myself and @QuentinBisson as codeowners for the `loki-mixin`. Mostly relevant for reviewing dashboard changes. Quentin I haven't kept up at all with the helm chart so if you should be listed for `/production/helm` as well LMK.