### PR TITLE
feat: Detect fields  based on per-tenant configuration and put them into structured metadata at ingest time

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -3400,6 +3400,10 @@ The `limits_config` block configures global and per-tenant limits in Loki. The v
 # CLI flag: -validation.increment-duplicate-timestamps
 [increment_duplicate_timestamp: <boolean> | default = false]
 
+# Detect fields from stream labels, structured metadata, or json/logfmt
+# formatted log line and put them into structured metadata of the log entry.
+[discover_generic_fields: <map of string to list of strings>]
+
 # If no service_name label exists, Loki maps a single label from the configured
 # list to service_name. If none of the configured labels exist in the stream,
 # label is set to unknown_service. Empty list disables setting the label.

--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -3400,8 +3400,9 @@ The `limits_config` block configures global and per-tenant limits in Loki. The v
 # CLI flag: -validation.increment-duplicate-timestamps
 [increment_duplicate_timestamp: <boolean> | default = false]
 
-# Detect fields from stream labels, structured metadata, or json/logfmt
-# formatted log line and put them into structured metadata of the log entry.
+# Experimental: Detect fields from stream labels, structured metadata, or
+# json/logfmt formatted log line and put them into structured metadata of the
+# log entry.
 [discover_generic_fields: <map of string to list of strings>]
 
 # If no service_name label exists, Loki maps a single label from the configured

--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -3403,7 +3403,8 @@ The `limits_config` block configures global and per-tenant limits in Loki. The v
 # Experimental: Detect fields from stream labels, structured metadata, or
 # json/logfmt formatted log line and put them into structured metadata of the
 # log entry.
