### PR TITLE
chore(blooms): Return decompression reader to pool

### DIFF
--- a/pkg/storage/bloom/v1/index.go
+++ b/pkg/storage/bloom/v1/index.go
@@ -102,6 +102,7 @@ func (b *BlockIndex) NewSeriesPageDecoder(r io.ReadSeeker, header SeriesPageHead
 	if err != nil {
 		return nil, errors.Wrap(err, "getting decompressor")
 	}
+	defer b.opts.Schema.DecompressorPool().PutReader(decompressor)
 
 	decompressed := make([]byte, header.DecompressedLen)
 	if _, err = io.ReadFull(decompressor, decompressed); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
This function was getting a decompression reader from the pool but not returning it (as far as I can see) so I added that in.

The decompressor only seems to be used within the scope of this function so returning it in a defer should be safe.