### PR TITLE
fix(ci): Provide correct build info for release builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ OPERATOR_IMAGE         := $(IMAGE_PREFIX)/loki-operator:$(IMAGE_TAG)
 
 # OCI (Docker) setup
 OCI_PLATFORMS  := --platform=linux/amd64,linux/arm64
-OCI_BUILD_ARGS := --build-arg GO_VERSION=$(GO_VERSION) --build-arg BUILD_IMAGE=$(BUILD_IMAGE)
+OCI_BUILD_ARGS := --build-arg GO_VERSION=$(GO_VERSION) --build-arg BUILD_IMAGE=$(BUILD_IMAGE) --build-arg IMAGE_TAG=$(IMAGE_TAG)
 OCI_PUSH_ARGS  := -o type=registry
 OCI_PUSH       := docker push
 OCI_TAG        := docker tag
@@ -612,7 +612,7 @@ loki-local-image: ## build the loki docker image locally (set LOCAL_ARCH=linux/a
 
 # Canary image
 loki-canary-image: ## build the canary docker image
-	$(OCI_BUILD) -t $(LOKI_CANARY_IMAGE) -f cmd/loki-canary/Dockerfile .
+	$(OCI_BUILD) -t $(CANARY_IMAGE) -f cmd/loki-canary/Dockerfile .
 loki-canary-boringcrypto-image:
 	$(OCI_BUILD) -t $(IMAGE_PREFIX)/loki-canary-boringcrypto:$(IMAGE_TAG) -f cmd/loki-canary-boringcrypto/Dockerfile .
 

--- a/clients/cmd/promtail/Dockerfile
+++ b/clients/cmd/promtail/Dockerfile
@@ -1,10 +1,12 @@
 ARG GO_VERSION=1.23
+ARG IMAGE_TAG
+
 FROM golang:${GO_VERSION}-bookworm as build
 
 COPY . /src/loki
 WORKDIR /src/loki
 RUN apt-get update && apt-get install -qy libsystemd-dev
-RUN make clean && make BUILD_IN_CONTAINER=false PROMTAIL_JOURNAL_ENABLED=true promtail
+RUN make clean && make BUILD_IN_CONTAINER=false PROMTAIL_JOURNAL_ENABLED=true IMAGE_TAG=${IMAGE_TAG} promtail
 
 # Promtail requires debian or ubuntu as the base image to support systemd journal reading
 FROM public.ecr.aws/ubuntu/ubuntu:noble

--- a/cmd/loki-canary-boringcrypto/Dockerfile
+++ b/cmd/loki-canary-boringcrypto/Dockerfile
@@ -1,10 +1,11 @@
 ARG GO_VERSION=1.23
+ARG IMAGE_TAG
 FROM golang:${GO_VERSION} as build
 
 COPY . /src/loki
 WORKDIR /src/loki
 RUN go env GOARCH > /goarch
-RUN make clean && make GOARCH=$(cat /goarch) BUILD_IN_CONTAINER=true GOEXPERIMENT=boringcrypto loki-canary-boringcrypto
+RUN make clean && make GOARCH=$(cat /goarch) BUILD_IN_CONTAINER=true GOEXPERIMENT=boringcrypto IMAGE_TAG=${IMAGE_TAG} loki-canary-boringcrypto
 
 FROM gcr.io/distroless/base-nossl:debug
 COPY --from=build /src/loki/cmd/loki-canary-boringcrypto/loki-canary-boringcrypto /usr/bin/loki-canary

--- a/cmd/loki-canary/Dockerfile
+++ b/cmd/loki-canary/Dockerfile
@@ -1,9 +1,10 @@
 ARG GO_VERSION=1.23
+ARG IMAGE_TAG
 FROM golang:${GO_VERSION} AS build
 
 COPY . /src/loki
 WORKDIR /src/loki
-RUN make clean && make BUILD_IN_CONTAINER=false loki-canary
+RUN make clean && make BUILD_IN_CONTAINER=false IMAGE_TAG=${IMAGE_TAG} loki-canary
 
 FROM gcr.io/distroless/static:debug
 

--- a/cmd/loki/Dockerfile
+++ b/cmd/loki/Dockerfile
@@ -1,4 +1,5 @@
 ARG GO_VERSION=1.23
+ARG IMAGE_TAG
 
 # UI build stage
 FROM node:20-alpine AS ui-builder
@@ -12,7 +13,7 @@ FROM golang:${GO_VERSION} AS build
 COPY . /src/loki
 COPY --from=ui-builder /src/loki/pkg/dataobj/explorer/dist /src/loki/pkg/dataobj/explorer/dist
 WORKDIR /src/loki
-RUN make clean && make BUILD_IN_CONTAINER=false loki
+RUN make clean && make BUILD_IN_CONTAINER=false IMAGE_TAG=${IMAGE_TAG} loki
 
 # Final stage
 FROM gcr.io/distroless/static:debug


### PR DESCRIPTION
**What this PR does / why we need it**:

Then building a binary or image release for an upcoming version from a release branch, we provide the version using `--build-arg IMAGE_TAG=...` in the Docker build step of the CI workflow ([ref](https://github.com/grafana/loki/blob/3df08bd39f45bbf8314f31a59f35b955b9a31a5e/.github/workflows/minor-release-pr.yml#L456)).

However, this argument was ignored in the Dockerfile and not further passed down to the `make ...` command inside build phase of the Dockerfile.

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
