### PR TITLE
chore(dataobj): fix dataobj_config metrics

### DIFF
--- a/pkg/dataobj/dataobj.go
+++ b/pkg/dataobj/dataobj.go
@@ -132,11 +132,12 @@ func NewBuilder(cfg BuilderConfig, bucket objstore.Bucket, tenantID string) (*Bu
 	}
 
 	var (
-		metrics = newMetrics(cfg)
+		metrics = newMetrics()
 
 		flushBuffer = bytes.NewBuffer(make([]byte, 0, int(cfg.TargetObjectSize)))
 		encoder     = encoding.NewEncoder(flushBuffer)
 	)
+	metrics.ObserveConfig(cfg)
 
 	return &Builder{
 		cfg:      cfg,

--- a/pkg/dataobj/metrics.go
+++ b/pkg/dataobj/metrics.go
@@ -16,9 +16,9 @@ type metrics struct {
 	streams  *streams.Metrics
 	encoding *encoding.Metrics
 
-	shaPrefixSize    prometheus.Metric
-	targetPageSize   prometheus.Metric
-	targetObjectSize prometheus.Metric
+	shaPrefixSize    prometheus.Gauge
+	targetPageSize   prometheus.Gauge
+	targetObjectSize prometheus.Gauge
 
 	appendTime prometheus.Histogram
 	buildTime  prometheus.Histogram
@@ -28,44 +28,35 @@ type metrics struct {
 }
 
 // newMetrics creates a new set of [metrics] for instrumenting data objects.
-func newMetrics(cfg BuilderConfig) *metrics {
+func newMetrics() *metrics {
 	return &metrics{
 		logs:     logs.NewMetrics(),
 		streams:  streams.NewMetrics(),
 		encoding: encoding.NewMetrics(),
 
-		shaPrefixSize: prometheus.MustNewConstMetric(
-			prometheus.NewDesc(
-				"loki_dataobj_config_sha_prefix_size",
-				"Configured SHA prefix size.",
-				nil,
-				nil,
-			),
-			prometheus.UntypedValue,
-			float64(cfg.SHAPrefixSize),
-		),
+		shaPrefixSize: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: "loki",
+			Subsystem: "dataobj",
+			Name:      "config_sha_prefix_size",
 
-		targetPageSize: prometheus.MustNewConstMetric(
-			prometheus.NewDesc(
-				"loki_dataobj_config_target_page_size_bytes",
-				"Configured target page size in bytes.",
-				nil,
-				nil,
-			),
-			prometheus.UntypedValue,
-			float64(cfg.TargetPageSize),
-		),
+			Help: "Configured SHA prefix size.",
+		}),
 
-		targetObjectSize: prometheus.MustNewConstMetric(
-			prometheus.NewDesc(
-				"loki_dataobj_config_target_object_size_bytes",
-				"Configured target object size in bytes.",
-				nil,
-				nil,
-			),
-			prometheus.UntypedValue,
-			float64(cfg.TargetObjectSize),
-		),
+		targetPageSize: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: "loki",
+			Subsystem: "dataobj",
+			Name:      "config_target_page_size_bytes",
+
+			Help: "Configured target page size in bytes.",
+		}),
+
+		targetObjectSize: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: "loki",
+			Subsystem: "dataobj",
+			Name:      "config_target_object_size_bytes",
+
+			Help: "Configured target object size in bytes.",
+		}),
 
 		appendTime: prometheus.NewHistogram(prometheus.HistogramOpts{
 			Namespace: "loki",
@@ -116,6 +107,13 @@ func newMetrics(cfg BuilderConfig) *metrics {
 	}
 }
 
+// ObserveConfig updates config metrics based on the provided [BuilderConfig].
+func (m *metrics) ObserveConfig(cfg BuilderConfig) {
+	m.shaPrefixSize.Set(float64(cfg.SHAPrefixSize))
+	m.targetPageSize.Set(float64(cfg.TargetPageSize))
+	m.targetObjectSize.Set(float64(cfg.TargetObjectSize))
+}
+
 // Register registers metrics to report to reg.
 func (m *metrics) Register(reg prometheus.Registerer) error {
 	var errs []error
@@ -123,6 +121,10 @@ func (m *metrics) Register(reg prometheus.Registerer) error {
 	errs = append(errs, m.logs.Register(reg))
 	errs = append(errs, m.streams.Register(reg))
 	errs = append(errs, m.encoding.Register(reg))
+
+	errs = append(errs, reg.Register(m.shaPrefixSize))
+	errs = append(errs, reg.Register(m.targetPageSize))
+	errs = append(errs, reg.Register(m.targetObjectSize))
 
 	errs = append(errs, reg.Register(m.appendTime))
 	errs = append(errs, reg.Register(m.buildTime))


### PR DESCRIPTION
The config metrics weren't registered, but you also can't register constant metrics so I needed to switch them over to a gauge. 