### PR TITLE
feat: create client for limits frontend to call limits service

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -798,11 +798,17 @@ compactor_grpc_client:
 [limits_config: <limits_config>]
 
 limits_frontend_config:
-  # The grpc_client block configures the gRPC client used to communicate between
-  # a client and server component in Loki.
-  # The CLI flags prefix for this block configuration is:
-  # querier.frontend-grpc-client
-  [grpc_client_config: <grpc_client>]
+  client_config:
+    # Configures client gRPC connections to limits service.
+    # The CLI flags prefix for this block configuration is:
+    # querier.frontend-grpc-client
+    [grpc_client_config: <grpc_client>]
+
+    # Configures client gRPC connections pool to limits service.
+    pool_config:
+      [client_cleanup_period: <duration>]
+
+      [remote_timeout: <duration>]
 
 # The frontend_worker configures the worker - running within the Loki querier -
 # picking up and executing queries enqueued by the query-frontend.

--- a/pkg/limits/frontend/client.go
+++ b/pkg/limits/frontend/client.go
@@ -1,57 +1,134 @@
 package frontend
 
 import (
-	"context"
+	"flag"
+	"io"
+	"time"
 
+	"github.com/go-kit/log"
+	"github.com/grafana/dskit/grpcclient"
+	"github.com/grafana/dskit/middleware"
 	"github.com/grafana/dskit/ring"
+	ring_client "github.com/grafana/dskit/ring/client"
+	"github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc"
+	"github.com/opentracing/opentracing-go"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/health/grpc_health_v1"
 
 	"github.com/grafana/loki/v3/pkg/logproto"
+	"github.com/grafana/loki/v3/pkg/util/server"
 )
 
-type IngestLimitsClient interface {
-	// ExceedsLimits checksif the request would exceed the current tenants
-	// limits.
-	ExceedsLimits(ctx context.Context, r *logproto.ExceedsLimitsRequest) (*logproto.ExceedsLimitsResponse, error)
+var (
+	limitsClients = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "loki_ingest_limits_clients",
+		Help: "The current number of ingest limits clients.",
+	})
+	limitsClientRequestDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "loki_ingest_limits_client_request_duration_seconds",
+		Help:    "Time spent doing ingest limits requests.",
+		Buckets: prometheus.ExponentialBuckets(0.001, 4, 6),
+	}, []string{"operation", "status_code"})
+)
+
+// ClientConfig contains the config for an ingest-limits client.
+type ClientConfig struct {
+	GRPCClientConfig             grpcclient.Config              `yaml:"grpc_client_config" doc:"description=Configures client gRPC connections to limits service."`
+	PoolConfig                   PoolConfig                     `yaml:"pool_config,omitempty" doc:"description=Configures client gRPC connections pool to limits service."`
+	GRPCUnaryClientInterceptors  []grpc.UnaryClientInterceptor  `yaml:"-"`
+	GRCPStreamClientInterceptors []grpc.StreamClientInterceptor `yaml:"-"`
 }
 
