### PR TITLE
feat: add client for limits-frontend service

### DIFF
--- a/pkg/limits/frontend/client/client.go
+++ b/pkg/limits/frontend/client/client.go
@@ -33,15 +33,15 @@ var (
 	}, []string{"operation", "status_code"})
 )
 
-// ClientConfig contains the config for an ingest-limits-frontend client.
-type ClientConfig struct {
+// Config contains the config for an ingest-limits-frontend client.
+type Config struct {
 	GRPCClientConfig             grpcclient.Config              `yaml:"grpc_client_config" doc:"description=Configures client gRPC connections to limits service."`
 	PoolConfig                   PoolConfig                     `yaml:"pool_config,omitempty" doc:"description=Configures client gRPC connections pool to limits service."`
 	GRPCUnaryClientInterceptors  []grpc.UnaryClientInterceptor  `yaml:"-"`
 	GRCPStreamClientInterceptors []grpc.StreamClientInterceptor `yaml:"-"`
 }
 
-func (cfg *ClientConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
+func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	cfg.GRPCClientConfig.RegisterFlagsWithPrefix(prefix+".limits-frontend-client", f)
 	cfg.PoolConfig.RegisterFlagsWithPrefix(prefix, f)
 }
@@ -68,7 +68,7 @@ type IngestLimitsFrontendClient struct {
 
 // NewIngestLimitsFrontendClient returns a new IngestLimitsFrontendClient for the
 // specified ingest-limits-frontend.
-func NewIngestLimitsFrontendClient(cfg ClientConfig, addr string) (*IngestLimitsFrontendClient, error) {
+func NewIngestLimitsFrontendClient(cfg Config, addr string) (*IngestLimitsFrontendClient, error) {
 	opts := []grpc.DialOption{
 		grpc.WithDefaultCallOptions(cfg.GRPCClientConfig.CallOptions()...),
 	}
@@ -89,8 +89,8 @@ func NewIngestLimitsFrontendClient(cfg ClientConfig, addr string) (*IngestLimits
 	}, nil
 }
 
-// getInterceptors returns the gRPC interceptors for the given ClientConfig.
-func getGRPCInterceptors(cfg *ClientConfig) ([]grpc.UnaryClientInterceptor, []grpc.StreamClientInterceptor) {
+// getInterceptors returns the gRPC interceptors for the given Config.
+func getGRPCInterceptors(cfg *Config) ([]grpc.UnaryClientInterceptor, []grpc.StreamClientInterceptor) {
 	var (
 		unaryInterceptors  []grpc.UnaryClientInterceptor
 		streamInterceptors []grpc.StreamClientInterceptor

--- a/pkg/limits/frontend/client/client.go
+++ b/pkg/limits/frontend/client/client.go
@@ -1,0 +1,128 @@
+package client
+
+import (
+	"flag"
+	"io"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/dskit/grpcclient"
+	"github.com/grafana/dskit/middleware"
+	"github.com/grafana/dskit/ring"
+	ring_client "github.com/grafana/dskit/ring/client"
+	"github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc"
+	"github.com/opentracing/opentracing-go"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/health/grpc_health_v1"
+
+	"github.com/grafana/loki/v3/pkg/logproto"
+	"github.com/grafana/loki/v3/pkg/util/server"
+)
+
+var (
+	frontendClients = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "loki_ingest_limits_frontend_clients",
+		Help: "The current number of ingest limits frontend clients.",
+	})
+	frontendRequestDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "loki_ingest_limits_frontend_client_request_duration_seconds",
+		Help:    "Time spent doing ingest limits frontend requests.",
+		Buckets: prometheus.ExponentialBuckets(0.001, 4, 6),
+	}, []string{"operation", "status_code"})
+)
+
+// ClientConfig contains the config for an ingest-limits-frontend client.
+type ClientConfig struct {
+	GRPCClientConfig             grpcclient.Config              `yaml:"grpc_client_config" doc:"description=Configures client gRPC connections to limits service."`
+	PoolConfig                   PoolConfig                     `yaml:"pool_config,omitempty" doc:"description=Configures client gRPC connections pool to limits service."`
+	GRPCUnaryClientInterceptors  []grpc.UnaryClientInterceptor  `yaml:"-"`
+	GRCPStreamClientInterceptors []grpc.StreamClientInterceptor `yaml:"-"`
+}
+
+func (cfg *ClientConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
+	cfg.GRPCClientConfig.RegisterFlagsWithPrefix(prefix+".limits-frontend-client", f)
+	cfg.PoolConfig.RegisterFlagsWithPrefix(prefix, f)
+}
+
+// PoolConfig contains the config for a pool of ingest-limits-frontend clients.
+type PoolConfig struct {
+	ClientCleanupPeriod     time.Duration `yaml:"client_cleanup_period"`
+	HealthCheckIngestLimits bool          `yaml:"health_check_ingest_limits"`
+	RemoteTimeout           time.Duration `yaml:"remote_timeout"`
+}
+
+func (cfg *PoolConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
+	f.DurationVar(&cfg.ClientCleanupPeriod, prefix+".client-cleanup-period", 15*time.Second, "How frequently to clean up clients for ingest-limits-frontend that have gone away.")
+	f.BoolVar(&cfg.HealthCheckIngestLimits, prefix+".health-check-ingest-limits", true, "Run a health check on each ingest-limits-frontend client during periodic cleanup.")
+	f.DurationVar(&cfg.RemoteTimeout, prefix+".remote-timeout", 1*time.Second, "Timeout for the health check.")
+}
+
+// IngestLimitsFrontendClient is a gRPC client for the ingest-limits-frontend.
+type IngestLimitsFrontendClient struct {
+	logproto.IngestLimitsFrontendClient
+	grpc_health_v1.HealthClient
+	io.Closer
+}
+
+// NewIngestLimitsFrontendClient returns a new IngestLimitsFrontendClient for the
+// specified ingest-limits-frontend.
+func NewIngestLimitsFrontendClient(cfg ClientConfig, addr string) (*IngestLimitsFrontendClient, error) {
+	opts := []grpc.DialOption{
+		grpc.WithDefaultCallOptions(cfg.GRPCClientConfig.CallOptions()...),
+	}
+	dialOpts, err := cfg.GRPCClientConfig.DialOption(getGRPCInterceptors(&cfg))
+	if err != nil {
+		return nil, err
+	}
+	opts = append(opts, dialOpts...)
+	// nolint:staticcheck // grpc.Dial() has been deprecated; we'll address it before upgrading to gRPC 2.
+	conn, err := grpc.Dial(addr, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return &IngestLimitsFrontendClient{
+		IngestLimitsFrontendClient: logproto.NewIngestLimitsFrontendClient(conn),
+		HealthClient:               grpc_health_v1.NewHealthClient(conn),
+		Closer:                     conn,
+	}, nil
+}
+
+// getInterceptors returns the gRPC interceptors for the given ClientConfig.
+func getGRPCInterceptors(cfg *ClientConfig) ([]grpc.UnaryClientInterceptor, []grpc.StreamClientInterceptor) {
+	var (
+		unaryInterceptors  []grpc.UnaryClientInterceptor
+		streamInterceptors []grpc.StreamClientInterceptor
+	)
+
+	unaryInterceptors = append(unaryInterceptors, cfg.GRPCUnaryClientInterceptors...)
+	unaryInterceptors = append(unaryInterceptors, server.UnaryClientQueryTagsInterceptor)
+	unaryInterceptors = append(unaryInterceptors, server.UnaryClientHTTPHeadersInterceptor)
+	unaryInterceptors = append(unaryInterceptors, otgrpc.OpenTracingClientInterceptor(opentracing.GlobalTracer()))
+	unaryInterceptors = append(unaryInterceptors, middleware.UnaryClientInstrumentInterceptor(frontendRequestDuration))
+
+	streamInterceptors = append(streamInterceptors, cfg.GRCPStreamClientInterceptors...)
+	streamInterceptors = append(streamInterceptors, server.StreamClientQueryTagsInterceptor)
+	streamInterceptors = append(streamInterceptors, server.StreamClientHTTPHeadersInterceptor)
+	streamInterceptors = append(streamInterceptors, otgrpc.OpenTracingStreamClientInterceptor(opentracing.GlobalTracer()))
+	streamInterceptors = append(streamInterceptors, middleware.StreamClientInstrumentInterceptor(frontendRequestDuration))
+
+	return unaryInterceptors, streamInterceptors
+}
+
+// NewIngestLimitsFrontendClientPool returns a new pool of IngestLimitsFrontendClients.
+func NewIngestLimitsFrontendClientPool(
+	name string,
+	cfg PoolConfig,
+	ring ring.ReadRing,
+	factory ring_client.PoolFactory,
+	logger log.Logger,
+) *ring_client.Pool {
+	poolCfg := ring_client.PoolConfig{
+		CheckInterval:      cfg.ClientCleanupPeriod,
+		HealthCheckEnabled: cfg.HealthCheckIngestLimits,
+		HealthCheckTimeout: cfg.RemoteTimeout,
+	}
+	return ring_client.NewPool(name, poolCfg, ring_client.NewRingServiceDiscovery(ring), factory, frontendClients, logger)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request adds a client for `limits-frontend` service. It will be used in distributors to make queries to the limits service.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
