### PR TITLE
chore(deps): Move from base-nossl to static

### DIFF
--- a/cmd/logcli/Dockerfile
+++ b/cmd/logcli/Dockerfile
@@ -1,12 +1,12 @@
 ARG GO_VERSION=1.23
-FROM golang:${GO_VERSION} as build
+FROM golang:${GO_VERSION} AS build
 
 COPY . /src/loki
 WORKDIR /src/loki
 RUN make clean && make BUILD_IN_CONTAINER=false logcli
 
 
-FROM gcr.io/distroless/base-nossl:debug
+FROM gcr.io/distroless/static:debug
 
 COPY --from=build /src/loki/cmd/logcli/logcli /usr/bin/logcli
 SHELL [ "/busybox/sh", "-c" ]

--- a/cmd/logql-analyzer/Dockerfile
+++ b/cmd/logql-analyzer/Dockerfile
@@ -1,11 +1,11 @@
 ARG GO_VERSION=1.23
-FROM golang:${GO_VERSION} as build
+FROM golang:${GO_VERSION} AS build
 
 COPY . /src/loki
 WORKDIR /src/loki
 RUN make clean && CGO_ENABLED=0 go build ./cmd/logql-analyzer/
 
-FROM gcr.io/distroless/base-nossl:debug
+FROM gcr.io/distroless/static:debug
 
 COPY --from=build /src/loki/logql-analyzer /usr/bin/logql-analyzer
 SHELL [ "/busybox/sh", "-c" ]

--- a/cmd/loki-canary/Dockerfile
+++ b/cmd/loki-canary/Dockerfile
@@ -1,11 +1,11 @@
 ARG GO_VERSION=1.23
-FROM golang:${GO_VERSION} as build
+FROM golang:${GO_VERSION} AS build
 
 COPY . /src/loki
 WORKDIR /src/loki
 RUN make clean && make BUILD_IN_CONTAINER=false loki-canary
 
-FROM gcr.io/distroless/base-nossl:debug
+FROM gcr.io/distroless/static:debug
 
 COPY --from=build /src/loki/cmd/loki-canary/loki-canary /usr/bin/loki-canary
 SHELL [ "/busybox/sh", "-c" ]

--- a/cmd/loki-canary/Dockerfile.cross
+++ b/cmd/loki-canary/Dockerfile.cross
@@ -3,7 +3,7 @@ ARG GO_VERSION=1.23
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/promtail -f cmd/promtail/Dockerfile .
-FROM golang:${GO_VERSION} as goenv
+FROM golang:${GO_VERSION} AS goenv
 RUN go env GOARCH > /goarch && \
   go env GOARM > /goarm
 
@@ -13,7 +13,7 @@ COPY . /src/loki
 WORKDIR /src/loki
 RUN make clean && GOARCH=$(cat /goarch) GOARM=$(cat /goarm) make BUILD_IN_CONTAINER=false loki-canary
 
-FROM gcr.io/distroless/base-nossl:debug
+FROM gcr.io/distroless/static:debug
 COPY --from=build /src/loki/cmd/loki-canary/loki-canary /usr/bin/loki-canary
 SHELL [ "/busybox/sh", "-c" ]
 RUN ln -s /busybox/sh /bin/sh

--- a/cmd/loki/Dockerfile
+++ b/cmd/loki/Dockerfile
@@ -1,11 +1,11 @@
 ARG GO_VERSION=1.23
-FROM golang:${GO_VERSION} as build
+FROM golang:${GO_VERSION} AS build
 
 COPY . /src/loki
 WORKDIR /src/loki
 RUN make clean && make BUILD_IN_CONTAINER=false loki
 
-FROM gcr.io/distroless/base-nossl:debug
+FROM gcr.io/distroless/static:debug
 
 COPY --from=build /src/loki/cmd/loki/loki /usr/bin/loki
 COPY cmd/loki/loki-docker-config.yaml /etc/loki/local-config.yaml

