### PR TITLE
test: Increase buffer size to prevent timeouts in tests

### DIFF
--- a/pkg/pattern/aggregation/push_test.go
+++ b/pkg/pattern/aggregation/push_test.go
@@ -94,6 +94,7 @@ func Test_Push(t *testing.T) {
 
 	t.Run("batches push requests", func(t *testing.T) {
 		// mock loki server
+		responses := make(chan response, 10)
 		mock := httptest.NewServer(createServerHandler(responses))
 		require.NotNil(t, mock)
 		defer mock.Close()


### PR DESCRIPTION
**What this PR does / why we need it**:
A recent [PR](https://github.com/grafana/loki/pull/15410) caused multiple occurrences of [timeouts](https://github.com/grafana/loki/actions/runs/12410129954/job/34645141970?pr=15493) in this particular test.  This PR increases the buffer size to work around this.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [X] Tests updated
- [X] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
