### PR TITLE
feat(loki-mixin): updated meta-monitoring support 

### DIFF
--- a/production/loki-mixin/README.md
+++ b/production/loki-mixin/README.md
@@ -20,15 +20,16 @@ To install it follow the instructions at: https://grafana.github.io/grizzly/inst
 jb install
 ```
 
-* On your Grafana instance create an API key with role 'Admin' under Configuration > API keys. 
+* On your Grafana instance create an API key with role 'Admin' under Configuration > API keys.
 Copy this key for the next step.
 
 ### Testing dashboards
 
+To simply test the dashboard layout
 To test the dashboard in your local grafana instance, in directory `production/loki-mixin` run the command:
 
 ```shell
-GRAFANA_URL=http://localhost:3000 GRAFANA_TOKEN=<API_KEY> JSONNET_PATH=$(pwd)/lib:$(pwd)/vendor grr watch ./ dashboards.libsonnet
+GRAFANA_URL=http://localhost:3000 GRAFANA_TOKEN=<API_KEY> JSONNET_PATH=$(pwd)/lib:$(pwd)/vendor grr watch ./ grr.libsonnet
 ```
 
 `grr watch` will detect changes when you save files and try to add/update dashboards:
@@ -42,6 +43,20 @@ Dashboard.writes-resources added
 Dashboard.reads updated
 Dashboard.writes updated
 ...
+```
+
+To test the dashboard and rules, in directory `production/loki-mixin` run the command:
+
+```shell
+GRAFANA_URL=http://localhost:3000 GRAFANA_TOKEN=<API_KEY> \
+  MIMIR_ADDRESS=http://localhost:9090 MIMIR_TENANT_ID=<TENANT_ID> MIMIR_API_KEY=<API_KEY> \
+  JSONNET_PATH=$(pwd)/lib:$(pwd)/vendor grr watch ./ grr.libsonnet
+```
+
+Alternatively, you can setup a [grizzly context](https://grafana.github.io/grizzly/configuration/) for reuse, in which case you can run the command:
+
+```shell
+grr watch ./ grr.libsonnet
 ```
 
 **Disclaimer:** Since these dashboards are used on our own production setup, these contain very specific configurations to our cloud environment which may need to overridden for other setups and use-cases.

--- a/production/loki-mixin/config.libsonnet
+++ b/production/loki-mixin/config.libsonnet
@@ -80,7 +80,10 @@
 
     // Meta-monitoring related configuration
     meta_monitoring: {
-      enabled: false,
+      enabled: true,
+
+      // The prefix used to match the job labels, i.e. job="logs/loki-ingester"
+      job_prefix: '((loki|enterprise-logs)-)?',
     },
   },
 }

--- a/production/loki-mixin/dashboards/dashboard-utils.libsonnet
+++ b/production/loki-mixin/dashboards/dashboard-utils.libsonnet
@@ -20,7 +20,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
               options: [],
               query: 'loki',
               refresh: 1,
-              regex: '',
+              regex: '(?!grafanacloud-.+(alert-state-history|usage-insights)).+',
               type: 'datasource',
             },
           ],

