### PR TITLE
chore: update usage tracker with received bytes on stream level instead of each log line

### DIFF
--- a/pkg/loghttp/push/push.go
+++ b/pkg/loghttp/push/push.go
@@ -282,7 +282,7 @@ func ParseLokiRequest(userID string, r *http.Request, tenantsRetention TenantsRe
 			retentionPeriod = tenantsRetention.RetentionPeriodFor(userID, lbs)
 		}
 		totalBytesReceived := int64(0)
-		
+
 		for _, e := range s.Entries {
 			pushStats.NumLines++
 			entryLabelsSize := int64(util.StructuredMetadataSize(e.StructuredMetadata))

--- a/pkg/loghttp/push/push.go
+++ b/pkg/loghttp/push/push.go
@@ -281,20 +281,23 @@ func ParseLokiRequest(userID string, r *http.Request, tenantsRetention TenantsRe
 		if tenantsRetention != nil {
 			retentionPeriod = tenantsRetention.RetentionPeriodFor(userID, lbs)
 		}
+		totalBytesReceived := int64(0)
+		
 		for _, e := range s.Entries {
 			pushStats.NumLines++
 			entryLabelsSize := int64(util.StructuredMetadataSize(e.StructuredMetadata))
 			pushStats.LogLinesBytes[retentionPeriod] += int64(len(e.Line))
 			pushStats.StructuredMetadataBytes[retentionPeriod] += entryLabelsSize
-
-			if tracker != nil {
-				tracker.ReceivedBytesAdd(r.Context(), userID, retentionPeriod, lbs, float64(len(e.Line)))
-				tracker.ReceivedBytesAdd(r.Context(), userID, retentionPeriod, lbs, float64(entryLabelsSize))
-			}
+			totalBytesReceived += int64(len(e.Line))
+			totalBytesReceived += entryLabelsSize
 
 			if e.Timestamp.After(pushStats.MostRecentEntryTimestamp) {
 				pushStats.MostRecentEntryTimestamp = e.Timestamp
 			}
+		}
+
+		if tracker != nil {
+			tracker.ReceivedBytesAdd(r.Context(), userID, retentionPeriod, lbs, float64(totalBytesReceived))
 		}
 
 		req.Streams[i] = s


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, we update the usage tracker for bytes received stats for each log line. Since it is on a hot path and the tracker would continue to evolve as we do more complex things, this PR reduces the update frequency to stream level.