### PR TITLE
fix: always write detected_level when enabled, even if unknown

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -501,7 +501,7 @@ func (d *Distributor) Push(ctx context.Context, req *logproto.PushRequest) (*log
 					} else {
 						logLevel = detectLogLevelFromLogEntry(entry, structuredMetadata)
 					}
-					if logLevel != constants.LogLevelUnknown && logLevel != "" {
+					if logLevel != "" {
 						entry.StructuredMetadata = append(entry.StructuredMetadata, logproto.LabelAdapter{
 							Name:  constants.LevelLabel,
 							Value: logLevel,

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -1640,7 +1640,7 @@ func Test_DetectLogLevels(t *testing.T) {
 		require.NoError(t, err)
 		topVal := ingester.Peek()
 		require.Equal(t, `{foo="bar"}`, topVal.Streams[0].Labels)
-		require.Len(t, topVal.Streams[0].Entries[0].StructuredMetadata, 0)
+		require.Len(t, topVal.Streams[0].Entries[0].StructuredMetadata, 1)
 	})
 
 	t.Run("log level detection enabled and warn logs", func(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Some aggregated metric lines are missing `detected_level` because when level is `unknown` we don't write `detected_level` to structured metadata. This PR offers a different approach to fix this than #14463, and it is to always write `detected_level` structured metadata when level detection is enabled, even if it's unknown.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
