### PR TITLE
chore: improve error message when can't find remote schemaconfig file

### DIFF
--- a/pkg/logcli/query/query.go
+++ b/pkg/logcli/query/query.go
@@ -427,7 +427,7 @@ func getLatestConfig(client chunk.ObjectClient, orgID string) (*config.SchemaCon
 	if err != errNotExists {
 		return nil, err
 	}
-	return nil, errNotExists
+	return nil, errors.New("could not find a schema config file matching any of the known patterns. First verify --org-id is correct. Then check the root of the bucket for a file with `schemaconfig` in the name. If no such file exists it may need to be created or re-synced from the source.")
 }
 
 // DoLocalQuery executes the query against the local store using a Loki configuration file.


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently if logcli fails to find the remote schemaconfig file it errors with

```
Query failed: doesn't exist
```

Which doesn't help the user understand the problem or troubleshoot the problem at all.

This PR makes the error more descriptive with some troubleshooting actions.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
