### PR TITLE
fix: Set hedging delay on partition-ingester calls in case of failure

### DIFF
--- a/pkg/querier/ingester_querier.go
+++ b/pkg/querier/ingester_querier.go
@@ -198,6 +198,7 @@ func (q *IngesterQuerier) forGivenIngesterSets(ctx context.Context, replicationS
 	// Ingesters must supply zone information for this to have an effect.
 	config := ring.DoUntilQuorumConfig{
 		MinimizeRequests: true,
+		HedgingDelay:     250 * time.Millisecond,
 	}
 	return concurrency.ForEachJobMergeResults[ring.ReplicationSet, responseFromIngesters](ctx, replicationSet, 0, func(ctx context.Context, set ring.ReplicationSet) ([]responseFromIngesters, error) {
 		return q.forGivenIngesters(ctx, set, config, f)

--- a/pkg/querier/ingester_querier_test.go
+++ b/pkg/querier/ingester_querier_test.go
@@ -132,6 +132,15 @@ func TestIngesterQuerier_earlyExitOnQuorum(t *testing.T) {
 		}
 	}
 
+	/*
+		Unary rpc calls receive ctx populated by the
+		replication set tracker to exit early on reaching quorum or max
+		failures.
+
+		This doesn't apply to the following stream rpc calls given how the code is
+		structured where we are processing the streams outside of
+		the work func, so these contexts must not be cancelled.
+	*/
 	tests = map[string]struct {
 		method string
 		testFn func(*IngesterQuerier) error


### PR DESCRIPTION
**What this PR does / why we need it**:

Enables a hedging delay on all query requests to the partition-ingester

Currently, the behaviour is to try another ingester if the first one returns an error. There may some cases where we don't return an error but instead timeout or just have high latency processing a lot of data. We don't set an explicit timeout on the requests (in fact, we ignore the context from the ring tracker on SelectLogs) so we won't see an error in the slow cases, and won't fire another request.
Setting the hedging delay will fire a request to the other instance in this case, which may return faster. Note: We will not cancel any outstanding requests - there are existing tests to ensure this behaviour so I haven't changed it.

Finally, the hedging value I chose is far higher than the p99 most of the time (~5ms) but lower than the slowest  p99 (800ms-2seconds) observed from cloud deployments. If a query is slow because there is a lot of data to query, this may double the overall workload. I tried to pick a value to trade off between waiting a long time and generating more work unneccessarily, but it will remain to be seen if this is a good one.

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
