### PR TITLE
chore: split kafka reader ifc into reader and offset manager

### DIFF
--- a/pkg/blockbuilder/builder/slimgester.go
+++ b/pkg/blockbuilder/builder/slimgester.go
@@ -383,7 +383,7 @@ func (i *BlockBuilder) runOne(ctx context.Context) (skipped bool, err error) {
 		return false, nil
 	}
 
-	if err = i.jobController.part.Commit(ctx, lastOffset); err != nil {
+	if err = i.jobController.offsetManager.Commit(ctx, lastOffset); err != nil {
 		level.Error(logger).Log(
 			"msg", "failed to commit offset",
 			"last_offset", lastOffset,

--- a/pkg/blockbuilder/scheduler/strategy_test.go
+++ b/pkg/blockbuilder/scheduler/strategy_test.go
@@ -140,7 +140,7 @@ func TestTimeRangePlanner_Plan(t *testing.T) {
 			require.NoError(t, err)
 
 			require.Equal(t, len(tc.expectedJobs), len(jobs))
-			require.Equal(t, tc.expectedJobs, jobs)
+			require.ElementsMatch(t, tc.expectedJobs, jobs)
 		})
 	}
 }

--- a/pkg/kafka/partition/committer_test.go
+++ b/pkg/kafka/partition/committer_test.go
@@ -42,7 +42,6 @@ func TestPartitionCommitter(t *testing.T) {
 		partitionID,
 		consumerGroup,
 		logger,
-		reg,
 	)
 	committer := newCommitter(reader, kafkaCfg.ConsumerGroupOffsetCommitInterval, logger, reg)
 

