### PR TITLE
feat: add gauge to track the partition_id

### DIFF
--- a/pkg/kafka/partition/metrics.go
+++ b/pkg/kafka/partition/metrics.go
@@ -12,6 +12,7 @@ import (
 )
 
 type readerMetrics struct {
+	partition         prometheus.Gauge
 	phase             *prometheus.GaugeVec
 	receiveDelay      *prometheus.HistogramVec
 	recordsPerFetch   prometheus.Histogram
@@ -25,6 +26,10 @@ type readerMetrics struct {
 // newReaderMetrics initializes and returns a new set of metrics for the PartitionReader.
 func newReaderMetrics(r prometheus.Registerer) readerMetrics {
 	return readerMetrics{
+		partition: promauto.With(r).NewGauge(prometheus.GaugeOpts{
+			Name: "loki_ingest_storage_reader_partition_id",
+			Help: "The partition ID assigned to this reader.",
+		}),
 		phase: promauto.With(r).NewGaugeVec(prometheus.GaugeOpts{
 			Name: "loki_ingest_storage_reader_phase",
 			Help: "The current phase of the consumer.",
@@ -60,12 +65,14 @@ func newReaderMetrics(r prometheus.Registerer) readerMetrics {
 	}
 }
 
-func (m *readerMetrics) reportStarting() {
+func (m *readerMetrics) reportStarting(partitionID int32) {
+	m.partition.Set(float64(partitionID))
 	m.phase.WithLabelValues(phaseStarting).Set(1)
 	m.phase.WithLabelValues(phaseRunning).Set(0)
 }
 
-func (m *readerMetrics) reportRunning() {
+func (m *readerMetrics) reportRunning(partitionID int32) {
+	m.partition.Set(float64(partitionID))
 	m.phase.WithLabelValues(phaseStarting).Set(0)
 	m.phase.WithLabelValues(phaseRunning).Set(1)
 }

--- a/pkg/kafka/partition/reader.go
+++ b/pkg/kafka/partition/reader.go
@@ -99,7 +99,7 @@ func (p *Reader) start(ctx context.Context) error {
 	if err != nil {
 		return errors.Wrap(err, "creating kafka reader client")
 	}
-	p.metrics.reportStarting()
+	p.metrics.reportStarting(p.partitionID)
 
 	// We manage our commits manually, so we must fetch the last offset for our consumer group to find out where to read from.
 	lastCommittedOffset := p.fetchLastCommittedOffset(ctx)
@@ -142,7 +142,7 @@ func (p *Reader) start(ctx context.Context) error {
 // data from Kafka, and send it to the consumer.
 func (p *Reader) run(ctx context.Context) error {
 	level.Info(p.logger).Log("msg", "starting partition reader", "partition", p.partitionID, "consumer_group", p.consumerGroup)
-	p.metrics.reportRunning()
+	p.metrics.reportRunning(p.partitionID)
 
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit adds a gauge to the reader metrics to track the partition_id. It will be used in dashboards to observe the number of starting and running ingesters per partition.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
