### PR TITLE
ci: remove test step from nix-ci

### DIFF
--- a/.github/workflows/nix-ci.yaml
+++ b/.github/workflows/nix-ci.yaml
@@ -18,14 +18,6 @@ jobs:
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - run: nix run --print-build-logs .#lint
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v30
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
-      - run: nix run --print-build-logs .#test
   packages:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/nix-ci.yaml
+++ b/.github/workflows/nix-ci.yaml
@@ -7,6 +7,7 @@ on:
   pull_request:
     paths:
       - "flake.nix"
+      - "flake.lock"
       - "go.mod"
       - "nix/**"
       - .github/workflows/nix-ci.yaml
@@ -33,6 +34,7 @@ jobs:
             nix:
               - 'nix/**'
               - 'flake.nix'
+              - 'flake.lock'
       - run: nix run --print-build-logs .#test
         if: steps.nix-changes.outputs.nix == 'true'
   packages:

--- a/.github/workflows/nix-ci.yaml
+++ b/.github/workflows/nix-ci.yaml
@@ -9,6 +9,7 @@ on:
       - "flake.nix"
       - "go.mod"
       - "nix/**"
+      - .github/workflows/nix-ci.yaml
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -18,6 +19,22 @@ jobs:
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - run: nix run --print-build-logs .#lint
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v30
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: dorny/paths-filter@v3
+        id: nix-changes
+        with:
+          filters: |
+            nix:
+              - 'nix/**'
+              - 'flake.nix'
+      - run: nix run --print-build-logs .#test
+        if: steps.nix-changes.outputs.nix == 'true'
   packages:
     runs-on: ubuntu-latest
     steps:

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1726560853,
-        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1728241625,
-        "narHash": "sha256-yumd4fBc/hi8a9QgA9IT8vlQuLZ2oqhkJXHPKxH/tRw=",
+        "lastModified": 1734424634,
+        "narHash": "sha256-cHar1vqHOOyC7f1+tVycPoWTfKIaqkoe1Q6TnKzuti4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c31898adf5a8ed202ce5bea9f347b1c6871f32d1",
+        "rev": "d3c42f187194c26d9f0309a8ecc469d6c878ce33",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
**What this PR does / why we need it**:

The nix tests are very hard to maintain, for 2 reasons, 1) we don't run them on every push, 2) they run in a sandbox, and things like relying on specific network interfaces are often introduced to our tests.

This PR adds a condition on the test step to only run if there have been changes to `flake.nix` or `nix/**`. This means that changes to `go.mod`, like we often see from renovate updates, will only lint and build the nix packages to make sure the changes don't break compilation, but will not run the tests. This should help the large number of renovate PRs that fail the nix test step, since I don't have the bandwidth the dig into every one of those failures.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
