### PR TITLE
fix(pattern): Correctly initialize overrides for pattern tee.

### DIFF
--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -745,7 +745,7 @@ func (t *Loki) setupModuleManager() error {
 		BloomBuilder:             {Server, BloomStore, Analytics, Store},
 		BloomStore:               {IndexGatewayRing, BloomGatewayClient},
 		PatternRingClient:        {Server, MemberlistKV, Analytics},
-		PatternIngesterTee:       {Server, MemberlistKV, Analytics, PatternRingClient},
+		PatternIngesterTee:       {Server, Overrides, MemberlistKV, Analytics, PatternRingClient},
 		PatternIngester:          {Server, MemberlistKV, Analytics, PatternRingClient, PatternIngesterTee, Overrides},
 		IngesterQuerier:          {Ring, PartitionRing, Overrides},
 		QuerySchedulerRing:       {Overrides, MemberlistKV},


### PR DESCRIPTION
Found a panic when the tee would fail and it seems to come from the limits not yet inialized.