### PR TITLE
chore: Disable digest updates for Loki renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -32,6 +32,9 @@
       "enabled": false
     }
   ],
+  "digest": {
+    "enabled": false
+  },
   "vulnerabilityAlerts": {
     "enabled": true,
     "addLabels": [


### PR DESCRIPTION
**What this PR does / why we need it**:
Digest updates tend to be ignored/closed, due to both their frequency and instability.  This turns off checking for digest updates within renovate.

```
renovate-config-validator renovate.json                        
 INFO: Validating renovate.json
 INFO: Config validated **successfully**
 ```
 
**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
