### PR TITLE
feat: present DF bytes values in queryable format

### DIFF
--- a/pkg/querier/queryrange/detected_fields.go
+++ b/pkg/querier/queryrange/detected_fields.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"slices"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/axiomhq/hyperloglog"
@@ -114,7 +115,13 @@ func parseDetectedFieldValues(limit uint32, streams []push.Stream, name string) 
 			parsedLabels, _ := parseEntry(entry, entryLbls)
 			if vals, ok := parsedLabels[name]; ok {
 				for _, v := range vals {
-					values[v] = struct{}{}
+					// special case bytes values, so they can be directly inserted into a query
+					if bs, err := humanize.ParseBytes(v); err == nil {
+						bsString := strings.Replace(humanize.Bytes(bs), " ", "", 1)
+						values[bsString] = struct{}{}
+					} else {
+						values[v] = struct{}{}
+					}
 				}
 			}
 		}

--- a/pkg/querier/queryrange/detected_fields_test.go
+++ b/pkg/querier/queryrange/detected_fields_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/grafana/loki/pkg/push"
 )
 
-func Test_parseDetectedFeilds(t *testing.T) {
+func Test_parseDetectedFields(t *testing.T) {
 	now := time.Now()
 
 	t.Run("when no parsers are supplied", func(t *testing.T) {
@@ -1317,6 +1317,70 @@ func TestQuerier_DetectedFields(t *testing.T) {
 			}, secondValues)
 		},
 	)
+
+	t.Run("correctly formats bytes values for detected fields", func(t *testing.T) {
+		lbls := `{cluster="us-east-1", namespace="mimir-dev", pod="mimir-ruler-nfb37", service_name="mimir-ruler"}`
+		metric, err := parser.ParseMetric(lbls)
+		require.NoError(t, err)
+		now := time.Now()
+
+		infoDetectdFiledMetadata := []push.LabelAdapter{
+			{
+				Name:  "detected_level",
+				Value: "info",
+			},
+		}
+
+		lines := []push.Entry{
+			{
+				Timestamp:          now,
+				Line:               "ts=2024-09-05T15:36:38.757788067Z caller=metrics.go:66 tenant=2419 level=info bytes=1024",
+				StructuredMetadata: infoDetectdFiledMetadata,
+			},
+			{
+				Timestamp:          now,
+				Line:               `ts=2024-09-05T15:36:38.698375619Z caller=grpc_logging.go:66 tenant=29 level=info bytes="1024 MB"`,
+				StructuredMetadata: infoDetectdFiledMetadata,
+			},
+			{
+				Timestamp:          now,
+				Line:               "ts=2024-09-05T15:36:38.629424175Z caller=grpc_logging.go:66 tenant=2919 level=info bytes=1024KB",
+				StructuredMetadata: infoDetectdFiledMetadata,
+			},
+		}
+		stream := push.Stream{
+			Labels:  lbls,
+			Entries: lines,
+			Hash:    metric.Hash(),
+		}
+
+		handler := NewDetectedFieldsHandler(
+			limitedHandler(stream),
+			logHandler(stream),
+			limits,
+		)
+
+		request := DetectedFieldsRequest{
+			logproto.DetectedFieldsRequest{
+				Start:     time.Now().Add(-1 * time.Minute),
+				End:       time.Now(),
+				Query:     `{cluster="us-east-1"} | logfmt`,
+				LineLimit: 1000,
+				Limit:     3,
+				Values:    true,
+				Name:      "bytes",
+			},
+			"/loki/api/v1/detected_field/bytes/values",
+		}
+
+		detectedFieldValues := handleRequest(handler, request).Values
+		slices.Sort(detectedFieldValues)
+		require.Equal(t, []string{
+			"1.0GB",
+			"1.0MB",
+			"1.0kB",
+		}, detectedFieldValues)
+	})
 }
 
 func BenchmarkQuerierDetectedFields(b *testing.B) {

--- a/pkg/querier/queryrange/detected_fields_test.go
+++ b/pkg/querier/queryrange/detected_fields_test.go
@@ -1334,7 +1334,7 @@ func TestQuerier_DetectedFields(t *testing.T) {
 		lines := []push.Entry{
 			{
 				Timestamp:          now,
-				Line:               "ts=2024-09-05T15:36:38.757788067Z caller=metrics.go:66 tenant=2419 level=info bytes=1024",
+				Line:               "ts=2024-09-05T15:36:38.757788067Z caller=metrics.go:66 tenant=2419 level=info bytes=1,024",
 				StructuredMetadata: infoDetectdFiledMetadata,
 			},
 			{


### PR DESCRIPTION
**What this PR does / why we need it**:

There are a lot of gotchyas with bytes in Loki. In the log line, bytes can be in many different formats, including spaces before the unit, no space before the unit, commas, decimals, basically anything that can be parsed by `humanize.ParseBytes`. However, for a query, we don't accept commas, and the unit must come directly after the number without a space.

This PR sanitizes bytes values returned by `detected_fields/{field_name}/values` to adhere to our rules for byte values in a query to make it easier for Explore Logs to construct queries from the values returned by this endpoint.

**Which issue(s) this PR fixes**:
Fixes #15052

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