-// RingIngestLimitsClient is an IngestLimitsClients that uses the ring to read the responses
-// from all limits backends.
-type RingIngestLimitsClient struct {
-	ring ring.ReadRing
+func (cfg ClientConfig) RegisterFlags(f *flag.FlagSet) {
+	cfg.GRPCClientConfig.RegisterFlagsWithPrefix("ingest-limits-frontend.grpc-client-config", f)
+	cfg.PoolConfig.RegisterFlagsWithPrefix("ingest-limits-frontend", f)
 }
 
-// NewRingIngestLimitsClients returns a new RingIngestLimitsCLient.
-func NewRingIngestLimitsClient(ring ring.ReadRing) *RingIngestLimitsClient {
-	return &RingIngestLimitsClient{
-		ring: ring,
+// PoolConfig contains the config for a pool of ingest-limits clients.
+type PoolConfig struct {
+	ClientCleanupPeriod time.Duration `yaml:"client_cleanup_period"`
+	RemoteTimeout       time.Duration `yaml:"remote_timeout"`
+}
+
+func (cfg *PoolConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
+	f.DurationVar(&cfg.ClientCleanupPeriod, prefix+".client-cleanup-period", 15*time.Second, "How frequently to clean up clients for ingesters that have gone away.")
+	f.DurationVar(&cfg.RemoteTimeout, prefix+".remote-timeout", 1*time.Second, "Timeout for the health check.")
+}
+
+// IngestLimitsClient is a gRPC client for the ingest-limits backend.
+// The ingest limits service uses a pool of clients to get usage data from
+// individual backends.
+type IngestLimitsClient struct {
+	logproto.IngestLimitsClient
+	grpc_health_v1.HealthClient
+	io.Closer
+}
+
+// NewIngestLimitsClient returns a new IngestLimitsClient for the specified
+// ingest-limits backend.
+func NewIngestLimitsClient(cfg ClientConfig, addr string) (*IngestLimitsClient, error) {
+	opts := []grpc.DialOption{
+		grpc.WithDefaultCallOptions(cfg.GRPCClientConfig.CallOptions()...),
 	}
+	dialOpts, err := cfg.GRPCClientConfig.DialOption(getGRPCInterceptors(&cfg))
+	if err != nil {
+		return nil, err
+	}
+	opts = append(opts, dialOpts...)
+	// nolint:staticcheck // grpc.Dial() has been deprecated; we'll address it before upgrading to gRPC 2.
+	conn, err := grpc.Dial(addr, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return &IngestLimitsClient{
+		IngestLimitsClient: logproto.NewIngestLimitsClient(conn),
+		HealthClient:       grpc_health_v1.NewHealthClient(conn),
+		Closer:             conn,
+	}, nil
 }
 
-func (c *RingIngestLimitsClient) forAllBackends(_ context.Context, _ func(context.Context, logproto.IngestLimitsClient) (interface{}, error)) ([]Response, error) {
-	return nil, nil
+// getInterceptors returns the gRPC interceptors for the given ClientConfig.
+func getGRPCInterceptors(cfg *ClientConfig) ([]grpc.UnaryClientInterceptor, []grpc.StreamClientInterceptor) {
+	var (
+		unaryInterceptors  []grpc.UnaryClientInterceptor
+		streamInterceptors []grpc.StreamClientInterceptor
+	)
+
+	unaryInterceptors = append(unaryInterceptors, cfg.GRPCUnaryClientInterceptors...)
+	unaryInterceptors = append(unaryInterceptors, server.UnaryClientQueryTagsInterceptor)
+	unaryInterceptors = append(unaryInterceptors, server.UnaryClientHTTPHeadersInterceptor)
+	unaryInterceptors = append(unaryInterceptors, otgrpc.OpenTracingClientInterceptor(opentracing.GlobalTracer()))
+	// if !cfg.Internal {
+	// 	unaryInterceptors = append(unaryInterceptors, middleware.ClientUserHeaderInterceptor)
+	// }
+	unaryInterceptors = append(unaryInterceptors, middleware.UnaryClientInstrumentInterceptor(limitsClientRequestDuration))
+
+	streamInterceptors = append(streamInterceptors, cfg.GRCPStreamClientInterceptors...)
+	streamInterceptors = append(streamInterceptors, server.StreamClientQueryTagsInterceptor)
+	streamInterceptors = append(streamInterceptors, server.StreamClientHTTPHeadersInterceptor)
+	streamInterceptors = append(streamInterceptors, otgrpc.OpenTracingStreamClientInterceptor(opentracing.GlobalTracer()))
+	// if !cfg.Internal {
+	// 	streamInterceptors = append(streamInterceptors, middleware.StreamClientUserHeaderInterceptor)
+	// }
+	streamInterceptors = append(streamInterceptors, middleware.StreamClientInstrumentInterceptor(limitsClientRequestDuration))
+
+	return unaryInterceptors, streamInterceptors
 }
 
-func (c *RingIngestLimitsClient) ExceedsLimits(_ context.Context, _ *logproto.ExceedsLimitsRequest) (*logproto.ExceedsLimitsResponse, error) {
-	return nil, nil
-	// req := &logproto.GetLimitsRequest{
-	// 	Tenant: tenantID,
-	// }
-	// resps, err := c.forAllBackends(ctx, func(_ context.Context, client logproto.IngestLimitsClient) (interface{}, error) {
-	// 	return client.NumStreams(ctx, req)
-	// })
-	// if err != nil {
-	// 	return nil, err
-	// }
-	// var sum uint64
-	// for _, resp := range resps {
-	// 	sum += resp.num
-	// }
-	// return &logproto.ExceedsLimitsResponse{
-
-	// }, nil
-}
-
-type Response struct {
-	Addr string
-	Data interface{}
+// NewIngestLimitsClientPool returns a new pool of IngestLimitsClients.
+func NewIngestLimitsClientPool(
+	name string,
+	cfg PoolConfig,
+	ring ring.ReadRing,
+	factory ring_client.PoolFactory,
+	logger log.Logger,
+) *ring_client.Pool {
+	poolCfg := ring_client.PoolConfig{
+		CheckInterval:      cfg.ClientCleanupPeriod,
+		HealthCheckEnabled: false, // TODO: Enable configuration of health checking. See queriers.
+		HealthCheckTimeout: cfg.RemoteTimeout,
+	}
+	return ring_client.NewPool(name, poolCfg, ring_client.NewRingServiceDiscovery(ring), factory, limitsClients, logger)
 }

--- a/pkg/limits/frontend/config.go
+++ b/pkg/limits/frontend/config.go
@@ -2,18 +2,17 @@ package frontend
 
 import (
 	"flag"
-
-	"github.com/grafana/dskit/grpcclient"
 )
 
 type Config struct {
-	GRPCClientConfig grpcclient.Config `yaml:"grpc_client_config"`
+	ClientConfig ClientConfig `yaml:"client_config"`
 }
 
 func (cfg Config) RegisterFlags(f *flag.FlagSet) {
-	cfg.GRPCClientConfig.RegisterFlagsWithPrefix("limits-frontend.grpc-client-config", f)
+	cfg.ClientConfig.RegisterFlags(f)
 }
 
+// TODO: Validate configuration. This is called during initialization.
 func (cfg Config) Validate() error {
 	return nil
 }

--- a/pkg/limits/frontend/frontend.go
+++ b/pkg/limits/frontend/frontend.go
@@ -1,3 +1,8 @@
+// Package frontend contains provides a frontend service for ingest limits.
+// It is responsible for receiving and answering gRPC requests from distributors,
+// such as exceeds limits requests, forwarding them to individual limits backends,
+// gathering and aggregating their responses (where required), and returning
+// the final result. 
 package frontend
 
 import (
@@ -5,22 +10,26 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/services"
+	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/grafana/loki/v3/pkg/logproto"
 )
 
+// Frontend is the limits-frontend service, and acts a service wrapper for
+// all components needed to run the limits-frontend.
 type Frontend struct {
 	services.Service
-
-	cfg    Config
-	logger log.Logger
-	client IngestLimitsClient
+	cfg     Config
+	logger  log.Logger
+	limits  IngestLimitsService
 }
 
-func NewFrontend(cfg Config, logger log.Logger) (*Frontend, error) {
+// NewFrontend returns a new Frontend.
+func NewFrontend(cfg Config, logger log.Logger, _ prometheus.Registerer, limits IngestLimitsService) (*Frontend, error) {
 	f := &Frontend{
-		cfg:    cfg,
-		logger: logger,
+		cfg:     cfg,
+		logger:  logger,
+		limits:  limits,
 	}
 	f.Service = services.NewBasicService(f.starting, f.running, f.stopping)
 	return f, nil
@@ -42,6 +51,7 @@ func (f *Frontend) stopping(_ error) error {
 	return nil
 }
 
-func (f *Frontend) ExceedsLimits(_ context.Context, _ *logproto.ExceedsLimitsRequest) (*logproto.ExceedsLimitsResponse, error) {
-	return nil, nil
+// ExceedsLimits implements logproto.IngestLimitsFrontendClient.
+func (f *Frontend) ExceedsLimits(ctx context.Context, r *logproto.ExceedsLimitsRequest) (*logproto.ExceedsLimitsResponse, error) {
+	return f.limits.ExceedsLimits(ctx, r)
 }

--- a/pkg/limits/frontend/frontend.go
+++ b/pkg/limits/frontend/frontend.go
@@ -2,7 +2,7 @@
 // It is responsible for receiving and answering gRPC requests from distributors,
 // such as exceeds limits requests, forwarding them to individual limits backends,
 // gathering and aggregating their responses (where required), and returning
-// the final result. 
+// the final result.
 package frontend
 
 import (
@@ -19,17 +19,17 @@ import (
 // all components needed to run the limits-frontend.
 type Frontend struct {
 	services.Service
-	cfg     Config
-	logger  log.Logger
-	limits  IngestLimitsService
+	cfg    Config
+	logger log.Logger
+	limits IngestLimitsService
 }
 
 // NewFrontend returns a new Frontend.
 func NewFrontend(cfg Config, logger log.Logger, _ prometheus.Registerer, limits IngestLimitsService) (*Frontend, error) {
 	f := &Frontend{
-		cfg:     cfg,
-		logger:  logger,
-		limits:  limits,
+		cfg:    cfg,
+		logger: logger,
+		limits: limits,
 	}
 	f.Service = services.NewBasicService(f.starting, f.running, f.stopping)
 	return f, nil

--- a/pkg/limits/frontend/service.go
+++ b/pkg/limits/frontend/service.go
@@ -1,0 +1,100 @@
+package frontend
+
+import (
+	"context"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/dskit/ring"
+	ring_client "github.com/grafana/dskit/ring/client"
+
+	"golang.org/x/sync/errgroup"
+
+	"github.com/grafana/loki/v3/pkg/logproto"
+)
+
+// IngestLimitsService is responsible for receiving, processing and
+// validating requests, forwarding them to individual limits backends,
+// gathering and aggregating their responses (where required), and returning
+// the final result. 
+type IngestLimitsService interface {
+	// ExceedsLimits checks if the request would exceed the current tenants
+	// limits.
+	ExceedsLimits(ctx context.Context, r *logproto.ExceedsLimitsRequest) (*logproto.ExceedsLimitsResponse, error)
+}
+
+var (
+	LimitsRead = ring.NewOp([]ring.InstanceState{ring.ACTIVE}, nil)
+)
+
+type ringFunc func(context.Context, logproto.IngestLimitsClient) (interface{}, error)
+
+// RingIngestLimitsService is an IngestLimitsService that uses the ring to read the responses
+// from all limits backends.
+type RingIngestLimitsService struct {
+	ring ring.ReadRing
+	pool *ring_client.Pool
+}
+
+// NewRingIngestLimitsService returns a new RingIngestLimitsClient.
+func NewRingIngestLimitsService(cfg Config, logger log.Logger, ring ring.ReadRing) *RingIngestLimitsService {
+	factory := ring_client.PoolAddrFunc(func(addr string) (ring_client.PoolClient, error) {
+		return NewIngestLimitsClient(cfg.ClientConfig, addr)
+	})
+	return &RingIngestLimitsService{
+		ring: ring,
+		pool: NewIngestLimitsClientPool("ingest-limits", cfg.ClientConfig.PoolConfig, ring, factory, logger),
+	}
+}
+
+func (s *RingIngestLimitsService) forAllBackends(ctx context.Context, f ringFunc) ([]Response, error) {
+	replicaSet, err := s.ring.GetReplicationSetForOperation(LimitsRead)
+	if err != nil {
+		return nil, err
+	}
+	return s.forGivenReplicaSet(ctx, replicaSet, f)
+}
+
+func (s *RingIngestLimitsService) forGivenReplicaSet(ctx context.Context, replicaSet ring.ReplicationSet, f ringFunc) ([]Response, error) {
+	g, ctx := errgroup.WithContext(ctx)
+	responses := make([]Response, len(replicaSet.Instances))
+	for i, instance := range replicaSet.Instances {
+		g.Go(func() error {
+			client, err := s.pool.GetClientFor(instance.Addr)
+			if err != nil {
+				return err
+			}
+			resp, err := f(ctx, client.(logproto.IngestLimitsClient))
+			if err != nil {
+				return err
+			}
+			responses[i] = Response{Addr: instance.Addr, Response: resp}
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+	return responses, nil
+}
+
+func (s *RingIngestLimitsService) ExceedsLimits(ctx context.Context, r *logproto.ExceedsLimitsRequest) (*logproto.ExceedsLimitsResponse, error) {
+	req := &logproto.GetStreamUsageRequest{
+		Tenant: r.Tenant,
+	}
+	resps, err := s.forAllBackends(ctx, func(_ context.Context, client logproto.IngestLimitsClient) (interface{}, error) {
+		return client.GetStreamUsage(ctx, req)
+	})
+	if err != nil {
+		return nil, err
+	}
+	var sum uint64
+	for _, resp := range resps {
+		sum += resp.Response.(*logproto.GetStreamUsageResponse).ActiveStreams
+	}
+	return &logproto.ExceedsLimitsResponse{}, nil
+}
+
+type Response struct {
+	Addr     string
+	Response interface{}
+}

--- a/pkg/limits/frontend/service.go
+++ b/pkg/limits/frontend/service.go
@@ -15,7 +15,7 @@ import (
 // IngestLimitsService is responsible for receiving, processing and
 // validating requests, forwarding them to individual limits backends,
 // gathering and aggregating their responses (where required), and returning
-// the final result. 
+// the final result.
 type IngestLimitsService interface {
 	// ExceedsLimits checks if the request would exceed the current tenants
 	// limits.

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -447,6 +447,8 @@ func (t *Loki) initIngestLimitsFrontend() (services.Service, error) {
 	ingestLimitsFrontend, err := limits_frontend.NewFrontend(
 		t.Cfg.LimitsFrontendConfig,
 		util_log.Logger,
+		prometheus.DefaultRegisterer,
+		nil,
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request creates the gRPC clients for the limits frontend, including client pools, and attempts to read all replicas from the ring.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
