### PR TITLE
add docs deploy preview

### DIFF
--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -1,0 +1,23 @@
+name: Deploy pr preview
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - closed
+    paths:
+      - "docs/sources/**"
+
+jobs:
+  deploy-pr-preview:
+    uses: grafana/writers-toolkit/.github/workflows/deploy-preview.yml@main
+    with:
+      sha: ${{ github.event.pull_request.head.sha }}
+      branch: ${{ github.head_ref }}
+      event_number: ${{ github.event.number }}
+      title: ${{ github.event.pull_request.title }}
+      repo: loki
+      website_directory: content/docs/loki/latest
+      relative_prefix: /docs/loki/latest/
+      index_file: true

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,20 +1,28 @@
 # Default owners for everything in the repo, unless a later match takes precedence.
-* @grafana/loki-team
+
+- @grafana/loki-team
 
 # Documentation.
+
 /docs/ @grafana/docs-logs @grafana/loki-team
+/.github/workflows/deploy-pr-preview.yml @grafana/docs-logs
 
 # Loki operator
+
 /operator/ @grafana/loki-team @periklis @xperimental @JoaoBraveCoding
-/.github/workflows/operator* @grafana/loki-team @periklis @xperimental @JoaoBraveCoding
+/.github/workflows/operator\* @grafana/loki-team @periklis @xperimental @JoaoBraveCoding
 
 # Logql grammar
+
 # The observability logs team is listed as co-codeowner for grammar file. This is to receive notifications about updates, so these can be implemented in https://github.com/grafana/lezer-logql
+
 /pkg/logql/syntax/expr.y @grafana/observability-logs @grafana/loki-team
 
 # Nix
+
 /nix/ @trevorwhitney
 flake.nix @trevorwhitney
 
 # No owners - allows sub-maintainers to merge changes.
+
 CHANGELOG.md


### PR DESCRIPTION
for https://github.com/grafana/website/issues/10101

**What is this feature?**

This PR adds a workflow to deploy the output of the `make docs` command to a public deploy preview. The workflow posts a comment with a link to the preview after it has been deployed.

**Why do we need this feature?**

Docs contributors will no longer need to run `make docs` on their machine, as they will be able to view the deploy preview instead.

**Who is this feature for?**

Everyone.


