### PR TITLE
fix: correct S3 bucket owner label key to prevent retrieval errors

### DIFF
--- a/tools/lambda-promtail/lambda-promtail/s3.go
+++ b/tools/lambda-promtail/lambda-promtail/s3.go
@@ -292,10 +292,10 @@ func processS3Event(ctx context.Context, ev *events.S3Event, pc Client, log *log
 			&s3.GetObjectInput{
 				Bucket:              aws.String(labels["bucket"]),
 				Key:                 aws.String(labels["key"]),
-				ExpectedBucketOwner: aws.String(labels["bucketOwner"]),
+				ExpectedBucketOwner: aws.String(labels["bucket_owner"]),
 			})
 		if err != nil {
-			return fmt.Errorf("failed to get object %s from bucket %s on account %s, %s", labels["key"], labels["bucket"], labels["bucketOwner"], err)
+			return fmt.Errorf("failed to get object %s from bucket %s on account %s, %s", labels["key"], labels["bucket"], labels["bucket_owner"], err)
 		}
 		err = parseS3Log(ctx, batch, labels, obj.Body, log)
 		if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR corrects a variable name used to access the S3 bucket owner in the processS3Event function. Currently, labels["bucketOwner"] is used, which results in an error as it should be labels["bucket_owner"] to match the key name in the labels map. This fix ensures that the code correctly retrieves the bucket owner identity from the S3 event, preventing failures during object retrieval.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

This change addresses an error encountered when fetching objects from an S3 bucket due to an incorrect map key reference. The update aligns the variable name with the correct label key.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
