### PR TITLE
docs: fix missing deploymentMode: SingleBinary

### DIFF
--- a/docs/sources/setup/install/helm/install-monolithic/_index.md
+++ b/docs/sources/setup/install/helm/install-monolithic/_index.md
@@ -271,6 +271,8 @@ loki:
 minio:
   enabled: false
 
+deploymentMode: SingleBinary
+
 singleBinary:
   replicas: 3
   persistence:
@@ -352,6 +354,8 @@ loki:
 # Disable minio storage
 minio:
   enabled: false
+
+deploymentMode: SingleBinary
 
 singleBinary:
   replicas: 3


### PR DESCRIPTION
**What this PR does / why we need it**:
This missing line causes the StatefulSet/loki to be missing. 
If one would copy the "s3"  or "azure" sections of this guide, it is possible to miss the "deploymentMode" config (I did it).
It was awful to figure out the mistake, because first timers will not notice the missing StatefullSet (since there is aready a deamonset).

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
