### PR TITLE
chore: Improve logging of jumphash server selector

### DIFF
--- a/pkg/bloomgateway/client_pool.go
+++ b/pkg/bloomgateway/client_pool.go
@@ -54,7 +54,7 @@ type AddressProvider interface {
 }
 
 func NewJumpHashClientPool(clientFactory ClientFactory, dnsProvider AddressProvider, updateInterval time.Duration, logger log.Logger) (*JumpHashClientPool, error) {
-	selector := jumphash.DefaultSelector()
+	selector := jumphash.DefaultSelector("bloomgateway")
 	err := selector.SetServers(dnsProvider.Addresses()...)
 	if err != nil {
 		level.Warn(logger).Log("msg", "error updating servers", "err", err)

--- a/pkg/storage/chunk/cache/memcached_client.go
+++ b/pkg/storage/chunk/cache/memcached_client.go
@@ -114,7 +114,7 @@ func (cfg *MemcachedClientConfig) RegisterFlagsWithPrefix(prefix, description st
 func NewMemcachedClient(cfg MemcachedClientConfig, name string, r prometheus.Registerer, logger log.Logger, metricsNamespace string) MemcachedClient {
 	var selector serverSelector
 	if cfg.ConsistentHash {
-		selector = jumphash.DefaultSelector()
+		selector = jumphash.DefaultSelector("memcached")
 	} else {
 		selector = &memcache.ServerList{}
 	}

--- a/pkg/util/jumphash/memcached_client_selector.go
+++ b/pkg/util/jumphash/memcached_client_selector.go
@@ -23,6 +23,7 @@ import (
 // with consistent DNS names where the naturally sorted order
 // is predictable.
 type Selector struct {
+	name            string
 	mu              sync.RWMutex
 	addrs           []net.Addr
 	resolveUnixAddr UnixResolver
@@ -33,15 +34,17 @@ type UnixResolver func(network, address string) (*net.UnixAddr, error)
 
 type TCPResolver func(network, address string) (*net.TCPAddr, error)
 
-func NewSelector(resolveUnixAddr UnixResolver, resolveTCPAddr TCPResolver) *Selector {
+func NewSelector(name string, resolveUnixAddr UnixResolver, resolveTCPAddr TCPResolver) *Selector {
 	return &Selector{
+		name:            name,
 		resolveUnixAddr: resolveUnixAddr,
 		resolveTCPAddr:  resolveTCPAddr,
 	}
 }
 
-func DefaultSelector() *Selector {
+func DefaultSelector(name string) *Selector {
 	return &Selector{
+		name:            name,
 		resolveUnixAddr: net.ResolveUnixAddr,
 		resolveTCPAddr:  net.ResolveTCPAddr,
 	}
@@ -102,7 +105,7 @@ func (s *Selector) SetServers(servers ...string) error {
 		}
 	}
 
-	level.Debug(util_log.Logger).Log("msg", "updating memcached servers", "servers", strings.Join(addresses(naddrs), ","), "count", len(naddrs))
+	level.Debug(util_log.Logger).Log("msg", "updating servers", "name", s.name, "servers", strings.Join(addresses(naddrs), ","), "count", len(naddrs))
 
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/pkg/util/jumphash/memcached_client_selector_test.go
+++ b/pkg/util/jumphash/memcached_client_selector_test.go
@@ -57,6 +57,7 @@ var mockTCPResolver = func(_, address string) (*net.TCPAddr, error) {
 
 func TestMemcachedJumpHashSelector_PickSever(t *testing.T) {
 	s := NewSelector(
+		"test",
 		mockUnixResolver,
 		mockTCPResolver,
 	)
@@ -84,6 +85,7 @@ func TestMemcachedJumpHashSelector_PickSever(t *testing.T) {
 
 func TestMemcachedJumpHashSelector_PickSever_ErrNoServers(t *testing.T) {
 	s := NewSelector(
+		"test",
 		mockUnixResolver,
 		mockTCPResolver,
 	)


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit adds the name of the server to the jumphash server selector logging by adding the name of the server to make the log lines distinguishable.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
