### PR TITLE
feat(TSDB): allow tsdb index creation in memory only

### DIFF
--- a/pkg/storage/stores/shipper/indexshipper/tsdb/builder.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/builder.go
@@ -169,7 +169,7 @@ func (b *Builder) Build(
 		}
 	}
 
-	if err := writer.Close(); err != nil {
+	if _, err := writer.Close(false); err != nil {
 		return id, err
 	}
 

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/builder.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/builder.go
@@ -111,7 +111,7 @@ func (b *Builder) Build(
 	name := fmt.Sprintf("%s-%x.staging", index.IndexFilename, rng)
 	tmpPath := filepath.Join(scratchDir, name)
 
-	var writer *index.Writer
+	var writer *index.Creator
 
 	writer, err = index.NewWriterWithVersion(ctx, b.version, tmpPath)
 	if err != nil {

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/chunk_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/chunk_test.go
@@ -433,7 +433,7 @@ func TestChunkEncodingRoundTrip(t *testing.T) {
 			} {
 				t.Run(fmt.Sprintf("version %d nChks %d pageSize %d", version, nChks, pageSize), func(t *testing.T) {
 					chks := mkChks(nChks)
-					var w Writer
+					var w Creator
 					w.Version = version
 					primary := encoding.EncWrap(tsdb_enc.Encbuf{B: make([]byte, 0)})
 					scratch := encoding.EncWrap(tsdb_enc.Encbuf{B: make([]byte, 0)})
@@ -583,7 +583,7 @@ func TestSearchWithPageMarkers(t *testing.T) {
 			},
 		} {
 			t.Run(fmt.Sprintf("%s-pagesize-%d", tc.desc, pageSize), func(t *testing.T) {
-				var w Writer
+				var w Creator
 				w.Version = FormatV3
 				primary := encoding.EncWrap(tsdb_enc.Encbuf{B: make([]byte, 0)})
 				scratch := encoding.EncWrap(tsdb_enc.Encbuf{B: make([]byte, 0)})
@@ -697,7 +697,7 @@ func TestDecoderChunkStats(t *testing.T) {
 				},
 			} {
 				t.Run(fmt.Sprintf("%s_version=%d_pageSize=%d", tc.desc, version, pageSize), func(t *testing.T) {
-					var w Writer
+					var w Creator
 					w.Version = version
 					primary := encoding.EncWrap(tsdb_enc.Encbuf{B: make([]byte, 0)})
 					scratch := encoding.EncWrap(tsdb_enc.Encbuf{B: make([]byte, 0)})
@@ -722,7 +722,7 @@ func BenchmarkChunkStats(b *testing.B) {
 		from, through := int64(nChks*40/100), int64(nChks*60/100)
 		for _, version := range []int{FormatV2, FormatV3} {
 			b.Run(fmt.Sprintf("version %d/%d chunks", version, nChks), func(b *testing.B) {
-				var w Writer
+				var w Creator
 				w.Version = version
 				primary := encoding.EncWrap(tsdb_enc.Encbuf{B: make([]byte, 0)})
 				scratch := encoding.EncWrap(tsdb_enc.Encbuf{B: make([]byte, 0)})
@@ -747,7 +747,7 @@ func BenchmarkReadChunks(b *testing.B) {
 		from, through := int64(nChks*40/100), int64(nChks*60/100)
 		for _, version := range []int{FormatV2, FormatV3} {
 			b.Run(fmt.Sprintf("version %d/%d chunks", version, nChks), func(b *testing.B) {
-				var w Writer
+				var w Creator
 				w.Version = version
 				primary := encoding.EncWrap(tsdb_enc.Encbuf{B: make([]byte, 0)})
 				scratch := encoding.EncWrap(tsdb_enc.Encbuf{B: make([]byte, 0)})

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/index.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/index.go
@@ -38,6 +38,7 @@ import (
 	"github.com/prometheus/prometheus/tsdb/fileutil"
 
 	"github.com/grafana/dskit/multierror"
+
 	"github.com/grafana/loki/v3/pkg/util/encoding"
 )
 

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/index.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/index.go
@@ -14,7 +14,6 @@
 package index
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"encoding/binary"
@@ -280,102 +279,6 @@ func (w *Writer) writeAt(buf []byte, pos uint64) error {
 
 func (w *Writer) addPadding(size int) error {
 	return w.f.AddPadding(size)
-}
-
-type FileWriter struct {
-	f        *os.File
-	fbuf     *bufio.Writer
-	position uint64
-	name     string
-}
-
-func NewFileWriter(name string) (*FileWriter, error) {
-	f, err := os.OpenFile(name, os.O_CREATE|os.O_RDWR, 0o666)
-	if err != nil {
-		return nil, err
-	}
-	return &FileWriter{
-		f:        f,
-		fbuf:     bufio.NewWriterSize(f, 1<<22),
-		position: 0,
-		name:     name,
-	}, nil
-}
-
-func (fw *FileWriter) Pos() uint64 {
-	return fw.position
-}
-
-func (fw *FileWriter) ReadFrom(r io.Reader) (int64, error) {
-	n, err := fw.fbuf.ReadFrom(r)
-	fw.position += uint64(n)
-	return n, err
-}
-
-func (fw *FileWriter) Write(p []byte) (n int, err error) {
-	n, err = fw.fbuf.Write(p)
-	fw.position += uint64(n)
-	if err != nil {
-		return n, err
-	}
-
-	// For now the index file must not grow beyond 64GiB. Some of the fixed-sized
-	// offset references in v1 are only 4 bytes large.
-	// Once we move to compressed/varint representations in those areas, this limitation
-	// can be lifted.
-	if fw.position > 16*math.MaxUint32 {
-		return n, errors.Errorf("%q exceeding max size of 64GiB", fw.name)
-	}
-	return n, nil
-}
-
-func (fw *FileWriter) WriteBufs(bufs ...[]byte) error {
-	for _, b := range bufs {
-		if _, err := fw.Write(b); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (fw *FileWriter) Flush() error {
-	return fw.fbuf.Flush()
-}
-
-func (fw *FileWriter) WriteAt(buf []byte, pos uint64) error {
-	if err := fw.Flush(); err != nil {
-		return err
-	}
-	_, err := fw.f.WriteAt(buf, int64(pos))
-	return err
-}
-
-// AddPadding adds zero byte padding until the file size is a multiple size.
-func (fw *FileWriter) AddPadding(size int) error {
-	p := fw.position % uint64(size)
-	if p == 0 {
-		return nil
-	}
-	p = uint64(size) - p
-
-	if _, err := fw.Write(make([]byte, p)); err != nil {
-		return errors.Wrap(err, "add padding")
-	}
-	return nil
-}
-
-func (fw *FileWriter) Close() error {
-	if err := fw.Flush(); err != nil {
-		return err
-	}
-	if err := fw.f.Sync(); err != nil {
-		return err
-	}
-	return fw.f.Close()
-}
-
-func (fw *FileWriter) Remove() error {
-	return os.Remove(fw.name)
 }
 
 // ensureStage handles transitions between write stages and ensures that IndexWriter

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/index_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/index_test.go
@@ -132,7 +132,8 @@ func TestIndexRW_Create_Open(t *testing.T) {
 	// An empty index must still result in a readable file.
 	iw, err := NewWriter(context.Background(), FormatV3, fn)
 	require.NoError(t, err)
-	require.NoError(t, iw.Close())
+	_, err = iw.Close()
+	require.NoError(t, err)
 
 	ir, err := NewFileReader(fn)
 	require.NoError(t, err)
@@ -178,7 +179,8 @@ func TestIndexRW_Postings(t *testing.T) {
 	require.NoError(t, iw.AddSeries(3, series[2], model.Fingerprint(series[2].Hash())))
 	require.NoError(t, iw.AddSeries(4, series[3], model.Fingerprint(series[3].Hash())))
 
-	require.NoError(t, iw.Close())
+	_, err = iw.Close()
+	require.NoError(t, err)
 
 	ir, err := NewFileReader(fn)
 	require.NoError(t, err)
@@ -266,7 +268,8 @@ func TestPostingsMany(t *testing.T) {
 	for i, s := range series {
 		require.NoError(t, iw.AddSeries(storage.SeriesRef(i), s, model.Fingerprint(s.Hash())))
 	}
-	require.NoError(t, iw.Close())
+	_, err = iw.Close()
+	require.NoError(t, err)
 
 	ir, err := NewFileReader(fn)
 	require.NoError(t, err)
@@ -406,7 +409,7 @@ func TestPersistence_index_e2e(t *testing.T) {
 		postings.Add(storage.SeriesRef(i), s.labels)
 	}
 
-	err = iw.Close()
+	_, err = iw.Close()
 	require.NoError(t, err)
 
 	ir, err := NewFileReader(filepath.Join(dir, IndexFilename))
@@ -741,7 +744,7 @@ func TestDecoder_ChunkSamples(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			err = iw.Close()
+			_, err = iw.Close()
 			require.NoError(t, err)
 
 			ir, err := NewFileReader(filepath.Join(dir, name))
@@ -997,7 +1000,7 @@ func BenchmarkInitReader_ReadOffsetTable(b *testing.B) {
 		require.NoError(b, err)
 	}
 
-	err = iw.Close()
+	_, err = iw.Close()
 	require.NoError(b, err)
 
 	bs, err := os.ReadFile(idxFile)

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/index_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/index_test.go
@@ -132,7 +132,7 @@ func TestIndexRW_Create_Open(t *testing.T) {
 	// An empty index must still result in a readable file.
 	iw, err := NewWriter(context.Background(), FormatV3, fn)
 	require.NoError(t, err)
-	_, err = iw.Close()
+	_, err = iw.Close(false)
 	require.NoError(t, err)
 
 	ir, err := NewFileReader(fn)
@@ -179,7 +179,7 @@ func TestIndexRW_Postings(t *testing.T) {
 	require.NoError(t, iw.AddSeries(3, series[2], model.Fingerprint(series[2].Hash())))
 	require.NoError(t, iw.AddSeries(4, series[3], model.Fingerprint(series[3].Hash())))
 
-	_, err = iw.Close()
+	_, err = iw.Close(false)
 	require.NoError(t, err)
 
 	ir, err := NewFileReader(fn)
@@ -268,7 +268,7 @@ func TestPostingsMany(t *testing.T) {
 	for i, s := range series {
 		require.NoError(t, iw.AddSeries(storage.SeriesRef(i), s, model.Fingerprint(s.Hash())))
 	}
-	_, err = iw.Close()
+	_, err = iw.Close(false)
 	require.NoError(t, err)
 
 	ir, err := NewFileReader(fn)
@@ -409,7 +409,7 @@ func TestPersistence_index_e2e(t *testing.T) {
 		postings.Add(storage.SeriesRef(i), s.labels)
 	}
 
-	_, err = iw.Close()
+	_, err = iw.Close(false)
 	require.NoError(t, err)
 
 	ir, err := NewFileReader(filepath.Join(dir, IndexFilename))
@@ -744,7 +744,7 @@ func TestDecoder_ChunkSamples(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			_, err = iw.Close()
+			_, err = iw.Close(false)
 			require.NoError(t, err)
 
 			ir, err := NewFileReader(filepath.Join(dir, name))
@@ -1000,7 +1000,7 @@ func BenchmarkInitReader_ReadOffsetTable(b *testing.B) {
 		require.NoError(b, err)
 	}
 
-	_, err = iw.Close()
+	_, err = iw.Close(false)
 	require.NoError(b, err)
 
 	bs, err := os.ReadFile(idxFile)

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/writer.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/writer.go
@@ -10,6 +10,8 @@ import (
 	"github.com/pkg/errors"
 )
 
+// interface used in tsdb creation -- originally extracted from
+// interacting with temporary files on the file system.
 type writer interface {
 	io.WriteCloser
 	io.ReaderFrom
@@ -99,7 +101,7 @@ func (fw *FileWriter) WriteAt(buf []byte, pos int64) (int, error) {
 	if pos+int64(len(buf)) > int64(fw.Pos()) {
 		return 0, errors.New("write exceeds buffer size")
 	}
-	return fw.f.WriteAt(buf, int64(pos))
+	return fw.f.WriteAt(buf, pos)
 }
 
 // AddPadding adds zero byte padding until the file size is a multiple size.

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/writer.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/writer.go
@@ -139,28 +139,28 @@ func (fw *FileWriter) Bytes() ([]byte, error) {
 	return io.ReadAll(fw.f)
 }
 
-type BufferWriter struct {
+type MemWriter struct {
 	buf *bytes.Buffer
 }
 
 // NewBufferWriter returns a new BufferWriter.
 // todo: pooling memory
-func NewBufferWriter() *BufferWriter {
-	return &BufferWriter{
+func NewBufferWriter() *MemWriter {
+	return &MemWriter{
 		buf: bytes.NewBuffer(nil),
 	}
 }
 
-func (bw *BufferWriter) Write(p []byte) (n int, err error) {
+func (bw *MemWriter) Write(p []byte) (n int, err error) {
 	n, err = bw.buf.Write(p)
 	return n, err
 }
 
-func (bw *BufferWriter) Pos() uint64 {
+func (bw *MemWriter) Pos() uint64 {
 	return uint64(bw.buf.Len())
 }
 
-func (bw *BufferWriter) WriteBufs(bufs ...[]byte) error {
+func (bw *MemWriter) WriteBufs(bufs ...[]byte) error {
 	for _, b := range bufs {
 		if _, err := bw.Write(b); err != nil {
 			return err
@@ -169,11 +169,11 @@ func (bw *BufferWriter) WriteBufs(bufs ...[]byte) error {
 	return nil
 }
 
-func (bw *BufferWriter) ReadFrom(r io.Reader) (int64, error) {
+func (bw *MemWriter) ReadFrom(r io.Reader) (int64, error) {
 	return io.Copy(bw.buf, r)
 }
 
-func (bw *BufferWriter) WriteAt(buf []byte, pos int64) (int, error) {
+func (bw *MemWriter) WriteAt(buf []byte, pos int64) (int, error) {
 	if pos+int64(len(buf)) > int64(bw.buf.Len()) {
 		return 0, errors.New("write exceeds buffer size")
 	}
@@ -188,7 +188,7 @@ func (bw *BufferWriter) WriteAt(buf []byte, pos int64) (int, error) {
 }
 
 // AddPadding adds zero byte padding until the file size is a multiple of size.
-func (bw *BufferWriter) AddPadding(size int) error {
+func (bw *MemWriter) AddPadding(size int) error {
 	if size <= 0 {
 		return nil
 	}
@@ -210,15 +210,15 @@ func (bw *BufferWriter) AddPadding(size int) error {
 	return nil
 }
 
-func (bw *BufferWriter) Bytes() ([]byte, error) {
+func (bw *MemWriter) Bytes() ([]byte, error) {
 	return bw.buf.Bytes(), nil
 }
 
-func (bw *BufferWriter) Close() error {
+func (bw *MemWriter) Close() error {
 	bw.buf.Reset()
 	return nil
 }
 
-func (bw *BufferWriter) Flush() error { return nil }
+func (bw *MemWriter) Flush() error { return nil }
 
-func (bw *BufferWriter) Remove() error { return nil }
+func (bw *MemWriter) Remove() error { return nil }

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/writer.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/writer.go
@@ -1,0 +1,106 @@
+package index
+
+import (
+	"bufio"
+	"io"
+	"math"
+	"os"
+
+	"github.com/pkg/errors"
+)
+
+type FileWriter struct {
+	f        *os.File
+	fbuf     *bufio.Writer
+	position uint64
+	name     string
+}
+
+func NewFileWriter(name string) (*FileWriter, error) {
+	f, err := os.OpenFile(name, os.O_CREATE|os.O_RDWR, 0o666)
+	if err != nil {
+		return nil, err
+	}
+	return &FileWriter{
+		f:        f,
+		fbuf:     bufio.NewWriterSize(f, 1<<22),
+		position: 0,
+		name:     name,
+	}, nil
+}
+
+func (fw *FileWriter) Pos() uint64 {
+	return fw.position
+}
+
+func (fw *FileWriter) ReadFrom(r io.Reader) (int64, error) {
+	n, err := fw.fbuf.ReadFrom(r)
+	fw.position += uint64(n)
+	return n, err
+}
+
+func (fw *FileWriter) Write(p []byte) (n int, err error) {
+	n, err = fw.fbuf.Write(p)
+	fw.position += uint64(n)
+	if err != nil {
+		return n, err
+	}
+
+	// For now the index file must not grow beyond 64GiB. Some of the fixed-sized
+	// offset references in v1 are only 4 bytes large.
+	// Once we move to compressed/varint representations in those areas, this limitation
+	// can be lifted.
+	if fw.position > 16*math.MaxUint32 {
+		return n, errors.Errorf("%q exceeding max size of 64GiB", fw.name)
+	}
+	return n, nil
+}
+
+func (fw *FileWriter) WriteBufs(bufs ...[]byte) error {
+	for _, b := range bufs {
+		if _, err := fw.Write(b); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (fw *FileWriter) Flush() error {
+	return fw.fbuf.Flush()
+}
+
+func (fw *FileWriter) WriteAt(buf []byte, pos uint64) error {
+	if err := fw.Flush(); err != nil {
+		return err
+	}
+	_, err := fw.f.WriteAt(buf, int64(pos))
+	return err
+}
+
+// AddPadding adds zero byte padding until the file size is a multiple size.
+func (fw *FileWriter) AddPadding(size int) error {
+	p := fw.position % uint64(size)
+	if p == 0 {
+		return nil
+	}
+	p = uint64(size) - p
+
+	if _, err := fw.Write(make([]byte, p)); err != nil {
+		return errors.Wrap(err, "add padding")
+	}
+	return nil
+}
+
+func (fw *FileWriter) Close() error {
+	if err := fw.Flush(); err != nil {
+		return err
+	}
+	if err := fw.f.Sync(); err != nil {
+		return err
+	}
+	return fw.f.Close()
+}
+
+func (fw *FileWriter) Remove() error {
+	return os.Remove(fw.name)
+}


### PR DESCRIPTION
In preparation for creating stateless ingesters, this PR adds support for TSDBs to be created by using memory as the backing temporary store rather than disk. This paves the way towards an easier operating model which doesn't require disks.

Note: this adds _support_ but doesn't use it in any existing code paths. I've essentially refactored the TSDB creator to use an interface which can be satisfied by disk or memory. The old code paths will continue to use disks for now to minimize changes.

```
# index files built pre and post change are byte equivalent
$ cmp 1730487398326535000-compactor-1000-3000-bd34932f.tsdb 1730487451442167000-compactor-1000-3000-bd34932f.tsdb
```