### PR TITLE
fix(approx_topk): Map approx_topk operation in all cases

### DIFF
--- a/pkg/logql/shardmapper.go
+++ b/pkg/logql/shardmapper.go
@@ -293,66 +293,7 @@ func (m ShardMapper) mapVectorAggregationExpr(expr *syntax.VectorAggregationExpr
 				return nil, 0, fmt.Errorf("approx_topk is not enabled. See -limits.shard_aggregations")
 			}
 
-			// TODO(owen-d): integrate bounded sharding with approx_topk
-			// I'm not doing this now because it uses a separate code path and may not handle
-			// bounded shards in the same way
-			shards, bytesPerShard, err := m.shards.Resolver().Shards(expr)
-			if err != nil {
-				return nil, 0, err
-			}
-
-			// approx_topk(k, inner) ->
-			// topk(
-			//   k,
-			//   eval_cms(
-			//     __count_min_sketch__(inner, shard=1) ++ __count_min_sketch__(inner, shard=2)...
-			//   )
-			// )
-
-			countMinSketchExpr := syntax.MustClone(expr)
-			countMinSketchExpr.Operation = syntax.OpTypeCountMinSketch
-			countMinSketchExpr.Params = 0
-
-			// Even if this query is not sharded the user wants an approximation. This is helpful if some
-			// inferred label has a very high cardinality. Note that the querier does not support CountMinSketchEvalExpr
-			// which is why it's evaluated on the front end.
-			if shards == 0 {
-				return &syntax.VectorAggregationExpr{
-					Left: &CountMinSketchEvalExpr{
-						downstreams: []DownstreamSampleExpr{{
-							SampleExpr: countMinSketchExpr,
-						}},
-					},
-					Grouping:  expr.Grouping,
-					Operation: syntax.OpTypeTopK,
-					Params:    expr.Params,
-				}, bytesPerShard, nil
-			}
-
-			downstreams := make([]DownstreamSampleExpr, 0, shards)
-			for shard := 0; shard < shards; shard++ {
-				s := NewPowerOfTwoShard(index.ShardAnnotation{
-					Shard: uint32(shard),
-					Of:    uint32(shards),
-				})
-				downstreams = append(downstreams, DownstreamSampleExpr{
-					shard: &ShardWithChunkRefs{
-						Shard: s,
-					},
-					SampleExpr: countMinSketchExpr,
-				})
-			}
-
-			sharded := &CountMinSketchEvalExpr{
-				downstreams: downstreams,
-			}
-
-			return &syntax.VectorAggregationExpr{
-				Left:      sharded,
-				Grouping:  expr.Grouping,
-				Operation: syntax.OpTypeTopK,
-				Params:    expr.Params,
-			}, bytesPerShard, nil
+			return m.mapApproxTopk(expr, false)
 		default:
 			// this should not be reachable. If an operation is shardable it should
 			// have an optimization listed. Nonetheless, we log this as a warning
@@ -369,31 +310,13 @@ func (m ShardMapper) mapVectorAggregationExpr(expr *syntax.VectorAggregationExpr
 		}
 	} else {
 		// if this AST contains unshardable operations, we still need to rewrite some operations (e.g. approx_topk) as if it had 0 shards as they are not supported on the querier
-		level.Error(util_log.Logger).Log(
-			"msg", "unshardable operation which is not supported by downstream querier",
-			"operation", expr.Operation,
-		)
 		switch expr.Operation {
 		case syntax.OpTypeApproxTopK:
-			_, bytesPerShard, err := m.shards.Resolver().Shards(expr)
-			if err != nil {
-				return nil, 0, err
-			}
-
-			countMinSketchExpr := syntax.MustClone(expr)
-			countMinSketchExpr.Operation = syntax.OpTypeCountMinSketch
-			countMinSketchExpr.Params = 0
-
-			return &syntax.VectorAggregationExpr{
-				Left: &CountMinSketchEvalExpr{
-					downstreams: []DownstreamSampleExpr{{
-						SampleExpr: countMinSketchExpr,
-					}},
-				},
-				Grouping:  expr.Grouping,
-				Operation: syntax.OpTypeTopK,
-				Params:    expr.Params,
-			}, bytesPerShard, nil
+			level.Error(util_log.Logger).Log(
+				"msg", "encountered unshardable approx_topk operation",
+				"operation", expr.Operation,
+			)
+			return m.mapApproxTopk(expr, true)
 		}
 	}
 
