### PR TITLE
chore(dataobj): support computation of min/max values in pages and columns

### DIFF
--- a/pkg/dataobj/internal/dataset/column_builder.go
+++ b/pkg/dataobj/internal/dataset/column_builder.go
@@ -202,15 +202,10 @@ func (cb *ColumnBuilder) buildStats() *datasetmd.Statistics {
 			panic(fmt.Sprintf("ColumnBuilder.buildStats: failed to unmarshal max value: %s", err))
 		}
 
-		if i == 0 {
-			minValue, maxValue = pageMin, pageMax
-			continue
-		}
-
-		if CompareValues(pageMin, minValue) < 0 {
+		if i == 0 || CompareValues(pageMin, minValue) < 0 {
 			minValue = pageMin
 		}
-		if CompareValues(pageMax, maxValue) > 0 {
+		if i == 0 || CompareValues(pageMax, maxValue) > 0 {
 			maxValue = pageMax
 		}
 	}

--- a/pkg/dataobj/internal/dataset/column_builder.go
+++ b/pkg/dataobj/internal/dataset/column_builder.go
@@ -162,12 +162,6 @@ func (cb *ColumnBuilder) Flush() (*MemColumn, error) {
 		Statistics:  cb.buildStats(),
 	}
 
-	// TODO(rfratto): Should we compute column-wide statistics if they're
-	// available in pages?
-	//
-	// That would potentially work for min/max values, but not for count
-	// distinct, unless we had a way to pass sketches around.
-
 	for _, page := range cb.pages {
 		info.RowsCount += page.Info.RowCount
 		info.ValuesCount += page.Info.ValuesCount

--- a/pkg/dataobj/internal/dataset/column_test.go
+++ b/pkg/dataobj/internal/dataset/column_test.go
@@ -1,6 +1,7 @@
 package dataset
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -60,4 +61,85 @@ func TestColumnBuilder_ReadWrite(t *testing.T) {
 		}
 	}
 	require.Equal(t, in, actual)
+}
+
+func TestColumnBuilder_MinMax(t *testing.T) {
+	var (
+		// We include the null string in the test to ensure that it's never
+		// considered in min/max ranges.
+		nullString = ""
+
+		aString = strings.Repeat("a", 100)
+		bString = strings.Repeat("b", 100)
+		cString = strings.Repeat("c", 100)
+
+		dString = strings.Repeat("d", 100)
+		eString = strings.Repeat("e", 100)
+		fString = strings.Repeat("f", 100)
+	)
+
+	in := []string{
+		nullString,
+
+		// We append strings out-of-order below to ensure that the min/max
+		// comparisons are working properly.
+		//
+		// Strings are grouped by which page they'll be appended to.
+
+		bString,
+		cString,
+		aString,
+
+		eString,
+		fString,
+		dString,
+	}
+
+	opts := BuilderOptions{
+		PageSizeHint: 301, // Slightly larger than the string length of 3 strings per page.
+		Value:        datasetmd.VALUE_TYPE_STRING,
+		Compression:  datasetmd.COMPRESSION_TYPE_NONE,
+		Encoding:     datasetmd.ENCODING_TYPE_PLAIN,
+
+		StoreRangeStats: true,
+	}
+	b, err := NewColumnBuilder("", opts)
+	require.NoError(t, err)
+
+	for i, s := range in {
+		require.NoError(t, b.Append(i, StringValue(s)))
+	}
+
+	col, err := b.Flush()
+	require.NoError(t, err)
+	require.Equal(t, datasetmd.VALUE_TYPE_STRING, col.Info.Type)
+	require.NotNil(t, col.Info.Statistics)
+
+	columnMin, columnMax := getMinMax(t, col.Info.Statistics)
+	require.Equal(t, aString, columnMin.String())
+	require.Equal(t, fString, columnMax.String())
+
+	require.Len(t, col.Pages, 2)
+	require.Equal(t, 3, col.Pages[0].Info.ValuesCount)
+	require.Equal(t, 3, col.Pages[1].Info.ValuesCount)
+
+	page0Min, page0Max := getMinMax(t, col.Pages[0].Info.Stats)
+	require.Equal(t, aString, page0Min.String())
+	require.Equal(t, cString, page0Max.String())
+
+	page1Min, page1Max := getMinMax(t, col.Pages[1].Info.Stats)
+	require.Equal(t, dString, page1Min.String())
+	require.Equal(t, fString, page1Max.String())
+}
+
+func getMinMax(t *testing.T, stats *datasetmd.Statistics) (min, max Value) {
+	t.Helper()
+	require.NotNil(t, stats)
+
+	var minValue, maxValue Value
+
+	require.NoError(t, minValue.UnmarshalBinary(stats.MinValue))
+	require.NoError(t, maxValue.UnmarshalBinary(stats.MaxValue))
+
+	return minValue, maxValue
 }

