### PR TITLE
chore: Print trace ID in panic when available.

### DIFF
--- a/pkg/util/server/recovery.go
+++ b/pkg/util/server/recovery.go
@@ -10,8 +10,10 @@ import (
 	"github.com/grafana/dskit/httpgrpc"
 	"github.com/grafana/dskit/middleware"
 	grpc_recovery "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/recovery"
+	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/uber/jaeger-client-go"
 
 	"github.com/grafana/loki/v3/pkg/querier/queryrange/queryrangebase"
 	"github.com/grafana/loki/v3/pkg/util/constants"
@@ -30,20 +32,20 @@ var (
 		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 			defer func() {
 				if p := recover(); p != nil {
-					WriteError(onPanic(p), w)
+					WriteError(onPanic(req.Context(), p), w)
 				}
 			}()
 			next.ServeHTTP(w, req)
 		})
 	})
-	RecoveryGRPCStreamInterceptor = grpc_recovery.StreamServerInterceptor(grpc_recovery.WithRecoveryHandler(onPanic))
-	RecoveryGRPCUnaryInterceptor  = grpc_recovery.UnaryServerInterceptor(grpc_recovery.WithRecoveryHandler(onPanic))
+	RecoveryGRPCStreamInterceptor = grpc_recovery.StreamServerInterceptor(grpc_recovery.WithRecoveryHandlerContext(onPanic))
+	RecoveryGRPCUnaryInterceptor  = grpc_recovery.UnaryServerInterceptor(grpc_recovery.WithRecoveryHandlerContext(onPanic))
 
 	RecoveryMiddleware queryrangebase.Middleware = queryrangebase.MiddlewareFunc(func(next queryrangebase.Handler) queryrangebase.Handler {
 		return queryrangebase.HandlerFunc(func(ctx context.Context, req queryrangebase.Request) (res queryrangebase.Response, err error) {
 			defer func() {
 				if p := recover(); p != nil {
-					err = onPanic(p)
+					err = onPanic(ctx, p)
 				}
 			}()
 			res, err = next.Do(ctx, req)
@@ -52,11 +54,27 @@ var (
 	})
 )
 
-func onPanic(p interface{}) error {
+func onPanic(ctx context.Context, p interface{}) error {
 	stack := make([]byte, maxStacksize)
 	stack = stack[:runtime.Stack(stack, true)]
+	traceID := jaegerTraceID(ctx)
+
 	// keep a multiline stack
-	fmt.Fprintf(os.Stderr, "panic: %v\n%s", p, stack)
+	fmt.Fprintf(os.Stderr, "panic: %v %s\n%s", p, traceID, stack)
 	panicTotal.Inc()
 	return httpgrpc.Errorf(http.StatusInternalServerError, "error while processing request: %v", p)
+}
+
+func jaegerTraceID(ctx context.Context) string {
+	span := opentracing.SpanFromContext(ctx)
+	if span == nil {
+		return ""
+	}
+
+	spanContext, ok := span.Context().(jaeger.SpanContext)
+	if !ok {
+		return ""
+	}
+
+	return "traceID=" + spanContext.TraceID().String()
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Debugging a panic log is simplified if the trace ID is printed as well.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
