### PR TITLE
chore(dataobj): support for building and flushing data objects

### DIFF
--- a/pkg/dataobj/dataobj.go
+++ b/pkg/dataobj/dataobj.go
@@ -2,15 +2,69 @@
 package dataobj
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
 
+	"github.com/grafana/dskit/flagext"
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/thanos-io/objstore"
 
+	"github.com/grafana/loki/v3/pkg/dataobj/internal/encoding"
+	"github.com/grafana/loki/v3/pkg/dataobj/internal/sections/logs"
+	"github.com/grafana/loki/v3/pkg/dataobj/internal/sections/streams"
 	"github.com/grafana/loki/v3/pkg/logproto"
+	"github.com/grafana/loki/v3/pkg/logql/syntax"
 )
 
+// ErrBufferFull is returned by [Builder.Append] when the buffer is full and
+// needs to flush; call [Builder.Flush] to flush it.
+var ErrBufferFull = errors.New("buffer full")
+
 // BuilderConfig configures a data object [Builder].
-type BuilderConfig struct{}
+type BuilderConfig struct {
+	// SHAPrefixSize sets the number of bytes of the SHA filename to use as a
+	// folder path.
+	SHAPrefixSize int
+
+	// TargetPageSize configures a target size for encoded pages within the data
+	// object. TargetPageSize accounts for encoding, but not for compression.
+	TargetPageSize flagext.Bytes
+
+	// TODO(rfratto): We need an additional parameter for TargetMetadataSize, as
+	// metadata payloads can't be split and must be downloaded in a single
+	// request.
+	//
+	// At the moment, we don't have a good mechanism for implementing a metadata
+	// size limit (we need to support some form of section splitting or column
+	// combinations), so the option is omitted for now.
+
+	// TargetObjectSize configures a target size for data objects.
+	TargetObjectSize flagext.Bytes
+}
+
+func (cfg *BuilderConfig) validate() error {
+	var errs []error
+
+	if cfg.SHAPrefixSize <= 0 {
+		errs = append(errs, errors.New("SHAPrefixSize must be greater than 0"))
+	}
+
+	if cfg.TargetPageSize <= 0 {
+		errs = append(errs, errors.New("TargetPageSize must be greater than 0"))
+	} else if cfg.TargetPageSize >= cfg.TargetObjectSize {
+		errs = append(errs, errors.New("TargetPageSize must be less than TargetObjectSize"))
+	}
+
+	if cfg.TargetObjectSize <= 0 || cfg.TargetObjectSize > 3_000_000_000 {
+		errs = append(errs, errors.New("TargetObjectSize must be greater than 0 and less than 3GB"))
+	}
+
+	return errors.Join(errs...)
+}
 
 // A Builder builds data objects from a set of incoming log data. Log data is
 // appended to a builder by calling [Builder.Append]. Buffered log data is
@@ -18,33 +72,137 @@ type BuilderConfig struct{}
 //
 // Methods on Builder are not goroutine-safe; callers are responsible for
 // synchronizing calls.
-type Builder struct{}
+type Builder struct {
+	cfg      BuilderConfig
+	bucket   objstore.Bucket
+	tenantID string
+
+	dirty bool // Whether the builder has been modified since the last flush.
+
+	streams *streams.Streams
+	logs    *logs.Logs
+}
 
 // NewBuilder creates a new Builder which stores data objects for the specified
 // tenant in a bucket.
