### PR TITLE
fix(aggregated_metrics): Fix the IsError method causing retries

### DIFF
--- a/pkg/util/http.go
+++ b/pkg/util/http.go
@@ -329,7 +329,7 @@ func ErrorTypeFromHTTPStatus(status int) string {
 }
 
 func IsError(status int) bool {
-	return status/200 != 0
+	return status/100 != 2
 }
 
 func IsServerError(status int) bool {

--- a/pkg/util/http.go
+++ b/pkg/util/http.go
@@ -329,7 +329,7 @@ func ErrorTypeFromHTTPStatus(status int) string {
 }
 
 func IsError(status int) bool {
-	return status/100 != 2
+	return status < 200 || status >= 300
 }
 
 func IsServerError(status int) bool {

--- a/pkg/util/http_test.go
+++ b/pkg/util/http_test.go
@@ -280,3 +280,59 @@ func TestErrorTypeFromHTTPStatus(t *testing.T) {
 		})
 	}
 }
+
+func TestIsError(t *testing.T) {
+	tests := []struct {
+		name           string
+		status         int
+		expectedResult bool
+	}{
+		{
+			name:           "200 OK",
+			status:         200,
+			expectedResult: false,
+		},
+		{
+			name:           "201 Created",
+			status:         201,
+			expectedResult: false,
+		},
+		{
+			name:           "400 Bad Request",
+			status:         400,
+			expectedResult: true,
+		},
+		{
+			name:           "404 Not Found",
+			status:         404,
+			expectedResult: true,
+		},
+		{
+			name:           "429 Too Many Requests",
+			status:         429,
+			expectedResult: true,
+		},
+		{
+			name:           "500 Internal Server Error",
+			status:         500,
+			expectedResult: true,
+		},
+		{
+			name:           "503 Service Unavailable",
+			status:         503,
+			expectedResult: true,
+		},
+		{
+			name:           "600 Unknown",
+			status:         600,
+			expectedResult: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := util.IsError(tt.status)
+			assert.Equal(t, tt.expectedResult, result)
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
The IsError method does not return true even though status is 204. This is causing retries that makes aggregated metrics incorrect.
This PR fixes it and adds some tests.

#incident-2024-12-05-metric-aggregation-is-broken


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
