### PR TITLE
chore(backport): Add querier fix into k231

### DIFF
--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -152,6 +152,9 @@ func New(cfg Config, store Store, ingesterQuerier *IngesterQuerier, limits Limit
 
 // Select Implements logql.Querier which select logs via matchers and regex filters.
 func (q *SingleTenantQuerier) SelectLogs(ctx context.Context, params logql.SelectLogParams) (iter.EntryIterator, error) {
+	// Create a new partition context for the query
+	// This is used to track which ingesters were used in the query and reuse the same ingesters for consecutive queries
+	ctx = NewPartitionContext(ctx)
 	var err error
 	params.Start, params.End, err = q.validateQueryRequest(ctx, params)
 	if err != nil {
@@ -211,6 +214,9 @@ func (q *SingleTenantQuerier) SelectLogs(ctx context.Context, params logql.Selec
 }
 
 func (q *SingleTenantQuerier) SelectSamples(ctx context.Context, params logql.SelectSampleParams) (iter.SampleIterator, error) {
+	// Create a new partition context for the query
+	// This is used to track which ingesters were used in the query and reuse the same ingesters for consecutive queries
+	ctx = NewPartitionContext(ctx)
 	var err error
 	params.Start, params.End, err = q.validateQueryRequest(ctx, params)
 	if err != nil {

--- a/pkg/querier/querier_mock_test.go
+++ b/pkg/querier/querier_mock_test.go
@@ -142,6 +142,19 @@ func (c *querierClientMock) Close() error {
 	return nil
 }
 
+type mockIngesterClientFactory struct {
+	requestedClients map[string]int
+}
+
+// newIngesterClientMockFactory creates a factory function always returning
+// the input querierClientMock
+func (f mockIngesterClientFactory) newIngesterClientMockFactory(c *querierClientMock) ring_client.PoolFactory {
+	return ring_client.PoolAddrFunc(func(addr string) (ring_client.PoolClient, error) {
+		f.requestedClients[addr]++
+		return c, nil
+	})
+}
+
 // newIngesterClientMockFactory creates a factory function always returning
 // the input querierClientMock
 func newIngesterClientMockFactory(c *querierClientMock) ring_client.PoolFactory {


### PR DESCRIPTION
Cherry-pick `feat: Use context propagation to call the same ingester in GetChunkID as Query (#15186)` (`70d9587863410b5610606bf20210402a2438ffd3`)

**What this PR does / why we need it**:
* Cherry-pick query fix into k231 to ensure querys don't fail during rollouts.