### PR TITLE
feat: Improve pattern ingester tracing (backport k226)

### DIFF
--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -682,6 +682,7 @@ func (t *Loki) initPatternIngesterTee() (services.Service, error) {
 		t.Cfg.Pattern,
 		t.Overrides,
 		t.PatternRingClient,
+		t.tenantConfigs,
 		t.Cfg.MetricsNamespace,
 		prometheus.DefaultRegisterer,
 		logger,

--- a/pkg/pattern/aggregation/push.go
+++ b/pkg/pattern/aggregation/push.go
@@ -8,12 +8,14 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/golang/snappy"
+	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
@@ -160,7 +162,13 @@ func (p *Push) Stop() {
 }
 
 // buildPayload creates the snappy compressed protobuf to send to Loki
-func (p *Push) buildPayload() ([]byte, error) {
+func (p *Push) buildPayload(ctx context.Context) ([]byte, error) {
+	sp, _ := opentracing.StartSpanFromContext(
+		ctx,
+		"patternIngester.aggregation.Push.buildPayload",
+	)
+	defer sp.Finish()
+
 	entries := p.entries.reset()
 
 	entriesByStream := make(map[string][]logproto.Entry)
@@ -179,6 +187,14 @@ func (p *Push) buildPayload() ([]byte, error) {
 	}
 
 	streams := make([]logproto.Stream, 0, len(entriesByStream))
+
+	// limit the number of services to log to 1000
+	serviceLimit := len(entriesByStream)
+	if serviceLimit > 1000 {
+		serviceLimit = 1000
+	}
+
+	services := make([]string, 0, serviceLimit)
 	for s, entries := range entriesByStream {
 		lbls, err := syntax.ParseLabels(s)
 		if err != nil {
@@ -190,6 +206,10 @@ func (p *Push) buildPayload() ([]byte, error) {
 			Entries: entries,
 			Hash:    lbls.Hash(),
 		})
+
+		if len(services) < serviceLimit {
+			services = append(services, lbls.Get(push.AggregatedMetricLabel))
+		}
 	}
 
 	req := &logproto.PushRequest{
@@ -201,6 +221,14 @@ func (p *Push) buildPayload() ([]byte, error) {
 	}
 
 	payload = snappy.Encode(nil, payload)
+
+	sp.LogKV(
+		"event", "build aggregated metrics payload",
+		"num_service", len(entriesByStream),
+		"first_1k_services", strings.Join(services, ","),
+		"num_streams", len(streams),
+		"num_entries", len(entries),
+	)
 
 	return payload, nil
 }
@@ -221,7 +249,7 @@ func (p *Push) run(pushPeriod time.Duration) {
 			cancel()
 			return
 		case <-pushTicker.C:
-			payload, err := p.buildPayload()
+			payload, err := p.buildPayload(ctx)
 			if err != nil {
 				level.Error(p.logger).Log("msg", "failed to build payload", "err", err)
 				continue
@@ -265,9 +293,14 @@ func (p *Push) send(ctx context.Context, payload []byte) (int, error) {
 		err  error
 		resp *http.Response
 	)
+
 	// Set a timeout for the request
 	ctx, cancel := context.WithTimeout(ctx, p.httpClient.Timeout)
 	defer cancel()
+
+	sp, ctx := opentracing.StartSpanFromContext(ctx, "patternIngester.aggregation.Push.send")
+	defer sp.Finish()
+
 	req, err := http.NewRequestWithContext(ctx, "POST", p.lokiURL, bytes.NewReader(payload))
 	if err != nil {
 		return -1, fmt.Errorf("failed to create push request: %w", err)

--- a/pkg/pattern/tee_service.go
+++ b/pkg/pattern/tee_service.go
@@ -21,6 +21,8 @@ import (
 	"github.com/grafana/loki/v3/pkg/loghttp/push"
 	"github.com/grafana/loki/v3/pkg/logproto"
 	"github.com/grafana/loki/v3/pkg/logql/syntax"
+	"github.com/grafana/loki/v3/pkg/runtime"
+	"github.com/grafana/loki/v3/pkg/util/spanlogger"
 
 	ring_client "github.com/grafana/dskit/ring/client"
 )
@@ -28,6 +30,7 @@ import (
 type TeeService struct {
 	cfg        Config
 	limits     Limits
+	tenantCfgs *runtime.TenantConfigs
 	logger     log.Logger
 	ringClient RingClient
 	wg         *sync.WaitGroup
@@ -51,6 +54,7 @@ func NewTeeService(
 	cfg Config,
 	limits Limits,
 	ringClient RingClient,
+	tenantCfgs *runtime.TenantConfigs,
 	metricsNamespace string,
 	registerer prometheus.Registerer,
 	logger log.Logger,
@@ -86,6 +90,7 @@ func NewTeeService(
 		),
 		cfg:        cfg,
 		limits:     limits,
+		tenantCfgs: tenantCfgs,
 		ringClient: ringClient,
 
 		wg:           &sync.WaitGroup{},
@@ -293,10 +298,11 @@ func (ts *TeeService) sendBatch(ctx context.Context, clientRequest clientRequest
 		// are gathered by this request
 		_ = instrument.CollectedRequest(
 			ctx,
-			"FlushTeedLogsToPatternIngested",
+			"FlushTeedLogsToPatternIngester",
 			ts.sendDuration,
 			instrument.ErrorCode,
 			func(ctx context.Context) error {
+				sp := spanlogger.FromContext(ctx)
 				client, err := ts.ringClient.GetClientFor(clientRequest.ingesterAddr)
 				if err != nil {
 					return err
@@ -313,6 +319,41 @@ func (ts *TeeService) sendBatch(ctx context.Context, clientRequest clientRequest
 					// Success here means the stream will be processed for both metrics and patterns
 					ts.ingesterAppends.WithLabelValues(clientRequest.ingesterAddr, "success").Inc()
 					ts.ingesterMetricAppends.WithLabelValues("success").Inc()
+
+					// limit logged labels to 1000
+					labelsLimit := len(req.Streams)
+					if labelsLimit > 1000 {
+						labelsLimit = 1000
+					}
+
+					labels := make([]string, 0, labelsLimit)
+					for _, stream := range req.Streams {
+						if len(labels) >= 1000 {
+							break
+						}
+
+						labels = append(labels, stream.Labels)
+					}
+
+					sp.LogKV(
+						"event", "forwarded push request to pattern ingester",
+						"num_streams", len(req.Streams),
+						"first_1k_labels", strings.Join(labels, ", "),
+						"tenant", clientRequest.tenant,
+					)
+
+					// this is basically the same as logging push request streams,
+					// so put it behind the same flag
+					if ts.tenantCfgs.LogPushRequestStreams(clientRequest.tenant) {
+						level.Debug(ts.logger).
+							Log(
+								"msg", "forwarded push request to pattern ingester",
+								"num_streams", len(req.Streams),
+								"first_1k_labels", strings.Join(labels, ", "),
+								"tenant", clientRequest.tenant,
+							)
+					}
+
 					return nil
 				}
 

--- a/pkg/pattern/tee_service_test.go
+++ b/pkg/pattern/tee_service_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/grafana/loki/v3/pkg/distributor"
 	"github.com/grafana/loki/v3/pkg/logproto"
+	"github.com/grafana/loki/v3/pkg/runtime"
 
 	"github.com/grafana/loki/pkg/push"
 )
@@ -51,6 +52,7 @@ func getTestTee(t *testing.T) (*TeeService, *mockPoolClient) {
 			metricAggregationEnabled: true,
 		},
 		ringClient,
+		runtime.DefaultTenantConfigs(),
 		"test",
 		nil,
 		log.NewNopLogger(),


### PR DESCRIPTION
Backport 80aec2548203957dbb834ba69e6d734d9054416d from #14707

---

**What this PR does / why we need it**:

We had to turn off aggregated metrics in a prod cluster because the `service_name` label being used for `__aggregated_metric__` had crazy cardinality, it was some huge JSON blob. This PR adds some more tracing and log signals to the aggregated metrics path through the pattern ingester so we can debug what's going on.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
