### PR TITLE
fix: remove unsafe pkg usage from util.mempool

### DIFF
--- a/pkg/util/mempool/pool.go
+++ b/pkg/util/mempool/pool.go
@@ -1,25 +1,20 @@
 package mempool
 
 import (
-	"errors"
 	"fmt"
 	"sync"
 	"time"
-	"unsafe"
 
 	"github.com/dustin/go-humanize"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 var (
-	errSlabExhausted = errors.New("slab exhausted")
-
-	reasonSizeExceeded  = "size-exceeded"
-	reasonSlabExhausted = "slab-exhausted"
+	reasonSizeExceeded = "size-exceeded"
 )
 
 type slab struct {
-	buffer      chan unsafe.Pointer
+	buffer      chan []byte
 	size, count int
 	once        sync.Once
 	metrics     *metrics
@@ -39,11 +34,10 @@ func newSlab(bufferSize, bufferCount int, m *metrics) *slab {
 }
 
 func (s *slab) init() {
-	s.buffer = make(chan unsafe.Pointer, s.count)
+	s.buffer = make(chan []byte, s.count)
 	for i := 0; i < s.count; i++ {
 		buf := make([]byte, 0, s.size)
-		ptr := unsafe.Pointer(unsafe.SliceData(buf)) //#nosec G103 -- Simple arena allocator implementation, does not appear to allow for any unsafe operations.
-		s.buffer <- ptr
+		s.buffer <- buf
 	}
 	s.metrics.availableBuffersPerSlab.WithLabelValues(s.name).Set(float64(s.count))
 }
@@ -54,8 +48,8 @@ func (s *slab) get(size int) ([]byte, error) {
 
 	waitStart := time.Now()
 	// wait for available buffer on channel
-	ptr := <-s.buffer
-	buf := unsafe.Slice((*byte)(ptr), s.size) //#nosec G103 -- Simple arena allocator implementation, does not appear to allow for any unsafe operations.
+	buf := <-s.buffer
+	buf = buf[:size]
 	s.metrics.waitDuration.WithLabelValues(s.name).Observe(time.Since(waitStart).Seconds())
 
 	return buf[:size], nil
@@ -67,9 +61,8 @@ func (s *slab) put(buf []byte) {
 		panic("slab is not initialized")
 	}
 
-	ptr := unsafe.Pointer(unsafe.SliceData(buf)) //#nosec G103 -- Simple arena allocator implementation, does not appear to allow for any unsafe operations.
 	// Note that memory is NOT zero'd on return, but since all allocations are of defined widths and we only ever then read a record of exactly that width into the allocation, it will always be overwritten before use and can't leak.
-	s.buffer <- ptr
+	s.buffer <- buf
 }
 
 // MemPool is an Allocator implementation that uses a fixed size memory pool

--- a/pkg/util/mempool/pool.go
+++ b/pkg/util/mempool/pool.go
@@ -49,7 +49,6 @@ func (s *slab) get(size int) ([]byte, error) {
 	waitStart := time.Now()
 	// wait for available buffer on channel
 	buf := <-s.buffer
-	buf = buf[:size]
 	s.metrics.waitDuration.WithLabelValues(s.name).Observe(time.Since(waitStart).Seconds())
 
 	return buf[:size], nil


### PR DESCRIPTION
**What this PR does / why we need it**:

Before this change, when I was running the tests with `-race`, the following error occurred:
```
fatal error: checkptr: unsafe.Slice result straddles multiple allocations

goroutine 60 gp=0xc0001ba8c0 m=5 mp=0xc000100008 [running]:
runtime.throw({0x14afd15?, 0xc0004e3d30?})
	runtime/panic.go:1067 +0x48 fp=0xc0004e3c18 sp=0xc0004e3be8 pc=0x4b0148
runtime.unsafeslicecheckptr(0x130a920, 0xc0002fa000, 0x40)
	runtime/unsafe.go:88 +0x65 fp=0xc0004e3c40 sp=0xc0004e3c18 pc=0x4a5b85
github.com/grafana/loki/v3/pkg/util/mempool.(*slab).get(0xc0002e5400, 0x10)
	github.com/grafana/loki/v3/pkg/util/mempool/pool.go:58 +0x25b fp=0xc0004e3d58 sp=0xc0004e3c40 pc=0x1299e7b
github.com/grafana/loki/v3/pkg/util/mempool.(*MemPool).Get(0xc0001a5f60, 0x10)
	github.com/grafana/loki/v3/pkg/util/mempool/pool.go:103 +0x146 fp=0xc0004e3e28 sp=0xc0004e3d58 pc=0x129a726
github.com/grafana/loki/v3/pkg/util/mempool.TestMemPool.func4(0xc00018d040)
	github.com/grafana/loki/v3/pkg/util/mempool/pool_test.go:63 +0x1f5 fp=0xc0004e3ee0 sp=0xc0004e3e28 pc=0x129b455
testing.tRunner(0xc00018d040, 0x14d9bd0)
```

And while the test can be fixed, I didn't see a reason to use `unsafe` in this package at all
