### PR TITLE
chore: Turn off digest updates for lambda-promtail, helm, and GH actions

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -37,6 +37,7 @@
       // Don't automatically merge GitHub Actions updates
       "matchManagers": ["github-actions"],
       "enabled": true,
+      "matchUpdateTypes": ["major", "minor", "patch"],
       "autoApprove": false,
       "automerge": false
     },
@@ -46,6 +47,7 @@
       // Updates to this require the docs to be updated
       "matchManagers": ["helm-requirements", "helm-values", "helmv3"],
       "groupName": "helm-{{packageName}}",
+      "matchUpdateTypes": ["major", "minor", "patch"],
       "autoApprove": false,
       "automerge": false
     },
@@ -56,6 +58,7 @@
       "matchFileNames": ["tools/lambda-promtail/go.mod"],
       "groupName": "lambdapromtail-{{packageName}}",
       "enabled": true,
+      "matchUpdateTypes": ["major", "minor", "patch"],
       "autoApprove": false,
       "automerge": false
     },


### PR DESCRIPTION
**What this PR does / why we need it**:
The previous [PR](https://github.com/grafana/loki/pull/14948) successfully turned of digest updates for the majority of the `go.mod` files.  This PR turns them off for lambda-promtail, helm, and GH action updates as well.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [X] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
