### PR TITLE
fix(dataobj): Fix shutdown race in dataobj consumer

### DIFF
--- a/pkg/dataobj/consumer/service.go
+++ b/pkg/dataobj/consumer/service.go
@@ -109,6 +109,10 @@ func (s *Service) handlePartitionsAssigned(ctx context.Context, client *kgo.Clie
 
 func (s *Service) handlePartitionsRevoked(partitions map[string][]int32) {
 	level.Info(s.logger).Log("msg", "partitions revoked", "partitions", formatPartitionsMap(partitions))
+	if s.State() == services.Stopping {
+		// On shutdown, franz-go will send one more partitionRevoked event which we need to ignore to shutdown gracefully.
+		return
+	}
 	s.partitionMtx.Lock()
 	defer s.partitionMtx.Unlock()
 


### PR DESCRIPTION
**What this PR does / why we need it**:
dataobj-consumers were hanging at shutdown. This PR fixes the hang by ignoring handlePartitionRevoked events when shutting down: The hang was due to waiting on the s.partitionMtx, which is also locked in `stopping()`. The handler needs to return so closing the Kafka client in `stopping()` can complete.