### PR TITLE
fix(helm): Update GEL Helm parameters to work with MinIO

### DIFF
--- a/docs/sources/setup/install/helm/reference.md
+++ b/docs/sources/setup/install/helm/reference.md
@@ -6922,8 +6922,15 @@ false
       "memory": "128Mi"
     }
   },
-  "rootPassword": "supersecret",
-  "rootUser": "enterprise-logs"
+  "rootPassword": "supersecretpassword",
+  "rootUser": "root-user",
+  "users": [
+    {
+      "accessKey": "logs-user",
+      "policy": "readwrite",
+      "secretKey": "supersecretpassword"
+    }
+  ]
 }
 </pre>
 </td>

--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -13,6 +13,9 @@ Entries should include a reference to the pull request that introduced the chang
 
 [//]: # (<AUTOMATED_UPDATES_LOCATOR> : do not remove this line. This locator is used by the CI pipeline to automatically create a changelog entry for each new Loki release. Add other chart versions and respective changelog entries bellow this line.)
 
+- [BUGFIX] Removed minio-mc init container from admin-api.
+- [BUGFIX] Fixed admin-api and gateway deployment container args.
+
 ## 6.25.0
 
 - [FEATURE] Added support for Overrides Exporter

--- a/production/helm/loki/templates/admin-api/deployment-admin-api.yaml
+++ b/production/helm/loki/templates/admin-api/deployment-admin-api.yaml
@@ -69,8 +69,8 @@ spec:
             - -admin.client.backend-type=s3
             - -admin.client.s3.endpoint={{ template "loki.minio" . }}
             - -admin.client.s3.bucket-name={{ .Values.loki.storage.bucketNames.admin }}
-            - -admin.client.s3.access-key-id={{ (index .Values.users 0).accessKey }}
-            - -admin.client.s3.secret-access-key={{ (index .Values.users 0).secretKey }}
+            - -admin.client.s3.access-key-id={{ (index .Values.minio.users 0).accessKey }}
+            - -admin.client.s3.secret-access-key={{ (index .Values.minio.users 0).secretKey }}
             - -admin.client.s3.insecure={{ .Values.loki.storage.s3.insecure }}
             {{- end }}
             {{- range $key, $value := .Values.adminApi.extraArgs }}

--- a/production/helm/loki/templates/admin-api/deployment-admin-api.yaml
+++ b/production/helm/loki/templates/admin-api/deployment-admin-api.yaml
@@ -50,7 +50,6 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.adminApi.podSecurityContext | nindent 8 }}
-      initContainers: {}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -69,7 +68,7 @@ spec:
             {{- if .Values.minio.enabled }}
             - -admin.client.backend-type=s3
             - -admin.client.s3.endpoint={{ template "loki.minio" . }}
-            - -admin.client.s3.bucket-name=enterprise-logs-admin
+            - -admin.client.s3.bucket-name={{ .Values.loki.storage.bucketNames.admin }}
             - -admin.client.s3.access-key-id={{ .Values.minio.accessKey }}
             - -admin.client.s3.secret-access-key={{ .Values.minio.secretKey }}
             - -admin.client.s3.insecure=true

--- a/production/helm/loki/templates/admin-api/deployment-admin-api.yaml
+++ b/production/helm/loki/templates/admin-api/deployment-admin-api.yaml
@@ -69,9 +69,9 @@ spec:
             - -admin.client.backend-type=s3
             - -admin.client.s3.endpoint={{ template "loki.minio" . }}
             - -admin.client.s3.bucket-name={{ .Values.loki.storage.bucketNames.admin }}
-            - -admin.client.s3.access-key-id={{ .Values.minio.accessKey }}
-            - -admin.client.s3.secret-access-key={{ .Values.minio.secretKey }}
-            - -admin.client.s3.insecure=true
+            - -admin.client.s3.access-key-id={{ (index .Values.users 0).accessKey }}
+            - -admin.client.s3.secret-access-key={{ (index .Values.users 0).secretKey }}
+            - -admin.client.s3.insecure={{ .Values.loki.storage.s3.insecure }}
             {{- end }}
             {{- range $key, $value := .Values.adminApi.extraArgs }}
             - "-{{ $key }}={{ $value }}"

--- a/production/helm/loki/templates/admin-api/deployment-admin-api.yaml
+++ b/production/helm/loki/templates/admin-api/deployment-admin-api.yaml
@@ -50,27 +50,7 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.adminApi.podSecurityContext | nindent 8 }}
-      initContainers:
-        # Taken from
-        # https://github.com/minio/charts/blob/a5c84bcbad884728bff5c9c23541f936d57a13b3/minio/templates/post-install-create-bucket-job.yaml
-      {{- if .Values.minio.enabled }}
-        - name: minio-mc
-          image: "{{ .Values.minio.mcImage.repository }}:{{ .Values.minio.mcImage.tag }}"
-          imagePullPolicy: {{ .Values.minio.mcImage.pullPolicy }}
-          command: ["/bin/sh", "/config/initialize"]
-          env:
-            - name: MINIO_ENDPOINT
-              value: {{ .Release.Name }}-minio
-            - name: MINIO_PORT
-              value: {{ .Values.minio.service.port | quote }}
-          volumeMounts:
-            - name: minio-configuration
-              mountPath: /config
-          {{- if .Values.minio.tls.enabled }}
-            - name: cert-secret-volume-mc
-              mountPath: {{ .Values.minio.configPathmc }}certs
-          {{ end }}
-        {{- end }}
+      initContainers: {}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/production/helm/loki/templates/gateway/deployment-gateway-enterprise.yaml
+++ b/production/helm/loki/templates/gateway/deployment-gateway-enterprise.yaml
@@ -70,7 +70,7 @@ spec:
             {{- if .Values.minio.enabled }}
             - -admin.client.backend-type=s3
             - -admin.client.s3.endpoint={{ template "loki.minio" . }}
