### PR TITLE
fix(build): Use Debian Bullseye base image for build image (#14368)

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,7 +2,7 @@
   "check":
     "uses": "grafana/loki-release/.github/workflows/check.yml@main"
     "with":
-      "build_image": "grafana/loki-build-image:0.33.6"
+      "build_image": "grafana/loki-build-image:0.34.1"
       "golang_ci_lint_version": "v1.55.1"
       "release_lib_ref": "main"
       "skip_validation": false

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -1,0 +1,433 @@
+"jobs":
+  "check":
+    "uses": "grafana/loki-release/.github/workflows/check.yml@main"
+    "with":
+      "build_image": "grafana/loki-build-image:0.34.1"
+      "golang_ci_lint_version": "v1.60.3"
+      "release_lib_ref": "main"
+      "skip_validation": false
+      "use_github_app_token": true
+  "fluent-bit":
+    "env":
+      "BUILD_TIMEOUT": 60
+      "IMAGE_PREFIX": "grafana"
+      "RELEASE_LIB_REF": "main"
+      "RELEASE_REPO": "grafana/loki"
+    "needs":
+    - "check"
+    "runs-on": "ubuntu-latest"
+    "steps":
+    - "name": "pull release library code"
+      "uses": "actions/checkout@v4"
+      "with":
+        "path": "lib"
+        "ref": "${{ env.RELEASE_LIB_REF }}"
+        "repository": "grafana/loki-release"
+    - "name": "pull code to release"
+      "uses": "actions/checkout@v4"
+      "with":
+        "path": "release"
+        "repository": "${{ env.RELEASE_REPO }}"
+    - "name": "setup node"
+      "uses": "actions/setup-node@v4"
+      "with":
+        "node-version": 20
+    - "name": "Set up QEMU"
+      "uses": "docker/setup-qemu-action@v3"
+    - "name": "set up docker buildx"
+      "uses": "docker/setup-buildx-action@v3"
+    - "name": "Login to DockerHub (from vault)"
+      "uses": "grafana/shared-workflows/actions/dockerhub-login@main"
+    - "id": "weekly-version"
+      "name": "Get weekly version"
+      "run": |
+        echo "version=$(./tools/image-tag)" >> $GITHUB_OUTPUT
+      "working-directory": "release"
+    - "name": "Build and push"
+      "timeout-minutes": "${{ fromJSON(env.BUILD_TIMEOUT) }}"
+      "uses": "docker/build-push-action@v6"
+      "with":
+        "build-args": "IMAGE_TAG=${{ steps.weekly-version.outputs.version }}"
+        "context": "release"
+        "file": "release/clients/cmd/fluent-bit/Dockerfile"
+        "platforms": "linux/amd64"
+        "push": true
+        "tags": "${{ env.IMAGE_PREFIX }}/fluent-bit-plugin-loki:${{ steps.weekly-version.outputs.version }}"
+  "fluentd":
+    "env":
+      "BUILD_TIMEOUT": 60
+      "IMAGE_PREFIX": "grafana"
+      "RELEASE_LIB_REF": "main"
+      "RELEASE_REPO": "grafana/loki"
+    "needs":
+    - "check"
+    "runs-on": "ubuntu-latest"
+    "steps":
+    - "name": "pull release library code"
+      "uses": "actions/checkout@v4"
+      "with":
+        "path": "lib"
+        "ref": "${{ env.RELEASE_LIB_REF }}"
+        "repository": "grafana/loki-release"
+    - "name": "pull code to release"
+      "uses": "actions/checkout@v4"
+      "with":
+        "path": "release"
+        "repository": "${{ env.RELEASE_REPO }}"
+    - "name": "setup node"
+      "uses": "actions/setup-node@v4"
+      "with":
+        "node-version": 20
+    - "name": "Set up QEMU"
+      "uses": "docker/setup-qemu-action@v3"
+    - "name": "set up docker buildx"
+      "uses": "docker/setup-buildx-action@v3"
+    - "name": "Login to DockerHub (from vault)"
+      "uses": "grafana/shared-workflows/actions/dockerhub-login@main"
+    - "id": "weekly-version"
+      "name": "Get weekly version"
+      "run": |
+        echo "version=$(./tools/image-tag)" >> $GITHUB_OUTPUT
+      "working-directory": "release"
+    - "name": "Build and push"
+      "timeout-minutes": "${{ fromJSON(env.BUILD_TIMEOUT) }}"
+      "uses": "docker/build-push-action@v6"
+      "with":
+        "build-args": "IMAGE_TAG=${{ steps.weekly-version.outputs.version }}"
+        "context": "release"
+        "file": "release/clients/cmd/fluentd/Dockerfile"
+        "platforms": "linux/amd64"
+        "push": true
+        "tags": "${{ env.IMAGE_PREFIX }}/fluent-plugin-loki:${{ steps.weekly-version.outputs.version }}"
+  "logcli":
+    "env":
+      "BUILD_TIMEOUT": 60
+      "IMAGE_PREFIX": "grafana"
+      "RELEASE_LIB_REF": "main"
+      "RELEASE_REPO": "grafana/loki"
+    "needs":
+    - "check"
+    "runs-on": "ubuntu-latest"
+    "steps":
+    - "name": "pull release library code"
+      "uses": "actions/checkout@v4"
+      "with":
+        "path": "lib"
+        "ref": "${{ env.RELEASE_LIB_REF }}"
+        "repository": "grafana/loki-release"
+    - "name": "pull code to release"
+      "uses": "actions/checkout@v4"
+      "with":
+        "path": "release"
+        "repository": "${{ env.RELEASE_REPO }}"
+    - "name": "setup node"
+      "uses": "actions/setup-node@v4"
+      "with":
+        "node-version": 20
+    - "name": "Set up QEMU"
+      "uses": "docker/setup-qemu-action@v3"
+    - "name": "set up docker buildx"
+      "uses": "docker/setup-buildx-action@v3"
+    - "name": "Login to DockerHub (from vault)"
+      "uses": "grafana/shared-workflows/actions/dockerhub-login@main"
+    - "id": "weekly-version"
+      "name": "Get weekly version"
+      "run": |
+        echo "version=$(./tools/image-tag)" >> $GITHUB_OUTPUT
+      "working-directory": "release"
+    - "name": "Build and push"
+      "timeout-minutes": "${{ fromJSON(env.BUILD_TIMEOUT) }}"
+      "uses": "docker/build-push-action@v6"
+      "with":
+        "build-args": "IMAGE_TAG=${{ steps.weekly-version.outputs.version }}"
+        "context": "release"
+        "file": "release/cmd/logcli/Dockerfile"
+        "platforms": "linux/amd64,linux/arm64,linux/arm"
+        "push": true
+        "tags": "${{ env.IMAGE_PREFIX }}/logcli:${{ steps.weekly-version.outputs.version }}"
+  "logstash":
+    "env":
+      "BUILD_TIMEOUT": 60
+      "IMAGE_PREFIX": "grafana"
+      "RELEASE_LIB_REF": "main"
+      "RELEASE_REPO": "grafana/loki"
+    "needs":
+    - "check"
+    "runs-on": "ubuntu-latest"
+    "steps":
+    - "name": "pull release library code"
+      "uses": "actions/checkout@v4"
+      "with":
+        "path": "lib"
+        "ref": "${{ env.RELEASE_LIB_REF }}"
+        "repository": "grafana/loki-release"
+    - "name": "pull code to release"
+      "uses": "actions/checkout@v4"
+      "with":
+        "path": "release"
+        "repository": "${{ env.RELEASE_REPO }}"
+    - "name": "setup node"
+      "uses": "actions/setup-node@v4"
+      "with":
+        "node-version": 20
+    - "name": "Set up QEMU"
+      "uses": "docker/setup-qemu-action@v3"
+    - "name": "set up docker buildx"
+      "uses": "docker/setup-buildx-action@v3"
+    - "name": "Login to DockerHub (from vault)"
+      "uses": "grafana/shared-workflows/actions/dockerhub-login@main"
+    - "id": "weekly-version"
+      "name": "Get weekly version"
+      "run": |
+        echo "version=$(./tools/image-tag)" >> $GITHUB_OUTPUT
+      "working-directory": "release"
+    - "name": "Build and push"
+      "timeout-minutes": "${{ fromJSON(env.BUILD_TIMEOUT) }}"
+      "uses": "docker/build-push-action@v6"
+      "with":
+        "build-args": "IMAGE_TAG=${{ steps.weekly-version.outputs.version }}"
+        "context": "release"
+        "file": "release/clients/cmd/logstash/Dockerfile"
+        "platforms": "linux/amd64"
+        "push": true
+        "tags": "${{ env.IMAGE_PREFIX }}/logstash-output-loki:${{ steps.weekly-version.outputs.version }}"
+  "loki":
+    "env":
+      "BUILD_TIMEOUT": 60
+      "IMAGE_PREFIX": "grafana"
+      "RELEASE_LIB_REF": "main"
+      "RELEASE_REPO": "grafana/loki"
+    "needs":
+    - "check"
+    "runs-on": "ubuntu-latest"
+    "steps":
+    - "name": "pull release library code"
+      "uses": "actions/checkout@v4"
+      "with":
+        "path": "lib"
+        "ref": "${{ env.RELEASE_LIB_REF }}"
+        "repository": "grafana/loki-release"
+    - "name": "pull code to release"
+      "uses": "actions/checkout@v4"
+      "with":
+        "path": "release"
+        "repository": "${{ env.RELEASE_REPO }}"
+    - "name": "setup node"
+      "uses": "actions/setup-node@v4"
+      "with":
+        "node-version": 20
+    - "name": "Set up QEMU"
+      "uses": "docker/setup-qemu-action@v3"
+    - "name": "set up docker buildx"
+      "uses": "docker/setup-buildx-action@v3"
+    - "name": "Login to DockerHub (from vault)"
+      "uses": "grafana/shared-workflows/actions/dockerhub-login@main"
+    - "id": "weekly-version"
+      "name": "Get weekly version"
+      "run": |
+        echo "version=$(./tools/image-tag)" >> $GITHUB_OUTPUT
+      "working-directory": "release"
+    - "name": "Build and push"
+      "timeout-minutes": "${{ fromJSON(env.BUILD_TIMEOUT) }}"
+      "uses": "docker/build-push-action@v6"
+      "with":
+        "build-args": "IMAGE_TAG=${{ steps.weekly-version.outputs.version }}"
+        "context": "release"
+        "file": "release/cmd/loki/Dockerfile"
+        "platforms": "linux/amd64,linux/arm64,linux/arm"
+        "push": true
+        "tags": "${{ env.IMAGE_PREFIX }}/loki:${{ steps.weekly-version.outputs.version }}"
+  "loki-canary":
+    "env":
+      "BUILD_TIMEOUT": 60
+      "IMAGE_PREFIX": "grafana"
+      "RELEASE_LIB_REF": "main"
+      "RELEASE_REPO": "grafana/loki"
+    "needs":
+    - "check"
+    "runs-on": "ubuntu-latest"
+    "steps":
+    - "name": "pull release library code"
+      "uses": "actions/checkout@v4"
+      "with":
+        "path": "lib"
+        "ref": "${{ env.RELEASE_LIB_REF }}"
+        "repository": "grafana/loki-release"
+    - "name": "pull code to release"
+      "uses": "actions/checkout@v4"
+      "with":
+        "path": "release"
+        "repository": "${{ env.RELEASE_REPO }}"
+    - "name": "setup node"
+      "uses": "actions/setup-node@v4"
+      "with":
+        "node-version": 20
+    - "name": "Set up QEMU"
+      "uses": "docker/setup-qemu-action@v3"
+    - "name": "set up docker buildx"
+      "uses": "docker/setup-buildx-action@v3"
+    - "name": "Login to DockerHub (from vault)"
+      "uses": "grafana/shared-workflows/actions/dockerhub-login@main"
+    - "id": "weekly-version"
+      "name": "Get weekly version"
+      "run": |
+        echo "version=$(./tools/image-tag)" >> $GITHUB_OUTPUT
+      "working-directory": "release"
+    - "name": "Build and push"
+      "timeout-minutes": "${{ fromJSON(env.BUILD_TIMEOUT) }}"
+      "uses": "docker/build-push-action@v6"
+      "with":
+        "build-args": "IMAGE_TAG=${{ steps.weekly-version.outputs.version }}"
+        "context": "release"
+        "file": "release/cmd/loki-canary/Dockerfile"
+        "platforms": "linux/amd64,linux/arm64,linux/arm"
+        "push": true
+        "tags": "${{ env.IMAGE_PREFIX }}/loki-canary:${{ steps.weekly-version.outputs.version }}"
+  "loki-canary-boringcrypto":
+    "env":
+      "BUILD_TIMEOUT": 60
+      "IMAGE_PREFIX": "grafana"
+      "RELEASE_LIB_REF": "main"
+      "RELEASE_REPO": "grafana/loki"
+    "needs":
+    - "check"
+    "runs-on": "ubuntu-latest"
+    "steps":
+    - "name": "pull release library code"
+      "uses": "actions/checkout@v4"
+      "with":
+        "path": "lib"
+        "ref": "${{ env.RELEASE_LIB_REF }}"
+        "repository": "grafana/loki-release"
+    - "name": "pull code to release"
+      "uses": "actions/checkout@v4"
+      "with":
+        "path": "release"
+        "repository": "${{ env.RELEASE_REPO }}"
+    - "name": "setup node"
+      "uses": "actions/setup-node@v4"
+      "with":
+        "node-version": 20
+    - "name": "Set up QEMU"
+      "uses": "docker/setup-qemu-action@v3"
+    - "name": "set up docker buildx"
+      "uses": "docker/setup-buildx-action@v3"
+    - "name": "Login to DockerHub (from vault)"
+      "uses": "grafana/shared-workflows/actions/dockerhub-login@main"
+    - "id": "weekly-version"
+      "name": "Get weekly version"
+      "run": |
+        echo "version=$(./tools/image-tag)" >> $GITHUB_OUTPUT
+      "working-directory": "release"
+    - "name": "Build and push"
+      "timeout-minutes": "${{ fromJSON(env.BUILD_TIMEOUT) }}"
+      "uses": "docker/build-push-action@v6"
+      "with":
+        "build-args": "IMAGE_TAG=${{ steps.weekly-version.outputs.version }}"
+        "context": "release"
+        "file": "release/cmd/loki-canary-boringcrypto/Dockerfile"
+        "platforms": "linux/amd64,linux/arm64,linux/arm"
+        "push": true
+        "tags": "${{ env.IMAGE_PREFIX }}/loki-canary-boringcrypto:${{ steps.weekly-version.outputs.version }}"
+  "promtail":
+    "env":
+      "BUILD_TIMEOUT": 60
+      "IMAGE_PREFIX": "grafana"
+      "RELEASE_LIB_REF": "main"
+      "RELEASE_REPO": "grafana/loki"
+    "needs":
+    - "check"
+    "runs-on": "ubuntu-latest"
+    "steps":
+    - "name": "pull release library code"
+      "uses": "actions/checkout@v4"
+      "with":
+        "path": "lib"
+        "ref": "${{ env.RELEASE_LIB_REF }}"
+        "repository": "grafana/loki-release"
+    - "name": "pull code to release"
+      "uses": "actions/checkout@v4"
+      "with":
+        "path": "release"
+        "repository": "${{ env.RELEASE_REPO }}"
+    - "name": "setup node"
+      "uses": "actions/setup-node@v4"
+      "with":
+        "node-version": 20
+    - "name": "Set up QEMU"
+      "uses": "docker/setup-qemu-action@v3"
+    - "name": "set up docker buildx"
+      "uses": "docker/setup-buildx-action@v3"
+    - "name": "Login to DockerHub (from vault)"
+      "uses": "grafana/shared-workflows/actions/dockerhub-login@main"
+    - "id": "weekly-version"
+      "name": "Get weekly version"
+      "run": |
+        echo "version=$(./tools/image-tag)" >> $GITHUB_OUTPUT
+      "working-directory": "release"
+    - "name": "Build and push"
+      "timeout-minutes": "${{ fromJSON(env.BUILD_TIMEOUT) }}"
+      "uses": "docker/build-push-action@v6"
+      "with":
+        "build-args": "IMAGE_TAG=${{ steps.weekly-version.outputs.version }}"
+        "context": "release"
+        "file": "release/clients/cmd/promtail/Dockerfile"
+        "platforms": "linux/amd64,linux/arm64,linux/arm"
+        "push": true
+        "tags": "${{ env.IMAGE_PREFIX }}/promtail:${{ steps.weekly-version.outputs.version }}"
+  "querytee":
+    "env":
+      "BUILD_TIMEOUT": 60
+      "IMAGE_PREFIX": "grafana"
+      "RELEASE_LIB_REF": "main"
+      "RELEASE_REPO": "grafana/loki"
+    "needs":
+    - "check"
+    "runs-on": "ubuntu-latest"
+    "steps":
+    - "name": "pull release library code"
+      "uses": "actions/checkout@v4"
+      "with":
+        "path": "lib"
+        "ref": "${{ env.RELEASE_LIB_REF }}"
+        "repository": "grafana/loki-release"
+    - "name": "pull code to release"
+      "uses": "actions/checkout@v4"
+      "with":
+        "path": "release"
+        "repository": "${{ env.RELEASE_REPO }}"
+    - "name": "setup node"
+      "uses": "actions/setup-node@v4"
+      "with":
+        "node-version": 20
+    - "name": "Set up QEMU"
+      "uses": "docker/setup-qemu-action@v3"
+    - "name": "set up docker buildx"
+      "uses": "docker/setup-buildx-action@v3"
+    - "name": "Login to DockerHub (from vault)"
+      "uses": "grafana/shared-workflows/actions/dockerhub-login@main"
+    - "id": "weekly-version"
+      "name": "Get weekly version"
+      "run": |
+        echo "version=$(./tools/image-tag)" >> $GITHUB_OUTPUT
+      "working-directory": "release"
+    - "name": "Build and push"
+      "timeout-minutes": "${{ fromJSON(env.BUILD_TIMEOUT) }}"
+      "uses": "docker/build-push-action@v6"
+      "with":
+        "build-args": "IMAGE_TAG=${{ steps.weekly-version.outputs.version }}"
+        "context": "release"
+        "file": "release/cmd/querytee/Dockerfile"
+        "platforms": "linux/amd64"
+        "push": true
+        "tags": "${{ env.IMAGE_PREFIX }}/loki-query-tee:${{ steps.weekly-version.outputs.version }}"
+"name": "publish images"
+"on":
+  "push":
+    "branches":
+    - "k[0-9]+*"
+    - "main"
+"permissions":
+  "contents": "write"
+  "id-token": "write"
+  "pull-requests": "write"

--- a/.github/workflows/minor-release-pr.yml
+++ b/.github/workflows/minor-release-pr.yml
@@ -16,7 +16,7 @@ jobs:
   check:
     uses: "grafana/loki-release/.github/workflows/check.yml@main"
     with:
-      build_image: "grafana/loki-build-image:0.33.6"
+      build_image: "grafana/loki-build-image:0.34.1"
       golang_ci_lint_version: "v1.55.1"
       release_lib_ref: "main"
       skip_validation: false
@@ -143,7 +143,7 @@ jobs:
           --env SKIP_ARM \
           --volume .:/src/loki \
           --workdir /src/loki \
-          --entrypoint /bin/sh "grafana/loki-build-image:0.33.6"
+          --entrypoint /bin/sh "grafana/loki-build-image:0.34.1"
           git config --global --add safe.directory /src/loki
           echo "${NFPM_SIGNING_KEY}" > $NFPM_SIGNING_KEY_FILE
           make dist packages

--- a/.github/workflows/patch-release-pr.yml
+++ b/.github/workflows/patch-release-pr.yml
@@ -16,7 +16,7 @@ jobs:
   check:
     uses: "grafana/loki-release/.github/workflows/check.yml@main"
     with:
-      build_image: "grafana/loki-build-image:0.33.6"
+      build_image: "grafana/loki-build-image:0.34.1"
       golang_ci_lint_version: "v1.55.1"
       release_lib_ref: "main"
       skip_validation: false
@@ -143,7 +143,7 @@ jobs:
           --env SKIP_ARM \
           --volume .:/src/loki \
           --workdir /src/loki \
-          --entrypoint /bin/sh "grafana/loki-build-image:0.33.6"
+          --entrypoint /bin/sh "grafana/loki-build-image:0.34.1"
           git config --global --add safe.directory /src/loki
           echo "${NFPM_SIGNING_KEY}" > $NFPM_SIGNING_KEY_FILE
           make dist packages

--- a/Makefile
+++ b/Makefile
@@ -36,8 +36,8 @@ DOCKER_IMAGE_DIRS := $(patsubst %/Dockerfile,%,$(DOCKERFILES))
 # or you can override this with an environment variable
 BUILD_IN_CONTAINER ?= true
 
-# ensure you run `make drone` and `make release-workflows` after changing this
-BUILD_IMAGE_VERSION ?= 0.33.6
+# ensure you run `make release-workflows` after changing this
+BUILD_IMAGE_VERSION ?= 0.34.1
 GO_VERSION := 1.22.6
 
 # Docker image info
@@ -664,7 +664,7 @@ else
 endif
 
 build-image: ensure-buildx-builder
-	$(SUDO) $(BUILD_OCI) --build-arg=GO_VERSION=$(GO_VERSION) -t $(IMAGE_PREFIX)/loki-build-image:$(IMAGE_TAG) ./loki-build-image
+	$(SUDO) $(BUILD_OCI) --build-arg=GO_VERSION=$(GO_VERSION) -t $(IMAGE_PREFIX)/loki-build-image:$(BUILD_IMAGE_VERSION) ./loki-build-image
 build-image-push: build-image ## push the docker build image
 ifneq (,$(findstring WIP,$(IMAGE_TAG)))
 	@echo "Cannot push a WIP image, commit changes first"; \

--- a/docs/sources/community/maintaining/release-loki-build-image.md
+++ b/docs/sources/community/maintaining/release-loki-build-image.md
@@ -14,23 +14,11 @@ if any changes were made in the folder `./loki-build-image/`.
 
 **To build and use the `loki-build-image`:**
 
-## Step 1
-
-1. Create a branch with the desired changes to the Dockerfile.
-2. Update the version tag of the `loki-build-image` pipeline defined in `.drone/drone.jsonnet` (search for `pipeline('loki-build-image')`) to a new version number (try to follow semver).
-3. Run `DRONE_SERVER=https://drone.grafana.net/ DRONE_TOKEN=<token> make drone` and commit the changes to the same branch.
-   1. The `<token>` is your personal drone token, which can be found by navigating to https://drone.grafana.net/account.
-4. Create a PR.
-5. Once approved and merged to `main`, the image with the new version is built and published.
-   {{% admonition type="note" %}}
-   Keep an eye on https://drone.grafana.net/grafana/loki for the build after merging ([example](https://drone.grafana.net/grafana/loki/17760/1/2)).
-   {{% /admonition %}}
-
-## Step 2
-
-1. Create a branch.
-2. Update the `BUILD_IMAGE_VERSION` variable in the `Makefile`.
-3. Run `loki-build-image/version-updater.sh <new-version>` to update all the references.
-4. Run `DRONE_SERVER=https://drone.grafana.net/ DRONE_TOKEN=<token> make drone` to update the Drone config to use the new build image.
-5. Create a new PR.
-
+1. Create a branch with the desired changes to the `./loki-build-image/Dockerfile`.
+1. Update the `BUILD_IMAGE_VERSION` variable in the `Makefile`.
+1. Commit your changes.
+1. Run `make build-image-push` to build and publish the new version of the build image.
+1. Run `make release-workflows` to update the Github workflows.
+1. Commit your changes.
+1. Push your changes to the remote branch.
+1. Open a PR against the `main` branch.

--- a/loki-build-image/Dockerfile
+++ b/loki-build-image/Dockerfile
@@ -5,8 +5,10 @@
 # See ../docs/sources/community/maintaining/release-loki-build-image.md for instructions
 # on how to publish a new build image.
 ARG GO_VERSION=1.22
+ARG GOLANG_BASE_IMAGE=golang:${GO_VERSION}-bullseye
+
 # Install helm (https://helm.sh/) and helm-docs (https://github.com/norwoodj/helm-docs) for generating Helm Chart reference.
-FROM golang:${GO_VERSION}-bookworm AS helm
+FROM ${GOLANG_BASE_IMAGE} AS helm
 ARG TARGETARCH
 ARG HELM_VER="v3.2.3"
 RUN curl -L "https://get.helm.sh/helm-${HELM_VER}-linux-$TARGETARCH.tar.gz" | tar zx && \
@@ -38,7 +40,7 @@ RUN apk add --no-cache curl && \
 FROM alpine:3.20.2 AS docker
 RUN apk add --no-cache docker-cli docker-cli-buildx
 
-FROM golang:${GO_VERSION}-bookworm AS drone
+FROM ${GOLANG_BASE_IMAGE} AS drone
 ARG TARGETARCH
 RUN curl -L "https://github.com/drone/drone-cli/releases/download/v1.7.0/drone_linux_$TARGETARCH".tar.gz | tar zx && \
     install -t /usr/local/bin drone
@@ -48,35 +50,35 @@ RUN curl -L "https://github.com/drone/drone-cli/releases/download/v1.7.0/drone_l
 # Error:
 # github.com/fatih/faillint@v1.5.0 requires golang.org/x/tools@v0.0.0-20200207224406-61798d64f025
 #   (not golang.org/x/tools@v0.0.0-20190918214920-58d531046acd from golang.org/x/tools/cmd/goyacc@58d531046acdc757f177387bc1725bfa79895d69)
-FROM golang:${GO_VERSION}-bookworm AS faillint
+FROM ${GOLANG_BASE_IMAGE} AS faillint
 RUN GO111MODULE=on go install github.com/fatih/faillint@v1.12.0
 RUN GO111MODULE=on go install golang.org/x/tools/cmd/goimports@v0.7.0
 
-FROM golang:${GO_VERSION}-bookworm AS delve
+FROM ${GOLANG_BASE_IMAGE} AS delve
 RUN GO111MODULE=on go install github.com/go-delve/delve/cmd/dlv@latest
 
 # Install ghr used to push binaries and template the release
 # This collides with the version of go tools used in the base image, thus we install it in its own image and copy it over.
-FROM golang:${GO_VERSION}-bookworm AS ghr
+FROM ${GOLANG_BASE_IMAGE} AS ghr
 RUN GO111MODULE=on go install github.com/tcnksm/ghr@9349474
 
 # Install nfpm (https://nfpm.goreleaser.com) for creating .deb and .rpm packages.
-FROM golang:${GO_VERSION}-bookworm AS nfpm
+FROM ${GOLANG_BASE_IMAGE} AS nfpm
 RUN GO111MODULE=on go install github.com/goreleaser/nfpm/v2/cmd/nfpm@v2.11.3
 
 # Install gotestsum
-FROM golang:${GO_VERSION}-bookworm AS gotestsum
+FROM ${GOLANG_BASE_IMAGE} AS gotestsum
 RUN GO111MODULE=on go install gotest.tools/gotestsum@v1.8.2
 
 # Install tools used to compile jsonnet.
-FROM golang:${GO_VERSION}-bookworm AS jsonnet
+FROM ${GOLANG_BASE_IMAGE} AS jsonnet
 RUN GO111MODULE=on go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@v0.5.1
 RUN GO111MODULE=on go install github.com/monitoring-mixins/mixtool/cmd/mixtool@16dc166166d91e93475b86b9355a4faed2400c18
 RUN GO111MODULE=on go install github.com/google/go-jsonnet/cmd/jsonnet@v0.20.0
 
 FROM aquasec/trivy AS trivy
 
-FROM golang:${GO_VERSION}-bookworm
+FROM ${GOLANG_BASE_IMAGE}
 RUN apt-get update && \
     apt-get install -qy \
     musl gnupg ragel \

--- a/pkg/querier/queryrange/queryrangebase/queryrange.pb.go
+++ b/pkg/querier/queryrange/queryrangebase/queryrange.pb.go
@@ -9,11 +9,11 @@ import (
 	proto "github.com/gogo/protobuf/proto"
 	_ "github.com/gogo/protobuf/types"
 	github_com_gogo_protobuf_types "github.com/gogo/protobuf/types"
+	_ "github.com/golang/protobuf/ptypes/duration"
 	github_com_grafana_loki_v3_pkg_logproto "github.com/grafana/loki/v3/pkg/logproto"
 	logproto "github.com/grafana/loki/v3/pkg/logproto"
 	definitions "github.com/grafana/loki/v3/pkg/querier/queryrange/queryrangebase/definitions"
 	resultscache "github.com/grafana/loki/v3/pkg/storage/chunk/cache/resultscache"
-	_ "google.golang.org/protobuf/types/known/durationpb"
 	io "io"
 	math "math"
 	math_bits "math/bits"
@@ -1022,7 +1022,7 @@ func (this *PrometheusRequest) String() string {
 		`Start:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Start), "Timestamp", "types.Timestamp", 1), `&`, ``, 1) + `,`,
 		`End:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.End), "Timestamp", "types.Timestamp", 1), `&`, ``, 1) + `,`,
 		`Step:` + fmt.Sprintf("%v", this.Step) + `,`,
