### PR TITLE
ci: disable renovate toolchain updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -24,7 +24,7 @@
     {
       // Disable Go version updates
       "matchManagers": ["gomod"],
-      "matchPackageNames": ["go"],
+      "matchPackageNames": ["go", "toolchain"],
       "enabled": false
     },
     {


### PR DESCRIPTION
**What this PR does / why we need it**:

Renovate keeps [trying to update the go toolchain past our go version](https://github.com/grafana/loki/pull/15184/files#diff-4af3383fe9a944e7db77181929918678d973c5dcf75903193cc8837771e5eec6R5), which I don't think is a good idea.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
