### PR TITLE
feat(blooms): Merge all resulting metas into a single one

### DIFF
--- a/pkg/bloombuild/planner/metrics.go
+++ b/pkg/bloombuild/planner/metrics.go
@@ -16,6 +16,7 @@ const (
 
 	phasePlanning = "planning"
 	phaseBuilding = "building"
+	phaseMerging  = "merging"
 )
 
 type Metrics struct {

--- a/pkg/bloombuild/planner/planner_test.go
+++ b/pkg/bloombuild/planner/planner_test.go
@@ -339,8 +339,10 @@ func Test_processTenantTaskResults(t *testing.T) {
 				},
 			},
 			expectedMetas: []bloomshipper.Meta{
-				plannertest.GenMeta(0, 10, []int{0}, []bloomshipper.BlockRef{plannertest.GenBlockRef(0, 10)}),
-				plannertest.GenMeta(10, 20, []int{0}, []bloomshipper.BlockRef{plannertest.GenBlockRef(10, 20)}),
+				plannertest.GenMeta(0, 20, []int{0}, []bloomshipper.BlockRef{
+					plannertest.GenBlockRef(0, 10),
+					plannertest.GenBlockRef(10, 20),
+				}),
 			},
 			expectedTasksSucceed: 2,
 		},
@@ -378,8 +380,10 @@ func Test_processTenantTaskResults(t *testing.T) {
 				},
 			},
 			expectedMetas: []bloomshipper.Meta{
-				plannertest.GenMeta(0, 10, []int{1}, []bloomshipper.BlockRef{plannertest.GenBlockRef(0, 10)}),
-				plannertest.GenMeta(8, 10, []int{2}, []bloomshipper.BlockRef{plannertest.GenBlockRef(8, 10)}),
+				plannertest.GenMeta(0, 10, []int{1, 2}, []bloomshipper.BlockRef{
+					plannertest.GenBlockRef(0, 10),
+					plannertest.GenBlockRef(8, 10),
+				}),
 			},
 			expectedTasksSucceed: 1,
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:

We often en up with thousands of metas per tenant-table tuple (as many as tasks). This PR merges all the resulting metas into a single (bigger one) that aggregates all the up to date metas for the tenant table once all tasks have completed. The unaggregated metas are deleted (blocks are kept as these are now referenced by the new merged meta).

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
