### PR TITLE
fix(operator): Fix building the size-calculator image

### DIFF
--- a/operator/calculator.Dockerfile
+++ b/operator/calculator.Dockerfile
@@ -1,9 +1,9 @@
 # Build the calculator binary
-FROM golang:1.22.6 as builder
+FROM golang:1.22.8 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
-COPY apis/ apis/
+COPY api/ api/
 COPY go.mod go.mod
 COPY go.sum go.sum
 # cache deps before building and copying source so that we don't need to re-download as much


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes the dockerfile to unbreak the main workflow for now:
- https://github.com/grafana/loki/actions/runs/11458601806

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:
We should evaluate removing the size-calculator from the code base, because it never materialized into production.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
