### PR TITLE
fix: Keep the service_name label after discovery in push.ParseLokiRequest before calculating retention and passing to the usage tracker

### DIFF
--- a/pkg/loghttp/push/push.go
+++ b/pkg/loghttp/push/push.go
@@ -264,9 +264,6 @@ func ParseLokiRequest(userID string, r *http.Request, tenantsRetention TenantsRe
 			lb := labels.NewBuilder(lbs)
 			lbs = lb.Set(LabelServiceName, serviceName).Labels()
 			s.Labels = lbs.String()
-
-			// Remove the added label after it's added to the stream so it's not consumed by subsequent steps
-			lbs = lb.Del(LabelServiceName).Labels()
 		}
 
 		if logPushRequestStreams {

--- a/pkg/loghttp/push/push_test.go
+++ b/pkg/loghttp/push/push_test.go
@@ -221,7 +221,7 @@ func TestParseRequest(t *testing.T) {
 			enableServiceDiscovery:    true,
 			expectedBytes:             len("fizzbuzz"),
 			expectedLines:             1,
-			expectedBytesUsageTracker: map[string]float64{`{foo="bar2", job="stuff"}`: float64(len("fizzbuss"))},
+			expectedBytesUsageTracker: map[string]float64{`{foo="bar2", job="stuff", service_name="stuff"}`: float64(len("fizzbuss"))},
 			expectedLabels:            labels.FromStrings("foo", "bar2", "job", "stuff", LabelServiceName, "stuff"),
 		},
 		{
@@ -232,7 +232,7 @@ func TestParseRequest(t *testing.T) {
 			enableServiceDiscovery:    true,
 			expectedBytes:             len("fizzbuzz"),
 			expectedLines:             1,
-			expectedBytesUsageTracker: map[string]float64{`{foo="bar2"}`: float64(len("fizzbuss"))},
+			expectedBytesUsageTracker: map[string]float64{`{foo="bar2", service_name="unknown_service"}`: float64(len("fizzbuss"))},
 			expectedLabels:            labels.FromStrings("foo", "bar2", LabelServiceName, ServiceUnknown),
 		},
 		{


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently [the label set](https://github.com/grafana/loki/blob/main/pkg/loghttp/push/push.go#L290-L293) passed to [usage trackers](https://github.com/grafana/loki/blob/main/pkg/loghttp/push/usage_tracker.go#L13) in `push.ParseLokiRequest` [does not include the `service_name` label](https://github.com/grafana/loki/blob/main/pkg/loghttp/push/push.go#L269).

This label could be useful at query time for usage metrics and shouldn't affect `RetentionPeriodFor` for a tenant so this PR keeps it.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

N/A

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
