### PR TITLE
chore: Lint in prep for golangci compatible with Go 1.23

### DIFF
--- a/pkg/logql/syntax/ast.go
+++ b/pkg/logql/syntax/ast.go
@@ -80,7 +80,7 @@ func ExtractLabelFiltersBeforeParser(e Expr) []*LabelFilterExpr {
 	)
 
 	visitor := &DepthFirstTraversal{
-		VisitLabelFilterFn: func(v RootVisitor, e *LabelFilterExpr) {
+		VisitLabelFilterFn: func(_ RootVisitor, e *LabelFilterExpr) {
 			if !foundParseStage {
 				filters = append(filters, e)
 			}
@@ -94,13 +94,13 @@ func ExtractLabelFiltersBeforeParser(e Expr) []*LabelFilterExpr {
 		// expression is added without updating this list, blooms can silently
 		// misbehave.
 
-		VisitLogfmtParserFn:           func(v RootVisitor, e *LogfmtParserExpr) { foundParseStage = true },
-		VisitLabelParserFn:            func(v RootVisitor, e *LabelParserExpr) { foundParseStage = true },
-		VisitJSONExpressionParserFn:   func(v RootVisitor, e *JSONExpressionParser) { foundParseStage = true },
-		VisitLogfmtExpressionParserFn: func(v RootVisitor, e *LogfmtExpressionParser) { foundParseStage = true },
-		VisitLabelFmtFn:               func(v RootVisitor, e *LabelFmtExpr) { foundParseStage = true },
-		VisitKeepLabelFn:              func(v RootVisitor, e *KeepLabelsExpr) { foundParseStage = true },
-		VisitDropLabelsFn:             func(v RootVisitor, e *DropLabelsExpr) { foundParseStage = true },
+		VisitLogfmtParserFn:           func(_ RootVisitor, _ *LogfmtParserExpr) { foundParseStage = true },
+		VisitLabelParserFn:            func(_ RootVisitor, _ *LabelParserExpr) { foundParseStage = true },
+		VisitJSONExpressionParserFn:   func(_ RootVisitor, _ *JSONExpressionParser) { foundParseStage = true },
+		VisitLogfmtExpressionParserFn: func(_ RootVisitor, _ *LogfmtExpressionParser) { foundParseStage = true },
+		VisitLabelFmtFn:               func(_ RootVisitor, _ *LabelFmtExpr) { foundParseStage = true },
+		VisitKeepLabelFn:              func(_ RootVisitor, _ *KeepLabelsExpr) { foundParseStage = true },
+		VisitDropLabelsFn:             func(_ RootVisitor, _ *DropLabelsExpr) { foundParseStage = true },
 	}
 	e.Accept(visitor)
 	return filters

--- a/pkg/querier/queryrange/detected_fields_test.go
+++ b/pkg/querier/queryrange/detected_fields_test.go
@@ -969,7 +969,7 @@ func TestQuerier_DetectedFields(t *testing.T) {
 
 	limitedHandler := func(stream logproto.Stream) base.Handler {
 		return base.HandlerFunc(
-			func(ctx context.Context, req base.Request) (base.Response, error) {
+			func(_ context.Context, _ base.Request) (base.Response, error) {
 				return &LokiResponse{
 					Status: "success",
 					Data: LokiData{
@@ -985,7 +985,7 @@ func TestQuerier_DetectedFields(t *testing.T) {
 
 	logHandler := func(stream logproto.Stream) base.Handler {
 		return base.HandlerFunc(
-			func(ctx context.Context, req base.Request) (base.Response, error) {
+			func(_ context.Context, _ base.Request) (base.Response, error) {
 				return &LokiResponse{
 					Status: "success",
 					Data: LokiData{
@@ -1028,7 +1028,7 @@ func TestQuerier_DetectedFields(t *testing.T) {
 			limitedHandler(mockLogfmtStreamWithLabels(1, 5, `{type="test", name="foo"}`)),
 			logHandler(mockLogfmtStreamWithLabels(1, 5, `{type="test", name="foo"}`)),
 			limits,
-		).Wrap(base.HandlerFunc(func(ctx context.Context, req base.Request) (base.Response, error) {
+		).Wrap(base.HandlerFunc(func(_ context.Context, _ base.Request) (base.Response, error) {
 			t.Fatal("should not be called")
 			return nil, nil
 		}))
@@ -1058,7 +1058,7 @@ func TestQuerier_DetectedFields(t *testing.T) {
 			limitedHandler(mockLogfmtStreamWithLabelsAndStructuredMetadata(1, 5, `{type="test", name="bob"}`)),
 			logHandler(mockLogfmtStreamWithLabelsAndStructuredMetadata(1, 5, `{type="test", name="bob"}`)),
 			limits,
-		).Wrap(base.HandlerFunc(func(ctx context.Context, req base.Request) (base.Response, error) {
+		).Wrap(base.HandlerFunc(func(_ context.Context, _ base.Request) (base.Response, error) {
 			t.Fatal("should not be called")
 			return nil, nil
 		}))
@@ -1090,7 +1090,7 @@ func TestQuerier_DetectedFields(t *testing.T) {
 			limitedHandler(mockLogfmtStreamWithLabels(1, 2, `{type="test", name="foo"}`)),
 			logHandler(mockLogfmtStreamWithLabels(1, 2, `{type="test", name="foo"}`)),
 			limits,
-		).Wrap(base.HandlerFunc(func(ctx context.Context, req base.Request) (base.Response, error) {
+		).Wrap(base.HandlerFunc(func(_ context.Context, _ base.Request) (base.Response, error) {
 			t.Fatal("should not be called")
 			return nil, nil
 		}))
@@ -1136,7 +1136,7 @@ func TestQuerier_DetectedFields(t *testing.T) {
 				),
 				logHandler(mockLogfmtStreamWithLabelsAndStructuredMetadata(1, 2, `{type="test"}`)),
 				limits,
-			).Wrap(base.HandlerFunc(func(ctx context.Context, req base.Request) (base.Response, error) {
+			).Wrap(base.HandlerFunc(func(_ context.Context, _ base.Request) (base.Response, error) {
 				t.Fatal("should not be called")
 				return nil, nil
 			}))
@@ -1188,7 +1188,7 @@ func TestQuerier_DetectedFields(t *testing.T) {
 				),
 				logHandler(mockLogfmtStreamWithLabelsAndStructuredMetadata(1, 2, `{type="test", name="bob"}`)),
 				limits,
-			).Wrap(base.HandlerFunc(func(ctx context.Context, req base.Request) (base.Response, error) {
+			).Wrap(base.HandlerFunc(func(_ context.Context, _ base.Request) (base.Response, error) {
 				t.Fatal("should not be called")
 				return nil, nil
 			}))


### PR DESCRIPTION
**What this PR does / why we need it**:
Newer golangci is more enforcing with linting

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
