### PR TITLE
docs: sandbox fix for quickstart

### DIFF
--- a/docs/sources/get-started/quick-start.md
+++ b/docs/sources/get-started/quick-start.md
@@ -18,6 +18,9 @@ killercoda:
         replacement: evaluate-loki_${1}_
   title: Loki Quickstart Demo
   description: This sandbox provides an online enviroment for testing the Loki quickstart demo.
+  details:
+    intro:
+      foreground: setup.sh
   backend:
     imageid: ubuntu
 ---
@@ -99,21 +102,9 @@ This quickstart assumes you are running Linux.
 
    With `evaluate-loki` as the current working directory, start the demo environment using `docker compose`:
 
-   <!-- INTERACTIVE ignore START -->
-
    ```bash
    docker compose up -d
    ```
-
-   <!-- INTERACTIVE ignore END -->
-
-   {{< docs/ignore >}}
-
-   ```bash
-   docker-compose up -d
-   ```
-
-   {{< /docs/ignore >}}
 
    At the end of the command, you should see something similar to the following:
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a quick fix to the changes added to the getting started demo:
- Added setup script to upgrade docker-compose to the latest version in sandbox.
- Removed out-of-date command

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
