### PR TITLE
refactor(kafka): do not pin partition reader to a single partiton

### DIFF
--- a/pkg/kafka/partition/reader.go
+++ b/pkg/kafka/partition/reader.go
@@ -154,9 +154,6 @@ func (r *KafkaReader) Poll(ctx context.Context, maxPollRecords int) ([]Record, e
 	// Build records slice
 	records := make([]Record, 0, fetches.NumRecords())
 	fetches.EachRecord(func(rec *kgo.Record) {
-		if rec.Partition != r.partitionID {
-			return
-		}
 		records = append(records, Record{
 			// This context carries the tracing data for this individual record;
 			// kotel populates this data when it fetches the messages.

--- a/pkg/kafka/partition/reader_service.go
+++ b/pkg/kafka/partition/reader_service.go
@@ -78,7 +78,6 @@ func NewReaderService(
 	readerMetrics := NewReaderMetrics(reg)
 	reader, err := NewKafkaReader(
 		kafkaCfg,
-		partitionID,
 		logger,
 		readerMetrics,
 	)
@@ -162,7 +161,7 @@ func (s *ReaderService) starting(ctx context.Context) error {
 		consumeOffset = lastCommittedOffset + 1
 	}
 	level.Debug(logger).Log("msg", "consuming from offset", "offset", consumeOffset)
-	s.reader.SetOffsetForConsumption(consumeOffset)
+	s.reader.SetOffsetForConsumption(s.partitionID, consumeOffset)
 
 	if err = s.processConsumerLagAtStartup(ctx, logger); err != nil {
 		return fmt.Errorf("failed to process consumer lag at startup: %w", err)

--- a/pkg/kafka/partition/reader_test.go
+++ b/pkg/kafka/partition/reader_test.go
@@ -214,7 +214,7 @@ func TestPartitionReader_ProcessCommits(t *testing.T) {
 	require.NoError(t, err)
 
 	// Init the client: This usually happens in "start" but we want to manage our own lifecycle for this test.
-	partitionReader.SetOffsetForConsumption(int64(KafkaStartOffset))
+	partitionReader.SetOffsetForConsumption(partitionID, int64(KafkaStartOffset))
 
 	stream := logproto.Stream{
 		Labels:  labels.FromStrings("foo", "bar").String(),

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -1835,11 +1835,10 @@ func (t *Loki) initBlockBuilder() (services.Service, error) {
 		return nil, err
 	}
 
-	readerMetrics := partition.NewReaderMetrics(prometheus.DefaultRegisterer)
-	readerFactory := func(partitionID int32) (partition.Reader, error) {
+	readerFactory := func(clientID string) (partition.Reader, error) {
+		readerMetrics := partition.NewReaderMetrics(prometheus.WrapRegistererWith(prometheus.Labels{"client_id": clientID}, prometheus.DefaultRegisterer))
 		return partition.NewKafkaReader(
 			t.Cfg.KafkaConfig,
-			partitionID,
 			logger,
 			readerMetrics,
 		)


### PR DESCRIPTION
**What this PR does / why we need it**:

Pinning a partition reader to a single partition prevents us from reusing the underlying kafka client to read from different partitions. This is not a problem for partition-ingesters as they are tied to a single partition but block builders can receive jobs to consume records from multiple partitions.

- Updates `Reader` so it is not tied to a partition. It is upto the caller to set the partition by calling `SetOffsetForConsumption`
- block builder now creates one reader per worker instead of one reader per partition
- block builder usage of `waitgroup` is replaced with `errgroup` to catch any errors from partition reader creation

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
