### PR TITLE
chore(dataobj): pool instances of dataobj encoders

### DIFF
--- a/pkg/dataobj/pools.go
+++ b/pkg/dataobj/pools.go
@@ -1,0 +1,15 @@
+package dataobj
+
+import (
+	"sync"
+
+	"github.com/grafana/loki/v3/pkg/dataobj/internal/encoding"
+)
+
+// encoderPool holds a pool of [encoding.Encoder] instances. Callers must
+// always reset pooled encoders before use.
+var encoderPool = sync.Pool{
+	New: func() any {
+		return encoding.NewEncoder(nil)
+	},
+}


### PR DESCRIPTION
While grafana/loki#16146 moved the final buffers used by dataobj builders to a shared pool, there was one remaining source of persistent memory footprint per builder: encoding.Encoder instances.

As encoding is an infrequent operation, builders do not need to persist implementations of encoding.Encoder, and instances can be shared across builders to reduce overhead.