### PR TITLE
fix: detected_level in aggregated metrics

### DIFF
--- a/pkg/pattern/aggregation/push.go
+++ b/pkg/pattern/aggregation/push.go
@@ -18,11 +18,11 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 
-	"github.com/grafana/loki/v3/pkg/loghttp/push"
 	"github.com/grafana/loki/v3/pkg/logproto"
 	"github.com/grafana/loki/v3/pkg/logql/syntax"
 	"github.com/grafana/loki/v3/pkg/util"
 	"github.com/grafana/loki/v3/pkg/util/build"
+	"github.com/grafana/loki/v3/pkg/util/constants"
 
 	"github.com/grafana/dskit/backoff"
 
@@ -309,7 +309,7 @@ func (p *Push) send(ctx context.Context, payload []byte) (int, error) {
 func AggregatedMetricEntry(
 	ts model.Time,
 	totalBytes, totalCount uint64,
-	service string,
+	level string,
 	lbls labels.Labels,
 ) string {
 	byteString := util.HumanizeBytes(totalBytes)
@@ -318,7 +318,7 @@ func AggregatedMetricEntry(
 		ts.UnixNano(),
 		byteString,
 		totalCount,
-		push.LabelServiceName, service,
+		constants.LevelLabel, level,
 	)
 
 	for _, l := range lbls {

--- a/pkg/pattern/instance.go
+++ b/pkg/pattern/instance.go
@@ -308,6 +308,7 @@ func (i *instance) writeAggregatedMetrics(
 	service := streamLbls.Get(push.LabelServiceName)
 	if service == "" {
 		service = push.ServiceUnknown
+		streamLbls = append(streamLbls, labels.Label{Name: push.LabelServiceName, Value: service})
 	}
 
 	newLbls := labels.Labels{
@@ -318,7 +319,7 @@ func (i *instance) writeAggregatedMetrics(
 	if i.writer != nil {
 		i.writer.WriteEntry(
 			now.Time(),
-			aggregation.AggregatedMetricEntry(now, totalBytes, totalCount, service, streamLbls),
+			aggregation.AggregatedMetricEntry(now, totalBytes, totalCount, level, streamLbls),
 			newLbls,
 		)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Some aggregated metric lines are missing `detected_level` because when level is `unknown` we don't write `detected_level` to structured metadata. This PR offers one way to fix this problem, by always writing `detected_level` to the aggregated metric log line.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
