### PR TITLE
docs: Show clusterName value instead cluster.local in NOTES.txt

### DIFF
--- a/production/helm/loki/templates/NOTES.txt
+++ b/production/helm/loki/templates/NOTES.txt
@@ -70,22 +70,22 @@ You can send logs from inside the cluster using the cluster DNS:
 
 {{- if .Values.gateway.enabled }}
 
-http://{{ include "loki.gatewayFullname" . }}.{{ $.Release.Namespace }}.svc.cluster.local/loki/api/v1/push
+http://{{ include "loki.gatewayFullname" . }}.{{ $.Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}/loki/api/v1/push
 
 {{- else }}
 {{- if eq (include "loki.deployment.isSingleBinary" .) "true" }}
 
-http://{{ include "loki.singleBinaryFullname" . }}.{{ $.Release.Namespace }}.svc.cluster.local:{{ .Values.loki.server.http_listen_port }}/loki/api/v1/push
+http://{{ include "loki.singleBinaryFullname" . }}.{{ $.Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:{{ .Values.loki.server.http_listen_port }}/loki/api/v1/push
 
 {{- end}}
 {{- if eq (include "loki.deployment.isScalable" .) "true" }}
 
-http://{{ include "loki.writeFullname" . }}.{{ $.Release.Namespace }}.svc.cluster.local:{{ .Values.loki.server.http_listen_port }}/loki/api/v1/push
+http://{{ include "loki.writeFullname" . }}.{{ $.Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:{{ .Values.loki.server.http_listen_port }}/loki/api/v1/push
 
 {{- end }}
 {{- if eq (include "loki.deployment.isDistributed" .) "true" }}
 
-http://{{ include "loki.distributorFullname" . }}.{{ $.Release.Namespace }}.svc.cluster.local:3100/loki/api/v1/push
+http://{{ include "loki.distributorFullname" . }}.{{ $.Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100/loki/api/v1/push
 
 {{- end }}
 {{- end }}
@@ -137,22 +137,22 @@ If Grafana operates within the cluster, you'll set up a new Loki datasource by u
 
 {{- if .Values.gateway.enabled }}
 
-http://{{ include "loki.gatewayFullname" . }}.{{ $.Release.Namespace }}.svc.cluster.local/
+http://{{ include "loki.gatewayFullname" . }}.{{ $.Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}/
 
 {{- else }}
 {{- if eq (include "loki.deployment.isSingleBinary" .) "true" }}
 
-http://{{ include "loki.singleBinaryFullname" . }}.{{ $.Release.Namespace }}.svc.cluster.local:{{ .Values.loki.server.http_listen_port }}/
+http://{{ include "loki.singleBinaryFullname" . }}.{{ $.Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:{{ .Values.loki.server.http_listen_port }}/
 
 {{- end}}
 {{- if eq (include "loki.deployment.isScalable" .) "true" }}
 
-http://{{ include "loki.readFullname" . }}.{{ $.Release.Namespace }}.svc.cluster.local:{{ .Values.loki.server.http_listen_port }}/
+http://{{ include "loki.readFullname" . }}.{{ $.Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:{{ .Values.loki.server.http_listen_port }}/
 
 {{- end }}
 {{- if eq (include "loki.deployment.isDistributed" .) "true" }}
 
-http://{{ include "loki.queryFrontendFullname" . }}.{{ $.Release.Namespace }}.svc.cluster.local:3100/
+http://{{ include "loki.queryFrontendFullname" . }}.{{ $.Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100/
 
 {{- end }}
 {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:
My clusterName is `foo.bar` but after installing loki with helm it shows me something like this

```
***********************************************************************
Connecting Grafana to Loki
***********************************************************************

If Grafana operates within the cluster, you'll set up a new Loki datasource by utilizing the following URL:

http://loki-gateway.logging.svc.cluster.local/
```

I expected to see this `http://loki-gateway.logging.svc.foo.bar/`

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