-func NewBuilder(cfg BuilderConfig, bucket objstore.Bucket, tenantID string) *Builder {
-	// TODO(rfratto): implement
-	_ = cfg
-	_ = bucket
-	_ = tenantID
-	return &Builder{}
+//
+// NewBuilder returns an error if BuilderConfig is invalid.
+func NewBuilder(cfg BuilderConfig, bucket objstore.Bucket, tenantID string) (*Builder, error) {
+	if err := cfg.validate(); err != nil {
+		return nil, err
+	}
+
+	return &Builder{
+		cfg:      cfg,
+		bucket:   bucket,
+		tenantID: tenantID,
+
+		streams: streams.New(int(cfg.TargetPageSize)),
+		logs:    logs.New(int(cfg.TargetPageSize)),
+	}, nil
 }
 
-// Append buffers a stream to be written to a data object. If the Builder is
-// full, Append returns false without appending the entry.
+// Append buffers a stream to be written to a data object. Append returns an
+// error if the stream labels cannot be parsed or [ErrBufferFull] if the
+// builder is full.
 //
 // Once a Builder is full, call [Builder.Flush] to flush the buffered data,
 // then call Append again with the same entry.
-func (b *Builder) Append(stream logproto.Stream) bool {
-	// TODO(rfratto): implement
-	_ = stream
-	return true
+func (b *Builder) Append(stream logproto.Stream) error {
+	ls, err := syntax.ParseLabels(stream.Labels)
+	if err != nil {
+		return err
+	}
+
+	// Check whether the buffer is full before a stream can be appended; this is
+	// tends to overestimate, but we may still go over our target size.
+	if b.dirty && b.estimatedSize()+labelsEstimate(ls)+streamSizeEstimate(stream) > int(b.cfg.TargetObjectSize) {
+		return ErrBufferFull
+	}
+
+	for _, entry := range stream.Entries {
+		streamID := b.streams.Record(ls, entry.Timestamp)
+
+		b.logs.Append(logs.Record{
+			StreamID:  streamID,
+			Timestamp: entry.Timestamp,
+			Metadata:  entry.StructuredMetadata,
+			Line:      entry.Line,
+		})
+	}
+
+	b.dirty = true
+	return nil
 }
 
-// Flush flushes all buffered data to object storage. Calling Flush be result
+func (b *Builder) estimatedSize() int {
+	var size int
+	size += b.streams.EstimatedSize()
+	size += b.logs.EstimatedSize()
+	return size
+}
+
+// labelsEstimate estimates the size of a set of labels in bytes.
+func labelsEstimate(ls labels.Labels) int {
+	var (
+		keysSize   int
+		valuesSize int
+	)
+
+	for _, l := range ls {
+		keysSize += len(l.Name)
+		valuesSize += len(l.Value)
+	}
+
+	// Keys are stored as columns directly, while values get compressed. We'll
+	// underestimate a 2x compression ratio.
+	return keysSize + valuesSize/2
+}
+
+// streamSizeEstimate estimates the size of a stream in bytes.
+func streamSizeEstimate(stream logproto.Stream) int {
+	var size int
+	for _, entry := range stream.Entries {
+		// We only check the size of the line and metadata. Timestamps and IDs
+		// encode so well that they're unlikely to make a singificant impact on our
+		// size estimate.
+		size += len(entry.Line) / 2 // Line with 2x compression ratio
+		for _, md := range entry.StructuredMetadata {
+			size += len(md.Name) + len(md.Value)/2
+		}
+	}
+	return size
+}
+
+// Flush flushes all buffered data to object storage. Calling Flush can result
 // in a no-op if there is no buffered data to flush.
 func (b *Builder) Flush(ctx context.Context) error {
-	// TODO(rfratto): implement
-	_ = ctx
-	return nil
+	if !b.dirty {
+		return nil
+	}
+	defer b.reset()
+
+	buf := bytesBufferPool.Get().(*bytes.Buffer)
+	buf.Reset()
+	defer bytesBufferPool.Put(buf)
+
+	enc := encoding.NewEncoder(buf)
+
+	if err := b.streams.EncodeTo(enc); err != nil {
+		return fmt.Errorf("encoding streams: %w", err)
+	} else if err := b.logs.EncodeTo(enc); err != nil {
+		return fmt.Errorf("encoding logs: %w", err)
+	} else if err := enc.Flush(); err != nil {
+		return fmt.Errorf("encoding object: %w", err)
+	}
+
+	sum := sha256.Sum224(buf.Bytes())
+	sumStr := hex.EncodeToString(sum[:])
+
+	path := fmt.Sprintf("tenant-%s/objects/%s/%s", b.tenantID, sumStr[:b.cfg.SHAPrefixSize], sumStr[b.cfg.SHAPrefixSize:])
+	return b.bucket.Upload(ctx, path, bytes.NewReader(buf.Bytes()))
+}
+
+func (b *Builder) reset() {
+	b.dirty = false
 }

--- a/pkg/dataobj/dataobj_test.go
+++ b/pkg/dataobj/dataobj_test.go
@@ -1,0 +1,177 @@
+package dataobj
+
+import (
+	"cmp"
+	"context"
+	"errors"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/thanos-io/objstore"
+
+	"github.com/grafana/loki/pkg/push"
+
+	"github.com/grafana/loki/v3/pkg/dataobj/internal/result"
+	"github.com/grafana/loki/v3/pkg/logproto"
+	"github.com/grafana/loki/v3/pkg/logql/syntax"
+)
+
+func Test(t *testing.T) {
+	bucket := objstore.NewInMemBucket()
+
+	streams := []logproto.Stream{
+		{
+			Labels: `{cluster="test",app="foo"}`,
+			Entries: []push.Entry{
+				{
+					Timestamp: time.Unix(10, 0).UTC(),
+					Line:      "hello",
+					StructuredMetadata: push.LabelsAdapter{
+						{Name: "trace_id", Value: "123"},
+					},
+				},
+				{
+					Timestamp: time.Unix(5, 0).UTC(),
+					Line:      "hello again",
+					StructuredMetadata: push.LabelsAdapter{
+						{Name: "trace_id", Value: "456"},
+						{Name: "span_id", Value: "789"},
+					},
+				},
+			},
+		},
+
+		{
+			Labels: `{cluster="test",app="bar"}`,
+			Entries: []push.Entry{
+				{
+					Timestamp: time.Unix(15, 0).UTC(),
+					Line:      "world",
+					StructuredMetadata: push.LabelsAdapter{
+						{Name: "trace_id", Value: "abc"},
+					},
+				},
+				{
+					Timestamp: time.Unix(20, 0).UTC(),
+					Line:      "world again",
+					StructuredMetadata: push.LabelsAdapter{
+						{Name: "trace_id", Value: "def"},
+						{Name: "span_id", Value: "ghi"},
+					},
+				},
+			},
+		},
+	}
+
+	t.Run("Build", func(t *testing.T) {
+		// Create a tiny builder which flushes a lot of objects and pages to properly
+		// test the builder.
+		builderConfig := BuilderConfig{
+			SHAPrefixSize: 2,
+
+			TargetPageSize:   1_500_000,
+			TargetObjectSize: 10_000_000,
+		}
+
+		builder, err := NewBuilder(builderConfig, bucket, "fake")
+		require.NoError(t, err)
+
+		for _, entry := range streams {
+			require.NoError(t, builder.Append(entry))
+		}
+		require.NoError(t, builder.Flush(context.Background()))
+	})
+
+	t.Run("Read", func(t *testing.T) {
+		reader := newReader(bucket)
+
+		objects, err := result.Collect(reader.Objects(context.Background(), "fake"))
+		require.NoError(t, err)
+		require.Len(t, objects, 1)
+
+		actual, err := result.Collect(reader.Streams(context.Background(), objects[0]))
+		require.NoError(t, err)
+		require.Equal(t, sortStreams(t, streams), actual)
+	})
+}
+
+// Test_Builder_Append ensures that appending to the buffer eventually reports
+// that the buffer is full.
+func Test_Builder_Append(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	bucket := objstore.NewInMemBucket()
+
+	// Create a tiny builder which flushes a lot of objects and pages to properly
+	// test the builder.
+	builderConfig := BuilderConfig{
+		SHAPrefixSize: 2,
+
+		TargetPageSize:   2048,
+		TargetObjectSize: 4096,
+	}
+
+	builder, err := NewBuilder(builderConfig, bucket, "fake")
+	require.NoError(t, err)
+
+	for {
+		require.NoError(t, ctx.Err())
+
+		err := builder.Append(logproto.Stream{
+			Labels: `{cluster="test",app="foo"}`,
+			Entries: []push.Entry{{
+				Timestamp: time.Now().UTC(),
+				Line:      strings.Repeat("a", 1024),
+			}},
+		})
+		if errors.Is(err, ErrBufferFull) {
+			break
+		}
+		require.NoError(t, err)
+	}
+}
+
+// sortStreams returns a new slice of streams where entries in individual
+// streams are sorted by timestamp and structured metadata are sorted by key.
+// The order of streams is preserved.
+func sortStreams(t *testing.T, streams []logproto.Stream) []logproto.Stream {
+	t.Helper()
+
+	res := make([]logproto.Stream, len(streams))
+	for i, in := range streams {
+		labels, err := syntax.ParseLabels(in.Labels)
+		require.NoError(t, err)
+
+		res[i] = logproto.Stream{
+			Labels:  labels.String(),
+			Entries: slices.Clone(in.Entries),
+			Hash:    labels.Hash(),
+		}
+
+		for j, ent := range res[i].Entries {
+			res[i].Entries[j].StructuredMetadata = slices.Clone(ent.StructuredMetadata)
+			slices.SortFunc(res[i].Entries[j].StructuredMetadata, func(i, j push.LabelAdapter) int {
+				return cmp.Compare(i.Name, j.Name)
+			})
+		}
+
+		slices.SortFunc(res[i].Entries, func(i, j push.Entry) int {
+			switch {
+			case i.Timestamp.Before(j.Timestamp):
+				return -1
+
+			case i.Timestamp.After(j.Timestamp):
+				return 1
+
+			default:
+				return 0
+			}
+		})
+	}
+
+	return res
+}

--- a/pkg/dataobj/internal/dataset/column_builder.go
+++ b/pkg/dataobj/internal/dataset/column_builder.go
@@ -80,6 +80,21 @@ func (cb *ColumnBuilder) Append(row int, value Value) error {
 	panic("ColumnBuilder.Append: failed to append value to fresh buffer")
 }
 
+// EstimatedSize returns the estimated size of all data in cb. EstimatedSize
+// includes the compressed size of all cut pages in cb, followed by the size
+// estimate of the in-progress page.
+//
+// Because compression isn't considered for the in-progress page, EstimatedSize
+// tends to overestimate the actual size after flushing.
+func (cb *ColumnBuilder) EstimatedSize() int {
+	var size int
+	for _, p := range cb.pages {
+		size += p.Info.CompressedSize
+	}
+	size += cb.builder.EstimatedSize()
+	return size
+}
+
 // Backfill adds NULLs into cb up to (but not including) the provided row
 // number. If values exist up to the provided row number, Backfill does
 // nothing.

--- a/pkg/dataobj/internal/dataset/page_builder.go
+++ b/pkg/dataobj/internal/dataset/page_builder.go
@@ -91,7 +91,7 @@ func (b *pageBuilder) Append(value Value) bool {
 	//
 	// We use a rough estimate which will tend to overshoot the page size, making
 	// sure we rarely go over.
-	if sz := b.estimatedSize(); sz > 0 && sz+valueSize(value) > b.opts.PageSizeHint {
+	if sz := b.EstimatedSize(); sz > 0 && sz+valueSize(value) > b.opts.PageSizeHint {
 		return false
 	}
 
@@ -117,7 +117,7 @@ func (b *pageBuilder) AppendNull() bool {
 	//
 	// Here we assume appending a NULL costs one byte, but in reality most NULLs
 	// have no cost depending on the state of our bitmap encoder.
-	if sz := b.estimatedSize(); sz > 0 && sz+1 > b.opts.PageSizeHint {
+	if sz := b.EstimatedSize(); sz > 0 && sz+1 > b.opts.PageSizeHint {
 		return false
 	}
 
@@ -150,9 +150,9 @@ func valueSize(v Value) int {
 	return 0
 }
 
-// estimatedSize returns the estimated uncompressed size of the builder in
+// EstimatedSize returns the estimated uncompressed size of the builder in
 // bytes.
-func (b *pageBuilder) estimatedSize() int {
+func (b *pageBuilder) EstimatedSize() int {
 	// This estimate doesn't account for any values in encoders which haven't
 	// been flushed yet. However, encoder buffers are usually small enough that
 	// we wouldn't massively overshoot our estimate.

--- a/pkg/dataobj/internal/encoding/decoder_bucket.go
+++ b/pkg/dataobj/internal/encoding/decoder_bucket.go
@@ -1,0 +1,288 @@
+package encoding
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/thanos-io/objstore"
+
+	"github.com/grafana/loki/v3/pkg/dataobj/internal/dataset"
+	"github.com/grafana/loki/v3/pkg/dataobj/internal/metadata/filemd"
+	"github.com/grafana/loki/v3/pkg/dataobj/internal/metadata/logsmd"
+	"github.com/grafana/loki/v3/pkg/dataobj/internal/metadata/streamsmd"
+	"github.com/grafana/loki/v3/pkg/dataobj/internal/result"
+)
+
+type bucketDecoder struct {
+	bucket objstore.BucketReader
+	path   string
+}
+
+// BucketDecoder decodes a data object from the provided path within the
+// specified [objstore.BucketReader].
+func BucketDecoder(bucket objstore.BucketReader, path string) Decoder {
+	// TODO(rfratto): bucketDecoder and readSeekerDecoder can be deduplicated
+	// into a single implementation that accepts some kind of "range reader"
+	// interface.
+	return &bucketDecoder{
+		bucket: bucket,
+		path:   path,
+	}
+}
+
+func (bd *bucketDecoder) Sections(ctx context.Context) ([]*filemd.SectionInfo, error) {
+	tailer, err := bd.tailer(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("reading tailer: %w", err)
+	}
+
+	rc, err := bd.bucket.GetRange(ctx, bd.path, int64(tailer.FileSize-tailer.MetadataSize-8), int64(tailer.MetadataSize))
+	if err != nil {
+		return nil, fmt.Errorf("getting metadata: %w", err)
+	}
+	defer rc.Close()
+
+	br, release := getBufioReader(rc)
+	defer release()
+
+	md, err := decodeFileMetadata(br)
+	if err != nil {
+		return nil, err
+	}
+	return md.Sections, nil
+}
+
+type tailer struct {
+	MetadataSize uint32
+	FileSize     uint32
+}
+
+func (bd *bucketDecoder) tailer(ctx context.Context) (tailer, error) {
+	attrs, err := bd.bucket.Attributes(ctx, bd.path)
+	if err != nil {
+		return tailer{}, fmt.Errorf("reading attributes: %w", err)
+	}
+
+	// Read the last 8 bytes of the object to get the metadata size and magic.
+	rc, err := bd.bucket.GetRange(ctx, bd.path, attrs.Size-8, 8)
+	if err != nil {
+		return tailer{}, fmt.Errorf("getting file tailer: %w", err)
+	}
+	defer rc.Close()
+
+	br, release := getBufioReader(rc)
+	defer release()
+
+	metadataSize, err := decodeTailer(br)
+	if err != nil {
+		return tailer{}, fmt.Errorf("scanning tailer: %w", err)
+	}
+
+	return tailer{
+		MetadataSize: metadataSize,
+		FileSize:     uint32(attrs.Size),
+	}, nil
+}
+
+func (bd *bucketDecoder) StreamsDecoder() StreamsDecoder {
+	return &bucketStreamsDecoder{
+		bucket: bd.bucket,
+		path:   bd.path,
+	}
+}
+
+func (bd *bucketDecoder) LogsDecoder() LogsDecoder {
+	return &bucketLogsDecoder{
+		bucket: bd.bucket,
+		path:   bd.path,
+	}
+}
+
+type bucketStreamsDecoder struct {
+	bucket objstore.BucketReader
+	path   string
+}
+
+func (bd *bucketStreamsDecoder) Columns(ctx context.Context, section *filemd.SectionInfo) ([]*streamsmd.ColumnDesc, error) {
+	if section.Type != filemd.SECTION_TYPE_STREAMS {
+		return nil, fmt.Errorf("unexpected section type: got=%d want=%d", section.Type, filemd.SECTION_TYPE_STREAMS)
+	}
+
+	rc, err := bd.bucket.GetRange(ctx, bd.path, int64(section.MetadataOffset), int64(section.MetadataSize))
+	if err != nil {
+		return nil, fmt.Errorf("reading streams section metadata: %w", err)
+	}
+	defer rc.Close()
+
+	br, release := getBufioReader(rc)
+	defer release()
+
+	md, err := decodeStreamsMetadata(br)
+	if err != nil {
+		return nil, err
+	}
+	return md.Columns, nil
+}
+
+func (bd *bucketStreamsDecoder) Pages(ctx context.Context, columns []*streamsmd.ColumnDesc) result.Seq[[]*streamsmd.PageDesc] {
+	getPages := func(ctx context.Context, column *streamsmd.ColumnDesc) ([]*streamsmd.PageDesc, error) {
+		rc, err := bd.bucket.GetRange(ctx, bd.path, int64(column.Info.MetadataOffset), int64(column.Info.MetadataSize))
+		if err != nil {
+			return nil, fmt.Errorf("reading column metadata: %w", err)
+		}
+		defer rc.Close()
+
+		br, release := getBufioReader(rc)
+		defer release()
+
+		md, err := decodeStreamsColumnMetadata(br)
+		if err != nil {
+			return nil, err
+		}
+		return md.Pages, nil
+	}
+
+	// TODO(rfratto): this retrieves all pages for all columns individually; we
+	// may be able to batch requests to minimize roundtrips.
+	return result.Iter(func(yield func([]*streamsmd.PageDesc) bool) error {
+		for _, column := range columns {
+			pages, err := getPages(ctx, column)
+			if err != nil {
+				return err
+			} else if !yield(pages) {
+				return nil
+			}
+		}
+
+		return nil
+	})
+}
+
+func (bd *bucketStreamsDecoder) ReadPages(ctx context.Context, pages []*streamsmd.PageDesc) result.Seq[dataset.PageData] {
+	getPageData := func(ctx context.Context, page *streamsmd.PageDesc) (dataset.PageData, error) {
+		rc, err := bd.bucket.GetRange(ctx, bd.path, int64(page.Info.DataOffset), int64(page.Info.DataSize))
+		if err != nil {
+			return nil, fmt.Errorf("reading page data: %w", err)
+		}
+		defer rc.Close()
+
+		br, release := getBufioReader(rc)
+		defer release()
+
+		data := make([]byte, page.Info.DataSize)
+		if _, err := io.ReadFull(br, data); err != nil {
+			return nil, fmt.Errorf("read page data: %w", err)
+		}
+		return dataset.PageData(data), nil
+	}
+
+	// TODO(rfratto): this retrieves all pages for all columns individually; we
+	// may be able to batch requests to minimize roundtrips.
+	return result.Iter(func(yield func(dataset.PageData) bool) error {
+		for _, page := range pages {
+			data, err := getPageData(ctx, page)
+			if err != nil {
+				return err
+			} else if !yield(data) {
+				return nil
+			}
+		}
+
+		return nil
+	})
+}
+
+type bucketLogsDecoder struct {
+	bucket objstore.BucketReader
+	path   string
+}
+
+func (bd *bucketLogsDecoder) Columns(ctx context.Context, section *filemd.SectionInfo) ([]*logsmd.ColumnDesc, error) {
+	if section.Type != filemd.SECTION_TYPE_LOGS {
+		return nil, fmt.Errorf("unexpected section type: got=%d want=%d", section.Type, filemd.SECTION_TYPE_STREAMS)
+	}
+
+	rc, err := bd.bucket.GetRange(ctx, bd.path, int64(section.MetadataOffset), int64(section.MetadataSize))
+	if err != nil {
+		return nil, fmt.Errorf("reading streams section metadata: %w", err)
+	}
+	defer rc.Close()
+
+	br, release := getBufioReader(rc)
+	defer release()
+
+	md, err := decodeLogsMetadata(br)
+	if err != nil {
+		return nil, err
+	}
+	return md.Columns, nil
+}
+
+func (bd *bucketLogsDecoder) Pages(ctx context.Context, columns []*logsmd.ColumnDesc) result.Seq[[]*logsmd.PageDesc] {
+	getPages := func(ctx context.Context, column *logsmd.ColumnDesc) ([]*logsmd.PageDesc, error) {
+		rc, err := bd.bucket.GetRange(ctx, bd.path, int64(column.Info.MetadataOffset), int64(column.Info.MetadataSize))
+		if err != nil {
+			return nil, fmt.Errorf("reading column metadata: %w", err)
+		}
+		defer rc.Close()
+
+		br, release := getBufioReader(rc)
+		defer release()
+
+		md, err := decodeLogsColumnMetadata(br)
+		if err != nil {
+			return nil, err
+		}
+		return md.Pages, nil
+	}
+
+	// TODO(rfratto): this retrieves all pages for all columns individually; we
+	// may be able to batch requests to minimize roundtrips.
+	return result.Iter(func(yield func([]*logsmd.PageDesc) bool) error {
+		for _, column := range columns {
+			pages, err := getPages(ctx, column)
+			if err != nil {
+				return err
+			} else if !yield(pages) {
+				return nil
+			}
+		}
+
+		return nil
+	})
+}
+
+func (bd *bucketLogsDecoder) ReadPages(ctx context.Context, pages []*logsmd.PageDesc) result.Seq[dataset.PageData] {
+	getPageData := func(ctx context.Context, page *logsmd.PageDesc) (dataset.PageData, error) {
+		rc, err := bd.bucket.GetRange(ctx, bd.path, int64(page.Info.DataOffset), int64(page.Info.DataSize))
+		if err != nil {
+			return nil, fmt.Errorf("reading page data: %w", err)
+		}
+		defer rc.Close()
+
+		br, release := getBufioReader(rc)
+		defer release()
+
+		data := make([]byte, page.Info.DataSize)
+		if _, err := io.ReadFull(br, data); err != nil {
+			return nil, fmt.Errorf("read page data: %w", err)
+		}
+		return dataset.PageData(data), nil
+	}
+
+	// TODO(rfratto): this retrieves all pages for all columns individually; we
+	// may be able to batch requests to minimize roundtrips.
+	return result.Iter(func(yield func(dataset.PageData) bool) error {
+		for _, page := range pages {
+			data, err := getPageData(ctx, page)
+			if err != nil {
+				return err
+			} else if !yield(data) {
+				return nil
+			}
+		}
+
+		return nil
+	})
+}

--- a/pkg/dataobj/internal/encoding/decoder_metadata.go
+++ b/pkg/dataobj/internal/encoding/decoder_metadata.go
@@ -16,6 +16,23 @@ import (
 
 // decode* methods for metadata shared by Decoder implementations.
 
+// decodeTailer decodes the tailer of the file to retrieve the metadata size
+// and the magic value.
+func decodeTailer(r streamio.Reader) (metadataSize uint32, err error) {
+	if err := binary.Read(r, binary.LittleEndian, &metadataSize); err != nil {
+		return 0, fmt.Errorf("read metadata size: %w", err)
+	}
+
+	var gotMagic [4]byte
+	if _, err := io.ReadFull(r, gotMagic[:]); err != nil {
+		return 0, fmt.Errorf("read magic: %w", err)
+	} else if string(gotMagic[:]) != string(magic) {
+		return 0, fmt.Errorf("unexpected magic: got=%q want=%q", gotMagic, magic)
+	}
+
+	return
+}
+
 // decodeFileMetadata decodes file metadata from r.
 func decodeFileMetadata(r streamio.Reader) (*filemd.Metadata, error) {
 	gotVersion, err := streamio.ReadUvarint(r)

--- a/pkg/dataobj/internal/encoding/pools.go
+++ b/pkg/dataobj/internal/encoding/pools.go
@@ -1,7 +1,9 @@
 package encoding
 
 import (
+	"bufio"
 	"bytes"
+	"io"
 	"sync"
 
 	"github.com/gogo/protobuf/proto"
@@ -17,4 +19,16 @@ var protoBufferPool = sync.Pool{
 	New: func() any {
 		return new(proto.Buffer)
 	},
+}
+
+var bufioPool = sync.Pool{
+	New: func() any {
+		return bufio.NewReader(nil)
+	},
+}
+
+func getBufioReader(r io.Reader) (rd *bufio.Reader, release func()) {
+	br := bufioPool.Get().(*bufio.Reader)
+	br.Reset(r)
+	return br, func() { bufioPool.Put(br) }
 }

--- a/pkg/dataobj/internal/sections/logs/logs.go
+++ b/pkg/dataobj/internal/sections/logs/logs.go
@@ -117,6 +117,21 @@ func (l *Logs) Append(entry Record) {
 	l.rows++
 }
 
+// EstimatedSize returns the estimated size of the Logs section in bytes.
+func (l *Logs) EstimatedSize() int {
+	var size int
+
+	size += l.streamIDs.EstimatedSize()
+	size += l.timestamps.EstimatedSize()
+	size += l.messages.EstimatedSize()
+
+	for _, md := range l.metadatas {
+		size += md.EstimatedSize()
+	}
+
+	return size
+}
+
 func (l *Logs) getMetadataColumn(key string) *dataset.ColumnBuilder {
 	idx, ok := l.metadataLookup[key]
 	if !ok {

--- a/pkg/dataobj/internal/sections/streams/streams.go
+++ b/pkg/dataobj/internal/sections/streams/streams.go
@@ -56,7 +56,7 @@ func New(pageSize int) *Streams {
 // calls to Record is used to track the number of rows for a stream.
 //
 // The stream ID of the recorded stream is returned.
-func (s *Streams) Record(streamLabels labels.Labels, ts time.Time) uint64 {
+func (s *Streams) Record(streamLabels labels.Labels, ts time.Time) int64 {
 	ts = ts.UTC()
 
 	stream := s.getOrAddStream(streamLabels)
@@ -67,7 +67,7 @@ func (s *Streams) Record(streamLabels labels.Labels, ts time.Time) uint64 {
 		stream.MaxTimestamp = ts
 	}
 	stream.Rows++
-	return uint64(stream.ID)
+	return stream.ID
 }
 
 // EstimatedSize returns the estimated size of the Streams section in bytes.

--- a/pkg/dataobj/internal/sections/streams/streams.go
+++ b/pkg/dataobj/internal/sections/streams/streams.go
@@ -15,6 +15,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/encoding"
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/metadata/datasetmd"
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/metadata/streamsmd"
+	"github.com/grafana/loki/v3/pkg/dataobj/internal/streamio"
 )
 
 // A Stream is an individual stream within a data object.
@@ -67,6 +68,43 @@ func (s *Streams) Record(streamLabels labels.Labels, ts time.Time) uint64 {
 	}
 	stream.Rows++
 	return uint64(stream.ID)
+}
+
+// EstimatedSize returns the estimated size of the Streams section in bytes.
+func (s *Streams) EstimatedSize() int {
+	// Since columns are only built when encoding, we can't use
+	// [dataset.ColumnBuilder.EstimatedSize] here.
+	//
+	// Instead, we use a basic heuristic, estimating delta encoding and
+	// compression:
+	//
+	// 1. Assume an ID delta of 1.
+	// 2. Assume a timestamp delta of 1s.
+	// 3. Assume a row count delta of 500.
+	// 4. Assume (conservative) 2x compression ratio of all label values.
+
+	var (
+		idDeltaSize        = streamio.VarintSize(1)
+		timestampDeltaSize = streamio.VarintSize(int64(time.Second))
+		rowDeltaSize       = streamio.VarintSize(500)
+	)
+
+	var labelsSize int
+	for _, stream := range s.ordered {
+		for _, lbl := range stream.Labels {
+			labelsSize += len(lbl.Value)
+		}
+	}
+
+	var sizeEstimate int
+
+	sizeEstimate += len(s.ordered) * idDeltaSize        // ID
+	sizeEstimate += len(s.ordered) * timestampDeltaSize // Min timestamp
+	sizeEstimate += len(s.ordered) * timestampDeltaSize // Max timestamp
+	sizeEstimate += len(s.ordered) * rowDeltaSize       // Rows
+	sizeEstimate += labelsSize / 2                      // All labels (2x compression ratio)
+
+	return sizeEstimate
 }
 
 func (s *Streams) getOrAddStream(streamLabels labels.Labels) *Stream {

--- a/pkg/dataobj/pools.go
+++ b/pkg/dataobj/pools.go
@@ -1,0 +1,12 @@
+package dataobj
+
+import (
+	"bytes"
+	"sync"
+)
+
+var bytesBufferPool = sync.Pool{
+	New: func() any {
+		return new(bytes.Buffer)
+	},
+}

--- a/pkg/dataobj/reader.go
+++ b/pkg/dataobj/reader.go
@@ -1,0 +1,111 @@
+package dataobj
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/thanos-io/objstore"
+
+	"github.com/grafana/loki/v3/pkg/dataobj/internal/encoding"
+	"github.com/grafana/loki/v3/pkg/dataobj/internal/result"
+	"github.com/grafana/loki/v3/pkg/dataobj/internal/sections/logs"
+	"github.com/grafana/loki/v3/pkg/dataobj/internal/sections/streams"
+	"github.com/grafana/loki/v3/pkg/logproto"
+)
+
+// reader connects to an object storage bucket and supports basic reading from
+// data objects.
+//
+// reader isn't exposed as a public API because it's insufficient for reading
+// at scale; more work is needed to support efficient reads and filtering data.
+// At the moment, reader is only used for tests.
+type reader struct {
+	bucket objstore.Bucket
+}
+
+func newReader(bucket objstore.Bucket) *reader {
+	return &reader{bucket: bucket}
+}
+
+// Objects returns an iterator over all data objects for the provided tenant.
+func (r *reader) Objects(ctx context.Context, tenant string) result.Seq[string] {
+	tenantPath := fmt.Sprintf("tenant-%s/objects/", tenant)
+
+	return result.Iter(func(yield func(string) bool) error {
+		errIterationStopped := errors.New("iteration stopped")
+
+		err := r.bucket.Iter(ctx, tenantPath, func(name string) error {
+			if !yield(name) {
+				return errIterationStopped
+			}
+			return nil
+		}, objstore.WithRecursiveIter())
+
+		switch {
+		case errors.Is(err, errIterationStopped):
+			return nil
+		default:
+			return err
+		}
+	})
+}
+
+// Streams returns an iterator over all [logproto.Stream] entries for the
+// provided object. Each emitted stream contains all logs for that stream in
+// ascending timestamp order. Streams are emitted in in the order they were
+// first appended to the data object.
+func (r *reader) Streams(ctx context.Context, object string) result.Seq[logproto.Stream] {
+	return result.Iter(func(yield func(logproto.Stream) bool) error {
+		dec := encoding.BucketDecoder(r.bucket, object)
+
+		streamRecords, err := result.Collect(streams.Iter(ctx, dec))
+		if err != nil {
+			return fmt.Errorf("reading streams dataset: %w", err)
+		}
+		streamRecordLookup := make(map[int64]streams.Stream, len(streamRecords))
+		for _, stream := range streamRecords {
+			streamRecordLookup[stream.ID] = stream
+		}
+
+		var (
+			lastID int64
+			batch  logproto.Stream
+		)
+
+		for result := range logs.Iter(ctx, dec) {
+			record, err := result.Value()
+			if err != nil {
+				return fmt.Errorf("iterating over logs: %w", err)
+			}
+
+			if lastID != record.StreamID {
+				if lastID != 0 && !yield(batch) {
+					return nil
+				}
+
+				streamRecord := streamRecordLookup[record.StreamID]
+
+				batch = logproto.Stream{
+					Labels: streamRecord.Labels.String(),
+					Hash:   streamRecord.Labels.Hash(),
+				}
+
+				lastID = record.StreamID
+			}
+
+			batch.Entries = append(batch.Entries, logproto.Entry{
+				Timestamp:          record.Timestamp,
+				Line:               record.Line,
+				StructuredMetadata: record.Metadata,
+			})
+		}
+		if len(batch.Entries) > 0 {
+			if !yield(batch) {
+				return nil
+			}
+		}
+
+		return nil
+	})
+}


### PR DESCRIPTION
This PR adds initial end-to-end support for data objects:

* dataobj.Builder gradually constructs a data object via calls to Append.
* Once the builder returns ErrBufferFull, the data object must be flushed with a call to Flush.

Whether a builder is full is based on basic heuristics: 

* The size of a logs section is determined by cut pages and the uncompressed size of the current head page. 
* The size of a streams section is determined by estimating the cost of delta-encoding and compressing label values. 
* The size of an incoming `logproto.Stream` is determined by its labels, line length, and metadata, with a compression estimate applied where appropriate. 

These estimates are conservative and tend to overestimate; this helps keep objects slightly under the limit when flushing. 

I needed to do a fair amount of additional plumbing work to wire this all together. I separated the code across a few commits to make this easier to review. 