### PR TITLE
feat(chunks): support custom MaxIdleConns and MaxIdleConnsPerHost in AWS s3 storage client

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -1142,6 +1142,16 @@ http_config:
   # CLI flag: -s3.http.idle-conn-timeout
   [idle_conn_timeout: <duration> | default = 1m30s]
 
+  # Maximum number of idle (keep-alive) connections across all hosts. Set to 0
+  # for no limit.
+  # CLI flag: -s3.http.max-idle-connections
+  [max_idle_connections: <int> | default = 200]
+
+  # Maximum number of idle (keep-alive) connections to keep per-host. Set to 0
+  # to use a built-in default value of 2.
+  # CLI flag: -s3.http.max-idle-connections-per-host
+  [max_idle_connections_per_host: <int> | default = 200]
+
   # If non-zero, specifies the amount of time to wait for a server's response
   # headers after fully writing the request.
   # CLI flag: -s3.http.response-header-timeout
@@ -5154,6 +5164,16 @@ http_config:
   # The maximum amount of time an idle connection will be held open.
   # CLI flag: -<prefix>.storage.s3.http.idle-conn-timeout
   [idle_conn_timeout: <duration> | default = 1m30s]
+
+  # Maximum number of idle (keep-alive) connections across all hosts. Set to 0
+  # for no limit.
+  # CLI flag: -<prefix>.storage.s3.http.max-idle-connections
+  [max_idle_connections: <int> | default = 200]
+
+  # Maximum number of idle (keep-alive) connections to keep per-host. Set to 0
+  # to use a built-in default value of 2.
+  # CLI flag: -<prefix>.storage.s3.http.max-idle-connections-per-host
+  [max_idle_connections_per_host: <int> | default = 200]
 
   # If non-zero, specifies the amount of time to wait for a server's response
   # headers after fully writing the request.


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, the S3 client used by chunks has the `MaxIdleConns` and `MaxIdleConnsPerHost` hardcoded with 200 values. This PR allows both values to be configurable from the client side but keeps the previous hardcoded values as default values.

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [X] Documentation added
- [X] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
