### PR TITLE
fix: Correctly propagate index stats to metrics.go log line

### DIFF
--- a/pkg/logqlmodel/stats/context.go
+++ b/pkg/logqlmodel/stats/context.go
@@ -108,6 +108,13 @@ func (c *Context) Index() Index {
 	return c.index
 }
 
+// Merge index stats from multiple respones in a concurrency-safe manner
+func (c *Context) MergeIndex(i Index) {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+	c.index.Merge(i)
+}
+
 // Caches returns the cache statistics accumulated so far.
 func (c *Context) Caches() Caches {
 	return Caches{

--- a/pkg/storage/stores/series/series_index_gateway_store.go
+++ b/pkg/storage/stores/series/series_index_gateway_store.go
@@ -60,8 +60,7 @@ func (c *IndexGatewayClientStore) GetChunkRefs(ctx context.Context, _ string, fr
 	}
 
 	statsCtx := statscontext.FromContext(ctx)
-	statsCtx.AddIndexTotalChunkRefs(response.Stats.TotalChunks)
-	statsCtx.AddIndexPostFilterChunkRefs(response.Stats.PostFilterChunks)
+	statsCtx.MergeIndex(response.Stats)
 
 	return result, nil
 }
@@ -131,23 +130,13 @@ func (c *IndexGatewayClientStore) Volume(ctx context.Context, _ string, from, th
 	})
 }
 
-func (c *IndexGatewayClientStore) GetShards(
-	ctx context.Context,
-	_ string,
-	from, through model.Time,
-	targetBytesPerShard uint64,
-	predicate chunk.Predicate,
-) (*logproto.ShardsResponse, error) {
-	resp, err := c.client.GetShards(ctx, &logproto.ShardsRequest{
+func (c *IndexGatewayClientStore) GetShards(ctx context.Context, _ string, from, through model.Time, targetBytesPerShard uint64, predicate chunk.Predicate) (*logproto.ShardsResponse, error) {
+	return c.client.GetShards(ctx, &logproto.ShardsRequest{
 		From:                from,
 		Through:             through,
 		Query:               predicate.Plan().AST.String(),
 		TargetBytesPerShard: targetBytesPerShard,
 	})
-	if err != nil {
-		return nil, err
-	}
-	return resp, nil
 }
 
 func (c *IndexGatewayClientStore) SetChunkFilterer(_ chunk.RequestChunkFilterer) {

--- a/pkg/storage/stores/series/series_index_gateway_store_test.go
+++ b/pkg/storage/stores/series/series_index_gateway_store_test.go
@@ -9,18 +9,52 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/loki/v3/pkg/logproto"
+	"github.com/grafana/loki/v3/pkg/logqlmodel/stats"
+	"github.com/grafana/loki/v3/pkg/storage/chunk"
 )
 
-type fakeClient struct {
+type mockClient struct {
 	GatewayClient
 }
 
-func (fakeClient) GetSeries(_ context.Context, _ *logproto.GetSeriesRequest) (*logproto.GetSeriesResponse, error) {
+func (mockClient) GetSeries(_ context.Context, _ *logproto.GetSeriesRequest) (*logproto.GetSeriesResponse, error) {
 	return &logproto.GetSeriesResponse{}, nil
 }
 
-func Test_IndexGatewayClient(t *testing.T) {
-	idx := NewIndexGatewayClientStore(fakeClient{}, log.NewNopLogger())
-	_, err := idx.GetSeries(context.Background(), "foo", model.Earliest, model.Latest)
+func (mockClient) GetChunkRef(_ context.Context, _ *logproto.GetChunkRefRequest) (*logproto.GetChunkRefResponse, error) {
+	return &logproto.GetChunkRefResponse{
+		Refs: []*logproto.ChunkRef{},
+		Stats: stats.Index{
+			TotalChunks:      1000,
+			PostFilterChunks: 10,
+			ShardsDuration:   0,
+			UsedBloomFilters: true,
+		},
+	}, nil
+}
+
+func Test_IndexGatewayClientStore_GetSeries(t *testing.T) {
+	idx := NewIndexGatewayClientStore(&mockClient{}, log.NewNopLogger())
+	_, err := idx.GetSeries(context.Background(), "tenant", model.Earliest, model.Latest)
 	require.NoError(t, err)
+}
+
+func Test_IndexGatewayClientStore_GetChunkRefs(t *testing.T) {
+	idx := NewIndexGatewayClientStore(&mockClient{}, log.NewNopLogger())
+
+	t.Run("stats context is merged correctly", func(t *testing.T) {
+		ctx := context.Background()
+		_, ctx = stats.NewContext(ctx)
+
+		_, err := idx.GetChunkRefs(ctx, "tenant", model.Earliest, model.Latest, chunk.NewPredicate(nil, nil))
+		require.NoError(t, err)
+
+		_, err = idx.GetChunkRefs(ctx, "tenant", model.Earliest, model.Latest, chunk.NewPredicate(nil, nil))
+		require.NoError(t, err)
+
+		statsCtx := stats.FromContext(ctx)
+		require.True(t, statsCtx.Index().UsedBloomFilters)
+		require.Equal(t, int64(2000), statsCtx.Index().TotalChunks)
+		require.Equal(t, int64(20), statsCtx.Index().PostFilterChunks)
+	})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

The `metrics.go` log line contains the `index_used_bloom_filter` field, which was not set to `true` when the query used bloom filters in the `GetChunkRef()` call on the index gateway.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
