### PR TITLE
chore: Configure renovate to be more in line to the end state

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -22,16 +22,6 @@
       ]
     },
     {
-      "matchFileNames": [
-        "operator/go.mod"
-      ],
-      "matchPackageNames": [
-        "github.com/grafana/loki",
-        "github.com/grafana/loki/operator/api/loki"
-      ],
-      "enabled": false
-    },
-    {
       "matchManagers": ["gomod"],
       "matchPackageNames": ["go"],
       "enabled": false
@@ -40,6 +30,36 @@
       "matchManagers": ["dockerfile"],
       "matchPackageNames": ["golang", "grafana/loki-build-image"],
       "enabled": false
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "enabled": true,
+      "autoApprove": false,
+      "automerge": false
+    },
+    {
+      "matchManagers": ["helm-requirements", "helm-values", "helmv3"],
+      "groupName": "helm-{{packageName}}",
+      "autoApprove": false,
+      "automerge": false
+    },
+    {
+      "matchFileNames": ["tools/lambda-promtail/go.mod"],
+      "groupName": "lambdapromtail-{{packageName}}",
+      "enabled": true,
+      "autoApprove": false,
+      "automerge": false
+    },
+    {
+      "matchFileNames": ["operator/go.mod"],
+      "enabled": false,
+      "autoApprove": false,
+      "automerge": false
+    },
+    {
+      "matchFileNames": ["!tools/lambda-promtail/go.mod", "!operator/go.mod"],
+      "groupName": "{{packageName}}",
+      "enabled": true
     }
   ],
   "digest": {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -22,28 +22,37 @@
       ]
     },
     {
+      // Disable Go version updates
       "matchManagers": ["gomod"],
       "matchPackageNames": ["go"],
       "enabled": false
     },
     {
+      // Disable Go and loki-build-image updates for Dockerfiles
       "matchManagers": ["dockerfile"],
       "matchPackageNames": ["golang", "grafana/loki-build-image"],
       "enabled": false
     },
     {
+      // Don't automatically merge GitHub Actions updates
       "matchManagers": ["github-actions"],
       "enabled": true,
       "autoApprove": false,
       "automerge": false
     },
     {
+      // Separate out Helm updates from other dependencies
+      // Don't automatically merge Helm updates
+      // Updates to this require the docs to be updated
       "matchManagers": ["helm-requirements", "helm-values", "helmv3"],
       "groupName": "helm-{{packageName}}",
       "autoApprove": false,
       "automerge": false
     },
     {
+      // Separate out lambda-promtail updates from other dependencies
+      // Don't automatically merge lambda-promtail updates
+      // Updates to this require the nix SHA to be updated
       "matchFileNames": ["tools/lambda-promtail/go.mod"],
       "groupName": "lambdapromtail-{{packageName}}",
       "enabled": true,
@@ -51,15 +60,20 @@
       "automerge": false
     },
     {
+      // Disable operator updates
       "matchFileNames": ["operator/go.mod"],
       "enabled": false,
       "autoApprove": false,
       "automerge": false
     },
     {
+      // Enable all other updates
       "matchFileNames": ["!tools/lambda-promtail/go.mod", "!operator/go.mod"],
       "groupName": "{{packageName}}",
-      "enabled": true
+      "enabled": true,
+      // After we have tested the above configuration, we can enable the following
+      "automerge": false,
+      "autoApprove": false
     }
   ],
   "digest": {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR attempts to align the renovate configuration to our end goal, with respect to the `main` branch.
Notably it:
- Separates out Helm updates, so they are not mixed with Dockerfile updates
- Explicitly sets Helm updates to not be automerged, since they require documentation updates
- Separates out lambda-promtail updates so they are not merged with other Go updates, since they require Nix updates
- Explicity sets the lamba-promtail updates to not be automerged
- Disables Renovate updates for the Operator code
- Explicitly sets GitHub actions to not be automerged
- Converts the configuration to JSON5, so that each rule can be annotated and explained

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [X] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
