### PR TITLE
feat(thanos): add new metric to track status codes

### DIFF
--- a/pkg/storage/bucket/azure/bucket_client.go
+++ b/pkg/storage/bucket/azure/bucket_client.go
@@ -8,11 +8,11 @@ import (
 	"github.com/thanos-io/objstore/providers/azure"
 )
 
-func NewBucketClient(cfg Config, name string, logger log.Logger) (objstore.Bucket, error) {
-	return newBucketClient(cfg, name, logger, azure.NewBucketWithConfig)
+func NewBucketClient(cfg Config, name string, logger log.Logger, wrapRT func(http.RoundTripper) http.RoundTripper) (objstore.Bucket, error) {
+	return newBucketClient(cfg, name, logger, wrapRT, azure.NewBucketWithConfig)
 }
 
-func newBucketClient(cfg Config, name string, logger log.Logger, factory func(log.Logger, azure.Config, string, func(http.RoundTripper) http.RoundTripper) (*azure.Bucket, error)) (objstore.Bucket, error) {
+func newBucketClient(cfg Config, name string, logger log.Logger, wrapRT func(http.RoundTripper) http.RoundTripper, factory func(log.Logger, azure.Config, string, func(http.RoundTripper) http.RoundTripper) (*azure.Bucket, error)) (objstore.Bucket, error) {
 	// Start with default config to make sure that all parameters are set to sensible values, especially
 	// HTTP Config field.
 	bucketConfig := azure.DefaultConfig
@@ -29,5 +29,5 @@ func newBucketClient(cfg Config, name string, logger log.Logger, factory func(lo
 		bucketConfig.Endpoint = cfg.Endpoint
 	}
 
-	return factory(logger, bucketConfig, name, nil)
+	return factory(logger, bucketConfig, name, wrapRT)
 }

--- a/pkg/storage/bucket/gcs/bucket_client.go
+++ b/pkg/storage/bucket/gcs/bucket_client.go
@@ -2,6 +2,7 @@ package gcs
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/go-kit/log"
 	"github.com/thanos-io/objstore"
@@ -9,7 +10,7 @@ import (
 )
 
 // NewBucketClient creates a new GCS bucket client
-func NewBucketClient(ctx context.Context, cfg Config, name string, logger log.Logger) (objstore.Bucket, error) {
+func NewBucketClient(ctx context.Context, cfg Config, name string, logger log.Logger, wrapRT func(http.RoundTripper) http.RoundTripper) (objstore.Bucket, error) {
 	// start with default http configs
 	bucketConfig := gcs.DefaultConfig
 	bucketConfig.Bucket = cfg.BucketName
@@ -18,5 +19,5 @@ func NewBucketClient(ctx context.Context, cfg Config, name string, logger log.Lo
 	bucketConfig.MaxRetries = cfg.MaxRetries
 	bucketConfig.HTTPConfig.Transport = cfg.Transport
 
-	return gcs.NewBucketWithConfig(ctx, logger, bucketConfig, name, nil)
+	return gcs.NewBucketWithConfig(ctx, logger, bucketConfig, name, wrapRT)
 }

--- a/pkg/storage/bucket/s3/bucket_client.go
+++ b/pkg/storage/bucket/s3/bucket_client.go
@@ -1,6 +1,8 @@
 package s3
 
 import (
+	"net/http"
+
 	"github.com/go-kit/log"
 	"github.com/prometheus/common/model"
 	"github.com/thanos-io/objstore"
@@ -14,23 +16,23 @@ const (
 )
 
 // NewBucketClient creates a new S3 bucket client
-func NewBucketClient(cfg Config, name string, logger log.Logger) (objstore.Bucket, error) {
+func NewBucketClient(cfg Config, name string, logger log.Logger, wrapRT func(http.RoundTripper) http.RoundTripper) (objstore.Bucket, error) {
 	s3Cfg, err := newS3Config(cfg)
 	if err != nil {
 		return nil, err
 	}
 
-	return s3.NewBucketWithConfig(logger, s3Cfg, name, nil)
+	return s3.NewBucketWithConfig(logger, s3Cfg, name, wrapRT)
 }
 
 // NewBucketReaderClient creates a new S3 bucket client
-func NewBucketReaderClient(cfg Config, name string, logger log.Logger) (objstore.BucketReader, error) {
+func NewBucketReaderClient(cfg Config, name string, logger log.Logger, wrapRT func(http.RoundTripper) http.RoundTripper) (objstore.BucketReader, error) {
 	s3Cfg, err := newS3Config(cfg)
 	if err != nil {
 		return nil, err
 	}
 
-	return s3.NewBucketWithConfig(logger, s3Cfg, name, nil)
+	return s3.NewBucketWithConfig(logger, s3Cfg, name, wrapRT)
 }
 
 func newS3Config(cfg Config) (s3.Config, error) {

--- a/pkg/storage/bucket/sse_bucket_client_test.go
+++ b/pkg/storage/bucket/sse_bucket_client_test.go
@@ -56,7 +56,7 @@ func TestSSEBucketClient_Upload_ShouldInjectCustomSSEConfig(t *testing.T) {
 				Insecure:        true,
 			}
 
-			s3Client, err := s3.NewBucketClient(s3Cfg, "test", log.NewNopLogger())
+			s3Client, err := s3.NewBucketClient(s3Cfg, "test", log.NewNopLogger(), nil)
 			require.NoError(t, err)
 
 			// Configure the config provider with NO KMS key ID.

--- a/pkg/storage/bucket/swift/bucket_client.go
+++ b/pkg/storage/bucket/swift/bucket_client.go
@@ -1,6 +1,8 @@
 package swift
 
 import (
+	"net/http"
+
 	"github.com/go-kit/log"
 	"github.com/prometheus/common/model"
 	"github.com/thanos-io/objstore"
@@ -9,7 +11,7 @@ import (
 )
 
 // NewBucketClient creates a new Swift bucket client
-func NewBucketClient(cfg Config, _ string, logger log.Logger) (objstore.Bucket, error) {
+func NewBucketClient(cfg Config, _ string, logger log.Logger, wrapper func(http.RoundTripper) http.RoundTripper) (objstore.Bucket, error) {
 	bucketConfig := swift.Config{
 		AuthVersion:       cfg.AuthVersion,
 		AuthUrl:           cfg.AuthURL,
@@ -37,5 +39,5 @@ func NewBucketClient(cfg Config, _ string, logger log.Logger) (objstore.Bucket, 
 	}
 	bucketConfig.HTTPConfig.Transport = cfg.Transport
 
-	return swift.NewContainerFromConfig(logger, &bucketConfig, false, nil)
+	return swift.NewContainerFromConfig(logger, &bucketConfig, false, wrapper)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Thanos objstore [metrics](https://github.com/thanos-io/objstore/blob/main/objstore.go#L483) do not track the status code of operations. `objstore_bucket_operation_failures_total` only reports if an operation failed, but nothing more. 

this pr adds a new metric `loki_objstore_bucket_transport_requests_total` to observe the total requests by status code and the http method. Since we are directly wrapping the transport we cannot partition the metric by the object store operation type (get, list...) instead this metric reports the http method.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
