### PR TITLE
fix: data race in ingester test

### DIFF
--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -8,9 +8,10 @@ import (
 	"net/http/httptest"
 	"sort"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
+
+	"go.uber.org/atomic"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"sort"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1498,7 +1499,7 @@ func jsonLine(ts int64, i int) string {
 
 type readRingMock struct {
 	replicationSet          ring.ReplicationSet
-	getAllHealthyCallsCount int
+	getAllHealthyCallsCount atomic.Int32
 	tokenRangesByIngester   map[string]ring.TokenRanges
 }
 
@@ -1538,7 +1539,7 @@ func (r *readRingMock) BatchGet(_ []uint32, _ ring.Operation) ([]ring.Replicatio
 }
 
 func (r *readRingMock) GetAllHealthy(_ ring.Operation) (ring.ReplicationSet, error) {
-	r.getAllHealthyCallsCount++
+	r.getAllHealthyCallsCount.Add(1)
 	return r.replicationSet, nil
 }
 

--- a/pkg/ingester/recalculate_owned_streams_test.go
+++ b/pkg/ingester/recalculate_owned_streams_test.go
@@ -25,12 +25,12 @@ func Test_recalculateOwnedStreams_newRecalculateOwnedStreamsIngester(t *testing.
 	}, 0)
 	strategy := newOwnedStreamsIngesterStrategy("test", mockRing, log.NewNopLogger())
 	service := newRecalculateOwnedStreamsSvc(mockInstancesSupplier.get, strategy, 50*time.Millisecond, log.NewNopLogger())
-	require.Equal(t, 0, mockRing.getAllHealthyCallsCount, "ring must be called only after service's start up")
+	require.Equal(t, int32(0), mockRing.getAllHealthyCallsCount.Load(), "ring must be called only after service's start up")
 	ctx := context.Background()
 	require.NoError(t, service.StartAsync(ctx))
 	require.NoError(t, service.AwaitRunning(ctx))
 	require.Eventually(t, func() bool {
-		return mockRing.getAllHealthyCallsCount >= 2
+		return mockRing.getAllHealthyCallsCount.Load() >= 2
 	}, 1*time.Second, 50*time.Millisecond, "expected at least two runs of the iteration")
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Without these changes, the tests fail when executed with `-race`:
```
WARNING: DATA RACE
Write at 0x00c0126fd5b0 by goroutine 47612:
  github.com/grafana/loki/v3/pkg/ingester.(*readRingMock).GetAllHealthy()
      github.com/grafana/loki/v3/pkg/ingester/ingester_test.go:1541 +0x6e
  github.com/grafana/loki/v3/pkg/ingester.(*ownedStreamsIngesterStrategy).checkRingForChanges()
      github.com/grafana/loki/v3/pkg/ingester/recalculate_owned_streams.go:117 +0x77
  github.com/grafana/loki/v3/pkg/ingester.(*recalculateOwnedStreamsSvc).recalculate()
      github.com/grafana/loki/v3/pkg/ingester/recalculate_owned_streams.go:54 +0x2af
  github.com/grafana/loki/v3/pkg/ingester.(*recalculateOwnedStreamsSvc).iteration()
      github.com/grafana/loki/v3/pkg/ingester/recalculate_owned_streams.go:44 +0x33
  github.com/grafana/loki/v3/pkg/ingester.(*recalculateOwnedStreamsSvc).iteration-fm()
      <autogenerated>:1 +0x17
  github.com/grafana/loki/v3/pkg/ingester.Test_recalculateOwnedStreams_newRecalculateOwnedStreamsIngester.newRecalculateOwnedStreamsSvc.NewTimerService.func5()
      github.com/grafana/dskit@v0.0.0-20241007172036-53283a0f6b41/services/services.go:33 +0x1d8
  github.com/grafana/dskit/services.(*BasicService).main()
      github.com/grafana/dskit@v0.0.0-20241007172036-53283a0f6b41/services/basic_service.go:193 +0x3b7
  github.com/grafana/dskit/services.(*BasicService).StartAsync.func1.gowrap1()
      github.com/grafana/dskit@v0.0.0-20241007172036-53283a0f6b41/services/basic_service.go:122 +0x33

Previous read at 0x00c0126fd5b0 by goroutine 47613:
  github.com/grafana/loki/v3/pkg/ingester.Test_recalculateOwnedStreams_newRecalculateOwnedStreamsIngester.func1()
      github.com/grafana/loki/v3/pkg/ingester/recalculate_owned_streams_test.go:33 +0x37
  github.com/stretchr/testify/assert.Eventually.func1()
      github.com/stretchr/testify@v1.10.0/assert/assertions.go:1949 +0x33
...
```