### PR TITLE
fix(logql): A renamed label should use ParsedLabel category to take precendence

### DIFF
--- a/pkg/logql/log/fmt.go
+++ b/pkg/logql/log/fmt.go
@@ -391,9 +391,9 @@ func (lf *LabelsFormatter) Process(ts int64, l []byte, lbs *LabelsBuilder) ([]by
 	defer smp.Put(m)
 	for _, f := range lf.formats {
 		if f.Rename {
-			v, category, ok := lbs.GetWithCategory(f.Value)
+			v, _, ok := lbs.GetWithCategory(f.Value)
 			if ok {
-				lbs.Set(category, f.Name, v)
+				lbs.Set(ParsedLabel, f.Name, v)
 				lbs.Del(f.Value)
 			}
 			continue

--- a/pkg/logql/log/fmt_test.go
+++ b/pkg/logql/log/fmt_test.go
@@ -516,6 +516,22 @@ func Test_labelsFormatter_Format(t *testing.T) {
 		want labels.Labels
 	}{
 		{
+			"rename label",
+			mustNewLabelsFormatter([]LabelFmt{
+				NewRenameLabelFmt("baz", "foo"),
+			}),
+			labels.FromStrings("foo", "blip", "bar", "blop"),
+			labels.FromStrings("bar", "blop", "baz", "blip"),
+		},
+		{
+			"rename and overwrite existing label",
+			mustNewLabelsFormatter([]LabelFmt{
+				NewRenameLabelFmt("bar", "foo"),
+			}),
+			labels.FromStrings("foo", "blip", "bar", "blop"),
+			labels.FromStrings("bar", "blip"),
+		},
+		{
 			"combined with template",
 			mustNewLabelsFormatter([]LabelFmt{NewTemplateLabelFmt("foo", "{{.foo}} and {{.bar}}")}),
 			labels.FromStrings("foo", "blip", "bar", "blop"),


### PR DESCRIPTION
**What this PR does / why we need it**:

Renaming labels using `label_format dst=src` is broken on main. Destination label does not appear in the resulting label set if the source is a stream label. This is because we don't [append the labels](https://github.com/grafana/loki/blob/fix-lbl-fmt-rename/pkg/logql/log/labels.go#L468) from `add[StreamLabel]` list to the resulting buffer, this looks like a conscious choice to not pollute StreamLabels.

I felt the correct fix here is to correctly tag the renamed label as a `ParsedLabel`. This also makes sure the new label supersedes any structured metadata if present.


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
