### PR TITLE
feat: hide __aggregated_metric__ in /series and /labels

### DIFF
--- a/pkg/distributor/validator.go
+++ b/pkg/distributor/validator.go
@@ -12,6 +12,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/loghttp/push"
 	"github.com/grafana/loki/v3/pkg/logproto"
 	"github.com/grafana/loki/v3/pkg/util"
+	"github.com/grafana/loki/v3/pkg/util/constants"
 	"github.com/grafana/loki/v3/pkg/validation"
 )
 
@@ -144,7 +145,7 @@ func (v Validator) ValidateEntry(ctx context.Context, vCtx validationContext, la
 }
 
 func (v Validator) IsAggregatedMetricStream(ls labels.Labels) bool {
-	return ls.Has(push.AggregatedMetricLabel)
+	return ls.Has(constants.AggregatedMetricLabel)
 }
 
 // Validate labels returns an error if the labels are invalid and if the stream is an aggregated metric stream

--- a/pkg/loghttp/push/push.go
+++ b/pkg/loghttp/push/push.go
@@ -73,11 +73,6 @@ var (
 	ErrRequestBodyTooLarge = errors.New("request body too large")
 )
 
-var (
-	ErrAllLogsFiltered     = errors.New("all logs lines filtered during parsing")
-	ErrRequestBodyTooLarge = errors.New("request body too large")
-)
-
 type TenantsRetention interface {
 	RetentionPeriodFor(userID string, lbs labels.Labels) time.Duration
 }

--- a/pkg/loghttp/push/push.go
+++ b/pkg/loghttp/push/push.go
@@ -63,10 +63,14 @@ var (
 )
 
 const (
-	applicationJSON       = "application/json"
-	LabelServiceName      = "service_name"
-	ServiceUnknown        = "unknown_service"
-	AggregatedMetricLabel = "__aggregated_metric__"
+	applicationJSON  = "application/json"
+	LabelServiceName = "service_name"
+	ServiceUnknown   = "unknown_service"
+)
+
+var (
+	ErrAllLogsFiltered     = errors.New("all logs lines filtered during parsing")
+	ErrRequestBodyTooLarge = errors.New("request body too large")
 )
 
 var (
@@ -318,7 +322,7 @@ func ParseLokiRequest(userID string, r *http.Request, limits Limits, maxRecvMsgS
 			return nil, nil, fmt.Errorf("couldn't parse labels: %w", err)
 		}
 
-		if lbs.Has(AggregatedMetricLabel) {
+		if lbs.Has(constants.AggregatedMetricLabel) {
 			pushStats.IsAggregatedMetric = true
 		}
 

--- a/pkg/pattern/aggregation/push.go
+++ b/pkg/pattern/aggregation/push.go
@@ -26,6 +26,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/logql/syntax"
 	"github.com/grafana/loki/v3/pkg/util"
 	"github.com/grafana/loki/v3/pkg/util/build"
+	"github.com/grafana/loki/v3/pkg/util/constants"
 
 	"github.com/grafana/dskit/backoff"
 
@@ -220,7 +221,7 @@ func (p *Push) buildPayload(ctx context.Context) ([]byte, error) {
 		})
 
 		if len(services) < serviceLimit {
-			services = append(services, lbls.Get(push.AggregatedMetricLabel))
+			services = append(services, lbls.Get(constants.AggregatedMetricLabel))
 		}
 	}
 

