### PR TITLE
chore: Add query hash to stats-report log line on bloom gateway

### DIFF
--- a/pkg/bloomgateway/bloomgateway.go
+++ b/pkg/bloomgateway/bloomgateway.go
@@ -169,13 +169,12 @@ func (g *Gateway) FilterChunkRefs(ctx context.Context, req *logproto.FilterChunk
 
 	sp, ctx := opentracing.StartSpanFromContext(ctx, "bloomgateway.FilterChunkRefs")
 	stats, ctx := ContextWithEmptyStats(ctx)
-	logger := spanlogger.FromContextWithFallback(
-		ctx,
-		utillog.WithContext(ctx, g.logger),
-	)
+	logger := spanlogger.FromContextWithFallback(ctx, utillog.WithContext(ctx, g.logger))
+
+	queryHash := req.Plan.Hash()
 
 	defer func() {
-		level.Info(logger).Log(stats.KVArgs()...)
+		level.Info(logger).Log(append([]any{"msg", "stats-report", "queryhash", queryHash}, stats.KVArgs()...))
 		sp.Finish()
 	}()
 

--- a/pkg/bloomgateway/stats.go
+++ b/pkg/bloomgateway/stats.go
@@ -67,7 +67,6 @@ func (s *Stats) KVArgs() []any {
 	filterRatio := float64(s.ChunksFiltered) / float64(max(s.ChunksRequested, 1))
 
 	return []any{
-		"msg", "stats-report",
 		"status", s.Status,
 		"tasks", s.NumTasks,
 		"matchers", s.NumMatchers,

--- a/pkg/logql/engine_test.go
+++ b/pkg/logql/engine_test.go
@@ -2610,7 +2610,10 @@ func TestHashingStability(t *testing.T) {
 		{`sum (count_over_time({app="myapp",env="myenv"} |= "error" |= "metrics.go" | logfmt [10s])) by(query_hash)`},
 	} {
 		params.queryString = test.qs
-		expectedQueryHash := util.HashedQuery(test.qs)
+		normalizedQueryString := syntax.MustParseExpr(test.qs).String()
+		expectedQueryHash := util.HashedQuery(normalizedQueryString)
+
+		t.Logf("\nOriginal query:   %s\nNormalized query: %s", test.qs, normalizedQueryString)
 
 		// check that both places will end up having the same query hash, even though they're emitting different log lines.
 		withEngine := queryWithEngine()

--- a/pkg/logql/metrics.go
+++ b/pkg/logql/metrics.go
@@ -130,7 +130,7 @@ func RecordRangeAndInstantQueryMetrics(
 	}
 
 	var (
-		query       = p.QueryString()
+		query       = syntax.MustParseExpr(p.QueryString()).String()
 		hashedQuery = util.HashedQuery(query)
 	)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

In order to correlate bloom filter query stats to individual queries, this PR adds the query hash to the `stats-report` log line.

**Special notes for your reviewer**:

On the bloom gateway we have the query plan (AST) from which we can derive the query string and subsequently the query hash. However, this results into a "normalized" query, whereas on the query frontend, when we log the `metrics.go` log line, we use the original query string to create the hash. This can cause different hashes for one and the same query. Therefore this PR also updates the metrics.go log line to use the hash from the normalized query string.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
