### PR TITLE
docs: Update release notes for 3.1.2 (#14538)

### DIFF
--- a/docs/sources/release-notes/v3-1.md
+++ b/docs/sources/release-notes/v3-1.md
@@ -1,6 +1,6 @@
 ---
 title: v3.1
-description: Version 3.0 release notes.
+description: Version 3.1 release notes.
 weight: 20
 ---
 
@@ -69,7 +69,7 @@ To learn more about breaking changes in this release, refer to the [Upgrade guid
 
 ## Upgrade Considerations
 
-he path from 2.9 to 3.0 included several breaking changes. For important upgrade guidance, refer to the [Upgrade Guide](https://grafana.com/docs/loki/<LOKI_VERSION>/setup/upgrade/) and the separate [Helm Upgrade Guide](https://grafana.com/docs/loki/<LOKI_VERSION>/setup/upgrade/upgrade-to-6x/).
+The path from 2.9 to 3.0 included several breaking changes. For important upgrade guidance, refer to the [Upgrade Guide](https://grafana.com/docs/loki/<LOKI_VERSION>/setup/upgrade/) and the separate [Helm Upgrade Guide](https://grafana.com/docs/loki/<LOKI_VERSION>/setup/upgrade/upgrade-to-6x/).
 
 - **BREAKING CHANGE** Update Helm chart to support distributed mode and 3.0 ([#12067](https://github.com/grafana/loki/issues/12067)).
 
@@ -78,6 +78,14 @@ Out of an abundance of caution, we advise that users with Loki or Grafana Enterp
 {{< /admonition >}}
 
 ## Bug fixes
+
+## 3.1.2 (2024-10-17)
+
+- **config:** Copy Alibaba and IBM object storage configuration from common ([#14316](https://github.com/grafana/loki/issues/14316)) ([7184d45](https://github.com/grafana/loki/commit/7184d45d8e080874feea8bfd223dedf5f20d3836)).
+- **docker-compose:** upgrade loki and grafana production image tags to 3.1.1 ([#14025](https://github.com/grafana/loki/issues/14025)) ([36fe29e](https://github.com/grafana/loki/commit/36fe29eb334d8300265ca437c0acb423a01c5041)).
+- **logql:** updated JSONExpressionParser not to unescape extracted values if it is JSON object. (backport release-3.1.x) ([#14503](https://github.com/grafana/loki/issues/14503)) ([759f9c8](https://github.com/grafana/loki/commit/759f9c8525227bb1272771a40429d12e015874d9)).
+- **promtail:** Revert build image to Debian Bullseye to fix libc version issue in Promtail ([#14387](https://github.com/grafana/loki/issues/14387)) ([05b6a65](https://github.com/grafana/loki/commit/05b6a65f8bf00b880f17465553b1adaf0cf56d60)).
+- **storage:** have GetObject check for canceled context (backport release-3.1.x) ([#14421](https://github.com/grafana/loki/issues/14421)) ([f3d69ff](https://github.com/grafana/loki/commit/f3d69ffa960c91c0239436a32bb0aa578c0f022a)).
 
 ## 3.1.1 (2024-08-08)
 


### PR DESCRIPTION
(cherry picked from commit 3f6792d2829c68a133fec0e0b0f27139cf04155f)

manual backport of #14538 