### PR TITLE
fix(blooms): Check length of tasks before accessing first element in slice

### DIFF
--- a/pkg/bloomgateway/bloomgateway.go
+++ b/pkg/bloomgateway/bloomgateway.go
@@ -200,9 +200,7 @@ func (g *Gateway) FilterChunkRefs(ctx context.Context, req *logproto.FilterChunk
 	// Shortcut if request does not contain filters
 	if len(matchers) == 0 {
 		stats.Status = labelSuccess
-		return &logproto.FilterChunkRefResponse{
-			ChunkRefs: req.Refs,
-		}, nil
+		return &logproto.FilterChunkRefResponse{ChunkRefs: req.Refs}, nil
 	}
 
 	blocks := make([]bloomshipper.BlockRef, 0, len(req.Blocks))
@@ -218,9 +216,7 @@ func (g *Gateway) FilterChunkRefs(ctx context.Context, req *logproto.FilterChunk
 	// Shortcut if request does not contain blocks
 	if len(blocks) == 0 {
 		stats.Status = labelSuccess
-		return &logproto.FilterChunkRefResponse{
-			ChunkRefs: req.Refs,
-		}, nil
+		return &logproto.FilterChunkRefResponse{ChunkRefs: req.Refs}, nil
 	}
 
 	seriesByDay := partitionRequest(req)
@@ -232,6 +228,14 @@ func (g *Gateway) FilterChunkRefs(ctx context.Context, req *logproto.FilterChunk
 		"blocks", len(req.Blocks),
 		"series_requested", len(req.Refs),
 	)
+
+	// len(seriesByDay) should never be 0
+	// Not sure how this can happen, but there was a bug report
+	// https://github.com/grafana/loki/issues/14623
+	if len(seriesByDay) == 0 {
+		stats.Status = labelSuccess
+		return &logproto.FilterChunkRefResponse{ChunkRefs: req.Refs}, nil
+	}
 
 	if len(seriesByDay) > 1 {
 		stats.Status = labelFailure


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds a length check for the partitioned series before accessing the first element of the resulting slice.

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/loki/issues/14623


**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
