### PR TITLE
feat(block-scheduler): introduce job lease and requeue expired jobs

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -236,6 +236,17 @@ block_scheduler:
   # CLI flag: -block-scheduler.max-jobs-planned-per-interval
   [max_jobs_planned_per_interval: <int> | default = 100]
 
+  job_queue:
+    # Interval to check for expired job leases
+    # CLI flag: -jobqueue.lease-expiry-check-interval
+    [lease_expiry_check_interval: <duration> | default = 1m]
+
+    # Duration after which a job lease is considered expired if the scheduler
+    # receives no updates from builders about the job. Expired jobs are
+    # re-enqueued
+    # CLI flag: -jobqueue.lease-duration
+    [lease_duration: <duration> | default = 10m]
+
 pattern_ingester:
   # Whether the pattern ingester is enabled.
   # CLI flag: -pattern-ingester.enabled

--- a/pkg/blockbuilder/scheduler/queue.go
+++ b/pkg/blockbuilder/scheduler/queue.go
@@ -1,6 +1,9 @@
 package scheduler
 
 import (
+	"context"
+	"errors"
+	"flag"
 	"fmt"
 	"sync"
 	"time"
@@ -21,6 +24,7 @@ const (
 // JobWithMetadata wraps a job with additional metadata for tracking its lifecycle
 type JobWithMetadata struct {
 	*types.Job
+
 	Priority   int
 	Status     types.JobStatus
 	StartTime  time.Time
@@ -60,21 +64,36 @@ func newJobQueueMetrics(r prometheus.Registerer) *jobQueueMetrics {
 	}
 }
 
+type JobQueueConfig struct {
+	LeaseExpiryCheckInterval time.Duration `yaml:"lease_expiry_check_interval"`
+	LeaseDuration            time.Duration `yaml:"lease_duration"`
+}
+
+func (cfg *JobQueueConfig) RegisterFlags(f *flag.FlagSet) {
+	f.DurationVar(&cfg.LeaseExpiryCheckInterval, "jobqueue.lease-expiry-check-interval", 1*time.Minute, "Interval to check for expired job leases")
+	f.DurationVar(&cfg.LeaseDuration, "jobqueue.lease-duration", 10*time.Minute, "Duration after which a job lease is considered expired if the scheduler receives no updates from builders about the job. Expired jobs are re-enqueued")
+}
+
 // JobQueue manages the queue of pending jobs and tracks their state.
 type JobQueue struct {
-	logger     log.Logger
+	cfg JobQueueConfig
+
+	mu         sync.RWMutex
 	pending    *PriorityQueue[string, *JobWithMetadata] // Jobs waiting to be processed, ordered by priority
 	inProgress map[string]*JobWithMetadata              // Jobs currently being processed
 	completed  *CircularBuffer[*JobWithMetadata]        // Last N completed jobs
 	statusMap  map[string]types.JobStatus               // Maps job ID to its current status
-	metrics    *jobQueueMetrics
-	mu         sync.RWMutex
+
+	logger  log.Logger
+	metrics *jobQueueMetrics
 }
 
 // NewJobQueue creates a new job queue instance
-func NewJobQueue(logger log.Logger, reg prometheus.Registerer) *JobQueue {
+func NewJobQueue(cfg JobQueueConfig, logger log.Logger, reg prometheus.Registerer) *JobQueue {
 	return &JobQueue{
+		cfg:    cfg,
 		logger: logger,
+
 		pending: NewPriorityQueue(
 			func(a, b *JobWithMetadata) bool {
 				return a.Priority > b.Priority // Higher priority first
@@ -86,6 +105,49 @@ func NewJobQueue(logger log.Logger, reg prometheus.Registerer) *JobQueue {
 		statusMap:  make(map[string]types.JobStatus),
 		metrics:    newJobQueueMetrics(reg),
 	}
+}
+
+func (q *JobQueue) RunLeaseExpiryChecker(ctx context.Context) {
+	ticker := time.NewTicker(q.cfg.LeaseExpiryCheckInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			level.Debug(q.logger).Log("msg", "checking for expired job leases")
+			if err := q.requeueExpiredJobs(); err != nil {
+				level.Error(q.logger).Log("msg", "failed to requeue expired jobs", "err", err)
+			}
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (q *JobQueue) requeueExpiredJobs() error {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	var multiErr error
+	for id, job := range q.inProgress {
+		if time.Since(job.UpdateTime) > q.cfg.LeaseDuration {
+			level.Warn(q.logger).Log("msg", "job lease expired. requeuing", "job", id, "update_time", job.UpdateTime, "now", time.Now())
+
+			// complete the job with expired status and re-enqueue
+			delete(q.inProgress, id)
+			q.metrics.inProgress.Dec()
+
+			job.Status = types.JobStatusExpired
+			q.addToCompletedBuffer(job)
+
+			if err := q.enqueueLockLess(job.Job, job.Priority); err != nil {
+				level.Error(q.logger).Log("msg", "failed to requeue expired job", "job", id, "err", err)
+				multiErr = errors.Join(multiErr, err)
+			}
+		}
+	}
+
+	return multiErr
 }
 
 // Exists checks if a job exists in any state and returns its status
@@ -126,8 +188,12 @@ func (q *JobQueue) Enqueue(job *types.Job, priority int) error {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 
+	return q.enqueueLockLess(job, priority)
+}
+
+func (q *JobQueue) enqueueLockLess(job *types.Job, priority int) error {
 	// Check if job already exists
-	if status, exists := q.statusMap[job.ID()]; exists {
+	if status, exists := q.statusMap[job.ID()]; exists && status != types.JobStatusExpired {
 		return fmt.Errorf("job %s already exists with status %v", job.ID(), status)
 	}
 
@@ -203,20 +269,29 @@ func (q *JobQueue) MarkComplete(id string, status types.JobStatus) {
 			level.Error(q.logger).Log("msg", "failed to remove job from pending queue", "job", id)
 		}
 		q.metrics.pending.Dec()
+	case types.JobStatusComplete:
+		level.Info(q.logger).Log("msg", "job is already complete, ignoring", "job", id)
+		return
 	default:
 		level.Error(q.logger).Log("msg", "unknown job status, cannot mark as complete", "job", id, "status", status)
+		return
 	}
 
 	jobMeta.Status = status
 	jobMeta.UpdateTime = time.Now()
 
-	// add it to the completed buffer, removing any evicted job from the statusMap
+	q.addToCompletedBuffer(jobMeta)
+}
+
+// add it to the completed buffer, removing any evicted job from the statusMap
+func (q *JobQueue) addToCompletedBuffer(jobMeta *JobWithMetadata) {
 	removal, evicted := q.completed.Push(jobMeta)
 	if evicted {
 		delete(q.statusMap, removal.ID())
 	}
-	q.statusMap[id] = status
-	q.metrics.completed.WithLabelValues(status.String()).Inc()
+
+	q.statusMap[jobMeta.ID()] = jobMeta.Status
+	q.metrics.completed.WithLabelValues(jobMeta.Status.String()).Inc()
 }
 
 // SyncJob registers a job as in-progress or updates its UpdateTime if already in progress

--- a/pkg/blockbuilder/scheduler/scheduler_test.go
+++ b/pkg/blockbuilder/scheduler/scheduler_test.go
@@ -41,7 +41,7 @@ func (m *mockOffsetManager) Commit(_ context.Context, _ int32, _ int64) error {
 }
 
 func newTestEnv(builderID string) (*testEnv, error) {
-	queue := NewJobQueue(log.NewNopLogger(), nil)
+	queue := NewJobQueue(testQueueCfg, log.NewNopLogger(), nil)
 	mockOffsetMgr := &mockOffsetManager{
 		topic:         "test-topic",
 		consumerGroup: "test-group",

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -1879,7 +1879,7 @@ func (t *Loki) initBlockScheduler() (services.Service, error) {
 
 	s, err := blockscheduler.NewScheduler(
 		t.Cfg.BlockScheduler,
-		blockscheduler.NewJobQueue(logger, prometheus.DefaultRegisterer),
+		blockscheduler.NewJobQueue(t.Cfg.BlockScheduler.JobQueueConfig, logger, prometheus.DefaultRegisterer),
 		offsetManager,
 		logger,
 		prometheus.DefaultRegisterer,


### PR DESCRIPTION
**What this PR does / why we need it**:

Introduces a job lease checker to expire jobs that have not received any updates from the builders for `-jobqueue.lease-duration`. Expired jobs are immediately re-enqueued so that this work can be assigned to another available builder.
This is helpful when a builder that picked a job is now unavailable either because it restarted, crashed or has become unresponsive, in such cases it is better to assign this work to another builder so as to not fall behind. 
 

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
