### PR TITLE
chore(blooms): Add setting to fetch bloom blocks async or synchronously

### DIFF
--- a/pkg/bloomgateway/bloomgateway.go
+++ b/pkg/bloomgateway/bloomgateway.go
@@ -82,6 +82,7 @@ func New(cfg Config, store bloomshipper.Store, logger log.Logger, reg prometheus
 		workerConfig: workerConfig{
 			maxItems:         cfg.NumMultiplexItems,
 			queryConcurrency: cfg.BlockQueryConcurrency,
+			async:            cfg.FetchBlocksAsync,
 		},
 		pendingTasks: &atomic.Int64{},
 

--- a/pkg/bloomgateway/config.go
+++ b/pkg/bloomgateway/config.go
@@ -11,10 +11,11 @@ type Config struct {
 	// Client configures the Bloom Gateway client
 	Client ClientConfig `yaml:"client,omitempty" doc:""`
 
-	WorkerConcurrency       int `yaml:"worker_concurrency"`
-	BlockQueryConcurrency   int `yaml:"block_query_concurrency"`
-	MaxOutstandingPerTenant int `yaml:"max_outstanding_per_tenant"`
-	NumMultiplexItems       int `yaml:"num_multiplex_tasks"`
+	WorkerConcurrency       int  `yaml:"worker_concurrency"`
+	BlockQueryConcurrency   int  `yaml:"block_query_concurrency"`
+	MaxOutstandingPerTenant int  `yaml:"max_outstanding_per_tenant"`
+	NumMultiplexItems       int  `yaml:"num_multiplex_tasks"`
+	FetchBlocksAsync        bool `yaml:"fetch_blocks_async" doc:"hidden"`
 }
 
 // RegisterFlags registers flags for the Bloom Gateway configuration.
@@ -29,6 +30,7 @@ func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.IntVar(&cfg.BlockQueryConcurrency, prefix+"block-query-concurrency", 8, "Number of blocks processed concurrently on a single worker. Usually set to 2x number of CPU cores.")
 	f.IntVar(&cfg.MaxOutstandingPerTenant, prefix+"max-outstanding-per-tenant", 1024, "Maximum number of outstanding tasks per tenant.")
 	f.IntVar(&cfg.NumMultiplexItems, prefix+"num-multiplex-tasks", 512, "How many tasks are multiplexed at once.")
+	f.BoolVar(&cfg.FetchBlocksAsync, prefix+"fetch-blocks-async", true, "Whether blocks should be fetched asynchronously.")
 	// TODO(chaudum): Figure out what the better place is for registering flags
 	// -bloom-gateway.client.* or -bloom-gateway-client.*
 	cfg.Client.RegisterFlags(f)

--- a/pkg/bloomgateway/processor_test.go
+++ b/pkg/bloomgateway/processor_test.go
@@ -128,7 +128,7 @@ func TestProcessor(t *testing.T) {
 		refs, metas, queriers, data := createBlocks(t, tenant, 10, now.Add(-1*time.Hour), now, 0x0000, 0x0fff)
 
 		mockStore := newMockBloomStore(refs, queriers, metas)
-		p := newProcessor("worker", 1, mockStore, log.NewNopLogger(), metrics)
+		p := newProcessor("worker", 1, false, mockStore, log.NewNopLogger(), metrics)
 
 		chunkRefs := createQueryInputFromBlockData(t, tenant, data, 10)
 		swb := seriesWithInterval{
@@ -179,7 +179,7 @@ func TestProcessor(t *testing.T) {
 		}
 
 		mockStore := newMockBloomStore(refs, queriers, metas)
-		p := newProcessor("worker", 1, mockStore, log.NewNopLogger(), metrics)
+		p := newProcessor("worker", 1, false, mockStore, log.NewNopLogger(), metrics)
 
 		chunkRefs := createQueryInputFromBlockData(t, tenant, data, 10)
 		swb := seriesWithInterval{
@@ -226,7 +226,7 @@ func TestProcessor(t *testing.T) {
 		mockStore := newMockBloomStore(refs, queriers, metas)
 		mockStore.err = errors.New("store failed")
 
-		p := newProcessor("worker", 1, mockStore, log.NewNopLogger(), metrics)
+		p := newProcessor("worker", 1, false, mockStore, log.NewNopLogger(), metrics)
 
 		chunkRefs := createQueryInputFromBlockData(t, tenant, data, 10)
 		swb := seriesWithInterval{

--- a/pkg/bloomgateway/worker.go
+++ b/pkg/bloomgateway/worker.go
@@ -22,6 +22,7 @@ const (
 type workerConfig struct {
 	maxItems         int
 	queryConcurrency int
+	async            bool
 }
 
 // worker is a datastructure that consumes tasks from the request queue,
@@ -64,7 +65,7 @@ func (w *worker) starting(_ context.Context) error {
 func (w *worker) running(_ context.Context) error {
 	idx := queue.StartIndexWithLocalQueue
 
-	p := newProcessor(w.id, w.cfg.queryConcurrency, w.store, w.logger, w.metrics)
+	p := newProcessor(w.id, w.cfg.queryConcurrency, w.cfg.async, w.store, w.logger, w.metrics)
 
 	for st := w.State(); st == services.Running || st == services.Stopping; {
 		taskCtx := context.Background()


### PR DESCRIPTION
**What this PR does / why we need it**:

In case bloom blocks are small, they could be downloaded synchronously to avoid missing blocks on cold start.

**Special notes for your reviewer**:

This is an undocumented setting.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