@@ -413,6 +336,69 @@ func (m ShardMapper) mapVectorAggregationExpr(expr *syntax.VectorAggregationExpr
 		Grouping:  expr.Grouping,
 		Params:    expr.Params,
 		Operation: expr.Operation,
+	}, bytesPerShard, nil
+}
+
+func (m ShardMapper) mapApproxTopk(expr *syntax.VectorAggregationExpr, forceNoShard bool) (*syntax.VectorAggregationExpr, uint64, error) {
+	// TODO(owen-d): integrate bounded sharding with approx_topk
+	// I'm not doing this now because it uses a separate code path and may not handle
+	// bounded shards in the same way
+	shards, bytesPerShard, err := m.shards.Resolver().Shards(expr)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	// approx_topk(k, inner) ->
+	// topk(
+	//   k,
+	//   eval_cms(
+	//     __count_min_sketch__(inner, shard=1) ++ __count_min_sketch__(inner, shard=2)...
+	//   )
+	// )
+
+	countMinSketchExpr := syntax.MustClone(expr)
+	countMinSketchExpr.Operation = syntax.OpTypeCountMinSketch
+	countMinSketchExpr.Params = 0
+
+	// Even if this query is not sharded the user wants an approximation. This is helpful if some
+	// inferred label has a very high cardinality. Note that the querier does not support CountMinSketchEvalExpr
+	// which is why it's evaluated on the front end.
+	if shards == 0 || forceNoShard {
+		return &syntax.VectorAggregationExpr{
+			Left: &CountMinSketchEvalExpr{
+				downstreams: []DownstreamSampleExpr{{
+					SampleExpr: countMinSketchExpr,
+				}},
+			},
+			Grouping:  expr.Grouping,
+			Operation: syntax.OpTypeTopK,
+			Params:    expr.Params,
+		}, bytesPerShard, nil
+	}
+
+	downstreams := make([]DownstreamSampleExpr, 0, shards)
+	for shard := 0; shard < shards; shard++ {
+		s := NewPowerOfTwoShard(index.ShardAnnotation{
+			Shard: uint32(shard),
+			Of:    uint32(shards),
+		})
+		downstreams = append(downstreams, DownstreamSampleExpr{
+			shard: &ShardWithChunkRefs{
+				Shard: s,
+			},
+			SampleExpr: countMinSketchExpr,
+		})
+	}
+
+	sharded := &CountMinSketchEvalExpr{
+		downstreams: downstreams,
+	}
+
+	return &syntax.VectorAggregationExpr{
+		Left:      sharded,
+		Grouping:  expr.Grouping,
+		Operation: syntax.OpTypeTopK,
+		Params:    expr.Params,
 	}, bytesPerShard, nil
 }
 

