### PR TITLE
fix: Change pushHandler to return 200 not 204

### DIFF
--- a/pkg/distributor/http.go
+++ b/pkg/distributor/http.go
@@ -73,7 +73,7 @@ func (d *Distributor) pushHandler(w http.ResponseWriter, r *http.Request, pushRe
 				"msg", "push request successful",
 			)
 		}
-		w.WriteHeader(http.StatusNoContent)
+		w.WriteHeader(http.StatusOK)
 		return
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Changes response-code for the `/otlp/v1/logs` endpoint to return 200-OK instead of 204-NoContent. 

See also:
* https://opentelemetry.io/docs/specs/otlp/#full-success-1 for the OTLP endpoint and what it accepts, which is only 200.
* open-telemetry/opentelemetry-python#3621 referencing Grafana Loki directly
* open-telemetry/opentelemetry-python#4338 regarding Zipkin endpoints and why validations are using both 200 and 202

The 200-OK behavior is per the OTLP specification this endpoint uses.

**Which issue(s) this PR fixes**:
Fixes #15761 

**Special notes for your reviewer**:
This is a change of behavior from historical, but is in better compliance with the spec.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
