### PR TITLE
docs: Update LogCLI topic

### DIFF
--- a/docs/sources/query/logcli/_index.md
+++ b/docs/sources/query/logcli/_index.md
@@ -11,5 +11,5 @@ weight: 600
 
 LogCLI is a command-line tool for querying and exploring logs in Grafana Loki:
 
-* Installation and Reference: [LogCLI](https://grafana.com/docs/loki/<LOKI_VERSION>/query/logcli/logcli/)
+* Installation and Reference: [LogCLI](https://grafana.com/docs/loki/<LOKI_VERSION>/query/logcli/getting-started/)
 * Getting started tutorial: [LogCLI Tutorial](https://grafana.com/docs/loki/<LOKI_VERSION>/query/logcli/logcli-tutorial)

--- a/docs/sources/query/logcli/getting-started.md
+++ b/docs/sources/query/logcli/getting-started.md
@@ -9,9 +9,9 @@ weight: 150
 
 # LogCLI getting started
 
-logcli is a command-line client for Loki that allows you to run [LogQL](https://grafana.com/docs/loki/<LOKI_VERSION>/query) queries against your Loki instance.  The "query" command will output extra information about the query and its results, such as the API URL, set of common labels, and set of excluded labels.
+logcli is a command-line client for Loki that lets you run [LogQL](https://grafana.com/docs/loki/<LOKI_VERSION>/query) queries against your Loki instance. The `query` command will output extra information about the query and its results, such as the API URL, set of common labels, and set of excluded labels.
 
-This is useful, for example, if you want to download a range of logs from Loki.  Or want to perform analytical administration tasks, for example, discover the number of log streams to understand your label cardinality, or find out the estimated volume of data that a query will search over.  You can also use logcli as part of shell scripts.
+This is useful, for example, if you want to download a range of logs from Loki. Or want to perform analytical administration tasks, for example, discover the number of log streams to understand your label cardinality, or find out the estimated volume of data that a query will search over. You can also use logcli as part of shell scripts.
 
 If you are a Grafana Cloud user, you can also use logcli to query logs that you have exported to long-term storage with [Cloud Logs Export](https://grafana.com/docs/grafana-cloud/send-data/logs/export/), or any other Loki formatted log data.
 
@@ -21,7 +21,7 @@ Note that logcli is a querying tool, it cannot be used to ingest logs.
 
 ## Install logcli
 
-As a best practice, you should download the version of logcli that matches your Loki version.  And upgrade your logcli when you upgrade your version of Loki.
+As a best practice, you should download the version of logcli that matches your Loki version. And upgrade your logcli when you upgrade your version of Loki.
 
 ### Binary (Recommended)
 
@@ -112,13 +112,6 @@ If you are running Loki behind a proxy server and you have
 [authentication](https://grafana.com/docs/loki/<LOKI_VERSION>/operations/authentication/) configured, you will also have to pass in LOKI_USERNAME
 and LOKI_PASSWORD, LOKI_BEARER_TOKEN or LOKI_BEARER_TOKEN_FILE accordingly.
 {{< /admonition >}}
-
-### Configuration
-
-Configuration values are considered in the following order (lowest to highest):
-
-- Environment variables
-- Command-line options
 
 ## LogCLI command reference
 
@@ -918,9 +911,9 @@ Args:
 
 ### Use `--stdin` to query locally
 
-You can use the logcli –stdin argument to run a command against a log file on your local machine, instead of a Loki instance.  This lets you use LogQL to query a local log file without having to load the file into Loki, for example if you have downloaded a log file and want to query it outside of Loki.
+You can use the logcli `–stdin` argument to run a command against a log file on your local machine, instead of a Loki instance. This lets you use LogQL to query a local log file without having to load the file into Loki, for example if you have downloaded a log file and want to query it outside of Loki.
 
-Say you have log files in your local, and just want to do run some LogQL queries for that, `--stdin` flag can help.
+If you have log files in your local machine, and just want to run some LogQL queries against those log files, `--stdin` flag can help.
 
 You may use `stdin` flag to do the following:
 
@@ -930,10 +923,10 @@ You may use `stdin` flag to do the following:
 - Use LogQL to parse and extract data from a local log file without ingesting the data into Loki.
 - Enable discussion on public forums, for example submitting questions and answers, and sharing LogQL expressions.
 
-#### NOTES on `stdin` usage
+#### Notes on `stdin` usage
 
-1. The `--limits` flag doesn't have any meaning when using `--stdin` (use pager like `less` for that)
-1. Be aware there are no **labels** when using `--stdin`. So the stream selector in the query is optional, for example, just `|="timeout"|logfmt|level="error"` is same as `{foo="bar"}|="timeout|logfmt|level="error"`
+1. The `--limits` flag doesn't have any meaning when using `--stdin` (use pager like `less` for that).
+1. Be aware there are no **labels** when using `--stdin`. So the stream selector in the query is optional, for example, just `|="timeout"|logfmt|level="error"` is same as `{foo="bar"}|="timeout|logfmt|level="error"`.
 
 {{< admonition type="note" >}}
 Currently `stdin` doesn't support any type of metric queries.
@@ -941,10 +934,10 @@ Currently `stdin` doesn't support any type of metric queries.
 
 #### `stdin` examples
 
-1. Line filter - `cat mylog.log | logcli --stdin query '|="too many open connections"'`
-1. Label matcher - `echo 'msg="timeout happened" level="warning"' | logcli --stdin query '|logfmt|level="warning"'`
-1. Different parsers (logfmt, json, pattern, regexp) - `cat mylog.log | logcli --stdin query '|pattern <ip> - - <_> "<method> <uri> <_>" <status> <size> <_> "<agent>" <_>'`
-1. Line formatters - `cat mylog.log | logcli --stdin query '|logfmt|line_format "{{.query}} {{.duration}}"'`
+- Line filter - `cat mylog.log | logcli --stdin query '|="too many open connections"'`
+- Label matcher - `echo 'msg="timeout happened" level="warning"' | logcli --stdin query '|logfmt|level="warning"'`
+- Different parsers (logfmt, json, pattern, regexp) - `cat mylog.log | logcli --stdin query '|pattern <ip> - - <_> "<method> <uri> <_>" <status> <size> <_> "<agent>" <_>'`
+- Line formatters - `cat mylog.log | logcli --stdin query '|logfmt|line_format "{{.query}} {{.duration}}"'`
 
 ## Batching
 
@@ -963,7 +956,7 @@ requests from logcli to Loki to be batched.
 
 When you run a query in Loki, it will return up to a certain number of log lines. By default, this limit is 5000 lines. You can configure this server limit with the `limits_config.max_entries_limit_per_query` in Loki's configuration.
 
-Batching allows you to query for a results set that is larger than this server-side limit, as long as the `--batch` value is less than the server limit.
+Batching lets you query for a results set that is larger than this server-side limit, as long as the `--batch` value is less than the server limit.
 
 Query metadata is output to `stderr` for each batch.
 To suppress the output of the query metadata, set the `--quiet` option on the `logcli query` command line.
@@ -984,9 +977,7 @@ loki-ops/consul
 loki-ops/loki-gw
 ```
 
-Print all labels and their unique values.
-
-This command is especially useful for finding [high-cardinality labels](https://grafana.com/docs/loki/<LOKI_VERSION>/get-started/labels/#cardinality) in the index.
+Print all labels and their unique values. This command is especially useful for finding [high-cardinality labels](https://grafana.com/docs/loki/<LOKI_VERSION>/get-started/labels/#cardinality) in the index.
 
 ```bash
 logcli series '{cluster="vinson"}' --analyze-labels
@@ -1023,9 +1014,7 @@ Common labels: {job="loki-ops/consul", namespace="loki-ops"}
 2018-06-25T12:52:09Z {instance="consul-8576459955-pl75w"} 2018/06/25 12:52:09 [INFO] raft: Compacting logs from 456973 to 465169
 ```
 
-Print all log streams for the given stream selector.
-
-This example shows all known label combinations that match your query.
+Print all log streams for the given stream selector. This example shows all known label combinations that match your query.
 
 ```bash
 logcli series -q --match='{namespace="loki",container_name="loki"}'
@@ -1035,7 +1024,7 @@ logcli series -q --match='{namespace="loki",container_name="loki"}'
 {app="loki", container_name="loki", controller_revision_hash="loki-57c9df47f4", filename="/var/log/pods/loki_loki-0_8ed03ded-bacb-4b13-a6fe-53a445a15887/loki/0.log", instance="loki-0", job="loki/loki", name="loki", namespace="loki", release="loki", statefulset_kubernetes_io_pod_name="loki-0", stream="stderr"}
 ```
 
-## Troubleshooting logcli
+## Troubleshoot logcli
 
 Make sure that the version of Logcli you are using matches your Loki version.
 You can check your logcli version with the following command:

--- a/docs/sources/query/logcli/getting-started.md
+++ b/docs/sources/query/logcli/getting-started.md
@@ -66,9 +66,11 @@ You can set up tab-completion for `logcli` with one of the two options, dependin
 
 Once you have installed logcli, you can run it in the following way:
 
-`logcli [<flags>] <command> [<args> ...]`
+`logcli <command> [<flags>, <args> ...]`
 
-`<command>` points to one of the commands, detailed in the command reference {ADD LINK} below.
+`<command>` points to one of the commands, detailed in the [command reference](http://localhost:3002/docs/loki/<LOKI_VERSION>/query/logcli/getting-started/#logcli-command-reference) below.
+
+`<flags>` is one of the subcommands available for each command.
 
 `<args>` is a list of space separated arguments. Arguments can optionally be overridden using environment variables. Environment variables will always take precedence over command line arguments.
 
@@ -122,8 +124,8 @@ Configuration values are considered in the following order (lowest to highest):
 
 The output of `logcli help`:
 
-```nohighlight
-usage: logcli [<flags>] <command> [<args> ...]
+```shell
+usage: logcli <command> [<flags>][<args> ...]
 
 A command-line for Loki.
 
@@ -239,7 +241,7 @@ Commands:
 
 The output of `logcli help query`:
 
-```nohighlight
+```shell
 usage: logcli query [<flags>] <query>
 
 Run a LogQL query.
@@ -382,7 +384,7 @@ Flags:
                                 file. Default will skip a range if it's part file is already downloaded.
       --merge-parts             Reads the part files in order and writes the output to stdout. Original part files will be deleted with this
                                 option.
-      --keep-parts              Overrides the default behaviour of --merge-parts which will delete the part files once all the files have been
+      --keep-parts              Overrides the default behavior of --merge-parts which will delete the part files once all the files have been
                                 read. This option will keep the part files.
       --forward                 Scan forwards through logs.
       --no-labels               Do not print any labels
@@ -407,7 +409,7 @@ Args:
 
 The output of `logcli help instant-query`:
 
-```nohighlight
+```shell
 usage: logcli instant-query [<flags>] <query>
 
 Run an instant LogQL query.
@@ -478,7 +480,7 @@ Args:
 
 The output of `logcli help labels`:
 
-```nohighlight
+```shell
 usage: logcli labels [<flags>] [<label>]
 
 Find values for a given label.
@@ -529,7 +531,7 @@ Args:
 
 The output of `logcli help series`:
 
-```nohighlight
+```shell
 usage: logcli series [<flags>] <matcher>
 
 Run series query.
@@ -588,7 +590,7 @@ Args:
 
 The output of `logcli help fmt`:
 
-```nohighlight
+```shell
 usage: logcli fmt
 
 Formats a LogQL query.
@@ -633,7 +635,7 @@ Flags:
 
 The output of `logcli help stats`:
 
-```nohighlight
+```shell
 usage: logcli stats [<flags>] <query>
 
 Run a stats query.
@@ -701,7 +703,7 @@ Args:
 
 The output of `logcli help volume`:
 
-```nohighlight
+```shell
 usage: logcli volume [<flags>] <query>
 
 Run a volume query.
@@ -773,7 +775,7 @@ Args:
 
 The output of `logcli help volume_range`:
 
-```nohighlight
+```shell
 usage: logcli volume_range [<flags>] <query>
 
 Run a volume query and return timeseries data.
@@ -847,7 +849,7 @@ Args:
 
 The output of `logcli help detected-fields`:
 
-```nohighlight
+```shell
 usage: logcli detected-fields [<flags>] <query> [<field>]
 
 Run a query for detected fields..
@@ -995,17 +997,17 @@ logcli series '{cluster="vinson"}' --analyze-labels
 Total Streams:  10
 Unique Labels:  10
 
-Label Name          	Unique Values  Found In Streams
-service_name        	8          	10
-pod                 	7          	7
-job                 	6          	10
-app_kubernetes_io_name  6          	6
-container           	5          	7
-namespace           	3          	10
-stream              	2          	7
-flags               	1          	7
-instance            	1          	3
-cluster             	1          	10
+Label Name       Unique Values  Found In Streams
+service_name        8          10
+pod                 7          7
+job                 6          10
+app_kubernetes_io_name  6          6
+container           5          7
+namespace           3          10
+stream              2          7
+flags               1          7
+instance            1          3
+cluster             1          10
 ```
 
 Get all logs for a given stream


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the content on the `logcli` page to
* better organize content
* provide more context on what the tool is for
* add additional examples
* fix formatting issues/ Vale linter issues