### PR TITLE
feat: add phase to log lines in kafka_consumer.go

### DIFF
--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -384,7 +384,7 @@ func New(cfg Config, clientConfig client.Config, store Store, limits Limits, con
 			cfg.KafkaIngestion.KafkaConfig,
 			i.ingestPartitionID,
 			cfg.LifecyclerConfig.ID,
-			NewKafkaConsumerFactory(i, logger, registerer),
+			NewKafkaConsumerFactory(i, registerer),
 			logger,
 			registerer,
 		)

--- a/pkg/ingester/kafka_consumer.go
+++ b/pkg/ingester/kafka_consumer.go
@@ -39,9 +39,9 @@ func newConsumerMetrics(reg prometheus.Registerer) *consumerMetrics {
 	}
 }
 
-func NewKafkaConsumerFactory(pusher logproto.PusherServer, logger log.Logger, reg prometheus.Registerer) partition.ConsumerFactory {
+func NewKafkaConsumerFactory(pusher logproto.PusherServer, reg prometheus.Registerer) partition.ConsumerFactory {
 	metrics := newConsumerMetrics(reg)
-	return func(committer partition.Committer) (partition.Consumer, error) {
+	return func(committer partition.Committer, logger log.Logger) (partition.Consumer, error) {
 		decoder, err := kafka.NewDecoder()
 		if err != nil {
 			return nil, err

--- a/pkg/ingester/kafka_consumer_test.go
+++ b/pkg/ingester/kafka_consumer_test.go
@@ -85,7 +85,7 @@ func TestConsumer(t *testing.T) {
 		pusher = &fakePusher{t: t}
 	)
 
-	consumer, err := NewKafkaConsumerFactory(pusher, log.NewLogfmtLogger(os.Stdout), prometheus.NewRegistry())(&noopCommitter{})
+	consumer, err := NewKafkaConsumerFactory(pusher, prometheus.NewRegistry())(&noopCommitter{}, log.NewLogfmtLogger(os.Stdout))
 	require.NoError(t, err)
 
 	records, err := kafka.Encode(0, tenantID, streamBar, 10000)

--- a/pkg/kafka/partition/reader_test.go
+++ b/pkg/kafka/partition/reader_test.go
@@ -82,7 +82,7 @@ func TestPartitionReader_BasicFunctionality(t *testing.T) {
 	_, kafkaCfg := testkafka.CreateCluster(t, 1, "test")
 	consumer := newMockConsumer()
 
-	consumerFactory := func(_ Committer) (Consumer, error) {
+	consumerFactory := func(_ Committer, _ log.Logger) (Consumer, error) {
 		return consumer, nil
 	}
 
@@ -136,7 +136,7 @@ func TestPartitionReader_ProcessCatchUpAtStartup(t *testing.T) {
 	_, kafkaCfg := testkafka.CreateCluster(t, 1, "test-topic")
 	var consumerStarting *mockConsumer
 
-	consumerFactory := func(_ Committer) (Consumer, error) {
+	consumerFactory := func(_ Committer, _ log.Logger) (Consumer, error) {
 		// Return two consumers to ensure we are processing requests during service `start()` and not during `run()`.
 		if consumerStarting == nil {
 			consumerStarting = newMockConsumer()
@@ -198,7 +198,7 @@ func TestPartitionReader_ProcessCommits(t *testing.T) {
 	_, kafkaCfg := testkafka.CreateCluster(t, 1, "test-topic")
 	consumer := newMockConsumer()
 
-	consumerFactory := func(_ Committer) (Consumer, error) {
+	consumerFactory := func(_ Committer, _ log.Logger) (Consumer, error) {
 		return consumer, nil
 	}
 
@@ -267,7 +267,7 @@ func TestPartitionReader_StartsAtNextOffset(t *testing.T) {
 	consumer := newMockConsumer()
 
 	kaf.CurrentNode()
-	consumerFactory := func(_ Committer) (Consumer, error) {
+	consumerFactory := func(_ Committer, _ log.Logger) (Consumer, error) {
 		return consumer, nil
 	}
 
@@ -329,7 +329,7 @@ func TestPartitionReader_StartsUpIfNoNewRecordsAreAvailable(t *testing.T) {
 	consumer := newMockConsumer()
 
 	kaf.CurrentNode()
-	consumerFactory := func(_ Committer) (Consumer, error) {
+	consumerFactory := func(_ Committer, _ log.Logger) (Consumer, error) {
 		return consumer, nil
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit adds the phase to the log lines in kafka_consumer.go to make it easier to understand if the ingester is in starting phase or in running phase.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
