### PR TITLE
chore(Mixin): Fix per_namespace_label  not used and add per_instance_label support

### DIFF
--- a/production/loki-mixin-compiled-ssd/dashboards/loki-logs.json
+++ b/production/loki-mixin-compiled-ssd/dashboards/loki-logs.json
@@ -985,7 +985,7 @@
                "multi": true,
                "name": "pod",
                "options": [ ],
-               "query": "label_values(kube_pod_container_info{cluster=\"$cluster\", namespace=\"$namespace\", container=~\"$container\"}, pod)",
+               "query": "label_values(kube_pod_container_info{cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"$container\"}, pod)",
                "refresh": 0,
                "regex": "",
                "sort": 1,

--- a/production/loki-mixin-compiled/dashboards/loki-logs.json
+++ b/production/loki-mixin-compiled/dashboards/loki-logs.json
@@ -985,7 +985,7 @@
                "multi": true,
                "name": "pod",
                "options": [ ],
-               "query": "label_values(kube_pod_container_info{cluster=\"$cluster\", namespace=\"$namespace\", container=~\"$container\"}, pod)",
+               "query": "label_values(kube_pod_container_info{cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"$container\"}, pod)",
                "refresh": 0,
                "regex": "",
                "sort": 1,

--- a/production/loki-mixin/config.libsonnet
+++ b/production/loki-mixin/config.libsonnet
@@ -17,6 +17,9 @@
     per_namespace_label: 'namespace',
     per_job_label: 'job',
 
+    // The Log Formater that is used within the Dashboards (logfmt,json)
+    log_format: 'json',
+
     // Grouping labels, to uniquely identify and group by {jobs, clusters}
     job_labels: [$._config.per_cluster_label, $._config.per_namespace_label, $._config.per_job_label],
     cluster_labels: [$._config.per_cluster_label, $._config.per_namespace_label],

--- a/production/loki-mixin/config.libsonnet
+++ b/production/loki-mixin/config.libsonnet
@@ -18,7 +18,7 @@
     per_job_label: 'job',
 
     // The Log Formater that is used within the Dashboards (logfmt,json)
-    log_format: 'json',
+    log_format: 'logfmt',
 
     // Grouping labels, to uniquely identify and group by {jobs, clusters}
     job_labels: [$._config.per_cluster_label, $._config.per_namespace_label, $._config.per_job_label],

--- a/production/loki-mixin/dashboards/dashboard-utils.libsonnet
+++ b/production/loki-mixin/dashboards/dashboard-utils.libsonnet
@@ -85,7 +85,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
     $._config.per_cluster_label + '=~"$cluster", job=~"($namespace)/%s"' % job,
 
   namespaceMatcher()::
