### PR TITLE
ci: tag provisioner and canary images in weekly helm release

### DIFF
--- a/.github/workflows/scripts/helm-weekly-release.sh
+++ b/.github/workflows/scripts/helm-weekly-release.sh
@@ -88,7 +88,11 @@ validate_version_update "${new_chart_version}" "${current_chart_version}" "${lat
 
 if ${k_release}; then
   update_yaml_node "${values_file}" .loki.image.tag "${latest_loki_tag}"
+  update_yaml_node "${values_file}" .lokiCanary.image.tag "${latest_loki_tag}"
+
   update_yaml_node "${values_file}" .enterprise.image.tag "${latest_gel_tag}"
+  update_yaml_node "${values_file}" .enterprise.provisioner.image.tag "${latest_gel_tag}"
+
   update_yaml_node "${chart_file}" .appVersion "$(extract_k_version "${latest_loki_tag}")"
 fi
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a small fix to the weekly helm release script to correctly tag the canary and provisioner images as well.

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/loki/actions/runs/11714266494/job/32658955775

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
