### PR TITLE
chore(dataobj): add compression ratio and final object size distributions 

### DIFF
--- a/pkg/dataobj/dataobj.go
+++ b/pkg/dataobj/dataobj.go
@@ -303,6 +303,8 @@ func (b *Builder) buildObject() error {
 		return fmt.Errorf("encoding object: %w", err)
 	}
 
+	b.metrics.builtSize.Observe(float64(b.flushBuffer.Len()))
+
 	// We pass context.Background() below to avoid allowing building an object to
 	// time out; timing out on build would discard anything we built and would
 	// cause data loss.

--- a/pkg/dataobj/internal/encoding/metrics.go
+++ b/pkg/dataobj/internal/encoding/metrics.go
@@ -351,9 +351,13 @@ func (m *Metrics) observeLogsSection(ctx context.Context, section *filemd.Sectio
 	for i, column := range columns {
 		columnType := column.Type.String()
 		pages := columnPages[i]
+		compression := column.Info.Compression
 
 		m.datasetColumnCompressedBytes.WithLabelValues(sectionType, columnType).Observe(float64(column.Info.CompressedSize))
 		m.datasetColumnUncompressedBytes.WithLabelValues(sectionType, columnType).Observe(float64(column.Info.UncompressedSize))
+		if compression != datasetmd.COMPRESSION_TYPE_NONE {
+			m.datasetColumnCompressionRatio.WithLabelValues(sectionType, columnType, compression.String()).Observe(float64(column.Info.UncompressedSize) / float64(column.Info.CompressedSize))
+		}
 		m.datasetColumnRows.WithLabelValues(sectionType, columnType).Observe(float64(column.Info.RowsCount))
 		m.datasetColumnValues.WithLabelValues(sectionType, columnType).Observe(float64(column.Info.ValuesCount))
 
@@ -362,6 +366,9 @@ func (m *Metrics) observeLogsSection(ctx context.Context, section *filemd.Sectio
 		for _, page := range pages {
 			m.datasetPageCompressedBytes.WithLabelValues(sectionType, columnType).Observe(float64(page.Info.CompressedSize))
 			m.datasetPageUncompressedBytes.WithLabelValues(sectionType, columnType).Observe(float64(page.Info.UncompressedSize))
+			if compression != datasetmd.COMPRESSION_TYPE_NONE {
+				m.datasetPageCompressionRatio.WithLabelValues(sectionType, columnType, compression.String()).Observe(float64(page.Info.UncompressedSize) / float64(page.Info.CompressedSize))
+			}
 			m.datasetPageRows.WithLabelValues(sectionType, columnType).Observe(float64(page.Info.RowsCount))
 			m.datasetPageValues.WithLabelValues(sectionType, columnType).Observe(float64(page.Info.ValuesCount))
 		}


### PR DESCRIPTION
This adds three new histograms:

* A distribution of constructed object sizes,
* a distribution of compression ratio across an entire column, and
* a distribution of compression ratio per compressed page.

The compression ratio histogram is only reported for columns where compression is being used.