### PR TITLE
feat: support federated query from multiple ingester clusters

### DIFF
--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -78,32 +78,33 @@ type Config struct {
 	HTTPPrefix   string                 `yaml:"http_prefix" doc:"hidden"`
 	BallastBytes int                    `yaml:"ballast_bytes"`
 
-	Server              server.Config              `yaml:"server,omitempty"`
-	InternalServer      internalserver.Config      `yaml:"internal_server,omitempty" doc:"hidden"`
-	Distributor         distributor.Config         `yaml:"distributor,omitempty"`
-	Querier             querier.Config             `yaml:"querier,omitempty"`
-	QueryScheduler      scheduler.Config           `yaml:"query_scheduler"`
-	Frontend            lokifrontend.Config        `yaml:"frontend,omitempty"`
-	QueryRange          queryrange.Config          `yaml:"query_range,omitempty"`
-	Ruler               ruler.Config               `yaml:"ruler,omitempty"`
-	RulerStorage        rulestore.Config           `yaml:"ruler_storage,omitempty" doc:"hidden"`
-	IngesterClient      ingester_client.Config     `yaml:"ingester_client,omitempty"`
-	Ingester            ingester.Config            `yaml:"ingester,omitempty"`
-	Pattern             pattern.Config             `yaml:"pattern_ingester,omitempty"`
-	IndexGateway        indexgateway.Config        `yaml:"index_gateway"`
-	BloomBuild          bloombuild.Config          `yaml:"bloom_build,omitempty" category:"experimental"`
-	BloomGateway        bloomgateway.Config        `yaml:"bloom_gateway,omitempty" category:"experimental"`
-	StorageConfig       storage.Config             `yaml:"storage_config,omitempty"`
-	ChunkStoreConfig    config.ChunkStoreConfig    `yaml:"chunk_store_config,omitempty"`
-	SchemaConfig        config.SchemaConfig        `yaml:"schema_config,omitempty"`
-	CompactorConfig     compactor.Config           `yaml:"compactor,omitempty"`
-	CompactorHTTPClient compactorclient.HTTPConfig `yaml:"compactor_client,omitempty" doc:"hidden"`
-	CompactorGRPCClient compactorclient.GRPCConfig `yaml:"compactor_grpc_client,omitempty"`
-	LimitsConfig        validation.Limits          `yaml:"limits_config"`
-	Worker              worker.Config              `yaml:"frontend_worker,omitempty"`
-	TableManager        index.TableManagerConfig   `yaml:"table_manager,omitempty"`
-	MemberlistKV        memberlist.KVConfig        `yaml:"memberlist"`
-	KafkaConfig         kafka.Config               `yaml:"kafka_config,omitempty" category:"experimental"`
+	Server               server.Config               `yaml:"server,omitempty"`
+	InternalServer       internalserver.Config       `yaml:"internal_server,omitempty" doc:"hidden"`
+	Distributor          distributor.Config          `yaml:"distributor,omitempty"`
+	Querier              querier.Config              `yaml:"querier,omitempty"`
+	QueryScheduler       scheduler.Config            `yaml:"query_scheduler"`
+	Frontend             lokifrontend.Config         `yaml:"frontend,omitempty"`
+	QueryRange           queryrange.Config           `yaml:"query_range,omitempty"`
+	Ruler                ruler.Config                `yaml:"ruler,omitempty"`
+	RulerStorage         rulestore.Config            `yaml:"ruler_storage,omitempty" doc:"hidden"`
+	IngesterClient       ingester_client.Config      `yaml:"ingester_client,omitempty"`
+	Ingester             ingester.Config             `yaml:"ingester,omitempty"`
+	MultiIngesterQuerier querier.MultiIngesterConfig `yaml:"mutli_ingester,omitempty"`
+	Pattern              pattern.Config              `yaml:"pattern_ingester,omitempty"`
+	IndexGateway         indexgateway.Config         `yaml:"index_gateway"`
+	BloomBuild           bloombuild.Config           `yaml:"bloom_build,omitempty" category:"experimental"`
+	BloomGateway         bloomgateway.Config         `yaml:"bloom_gateway,omitempty" category:"experimental"`
+	StorageConfig        storage.Config              `yaml:"storage_config,omitempty"`
+	ChunkStoreConfig     config.ChunkStoreConfig     `yaml:"chunk_store_config,omitempty"`
+	SchemaConfig         config.SchemaConfig         `yaml:"schema_config,omitempty"`
+	CompactorConfig      compactor.Config            `yaml:"compactor,omitempty"`
+	CompactorHTTPClient  compactorclient.HTTPConfig  `yaml:"compactor_client,omitempty" doc:"hidden"`
+	CompactorGRPCClient  compactorclient.GRPCConfig  `yaml:"compactor_grpc_client,omitempty"`
+	LimitsConfig         validation.Limits           `yaml:"limits_config"`
+	Worker               worker.Config               `yaml:"frontend_worker,omitempty"`
+	TableManager         index.TableManagerConfig    `yaml:"table_manager,omitempty"`
+	MemberlistKV         memberlist.KVConfig         `yaml:"memberlist"`
+	KafkaConfig          kafka.Config                `yaml:"kafka_config,omitempty" category:"experimental"`
 
 	RuntimeConfig     runtimeconfig.Config `yaml:"runtime_config,omitempty"`
 	OperationalConfig runtime.Config       `yaml:"operational_config,omitempty"`
@@ -352,7 +353,7 @@ type Loki struct {
 	Querier                   querier.Querier
 	cacheGenerationLoader     queryrangebase.CacheGenNumberLoader
 	querierAPI                *querier.QuerierAPI
-	ingesterQuerier           *querier.IngesterQuerier
+	ingesterQuerier           storage.IIngesterQuerier
 	Store                     storage.Store
 	BloomStore                bloomshipper.Store
 	tableManager              *index.TableManager

--- a/pkg/querier/multi_ingester_querier.go
+++ b/pkg/querier/multi_ingester_querier.go
@@ -1,0 +1,360 @@
+package querier
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/loki/v3/pkg/storage"
+	"github.com/grafana/loki/v3/pkg/storage/stores/index/seriesvolume"
+	index_stats "github.com/grafana/loki/v3/pkg/storage/stores/index/stats"
+
+	"github.com/grafana/dskit/ring"
+	"github.com/grafana/dskit/services"
+	"github.com/grafana/loki/v3/pkg/ingester"
+	"github.com/grafana/loki/v3/pkg/ingester/client"
+	"github.com/grafana/loki/v3/pkg/iter"
+	"github.com/grafana/loki/v3/pkg/logproto"
+	"github.com/grafana/loki/v3/pkg/logql"
+	util_log "github.com/grafana/loki/v3/pkg/util/log"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"golang.org/x/sync/errgroup"
+)
+
+type MultiIngesterConfig struct {
+	MultiIngesterConfig []ring.LifecyclerConfig `yaml:"lifecyclers,omitempty"`
+}
+
+type MultiIngesterQuerier struct {
+	services.Service
+	cfg              *MultiIngesterConfig
+	manager          *services.Manager
+	ring             []*ring.Ring
+	ingesterQueriers []storage.IIngesterQuerier
+}
+
+func NewMultiIngesterQuerier(cfg MultiIngesterConfig, clientCfg client.Config, extraQueryDelay time.Duration, namespace string) (storage.IIngesterQuerier, error) {
+	var (
+		err  error
+		srvc = make([]services.Service, 0, len(cfg.MultiIngesterConfig))
+		miq  = &MultiIngesterQuerier{
+			cfg:              &cfg,
+			ring:             make([]*ring.Ring, 0, len(cfg.MultiIngesterConfig)),
+			ingesterQueriers: make([]storage.IIngesterQuerier, 0, len(cfg.MultiIngesterConfig)),
+		}
+	)
+
+	for i, c := range cfg.MultiIngesterConfig {
+		r, err := ring.New(c.RingConfig, "ingester", ingester.RingKey, util_log.Logger, prometheus.WrapRegistererWithPrefix("cortex_"+strconv.Itoa(i)+"_", prometheus.DefaultRegisterer))
+		if err != nil {
+			return nil, err
+		}
+		miq.ring = append(miq.ring, r)
+
+		logger := log.With(util_log.Logger, "component", "querier")
+		ingesterQuerier, err := NewIngesterQuerier(clientCfg, r, extraQueryDelay, namespace, logger)
+		if err != nil {
+			return nil, err
+		}
+		miq.ingesterQueriers = append(miq.ingesterQueriers, ingesterQuerier)
+		srvc = append(srvc, r)
+	}
+	if miq.manager, err = services.NewManager(srvc...); err != nil {
+		return nil, err
+	}
+
+	if err = services.StartManagerAndAwaitHealthy(context.Background(), miq.manager); err != nil {
+		return nil, err
+	}
+
+	return miq, nil
+}
+
+func (miq *MultiIngesterQuerier) GetSubServices() *services.Manager {
+	return miq.manager
+}
+
+func (miq *MultiIngesterQuerier) SelectLogs(ctx context.Context, params logql.SelectLogParams) ([]iter.EntryIterator, error) {
+	var (
+		m    sync.Mutex
+		iter []iter.EntryIterator
+	)
+	g, _ := errgroup.WithContext(ctx)
+	for idx := range miq.ingesterQueriers {
+		idx := idx
+		g.Go(func() error {
+			if i, err := miq.ingesterQueriers[idx].SelectLogs(ctx, params); err != nil {
+				return err
+			} else {
+				m.Lock()
+				iter = append(iter, i...)
+				m.Unlock()
+			}
+			return nil
+		})
+	}
+	return iter, g.Wait()
+}
+
+func (miq *MultiIngesterQuerier) SelectSample(ctx context.Context, params logql.SelectSampleParams) ([]iter.SampleIterator, error) {
+	var (
+		m    sync.Mutex
+		iter []iter.SampleIterator
+	)
+	g, _ := errgroup.WithContext(ctx)
+	for idx := range miq.ingesterQueriers {
+		idx := idx
+		g.Go(func() error {
+			if i, err := miq.ingesterQueriers[idx].SelectSample(ctx, params); err != nil {
+				return err
+			} else {
+				m.Lock()
+				iter = append(iter, i...)
+				m.Unlock()
+			}
+			return nil
+		})
+	}
+	return iter, g.Wait()
+}
+
+func (miq *MultiIngesterQuerier) Label(ctx context.Context, req *logproto.LabelRequest) ([][]string, error) {
+	var (
+		m    sync.Mutex
+		iter [][]string
+	)
+	g, _ := errgroup.WithContext(ctx)
+	for idx := range miq.ingesterQueriers {
+		idx := idx
+		g.Go(func() error {
+			if i, err := miq.ingesterQueriers[idx].Label(ctx, req); err != nil {
+				return err
+			} else {
+				m.Lock()
+				iter = append(iter, i...)
+				m.Unlock()
+			}
+			return nil
+		})
+	}
+	return iter, g.Wait()
+}
+
+func (miq *MultiIngesterQuerier) Tail(ctx context.Context, req *logproto.TailRequest) (map[string]logproto.Querier_TailClient, error) {
+	var (
+		m           sync.Mutex
+		tailClients = make(map[string]logproto.Querier_TailClient)
+	)
+	g, _ := errgroup.WithContext(ctx)
+	for idx := range miq.ingesterQueriers {
+		idx := idx
+		g.Go(func() error {
+			if i, err := miq.ingesterQueriers[idx].Tail(ctx, req); err != nil {
+				return err
+			} else {
+				m.Lock()
+				for k, v := range i {
+					tailClients[k] = v
+				}
+				m.Unlock()
+			}
+			return nil
+		})
+	}
+	return tailClients, g.Wait()
+}
+
+func (miq *MultiIngesterQuerier) TailDisconnectedIngesters(ctx context.Context, req *logproto.TailRequest, connectedIngestersAddr []string) (map[string]logproto.Querier_TailClient, error) {
+	var (
+		m           sync.Mutex
+		tailClients = make(map[string]logproto.Querier_TailClient)
+	)
+	g, _ := errgroup.WithContext(ctx)
+	for idx := range miq.ingesterQueriers {
+		idx := idx
+		g.Go(func() error {
+			if i, err := miq.ingesterQueriers[idx].TailDisconnectedIngesters(ctx, req, connectedIngestersAddr); err != nil {
+				return err
+			} else {
+				m.Lock()
+				for k, v := range i {
+					tailClients[k] = v
+				}
+				m.Unlock()
+			}
+			return nil
+		})
+	}
+	return tailClients, g.Wait()
+}
+
+func (miq *MultiIngesterQuerier) Series(ctx context.Context, req *logproto.SeriesRequest) ([][]logproto.SeriesIdentifier, error) {
+	var (
+		m              sync.Mutex
+		replicationSet [][]logproto.SeriesIdentifier
+	)
+	g, _ := errgroup.WithContext(ctx)
+	for idx := range miq.ingesterQueriers {
+		idx := idx
+		g.Go(func() error {
+			if i, err := miq.ingesterQueriers[idx].Series(ctx, req); err != nil {
+				return err
+			} else {
+				m.Lock()
+				replicationSet = append(replicationSet, i...)
+				m.Unlock()
+			}
+			return nil
+		})
+	}
+	return replicationSet, g.Wait()
+}
+
+func (miq *MultiIngesterQuerier) TailersCount(ctx context.Context) ([]uint32, error) {
+	var (
+		m      sync.Mutex
+		counts []uint32
+	)
+	g, _ := errgroup.WithContext(ctx)
+	for idx := range miq.ingesterQueriers {
+		idx := idx
+		g.Go(func() error {
+			if i, err := miq.ingesterQueriers[idx].TailersCount(ctx); err != nil {
+				return err
+			} else {
+				m.Lock()
+				counts = append(counts, i...)
+				m.Unlock()
+			}
+			return nil
+		})
+	}
+	return counts, g.Wait()
+}
+
+func (miq *MultiIngesterQuerier) GetChunkIDs(ctx context.Context, from, through model.Time, matchers ...*labels.Matcher) ([]string, error) {
+	var (
+		m        sync.Mutex
+		chunkIDs []string
+	)
+	g, _ := errgroup.WithContext(ctx)
+	for idx := range miq.ingesterQueriers {
+		idx := idx
+		g.Go(func() error {
+			if i, err := miq.ingesterQueriers[idx].GetChunkIDs(ctx, from, through, matchers...); err != nil {
+				return err
+			} else {
+				m.Lock()
+				chunkIDs = append(chunkIDs, i...)
+				m.Unlock()
+			}
+			return nil
+		})
+	}
+	return chunkIDs, g.Wait()
+}
+
+func (miq *MultiIngesterQuerier) Stats(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) (*index_stats.Stats, error) {
+	var (
+		m      sync.Mutex
+		merged index_stats.Stats
+	)
+	g, _ := errgroup.WithContext(ctx)
+	for idx := range miq.ingesterQueriers {
+		idx := idx
+		g.Go(func() error {
+			if resp, err := miq.ingesterQueriers[idx].Stats(ctx, userID, from, through, matchers...); err != nil {
+				return err
+			} else {
+				m.Lock()
+				merged = index_stats.MergeStats(resp, &merged)
+				m.Unlock()
+			}
+			return nil
+		})
+	}
+	return &merged, g.Wait()
+}
+
+func (miq *MultiIngesterQuerier) Volume(ctx context.Context, userID string, from, through model.Time, limit int32, targetLabels []string, aggregateBy string, matchers ...*labels.Matcher) (*logproto.VolumeResponse, error) {
+	var (
+		m      sync.Mutex
+		merged *logproto.VolumeResponse
+	)
+	g, _ := errgroup.WithContext(ctx)
+	for idx := range miq.ingesterQueriers {
+		idx := idx
+		g.Go(func() error {
+			if resp, err := miq.ingesterQueriers[idx].Volume(ctx, userID, from, through, limit, targetLabels, aggregateBy, matchers...); err != nil {
+				return err
+			} else {
+				m.Lock()
+				merged = seriesvolume.Merge([]*logproto.VolumeResponse{merged, resp}, limit)
+				m.Unlock()
+			}
+			return nil
+		})
+	}
+	return merged, g.Wait()
+}
+
+func (miq *MultiIngesterQuerier) DetectedLabel(ctx context.Context, req *logproto.DetectedLabelsRequest) (*logproto.LabelToValuesResponse, error) {
+	var (
+		m    sync.Mutex
+		iter *logproto.LabelToValuesResponse
+	)
+	g, _ := errgroup.WithContext(ctx)
+	for idx := range miq.ingesterQueriers {
+		idx := idx
+		g.Go(func() error {
+			if i, err := miq.ingesterQueriers[idx].DetectedLabel(ctx, req); err != nil {
+				return err
+			} else {
+				m.Lock()
+				// TODO: implement MergeLabelToValuesResponse
+				iter = i
+				//iter = logproto.MergeLabelToValuesResponse(iter, i)
+				m.Unlock()
+			}
+			return nil
+		})
+	}
+	return iter, g.Wait()
+
+}
+
+func (miq *MultiIngesterQuerier) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	var (
+		mu  sync.Mutex
+		rss ring.ReplicationSet
+	)
+	g, _ := errgroup.WithContext(req.Context())
+	for _, r := range miq.ring {
+		r := r
+		g.Go(func() error {
+			rs, err := r.GetAllHealthy(ring.Read)
+			if err != nil {
+				return err
+			}
+			mu.Lock()
+			rss.Instances = append(rss.Instances, rs.Instances...)
+			rss.MaxErrors += rs.MaxErrors
+			rss.MaxUnavailableZones += rs.MaxUnavailableZones
+			mu.Unlock()
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(err.Error()))
+		return
+	}
+	body, _ := json.Marshal(rss)
+	w.Write(body)
+}

--- a/pkg/querier/multi_ingester_querier_test.go
+++ b/pkg/querier/multi_ingester_querier_test.go
@@ -1,0 +1,187 @@
+package querier
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/grafana/dskit/kv"
+	"github.com/grafana/dskit/kv/consul"
+	"github.com/grafana/dskit/ring"
+	"github.com/grafana/dskit/services"
+	"github.com/grafana/loki/v3/pkg/ingester/client"
+	"github.com/grafana/loki/v3/pkg/iter"
+	"github.com/grafana/loki/v3/pkg/logproto"
+	"github.com/grafana/loki/v3/pkg/logql"
+	"github.com/grafana/loki/v3/pkg/storage"
+	"github.com/grafana/loki/v3/pkg/storage/stores/index/stats"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func buildMultiIngesterConfig() MultiIngesterConfig {
+	mic := MultiIngesterConfig{
+		MultiIngesterConfig: []ring.LifecyclerConfig{
+			{
+				RingConfig: ring.Config{
+					KVStore: kv.Config{
+						Store:  "consul",
+						Prefix: "collectors/",
+						StoreConfig: kv.StoreConfig{
+							Consul: consul.Config{
+								Host:              "127.0.0.1:8500",
+								HTTPClientTimeout: time.Second * 20,
+								ConsistentReads:   true,
+							},
+						},
+					},
+					ReplicationFactor: 1,
+				},
+				FinalSleep: 0,
+			}, {
+				RingConfig: ring.Config{
+					KVStore: kv.Config{
+						Store:  "consul",
+						Prefix: "collectors/",
+						StoreConfig: kv.StoreConfig{
+							Consul: consul.Config{
+								Host:              "127.0.0.1:8501",
+								HTTPClientTimeout: time.Second * 20,
+								ConsistentReads:   true,
+							},
+						},
+					},
+					ReplicationFactor: 1,
+				},
+				FinalSleep: 0,
+			},
+		},
+	}
+	return mic
+}
+
+func TestLabels(t *testing.T) {
+	mic := buildMultiIngesterConfig()
+	cc := client.Config{}
+	iq, err := NewMultiIngesterQuerier(mic, cc, 0, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	bs := services.NewIdleService(func(ctx context.Context) error {
+		return services.StartManagerAndAwaitHealthy(ctx, iq.(*MultiIngesterQuerier).GetSubServices())
+	}, func(failureCase error) error {
+		return nil
+	})
+	bs.StartAsync(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+	now := time.Now()
+	before := now.Add(-30 * time.Minute)
+	req := &logproto.LabelRequest{
+		Start: &before,
+		End:   &now,
+	}
+	labels, err := iq.Label(ctx, req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("labels: %+v\n", labels)
+}
+
+// MockIngesterQuerier is a mock implementation of the IIngesterQuerier interface
+type MockIngesterQuerier struct {
+	mock.Mock
+}
+
+func (m *MockIngesterQuerier) SelectLogs(ctx context.Context, params logql.SelectLogParams) ([]iter.EntryIterator, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *MockIngesterQuerier) SelectSample(ctx context.Context, params logql.SelectSampleParams) ([]iter.SampleIterator, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *MockIngesterQuerier) Label(ctx context.Context, req *logproto.LabelRequest) ([][]string, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *MockIngesterQuerier) Tail(ctx context.Context, req *logproto.TailRequest) (map[string]logproto.Querier_TailClient, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *MockIngesterQuerier) TailDisconnectedIngesters(ctx context.Context, req *logproto.TailRequest, connectedIngestersAddr []string) (map[string]logproto.Querier_TailClient, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *MockIngesterQuerier) Series(ctx context.Context, req *logproto.SeriesRequest) ([][]logproto.SeriesIdentifier, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *MockIngesterQuerier) TailersCount(ctx context.Context) ([]uint32, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *MockIngesterQuerier) GetChunkIDs(ctx context.Context, from, through model.Time, matchers ...*labels.Matcher) ([]string, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *MockIngesterQuerier) Volume(ctx context.Context, userID string, from, through model.Time, limit int32, targetLabels []string, aggregateBy string, matchers ...*labels.Matcher) (*logproto.VolumeResponse, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *MockIngesterQuerier) DetectedLabel(ctx context.Context, req *logproto.DetectedLabelsRequest) (*logproto.LabelToValuesResponse, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *MockIngesterQuerier) Stats(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) (*stats.Stats, error) {
+	args := m.Called(ctx, userID, from, through, matchers)
+	time.Sleep(time.Second)
+	return args.Get(0).(*stats.Stats), args.Error(1)
+}
+
+func TestStats(t *testing.T) {
+	// Create mock ingester queriers
+	mockQuerier1 := new(MockIngesterQuerier)
+	mockQuerier2 := new(MockIngesterQuerier)
+
+	// Set up expected responses
+	mockStats1 := &stats.Stats{Chunks: 10}
+	mockStats2 := &stats.Stats{Chunks: 20}
+
+	mockQuerier1.On("Stats", mock.Anything, "test-user", mock.Anything, mock.Anything, mock.Anything).Return(mockStats1, nil)
+	mockQuerier2.On("Stats", mock.Anything, "test-user", mock.Anything, mock.Anything, mock.Anything).Return(mockStats2, nil)
+
+	// Initialize MultiIngesterQuerier with mock ingester queriers
+	miq := &MultiIngesterQuerier{
+		ingesterQueriers: []storage.IIngesterQuerier{mockQuerier1, mockQuerier2},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+
+	from := model.TimeFromUnix(time.Now().Add(-1 * time.Hour).Unix())
+	through := model.TimeFromUnix(time.Now().Unix())
+	matchers := []*labels.Matcher{
+		labels.MustNewMatcher(labels.MatchEqual, "foo", "bar"),
+	}
+
+	// Call the Stats method
+	resp, err := miq.Stats(ctx, "test-user", from, through, matchers...)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	// Validate the merged stats
+	require.Equal(t, int64(30), int64(resp.Chunks))
+}

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -126,7 +126,7 @@ type SingleTenantQuerier struct {
 	cfg             Config
 	store           Store
 	limits          Limits
-	ingesterQuerier *IngesterQuerier
+	ingesterQuerier storage.IIngesterQuerier
 	patternQuerier  PatterQuerier
 	deleteGetter    deleteGetter
 	metrics         *Metrics
@@ -138,7 +138,7 @@ type deleteGetter interface {
 }
 
 // New makes a new Querier.
-func New(cfg Config, store Store, ingesterQuerier *IngesterQuerier, limits Limits, d deleteGetter, r prometheus.Registerer, logger log.Logger) (*SingleTenantQuerier, error) {
+func New(cfg Config, store Store, ingesterQuerier storage.IIngesterQuerier, limits Limits, d deleteGetter, r prometheus.Registerer, logger log.Logger) (*SingleTenantQuerier, error) {
 	return &SingleTenantQuerier{
 		cfg:             cfg,
 		store:           store,

--- a/pkg/storage/async_store.go
+++ b/pkg/storage/async_store.go
@@ -6,6 +6,8 @@ import (
 	"time"
 
 	"github.com/c2h5oh/datasize"
+	"github.com/grafana/loki/v3/pkg/iter"
+	"github.com/grafana/loki/v3/pkg/logql"
 	"github.com/opentracing/opentracing-go"
 
 	"github.com/grafana/loki/v3/pkg/logproto"
@@ -31,6 +33,20 @@ type IngesterQuerier interface {
 	GetChunkIDs(ctx context.Context, from, through model.Time, matchers ...*labels.Matcher) ([]string, error)
 	Stats(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) (*stats.Stats, error)
 	Volume(ctx context.Context, userID string, from, through model.Time, limit int32, targetLabels []string, aggregateBy string, matchers ...*labels.Matcher) (*logproto.VolumeResponse, error)
+}
+
+type IIngesterQuerier interface {
+	SelectLogs(ctx context.Context, params logql.SelectLogParams) ([]iter.EntryIterator, error)
+	SelectSample(ctx context.Context, params logql.SelectSampleParams) ([]iter.SampleIterator, error)
+	Label(ctx context.Context, req *logproto.LabelRequest) ([][]string, error)
+	Tail(ctx context.Context, req *logproto.TailRequest) (map[string]logproto.Querier_TailClient, error)
+	TailDisconnectedIngesters(ctx context.Context, req *logproto.TailRequest, connectedIngestersAddr []string) (map[string]logproto.Querier_TailClient, error)
+	Series(ctx context.Context, req *logproto.SeriesRequest) ([][]logproto.SeriesIdentifier, error)
+	TailersCount(ctx context.Context) ([]uint32, error)
+	GetChunkIDs(ctx context.Context, from, through model.Time, matchers ...*labels.Matcher) ([]string, error)
+	Stats(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) (*stats.Stats, error)
+	Volume(ctx context.Context, userID string, from, through model.Time, limit int32, targetLabels []string, aggregateBy string, matchers ...*labels.Matcher) (*logproto.VolumeResponse, error)
+	DetectedLabel(ctx context.Context, req *logproto.DetectedLabelsRequest) (*logproto.LabelToValuesResponse, error)
 }
 
 type AsyncStoreCfg struct {


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Since Loki now supports storing both TSDB and Chunks in object storage, we can deploy multiple write clusters across different availability zones or data centers. By sharing the same object storage, logs from different clusters can be merged, facilitating easy implementation of federated queries. The main challenge is the scattered nature of real-time data from the ingester.

This feature introduces the ability to query multiple write clusters within the query path and merge their results.

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
