### PR TITLE
chore(metric_extraction): Optimize labels result

### DIFF
--- a/pkg/logql/log/labels.go
+++ b/pkg/logql/log/labels.go
@@ -583,16 +583,36 @@ func (b *LabelsBuilder) LabelsResult() LabelsResult {
 		return b.currentResult
 	}
 
-	stream := b.labels(StreamLabel).Copy()
-	structuredMetadata := b.labels(StructuredMetadataLabel).Copy()
-	parsed := b.labels(ParsedLabel).Copy()
-	b.buf = flattenLabels(b.buf, stream, structuredMetadata, parsed)
+	// Get all labels at once and sort them
+	b.buf = b.UnsortedLabels(b.buf)
+	sort.Sort(b.buf)
 	hash := b.hasher.Hash(b.buf)
+
 	if cached, ok := b.resultCache[hash]; ok {
 		return cached
 	}
 
-	result := NewLabelsResult(b.buf.String(), hash, stream, structuredMetadata, parsed)
+	// Now segregate the sorted labels into their categories
+	var stream, meta, parsed []labels.Label
+
+	for _, l := range b.buf {
+		// Skip error labels for stream and meta categories
+		if l.Name == logqlmodel.ErrorLabel || l.Name == logqlmodel.ErrorDetailsLabel {
+			parsed = append(parsed, l)
+			continue
+		}
+
+		// Check which category this label belongs to
+		if labelsContain(b.add[ParsedLabel], l.Name) {
+			parsed = append(parsed, l)
+		} else if labelsContain(b.add[StructuredMetadataLabel], l.Name) {
+			meta = append(meta, l)
+		} else {
+			stream = append(stream, l)
+		}
+	}
+
+	result := NewLabelsResult(b.buf.String(), hash, labels.New(stream...), labels.New(meta...), labels.New(parsed...))
 	b.resultCache[hash] = result
 
 	return result

--- a/pkg/logql/log/labels_test.go
+++ b/pkg/logql/log/labels_test.go
@@ -3,6 +3,7 @@ package log
 import (
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/assert"
@@ -462,4 +463,42 @@ func assertLabelResult(t *testing.T, lbs labels.Labels, res LabelsResult) {
 		lbs.String(),
 		res.String(),
 	)
+}
+
+// benchmark streamLineSampleExtractor.Process method
+func BenchmarkStreamLineSampleExtractor_Process(b *testing.B) {
+	// Setup some test data
+	baseLabels := labels.FromStrings(
+		"namespace", "prod",
+		"cluster", "us-east-1",
+		"pod", "my-pod-123",
+		"container", "main",
+		"stream", "stdout",
+	)
+
+	structuredMeta := []labels.Label{
+		{Name: "level", Value: "info"},
+		{Name: "caller", Value: "http.go:42"},
+		{Name: "user", Value: "john"},
+		{Name: "trace_id", Value: "abc123"},
+	}
+
+	testLine := []byte(`{"timestamp":"2024-01-01T00:00:00Z","level":"info","message":"test message","duration_ms":150}`)
+
+	// JSON parsing + filtering + label extraction
+	matcher := labels.MustNewMatcher(labels.MatchEqual, "level", "info")
+	filter := NewStringLabelFilter(matcher)
+	stages := []Stage{
+		NewJSONParser(),
+		filter,
+	}
+	ex, err := NewLineSampleExtractor(CountExtractor, stages, []string{}, false, false)
+	require.NoError(b, err)
+	streamEx := ex.ForStream(baseLabels)
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, _, _ = streamEx.Process(time.Now().UnixNano(), testLine, structuredMeta...)
+	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

The current implementation of `LabelsResult` method used in critical flows within metrics_generation, pipeline, etc fetched UnsortedLabels in the buffer for each category (ParsedLabel, structured metadata, StreamLabel) and individually sorts them. The sorted results are cached in memory. Majority of resource utilisation here was on sorting labels of each of the categories and creating a copy from buffer. 



The new implementation fetches all Unsorted Labels and sorts them collectively and caches the result first. Individual categories are segregated after caching.

(notice the labels.Copy is gone in the newer implementation in memory profile)

## Results:

### BenchmarkStreamLineSampleExtractor_Process

#### Cpu before: 
<img width="1919" alt="cpu_before" src="https://github.com/user-attachments/assets/53f0567d-b074-47fe-8beb-8d0cbc344e22">

#### Cpu after
<img width="1919" alt="cpu_aft" src="https://github.com/user-attachments/assets/db64066d-3d16-42b2-97a9-f5c537c82621">


#### Mem before: 
<img width="1919" alt="mem_before" src="https://github.com/user-attachments/assets/f6b7ef6a-213f-4e44-80aa-d52d1aaaa2fb">


#### Cpu after: 
<img width="1919" alt="mem_after" src="https://github.com/user-attachments/assets/74c54949-129c-42f0-b36b-9165588098ea">

### BenchmarkReadWithStructuredMetadata: create a memchunk and iterate on it

####  cpu and memory 

<img width="1308" alt="Screenshot 2024-11-22 at 14 05 34" src="https://github.com/user-attachments/assets/5d49d5d9-6c32-47f3-8394-3aa8f408cc6f">


#### benchstat result - 

<img width="631" alt="benchstat" src="https://github.com/user-attachments/assets/286e8adf-5bda-4e79-8478-70eabc4e6ba0">

## Overall Summary from the results:

Excluding some variability in the measurements, The new implementation is at least **28% faster** than the older one  with a dramatic 89% improvement in memory usage. Each run also took 79.8% fewer allocs/op than the old implementation. 


**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
