### PR TITLE
fix(logcli): create new tail response for every line

### DIFF
--- a/pkg/logcli/query/tail.go
+++ b/pkg/logcli/query/tail.go
@@ -45,10 +45,10 @@ func (q *Query) TailQuery(delayFor time.Duration, c client.Client, out output.Lo
 		log.Println("Print only labels key:", color.RedString(strings.Join(q.ShowLabelsKey, ",")))
 	}
 
-	tailResponse := new(loghttp.TailResponse)
 	lastReceivedTimestamp := q.Start
 
 	for {
+		tailResponse := new(loghttp.TailResponse)
 		err := unmarshal.ReadTailResponseJSON(tailResponse, conn)
 		if err != nil {
 			// Check if the websocket connection closed unexpectedly. If so, retry.


### PR DESCRIPTION
**What this PR does / why we need it**:
When tailing with logcli, the loghttp.TailResponse is created outside of the loop, resulting in stale labels within the TailResponse LabelSet as the unmarshal does not clear the map.

**Which issue(s) this PR fixes**:
Fixes #8617

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
