### PR TITLE
feat: log stream limit errors back to insights logging

### DIFF
--- a/pkg/ingester/instance.go
+++ b/pkg/ingester/instance.go
@@ -341,6 +341,7 @@ func (i *instance) onStreamCreationError(ctx context.Context, pushReqStream logp
 	if i.customStreamsTracker != nil {
 		i.customStreamsTracker.DiscardedBytesAdd(ctx, i.instanceID, validation.StreamLimit, labels, float64(bytes))
 	}
+	i.writeFailures.Log(i.instanceID, fmt.Errorf(validation.StreamLimitErrorMsg, labels, i.instanceID))
 	return nil, httpgrpc.Errorf(http.StatusTooManyRequests, validation.StreamLimitErrorMsg, labels, i.instanceID)
 }
 


### PR DESCRIPTION
At the moment `stream_limit`, as in the limit for the maximum # of active streams a tenant may have, is only propagated back to end users via HTTP errors to their logs agent. We have internal logging of these errors as well, but it would be useful to also propagate such error messages back to Grafana Cloud Logs users in their Logs Usage Insights datasource so that they can more easily self serve investigations into these errors, and so we could also build a dashboard to aid in such investigations if we decided to do so.

This PR adds logging of the `stream_limit` errors to the `writeFailures` logging, which is just a simple wrapper for correctly logging the tenant ID and `insight=true` to ingestion path logging which we want to propagated to usage insights datasources.