### PR TITLE
feat(logcli): add gzip compression option

### DIFF
--- a/cmd/logcli/main.go
+++ b/cmd/logcli/main.go
@@ -483,6 +483,7 @@ func newQueryClient(app *kingpin.Application) client.Client {
 	app.Flag("max-backoff", "Maximum backoff time between retries. Can also be set using LOKI_CLIENT_MAX_BACKOFF env var.").Default("0").Envar("LOKI_CLIENT_MAX_BACKOFF").IntVar(&client.BackoffConfig.MaxBackoff)
 	app.Flag("auth-header", "The authorization header used. Can also be set using LOKI_AUTH_HEADER env var.").Default("Authorization").Envar("LOKI_AUTH_HEADER").StringVar(&client.AuthHeader)
 	app.Flag("proxy-url", "The http or https proxy to use when making requests. Can also be set using LOKI_HTTP_PROXY_URL env var.").Default("").Envar("LOKI_HTTP_PROXY_URL").StringVar(&client.ProxyURL)
+	app.Flag("compress", "Request that Loki compress returned data in transit. Can also be set using LOKI_HTTP_COMPRESSION env var.").Default("false").Envar("LOKI_HTTP_COMPRESSION").BoolVar(&client.Compression)
 
 	return client
 }

--- a/docs/sources/query/logcli.md
+++ b/docs/sources/query/logcli.md
@@ -371,6 +371,7 @@ Flags:
       --auth-header="Authorization"
                                 The authorization header used. Can also be set using LOKI_AUTH_HEADER env var.
       --proxy-url=""            The http or https proxy to use when making requests. Can also be set using LOKI_HTTP_PROXY_URL env var.
+      --compress                Request that Loki compress returned data in transit. Can also be set using LOKI_HTTP_COMPRESSION env var.
       --limit=30                Limit on number of entries to print. Setting it to 0 will fetch all entries.
       --since=1h                Lookback window.
       --from=FROM               Start looking for logs at this absolute time (inclusive)
@@ -465,6 +466,7 @@ Flags:
       --auth-header="Authorization"
                               The authorization header used. Can also be set using LOKI_AUTH_HEADER env var.
       --proxy-url=""          The http or https proxy to use when making requests. Can also be set using LOKI_HTTP_PROXY_URL env var.
+      --compress              Request that Loki compress returned data in transit. Can also be set using LOKI_HTTP_COMPRESSION env var.
       --limit=30              Limit on number of entries to print. Setting it to 0 will fetch all entries.
       --now=NOW               Time at which to execute the instant query.
       --forward               Scan forwards through logs.
@@ -525,6 +527,7 @@ Flags:
       --auth-header="Authorization"
                               The authorization header used. Can also be set using LOKI_AUTH_HEADER env var.
       --proxy-url=""          The http or https proxy to use when making requests. Can also be set using LOKI_HTTP_PROXY_URL env var.
+      --compress              Request that Loki compress returned data in transit. Can also be set using LOKI_HTTP_COMPRESSION env var.
       --since=1h              Lookback window.
       --from=FROM             Start looking for labels at this absolute time (inclusive)
       --to=TO                 Stop looking for labels at this absolute time (exclusive)
@@ -581,6 +584,7 @@ Flags:
       --auth-header="Authorization"
                               The authorization header used. Can also be set using LOKI_AUTH_HEADER env var.
       --proxy-url=""          The http or https proxy to use when making requests. Can also be set using LOKI_HTTP_PROXY_URL env var.
+      --compress              Request that Loki compress returned data in transit. Can also be set using LOKI_HTTP_COMPRESSION env var.
       --since=1h              Lookback window.
       --from=FROM             Start looking for logs at this absolute time (inclusive)
       --to=TO                 Stop looking for logs at this absolute time (exclusive)
@@ -633,6 +637,7 @@ Flags:
       --auth-header="Authorization"
                               The authorization header used. Can also be set using LOKI_AUTH_HEADER env var.
       --proxy-url=""          The http or https proxy to use when making requests. Can also be set using LOKI_HTTP_PROXY_URL env var.
+      --compress              Request that Loki compress returned data in transit. Can also be set using LOKI_HTTP_COMPRESSION env var.
 ```
 
 ### `stats` command reference
@@ -694,6 +699,7 @@ Flags:
       --auth-header="Authorization"
                               The authorization header used. Can also be set using LOKI_AUTH_HEADER env var.
       --proxy-url=""          The http or https proxy to use when making requests. Can also be set using LOKI_HTTP_PROXY_URL env var.
+      --compress              Request that Loki compress returned data in transit. Can also be set using LOKI_HTTP_COMPRESSION env var.
       --since=1h              Lookback window.
       --from=FROM             Start looking for logs at this absolute time (inclusive)
       --to=TO                 Stop looking for logs at this absolute time (exclusive)
@@ -761,6 +767,7 @@ Flags:
       --auth-header="Authorization"
                               The authorization header used. Can also be set using LOKI_AUTH_HEADER env var.
       --proxy-url=""          The http or https proxy to use when making requests. Can also be set using LOKI_HTTP_PROXY_URL env var.
+      --compress              Request that Loki compress returned data in transit. Can also be set using LOKI_HTTP_COMPRESSION env var.
       --since=1h              Lookback window.
       --from=FROM             Start looking for logs at this absolute time (inclusive)
       --to=TO                 Stop looking for logs at this absolute time (exclusive)
@@ -833,6 +840,7 @@ Flags:
       --auth-header="Authorization"
                               The authorization header used. Can also be set using LOKI_AUTH_HEADER env var.
       --proxy-url=""          The http or https proxy to use when making requests. Can also be set using LOKI_HTTP_PROXY_URL env var.
+      --compress              Request that Loki compress returned data in transit. Can also be set using LOKI_HTTP_COMPRESSION env var.
       --since=1h              Lookback window.
       --from=FROM             Start looking for logs at this absolute time (inclusive)
       --to=TO                 Stop looking for logs at this absolute time (exclusive)


### PR DESCRIPTION
**What this PR does / why we need it**:

Passing --compress to logcli will enable (or more accurately not disable) compression on the http.Transport, allowing Loki to return gzip-compressed payloads.

This improves overall execution time and reduces data transfer by 10-15x.

**Which issue(s) this PR fixes**:

#14597

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
