### PR TITLE
fix: logcli: Check for errors before checking for `exists` when fetching data

### DIFF
--- a/pkg/logcli/query/query.go
+++ b/pkg/logcli/query/query.go
@@ -553,11 +553,11 @@ func LoadSchemaUsingObjectClient(oc chunk.ObjectClient, name string) (*config.Sc
 	defer cancel()
 
 	ok, err := oc.ObjectExists(ctx, name)
-	if !ok {
-		return nil, errNotExists
-	}
 	if err != nil {
 		return nil, err
+	}
+	if !ok {
+		return nil, errNotExists
 	}
 
 	rdr, _, err := oc.GetObject(ctx, name)


### PR DESCRIPTION
**What this PR does / why we need it**:
When getting data from object storage, we're first checking for the `exists` return and only then for the error returned. Everytime an error is returned an `exists=false` is also returned, and that is taken more precedence than the error itself.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
