### PR TITLE
fix(ci): transform TestChunkSize into a benchmark

### DIFF
--- a/pkg/chunkenc/memchunk_test.go
+++ b/pkg/chunkenc/memchunk_test.go
@@ -710,8 +710,8 @@ func BenchmarkEncodingsAndChunkSize(b *testing.B) {
 					result = append(result, res{
 						name:           name,
 						count:          count,
-						size:           uint64(insertedTotal),
-						compressedSize: uint64(compressedTotal),
+						size:           insertedTotal,
+						compressedSize: compressedTotal,
 						ratio:          averageRatio,
 					})
 					b.ReportMetric(averageRatio, "compression_ratio")

--- a/pkg/chunkenc/memchunk_test.go
+++ b/pkg/chunkenc/memchunk_test.go
@@ -715,6 +715,8 @@ func BenchmarkEncodingsAndChunkSize(b *testing.B) {
 						ratio:          averageRatio,
 					})
 					b.ReportMetric(averageRatio, "compression_ratio")
+					b.ReportMetric(float64(insertedTotal)/float64(count*1024), "avg_size_kb")
+					b.ReportMetric(float64(compressedTotal)/float64(count*1024), "avg_compressed_size_kb")
 				})
 			}
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

I am trying to fix some things in our tests and noticed that `TestChunkSize` was taking a long while and sometimes timing out the `120s` timeout I had. So I took a look and noticed that it was actually a benchmark masquerading as a test :sweat_smile: It wasn't actually testing anything, just collecting stats, and upon further inspection it wasn't doing a very good job of that either. So I fixed it up a bit and made it into a benchmark, to reduce the test execution time in CI.

**Special notes for your reviewer**:

Another potential improvement here would be to make the `fillChunk()` somewhat randomized. It can accept a RNG and fill the chunks with pseudo-random log lines, for more accurate tests. But that function is used in a bunch of other tests, so I decided to not make the change in this PR.

**Results**:

