### PR TITLE
fix(operator): Publish images on docker hub upon release

### DIFF
--- a/.github/workflows/operator-release-please.yml
+++ b/.github/workflows/operator-release-please.yml
@@ -17,6 +17,9 @@ jobs:
     outputs:
       release_created: ${{ steps.release.outputs.operator--release_created }}
       release_name: ${{ steps.release.outputs.operator--tag_name }}
+      release_major: ${{ steps.release.outputs.operator--major }}
+      release_minor: ${{ steps.release.outputs.operator--minor }}
+      release_patch: ${{ steps.release.outputs.operator--patch }}
     steps:
       - id: "get_github_app_token"
         name: Get GitHub App Token
@@ -54,3 +57,26 @@ jobs:
         working-directory: "release"
         run: |
           gh release edit "${{ needs.releasePlease.outputs.release_name }}" --draft=false --latest=false
+  publishImages:
+    env:
+      BUILD_TIMEOUT: 60
+      IMAGE_PREFIX: "grafana"
+    needs:
+      - "publishRelease"
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Set up QEMU"
+        uses: "docker/setup-qemu-action@v3"
+      - name: "Set up docker buildx"
+        uses: "docker/setup-buildx-action@v3"
+      - name: "Login to DockerHub (from vault)"
+        uses: "grafana/shared-workflows/actions/dockerhub-login@main"
+      - name: "Build and push"
+        timeout-minutes: "${{ env.BUILD_TIMEOUT }}"
+        uses: "docker/build-push-action@v6"
+        with:
+          context: "operator"
+          file: "Dockerfile"
+          platforms: "linux/amd64,linux/arm64,linux/arm"
+          push: true
+          tags: "${{ env.IMAGE_PREFIX }}/loki-operator:${{ steps.releasePlease.outputs.release_major }}.${{ steps.releasePlease.outputs.release_minor }}.${{ steps.releasePlease.outputs.release_patch }}"


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds missing workflow to publish release images for the Loki Operator on Docker Hub.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
