### PR TITLE
fix: Update renovate ignore for operator API with new module path

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -16,7 +16,7 @@
         "matchFileNames": [ "operator/go.mod" ],
         "matchPackageNames": [
           "github.com/grafana/loki",
-          "github.com/grafana/loki/operator/apis/loki"
+          "github.com/grafana/loki/operator/api/loki"
         ],
         "enabled": false
       }


### PR DESCRIPTION
**What this PR does / why we need it**:

This updates the renovate ignore list with the new path of the operator API module.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
