### PR TITLE
chore: switch promtails base image from debian to ubuntu (backport release-3.3.x)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -874,6 +874,7 @@ trivy: loki-image build-image
 snyk: loki-image build-image
 	snyk container test $(IMAGE_PREFIX)/loki:$(IMAGE_TAG) --file=cmd/loki/Dockerfile
 	snyk container test $(IMAGE_PREFIX)/loki-build-image:$(IMAGE_TAG) --file=loki-build-image/Dockerfile
+	snyk container test $(IMAGE_PREFIX)/promtail:$(IMAGE_TAG) --file=clients/cmd/promtail/Dockerfile
 	snyk code test
 
 .PHONY: scan-vulnerabilities

--- a/clients/cmd/promtail/Dockerfile
+++ b/clients/cmd/promtail/Dockerfile
@@ -6,12 +6,13 @@ WORKDIR /src/loki
 RUN apt-get update && apt-get install -qy libsystemd-dev
 RUN make clean && make BUILD_IN_CONTAINER=false PROMTAIL_JOURNAL_ENABLED=true promtail
 
-# Promtail requires debian as the base image to support systemd journal reading
-FROM debian:12.5-slim
+# Promtail requires debian or ubuntu as the base image to support systemd journal reading
+FROM public.ecr.aws/ubuntu/ubuntu:noble
 # tzdata required for the timestamp stage to work
-RUN apt-get update && \
-  apt-get install -qy tzdata ca-certificates libsystemd-dev && \
-  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+# Install dependencies needed at runtime.
+RUN  apt-get update \
+ &&  apt-get install -qy libsystemd-dev tzdata ca-certificates \
+ &&  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 COPY --from=build /src/loki/clients/cmd/promtail/promtail /usr/bin/promtail
 COPY clients/cmd/promtail/promtail-docker-config.yaml /etc/promtail/config.yml
 ENTRYPOINT ["/usr/bin/promtail"]

--- a/clients/cmd/promtail/Dockerfile.arm32
+++ b/clients/cmd/promtail/Dockerfile.arm32
@@ -5,8 +5,8 @@ WORKDIR /src/loki
 RUN apt-get update && apt-get install -qy libsystemd-dev
 RUN make clean && make BUILD_IN_CONTAINER=false PROMTAIL_JOURNAL_ENABLED=true promtail
 
-# Promtail requires debian as the base image to support systemd journal reading
-FROM debian:12.5-slim
+# Promtail requires debian or ubuntu as the base image to support systemd journal reading
+FROM public.ecr.aws/ubuntu/ubuntu:noble
 # tzdata required for the timestamp stage to work
 RUN apt-get update && \
   apt-get install -qy tzdata ca-certificates wget libsystemd-dev && \

--- a/clients/cmd/promtail/Dockerfile.cross
+++ b/clients/cmd/promtail/Dockerfile.cross
@@ -13,8 +13,8 @@ COPY . /src/loki
 WORKDIR /src/loki
 RUN make clean && GOARCH=$(cat /goarch) GOARM=$(cat /goarm) make BUILD_IN_CONTAINER=false PROMTAIL_JOURNAL_ENABLED=true promtail
 
-# Promtail requires debian as the base image to support systemd journal reading
-FROM debian:12.5-slim
+# Promtail requires debian or ubuntu as the base image to support systemd journal reading
+FROM public.ecr.aws/ubuntu/ubuntu:noble
 # tzdata required for the timestamp stage to work
 RUN apt-get update && \
   apt-get install -qy tzdata ca-certificates wget libsystemd-dev && \


### PR DESCRIPTION
Backport 4d9c5bb20aba82087d87836d88d2260f7dd913ac from #15195

---

This PR changes promtails base image from `debian:12.8-slim` to `ubuntu:noble-20241015`, `noble` being ubunutu's most recent lts version. The current debian base image has a lot of security CVEs that won't be updated, while ubuntu updates packages much more regularly.

Just as a quick example, the result of a trivy scan on the promtail image with debian base gives `Total: 79 (UNKNOWN: 0, LOW: 59, MEDIUM: 14, HIGH: 5, CRITICAL: 1)` while the trivy scan for the promtail image with ubunutu base results in `Total: 15 (UNKNOWN: 0, LOW: 7, MEDIUM: 8, HIGH: 0, CRITICAL: 0)`

~~EDIT: Moved to draft until I've confirmed the new image can still grab systemd/journal logs~~

EDIT: Couldn't trace through the makefile/Dockerfile what needs to be set for the image to build with promtail and cgo locally, but given we publish images that can get logs from journal then the automation should be set up properly. If I enforce `CGO_ENABLED=1` for the `make promtail-image` target locally, I can use that image to get logs via the journal scrape job.

I ran promtail in a docker container with a scrape config like this:
```
scrape_configs:
- job_name: journal
  journal:
    path: /var/log/journal
    max_age: 12h
    labels:
      job: systemd-journal
```

I also mounted my machines `/var/log/journal` directory to the same path on the container, and set `--network="host"` so that:
```
clients:
  - url: http://127.0.0.1:3100/loki/api/v1/push
```
would be able to send to loki running locally on my machine.

Then once both promtail in docker and loki locally are running, I added loki as a datasource to my local grafana as well.


In my journalctl logs I see:
<img width="839" alt="2024-12-01_14-38" src="https://github.com/user-attachments/assets/9a8a91fd-5078-481e-81aa-b8d7f69c30d4">


and we can see the same in the logs that make it to loki 
<img width="705" alt="2024-12-01_14-37" src="https://github.com/user-attachments/assets/a942c24a-1833-48c1-b40f-bc3078b68b33">
from promtail



