### PR TITLE
fix: more promtail 2.9.x security fixes

### DIFF
--- a/clients/cmd/promtail/Dockerfile
+++ b/clients/cmd/promtail/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22.5-bullseye as build
+FROM golang:1.22.10-bullseye as build
 
 COPY . /src/loki
 WORKDIR /src/loki


### PR DESCRIPTION
Even after updating from debian to ubuntu, promtail 2.9.x still needs some additional security fixes