### PR TITLE
feat: Allow configure podDisruptionBudget

### DIFF
--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -3,7 +3,7 @@ name: loki
 description: Helm chart for Grafana Loki and Grafana Enterprise Logs supporting both simple, scalable and distributed modes.
 type: application
 appVersion: 3.3.2
-version: 6.24.0
+version: 6.24.1
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/production/helm/loki/templates/backend/poddisruptionbudget-backend.yaml
+++ b/production/helm/loki/templates/backend/poddisruptionbudget-backend.yaml
@@ -1,5 +1,4 @@
-{{- $isSimpleScalable := eq (include "loki.deployment.isScalable" .) "true" -}}
-{{- if and $isSimpleScalable (gt (int .Values.backend.replicas) 1) (not .Values.read.legacyReadTarget ) }}
+{{- if .Values.backend.PodDisruptionBudget.create}}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
@@ -11,5 +10,7 @@ spec:
   selector:
     matchLabels:
       {{- include "loki.backendSelectorLabels" . | nindent 6 }}
-  maxUnavailable: 1
+  {{- with .Values.backend.PodDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ . | default 1 }}
+  {{- end }}
 {{- end }}

--- a/production/helm/loki/templates/chunks-cache/poddisruptionbudget-chunks-cache.yaml
+++ b/production/helm/loki/templates/chunks-cache/poddisruptionbudget-chunks-cache.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.chunksCache.enabled }}
+{{- if .Values.chunksCache.PodDisruptionBudget.create }}
 apiVersion: {{ include "loki.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
@@ -12,5 +13,8 @@ spec:
     matchLabels:
       {{- include "loki.selectorLabels" . | nindent 6 }}
       app.kubernetes.io/component: memcached-chunks-cache
-  maxUnavailable: 1
-{{- end -}}
+  {{- with .Values.chunksCache.PodDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ . | default 1 }}
+  {{- end}}
+{{- end }}
+{{- end }}

--- a/production/helm/loki/templates/gateway/poddisruptionbudget-gateway.yaml
+++ b/production/helm/loki/templates/gateway/poddisruptionbudget-gateway.yaml
@@ -1,4 +1,5 @@
 {{- if and .Values.gateway.enabled }}
+{{- if and .Values.gateway.PodDisruptionBudget.create}}
 {{- if or 
   (and (not .Values.gateway.autoscaling.enabled) (gt (int .Values.gateway.replicas) 1)) 
   (and .Values.gateway.autoscaling.enabled (gt (int .Values.gateway.autoscaling.minReplicas) 1))
@@ -14,6 +15,8 @@ spec:
   selector:
     matchLabels:
       {{- include "loki.gatewaySelectorLabels" . | nindent 6 }}
-  maxUnavailable: 1
+  {{- with .Values.gateway.PodDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ . | default 1 }}
+  {{- end}}
 {{- end }}
 {{- end }}

--- a/production/helm/loki/templates/read/poddisruptionbudget-read.yaml
+++ b/production/helm/loki/templates/read/poddisruptionbudget-read.yaml
@@ -1,5 +1,4 @@
-{{- $isSimpleScalable := eq (include "loki.deployment.isScalable" .) "true" -}}
-{{- if and $isSimpleScalable (gt (int .Values.read.replicas) 1) }}
+{{- if  .Values.read.PodDisruptionBudget.create }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
@@ -11,5 +10,7 @@ spec:
   selector:
     matchLabels:
       {{- include "loki.readSelectorLabels" . | nindent 6 }}
-  maxUnavailable: 1
+  {{- with .Values.read.PodDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ . | default 1 }}
+  {{- end }}
 {{- end }}

--- a/production/helm/loki/templates/results-cache/poddisruptionbudget-results-cache.yaml
+++ b/production/helm/loki/templates/results-cache/poddisruptionbudget-results-cache.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.resultsCache.enabled }}
+{{- if .Values.resultsCache.PodDisruptionBudget.create }}
 apiVersion: {{ include "loki.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
@@ -12,5 +13,8 @@ spec:
     matchLabels:
       {{- include "loki.selectorLabels" . | nindent 6 }}
       app.kubernetes.io/component: memcached-results-cache
-  maxUnavailable: 1
-{{- end -}}
+  {{- with .Values.resultsCache.PodDisruptionBudget.maxUnavailable}}    
+  maxUnavailable: {{ . | default 1}}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/production/helm/loki/templates/write/poddisruptionbudget-write.yaml
+++ b/production/helm/loki/templates/write/poddisruptionbudget-write.yaml
@@ -1,5 +1,4 @@
-{{- $isSimpleScalable := eq (include "loki.deployment.isScalable" .) "true" -}}
-{{- if and $isSimpleScalable (gt (int .Values.write.replicas) 1) }}
+{{- if .Values.write.PodDisruptionBudget.create }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
@@ -11,5 +10,7 @@ spec:
   selector:
     matchLabels:
       {{- include "loki.writeSelectorLabels" . | nindent 6 }}
-  maxUnavailable: 1
+  {{- with .Values.write.PodDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ . | default 1 }}
+  {{- end }}
 {{- end }}

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -11,11 +11,11 @@ global:
   # -- Overrides the priorityClassName for all pods
   priorityClassName: null
   # -- configures cluster domain ("cluster.local" by default)
-  clusterDomain: "cluster.local"
+  clusterDomain: 'cluster.local'
   # -- configures DNS service name
-  dnsService: "kube-dns"
+  dnsService: 'kube-dns'
   # -- configures DNS service namespace
-  dnsNamespace: "kube-system"
+  dnsNamespace: 'kube-system'
 # -- Overrides the chart's name
 nameOverride: null
 # -- Overrides the chart's computed fullname
@@ -348,7 +348,7 @@ loki:
       disable_dualstack: false
     gcs:
       chunkBufferSize: 0
-      requestTimeout: "0s"
+      requestTimeout: '0s'
       enableHttp2: true
     azure:
       accountName: null
@@ -389,16 +389,16 @@ loki:
   memcached:
     chunk_cache:
       enabled: false
-      host: ""
-      service: "memcached-client"
+      host: ''
+      service: 'memcached-client'
       batch_size: 256
       parallelism: 10
     results_cache:
       enabled: false
-      host: ""
-      service: "memcached-client"
-      timeout: "500ms"
-      default_validity: "12h"
+      host: ''
+      service: 'memcached-client'
+      timeout: '500ms'
+      default_validity: '12h'
   # -- Check https://grafana.com/docs/loki/latest/configuration/#schema_config for more info on how to configure schemas
   schemaConfig: {}
   # -- a real Loki install requires a proper schemaConfig defined above this, however for testing or playing around
@@ -432,7 +432,7 @@ loki:
     bloom_shipper:
       working_directory: /var/loki/data/bloomshipper
     hedging:
-      at: "250ms"
+      at: '250ms'
       max_per_second: 20
       up_to: 3
   # --  Optional compactor configuration
@@ -491,13 +491,13 @@ enterprise:
   # license.jwt.
   # To set the license contents, use the flag `--set-file 'enterprise.license.contents=./license.jwt'`
   license:
-    contents: "NOTAVALIDLICENSE"
+    contents: 'NOTAVALIDLICENSE'
   # -- Set to true when providing an external license
   useExternalLicense: false
   # -- Name of external license secret to use
   externalLicenseName: null
   # -- Name of the external config secret to use
-  externalConfigName: ""
+  externalConfigName: ''
   # -- Use GEL gateway, if false will use the default nginx gateway
   gelGateway: true
   # -- If enabled, the correct admin_client storage will be configured. If disabled while running enterprise,
@@ -540,7 +540,7 @@ enterprise:
     # -- Whether the job should be part of the deployment
     enabled: true
     # -- Comma-separated list of Loki modules to load for tokengen
-    targetModule: "tokengen"
+    targetModule: 'tokengen'
     # -- Additional CLI arguments for the `tokengen` target
     extraArgs: []
     # -- Additional Kubernetes environment
@@ -568,7 +568,7 @@ enterprise:
     # -- Environment variables from secrets or configmaps to add to the tokengen pods
     extraEnvFrom: []
     # -- The name of the PriorityClass for tokengen Pods
-    priorityClassName: ""
+    priorityClassName: ''
   # -- Configuration for `provisioner` target
   provisioner:
     # -- Whether the job should be part of the deployment
@@ -639,10 +639,10 @@ test:
   enabled: true
   # -- Used to directly query the metrics endpoint of the canary for testing, this approach avoids needing prometheus for testing.
   # This in a newer approach to using prometheusAddress such that tests do not have a dependency on prometheus
-  canaryServiceAddress: "http://loki-canary:3500/metrics"
+  canaryServiceAddress: 'http://loki-canary:3500/metrics'
   # -- Address of the prometheus server to query for the test. This overrides any value set for canaryServiceAddress.
   # This is kept for backward compatibility and may be removed in future releases. Previous value was 'http://prometheus:9090'
-  prometheusAddress: ""
+  prometheusAddress: ''
   # -- Number of times to retry the test before failing
   timeout: 1m
   # -- Additional labels for the test pods
@@ -656,7 +656,7 @@ test:
     # -- Docker image repository
     repository: grafana/loki-helm-test
     # -- Overrides the image tag whose default is the chart's appVersion
-    tag: "ewelch-distributed-helm-chart-17db5ee"
+    tag: 'ewelch-distributed-helm-chart-17db5ee'
     # -- Overrides the image tag with an image digest
     digest: null
     # -- Docker image pull policy
@@ -934,6 +934,9 @@ gateway:
     #     - type: Pods
     #       value: 1
     #       periodSeconds: 180
+  podDisruptionBudget:
+    create: true
+    maxUnavailable: 1
   deploymentStrategy:
     type: RollingUpdate
   image:
@@ -1024,7 +1027,7 @@ gateway:
     # -- Specifies whether an ingress for the gateway should be created
     enabled: false
     # -- Ingress Class Name. MAY be required for Kubernetes versions >= 1.18
-    ingressClassName: ""
+    ingressClassName: ''
     # -- Annotations for the gateway ingress
     annotations: {}
     # -- Labels for the gateway ingress
@@ -1084,7 +1087,7 @@ gateway:
               '"$request" $body_bytes_sent "$http_referer" '
               '"$http_user_agent" "$http_x_forwarded_for"';
     # -- Allows appending custom configuration to the server block
-    serverSnippet: ""
+    serverSnippet: ''
     # -- Allows appending custom configuration to the http block, passed through the `tpl` function to allow templating
     httpSnippet: >-
       {{ if .Values.loki.tenants }}proxy_set_header X-Scope-OrgID $remote_user;{{ end }}
@@ -1099,7 +1102,7 @@ gateway:
     # -- Override Backend URL
     customBackendUrl: null
     # -- Allows overriding the DNS resolver address nginx will use.
-    resolver: ""
+    resolver: ''
     # -- Config file contents for Nginx. Passed through the `tpl` function to allow templating
     # @default -- See values.yaml
     file: |
@@ -1178,7 +1181,7 @@ enterpriseGateway:
 # You'll need to supply authn configuration for your ingress controller.
 ingress:
   enabled: false
-  ingressClassName: ""
+  ingressClassName: ''
   annotations: {}
   #    nginx.ingress.kubernetes.io/auth-type: basic
   #    nginx.ingress.kubernetes.io/auth-secret: loki-distributed-basic-auth
@@ -1256,7 +1259,7 @@ migrate:
     enabled: false
     # -- If migrating from a distributed service, provide the distributed deployment's
     # memberlist service DNS so the new deployment can join its ring.
-    memberlistService: ""
+    memberlistService: ''
 ######################################################################################################################
 #
 # Single Binary Deployment
@@ -1303,7 +1306,7 @@ singleBinary:
     # -- Additional labels for single binary Service
     labels: {}
   # -- Comma-separated list of Loki modules to load for the single binary
-  targetModule: "all"
+  targetModule: 'all'
   # -- Labels for single binary service
   extraArgs: []
   # -- Environment variables to add to the single binary pods
@@ -1391,6 +1394,9 @@ write:
             value: 1
             periodSeconds: 1800
         stabilizationWindowSeconds: 3600
+  podDisruptionBudget:
+    create: true
+    maxUnavailable: 1
   image:
     # -- The Docker registry for the write image. Overrides `loki.image.registry`
     registry: null
@@ -1414,7 +1420,7 @@ write:
     # -- Additional labels for write Service
     labels: {}
   # -- Comma-separated list of Loki modules to load for the write
-  targetModule: "write"
+  targetModule: 'write'
   # -- Additional CLI args for the write
   extraArgs: []
   # -- Environment variables to add to the write pods
@@ -1462,7 +1468,7 @@ write:
   # -- Tolerations for write pods
   tolerations: []
   # -- The default is to deploy all pods in parallel.
-  podManagementPolicy: "Parallel"
+  podManagementPolicy: 'Parallel'
   persistence:
     # -- Enable volume claims in pod spec
     volumeClaimsEnabled: true
@@ -1512,6 +1518,9 @@ read:
     #   - type: Pods
     #     value: 1
     #     periodSeconds: 180
+  podDisruptionBudget:
+    create: true
+    maxUnavailable: 1
   image:
     # -- The Docker registry for the read image. Overrides `loki.image.registry`
     registry: null
@@ -1535,7 +1544,7 @@ read:
     # -- Additional labels for read Service
     labels: {}
   # -- Comma-separated list of Loki modules to load for the read
-  targetModule: "read"
+  targetModule: 'read'
   # -- Whether or not to use the 2 target type simple scalable mode (read, write) or the
   # 3 target type (read, write, backend). Legacy refers to the 2 target type, so true will
   # run two targets, false will run 3 targets.
@@ -1576,7 +1585,7 @@ read:
   # -- Tolerations for read pods
   tolerations: []
   # -- The default is to deploy all pods in parallel.
-  podManagementPolicy: "Parallel"
+  podManagementPolicy: 'Parallel'
   persistence:
     # -- Enable StatefulSetAutoDeletePVC feature
     enableStatefulSetAutoDeletePVC: true
@@ -1621,6 +1630,9 @@ backend:
     #     - type: Pods
     #       value: 1
     #       periodSeconds: 180
+  podDisruptionBudget:
+    create: true
+    maxUnavailable: 1
   image:
     # -- The Docker registry for the backend image. Overrides `loki.image.registry`
     registry: null
@@ -1644,7 +1656,7 @@ backend:
     # -- Additional labels for backend Service
     labels: {}
   # -- Comma-separated list of Loki modules to load for the backend
-  targetModule: "backend"
+  targetModule: 'backend'
   # -- Additional CLI args for the backend
   extraArgs: []
   # -- Environment variables to add to the backend pods
@@ -1681,7 +1693,7 @@ backend:
   # -- Tolerations for backend pods
   tolerations: []
   # -- The default is to deploy all pods in parallel.
-  podManagementPolicy: "Parallel"
+  podManagementPolicy: 'Parallel'
   persistence:
     # -- Enable volume claims in pod spec
     volumeClaimsEnabled: true
@@ -1848,7 +1860,7 @@ ingester:
   # -- Adds the appProtocol field to the ingester service. This allows ingester to work with istio protocol selection.
   appProtocol:
     # -- Set the optional grpc service protocol. Ex: "grpc", "http2" or "https"
-    grpc: ""
+    grpc: ''
   # -- Enabling zone awareness on ingesters will create 3 statefulests where all writes will send a replica to each zone.
   # This is primarily intended to accelerate rollout operations by allowing for multiple ingesters within a single
   # zone to be shutdown and restart simultaneously (the remaining 2 zones will be guaranteed to have at least one copy
@@ -1994,7 +2006,7 @@ distributor:
   # -- Adds the appProtocol field to the distributor service. This allows distributor to work with istio protocol selection.
   appProtocol:
     # -- Set the optional grpc service protocol. Ex: "grpc", "http2" or "https"
-    grpc: ""
+    grpc: ''
 # --  Configuration for the querier
 querier:
   # -- Number of replicas for the querier
@@ -2112,7 +2124,7 @@ querier:
   # -- Adds the appProtocol field to the querier service. This allows querier to work with istio protocol selection.
   appProtocol:
     # -- Set the optional grpc service protocol. Ex: "grpc", "http2" or "https"
-    grpc: ""
+    grpc: ''
 # -- Configuration for the query-frontend
 queryFrontend:
   # -- Number of replicas for the query-frontend
@@ -2204,7 +2216,7 @@ queryFrontend:
   # -- Adds the appProtocol field to the queryFrontend service. This allows queryFrontend to work with istio protocol selection.
   appProtocol:
     # -- Set the optional grpc service protocol. Ex: "grpc", "http2" or "https"
-    grpc: ""
+    grpc: ''
 # -- Configuration for the query-scheduler
 queryScheduler:
   # -- Number of replicas for the query-scheduler.
@@ -2268,7 +2280,7 @@ queryScheduler:
   tolerations: []
   # -- Set the optional grpc service protocol. Ex: "grpc", "http2" or "https"
   appProtocol:
-    grpc: ""
+    grpc: ''
 # -- Configuration for the index-gateway
 indexGateway:
   # -- Number of replicas for the index-gateway
@@ -2353,7 +2365,7 @@ indexGateway:
     whenScaled: Retain
   # -- Set the optional grpc service protocol. Ex: "grpc", "http2" or "https"
   appProtocol:
-    grpc: ""
+    grpc: ''
   # -- UpdateStrategy for the indexGateway StatefulSet.
   updateStrategy:
     # -- One of  'OnDelete' or 'RollingUpdate'
@@ -2426,7 +2438,7 @@ compactor:
   tolerations: []
   # -- Set the optional grpc service protocol. Ex: "grpc", "http2" or "https"
   appProtocol:
-    grpc: ""
+    grpc: ''
   persistence:
     # -- Enable creating PVCs for the compactor
     enabled: false
@@ -2534,7 +2546,7 @@ bloomGateway:
   tolerations: []
   # -- Set the optional grpc service protocol. Ex: "grpc", "http2" or "https"
   appProtocol:
-    grpc: ""
+    grpc: ''
   persistence:
     # -- Enable creating PVCs for the bloom-gateway
     enabled: false
@@ -2633,7 +2645,7 @@ bloomPlanner:
   tolerations: []
   # -- Set the optional grpc service protocol. Ex: "grpc", "http2" or "https"
   appProtocol:
-    grpc: ""
+    grpc: ''
   persistence:
     # -- Enable creating PVCs for the bloom-planner
     enabled: false
@@ -2756,7 +2768,7 @@ bloomBuilder:
   # -- Adds the appProtocol field to the queryFrontend service. This allows bloomBuilder to work with istio protocol selection.
   appProtocol:
     # -- Set the optional grpc service protocol. Ex: "grpc", "http2" or "https"
-    grpc: ""
+    grpc: ''
 # -- Configuration for the pattern ingester
 patternIngester:
   # -- Number of replicas for the pattern ingester
@@ -2824,7 +2836,7 @@ patternIngester:
   tolerations: []
   # -- Set the optional grpc service protocol. Ex: "grpc", "http2" or "https"
   appProtocol:
-    grpc: ""
+    grpc: ''
   persistence:
     # -- Enable creating PVCs for the pattern ingester
     enabled: false
@@ -2949,7 +2961,7 @@ ruler:
     annotations: {}
   # -- Set the optional grpc service protocol. Ex: "grpc", "http2" or "https"
   appProtocol:
-    grpc: ""
+    grpc: ''
   # -- Directories containing rules files
   directories: {}
   # tenant_foo:
@@ -3105,6 +3117,7 @@ resultsCache:
   tolerations: []
   # -- Pod Disruption Budget
   podDisruptionBudget:
+    create: true
     maxUnavailable: 1
   # -- The name of the PriorityClass for results-cache pods
   priorityClassName: null
@@ -3122,7 +3135,7 @@ resultsCache:
   # -- Add extended options for results-cache memcached container. The format is the same as for the memcached -o/--extend flag.
   # Example:
   # extraExtendedOptions: 'tls,modern,track_sizes'
-  extraExtendedOptions: ""
+  extraExtendedOptions: ''
   # -- Additional CLI args for results-cache
   extraArgs: {}
   # -- Additional containers to be added to the results-cache pod.
@@ -3207,6 +3220,7 @@ chunksCache:
   tolerations: []
   # -- Pod Disruption Budget
   podDisruptionBudget:
+    create: true
     maxUnavailable: 1
   # -- The name of the PriorityClass for chunks-cache pods
   priorityClassName: null
@@ -3224,7 +3238,7 @@ chunksCache:
   # -- Add extended options for chunks-cache memcached container. The format is the same as for the memcached -o/--extend flag.
   # Example:
   # extraExtendedOptions: 'tls,no_hashexpand'
-  extraExtendedOptions: ""
+  extraExtendedOptions: ''
   # -- Additional CLI args for chunks-cache
   extraArgs: {}
   # -- Additional containers to be added to the chunks-cache pod.
@@ -3361,7 +3375,7 @@ sidecar:
     # -- Docker image tag
     tag: 1.28.0
     # -- Docker image sha. If empty, no sha will be used
-    sha: ""
+    sha: ''
     # -- Docker image pull policy
     pullPolicy: IfNotPresent
   # -- Resource requests and limits for the sidecar
@@ -3388,7 +3402,7 @@ sidecar:
     # -- Label that the configmaps/secrets with rules will be marked with.
     label: loki_rule
     # -- Label value that the configmaps/secrets with rules will be set to.
-    labelValue: ""
+    labelValue: ''
     # -- Folder into which the rules will be placed.
     folder: /rules
     # -- Comma separated list of namespaces. If specified, the sidecar will search for config-maps/secrets inside these namespaces.
@@ -3433,7 +3447,7 @@ monitoring:
     annotations: {}
     # -- Labels for the dashboards ConfigMap
     labels:
-      grafana_dashboard: "1"
+      grafana_dashboard: '1'
   # -- DEPRECATED Recording rules for monitoring Loki, required for some dashboards
   rules:
     # -- If enabled, create PrometheusRule resource with Loki recording rules
@@ -3510,12 +3524,12 @@ monitoring:
     # -- Tenant to use for self monitoring
     tenant:
       # -- Name of the tenant
-      name: "self-monitoring"
+      name: 'self-monitoring'
       # -- Password of the gateway for Basic auth
       password: null
       # -- Namespace to create additional tenant token secret in. Useful if your Grafana instance
       # is in a separate namespace. Token will still be created in the canary namespace.
-      secretNamespace: "{{ .Release.Namespace }}"
+      secretNamespace: '{{ .Release.Namespace }}'
     # -- DEPRECATED Grafana Agent configuration
     grafanaAgent:
       # -- DEPRECATED Controls whether to install the Grafana Agent Operator and its CRDs.


### PR DESCRIPTION
**What this PR does / why we need it**:
Enale the option to configre podDisruptionBudget to backend, chunks-cache, gateway, read, results-cache and write

**Which issue(s) this PR fixes**:
Fixes #13989
Fixes #9885
Fixes #8588

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