-            - -admin.client.s3.bucket-name=enterprise-logs-admin
+            - -admin.client.s3.bucket-name={{ .Values.loki.storage.bucketNames.admin }}
             - -admin.client.s3.access-key-id={{ .Values.minio.accessKey }}
             - -admin.client.s3.secret-access-key={{ .Values.minio.secretKey }}
             - -admin.client.s3.insecure=true

--- a/production/helm/loki/templates/gateway/deployment-gateway-enterprise.yaml
+++ b/production/helm/loki/templates/gateway/deployment-gateway-enterprise.yaml
@@ -71,9 +71,9 @@ spec:
             - -admin.client.backend-type=s3
             - -admin.client.s3.endpoint={{ template "loki.minio" . }}
             - -admin.client.s3.bucket-name={{ .Values.loki.storage.bucketNames.admin }}
-            - -admin.client.s3.access-key-id={{ .Values.minio.accessKey }}
-            - -admin.client.s3.secret-access-key={{ .Values.minio.secretKey }}
-            - -admin.client.s3.insecure=true
+            - -admin.client.s3.access-key-id={{ (index .Values.users 0).accessKey }}
+            - -admin.client.s3.secret-access-key={{ (index .Values.users 0).secretKey }}
+            - -admin.client.s3.insecure={{ .Values.loki.storage.s3.insecure }}
             {{- end }}
             {{- if and $isDistributed .Values.enterpriseGateway.useDefaultProxyURLs }}
             - -gateway.proxy.default.url=http://{{ template "loki.fullname" . }}-admin-api.{{ .Release.Namespace }}.svc:3100

--- a/production/helm/loki/templates/gateway/deployment-gateway-enterprise.yaml
+++ b/production/helm/loki/templates/gateway/deployment-gateway-enterprise.yaml
@@ -71,8 +71,8 @@ spec:
             - -admin.client.backend-type=s3
             - -admin.client.s3.endpoint={{ template "loki.minio" . }}
             - -admin.client.s3.bucket-name={{ .Values.loki.storage.bucketNames.admin }}
-            - -admin.client.s3.access-key-id={{ (index .Values.users 0).accessKey }}
-            - -admin.client.s3.secret-access-key={{ (index .Values.users 0).secretKey }}
+            - -admin.client.s3.access-key-id={{ (index .Values.minio.users 0).accessKey }}
+            - -admin.client.s3.secret-access-key={{ (index .Values.minio.users 0).secretKey }}
             - -admin.client.s3.insecure={{ .Values.loki.storage.s3.insecure }}
             {{- end }}
             {{- if and $isDistributed .Values.enterpriseGateway.useDefaultProxyURLs }}

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -3372,8 +3372,16 @@ minio:
   # https://docs.min.io/docs/minio-erasure-code-quickstart-guide
   # Since we only have 1 replica, that means 2 drives must be used.
   drivesPerNode: 2
-  rootUser: enterprise-logs
-  rootPassword: supersecret
+  # root user; not used for GEL authentication
+  rootUser: root-user
+  rootPassword: supersecretpassword
+  # The first user in the list below is used for Loki/GEL authentication.
+  # You can add additional users if desired; they will not impact Loki/GEL.
+  # `accessKey` = username, `secretKey` = password
+  users:
+    - accessKey: logs-user
+      secretKey: supersecretpassword
+      policy: readwrite
   buckets:
     - name: chunks
       policy: none


### PR DESCRIPTION
**What this PR does / why we need it**:

GEL failed to deploy when deployed with MinIO via the `minio` sub-chart. 

- Removed the minio-mc init container from admin-api; it was unnecessary and caused the admin-api deployment to fail. The MinIO Helm chart now handles this with a [standalone job](https://github.com/minio/minio/blob/master/helm/minio/templates/post-job.yaml).
- Updated the admin-api and gateway deployment container args to pull the correct values from the template.
  - bucket-name
  - access-key-id
  - secret-access-key
  - insecure

Note that `access-key-id` and `secret-access-key` are now pulled from the first entry under `minio.users`. Example:

```yaml
minio:
  users:
    # these will be your primary GEL access credentials
    - accessKey: FIXME_ACCESS_KEY_ID_0
      secretKey: FIXME_SECRET_ACCESS_KEY_0
      policy: readwrite
    # this is another normal user that can read/write to all buckets
    - accessKey: FIXME_ACCESS_KEY_ID_1
      secretKey: FIXME_SECRET_ACCESS_KEY_1
      policy: readwrite
```

Older versions of the MinIO chart supported `minio.accessKey` and `minio.secretKey` as your primary/default service account/access credentials, but this no longer appears to be the case. Pulling the first entry from `minio.users` was preferable to introducing additional parameters to set these credentials in the sub-chart.

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
