### PR TITLE
test(bloombuild/planner/strategies): use require.ElementsMatch in test

### DIFF
--- a/pkg/bloombuild/planner/strategies/splitkeyspace_test.go
+++ b/pkg/bloombuild/planner/strategies/splitkeyspace_test.go
@@ -120,7 +120,7 @@ func Test_gapsBetweenTSDBsAndMetas(t *testing.T) {
 				require.Error(t, err)
 				return
 			}
-			require.Equal(t, tc.exp, gaps)
+			require.ElementsMatch(t, tc.exp, gaps)
 		})
 	}
 }
@@ -323,7 +323,7 @@ func Test_blockPlansForGaps(t *testing.T) {
 				require.Error(t, err)
 				return
 			}
-			require.Equal(t, tc.exp, plans)
+			require.ElementsMatch(t, tc.exp, plans)
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Use require.ElementsMatch in tests to permit plans having a different order and avoid test flaking; this is what the tests did prior to refactoring in #13690.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
