### PR TITLE
feat(kafka): enqueue commit offset only once per batch process

### DIFF
--- a/pkg/ingester/kafka_consumer.go
+++ b/pkg/ingester/kafka_consumer.go
@@ -152,5 +152,5 @@ func retryWithBackoff(ctx context.Context, fn func(attempts int) error) error {
 		}
 		backoff.Wait()
 	}
-	return b.Err()
+	return backoff.Err()
 }

--- a/pkg/ingester/kafka_consumer.go
+++ b/pkg/ingester/kafka_consumer.go
@@ -152,5 +152,5 @@ func retryWithBackoff(ctx context.Context, fn func(attempts int) error) error {
 		}
 		backoff.Wait()
 	}
-	return nil
+	return b.Err()
 }

--- a/pkg/ingester/kafka_consumer_test.go
+++ b/pkg/ingester/kafka_consumer_test.go
@@ -74,6 +74,8 @@ func (f *fakePusher) Push(ctx context.Context, in *logproto.PushRequest) (*logpr
 
 type noopCommitter struct{}
 
+func (nc *noopCommitter) EnqueueOffset(_ int64) {}
+
 func (noopCommitter) Commit(_ context.Context, _ int64) error { return nil }
 
 func TestConsumer(t *testing.T) {

--- a/pkg/kafka/ingester/consumer_test.go
+++ b/pkg/kafka/ingester/consumer_test.go
@@ -33,6 +33,11 @@ func (m *mockCommitter) Commit(_ context.Context, offset int64) error {
 	return nil
 }
 
+func (m *mockCommitter) EnqueueOffset(offset int64) {
+	// For testing purposes, we'll just set the committed offset directly
+	m.committed = offset
+}
+
 func TestConsumer_PeriodicFlush(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -46,7 +51,7 @@ func TestConsumer_PeriodicFlush(t *testing.T) {
 	flushInterval := 100 * time.Millisecond
 	maxFlushSize := int64(1000)
 
-	committer := &mockCommitter{}
+	committer := newMockCommitter()
 	consumerFactory := NewConsumerFactory(metastore, storage, flushInterval, maxFlushSize, log.NewLogfmtLogger(os.Stdout), reg)
 	consumer, err := consumerFactory(committer)
 	require.NoError(t, err)
@@ -99,7 +104,7 @@ func TestConsumer_ShutdownFlush(t *testing.T) {
 	flushInterval := 1 * time.Hour
 	maxFlushSize := int64(1000)
 
-	committer := &mockCommitter{}
+	committer := newMockCommitter()
 	consumerFactory := NewConsumerFactory(metastore, storage, flushInterval, maxFlushSize, log.NewLogfmtLogger(os.Stdout), reg)
 	consumer, err := consumerFactory(committer)
 	require.NoError(t, err)
@@ -153,7 +158,7 @@ func TestConsumer_MaxFlushSize(t *testing.T) {
 	flushInterval := 1 * time.Hour
 	maxFlushSize := int64(10)
 
-	committer := &mockCommitter{}
+	committer := newMockCommitter()
 	consumerFactory := NewConsumerFactory(metastore, storage, flushInterval, maxFlushSize, log.NewLogfmtLogger(os.Stdout), reg)
 	consumer, err := consumerFactory(committer)
 	require.NoError(t, err)

--- a/pkg/kafka/partition/committer.go
+++ b/pkg/kafka/partition/committer.go
@@ -19,6 +19,7 @@ import (
 // Committer defines an interface for committing offsets
 type Committer interface {
 	Commit(ctx context.Context, offset int64) error
+	EnqueueOffset(offset int64)
 }
 
 // partitionCommitter is responsible for committing offsets for a specific Kafka partition
@@ -113,7 +114,7 @@ func (r *partitionCommitter) autoCommitLoop(ctx context.Context) {
 	}
 }
 
-func (r *partitionCommitter) enqueueOffset(o int64) {
+func (r *partitionCommitter) EnqueueOffset(o int64) {
 	if r.kafkaCfg.ConsumerGroupOffsetCommitInterval > 0 {
 		r.toCommit.Store(o)
 	}

--- a/pkg/kafka/partition/reader.go
+++ b/pkg/kafka/partition/reader.go
@@ -123,7 +123,6 @@ func (p *Reader) startFetchLoop(ctx context.Context) <-chan []Record {
 				return
 			default:
 				records <- p.poll(ctx)
-				p.committer.enqueueOffset(p.lastProcessedOffset)
 			}
 		}
 	}()


### PR DESCRIPTION
**What this PR does / why we need it**:

This ensure we enqueue commit in ingester only once we have processed the batch and not when it was sent to the channel for processing which could cause dataloss if the ingester crashes in between

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/loki-private/issues/1123

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
