### PR TITLE
docs: Removed manual persistence mapping, turned off ingester zone

### DIFF
--- a/docs/sources/setup/install/helm/deployment-guides/aws.md
+++ b/docs/sources/setup/install/helm/deployment-guides/aws.md
@@ -314,51 +314,33 @@ deploymentMode: Distributed
 
 ingester:
  replicas: 3
- persistence:
-   storageClass: gp3
-   accessModes:
-     - ReadWriteOnce
-   size: 10Gi
+ zoneAwareReplication:
+  enabled: false
 
 querier:
  replicas: 3
  maxUnavailable: 2
- persistence:
-   storageClass: gp3
-   accessModes:
-     - ReadWriteOnce
-   size: 10Gi
+
 queryFrontend:
  replicas: 2
  maxUnavailable: 1
+
 queryScheduler:
  replicas: 2
+
 distributor:
  replicas: 3
  maxUnavailable: 2
 compactor:
  replicas: 1
- persistence:
-   storageClass: gp3
-   accessModes:
-     - ReadWriteOnce
-   size: 10Gi
+
 indexGateway:
  replicas: 2
  maxUnavailable: 1
- persistence:
-   storageClass: gp3
-   accessModes:
-     - ReadWriteOnce
-   size: 10Gi
+
 ruler:
  replicas: 1
  maxUnavailable: 1
- persistence:
-   storageClass: gp3
-   accessModes:
-     - ReadWriteOnce
-   size: 10Gi
 
 
 # This exposes the Loki gateway so it can be written to and queried externaly

--- a/docs/sources/setup/install/helm/install-microservices/_index.md
+++ b/docs/sources/setup/install/helm/install-microservices/_index.md
@@ -80,6 +80,8 @@ We do not recommend running in Microservice mode with `filesystem` storage. For 
 
      ingester:
        replicas: 3 # To ensure data durability with replication
+       zoneAwareReplication:
+          enabled: false
      querier:
        replicas: 3 # Improve query performance via parallelism
        maxUnavailable: 2
@@ -245,6 +247,8 @@ loki:
 
   ingester:
     replicas: 3
+    zoneAwareReplication:
+      enabled: false
   querier:
     replicas: 3
     maxUnavailable: 2
@@ -331,6 +335,8 @@ deploymentMode: Distributed
 
 ingester:
   replicas: 3
+  zoneAwareReplication:
+    enabled: false
 querier:
   replicas: 3
   maxUnavailable: 2


### PR DESCRIPTION
**What this PR does / why we need it**:
Removed manually persistence mapping in AWS deployment as not required. Also at the recommendation of the community made ZoneAwareReplication false to save costs.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
