### PR TITLE
ci: fix the docker driver build

### DIFF
--- a/.github/jsonnetfile.json
+++ b/.github/jsonnetfile.json
@@ -8,7 +8,7 @@
           "subdir": "workflows"
         }
       },
-      "version": "502f98811e3768072698cc5c589c889c60025428"
+      "version": "186e3449678a196bf08d9d55355e3b22d8e20ebf"
     }
   ],
   "legacyImports": true

--- a/.github/jsonnetfile.json
+++ b/.github/jsonnetfile.json
@@ -8,7 +8,7 @@
           "subdir": "workflows"
         }
       },
-      "version": "62e4b9937d80cb0300a1364b632563dab20f3fe8"
+      "version": "502f98811e3768072698cc5c589c889c60025428"
     }
   ],
   "legacyImports": true

--- a/.github/jsonnetfile.json
+++ b/.github/jsonnetfile.json
@@ -8,7 +8,7 @@
           "subdir": "workflows"
         }
       },
-      "version": "863f36141d0b3f5fa6af0e4624ff2f1fe0409944"
+      "version": "4c6239765a8fea60cb344099f5bc1d4cf8d32abd"
     }
   ],
   "legacyImports": true

--- a/.github/jsonnetfile.json
+++ b/.github/jsonnetfile.json
@@ -8,7 +8,7 @@
           "subdir": "workflows"
         }
       },
-      "version": "4412f1a7c0dc4590a627e46a534f87454548296a"
+      "version": "62e4b9937d80cb0300a1364b632563dab20f3fe8"
     }
   ],
   "legacyImports": true

--- a/.github/jsonnetfile.json
+++ b/.github/jsonnetfile.json
@@ -8,7 +8,7 @@
           "subdir": "workflows"
         }
       },
-      "version": "4c6239765a8fea60cb344099f5bc1d4cf8d32abd"
+      "version": "4412f1a7c0dc4590a627e46a534f87454548296a"
     }
   ],
   "legacyImports": true

--- a/.github/jsonnetfile.json
+++ b/.github/jsonnetfile.json
@@ -8,7 +8,7 @@
           "subdir": "workflows"
         }
       },
-      "version": "21f1189544e3976070cbdb6463f64c7a32dcc176"
+      "version": "844ff60d1a4d5c5e88d324dec0b5d38377fa70e9"
     }
   ],
   "legacyImports": true

--- a/.github/jsonnetfile.json
+++ b/.github/jsonnetfile.json
@@ -8,7 +8,7 @@
           "subdir": "workflows"
         }
       },
-      "version": "186e3449678a196bf08d9d55355e3b22d8e20ebf"
+      "version": "cfa24256090828f566f1ba59292ce65d8db4a4ae"
     }
   ],
   "legacyImports": true

--- a/.github/jsonnetfile.json
+++ b/.github/jsonnetfile.json
@@ -8,7 +8,7 @@
           "subdir": "workflows"
         }
       },
-      "version": "eb3dded9066b016c661282e9b627e4ce8b47ec72"
+      "version": "f2b424ceaed7ab6e820c635b62cd40da8cdede73"
     }
   ],
   "legacyImports": true

--- a/.github/jsonnetfile.json
+++ b/.github/jsonnetfile.json
@@ -8,7 +8,7 @@
           "subdir": "workflows"
         }
       },
-      "version": "f2b424ceaed7ab6e820c635b62cd40da8cdede73"
+      "version": "863f36141d0b3f5fa6af0e4624ff2f1fe0409944"
     }
   ],
   "legacyImports": true

--- a/.github/jsonnetfile.json
+++ b/.github/jsonnetfile.json
@@ -8,7 +8,7 @@
           "subdir": "workflows"
         }
       },
-      "version": "844ff60d1a4d5c5e88d324dec0b5d38377fa70e9"
+      "version": "eb3dded9066b016c661282e9b627e4ce8b47ec72"
     }
   ],
   "legacyImports": true

--- a/.github/jsonnetfile.lock.json
+++ b/.github/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "workflows"
         }
       },
-      "version": "863f36141d0b3f5fa6af0e4624ff2f1fe0409944",
-      "sum": "g2uWtYGTJB/mjSZila6RJDIFHIR36vpukr8dJRwesoY="
+      "version": "4c6239765a8fea60cb344099f5bc1d4cf8d32abd",
+      "sum": "b/DPZmLBEudcKVH1kif8/BUo0u6eAaAuX7aLEyDnpJM="
     }
   ],
   "legacyImports": false

--- a/.github/jsonnetfile.lock.json
+++ b/.github/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "workflows"
         }
       },
-      "version": "eb3dded9066b016c661282e9b627e4ce8b47ec72",
-      "sum": "wAHZMWLgXwZynIW2n1e1UqMyLVkWlcxPlfcbZgH7/8Y="
+      "version": "f2b424ceaed7ab6e820c635b62cd40da8cdede73",
+      "sum": "TEv+ee9EM5ezJEtOaLArP+cAO2Zqme7DKzAYgmOq9oE="
     }
   ],
   "legacyImports": false

--- a/.github/jsonnetfile.lock.json
+++ b/.github/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "workflows"
         }
       },
-      "version": "844ff60d1a4d5c5e88d324dec0b5d38377fa70e9",
-      "sum": "y7FKVPstUEnlSokPkoxI2/euZDz800PIW7bBuPQN1Z8="
+      "version": "eb3dded9066b016c661282e9b627e4ce8b47ec72",
+      "sum": "wAHZMWLgXwZynIW2n1e1UqMyLVkWlcxPlfcbZgH7/8Y="
     }
   ],
   "legacyImports": false

--- a/.github/jsonnetfile.lock.json
+++ b/.github/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "workflows"
         }
       },
-      "version": "62e4b9937d80cb0300a1364b632563dab20f3fe8",
-      "sum": "8XWtvG8Ti+y8sLtrgaZNdr6A7Zc573CGJqqxcUX+N8A="
+      "version": "502f98811e3768072698cc5c589c889c60025428",
+      "sum": "a/V79sNGV4kSBRc2b8UtAKnceSR6fmvSKYlrCPDoBKY="
     }
   ],
   "legacyImports": false

--- a/.github/jsonnetfile.lock.json
+++ b/.github/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "workflows"
         }
       },
-      "version": "f2b424ceaed7ab6e820c635b62cd40da8cdede73",
-      "sum": "TEv+ee9EM5ezJEtOaLArP+cAO2Zqme7DKzAYgmOq9oE="
+      "version": "863f36141d0b3f5fa6af0e4624ff2f1fe0409944",
+      "sum": "g2uWtYGTJB/mjSZila6RJDIFHIR36vpukr8dJRwesoY="
     }
   ],
   "legacyImports": false

--- a/.github/jsonnetfile.lock.json
+++ b/.github/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "workflows"
         }
       },
-      "version": "21f1189544e3976070cbdb6463f64c7a32dcc176",
-      "sum": "IPS1oGR8k7jk6J2snciTycWFgtISCwXSPhJ3A+nEGvY="
+      "version": "844ff60d1a4d5c5e88d324dec0b5d38377fa70e9",
+      "sum": "y7FKVPstUEnlSokPkoxI2/euZDz800PIW7bBuPQN1Z8="
     }
   ],
   "legacyImports": false

--- a/.github/jsonnetfile.lock.json
+++ b/.github/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "workflows"
         }
       },
-      "version": "4c6239765a8fea60cb344099f5bc1d4cf8d32abd",
-      "sum": "b/DPZmLBEudcKVH1kif8/BUo0u6eAaAuX7aLEyDnpJM="
+      "version": "4412f1a7c0dc4590a627e46a534f87454548296a",
+      "sum": "CtZqSFtQLVXoihwHo8UzqtJFGHBOjCiSML9lgdobAn0="
     }
   ],
   "legacyImports": false

--- a/.github/jsonnetfile.lock.json
+++ b/.github/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "workflows"
         }
       },
-      "version": "4412f1a7c0dc4590a627e46a534f87454548296a",
-      "sum": "CtZqSFtQLVXoihwHo8UzqtJFGHBOjCiSML9lgdobAn0="
+      "version": "62e4b9937d80cb0300a1364b632563dab20f3fe8",
+      "sum": "8XWtvG8Ti+y8sLtrgaZNdr6A7Zc573CGJqqxcUX+N8A="
     }
   ],
   "legacyImports": false

--- a/.github/jsonnetfile.lock.json
+++ b/.github/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "workflows"
         }
       },
-      "version": "186e3449678a196bf08d9d55355e3b22d8e20ebf",
-      "sum": "T9x+84EmTZEkrcxzsQYZI5HffdnnIJs6q1tCfe7VVes="
+      "version": "cfa24256090828f566f1ba59292ce65d8db4a4ae",
+      "sum": "tml1dcFlo15kEE6JvN/nPY2xkhfeF3ERZjAyFbnguHA="
     }
   ],
   "legacyImports": false

--- a/.github/jsonnetfile.lock.json
+++ b/.github/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "workflows"
         }
       },
-      "version": "502f98811e3768072698cc5c589c889c60025428",
-      "sum": "a/V79sNGV4kSBRc2b8UtAKnceSR6fmvSKYlrCPDoBKY="
+      "version": "186e3449678a196bf08d9d55355e3b22d8e20ebf",
+      "sum": "T9x+84EmTZEkrcxzsQYZI5HffdnnIJs6q1tCfe7VVes="
     }
   ],
   "legacyImports": false

--- a/.github/release-workflows.jsonnet
+++ b/.github/release-workflows.jsonnet
@@ -1,9 +1,13 @@
 local lokiRelease = import 'workflows/main.jsonnet';
+
 local build = lokiRelease.build;
-
 local releaseLibRef = 'main';
-
 local checkTemplate = 'grafana/loki-release/.github/workflows/check.yml@%s' % releaseLibRef;
