### PR TITLE
chore(dataobj): instrument data objects

### DIFF
--- a/pkg/dataobj/dataobj.go
+++ b/pkg/dataobj/dataobj.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/grafana/dskit/flagext"
 	lru "github.com/hashicorp/golang-lru/v2"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/thanos-io/objstore"
 
@@ -54,10 +55,11 @@ type BuilderConfig struct {
 
 // RegisterFlagsWithPrefix registers flags with the given prefix.
 func (cfg *BuilderConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
-	f.IntVar(&cfg.SHAPrefixSize, prefix+"sha-prefix-size", 2, "The size of the SHA prefix to use for the data object builder.")
 	_ = cfg.TargetPageSize.Set("2MB")
-	f.Var(&cfg.TargetPageSize, prefix+"target-page-size", "The size of the target page to use for the data object builder.")
 	_ = cfg.TargetObjectSize.Set("1GB")
+
+	f.IntVar(&cfg.SHAPrefixSize, prefix+"sha-prefix-size", 2, "The size of the SHA prefix to use for the data object builder.")
+	f.Var(&cfg.TargetPageSize, prefix+"target-page-size", "The size of the target page to use for the data object builder.")
 	f.Var(&cfg.TargetObjectSize, prefix+"target-object-size", "The size of the target object to use for the data object builder.")
 	f.StringVar(&cfg.StorageBucketPrefix, prefix+"storage-bucket-prefix", "dataobj/", "The prefix to use for the storage bucket.")
 }
@@ -91,12 +93,14 @@ func (cfg *BuilderConfig) Validate() error {
 // synchronizing calls.
 type Builder struct {
 	cfg      BuilderConfig
+	metrics  *metrics
 	bucket   objstore.Bucket
 	tenantID string
 
 	labelCache *lru.Cache[string, labels.Labels]
 
-	state builderState
+	currentSizeEstimate int
+	state               builderState
 
 	streams *streams.Streams
 	logs    *logs.Logs
@@ -133,19 +137,22 @@ func NewBuilder(cfg BuilderConfig, bucket objstore.Bucket, tenantID string) (*Bu
 	}
 
 	var (
+		metrics = newMetrics(cfg)
+
 		flushBuffer = bytes.NewBuffer(make([]byte, 0, int(cfg.TargetObjectSize)))
 		encoder     = encoding.NewEncoder(flushBuffer)
 	)
 
 	return &Builder{
 		cfg:      cfg,
+		metrics:  metrics,
 		bucket:   bucket,
 		tenantID: tenantID,
 
 		labelCache: labelCache,
 
-		streams: streams.New(int(cfg.TargetPageSize)),
-		logs:    logs.New(int(cfg.TargetPageSize)),
+		streams: streams.New(metrics.streams, int(cfg.TargetPageSize)),
+		logs:    logs.New(metrics.logs, int(cfg.TargetPageSize)),
 
 		flushBuffer: flushBuffer,
 		encoder:     encoder,
@@ -171,9 +178,16 @@ func (b *Builder) Append(stream logproto.Stream) error {
 
 	// Check whether the buffer is full before a stream can be appended; this is
 	// tends to overestimate, but we may still go over our target size.
-	if b.state != builderStateEmpty && b.estimatedSize()+labelsEstimate(ls)+streamSizeEstimate(stream) > int(b.cfg.TargetObjectSize) {
+	//
+	// Since this check only happens after the first call to Append,
+	// b.currentSizeEstimate will always be updated to reflect the size following
+	// the previous append.
+	if b.state != builderStateEmpty && b.currentSizeEstimate+labelsEstimate(ls)+streamSizeEstimate(stream) > int(b.cfg.TargetObjectSize) {
 		return ErrBufferFull
 	}
+
+	timer := prometheus.NewTimer(b.metrics.appendTime)
+	defer timer.ObserveDuration()
 
 	for _, entry := range stream.Entries {
 		streamID := b.streams.Record(ls, entry.Timestamp)
@@ -186,6 +200,7 @@ func (b *Builder) Append(stream logproto.Stream) error {
 		})
 	}
 
+	b.currentSizeEstimate = b.estimatedSize()
 	b.state = builderStateDirty
 	return nil
 }
@@ -208,6 +223,7 @@ func (b *Builder) estimatedSize() int {
 	var size int
 	size += b.streams.EstimatedSize()
 	size += b.logs.EstimatedSize()
+	b.metrics.sizeEstimate.Set(float64(size))
 	return size
 }
 
@@ -254,11 +270,14 @@ func (b *Builder) Flush(ctx context.Context) error {
 	case builderStateEmpty:
 		return nil // Nothing to flush
 	case builderStateDirty:
-		if err := b.buildObject(); err != nil {
+		if err := b.buildObject(ctx); err != nil {
 			return fmt.Errorf("building object: %w", err)
 		}
 		b.state = builderStateFlush
 	}
+
+	timer := prometheus.NewTimer(b.metrics.flushTime)
+	defer timer.ObserveDuration()
 
 	sum := sha256.Sum224(b.flushBuffer.Bytes())
 	sumStr := hex.EncodeToString(sum[:])
@@ -273,7 +292,10 @@ func (b *Builder) Flush(ctx context.Context) error {
 	return nil
 }
 
-func (b *Builder) buildObject() error {
+func (b *Builder) buildObject(ctx context.Context) error {
+	timer := prometheus.NewTimer(b.metrics.buildTime)
+	defer timer.ObserveDuration()
+
 	// We reset after a successful flush, but we also reset the buffer before
 	// building for safety.
 	b.flushBuffer.Reset()
@@ -286,7 +308,8 @@ func (b *Builder) buildObject() error {
 		return fmt.Errorf("encoding object: %w", err)
 	}
 
-	return nil
+	dec := encoding.ReadSeekerDecoder(bytes.NewReader(b.flushBuffer.Bytes()))
+	return b.metrics.encoding.Observe(ctx, dec)
 }
 
 // Reset discards pending data and resets the builder to an empty state.
@@ -296,4 +319,21 @@ func (b *Builder) Reset() {
 
 	b.state = builderStateEmpty
 	b.flushBuffer.Reset()
+	b.metrics.sizeEstimate.Set(0)
+}
+
+// RegisterMetrics registers metrics about builder to report to reg. All
+// metrics will have a tenant label set to the tenant ID of the Builder.
+//
+// If multiple Builders for the same tenant are running in the same process,
+// reg must contain additional labels to differentiate between them.
+func (b *Builder) RegisterMetrics(reg prometheus.Registerer) error {
+	reg = prometheus.WrapRegistererWith(prometheus.Labels{"tenant": b.tenantID}, reg)
+	return b.metrics.Register(reg)
+}
+
+// UnregisterMetrics unregisters metrics about builder from reg.
+func (b *Builder) UnregisterMetrics(reg prometheus.Registerer) {
+	reg = prometheus.WrapRegistererWith(prometheus.Labels{"tenant": b.tenantID}, reg)
+	b.metrics.Unregister(reg)
 }

--- a/pkg/dataobj/dataobj_test.go
+++ b/pkg/dataobj/dataobj_test.go
@@ -74,8 +74,6 @@ func Test(t *testing.T) {
 
 			TargetPageSize:   1_500_000,
 			TargetObjectSize: 10_000_000,
-
-			StorageBucketPrefix: "dataobj/",
 		}
 
 		builder, err := NewBuilder(builderConfig, bucket, "fake")
@@ -88,7 +86,7 @@ func Test(t *testing.T) {
 	})
 
 	t.Run("Read", func(t *testing.T) {
-		reader := newReader(bucket, "dataobj/")
+		reader := newReader(bucket)
 
 		objects, err := result.Collect(reader.Objects(context.Background(), "fake"))
 		require.NoError(t, err)

--- a/pkg/dataobj/internal/encoding/encoding_test.go
+++ b/pkg/dataobj/internal/encoding/encoding_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/dataset"
@@ -77,6 +78,15 @@ func TestStreams(t *testing.T) {
 
 		require.NoError(t, streamsEnc.Commit())
 		require.NoError(t, enc.Flush())
+	})
+
+	t.Run("Metrics", func(t *testing.T) {
+		dec := encoding.ReadSeekerDecoder(bytes.NewReader(buf.Bytes()))
+
+		metrics := encoding.NewMetrics()
+		metrics.Register(prometheus.NewRegistry())
+
+		metrics.Observe(context.Background(), dec)
 	})
 
 	t.Run("Decode", func(t *testing.T) {

--- a/pkg/dataobj/internal/encoding/encoding_test.go
+++ b/pkg/dataobj/internal/encoding/encoding_test.go
@@ -84,9 +84,8 @@ func TestStreams(t *testing.T) {
 		dec := encoding.ReadSeekerDecoder(bytes.NewReader(buf.Bytes()))
 
 		metrics := encoding.NewMetrics()
-		metrics.Register(prometheus.NewRegistry())
-
-		metrics.Observe(context.Background(), dec)
+		require.NoError(t, metrics.Register(prometheus.NewRegistry()))
+		require.NoError(t, metrics.Observe(context.Background(), dec))
 	})
 
 	t.Run("Decode", func(t *testing.T) {

--- a/pkg/dataobj/internal/encoding/metrics.go
+++ b/pkg/dataobj/internal/encoding/metrics.go
@@ -1,0 +1,343 @@
+package encoding
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/gogo/protobuf/proto"
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/grafana/loki/v3/pkg/dataobj/internal/metadata/filemd"
+	"github.com/grafana/loki/v3/pkg/dataobj/internal/metadata/logsmd"
+	"github.com/grafana/loki/v3/pkg/dataobj/internal/metadata/streamsmd"
+	"github.com/grafana/loki/v3/pkg/dataobj/internal/result"
+)
+
+// Metrics instruments encoded data objects.
+type Metrics struct {
+	sectionsCount       prometheus.Histogram
+	fileMetadataSize    prometheus.Histogram
+	sectionMetadataSize *prometheus.HistogramVec
+
+	datasetColumnMetadataSize      *prometheus.HistogramVec
+	datasetColumnMetadataTotalSize *prometheus.HistogramVec
+
+	datasetColumnCount             *prometheus.HistogramVec
+	datasetColumnCompressedBytes   *prometheus.HistogramVec
+	datasetColumnUncompressedBytes *prometheus.HistogramVec
+	datasetColumnRows              *prometheus.HistogramVec
+	datasetColumnValues            *prometheus.HistogramVec
+
+	datasetPageCount             *prometheus.HistogramVec
+	datasetPageCompressedBytes   *prometheus.HistogramVec
+	datasetPageUncompressedBytes *prometheus.HistogramVec
+	datasetPageRows              *prometheus.HistogramVec
+	datasetPageValues            *prometheus.HistogramVec
+}
+
+// NewMetrics creates a new set of metrics for encoding.
+func NewMetrics() *Metrics {
+	// To limit the number of time series per data object builder, these metrics
+	// are only available as classic histograms, otherwise we would have 10x the
+	// total number of metrics.
+
+	return &Metrics{
+		sectionsCount: newNativeHistogram(prometheus.HistogramOpts{
+			Namespace: "loki_dataobj",
+			Subsystem: "encoding",
+			Name:      "sections_count",
+			Help:      "Distribution of sections per encoded data object.",
+		}),
+
+		fileMetadataSize: newNativeHistogram(prometheus.HistogramOpts{
+			Namespace: "loki_dataobj",
+			Subsystem: "encoding",
+			Name:      "file_metadata_size",
+			Help:      "Distribution of metadata size per encoded data object.",
+		}),
+
+		sectionMetadataSize: newNativeHistogramVec(prometheus.HistogramOpts{
+			Namespace: "loki_dataobj",
+			Subsystem: "encoding",
+			Name:      "section_metadata_size",
+			Help:      "Distribution of metadata size per encoded section.",
+		}, []string{"section"}),
+
+		datasetColumnMetadataSize: newNativeHistogramVec(prometheus.HistogramOpts{
+			Namespace: "loki_dataobj",
+			Subsystem: "encoding",
+			Name:      "dataset_column_metadata_size",
+			Help:      "Distribution of column metadata size per encoded dataset column.",
+		}, []string{"section"}),
+
+		datasetColumnMetadataTotalSize: newNativeHistogramVec(prometheus.HistogramOpts{
+			Namespace: "loki_dataobj",
+			Subsystem: "encoding",
+			Name:      "dataset_column_metadata_total_size",
+			Help:      "Distribution of metadata size across all columns per encoded section.",
+		}, []string{"section"}),
+
+		datasetColumnCount: newNativeHistogramVec(prometheus.HistogramOpts{
+			Namespace: "loki_dataobj",
+			Subsystem: "encoding",
+			Name:      "dataset_column_count",
+			Help:      "Distribution of column counts per encoded dataset section.",
+		}, []string{"section"}),
+
+		datasetColumnCompressedBytes: newNativeHistogramVec(prometheus.HistogramOpts{
+			Namespace: "loki_dataobj",
+			Subsystem: "encoding",
+			Name:      "dataset_column_compressed_bytes",
+			Help:      "Distribution of compressed bytes per encoded dataset column.",
+		}, []string{"section", "column_type"}),
+
+		datasetColumnUncompressedBytes: newNativeHistogramVec(prometheus.HistogramOpts{
+			Namespace: "loki_dataobj",
+			Subsystem: "encoding",
+			Name:      "dataset_column_uncompressed_bytes",
+			Help:      "Distribution of uncompressed bytes per encoded dataset column.",
+		}, []string{"section", "column_type"}),
+
+		datasetColumnRows: newNativeHistogramVec(prometheus.HistogramOpts{
+			Namespace: "loki_dataobj",
+			Subsystem: "encoding",
+			Name:      "dataset_column_rows",
+			Help:      "Distribution of row counts per encoded dataset column.",
+		}, []string{"section", "column_type"}),
+
+		datasetColumnValues: newNativeHistogramVec(prometheus.HistogramOpts{
+			Namespace: "loki_dataobj",
+			Subsystem: "encoding",
+			Name:      "dataset_column_values",
+			Help:      "Distribution of value counts per encoded dataset column.",
+		}, []string{"section", "column_type"}),
+
+		datasetPageCount: newNativeHistogramVec(prometheus.HistogramOpts{
+			Namespace: "loki_dataobj",
+			Subsystem: "encoding",
+			Name:      "dataset_page_count",
+			Help:      "Distribution of page count per encoded dataset column.",
+		}, []string{"section", "column_type"}),
+
+		datasetPageCompressedBytes: newNativeHistogramVec(prometheus.HistogramOpts{
+			Namespace: "loki_dataobj",
+			Subsystem: "encoding",
+			Name:      "dataset_page_compressed_bytes",
+			Help:      "Distribution of compressed bytes per encoded dataset page.",
+		}, []string{"section", "column_type"}),
+
+		datasetPageUncompressedBytes: newNativeHistogramVec(prometheus.HistogramOpts{
+			Namespace: "loki_dataobj",
+			Subsystem: "encoding",
+			Name:      "dataset_page_uncompressed_bytes",
+			Help:      "Distribution of uncompressed bytes per encoded dataset page.",
+		}, []string{"section", "column_type"}),
+
+		datasetPageRows: newNativeHistogramVec(prometheus.HistogramOpts{
+			Namespace: "loki_dataobj",
+			Subsystem: "encoding",
+			Name:      "dataset_page_rows",
+			Help:      "Distribution of row counts per encoded dataset page",
+		}, []string{"section", "column_type"}),
+
+		datasetPageValues: newNativeHistogramVec(prometheus.HistogramOpts{
+			Namespace: "loki_dataobj",
+			Subsystem: "encoding",
+			Name:      "dataset_page_values",
+			Help:      "Distribution of value counts per encoded dataset page",
+		}, []string{"section", "column_type"}),
+	}
+}
+
+func newNativeHistogram(opts prometheus.HistogramOpts) prometheus.Histogram {
+	opts.NativeHistogramBucketFactor = 1.1
+	opts.NativeHistogramMaxBucketNumber = 100
+	opts.NativeHistogramMinResetDuration = time.Hour
+
+	return prometheus.NewHistogram(opts)
+}
+
+func newNativeHistogramVec(opts prometheus.HistogramOpts, labels []string) *prometheus.HistogramVec {
+	opts.NativeHistogramBucketFactor = 1.1
+	opts.NativeHistogramMaxBucketNumber = 100
+	opts.NativeHistogramMinResetDuration = time.Hour
+
+	return prometheus.NewHistogramVec(opts, labels)
+}
+
+// Register registers metrics to report to reg.
+func (m *Metrics) Register(reg prometheus.Registerer) error {
+	var errs []error
+	errs = append(errs, reg.Register(m.sectionsCount))
+	errs = append(errs, reg.Register(m.fileMetadataSize))
+	errs = append(errs, reg.Register(m.sectionMetadataSize))
+	errs = append(errs, reg.Register(m.datasetColumnMetadataSize))
+	errs = append(errs, reg.Register(m.datasetColumnMetadataTotalSize))
+	errs = append(errs, reg.Register(m.datasetColumnCount))
+	errs = append(errs, reg.Register(m.datasetColumnCompressedBytes))
+	errs = append(errs, reg.Register(m.datasetColumnUncompressedBytes))
+	errs = append(errs, reg.Register(m.datasetColumnRows))
+	errs = append(errs, reg.Register(m.datasetColumnValues))
+	errs = append(errs, reg.Register(m.datasetPageCount))
+	errs = append(errs, reg.Register(m.datasetPageCompressedBytes))
+	errs = append(errs, reg.Register(m.datasetPageUncompressedBytes))
+	errs = append(errs, reg.Register(m.datasetPageRows))
+	errs = append(errs, reg.Register(m.datasetPageValues))
+	return errors.Join(errs...)
+}
+
+// Unregister unregisters metrics from the provided Registerer.
+func (m *Metrics) Unregister(reg prometheus.Registerer) {
+	reg.Unregister(m.sectionsCount)
+	reg.Unregister(m.fileMetadataSize)
+	reg.Unregister(m.sectionMetadataSize)
+	reg.Unregister(m.datasetColumnMetadataSize)
+	reg.Unregister(m.datasetColumnMetadataTotalSize)
+	reg.Unregister(m.datasetColumnCount)
+	reg.Unregister(m.datasetColumnCompressedBytes)
+	reg.Unregister(m.datasetColumnUncompressedBytes)
+	reg.Unregister(m.datasetColumnRows)
+	reg.Unregister(m.datasetColumnValues)
+	reg.Unregister(m.datasetPageCount)
+	reg.Unregister(m.datasetPageCompressedBytes)
+	reg.Unregister(m.datasetPageUncompressedBytes)
+	reg.Unregister(m.datasetPageRows)
+	reg.Unregister(m.datasetPageValues)
+}
+
+// Observe observes the data object statistics for the given [Decoder].
+func (m *Metrics) Observe(ctx context.Context, dec Decoder) error {
+	sections, err := dec.Sections(ctx)
+	if err != nil {
+		return err
+	}
+
+	// TODO(rfratto): our Decoder interface should be updated to not hide the
+	// metadata types to avoid recreating them here.
+
+	m.sectionsCount.Observe(float64(len(sections)))
+	m.fileMetadataSize.Observe(float64(proto.Size(&filemd.Metadata{Sections: sections})))
+	for _, section := range sections {
+		m.sectionMetadataSize.WithLabelValues(section.Type.String()).Observe(float64(section.MetadataSize))
+	}
+
+	var (
+		streamsDecoder = dec.StreamsDecoder()
+		logsDecoder    = dec.LogsDecoder()
+	)
+
+	var errs []error
+
+	for _, section := range sections {
+		switch section.Type {
+		case filemd.SECTION_TYPE_STREAMS:
+			errs = append(errs, m.observeStreamsSection(ctx, section, streamsDecoder))
+		case filemd.SECTION_TYPE_LOGS:
+			errs = append(errs, m.observeLogsSection(ctx, section, logsDecoder))
+		default:
+			errs = append(errs, fmt.Errorf("unknown section type %q", section.Type.String()))
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+func (m *Metrics) observeStreamsSection(ctx context.Context, section *filemd.SectionInfo, dec StreamsDecoder) error {
+	sectionType := section.Type.String()
+
+	columns, err := dec.Columns(ctx, section)
+	if err != nil {
+		return err
+	}
+	m.datasetColumnCount.WithLabelValues(sectionType).Observe(float64(len(columns)))
+
+	columnPages, err := result.Collect(dec.Pages(ctx, columns))
+	if err != nil {
+		return err
+	} else if len(columnPages) != len(columns) {
+		return fmt.Errorf("expected %d page lists, got %d", len(columns), len(columnPages))
+	}
+
+	// Count metadata sizes across columns.
+	{
+		var totalColumnMetadataSize int
+		for i := range columns {
+			columnMetadataSize := proto.Size(&streamsmd.ColumnMetadata{Pages: columnPages[i]})
+			m.datasetColumnMetadataSize.WithLabelValues(sectionType).Observe(float64(columnMetadataSize))
+			totalColumnMetadataSize += columnMetadataSize
+		}
+		m.datasetColumnMetadataTotalSize.WithLabelValues(sectionType).Observe(float64(totalColumnMetadataSize))
+	}
+
+	for i, column := range columns {
+		columnType := column.Type.String()
+		pages := columnPages[i]
+
+		m.datasetColumnCompressedBytes.WithLabelValues(sectionType, columnType).Observe(float64(column.Info.CompressedSize))
+		m.datasetColumnUncompressedBytes.WithLabelValues(sectionType, columnType).Observe(float64(column.Info.UncompressedSize))
+		m.datasetColumnRows.WithLabelValues(sectionType, columnType).Observe(float64(column.Info.RowsCount))
+		m.datasetColumnValues.WithLabelValues(sectionType, columnType).Observe(float64(column.Info.ValuesCount))
+
+		m.datasetPageCount.WithLabelValues(sectionType, columnType).Observe(float64(len(pages)))
+
+		for _, page := range pages {
+			m.datasetPageCompressedBytes.WithLabelValues(sectionType, columnType).Observe(float64(page.Info.CompressedSize))
+			m.datasetPageUncompressedBytes.WithLabelValues(sectionType, columnType).Observe(float64(page.Info.UncompressedSize))
+			m.datasetPageRows.WithLabelValues(sectionType, columnType).Observe(float64(page.Info.RowsCount))
+			m.datasetPageValues.WithLabelValues(sectionType, columnType).Observe(float64(page.Info.ValuesCount))
+		}
+	}
+
+	return nil
+}
+
+func (m *Metrics) observeLogsSection(ctx context.Context, section *filemd.SectionInfo, dec LogsDecoder) error {
+	sectionType := section.Type.String()
+
+	columns, err := dec.Columns(ctx, section)
+	if err != nil {
+		return err
+	}
+	m.datasetColumnCount.WithLabelValues(sectionType).Observe(float64(len(columns)))
+
+	columnPages, err := result.Collect(dec.Pages(ctx, columns))
+	if err != nil {
+		return err
+	} else if len(columnPages) != len(columns) {
+		return fmt.Errorf("expected %d page lists, got %d", len(columns), len(columnPages))
+	}
+
+	// Count metadata sizes across columns.
+	{
+		var totalColumnMetadataSize int
+		for i := range columns {
+			columnMetadataSize := proto.Size(&logsmd.ColumnMetadata{Pages: columnPages[i]})
+			m.datasetColumnMetadataSize.WithLabelValues(sectionType).Observe(float64(columnMetadataSize))
+			totalColumnMetadataSize += columnMetadataSize
+		}
+		m.datasetColumnMetadataTotalSize.WithLabelValues(sectionType).Observe(float64(totalColumnMetadataSize))
+	}
+
+	for i, column := range columns {
+		columnType := column.Type.String()
+		pages := columnPages[i]
+
+		m.datasetColumnCompressedBytes.WithLabelValues(sectionType, columnType).Observe(float64(column.Info.CompressedSize))
+		m.datasetColumnUncompressedBytes.WithLabelValues(sectionType, columnType).Observe(float64(column.Info.UncompressedSize))
+		m.datasetColumnRows.WithLabelValues(sectionType, columnType).Observe(float64(column.Info.RowsCount))
+		m.datasetColumnValues.WithLabelValues(sectionType, columnType).Observe(float64(column.Info.ValuesCount))
+
+		m.datasetPageCount.WithLabelValues(sectionType, columnType).Observe(float64(len(pages)))
+
+		for _, page := range pages {
+			m.datasetPageCompressedBytes.WithLabelValues(sectionType, columnType).Observe(float64(page.Info.CompressedSize))
+			m.datasetPageUncompressedBytes.WithLabelValues(sectionType, columnType).Observe(float64(page.Info.UncompressedSize))
+			m.datasetPageRows.WithLabelValues(sectionType, columnType).Observe(float64(page.Info.RowsCount))
+			m.datasetPageValues.WithLabelValues(sectionType, columnType).Observe(float64(page.Info.ValuesCount))
+		}
+	}
+
+	return nil
+}

--- a/pkg/dataobj/internal/sections/logs/logs.go
+++ b/pkg/dataobj/internal/sections/logs/logs.go
@@ -10,8 +10,9 @@ import (
 	"slices"
 	"time"
 
-	"github.com/grafana/loki/pkg/push"
 	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/grafana/loki/pkg/push"
 
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/dataset"
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/encoding"

--- a/pkg/dataobj/internal/sections/logs/logs_test.go
+++ b/pkg/dataobj/internal/sections/logs/logs_test.go
@@ -44,7 +44,7 @@ func Test(t *testing.T) {
 		},
 	}
 
-	tracker := logs.New(1024)
+	tracker := logs.New(nil, 1024)
 	for _, record := range records {
 		tracker.Append(record)
 	}

--- a/pkg/dataobj/internal/sections/logs/metrics.go
+++ b/pkg/dataobj/internal/sections/logs/metrics.go
@@ -1,0 +1,65 @@
+package logs
+
+import (
+	"errors"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// Metrics instruments the logs section.
+type Metrics struct {
+	encodeSeconds prometheus.Histogram
+	appendsTotal  prometheus.Counter
+	recordCount   prometheus.Gauge
+}
+
+// NewMetrics creates a new set of metrics for the logs section.
+func NewMetrics() *Metrics {
+	return &Metrics{
+		encodeSeconds: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Namespace: "loki_dataobj",
+			Subsystem: "logs",
+			Name:      "encode_seconds",
+
+			Help: "Time taken encoding the logs section in seconds.",
+
+			Buckets:                         prometheus.DefBuckets,
+			NativeHistogramBucketFactor:     1.1,
+			NativeHistogramMaxBucketNumber:  100,
+			NativeHistogramMinResetDuration: time.Hour,
+		}),
+
+		appendsTotal: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: "loki_dataobj",
+			Subsystem: "logs",
+			Name:      "appends_total",
+
+			Help: "The total number of log records appended.",
+		}),
+
+		recordCount: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: "loki_dataobj",
+			Subsystem: "logs",
+			Name:      "records_count",
+
+			Help: "The current number of log records buffered; this resets after an encode.",
+		}),
+	}
+}
+
+// Register registers metrics to report to reg.
+func (m *Metrics) Register(reg prometheus.Registerer) error {
+	var errs []error
+	errs = append(errs, reg.Register(m.encodeSeconds))
+	errs = append(errs, reg.Register(m.appendsTotal))
+	errs = append(errs, reg.Register(m.recordCount))
+	return errors.Join(errs...)
+}
+
+// Unregister unregisters metrics from the provided Registerer.
+func (m *Metrics) Unregister(reg prometheus.Registerer) {
+	reg.Unregister(m.encodeSeconds)
+	reg.Unregister(m.appendsTotal)
+	reg.Unregister(m.recordCount)
+}

--- a/pkg/dataobj/internal/sections/streams/metrics.go
+++ b/pkg/dataobj/internal/sections/streams/metrics.go
@@ -1,0 +1,87 @@
+package streams
+
+import (
+	"errors"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// Metrics instruments the streams section.
+type Metrics struct {
+	encodeSeconds prometheus.Histogram
+	recordsTotal  prometheus.Counter
+	streamCount   prometheus.Gauge
+	minTimestamp  prometheus.Gauge
+	maxTimestamp  prometheus.Gauge
+}
+
+// NewMetrics creates a new set of metrics for the streams section.
+func NewMetrics() *Metrics {
+	return &Metrics{
+		encodeSeconds: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Namespace: "loki_dataobj",
+			Subsystem: "streams",
+			Name:      "encode_seconds",
+
+			Help: "Time taken encoding streams section in seconds.",
+
+			Buckets:                         prometheus.DefBuckets,
+			NativeHistogramBucketFactor:     1.1,
+			NativeHistogramMaxBucketNumber:  100,
+			NativeHistogramMinResetDuration: time.Hour,
+		}),
+
+		recordsTotal: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: "loki_dataobj",
+			Subsystem: "streams",
+			Name:      "records_total",
+
+			Help: "The total number of stream records appended.",
+		}),
+
+		streamCount: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: "loki_dataobj",
+			Subsystem: "streams",
+			Name:      "stream_count",
+
+			Help: "The current number of tracked streams; this resets after an encode.",
+		}),
+
+		minTimestamp: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: "loki_dataobj",
+			Subsystem: "streams",
+			Name:      "min_timestamp",
+
+			Help: "The minimum timestamp (in unix seconds) across all streams; this resets after an encode.",
+		}),
+
+		maxTimestamp: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: "loki_dataobj",
+			Subsystem: "streams",
+			Name:      "max_timestamp",
+
+			Help: "The maximum timestamp (in unix seconds) across all streams; this resets after an encode.",
+		}),
+	}
+}
+
+// Register registers metrics to report to reg.
+func (m *Metrics) Register(reg prometheus.Registerer) error {
+	var errs []error
+	errs = append(errs, reg.Register(m.encodeSeconds))
+	errs = append(errs, reg.Register(m.recordsTotal))
+	errs = append(errs, reg.Register(m.streamCount))
+	errs = append(errs, reg.Register(m.minTimestamp))
+	errs = append(errs, reg.Register(m.maxTimestamp))
+	return errors.Join(errs...)
+}
+
+// Unregister unregisters metrics from the provided Registerer.
+func (m *Metrics) Unregister(reg prometheus.Registerer) {
+	reg.Unregister(m.encodeSeconds)
+	reg.Unregister(m.recordsTotal)
+	reg.Unregister(m.streamCount)
+	reg.Unregister(m.minTimestamp)
+	reg.Unregister(m.maxTimestamp)
+}

