### PR TITLE
ci: Fix `gochecksumtype` linter error

### DIFF
--- a/pkg/logql/syntax/walk_test.go
+++ b/pkg/logql/syntax/walk_test.go
@@ -79,6 +79,8 @@ func Test_AppendMatchers(t *testing.T) {
 				switch me := e.(type) {
 				case *MatchersExpr:
 					me.AppendMatchers(test.matchers)
+				default:
+					// do nothing
 				}
 			})
 			require.Equal(t, test.want, expr.String())


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes failing golangciLint step in CI
ref: https://github.com/grafana/loki/actions/runs/13145215326/job/36681649009