-		`Timeout:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Timeout), "Duration", "durationpb.Duration", 1), `&`, ``, 1) + `,`,
+		`Timeout:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Timeout), "Duration", "duration.Duration", 1), `&`, ``, 1) + `,`,
 		`Query:` + fmt.Sprintf("%v", this.Query) + `,`,
 		`CachingOptions:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.CachingOptions), "CachingOptions", "resultscache.CachingOptions", 1), `&`, ``, 1) + `,`,
 		`Headers:` + repeatedStringForHeaders + `,`,

--- a/pkg/querier/stats/stats.pb.go
+++ b/pkg/querier/stats/stats.pb.go
@@ -8,7 +8,7 @@ import (
 	_ "github.com/gogo/protobuf/gogoproto"
 	proto "github.com/gogo/protobuf/proto"
 	github_com_gogo_protobuf_types "github.com/gogo/protobuf/types"
-	_ "google.golang.org/protobuf/types/known/durationpb"
+	_ "github.com/golang/protobuf/ptypes/duration"
 	io "io"
 	math "math"
 	math_bits "math/bits"
@@ -251,7 +251,7 @@ func (this *Stats) String() string {
 		return "nil"
 	}
 	s := strings.Join([]string{`&Stats{`,
-		`WallTime:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.WallTime), "Duration", "durationpb.Duration", 1), `&`, ``, 1) + `,`,
+		`WallTime:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.WallTime), "Duration", "duration.Duration", 1), `&`, ``, 1) + `,`,
 		`FetchedSeriesCount:` + fmt.Sprintf("%v", this.FetchedSeriesCount) + `,`,
 		`FetchedChunkBytes:` + fmt.Sprintf("%v", this.FetchedChunkBytes) + `,`,
 		`}`,

--- a/pkg/ruler/base/ruler.pb.go
+++ b/pkg/ruler/base/ruler.pb.go
@@ -11,13 +11,13 @@ import (
 	proto "github.com/gogo/protobuf/proto"
 	_ "github.com/gogo/protobuf/types"
 	github_com_gogo_protobuf_types "github.com/gogo/protobuf/types"
+	_ "github.com/golang/protobuf/ptypes/duration"
 	_ "github.com/grafana/loki/v3/pkg/logproto"
 	github_com_grafana_loki_v3_pkg_logproto "github.com/grafana/loki/v3/pkg/logproto"
 	rulespb "github.com/grafana/loki/v3/pkg/ruler/rulespb"
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
-	_ "google.golang.org/protobuf/types/known/durationpb"
 	io "io"
 	math "math"
 	math_bits "math/bits"
@@ -1433,7 +1433,7 @@ func (this *GroupStateDesc) String() string {
 		`Group:` + strings.Replace(fmt.Sprintf("%v", this.Group), "RuleGroupDesc", "rulespb.RuleGroupDesc", 1) + `,`,
 		`ActiveRules:` + repeatedStringForActiveRules + `,`,
 		`EvaluationTimestamp:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.EvaluationTimestamp), "Timestamp", "types.Timestamp", 1), `&`, ``, 1) + `,`,
