### PR TITLE
fix: Update _index.md to change loki-stack reference

### DIFF
--- a/docs/sources/setup/install/helm/install-monolithic/_index.md
+++ b/docs/sources/setup/install/helm/install-monolithic/_index.md
@@ -197,7 +197,7 @@ In this configuration, we need to make sure to update the `commonConfig.replicat
 1. Deploy Loki using the configuration file `values.yaml`:
 
    ```bash
-    helm install loki grafana/loki-stack -f values.yaml
+    helm install loki grafana/loki -f values.yaml
     ```
 1. Install or upgrade the Loki deployment.
      - To install:


### PR DESCRIPTION
Changes reference to loki-stack to loki as loki-stack is deprecated

**What this PR does / why we need it**:
Changes reference to loki-stack chart that is deprecated to the correct loki chart

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
Ran into this issue last night when installing Loki for the first time - using the old deprecated chart causes the config to not work.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
