### PR TITLE
docs: Release notes for 2.9.11 (#15280)

### DIFF
--- a/docs/sources/release-notes/v2-9.md
+++ b/docs/sources/release-notes/v2-9.md
@@ -34,6 +34,22 @@ Grafana Labs is excited to announce the release of Loki 2.9.0 Here's a summary o
 
 ## Bug fixes
 
+### 2.9.11 (2026-12-05)
+
+- **docker:** Update Docker to 23.0.15 ([#](https://github.com/grafana/loki/issues/)).
+- **lamba-promtail:** Lamba-promtail updates, some of which address CVEs([#14105](https://github.com/grafana/loki/issues/14105)).
+- **promtail:** Switch Promtail base image from Debian to Ubuntu to fix critical security issues ([#15195](https://github.com/grafana/loki/issues/15195)).
+- **storage:** Fix bug in cache of the index object client([#10585](https://github.com/grafana/loki/issues/10585)).
+
+### 2.9.10 (2026-08-09)
+
+- Update dependencies versions to remove CVE ([#13835](https://github.com/grafana/loki/pull/13835)) ([567bef2](https://github.com/grafana/loki/commit/567bef286376663407c54f5da07fa00963ba5485)).
+
+### 2.9.9 (2024 -07-04)
+
+- **Ingester:** Add `ingester_chunks_flush_failures_total` [12925](https://github.com/grafana/loki/pull/12925).
+- **Ingester:** Add backoff to flush op [13140](https://github.com/grafana/loki/pull/13140).
+
 ### 2.9.8 (2024-05-03)
 
 - **deps:** update module golang.org/x/net to v0.23.0 [security] (release-2.9.x) ([#12865](https://github.com/grafana/loki/issues/12865)) ([94e0029](https://github.com/grafana/loki/commit/94e00299ec9b36ad97c147641566b6922268c54e)).


### PR DESCRIPTION
**What this PR does / why we need it**:

manual backport of https://github.com/grafana/loki/pull/15280 to 3.1.x branch