--- a/cmd/loki/Dockerfile.cross
+++ b/cmd/loki/Dockerfile.cross
@@ -2,7 +2,7 @@ ARG GO_VERSION=1.23
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/loki -f cmd/loki/Dockerfile .
-FROM golang:${GO_VERSION} as goenv
+FROM golang:${GO_VERSION} AS goenv
 RUN go env GOARCH > /goarch && \
     go env GOARM > /goarm
 
@@ -10,7 +10,7 @@ COPY . /src/loki
 WORKDIR /src/loki
 RUN make clean && GOARCH=$(cat /goarch) GOARM=$(cat /goarm) make BUILD_IN_CONTAINER=false loki
 
-FROM gcr.io/distroless/base-nossl:debug
+FROM gcr.io/distroless/static:debug
 
 COPY --from=goenv /src/loki/cmd/loki/loki /usr/bin/loki
 COPY cmd/loki/loki-local-config.yaml /etc/loki/local-config.yaml

--- a/cmd/migrate/Dockerfile
+++ b/cmd/migrate/Dockerfile
@@ -1,10 +1,10 @@
 ARG GO_VERSION=1.23
-FROM golang:${GO_VERSION} as build
+FROM golang:${GO_VERSION} AS build
 COPY . /src/loki
 WORKDIR /src/loki
 RUN make clean && make BUILD_IN_CONTAINER=false migrate
 
-FROM gcr.io/distroless/base-nossl:debug
+FROM gcr.io/distroless/static:debug
 
 COPY --from=build /src/loki/cmd/migrate/migrate /usr/bin/migrate
 SHELL [ "/busybox/sh", "-c" ]

--- a/cmd/querytee/Dockerfile
+++ b/cmd/querytee/Dockerfile
@@ -5,7 +5,7 @@ COPY . /src/loki
 WORKDIR /src/loki
 RUN make clean && make BUILD_IN_CONTAINER=false loki-querytee
 
-FROM gcr.io/distroless/base-nossl:debug
+FROM gcr.io/distroless/static:debug
 COPY --from=build /src/loki/cmd/querytee/querytee /usr/bin/querytee
 
 SHELL [ "/busybox/sh", "-c" ]

--- a/cmd/querytee/Dockerfile.cross
+++ b/cmd/querytee/Dockerfile.cross
@@ -3,7 +3,7 @@ ARG BUILD_IMAGE=grafana/loki-build-image:0.34.0
 # This file is intended to be called from the root like so:
 # docker build -t grafana/promtail -f cmd/promtail/Dockerfile .
 ARG GO_VERSION=1.23
-FROM golang:${GO_VERSION} as goenv
+FROM golang:${GO_VERSION} AS goenv
 RUN go env GOARCH > /goarch && \
   go env GOARM > /goarm
 
@@ -13,7 +13,7 @@ COPY . /src/loki
 WORKDIR /src/loki
 RUN make clean && GOARCH=$(cat /goarch) GOARM=$(cat /goarm) make BUILD_IN_CONTAINER=false loki-querytee
 
-FROM gcr.io/distroless/base-nossl:debug
+FROM gcr.io/distroless/static:debug
 COPY --from=build /src/loki/cmd/querytee/querytee /usr/bin/querytee
 SHELL [ "/busybox/sh", "-c" ]
 RUN ln -s /busybox/sh /bin/sh

--- a/production/helm/loki/src/helm-test/Dockerfile
+++ b/production/helm/loki/src/helm-test/Dockerfile
@@ -8,6 +8,6 @@ COPY . /src/loki
 WORKDIR /src/loki
 RUN make clean && make BUILD_IN_CONTAINER=false helm-test
 
-FROM gcr.io/distroless/base-nossl:debug
+FROM gcr.io/distroless/static:debug
 COPY --from=build /src/loki/production/helm/loki/src/helm-test/helm-test /usr/bin/helm-test
 ENTRYPOINT [ "/usr/bin/helm-test" ]


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes the inclusion of glibc into most of the Docker images created by the Loki build system.

It excludes:
- The loki-canary BoringCrypto image, as it requires `glibc` as part of the `CGO` dependency
- The debug image for Loki, as it installs `dlv`, which in turn requires `glibc`

**Which issue(s) this PR fixes**:
This removes an unneeded dependency, which adds some low severity CVE items into the Docker images that we generate.

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [X] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
