### PR TITLE
fix(block-scheduler): one job per partition (local branch copy)

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -232,10 +232,6 @@ block_scheduler:
   # CLI flag: -block-scheduler.target-record-count
   [target_record_count: <int> | default = 1000]
 
-  # Maximum number of jobs that the planner can return.
-  # CLI flag: -block-scheduler.max-jobs-planned-per-interval
-  [max_jobs_planned_per_interval: <int> | default = 100]
-
   job_queue:
     # Interval to check for expired job leases
     # CLI flag: -jobqueue.lease-expiry-check-interval

--- a/pkg/blockbuilder/scheduler/scheduler.go
+++ b/pkg/blockbuilder/scheduler/scheduler.go
@@ -263,7 +263,7 @@ func (s *BlockScheduler) HandleCompleteJob(ctx context.Context, job *types.Job, 
 				return jobs[i].Job.Partition() >= job.Partition()
 			})
 
-			if nextJob < len(jobs) {
+			if nextJob < len(jobs) && jobs[nextJob].Job.Partition() == job.Partition() {
 				_, _, _ = s.idempotentEnqueue(jobs[nextJob])
 			}
 

--- a/pkg/blockbuilder/scheduler/scheduler.go
+++ b/pkg/blockbuilder/scheduler/scheduler.go
@@ -25,13 +25,12 @@ var (
 )
 
 type Config struct {
-	ConsumerGroup             string         `yaml:"consumer_group"`
-	Interval                  time.Duration  `yaml:"interval"`
-	LookbackPeriod            time.Duration  `yaml:"lookback_period"`
-	Strategy                  string         `yaml:"strategy"`
-	TargetRecordCount         int64          `yaml:"target_record_count"`
-	MaxJobsPlannedPerInterval int            `yaml:"max_jobs_planned_per_interval"`
-	JobQueueConfig            JobQueueConfig `yaml:"job_queue"`
+	ConsumerGroup     string         `yaml:"consumer_group"`
+	Interval          time.Duration  `yaml:"interval"`
+	LookbackPeriod    time.Duration  `yaml:"lookback_period"`
+	Strategy          string         `yaml:"strategy"`
+	TargetRecordCount int64          `yaml:"target_record_count"`
+	JobQueueConfig    JobQueueConfig `yaml:"job_queue"`
 }
 
 func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
@@ -55,12 +54,6 @@ func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 			"Target record count used by the planner to plan jobs. Only used when strategy is %s",
 			RecordCountStrategy,
 		),
-	)
-	f.IntVar(
-		&cfg.MaxJobsPlannedPerInterval,
-		prefix+"max-jobs-planned-per-interval",
-		100,
-		"Maximum number of jobs that the planner can return.",
 	)
 	cfg.JobQueueConfig.RegisterFlags(f)
 }
@@ -155,7 +148,7 @@ func (s *BlockScheduler) runOnce(ctx context.Context) error {
 
 	s.publishLagMetrics(lag)
 
-	jobs, err := s.planner.Plan(ctx, s.cfg.MaxJobsPlannedPerInterval)
+	jobs, err := s.planner.Plan(ctx, 1) // TODO(owen-d): parallelize work within a partition
 	if err != nil {
 		level.Error(s.logger).Log("msg", "failed to plan jobs", "err", err)
 	}

--- a/pkg/blockbuilder/scheduler/scheduler.go
+++ b/pkg/blockbuilder/scheduler/scheduler.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -156,25 +157,10 @@ func (s *BlockScheduler) runOnce(ctx context.Context) error {
 	for _, job := range jobs {
 		// TODO: end offset keeps moving each time we plan jobs, maybe we should not use it as part of the job ID
 
-		logger := log.With(
-			s.logger,
-			"job", job.Job.ID(),
-			"priority", job.Priority,
-		)
+		added, status, err := s.idempotentEnqueue(job)
 
-		status, ok := s.queue.Exists(job.Job)
-
-		// scheduler is unaware of incoming job; enqueue
-		if !ok {
-			level.Debug(logger).Log(
-				"msg", "job does not exist, enqueueing",
-			)
-
-			// enqueue
-			if err := s.queue.Enqueue(job.Job, job.Priority); err != nil {
-				level.Error(logger).Log("msg", "failed to enqueue job", "err", err)
-			}
-
+		// if we've either added or encountered an error, move on; we're done this cycle
+		if added || err != nil {
 			continue
 		}
 
@@ -225,6 +211,34 @@ func (s *BlockScheduler) HandleGetJob(ctx context.Context) (*types.Job, bool, er
 	}
 }
 
+// if added is true, the job was added to the queue, otherwise status is the current status of the job
+func (s *BlockScheduler) idempotentEnqueue(job *JobWithMetadata) (added bool, status types.JobStatus, err error) {
+	logger := log.With(
+		s.logger,
+		"job", job.Job.ID(),
+		"priority", job.Priority,
+	)
+
+	status, ok := s.queue.Exists(job.Job)
+
+	// scheduler is unaware of incoming job; enqueue
+	if !ok {
+		level.Debug(logger).Log(
+			"msg", "job does not exist, enqueueing",
+		)
+
+		// enqueue
+		if err := s.queue.Enqueue(job.Job, job.Priority); err != nil {
+			level.Error(logger).Log("msg", "failed to enqueue job", "err", err)
+			return false, types.JobStatusUnknown, err
+		}
+
+		return true, types.JobStatusPending, nil
+	}
+
+	return false, status, nil
+}
+
 func (s *BlockScheduler) HandleCompleteJob(ctx context.Context, job *types.Job, success bool) (err error) {
 	logger := log.With(s.logger, "job", job.ID())
 
@@ -236,6 +250,23 @@ func (s *BlockScheduler) HandleCompleteJob(ctx context.Context, job *types.Job, 
 		); err == nil {
 			s.queue.MarkComplete(job.ID(), types.JobStatusComplete)
 			level.Info(logger).Log("msg", "job completed successfully")
+
+			// TODO(owen-d): cleaner way to enqueue next job for this partition,
+			// don't make it part of the response cycle to job completion, etc.
+			jobs, err := s.planner.Plan(ctx, 1)
+			if err != nil {
+				level.Error(logger).Log("msg", "failed to plan subsequent jobs", "err", err)
+			}
+
+			// find first job for this partition
+			nextJob := sort.Search(len(jobs), func(i int) bool {
+				return jobs[i].Job.Partition() >= job.Partition()
+			})
+
+			if nextJob < len(jobs) {
+				_, _, _ = s.idempotentEnqueue(jobs[nextJob])
+			}
+
 			return nil
 		}
 


### PR DESCRIPTION
*Local branch copy of* https://github.com/grafana/loki/pull/15578 to debug possible fork permission issues

* Removes `max_jobs_planned_per_interval`. We don't want this yet and it was being used incorrectly as the planners `maxJobsPerPartition` argument.
* Hardcodes one job per partition during planning
* enqueues the next job for some partition when the current one finishes.

Some of it is a bit hacky & will need refactoring, but this should work well enough in the meantime to flesh out issues.