### PR TITLE
fix(operator): Disable log level discovery for OpenShift tenancy modes

### DIFF
--- a/operator/internal/manifests/config.go
+++ b/operator/internal/manifests/config.go
@@ -194,6 +194,7 @@ func ConfigOptions(opt Options) config.Options {
 		ObjectStorage:         opt.ObjectStorage,
 		HTTPTimeouts:          opt.Timeouts.Loki,
 		EnableRemoteReporting: opt.Gates.GrafanaLabsUsageReport,
+		DiscoverLogLevels:     discoverLogLevels(&opt.Stack),
 		Ruler: config.Ruler{
 			Enabled:               rulerEnabled,
 			RulesStorageDirectory: rulesStorageDirectory,
@@ -395,4 +396,17 @@ func retentionConfig(ls *lokiv1.LokiStackSpec) config.RetentionOptions {
 		Enabled:           true,
 		DeleteWorkerCount: deleteWorkerCountMap[ls.Size],
 	}
+}
+
+func discoverLogLevels(ls *lokiv1.LokiStackSpec) bool {
+	if ls.Tenants == nil {
+		return true
+	}
+
+	if ls.Tenants.Mode == lokiv1.OpenshiftLogging ||
+		ls.Tenants.Mode == lokiv1.OpenshiftNetwork {
+		return false
+	}
+
+	return true
 }

--- a/operator/internal/manifests/internal/config/build_test.go
+++ b/operator/internal/manifests/internal/config/build_test.go
@@ -97,6 +97,7 @@ limits_config:
   max_line_size: 256000
   max_entries_limit_per_query: 5000
   discover_service_name: []
+  discover_log_levels: true
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -259,6 +260,7 @@ overrides:
 		},
 		Shippers:              []string{"boltdb"},
 		EnableRemoteReporting: true,
+		DiscoverLogLevels:     true,
 		HTTPTimeouts: HTTPTimeoutConfig{
 			IdleTimeout:  30 * time.Second,
 			ReadTimeout:  30 * time.Second,
@@ -355,6 +357,7 @@ limits_config:
   max_line_size: 256000
   max_entries_limit_per_query: 5000
   discover_service_name: []
+  discover_log_levels: false
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -782,6 +785,7 @@ limits_config:
   max_line_size: 256000
   max_entries_limit_per_query: 5000
   discover_service_name: []
+  discover_log_levels: false
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -1141,6 +1145,7 @@ limits_config:
   max_line_size: 256000
   max_entries_limit_per_query: 5000
   discover_service_name: []
+  discover_log_levels: false
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -1501,6 +1506,7 @@ limits_config:
   max_line_size: 256000
   max_entries_limit_per_query: 5000
   discover_service_name: []
+  discover_log_levels: false
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -1895,6 +1901,7 @@ limits_config:
   max_line_size: 256000
   max_entries_limit_per_query: 5000
   discover_service_name: []
+  discover_log_levels: false
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -2231,6 +2238,7 @@ limits_config:
   max_line_size: 256000
   max_entries_limit_per_query: 5000
   discover_service_name: []
+  discover_log_levels: false
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -2671,6 +2679,7 @@ limits_config:
   max_line_size: 256000
   max_entries_limit_per_query: 5000
   discover_service_name: []
+  discover_log_levels: false
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -2996,6 +3005,7 @@ limits_config:
   max_line_size: 256000
   max_entries_limit_per_query: 5000
   discover_service_name: []
+  discover_log_levels: false
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -3494,6 +3504,7 @@ limits_config:
   max_line_size: 256000
   max_entries_limit_per_query: 5000
   discover_service_name: []
+  discover_log_levels: false
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -3756,6 +3767,7 @@ limits_config:
   max_line_size: 256000
   max_entries_limit_per_query: 5000
   discover_service_name: []
+  discover_log_levels: false
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -4019,6 +4031,7 @@ limits_config:
   max_line_size: 256000
   max_entries_limit_per_query: 5000
   discover_service_name: []
+  discover_log_levels: false
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -4283,6 +4296,7 @@ limits_config:
   max_line_size: 256000
   max_entries_limit_per_query: 5000
   discover_service_name: []
+  discover_log_levels: false
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -4583,6 +4597,7 @@ limits_config:
   max_line_size: 256000
   max_entries_limit_per_query: 5000
   discover_service_name: []
+  discover_log_levels: false
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -4881,6 +4896,7 @@ limits_config:
   max_line_size: 256000
   max_entries_limit_per_query: 5000
   discover_service_name: []
+  discover_log_levels: false
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -5380,6 +5396,7 @@ limits_config:
   max_line_size: 256000
   max_entries_limit_per_query: 5000
   discover_service_name: []
+  discover_log_levels: false
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -5557,6 +5574,7 @@ limits_config:
   max_line_size: 256000
   max_entries_limit_per_query: 5000
   discover_service_name: []
+  discover_log_levels: false
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -5727,6 +5745,7 @@ limits_config:
   max_line_size: 256000
   max_entries_limit_per_query: 5000
   discover_service_name: []
+  discover_log_levels: false
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -6118,6 +6137,7 @@ limits_config:
   max_line_size: 256000
   max_entries_limit_per_query: 5000
   discover_service_name: []
+  discover_log_levels: false
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h

--- a/operator/internal/manifests/internal/config/loki-config.yaml
+++ b/operator/internal/manifests/internal/config/loki-config.yaml
@@ -198,6 +198,7 @@ limits_config:
   max_line_size: {{ .Stack.Limits.Global.IngestionLimits.MaxLineSize }}
   max_entries_limit_per_query: {{ .Stack.Limits.Global.QueryLimits.MaxEntriesLimitPerQuery }}
   discover_service_name: []
+  discover_log_levels: {{ .DiscoverLogLevels }}
   max_global_streams_per_user: {{ .Stack.Limits.Global.IngestionLimits.MaxGlobalStreamsPerTenant }}
   max_chunks_per_query: {{ .Stack.Limits.Global.QueryLimits.MaxChunksPerQuery }}
   max_query_length: 721h

--- a/operator/internal/manifests/internal/config/options.go
+++ b/operator/internal/manifests/internal/config/options.go
@@ -29,6 +29,7 @@ type Options struct {
 	MaxConcurrent         MaxConcurrent
 	WriteAheadLog         WriteAheadLog
 	EnableRemoteReporting bool
+	DiscoverLogLevels     bool
 	Shippers              []string
 
 	ObjectStorage storage.Options


### PR DESCRIPTION
**What this PR does / why we need it**:

Loki recently introduced an automatic log level discovery, that aims to provide the log level of an entry if it was not provided. For OpenShift Logging this causes confusion because the collector already has a log level discovery included, but it uses a different field, so there are sometimes two disagreeing log levels on an event which is confusing.

This PR disables the log level discovery for OpenShift tenancy modes to avoid this issue.

**Which issue(s) this PR fixes**:

[LOG-6286](https://issues.redhat.com/browse/LOG-6286)

**Special notes for your reviewer**:

- This also disables the discovery for the `openshift-network` tenancy mode, because that mode uses Loki for non-logging data, which does not need this field.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
