### PR TITLE
chore(build): Update workflow to leverage updates to latest GH and Docker tags

### DIFF
--- a/.github/jsonnetfile.json
+++ b/.github/jsonnetfile.json
@@ -8,7 +8,7 @@
           "subdir": "workflows"
         }
       },
-      "version": "5343bc71d96dc4247021a66c3da8fd5cd4c957dd"
+      "version": "965213a0fe2632438ab0524d606cb71d414e2388"
     }
   ],
   "legacyImports": true

--- a/.github/jsonnetfile.lock.json
+++ b/.github/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "workflows"
         }
       },
-      "version": "5343bc71d96dc4247021a66c3da8fd5cd4c957dd",
-      "sum": "/+ozeV2rndtz8N3cZmrWxbNJFI7fkwoDzhECMHG1RoA="
+      "version": "965213a0fe2632438ab0524d606cb71d414e2388",
+      "sum": "DXmqwVyytIhA0tHlMQUCLD8buVjjCb04YcIxJ3BLFqM="
     }
   ],
   "legacyImports": false

--- a/.github/vendor/github.com/grafana/loki-release/workflows/release.libsonnet
+++ b/.github/vendor/github.com/grafana/loki-release/workflows/release.libsonnet
@@ -182,6 +182,7 @@ local pullRequestFooter = 'Merging this PR will release the [artifacts](https://
         + step.with({
           imageDir: 'images',
           imagePrefix: '${{ env.IMAGE_PREFIX }}',
+          isLatest: '${{ needs.createRelease.outputs.isLatest }}',
         }),
       ]
     ),
@@ -219,6 +220,7 @@ local pullRequestFooter = 'Merging this PR will release the [artifacts](https://
           imagePrefix: '${{ env.IMAGE_PREFIX }}',
           isPlugin: true,
           buildDir: 'release/%s' % path,
+          isLatest: '${{ needs.createRelease.outputs.isLatest }}',
         }),
       ]
     ),

