### PR TITLE
chore: revert "fix: scheduling constraints (#16045)"

### DIFF
--- a/production/ksonnet/loki/multi-zone.libsonnet
+++ b/production/ksonnet/loki/multi-zone.libsonnet
@@ -30,7 +30,6 @@ local rolloutOperator = import 'rollout-operator.libsonnet';
     // If use_topology_spread is false, ingesters will not be scheduled on nodes already running ingesters.
     multi_zone_ingester_use_topology_spread: false,
     multi_zone_ingester_topology_spread_max_skew: 1,
-    multi_zone_ingester_topology_spread_when_unsatisfiable: 'ScheduleAnyway',
 
     node_selector: null,
   },
@@ -117,7 +116,7 @@ local rolloutOperator = import 'rollout-operator.libsonnet';
           // Evenly spread queriers among available nodes.
           topologySpreadConstraints.labelSelector.withMatchLabels({ name: name }) +
           topologySpreadConstraints.withTopologyKey('kubernetes.io/hostname') +
-          topologySpreadConstraints.withWhenUnsatisfiable($._config.multi_zone_ingester_topology_spread_when_unsatisfiable) +
+          topologySpreadConstraints.withWhenUnsatisfiable('ScheduleAnyway') +
           topologySpreadConstraints.withMaxSkew($._config.multi_zone_ingester_topology_spread_max_skew),
         )
       else {}


### PR DESCRIPTION
This reverts commit b45a31e84f83a9921fb34fc4faf15abb4d144e54.

We are no longer going this direction with the ingesters.

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