Here are the results of running the new benchmark:
```
BenchmarkEncodingsAndChunkSize/none_block_size_66_kB_format_0-8         	    1560	    722085 ns/op	         0.9853 compression_ratio	 1776121 B/op	      95 allocs/op
BenchmarkEncodingsAndChunkSize/none_block_size_66_kB_format_1-8         	    1686	    693617 ns/op	         0.9852 compression_ratio	 1776572 B/op	      95 allocs/op
BenchmarkEncodingsAndChunkSize/none_block_size_66_kB_format_2-8         	     608	   1801384 ns/op	         0.9852 compression_ratio	 3079095 B/op	   29031 allocs/op
BenchmarkEncodingsAndChunkSize/none_block_size_66_kB_format_3-8         	     325	   3400426 ns/op	         0.9428 compression_ratio	 3206271 B/op	   33507 allocs/op
BenchmarkEncodingsAndChunkSize/none_block_size_262_kB_format_0-8        	    1628	    661679 ns/op	         0.9855 compression_ratio	 1705198 B/op	      40 allocs/op
BenchmarkEncodingsAndChunkSize/none_block_size_262_kB_format_1-8        	    1816	    662358 ns/op	         0.9854 compression_ratio	 1707810 B/op	      40 allocs/op
BenchmarkEncodingsAndChunkSize/none_block_size_262_kB_format_2-8        	     616	   1731998 ns/op	         0.9854 compression_ratio	 2860326 B/op	   28685 allocs/op
BenchmarkEncodingsAndChunkSize/none_block_size_262_kB_format_3-8        	     384	   3415800 ns/op	         0.9430 compression_ratio	 3115300 B/op	   32999 allocs/op
BenchmarkEncodingsAndChunkSize/none_block_size_524_kB_format_0-8        	    1542	    689438 ns/op	         0.9855 compression_ratio	 1896880 B/op	      32 allocs/op
BenchmarkEncodingsAndChunkSize/none_block_size_524_kB_format_1-8        	    1600	    676309 ns/op	         0.9855 compression_ratio	 1900748 B/op	      32 allocs/op
BenchmarkEncodingsAndChunkSize/none_block_size_524_kB_format_2-8        	     658	   1925849 ns/op	         0.9855 compression_ratio	 3004516 B/op	   28676 allocs/op
BenchmarkEncodingsAndChunkSize/none_block_size_524_kB_format_3-8        	     364	   3286528 ns/op	         0.9430 compression_ratio	 3195932 B/op	   32928 allocs/op
BenchmarkEncodingsAndChunkSize/gzip_block_size_66_kB_format_0-8         	      19	  85408247 ns/op	        16.39 compression_ratio	 4701841 B/op	    2778 allocs/op
BenchmarkEncodingsAndChunkSize/gzip_block_size_66_kB_format_1-8         	      19	  67163512 ns/op	        16.38 compression_ratio	 4767361 B/op	    2778 allocs/op
BenchmarkEncodingsAndChunkSize/gzip_block_size_66_kB_format_2-8         	      13	  93098193 ns/op	        16.38 compression_ratio	27160568 B/op	  463156 allocs/op
BenchmarkEncodingsAndChunkSize/gzip_block_size_66_kB_format_3-8         	       9	 112434909 ns/op	        15.69 compression_ratio	29126536 B/op	  531398 allocs/op
BenchmarkEncodingsAndChunkSize/gzip_block_size_262_kB_format_0-8        	      16	  74921449 ns/op	        17.69 compression_ratio	 3129392 B/op	     820 allocs/op
BenchmarkEncodingsAndChunkSize/gzip_block_size_262_kB_format_1-8        	      19	  80269819 ns/op	        17.69 compression_ratio	 3111376 B/op	     821 allocs/op
BenchmarkEncodingsAndChunkSize/gzip_block_size_262_kB_format_2-8        	      15	  77886402 ns/op	        17.69 compression_ratio	22350467 B/op	  432802 allocs/op
BenchmarkEncodingsAndChunkSize/gzip_block_size_262_kB_format_3-8        	      14	 105463112 ns/op	        17.09 compression_ratio	27028572 B/op	  498513 allocs/op
BenchmarkEncodingsAndChunkSize/gzip_block_size_524_kB_format_0-8        	      30	  44527260 ns/op	        17.87 compression_ratio	 2771226 B/op	     388 allocs/op
BenchmarkEncodingsAndChunkSize/gzip_block_size_524_kB_format_1-8        	      26	  67705159 ns/op	        17.87 compression_ratio	 2784971 B/op	     389 allocs/op
BenchmarkEncodingsAndChunkSize/gzip_block_size_524_kB_format_2-8        	      20	  73070333 ns/op	        17.87 compression_ratio	20033633 B/op	  353386 allocs/op
BenchmarkEncodingsAndChunkSize/gzip_block_size_524_kB_format_3-8        	      12	  95781038 ns/op	        17.40 compression_ratio	23155185 B/op	  409407 allocs/op
BenchmarkEncodingsAndChunkSize/lz4-64k_block_size_66_kB_format_0-8      	      72	  17025517 ns/op	        11.52 compression_ratio	 3481267 B/op	    1794 allocs/op
BenchmarkEncodingsAndChunkSize/lz4-64k_block_size_66_kB_format_1-8      	      63	  18237696 ns/op	        11.51 compression_ratio	 3482051 B/op	    1794 allocs/op
BenchmarkEncodingsAndChunkSize/lz4-64k_block_size_66_kB_format_2-8      	      40	  31511539 ns/op	        11.51 compression_ratio	18746164 B/op	  325300 allocs/op
BenchmarkEncodingsAndChunkSize/lz4-64k_block_size_66_kB_format_3-8      	      27	  55356788 ns/op	        11.65 compression_ratio	19894638 B/op	  395340 allocs/op
BenchmarkEncodingsAndChunkSize/lz4-64k_block_size_262_kB_format_0-8     	      85	  12680009 ns/op	        12.08 compression_ratio	 3375423 B/op	     517 allocs/op
BenchmarkEncodingsAndChunkSize/lz4-64k_block_size_262_kB_format_1-8     	      90	  13999464 ns/op	        12.08 compression_ratio	 3350585 B/op	     516 allocs/op
BenchmarkEncodingsAndChunkSize/lz4-64k_block_size_262_kB_format_2-8     	      55	  27873440 ns/op	        12.08 compression_ratio	16493100 B/op	  295372 allocs/op
BenchmarkEncodingsAndChunkSize/lz4-64k_block_size_262_kB_format_3-8     	      33	  49769999 ns/op	        11.74 compression_ratio	19613938 B/op	  343929 allocs/op
BenchmarkEncodingsAndChunkSize/lz4-64k_block_size_524_kB_format_0-8     	      73	  14024439 ns/op	        12.19 compression_ratio	 3231619 B/op	     256 allocs/op
BenchmarkEncodingsAndChunkSize/lz4-64k_block_size_524_kB_format_1-8     	     100	  11991145 ns/op	        12.19 compression_ratio	 3254541 B/op	     256 allocs/op
BenchmarkEncodingsAndChunkSize/lz4-64k_block_size_524_kB_format_2-8     	      43	  23430437 ns/op	        12.19 compression_ratio	14955438 B/op	  245007 allocs/op
BenchmarkEncodingsAndChunkSize/lz4-64k_block_size_524_kB_format_3-8     	      36	  30930913 ns/op	        11.75 compression_ratio	16624529 B/op	  276551 allocs/op
BenchmarkEncodingsAndChunkSize/lz4-256k_block_size_66_kB_format_0-8     	      60	  17746498 ns/op	        12.24 compression_ratio	 1807698 B/op	    1694 allocs/op
BenchmarkEncodingsAndChunkSize/lz4-256k_block_size_66_kB_format_1-8     	      86	  15934301 ns/op	        12.23 compression_ratio	 1819436 B/op	    1694 allocs/op
BenchmarkEncodingsAndChunkSize/lz4-256k_block_size_66_kB_format_2-8     	      37	  32019109 ns/op	        12.23 compression_ratio	18056950 B/op	  345188 allocs/op
BenchmarkEncodingsAndChunkSize/lz4-256k_block_size_66_kB_format_3-8     	      30	  58823318 ns/op	        11.65 compression_ratio	19943295 B/op	  395337 allocs/op
BenchmarkEncodingsAndChunkSize/lz4-256k_block_size_262_kB_format_0-8    	      87	  16215422 ns/op	        12.80 compression_ratio	 3691669 B/op	     464 allocs/op
BenchmarkEncodingsAndChunkSize/lz4-256k_block_size_262_kB_format_1-8    	      92	  16121792 ns/op	        12.80 compression_ratio	 3722628 B/op	     465 allocs/op
BenchmarkEncodingsAndChunkSize/lz4-256k_block_size_262_kB_format_2-8    	      50	  31852376 ns/op	        12.80 compression_ratio	17800791 B/op	  314887 allocs/op
BenchmarkEncodingsAndChunkSize/lz4-256k_block_size_262_kB_format_3-8    	      28	  42408394 ns/op	        12.58 compression_ratio	18934493 B/op	  369560 allocs/op
BenchmarkEncodingsAndChunkSize/lz4-256k_block_size_524_kB_format_0-8    	     100	  12843100 ns/op	        12.94 compression_ratio	 2486120 B/op	     215 allocs/op
BenchmarkEncodingsAndChunkSize/lz4-256k_block_size_524_kB_format_1-8    	     100	  10397314 ns/op	        12.94 compression_ratio	 2471842 B/op	     215 allocs/op
BenchmarkEncodingsAndChunkSize/lz4-256k_block_size_524_kB_format_2-8    	      50	  26497299 ns/op	        12.94 compression_ratio	14766222 B/op	  255100 allocs/op
BenchmarkEncodingsAndChunkSize/lz4-256k_block_size_524_kB_format_3-8    	      28	  37304967 ns/op	        12.55 compression_ratio	16470928 B/op	  297428 allocs/op
BenchmarkEncodingsAndChunkSize/lz4-1M_block_size_66_kB_format_0-8       	      45	  22354764 ns/op	        12.24 compression_ratio	 1832505 B/op	    1694 allocs/op
BenchmarkEncodingsAndChunkSize/lz4-1M_block_size_66_kB_format_1-8       	     100	  16904729 ns/op	        12.23 compression_ratio	 1840148 B/op	    1694 allocs/op
BenchmarkEncodingsAndChunkSize/lz4-1M_block_size_66_kB_format_2-8       	      46	  36027266 ns/op	        12.23 compression_ratio	18285308 B/op	  345186 allocs/op
BenchmarkEncodingsAndChunkSize/lz4-1M_block_size_66_kB_format_3-8       	      25	  43927903 ns/op	        11.65 compression_ratio	20152582 B/op	  395335 allocs/op
BenchmarkEncodingsAndChunkSize/lz4-1M_block_size_262_kB_format_0-8      	      94	  17424720 ns/op	        13.03 compression_ratio	 1541289 B/op	     416 allocs/op
BenchmarkEncodingsAndChunkSize/lz4-1M_block_size_262_kB_format_1-8      	      78	  15965871 ns/op	        13.03 compression_ratio	 1527165 B/op	     416 allocs/op
BenchmarkEncodingsAndChunkSize/lz4-1M_block_size_262_kB_format_2-8      	      50	  27618418 ns/op	        13.03 compression_ratio	15952471 B/op	  319811 allocs/op
BenchmarkEncodingsAndChunkSize/lz4-1M_block_size_262_kB_format_3-8      	      25	  45316312 ns/op	        12.58 compression_ratio	19225772 B/op	  369559 allocs/op
BenchmarkEncodingsAndChunkSize/lz4-1M_block_size_524_kB_format_0-8      	     100	  14810537 ns/op	        13.17 compression_ratio	 1492399 B/op	     188 allocs/op
BenchmarkEncodingsAndChunkSize/lz4-1M_block_size_524_kB_format_1-8      	     100	  12488575 ns/op	        13.17 compression_ratio	 1475324 B/op	     188 allocs/op
BenchmarkEncodingsAndChunkSize/lz4-1M_block_size_524_kB_format_2-8      	      52	  26210494 ns/op	        13.17 compression_ratio	14295800 B/op	  264570 allocs/op
BenchmarkEncodingsAndChunkSize/lz4-1M_block_size_524_kB_format_3-8      	      30	  36439058 ns/op	        12.77 compression_ratio	16319595 B/op	  306622 allocs/op
BenchmarkEncodingsAndChunkSize/lz4_block_size_66_kB_format_0-8          	      94	  17923237 ns/op	        12.24 compression_ratio	 1942099 B/op	    1694 allocs/op
BenchmarkEncodingsAndChunkSize/lz4_block_size_66_kB_format_1-8          	      75	  16622860 ns/op	        12.23 compression_ratio	 1917781 B/op	    1694 allocs/op
BenchmarkEncodingsAndChunkSize/lz4_block_size_66_kB_format_2-8          	      49	  30010859 ns/op	        12.23 compression_ratio	18795011 B/op	  345184 allocs/op
BenchmarkEncodingsAndChunkSize/lz4_block_size_66_kB_format_3-8          	      24	  51955368 ns/op	        11.65 compression_ratio	20790420 B/op	  395332 allocs/op
BenchmarkEncodingsAndChunkSize/lz4_block_size_262_kB_format_0-8         	      80	  17700154 ns/op	        13.03 compression_ratio	 1596570 B/op	     416 allocs/op
BenchmarkEncodingsAndChunkSize/lz4_block_size_262_kB_format_1-8         	      99	  13272346 ns/op	        13.03 compression_ratio	 1530056 B/op	     415 allocs/op
BenchmarkEncodingsAndChunkSize/lz4_block_size_262_kB_format_2-8         	      37	  36545126 ns/op	        13.03 compression_ratio	16412051 B/op	  319809 allocs/op
BenchmarkEncodingsAndChunkSize/lz4_block_size_262_kB_format_3-8         	      22	  50419362 ns/op	        12.58 compression_ratio	20551347 B/op	  369560 allocs/op
BenchmarkEncodingsAndChunkSize/lz4_block_size_524_kB_format_0-8         	      82	  15051382 ns/op	        13.17 compression_ratio	 1530180 B/op	     189 allocs/op
BenchmarkEncodingsAndChunkSize/lz4_block_size_524_kB_format_1-8         	     109	  14837260 ns/op	        13.17 compression_ratio	 1493970 B/op	     188 allocs/op
BenchmarkEncodingsAndChunkSize/lz4_block_size_524_kB_format_2-8         	      46	  23888608 ns/op	        13.17 compression_ratio	14872674 B/op	  264569 allocs/op
BenchmarkEncodingsAndChunkSize/lz4_block_size_524_kB_format_3-8         	      30	  43174891 ns/op	        12.77 compression_ratio	17373398 B/op	  306624 allocs/op
BenchmarkEncodingsAndChunkSize/snappy_block_size_66_kB_format_0-8       	     159	   8422027 ns/op	         8.872 compression_ratio	 3710807 B/op	     590 allocs/op
BenchmarkEncodingsAndChunkSize/snappy_block_size_66_kB_format_1-8       	     127	   9417588 ns/op	         8.868 compression_ratio	 3718227 B/op	     590 allocs/op
BenchmarkEncodingsAndChunkSize/snappy_block_size_66_kB_format_2-8       	      64	  19151304 ns/op	         8.868 compression_ratio	15415480 B/op	  249301 allocs/op
BenchmarkEncodingsAndChunkSize/snappy_block_size_66_kB_format_3-8       	      38	  31747455 ns/op	         8.884 compression_ratio	15309437 B/op	  298992 allocs/op
BenchmarkEncodingsAndChunkSize/snappy_block_size_262_kB_format_0-8      	     159	   7484807 ns/op	         9.204 compression_ratio	 3926545 B/op	     230 allocs/op
BenchmarkEncodingsAndChunkSize/snappy_block_size_262_kB_format_1-8      	     159	   7801441 ns/op	         9.203 compression_ratio	 3933318 B/op	     230 allocs/op
BenchmarkEncodingsAndChunkSize/snappy_block_size_262_kB_format_2-8      	      73	  17469657 ns/op	         9.203 compression_ratio	13967738 B/op	  226051 allocs/op
BenchmarkEncodingsAndChunkSize/snappy_block_size_262_kB_format_3-8      	      46	  25358920 ns/op	         8.886 compression_ratio	16008025 B/op	  262076 allocs/op
BenchmarkEncodingsAndChunkSize/snappy_block_size_524_kB_format_0-8      	     212	   5559262 ns/op	         9.256 compression_ratio	 3434497 B/op	     129 allocs/op
BenchmarkEncodingsAndChunkSize/snappy_block_size_524_kB_format_1-8      	     195	   5840640 ns/op	         9.255 compression_ratio	 3407653 B/op	     129 allocs/op
BenchmarkEncodingsAndChunkSize/snappy_block_size_524_kB_format_2-8      	      87	  13813979 ns/op	         9.255 compression_ratio	12259381 B/op	  186204 allocs/op
BenchmarkEncodingsAndChunkSize/snappy_block_size_524_kB_format_3-8      	      52	  23436612 ns/op	         8.920 compression_ratio	13495201 B/op	  215061 allocs/op
BenchmarkEncodingsAndChunkSize/flate_block_size_66_kB_format_0-8        	      20	  55913764 ns/op	        16.50 compression_ratio	 4688819 B/op	    2418 allocs/op
BenchmarkEncodingsAndChunkSize/flate_block_size_66_kB_format_1-8        	      19	  57025733 ns/op	        16.49 compression_ratio	 4692982 B/op	    2419 allocs/op
BenchmarkEncodingsAndChunkSize/flate_block_size_66_kB_format_2-8        	      16	  84590085 ns/op	        16.49 compression_ratio	26708764 B/op	  464922 allocs/op
BenchmarkEncodingsAndChunkSize/flate_block_size_66_kB_format_3-8        	       9	 114076485 ns/op	        15.74 compression_ratio	29201413 B/op	  535177 allocs/op
BenchmarkEncodingsAndChunkSize/flate_block_size_262_kB_format_0-8       	      22	  54333581 ns/op	        17.72 compression_ratio	 3007765 B/op	     731 allocs/op
BenchmarkEncodingsAndChunkSize/flate_block_size_262_kB_format_1-8       	      21	  57243339 ns/op	        17.71 compression_ratio	 3007798 B/op	     731 allocs/op
BenchmarkEncodingsAndChunkSize/flate_block_size_262_kB_format_2-8       	      18	  74504391 ns/op	        17.71 compression_ratio	22697010 B/op	  432745 allocs/op
BenchmarkEncodingsAndChunkSize/flate_block_size_262_kB_format_3-8       	      13	 122786253 ns/op	        17.12 compression_ratio	26940824 B/op	  498443 allocs/op
BenchmarkEncodingsAndChunkSize/flate_block_size_524_kB_format_0-8       	      27	  44444380 ns/op	        17.88 compression_ratio	 2778745 B/op	     352 allocs/op
BenchmarkEncodingsAndChunkSize/flate_block_size_524_kB_format_1-8       	      28	  41242731 ns/op	        17.88 compression_ratio	 2775361 B/op	     353 allocs/op
BenchmarkEncodingsAndChunkSize/flate_block_size_524_kB_format_2-8       	      16	  63442105 ns/op	        17.88 compression_ratio	20197440 B/op	  353362 allocs/op
BenchmarkEncodingsAndChunkSize/flate_block_size_524_kB_format_3-8       	      14	  94981170 ns/op	        17.41 compression_ratio	23436836 B/op	  409381 allocs/op
BenchmarkEncodingsAndChunkSize/zstd_block_size_66_kB_format_0-8         	      30	  37858202 ns/op	        19.03 compression_ratio	 1826113 B/op	     889 allocs/op
BenchmarkEncodingsAndChunkSize/zstd_block_size_66_kB_format_1-8         	      28	  35876284 ns/op	        19.01 compression_ratio	 1832099 B/op	     889 allocs/op
BenchmarkEncodingsAndChunkSize/zstd_block_size_66_kB_format_2-8         	      20	  61202262 ns/op	        19.01 compression_ratio	27785613 B/op	  534332 allocs/op
BenchmarkEncodingsAndChunkSize/zstd_block_size_66_kB_format_3-8         	      14	  95822827 ns/op	        18.34 compression_ratio	31440540 B/op	  620255 allocs/op
BenchmarkEncodingsAndChunkSize/zstd_block_size_262_kB_format_0-8        	      26	  43336702 ns/op	        20.33 compression_ratio	 2701556 B/op	    1532 allocs/op
BenchmarkEncodingsAndChunkSize/zstd_block_size_262_kB_format_1-8        	      24	  49281934 ns/op	        20.32 compression_ratio	 2701501 B/op	    1532 allocs/op
BenchmarkEncodingsAndChunkSize/zstd_block_size_262_kB_format_2-8        	      13	  80923628 ns/op	        20.32 compression_ratio	25825270 B/op	  492853 allocs/op
BenchmarkEncodingsAndChunkSize/zstd_block_size_262_kB_format_3-8        	       7	 148586434 ns/op	        19.99 compression_ratio	37920912 B/op	  580554 allocs/op
BenchmarkEncodingsAndChunkSize/zstd_block_size_524_kB_format_0-8        	      27	  49385480 ns/op	        32.30 compression_ratio	 3515753 B/op	    1406 allocs/op
BenchmarkEncodingsAndChunkSize/zstd_block_size_524_kB_format_1-8        	      24	  46502919 ns/op	        32.29 compression_ratio	 4479946 B/op	    1410 allocs/op
BenchmarkEncodingsAndChunkSize/zstd_block_size_524_kB_format_2-8        	      15	  94460574 ns/op	        32.29 compression_ratio	36804882 B/op	  628306 allocs/op
BenchmarkEncodingsAndChunkSize/zstd_block_size_524_kB_format_3-8        	       8	 139126279 ns/op	        29.16 compression_ratio	43129707 B/op	  676589 allocs/op
name	count	uncompressed	compressed	ratio
zstd_block_size_524 kB_format_0	(count 27)
34 MB	1.0 MB	32.297404
zstd_block_size_524 kB_format_0	(count 1)
34 MB	1.0 MB	32.297404
zstd_block_size_524 kB_format_1	(count 24)
34 MB	1.0 MB	32.291436
zstd_block_size_524 kB_format_2	(count 15)
34 MB	1.0 MB	32.291436
zstd_block_size_524 kB_format_2	(count 1)
34 MB	1.0 MB	32.291436
zstd_block_size_524 kB_format_1	(count 18)
34 MB	1.0 MB	32.291436
zstd_block_size_524 kB_format_1	(count 1)
34 MB	1.0 MB	32.291436
zstd_block_size_524 kB_format_3	(count 1)
30 MB	1.0 MB	29.162544
zstd_block_size_524 kB_format_3	(count 7)
30 MB	1.0 MB	29.162544
zstd_block_size_524 kB_format_3	(count 8)
30 MB	1.0 MB	29.162544
zstd_block_size_262 kB_format_0	(count 26)
26 MB	1.3 MB	20.325232
zstd_block_size_262 kB_format_0	(count 1)
26 MB	1.3 MB	20.325232
zstd_block_size_262 kB_format_0	(count 16)
26 MB	1.3 MB	20.325232
zstd_block_size_262 kB_format_1	(count 20)
26 MB	1.3 MB	20.320509
zstd_block_size_262 kB_format_2	(count 1)
26 MB	1.3 MB	20.320509
zstd_block_size_262 kB_format_1	(count 24)
26 MB	1.3 MB	20.320509
zstd_block_size_262 kB_format_1	(count 1)
26 MB	1.3 MB	20.320509
zstd_block_size_262 kB_format_2	(count 13)
26 MB	1.3 MB	20.320509
zstd_block_size_262 kB_format_3	(count 1)
26 MB	1.3 MB	19.994865
zstd_block_size_262 kB_format_3	(count 7)
26 MB	1.3 MB	19.994865
zstd_block_size_66 kB_format_0	(count 1)
28 MB	1.5 MB	19.027133
zstd_block_size_66 kB_format_0	(count 20)
28 MB	1.5 MB	19.027133
zstd_block_size_66 kB_format_0	(count 30)
28 MB	1.5 MB	19.027133
zstd_block_size_66 kB_format_1	(count 28)
28 MB	1.5 MB	19.010603
zstd_block_size_66 kB_format_2	(count 20)
28 MB	1.5 MB	19.010603
zstd_block_size_66 kB_format_2	(count 1)
28 MB	1.5 MB	19.010603
zstd_block_size_66 kB_format_1	(count 1)
28 MB	1.5 MB	19.010603
zstd_block_size_66 kB_format_3	(count 1)
27 MB	1.5 MB	18.338979
zstd_block_size_66 kB_format_3	(count 9)
27 MB	1.5 MB	18.338979
zstd_block_size_66 kB_format_3	(count 14)
27 MB	1.5 MB	18.338979
flate_block_size_524 kB_format_0	(count 16)
19 MB	1.1 MB	17.879185
flate_block_size_524 kB_format_0	(count 27)
19 MB	1.1 MB	17.879185
flate_block_size_524 kB_format_0	(count 1)
19 MB	1.1 MB	17.879185
flate_block_size_524 kB_format_2	(count 1)
19 MB	1.1 MB	17.877355
flate_block_size_524 kB_format_2	(count 16)
19 MB	1.1 MB	17.877355
flate_block_size_524 kB_format_2	(count 12)
19 MB	1.1 MB	17.877355
flate_block_size_524 kB_format_1	(count 1)
19 MB	1.1 MB	17.877355
flate_block_size_524 kB_format_1	(count 28)
19 MB	1.1 MB	17.877355
flate_block_size_524 kB_format_1	(count 16)
19 MB	1.1 MB	17.877355
gzip_block_size_524 kB_format_0	(count 1)
19 MB	1.1 MB	17.867884
gzip_block_size_524 kB_format_0	(count 30)
19 MB	1.1 MB	17.867884
gzip_block_size_524 kB_format_0	(count 15)
19 MB	1.1 MB	17.867884
gzip_block_size_524 kB_format_2	(count 20)
19 MB	1.1 MB	17.866057
gzip_block_size_524 kB_format_2	(count 12)
19 MB	1.1 MB	17.866057
gzip_block_size_524 kB_format_2	(count 1)
19 MB	1.1 MB	17.866057
gzip_block_size_524 kB_format_1	(count 26)
19 MB	1.1 MB	17.866057
gzip_block_size_524 kB_format_1	(count 1)
19 MB	1.1 MB	17.866057
flate_block_size_262 kB_format_0	(count 22)
23 MB	1.3 MB	17.717022
flate_block_size_262 kB_format_0	(count 1)
23 MB	1.3 MB	17.717022
flate_block_size_262 kB_format_1	(count 21)
23 MB	1.3 MB	17.713432
flate_block_size_262 kB_format_2	(count 18)
23 MB	1.3 MB	17.713432
flate_block_size_262 kB_format_2	(count 10)
23 MB	1.3 MB	17.713432
flate_block_size_262 kB_format_2	(count 1)
23 MB	1.3 MB	17.713432
flate_block_size_262 kB_format_1	(count 1)
23 MB	1.3 MB	17.713432
gzip_block_size_262 kB_format_0	(count 16)
23 MB	1.3 MB	17.694899
gzip_block_size_262 kB_format_0	(count 1)
23 MB	1.3 MB	17.694899
gzip_block_size_262 kB_format_1	(count 1)
23 MB	1.3 MB	17.691317
gzip_block_size_262 kB_format_1	(count 19)
23 MB	1.3 MB	17.691317
gzip_block_size_262 kB_format_2	(count 15)
23 MB	1.3 MB	17.691317
gzip_block_size_262 kB_format_2	(count 1)
23 MB	1.3 MB	17.691317
flate_block_size_524 kB_format_3	(count 14)
18 MB	1.0 MB	17.407570
flate_block_size_524 kB_format_3	(count 1)
18 MB	1.0 MB	17.407570
flate_block_size_524 kB_format_3	(count 9)
18 MB	1.0 MB	17.407570
gzip_block_size_524 kB_format_3	(count 1)
18 MB	1.0 MB	17.395084
gzip_block_size_524 kB_format_3	(count 9)
18 MB	1.0 MB	17.395084
gzip_block_size_524 kB_format_3	(count 12)
18 MB	1.0 MB	17.395084
flate_block_size_262 kB_format_3	(count 13)
22 MB	1.3 MB	17.118775
flate_block_size_262 kB_format_3	(count 1)
22 MB	1.3 MB	17.118775
gzip_block_size_262 kB_format_3	(count 1)
22 MB	1.3 MB	17.094868
gzip_block_size_262 kB_format_3	(count 14)
22 MB	1.3 MB	17.094868
flate_block_size_66 kB_format_0	(count 20)
24 MB	1.5 MB	16.499708
flate_block_size_66 kB_format_0	(count 1)
24 MB	1.5 MB	16.499708
flate_block_size_66 kB_format_1	(count 1)
24 MB	1.5 MB	16.487277
flate_block_size_66 kB_format_2	(count 1)
24 MB	1.5 MB	16.487277
flate_block_size_66 kB_format_2	(count 16)
24 MB	1.5 MB	16.487277
flate_block_size_66 kB_format_1	(count 19)
24 MB	1.5 MB	16.487277
gzip_block_size_66 kB_format_0	(count 19)
24 MB	1.5 MB	16.391820
gzip_block_size_66 kB_format_0	(count 1)
24 MB	1.5 MB	16.391820
gzip_block_size_66 kB_format_0	(count 16)
24 MB	1.5 MB	16.391820
gzip_block_size_66 kB_format_2	(count 13)
24 MB	1.5 MB	16.379549
gzip_block_size_66 kB_format_1	(count 1)
24 MB	1.5 MB	16.379549
gzip_block_size_66 kB_format_1	(count 19)
24 MB	1.5 MB	16.379549
gzip_block_size_66 kB_format_2	(count 1)
24 MB	1.5 MB	16.379549
flate_block_size_66 kB_format_3	(count 1)
23 MB	1.5 MB	15.741083
flate_block_size_66 kB_format_3	(count 7)
23 MB	1.5 MB	15.741083
flate_block_size_66 kB_format_3	(count 9)
23 MB	1.5 MB	15.741083
gzip_block_size_66 kB_format_3	(count 9)
23 MB	1.5 MB	15.689526
gzip_block_size_66 kB_format_3	(count 1)
23 MB	1.5 MB	15.689526
lz4_block_size_524 kB_format_0	(count 1)
14 MB	1.1 MB	13.174347
lz4_block_size_524 kB_format_0	(count 82)
14 MB	1.1 MB	13.174347
lz4-1M_block_size_524 kB_format_0	(count 100)
14 MB	1.1 MB	13.174347
lz4-1M_block_size_524 kB_format_0	(count 1)
14 MB	1.1 MB	13.174347
lz4_block_size_524 kB_format_0	(count 50)
14 MB	1.1 MB	13.174347
lz4_block_size_524 kB_format_0	(count 66)
14 MB	1.1 MB	13.174347
lz4_block_size_524 kB_format_2	(count 30)
14 MB	1.1 MB	13.173353
lz4_block_size_524 kB_format_1	(count 1)
14 MB	1.1 MB	13.173353
lz4_block_size_524 kB_format_1	(count 62)
14 MB	1.1 MB	13.173353
lz4_block_size_524 kB_format_2	(count 1)
14 MB	1.1 MB	13.173353
lz4_block_size_524 kB_format_1	(count 75)
14 MB	1.1 MB	13.173353
lz4_block_size_524 kB_format_1	(count 109)
14 MB	1.1 MB	13.173353
lz4-1M_block_size_524 kB_format_1	(count 1)
14 MB	1.1 MB	13.173353
lz4-1M_block_size_524 kB_format_1	(count 100)
14 MB	1.1 MB	13.173353
lz4-1M_block_size_524 kB_format_2	(count 1)
14 MB	1.1 MB	13.173353
lz4-1M_block_size_524 kB_format_2	(count 33)
14 MB	1.1 MB	13.173353
lz4-1M_block_size_524 kB_format_2	(count 43)
14 MB	1.1 MB	13.173353
lz4_block_size_524 kB_format_2	(count 46)
14 MB	1.1 MB	13.173353
lz4-1M_block_size_524 kB_format_2	(count 52)
14 MB	1.1 MB	13.173353
lz4_block_size_262 kB_format_0	(count 45)
17 MB	1.3 MB	13.031562
lz4_block_size_262 kB_format_0	(count 1)
17 MB	1.3 MB	13.031562
lz4-1M_block_size_262 kB_format_0	(count 94)
17 MB	1.3 MB	13.031562
lz4-1M_block_size_262 kB_format_0	(count 40)
17 MB	1.3 MB	13.031562
lz4-1M_block_size_262 kB_format_0	(count 1)
17 MB	1.3 MB	13.031562
lz4_block_size_262 kB_format_0	(count 80)
17 MB	1.3 MB	13.031562
lz4-1M_block_size_262 kB_format_1	(count 78)
17 MB	1.3 MB	13.029619
lz4-1M_block_size_262 kB_format_2	(count 26)
17 MB	1.3 MB	13.029619
lz4-1M_block_size_262 kB_format_1	(count 45)
17 MB	1.3 MB	13.029619
lz4-1M_block_size_262 kB_format_1	(count 1)
17 MB	1.3 MB	13.029619
lz4-1M_block_size_262 kB_format_2	(count 1)
17 MB	1.3 MB	13.029619
lz4-1M_block_size_262 kB_format_2	(count 32)
17 MB	1.3 MB	13.029619
lz4-1M_block_size_262 kB_format_2	(count 50)
17 MB	1.3 MB	13.029619
lz4_block_size_262 kB_format_2	(count 37)
17 MB	1.3 MB	13.029619
lz4_block_size_262 kB_format_2	(count 26)
17 MB	1.3 MB	13.029619
lz4_block_size_262 kB_format_2	(count 1)
17 MB	1.3 MB	13.029619
lz4_block_size_262 kB_format_1	(count 99)
17 MB	1.3 MB	13.029619
lz4_block_size_262 kB_format_1	(count 1)
17 MB	1.3 MB	13.029619
lz4-256k_block_size_524 kB_format_0	(count 100)
14 MB	1.1 MB	12.940461
lz4-256k_block_size_524 kB_format_0	(count 1)
14 MB	1.1 MB	12.940461
lz4-256k_block_size_524 kB_format_1	(count 100)
14 MB	1.1 MB	12.939504
lz4-256k_block_size_524 kB_format_2	(count 50)
14 MB	1.1 MB	12.939504
lz4-256k_block_size_524 kB_format_1	(count 1)
14 MB	1.1 MB	12.939504
lz4-256k_block_size_524 kB_format_2	(count 1)
14 MB	1.1 MB	12.939504
lz4-256k_block_size_524 kB_format_2	(count 37)
14 MB	1.1 MB	12.939504
lz4-256k_block_size_262 kB_format_0	(count 1)
17 MB	1.3 MB	12.800857
lz4-256k_block_size_262 kB_format_0	(count 87)
17 MB	1.3 MB	12.800857
lz4-256k_block_size_262 kB_format_0	(count 46)
17 MB	1.3 MB	12.800857
lz4-256k_block_size_262 kB_format_2	(count 50)
17 MB	1.3 MB	12.798982
lz4-256k_block_size_262 kB_format_1	(count 1)
17 MB	1.3 MB	12.798982
lz4-256k_block_size_262 kB_format_1	(count 92)
17 MB	1.3 MB	12.798982
lz4-256k_block_size_262 kB_format_2	(count 1)
17 MB	1.3 MB	12.798982
lz4-1M_block_size_524 kB_format_3	(count 19)
14 MB	1.1 MB	12.765288
lz4_block_size_524 kB_format_3	(count 20)
14 MB	1.1 MB	12.765288
lz4_block_size_524 kB_format_3	(count 30)
14 MB	1.1 MB	12.765288
lz4_block_size_524 kB_format_3	(count 1)
14 MB	1.1 MB	12.765288
lz4-1M_block_size_524 kB_format_3	(count 30)
14 MB	1.1 MB	12.765288
lz4-1M_block_size_524 kB_format_3	(count 24)
14 MB	1.1 MB	12.765288
lz4-1M_block_size_524 kB_format_3	(count 1)
14 MB	1.1 MB	12.765288
lz4-1M_block_size_262 kB_format_3	(count 15)
16 MB	1.3 MB	12.584384
lz4_block_size_262 kB_format_3	(count 22)
16 MB	1.3 MB	12.584384
lz4_block_size_262 kB_format_3	(count 1)
16 MB	1.3 MB	12.584384
lz4-1M_block_size_262 kB_format_3	(count 25)
16 MB	1.3 MB	12.584384
lz4-1M_block_size_262 kB_format_3	(count 1)
16 MB	1.3 MB	12.584384
lz4-256k_block_size_262 kB_format_3	(count 28)
16 MB	1.3 MB	12.584384
lz4-256k_block_size_262 kB_format_3	(count 1)
16 MB	1.3 MB	12.584384
lz4-256k_block_size_524 kB_format_3	(count 28)
13 MB	1.1 MB	12.552114
lz4-256k_block_size_524 kB_format_3	(count 1)
13 MB	1.1 MB	12.552114
lz4-256k_block_size_66 kB_format_0	(count 60)
18 MB	1.5 MB	12.241545
lz4-1M_block_size_66 kB_format_0	(count 45)
18 MB	1.5 MB	12.241545
lz4-1M_block_size_66 kB_format_0	(count 1)
18 MB	1.5 MB	12.241545
lz4-256k_block_size_66 kB_format_0	(count 1)
18 MB	1.5 MB	12.241545
lz4_block_size_66 kB_format_0	(count 1)
18 MB	1.5 MB	12.241545
lz4_block_size_66 kB_format_0	(count 43)
18 MB	1.5 MB	12.241545
lz4_block_size_66 kB_format_0	(count 94)
18 MB	1.5 MB	12.241545
lz4-256k_block_size_66 kB_format_0	(count 46)
18 MB	1.5 MB	12.241545
lz4-256k_block_size_66 kB_format_1	(count 86)
18 MB	1.5 MB	12.234700
lz4-1M_block_size_66 kB_format_1	(count 100)
18 MB	1.5 MB	12.234700
lz4_block_size_66 kB_format_2	(count 49)
18 MB	1.5 MB	12.234700
lz4-1M_block_size_66 kB_format_2	(count 46)
18 MB	1.5 MB	12.234700
lz4-1M_block_size_66 kB_format_2	(count 1)
18 MB	1.5 MB	12.234700
lz4_block_size_66 kB_format_1	(count 1)
18 MB	1.5 MB	12.234700
lz4_block_size_66 kB_format_2	(count 1)
18 MB	1.5 MB	12.234700
lz4-1M_block_size_66 kB_format_1	(count 1)
18 MB	1.5 MB	12.234700
lz4-256k_block_size_66 kB_format_2	(count 37)
18 MB	1.5 MB	12.234700
lz4-256k_block_size_66 kB_format_2	(count 27)
18 MB	1.5 MB	12.234700
lz4-256k_block_size_66 kB_format_2	(count 1)
18 MB	1.5 MB	12.234700
lz4_block_size_66 kB_format_1	(count 75)
18 MB	1.5 MB	12.234700
lz4-256k_block_size_66 kB_format_1	(count 1)
18 MB	1.5 MB	12.234700
lz4-64k_block_size_524 kB_format_0	(count 1)
13 MB	1.1 MB	12.188250
lz4-64k_block_size_524 kB_format_0	(count 73)
13 MB	1.1 MB	12.188250
lz4-64k_block_size_524 kB_format_2	(count 43)
13 MB	1.1 MB	12.187399
lz4-64k_block_size_524 kB_format_1	(count 1)
13 MB	1.1 MB	12.187399
lz4-64k_block_size_524 kB_format_1	(count 100)
13 MB	1.1 MB	12.187399
lz4-64k_block_size_524 kB_format_2	(count 1)
13 MB	1.1 MB	12.187399
lz4-64k_block_size_262 kB_format_0	(count 85)
16 MB	1.3 MB	12.078533
lz4-64k_block_size_262 kB_format_0	(count 1)
16 MB	1.3 MB	12.078533
lz4-64k_block_size_262 kB_format_2	(count 55)
16 MB	1.3 MB	12.076864
lz4-64k_block_size_262 kB_format_1	(count 1)
16 MB	1.3 MB	12.076864
lz4-64k_block_size_262 kB_format_1	(count 50)
16 MB	1.3 MB	12.076864
lz4-64k_block_size_262 kB_format_1	(count 90)
16 MB	1.3 MB	12.076864
lz4-64k_block_size_262 kB_format_2	(count 1)
16 MB	1.3 MB	12.076864
lz4-64k_block_size_262 kB_format_1	(count 72)
16 MB	1.3 MB	12.076864
lz4-64k_block_size_524 kB_format_3	(count 21)
12 MB	1.0 MB	11.745688
lz4-64k_block_size_524 kB_format_3	(count 1)
12 MB	1.0 MB	11.745688
lz4-64k_block_size_524 kB_format_3	(count 30)
12 MB	1.0 MB	11.745688
lz4-64k_block_size_524 kB_format_3	(count 36)
12 MB	1.0 MB	11.745688
lz4-64k_block_size_262 kB_format_3	(count 33)
15 MB	1.3 MB	11.735705
lz4-64k_block_size_262 kB_format_3	(count 1)
15 MB	1.3 MB	11.735705
lz4-256k_block_size_66 kB_format_3	(count 30)
17 MB	1.5 MB	11.653477
lz4-1M_block_size_66 kB_format_3	(count 1)
17 MB	1.5 MB	11.653477
lz4-1M_block_size_66 kB_format_3	(count 25)
17 MB	1.5 MB	11.653477
lz4-256k_block_size_66 kB_format_3	(count 1)
17 MB	1.5 MB	11.653477
lz4-256k_block_size_66 kB_format_3	(count 15)
17 MB	1.5 MB	11.653477
lz4_block_size_66 kB_format_3	(count 24)
17 MB	1.5 MB	11.653477
lz4_block_size_66 kB_format_3	(count 19)
17 MB	1.5 MB	11.653477
lz4_block_size_66 kB_format_3	(count 1)
17 MB	1.5 MB	11.653477
lz4-64k_block_size_66 kB_format_3	(count 27)
17 MB	1.5 MB	11.653477
lz4-64k_block_size_66 kB_format_3	(count 1)
17 MB	1.5 MB	11.653477
lz4-64k_block_size_66 kB_format_0	(count 72)
17 MB	1.5 MB	11.517938
lz4-64k_block_size_66 kB_format_0	(count 48)
17 MB	1.5 MB	11.517938
lz4-64k_block_size_66 kB_format_0	(count 1)
17 MB	1.5 MB	11.517938
lz4-64k_block_size_66 kB_format_2	(count 1)
17 MB	1.5 MB	11.511878
lz4-64k_block_size_66 kB_format_2	(count 40)
17 MB	1.5 MB	11.511878
lz4-64k_block_size_66 kB_format_1	(count 1)
17 MB	1.5 MB	11.511878
lz4-64k_block_size_66 kB_format_1	(count 48)
17 MB	1.5 MB	11.511878
lz4-64k_block_size_66 kB_format_1	(count 63)
17 MB	1.5 MB	11.511878
lz4-64k_block_size_66 kB_format_2	(count 25)
17 MB	1.5 MB	11.511878
snappy_block_size_524 kB_format_0	(count 100)
10 MB	1.1 MB	9.255906
snappy_block_size_524 kB_format_0	(count 1)
10 MB	1.1 MB	9.255906
snappy_block_size_524 kB_format_0	(count 212)
10 MB	1.1 MB	9.255906
snappy_block_size_524 kB_format_1	(count 1)
10 MB	1.1 MB	9.255416
snappy_block_size_524 kB_format_1	(count 100)
10 MB	1.1 MB	9.255416
snappy_block_size_524 kB_format_1	(count 195)
10 MB	1.1 MB	9.255416
snappy_block_size_524 kB_format_2	(count 1)
10 MB	1.1 MB	9.255416
snappy_block_size_524 kB_format_2	(count 56)
10 MB	1.1 MB	9.255416
snappy_block_size_524 kB_format_2	(count 87)
10 MB	1.1 MB	9.255416
snappy_block_size_262 kB_format_0	(count 1)
12 MB	1.3 MB	9.204198
snappy_block_size_262 kB_format_0	(count 159)
12 MB	1.3 MB	9.204198
snappy_block_size_262 kB_format_0	(count 100)
12 MB	1.3 MB	9.204198
snappy_block_size_262 kB_format_1	(count 1)
12 MB	1.3 MB	9.203228
snappy_block_size_262 kB_format_1	(count 100)
12 MB	1.3 MB	9.203228
snappy_block_size_262 kB_format_1	(count 159)
12 MB	1.3 MB	9.203228
snappy_block_size_262 kB_format_2	(count 1)
12 MB	1.3 MB	9.203228
snappy_block_size_262 kB_format_2	(count 49)
12 MB	1.3 MB	9.203228
snappy_block_size_262 kB_format_2	(count 73)
12 MB	1.3 MB	9.203228
snappy_block_size_524 kB_format_3	(count 26)
9.6 MB	1.1 MB	8.920287
snappy_block_size_524 kB_format_3	(count 1)
9.6 MB	1.1 MB	8.920287
snappy_block_size_524 kB_format_3	(count 52)
9.6 MB	1.1 MB	8.920287
snappy_block_size_262 kB_format_3	(count 26)
12 MB	1.3 MB	8.886308
snappy_block_size_262 kB_format_3	(count 46)
12 MB	1.3 MB	8.886308
snappy_block_size_262 kB_format_3	(count 1)
12 MB	1.3 MB	8.886308
snappy_block_size_66 kB_format_3	(count 38)
13 MB	1.5 MB	8.884151
snappy_block_size_66 kB_format_3	(count 24)
13 MB	1.5 MB	8.884151
snappy_block_size_66 kB_format_3	(count 1)
13 MB	1.5 MB	8.884151
snappy_block_size_66 kB_format_0	(count 1)
13 MB	1.5 MB	8.872077
snappy_block_size_66 kB_format_0	(count 159)
13 MB	1.5 MB	8.872077
snappy_block_size_66 kB_format_0	(count 100)
13 MB	1.5 MB	8.872077
snappy_block_size_66 kB_format_2	(count 1)
13 MB	1.5 MB	8.868481
snappy_block_size_66 kB_format_1	(count 127)
13 MB	1.5 MB	8.868481
snappy_block_size_66 kB_format_2	(count 44)
13 MB	1.5 MB	8.868481
snappy_block_size_66 kB_format_2	(count 64)
13 MB	1.5 MB	8.868481
snappy_block_size_66 kB_format_1	(count 1)
13 MB	1.5 MB	8.868481
snappy_block_size_66 kB_format_1	(count 91)
13 MB	1.5 MB	8.868481
none_block_size_524 kB_format_0	(count 1)
1.5 MB	1.5 MB	0.985492
none_block_size_524 kB_format_0	(count 100)
1.5 MB	1.5 MB	0.985492
none_block_size_524 kB_format_0	(count 1542)
1.5 MB	1.5 MB	0.985492
none_block_size_524 kB_format_1	(count 1600)
1.5 MB	1.5 MB	0.985486
none_block_size_524 kB_format_1	(count 1)
1.5 MB	1.5 MB	0.985486
none_block_size_524 kB_format_2	(count 100)
1.5 MB	1.5 MB	0.985486
none_block_size_524 kB_format_2	(count 1)
1.5 MB	1.5 MB	0.985486
none_block_size_524 kB_format_2	(count 658)
1.5 MB	1.5 MB	0.985486
none_block_size_524 kB_format_1	(count 100)
1.5 MB	1.5 MB	0.985486
none_block_size_262 kB_format_0	(count 100)
1.5 MB	1.5 MB	0.985456
none_block_size_262 kB_format_0	(count 1628)
1.5 MB	1.5 MB	0.985456
none_block_size_262 kB_format_0	(count 1)
1.5 MB	1.5 MB	0.985456
none_block_size_262 kB_format_1	(count 1816)
1.5 MB	1.5 MB	0.985445
none_block_size_262 kB_format_1	(count 1)
1.5 MB	1.5 MB	0.985445
none_block_size_262 kB_format_1	(count 100)
1.5 MB	1.5 MB	0.985445
none_block_size_262 kB_format_1	(count 1364)
1.5 MB	1.5 MB	0.985445
none_block_size_262 kB_format_2	(count 616)
1.5 MB	1.5 MB	0.985445
none_block_size_262 kB_format_2	(count 100)
1.5 MB	1.5 MB	0.985445
none_block_size_262 kB_format_2	(count 1)
1.5 MB	1.5 MB	0.985445
none_block_size_66 kB_format_0	(count 1)
1.5 MB	1.5 MB	0.985269
none_block_size_66 kB_format_0	(count 100)
1.5 MB	1.5 MB	0.985269
none_block_size_66 kB_format_0	(count 1131)
1.5 MB	1.5 MB	0.985269
none_block_size_66 kB_format_0	(count 1560)
1.5 MB	1.5 MB	0.985269
none_block_size_66 kB_format_2	(count 608)
1.5 MB	1.5 MB	0.985224
none_block_size_66 kB_format_1	(count 1)
1.5 MB	1.5 MB	0.985224
none_block_size_66 kB_format_1	(count 100)
1.5 MB	1.5 MB	0.985224
none_block_size_66 kB_format_1	(count 1686)
1.5 MB	1.5 MB	0.985224
none_block_size_66 kB_format_2	(count 1)
1.5 MB	1.5 MB	0.985224
none_block_size_66 kB_format_2	(count 100)
1.5 MB	1.5 MB	0.985224
none_block_size_524 kB_format_3	(count 100)
1.4 MB	1.5 MB	0.943047
none_block_size_524 kB_format_3	(count 1)
1.4 MB	1.5 MB	0.943047
none_block_size_524 kB_format_3	(count 364)
1.4 MB	1.5 MB	0.943047
none_block_size_262 kB_format_3	(count 1)
1.4 MB	1.5 MB	0.943012
none_block_size_262 kB_format_3	(count 384)
1.4 MB	1.5 MB	0.943012
none_block_size_262 kB_format_3	(count 100)
1.4 MB	1.5 MB	0.943012
none_block_size_66 kB_format_3	(count 1)
1.4 MB	1.5 MB	0.942824
none_block_size_66 kB_format_3	(count 100)
1.4 MB	1.5 MB	0.942824
none_block_size_66 kB_format_3	(count 325)
1.4 MB	1.5 MB	0.942824
```