--- a/.github/vendor/github.com/grafana/loki-release/workflows/workflows.jsonnet
+++ b/.github/vendor/github.com/grafana/loki-release/workflows/workflows.jsonnet
@@ -10,13 +10,13 @@ local dockerPluginDir = 'clients/cmd/docker-driver';
     lokiRelease.releasePRWorkflow(
       imageJobs={
         loki: build.image('fake-loki', 'cmd/loki'),
-        'loki-docker-driver': build.dockerPlugin('loki-docker-driver', dockerPluginDir, buildImage=buildImage, platform=['linux/amd64', 'linux/arm64']),
+        'loki-docker-driver': build.dockerPlugin('loki-docker-driver', dockerPluginDir, buildImage=buildImage),
       },
       buildImage=buildImage,
       buildArtifactsBucket='loki-build-artifacts',
       branches=['release-[0-9]+.[0-9]+.x'],
       imagePrefix='trevorwhitney075',
-      releaseLibRef='release-1.14.x',
+      releaseLibRef='main',
       releaseRepo='grafana/loki-release',
       skipValidation=false,
       versioningStrategy='always-bump-patch',
@@ -28,14 +28,14 @@ local dockerPluginDir = 'clients/cmd/docker-driver';
     lokiRelease.releasePRWorkflow(
       imageJobs={
         loki: build.image('fake-loki', 'cmd/loki'),
-        'loki-docker-driver': build.dockerPlugin('loki-docker-driver', dockerPluginDir, buildImage=buildImage, platform=['linux/amd64', 'linux/arm64']),
+        'loki-docker-driver': build.dockerPlugin('loki-docker-driver', dockerPluginDir, buildImage=buildImage),
       },
       buildImage=buildImage,
       buildArtifactsBucket='loki-build-artifacts',
       branches=['release-[0-9]+.[0-9]+.x'],
       dryRun=true,
       imagePrefix='trevorwhitney075',
-      releaseLibRef='release-1.14.x',
+      releaseLibRef='main',
       releaseRepo='grafana/loki-release',
       skipValidation=false,
       versioningStrategy='always-bump-patch',
@@ -54,7 +54,7 @@ local dockerPluginDir = 'clients/cmd/docker-driver';
       getDockerCredsFromVault=false,
       imagePrefix='trevorwhitney075',
       pluginBuildDir=dockerPluginDir,
-      releaseLibRef='release-1.14.x',
+      releaseLibRef='main',
       releaseRepo='grafana/loki-release',
       useGitHubAppToken=true,
     ) + {

--- a/.github/workflows/minor-release-pr.yml
+++ b/.github/workflows/minor-release-pr.yml
@@ -618,7 +618,7 @@ jobs:
   loki-docker-driver:
     needs:
     - "version"
-    runs-on: "ubuntu-latest"
+    runs-on: "${{ matrix.runs_on }}"
     steps:
     - name: "pull release library code"
       uses: "actions/checkout@v4"
@@ -649,9 +649,9 @@ jobs:
         mkdir -p images
         mkdir -p plugins
         
-        platform="$(echo "${{ matrix.platform}}" |  sed  "s/\(.*\)\/\(.*\)/\1-\2/")"
+        platform="$(echo "${{ matrix.arch}}" |  sed  "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
-        echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
+        echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
         if [[ "${platform}" == "linux/arm64" ]]; then
           echo "plugin_arch=-arm64" >> $GITHUB_OUTPUT
         else
@@ -670,7 +670,7 @@ jobs:
         context: "release"
         file: "release/clients/cmd/docker-driver/Dockerfile"
         outputs: "type=local,dest=release/plugins/loki-docker-driver-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}"
-        platforms: "${{ matrix.platform }}"
+        platforms: "${{ matrix.arch }}"
         push: false
         tags: "${{ env.IMAGE_PREFIX }}/loki-docker-driver:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
     - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
@@ -689,7 +689,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        platform:
+        include:
         - arch: "linux/amd64"
           runs_on:
           - "github-hosted-ubuntu-x64-small"

--- a/.github/workflows/patch-release-pr.yml
+++ b/.github/workflows/patch-release-pr.yml
@@ -618,7 +618,7 @@ jobs:
   loki-docker-driver:
     needs:
     - "version"
-    runs-on: "ubuntu-latest"
+    runs-on: "${{ matrix.runs_on }}"
     steps:
     - name: "pull release library code"
       uses: "actions/checkout@v4"
@@ -649,9 +649,9 @@ jobs:
         mkdir -p images
         mkdir -p plugins
         
-        platform="$(echo "${{ matrix.platform}}" |  sed  "s/\(.*\)\/\(.*\)/\1-\2/")"
+        platform="$(echo "${{ matrix.arch}}" |  sed  "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
-        echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
+        echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
         if [[ "${platform}" == "linux/arm64" ]]; then
           echo "plugin_arch=-arm64" >> $GITHUB_OUTPUT
         else
@@ -670,7 +670,7 @@ jobs:
         context: "release"
         file: "release/clients/cmd/docker-driver/Dockerfile"
         outputs: "type=local,dest=release/plugins/loki-docker-driver-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}"
-        platforms: "${{ matrix.platform }}"
+        platforms: "${{ matrix.arch }}"
         push: false
         tags: "${{ env.IMAGE_PREFIX }}/loki-docker-driver:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
     - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
@@ -689,7 +689,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        platform:
+        include:
         - arch: "linux/amd64"
           runs_on:
           - "github-hosted-ubuntu-x64-small"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,6 +151,7 @@ jobs:
         buildDir: "release/clients/cmd/docker-driver"
         imageDir: "plugins"
         imagePrefix: "${{ env.IMAGE_PREFIX }}"
+        isLatest: "${{ needs.createRelease.outputs.isLatest }}"
         isPlugin: true
   publishImages:
     needs:
@@ -186,6 +187,7 @@ jobs:
       with:
         imageDir: "images"
         imagePrefix: "${{ env.IMAGE_PREFIX }}"
+        isLatest: "${{ needs.createRelease.outputs.isLatest }}"
   publishRelease:
     needs:
     - "createRelease"


### PR DESCRIPTION

**What this PR does / why we need it**:
Restores the automatic setting of the `latest` tag for both GitHub and DockerHub images.

**Which issue(s) this PR fixes**:
Relates to https://github.com/grafana/loki-release/pull/206

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [X] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
