### PR TITLE
fix: correct typo in architecture name (amr64 -> arm64)

### DIFF
--- a/docs/sources/send-data/docker-driver/_index.md
+++ b/docs/sources/send-data/docker-driver/_index.md
@@ -31,7 +31,7 @@ docker plugin install grafana/loki-docker-driver:3.3.2-arm64 --alias loki --gran
 ```
 
 {{< admonition type="note" >}}
-Add `-arm64` to the image tag for AMR64 hosts.
+Add `-arm64` to the image tag for ARM64 hosts.
 {{< /admonition >}}
 
 To check installed plugins, use the `docker plugin ls` command.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a typo in the architecture name, changing `amr64` to `arm64`. This ensures accuracy and consistency in the documentation.

**Special notes for your reviewer**:
No major changes.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
