### PR TITLE
ci: Fix only run on fork guard

### DIFF
--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   deploy-pr-preview:
-    if: github.repository == 'grafana/loki'
+    if: ! github.event.pull_request.head.repo.fork
     uses: grafana/writers-toolkit/.github/workflows/deploy-preview.yml@main
     with:
       sha: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION

**What this PR does / why we need it**:

The previous guard fails because `github.repository` resolves to the base repository on `pull_request` events.


**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
