### PR TITLE
feat(lambda-promtail): Add terraform variable for s3 bucket notification filter prefix

### DIFF
--- a/tools/lambda-promtail/main.tf
+++ b/tools/lambda-promtail/main.tf
@@ -281,7 +281,7 @@ resource "aws_s3_bucket_notification" "this" {
   lambda_function {
     lambda_function_arn = aws_lambda_function.this.arn
     events              = ["s3:ObjectCreated:*"]
-    filter_prefix       = "AWSLogs/"
+    filter_prefix       = var.filter_prefix
     filter_suffix       = var.filter_suffix
   }
 

--- a/tools/lambda-promtail/variables.tf
+++ b/tools/lambda-promtail/variables.tf
@@ -16,6 +16,12 @@ variable "bucket_names" {
   default     = []
 }
 
+variable "filter_prefix" {
+  type        = string
+  description = "Prefix for S3 bucket notification filter"
+  default     = "AWSLogs/"
+}
+
 variable "filter_suffix" {
   type        = string
   description = "Suffix for S3 bucket notification filter"


### PR DESCRIPTION
**What this PR does / why we need it**: Exposes the filter_prefix in the lambda_function of the aws_s3_bucket_notification resource as a terraform variable.

**Which issue(s) this PR fixes**:
Fixes #15380