### PR TITLE
ci: add logql-analyzer CI

### DIFF
--- a/.github/workflows/logql-analyzer.yml
+++ b/.github/workflows/logql-analyzer.yml
@@ -23,6 +23,25 @@ jobs:
       with:
         fetch-tags: true
 
+    - name: Run shell command
+      id: prepare
+      env:
+        MAJOR_MINOR_VERSION_REGEXP: '([0-9]+\\.[0-9]+)'
+        RELEASE_TAG_REGEXP: '^([0-9]+\\.[0-9]+\\.[0-9]+)$'
+      run: |
+        echo $("${WORKSPACE_ROOT}/loki/tools/image-tag") > .tag
+        if [[ "${RELEASE_VERSION}" == "test" ]]; then
+          echo "RELEASE_VERSION is not set, using image tag"
+          RELEASE_VERSION=$(cat .tag)
+        fi
+
+        # if the tag matches the pattern `D.D.D` then RELEASE_NAME="D-D-x", otherwise RELEASE_NAME="next"
+        RELEASE_NAME=$([[ $RELEASE_VERSION =~ $RELEASE_TAG_REGEXP ]] && echo $RELEASE_TAG | grep -oE $MAJOR_MINOR_VERSION_REGEXP | sed "s/\\./-/g" | sed "s/$/-x/" || echo "next")
+        echo "RELEASE_NAME: $RELEASE_NAME"
+
+        echo "::set-output name=release_version::${RELEASE_VERSION}"
+        echo "::set-output name=release_name::${RELEASE_NAME}"
+
     - id: "get-github-app-token"
       name: "get github app token"
       uses: "actions/create-github-app-token@v1"
@@ -44,7 +63,7 @@ jobs:
       with:
         build-args: "IMAGE_TAG=${RELEASE_VERSION}"
         file: "cmd/logql-analyzer/Dockerfile"
-        platforms: "linux/amd64,linux/arm64,linux/arm"
+        platforms: "linux/amd64"
         push: true
         tags: "${{ env.IMAGE_PREFIX }}/logql-analyzer:${RELEASE_VERSION}"
 
@@ -53,25 +72,12 @@ jobs:
       with:
         environment: "prod"
 
-    - name: Run shell command
-      id: prepare
-      run: |
-        echo $("${WORKSPACE_ROOT}/loki/tools/image-tag") > .tag
-        RELEASE_TAG=$(cat .tag)
-        echo "RELEASE_TAG: $RELEASE_TAG"
-
-        # if the tag matches the pattern `D.D.D` then RELEASE_NAME="D-D-x", otherwise RELEASE_NAME="next"
-        RELEASE_NAME=$([[ $RELEASE_TAG =~ $RELEASE_TAG_REGEXP ]] && echo $RELEASE_TAG | grep -oE $MAJOR_MINOR_VERSION_REGEXP | sed "s/\\./-/g" | sed "s/$/-x/" || echo "next")
-        echo "RELEASE_NAME: $RELEASE_NAME"
-
-        echo "::set-output name=release_tag::${RELEASE_TAG}"
-        echo "::set-output name=release_name::${RELEASE_NAME}"
 
     - name: Update to latest image
       env:
         GITHUB_TOKEN: ${{ steps.get-github-app-token.outputs.token }}
         RELEASE_NAME: ${{ steps.prepare.outputs.release_name }}
-        RELEASE_TAG: ${{ steps.prepare.outputs.release_tag }}
+        RELEASE_VERSION: ${{ steps.prepare.outputs.release_version }}
       run: |
         set -e -o pipefail
 
@@ -92,7 +98,7 @@ jobs:
               {
                 "file_path": "ksonnet/environments/logql-analyzer/supported-versions.libsonnet",
                 "jsonnet_key": "${RELEASE_NAME}",
-                "jsonnet_value": "grafana/logql-analyzer:${RELEASE_TAG}-amd64",
+                "jsonnet_value": "grafana/logql-analyzer:${RELEASE_VERSION}-amd64",
                 "upsert": true
               }
             ]

--- a/.github/workflows/logql-analyzer.yml
+++ b/.github/workflows/logql-analyzer.yml
@@ -2,9 +2,6 @@ name: LogQL Analyzer
 
 on:
   workflow_dispatch:
-  pull_request:
-    branches:
-      - logql-analyzer-ci
   release:
     types:
       - released

--- a/.github/workflows/logql-analyzer.yml
+++ b/.github/workflows/logql-analyzer.yml
@@ -57,20 +57,24 @@ jobs:
         environment: "prod"
 
     - name: Run shell command
