### PR TITLE
chore: Renovate - Turn off digest updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -61,16 +61,17 @@
     },
     {
       // Disable operator updates
-      "matchFileNames": ["operator/go.mod"],
+      "matchFileNames": ["operator/go.mod", "operator/api/loki/go.mod"],
       "enabled": false,
       "autoApprove": false,
       "automerge": false
     },
     {
       // Enable all other updates
-      "matchFileNames": ["!tools/lambda-promtail/go.mod", "!operator/go.mod"],
+      "matchFileNames": ["!tools/lambda-promtail/go.mod", "!operator/go.mod", "!operator/api/loki/go.mod"],
       "groupName": "{{packageName}}",
       "enabled": true,
+      "matchUpdateTypes": ["major", "minor", "patch"],
       // After we have tested the above configuration, we can enable the following
       "automerge": false,
       "autoApprove": false


### PR DESCRIPTION
**What this PR does / why we need it**:
The previous [PR](https://github.com/grafana/loki/pull/14943) somehow turned on "digest" updates.  This PR attempts to address this, as well as fencing off the `operator/api/loki/go.mod` file along with the `operator/go.mod` file.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [X] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
