### PR TITLE
chore: Fix wording in Loki Operator ADOPTERS.md files

### DIFF
--- a/operator/ADOPTERS.md
+++ b/operator/ADOPTERS.md
@@ -22,7 +22,7 @@ Details (optional):
 - Ruler for LokiStack
 -->
 
-This document tracks people and use cases for the Prometheus Operator in production. By creating a list of production use cases we hope to build a community of advisors that we can reach out to with experience using various the Prometheus Operator applications, operation environments, and cluster sizes. The Prometheus Operator development team may reach out periodically to check-in on how the Prometheus Operator is working in the field and update this list.
+This document tracks people and use cases for the Loki Operator in production. By creating a list of production use cases we hope to build a community of advisors that we can reach out to with experience using various the Loki Operator applications, operation environments, and cluster sizes. The Loki Operator development team may reach out periodically to check-in on how the Loki Operator is working in the field and update this list.
 
 Go ahead and [add your organization](https://github.com/grafana/loki/edit/main/operator/ADOPTERS.md) to the list.
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Replaces "Prometheus Operator" with "Loki Operator". This was clearly a copy-paste error.

**Which issue(s) this PR fixes**:

Fixes #15339