### PR TITLE
docs: update contributing guidelines for the helm chart

### DIFF
--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -15,6 +15,8 @@ Entries should include a reference to the pull request that introduced the chang
 
 ## 6.18.0
 
+- [CHANGE] Added automated weekly releases, which created this release.
+
 ## 6.17.1
 
 - [BUGFIX] Added missing `loki.storage.azure.chunkDelimiter` parameter to Helm chart.

--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -24,6 +24,39 @@ Find more information in the Loki Helm Chart [documentation](https://grafana.com
 
 If you made any changes to the [Chart.yaml](https://github.com/grafana/loki/blob/main/production/helm/loki/Chart.yaml) or [values.yaml](https://github.com/grafana/loki/blob/main/production/helm/loki/values.yaml) run `make helm-docs` from the root of the repository to update the documentation and commit the changed files.
 
+Futhermore, please add an entry to the [CHANGELOG.md](./CHANGELOG.md) file about what you changed.  This file has a header that looks like this:
+
+```
+[//]: # (<AUTOMATED_UPDATES_LOCATOR> : do not remove this line. This locator is used by the CI pipeline to automatically create a changelog entry for each new Loki release. Add other chart versions and respective changelog entries bellow this line.)
+````
+
+Place your changes as a bulleted list below this header. The helm chart is automatically released once a week, at which point the `CHANGELOG.md` file will be updated to reflect the release of all changes between this header the the header of the previous version as the changes for that weeks release. For example, if the weekly release will be `1.21.0`, and the `CHANGELOG.md` file has the following entries:
+
+```
+[//]: # (<AUTOMATED_UPDATES_LOCATOR> : do not remove this line. This locator is used by the CI pipeline to automatically create a changelog entry for each new Loki release. Add other chart versions and respective changelog entries bellow this line.)
+
+- [CHANGE] Changed the thing
+- [FEATURE] Cool new feature
+
+## 1.20.0
+
+- [BUGFIX] Fixed the bug
+```
+
+Then the weekly release will create a `CHANGELOG.md` with the following content:
+```
+[//]: # (<AUTOMATED_UPDATES_LOCATOR> : do not remove this line. This locator is used by the CI pipeline to automatically create a changelog entry for each new Loki release. Add other chart versions and respective changelog entries bellow this line.)
+
+## 1.21.0
+
+- [CHANGE] Changed the thing
+- [FEATURE] Cool new feature
+
+## 1.20.0
+
+- [BUGFIX] Fixed the bug
+```
+
 #### Versioning
 
 Normally contributors need _not_ bump the version nor update the [CHANGELOG.md](https://github.com/grafana/loki/blob/main/production/helm/loki/CHANGELOG.md). A new version of the Chart will follow this cadence:

--- a/production/helm/loki/README.md.gotmpl
+++ b/production/helm/loki/README.md.gotmpl
@@ -14,6 +14,39 @@ Find more information in the Loki Helm Chart [documentation](https://grafana.com
 
 If you made any changes to the [Chart.yaml](https://github.com/grafana/loki/blob/main/production/helm/loki/Chart.yaml) or [values.yaml](https://github.com/grafana/loki/blob/main/production/helm/loki/values.yaml) run `make helm-docs` from the root of the repository to update the documentation and commit the changed files.
 
+Futhermore, please add an entry to the [CHANGELOG.md](./CHANGELOG.md) file about what you changed.  This file has a header that looks like this:
+
+```
+[//]: # (<AUTOMATED_UPDATES_LOCATOR> : do not remove this line. This locator is used by the CI pipeline to automatically create a changelog entry for each new Loki release. Add other chart versions and respective changelog entries bellow this line.)
+````
+
+Place your changes as a bulleted list below this header. The helm chart is automatically released once a week, at which point the `CHANGELOG.md` file will be updated to reflect the release of all changes between this header the the header of the previous version as the changes for that weeks release. For example, if the weekly release will be `1.21.0`, and the `CHANGELOG.md` file has the following entries:
+
+```
+[//]: # (<AUTOMATED_UPDATES_LOCATOR> : do not remove this line. This locator is used by the CI pipeline to automatically create a changelog entry for each new Loki release. Add other chart versions and respective changelog entries bellow this line.)
+
+- [CHANGE] Changed the thing
+- [FEATURE] Cool new feature
+
+## 1.20.0
+
+- [BUGFIX] Fixed the bug
+```
+
+Then the weekly release will create a `CHANGELOG.md` with the following content:
+```
+[//]: # (<AUTOMATED_UPDATES_LOCATOR> : do not remove this line. This locator is used by the CI pipeline to automatically create a changelog entry for each new Loki release. Add other chart versions and respective changelog entries bellow this line.)
+
+## 1.21.0
+
+- [CHANGE] Changed the thing
+- [FEATURE] Cool new feature
+
+## 1.20.0
+
+- [BUGFIX] Fixed the bug
+```
+
 #### Versioning
 
 Normally contributors need _not_ bump the version nor update the [CHANGELOG.md](https://github.com/grafana/loki/blob/main/production/helm/loki/CHANGELOG.md). A new version of the Chart will follow this cadence:


### PR DESCRIPTION
**What this PR does / why we need it**:

With the [addition of automated weekly releases](https://github.com/grafana/loki/pull/14501) of the Helm chart, changes to the Helm changelog should now go below the special header, as the release process will automatically add the header for the new version.

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
