### PR TITLE
chore: Renovate - Remove special case for lambda-promtail

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -52,17 +52,6 @@
       "automerge": false
     },
     {
-      // Separate out lambda-promtail updates from other dependencies
-      // Don't automatically merge lambda-promtail updates
-      // Updates to this require the nix SHA to be updated
-      "matchFileNames": ["tools/lambda-promtail/go.mod"],
-      "groupName": "lambdapromtail-{{packageName}}",
-      "enabled": true,
-      "matchUpdateTypes": ["major", "minor", "patch"],
-      "autoApprove": false,
-      "automerge": false
-    },
-    {
       // Disable operator updates
       "matchFileNames": ["operator/go.mod", "operator/api/loki/go.mod"],
       "enabled": false,
@@ -71,7 +60,7 @@
     },
     {
       // Enable all other updates
-      "matchFileNames": ["!tools/lambda-promtail/go.mod", "!operator/go.mod", "!operator/api/loki/go.mod"],
+      "matchFileNames": ["!operator/go.mod", "!operator/api/loki/go.mod"],
       "groupName": "{{packageName}}",
       "enabled": true,
       "matchUpdateTypes": ["major", "minor", "patch"],


### PR DESCRIPTION
**What this PR does / why we need it**:
With the rework in [this PR](https://github.com/grafana/loki/pull/15308), lambda-promtail no longer needs a nix checksum updated each time, so the special-case handling can be removed.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [X] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
