### PR TITLE
feat(distributor): Store no shard stream metadata only

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -401,7 +401,7 @@ func (d *Distributor) stopping(_ error) error {
 }
 
 type KeyedStream struct {
-	HashKey     uint32
+	RingToken   uint32
 	HashNoShard uint64
 	Stream      logproto.Stream
 }
@@ -473,7 +473,7 @@ func (d *Distributor) Push(ctx context.Context, req *logproto.PushRequest) (*log
 			return
 		}
 		streams = append(streams, KeyedStream{
-			HashKey:     lokiring.TokenFor(tenantID, stream.Labels),
+			RingToken:   lokiring.TokenFor(tenantID, stream.Labels),
 			HashNoShard: stream.Hash,
 			Stream:      stream,
 		})
@@ -681,7 +681,7 @@ func (d *Distributor) Push(ctx context.Context, req *logproto.PushRequest) (*log
 			}
 
 			for i, stream := range streams {
-				replicationSet, err := d.ingestersRing.Get(stream.HashKey, ring.WriteNoExtend, descs[:0], nil, nil)
+				replicationSet, err := d.ingestersRing.Get(stream.RingToken, ring.WriteNoExtend, descs[:0], nil, nil)
 				if err != nil {
 					return err
 				}
@@ -859,7 +859,7 @@ func (d *Distributor) shardStream(stream logproto.Stream, pushSize int, tenantID
 	shardCount := d.shardCountFor(logger, &stream, pushSize, tenantID, shardStreamsCfg)
 
 	if shardCount <= 1 {
-		return []KeyedStream{{HashKey: lokiring.TokenFor(tenantID, stream.Labels), HashNoShard: stream.Hash, Stream: stream}}
+		return []KeyedStream{{RingToken: lokiring.TokenFor(tenantID, stream.Labels), HashNoShard: stream.Hash, Stream: stream}}
 	}
 
 	d.streamShardCount.Inc()
@@ -903,7 +903,7 @@ func (d *Distributor) createShards(stream logproto.Stream, totalShards int, tena
 		shard := d.createShard(streamLabels, streamPattern, shardNum, entriesPerShard)
 
 		derivedStreams = append(derivedStreams, KeyedStream{
-			HashKey:     lokiring.TokenFor(tenantID, shard.Labels),
+			RingToken:   lokiring.TokenFor(tenantID, shard.Labels),
 			HashNoShard: stream.Hash,
 			Stream:      shard,
 		})
@@ -1078,7 +1078,7 @@ func (d *Distributor) sendStreamToKafka(ctx context.Context, stream KeyedStream,
 	if len(stream.Stream.Entries) == 0 {
 		return nil
 	}
-	partitionID, err := subring.ActivePartitionForKey(stream.HashKey)
+	partitionID, err := subring.ActivePartitionForKey(stream.RingToken)
 	if err != nil {
 		d.kafkaAppends.WithLabelValues("kafka", "fail").Inc()
 		return fmt.Errorf("failed to find active partition for stream: %w", err)

--- a/pkg/distributor/tee_test.go
+++ b/pkg/distributor/tee_test.go
@@ -22,8 +22,8 @@ func TestWrapTee(t *testing.T) {
 	tee3 := new(mockedTee)
 	streams := []KeyedStream{
 		{
-			HashKey: 1,
-			Stream:  push.Stream{},
+			RingToken: 1,
+			Stream:    push.Stream{},
 		},
 	}
 	tee1.On("Duplicate", "1", streams).Once()

--- a/pkg/kafka/encoding.go
+++ b/pkg/kafka/encoding.go
@@ -197,9 +197,9 @@ func sovPush(x uint64) (n int) {
 
 // EncodeStreamMetadata encodes the stream metadata into a Kafka record
 // using the tenantID as the key and partition as the target partition
-func EncodeStreamMetadata(partition int32, topic string, tenantID string, stream logproto.Stream) *kgo.Record {
-	// Validate stream
-	if stream.Labels == "" || stream.Hash == 0 {
+func EncodeStreamMetadata(partition int32, topic string, tenantID string, streamHash uint64) *kgo.Record {
+	// Validate stream hash
+	if streamHash == 0 {
 		return nil
 	}
 
@@ -207,8 +207,8 @@ func EncodeStreamMetadata(partition int32, topic string, tenantID string, stream
 	metadata := metadataPool.Get().(*logproto.StreamMetadata)
 	defer metadataPool.Put(metadata)
 
-	// Transform stream into metadata
-	metadata.StreamHash = stream.Hash
+	// Set stream hash
+	metadata.StreamHash = streamHash
 
 	// Encode the metadata into a byte slice
 	value, err := metadata.Marshal()

--- a/pkg/kafka/encoding_test.go
+++ b/pkg/kafka/encoding_test.go
@@ -154,54 +154,26 @@ func generateRandomString(length int) string {
 func TestEncodeDecodeStreamMetadata(t *testing.T) {
 	tests := []struct {
 		name      string
-		stream    logproto.Stream
+		hash      uint64
 		partition int32
 		topic     string
 		tenantID  string
 		expectErr bool
 	}{
 		{
-			name: "Valid metadata",
-			stream: logproto.Stream{
-				Labels: `{app="test"}`,
-				Hash:   12345,
-			},
+			name:      "Valid metadata",
+			hash:      12345,
 			partition: 1,
 			topic:     "logs",
 			tenantID:  "tenant-1",
 			expectErr: false,
 		},
 		{
-			name: "Empty labels - should error",
-			stream: logproto.Stream{
-				Labels: "",
-				Hash:   67890,
-			},
-			partition: 2,
-			topic:     "metrics",
-			tenantID:  "tenant-2",
-			expectErr: true,
-		},
-		{
-			name: "Zero hash - should error",
-			stream: logproto.Stream{
-				Labels: `{app="test"}`,
-				Hash:   0,
-			},
+			name:      "Zero hash - should error",
+			hash:      0,
 			partition: 3,
 			topic:     "traces",
 			tenantID:  "tenant-3",
-			expectErr: true,
-		},
-		{
-			name: "Empty labels and zero hash - should error",
-			stream: logproto.Stream{
-				Labels: "",
-				Hash:   0,
-			},
-			partition: 4,
-			topic:     "traces",
-			tenantID:  "tenant-4",
 			expectErr: true,
 		},
 	}
@@ -209,7 +181,7 @@ func TestEncodeDecodeStreamMetadata(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Encode metadata
-			record := EncodeStreamMetadata(tt.partition, tt.topic, tt.tenantID, tt.stream)
+			record := EncodeStreamMetadata(tt.partition, tt.topic, tt.tenantID, tt.hash)
 			if tt.expectErr {
 				require.Nil(t, record)
 				return
@@ -227,7 +199,7 @@ func TestEncodeDecodeStreamMetadata(t *testing.T) {
 			require.NotNil(t, metadata)
 
 			// Verify decoded values
-			require.Equal(t, tt.stream.Hash, metadata.StreamHash)
+			require.Equal(t, tt.hash, metadata.StreamHash)
 
 			// Return metadata to pool
 			metadataPool.Put(metadata)

--- a/pkg/pattern/tee_service.go
+++ b/pkg/pattern/tee_service.go
@@ -234,7 +234,7 @@ func (ts *TeeService) batchesForTenant(
 	for _, stream := range streams {
 		var descs [1]ring.InstanceDesc
 		replicationSet, err := ts.ringClient.Ring().
-			Get(stream.HashKey, ring.WriteNoExtend, descs[:0], nil, nil)
+			Get(stream.RingToken, ring.WriteNoExtend, descs[:0], nil, nil)
 		if err != nil || len(replicationSet.Instances) == 0 {
 			ts.teedStreams.WithLabelValues("dropped").Inc()
 			continue

--- a/pkg/pattern/tee_service_test.go
+++ b/pkg/pattern/tee_service_test.go
@@ -71,7 +71,7 @@ func TestPatternTeeBasic(t *testing.T) {
 
 	now := time.Now()
 	tee.Duplicate("test-tenant", []distributor.KeyedStream{
-		{HashKey: 123, Stream: push.Stream{
+		{RingToken: 123, Stream: push.Stream{
 			Labels: `{foo="bar"}`,
 			Entries: []push.Entry{
 				{Timestamp: now, Line: "foo1"},
@@ -82,7 +82,7 @@ func TestPatternTeeBasic(t *testing.T) {
 	})
 
 	tee.Duplicate("test-tenant", []distributor.KeyedStream{
-		{HashKey: 123, Stream: push.Stream{
+		{RingToken: 123, Stream: push.Stream{
 			Labels: `{foo="bar"}`,
 			Entries: []push.Entry{
 				{Timestamp: now.Add(3 * time.Second), Line: "foo2"},
@@ -93,7 +93,7 @@ func TestPatternTeeBasic(t *testing.T) {
 	})
 
 	tee.Duplicate("test-tenant", []distributor.KeyedStream{
-		{HashKey: 456, Stream: push.Stream{
+		{RingToken: 456, Stream: push.Stream{
 			Labels: `{ping="pong"}`,
 			Entries: []push.Entry{
 				{Timestamp: now.Add(1 * time.Second), Line: "ping"},
@@ -162,14 +162,14 @@ func TestPatternTeeEmptyStream(t *testing.T) {
 	require.NoError(t, tee.Start(ctx))
 
 	tee.Duplicate("test-tenant", []distributor.KeyedStream{
-		{HashKey: 123, Stream: push.Stream{
+		{RingToken: 123, Stream: push.Stream{
 			Labels:  `{foo="bar"}`,
 			Entries: []push.Entry{},
 		}},
 	})
 
 	tee.Duplicate("test-tenant", []distributor.KeyedStream{
-		{HashKey: 456, Stream: push.Stream{
+		{RingToken: 456, Stream: push.Stream{
 			Labels:  `{ping="pong"}`,
 			Entries: []push.Entry{},
 		}},


### PR DESCRIPTION
**What this PR does / why we need it**:
When counting the amount or rates of a stream the respective ingest limits apply across all shards. In that regard the stream metadata are stored using the original hash rather than the one populated by shard creation. However the present implementation will write more metadata records for a shared stream, i.e. equal to the amount of shards. This is a slight waste of records though.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
