### PR TITLE
feat(ksonnet): Add no_schedule_constraints option to distributors

### DIFF
--- a/production/ksonnet/loki/distributor.libsonnet
+++ b/production/ksonnet/loki/distributor.libsonnet
@@ -35,7 +35,8 @@ local k = import 'ksonnet-util/kausal.libsonnet';
     ) +
     deployment.mixin.spec.strategy.rollingUpdate.withMaxSurge(5) +
     deployment.mixin.spec.strategy.rollingUpdate.withMaxUnavailable(1) +
-    if $._config.distributor.use_topology_spread then
+    if $._config.distributor.no_schedule_constraints then {}
+    else if $._config.distributor.use_topology_spread then
       deployment.spec.template.spec.withTopologySpreadConstraints(
         // Evenly spread queriers among available nodes.
         topologySpreadConstraints.labelSelector.withMatchLabels({ name: 'distributor' }) +


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds the option to remove schedule constraints completely for the distributors.
This is already in place for queriers, and is not required for other components because we don't apply anti-affinity by default.