### PR TITLE
fix: Fix label values query when server.http_path_prefix is set

### DIFF
--- a/pkg/querier/queryrange/roundtrip.go
+++ b/pkg/querier/queryrange/roundtrip.go
@@ -506,32 +506,34 @@ func getOperation(path string) string {
 	switch {
 	case strings.HasSuffix(path, "/query_range") || strings.HasSuffix(path, "/prom/query"):
 		return QueryRangeOp
+	case strings.HasSuffix(path, "/query"):
+		return InstantQueryOp
 	case strings.HasSuffix(path, "/series"):
 		return SeriesOp
 	case strings.HasSuffix(path, "/labels") || strings.HasSuffix(path, "/label"):
 		return LabelNamesOp
-	case strings.HasSuffix(path, "/v1/query"):
-		return InstantQueryOp
-	case path == "/loki/api/v1/index/stats":
+	case strings.HasSuffix(path, "/index/stats"):
 		return IndexStatsOp
-	case path == "/loki/api/v1/index/volume":
+	case strings.HasSuffix(path, "/index/volume"):
 		return VolumeOp
-	case path == "/loki/api/v1/index/volume_range":
+	case strings.HasSuffix(path, "/index/volume_range"):
 		return VolumeRangeOp
-	case path == "/loki/api/v1/index/shards":
+	case strings.HasSuffix(path, "/index/shards"):
 		return IndexShardsOp
-	case path == "/loki/api/v1/detected_fields":
+	case strings.HasSuffix(path, "/detected_fields"):
 		return DetectedFieldsOp
+	case strings.HasSuffix(path, "/patterns"):
+		return PatternsQueryOp
+	case strings.HasSuffix(path, "/detected_labels"):
+		return DetectedLabelsOp
 	case strings.HasSuffix(path, "/values"):
-		if strings.HasPrefix(path, "/loki/api/v1/label") || strings.HasPrefix(path, "/api/prom/label") {
+		if strings.Contains(path, "/label") {
 			return LabelNamesOp
 		}
-
-		return DetectedFieldsOp
-	case path == "/loki/api/v1/patterns":
-		return PatternsQueryOp
-	case path == "/loki/api/v1/detected_labels":
-		return DetectedLabelsOp
+		if strings.Contains(path, "/detected_field") {
+			return DetectedFieldsOp
+		}
+		return ""
 	default:
 		return ""
 	}

--- a/pkg/querier/queryrange/roundtrip_test.go
+++ b/pkg/querier/queryrange/roundtrip_test.go
@@ -1273,11 +1273,14 @@ func Test_getOperation(t *testing.T) {
 		},
 	}
 
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			got := getOperation(tc.path)
-			assert.Equal(t, tc.expectedOp, got)
-		})
+	for _, pathPrefix := range []string{"", "/proxy"} {
+		for _, tc := range cases {
+			name := tc.name + pathPrefix + tc.path
+			t.Run(name, func(t *testing.T) {
+				got := getOperation(pathPrefix + tc.path)
+				assert.Equal(t, tc.expectedOp, got)
+			})
+		}
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit fixes a bug in the query range round tripper. It fixes the detection of the operation when decoding a HTTP request into a queryrange request object by comparing the path suffix rather than the equality of the full path.

**Which issue(s) this PR fixes**:
Fixes #15585

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
