### PR TITLE
ci: Move IMAGE_TAG Dockerfile ARG into build phase

### DIFF
--- a/clients/cmd/promtail/Dockerfile
+++ b/clients/cmd/promtail/Dockerfile
@@ -1,7 +1,7 @@
 ARG GO_VERSION=1.23
-ARG IMAGE_TAG
 
 FROM golang:${GO_VERSION}-bookworm as build
+ARG IMAGE_TAG
 
 COPY . /src/loki
 WORKDIR /src/loki

--- a/cmd/loki-canary-boringcrypto/Dockerfile
+++ b/cmd/loki-canary-boringcrypto/Dockerfile
@@ -1,6 +1,6 @@
 ARG GO_VERSION=1.23
-ARG IMAGE_TAG
 FROM golang:${GO_VERSION} as build
+ARG IMAGE_TAG
 
 COPY . /src/loki
 WORKDIR /src/loki

--- a/cmd/loki-canary/Dockerfile
+++ b/cmd/loki-canary/Dockerfile
@@ -1,6 +1,6 @@
 ARG GO_VERSION=1.23
-ARG IMAGE_TAG
 FROM golang:${GO_VERSION} AS build
+ARG IMAGE_TAG
 
 COPY . /src/loki
 WORKDIR /src/loki

--- a/cmd/loki/Dockerfile
+++ b/cmd/loki/Dockerfile
@@ -1,5 +1,4 @@
 ARG GO_VERSION=1.23
-ARG IMAGE_TAG
 
 # UI build stage
 FROM node:20-alpine AS ui-builder
@@ -10,6 +9,7 @@ RUN make -C pkg/dataobj/explorer/ui build
 
 # Go build stage
 FROM golang:${GO_VERSION} AS build
+ARG IMAGE_TAG
 COPY . /src/loki
 COPY --from=ui-builder /src/loki/pkg/dataobj/explorer/dist /src/loki/pkg/dataobj/explorer/dist
 WORKDIR /src/loki

--- a/cmd/querytee/Dockerfile
+++ b/cmd/querytee/Dockerfile
@@ -1,9 +1,10 @@
 ARG GO_VERSION=1.23
 FROM golang:${GO_VERSION} as build
+ARG IMAGE_TAG
 
 COPY . /src/loki
 WORKDIR /src/loki
-RUN make clean && make BUILD_IN_CONTAINER=false loki-querytee
+RUN make clean && make BUILD_IN_CONTAINER=false IMAGE_TAG=${IMAGE_TAG} loki-querytee
 
 FROM gcr.io/distroless/static:debug
 COPY --from=build /src/loki/cmd/querytee/querytee /usr/bin/querytee


### PR DESCRIPTION
**What this PR does / why we need it**:

In order to access the variable ${IMAGE_TAG} that is provided as `--build-arg IMAGE_TAG=x.x.x` in the `docker build` command, the `ARG` definition in the Dockerfile needs to be inside the build step block, otherwise it is empty.

**Special notes for your reviewer**:

Fix for ##15939