### PR TITLE
fix: promtail config unmarshalling

### DIFF
--- a/clients/pkg/promtail/config/config.go
+++ b/clients/pkg/promtail/config/config.go
@@ -42,7 +42,6 @@ type Config struct {
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
 func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	*c = Config{}
 	// We want to set c to the defaults and then overwrite it with the input.
 	// To make unmarshal fill the plain data struct rather than calling UnmarshalYAML
 	// again, we have to hide it using a type indirection.


### PR DESCRIPTION
fix bug introduced in https://github.com/grafana/loki/pull/13719 that caused unmarshaling to use an empty struct, which resulted in all default values being missing, supersedes https://github.com/grafana/loki/pull/14259