### PR TITLE
fix(kafka): Read from beginning if no committed offset

### DIFF
--- a/pkg/kafka/partition/reader.go
+++ b/pkg/kafka/partition/reader.go
@@ -103,6 +103,10 @@ func (p *Reader) start(ctx context.Context) error {
 
 	// We manage our commits manually, so we must fetch the last offset for our consumer group to find out where to read from.
 	lastCommittedOffset := p.fetchLastCommittedOffset(ctx)
+	if lastCommittedOffset == kafkaEndOffset {
+		level.Warn(p.logger).Log("msg", "no committed offset found for partition, starting from the beginning", "partition", p.partitionID, "consumer_group", p.consumerGroup)
+		lastCommittedOffset = kafkaStartOffset // If we haven't committed any offsets yet, we start reading from the beginning.
+	}
 	if lastCommittedOffset > 0 {
 		lastCommittedOffset++ // We want to begin to read from the next offset, but only if we've previously committed an offset.
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
If there is no offset for a consumer group & partition, kafka returns `-1` which is a special offset for "latest". I am remapping this to `-2`, which means replay from the start. By using -1, we would start consuming from the latest offset instead of replaying older data in the case where we start a new consumer group, and therefore the latest data would unavailable.

I don't know if this affects environments with long-lived partition-ingesters, but if kafka expires or cleans up a consumer group after some time, we might trigger this on scale up to new partitions and the latest data would be unavailable.