### PR TITLE
fix: Determine when all logs have been filtered

### DIFF
--- a/pkg/distributor/http.go
+++ b/pkg/distributor/http.go
@@ -1,6 +1,7 @@
 package distributor
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -42,16 +43,26 @@ func (d *Distributor) pushHandler(w http.ResponseWriter, r *http.Request, pushRe
 	logPushRequestStreams := d.tenantConfigs.LogPushRequestStreams(tenantID)
 	req, err := push.ParseRequest(logger, tenantID, r, d.tenantsRetention, d.validator.Limits, pushRequestParser, d.usageTracker, logPushRequestStreams)
 	if err != nil {
+		if !errors.Is(err, push.ErrAllLogsFiltered) {
+			if d.tenantConfigs.LogPushRequest(tenantID) {
+				level.Debug(logger).Log(
+					"msg", "push request failed",
+					"code", http.StatusBadRequest,
+					"err", err,
+				)
+			}
+			d.writeFailuresManager.Log(tenantID, fmt.Errorf("couldn't parse push request: %w", err))
+
+			errorWriter(w, err.Error(), http.StatusBadRequest, logger)
+			return
+		}
+
 		if d.tenantConfigs.LogPushRequest(tenantID) {
 			level.Debug(logger).Log(
-				"msg", "push request failed",
-				"code", http.StatusBadRequest,
-				"err", err,
+				"msg", "successful push request filtered all lines",
 			)
 		}
-		d.writeFailuresManager.Log(tenantID, fmt.Errorf("couldn't parse push request: %w", err))
-
-		errorWriter(w, err.Error(), http.StatusBadRequest, logger)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 

--- a/pkg/distributor/http_test.go
+++ b/pkg/distributor/http_test.go
@@ -63,27 +63,66 @@ func TestDistributorRingHandler(t *testing.T) {
 }
 
 func TestRequestParserWrapping(t *testing.T) {
-	limits := &validation.Limits{}
-	flagext.DefaultValues(limits)
-	limits.RejectOldSamples = false
-	distributors, _ := prepare(t, 1, 3, limits, nil)
+	t.Run("it calls the parser wrapper if there is one", func(t *testing.T) {
+		limits := &validation.Limits{}
+		flagext.DefaultValues(limits)
+		limits.RejectOldSamples = false
+		distributors, _ := prepare(t, 1, 3, limits, nil)
 
-	var called bool
-	distributors[0].RequestParserWrapper = func(requestParser push.RequestParser) push.RequestParser {
-		called = true
-		return requestParser
-	}
+		var called bool
+		distributors[0].RequestParserWrapper = func(requestParser push.RequestParser) push.RequestParser {
+			called = true
+			return requestParser
+		}
 
-	ctx := user.InjectOrgID(context.Background(), "test-user")
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "fake-path", nil)
-	require.NoError(t, err)
+		ctx := user.InjectOrgID(context.Background(), "test-user")
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, "fake-path", nil)
+		require.NoError(t, err)
 
-	distributors[0].pushHandler(httptest.NewRecorder(), req, stubParser, push.HTTPError)
+		rec := httptest.NewRecorder()
+		distributors[0].pushHandler(rec, req, newFakeParser().parseRequest, push.HTTPError)
 
-	require.True(t, called)
+		// unprocessable code because there are no streams in the request.
+		require.Equal(t, http.StatusUnprocessableEntity, rec.Code)
+		require.True(t, called)
+	})
+
+	t.Run("it returns 204 when the parser wrapper filteres all log lines", func(t *testing.T) {
+		limits := &validation.Limits{}
+		flagext.DefaultValues(limits)
+		limits.RejectOldSamples = false
+		distributors, _ := prepare(t, 1, 3, limits, nil)
+
+		var called bool
+		distributors[0].RequestParserWrapper = func(requestParser push.RequestParser) push.RequestParser {
+			called = true
+			return requestParser
+		}
+
+		ctx := user.InjectOrgID(context.Background(), "test-user")
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, "fake-path", nil)
+		require.NoError(t, err)
+
+		parser := newFakeParser()
+		parser.parseErr = push.ErrAllLogsFiltered
+
+		rec := httptest.NewRecorder()
+		distributors[0].pushHandler(rec, req, parser.parseRequest, push.HTTPError)
+
+		require.True(t, called)
+		require.Equal(t, http.StatusNoContent, rec.Code)
+	})
 }
 
-func stubParser(
+type fakeParser struct {
+	parseErr error
+}
+
+func newFakeParser() *fakeParser {
+	return &fakeParser{}
+}
+
+func (p *fakeParser) parseRequest(
 	_ string,
 	_ *http.Request,
 	_ push.TenantsRetention,
@@ -92,5 +131,5 @@ func stubParser(
 	_ bool,
 	_ log.Logger,
 ) (*logproto.PushRequest, *push.Stats, error) {
-	return &logproto.PushRequest{}, &push.Stats{}, nil
+	return &logproto.PushRequest{}, &push.Stats{}, p.parseErr
 }


### PR DESCRIPTION
Adaptive Logs filters logs in Loki's push path. There can be the case where all logs are filtered resulting in an empty push request. [This PR](https://github.com/grafana/loki/issues/13399) made empty push requests a validation error which means that some users are seeing push errors related to Adaptive Logs

The request parser [here](https://github.com/grafana/loki/blob/91ff737136cdaf59c857e76f72736124c24c01c3/pkg/loghttp/push/push.go#L112) is keeping interesting statistics that we'd like to keep so This PR introduces a new error `ErrAllLogsFiltered` that can be returned from the parser. When that error is seen, Loki returns a `204` directly to the user without passing the push request to the distributor. 
