### PR TITLE
chore(ci): Republish lambda promtail images

### DIFF
--- a/.github/release-workflows.jsonnet
+++ b/.github/release-workflows.jsonnet
@@ -40,7 +40,7 @@ local weeklyImageJobs = {
   promtail: build.weeklyImage('promtail', 'clients/cmd/promtail', platform=platforms.all),
 };
 
-local lambdaPromtailJob = 
+local lambdaPromtailJob =
   job.new()
   + job.withNeeds(['check'])
   + job.withEnv({
@@ -52,10 +52,10 @@ local lambdaPromtailJob =
     REPO: 'loki',
   })
   + job.withOutputs({
-    'image_digest_linux_amd64': '${{ steps.digest.outputs.digest_linux_amd64 }}',
-    'image_digest_linux_arm64': '${{ steps.digest.outputs.digest_linux_arm64 }}',
-    'image_name': '${{ steps.weekly-version.outputs.image_name }}',
-    'image_tag': '${{ steps.weekly-version.outputs.image_version }}',
+    image_digest_linux_amd64: '${{ steps.digest.outputs.digest_linux_amd64 }}',
+    image_digest_linux_arm64: '${{ steps.digest.outputs.digest_linux_arm64 }}',
+    image_name: '${{ steps.weekly-version.outputs.image_name }}',
+    image_tag: '${{ steps.weekly-version.outputs.image_version }}',
   })
   + job.withStrategy({
     'fail-fast': true,

--- a/.github/release-workflows.jsonnet
+++ b/.github/release-workflows.jsonnet
@@ -40,6 +40,100 @@ local weeklyImageJobs = {
   promtail: build.weeklyImage('promtail', 'clients/cmd/promtail', platform=platforms.all),
 };
 
+local lambdaPromtailJob = 
+  job.new()
+  + job.withNeeds(['check'])
+  + job.withEnv({
+    BUILD_TIMEOUT: imageBuildTimeoutMin,
+    GO_VERSION: goVersion,
+    IMAGE_PREFIX: 'public.ecr.aws/grafana',
+    RELEASE_LIB_REF: releaseLibRef,
+    RELEASE_REPO: 'grafana/loki',
+    REPO: 'loki',
+  })
+  + job.withOutputs({
+    'image_digest_linux_amd64': '${{ steps.digest.outputs.digest_linux_amd64 }}',
+    'image_digest_linux_arm64': '${{ steps.digest.outputs.digest_linux_arm64 }}',
+    'image_name': '${{ steps.weekly-version.outputs.image_name }}',
+    'image_tag': '${{ steps.weekly-version.outputs.image_version }}',
+  })
+  + job.withStrategy({
+    'fail-fast': true,
+    matrix: {
+      include: [
+        { arch: 'linux/amd64', runs_on: ['github-hosted-ubuntu-x64-small'] },
+        { arch: 'linux/arm64', runs_on: ['github-hosted-ubuntu-arm64-small'] },
+      ],
+    },
+  })
+  + { 'runs-on': '${{ matrix.runs_on }}' }
+  + job.withSteps([
+    step.new('pull release library code', 'actions/checkout@v4')
+    + step.with({
+      path: 'lib',
+      ref: '${{ env.RELEASE_LIB_REF }}',
+      repository: 'grafana/loki-release',
+    }),
+    step.new('pull code to release', 'actions/checkout@v4')
+    + step.with({
+      path: 'release',
+      repository: '${{ env.RELEASE_REPO }}',
+    }),
+    step.new('setup node', 'actions/setup-node@v4')
+    + step.with({
+      'node-version': '20',
+    }),
+    step.new('Set up Docker buildx', 'docker/setup-buildx-action@v3'),
+    step.new('get-secrets', 'grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets-v1.1.0')
+    + { id: 'get-secrets' }
+    + step.with({
+      repo_secrets: |||
+        ECR_ACCESS_KEY=aws-credentials:access_key_id
+        ECR_SECRET_KEY=aws-credentials:secret_access_key
+      |||,
+    }),
+    step.new('Configure AWS credentials', 'aws-actions/configure-aws-credentials@v4')
+    + step.with({
+      'aws-access-key-id': '${{ env.ECR_ACCESS_KEY }}',
+      'aws-secret-access-key': '${{ env.ECR_SECRET_KEY }}',
+      'aws-region': 'us-east-1',
+    }),
+    step.new('Login to Amazon ECR Public', 'aws-actions/amazon-ecr-login@v2')
+    + step.with({
+      'registry-type': 'public',
+    }),
+    step.new('Get weekly version')
+    + { id: 'weekly-version' }
+    + { 'working-directory': 'release' }
+    + step.withRun(|||
+      version=$(./tools/image-tag)
+      echo "image_version=$version" >> $GITHUB_OUTPUT
+      echo "image_name=${{ env.IMAGE_PREFIX }}/lambda-promtail" >> $GITHUB_OUTPUT
+      echo "image_full_name=${{ env.IMAGE_PREFIX }}/lambda-promtail:$version" >> $GITHUB_OUTPUT
+    |||),
+    step.new('Prepare tag name')
+    + { id: 'prepare-tag' }
+    + step.withRun(|||
+      arch=$(echo ${{ matrix.arch }} | cut -d'/' -f2)
+      echo "IMAGE_TAG=${{ steps.weekly-version.outputs.image_name }}:${{ steps.weekly-version.outputs.image_version }}-${arch}" >> $GITHUB_OUTPUT
+    |||),
+    step.new('Build and push', 'docker/build-push-action@v6')
+    + { id: 'build-push' }
+    + { 'timeout-minutes': '${{ fromJSON(env.BUILD_TIMEOUT) }}' }
+    + step.with({
+      'build-args': |||
+        IMAGE_TAG=${{ steps.weekly-version.outputs.image_version }}
+        GO_VERSION=${{ env.GO_VERSION }}
+      |||,
+      context: 'release',
+      file: 'release/tools/lambda-promtail/Dockerfile',
+      outputs: 'type=image,push=true',
+      platform: '${{ matrix.arch }}',
+      provenance: false,
+      tags: '${{ steps.prepare-tag.outputs.IMAGE_TAG }}',
+    }),
+  ]);
+
 {
   'patch-release-pr.yml': std.manifestYamlDoc(
     lokiRelease.releasePRWorkflow(
@@ -116,7 +210,7 @@ local weeklyImageJobs = {
     on: {
       push: {
         branches: [
-          'k[0-9]+*',  // This is a weird glob pattern, not a regexp, do not use ".*", see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
+          'k[0-9]+*',
           'main',
         ],
       },
@@ -150,6 +244,8 @@ local weeklyImageJobs = {
           GO_VERSION: goVersion,
         })
       for name in std.objectFields(weeklyImageJobs)
+    } + {
+      'lambda-promtail-image': lambdaPromtailJob,
     } + {
       ['%s-manifest' % name]:
         job.new()

--- a/.github/release-workflows.jsonnet
+++ b/.github/release-workflows.jsonnet
@@ -210,7 +210,7 @@ local lambdaPromtailJob =
     on: {
       push: {
         branches: [
-          'k[0-9]+*',
+          'k[0-9]+*',  // This is a weird glob pattern, not a regexp, do not use ".*", see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
           'main',
         ],
       },

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,17 +1,15 @@
-name: "check"
-
-on:
-  pull_request:
-  push:
-    branches:
-      - main
-
-jobs:
-  check:
-    uses: "grafana/loki-release/.github/workflows/check.yml@main"
-    with:
-      build_image: "grafana/loki-build-image:0.34.5"
-      golang_ci_lint_version: "v1.60.3"
-      release_lib_ref: "main"
-      skip_validation: false
-      use_github_app_token: true
+"jobs":
+  "check":
+    "uses": "grafana/loki-release/.github/workflows/check.yml@main"
+    "with":
+      "build_image": "grafana/loki-build-image:0.34.5"
+      "golang_ci_lint_version": "v1.60.3"
+      "release_lib_ref": "main"
+      "skip_validation": false
+      "use_github_app_token": true
+"name": "check"
+"on":
+  "pull_request": {}
+  "push":
+    "branches":
+    - "main"

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -7,6 +7,94 @@
       "release_lib_ref": "main"
       "skip_validation": false
       "use_github_app_token": true
+  "lambda-promtail-image":
+    "env":
+      "BUILD_TIMEOUT": 60
+      "GO_VERSION": "1.23.6"
+      "IMAGE_PREFIX": "public.ecr.aws/grafana"
+      "RELEASE_LIB_REF": "main"
+      "RELEASE_REPO": "grafana/loki"
+      "REPO": "loki"
+    "needs":
+    - "check"
+    "outputs":
+      "image_digest_linux_amd64": "${{ steps.digest.outputs.digest_linux_amd64 }}"
+      "image_digest_linux_arm64": "${{ steps.digest.outputs.digest_linux_arm64 }}"
+      "image_name": "${{ steps.weekly-version.outputs.image_name }}"
+      "image_tag": "${{ steps.weekly-version.outputs.image_version }}"
+    "runs-on": "${{ matrix.runs_on }}"
+    "steps":
+    - "name": "pull release library code"
+      "uses": "actions/checkout@v4"
+      "with":
+        "path": "lib"
+        "ref": "${{ env.RELEASE_LIB_REF }}"
+        "repository": "grafana/loki-release"
+    - "name": "pull code to release"
+      "uses": "actions/checkout@v4"
+      "with":
+        "path": "release"
+        "repository": "${{ env.RELEASE_REPO }}"
+    - "name": "setup node"
+      "uses": "actions/setup-node@v4"
+      "with":
+        "node-version": "20"
+    - "name": "Set up Docker buildx"
+      "uses": "docker/setup-buildx-action@v3"
+    - "id": "get-secrets"
+      "name": "get-secrets"
+      "uses": "grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets-v1.1.0"
+      "with":
+        "repo_secrets": |
+          ECR_ACCESS_KEY=aws-credentials:access_key_id
+          ECR_SECRET_KEY=aws-credentials:secret_access_key
+    - "name": "Configure AWS credentials"
+      "uses": "aws-actions/configure-aws-credentials@v4"
+      "with":
+        "aws-access-key-id": "${{ env.ECR_ACCESS_KEY }}"
+        "aws-region": "us-east-1"
+        "aws-secret-access-key": "${{ env.ECR_SECRET_KEY }}"
+    - "name": "Login to Amazon ECR Public"
+      "uses": "aws-actions/amazon-ecr-login@v2"
+      "with":
+        "registry-type": "public"
+    - "id": "weekly-version"
+      "name": "Get weekly version"
+      "run": |
+        version=$(./tools/image-tag)
+        echo "image_version=$version" >> $GITHUB_OUTPUT
+        echo "image_name=${{ env.IMAGE_PREFIX }}/lambda-promtail" >> $GITHUB_OUTPUT
+        echo "image_full_name=${{ env.IMAGE_PREFIX }}/lambda-promtail:$version" >> $GITHUB_OUTPUT
+      "working-directory": "release"
+    - "id": "prepare-tag"
+      "name": "Prepare tag name"
+      "run": |
+        arch=$(echo ${{ matrix.arch }} | cut -d'/' -f2)
+        echo "IMAGE_TAG=${{ steps.weekly-version.outputs.image_name }}:${{ steps.weekly-version.outputs.image_version }}-${arch}" >> $GITHUB_OUTPUT
+    - "id": "build-push"
+      "name": "Build and push"
+      "timeout-minutes": "${{ fromJSON(env.BUILD_TIMEOUT) }}"
+      "uses": "docker/build-push-action@v6"
+      "with":
+        "build-args": |
+          IMAGE_TAG=${{ steps.weekly-version.outputs.image_version }}
+          GO_VERSION=${{ env.GO_VERSION }}
+        "context": "release"
+        "file": "release/tools/lambda-promtail/Dockerfile"
+        "outputs": "type=image,push=true"
+        "platform": "${{ matrix.arch }}"
+        "provenance": false
+        "tags": "${{ steps.prepare-tag.outputs.IMAGE_TAG }}"
+    "strategy":
+      "fail-fast": true
+      "matrix":
+        "include":
+        - "arch": "linux/amd64"
+          "runs_on":
+          - "github-hosted-ubuntu-x64-small"
+        - "arch": "linux/arm64"
+          "runs_on":
+          - "github-hosted-ubuntu-arm64-small"
   "loki-canary-boringcrypto-image":
     "env":
       "BUILD_TIMEOUT": 60
@@ -439,91 +527,6 @@
           ${{ needs.promtail-image.outputs.image_name }}@${{ needs.promtail-image.outputs.image_digest_linux_arm64 }} \
           ${{ needs.promtail-image.outputs.image_name }}@${{ needs.promtail-image.outputs.image_digest_linux_arm }}
         docker buildx imagetools inspect $IMAGE
-  lambda-promtail-image:
-    env:
-      BUILD_TIMEOUT: "60"
-      GO_VERSION: "1.23.6"
-      IMAGE_PREFIX: "public.ecr.aws/grafana"
-      RELEASE_LIB_REF: "main"
-      RELEASE_REPO: "grafana/loki"
-      REPO: "loki"
-    needs:
-      - "check"
-    outputs:
-      image_digest_linux_amd64: "${{ steps.digest.outputs.digest_linux_amd64 }}"
-      image_digest_linux_arm64: "${{ steps.digest.outputs.digest_linux_arm64 }}"
-      image_name: "${{ steps.weekly-version.outputs.image_name }}"
-      image_tag: "${{ steps.weekly-version.outputs.image_version }}"
-    runs-on: "${{ matrix.runs_on }}"
-    steps:
-    - name: "pull release library code"
-      uses: "actions/checkout@v4"
-      with:
-        path: "lib"
-        ref: "${{ env.RELEASE_LIB_REF }}"
-        repository: "grafana/loki-release"
-    - name: "pull code to release"
-      uses: "actions/checkout@v4"
-      with:
-        path: "release"
-        repository: "${{ env.RELEASE_REPO }}"
-    - name: "setup node"
-      uses: "actions/setup-node@v4"
-      with:
-        node-version: "20"
-    - name: "Set up Docker buildx"
-      uses: "docker/setup-buildx-action@v3"
-    - id: "get-secrets"
-      uses: "grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets-v1.1.0"
-      with:
-        repo_secrets: |
-          ECR_ACCESS_KEY=aws-credentials:access_key_id
-          ECR_SECRET_KEY=aws-credentials:secret_access_key
-    - name: "Configure AWS credentials"
-      uses: "aws-actions/configure-aws-credentials@v4"
-      with:
-        aws-access-key-id: "${{ env.ECR_ACCESS_KEY }}"
-        aws-secret-access-key: "${{ env.ECR_SECRET_KEY }}"
-        aws-region: "us-east-1"
-    - name: "Login to Amazon ECR Public"
-      uses: "aws-actions/amazon-ecr-login@v2"
-      with:
-        registry-type: "public"
-    - id: "weekly-version"
-      name: "Get weekly version"
-      run: |
-        version=$(./tools/image-tag)
-        echo "image_version=$version" >> $GITHUB_OUTPUT
-        echo "image_name=${{ env.IMAGE_PREFIX }}/lambda-promtail" >> $GITHUB_OUTPUT
-        echo "image_full_name=${{ env.IMAGE_PREFIX }}/lambda-promtail:$version" >> $GITHUB_OUTPUT
-      working-directory: "release"
-    - id: "prepare-tag"
-      name: "Prepare tag name"
-      run: |
-        arch=$(echo ${{ matrix.arch }} | cut -d'/' -f2)
-        echo "IMAGE_TAG=${{ steps.weekly-version.outputs.image_name }}:${{ steps.weekly-version.outputs.image_version }}-${arch}" >> $GITHUB_OUTPUT
-    - id: "build-push"
-      name: "Build and push"
-      timeout-minutes: "${{ fromJSON(env.BUILD_TIMEOUT) }}"
-      uses: "docker/build-push-action@v6"
-      with:
-        build-args: |
-          IMAGE_TAG=${{ steps.weekly-version.outputs.image_version }}
-          GO_VERSION=${{ env.GO_VERSION }}
-        context: "release"
-        file: "release/tools/lambda-promtail/Dockerfile"
-        outputs: "type=image,push=true"
-        platform: "${{ matrix.arch }}"
-        provenance: false
-        tags: "${{ steps.prepare-tag.outputs.IMAGE_TAG }}"
-    strategy:
-      fail-fast: true
-      matrix:
-        include:
-        - arch: "linux/amd64"
-          runs_on: "github-hosted-ubuntu-x64-small"
-        - arch: "linux/arm64"
-          runs_on: "github-hosted-ubuntu-arm64-small"      
 "name": "Publish images"
 "on":
   "push":

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -1,345 +1,325 @@
-name: "Publish images"
-
-on:
-  push:
-    branches:
-      - "k[0-9]+*"
-      - "main"
-  workflow_dispatch: {}
-
-permissions:
-  contents: "write"
-  id-token: "write"
-  pull-requests: "write"
-
-env:
-  BUILD_TIMEOUT: "60"
-  GO_VERSION: "1.23.6"
-  IMAGE_PREFIX: "grafana"
-  RELEASE_LIB_REF: "main"
-  RELEASE_REPO: "grafana/loki"
-
-jobs:
-  check:
-    uses: "grafana/loki-release/.github/workflows/check.yml@main"
-    with:
-      build_image: "grafana/loki-build-image:0.34.5"
-      golang_ci_lint_version: "v1.60.3"
-      release_lib_ref: "main"
-      skip_validation: false
-      use_github_app_token: true
-
-  loki-canary-boringcrypto-image:
-    needs: ["check"]
-    runs-on: "${{ matrix.runs_on }}"
-    outputs:
-      image_digest_linux_amd64: "${{ steps.digest.outputs.digest_linux_amd64 }}"
-      image_digest_linux_arm: "${{ steps.digest.outputs.digest_linux_arm }}"
-      image_digest_linux_arm64: "${{ steps.digest.outputs.digest_linux_arm64 }}"
-      image_name: "${{ steps.weekly-version.outputs.image_name }}"
-      image_tag: "${{ steps.weekly-version.outputs.image_version }}"
-    steps:
-      - name: "pull release library code"
-        uses: "actions/checkout@v4"
-        with:
-          path: "lib"
-          ref: "${{ env.RELEASE_LIB_REF }}"
-          repository: "grafana/loki-release"
-
-      - name: "pull code to release"
-        uses: "actions/checkout@v4"
-        with:
-          path: "release"
-          repository: "${{ env.RELEASE_REPO }}"
-
-      - name: "setup node"
-        uses: "actions/setup-node@v4"
-        with:
-          node-version: "20"
-
-      - name: "Set up Docker buildx"
-        uses: "docker/setup-buildx-action@v3"
-
-      - name: "Login to DockerHub (from Vault)"
-        uses: "grafana/shared-workflows/actions/dockerhub-login@main"
-
-      - id: "weekly-version"
-        name: "Get weekly version"
-        working-directory: "release"
-        run: |
-          version=$(./tools/image-tag)
-          echo "image_version=$version" >> $GITHUB_OUTPUT
-          echo "image_name=${{ env.IMAGE_PREFIX }}/loki-canary-boringcrypto" >> $GITHUB_OUTPUT
-          echo "image_full_name=${{ env.IMAGE_PREFIX }}/loki-canary-boringcrypto:$version" >> $GITHUB_OUTPUT
-
-      - id: "platform"
-        name: "Parse image platform"
-        working-directory: "release"
-        run: |
-          platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
-          echo "platform=${platform}" >> $GITHUB_OUTPUT
-          echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
-
-      - id: "build-push"
-        name: "Build and push"
-        timeout-minutes: "${{ fromJSON(env.BUILD_TIMEOUT) }}"
-        uses: "docker/build-push-action@v6"
-        with:
-          build-args: |
-            IMAGE_TAG=${{ steps.weekly-version.outputs.image_version }}
-            GO_VERSION=${{ env.GO_VERSION }}
-          context: "release"
-          file: "release/cmd/loki-canary-boringcrypto/Dockerfile"
-          outputs: "push-by-digest=true,type=image,name=${{ steps.weekly-version.outputs.image_name }},push=true"
-          platforms: "${{ matrix.arch }}"
-          provenance: true
-          tags: "${{ steps.weekly-version.outputs.image_name }}"
-
-      - id: "digest"
-        name: "Process image digest"
-        working-directory: "release"
-        run: |
-          arch=$(echo ${{ matrix.arch }} | tr "/" "_")
-          echo "digest_$arch=${{ steps.build-push.outputs.digest }}" >> $GITHUB_OUTPUT
-
-    strategy:
-      fail-fast: true
-      matrix:
-        include:
-          - arch: "linux/amd64"
-            runs_on: "github-hosted-ubuntu-x64-small"
-          - arch: "linux/arm64"
-            runs_on: "github-hosted-ubuntu-arm64-small"
-          - arch: "linux/arm"
-            runs_on: "github-hosted-ubuntu-arm64-small"
-
-  loki-canary-boringcrypto-manifest:
-    needs: ["loki-canary-boringcrypto-image"]
-    runs-on: "ubuntu-latest"
-    steps:
-      - name: "Set up Docker buildx"
-        uses: "docker/setup-buildx-action@v3"
-
-      - name: "Login to DockerHub (from Vault)"
-        uses: "grafana/shared-workflows/actions/dockerhub-login@main"
-
-      - name: "Publish multi-arch manifest"
-        run: |
-          # Unfortunately there is no better way atm than having a separate named output for each digest
-          echo 'linux/arm64 ${{ needs.loki-canary-boringcrypto-image.outputs.image_digest_linux_amd64 }}'
-          echo 'linux/amd64 ${{ needs.loki-canary-boringcrypto-image.outputs.image_digest_linux_arm64 }}'
-          echo 'linux/arm   ${{ needs.loki-canary-boringcrypto-image.outputs.image_digest_linux_arm }}'
-          IMAGE=${{ needs.loki-canary-boringcrypto-image.outputs.image_name }}:${{ needs.loki-canary-boringcrypto-image.outputs.image_tag }}
-          echo "Create multi-arch manifest for $IMAGE"
-          docker buildx imagetools create -t $IMAGE \
-            ${{ needs.loki-canary-boringcrypto-image.outputs.image_name }}@${{ needs.loki-canary-boringcrypto-image.outputs.image_digest_linux_amd64 }} \
-            ${{ needs.loki-canary-boringcrypto-image.outputs.image_name }}@${{ needs.loki-canary-boringcrypto-image.outputs.image_digest_linux_arm64 }} \
-            ${{ needs.loki-canary-boringcrypto-image.outputs.image_name }}@${{ needs.loki-canary-boringcrypto-image.outputs.image_digest_linux_arm }}
-          docker buildx imagetools inspect $IMAGE
-
-  loki-canary-image:
-    env:
-      BUILD_TIMEOUT: 60
-      GO_VERSION: "1.23.6"
-      IMAGE_PREFIX: "grafana"
-      RELEASE_LIB_REF: "main"
-      RELEASE_REPO: "grafana/loki"
-    needs:
-      - check
-    outputs:
-      image_digest_linux_amd64: "${{ steps.digest.outputs.digest_linux_amd64 }}"
-      image_digest_linux_arm: "${{ steps.digest.outputs.digest_linux_arm }}"
-      image_digest_linux_arm64: "${{ steps.digest.outputs.digest_linux_arm64 }}"
-      image_name: "${{ steps.weekly-version.outputs.image_name }}"
-      image_tag: "${{ steps.weekly-version.outputs.image_version }}"
-    runs-on: "${{ matrix.runs_on }}"
-    steps:
-    - name: "pull release library code"
-      uses: "actions/checkout@v4"
-      with:
-        path: "lib"
-        ref: "${{ env.RELEASE_LIB_REF }}"
-        repository: "grafana/loki-release"
-    - name: "pull code to release"
-      uses: "actions/checkout@v4"
-      with:
-        path: "release"
-        repository: "${{ env.RELEASE_REPO }}"
-    - name: "setup node"
-      uses: "actions/setup-node@v4"
-      with:
-        node-version: 20
-    - name: "Set up Docker buildx"
-      uses: "docker/setup-buildx-action@v3"
-    - name: "Login to DockerHub (from Vault)"
-      uses: "grafana/shared-workflows/actions/dockerhub-login@main"
-    - id: "weekly-version"
-      name: "Get weekly version"
-      run: |
+"jobs":
+  "check":
+    "uses": "grafana/loki-release/.github/workflows/check.yml@main"
+    "with":
+      "build_image": "grafana/loki-build-image:0.34.5"
+      "golang_ci_lint_version": "v1.60.3"
+      "release_lib_ref": "main"
+      "skip_validation": false
+      "use_github_app_token": true
+  "loki-canary-boringcrypto-image":
+    "env":
+      "BUILD_TIMEOUT": 60
+      "GO_VERSION": "1.23.6"
+      "IMAGE_PREFIX": "grafana"
+      "RELEASE_LIB_REF": "main"
+      "RELEASE_REPO": "grafana/loki"
+    "needs":
+    - "check"
+    "outputs":
+      "image_digest_linux_amd64": "${{ steps.digest.outputs.digest_linux_amd64 }}"
+      "image_digest_linux_arm": "${{ steps.digest.outputs.digest_linux_arm }}"
+      "image_digest_linux_arm64": "${{ steps.digest.outputs.digest_linux_arm64 }}"
+      "image_name": "${{ steps.weekly-version.outputs.image_name }}"
+      "image_tag": "${{ steps.weekly-version.outputs.image_version }}"
+    "runs-on": "${{ matrix.runs_on }}"
+    "steps":
+    - "name": "pull release library code"
+      "uses": "actions/checkout@v4"
+      "with":
+        "path": "lib"
+        "ref": "${{ env.RELEASE_LIB_REF }}"
+        "repository": "grafana/loki-release"
+    - "name": "pull code to release"
+      "uses": "actions/checkout@v4"
+      "with":
+        "path": "release"
+        "repository": "${{ env.RELEASE_REPO }}"
+    - "name": "setup node"
+      "uses": "actions/setup-node@v4"
+      "with":
+        "node-version": 20
+    - "name": "Set up Docker buildx"
+      "uses": "docker/setup-buildx-action@v3"
+    - "name": "Login to DockerHub (from Vault)"
+      "uses": "grafana/shared-workflows/actions/dockerhub-login@main"
+    - "id": "weekly-version"
+      "name": "Get weekly version"
+      "run": |
+        version=$(./tools/image-tag)
+        echo "image_version=$version" >> $GITHUB_OUTPUT
+        echo "image_name=${{ env.IMAGE_PREFIX }}/loki-canary-boringcrypto" >> $GITHUB_OUTPUT
+        echo "image_full_name=${{ env.IMAGE_PREFIX }}/loki-canary-boringcrypto:$version" >> $GITHUB_OUTPUT
+      "working-directory": "release"
+    - "id": "platform"
+      "name": "Parse image platform"
+      "run": |
+        platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
+        echo "platform=${platform}" >> $GITHUB_OUTPUT
+        echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
+      "working-directory": "release"
+    - "id": "build-push"
+      "name": "Build and push"
+      "timeout-minutes": "${{ fromJSON(env.BUILD_TIMEOUT) }}"
+      "uses": "docker/build-push-action@v6"
+      "with":
+        "build-args": |
+          IMAGE_TAG=${{ steps.weekly-version.outputs.image_version }}
+          GO_VERSION=${{ env.GO_VERSION }}
+        "context": "release"
+        "file": "release/cmd/loki-canary-boringcrypto/Dockerfile"
+        "outputs": "push-by-digest=true,type=image,name=${{ steps.weekly-version.outputs.image_name }},push=true"
+        "platforms": "${{ matrix.arch }}"
+        "provenance": true
+        "tags": "${{ steps.weekly-version.outputs.image_name }}"
+    - "id": "digest"
+      "name": "Process image digest"
+      "run": |
+        arch=$(echo ${{ matrix.arch }} | tr "/" "_")
+        echo "digest_$arch=${{ steps.build-push.outputs.digest }}" >> $GITHUB_OUTPUT
+      "working-directory": "release"
+    "strategy":
+      "fail-fast": true
+      "matrix":
+        "include":
+        - "arch": "linux/amd64"
+          "runs_on":
+          - "github-hosted-ubuntu-x64-small"
+        - "arch": "linux/arm64"
+          "runs_on":
+          - "github-hosted-ubuntu-arm64-small"
+        - "arch": "linux/arm"
+          "runs_on":
+          - "github-hosted-ubuntu-arm64-small"
+  "loki-canary-boringcrypto-manifest":
+    "env":
+      "BUILD_TIMEOUT": 60
+    "needs":
+    - "loki-canary-boringcrypto-image"
+    "runs-on": "ubuntu-latest"
+    "steps":
+    - "name": "Set up Docker buildx"
+      "uses": "docker/setup-buildx-action@v3"
+    - "name": "Login to DockerHub (from Vault)"
+      "uses": "grafana/shared-workflows/actions/dockerhub-login@main"
+    - "name": "Publish multi-arch manifest"
+      "run": |
+        # Unfortunately there is no better way atm than having a separate named output for each digest
+        echo 'linux/arm64 ${{ needs.loki-canary-boringcrypto-image.outputs.image_digest_linux_amd64 }}'
+        echo 'linux/amd64 ${{ needs.loki-canary-boringcrypto-image.outputs.image_digest_linux_arm64 }}'
+        echo 'linux/arm   ${{ needs.loki-canary-boringcrypto-image.outputs.image_digest_linux_arm }}'
+        IMAGE=${{ needs.loki-canary-boringcrypto-image.outputs.image_name }}:${{ needs.loki-canary-boringcrypto-image.outputs.image_tag }}
+        echo "Create multi-arch manifest for $IMAGE"
+        docker buildx imagetools create -t $IMAGE \
+          ${{ needs.loki-canary-boringcrypto-image.outputs.image_name }}@${{ needs.loki-canary-boringcrypto-image.outputs.image_digest_linux_amd64 }} \
+          ${{ needs.loki-canary-boringcrypto-image.outputs.image_name }}@${{ needs.loki-canary-boringcrypto-image.outputs.image_digest_linux_arm64 }} \
+          ${{ needs.loki-canary-boringcrypto-image.outputs.image_name }}@${{ needs.loki-canary-boringcrypto-image.outputs.image_digest_linux_arm }}
+        docker buildx imagetools inspect $IMAGE
+  "loki-canary-image":
+    "env":
+      "BUILD_TIMEOUT": 60
+      "GO_VERSION": "1.23.6"
+      "IMAGE_PREFIX": "grafana"
+      "RELEASE_LIB_REF": "main"
+      "RELEASE_REPO": "grafana/loki"
+    "needs":
+    - "check"
+    "outputs":
+      "image_digest_linux_amd64": "${{ steps.digest.outputs.digest_linux_amd64 }}"
+      "image_digest_linux_arm": "${{ steps.digest.outputs.digest_linux_arm }}"
+      "image_digest_linux_arm64": "${{ steps.digest.outputs.digest_linux_arm64 }}"
+      "image_name": "${{ steps.weekly-version.outputs.image_name }}"
+      "image_tag": "${{ steps.weekly-version.outputs.image_version }}"
+    "runs-on": "${{ matrix.runs_on }}"
+    "steps":
+    - "name": "pull release library code"
+      "uses": "actions/checkout@v4"
+      "with":
+        "path": "lib"
+        "ref": "${{ env.RELEASE_LIB_REF }}"
+        "repository": "grafana/loki-release"
+    - "name": "pull code to release"
+      "uses": "actions/checkout@v4"
+      "with":
+        "path": "release"
+        "repository": "${{ env.RELEASE_REPO }}"
+    - "name": "setup node"
+      "uses": "actions/setup-node@v4"
+      "with":
+        "node-version": 20
+    - "name": "Set up Docker buildx"
+      "uses": "docker/setup-buildx-action@v3"
+    - "name": "Login to DockerHub (from Vault)"
+      "uses": "grafana/shared-workflows/actions/dockerhub-login@main"
+    - "id": "weekly-version"
+      "name": "Get weekly version"
+      "run": |
         version=$(./tools/image-tag)
         echo "image_version=$version" >> $GITHUB_OUTPUT
         echo "image_name=${{ env.IMAGE_PREFIX }}/loki-canary" >> $GITHUB_OUTPUT
         echo "image_full_name=${{ env.IMAGE_PREFIX }}/loki-canary:$version" >> $GITHUB_OUTPUT
-      working-directory: "release"
-    - id: "platform"
-      name: "Parse image platform"
-      run: |
+      "working-directory": "release"
+    - "id": "platform"
+      "name": "Parse image platform"
+      "run": |
         platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
-      working-directory: "release"
-
-    - id: "build-push"
-      name: "Build and push"
-      timeout-minutes: "${{ fromJSON(env.BUILD_TIMEOUT) }}"
-      uses: "docker/build-push-action@v6"
-      with:
-        build-args: |
+      "working-directory": "release"
+    - "id": "build-push"
+      "name": "Build and push"
+      "timeout-minutes": "${{ fromJSON(env.BUILD_TIMEOUT) }}"
+      "uses": "docker/build-push-action@v6"
+      "with":
+        "build-args": |
           IMAGE_TAG=${{ steps.weekly-version.outputs.image_version }}
           GO_VERSION=${{ env.GO_VERSION }}
-        context: "release"
-        file: "release/cmd/loki-canary/Dockerfile"
-        outputs: "push-by-digest=true,type=image,name=${{ steps.weekly-version.outputs.image_name }},push=true"
-        platforms: "${{ matrix.arch }}"
-        provenance: true
-        tags: "${{ steps.weekly-version.outputs.image_name }}"
-
-    - id: "digest"
-      name: "Process image digest"
-      run: |
+        "context": "release"
+        "file": "release/cmd/loki-canary/Dockerfile"
+        "outputs": "push-by-digest=true,type=image,name=${{ steps.weekly-version.outputs.image_name }},push=true"
+        "platforms": "${{ matrix.arch }}"
+        "provenance": true
+        "tags": "${{ steps.weekly-version.outputs.image_name }}"
+    - "id": "digest"
+      "name": "Process image digest"
+      "run": |
         arch=$(echo ${{ matrix.arch }} | tr "/" "_")
         echo "digest_$arch=${{ steps.build-push.outputs.digest }}" >> $GITHUB_OUTPUT
-      working-directory: "release"
-    strategy:
-      fail-fast: true
-      matrix:
-        include:
-        - arch: linux/amd64
-          runs_on: github-hosted-ubuntu-x64-small
-        - arch: linux/arm64
-          runs_on: github-hosted-ubuntu-arm64-small
-        - arch: linux/arm
-          runs_on: github-hosted-ubuntu-arm64-small
-
-  loki-canary-manifest:
-    needs: ["loki-canary-image"]
-    runs-on: "ubuntu-latest"
-    steps:
-      - name: "Set up Docker buildx"
-        uses: "docker/setup-buildx-action@v3"
-
-      - name: "Login to DockerHub (from Vault)"
-        uses: "grafana/shared-workflows/actions/dockerhub-login@main"
-
-      - name: "Publish multi-arch manifest"
-        run: |
-          # Unfortunately there is no better way atm than having a separate named output for each digest
-          echo 'linux/arm64 ${{ needs.loki-canary-image.outputs.image_digest_linux_amd64 }}'
-          echo 'linux/amd64 ${{ needs.loki-canary-image.outputs.image_digest_linux_arm64 }}'
-          echo 'linux/arm   ${{ needs.loki-canary-image.outputs.image_digest_linux_arm }}'
-          IMAGE=${{ needs.loki-canary-image.outputs.image_name }}:${{ needs.loki-canary-image.outputs.image_tag }}
-          echo "Create multi-arch manifest for $IMAGE"
-          docker buildx imagetools create -t $IMAGE \
-            ${{ needs.loki-canary-image.outputs.image_name }}@${{ needs.loki-canary-image.outputs.image_digest_linux_amd64 }} \
-            ${{ needs.loki-canary-image.outputs.image_name }}@${{ needs.loki-canary-image.outputs.image_digest_linux_arm64 }} \
-            ${{ needs.loki-canary-image.outputs.image_name }}@${{ needs.loki-canary-image.outputs.image_digest_linux_arm }}
-          docker buildx imagetools inspect $IMAGE
-
-  loki-image:
-    env:
-      BUILD_TIMEOUT: 60
-      GO_VERSION: "1.23.6"
-      IMAGE_PREFIX: "grafana"
-      RELEASE_LIB_REF: "main"
-      RELEASE_REPO: "grafana/loki"
-    needs:
-      - check
-    outputs:
-      image_digest_linux_amd64: "${{ steps.digest.outputs.digest_linux_amd64 }}"
-      image_digest_linux_arm: "${{ steps.digest.outputs.digest_linux_arm }}"
-      image_digest_linux_arm64: "${{ steps.digest.outputs.digest_linux_arm64 }}"
-      image_name: "${{ steps.weekly-version.outputs.image_name }}"
-      image_tag: "${{ steps.weekly-version.outputs.image_version }}"
-    runs-on: "${{ matrix.runs_on }}"
-    steps:
-    - name: "pull release library code"
-      uses: "actions/checkout@v4"
-      with:
-        path: "lib"
-        ref: "${{ env.RELEASE_LIB_REF }}"
-        repository: "grafana/loki-release"
-    - name: "pull code to release"
-      uses: "actions/checkout@v4"
-      with:
-        path: "release"
-        repository: "${{ env.RELEASE_REPO }}"
-    - name: "setup node"
-      uses: "actions/setup-node@v4"
-      with:
-        node-version: 20
-    - name: "Set up Docker buildx"
-      uses: "docker/setup-buildx-action@v3"
-    - name: "Login to DockerHub (from Vault)"
-      uses: "grafana/shared-workflows/actions/dockerhub-login@main"
-    - id: "weekly-version"
-      name: "Get weekly version"
-      run: |
+      "working-directory": "release"
+    "strategy":
+      "fail-fast": true
+      "matrix":
+        "include":
+        - "arch": "linux/amd64"
+          "runs_on":
+          - "github-hosted-ubuntu-x64-small"
+        - "arch": "linux/arm64"
+          "runs_on":
+          - "github-hosted-ubuntu-arm64-small"
+        - "arch": "linux/arm"
+          "runs_on":
+          - "github-hosted-ubuntu-arm64-small"
+  "loki-canary-manifest":
+    "env":
+      "BUILD_TIMEOUT": 60
+    "needs":
+    - "loki-canary-image"
+    "runs-on": "ubuntu-latest"
+    "steps":
+    - "name": "Set up Docker buildx"
+      "uses": "docker/setup-buildx-action@v3"
+    - "name": "Login to DockerHub (from Vault)"
+      "uses": "grafana/shared-workflows/actions/dockerhub-login@main"
+    - "name": "Publish multi-arch manifest"
+      "run": |
+        # Unfortunately there is no better way atm than having a separate named output for each digest
+        echo 'linux/arm64 ${{ needs.loki-canary-image.outputs.image_digest_linux_amd64 }}'
+        echo 'linux/amd64 ${{ needs.loki-canary-image.outputs.image_digest_linux_arm64 }}'
+        echo 'linux/arm   ${{ needs.loki-canary-image.outputs.image_digest_linux_arm }}'
+        IMAGE=${{ needs.loki-canary-image.outputs.image_name }}:${{ needs.loki-canary-image.outputs.image_tag }}
+        echo "Create multi-arch manifest for $IMAGE"
+        docker buildx imagetools create -t $IMAGE \
+          ${{ needs.loki-canary-image.outputs.image_name }}@${{ needs.loki-canary-image.outputs.image_digest_linux_amd64 }} \
+          ${{ needs.loki-canary-image.outputs.image_name }}@${{ needs.loki-canary-image.outputs.image_digest_linux_arm64 }} \
+          ${{ needs.loki-canary-image.outputs.image_name }}@${{ needs.loki-canary-image.outputs.image_digest_linux_arm }}
+        docker buildx imagetools inspect $IMAGE
+  "loki-image":
+    "env":
+      "BUILD_TIMEOUT": 60
+      "GO_VERSION": "1.23.6"
+      "IMAGE_PREFIX": "grafana"
+      "RELEASE_LIB_REF": "main"
+      "RELEASE_REPO": "grafana/loki"
+    "needs":
+    - "check"
+    "outputs":
+      "image_digest_linux_amd64": "${{ steps.digest.outputs.digest_linux_amd64 }}"
+      "image_digest_linux_arm": "${{ steps.digest.outputs.digest_linux_arm }}"
+      "image_digest_linux_arm64": "${{ steps.digest.outputs.digest_linux_arm64 }}"
+      "image_name": "${{ steps.weekly-version.outputs.image_name }}"
+      "image_tag": "${{ steps.weekly-version.outputs.image_version }}"
+    "runs-on": "${{ matrix.runs_on }}"
+    "steps":
+    - "name": "pull release library code"
+      "uses": "actions/checkout@v4"
+      "with":
+        "path": "lib"
+        "ref": "${{ env.RELEASE_LIB_REF }}"
+        "repository": "grafana/loki-release"
+    - "name": "pull code to release"
+      "uses": "actions/checkout@v4"
+      "with":
+        "path": "release"
+        "repository": "${{ env.RELEASE_REPO }}"
+    - "name": "setup node"
+      "uses": "actions/setup-node@v4"
+      "with":
+        "node-version": 20
+    - "name": "Set up Docker buildx"
+      "uses": "docker/setup-buildx-action@v3"
+    - "name": "Login to DockerHub (from Vault)"
+      "uses": "grafana/shared-workflows/actions/dockerhub-login@main"
+    - "id": "weekly-version"
+      "name": "Get weekly version"
+      "run": |
         version=$(./tools/image-tag)
         echo "image_version=$version" >> $GITHUB_OUTPUT
         echo "image_name=${{ env.IMAGE_PREFIX }}/loki" >> $GITHUB_OUTPUT
         echo "image_full_name=${{ env.IMAGE_PREFIX }}/loki:$version" >> $GITHUB_OUTPUT
-      working-directory: "release"
-    - id: "platform"
-      name: "Parse image platform"
-      run: |
+      "working-directory": "release"
+    - "id": "platform"
+      "name": "Parse image platform"
+      "run": |
         platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
-      working-directory: "release"
-    - id: "build-push"
-      name: "Build and push"
-      timeout-minutes: "${{ fromJSON(env.BUILD_TIMEOUT) }}"
-      uses: "docker/build-push-action@v6"
-      with:
-        build-args: |
+      "working-directory": "release"
+    - "id": "build-push"
+      "name": "Build and push"
+      "timeout-minutes": "${{ fromJSON(env.BUILD_TIMEOUT) }}"
+      "uses": "docker/build-push-action@v6"
+      "with":
+        "build-args": |
           IMAGE_TAG=${{ steps.weekly-version.outputs.image_version }}
           GO_VERSION=${{ env.GO_VERSION }}
-        context: "release"
-        file: "release/cmd/loki/Dockerfile"
-        outputs: "push-by-digest=true,type=image,name=${{ steps.weekly-version.outputs.image_name }},push=true"
-        platforms: "${{ matrix.arch }}"
-        provenance: true
-        tags: "${{ steps.weekly-version.outputs.image_name }}"
-    - id: "digest"
-      name: "Process image digest"
-      run: |
+        "context": "release"
+        "file": "release/cmd/loki/Dockerfile"
+        "outputs": "push-by-digest=true,type=image,name=${{ steps.weekly-version.outputs.image_name }},push=true"
+        "platforms": "${{ matrix.arch }}"
+        "provenance": true
+        "tags": "${{ steps.weekly-version.outputs.image_name }}"
+    - "id": "digest"
+      "name": "Process image digest"
+      "run": |
         arch=$(echo ${{ matrix.arch }} | tr "/" "_")
         echo "digest_$arch=${{ steps.build-push.outputs.digest }}" >> $GITHUB_OUTPUT
-      working-directory: "release"
-    strategy:
-      fail-fast: true
-      matrix:
-        include:
-        - arch: linux/amd64
-          runs_on: github-hosted-ubuntu-x64-small
-        - arch: linux/arm64
-          runs_on: github-hosted-ubuntu-arm64-small
-        - arch: linux/arm
-          runs_on: github-hosted-ubuntu-arm64-small
-
-  loki-manifest:
-    env:
-      BUILD_TIMEOUT: 60
-    needs:
-      - loki-image
-    runs-on: ubuntu-latest
-    steps:
-    - name: "Set up Docker buildx"
-      uses: "docker/setup-buildx-action@v3"
-    - name: "Login to DockerHub (from Vault)"
-      uses: "grafana/shared-workflows/actions/dockerhub-login@main"
-    - name: "Publish multi-arch manifest"
-      run: |
+      "working-directory": "release"
+    "strategy":
+      "fail-fast": true
+      "matrix":
+        "include":
+        - "arch": "linux/amd64"
+          "runs_on":
+          - "github-hosted-ubuntu-x64-small"
+        - "arch": "linux/arm64"
+          "runs_on":
+          - "github-hosted-ubuntu-arm64-small"
+        - "arch": "linux/arm"
+          "runs_on":
+          - "github-hosted-ubuntu-arm64-small"
+  "loki-manifest":
+    "env":
+      "BUILD_TIMEOUT": 60
+    "needs":
+    - "loki-image"
+    "runs-on": "ubuntu-latest"
+    "steps":
+    - "name": "Set up Docker buildx"
+      "uses": "docker/setup-buildx-action@v3"
+    - "name": "Login to DockerHub (from Vault)"
+      "uses": "grafana/shared-workflows/actions/dockerhub-login@main"
+    - "name": "Publish multi-arch manifest"
+      "run": |
         # Unfortunately there is no better way atm than having a separate named output for each digest
         echo 'linux/arm64 ${{ needs.loki-image.outputs.image_digest_linux_amd64 }}'
         echo 'linux/amd64 ${{ needs.loki-image.outputs.image_digest_linux_arm64 }}'
@@ -351,195 +331,122 @@ jobs:
           ${{ needs.loki-image.outputs.image_name }}@${{ needs.loki-image.outputs.image_digest_linux_arm64 }} \
           ${{ needs.loki-image.outputs.image_name }}@${{ needs.loki-image.outputs.image_digest_linux_arm }}
         docker buildx imagetools inspect $IMAGE
-
-  promtail-image:
-    env:
-      BUILD_TIMEOUT: 60
-      GO_VERSION: "1.23.6"
-      IMAGE_PREFIX: "grafana"
-      RELEASE_LIB_REF: "main"
-      RELEASE_REPO: "grafana/loki"
-    needs:
-      - check
-    outputs:
-      image_digest_linux_amd64: "${{ steps.digest.outputs.digest_linux_amd64 }}"
-      image_digest_linux_arm: "${{ steps.digest.outputs.digest_linux_arm }}"
-      image_digest_linux_arm64: "${{ steps.digest.outputs.digest_linux_arm64 }}"
-      image_name: "${{ steps.weekly-version.outputs.image_name }}"
-      image_tag: "${{ steps.weekly-version.outputs.image_version }}"
-    runs-on: "${{ matrix.runs_on }}"
-    steps:
-    - name: "pull release library code"
-      uses: "actions/checkout@v4"
-      with:
-        path: "lib"
-        ref: "${{ env.RELEASE_LIB_REF }}"
-        repository: "grafana/loki-release"
-    - name: "pull code to release"
-      uses: "actions/checkout@v4"
-      with:
-        path: "release"
-        repository: "${{ env.RELEASE_REPO }}"
-    - name: "setup node"
-      uses: "actions/setup-node@v4"
-      with:
-        node-version: 20
-    - name: "Set up Docker buildx"
-      uses: "docker/setup-buildx-action@v3"
-    - name: "Login to DockerHub (from Vault)"
-      uses: "grafana/shared-workflows/actions/dockerhub-login@main"
-    - id: "weekly-version"
-      name: "Get weekly version"
-      run: |
+  "promtail-image":
+    "env":
+      "BUILD_TIMEOUT": 60
+      "GO_VERSION": "1.23.6"
+      "IMAGE_PREFIX": "grafana"
+      "RELEASE_LIB_REF": "main"
+      "RELEASE_REPO": "grafana/loki"
+    "needs":
+    - "check"
+    "outputs":
+      "image_digest_linux_amd64": "${{ steps.digest.outputs.digest_linux_amd64 }}"
+      "image_digest_linux_arm": "${{ steps.digest.outputs.digest_linux_arm }}"
+      "image_digest_linux_arm64": "${{ steps.digest.outputs.digest_linux_arm64 }}"
+      "image_name": "${{ steps.weekly-version.outputs.image_name }}"
+      "image_tag": "${{ steps.weekly-version.outputs.image_version }}"
+    "runs-on": "${{ matrix.runs_on }}"
+    "steps":
+    - "name": "pull release library code"
+      "uses": "actions/checkout@v4"
+      "with":
+        "path": "lib"
+        "ref": "${{ env.RELEASE_LIB_REF }}"
+        "repository": "grafana/loki-release"
+    - "name": "pull code to release"
+      "uses": "actions/checkout@v4"
+      "with":
+        "path": "release"
+        "repository": "${{ env.RELEASE_REPO }}"
+    - "name": "setup node"
+      "uses": "actions/setup-node@v4"
+      "with":
+        "node-version": 20
+    - "name": "Set up Docker buildx"
+      "uses": "docker/setup-buildx-action@v3"
+    - "name": "Login to DockerHub (from Vault)"
+      "uses": "grafana/shared-workflows/actions/dockerhub-login@main"
+    - "id": "weekly-version"
+      "name": "Get weekly version"
+      "run": |
         version=$(./tools/image-tag)
         echo "image_version=$version" >> $GITHUB_OUTPUT
         echo "image_name=${{ env.IMAGE_PREFIX }}/promtail" >> $GITHUB_OUTPUT
         echo "image_full_name=${{ env.IMAGE_PREFIX }}/promtail:$version" >> $GITHUB_OUTPUT
-      working-directory: "release"
-    - id: "platform"
-      name: "Parse image platform"
-      run: |
+      "working-directory": "release"
+    - "id": "platform"
+      "name": "Parse image platform"
+      "run": |
         platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
-      working-directory: "release"
-    - id: "build-push"
-      name: "Build and push"
-      timeout-minutes: "${{ fromJSON(env.BUILD_TIMEOUT) }}"
-      uses: "docker/build-push-action@v6"
-      with:
-        build-args: |
+      "working-directory": "release"
+    - "id": "build-push"
+      "name": "Build and push"
+      "timeout-minutes": "${{ fromJSON(env.BUILD_TIMEOUT) }}"
+      "uses": "docker/build-push-action@v6"
+      "with":
+        "build-args": |
           IMAGE_TAG=${{ steps.weekly-version.outputs.image_version }}
           GO_VERSION=${{ env.GO_VERSION }}
-        context: "release"
-        file: "release/clients/cmd/promtail/Dockerfile"
-        outputs: "push-by-digest=true,type=image,name=${{ steps.weekly-version.outputs.image_name }},push=true"
-        platforms: "${{ matrix.arch }}"
-        provenance: true
-        tags: "${{ steps.weekly-version.outputs.image_name }}"
-    - id: "digest"
-      name: "Process image digest"
-      run: |
+        "context": "release"
+        "file": "release/clients/cmd/promtail/Dockerfile"
+        "outputs": "push-by-digest=true,type=image,name=${{ steps.weekly-version.outputs.image_name }},push=true"
+        "platforms": "${{ matrix.arch }}"
+        "provenance": true
+        "tags": "${{ steps.weekly-version.outputs.image_name }}"
+    - "id": "digest"
+      "name": "Process image digest"
+      "run": |
         arch=$(echo ${{ matrix.arch }} | tr "/" "_")
         echo "digest_$arch=${{ steps.build-push.outputs.digest }}" >> $GITHUB_OUTPUT
-      working-directory: "release"
-    strategy:
-      fail-fast: true
-      matrix:
-        include:
-        - arch: linux/amd64
-          runs_on: github-hosted-ubuntu-x64-small
-        - arch: linux/arm64
-          runs_on: github-hosted-ubuntu-arm64-small
-        - arch: linux/arm
-          runs_on: github-hosted-ubuntu-arm64-small
-
-  promtail-manifest:
-    needs: ["promtail-image"]
-    runs-on: "ubuntu-latest"
-    steps:
-      - name: "Set up Docker buildx"
-        uses: "docker/setup-buildx-action@v3"
-
-      - name: "Login to DockerHub (from Vault)"
-        uses: "grafana/shared-workflows/actions/dockerhub-login@main"
-
-      - name: "Publish multi-arch manifest"
-        run: |
-          # Unfortunately there is no better way atm than having a separate named output for each digest
-          echo 'linux/arm64 ${{ needs.promtail-image.outputs.image_digest_linux_amd64 }}'
-          echo 'linux/amd64 ${{ needs.promtail-image.outputs.image_digest_linux_arm64 }}'
-          echo 'linux/arm   ${{ needs.promtail-image.outputs.image_digest_linux_arm }}'
-          IMAGE=${{ needs.promtail-image.outputs.image_name }}:${{ needs.promtail-image.outputs.image_tag }}
-          echo "Create multi-arch manifest for $IMAGE"
-          docker buildx imagetools create -t $IMAGE \
-            ${{ needs.promtail-image.outputs.image_name }}@${{ needs.promtail-image.outputs.image_digest_linux_amd64 }} \
-            ${{ needs.promtail-image.outputs.image_name }}@${{ needs.promtail-image.outputs.image_digest_linux_arm64 }} \
-            ${{ needs.promtail-image.outputs.image_name }}@${{ needs.promtail-image.outputs.image_digest_linux_arm }}
-          docker buildx imagetools inspect $IMAGE
-          
-  lambda-promtail-image:
-    env:
-      BUILD_TIMEOUT: "60"
-      GO_VERSION: "1.23.6"
-      IMAGE_PREFIX: "public.ecr.aws/grafana"
-      RELEASE_LIB_REF: "main"
-      RELEASE_REPO: "grafana/loki"
-      REPO: "loki"
-    needs:
-      - "check"
-    outputs:
-      image_digest_linux_amd64: "${{ steps.digest.outputs.digest_linux_amd64 }}"
-      image_digest_linux_arm64: "${{ steps.digest.outputs.digest_linux_arm64 }}"
-      image_name: "${{ steps.weekly-version.outputs.image_name }}"
-      image_tag: "${{ steps.weekly-version.outputs.image_version }}"
-    runs-on: "${{ matrix.runs_on }}"
-    steps:
-    - name: "pull release library code"
-      uses: "actions/checkout@v4"
-      with:
-        path: "lib"
-        ref: "${{ env.RELEASE_LIB_REF }}"
-        repository: "grafana/loki-release"
-    - name: "pull code to release"
-      uses: "actions/checkout@v4"
-      with:
-        path: "release"
-        repository: "${{ env.RELEASE_REPO }}"
-    - name: "setup node"
-      uses: "actions/setup-node@v4"
-      with:
-        node-version: "20"
-    - name: "Set up Docker buildx"
-      uses: "docker/setup-buildx-action@v3"
-    - id: "get-secrets"
-      uses: "grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets-v1.1.0"
-      with:
-        repo_secrets: |
-          ECR_ACCESS_KEY=aws-credentials:access_key_id
-          ECR_SECRET_KEY=aws-credentials:secret_access_key
-    - name: "Configure AWS credentials"
-      uses: "aws-actions/configure-aws-credentials@v4"
-      with:
-        aws-access-key-id: "${{ env.ECR_ACCESS_KEY }}"
-        aws-secret-access-key: "${{ env.ECR_SECRET_KEY }}"
-        aws-region: "us-east-1"
-    - name: "Login to Amazon ECR Public"
-      uses: "aws-actions/amazon-ecr-login@v2"
-      with:
-        registry-type: "public"
-    - id: "weekly-version"
-      name: "Get weekly version"
-      run: |
-        version=$(./tools/image-tag)
-        echo "image_version=$version" >> $GITHUB_OUTPUT
-        echo "image_name=${{ env.IMAGE_PREFIX }}/lambda-promtail" >> $GITHUB_OUTPUT
-        echo "image_full_name=${{ env.IMAGE_PREFIX }}/lambda-promtail:$version" >> $GITHUB_OUTPUT
-      working-directory: "release"
-    - id: "prepare-tag"
-      name: "Prepare tag name"
-      run: |
-        arch=$(echo ${{ matrix.arch }} | cut -d'/' -f2)
-        echo "IMAGE_TAG=${{ steps.weekly-version.outputs.image_name }}:${{ steps.weekly-version.outputs.image_version }}-${arch}" >> $GITHUB_OUTPUT
-    - id: "build-push"
-      name: "Build and push"
-      timeout-minutes: "${{ fromJSON(env.BUILD_TIMEOUT) }}"
-      uses: "docker/build-push-action@v6"
-      with:
-        build-args: |
-          IMAGE_TAG=${{ steps.weekly-version.outputs.image_version }}
-          GO_VERSION=${{ env.GO_VERSION }}
-        context: "release"
-        file: "release/tools/lambda-promtail/Dockerfile"
-        outputs: "type=image,push=true"
-        platform: "${{ matrix.arch }}"
-        provenance: false
-        tags: "${{ steps.prepare-tag.outputs.IMAGE_TAG }}"
-    strategy:
-      fail-fast: true
-      matrix:
-        include:
-        - arch: "linux/amd64"
-          runs_on: "github-hosted-ubuntu-x64-small"
-        - arch: "linux/arm64"
-          runs_on: "github-hosted-ubuntu-arm64-small"
+      "working-directory": "release"
+    "strategy":
+      "fail-fast": true
+      "matrix":
+        "include":
+        - "arch": "linux/amd64"
+          "runs_on":
+          - "github-hosted-ubuntu-x64-small"
+        - "arch": "linux/arm64"
+          "runs_on":
+          - "github-hosted-ubuntu-arm64-small"
+        - "arch": "linux/arm"
+          "runs_on":
+          - "github-hosted-ubuntu-arm64-small"
+  "promtail-manifest":
+    "env":
+      "BUILD_TIMEOUT": 60
+    "needs":
+    - "promtail-image"
+    "runs-on": "ubuntu-latest"
+    "steps":
+    - "name": "Set up Docker buildx"
+      "uses": "docker/setup-buildx-action@v3"
+    - "name": "Login to DockerHub (from Vault)"
+      "uses": "grafana/shared-workflows/actions/dockerhub-login@main"
+    - "name": "Publish multi-arch manifest"
+      "run": |
+        # Unfortunately there is no better way atm than having a separate named output for each digest
+        echo 'linux/arm64 ${{ needs.promtail-image.outputs.image_digest_linux_amd64 }}'
+        echo 'linux/amd64 ${{ needs.promtail-image.outputs.image_digest_linux_arm64 }}'
+        echo 'linux/arm   ${{ needs.promtail-image.outputs.image_digest_linux_arm }}'
+        IMAGE=${{ needs.promtail-image.outputs.image_name }}:${{ needs.promtail-image.outputs.image_tag }}
+        echo "Create multi-arch manifest for $IMAGE"
+        docker buildx imagetools create -t $IMAGE \
+          ${{ needs.promtail-image.outputs.image_name }}@${{ needs.promtail-image.outputs.image_digest_linux_amd64 }} \
+          ${{ needs.promtail-image.outputs.image_name }}@${{ needs.promtail-image.outputs.image_digest_linux_arm64 }} \
+          ${{ needs.promtail-image.outputs.image_name }}@${{ needs.promtail-image.outputs.image_digest_linux_arm }}
+        docker buildx imagetools inspect $IMAGE
+"name": "Publish images"
+"on":
+  "push":
+    "branches":
+    - "k[0-9]+*"
+    - "main"
+  "workflow_dispatch": {}
+"permissions":
+  "contents": "write"
+  "id-token": "write"
+  "pull-requests": "write"

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -439,6 +439,91 @@
           ${{ needs.promtail-image.outputs.image_name }}@${{ needs.promtail-image.outputs.image_digest_linux_arm64 }} \
           ${{ needs.promtail-image.outputs.image_name }}@${{ needs.promtail-image.outputs.image_digest_linux_arm }}
         docker buildx imagetools inspect $IMAGE
+  lambda-promtail-image:
+    env:
+      BUILD_TIMEOUT: "60"
+      GO_VERSION: "1.23.6"
+      IMAGE_PREFIX: "public.ecr.aws/grafana"
+      RELEASE_LIB_REF: "main"
+      RELEASE_REPO: "grafana/loki"
+      REPO: "loki"
+    needs:
+      - "check"
+    outputs:
+      image_digest_linux_amd64: "${{ steps.digest.outputs.digest_linux_amd64 }}"
+      image_digest_linux_arm64: "${{ steps.digest.outputs.digest_linux_arm64 }}"
+      image_name: "${{ steps.weekly-version.outputs.image_name }}"
+      image_tag: "${{ steps.weekly-version.outputs.image_version }}"
+    runs-on: "${{ matrix.runs_on }}"
+    steps:
+    - name: "pull release library code"
+      uses: "actions/checkout@v4"
+      with:
+        path: "lib"
+        ref: "${{ env.RELEASE_LIB_REF }}"
+        repository: "grafana/loki-release"
+    - name: "pull code to release"
+      uses: "actions/checkout@v4"
+      with:
+        path: "release"
+        repository: "${{ env.RELEASE_REPO }}"
+    - name: "setup node"
+      uses: "actions/setup-node@v4"
+      with:
+        node-version: "20"
+    - name: "Set up Docker buildx"
+      uses: "docker/setup-buildx-action@v3"
+    - id: "get-secrets"
+      uses: "grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets-v1.1.0"
+      with:
+        repo_secrets: |
+          ECR_ACCESS_KEY=aws-credentials:access_key_id
+          ECR_SECRET_KEY=aws-credentials:secret_access_key
+    - name: "Configure AWS credentials"
+      uses: "aws-actions/configure-aws-credentials@v4"
+      with:
+        aws-access-key-id: "${{ env.ECR_ACCESS_KEY }}"
+        aws-secret-access-key: "${{ env.ECR_SECRET_KEY }}"
+        aws-region: "us-east-1"
+    - name: "Login to Amazon ECR Public"
+      uses: "aws-actions/amazon-ecr-login@v2"
+      with:
+        registry-type: "public"
+    - id: "weekly-version"
+      name: "Get weekly version"
+      run: |
+        version=$(./tools/image-tag)
+        echo "image_version=$version" >> $GITHUB_OUTPUT
+        echo "image_name=${{ env.IMAGE_PREFIX }}/lambda-promtail" >> $GITHUB_OUTPUT
+        echo "image_full_name=${{ env.IMAGE_PREFIX }}/lambda-promtail:$version" >> $GITHUB_OUTPUT
+      working-directory: "release"
+    - id: "prepare-tag"
+      name: "Prepare tag name"
+      run: |
+        arch=$(echo ${{ matrix.arch }} | cut -d'/' -f2)
+        echo "IMAGE_TAG=${{ steps.weekly-version.outputs.image_name }}:${{ steps.weekly-version.outputs.image_version }}-${arch}" >> $GITHUB_OUTPUT
+    - id: "build-push"
+      name: "Build and push"
+      timeout-minutes: "${{ fromJSON(env.BUILD_TIMEOUT) }}"
+      uses: "docker/build-push-action@v6"
+      with:
+        build-args: |
+          IMAGE_TAG=${{ steps.weekly-version.outputs.image_version }}
+          GO_VERSION=${{ env.GO_VERSION }}
+        context: "release"
+        file: "release/tools/lambda-promtail/Dockerfile"
+        outputs: "type=image,push=true"
+        platform: "${{ matrix.arch }}"
+        provenance: false
+        tags: "${{ steps.prepare-tag.outputs.IMAGE_TAG }}"
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+        - arch: "linux/amd64"
+          runs_on: "github-hosted-ubuntu-x64-small"
+        - arch: "linux/arm64"
+          runs_on: "github-hosted-ubuntu-arm64-small"      
 "name": "Publish images"
 "on":
   "push":

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -457,3 +457,89 @@ jobs:
             ${{ needs.promtail-image.outputs.image_name }}@${{ needs.promtail-image.outputs.image_digest_linux_arm64 }} \
             ${{ needs.promtail-image.outputs.image_name }}@${{ needs.promtail-image.outputs.image_digest_linux_arm }}
           docker buildx imagetools inspect $IMAGE
+          
+  lambda-promtail-image:
+    env:
+      BUILD_TIMEOUT: "60"
+      GO_VERSION: "1.23.6"
+      IMAGE_PREFIX: "public.ecr.aws/grafana"
+      RELEASE_LIB_REF: "main"
+      RELEASE_REPO: "grafana/loki"
+      REPO: "loki"
+    needs:
+      - "check"
+    outputs:
+      image_digest_linux_amd64: "${{ steps.digest.outputs.digest_linux_amd64 }}"
+      image_digest_linux_arm64: "${{ steps.digest.outputs.digest_linux_arm64 }}"
+      image_name: "${{ steps.weekly-version.outputs.image_name }}"
+      image_tag: "${{ steps.weekly-version.outputs.image_version }}"
+    runs-on: "${{ matrix.runs_on }}"
+    steps:
+    - name: "pull release library code"
+      uses: "actions/checkout@v4"
+      with:
+        path: "lib"
+        ref: "${{ env.RELEASE_LIB_REF }}"
+        repository: "grafana/loki-release"
+    - name: "pull code to release"
+      uses: "actions/checkout@v4"
+      with:
+        path: "release"
+        repository: "${{ env.RELEASE_REPO }}"
+    - name: "setup node"
+      uses: "actions/setup-node@v4"
+      with:
+        node-version: "20"
+    - name: "Set up Docker buildx"
+      uses: "docker/setup-buildx-action@v3"
+    - id: "get-secrets"
+      uses: "grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets-v1.1.0"
+      with:
+        repo_secrets: |
+          ECR_ACCESS_KEY=aws-credentials:access_key_id
+          ECR_SECRET_KEY=aws-credentials:secret_access_key
+    - name: "Configure AWS credentials"
+      uses: "aws-actions/configure-aws-credentials@v4"
+      with:
+        aws-access-key-id: "${{ env.ECR_ACCESS_KEY }}"
+        aws-secret-access-key: "${{ env.ECR_SECRET_KEY }}"
+        aws-region: "us-east-1"
+    - name: "Login to Amazon ECR Public"
+      uses: "aws-actions/amazon-ecr-login@v2"
+      with:
+        registry-type: "public"
+    - id: "weekly-version"
+      name: "Get weekly version"
+      run: |
+        version=$(./tools/image-tag)
+        echo "image_version=$version" >> $GITHUB_OUTPUT
+        echo "image_name=${{ env.IMAGE_PREFIX }}/lambda-promtail" >> $GITHUB_OUTPUT
+        echo "image_full_name=${{ env.IMAGE_PREFIX }}/lambda-promtail:$version" >> $GITHUB_OUTPUT
+      working-directory: "release"
+    - id: "prepare-tag"
+      name: "Prepare tag name"
+      run: |
+        arch=$(echo ${{ matrix.arch }} | cut -d'/' -f2)
+        echo "IMAGE_TAG=${{ steps.weekly-version.outputs.image_name }}:${{ steps.weekly-version.outputs.image_version }}-${arch}" >> $GITHUB_OUTPUT
+    - id: "build-push"
+      name: "Build and push"
+      timeout-minutes: "${{ fromJSON(env.BUILD_TIMEOUT) }}"
+      uses: "docker/build-push-action@v6"
+      with:
+        build-args: |
+          IMAGE_TAG=${{ steps.weekly-version.outputs.image_version }}
+          GO_VERSION=${{ env.GO_VERSION }}
+        context: "release"
+        file: "release/tools/lambda-promtail/Dockerfile"
+        outputs: "type=image,push=true"
+        platform: "${{ matrix.arch }}"
+        provenance: false
+        tags: "${{ steps.prepare-tag.outputs.IMAGE_TAG }}"
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+        - arch: "linux/amd64"
+          runs_on: "github-hosted-ubuntu-x64-small"
+        - arch: "linux/arm64"
+          runs_on: "github-hosted-ubuntu-arm64-small"


### PR DESCRIPTION
**What this PR does / why we need it**:
Restores the publishing of the `lambda-promtail` images

**Which issue(s) this PR fixes**:
Images can now be seen in the AWS ECR [repository](https://gallery.ecr.aws/grafana/lambda-promtail)

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
