### PR TITLE
fix(blockbuilder): copy entries returned by record decoder

### DIFF
--- a/pkg/blockbuilder/builder/builder.go
+++ b/pkg/blockbuilder/builder/builder.go
@@ -20,6 +20,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/compression"
 	"github.com/grafana/loki/v3/pkg/kafka"
 	"github.com/grafana/loki/v3/pkg/kafka/partition"
+	"github.com/grafana/loki/v3/pkg/logproto"
 	"github.com/grafana/loki/v3/pkg/storage/chunk"
 	"github.com/grafana/loki/v3/pkg/storage/config"
 	"github.com/grafana/loki/v3/pkg/storage/stores"
@@ -546,11 +547,15 @@ func (i *BlockBuilder) loadRecords(ctx context.Context, partitionID int32, offse
 				continue
 			}
 
+			// decorder reuses entries slice, so we need to copy it
+			entries := make([]logproto.Entry, len(stream.Entries))
+			copy(entries, stream.Entries)
+
 			converted = append(converted, AppendInput{
 				tenant:    record.TenantID,
 				labels:    labels,
 				labelsStr: stream.Labels,
-				entries:   stream.Entries,
+				entries:   entries,
 			})
 		}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Record decoder reuses the stream and entries slice, this would not be a problem if these entries are consumed synchronously. But the block builder buffers the entries and consumes them in batches through a channel while the decoder reuses the entries slice on each decode call.
Making a copy of the entries to avoid this problem. 

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
