### PR TITLE
fix: incorrect error check in autoCommitLoop

### DIFF
--- a/pkg/kafka/partition/committer.go
+++ b/pkg/kafka/partition/committer.go
@@ -95,11 +95,13 @@ func (c *partitionCommitter) autoCommitLoop(ctx context.Context) {
 				continue
 			}
 
-			if err := c.Commit(ctx, currOffset); err == nil {
-				level.Error(c.logger).Log("msg", "failed to commit", "offset", currOffset)
-				c.lastCommittedOffset.Set(float64(currOffset))
-				previousOffset = currOffset
+			if err := c.Commit(ctx, currOffset); err != nil {
+				level.Error(c.logger).Log("msg", "failed to commit", "offset", currOffset, "err", err)
+				continue
 			}
+
+			c.lastCommittedOffset.Set(float64(currOffset))
+			previousOffset = currOffset
 		}
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit fixes an incorrect error check in `autoCommitLoop`.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
