### PR TITLE
chore(block-scheduler): planner improvements to limit jobs and consider retention when planning

### DIFF
--- a/pkg/blockbuilder/scheduler/queue.go
+++ b/pkg/blockbuilder/scheduler/queue.go
@@ -68,8 +68,7 @@ type JobQueue struct {
 	completed  *CircularBuffer[*JobWithMetadata]        // Last N completed jobs
 	statusMap  map[string]types.JobStatus               // Maps job ID to its current status
 	metrics    *jobQueueMetrics
-
-	mu sync.RWMutex
+	mu         sync.RWMutex
 }
 
 func NewJobQueueWithLogger(logger log.Logger, reg prometheus.Registerer) *JobQueue {

--- a/pkg/blockbuilder/scheduler/strategy_test.go
+++ b/pkg/blockbuilder/scheduler/strategy_test.go
@@ -147,8 +147,7 @@ func TestRecordCountPlanner_Plan(t *testing.T) {
 			}
 			require.NoError(t, cfg.Validate())
 			planner := NewRecordCountPlanner(mockReader, tc.recordCount, time.Hour, log.NewNopLogger())
-
-			jobs, err := planner.Plan(context.Background())
+			jobs, err := planner.Plan(context.Background(), 0)
 			require.NoError(t, err)
 
 			require.Equal(t, len(tc.expectedJobs), len(jobs))

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -1879,7 +1879,7 @@ func (t *Loki) initBlockScheduler() (services.Service, error) {
 
 	s, err := blockscheduler.NewScheduler(
 		t.Cfg.BlockScheduler,
-		blockscheduler.NewJobQueueWithLogger(logger),
+		blockscheduler.NewJobQueueWithLogger(logger, prometheus.DefaultRegisterer),
 		offsetManager,
 		logger,
 		prometheus.DefaultRegisterer,


### PR DESCRIPTION
**What this PR does / why we need it**:

- Adds config to limit the number of jobs that can be returned every time we call plan. Without this, the planner could overwhelm the job queue by adding a large number of jobs if the partition is lagging.
- Last committed offset could be lower than the start offset if we are failing to catch-up with retention, consider this when planning jobs. This is unlikely to happen if the builders are actively running.


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
