### PR TITLE
feat: line_format bypass template execution if possible

### DIFF
--- a/pkg/logql/log/fmt.go
+++ b/pkg/logql/log/fmt.go
@@ -215,6 +215,9 @@ func NewFormatter(tmpl string) (*LineFormatter, error) {
 	}
 	lf.Template = t
 
+	// determine if the template is a simple key substitution, e.g. line_format `{{.message}}`
+	// if it is, save the key name and we can use it later to directly copy the string
+	// bytes of the value to avoid copying and allocating a new string.
 	if len(t.Root.Nodes) == 1 && t.Root.Nodes[0].Type() == parse.NodeAction {
 		actionNode := t.Root.Nodes[0].(*parse.ActionNode)
 		if len(actionNode.Pipe.Cmds) == 1 && len(actionNode.Pipe.Cmds[0].Args) == 1 {

--- a/pkg/logql/log/fmt_test.go
+++ b/pkg/logql/log/fmt_test.go
@@ -479,6 +479,33 @@ func Test_lineFormatter_Format(t *testing.T) {
 			labels.FromStrings("foo", "hello"),
 			[]byte("1"),
 		},
+		{
+			"simple key template",
+			newMustLineFormatter("{{.foo}}"),
+			labels.FromStrings("foo", "bar"),
+			0,
+			[]byte("bar"),
+			labels.FromStrings("foo", "bar"),
+			nil,
+		},
+		{
+			"simple key template with space",
+			newMustLineFormatter("{{.foo}}  "),
+			labels.FromStrings("foo", "bar"),
+			0,
+			[]byte("bar  "),
+			labels.FromStrings("foo", "bar"),
+			nil,
+		},
+		{
+			"simple key template with missing key",
+			newMustLineFormatter("{{.missing}}"),
+			labels.FromStrings("foo", "bar"),
+			0,
+			[]byte{},
+			labels.FromStrings("foo", "bar"),
+			nil,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -916,7 +943,7 @@ func TestLabelFormatter_RequiredLabelNames(t *testing.T) {
 }
 
 func TestDecolorizer(t *testing.T) {
-	var decolorizer, _ = NewDecolorizer()
+	decolorizer, _ := NewDecolorizer()
 	tests := []struct {
 		name     string
 		src      []byte
@@ -927,7 +954,7 @@ func TestDecolorizer(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var result, _ = decolorizer.Process(0, tt.src, nil)
+			result, _ := decolorizer.Process(0, tt.src, nil)
 			require.Equal(t, tt.expected, result)
 		})
 	}
@@ -979,7 +1006,6 @@ func TestMapPoolPanic(_ *testing.T) {
 			}
 			smp.Put(m)
 			wgFinished.Done()
-
 		}()
 	}
 	wg.Done()


### PR DESCRIPTION
**What this PR does / why we need it**:

This allows to bypass template format execution if this is a simple swap of the line with another key. Making that trick faster to use.

```
{bar="foo"} | json | line_format `{{.message}}` | pattern "<_>: <_> <something>" ....
```

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
