### PR TITLE
fix: don't send empty aggregated metric payloads

### DIFF
--- a/pkg/pattern/aggregation/push.go
+++ b/pkg/pattern/aggregation/push.go
@@ -222,6 +222,10 @@ func (p *Push) buildPayload(ctx context.Context) ([]byte, error) {
 		}
 	}
 
+	if len(streams) == 0 {
+		return nil, nil
+	}
+
 	req := &logproto.PushRequest{
 		Streams: streams,
 	}

--- a/pkg/pattern/aggregation/push.go
+++ b/pkg/pattern/aggregation/push.go
@@ -177,6 +177,9 @@ func (p *Push) buildPayload(ctx context.Context) ([]byte, error) {
 	defer sp.Finish()
 
 	entries := p.entries.reset()
+	if len(entries) == 0 {
+		return nil, nil
+	}
 
 	entriesByStream := make(map[string][]logproto.Entry)
 	for _, e := range entries {
@@ -265,6 +268,10 @@ func (p *Push) run(pushPeriod time.Duration) {
 			payload, err := p.buildPayload(ctx)
 			if err != nil {
 				level.Error(p.logger).Log("msg", "failed to build payload", "err", err)
+				continue
+			}
+
+			if len(payload) == 0 {
 				continue
 			}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Prevent the pattern ingester from sending empty aggregated metric payloads when there are no aggregated metrics to send.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
