### PR TITLE
fix: More correctly report starting phase during kafka-reader startup

### DIFF
--- a/pkg/kafka/partition/reader.go
+++ b/pkg/kafka/partition/reader.go
@@ -477,7 +477,7 @@ func (p *Reader) recordFetchesMetrics(fetches kgo.Fetches) {
 	fetches.EachRecord(func(record *kgo.Record) {
 		numRecords++
 		delay := now.Sub(record.Timestamp).Seconds()
-		if p.lastProcessedOffset == -1 {
+		if p.Service.State() == services.Starting {
 			p.metrics.receiveDelayWhenStarting.Observe(delay)
 		} else {
 			p.metrics.receiveDelayWhenRunning.Observe(delay)


### PR DESCRIPTION
**What this PR does / why we need it**:
Separates starting/running phases of kafka reader based on service state

* We only emit a single datapoint for the startup phase in Kafka. Now we've implemented logic to delay startup until kafka is ready, I'm switching this to use the service state to better indicate how this happens.
