### PR TITLE
fix: adding support for tenant_id mapped from logstash field in the logstash loki plugin

### DIFF
--- a/clients/cmd/logstash/lib/logstash/outputs/loki.rb
+++ b/clients/cmd/logstash/lib/logstash/outputs/loki.rb
@@ -205,6 +205,7 @@ class LogStash::Outputs::Loki < LogStash::Outputs::Base
   public
   def receive(event)
     @entries << Entry.new(event, @message_field, @include_fields, @metadata_fields)
+    @tenant_id = event.sprintf(@tenant_id)
   end
 
   def close

--- a/clients/cmd/logstash/loki.conf
+++ b/clients/cmd/logstash/loki.conf
@@ -8,7 +8,7 @@ output {
   loki {
     url => "http://localhost:3100/loki/api/v1/push"
 
-    #tenant_id => "fake" #default none
+    #tenant_id => "fake" or "%{[fields][tenant_id]}" #default none 
 
     #message_field => "message" #default message
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adding Support for the Logstash Loki Plugin that tenant_id can be mapped directly from a logstash field. So the tenant_id can be used dynamically. 
**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
