### PR TITLE
docs: Release notes for 2.9.11

### DIFF
--- a/docs/sources/release-notes/v2-9.md
+++ b/docs/sources/release-notes/v2-9.md
@@ -36,6 +36,13 @@ For a full list of all changes and fixes, refer to the [CHANGELOG](https://githu
 
 ## Bug fixes
 
+### 2.9.11 (2026-12-05)
+
+- **docker:** Update Docker to 23.0.15 ([#](https://github.com/grafana/loki/issues/)).
+- **lamba-promtail:** Lamba-promtail updates, some of which address CVEs([#14105](https://github.com/grafana/loki/issues/14105)).
+- **promtail:** Switch Promtail base image from Debian to Ubuntu to fix critical security issues ([#15195](https://github.com/grafana/loki/issues/15195)).
+- **storage:** Fix bug in cache of the index object client([#10585](https://github.com/grafana/loki/issues/10585)).
+
 ### 2.9.10 (2026-08-09)
 
 - Update dependencies versions to remove CVE ([#13835](https://github.com/grafana/loki/pull/13835)) ([567bef2](https://github.com/grafana/loki/commit/567bef286376663407c54f5da07fa00963ba5485)).


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates the release notes for Loki 2.9.11.

The Release PR https://github.com/grafana/loki/pull/15267 did not include all of the backported updates, so searched `is:pr base:release-2.9.x -label:type/docs is:closed ` and used that as a base.
