### PR TITLE
docs: update docker-driver image reference

### DIFF
--- a/docs/sources/send-data/docker-driver/_index.md
+++ b/docs/sources/send-data/docker-driver/_index.md
@@ -24,10 +24,10 @@ the [Loki repository](https://github.com/grafana/loki/issues).
 
 The Docker plugin must be installed on each Docker host that will be running containers you want to collect logs from.
 
-Run the following command to install the plugin, updating the release version if needed:
+Run the following command to install the plugin, updating the release version, or changing the architecture (`arm64` and `amd64` are currently supported), if needed:
 
 ```bash
-docker plugin install grafana/loki-docker-driver:2.9.2 --alias loki --grant-all-permissions
+docker plugin install grafana/loki-docker-driver:3.3.2-arm64 --alias loki --grant-all-permissions
 ```
 
 {{< admonition type="note" >}}
@@ -52,12 +52,12 @@ Once you have successfully installed the plugin you can [configure](https://graf
 
 ## Upgrade the Docker driver client
 
-The upgrade process involves disabling the existing plugin, upgrading, then
+The upgrade process involves disabling the existing plugin, upgrading (chaning version and architecture as needed), then
 re-enabling and restarting Docker:
 
 ```bash
 docker plugin disable loki --force
-docker plugin upgrade loki grafana/loki-docker-driver:2.9.2 --grant-all-permissions
+docker plugin upgrade loki grafana/loki-docker-driver:3.3.2-arm64 --grant-all-permissions
 docker plugin enable loki
 systemctl restart docker
 ```


### PR DESCRIPTION
**What this PR does / why we need it**:

We are now publishing both `arm64` and `amd64` versions of the docker driver image. This PR updates the docs to reflect that.

**Which issue(s) this PR fixes**:
Re: #15318

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
