### PR TITLE
feat: add s3 event bucketowner

### DIFF
--- a/tools/lambda-promtail/lambda-promtail/eventbridge.go
+++ b/tools/lambda-promtail/lambda-promtail/eventbridge.go
@@ -47,7 +47,8 @@ func processEventBridgeEvent(ctx context.Context, ev *events.CloudWatchEvent, pc
 				AWSRegion: ev.Region,
 				S3: events.S3Entity{
 					Bucket: events.S3Bucket{
-						Name: eventDetail.Bucket.Name,
+						Name:          eventDetail.Bucket.Name,
+						OwnerIdentity: events.S3UserIdentity{PrincipalID: ev.AccountID},
 					},
 					Object: events.S3Object{
 						Key: eventDetail.Object.Key,

--- a/tools/lambda-promtail/lambda-promtail/eventbridge_test.go
+++ b/tools/lambda-promtail/lambda-promtail/eventbridge_test.go
@@ -31,7 +31,8 @@ func Test_processEventBridgeEvent(t *testing.T) {
 				AWSRegion: "us-east-2",
 				S3: events.S3Entity{
 					Bucket: events.S3Bucket{
-						Name: "bucket",
+						Name:          "bucket",
+						OwnerIdentity: events.S3UserIdentity{PrincipalID: ebEvent.AccountID},
 					},
 					Object: events.S3Object{
 						Key: "pizza.txt",

--- a/tools/lambda-promtail/lambda-promtail/s3.go
+++ b/tools/lambda-promtail/lambda-promtail/s3.go
@@ -292,10 +292,10 @@ func processS3Event(ctx context.Context, ev *events.S3Event, pc Client, log *log
 			&s3.GetObjectInput{
 				Bucket:              aws.String(labels["bucket"]),
 				Key:                 aws.String(labels["key"]),
-				ExpectedBucketOwner: aws.String(labels["bucketOwner"]),
+				ExpectedBucketOwner: aws.String(labels["bucket_owner"]),
 			})
 		if err != nil {
-			return fmt.Errorf("failed to get object %s from bucket %s on account %s, %s", labels["key"], labels["bucket"], labels["bucketOwner"], err)
+			return fmt.Errorf("failed to get object %s from bucket %s on account %s, %s", labels["key"], labels["bucket"], labels["bucket_owner"], err)
 		}
 		err = parseS3Log(ctx, batch, labels, obj.Body, log)
 		if err != nil {


### PR DESCRIPTION
fix: s3 event label typo

**What this PR does / why we need it**:
If you have set the ownership security of the S3 Bucket in the S3 log function through the Event bridge of Tool Lambda Promtail, there is a bug in which InvalidBucketOwnerAWSAccountID occurs because there is no Bucket Owenr.

Through this PR, I have added the Bucket Owner Account ID as an S3 event in the event parsed from Lambda Promtail's Eventbridge and corrected a typo in the Bucket Owner label in the S3 Event so that logs can be collected normally even in situations where BucketOwnership authentication is present. It has been supplemented.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [O ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ O] Documentation added
- [ O] Tests updated
- [ O] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
    - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [O ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ O] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
