### PR TITLE
chore: refactor detected fields handler

### DIFF
--- a/pkg/querier/queryrange/detected_fields_test.go
+++ b/pkg/querier/queryrange/detected_fields_test.go
@@ -1028,10 +1028,7 @@ func TestQuerier_DetectedFields(t *testing.T) {
 			limitedHandler(mockLogfmtStreamWithLabels(1, 5, `{type="test", name="foo"}`)),
 			logHandler(mockLogfmtStreamWithLabels(1, 5, `{type="test", name="foo"}`)),
 			limits,
-		).Wrap(base.HandlerFunc(func(_ context.Context, _ base.Request) (base.Response, error) {
-			t.Fatal("should not be called")
-			return nil, nil
-		}))
+		)
 
 		detectedFields := handleRequest(handler, request)
 		// log lines come from querier_mock_test.go
@@ -1058,10 +1055,7 @@ func TestQuerier_DetectedFields(t *testing.T) {
 			limitedHandler(mockLogfmtStreamWithLabelsAndStructuredMetadata(1, 5, `{type="test", name="bob"}`)),
 			logHandler(mockLogfmtStreamWithLabelsAndStructuredMetadata(1, 5, `{type="test", name="bob"}`)),
 			limits,
-		).Wrap(base.HandlerFunc(func(_ context.Context, _ base.Request) (base.Response, error) {
-			t.Fatal("should not be called")
-			return nil, nil
-		}))
+		)
 
 		detectedFields := handleRequest(handler, request)
 		// log lines come from querier_mock_test.go
@@ -1090,10 +1084,7 @@ func TestQuerier_DetectedFields(t *testing.T) {
 			limitedHandler(mockLogfmtStreamWithLabels(1, 2, `{type="test", name="foo"}`)),
 			logHandler(mockLogfmtStreamWithLabels(1, 2, `{type="test", name="foo"}`)),
 			limits,
-		).Wrap(base.HandlerFunc(func(_ context.Context, _ base.Request) (base.Response, error) {
-			t.Fatal("should not be called")
-			return nil, nil
-		}))
+		)
 
 		detectedFields := handleRequest(handler, request)
 		// log lines come from querier_mock_test.go
@@ -1136,10 +1127,7 @@ func TestQuerier_DetectedFields(t *testing.T) {
 				),
 				logHandler(mockLogfmtStreamWithLabelsAndStructuredMetadata(1, 2, `{type="test"}`)),
 				limits,
-			).Wrap(base.HandlerFunc(func(_ context.Context, _ base.Request) (base.Response, error) {
-				t.Fatal("should not be called")
-				return nil, nil
-			}))
+			)
 
 			detectedFields := handleRequest(handler, request)
 			// log lines come from querier_mock_test.go
@@ -1188,10 +1176,7 @@ func TestQuerier_DetectedFields(t *testing.T) {
 				),
 				logHandler(mockLogfmtStreamWithLabelsAndStructuredMetadata(1, 2, `{type="test", name="bob"}`)),
 				limits,
-			).Wrap(base.HandlerFunc(func(_ context.Context, _ base.Request) (base.Response, error) {
-				t.Fatal("should not be called")
-				return nil, nil
-			}))
+			)
 
 			detectedFields := handleRequest(handler, request)
 			// log lines come from querier_mock_test.go

--- a/pkg/querier/queryrange/roundtrip.go
+++ b/pkg/querier/queryrange/roundtrip.go
@@ -1222,7 +1222,6 @@ func NewDetectedFieldsTripperware(
 		limitedHandler := limitedTripperware.Wrap(next)
 		logHandler := logTripperware.Wrap(next)
 
-		detectedFieldsHandler := NewDetectedFieldsHandler(limitedHandler, logHandler, limits)
-		return NewLimitedRoundTripper(next, limits, schema.Configs, detectedFieldsHandler)
+		return NewDetectedFieldsHandler(limitedHandler, logHandler, limits)
 	}), nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This refactors `NewDetectedFieldsHandler` to return a `base.Handler` instead of a `base.Middleware` since it no longer needs access to `next`, and is therefore not really a _middle_-ware.

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