+      id: prepare
       run: |
         echo $("${WORKSPACE_ROOT}/loki/tools/image-tag") > .tag
-        export RELEASE_TAG=$(cat .tag)
+        RELEASE_TAG=$(cat .tag)
+        echo "RELEASE_TAG: $RELEASE_TAG"
+
         # if the tag matches the pattern `D.D.D` then RELEASE_NAME="D-D-x", otherwise RELEASE_NAME="next"
-        export RELEASE_NAME=$([[ $RELEASE_TAG =~ $RELEASE_TAG_REGEXP ]] && echo $RELEASE_TAG | grep -oE $MAJOR_MINOR_VERSION_REGEXP | sed "s/\\./-/g" | sed "s/$/-x/" || echo "next")
-        echo $RELEASE_NAME
-        echo $PLUGIN_CONFIG_TEMPLATE > updater-config.yaml
-        # replace placeholders with RELEASE_NAME and RELEASE TAG
-        sed -i "s/\\"{{release}}\\"/\\"$RELEASE_NAME\\"/g" %s % configFileName
-        sed -i "s/{{version}}/$RELEASE_TAG/g" %s % configFileName
+        RELEASE_NAME=$([[ $RELEASE_TAG =~ $RELEASE_TAG_REGEXP ]] && echo $RELEASE_TAG | grep -oE $MAJOR_MINOR_VERSION_REGEXP | sed "s/\\./-/g" | sed "s/$/-x/" || echo "next")
+        echo "RELEASE_NAME: $RELEASE_NAME"
+
+        echo "::set-output name=release_tag::${RELEASE_TAG}"
+        echo "::set-output name=release_name::${RELEASE_NAME}"
 
     - name: Update to latest image
       env:
         GITHUB_TOKEN: ${{ steps.get-github-app-token.outputs.token }}
+        RELEASE_NAME: ${{ steps.prepare.outputs.release_name }}
+        RELEASE_TAG: ${{ steps.prepare.outputs.release_tag }}
       run: |
         set -e -o pipefail
 
@@ -91,7 +95,7 @@ jobs:
               {
                 "file_path": "ksonnet/environments/logql-analyzer/supported-versions.libsonnet",
                 "jsonnet_key": "${RELEASE_NAME}",
-                "jsonnet_value": "grafana/logql-analyzer:${RELEASE_VERSION}-amd64",
+                "jsonnet_value": "grafana/logql-analyzer:${RELEASE_TAG}-amd64",
                 "upsert": true
               }
             ]

--- a/.github/workflows/logql-analyzer.yml
+++ b/.github/workflows/logql-analyzer.yml
@@ -99,5 +99,5 @@ jobs:
         EOF
 
         docker run --rm \
-        -e GITHUB_TOKEN="$GITHUB_TOKEN" \
-        -e CONFIG_JSON="$(cat config.json)" us-docker.pkg.dev/grafanalabs-global/docker-deployment-tools-prod/updater |& tee updater-output.log
+          -e GITHUB_TOKEN="$GITHUB_TOKEN" \
+          -e CONFIG_JSON="$(cat config.json)" us-docker.pkg.dev/grafanalabs-global/docker-deployment-tools-prod/updater |& tee updater-output.log

--- a/.github/workflows/logql-analyzer.yml
+++ b/.github/workflows/logql-analyzer.yml
@@ -1,6 +1,7 @@
 name: LogQL Analyzer
 
 on:
+  workflow_dispatch:
   pull_request:
     branches:
       - logql-analyzer-ci

--- a/.github/workflows/logql-analyzer.yml
+++ b/.github/workflows/logql-analyzer.yml
@@ -61,17 +61,16 @@ jobs:
       timeout-minutes: "${{ fromJSON(env.BUILD_TIMEOUT) }}"
       uses: "docker/build-push-action@v6"
       with:
-        build-args: "IMAGE_TAG=${RELEASE_VERSION}"
+        build-args: "IMAGE_TAG=${{ steps.prepare.outputs.release_version }}"
         file: "cmd/logql-analyzer/Dockerfile"
         platforms: "linux/amd64"
         push: true
-        tags: "${{ env.IMAGE_PREFIX }}/logql-analyzer:${RELEASE_VERSION}"
+        tags: "grafana/logql-analyzer:${{ steps.prepare.outputs.release_version }}"
 
     - name: Log in to Google Artifact Registry
       uses: grafana/shared-workflows/actions/login-to-gar@main
       with:
         environment: "prod"
-
 
     - name: Update to latest image
       env:

