### PR TITLE
fix(helm): Add conditional to include ruler config only when enabled

### DIFF
--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -13,6 +13,7 @@ Entries should include a reference to the pull request that introduced the chang
 
 [//]: # (<AUTOMATED_UPDATES_LOCATOR> : do not remove this line. This locator is used by the CI pipeline to automatically create a changelog entry for each new Loki release. Add other chart versions and respective changelog entries bellow this line.)
 
+- [BUGFIX] Add conditional to include ruler config only if `ruler.enabled=true`
 - [BUGFIX] Disables the Helm test pod when `test.enabled=false`.
 
 ## 6.23.0

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -205,7 +205,9 @@ loki:
     {{- toYaml .Values.loki.testSchemaConfig | nindent 2}}
     {{- end }}
 
+    {{- if .Values.ruler.enabled }}
     {{ include "loki.rulerConfig" . }}
+    {{- end }}
 
     {{- if or .Values.tableManager.retention_deletes_enabled .Values.tableManager.retention_period }}
     table_manager:


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a conditional statement to include rulerconfig only if `ruler.enabled=true`. Without this conditional, the loki-backend pod fails when no bucket is provided for the ruler, even when `ruler.enabled=false`

**Which issue(s) this PR fixes**:
Fixes #15357

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
