### PR TITLE
fix(operator): Fix RBAC permission for poddisruptionbudgets

### DIFF
--- a/operator/bundle/community-openshift/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/community-openshift/manifests/loki-operator.clusterserviceversion.yaml
@@ -150,7 +150,7 @@ metadata:
     categories: OpenShift Optional, Logging & Tracing
     certified: "false"
     containerImage: docker.io/grafana/loki-operator:0.7.1
-    createdAt: "2024-11-08T17:18:30Z"
+    createdAt: "2024-11-25T18:28:02Z"
     description: The Community Loki Operator provides Kubernetes native deployment
       and management of Loki and related logging components.
     features.operators.openshift.io/disconnected: "true"
@@ -1771,7 +1771,7 @@ spec:
           - update
           - watch
         - apiGroups:
-          - policy/v1
+          - policy
           resources:
           - poddisruptionbudgets
           verbs:

--- a/operator/bundle/community/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/community/manifests/loki-operator.clusterserviceversion.yaml
@@ -150,7 +150,7 @@ metadata:
     categories: OpenShift Optional, Logging & Tracing
     certified: "false"
     containerImage: docker.io/grafana/loki-operator:0.7.1
-    createdAt: "2024-11-08T17:18:28Z"
+    createdAt: "2024-11-25T18:27:59Z"
     description: The Community Loki Operator provides Kubernetes native deployment
       and management of Loki and related logging components.
     operators.operatorframework.io/builder: operator-sdk-unknown
@@ -1751,7 +1751,7 @@ spec:
           - update
           - watch
         - apiGroups:
-          - policy/v1
+          - policy
           resources:
           - poddisruptionbudgets
           verbs:

--- a/operator/bundle/openshift/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/openshift/manifests/loki-operator.clusterserviceversion.yaml
@@ -150,7 +150,7 @@ metadata:
     categories: OpenShift Optional, Logging & Tracing
     certified: "false"
     containerImage: quay.io/openshift-logging/loki-operator:0.1.0
-    createdAt: "2024-11-08T17:18:32Z"
+    createdAt: "2024-11-25T18:28:06Z"
     description: |
       The Loki Operator for OCP provides a means for configuring and managing a Loki stack for cluster logging.
       ## Prerequisites and Requirements
@@ -1756,7 +1756,7 @@ spec:
           - update
           - watch
         - apiGroups:
-          - policy/v1
+          - policy
           resources:
           - poddisruptionbudgets
           verbs:

--- a/operator/config/rbac/role.yaml
+++ b/operator/config/rbac/role.yaml
@@ -146,7 +146,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - policy/v1
+  - policy
   resources:
   - poddisruptionbudgets
   verbs:

--- a/operator/internal/controller/loki/lokistack_controller.go
+++ b/operator/internal/controller/loki/lokistack_controller.go
@@ -125,7 +125,7 @@ type LokiStackReconciler struct {
 // +kubebuilder:rbac:urls=/api/v2/alerts,verbs=create
 // +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;create;update
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses,verbs=get;list;watch;create;update
-// +kubebuilder:rbac:groups=policy/v1,resources=poddisruptionbudgets,verbs=get;list;watch;create;update
+// +kubebuilder:rbac:groups=policy,resources=poddisruptionbudgets,verbs=get;list;watch;create;update
 // +kubebuilder:rbac:groups=config.openshift.io,resources=dnses;apiservers;proxies,verbs=get;list;watch
 // +kubebuilder:rbac:groups=route.openshift.io,resources=routes,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups=cloudcredential.openshift.io,resources=credentialsrequests,verbs=get;list;watch;create;update;delete


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes an RBAC issue accidentally introduced by #14817. The current permission references `policy/v1` as an API group which is not valid (groups do not contain a version).

The current state causes the operator to stop working once it tries to interact with PodDisruptionBudget resources, because it can not recover from the error returned by the API.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
