### PR TITLE
fix(promtail): windows forward event crash

### DIFF
--- a/clients/pkg/promtail/targets/windows/win_eventlog/event.go
+++ b/clients/pkg/promtail/targets/windows/win_eventlog/event.go
@@ -33,26 +33,39 @@ package win_eventlog
 // More info on schema, if there will be need to add more:
 // https://docs.microsoft.com/en-us/windows/win32/wes/eventschema-elements
 type Event struct {
-	Source        Provider    `xml:"System>Provider"`
-	EventID       int         `xml:"System>EventID"`
-	Version       int         `xml:"System>Version"`
-	Level         int         `xml:"System>Level"`
-	Task          int         `xml:"System>Task"`
-	Opcode        int         `xml:"System>Opcode"`
-	Keywords      string      `xml:"System>Keywords"`
-	TimeCreated   TimeCreated `xml:"System>TimeCreated"`
-	EventRecordID int         `xml:"System>EventRecordID"`
-	Correlation   Correlation `xml:"System>Correlation"`
-	Execution     Execution   `xml:"System>Execution"`
-	Channel       string      `xml:"System>Channel"`
-	Computer      string      `xml:"System>Computer"`
-	Security      Security    `xml:"System>Security"`
-	UserData      UserData    `xml:"UserData"`
-	EventData     EventData   `xml:"EventData"`
+	Source        Provider       `xml:"System>Provider"`
+	EventID       int            `xml:"System>EventID"`
+	Version       int            `xml:"System>Version"`
+	Level         int            `xml:"System>Level"`
+	Task          int            `xml:"System>Task"`
+	Opcode        int            `xml:"System>Opcode"`
+	Keywords      string         `xml:"System>Keywords"`
+	TimeCreated   TimeCreated    `xml:"System>TimeCreated"`
+	EventRecordID int            `xml:"System>EventRecordID"`
+	Correlation   Correlation    `xml:"System>Correlation"`
+	Execution     Execution      `xml:"System>Execution"`
+	Channel       string         `xml:"System>Channel"`
+	Computer      string         `xml:"System>Computer"`
+	Security      Security       `xml:"System>Security"`
+	UserData      UserData       `xml:"UserData"`
+	EventData     EventData      `xml:"EventData"`
+	RenderingInfo *RenderingInfo `xml:"RenderingInfo"`
 	Message       string
 	LevelText     string
 	TaskText      string
 	OpcodeText    string
+}
+
+// RenderingInfo is provided for events forwarded by Windows Event Collector
+// see https://learn.microsoft.com/en-us/windows/win32/api/winevt/nf-winevt-evtformatmessage#parameters
+type RenderingInfo struct {
+	Message  string   `xml:"Message"`
+	Level    string   `xml:"Level"`
+	Task     string   `xml:"Task"`
+	Opcode   string   `xml:"Opcode"`
+	Channel  string   `xml:"Channel"`
+	Provider string   `xml:"Provider"`
+	Keywords []string `xml:"Keywords>Keyword"`
 }
 
 // UserData Application-provided XML data


### PR DESCRIPTION
**What this PR does / why we need it**:

In Alloy we are still using the win_eventlog pkg from Promtail and a user reported that some windows events would make Alloy crash during ingestion (https://github.com/grafana/alloy/issues/2616).

During the investigation, I found out that this code was taken from Telegraf and that this is a problem that they encountered and solved via https://github.com/influxdata/telegraf/pull/12375.

I ported the fix to my local loki and built a custom Alloy version with it. The user tested and reported that the bug was solved: https://github.com/grafana/alloy/issues/2616#issuecomment-2646161039

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
