### PR TITLE
docs: change order of TOC

### DIFF
--- a/docs/sources/send-data/alloy/_index.md
+++ b/docs/sources/send-data/alloy/_index.md
@@ -2,7 +2,7 @@
 title: Ingesting logs to Loki using Alloy
 menuTitle:  Grafana Alloy
 description: Configuring Grafana Alloy to send logs to Loki.
-weight:  250
+weight:  100
 ---
 
 

--- a/docs/sources/send-data/otel/_index.md
+++ b/docs/sources/send-data/otel/_index.md
@@ -1,10 +1,10 @@
 ---
 title: Ingesting logs to Loki using OpenTelemetry Collector
-menuTitle:  OTel Collector
+menuTitle:  OpenTelemetry
 description: Configuring the OpenTelemetry Collector to send logs to Loki.
 aliases: 
 - ../clients/k6/
-weight:  250
+weight:  200
 ---
 
 # Ingesting logs to Loki using OpenTelemetry Collector

--- a/docs/sources/send-data/promtail/_index.md
+++ b/docs/sources/send-data/promtail/_index.md
@@ -4,7 +4,7 @@ menuTitle:  Promtail
 description: How to use the Promtail agent to ship logs to Loki
 aliases: 
 - ../clients/promtail/ # /docs/loki/latest/clients/promtail/
-weight:  200
+weight:  300
 ---
 # Promtail agent
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Based on a conversation with @cyrille-leclerc , moving Alloy and OTEL higher in the Send Data table of contents since they are the preferred clients.