### PR TITLE
Dns config support with Simple Scaleable Mode

### DIFF
--- a/production/helm/loki/templates/backend/statefulset-backend.yaml
+++ b/production/helm/loki/templates/backend/statefulset-backend.yaml
@@ -213,7 +213,7 @@ spec:
       {{- end }}
       {{- with .Values.backend.dnsConfig }}
       dnsConfig:
-        {{- tpl . $ | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.backend.nodeSelector }}
       nodeSelector:

--- a/production/helm/loki/templates/read/deployment-read.yaml
+++ b/production/helm/loki/templates/read/deployment-read.yaml
@@ -124,7 +124,7 @@ spec:
       {{- end }}
       {{- with .Values.read.dnsConfig }}
       dnsConfig:
-        {{- tpl . $ | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.read.nodeSelector }}
       nodeSelector:

--- a/production/helm/loki/templates/read/statefulset-read.yaml
+++ b/production/helm/loki/templates/read/statefulset-read.yaml
@@ -141,7 +141,7 @@ spec:
       {{- end }}
       {{- with .Values.read.dnsConfig }}
       dnsConfig:
-        {{- tpl . $ | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.read.nodeSelector }}
       nodeSelector:

--- a/production/helm/loki/templates/write/statefulset-write.yaml
+++ b/production/helm/loki/templates/write/statefulset-write.yaml
@@ -151,7 +151,7 @@ spec:
       {{- end }}
       {{- with .Values.write.dnsConfig }}
       dnsConfig:
-        {{- tpl . $ | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.write.nodeSelector }}
       nodeSelector:


### PR DESCRIPTION
**What this PR does / why we need it**:
TPL function causes the DNSconfig to be a string instead it is object as per kubernetes pod spec.
Ref: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

**Before this PR**
* Expects string
```yaml
write:
  replicas: 3
  autoscaling:
    minReplicas: 3
    enabled: true
  dnsConfig: 1.1.1.1               # <---- accepts only string
```

* Final rendered template
```yaml
.....
      affinity:
        podAntiAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
          - labelSelector:
              matchLabels:
                app.kubernetes.io/component: write
            topologyKey: kubernetes.io/hostname
      dnsConfig:
        1.1.1.1
      volumes:
        - name: config
          configMap:
            name: loki
            items:
              - key: "config.yaml"
                path: "config.yaml"
        - name: runtime-config
....
```


* try to pass correct format as per k8s spec then helm chart fails as it expects a string instead of object.
```yaml
write:
  replicas: 3
  autoscaling:
    enabled: true
    minReplicas: 3
  dnsConfig:
    nameservers:
      - 1.1.1.1
    searches:
      - .s3-outposts.me-south-1.amazonaws.com
```

```txt
$ helm template grafana/loki -f grafana-loki.yaml --debug
install.go:218: [debug] Original chart version: ""
install.go:235: [debug] CHART PATH: /home/pox/.cache/helm/repository/loki-6.24.0.tgz


Error: template: loki/templates/write/statefulset-write.yaml:154:16: executing "loki/templates/write/statefulset-write.yaml" at <.>: wrong type for value; expected string; got map[string]interface {}
helm.go:84: [debug] template: loki/templates/write/statefulset-write.yaml:154:16: executing "loki/templates/write/statefulset-write.yaml" at <.>: wrong type for value; expected string; got map[string]interface {}
```


**After PR***
* DNS Config will be object as per k8s spec as mentioned below
```yaml
write:
  replicas: 3
  autoscaling:
    enabled: true
    minReplicas: 3
  dnsConfig:
    nameservers:
      - 1.1.1.1
    searches:
      - .s3-outposts.me-south-1.amazonaws.com
```

* final rendered template
```yaml
      affinity:
        podAntiAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
          - labelSelector:
              matchLabels:
                app.kubernetes.io/component: write
            topologyKey: kubernetes.io/hostname
      dnsConfig:
        nameservers:
        - 1.1.1.1
        searches:
        - s3-outposts.me-south-1.amazonaws.com
      volumes:
        - name: config
          configMap:
            name: loki
            items:
              - key: "config.yaml"
                path: "config.yaml"
```
* final changes in the POD resolve.conf

```bash
/ $ cat /etc/resolv.conf
search default.svc.cluster.local svc.cluster.local cluster.local me-south-1.compute.internal s3-outposts.me-south-1.amazonaws.com
nameserver 10.104.0.10
nameserver 1.1.1.1
options ndots:5
```