### PR TITLE
fix: data race in distributor tests

### DIFF
--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -583,6 +583,8 @@ func TestDistributorPushToKafka(t *testing.T) {
 		require.Equal(t, 1, len(ingesters[0].pushed))
 		require.Equal(t, 1, len(ingesters[1].pushed))
 		require.Eventually(t, func() bool {
+			ingesters[2].mu.Lock()
+			defer ingesters[2].mu.Unlock()
 			return len(ingesters[2].pushed) == 1
 		}, time.Second, 10*time.Millisecond)
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:

Tiny data race in the tests itself, without this fix the tests (when executed with `-race`) fail with:
```
WARNING: DATA RACE
Read at 0x00c00187a6a8 by goroutine 10064:
  github.com/grafana/loki/v3/pkg/distributor.TestDistributorPushToKafka.func3.1()
      github.com/grafana/loki/v3/pkg/distributor/distributor_test.go:586 +0x48
  github.com/stretchr/testify/assert.Eventually.func1()
      github.com/stretchr/testify@v1.10.0/assert/assertions.go:1949 +0x33

Previous write at 0x00c00187a6a8 by goroutine 9930:
  github.com/grafana/loki/v3/pkg/distributor.(*mockIngester).Push()
      github.com/grafana/loki/v3/pkg/distributor/distributor_test.go:1872 +0x3c4
  github.com/grafana/loki/v3/pkg/distributor.(*Distributor).sendStreamsErr()
      github.com/grafana/loki/v3/pkg/distributor/distributor.go:1035 +0x3af
...
```