### PR TITLE
refactor(bloom): Compute chunkrefs for series right before sending task to builder

### DIFF
--- a/pkg/bloombuild/common/tsdb.go
+++ b/pkg/bloombuild/common/tsdb.go
@@ -124,9 +124,9 @@ func (b *BloomTSDBStore) LoadTSDB(
 	return idx, nil
 }
 
-func NewTSDBSeriesIter(ctx context.Context, user string, f sharding.ForSeries, bounds v1.FingerprintBounds) (iter.Iterator[*v1.Series], error) {
+func NewTSDBSeriesIter(ctx context.Context, user string, f sharding.ForSeries, bounds v1.FingerprintBounds) (iter.Iterator[model.Fingerprint], error) {
 	// TODO(salvacorts): Create a pool
-	series := make([]*v1.Series, 0, 100)
+	series := make([]model.Fingerprint, 0, 100)
 
 	if err := f.ForSeries(
 		ctx,
@@ -138,19 +138,7 @@ func NewTSDBSeriesIter(ctx context.Context, user string, f sharding.ForSeries, b
 			case <-ctx.Done():
 				return true
 			default:
-				res := &v1.Series{
-					Fingerprint: fp,
-					Chunks:      make(v1.ChunkRefs, 0, len(chks)),
-				}
-				for _, chk := range chks {
-					res.Chunks = append(res.Chunks, v1.ChunkRef{
-						From:     model.Time(chk.MinTime),
-						Through:  model.Time(chk.MaxTime),
-						Checksum: chk.Checksum,
-					})
-				}
-
-				series = append(series, res)
+				series = append(series, fp)
 				return false
 			}
 		},
@@ -161,7 +149,7 @@ func NewTSDBSeriesIter(ctx context.Context, user string, f sharding.ForSeries, b
 
 	select {
 	case <-ctx.Done():
-		return iter.NewEmptyIter[*v1.Series](), ctx.Err()
+		return iter.NewEmptyIter[model.Fingerprint](), ctx.Err()
 	default:
 		return iter.NewCancelableIter(ctx, iter.NewSliceIter(series)), nil
 	}

--- a/pkg/bloombuild/common/tsdb_test.go
+++ b/pkg/bloombuild/common/tsdb_test.go
@@ -66,10 +66,10 @@ func TestTSDBSeriesIter(t *testing.T) {
 	itr, err := NewTSDBSeriesIter(context.Background(), "", forSeriesTestImpl(input), v1.NewBounds(0, math.MaxUint64))
 	require.NoError(t, err)
 
-	v1.EqualIterators(
+	v1.CompareIterators(
 		t,
-		func(a, b *v1.Series) {
-			require.Equal(t, a, b)
+		func(t *testing.T, a model.Fingerprint, b *v1.Series) {
+			require.Equal(t, a, b.Fingerprint)
 		},
 		itr,
 		srcItr,

--- a/pkg/bloombuild/planner/planner.go
+++ b/pkg/bloombuild/planner/planner.go
@@ -374,7 +374,7 @@ func (p *Planner) computeTasks(
 	ctx context.Context,
 	table config.DayTable,
 	tenant string,
-) ([]*protos.Task, []bloomshipper.Meta, error) {
+) ([]*strategies.Task, []bloomshipper.Meta, error) {
 	strategy, err := strategies.NewStrategy(tenant, p.limits, p.logger)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error creating strategy: %w", err)
@@ -847,8 +847,13 @@ func (p *Planner) forwardTaskToBuilder(
 	builderID string,
 	task *QueueTask,
 ) (*protos.TaskResult, error) {
+	protoTask, err := task.ToProtoTask(builder.Context())
+	if err != nil {
+		return nil, fmt.Errorf("error converting task to proto task: %w", err)
+	}
+
 	msg := &protos.PlannerToBuilder{
-		Task: task.ToProtoTask(),
+		Task: protoTask,
 	}
 
 	if err := builder.Send(msg); err != nil {

--- a/pkg/bloombuild/planner/planner_test.go
+++ b/pkg/bloombuild/planner/planner_test.go
@@ -713,12 +713,21 @@ func (f *fakeBuilder) Recv() (*protos.BuilderToPlanner, error) {
 }
 
 func createTasks(n int, resultsCh chan *protos.TaskResult) []*QueueTask {
+	forSeries := plannertest.NewFakeForSeries(plannertest.GenV1Series(v1.NewBounds(0, 100)))
+
 	tasks := make([]*QueueTask, 0, n)
 	// Enqueue tasks
 	for i := 0; i < n; i++ {
 		task := NewQueueTask(
 			context.Background(), time.Now(),
-			protos.NewTask(config.NewDayTable(plannertest.TestDay, "fake"), "fakeTenant", v1.NewBounds(0, 10), plannertest.TsdbID(1), nil),
+			strategies.NewTask(
+				config.NewDayTable(plannertest.TestDay, "fake"),
+				"fakeTenant",
+				v1.NewBounds(0, 10),
+				plannertest.TsdbID(1),
+				forSeries,
+				nil,
+			),
 			resultsCh,
 		)
 		tasks = append(tasks, task)

--- a/pkg/bloombuild/planner/strategies/chunksize.go
+++ b/pkg/bloombuild/planner/strategies/chunksize.go
@@ -12,7 +12,6 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 
-	"github.com/grafana/loki/v3/pkg/bloombuild/protos"
 	iter "github.com/grafana/loki/v3/pkg/iter/v2"
 	v1 "github.com/grafana/loki/v3/pkg/storage/bloom/v1"
 	"github.com/grafana/loki/v3/pkg/storage/config"
@@ -50,7 +49,7 @@ func (s *ChunkSizeStrategy) Plan(
 	tenant string,
 	tsdbs TSDBSet,
 	metas []bloomshipper.Meta,
-) ([]*protos.Task, error) {
+) ([]*Task, error) {
 	targetTaskSize := s.limits.BloomTaskTargetSeriesChunksSizeBytes(tenant)
 
 	logger := log.With(s.logger, "table", table.Addr(), "tenant", tenant)
@@ -73,29 +72,29 @@ func (s *ChunkSizeStrategy) Plan(
 		return nil, fmt.Errorf("failed to get sized series iter: %w", err)
 	}
 
-	tasks := make([]*protos.Task, 0, iterSize)
+	tasks := make([]*Task, 0, iterSize)
 	for sizedIter.Next() {
-		series := sizedIter.At()
-		if series.Len() == 0 {
+		batch := sizedIter.At()
+		if batch.Len() == 0 {
 			// This should never happen, but just in case.
-			level.Warn(logger).Log("msg", "got empty series batch", "tsdb", series.TSDB().Name())
+			level.Warn(logger).Log("msg", "got empty series batch", "tsdb", batch.TSDB().Name())
 			continue
 		}
 
-		bounds := series.Bounds()
+		bounds := batch.Bounds()
 
 		blocks, err := getBlocksMatchingBounds(metas, bounds)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get blocks matching bounds: %w", err)
 		}
 
-		planGap := protos.Gap{
+		planGap := Gap{
 			Bounds: bounds,
-			Series: series.V1Series(),
+			Series: batch.series,
 			Blocks: blocks,
 		}
 
-		tasks = append(tasks, protos.NewTask(table, tenant, bounds, series.TSDB(), []protos.Gap{planGap}))
+		tasks = append(tasks, NewTask(table, tenant, bounds, batch.TSDB(), tsdbs[batch.TSDB()], []Gap{planGap}))
 	}
 	if err := sizedIter.Err(); err != nil {
 		return nil, fmt.Errorf("failed to iterate over sized series: %w", err)
@@ -155,20 +154,16 @@ func getBlocksMatchingBounds(metas []bloomshipper.Meta, bounds v1.FingerprintBou
 	return deduped, nil
 }
 
-type seriesWithChunks struct {
-	tsdb   tsdb.SingleTenantTSDBIdentifier
-	fp     model.Fingerprint
-	chunks []index.ChunkMeta
-}
-
 type seriesBatch struct {
-	series []seriesWithChunks
+	tsdb   tsdb.SingleTenantTSDBIdentifier
+	series []model.Fingerprint
 	size   uint64
 }
 
-func newSeriesBatch() seriesBatch {
+func newSeriesBatch(tsdb tsdb.SingleTenantTSDBIdentifier) seriesBatch {
 	return seriesBatch{
-		series: make([]seriesWithChunks, 0, 100),
+		tsdb:   tsdb,
+		series: make([]model.Fingerprint, 0, 100),
 	}
 }
 
@@ -179,32 +174,11 @@ func (b *seriesBatch) Bounds() v1.FingerprintBounds {
 
 	// We assume that the series are sorted by fingerprint.
 	// This is guaranteed since series are iterated in order by the TSDB.
-	return v1.NewBounds(b.series[0].fp, b.series[len(b.series)-1].fp)
+	return v1.NewBounds(b.series[0], b.series[len(b.series)-1])
 }
 
-func (b *seriesBatch) V1Series() []*v1.Series {
-	series := make([]*v1.Series, 0, len(b.series))
-	for _, s := range b.series {
-		res := &v1.Series{
-			Fingerprint: s.fp,
-			Chunks:      make(v1.ChunkRefs, 0, len(s.chunks)),
-		}
-		for _, chk := range s.chunks {
-			res.Chunks = append(res.Chunks, v1.ChunkRef{
-				From:     model.Time(chk.MinTime),
-				Through:  model.Time(chk.MaxTime),
-				Checksum: chk.Checksum,
-			})
-		}
-
-		series = append(series, res)
-	}
-
-	return series
-}
-
-func (b *seriesBatch) Append(s seriesWithChunks, size uint64) {
-	b.series = append(b.series, s)
+func (b *seriesBatch) Append(series model.Fingerprint, size uint64) {
+	b.series = append(b.series, series)
 	b.size += size
 }
 
@@ -217,10 +191,7 @@ func (b *seriesBatch) Size() uint64 {
 }
 
 func (b *seriesBatch) TSDB() tsdb.SingleTenantTSDBIdentifier {
-	if len(b.series) == 0 {
-		return tsdb.SingleTenantTSDBIdentifier{}
-	}
-	return b.series[0].tsdb
+	return b.tsdb
 }
 
 func (s *ChunkSizeStrategy) sizedSeriesIter(
@@ -230,9 +201,12 @@ func (s *ChunkSizeStrategy) sizedSeriesIter(
 	targetTaskSizeBytes uint64,
 ) (iter.Iterator[seriesBatch], int, error) {
 	batches := make([]seriesBatch, 0, 100)
-	currentBatch := newSeriesBatch()
+	var currentBatch seriesBatch
 
 	for _, idx := range tsdbsWithGaps {
+		// We cut a new batch for each TSDB.
+		currentBatch = newSeriesBatch(idx.tsdbIdentifier)
+
 		for _, gap := range idx.gaps {
 			if err := idx.tsdb.ForSeries(
 				ctx,
@@ -253,14 +227,10 @@ func (s *ChunkSizeStrategy) sizedSeriesIter(
 						// AND Adding this series to the batch would exceed the target task size.
 						if currentBatch.Len() > 0 && currentBatch.Size()+seriesSize > targetTaskSizeBytes {
 							batches = append(batches, currentBatch)
-							currentBatch = newSeriesBatch()
+							currentBatch = newSeriesBatch(idx.tsdbIdentifier)
 						}
 
-						currentBatch.Append(seriesWithChunks{
-							tsdb:   idx.tsdbIdentifier,
-							fp:     fp,
-							chunks: chks,
-						}, seriesSize)
+						currentBatch.Append(fp, seriesSize)
 						return false
 					}
 				},
@@ -269,10 +239,10 @@ func (s *ChunkSizeStrategy) sizedSeriesIter(
 				return nil, 0, err
 			}
 
-			// Add the last batch for this TSDB if it's not empty.
+			// Add the last batch for this gap if it's not empty.
 			if currentBatch.Len() > 0 {
 				batches = append(batches, currentBatch)
-				currentBatch = newSeriesBatch()
+				currentBatch = newSeriesBatch(idx.tsdbIdentifier)
 			}
 		}
 	}

--- a/pkg/bloombuild/planner/strategies/chunksize_test.go
+++ b/pkg/bloombuild/planner/strategies/chunksize_test.go
@@ -7,15 +7,15 @@ import (
 	"github.com/go-kit/log"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/loki/v3/pkg/bloombuild/common"
 	"github.com/grafana/loki/v3/pkg/bloombuild/planner/plannertest"
-	"github.com/grafana/loki/v3/pkg/bloombuild/protos"
 	v1 "github.com/grafana/loki/v3/pkg/storage/bloom/v1"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/bloomshipper"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb"
 )
 
-func taskForGap(tsdb tsdb.SingleTenantTSDBIdentifier, bounds v1.FingerprintBounds, blocks []bloomshipper.BlockRef) *protos.Task {
-	return protos.NewTask(plannertest.TestTable, "fake", bounds, tsdb, []protos.Gap{
+func taskForGap(tsdb tsdb.SingleTenantTSDBIdentifier, forSeries common.ClosableForSeries, bounds v1.FingerprintBounds, blocks []bloomshipper.BlockRef) *Task {
+	return NewTask(plannertest.TestTable, "fake", bounds, tsdb, forSeries, []Gap{
 		{
 			Bounds: bounds,
 			Series: plannertest.GenSeriesWithStep(bounds, 10),
@@ -25,12 +25,14 @@ func taskForGap(tsdb tsdb.SingleTenantTSDBIdentifier, bounds v1.FingerprintBound
 }
 
 func Test_ChunkSizeStrategy_Plan(t *testing.T) {
+	forSeries := plannertest.NewFakeForSeries(plannertest.GenV1SeriesWithStep(v1.NewBounds(0, 100), 10))
+
 	for _, tc := range []struct {
 		name          string
 		limits        ChunkSizeStrategyLimits
 		originalMetas []bloomshipper.Meta
 		tsdbs         TSDBSet
-		expectedTasks []*protos.Task
+		expectedTasks []*Task
 	}{
 		{
 			name:   "no previous blocks and metas",
@@ -38,17 +40,17 @@ func Test_ChunkSizeStrategy_Plan(t *testing.T) {
 
 			// Each series will have 1 chunk of 100KB each
 			tsdbs: TSDBSet{
-				plannertest.TsdbID(0): newFakeForSeries(plannertest.GenSeriesWithStep(v1.NewBounds(0, 100), 10)), // 10 series
+				plannertest.TsdbID(0): forSeries, // 10 series
 			},
 
 			// We expect 5 tasks, each with 2 series each
-			expectedTasks: []*protos.Task{
-				taskForGap(plannertest.TsdbID(0), v1.NewBounds(0, 10), nil),
-				taskForGap(plannertest.TsdbID(0), v1.NewBounds(20, 30), nil),
-				taskForGap(plannertest.TsdbID(0), v1.NewBounds(40, 50), nil),
-				taskForGap(plannertest.TsdbID(0), v1.NewBounds(60, 70), nil),
-				taskForGap(plannertest.TsdbID(0), v1.NewBounds(80, 90), nil),
-				taskForGap(plannertest.TsdbID(0), v1.NewBounds(100, 100), nil),
+			expectedTasks: []*Task{
+				taskForGap(plannertest.TsdbID(0), forSeries, v1.NewBounds(0, 10), nil),
+				taskForGap(plannertest.TsdbID(0), forSeries, v1.NewBounds(20, 30), nil),
+				taskForGap(plannertest.TsdbID(0), forSeries, v1.NewBounds(40, 50), nil),
+				taskForGap(plannertest.TsdbID(0), forSeries, v1.NewBounds(60, 70), nil),
+				taskForGap(plannertest.TsdbID(0), forSeries, v1.NewBounds(80, 90), nil),
+				taskForGap(plannertest.TsdbID(0), forSeries, v1.NewBounds(100, 100), nil),
 			},
 		},
 		{
@@ -84,11 +86,11 @@ func Test_ChunkSizeStrategy_Plan(t *testing.T) {
 			},
 
 			tsdbs: TSDBSet{
-				plannertest.TsdbID(0): newFakeForSeries(plannertest.GenSeriesWithStep(v1.NewBounds(0, 100), 10)), // 10 series
+				plannertest.TsdbID(0): forSeries, // 10 series
 			},
 
 			// We expect no tasks
-			expectedTasks: []*protos.Task{},
+			expectedTasks: []*Task{},
 		},
 		{
 			name:   "Original metas do not cover the entire range",
@@ -121,12 +123,12 @@ func Test_ChunkSizeStrategy_Plan(t *testing.T) {
 			},
 
 			tsdbs: TSDBSet{
-				plannertest.TsdbID(0): newFakeForSeries(plannertest.GenSeriesWithStep(v1.NewBounds(0, 100), 10)), // 10 series
+				plannertest.TsdbID(0): forSeries, // 10 series
 			},
 
 			// We expect 1 tasks for the missing series
-			expectedTasks: []*protos.Task{
-				taskForGap(plannertest.TsdbID(0), v1.NewBounds(20, 30), nil),
+			expectedTasks: []*Task{
+				taskForGap(plannertest.TsdbID(0), forSeries, v1.NewBounds(20, 30), nil),
 			},
 		},
 		{
@@ -150,32 +152,32 @@ func Test_ChunkSizeStrategy_Plan(t *testing.T) {
 			},
 
 			tsdbs: TSDBSet{
-				plannertest.TsdbID(1): newFakeForSeries(plannertest.GenSeriesWithStep(v1.NewBounds(0, 100), 10)), // 10 series
+				plannertest.TsdbID(1): forSeries, // 10 series
 			},
 
 			// We expect 5 tasks, each with 2 series each
-			expectedTasks: []*protos.Task{
-				taskForGap(plannertest.TsdbID(1), v1.NewBounds(0, 10), []bloomshipper.BlockRef{
+			expectedTasks: []*Task{
+				taskForGap(plannertest.TsdbID(1), forSeries, v1.NewBounds(0, 10), []bloomshipper.BlockRef{
 					plannertest.GenBlockRef(0, 0),
 					plannertest.GenBlockRef(10, 10),
 				}),
-				taskForGap(plannertest.TsdbID(1), v1.NewBounds(20, 30), []bloomshipper.BlockRef{
+				taskForGap(plannertest.TsdbID(1), forSeries, v1.NewBounds(20, 30), []bloomshipper.BlockRef{
 					plannertest.GenBlockRef(20, 20),
 					plannertest.GenBlockRef(30, 30),
 				}),
-				taskForGap(plannertest.TsdbID(1), v1.NewBounds(40, 50), []bloomshipper.BlockRef{
+				taskForGap(plannertest.TsdbID(1), forSeries, v1.NewBounds(40, 50), []bloomshipper.BlockRef{
 					plannertest.GenBlockRef(40, 40),
 					plannertest.GenBlockRef(50, 50),
 				}),
-				taskForGap(plannertest.TsdbID(1), v1.NewBounds(60, 70), []bloomshipper.BlockRef{
+				taskForGap(plannertest.TsdbID(1), forSeries, v1.NewBounds(60, 70), []bloomshipper.BlockRef{
 					plannertest.GenBlockRef(60, 60),
 					plannertest.GenBlockRef(70, 70),
 				}),
-				taskForGap(plannertest.TsdbID(1), v1.NewBounds(80, 90), []bloomshipper.BlockRef{
+				taskForGap(plannertest.TsdbID(1), forSeries, v1.NewBounds(80, 90), []bloomshipper.BlockRef{
 					plannertest.GenBlockRef(80, 80),
 					plannertest.GenBlockRef(90, 90),
 				}),
-				taskForGap(plannertest.TsdbID(1), v1.NewBounds(100, 100), []bloomshipper.BlockRef{
+				taskForGap(plannertest.TsdbID(1), forSeries, v1.NewBounds(100, 100), []bloomshipper.BlockRef{
 					plannertest.GenBlockRef(100, 100),
 				}),
 			},
@@ -205,20 +207,20 @@ func Test_ChunkSizeStrategy_Plan(t *testing.T) {
 			},
 
 			tsdbs: TSDBSet{
-				plannertest.TsdbID(1): newFakeForSeries(plannertest.GenSeriesWithStep(v1.NewBounds(0, 100), 10)), // 10 series
+				plannertest.TsdbID(1): forSeries, // 10 series
 			},
 
 			// We expect 5 tasks, each with 2 series each
-			expectedTasks: []*protos.Task{
-				taskForGap(plannertest.TsdbID(1), v1.NewBounds(0, 10), []bloomshipper.BlockRef{
+			expectedTasks: []*Task{
+				taskForGap(plannertest.TsdbID(1), forSeries, v1.NewBounds(0, 10), []bloomshipper.BlockRef{
 					plannertest.GenBlockRef(0, 0),
 					plannertest.GenBlockRef(10, 10),
 				}),
-				taskForGap(plannertest.TsdbID(1), v1.NewBounds(20, 30), []bloomshipper.BlockRef{
+				taskForGap(plannertest.TsdbID(1), forSeries, v1.NewBounds(20, 30), []bloomshipper.BlockRef{
 					plannertest.GenBlockRef(20, 20),
 					plannertest.GenBlockRef(30, 30),
 				}),
-				taskForGap(plannertest.TsdbID(1), v1.NewBounds(40, 40), []bloomshipper.BlockRef{
+				taskForGap(plannertest.TsdbID(1), forSeries, v1.NewBounds(40, 40), []bloomshipper.BlockRef{
 					plannertest.GenBlockRef(40, 40),
 				}),
 			},

--- a/pkg/bloombuild/planner/strategies/factory.go
+++ b/pkg/bloombuild/planner/strategies/factory.go
@@ -7,7 +7,6 @@ import (
 	"github.com/go-kit/log"
 
 	"github.com/grafana/loki/v3/pkg/bloombuild/common"
-	"github.com/grafana/loki/v3/pkg/bloombuild/protos"
 	"github.com/grafana/loki/v3/pkg/storage/config"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/bloomshipper"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb"
@@ -29,7 +28,7 @@ type TSDBSet = map[tsdb.SingleTenantTSDBIdentifier]common.ClosableForSeries
 type PlanningStrategy interface {
 	Name() string
 	// Plan returns a set of tasks for a given tenant-table tuple and TSDBs.
-	Plan(ctx context.Context, table config.DayTable, tenant string, tsdbs TSDBSet, metas []bloomshipper.Meta) ([]*protos.Task, error)
+	Plan(ctx context.Context, table config.DayTable, tenant string, tsdbs TSDBSet, metas []bloomshipper.Meta) ([]*Task, error)
 }
 
 func NewStrategy(

--- a/pkg/bloombuild/planner/strategies/splitkeyspace.go
+++ b/pkg/bloombuild/planner/strategies/splitkeyspace.go
@@ -8,7 +8,6 @@ import (
 	"github.com/go-kit/log/level"
 
 	"github.com/grafana/loki/v3/pkg/bloombuild/common"
-	"github.com/grafana/loki/v3/pkg/bloombuild/protos"
 	iter "github.com/grafana/loki/v3/pkg/iter/v2"
 	v1 "github.com/grafana/loki/v3/pkg/storage/bloom/v1"
 	"github.com/grafana/loki/v3/pkg/storage/config"
@@ -45,14 +44,14 @@ func (s *SplitKeyspaceStrategy) Plan(
 	tenant string,
 	tsdbs TSDBSet,
 	metas []bloomshipper.Meta,
-) ([]*protos.Task, error) {
+) ([]*Task, error) {
 	splitFactor := s.limits.BloomSplitSeriesKeyspaceBy(tenant)
 	ownershipRanges := SplitFingerprintKeyspaceByFactor(splitFactor)
 
 	logger := log.With(s.logger, "table", table.Addr(), "tenant", tenant)
 	level.Debug(s.logger).Log("msg", "loading work for tenant", "splitFactor", splitFactor)
 
-	var tasks []*protos.Task
+	var tasks []*Task
 	for _, ownershipRange := range ownershipRanges {
 		logger := log.With(logger, "ownership", ownershipRange.String())
 
@@ -67,7 +66,7 @@ func (s *SplitKeyspaceStrategy) Plan(
 		}
 
 		for _, gap := range gaps {
-			tasks = append(tasks, protos.NewTask(table, tenant, ownershipRange, gap.tsdb, gap.gaps))
+			tasks = append(tasks, NewTask(table, tenant, ownershipRange, gap.tsdb, tsdbs[gap.tsdb], gap.gaps))
 		}
 	}
 
@@ -85,7 +84,7 @@ func (s *SplitKeyspaceStrategy) Plan(
 //     This is a performance optimization to avoid expensive re-reindexing
 type blockPlan struct {
 	tsdb tsdb.SingleTenantTSDBIdentifier
-	gaps []protos.Gap
+	gaps []Gap
 }
 
 func (s *SplitKeyspaceStrategy) findOutdatedGaps(
@@ -175,11 +174,11 @@ func blockPlansForGaps(
 	for _, idx := range tsdbs {
 		plan := blockPlan{
 			tsdb: idx.tsdbIdentifier,
-			gaps: make([]protos.Gap, 0, len(idx.gaps)),
+			gaps: make([]Gap, 0, len(idx.gaps)),
 		}
 
 		for _, gap := range idx.gaps {
-			planGap := protos.Gap{
+			planGap := Gap{
 				Bounds: gap,
 			}
 

--- a/pkg/bloombuild/planner/strategies/splitkeyspace_test.go
+++ b/pkg/bloombuild/planner/strategies/splitkeyspace_test.go
@@ -4,17 +4,13 @@ import (
 	"context"
 	"testing"
 
-	"github.com/prometheus/common/model"
-	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/loki/v3/pkg/bloombuild/common"
 	"github.com/grafana/loki/v3/pkg/bloombuild/planner/plannertest"
-	"github.com/grafana/loki/v3/pkg/bloombuild/protos"
 	v1 "github.com/grafana/loki/v3/pkg/storage/bloom/v1"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/bloomshipper"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb"
-	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb/index"
 )
 
 func Test_gapsBetweenTSDBsAndMetas(t *testing.T) {
@@ -139,7 +135,7 @@ func Test_blockPlansForGaps(t *testing.T) {
 			exp: []blockPlan{
 				{
 					tsdb: plannertest.TsdbID(0),
-					gaps: []protos.Gap{
+					gaps: []Gap{
 						{
 							Bounds: v1.NewBounds(0, 10),
 							Series: plannertest.GenSeries(v1.NewBounds(0, 10)),
@@ -158,7 +154,7 @@ func Test_blockPlansForGaps(t *testing.T) {
 			exp: []blockPlan{
 				{
 					tsdb: plannertest.TsdbID(0),
-					gaps: []protos.Gap{
+					gaps: []Gap{
 						{
 							Bounds: v1.NewBounds(0, 10),
 							Series: plannertest.GenSeries(v1.NewBounds(0, 10)),
@@ -182,7 +178,7 @@ func Test_blockPlansForGaps(t *testing.T) {
 			exp: []blockPlan{
 				{
 					tsdb: plannertest.TsdbID(0),
-					gaps: []protos.Gap{
+					gaps: []Gap{
 						{
 							Bounds: v1.NewBounds(0, 8),
 							Series: plannertest.GenSeries(v1.NewBounds(0, 8)),
@@ -202,7 +198,7 @@ func Test_blockPlansForGaps(t *testing.T) {
 			exp: []blockPlan{
 				{
 					tsdb: plannertest.TsdbID(0),
-					gaps: []protos.Gap{
+					gaps: []Gap{
 						{
 							Bounds: v1.NewBounds(0, 8),
 							Series: plannertest.GenSeries(v1.NewBounds(0, 8)),
@@ -229,7 +225,7 @@ func Test_blockPlansForGaps(t *testing.T) {
 			exp: []blockPlan{
 				{
 					tsdb: plannertest.TsdbID(0),
-					gaps: []protos.Gap{
+					gaps: []Gap{
 						// tsdb (id=0) can source chunks from the blocks built from tsdb (id=1)
 						{
 							Bounds: v1.NewBounds(3, 5),
@@ -246,7 +242,7 @@ func Test_blockPlansForGaps(t *testing.T) {
 				// tsdb (id=1) can source chunks from the blocks built from tsdb (id=0)
 				{
 					tsdb: plannertest.TsdbID(1),
-					gaps: []protos.Gap{
+					gaps: []Gap{
 						{
 							Bounds: v1.NewBounds(0, 2),
 							Series: plannertest.GenSeries(v1.NewBounds(0, 2)),
@@ -281,7 +277,7 @@ func Test_blockPlansForGaps(t *testing.T) {
 			exp: []blockPlan{
 				{
 					tsdb: plannertest.TsdbID(0),
-					gaps: []protos.Gap{
+					gaps: []Gap{
 						{
 							Bounds: v1.NewBounds(0, 10),
 							Series: plannertest.GenSeries(v1.NewBounds(0, 10)),
@@ -300,7 +296,7 @@ func Test_blockPlansForGaps(t *testing.T) {
 			// We add series spanning the whole FP ownership range
 			tsdbs := make(map[tsdb.SingleTenantTSDBIdentifier]common.ClosableForSeries)
 			for _, id := range tc.tsdbs {
-				tsdbs[id] = newFakeForSeries(plannertest.GenSeries(tc.ownershipRange))
+				tsdbs[id] = plannertest.NewFakeForSeries(plannertest.GenV1Series(tc.ownershipRange))
 			}
 
 			// we reuse the gapsBetweenTSDBsAndMetas function to generate the gaps as this function is tested
@@ -321,44 +317,4 @@ func Test_blockPlansForGaps(t *testing.T) {
 			require.ElementsMatch(t, tc.exp, plans)
 		})
 	}
-}
-
-type fakeForSeries struct {
-	series []*v1.Series
-}
-
-func newFakeForSeries(series []*v1.Series) *fakeForSeries {
-	return &fakeForSeries{
-		series: series,
-	}
-}
-
-func (f fakeForSeries) ForSeries(_ context.Context, _ string, ff index.FingerprintFilter, _ model.Time, _ model.Time, fn func(labels.Labels, model.Fingerprint, []index.ChunkMeta) (stop bool), _ ...*labels.Matcher) error {
-	overlapping := make([]*v1.Series, 0, len(f.series))
-	for _, s := range f.series {
-		if ff.Match(s.Fingerprint) {
-			overlapping = append(overlapping, s)
-		}
-	}
-
-	for _, s := range overlapping {
-		chunks := make([]index.ChunkMeta, 0, len(s.Chunks))
-		for _, c := range s.Chunks {
-			chunks = append(chunks, index.ChunkMeta{
-				MinTime:  int64(c.From),
-				MaxTime:  int64(c.Through),
-				Checksum: c.Checksum,
-				KB:       100,
-			})
-		}
-
-		if fn(labels.EmptyLabels(), s.Fingerprint, chunks) {
-			break
-		}
-	}
-	return nil
-}
-
-func (f fakeForSeries) Close() error {
-	return nil
 }

--- a/pkg/bloombuild/planner/strategies/task.go
+++ b/pkg/bloombuild/planner/strategies/task.go
@@ -1,0 +1,139 @@
+package strategies
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"slices"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+
+	"github.com/grafana/loki/v3/pkg/bloombuild/common"
+	"github.com/grafana/loki/v3/pkg/bloombuild/protos"
+	"github.com/grafana/loki/v3/pkg/logproto"
+	v1 "github.com/grafana/loki/v3/pkg/storage/bloom/v1"
+	"github.com/grafana/loki/v3/pkg/storage/config"
+	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/bloomshipper"
+	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb"
+	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb/index"
+)
+
+type Gap struct {
+	Bounds v1.FingerprintBounds
+	Series []model.Fingerprint
+	Blocks []bloomshipper.BlockRef
+}
+
+// Task represents a task that is enqueued in the planner.
+type Task struct {
+	ID              string
+	Table           config.DayTable
+	Tenant          string
+	OwnershipBounds v1.FingerprintBounds
+	tsdbIdentifier  tsdb.SingleTenantTSDBIdentifier
+	forSeries       common.ClosableForSeries
+	Gaps            []Gap
+}
+
+func NewTask(
+	table config.DayTable,
+	tenant string,
+	bounds v1.FingerprintBounds,
+	tsdb tsdb.SingleTenantTSDBIdentifier,
+	forSeries common.ClosableForSeries,
+	gaps []Gap,
+) *Task {
+	return &Task{
+		ID:              fmt.Sprintf("%s-%s-%s-%d", table.Addr(), tenant, bounds.String(), len(gaps)),
+		Table:           table,
+		Tenant:          tenant,
+		OwnershipBounds: bounds,
+		tsdbIdentifier:  tsdb,
+		forSeries:       forSeries,
+		Gaps:            gaps,
+	}
+}
+
+// TODO: move to planner.Task and pass forSeries comming from the planner.
+// ToProtoTask converts a Task to a ProtoTask.
+// It will use the opened TSDB to get the chunks for the series in the gaps.
+func (t *Task) ToProtoTask(ctx context.Context) (*protos.ProtoTask, error) {
+	if t == nil {
+		return nil, nil
+	}
+
+	protoGaps := make([]*protos.ProtoGapWithBlocks, 0, len(t.Gaps))
+	for _, gap := range t.Gaps {
+		blockRefs := make([]string, 0, len(gap.Blocks))
+		for _, block := range gap.Blocks {
+			blockRefs = append(blockRefs, block.String())
+		}
+
+		if !slices.IsSorted(gap.Series) {
+			slices.Sort(gap.Series)
+		}
+
+		series := make([]*protos.ProtoSeries, 0, len(gap.Series))
+		if err := t.forSeries.ForSeries(
+			ctx,
+			t.Tenant,
+			gap.Bounds,
+			0, math.MaxInt64,
+			func(_ labels.Labels, fp model.Fingerprint, chks []index.ChunkMeta) (stop bool) {
+				select {
+				case <-ctx.Done():
+					return true
+				default:
+					// Skip this series if it's not in the gap.
+					// Series are sorted, so we can break early.
+					if _, found := slices.BinarySearch(gap.Series, fp); !found {
+						return false
+					}
+
+					chunks := make([]*logproto.ShortRef, 0, len(chks))
+					for _, chk := range chks {
+						chunks = append(chunks, &logproto.ShortRef{
+							From:     model.Time(chk.MinTime),
+							Through:  model.Time(chk.MaxTime),
+							Checksum: chk.Checksum,
+						})
+					}
+
+					series = append(series, &protos.ProtoSeries{
+						Fingerprint: uint64(fp),
+						Chunks:      chunks,
+					})
+					return false
+				}
+			},
+			labels.MustNewMatcher(labels.MatchEqual, "", ""),
+		); err != nil {
+			return nil, fmt.Errorf("failed to load series from TSDB for gap (%s): %w", gap.Bounds.String(), err)
+		}
+
+		protoGaps = append(protoGaps, &protos.ProtoGapWithBlocks{
+			Bounds: protos.ProtoFingerprintBounds{
+				Min: gap.Bounds.Min,
+				Max: gap.Bounds.Max,
+			},
+			Series:   series,
+			BlockRef: blockRefs,
+		})
+	}
+
+	return &protos.ProtoTask{
+		Id: t.ID,
+		Table: protos.DayTable{
+			DayTimestampMS: int64(t.Table.Time),
+			Prefix:         t.Table.Prefix,
+		},
+		Tenant: t.Tenant,
+		Bounds: protos.ProtoFingerprintBounds{
+			Min: t.OwnershipBounds.Min,
+			Max: t.OwnershipBounds.Max,
+		},
+		Tsdb: t.tsdbIdentifier.Path(),
+		Gaps: protoGaps,
+	}, nil
+}

--- a/pkg/bloombuild/planner/task.go
+++ b/pkg/bloombuild/planner/task.go
@@ -6,11 +6,12 @@ import (
 
 	"go.uber.org/atomic"
 
+	"github.com/grafana/loki/v3/pkg/bloombuild/planner/strategies"
 	"github.com/grafana/loki/v3/pkg/bloombuild/protos"
 )
 
 type QueueTask struct {
-	*protos.Task
+	*strategies.Task
 
 	resultsChannel chan *protos.TaskResult
 
@@ -23,7 +24,7 @@ type QueueTask struct {
 func NewQueueTask(
 	ctx context.Context,
 	queueTime time.Time,
-	task *protos.Task,
+	task *strategies.Task,
 	resultsChannel chan *protos.TaskResult,
 ) *QueueTask {
 	return &QueueTask{

--- a/pkg/bloombuild/protos/compat.go
+++ b/pkg/bloombuild/protos/compat.go
@@ -7,7 +7,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
 
-	"github.com/grafana/loki/v3/pkg/logproto"
 	v1 "github.com/grafana/loki/v3/pkg/storage/bloom/v1"
 	"github.com/grafana/loki/v3/pkg/storage/config"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/bloomshipper"
@@ -104,58 +103,6 @@ func FromProtoTask(task *ProtoTask) (*Task, error) {
 		TSDB: tsdbRef,
 		Gaps: gaps,
 	}, nil
-}
-
-func (t *Task) ToProtoTask() *ProtoTask {
-	if t == nil {
-		return nil
-	}
-
-	protoGaps := make([]*ProtoGapWithBlocks, 0, len(t.Gaps))
-	for _, gap := range t.Gaps {
-		blockRefs := make([]string, 0, len(gap.Blocks))
-		for _, block := range gap.Blocks {
-			blockRefs = append(blockRefs, block.String())
-		}
-
-		series := make([]*ProtoSeries, 0, len(gap.Series))
-		for _, s := range gap.Series {
-			chunks := make([]*logproto.ShortRef, 0, len(s.Chunks))
-			for _, c := range s.Chunks {
-				chunk := logproto.ShortRef(c)
-				chunks = append(chunks, &chunk)
-			}
-
-			series = append(series, &ProtoSeries{
-				Fingerprint: uint64(s.Fingerprint),
-				Chunks:      chunks,
-			})
-		}
-
-		protoGaps = append(protoGaps, &ProtoGapWithBlocks{
-			Bounds: ProtoFingerprintBounds{
-				Min: gap.Bounds.Min,
-				Max: gap.Bounds.Max,
-			},
-			Series:   series,
-			BlockRef: blockRefs,
-		})
-	}
-
-	return &ProtoTask{
-		Id: t.ID,
-		Table: DayTable{
-			DayTimestampMS: int64(t.Table.Time),
-			Prefix:         t.Table.Prefix,
-		},
-		Tenant: t.Tenant,
-		Bounds: ProtoFingerprintBounds{
-			Min: t.OwnershipBounds.Min,
-			Max: t.OwnershipBounds.Max,
-		},
-		Tsdb: t.TSDB.Path(),
-		Gaps: protoGaps,
-	}
 }
 
 func (t *Task) GetLogger(logger log.Logger) log.Logger {


### PR DESCRIPTION
… before sending to builder

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
