### PR TITLE
fix: data race / nil channel read in pattern aggregation push

### DIFF
--- a/pkg/pattern/aggregation/push.go
+++ b/pkg/pattern/aggregation/push.go
@@ -246,7 +246,7 @@ func (p *Push) buildPayload(ctx context.Context) ([]byte, error) {
 
 // run pulls lines out of the channel and sends them to Loki
 func (p *Push) run(pushPeriod time.Duration) {
-	p.running.Done()
+	defer p.running.Done()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	pushTicker := time.NewTimer(pushPeriod)

--- a/pkg/pattern/aggregation/push.go
+++ b/pkg/pattern/aggregation/push.go
@@ -59,8 +59,9 @@ type Push struct {
 	contentType string
 	logger      log.Logger
 
-	// shutdown channels
-	quit chan struct{}
+	running  sync.WaitGroup
+	quit     chan struct{}
+	quitOnce sync.Once
 
 	// auth
 	username, password string
@@ -149,6 +150,7 @@ func NewPush(
 		metrics: metrics,
 	}
 
+	p.running.Add(1)
 	go p.run(pushPeriod)
 	return p, nil
 }
@@ -160,10 +162,10 @@ func (p *Push) WriteEntry(ts time.Time, e string, lbls labels.Labels) {
 
 // Stop will cancel any ongoing requests and stop the goroutine listening for requests
 func (p *Push) Stop() {
-	if p.quit != nil {
+	p.quitOnce.Do(func() {
 		close(p.quit)
-		p.quit = nil
-	}
+	})
+	p.running.Wait()
 }
 
 // buildPayload creates the snappy compressed protobuf to send to Loki
@@ -244,6 +246,8 @@ func (p *Push) buildPayload(ctx context.Context) ([]byte, error) {
 
 // run pulls lines out of the channel and sends them to Loki
 func (p *Push) run(pushPeriod time.Duration) {
+	p.running.Done()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	pushTicker := time.NewTimer(pushPeriod)
 	defer pushTicker.Stop()

--- a/pkg/pattern/aggregation/push_test.go
+++ b/pkg/pattern/aggregation/push_test.go
@@ -169,6 +169,7 @@ func Test_Push(t *testing.T) {
 			lbls2,
 		)
 
+		p.running.Add(1)
 		go p.run(time.Nanosecond)
 
 		select {


### PR DESCRIPTION
**What this PR does / why we need it**:

This fixes a few different issues:
1. Setting `p.quit = nil` like that is actually a data race and the tests failed when executed with the `-race` flag:
    ```
    WARNING: DATA RACE
    Read at 0x00c000838508 by goroutine 82:
    github.com/grafana/loki/v3/pkg/pattern/aggregation.(*Push).run()
        github.com/grafana/loki/v3/pkg/pattern/aggregation/push.go:257 +0x184
    github.com/grafana/loki/v3/pkg/pattern/aggregation.Test_Push.func3.gowrap2()
        github.com/grafana/loki/v3/pkg/pattern/aggregation/push_test.go:172 +0x38

    Previous write at 0x00c000838508 by goroutine 80:
    github.com/grafana/loki/v3/pkg/pattern/aggregation.(*Push).Stop()
        github.com/grafana/loki/v3/pkg/pattern/aggregation/push.go:165 +0x1884
    github.com/grafana/loki/v3/pkg/pattern/aggregation.Test_Push.func3()
        github.com/grafana/loki/v3/pkg/pattern/aggregation/push_test.go:176 +0x1833
    testing.tRunner()
        testing/testing.go:1690 +0x226
    testing.(*T).Run.gowrap1()
        testing/testing.go:1743 +0x44
    ```
    This would be a problem not just in the tests, but in the actual execution of this module.
2. However, even if this had succeeded and the channel had been set to `nil`, that is even worse! [Trying to read from a `nil` channel blocks forever](https://golangbyexample.com/send-receive-nil-channel-go/), so the `run()` method would have blocked on `case <-p.quit:` instead of finished gracefully :grimacing: 
3. Finally, even if we somehow got to the desired result of `Push.run()` gracefully stopping, the `Push.Stop()` method didn't actually wait for that to happen, which might be breaking the expectation of upstream users of that method. It's generally a good idea to expect that whatever you have called the `Stop()` method of something, that thing has actually stopped once the method returns. It's much easier to reason about its behavior that way.
