### PR TITLE
feat(kafka): Add support for SASL auth to Kafka

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -793,6 +793,16 @@ kafka_config:
   # CLI flag: -kafka.write-timeout
   [write_timeout: <duration> | default = 10s]
 
+  # The SASL username for authentication to Kafka using the PLAIN mechanism.
+  # Both username and password must be set.
+  # CLI flag: -kafka.sasl-username
+  [sasl_username: <string> | default = ""]
+
+  # The SASL password for authentication to Kafka using the PLAIN mechanism.
+  # Both username and password must be set.
+  # CLI flag: -kafka.sasl-password
+  [sasl_password: <string> | default = ""]
+
   # The consumer group used by the consumer to track the last consumed offset.
   # The consumer group must be different for each ingester. If the configured
   # consumer group contains the '<partition>' placeholder, it is replaced with

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -47,6 +47,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/ingester"
 	"github.com/grafana/loki/v3/pkg/ingester/client"
 	"github.com/grafana/loki/v3/pkg/kafka"
+	kafka_client "github.com/grafana/loki/v3/pkg/kafka/client"
 	"github.com/grafana/loki/v3/pkg/loghttp/push"
 	"github.com/grafana/loki/v3/pkg/logproto"
 	"github.com/grafana/loki/v3/pkg/logql/log/logfmt"
