### PR TITLE
chore(dataobj): add Dataset with iteration and sorting support

### DIFF
--- a/pkg/dataobj/internal/dataset/dataset.go
+++ b/pkg/dataobj/internal/dataset/dataset.go
@@ -1,3 +1,82 @@
 // Package dataset contains utilities for working with datasets. Datasets hold
 // columnar data across multiple pages.
 package dataset
+
+import (
+	"context"
+
+	"github.com/grafana/loki/v3/pkg/dataobj/internal/result"
+)
+
+// A Dataset holds a collection of [Columns], each of which is split into a set
+// of [Pages] and further split into a sequence of [Values].
+//
+// Dataset is read-only; callers must not modify any of the values returned by
+// methods in Dataset.
+type Dataset interface {
+	// ListColumns returns the set of [Column]s in the Dataset. The order of
+	// Columns in the returned sequence must be consistent across calls.
+	ListColumns(ctx context.Context) result.Seq[Column]
+
+	// ListPages retrieves a set of [Pages] given a list of [Column]s.
+	// Implementations of Dataset may use ListPages to optimize for batch reads.
+	// The order of [Pages] in the returned sequence must match the order of the
+	// columns argument.
+	ListPages(ctx context.Context, columns []Column) result.Seq[Pages]
+
+	// ReadPages returns the set of [PageData] for the specified slice of pages.
+	// Implementations of Dataset may use ReadPages to optimize for batch reads.
+	// The order of [PageData] in the returned sequence must match the order of
+	// the pages argument.
+	ReadPages(ctx context.Context, pages []Page) result.Seq[PageData]
+}
+
+// FromMemory returns an in-memory [Dataset] from the given list of
+// [MemColumn]s.
+func FromMemory(columns []*MemColumn) Dataset {
+	return memDataset(columns)
+}
+
+type memDataset []*MemColumn
+
+func (d memDataset) ListColumns(_ context.Context) result.Seq[Column] {
+	return result.Iter(func(yield func(Column) bool) error {
+		for _, c := range d {
+			if !yield(c) {
+				return nil
+			}
+		}
+
+		return nil
+	})
+}
+
+func (d memDataset) ListPages(ctx context.Context, columns []Column) result.Seq[Pages] {
+	return result.Iter(func(yield func(Pages) bool) error {
+		for _, c := range columns {
+			pages, err := result.Collect(c.ListPages(ctx))
+			if err != nil {
+				return err
+			} else if !yield(Pages(pages)) {
+				return nil
+			}
+		}
+
+		return nil
+	})
+}
+
+func (d memDataset) ReadPages(ctx context.Context, pages []Page) result.Seq[PageData] {
+	return result.Iter(func(yield func(PageData) bool) error {
+		for _, p := range pages {
+			data, err := p.ReadPage(ctx)
+			if err != nil {
+				return err
+			} else if !yield(data) {
+				return nil
+			}
+		}
+
+		return nil
+	})
+}