-[discover_generic_fields: <map of string to list of strings>]
+discover_generic_fields:
+  [fields: <map of string to list of strings>]
 
 # If no service_name label exists, Loki maps a single label from the configured
 # list to service_name. If none of the configured labels exist in the stream,

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -460,7 +460,7 @@ func (d *Distributor) Push(ctx context.Context, req *logproto.PushRequest) (*log
 
 	now := time.Now()
 	validationContext := d.validator.getValidationContextForTime(now, tenantID)
-	levelDetector := newLevelDetector(validationContext)
+	levelDetector := newFieldDetector(validationContext)
 	shouldDiscoverLevels := levelDetector.shouldDiscoverLogLevels()
 
 	shardStreamsCfg := d.validator.Limits.ShardStreams(tenantID)

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -460,9 +460,9 @@ func (d *Distributor) Push(ctx context.Context, req *logproto.PushRequest) (*log
 
 	now := time.Now()
 	validationContext := d.validator.getValidationContextForTime(now, tenantID)
-	levelDetector := newFieldDetector(validationContext)
-	shouldDiscoverLevels := levelDetector.shouldDiscoverLogLevels()
-	shouldDiscoverGenericFields := levelDetector.shouldDiscoverGenericFields()
+	fieldDetector := newFieldDetector(validationContext)
+	shouldDiscoverLevels := fieldDetector.shouldDiscoverLogLevels()
+	shouldDiscoverGenericFields := fieldDetector.shouldDiscoverGenericFields()
 
 	shardStreamsCfg := d.validator.Limits.ShardStreams(tenantID)
 	maybeShardByRate := func(stream logproto.Stream, pushSize int) {
@@ -548,14 +548,14 @@ func (d *Distributor) Push(ctx context.Context, req *logproto.PushRequest) (*log
 					}
 				}
 				if shouldDiscoverLevels {
-					logLevel, ok := levelDetector.extractLogLevel(lbs, structuredMetadata, entry)
+					logLevel, ok := fieldDetector.extractLogLevel(lbs, structuredMetadata, entry)
 					if ok {
 						entry.StructuredMetadata = append(entry.StructuredMetadata, logLevel)
 					}
 				}
 				if shouldDiscoverGenericFields {
-					for field, hints := range levelDetector.validationContext.discoverGenericFields {
-						extracted, ok := levelDetector.extractGenericField(field, hints, lbs, structuredMetadata, entry)
+					for field, hints := range fieldDetector.validationContext.discoverGenericFields {
+						extracted, ok := fieldDetector.extractGenericField(field, hints, lbs, structuredMetadata, entry)
 						if ok {
 							entry.StructuredMetadata = append(entry.StructuredMetadata, extracted)
 						}

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -549,7 +549,7 @@ func (d *Distributor) Push(ctx context.Context, req *logproto.PushRequest) (*log
 					}
 				}
 				if shouldDiscoverLevels {
-					pprof.Do(ctx, pprof.Labels("action", "discover_log_level"), func(ctx context.Context) {
+					pprof.Do(ctx, pprof.Labels("action", "discover_log_level"), func(_ context.Context) {
 						logLevel, ok := fieldDetector.extractLogLevel(lbs, structuredMetadata, entry)
 						if ok {
 							entry.StructuredMetadata = append(entry.StructuredMetadata, logLevel)
@@ -557,7 +557,7 @@ func (d *Distributor) Push(ctx context.Context, req *logproto.PushRequest) (*log
 					})
 				}
 				if shouldDiscoverGenericFields {
-					pprof.Do(ctx, pprof.Labels("action", "discover_generic_fields"), func(ctx context.Context) {
+					pprof.Do(ctx, pprof.Labels("action", "discover_generic_fields"), func(_ context.Context) {
 						for field, hints := range fieldDetector.validationContext.discoverGenericFields {
 							extracted, ok := fieldDetector.extractGenericField(field, hints, lbs, structuredMetadata, entry)
 							if ok {

--- a/pkg/distributor/field_detection.go
+++ b/pkg/distributor/field_detection.go
@@ -210,7 +210,7 @@ func getValueUsingJSONParser(line []byte, hints []string) []byte {
 		if err != nil {
 			continue
 		}
-		l, _, _, err := jsonparser.Get(line, log.JSONPathsToStrings(parsed)...)
+		l, _, _, err := jsonparser.Get(line, log.JSONPathToStrings(parsed)...)
 		if err != nil {
 			continue
 		}

--- a/pkg/distributor/field_detection_test.go
+++ b/pkg/distributor/field_detection_test.go
@@ -120,7 +120,7 @@ func Test_DetectLogLevels(t *testing.T) {
 }
 
 func Test_detectLogLevelFromLogEntry(t *testing.T) {
-	ld := newLevelDetector(
+	ld := newFieldDetector(
 		validationContext{
 			discoverLogLevels:       true,
 			allowStructuredMetadata: true,
@@ -285,7 +285,7 @@ func Test_detectLogLevelFromLogEntry(t *testing.T) {
 }
 
 func Test_detectLogLevelFromLogEntryWithCustomLabels(t *testing.T) {
-	ld := newLevelDetector(
+	ld := newFieldDetector(
 		validationContext{
 			discoverLogLevels:       true,
 			allowStructuredMetadata: true,
@@ -391,7 +391,7 @@ func Benchmark_extractLogLevelFromLogLine(b *testing.B) {
 		"Wm3 S7if5qCXPzvuMZ2 gNHdst Z39s9uNc58QBDeYRW umyIF BDqEdqhE tAs2gidkqee3aux8b NLDb7 ZZLekc0cQZ GUKQuBg2pL2y1S " +
 		"RJtBuW ABOqQHLSlNuUw ZlM2nGS2 jwA7cXEOJhY 3oPv4gGAz  Uqdre16MF92C06jOH dayqTCK8XmIilT uvgywFSfNadYvRDQa " +
 		"iUbswJNcwqcr6huw LAGrZS8NGlqqzcD2wFU rm Uqcrh3TKLUCkfkwLm  5CIQbxMCUz boBrEHxvCBrUo YJoF2iyif4xq3q yk "
-	ld := &LevelDetector{
+	ld := &FieldDetector{
 		validationContext: validationContext{
 			discoverLogLevels:       true,
 			allowStructuredMetadata: true,
@@ -407,7 +407,7 @@ func Benchmark_extractLogLevelFromLogLine(b *testing.B) {
 func Benchmark_optParseExtractLogLevelFromLogLineJson(b *testing.B) {
 	logLine := `{"msg": "something" , "level": "error", "id": "1"}`
 
-	ld := newLevelDetector(
+	ld := newFieldDetector(
 		validationContext{
 			discoverLogLevels:       true,
 			allowStructuredMetadata: true,
@@ -422,7 +422,7 @@ func Benchmark_optParseExtractLogLevelFromLogLineJson(b *testing.B) {
 
 func Benchmark_optParseExtractLogLevelFromLogLineLogfmt(b *testing.B) {
 	logLine := `FOO=bar MSG="message with keyword error but it should not get picked up" LEVEL=inFO`
-	ld := newLevelDetector(
+	ld := newFieldDetector(
 		validationContext{
 			discoverLogLevels:       true,
 			allowStructuredMetadata: true,

--- a/pkg/distributor/field_detection_test.go
+++ b/pkg/distributor/field_detection_test.go
@@ -468,8 +468,9 @@ func Test_DetectGenericFields(t *testing.T) {
 	detector := newFieldDetector(
 		validationContext{
 			discoverGenericFields: map[string][]string{
-				"trace_id": []string{"trace_id"},
-				"org_id":   []string{"org_id", "user_id", "tenant_id"},
+				"trace_id":   []string{"trace_id"},
+				"org_id":     []string{"org_id", "user_id", "tenant_id"},
+				"product_id": []string{"product.id"}, // jsonpath
 			},
 			allowStructuredMetadata: true,
 		})
@@ -575,6 +576,19 @@ func Test_DetectGenericFields(t *testing.T) {
 			},
 			expected: push.LabelsAdapter{
 				{Name: "org_id", Value: "fake_b"}, // first field from configuration that matches takes precedence
+			},
+		},
+		{
+			name: "logline matches jsonpath",
+			labels: labels.Labels{
+				{Name: "env", Value: "prod"},
+			},
+			entry: push.Entry{
+				Line:               `{"product": {"details": "product details", "id": "P2024/01"}}`,
+				StructuredMetadata: push.LabelsAdapter{},
+			},
+			expected: push.LabelsAdapter{
+				{Name: "product_id", Value: "P2024/01"},
 			},
 		},
 	} {

--- a/pkg/distributor/field_detection_test.go
+++ b/pkg/distributor/field_detection_test.go
@@ -538,6 +538,19 @@ func Test_DetectGenericFields(t *testing.T) {
 			},
 		},
 		{
+			name: "logline (logfmt) matches multiple fields",
+			labels: labels.Labels{
+				{Name: "env", Value: "prod"},
+			},
+			entry: push.Entry{
+				Line:               `msg="this log line matches" tenant_id="fake_a" org_id=fake_b duration=1h`,
+				StructuredMetadata: push.LabelsAdapter{},
+			},
+			expected: push.LabelsAdapter{
+				{Name: "org_id", Value: "fake_b"}, // first field from configuration that matches takes precedence
+			},
+		},
+		{
 			name: "logline (json) matches",
 			labels: labels.Labels{
 				{Name: "env", Value: "prod"},
@@ -549,6 +562,19 @@ func Test_DetectGenericFields(t *testing.T) {
 			expected: push.LabelsAdapter{
 				{Name: "trace_id", Value: "8c5f2ecbade6f01d"},
 				{Name: "org_id", Value: "fake"},
+			},
+		},
+		{
+			name: "logline (json) matches multiple fields",
+			labels: labels.Labels{
+				{Name: "env", Value: "prod"},
+			},
+			entry: push.Entry{
+				Line:               `{"msg": "this log line matches", "tenant_id": "fake_a", "org_id": "fake_b", "duration": "1s"}`,
+				StructuredMetadata: push.LabelsAdapter{},
+			},
+			expected: push.LabelsAdapter{
+				{Name: "org_id", Value: "fake_b"}, // first field from configuration that matches takes precedence
 			},
 		},
 	} {

--- a/pkg/distributor/field_detection_test.go
+++ b/pkg/distributor/field_detection_test.go
@@ -448,7 +448,7 @@ func Test_DetectGenericFields_Enabled(t *testing.T) {
 	t.Run("disabled if structured metadata is not allowed", func(t *testing.T) {
 		detector := newFieldDetector(
 			validationContext{
-				discoverGenericFields:   map[string][]string{"trace_id": []string{"trace_id", "TRACE_ID"}},
+				discoverGenericFields:   map[string][]string{"trace_id": {"trace_id", "TRACE_ID"}},
 				allowStructuredMetadata: false,
 			})
 		require.False(t, detector.shouldDiscoverGenericFields())
@@ -456,7 +456,7 @@ func Test_DetectGenericFields_Enabled(t *testing.T) {
 	t.Run("enabled if structured metadata is allowed and map is not empty", func(t *testing.T) {
 		detector := newFieldDetector(
 			validationContext{
-				discoverGenericFields:   map[string][]string{"trace_id": []string{"trace_id", "TRACE_ID"}},
+				discoverGenericFields:   map[string][]string{"trace_id": {"trace_id", "TRACE_ID"}},
 				allowStructuredMetadata: true,
 			})
 		require.True(t, detector.shouldDiscoverGenericFields())
@@ -468,9 +468,9 @@ func Test_DetectGenericFields(t *testing.T) {
 	detector := newFieldDetector(
 		validationContext{
 			discoverGenericFields: map[string][]string{
-				"trace_id":   []string{"trace_id"},
-				"org_id":     []string{"org_id", "user_id", "tenant_id"},
-				"product_id": []string{"product.id"}, // jsonpath
+				"trace_id":   {"trace_id"},
+				"org_id":     {"org_id", "user_id", "tenant_id"},
+				"product_id": {"product.id"}, // jsonpath
 			},
 			allowStructuredMetadata: true,
 		})

--- a/pkg/distributor/limits.go
+++ b/pkg/distributor/limits.go
@@ -23,6 +23,7 @@ type Limits interface {
 
 	IncrementDuplicateTimestamps(userID string) bool
 	DiscoverServiceName(userID string) []string
+	DiscoverGenericFields(userID string) map[string][]string
 	DiscoverLogLevels(userID string) bool
 	LogLevelFields(userID string) []string
 

--- a/pkg/distributor/validator.go
+++ b/pkg/distributor/validator.go
@@ -45,6 +45,7 @@ type validationContext struct {
 
 	incrementDuplicateTimestamps bool
 	discoverServiceName          []string
+	discoverGenericFields        map[string][]string
 	discoverLogLevels            bool
 	logLevelFields               []string
 
@@ -73,6 +74,7 @@ func (v Validator) getValidationContextForTime(now time.Time, userID string) val
 		discoverServiceName:          v.DiscoverServiceName(userID),
 		discoverLogLevels:            v.DiscoverLogLevels(userID),
 		logLevelFields:               v.LogLevelFields(userID),
+		discoverGenericFields:        v.DiscoverGenericFields(userID),
 		allowStructuredMetadata:      v.AllowStructuredMetadata(userID),
 		maxStructuredMetadataSize:    v.MaxStructuredMetadataSize(userID),
 		maxStructuredMetadataCount:   v.MaxStructuredMetadataCount(userID),

--- a/pkg/logql/log/parser.go
+++ b/pkg/logql/log/parser.go
@@ -571,7 +571,7 @@ func NewJSONExpressionParser(expressions []LabelExtractionExpr) (*JSONExpression
 		}
 
 		ids = append(ids, exp.Identifier)
-		paths = append(paths, JSONPathsToStrings(path))
+		paths = append(paths, JSONPathToStrings(path))
 	}
 
 	return &JSONExpressionParser{
@@ -581,17 +581,17 @@ func NewJSONExpressionParser(expressions []LabelExtractionExpr) (*JSONExpression
 	}, nil
 }
 
-func JSONPathsToStrings(paths []interface{}) []string {
-	stingPaths := make([]string, 0, len(paths))
+func JSONPathToStrings(paths []interface{}) []string {
+	stringPaths := make([]string, 0, len(paths))
 	for _, p := range paths {
 		switch v := p.(type) {
 		case int:
-			stingPaths = append(stingPaths, fmt.Sprintf("[%d]", v))
+			stringPaths = append(stringPaths, fmt.Sprintf("[%d]", v))
 		case string:
-			stingPaths = append(stingPaths, v)
+			stringPaths = append(stringPaths, v)
 		}
 	}
-	return stingPaths
+	return stringPaths
 }
 
 func (j *JSONExpressionParser) Process(_ int64, line []byte, lbs *LabelsBuilder) ([]byte, bool) {

--- a/pkg/logql/log/parser.go
+++ b/pkg/logql/log/parser.go
@@ -571,7 +571,7 @@ func NewJSONExpressionParser(expressions []LabelExtractionExpr) (*JSONExpression
 		}
 
 		ids = append(ids, exp.Identifier)
-		paths = append(paths, pathsToString(path))
+		paths = append(paths, JSONPathsToStrings(path))
 	}
 
 	return &JSONExpressionParser{
@@ -581,7 +581,7 @@ func NewJSONExpressionParser(expressions []LabelExtractionExpr) (*JSONExpression
 	}, nil
 }
 
-func pathsToString(paths []interface{}) []string {
+func JSONPathsToStrings(paths []interface{}) []string {
 	stingPaths := make([]string, 0, len(paths))
 	for _, p := range paths {
 		switch v := p.(type) {

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -86,7 +86,7 @@ type Limits struct {
 	IncrementDuplicateTimestamp bool             `yaml:"increment_duplicate_timestamp" json:"increment_duplicate_timestamp"`
 
 	// Metadata field extraction
-	DiscoverGenericFields map[string][]string `yaml:"discover_generic_fields" json:"discover_generic_fields" doc:"description=Detect fields from stream labels, structured metadata, or json/logfmt formatted log line and put them into structured metadata of the log entry."`
+	DiscoverGenericFields map[string][]string `yaml:"discover_generic_fields" json:"discover_generic_fields" doc:"description=Experimental: Detect fields from stream labels, structured metadata, or json/logfmt formatted log line and put them into structured metadata of the log entry."`
 	DiscoverServiceName   []string            `yaml:"discover_service_name" json:"discover_service_name"`
 	DiscoverLogLevels     bool                `yaml:"discover_log_levels" json:"discover_log_levels"`
 	LogLevelFields        []string            `yaml:"log_level_fields" json:"log_level_fields"`

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -84,9 +84,12 @@ type Limits struct {
 	MaxLineSize                 flagext.ByteSize `yaml:"max_line_size" json:"max_line_size"`
 	MaxLineSizeTruncate         bool             `yaml:"max_line_size_truncate" json:"max_line_size_truncate"`
 	IncrementDuplicateTimestamp bool             `yaml:"increment_duplicate_timestamp" json:"increment_duplicate_timestamp"`
-	DiscoverServiceName         []string         `yaml:"discover_service_name" json:"discover_service_name"`
-	DiscoverLogLevels           bool             `yaml:"discover_log_levels" json:"discover_log_levels"`
-	LogLevelFields              []string         `yaml:"log_level_fields" json:"log_level_fields"`
+
+	// Metadata field extraction
+	DiscoverGenericFields map[string][]string `yaml:"discover_generic_fields" json:"discover_generic_fields" doc:"description=Detect fields from stream labels, structured metadata, or json/logfmt formatted log line and put them into structured metadata of the log entry."`
+	DiscoverServiceName   []string            `yaml:"discover_service_name" json:"discover_service_name"`
+	DiscoverLogLevels     bool                `yaml:"discover_log_levels" json:"discover_log_levels"`
+	LogLevelFields        []string            `yaml:"log_level_fields" json:"log_level_fields"`
 
 	// Ingester enforced limits.
 	UseOwnedStreamCount     bool             `yaml:"use_owned_stream_count" json:"use_owned_stream_count"`
@@ -428,7 +431,6 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	)
 
 	l.ShardStreams.RegisterFlagsWithPrefix("shard-streams", f)
-
 	f.IntVar(&l.VolumeMaxSeries, "limits.volume-max-series", 1000, "The default number of aggregated series or labels that can be returned from a log-volume endpoint")
 
 	f.BoolVar(&l.AllowStructuredMetadata, "validation.allow-structured-metadata", true, "Allow user to send structured metadata (non-indexed labels) in push payload.")
@@ -994,6 +996,10 @@ func (o *Overrides) PerStreamRateLimit(userID string) RateLimit {
 
 func (o *Overrides) IncrementDuplicateTimestamps(userID string) bool {
 	return o.getOverridesForUser(userID).IncrementDuplicateTimestamp
+}
+
+func (o *Overrides) DiscoverGenericFields(userID string) map[string][]string {
+	return o.getOverridesForUser(userID).DiscoverGenericFields
 }
 
 func (o *Overrides) DiscoverServiceName(userID string) []string {

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -86,7 +86,7 @@ type Limits struct {
 	IncrementDuplicateTimestamp bool             `yaml:"increment_duplicate_timestamp" json:"increment_duplicate_timestamp"`
 
 	// Metadata field extraction
-	DiscoverGenericFields map[string][]string `yaml:"discover_generic_fields" json:"discover_generic_fields" doc:"description=Experimental: Detect fields from stream labels, structured metadata, or json/logfmt formatted log line and put them into structured metadata of the log entry."`
+	DiscoverGenericFields FieldDetectorConfig `yaml:"discover_generic_fields" json:"discover_generic_fields" doc:"description=Experimental: Detect fields from stream labels, structured metadata, or json/logfmt formatted log line and put them into structured metadata of the log entry."`
 	DiscoverServiceName   []string            `yaml:"discover_service_name" json:"discover_service_name"`
 	DiscoverLogLevels     bool                `yaml:"discover_log_levels" json:"discover_log_levels"`
 	LogLevelFields        []string            `yaml:"log_level_fields" json:"log_level_fields"`
@@ -245,6 +245,10 @@ type Limits struct {
 	S3SSEType                 string `yaml:"s3_sse_type" json:"s3_sse_type" doc:"nocli|description=S3 server-side encryption type. Required to enable server-side encryption overrides for a specific tenant. If not set, the default S3 client settings are used."`
 	S3SSEKMSKeyID             string `yaml:"s3_sse_kms_key_id" json:"s3_sse_kms_key_id" doc:"nocli|description=S3 server-side encryption KMS Key ID. Ignored if the SSE type override is not set."`
 	S3SSEKMSEncryptionContext string `yaml:"s3_sse_kms_encryption_context" json:"s3_sse_kms_encryption_context" doc:"nocli|description=S3 server-side encryption KMS encryption context. If unset and the key ID override is set, the encryption context will not be provided to S3. Ignored if the SSE type override is not set."`
+}
+
+type FieldDetectorConfig struct {
+	Fields map[string][]string `yaml:"fields" json:"fields"`
 }
 
 type StreamRetention struct {
@@ -999,7 +1003,7 @@ func (o *Overrides) IncrementDuplicateTimestamps(userID string) bool {
 }
 
 func (o *Overrides) DiscoverGenericFields(userID string) map[string][]string {
-	return o.getOverridesForUser(userID).DiscoverGenericFields
+	return o.getOverridesForUser(userID).DiscoverGenericFields.Fields
 }
 
 func (o *Overrides) DiscoverServiceName(userID string) []string {

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -248,7 +248,7 @@ type Limits struct {
 }
 
 type FieldDetectorConfig struct {
-	Fields map[string][]string `yaml:"fields" json:"fields"`
+	Fields map[string][]string `yaml:"fields,omitempty" json:"fields,omitempty"`
 }
 
 type StreamRetention struct {

--- a/pkg/validation/limits_test.go
+++ b/pkg/validation/limits_test.go
@@ -214,6 +214,7 @@ ruler_remote_write_headers:
   foo: "bar"
 `,
 			exp: Limits{
+				DiscoverGenericFields:   map[string][]string{},
 				RulerRemoteWriteHeaders: OverwriteMarshalingStringMap{map[string]string{"foo": "bar"}},
 				DiscoverServiceName:     []string{},
 				LogLevelFields:          []string{},
@@ -234,8 +235,9 @@ ruler_remote_write_headers:
 ruler_remote_write_headers:
 `,
 			exp: Limits{
-				DiscoverServiceName: []string{},
-				LogLevelFields:      []string{},
+				DiscoverGenericFields: map[string][]string{},
+				DiscoverServiceName:   []string{},
+				LogLevelFields:        []string{},
 				// Rest from new defaults
 				StreamRetention: []StreamRetention{
 					{
@@ -254,8 +256,9 @@ retention_stream:
     selector: '{foo="bar"}'
 `,
 			exp: Limits{
-				DiscoverServiceName: []string{},
-				LogLevelFields:      []string{},
+				DiscoverGenericFields: map[string][]string{},
+				DiscoverServiceName:   []string{},
+				LogLevelFields:        []string{},
 				StreamRetention: []StreamRetention{
 					{
 						Period:   model.Duration(24 * time.Hour),
@@ -274,9 +277,10 @@ retention_stream:
 reject_old_samples: true
 `,
 			exp: Limits{
-				RejectOldSamples:    true,
-				DiscoverServiceName: []string{},
-				LogLevelFields:      []string{},
+				RejectOldSamples:      true,
+				DiscoverGenericFields: map[string][]string{},
+				DiscoverServiceName:   []string{},
+				LogLevelFields:        []string{},
 
 				// Rest from new defaults
 				RulerRemoteWriteHeaders: OverwriteMarshalingStringMap{map[string]string{"a": "b"}},
@@ -295,8 +299,9 @@ reject_old_samples: true
 query_timeout: 5m
 `,
 			exp: Limits{
-				DiscoverServiceName: []string{},
-				LogLevelFields:      []string{},
+				DiscoverGenericFields: map[string][]string{},
+				DiscoverServiceName:   []string{},
+				LogLevelFields:        []string{},
 
 				QueryTimeout: model.Duration(5 * time.Minute),
 

--- a/pkg/validation/limits_test.go
+++ b/pkg/validation/limits_test.go
@@ -214,7 +214,7 @@ ruler_remote_write_headers:
   foo: "bar"
 `,
 			exp: Limits{
-				DiscoverGenericFields:   map[string][]string{},
+				DiscoverGenericFields:   FieldDetectorConfig{},
 				RulerRemoteWriteHeaders: OverwriteMarshalingStringMap{map[string]string{"foo": "bar"}},
 				DiscoverServiceName:     []string{},
 				LogLevelFields:          []string{},
@@ -235,7 +235,7 @@ ruler_remote_write_headers:
 ruler_remote_write_headers:
 `,
 			exp: Limits{
-				DiscoverGenericFields: map[string][]string{},
+				DiscoverGenericFields: FieldDetectorConfig{},
 				DiscoverServiceName:   []string{},
 				LogLevelFields:        []string{},
 				// Rest from new defaults
@@ -256,7 +256,7 @@ retention_stream:
     selector: '{foo="bar"}'
 `,
 			exp: Limits{
-				DiscoverGenericFields: map[string][]string{},
+				DiscoverGenericFields: FieldDetectorConfig{},
 				DiscoverServiceName:   []string{},
 				LogLevelFields:        []string{},
 				StreamRetention: []StreamRetention{
@@ -278,7 +278,7 @@ reject_old_samples: true
 `,
 			exp: Limits{
 				RejectOldSamples:      true,
-				DiscoverGenericFields: map[string][]string{},
+				DiscoverGenericFields: FieldDetectorConfig{},
 				DiscoverServiceName:   []string{},
 				LogLevelFields:        []string{},
 
@@ -299,7 +299,7 @@ reject_old_samples: true
 query_timeout: 5m
 `,
 			exp: Limits{
-				DiscoverGenericFields: map[string][]string{},
+				DiscoverGenericFields: FieldDetectorConfig{},
 				DiscoverServiceName:   []string{},
 				LogLevelFields:        []string{},
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR introduces a new feature that allows for extraction of "fields" into structured metadata at ingest time.

Fields can either be regular labels, structured metadata keys, or keys from `logfmt` or `json` formatted log lines. 

The fields are defined in a per-tenant configuration as `map[string][]string`, where the key is the target key of the structured metadata, and the value is the list of source fields in given order and the order given above.

Example configuration:

```yaml
limits_config:
  discover_generic_fields:
    trace_id:
      - "trace_id"
      - "TRACE_ID"
      - "traceID"
      - "TraceID"
    org_id:
      - "org_id"
      - "tenant_id"
      - "user_id"
```

**Update**: The fields moved into a "fields" objects:

```yaml
limits_config:
  discover_generic_fields:
    fields:
      trace_id:
        - "trace_id"
        - "TRACE_ID"
        - "traceID"
        - "TraceID"
      org_id:
        - "org_id"
        - "tenant_id"
        - "user_id"
```

While parsing of log lines comes with a certain penalty at ingest time (increased latency and CPU usage on distributors), the idea is to extract certain fields once to avoid parsing the log lines every single time at query time. This is mainly useful in combination with bloom filters.

**Discussion**

Should the value of the config map support jsonpath expression, such as

```
limits_config:
  discover_generic_fields:
    ticket_id:
      - "message.ticket.id"
```
Where the log line looks like this:

```json
{"timestamp": 1733128051000, "message": {"ticket": {"id": "2024-d95f87018cdb1f10"}}}
```

:heavy_check_mark: jsonpath support has been implemented with https://github.com/grafana/loki/pull/15188/commits/d216856a5b7cef2f46f613173f34a6febea420c7

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
