### PR TITLE
feat(operator): extend LokiStack authorization to support OTel Semantics

### DIFF
--- a/operator/internal/manifests/gateway_tenants_test.go
+++ b/operator/internal/manifests/gateway_tenants_test.go
@@ -716,7 +716,7 @@ func TestConfigureDeploymentForMode(t *testing.T) {
 								{
 									Name: gatewayContainerName,
 									Args: []string{
-										"--logs.auth.extract-selectors=kubernetes_namespace_name",
+										"--logs.auth.extract-selectors=kubernetes_namespace_name,k8s_namespace_name",
 									},
 								},
 								{
@@ -730,7 +730,8 @@ func TestConfigureDeploymentForMode(t *testing.T) {
 										"--opa.skip-tenants=audit,infrastructure",
 										"--opa.package=lokistack",
 										"--opa.admin-groups=system:cluster-admins,cluster-admin,dedicated-admin",
-										"--opa.matcher=kubernetes_namespace_name",
+										"--opa.matcher=kubernetes_namespace_name,k8s_namespace_name",
+										"--opa.matcher-op=or",
 										`--openshift.mappings=application=loki.grafana.com`,
 										`--openshift.mappings=infrastructure=loki.grafana.com`,
 										`--openshift.mappings=audit=loki.grafana.com`,
@@ -825,7 +826,7 @@ func TestConfigureDeploymentForMode(t *testing.T) {
 								{
 									Name: gatewayContainerName,
 									Args: []string{
-										"--logs.auth.extract-selectors=kubernetes_namespace_name",
+										"--logs.auth.extract-selectors=kubernetes_namespace_name,k8s_namespace_name",
 									},
 								},
 								{
@@ -839,7 +840,8 @@ func TestConfigureDeploymentForMode(t *testing.T) {
 										"--opa.skip-tenants=audit,infrastructure",
 										"--opa.package=lokistack",
 										"--opa.admin-groups=system:cluster-admins,cluster-admin,dedicated-admin",
-										"--opa.matcher=kubernetes_namespace_name",
+										"--opa.matcher=kubernetes_namespace_name,k8s_namespace_name",
+										"--opa.matcher-op=or",
 										"--tls.internal.server.cert-file=/var/run/tls/http/server/tls.crt",
 										"--tls.internal.server.key-file=/var/run/tls/http/server/tls.key",
 										"--tls.min-version=min-version",
@@ -1162,7 +1164,7 @@ func TestConfigureDeploymentForMode(t *testing.T) {
 								{
 									Name: gatewayContainerName,
 									Args: []string{
-										"--logs.auth.extract-selectors=kubernetes_namespace_name",
+										"--logs.auth.extract-selectors=kubernetes_namespace_name,k8s_namespace_name",
 									},
 								},
 								{
@@ -1176,7 +1178,8 @@ func TestConfigureDeploymentForMode(t *testing.T) {
 										"--opa.skip-tenants=audit,infrastructure",
 										"--opa.package=lokistack",
 										"--opa.admin-groups=custom-admins,other-admins",
-										"--opa.matcher=kubernetes_namespace_name",
+										"--opa.matcher=kubernetes_namespace_name,k8s_namespace_name",
+										"--opa.matcher-op=or",
 										`--openshift.mappings=application=loki.grafana.com`,
 										`--openshift.mappings=infrastructure=loki.grafana.com`,
 										`--openshift.mappings=audit=loki.grafana.com`,
@@ -1259,7 +1262,7 @@ func TestConfigureDeploymentForMode(t *testing.T) {
 								{
 									Name: gatewayContainerName,
 									Args: []string{
-										"--logs.auth.extract-selectors=kubernetes_namespace_name",
+										"--logs.auth.extract-selectors=kubernetes_namespace_name,k8s_namespace_name",
 									},
 								},
 								{
@@ -1272,7 +1275,8 @@ func TestConfigureDeploymentForMode(t *testing.T) {
 										"--web.healthchecks.url=http://localhost:8082",
 										"--opa.skip-tenants=audit,infrastructure",
 										"--opa.package=lokistack",
-										"--opa.matcher=kubernetes_namespace_name",
+										"--opa.matcher=kubernetes_namespace_name,k8s_namespace_name",
+										"--opa.matcher-op=or",
 										`--openshift.mappings=application=loki.grafana.com`,
 										`--openshift.mappings=infrastructure=loki.grafana.com`,
 										`--openshift.mappings=audit=loki.grafana.com`,

--- a/operator/internal/manifests/gateway_test.go
+++ b/operator/internal/manifests/gateway_test.go
@@ -726,7 +726,7 @@ func TestBuildGateway_WithRulesEnabled(t *testing.T) {
 			wantArgs: []string{
 				"--logs.rules.endpoint=https://abcd-ruler-http.efgh.svc.cluster.local:3100",
 				"--logs.rules.read-only=true",
-				"--logs.rules.label-filters=application:kubernetes_namespace_name",
+				"--logs.rules.label-filters=application:kubernetes_namespace_name,k8s_namespace_name",
 			},
 		},
 		{

--- a/operator/internal/manifests/openshift/alertingrule.go
+++ b/operator/internal/manifests/openshift/alertingrule.go
@@ -6,7 +6,7 @@ func AlertingRuleTenantLabels(ar *lokiv1.AlertingRule) {
 	switch ar.Spec.TenantID {
 	case tenantApplication:
 		appendAlertingRuleLabels(ar, map[string]string{
-			opaDefaultLabelMatcher:    ar.Namespace,
+			opaDefaultLabelMatchers:   ar.Namespace,
 			ocpMonitoringGroupByLabel: ar.Namespace,
 		})
 	case tenantInfrastructure, tenantAudit, tenantNetwork:

--- a/operator/internal/manifests/openshift/alertingrule_test.go
+++ b/operator/internal/manifests/openshift/alertingrule_test.go
@@ -46,7 +46,7 @@ func TestAlertingRuleTenantLabels(t *testing.T) {
 								{
 									Alert: "alert",
 									Labels: map[string]string{
-										opaDefaultLabelMatcher:    "test-ns",
+										opaDefaultLabelMatchers:   "test-ns",
 										ocpMonitoringGroupByLabel: "test-ns",
 									},
 								},

--- a/operator/internal/manifests/openshift/configure.go
+++ b/operator/internal/manifests/openshift/configure.go
@@ -81,7 +81,7 @@ func ConfigureGatewayDeployment(
 			}
 
 			d.Spec.Template.Spec.Containers[i].Args = append(d.Spec.Template.Spec.Containers[i].Args,
-				fmt.Sprintf("--logs.auth.extract-selectors=%s", opaDefaultLabelMatcher),
+				fmt.Sprintf("--logs.auth.extract-selectors=%s", opaDefaultLabelMatchers),
 			)
 		}
 	}
@@ -102,7 +102,7 @@ func ConfigureGatewayDeploymentRulesAPI(d *appsv1.Deployment, containerName stri
 
 	container := corev1.Container{
 		Args: []string{
-			fmt.Sprintf("--logs.rules.label-filters=%s:%s", tenantApplication, opaDefaultLabelMatcher),
+			fmt.Sprintf("--logs.rules.label-filters=%s:%s", tenantApplication, opaDefaultLabelMatchers),
 		},
 	}
 

--- a/operator/internal/manifests/openshift/opa_openshift.go
+++ b/operator/internal/manifests/openshift/opa_openshift.go
@@ -19,7 +19,7 @@ const (
 	opaDefaultPackage         = "lokistack"
 	opaDefaultAPIGroup        = "loki.grafana.com"
 	opaMetricsPortName        = "opa-metrics"
-	opaDefaultLabelMatcher    = "kubernetes_namespace_name"
+	opaDefaultLabelMatchers   = "kubernetes_namespace_name,k8s_namespace_name"
 	opaNetworkLabelMatchers   = "SrcK8S_Namespace,DstK8S_Namespace"
 	ocpMonitoringGroupByLabel = "namespace"
 )
@@ -53,7 +53,8 @@ func newOPAOpenShiftContainer(mode lokiv1.ModeType, secretVolumeName, tlsDir, mi
 
 	if mode != lokiv1.OpenshiftNetwork {
 		args = append(args, []string{
-			fmt.Sprintf("--opa.matcher=%s", opaDefaultLabelMatcher),
+			fmt.Sprintf("--opa.matcher=%s", opaDefaultLabelMatchers),
+			"--opa.matcher-op=or",
 		}...)
 	} else {
 		args = append(args, []string{

--- a/operator/internal/manifests/openshift/recordingrule.go
+++ b/operator/internal/manifests/openshift/recordingrule.go
@@ -6,7 +6,7 @@ func RecordingRuleTenantLabels(r *lokiv1.RecordingRule) {
 	switch r.Spec.TenantID {
 	case tenantApplication:
 		appendRecordingRuleLabels(r, map[string]string{
-			opaDefaultLabelMatcher:    r.Namespace,
+			opaDefaultLabelMatchers:   r.Namespace,
 			ocpMonitoringGroupByLabel: r.Namespace,
 		})
 	case tenantInfrastructure, tenantAudit, tenantNetwork:

--- a/operator/internal/manifests/openshift/recordingrule_test.go
+++ b/operator/internal/manifests/openshift/recordingrule_test.go
@@ -46,7 +46,7 @@ func TestRecordingRuleTenantLabels(t *testing.T) {
 								{
 									Record: "record",
 									Labels: map[string]string{
-										opaDefaultLabelMatcher:    "test-ns",
+										opaDefaultLabelMatchers:   "test-ns",
 										ocpMonitoringGroupByLabel: "test-ns",
 									},
 								},


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
