### PR TITLE
chore: Fix flaky `TestAcquireWithTiming` test

### DIFF
--- a/pkg/querier/queryrange/limits_test.go
+++ b/pkg/querier/queryrange/limits_test.go
@@ -772,6 +772,7 @@ func Test_MaxQuerySize_MaxLookBackPeriod(t *testing.T) {
 }
 
 func TestAcquireWithTiming(t *testing.T) {
+	t.Skip("flaky test")
 
 	ctx := context.Background()
 	sem := NewSemaphoreWithTiming(2)

--- a/pkg/querier/queryrange/limits_test.go
+++ b/pkg/querier/queryrange/limits_test.go
@@ -772,15 +772,13 @@ func Test_MaxQuerySize_MaxLookBackPeriod(t *testing.T) {
 }
 
 func TestAcquireWithTiming(t *testing.T) {
-	t.Skip("flaky test")
-
 	ctx := context.Background()
 	sem := NewSemaphoreWithTiming(2)
 
 	// Channel to collect waiting times
 	waitingTimes := make(chan struct {
 		GoroutineID int
-		WaitingTime int64
+		WaitingTime time.Duration
 	}, 3)
 
 	tryAcquire := func(n int64, goroutineID int) {
@@ -790,8 +788,8 @@ func TestAcquireWithTiming(t *testing.T) {
 		}
 		waitingTimes <- struct {
 			GoroutineID int
-			WaitingTime int64
-		}{goroutineID, elapsed.Milliseconds()}
+			WaitingTime time.Duration
+		}{goroutineID, elapsed}
 
 		defer sem.sem.Release(n)
 
@@ -809,13 +807,13 @@ func TestAcquireWithTiming(t *testing.T) {
 	// Collect and sort waiting times
 	var waitingDurations []struct {
 		GoroutineID int
-		WaitingTime int64
+		WaitingTime time.Duration
 	}
 	for i := 0; i < 3; i++ {
 		waitingDurations = append(waitingDurations, <-waitingTimes)
 	}
 	// Find and check the waiting time for the third goroutine
-	var waiting3 int64
+	var waiting3 time.Duration
 	for _, waiting := range waitingDurations {
 		if waiting.GoroutineID == 3 {
 			waiting3 = waiting.WaitingTime
@@ -823,7 +821,7 @@ func TestAcquireWithTiming(t *testing.T) {
 		}
 	}
 
-	// Check that the waiting time for the third request is larger than 0 milliseconds and less than or equal to 10-5=5 milliseconds
-	require.Greater(t, waiting3, 0*time.Millisecond)
-	require.LessOrEqual(t, waiting3, 5*time.Millisecond)
+	// Check that the waiting time for the third request is larger than 0 milliseconds and less than 10 milliseconds
+	require.Greater(t, waiting3, 0*time.Nanosecond)
+	require.Less(t, waiting3, 10*time.Millisecond)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

The test case is flaky. Recent failure on release branch: https://github.com/grafana/loki/actions/runs/12049536800/job/33596506996?pr=15148