### PR TITLE
feat(kafka): Add partition-ingester to loki-mixin dashboards

### DIFF
--- a/production/loki-mixin/config.libsonnet
+++ b/production/loki-mixin/config.libsonnet
@@ -82,5 +82,9 @@
     meta_monitoring: {
       enabled: false,
     },
+
+    partition_ingester: {
+      enabled: false,
+    }
   },
 }

--- a/production/loki-mixin/config.libsonnet
+++ b/production/loki-mixin/config.libsonnet
@@ -85,6 +85,6 @@
 
     partition_ingester: {
       enabled: false,
-    }
+    },
   },
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Add partition-ingester to the loki-writes & loki-writes-resources dashboards.

* Enabled via the partition_ingester.enabled config.
* Panels are copied from the `ingester` section and adjusted for the partition ingester.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
