### PR TITLE
fix: Make policy test non-flaky

### DIFF
--- a/pkg/validation/ingestion_policies_test.go
+++ b/pkg/validation/ingestion_policies_test.go
@@ -31,7 +31,7 @@ func Test_PolicyStreamMapping_PolicyFor(t *testing.T) {
 		"policy3": []*PriorityStream{
 			{
 				Selector: `{qyx="qzx", qox="qox"}`,
-				Priority: 1,
+				Priority: 2,
 				Matchers: []*labels.Matcher{
 					labels.MustNewMatcher(labels.MatchEqual, "qyx", "qzx"),
 					labels.MustNewMatcher(labels.MatchEqual, "qox", "qox"),
@@ -51,7 +51,7 @@ func Test_PolicyStreamMapping_PolicyFor(t *testing.T) {
 		"policy5": []*PriorityStream{
 			{
 				Selector: `{qab=~"qzx.*"}`,
-				Priority: 1,
+				Priority: 2,
 				Matchers: []*labels.Matcher{
 					labels.MustNewMatcher(labels.MatchRegexp, "qab", "qzx.*"),
 				},
@@ -94,7 +94,7 @@ func Test_PolicyStreamMapping_PolicyFor(t *testing.T) {
 	require.Equal(t, "policy1", mapping.PolicyFor(labels.FromStrings("foo", "bar")))
 	// matches both policy2 and policy1 but policy1 has higher priority.
 	require.Equal(t, "policy1", mapping.PolicyFor(labels.FromStrings("foo", "bar", "daz", "baz")))
-	// matches policy3 and policy4 but policy3 appears first.
+	// matches policy3 and policy4 but policy3 has higher priority..
 	require.Equal(t, "policy3", mapping.PolicyFor(labels.FromStrings("qyx", "qzx", "qox", "qox")))
 	// matches no policy.
 	require.Equal(t, "", mapping.PolicyFor(labels.FromStrings("foo", "fooz", "daz", "qux", "quux", "corge")))


### PR DESCRIPTION
**What this PR does / why we need it**:
This test scenario I'm fixing is flaky because it assumes items will appear in a specific order but Go doesn't guarantee that (it actually randomizes them by design).

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
