### PR TITLE
chore: align delete request splits to shard interval

### DIFF
--- a/pkg/compactor/deletion/request_handler.go
+++ b/pkg/compactor/deletion/request_handler.go
@@ -67,6 +67,8 @@ func (dm *DeleteRequestHandler) AddDeleteRequestHandler(w http.ResponseWriter, r
 	}
 
 	var shardByInterval time.Duration
+	var deleteRequests []DeleteRequest
+	// shard delete requests only when there are line filters
 	if parsedExpr.HasFilter() {
 		var err error
 		shardByInterval, err = dm.interval(params, startTime, endTime)
@@ -74,11 +76,31 @@ func (dm *DeleteRequestHandler) AddDeleteRequestHandler(w http.ResponseWriter, r
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
+
+		deleteRequests = make([]DeleteRequest, 0, endTime.Sub(startTime)/shardByInterval)
+		// although delete request end time is inclusive, setting endTimeInclusive to true would keep 1ms gap between the splits,
+		// which might make us miss deletion of some of the logs. We set it to false to have some overlap between the request to stay safe.
+		util.ForInterval(shardByInterval, startTime.Time(), endTime.Time(), false, func(start, end time.Time) {
+			deleteRequests = append(deleteRequests,
+				DeleteRequest{
+					StartTime: model.Time(start.UnixMilli()),
+					EndTime:   model.Time(end.UnixMilli()),
+					Query:     query,
+					UserID:    userID,
+				},
+			)
+		})
 	} else {
-		shardByInterval = endTime.Sub(startTime) + time.Minute
+		deleteRequests = []DeleteRequest{
+			{
+				StartTime: startTime,
+				EndTime:   endTime,
+				Query:     query,
+				UserID:    userID,
+			},
+		}
 	}
 
-	deleteRequests := shardDeleteRequestsByInterval(startTime, endTime, query, userID, shardByInterval)
 	createdDeleteRequests, err := dm.deleteRequestsStore.AddDeleteRequestGroup(ctx, deleteRequests)
 	if err != nil {
 		level.Error(util_log.Logger).Log("msg", "error adding delete request to the store", "err", err)
@@ -102,25 +124,6 @@ func (dm *DeleteRequestHandler) AddDeleteRequestHandler(w http.ResponseWriter, r
 
 	dm.metrics.deleteRequestsReceivedTotal.WithLabelValues(userID).Inc()
 	w.WriteHeader(http.StatusNoContent)
-}
-
-func shardDeleteRequestsByInterval(startTime, endTime model.Time, query, userID string, interval time.Duration) []DeleteRequest {
-	deleteRequests := make([]DeleteRequest, 0, endTime.Sub(startTime)/interval)
-	for start := startTime; start.Before(endTime); start = start.Add(interval) + 1 {
-		end := start.Add(interval)
-		if end.After(endTime) {
-			end = endTime
-		}
-
-		deleteRequests = append(deleteRequests,
-			DeleteRequest{
-				StartTime: start,
-				EndTime:   end,
-				Query:     query,
-				UserID:    userID,
-			})
-	}
-	return deleteRequests
 }
 
 func (dm *DeleteRequestHandler) interval(params url.Values, startTime, endTime model.Time) (time.Duration, error) {

--- a/pkg/compactor/deletion/request_handler_test.go
+++ b/pkg/compactor/deletion/request_handler_test.go
@@ -52,38 +52,30 @@ func TestAddDeleteRequestHandler(t *testing.T) {
 		store := &mockDeleteRequestsStore{}
 		h := NewDeleteRequestHandler(store, 0, nil)
 
-		from := model.TimeFromUnix(model.Now().Add(-3 * time.Hour).Unix())
-		to := model.TimeFromUnix(from.Add(3 * time.Hour).Unix())
+		now := model.Now()
+		from := model.TimeFromUnix(now.Add(-3 * time.Hour).Unix())
+		to := model.TimeFromUnix(now.Unix())
+		maxInterval := time.Hour
 
 		req := buildRequest("org-id", `{foo="bar"} |= "foo"`, unixString(from), unixString(to))
 		params := req.URL.Query()
-		params.Set("max_interval", "1h")
+		params.Set("max_interval", maxInterval.String())
 		req.URL.RawQuery = params.Encode()
 
 		w := httptest.NewRecorder()
 		h.AddDeleteRequestHandler(w, req)
 
 		require.Equal(t, w.Code, http.StatusNoContent)
-		require.Len(t, store.addReqs, 3)
-
-		for i, req := range store.addReqs {
-			startTime := from.Add(time.Duration(i)*time.Hour) + model.Time(i)
-			endTime := from.Add(time.Duration(i+1)*time.Hour) + model.Time(i)
-			if endTime.After(to) {
-				endTime = to
-			}
-
-			require.Equal(t, startTime, req.StartTime)
-			require.Equal(t, endTime, req.EndTime)
-		}
+		verifyRequestSplits(t, from, to, maxInterval, store.addReqs)
 	})
 
 	t.Run("it uses the default for sharding when the query param isn't present", func(t *testing.T) {
 		store := &mockDeleteRequestsStore{}
 		h := NewDeleteRequestHandler(store, time.Hour, nil)
 
-		from := model.TimeFromUnix(model.Now().Add(-3 * time.Hour).Unix())
-		to := model.TimeFromUnix(from.Add(3 * time.Hour).Unix())
+		now := model.Now()
+		from := model.TimeFromUnix(now.Add(-3 * time.Hour).Unix())
+		to := model.TimeFromUnix(now.Unix())
 
 		req := buildRequest("org-id", `{foo="bar"} |= "foo"`, unixString(from), unixString(to))
 
@@ -91,18 +83,7 @@ func TestAddDeleteRequestHandler(t *testing.T) {
 		h.AddDeleteRequestHandler(w, req)
 
 		require.Equal(t, w.Code, http.StatusNoContent)
-		require.Len(t, store.addReqs, 3)
-
-		for i, req := range store.addReqs {
-			startTime := from.Add(time.Duration(i)*time.Hour) + model.Time(i)
-			endTime := from.Add(time.Duration(i+1)*time.Hour) + model.Time(i)
-			if endTime.After(to) {
-				endTime = to
-			}
-
-			require.Equal(t, startTime, req.StartTime)
-			require.Equal(t, endTime, req.EndTime)
-		}
+		verifyRequestSplits(t, from, to, time.Hour, store.addReqs)
 	})
 
 	t.Run("it does not shard deletes without line filter", func(t *testing.T) {
@@ -483,4 +464,36 @@ func unixString(t model.Time) string {
 func toTime(t string) model.Time {
 	modelTime, _ := util.ParseTime(t)
 	return model.Time(modelTime)
+}
+
+func verifyRequestSplits(t *testing.T, from, to model.Time, shardInterval time.Duration, reqs []DeleteRequest) {
+	numExpectedRequests := 3
+	shardAlignedStart := model.TimeFromUnixNano(time.Unix(0, from.UnixNano()-from.UnixNano()%shardInterval.Nanoseconds()).UnixNano())
+	if !from.Equal(shardAlignedStart) {
+		numExpectedRequests++
+	}
+
+	require.Len(t, reqs, numExpectedRequests)
+	for i := 0; i < numExpectedRequests; i++ {
+		if i == 0 {
+			// start of first request should be same as the start time in original request
+			require.Equal(t, from, reqs[i].StartTime)
+			// end of first request should be shard interval aligned start + shardInterval
+			expectedEnd := shardAlignedStart.Add(shardInterval)
+			if expectedEnd.After(to) {
+				expectedEnd = to
+			}
+			require.Equal(t, expectedEnd, reqs[i].EndTime)
+		} else {
+			// start of this request should be equal to end of last request
+			require.Equal(t, reqs[i-1].EndTime, reqs[i].StartTime)
+			// if this is not last request then end of this split should be start + interval
+			// if this is last request then end should be equal end of original request
+			expectedEnd := reqs[i].StartTime.Add(shardInterval)
+			if i == numExpectedRequests-1 {
+				expectedEnd = to
+			}
+			require.Equal(t, expectedEnd, reqs[i].EndTime)
+		}
+	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, we do not align delete requests while splitting them. This PR aligns the splits with the split interval for 2 reasons:
1. With deterministically split delete requests, we can easily dedupe delete requests which significantly overlap an existing request with the same selector.
2. 24h splits would align with 24h index table interval. While there won't be any significant improvement, it is better for the splits to cover a whole single table instead of partially covering multiple tables.

**Checklist**
- [x] Tests updated