+local buildImageVersion = std.extVar('BUILD_IMAGE_VERSION');
+local buildImage = 'grafana/loki-build-image:%s' % buildImageVersion;
+local golangCiLintVersion = 'v1.60.3';
+local imageBuildTimeoutMin = 60;
+local imagePrefix = 'grafana';
 
 local imageJobs = {
   loki: build.image('loki', 'cmd/loki'),
@@ -15,7 +19,7 @@ local imageJobs = {
   'loki-canary-boringcrypto': build.image('loki-canary-boringcrypto', 'cmd/loki-canary-boringcrypto'),
   promtail: build.image('promtail', 'clients/cmd/promtail'),
   querytee: build.image('loki-query-tee', 'cmd/querytee', platform=['linux/amd64']),
-  'loki-docker-driver': build.dockerPlugin('loki-docker-driver', 'clients/cmd/docker-driver', platform=['linux/amd64', 'linux/arm64']),
+  'loki-docker-driver': build.dockerPlugin('loki-docker-driver', 'clients/cmd/docker-driver', buildImage=buildImage),
 };
 
 local weeklyImageJobs = {
@@ -23,14 +27,8 @@ local weeklyImageJobs = {
   'loki-canary': build.weeklyImage('loki-canary', 'cmd/loki-canary'),
   'loki-canary-boringcrypto': build.weeklyImage('loki-canary-boringcrypto', 'cmd/loki-canary-boringcrypto'),
   promtail: build.weeklyImage('promtail', 'clients/cmd/promtail'),
+  'loki-docker-driver': build.dockerPlugin('loki-docker-driver', 'clients/cmd/docker-driver', buildImage=buildImage),
 };
-
-local buildImageVersion = std.extVar('BUILD_IMAGE_VERSION');
-local buildImage = 'grafana/loki-build-image:%s' % buildImageVersion;
-local golangCiLintVersion = 'v1.60.3';
-
-local imageBuildTimeoutMin = 60;
-local imagePrefix = 'grafana';
 
 {
   'patch-release-pr.yml': std.manifestYamlDoc(

--- a/.github/release-workflows.jsonnet
+++ b/.github/release-workflows.jsonnet
@@ -19,7 +19,7 @@ local imageJobs = {
   'loki-canary-boringcrypto': build.image('loki-canary-boringcrypto', 'cmd/loki-canary-boringcrypto'),
   promtail: build.image('promtail', 'clients/cmd/promtail'),
   querytee: build.image('loki-query-tee', 'cmd/querytee', platform=['linux/amd64']),
-  'loki-docker-driver': build.dockerPlugin('loki-docker-driver', 'clients/cmd/docker-driver', buildImage=buildImage),
+  'loki-docker-driver': build.dockerPlugin('loki-docker-driver', 'clients/cmd/docker-driver', buildImage=buildImage, platform=['linux/amd64', 'linux/arm64']),
 };
 
 local weeklyImageJobs = {
@@ -27,7 +27,7 @@ local weeklyImageJobs = {
   'loki-canary': build.weeklyImage('loki-canary', 'cmd/loki-canary'),
   'loki-canary-boringcrypto': build.weeklyImage('loki-canary-boringcrypto', 'cmd/loki-canary-boringcrypto'),
   promtail: build.weeklyImage('promtail', 'clients/cmd/promtail'),
-  'loki-docker-driver': build.dockerPlugin('loki-docker-driver', 'clients/cmd/docker-driver', buildImage=buildImage),
+  'loki-docker-driver': build.dockerPlugin('loki-docker-driver', 'clients/cmd/docker-driver', buildImage=buildImage, platform=['linux/amd64', 'linux/arm64']),
 };
 
 {

--- a/.github/release-workflows.jsonnet
+++ b/.github/release-workflows.jsonnet
@@ -8,6 +8,7 @@ local buildImage = 'grafana/loki-build-image:%s' % buildImageVersion;
 local golangCiLintVersion = 'v1.60.3';
 local imageBuildTimeoutMin = 60;
 local imagePrefix = 'grafana';
+local dockerPluginDir = 'clients/cmd/docker-driver';
 
 local imageJobs = {
   loki: build.image('loki', 'cmd/loki'),
@@ -19,7 +20,7 @@ local imageJobs = {
   'loki-canary-boringcrypto': build.image('loki-canary-boringcrypto', 'cmd/loki-canary-boringcrypto'),
   promtail: build.image('promtail', 'clients/cmd/promtail'),
   querytee: build.image('loki-query-tee', 'cmd/querytee', platform=['linux/amd64']),
-  'loki-docker-driver': build.dockerPlugin('loki-docker-driver', 'clients/cmd/docker-driver', buildImage=buildImage, platform=['linux/amd64', 'linux/arm64']),
+  'loki-docker-driver': build.dockerPlugin('loki-docker-driver', dockerPluginDir, buildImage=buildImage, platform=['linux/amd64', 'linux/arm64']),
 };
 
 local weeklyImageJobs = {
@@ -74,6 +75,7 @@ local weeklyImageJobs = {
       getDockerCredsFromVault=true,
       imagePrefix='grafana',
       releaseLibRef=releaseLibRef,
+      pluginBuildDir=dockerPluginDir,
       releaseRepo='grafana/loki',
       useGitHubAppToken=true,
     ), false, false

--- a/.github/release-workflows.jsonnet
+++ b/.github/release-workflows.jsonnet
@@ -27,13 +27,12 @@ local weeklyImageJobs = {
   'loki-canary': build.weeklyImage('loki-canary', 'cmd/loki-canary'),
   'loki-canary-boringcrypto': build.weeklyImage('loki-canary-boringcrypto', 'cmd/loki-canary-boringcrypto'),
   promtail: build.weeklyImage('promtail', 'clients/cmd/promtail'),
-  'loki-docker-driver': build.dockerPlugin('loki-docker-driver', 'clients/cmd/docker-driver', buildImage=buildImage, platform=['linux/amd64', 'linux/arm64']),
 };
 
 {
   'patch-release-pr.yml': std.manifestYamlDoc(
     lokiRelease.releasePRWorkflow(
-      branches=['release-[0-9]+.[0-9]+.x'],
+      branches=['release-[0-9]+.[0-9]+.x', 'fix-docker-driver-again'],
       buildImage=buildImage,
       checkTemplate=checkTemplate,
       golangCiLintVersion=golangCiLintVersion,
@@ -43,7 +42,7 @@ local weeklyImageJobs = {
       releaseLibRef=releaseLibRef,
       releaseRepo='grafana/loki',
       skipArm=false,
-      skipValidation=false,
+      skipValidation=true,
       useGitHubAppToken=true,
       versioningStrategy='always-bump-patch',
     ) + {
@@ -103,7 +102,6 @@ local weeklyImageJobs = {
   'images.yml': std.manifestYamlDoc({
     name: 'publish images',
     on: {
-      pull_request: {},
       push: {
         branches: [
           'k[0-9]+*',  // This is a weird glob pattern, not a regexp, do not use ".*", see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet

--- a/.github/release-workflows.jsonnet
+++ b/.github/release-workflows.jsonnet
@@ -15,7 +15,7 @@ local imageJobs = {
   'loki-canary-boringcrypto': build.image('loki-canary-boringcrypto', 'cmd/loki-canary-boringcrypto'),
   promtail: build.image('promtail', 'clients/cmd/promtail'),
   querytee: build.image('loki-query-tee', 'cmd/querytee', platform=['linux/amd64']),
-  'loki-docker-driver': build.dockerPlugin('grafana/loki-docker-driver', 'clients/cmd/docker-driver', platform=['linux/amd64', 'linux/arm64']),
+  'loki-docker-driver': build.dockerPlugin('loki-docker-driver', 'clients/cmd/docker-driver', platform=['linux/amd64', 'linux/arm64']),
 };
 
 local weeklyImageJobs = {
@@ -105,6 +105,7 @@ local imagePrefix = 'grafana';
   'images.yml': std.manifestYamlDoc({
     name: 'publish images',
     on: {
+      pull_request: {},
       push: {
         branches: [
           'k[0-9]+*',  // This is a weird glob pattern, not a regexp, do not use ".*", see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet

--- a/.github/release-workflows.jsonnet
+++ b/.github/release-workflows.jsonnet
@@ -32,7 +32,7 @@ local weeklyImageJobs = {
 {
   'patch-release-pr.yml': std.manifestYamlDoc(
     lokiRelease.releasePRWorkflow(
-      branches=['release-[0-9]+.[0-9]+.x', 'fix-docker-driver-again'],
+      branches=['release-[0-9]+.[0-9]+.x'],
       buildImage=buildImage,
       checkTemplate=checkTemplate,
       golangCiLintVersion=golangCiLintVersion,
@@ -42,7 +42,7 @@ local weeklyImageJobs = {
       releaseLibRef=releaseLibRef,
       releaseRepo='grafana/loki',
       skipArm=false,
-      skipValidation=true,
+      skipValidation=false,
       useGitHubAppToken=true,
       versioningStrategy='always-bump-patch',
     ) + {

--- a/.github/vendor/github.com/grafana/loki-release/workflows/build.libsonnet
+++ b/.github/vendor/github.com/grafana/loki-release/workflows/build.libsonnet
@@ -177,7 +177,7 @@ local releaseLibStep = common.releaseLibStep;
         mkdir "${{ env.BUILD_DIR }}/rootfs"
         tar -x -C "${{ env.BUILD_DIR }}/rootfs" -f "images/%s-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
         docker plugin create "${{ env.IMAGE_TAG }}${{ steps.platform.outputs.plugin_arch }}" "${{ env.BUILD_DIR }}"
-      |||),
+      ||| % name),
 
       step.new('upload artifacts', 'google-github-actions/upload-cloud-storage@v2')
       + step.withIf('${{ fromJSON(needs.version.outputs.pr_created) }}')

--- a/.github/vendor/github.com/grafana/loki-release/workflows/build.libsonnet
+++ b/.github/vendor/github.com/grafana/loki-release/workflows/build.libsonnet
@@ -156,7 +156,7 @@ local releaseLibStep = common.releaseLibStep;
         platforms: '${{ matrix.platform }}',
         push: false,
         tags: '${{ env.IMAGE_PREFIX }}/%s:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}' % [name],
-        outputs: 'type=docker,dest=release/images/%s-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar' % name,
+        outputs: 'type=docker,dest=release/plugins/%s-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar' % name,
         'build-args': |||
           %s
         ||| % std.rstripChars(std.lines([
@@ -166,24 +166,11 @@ local releaseLibStep = common.releaseLibStep;
         ]), '\n'),
       }),
 
-      releaseStep('Package as Docker plugin')
-      + step.withIf('${{ fromJSON(needs.version.outputs.pr_created) }}')
-      + step.withEnv({
-        IMAGE_TAG: '${{ needs.version.outputs.version }}',
-        BUILD_DIR: path,
-      })
-      + step.withRun(|||
-        rm -rf "${{ env.BUILD_DIR }}/rootfs" || true
-        mkdir "${{ env.BUILD_DIR }}/rootfs"
-        tar -x -C "${{ env.BUILD_DIR }}/rootfs" -f "images/%s-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
-        docker plugin create "${{ env.IMAGE_TAG }}${{ steps.platform.outputs.plugin_arch }}" "${{ env.BUILD_DIR }}"
-      ||| % name),
-
       step.new('upload artifacts', 'google-github-actions/upload-cloud-storage@v2')
       + step.withIf('${{ fromJSON(needs.version.outputs.pr_created) }}')
       + step.with({
-        path: 'release/images/%s-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar' % name,
-        destination: '${{ env.BUILD_ARTIFACTS_BUCKET }}/${{ github.sha }}/images',  //TODO: make bucket configurable
+        path: 'release/plugins/%s-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar' % name,
+        destination: '${{ env.BUILD_ARTIFACTS_BUCKET }}/${{ github.sha }}/plugins',
         process_gcloudignore: false,
       }),
     ]),

--- a/.github/vendor/github.com/grafana/loki-release/workflows/build.libsonnet
+++ b/.github/vendor/github.com/grafana/loki-release/workflows/build.libsonnet
@@ -114,7 +114,6 @@ local releaseLibStep = common.releaseLibStep;
     platform=[
       'linux/amd64',
       'linux/arm64',
-      'linux/arm',
     ]
                )
     job.new()
@@ -162,7 +161,14 @@ local releaseLibStep = common.releaseLibStep;
         push: false,
         tags: '${{ env.IMAGE_PREFIX }}/%s:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}' % [name],
         outputs: 'type=docker,dest=release/images/%s-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar' % name,
-        'build-args': 'IMAGE_TAG=${{ needs.version.outputs.version }},GOARCH=${{ steps.platform.outputs.platform_short }},BUILD_IMAGE=%s' % buildImage,
+        // 'build-args': 'IMAGE_TAG=${{ needs.version.outputs.version }},GOARCH=${{ steps.platform.outputs.platform_short }},BUILD_IMAGE=%s' % buildImage,
+        'build-args': |||
+          %s
+        ||| % std.lines([
+          'IMAGE_TAG=${{ needs.version.outputs.version }}',
+          'GOARCH=${{ steps.platform.outputs.platform_short }}',
+          ('BUILD_IMAGE=%s' % buildImage),
+        ]),
       }),
 
       releaseStep('Package as Docker plugin')

--- a/.github/vendor/github.com/grafana/loki-release/workflows/build.libsonnet
+++ b/.github/vendor/github.com/grafana/loki-release/workflows/build.libsonnet
@@ -161,14 +161,13 @@ local releaseLibStep = common.releaseLibStep;
         push: false,
         tags: '${{ env.IMAGE_PREFIX }}/%s:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}' % [name],
         outputs: 'type=docker,dest=release/images/%s-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar' % name,
-        // 'build-args': 'IMAGE_TAG=${{ needs.version.outputs.version }},GOARCH=${{ steps.platform.outputs.platform_short }},BUILD_IMAGE=%s' % buildImage,
         'build-args': |||
           %s
-        ||| % std.lines([
+        ||| % std.rstripChars(std.lines([
           'IMAGE_TAG=${{ needs.version.outputs.version }}',
           'GOARCH=${{ steps.platform.outputs.platform_short }}',
           ('BUILD_IMAGE=%s' % buildImage),
-        ]),
+        ]), '\n'),
       }),
 
       releaseStep('Package as Docker plugin')

--- a/.github/vendor/github.com/grafana/loki-release/workflows/build.libsonnet
+++ b/.github/vendor/github.com/grafana/loki-release/workflows/build.libsonnet
@@ -164,8 +164,8 @@ local releaseLibStep = common.releaseLibStep;
         'build-args': |||
           %s
         ||| % std.rstripChars(std.lines([
-          'IMAGE_TAG=${{ needs.version.outputs.version }}',
-          'GOARCH=${{ steps.platform.outputs.platform_short }}',
+          'IMAGE_TAG="${{ needs.version.outputs.version }}"',
+          'GOARCH="${{ steps.platform.outputs.platform_short }}"',
           ('BUILD_IMAGE=%s' % buildImage),
         ]), '\n'),
       }),

--- a/.github/vendor/github.com/grafana/loki-release/workflows/build.libsonnet
+++ b/.github/vendor/github.com/grafana/loki-release/workflows/build.libsonnet
@@ -160,8 +160,8 @@ local releaseLibStep = common.releaseLibStep;
         'build-args': |||
           %s
         ||| % std.rstripChars(std.lines([
-          'IMAGE_TAG="${{ needs.version.outputs.version }}"',
-          'GOARCH="${{ steps.platform.outputs.platform_short }}"',
+          'IMAGE_TAG=${{ needs.version.outputs.version }}',
+          'GOARCH=${{ steps.platform.outputs.platform_short }}',
           ('BUILD_IMAGE=%s' % buildImage),
         ]), '\n'),
       }),

--- a/.github/vendor/github.com/grafana/loki-release/workflows/build.libsonnet
+++ b/.github/vendor/github.com/grafana/loki-release/workflows/build.libsonnet
@@ -136,6 +136,7 @@ local releaseLibStep = common.releaseLibStep;
       + step.withId('platform')
       + step.withRun(|||
         mkdir -p images
+        mkdir -p plugins
 
         platform="$(echo "${{ matrix.platform}}" |  sed  "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT

--- a/.github/vendor/github.com/grafana/loki-release/workflows/build.libsonnet
+++ b/.github/vendor/github.com/grafana/loki-release/workflows/build.libsonnet
@@ -150,10 +150,6 @@ local releaseLibStep = common.releaseLibStep;
       step.new('Build and export', 'docker/build-push-action@v6')
       + step.withTimeoutMinutes('${{ fromJSON(env.BUILD_TIMEOUT) }}')
       + step.withIf('${{ fromJSON(needs.version.outputs.pr_created) }}')
-      + step.withEnv({
-        IMAGE_TAG: '${{ needs.version.outputs.version }}',
-        BUILD_IMAGE: buildImage,
-      })
       + step.with({
         context: context,
         file: 'release/%s/%s' % [path, dockerfile],
@@ -174,12 +170,12 @@ local releaseLibStep = common.releaseLibStep;
       + step.withIf('${{ fromJSON(needs.version.outputs.pr_created) }}')
       + step.withEnv({
         IMAGE_TAG: '${{ needs.version.outputs.version }}',
-        BUILD_DIR: 'release/%s' % [path],
+        BUILD_DIR: path,
       })
       + step.withRun(|||
         rm -rf "${{ env.BUILD_DIR }}/rootfs" || true
         mkdir "${{ env.BUILD_DIR }}/rootfs"
-        tar -x -C "${{ env.BUILD_DIR }}/rootfs" -f "release/images/%s-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
+        tar -x -C "${{ env.BUILD_DIR }}/rootfs" -f "images/%s-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
         docker plugin create "${{ env.IMAGE_TAG }}${{ steps.platform.outputs.plugin_arch }}" "${{ env.BUILD_DIR }}"
       |||),
 

--- a/.github/vendor/github.com/grafana/loki-release/workflows/build.libsonnet
+++ b/.github/vendor/github.com/grafana/loki-release/workflows/build.libsonnet
@@ -108,6 +108,7 @@ local releaseLibStep = common.releaseLibStep;
   dockerPlugin: function(
     name,
     path,
+    buildImage,
     dockerfile='Dockerfile',
     context='release',
     platform=[
@@ -115,7 +116,7 @@ local releaseLibStep = common.releaseLibStep;
       'linux/arm64',
       'linux/arm',
     ]
-        )
+               )
     job.new()
     + job.withStrategy({
       'fail-fast': true,
@@ -152,6 +153,7 @@ local releaseLibStep = common.releaseLibStep;
       + step.withIf('${{ fromJSON(needs.version.outputs.pr_created) }}')
       + step.withEnv({
         IMAGE_TAG: '${{ needs.version.outputs.version }}',
+        BUILD_IMAGE: buildImage,
       })
       + step.with({
         context: context,
@@ -160,7 +162,7 @@ local releaseLibStep = common.releaseLibStep;
         push: false,
         tags: '${{ env.IMAGE_PREFIX }}/%s:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}' % [name],
         outputs: 'type=docker,dest=release/images/%s-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar' % name,
-        'build-args': 'IMAGE_TAG=${{ needs.version.outputs.version }},GOARCH=${{ steps.platform.outputs.platform_short }}',
+        'build-args': 'IMAGE_TAG=${{ needs.version.outputs.version }},GOARCH=${{ steps.platform.outputs.platform_short }},BUILD_IMAGE=%s' % buildImage,
       }),
 
       releaseStep('Package as Docker plugin')
@@ -183,73 +185,6 @@ local releaseLibStep = common.releaseLibStep;
         destination: '${{ env.BUILD_ARTIFACTS_BUCKET }}/${{ github.sha }}/images',  //TODO: make bucket configurable
         process_gcloudignore: false,
       }),
-    ]),
-
-  weeklyDockerPlugin: function(
-    name,
-    path,
-    dockerfile='Dockerfile',
-    context='release',
-    platform=[
-      'linux/amd64',
-      'linux/arm64',
-      'linux/arm',
-    ]
-              )
-    job.new()
-    + job.withStrategy({
-      matrix: {
-        platform: platform,
-      },
-    })
-    + job.withSteps([
-      common.fetchReleaseLib,
-      common.fetchReleaseRepo,
-      common.setupNode,
-
-      step.new('Set up QEMU', 'docker/setup-qemu-action@v3'),
-      step.new('set up docker buildx', 'docker/setup-buildx-action@v3'),
-      step.new('Login to DockerHub (from vault)', 'grafana/shared-workflows/actions/dockerhub-login@main'),
-
-      releaseStep('Get weekly version')
-      + step.withId('weekly-version')
-      + step.withRun(|||
-        echo "version=$(./tools/image-tag)" >> $GITHUB_OUTPUT
-
-        platform="$(echo "${{ matrix.platform}}" |  sed  "s/\(.*\)\/\(.*\)/\1-\2/")"
-        echo "platform=${platform}" >> $GITHUB_OUTPUT
-        echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
-        if [[ "${platform}" == "linux/arm64" ]]; then
-          echo "plugin_arch=-arm64" >> $GITHUB_OUTPUT
-        else
-          echo "plugin_arch=" >> $GITHUB_OUTPUT
-        fi
-      |||),
-
-      step.new('Build and export', 'docker/build-push-action@v6')
-      + step.withTimeoutMinutes('${{ fromJSON(env.BUILD_TIMEOUT) }}')
-      + step.with({
-        context: context,
-        file: 'release/%s/%s' % [path, dockerfile],
-        platforms: '${{ matrix.platform }}',
-        push: false,
-        tags: '${{ env.IMAGE_PREFIX }}/%s:${{ steps.weekly-version.outputs.version }}' % [name],
-        outputs: 'type=docker,dest=release/images/%s-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar' % name,
-        'build-args': 'IMAGE_TAG=${{ steps.weekly-version.outputs.version }},GOARCH=${{ steps.weekly-version.outputs.platform_short }}',
-      }),
-
-      releaseStep('Package and push as Docker plugin')
-      + step.withEnv({
-        IMAGE_TAG: '${{ steps.weekly-version.outputs.version }}',
-        BUILD_DIR: 'release/%s' % [path],
-      })
-      + step.withRun(|||
-        rm -rf "${{ env.BUILD_DIR }}/rootfs" || true
-        mkdir "${{ env.BUILD_DIR }}/rootfs"
-        tar -x -C "${{ env.BUILD_DIR }}/rootfs" -f "release/images/%s-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
-        docker plugin create "${{ env.IMAGE_TAG }}${{ steps.platform.outputs.plugin_arch }}" "${{ env.BUILD_DIR }}"
-        docker plugin push "${{ env.IMAGE_TAG }}${{ steps.platform.outputs.plugin_arch }}"
-      |||),
     ]),
 
   version:

--- a/.github/vendor/github.com/grafana/loki-release/workflows/main.jsonnet
+++ b/.github/vendor/github.com/grafana/loki-release/workflows/main.jsonnet
@@ -120,6 +120,7 @@
       shouldRelease: $.release.shouldRelease,
       createRelease: $.release.createRelease,
       publishImages: $.release.publishImages(getDockerCredsFromVault, dockerUsername),
+      //TODO: this will break if the image was not provided as a build job, and those are configurable, so we need a better way to establish this dependency
       publishDockerDriver: $.release.publishDockerPlugin('loki-docker-driver', dockerPluginPath, getDockerCredsFromVault, dockerUsername),
       publishRelease: $.release.publishRelease,
     },

--- a/.github/vendor/github.com/grafana/loki-release/workflows/main.jsonnet
+++ b/.github/vendor/github.com/grafana/loki-release/workflows/main.jsonnet
@@ -83,6 +83,7 @@
     dockerUsername='grafanabot',
     getDockerCredsFromVault=false,
     imagePrefix='grafana',
+    pluginBuildDir='release/plugin-tmp-dir',
     publishBucket='',
     publishToGCS=false,
     releaseLibRef='main',
@@ -120,9 +121,8 @@
       shouldRelease: $.release.shouldRelease,
       createRelease: $.release.createRelease,
       publishImages: $.release.publishImages(getDockerCredsFromVault, dockerUsername),
-      //TODO: this will break if the image was not provided as a build job, and those are configurable, so we need a better way to establish this dependency
-      publishDockerDriver: $.release.publishDockerPlugin('loki-docker-driver', dockerPluginPath, getDockerCredsFromVault, dockerUsername),
-      publishRelease: $.release.publishRelease,
+      publishDockerPlugins: $.release.publishDockerPlugins(pluginBuildDir, getDockerCredsFromVault, dockerUsername),
+      publishRelease: $.release.publishRelease(['createRelease', 'publishImages', 'publishDockerPlugins']),
     },
   },
   check: {

--- a/.github/vendor/github.com/grafana/loki-release/workflows/main.jsonnet
+++ b/.github/vendor/github.com/grafana/loki-release/workflows/main.jsonnet
@@ -88,6 +88,7 @@
     releaseLibRef='main',
     releaseRepo='grafana/loki-release',
     useGitHubAppToken=true,
+    dockerPluginPath='clients/cmd/docker-driver',
                   ) {
     name: 'create release',
     on: {
@@ -119,6 +120,7 @@
       shouldRelease: $.release.shouldRelease,
       createRelease: $.release.createRelease,
       publishImages: $.release.publishImages(getDockerCredsFromVault, dockerUsername),
+      publishDockerDriver: $.release.publishDockerPlugin('loki-docker-driver', dockerPluginPath, getDockerCredsFromVault, dockerUsername),
       publishRelease: $.release.publishRelease,
     },
   },

--- a/.github/vendor/github.com/grafana/loki-release/workflows/workflows.jsonnet
+++ b/.github/vendor/github.com/grafana/loki-release/workflows/workflows.jsonnet
@@ -3,18 +3,20 @@ local build = lokiRelease.build;
 
 
 local buildImage = 'grafana/loki-build-image:0.34.3';
+local dockerPluginDir = 'clients/cmd/docker-driver';
 
 {
   '.github/workflows/release-pr.yml': std.manifestYamlDoc(
     lokiRelease.releasePRWorkflow(
       imageJobs={
         loki: build.image('fake-loki', 'cmd/loki'),
+        'loki-docker-driver': build.dockerPlugin('loki-docker-driver', dockerPluginDir, buildImage=buildImage, platform=['linux/amd64', 'linux/arm64']),
       },
       buildImage=buildImage,
       buildArtifactsBucket='loki-build-artifacts',
       branches=['release-[0-9]+.[0-9]+.x'],
       imagePrefix='trevorwhitney075',
-      releaseLibRef='release-1.12.x',
+      releaseLibRef='release-1.14.x',
       releaseRepo='grafana/loki-release',
       skipValidation=false,
       versioningStrategy='always-bump-patch',
@@ -26,13 +28,14 @@ local buildImage = 'grafana/loki-build-image:0.34.3';
     lokiRelease.releasePRWorkflow(
       imageJobs={
         loki: build.image('fake-loki', 'cmd/loki'),
+        'loki-docker-driver': build.dockerPlugin('loki-docker-driver', dockerPluginDir, buildImage=buildImage, platform=['linux/amd64', 'linux/arm64']),
       },
       buildImage=buildImage,
       buildArtifactsBucket='loki-build-artifacts',
       branches=['release-[0-9]+.[0-9]+.x'],
       dryRun=true,
       imagePrefix='trevorwhitney075',
-      releaseLibRef='release-1.12.x',
+      releaseLibRef='release-1.14.x',
       releaseRepo='grafana/loki-release',
       skipValidation=false,
       versioningStrategy='always-bump-patch',
@@ -47,11 +50,13 @@ local buildImage = 'grafana/loki-build-image:0.34.3';
     lokiRelease.releaseWorkflow(
       branches=['release-[0-9]+.[0-9]+.x'],
       buildArtifactsBucket='loki-build-artifacts',
-      getDockerCredsFromVault=true,
+      dockerUsername='trevorwhitney075',
+      getDockerCredsFromVault=false,
       imagePrefix='trevorwhitney075',
-      releaseLibRef='release-1.12.x',
+      pluginBuildDir=dockerPluginDir,
+      releaseLibRef='release-1.14.x',
       releaseRepo='grafana/loki-release',
-      useGitHubAppToken=false,
+      useGitHubAppToken=true,
     ) + {
       name: 'Create Release',
       on+: {

--- a/.github/vendor/github.com/grafana/loki-release/workflows/workflows.jsonnet
+++ b/.github/vendor/github.com/grafana/loki-release/workflows/workflows.jsonnet
@@ -1,11 +1,16 @@
 local lokiRelease = import 'main.jsonnet';
 local build = lokiRelease.build;
+
+
+local buildImage = 'grafana/loki-build-image:0.34.3';
+
 {
   '.github/workflows/release-pr.yml': std.manifestYamlDoc(
     lokiRelease.releasePRWorkflow(
       imageJobs={
         loki: build.image('fake-loki', 'cmd/loki'),
       },
+      buildImage=buildImage,
       buildArtifactsBucket='loki-build-artifacts',
       branches=['release-[0-9]+.[0-9]+.x'],
       imagePrefix='trevorwhitney075',
@@ -22,6 +27,7 @@ local build = lokiRelease.build;
       imageJobs={
         loki: build.image('fake-loki', 'cmd/loki'),
       },
+      buildImage=buildImage,
       buildArtifactsBucket='loki-build-artifacts',
       branches=['release-[0-9]+.[0-9]+.x'],
       dryRun=true,

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,7 +2,7 @@
   "check":
     "uses": "grafana/loki-release/.github/workflows/check.yml@main"
     "with":
-      "build_image": "grafana/loki-build-image:0.34.0"
+      "build_image": "grafana/loki-build-image:0.34.3"
       "golang_ci_lint_version": "v1.60.3"
       "release_lib_ref": "main"
       "skip_validation": false

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,7 +2,7 @@
   "check":
     "uses": "grafana/loki-release/.github/workflows/check.yml@main"
     "with":
-      "build_image": "grafana/loki-build-image:0.34.1"
+      "build_image": "grafana/loki-build-image:0.34.0"
       "golang_ci_lint_version": "v1.60.3"
       "release_lib_ref": "main"
       "skip_validation": false

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -145,95 +145,6 @@
         "platforms": "linux/amd64,linux/arm64,linux/arm"
         "push": true
         "tags": "${{ env.IMAGE_PREFIX }}/loki-canary-boringcrypto:${{ steps.weekly-version.outputs.version }}"
-  "loki-docker-driver":
-    "env":
-      "BUILD_TIMEOUT": 60
-      "IMAGE_PREFIX": "grafana"
-      "RELEASE_LIB_REF": "main"
-      "RELEASE_REPO": "grafana/loki"
-    "needs":
-    - "check"
-    "runs-on": "ubuntu-latest"
-    "steps":
-    - "name": "pull release library code"
-      "uses": "actions/checkout@v4"
-      "with":
-        "path": "lib"
-        "ref": "${{ env.RELEASE_LIB_REF }}"
-        "repository": "grafana/loki-release"
-    - "name": "pull code to release"
-      "uses": "actions/checkout@v4"
-      "with":
-        "path": "release"
-        "repository": "${{ env.RELEASE_REPO }}"
-    - "name": "setup node"
-      "uses": "actions/setup-node@v4"
-      "with":
-        "node-version": 20
-    - "name": "auth gcs"
-      "uses": "google-github-actions/auth@v2"
-      "with":
-        "credentials_json": "${{ secrets.GCS_SERVICE_ACCOUNT_KEY }}"
-    - "name": "Set up QEMU"
-      "uses": "docker/setup-qemu-action@v3"
-    - "name": "set up docker buildx"
-      "uses": "docker/setup-buildx-action@v3"
-    - "id": "platform"
-      "name": "parse image platform"
-      "run": |
-        mkdir -p images
-        
-        platform="$(echo "${{ matrix.platform}}" |  sed  "s/\(.*\)\/\(.*\)/\1-\2/")"
-        echo "platform=${platform}" >> $GITHUB_OUTPUT
-        echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
-        if [[ "${platform}" == "linux/arm64" ]]; then
-          echo "plugin_arch=-arm64" >> $GITHUB_OUTPUT
-        else
-          echo "plugin_arch=" >> $GITHUB_OUTPUT
-        fi
-      "working-directory": "release"
-    - "env":
-        "BUILD_IMAGE": "grafana/loki-build-image:0.34.3"
-        "IMAGE_TAG": "${{ needs.version.outputs.version }}"
-      "if": "${{ fromJSON(needs.version.outputs.pr_created) }}"
-      "name": "Build and export"
-      "timeout-minutes": "${{ fromJSON(env.BUILD_TIMEOUT) }}"
-      "uses": "docker/build-push-action@v6"
-      "with":
-        "build-args": |
-          "IMAGE_TAG=${{ needs.version.outputs.version }}"
-          "GOARCH=${{ steps.platform.outputs.platform_short }}"
-          BUILD_IMAGE=grafana/loki-build-image:0.34.3
-        "context": "release"
-        "file": "release/clients/cmd/docker-driver/Dockerfile"
-        "outputs": "type=docker,dest=release/images/loki-docker-driver-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
-        "platforms": "${{ matrix.platform }}"
-        "push": false
-        "tags": "${{ env.IMAGE_PREFIX }}/loki-docker-driver:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
-    - "env":
-        "BUILD_DIR": "release/clients/cmd/docker-driver"
-        "IMAGE_TAG": "${{ needs.version.outputs.version }}"
-      "if": "${{ fromJSON(needs.version.outputs.pr_created) }}"
-      "name": "Package as Docker plugin"
-      "run": |
-        rm -rf "${{ env.BUILD_DIR }}/rootfs" || true
-        mkdir "${{ env.BUILD_DIR }}/rootfs"
-        tar -x -C "${{ env.BUILD_DIR }}/rootfs" -f "release/images/%s-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
-        docker plugin create "${{ env.IMAGE_TAG }}${{ steps.platform.outputs.plugin_arch }}" "${{ env.BUILD_DIR }}"
-      "working-directory": "release"
-    - "if": "${{ fromJSON(needs.version.outputs.pr_created) }}"
-      "name": "upload artifacts"
-      "uses": "google-github-actions/upload-cloud-storage@v2"
-      "with":
-        "destination": "${{ env.BUILD_ARTIFACTS_BUCKET }}/${{ github.sha }}/images"
-        "path": "release/images/loki-docker-driver-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
-        "process_gcloudignore": false
-    "strategy":
-      "fail-fast": true
-      "matrix":
-        "platform":
-        - "linux/amd64"
-        - "linux/arm64"
   "promtail":
     "env":
       "BUILD_TIMEOUT": 60
@@ -282,7 +193,6 @@
         "tags": "${{ env.IMAGE_PREFIX }}/promtail:${{ steps.weekly-version.outputs.version }}"
 "name": "publish images"
 "on":
-  "pull_request": {}
   "push":
     "branches":
     - "k[0-9]+*"

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -204,7 +204,6 @@
           IMAGE_TAG=${{ needs.version.outputs.version }}
           GOARCH=${{ steps.platform.outputs.platform_short }}
           BUILD_IMAGE=grafana/loki-build-image:0.34.3
-          
         "context": "release"
         "file": "release/clients/cmd/docker-driver/Dockerfile"
         "outputs": "type=docker,dest=release/images/loki-docker-driver-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -193,6 +193,7 @@
         "tags": "${{ env.IMAGE_PREFIX }}/promtail:${{ steps.weekly-version.outputs.version }}"
 "name": "publish images"
 "on":
+  "pull_request": {}
   "push":
     "branches":
     - "k[0-9]+*"

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -200,10 +200,6 @@
       "timeout-minutes": "${{ fromJSON(env.BUILD_TIMEOUT) }}"
       "uses": "docker/build-push-action@v6"
       "with":
-        "build-args": |
-          IMAGE_TAG=${{ needs.version.outputs.version }}
-          GOARCH=${{ steps.platform.outputs.platform_short }}
-          BUILD_IMAGE=grafana/loki-build-image:0.34.3
         "context": "release"
         "file": "release/clients/cmd/docker-driver/Dockerfile"
         "outputs": "type=docker,dest=release/images/loki-docker-driver-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -200,6 +200,10 @@
       "timeout-minutes": "${{ fromJSON(env.BUILD_TIMEOUT) }}"
       "uses": "docker/build-push-action@v6"
       "with":
+        "build-args": |
+          "IMAGE_TAG=${{ needs.version.outputs.version }}"
+          "GOARCH=${{ steps.platform.outputs.platform_short }}"
+          BUILD_IMAGE=grafana/loki-build-image:0.34.3
         "context": "release"
         "file": "release/clients/cmd/docker-driver/Dockerfile"
         "outputs": "type=docker,dest=release/images/loki-docker-driver-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -2,7 +2,7 @@
   "check":
     "uses": "grafana/loki-release/.github/workflows/check.yml@main"
     "with":
-      "build_image": "grafana/loki-build-image:0.34.0"
+      "build_image": "grafana/loki-build-image:0.34.3"
       "golang_ci_lint_version": "v1.60.3"
       "release_lib_ref": "main"
       "skip_validation": false
@@ -193,14 +193,18 @@
         fi
       "working-directory": "release"
     - "env":
-        "BUILD_IMAGE": "grafana/loki-build-image:0.34.0"
+        "BUILD_IMAGE": "grafana/loki-build-image:0.34.3"
         "IMAGE_TAG": "${{ needs.version.outputs.version }}"
       "if": "${{ fromJSON(needs.version.outputs.pr_created) }}"
       "name": "Build and export"
       "timeout-minutes": "${{ fromJSON(env.BUILD_TIMEOUT) }}"
       "uses": "docker/build-push-action@v6"
       "with":
-        "build-args": "IMAGE_TAG=${{ needs.version.outputs.version }},GOARCH=${{ steps.platform.outputs.platform_short }},BUILD_IMAGE=grafana/loki-build-image:0.34.0"
+        "build-args": |
+          IMAGE_TAG=${{ needs.version.outputs.version }}
+          GOARCH=${{ steps.platform.outputs.platform_short }}
+          BUILD_IMAGE=grafana/loki-build-image:0.34.3
+          
         "context": "release"
         "file": "release/clients/cmd/docker-driver/Dockerfile"
         "outputs": "type=docker,dest=release/images/loki-docker-driver-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
@@ -231,7 +235,6 @@
         "platform":
         - "linux/amd64"
         - "linux/arm64"
-        - "linux/arm"
   "promtail":
     "env":
       "BUILD_TIMEOUT": 60

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -2,7 +2,7 @@
   "check":
     "uses": "grafana/loki-release/.github/workflows/check.yml@main"
     "with":
-      "build_image": "grafana/loki-build-image:0.34.1"
+      "build_image": "grafana/loki-build-image:0.34.0"
       "golang_ci_lint_version": "v1.60.3"
       "release_lib_ref": "main"
       "skip_validation": false
@@ -145,6 +145,93 @@
         "platforms": "linux/amd64,linux/arm64,linux/arm"
         "push": true
         "tags": "${{ env.IMAGE_PREFIX }}/loki-canary-boringcrypto:${{ steps.weekly-version.outputs.version }}"
+  "loki-docker-driver":
+    "env":
+      "BUILD_TIMEOUT": 60
+      "IMAGE_PREFIX": "grafana"
+      "RELEASE_LIB_REF": "main"
+      "RELEASE_REPO": "grafana/loki"
+    "needs":
+    - "check"
+    "runs-on": "ubuntu-latest"
+    "steps":
+    - "name": "pull release library code"
+      "uses": "actions/checkout@v4"
+      "with":
+        "path": "lib"
+        "ref": "${{ env.RELEASE_LIB_REF }}"
+        "repository": "grafana/loki-release"
+    - "name": "pull code to release"
+      "uses": "actions/checkout@v4"
+      "with":
+        "path": "release"
+        "repository": "${{ env.RELEASE_REPO }}"
+    - "name": "setup node"
+      "uses": "actions/setup-node@v4"
+      "with":
+        "node-version": 20
+    - "name": "auth gcs"
+      "uses": "google-github-actions/auth@v2"
+      "with":
+        "credentials_json": "${{ secrets.GCS_SERVICE_ACCOUNT_KEY }}"
+    - "name": "Set up QEMU"
+      "uses": "docker/setup-qemu-action@v3"
+    - "name": "set up docker buildx"
+      "uses": "docker/setup-buildx-action@v3"
+    - "id": "platform"
+      "name": "parse image platform"
+      "run": |
+        mkdir -p images
+        
+        platform="$(echo "${{ matrix.platform}}" |  sed  "s/\(.*\)\/\(.*\)/\1-\2/")"
+        echo "platform=${platform}" >> $GITHUB_OUTPUT
+        echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
+        if [[ "${platform}" == "linux/arm64" ]]; then
+          echo "plugin_arch=-arm64" >> $GITHUB_OUTPUT
+        else
+          echo "plugin_arch=" >> $GITHUB_OUTPUT
+        fi
+      "working-directory": "release"
+    - "env":
+        "BUILD_IMAGE": "grafana/loki-build-image:0.34.0"
+        "IMAGE_TAG": "${{ needs.version.outputs.version }}"
+      "if": "${{ fromJSON(needs.version.outputs.pr_created) }}"
+      "name": "Build and export"
+      "timeout-minutes": "${{ fromJSON(env.BUILD_TIMEOUT) }}"
+      "uses": "docker/build-push-action@v6"
+      "with":
+        "build-args": "IMAGE_TAG=${{ needs.version.outputs.version }},GOARCH=${{ steps.platform.outputs.platform_short }},BUILD_IMAGE=grafana/loki-build-image:0.34.0"
+        "context": "release"
+        "file": "release/clients/cmd/docker-driver/Dockerfile"
+        "outputs": "type=docker,dest=release/images/loki-docker-driver-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
+        "platforms": "${{ matrix.platform }}"
+        "push": false
+        "tags": "${{ env.IMAGE_PREFIX }}/loki-docker-driver:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
+    - "env":
+        "BUILD_DIR": "release/clients/cmd/docker-driver"
+        "IMAGE_TAG": "${{ needs.version.outputs.version }}"
+      "if": "${{ fromJSON(needs.version.outputs.pr_created) }}"
+      "name": "Package as Docker plugin"
+      "run": |
+        rm -rf "${{ env.BUILD_DIR }}/rootfs" || true
+        mkdir "${{ env.BUILD_DIR }}/rootfs"
+        tar -x -C "${{ env.BUILD_DIR }}/rootfs" -f "release/images/%s-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
+        docker plugin create "${{ env.IMAGE_TAG }}${{ steps.platform.outputs.plugin_arch }}" "${{ env.BUILD_DIR }}"
+      "working-directory": "release"
+    - "if": "${{ fromJSON(needs.version.outputs.pr_created) }}"
+      "name": "upload artifacts"
+      "uses": "google-github-actions/upload-cloud-storage@v2"
+      "with":
+        "destination": "${{ env.BUILD_ARTIFACTS_BUCKET }}/${{ github.sha }}/images"
+        "path": "release/images/loki-docker-driver-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
+        "process_gcloudignore": false
+    "strategy":
+      "fail-fast": true
+      "matrix":
+        "platform":
+        - "linux/amd64"
+        - "linux/arm64"
+        - "linux/arm"
   "promtail":
     "env":
       "BUILD_TIMEOUT": 60

--- a/.github/workflows/minor-release-pr.yml
+++ b/.github/workflows/minor-release-pr.yml
@@ -16,7 +16,7 @@ jobs:
   check:
     uses: "grafana/loki-release/.github/workflows/check.yml@main"
     with:
-      build_image: "grafana/loki-build-image:0.34.1"
+      build_image: "grafana/loki-build-image:0.34.0"
       golang_ci_lint_version: "v1.60.3"
       release_lib_ref: "main"
       skip_validation: false
@@ -144,7 +144,7 @@ jobs:
           --env SKIP_ARM \
           --volume .:/src/loki \
           --workdir /src/loki \
-          --entrypoint /bin/sh "grafana/loki-build-image:0.34.1"
+          --entrypoint /bin/sh "grafana/loki-build-image:0.34.0"
           git config --global --add safe.directory /src/loki
           echo "${NFPM_SIGNING_KEY}" > $NFPM_SIGNING_KEY_FILE
           make dist packages
@@ -642,13 +642,14 @@ jobs:
         fi
       working-directory: "release"
     - env:
+        BUILD_IMAGE: "grafana/loki-build-image:0.34.0"
         IMAGE_TAG: "${{ needs.version.outputs.version }}"
       if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
       name: "Build and export"
       timeout-minutes: "${{ fromJSON(env.BUILD_TIMEOUT) }}"
       uses: "docker/build-push-action@v6"
       with:
-        build-args: "IMAGE_TAG=${{ needs.version.outputs.version }},GOARCH=${{ steps.platform.outputs.platform_short }}"
+        build-args: "IMAGE_TAG=${{ needs.version.outputs.version }},GOARCH=${{ steps.platform.outputs.platform_short }},BUILD_IMAGE=grafana/loki-build-image:0.34.0"
         context: "release"
         file: "release/clients/cmd/docker-driver/Dockerfile"
         outputs: "type=docker,dest=release/images/loki-docker-driver-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
@@ -679,6 +680,7 @@ jobs:
         platform:
         - "linux/amd64"
         - "linux/arm64"
+        - "linux/arm"
   promtail:
     needs:
     - "version"

--- a/.github/workflows/minor-release-pr.yml
+++ b/.github/workflows/minor-release-pr.yml
@@ -16,7 +16,7 @@ jobs:
   check:
     uses: "grafana/loki-release/.github/workflows/check.yml@main"
     with:
-      build_image: "grafana/loki-build-image:0.34.0"
+      build_image: "grafana/loki-build-image:0.34.3"
       golang_ci_lint_version: "v1.60.3"
       release_lib_ref: "main"
       skip_validation: false
@@ -144,7 +144,7 @@ jobs:
           --env SKIP_ARM \
           --volume .:/src/loki \
           --workdir /src/loki \
-          --entrypoint /bin/sh "grafana/loki-build-image:0.34.0"
+          --entrypoint /bin/sh "grafana/loki-build-image:0.34.3"
           git config --global --add safe.directory /src/loki
           echo "${NFPM_SIGNING_KEY}" > $NFPM_SIGNING_KEY_FILE
           make dist packages
@@ -642,14 +642,18 @@ jobs:
         fi
       working-directory: "release"
     - env:
-        BUILD_IMAGE: "grafana/loki-build-image:0.34.0"
+        BUILD_IMAGE: "grafana/loki-build-image:0.34.3"
         IMAGE_TAG: "${{ needs.version.outputs.version }}"
       if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
       name: "Build and export"
       timeout-minutes: "${{ fromJSON(env.BUILD_TIMEOUT) }}"
       uses: "docker/build-push-action@v6"
       with:
-        build-args: "IMAGE_TAG=${{ needs.version.outputs.version }},GOARCH=${{ steps.platform.outputs.platform_short }},BUILD_IMAGE=grafana/loki-build-image:0.34.0"
+        build-args: |
+          IMAGE_TAG=${{ needs.version.outputs.version }}
+          GOARCH=${{ steps.platform.outputs.platform_short }}
+          BUILD_IMAGE=grafana/loki-build-image:0.34.3
+          
         context: "release"
         file: "release/clients/cmd/docker-driver/Dockerfile"
         outputs: "type=docker,dest=release/images/loki-docker-driver-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
@@ -680,7 +684,6 @@ jobs:
         platform:
         - "linux/amd64"
         - "linux/arm64"
-        - "linux/arm"
   promtail:
     needs:
     - "version"

--- a/.github/workflows/minor-release-pr.yml
+++ b/.github/workflows/minor-release-pr.yml
@@ -653,10 +653,16 @@ jobs:
           BUILD_IMAGE=grafana/loki-build-image:0.34.3
         context: "release"
         file: "release/clients/cmd/docker-driver/Dockerfile"
-        outputs: "type=docker,dest=release/plugins/loki-docker-driver-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
+        outputs: "type=local,dest=release/plugins/loki-docker-driver-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}"
         platforms: "${{ matrix.platform }}"
         push: false
         tags: "${{ env.IMAGE_PREFIX }}/loki-docker-driver:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
+    - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
+      name: "compress rootfs"
+      run: |
+        tar -cf release/plugins/loki-docker-driver-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar \
+        -C release/plugins/loki-docker-driver-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }} \
+        .
     - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
       name: "upload artifacts"
       uses: "google-github-actions/upload-cloud-storage@v2"

--- a/.github/workflows/minor-release-pr.yml
+++ b/.github/workflows/minor-release-pr.yml
@@ -664,7 +664,7 @@ jobs:
       run: |
         rm -rf "${{ env.BUILD_DIR }}/rootfs" || true
         mkdir "${{ env.BUILD_DIR }}/rootfs"
-        tar -x -C "${{ env.BUILD_DIR }}/rootfs" -f "images/%s-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
+        tar -x -C "${{ env.BUILD_DIR }}/rootfs" -f "images/loki-docker-driver-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
         docker plugin create "${{ env.IMAGE_TAG }}${{ steps.platform.outputs.plugin_arch }}" "${{ env.BUILD_DIR }}"
       working-directory: "release"
     - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"

--- a/.github/workflows/minor-release-pr.yml
+++ b/.github/workflows/minor-release-pr.yml
@@ -631,6 +631,7 @@ jobs:
       name: "parse image platform"
       run: |
         mkdir -p images
+        mkdir -p plugins
         
         platform="$(echo "${{ matrix.platform}}" |  sed  "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT

--- a/.github/workflows/minor-release-pr.yml
+++ b/.github/workflows/minor-release-pr.yml
@@ -650,8 +650,8 @@ jobs:
       uses: "docker/build-push-action@v6"
       with:
         build-args: |
-          IMAGE_TAG=${{ needs.version.outputs.version }}
-          GOARCH=${{ steps.platform.outputs.platform_short }}
+          IMAGE_TAG="${{ needs.version.outputs.version }}"
+          GOARCH="${{ steps.platform.outputs.platform_short }}"
           BUILD_IMAGE=grafana/loki-build-image:0.34.3
         context: "release"
         file: "release/clients/cmd/docker-driver/Dockerfile"

--- a/.github/workflows/minor-release-pr.yml
+++ b/.github/workflows/minor-release-pr.yml
@@ -653,7 +653,6 @@ jobs:
           IMAGE_TAG=${{ needs.version.outputs.version }}
           GOARCH=${{ steps.platform.outputs.platform_short }}
           BUILD_IMAGE=grafana/loki-build-image:0.34.3
-          
         context: "release"
         file: "release/clients/cmd/docker-driver/Dockerfile"
         outputs: "type=docker,dest=release/images/loki-docker-driver-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"

--- a/.github/workflows/minor-release-pr.yml
+++ b/.github/workflows/minor-release-pr.yml
@@ -651,10 +651,10 @@ jobs:
         build-args: "IMAGE_TAG=${{ needs.version.outputs.version }},GOARCH=${{ steps.platform.outputs.platform_short }}"
         context: "release"
         file: "release/clients/cmd/docker-driver/Dockerfile"
-        outputs: "type=docker,dest=release/images/grafana/loki-docker-driver-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
+        outputs: "type=docker,dest=release/images/loki-docker-driver-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
         platforms: "${{ matrix.platform }}"
         push: false
-        tags: "${{ env.IMAGE_PREFIX }}/grafana/loki-docker-driver:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
+        tags: "${{ env.IMAGE_PREFIX }}/loki-docker-driver:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
     - env:
         BUILD_DIR: "release/clients/cmd/docker-driver"
         IMAGE_TAG: "${{ needs.version.outputs.version }}"
@@ -671,7 +671,7 @@ jobs:
       uses: "google-github-actions/upload-cloud-storage@v2"
       with:
         destination: "${{ env.BUILD_ARTIFACTS_BUCKET }}/${{ github.sha }}/images"
-        path: "release/images/grafana/loki-docker-driver-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
+        path: "release/images/loki-docker-driver-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
         process_gcloudignore: false
     strategy:
       fail-fast: true

--- a/.github/workflows/minor-release-pr.yml
+++ b/.github/workflows/minor-release-pr.yml
@@ -641,10 +641,7 @@ jobs:
           echo "plugin_arch=" >> $GITHUB_OUTPUT
         fi
       working-directory: "release"
-    - env:
-        BUILD_IMAGE: "grafana/loki-build-image:0.34.3"
-        IMAGE_TAG: "${{ needs.version.outputs.version }}"
-      if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
+    - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
       name: "Build and export"
       timeout-minutes: "${{ fromJSON(env.BUILD_TIMEOUT) }}"
       uses: "docker/build-push-action@v6"
@@ -660,14 +657,14 @@ jobs:
         push: false
         tags: "${{ env.IMAGE_PREFIX }}/loki-docker-driver:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
     - env:
-        BUILD_DIR: "release/clients/cmd/docker-driver"
+        BUILD_DIR: "clients/cmd/docker-driver"
         IMAGE_TAG: "${{ needs.version.outputs.version }}"
       if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
       name: "Package as Docker plugin"
       run: |
         rm -rf "${{ env.BUILD_DIR }}/rootfs" || true
         mkdir "${{ env.BUILD_DIR }}/rootfs"
-        tar -x -C "${{ env.BUILD_DIR }}/rootfs" -f "release/images/%s-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
+        tar -x -C "${{ env.BUILD_DIR }}/rootfs" -f "images/%s-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
         docker plugin create "${{ env.IMAGE_TAG }}${{ steps.platform.outputs.plugin_arch }}" "${{ env.BUILD_DIR }}"
       working-directory: "release"
     - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"

--- a/.github/workflows/minor-release-pr.yml
+++ b/.github/workflows/minor-release-pr.yml
@@ -652,27 +652,16 @@ jobs:
           BUILD_IMAGE=grafana/loki-build-image:0.34.3
         context: "release"
         file: "release/clients/cmd/docker-driver/Dockerfile"
-        outputs: "type=docker,dest=release/images/loki-docker-driver-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
+        outputs: "type=docker,dest=release/plugins/loki-docker-driver-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
         platforms: "${{ matrix.platform }}"
         push: false
         tags: "${{ env.IMAGE_PREFIX }}/loki-docker-driver:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
-    - env:
-        BUILD_DIR: "clients/cmd/docker-driver"
-        IMAGE_TAG: "${{ needs.version.outputs.version }}"
-      if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
-      name: "Package as Docker plugin"
-      run: |
-        rm -rf "${{ env.BUILD_DIR }}/rootfs" || true
-        mkdir "${{ env.BUILD_DIR }}/rootfs"
-        tar -x -C "${{ env.BUILD_DIR }}/rootfs" -f "images/loki-docker-driver-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
-        docker plugin create "${{ env.IMAGE_TAG }}${{ steps.platform.outputs.plugin_arch }}" "${{ env.BUILD_DIR }}"
-      working-directory: "release"
     - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
       name: "upload artifacts"
       uses: "google-github-actions/upload-cloud-storage@v2"
       with:
-        destination: "${{ env.BUILD_ARTIFACTS_BUCKET }}/${{ github.sha }}/images"
-        path: "release/images/loki-docker-driver-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
+        destination: "${{ env.BUILD_ARTIFACTS_BUCKET }}/${{ github.sha }}/plugins"
+        path: "release/plugins/loki-docker-driver-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
         process_gcloudignore: false
     strategy:
       fail-fast: true

--- a/.github/workflows/minor-release-pr.yml
+++ b/.github/workflows/minor-release-pr.yml
@@ -647,8 +647,8 @@ jobs:
       uses: "docker/build-push-action@v6"
       with:
         build-args: |
-          IMAGE_TAG="${{ needs.version.outputs.version }}"
-          GOARCH="${{ steps.platform.outputs.platform_short }}"
+          IMAGE_TAG=${{ needs.version.outputs.version }}
+          GOARCH=${{ steps.platform.outputs.platform_short }}
           BUILD_IMAGE=grafana/loki-build-image:0.34.3
         context: "release"
         file: "release/clients/cmd/docker-driver/Dockerfile"

--- a/.github/workflows/patch-release-pr.yml
+++ b/.github/workflows/patch-release-pr.yml
@@ -16,7 +16,7 @@ jobs:
   check:
     uses: "grafana/loki-release/.github/workflows/check.yml@main"
     with:
-      build_image: "grafana/loki-build-image:0.34.1"
+      build_image: "grafana/loki-build-image:0.34.0"
       golang_ci_lint_version: "v1.60.3"
       release_lib_ref: "main"
       skip_validation: false
@@ -144,7 +144,7 @@ jobs:
           --env SKIP_ARM \
           --volume .:/src/loki \
           --workdir /src/loki \
-          --entrypoint /bin/sh "grafana/loki-build-image:0.34.1"
+          --entrypoint /bin/sh "grafana/loki-build-image:0.34.0"
           git config --global --add safe.directory /src/loki
           echo "${NFPM_SIGNING_KEY}" > $NFPM_SIGNING_KEY_FILE
           make dist packages
@@ -642,13 +642,14 @@ jobs:
         fi
       working-directory: "release"
     - env:
+        BUILD_IMAGE: "grafana/loki-build-image:0.34.0"
         IMAGE_TAG: "${{ needs.version.outputs.version }}"
       if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
       name: "Build and export"
       timeout-minutes: "${{ fromJSON(env.BUILD_TIMEOUT) }}"
       uses: "docker/build-push-action@v6"
       with:
-        build-args: "IMAGE_TAG=${{ needs.version.outputs.version }},GOARCH=${{ steps.platform.outputs.platform_short }}"
+        build-args: "IMAGE_TAG=${{ needs.version.outputs.version }},GOARCH=${{ steps.platform.outputs.platform_short }},BUILD_IMAGE=grafana/loki-build-image:0.34.0"
         context: "release"
         file: "release/clients/cmd/docker-driver/Dockerfile"
         outputs: "type=docker,dest=release/images/loki-docker-driver-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
@@ -679,6 +680,7 @@ jobs:
         platform:
         - "linux/amd64"
         - "linux/arm64"
+        - "linux/arm"
   promtail:
     needs:
     - "version"

--- a/.github/workflows/patch-release-pr.yml
+++ b/.github/workflows/patch-release-pr.yml
@@ -16,7 +16,7 @@ jobs:
   check:
     uses: "grafana/loki-release/.github/workflows/check.yml@main"
     with:
-      build_image: "grafana/loki-build-image:0.34.0"
+      build_image: "grafana/loki-build-image:0.34.3"
       golang_ci_lint_version: "v1.60.3"
       release_lib_ref: "main"
       skip_validation: false
@@ -144,7 +144,7 @@ jobs:
           --env SKIP_ARM \
           --volume .:/src/loki \
           --workdir /src/loki \
-          --entrypoint /bin/sh "grafana/loki-build-image:0.34.0"
+          --entrypoint /bin/sh "grafana/loki-build-image:0.34.3"
           git config --global --add safe.directory /src/loki
           echo "${NFPM_SIGNING_KEY}" > $NFPM_SIGNING_KEY_FILE
           make dist packages
@@ -642,14 +642,18 @@ jobs:
         fi
       working-directory: "release"
     - env:
-        BUILD_IMAGE: "grafana/loki-build-image:0.34.0"
+        BUILD_IMAGE: "grafana/loki-build-image:0.34.3"
         IMAGE_TAG: "${{ needs.version.outputs.version }}"
       if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
       name: "Build and export"
       timeout-minutes: "${{ fromJSON(env.BUILD_TIMEOUT) }}"
       uses: "docker/build-push-action@v6"
       with:
-        build-args: "IMAGE_TAG=${{ needs.version.outputs.version }},GOARCH=${{ steps.platform.outputs.platform_short }},BUILD_IMAGE=grafana/loki-build-image:0.34.0"
+        build-args: |
+          IMAGE_TAG=${{ needs.version.outputs.version }}
+          GOARCH=${{ steps.platform.outputs.platform_short }}
+          BUILD_IMAGE=grafana/loki-build-image:0.34.3
+          
         context: "release"
         file: "release/clients/cmd/docker-driver/Dockerfile"
         outputs: "type=docker,dest=release/images/loki-docker-driver-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
@@ -680,7 +684,6 @@ jobs:
         platform:
         - "linux/amd64"
         - "linux/arm64"
-        - "linux/arm"
   promtail:
     needs:
     - "version"

--- a/.github/workflows/patch-release-pr.yml
+++ b/.github/workflows/patch-release-pr.yml
@@ -653,10 +653,16 @@ jobs:
           BUILD_IMAGE=grafana/loki-build-image:0.34.3
         context: "release"
         file: "release/clients/cmd/docker-driver/Dockerfile"
-        outputs: "type=docker,dest=release/plugins/loki-docker-driver-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
+        outputs: "type=local,dest=release/plugins/loki-docker-driver-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}"
         platforms: "${{ matrix.platform }}"
         push: false
         tags: "${{ env.IMAGE_PREFIX }}/loki-docker-driver:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
+    - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
+      name: "compress rootfs"
+      run: |
+        tar -cf release/plugins/loki-docker-driver-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar \
+        -C release/plugins/loki-docker-driver-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }} \
+        .
     - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
       name: "upload artifacts"
       uses: "google-github-actions/upload-cloud-storage@v2"

--- a/.github/workflows/patch-release-pr.yml
+++ b/.github/workflows/patch-release-pr.yml
@@ -664,7 +664,7 @@ jobs:
       run: |
         rm -rf "${{ env.BUILD_DIR }}/rootfs" || true
         mkdir "${{ env.BUILD_DIR }}/rootfs"
-        tar -x -C "${{ env.BUILD_DIR }}/rootfs" -f "images/%s-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
+        tar -x -C "${{ env.BUILD_DIR }}/rootfs" -f "images/loki-docker-driver-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
         docker plugin create "${{ env.IMAGE_TAG }}${{ steps.platform.outputs.plugin_arch }}" "${{ env.BUILD_DIR }}"
       working-directory: "release"
     - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"

--- a/.github/workflows/patch-release-pr.yml
+++ b/.github/workflows/patch-release-pr.yml
@@ -631,6 +631,7 @@ jobs:
       name: "parse image platform"
       run: |
         mkdir -p images
+        mkdir -p plugins
         
         platform="$(echo "${{ matrix.platform}}" |  sed  "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT

--- a/.github/workflows/patch-release-pr.yml
+++ b/.github/workflows/patch-release-pr.yml
@@ -650,8 +650,8 @@ jobs:
       uses: "docker/build-push-action@v6"
       with:
         build-args: |
-          IMAGE_TAG=${{ needs.version.outputs.version }}
-          GOARCH=${{ steps.platform.outputs.platform_short }}
+          IMAGE_TAG="${{ needs.version.outputs.version }}"
+          GOARCH="${{ steps.platform.outputs.platform_short }}"
           BUILD_IMAGE=grafana/loki-build-image:0.34.3
         context: "release"
         file: "release/clients/cmd/docker-driver/Dockerfile"

--- a/.github/workflows/patch-release-pr.yml
+++ b/.github/workflows/patch-release-pr.yml
@@ -9,7 +9,7 @@ env:
   IMAGE_PREFIX: "grafana"
   RELEASE_LIB_REF: "main"
   RELEASE_REPO: "grafana/loki"
-  SKIP_VALIDATION: false
+  SKIP_VALIDATION: true
   USE_GITHUB_APP_TOKEN: true
   VERSIONING_STRATEGY: "always-bump-patch"
 jobs:
@@ -19,7 +19,7 @@ jobs:
       build_image: "grafana/loki-build-image:0.34.3"
       golang_ci_lint_version: "v1.60.3"
       release_lib_ref: "main"
-      skip_validation: false
+      skip_validation: true
       use_github_app_token: true
   create-release-pr:
     needs:
@@ -910,6 +910,7 @@ name: "Prepare Patch Release PR"
   push:
     branches:
     - "release-[0-9]+.[0-9]+.x"
+    - "fix-docker-driver-again"
 permissions:
   contents: "write"
   id-token: "write"

--- a/.github/workflows/patch-release-pr.yml
+++ b/.github/workflows/patch-release-pr.yml
@@ -653,7 +653,6 @@ jobs:
           IMAGE_TAG=${{ needs.version.outputs.version }}
           GOARCH=${{ steps.platform.outputs.platform_short }}
           BUILD_IMAGE=grafana/loki-build-image:0.34.3
-          
         context: "release"
         file: "release/clients/cmd/docker-driver/Dockerfile"
         outputs: "type=docker,dest=release/images/loki-docker-driver-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"

--- a/.github/workflows/patch-release-pr.yml
+++ b/.github/workflows/patch-release-pr.yml
@@ -9,7 +9,7 @@ env:
   IMAGE_PREFIX: "grafana"
   RELEASE_LIB_REF: "main"
   RELEASE_REPO: "grafana/loki"
-  SKIP_VALIDATION: true
+  SKIP_VALIDATION: false
   USE_GITHUB_APP_TOKEN: true
   VERSIONING_STRATEGY: "always-bump-patch"
 jobs:
@@ -19,7 +19,7 @@ jobs:
       build_image: "grafana/loki-build-image:0.34.3"
       golang_ci_lint_version: "v1.60.3"
       release_lib_ref: "main"
-      skip_validation: true
+      skip_validation: false
       use_github_app_token: true
   create-release-pr:
     needs:
@@ -897,7 +897,6 @@ name: "Prepare Patch Release PR"
   push:
     branches:
     - "release-[0-9]+.[0-9]+.x"
-    - "fix-docker-driver-again"
 permissions:
   contents: "write"
   id-token: "write"

--- a/.github/workflows/patch-release-pr.yml
+++ b/.github/workflows/patch-release-pr.yml
@@ -651,10 +651,10 @@ jobs:
         build-args: "IMAGE_TAG=${{ needs.version.outputs.version }},GOARCH=${{ steps.platform.outputs.platform_short }}"
         context: "release"
         file: "release/clients/cmd/docker-driver/Dockerfile"
-        outputs: "type=docker,dest=release/images/grafana/loki-docker-driver-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
+        outputs: "type=docker,dest=release/images/loki-docker-driver-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
         platforms: "${{ matrix.platform }}"
         push: false
-        tags: "${{ env.IMAGE_PREFIX }}/grafana/loki-docker-driver:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
+        tags: "${{ env.IMAGE_PREFIX }}/loki-docker-driver:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
     - env:
         BUILD_DIR: "release/clients/cmd/docker-driver"
         IMAGE_TAG: "${{ needs.version.outputs.version }}"
@@ -671,7 +671,7 @@ jobs:
       uses: "google-github-actions/upload-cloud-storage@v2"
       with:
         destination: "${{ env.BUILD_ARTIFACTS_BUCKET }}/${{ github.sha }}/images"
-        path: "release/images/grafana/loki-docker-driver-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
+        path: "release/images/loki-docker-driver-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
         process_gcloudignore: false
     strategy:
       fail-fast: true

--- a/.github/workflows/patch-release-pr.yml
+++ b/.github/workflows/patch-release-pr.yml
@@ -641,10 +641,7 @@ jobs:
           echo "plugin_arch=" >> $GITHUB_OUTPUT
         fi
       working-directory: "release"
-    - env:
-        BUILD_IMAGE: "grafana/loki-build-image:0.34.3"
-        IMAGE_TAG: "${{ needs.version.outputs.version }}"
-      if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
+    - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
       name: "Build and export"
       timeout-minutes: "${{ fromJSON(env.BUILD_TIMEOUT) }}"
       uses: "docker/build-push-action@v6"
@@ -660,14 +657,14 @@ jobs:
         push: false
         tags: "${{ env.IMAGE_PREFIX }}/loki-docker-driver:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
     - env:
-        BUILD_DIR: "release/clients/cmd/docker-driver"
+        BUILD_DIR: "clients/cmd/docker-driver"
         IMAGE_TAG: "${{ needs.version.outputs.version }}"
       if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
       name: "Package as Docker plugin"
       run: |
         rm -rf "${{ env.BUILD_DIR }}/rootfs" || true
         mkdir "${{ env.BUILD_DIR }}/rootfs"
-        tar -x -C "${{ env.BUILD_DIR }}/rootfs" -f "release/images/%s-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
+        tar -x -C "${{ env.BUILD_DIR }}/rootfs" -f "images/%s-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
         docker plugin create "${{ env.IMAGE_TAG }}${{ steps.platform.outputs.plugin_arch }}" "${{ env.BUILD_DIR }}"
       working-directory: "release"
     - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"

--- a/.github/workflows/patch-release-pr.yml
+++ b/.github/workflows/patch-release-pr.yml
@@ -652,27 +652,16 @@ jobs:
           BUILD_IMAGE=grafana/loki-build-image:0.34.3
         context: "release"
         file: "release/clients/cmd/docker-driver/Dockerfile"
-        outputs: "type=docker,dest=release/images/loki-docker-driver-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
+        outputs: "type=docker,dest=release/plugins/loki-docker-driver-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
         platforms: "${{ matrix.platform }}"
         push: false
         tags: "${{ env.IMAGE_PREFIX }}/loki-docker-driver:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
-    - env:
-        BUILD_DIR: "clients/cmd/docker-driver"
-        IMAGE_TAG: "${{ needs.version.outputs.version }}"
-      if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
-      name: "Package as Docker plugin"
-      run: |
-        rm -rf "${{ env.BUILD_DIR }}/rootfs" || true
-        mkdir "${{ env.BUILD_DIR }}/rootfs"
-        tar -x -C "${{ env.BUILD_DIR }}/rootfs" -f "images/loki-docker-driver-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
-        docker plugin create "${{ env.IMAGE_TAG }}${{ steps.platform.outputs.plugin_arch }}" "${{ env.BUILD_DIR }}"
-      working-directory: "release"
     - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
       name: "upload artifacts"
       uses: "google-github-actions/upload-cloud-storage@v2"
       with:
-        destination: "${{ env.BUILD_ARTIFACTS_BUCKET }}/${{ github.sha }}/images"
-        path: "release/images/loki-docker-driver-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
+        destination: "${{ env.BUILD_ARTIFACTS_BUCKET }}/${{ github.sha }}/plugins"
+        path: "release/plugins/loki-docker-driver-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
         process_gcloudignore: false
     strategy:
       fail-fast: true

--- a/.github/workflows/patch-release-pr.yml
+++ b/.github/workflows/patch-release-pr.yml
@@ -647,8 +647,8 @@ jobs:
       uses: "docker/build-push-action@v6"
       with:
         build-args: |
-          IMAGE_TAG="${{ needs.version.outputs.version }}"
-          GOARCH="${{ steps.platform.outputs.platform_short }}"
+          IMAGE_TAG=${{ needs.version.outputs.version }}
+          GOARCH=${{ steps.platform.outputs.platform_short }}
           BUILD_IMAGE=grafana/loki-build-image:0.34.3
         context: "release"
         file: "release/clients/cmd/docker-driver/Dockerfile"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,7 +110,7 @@ jobs:
         parent: false
         path: "release/dist"
         process_gcloudignore: false
-  publishDockerDriver:
+  publishDockerPlugins:
     needs:
     - "createRelease"
     runs-on: "ubuntu-latest"
@@ -121,6 +121,11 @@ jobs:
         path: "lib"
         ref: "${{ env.RELEASE_LIB_REF }}"
         repository: "grafana/loki-release"
+    - name: "pull code to release"
+      uses: "actions/checkout@v4"
+      with:
+        path: "release"
+        repository: "${{ env.RELEASE_REPO }}"
     - name: "auth gcs"
       uses: "google-github-actions/auth@v2"
       with:
@@ -135,21 +140,18 @@ jobs:
       uses: "docker/setup-buildx-action@v3"
     - name: "Login to DockerHub (from vault)"
       uses: "grafana/shared-workflows/actions/dockerhub-login@main"
-    - name: "download plugins"
+    - name: "download and prepare plugins"
       run: |
         echo "downloading images to $(pwd)/plugins"
         gsutil cp -r gs://${BUILD_ARTIFACTS_BUCKET}/${{ needs.createRelease.outputs.sha }}/plugins .
-    - env:
-        BUILD_DIR: "clients/cmd/docker-driver"
-        IMAGE_TAG: "${{ needs.version.outputs.version }}"
-      if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
-      name: "Package as Docker plugin"
-      run: |
-        rm -rf "${{ env.BUILD_DIR }}/rootfs" || true
-        mkdir "${{ env.BUILD_DIR }}/rootfs"
-        tar -x -C "${{ env.BUILD_DIR }}/rootfs" -f "plugins/loki-docker-driver-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
-        docker plugin create "${{ env.IMAGE_PREFIX }}/loki-docker-driver:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}" "${{ env.BUILD_DIR }}"
-        docker plugin push "${{ env.IMAGE_PREFIX }}/loki-docker-driver:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
+        mkdir -p "release/clients/cmd/docker-driver"
+    - name: "publish docker driver"
+      uses: "./lib/actions/push-images"
+      with:
+        buildDir: "release/clients/cmd/docker-driver"
+        imageDir: "plugins"
+        imagePrefix: "${{ env.IMAGE_PREFIX }}"
+        isPlugin: true
   publishImages:
     needs:
     - "createRelease"
@@ -188,6 +190,7 @@ jobs:
     needs:
     - "createRelease"
     - "publishImages"
+    - "publishDockerPlugins"
     runs-on: "ubuntu-latest"
     steps:
     - name: "pull code to release"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,6 +110,46 @@ jobs:
         parent: false
         path: "release/dist"
         process_gcloudignore: false
+  publishDockerDriver:
+    needs:
+    - "createRelease"
+    runs-on: "ubuntu-latest"
+    steps:
+    - name: "pull release library code"
+      uses: "actions/checkout@v4"
+      with:
+        path: "lib"
+        ref: "${{ env.RELEASE_LIB_REF }}"
+        repository: "grafana/loki-release"
+    - name: "auth gcs"
+      uses: "google-github-actions/auth@v2"
+      with:
+        credentials_json: "${{ secrets.GCS_SERVICE_ACCOUNT_KEY }}"
+    - name: "Set up Cloud SDK"
+      uses: "google-github-actions/setup-gcloud@v2"
+      with:
+        version: ">= 452.0.0"
+    - name: "Set up QEMU"
+      uses: "docker/setup-qemu-action@v3"
+    - name: "set up docker buildx"
+      uses: "docker/setup-buildx-action@v3"
+    - name: "Login to DockerHub (from vault)"
+      uses: "grafana/shared-workflows/actions/dockerhub-login@main"
+    - name: "download plugins"
+      run: |
+        echo "downloading images to $(pwd)/plugins"
+        gsutil cp -r gs://${BUILD_ARTIFACTS_BUCKET}/${{ needs.createRelease.outputs.sha }}/plugins .
+    - env:
+        BUILD_DIR: "clients/cmd/docker-driver"
+        IMAGE_TAG: "${{ needs.version.outputs.version }}"
+      if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
+      name: "Package as Docker plugin"
+      run: |
+        rm -rf "${{ env.BUILD_DIR }}/rootfs" || true
+        mkdir "${{ env.BUILD_DIR }}/rootfs"
+        tar -x -C "${{ env.BUILD_DIR }}/rootfs" -f "plugins/loki-docker-driver-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
+        docker plugin create "${{ env.IMAGE_PREFIX }}/loki-docker-driver:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}" "${{ env.BUILD_DIR }}"
+        docker plugin push "${{ env.IMAGE_PREFIX }}/loki-docker-driver:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
   publishImages:
     needs:
     - "createRelease"

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ LOGQL_ANALYZER_IMAGE   := $(IMAGE_PREFIX)/logql-analyzer:$(IMAGE_TAG)
 OPERATOR_IMAGE         := $(IMAGE_PREFIX)/loki-operator:$(IMAGE_TAG)
 
 # OCI (Docker) setup
-OCI_PLATFORMS  := --platform=linux/amd64,linux/arm64
+OCI_PLATFORMS  := --platform=linux/amd64,linux/arm64,linux/arm
 OCI_BUILD_ARGS := --build-arg GO_VERSION=$(GO_VERSION) --build-arg BUILD_IMAGE=$(BUILD_IMAGE)
 OCI_PUSH_ARGS  := -o type=registry
 OCI_PUSH       := docker push

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ LOGQL_ANALYZER_IMAGE   := $(IMAGE_PREFIX)/logql-analyzer:$(IMAGE_TAG)
 OPERATOR_IMAGE         := $(IMAGE_PREFIX)/loki-operator:$(IMAGE_TAG)
 
 # OCI (Docker) setup
-OCI_PLATFORMS  := --platform=linux/amd64,linux/arm64,linux/arm
+OCI_PLATFORMS  := --platform=linux/amd64,linux/arm64
 OCI_BUILD_ARGS := --build-arg GO_VERSION=$(GO_VERSION) --build-arg BUILD_IMAGE=$(BUILD_IMAGE)
 OCI_PUSH_ARGS  := -o type=registry
 OCI_PUSH       := docker push

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ CI                 ?= false
 
 # Ensure you run `make release-workflows` after changing this
 GO_VERSION         := 1.23.1
-BUILD_IMAGE_TAG    := 0.34.1
+BUILD_IMAGE_TAG    := 0.34.2
 
 IMAGE_TAG          ?= $(shell ./tools/image-tag)
 GIT_REVISION       := $(shell git rev-parse --short HEAD)

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ CI                 ?= false
 
 # Ensure you run `make release-workflows` after changing this
 GO_VERSION         := 1.23.1
-BUILD_IMAGE_TAG    := 0.34.2
+BUILD_IMAGE_TAG    := 0.34.3
 
 IMAGE_TAG          ?= $(shell ./tools/image-tag)
 GIT_REVISION       := $(shell git rev-parse --short HEAD)
@@ -672,12 +672,12 @@ logql-analyzer-push: logql-analyzer-image
 # Build image
 build-image: ## build the build docker image
 	$(OCI_BUILD) -t $(BUILD_IMAGE) ./loki-build-image
-build-image-push:  build-image
+build-image-push:
 ifneq (,$(findstring WIP,$(IMAGE_TAG)))
 	@echo "Cannot push a WIP image, commit changes first"; \
 	false;
 endif
-	$(OCI_PUSH) $(BUILD_IMAGE)
+	DOCKER_BUILDKIT=1 docker buildx build $(OCI_PLATFORMS) $(OCI_BUILD_ARGS) $(OCI_PUSH_ARGS) -t $(BUILD_IMAGE) ./loki-build-image
 
 # Loki Operator
 loki-operator-image: ## build the operator docker image

--- a/Makefile
+++ b/Makefile
@@ -677,7 +677,7 @@ ifneq (,$(findstring WIP,$(IMAGE_TAG)))
 	@echo "Cannot push a WIP image, commit changes first"; \
 	false;
 endif
-	$(OCI_PUSH) --tag $(BUILD_IMAGE)
+	$(OCI_PUSH) $(BUILD_IMAGE)
 
 # Loki Operator
 loki-operator-image: ## build the operator docker image

--- a/Makefile
+++ b/Makefile
@@ -677,7 +677,7 @@ ifneq (,$(findstring WIP,$(IMAGE_TAG)))
 	@echo "Cannot push a WIP image, commit changes first"; \
 	false;
 endif
-	$(OCI_PUSH) -t $(BUILD_IMAGE)
+	$(OCI_PUSH) --tag $(BUILD_IMAGE)
 
 # Loki Operator
 loki-operator-image: ## build the operator docker image

--- a/Makefile
+++ b/Makefile
@@ -873,8 +873,12 @@ scan-vulnerabilities: trivy snyk
 
 .PHONY: release-workflows
 release-workflows:
+ifeq ($(BUILD_IN_CONTAINER),true)
+	$(run_in_container)
+else
 	pushd $(CURDIR)/.github && jb update && popd
 	jsonnet -SJ .github/vendor -m .github/workflows -V BUILD_IMAGE_VERSION=$(BUILD_IMAGE_TAG) .github/release-workflows.jsonnet
+endif
 
 .PHONY: release-workflows-check
 release-workflows-check:

--- a/clients/cmd/docker-driver/Dockerfile
+++ b/clients/cmd/docker-driver/Dockerfile
@@ -1,10 +1,10 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.34.0
+ARG GO_VERSION=1.23
 ARG GOARCH=amd64
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/loki-docker-driver -f clients/cmd/docker-driver/Dockerfile .
 
-FROM $BUILD_IMAGE AS build
+FROM golang:${GO_VERSION}-bookworm as build
 COPY . /src/loki
 WORKDIR /src/loki
 

--- a/clients/cmd/docker-driver/Dockerfile
+++ b/clients/cmd/docker-driver/Dockerfile
@@ -1,10 +1,10 @@
-ARG GO_VERSION=1.23
+ARG BUILD_IMAGE=grafana/loki-build-image:0.34.0
 ARG GOARCH=amd64
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/loki-docker-driver -f clients/cmd/docker-driver/Dockerfile .
 
-FROM golang:${GO_VERSION}-bookworm as build
+FROM $BUILD_IMAGE AS build
 COPY . /src/loki
 WORKDIR /src/loki
 


### PR DESCRIPTION
**What this PR does / why we need it**:

https://github.com/grafana/loki/pull/9247 did not seem to fix the docker driver build. It first [failed](https://github.com/grafana/loki/actions/runs/12260541067/job/34205830742) because of the an incorrect prefix in the job definition, and after that was fixed it [failed again](https://github.com/grafana/loki/actions/runs/12260816211/job/34206788442) because of an undefined env variable.

Depends on https://github.com/grafana/loki-release/pull/165

**Which issue(s) this PR fixes**:
Fixes #5682, #15318

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
