### PR TITLE
chore: upload delete requests table only when there are updates since last upload

### DIFF
--- a/pkg/compactor/deletion/delete_requests_manager.go
+++ b/pkg/compactor/deletion/delete_requests_manager.go
@@ -112,6 +112,12 @@ func (d *DeleteRequestsManager) mergeShardedRequests(ctx context.Context) error 
 			continue
 		}
 
+		level.Info(util_log.Logger).Log("msg", "merging sharded request",
+			"request_id", req.RequestID,
+			"num_shards", len(deletesPerRequest),
+			"start_time", req.StartTime.Unix(),
+			"end_time", req.EndTime.Unix(),
+		)
 		if err := d.deleteRequestsStore.MergeShardedRequests(ctx, req, deletesPerRequest[req.RequestID]); err != nil {
 			return err
 		}

--- a/pkg/compactor/deletion/delete_requests_table.go
+++ b/pkg/compactor/deletion/delete_requests_table.go
@@ -24,6 +24,8 @@ import (
 type deleteRequestsTable struct {
 	indexStorageClient storage.Client
 	dbPath             string
+	updatedAt          time.Time
+	uploadedAt         time.Time
 
 	boltdbIndexClient *local.BoltIndexClient
 	db                *bbolt.DB
@@ -98,6 +100,10 @@ func (t *deleteRequestsTable) loop() {
 }
 
 func (t *deleteRequestsTable) uploadFile() error {
+	if t.uploadedAt.After(t.updatedAt) {
+		level.Debug(util_log.Logger).Log("msg", "skipping uploading delete requests db since there have been no updates to the table since last upload")
+		return nil
+	}
 	level.Debug(util_log.Logger).Log("msg", "uploading delete requests db")
 
 	tempFilePath := fmt.Sprintf("%s.%s", t.dbPath, tempFileSuffix)
@@ -144,7 +150,12 @@ func (t *deleteRequestsTable) uploadFile() error {
 		return err
 	}
 
-	return t.indexStorageClient.PutFile(context.Background(), DeleteRequestsTableName, deleteRequestsIndexFileName, f)
+	if err := t.indexStorageClient.PutFile(context.Background(), DeleteRequestsTableName, deleteRequestsIndexFileName, f); err != nil {
+		return err
+	}
+
+	t.uploadedAt = time.Now()
+	return nil
 }
 
 func (t *deleteRequestsTable) Stop() {
@@ -178,6 +189,7 @@ func (t *deleteRequestsTable) BatchWrite(ctx context.Context, batch index.WriteB
 		}
 	}
 
+	t.updatedAt = time.Now()
 	return nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
We upload delete requests db every 5 mins, irrespective of whether there are any updates.
This PR changes it to upload the db only when there have been any updates since the last upload. This would reduce unnecessary work and make incrementally updated versions easier to recover from object storage.
