### PR TITLE
fix(ci): Remove submodule once and for all

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ dist
 pkg/loki/wal
 tools/lambda-promtail/main
 
+# Submodule added by `act` CLI
+_shared-workflows-dockerhub-login
+
 # Workspaces
 *.work
 *.work.sum


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes the workflow submodule added by the GH action for Helm chart release and add the path to the gitignore file.
