### PR TITLE
feat(helm): Allow provisioner to be namespaced

### DIFF
--- a/docs/sources/setup/install/helm/reference.md
+++ b/docs/sources/setup/install/helm/reference.md
@@ -3075,6 +3075,7 @@ null
     "enabled": true,
     "env": [],
     "extraVolumeMounts": [],
+    "hookType": "post-install",
     "image": {
       "digest": null,
       "pullPolicy": "IfNotPresent",
@@ -3263,6 +3264,7 @@ null
   "enabled": true,
   "env": [],
   "extraVolumeMounts": [],
+  "hookType": "post-install",
   "image": {
     "digest": null,
     "pullPolicy": "IfNotPresent",
@@ -3336,6 +3338,15 @@ true
 			<td>Volume mounts to add to the provisioner pods</td>
 			<td><pre lang="json">
 []
+</pre>
+</td>
+		</tr>
+		<tr>
+			<td>enterprise.provisioner.hookType</td>
+			<td>string</td>
+			<td>Hook type(s) to customize when the job runs.  defaults to post-install</td>
+			<td><pre lang="json">
+"post-install"
 </pre>
 </td>
 		</tr>

--- a/production/helm/loki/templates/provisioner/job-provisioner.yaml
+++ b/production/helm/loki/templates/provisioner/job-provisioner.yaml
@@ -14,7 +14,7 @@ metadata:
     {{- with .Values.enterprise.provisioner.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-    "helm.sh/hook": post-install
+    "helm.sh/hook": {{ .Values.enterprise.provisioner.hookType | default "post-install" | quote }}
     "helm.sh/hook-weight": "15"
 spec:
   backoffLimit: 6

--- a/production/helm/loki/templates/provisioner/role-provisioner.yaml
+++ b/production/helm/loki/templates/provisioner/role-provisioner.yaml
@@ -1,6 +1,6 @@
-{{ if and (and .Values.enterprise.provisioner.enabled .Values.enterprise.enabled) (not .Values.rbac.namespaced)}}
+{{ if and .Values.enterprise.provisioner.enabled .Values.enterprise.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: {{ if not .Values.rbac.namespaced }}Cluster{{ end }}Role
 metadata:
   name: {{ template "enterprise-logs.provisionerFullname" . }}
   namespace: {{ $.Release.Namespace }}

--- a/production/helm/loki/templates/provisioner/rolebinding-provisioner.yaml
+++ b/production/helm/loki/templates/provisioner/rolebinding-provisioner.yaml
@@ -1,7 +1,7 @@
-{{ if and (and .Values.enterprise.provisioner.enabled .Values.enterprise.enabled) (not .Values.rbac.namespaced)}}
+{{ if and .Values.enterprise.provisioner.enabled .Values.enterprise.enabled}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: {{ if not .Values.rbac.namespaced }}Cluster{{ else }}Role{{ end }}Binding
 metadata:
   name: {{ template "enterprise-logs.provisionerFullname" . }}
   namespace: {{ $.Release.Namespace }}
@@ -17,7 +17,7 @@ metadata:
     "helm.sh/hook": post-install
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: {{ if not .Values.rbac.namespaced }}Cluster{{ end }}Role
   name: {{ template "enterprise-logs.provisionerFullname" . }}
 subjects:
   - kind: ServiceAccount

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -611,6 +611,8 @@ enterprise:
     enabled: true
     # -- Name of the secret to store provisioned tokens in
     provisionedSecretPrefix: null
+    # -- Hook type(s) to customize when the job runs.  defaults to post-install
+    hookType: "post-install"
     # -- Additional tenants to be created. Each tenant will get a read and write policy
     # and associated token. Tenant must have a name and a namespace for the secret containting
     # the token to be created in. For example


### PR DESCRIPTION
**What this PR does / why we need it**:

In the Grafana Federal Cloud we have clusters where we cannot create ClusterRole/ClusterRoleBinding due to an increased security posture.  To ensure we can deploy the provisioner in these clusters, this PR conditionally generates Role instead of ClusterRole if enterprise and enterprise.provisioner are enabled and rbac.namespaced is true.

This PR also updates the provisioner job helm hooks to allow it to be customized to run on other hookTypes. This still defaults to post-install and should have no impact to current usage.  This will allow the Grafana Federal Cloud to use the provisioner after helm post-upgrades to attempt to create tenants as required.

**Which issue(s) this PR fixes**:
Fixes grafana/deployment_tools#185454.

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
