### PR TITLE
fix: data race in bloombuild tests

### DIFF
--- a/pkg/bloombuild/planner/planner_test.go
+++ b/pkg/bloombuild/planner/planner_test.go
@@ -713,7 +713,10 @@ func (f *fakeBuilder) Send(req *protos.PlannerToBuilder) error {
 }
 
 func (f *fakeBuilder) Recv() (*protos.BuilderToPlanner, error) {
-	if len(f.tasks) == 0 {
+	f.mx.Lock()
+	tasksLen := len(f.tasks)
+	f.mx.Unlock()
+	if tasksLen == 0 {
 		// First call to Recv answers with builderID
 		return &protos.BuilderToPlanner{
 			BuilderID: f.id,


### PR DESCRIPTION
**What this PR does / why we need it**:

The tests failed when executed with `-race` with the following data race warning:
```
WARNING: DATA RACE
Write at 0x00c00624a118 by goroutine 94542:
  github.com/grafana/loki/v3/pkg/bloombuild/planner.(*fakeBuilder).Send()
      pkg/bloombuild/planner/planner_test.go:710 +0x1f5
  github.com/grafana/loki/v3/pkg/bloombuild/planner.(*Planner).forwardTaskToBuilder()
      pkg/bloombuild/planner/planner.go:842 +0xf9
  github.com/grafana/loki/v3/pkg/bloombuild/planner.(*Planner).BuilderLoop()
      pkg/bloombuild/planner/planner.go:777 +0xdcc
  github.com/grafana/loki/v3/pkg/bloombuild/planner.Test_BuilderLoop.func8.2()
      pkg/bloombuild/planner/planner_test.go:199 +0x5a
  github.com/grafana/loki/v3/pkg/bloombuild/planner.Test_BuilderLoop.func8.gowrap1()
      pkg/bloombuild/planner/planner_test.go:201 +0x4f

Previous read at 0x00c00624a118 by goroutine 94673:
  github.com/grafana/loki/v3/pkg/bloombuild/planner.(*fakeBuilder).Recv()
      pkg/bloombuild/planner/planner_test.go:716 +0x5e
  github.com/grafana/loki/v3/pkg/bloombuild/planner.(*Planner).receiveResultFromBuilder()
      pkg/bloombuild/planner/planner.go:889 +0x64
  github.com/grafana/loki/v3/pkg/bloombuild/planner.(*Planner).forwardTaskToBuilder.func1()
      pkg/bloombuild/planner/planner.go:851 +0xa4
...
==================
--- FAIL: Test_BuilderLoop (15.23s)
    --- FAIL: Test_BuilderLoop/timeout (5.05s)
        testing.go:1399: race detected during execution of test
FAIL
FAIL	github.com/grafana/loki/v3/pkg/bloombuild/planner	21.193s
```