### PR TITLE
docs: broken URLs fixed

### DIFF
--- a/docs/sources/setup/install/helm/deployment-guides/aws.md
+++ b/docs/sources/setup/install/helm/deployment-guides/aws.md
@@ -576,6 +576,6 @@ k6 is one of the fastest ways to test your Loki deployment. This will allow you 
 
 Now that you have successfully deployed Loki in microservices mode on AWS, you may wish to explore the following:
 
-- [Sending data to Loki](https://grafana.com/docs/loki/<LOKI_VERSION/send-data/)
+- [Sending data to Loki](https://grafana.com/docs/loki/<LOKI_VERSION>/send-data/)
 - [Querying Loki](https://grafana.com/docs/loki/<LOKI_VERSION>/query/)
-- [Manage](https://grafana.com/docs/loki/<LOKI_VERSION/operations/)
+- [Manage](https://grafana.com/docs/loki/<LOKI_VERSION>/operations/)

--- a/docs/sources/setup/install/helm/deployment-guides/azure.md
+++ b/docs/sources/setup/install/helm/deployment-guides/azure.md
@@ -585,6 +585,6 @@ k6 is one of the fastest ways to test your Loki deployment. This will allow you 
 
 Now that you have successfully deployed Loki in microservices mode on Microsoft Azure, you may wish to explore the following:
 
-- [Sending data to Loki](https://grafana.com/docs/loki/<LOKI_VERSION/send-data/)
+- [Sending data to Loki](https://grafana.com/docs/loki/<LOKI_VERSION>/send-data/)
 - [Querying Loki](https://grafana.com/docs/loki/<LOKI_VERSION>/query/)
-- [Manage Loki](https://grafana.com/docs/loki/<LOKI_VERSION/operations/)
+- [Manage Loki](https://grafana.com/docs/loki/<LOKI_VERSION>/operations/)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the broken links in Loki documentation.

**Which issue(s) this PR fixes**:
Fixes broken links in Loki documentation.

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
