### PR TITLE
feat(helm): Enable Parallel Queriers for ruler for scalable remote rule execution

### DIFF
--- a/production/helm/loki/templates/ruler-querier/_helpers-ruler-querier.tpl
+++ b/production/helm/loki/templates/ruler-querier/_helpers-ruler-querier.tpl
@@ -1,0 +1,32 @@
+{{/*
+ruler querier fullname
+*/}}
+{{- define "loki.rulerQuerierFullname" -}}
+{{ include "loki.fullname" . }}-ruler-querier
+{{- end }}
+
+{{/*
+ruler querier common labels
+*/}}
+{{- define "loki.rulerQuerierLabels" -}}
+{{ include "loki.labels" . }}
+app.kubernetes.io/component: ruler-querier
+{{- end }}
+
+{{/*
+ruler querier selector labels
+*/}}
+{{- define "loki.rulerQuerierSelectorLabels" -}}
+{{ include "loki.selectorLabels" . }}
+app.kubernetes.io/component: ruler-querier
+{{- end }}
+
+{{/*
+ruler querier priority class name
+*/}}
+{{- define "loki.rulerQuerierPriorityClassName" -}}
+{{- $pcn := coalesce .Values.global.priorityClassName .Values.rulerQuerier.priorityClassName -}}
+{{- if $pcn }}
+priorityClassName: {{ $pcn }}
+{{- end }}
+{{- end }}

