### PR TITLE
chore: Update Golang in CI and build env to 1.23.6

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,7 +2,7 @@
   "check":
     "uses": "grafana/loki-release/.github/workflows/check.yml@main"
     "with":
-      "build_image": "grafana/loki-build-image:0.34.4"
+      "build_image": "grafana/loki-build-image:0.34.5"
       "golang_ci_lint_version": "v1.60.3"
       "release_lib_ref": "main"
       "skip_validation": false

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -2,7 +2,7 @@
   "check":
     "uses": "grafana/loki-release/.github/workflows/check.yml@main"
     "with":
-      "build_image": "grafana/loki-build-image:0.34.4"
+      "build_image": "grafana/loki-build-image:0.34.5"
       "golang_ci_lint_version": "v1.60.3"
       "release_lib_ref": "main"
       "skip_validation": false

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -10,7 +10,7 @@
   "loki-canary-boringcrypto-image":
     "env":
       "BUILD_TIMEOUT": 60
-      "GO_VERSION": "1.23.5"
+      "GO_VERSION": "1.23.6"
       "IMAGE_PREFIX": "grafana"
       "RELEASE_LIB_REF": "main"
       "RELEASE_REPO": "grafana/loki"
@@ -118,7 +118,7 @@
   "loki-canary-image":
     "env":
       "BUILD_TIMEOUT": 60
-      "GO_VERSION": "1.23.5"
+      "GO_VERSION": "1.23.6"
       "IMAGE_PREFIX": "grafana"
       "RELEASE_LIB_REF": "main"
       "RELEASE_REPO": "grafana/loki"
@@ -226,7 +226,7 @@
   "loki-image":
     "env":
       "BUILD_TIMEOUT": 60
-      "GO_VERSION": "1.23.5"
+      "GO_VERSION": "1.23.6"
       "IMAGE_PREFIX": "grafana"
       "RELEASE_LIB_REF": "main"
       "RELEASE_REPO": "grafana/loki"
@@ -334,7 +334,7 @@
   "promtail-image":
     "env":
       "BUILD_TIMEOUT": 60
-      "GO_VERSION": "1.23.5"
+      "GO_VERSION": "1.23.6"
       "IMAGE_PREFIX": "grafana"
       "RELEASE_LIB_REF": "main"
       "RELEASE_REPO": "grafana/loki"

--- a/.github/workflows/minor-release-pr.yml
+++ b/.github/workflows/minor-release-pr.yml
@@ -16,7 +16,7 @@ jobs:
   check:
     uses: "grafana/loki-release/.github/workflows/check.yml@main"
     with:
-      build_image: "grafana/loki-build-image:0.34.4"
+      build_image: "grafana/loki-build-image:0.34.5"
       golang_ci_lint_version: "v1.60.3"
       release_lib_ref: "main"
       skip_validation: false
@@ -144,7 +144,7 @@ jobs:
           --env SKIP_ARM \
           --volume .:/src/loki \
           --workdir /src/loki \
-          --entrypoint /bin/sh "grafana/loki-build-image:0.34.4"
+          --entrypoint /bin/sh "grafana/loki-build-image:0.34.5"
           git config --global --add safe.directory /src/loki
           echo "${NFPM_SIGNING_KEY}" > $NFPM_SIGNING_KEY_FILE
           make dist packages
@@ -666,7 +666,7 @@ jobs:
         build-args: |
           IMAGE_TAG=${{ needs.version.outputs.version }}
           GOARCH=${{ steps.platform.outputs.platform_short }}
-          BUILD_IMAGE=grafana/loki-build-image:0.34.4
+          BUILD_IMAGE=grafana/loki-build-image:0.34.5
         context: "release"
         file: "release/clients/cmd/docker-driver/Dockerfile"
         outputs: "type=local,dest=release/plugins/loki-docker-driver-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}"

--- a/.github/workflows/patch-release-pr.yml
+++ b/.github/workflows/patch-release-pr.yml
@@ -16,7 +16,7 @@ jobs:
   check:
     uses: "grafana/loki-release/.github/workflows/check.yml@main"
     with:
-      build_image: "grafana/loki-build-image:0.34.4"
+      build_image: "grafana/loki-build-image:0.34.5"
       golang_ci_lint_version: "v1.60.3"
       release_lib_ref: "main"
       skip_validation: false
@@ -144,7 +144,7 @@ jobs:
           --env SKIP_ARM \
           --volume .:/src/loki \
           --workdir /src/loki \
-          --entrypoint /bin/sh "grafana/loki-build-image:0.34.4"
+          --entrypoint /bin/sh "grafana/loki-build-image:0.34.5"
           git config --global --add safe.directory /src/loki
           echo "${NFPM_SIGNING_KEY}" > $NFPM_SIGNING_KEY_FILE
           make dist packages
@@ -666,7 +666,7 @@ jobs:
         build-args: |
           IMAGE_TAG=${{ needs.version.outputs.version }}
           GOARCH=${{ steps.platform.outputs.platform_short }}
-          BUILD_IMAGE=grafana/loki-build-image:0.34.4
+          BUILD_IMAGE=grafana/loki-build-image:0.34.5
         context: "release"
         file: "release/clients/cmd/docker-driver/Dockerfile"
         outputs: "type=local,dest=release/plugins/loki-docker-driver-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}"

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ BUILD_IN_CONTAINER ?= true
 CI                 ?= false
 
 # Ensure you run `make release-workflows` after changing this
-GO_VERSION         := 1.23.5
+GO_VERSION         := 1.23.6
 BUILD_IMAGE_TAG    := 0.34.4
 
 IMAGE_TAG          ?= $(shell ./tools/image-tag)

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,8 @@ CI                 ?= false
 
 # Ensure you run `make release-workflows` after changing this
 GO_VERSION         := 1.23.6
-BUILD_IMAGE_TAG    := 0.34.4
+# Ensure you run `make IMAGE_TAG=<updated-tag> build-image-push` after changing this
+BUILD_IMAGE_TAG    := 0.34.5
 
 IMAGE_TAG          ?= $(shell ./tools/image-tag)
 GIT_REVISION       := $(shell git rev-parse --short HEAD)

--- a/loki-build-image/README.md
+++ b/loki-build-image/README.md
@@ -2,6 +2,10 @@
 
 ## Versions
 
+### 0.34.5
+
+- Update to Go 1.23.6
+
 ### 0.34.4
 
 - Update to Go 1.23.5

--- a/tools/lambda-promtail/Dockerfile
+++ b/tools/lambda-promtail/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22-alpine AS build-image
+FROM golang:1.23-alpine AS build-image
 
 COPY tools/lambda-promtail /src/lambda-promtail
 WORKDIR /src/lambda-promtail


### PR DESCRIPTION
**What this PR does / why we need it**:

>  go1.23.6 (released 2025-02-04) includes security fixes to the crypto/elliptic package, as well as bug fixes to the compiler and the go command. See the Go 1.23.6 milestone on our issue tracker for details. 

ref: https://go.dev/doc/devel/release#go1.23.0