### PR TITLE
fix: account for the adaptive logs label when calculating structured metadata size

### DIFF
--- a/pkg/util/constants/adaptive_logs.go
+++ b/pkg/util/constants/adaptive_logs.go
@@ -1,0 +1,4 @@
+package constants
+
+// Label added by adaptive logs.
+const SampledLogNameLabel = "__adaptive_logs_sampled__"

--- a/pkg/util/entry_size.go
+++ b/pkg/util/entry_size.go
@@ -20,7 +20,7 @@ func EntryTotalSize(entry *push.Entry) int {
 	return len(entry.Line) + StructuredMetadataSize(entry.StructuredMetadata)
 }
 
-var excludedStructuredMetadataLabels = []string{constants.LevelLabel}
+var excludedStructuredMetadataLabels = []string{constants.LevelLabel, constants.SampledLogNameLabel}
 
 func StructuredMetadataSize(metas push.LabelsAdapter) int {
 	size := 0


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the calculation of StructuredMetadataSize to exclude the label added by adaptive logs.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
