### PR TITLE
fix(operator): Disable automatic discovery of service name

### DIFF
--- a/operator/internal/manifests/internal/config/build_test.go
+++ b/operator/internal/manifests/internal/config/build_test.go
@@ -96,6 +96,7 @@ limits_config:
   max_streams_per_user: 0
   max_line_size: 256000
   max_entries_limit_per_query: 5000
+  discover_service_name: []
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -353,6 +354,7 @@ limits_config:
   max_streams_per_user: 0
   max_line_size: 256000
   max_entries_limit_per_query: 5000
+  discover_service_name: []
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -779,6 +781,7 @@ limits_config:
   max_streams_per_user: 0
   max_line_size: 256000
   max_entries_limit_per_query: 5000
+  discover_service_name: []
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -1137,6 +1140,7 @@ limits_config:
   max_streams_per_user: 0
   max_line_size: 256000
   max_entries_limit_per_query: 5000
+  discover_service_name: []
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -1496,6 +1500,7 @@ limits_config:
   max_streams_per_user: 0
   max_line_size: 256000
   max_entries_limit_per_query: 5000
+  discover_service_name: []
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -1889,6 +1894,7 @@ limits_config:
   max_streams_per_user: 0
   max_line_size: 256000
   max_entries_limit_per_query: 5000
+  discover_service_name: []
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -2224,6 +2230,7 @@ limits_config:
   max_streams_per_user: 0
   max_line_size: 256000
   max_entries_limit_per_query: 5000
+  discover_service_name: []
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -2663,6 +2670,7 @@ limits_config:
   max_streams_per_user: 0
   max_line_size: 256000
   max_entries_limit_per_query: 5000
+  discover_service_name: []
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -2987,6 +2995,7 @@ limits_config:
   max_streams_per_user: 0
   max_line_size: 256000
   max_entries_limit_per_query: 5000
+  discover_service_name: []
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -3484,6 +3493,7 @@ limits_config:
   max_streams_per_user: 0
   max_line_size: 256000
   max_entries_limit_per_query: 5000
+  discover_service_name: []
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -3745,6 +3755,7 @@ limits_config:
   max_streams_per_user: 0
   max_line_size: 256000
   max_entries_limit_per_query: 5000
+  discover_service_name: []
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -4007,6 +4018,7 @@ limits_config:
   max_streams_per_user: 0
   max_line_size: 256000
   max_entries_limit_per_query: 5000
+  discover_service_name: []
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -4270,6 +4282,7 @@ limits_config:
   max_streams_per_user: 0
   max_line_size: 256000
   max_entries_limit_per_query: 5000
+  discover_service_name: []
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -4569,6 +4582,7 @@ limits_config:
   max_streams_per_user: 0
   max_line_size: 256000
   max_entries_limit_per_query: 5000
+  discover_service_name: []
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -4866,6 +4880,7 @@ limits_config:
   max_streams_per_user: 0
   max_line_size: 256000
   max_entries_limit_per_query: 5000
+  discover_service_name: []
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -5364,6 +5379,7 @@ limits_config:
   max_streams_per_user: 0
   max_line_size: 256000
   max_entries_limit_per_query: 5000
+  discover_service_name: []
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -5540,6 +5556,7 @@ limits_config:
   max_streams_per_user: 0
   max_line_size: 256000
   max_entries_limit_per_query: 5000
+  discover_service_name: []
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -5709,6 +5726,7 @@ limits_config:
   max_streams_per_user: 0
   max_line_size: 256000
   max_entries_limit_per_query: 5000
+  discover_service_name: []
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -6101,6 +6119,7 @@ limits_config:
   max_streams_per_user: 0
   max_line_size: 256000
   max_entries_limit_per_query: 5000
+  discover_service_name: []
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h

--- a/operator/internal/manifests/internal/config/loki-config.yaml
+++ b/operator/internal/manifests/internal/config/loki-config.yaml
@@ -202,6 +202,7 @@ limits_config:
   max_streams_per_user: 0
   max_line_size: {{ .Stack.Limits.Global.IngestionLimits.MaxLineSize }}
   max_entries_limit_per_query: {{ .Stack.Limits.Global.QueryLimits.MaxEntriesLimitPerQuery }}
+  discover_service_name: []
   max_global_streams_per_user: {{ .Stack.Limits.Global.IngestionLimits.MaxGlobalStreamsPerTenant }}
   max_chunks_per_query: {{ .Stack.Limits.Global.QueryLimits.MaxChunksPerQuery }}
   max_query_length: 721h


### PR DESCRIPTION
**What this PR does / why we need it**:

This disables the automatic discovery of service name until we figure out a better way to provide the data, probably involving the new OTLP input.

**Which issue(s) this PR fixes**:

[LOG-6254](https://issues.redhat.com/browse/LOG-6254)

**Special notes for your reviewer**:

This is to be backported to the previous non-OTLP releases of the operator (6.0 and below).

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
