### PR TITLE
chore(block-scheduler): add scheduler grpc methods to auth mw ignore list

### DIFF
--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -430,6 +430,9 @@ func (t *Loki) setupAuthMiddleware() {
 			"/schedulerpb.SchedulerForFrontend/FrontendLoop",
 			"/schedulerpb.SchedulerForQuerier/QuerierLoop",
 			"/schedulerpb.SchedulerForQuerier/NotifyQuerierShutdown",
+			"/blockbuilder.types.SchedulerService/GetJob",
+			"/blockbuilder.types.SchedulerService/CompleteJob",
+			"/blockbuilder.types.SchedulerService/SyncJob",
 		})
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**

By default loki applies user header interceptor middleware for all grpc methods on the server side which tries to extract user information from grpc metadata. But block scheduler methods are internal and their functionality is not tied to a single user. Adding the scheduler methods to the ignore list to not fail in the interceptor.

Similarly `grpcclient.Instrument()` tries to extract user information from context to perform per-tenant instrumentation cauing these methods to fail. Updated the Dial opts to only include the required interceptors.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
