### PR TITLE
feat(logcli): Include common labels

### DIFF
--- a/cmd/logcli/main.go
+++ b/cmd/logcli/main.go
@@ -597,6 +597,7 @@ func newQuery(instant bool, cmd *kingpin.CmdClause) *query.Query {
 	cmd.Flag("no-labels", "Do not print any labels").Default("false").BoolVar(&q.NoLabels)
 	cmd.Flag("exclude-label", "Exclude labels given the provided key during output.").StringsVar(&q.IgnoreLabelsKey)
 	cmd.Flag("include-label", "Include labels given the provided key during output.").StringsVar(&q.ShowLabelsKey)
+	cmd.Flag("include-common-labels", "Include common labels in the main output.").BoolVar(&q.IncludeCommonLabels)
 	cmd.Flag("labels-length", "Set a fixed padding to labels").Default("0").IntVar(&q.FixedLabelsLen)
 	cmd.Flag("store-config", "Execute the current query using a configured storage from a given Loki configuration file.").Default("").StringVar(&q.LocalConfig)
 	cmd.Flag("remote-schema", "Execute the current query using a remote schema retrieved from the configured -schema-store.").Default("false").BoolVar(&q.FetchSchemaFromStorage)

--- a/cmd/logcli/main.go
+++ b/cmd/logcli/main.go
@@ -597,7 +597,7 @@ func newQuery(instant bool, cmd *kingpin.CmdClause) *query.Query {
 	cmd.Flag("no-labels", "Do not print any labels").Default("false").BoolVar(&q.NoLabels)
 	cmd.Flag("exclude-label", "Exclude labels given the provided key during output.").StringsVar(&q.IgnoreLabelsKey)
 	cmd.Flag("include-label", "Include labels given the provided key during output.").StringsVar(&q.ShowLabelsKey)
-	cmd.Flag("include-common-labels", "Include common labels in the main output.").BoolVar(&q.IncludeCommonLabels)
+	cmd.Flag("include-common-labels", "Include common labels in output for each log line.").BoolVar(&q.IncludeCommonLabels).Default("false")
 	cmd.Flag("labels-length", "Set a fixed padding to labels").Default("0").IntVar(&q.FixedLabelsLen)
 	cmd.Flag("store-config", "Execute the current query using a configured storage from a given Loki configuration file.").Default("").StringVar(&q.LocalConfig)
 	cmd.Flag("remote-schema", "Execute the current query using a remote schema retrieved from the configured -schema-store.").Default("false").BoolVar(&q.FetchSchemaFromStorage)

--- a/cmd/logcli/main.go
+++ b/cmd/logcli/main.go
@@ -597,7 +597,7 @@ func newQuery(instant bool, cmd *kingpin.CmdClause) *query.Query {
 	cmd.Flag("no-labels", "Do not print any labels").Default("false").BoolVar(&q.NoLabels)
 	cmd.Flag("exclude-label", "Exclude labels given the provided key during output.").StringsVar(&q.IgnoreLabelsKey)
 	cmd.Flag("include-label", "Include labels given the provided key during output.").StringsVar(&q.ShowLabelsKey)
-	cmd.Flag("include-common-labels", "Include common labels in output for each log line.").BoolVar(&q.IncludeCommonLabels).Default("false")
+	cmd.Flag("include-common-labels", "Include common labels in output for each log line.").Default("false").BoolVar(&q.IncludeCommonLabels)
 	cmd.Flag("labels-length", "Set a fixed padding to labels").Default("0").IntVar(&q.FixedLabelsLen)
 	cmd.Flag("store-config", "Execute the current query using a configured storage from a given Loki configuration file.").Default("").StringVar(&q.LocalConfig)
 	cmd.Flag("remote-schema", "Execute the current query using a remote schema retrieved from the configured -schema-store.").Default("false").BoolVar(&q.FetchSchemaFromStorage)

--- a/pkg/logcli/index/volume.go
+++ b/pkg/logcli/index/volume.go
@@ -24,7 +24,7 @@ func GetVolumeRange(q *volume.Query, c client.Client, out output.LogOutput, stat
 func do(q *volume.Query, rangeQuery bool, c client.Client, out output.LogOutput, statistics bool) {
 	resp := getVolume(q, rangeQuery, c)
 
-	resultsPrinter := print.NewQueryResultPrinter(nil, nil, q.Quiet, 0, false)
+	resultsPrinter := print.NewQueryResultPrinter(nil, nil, q.Quiet, 0, false, false)
 
 	if statistics {
 		resultsPrinter.PrintStats(resp.Data.Statistics)

--- a/pkg/logcli/print/print.go
+++ b/pkg/logcli/print/print.go
@@ -19,20 +19,22 @@ import (
 )
 
 type QueryResultPrinter struct {
-	ShowLabelsKey   []string
-	IgnoreLabelsKey []string
-	Quiet           bool
-	FixedLabelsLen  int
-	Forward         bool
+	ShowLabelsKey       []string
+	IgnoreLabelsKey     []string
+	Quiet               bool
+	FixedLabelsLen      int
+	Forward             bool
+	IncludeCommonLabels bool
 }
 
-func NewQueryResultPrinter(showLabelsKey []string, ignoreLabelsKey []string, quiet bool, fixedLabelsLen int, forward bool) *QueryResultPrinter {
+func NewQueryResultPrinter(showLabelsKey []string, ignoreLabelsKey []string, quiet bool, fixedLabelsLen int, forward bool, includeCommonLabels bool) *QueryResultPrinter {
 	return &QueryResultPrinter{
-		ShowLabelsKey:   showLabelsKey,
-		IgnoreLabelsKey: ignoreLabelsKey,
-		Quiet:           quiet,
-		FixedLabelsLen:  fixedLabelsLen,
-		Forward:         forward,
+		ShowLabelsKey:       showLabelsKey,
+		IgnoreLabelsKey:     ignoreLabelsKey,
+		Quiet:               quiet,
+		FixedLabelsLen:      fixedLabelsLen,
+		Forward:             forward,
+		IncludeCommonLabels: includeCommonLabels,
 	}
 }
 
@@ -83,8 +85,11 @@ func (r *QueryResultPrinter) printStream(streams loghttp.Streams, out output.Log
 	// calculate the max labels length
 	maxLabelsLen := r.FixedLabelsLen
 	for i, s := range streams {
+		ls := s.Labels
 		// Remove common labels
-		ls := subtract(s.Labels, common)
+		if !r.IncludeCommonLabels {
+			ls = subtract(s.Labels, common)
+		}
 
 		if len(r.ShowLabelsKey) > 0 {
 			ls = matchLabels(true, ls, r.ShowLabelsKey)

--- a/pkg/logcli/query/query.go
+++ b/pkg/logcli/query/query.go
@@ -50,6 +50,7 @@ type Query struct {
 	NoLabels               bool
 	IgnoreLabelsKey        []string
 	ShowLabelsKey          []string
+	IncludeCommonLabels    bool
 	FixedLabelsLen         int
 	ColoredOutput          bool
 	LocalConfig            string
@@ -118,7 +119,7 @@ func (q *Query) DoQuery(c client.Client, out output.LogOutput, statistics bool) 
 		out = out.WithWriter(partFile)
 	}
 
-	result := print.NewQueryResultPrinter(q.ShowLabelsKey, q.IgnoreLabelsKey, q.Quiet, q.FixedLabelsLen, q.Forward)
+	result := print.NewQueryResultPrinter(q.ShowLabelsKey, q.IgnoreLabelsKey, q.Quiet, q.FixedLabelsLen, q.Forward, q.IncludeCommonLabels)
 
 	if q.isInstant() {
 		resp, err = c.Query(q.QueryString, q.Limit, q.Start, d, q.Quiet)
@@ -523,7 +524,7 @@ func (q *Query) DoLocalQuery(out output.LogOutput, statistics bool, orgID string
 		return err
 	}
 
-	resPrinter := print.NewQueryResultPrinter(q.ShowLabelsKey, q.IgnoreLabelsKey, q.Quiet, q.FixedLabelsLen, q.Forward)
+	resPrinter := print.NewQueryResultPrinter(q.ShowLabelsKey, q.IgnoreLabelsKey, q.Quiet, q.FixedLabelsLen, q.Forward, q.IncludeCommonLabels)
 	if statistics {
 		resPrinter.PrintStats(result.Statistics)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a new `--include-common-labels` flag to `logcli query`, which causes the output to include all common labels.

This is mostly useful with `--quiet` and `--output=jsonl` as it allows users to get structured information from Loki that has *all* the information that Loki can provide.

**Which issue(s) this PR fixes**:
Fixes #5702

**Special notes for your reviewer**:

- The suggestion on the PR was `--all-labels`. Given there are other label selection options, I thought it was easiest to add something to directly control the behaviour to remove common labels.
- I have not written tests, but I have verified that it works locally

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
