### PR TITLE
fix(blockbuilder): use index path prefix in objectclient for tsdb creation

### DIFF
--- a/pkg/blockbuilder/builder/storage.go
+++ b/pkg/blockbuilder/builder/storage.go
@@ -44,10 +44,11 @@ func NewMultiStore(
 		if err != nil {
 			return nil, fmt.Errorf("creating object client for period %s: %w ", periodicConfig.From, err)
 		}
+		prefixed := client.NewPrefixedObjectClient(objectClient, periodicConfig.IndexTables.PathPrefix)
 		store.stores = append(store.stores, &storeEntry{
 			start:        periodicConfig.From.Time,
 			cfg:          periodicConfig,
-			objectClient: objectClient,
+			objectClient: prefixed,
 		})
 	}
 	return store, nil


### PR DESCRIPTION
Fixes an issue where we wrote indices one "level" up, e.g. we'd write `bucket/index_1000/$file.tsdb` instead of `bucket/index/index_1000/$file.tsdb`. This must be consistent across components and this snuck through because different code paths are used for index uploads in the blockbuilder vs index shipper. It's not worth the heavy refactoring to align these considering this is a stopgap while we introduce new format(s) in the builder/scheduler architecture.