### PR TITLE
perf(blooms): Replace JSON lib for encoding/decoding metas

### DIFF
--- a/pkg/storage/stores/shipper/bloomshipper/fetcher.go
+++ b/pkg/storage/stores/shipper/bloomshipper/fetcher.go
@@ -2,7 +2,6 @@ package bloomshipper
 
 import (
 	"context"
-	"encoding/json"
 	"os"
 	"path/filepath"
 	"sync"
@@ -11,6 +10,7 @@ import (
 	"github.com/dolthub/swiss"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/utils/keymutex"
@@ -189,6 +189,8 @@ func (f *Fetcher) processMetasCacheResponse(_ context.Context, refs []MetaRef, k
 
 	var lastErr error
 	var size int64
+
+	json := jsoniter.ConfigFastest
 	for i, ref := range refs {
 		if raw, ok := found[f.client.Meta(ref).Addr()]; ok {
 			meta := Meta{
@@ -209,6 +211,8 @@ func (f *Fetcher) writeBackMetas(ctx context.Context, metas []Meta) error {
 	var err error
 	keys := make([]string, len(metas))
 	data := make([][]byte, len(metas))
+
+	json := jsoniter.ConfigFastest
 	for i := range metas {
 		keys[i] = f.client.Meta(metas[i].MetaRef).Addr()
 		data[i], err = json.Marshal(metas[i])


### PR DESCRIPTION
**What this PR does / why we need it**:

A lot of CPU time is spent in decoding the meta files, which are JSON files.

See this CPU profile from a trace:

![screenshot_20241105_101340](https://github.com/user-attachments/assets/6f376843-9df1-4159-94e5-cc0e98a8d2f7)

[`github.com/json-iterator/go`][1] is a drop-in replacement for the Go stdlib `encoding/json`.

**Benchmark**

```
$ benchstat old.txt new.txt 
goos: linux
goarch: amd64
pkg: github.com/grafana/loki/v3/pkg/storage/stores/shipper/bloomshipper
cpu: 11th Gen Intel(R) Core(TM) i7-1185G7 @ 3.00GHz
                                     │   old.txt    │               new.txt                │
                                     │    sec/op    │    sec/op     vs base                │
_Fetcher_processMetasCacheResponse-8   4.318µ ± 12%   2.095µ ± 49%  -51.49% (p=0.000 n=10)

                                     │   old.txt   │              new.txt               │
                                     │    B/op     │    B/op     vs base                │
_Fetcher_processMetasCacheResponse-8   1301.0 ± 0%   869.0 ± 0%  -33.21% (p=0.000 n=10)

                                     │  old.txt   │              new.txt               │
                                     │ allocs/op  │ allocs/op   vs base                │
_Fetcher_processMetasCacheResponse-8   27.00 ± 0%   15.00 ± 0%  -44.44% (p=0.000 n=10)
```

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)

[1]: https://github.com/json-iterator/go