### PR TITLE
ci: make helm release manual

### DIFF
--- a/.github/workflows/helm-ci.yml
+++ b/.github/workflows/helm-ci.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - "production/helm/**"
+      - ".github/workflows/helm-ci.yml"
 
 env:
   CT_CONFIGFILE: production/helm/ct.yaml

--- a/.github/workflows/helm-ci.yml
+++ b/.github/workflows/helm-ci.yml
@@ -27,14 +27,6 @@ jobs:
       - name: Lint Yaml
         run: make helm-lint
 
-      - id: "get_github_app_token"
-        name: "Get Github app token"
-        uses: "actions/create-github-app-token@v1"
-        with:
-          app-id: "${{ secrets.APP_ID }}"
-          owner: "${{ github.repository_owner }}"
-          private-key: "${{ secrets.APP_PRIVATE_KEY }}"
-
       - name: Lint Code Base
         uses: docker://github/super-linter:v3.12.0
         env:
@@ -45,7 +37,7 @@ jobs:
           VALIDATE_YAML: false
           VALIDATE_GO: false
           DEFAULT_BRANCH: main
-          GITHUB_TOKEN: ${{ steps.get_github_app_token.outputs.token }}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
   call-test:
     name: Test Helm Chart
     runs-on: ubuntu-latest

--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -1,12 +1,7 @@
 name: helm-release
 
 on:
-  push:
-    branches:
-      - main
-      - helm-5.48
-    paths:
-      - 'production/helm/loki/Chart.yaml'
+  workflow_dispatch: # must be invoked manually
 
 jobs:
   call-update-helm-repo:


### PR DESCRIPTION
**What this PR does / why we need it**:

1. Make the helm release action a manual action, since we now automatically release weeklies from #14290
3. Use the default `secrets.GITHUB_SECRET` for the super linter in the `helm-ci` to fix issues with forks not being able to get a token from the GitHub app.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
