### PR TITLE
feat(blooms): Only write key and key=value to blooms

### DIFF
--- a/docs/sources/operations/bloom-filters.md
+++ b/docs/sources/operations/bloom-filters.md
@@ -176,10 +176,10 @@ If there are new TSDB files or any of them have changed, the planner will create
 The builder pulls a task from the planner's queue and processes the containing streams and chunks.
 For a given stream, the builder will iterate through all the log lines inside its new chunks and build a bloom for the stream.
 In case of changes for a previously processed TSDB file, builders will try to reuse blooms from existing blocks instead of building new ones from scratch.
-The builder converts structured metadata from each log line of each chunk of a stream and appends the hash of each key, value, and key-value pair to the bloom, followed by the hashes combined with the chunk identifier.
+The builder converts structured metadata from each log line of each chunk of a stream and appends the hash of each key, and key-value pair to the bloom, followed by the hashes combined with the chunk identifier.
 The first set of hashes allows gateways to skip whole streams, while the latter is for skipping individual chunks.
 
-For example, given structured metadata `foo=bar` in the chunk `c6dj8g`, we append to the stream bloom the following hashes: `hash("foo")`, `hash("bar")`, `hash("foo=bar")`, `hash("c6dj8g" + "foo")` ... `hash("c6dj8g" + "foo=bar")`.
+For example, given structured metadata `foo=bar` in the chunk `c6dj8g`, we append to the stream bloom the following hashes: `hash("foo")`, `hash("foo=bar")`, `hash("c6dj8g" + "foo")` and `hash("c6dj8g" + "foo=bar")`.
 
 ## Query sharding
 

--- a/pkg/storage/bloom/v1/tokenizer.go
+++ b/pkg/storage/bloom/v1/tokenizer.go
@@ -25,7 +25,6 @@ func (t *StructuredMetadataTokenizer) Tokens(kv push.LabelAdapter) iter.Iterator
 	combined := fmt.Sprintf("%s=%s", kv.Name, kv.Value)
 	t.tokens = append(t.tokens[:0],
 		kv.Name, t.prefix+kv.Name,
-		kv.Value, t.prefix+kv.Value,
 		combined, t.prefix+combined,
 	)
 	return iter.NewSliceIter(t.tokens)

--- a/pkg/storage/bloom/v1/tokenizer_test.go
+++ b/pkg/storage/bloom/v1/tokenizer_test.go
@@ -14,7 +14,7 @@ func TestStructuredMetadataTokenizer(t *testing.T) {
 	tokenizer := NewStructuredMetadataTokenizer("chunk")
 
 	metadata := push.LabelAdapter{Name: "pod", Value: "loki-1"}
-	expected := []string{"pod", "chunkpod", "loki-1", "chunkloki-1", "pod=loki-1", "chunkpod=loki-1"}
+	expected := []string{"pod", "chunkpod", "pod=loki-1", "chunkpod=loki-1"}
 
 	tokenIter := tokenizer.Tokens(metadata)
 	got, err := v2.Collect(tokenIter)


### PR DESCRIPTION
**What this PR does / why we need it**:

We can avoid adding the plain value of a structured metadata field to the blooms.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
