### PR TITLE
fix(logql): updated JSONExpressionParser not to unescape extracted values if it is JSON object.

### DIFF
--- a/pkg/logql/log/parser.go
+++ b/pkg/logql/log/parser.go
@@ -625,6 +625,8 @@ func (j *JSONExpressionParser) Process(_ int64, line []byte, lbs *LabelsBuilder)
 		switch typ {
 		case jsonparser.Null:
 			lbs.Set(ParsedLabel, key, "")
+		case jsonparser.Object:
+			lbs.Set(ParsedLabel, key, string(data))
 		default:
 			lbs.Set(ParsedLabel, key, unescapeJSONString(data))
 		}

--- a/pkg/logql/log/parser_test.go
+++ b/pkg/logql/log/parser_test.go
@@ -542,13 +542,35 @@ func TestJSONExpressionParser(t *testing.T) {
 			),
 			NoParserHints(),
 		},
+		{
+			"nested object with escaped value",
+			[]byte(`{"app":{"name":"great \"loki\""}`),
+			[]LabelExtractionExpr{
+				NewLabelExtractionExpr("app", `app`),
+			},
+			labels.FromStrings("foo", "bar"),
+			labels.FromStrings("foo", "bar",
+				"app", `{"name":"great \"loki\""}`,
+			),
+			NoParserHints(),
+		},
+		{
+			"field with escaped value inside the json string",
+			[]byte(`{"app":"{\"name\":\"great \\\"loki\\\"\"}"}`),
+			[]LabelExtractionExpr{
+				NewLabelExtractionExpr("app", `app`),
+			},
+			labels.FromStrings("foo", "bar"),
+			labels.FromStrings("foo", "bar",
+				"app", `{"name":"great \"loki\""}`,
+			),
+			NoParserHints(),
+		},
 	}
 	for _, tt := range tests {
-		j, err := NewJSONExpressionParser(tt.expressions)
-		if err != nil {
-			t.Fatalf("cannot create JSON expression parser: %s", err.Error())
-		}
 		t.Run(tt.name, func(t *testing.T) {
+			j, err := NewJSONExpressionParser(tt.expressions)
+			require.NoError(t, err, "cannot create JSON expression parser")
 			b := NewBaseLabelsBuilderWithGrouping(nil, tt.hints, false, false).ForLabels(tt.lbs, tt.lbs.Hash())
 			b.Reset()
 			_, _ = j.Process(0, tt.line, b)


### PR DESCRIPTION
**What this PR does / why we need it**:
updated JSONExpressionParser not to unescape extracted values if it is a JSON object.

re: https://github.com/grafana/loki/pull/9410

**Which issue(s) this PR fixes**:
Fixes #14166

**Special notes for your reviewer**:
Execution plan before: 
![before](https://github.com/user-attachments/assets/71ebeb0c-9afd-4a88-b6cd-96c2554f6c2a)

And execution plan after: 
![after](https://github.com/user-attachments/assets/4506c112-c83b-4601-ac31-f28bcd2d0fee)


**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
