### PR TITLE
chore(dataobj): do not panic on unrecognized compression type

### DIFF
--- a/pkg/dataobj/internal/dataset/page.go
+++ b/pkg/dataobj/internal/dataset/page.go
@@ -112,9 +112,12 @@ func (p *MemPage) reader(compression datasetmd.CompressionType) (presence io.Rea
 	case datasetmd.COMPRESSION_TYPE_ZSTD:
 		zr := &fixedZstdReader{page: p, data: compressedValuesData}
 		return bitmapReader, zr, nil
-	}
 
-	panic(fmt.Sprintf("dataset.MemPage.reader: unknown compression type %q", compression.String()))
+	default:
+		// We do *not* want to panic here, as we may be trying to read a page from
+		// a newer format.
+		return nil, nil, fmt.Errorf("unknown compression type %q", compression.String())
+	}
 }
 
 var snappyPool = sync.Pool{


### PR DESCRIPTION
Opening a page for reading should not cause a panic. An unknown compression type may be encountered if an older version of the dataobj reading code is trying to read an object produced by a newer version (where new compression types are available).

Because of this, the read path should never panic when encountering an unexpected value in an object; this was the only panic on the read path and is now removed.