### PR TITLE
feat(helm): Reader PodDisruptionBudget maxUnavailable configurable (#14603)

### DIFF
--- a/production/helm/loki/templates/read/deployment-read.yaml
+++ b/production/helm/loki/templates/read/deployment-read.yaml
@@ -25,7 +25,9 @@ spec:
   strategy:
     rollingUpdate:
       maxSurge: 0
-      maxUnavailable: 1
+      {{- with .Values.read.maxUnavailable }}
+      maxUnavailable: {{ . }}
+      {{- end }}
   revisionHistoryLimit: {{ .Values.loki.revisionHistoryLimit }}
   selector:
     matchLabels:

--- a/production/helm/loki/templates/read/poddisruptionbudget-read.yaml
+++ b/production/helm/loki/templates/read/poddisruptionbudget-read.yaml
@@ -11,5 +11,7 @@ spec:
   selector:
     matchLabels:
       {{- include "loki.readSelectorLabels" . | nindent 6 }}
-  maxUnavailable: 1
+  {{- with .Values.read.maxUnavailable }}
+  maxUnavailable: {{ . }}
+  {{- end }}
 {{- end }}

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -1515,6 +1515,8 @@ read:
   priorityClassName: null
   # -- Annotations for read deployment
   annotations: {}
+  # -- Pod Disruption Budget / Deployment Rollout Strategy maxUnavailable
+  maxUnavailable: 1
   # -- Annotations for read pods
   podAnnotations: {}
   # -- Additional labels for each `read` pod


### PR DESCRIPTION
**What this PR does / why we need it**:

Make `maxUnavailable` configurable for Reader pods (just as some other deployments/statefulsets) through an optional Helm Value. Default is "1", just as the previously hard-coded value was.

**Which issue(s) this PR fixes**:
Fixes #14603

**Special notes for your reviewer**:
Packaged the helm chart, and tested it, worked as expected. Example:
````
$ kubectl -n loki get pdb loki-read
NAME        MIN AVAILABLE   MAX UNAVAILABLE   ALLOWED DISRUPTIONS   AGE
loki-read   N/A             51%               2                     16d
````

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added (*...to values.yaml as a comment*)
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