-    $._config.per_cluster_label + '=~"$cluster", '+ $._config.per_namespace_label +'=~"$namespace"',
+    $._config.per_cluster_label + '=~"$cluster", ' + $._config.per_namespace_label + '=~"$namespace"',
 
   logPanel(title, selector, datasource='$loki_datasource'):: {
     title: title,

--- a/production/loki-mixin/dashboards/dashboard-utils.libsonnet
+++ b/production/loki-mixin/dashboards/dashboard-utils.libsonnet
@@ -35,9 +35,9 @@ local utils = import 'mixin-utils/utils.libsonnet';
 
       addNamespace(multi=false)::
         if multi then
-          self.addMultiTemplate('namespace', 'loki_build_info{' + $._config.per_cluster_label + '=~"$cluster"}', 'namespace')
+          self.addMultiTemplate('namespace', 'loki_build_info{' + $._config.per_cluster_label + '=~"$cluster"}', $._config.per_namespace_label)
         else
-          self.addTemplate('namespace', 'loki_build_info{' + $._config.per_cluster_label + '=~"$cluster"}', 'namespace'),
+          self.addTemplate('namespace', 'loki_build_info{' + $._config.per_cluster_label + '=~"$cluster"}', $._config.per_namespace_label),
 
       addTag()::
         self + {
@@ -75,17 +75,17 @@ local utils = import 'mixin-utils/utils.libsonnet';
 
         if multi then
           d.addMultiTemplate('cluster', 'loki_build_info', $._config.per_cluster_label)
-          .addMultiTemplate('namespace', 'loki_build_info{' + $._config.per_cluster_label + '=~"$cluster"}', 'namespace')
+          .addMultiTemplate('namespace', 'loki_build_info{' + $._config.per_cluster_label + '=~"$cluster"}', $._config.per_namespace_label)
         else
           d.addTemplate('cluster', 'loki_build_info', $._config.per_cluster_label)
-          .addTemplate('namespace', 'loki_build_info{' + $._config.per_cluster_label + '=~"$cluster"}', 'namespace'),
+          .addTemplate('namespace', 'loki_build_info{' + $._config.per_cluster_label + '=~"$cluster"}', $._config.per_namespace_label),
     },
 
   jobMatcher(job)::
     $._config.per_cluster_label + '=~"$cluster", job=~"($namespace)/%s"' % job,
 
   namespaceMatcher()::
-    $._config.per_cluster_label + '=~"$cluster", namespace=~"$namespace"',
+    $._config.per_cluster_label + '=~"$cluster", '+ $._config.per_namespace_label +'=~"$namespace"',
 
   logPanel(title, selector, datasource='$loki_datasource'):: {
     title: title,

--- a/production/loki-mixin/dashboards/loki-bloom-build.libsonnet
+++ b/production/loki-mixin/dashboards/loki-bloom-build.libsonnet
@@ -12,7 +12,7 @@ local template = import 'grafonnet/template.libsonnet';
     template.new(
       'tenant',
       '$datasource',
-      'label_values(loki_bloomplanner_tenant_tasks_planned{cluster="$cluster", namespace="$namespace"}, tenant)',
+      'label_values(loki_bloomplanner_tenant_tasks_planned{cluster="$cluster", '+ $._config.per_namespace_label +'="$namespace"}, tenant)',
       label='Tenant',
       sort=3,  // numerical ascending
       includeAll=true,

--- a/production/loki-mixin/dashboards/loki-bloom-build.libsonnet
+++ b/production/loki-mixin/dashboards/loki-bloom-build.libsonnet
@@ -12,7 +12,7 @@ local template = import 'grafonnet/template.libsonnet';
     template.new(
       'tenant',
       '$datasource',
-      'label_values(loki_bloomplanner_tenant_tasks_planned{cluster="$cluster", '+ $._config.per_namespace_label +'="$namespace"}, tenant)',
+      'label_values(loki_bloomplanner_tenant_tasks_planned{cluster="$cluster", ' + $._config.per_namespace_label + '="$namespace"}, tenant)',
       label='Tenant',
       sort=3,  // numerical ascending
       includeAll=true,

--- a/production/loki-mixin/dashboards/loki-canary-dashboard.libsonnet
+++ b/production/loki-mixin/dashboards/loki-canary-dashboard.libsonnet
@@ -49,60 +49,60 @@ local grafana = import 'grafonnet/grafana.libsonnet';
         panels: [
           // grid row 1
           dashboard.panel('Canary Entries Total') +
-          dashboard.newStatPanel('sum(count(loki_canary_entries_total{' + $._config.per_cluster_label + '=~"$cluster", namespace=~"$namespace"}))', unit='short') +
+          dashboard.newStatPanel('sum(count(loki_canary_entries_total{' + $._config.per_cluster_label + '=~"$cluster", '+ $._config.per_namespace_label +'=~"$namespace"}))', unit='short') +
           { gridPos: { h: 4, w: 3, x: 0, y: 0 } },
 
           dashboard.panel('Canary Logs Total') +
-          dashboard.newStatPanel('sum(increase(loki_canary_entries_total{' + $._config.per_cluster_label + '=~"$cluster",namespace=~"$namespace"}[$__range]))', unit='short') +
+          dashboard.newStatPanel('sum(increase(loki_canary_entries_total{' + $._config.per_cluster_label + '=~"$cluster",'+ $._config.per_namespace_label +'=~"$namespace"}[$__range]))', unit='short') +
           { gridPos: { h: 4, w: 3, x: 3, y: 0 } },
 
           dashboard.panel('Missing') +
-          dashboard.newStatPanel('sum(increase(loki_canary_missing_entries_total{' + $._config.per_cluster_label + '=~"$cluster",namespace=~"$namespace"}[$__range]))', unit='short') +
+          dashboard.newStatPanel('sum(increase(loki_canary_missing_entries_total{' + $._config.per_cluster_label + '=~"$cluster",'+ $._config.per_namespace_label +'=~"$namespace"}[$__range]))', unit='short') +
           { gridPos: { h: 4, w: 3, x: 6, y: 0 } },
 
           dashboard.panel('Spotcheck Missing') +
-          dashboard.newStatPanel('sum(increase(loki_canary_spot_check_missing_entries_total{' + $._config.per_cluster_label + '=~"$cluster",namespace=~"$namespace"}[$__range]))', unit='short') +
+          dashboard.newStatPanel('sum(increase(loki_canary_spot_check_missing_entries_total{' + $._config.per_cluster_label + '=~"$cluster",'+ $._config.per_namespace_label +'=~"$namespace"}[$__range]))', unit='short') +
           { gridPos: { h: 4, w: 3, x: 9, y: 0 } },
 
           // grid row 2
           dashboard.panel('Spotcheck Total') +
-          dashboard.newStatPanel('sum(increase(loki_canary_spot_check_entries_total{' + $._config.per_cluster_label + '=~"$cluster",namespace=~"$namespace"}[$__range]))', unit='short') +
+          dashboard.newStatPanel('sum(increase(loki_canary_spot_check_entries_total{' + $._config.per_cluster_label + '=~"$cluster",'+ $._config.per_namespace_label +'=~"$namespace"}[$__range]))', unit='short') +
           { gridPos: { h: 4, w: 3, x: 0, y: 4 } },
 
           dashboard.panel('Metric Test Error %') +
-          dashboard.newStatPanel('((sum(loki_canary_metric_test_expected{' + $._config.per_cluster_label + '=~"$cluster",namespace=~"$namespace"}) - sum(loki_canary_metric_test_actual{' + $._config.per_cluster_label + '=~"$cluster",namespace=~"$namespace"}))/(sum(loki_canary_metric_test_actual{' + $._config.per_cluster_label + '=~"$cluster",namespace=~"$namespace"}))) * 100') +
+          dashboard.newStatPanel('((sum(loki_canary_metric_test_expected{' + $._config.per_cluster_label + '=~"$cluster",'+ $._config.per_namespace_label +'=~"$namespace"}) - sum(loki_canary_metric_test_actual{' + $._config.per_cluster_label + '=~"$cluster",'+ $._config.per_namespace_label +'=~"$namespace"}))/(sum(loki_canary_metric_test_actual{' + $._config.per_cluster_label + '=~"$cluster",'+ $._config.per_namespace_label +'=~"$namespace"}))) * 100') +
           { gridPos: { h: 4, w: 3, x: 3, y: 4 } },
 
           dashboard.panel('Missing %') +
-          dashboard.newStatPanel('(sum(increase(loki_canary_missing_entries_total{' + $._config.per_cluster_label + '=~"$cluster",namespace=~"$namespace"}[$__range]))/sum(increase(loki_canary_entries_total{' + $._config.per_cluster_label + '=~"$cluster",namespace=~"$namespace"}[$__range])))*100') +
+          dashboard.newStatPanel('(sum(increase(loki_canary_missing_entries_total{' + $._config.per_cluster_label + '=~"$cluster",'+ $._config.per_namespace_label +'=~"$namespace"}[$__range]))/sum(increase(loki_canary_entries_total{' + $._config.per_cluster_label + '=~"$cluster",'+ $._config.per_namespace_label +'=~"$namespace"}[$__range])))*100') +
           { gridPos: { h: 4, w: 3, x: 6, y: 4 } },
 
           dashboard.panel('Spotcheck Missing %') +
-          dashboard.newStatPanel('(sum(increase(loki_canary_spot_check_missing_entries_total{' + $._config.per_cluster_label + '=~"$cluster",namespace=~"$namespace"}[$__range]))/sum(increase(loki_canary_spot_check_entries_total{' + $._config.per_cluster_label + '=~"$cluster",namespace=~"$namespace"}[$__range]))) * 100') +
+          dashboard.newStatPanel('(sum(increase(loki_canary_spot_check_missing_entries_total{' + $._config.per_cluster_label + '=~"$cluster",'+ $._config.per_namespace_label +'=~"$namespace"}[$__range]))/sum(increase(loki_canary_spot_check_entries_total{' + $._config.per_cluster_label + '=~"$cluster",'+ $._config.per_namespace_label +'=~"$namespace"}[$__range]))) * 100') +
           { gridPos: { h: 4, w: 3, x: 9, y: 4 } },
 
           // grid row 3
           dashboard.panel('Metric Test Expected') +
-          dashboard.newStatPanel('sum(loki_canary_metric_test_expected{' + $._config.per_cluster_label + '=~"$cluster",namespace=~"$namespace"})', unit='short') +
+          dashboard.newStatPanel('sum(loki_canary_metric_test_expected{' + $._config.per_cluster_label + '=~"$cluster",'+ $._config.per_namespace_label +'=~"$namespace"})', unit='short') +
           { gridPos: { h: 4, w: 3, x: 0, y: 8 } },
 
           dashboard.panel('Metric Test Actual') +
-          dashboard.newStatPanel('sum(loki_canary_metric_test_actual{' + $._config.per_cluster_label + '=~"$cluster",namespace=~"$namespace"})', unit='short') +
+          dashboard.newStatPanel('sum(loki_canary_metric_test_actual{' + $._config.per_cluster_label + '=~"$cluster",'+ $._config.per_namespace_label +'=~"$namespace"})', unit='short') +
           { gridPos: { h: 4, w: 3, x: 3, y: 8 } },
 
           dashboard.panel('Websocket Missing') +
-          dashboard.newStatPanel('sum(increase(loki_canary_websocket_missing_entries_total{' + $._config.per_cluster_label + '=~"$cluster",namespace=~"$namespace"}[$__range]))', unit='short') +
+          dashboard.newStatPanel('sum(increase(loki_canary_websocket_missing_entries_total{' + $._config.per_cluster_label + '=~"$cluster",'+ $._config.per_namespace_label +'=~"$namespace"}[$__range]))', unit='short') +
           { gridPos: { h: 4, w: 3, x: 6, y: 8 } },
 
           dashboard.panel('Websocket Missing %') +
-          dashboard.newStatPanel('(sum(increase(loki_canary_websocket_missing_entries_total{' + $._config.per_cluster_label + '=~"$cluster",namespace=~"$namespace"}[$__range]))/sum(increase(loki_canary_entries_total{' + $._config.per_cluster_label + '=~"$cluster",namespace=~"$namespace"}[$__range])))*100') +
+          dashboard.newStatPanel('(sum(increase(loki_canary_websocket_missing_entries_total{' + $._config.per_cluster_label + '=~"$cluster",'+ $._config.per_namespace_label +'=~"$namespace"}[$__range]))/sum(increase(loki_canary_entries_total{' + $._config.per_cluster_label + '=~"$cluster",'+ $._config.per_namespace_label +'=~"$namespace"}[$__range])))*100') +
           { gridPos: { h: 4, w: 3, x: 9, y: 8 } },
           // end of grid
 
           dashboard.panel('Log Write to read Latency Percentiles') +
           dashboard.queryPanel([
-            'histogram_quantile(0.95, sum(rate(loki_canary_response_latency_seconds_bucket{' + $._config.per_cluster_label + '=~"$cluster",namespace=~"$namespace"}[$__rate_interval])) by (le))',
-            'histogram_quantile(0.50, sum(rate(loki_canary_response_latency_seconds_bucket{' + $._config.per_cluster_label + '=~"$cluster",namespace=~"$namespace"}[$__rate_interval])) by (le))',
+            'histogram_quantile(0.95, sum(rate(loki_canary_response_latency_seconds_bucket{' + $._config.per_cluster_label + '=~"$cluster",'+ $._config.per_namespace_label +'=~"$namespace"}[$__rate_interval])) by (le))',
+            'histogram_quantile(0.50, sum(rate(loki_canary_response_latency_seconds_bucket{' + $._config.per_cluster_label + '=~"$cluster",'+ $._config.per_namespace_label +'=~"$namespace"}[$__rate_interval])) by (le))',
           ], ['p95', 'p50']) +
           { gridPos: { h: 6, w: 12, x: 12, y: 0 } },
 
@@ -115,7 +115,7 @@ local grafana = import 'grafonnet/grafana.libsonnet';
           ).addTargets(
             [
               grafana.prometheus.target(
-                'sum(rate(loki_canary_response_latency_seconds_bucket{' + $._config.per_cluster_label + '=~"$cluster",namespace=~"$namespace"}[$__rate_interval])) by (le)',
+                'sum(rate(loki_canary_response_latency_seconds_bucket{' + $._config.per_cluster_label + '=~"$cluster",'+ $._config.per_namespace_label +'=~"$namespace"}[$__rate_interval])) by (le)',
                 legendFormat='{{le}}',
                 format='heatmap',
               ),
@@ -125,24 +125,24 @@ local grafana = import 'grafonnet/grafana.libsonnet';
 
           dashboard.panel('Spot Check Query') +
           dashboard.queryPanel([
-            'histogram_quantile(0.99, sum(rate(loki_canary_spot_check_request_duration_seconds_bucket{' + $._config.per_cluster_label + '=~"$cluster",namespace=~"$namespace"}[$__rate_interval])) by (le))',
-            'histogram_quantile(0.50, sum(rate(loki_canary_spot_check_request_duration_seconds_bucket{' + $._config.per_cluster_label + '=~"$cluster",namespace=~"$namespace"}[$__rate_interval])) by (le))',
+            'histogram_quantile(0.99, sum(rate(loki_canary_spot_check_request_duration_seconds_bucket{' + $._config.per_cluster_label + '=~"$cluster",'+ $._config.per_namespace_label +'=~"$namespace"}[$__rate_interval])) by (le))',
+            'histogram_quantile(0.50, sum(rate(loki_canary_spot_check_request_duration_seconds_bucket{' + $._config.per_cluster_label + '=~"$cluster",'+ $._config.per_namespace_label +'=~"$namespace"}[$__rate_interval])) by (le))',
           ], ['p99', 'p95']) +
           { gridPos: { h: 6, w: 12, x: 0, y: 14 } },
 
           dashboard.panel('Metric Test Query') +
           dashboard.queryPanel([
-            'histogram_quantile(0.99, sum(rate(loki_canary_metric_test_request_duration_seconds_bucket{' + $._config.per_cluster_label + '=~"$cluster",namespace=~"$namespace"}[15m])) by (le))',
-            'histogram_quantile(0.50, sum(rate(loki_canary_metric_test_request_duration_seconds_bucket{' + $._config.per_cluster_label + '=~"$cluster",namespace=~"$namespace"}[15m])) by (le))',
+            'histogram_quantile(0.99, sum(rate(loki_canary_metric_test_request_duration_seconds_bucket{' + $._config.per_cluster_label + '=~"$cluster",'+ $._config.per_namespace_label +'=~"$namespace"}[15m])) by (le))',
+            'histogram_quantile(0.50, sum(rate(loki_canary_metric_test_request_duration_seconds_bucket{' + $._config.per_cluster_label + '=~"$cluster",'+ $._config.per_namespace_label +'=~"$namespace"}[15m])) by (le))',
           ], ['p99', 'p95'],) +
           { gridPos: { h: 6, w: 12, x: 12, y: 14 } },
 
           dashboard.panel('Spot Check Missing %') +
-          dashboard.queryPanel('topk(20, (sum by (' + $._config.per_cluster_label + ', pod) (increase(loki_canary_spot_check_missing_entries_total{' + $._config.per_cluster_label + '=~"$cluster",namespace=~"$namespace"}[$__rate_interval]))/sum by (' + $._config.per_cluster_label + ', pod) (increase(loki_canary_spot_check_entries_total{' + $._config.per_cluster_label + '=~"$cluster",namespace=~"$namespace"}[$__rate_interval])) * 100)) > 0', '') +
+          dashboard.queryPanel('topk(20, (sum by (' + $._config.per_cluster_label + ', pod) (increase(loki_canary_spot_check_missing_entries_total{' + $._config.per_cluster_label + '=~"$cluster",'+ $._config.per_namespace_label +'=~"$namespace"}[$__rate_interval]))/sum by (' + $._config.per_cluster_label + ', pod) (increase(loki_canary_spot_check_entries_total{' + $._config.per_cluster_label + '=~"$cluster",'+ $._config.per_namespace_label +'=~"$namespace"}[$__rate_interval])) * 100)) > 0', '') +
           { gridPos: { h: 6, w: 12, x: 0, y: 20 } },
 
           g.panel('Missing logs') +
-          g.queryPanel('topk(20,(sum by (' + $._config.per_cluster_label + ', pod)(increase(loki_canary_missing_entries_total{' + $._config.per_cluster_label + '=~"$cluster",namespace=~"$namespace"}[$__rate_interval]))/sum by (' + $._config.per_cluster_label + ', pod)(increase(loki_canary_entries_total{' + $._config.per_cluster_label + '=~"$cluster",namespace=~"$namespace"}[$__rate_interval])))*100) > 0', 'Missing {{ ' + $._config.per_cluster_label + ' }} {{ pod }}') +
+          g.queryPanel('topk(20,(sum by (' + $._config.per_cluster_label + ', pod)(increase(loki_canary_missing_entries_total{' + $._config.per_cluster_label + '=~"$cluster",'+ $._config.per_namespace_label +'=~"$namespace"}[$__rate_interval]))/sum by (' + $._config.per_cluster_label + ', pod)(increase(loki_canary_entries_total{' + $._config.per_cluster_label + '=~"$cluster",'+ $._config.per_namespace_label +'=~"$namespace"}[$__rate_interval])))*100) > 0', 'Missing {{ ' + $._config.per_cluster_label + ' }} {{ pod }}') +
           { gridPos: { h: 6, w: 12, x: 12, y: 20 } },
 
         ],

--- a/production/loki-mixin/dashboards/loki-canary-dashboard.libsonnet
+++ b/production/loki-mixin/dashboards/loki-canary-dashboard.libsonnet
@@ -49,60 +49,60 @@ local grafana = import 'grafonnet/grafana.libsonnet';
         panels: [
           // grid row 1
           dashboard.panel('Canary Entries Total') +
-          dashboard.newStatPanel('sum(count(loki_canary_entries_total{' + $._config.per_cluster_label + '=~"$cluster", '+ $._config.per_namespace_label +'=~"$namespace"}))', unit='short') +
+          dashboard.newStatPanel('sum(count(loki_canary_entries_total{' + $._config.per_cluster_label + '=~"$cluster", ' + $._config.per_namespace_label + '=~"$namespace"}))', unit='short') +
           { gridPos: { h: 4, w: 3, x: 0, y: 0 } },
 
           dashboard.panel('Canary Logs Total') +
-          dashboard.newStatPanel('sum(increase(loki_canary_entries_total{' + $._config.per_cluster_label + '=~"$cluster",'+ $._config.per_namespace_label +'=~"$namespace"}[$__range]))', unit='short') +
+          dashboard.newStatPanel('sum(increase(loki_canary_entries_total{' + $._config.per_cluster_label + '=~"$cluster",' + $._config.per_namespace_label + '=~"$namespace"}[$__range]))', unit='short') +
           { gridPos: { h: 4, w: 3, x: 3, y: 0 } },
 
           dashboard.panel('Missing') +
-          dashboard.newStatPanel('sum(increase(loki_canary_missing_entries_total{' + $._config.per_cluster_label + '=~"$cluster",'+ $._config.per_namespace_label +'=~"$namespace"}[$__range]))', unit='short') +
+          dashboard.newStatPanel('sum(increase(loki_canary_missing_entries_total{' + $._config.per_cluster_label + '=~"$cluster",' + $._config.per_namespace_label + '=~"$namespace"}[$__range]))', unit='short') +
           { gridPos: { h: 4, w: 3, x: 6, y: 0 } },
 
           dashboard.panel('Spotcheck Missing') +
-          dashboard.newStatPanel('sum(increase(loki_canary_spot_check_missing_entries_total{' + $._config.per_cluster_label + '=~"$cluster",'+ $._config.per_namespace_label +'=~"$namespace"}[$__range]))', unit='short') +
+          dashboard.newStatPanel('sum(increase(loki_canary_spot_check_missing_entries_total{' + $._config.per_cluster_label + '=~"$cluster",' + $._config.per_namespace_label + '=~"$namespace"}[$__range]))', unit='short') +
           { gridPos: { h: 4, w: 3, x: 9, y: 0 } },
 
           // grid row 2
           dashboard.panel('Spotcheck Total') +
-          dashboard.newStatPanel('sum(increase(loki_canary_spot_check_entries_total{' + $._config.per_cluster_label + '=~"$cluster",'+ $._config.per_namespace_label +'=~"$namespace"}[$__range]))', unit='short') +
+          dashboard.newStatPanel('sum(increase(loki_canary_spot_check_entries_total{' + $._config.per_cluster_label + '=~"$cluster",' + $._config.per_namespace_label + '=~"$namespace"}[$__range]))', unit='short') +
           { gridPos: { h: 4, w: 3, x: 0, y: 4 } },
 
           dashboard.panel('Metric Test Error %') +
-          dashboard.newStatPanel('((sum(loki_canary_metric_test_expected{' + $._config.per_cluster_label + '=~"$cluster",'+ $._config.per_namespace_label +'=~"$namespace"}) - sum(loki_canary_metric_test_actual{' + $._config.per_cluster_label + '=~"$cluster",'+ $._config.per_namespace_label +'=~"$namespace"}))/(sum(loki_canary_metric_test_actual{' + $._config.per_cluster_label + '=~"$cluster",'+ $._config.per_namespace_label +'=~"$namespace"}))) * 100') +
+          dashboard.newStatPanel('((sum(loki_canary_metric_test_expected{' + $._config.per_cluster_label + '=~"$cluster",' + $._config.per_namespace_label + '=~"$namespace"}) - sum(loki_canary_metric_test_actual{' + $._config.per_cluster_label + '=~"$cluster",' + $._config.per_namespace_label + '=~"$namespace"}))/(sum(loki_canary_metric_test_actual{' + $._config.per_cluster_label + '=~"$cluster",' + $._config.per_namespace_label + '=~"$namespace"}))) * 100') +
           { gridPos: { h: 4, w: 3, x: 3, y: 4 } },
 
           dashboard.panel('Missing %') +
-          dashboard.newStatPanel('(sum(increase(loki_canary_missing_entries_total{' + $._config.per_cluster_label + '=~"$cluster",'+ $._config.per_namespace_label +'=~"$namespace"}[$__range]))/sum(increase(loki_canary_entries_total{' + $._config.per_cluster_label + '=~"$cluster",'+ $._config.per_namespace_label +'=~"$namespace"}[$__range])))*100') +
+          dashboard.newStatPanel('(sum(increase(loki_canary_missing_entries_total{' + $._config.per_cluster_label + '=~"$cluster",' + $._config.per_namespace_label + '=~"$namespace"}[$__range]))/sum(increase(loki_canary_entries_total{' + $._config.per_cluster_label + '=~"$cluster",' + $._config.per_namespace_label + '=~"$namespace"}[$__range])))*100') +
           { gridPos: { h: 4, w: 3, x: 6, y: 4 } },
 
           dashboard.panel('Spotcheck Missing %') +
-          dashboard.newStatPanel('(sum(increase(loki_canary_spot_check_missing_entries_total{' + $._config.per_cluster_label + '=~"$cluster",'+ $._config.per_namespace_label +'=~"$namespace"}[$__range]))/sum(increase(loki_canary_spot_check_entries_total{' + $._config.per_cluster_label + '=~"$cluster",'+ $._config.per_namespace_label +'=~"$namespace"}[$__range]))) * 100') +
+          dashboard.newStatPanel('(sum(increase(loki_canary_spot_check_missing_entries_total{' + $._config.per_cluster_label + '=~"$cluster",' + $._config.per_namespace_label + '=~"$namespace"}[$__range]))/sum(increase(loki_canary_spot_check_entries_total{' + $._config.per_cluster_label + '=~"$cluster",' + $._config.per_namespace_label + '=~"$namespace"}[$__range]))) * 100') +
           { gridPos: { h: 4, w: 3, x: 9, y: 4 } },
 
           // grid row 3
           dashboard.panel('Metric Test Expected') +
-          dashboard.newStatPanel('sum(loki_canary_metric_test_expected{' + $._config.per_cluster_label + '=~"$cluster",'+ $._config.per_namespace_label +'=~"$namespace"})', unit='short') +
+          dashboard.newStatPanel('sum(loki_canary_metric_test_expected{' + $._config.per_cluster_label + '=~"$cluster",' + $._config.per_namespace_label + '=~"$namespace"})', unit='short') +
           { gridPos: { h: 4, w: 3, x: 0, y: 8 } },
 
           dashboard.panel('Metric Test Actual') +
-          dashboard.newStatPanel('sum(loki_canary_metric_test_actual{' + $._config.per_cluster_label + '=~"$cluster",'+ $._config.per_namespace_label +'=~"$namespace"})', unit='short') +
+          dashboard.newStatPanel('sum(loki_canary_metric_test_actual{' + $._config.per_cluster_label + '=~"$cluster",' + $._config.per_namespace_label + '=~"$namespace"})', unit='short') +
           { gridPos: { h: 4, w: 3, x: 3, y: 8 } },
 
           dashboard.panel('Websocket Missing') +
-          dashboard.newStatPanel('sum(increase(loki_canary_websocket_missing_entries_total{' + $._config.per_cluster_label + '=~"$cluster",'+ $._config.per_namespace_label +'=~"$namespace"}[$__range]))', unit='short') +
+          dashboard.newStatPanel('sum(increase(loki_canary_websocket_missing_entries_total{' + $._config.per_cluster_label + '=~"$cluster",' + $._config.per_namespace_label + '=~"$namespace"}[$__range]))', unit='short') +
           { gridPos: { h: 4, w: 3, x: 6, y: 8 } },
 
           dashboard.panel('Websocket Missing %') +
-          dashboard.newStatPanel('(sum(increase(loki_canary_websocket_missing_entries_total{' + $._config.per_cluster_label + '=~"$cluster",'+ $._config.per_namespace_label +'=~"$namespace"}[$__range]))/sum(increase(loki_canary_entries_total{' + $._config.per_cluster_label + '=~"$cluster",'+ $._config.per_namespace_label +'=~"$namespace"}[$__range])))*100') +
+          dashboard.newStatPanel('(sum(increase(loki_canary_websocket_missing_entries_total{' + $._config.per_cluster_label + '=~"$cluster",' + $._config.per_namespace_label + '=~"$namespace"}[$__range]))/sum(increase(loki_canary_entries_total{' + $._config.per_cluster_label + '=~"$cluster",' + $._config.per_namespace_label + '=~"$namespace"}[$__range])))*100') +
           { gridPos: { h: 4, w: 3, x: 9, y: 8 } },
           // end of grid
 
           dashboard.panel('Log Write to read Latency Percentiles') +
           dashboard.queryPanel([
-            'histogram_quantile(0.95, sum(rate(loki_canary_response_latency_seconds_bucket{' + $._config.per_cluster_label + '=~"$cluster",'+ $._config.per_namespace_label +'=~"$namespace"}[$__rate_interval])) by (le))',
-            'histogram_quantile(0.50, sum(rate(loki_canary_response_latency_seconds_bucket{' + $._config.per_cluster_label + '=~"$cluster",'+ $._config.per_namespace_label +'=~"$namespace"}[$__rate_interval])) by (le))',
+            'histogram_quantile(0.95, sum(rate(loki_canary_response_latency_seconds_bucket{' + $._config.per_cluster_label + '=~"$cluster",' + $._config.per_namespace_label + '=~"$namespace"}[$__rate_interval])) by (le))',
+            'histogram_quantile(0.50, sum(rate(loki_canary_response_latency_seconds_bucket{' + $._config.per_cluster_label + '=~"$cluster",' + $._config.per_namespace_label + '=~"$namespace"}[$__rate_interval])) by (le))',
           ], ['p95', 'p50']) +
           { gridPos: { h: 6, w: 12, x: 12, y: 0 } },
 
@@ -115,7 +115,7 @@ local grafana = import 'grafonnet/grafana.libsonnet';
           ).addTargets(
             [
               grafana.prometheus.target(
-                'sum(rate(loki_canary_response_latency_seconds_bucket{' + $._config.per_cluster_label + '=~"$cluster",'+ $._config.per_namespace_label +'=~"$namespace"}[$__rate_interval])) by (le)',
+                'sum(rate(loki_canary_response_latency_seconds_bucket{' + $._config.per_cluster_label + '=~"$cluster",' + $._config.per_namespace_label + '=~"$namespace"}[$__rate_interval])) by (le)',
                 legendFormat='{{le}}',
                 format='heatmap',
               ),
@@ -125,24 +125,24 @@ local grafana = import 'grafonnet/grafana.libsonnet';
 
           dashboard.panel('Spot Check Query') +
           dashboard.queryPanel([
-            'histogram_quantile(0.99, sum(rate(loki_canary_spot_check_request_duration_seconds_bucket{' + $._config.per_cluster_label + '=~"$cluster",'+ $._config.per_namespace_label +'=~"$namespace"}[$__rate_interval])) by (le))',
-            'histogram_quantile(0.50, sum(rate(loki_canary_spot_check_request_duration_seconds_bucket{' + $._config.per_cluster_label + '=~"$cluster",'+ $._config.per_namespace_label +'=~"$namespace"}[$__rate_interval])) by (le))',
+            'histogram_quantile(0.99, sum(rate(loki_canary_spot_check_request_duration_seconds_bucket{' + $._config.per_cluster_label + '=~"$cluster",' + $._config.per_namespace_label + '=~"$namespace"}[$__rate_interval])) by (le))',
+            'histogram_quantile(0.50, sum(rate(loki_canary_spot_check_request_duration_seconds_bucket{' + $._config.per_cluster_label + '=~"$cluster",' + $._config.per_namespace_label + '=~"$namespace"}[$__rate_interval])) by (le))',
           ], ['p99', 'p95']) +
           { gridPos: { h: 6, w: 12, x: 0, y: 14 } },
 
           dashboard.panel('Metric Test Query') +
           dashboard.queryPanel([
-            'histogram_quantile(0.99, sum(rate(loki_canary_metric_test_request_duration_seconds_bucket{' + $._config.per_cluster_label + '=~"$cluster",'+ $._config.per_namespace_label +'=~"$namespace"}[15m])) by (le))',
-            'histogram_quantile(0.50, sum(rate(loki_canary_metric_test_request_duration_seconds_bucket{' + $._config.per_cluster_label + '=~"$cluster",'+ $._config.per_namespace_label +'=~"$namespace"}[15m])) by (le))',
+            'histogram_quantile(0.99, sum(rate(loki_canary_metric_test_request_duration_seconds_bucket{' + $._config.per_cluster_label + '=~"$cluster",' + $._config.per_namespace_label + '=~"$namespace"}[15m])) by (le))',
+            'histogram_quantile(0.50, sum(rate(loki_canary_metric_test_request_duration_seconds_bucket{' + $._config.per_cluster_label + '=~"$cluster",' + $._config.per_namespace_label + '=~"$namespace"}[15m])) by (le))',
           ], ['p99', 'p95'],) +
           { gridPos: { h: 6, w: 12, x: 12, y: 14 } },
 
           dashboard.panel('Spot Check Missing %') +
-          dashboard.queryPanel('topk(20, (sum by (' + $._config.per_cluster_label + ', pod) (increase(loki_canary_spot_check_missing_entries_total{' + $._config.per_cluster_label + '=~"$cluster",'+ $._config.per_namespace_label +'=~"$namespace"}[$__rate_interval]))/sum by (' + $._config.per_cluster_label + ', pod) (increase(loki_canary_spot_check_entries_total{' + $._config.per_cluster_label + '=~"$cluster",'+ $._config.per_namespace_label +'=~"$namespace"}[$__rate_interval])) * 100)) > 0', '') +
+          dashboard.queryPanel('topk(20, (sum by (' + $._config.per_cluster_label + ', pod) (increase(loki_canary_spot_check_missing_entries_total{' + $._config.per_cluster_label + '=~"$cluster",' + $._config.per_namespace_label + '=~"$namespace"}[$__rate_interval]))/sum by (' + $._config.per_cluster_label + ', pod) (increase(loki_canary_spot_check_entries_total{' + $._config.per_cluster_label + '=~"$cluster",' + $._config.per_namespace_label + '=~"$namespace"}[$__rate_interval])) * 100)) > 0', '') +
           { gridPos: { h: 6, w: 12, x: 0, y: 20 } },
 
           g.panel('Missing logs') +
-          g.queryPanel('topk(20,(sum by (' + $._config.per_cluster_label + ', pod)(increase(loki_canary_missing_entries_total{' + $._config.per_cluster_label + '=~"$cluster",'+ $._config.per_namespace_label +'=~"$namespace"}[$__rate_interval]))/sum by (' + $._config.per_cluster_label + ', pod)(increase(loki_canary_entries_total{' + $._config.per_cluster_label + '=~"$cluster",'+ $._config.per_namespace_label +'=~"$namespace"}[$__rate_interval])))*100) > 0', 'Missing {{ ' + $._config.per_cluster_label + ' }} {{ pod }}') +
+          g.queryPanel('topk(20,(sum by (' + $._config.per_cluster_label + ', pod)(increase(loki_canary_missing_entries_total{' + $._config.per_cluster_label + '=~"$cluster",' + $._config.per_namespace_label + '=~"$namespace"}[$__rate_interval]))/sum by (' + $._config.per_cluster_label + ', pod)(increase(loki_canary_entries_total{' + $._config.per_cluster_label + '=~"$cluster",' + $._config.per_namespace_label + '=~"$namespace"}[$__rate_interval])))*100) > 0', 'Missing {{ ' + $._config.per_cluster_label + ' }} {{ pod }}') +
           { gridPos: { h: 6, w: 12, x: 12, y: 20 } },
 
         ],

--- a/production/loki-mixin/dashboards/loki-deletion.libsonnet
+++ b/production/loki-mixin/dashboards/loki-deletion.libsonnet
@@ -67,10 +67,10 @@ local utils = import 'mixin-utils/utils.libsonnet';
         ).addRow(
           g.row('List of deletion requests')
           .addPanel(
-            $.logPanel('In progress/finished', '{%s, %s} |~ "Started processing delete request|delete request for user marked as processed" | %s | line_format "{{.ts}} user={{.user}} delete_request_id={{.delete_request_id}} msg={{.msg}}" ' % [$.namespaceMatcher(), compactor_matcher,$._config.log_format]),
+            $.logPanel('In progress/finished', '{%s, %s} |~ "Started processing delete request|delete request for user marked as processed" | %s | line_format "{{.ts}} user={{.user}} delete_request_id={{.delete_request_id}} msg={{.msg}}" ' % [$.namespaceMatcher(), compactor_matcher, $._config.log_format]),
           )
           .addPanel(
-            $.logPanel('Requests', '{%s, %s} |~ "delete request for user added" | %s | line_format "{{.ts}} user={{.user}} query=\'{{.query}}\'"' % [$.namespaceMatcher(), compactor_matcher,$._config.log_format]),
+            $.logPanel('Requests', '{%s, %s} |~ "delete request for user added" | %s | line_format "{{.ts}} user={{.user}} query=\'{{.query}}\'"' % [$.namespaceMatcher(), compactor_matcher, $._config.log_format]),
           )
         ),
     },

--- a/production/loki-mixin/dashboards/loki-deletion.libsonnet
+++ b/production/loki-mixin/dashboards/loki-deletion.libsonnet
@@ -2,7 +2,7 @@ local g = import 'grafana-builder/grafana.libsonnet';
 local utils = import 'mixin-utils/utils.libsonnet';
 
 (import 'dashboard-utils.libsonnet') {
-  local compactor_matcher = 'pod=~"(.*compactor|%s-backend.*|loki-single-binary)"' % $._config.ssd.pod_prefix_matcher,
+  local compactor_matcher = $._config.per_instance_label + '=~"(.*compactor|%s-backend.*|loki-single-binary)"' % $._config.ssd.pod_prefix_matcher,
   grafanaDashboards+::
     {
       'loki-deletion.json':
@@ -67,10 +67,10 @@ local utils = import 'mixin-utils/utils.libsonnet';
         ).addRow(
           g.row('List of deletion requests')
           .addPanel(
-            $.logPanel('In progress/finished', '{%s, %s} |~ "Started processing delete request|delete request for user marked as processed" | logfmt | line_format "{{.ts}} user={{.user}} delete_request_id={{.delete_request_id}} msg={{.msg}}" ' % [$.namespaceMatcher(), compactor_matcher]),
+            $.logPanel('In progress/finished', '{%s, %s} |~ "Started processing delete request|delete request for user marked as processed" | %s | line_format "{{.ts}} user={{.user}} delete_request_id={{.delete_request_id}} msg={{.msg}}" ' % [$.namespaceMatcher(), compactor_matcher,$._config.log_format]),
           )
           .addPanel(
-            $.logPanel('Requests', '{%s, %s} |~ "delete request for user added" | logfmt | line_format "{{.ts}} user={{.user}} query=\'{{.query}}\'"' % [$.namespaceMatcher(), compactor_matcher]),
+            $.logPanel('Requests', '{%s, %s} |~ "delete request for user added" | %s | line_format "{{.ts}} user={{.user}} query=\'{{.query}}\'"' % [$.namespaceMatcher(), compactor_matcher,$._config.log_format]),
           )
         ),
     },

--- a/production/loki-mixin/dashboards/loki-logs.libsonnet
+++ b/production/loki-mixin/dashboards/loki-logs.libsonnet
@@ -16,7 +16,7 @@ local template = import 'grafonnet/template.libsonnet';
     template.new(
       'pod',
       '$datasource',
-      'label_values(kube_pod_container_info{' + $._config.per_cluster_label + '="$cluster", '+ $._config.per_namespace_label +'="$namespace", ' + $._config.per_instance_label + '"$container"}, pod)',
+      'label_values(kube_pod_container_info{' + $._config.per_cluster_label + '="$cluster", ' + $._config.per_namespace_label + '="$namespace", ' + $._config.per_instance_label + '"$container"}, pod)',
       sort=1,
       multi=true,
     ),

--- a/production/loki-mixin/dashboards/loki-logs.libsonnet
+++ b/production/loki-mixin/dashboards/loki-logs.libsonnet
@@ -3,12 +3,11 @@ local template = import 'grafonnet/template.libsonnet';
 
 
 (import 'dashboard-utils.libsonnet') {
-
   local containerTemplate =
     template.new(
       'container',
       '$datasource',
-      'label_values(kube_pod_container_info{' + $._config.per_cluster_label + '="$cluster", namespace="$namespace"}, container)',
+      'label_values(kube_pod_container_info{' + $._config.per_cluster_label + '="$cluster", '+ $._config.per_namespace_label +'="$namespace"}, container)',
       sort=1,
       multi=true,
     ),
@@ -17,7 +16,7 @@ local template = import 'grafonnet/template.libsonnet';
     template.new(
       'pod',
       '$datasource',
-      'label_values(kube_pod_container_info{' + $._config.per_cluster_label + '="$cluster", namespace="$namespace", container=~"$container"}, pod)',
+      'label_values(kube_pod_container_info{' + $._config.per_cluster_label + '="$cluster", '+ $._config.per_namespace_label +'="$namespace", container=~"$container"}, pod)',
       sort=1,
       multi=true,
     ),

--- a/production/loki-mixin/dashboards/loki-logs.libsonnet
+++ b/production/loki-mixin/dashboards/loki-logs.libsonnet
@@ -7,7 +7,7 @@ local template = import 'grafonnet/template.libsonnet';
     template.new(
       'container',
       '$datasource',
-      'label_values(kube_pod_container_info{' + $._config.per_cluster_label + '="$cluster", '+ $._config.per_namespace_label +'="$namespace"}, container)',
+      'label_values(kube_pod_container_info{' + $._config.per_cluster_label + '="$cluster", ' + $._config.per_namespace_label + '="$namespace"}, container)',
       sort=1,
       multi=true,
     ),
@@ -16,7 +16,7 @@ local template = import 'grafonnet/template.libsonnet';
     template.new(
       'pod',
       '$datasource',
-      'label_values(kube_pod_container_info{' + $._config.per_cluster_label + '="$cluster", ' + $._config.per_namespace_label + '="$namespace", ' + $._config.per_instance_label + '"$container"}, pod)',
+      'label_values(kube_pod_container_info{' + $._config.per_cluster_label + '="$cluster", ' + $._config.per_namespace_label + '="$namespace", ' + $._config.per_instance_label + '=~"$container"}, pod)',
       sort=1,
       multi=true,
     ),

--- a/production/loki-mixin/dashboards/loki-logs.libsonnet
+++ b/production/loki-mixin/dashboards/loki-logs.libsonnet
@@ -16,7 +16,7 @@ local template = import 'grafonnet/template.libsonnet';
     template.new(
       'pod',
       '$datasource',
-      'label_values(kube_pod_container_info{' + $._config.per_cluster_label + '="$cluster", '+ $._config.per_namespace_label +'="$namespace", container=~"$container"}, pod)',
+      'label_values(kube_pod_container_info{' + $._config.per_cluster_label + '="$cluster", '+ $._config.per_namespace_label +'="$namespace", ' + $._config.per_instance_label + '"$container"}, pod)',
       sort=1,
       multi=true,
     ),

--- a/production/loki-mixin/dashboards/loki-operational.libsonnet
+++ b/production/loki-mixin/dashboards/loki-operational.libsonnet
@@ -121,7 +121,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
                                    std.strReplace(
                                      std.strReplace(
                                        expr,
-                                       'pod=~"backend.*"',
+                                       $._config.per_instance_label + '=~"backend.*"',
                                        matcherStr('backend', matcher='pod', sep='')
                                      ),
                                      'job="$namespace/backend",',
@@ -136,7 +136,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
                                    std.strReplace(
                                      std.strReplace(
                                        expr,
-                                       'pod=~"querier.*"',
+                                       $._config.per_instance_label + '=~"querier.*"',
                                        matcherStr('querier', matcher='pod', sep='')
                                      ),
                                      'job="$namespace/querier",',
@@ -160,10 +160,10 @@ local utils = import 'mixin-utils/utils.libsonnet';
                                                      std.strReplace(
                                                        std.strReplace(
                                                          expr,
-                                                         'pod=~"ingester.*"',
+                                                         $._config.per_instance_label + '=~"ingester.*"',
                                                          matcherStr('ingester', matcher='pod', sep='')
                                                        ),
-                                                       'pod=~"distributor.*"',
+                                                       $._config.per_instance_label + '=~"distributor.*"',
                                                        matcherStr('distributor', matcher='pod', sep='')
                                                      ),
                                                      'job="$namespace/cortex-gw",',

--- a/production/loki-mixin/dashboards/loki-reads-resources.libsonnet
+++ b/production/loki-mixin/dashboards/loki-reads-resources.libsonnet
@@ -1,13 +1,13 @@
 (import 'dashboard-utils.libsonnet') {
   local index_gateway_pod_matcher = if $._config.meta_monitoring.enabled
-  then 'container=~"loki|index-gateway", pod=~"(*.index-gateway.*|loki-single-binary)"'
+  then 'container=~"loki|index-gateway", ' + $._config.per_instance_label + '=~"(*.index-gateway.*|loki-single-binary)"'
   else 'container="index-gateway"',
   local index_gateway_job_matcher = if $._config.meta_monitoring.enabled
   then '(.*index-gateway.*|loki-single-binary)'
   else 'index-gateway',
 
   local ingester_pod_matcher = if $._config.meta_monitoring.enabled
-  then 'container=~"loki|ingester|partition-ingester", pod=~"(.*ingester.*|loki-single-binary)"'
+  then 'container=~"loki|ingester|partition-ingester", ' + $._config.per_instance_label + '=~"(.*ingester.*|loki-single-binary)"'
   else 'container=~"ingester|partition-ingester"',
   local ingester_job_matcher = if $._config.meta_monitoring.enabled
   then '(.*ingester.*|loki-single-binary)'

--- a/production/loki-mixin/dashboards/loki-resources-overview.libsonnet
+++ b/production/loki-mixin/dashboards/loki-resources-overview.libsonnet
@@ -1,11 +1,11 @@
 (import 'dashboard-utils.libsonnet') {
-  local read_pod_matcher = 'container="loki", pod=~"%s-read.*"' % $._config.ssd.pod_prefix_matcher,
+  local read_pod_matcher = 'container="loki", ' + $._config.per_instance_label + '=~"%s-read.*"' % $._config.ssd.pod_prefix_matcher,
   local read_job_matcher = '%s-read' % $._config.ssd.pod_prefix_matcher,
 
-  local write_pod_matcher = 'container="loki", pod=~"%s-write.*"' % $._config.ssd.pod_prefix_matcher,
+  local write_pod_matcher = 'container="loki", ' + $._config.per_instance_label + '=~"%s-write.*"' % $._config.ssd.pod_prefix_matcher,
   local write_job_matcher = '%s-write' % $._config.ssd.pod_prefix_matcher,
 
-  local backend_pod_matcher = 'container="loki", pod=~"%s-backend.*"' % $._config.ssd.pod_prefix_matcher,
+  local backend_pod_matcher = 'container="loki", ' + $._config.per_instance_label + '=~"%s-backend.*"' % $._config.ssd.pod_prefix_matcher,
   local backend_job_matcher = '%s-backend' % $._config.ssd.pod_prefix_matcher,
 
   // This dashboard is for the single scalable deployment only and it :

--- a/production/loki-mixin/dashboards/loki-retention.libsonnet
+++ b/production/loki-mixin/dashboards/loki-retention.libsonnet
@@ -1,7 +1,7 @@
 (import 'dashboard-utils.libsonnet') {
   local compactor_pod_matcher = if $._config.meta_monitoring.enabled
-  then 'pod=~"(.*compactor.*|%s-backend.*|loki-single-binary)"' % $._config.ssd.pod_prefix_matcher
-  else if $._config.ssd.enabled then 'container="loki", pod=~"%s-read.*"' % $._config.ssd.pod_prefix_matcher else 'container="compactor"',
+  then $._config.per_instance_label + '=~"(.*compactor.*|%s-backend.*|loki-single-binary)"' % $._config.ssd.pod_prefix_matcher
+  else if $._config.ssd.enabled then 'container="loki", ' + $._config.per_instance_label + '=~"%s-read.*"' % $._config.ssd.pod_prefix_matcher else 'container="compactor"',
   local compactor_job_matcher = if $._config.meta_monitoring.enabled
   then '"(.*compactor|%s-backend.*|loki-single-binary)"' % $._config.ssd.pod_prefix_matcher
   else if $._config.ssd.enabled then '%s-backend' % $._config.ssd.pod_prefix_matcher else 'compactor',

--- a/production/loki-mixin/dashboards/loki-writes-resources.libsonnet
+++ b/production/loki-mixin/dashboards/loki-writes-resources.libsonnet
@@ -1,6 +1,6 @@
 (import 'dashboard-utils.libsonnet') {
   local ingester_pod_matcher = if $._config.meta_monitoring.enabled
-  then 'container=~"loki|ingester|partition-ingester", pod=~"(.*ingester.*|loki-single-binary)"'
+  then 'container=~"loki|ingester|partition-ingester", ' + $._config.per_instance_label + '=~"(.*ingester.*|loki-single-binary)"'
   else 'container=~"ingester|partition-ingester"',
   local ingester_job_matcher = if $._config.meta_monitoring.enabled
   then '(.*ingester.*|loki-single-binary)'

--- a/production/loki-mixin/dashboards/recording-rules.libsonnet
+++ b/production/loki-mixin/dashboards/recording-rules.libsonnet
@@ -7,7 +7,7 @@ local template = import 'grafonnet/template.libsonnet';
     template.new(
       'tenant',
       '$datasource',
-      'query_result(sum by (id) (grafanacloud_logs_instance_info) and sum(label_replace(loki_tenant:active_streams{' + $._config.per_cluster_label + '="$cluster",namespace="$namespace"},"id","$1","tenant","(.*)")) by(id))',
+      'query_result(sum by (id) (grafanacloud_logs_instance_info) and sum(label_replace(loki_tenant:active_streams{' + $._config.per_cluster_label + '="$cluster",'+ $._config.per_namespace_label +'="$namespace"},"id","$1","tenant","(.*)")) by(id))',
       regex='/"([^"]+)"/',
       sort=1,
       includeAll=true,

--- a/production/loki-mixin/dashboards/recording-rules.libsonnet
+++ b/production/loki-mixin/dashboards/recording-rules.libsonnet
@@ -7,7 +7,7 @@ local template = import 'grafonnet/template.libsonnet';
     template.new(
       'tenant',
       '$datasource',
-      'query_result(sum by (id) (grafanacloud_logs_instance_info) and sum(label_replace(loki_tenant:active_streams{' + $._config.per_cluster_label + '="$cluster",'+ $._config.per_namespace_label +'="$namespace"},"id","$1","tenant","(.*)")) by(id))',
+      'query_result(sum by (id) (grafanacloud_logs_instance_info) and sum(label_replace(loki_tenant:active_streams{' + $._config.per_cluster_label + '="$cluster",' + $._config.per_namespace_label + '="$namespace"},"id","$1","tenant","(.*)")) by(id))',
       regex='/"([^"]+)"/',
       sort=1,
       includeAll=true,


### PR DESCRIPTION
Mixin not using per_namespace_label in generation of Dashboards.

Mixin is not changing when per_namespace_label is set.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
