### PR TITLE
fix: allow comparison against zero bytes

### DIFF
--- a/pkg/logql/log/metrics_extraction_test.go
+++ b/pkg/logql/log/metrics_extraction_test.go
@@ -163,6 +163,22 @@ func Test_labelSampleExtractor_Extract(t *testing.T) {
 			wantOk: true,
 		},
 		{
+			name: "convert bytes without spaces",
+			ex: mustSampleExtractor(LabelExtractorWithStages(
+				"foo", ConvertBytes, []string{"bar", "buzz"}, false, false, nil, NoopStage,
+			)),
+			in: labels.FromStrings("foo", "13MiB",
+				"bar", "foo",
+				"buzz", "blip",
+				"namespace", "dev",
+			),
+			want: 13 * 1024 * 1024,
+			wantLbs: labels.FromStrings("bar", "foo",
+				"buzz", "blip",
+			),
+			wantOk: true,
+		},
+		{
 			name: "convert bytes with structured metadata",
 			ex: mustSampleExtractor(LabelExtractorWithStages(
 				"foo", ConvertBytes, []string{"bar", "buzz"}, false, false, nil, NoopStage,

--- a/pkg/logql/syntax/lex_test.go
+++ b/pkg/logql/syntax/lex_test.go
@@ -108,6 +108,8 @@ func TestLex(t *testing.T) {
 		{`34+-123`, []int{NUMBER, ADD, SUB, NUMBER}},
 		{`34-123`, []int{NUMBER, SUB, NUMBER}},
 		{`sum(rate({foo="bar"}[5m])-1 > 30`, []int{SUM, OPEN_PARENTHESIS, RATE, OPEN_PARENTHESIS, OPEN_BRACE, IDENTIFIER, EQ, STRING, CLOSE_BRACE, RANGE, CLOSE_PARENTHESIS, SUB, NUMBER, GT, NUMBER}},
+		{`{foo="bar"} | logfmt | bytes  < 0B`, []int{OPEN_BRACE, IDENTIFIER, EQ, STRING, CLOSE_BRACE, PIPE, LOGFMT, PIPE, IDENTIFIER, LT, BYTES}},
+		{`{foo="bar"} | logfmt | bytes  < 1B`, []int{OPEN_BRACE, IDENTIFIER, EQ, STRING, CLOSE_BRACE, PIPE, LOGFMT, PIPE, IDENTIFIER, LT, BYTES}},
 	} {
 		t.Run(tc.input, func(t *testing.T) {
 			actual := []int{}

--- a/pkg/logql/syntax/lex_test.go
+++ b/pkg/logql/syntax/lex_test.go
@@ -110,6 +110,8 @@ func TestLex(t *testing.T) {
 		{`sum(rate({foo="bar"}[5m])-1 > 30`, []int{SUM, OPEN_PARENTHESIS, RATE, OPEN_PARENTHESIS, OPEN_BRACE, IDENTIFIER, EQ, STRING, CLOSE_BRACE, RANGE, CLOSE_PARENTHESIS, SUB, NUMBER, GT, NUMBER}},
 		{`{foo="bar"} | logfmt | bytes  < 0B`, []int{OPEN_BRACE, IDENTIFIER, EQ, STRING, CLOSE_BRACE, PIPE, LOGFMT, PIPE, IDENTIFIER, LT, BYTES}},
 		{`{foo="bar"} | logfmt | bytes  < 1B`, []int{OPEN_BRACE, IDENTIFIER, EQ, STRING, CLOSE_BRACE, PIPE, LOGFMT, PIPE, IDENTIFIER, LT, BYTES}},
+		{`0b01`, []int{NUMBER}},
+		{`0b10`, []int{NUMBER}},
 	} {
 		t.Run(tc.input, func(t *testing.T) {
 			actual := []int{}

--- a/pkg/logql/syntax/query_scanner.go
+++ b/pkg/logql/syntax/query_scanner.go
@@ -409,7 +409,7 @@ func (s *Scanner) scanNumber(ch rune, seenDot bool) (rune, rune) {
 				ch = s.next()
 				base, prefix = 8, 'o'
 			case 'b':
-				if !unicode.IsSpace(s.Peek()) {
+				if s.Peek() == '1' || s.Peek() == '0' {
 					ch = s.next()
 					base, prefix = 2, 'b'
 				}

--- a/pkg/logql/syntax/query_scanner.go
+++ b/pkg/logql/syntax/query_scanner.go
@@ -409,7 +409,7 @@ func (s *Scanner) scanNumber(ch rune, seenDot bool) (rune, rune) {
 				ch = s.next()
 				base, prefix = 8, 'o'
 			case 'b':
-				if s.Peek() == '1' || s.Peek() == '0' {
+				if peek := s.Peek(); peek == '0' || peek == '1' {
 					ch = s.next()
 					base, prefix = 2, 'b'
 				}

--- a/pkg/logql/syntax/query_scanner.go
+++ b/pkg/logql/syntax/query_scanner.go
@@ -409,8 +409,10 @@ func (s *Scanner) scanNumber(ch rune, seenDot bool) (rune, rune) {
 				ch = s.next()
 				base, prefix = 8, 'o'
 			case 'b':
-				ch = s.next()
-				base, prefix = 2, 'b'
+				if !unicode.IsSpace(s.Peek()) {
+					ch = s.next()
+					base, prefix = 2, 'b'
+				}
 			default:
 				base, prefix = 8, '0'
 				digsep = 1 // leading 0


### PR DESCRIPTION
**What this PR does / why we need it**:

Allows query comparisons against zero bytes, ie `{foo="bar"} | logfmt | bytes < 0b`.

**Which issue(s) this PR fixes**:
Fixes #14993

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
