### PR TITLE
chore: remove ListenPort from initIngestLimitsRing

### DIFF
--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -398,8 +398,6 @@ func (t *Loki) initIngestLimitsRing() (_ services.Service, err error) {
 		return nil, nil
 	}
 
-	t.Cfg.IngestLimits.LifecyclerConfig.ListenPort = t.Cfg.Server.GRPCListenPort
-
 	reg := prometheus.WrapRegistererWithPrefix(t.Cfg.MetricsNamespace+"_", prometheus.DefaultRegisterer)
 
 	t.ingestLimitsRing, err = ring.New(


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit removes the initialization of `ListenPort` for the `IngestLimits` ring lifecycler from `InitIngestLimitsRing`. It is not needed here, as the client does not register itself in the ring. It is just needed in `InitIngestLimits`.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