--- a/pkg/dataobj/internal/sections/streams/streams_test.go
+++ b/pkg/dataobj/internal/sections/streams/streams_test.go
@@ -26,7 +26,7 @@ func Test(t *testing.T) {
 		{labels.FromStrings("cluster", "test", "app", "foo"), time.Unix(9, 0).UTC()},
 	}
 
-	tracker := streams.New(1024)
+	tracker := streams.New(nil, 1024)
 	for _, tc := range tt {
 		tracker.Record(tc.Labels, tc.Time)
 	}

--- a/pkg/dataobj/metrics.go
+++ b/pkg/dataobj/metrics.go
@@ -1,0 +1,147 @@
+package dataobj
+
+import (
+	"errors"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/grafana/loki/v3/pkg/dataobj/internal/encoding"
+	"github.com/grafana/loki/v3/pkg/dataobj/internal/sections/logs"
+	"github.com/grafana/loki/v3/pkg/dataobj/internal/sections/streams"
+)
+
+// metrics provides instrumnetation for the dataobj package.
+type metrics struct {
+	logs     *logs.Metrics
+	streams  *streams.Metrics
+	encoding *encoding.Metrics
+
+	shaPrefixSize    prometheus.Metric
+	targetPageSize   prometheus.Metric
+	targetObjectSize prometheus.Metric
+
+	appendTime prometheus.Histogram
+	buildTime  prometheus.Histogram
+	flushTime  prometheus.Histogram
+
+	sizeEstimate prometheus.Gauge
+}
+
+// newMetrics creates a new set of [metrics] for instrumenting data objects.
+func newMetrics(cfg BuilderConfig) *metrics {
+	return &metrics{
+		logs:     logs.NewMetrics(),
+		streams:  streams.NewMetrics(),
+		encoding: encoding.NewMetrics(),
+
+		shaPrefixSize: prometheus.MustNewConstMetric(
+			prometheus.NewDesc(
+				"loki_dataobj_config_sha_prefix_size",
+				"Configured SHA prefix size.",
+				nil,
+				nil,
+			),
+			prometheus.UntypedValue,
+			float64(cfg.SHAPrefixSize),
+		),
+
+		targetPageSize: prometheus.MustNewConstMetric(
+			prometheus.NewDesc(
+				"loki_dataobj_config_target_page_size_bytes",
+				"Configured target page size in bytes.",
+				nil,
+				nil,
+			),
+			prometheus.UntypedValue,
+			float64(cfg.TargetPageSize),
+		),
+
+		targetObjectSize: prometheus.MustNewConstMetric(
+			prometheus.NewDesc(
+				"loki_dataobj_config_target_object_size_bytes",
+				"Configured target object size in bytes.",
+				nil,
+				nil,
+			),
+			prometheus.UntypedValue,
+			float64(cfg.TargetObjectSize),
+		),
+
+		appendTime: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Namespace: "loki",
+			Subsystem: "dataobj",
+			Name:      "append_time_seconds",
+
+			Help: "Time taken appending a set of log lines in a stream to a data object.",
+
+			Buckets:                         prometheus.DefBuckets,
+			NativeHistogramBucketFactor:     1.1,
+			NativeHistogramMaxBucketNumber:  100,
+			NativeHistogramMinResetDuration: 0,
+		}),
+
+		buildTime: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Namespace: "loki",
+			Subsystem: "dataobj",
+			Name:      "build_time_seconds",
+
+			Help: "Time taken building a data object to flush.",
+
+			Buckets:                         prometheus.DefBuckets,
+			NativeHistogramBucketFactor:     1.1,
+			NativeHistogramMaxBucketNumber:  100,
+			NativeHistogramMinResetDuration: 0,
+		}),
+
+		flushTime: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Namespace: "loki",
+			Subsystem: "dataobj",
+			Name:      "flush_time_seconds",
+
+			Help: "Time taken flushing data objects to object storage.",
+
+			Buckets:                         prometheus.DefBuckets,
+			NativeHistogramBucketFactor:     1.1,
+			NativeHistogramMaxBucketNumber:  100,
+			NativeHistogramMinResetDuration: 0,
+		}),
+
+		sizeEstimate: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: "loki",
+			Subsystem: "dataobj",
+			Name:      "size_estimate_bytes",
+
+			Help: "Current estimated size of the data object in bytes.",
+		}),
+	}
+}
+
+// Register registers metrics to report to reg.
+func (m *metrics) Register(reg prometheus.Registerer) error {
+	var errs []error
+
+	errs = append(errs, m.logs.Register(reg))
+	errs = append(errs, m.streams.Register(reg))
+	errs = append(errs, m.encoding.Register(reg))
+
+	errs = append(errs, reg.Register(m.appendTime))
+	errs = append(errs, reg.Register(m.buildTime))
+	errs = append(errs, reg.Register(m.flushTime))
+
+	errs = append(errs, reg.Register(m.sizeEstimate))
+
+	return errors.Join(errs...)
+}
+
+// Unregister unregisters metrics from the provided Registerer.
+func (m *metrics) Unregister(reg prometheus.Registerer) {
+	m.logs.Unregister(reg)
+	m.streams.Unregister(reg)
+	m.encoding.Unregister(reg)
+
+	reg.Unregister(m.appendTime)
+	reg.Unregister(m.buildTime)
+	reg.Unregister(m.flushTime)
+
+	reg.Unregister(m.sizeEstimate)
+}

