### PR TITLE
chore: Differentiate clients in limits package

### DIFF
--- a/pkg/limits/frontend/config.go
+++ b/pkg/limits/frontend/config.go
@@ -6,7 +6,7 @@ import (
 )
 
 type Config struct {
-	ClientConfig ClientConfig `yaml:"client_config"`
+	ClientConfig BackendClientConfig `yaml:"client_config"`
 }
 
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
@@ -15,8 +15,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 
 func (cfg *Config) Validate() error {
 	if err := cfg.ClientConfig.GRPCClientConfig.Validate(); err != nil {
-		return fmt.Errorf("client grpc config is invalid: %w", err)
+		return fmt.Errorf("invalid gRPC client config: %w", err)
 	}
-
 	return nil
 }

--- a/pkg/limits/frontend/frontend.go
+++ b/pkg/limits/frontend/frontend.go
@@ -40,7 +40,7 @@ func New(cfg Config, ringName string, ring ring.ReadRing, limits Limits, logger 
 	var servs []services.Service
 
 	factory := ring_client.PoolAddrFunc(func(addr string) (ring_client.PoolClient, error) {
-		return NewIngestLimitsClient(cfg.ClientConfig, addr)
+		return NewIngestLimitsBackendClient(cfg.ClientConfig, addr)
 	})
 
 	pool := NewIngestLimitsClientPool(ringName, cfg.ClientConfig.PoolConfig, ring, factory, logger)


### PR DESCRIPTION
**What this PR does / why we need it**:

The limits package will have two clients: a client for the limits-frontend to connect to limits service backends, and a client for the distributor to connect to the limits-frontend. Naming both of these clients "client" will cause naming collisions and also confusion when reading godoc/source code. To avoid both of these problems, we rename the clients to IngestLimitsBackendClient and IngestLimitsFrontendClient, and do the same for their respective configs etc.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
