### PR TITLE
chore: remove minor dead code that was missed in a PR review

### DIFF
--- a/pkg/logql/log/pipeline.go
+++ b/pkg/logql/log/pipeline.go
@@ -68,7 +68,7 @@ func (n *noopPipeline) ForStream(labels labels.Labels) StreamPipeline {
 	}
 	n.mu.RUnlock()
 
-	sp := &noopStreamPipeline{n.baseBuilder.ForLabels(labels, h), make([]int, 0, 10)}
+	sp := &noopStreamPipeline{n.baseBuilder.ForLabels(labels, h)}
 
 	n.mu.Lock()
 	defer n.mu.Unlock()
@@ -93,8 +93,7 @@ func IsNoopPipeline(p Pipeline) bool {
 }
 
 type noopStreamPipeline struct {
-	builder    *LabelsBuilder
-	offsetsBuf []int
+	builder *LabelsBuilder
 }
 
 func (n noopStreamPipeline) ReferencedStructuredMetadata() bool {
@@ -181,13 +180,12 @@ func NewPipeline(stages []Stage) Pipeline {
 }
 
 type streamPipeline struct {
-	stages     []Stage
-	builder    *LabelsBuilder
-	offsetsBuf []int
+	stages  []Stage
+	builder *LabelsBuilder
 }
 
 func NewStreamPipeline(stages []Stage, labelsBuilder *LabelsBuilder) StreamPipeline {
-	return &streamPipeline{stages, labelsBuilder, make([]int, 0, 10)}
+	return &streamPipeline{stages, labelsBuilder}
 }
 
 func (p *pipeline) ForStream(labels labels.Labels) StreamPipeline {


### PR DESCRIPTION
`offsetsBuf` wasn't actually being used anywhere, looks like this just got missed in a refactor commit as part of https://github.com/grafana/loki/pull/13983
cc @MasslessParticle @ashwanthgoli 