### PR TITLE
chore: Fix `unused-parameter` linter errors

### DIFF
--- a/pkg/bloomgateway/client.go
+++ b/pkg/bloomgateway/client.go
@@ -23,7 +23,6 @@ import (
 	"github.com/grafana/loki/v3/pkg/querier/plan"
 	"github.com/grafana/loki/v3/pkg/queue"
 	v1 "github.com/grafana/loki/v3/pkg/storage/bloom/v1"
-	"github.com/grafana/loki/v3/pkg/storage/chunk/cache/resultscache"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/bloomshipper"
 	"github.com/grafana/loki/v3/pkg/util/discovery"
 )
@@ -121,14 +120,7 @@ type GatewayClient struct {
 	dnsProvider *discovery.DNS
 }
 
-func NewClient(
-	cfg ClientConfig,
-	limits Limits,
-	registerer prometheus.Registerer,
-	logger log.Logger,
-	cacheGen resultscache.CacheGenNumberLoader,
-	retentionEnabled bool,
-) (*GatewayClient, error) {
+func NewClient(cfg ClientConfig, registerer prometheus.Registerer, logger log.Logger) (*GatewayClient, error) {
 	metrics := newClientMetrics(registerer)
 
 	dialOpts, err := cfg.GRPCClientConfig.DialOption(grpcclient.Instrument(metrics.requestLatency))

--- a/pkg/bloomgateway/client_test.go
+++ b/pkg/bloomgateway/client_test.go
@@ -28,14 +28,12 @@ func (p *errorMockPool) Addr(_ string) (string, error) {
 func TestBloomGatewayClient(t *testing.T) {
 	logger := log.NewNopLogger()
 
-	limits := newLimits()
-
 	cfg := ClientConfig{}
 	flagext.DefaultValues(&cfg)
 
 	t.Run("FilterChunks returns response", func(t *testing.T) {
 		reg := prometheus.NewRegistry()
-		c, err := NewClient(cfg, limits, reg, logger, nil, false)
+		c, err := NewClient(cfg, reg, logger)
 		require.NoError(t, err)
 		expr, err := syntax.ParseExpr(`{foo="bar"}`)
 		require.NoError(t, err)
@@ -46,7 +44,7 @@ func TestBloomGatewayClient(t *testing.T) {
 
 	t.Run("pool error is suppressed and returns full list of chunks", func(t *testing.T) {
 		reg := prometheus.NewRegistry()
-		c, err := NewClient(cfg, limits, reg, logger, nil, false)
+		c, err := NewClient(cfg, reg, logger)
 		require.NoError(t, err)
 		c.pool = &errorMockPool{}
 

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -1544,14 +1544,7 @@ func (t *Loki) initIndexGateway() (services.Service, error) {
 
 	var bloomQuerier indexgateway.BloomQuerier
 	if t.Cfg.BloomGateway.Enabled {
-		bloomGatewayClient, err := bloomgateway.NewClient(
-			t.Cfg.BloomGateway.Client,
-			t.Overrides,
-			prometheus.DefaultRegisterer,
-			logger,
-			t.cacheGenerationLoader,
-			t.Cfg.CompactorConfig.RetentionEnabled,
-		)
+		bloomGatewayClient, err := bloomgateway.NewClient(t.Cfg.BloomGateway.Client, prometheus.DefaultRegisterer, logger)
 		if err != nil {
 			return nil, err
 		}
@@ -1675,14 +1668,7 @@ func (t *Loki) initBloomBuilder() (services.Service, error) {
 	var bloomGatewayClient bloomgateway.Client
 	if t.Cfg.BloomGateway.Enabled {
 		var err error
-		bloomGatewayClient, err = bloomgateway.NewClient(
-			t.Cfg.BloomGateway.Client,
-			t.Overrides,
-			prometheus.DefaultRegisterer,
-			logger,
-			t.cacheGenerationLoader,
-			t.Cfg.CompactorConfig.RetentionEnabled,
-		)
+		bloomGatewayClient, err = bloomgateway.NewClient(t.Cfg.BloomGateway.Client, prometheus.DefaultRegisterer, logger)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes linter error which prevents the CI pipeline to succeed.

![screenshot_20250120_135712](https://github.com/user-attachments/assets/ea5d1062-fd4c-4645-aedf-1aae30628513)
