### PR TITLE
chore: Update docs, dockerfiles to use latest versions of promtail&loki

### DIFF
--- a/clients/cmd/fluentd/docker/docker-compose.yml
+++ b/clients/cmd/fluentd/docker/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   loki:
     build:

--- a/docs/sources/send-data/promtail/installation.md
+++ b/docs/sources/send-data/promtail/installation.md
@@ -30,7 +30,7 @@ See the instructions [here](https://grafana.com/docs/loki/<LOKI_VERSION>/setup/i
 1. Make sure to modify the tag to the most recent version.
 
     ```bash
-    docker pull grafana/promtail:3.0.0
+    docker pull grafana/promtail:3.2.1
     ```
 
 1. Create your Promtail configuration file in a file called `promtail-config.yaml`. Refer to the [Promtail configuration reference](https://grafana.com/docs/loki/<LOKI_VERSION>/send-data/promtail/configuration/) for more details.
@@ -38,7 +38,7 @@ See the instructions [here](https://grafana.com/docs/loki/<LOKI_VERSION>/setup/i
 1. Note that you will need to replace `<local-path>` in the commands with your local path.
 
     ```bash
-    docker run -v <local-path>:/mnt/config -v /var/log:/var/log --link loki grafana/promtail:3.0.0 --config.file=/mnt/config/promtail-config.yaml
+    docker run -v <local-path>:/mnt/config -v /var/log:/var/log --link loki grafana/promtail:3.2.1 --config.file=/mnt/config/promtail-config.yaml
     ```
 
 ## Install on MacOS with Homebrew

--- a/docs/sources/setup/install/docker.md
+++ b/docs/sources/setup/install/docker.md
@@ -37,8 +37,8 @@ The configuration files associated with these installation instructions run Loki
 1. Copy and paste the following commands into your command line to start the Docker containers using the configuration files you downloaded in the previous step.
 
     ```bash
-    docker run --name loki -d -v $(pwd):/mnt/config -p 3100:3100 grafana/loki:3.0.0 -config.file=/mnt/config/loki-config.yaml
-    docker run --name promtail -d -v $(pwd):/mnt/config -v /var/log:/var/log --link loki grafana/promtail:3.0.0 -config.file=/mnt/config/promtail-config.yaml
+    docker run --name loki -d -v $(pwd):/mnt/config -p 3100:3100 grafana/loki:3.2.1 -config.file=/mnt/config/loki-config.yaml
+    docker run --name promtail -d -v $(pwd):/mnt/config -v /var/log:/var/log --link loki grafana/promtail:3.2.1 -config.file=/mnt/config/promtail-config.yaml
     ```
 
     {{< admonition type="note" >}}
@@ -56,8 +56,8 @@ The configuration files associated with these installation instructions run Loki
     ```bash
 
     CONTAINER ID   IMAGE                    COMMAND                  CREATED              STATUS              PORTS                                       NAMES
-    9485de9ad351   grafana/promtail:3.0.0   "/usr/bin/promtail -…"   About a minute ago   Up About a minute                                               promtail
-    cece1df84519   grafana/loki:3.0.0       "/usr/bin/loki -conf…"   About a minute ago   Up About a minute   0.0.0.0:3100->3100/tcp, :::3100->3100/tcp   loki
+    9485de9ad351   grafana/promtail:3.2.1   "/usr/bin/promtail -…"   About a minute ago   Up About a minute                                               promtail
+    cece1df84519   grafana/loki:3.2.1       "/usr/bin/loki -conf…"   About a minute ago   Up About a minute   0.0.0.0:3100->3100/tcp, :::3100->3100/tcp   loki
     ```
 
 1. Verify that Loki is up and running.
@@ -78,8 +78,8 @@ wget https://raw.githubusercontent.com/grafana/loki/v3.0.0/clients/cmd/promtail/
 1. Copy and paste the following commands into your command line to start the Docker containers using the configuration files you downloaded in the previous step. Note that you will need to replace the `<local-path>` in the commands with your local path.
 
 ```bash
-docker run --name loki -v <local-path>:/mnt/config -p 3100:3100 grafana/loki:3.0.0 --config.file=/mnt/config/loki-config.yaml
-docker run -v <local-path>:/mnt/config -v /var/log:/var/log --link loki grafana/promtail:3.0.0 --config.file=/mnt/config/promtail-config.yaml
+docker run --name loki -v <local-path>:/mnt/config -p 3100:3100 grafana/loki:3.2.1 --config.file=/mnt/config/loki-config.yaml
+docker run -v <local-path>:/mnt/config -v /var/log:/var/log --link loki grafana/promtail:3.2.1 --config.file=/mnt/config/promtail-config.yaml
 ```
 
 1. Verify that Loki is up and running.

--- a/examples/getting-started/docker-compose.yaml
+++ b/examples/getting-started/docker-compose.yaml
@@ -1,12 +1,10 @@
 ---
-version: "3"
-
 networks:
   loki:
 
 services:
   read:
-    image: grafana/loki:3.1.0
+    image: grafana/loki:latest
     command: "-config.file=/etc/loki/config.yaml -target=read"
     ports:
       - 3101:3100
@@ -27,7 +25,7 @@ services:
           - loki
 
   write:
-    image: grafana/loki:3.1.0
+    image: grafana/loki:latest
     command: "-config.file=/etc/loki/config.yaml -target=write"
     ports:
       - 3102:3100
@@ -121,7 +119,7 @@ services:
       - loki
 
   backend:
-    image: grafana/loki:3.1.0
+    image: grafana/loki:latest
     volumes:
       - ./loki-config.yaml:/etc/loki/config.yaml
     ports:

--- a/production/docker-compose.yaml
+++ b/production/docker-compose.yaml
@@ -1,11 +1,9 @@
-version: "3"
-
 networks:
   loki:
 
 services:
   loki:
-    image: grafana/loki:2.9.10
+    image: grafana/loki:latest
     ports:
       - "3100:3100"
     command: -config.file=/etc/loki/local-config.yaml
@@ -13,7 +11,7 @@ services:
       - loki
 
   promtail:
-    image: grafana/promtail:2.9.10
+    image: grafana/promtail:latest
     volumes:
       - /var/log:/var/log
     command: -config.file=/etc/promtail/config.yml

--- a/production/docker/docker-compose.yaml
+++ b/production/docker/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 networks:
   loki:
 
@@ -14,7 +12,7 @@ services:
   # Loki would not have permissions to create the directories.
   # Therefore the init container changes permissions of the mounted directory.
   init:
-    image: &lokiImage grafana/loki:2.9.10
+    image: &lokiImage grafana/loki:latest
     user: root
     entrypoint:
       - "chown"
@@ -71,7 +69,7 @@ services:
       - ./loki/:/var/log/
 
   promtail:
-    image: grafana/promtail:2.9.10
+    image: grafana/promtail:latest
     volumes:
       - ./loki/:/var/log/
       - ./config:/etc/promtail/
@@ -104,7 +102,7 @@ services:
       - loki
 
   loki-gateway:
-    image: nginx:1.27
+    image: nginx:latest
     volumes:
       - ./config/nginx.conf:/etc/nginx/nginx.conf
     ports:

--- a/tools/dev/loki-tsdb-storage-s3/docker-compose.yml
+++ b/tools/dev/loki-tsdb-storage-s3/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.4'
 services:
   consul:
     logging: &logging

--- a/tools/kafka/plain/docker-compose.yml
+++ b/tools/kafka/plain/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '2'
 services:
   zookeeper:
     image: wurstmeister/zookeeper

--- a/tools/kafka/sasl-plain/docker-compose.yml
+++ b/tools/kafka/sasl-plain/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '2'
 services:
   zookeeper:
     image: confluentinc/cp-zookeeper:latest
@@ -14,7 +13,7 @@ services:
       - ./conf:/etc/kafka/secrets
 
   kafka:
-    image: confluentinc/cp-kafka:6.2.15
+    image: confluentinc/cp-kafka:latest
     depends_on:
       - zookeeper
     ports:

--- a/tools/kafka/sasl-scram/docker-compose.yml
+++ b/tools/kafka/sasl-scram/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '2'
 services:
   zookeeper:
     image: confluentinc/cp-zookeeper:latest
@@ -14,7 +13,7 @@ services:
       - ./conf:/etc/kafka/secrets
 
   kafka:
-    image: confluentinc/cp-kafka:6.2.15
+    image: confluentinc/cp-kafka:latest
     depends_on:
       - zookeeper
     ports:

--- a/tools/kafka/sasl-ssl/docker-compose.yml
+++ b/tools/kafka/sasl-ssl/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '2'
 services:
   zookeeper:
     image: confluentinc/cp-zookeeper:latest
@@ -14,7 +13,7 @@ services:
       - ./conf:/etc/kafka/secrets
 
   kafka:
-    image: confluentinc/cp-kafka:6.2.15
+    image: confluentinc/cp-kafka:latest
     depends_on:
       - zookeeper
     ports:

--- a/tools/kafka/ssl/docker-compose.yml
+++ b/tools/kafka/ssl/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '2'
 services:
   zookeeper:
     image: confluentinc/cp-zookeeper:latest
@@ -9,7 +8,7 @@ services:
       ZOOKEEPER_CLIENT_PORT: 22181
 
   kafka:
-    image: confluentinc/cp-kafka:6.2.15
+    image: confluentinc/cp-kafka:latest
     depends_on:
       - zookeeper
     ports:


### PR DESCRIPTION
Also, additionally removed the 'version' attribute from dockerfiles, since those are obsolete

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [X] Documentation added
- [ ] Tests updated
- [X] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