--- a/pkg/dataobj/internal/dataset/page_builder.go
+++ b/pkg/dataobj/internal/dataset/page_builder.go
@@ -148,22 +148,13 @@ func (b *pageBuilder) updateMinMax(value Value) {
 		return
 	}
 
-	// We want our statistics to track the minimum and maximum non-NULL values
-	// here, so we initialize minValue/maxValue to the first non-NULL value we
-	// see (using b.values instead of b.rows).
-	//
-	// If we tracked NULL values, then minValue would always be NULL, since NULL
-	// sorts first based on [CompareValues].
-	if b.values == 0 {
-		b.minValue = value
-		b.maxValue = value
-		return
-	}
-
-	if CompareValues(value, b.minValue) < 0 {
+	// We'll init minValue/maxValue if this is our first non-NULL value (b.values == 0).
+	// This allows us to only avoid comparing against NULL values, which would lead to
+	// NULL always being the min.
+	if b.values == 0 || CompareValues(value, b.minValue) < 0 {
 		b.minValue = value
 	}
-	if CompareValues(value, b.maxValue) > 0 {
+	if b.values == 0 || CompareValues(value, b.maxValue) > 0 {
 		b.maxValue = value
 	}
 }

--- a/pkg/dataobj/internal/dataset/value_test.go
+++ b/pkg/dataobj/internal/dataset/value_test.go
@@ -1,0 +1,78 @@
+package dataset_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/dataobj/internal/dataset"
+	"github.com/grafana/loki/v3/pkg/dataobj/internal/metadata/datasetmd"
+)
+
+func TestValue_MarshalBinary(t *testing.T) {
+	t.Run("Null", func(t *testing.T) {
+		var expect dataset.Value
+		require.True(t, expect.IsNil())
+
+		b, err := expect.MarshalBinary()
+		require.NoError(t, err)
+
+		var actual dataset.Value
+		require.NoError(t, actual.UnmarshalBinary(b))
+		require.True(t, actual.IsNil())
+	})
+
+	t.Run("Int64Value", func(t *testing.T) {
+		expect := dataset.Int64Value(-1234)
+		require.Equal(t, datasetmd.VALUE_TYPE_INT64, expect.Type())
+
+		b, err := expect.MarshalBinary()
+		require.NoError(t, err)
+
+		var actual dataset.Value
+		require.NoError(t, actual.UnmarshalBinary(b))
+		require.Equal(t, datasetmd.VALUE_TYPE_INT64, actual.Type())
+		require.Equal(t, expect.Int64(), actual.Int64())
+	})
+
+	t.Run("Uint64Value", func(t *testing.T) {
+		expect := dataset.Uint64Value(1234)
+		require.Equal(t, datasetmd.VALUE_TYPE_UINT64, expect.Type())
+
+		b, err := expect.MarshalBinary()
+		require.NoError(t, err)
+
+		var actual dataset.Value
+		require.NoError(t, actual.UnmarshalBinary(b))
+		require.Equal(t, datasetmd.VALUE_TYPE_UINT64, actual.Type())
+		require.Equal(t, expect.Uint64(), actual.Uint64())
+	})
+
+	t.Run("StringValue", func(t *testing.T) {
+		t.Run("Empty", func(t *testing.T) {
+			expect := dataset.StringValue("")
+			require.Equal(t, datasetmd.VALUE_TYPE_STRING, expect.Type())
+
+			b, err := expect.MarshalBinary()
+			require.NoError(t, err)
+
+			var actual dataset.Value
+			require.NoError(t, actual.UnmarshalBinary(b))
+			require.Equal(t, datasetmd.VALUE_TYPE_STRING, actual.Type())
+			require.Equal(t, expect.String(), actual.String())
+		})
+
+		t.Run("Non-empty", func(t *testing.T) {
+			expect := dataset.StringValue("hello, world!")
+			require.Equal(t, datasetmd.VALUE_TYPE_STRING, expect.Type())
+
+			b, err := expect.MarshalBinary()
+			require.NoError(t, err)
+
+			var actual dataset.Value
+			require.NoError(t, actual.UnmarshalBinary(b))
+			require.Equal(t, datasetmd.VALUE_TYPE_STRING, actual.Type())
+			require.Equal(t, expect.String(), actual.String())
+		})
+	})
+}

