### PR TITLE
fix(blooms): Fix tenants slice on loadTenantTables

### DIFF
--- a/pkg/bloombuild/planner/planner.go
+++ b/pkg/bloombuild/planner/planner.go
@@ -654,7 +654,7 @@ func (p *Planner) loadTenantTables(
 
 		// If this is the first this we see this table, initialize the map
 		if tenantTables[table] == nil {
-			tenantTables[table] = make([]string, tenants.Remaining())
+			tenantTables[table] = make([]string, 0, tenants.Remaining())
 		}
 
 		for tenants.Next() && tenants.Err() == nil && ctx.Err() == nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

Followup for https://github.com/grafana/loki/pull/14770. There were still empty tenants. Due to how we initialise and populate the slice.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