--- a/production/loki-mixin/dashboards/loki-bloom-build.libsonnet
+++ b/production/loki-mixin/dashboards/loki-bloom-build.libsonnet
@@ -23,29 +23,11 @@ local template = import 'grafonnet/template.libsonnet';
     'loki-bloom-build.json':
       raw
       {
-        local replaceClusterMatchers(expr) =
-          // Replace the recording rules cluster label with the per-cluster label
-          std.strReplace(
-            // Replace the cluster label for equality matchers with the per-cluster label
-            std.strReplace(
-              // Replace the cluster label for regex matchers with the per-cluster label
-              std.strReplace(
-                expr,
-                'cluster=~"$cluster"',
-                $._config.per_cluster_label + '=~"$cluster"'
-              ),
-              'cluster="$cluster"',
-              $._config.per_cluster_label + '="$cluster"'
-            ),
-            'cluster_job',
-            $._config.per_cluster_label + '_job'
-          ),
-
         panels: [
           p {
             targets: if std.objectHas(p, 'targets') then [
               e {
-                expr: replaceClusterMatchers(e.expr),
+                expr: $.replaceMatchers(e.expr),
               }
               for e in p.targets
             ] else [],
@@ -53,7 +35,7 @@ local template = import 'grafonnet/template.libsonnet';
               sp {
                 targets: if std.objectHas(sp, 'targets') then [
                   spe {
-                    expr: replaceClusterMatchers(spe.expr),
+                    expr: $.replaceMatchers(spe.expr),
                   }
                   for spe in sp.targets
                 ] else [],
@@ -61,7 +43,7 @@ local template = import 'grafonnet/template.libsonnet';
                   ssp {
                     targets: if std.objectHas(ssp, 'targets') then [
                       sspe {
-                        expr: replaceClusterMatchers(sspe.expr),
+                        expr: $.replaceMatchers(sspe.expr),
                       }
                       for sspe in ssp.targets
                     ] else [],

--- a/production/loki-mixin/dashboards/loki-bloom-gateway.libsonnet
+++ b/production/loki-mixin/dashboards/loki-bloom-gateway.libsonnet
@@ -10,29 +10,11 @@ local raw = (import './dashboard-bloom-gateway.json');
     'loki-bloom-gateway.json':
       raw
       {
-        local replaceClusterMatchers(expr) =
-          // Replace the recording rules cluster label with the per-cluster label
-          std.strReplace(
-            // Replace the cluster label for equality matchers with the per-cluster label
-            std.strReplace(
-              // Replace the cluster label for regex matchers with the per-cluster label
-              std.strReplace(
-                expr,
-                'cluster=~"$cluster"',
-                $._config.per_cluster_label + '=~"$cluster"'
-              ),
-              'cluster="$cluster"',
-              $._config.per_cluster_label + '="$cluster"'
-            ),
-            'cluster_job',
-            $._config.per_cluster_label + '_job'
-          ),
-
         panels: [
           p {
             targets: if std.objectHas(p, 'targets') then [
               e {
-                expr: replaceClusterMatchers(e.expr),
+                expr: $.replaceMatchers(e.expr),
               }
               for e in p.targets
             ] else [],
@@ -40,7 +22,7 @@ local raw = (import './dashboard-bloom-gateway.json');
               sp {
                 targets: if std.objectHas(sp, 'targets') then [
                   spe {
-                    expr: replaceClusterMatchers(spe.expr),
+                    expr: $.replaceMatchers(spe.expr),
                   }
                   for spe in sp.targets
                 ] else [],
@@ -48,7 +30,7 @@ local raw = (import './dashboard-bloom-gateway.json');
                   ssp {
                     targets: if std.objectHas(ssp, 'targets') then [
                       sspe {
-                        expr: replaceClusterMatchers(sspe.expr),
+                        expr: $.replaceMatchers(sspe.expr),
                       }
                       for sspe in ssp.targets
                     ] else [],

--- a/production/loki-mixin/dashboards/loki-chunks.libsonnet
+++ b/production/loki-mixin/dashboards/loki-chunks.libsonnet
@@ -8,7 +8,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
                           local cfg = self,
                           labelsSelector:: $._config.per_cluster_label + '="$cluster", job=~"$namespace/%s"' % (
                             if $._config.meta_monitoring.enabled
-                            then '(ingester.*|partition-ingester.*|%s-write|loki-single-binary)' % $._config.ssd.pod_prefix_matcher
+                            then '%s(ingester.*|partition-ingester.*|%s-write|loki-single-binary)' % [$._config.meta_monitoring.job_prefix, $._config.ssd.pod_prefix_matcher]
                             else if $._config.ssd.enabled then '%s-write' % $._config.ssd.pod_prefix_matcher else '(ingester.*|partition-ingester.*)'
                           ),
                         } +

--- a/production/loki-mixin/dashboards/loki-operational.libsonnet
+++ b/production/loki-mixin/dashboards/loki-operational.libsonnet
@@ -33,16 +33,16 @@ local utils = import 'mixin-utils/utils.libsonnet';
                                jobMatchers:: {
                                  cortexgateway: [utils.selector.re('job', '($namespace)/cortex-gw(-internal)?')],
                                  distributor: if $._config.meta_monitoring.enabled
-                                 then [utils.selector.re('job', '($namespace)/(distributor|%s-write|loki-single-binary)' % $._config.ssd.pod_prefix_matcher)]
+                                 then [utils.selector.re('job', '($namespace)/%s(distributor|%s-write|loki-single-binary)' % [$._config.meta_monitoring.job_prefix, $._config.ssd.pod_prefix_matcher])]
                                  else [utils.selector.re('job', '($namespace)/%s' % (if $._config.ssd.enabled then '%s-write' % $._config.ssd.pod_prefix_matcher else 'distributor'))],
                                  ingester: if $._config.meta_monitoring.enabled
-                                 then [utils.selector.re('job', '($namespace)/(partition-ingester.*|ingester.*|%s-write|loki-single-binary)' % $._config.ssd.pod_prefix_matcher)]
+                                 then [utils.selector.re('job', '($namespace)/%s(partition-ingester.*|ingester.*|%s-write|loki-single-binary)' % [$._config.meta_monitoring.job_prefix, $._config.ssd.pod_prefix_matcher])]
                                  else [utils.selector.re('job', '($namespace)/%s' % (if $._config.ssd.enabled then '%s-write' % $._config.ssd.pod_prefix_matcher else '(ingester.*|partition-ingester.*)'))],
                                  querier: if $._config.meta_monitoring.enabled
-                                 then [utils.selector.re('job', '($namespace)/(querier|%s-read|loki-single-binary)' % $._config.ssd.pod_prefix_matcher)]
+                                 then [utils.selector.re('job', '($namespace)/%s(querier|%s-read|loki-single-binary)' % [$._config.meta_monitoring.job_prefix, $._config.ssd.pod_prefix_matcher])]
                                  else [utils.selector.re('job', '($namespace)/%s' % (if $._config.ssd.enabled then '%s-read' % $._config.ssd.pod_prefix_matcher else 'querier'))],
                                  queryFrontend: if $._config.meta_monitoring.enabled
-                                 then [utils.selector.re('job', '($namespace)/(query-frontend|%s-read|loki-single-binary)' % $._config.ssd.pod_prefix_matcher)]
+                                 then [utils.selector.re('job', '($namespace)/%s(query-frontend|%s-read|loki-single-binary)' % [$._config.meta_monitoring.job_prefix, $._config.ssd.pod_prefix_matcher])]
                                  else [utils.selector.re('job', '($namespace)/%s' % (if $._config.ssd.enabled then '%s-read' % $._config.ssd.pod_prefix_matcher else 'query-frontend'))],
                                  backend: [utils.selector.re('job', '($namespace)/%s-backend' % $._config.ssd.pod_prefix_matcher)],
                                },

--- a/production/loki-mixin/dashboards/loki-reads-resources.libsonnet
+++ b/production/loki-mixin/dashboards/loki-reads-resources.libsonnet
@@ -10,7 +10,7 @@
   then 'container=~"loki|ingester|partition-ingester", pod=~"(ingester.*|partition-ingester.*|loki-single-binary)"'
   else 'container=~"ingester|partition-ingester"',
   local ingester_job_matcher = if $._config.meta_monitoring.enabled
-  then '(ingester.*|partition-ingester.*|loki-single-binary)'
+  then '%s(ingester.*|partition-ingester.*|loki-single-binary)' % $._config.meta_monitoring.job_prefix
   else '(ingester|partition-ingester).*',
 
   grafanaDashboards+:: if $._config.ssd.enabled then {} else {

--- a/production/loki-mixin/dashboards/loki-reads.libsonnet
+++ b/production/loki-mixin/dashboards/loki-reads.libsonnet
@@ -68,25 +68,25 @@ local utils = import 'mixin-utils/utils.libsonnet';
                          matchers:: {
                            cortexgateway: [utils.selector.re('job', '($namespace)/cortex-gw(-internal)?')],
                            queryFrontend: if $._config.meta_monitoring.enabled
-                           then [utils.selector.re('job', '($namespace)/(query-frontend|%s-read|loki-single-binary)' % $._config.ssd.pod_prefix_matcher)]
+                           then [utils.selector.re('job', '($namespace)/%s(query-frontend|%s-read|loki-single-binary)' % [$._config.meta_monitoring.job_prefix,$._config.ssd.pod_prefix_matcher])]
                            else [utils.selector.re('job', '($namespace)/%s' % (if $._config.ssd.enabled then '%s-read' % $._config.ssd.pod_prefix_matcher else 'query-frontend'))],
                            querier: if $._config.meta_monitoring.enabled
-                           then [utils.selector.re('job', '($namespace)/(querier|%s-read|loki-single-binary)' % $._config.ssd.pod_prefix_matcher)]
+                           then [utils.selector.re('job', '($namespace)/%s(querier|%s-read|loki-single-binary)' % [$._config.meta_monitoring.job_prefix,$._config.ssd.pod_prefix_matcher])]
                            else [utils.selector.re('job', '($namespace)/%s' % (if $._config.ssd.enabled then '%s-read' % $._config.ssd.pod_prefix_matcher else 'querier'))],
                            ingester: if $._config.meta_monitoring.enabled
-                           then [utils.selector.re('job', '($namespace)/(partition-ingester.*|ingester.*|%s-write|loki-single-binary)' % $._config.ssd.pod_prefix_matcher)]
+                           then [utils.selector.re('job', '($namespace)/%s(partition-ingester.*|ingester.*|%s-write|loki-single-binary)' % [$._config.meta_monitoring.job_prefix,$._config.ssd.pod_prefix_matcher])]
                            else [utils.selector.re('job', '($namespace)/%s' % (if $._config.ssd.enabled then '%s-write' % $._config.ssd.pod_prefix_matcher else '(ingester.*|partition-ingester.*)'))],
                            ingesterZoneAware: if $._config.meta_monitoring.enabled
-                           then [utils.selector.re('job', '($namespace)/(partition-ingester-.*|ingester-zone-.*|%s-write|loki-single-binary)' % $._config.ssd.pod_prefix_matcher)]
+                           then [utils.selector.re('job', '($namespace)/%s(partition-ingester-.*|ingester-zone-.*|%s-write|loki-single-binary)' % [$._config.meta_monitoring.job_prefix,$._config.ssd.pod_prefix_matcher])]
                            else [utils.selector.re('job', '($namespace)/%s' % (if $._config.ssd.enabled then '%s-write' % $._config.ssd.pod_prefix_matcher else '(partition-ingester-.*|ingester-zone.*)'))],
                            querierOrIndexGateway: if $._config.meta_monitoring.enabled
-                           then [utils.selector.re('job', '($namespace)/(querier|index-gateway|%s-read|loki-single-binary)' % $._config.ssd.pod_prefix_matcher)]
+                           then [utils.selector.re('job', '($namespace)/%s(querier|index-gateway|%s-read|loki-single-binary)' % [$._config.meta_monitoring.job_prefix,$._config.ssd.pod_prefix_matcher])]
                            else [utils.selector.re('job', '($namespace)/%s' % (if $._config.ssd.enabled then '%s-read' % $._config.ssd.pod_prefix_matcher else '(querier|index-gateway)'))],
                            indexGateway: if $._config.meta_monitoring.enabled
-                           then [utils.selector.re('job', '($namespace)/(index-gateway|%s-backend|loki-single-binary)' % $._config.ssd.pod_prefix_matcher)]
+                           then [utils.selector.re('job', '($namespace)/%s(index-gateway|%s-backend|loki-single-binary)' % [$._config.meta_monitoring.job_prefix,$._config.ssd.pod_prefix_matcher])]
                            else [utils.selector.re('job', '($namespace)/%s' % (if $._config.ssd.enabled then '%s-backend' % $._config.ssd.pod_prefix_matcher else 'index-gateway'))],
                            bloomGateway: if $._config.meta_monitoring.enabled
-                           then [utils.selector.re('job', '($namespace)/(bloom-gateway|%s-backend|loki-single-binary)' % $._config.ssd.pod_prefix_matcher)]
+                           then [utils.selector.re('job', '($namespace)/%s(bloom-gateway|%s-backend|loki-single-binary)' % [$._config.meta_monitoring.job_prefix,$._config.ssd.pod_prefix_matcher])]
                            else [utils.selector.re('job', '($namespace)/%s' % (if $._config.ssd.enabled then '%s-backend' % $._config.ssd.pod_prefix_matcher else 'bloom-gateway'))],
                          },
 

--- a/production/loki-mixin/dashboards/loki-writes-resources.libsonnet
+++ b/production/loki-mixin/dashboards/loki-writes-resources.libsonnet
@@ -3,7 +3,7 @@
   then 'container=~"loki|ingester|partition-ingester", pod=~"(ingester.*|partition-ingester.*|loki-single-binary)"'
   else 'container=~"ingester|partition-ingester"',
   local ingester_job_matcher = if $._config.meta_monitoring.enabled
-  then '(ingester.*|partition-ingester.*|loki-single-binary)'
+  then '%s(ingester.*|partition-ingester.*|loki-single-binary)' % $._config.meta_monitoring.job_prefix
   else '(ingester.*|partition-ingester.*)',
 
   grafanaDashboards+:: if $._config.ssd.enabled then {} else {

--- a/production/loki-mixin/dashboards/loki-writes.libsonnet
+++ b/production/loki-mixin/dashboards/loki-writes.libsonnet
@@ -6,230 +6,230 @@ local utils = import 'mixin-utils/utils.libsonnet';
     local showBigTable = false,
 
     'loki-writes.json': {
-                          local cfg = self,
+      local cfg = self,
 
-                          showMultiCluster:: true,
-                          clusterMatchers::
-                            if cfg.showMultiCluster then
-                              [utils.selector.re($._config.per_cluster_label, '$cluster')]
-                            else
-                              [],
+      showMultiCluster:: true,
+      clusterMatchers::
+        if cfg.showMultiCluster then
+          [utils.selector.re($._config.per_cluster_label, '$cluster')]
+        else
+          [],
 
-                          matchers:: {
-                            cortexgateway: [utils.selector.re('job', '($namespace)/cortex-gw(-internal)?')],
-                            distributor: if $._config.meta_monitoring.enabled
-                            then [utils.selector.re('job', '($namespace)/(distributor|%s-write|loki-single-binary)' % $._config.ssd.pod_prefix_matcher)]
-                            else [utils.selector.re('job', '($namespace)/%s' % (if $._config.ssd.enabled then '%s-write' % $._config.ssd.pod_prefix_matcher else 'distributor'))],
-                            ingester: if $._config.meta_monitoring.enabled
-                            then [utils.selector.re('job', '($namespace)/(partition-ingester.*|ingester.*|%s-write|loki-single-binary)' % $._config.ssd.pod_prefix_matcher)]
-                            else [utils.selector.re('job', '($namespace)/%s' % (if $._config.ssd.enabled then '%s-write' % $._config.ssd.pod_prefix_matcher else '(ingester.*|partition-ingester.*)'))],
-                            ingester_zone: if $._config.meta_monitoring.enabled
-                            then [utils.selector.re('job', '($namespace)/(partition-ingester-.*|ingester-zone-.*|%s-write|loki-single-binary)' % $._config.ssd.pod_prefix_matcher)]
-                            else [utils.selector.re('job', '($namespace)/%s' % (if $._config.ssd.enabled then '%s-write' % $._config.ssd.pod_prefix_matcher else '(ingester-zone.*|partition-ingester-.*)'))],
-                          },
+      matchers:: {
+        cortexgateway: [utils.selector.re('job', '($namespace)/cortex-gw(-internal)?')],
+        distributor: if $._config.meta_monitoring.enabled
+        then [utils.selector.re('job', '($namespace)/%s(distributor|%s-write|loki-single-binary)' % [$._config.meta_monitoring.job_prefix, $._config.ssd.pod_prefix_matcher])]
+        else [utils.selector.re('job', '($namespace)/%s' % (if $._config.ssd.enabled then '%s-write' % $._config.ssd.pod_prefix_matcher else 'distributor'))],
+        ingester: if $._config.meta_monitoring.enabled
+        then [utils.selector.re('job', '($namespace)/%s(partition-ingester.*|ingester.*|%s-write|loki-single-binary)' % [$._config.meta_monitoring.job_prefix, $._config.ssd.pod_prefix_matcher])]
+        else [utils.selector.re('job', '($namespace)/%s' % (if $._config.ssd.enabled then '%s-write' % $._config.ssd.pod_prefix_matcher else '(ingester.*|partition-ingester.*)'))],
+        ingester_zone: if $._config.meta_monitoring.enabled
+        then [utils.selector.re('job', '($namespace)/%s(partition-ingester-.*|ingester-zone-.*|%s-write|loki-single-binary)' % [$._config.meta_monitoring.job_prefix, $._config.ssd.pod_prefix_matcher])]
+        else [utils.selector.re('job', '($namespace)/%s' % (if $._config.ssd.enabled then '%s-write' % $._config.ssd.pod_prefix_matcher else '(ingester-zone.*|partition-ingester-.*)'))],
+      },
 
-                          local selector(matcherId) =
-                            local ms = cfg.clusterMatchers + cfg.matchers[matcherId];
-                            if std.length(ms) > 0 then
-                              std.join(',', ['%(label)s%(op)s"%(value)s"' % matcher for matcher in ms]) + ','
-                            else '',
+      local selector(matcherId) =
+        local ms = cfg.clusterMatchers + cfg.matchers[matcherId];
+        if std.length(ms) > 0 then
+          std.join(',', ['%(label)s%(op)s"%(value)s"' % matcher for matcher in ms]) + ','
+        else '',
 
-                          cortexGwSelector:: selector('cortexgateway'),
-                          distributorSelector:: selector('distributor'),
-                          ingesterSelector:: selector('ingester'),
-                          ingesterZoneSelector:: selector('ingester_zone'),
-                        } +
-                        $.dashboard('Loki / Writes', uid='writes')
-                        .addCluster()
-                        .addNamespace()
-                        .addTag()
-                        .addRowIf(
-                          $._config.internal_components,
-                          $.row('Frontend (cortex_gw)')
-                          .addPanel(
-                            $.newQueryPanel('QPS') +
-                            $.newQpsPanel('loki_request_duration_seconds_count{%s route=~"api_prom_push|loki_api_v1_push|otlp_v1_logs"}' % dashboards['loki-writes.json'].cortexGwSelector)
-                          )
-                          .addPanel(
-                            $.newQueryPanel('Latency', 'ms') +
-                            utils.latencyRecordingRulePanel(
-                              'loki_request_duration_seconds',
-                              dashboards['loki-writes.json'].clusterMatchers +
-                              dashboards['loki-writes.json'].matchers.cortexgateway +
-                              [utils.selector.re('route', 'api_prom_push|loki_api_v1_push|otlp_v1_logs')],
-                            )
-                          )
-                          .addPanel(
-                            $.p99LatencyByPod(
-                              'loki_request_duration_seconds',
-                              $.toPrometheusSelector(
-                                dashboards['loki-writes.json'].clusterMatchers +
-                                dashboards['loki-writes.json'].matchers.cortexgateway +
-                                [utils.selector.re('route', 'api_prom_push|loki_api_v1_push|otlp_v1_logs')],
-                              ),
-                            )
-                          )
-                        )
-                        .addRow(
-                          $.row(if $._config.ssd.enabled then 'Write Path' else 'Distributor')
-                          .addPanel(
-                            $.newQueryPanel('QPS') +
-                            $.newQpsPanel('loki_request_duration_seconds_count{%s, route=~"api_prom_push|loki_api_v1_push|otlp_v1_logs|/httpgrpc.HTTP/Handle"}' % std.rstripChars(dashboards['loki-writes.json'].distributorSelector, ','))
-                          )
-                          .addPanel(
-                            $.newQueryPanel('Latency', 'ms') +
-                            utils.latencyRecordingRulePanel(
-                              'loki_request_duration_seconds',
-                              dashboards['loki-writes.json'].clusterMatchers +
-                              dashboards['loki-writes.json'].matchers.distributor +
-                              [utils.selector.re('route', 'api_prom_push|loki_api_v1_push|otlp_v1_logs|/httpgrpc.HTTP/Handle')],
-                            )
-                          )
-                          .addPanel(
-                            $.p99LatencyByPod(
-                              'loki_request_duration_seconds',
-                              $.toPrometheusSelector(
-                                dashboards['loki-writes.json'].clusterMatchers +
-                                dashboards['loki-writes.json'].matchers.distributor +
-                                [utils.selector.re('route', 'api_prom_push|loki_api_v1_push|otlp_v1_logs|/httpgrpc.HTTP/Handle')],
-                              ),
-                            )
-                          )
-                        )
-                        .addRowIf(
-                          $._config.tsdb,
-                          $.row((if $._config.ssd.enabled then 'Write Path' else 'Distributor') + ' - Structured Metadata')
-                          .addPanel(
-                            $.newQueryPanel('Per Total Received Bytes') +
-                            $.queryPanel('sum (rate(loki_distributor_structured_metadata_bytes_received_total{%s}[$__rate_interval])) / sum(rate(loki_distributor_bytes_received_total{%s}[$__rate_interval]))' % [dashboards['loki-writes.json'].distributorSelector, dashboards['loki-writes.json'].distributorSelector], 'bytes')
-                          )
-                          .addPanel(
-                            $.newQueryPanel('Per Tenant') +
-                            $.queryPanel('sum by (tenant) (rate(loki_distributor_structured_metadata_bytes_received_total{%s}[$__rate_interval])) / ignoring(tenant) group_left sum(rate(loki_distributor_structured_metadata_bytes_received_total{%s}[$__rate_interval]))' % [dashboards['loki-writes.json'].distributorSelector, dashboards['loki-writes.json'].distributorSelector], '{{tenant}}') + {
-                              stack: true,
-                              yaxes: [
-                                { format: 'short', label: null, logBase: 1, max: 1, min: 0, show: true },
-                                { format: 'short', label: null, logBase: 1, max: 1, min: null, show: false },
-                              ],
-                            },
-                          )
-                        )
-                        .addRowIf(
-                          !$._config.ssd.enabled,
-                          $.row('Ingester - Zone Aware')
-                          .addPanel(
-                            $.newQueryPanel('QPS') +
-                            $.newQpsPanel('loki_request_duration_seconds_count{%s route="/logproto.Pusher/Push"}' % dashboards['loki-writes.json'].ingesterZoneSelector)
-                          )
-                          .addPanel(
-                            $.newQueryPanel('Latency', 'ms') +
-                            utils.latencyRecordingRulePanel(
-                              'loki_request_duration_seconds',
-                              dashboards['loki-writes.json'].clusterMatchers +
-                              dashboards['loki-writes.json'].matchers.ingester_zone +
-                              [utils.selector.eq('route', '/logproto.Pusher/Push')],
-                            )
-                          )
-                          .addPanel(
-                            $.p99LatencyByPod(
-                              'loki_request_duration_seconds',
-                              $.toPrometheusSelector(
-                                dashboards['loki-writes.json'].clusterMatchers +
-                                dashboards['loki-writes.json'].matchers.ingester_zone +
-                                [utils.selector.eq('route', '/logproto.Pusher/Push')],
-                              ),
-                            )
-                          )
-                        )
-                        .addRowIf(
-                          !$._config.ssd.enabled,
-                          $.row('Ingester')
-                          .addPanel(
-                            $.newQueryPanel('QPS') +
-                            $.newQpsPanel('loki_request_duration_seconds_count{%s route="/logproto.Pusher/Push"}' % dashboards['loki-writes.json'].ingesterSelector)
-                          )
-                          .addPanel(
-                            $.newQueryPanel('Latency', 'ms') +
-                            utils.latencyRecordingRulePanel(
-                              'loki_request_duration_seconds',
-                              dashboards['loki-writes.json'].clusterMatchers +
-                              dashboards['loki-writes.json'].matchers.ingester +
-                              [utils.selector.eq('route', '/logproto.Pusher/Push')],
-                            )
-                          )
-                          .addPanel(
-                            $.p99LatencyByPod(
-                              'loki_request_duration_seconds',
-                              $.toPrometheusSelector(
-                                dashboards['loki-writes.json'].clusterMatchers +
-                                dashboards['loki-writes.json'].matchers.ingester +
-                                [utils.selector.eq('route', '/logproto.Pusher/Push')]
-                              ),
-                            )
-                          )
-                        )
-                        .addRowIf(
-                          !$._config.ssd.enabled,
-                          $.row('Index')
-                          .addPanel(
-                            $.newQueryPanel('QPS') +
-                            $.newQpsPanel('loki_index_request_duration_seconds_count{%s operation="index_chunk"}' % dashboards['loki-writes.json'].ingesterSelector)
-                          )
-                          .addPanel(
-                            $.newQueryPanel('Latency', 'ms') +
-                            $.latencyPanel('loki_index_request_duration_seconds', '{%s operation="index_chunk"}' % dashboards['loki-writes.json'].ingesterSelector)
-                          )
-                          .addPanel(
-                            $.p99LatencyByPod(
-                              'loki_index_request_duration_seconds',
-                              '{%s operation="index_chunk"}' % dashboards['loki-writes.json'].ingesterSelector,
-                            )
-                          )
-                        )
-                        .addRowIf(
-                          showBigTable,
-                          $.row('BigTable')
-                          .addPanel(
-                            $.newQueryPanel('QPS') +
-                            $.newQpsPanel('loki_bigtable_request_duration_seconds_count{%s operation="/google.bigtable.v2.Bigtable/MutateRows"}' % dashboards['loki-writes.json'].ingesterSelector)
-                          )
-                          .addPanel(
-                            $.newQueryPanel('Latency', 'ms') +
-                            utils.latencyRecordingRulePanel(
-                              'loki_bigtable_request_duration_seconds',
-                              dashboards['loki-writes.json'].clusterMatchers +
-                              dashboards['loki-writes.json'].matchers.ingester +
-                              [utils.selector.eq('operation', '/google.bigtable.v2.Bigtable/MutateRows')],
-                            )
-                          )
-                          .addPanel(
-                            $.p99LatencyByPod(
-                              'loki_bigtable_request_duration_seconds',
-                              $.toPrometheusSelector(
-                                dashboards['loki-writes.json'].clusterMatchers +
-                                dashboards['loki-writes.json'].matchers.ingester +
-                                [utils.selector.eq('operation', '/google.bigtable.v2.Bigtable/MutateRows')],
-                              ),
-                            )
-                          )
-                        )
-                        .addRowIf(
-                          !$._config.ssd.enabled,
-                          $.row('BoltDB Index')
-                          .addPanel(
-                            $.newQueryPanel('QPS') +
-                            $.newQpsPanel('loki_boltdb_shipper_request_duration_seconds_count{%s operation="WRITE"}' % dashboards['loki-writes.json'].ingesterSelector)
-                          )
-                          .addPanel(
-                            $.newQueryPanel('Latency', 'ms') +
-                            $.latencyPanel('loki_boltdb_shipper_request_duration_seconds', '{%s operation="WRITE"}' % dashboards['loki-writes.json'].ingesterSelector)
-                          )
-                          .addPanel(
-                            $.p99LatencyByPod(
-                              'loki_boltdb_shipper_request_duration_seconds',
-                              '{%s operation="WRITE"}' % dashboards['loki-writes.json'].ingesterSelector,
-                            )
-                          )
-                        ),
+      cortexGwSelector:: selector('cortexgateway'),
+      distributorSelector:: selector('distributor'),
+      ingesterSelector:: selector('ingester'),
+      ingesterZoneSelector:: selector('ingester_zone'),
+    } +
+    $.dashboard('Loki / Writes', uid='writes')
+    .addCluster()
+    .addNamespace()
+    .addTag()
+    .addRowIf(
+      $._config.internal_components,
+      $.row('Frontend (cortex_gw)')
+      .addPanel(
+        $.newQueryPanel('QPS') +
+        $.newQpsPanel('loki_request_duration_seconds_count{%s route=~"api_prom_push|loki_api_v1_push|otlp_v1_logs"}' % dashboards['loki-writes.json'].cortexGwSelector)
+      )
+      .addPanel(
+        $.newQueryPanel('Latency', 'ms') +
+        utils.latencyRecordingRulePanel(
+          'loki_request_duration_seconds',
+          dashboards['loki-writes.json'].clusterMatchers +
+          dashboards['loki-writes.json'].matchers.cortexgateway +
+          [utils.selector.re('route', 'api_prom_push|loki_api_v1_push|otlp_v1_logs')],
+        )
+      )
+      .addPanel(
+        $.p99LatencyByPod(
+          'loki_request_duration_seconds',
+          $.toPrometheusSelector(
+            dashboards['loki-writes.json'].clusterMatchers +
+            dashboards['loki-writes.json'].matchers.cortexgateway +
+            [utils.selector.re('route', 'api_prom_push|loki_api_v1_push|otlp_v1_logs')],
+          ),
+        )
+      )
+    )
+    .addRow(
+      $.row(if $._config.ssd.enabled then 'Write Path' else 'Distributor')
+      .addPanel(
+        $.newQueryPanel('QPS') +
+        $.newQpsPanel('loki_request_duration_seconds_count{%s, route=~"api_prom_push|loki_api_v1_push|otlp_v1_logs|/httpgrpc.HTTP/Handle"}' % std.rstripChars(dashboards['loki-writes.json'].distributorSelector, ','))
+      )
+      .addPanel(
+        $.newQueryPanel('Latency', 'ms') +
+        utils.latencyRecordingRulePanel(
+          'loki_request_duration_seconds',
+          dashboards['loki-writes.json'].clusterMatchers +
+          dashboards['loki-writes.json'].matchers.distributor +
+          [utils.selector.re('route', 'api_prom_push|loki_api_v1_push|otlp_v1_logs|/httpgrpc.HTTP/Handle')],
+        )
+      )
+      .addPanel(
+        $.p99LatencyByPod(
+          'loki_request_duration_seconds',
+          $.toPrometheusSelector(
+            dashboards['loki-writes.json'].clusterMatchers +
+            dashboards['loki-writes.json'].matchers.distributor +
+            [utils.selector.re('route', 'api_prom_push|loki_api_v1_push|otlp_v1_logs|/httpgrpc.HTTP/Handle')],
+          ),
+        )
+      )
+    )
+    .addRowIf(
+      $._config.tsdb,
+      $.row((if $._config.ssd.enabled then 'Write Path' else 'Distributor') + ' - Structured Metadata')
+      .addPanel(
+        $.newQueryPanel('Per Total Received Bytes') +
+        $.queryPanel('sum (rate(loki_distributor_structured_metadata_bytes_received_total{%s}[$__rate_interval])) / sum(rate(loki_distributor_bytes_received_total{%s}[$__rate_interval]))' % [dashboards['loki-writes.json'].distributorSelector, dashboards['loki-writes.json'].distributorSelector], 'bytes')
+      )
+      .addPanel(
+        $.newQueryPanel('Per Tenant') +
+        $.queryPanel('sum by (tenant) (rate(loki_distributor_structured_metadata_bytes_received_total{%s}[$__rate_interval])) / ignoring(tenant) group_left sum(rate(loki_distributor_structured_metadata_bytes_received_total{%s}[$__rate_interval]))' % [dashboards['loki-writes.json'].distributorSelector, dashboards['loki-writes.json'].distributorSelector], '{{tenant}}') + {
+          stack: true,
+          yaxes: [
+            { format: 'short', label: null, logBase: 1, max: 1, min: 0, show: true },
+            { format: 'short', label: null, logBase: 1, max: 1, min: null, show: false },
+          ],
+        },
+      )
+    )
+    .addRowIf(
+      !$._config.ssd.enabled,
+      $.row('Ingester - Zone Aware')
+      .addPanel(
+        $.newQueryPanel('QPS') +
+        $.newQpsPanel('loki_request_duration_seconds_count{%s route="/logproto.Pusher/Push"}' % dashboards['loki-writes.json'].ingesterZoneSelector)
+      )
+      .addPanel(
+        $.newQueryPanel('Latency', 'ms') +
+        utils.latencyRecordingRulePanel(
+          'loki_request_duration_seconds',
+          dashboards['loki-writes.json'].clusterMatchers +
+          dashboards['loki-writes.json'].matchers.ingester_zone +
+          [utils.selector.eq('route', '/logproto.Pusher/Push')],
+        )
+      )
+      .addPanel(
+        $.p99LatencyByPod(
+          'loki_request_duration_seconds',
+          $.toPrometheusSelector(
+            dashboards['loki-writes.json'].clusterMatchers +
+            dashboards['loki-writes.json'].matchers.ingester_zone +
+            [utils.selector.eq('route', '/logproto.Pusher/Push')],
+          ),
+        )
+      )
+    )
+    .addRowIf(
+      !$._config.ssd.enabled,
+      $.row('Ingester')
+      .addPanel(
+        $.newQueryPanel('QPS') +
+        $.newQpsPanel('loki_request_duration_seconds_count{%s route="/logproto.Pusher/Push"}' % dashboards['loki-writes.json'].ingesterSelector)
+      )
+      .addPanel(
+        $.newQueryPanel('Latency', 'ms') +
+        utils.latencyRecordingRulePanel(
+          'loki_request_duration_seconds',
+          dashboards['loki-writes.json'].clusterMatchers +
+          dashboards['loki-writes.json'].matchers.ingester +
+          [utils.selector.eq('route', '/logproto.Pusher/Push')],
+        )
+      )
+      .addPanel(
+        $.p99LatencyByPod(
+          'loki_request_duration_seconds',
+          $.toPrometheusSelector(
+            dashboards['loki-writes.json'].clusterMatchers +
+            dashboards['loki-writes.json'].matchers.ingester +
+            [utils.selector.eq('route', '/logproto.Pusher/Push')]
+          ),
+        )
+      )
+    )
+    .addRowIf(
+      !$._config.ssd.enabled,
+      $.row('Index')
+      .addPanel(
+        $.newQueryPanel('QPS') +
+        $.newQpsPanel('loki_index_request_duration_seconds_count{%s operation="index_chunk"}' % dashboards['loki-writes.json'].ingesterSelector)
+      )
+      .addPanel(
+        $.newQueryPanel('Latency', 'ms') +
+        $.latencyPanel('loki_index_request_duration_seconds', '{%s operation="index_chunk"}' % dashboards['loki-writes.json'].ingesterSelector)
+      )
+      .addPanel(
+        $.p99LatencyByPod(
+          'loki_index_request_duration_seconds',
+          '{%s operation="index_chunk"}' % dashboards['loki-writes.json'].ingesterSelector,
+        )
+      )
+    )
+    .addRowIf(
+      showBigTable,
+      $.row('BigTable')
+      .addPanel(
+        $.newQueryPanel('QPS') +
+        $.newQpsPanel('loki_bigtable_request_duration_seconds_count{%s operation="/google.bigtable.v2.Bigtable/MutateRows"}' % dashboards['loki-writes.json'].ingesterSelector)
+      )
+      .addPanel(
+        $.newQueryPanel('Latency', 'ms') +
+        utils.latencyRecordingRulePanel(
+          'loki_bigtable_request_duration_seconds',
+          dashboards['loki-writes.json'].clusterMatchers +
+          dashboards['loki-writes.json'].matchers.ingester +
+          [utils.selector.eq('operation', '/google.bigtable.v2.Bigtable/MutateRows')],
+        )
+      )
+      .addPanel(
+        $.p99LatencyByPod(
+          'loki_bigtable_request_duration_seconds',
+          $.toPrometheusSelector(
+            dashboards['loki-writes.json'].clusterMatchers +
+            dashboards['loki-writes.json'].matchers.ingester +
+            [utils.selector.eq('operation', '/google.bigtable.v2.Bigtable/MutateRows')],
+          ),
+        )
+      )
+    )
+    .addRowIf(
+      !$._config.ssd.enabled,
+      $.row('BoltDB Index')
+      .addPanel(
+        $.newQueryPanel('QPS') +
+        $.newQpsPanel('loki_boltdb_shipper_request_duration_seconds_count{%s operation="WRITE"}' % dashboards['loki-writes.json'].ingesterSelector)
+      )
+      .addPanel(
+        $.newQueryPanel('Latency', 'ms') +
+        $.latencyPanel('loki_boltdb_shipper_request_duration_seconds', '{%s operation="WRITE"}' % dashboards['loki-writes.json'].ingesterSelector)
+      )
+      .addPanel(
+        $.p99LatencyByPod(
+          'loki_boltdb_shipper_request_duration_seconds',
+          '{%s operation="WRITE"}' % dashboards['loki-writes.json'].ingesterSelector,
+        )
+      )
+    ),
   },
 }

--- a/production/loki-mixin/grr.libsonnet
+++ b/production/loki-mixin/grr.libsonnet
@@ -1,0 +1,20 @@
+local grr = import 'grizzly/grizzly.libsonnet';
+local mixin = import 'mixin.libsonnet';
+
+{
+  folders: [
+    grr.folder.new(std.asciiLower(mixin.grafanaDashboardFolder), mixin.grafanaDashboardFolder),
+  ],
+  dashboards: [
+    grr.dashboard.new(mixin.grafanaDashboards[d].uid, mixin.grafanaDashboards[d]) +
+    grr.resource.addMetadata('folder', mixin.grafanaDashboardFolder)
+    for d in std.objectFields(mixin.grafanaDashboards)
+  ],
+  datasources: [],
+  prometheus_rule_groups: [
+    grr.prometheus.rule_group.new(std.asciiLower(mixin.grafanaDashboardFolder), group.name, { rules: group.rules })
+    for rules in [mixin.prometheusAlerts.groups, mixin.prometheusRules.groups]
+    for group in rules
+  ],
+  sm: [],
+}

--- a/production/loki-mixin/jsonnetfile.json
+++ b/production/loki-mixin/jsonnetfile.json
@@ -23,6 +23,15 @@
       "source": {
         "git": {
           "remote": "https://github.com/grafana/jsonnet-libs.git",
+          "subdir": "grizzly"
+        }
+      },
+      "version": "master"
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/jsonnet-libs.git",
           "subdir": "mixin-utils"
         }
       },

--- a/production/loki-mixin/jsonnetfile.lock.json
+++ b/production/loki-mixin/jsonnetfile.lock.json
@@ -18,8 +18,18 @@
           "subdir": "grafana-builder"
         }
       },
-      "version": "1d31bb1b58a2a2a3ffb2296cd5aa4d5e4ae5576b",
+      "version": "166299f44d04f30db0b844570efe03d60ac3e8c1",
       "sum": "yxqWcq/N3E/a/XreeU6EuE6X7kYPnG0AspAQFKOjASo="
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/jsonnet-libs.git",
+          "subdir": "grizzly"
+        }
+      },
+      "version": "166299f44d04f30db0b844570efe03d60ac3e8c1",
+      "sum": "yY8w1JvVAuxB3Z62R3OxDVcSRPUKIvEWQZ2ShyD7uis="
     },
     {
       "source": {
@@ -28,8 +38,8 @@
           "subdir": "mixin-utils"
         }
       },
-      "version": "1d31bb1b58a2a2a3ffb2296cd5aa4d5e4ae5576b",
-      "sum": "LoYq5QxJmUXEtqkEG8CFUBLBhhzDDaNANHc7Gz36ZdM="
+      "version": "166299f44d04f30db0b844570efe03d60ac3e8c1",
+      "sum": "SRElwa/XrKAN8aZA9zvdRUx8iebl2It7KNQ7VFvMcBA="
     },
     {
       "source": {
@@ -38,8 +48,8 @@
           "subdir": "operations/mimir-mixin"
         }
       },
