### PR TITLE
Update loki-http-api.md

### DIFF
--- a/docs/sources/reference/loki-http-api.md
+++ b/docs/sources/reference/loki-http-api.md
@@ -149,8 +149,7 @@ being returned.
 
 The API accepts several formats for timestamps:
 
-- An integer with ten or fewer digits is interpreted as a Unix timestamp in seconds.
-- More than ten digits are interpreted as a Unix timestamp in nanoseconds.
+- All epoch values will be interpreted as a Unix timestamp in nanoseconds.
 - A floating point number is a Unix timestamp with fractions of a second.
 - A string in `RFC3339` and `RFC3339Nano` format, as supported by Go's [time](https://pkg.go.dev/time) package.
 


### PR DESCRIPTION
An integer with ten or fewer digits is interpreted as a Unix timestamp in seconds.

This point needs to be updated as loki will consider all the epoch values in nanoseconds. FYI: https://raintank-corp.slack.com/archives/C9T1FLN9K/p1736320730034239

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
