### PR TITLE
chore(ksonnet): add ruler_storage section only if thanos storage is enabled

### DIFF
--- a/production/ksonnet/loki/config.libsonnet
+++ b/production/ksonnet/loki/config.libsonnet
@@ -392,11 +392,15 @@
         },
       } else {},
 
-      ruler_storage: if $._config.use_thanos_objstore && $._config.ruler_enabled then {
-        backend: $._config.storage_backend,
-      } + $._config.thanos_object_store_config else {},
 
-    },
+    } + (
+      if $._config.use_thanos_objstore && $._config.ruler_enabled then {
+        ruler_storage: {
+          backend: $._config.storage_backend,
+        } + $._config.thanos_object_store_config,
+      }
+      else {}
+    ),
   },
 
   local k = import 'ksonnet-util/kausal.libsonnet',

--- a/production/ksonnet/loki/config.libsonnet
+++ b/production/ksonnet/loki/config.libsonnet
@@ -392,7 +392,7 @@
         },
       } else {},
 
-      ruler_storage: if $._config.ruler_enabled then {
+      ruler_storage: if $._config.use_thanos_objstore && $._config.ruler_enabled then {
         backend: $._config.storage_backend,
       } + $._config.thanos_object_store_config else {},
 


### PR DESCRIPTION
**What this PR does / why we need it**:

`ruler_storage` config section is only required when using thanos storage clients. 

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
