### PR TITLE
feat(ingest-limits): Move config struct to new limits pkg

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -906,14 +906,10 @@ kafka_config:
   # CLI flag: -kafka.max-consumer-lag-at-startup
   [max_consumer_lag_at_startup: <duration> | default = 15s]
 
-  ingest_limits:
-    # Enable the ingest limits.
-    # CLI flag: -kafka.ingest-limits.enabled
-    [enabled: <boolean> | default = false]
+ingest_limits:
+  [enabled: <boolean>]
 
-    # The window size to use for the limiter.
-    # CLI flag: -kafka.ingest-limits.window-size
-    [window_size: <duration> | default = 1m]
+  [window_size: <duration>]
 
 # Configuration for 'runtime config' module, responsible for reloading runtime
 # configuration file.

--- a/pkg/kafka/config.go
+++ b/pkg/kafka/config.go
@@ -33,18 +33,6 @@ var (
 	ErrInvalidProducerMaxRecordSizeBytes   = fmt.Errorf("the configured producer max record size bytes must be a value between %d and %d", minProducerRecordDataBytesLimit, maxProducerRecordDataBytesLimit)
 )
 
-// IngestLimitsConfig holds configuration for the IngestLimits service.
-type IngestLimitsConfig struct {
-	Enabled    bool          `yaml:"enabled"`
-	WindowSize time.Duration `yaml:"window_size"`
-}
-
-// RegisterFlags registers the configuration flags.
-func (cfg *IngestLimitsConfig) RegisterFlagsWithPrefix(prefix string, fs *flag.FlagSet) {
-	fs.BoolVar(&cfg.Enabled, prefix+".ingest-limits.enabled", false, "Enable the ingest limits.")
-	fs.DurationVar(&cfg.WindowSize, prefix+".ingest-limits.window-size", 1*time.Minute, "The window size to use for the limiter.")
-}
-
 // Config holds the generic config for the Kafka backend.
 type Config struct {
 	Address      string        `yaml:"address"`
@@ -68,13 +56,10 @@ type Config struct {
 	ProducerMaxBufferedBytes   int64 `yaml:"producer_max_buffered_bytes"`
 
 	MaxConsumerLagAtStartup time.Duration `yaml:"max_consumer_lag_at_startup"`
-
-	IngestLimits IngestLimitsConfig `yaml:"ingest_limits,omitempty"`
 }
 
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	cfg.RegisterFlagsWithPrefix("kafka", f)
-	cfg.IngestLimits.RegisterFlagsWithPrefix("kafka", f)
 }
 
 func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {

--- a/pkg/limits/config.go
+++ b/pkg/limits/config.go
@@ -1,0 +1,24 @@
+package limits
+
+import (
+	"flag"
+	"time"
+
+	"github.com/grafana/loki/v3/pkg/kafka"
+)
+
+// Config represents the configuration for the ingest limits service.
+type Config struct {
+	// Enabled enables the ingest limits service.
+	Enabled bool `yaml:"enabled"`
+	// WindowSize defines the time window for which stream metadata is considered active.
+	// Stream metadata older than WindowSize will be evicted from the metadata map.
+	WindowSize time.Duration `yaml:"window_size"`
+
+	KafkaConfig kafka.Config `yaml:"-"`
+}
+
+func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
+	f.BoolVar(&cfg.Enabled, "ingest-limits.enabled", false, "Enable the ingest limits service.")
+	f.DurationVar(&cfg.WindowSize, "ingest-limits.window-size", 1*time.Hour, "The time window for which stream metadata is considered active.")
+}

