### PR TITLE
fix: Add flags for path & configure kafka for non-memberlist kv store

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -1620,6 +1620,8 @@ The `chunk_store_config` block configures how chunks will be cached and how long
 Common configuration to be shared between multiple modules. If a more specific configuration is given in other sections, the related configuration within this section will be ignored.
 
 ```yaml
+# prefix for the path
+# CLI flag: -common.path-prefix
 [path_prefix: <string> | default = ""]
 
 storage:
@@ -3148,6 +3150,10 @@ kafka_ingestion:
     # 0 disables partitions deletion.
     # CLI flag: -ingester.partition-ring.delete-inactive-partition-after
     [delete_inactive_partition_after: <duration> | default = 13h]
+
+  # Whether the ingester write chunks to the store or discard them on flush.
+  # CLI flag: -ingester.kafka-partition
+  [partition: <int> | default = -1]
 ```
 
 ### ingester_client
@@ -3282,7 +3288,7 @@ The `limits_config` block configures global and per-tenant limits in Loki. The v
 # When true an ingester takes into account only the streams that it owns
 # according to the ring while applying the stream limit.
 # CLI flag: -ingester.use-owned-stream-count
-[use_owned_stream_count: <boolean> | default = false]
+[use_owned_stream_count: <boolean> | default = true]
 
 # Maximum number of active streams per user, per ingester. 0 to disable.
 # CLI flag: -ingester.max-streams-per-user

--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -3150,10 +3150,6 @@ kafka_ingestion:
     # 0 disables partitions deletion.
     # CLI flag: -ingester.partition-ring.delete-inactive-partition-after
     [delete_inactive_partition_after: <duration> | default = 13h]
-
-  # Whether the ingester write chunks to the store or discard them on flush.
-  # CLI flag: -ingester.kafka-partition
-  [partition: <int> | default = -1]
 ```
 
 ### ingester_client
@@ -3288,7 +3284,7 @@ The `limits_config` block configures global and per-tenant limits in Loki. The v
 # When true an ingester takes into account only the streams that it owns
 # according to the ring while applying the stream limit.
 # CLI flag: -ingester.use-owned-stream-count
-[use_owned_stream_count: <boolean> | default = true]
+[use_owned_stream_count: <boolean> | default = false]
 
 # Maximum number of active streams per user, per ingester. 0 to disable.
 # CLI flag: -ingester.max-streams-per-user

--- a/pkg/loki/common/common.go
+++ b/pkg/loki/common/common.go
@@ -66,6 +66,7 @@ func (c *Config) RegisterFlags(f *flag.FlagSet) {
 
 	f.StringVar(&c.CompactorAddress, "common.compactor-address", "", "the http address of the compactor in the form http://host:port")
 	f.StringVar(&c.CompactorGRPCAddress, "common.compactor-grpc-address", "", "the grpc address of the compactor in the form host:port")
+	f.StringVar(&c.PathPrefix, "common.path-prefix", "", "prefix for the path")
 }
 
 type Storage struct {

--- a/pkg/loki/config_wrapper.go
+++ b/pkg/loki/config_wrapper.go
@@ -244,6 +244,7 @@ func applyConfigToRings(r, defaults *ConfigWrapper, rc lokiring.RingConfig, merg
 		r.Ingester.LifecyclerConfig.Zone = rc.InstanceZone
 		r.Ingester.LifecyclerConfig.ListenPort = rc.ListenPort
 		r.Ingester.LifecyclerConfig.ObservePeriod = rc.ObservePeriod
+		r.Ingester.KafkaIngestion.PartitionRingConfig.KVStore = rc.KVStore
 	}
 
 	if mergeWithExisting {


### PR DESCRIPTION
**What this PR does / why we need it**:

I found the path.prefix flag useful for running multiple Loki's locally. It exists as a yaml already, so I just added the flag.
Also configured the kafka ingester KV store for non-memberlist backends, which should be configurable. It is useful for running locally too.
