### PR TITLE
S3 terraform fixes

### DIFF
--- a/docs/sources/configure/storage.md
+++ b/docs/sources/configure/storage.md
@@ -342,18 +342,15 @@ This guide assumes a provisioned EKS cluster.
    export AWS_REGION=<region of EKS cluster>
    ```
 
-4. Save the OIDC provider in an environment variable:
+4. Apply the Terraform module:
 
-   ```bash
-   oidc_provider=$(aws eks describe-cluster --name <EKS cluster> --query "cluster.identity.oidc.issuer" --output text | sed -e "s/^https:\/\///")
+   ```sh
+   terraform apply \
+     -var=region="$AWS_REGION" \
+     -var=cluster_name=<EKS cluster> \
+     -var=namespace=<service account namespace>
+     -var=bucket_name=<s3 bucket name>
    ```
-
-   See the [IAM OIDC provider guide](https://docs.aws.amazon.com/eks/latest/userguide/enable-iam-roles-for-service-accounts.html) for a guide for creating a provider.
-
-5. Apply the Terraform module `terraform -var region="$AWS_REGION" -var cluster_name=<EKS cluster> -var oidc_id="$oidc_provider"`
-
-   Note, the bucket name defaults to `loki-data` but can be changed via the
-   `bucket_name` variable.
 
 ### Azure deployment (Azure Blob Storage Single Store)
 

--- a/production/terraform/modules/s3/main.tf
+++ b/production/terraform/modules/s3/main.tf
@@ -71,8 +71,6 @@ resource "aws_s3_bucket_policy" "grant-access" {
 resource "aws_iam_role" "loki" {
   name               = "LokiStorage-${var.cluster_name}"
   assume_role_policy = data.aws_iam_policy_document.oidc.json
-
-  inline_policy {}
 }
 
 resource "aws_iam_policy" "loki" {

--- a/production/terraform/modules/s3/main.tf
+++ b/production/terraform/modules/s3/main.tf
@@ -51,7 +51,7 @@ resource "aws_s3_bucket_policy" "grant-access" {
             Sid: "Statement1",
             Effect: "Allow",
             Principal: {
-                AWS: aws_iam_role.loki.arn  
+                AWS: aws_iam_role.loki.arn
             },
             Action: [
               "s3:PutObject",


### PR DESCRIPTION
**What this PR does / why we need it**:

I followed the guide on using Terraform to set up S3 buckets for Loki storage in an EKS cluster.

I cleaned up the terraform files to eliminate warnings, and updated the guide to accurately reflect how the terraform module is used when installing the helm chart.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

The helm chart further assumes 3 buckets for s3 storage, but the terraform project only creates 1.

I have a solution for this locally, but I think it would make sense to update the docs and terraform project to reflect this. I am not sure what the impact would be/if the terraform project is also used elsewhere.

Let me know if you want me to work on an approach for this/point me in the right direction if possible.

Also note: I am rebasing to fix the commit naming, but creating the PR to get these notes out.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [ ] Tests updated (**Not applicable**)
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)