### PR TITLE
chore: fix missing module for ingest-limits-frontend

### DIFF
--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -684,6 +684,7 @@ func (t *Loki) setupModuleManager() error {
 	mm.RegisterModule(TenantConfigs, t.initTenantConfigs, modules.UserInvisibleModule)
 	mm.RegisterModule(Distributor, t.initDistributor)
 	mm.RegisterModule(IngestLimits, t.initIngestLimits, modules.UserInvisibleModule)
+	mm.RegisterModule(IngestLimitsFrontend, t.initIngestLimitsFrontend, modules.UserInvisibleModule)
 	mm.RegisterModule(Store, t.initStore, modules.UserInvisibleModule)
 	mm.RegisterModule(Querier, t.initQuerier)
 	mm.RegisterModule(Ingester, t.initIngester)
@@ -728,6 +729,7 @@ func (t *Loki) setupModuleManager() error {
 		TenantConfigs:            {RuntimeConfig},
 		Distributor:              {Ring, Server, Overrides, TenantConfigs, PatternRingClient, PatternIngesterTee, Analytics, PartitionRing},
 		IngestLimits:             {Server},
+		IngestLimitsFrontend:     {Server},
 		Store:                    {Overrides, IndexGatewayRing},
 		Ingester:                 {Store, Server, MemberlistKV, TenantConfigs, Analytics, PartitionRing},
 		Querier:                  {Store, Ring, Server, IngesterQuerier, PatternRingClient, Overrides, Analytics, CacheGenerationLoader, QuerySchedulerRing},
@@ -762,7 +764,7 @@ func (t *Loki) setupModuleManager() error {
 	}
 
 	if t.Cfg.Distributor.KafkaEnabled {
-		deps[All] = append(deps[All], IngestLimits)
+		deps[All] = append(deps[All], IngestLimits, IngestLimitsFrontend)
 	}
 
 	if t.Cfg.Querier.PerRequestLimitsEnabled {


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a missing module for `ingest-limits-frontend` that prevented it from being started with `-target`.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
