### PR TITLE
chore!: Remove `wget` from Promtail docker image

### DIFF
--- a/clients/cmd/promtail/Dockerfile
+++ b/clients/cmd/promtail/Dockerfile
@@ -10,7 +10,7 @@ RUN make clean && make BUILD_IN_CONTAINER=false PROMTAIL_JOURNAL_ENABLED=true pr
 FROM debian:12.8-slim
 # tzdata required for the timestamp stage to work
 RUN apt-get update && \
-  apt-get install -qy tzdata ca-certificates wget libsystemd-dev && \
+  apt-get install -qy tzdata ca-certificates libsystemd-dev && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 COPY --from=build /src/loki/clients/cmd/promtail/promtail /usr/bin/promtail
 COPY clients/cmd/promtail/promtail-docker-config.yaml /etc/promtail/config.yml


### PR DESCRIPTION
**What this PR does / why we need it**:

The package has been added to the Docker image with PR #11711 with the intention to support the Docker healthcheck.

However, to reduce the attack surface of our Docker images, we want to keep them as slim as possible. The current version of Promtail (3.3.0) for example contains a wget version with vulnerability [CVE-2024-38428](https://security-tracker.debian.org/tracker/CVE-2024-38428).

The healthcheck can be achieved by other means, e.g.

1. Extend the `grafana/promtail` base image and add `wget` using `apt install wget`
   https://github.com/grafana/loki/issues/11590#issuecomment-2106037181
3. Use low-level `/dev/tcp/127.0.0.1:9080` to establish a connection and check the exit code
   https://github.com/grafana/loki/issues/11590#issuecomment-2333481326

**Special notes for your reviewer**:

Original discussion about adding wget https://github.com/grafana/loki/issues/11590

**This may break someone's Docker compose installation, when they require on the `wget` powered health check.**

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
