### PR TITLE
chore: add jaeger mixin to pattern ingester container

### DIFF
--- a/production/ksonnet/loki/patterns.libsonnet
+++ b/production/ksonnet/loki/patterns.libsonnet
@@ -30,7 +30,8 @@ local k = import 'ksonnet-util/kausal.libsonnet';
     container.mixin.readinessProbe.withTimeoutSeconds(1) +
     k.util.resourcesRequests('1', '7Gi') +
     k.util.resourcesLimits('2', '14Gi') +
-    container.withEnvMixin($._config.commonEnvs),
+    container.withEnvMixin($._config.commonEnvs) +
+    $.jaeger_mixin,
 
 
   pattern_ingester_statefulset:


### PR DESCRIPTION
**What this PR does / why we need it**:

Add jaeger mixing to get tracing info from pattern ingester container

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
