### PR TITLE
fix: export ExcludedMetadataLabels so it can be extended in GEL

### DIFF
--- a/pkg/util/entry_size.go
+++ b/pkg/util/entry_size.go
@@ -20,12 +20,12 @@ func EntryTotalSize(entry *push.Entry) int {
 	return len(entry.Line) + StructuredMetadataSize(entry.StructuredMetadata)
 }
 
-var excludedStructuredMetadataLabels = []string{constants.LevelLabel}
+var ExcludedStructuredMetadataLabels = []string{constants.LevelLabel}
 
 func StructuredMetadataSize(metas push.LabelsAdapter) int {
 	size := 0
 	for _, meta := range metas {
-		if slices.Contains(excludedStructuredMetadataLabels, meta.Name) {
+		if slices.Contains(ExcludedStructuredMetadataLabels, meta.Name) {
 			continue
 		}
 		size += len(meta.Name) + len(meta.Value)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR exports ExcludedMetadataLabels so it can be extended in GEL for any other labels(eg. Adaptive Logs) that need to be accounted for while computing metadata size.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