@@ -234,11 +235,11 @@ func New(
 
 	var kafkaWriter KafkaProducer
 	if cfg.KafkaEnabled {
-		kafkaClient, err := kafka.NewWriterClient(cfg.KafkaConfig, 20, logger, registerer)
+		kafkaClient, err := kafka_client.NewWriterClient(cfg.KafkaConfig, 20, logger, registerer)
 		if err != nil {
 			return nil, fmt.Errorf("failed to start kafka client: %w", err)
 		}
-		kafkaWriter = kafka.NewProducer(kafkaClient, cfg.KafkaConfig.ProducerMaxBufferedBytes,
+		kafkaWriter = kafka_client.NewProducer(kafkaClient, cfg.KafkaConfig.ProducerMaxBufferedBytes,
 			prometheus.WrapRegistererWithPrefix("_kafka_", registerer))
 	}
 

--- a/pkg/kafka/client/logger.go
+++ b/pkg/kafka/client/logger.go
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
-package kafka
+package client
 
 import (
 	"github.com/go-kit/log"

--- a/pkg/kafka/client/reader_client.go
+++ b/pkg/kafka/client/reader_client.go
@@ -58,8 +58,8 @@ func setDefaultNumberOfPartitionsForAutocreatedTopics(cfg kafka.Config, cl *kgo.
 		return
 	}
 
+	// Note: this client doesn't get closed because it is owned by the caller
 	adm := kadm.NewClient(cl)
-	defer adm.Close()
 
 	defaultNumberOfPartitions := fmt.Sprintf("%d", cfg.AutoCreateTopicDefaultPartitions)
 	_, err := adm.AlterBrokerConfigsState(context.Background(), []kadm.AlterConfig{

--- a/pkg/kafka/client/reader_client_test.go
+++ b/pkg/kafka/client/reader_client_test.go
@@ -1,0 +1,104 @@
+package client
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/dskit/flagext"
+	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/kfake"
+	"github.com/twmb/franz-go/pkg/kgo"
+	"github.com/twmb/franz-go/pkg/kmsg"
+
+	"github.com/grafana/loki/v3/pkg/kafka"
+	"github.com/grafana/loki/v3/pkg/kafka/testkafka"
+)
+
+func TestNewReaderClient(t *testing.T) {
+	_, addr := testkafka.CreateClusterWithoutCustomConsumerGroupsSupport(t, 1, "test", kfake.EnableSASL(), kfake.Superuser("PLAIN", "user", "password"))
+
+	tests := []struct {
+		name    string
+		config  kafka.Config
+		wantErr bool
+	}{
+		{
+			name: "valid config",
+			config: kafka.Config{
+				Address:      addr,
+				Topic:        "abcd",
+				SASLUsername: "user",
+				SASLPassword: flagext.SecretWithValue("password"),
+			},
+			wantErr: false,
+		},
+		{
+			name: "wrong password",
+			config: kafka.Config{
+				Address:      addr,
+				Topic:        "abcd",
+				SASLUsername: "user",
+				SASLPassword: flagext.SecretWithValue("wrong wrong wrong"),
+			},
+			wantErr: true,
+		},
+		{
+			name: "wrong username",
+			config: kafka.Config{
+				Address:      addr,
+				Topic:        "abcd",
+				SASLUsername: "wrong wrong wrong",
+				SASLPassword: flagext.SecretWithValue("password"),
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, err := NewReaderClient(tt.config, nil, nil)
+			require.NoError(t, err)
+
+			err = client.Ping(context.Background())
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestSetDefaultNumberOfPartitionsForAutocreatedTopics(t *testing.T) {
+	cluster, err := kfake.NewCluster(kfake.NumBrokers(1))
+	require.NoError(t, err)
+	t.Cleanup(cluster.Close)
+
+	addrs := cluster.ListenAddrs()
+	require.Len(t, addrs, 1)
+
+	cfg := kafka.Config{
+		Address:                          addrs[0],
+		AutoCreateTopicDefaultPartitions: 100,
+	}
+
+	cluster.ControlKey(kmsg.AlterConfigs.Int16(), func(request kmsg.Request) (kmsg.Response, error, bool) {
+		r := request.(*kmsg.AlterConfigsRequest)
+
+		require.Len(t, r.Resources, 1)
+		res := r.Resources[0]
+		require.Equal(t, kmsg.ConfigResourceTypeBroker, res.ResourceType)
+		require.Len(t, res.Configs, 1)
+		cfg := res.Configs[0]
+		require.Equal(t, "num.partitions", cfg.Name)
+		require.NotNil(t, *cfg.Value)
+		require.Equal(t, "100", *cfg.Value)
+
+		return &kmsg.AlterConfigsResponse{}, nil, true
+	})
+
+	client, err := kgo.NewClient(commonKafkaClientOptions(cfg, nil, log.NewNopLogger())...)
+	require.NoError(t, err)
+
+	setDefaultNumberOfPartitionsForAutocreatedTopics(cfg, client, log.NewNopLogger())
+}

--- a/pkg/kafka/client/writer_client_test.go
+++ b/pkg/kafka/client/writer_client_test.go
@@ -1,0 +1,71 @@
+package client
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/grafana/dskit/flagext"
+	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/kfake"
+
+	"github.com/grafana/loki/v3/pkg/kafka"
+	"github.com/grafana/loki/v3/pkg/kafka/testkafka"
+)
+
+func TestNewWriterClient(t *testing.T) {
+	_, addr := testkafka.CreateClusterWithoutCustomConsumerGroupsSupport(t, 1, "test", kfake.EnableSASL(), kfake.Superuser("PLAIN", "user", "password"))
+
+	tests := []struct {
+		name    string
+		config  kafka.Config
+		wantErr bool
+	}{
+		{
+			name: "valid config",
+			config: kafka.Config{
+				Address:      addr,
+				Topic:        "abcd",
+				WriteTimeout: time.Second,
+				SASLUsername: "user",
+				SASLPassword: flagext.SecretWithValue("password"),
+			},
+			wantErr: false,
+		},
+		{
+			name: "wrong password",
+			config: kafka.Config{
+				Address:      addr,
+				Topic:        "abcd",
+				WriteTimeout: time.Second,
+				SASLUsername: "user",
+				SASLPassword: flagext.SecretWithValue("wrong wrong wrong"),
+			},
+			wantErr: true,
+		},
+		{
+			name: "wrong username",
+			config: kafka.Config{
+				Address:      addr,
+				Topic:        "abcd",
+				WriteTimeout: time.Second,
+				SASLUsername: "wrong wrong wrong",
+				SASLPassword: flagext.SecretWithValue("password"),
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, err := NewWriterClient(tt.config, 10, nil, nil)
+			require.NoError(t, err)
+
+			err = client.Ping(context.Background())
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/kafka/partition/committer_test.go
+++ b/pkg/kafka/partition/committer_test.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus/testutil"
 
-	"github.com/grafana/loki/v3/pkg/kafka"
+	"github.com/grafana/loki/v3/pkg/kafka/client"
 	"github.com/grafana/loki/v3/pkg/kafka/testkafka"
 )
 
@@ -24,7 +24,7 @@ func TestPartitionCommitter(t *testing.T) {
 	topicName := "test-topic"
 	_, kafkaCfg := testkafka.CreateCluster(t, numPartitions, topicName)
 
-	client, err := kafka.NewReaderClient(kafkaCfg, kprom.NewMetrics("foo"), log.NewNopLogger())
+	client, err := client.NewReaderClient(kafkaCfg, kprom.NewMetrics("foo"), log.NewNopLogger())
 	require.NoError(t, err)
 
 	// Create a Kafka admin client

--- a/pkg/kafka/partition/reader.go
+++ b/pkg/kafka/partition/reader.go
@@ -22,6 +22,7 @@ import (
 	"github.com/twmb/franz-go/plugin/kprom"
 
 	"github.com/grafana/loki/v3/pkg/kafka"
+	"github.com/grafana/loki/v3/pkg/kafka/client"
 )
 
 var errWaitTargetLagDeadlineExceeded = errors.New("waiting for target lag deadline exceeded")
@@ -94,7 +95,7 @@ func NewReader(
 // This method is called when the PartitionReader service starts.
 func (p *Reader) start(ctx context.Context) error {
 	var err error
-	p.client, err = kafka.NewReaderClient(p.kafkaCfg, p.metrics.kprom, p.logger)
+	p.client, err = client.NewReaderClient(p.kafkaCfg, p.metrics.kprom, p.logger)
 	if err != nil {
 		return errors.Wrap(err, "creating kafka reader client")
 	}
@@ -535,7 +536,7 @@ func newReaderMetrics(reg prometheus.Registerer) readerMetrics {
 	return readerMetrics{
 		receiveDelayWhenStarting: receiveDelay.WithLabelValues("starting"),
 		receiveDelayWhenRunning:  receiveDelay.WithLabelValues("running"),
-		kprom:                    kafka.NewReaderClientMetrics("partition-reader", reg),
+		kprom:                    client.NewReaderClientMetrics("partition-reader", reg),
 		fetchWaitDuration: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
 			Name:                        "loki_ingest_storage_reader_records_batch_wait_duration_seconds",
 			Help:                        "How long a consumer spent waiting for a batch of records from the Kafka client. If fetching is faster than processing, then this will be close to 0.",

--- a/pkg/kafka/partition/reader_test.go
+++ b/pkg/kafka/partition/reader_test.go
@@ -59,7 +59,7 @@ func (m *mockConsumer) Flush(ctx context.Context) error {
 }
 
 func TestPartitionReader_BasicFunctionality(t *testing.T) {
-	_, kafkaCfg := testkafka.CreateCluster(t, 1, "test-topic")
+	_, kafkaCfg := testkafka.CreateCluster(t, 1, "test")
 	consumer := newMockConsumer()
 
 	consumerFactory := func(_ Committer) (Consumer, error) {
@@ -83,8 +83,8 @@ func TestPartitionReader_BasicFunctionality(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, records, 1)
 
-	producer.ProduceSync(context.Background(), records...)
-	producer.ProduceSync(context.Background(), records...)
+	require.NoError(t, producer.ProduceSync(context.Background(), records...).FirstErr())
+	require.NoError(t, producer.ProduceSync(context.Background(), records...).FirstErr())
 
 	// Wait for records to be processed
 	assert.Eventually(t, func() bool {

--- a/pkg/kafka/partition/reader_test.go
+++ b/pkg/kafka/partition/reader_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/twmb/franz-go/pkg/kgo"
 
 	"github.com/grafana/loki/v3/pkg/kafka"
+	"github.com/grafana/loki/v3/pkg/kafka/client"
 	"github.com/grafana/loki/v3/pkg/kafka/testkafka"
 	"github.com/grafana/loki/v3/pkg/logproto"
 )
@@ -67,7 +68,7 @@ func TestPartitionReader_BasicFunctionality(t *testing.T) {
 
 	partitionReader, err := NewReader(kafkaCfg, 0, "test-consumer-group", consumerFactory, log.NewNopLogger(), prometheus.NewRegistry())
 	require.NoError(t, err)
-	producer, err := kafka.NewWriterClient(kafkaCfg, 100, log.NewNopLogger(), prometheus.NewRegistry())
+	producer, err := client.NewWriterClient(kafkaCfg, 100, log.NewNopLogger(), prometheus.NewRegistry())
 	require.NoError(t, err)
 
 	err = services.StartAndAwaitRunning(context.Background(), partitionReader)
@@ -121,7 +122,7 @@ func TestPartitionReader_ProcessCatchUpAtStartup(t *testing.T) {
 
 	partitionReader, err := NewReader(kafkaCfg, 0, "test-consumer-group", consumerFactory, log.NewNopLogger(), prometheus.NewRegistry())
 	require.NoError(t, err)
-	producer, err := kafka.NewWriterClient(kafkaCfg, 100, log.NewNopLogger(), prometheus.NewRegistry())
+	producer, err := client.NewWriterClient(kafkaCfg, 100, log.NewNopLogger(), prometheus.NewRegistry())
 	require.NoError(t, err)
 
 	stream := logproto.Stream{
@@ -175,11 +176,11 @@ func TestPartitionReader_ProcessCommits(t *testing.T) {
 	partitionID := int32(0)
 	partitionReader, err := NewReader(kafkaCfg, partitionID, "test-consumer-group", consumerFactory, log.NewNopLogger(), prometheus.NewRegistry())
 	require.NoError(t, err)
-	producer, err := kafka.NewWriterClient(kafkaCfg, 100, log.NewNopLogger(), prometheus.NewRegistry())
+	producer, err := client.NewWriterClient(kafkaCfg, 100, log.NewNopLogger(), prometheus.NewRegistry())
 	require.NoError(t, err)
 
 	// Init the client: This usually happens in "start" but we want to manage our own lifecycle for this test.
-	partitionReader.client, err = kafka.NewReaderClient(kafkaCfg, nil, log.NewNopLogger(),
+	partitionReader.client, err = client.NewReaderClient(kafkaCfg, nil, log.NewNopLogger(),
 		kgo.ConsumePartitions(map[string]map[int32]kgo.Offset{
 			kafkaCfg.Topic: {partitionID: kgo.NewOffset().AtStart()},
 		}),

--- a/pkg/kafka/testkafka/cluster.go
+++ b/pkg/kafka/testkafka/cluster.go
@@ -16,8 +16,8 @@ import (
 )
 
 // CreateCluster returns a fake Kafka cluster for unit testing.
-func CreateCluster(t testing.TB, numPartitions int32, topicName string) (*kfake.Cluster, kafka.Config) {
-	cluster, addr := CreateClusterWithoutCustomConsumerGroupsSupport(t, numPartitions, topicName)
+func CreateCluster(t testing.TB, numPartitions int32, topicName string, opts ...kfake.Opt) (*kfake.Cluster, kafka.Config) {
+	cluster, addr := CreateClusterWithoutCustomConsumerGroupsSupport(t, numPartitions, topicName, opts...)
 	addSupportForConsumerGroups(t, cluster, topicName, numPartitions)
 
 	return cluster, createTestKafkaConfig(addr, topicName)
@@ -34,8 +34,16 @@ func createTestKafkaConfig(clusterAddr, topicName string) kafka.Config {
 	return cfg
 }
 
-func CreateClusterWithoutCustomConsumerGroupsSupport(t testing.TB, numPartitions int32, topicName string) (*kfake.Cluster, string) {
-	cluster, err := kfake.NewCluster(kfake.NumBrokers(1), kfake.SeedTopics(numPartitions, topicName))
+func CreateClusterWithoutCustomConsumerGroupsSupport(t testing.TB, numPartitions int32, topicName string, opts ...kfake.Opt) (*kfake.Cluster, string) {
+	cfg := []kfake.Opt{
+		kfake.NumBrokers(1),
+		kfake.SeedTopics(numPartitions, topicName),
+	}
+
+	// Apply options.
+	cfg = append(cfg, opts...)
+
+	cluster, err := kfake.NewCluster(cfg...)
 	require.NoError(t, err)
 	t.Cleanup(cluster.Close)
 

--- a/vendor/github.com/twmb/franz-go/pkg/sasl/plain/plain.go
+++ b/vendor/github.com/twmb/franz-go/pkg/sasl/plain/plain.go
@@ -1,0 +1,60 @@
+// Package plain provides PLAIN sasl authentication as specified in RFC4616.
+package plain
+
+import (
+	"context"
+	"errors"
+
+	"github.com/twmb/franz-go/pkg/sasl"
+)
+
+// Auth contains information for authentication.
+type Auth struct {
+	// Zid is an optional authorization ID to use in authenticating.
+	Zid string
+
+	// User is username to use for authentication.
+	User string
+
+	// Pass is the password to use for authentication.
+	Pass string
+
+	_ struct{} // require explicit field initialization
+}
+
+// AsMechanism returns a sasl mechanism that will use 'a' as credentials for
+// all sasl sessions.
+//
+// This is a shortcut for using the Plain function and is useful when you do
+// not need to live-rotate credentials.
+func (a Auth) AsMechanism() sasl.Mechanism {
+	return Plain(func(context.Context) (Auth, error) {
+		return a, nil
+	})
+}
+
+// Plain returns a sasl mechanism that will call authFn whenever sasl
+// authentication is needed. The returned Auth is used for a single session.
+func Plain(authFn func(context.Context) (Auth, error)) sasl.Mechanism {
+	return plain(authFn)
+}
+
+type plain func(context.Context) (Auth, error)
+
+func (plain) Name() string { return "PLAIN" }
+func (fn plain) Authenticate(ctx context.Context, _ string) (sasl.Session, []byte, error) {
+	auth, err := fn(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	if auth.User == "" || auth.Pass == "" {
+		return nil, nil, errors.New("PLAIN user and pass must be non-empty")
+	}
+	return session{}, []byte(auth.Zid + "\x00" + auth.User + "\x00" + auth.Pass), nil
+}
+
+type session struct{}
+
+func (session) Challenge([]byte) (bool, []byte, error) {
+	return true, nil, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1602,6 +1602,7 @@ github.com/twmb/franz-go/pkg/kgo
 github.com/twmb/franz-go/pkg/kgo/internal/sticky
 github.com/twmb/franz-go/pkg/kversion
 github.com/twmb/franz-go/pkg/sasl
+github.com/twmb/franz-go/pkg/sasl/plain
 # github.com/twmb/franz-go/pkg/kadm v1.13.0
 ## explicit; go 1.21
 github.com/twmb/franz-go/pkg/kadm


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds support for SASL authentication to Kafka.

**Special notes for your reviewer**:
* I had to refactor some of the client code into its own package due to import cycles (client test in `kafka` package imports `testkafka` which imports `kafka` for the config) so this change ended up being larger than I expected.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.