### PR TITLE
chore(storage/bloom/v1): bind bloom page size to max bloom size

### DIFF
--- a/pkg/storage/bloom/v1/builder_test.go
+++ b/pkg/storage/bloom/v1/builder_test.go
@@ -23,6 +23,22 @@ var blockEncodings = []compression.Codec{
 	compression.Zstd,
 }
 
+func TestBlockOptions_BloomPageSize(t *testing.T) {
+	t.Parallel()
+
+	var (
+		maxBlockSizeBytes = uint64(50 << 10)
+		maxBloomSizeBytes = uint64(10 << 10)
+	)
+
+	opts := NewBlockOptions(compression.None, maxBlockSizeBytes, maxBloomSizeBytes)
+
+	require.GreaterOrEqual(
+		t, opts.BloomPageSize, maxBloomSizeBytes,
+		"opts.BloomPageSize should be greater or equal to the maximum bloom size to avoid having too many overfilled pages",
+	)
+}
+
 func TestBlockOptions_RoundTrip(t *testing.T) {
 	t.Parallel()
 	opts := BlockOptions{


### PR DESCRIPTION
**What this PR does / why we need it**:
Previously, the bloom page size was hard-coded to 256KB. However, 256KB is much smaller than the normal bloom size, leading to nearly every bloom page to be overfilled with a single, massive bloom.

Binding the bloom page size to the maximum bloom size allows bloom pages to contain multiple smaller blooms (which are still larger than 256KB) or one maxed out bloom.

**Which issue(s) this PR fixes**:
N/A 

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
