### PR TITLE
fix: data race in chunk client hedging tests

### DIFF
--- a/pkg/storage/chunk/client/hedging/hedging.go
+++ b/pkg/storage/chunk/client/hedging/hedging.go
@@ -64,12 +64,6 @@ func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.IntVar(&cfg.MaxPerSecond, prefix+"hedge-max-per-second", 5, "The maximum of hedge requests allowed per seconds.")
 }
 
-// Client returns a hedged http client.
-// The client transport will be mutated to use the hedged roundtripper.
-func (cfg *Config) Client(client *http.Client) (*http.Client, error) {
-	return cfg.ClientWithRegisterer(client, prometheus.DefaultRegisterer)
-}
-
 // ClientWithRegisterer returns a hedged http client with instrumentation registered to the provided registerer.
 // The client transport will be mutated to use the hedged roundtripper.
 func (cfg *Config) ClientWithRegisterer(client *http.Client, reg prometheus.Registerer) (*http.Client, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Before these changes, the tests here failed with a bunch of data races, e.g.:
```
WARNING: DATA RACE
Read at 0x000000eb74e0 by goroutine 17:
  github.com/grafana/loki/v3/pkg/storage/chunk/client/hedging.(*winnerTrackingRoundTripper).RoundTrip()
      github.com/grafana/loki/v3/pkg/storage/chunk/client/hedging/hedging.go:160 +0xa4
  github.com/cristalhq/hedgedhttp.(*hedgedTransport).RoundTrip.func2()
      github.com/cristalhq/hedgedhttp@v0.9.1/hedged.go:211 +0xa4
  github.com/cristalhq/hedgedhttp.runInPool.func1()
      github.com/cristalhq/hedgedhttp@v0.9.1/hedged.go:305 +0x39

Previous write at 0x000000eb74e0 by goroutine 22:
  github.com/grafana/loki/v3/pkg/storage/chunk/client/hedging.initMetrics()
      github.com/grafana/loki/v3/pkg/storage/chunk/client/hedging/hedging.go:39 +0x2cf
  github.com/grafana/loki/v3/pkg/storage/chunk/client/hedging.resetMetrics()
      github.com/grafana/loki/v3/pkg/storage/chunk/client/hedging/hedging_test.go:25 +0x1f5
  github.com/grafana/loki/v3/pkg/storage/chunk/client/hedging.TestHedgingRateLimit()
      github.com/grafana/loki/v3/pkg/storage/chunk/client/hedging/hedging_test.go:64 +0x33
...

WARNING: DATA RACE
Read at 0x00c00023c750 by goroutine 17:
  github.com/prometheus/client_golang/prometheus.(*MetricVec).GetMetricWithLabelValues()
      github.com/prometheus/client_golang@v1.20.5/prometheus/vec.go:213 +0x55
  github.com/prometheus/client_golang/prometheus.(*CounterVec).GetMetricWithLabelValues()
      github.com/prometheus/client_golang@v1.20.5/prometheus/counter.go:249 +0x57
  github.com/prometheus/client_golang/prometheus.(*CounterVec).WithLabelValues()
      github.com/prometheus/client_golang@v1.20.5/prometheus/counter.go:282 +0xfb
  github.com/grafana/loki/v3/pkg/storage/chunk/client/hedging.(*winnerTrackingRoundTripper).RoundTrip()
      github.com/grafana/loki/v3/pkg/storage/chunk/client/hedging/hedging.go:160 +0x99
  github.com/cristalhq/hedgedhttp.(*hedgedTransport).RoundTrip.func2()
      github.com/cristalhq/hedgedhttp@v0.9.1/hedged.go:211 +0xa4
  github.com/cristalhq/hedgedhttp.runInPool.func1()
      github.com/cristalhq/hedgedhttp@v0.9.1/hedged.go:305 +0x39

Previous write at 0x00c00023c750 by goroutine 22:
  github.com/prometheus/client_golang/prometheus.NewMetricVec()
      github.com/prometheus/client_golang@v1.20.5/prometheus/vec.go:48 +0x175
  github.com/prometheus/client_golang/prometheus.v2.NewCounterVec()
      github.com/prometheus/client_golang@v1.20.5/prometheus/counter.go:213 +0x9d
  github.com/prometheus/client_golang/prometheus.NewCounterVec()
      github.com/prometheus/client_golang@v1.20.5/prometheus/counter.go:195 +0x2be
  github.com/grafana/loki/v3/pkg/storage/chunk/client/hedging.initMetrics()
      github.com/grafana/loki/v3/pkg/storage/chunk/client/hedging/hedging.go:39 +0x192
  github.com/grafana/loki/v3/pkg/storage/chunk/client/hedging.resetMetrics()
      github.com/grafana/loki/v3/pkg/storage/chunk/client/hedging/hedging_test.go:25 +0x1f5
  github.com/grafana/loki/v3/pkg/storage/chunk/client/hedging.TestHedgingRateLimit()
      github.com/grafana/loki/v3/pkg/storage/chunk/client/hedging/hedging_test.go:64 +0x33
...