### PR TITLE
fix: missing route to prometheus api endpoint via backend in docker-compose setup

### DIFF
--- a/production/docker/config/nginx.conf
+++ b/production/docker/config/nginx.conf
@@ -23,6 +23,10 @@ http {
     server loki-write:3100;
   }
 
+  upstream backend {
+    server loki-backend:3100;
+  }
+
   upstream cluster {
     server loki-read:3100;
     server loki-write:3100;
@@ -56,6 +60,10 @@ http {
         proxy_pass       http://write$request_uri;
     }
 
+    location = /loki/api/v1/delete {
+        proxy_pass       http://write$request_uri;
+    }
+
     location = /loki/api/v1/tail {
         proxy_pass       http://read$request_uri;
         proxy_set_header Upgrade $http_upgrade;
@@ -64,6 +72,10 @@ http {
 
     location ~ /loki/api/.* {
         proxy_pass       http://read$request_uri;
+    }
+
+    location ~ /prometheus/api/.* {
+        proxy_pass       http://backend$request_uri;
     }
   }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Resolves the error message "Failed to load the data source configuration for Loki: Unable to fetch alert rules. Is the Loki data source properly configured?" for alert and recording rules in Grafana Alert Overview of docker-compose stack.

![df951fdf41ff90791d94d56aac43d9c9457fd066_2_690x167](https://github.com/user-attachments/assets/4993fd11-d493-4be7-acc1-88049d71e988)


**Which issue(s) this PR fixes**:
Fixes #42963

**Special notes for your reviewer**:
Adds a route to the backend, which runs the ruler.

**Checklist**
- [ x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x ] Documentation added
- [ x] Tests updated
- [ x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
