### PR TITLE
chore(dataobj): temporarily disable sorting

### DIFF
--- a/pkg/dataobj/dataobj_test.go
+++ b/pkg/dataobj/dataobj_test.go
@@ -94,7 +94,10 @@ func Test(t *testing.T) {
 
 		actual, err := result.Collect(reader.Streams(context.Background(), objects[0]))
 		require.NoError(t, err)
-		require.Equal(t, sortStreams(t, streams), actual)
+
+		// TODO(rfratto): reenable once sorting is reintroduced.
+		_ = actual
+		// require.Equal(t, sortStreams(t, streams), actual)
 	})
 }
 

--- a/pkg/dataobj/internal/sections/logs/logs_test.go
+++ b/pkg/dataobj/internal/sections/logs/logs_test.go
@@ -15,6 +15,8 @@ import (
 )
 
 func Test(t *testing.T) {
+	t.Skip("Disabled until sorting is reimplemented")
+
 	records := []logs.Record{
 		{
 			StreamID:  1,


### PR DESCRIPTION
During testing, @cyriltovena and I have discovered that sorting the logs dataset is far too slow due to the number of page loads required to iterate over the single table in sorted order.

To move testing along, sorting is being disabled for now, but it will return once the logs section implementation is refactored to lessen the work on the dataset.Sort implementation.