### PR TITLE
chore: move ingest-limits/ring inside check for internal server

### DIFF
--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -398,6 +398,7 @@ func (t *Loki) initIngestLimitsRing() (_ services.Service, err error) {
 		return nil, nil
 	}
 
+	// Members of the ring are expected to listen on their gRPC server port.
 	t.Cfg.IngestLimits.LifecyclerConfig.ListenPort = t.Cfg.Server.GRPCListenPort
 
 	reg := prometheus.WrapRegistererWithPrefix(t.Cfg.MetricsNamespace+"_", prometheus.DefaultRegisterer)
@@ -410,10 +411,9 @@ func (t *Loki) initIngestLimitsRing() (_ services.Service, err error) {
 		reg,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create %s ring: %w", limits.RingName, err)
+		return nil, fmt.Errorf("failed to create %s ingest-limits ring: %w", limits.RingName, err)
 	}
 
-	t.Server.HTTP.Path("/ingest-limits/ring").Methods("GET", "POST").Handler(t.ingestLimitsRing)
 	if t.Cfg.InternalServer.Enable {
 		t.InternalServer.HTTP.Path("/ingest-limits/ring").Methods("GET", "POST").Handler(t.ingestLimitsRing)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request moves registration of the HTTP handler for `ingest-limits/ring` inside the check for `t.Cfg.InternalServer.Enable`.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
