### PR TITLE
chore(dataobj): Add iterator for metastores

### DIFF
--- a/pkg/dataobj/metastore/metastore_test.go
+++ b/pkg/dataobj/metastore/metastore_test.go
@@ -97,3 +97,85 @@ func TestWriteMetastores(t *testing.T) {
 		require.Greater(t, len(obj), originalSize)
 	}
 }
+
+func TestIter(t *testing.T) {
+	tenantID := "TEST"
+	now := time.Date(2025, 1, 1, 15, 0, 0, 0, time.UTC)
+
+	for _, tc := range []struct {
+		name     string
+		start    time.Time
+		end      time.Time
+		expected []string
+	}{
+		{
+			name:     "within single window",
+			start:    now,
+			end:      now.Add(1 * time.Hour),
+			expected: []string{"tenant-TEST/metastore/2025-01-01T12:00:00Z.store"},
+		},
+		{
+			name:     "same start and end",
+			start:    now,
+			end:      now,
+			expected: []string{"tenant-TEST/metastore/2025-01-01T12:00:00Z.store"},
+		},
+		{
+			name:  "begin at start of window",
+			start: now.Add(-3 * time.Hour),
+			end:   now,
+			expected: []string{
+				"tenant-TEST/metastore/2025-01-01T12:00:00Z.store",
+			},
+		},
+		{
+			name:  "end at start of next window",
+			start: now.Add(-4 * time.Hour),
+			end:   now.Add(-3 * time.Hour),
+			expected: []string{
+				"tenant-TEST/metastore/2025-01-01T00:00:00Z.store",
+				"tenant-TEST/metastore/2025-01-01T12:00:00Z.store",
+			},
+		},
+		{
+			name:  "start and end in different windows",
+			start: now.Add(-12 * time.Hour),
+			end:   now,
+			expected: []string{
+				"tenant-TEST/metastore/2025-01-01T00:00:00Z.store",
+				"tenant-TEST/metastore/2025-01-01T12:00:00Z.store",
+			},
+		},
+		{
+			name:  "span several windows",
+			start: now,
+			end:   now.Add(48 * time.Hour),
+			expected: []string{
+				"tenant-TEST/metastore/2025-01-01T12:00:00Z.store",
+				"tenant-TEST/metastore/2025-01-02T00:00:00Z.store",
+				"tenant-TEST/metastore/2025-01-02T12:00:00Z.store",
+				"tenant-TEST/metastore/2025-01-03T00:00:00Z.store",
+				"tenant-TEST/metastore/2025-01-03T12:00:00Z.store",
+			},
+		},
+		{
+			name:  "start and end in different years",
+			start: time.Date(2024, 12, 31, 3, 0, 0, 0, time.UTC),
+			end:   time.Date(2025, 1, 1, 9, 0, 0, 0, time.UTC),
+			expected: []string{
+				"tenant-TEST/metastore/2024-12-31T00:00:00Z.store",
+				"tenant-TEST/metastore/2024-12-31T12:00:00Z.store",
+				"tenant-TEST/metastore/2025-01-01T00:00:00Z.store",
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			iter := Iter(tenantID, tc.start, tc.end)
+			actual := []string{}
+			for store := range iter {
+				actual = append(actual, store)
+			}
+			require.Equal(t, tc.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a function to iterate over all the metastores within a specific time period for a tenant
* This makes the files in object storage discoverable when all you have is the Start/End time period.
