### PR TITLE
feat: Configurable list of json fields to mine patterns

### DIFF
--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -638,6 +638,7 @@ func (t *Loki) initPatternIngester() (_ services.Service, err error) {
 	t.Cfg.Pattern.LifecyclerConfig.ListenPort = t.Cfg.Server.GRPCListenPort
 	t.PatternIngester, err = pattern.New(
 		t.Cfg.Pattern,
+		t.Overrides,
 		t.PatternRingClient,
 		t.Cfg.MetricsNamespace,
 		prometheus.DefaultRegisterer,

--- a/pkg/pattern/drain/drain.go
+++ b/pkg/pattern/drain/drain.go
@@ -48,7 +48,7 @@ type Config struct {
 }
 
 type Limits interface {
-	PatternIngesterTokenizableJsonFields(userID string) []string
+	PatternIngesterTokenizableJSONFields(userID string) []string
 }
 
 func createLogClusterCache(maxSize int, onEvict func(int, *LogCluster)) *LogClusterCache {
@@ -157,7 +157,7 @@ func New(tenantID string, config *Config, limits Limits, format string, metrics 
 	var tokenizer LineTokenizer
 	switch format {
 	case FormatJSON:
-		fieldsToTokenize := limits.PatternIngesterTokenizableJsonFields(tenantID)
+		fieldsToTokenize := limits.PatternIngesterTokenizableJSONFields(tenantID)
 		tokenizer = newJSONTokenizer(config.ParamString, config.MaxAllowedLineLength, fieldsToTokenize)
 	case FormatLogfmt:
 		tokenizer = newLogfmtTokenizer(config.ParamString, config.MaxAllowedLineLength)

--- a/pkg/pattern/drain/drain_benchmark_test.go
+++ b/pkg/pattern/drain/drain_benchmark_test.go
@@ -35,7 +35,7 @@ func BenchmarkDrain_TrainExtractsPatterns(b *testing.B) {
 				line := scanner.Text()
 				lines = append(lines, line)
 			}
-			drain := New(DefaultConfig(), DetectLogFormat(lines[0]), nil)
+			drain := New("", DefaultConfig(), &fakeLimits{}, DetectLogFormat(lines[0]), nil)
 
 			b.ReportAllocs()
 			b.ResetTimer()

--- a/pkg/pattern/drain/drain_test.go
+++ b/pkg/pattern/drain/drain_test.go
@@ -670,6 +670,6 @@ type fakeLimits struct {
 	Limits
 }
 
-func (f *fakeLimits) PatternIngesterTokenizableJsonFields(_ string) []string {
+func (f *fakeLimits) PatternIngesterTokenizableJSONFields(_ string) []string {
 	return []string{"log", "message", "msg", "msg_", "_msg", "content"}
 }

--- a/pkg/pattern/drain/drain_test.go
+++ b/pkg/pattern/drain/drain_test.go
@@ -27,7 +27,7 @@ func TestDrain_TrainExtractsPatterns(t *testing.T) {
 		format    string
 	}{
 		{
-			drain:     New(DefaultConfig(), "", nil),
+			drain:     New("", DefaultConfig(), &fakeLimits{}, "", nil),
 			inputFile: `testdata/agent-logfmt.txt`,
 			format:    FormatLogfmt,
 			patterns: []string{
@@ -56,7 +56,7 @@ func TestDrain_TrainExtractsPatterns(t *testing.T) {
 			},
 		},
 		{
-			drain:     New(DefaultConfig(), "", nil),
+			drain:     New("", DefaultConfig(), &fakeLimits{}, "", nil),
 			inputFile: `testdata/ingester-logfmt.txt`,
 			format:    FormatLogfmt,
 			patterns: []string{
@@ -66,7 +66,7 @@ func TestDrain_TrainExtractsPatterns(t *testing.T) {
 			},
 		},
 		{
-			drain:     New(DefaultConfig(), "", nil),
+			drain:     New("", DefaultConfig(), &fakeLimits{}, "", nil),
 			inputFile: `testdata/drone-json.txt`,
 			format:    FormatJSON,
 			patterns: []string{
@@ -79,7 +79,7 @@ func TestDrain_TrainExtractsPatterns(t *testing.T) {
 			},
 		},
 		{
-			drain:     New(DefaultConfig(), "", nil),
+			drain:     New("", DefaultConfig(), &fakeLimits{}, "", nil),
 			inputFile: "testdata/distributor-logfmt.txt",
 			format:    FormatLogfmt,
 			patterns: []string{
@@ -91,7 +91,7 @@ func TestDrain_TrainExtractsPatterns(t *testing.T) {
 			},
 		},
 		{
-			drain:     New(DefaultConfig(), "", nil),
+			drain:     New("", DefaultConfig(), &fakeLimits{}, "", nil),
 			inputFile: "testdata/journald.txt",
 			format:    FormatUnknown,
 			patterns: []string{
@@ -211,7 +211,7 @@ func TestDrain_TrainExtractsPatterns(t *testing.T) {
 			},
 		},
 		{
-			drain:     New(DefaultConfig(), "", nil),
+			drain:     New("", DefaultConfig(), &fakeLimits{}, "", nil),
 			inputFile: "testdata/kafka.txt",
 			format:    FormatUnknown,
 			patterns: []string{
@@ -232,7 +232,7 @@ func TestDrain_TrainExtractsPatterns(t *testing.T) {
 			},
 		},
 		{
-			drain:     New(DefaultConfig(), "", nil),
+			drain:     New("", DefaultConfig(), &fakeLimits{}, "", nil),
 			inputFile: "testdata/kubernetes.txt",
 			format:    FormatUnknown,
 			patterns: []string{
@@ -273,7 +273,7 @@ func TestDrain_TrainExtractsPatterns(t *testing.T) {
 			},
 		},
 		{
-			drain:     New(DefaultConfig(), "", nil),
+			drain:     New("", DefaultConfig(), &fakeLimits{}, "", nil),
 			inputFile: "testdata/vault.txt",
 			format:    FormatUnknown,
 			patterns: []string{
@@ -281,7 +281,7 @@ func TestDrain_TrainExtractsPatterns(t *testing.T) {
 			},
 		},
 		{
-			drain:     New(DefaultConfig(), "", nil),
+			drain:     New("", DefaultConfig(), &fakeLimits{}, "", nil),
 			inputFile: "testdata/calico.txt",
 			format:    FormatUnknown,
 			patterns: []string{
@@ -374,7 +374,7 @@ func TestDrain_TrainExtractsPatterns(t *testing.T) {
 			},
 		},
 		{
-			drain:     New(DefaultConfig(), "", nil),
+			drain:     New("", DefaultConfig(), &fakeLimits{}, "", nil),
 			inputFile: "testdata/grafana-ruler.txt",
 			format:    FormatLogfmt,
 			patterns: []string{
@@ -470,7 +470,7 @@ func TestDrain_TrainGeneratesPatternsMatchableByLokiPatternFilter(t *testing.T) 
 	}{
 		{
 			name:  "should extract patterns that all lines match",
-			drain: New(DefaultConfig(), "", nil),
+			drain: New("", DefaultConfig(), &fakeLimits{}, "", nil),
 			inputLines: []string{
 				"test 1 test test",
 				"test 2 test test",
@@ -480,7 +480,7 @@ func TestDrain_TrainGeneratesPatternsMatchableByLokiPatternFilter(t *testing.T) 
 		},
 		{
 			name:  "should extract patterns that match if line ends with newlines",
-			drain: New(DefaultConfig(), "", nil),
+			drain: New("", DefaultConfig(), &fakeLimits{}, "", nil),
 			inputLines: []string{
 				`test 1 test test
 `,
@@ -494,7 +494,7 @@ func TestDrain_TrainGeneratesPatternsMatchableByLokiPatternFilter(t *testing.T) 
 		},
 		{
 			name:  "should extract patterns that match if line ends with empty space",
-			drain: New(DefaultConfig(), "", nil),
+			drain: New("", DefaultConfig(), &fakeLimits{}, "", nil),
 			inputLines: []string{
 				`test 1 test test			`,
 				`test 2 test test			`,
@@ -504,7 +504,7 @@ func TestDrain_TrainGeneratesPatternsMatchableByLokiPatternFilter(t *testing.T) 
 		},
 		{
 			name:  "should extract patterns that match if line starts with empty space",
-			drain: New(DefaultConfig(), "", nil),
+			drain: New("", DefaultConfig(), &fakeLimits{}, "", nil),
 			inputLines: []string{
 				`			test 1 test test`,
 				`			test 2 test test`,
@@ -514,7 +514,7 @@ func TestDrain_TrainGeneratesPatternsMatchableByLokiPatternFilter(t *testing.T) 
 		},
 		{
 			name:  "Scheduler patterns are matchable",
-			drain: New(DefaultConfig(), "", nil),
+			drain: New("", DefaultConfig(), &fakeLimits{}, "", nil),
 			inputLines: []string{
 				`ts=2024-05-30T12:50:36.648377186Z caller=scheduler_processor.go:143 level=warn msg="error contacting scheduler" err="rpc error: code = Unavailable desc = connection error: desc = \"error reading server preface: EOF\"" addr=10.0.151.101:9095`,
 				`ts=2024-05-30T12:50:36.350575929Z caller=scheduler_processor.go:143 level=warn msg="error contacting scheduler" err="rpc error: code = Unavailable desc = connection error: desc = \"error reading server preface: EOF\"" addr=10.0.151.101:9095`,
@@ -611,7 +611,7 @@ func TestDrain_PruneTreeClearsOldBranches(t *testing.T) {
 	}{
 		{
 			name:  "should prune old branches",
-			drain: New(DefaultConfig(), "", nil),
+			drain: New("", DefaultConfig(), &fakeLimits{}, "", nil),
 			inputLines: []string{
 				"test test test A",
 				"test test test B",
@@ -664,4 +664,12 @@ func countNodes(node *Node) int {
 		total += countNodes(child)
 	}
 	return total
+}
+
+type fakeLimits struct {
+	Limits
+}
+
+func (f *fakeLimits) PatternIngesterTokenizableJsonFields(_ string) []string {
+	return []string{"log", "message", "msg", "msg_", "_msg", "content"}
 }

--- a/pkg/pattern/drain/drain_test.go
+++ b/pkg/pattern/drain/drain_test.go
@@ -14,12 +14,15 @@ import (
 	"github.com/grafana/loki/v3/pkg/logql/log/pattern"
 )
 
+const (
+	testTenant = "fake"
+)
+
 func TestDrain_TrainExtractsPatterns(t *testing.T) {
 	t.Parallel()
 
 	// Set this so the test will print the patterns found, in string slice format for easy copy-paste
 	outputPatternsForTestUpdate := false
-
 	tests := []struct {
 		drain     *Drain
 		inputFile string
@@ -27,7 +30,7 @@ func TestDrain_TrainExtractsPatterns(t *testing.T) {
 		format    string
 	}{
 		{
-			drain:     New("", DefaultConfig(), &fakeLimits{}, "", nil),
+			drain:     New(testTenant, DefaultConfig(), &fakeLimits{}, "", nil),
 			inputFile: `testdata/agent-logfmt.txt`,
 			format:    FormatLogfmt,
 			patterns: []string{
@@ -56,7 +59,7 @@ func TestDrain_TrainExtractsPatterns(t *testing.T) {
 			},
 		},
 		{
-			drain:     New("", DefaultConfig(), &fakeLimits{}, "", nil),
+			drain:     New(testTenant, DefaultConfig(), &fakeLimits{}, "", nil),
 			inputFile: `testdata/ingester-logfmt.txt`,
 			format:    FormatLogfmt,
 			patterns: []string{
@@ -66,7 +69,7 @@ func TestDrain_TrainExtractsPatterns(t *testing.T) {
 			},
 		},
 		{
-			drain:     New("", DefaultConfig(), &fakeLimits{}, "", nil),
+			drain:     New(testTenant, DefaultConfig(), &fakeLimits{}, "", nil),
 			inputFile: `testdata/drone-json.txt`,
 			format:    FormatJSON,
 			patterns: []string{
@@ -79,7 +82,7 @@ func TestDrain_TrainExtractsPatterns(t *testing.T) {
 			},
 		},
 		{
-			drain:     New("", DefaultConfig(), &fakeLimits{}, "", nil),
+			drain:     New(testTenant, DefaultConfig(), &fakeLimits{}, "", nil),
 			inputFile: "testdata/distributor-logfmt.txt",
 			format:    FormatLogfmt,
 			patterns: []string{
@@ -91,7 +94,7 @@ func TestDrain_TrainExtractsPatterns(t *testing.T) {
 			},
 		},
 		{
-			drain:     New("", DefaultConfig(), &fakeLimits{}, "", nil),
+			drain:     New(testTenant, DefaultConfig(), &fakeLimits{}, "", nil),
 			inputFile: "testdata/journald.txt",
 			format:    FormatUnknown,
 			patterns: []string{
@@ -211,7 +214,7 @@ func TestDrain_TrainExtractsPatterns(t *testing.T) {
 			},
 		},
 		{
-			drain:     New("", DefaultConfig(), &fakeLimits{}, "", nil),
+			drain:     New(testTenant, DefaultConfig(), &fakeLimits{}, "", nil),
 			inputFile: "testdata/kafka.txt",
 			format:    FormatUnknown,
 			patterns: []string{
@@ -232,7 +235,7 @@ func TestDrain_TrainExtractsPatterns(t *testing.T) {
 			},
 		},
 		{
-			drain:     New("", DefaultConfig(), &fakeLimits{}, "", nil),
+			drain:     New(testTenant, DefaultConfig(), &fakeLimits{}, "", nil),
 			inputFile: "testdata/kubernetes.txt",
 			format:    FormatUnknown,
 			patterns: []string{
@@ -273,7 +276,7 @@ func TestDrain_TrainExtractsPatterns(t *testing.T) {
 			},
 		},
 		{
-			drain:     New("", DefaultConfig(), &fakeLimits{}, "", nil),
+			drain:     New(testTenant, DefaultConfig(), &fakeLimits{}, "", nil),
 			inputFile: "testdata/vault.txt",
 			format:    FormatUnknown,
 			patterns: []string{
@@ -281,7 +284,7 @@ func TestDrain_TrainExtractsPatterns(t *testing.T) {
 			},
 		},
 		{
-			drain:     New("", DefaultConfig(), &fakeLimits{}, "", nil),
+			drain:     New(testTenant, DefaultConfig(), &fakeLimits{}, "", nil),
 			inputFile: "testdata/calico.txt",
 			format:    FormatUnknown,
 			patterns: []string{
@@ -374,7 +377,7 @@ func TestDrain_TrainExtractsPatterns(t *testing.T) {
 			},
 		},
 		{
-			drain:     New("", DefaultConfig(), &fakeLimits{}, "", nil),
+			drain:     New(testTenant, DefaultConfig(), &fakeLimits{}, "", nil),
 			inputFile: "testdata/grafana-ruler.txt",
 			format:    FormatLogfmt,
 			patterns: []string{
@@ -470,7 +473,7 @@ func TestDrain_TrainGeneratesPatternsMatchableByLokiPatternFilter(t *testing.T) 
 	}{
 		{
 			name:  "should extract patterns that all lines match",
-			drain: New("", DefaultConfig(), &fakeLimits{}, "", nil),
+			drain: New(testTenant, DefaultConfig(), &fakeLimits{}, "", nil),
 			inputLines: []string{
 				"test 1 test test",
 				"test 2 test test",
@@ -480,7 +483,7 @@ func TestDrain_TrainGeneratesPatternsMatchableByLokiPatternFilter(t *testing.T) 
 		},
 		{
 			name:  "should extract patterns that match if line ends with newlines",
-			drain: New("", DefaultConfig(), &fakeLimits{}, "", nil),
+			drain: New(testTenant, DefaultConfig(), &fakeLimits{}, "", nil),
 			inputLines: []string{
 				`test 1 test test
 `,
@@ -494,7 +497,7 @@ func TestDrain_TrainGeneratesPatternsMatchableByLokiPatternFilter(t *testing.T) 
 		},
 		{
 			name:  "should extract patterns that match if line ends with empty space",
-			drain: New("", DefaultConfig(), &fakeLimits{}, "", nil),
+			drain: New(testTenant, DefaultConfig(), &fakeLimits{}, "", nil),
 			inputLines: []string{
 				`test 1 test test			`,
 				`test 2 test test			`,
@@ -504,7 +507,7 @@ func TestDrain_TrainGeneratesPatternsMatchableByLokiPatternFilter(t *testing.T) 
 		},
 		{
 			name:  "should extract patterns that match if line starts with empty space",
-			drain: New("", DefaultConfig(), &fakeLimits{}, "", nil),
+			drain: New(testTenant, DefaultConfig(), &fakeLimits{}, "", nil),
 			inputLines: []string{
 				`			test 1 test test`,
 				`			test 2 test test`,
@@ -514,7 +517,7 @@ func TestDrain_TrainGeneratesPatternsMatchableByLokiPatternFilter(t *testing.T) 
 		},
 		{
 			name:  "Scheduler patterns are matchable",
-			drain: New("", DefaultConfig(), &fakeLimits{}, "", nil),
+			drain: New(testTenant, DefaultConfig(), &fakeLimits{}, "", nil),
 			inputLines: []string{
 				`ts=2024-05-30T12:50:36.648377186Z caller=scheduler_processor.go:143 level=warn msg="error contacting scheduler" err="rpc error: code = Unavailable desc = connection error: desc = \"error reading server preface: EOF\"" addr=10.0.151.101:9095`,
 				`ts=2024-05-30T12:50:36.350575929Z caller=scheduler_processor.go:143 level=warn msg="error contacting scheduler" err="rpc error: code = Unavailable desc = connection error: desc = \"error reading server preface: EOF\"" addr=10.0.151.101:9095`,
@@ -611,7 +614,7 @@ func TestDrain_PruneTreeClearsOldBranches(t *testing.T) {
 	}{
 		{
 			name:  "should prune old branches",
-			drain: New("", DefaultConfig(), &fakeLimits{}, "", nil),
+			drain: New(testTenant, DefaultConfig(), &fakeLimits{}, "", nil),
 			inputLines: []string{
 				"test test test A",
 				"test test test B",

--- a/pkg/pattern/drain/line_tokenizer.go
+++ b/pkg/pattern/drain/line_tokenizer.go
@@ -263,17 +263,23 @@ func (t *logfmtTokenizer) Clone(tokens []string, _ interface{}) ([]string, inter
 
 type jsonTokenizer struct {
 	*punctuationTokenizer
-	varReplace    string
-	maxLineLength int
+	varReplace       string
+	maxLineLength    int
+	fieldsToTokenize []string
 }
 
-func newJSONTokenizer(varReplace string, maxLineLength int) *jsonTokenizer {
-	return &jsonTokenizer{newPunctuationTokenizer(maxLineLength), varReplace, maxLineLength}
+func newJSONTokenizer(varReplace string, maxLineLength int, fieldsToTokenize []string) *jsonTokenizer {
+	return &jsonTokenizer{
+		punctuationTokenizer: newPunctuationTokenizer(maxLineLength),
+		varReplace:           varReplace,
+		maxLineLength:        maxLineLength,
+		fieldsToTokenize:     fieldsToTokenize,
+	}
 }
 
 func (t *jsonTokenizer) Tokenize(line string, tokens []string, state interface{}) ([]string, interface{}) {
 	var found []byte
-	for _, key := range []string{"log", "message", "msg", "msg_", "_msg", "content"} {
+	for _, key := range t.fieldsToTokenize {
 		msg, ty, _, err := jsonparser.Get(unsafeBytes(line), key)
 		if err == nil && ty == jsonparser.String {
 			found = msg

--- a/pkg/pattern/drain/line_tokenizer_test.go
+++ b/pkg/pattern/drain/line_tokenizer_test.go
@@ -325,7 +325,8 @@ func TestJsonTokenizer(t *testing.T) {
 		},
 	}
 
-	tokenizer := newJSONTokenizer(param, DefaultConfig().MaxAllowedLineLength)
+	fieldsToTokenize := []string{"log", "message", "msg", "msg_", "_msg", "content"}
+	tokenizer := newJSONTokenizer(param, DefaultConfig().MaxAllowedLineLength, fieldsToTokenize)
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/pattern/flush_test.go
+++ b/pkg/pattern/flush_test.go
@@ -41,7 +41,7 @@ func TestSweepInstance(t *testing.T) {
 		ring: fakeRing,
 	}
 
-	ing, err := New(defaultIngesterTestConfig(t), ringClient, "foo", nil, log.NewNopLogger())
+	ing, err := New(defaultIngesterTestConfig(t), &fakeLimits{}, ringClient, "foo", nil, log.NewNopLogger())
 	require.NoError(t, err)
 	defer services.StopAndAwaitTerminated(context.Background(), ing) //nolint:errcheck
 	err = services.StartAndAwaitRunning(context.Background(), ing)

--- a/pkg/pattern/ingester.go
+++ b/pkg/pattern/ingester.go
@@ -148,6 +148,10 @@ func (cfg *Config) Validate() error {
 	return cfg.LifecyclerConfig.Validate()
 }
 
+type Limits interface {
+	drain.Limits
+}
+
 type Ingester struct {
 	services.Service
 	lifecycler *ring.Lifecycler
@@ -156,6 +160,7 @@ type Ingester struct {
 	lifecyclerWatcher *services.FailureWatcher
 
 	cfg        Config
+	limits     Limits
 	registerer prometheus.Registerer
 	logger     log.Logger
 
@@ -175,6 +180,7 @@ type Ingester struct {
 
 func New(
 	cfg Config,
+	limits Limits,
 	ringClient RingClient,
 	metricsNamespace string,
 	registerer prometheus.Registerer,
@@ -189,6 +195,7 @@ func New(
 
 	i := &Ingester{
 		cfg:         cfg,
+		limits:      limits,
 		ringClient:  ringClient,
 		logger:      log.With(logger, "component", "pattern-ingester"),
 		registerer:  registerer,
@@ -416,6 +423,7 @@ func (i *Ingester) GetOrCreateInstance(instanceID string) (*instance, error) { /
 			i.logger,
 			i.metrics,
 			i.drainCfg,
+			i.limits,
 			i.ringClient,
 			i.lifecycler.ID,
 			writer,

--- a/pkg/pattern/ingester_test.go
+++ b/pkg/pattern/ingester_test.go
@@ -343,6 +343,6 @@ type fakeLimits struct {
 	Limits
 }
 
-func (f *fakeLimits) PatternIngesterTokenizableJsonFields(_ string) []string {
+func (f *fakeLimits) PatternIngesterTokenizableJSONFields(_ string) []string {
 	return []string{"log", "message", "msg", "msg_", "_msg", "content"}
 }

--- a/pkg/pattern/ingester_test.go
+++ b/pkg/pattern/ingester_test.go
@@ -54,6 +54,7 @@ func TestInstancePushQuery(t *testing.T) {
 		log.NewNopLogger(),
 		newIngesterMetrics(nil, "test"),
 		drain.DefaultConfig(),
+		&fakeLimits{},
 		ringClient,
 		ingesterID,
 		mockWriter,
@@ -141,6 +142,7 @@ func TestInstancePushAggregateMetrics(t *testing.T) {
 			log.NewNopLogger(),
 			newIngesterMetrics(nil, "test"),
 			drain.DefaultConfig(),
+			&fakeLimits{},
 			ringClient,
 			ingesterID,
 			mockWriter,
@@ -335,4 +337,12 @@ func (m *mockEntryWriter) WriteEntry(ts time.Time, entry string, lbls labels.Lab
 
 func (m *mockEntryWriter) Stop() {
 	_ = m.Called()
+}
+
+type fakeLimits struct {
+	Limits
+}
+
+func (f *fakeLimits) PatternIngesterTokenizableJsonFields(_ string) []string {
+	return []string{"log", "message", "msg", "msg_", "_msg", "content"}
 }

--- a/pkg/pattern/stream.go
+++ b/pkg/pattern/stream.go
@@ -35,6 +35,7 @@ func newStream(
 	guessedFormat string,
 	instanceID string,
 	drainCfg *drain.Config,
+	drainLimits drain.Limits,
 ) (*stream, error) {
 	return &stream{
 		fp:           fp,
@@ -42,7 +43,7 @@ func newStream(
 		labelsString: labels.String(),
 		labelHash:    labels.Hash(),
 		logger:       logger,
-		patterns: drain.New(drainCfg, guessedFormat, &drain.Metrics{
+		patterns: drain.New(instanceID, drainCfg, drainLimits, guessedFormat, &drain.Metrics{
 			PatternsEvictedTotal:  metrics.patternsDiscardedTotal.WithLabelValues(instanceID, guessedFormat, "false"),
 			PatternsPrunedTotal:   metrics.patternsDiscardedTotal.WithLabelValues(instanceID, guessedFormat, "true"),
 			PatternsDetectedTotal: metrics.patternsDetectedTotal.WithLabelValues(instanceID, guessedFormat),

--- a/pkg/pattern/stream_test.go
+++ b/pkg/pattern/stream_test.go
@@ -18,15 +18,7 @@ import (
 
 func TestAddStream(t *testing.T) {
 	lbs := labels.New(labels.Label{Name: "test", Value: "test"})
-	stream, err := newStream(
-		model.Fingerprint(lbs.Hash()),
-		lbs,
-		newIngesterMetrics(nil, "test"),
-		log.NewNopLogger(),
-		drain.FormatUnknown,
-		"123",
-		drain.DefaultConfig(),
-	)
+	stream, err := newStream(model.Fingerprint(lbs.Hash()), lbs, newIngesterMetrics(nil, "test"), log.NewNopLogger(), drain.FormatUnknown, "123", drain.DefaultConfig(), &fakeLimits{})
 	require.NoError(t, err)
 
 	err = stream.Push(context.Background(), []push.Entry{
@@ -54,15 +46,7 @@ func TestAddStream(t *testing.T) {
 
 func TestPruneStream(t *testing.T) {
 	lbs := labels.New(labels.Label{Name: "test", Value: "test"})
-	stream, err := newStream(
-		model.Fingerprint(lbs.Hash()),
-		lbs,
-		newIngesterMetrics(nil, "test"),
-		log.NewNopLogger(),
-		drain.FormatUnknown,
-		"123",
-		drain.DefaultConfig(),
-	)
+	stream, err := newStream(model.Fingerprint(lbs.Hash()), lbs, newIngesterMetrics(nil, "test"), log.NewNopLogger(), drain.FormatUnknown, "123", drain.DefaultConfig(), &fakeLimits{})
 	require.NoError(t, err)
 
 	err = stream.Push(context.Background(), []push.Entry{

--- a/pkg/util/limiter/combined_limits.go
+++ b/pkg/util/limiter/combined_limits.go
@@ -8,6 +8,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/distributor"
 	"github.com/grafana/loki/v3/pkg/indexgateway"
 	"github.com/grafana/loki/v3/pkg/ingester"
+	"github.com/grafana/loki/v3/pkg/pattern"
 	querier_limits "github.com/grafana/loki/v3/pkg/querier/limits"
 	queryrange_limits "github.com/grafana/loki/v3/pkg/querier/queryrange/limits"
 	"github.com/grafana/loki/v3/pkg/ruler"
@@ -28,4 +29,5 @@ type CombinedLimits interface {
 	bloomgateway.Limits
 	bloomplanner.Limits
 	bloombuilder.Limits
+	pattern.Limits
 }

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -226,7 +226,7 @@ type Limits struct {
 
 	IngestionPartitionsTenantShardSize int `yaml:"ingestion_partitions_tenant_shard_size" json:"ingestion_partitions_tenant_shard_size" category:"experimental"`
 
-	PatternIngesterTokenizableJsonFields dskit_flagext.StringSliceCSV `yaml:"pattern_ingester_tokenizable_json_fields" json:"pattern_ingester_tokenizable_json_fields" doc:"hidden"`
+	PatternIngesterTokenizableJSONFields dskit_flagext.StringSliceCSV `yaml:"pattern_ingester_tokenizable_json_fields" json:"pattern_ingester_tokenizable_json_fields" doc:"hidden"`
 }
 
 type StreamRetention struct {
@@ -421,8 +421,8 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 
 	f.IntVar(&l.IngestionPartitionsTenantShardSize, "limits.ingestion-partition-tenant-shard-size", 0, "The number of partitions a tenant's data should be sharded to when using kafka ingestion. Tenants are sharded across partitions using shuffle-sharding. 0 disables shuffle sharding and tenant is sharded across all partitions.")
 
-	_ = l.PatternIngesterTokenizableJsonFields.Set("log,message,msg,msg_,_msg,content")
-	f.Var(&l.PatternIngesterTokenizableJsonFields, "limits.pattern-ingester-tokenizable-json-fields", "List of JSON fields that should be tokenized in the ingester.")
+	_ = l.PatternIngesterTokenizableJSONFields.Set("log,message,msg,msg_,_msg,content")
+	f.Var(&l.PatternIngesterTokenizableJSONFields, "limits.pattern-ingester-tokenizable-json-fields", "List of JSON fields that should be tokenized in the ingester.")
 }
 
 // SetGlobalOTLPConfig set GlobalOTLPConfig which is used while unmarshaling per-tenant otlp config to use the default list of resource attributes picked as index labels.
@@ -1059,8 +1059,8 @@ func (o *Overrides) BlockIngestionStatusCode(userID string) int {
 	return o.getOverridesForUser(userID).BlockIngestionStatusCode
 }
 
-func (o *Overrides) PatternIngesterTokenizableJsonFields(userID string) []string {
-	return o.getOverridesForUser(userID).PatternIngesterTokenizableJsonFields
+func (o *Overrides) PatternIngesterTokenizableJSONFields(userID string) []string {
+	return o.getOverridesForUser(userID).PatternIngesterTokenizableJSONFields
 }
 
 func (o *Overrides) getOverridesForUser(userID string) *Limits {

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -226,7 +226,7 @@ type Limits struct {
 
 	IngestionPartitionsTenantShardSize int `yaml:"ingestion_partitions_tenant_shard_size" json:"ingestion_partitions_tenant_shard_size" category:"experimental"`
 
-	PatternIngesterTokenizableJsonFields dskit_flagext.StringSliceCSV `yaml:"pattern_ingester_tokenizable_json_fields" json:"pattern_ingester_tokenizable_json_fields" doc:"description=List of JSON fields that should be tokenized in the ingester."`
+	PatternIngesterTokenizableJsonFields dskit_flagext.StringSliceCSV `yaml:"pattern_ingester_tokenizable_json_fields" json:"pattern_ingester_tokenizable_json_fields" doc:"hidden"`
 }
 
 type StreamRetention struct {

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -225,6 +225,8 @@ type Limits struct {
 	BlockIngestionStatusCode int                `yaml:"block_ingestion_status_code" json:"block_ingestion_status_code"`
 
 	IngestionPartitionsTenantShardSize int `yaml:"ingestion_partitions_tenant_shard_size" json:"ingestion_partitions_tenant_shard_size" category:"experimental"`
+
+	PatternIngesterTokenizableJsonFields dskit_flagext.StringSliceCSV `yaml:"pattern_ingester_tokenizable_json_fields" json:"pattern_ingester_tokenizable_json_fields" doc:"description=List of JSON fields that should be tokenized in the ingester."`
 }
 
 type StreamRetention struct {
@@ -418,6 +420,9 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&l.BlockIngestionStatusCode, "limits.block-ingestion-status-code", defaultBlockedIngestionStatusCode, "HTTP status code to return when ingestion is blocked. If 200, the ingestion will be blocked without returning an error to the client. By Default, a custom status code (260) is returned to the client along with an error message.")
 
 	f.IntVar(&l.IngestionPartitionsTenantShardSize, "limits.ingestion-partition-tenant-shard-size", 0, "The number of partitions a tenant's data should be sharded to when using kafka ingestion. Tenants are sharded across partitions using shuffle-sharding. 0 disables shuffle sharding and tenant is sharded across all partitions.")
+
+	_ = l.PatternIngesterTokenizableJsonFields.Set("log,message,msg,msg_,_msg,content")
+	f.Var(&l.PatternIngesterTokenizableJsonFields, "limits.pattern-ingester-tokenizable-json-fields", "List of JSON fields that should be tokenized in the ingester.")
 }
 
 // SetGlobalOTLPConfig set GlobalOTLPConfig which is used while unmarshaling per-tenant otlp config to use the default list of resource attributes picked as index labels.
@@ -1052,6 +1057,10 @@ func (o *Overrides) BlockIngestionUntil(userID string) time.Time {
 
 func (o *Overrides) BlockIngestionStatusCode(userID string) int {
 	return o.getOverridesForUser(userID).BlockIngestionStatusCode
+}
+
+func (o *Overrides) PatternIngesterTokenizableJsonFields(userID string) []string {
+	return o.getOverridesForUser(userID).PatternIngesterTokenizableJsonFields
 }
 
 func (o *Overrides) getOverridesForUser(userID string) *Limits {

--- a/pkg/validation/limits_test.go
+++ b/pkg/validation/limits_test.go
@@ -354,3 +354,63 @@ func TestLimitsValidation(t *testing.T) {
 		})
 	}
 }
+
+func Test_PatternIngesterTokenizableJSONFields(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		yaml     string
+		expected []string
+	}{
+		{
+			name: "only defaults",
+			yaml: `
+pattern_ingester_tokenizable_json_fields_default: log,message
+`,
+			expected: []string{"log", "message"},
+		},
+		{
+			name: "with append",
+			yaml: `
+pattern_ingester_tokenizable_json_fields_default: log,message
+pattern_ingester_tokenizable_json_fields_append: msg,body
+`,
+			expected: []string{"log", "message", "msg", "body"},
+		},
+		{
+			name: "with delete",
+			yaml: `
+pattern_ingester_tokenizable_json_fields_default: log,message
+pattern_ingester_tokenizable_json_fields_delete: message
+`,
+			expected: []string{"log"},
+		},
+		{
+			name: "with append and delete from default",
+			yaml: `
+pattern_ingester_tokenizable_json_fields_default: log,message
+pattern_ingester_tokenizable_json_fields_append: msg,body
+pattern_ingester_tokenizable_json_fields_delete: message
+`,
+			expected: []string{"log", "msg", "body"},
+		},
+		{
+			name: "with append and delete from append",
+			yaml: `
+pattern_ingester_tokenizable_json_fields_default: log,message
+pattern_ingester_tokenizable_json_fields_append: msg,body
+pattern_ingester_tokenizable_json_fields_delete: body
+`,
+			expected: []string{"log", "message", "msg"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			overrides := Overrides{
+				defaultLimits: &Limits{},
+			}
+			require.NoError(t, yaml.Unmarshal([]byte(tc.yaml), overrides.defaultLimits))
+
+			actual := overrides.PatternIngesterTokenizableJSONFields("fake")
+			require.ElementsMatch(t, tc.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR makes [the hardcoded list of json fields][1] to mine patterns for configurable. This would allow us to:
- Add more as we learn it fits without having to release a new version
- Support customers with legit requests to add one of their fields
- Remove fields if we see any yield unuseful patterns for a customer

This list is now configurable via the following overrides:
- `pattern_ingester_tokenizable_json_fields_default`: It takes a comma-separated list of fields. By default we set it to the currently hardcoded list: `log,message,msg,msg_,_msg,content`.
- `pattern_ingester_tokenizable_json_fields_append`: Also comma-separated. Appends content to default list.
- `pattern_ingester_tokenizable_json_fields_delete`: Comma-separated. Deletes keys from (default U append).

The docs are hidden.

**Special notes for your reviewer**:
- As far as I could tell, the tenant is passed down to the `pattern.stream` via the `instanceID` of the `pattern.instance` which in turns comes from the  `pattern.Ingester` at `GetOrCreateInstance` where the `instanceID` comes [from the tenantID][2] in the ctx.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)

[1]: https://github.com/grafana/loki/blob/41fafd87933224d5d43592e91e339322fc90a466/pkg/pattern/drain/line_tokenizer.go#L276-L282
[2]: https://github.com/grafana/loki/blob/0af0211d5e06ad1290a286c9cadc0b5dbe4ebd15/pkg/pattern/ingester.go#L345