### PR TITLE
fix(operator): adjust PDBMinAvailable for 1x.pico size

### DIFF
--- a/operator/internal/manifests/internal/sizes.go
+++ b/operator/internal/manifests/internal/sizes.go
@@ -68,7 +68,7 @@ var ResourceRequirementsTable = map[lokiv1.LokiStackSizeType]ComponentResources{
 				corev1.ResourceCPU:    resource.MustParse("500m"),
 				corev1.ResourceMemory: resource.MustParse("3Gi"),
 			},
-			PDBMinAvailable: 1,
+			PDBMinAvailable: 2,
 		},
 		Distributor: corev1.ResourceRequirements{
 			Requests: map[corev1.ResourceName]resource.Quantity{


### PR DESCRIPTION
**What this PR does / why we need it**:
The 1x.pico configuration, introduced in #14407, was modified as follows:

The replicationFactor of the Ingester was increased from 1 to 2.
The number of Ingester replicas was increased from 2 to 3.
However, the PDBMinAvailable[[1]](https://github.com/grafana/loki/blob/716d54e2a9617a80c2496a46e9c4cbf8ed51a5d9/operator/internal/manifests/internal/sizes.go#L71)  setting is still 1 after these changes. This means that two out of the three Ingester pods can be down at the same time, which affects High Availability. To address this issue, this PR updates the PDBMinAvailable setting to 2.

**Which issue(s) this PR fixes**:

Fixes [LOG-6679](https://issues.redhat.com/browse/LOG-6679)

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [X] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
