### PR TITLE
fix: move partition_id into label to make PromQL easier

### DIFF
--- a/pkg/kafka/partition/metrics.go
+++ b/pkg/kafka/partition/metrics.go
@@ -2,6 +2,7 @@ package partition
 
 import (
 	"math"
+	"strconv"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -12,7 +13,7 @@ import (
 )
 
 type readerMetrics struct {
-	partition         prometheus.Gauge
+	partition         *prometheus.GaugeVec
 	phase             *prometheus.GaugeVec
 	receiveDelay      *prometheus.HistogramVec
 	recordsPerFetch   prometheus.Histogram
@@ -26,10 +27,10 @@ type readerMetrics struct {
 // newReaderMetrics initializes and returns a new set of metrics for the PartitionReader.
 func newReaderMetrics(r prometheus.Registerer) readerMetrics {
 	return readerMetrics{
-		partition: promauto.With(r).NewGauge(prometheus.GaugeOpts{
-			Name: "loki_ingest_storage_reader_partition_id",
+		partition: promauto.With(r).NewGaugeVec(prometheus.GaugeOpts{
+			Name: "loki_ingest_storage_reader_partition",
 			Help: "The partition ID assigned to this reader.",
-		}),
+		}, []string{"id"}),
 		phase: promauto.With(r).NewGaugeVec(prometheus.GaugeOpts{
 			Name: "loki_ingest_storage_reader_phase",
 			Help: "The current phase of the consumer.",
@@ -66,13 +67,13 @@ func newReaderMetrics(r prometheus.Registerer) readerMetrics {
 }
 
 func (m *readerMetrics) reportStarting(partitionID int32) {
-	m.partition.Set(float64(partitionID))
+	m.partition.WithLabelValues(strconv.Itoa(int(partitionID))).Set(1)
 	m.phase.WithLabelValues(phaseStarting).Set(1)
 	m.phase.WithLabelValues(phaseRunning).Set(0)
 }
 
 func (m *readerMetrics) reportRunning(partitionID int32) {
-	m.partition.Set(float64(partitionID))
+	m.partition.WithLabelValues(strconv.Itoa(int(partitionID))).Set(1)
 	m.phase.WithLabelValues(phaseStarting).Set(0)
 	m.phase.WithLabelValues(phaseRunning).Set(1)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Moves the `partition_id` from the value to a label to make PromQL counts easier.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
