### PR TITLE
fix(operator): Add log attribute for level to structured metadata

### DIFF
--- a/operator/internal/manifests/openshift/otlp.go
+++ b/operator/internal/manifests/openshift/otlp.go
@@ -86,6 +86,7 @@ func DefaultOTLPAttributes(disableRecommended bool) config.OTLPAttributeConfig {
 				"k8s.event.user_agent",
 				"k8s.user.groups",
 				"k8s.user.username",
+				"level",
 				"log.iostream",
 			},
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds another log attribute to the default set of OTLP attributes for OpenShift. This attribute is used by the current visualization to show the log severity and filter for it. This is a workaround for the current version until the visualization supports the new label (`severity_text`).

**Which issue(s) this PR fixes**:

Fixes [LOG-6324](https://issues.redhat.com/browse/LOG-6324)

**Special notes for your reviewer**:

**Checklist**

- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
