### PR TITLE
fix: fix bug in query result marshaling for invalid utf8 characters

### DIFF
--- a/pkg/util/marshal/query_test.go
+++ b/pkg/util/marshal/query_test.go
@@ -1,16 +1,19 @@
 package marshal
 
 import (
-	"github.com/grafana/loki/v3/pkg/logqlmodel"
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/logqlmodel"
 )
 
 func TestNewStreams(t *testing.T) {
-	_, err := NewStreams(logqlmodel.Streams{
+	s, err := NewStreams(logqlmodel.Streams{
 		{
 			Labels: "{asdf=\"�\"}",
 		},
 	})
 	require.NoError(t, err)
+	require.Equal(t, " ", s[0].Labels["asdf"], "expected only a space for label who only contained invalid UTF8 rune")
 }

--- a/pkg/util/marshal/query_test.go
+++ b/pkg/util/marshal/query_test.go
@@ -1,0 +1,16 @@
+package marshal
+
+import (
+	"github.com/grafana/loki/v3/pkg/logqlmodel"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestNewStreams(t *testing.T) {
+	_, err := NewStreams(logqlmodel.Streams{
+		{
+			Labels: "{asdf=\"�\"}",
+		},
+	})
+	require.NoError(t, err)
+}


### PR DESCRIPTION
Potentially we want to fix this by actually sanitizing data for OTLP ingestion/structured metadata, but I think we should include a fix to allow users with data that is already stored in Loki to query it out.

The bug is present for streams which have structured metadata which contains invalid UTF-8 characters. When you write a query like `{label="x"}` there's no problem, but as soon as you do `label="x"} |= "some filter"` the bug kicks in because we pull in the structured metadata. 

When we then go to marshal the labelset on the query result we run into an error [here](https://github.com/grafana/loki/blob/275c97cec7f70e68c56192c565d53a6c2a18ff78/pkg/util/marshal/query.go#L90-L109) because the underlying call to `NewLabelSet` calls Prometheus' `ParseMetric` which enforces "any valid Unicode character" in the label value. This fails if there's an invalid character. I'm not entirely sure what the invalid character is or where it's coming from, but we have precedent for checking for it already as `RuneError` ([here](https://pkg.go.dev/unicode/utf8#pkg-constants)) in other places. For this PR I've simply copied what we do for the JSONParser from [here](https://github.com/grafana/loki/pull/14068/files#diff-8d0a5078b0188ec4746db8836eb4a1d7b6b3e5664eb95a828f350b7b1d26dcbbR45-R50).