### PR TITLE
fix(ci): Pass image tag details to logcli docker build

### DIFF
--- a/cmd/logcli/Dockerfile
+++ b/cmd/logcli/Dockerfile
@@ -1,9 +1,10 @@
 ARG GO_VERSION=1.23
+ARG IMAGE_TAG
 FROM golang:${GO_VERSION} AS build
 
 COPY . /src/loki
 WORKDIR /src/loki
-RUN make clean && make BUILD_IN_CONTAINER=false logcli
+RUN make clean && make BUILD_IN_CONTAINER=false IMAGE_TAG=${IMAGE_TAG} logcli
 
 
 FROM gcr.io/distroless/static:debug


### PR DESCRIPTION
**What this PR does / why we need it**:
Follow on to https://github.com/grafana/loki/pull/15939.  This adds build info to the `logcli` Docker image.

```
% docker run docker.io/grafana/logcli:paul1r-fix_build_info_logcli-656b1fa-WIP  --version
logcli, version  (branch: paul1r/fix_build_info_logcli, revision: 656b1faaa)
  build user:       root@buildkitsandbox
  build date:       2025-02-10T14:13:41Z
  go version:       go1.23.6
  platform:         linux/arm64
  tags:             netgo

```
**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [X] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
