### PR TITLE
docs: added additional GCS authentication information

### DIFF
--- a/docs/sources/configure/storage.md
+++ b/docs/sources/configure/storage.md
@@ -237,9 +237,14 @@ storage_config:
   tsdb_shipper:
     active_index_directory: /loki/index
     cache_location: /loki/index_cache
-    cache_ttl: 24h         # Can be increased for faster performance over longer query periods, uses more disk space
+    cache_ttl: 24h # Can be increased for faster performance over longer query periods, uses more disk space
   gcs:
       bucket_name: <bucket>
+      service_account: |    
+        {
+          "type": "service_account",
+          ...
+        }
 
 schema_config:
   configs:
@@ -251,6 +256,12 @@ schema_config:
         prefix: index_
         period: 24h
 ```
+
+`service_account` should contain JSON from either a GCP Console client_credentials.json file or a GCP service account key. If this value is blank, most services will fall back to GCP's Application Default Credentials strategy. See [How Application Default Credentials works](https://cloud.google.com/docs/authentication/application-default-credentials) for more information about ADC.
+
+{{< admonition type="note" >}}
+NOTE: GCP recommends [Workload Identity Federation](https://cloud.google.com/iam/docs/workload-identity-federation) instead of a service account key.
+{{< /admonition >}}
 
 ### AWS deployment (S3 Single Store)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Added some basic info about GCS authentication.

**Special notes for your reviewer:**

Not all of Loki/GEL's services support ADC. I had to use `loki.structuredConfig.admin_client.storage.gcs.service_account` to force the Admin API to use service account credentials. It did not seem capable of utilizing `GOOGLE_APPLICATION_CREDENTIALS`. 

I'm uncertain how to document this other than to exhaustive documentation. Maybe such detail is more appropriate in the Helm chart docs/examples?

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