--- a/production/helm/loki/templates/ruler-querier/deployment-ruler-querier.yaml
+++ b/production/helm/loki/templates/ruler-querier/deployment-ruler-querier.yaml
@@ -1,0 +1,168 @@
+{{- if .Values.ruler.remoteEvaluationDedicatedQueryPath }}
+{{- $isDistributed := eq (include "loki.deployment.isDistributed" .) "true" -}}
+{{- if $isDistributed }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "loki.rulerQuerierFullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "loki.rulerQuerierLabels" . | nindent 4 }}
+    app.kubernetes.io/part-of: memberlist
+  {{- with .Values.loki.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+{{- if not .Values.rulerQuerier.autoscaling.enabled }}
+  replicas: {{ .Values.rulerQuerier.replicas }}
+{{- end }}
+  strategy:
+    rollingUpdate:
+      maxSurge: {{ .Values.rulerQuerier.maxSurge }}
+      maxUnavailable: 1
+  revisionHistoryLimit: {{ .Values.loki.revisionHistoryLimit }}
+  selector:
+    matchLabels:
+      {{- include "loki.rulerQuerierSelectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        {{- include "loki.config.checksum" . | nindent 8 }}
+        {{- with .Values.loki.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.rulerQuerier.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "loki.rulerQuerierSelectorLabels" . | nindent 8 }}
+        app.kubernetes.io/part-of: memberlist
+        {{- with .Values.loki.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.rulerQuerier.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
+      {{- with .Values.rulerQuerier.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- end }}
+      serviceAccountName: {{ include "loki.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.rulerQuerier.hostAliases }}
+      hostAliases:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- include "loki.rulerQuerierPriorityClassName" . | nindent 6 }}
+      securityContext:
+        {{- toYaml .Values.loki.podSecurityContext | nindent 8 }}
+      terminationGracePeriodSeconds: {{ .Values.rulerQuerier.terminationGracePeriodSeconds }}
+      {{- with .Values.rulerQuerier.initContainers }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: ruler-querier
+          image: {{ include "loki.image" . }}
+          imagePullPolicy: {{ .Values.loki.image.pullPolicy }}
+          args:
+            - -config.file=/etc/loki/config/config.yaml
+            - -target=querier
+            {{- if .Values.ingester.zoneAwareReplication.enabled }}
+            {{- if and (.Values.ingester.zoneAwareReplication.migration.enabled) (not .Values.ingester.zoneAwareReplication.migration.readPath) }}
+            - -distributor.zone-awareness-enabled=false
+            {{- else }}
+            - -distributor.zone-awareness-enabled=true
+            {{- end }}
+            {{- end }}
+            {{- with .Values.rulerQuerier.extraArgs }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          ports:
+            - name: http-metrics
+              containerPort: 3100
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
+              protocol: TCP
+            - name: http-memberlist
+              containerPort: 7946
+              protocol: TCP
+          {{- with .Values.rulerQuerier.extraEnv }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.rulerQuerier.extraEnvFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            {{- toYaml .Values.loki.containerSecurityContext | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.loki.readinessProbe | nindent 12 }}
+          livenessProbe:
+            {{- toYaml .Values.loki.livenessProbe | nindent 12 }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/loki/config
+            - name: runtime-config
+              mountPath: /etc/loki/runtime-config
+            - name: data
+              mountPath: /var/loki
+            {{- if .Values.enterprise.enabled }}
+            - name: license
+              mountPath: /etc/loki/license
+            {{- end }}
+            {{- with .Values.rulerQuerier.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.rulerQuerier.resources | nindent 12 }}
+        {{- if .Values.rulerQuerier.extraContainers }}
+        {{- toYaml .Values.rulerQuerier.extraContainers | nindent 8}}
+        {{- end }}
+      {{- with .Values.rulerQuerier.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.rulerQuerier.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.rulerQuerier.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.rulerQuerier.dnsConfig }}
+      dnsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: config
+          {{- include "loki.configVolume" . | nindent 10 }}
+        - name: runtime-config
+          configMap:
+            name: {{ template "loki.name" . }}-runtime
+        {{- if .Values.enterprise.enabled }}
+        - name: license
+          secret:
+          {{- if .Values.enterprise.useExternalLicense }}
+            secretName: {{ .Values.enterprise.externalLicenseName }}
+          {{- else }}
+            secretName: enterprise-logs-license
+          {{- end }}
+        {{- end }}
+        - name: data
+          emptyDir: {}
+        {{- with .Values.rulerQuerier.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+{{- end }}
+{{- end }}

--- a/production/helm/loki/templates/ruler-querier/hpa.yaml
+++ b/production/helm/loki/templates/ruler-querier/hpa.yaml
@@ -1,0 +1,57 @@
+{{- if .Values.ruler.remoteEvaluationDedicatedQueryPath }}
+{{- $isDistributed := eq (include "loki.deployment.isDistributed" .) "true" -}}
+{{- if and $isDistributed .Values.rulerQuerier.autoscaling.enabled }}
+{{- $apiVersion := include "loki.hpa.apiVersion" . -}}
+apiVersion: {{ $apiVersion }}
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "loki.rulerQuerierFullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "loki.rulerQuerierLabels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "loki.rulerQuerierFullname" . }}
+  minReplicas: {{ .Values.rulerQuerier.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.rulerQuerier.autoscaling.maxReplicas }}
+  metrics:
+  {{- with .Values.rulerQuerier.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        {{- if (eq $apiVersion "autoscaling/v2") }}
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
+        {{- else }}
+        targetAverageUtilization: {{ . }}
+        {{- end }}
+  {{- end }}
+  {{- with .Values.rulerQuerier.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        {{- if (eq $apiVersion "autoscaling/v2") }}
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
+        {{- else }}
+        targetAverageUtilization: {{ . }}
+        {{- end }}
+  {{- end }}
+  {{- with .Values.rulerQuerier.autoscaling.customMetrics }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- if .Values.rulerQuerier.autoscaling.behavior.enabled }}
+  behavior:
+    {{- with .Values.rulerQuerier.autoscaling.behavior.scaleDown }}
+    scaleDown: {{ toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.rulerQuerier.autoscaling.behavior.scaleUp }}
+    scaleUp: {{ toYaml . | nindent 6 }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/production/helm/loki/templates/ruler-querier/poddisruptionbudget-ruler-querier.yaml
+++ b/production/helm/loki/templates/ruler-querier/poddisruptionbudget-ruler-querier.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.ruler.remoteEvaluationDedicatedQueryPath }}
+{{- $isDistributed := eq (include "loki.deployment.isDistributed" .) "true" -}}
+{{- if and $isDistributed (gt (int .Values.rulerQuerier.replicas) 1) }}
+{{- if kindIs "invalid" .Values.rulerQuerier.maxUnavailable }}
+{{- fail "`.Values.rulerQuerier.maxUnavailable` must be set when `.Values.rulerQuerier.replicas` is greater than 1." }}
+{{- else }}
+apiVersion: {{ include "loki.pdb.apiVersion" . }}
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "loki.rulerQuerierFullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "loki.rulerQuerierLabels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "loki.rulerQuerierSelectorLabels" . | nindent 6 }}
+  {{- with .Values.rulerQuerier.maxUnavailable }}
+  maxUnavailable: {{ . }}
+  {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/production/helm/loki/templates/ruler-querier/service-ruler-querier.yaml
+++ b/production/helm/loki/templates/ruler-querier/service-ruler-querier.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.ruler.remoteEvaluationDedicatedQueryPath }}
+{{- $isDistributed := eq (include "loki.deployment.isDistributed" .) "true" -}}
+{{- if $isDistributed -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "loki.rulerQuerierFullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "loki.rulerQuerierLabels" . | nindent 4 }}
+    {{- with .Values.rulerQuerier.serviceLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- with .Values.loki.serviceAnnotations }}
+    {{- toYaml . | nindent 4}}
+    {{- end }}
+    {{- with .Values.rulerQuerier.serviceAnnotations }}
+    {{- toYaml . | nindent 4}}
+    {{- end }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: http-metrics
+      port: 3100
+      targetPort: http-metrics
+      protocol: TCP
+    - name: grpc
+      port: 9095
+      targetPort: grpc
+      protocol: TCP
+      {{- if .Values.rulerQuerier.appProtocol.grpc }}
+      appProtocol: {{ .Values.rulerQuerier.appProtocol.grpc }}
+      {{- end }}
+  selector:
+    {{- include "loki.rulerQuerierSelectorLabels" . | nindent 4 }}
+{{- end -}}
+{{- end -}}

--- a/production/helm/loki/templates/ruler-query-frontend/_helpers-ruler-query-frontend.tpl
+++ b/production/helm/loki/templates/ruler-query-frontend/_helpers-ruler-query-frontend.tpl
@@ -1,0 +1,32 @@
+{{/*
+ruler-query-frontend fullname
+*/}}
+{{- define "loki.rulerQueryFrontendFullname" -}}
+{{ include "loki.fullname" . }}-ruler-query-frontend
+{{- end }}
+
+{{/*
+ruler-query-frontend common labels
+*/}}
+{{- define "loki.rulerQueryFrontendLabels" -}}
+{{ include "loki.labels" . }}
+app.kubernetes.io/component: ruler-query-frontend
+{{- end }}
+
+{{/*
+ruler-query-frontend selector labels
+*/}}
+{{- define "loki.rulerQueryFrontendSelectorLabels" -}}
+{{ include "loki.selectorLabels" . }}
+app.kubernetes.io/component: ruler-query-frontend
+{{- end }}
+
+{{/*
+ruler-query-frontend priority class name
+*/}}
+{{- define "loki.rulerQueryFrontendPriorityClassName" -}}
+{{- $pcn := coalesce .Values.global.priorityClassName .Values.rulerQueryFrontend.priorityClassName -}}
+{{- if $pcn }}
+priorityClassName: {{ $pcn }}
+{{- end }}
+{{- end }}

--- a/production/helm/loki/templates/ruler-query-frontend/deployment-ruler-query-frontend.yaml
+++ b/production/helm/loki/templates/ruler-query-frontend/deployment-ruler-query-frontend.yaml
@@ -1,0 +1,144 @@
+{{- if .Values.ruler.remoteEvaluationDedicatedQueryPath }}
+{{- $isDistributed := eq (include "loki.deployment.isDistributed" .) "true" -}}
+{{- if $isDistributed -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "loki.rulerQueryFrontendFullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "loki.rulerQueryFrontendLabels" . | nindent 4 }}
+  {{- with .Values.loki.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+{{- if not .Values.rulerQueryFrontend.autoscaling.enabled }}
+  replicas: {{ .Values.rulerQueryFrontend.replicas }}
+{{- end }}
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  revisionHistoryLimit: {{ .Values.loki.revisionHistoryLimit }}
+  selector:
+    matchLabels:
+      {{- include "loki.rulerQueryFrontendSelectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        {{- include "loki.config.checksum" . | nindent 8 }}
+        {{- with .Values.loki.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.rulerQueryFrontend.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "loki.rulerQueryFrontendSelectorLabels" . | nindent 8 }}
+        app.kubernetes.io/part-of: memberlist
+        {{- with .Values.loki.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.rulerQueryFrontend.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "loki.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.rulerQueryFrontend.hostAliases }}
+      hostAliases:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- include "loki.rulerQueryFrontendPriorityClassName" . | nindent 6 }}
+      securityContext:
+        {{- toYaml .Values.loki.podSecurityContext | nindent 8 }}
+      terminationGracePeriodSeconds: {{ .Values.rulerQueryFrontend.terminationGracePeriodSeconds }}
+      containers:
+        - name: ruler-query-frontend
+          image: {{ include "loki.image" . }}
+          imagePullPolicy: {{ .Values.loki.image.pullPolicy }}
+          {{- if or .Values.loki.command .Values.rulerQueryFrontend.command }}
+          command:
+            - {{ coalesce .Values.rulerQueryFrontend.command .Values.loki.command | quote }}
+          {{- end }}
+          args:
+            - -config.file=/etc/loki/config/config.yaml
+            - -target=query-frontend
+            {{- with .Values.rulerQueryFrontend.extraArgs }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          ports:
+            - name: http-metrics
+              containerPort: 3100
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
+              protocol: TCP
+            - name: http-memberlist
+              containerPort: 7946
+              protocol: TCP
+          {{- with .Values.rulerQueryFrontend.extraEnv }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.rulerQueryFrontend.extraEnvFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            {{- toYaml .Values.loki.containerSecurityContext | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.loki.readinessProbe | nindent 12 }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/loki/config
+            - name: runtime-config
+              mountPath: /etc/loki/runtime-config
+            {{- if .Values.enterprise.enabled }}
+            - name: license
+              mountPath: /etc/loki/license
+            {{- end }}
+            {{- with .Values.rulerQueryFrontend.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.rulerQueryFrontend.resources | nindent 12 }}
+        {{- if .Values.rulerQueryFrontend.extraContainers }}
+        {{- toYaml .Values.rulerQueryFrontend.extraContainers | nindent 8}}
+        {{- end }}
+      {{- with .Values.rulerQueryFrontend.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.rulerQueryFrontend.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.rulerQueryFrontend.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: config
+          {{- include "loki.configVolume" . | nindent 10 }}
+        - name: runtime-config
+          configMap:
+            name: {{ template "loki.name" . }}-runtime
+        {{- if .Values.enterprise.enabled }}
+        - name: license
+          secret:
+          {{- if .Values.enterprise.useExternalLicense }}
+            secretName: {{ .Values.enterprise.externalLicenseName }}
+          {{- else }}
+            secretName: enterprise-logs-license
+          {{- end }}
+        {{- end }}
+        {{- with .Values.rulerQueryFrontend.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+{{- end -}}
+{{- end -}}

--- a/production/helm/loki/templates/ruler-query-frontend/hpa.yaml
+++ b/production/helm/loki/templates/ruler-query-frontend/hpa.yaml
@@ -1,0 +1,57 @@
+{{- if .Values.ruler.remoteEvaluationDedicatedQueryPath }}
+{{- $isDistributed := eq (include "loki.deployment.isDistributed" .) "true" -}}
+{{- if and $isDistributed .Values.rulerQueryFrontend.autoscaling.enabled }}
+{{- $apiVersion := include "loki.hpa.apiVersion" . -}}
+apiVersion: {{ $apiVersion }}
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "loki.rulerQueryFrontendFullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "loki.rulerQueryFrontendLabels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "loki.rulerQueryFrontendFullname" . }}
+  minReplicas: {{ .Values.rulerQueryFrontend.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.rulerQueryFrontend.autoscaling.maxReplicas }}
+  metrics:
+  {{- with .Values.rulerQueryFrontend.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        {{- if (eq $apiVersion "autoscaling/v2") }}
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
+        {{- else }}
+        targetAverageUtilization: {{ . }}
+        {{- end }}
+  {{- end }}
+  {{- with .Values.rulerQueryFrontend.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        {{- if (eq $apiVersion "autoscaling/v2") }}
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
+        {{- else }}
+        targetAverageUtilization: {{ . }}
+        {{- end }}
+  {{- end }}
+  {{- with .Values.rulerQueryFrontend.autoscaling.customMetrics }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- if .Values.rulerQueryFrontend.autoscaling.behavior.enabled }}
+  behavior:
+    {{- with .Values.rulerQueryFrontend.autoscaling.behavior.scaleDown }}
+    scaleDown: {{ toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.rulerQueryFrontend.autoscaling.behavior.scaleUp }}
+    scaleUp: {{ toYaml . | nindent 6 }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/production/helm/loki/templates/ruler-query-frontend/poddisruptionbudget-ruler-query-frontend.yaml
+++ b/production/helm/loki/templates/ruler-query-frontend/poddisruptionbudget-ruler-query-frontend.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.ruler.remoteEvaluationDedicatedQueryPath }}
+{{- $isDistributed := eq (include "loki.deployment.isDistributed" .) "true" -}}
+{{- if and $isDistributed (gt (int .Values.rulerQueryFrontend.replicas) 1) }}
+{{- if kindIs "invalid" .Values.rulerQueryFrontend.maxUnavailable }}
+{{- fail "`.Values.rulerQueryFrontend.maxUnavailable` must be set when `.Values.rulerQueryFrontend.replicas` is greater than 1." }}
+{{- else }}
+apiVersion: {{ include "loki.pdb.apiVersion" . }}
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "loki.rulerQueryFrontendFullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "loki.rulerQueryFrontendLabels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "loki.rulerQueryFrontendSelectorLabels" . | nindent 6 }}
+  {{- with .Values.rulerQueryFrontend.maxUnavailable }}
+  maxUnavailable: {{ . }}
+  {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/production/helm/loki/templates/ruler-query-frontend/service-ruler-query-frontend-headless.yaml
+++ b/production/helm/loki/templates/ruler-query-frontend/service-ruler-query-frontend-headless.yaml
@@ -1,0 +1,48 @@
+{{- if .Values.ruler.remoteEvaluationDedicatedQueryPath }}
+{{- $isDistributed := eq (include "loki.deployment.isDistributed" .) "true" -}}
+{{- if $isDistributed -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "loki.rulerQueryFrontendFullname" . }}-headless
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "loki.rulerQueryFrontendLabels" . | nindent 4 }}
+    {{- with .Values.rulerQueryFrontend.serviceLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    prometheus.io/service-monitor: "false"
+  annotations:
+    {{- with .Values.loki.serviceAnnotations }}
+    {{- toYaml . | nindent 4}}
+    {{- end }}
+    {{- with .Values.rulerQueryFrontend.serviceAnnotations }}
+    {{- toYaml . | nindent 4}}
+    {{- end }}
+spec:
+  clusterIP: None
+  type: ClusterIP
+  publishNotReadyAddresses: true
+  ports:
+    - name: http-metrics
+      port: 3100
+      targetPort: http-metrics
+      protocol: TCP
+    - name: grpc
+      port: 9095
+      targetPort: grpc
+      protocol: TCP
+      {{- if .Values.rulerQueryFrontend.appProtocol.grpc }}
+      appProtocol: {{ .Values.rulerQueryFrontend.appProtocol.grpc }}
+      {{- end }}
+    - name: grpclb
+      port: 9096
+      targetPort: grpc
+      protocol: TCP
+      {{- if .Values.rulerQueryFrontend.appProtocol.grpc }}
+      appProtocol: {{ .Values.rulerQueryFrontend.appProtocol.grpc }}
+      {{- end }}
+  selector:
+    {{- include "loki.rulerQueryFrontendSelectorLabels" . | nindent 4 }}
+{{- end -}}
+{{- end -}}

--- a/production/helm/loki/templates/ruler-query-frontend/service-ruler-query-frontend.yaml
+++ b/production/helm/loki/templates/ruler-query-frontend/service-ruler-query-frontend.yaml
@@ -1,0 +1,46 @@
+{{- if .Values.ruler.remoteEvaluationDedicatedQueryPath }}
+{{- $isDistributed := eq (include "loki.deployment.isDistributed" .) "true" -}}
+{{- if $isDistributed -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "loki.rulerQueryFrontendFullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "loki.rulerQueryFrontendLabels" . | nindent 4 }}
+    {{- with .Values.rulerQueryFrontend.serviceLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- with .Values.loki.serviceAnnotations }}
+    {{- toYaml . | nindent 4}}
+    {{- end }}
+    {{- with .Values.rulerQueryFrontend.serviceAnnotations }}
+    {{- toYaml . | nindent 4}}
+    {{- end }}
+spec:
+  type: ClusterIP
+  publishNotReadyAddresses: true
+  ports:
+    - name: http-metrics
+      port: 3100
+      targetPort: http-metrics
+      protocol: TCP
+    - name: grpc
+      port: 9095
+      targetPort: grpc
+      protocol: TCP
+      {{- if .Values.rulerQueryFrontend.appProtocol.grpc }}
+      appProtocol: {{ .Values.rulerQueryFrontend.appProtocol.grpc }}
+      {{- end }}
+    - name: grpclb
+      port: 9096
+      targetPort: grpc
+      protocol: TCP
+      {{- if .Values.rulerQueryFrontend.appProtocol.grpc }}
+      appProtocol: {{ .Values.rulerQueryFrontend.appProtocol.grpc }}
+      {{- end }}
+  selector:
+    {{- include "loki.rulerQueryFrontendSelectorLabels" . | nindent 4 }}
+{{- end -}}
+{{- end -}}

--- a/production/helm/loki/templates/ruler-query-scheduler/_helpers-ruler-query-scheduler.tpl
+++ b/production/helm/loki/templates/ruler-query-scheduler/_helpers-ruler-query-scheduler.tpl
@@ -1,0 +1,40 @@
+{{/*
+ruler-query-scheduler fullname
+*/}}
+{{- define "loki.rulerQuerySchedulerFullname" -}}
+{{ include "loki.fullname" . }}-ruler-query-scheduler
+{{- end }}
+
+{{/*
+ruler-query-scheduler common labels
+*/}}
+{{- define "loki.rulerQuerySchedulerLabels" -}}
+{{ include "loki.labels" . }}
+app.kubernetes.io/component: ruler-query-scheduler
+{{- end }}
+
+{{/*
+query-scheduler selector labels
+*/}}
+{{- define "loki.rulerQuerySchedulerSelectorLabels" -}}
+{{ include "loki.selectorLabels" . }}
+app.kubernetes.io/component: ruler-query-scheduler
+{{- end }}
+
+{{/*
+ruler-query-scheduler image
+*/}}
+{{- define "loki.rulerQuerySchedulerImage" -}}
+{{- $dict := dict "loki" .Values.loki.image "service" .Values.rulerQueryScheduler.image "global" .Values.global.image "defaultVersion" .Chart.AppVersion -}}
+{{- include "loki.lokiImage" $dict -}}
+{{- end }}
+
+{{/*
+ruler-query-scheduler priority class name
+*/}}
+{{- define "loki.rulerQuerySchedulerPriorityClassName" -}}
+{{- $pcn := coalesce .Values.global.priorityClassName .Values.rulerQueryScheduler.priorityClassName -}}
+{{- if $pcn }}
+priorityClassName: {{ $pcn }}
+{{- end }}
+{{- end }}

--- a/production/helm/loki/templates/ruler-query-scheduler/deployment-ruler-query-scheduler.yaml
+++ b/production/helm/loki/templates/ruler-query-scheduler/deployment-ruler-query-scheduler.yaml
@@ -1,0 +1,142 @@
+{{- if .Values.ruler.remoteEvaluationDedicatedQueryPath }}
+{{- $isDistributed := eq (include "loki.deployment.isDistributed" .) "true" -}}
+{{- if $isDistributed }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "loki.rulerQuerySchedulerFullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "loki.rulerQuerySchedulerLabels" . | nindent 4 }}
+  {{- with .Values.loki.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  replicas: {{ .Values.rulerQueryScheduler.replicas }}
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  revisionHistoryLimit: {{ .Values.loki.revisionHistoryLimit }}
+  selector:
+    matchLabels:
+      {{- include "loki.rulerQuerySchedulerSelectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        {{- include "loki.config.checksum" . | nindent 8 }}
+        {{- with .Values.loki.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.rulerQueryScheduler.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "loki.rulerQuerySchedulerSelectorLabels" . | nindent 8 }}
+        {{- with .Values.loki.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.rulerQueryScheduler.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        app.kubernetes.io/part-of: memberlist
+    spec:
+      serviceAccountName: {{ include "loki.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.rulerQueryScheduler.hostAliases }}
+      hostAliases:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- include "loki.rulerQuerySchedulerPriorityClassName" . | nindent 6 }}
+      securityContext:
+        {{- toYaml .Values.loki.podSecurityContext | nindent 8 }}
+      terminationGracePeriodSeconds: {{ .Values.rulerQueryScheduler.terminationGracePeriodSeconds }}
+      containers:
+        - name: ruler-query-scheduler
+          image: {{ include "loki.image" . }}
+          imagePullPolicy: {{ .Values.loki.image.pullPolicy }}
+          args:
+            - -config.file=/etc/loki/config/config.yaml
+            - -target=query-scheduler
+            {{- with .Values.rulerQueryScheduler.extraArgs }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          ports:
+            - name: http-metrics
+              containerPort: 3100
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
+              protocol: TCP
+            - name: http-memberlist
+              containerPort: 7946
+              protocol: TCP
+          {{- with .Values.rulerQueryScheduler.extraEnv }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.rulerQueryScheduler.extraEnvFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            {{- toYaml .Values.loki.containerSecurityContext | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.loki.readinessProbe | nindent 12 }}
+          livenessProbe:
+            {{- toYaml .Values.loki.livenessProbe | nindent 12 }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/loki/config
+            - name: runtime-config
+              mountPath: /etc/loki/runtime-config
+            {{- if .Values.enterprise.enabled }}
+            - name: license
+              mountPath: /etc/loki/license
+            {{- end }}
+            {{- with .Values.rulerQueryScheduler.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.rulerQueryScheduler.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+        {{- if .Values.rulerQueryScheduler.extraContainers }}
+        {{- toYaml .Values.rulerQueryScheduler.extraContainers | nindent 8}}
+        {{- end }}
+      {{- with .Values.rulerQueryScheduler.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.rulerQueryScheduler.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.rulerQueryScheduler.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: config
+          {{- include "loki.configVolume" . | nindent 10 }}
+        - name: runtime-config
+          configMap:
+            name: {{ template "loki.name" . }}-runtime
+        {{- if .Values.enterprise.enabled }}
+        - name: license
+          secret:
+          {{- if .Values.enterprise.useExternalLicense }}
+            secretName: {{ .Values.enterprise.externalLicenseName }}
+          {{- else }}
+            secretName: enterprise-logs-license
+          {{- end }}
+        {{- end }}
+        {{- with .Values.rulerQueryScheduler.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+{{- end }}
+{{- end }}

--- a/production/helm/loki/templates/ruler-query-scheduler/poddisruptionbudget-ruler-query-scheduler.yaml
+++ b/production/helm/loki/templates/ruler-query-scheduler/poddisruptionbudget-ruler-query-scheduler.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.ruler.remoteEvaluationDedicatedQueryPath }}
+{{- $isDistributed := eq (include "loki.deployment.isDistributed" .) "true" -}}
+{{- if and $isDistributed (gt (int .Values.rulerQueryScheduler.replicas) 1) }}
+{{- if kindIs "invalid" .Values.rulerQueryScheduler.maxUnavailable }}
+{{- fail "`.Values.rulerQueryScheduler.maxUnavailable` must be set when `.Values.rulerQueryScheduler.replicas` is greater than 1." }}
+{{- else }}
+apiVersion: {{ include "loki.pdb.apiVersion" . }}
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "loki.rulerQuerySchedulerFullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "loki.rulerQuerySchedulerLabels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "loki.rulerQuerySchedulerSelectorLabels" . | nindent 6 }}
+  {{- with .Values.rulerQueryScheduler.maxUnavailable }}
+  maxUnavailable: {{ . }}
+  {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/production/helm/loki/templates/ruler-query-scheduler/service-ruler-query-scheduler.yaml
+++ b/production/helm/loki/templates/ruler-query-scheduler/service-ruler-query-scheduler.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.ruler.remoteEvaluationDedicatedQueryPath }}
+{{- $isDistributed := eq (include "loki.deployment.isDistributed" .) "true" -}}
+{{- if $isDistributed }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "loki.rulerQuerySchedulerFullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "loki.rulerQuerySchedulerLabels" . | nindent 4 }}
+    {{- with .Values.rulerQueryScheduler.serviceLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- with .Values.loki.serviceAnnotations }}
+    {{- toYaml . | nindent 4}}
+    {{- end }}
+    {{- with .Values.rulerQueryScheduler.serviceAnnotations }}
+    {{- toYaml . | nindent 4}}
+    {{- end }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+    - name: http-metrics
+      port: 3100
+      targetPort: http-metrics
+      protocol: TCP
+    - name: grpclb
+      port: 9095
+      targetPort: grpc
+      protocol: TCP
+      {{- with .Values.rulerQueryScheduler.appProtocol.grpc }}
+      appProtocol: {{ . }}
+      {{- end }}
+  selector:
+    {{- include "loki.rulerQuerySchedulerSelectorLabels" . | nindent 4 }}
+{{- end }}
+{{- end }}

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -287,6 +287,7 @@ loki:
     bloom_gateway:
       {{- tpl (. | toYaml) $ | nindent 4 }}
     {{- end }}
+
   # Should authentication be enabled
   auth_enabled: true
   # -- memberlist configuration (overrides embedded default)
@@ -2962,6 +2963,284 @@ ruler:
   #         - alert: HighThroughputLogStreams
   #           expr: sum by(container) (rate({job=~"loki-dev/.*"}[1m])) > 1000
   #           for: 2m
+
+  remoteEvaluationDedicatedQueryPath: false
+
+# --  Configuration for the parallel ruler querier
+# -- Only deployed if .Values.ruler.remoteEvaluationDedicatedQueryPath
+rulerQuerier:
+  # -- Number of replicas for the querier
+  replicas: 2
+  # -- hostAliases to add
+  hostAliases: []
+  #  - ip: 1.2.3.4
+  #    hostnames:
+  #      - domain.tld
+  autoscaling:
+    # -- Enable autoscaling for the querier, this is only used if `indexGateway.enabled: true`
+    enabled: false
+    # -- Minimum autoscaling replicas for the querier
+    minReplicas: 1
+    # -- Maximum autoscaling replicas for the querier
+    maxReplicas: 3
+    # -- Target CPU utilisation percentage for the querier
+    targetCPUUtilizationPercentage: 60
+    # -- Target memory utilisation percentage for the querier
+    targetMemoryUtilizationPercentage: null
+    # -- Allows one to define custom metrics using the HPA/v2 schema (for example, Pods, Object or External metrics)
+    customMetrics: []
+    # - type: External
+    #   external:
+    #     metric:
+    #       name: loki_inflight_queries
+    #     target:
+    #       type: AverageValue
+    #       averageValue: 12
+    behavior:
+      # -- Enable autoscaling behaviours
+      enabled: false
+      # -- define scale down policies, must conform to HPAScalingRules
+      scaleDown: {}
+      # -- define scale up policies, must conform to HPAScalingRules
+      scaleUp: {}
+  image:
+    # -- The Docker registry for the querier image. Overrides `loki.image.registry`
+    registry: null
+    # -- Docker image repository for the querier image. Overrides `loki.image.repository`
+    repository: null
+    # -- Docker image tag for the querier image. Overrides `loki.image.tag`
+    tag: null
+  # -- Command to execute instead of defined in Docker image
+  command: null
+  # -- The name of the PriorityClass for querier pods
+  priorityClassName: null
+  # -- Labels for querier pods
+  podLabels: {}
+  # -- Annotations for querier pods
+  podAnnotations: {}
+  # -- Labels for querier service
+  serviceLabels: {}
+  # -- Annotations for querier service
+  serviceAnnotations: {}
+  # -- Additional CLI args for the querier
+  extraArgs: []
+  # -- Environment variables to add to the querier pods
+  extraEnv: []
+  # -- Environment variables from secrets or configmaps to add to the querier pods
+  extraEnvFrom: []
+  # -- Volume mounts to add to the querier pods
+  extraVolumeMounts: []
+  # -- Volumes to add to the querier pods
+  extraVolumes: []
+  # -- Resource requests and limits for the querier
+  resources: {}
+  # -- Containers to add to the querier pods
+  extraContainers: []
+  # -- Init containers to add to the querier pods
+  initContainers: []
+  # -- Grace period to allow the querier to shutdown before it is killed
+  terminationGracePeriodSeconds: 30
+  # -- topologySpread for querier pods.
+  # @default -- Defaults to allow skew no more then 1 node
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          app.kubernetes.io/component: querier
+  # -- Affinity for querier pods.
+  # @default -- Hard node anti-affinity
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              app.kubernetes.io/component: querier
+          topologyKey: kubernetes.io/hostname
+  # -- Pod Disruption Budget maxUnavailable
+  maxUnavailable: null
+  # -- Max Surge for querier pods
+  maxSurge: 0
+  # -- Node selector for querier pods
+  nodeSelector: {}
+  # -- Tolerations for querier pods
+  tolerations: []
+  # -- DNSConfig for querier pods
+  dnsConfig: {}
+  persistence:
+    # -- Enable creating PVCs for the querier cache
+    enabled: false
+    # -- Size of persistent disk
+    size: 10Gi
+    # -- Storage class to be used.
+    # If defined, storageClassName: <storageClass>.
+    # If set to "-", storageClassName: "", which disables dynamic provisioning.
+    # If empty or set to null, no storageClassName spec is
+    # set, choosing the default provisioner (gp2 on AWS, standard on GKE, AWS, and OpenStack).
+    storageClass: null
+    # -- Annotations for querier PVCs
+    annotations: {}
+  # -- Adds the appProtocol field to the querier service. This allows querier to work with istio protocol selection.
+  appProtocol:
+    # -- Set the optional grpc service protocol. Ex: "grpc", "http2" or "https"
+    grpc: ""
+
+# -- Configuration for the parallel ruler query-frontend
+# -- Only deployed if .Values.ruler.remoteEvaluationDedicatedQueryPath
+rulerQueryFrontend:
+  # -- Number of replicas for the query-frontend
+  replicas: 2
+  # -- hostAliases to add
+  hostAliases: []
+  #  - ip: 1.2.3.4
+  #    hostnames:
+  #      - domain.tld
+  autoscaling:
+    # -- Enable autoscaling for the query-frontend
+    enabled: false
+    # -- Minimum autoscaling replicas for the query-frontend
+    minReplicas: 1
+    # -- Maximum autoscaling replicas for the query-frontend
+    maxReplicas: 3
+    # -- Target CPU utilisation percentage for the query-frontend
+    targetCPUUtilizationPercentage: 60
+    # -- Target memory utilisation percentage for the query-frontend
+    targetMemoryUtilizationPercentage: null
+    # -- Allows one to define custom metrics using the HPA/v2 schema (for example, Pods, Object or External metrics)
+    customMetrics: []
+    # - type: Pods
+    #   pods:
+    #     metric:
+    #       name: loki_query_rate
+    #     target:
+    #       type: AverageValue
+    #       averageValue: 100
+    behavior:
+      # -- Enable autoscaling behaviours
+      enabled: false
+      # -- define scale down policies, must conform to HPAScalingRules
+      scaleDown: {}
+      # -- define scale up policies, must conform to HPAScalingRules
+      scaleUp: {}
+  image:
+    # -- The Docker registry for the query-frontend image. Overrides `loki.image.registry`
+    registry: null
+    # -- Docker image repository for the query-frontend image. Overrides `loki.image.repository`
+    repository: null
+    # -- Docker image tag for the query-frontend image. Overrides `loki.image.tag`
+    tag: null
+  # -- Command to execute instead of defined in Docker image
+  command: null
+  # -- The name of the PriorityClass for query-frontend pods
+  priorityClassName: null
+  # -- Labels for query-frontend pods
+  podLabels: {}
+  # -- Annotations for query-frontend pods
+  podAnnotations: {}
+  # -- Labels for query-frontend service
+  serviceLabels: {}
+  # -- Annotations for query-frontend service
+  serviceAnnotations: {}
+  # -- Additional CLI args for the query-frontend
+  extraArgs: []
+  # -- Environment variables to add to the query-frontend pods
+  extraEnv: []
+  # -- Environment variables from secrets or configmaps to add to the query-frontend pods
+  extraEnvFrom: []
+  # -- Volume mounts to add to the query-frontend pods
+  extraVolumeMounts: []
+  # -- Volumes to add to the query-frontend pods
+  extraVolumes: []
+  # -- Resource requests and limits for the query-frontend
+  resources: {}
+  # -- Containers to add to the query-frontend pods
+  extraContainers: []
+  # -- Grace period to allow the query-frontend to shutdown before it is killed
+  terminationGracePeriodSeconds: 30
+  # -- Affinity for query-frontend pods.
+  # @default -- Hard node anti-affinity
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              app.kubernetes.io/component: query-frontend
+          topologyKey: kubernetes.io/hostname
+  # -- Pod Disruption Budget maxUnavailable
+  maxUnavailable: 1
+  # -- Node selector for query-frontend pods
+  nodeSelector: {}
+  # -- Tolerations for query-frontend pods
+  tolerations: []
+  # -- Adds the appProtocol field to the queryFrontend service. This allows queryFrontend to work with istio protocol selection.
+  appProtocol:
+    # -- Set the optional grpc service protocol. Ex: "grpc", "http2" or "https"
+    grpc: ""
+
+
+rulerQueryScheduler:
+  # -- Number of replicas for the query-scheduler.
+  # It should be lower than `-querier.max-concurrent` to avoid generating back-pressure in queriers;
+  # it's also recommended that this value evenly divides the latter
+  replicas: 0
+  # -- hostAliases to add
+  hostAliases: []
+  #  - ip: 1.2.3.4
+  #    hostnames:
+  #      - domain.tld
+  image:
+    # -- The Docker registry for the query-scheduler image. Overrides `loki.image.registry`
+    registry: null
+    # -- Docker image repository for the query-scheduler image. Overrides `loki.image.repository`
+    repository: null
+    # -- Docker image tag for the query-scheduler image. Overrides `loki.image.tag`
+    tag: null
+  # -- The name of the PriorityClass for query-scheduler pods
+  priorityClassName: null
+  # -- Labels for query-scheduler pods
+  podLabels: {}
+  # -- Annotations for query-scheduler pods
+  podAnnotations: {}
+  # -- Labels for query-scheduler service
+  serviceLabels: {}
+  # -- Annotations for query-scheduler service
+  serviceAnnotations: {}
+  # -- Additional CLI args for the query-scheduler
+  extraArgs: []
+  # -- Environment variables to add to the query-scheduler pods
+  extraEnv: []
+  # -- Environment variables from secrets or configmaps to add to the query-scheduler pods
+  extraEnvFrom: []
+  # -- Volume mounts to add to the query-scheduler pods
+  extraVolumeMounts: []
+  # -- Volumes to add to the query-scheduler pods
+  extraVolumes: []
+  # -- Resource requests and limits for the query-scheduler
+  resources: {}
+  # -- Containers to add to the query-scheduler pods
+  extraContainers: []
+  # -- Grace period to allow the query-scheduler to shutdown before it is killed
+  terminationGracePeriodSeconds: 30
+  # -- Affinity for query-scheduler pods.
+  # @default -- Hard node anti-affinity
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              app.kubernetes.io/component: query-scheduler
+          topologyKey: kubernetes.io/hostname
+  # -- Pod Disruption Budget maxUnavailable
+  maxUnavailable: 1
+  # -- Node selector for query-scheduler pods
+  nodeSelector: {}
+  # -- Tolerations for query-scheduler pods
+  tolerations: []
+  # -- Set the optional grpc service protocol. Ex: "grpc", "http2" or "https"
+  appProtocol:
+    grpc: ""
+
 memcached:
   image:
     # -- Memcached Docker image repository


### PR DESCRIPTION
**What this PR does / why we need it**:
Updated Helm Chart to deploy parallel read path for the ruler when evaluation mode is remote. Provides the ability to have a scalable read path for the ruler, without impacts to or from ad-hoc queries. 

Includes
- rulerQuerier
- rulerQueryFrontend
- rulerQueryScheduler

Query execution follows 

Only deployed if ruler.remoteEvaluationDedicatedQueryPath is true

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
