### PR TITLE
chore(operator): Bump netlify environment

### DIFF
--- a/operator/netlify.toml
+++ b/operator/netlify.toml
@@ -4,9 +4,9 @@
 
 [build.environment]
   # HUGO_VERSION = "..." is set by bingo which allows reproducible local environment.
-  NODE_VERSION = "15.5.1"
-  NPM_VERSION = "7.3.0"
-  GO_VERSION = "1.20.1"
+  NODE_VERSION = "22.10.0"
+  NPM_VERSION = "10.9.0"
+  GO_VERSION = "1.22.8"
 
 [context.production]
   command = "(env && make web) || (sleep 30; false)"


### PR DESCRIPTION
**What this PR does / why we need it**:
Bingo environment expected go1.22 to install `gen-crd-api-reference-docs-v0.0.3` but netlify is configured with go1.20. Solves:
```
10:51:17 AM: I1024 08:51:17.620955    6274 main.go:155] parsing go packages in directory github.com/grafana/loki/operator/api/loki/
10:51:17 AM: panic: runtime error: invalid memory address or nil pointer dereference
10:51:17 AM: [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x80bf14]
10:51:17 AM: goroutine 1 [running]:
10:51:17 AM: k8s.io/gengo/parser.(*Builder).AddDirRecursive(0xc00014f720, {0x7ffc609cd9b7, 0x2a})
10:51:17 AM: 	/opt/buildhome/.gimme_cache/gopath/pkg/mod/k8s.io/gengo@v0.0.0-20201203183100-97869a43a9d9/parser/parse.go:234 +0x114
10:51:17 AM: main.parseAPIPackages({0x7ffc609cd9b7?, 0x2a?})
10:51:17 AM: 	/opt/buildhome/.gimme_cache/gopath/pkg/mod/github.com/!via!q/gen-crd-api-reference-docs@v0.0.3/main.go:229 +0x49
10:51:17 AM: main.main()
10:51:17 AM: 	/opt/buildhome/.gimme_cache/gopath/pkg/mod/github.com/!via!q/gen-crd-api-reference-docs@v0.0.3/main.go:156 +0x208
10:51:17 AM: make: *** [Makefile:317: docs/operator/api.md] Error 2
```

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

Updates also the `NODE_VERSION` to use a modern and supported nodejs version.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