-		`EvaluationDuration:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.EvaluationDuration), "Duration", "durationpb.Duration", 1), `&`, ``, 1) + `,`,
+		`EvaluationDuration:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.EvaluationDuration), "Duration", "duration.Duration", 1), `&`, ``, 1) + `,`,
 		`}`,
 	}, "")
 	return s
@@ -1454,7 +1454,7 @@ func (this *RuleStateDesc) String() string {
 		`LastError:` + fmt.Sprintf("%v", this.LastError) + `,`,
 		`Alerts:` + repeatedStringForAlerts + `,`,
 		`EvaluationTimestamp:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.EvaluationTimestamp), "Timestamp", "types.Timestamp", 1), `&`, ``, 1) + `,`,
-		`EvaluationDuration:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.EvaluationDuration), "Duration", "durationpb.Duration", 1), `&`, ``, 1) + `,`,
+		`EvaluationDuration:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.EvaluationDuration), "Duration", "duration.Duration", 1), `&`, ``, 1) + `,`,
 		`}`,
 	}, "")
 	return s

--- a/pkg/ruler/rulespb/rules.pb.go
+++ b/pkg/ruler/rulespb/rules.pb.go
@@ -9,9 +9,9 @@ import (
 	proto "github.com/gogo/protobuf/proto"
 	github_com_gogo_protobuf_types "github.com/gogo/protobuf/types"
 	types "github.com/gogo/protobuf/types"
+	_ "github.com/golang/protobuf/ptypes/duration"
 	_ "github.com/grafana/loki/v3/pkg/logproto"
 	github_com_grafana_loki_v3_pkg_logproto "github.com/grafana/loki/v3/pkg/logproto"
-	_ "google.golang.org/protobuf/types/known/durationpb"
 	io "io"
 	math "math"
 	math_bits "math/bits"
@@ -657,7 +657,7 @@ func (this *RuleGroupDesc) String() string {
 	s := strings.Join([]string{`&RuleGroupDesc{`,
 		`Name:` + fmt.Sprintf("%v", this.Name) + `,`,
 		`Namespace:` + fmt.Sprintf("%v", this.Namespace) + `,`,
-		`Interval:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Interval), "Duration", "durationpb.Duration", 1), `&`, ``, 1) + `,`,
+		`Interval:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Interval), "Duration", "duration.Duration", 1), `&`, ``, 1) + `,`,
 		`Rules:` + repeatedStringForRules + `,`,
 		`User:` + fmt.Sprintf("%v", this.User) + `,`,
 		`Options:` + repeatedStringForOptions + `,`,
@@ -674,7 +674,7 @@ func (this *RuleDesc) String() string {
 		`Expr:` + fmt.Sprintf("%v", this.Expr) + `,`,
 		`Record:` + fmt.Sprintf("%v", this.Record) + `,`,
 		`Alert:` + fmt.Sprintf("%v", this.Alert) + `,`,
-		`For:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.For), "Duration", "durationpb.Duration", 1), `&`, ``, 1) + `,`,
+		`For:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.For), "Duration", "duration.Duration", 1), `&`, ``, 1) + `,`,
 		`Labels:` + fmt.Sprintf("%v", this.Labels) + `,`,
 		`Annotations:` + fmt.Sprintf("%v", this.Annotations) + `,`,
 		`}`,

--- a/pkg/storage/chunk/client/grpc/grpc.pb.go
+++ b/pkg/storage/chunk/client/grpc/grpc.pb.go
@@ -9,10 +9,10 @@ import (
 	fmt "fmt"
 	proto "github.com/gogo/protobuf/proto"
 	github_com_gogo_protobuf_sortkeys "github.com/gogo/protobuf/sortkeys"
+	empty "github.com/golang/protobuf/ptypes/empty"
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
-	emptypb "google.golang.org/protobuf/types/known/emptypb"
 	io "io"
 	math "math"
 	math_bits "math/bits"
@@ -1998,30 +1998,30 @@ const _ = grpc.SupportPackageIsVersion4
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
 type GrpcStoreClient interface {
 	// / WriteIndex writes batch of indexes to the index tables.
-	WriteIndex(ctx context.Context, in *WriteIndexRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
+	WriteIndex(ctx context.Context, in *WriteIndexRequest, opts ...grpc.CallOption) (*empty.Empty, error)
 	// / QueryIndex reads the indexes required for given query & sends back the batch of rows
 	// / in rpc streams
 	QueryIndex(ctx context.Context, in *QueryIndexRequest, opts ...grpc.CallOption) (GrpcStore_QueryIndexClient, error)
 	// / DeleteIndex deletes the batch of index entries from the index tables
-	DeleteIndex(ctx context.Context, in *DeleteIndexRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
+	DeleteIndex(ctx context.Context, in *DeleteIndexRequest, opts ...grpc.CallOption) (*empty.Empty, error)
 	// / PutChunks saves the batch of chunks into the chunk tables.
-	PutChunks(ctx context.Context, in *PutChunksRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
+	PutChunks(ctx context.Context, in *PutChunksRequest, opts ...grpc.CallOption) (*empty.Empty, error)
 	// / GetChunks requests for batch of chunks and the batch of chunks are sent back in rpc streams
 	// / batching needs to be performed at server level as per requirement instead of sending single chunk per stream.
 	// / In GetChunks rpc request send buf as nil
 	GetChunks(ctx context.Context, in *GetChunksRequest, opts ...grpc.CallOption) (GrpcStore_GetChunksClient, error)
 	// / DeleteChunks deletes the chunks based on chunkID.
-	DeleteChunks(ctx context.Context, in *ChunkID, opts ...grpc.CallOption) (*emptypb.Empty, error)
+	DeleteChunks(ctx context.Context, in *ChunkID, opts ...grpc.CallOption) (*empty.Empty, error)
 	// / Lists all the tables that exists in the database.
-	ListTables(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*ListTablesResponse, error)
+	ListTables(ctx context.Context, in *empty.Empty, opts ...grpc.CallOption) (*ListTablesResponse, error)
 	// / Creates a table with provided name & attributes.
-	CreateTable(ctx context.Context, in *CreateTableRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
+	CreateTable(ctx context.Context, in *CreateTableRequest, opts ...grpc.CallOption) (*empty.Empty, error)
 	// Deletes a table using table name provided.
-	DeleteTable(ctx context.Context, in *DeleteTableRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
+	DeleteTable(ctx context.Context, in *DeleteTableRequest, opts ...grpc.CallOption) (*empty.Empty, error)
 	// Describes a table information for the provided table.
 	DescribeTable(ctx context.Context, in *DescribeTableRequest, opts ...grpc.CallOption) (*DescribeTableResponse, error)
 	// Update a table with newly provided table information.
-	UpdateTable(ctx context.Context, in *UpdateTableRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
+	UpdateTable(ctx context.Context, in *UpdateTableRequest, opts ...grpc.CallOption) (*empty.Empty, error)
 }
 
 type grpcStoreClient struct {
@@ -2032,8 +2032,8 @@ func NewGrpcStoreClient(cc *grpc.ClientConn) GrpcStoreClient {
 	return &grpcStoreClient{cc}
 }
 
-func (c *grpcStoreClient) WriteIndex(ctx context.Context, in *WriteIndexRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
-	out := new(emptypb.Empty)
+func (c *grpcStoreClient) WriteIndex(ctx context.Context, in *WriteIndexRequest, opts ...grpc.CallOption) (*empty.Empty, error) {
+	out := new(empty.Empty)
 	err := c.cc.Invoke(ctx, "/grpc.grpc_store/WriteIndex", in, out, opts...)
 	if err != nil {
 		return nil, err
@@ -2073,8 +2073,8 @@ func (x *grpcStoreQueryIndexClient) Recv() (*QueryIndexResponse, error) {
 	return m, nil
 }
 
-func (c *grpcStoreClient) DeleteIndex(ctx context.Context, in *DeleteIndexRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
-	out := new(emptypb.Empty)
+func (c *grpcStoreClient) DeleteIndex(ctx context.Context, in *DeleteIndexRequest, opts ...grpc.CallOption) (*empty.Empty, error) {
+	out := new(empty.Empty)
 	err := c.cc.Invoke(ctx, "/grpc.grpc_store/DeleteIndex", in, out, opts...)
 	if err != nil {
 		return nil, err
@@ -2082,8 +2082,8 @@ func (c *grpcStoreClient) DeleteIndex(ctx context.Context, in *DeleteIndexReques
 	return out, nil
 }
 
-func (c *grpcStoreClient) PutChunks(ctx context.Context, in *PutChunksRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
-	out := new(emptypb.Empty)
+func (c *grpcStoreClient) PutChunks(ctx context.Context, in *PutChunksRequest, opts ...grpc.CallOption) (*empty.Empty, error) {
+	out := new(empty.Empty)
 	err := c.cc.Invoke(ctx, "/grpc.grpc_store/PutChunks", in, out, opts...)
 	if err != nil {
 		return nil, err
@@ -2123,8 +2123,8 @@ func (x *grpcStoreGetChunksClient) Recv() (*GetChunksResponse, error) {
 	return m, nil
 }
 
-func (c *grpcStoreClient) DeleteChunks(ctx context.Context, in *ChunkID, opts ...grpc.CallOption) (*emptypb.Empty, error) {
-	out := new(emptypb.Empty)
+func (c *grpcStoreClient) DeleteChunks(ctx context.Context, in *ChunkID, opts ...grpc.CallOption) (*empty.Empty, error) {
+	out := new(empty.Empty)
 	err := c.cc.Invoke(ctx, "/grpc.grpc_store/DeleteChunks", in, out, opts...)
 	if err != nil {
 		return nil, err
@@ -2132,7 +2132,7 @@ func (c *grpcStoreClient) DeleteChunks(ctx context.Context, in *ChunkID, opts ..
 	return out, nil
 }
 
-func (c *grpcStoreClient) ListTables(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*ListTablesResponse, error) {
+func (c *grpcStoreClient) ListTables(ctx context.Context, in *empty.Empty, opts ...grpc.CallOption) (*ListTablesResponse, error) {
 	out := new(ListTablesResponse)
 	err := c.cc.Invoke(ctx, "/grpc.grpc_store/ListTables", in, out, opts...)
 	if err != nil {
@@ -2141,8 +2141,8 @@ func (c *grpcStoreClient) ListTables(ctx context.Context, in *emptypb.Empty, opt
 	return out, nil
 }
 
-func (c *grpcStoreClient) CreateTable(ctx context.Context, in *CreateTableRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
-	out := new(emptypb.Empty)
+func (c *grpcStoreClient) CreateTable(ctx context.Context, in *CreateTableRequest, opts ...grpc.CallOption) (*empty.Empty, error) {
+	out := new(empty.Empty)
 	err := c.cc.Invoke(ctx, "/grpc.grpc_store/CreateTable", in, out, opts...)
 	if err != nil {
 		return nil, err
@@ -2150,8 +2150,8 @@ func (c *grpcStoreClient) CreateTable(ctx context.Context, in *CreateTableReques
 	return out, nil
 }
 
-func (c *grpcStoreClient) DeleteTable(ctx context.Context, in *DeleteTableRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
-	out := new(emptypb.Empty)
+func (c *grpcStoreClient) DeleteTable(ctx context.Context, in *DeleteTableRequest, opts ...grpc.CallOption) (*empty.Empty, error) {
+	out := new(empty.Empty)
 	err := c.cc.Invoke(ctx, "/grpc.grpc_store/DeleteTable", in, out, opts...)
 	if err != nil {
 		return nil, err
@@ -2168,8 +2168,8 @@ func (c *grpcStoreClient) DescribeTable(ctx context.Context, in *DescribeTableRe
 	return out, nil
 }
 
-func (c *grpcStoreClient) UpdateTable(ctx context.Context, in *UpdateTableRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
-	out := new(emptypb.Empty)
+func (c *grpcStoreClient) UpdateTable(ctx context.Context, in *UpdateTableRequest, opts ...grpc.CallOption) (*empty.Empty, error) {
+	out := new(empty.Empty)
 	err := c.cc.Invoke(ctx, "/grpc.grpc_store/UpdateTable", in, out, opts...)
 	if err != nil {
 		return nil, err
@@ -2180,67 +2180,67 @@ func (c *grpcStoreClient) UpdateTable(ctx context.Context, in *UpdateTableReques
 // GrpcStoreServer is the server API for GrpcStore service.
 type GrpcStoreServer interface {
 	// / WriteIndex writes batch of indexes to the index tables.
-	WriteIndex(context.Context, *WriteIndexRequest) (*emptypb.Empty, error)
+	WriteIndex(context.Context, *WriteIndexRequest) (*empty.Empty, error)
 	// / QueryIndex reads the indexes required for given query & sends back the batch of rows
 	// / in rpc streams
 	QueryIndex(*QueryIndexRequest, GrpcStore_QueryIndexServer) error
 	// / DeleteIndex deletes the batch of index entries from the index tables
-	DeleteIndex(context.Context, *DeleteIndexRequest) (*emptypb.Empty, error)
+	DeleteIndex(context.Context, *DeleteIndexRequest) (*empty.Empty, error)
 	// / PutChunks saves the batch of chunks into the chunk tables.
-	PutChunks(context.Context, *PutChunksRequest) (*emptypb.Empty, error)
+	PutChunks(context.Context, *PutChunksRequest) (*empty.Empty, error)
 	// / GetChunks requests for batch of chunks and the batch of chunks are sent back in rpc streams
 	// / batching needs to be performed at server level as per requirement instead of sending single chunk per stream.
 	// / In GetChunks rpc request send buf as nil
 	GetChunks(*GetChunksRequest, GrpcStore_GetChunksServer) error
 	// / DeleteChunks deletes the chunks based on chunkID.
-	DeleteChunks(context.Context, *ChunkID) (*emptypb.Empty, error)
+	DeleteChunks(context.Context, *ChunkID) (*empty.Empty, error)
 	// / Lists all the tables that exists in the database.
-	ListTables(context.Context, *emptypb.Empty) (*ListTablesResponse, error)
+	ListTables(context.Context, *empty.Empty) (*ListTablesResponse, error)
 	// / Creates a table with provided name & attributes.
-	CreateTable(context.Context, *CreateTableRequest) (*emptypb.Empty, error)
+	CreateTable(context.Context, *CreateTableRequest) (*empty.Empty, error)
 	// Deletes a table using table name provided.
-	DeleteTable(context.Context, *DeleteTableRequest) (*emptypb.Empty, error)
+	DeleteTable(context.Context, *DeleteTableRequest) (*empty.Empty, error)
 	// Describes a table information for the provided table.
 	DescribeTable(context.Context, *DescribeTableRequest) (*DescribeTableResponse, error)
 	// Update a table with newly provided table information.
-	UpdateTable(context.Context, *UpdateTableRequest) (*emptypb.Empty, error)
+	UpdateTable(context.Context, *UpdateTableRequest) (*empty.Empty, error)
 }
 
 // UnimplementedGrpcStoreServer can be embedded to have forward compatible implementations.
 type UnimplementedGrpcStoreServer struct {
 }
 
-func (*UnimplementedGrpcStoreServer) WriteIndex(ctx context.Context, req *WriteIndexRequest) (*emptypb.Empty, error) {
+func (*UnimplementedGrpcStoreServer) WriteIndex(ctx context.Context, req *WriteIndexRequest) (*empty.Empty, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method WriteIndex not implemented")
 }
 func (*UnimplementedGrpcStoreServer) QueryIndex(req *QueryIndexRequest, srv GrpcStore_QueryIndexServer) error {
 	return status.Errorf(codes.Unimplemented, "method QueryIndex not implemented")
 }
-func (*UnimplementedGrpcStoreServer) DeleteIndex(ctx context.Context, req *DeleteIndexRequest) (*emptypb.Empty, error) {
+func (*UnimplementedGrpcStoreServer) DeleteIndex(ctx context.Context, req *DeleteIndexRequest) (*empty.Empty, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method DeleteIndex not implemented")
 }
-func (*UnimplementedGrpcStoreServer) PutChunks(ctx context.Context, req *PutChunksRequest) (*emptypb.Empty, error) {
+func (*UnimplementedGrpcStoreServer) PutChunks(ctx context.Context, req *PutChunksRequest) (*empty.Empty, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method PutChunks not implemented")
 }
 func (*UnimplementedGrpcStoreServer) GetChunks(req *GetChunksRequest, srv GrpcStore_GetChunksServer) error {
 	return status.Errorf(codes.Unimplemented, "method GetChunks not implemented")
 }
-func (*UnimplementedGrpcStoreServer) DeleteChunks(ctx context.Context, req *ChunkID) (*emptypb.Empty, error) {
+func (*UnimplementedGrpcStoreServer) DeleteChunks(ctx context.Context, req *ChunkID) (*empty.Empty, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method DeleteChunks not implemented")
 }
-func (*UnimplementedGrpcStoreServer) ListTables(ctx context.Context, req *emptypb.Empty) (*ListTablesResponse, error) {
+func (*UnimplementedGrpcStoreServer) ListTables(ctx context.Context, req *empty.Empty) (*ListTablesResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method ListTables not implemented")
 }
-func (*UnimplementedGrpcStoreServer) CreateTable(ctx context.Context, req *CreateTableRequest) (*emptypb.Empty, error) {
+func (*UnimplementedGrpcStoreServer) CreateTable(ctx context.Context, req *CreateTableRequest) (*empty.Empty, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method CreateTable not implemented")
 }
-func (*UnimplementedGrpcStoreServer) DeleteTable(ctx context.Context, req *DeleteTableRequest) (*emptypb.Empty, error) {
+func (*UnimplementedGrpcStoreServer) DeleteTable(ctx context.Context, req *DeleteTableRequest) (*empty.Empty, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method DeleteTable not implemented")
 }
 func (*UnimplementedGrpcStoreServer) DescribeTable(ctx context.Context, req *DescribeTableRequest) (*DescribeTableResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method DescribeTable not implemented")
 }
-func (*UnimplementedGrpcStoreServer) UpdateTable(ctx context.Context, req *UpdateTableRequest) (*emptypb.Empty, error) {
+func (*UnimplementedGrpcStoreServer) UpdateTable(ctx context.Context, req *UpdateTableRequest) (*empty.Empty, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method UpdateTable not implemented")
 }
 
@@ -2363,7 +2363,7 @@ func _GrpcStore_DeleteChunks_Handler(srv interface{}, ctx context.Context, dec f
 }
 
 func _GrpcStore_ListTables_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(emptypb.Empty)
+	in := new(empty.Empty)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
@@ -2375,7 +2375,7 @@ func _GrpcStore_ListTables_Handler(srv interface{}, ctx context.Context, dec fun
 		FullMethod: "/grpc.grpc_store/ListTables",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(GrpcStoreServer).ListTables(ctx, req.(*emptypb.Empty))
+		return srv.(GrpcStoreServer).ListTables(ctx, req.(*empty.Empty))
 	}
 	return interceptor(ctx, in, info, handler)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This change is necessary to allow the binaries built using the Loki build image to run on operating systems with older libc version.

---

Backport of #14368
