### PR TITLE
feat: add opt-in support for ProxyFroomEnvironment in logcli (#11742)

### DIFF
--- a/cmd/logcli/main.go
+++ b/cmd/logcli/main.go
@@ -484,6 +484,7 @@ func newQueryClient(app *kingpin.Application) client.Client {
 	app.Flag("auth-header", "The authorization header used. Can also be set using LOKI_AUTH_HEADER env var.").Default("Authorization").Envar("LOKI_AUTH_HEADER").StringVar(&client.AuthHeader)
 	app.Flag("proxy-url", "The http or https proxy to use when making requests. Can also be set using LOKI_HTTP_PROXY_URL env var.").Default("").Envar("LOKI_HTTP_PROXY_URL").StringVar(&client.ProxyURL)
 	app.Flag("compress", "Request that Loki compress returned data in transit. Can also be set using LOKI_HTTP_COMPRESSION env var.").Default("false").Envar("LOKI_HTTP_COMPRESSION").BoolVar(&client.Compression)
+	app.Flag("envproxy", "Use ProxyFromEnvironment to use net/http ProxyFromEnvironment configuration, eg HTTP_PROXY").Default("false").Envar("LOKI_ENV_PROXY").BoolVar(&client.EnvironmentProxy)
 
 	return client
 }

--- a/pkg/logcli/client/client.go
+++ b/pkg/logcli/client/client.go
@@ -74,21 +74,22 @@ type BackoffConfig struct {
 
 // Client contains fields necessary to query a Loki instance
 type DefaultClient struct {
-	TLSConfig       config.TLSConfig
-	Username        string
-	Password        string
-	Address         string
-	OrgID           string
-	Tripperware     Tripperware
-	BearerToken     string
-	BearerTokenFile string
-	Retries         int
-	QueryTags       string
-	NoCache         bool
-	AuthHeader      string
-	ProxyURL        string
-	BackoffConfig   BackoffConfig
-	Compression     bool
+	TLSConfig        config.TLSConfig
+	Username         string
+	Password         string
+	Address          string
+	OrgID            string
+	Tripperware      Tripperware
+	BearerToken      string
+	BearerTokenFile  string
+	Retries          int
+	QueryTags        string
+	NoCache          bool
+	AuthHeader       string
+	ProxyURL         string
+	BackoffConfig    BackoffConfig
+	Compression      bool
+	EnvironmentProxy bool
 }
 
 // Query uses the /api/v1/query endpoint to execute an instant query
@@ -304,6 +305,10 @@ func (c *DefaultClient) doRequest(path, query string, quiet bool, out interface{
 	// Parse the URL to extract the host
 	clientConfig := config.HTTPClientConfig{
 		TLSConfig: c.TLSConfig,
+	}
+
+	if c.EnvironmentProxy {
+		clientConfig.ProxyFromEnvironment = true
 	}
 
 	if c.ProxyURL != "" {


### PR DESCRIPTION
This is enabled with the --envproxy flag. This is opt in because for a very small subset of users, it may cause a breaking change. If a user has a proxy url configured  but also sets a HTTP_PROXY variable, then this will cause an error in the request.

**What this PR does / why we need it**:

HTTP_PROXY is a standard approach to configuring CLIs.
In my use-case, it allows me to use an internal tool to do proxy oauth so I can use logcli via CLI behind auth.

**Which issue(s) this PR fixes**:
Fixes #11742

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
