### PR TITLE
docs: Release notes for 3.3.2

### DIFF
--- a/docs/sources/release-notes/v3-3.md
+++ b/docs/sources/release-notes/v3-3.md
@@ -79,11 +79,18 @@ For important upgrade guidance, refer to the [Upgrade Guide](https://grafana.com
 
 - **BREAKING CHANGE - blooms:** Introduce a new block schema (V3) ([#14038](https://github.com/grafana/loki/issues/14038)).
 - **BREAKING CHANGE - blooms:** Index structured metadata into blooms ([#14061](https://github.com/grafana/loki/issues/14061)).
+- **BREAKING CHANGE - docker:** Remove wget from Promtail docker image([#15101](https://github.com/grafana/loki/issues/15101)).
 - **BREAKING CHANGE - operator:** Migrate project layout to kubebuilder go/v4 ([#14447](https://github.com/grafana/loki/issues/14447)).
 - **BREAKING CHANGE - operator:** Rename Loki API go module ([#14568](https://github.com/grafana/loki/issues/14568)).
 - **BREAKING CHANGE - operator:** Provide default OTLP attribute configuration ([#14410](https://github.com/grafana/loki/issues/14410)).
 
 ## Bug fixes
+
+### 3.3.1 (2024-12-04)
+
+- **BREAKING CHANGE - docker:** Remove wget from Promtail docker image([#15101](https://github.com/grafana/loki/issues/15101)).
+- **docker:** Move from base-nossl to static. This PR removes the inclusion of glibc into most of the Docker images created by the Loki build system. ([#15203](https://github.com/grafana/loki/issues/15203)).
+ - **promtail:** Switch Promtail base image from Debian to Ubuntu ([#15195](https://github.com/grafana/loki/issues/15195)).
 
 ### 3.3.0 (2024-11-19)
 

--- a/docs/sources/release-notes/v3-3.md
+++ b/docs/sources/release-notes/v3-3.md
@@ -90,7 +90,7 @@ For important upgrade guidance, refer to the [Upgrade Guide](https://grafana.com
 
 - **BREAKING CHANGE - docker:** Remove wget from Promtail docker image([#15101](https://github.com/grafana/loki/issues/15101)).
 - **docker:** Move from base-nossl to static. This PR removes the inclusion of glibc into most of the Docker images created by the Loki build system. ([#15203](https://github.com/grafana/loki/issues/15203)).
- - **promtail:** Switch Promtail base image from Debian to Ubuntu ([#15195](https://github.com/grafana/loki/issues/15195)).
+ - **promtail:** Switch Promtail base image from Debian to Ubuntu to fix critical security issues ([#15195](https://github.com/grafana/loki/issues/15195)).
 
 ### 3.3.0 (2024-11-19)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the release notes for Loki 3.3.2.

The Release PR https://github.com/grafana/loki/pull/15148 did not include all of the backported updates, so searched `is:pr base:release-3.3.x -label:type/docs is:closed ` and used that as a base.