### PR TITLE
feat: More detailed tracing for distributors

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -641,7 +641,7 @@ func (d *Distributor) Push(ctx context.Context, req *logproto.PushRequest) (*log
 	var kafkaSpan opentracing.Span
 	if d.cfg.KafkaEnabled {
 		var kafkaCtx context.Context
-		kafkaSpan, kafkaCtx = opentracing.StartSpanFromContext(ctx, "KafkaSend")
+		kafkaSpan, kafkaCtx = opentracing.StartSpanFromContext(ctx, "sendStreamsToKafka")
 		kafkaTracker.streamsPending.Store(int32(len(streams)))
 
 		subring, err := d.partitionRing.PartitionRing().ShuffleShard(tenantID, d.validator.IngestionPartitionsTenantShardSize(tenantID))
@@ -659,7 +659,7 @@ func (d *Distributor) Push(ctx context.Context, req *logproto.PushRequest) (*log
 	var ingesterSpan opentracing.Span
 	if d.cfg.IngesterEnabled {
 		var ingesterCtx context.Context
-		ingesterSpan, ingesterCtx = opentracing.StartSpanFromContext(ctx, "IngesterSend")
+		ingesterSpan, ingesterCtx = opentracing.StartSpanFromContext(ctx, "sendStreamsToIngesters")
 		ingesterTracker.streamsPending.Store(int32(len(streams)))
 
 		streamTrackers := make([]streamTracker, len(streams))

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -319,8 +319,8 @@ func New(
 		kafkaBytesPerRecord: promauto.With(registerer).NewHistogram(prometheus.HistogramOpts{
 			Namespace: constants.Loki,
 			Name:      "distributor_kafka_bytes_per_record",
-			Help:      "The number of records a single per-partition write request has been split into.",
-			Buckets:   prometheus.ExponentialBuckets(1, 2, 8),
+			Help:      "The number of bytes per kafka record generated.",
+			Buckets:   prometheus.ExponentialBuckets(64, 4, 10), // 64b - 64kb
 		}),
 		writeFailuresManager: writefailures.NewManager(logger, registerer, cfg.WriteFailuresLogging, configs, "distributor"),
 		kafkaWriter:          kafkaWriter,

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -62,7 +62,7 @@ const (
 
 var (
 	success = &logproto.PushResponse{}
-	ctx     = user.InjectOrgID(context.Background(), "test")
+	ctx, _  = context.WithTimeout(user.InjectOrgID(context.Background(), "test"), 10*time.Second)
 )
 
 func TestDistributor(t *testing.T) {

--- a/pkg/kafka/client/writer_client.go
+++ b/pkg/kafka/client/writer_client.go
@@ -62,8 +62,8 @@ func NewWriterClient(kafkaCfg kafka.Config, maxInflightProduceRequests int, logg
 		// doesn't take longer than 1s to process them (if it takes longer, the client will buffer data and stop
 		// issuing new Produce requests until some previous ones complete).
 		kgo.DisableIdempotentWrite(),
-		kgo.ProducerLinger(50*time.Millisecond),
-		kgo.MaxProduceRequestsInflightPerBroker(maxInflightProduceRequests),
+		kgo.ProducerLinger(kafkaCfg.LingerDuration),
+		kgo.MaxProduceRequestsInflightPerBroker(kafkaCfg.ConcurrentRequests),
 
 		// Unlimited number of Produce retries but a deadline on the max time a record can take to be delivered.
 		// With the default config it would retry infinitely.

--- a/pkg/kafka/config.go
+++ b/pkg/kafka/config.go
@@ -29,6 +29,8 @@ const (
 var (
 	ErrMissingKafkaAddress                 = errors.New("the Kafka address has not been configured")
 	ErrMissingKafkaTopic                   = errors.New("the Kafka topic has not been configured")
+	ErrInconsistentConsumerLagAtStartup    = errors.New("the target and max consumer lag at startup must be either both set to 0 or to a value greater than 0")
+	ErrInvalidMaxConsumerLagAtStartup      = errors.New("the configured max consumer lag at startup must greater or equal than the configured target consumer lag")
 	ErrInconsistentSASLUsernameAndPassword = errors.New("both sasl username and password must be set")
 	ErrInvalidProducerMaxRecordSizeBytes   = fmt.Errorf("the configured producer max record size bytes must be a value between %d and %d", minProducerRecordDataBytesLimit, maxProducerRecordDataBytesLimit)
 )

--- a/pkg/loghttp/push/push.go
+++ b/pkg/loghttp/push/push.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/go-kit/log/level"
+	"github.com/opentracing/opentracing-go"
 
 	"github.com/grafana/loki/pkg/push"
 
@@ -110,6 +111,9 @@ type Stats struct {
 }
 
 func ParseRequest(logger log.Logger, userID string, r *http.Request, tenantsRetention TenantsRetention, limits Limits, pushRequestParser RequestParser, tracker UsageTracker, logPushRequestStreams bool) (*logproto.PushRequest, error) {
+	span, ctx := opentracing.StartSpanFromContext(r.Context(), "parseRequest")
+	defer span.Finish()
+	r = r.WithContext(ctx)
 	req, pushStats, err := pushRequestParser(userID, r, tenantsRetention, limits, tracker, logPushRequestStreams, logger)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**What this PR does / why we need it**:

Improves the tracing in the distributor. Currently we just get a single span for the whole request.
* Adds subspan for parseRequest, as this can be overridden by adaptive logs, for example.
* Splits the tracker for Kafka & Ingester pushes and creates separate spans for each of them.
* Instruments the kafka write client's ProduceSync.
* Adds a metric to track record sizes in bytes.