### PR TITLE
fix: bytes unit detection in detected fields

### DIFF
--- a/pkg/querier/queryrange/detected_fields.go
+++ b/pkg/querier/queryrange/detected_fields.go
@@ -91,6 +91,45 @@ func NewDetectedFieldsHandler(
 		})
 }
 
+type bytesUnit []string
+
+func (b bytesUnit) Contains(s string) bool {
+	for _, u := range b {
+		if strings.HasSuffix(s, u) {
+			return true
+		}
+	}
+	return false
+}
+
+var allowedBytesUnits = bytesUnit{
+	"b",
+	"kib",
+	"kb",
+	"mib",
+	"mb",
+	"gib",
+	"gb",
+	"tib",
+	"tb",
+	"pib",
+	"pb",
+	"eib",
+	"eb",
+	"ki",
+	"k",
+	"mi",
+	"m",
+	"gi",
+	"g",
+	"ti",
+	"t",
+	"pi",
+	"p",
+	"ei",
+	"e",
+}
+
 func parseDetectedFieldValues(limit uint32, streams []push.Stream, name string) []string {
 	values := map[string]struct{}{}
 	for _, stream := range streams {
@@ -116,7 +155,7 @@ func parseDetectedFieldValues(limit uint32, streams []push.Stream, name string) 
 			if vals, ok := parsedLabels[name]; ok {
 				for _, v := range vals {
 					// special case bytes values, so they can be directly inserted into a query
-					if bs, err := humanize.ParseBytes(v); err == nil {
+					if bs, err := humanize.ParseBytes(v); err == nil && allowedBytesUnits.Contains(strings.ToLower(v)) {
 						bsString := strings.Replace(humanize.Bytes(bs), " ", "", 1)
 						values[bsString] = struct{}{}
 					} else {

--- a/pkg/querier/queryrange/detected_fields_test.go
+++ b/pkg/querier/queryrange/detected_fields_test.go
@@ -1334,7 +1334,7 @@ func TestQuerier_DetectedFields(t *testing.T) {
 		lines := []push.Entry{
 			{
 				Timestamp:          now,
-				Line:               "ts=2024-09-05T15:36:38.757788067Z caller=metrics.go:66 tenant=2419 level=info bytes=1,024",
+				Line:               "ts=2024-09-05T15:36:38.757788067Z caller=metrics.go:66 tenant=2419 level=info bytes=1024",
 				StructuredMetadata: infoDetectdFiledMetadata,
 			},
 			{
@@ -1378,7 +1378,29 @@ func TestQuerier_DetectedFields(t *testing.T) {
 		require.Equal(t, []string{
 			"1.0GB",
 			"1.0MB",
-			"1.0kB",
+			"1024",
+		}, detectedFieldValues)
+
+		// does not affect other numeric values
+		request = DetectedFieldsRequest{
+			logproto.DetectedFieldsRequest{
+				Start:     time.Now().Add(-1 * time.Minute),
+				End:       time.Now(),
+				Query:     `{cluster="us-east-1"} | logfmt`,
+				LineLimit: 1000,
+				Limit:     3,
+				Values:    true,
+				Name:      "tenant",
+			},
+			"/loki/api/v1/detected_field/tenant/values",
+		}
+
+		detectedFieldValues = handleRequest(handler, request).Values
+		slices.Sort(detectedFieldValues)
+		require.Equal(t, []string{
+			"2419",
+			"29",
+			"2919",
 		}, detectedFieldValues)
 	})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

DF field values are currently turning all numeric fields into bytes, this is a bug. This fixes that bug.

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