--- a/pkg/dataobj/reader.go
+++ b/pkg/dataobj/reader.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"path"
 
 	"github.com/thanos-io/objstore"
 
@@ -23,19 +22,15 @@ import (
 // At the moment, reader is only used for tests.
 type reader struct {
 	bucket objstore.Bucket
-	prefix string
 }
 
-func newReader(bucket objstore.Bucket, prefix string) *reader {
-	return &reader{
-		bucket: bucket,
-		prefix: prefix,
-	}
+func newReader(bucket objstore.Bucket) *reader {
+	return &reader{bucket: bucket}
 }
 
 // Objects returns an iterator over all data objects for the provided tenant.
 func (r *reader) Objects(ctx context.Context, tenant string) result.Seq[string] {
-	tenantPath := path.Join(r.prefix, fmt.Sprintf("tenant-%s/objects/", tenant))
+	tenantPath := fmt.Sprintf("tenant-%s/objects/", tenant)
 
 	return result.Iter(func(yield func(string) bool) error {
 		errIterationStopped := errors.New("iteration stopped")


### PR DESCRIPTION
This commit adds detailed instrumentation for data objects:

* Configuration information for the dataobj.Builder, which can be used to determine page and object efficiency.

* Performance information about dataobj.Builder.

* Current stats about the object being appended to.

* Many histograms recording the distribution of data in sections, columns, and pages. To limit the number of time series per builder, these stats are not available as classic histograms.

As a result, this introduces quite a few time series, around 80 per builder instance.