-      "version": "61dd68b7397e197ff6bb81251737ead633fd42b9",
-      "sum": "en5dwfa7Hh4t7pWAoMc1uDXHGStqxqL1Vj+E/5NGwRQ="
+      "version": "6dedf22c205a4f860c413aa724c2d88c6da9d519",
+      "sum": "CbDm61yuOo/bKQFK5CcNITtkjcn6d81eEVG3FLVLnOM="
     },
     {
       "source": {
@@ -48,7 +58,7 @@
           "subdir": "jsonnet/kube-prometheus/lib"
         }
       },
-      "version": "74f4e0cda3f3c2a4e8a1ab7d9bdbee019a47c851",
+      "version": "8e16c980bf74e26709484677181e6f94808a45a3",
       "sum": "QKRgrgEZ3k9nLmLCrDBaeIGVqQZf+AvZTcnhdLk3TrA="
     }
   ],


### PR DESCRIPTION
**What this PR does / why we need it**:

1. Filtered the logs datasource by default to exclude Loki datasources that match `(?!grafanacloud-.+(alert-state-history|usage-insights)).+`
2. Added `grr.libsonnet` file to add better support for Grizzly so that Dashboard Folders, Dashboards and Prometheus Rules can be sync'd
3. Adds support for the meta-monitoring chart when used. The meta-monitoring chart was setting the job label to `namespace/name-component` 

```
rule {
        source_labels = ["__meta_kubernetes_namespace", "__meta_kubernetes_pod_label_app_kubernetes_io_name", "__meta_kubernetes_pod_label_app_kubernetes_io_component"]
        separator = "/"
        regex = "(.*)/(.*)/(.*)"
        replacement = "${1}/${2}-${3}"
        target_label = "job"
      }
```

This update handles that scenario by injecting `((loki|enterprise-logs)-)?` to the selectors i.e. 

```
job="$namespace/((loki|enterprise-logs)-)?querier"
```

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [X] Documentation added
- [X] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
