### PR TITLE
ci: fix cron schedule for weekly helm task

### DIFF
--- a/.github/workflows/helm-weekly-release-pr.yaml
+++ b/.github/workflows/helm-weekly-release-pr.yaml
@@ -2,7 +2,7 @@ name: Helm weekly release PR
 
 on:
   schedule:
-    - cron: '0 10 * * 1-5' # 10 UTC on weekdays; if we miss published images one day, they should align the day after
+    - cron: '0 10 * * 2' # 10 UTC every Tuesday (since ks get cut on Monday)
 
   workflow_dispatch: # for manual testing
 


### PR DESCRIPTION
**What this PR does / why we need it**:

I'm bad at cron syntax. This changes the weekly helm release task to run every Tuesday at 10:00 UTC (since ks get cut on Mondays). I accidentally had it running everyday at 10, which is too often.

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
