### PR TITLE
feat: Add writer addr to loki canary

### DIFF
--- a/docs/sources/operations/loki-canary/_index.md
+++ b/docs/sources/operations/loki-canary/_index.md
@@ -1,14 +1,14 @@
 ---
 title: Loki Canary
-menuTitle:  
+menuTitle:
 description: Describes how to use Loki Canary to audit the log-capturing performance of a Grafana Loki cluster to ensure Loki is ingesting logs without data loss.
-weight: 
+weight:
 ---
 # Loki Canary
 
-Loki Canary is a standalone app that audits the log-capturing performance of a Grafana Loki cluster.  
+Loki Canary is a standalone app that audits the log-capturing performance of a Grafana Loki cluster.
 This component emits and periodically queries for logs, making sure that Loki is ingesting logs without any data loss.
-When something is wrong with Loki, the Canary often provides the first indication. 
+When something is wrong with Loki, the Canary often provides the first indication.
 
 Loki Canary generates artificial log lines.
 These log lines are sent to the Loki cluster.
@@ -311,7 +311,7 @@ All options:
 
 ```
   -addr string
-    	The Loki server URL:Port, e.g. loki:3100. Loki address can also be set using the environment variable LOKI_ADDRESS.
+    	The read target of Loki server URL:Port, e.g. loki:3100. Loki address can also be set using the environment variable LOKI_ADDRESS.
   -buckets int
     	Number of buckets in the response_latency histogram (default 10)
   -ca-file string
@@ -374,6 +374,8 @@ All options:
     	Print this builds version information
   -wait duration
     	Duration to wait for log entries on websocket before querying loki for them (default 1m0s)
+  -write-addr string
+      The write target of Loki server URL:Port, e.g. loki-writer:3100. Loki write address can also be set using the environment variable LOKI_WRITE_ADDRESS. If not set, the read address will be used. This is useful when using push mode with distributed Loki setup.
   -write-max-backoff duration
     	Maximum backoff time between retries  (default 5m0s)
   -write-max-retries int

--- a/docs/sources/operations/loki-canary/_index.md
+++ b/docs/sources/operations/loki-canary/_index.md
@@ -375,7 +375,7 @@ All options:
   -wait duration
     	Duration to wait for log entries on websocket before querying loki for them (default 1m0s)
   -write-addr string
-      The write target of Loki server URL:Port, e.g. loki-writer:3100. Loki write address can also be set using the environment variable LOKI_WRITE_ADDRESS. If not set, the read address will be used. This is useful when using push mode with distributed Loki setup.
+    	The write target of Loki server URL:Port, e.g. loki-writer:3100. Loki write address can also be set using the environment variable LOKI_WRITE_ADDRESS. If not set, the read address will be used. This is useful when using push mode with distributed Loki setup.
   -write-max-backoff duration
     	Maximum backoff time between retries  (default 5m0s)
   -write-max-retries int


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Currently loki canary supports only one endpoint, when using it with a loki distributed cluster and `push mode` is enabled, there's no way to query/send logs by single endpoint.

This PR added a new flag `write-addr` to allow users define dedicated write endpoint to support above use case, by default, this write addr use the same value as `addr`.

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
