### PR TITLE
ci: fix docker driver platforms (fixes k239 release)

### DIFF
--- a/.github/release-workflows.jsonnet
+++ b/.github/release-workflows.jsonnet
@@ -30,7 +30,7 @@ local imageJobs = {
   'loki-canary-boringcrypto': build.image('loki-canary-boringcrypto', 'cmd/loki-canary-boringcrypto', platform=platforms.all),
   promtail: build.image('promtail', 'clients/cmd/promtail', platform=platforms.all),
   querytee: build.image('loki-query-tee', 'cmd/querytee', platform=platforms.amd),
-  'loki-docker-driver': build.dockerPlugin('loki-docker-driver', dockerPluginDir, buildImage=buildImage, platform=platforms.all),
+  'loki-docker-driver': build.dockerPlugin('loki-docker-driver', dockerPluginDir, buildImage=buildImage, platform=[r.forPlatform('linux/amd64'), r.forPlatform('linux/arm64')]),
 };
 
 local weeklyImageJobs = {

--- a/.github/workflows/minor-release-pr.yml
+++ b/.github/workflows/minor-release-pr.yml
@@ -696,9 +696,6 @@ jobs:
         - arch: "linux/arm64"
           runs_on:
           - "github-hosted-ubuntu-arm64-small"
-        - arch: "linux/arm"
-          runs_on:
-          - "github-hosted-ubuntu-arm64-small"
   promtail:
     needs:
     - "version"

--- a/.github/workflows/patch-release-pr.yml
+++ b/.github/workflows/patch-release-pr.yml
@@ -696,9 +696,6 @@ jobs:
         - arch: "linux/arm64"
           runs_on:
           - "github-hosted-ubuntu-arm64-small"
-        - arch: "linux/arm"
-          runs_on:
-          - "github-hosted-ubuntu-arm64-small"
   promtail:
     needs:
     - "version"


### PR DESCRIPTION
**What this PR does / why we need it**:

We only publish amd64 and arm64 versions of the docker driver, and only have a build image for those platforms, so this removes `linux/arm` as a target.

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [X] Documentation added
- [X] Tests updated
- [X] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [X] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [X] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
