### PR TITLE
fix: Ensure successive WAL replays don't overwrite each other

### DIFF
--- a/pkg/ingester/recovery.go
+++ b/pkg/ingester/recovery.go
@@ -196,9 +196,6 @@ func (r *ingesterRecoverer) Close() {
 			s.chunkMtx.Lock()
 			defer s.chunkMtx.Unlock()
 
-			// reset all the incrementing stream counters after a successful WAL replay.
-			s.resetCounter()
-
 			if len(s.chunks) == 0 {
 				inst.removeStream(s)
 				return nil

--- a/pkg/ingester/recovery_test.go
+++ b/pkg/ingester/recovery_test.go
@@ -304,7 +304,7 @@ func TestSeriesRecoveryNoDuplicates(t *testing.T) {
 	require.Equal(t, expected, result.resps[0].Streams)
 }
 
-func TestRecoveryWritesNewRecords(t *testing.T) {
+func TestRecoveryWritesContinuesEntryCountAfterWALReplay(t *testing.T) {
 	ingesterConfig := defaultIngesterTestConfig(t)
 	limits, err := validation.NewOverrides(defaultLimitsTestConfig(), nil)
 	require.NoError(t, err)
@@ -335,9 +335,10 @@ func TestRecoveryWritesNewRecords(t *testing.T) {
 
 	// Check that the entry count continues counting from the last WAL entry to avoid overwriting existing entries in the WAL on future replays.
 	for _, inst := range i.getInstances() {
-		inst.forAllStreams(context.Background(), func(s *stream) error {
+		err := inst.forAllStreams(context.Background(), func(s *stream) error {
 			assert.Equal(t, int64(entriesPerStream), s.entryCt)
 			return nil
 		})
+		require.NoError(t, err)
 	}
 }

--- a/pkg/ingester/recovery_test.go
+++ b/pkg/ingester/recovery_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/tsdb/chunks"
 	"github.com/prometheus/prometheus/tsdb/record"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/loki/v3/pkg/distributor/writefailures"
@@ -301,4 +302,42 @@ func TestSeriesRecoveryNoDuplicates(t *testing.T) {
 		},
 	}
 	require.Equal(t, expected, result.resps[0].Streams)
+}
+
+func TestRecoveryWritesNewRecords(t *testing.T) {
+	ingesterConfig := defaultIngesterTestConfig(t)
+	limits, err := validation.NewOverrides(defaultLimitsTestConfig(), nil)
+	require.NoError(t, err)
+
+	store := &mockStore{
+		chunks: map[string][]chunk.Chunk{},
+	}
+
+	readRingMock := mockReadRingWithOneActiveIngester()
+
+	i, err := New(ingesterConfig, client.Config{}, store, limits, loki_runtime.DefaultTenantConfigs(), nil, writefailures.Cfg{}, constants.Loki, log.NewNopLogger(), nil, readRingMock, nil)
+	require.NoError(t, err)
+
+	var (
+		users            = 10
+		streamsCt        = 1000
+		entriesPerStream = 50
+	)
+
+	reader, _ := buildMemoryReader(users, streamsCt, entriesPerStream, true)
+
+	recoverer := newIngesterRecoverer(i)
+
+	err = RecoverWAL(context.Background(), reader, recoverer)
+	require.NoError(t, err)
+
+	recoverer.Close()
+
+	// Check that the entry count continues counting from the last WAL entry to avoid overwriting existing entries in the WAL on future replays.
+	for _, inst := range i.getInstances() {
+		inst.forAllStreams(context.Background(), func(s *stream) error {
+			assert.Equal(t, int64(entriesPerStream), s.entryCt)
+			return nil
+		})
+	}
 }

--- a/pkg/ingester/stream.go
+++ b/pkg/ingester/stream.go
@@ -649,10 +649,6 @@ func (s *stream) addTailer(t *tailer) {
 	s.tailers[t.getID()] = t
 }
 
-func (s *stream) resetCounter() {
-	s.entryCt = 0
-}
-
 func headBlockType(chunkfmt byte, unorderedWrites bool) chunkenc.HeadBlockFmt {
 	if unorderedWrites {
 		if chunkfmt >= chunkenc.ChunkFormatV3 {

--- a/pkg/ingester/wal.go
+++ b/pkg/ingester/wal.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/go-kit/log/level"
+	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/tsdb/wlog"
 
@@ -108,7 +109,7 @@ func (w *walWrapper) Log(record *wal.Record) error {
 	}
 	select {
 	case <-w.quit:
-		return nil
+		return errors.New("wal is stopped")
 	default:
 		buf := recordPool.GetBytes()
 		defer func() {


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes an edge case in WAL replay where log lines could be lost on WAL replay.
We previously reset the stream counter to 0 after a successful WAL replay. This is a problem if the ingester restarts again before the WAL content is flushed, as we will discard any new WAL entries - anything received after the previous replay - as a duplicate instead of a new log line.

e.g. in this scenario, each startup will create a new segment file in the WAL. After replay, we'd ingest `1A, 1B, 1C, 2D` but `2A, 2B, 2C` will be classed as duplicates of 1A, 1B, and 1C because they have the same entry count.
<img width="251" alt="image" src="https://github.com/user-attachments/assets/6f7e8378-5543-4d66-bb60-d49bec22d871">

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
