### PR TITLE
chore(dataobj): Add fallback tenant ID for dataobj partition-processor

### DIFF
--- a/pkg/dataobj/consumer/config.go
+++ b/pkg/dataobj/consumer/config.go
@@ -12,6 +12,8 @@ type Config struct {
 	UploaderConfig uploader.Config `yaml:"uploader"`
 	// StorageBucketPrefix is the prefix to use for the storage bucket.
 	StorageBucketPrefix string `yaml:"storage_bucket_prefix"`
+	// TenantIDFallback is the tenant ID to use if the tenant ID cannot be decoded from the topic.
+	TenantIDFallback string `yaml:"tenant_id_fallback"`
 }
 
 func (cfg *Config) Validate() error {
@@ -30,4 +32,5 @@ func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	cfg.BuilderConfig.RegisterFlagsWithPrefix(prefix, f)
 	cfg.UploaderConfig.RegisterFlagsWithPrefix(prefix, f)
 	f.StringVar(&cfg.StorageBucketPrefix, prefix+"storage-bucket-prefix", "dataobj/", "The prefix to use for the storage bucket.")
+	f.StringVar(&cfg.TenantIDFallback, prefix+"tenant-id-fallback", "", "The tenant ID to use if the tenant ID cannot be decoded from the topic.")
 }

--- a/pkg/dataobj/consumer/partition_processor.go
+++ b/pkg/dataobj/consumer/partition_processor.go
@@ -178,7 +178,6 @@ func (p *partitionProcessor) processRecord(record *kgo.Record) {
 
 	// todo: handle multi-tenant
 	if !bytes.Equal(record.Key, p.tenantID) {
-		level.Error(p.logger).Log("msg", "record key does not match tenant ID", "key", record.Key, "tenant_id", p.tenantID)
 		return
 	}
 	stream, err := p.decoder.DecodeWithoutLabels(record.Value)


### PR DESCRIPTION
**What this PR does / why we need it**:
Adding a fallback option for tenant-ID in case we are ingesting from a single shared topic.

This is to support both shared topics & per-tenant topics while they are in development.