### PR TITLE
chore(ci): Build Docker images "natively"

### DIFF
--- a/.github/release-workflows.jsonnet
+++ b/.github/release-workflows.jsonnet
@@ -156,14 +156,14 @@ local weeklyImageJobs = {
           step.new('Publish multi-arch manifest')
           + step.withRun(|||
             # Unfortunately there is no better way atm than having a separate named output for each digest
-            echo '${{ needs.%(name)s.outputs.image_digest_linux_amd64 }}'
-            echo '${{ needs.%(name)s.outputs.image_digest_linux_arm64 }}'
-            echo '${{ needs.%(name)s.outputs.image_digest_linux_arm }}'
+            echo 'linux/arm64 ${{ needs.%(name)s.outputs.image_digest_linux_amd64 }}'
+            echo 'linux/amd64 ${{ needs.%(name)s.outputs.image_digest_linux_arm64 }}'
+            echo 'linux/arm   ${{ needs.%(name)s.outputs.image_digest_linux_arm }}'
             IMAGE=${{ needs.%(name)s.outputs.image_name }}:${{ needs.%(name)s.outputs.image_tag }}
-            echo "IMAGE=$IMAGE"
+            echo "Create multi-arch manifest for $IMAGE"
             docker buildx imagetools create -t $IMAGE \
               ${{ needs.%(name)s.outputs.image_name }}@${{ needs.%(name)s.outputs.image_digest_linux_amd64 }} \
-              ${{ needs.%(name)s.outputs.image_name }}@${{ needs.%(name)s.outputs.image_digest_linux_arm64 }}
+              ${{ needs.%(name)s.outputs.image_name }}@${{ needs.%(name)s.outputs.image_digest_linux_arm64 }} \
               ${{ needs.%(name)s.outputs.image_name }}@${{ needs.%(name)s.outputs.image_digest_linux_arm }}
             docker buildx imagetools inspect $IMAGE
           ||| % { name: '%s-image' % name }),

--- a/.github/release-workflows.jsonnet
+++ b/.github/release-workflows.jsonnet
@@ -146,7 +146,7 @@ local weeklyImageJobs = {
     } + {
       ['%s-manifest' % name]:
         job.new()
-        + job.withNeeds(['check', '%s-image' % name])
+        + job.withNeeds(['%s-image' % name])
         + job.withSteps([
           step.new('Set up Docker buildx', 'docker/setup-buildx-action@v3'),
           step.new('Login to DockerHub (from Vault)', 'grafana/shared-workflows/actions/dockerhub-login@main'),

--- a/.github/release-workflows.jsonnet
+++ b/.github/release-workflows.jsonnet
@@ -140,6 +140,7 @@ local weeklyImageJobs = {
             RELEASE_REPO: 'grafana/loki',
             RELEASE_LIB_REF: releaseLibRef,
             IMAGE_PREFIX: imagePrefix,
+            GO_VERSION: goVersion,
           },
         }
       for name in std.objectFields(weeklyImageJobs)

--- a/.github/release-workflows.jsonnet
+++ b/.github/release-workflows.jsonnet
@@ -112,6 +112,7 @@ local weeklyImageJobs = {
           'main',
         ],
       },
+      workflow_dispatch: {},
     },
     permissions: {
       'id-token': 'write',

--- a/.github/vendor/github.com/grafana/loki-release/workflows/build.libsonnet
+++ b/.github/vendor/github.com/grafana/loki-release/workflows/build.libsonnet
@@ -129,7 +129,8 @@ local releaseLibStep = common.releaseLibStep;
         platforms: '${{ matrix.arch }}',
         provenance: true,
         outputs: 'push-by-digest=true,type=image,name=${{ steps.weekly-version.outputs.image_name }},push=true',
-        tags: '${{ steps.weekly-version.outputs.image_name }},${{ steps.weekly-version.outputs.image_name }}-${{ steps.platform.outputs.platform_short }}',
+        tags: '${{ steps.weekly-version.outputs.image_name }}',
+        // tags: '${{ steps.weekly-version.outputs.image_name }},${{ steps.weekly-version.outputs.image_name }}-${{ steps.platform.outputs.platform_short }}',
         'build-args': |||
           IMAGE_TAG=${{ steps.weekly-version.outputs.image_version }}
           GO_VERSION=${{ env.GO_VERSION }}

--- a/.github/vendor/github.com/grafana/loki-release/workflows/runner.libsonnet
+++ b/.github/vendor/github.com/grafana/loki-release/workflows/runner.libsonnet
@@ -1,20 +1,32 @@
-local mapping = {
+local defaultMapping = {
   'linux/amd64': ['github-hosted-ubuntu-x64-small'],
   'linux/arm64': ['github-hosted-ubuntu-arm64-small'],
-  'linux/arm': ['github-hosted-ubuntu-arm64-small'],
-  'linux/arm/v6': ['github-hosted-ubuntu-arm64-small'],
-  'linux/arm/v7': ['github-hosted-ubuntu-arm64-small'],
+  'linux/arm': ['github-hosted-ubuntu-arm64-small'],  // equal to linux/arm/v7
 };
 
 {
+  mapping:: {},
+
+  withDefaultMapping: function()
+    self + {
+      mapping:: defaultMapping,
+    },
+
+  withMapping: function(m)
+    self + {
+      mapping:: m,
+    },
+
   forPlatform: function(arch)
-    if std.objectHas(mapping, arch)
+    local m = self.mapping;
+
+    if std.objectHasEx(m, arch, true)
     then {
       arch: arch,
-      runs_on: mapping[arch],
+      runs_on: m[arch],
     }
     else {
       arch: arch,
-      runs_on: 'ubuntu-latest',
+      runs_on: ['ubuntu-latest'],
     },
 }

--- a/.github/vendor/github.com/grafana/loki-release/workflows/runner.libsonnet
+++ b/.github/vendor/github.com/grafana/loki-release/workflows/runner.libsonnet
@@ -1,0 +1,20 @@
+local mapping = {
+  'linux/amd64': 'ubuntu-amd64',
+  'linux/arm64': 'ubuntu-arm64',
+  'linux/arm': 'ubuntu-arm',
+  'linux/arm/v6': 'ubuntu-arm',
+  'linux/arm/v7': 'ubuntu-arm',
+};
+
+{
+  forPlatform: function(arch)
+    if std.objectHas(mapping, arch)
+    then {
+      arch: arch,
+      runs_on: mapping[arch],
+    }
+    else {
+      arch: arch,
+      runs_on: 'ubuntu-latest',
+    },
+}

--- a/.github/vendor/github.com/grafana/loki-release/workflows/runner.libsonnet
+++ b/.github/vendor/github.com/grafana/loki-release/workflows/runner.libsonnet
@@ -1,9 +1,9 @@
 local mapping = {
-  'linux/amd64': 'ubuntu-amd64',
-  'linux/arm64': 'ubuntu-arm64',
-  'linux/arm': 'ubuntu-arm',
-  'linux/arm/v6': 'ubuntu-arm',
-  'linux/arm/v7': 'ubuntu-arm',
+  'linux/amd64': ['github-hosted-ubuntu-x64-small'],
+  'linux/arm64': ['github-hosted-ubuntu-arm64-small'],
+  'linux/arm': ['github-hosted-ubuntu-arm64-small'],
+  'linux/arm/v6': ['github-hosted-ubuntu-arm64-small'],
+  'linux/arm/v7': ['github-hosted-ubuntu-arm64-small'],
 };
 
 {

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -82,11 +82,14 @@
       "matrix":
         "include":
         - "arch": "linux/amd64"
-          "runs_on": "ubuntu-amd64"
+          "runs_on":
+          - "github-hosted-ubuntu-x64-small"
         - "arch": "linux/arm64"
-          "runs_on": "ubuntu-arm64"
+          "runs_on":
+          - "github-hosted-ubuntu-arm64-small"
         - "arch": "linux/arm"
-          "runs_on": "ubuntu-arm"
+          "runs_on":
+          - "github-hosted-ubuntu-arm64-small"
   "loki-canary-boringcrypto-manifest":
     "env":
       "BUILD_TIMEOUT": 60
@@ -186,11 +189,14 @@
       "matrix":
         "include":
         - "arch": "linux/amd64"
-          "runs_on": "ubuntu-amd64"
+          "runs_on":
+          - "github-hosted-ubuntu-x64-small"
         - "arch": "linux/arm64"
-          "runs_on": "ubuntu-arm64"
+          "runs_on":
+          - "github-hosted-ubuntu-arm64-small"
         - "arch": "linux/arm"
-          "runs_on": "ubuntu-arm"
+          "runs_on":
+          - "github-hosted-ubuntu-arm64-small"
   "loki-canary-manifest":
     "env":
       "BUILD_TIMEOUT": 60
@@ -290,11 +296,14 @@
       "matrix":
         "include":
         - "arch": "linux/amd64"
-          "runs_on": "ubuntu-amd64"
+          "runs_on":
+          - "github-hosted-ubuntu-x64-small"
         - "arch": "linux/arm64"
-          "runs_on": "ubuntu-arm64"
+          "runs_on":
+          - "github-hosted-ubuntu-arm64-small"
         - "arch": "linux/arm"
-          "runs_on": "ubuntu-arm"
+          "runs_on":
+          - "github-hosted-ubuntu-arm64-small"
   "loki-manifest":
     "env":
       "BUILD_TIMEOUT": 60
@@ -394,11 +403,14 @@
       "matrix":
         "include":
         - "arch": "linux/amd64"
-          "runs_on": "ubuntu-amd64"
+          "runs_on":
+          - "github-hosted-ubuntu-x64-small"
         - "arch": "linux/arm64"
-          "runs_on": "ubuntu-arm64"
+          "runs_on":
+          - "github-hosted-ubuntu-arm64-small"
         - "arch": "linux/arm"
-          "runs_on": "ubuntu-arm"
+          "runs_on":
+          - "github-hosted-ubuntu-arm64-small"
   "promtail-manifest":
     "env":
       "BUILD_TIMEOUT": 60

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -71,7 +71,7 @@
         "outputs": "push-by-digest=true,type=image,name=${{ steps.weekly-version.outputs.image_name }},push=true"
         "platforms": "${{ matrix.arch }}"
         "provenance": true
-        "tags": "${{ steps.weekly-version.outputs.image_name }},${{ steps.weekly-version.outputs.image_name }}-${{ steps.platform.outputs.platform_short }}"
+        "tags": "${{ steps.weekly-version.outputs.image_name }}"
     - "id": "digest"
       "name": "Process image digest"
       "run": |
@@ -178,7 +178,7 @@
         "outputs": "push-by-digest=true,type=image,name=${{ steps.weekly-version.outputs.image_name }},push=true"
         "platforms": "${{ matrix.arch }}"
         "provenance": true
-        "tags": "${{ steps.weekly-version.outputs.image_name }},${{ steps.weekly-version.outputs.image_name }}-${{ steps.platform.outputs.platform_short }}"
+        "tags": "${{ steps.weekly-version.outputs.image_name }}"
     - "id": "digest"
       "name": "Process image digest"
       "run": |
@@ -285,7 +285,7 @@
         "outputs": "push-by-digest=true,type=image,name=${{ steps.weekly-version.outputs.image_name }},push=true"
         "platforms": "${{ matrix.arch }}"
         "provenance": true
-        "tags": "${{ steps.weekly-version.outputs.image_name }},${{ steps.weekly-version.outputs.image_name }}-${{ steps.platform.outputs.platform_short }}"
+        "tags": "${{ steps.weekly-version.outputs.image_name }}"
     - "id": "digest"
       "name": "Process image digest"
       "run": |
@@ -392,7 +392,7 @@
         "outputs": "push-by-digest=true,type=image,name=${{ steps.weekly-version.outputs.image_name }},push=true"
         "platforms": "${{ matrix.arch }}"
         "provenance": true
-        "tags": "${{ steps.weekly-version.outputs.image_name }},${{ steps.weekly-version.outputs.image_name }}-${{ steps.platform.outputs.platform_short }}"
+        "tags": "${{ steps.weekly-version.outputs.image_name }}"
     - "id": "digest"
       "name": "Process image digest"
       "run": |

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -1,4 +1,12 @@
 "jobs":
+  "check":
+    "uses": "grafana/loki-release/.github/workflows/check.yml@main"
+    "with":
+      "build_image": "grafana/loki-build-image:0.34.4"
+      "golang_ci_lint_version": "v1.60.3"
+      "release_lib_ref": "main"
+      "skip_validation": false
+      "use_github_app_token": true
   "loki-canary-boringcrypto-image":
     "env":
       "BUILD_TIMEOUT": 60
@@ -6,6 +14,8 @@
       "IMAGE_PREFIX": "grafana"
       "RELEASE_LIB_REF": "main"
       "RELEASE_REPO": "grafana/loki"
+    "needs":
+    - "check"
     "outputs":
       "image_digest_linux_amd64": "${{ steps.digest.outputs.digest_linux_amd64 }}"
       "image_digest_linux_arm": "${{ steps.digest.outputs.digest_linux_arm }}"
@@ -112,6 +122,8 @@
       "IMAGE_PREFIX": "grafana"
       "RELEASE_LIB_REF": "main"
       "RELEASE_REPO": "grafana/loki"
+    "needs":
+    - "check"
     "outputs":
       "image_digest_linux_amd64": "${{ steps.digest.outputs.digest_linux_amd64 }}"
       "image_digest_linux_arm": "${{ steps.digest.outputs.digest_linux_arm }}"
@@ -218,6 +230,8 @@
       "IMAGE_PREFIX": "grafana"
       "RELEASE_LIB_REF": "main"
       "RELEASE_REPO": "grafana/loki"
+    "needs":
+    - "check"
     "outputs":
       "image_digest_linux_amd64": "${{ steps.digest.outputs.digest_linux_amd64 }}"
       "image_digest_linux_arm": "${{ steps.digest.outputs.digest_linux_arm }}"
@@ -324,6 +338,8 @@
       "IMAGE_PREFIX": "grafana"
       "RELEASE_LIB_REF": "main"
       "RELEASE_REPO": "grafana/loki"
+    "needs":
+    - "check"
     "outputs":
       "image_digest_linux_amd64": "${{ steps.digest.outputs.digest_linux_amd64 }}"
       "image_digest_linux_arm": "${{ steps.digest.outputs.digest_linux_arm }}"

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -429,6 +429,7 @@
     "branches":
     - "k[0-9]+*"
     - "main"
+  "workflow_dispatch": {}
 "permissions":
   "contents": "write"
   "id-token": "write"

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -10,6 +10,7 @@
   "loki-canary-boringcrypto-image":
     "env":
       "BUILD_TIMEOUT": 60
+      "GO_VERSION": "1.23.5"
       "IMAGE_PREFIX": "grafana"
       "RELEASE_LIB_REF": "main"
       "RELEASE_REPO": "grafana/loki"
@@ -116,6 +117,7 @@
   "loki-canary-image":
     "env":
       "BUILD_TIMEOUT": 60
+      "GO_VERSION": "1.23.5"
       "IMAGE_PREFIX": "grafana"
       "RELEASE_LIB_REF": "main"
       "RELEASE_REPO": "grafana/loki"
@@ -222,6 +224,7 @@
   "loki-image":
     "env":
       "BUILD_TIMEOUT": 60
+      "GO_VERSION": "1.23.5"
       "IMAGE_PREFIX": "grafana"
       "RELEASE_LIB_REF": "main"
       "RELEASE_REPO": "grafana/loki"
@@ -328,6 +331,7 @@
   "promtail-image":
     "env":
       "BUILD_TIMEOUT": 60
+      "GO_VERSION": "1.23.5"
       "IMAGE_PREFIX": "grafana"
       "RELEASE_LIB_REF": "main"
       "RELEASE_REPO": "grafana/loki"

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -95,14 +95,14 @@
     - "name": "Publish multi-arch manifest"
       "run": |
         # Unfortunately there is no better way atm than having a separate named output for each digest
-        echo '${{ needs.loki-canary-boringcrypto-image.outputs.image_digest_linux_amd64 }}'
-        echo '${{ needs.loki-canary-boringcrypto-image.outputs.image_digest_linux_arm64 }}'
-        echo '${{ needs.loki-canary-boringcrypto-image.outputs.image_digest_linux_arm }}'
+        echo 'linux/arm64 ${{ needs.loki-canary-boringcrypto-image.outputs.image_digest_linux_amd64 }}'
+        echo 'linux/amd64 ${{ needs.loki-canary-boringcrypto-image.outputs.image_digest_linux_arm64 }}'
+        echo 'linux/arm   ${{ needs.loki-canary-boringcrypto-image.outputs.image_digest_linux_arm }}'
         IMAGE=${{ needs.loki-canary-boringcrypto-image.outputs.image_name }}:${{ needs.loki-canary-boringcrypto-image.outputs.image_tag }}
-        echo "IMAGE=$IMAGE"
+        echo "Create multi-arch manifest for $IMAGE"
         docker buildx imagetools create -t $IMAGE \
           ${{ needs.loki-canary-boringcrypto-image.outputs.image_name }}@${{ needs.loki-canary-boringcrypto-image.outputs.image_digest_linux_amd64 }} \
-          ${{ needs.loki-canary-boringcrypto-image.outputs.image_name }}@${{ needs.loki-canary-boringcrypto-image.outputs.image_digest_linux_arm64 }}
+          ${{ needs.loki-canary-boringcrypto-image.outputs.image_name }}@${{ needs.loki-canary-boringcrypto-image.outputs.image_digest_linux_arm64 }} \
           ${{ needs.loki-canary-boringcrypto-image.outputs.image_name }}@${{ needs.loki-canary-boringcrypto-image.outputs.image_digest_linux_arm }}
         docker buildx imagetools inspect $IMAGE
   "loki-canary-image":
@@ -201,14 +201,14 @@
     - "name": "Publish multi-arch manifest"
       "run": |
         # Unfortunately there is no better way atm than having a separate named output for each digest
-        echo '${{ needs.loki-canary-image.outputs.image_digest_linux_amd64 }}'
-        echo '${{ needs.loki-canary-image.outputs.image_digest_linux_arm64 }}'
-        echo '${{ needs.loki-canary-image.outputs.image_digest_linux_arm }}'
+        echo 'linux/arm64 ${{ needs.loki-canary-image.outputs.image_digest_linux_amd64 }}'
+        echo 'linux/amd64 ${{ needs.loki-canary-image.outputs.image_digest_linux_arm64 }}'
+        echo 'linux/arm   ${{ needs.loki-canary-image.outputs.image_digest_linux_arm }}'
         IMAGE=${{ needs.loki-canary-image.outputs.image_name }}:${{ needs.loki-canary-image.outputs.image_tag }}
-        echo "IMAGE=$IMAGE"
+        echo "Create multi-arch manifest for $IMAGE"
         docker buildx imagetools create -t $IMAGE \
           ${{ needs.loki-canary-image.outputs.image_name }}@${{ needs.loki-canary-image.outputs.image_digest_linux_amd64 }} \
-          ${{ needs.loki-canary-image.outputs.image_name }}@${{ needs.loki-canary-image.outputs.image_digest_linux_arm64 }}
+          ${{ needs.loki-canary-image.outputs.image_name }}@${{ needs.loki-canary-image.outputs.image_digest_linux_arm64 }} \
           ${{ needs.loki-canary-image.outputs.image_name }}@${{ needs.loki-canary-image.outputs.image_digest_linux_arm }}
         docker buildx imagetools inspect $IMAGE
   "loki-image":
@@ -307,14 +307,14 @@
     - "name": "Publish multi-arch manifest"
       "run": |
         # Unfortunately there is no better way atm than having a separate named output for each digest
-        echo '${{ needs.loki-image.outputs.image_digest_linux_amd64 }}'
-        echo '${{ needs.loki-image.outputs.image_digest_linux_arm64 }}'
-        echo '${{ needs.loki-image.outputs.image_digest_linux_arm }}'
+        echo 'linux/arm64 ${{ needs.loki-image.outputs.image_digest_linux_amd64 }}'
+        echo 'linux/amd64 ${{ needs.loki-image.outputs.image_digest_linux_arm64 }}'
+        echo 'linux/arm   ${{ needs.loki-image.outputs.image_digest_linux_arm }}'
         IMAGE=${{ needs.loki-image.outputs.image_name }}:${{ needs.loki-image.outputs.image_tag }}
-        echo "IMAGE=$IMAGE"
+        echo "Create multi-arch manifest for $IMAGE"
         docker buildx imagetools create -t $IMAGE \
           ${{ needs.loki-image.outputs.image_name }}@${{ needs.loki-image.outputs.image_digest_linux_amd64 }} \
-          ${{ needs.loki-image.outputs.image_name }}@${{ needs.loki-image.outputs.image_digest_linux_arm64 }}
+          ${{ needs.loki-image.outputs.image_name }}@${{ needs.loki-image.outputs.image_digest_linux_arm64 }} \
           ${{ needs.loki-image.outputs.image_name }}@${{ needs.loki-image.outputs.image_digest_linux_arm }}
         docker buildx imagetools inspect $IMAGE
   "promtail-image":
@@ -413,14 +413,14 @@
     - "name": "Publish multi-arch manifest"
       "run": |
         # Unfortunately there is no better way atm than having a separate named output for each digest
-        echo '${{ needs.promtail-image.outputs.image_digest_linux_amd64 }}'
-        echo '${{ needs.promtail-image.outputs.image_digest_linux_arm64 }}'
-        echo '${{ needs.promtail-image.outputs.image_digest_linux_arm }}'
+        echo 'linux/arm64 ${{ needs.promtail-image.outputs.image_digest_linux_amd64 }}'
+        echo 'linux/amd64 ${{ needs.promtail-image.outputs.image_digest_linux_arm64 }}'
+        echo 'linux/arm   ${{ needs.promtail-image.outputs.image_digest_linux_arm }}'
         IMAGE=${{ needs.promtail-image.outputs.image_name }}:${{ needs.promtail-image.outputs.image_tag }}
-        echo "IMAGE=$IMAGE"
+        echo "Create multi-arch manifest for $IMAGE"
         docker buildx imagetools create -t $IMAGE \
           ${{ needs.promtail-image.outputs.image_name }}@${{ needs.promtail-image.outputs.image_digest_linux_amd64 }} \
-          ${{ needs.promtail-image.outputs.image_name }}@${{ needs.promtail-image.outputs.image_digest_linux_arm64 }}
+          ${{ needs.promtail-image.outputs.image_name }}@${{ needs.promtail-image.outputs.image_digest_linux_arm64 }} \
           ${{ needs.promtail-image.outputs.image_name }}@${{ needs.promtail-image.outputs.image_digest_linux_arm }}
         docker buildx imagetools inspect $IMAGE
 "name": "Publish images"

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -1,12 +1,4 @@
 "jobs":
-  "check":
-    "uses": "grafana/loki-release/.github/workflows/check.yml@main"
-    "with":
-      "build_image": "grafana/loki-build-image:0.34.4"
-      "golang_ci_lint_version": "v1.60.3"
-      "release_lib_ref": "main"
-      "skip_validation": false
-      "use_github_app_token": true
   "loki-canary-boringcrypto-image":
     "env":
       "BUILD_TIMEOUT": 60
@@ -14,8 +6,6 @@
       "IMAGE_PREFIX": "grafana"
       "RELEASE_LIB_REF": "main"
       "RELEASE_REPO": "grafana/loki"
-    "needs":
-    - "check"
     "outputs":
       "image_digest_linux_amd64": "${{ steps.digest.outputs.digest_linux_amd64 }}"
       "image_digest_linux_arm": "${{ steps.digest.outputs.digest_linux_arm }}"
@@ -102,17 +92,18 @@
       "uses": "docker/setup-buildx-action@v3"
     - "name": "Login to DockerHub (from Vault)"
       "uses": "grafana/shared-workflows/actions/dockerhub-login@main"
-    - "name": "Create and publish manifest"
+    - "name": "Publish multi-arch manifest"
       "run": |
         # Unfortunately there is no better way atm than having a separate named output for each digest
-        echo '${{ needs.loki-canary-boringcrypto.outputs.image_digest_linux_amd64 }}'
-        echo '${{ needs.loki-canary-boringcrypto.outputs.image_digest_linux_arm64 }}'
-        echo '${{ needs.loki-canary-boringcrypto.outputs.image_digest_linux_arm }}'
-        IMAGE=${{ needs.loki-canary-boringcrypto.outputs.image_name }}:${{ needs.loki-canary-boringcrypto.outputs.image_tag }}
+        echo '${{ needs.loki-canary-boringcrypto-image.outputs.image_digest_linux_amd64 }}'
+        echo '${{ needs.loki-canary-boringcrypto-image.outputs.image_digest_linux_arm64 }}'
+        echo '${{ needs.loki-canary-boringcrypto-image.outputs.image_digest_linux_arm }}'
+        IMAGE=${{ needs.loki-canary-boringcrypto-image.outputs.image_name }}:${{ needs.loki-canary-boringcrypto-image.outputs.image_tag }}
+        echo "IMAGE=$IMAGE"
         docker buildx imagetools create -t $IMAGE \
-          ${{ needs.loki-canary-boringcrypto.outputs.image_name }}@${{ needs.loki-canary-boringcrypto.outputs.image_digest_linux_amd64 }} \
-          ${{ needs.loki-canary-boringcrypto.outputs.image_name }}@${{ needs.loki-canary-boringcrypto.outputs.image_digest_linux_arm64 }}
-          ${{ needs.loki-canary-boringcrypto.outputs.image_name }}@${{ needs.loki-canary-boringcrypto.outputs.image_digest_linux_arm }}
+          ${{ needs.loki-canary-boringcrypto-image.outputs.image_name }}@${{ needs.loki-canary-boringcrypto-image.outputs.image_digest_linux_amd64 }} \
+          ${{ needs.loki-canary-boringcrypto-image.outputs.image_name }}@${{ needs.loki-canary-boringcrypto-image.outputs.image_digest_linux_arm64 }}
+          ${{ needs.loki-canary-boringcrypto-image.outputs.image_name }}@${{ needs.loki-canary-boringcrypto-image.outputs.image_digest_linux_arm }}
         docker buildx imagetools inspect $IMAGE
   "loki-canary-image":
     "env":
@@ -121,8 +112,6 @@
       "IMAGE_PREFIX": "grafana"
       "RELEASE_LIB_REF": "main"
       "RELEASE_REPO": "grafana/loki"
-    "needs":
-    - "check"
     "outputs":
       "image_digest_linux_amd64": "${{ steps.digest.outputs.digest_linux_amd64 }}"
       "image_digest_linux_arm": "${{ steps.digest.outputs.digest_linux_arm }}"
@@ -209,17 +198,18 @@
       "uses": "docker/setup-buildx-action@v3"
     - "name": "Login to DockerHub (from Vault)"
       "uses": "grafana/shared-workflows/actions/dockerhub-login@main"
-    - "name": "Create and publish manifest"
+    - "name": "Publish multi-arch manifest"
       "run": |
         # Unfortunately there is no better way atm than having a separate named output for each digest
-        echo '${{ needs.loki-canary.outputs.image_digest_linux_amd64 }}'
-        echo '${{ needs.loki-canary.outputs.image_digest_linux_arm64 }}'
-        echo '${{ needs.loki-canary.outputs.image_digest_linux_arm }}'
-        IMAGE=${{ needs.loki-canary.outputs.image_name }}:${{ needs.loki-canary.outputs.image_tag }}
+        echo '${{ needs.loki-canary-image.outputs.image_digest_linux_amd64 }}'
+        echo '${{ needs.loki-canary-image.outputs.image_digest_linux_arm64 }}'
+        echo '${{ needs.loki-canary-image.outputs.image_digest_linux_arm }}'
+        IMAGE=${{ needs.loki-canary-image.outputs.image_name }}:${{ needs.loki-canary-image.outputs.image_tag }}
+        echo "IMAGE=$IMAGE"
         docker buildx imagetools create -t $IMAGE \
-          ${{ needs.loki-canary.outputs.image_name }}@${{ needs.loki-canary.outputs.image_digest_linux_amd64 }} \
-          ${{ needs.loki-canary.outputs.image_name }}@${{ needs.loki-canary.outputs.image_digest_linux_arm64 }}
-          ${{ needs.loki-canary.outputs.image_name }}@${{ needs.loki-canary.outputs.image_digest_linux_arm }}
+          ${{ needs.loki-canary-image.outputs.image_name }}@${{ needs.loki-canary-image.outputs.image_digest_linux_amd64 }} \
+          ${{ needs.loki-canary-image.outputs.image_name }}@${{ needs.loki-canary-image.outputs.image_digest_linux_arm64 }}
+          ${{ needs.loki-canary-image.outputs.image_name }}@${{ needs.loki-canary-image.outputs.image_digest_linux_arm }}
         docker buildx imagetools inspect $IMAGE
   "loki-image":
     "env":
@@ -228,8 +218,6 @@
       "IMAGE_PREFIX": "grafana"
       "RELEASE_LIB_REF": "main"
       "RELEASE_REPO": "grafana/loki"
-    "needs":
-    - "check"
     "outputs":
       "image_digest_linux_amd64": "${{ steps.digest.outputs.digest_linux_amd64 }}"
       "image_digest_linux_arm": "${{ steps.digest.outputs.digest_linux_arm }}"
@@ -316,17 +304,18 @@
       "uses": "docker/setup-buildx-action@v3"
     - "name": "Login to DockerHub (from Vault)"
       "uses": "grafana/shared-workflows/actions/dockerhub-login@main"
-    - "name": "Create and publish manifest"
+    - "name": "Publish multi-arch manifest"
       "run": |
         # Unfortunately there is no better way atm than having a separate named output for each digest
-        echo '${{ needs.loki.outputs.image_digest_linux_amd64 }}'
-        echo '${{ needs.loki.outputs.image_digest_linux_arm64 }}'
-        echo '${{ needs.loki.outputs.image_digest_linux_arm }}'
-        IMAGE=${{ needs.loki.outputs.image_name }}:${{ needs.loki.outputs.image_tag }}
+        echo '${{ needs.loki-image.outputs.image_digest_linux_amd64 }}'
+        echo '${{ needs.loki-image.outputs.image_digest_linux_arm64 }}'
+        echo '${{ needs.loki-image.outputs.image_digest_linux_arm }}'
+        IMAGE=${{ needs.loki-image.outputs.image_name }}:${{ needs.loki-image.outputs.image_tag }}
+        echo "IMAGE=$IMAGE"
         docker buildx imagetools create -t $IMAGE \
-          ${{ needs.loki.outputs.image_name }}@${{ needs.loki.outputs.image_digest_linux_amd64 }} \
-          ${{ needs.loki.outputs.image_name }}@${{ needs.loki.outputs.image_digest_linux_arm64 }}
-          ${{ needs.loki.outputs.image_name }}@${{ needs.loki.outputs.image_digest_linux_arm }}
+          ${{ needs.loki-image.outputs.image_name }}@${{ needs.loki-image.outputs.image_digest_linux_amd64 }} \
+          ${{ needs.loki-image.outputs.image_name }}@${{ needs.loki-image.outputs.image_digest_linux_arm64 }}
+          ${{ needs.loki-image.outputs.image_name }}@${{ needs.loki-image.outputs.image_digest_linux_arm }}
         docker buildx imagetools inspect $IMAGE
   "promtail-image":
     "env":
@@ -335,8 +324,6 @@
       "IMAGE_PREFIX": "grafana"
       "RELEASE_LIB_REF": "main"
       "RELEASE_REPO": "grafana/loki"
-    "needs":
-    - "check"
     "outputs":
       "image_digest_linux_amd64": "${{ steps.digest.outputs.digest_linux_amd64 }}"
       "image_digest_linux_arm": "${{ steps.digest.outputs.digest_linux_arm }}"
@@ -423,19 +410,20 @@
       "uses": "docker/setup-buildx-action@v3"
     - "name": "Login to DockerHub (from Vault)"
       "uses": "grafana/shared-workflows/actions/dockerhub-login@main"
-    - "name": "Create and publish manifest"
+    - "name": "Publish multi-arch manifest"
       "run": |
         # Unfortunately there is no better way atm than having a separate named output for each digest
-        echo '${{ needs.promtail.outputs.image_digest_linux_amd64 }}'
-        echo '${{ needs.promtail.outputs.image_digest_linux_arm64 }}'
-        echo '${{ needs.promtail.outputs.image_digest_linux_arm }}'
-        IMAGE=${{ needs.promtail.outputs.image_name }}:${{ needs.promtail.outputs.image_tag }}
+        echo '${{ needs.promtail-image.outputs.image_digest_linux_amd64 }}'
+        echo '${{ needs.promtail-image.outputs.image_digest_linux_arm64 }}'
+        echo '${{ needs.promtail-image.outputs.image_digest_linux_arm }}'
+        IMAGE=${{ needs.promtail-image.outputs.image_name }}:${{ needs.promtail-image.outputs.image_tag }}
+        echo "IMAGE=$IMAGE"
         docker buildx imagetools create -t $IMAGE \
-          ${{ needs.promtail.outputs.image_name }}@${{ needs.promtail.outputs.image_digest_linux_amd64 }} \
-          ${{ needs.promtail.outputs.image_name }}@${{ needs.promtail.outputs.image_digest_linux_arm64 }}
-          ${{ needs.promtail.outputs.image_name }}@${{ needs.promtail.outputs.image_digest_linux_arm }}
+          ${{ needs.promtail-image.outputs.image_name }}@${{ needs.promtail-image.outputs.image_digest_linux_amd64 }} \
+          ${{ needs.promtail-image.outputs.image_name }}@${{ needs.promtail-image.outputs.image_digest_linux_arm64 }}
+          ${{ needs.promtail-image.outputs.image_name }}@${{ needs.promtail-image.outputs.image_digest_linux_arm }}
         docker buildx imagetools inspect $IMAGE
-"name": "publish images"
+"name": "Publish images"
 "on":
   "push":
     "branches":

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -7,7 +7,7 @@
       "release_lib_ref": "main"
       "skip_validation": false
       "use_github_app_token": true
-  "loki":
+  "loki-canary-boringcrypto-image":
     "env":
       "BUILD_TIMEOUT": 60
       "IMAGE_PREFIX": "grafana"
@@ -15,7 +15,13 @@
       "RELEASE_REPO": "grafana/loki"
     "needs":
     - "check"
-    "runs-on": "ubuntu-latest"
+    "outputs":
+      "image_digest_linux_amd64": "${{ steps.digest.outputs.digest_linux_amd64 }}"
+      "image_digest_linux_arm": "${{ steps.digest.outputs.digest_linux_arm }}"
+      "image_digest_linux_arm64": "${{ steps.digest.outputs.digest_linux_arm64 }}"
+      "image_name": "${{ steps.weekly-version.outputs.image_name }}"
+      "image_tag": "${{ steps.weekly-version.outputs.image_version }}"
+    "runs-on": "${{ matrix.runs_on }}"
     "steps":
     - "name": "pull release library code"
       "uses": "actions/checkout@v4"
@@ -32,120 +38,80 @@
       "uses": "actions/setup-node@v4"
       "with":
         "node-version": 20
-    - "name": "Set up QEMU"
-      "uses": "docker/setup-qemu-action@v3"
-    - "name": "set up docker buildx"
+    - "name": "Set up Docker buildx"
       "uses": "docker/setup-buildx-action@v3"
-    - "name": "Login to DockerHub (from vault)"
+    - "name": "Login to DockerHub (from Vault)"
       "uses": "grafana/shared-workflows/actions/dockerhub-login@main"
     - "id": "weekly-version"
       "name": "Get weekly version"
       "run": |
-        echo "version=$(./tools/image-tag)" >> $GITHUB_OUTPUT
+        version=$(./tools/image-tag)
+        echo "image_version=$version" >> $GITHUB_OUTPUT
+        echo "image_name=${{ env.IMAGE_PREFIX }}/loki-canary-boringcrypto" >> $GITHUB_OUTPUT
+        echo "image_full_name=${{ env.IMAGE_PREFIX }}/loki-canary-boringcrypto:$version" >> $GITHUB_OUTPUT
       "working-directory": "release"
-    - "name": "Build and push"
-      "timeout-minutes": "${{ fromJSON(env.BUILD_TIMEOUT) }}"
-      "uses": "docker/build-push-action@v6"
-      "with":
-        "build-args": "IMAGE_TAG=${{ steps.weekly-version.outputs.version }}"
-        "context": "release"
-        "file": "release/cmd/loki/Dockerfile"
-        "platforms": "linux/amd64,linux/arm64,linux/arm"
-        "push": true
-        "tags": "${{ env.IMAGE_PREFIX }}/loki:${{ steps.weekly-version.outputs.version }}"
-  "loki-canary":
-    "env":
-      "BUILD_TIMEOUT": 60
-      "IMAGE_PREFIX": "grafana"
-      "RELEASE_LIB_REF": "main"
-      "RELEASE_REPO": "grafana/loki"
-    "needs":
-    - "check"
-    "runs-on": "ubuntu-latest"
-    "steps":
-    - "name": "pull release library code"
-      "uses": "actions/checkout@v4"
-      "with":
-        "path": "lib"
-        "ref": "${{ env.RELEASE_LIB_REF }}"
-        "repository": "grafana/loki-release"
-    - "name": "pull code to release"
-      "uses": "actions/checkout@v4"
-      "with":
-        "path": "release"
-        "repository": "${{ env.RELEASE_REPO }}"
-    - "name": "setup node"
-      "uses": "actions/setup-node@v4"
-      "with":
-        "node-version": 20
-    - "name": "Set up QEMU"
-      "uses": "docker/setup-qemu-action@v3"
-    - "name": "set up docker buildx"
-      "uses": "docker/setup-buildx-action@v3"
-    - "name": "Login to DockerHub (from vault)"
-      "uses": "grafana/shared-workflows/actions/dockerhub-login@main"
-    - "id": "weekly-version"
-      "name": "Get weekly version"
+    - "id": "platform"
+      "name": "Parse image platform"
       "run": |
-        echo "version=$(./tools/image-tag)" >> $GITHUB_OUTPUT
+        platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
+        echo "platform=${platform}" >> $GITHUB_OUTPUT
+        echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
       "working-directory": "release"
-    - "name": "Build and push"
+    - "id": "build-push"
+      "name": "Build and push"
       "timeout-minutes": "${{ fromJSON(env.BUILD_TIMEOUT) }}"
       "uses": "docker/build-push-action@v6"
       "with":
-        "build-args": "IMAGE_TAG=${{ steps.weekly-version.outputs.version }}"
-        "context": "release"
-        "file": "release/cmd/loki-canary/Dockerfile"
-        "platforms": "linux/amd64,linux/arm64,linux/arm"
-        "push": true
-        "tags": "${{ env.IMAGE_PREFIX }}/loki-canary:${{ steps.weekly-version.outputs.version }}"
-  "loki-canary-boringcrypto":
-    "env":
-      "BUILD_TIMEOUT": 60
-      "IMAGE_PREFIX": "grafana"
-      "RELEASE_LIB_REF": "main"
-      "RELEASE_REPO": "grafana/loki"
-    "needs":
-    - "check"
-    "runs-on": "ubuntu-latest"
-    "steps":
-    - "name": "pull release library code"
-      "uses": "actions/checkout@v4"
-      "with":
-        "path": "lib"
-        "ref": "${{ env.RELEASE_LIB_REF }}"
-        "repository": "grafana/loki-release"
-    - "name": "pull code to release"
-      "uses": "actions/checkout@v4"
-      "with":
-        "path": "release"
-        "repository": "${{ env.RELEASE_REPO }}"
-    - "name": "setup node"
-      "uses": "actions/setup-node@v4"
-      "with":
-        "node-version": 20
-    - "name": "Set up QEMU"
-      "uses": "docker/setup-qemu-action@v3"
-    - "name": "set up docker buildx"
-      "uses": "docker/setup-buildx-action@v3"
-    - "name": "Login to DockerHub (from vault)"
-      "uses": "grafana/shared-workflows/actions/dockerhub-login@main"
-    - "id": "weekly-version"
-      "name": "Get weekly version"
-      "run": |
-        echo "version=$(./tools/image-tag)" >> $GITHUB_OUTPUT
-      "working-directory": "release"
-    - "name": "Build and push"
-      "timeout-minutes": "${{ fromJSON(env.BUILD_TIMEOUT) }}"
-      "uses": "docker/build-push-action@v6"
-      "with":
-        "build-args": "IMAGE_TAG=${{ steps.weekly-version.outputs.version }}"
+        "build-args": |
+          IMAGE_TAG=${{ steps.weekly-version.outputs.image_version }}
+          GO_VERSION=${{ env.GO_VERSION }}
         "context": "release"
         "file": "release/cmd/loki-canary-boringcrypto/Dockerfile"
-        "platforms": "linux/amd64,linux/arm64,linux/arm"
-        "push": true
-        "tags": "${{ env.IMAGE_PREFIX }}/loki-canary-boringcrypto:${{ steps.weekly-version.outputs.version }}"
-  "promtail":
+        "outputs": "push-by-digest=true,type=image,name=${{ steps.weekly-version.outputs.image_name }},push=true"
+        "platforms": "${{ matrix.arch }}"
+        "provenance": true
+        "tags": "${{ steps.weekly-version.outputs.image_name }},${{ steps.weekly-version.outputs.image_name }}-${{ steps.platform.outputs.platform_short }}"
+    - "id": "digest"
+      "name": "Process image digest"
+      "run": |
+        arch=$(echo ${{ matrix.arch }} | tr "/" "_")
+        echo "digest_$arch=${{ steps.build-push.outputs.digest }}" >> $GITHUB_OUTPUT
+      "working-directory": "release"
+    "strategy":
+      "fail-fast": true
+      "matrix":
+        "include":
+        - "arch": "linux/amd64"
+          "runs_on": "ubuntu-amd64"
+        - "arch": "linux/arm64"
+          "runs_on": "ubuntu-arm64"
+        - "arch": "linux/arm"
+          "runs_on": "ubuntu-arm"
+  "loki-canary-boringcrypto-manifest":
+    "env":
+      "BUILD_TIMEOUT": 60
+    "needs":
+    - "check"
+    - "loki-canary-boringcrypto-image"
+    "runs-on": "ubuntu-latest"
+    "steps":
+    - "name": "Set up Docker buildx"
+      "uses": "docker/setup-buildx-action@v3"
+    - "name": "Login to DockerHub (from Vault)"
+      "uses": "grafana/shared-workflows/actions/dockerhub-login@main"
+    - "name": "Create and publish manifest"
+      "run": |
+        # Unfortunately there is no better way atm than having a separate named output for each digest
+        echo '${{ needs.loki-canary-boringcrypto.outputs.image_digest_linux_amd64 }}'
+        echo '${{ needs.loki-canary-boringcrypto.outputs.image_digest_linux_arm64 }}'
+        echo '${{ needs.loki-canary-boringcrypto.outputs.image_digest_linux_arm }}'
+        IMAGE=${{ needs.loki-canary-boringcrypto.outputs.image_name }}:${{ needs.loki-canary-boringcrypto.outputs.image_tag }}
+        docker buildx imagetools create -t $IMAGE \
+          ${{ needs.loki-canary-boringcrypto.outputs.image_name }}@${{ needs.loki-canary-boringcrypto.outputs.image_digest_linux_amd64 }} \
+          ${{ needs.loki-canary-boringcrypto.outputs.image_name }}@${{ needs.loki-canary-boringcrypto.outputs.image_digest_linux_arm64 }}
+          ${{ needs.loki-canary-boringcrypto.outputs.image_name }}@${{ needs.loki-canary-boringcrypto.outputs.image_digest_linux_arm }}
+        docker buildx imagetools inspect $IMAGE
+  "loki-canary-image":
     "env":
       "BUILD_TIMEOUT": 60
       "IMAGE_PREFIX": "grafana"
@@ -153,7 +119,13 @@
       "RELEASE_REPO": "grafana/loki"
     "needs":
     - "check"
-    "runs-on": "ubuntu-latest"
+    "outputs":
+      "image_digest_linux_amd64": "${{ steps.digest.outputs.digest_linux_amd64 }}"
+      "image_digest_linux_arm": "${{ steps.digest.outputs.digest_linux_arm }}"
+      "image_digest_linux_arm64": "${{ steps.digest.outputs.digest_linux_arm64 }}"
+      "image_name": "${{ steps.weekly-version.outputs.image_name }}"
+      "image_tag": "${{ steps.weekly-version.outputs.image_version }}"
+    "runs-on": "${{ matrix.runs_on }}"
     "steps":
     - "name": "pull release library code"
       "uses": "actions/checkout@v4"
@@ -170,27 +142,287 @@
       "uses": "actions/setup-node@v4"
       "with":
         "node-version": 20
-    - "name": "Set up QEMU"
-      "uses": "docker/setup-qemu-action@v3"
-    - "name": "set up docker buildx"
+    - "name": "Set up Docker buildx"
       "uses": "docker/setup-buildx-action@v3"
-    - "name": "Login to DockerHub (from vault)"
+    - "name": "Login to DockerHub (from Vault)"
       "uses": "grafana/shared-workflows/actions/dockerhub-login@main"
     - "id": "weekly-version"
       "name": "Get weekly version"
       "run": |
-        echo "version=$(./tools/image-tag)" >> $GITHUB_OUTPUT
+        version=$(./tools/image-tag)
+        echo "image_version=$version" >> $GITHUB_OUTPUT
+        echo "image_name=${{ env.IMAGE_PREFIX }}/loki-canary" >> $GITHUB_OUTPUT
+        echo "image_full_name=${{ env.IMAGE_PREFIX }}/loki-canary:$version" >> $GITHUB_OUTPUT
       "working-directory": "release"
-    - "name": "Build and push"
+    - "id": "platform"
+      "name": "Parse image platform"
+      "run": |
+        platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
+        echo "platform=${platform}" >> $GITHUB_OUTPUT
+        echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
+      "working-directory": "release"
+    - "id": "build-push"
+      "name": "Build and push"
       "timeout-minutes": "${{ fromJSON(env.BUILD_TIMEOUT) }}"
       "uses": "docker/build-push-action@v6"
       "with":
-        "build-args": "IMAGE_TAG=${{ steps.weekly-version.outputs.version }}"
+        "build-args": |
+          IMAGE_TAG=${{ steps.weekly-version.outputs.image_version }}
+          GO_VERSION=${{ env.GO_VERSION }}
+        "context": "release"
+        "file": "release/cmd/loki-canary/Dockerfile"
+        "outputs": "push-by-digest=true,type=image,name=${{ steps.weekly-version.outputs.image_name }},push=true"
+        "platforms": "${{ matrix.arch }}"
+        "provenance": true
+        "tags": "${{ steps.weekly-version.outputs.image_name }},${{ steps.weekly-version.outputs.image_name }}-${{ steps.platform.outputs.platform_short }}"
+    - "id": "digest"
+      "name": "Process image digest"
+      "run": |
+        arch=$(echo ${{ matrix.arch }} | tr "/" "_")
+        echo "digest_$arch=${{ steps.build-push.outputs.digest }}" >> $GITHUB_OUTPUT
+      "working-directory": "release"
+    "strategy":
+      "fail-fast": true
+      "matrix":
+        "include":
+        - "arch": "linux/amd64"
+          "runs_on": "ubuntu-amd64"
+        - "arch": "linux/arm64"
+          "runs_on": "ubuntu-arm64"
+        - "arch": "linux/arm"
+          "runs_on": "ubuntu-arm"
+  "loki-canary-manifest":
+    "env":
+      "BUILD_TIMEOUT": 60
+    "needs":
+    - "check"
+    - "loki-canary-image"
+    "runs-on": "ubuntu-latest"
+    "steps":
+    - "name": "Set up Docker buildx"
+      "uses": "docker/setup-buildx-action@v3"
+    - "name": "Login to DockerHub (from Vault)"
+      "uses": "grafana/shared-workflows/actions/dockerhub-login@main"
+    - "name": "Create and publish manifest"
+      "run": |
+        # Unfortunately there is no better way atm than having a separate named output for each digest
+        echo '${{ needs.loki-canary.outputs.image_digest_linux_amd64 }}'
+        echo '${{ needs.loki-canary.outputs.image_digest_linux_arm64 }}'
+        echo '${{ needs.loki-canary.outputs.image_digest_linux_arm }}'
+        IMAGE=${{ needs.loki-canary.outputs.image_name }}:${{ needs.loki-canary.outputs.image_tag }}
+        docker buildx imagetools create -t $IMAGE \
+          ${{ needs.loki-canary.outputs.image_name }}@${{ needs.loki-canary.outputs.image_digest_linux_amd64 }} \
+          ${{ needs.loki-canary.outputs.image_name }}@${{ needs.loki-canary.outputs.image_digest_linux_arm64 }}
+          ${{ needs.loki-canary.outputs.image_name }}@${{ needs.loki-canary.outputs.image_digest_linux_arm }}
+        docker buildx imagetools inspect $IMAGE
+  "loki-image":
+    "env":
+      "BUILD_TIMEOUT": 60
+      "IMAGE_PREFIX": "grafana"
+      "RELEASE_LIB_REF": "main"
+      "RELEASE_REPO": "grafana/loki"
+    "needs":
+    - "check"
+    "outputs":
+      "image_digest_linux_amd64": "${{ steps.digest.outputs.digest_linux_amd64 }}"
+      "image_digest_linux_arm": "${{ steps.digest.outputs.digest_linux_arm }}"
+      "image_digest_linux_arm64": "${{ steps.digest.outputs.digest_linux_arm64 }}"
+      "image_name": "${{ steps.weekly-version.outputs.image_name }}"
+      "image_tag": "${{ steps.weekly-version.outputs.image_version }}"
+    "runs-on": "${{ matrix.runs_on }}"
+    "steps":
+    - "name": "pull release library code"
+      "uses": "actions/checkout@v4"
+      "with":
+        "path": "lib"
+        "ref": "${{ env.RELEASE_LIB_REF }}"
+        "repository": "grafana/loki-release"
+    - "name": "pull code to release"
+      "uses": "actions/checkout@v4"
+      "with":
+        "path": "release"
+        "repository": "${{ env.RELEASE_REPO }}"
+    - "name": "setup node"
+      "uses": "actions/setup-node@v4"
+      "with":
+        "node-version": 20
+    - "name": "Set up Docker buildx"
+      "uses": "docker/setup-buildx-action@v3"
+    - "name": "Login to DockerHub (from Vault)"
+      "uses": "grafana/shared-workflows/actions/dockerhub-login@main"
+    - "id": "weekly-version"
+      "name": "Get weekly version"
+      "run": |
+        version=$(./tools/image-tag)
+        echo "image_version=$version" >> $GITHUB_OUTPUT
+        echo "image_name=${{ env.IMAGE_PREFIX }}/loki" >> $GITHUB_OUTPUT
+        echo "image_full_name=${{ env.IMAGE_PREFIX }}/loki:$version" >> $GITHUB_OUTPUT
+      "working-directory": "release"
+    - "id": "platform"
+      "name": "Parse image platform"
+      "run": |
+        platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
+        echo "platform=${platform}" >> $GITHUB_OUTPUT
+        echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
+      "working-directory": "release"
+    - "id": "build-push"
+      "name": "Build and push"
+      "timeout-minutes": "${{ fromJSON(env.BUILD_TIMEOUT) }}"
+      "uses": "docker/build-push-action@v6"
+      "with":
+        "build-args": |
+          IMAGE_TAG=${{ steps.weekly-version.outputs.image_version }}
+          GO_VERSION=${{ env.GO_VERSION }}
+        "context": "release"
+        "file": "release/cmd/loki/Dockerfile"
+        "outputs": "push-by-digest=true,type=image,name=${{ steps.weekly-version.outputs.image_name }},push=true"
+        "platforms": "${{ matrix.arch }}"
+        "provenance": true
+        "tags": "${{ steps.weekly-version.outputs.image_name }},${{ steps.weekly-version.outputs.image_name }}-${{ steps.platform.outputs.platform_short }}"
+    - "id": "digest"
+      "name": "Process image digest"
+      "run": |
+        arch=$(echo ${{ matrix.arch }} | tr "/" "_")
+        echo "digest_$arch=${{ steps.build-push.outputs.digest }}" >> $GITHUB_OUTPUT
+      "working-directory": "release"
+    "strategy":
+      "fail-fast": true
+      "matrix":
+        "include":
+        - "arch": "linux/amd64"
+          "runs_on": "ubuntu-amd64"
+        - "arch": "linux/arm64"
+          "runs_on": "ubuntu-arm64"
+        - "arch": "linux/arm"
+          "runs_on": "ubuntu-arm"
+  "loki-manifest":
+    "env":
+      "BUILD_TIMEOUT": 60
+    "needs":
+    - "check"
+    - "loki-image"
+    "runs-on": "ubuntu-latest"
+    "steps":
+    - "name": "Set up Docker buildx"
+      "uses": "docker/setup-buildx-action@v3"
+    - "name": "Login to DockerHub (from Vault)"
+      "uses": "grafana/shared-workflows/actions/dockerhub-login@main"
+    - "name": "Create and publish manifest"
+      "run": |
+        # Unfortunately there is no better way atm than having a separate named output for each digest
+        echo '${{ needs.loki.outputs.image_digest_linux_amd64 }}'
+        echo '${{ needs.loki.outputs.image_digest_linux_arm64 }}'
+        echo '${{ needs.loki.outputs.image_digest_linux_arm }}'
+        IMAGE=${{ needs.loki.outputs.image_name }}:${{ needs.loki.outputs.image_tag }}
+        docker buildx imagetools create -t $IMAGE \
+          ${{ needs.loki.outputs.image_name }}@${{ needs.loki.outputs.image_digest_linux_amd64 }} \
+          ${{ needs.loki.outputs.image_name }}@${{ needs.loki.outputs.image_digest_linux_arm64 }}
+          ${{ needs.loki.outputs.image_name }}@${{ needs.loki.outputs.image_digest_linux_arm }}
+        docker buildx imagetools inspect $IMAGE
+  "promtail-image":
+    "env":
+      "BUILD_TIMEOUT": 60
+      "IMAGE_PREFIX": "grafana"
+      "RELEASE_LIB_REF": "main"
+      "RELEASE_REPO": "grafana/loki"
+    "needs":
+    - "check"
+    "outputs":
+      "image_digest_linux_amd64": "${{ steps.digest.outputs.digest_linux_amd64 }}"
+      "image_digest_linux_arm": "${{ steps.digest.outputs.digest_linux_arm }}"
+      "image_digest_linux_arm64": "${{ steps.digest.outputs.digest_linux_arm64 }}"
+      "image_name": "${{ steps.weekly-version.outputs.image_name }}"
+      "image_tag": "${{ steps.weekly-version.outputs.image_version }}"
+    "runs-on": "${{ matrix.runs_on }}"
+    "steps":
+    - "name": "pull release library code"
+      "uses": "actions/checkout@v4"
+      "with":
+        "path": "lib"
+        "ref": "${{ env.RELEASE_LIB_REF }}"
+        "repository": "grafana/loki-release"
+    - "name": "pull code to release"
+      "uses": "actions/checkout@v4"
+      "with":
+        "path": "release"
+        "repository": "${{ env.RELEASE_REPO }}"
+    - "name": "setup node"
+      "uses": "actions/setup-node@v4"
+      "with":
+        "node-version": 20
+    - "name": "Set up Docker buildx"
+      "uses": "docker/setup-buildx-action@v3"
+    - "name": "Login to DockerHub (from Vault)"
+      "uses": "grafana/shared-workflows/actions/dockerhub-login@main"
+    - "id": "weekly-version"
+      "name": "Get weekly version"
+      "run": |
+        version=$(./tools/image-tag)
+        echo "image_version=$version" >> $GITHUB_OUTPUT
+        echo "image_name=${{ env.IMAGE_PREFIX }}/promtail" >> $GITHUB_OUTPUT
+        echo "image_full_name=${{ env.IMAGE_PREFIX }}/promtail:$version" >> $GITHUB_OUTPUT
+      "working-directory": "release"
+    - "id": "platform"
+      "name": "Parse image platform"
+      "run": |
+        platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
+        echo "platform=${platform}" >> $GITHUB_OUTPUT
+        echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
+      "working-directory": "release"
+    - "id": "build-push"
+      "name": "Build and push"
+      "timeout-minutes": "${{ fromJSON(env.BUILD_TIMEOUT) }}"
+      "uses": "docker/build-push-action@v6"
+      "with":
+        "build-args": |
+          IMAGE_TAG=${{ steps.weekly-version.outputs.image_version }}
+          GO_VERSION=${{ env.GO_VERSION }}
         "context": "release"
         "file": "release/clients/cmd/promtail/Dockerfile"
-        "platforms": "linux/amd64,linux/arm64,linux/arm"
-        "push": true
-        "tags": "${{ env.IMAGE_PREFIX }}/promtail:${{ steps.weekly-version.outputs.version }}"
+        "outputs": "push-by-digest=true,type=image,name=${{ steps.weekly-version.outputs.image_name }},push=true"
+        "platforms": "${{ matrix.arch }}"
+        "provenance": true
+        "tags": "${{ steps.weekly-version.outputs.image_name }},${{ steps.weekly-version.outputs.image_name }}-${{ steps.platform.outputs.platform_short }}"
+    - "id": "digest"
+      "name": "Process image digest"
+      "run": |
+        arch=$(echo ${{ matrix.arch }} | tr "/" "_")
+        echo "digest_$arch=${{ steps.build-push.outputs.digest }}" >> $GITHUB_OUTPUT
+      "working-directory": "release"
+    "strategy":
+      "fail-fast": true
+      "matrix":
+        "include":
+        - "arch": "linux/amd64"
+          "runs_on": "ubuntu-amd64"
+        - "arch": "linux/arm64"
+          "runs_on": "ubuntu-arm64"
+        - "arch": "linux/arm"
+          "runs_on": "ubuntu-arm"
+  "promtail-manifest":
+    "env":
+      "BUILD_TIMEOUT": 60
+    "needs":
+    - "check"
+    - "promtail-image"
+    "runs-on": "ubuntu-latest"
+    "steps":
+    - "name": "Set up Docker buildx"
+      "uses": "docker/setup-buildx-action@v3"
+    - "name": "Login to DockerHub (from Vault)"
+      "uses": "grafana/shared-workflows/actions/dockerhub-login@main"
+    - "name": "Create and publish manifest"
+      "run": |
+        # Unfortunately there is no better way atm than having a separate named output for each digest
+        echo '${{ needs.promtail.outputs.image_digest_linux_amd64 }}'
+        echo '${{ needs.promtail.outputs.image_digest_linux_arm64 }}'
+        echo '${{ needs.promtail.outputs.image_digest_linux_arm }}'
+        IMAGE=${{ needs.promtail.outputs.image_name }}:${{ needs.promtail.outputs.image_tag }}
+        docker buildx imagetools create -t $IMAGE \
+          ${{ needs.promtail.outputs.image_name }}@${{ needs.promtail.outputs.image_digest_linux_amd64 }} \
+          ${{ needs.promtail.outputs.image_name }}@${{ needs.promtail.outputs.image_digest_linux_arm64 }}
+          ${{ needs.promtail.outputs.image_name }}@${{ needs.promtail.outputs.image_digest_linux_arm }}
+        docker buildx imagetools inspect $IMAGE
 "name": "publish images"
 "on":
   "push":

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -94,7 +94,6 @@
     "env":
       "BUILD_TIMEOUT": 60
     "needs":
-    - "check"
     - "loki-canary-boringcrypto-image"
     "runs-on": "ubuntu-latest"
     "steps":
@@ -201,7 +200,6 @@
     "env":
       "BUILD_TIMEOUT": 60
     "needs":
-    - "check"
     - "loki-canary-image"
     "runs-on": "ubuntu-latest"
     "steps":
@@ -308,7 +306,6 @@
     "env":
       "BUILD_TIMEOUT": 60
     "needs":
-    - "check"
     - "loki-image"
     "runs-on": "ubuntu-latest"
     "steps":
@@ -415,7 +412,6 @@
     "env":
       "BUILD_TIMEOUT": 60
     "needs":
-    - "check"
     - "promtail-image"
     "runs-on": "ubuntu-latest"
     "steps":

--- a/.github/workflows/minor-release-pr.yml
+++ b/.github/workflows/minor-release-pr.yml
@@ -160,7 +160,7 @@ jobs:
   fluent-bit:
     needs:
     - "version"
-    runs-on: "ubuntu-latest"
+    runs-on: "${{ matrix.runs_on }}"
     steps:
     - name: "pull release library code"
       uses: "actions/checkout@v4"
@@ -183,16 +183,16 @@ jobs:
         credentials_json: "${{ secrets.GCS_SERVICE_ACCOUNT_KEY }}"
     - name: "Set up QEMU"
       uses: "docker/setup-qemu-action@v3"
-    - name: "set up docker buildx"
+    - name: "Set up Docker buildx"
       uses: "docker/setup-buildx-action@v3"
     - id: "platform"
-      name: "parse image platform"
+      name: "Parse image platform"
       run: |
-        mkdir -p images
+        mkdir -p release/images
         
-        platform="$(echo "${{ matrix.platform}}" |  sed  "s/\(.*\)\/\(.*\)/\1-\2/")"
+        platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
-        echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
+        echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
       working-directory: "release"
     - env:
         IMAGE_TAG: "${{ needs.version.outputs.version }}"
@@ -205,10 +205,10 @@ jobs:
         context: "release"
         file: "release/clients/cmd/fluent-bit/Dockerfile"
         outputs: "type=docker,dest=release/images/fluent-bit-plugin-loki-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
-        platforms: "${{ matrix.platform }}"
+        platforms: "${{ matrix.arch }}"
         tags: "${{ env.IMAGE_PREFIX }}/fluent-bit-plugin-loki:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
     - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
-      name: "upload artifacts"
+      name: "Upload artifacts"
       uses: "google-github-actions/upload-cloud-storage@v2"
       with:
         destination: "${{ env.BUILD_ARTIFACTS_BUCKET }}/${{ github.sha }}/images"
@@ -217,12 +217,13 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        platform:
-        - "linux/amd64"
+        include:
+        - arch: "linux/amd64"
+          runs_on: "ubuntu-amd64"
   fluentd:
     needs:
     - "version"
-    runs-on: "ubuntu-latest"
+    runs-on: "${{ matrix.runs_on }}"
     steps:
     - name: "pull release library code"
       uses: "actions/checkout@v4"
@@ -245,16 +246,16 @@ jobs:
         credentials_json: "${{ secrets.GCS_SERVICE_ACCOUNT_KEY }}"
     - name: "Set up QEMU"
       uses: "docker/setup-qemu-action@v3"
-    - name: "set up docker buildx"
+    - name: "Set up Docker buildx"
       uses: "docker/setup-buildx-action@v3"
     - id: "platform"
-      name: "parse image platform"
+      name: "Parse image platform"
       run: |
-        mkdir -p images
+        mkdir -p release/images
         
-        platform="$(echo "${{ matrix.platform}}" |  sed  "s/\(.*\)\/\(.*\)/\1-\2/")"
+        platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
-        echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
+        echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
       working-directory: "release"
     - env:
         IMAGE_TAG: "${{ needs.version.outputs.version }}"
@@ -267,10 +268,10 @@ jobs:
         context: "release"
         file: "release/clients/cmd/fluentd/Dockerfile"
         outputs: "type=docker,dest=release/images/fluent-plugin-loki-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
-        platforms: "${{ matrix.platform }}"
+        platforms: "${{ matrix.arch }}"
         tags: "${{ env.IMAGE_PREFIX }}/fluent-plugin-loki:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
     - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
-      name: "upload artifacts"
+      name: "Upload artifacts"
       uses: "google-github-actions/upload-cloud-storage@v2"
       with:
         destination: "${{ env.BUILD_ARTIFACTS_BUCKET }}/${{ github.sha }}/images"
@@ -279,12 +280,13 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        platform:
-        - "linux/amd64"
+        include:
+        - arch: "linux/amd64"
+          runs_on: "ubuntu-amd64"
   logcli:
     needs:
     - "version"
-    runs-on: "ubuntu-latest"
+    runs-on: "${{ matrix.runs_on }}"
     steps:
     - name: "pull release library code"
       uses: "actions/checkout@v4"
@@ -307,16 +309,16 @@ jobs:
         credentials_json: "${{ secrets.GCS_SERVICE_ACCOUNT_KEY }}"
     - name: "Set up QEMU"
       uses: "docker/setup-qemu-action@v3"
-    - name: "set up docker buildx"
+    - name: "Set up Docker buildx"
       uses: "docker/setup-buildx-action@v3"
     - id: "platform"
-      name: "parse image platform"
+      name: "Parse image platform"
       run: |
-        mkdir -p images
+        mkdir -p release/images
         
-        platform="$(echo "${{ matrix.platform}}" |  sed  "s/\(.*\)\/\(.*\)/\1-\2/")"
+        platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
-        echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
+        echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
       working-directory: "release"
     - env:
         IMAGE_TAG: "${{ needs.version.outputs.version }}"
@@ -329,10 +331,10 @@ jobs:
         context: "release"
         file: "release/cmd/logcli/Dockerfile"
         outputs: "type=docker,dest=release/images/logcli-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
-        platforms: "${{ matrix.platform }}"
+        platforms: "${{ matrix.arch }}"
         tags: "${{ env.IMAGE_PREFIX }}/logcli:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
     - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
-      name: "upload artifacts"
+      name: "Upload artifacts"
       uses: "google-github-actions/upload-cloud-storage@v2"
       with:
         destination: "${{ env.BUILD_ARTIFACTS_BUCKET }}/${{ github.sha }}/images"
@@ -341,14 +343,17 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        platform:
-        - "linux/amd64"
-        - "linux/arm64"
-        - "linux/arm"
+        include:
+        - arch: "linux/amd64"
+          runs_on: "ubuntu-amd64"
+        - arch: "linux/arm64"
+          runs_on: "ubuntu-arm64"
+        - arch: "linux/arm"
+          runs_on: "ubuntu-arm"
   logstash:
     needs:
     - "version"
-    runs-on: "ubuntu-latest"
+    runs-on: "${{ matrix.runs_on }}"
     steps:
     - name: "pull release library code"
       uses: "actions/checkout@v4"
@@ -371,16 +376,16 @@ jobs:
         credentials_json: "${{ secrets.GCS_SERVICE_ACCOUNT_KEY }}"
     - name: "Set up QEMU"
       uses: "docker/setup-qemu-action@v3"
-    - name: "set up docker buildx"
+    - name: "Set up Docker buildx"
       uses: "docker/setup-buildx-action@v3"
     - id: "platform"
-      name: "parse image platform"
+      name: "Parse image platform"
       run: |
-        mkdir -p images
+        mkdir -p release/images
         
-        platform="$(echo "${{ matrix.platform}}" |  sed  "s/\(.*\)\/\(.*\)/\1-\2/")"
+        platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
-        echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
+        echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
       working-directory: "release"
     - env:
         IMAGE_TAG: "${{ needs.version.outputs.version }}"
@@ -393,10 +398,10 @@ jobs:
         context: "release"
         file: "release/clients/cmd/logstash/Dockerfile"
         outputs: "type=docker,dest=release/images/logstash-output-loki-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
-        platforms: "${{ matrix.platform }}"
+        platforms: "${{ matrix.arch }}"
         tags: "${{ env.IMAGE_PREFIX }}/logstash-output-loki:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
     - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
-      name: "upload artifacts"
+      name: "Upload artifacts"
       uses: "google-github-actions/upload-cloud-storage@v2"
       with:
         destination: "${{ env.BUILD_ARTIFACTS_BUCKET }}/${{ github.sha }}/images"
@@ -405,12 +410,13 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        platform:
-        - "linux/amd64"
+        include:
+        - arch: "linux/amd64"
+          runs_on: "ubuntu-amd64"
   loki:
     needs:
     - "version"
-    runs-on: "ubuntu-latest"
+    runs-on: "${{ matrix.runs_on }}"
     steps:
     - name: "pull release library code"
       uses: "actions/checkout@v4"
@@ -433,16 +439,16 @@ jobs:
         credentials_json: "${{ secrets.GCS_SERVICE_ACCOUNT_KEY }}"
     - name: "Set up QEMU"
       uses: "docker/setup-qemu-action@v3"
-    - name: "set up docker buildx"
+    - name: "Set up Docker buildx"
       uses: "docker/setup-buildx-action@v3"
     - id: "platform"
-      name: "parse image platform"
+      name: "Parse image platform"
       run: |
-        mkdir -p images
+        mkdir -p release/images
         
-        platform="$(echo "${{ matrix.platform}}" |  sed  "s/\(.*\)\/\(.*\)/\1-\2/")"
+        platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
-        echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
+        echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
       working-directory: "release"
     - env:
         IMAGE_TAG: "${{ needs.version.outputs.version }}"
@@ -455,10 +461,10 @@ jobs:
         context: "release"
         file: "release/cmd/loki/Dockerfile"
         outputs: "type=docker,dest=release/images/loki-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
-        platforms: "${{ matrix.platform }}"
+        platforms: "${{ matrix.arch }}"
         tags: "${{ env.IMAGE_PREFIX }}/loki:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
     - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
-      name: "upload artifacts"
+      name: "Upload artifacts"
       uses: "google-github-actions/upload-cloud-storage@v2"
       with:
         destination: "${{ env.BUILD_ARTIFACTS_BUCKET }}/${{ github.sha }}/images"
@@ -467,14 +473,17 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        platform:
-        - "linux/amd64"
-        - "linux/arm64"
-        - "linux/arm"
+        include:
+        - arch: "linux/amd64"
+          runs_on: "ubuntu-amd64"
+        - arch: "linux/arm64"
+          runs_on: "ubuntu-arm64"
+        - arch: "linux/arm"
+          runs_on: "ubuntu-arm"
   loki-canary:
     needs:
     - "version"
-    runs-on: "ubuntu-latest"
+    runs-on: "${{ matrix.runs_on }}"
     steps:
     - name: "pull release library code"
       uses: "actions/checkout@v4"
@@ -497,16 +506,16 @@ jobs:
         credentials_json: "${{ secrets.GCS_SERVICE_ACCOUNT_KEY }}"
     - name: "Set up QEMU"
       uses: "docker/setup-qemu-action@v3"
-    - name: "set up docker buildx"
+    - name: "Set up Docker buildx"
       uses: "docker/setup-buildx-action@v3"
     - id: "platform"
-      name: "parse image platform"
+      name: "Parse image platform"
       run: |
-        mkdir -p images
+        mkdir -p release/images
         
-        platform="$(echo "${{ matrix.platform}}" |  sed  "s/\(.*\)\/\(.*\)/\1-\2/")"
+        platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
-        echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
+        echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
       working-directory: "release"
     - env:
         IMAGE_TAG: "${{ needs.version.outputs.version }}"
@@ -519,10 +528,10 @@ jobs:
         context: "release"
         file: "release/cmd/loki-canary/Dockerfile"
         outputs: "type=docker,dest=release/images/loki-canary-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
-        platforms: "${{ matrix.platform }}"
+        platforms: "${{ matrix.arch }}"
         tags: "${{ env.IMAGE_PREFIX }}/loki-canary:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
     - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
-      name: "upload artifacts"
+      name: "Upload artifacts"
       uses: "google-github-actions/upload-cloud-storage@v2"
       with:
         destination: "${{ env.BUILD_ARTIFACTS_BUCKET }}/${{ github.sha }}/images"
@@ -531,14 +540,17 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        platform:
-        - "linux/amd64"
-        - "linux/arm64"
-        - "linux/arm"
+        include:
+        - arch: "linux/amd64"
+          runs_on: "ubuntu-amd64"
+        - arch: "linux/arm64"
+          runs_on: "ubuntu-arm64"
+        - arch: "linux/arm"
+          runs_on: "ubuntu-arm"
   loki-canary-boringcrypto:
     needs:
     - "version"
-    runs-on: "ubuntu-latest"
+    runs-on: "${{ matrix.runs_on }}"
     steps:
     - name: "pull release library code"
       uses: "actions/checkout@v4"
@@ -561,16 +573,16 @@ jobs:
         credentials_json: "${{ secrets.GCS_SERVICE_ACCOUNT_KEY }}"
     - name: "Set up QEMU"
       uses: "docker/setup-qemu-action@v3"
-    - name: "set up docker buildx"
+    - name: "Set up Docker buildx"
       uses: "docker/setup-buildx-action@v3"
     - id: "platform"
-      name: "parse image platform"
+      name: "Parse image platform"
       run: |
-        mkdir -p images
+        mkdir -p release/images
         
-        platform="$(echo "${{ matrix.platform}}" |  sed  "s/\(.*\)\/\(.*\)/\1-\2/")"
+        platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
-        echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
+        echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
       working-directory: "release"
     - env:
         IMAGE_TAG: "${{ needs.version.outputs.version }}"
@@ -583,10 +595,10 @@ jobs:
         context: "release"
         file: "release/cmd/loki-canary-boringcrypto/Dockerfile"
         outputs: "type=docker,dest=release/images/loki-canary-boringcrypto-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
-        platforms: "${{ matrix.platform }}"
+        platforms: "${{ matrix.arch }}"
         tags: "${{ env.IMAGE_PREFIX }}/loki-canary-boringcrypto:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
     - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
-      name: "upload artifacts"
+      name: "Upload artifacts"
       uses: "google-github-actions/upload-cloud-storage@v2"
       with:
         destination: "${{ env.BUILD_ARTIFACTS_BUCKET }}/${{ github.sha }}/images"
@@ -595,10 +607,13 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        platform:
-        - "linux/amd64"
-        - "linux/arm64"
-        - "linux/arm"
+        include:
+        - arch: "linux/amd64"
+          runs_on: "ubuntu-amd64"
+        - arch: "linux/arm64"
+          runs_on: "ubuntu-arm64"
+        - arch: "linux/arm"
+          runs_on: "ubuntu-arm"
   loki-docker-driver:
     needs:
     - "version"
@@ -679,7 +694,7 @@ jobs:
   promtail:
     needs:
     - "version"
-    runs-on: "ubuntu-latest"
+    runs-on: "${{ matrix.runs_on }}"
     steps:
     - name: "pull release library code"
       uses: "actions/checkout@v4"
@@ -702,16 +717,16 @@ jobs:
         credentials_json: "${{ secrets.GCS_SERVICE_ACCOUNT_KEY }}"
     - name: "Set up QEMU"
       uses: "docker/setup-qemu-action@v3"
-    - name: "set up docker buildx"
+    - name: "Set up Docker buildx"
       uses: "docker/setup-buildx-action@v3"
     - id: "platform"
-      name: "parse image platform"
+      name: "Parse image platform"
       run: |
-        mkdir -p images
+        mkdir -p release/images
         
-        platform="$(echo "${{ matrix.platform}}" |  sed  "s/\(.*\)\/\(.*\)/\1-\2/")"
+        platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
-        echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
+        echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
       working-directory: "release"
     - env:
         IMAGE_TAG: "${{ needs.version.outputs.version }}"
@@ -724,10 +739,10 @@ jobs:
         context: "release"
         file: "release/clients/cmd/promtail/Dockerfile"
         outputs: "type=docker,dest=release/images/promtail-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
-        platforms: "${{ matrix.platform }}"
+        platforms: "${{ matrix.arch }}"
         tags: "${{ env.IMAGE_PREFIX }}/promtail:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
     - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
-      name: "upload artifacts"
+      name: "Upload artifacts"
       uses: "google-github-actions/upload-cloud-storage@v2"
       with:
         destination: "${{ env.BUILD_ARTIFACTS_BUCKET }}/${{ github.sha }}/images"
@@ -736,14 +751,17 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        platform:
-        - "linux/amd64"
-        - "linux/arm64"
-        - "linux/arm"
+        include:
+        - arch: "linux/amd64"
+          runs_on: "ubuntu-amd64"
+        - arch: "linux/arm64"
+          runs_on: "ubuntu-arm64"
+        - arch: "linux/arm"
+          runs_on: "ubuntu-arm"
   querytee:
     needs:
     - "version"
-    runs-on: "ubuntu-latest"
+    runs-on: "${{ matrix.runs_on }}"
     steps:
     - name: "pull release library code"
       uses: "actions/checkout@v4"
@@ -766,16 +784,16 @@ jobs:
         credentials_json: "${{ secrets.GCS_SERVICE_ACCOUNT_KEY }}"
     - name: "Set up QEMU"
       uses: "docker/setup-qemu-action@v3"
-    - name: "set up docker buildx"
+    - name: "Set up Docker buildx"
       uses: "docker/setup-buildx-action@v3"
     - id: "platform"
-      name: "parse image platform"
+      name: "Parse image platform"
       run: |
-        mkdir -p images
+        mkdir -p release/images
         
-        platform="$(echo "${{ matrix.platform}}" |  sed  "s/\(.*\)\/\(.*\)/\1-\2/")"
+        platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
-        echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
+        echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
       working-directory: "release"
     - env:
         IMAGE_TAG: "${{ needs.version.outputs.version }}"
@@ -788,10 +806,10 @@ jobs:
         context: "release"
         file: "release/cmd/querytee/Dockerfile"
         outputs: "type=docker,dest=release/images/loki-query-tee-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
-        platforms: "${{ matrix.platform }}"
+        platforms: "${{ matrix.arch }}"
         tags: "${{ env.IMAGE_PREFIX }}/loki-query-tee:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
     - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
-      name: "upload artifacts"
+      name: "Upload artifacts"
       uses: "google-github-actions/upload-cloud-storage@v2"
       with:
         destination: "${{ env.BUILD_ARTIFACTS_BUCKET }}/${{ github.sha }}/images"
@@ -800,8 +818,9 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        platform:
-        - "linux/amd64"
+        include:
+        - arch: "linux/amd64"
+          runs_on: "ubuntu-amd64"
   version:
     needs:
     - "check"

--- a/.github/workflows/minor-release-pr.yml
+++ b/.github/workflows/minor-release-pr.yml
@@ -219,7 +219,8 @@ jobs:
       matrix:
         include:
         - arch: "linux/amd64"
-          runs_on: "ubuntu-amd64"
+          runs_on:
+          - "github-hosted-ubuntu-x64-small"
   fluentd:
     needs:
     - "version"
@@ -282,7 +283,8 @@ jobs:
       matrix:
         include:
         - arch: "linux/amd64"
-          runs_on: "ubuntu-amd64"
+          runs_on:
+          - "github-hosted-ubuntu-x64-small"
   logcli:
     needs:
     - "version"
@@ -345,11 +347,14 @@ jobs:
       matrix:
         include:
         - arch: "linux/amd64"
-          runs_on: "ubuntu-amd64"
+          runs_on:
+          - "github-hosted-ubuntu-x64-small"
         - arch: "linux/arm64"
-          runs_on: "ubuntu-arm64"
+          runs_on:
+          - "github-hosted-ubuntu-arm64-small"
         - arch: "linux/arm"
-          runs_on: "ubuntu-arm"
+          runs_on:
+          - "github-hosted-ubuntu-arm64-small"
   logstash:
     needs:
     - "version"
@@ -412,7 +417,8 @@ jobs:
       matrix:
         include:
         - arch: "linux/amd64"
-          runs_on: "ubuntu-amd64"
+          runs_on:
+          - "github-hosted-ubuntu-x64-small"
   loki:
     needs:
     - "version"
@@ -475,11 +481,14 @@ jobs:
       matrix:
         include:
         - arch: "linux/amd64"
-          runs_on: "ubuntu-amd64"
+          runs_on:
+          - "github-hosted-ubuntu-x64-small"
         - arch: "linux/arm64"
-          runs_on: "ubuntu-arm64"
+          runs_on:
+          - "github-hosted-ubuntu-arm64-small"
         - arch: "linux/arm"
-          runs_on: "ubuntu-arm"
+          runs_on:
+          - "github-hosted-ubuntu-arm64-small"
   loki-canary:
     needs:
     - "version"
@@ -542,11 +551,14 @@ jobs:
       matrix:
         include:
         - arch: "linux/amd64"
-          runs_on: "ubuntu-amd64"
+          runs_on:
+          - "github-hosted-ubuntu-x64-small"
         - arch: "linux/arm64"
-          runs_on: "ubuntu-arm64"
+          runs_on:
+          - "github-hosted-ubuntu-arm64-small"
         - arch: "linux/arm"
-          runs_on: "ubuntu-arm"
+          runs_on:
+          - "github-hosted-ubuntu-arm64-small"
   loki-canary-boringcrypto:
     needs:
     - "version"
@@ -609,11 +621,14 @@ jobs:
       matrix:
         include:
         - arch: "linux/amd64"
-          runs_on: "ubuntu-amd64"
+          runs_on:
+          - "github-hosted-ubuntu-x64-small"
         - arch: "linux/arm64"
-          runs_on: "ubuntu-arm64"
+          runs_on:
+          - "github-hosted-ubuntu-arm64-small"
         - arch: "linux/arm"
-          runs_on: "ubuntu-arm"
+          runs_on:
+          - "github-hosted-ubuntu-arm64-small"
   loki-docker-driver:
     needs:
     - "version"
@@ -753,11 +768,14 @@ jobs:
       matrix:
         include:
         - arch: "linux/amd64"
-          runs_on: "ubuntu-amd64"
+          runs_on:
+          - "github-hosted-ubuntu-x64-small"
         - arch: "linux/arm64"
-          runs_on: "ubuntu-arm64"
+          runs_on:
+          - "github-hosted-ubuntu-arm64-small"
         - arch: "linux/arm"
-          runs_on: "ubuntu-arm"
+          runs_on:
+          - "github-hosted-ubuntu-arm64-small"
   querytee:
     needs:
     - "version"
@@ -820,7 +838,8 @@ jobs:
       matrix:
         include:
         - arch: "linux/amd64"
-          runs_on: "ubuntu-amd64"
+          runs_on:
+          - "github-hosted-ubuntu-x64-small"
   version:
     needs:
     - "check"

--- a/.github/workflows/minor-release-pr.yml
+++ b/.github/workflows/minor-release-pr.yml
@@ -181,8 +181,6 @@ jobs:
       uses: "google-github-actions/auth@v2"
       with:
         credentials_json: "${{ secrets.GCS_SERVICE_ACCOUNT_KEY }}"
-    - name: "Set up QEMU"
-      uses: "docker/setup-qemu-action@v3"
     - name: "Set up Docker buildx"
       uses: "docker/setup-buildx-action@v3"
     - id: "platform"
@@ -245,8 +243,6 @@ jobs:
       uses: "google-github-actions/auth@v2"
       with:
         credentials_json: "${{ secrets.GCS_SERVICE_ACCOUNT_KEY }}"
-    - name: "Set up QEMU"
-      uses: "docker/setup-qemu-action@v3"
     - name: "Set up Docker buildx"
       uses: "docker/setup-buildx-action@v3"
     - id: "platform"
@@ -309,8 +305,6 @@ jobs:
       uses: "google-github-actions/auth@v2"
       with:
         credentials_json: "${{ secrets.GCS_SERVICE_ACCOUNT_KEY }}"
-    - name: "Set up QEMU"
-      uses: "docker/setup-qemu-action@v3"
     - name: "Set up Docker buildx"
       uses: "docker/setup-buildx-action@v3"
     - id: "platform"
@@ -379,8 +373,6 @@ jobs:
       uses: "google-github-actions/auth@v2"
       with:
         credentials_json: "${{ secrets.GCS_SERVICE_ACCOUNT_KEY }}"
-    - name: "Set up QEMU"
-      uses: "docker/setup-qemu-action@v3"
     - name: "Set up Docker buildx"
       uses: "docker/setup-buildx-action@v3"
     - id: "platform"
@@ -443,8 +435,6 @@ jobs:
       uses: "google-github-actions/auth@v2"
       with:
         credentials_json: "${{ secrets.GCS_SERVICE_ACCOUNT_KEY }}"
-    - name: "Set up QEMU"
-      uses: "docker/setup-qemu-action@v3"
     - name: "Set up Docker buildx"
       uses: "docker/setup-buildx-action@v3"
     - id: "platform"
@@ -513,8 +503,6 @@ jobs:
       uses: "google-github-actions/auth@v2"
       with:
         credentials_json: "${{ secrets.GCS_SERVICE_ACCOUNT_KEY }}"
-    - name: "Set up QEMU"
-      uses: "docker/setup-qemu-action@v3"
     - name: "Set up Docker buildx"
       uses: "docker/setup-buildx-action@v3"
     - id: "platform"
@@ -583,8 +571,6 @@ jobs:
       uses: "google-github-actions/auth@v2"
       with:
         credentials_json: "${{ secrets.GCS_SERVICE_ACCOUNT_KEY }}"
-    - name: "Set up QEMU"
-      uses: "docker/setup-qemu-action@v3"
     - name: "Set up Docker buildx"
       uses: "docker/setup-buildx-action@v3"
     - id: "platform"
@@ -704,8 +690,15 @@ jobs:
       fail-fast: true
       matrix:
         platform:
-        - "linux/amd64"
-        - "linux/arm64"
+        - arch: "linux/amd64"
+          runs_on:
+          - "github-hosted-ubuntu-x64-small"
+        - arch: "linux/arm64"
+          runs_on:
+          - "github-hosted-ubuntu-arm64-small"
+        - arch: "linux/arm"
+          runs_on:
+          - "github-hosted-ubuntu-arm64-small"
   promtail:
     needs:
     - "version"
@@ -730,8 +723,6 @@ jobs:
       uses: "google-github-actions/auth@v2"
       with:
         credentials_json: "${{ secrets.GCS_SERVICE_ACCOUNT_KEY }}"
-    - name: "Set up QEMU"
-      uses: "docker/setup-qemu-action@v3"
     - name: "Set up Docker buildx"
       uses: "docker/setup-buildx-action@v3"
     - id: "platform"
@@ -800,8 +791,6 @@ jobs:
       uses: "google-github-actions/auth@v2"
       with:
         credentials_json: "${{ secrets.GCS_SERVICE_ACCOUNT_KEY }}"
-    - name: "Set up QEMU"
-      uses: "docker/setup-qemu-action@v3"
     - name: "Set up Docker buildx"
       uses: "docker/setup-buildx-action@v3"
     - id: "platform"

--- a/.github/workflows/patch-release-pr.yml
+++ b/.github/workflows/patch-release-pr.yml
@@ -160,7 +160,7 @@ jobs:
   fluent-bit:
     needs:
     - "version"
-    runs-on: "ubuntu-latest"
+    runs-on: "${{ matrix.runs_on }}"
     steps:
     - name: "pull release library code"
       uses: "actions/checkout@v4"
@@ -183,16 +183,16 @@ jobs:
         credentials_json: "${{ secrets.GCS_SERVICE_ACCOUNT_KEY }}"
     - name: "Set up QEMU"
       uses: "docker/setup-qemu-action@v3"
-    - name: "set up docker buildx"
+    - name: "Set up Docker buildx"
       uses: "docker/setup-buildx-action@v3"
     - id: "platform"
-      name: "parse image platform"
+      name: "Parse image platform"
       run: |
-        mkdir -p images
+        mkdir -p release/images
         
-        platform="$(echo "${{ matrix.platform}}" |  sed  "s/\(.*\)\/\(.*\)/\1-\2/")"
+        platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
-        echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
+        echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
       working-directory: "release"
     - env:
         IMAGE_TAG: "${{ needs.version.outputs.version }}"
@@ -205,10 +205,10 @@ jobs:
         context: "release"
         file: "release/clients/cmd/fluent-bit/Dockerfile"
         outputs: "type=docker,dest=release/images/fluent-bit-plugin-loki-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
-        platforms: "${{ matrix.platform }}"
+        platforms: "${{ matrix.arch }}"
         tags: "${{ env.IMAGE_PREFIX }}/fluent-bit-plugin-loki:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
     - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
-      name: "upload artifacts"
+      name: "Upload artifacts"
       uses: "google-github-actions/upload-cloud-storage@v2"
       with:
         destination: "${{ env.BUILD_ARTIFACTS_BUCKET }}/${{ github.sha }}/images"
@@ -217,12 +217,13 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        platform:
-        - "linux/amd64"
+        include:
+        - arch: "linux/amd64"
+          runs_on: "ubuntu-amd64"
   fluentd:
     needs:
     - "version"
-    runs-on: "ubuntu-latest"
+    runs-on: "${{ matrix.runs_on }}"
     steps:
     - name: "pull release library code"
       uses: "actions/checkout@v4"
@@ -245,16 +246,16 @@ jobs:
         credentials_json: "${{ secrets.GCS_SERVICE_ACCOUNT_KEY }}"
     - name: "Set up QEMU"
       uses: "docker/setup-qemu-action@v3"
-    - name: "set up docker buildx"
+    - name: "Set up Docker buildx"
       uses: "docker/setup-buildx-action@v3"
     - id: "platform"
-      name: "parse image platform"
+      name: "Parse image platform"
       run: |
-        mkdir -p images
+        mkdir -p release/images
         
-        platform="$(echo "${{ matrix.platform}}" |  sed  "s/\(.*\)\/\(.*\)/\1-\2/")"
+        platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
-        echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
+        echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
       working-directory: "release"
     - env:
         IMAGE_TAG: "${{ needs.version.outputs.version }}"
@@ -267,10 +268,10 @@ jobs:
         context: "release"
         file: "release/clients/cmd/fluentd/Dockerfile"
         outputs: "type=docker,dest=release/images/fluent-plugin-loki-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
-        platforms: "${{ matrix.platform }}"
+        platforms: "${{ matrix.arch }}"
         tags: "${{ env.IMAGE_PREFIX }}/fluent-plugin-loki:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
     - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
-      name: "upload artifacts"
+      name: "Upload artifacts"
       uses: "google-github-actions/upload-cloud-storage@v2"
       with:
         destination: "${{ env.BUILD_ARTIFACTS_BUCKET }}/${{ github.sha }}/images"
@@ -279,12 +280,13 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        platform:
-        - "linux/amd64"
+        include:
+        - arch: "linux/amd64"
+          runs_on: "ubuntu-amd64"
   logcli:
     needs:
     - "version"
-    runs-on: "ubuntu-latest"
+    runs-on: "${{ matrix.runs_on }}"
     steps:
     - name: "pull release library code"
       uses: "actions/checkout@v4"
@@ -307,16 +309,16 @@ jobs:
         credentials_json: "${{ secrets.GCS_SERVICE_ACCOUNT_KEY }}"
     - name: "Set up QEMU"
       uses: "docker/setup-qemu-action@v3"
-    - name: "set up docker buildx"
+    - name: "Set up Docker buildx"
       uses: "docker/setup-buildx-action@v3"
     - id: "platform"
-      name: "parse image platform"
+      name: "Parse image platform"
       run: |
-        mkdir -p images
+        mkdir -p release/images
         
-        platform="$(echo "${{ matrix.platform}}" |  sed  "s/\(.*\)\/\(.*\)/\1-\2/")"
+        platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
-        echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
+        echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
       working-directory: "release"
     - env:
         IMAGE_TAG: "${{ needs.version.outputs.version }}"
@@ -329,10 +331,10 @@ jobs:
         context: "release"
         file: "release/cmd/logcli/Dockerfile"
         outputs: "type=docker,dest=release/images/logcli-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
-        platforms: "${{ matrix.platform }}"
+        platforms: "${{ matrix.arch }}"
         tags: "${{ env.IMAGE_PREFIX }}/logcli:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
     - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
-      name: "upload artifacts"
+      name: "Upload artifacts"
       uses: "google-github-actions/upload-cloud-storage@v2"
       with:
         destination: "${{ env.BUILD_ARTIFACTS_BUCKET }}/${{ github.sha }}/images"
@@ -341,14 +343,17 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        platform:
-        - "linux/amd64"
-        - "linux/arm64"
-        - "linux/arm"
+        include:
+        - arch: "linux/amd64"
+          runs_on: "ubuntu-amd64"
+        - arch: "linux/arm64"
+          runs_on: "ubuntu-arm64"
+        - arch: "linux/arm"
+          runs_on: "ubuntu-arm"
   logstash:
     needs:
     - "version"
-    runs-on: "ubuntu-latest"
+    runs-on: "${{ matrix.runs_on }}"
     steps:
     - name: "pull release library code"
       uses: "actions/checkout@v4"
@@ -371,16 +376,16 @@ jobs:
         credentials_json: "${{ secrets.GCS_SERVICE_ACCOUNT_KEY }}"
     - name: "Set up QEMU"
       uses: "docker/setup-qemu-action@v3"
-    - name: "set up docker buildx"
+    - name: "Set up Docker buildx"
       uses: "docker/setup-buildx-action@v3"
     - id: "platform"
-      name: "parse image platform"
+      name: "Parse image platform"
       run: |
-        mkdir -p images
+        mkdir -p release/images
         
-        platform="$(echo "${{ matrix.platform}}" |  sed  "s/\(.*\)\/\(.*\)/\1-\2/")"
+        platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
-        echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
+        echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
       working-directory: "release"
     - env:
         IMAGE_TAG: "${{ needs.version.outputs.version }}"
@@ -393,10 +398,10 @@ jobs:
         context: "release"
         file: "release/clients/cmd/logstash/Dockerfile"
         outputs: "type=docker,dest=release/images/logstash-output-loki-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
-        platforms: "${{ matrix.platform }}"
+        platforms: "${{ matrix.arch }}"
         tags: "${{ env.IMAGE_PREFIX }}/logstash-output-loki:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
     - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
-      name: "upload artifacts"
+      name: "Upload artifacts"
       uses: "google-github-actions/upload-cloud-storage@v2"
       with:
         destination: "${{ env.BUILD_ARTIFACTS_BUCKET }}/${{ github.sha }}/images"
@@ -405,12 +410,13 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        platform:
-        - "linux/amd64"
+        include:
+        - arch: "linux/amd64"
+          runs_on: "ubuntu-amd64"
   loki:
     needs:
     - "version"
-    runs-on: "ubuntu-latest"
+    runs-on: "${{ matrix.runs_on }}"
     steps:
     - name: "pull release library code"
       uses: "actions/checkout@v4"
@@ -433,16 +439,16 @@ jobs:
         credentials_json: "${{ secrets.GCS_SERVICE_ACCOUNT_KEY }}"
     - name: "Set up QEMU"
       uses: "docker/setup-qemu-action@v3"
-    - name: "set up docker buildx"
+    - name: "Set up Docker buildx"
       uses: "docker/setup-buildx-action@v3"
     - id: "platform"
-      name: "parse image platform"
+      name: "Parse image platform"
       run: |
-        mkdir -p images
+        mkdir -p release/images
         
-        platform="$(echo "${{ matrix.platform}}" |  sed  "s/\(.*\)\/\(.*\)/\1-\2/")"
+        platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
-        echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
+        echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
       working-directory: "release"
     - env:
         IMAGE_TAG: "${{ needs.version.outputs.version }}"
@@ -455,10 +461,10 @@ jobs:
         context: "release"
         file: "release/cmd/loki/Dockerfile"
         outputs: "type=docker,dest=release/images/loki-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
-        platforms: "${{ matrix.platform }}"
+        platforms: "${{ matrix.arch }}"
         tags: "${{ env.IMAGE_PREFIX }}/loki:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
     - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
-      name: "upload artifacts"
+      name: "Upload artifacts"
       uses: "google-github-actions/upload-cloud-storage@v2"
       with:
         destination: "${{ env.BUILD_ARTIFACTS_BUCKET }}/${{ github.sha }}/images"
@@ -467,14 +473,17 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        platform:
-        - "linux/amd64"
-        - "linux/arm64"
-        - "linux/arm"
+        include:
+        - arch: "linux/amd64"
+          runs_on: "ubuntu-amd64"
+        - arch: "linux/arm64"
+          runs_on: "ubuntu-arm64"
+        - arch: "linux/arm"
+          runs_on: "ubuntu-arm"
   loki-canary:
     needs:
     - "version"
-    runs-on: "ubuntu-latest"
+    runs-on: "${{ matrix.runs_on }}"
     steps:
     - name: "pull release library code"
       uses: "actions/checkout@v4"
@@ -497,16 +506,16 @@ jobs:
         credentials_json: "${{ secrets.GCS_SERVICE_ACCOUNT_KEY }}"
     - name: "Set up QEMU"
       uses: "docker/setup-qemu-action@v3"
-    - name: "set up docker buildx"
+    - name: "Set up Docker buildx"
       uses: "docker/setup-buildx-action@v3"
     - id: "platform"
-      name: "parse image platform"
+      name: "Parse image platform"
       run: |
-        mkdir -p images
+        mkdir -p release/images
         
-        platform="$(echo "${{ matrix.platform}}" |  sed  "s/\(.*\)\/\(.*\)/\1-\2/")"
+        platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
-        echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
+        echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
       working-directory: "release"
     - env:
         IMAGE_TAG: "${{ needs.version.outputs.version }}"
@@ -519,10 +528,10 @@ jobs:
         context: "release"
         file: "release/cmd/loki-canary/Dockerfile"
         outputs: "type=docker,dest=release/images/loki-canary-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
-        platforms: "${{ matrix.platform }}"
+        platforms: "${{ matrix.arch }}"
         tags: "${{ env.IMAGE_PREFIX }}/loki-canary:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
     - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
-      name: "upload artifacts"
+      name: "Upload artifacts"
       uses: "google-github-actions/upload-cloud-storage@v2"
       with:
         destination: "${{ env.BUILD_ARTIFACTS_BUCKET }}/${{ github.sha }}/images"
@@ -531,14 +540,17 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        platform:
-        - "linux/amd64"
-        - "linux/arm64"
-        - "linux/arm"
+        include:
+        - arch: "linux/amd64"
+          runs_on: "ubuntu-amd64"
+        - arch: "linux/arm64"
+          runs_on: "ubuntu-arm64"
+        - arch: "linux/arm"
+          runs_on: "ubuntu-arm"
   loki-canary-boringcrypto:
     needs:
     - "version"
-    runs-on: "ubuntu-latest"
+    runs-on: "${{ matrix.runs_on }}"
     steps:
     - name: "pull release library code"
       uses: "actions/checkout@v4"
@@ -561,16 +573,16 @@ jobs:
         credentials_json: "${{ secrets.GCS_SERVICE_ACCOUNT_KEY }}"
     - name: "Set up QEMU"
       uses: "docker/setup-qemu-action@v3"
-    - name: "set up docker buildx"
+    - name: "Set up Docker buildx"
       uses: "docker/setup-buildx-action@v3"
     - id: "platform"
-      name: "parse image platform"
+      name: "Parse image platform"
       run: |
-        mkdir -p images
+        mkdir -p release/images
         
-        platform="$(echo "${{ matrix.platform}}" |  sed  "s/\(.*\)\/\(.*\)/\1-\2/")"
+        platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
-        echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
+        echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
       working-directory: "release"
     - env:
         IMAGE_TAG: "${{ needs.version.outputs.version }}"
@@ -583,10 +595,10 @@ jobs:
         context: "release"
         file: "release/cmd/loki-canary-boringcrypto/Dockerfile"
         outputs: "type=docker,dest=release/images/loki-canary-boringcrypto-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
-        platforms: "${{ matrix.platform }}"
+        platforms: "${{ matrix.arch }}"
         tags: "${{ env.IMAGE_PREFIX }}/loki-canary-boringcrypto:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
     - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
-      name: "upload artifacts"
+      name: "Upload artifacts"
       uses: "google-github-actions/upload-cloud-storage@v2"
       with:
         destination: "${{ env.BUILD_ARTIFACTS_BUCKET }}/${{ github.sha }}/images"
@@ -595,10 +607,13 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        platform:
-        - "linux/amd64"
-        - "linux/arm64"
-        - "linux/arm"
+        include:
+        - arch: "linux/amd64"
+          runs_on: "ubuntu-amd64"
+        - arch: "linux/arm64"
+          runs_on: "ubuntu-arm64"
+        - arch: "linux/arm"
+          runs_on: "ubuntu-arm"
   loki-docker-driver:
     needs:
     - "version"
@@ -679,7 +694,7 @@ jobs:
   promtail:
     needs:
     - "version"
-    runs-on: "ubuntu-latest"
+    runs-on: "${{ matrix.runs_on }}"
     steps:
     - name: "pull release library code"
       uses: "actions/checkout@v4"
@@ -702,16 +717,16 @@ jobs:
         credentials_json: "${{ secrets.GCS_SERVICE_ACCOUNT_KEY }}"
     - name: "Set up QEMU"
       uses: "docker/setup-qemu-action@v3"
-    - name: "set up docker buildx"
+    - name: "Set up Docker buildx"
       uses: "docker/setup-buildx-action@v3"
     - id: "platform"
-      name: "parse image platform"
+      name: "Parse image platform"
       run: |
-        mkdir -p images
+        mkdir -p release/images
         
-        platform="$(echo "${{ matrix.platform}}" |  sed  "s/\(.*\)\/\(.*\)/\1-\2/")"
+        platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
-        echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
+        echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
       working-directory: "release"
     - env:
         IMAGE_TAG: "${{ needs.version.outputs.version }}"
@@ -724,10 +739,10 @@ jobs:
         context: "release"
         file: "release/clients/cmd/promtail/Dockerfile"
         outputs: "type=docker,dest=release/images/promtail-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
-        platforms: "${{ matrix.platform }}"
+        platforms: "${{ matrix.arch }}"
         tags: "${{ env.IMAGE_PREFIX }}/promtail:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
     - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
-      name: "upload artifacts"
+      name: "Upload artifacts"
       uses: "google-github-actions/upload-cloud-storage@v2"
       with:
         destination: "${{ env.BUILD_ARTIFACTS_BUCKET }}/${{ github.sha }}/images"
@@ -736,14 +751,17 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        platform:
-        - "linux/amd64"
-        - "linux/arm64"
-        - "linux/arm"
+        include:
+        - arch: "linux/amd64"
+          runs_on: "ubuntu-amd64"
+        - arch: "linux/arm64"
+          runs_on: "ubuntu-arm64"
+        - arch: "linux/arm"
+          runs_on: "ubuntu-arm"
   querytee:
     needs:
     - "version"
-    runs-on: "ubuntu-latest"
+    runs-on: "${{ matrix.runs_on }}"
     steps:
     - name: "pull release library code"
       uses: "actions/checkout@v4"
@@ -766,16 +784,16 @@ jobs:
         credentials_json: "${{ secrets.GCS_SERVICE_ACCOUNT_KEY }}"
     - name: "Set up QEMU"
       uses: "docker/setup-qemu-action@v3"
-    - name: "set up docker buildx"
+    - name: "Set up Docker buildx"
       uses: "docker/setup-buildx-action@v3"
     - id: "platform"
-      name: "parse image platform"
+      name: "Parse image platform"
       run: |
-        mkdir -p images
+        mkdir -p release/images
         
-        platform="$(echo "${{ matrix.platform}}" |  sed  "s/\(.*\)\/\(.*\)/\1-\2/")"
+        platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
-        echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
+        echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
       working-directory: "release"
     - env:
         IMAGE_TAG: "${{ needs.version.outputs.version }}"
@@ -788,10 +806,10 @@ jobs:
         context: "release"
         file: "release/cmd/querytee/Dockerfile"
         outputs: "type=docker,dest=release/images/loki-query-tee-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
-        platforms: "${{ matrix.platform }}"
+        platforms: "${{ matrix.arch }}"
         tags: "${{ env.IMAGE_PREFIX }}/loki-query-tee:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
     - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
-      name: "upload artifacts"
+      name: "Upload artifacts"
       uses: "google-github-actions/upload-cloud-storage@v2"
       with:
         destination: "${{ env.BUILD_ARTIFACTS_BUCKET }}/${{ github.sha }}/images"
@@ -800,8 +818,9 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        platform:
-        - "linux/amd64"
+        include:
+        - arch: "linux/amd64"
+          runs_on: "ubuntu-amd64"
   version:
     needs:
     - "check"

--- a/.github/workflows/patch-release-pr.yml
+++ b/.github/workflows/patch-release-pr.yml
@@ -219,7 +219,8 @@ jobs:
       matrix:
         include:
         - arch: "linux/amd64"
-          runs_on: "ubuntu-amd64"
+          runs_on:
+          - "github-hosted-ubuntu-x64-small"
   fluentd:
     needs:
     - "version"
@@ -282,7 +283,8 @@ jobs:
       matrix:
         include:
         - arch: "linux/amd64"
-          runs_on: "ubuntu-amd64"
+          runs_on:
+          - "github-hosted-ubuntu-x64-small"
   logcli:
     needs:
     - "version"
@@ -345,11 +347,14 @@ jobs:
       matrix:
         include:
         - arch: "linux/amd64"
-          runs_on: "ubuntu-amd64"
+          runs_on:
+          - "github-hosted-ubuntu-x64-small"
         - arch: "linux/arm64"
-          runs_on: "ubuntu-arm64"
+          runs_on:
+          - "github-hosted-ubuntu-arm64-small"
         - arch: "linux/arm"
-          runs_on: "ubuntu-arm"
+          runs_on:
+          - "github-hosted-ubuntu-arm64-small"
   logstash:
     needs:
     - "version"
@@ -412,7 +417,8 @@ jobs:
       matrix:
         include:
         - arch: "linux/amd64"
-          runs_on: "ubuntu-amd64"
+          runs_on:
+          - "github-hosted-ubuntu-x64-small"
   loki:
     needs:
     - "version"
@@ -475,11 +481,14 @@ jobs:
       matrix:
         include:
         - arch: "linux/amd64"
-          runs_on: "ubuntu-amd64"
+          runs_on:
+          - "github-hosted-ubuntu-x64-small"
         - arch: "linux/arm64"
-          runs_on: "ubuntu-arm64"
+          runs_on:
+          - "github-hosted-ubuntu-arm64-small"
         - arch: "linux/arm"
-          runs_on: "ubuntu-arm"
+          runs_on:
+          - "github-hosted-ubuntu-arm64-small"
   loki-canary:
     needs:
     - "version"
@@ -542,11 +551,14 @@ jobs:
       matrix:
         include:
         - arch: "linux/amd64"
-          runs_on: "ubuntu-amd64"
+          runs_on:
+          - "github-hosted-ubuntu-x64-small"
         - arch: "linux/arm64"
-          runs_on: "ubuntu-arm64"
+          runs_on:
+          - "github-hosted-ubuntu-arm64-small"
         - arch: "linux/arm"
-          runs_on: "ubuntu-arm"
+          runs_on:
+          - "github-hosted-ubuntu-arm64-small"
   loki-canary-boringcrypto:
     needs:
     - "version"
@@ -609,11 +621,14 @@ jobs:
       matrix:
         include:
         - arch: "linux/amd64"
-          runs_on: "ubuntu-amd64"
+          runs_on:
+          - "github-hosted-ubuntu-x64-small"
         - arch: "linux/arm64"
-          runs_on: "ubuntu-arm64"
+          runs_on:
+          - "github-hosted-ubuntu-arm64-small"
         - arch: "linux/arm"
-          runs_on: "ubuntu-arm"
+          runs_on:
+          - "github-hosted-ubuntu-arm64-small"
   loki-docker-driver:
     needs:
     - "version"
@@ -753,11 +768,14 @@ jobs:
       matrix:
         include:
         - arch: "linux/amd64"
-          runs_on: "ubuntu-amd64"
+          runs_on:
+          - "github-hosted-ubuntu-x64-small"
         - arch: "linux/arm64"
-          runs_on: "ubuntu-arm64"
+          runs_on:
+          - "github-hosted-ubuntu-arm64-small"
         - arch: "linux/arm"
-          runs_on: "ubuntu-arm"
+          runs_on:
+          - "github-hosted-ubuntu-arm64-small"
   querytee:
     needs:
     - "version"
@@ -820,7 +838,8 @@ jobs:
       matrix:
         include:
         - arch: "linux/amd64"
-          runs_on: "ubuntu-amd64"
+          runs_on:
+          - "github-hosted-ubuntu-x64-small"
   version:
     needs:
     - "check"

--- a/.github/workflows/patch-release-pr.yml
+++ b/.github/workflows/patch-release-pr.yml
@@ -181,8 +181,6 @@ jobs:
       uses: "google-github-actions/auth@v2"
       with:
         credentials_json: "${{ secrets.GCS_SERVICE_ACCOUNT_KEY }}"
-    - name: "Set up QEMU"
-      uses: "docker/setup-qemu-action@v3"
     - name: "Set up Docker buildx"
       uses: "docker/setup-buildx-action@v3"
     - id: "platform"
@@ -245,8 +243,6 @@ jobs:
       uses: "google-github-actions/auth@v2"
       with:
         credentials_json: "${{ secrets.GCS_SERVICE_ACCOUNT_KEY }}"
-    - name: "Set up QEMU"
-      uses: "docker/setup-qemu-action@v3"
     - name: "Set up Docker buildx"
       uses: "docker/setup-buildx-action@v3"
     - id: "platform"
@@ -309,8 +305,6 @@ jobs:
       uses: "google-github-actions/auth@v2"
       with:
         credentials_json: "${{ secrets.GCS_SERVICE_ACCOUNT_KEY }}"
-    - name: "Set up QEMU"
-      uses: "docker/setup-qemu-action@v3"
     - name: "Set up Docker buildx"
       uses: "docker/setup-buildx-action@v3"
     - id: "platform"
@@ -379,8 +373,6 @@ jobs:
       uses: "google-github-actions/auth@v2"
       with:
         credentials_json: "${{ secrets.GCS_SERVICE_ACCOUNT_KEY }}"
-    - name: "Set up QEMU"
-      uses: "docker/setup-qemu-action@v3"
     - name: "Set up Docker buildx"
       uses: "docker/setup-buildx-action@v3"
     - id: "platform"
@@ -443,8 +435,6 @@ jobs:
       uses: "google-github-actions/auth@v2"
       with:
         credentials_json: "${{ secrets.GCS_SERVICE_ACCOUNT_KEY }}"
-    - name: "Set up QEMU"
-      uses: "docker/setup-qemu-action@v3"
     - name: "Set up Docker buildx"
       uses: "docker/setup-buildx-action@v3"
     - id: "platform"
@@ -513,8 +503,6 @@ jobs:
       uses: "google-github-actions/auth@v2"
       with:
         credentials_json: "${{ secrets.GCS_SERVICE_ACCOUNT_KEY }}"
-    - name: "Set up QEMU"
-      uses: "docker/setup-qemu-action@v3"
     - name: "Set up Docker buildx"
       uses: "docker/setup-buildx-action@v3"
     - id: "platform"
@@ -583,8 +571,6 @@ jobs:
       uses: "google-github-actions/auth@v2"
       with:
         credentials_json: "${{ secrets.GCS_SERVICE_ACCOUNT_KEY }}"
-    - name: "Set up QEMU"
-      uses: "docker/setup-qemu-action@v3"
     - name: "Set up Docker buildx"
       uses: "docker/setup-buildx-action@v3"
     - id: "platform"
@@ -704,8 +690,15 @@ jobs:
       fail-fast: true
       matrix:
         platform:
-        - "linux/amd64"
-        - "linux/arm64"
+        - arch: "linux/amd64"
+          runs_on:
+          - "github-hosted-ubuntu-x64-small"
+        - arch: "linux/arm64"
+          runs_on:
+          - "github-hosted-ubuntu-arm64-small"
+        - arch: "linux/arm"
+          runs_on:
+          - "github-hosted-ubuntu-arm64-small"
   promtail:
     needs:
     - "version"
@@ -730,8 +723,6 @@ jobs:
       uses: "google-github-actions/auth@v2"
       with:
         credentials_json: "${{ secrets.GCS_SERVICE_ACCOUNT_KEY }}"
-    - name: "Set up QEMU"
-      uses: "docker/setup-qemu-action@v3"
     - name: "Set up Docker buildx"
       uses: "docker/setup-buildx-action@v3"
     - id: "platform"
@@ -800,8 +791,6 @@ jobs:
       uses: "google-github-actions/auth@v2"
       with:
         credentials_json: "${{ secrets.GCS_SERVICE_ACCOUNT_KEY }}"
-    - name: "Set up QEMU"
-      uses: "docker/setup-qemu-action@v3"
     - name: "Set up Docker buildx"
       uses: "docker/setup-buildx-action@v3"
     - id: "platform"

--- a/Makefile
+++ b/Makefile
@@ -148,6 +148,12 @@ DOC_TEMPLATE_PATH := docs/templates
 DOC_FLAGS_TEMPLATE := $(DOC_TEMPLATE_PATH)/configuration.template
 DOC_FLAGS := $(DOC_SOURCES_PATH)/shared/configuration.md
 
+.PHONY: print-env
+print-env:  # Print variables from Makefile so they can be used in GH actions
+	@echo "GO_VERSION=$(GO_VERSION)"
+	@echo "IMAGE_TAG=$(IMAGE_TAG)"
+	@echo "BUILD_IMAGE_TAG=$(BUILD_IMAGE_TAG)"
+
 ##########
 # Docker #
 ##########
@@ -836,7 +842,7 @@ ifeq ($(BUILD_IN_CONTAINER),true)
 	$(run_in_container)
 else
 	# pushd $(CURDIR)/.github && jb update && popd
-	jsonnet -SJ .github/vendor -m .github/workflows -V BUILD_IMAGE_VERSION=$(BUILD_IMAGE_TAG) .github/release-workflows.jsonnet
+	jsonnet -SJ .github/vendor -m .github/workflows -V BUILD_IMAGE_VERSION=$(BUILD_IMAGE_TAG) -V GO_VERSION=$(GO_VERSION) .github/release-workflows.jsonnet
 endif
 
 .PHONY: release-workflows-check

--- a/Makefile
+++ b/Makefile
@@ -835,7 +835,7 @@ release-workflows:
 ifeq ($(BUILD_IN_CONTAINER),true)
 	$(run_in_container)
 else
-	pushd $(CURDIR)/.github && jb update && popd
+	# pushd $(CURDIR)/.github && jb update && popd
 	jsonnet -SJ .github/vendor -m .github/workflows -V BUILD_IMAGE_VERSION=$(BUILD_IMAGE_TAG) .github/release-workflows.jsonnet
 endif
 


### PR DESCRIPTION
DO NOT MERGE. THIS PR IS FOR DEMONSTRATIONAL PURPOSE ONLY.

**What this PR does / why we need it**:

This PR changes the way how multi-arch images are built. Instead of cross-compiling on emulated architecture using multiple platforms in the `docker buildx build` command, it uses dedicated arm and amd runners to build images "natively" and later combining the resulting image digests into a multi-arch manifest.


![screenshot_20250121_150220](https://github.com/user-attachments/assets/9f3a3d82-0e64-4213-bcbe-d80bf3a658dd)

Link to [successfull workflow run](https://github.com/grafana/loki/actions/runs/12905694371).
**Duration down from ~1h15m to ~15m.**

![screenshot_20250122_101603](https://github.com/user-attachments/assets/866c0201-ecae-4b5a-b6df-eb86a0dee977)


Related pull request https://github.com/grafana/loki-release/pull/180