--- a/pkg/pattern/ingester_test.go
+++ b/pkg/pattern/ingester_test.go
@@ -282,7 +282,7 @@ func TestInstancePushAggregateMetrics(t *testing.T) {
 				lbs,
 			),
 			labels.New(
-				labels.Label{Name: loghttp_push.AggregatedMetricLabel, Value: "test_service"},
+				labels.Label{Name: constants.AggregatedMetricLabel, Value: "test_service"},
 			),
 			[]logproto.LabelAdapter{
 				{Name: constants.LevelLabel, Value: constants.LogLevelInfo},
@@ -301,7 +301,7 @@ func TestInstancePushAggregateMetrics(t *testing.T) {
 				lbs2,
 			),
 			labels.New(
-				labels.Label{Name: loghttp_push.AggregatedMetricLabel, Value: "foo_service"},
+				labels.Label{Name: constants.AggregatedMetricLabel, Value: "foo_service"},
 			),
 			[]logproto.LabelAdapter{
 				{Name: constants.LevelLabel, Value: constants.LogLevelError},
@@ -320,7 +320,7 @@ func TestInstancePushAggregateMetrics(t *testing.T) {
 				lbs3,
 			),
 			labels.New(
-				labels.Label{Name: loghttp_push.AggregatedMetricLabel, Value: "baz_service"},
+				labels.Label{Name: constants.AggregatedMetricLabel, Value: "baz_service"},
 			),
 			[]logproto.LabelAdapter{
 				{Name: constants.LevelLabel, Value: constants.LogLevelError},

--- a/pkg/pattern/ingester_test.go
+++ b/pkg/pattern/ingester_test.go
@@ -21,8 +21,6 @@ import (
 
 	"github.com/grafana/loki/v3/pkg/pattern/drain"
 
-	loghttp_push "github.com/grafana/loki/v3/pkg/loghttp/push"
-
 	"github.com/grafana/loki/pkg/push"
 )
 

--- a/pkg/pattern/instance.go
+++ b/pkg/pattern/instance.go
@@ -327,7 +327,7 @@ func (i *instance) writeAggregatedMetrics(
 	}
 
 	newLbls := labels.Labels{
-		labels.Label{Name: push.AggregatedMetricLabel, Value: service},
+		labels.Label{Name: constants.AggregatedMetricLabel, Value: service},
 	}
 
 	sturcturedMetadata := []logproto.LabelAdapter{

--- a/pkg/pattern/tee_service.go
+++ b/pkg/pattern/tee_service.go
@@ -437,7 +437,7 @@ func (ts *TeeService) Duplicate(tenant string, streams []distributor.KeyedStream
 			continue
 		}
 
-		if lbls.Has(push.AggregatedMetricLabel) {
+		if lbls.Has(constants.AggregatedMetricLabel) {
 			continue
 		}
 

--- a/pkg/pattern/tee_service.go
+++ b/pkg/pattern/tee_service.go
@@ -18,10 +18,10 @@ import (
 	"github.com/grafana/dskit/user"
 
 	"github.com/grafana/loki/v3/pkg/distributor"
-	"github.com/grafana/loki/v3/pkg/loghttp/push"
 	"github.com/grafana/loki/v3/pkg/logproto"
 	"github.com/grafana/loki/v3/pkg/logql/syntax"
 	"github.com/grafana/loki/v3/pkg/runtime"
+	"github.com/grafana/loki/v3/pkg/util/constants"
 	"github.com/grafana/loki/v3/pkg/util/spanlogger"
 
 	ring_client "github.com/grafana/dskit/ring/client"

--- a/pkg/querier/http.go
+++ b/pkg/querier/http.go
@@ -198,7 +198,7 @@ func (q *QuerierAPI) SeriesHandler(ctx context.Context, req *logproto.SeriesRequ
 	status, _ := serverutil.ClientHTTPStatusAndError(err)
 	logql.RecordSeriesQueryMetrics(ctx, utillog.Logger, req.Start, req.End, req.Groups, strconv.Itoa(status), req.GetShards(), statResult)
 
-	// filter the repsonse to catch the empty matcher case
+	// filter the response to catch the empty matcher case
 	if !aggMetricsRequestedInAnyGroup && q.metricAggregationEnabled(ctx) {
 		return q.filterAggregatedMetricsFromSeriesResp(resp), statResult, err
 	}
@@ -345,7 +345,7 @@ func (q *QuerierAPI) filterAggregatedMetricsFromSeriesResp(resp *logproto.Series
 		}
 
 		if slices.Contains(keys, constants.AggregatedMetricLabel) {
-			slices.Delete(resp.Series, i, i+1)
+			resp.Series = slices.Delete(resp.Series, i, i+1)
 			i--
 		}
 	}

--- a/pkg/querier/http_test.go
+++ b/pkg/querier/http_test.go
@@ -207,7 +207,7 @@ func TestSeriesHandler(t *testing.T) {
 		require.JSONEq(t, expected, res.Body.String())
 	})
 
-	t.Run("ignores __aggregated_metric__ series unless explicitly requested", func(t *testing.T) {
+	t.Run("ignores __aggregated_metric__ series, when possible, unless explicitly requested", func(t *testing.T) {
 		ret := func() *logproto.SeriesResponse {
 			return &logproto.SeriesResponse{
 				Series: []logproto.SeriesIdentifier{},
@@ -224,8 +224,10 @@ func TestSeriesHandler(t *testing.T) {
 			expectedGroups []string
 		}{
 			{
+				// we can't add the negated __aggregated_metric__ matcher to an empty matcher set,
+				// as that will produce an invalid query
 				match:          "{}",
-				expectedGroups: []string{fmt.Sprintf(`{%s=""}`, constants.AggregatedMetricLabel)},
+				expectedGroups: []string{},
 			},
 			{
 				match:          `{foo="bar"}`,

--- a/pkg/querier/limits/definitions.go
+++ b/pkg/querier/limits/definitions.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/grafana/loki/v3/pkg/logql"
+	"github.com/grafana/loki/v3/pkg/pattern/aggregation"
 )
 
 type TimeRangeLimits interface {
@@ -14,6 +15,7 @@ type TimeRangeLimits interface {
 
 type Limits interface {
 	logql.Limits
+	aggregation.Limits
 	TimeRangeLimits
 	QueryTimeout(context.Context, string) time.Duration
 	MaxStreamsMatchersPerQuery(context.Context, string) int

--- a/pkg/querier/limits/validation.go
+++ b/pkg/querier/limits/validation.go
@@ -12,8 +12,8 @@ import (
 	"github.com/grafana/dskit/tenant"
 	"github.com/prometheus/common/model"
 
-	"github.com/grafana/loki/v3/pkg/loghttp/push"
 	"github.com/grafana/loki/v3/pkg/logql"
+	"github.com/grafana/loki/v3/pkg/util/constants"
 	"github.com/grafana/loki/v3/pkg/util/httpreq"
 	"github.com/grafana/loki/v3/pkg/util/spanlogger"
 	util_validation "github.com/grafana/loki/v3/pkg/util/validation"
@@ -58,7 +58,7 @@ func ValidateAggregatedMetricQuery(ctx context.Context, req logql.QueryParams) e
 	matchers := selector.Matchers()
 
 	for _, matcher := range matchers {
-		if matcher.Name == push.AggregatedMetricLabel {
+		if matcher.Name == constants.AggregatedMetricLabel {
 			isAggregatedMetricQuery = true
 			break
 		}

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -62,6 +62,7 @@ type Config struct {
 	MultiTenantQueriesEnabled     bool             `yaml:"multi_tenant_queries_enabled"`
 	PerRequestLimitsEnabled       bool             `yaml:"per_request_limits_enabled"`
 	QueryPartitionIngesters       bool             `yaml:"query_partition_ingesters" category:"experimental"`
+	MetricAggregationEnabled      bool             `yaml:"_" doc:"hidden"`
 }
 
 // RegisterFlags register flags.

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -62,7 +62,6 @@ type Config struct {
 	MultiTenantQueriesEnabled     bool             `yaml:"multi_tenant_queries_enabled"`
 	PerRequestLimitsEnabled       bool             `yaml:"per_request_limits_enabled"`
 	QueryPartitionIngesters       bool             `yaml:"query_partition_ingesters" category:"experimental"`
-	MetricAggregationEnabled      bool             `yaml:"_" doc:"hidden"`
 }
 
 // RegisterFlags register flags.

--- a/pkg/querier/testutil/limits.go
+++ b/pkg/querier/testutil/limits.go
@@ -18,6 +18,7 @@ type MockLimits struct {
 	MaxEntriesLimitPerQueryVal    int
 	MaxStreamsMatchersPerQueryVal int
 	EnableMultiVariantQueriesVal  bool
+	MetricAggregationEnabledVal   bool
 }
 
 func (m *MockLimits) EnableMultiVariantQueries(_ string) bool {
@@ -58,4 +59,8 @@ func (m *MockLimits) MaxStreamsMatchersPerQuery(_ context.Context, _ string) int
 
 func (m *MockLimits) BlockedQueries(_ context.Context, _ string) []*validation.BlockedQuery {
 	return nil
+}
+
+func (m *MockLimits) MetricAggregationEnabled(_ string) bool {
+	return m.MetricAggregationEnabledVal
 }

--- a/pkg/util/constants/aggregated_metrics.go
+++ b/pkg/util/constants/aggregated_metrics.go
@@ -1,0 +1,5 @@
+package constants
+
+const (
+	AggregatedMetricLabel = "__aggregated_metric__"
+)


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR removes `{__aggregated_metric=~".+"}` streams from the `/series` endpoint, unless an `__aggregated_metric__` matcher is explicitly requested. It does the same for `/labels`, so `__aggregated_metric__` will not appear in a `/labels` response, but you can still request `/labels/__aggregated_metric__/values`.

This will alleviate confusion for people using a tool like `logcli series --analyze-labels` for cardinatlity analysis.

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