--- a/pkg/logql/shardmapper_test.go
+++ b/pkg/logql/shardmapper_test.go
@@ -245,7 +245,7 @@ func TestMappingStrings(t *testing.T) {
                sum by (foo_extracted) (
                    downstream<sumby(foo_extracted)(quantile_over_time(0.95,{foo="baz"}|logfmt|unwrapfoo_extracted|__error__=""[5m])),shard=0_of_2>++downstream<sumby(foo_extracted)(quantile_over_time(0.95,{foo="baz"}|logfmt|unwrapfoo_extracted|__error__=""[5m])),shard=1_of_2>
                )
-               / 
+               /
                sum by (foo_extracted) (
                    downstream<countby(foo_extracted)(quantile_over_time(0.95,{foo="baz"}|logfmt|unwrapfoo_extracted|__error__=""[5m])),shard=0_of_2>++downstream<countby(foo_extracted)(quantile_over_time(0.95,{foo="baz"}|logfmt|unwrapfoo_extracted|__error__=""[5m])),shard=1_of_2>
                )
@@ -653,6 +653,52 @@ func TestMapping(t *testing.T) {
 			},
 		},
 		{
+			in: `rate({foo="bar"}[5m]) > 3`,
+			expr: &syntax.BinOpExpr{
+				Op: syntax.OpTypeGT,
+				SampleExpr: &ConcatSampleExpr{
+					DownstreamSampleExpr: DownstreamSampleExpr{
+						shard: NewPowerOfTwoShard(index.ShardAnnotation{
+							Shard: 0,
+							Of:    2,
+						}).Bind(nil),
+						SampleExpr: &syntax.RangeAggregationExpr{
+							Operation: syntax.OpRangeTypeRate,
+							Left: &syntax.LogRangeExpr{
+								Left: &syntax.MatchersExpr{
+									Mts: []*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")},
+								},
+								Interval: 5 * time.Minute,
+							},
+						},
+					},
+					next: &ConcatSampleExpr{
+						DownstreamSampleExpr: DownstreamSampleExpr{
+							shard: NewPowerOfTwoShard(index.ShardAnnotation{
+								Shard: 1,
+								Of:    2,
+							}).Bind(nil),
+							SampleExpr: &syntax.RangeAggregationExpr{
+								Operation: syntax.OpRangeTypeRate,
+								Left: &syntax.LogRangeExpr{
+									Left: &syntax.MatchersExpr{
+										Mts: []*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")},
+									},
+									Interval: 5 * time.Minute,
+								},
+							},
+						},
+						next: nil,
+					},
+				},
+				RHS: &syntax.LiteralExpr{Val: 3},
+				Opts: &syntax.BinOpOptions{
+					ReturnBool:     false,
+					VectorMatching: &syntax.VectorMatching{},
+				},
+			},
+		},
+		{
 			in: `count_over_time({foo="bar"}[5m])`,
 			expr: &ConcatSampleExpr{
 				DownstreamSampleExpr: DownstreamSampleExpr{
@@ -831,6 +877,103 @@ func TestMapping(t *testing.T) {
 						},
 					},
 				},
+			},
+		},
+		{
+			in: `approx_topk(3, rate({foo="bar"}[5m]) > 3)`,
+			expr: &syntax.VectorAggregationExpr{
+				Grouping:  &syntax.Grouping{},
+				Params:    3,
+				Operation: syntax.OpTypeTopK,
+				Left: &CountMinSketchEvalExpr{
+					downstreams: []DownstreamSampleExpr{
+						{
+							shard: NewPowerOfTwoShard(index.ShardAnnotation{
+								Shard: 0,
+								Of:    2,
+							}).Bind(nil),
+							SampleExpr: &syntax.VectorAggregationExpr{
+								Operation: syntax.OpTypeCountMinSketch,
+								Left: &syntax.BinOpExpr{
+									Op: syntax.OpTypeGT,
+									SampleExpr: &syntax.RangeAggregationExpr{
+										Operation: syntax.OpRangeTypeRate,
+										Left: &syntax.LogRangeExpr{
+											Left: &syntax.MatchersExpr{
+												Mts: []*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")},
+											},
+											Interval: 5 * time.Minute,
+										},
+									},
+									RHS: &syntax.LiteralExpr{Val: 3},
+									Opts: &syntax.BinOpOptions{
+										ReturnBool:     false,
+										VectorMatching: &syntax.VectorMatching{},
+									},
+								},
+								Grouping: &syntax.Grouping{},
+							},
+						},
+						{
+							shard: NewPowerOfTwoShard(index.ShardAnnotation{
+								Shard: 1,
+								Of:    2,
+							}).Bind(nil),
+							SampleExpr: &syntax.VectorAggregationExpr{
+								Operation: syntax.OpTypeCountMinSketch,
+								Left: &syntax.BinOpExpr{
+									Op: syntax.OpTypeGT,
+									SampleExpr: &syntax.RangeAggregationExpr{
+										Operation: syntax.OpRangeTypeRate,
+										Left: &syntax.LogRangeExpr{
+											Left: &syntax.MatchersExpr{
+												Mts: []*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")},
+											},
+											Interval: 5 * time.Minute,
+										},
+									},
+									RHS: &syntax.LiteralExpr{Val: 3},
+									Opts: &syntax.BinOpOptions{
+										ReturnBool:     false,
+										VectorMatching: &syntax.VectorMatching{},
+									},
+								},
+								Grouping: &syntax.Grouping{},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			// A contrived query that is not shardable: but we must rewrite `approx_topk` as if it had 0 shards because the approx_topk operation is not supported on the querier
+			in: `approx_topk(3, topk(5, rate({foo="bar"}[5m])))`,
+			expr: &syntax.VectorAggregationExpr{
+				Left: &CountMinSketchEvalExpr{
+					downstreams: []DownstreamSampleExpr{{
+						SampleExpr: &syntax.VectorAggregationExpr{
+							Operation: syntax.OpTypeCountMinSketch,
+							Left: &syntax.VectorAggregationExpr{Operation: syntax.OpTypeTopK,
+								Params: 5,
+								Left: &syntax.RangeAggregationExpr{
+									Operation: syntax.OpRangeTypeRate,
+									Left: &syntax.LogRangeExpr{
+										Left: &syntax.MatchersExpr{
+											Mts: []*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")},
+										},
+										Interval: 5 * time.Minute,
+									},
+								},
+								Grouping: &syntax.Grouping{},
+							},
+							Grouping: &syntax.Grouping{},
+						},
+						shard: nil,
+					}},
+				},
+				Grouping:  &syntax.Grouping{},
+				Operation: syntax.OpTypeTopK,
+				Params:    3,
 			},
 		},
 		{

--- a/pkg/logql/shardmapper_test.go
+++ b/pkg/logql/shardmapper_test.go
@@ -888,37 +888,7 @@ func TestMapping(t *testing.T) {
 				Left: &CountMinSketchEvalExpr{
 					downstreams: []DownstreamSampleExpr{
 						{
-							shard: NewPowerOfTwoShard(index.ShardAnnotation{
-								Shard: 0,
-								Of:    2,
-							}).Bind(nil),
-							SampleExpr: &syntax.VectorAggregationExpr{
-								Operation: syntax.OpTypeCountMinSketch,
-								Left: &syntax.BinOpExpr{
-									Op: syntax.OpTypeGT,
-									SampleExpr: &syntax.RangeAggregationExpr{
-										Operation: syntax.OpRangeTypeRate,
-										Left: &syntax.LogRangeExpr{
-											Left: &syntax.MatchersExpr{
-												Mts: []*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")},
-											},
-											Interval: 5 * time.Minute,
-										},
-									},
-									RHS: &syntax.LiteralExpr{Val: 3},
-									Opts: &syntax.BinOpOptions{
-										ReturnBool:     false,
-										VectorMatching: &syntax.VectorMatching{},
-									},
-								},
-								Grouping: &syntax.Grouping{},
-							},
-						},
-						{
-							shard: NewPowerOfTwoShard(index.ShardAnnotation{
-								Shard: 1,
-								Of:    2,
-							}).Bind(nil),
+							shard: nil,
 							SampleExpr: &syntax.VectorAggregationExpr{
 								Operation: syntax.OpTypeCountMinSketch,
 								Left: &syntax.BinOpExpr{

--- a/pkg/logql/syntax/ast.go
+++ b/pkg/logql/syntax/ast.go
@@ -2291,12 +2291,6 @@ var shardableOps = map[string]bool{
 	// binops - arith
 	OpTypeAdd: true,
 	OpTypeMul: true,
-
-	// binops - comparison
-	OpTypeGT:  true,
-	OpTypeGTE: true,
-	OpTypeLT:  true,
-	OpTypeLTE: true,
 }
 
 type MatcherRange struct {

--- a/pkg/logql/syntax/ast.go
+++ b/pkg/logql/syntax/ast.go
@@ -2291,6 +2291,12 @@ var shardableOps = map[string]bool{
 	// binops - arith
 	OpTypeAdd: true,
 	OpTypeMul: true,
+
+	// binops - comparison
+	OpTypeGT:  true,
+	OpTypeGTE: true,
+	OpTypeLT:  true,
+	OpTypeLTE: true,
 }
 
 type MatcherRange struct {


### PR DESCRIPTION
**What this PR does / why we need it**:
Calling approx_topk on some types of queries was causing a panic in the querier.
* This is because the approx_topk operation is not supported on the querier and can only be executed on the front-end and MUST be rewritten.
* In some operations, the approx_topk was not considered shardable and we did not rewrite this query. Specifically, comparison operators are not considered shardable and so skip the rewriting & cause the queriers to panic.

This PR does 2 things:
~1. Adds comparison operators to "shardableOps" map. This means they will be considered shardable and trigger the sharding logic. This is the same as the existing arithmetic operators - we don't have any special logic for them, though it doesn't really give us any benefit either.~ Removed because it not clear this is still correct.
2. Adds a catch-all for the approx_topk operation. If the inner query is NOT shardable, we still rewrite the logic as if there are 0 shards and send the inner query to the querier. This won't panic but it shouldn't be happening a lot so I added an error log.

I added tests for these cases & did some local testing to check they behave as intended.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
