### PR TITLE
chore: Fix variable declaration for Bloom Build dashboard

### DIFF
--- a/production/loki-mixin-compiled-ssd/dashboards/loki-bloom-build.json
+++ b/production/loki-mixin-compiled-ssd/dashboards/loki-bloom-build.json
@@ -6367,7 +6367,7 @@
                "multi": false,
                "name": "tenant",
                "options": [ ],
-               "query": "label_values(loki_bloomplanner_tenant_tasks_planned{cluster=\"$cluster\", namespace=\"$namespace\"})",
+               "query": "label_values(loki_bloomplanner_tenant_tasks_planned{cluster=\"$cluster\", namespace=\"$namespace\"}, tenant)",
                "refresh": 0,
                "regex": "",
                "sort": 3,

--- a/production/loki-mixin-compiled/dashboards/loki-bloom-build.json
+++ b/production/loki-mixin-compiled/dashboards/loki-bloom-build.json
@@ -6367,7 +6367,7 @@
                "multi": false,
                "name": "tenant",
                "options": [ ],
-               "query": "label_values(loki_bloomplanner_tenant_tasks_planned{cluster=\"$cluster\", namespace=\"$namespace\"})",
+               "query": "label_values(loki_bloomplanner_tenant_tasks_planned{cluster=\"$cluster\", namespace=\"$namespace\"}, tenant)",
                "refresh": 0,
                "regex": "",
                "sort": 3,

--- a/production/loki-mixin/dashboards/loki-bloom-build.libsonnet
+++ b/production/loki-mixin/dashboards/loki-bloom-build.libsonnet
@@ -12,7 +12,7 @@ local template = import 'grafonnet/template.libsonnet';
     template.new(
       'tenant',
       '$datasource',
-      'label_values(loki_bloomplanner_tenant_tasks_planned{cluster="$cluster", namespace="$namespace"})',
+      'label_values(loki_bloomplanner_tenant_tasks_planned{cluster="$cluster", namespace="$namespace"}, tenant)',
       label='Tenant',
       sort=3,  // numerical ascending
       includeAll=true,


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the `tenant` variable declaration for the "Bloom Build" dashboard introduced with ##14529