### PR TITLE
docs: Release notes for 3.2.2

### DIFF
--- a/docs/sources/release-notes/v3-2.md
+++ b/docs/sources/release-notes/v3-2.md
@@ -63,6 +63,7 @@ For important upgrade guidance, refer to the [Upgrade Guide](https://grafana.com
 
 - **BREAKING CHANGE - API:** Fail log queries when executed on instant query endpoint ([#13421](https://github.com/grafana/loki/issues/13421)).
 - **BREAKING CHANGE - blooms:** Remove bloom compactor component ([#13969](https://github.com/grafana/loki/issues/13969)).
+- **BREAKING CHANGE - docker:** Remove wget from Promtail docker image([#15101](https://github.com/grafana/loki/issues/15101)).
 - **BREAKING CHANGE - Helm:** Update Helm chart to support distributed mode and 3.0 ([#12067](https://github.com/grafana/loki/issues/12067)).
 - **BREAKING CHANGE - Helm:** Fix how we set imagePullSecrets for enterprise-gateway and admin-api. ([#13761](https://github.com/grafana/loki/issues/13761)) ([3be5a45](https://github.com/grafana/loki/commit/3be5a4576fd0f0dca321e017a637f7a3159c00e5)).
 - **BREAKING CHANGE - jsonnet:** Convert read statefulset into deployment for loki-simple-scalable ([#13977](https://github.com/grafana/loki/issues/13977)).
@@ -72,6 +73,15 @@ Out of an abundance of caution, we advise that users with Loki or Grafana Enterp
 {{< /admonition >}}
 
 ## Bug fixes
+
+### 3.2.2 (2024-12-04)
+
+- **ci:** Fix the LogQL Analyzer CI ([#14511](https://github.com/grafana/loki/issues/14511)).
+- **BREAKING CHANGE - docker:** Remove wget from Promtail docker image([#15101](https://github.com/grafana/loki/issues/15101)).
+- **docker:** Move from base-nossl to static. This PR removes the inclusion of glibc into most of the Docker images created by the Loki build system. ([#15203](https://github.com/grafana/loki/issues/15203)).
+- **logql:** Updated JSONExpressionParser not to unescape extracted values if it is JSON object.  ([#14499](https://github.com/grafana/loki/issues/14499)).
+- **promtail:** Switch Promtail base image from Debian to Ubuntu ([#15195](https://github.com/grafana/loki/issues/15195)).
+- **storage:** Have GetObject check for canceled context. S3ObjectClient.GetObject incorrectly returned nil, 0, nil when the provided context is already canceled ([#14420](https://github.com/grafana/loki/issues/14420)).
 
 ### 3.2.1 (2024-10-17)
 

--- a/docs/sources/release-notes/v3-2.md
+++ b/docs/sources/release-notes/v3-2.md
@@ -76,7 +76,6 @@ Out of an abundance of caution, we advise that users with Loki or Grafana Enterp
 
 ### 3.2.2 (2024-12-04)
 
-- **ci:** Fix the LogQL Analyzer CI ([#14511](https://github.com/grafana/loki/issues/14511)).
 - **BREAKING CHANGE - docker:** Remove wget from Promtail docker image([#15101](https://github.com/grafana/loki/issues/15101)).
 - **docker:** Move from base-nossl to static. This PR removes the inclusion of glibc into most of the Docker images created by the Loki build system. ([#15203](https://github.com/grafana/loki/issues/15203)).
 - **logql:** Updated JSONExpressionParser not to unescape extracted values if it is JSON object.  ([#14499](https://github.com/grafana/loki/issues/14499)).

--- a/docs/sources/release-notes/v3-2.md
+++ b/docs/sources/release-notes/v3-2.md
@@ -79,7 +79,7 @@ Out of an abundance of caution, we advise that users with Loki or Grafana Enterp
 - **BREAKING CHANGE - docker:** Remove wget from Promtail docker image([#15101](https://github.com/grafana/loki/issues/15101)).
 - **docker:** Move from base-nossl to static. This PR removes the inclusion of glibc into most of the Docker images created by the Loki build system. ([#15203](https://github.com/grafana/loki/issues/15203)).
 - **logql:** Updated JSONExpressionParser not to unescape extracted values if it is JSON object.  ([#14499](https://github.com/grafana/loki/issues/14499)).
-- **promtail:** Switch Promtail base image from Debian to Ubuntu ([#15195](https://github.com/grafana/loki/issues/15195)).
+- **promtail:** Switch Promtail base image from Debian to Ubuntu to fix critical security issues ([#15195](https://github.com/grafana/loki/issues/15195)).
 - **storage:** Have GetObject check for canceled context. S3ObjectClient.GetObject incorrectly returned nil, 0, nil when the provided context is already canceled ([#14420](https://github.com/grafana/loki/issues/14420)).
 
 ### 3.2.1 (2024-10-17)


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the release notes for Loki 3.2.2.

The Release PR https://github.com/grafana/loki/pull/15147 did not include all of the backported updates, so searched `is:pr base:release-3.2.x -label:type/docs is:closed ` and used that as a base.
