### PR TITLE
chore: Remove ifc from interface names

### DIFF
--- a/pkg/blockbuilder/controller.go
+++ b/pkg/blockbuilder/controller.go
@@ -65,13 +65,13 @@ type PartitionController interface {
 //	containing log data and "committed" is the consumer group
 type PartitionJobController struct {
 	stepLen int64
-	part    partition.ReaderIfc
+	part    partition.Reader
 	backoff backoff.Config
 	decoder *kafka.Decoder
 }
 
 func NewPartitionJobController(
-	controller partition.ReaderIfc,
+	controller partition.Reader,
 	backoff backoff.Config,
 ) (*PartitionJobController, error) {
 	decoder, err := kafka.NewDecoder()

--- a/pkg/kafka/partition/committer.go
+++ b/pkg/kafka/partition/committer.go
@@ -26,7 +26,7 @@ type partitionCommitter struct {
 	lastCommittedOffset   prometheus.Gauge
 
 	logger     log.Logger
-	reader     ReaderIfc
+	reader     Reader
 	commitFreq time.Duration
 
 	toCommit *atomic.Int64
@@ -34,7 +34,7 @@ type partitionCommitter struct {
 	cancel   context.CancelFunc
 }
 
-func newCommitter(reader ReaderIfc, commitFreq time.Duration, logger log.Logger, reg prometheus.Registerer) *partitionCommitter {
+func newCommitter(reader Reader, commitFreq time.Duration, logger log.Logger, reg prometheus.Registerer) *partitionCommitter {
 	c := &partitionCommitter{
 		logger:     logger,
 		reader:     reader,

--- a/pkg/kafka/partition/committer_test.go
+++ b/pkg/kafka/partition/committer_test.go
@@ -36,7 +36,7 @@ func TestPartitionCommitter(t *testing.T) {
 	reg := prometheus.NewRegistry()
 	partitionID := int32(1)
 	consumerGroup := "test-consumer-group"
-	reader := newReader(
+	reader := newStdReader(
 		client,
 		kafkaCfg.Topic,
 		partitionID,

--- a/pkg/kafka/partition/reader.go
+++ b/pkg/kafka/partition/reader.go
@@ -37,7 +37,7 @@ type Record struct {
 	Offset   int64
 }
 
-type ReaderIfc interface {
+type Reader interface {
 	Topic() string
 	Partition() int32
 	ConsumerGroup() string
@@ -91,8 +91,8 @@ func newReaderMetrics(r prometheus.Registerer) *readerMetrics {
 	}
 }
 
-// Reader provides low-level access to Kafka partition reading operations
-type Reader struct {
+// StdReader provides low-level access to Kafka partition reading operations
+type StdReader struct {
 	client        *kgo.Client
 	topic         string
 	partitionID   int32
@@ -101,13 +101,13 @@ type Reader struct {
 	logger        log.Logger
 }
 
-func NewReader(
+func NewStdReader(
 	cfg kafka.Config,
 	partitionID int32,
 	instanceID string,
 	logger log.Logger,
 	reg prometheus.Registerer,
-) (*Reader, error) {
+) (*StdReader, error) {
 	// Create a new Kafka client for this reader
 	clientMetrics := client.NewReaderClientMetrics("partition-reader", reg)
 	c, err := client.NewReaderClient(
@@ -120,7 +120,7 @@ func NewReader(
 	}
 
 	// Create the reader
-	return newReader(
+	return newStdReader(
 		c,
 		cfg.Topic,
 		partitionID,
@@ -130,16 +130,16 @@ func NewReader(
 	), nil
 }
 
-// NewReader creates a new Reader instance
-func newReader(
+// newStdReader creates a new StdReader instance
+func newStdReader(
 	client *kgo.Client,
 	topic string,
 	partitionID int32,
 	consumerGroup string,
 	logger log.Logger,
 	reg prometheus.Registerer,
-) *Reader {
-	return &Reader{
+) *StdReader {
+	return &StdReader{
 		client:        client,
 		topic:         topic,
 		partitionID:   partitionID,
@@ -150,22 +150,22 @@ func newReader(
 }
 
 // Topic returns the topic being read
-func (r *Reader) Topic() string {
+func (r *StdReader) Topic() string {
 	return r.topic
 }
 
 // Partition returns the partition being read
-func (r *Reader) Partition() int32 {
+func (r *StdReader) Partition() int32 {
 	return r.partitionID
 }
 
 // ConsumerGroup returns the consumer group
-func (r *Reader) ConsumerGroup() string {
+func (r *StdReader) ConsumerGroup() string {
 	return r.consumerGroup
 }
 
 // FetchLastCommittedOffset retrieves the last committed offset for this partition
-func (r *Reader) FetchLastCommittedOffset(ctx context.Context) (int64, error) {
+func (r *StdReader) FetchLastCommittedOffset(ctx context.Context) (int64, error) {
 	req := kmsg.NewPtrOffsetFetchRequest()
 	req.Topics = []kmsg.OffsetFetchRequestTopic{{
 		Topic:      r.topic,
@@ -210,7 +210,7 @@ func (r *Reader) FetchLastCommittedOffset(ctx context.Context) (int64, error) {
 }
 
 // FetchPartitionOffset retrieves the offset for a specific position
-func (r *Reader) FetchPartitionOffset(ctx context.Context, position SpecialOffset) (int64, error) {
+func (r *StdReader) FetchPartitionOffset(ctx context.Context, position SpecialOffset) (int64, error) {
 	partitionReq := kmsg.NewListOffsetsRequestTopicPartition()
 	partitionReq.Partition = r.partitionID
 	partitionReq.Timestamp = int64(position)
@@ -257,7 +257,7 @@ func (r *Reader) FetchPartitionOffset(ctx context.Context, position SpecialOffse
 }
 
 // Poll retrieves the next batch of records from Kafka
-func (r *Reader) Poll(ctx context.Context) ([]Record, error) {
+func (r *StdReader) Poll(ctx context.Context) ([]Record, error) {
 	start := time.Now()
 	fetches := r.client.PollFetches(ctx)
 	r.metrics.fetchWaitDuration.Observe(time.Since(start).Seconds())
@@ -303,14 +303,14 @@ func (r *Reader) Poll(ctx context.Context) ([]Record, error) {
 	return records, nil
 }
 
-func (r *Reader) SetOffsetForConsumption(offset int64) {
+func (r *StdReader) SetOffsetForConsumption(offset int64) {
 	r.client.AddConsumePartitions(map[string]map[int32]kgo.Offset{
 		r.topic: {r.partitionID: kgo.NewOffset().At(offset)},
 	})
 }
 
 // Commit commits an offset to the consumer group
-func (r *Reader) Commit(ctx context.Context, offset int64) error {
+func (r *StdReader) Commit(ctx context.Context, offset int64) error {
 	admin := kadm.NewClient(r.client)
 
 	// Commit the last consumed offset.

--- a/pkg/kafka/partition/reader_service.go
+++ b/pkg/kafka/partition/reader_service.go
@@ -55,7 +55,7 @@ type ReaderService struct {
 	services.Service
 
 	cfg             ReaderConfig
-	reader          ReaderIfc
+	reader          Reader
 	consumerFactory ConsumerFactory
 	logger          log.Logger
 	metrics         *serviceMetrics
@@ -82,7 +82,7 @@ func NewReaderService(
 ) (*ReaderService, error) {
 
 	// Create the reader
-	reader, err := NewReader(
+	reader, err := NewStdReader(
 		kafkaCfg,
 		partitionID,
 		instanceID,
@@ -109,7 +109,7 @@ func NewReaderService(
 
 func newReaderServiceFromIfc(
 	cfg ReaderConfig,
-	reader ReaderIfc,
+	reader Reader,
 	consumerFactory ConsumerFactory,
 	logger log.Logger,
 	reg prometheus.Registerer,

--- a/pkg/kafka/partition/reader_test.go
+++ b/pkg/kafka/partition/reader_test.go
@@ -63,7 +63,7 @@ func readersFromKafkaCfg(
 	kafkaCfg kafka.Config,
 	consumerFactory ConsumerFactory,
 	partition int32,
-) (ReaderIfc, *ReaderService) {
+) (Reader, *ReaderService) {
 	partitionReader, err := NewReaderService(
 		kafkaCfg,
 		partition,

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -1791,7 +1791,7 @@ func (t *Loki) initBlockBuilder() (services.Service, error) {
 		return nil, fmt.Errorf("calculating block builder partition ID: %w", err)
 	}
 
-	reader, err := partition.NewReader(
+	reader, err := partition.NewStdReader(
 		t.Cfg.KafkaConfig,
 		ingestPartitionID,
 		id,


### PR DESCRIPTION
Ths is a nit, but I think we should avoid using type information in the type definition, this commit renames ReaderIfc to Reader and Reader to StdReader.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
