### PR TITLE
[fix] Set a maximum retries for Docker driver to avoid deadlock.

### DIFF
--- a/clients/cmd/docker-driver/driver.go
+++ b/clients/cmd/docker-driver/driver.go
@@ -81,14 +81,14 @@ func (d *driver) StartLogging(file string, logCtx logger.Info) error {
 		return err
 	}
 
-	keepFile, err := parseBoolean(cfgKeepFile, logCtx, false)
+	keepFile, err := parseBoolean(cfgKeepFile, logCtx, true)
 	if err != nil {
 		return err
 	}
 
 	var jsonl logger.Logger
 	if !noFile {
-		if err := os.MkdirAll(folder, 0755); err != nil {
+		if err := os.MkdirAll(folder, 0o755); err != nil {
 			return errors.Wrap(err, "error setting up logger dir")
 		}
 
@@ -102,7 +102,7 @@ func (d *driver) StartLogging(file string, logCtx logger.Info) error {
 	if err != nil {
 		return errors.Wrap(err, "error creating loki logger")
 	}
-	f, err := fifo.OpenFifo(context.Background(), file, syscall.O_RDONLY, 0700)
+	f, err := fifo.OpenFifo(context.Background(), file, syscall.O_RDONLY, 0o700)
 	if err != nil {
 		return errors.Wrapf(err, "error opening logger fifo: %q", file)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
There's a long ticket claiming that the Docker driver would deadlock when the configured Loki endpoint becomes unreachable. The root cause is that the Loki client retries forever until it can reach Loki again. This looks like a deadlock.

This issues is documented with a [workaround](https://grafana.com/docs/loki/latest/send-data/docker-driver/#known-issue-deadlocked-docker-daemon). However, users still struggle. That's why this change proposes to make the workaround the default behavior.

**Which issue(s) this PR fixes**:
Fixes #2361

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
