### PR TITLE
docs: add exception to spelling rule

### DIFF
--- a/docs/sources/community/governance.md
+++ b/docs/sources/community/governance.md
@@ -25,7 +25,7 @@ The Loki developers and community are expected to follow the values defined in t
 
 ## Projects
 
-Each project must have a [`MAINTAINERS.md`][maintainers] file with at least one maintainer. Where a project has a release process, access and documentation should be such that more than one person can perform a release. Releases should be announced on the [announcemount][announce] and [users][users] mailing lists. Any new projects should be first proposed on the [team mailing list][team] following the voting procedures listed below.
+Each project must have a [`MAINTAINERS.md`][maintainers] file with at least one maintainer. Where a project has a release process, access and documentation should be such that more than one person can perform a release. Releases should be announced on the [announcement][announce] and [users][users] mailing lists. Any new projects should be first proposed on the [team mailing list][team] following the voting procedures listed below.
 
 ## Decision making
 
@@ -50,7 +50,7 @@ Upon death of a member, they leave the team automatically.
 In case a member leaves, the [offboarding](#offboarding) procedure is applied.
 
 The current team members are:
-
+<!-- vale Grafana.GrafanaSpelling = NO -->
 - Aditya C S - [adityacs](https://github.com/adityacs)
 - Ashwanth Goli - [ashwanthgoli](https://github.com/ashwanthgoli) ([Grafana Labs](/))
 - Cyril Tovena - [cyriltovena](https://github.com/cyriltovena) ([Grafana Labs](/))
@@ -73,12 +73,13 @@ The current team members are:
 - Tom Wilkie - [tomwilkie](https://github.com/tomwilkie) ([Grafana Labs](/))
 
 The current Loki SIG Operator team members are:
+
 - Brett Jones - [blockloop](https://github.com/blockloop/) ([InVision](https://www.invisionapp.com/))
 - Cyril Tovena - [cyriltovena](https://github.com/cyriltovena) ([Grafana Labs](/))
 - Gerard Vanloo - [Red-GV](https://github.com/Red-GV) ([IBM](https://www.ibm.com))
 - Periklis Tsirakidis - [periklis](https://github.com/periklis) ([Red Hat](https://www.redhat.com))
 - Sashank Agrawal - [sasagarw](https://github.com/sasagarw/) ([Red Hat](https://www.redhat.com))
-
+<!-- vale Grafana.GrafanaSpelling = YES -->
 ### Maintainers
 
 Maintainers lead one or more project(s) or parts thereof and serve as a point of conflict resolution amongst the contributors to this project. Ideally, maintainers are also team members, but exceptions are possible for suitable maintainers that, for whatever reason, are not yet team members.
@@ -161,7 +162,6 @@ The new member is
 - announced on the [developers mailing list][devs] by an existing team member. Ideally, the new member replies in this thread, acknowledging team membership.
 - added to the projects with commit rights.
 - added to the [team mailing list][team].
-
 
 ### Offboarding
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Add exception to the Grafana Vale spelling rule for names in the list of maintainers in the Governance file.