### PR TITLE
fix(ci): updated release workflow to use github app token

### DIFF
--- a/.github/release-workflows.jsonnet
+++ b/.github/release-workflows.jsonnet
@@ -70,7 +70,7 @@ local imagePrefix = 'grafana';
       imagePrefix='grafana',
       releaseLibRef=releaseLibRef,
       releaseRepo='grafana/loki',
-      useGitHubAppToken=false,
+      useGitHubAppToken=true,
     ), false, false
   ),
   'check.yml': std.manifestYamlDoc({

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ env:
   PUBLISH_TO_GCS: false
   RELEASE_LIB_REF: "main"
   RELEASE_REPO: "grafana/loki"
-  USE_GITHUB_APP_TOKEN: false
+  USE_GITHUB_APP_TOKEN: true
 jobs:
   createRelease:
     if: "${{ fromJSON(needs.shouldRelease.outputs.shouldRelease) }}"


### PR DESCRIPTION
**What this PR does / why we need it**:
This change is necessary to fix  broken authentication [on this workflow](https://github.com/grafana/loki/actions/runs/11392332777/job/31698181231)

