### PR TITLE
chore: move catch up logic to processConsumerLag

### DIFF
--- a/pkg/kafka/partition/reader_service.go
+++ b/pkg/kafka/partition/reader_service.go
@@ -155,16 +155,22 @@ func (s *ReaderService) starting(ctx context.Context) error {
 	level.Debug(s.logger).Log("msg", "consuming from offset", "offset", consumeOffset)
 	s.reader.SetOffsetForConsumption(consumeOffset)
 
-	if targetLag, maxLag := s.cfg.TargetConsumerLagAtStartup, s.cfg.MaxConsumerLagAtStartup; targetLag > 0 && maxLag > 0 {
+	return s.processConsumerLag(ctx)
+}
+
+func (s *ReaderService) processConsumerLag(ctx context.Context) error {
+	targetLag := s.cfg.TargetConsumerLagAtStartup
+	maxLag := s.cfg.MaxConsumerLagAtStartup
+
+	if targetLag > 0 && maxLag > 0 {
 		consumer, err := s.consumerFactory(s.committer)
 		if err != nil {
-			return fmt.Errorf("creating consumer: %w", err)
+			return fmt.Errorf("failed to create consumer: %w", err)
 		}
 
 		cancelCtx, cancel := context.WithCancel(ctx)
 		recordsChan := make(chan []Record)
 		wait := consumer.Start(cancelCtx, recordsChan)
-
 		defer func() {
 			close(recordsChan)
 			cancel()


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a small chore to move the catch up logic to `processConsumerLag`. We can do this as it does not depend on any variables in `starting` other than the context.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