--- a/pkg/kafka/partition/committer_test.go
+++ b/pkg/kafka/partition/committer_test.go
@@ -36,7 +36,7 @@ func TestPartitionCommitter(t *testing.T) {
 	reg := prometheus.NewRegistry()
 	partitionID := int32(1)
 	consumerGroup := "test-consumer-group"
-	reader := newKafkaReader(
+	reader := newKafkaOffsetManager(
 		client,
 		kafkaCfg.Topic,
 		partitionID,

--- a/pkg/kafka/partition/offset_manager.go
+++ b/pkg/kafka/partition/offset_manager.go
@@ -44,7 +44,7 @@ func NewKafkaOffsetManager(
 	logger log.Logger,
 	reg prometheus.Registerer,
 ) (*KafkaOffsetManager, error) {
-	// Create a new Kafka client for this reader
+	// Create a new Kafka client for the partition manager.
 	clientMetrics := client.NewReaderClientMetrics("partition-manager", reg)
 	c, err := client.NewReaderClient(
 		cfg,
@@ -55,14 +55,12 @@ func NewKafkaOffsetManager(
 		return nil, fmt.Errorf("creating kafka client: %w", err)
 	}
 
-	// Create the reader
 	return newKafkaOffsetManager(
 		c,
 		cfg.Topic,
 		partitionID,
 		cfg.GetConsumerGroup(instanceID, partitionID),
 		logger,
-		reg,
 	), nil
 }
 
@@ -73,7 +71,6 @@ func newKafkaOffsetManager(
 	partitionID int32,
 	consumerGroup string,
 	logger log.Logger,
-	reg prometheus.Registerer,
 ) *KafkaOffsetManager {
 	return &KafkaOffsetManager{
 		client:        client,

--- a/pkg/kafka/partition/offset_manager.go
+++ b/pkg/kafka/partition/offset_manager.go
@@ -1,0 +1,212 @@
+package partition
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/twmb/franz-go/pkg/kadm"
+	"github.com/twmb/franz-go/pkg/kerr"
+	"github.com/twmb/franz-go/pkg/kgo"
+	"github.com/twmb/franz-go/pkg/kmsg"
+
+	"github.com/grafana/loki/v3/pkg/kafka"
+	"github.com/grafana/loki/v3/pkg/kafka/client"
+)
+
+type OffsetManager interface {
+	Topic() string
+	Partition() int32
+	ConsumerGroup() string
+
+	FetchLastCommittedOffset(ctx context.Context) (int64, error)
+	FetchPartitionOffset(ctx context.Context, position SpecialOffset) (int64, error)
+	Commit(ctx context.Context, offset int64) error
+}
+
+var _ OffsetManager = &KafkaOffsetManager{}
+
+type KafkaOffsetManager struct {
+	client        *kgo.Client
+	topic         string
+	partitionID   int32
+	consumerGroup string
+	logger        log.Logger
+}
+
+func NewKafkaOffsetManager(
+	cfg kafka.Config,
+	partitionID int32,
+	instanceID string,
+	logger log.Logger,
+	reg prometheus.Registerer,
+) (*KafkaOffsetManager, error) {
+	// Create a new Kafka client for this reader
+	clientMetrics := client.NewReaderClientMetrics("partition-manager", reg)
+	c, err := client.NewReaderClient(
+		cfg,
+		clientMetrics,
+		log.With(logger, "component", "kafka-client"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("creating kafka client: %w", err)
+	}
+
+	// Create the reader
+	return newKafkaOffsetManager(
+		c,
+		cfg.Topic,
+		partitionID,
+		cfg.GetConsumerGroup(instanceID, partitionID),
+		logger,
+		reg,
+	), nil
+}
+
+// newKafkaReader creates a new KafkaReader instance
+func newKafkaOffsetManager(
+	client *kgo.Client,
+	topic string,
+	partitionID int32,
+	consumerGroup string,
+	logger log.Logger,
+	reg prometheus.Registerer,
+) *KafkaOffsetManager {
+	return &KafkaOffsetManager{
+		client:        client,
+		topic:         topic,
+		partitionID:   partitionID,
+		consumerGroup: consumerGroup,
+		logger:        logger,
+	}
+}
+
+// Topic returns the topic being read
+func (r *KafkaOffsetManager) Topic() string {
+	return r.topic
+}
+
+// Partition returns the partition being read
+func (r *KafkaOffsetManager) Partition() int32 {
+	return r.partitionID
+}
+
+// ConsumerGroup returns the consumer group
+func (r *KafkaOffsetManager) ConsumerGroup() string {
+	return r.consumerGroup
+}
+
+// FetchLastCommittedOffset retrieves the last committed offset for this partition
+func (r *KafkaOffsetManager) FetchLastCommittedOffset(ctx context.Context) (int64, error) {
+	req := kmsg.NewPtrOffsetFetchRequest()
+	req.Topics = []kmsg.OffsetFetchRequestTopic{{
+		Topic:      r.topic,
+		Partitions: []int32{r.partitionID},
+	}}
+	req.Group = r.consumerGroup
+
+	resps := r.client.RequestSharded(ctx, req)
+
+	// Since we issued a request for only 1 partition, we expect exactly 1 response.
+	if expected, actual := 1, len(resps); actual != expected {
+		return 0, fmt.Errorf("unexpected number of responses: %d", len(resps))
+	}
+
+	// Ensure no error occurred.
+	res := resps[0]
+	if res.Err != nil {
+		return 0, res.Err
+	}
+
+	// Parse the response.
+	fetchRes, ok := res.Resp.(*kmsg.OffsetFetchResponse)
+	if !ok {
+		return 0, errors.New("unexpected response type")
+	}
+
+	if len(fetchRes.Groups) != 1 ||
+		len(fetchRes.Groups[0].Topics) != 1 ||
+		len(fetchRes.Groups[0].Topics[0].Partitions) != 1 {
+		level.Debug(r.logger).Log(
+			"msg", "malformed response, setting to start offset",
+		)
+		return int64(KafkaStartOffset), nil
+	}
+
+	partition := fetchRes.Groups[0].Topics[0].Partitions[0]
+	if err := kerr.ErrorForCode(partition.ErrorCode); err != nil {
+		return 0, err
+	}
+
+	return partition.Offset, nil
+}
+
+// FetchPartitionOffset retrieves the offset for a specific position
+func (r *KafkaOffsetManager) FetchPartitionOffset(ctx context.Context, position SpecialOffset) (int64, error) {
+	partitionReq := kmsg.NewListOffsetsRequestTopicPartition()
+	partitionReq.Partition = r.partitionID
+	partitionReq.Timestamp = int64(position)
+
+	topicReq := kmsg.NewListOffsetsRequestTopic()
+	topicReq.Topic = r.topic
+	topicReq.Partitions = []kmsg.ListOffsetsRequestTopicPartition{partitionReq}
+
+	req := kmsg.NewPtrListOffsetsRequest()
+	req.IsolationLevel = 0 // 0 means READ_UNCOMMITTED.
+	req.Topics = []kmsg.ListOffsetsRequestTopic{topicReq}
+
+	// Even if we share the same client, other in-flight requests are not canceled once this context is canceled
+	// (or its deadline is exceeded). We've verified it with a unit test.
+	resps := r.client.RequestSharded(ctx, req)
+
+	// Since we issued a request for only 1 partition, we expect exactly 1 response.
+	if len(resps) != 1 {
+		return 0, fmt.Errorf("unexpected number of responses: %d", len(resps))
+	}
+
+	// Ensure no error occurred.
+	res := resps[0]
+	if res.Err != nil {
+		return 0, res.Err
+	}
+
+	listRes, ok := res.Resp.(*kmsg.ListOffsetsResponse)
+	if !ok {
+		return 0, errors.New("unexpected response type")
+	}
+
+	if len(listRes.Topics) != 1 ||
+		len(listRes.Topics[0].Partitions) != 1 {
+		return 0, errors.New("malformed response")
+	}
+
+	partition := listRes.Topics[0].Partitions[0]
+	if err := kerr.ErrorForCode(partition.ErrorCode); err != nil {
+		return 0, err
+	}
+
+	return partition.Offset, nil
+}
+
+// Commit commits an offset to the consumer group
+func (r *KafkaOffsetManager) Commit(ctx context.Context, offset int64) error {
+	admin := kadm.NewClient(r.client)
+
+	// Commit the last consumed offset.
+	toCommit := kadm.Offsets{}
+	toCommit.AddOffset(r.topic, r.partitionID, offset, -1)
+
+	committed, err := admin.CommitOffsets(ctx, r.consumerGroup, toCommit)
+	if err != nil {
+		return err
+	} else if !committed.Ok() {
+		return committed.Error()
+	}
+
+	committedOffset, _ := committed.Lookup(r.topic, r.partitionID)
+	level.Debug(r.logger).Log("msg", "last commit offset successfully committed to Kafka", "offset", committedOffset.At)
+	return nil
+}

--- a/pkg/kafka/partition/reader.go
+++ b/pkg/kafka/partition/reader.go
@@ -116,31 +116,13 @@ func NewKafkaReader(
 		return nil, fmt.Errorf("creating kafka client: %w", err)
 	}
 
-	// Create the reader
-	return newKafkaReader(
-		c,
-		cfg.Topic,
-		partitionID,
-		logger,
-		reg,
-	), nil
-}
-
-// newKafkaReader creates a new KafkaReader instance
-func newKafkaReader(
-	client *kgo.Client,
-	topic string,
-	partitionID int32,
-	logger log.Logger,
-	reg prometheus.Registerer,
-) *KafkaReader {
 	return &KafkaReader{
-		client:      client,
-		topic:       topic,
+		client:      c,
+		topic:       cfg.Topic,
 		partitionID: partitionID,
 		metrics:     readerMetric,
 		logger:      logger,
-	}
+	}, nil
 }
 
 // Topic returns the topic being read

--- a/pkg/kafka/partition/reader.go
+++ b/pkg/kafka/partition/reader.go
@@ -25,10 +25,10 @@ const (
 	KafkaEndOffset   SpecialOffset = -1
 )
 
-var readerMetric *readerMetrics
+var rm *readerMetrics
 
 func init() {
-	readerMetric = newReaderMetrics(prometheus.DefaultRegisterer)
+	rm = newReaderMetrics(prometheus.DefaultRegisterer)
 }
 
 type Record struct {
@@ -120,7 +120,7 @@ func NewKafkaReader(
 		client:      c,
 		topic:       cfg.Topic,
 		partitionID: partitionID,
-		metrics:     readerMetric,
+		metrics:     rm,
 		logger:      logger,
 	}, nil
 }

--- a/pkg/kafka/partition/reader.go
+++ b/pkg/kafka/partition/reader.go
@@ -7,15 +7,11 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
-	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/multierror"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	"github.com/twmb/franz-go/pkg/kadm"
-	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kgo"
-	"github.com/twmb/franz-go/pkg/kmsg"
 
 	"github.com/grafana/loki/v3/pkg/kafka"
 
@@ -29,6 +25,12 @@ const (
 	KafkaEndOffset   SpecialOffset = -1
 )
 
+var readerMetric *readerMetrics
+
+func init() {
+	readerMetric = newReaderMetrics(prometheus.DefaultRegisterer)
+}
+
 type Record struct {
 	// Context holds the tracing (and potentially other) info, that the record was enriched with on fetch from Kafka.
 	Ctx      context.Context
@@ -40,11 +42,7 @@ type Record struct {
 type Reader interface {
 	Topic() string
 	Partition() int32
-	ConsumerGroup() string
-	FetchLastCommittedOffset(ctx context.Context) (int64, error)
-	FetchPartitionOffset(ctx context.Context, position SpecialOffset) (int64, error)
 	Poll(ctx context.Context, maxPollRecords int) ([]Record, error)
-	Commit(ctx context.Context, offset int64) error
 	// Set the target offset for consumption. reads will begin from here.
 	SetOffsetForConsumption(offset int64)
 }
@@ -104,7 +102,6 @@ type KafkaReader struct {
 func NewKafkaReader(
 	cfg kafka.Config,
 	partitionID int32,
-	instanceID string,
 	logger log.Logger,
 	reg prometheus.Registerer,
 ) (*KafkaReader, error) {
@@ -124,7 +121,6 @@ func NewKafkaReader(
 		c,
 		cfg.Topic,
 		partitionID,
-		cfg.GetConsumerGroup(instanceID, partitionID),
 		logger,
 		reg,
 	), nil
@@ -135,17 +131,15 @@ func newKafkaReader(
 	client *kgo.Client,
 	topic string,
 	partitionID int32,
-	consumerGroup string,
 	logger log.Logger,
 	reg prometheus.Registerer,
 ) *KafkaReader {
 	return &KafkaReader{
-		client:        client,
-		topic:         topic,
-		partitionID:   partitionID,
-		consumerGroup: consumerGroup,
-		metrics:       newReaderMetrics(reg),
-		logger:        logger,
+		client:      client,
+		topic:       topic,
+		partitionID: partitionID,
+		metrics:     readerMetric,
+		logger:      logger,
 	}
 }
 
@@ -157,103 +151,6 @@ func (r *KafkaReader) Topic() string {
 // Partition returns the partition being read
 func (r *KafkaReader) Partition() int32 {
 	return r.partitionID
-}
-
-// ConsumerGroup returns the consumer group
-func (r *KafkaReader) ConsumerGroup() string {
-	return r.consumerGroup
-}
-
-// FetchLastCommittedOffset retrieves the last committed offset for this partition
-func (r *KafkaReader) FetchLastCommittedOffset(ctx context.Context) (int64, error) {
-	req := kmsg.NewPtrOffsetFetchRequest()
-	req.Topics = []kmsg.OffsetFetchRequestTopic{{
-		Topic:      r.topic,
-		Partitions: []int32{r.partitionID},
-	}}
-	req.Group = r.consumerGroup
-
-	resps := r.client.RequestSharded(ctx, req)
-
-	// Since we issued a request for only 1 partition, we expect exactly 1 response.
-	if expected, actual := 1, len(resps); actual != expected {
-		return 0, fmt.Errorf("unexpected number of responses: %d", len(resps))
-	}
-
-	// Ensure no error occurred.
-	res := resps[0]
-	if res.Err != nil {
-		return 0, res.Err
-	}
-
-	// Parse the response.
-	fetchRes, ok := res.Resp.(*kmsg.OffsetFetchResponse)
-	if !ok {
-		return 0, errors.New("unexpected response type")
-	}
-
-	if len(fetchRes.Groups) != 1 ||
-		len(fetchRes.Groups[0].Topics) != 1 ||
-		len(fetchRes.Groups[0].Topics[0].Partitions) != 1 {
-		level.Debug(r.logger).Log(
-			"msg", "malformed response, setting to start offset",
-		)
-		return int64(KafkaStartOffset), nil
-	}
-
-	partition := fetchRes.Groups[0].Topics[0].Partitions[0]
-	if err := kerr.ErrorForCode(partition.ErrorCode); err != nil {
-		return 0, err
-	}
-
-	return partition.Offset, nil
-}
-
-// FetchPartitionOffset retrieves the offset for a specific position
-func (r *KafkaReader) FetchPartitionOffset(ctx context.Context, position SpecialOffset) (int64, error) {
-	partitionReq := kmsg.NewListOffsetsRequestTopicPartition()
-	partitionReq.Partition = r.partitionID
-	partitionReq.Timestamp = int64(position)
-
-	topicReq := kmsg.NewListOffsetsRequestTopic()
-	topicReq.Topic = r.topic
-	topicReq.Partitions = []kmsg.ListOffsetsRequestTopicPartition{partitionReq}
-
-	req := kmsg.NewPtrListOffsetsRequest()
-	req.IsolationLevel = 0 // 0 means READ_UNCOMMITTED.
-	req.Topics = []kmsg.ListOffsetsRequestTopic{topicReq}
-
-	// Even if we share the same client, other in-flight requests are not canceled once this context is canceled
-	// (or its deadline is exceeded). We've verified it with a unit test.
-	resps := r.client.RequestSharded(ctx, req)
-
-	// Since we issued a request for only 1 partition, we expect exactly 1 response.
-	if len(resps) != 1 {
-		return 0, fmt.Errorf("unexpected number of responses: %d", len(resps))
-	}
-
-	// Ensure no error occurred.
-	res := resps[0]
-	if res.Err != nil {
-		return 0, res.Err
-	}
-
-	listRes, ok := res.Resp.(*kmsg.ListOffsetsResponse)
-	if !ok {
-		return 0, errors.New("unexpected response type")
-	}
-
-	if len(listRes.Topics) != 1 ||
-		len(listRes.Topics[0].Partitions) != 1 {
-		return 0, errors.New("malformed response")
-	}
-
-	partition := listRes.Topics[0].Partitions[0]
-	if err := kerr.ErrorForCode(partition.ErrorCode); err != nil {
-		return 0, err
-	}
-
-	return partition.Offset, nil
 }
 
 // Poll retrieves the next batch of records from Kafka
@@ -308,24 +205,4 @@ func (r *KafkaReader) SetOffsetForConsumption(offset int64) {
 	r.client.AddConsumePartitions(map[string]map[int32]kgo.Offset{
 		r.topic: {r.partitionID: kgo.NewOffset().At(offset)},
 	})
-}
-
-// Commit commits an offset to the consumer group
-func (r *KafkaReader) Commit(ctx context.Context, offset int64) error {
-	admin := kadm.NewClient(r.client)
-
-	// Commit the last consumed offset.
-	toCommit := kadm.Offsets{}
-	toCommit.AddOffset(r.topic, r.partitionID, offset, -1)
-
-	committed, err := admin.CommitOffsets(ctx, r.consumerGroup, toCommit)
-	if err != nil {
-		return err
-	} else if !committed.Ok() {
-		return committed.Error()
-	}
-
-	committedOffset, _ := committed.Lookup(r.topic, r.partitionID)
-	level.Debug(r.logger).Log("msg", "last commit offset successfully committed to Kafka", "offset", committedOffset.At)
-	return nil
 }

--- a/pkg/kafka/partition/reader_service.go
+++ b/pkg/kafka/partition/reader_service.go
@@ -50,6 +50,7 @@ type ReaderService struct {
 
 	cfg             ReaderConfig
 	reader          Reader
+	offsetManager   OffsetManager
 	consumerFactory ConsumerFactory
 	logger          log.Logger
 	metrics         *serviceMetrics
@@ -76,19 +77,32 @@ func NewReaderService(
 	reader, err := NewKafkaReader(
 		kafkaCfg,
 		partitionID,
-		instanceID,
 		logger,
 		reg,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("creating kafka reader: %w", err)
 	}
+
+	offsetManager, err := NewKafkaOffsetManager(
+		kafkaCfg,
+		partitionID,
+
+		instanceID,
+		logger,
+		reg,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("creating kafka offset manager: %w", err)
+	}
+
 	return newReaderService(
 		ReaderConfig{
 			MaxConsumerLagAtStartup:       kafkaCfg.MaxConsumerLagAtStartup,
 			ConsumerGroupOffsetCommitFreq: kafkaCfg.ConsumerGroupOffsetCommitInterval,
 		},
 		reader,
+		offsetManager,
 		consumerFactory,
 		logger,
 		reg,
@@ -98,6 +112,7 @@ func NewReaderService(
 func newReaderService(
 	cfg ReaderConfig,
 	reader Reader,
+	offsetManager OffsetManager,
 	consumerFactory ConsumerFactory,
 	logger log.Logger,
 	reg prometheus.Registerer,
@@ -105,14 +120,15 @@ func newReaderService(
 	s := &ReaderService{
 		cfg:                 cfg,
 		reader:              reader,
+		offsetManager:       offsetManager,
 		consumerFactory:     consumerFactory,
-		logger:              log.With(logger, "partition", reader.Partition(), "consumer_group", reader.ConsumerGroup()),
+		logger:              log.With(logger, "partition", offsetManager.Partition(), "consumer_group", offsetManager.ConsumerGroup()),
 		metrics:             newServiceMetrics(reg),
 		lastProcessedOffset: int64(KafkaEndOffset),
 	}
 
 	// Create the committer
-	s.committer = newCommitter(reader, cfg.ConsumerGroupOffsetCommitFreq, logger, reg)
+	s.committer = newCommitter(offsetManager, cfg.ConsumerGroupOffsetCommitFreq, logger, reg)
 
 	s.Service = services.NewBasicService(s.starting, s.running, nil)
 	return s
@@ -120,13 +136,13 @@ func newReaderService(
 
 func (s *ReaderService) starting(ctx context.Context) error {
 	level.Info(s.logger).Log("msg", "starting reader service")
-	s.metrics.reportOwnerOfPartition(s.reader.Partition())
+	s.metrics.reportOwnerOfPartition(s.offsetManager.Partition())
 	s.metrics.reportStarting()
 
 	logger := log.With(s.logger, "phase", phaseStarting)
 
 	// Fetch the last committed offset to determine where to start reading
-	lastCommittedOffset, err := s.reader.FetchLastCommittedOffset(ctx)
+	lastCommittedOffset, err := s.offsetManager.FetchLastCommittedOffset(ctx)
 	if err != nil {
 		return fmt.Errorf("fetching last committed offset: %w", err)
 	}
@@ -219,14 +235,14 @@ func (s *ReaderService) fetchUntilLagSatisfied(
 
 	for b.Ongoing() {
 		// Send a direct request to the Kafka backend to fetch the partition start offset.
-		partitionStartOffset, err := s.reader.FetchPartitionOffset(ctx, KafkaStartOffset)
+		partitionStartOffset, err := s.offsetManager.FetchPartitionOffset(ctx, KafkaStartOffset)
 		if err != nil {
 			level.Warn(logger).Log("msg", "partition reader failed to fetch partition start offset", "err", err)
 			b.Wait()
 			continue
 		}
 
-		consumerGroupLastCommittedOffset, err := s.reader.FetchLastCommittedOffset(ctx)
+		consumerGroupLastCommittedOffset, err := s.offsetManager.FetchLastCommittedOffset(ctx)
 		if err != nil {
 			level.Warn(logger).Log("msg", "partition reader failed to fetch last committed offset", "err", err)
 			b.Wait()
@@ -237,7 +253,7 @@ func (s *ReaderService) fetchUntilLagSatisfied(
 		// We intentionally don't use WaitNextFetchLastProducedOffset() to not introduce further
 		// latency.
 		lastProducedOffsetRequestedAt := time.Now()
-		lastProducedOffset, err := s.reader.FetchPartitionOffset(ctx, KafkaEndOffset)
+		lastProducedOffset, err := s.offsetManager.FetchPartitionOffset(ctx, KafkaEndOffset)
 		if err != nil {
 			level.Warn(logger).Log("msg", "partition reader failed to fetch last produced offset", "err", err)
 			b.Wait()

--- a/pkg/kafka/partition/reader_service.go
+++ b/pkg/kafka/partition/reader_service.go
@@ -87,7 +87,6 @@ func NewReaderService(
 	offsetManager, err := NewKafkaOffsetManager(
 		kafkaCfg,
 		partitionID,
-
 		instanceID,
 		logger,
 		reg,

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -1824,7 +1824,6 @@ func (t *Loki) initBlockBuilder() (services.Service, error) {
 	reader, err := partition.NewKafkaReader(
 		t.Cfg.KafkaConfig,
 		ingestPartitionID,
-		id,
 		logger,
 		prometheus.DefaultRegisterer,
 	)
@@ -1832,8 +1831,17 @@ func (t *Loki) initBlockBuilder() (services.Service, error) {
 		return nil, err
 	}
 
+	offsetManager, err := partition.NewKafkaOffsetManager(
+		t.Cfg.KafkaConfig,
+		ingestPartitionID,
+		id,
+		logger,
+		prometheus.DefaultRegisterer,
+	)
+
 	controller, err := blockbuilder.NewPartitionJobController(
 		reader,
+		offsetManager,
 		t.Cfg.BlockBuilder.Backoff,
 		logger,
 	)

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -1838,6 +1838,9 @@ func (t *Loki) initBlockBuilder() (services.Service, error) {
 		logger,
 		prometheus.DefaultRegisterer,
 	)
+	if err != nil {
+		return nil, err
+	}
 
 	controller, err := blockbuilder.NewPartitionJobController(
 		reader,


### PR DESCRIPTION
**What this PR does / why we need it**:

Splits the existing kafka Reader interface and implementations into smaller parts:
- Reader that only supports `Poll` and a seek method
- OffsetManager to read partition offsets and manage commits

This is needed for read-only components such as block builders that only poll records from a single or multiple partitions, they do not read offsets or commit messages.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:
`readerMetrics` is now a global that is registered during init, this is to avoid duplicate registration when multiple clients are created.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
