### PR TITLE
fix: Ensure partition-reader starts up correctly

### DIFF
--- a/pkg/kafka/partition/reader.go
+++ b/pkg/kafka/partition/reader.go
@@ -104,7 +104,7 @@ func (p *Reader) start(ctx context.Context) error {
 	// We manage our commits manually, so we must fetch the last offset for our consumer group to find out where to read from.
 	lastCommittedOffset := p.fetchLastCommittedOffset(ctx)
 	if lastCommittedOffset > 0 {
-		lastCommittedOffset += 1 // We want to begin to read from the next offset, but only if we've previously committed an offset.
+		lastCommittedOffset++ // We want to begin to read from the next offset, but only if we've previously committed an offset.
 	}
 	p.client.AddConsumePartitions(map[string]map[int32]kgo.Offset{
 		p.kafkaCfg.Topic: {p.partitionID: kgo.NewOffset().At(lastCommittedOffset)},

--- a/pkg/kafka/partition/reader_test.go
+++ b/pkg/kafka/partition/reader_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/kadm"
 	"github.com/twmb/franz-go/pkg/kgo"
 
 	"github.com/grafana/loki/v3/pkg/kafka"
@@ -231,4 +232,112 @@ func TestPartitionReader_ProcessCommits(t *testing.T) {
 	}
 	// We expect to have processed all the records, including initial + one per iteration.
 	assert.Equal(t, iterations+1, recordsCount)
+}
+
+func TestPartitionReader_StartsAtNextOffset(t *testing.T) {
+	kaf, kafkaCfg := testkafka.CreateCluster(t, 1, "test")
+	consumer := newMockConsumer()
+
+	kaf.CurrentNode()
+	consumerFactory := func(_ Committer) (Consumer, error) {
+		return consumer, nil
+	}
+
+	// Produce some records
+	producer, err := client.NewWriterClient(kafkaCfg, 100, log.NewNopLogger(), prometheus.NewRegistry())
+	require.NoError(t, err)
+	stream := logproto.Stream{
+		Labels: labels.FromStrings("foo", "bar").String(),
+	}
+	for i := 0; i < 5; i++ {
+		stream.Entries = []logproto.Entry{{Timestamp: time.Now(), Line: fmt.Sprintf("test-%d", i)}}
+		records, err := kafka.Encode(0, "test-tenant", stream, 10<<20)
+		require.NoError(t, err)
+		require.Len(t, records, 1)
+
+		producer.ProduceSync(context.Background(), records...)
+	}
+
+	// Set our offset part way through the records we just produced
+	offset := int64(1)
+	kafkaClient, err := client.NewReaderClient(kafkaCfg, nil, log.NewNopLogger())
+	require.NoError(t, err)
+	admClient := kadm.NewClient(kafkaClient)
+	toCommit := kadm.Offsets{}
+	toCommit.AddOffset(kafkaCfg.Topic, 0, offset, -1)
+	resp, err := admClient.CommitOffsets(context.Background(), "test-consumer-group", toCommit)
+	require.NoError(t, err)
+	require.NoError(t, resp.Error())
+
+	// Start reading
+	partitionReader, err := NewReader(kafkaCfg, 0, "test-consumer-group", consumerFactory, log.NewNopLogger(), prometheus.NewRegistry())
+	require.NoError(t, err)
+	err = services.StartAndAwaitRunning(context.Background(), partitionReader)
+	require.NoError(t, err)
+
+	// Wait for records to be processed
+	require.Eventually(t, func() bool {
+		return len(consumer.recordsChan) == 1 // All pending messages will be received in one batch
+	}, 10*time.Second, 10*time.Millisecond)
+
+	// Check we only received records from the last commit onwards, and the last committed offset is not reprocessed.
+	receivedRecords := <-consumer.recordsChan
+	require.Len(t, receivedRecords, 3) // Offsets are 0 based, so we should read offsets 2,3,4
+	for _, record := range receivedRecords {
+		assert.NotContainsf(t, record.Content, "test-0", "record %q should not contain test-0", record.Content)
+		assert.NotContainsf(t, record.Content, "test-1", "record %q should not contain test-1", record.Content)
+	}
+
+	err = services.StopAndAwaitTerminated(context.Background(), partitionReader)
+	require.NoError(t, err)
+}
+
+func TestPartitionReader_StartsUpIfNoNewRecordsAreAvailable(t *testing.T) {
+	kaf, kafkaCfg := testkafka.CreateCluster(t, 1, "test")
+	consumer := newMockConsumer()
+
+	kaf.CurrentNode()
+	consumerFactory := func(_ Committer) (Consumer, error) {
+		return consumer, nil
+	}
+
+	// Produce some records
+	producer, err := client.NewWriterClient(kafkaCfg, 100, log.NewNopLogger(), prometheus.NewRegistry())
+	require.NoError(t, err)
+	stream := logproto.Stream{
+		Labels: labels.FromStrings("foo", "bar").String(),
+	}
+	for i := 0; i < 5; i++ {
+		stream.Entries = []logproto.Entry{{Timestamp: time.Now(), Line: fmt.Sprintf("test-%d", i)}}
+		records, err := kafka.Encode(0, "test-tenant", stream, 10<<20)
+		require.NoError(t, err)
+		require.Len(t, records, 1)
+
+		producer.ProduceSync(context.Background(), records...)
+	}
+
+	// Set our offset to the last record produced
+	offset := int64(4)
+	kafkaClient, err := client.NewReaderClient(kafkaCfg, nil, log.NewNopLogger())
+	require.NoError(t, err)
+	admClient := kadm.NewClient(kafkaClient)
+	toCommit := kadm.Offsets{}
+	toCommit.AddOffset(kafkaCfg.Topic, 0, offset, -1)
+	resp, err := admClient.CommitOffsets(context.Background(), "test-consumer-group", toCommit)
+	require.NoError(t, err)
+	require.NoError(t, resp.Error())
+
+	// Start reading
+	partitionReader, err := NewReader(kafkaCfg, 0, "test-consumer-group", consumerFactory, log.NewNopLogger(), prometheus.NewRegistry())
+	require.NoError(t, err)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	err = services.StartAndAwaitRunning(ctx, partitionReader)
+	require.NoError(t, err)
+
+	// Check we didn't receive any records: This is a sanity check. We shouldn't get this far if we deadlock during startup.
+	require.Len(t, consumer.recordsChan, 0)
+
+	err = services.StopAndAwaitTerminated(context.Background(), partitionReader)
+	require.NoError(t, err)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This fixes an edge case where there are no new records available in Kafka during start up, which would cause a deadlock.
It also ensures we don't process the last comitted offset again at startup because we already processed and committed it.

* I also added a 30 second timeout & log line on each Poll call, which is very useful to debug why Loki isn't starting up sometimes!

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
