### PR TITLE
chore(blooms): Add number of skipped bloom blocks to stats-report log line

### DIFF
--- a/pkg/bloomgateway/processor.go
+++ b/pkg/bloomgateway/processor.go
@@ -114,26 +114,28 @@ func (p *processor) processBlocks(ctx context.Context, bqs []*bloomshipper.Close
 	}()
 
 	return concurrency.ForEachJob(ctx, len(bqs), p.concurrency, func(ctx context.Context, i int) error {
-		bq := bqs[i]
-		if bq == nil {
+		blockQuerier := bqs[i]
+		blockWithTasks := data[i]
+
+		// block has not been downloaded or is otherwise not available (yet)
+		// therefore no querier for this block available
+		if blockQuerier == nil {
+			for _, task := range blockWithTasks.tasks {
+				stats := FromContext(task.ctx)
+				stats.IncSkippedBlocks()
+			}
+
 			p.metrics.blocksNotAvailable.WithLabelValues(p.id).Inc()
 			return nil
 		}
 
-		block := data[i]
-
-		if !block.ref.Bounds.Equal(bq.Bounds) {
-			return errors.Errorf("block and querier bounds differ: %s vs %s", block.ref.Bounds, bq.Bounds)
+		if !blockWithTasks.ref.Bounds.Equal(blockQuerier.Bounds) {
+			return errors.Errorf("block and querier bounds differ: %s vs %s", blockWithTasks.ref.Bounds, blockQuerier.Bounds)
 		}
 
 		var errs multierror.MultiError
-		errs.Add(
-			errors.Wrap(
-				p.processBlock(ctx, bq, block.tasks),
-				"processing block",
-			),
-		)
-		errs.Add(bq.Close())
+		errs.Add(errors.Wrap(p.processBlock(ctx, blockQuerier, blockWithTasks.tasks), "processing block"))
+		errs.Add(blockQuerier.Close())
 		hasClosed[i] = true
 		return errs.Err()
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:

We already log the number of processed blocks, so we also want to know the number of skipped blocks, because they have not been available. This will give better insights on a per-query basis, additionally to the metric of overall skipped unavailable blocks `loki_bloom_gateway_blocks_not_available_total`.


**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
