### PR TITLE
fix: RangeQuery goroutine leak

### DIFF
--- a/pkg/querier/queryrange/downstreamer.go
+++ b/pkg/querier/queryrange/downstreamer.go
@@ -170,10 +170,12 @@ func (in instance) For(
 	go func() {
 		err := concurrency.ForEachJob(ctx, len(queries), in.parallelism, func(ctx context.Context, i int) error {
 			res, err := fn(queries[i])
+			if err != nil {
+				return err
+			}
 			response := logql.Resp{
 				I:   i,
 				Res: res,
-				Err: err,
 			}
 
 			// Feed the result into the channel unless the work has completed.
@@ -181,7 +183,7 @@ func (in instance) For(
 			case <-ctx.Done():
 			case ch <- response:
 			}
-			return err
+			return nil
 		})
 		if err != nil {
 			ch <- logql.Resp{
@@ -192,25 +194,16 @@ func (in instance) For(
 		close(ch)
 	}()
 
-	var returnErr error
+	var err error
 	for resp := range ch {
-		if returnErr != nil {
+		if err != nil {
+			err = resp.Err
 			continue
 		}
-		if resp.Err != nil {
-			returnErr = resp.Err
-			continue
-		}
-		if err := acc.Accumulate(ctx, resp.Res, resp.I); err != nil {
-			returnErr = err
-		}
+		err = acc.Accumulate(ctx, resp.Res, resp.I)
 	}
 
-	if returnErr != nil {
-		return nil, returnErr
-	}
-
-	return acc.Result(), nil
+	return acc.Result(), err
 }
 
 // convert to matrix

--- a/pkg/querier/queryrange/downstreamer.go
+++ b/pkg/querier/queryrange/downstreamer.go
@@ -196,7 +196,10 @@ func (in instance) For(
 
 	var err error
 	for resp := range ch {
-		if err != nil || resp.Err != nil {
+		if err != nil {
+			continue
+		}
+		if resp.Err != nil {
 			err = resp.Err
 			continue
 		}

--- a/pkg/querier/queryrange/downstreamer.go
+++ b/pkg/querier/queryrange/downstreamer.go
@@ -192,14 +192,24 @@ func (in instance) For(
 		close(ch)
 	}()
 
+	var returnErr error
 	for resp := range ch {
+		if returnErr != nil {
+			continue
+		}
 		if resp.Err != nil {
-			return nil, resp.Err
+			returnErr = resp.Err
+			continue
 		}
 		if err := acc.Accumulate(ctx, resp.Res, resp.I); err != nil {
-			return nil, err
+			returnErr = err
 		}
 	}
+
+	if returnErr != nil {
+		return nil, returnErr
+	}
+
 	return acc.Result(), nil
 }
 

--- a/pkg/querier/queryrange/downstreamer.go
+++ b/pkg/querier/queryrange/downstreamer.go
@@ -197,7 +197,6 @@ func (in instance) For(
 	var err error
 	for resp := range ch {
 		if err != nil {
-			err = resp.Err
 			continue
 		}
 		err = acc.Accumulate(ctx, resp.Res, resp.I)

--- a/pkg/querier/queryrange/downstreamer.go
+++ b/pkg/querier/queryrange/downstreamer.go
@@ -196,7 +196,8 @@ func (in instance) For(
 
 	var err error
 	for resp := range ch {
-		if err != nil {
+		if err != nil || resp.Err != nil {
+			err = resp.Err
 			continue
 		}
 		err = acc.Accumulate(ctx, resp.Res, resp.I)


### PR DESCRIPTION
every time https://github.com/grafana/loki/blob/main/pkg/querier/queryrange/downstreamer.go#L197 this function return. there is no receiver for this channel.

https://github.com/grafana/loki/blob/main/pkg/querier/queryrange/downstreamer.go#L187. but there still have some error send to this channel. which result in goroutine leakage.

we can get this leakage through pprof/goroutine
![image](https://github.com/user-attachments/assets/d5fce10a-51a5-414a-a396-aead75232b28)