--- a/pkg/dataobj/internal/metadata/datasetmd/datasetmd.pb.go
+++ b/pkg/dataobj/internal/metadata/datasetmd/datasetmd.pb.go
@@ -256,9 +256,17 @@ func (m *ColumnInfo) GetValuesCount() uint64 {
 // Statistics about a column or a page. All statistics are optional and are
 // conditionally set depending on the column type.
 type Statistics struct {
-	// Minimum value.
+	// Minimum value. Applications should only set min_value to an encoding of a
+	// non-NULL value. If there is no non-NULL value, min_value should be unset.
+	//
+	// Applications must not assume that an unset min_value means that the column
+	// is empty; check for values_count == 0 instead.
 	MinValue []byte `protobuf:"bytes,1,opt,name=min_value,json=minValue,proto3" json:"min_value,omitempty"`
-	// Maximum value.
+	// Maximum value. Applications should only set max_value to an encoding of a
+	// non-NULL value. If there is no non-NULL value, max_value should be unset.
+	//
+	// Applications must not assume that an unset max_value means that the column
+	// is empty; check for values_count == 0 instead.
 	MaxValue []byte `protobuf:"bytes,2,opt,name=max_value,json=maxValue,proto3" json:"max_value,omitempty"`
 }
 

--- a/pkg/dataobj/internal/metadata/datasetmd/datasetmd.proto
+++ b/pkg/dataobj/internal/metadata/datasetmd/datasetmd.proto
@@ -73,10 +73,18 @@ enum CompressionType {
 // Statistics about a column or a page. All statistics are optional and are
 // conditionally set depending on the column type.
 message Statistics {
-  // Minimum value.
+  // Minimum value. Applications should only set min_value to an encoding of a
+  // non-NULL value. If there is no non-NULL value, min_value should be unset.
+  //
+  // Applications must not assume that an unset min_value means that the column
+  // is empty; check for values_count == 0 instead.
   bytes min_value = 1;
 
-  // Maximum value.
+  // Maximum value. Applications should only set max_value to an encoding of a
+  // non-NULL value. If there is no non-NULL value, max_value should be unset.
+  //
+  // Applications must not assume that an unset max_value means that the column
+  // is empty; check for values_count == 0 instead.
   bytes max_value = 2;
 }
 

--- a/pkg/dataobj/internal/sections/logs/table.go
+++ b/pkg/dataobj/internal/sections/logs/table.go
@@ -117,10 +117,11 @@ func (b *tableBuffer) StreamID(pageSize int) *dataset.ColumnBuilder {
 	}
 
 	col, err := dataset.NewColumnBuilder("", dataset.BuilderOptions{
-		PageSizeHint: pageSize,
-		Value:        datasetmd.VALUE_TYPE_INT64,
-		Encoding:     datasetmd.ENCODING_TYPE_DELTA,
-		Compression:  datasetmd.COMPRESSION_TYPE_NONE,
+		PageSizeHint:    pageSize,
+		Value:           datasetmd.VALUE_TYPE_INT64,
+		Encoding:        datasetmd.ENCODING_TYPE_DELTA,
+		Compression:     datasetmd.COMPRESSION_TYPE_NONE,
+		StoreRangeStats: true,
 	})
 	if err != nil {
 		// We control the Value/Encoding tuple so this can't fail; if it does,
@@ -140,10 +141,11 @@ func (b *tableBuffer) Timestamp(pageSize int) *dataset.ColumnBuilder {
 	}
 
 	col, err := dataset.NewColumnBuilder("", dataset.BuilderOptions{
-		PageSizeHint: pageSize,
-		Value:        datasetmd.VALUE_TYPE_INT64,
-		Encoding:     datasetmd.ENCODING_TYPE_DELTA,
-		Compression:  datasetmd.COMPRESSION_TYPE_NONE,
+		PageSizeHint:    pageSize,
+		Value:           datasetmd.VALUE_TYPE_INT64,
+		Encoding:        datasetmd.ENCODING_TYPE_DELTA,
+		Compression:     datasetmd.COMPRESSION_TYPE_NONE,
+		StoreRangeStats: true,
 	})
 	if err != nil {
 		// We control the Value/Encoding tuple so this can't fail; if it does,
@@ -176,6 +178,7 @@ func (b *tableBuffer) Metadata(key string, pageSize int, compressionOpts dataset
 		Encoding:           datasetmd.ENCODING_TYPE_PLAIN,
 		Compression:        datasetmd.COMPRESSION_TYPE_ZSTD,
 		CompressionOptions: compressionOpts,
+		StoreRangeStats:    true,
 	})
 	if err != nil {
 		// We control the Value/Encoding tuple so this can't fail; if it does,
@@ -206,6 +209,12 @@ func (b *tableBuffer) Message(pageSize int, compressionOpts dataset.CompressionO
 		Encoding:           datasetmd.ENCODING_TYPE_PLAIN,
 		Compression:        datasetmd.COMPRESSION_TYPE_ZSTD,
 		CompressionOptions: compressionOpts,
+
+		// We explicitly don't have range stats for the message column:
+		//
+		// A "min log line" and "max log line" isn't very valuable, and since log
+		// lines can be quite long, it would consume a fair amount of metadata.
+		StoreRangeStats: false,
 	})
 	if err != nil {
 		// We control the Value/Encoding tuple so this can't fail; if it does,

--- a/pkg/dataobj/internal/sections/streams/streams.go
+++ b/pkg/dataobj/internal/sections/streams/streams.go
@@ -226,10 +226,11 @@ func (s *Streams) EncodeTo(enc *encoding.Encoder) error {
 		}
 
 		builder, err := dataset.NewColumnBuilder(name, dataset.BuilderOptions{
-			PageSizeHint: s.pageSize,
-			Value:        datasetmd.VALUE_TYPE_STRING,
-			Encoding:     datasetmd.ENCODING_TYPE_PLAIN,
-			Compression:  datasetmd.COMPRESSION_TYPE_ZSTD,
+			PageSizeHint:    s.pageSize,
+			Value:           datasetmd.VALUE_TYPE_STRING,
+			Encoding:        datasetmd.ENCODING_TYPE_PLAIN,
+			Compression:     datasetmd.COMPRESSION_TYPE_ZSTD,
+			StoreRangeStats: true,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("creating label column: %w", err)
@@ -297,10 +298,11 @@ func (s *Streams) EncodeTo(enc *encoding.Encoder) error {
 
 func numberColumnBuilder(pageSize int) (*dataset.ColumnBuilder, error) {
 	return dataset.NewColumnBuilder("", dataset.BuilderOptions{
-		PageSizeHint: pageSize,
-		Value:        datasetmd.VALUE_TYPE_INT64,
-		Encoding:     datasetmd.ENCODING_TYPE_DELTA,
-		Compression:  datasetmd.COMPRESSION_TYPE_NONE,
+		PageSizeHint:    pageSize,
+		Value:           datasetmd.VALUE_TYPE_INT64,
+		Encoding:        datasetmd.ENCODING_TYPE_DELTA,
+		Compression:     datasetmd.COMPRESSION_TYPE_NONE,
+		StoreRangeStats: true,
 	})
 }
 


### PR DESCRIPTION
This commit adds support for storing the minimum and maximum non-NULL value encountered in a page and a column. The minimum and maximum value of a column is determined by the minimum and maximum value across all pages in that column.

These range statistics are primarily useful at read time; if a value being searched for is outside of the min/max value range of a page, the row range represented by that page can be disqualified from the entire dataset. With most pages typically covering hundreds of thousands of rows (up to millions), this can dramatically reduce the search area when reading. 

Range statistics are opt-in to avoid bloating the statistics size when a min/max value would be less meaningful, such as a "minimum log line" in the message column of a logs section.

dataset.Value now implements encoding.BinaryMarshaler and encoding.BinaryUnmarshaler to be encoded and decoded from stats, using a simple encoding for various types:

* NULL values are encoded as an empty byte array.

* Non-NULL values are encoded first with the metadata type (uvarint), followed by:

  * The uvarint encoding of VALUE_TYPE_UINT64 values.
  * The varint encoding of VALUE_TYPE_INT64 values.
  * The set of bytes representing a string for VALUE_TYPE_STRING values.

Range statistics will now be computed for all column types in both sections, with the sole exception being the message column in the logs section.