### PR TITLE
feat: dedupe duplicate delete requests while loading them for processing in compactor

### DIFF
--- a/pkg/compactor/deletion/delete_request.go
+++ b/pkg/compactor/deletion/delete_request.go
@@ -162,7 +162,11 @@ func (d *DeleteRequest) IsDeleted(entry retention.ChunkEntry) (bool, filter.Func
 }
 
 func (d *DeleteRequest) IsDuplicate(o *DeleteRequest) (bool, error) {
-	if d.RequestID == o.RequestID || d.UserID != o.UserID || d.StartTime != o.StartTime || d.EndTime != o.EndTime {
+	// we would never have duplicates from same request
+	if d.RequestID == o.RequestID {
+		return false, nil
+	}
+	if d.UserID != o.UserID || d.StartTime != o.StartTime || d.EndTime != o.EndTime {
 		return false, nil
 	}
 

--- a/pkg/compactor/deletion/delete_request.go
+++ b/pkg/compactor/deletion/delete_request.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/go-kit/log/level"
+	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 
@@ -158,6 +159,29 @@ func (d *DeleteRequest) IsDeleted(entry retention.ChunkEntry) (bool, filter.Func
 	}
 
 	return true, ff
+}
+
+func (d *DeleteRequest) IsDuplicate(o *DeleteRequest) (bool, error) {
+	if d.RequestID == o.RequestID || d.UserID != o.UserID || d.StartTime != o.StartTime || d.EndTime != o.EndTime {
+		return false, nil
+	}
+
+	if d.logSelectorExpr == nil {
+		if err := d.SetQuery(d.Query); err != nil {
+			return false, errors.Wrapf(err, "failed to init log selector expr for request_id=%s, user_id=%s", d.RequestID, d.UserID)
+		}
+	}
+	if o.logSelectorExpr == nil {
+		if err := o.SetQuery(o.Query); err != nil {
+			return false, errors.Wrapf(err, "failed to init log selector expr for request_id=%s, user_id=%s", o.RequestID, o.UserID)
+		}
+	}
+
+	if d.logSelectorExpr.String() != o.logSelectorExpr.String() {
+		return false, nil
+	}
+
+	return true, nil
 }
 
 func intervalsOverlap(interval1, interval2 model.Interval) bool {

--- a/pkg/compactor/deletion/delete_requests_manager.go
+++ b/pkg/compactor/deletion/delete_requests_manager.go
@@ -35,6 +35,7 @@ type DeleteRequestsManager struct {
 
 	deleteRequestsToProcess    map[string]*userDeleteRequests
 	deleteRequestsToProcessMtx sync.Mutex
+	duplicateRequests          []DeleteRequest
 	metrics                    *deleteRequestsManagerMetrics
 	wg                         sync.WaitGroup
 	done                       chan struct{}
@@ -141,6 +142,23 @@ func (d *DeleteRequestsManager) loadDeleteRequestsToProcess() error {
 				)
 				d.markRequestAsProcessed(deleteRequest)
 				continue
+			}
+		}
+		if ur, ok := d.deleteRequestsToProcess[deleteRequest.UserID]; ok {
+			for _, requestLoadedForProcessing := range ur.requests {
+				isDuplicate, err := requestLoadedForProcessing.IsDuplicate(&deleteRequest)
+				if err != nil {
+					return err
+				}
+				if isDuplicate {
+					level.Info(util_log.Logger).Log(
+						"msg", "found duplicate request of one of the requests loaded for processing",
+						"loaded_request_id", requestLoadedForProcessing.RequestID,
+						"duplicate_request_id", deleteRequest.RequestID,
+						"user", deleteRequest.UserID,
+					)
+					d.duplicateRequests = append(d.duplicateRequests, deleteRequest)
+				}
 			}
 		}
 		if reqCount >= d.batchSize {
@@ -355,6 +373,15 @@ func (d *DeleteRequestsManager) MarkPhaseFinished() {
 		for _, deleteRequest := range userDeleteRequests.requests {
 			d.markRequestAsProcessed(*deleteRequest)
 		}
+	}
+
+	for _, req := range d.duplicateRequests {
+		level.Info(util_log.Logger).Log("msg", "marking duplicate delete request as processed",
+			"delete_request_id", req.RequestID,
+			"sequence_num", req.SequenceNum,
+			"user", req.UserID,
+		)
+		d.markRequestAsProcessed(req)
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
While loading delete requests for processing, we will look for duplicate delete requests and mark them as processed when we are done processing the loaded requests. This should avoid wasting resources in processing the same requests sent multiple times by the users.

**Checklist**
- [x] Tests updated
