### PR TITLE
fix: Comment out metric_aggregation_enabled and metric_aggregation due to issue in Loki 3.1.2

### DIFF
--- a/cmd/loki/loki-local-config.yaml
+++ b/cmd/loki/loki-local-config.yaml
@@ -25,9 +25,6 @@ query_range:
         enabled: true
         max_size_mb: 100
 
-limits_config:
-  metric_aggregation_enabled: true
-
 schema_config:
   configs:
     - from: 2020-10-24
@@ -40,8 +37,6 @@ schema_config:
 
 pattern_ingester:
   enabled: true
-  metric_aggregation:
-    loki_address: localhost:3100
 
 ruler:
   alertmanager_url: http://localhost:9093


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR comments out the metric_aggregation_enabled and metric_aggregation options in the loki-local-config.yaml file, as these configurations are not supported in Loki 3.1.2 and cause a parsing error when used.

**Which issue(s) this PR fixes**:
Fixes #15567

**Special notes for your reviewer**:

The commented-out configurations align the example configuration file with the behavior of Loki 3.1.2 to prevent confusion and errors for users attempting to use unsupported settings.


**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