--- a/pkg/dataobj/internal/dataset/dataset_iter.go
+++ b/pkg/dataobj/internal/dataset/dataset_iter.go
@@ -1,0 +1,112 @@
+package dataset
+
+import (
+	"context"
+	"math"
+
+	"github.com/grafana/loki/v3/pkg/dataobj/internal/result"
+)
+
+// Iter iterates over the rows for the given list of columns. Each [Row] in the
+// returned sequence will only contain values for the columns matching the
+// columns argument. Values in each row match the order of the columns argument
+// slice.
+//
+// Iter lazily fetches pages as needed.
+func Iter(ctx context.Context, columns []Column) result.Seq[Row] {
+	// TODO(rfratto): Iter is insufficient for reading at scale:
+	//
+	// * Pages are lazily fetched one at a time, which would cause many round
+	//   trips to the underlying storage.
+	//
+	// * There's no support for filtering at the page or row level, meaning we
+	//   may overfetch data.
+	//
+	// The current implementation is acceptable only for in-memory Datasets. A
+	// more efficient implementation is needed for reading Datasets backed by
+	// object storage.
+
+	totalRows := math.MinInt64
+	for _, col := range columns {
+		totalRows = max(totalRows, col.ColumnInfo().RowsCount)
+	}
+
+	type pullColumnIter struct {
+		Next func() (result.Result[Value], bool)
+		Stop func()
+	}
+
+	return result.Iter(func(yield func(Row) bool) error {
+		// Create pull-based iters for all of our columns; this will allow us to
+		// get one value at a time per column.
+		pullColumns := make([]pullColumnIter, 0, len(columns))
+		for _, col := range columns {
+			pages, err := result.Collect(col.ListPages(ctx))
+			if err != nil {
+				return err
+			}
+
+			next, stop := result.Pull(lazyColumnIter(ctx, col.ColumnInfo(), pages))
+			pullColumns = append(pullColumns, pullColumnIter{Next: next, Stop: stop})
+		}
+
+		// Start emitting rows; each row is composed of the next value from all of
+		// our columns. If a column ends early, it's left as the zero [Value],
+		// corresponding to a NULL.
+		for rowIndex := 0; rowIndex < totalRows; rowIndex++ {
+			rowValues := make([]Value, len(pullColumns))
+
+			for i, column := range pullColumns {
+				res, ok := column.Next()
+				value, err := res.Value()
+				if !ok {
+					continue
+				} else if err != nil {
+					return err
+				}
+
+				rowValues[i] = value
+			}
+
+			row := Row{Index: rowIndex, Values: rowValues}
+			if !yield(row) {
+				return nil
+			}
+		}
+
+		return nil
+	})
+}
+
+func lazyColumnIter(ctx context.Context, column *ColumnInfo, pages []Page) result.Seq[Value] {
+	return result.Iter(func(yield func(Value) bool) error {
+		for _, page := range pages {
+			pageData, err := page.ReadPage(ctx)
+			if err != nil {
+				return err
+			}
+			memPage := &MemPage{
+				Info: *page.PageInfo(),
+				Data: pageData,
+			}
+
+			for result := range iterMemPage(memPage, column.Type, column.Compression) {
+				val, err := result.Value()
+				if err != nil {
+					return err
+				} else if !yield(val) {
+					return nil
+				}
+			}
+		}
+
+		return nil
+	})
+}
+
+// A Row in a Dataset is a set of values across multiple columns with the same
+// row number.
+type Row struct {
+	Index  int     // Index of the row in the dataset.
+	Values []Value // Values for the row, one per [Column].
+}

