### PR TITLE
chore(dataobj): fix bug where instances of *bytes.Buffer are incorrectly shared

### DIFF
--- a/pkg/dataobj/internal/encoding/encoder_logs.go
+++ b/pkg/dataobj/internal/encoding/encoder_logs.go
@@ -94,6 +94,7 @@ func (enc *LogsEncoder) Commit() error {
 	} else if enc.curColumn != nil {
 		return ErrElementExist
 	}
+	enc.closed = true
 
 	defer bytesBufferPool.Put(enc.data)
 

--- a/pkg/dataobj/internal/encoding/encoder_streams.go
+++ b/pkg/dataobj/internal/encoding/encoder_streams.go
@@ -94,6 +94,7 @@ func (enc *StreamsEncoder) Commit() error {
 	} else if enc.curColumn != nil {
 		return ErrElementExist
 	}
+	enc.closed = true
 
 	defer bytesBufferPool.Put(enc.data)
 

--- a/pkg/dataobj/internal/encoding/encoder_test.go
+++ b/pkg/dataobj/internal/encoding/encoder_test.go
@@ -1,0 +1,79 @@
+package encoding_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/dataobj/internal/dataset"
+	"github.com/grafana/loki/v3/pkg/dataobj/internal/encoding"
+	"github.com/grafana/loki/v3/pkg/dataobj/internal/metadata/logsmd"
+	"github.com/grafana/loki/v3/pkg/dataobj/internal/metadata/streamsmd"
+	"github.com/grafana/loki/v3/pkg/dataobj/internal/streamio"
+)
+
+func Test_Encoders(t *testing.T) {
+	newEncoders := getEncoders(t)
+
+	for _, newEncoder := range newEncoders {
+		t.Run(fmt.Sprintf("%T/Only permit one call to Commit", newEncoder), func(t *testing.T) {
+			encoder := newEncoder()
+
+			require.NoError(t, encoder.Commit())
+			require.ErrorIs(t, encoder.Commit(), encoding.ErrClosed)
+		})
+
+		t.Run(fmt.Sprintf("%T/Commit must fail after discard", newEncoder), func(t *testing.T) {
+			encoder := newEncoder()
+
+			require.NoError(t, encoder.Discard())
+			require.ErrorIs(t, encoder.Commit(), encoding.ErrClosed)
+		})
+	}
+}
+
+type encoder interface {
+	Commit() error
+	Discard() error
+}
+
+type newEncoder func() encoder
+
+func getEncoders(t *testing.T) []newEncoder {
+	t.Helper()
+
+	return []newEncoder{
+		func() encoder {
+			enc := encoding.NewEncoder(streamio.Discard)
+			streamsEnc, err := enc.OpenStreams()
+			require.NoError(t, err)
+			return streamsEnc
+		},
+
+		func() encoder {
+			enc := encoding.NewEncoder(streamio.Discard)
+			streamsEnc, err := enc.OpenStreams()
+			require.NoError(t, err)
+			columnEnc, err := streamsEnc.OpenColumn(streamsmd.COLUMN_TYPE_LABEL, &dataset.ColumnInfo{})
+			require.NoError(t, err)
+			return columnEnc
+		},
+
+		func() encoder {
+			enc := encoding.NewEncoder(streamio.Discard)
+			logsEnc, err := enc.OpenLogs()
+			require.NoError(t, err)
+			return logsEnc
+		},
+
+		func() encoder {
+			enc := encoding.NewEncoder(streamio.Discard)
+			logsEnc, err := enc.OpenLogs()
+			require.NoError(t, err)
+			columnEnc, err := logsEnc.OpenColumn(logsmd.COLUMN_TYPE_MESSAGE, &dataset.ColumnInfo{})
+			require.NoError(t, err)
+			return columnEnc
+		},
+	}
+}


### PR DESCRIPTION
encoding.LogsEncoder and encoding.StreamsEncoder failed to set

    enc.close = true

on a call to Close. Because the logs and stream sections call Discard on a defer, this means that the *bytes.Buffers were being placed into the pool twice.