--- a/pkg/limits/ingest_limits.go
+++ b/pkg/limits/ingest_limits.go
@@ -26,7 +26,7 @@ import (
 type IngestLimits struct {
 	services.Service
 
-	cfg    kafka.IngestLimitsConfig
+	cfg    Config
 	logger log.Logger
 	client *kgo.Client
 
@@ -37,10 +37,10 @@ type IngestLimits struct {
 
 // NewIngestLimits creates a new IngestLimits service. It initializes the metadata map and sets up a Kafka client
 // The client is configured to consume stream metadata from a dedicated topic with the metadata suffix.
-func NewIngestLimits(cfg kafka.Config, logger log.Logger, reg prometheus.Registerer) (*IngestLimits, error) {
+func NewIngestLimits(cfg Config, logger log.Logger, reg prometheus.Registerer) (*IngestLimits, error) {
 	var err error
 	s := &IngestLimits{
-		cfg:      cfg.IngestLimits,
+		cfg:      cfg,
 		logger:   logger,
 		metadata: make(map[string]map[uint64]int64),
 	}
@@ -50,7 +50,7 @@ func NewIngestLimits(cfg kafka.Config, logger log.Logger, reg prometheus.Registe
 		kprom.FetchAndProduceDetail(kprom.Batches, kprom.Records, kprom.CompressedBytes, kprom.UncompressedBytes))
 
 	// Create a copy of the config to modify the topic
-	kCfg := cfg
+	kCfg := cfg.KafkaConfig
 	kCfg.Topic = kafka.MetadataTopicFor(kCfg.Topic)
 
 	s.client, err = client.NewReaderClient(kCfg, metrics, logger,

--- a/pkg/limits/ingest_limits_test.go
+++ b/pkg/limits/ingest_limits_test.go
@@ -104,7 +104,7 @@ func TestIngestLimits_GetStreamLimits(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Create IngestLimits instance with mock data
 			s := &IngestLimits{
-				cfg: kafka.IngestLimitsConfig{
+				cfg: Config{
 					WindowSize: tt.windowSize,
 				},
 				logger:   log.NewNopLogger(),
@@ -148,7 +148,7 @@ func TestIngestLimits_GetStreamLimits_Concurrent(t *testing.T) {
 	}
 
 	s := &IngestLimits{
-		cfg: kafka.IngestLimitsConfig{
+		cfg: Config{
 			WindowSize: time.Hour,
 		},
 		logger:   log.NewNopLogger(),
@@ -189,17 +189,17 @@ func TestIngestLimits_GetStreamLimits_Concurrent(t *testing.T) {
 }
 
 func TestNewIngestLimits(t *testing.T) {
-	cfg := kafka.Config{
-		IngestLimits: kafka.IngestLimitsConfig{
-			WindowSize: time.Hour,
+	cfg := Config{
+		KafkaConfig: kafka.Config{
+			Topic: "test-topic",
 		},
-		Topic: "test-topic",
+		WindowSize: time.Hour,
 	}
 
 	s, err := NewIngestLimits(cfg, log.NewNopLogger(), prometheus.NewRegistry())
 	require.NoError(t, err)
 	require.NotNil(t, s)
 	require.NotNil(t, s.client)
-	require.Equal(t, cfg.IngestLimits, s.cfg)
+	require.Equal(t, cfg, s.cfg)
 	require.NotNil(t, s.metadata)
 }

--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -111,7 +111,7 @@ type Config struct {
 	TableManager         index.TableManagerConfig   `yaml:"table_manager,omitempty"`
 	MemberlistKV         memberlist.KVConfig        `yaml:"memberlist"`
 	KafkaConfig          kafka.Config               `yaml:"kafka_config,omitempty" category:"experimental"`
-	IngestLimits         limits.Config              `yaml:"ingest_limits,omitempty"`
+	IngestLimits         limits.Config              `yaml:"ingest_limits,omitempty" category:"experimental"`
 
 	RuntimeConfig     runtimeconfig.Config `yaml:"runtime_config,omitempty"`
 	OperationalConfig runtime.Config       `yaml:"operational_config,omitempty"`

--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -111,6 +111,7 @@ type Config struct {
 	TableManager         index.TableManagerConfig   `yaml:"table_manager,omitempty"`
 	MemberlistKV         memberlist.KVConfig        `yaml:"memberlist"`
 	KafkaConfig          kafka.Config               `yaml:"kafka_config,omitempty" category:"experimental"`
+	IngestLimits         limits.Config              `yaml:"ingest_limits,omitempty"`
 
 	RuntimeConfig     runtimeconfig.Config `yaml:"runtime_config,omitempty"`
 	OperationalConfig runtime.Config       `yaml:"operational_config,omitempty"`

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -387,12 +387,14 @@ func (t *Loki) initDistributor() (services.Service, error) {
 }
 
 func (t *Loki) initIngestLimits() (services.Service, error) {
-	if !t.Cfg.KafkaConfig.IngestLimits.Enabled {
+	if !t.Cfg.IngestLimits.Enabled || !t.Cfg.Distributor.KafkaEnabled {
 		return nil, nil
 	}
 
+	t.Cfg.IngestLimits.KafkaConfig = t.Cfg.KafkaConfig
+
 	ingestLimits, err := limits.NewIngestLimits(
-		t.Cfg.KafkaConfig,
+		t.Cfg.IngestLimits,
 		util_log.Logger,
 		prometheus.DefaultRegisterer,
 	)
@@ -410,7 +412,7 @@ func (t *Loki) initIngestLimits() (services.Service, error) {
 }
 
 func (t *Loki) initIngestLimitsFrontend() (services.Service, error) {
-	if !t.Cfg.KafkaConfig.IngestLimits.Enabled {
+	if !t.Cfg.IngestLimits.Enabled {
 		return nil, nil
 	}
 

--- a/tools/dev/kafka/loki-local-config.debug.yaml
+++ b/tools/dev/kafka/loki-local-config.debug.yaml
@@ -21,9 +21,10 @@ common:
 
 kafka_config:
   topic: "loki"
-  ingest_limits:
-    enabled: true
-    window_size: 1m
+
+ingest_limits:
+  enabled: true
+  window_size: 1m
 
 querier:
   query_partition_ingesters: true


### PR DESCRIPTION
**What this PR does / why we need it**:
Moves the ingest limits config from the `kafka` pkg to the `limits` pkg.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