--- a/pkg/dataobj/internal/dataset/dataset_sort.go
+++ b/pkg/dataobj/internal/dataset/dataset_sort.go
@@ -1,0 +1,173 @@
+package dataset
+
+import (
+	"context"
+	"fmt"
+	"slices"
+
+	"github.com/grafana/loki/v3/pkg/dataobj/internal/result"
+)
+
+// Sort returns a new Dataset with rows sorted by the given sortBy columns in
+// ascending order. The order of columns in the new Dataset will match the
+// order in set. pageSizeHint specifies the page size to target for newly
+// created pages.
+//
+// If sortBy is empty or if the columns in sortBy contain no rows, Sort returns
+// set.
+func Sort(ctx context.Context, set Dataset, sortBy []Column, pageSizeHint int) (Dataset, error) {
+	if len(sortBy) == 0 {
+		return set, nil
+	}
+
+	// First, we need to know the final sort over of entries in sortBy. Then, we
+	// sort the rows by sortBy.
+	var sortedRows []Row
+	for ent := range Iter(ctx, sortBy) {
+		row, err := ent.Value()
+		if err != nil {
+			return nil, fmt.Errorf("iterating over existing dataset: %w", err)
+		} else if len(row.Values) != len(sortBy) {
+			return nil, fmt.Errorf("row column mismatch: expected %d, got %d", len(sortBy), len(row.Values))
+		}
+		sortedRows = append(sortedRows, row)
+	}
+
+	if len(sortedRows) == 0 {
+		// Empty dataset; nothing to sort.
+		return set, nil
+	}
+
+	// Order sortedRows in the proper order. After this, sortRows[0] correponds
+	// to what should be the new first row, while sortRows[0].Index tells us what
+	// its original index (in the unsorted Dataset) was.
+	slices.SortStableFunc(sortedRows, func(a, b Row) int {
+		for i, aValue := range a.Values {
+			if i >= len(b.Values) {
+				// a.Values and b.Values are always be the same length, but we check
+				// here anyways to avoid a panic.
+				break
+			}
+			bValue := b.Values[i]
+
+			// We return the first non-zero comparison result. Otherwise, the rows
+			// are equal (in terms of sortBy).
+			switch CompareValues(aValue, bValue) {
+			case -1:
+				return -1
+			case 1:
+				return 1
+			}
+		}
+
+		return 0
+	})
+
+	origColumns, err := result.Collect(set.ListColumns(ctx))
+	if err != nil {
+		return nil, fmt.Errorf("listing columns: %w", err)
+	}
+
+	newColumns := make([]*MemColumn, 0, len(origColumns))
+	for _, origColumn := range origColumns {
+		origInfo := origColumn.ColumnInfo()
+		pages, err := result.Collect(origColumn.ListPages(ctx))
+		if err != nil {
+			return nil, fmt.Errorf("getting pages: %w", err)
+		} else if len(pages) == 0 {
+			return nil, fmt.Errorf("unexpected column with no pages")
+		}
+
+		newColumn, err := NewColumnBuilder(origInfo.Name, BuilderOptions{
+			PageSizeHint: pageSizeHint,
+			Value:        origInfo.Type,
+			Compression:  origInfo.Compression,
+
+			// TODO(rfratto): This only works now as all pages have the same
+			// encoding. If we add support for mixed encoding we'll need to do
+			// something different here.
+			Encoding: pages[0].PageInfo().Encoding,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("creating new column: %w", err)
+		}
+
+		// newColumn becomes populated in sorted order by populating row 0 from
+		// sortedRows[0].Index, row 1 from sortedRows[1].Index, and so on.
+		//
+		// While sortedRows contains all rows across the columns to sort by,
+		// columns to sort by have a smaller memory footprint than other columns
+		// (for example, loading the entire set of timestamps is far smaller than
+		// the entire set of log lines).
+		//
+		// To minimize the memory overhead of sorting, we only collect values from
+		// a single page at a time. This is more memory-efficient, but comes at the
+		// cost of more page reads for very unsorted data.
+		var (
+			curPage       Page    // Current page for iteration.
+			curPageValues []Value // Values in the current page.
+		)
+		for i, sortRow := range sortedRows {
+			// To avoid re-reading pages for every row to sort, we cache the most
+			// recent nextPage and its values. This way we only need to read a
+			// nextPage once sortRow crosses over to a new nextPage.
+			//
+			// If origColumn is shorter than other columns in set, pageForRow will
+			// return (nil, -1), indicating that the row isn't available in the
+			// column. In case, we want to append the zero [Value] to denote a NULL.
+			nextPage, rowInPage := pageForRow(pages, sortRow.Index)
+			if nextPage != nil && nextPage != curPage {
+				curPage = nextPage
+
+				data, err := curPage.ReadPage(ctx)
+				if err != nil {
+					return nil, fmt.Errorf("getting page data: %w", err)
+				}
+
+				memPage := &MemPage{
+					Info: *curPage.PageInfo(),
+					Data: data,
+				}
+				curPageValues, err = result.Collect(iterMemPage(memPage, origInfo.Type, origInfo.Compression))
+				if err != nil {
+					return nil, fmt.Errorf("reading page: %w", err)
+				}
+			}
+
+			var value Value
+			if rowInPage != -1 {
+				value = curPageValues[rowInPage]
+			}
+
+			if err := newColumn.Append(i, value); err != nil {
+				return nil, fmt.Errorf("appending value: %w", err)
+			}
+		}
+
+		memColumn, err := newColumn.Flush()
+		if err != nil {
+			return nil, fmt.Errorf("flushing column: %w", err)
+		}
+		newColumns = append(newColumns, memColumn)
+	}
+
+	return FromMemory(newColumns), nil
+}
+
+// pageForRow returns the page that contains the provided column row number
+// along with the relative row number for that page.
+func pageForRow(pages []Page, row int) (Page, int) {
+	startRow := 0
+
+	for _, page := range pages {
+		info := page.PageInfo()
+
+		if row >= startRow && row < startRow+info.RowCount {
+			return page, row - startRow
+		}
+
+		startRow += info.RowCount
+	}
+
+	return nil, -1
+}

--- a/pkg/dataobj/internal/dataset/dataset_sort_test.go
+++ b/pkg/dataobj/internal/dataset/dataset_sort_test.go
@@ -1,0 +1,143 @@
+package dataset_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/dataobj/internal/dataset"
+	"github.com/grafana/loki/v3/pkg/dataobj/internal/metadata/datasetmd"
+	"github.com/grafana/loki/v3/pkg/dataobj/internal/result"
+)
+
+func TestSort(t *testing.T) {
+	var (
+		in     = []int64{1, 5, 3, 2, 9, 6, 8, 4, 7}
+		expect = []int64{1, 2, 3, 4, 5, 6, 7, 8, 9}
+	)
+
+	colBuilder, err := dataset.NewColumnBuilder("", dataset.BuilderOptions{
+		PageSizeHint: 1, // Generate a ton of pages.
+
+		Value:       datasetmd.VALUE_TYPE_INT64,
+		Encoding:    datasetmd.ENCODING_TYPE_DELTA,
+		Compression: datasetmd.COMPRESSION_TYPE_NONE,
+	})
+	require.NoError(t, err)
+
+	for i, v := range in {
+		require.NoError(t, colBuilder.Append(i, dataset.Int64Value(v)))
+	}
+	col, err := colBuilder.Flush()
+	require.NoError(t, err)
+
+	dset := dataset.FromMemory([]*dataset.MemColumn{col})
+	dset, err = dataset.Sort(context.Background(), dset, []dataset.Column{col}, 1024)
+	require.NoError(t, err)
+
+	newColumns, err := result.Collect(dset.ListColumns(context.Background()))
+	require.NoError(t, err)
+
+	var actual []int64
+	for entry := range dataset.Iter(context.Background(), newColumns) {
+		row, err := entry.Value()
+		require.NoError(t, err)
+		require.Equal(t, len(actual), row.Index)
+		require.Len(t, row.Values, 1)
+		require.Equal(t, datasetmd.VALUE_TYPE_INT64, row.Values[0].Type())
+
+		actual = append(actual, row.Values[0].Int64())
+	}
+	require.Equal(t, expect, actual)
+}
+
+func TestSort_MultipleFields(t *testing.T) {
+	type Person struct {
+		Name     string
+		Age      int
+		Location string
+	}
+	people := []Person{
+		{"Bob", 25, "New York"},
+		{"David", 35, "Chicago"},
+		{"Eve", 30, "Los Angeles"},
+		{"Alice", 30, "San Francisco"},
+		{"Charlie", 40, ""}, // Ensure NULLs are handled properly in sorting.
+	}
+
+	nameBuilder, err := dataset.NewColumnBuilder("name", dataset.BuilderOptions{
+		Value:       datasetmd.VALUE_TYPE_STRING,
+		Encoding:    datasetmd.ENCODING_TYPE_PLAIN,
+		Compression: datasetmd.COMPRESSION_TYPE_NONE,
+	})
+	require.NoError(t, err)
+
+	ageBuilder, err := dataset.NewColumnBuilder("age", dataset.BuilderOptions{
+		Value:       datasetmd.VALUE_TYPE_INT64,
+		Encoding:    datasetmd.ENCODING_TYPE_DELTA,
+		Compression: datasetmd.COMPRESSION_TYPE_NONE,
+	})
+	require.NoError(t, err)
+
+	locationBuilder, err := dataset.NewColumnBuilder("location", dataset.BuilderOptions{
+		Value:       datasetmd.VALUE_TYPE_STRING,
+		Encoding:    datasetmd.ENCODING_TYPE_PLAIN,
+		Compression: datasetmd.COMPRESSION_TYPE_NONE,
+	})
+	require.NoError(t, err)
+
+	for i, p := range people {
+		require.NoError(t, nameBuilder.Append(i, dataset.StringValue(p.Name)))
+		require.NoError(t, ageBuilder.Append(i, dataset.Int64Value(int64(p.Age))))
+		require.NoError(t, locationBuilder.Append(i, dataset.StringValue(p.Location)))
+	}
+
+	nameCol, err := nameBuilder.Flush()
+	require.NoError(t, err)
+	ageCol, err := ageBuilder.Flush()
+	require.NoError(t, err)
+	locationCol, err := locationBuilder.Flush()
+	require.NoError(t, err)
+
+	dset := dataset.FromMemory([]*dataset.MemColumn{nameCol, ageCol, locationCol})
+	dset, err = dataset.Sort(context.Background(), dset, []dataset.Column{ageCol, nameCol}, 1024)
+	require.NoError(t, err)
+
+	newColumns, err := result.Collect(dset.ListColumns(context.Background()))
+	require.NoError(t, err)
+
+	expect := []Person{
+		{"Bob", 25, "New York"},
+		{"Alice", 30, "San Francisco"},
+		{"Eve", 30, "Los Angeles"},
+		{"David", 35, "Chicago"},
+		{"Charlie", 40, ""},
+	}
+	var actual []Person
+
+	for result := range dataset.Iter(context.Background(), newColumns) {
+		row, err := result.Value()
+		require.NoError(t, err)
+		require.Equal(t, len(actual), row.Index)
+		require.Len(t, row.Values, 3)
+
+		var p Person
+
+		if !row.Values[0].IsNil() {
+			require.Equal(t, datasetmd.VALUE_TYPE_STRING, row.Values[0].Type())
+			p.Name = row.Values[0].String()
+		}
+		if !row.Values[1].IsNil() {
+			require.Equal(t, datasetmd.VALUE_TYPE_INT64, row.Values[1].Type())
+			p.Age = int(row.Values[1].Int64())
+		}
+		if !row.Values[2].IsNil() {
+			require.Equal(t, datasetmd.VALUE_TYPE_STRING, row.Values[2].Type())
+			p.Location = row.Values[2].String()
+		}
+
+		actual = append(actual, p)
+	}
+	require.Equal(t, expect, actual)
+}


### PR DESCRIPTION
This commit adds dataset.Dataset, the representation of a set of columns (each of which is split into a set of pages). A Dataset is represented by an interface to allow for implementations where Datasets, Columns, and Pages are backed by object storage or a cache layer.

Two utilities are introduced on top of a Dataset:

* dataset.Sort returns a new Dataset for which values are sorted in ascending order from a selected set of columns.

* dataset.Iter allows for iterating over rows in a dataset from a selected set of columns.

  This initial implementation is insufficient for reading at scale: there is no predicate support for filtering out pages and it lazily loads one page at a time during iteration. Both of these would cause unnecessary roundtrips to object storage.

  However, dataset.Iter is useful in the interrim for tests and in the implementation of dataset.Sort. It will eventually be replaced with a more sophisticated mechanism for scanning through a Dataset.