--- a/.github/workflows/logql-analyzer.yml
+++ b/.github/workflows/logql-analyzer.yml
@@ -1,0 +1,102 @@
+name: LogQL Analyzer
+
+on:
+  pull_request:
+    branches:
+      - logql-analyzer-ci
+  release:
+    types:
+      - released
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+
+    env:
+      BUILD_TIMEOUT: 60
+      IMAGE_PREFIX: "grafana"
+      RELEASE_VERSION: "${{ github.event.release.tag_name || 'test' }}"
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-tags: true
+
+    - id: "get-github-app-token"
+      name: "get github app token"
+      uses: "actions/create-github-app-token@v1"
+      with:
+        app-id: "${{ secrets.APP_ID }}"
+        owner: "${{ github.repository_owner }}"
+        private-key: "${{ secrets.APP_PRIVATE_KEY }}"
+
+    - name: "Set up QEMU"
+      uses: "docker/setup-qemu-action@v3"
+    - name: "set up docker buildx"
+      uses: "docker/setup-buildx-action@v3"
+    - name: "Login to DockerHub (from vault)"
+      uses: "grafana/shared-workflows/actions/dockerhub-login@main"
+
+    - name: "Build and push"
+      timeout-minutes: "${{ fromJSON(env.BUILD_TIMEOUT) }}"
+      uses: "docker/build-push-action@v6"
+      with:
+        build-args: "IMAGE_TAG=${RELEASE_VERSION}"
+        file: "cmd/logql-analyzer/Dockerfile"
+        platforms: "linux/amd64,linux/arm64,linux/arm"
+        push: true
+        tags: "${{ env.IMAGE_PREFIX }}/logql-analyzer:${RELEASE_VERSION}"
+
+    - name: Log in to Google Artifact Registry
+      uses: grafana/shared-workflows/actions/login-to-gar@main
+      with:
+        environment: "prod"
+
+    - name: Run shell command
+      run: |
+        echo $("${WORKSPACE_ROOT}/loki/tools/image-tag") > .tag
+        export RELEASE_TAG=$(cat .tag)
+        # if the tag matches the pattern `D.D.D` then RELEASE_NAME="D-D-x", otherwise RELEASE_NAME="next"
+        export RELEASE_NAME=$([[ $RELEASE_TAG =~ $RELEASE_TAG_REGEXP ]] && echo $RELEASE_TAG | grep -oE $MAJOR_MINOR_VERSION_REGEXP | sed "s/\\./-/g" | sed "s/$/-x/" || echo "next")
+        echo $RELEASE_NAME
+        echo $PLUGIN_CONFIG_TEMPLATE > updater-config.yaml
+        # replace placeholders with RELEASE_NAME and RELEASE TAG
+        sed -i "s/\\"{{release}}\\"/\\"$RELEASE_NAME\\"/g" %s % configFileName
+        sed -i "s/{{version}}/$RELEASE_TAG/g" %s % configFileName
+
+    - name: Update to latest image
+      env:
+        GITHUB_TOKEN: ${{ steps.get-github-app-token.outputs.token }}
+      run: |
+        set -e -o pipefail
+
+        cat << EOF > config.json
+        {
+          "repo_name": "deployment_tools",
+          "destination_branch": "master",
+          "git_author_email": "119986603+updater-for-ci[bot]@users.noreply.github.com",
+          "git_author_name": "version_bumper[bot]",
+          "git_committer_email": "119986603+updater-for-ci[bot]@users.noreply.github.com",
+          "git_committer_name": "version_bumper[bot]",
+          "pull_request_branch_prefix": "logql-analyzer/updater",
+          "pull_request_enabled": true,
+          "pull_request_existing_strategy": "replace",
+          "pull_request_title_prefix": "[logql-analyzer updater] ",
+          "pull_request_message": "Add logql-analyzer version to ${RELEASE_VERSION} to supported versions",
+          "update_jsonnet_attribute_configs": [
+              {
+                "file_path": "ksonnet/environments/logql-analyzer/supported-versions.libsonnet",
+                "jsonnet_key": "${RELEASE_NAME}",
+                "jsonnet_value": "grafana/logql-analyzer:${RELEASE_VERSION}-amd64",
+                "upsert": true
+              }
+            ]
+        }
+        EOF
+
+        docker run --rm \
+        -e GITHUB_TOKEN="$GITHUB_TOKEN" \
+        -e CONFIG_JSON="$(cat config.json)" us-docker.pkg.dev/grafanalabs-global/docker-deployment-tools-prod/updater |& tee updater-output.log


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds `logql-analyzer` CI that got removed with the drone removal.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
