### PR TITLE
fix(s3): disable client retries when congestion control is enabled

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -5646,13 +5646,6 @@ congestion_control:
 # CLI flag: -store.max-parallel-get-chunk
 [max_parallel_get_chunk: <int> | default = 150]
 
-# Enables the use of thanos-io/objstore clients for connecting to object
-# storage. When set to true, the configuration inside
-# `storage_config.object_store` or `common.storage.object_store` block takes
-# effect.
-# CLI flag: -use-thanos-objstore
-[use_thanos_objstore: <boolean> | default = false]
-
 # The maximum number of chunks to fetch per batch.
 # CLI flag: -store.max-chunk-batch-size
 [max_chunk_batch_size: <int> | default = 50]

--- a/pkg/storage/factory.go
+++ b/pkg/storage/factory.go
@@ -295,7 +295,7 @@ type Config struct {
 	DisableBroadIndexQueries bool         `yaml:"disable_broad_index_queries"`
 	MaxParallelGetChunk      int          `yaml:"max_parallel_get_chunk"`
 
-	UseThanosObjstore bool          `yaml:"use_thanos_objstore" doc:"hidden`
+	UseThanosObjstore bool          `yaml:"use_thanos_objstore" doc:"hidden"`
 	ObjectStore       bucket.Config `yaml:"object_store" doc:"hidden"`
 
 	MaxChunkBatchSize   int                       `yaml:"max_chunk_batch_size"`
@@ -649,6 +649,10 @@ func internalNewObjectClient(storeName, component string, cfg Config, clientMetr
 				return nil, fmt.Errorf("Unrecognized named aws storage config %s", storeName)
 			}
 			s3Cfg = awsCfg.S3Config
+		}
+
+		if cfg.CongestionControl.Enabled {
+			s3Cfg.BackoffConfig.MaxRetries = 1
 		}
 		return aws.NewS3ObjectClient(s3Cfg, cfg.Hedging)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

With congestion control enabled, we want the cc controller to handle all retries. It is necessary to disable retries performed by the object client.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
