### PR TITLE
fix: level detection for warning level

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -1157,7 +1157,7 @@ func extractLogLevelFromLogLine(log string) string {
 		return constants.LogLevelDebug
 	case bytes.EqualFold(v, []byte("info")), bytes.EqualFold(v, []byte("inf")):
 		return constants.LogLevelInfo
-	case bytes.EqualFold(v, []byte("warn")), bytes.EqualFold(v, []byte("wrn")):
+	case bytes.EqualFold(v, []byte("warn")), bytes.EqualFold(v, []byte("wrn")), bytes.EqualFold(v, []byte("warning")):
 		return constants.LogLevelWarn
 	case bytes.EqualFold(v, []byte("error")), bytes.EqualFold(v, []byte("err")):
 		return constants.LogLevelError

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -1413,7 +1413,7 @@ func makeWriteRequestWithLabelsWithLevel(lines, size int, labels []string, level
 
 		for j := 0; j < lines; j++ {
 			// Construct the log line, honoring the input size
-			line := "msg=" + strconv.Itoa(j) + strings.Repeat("0", size) + " severity=" + level
+			line := "msg=an error occured " + strconv.Itoa(j) + strings.Repeat("0", size) + " severity=" + level
 
 			stream.Entries = append(stream.Entries, logproto.Entry{
 				Timestamp: time.Now().Add(time.Duration(j) * time.Millisecond),
@@ -1644,20 +1644,28 @@ func Test_DetectLogLevels(t *testing.T) {
 	})
 
 	t.Run("log level detection enabled and warn logs", func(t *testing.T) {
-		limits, ingester := setup(true)
-		distributors, _ := prepare(t, 1, 5, limits, func(_ string) (ring_client.PoolClient, error) { return ingester, nil })
+		for _, level := range []string{"warn", "Wrn", "WARNING"} {
+			limits, ingester := setup(true)
+			distributors, _ := prepare(
+				t,
+				1,
+				5,
+				limits,
+				func(_ string) (ring_client.PoolClient, error) { return ingester, nil },
+			)
 
-		writeReq := makeWriteRequestWithLabelsWithLevel(1, 10, []string{`{foo="bar"}`}, "warn")
-		_, err := distributors[0].Push(ctx, writeReq)
-		require.NoError(t, err)
-		topVal := ingester.Peek()
-		require.Equal(t, `{foo="bar"}`, topVal.Streams[0].Labels)
-		require.Equal(t, push.LabelsAdapter{
-			{
-				Name:  constants.LevelLabel,
-				Value: constants.LogLevelWarn,
-			},
-		}, topVal.Streams[0].Entries[0].StructuredMetadata)
+			writeReq := makeWriteRequestWithLabelsWithLevel(1, 10, []string{`{foo="bar"}`}, level)
+			_, err := distributors[0].Push(ctx, writeReq)
+			require.NoError(t, err)
+			topVal := ingester.Peek()
+			require.Equal(t, `{foo="bar"}`, topVal.Streams[0].Labels)
+			require.Equal(t, push.LabelsAdapter{
+				{
+					Name:  constants.LevelLabel,
+					Value: constants.LogLevelWarn,
+				},
+			}, topVal.Streams[0].Entries[0].StructuredMetadata, fmt.Sprintf("level: %s", level))
+		}
 	})
 
 	t.Run("log level detection enabled but log level already present in stream", func(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Error detection is not correctly identifying "warning" level in structured (ie. `json` or `logfmt`) logs, which causes it to fall through to detecting by log line content, in which case a string like "error" or "info" will be used instead of the correct log level.

**Which issue(s) this PR fixes**:
Fixes #14443

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
