### PR TITLE
Fix: Add label to exlude memcache extstore volume from disk full alerting

### DIFF
--- a/production/helm/loki/templates/memcached/_memcached-statefulset.tpl
+++ b/production/helm/loki/templates/memcached/_memcached-statefulset.tpl
@@ -163,6 +163,8 @@ spec:
   volumeClaimTemplates:
     - metadata:
         name: data
+        labels:
+          excluded_from_alerts: "true"
       spec:
         accessModes: [ "ReadWriteOnce" ]
         {{- with .persistence.storageClass }}


### PR DESCRIPTION
**What this PR does / why we need it**:

Memcached: Add special label that exludes the always full extstore PVC from the alert KubePersistentVolumeFillingUp

The volume is meant to be full so the standard monitoring alert will be noise.

The alert is described at https://github.com/prometheus-operator/kube-prometheus/wiki/kubepersistentvolumefillingup

But I found a magic label that can be attached to the PVC:

https://github.com/kubernetes-monitoring/kubernetes-mixin/pull/711

Related to #14049 

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
