### PR TITLE
Fix: Update openshift service address in grafana connection examples

### DIFF
--- a/operator/hack/addon_grafana_gateway_ocp.yaml
+++ b/operator/hack/addon_grafana_gateway_ocp.yaml
@@ -191,7 +191,7 @@ spec:
               key: service-ca.crt
               name: openshift-service-ca.crt
         - name: GATEWAY_ADDRESS
-          value: lokistack-dev-gateway-http.openshift-logging.svc:8080
+          value: logging-loki-gateway-http.openshift-logging.svc.cluster.local:8080
         - name: GF_PATHS_PROVISIONING
           value: /var/lib/provisioning
         - name: GF_SECURITY_ADMIN_USER

--- a/operator/hack/addon_grafana_gateway_ocp_oauth.yaml
+++ b/operator/hack/addon_grafana_gateway_ocp_oauth.yaml
@@ -137,7 +137,7 @@ spec:
               key: service-ca.crt
               name: openshift-service-ca.crt
         - name: GATEWAY_ADDRESS
-          value: lokistack-dev-gateway-http.openshift-logging.svc:8080
+          value: logging-loki-gateway-http.openshift-logging.svc.cluster.local:8080
         - name: GF_SECURITY_ADMIN_USER
           value: kube:admin
         image: docker.io/grafana/grafana:8.5.27


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the openshift operator service address in the examples provided. 
Users are opening cases against the Red Hat support desk reporting that this integration does not work. 

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

Hello Robert ::waves:: 
Hello Periklis ::waves:: 

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
