### PR TITLE
chore: refactor delete requests store interface to prepare for replacing boltdb with sqlite for storing delete requests

### DIFF
--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -369,6 +369,7 @@ func (c *Compactor) initDeletes(objectClient client.ObjectClient, r prometheus.R
 	c.DeleteRequestsHandler = deletion.NewDeleteRequestHandler(
 		c.deleteRequestsStore,
 		c.cfg.DeleteMaxInterval,
+		c.cfg.DeleteRequestCancelPeriod,
 		r,
 	)
 

--- a/pkg/compactor/deletion/delete_requests_manager.go
+++ b/pkg/compactor/deletion/delete_requests_manager.go
@@ -3,9 +3,7 @@ package deletion
 import (
 	"context"
 	"fmt"
-	"slices"
 	"sort"
-	"strings"
 	"sync"
 	"time"
 
@@ -58,7 +56,7 @@ func NewDeleteRequestsManager(store DeleteRequestsStore, deleteRequestCancelPeri
 
 	go dm.loop()
 
-	if err := dm.mergeShardedRequests(context.Background()); err != nil {
+	if err := dm.deleteRequestsStore.MergeShardedRequests(context.Background()); err != nil {
 		level.Error(util_log.Logger).Log("msg", "failed to merge sharded requests", "err", err)
 	}
 
@@ -89,70 +87,8 @@ func (d *DeleteRequestsManager) Stop() {
 	d.wg.Wait()
 }
 
-// mergeShardedRequests merges the sharded requests back to a single request when we are done with processing all the shards
-func (d *DeleteRequestsManager) mergeShardedRequests(ctx context.Context) error {
-	deleteGroups, err := d.deleteRequestsStore.GetAllDeleteRequests(context.Background())
-	if err != nil {
-		return err
-	}
-
-	slices.SortFunc(deleteGroups, func(a, b DeleteRequest) int {
-		return strings.Compare(a.RequestID, b.RequestID)
-	})
-	deleteRequests := mergeDeletes(deleteGroups)
-	for _, req := range deleteRequests {
-		// do not consider requests which do not have an id. Request ID won't be set in some tests or there is a bug in our code for loading requests.
-		if req.RequestID == "" {
-			level.Error(util_log.Logger).Log("msg", "skipped considering request without an id for merging its shards",
-				"user_id", req.UserID,
-				"start_time", req.StartTime.Unix(),
-				"end_time", req.EndTime.Unix(),
-				"query", req.Query,
-			)
-			continue
-		}
-		// do not do anything if we are not done with processing all the shards or the number of shards is 1
-		if req.Status != StatusProcessed {
-			continue
-		}
-
-		var idxStart, idxEnd int
-		for i := range deleteGroups {
-			if req.RequestID == deleteGroups[i].RequestID {
-				idxStart = i
-				break
-			}
-		}
-
-		for i := len(deleteGroups) - 1; i > 0; i-- {
-			if req.RequestID == deleteGroups[i].RequestID {
-				idxEnd = i
-				break
-			}
-		}
-
-		// do not do anything if the number of shards is 1
-		if idxStart == idxEnd {
-			continue
-		}
-		reqShards := deleteGroups[idxStart : idxEnd+1]
-
-		level.Info(util_log.Logger).Log("msg", "merging sharded request",
-			"request_id", req.RequestID,
-			"num_shards", len(reqShards),
-			"start_time", req.StartTime.Unix(),
-			"end_time", req.EndTime.Unix(),
-		)
-		if err := d.deleteRequestsStore.MergeShardedRequests(ctx, req, reqShards); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
 func (d *DeleteRequestsManager) updateMetrics() error {
-	deleteRequests, err := d.deleteRequestsStore.GetDeleteRequestsByStatus(context.Background(), StatusReceived)
+	deleteRequests, err := d.deleteRequestsStore.GetUnprocessedShards(context.Background())
 	if err != nil {
 		return err
 	}
@@ -267,7 +203,7 @@ func (d *DeleteRequestsManager) loadDeleteRequestsToProcess() error {
 }
 
 func (d *DeleteRequestsManager) filteredSortedDeleteRequests() ([]DeleteRequest, error) {
-	deleteRequests, err := d.deleteRequestsStore.GetDeleteRequestsByStatus(context.Background(), StatusReceived)
+	deleteRequests, err := d.deleteRequestsStore.GetUnprocessedShards(context.Background())
 	if err != nil {
 		return nil, err
 	}
@@ -418,7 +354,7 @@ func (d *DeleteRequestsManager) MarkPhaseTimedOut() {
 }
 
 func (d *DeleteRequestsManager) markRequestAsProcessed(deleteRequest DeleteRequest) {
-	if err := d.deleteRequestsStore.UpdateStatus(context.Background(), deleteRequest, StatusProcessed); err != nil {
+	if err := d.deleteRequestsStore.MarkShardAsProcessed(context.Background(), deleteRequest); err != nil {
 		level.Error(util_log.Logger).Log(
 			"msg", "failed to mark delete request for user as processed",
 			"delete_request_id", deleteRequest.RequestID,
@@ -462,7 +398,7 @@ func (d *DeleteRequestsManager) MarkPhaseFinished() {
 		d.markRequestAsProcessed(req)
 	}
 
-	if err := d.mergeShardedRequests(context.Background()); err != nil {
+	if err := d.deleteRequestsStore.MergeShardedRequests(context.Background()); err != nil {
 		level.Error(util_log.Logger).Log("msg", "failed to merge sharded requests", "err", err)
 	}
 }

--- a/pkg/compactor/deletion/delete_requests_manager_test.go
+++ b/pkg/compactor/deletion/delete_requests_manager_test.go
@@ -981,7 +981,7 @@ func TestDeleteRequestsManager_Expired(t *testing.T) {
 
 			mgr.MarkPhaseFinished()
 
-			processedRequests, err := mockDeleteRequestsStore.GetDeleteRequestsByStatus(context.Background(), StatusProcessed)
+			processedRequests, err := mockDeleteRequestsStore.getDeleteRequestsByStatus(StatusProcessed)
 			require.NoError(t, err)
 			require.Len(t, processedRequests, len(tc.expectedRequestsMarkedAsProcessed))
 
@@ -1018,14 +1018,24 @@ func TestDeleteRequestsManager_IntervalMayHaveExpiredChunks(t *testing.T) {
 	}
 }
 
+type storeAddReqDetails struct {
+	userID, query      string
+	startTime, endTime model.Time
+	shardByInterval    time.Duration
+}
+
+type removeReqDetails struct {
+	userID, reqID string
+}
+
 type mockDeleteRequestsStore struct {
 	DeleteRequestsStore
 	deleteRequests           []DeleteRequest
-	addReqs                  []DeleteRequest
+	addReq                   storeAddReqDetails
 	addErr                   error
 	returnZeroDeleteRequests bool
 
-	removeReqs []DeleteRequest
+	removeReqs removeReqDetails
 	removeErr  error
 
 	getUser   string
@@ -1040,7 +1050,11 @@ type mockDeleteRequestsStore struct {
 	genNumber string
 }
 
-func (m *mockDeleteRequestsStore) GetDeleteRequestsByStatus(_ context.Context, status DeleteRequestStatus) ([]DeleteRequest, error) {
+func (m *mockDeleteRequestsStore) GetUnprocessedShards(ctx context.Context) ([]DeleteRequest, error) {
+	return m.getDeleteRequestsByStatus(StatusReceived)
+}
+
+func (m *mockDeleteRequestsStore) getDeleteRequestsByStatus(status DeleteRequestStatus) ([]DeleteRequest, error) {
 	reqs := make([]DeleteRequest, 0, len(m.deleteRequests))
 	for i := range m.deleteRequests {
 		if m.deleteRequests[i].Status == status {
@@ -1050,27 +1064,36 @@ func (m *mockDeleteRequestsStore) GetDeleteRequestsByStatus(_ context.Context, s
 	return reqs, nil
 }
 
-func (m *mockDeleteRequestsStore) GetAllDeleteRequests(_ context.Context) ([]DeleteRequest, error) {
+func (m *mockDeleteRequestsStore) GetAllRequests(_ context.Context) ([]DeleteRequest, error) {
 	return m.deleteRequests, nil
 }
 
-func (m *mockDeleteRequestsStore) AddDeleteRequestGroup(_ context.Context, reqs []DeleteRequest) ([]DeleteRequest, error) {
-	m.addReqs = reqs
-	if m.returnZeroDeleteRequests {
-		return []DeleteRequest{}, m.addErr
+func (m *mockDeleteRequestsStore) AddDeleteRequest(ctx context.Context, userID, query string, startTime, endTime model.Time, shardByInterval time.Duration) (string, error) {
+	m.addReq = storeAddReqDetails{
+		userID:          userID,
+		query:           query,
+		startTime:       startTime,
+		endTime:         endTime,
+		shardByInterval: shardByInterval,
 	}
-	return m.addReqs, m.addErr
+	return "", m.addErr
 }
 
-func (m *mockDeleteRequestsStore) RemoveDeleteRequests(_ context.Context, reqs []DeleteRequest) error {
-	m.removeReqs = reqs
+func (m *mockDeleteRequestsStore) RemoveDeleteRequest(ctx context.Context, userID string, requestID string) error {
+	m.removeReqs = removeReqDetails{
+		userID: userID,
+		reqID:  requestID,
+	}
 	return m.removeErr
 }
 
-func (m *mockDeleteRequestsStore) GetDeleteRequestGroup(_ context.Context, userID, requestID string) ([]DeleteRequest, error) {
+func (m *mockDeleteRequestsStore) GetDeleteRequest(ctx context.Context, userID, requestID string) (DeleteRequest, error) {
 	m.getUser = userID
 	m.getID = requestID
-	return m.getResult, m.getErr
+	if m.getErr != nil {
+		return DeleteRequest{}, m.getErr
+	}
+	return m.getResult[0], m.getErr
 }
 
 func (m *mockDeleteRequestsStore) GetAllDeleteRequestsForUser(_ context.Context, userID string) ([]DeleteRequest, error) {
@@ -1082,32 +1105,17 @@ func (m *mockDeleteRequestsStore) GetCacheGenerationNumber(_ context.Context, _ 
 	return m.genNumber, m.getErr
 }
 
-func (m *mockDeleteRequestsStore) UpdateStatus(_ context.Context, req DeleteRequest, newStatus DeleteRequestStatus) error {
+func (m *mockDeleteRequestsStore) MarkShardAsProcessed(ctx context.Context, req DeleteRequest) error {
 	for i := range m.deleteRequests {
 		if requestsAreEqual(m.deleteRequests[i], req) {
-			m.deleteRequests[i].Status = newStatus
+			m.deleteRequests[i].Status = StatusProcessed
 		}
 	}
 
 	return nil
 }
 
-func (m *mockDeleteRequestsStore) MergeShardedRequests(_ context.Context, requestToAdd DeleteRequest, requestsToRemove []DeleteRequest) error {
-	n := 0
-	for i := range m.deleteRequests {
-		for j := range requestsToRemove {
-			if requestsAreEqual(m.deleteRequests[i], requestsToRemove[j]) {
-				continue
-			}
-			m.deleteRequests[n] = m.deleteRequests[i]
-			n++
-			break
-		}
-	}
-
-	m.deleteRequests = m.deleteRequests[:n]
-	m.deleteRequests = append(m.deleteRequests, requestToAdd)
-
+func (m *mockDeleteRequestsStore) MergeShardedRequests(_ context.Context) error {
 	return nil
 }
 
@@ -1122,86 +1130,6 @@ func requestsAreEqual(req1, req2 DeleteRequest) bool {
 	}
 
 	return false
-}
-
-func TestDeleteRequestsManager_mergeShardedRequests(t *testing.T) {
-	for _, tc := range []struct {
-		name                   string
-		reqsToAdd              []DeleteRequest
-		shouldMarkProcessed    func(DeleteRequest) bool
-		requestsShouldBeMerged bool
-	}{
-		{
-			name: "no requests in store",
-		},
-		{
-			name:      "none of the requests are processed - should not merge",
-			reqsToAdd: buildRequests(time.Hour, `{foo="bar"}`, user1, now.Add(-24*time.Hour), now),
-			shouldMarkProcessed: func(_ DeleteRequest) bool {
-				return false
-			},
-		},
-		{
-			name:      "not all requests are processed - should not merge",
-			reqsToAdd: buildRequests(time.Hour, `{foo="bar"}`, user1, now.Add(-24*time.Hour), now),
-			shouldMarkProcessed: func(request DeleteRequest) bool {
-				return request.SequenceNum%2 == 0
-			},
-		},
-		{
-			name:      "all the requests are processed - should merge",
-			reqsToAdd: buildRequests(time.Hour, `{foo="bar"}`, user1, now.Add(-24*time.Hour), now),
-			shouldMarkProcessed: func(_ DeleteRequest) bool {
-				return true
-			},
-			requestsShouldBeMerged: true,
-		},
-		{ // build requests for 2 different users and mark all requests as processed for just one of the two
-			name: "merging requests from one user should not touch another users requests",
-			reqsToAdd: append(
-				buildRequests(time.Hour, `{foo="bar"}`, user1, now.Add(-24*time.Hour), now),
-				buildRequests(time.Hour, `{foo="bar"}`, user2, now.Add(-24*time.Hour), now)...,
-			),
-			shouldMarkProcessed: func(request DeleteRequest) bool {
-				return request.UserID == user2
-			},
-		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			mgr := setupManager(t)
-			reqs, err := mgr.deleteRequestsStore.AddDeleteRequestGroup(context.Background(), tc.reqsToAdd)
-			require.NoError(t, err)
-			require.GreaterOrEqual(t, len(reqs), len(tc.reqsToAdd))
-
-			for _, req := range reqs {
-				if !tc.shouldMarkProcessed(req) {
-					continue
-				}
-				require.NoError(t, mgr.deleteRequestsStore.UpdateStatus(context.Background(), req, StatusProcessed))
-			}
-
-			inStoreReqs, err := mgr.deleteRequestsStore.GetAllDeleteRequestsForUser(context.Background(), user1)
-			require.NoError(t, err)
-
-			require.NoError(t, mgr.mergeShardedRequests(context.Background()))
-			inStoreReqsAfterMerging, err := mgr.deleteRequestsStore.GetAllDeleteRequestsForUser(context.Background(), user1)
-			require.NoError(t, err)
-
-			if tc.requestsShouldBeMerged {
-				require.Len(t, inStoreReqsAfterMerging, 1)
-				require.True(t, requestsAreEqual(inStoreReqsAfterMerging[0], DeleteRequest{
-					UserID:    user1,
-					Query:     tc.reqsToAdd[0].Query,
-					StartTime: tc.reqsToAdd[0].StartTime,
-					EndTime:   tc.reqsToAdd[len(tc.reqsToAdd)-1].EndTime,
-					Status:    StatusProcessed,
-				}))
-			} else {
-				require.Len(t, inStoreReqsAfterMerging, len(inStoreReqs))
-				require.Equal(t, inStoreReqs, inStoreReqsAfterMerging)
-			}
-		})
-	}
 }
 
 func setupManager(t *testing.T) *DeleteRequestsManager {

--- a/pkg/compactor/deletion/delete_requests_manager_test.go
+++ b/pkg/compactor/deletion/delete_requests_manager_test.go
@@ -1050,7 +1050,7 @@ type mockDeleteRequestsStore struct {
 	genNumber string
 }
 
-func (m *mockDeleteRequestsStore) GetUnprocessedShards(ctx context.Context) ([]DeleteRequest, error) {
+func (m *mockDeleteRequestsStore) GetUnprocessedShards(_ context.Context) ([]DeleteRequest, error) {
 	return m.getDeleteRequestsByStatus(StatusReceived)
 }
 
@@ -1068,7 +1068,7 @@ func (m *mockDeleteRequestsStore) GetAllRequests(_ context.Context) ([]DeleteReq
 	return m.deleteRequests, nil
 }
 
-func (m *mockDeleteRequestsStore) AddDeleteRequest(ctx context.Context, userID, query string, startTime, endTime model.Time, shardByInterval time.Duration) (string, error) {
+func (m *mockDeleteRequestsStore) AddDeleteRequest(_ context.Context, userID, query string, startTime, endTime model.Time, shardByInterval time.Duration) (string, error) {
 	m.addReq = storeAddReqDetails{
 		userID:          userID,
 		query:           query,
@@ -1079,7 +1079,7 @@ func (m *mockDeleteRequestsStore) AddDeleteRequest(ctx context.Context, userID, 
 	return "", m.addErr
 }
 
-func (m *mockDeleteRequestsStore) RemoveDeleteRequest(ctx context.Context, userID string, requestID string) error {
+func (m *mockDeleteRequestsStore) RemoveDeleteRequest(_ context.Context, userID string, requestID string) error {
 	m.removeReqs = removeReqDetails{
 		userID: userID,
 		reqID:  requestID,
@@ -1087,7 +1087,7 @@ func (m *mockDeleteRequestsStore) RemoveDeleteRequest(ctx context.Context, userI
 	return m.removeErr
 }
 
-func (m *mockDeleteRequestsStore) GetDeleteRequest(ctx context.Context, userID, requestID string) (DeleteRequest, error) {
+func (m *mockDeleteRequestsStore) GetDeleteRequest(_ context.Context, userID, requestID string) (DeleteRequest, error) {
 	m.getUser = userID
 	m.getID = requestID
 	if m.getErr != nil {
@@ -1105,7 +1105,7 @@ func (m *mockDeleteRequestsStore) GetCacheGenerationNumber(_ context.Context, _ 
 	return m.genNumber, m.getErr
 }
 
-func (m *mockDeleteRequestsStore) MarkShardAsProcessed(ctx context.Context, req DeleteRequest) error {
+func (m *mockDeleteRequestsStore) MarkShardAsProcessed(_ context.Context, req DeleteRequest) error {
 	for i := range m.deleteRequests {
 		if requestsAreEqual(m.deleteRequests[i], req) {
 			m.deleteRequests[i].Status = StatusProcessed

--- a/pkg/compactor/deletion/delete_requests_store.go
+++ b/pkg/compactor/deletion/delete_requests_store.go
@@ -7,18 +7,20 @@ import (
 	"errors"
 	"fmt"
 	"hash/fnv"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
 	"time"
 	"unsafe"
 
+	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/user"
-
 	"github.com/prometheus/common/model"
 
 	"github.com/grafana/loki/v3/pkg/storage/stores/series/index"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/storage"
+	util_log "github.com/grafana/loki/v3/pkg/util/log"
 )
 
 type (
@@ -41,15 +43,19 @@ const (
 var ErrDeleteRequestNotFound = errors.New("could not find matching delete requests")
 
 type DeleteRequestsStore interface {
-	AddDeleteRequestGroup(ctx context.Context, req []DeleteRequest) ([]DeleteRequest, error)
-	GetDeleteRequestsByStatus(ctx context.Context, status DeleteRequestStatus) ([]DeleteRequest, error)
-	GetAllDeleteRequests(ctx context.Context) ([]DeleteRequest, error)
+	AddDeleteRequest(ctx context.Context, userID, query string, startTime, endTime model.Time, shardByInterval time.Duration) (string, error)
+	GetAllRequests(ctx context.Context) ([]DeleteRequest, error)
 	GetAllDeleteRequestsForUser(ctx context.Context, userID string) ([]DeleteRequest, error)
-	UpdateStatus(ctx context.Context, req DeleteRequest, newStatus DeleteRequestStatus) error
-	GetDeleteRequestGroup(ctx context.Context, userID, requestID string) ([]DeleteRequest, error)
-	RemoveDeleteRequests(ctx context.Context, req []DeleteRequest) error
+	RemoveDeleteRequest(ctx context.Context, userID string, requestID string) error
+	GetDeleteRequest(ctx context.Context, userID, requestID string) (DeleteRequest, error)
 	GetCacheGenerationNumber(ctx context.Context, userID string) (string, error)
-	MergeShardedRequests(ctx context.Context, requestToAdd DeleteRequest, requestsToRemove []DeleteRequest) error
+	MergeShardedRequests(ctx context.Context) error
+
+	// ToDo(Sandeep): To keep changeset smaller, below 2 methods treat a single shard as individual request. This can be refactored later in a separate PR.
+	MarkShardAsProcessed(ctx context.Context, req DeleteRequest) error
+	GetUnprocessedShards(ctx context.Context) ([]DeleteRequest, error)
+	GetAllShards(ctx context.Context) ([]DeleteRequest, error)
+
 	Stop()
 	Name() string
 }
@@ -77,25 +83,25 @@ func (ds *deleteRequestsStore) Stop() {
 	ds.indexClient.Stop()
 }
 
-// AddDeleteRequestGroup creates entries for new delete requests. All passed delete requests will be associated to
+// AddDeleteRequest creates entries for new delete requests. All passed delete requests will be associated to
 // each other by request id
-func (ds *deleteRequestsStore) AddDeleteRequestGroup(ctx context.Context, reqs []DeleteRequest) ([]DeleteRequest, error) {
+func (ds *deleteRequestsStore) AddDeleteRequest(ctx context.Context, userID, query string, startTime, endTime model.Time, shardByInterval time.Duration) (string, error) {
+	reqs := buildRequests(shardByInterval, query, userID, startTime, endTime)
 	if len(reqs) == 0 {
-		return nil, nil
+		return "", fmt.Errorf("zero delete requests created")
 	}
-
 	createdAt := ds.now()
 	writeBatch := ds.indexClient.NewWriteBatch()
 	requestID, err := ds.generateID(ctx, reqs[0])
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 
 	var results []DeleteRequest
 	for i, req := range reqs {
 		newReq, err := newRequest(req, requestID, createdAt, i)
 		if err != nil {
-			return nil, err
+			return "", err
 		}
 
 		results = append(results, newReq)
@@ -104,13 +110,13 @@ func (ds *deleteRequestsStore) AddDeleteRequestGroup(ctx context.Context, reqs [
 	ds.updateCacheGen(reqs[0].UserID, writeBatch)
 
 	if err := ds.indexClient.BatchWrite(ctx, writeBatch); err != nil {
-		return nil, err
+		return "", err
 	}
 
-	return results, nil
+	return requestID, nil
 }
 
-func (ds *deleteRequestsStore) MergeShardedRequests(ctx context.Context, requestToAdd DeleteRequest, requestsToRemove []DeleteRequest) error {
+func (ds *deleteRequestsStore) mergeShardedRequests(ctx context.Context, requestToAdd DeleteRequest, requestsToRemove []DeleteRequest) error {
 	writeBatch := ds.indexClient.NewWriteBatch()
 
 	ds.writeDeleteRequest(requestToAdd, writeBatch)
@@ -122,8 +128,8 @@ func (ds *deleteRequestsStore) MergeShardedRequests(ctx context.Context, request
 	return ds.indexClient.BatchWrite(ctx, writeBatch)
 }
 
-func newRequest(req DeleteRequest, requestID []byte, createdAt model.Time, seqNumber int) (DeleteRequest, error) {
-	req.RequestID = string(requestID)
+func newRequest(req DeleteRequest, requestID string, createdAt model.Time, seqNumber int) (DeleteRequest, error) {
+	req.RequestID = requestID
 	req.Status = StatusReceived
 	req.CreatedAt = createdAt
 	req.SequenceNum = int64(seqNumber)
@@ -162,15 +168,15 @@ func backwardCompatibleDeleteRequestHash(userID, requestID string, sequenceNumbe
 	return fmt.Sprintf("%s:%s:%d", userID, requestID, sequenceNumber)
 }
 
-func (ds *deleteRequestsStore) generateID(ctx context.Context, req DeleteRequest) ([]byte, error) {
+func (ds *deleteRequestsStore) generateID(ctx context.Context, req DeleteRequest) (string, error) {
 	requestID := generateUniqueID(req.UserID, req.Query)
 
 	for {
-		if _, err := ds.GetDeleteRequestGroup(ctx, req.UserID, string(requestID)); err != nil {
-			if err == ErrDeleteRequestNotFound {
+		if _, err := ds.GetDeleteRequest(ctx, req.UserID, requestID); err != nil {
+			if errors.Is(err, ErrDeleteRequestNotFound) {
 				return requestID, nil
 			}
-			return nil, err
+			return "", err
 		}
 
 		// we have a collision here, lets recreate a new requestID and check for collision
@@ -179,44 +185,77 @@ func (ds *deleteRequestsStore) generateID(ctx context.Context, req DeleteRequest
 	}
 }
 
-// GetDeleteRequestsByStatus returns all delete requests for given status.
-func (ds *deleteRequestsStore) GetDeleteRequestsByStatus(ctx context.Context, status DeleteRequestStatus) ([]DeleteRequest, error) {
+// GetUnprocessedShards returns all the unprocessed shards as individual delete requests.
+func (ds *deleteRequestsStore) GetUnprocessedShards(ctx context.Context) ([]DeleteRequest, error) {
 	return ds.queryDeleteRequests(ctx, index.Query{
 		TableName:  DeleteRequestsTableName,
 		HashValue:  string(deleteRequestID),
-		ValueEqual: []byte(status),
+		ValueEqual: []byte(StatusReceived),
 	})
 }
 
-// GetAllDeleteRequests returns all the delete requests.
-func (ds *deleteRequestsStore) GetAllDeleteRequests(ctx context.Context) ([]DeleteRequest, error) {
+// GetAllShards returns all the shards as individual delete requests.
+func (ds *deleteRequestsStore) GetAllShards(ctx context.Context) ([]DeleteRequest, error) {
 	return ds.queryDeleteRequests(ctx, index.Query{
 		TableName: DeleteRequestsTableName,
 		HashValue: string(deleteRequestID),
 	})
 }
 
+// GetAllRequests returns all the delete requests.
+func (ds *deleteRequestsStore) GetAllRequests(ctx context.Context) ([]DeleteRequest, error) {
+	deleteGroups, err := ds.GetAllShards(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	deleteRequests := mergeDeletes(deleteGroups)
+	return deleteRequests, nil
+}
+
 // GetAllDeleteRequestsForUser returns all delete requests for a user.
 func (ds *deleteRequestsStore) GetAllDeleteRequestsForUser(ctx context.Context, userID string) ([]DeleteRequest, error) {
-	return ds.queryDeleteRequests(ctx, index.Query{
+	deleteGroups, err := ds.queryDeleteRequests(ctx, index.Query{
 		TableName:        DeleteRequestsTableName,
 		HashValue:        string(deleteRequestID),
 		RangeValuePrefix: []byte(userID),
 	})
+	if err != nil {
+		return nil, err
+	}
+
+	deleteRequests := mergeDeletes(deleteGroups)
+	return deleteRequests, nil
 }
 
-// UpdateStatus updates status of a delete request.
-func (ds *deleteRequestsStore) UpdateStatus(ctx context.Context, req DeleteRequest, newStatus DeleteRequestStatus) error {
+// MarkShardAsProcessed marks a delete request shard as processed.
+func (ds *deleteRequestsStore) MarkShardAsProcessed(ctx context.Context, req DeleteRequest) error {
 	userIDAndRequestID := backwardCompatibleDeleteRequestHash(req.UserID, req.RequestID, req.SequenceNum)
 
 	writeBatch := ds.indexClient.NewWriteBatch()
-	writeBatch.Add(DeleteRequestsTableName, string(deleteRequestID), []byte(userIDAndRequestID), []byte(newStatus))
+	writeBatch.Add(DeleteRequestsTableName, string(deleteRequestID), []byte(userIDAndRequestID), []byte(StatusProcessed))
 
 	return ds.indexClient.BatchWrite(ctx, writeBatch)
 }
 
-// GetDeleteRequestGroup returns delete requests with given requestID.
-func (ds *deleteRequestsStore) GetDeleteRequestGroup(ctx context.Context, userID, requestID string) ([]DeleteRequest, error) {
+// GetDeleteRequest finds and returns delete request with given ID.
+func (ds *deleteRequestsStore) GetDeleteRequest(ctx context.Context, userID, requestID string) (DeleteRequest, error) {
+	reqGroup, err := ds.getDeleteRequestGroup(ctx, userID, requestID)
+	if err != nil {
+		return DeleteRequest{}, err
+	}
+
+	startTime, endTime, status := mergeData(reqGroup)
+	deleteRequest := reqGroup[0]
+	deleteRequest.StartTime = startTime
+	deleteRequest.EndTime = endTime
+	deleteRequest.Status = status
+
+	return deleteRequest, nil
+}
+
+// getDeleteRequestGroup returns delete requests with given requestID.
+func (ds *deleteRequestsStore) getDeleteRequestGroup(ctx context.Context, userID, requestID string) ([]DeleteRequest, error) {
 	userIDAndRequestID := fmt.Sprintf("%s:%s", userID, requestID)
 
 	deleteRequests, err := ds.queryDeleteRequests(ctx, index.Query{
@@ -341,8 +380,13 @@ func unmarshalDeleteRequestDetails(itr index.ReadBatchIterator, req DeleteReques
 	return requestWithDetails, nil
 }
 
-// RemoveDeleteRequests the passed delete requests
-func (ds *deleteRequestsStore) RemoveDeleteRequests(ctx context.Context, reqs []DeleteRequest) error {
+// RemoveDeleteRequest removes the passed delete request
+func (ds *deleteRequestsStore) RemoveDeleteRequest(ctx context.Context, userID, requestID string) error {
+	reqs, err := ds.getDeleteRequestGroup(ctx, userID, requestID)
+	if err != nil {
+		return err
+	}
+
 	if len(reqs) == 0 {
 		return nil
 	}
@@ -367,6 +411,68 @@ func (ds *deleteRequestsStore) removeRequest(req DeleteRequest, writeBatch index
 
 func (ds *deleteRequestsStore) Name() string {
 	return "delete_requests_store"
+}
+
+// MergeShardedRequests merges the sharded requests back to a single request when we are done with processing all the shards
+func (ds *deleteRequestsStore) MergeShardedRequests(ctx context.Context) error {
+	deleteGroups, err := ds.GetAllShards(context.Background())
+	if err != nil {
+		return err
+	}
+
+	slices.SortFunc(deleteGroups, func(a, b DeleteRequest) int {
+		return strings.Compare(a.RequestID, b.RequestID)
+	})
+	deleteRequests := mergeDeletes(deleteGroups)
+	for _, req := range deleteRequests {
+		// do not consider requests which do not have an id. Request ID won't be set in some tests or there is a bug in our code for loading requests.
+		if req.RequestID == "" {
+			level.Error(util_log.Logger).Log("msg", "skipped considering request without an id for merging its shards",
+				"user_id", req.UserID,
+				"start_time", req.StartTime.Unix(),
+				"end_time", req.EndTime.Unix(),
+				"query", req.Query,
+			)
+			continue
+		}
+		// do not do anything if we are not done with processing all the shards or the number of shards is 1
+		if req.Status != StatusProcessed {
+			continue
+		}
+
+		var idxStart, idxEnd int
+		for i := range deleteGroups {
+			if req.RequestID == deleteGroups[i].RequestID {
+				idxStart = i
+				break
+			}
+		}
+
+		for i := len(deleteGroups) - 1; i > 0; i-- {
+			if req.RequestID == deleteGroups[i].RequestID {
+				idxEnd = i
+				break
+			}
+		}
+
+		// do not do anything if the number of shards is 1
+		if idxStart == idxEnd {
+			continue
+		}
+		reqShards := deleteGroups[idxStart : idxEnd+1]
+
+		level.Info(util_log.Logger).Log("msg", "merging sharded request",
+			"request_id", req.RequestID,
+			"num_shards", len(reqShards),
+			"start_time", req.StartTime.Unix(),
+			"end_time", req.EndTime.Unix(),
+		)
+		if err := ds.mergeShardedRequests(ctx, req, reqShards); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func parseDeleteRequestTimestamps(rangeValue []byte, deleteRequest DeleteRequest) (DeleteRequest, error) {
@@ -397,7 +503,7 @@ func parseDeleteRequestTimestamps(rangeValue []byte, deleteRequest DeleteRequest
 }
 
 // An id is useful in managing delete requests
-func generateUniqueID(orgID string, query string) []byte {
+func generateUniqueID(orgID string, query string) string {
 	uniqueID := fnv.New32()
 	_, _ = uniqueID.Write([]byte(orgID))
 
@@ -407,7 +513,7 @@ func generateUniqueID(orgID string, query string) []byte {
 
 	_, _ = uniqueID.Write([]byte(query))
 
-	return encodeUniqueID(uniqueID.Sum32())
+	return string(encodeUniqueID(uniqueID.Sum32()))
 }
 
 func encodeUniqueID(t uint32) []byte {

--- a/pkg/compactor/deletion/delete_requests_store_test.go
+++ b/pkg/compactor/deletion/delete_requests_store_test.go
@@ -21,23 +21,31 @@ func TestDeleteRequestsStore(t *testing.T) {
 
 	// add requests for both the users to the store
 	for i := 0; i < len(tc.user1Requests); i++ {
-		resp, err := tc.store.AddDeleteRequestGroup(
+		resp, err := tc.store.AddDeleteRequest(
 			context.Background(),
-			[]DeleteRequest{tc.user1Requests[i]},
+			tc.user1Requests[i].UserID,
+			tc.user1Requests[i].Query,
+			tc.user1Requests[i].StartTime,
+			tc.user1Requests[i].EndTime,
+			0,
 		)
 		require.NoError(t, err)
-		tc.user1Requests[i] = resp[0]
+		tc.user1Requests[i].RequestID = resp
 
-		resp, err = tc.store.AddDeleteRequestGroup(
+		resp, err = tc.store.AddDeleteRequest(
 			context.Background(),
-			[]DeleteRequest{tc.user2Requests[i]},
+			tc.user2Requests[i].UserID,
+			tc.user2Requests[i].Query,
+			tc.user2Requests[i].StartTime,
+			tc.user2Requests[i].EndTime,
+			0,
 		)
 		require.NoError(t, err)
-		tc.user2Requests[i] = resp[0]
+		tc.user2Requests[i].RequestID = resp
 	}
 
 	// get all requests with StatusReceived and see if they have expected values
-	deleteRequests, err := tc.store.GetDeleteRequestsByStatus(context.Background(), StatusReceived)
+	deleteRequests, err := tc.store.GetUnprocessedShards(context.Background())
 	require.NoError(t, err)
 	compareRequests(t, append(tc.user1Requests, tc.user2Requests...), deleteRequests)
 
@@ -60,14 +68,13 @@ func TestDeleteRequestsStore(t *testing.T) {
 
 	// get individual delete requests by id and see if they have expected values
 	for _, expectedRequest := range append(user1Requests, user2Requests...) {
-		actualRequest, err := tc.store.GetDeleteRequestGroup(context.Background(), expectedRequest.UserID, expectedRequest.RequestID)
+		actualRequest, err := tc.store.GetDeleteRequest(context.Background(), expectedRequest.UserID, expectedRequest.RequestID)
 		require.NoError(t, err)
-		require.Len(t, actualRequest, 1)
-		require.Equal(t, expectedRequest, actualRequest[0])
+		require.Equal(t, expectedRequest, actualRequest)
 	}
 
 	// try a non-existent request and see if it throws ErrDeleteRequestNotFound
-	_, err = tc.store.GetDeleteRequestGroup(context.Background(), "user3", "na")
+	_, err = tc.store.GetDeleteRequest(context.Background(), "user3", "na")
 	require.ErrorIs(t, err, ErrDeleteRequestNotFound)
 
 	// update some of the delete requests for both the users to processed
@@ -81,7 +88,7 @@ func TestDeleteRequestsStore(t *testing.T) {
 			request = tc.user2Requests[i]
 		}
 
-		require.NoError(t, tc.store.UpdateStatus(context.Background(), request, StatusProcessed))
+		require.NoError(t, tc.store.MarkShardAsProcessed(context.Background(), request))
 	}
 
 	// see if requests in the store have right values
@@ -116,11 +123,11 @@ func TestDeleteRequestsStore(t *testing.T) {
 			remainingRequests = append(remainingRequests, tc.user1Requests[i])
 		}
 
-		require.NoError(t, tc.store.RemoveDeleteRequests(context.Background(), []DeleteRequest{request}))
+		require.NoError(t, tc.store.RemoveDeleteRequest(context.Background(), request.UserID, request.RequestID))
 	}
 
 	// see if the store has the right remaining requests
-	deleteRequests, err = tc.store.GetDeleteRequestsByStatus(context.Background(), StatusReceived)
+	deleteRequests, err = tc.store.GetUnprocessedShards(context.Background())
 	require.NoError(t, err)
 	compareRequests(t, remainingRequests, deleteRequests)
 
@@ -138,42 +145,37 @@ func TestBatchCreateGet(t *testing.T) {
 		tc := setup(t)
 		defer tc.store.Stop()
 
-		requests, err := tc.store.AddDeleteRequestGroup(context.Background(), tc.user1Requests)
+		reqID, err := tc.store.AddDeleteRequest(context.Background(), user1, `{foo="bar"}`, now.Add(-24*time.Hour), now, time.Hour)
+		require.NoError(t, err)
+
+		requests, err := tc.store.getDeleteRequestGroup(context.Background(), user1, reqID)
 		require.NoError(t, err)
 
 		for i, req := range requests {
 			require.Equal(t, req.RequestID, requests[0].RequestID)
 			require.Equal(t, req.Status, requests[0].Status)
 			require.Equal(t, req.CreatedAt, requests[0].CreatedAt)
+			require.Equal(t, req.Query, requests[0].Query)
+			require.Equal(t, req.UserID, requests[0].UserID)
 
 			require.Equal(t, req.SequenceNum, int64(i))
 		}
-	})
-
-	t.Run("returns all the requests that share a request id", func(t *testing.T) {
-		tc := setup(t)
-		defer tc.store.Stop()
-
-		savedRequests, err := tc.store.AddDeleteRequestGroup(context.Background(), tc.user1Requests)
-		require.NoError(t, err)
-
-		results, err := tc.store.GetDeleteRequestGroup(context.Background(), savedRequests[0].UserID, savedRequests[0].RequestID)
-		require.NoError(t, err)
-
-		compareRequests(t, savedRequests, results)
 	})
 
 	t.Run("updates a single request with a new status", func(t *testing.T) {
 		tc := setup(t)
 		defer tc.store.Stop()
 
-		savedRequests, err := tc.store.AddDeleteRequestGroup(context.Background(), tc.user1Requests)
+		reqID, err := tc.store.AddDeleteRequest(context.Background(), user1, `{foo="bar"}`, now.Add(-24*time.Hour), now, time.Hour)
 		require.NoError(t, err)
 
-		err = tc.store.UpdateStatus(context.Background(), savedRequests[1], StatusProcessed)
+		savedRequests, err := tc.store.getDeleteRequestGroup(context.Background(), user1, reqID)
 		require.NoError(t, err)
 
-		results, err := tc.store.GetDeleteRequestGroup(context.Background(), savedRequests[0].UserID, savedRequests[0].RequestID)
+		err = tc.store.MarkShardAsProcessed(context.Background(), savedRequests[1])
+		require.NoError(t, err)
+
+		results, err := tc.store.getDeleteRequestGroup(context.Background(), savedRequests[0].UserID, savedRequests[0].RequestID)
 		require.NoError(t, err)
 
 		require.Equal(t, StatusProcessed, results[1].Status)
@@ -183,16 +185,149 @@ func TestBatchCreateGet(t *testing.T) {
 		tc := setup(t)
 		defer tc.store.Stop()
 
-		savedRequests, err := tc.store.AddDeleteRequestGroup(context.Background(), tc.user1Requests)
+		reqID, err := tc.store.AddDeleteRequest(context.Background(), user1, `{foo="bar"}`, now.Add(-24*time.Hour), now, time.Hour)
 		require.NoError(t, err)
 
-		err = tc.store.RemoveDeleteRequests(context.Background(), savedRequests)
+		err = tc.store.RemoveDeleteRequest(context.Background(), user1, reqID)
 		require.NoError(t, err)
 
-		results, err := tc.store.GetDeleteRequestGroup(context.Background(), savedRequests[0].UserID, savedRequests[0].RequestID)
+		results, err := tc.store.GetDeleteRequest(context.Background(), user1, reqID)
 		require.ErrorIs(t, err, ErrDeleteRequestNotFound)
 		require.Empty(t, results)
 	})
+}
+
+func TestDeleteRequestsStore_MergeShardedRequests(t *testing.T) {
+	for _, tc := range []struct {
+		name                   string
+		reqsToAdd              []storeAddReqDetails
+		shouldMarkProcessed    func(DeleteRequest) bool
+		requestsShouldBeMerged bool
+	}{
+		{
+			name: "no requests in store",
+		},
+		{
+			name: "none of the requests are processed - should not merge",
+			reqsToAdd: []storeAddReqDetails{
+				{
+					userID:          user1,
+					query:           `{foo="bar"}`,
+					startTime:       now.Add(-24 * time.Hour),
+					endTime:         now,
+					shardByInterval: time.Hour,
+				},
+			},
+			shouldMarkProcessed: func(_ DeleteRequest) bool {
+				return false
+			},
+		},
+		{
+			name: "not all requests are processed - should not merge",
+			reqsToAdd: []storeAddReqDetails{
+				{
+					userID:          user1,
+					query:           `{foo="bar"}`,
+					startTime:       now.Add(-24 * time.Hour),
+					endTime:         now,
+					shardByInterval: time.Hour,
+				},
+			},
+			shouldMarkProcessed: func(request DeleteRequest) bool {
+				return request.SequenceNum%2 == 0
+			},
+		},
+		{
+			name: "all the requests are processed - should merge",
+			reqsToAdd: []storeAddReqDetails{
+				{
+					userID:          user1,
+					query:           `{foo="bar"}`,
+					startTime:       now.Add(-24 * time.Hour),
+					endTime:         now,
+					shardByInterval: time.Hour,
+				},
+			},
+			shouldMarkProcessed: func(_ DeleteRequest) bool {
+				return true
+			},
+			requestsShouldBeMerged: true,
+		},
+		{ // build requests for 2 different users and mark all requests as processed for just one of the two
+			name: "merging requests from one user should not touch another users requests",
+			reqsToAdd: append(
+				[]storeAddReqDetails{
+					{
+						userID:          user1,
+						query:           `{foo="bar"}`,
+						startTime:       now.Add(-24 * time.Hour),
+						endTime:         now,
+						shardByInterval: time.Hour,
+					},
+					{
+						userID:          user2,
+						query:           `{foo="bar"}`,
+						startTime:       now.Add(-24 * time.Hour),
+						endTime:         now,
+						shardByInterval: time.Hour,
+					},
+				},
+			),
+			shouldMarkProcessed: func(request DeleteRequest) bool {
+				return request.UserID == user2
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+
+			workingDir := filepath.Join(tempDir, "working-dir")
+			objectStorePath := filepath.Join(tempDir, "object-store")
+
+			objectClient, err := local.NewFSObjectClient(local.FSConfig{
+				Directory: objectStorePath,
+			})
+			require.NoError(t, err)
+			ds, err := NewDeleteStore(workingDir, storage.NewIndexStorageClient(objectClient, ""))
+			require.NoError(t, err)
+
+			for _, addReqDetails := range tc.reqsToAdd {
+				_, err := ds.AddDeleteRequest(context.Background(), addReqDetails.userID, addReqDetails.query, addReqDetails.startTime, addReqDetails.endTime, addReqDetails.shardByInterval)
+				require.NoError(t, err)
+			}
+
+			reqs, err := ds.GetAllShards(context.Background())
+			require.NoError(t, err)
+
+			for _, req := range reqs {
+				if !tc.shouldMarkProcessed(req) {
+					continue
+				}
+				require.NoError(t, ds.MarkShardAsProcessed(context.Background(), req))
+			}
+
+			inStoreReqs, err := ds.GetAllDeleteRequestsForUser(context.Background(), user1)
+			require.NoError(t, err)
+
+			require.NoError(t, ds.MergeShardedRequests(context.Background()))
+			inStoreReqsAfterMerging, err := ds.GetAllDeleteRequestsForUser(context.Background(), user1)
+			require.NoError(t, err)
+
+			if tc.requestsShouldBeMerged {
+				require.Len(t, inStoreReqsAfterMerging, 1)
+				require.True(t, requestsAreEqual(inStoreReqsAfterMerging[0], DeleteRequest{
+					UserID:    user1,
+					Query:     tc.reqsToAdd[0].query,
+					StartTime: tc.reqsToAdd[0].startTime,
+					EndTime:   tc.reqsToAdd[len(tc.reqsToAdd)-1].endTime,
+					Status:    StatusProcessed,
+				}))
+			} else {
+				require.Len(t, inStoreReqsAfterMerging, len(inStoreReqs))
+				require.Equal(t, inStoreReqs, inStoreReqsAfterMerging)
+			}
+		})
+	}
 }
 
 func compareRequests(t *testing.T, expected []DeleteRequest, actual []DeleteRequest) {

--- a/pkg/compactor/deletion/delete_requests_store_test.go
+++ b/pkg/compactor/deletion/delete_requests_store_test.go
@@ -255,24 +255,22 @@ func TestDeleteRequestsStore_MergeShardedRequests(t *testing.T) {
 		},
 		{ // build requests for 2 different users and mark all requests as processed for just one of the two
 			name: "merging requests from one user should not touch another users requests",
-			reqsToAdd: append(
-				[]storeAddReqDetails{
-					{
-						userID:          user1,
-						query:           `{foo="bar"}`,
-						startTime:       now.Add(-24 * time.Hour),
-						endTime:         now,
-						shardByInterval: time.Hour,
-					},
-					{
-						userID:          user2,
-						query:           `{foo="bar"}`,
-						startTime:       now.Add(-24 * time.Hour),
-						endTime:         now,
-						shardByInterval: time.Hour,
-					},
+			reqsToAdd: []storeAddReqDetails{
+				{
+					userID:          user1,
+					query:           `{foo="bar"}`,
+					startTime:       now.Add(-24 * time.Hour),
+					endTime:         now,
+					shardByInterval: time.Hour,
 				},
-			),
+				{
+					userID:          user2,
+					query:           `{foo="bar"}`,
+					startTime:       now.Add(-24 * time.Hour),
+					endTime:         now,
+					shardByInterval: time.Hour,
+				},
+			},
 			shouldMarkProcessed: func(request DeleteRequest) bool {
 				return request.UserID == user2
 			},

--- a/pkg/compactor/deletion/delete_requests_table.go
+++ b/pkg/compactor/deletion/delete_requests_table.go
@@ -33,7 +33,10 @@ type deleteRequestsTable struct {
 	wg                sync.WaitGroup
 }
 
-const deleteRequestsIndexFileName = DeleteRequestsTableName + ".gz"
+const (
+	deleteRequestsIndexFileName  = DeleteRequestsTableName + ".gz"
+	deleteRequestsSQLiteFileName = DeleteRequestsTableName + ".sqlite.gz"
+)
 
 func newDeleteRequestsTable(workingDirectory string, indexStorageClient storage.Client) (index.Client, error) {
 	dbPath := filepath.Join(workingDirectory, DeleteRequestsTableName, DeleteRequestsTableName)

--- a/pkg/compactor/deletion/noop_delete_requests_store.go
+++ b/pkg/compactor/deletion/noop_delete_requests_store.go
@@ -2,6 +2,8 @@ package deletion
 
 import (
 	"context"
+	"github.com/prometheus/common/model"
+	"time"
 )
 
 func NewNoOpDeleteRequestsStore() DeleteRequestsStore {
@@ -10,19 +12,27 @@ func NewNoOpDeleteRequestsStore() DeleteRequestsStore {
 
 type noOpDeleteRequestsStore struct{}
 
-func (d *noOpDeleteRequestsStore) GetAllDeleteRequests(_ context.Context) ([]DeleteRequest, error) {
+func (d *noOpDeleteRequestsStore) GetDeleteRequest(ctx context.Context, userID, requestID string) (DeleteRequest, error) {
+	return DeleteRequest{}, nil
+}
+
+func (d *noOpDeleteRequestsStore) GetAllRequests(_ context.Context) ([]DeleteRequest, error) {
 	return nil, nil
 }
 
-func (d *noOpDeleteRequestsStore) MergeShardedRequests(_ context.Context, _ DeleteRequest, _ []DeleteRequest) error {
+func (d *noOpDeleteRequestsStore) GetAllShards(ctx context.Context) ([]DeleteRequest, error) {
+	return nil, nil
+}
+
+func (d *noOpDeleteRequestsStore) MergeShardedRequests(_ context.Context) error {
 	return nil
 }
 
-func (d *noOpDeleteRequestsStore) AddDeleteRequestGroup(_ context.Context, _ []DeleteRequest) ([]DeleteRequest, error) {
-	return nil, nil
+func (d *noOpDeleteRequestsStore) AddDeleteRequest(ctx context.Context, userID, query string, startTime, endTime model.Time, shardByInterval time.Duration) (string, error) {
+	return "", nil
 }
 
-func (d *noOpDeleteRequestsStore) GetDeleteRequestsByStatus(_ context.Context, _ DeleteRequestStatus) ([]DeleteRequest, error) {
+func (d *noOpDeleteRequestsStore) GetUnprocessedShards(_ context.Context) ([]DeleteRequest, error) {
 	return nil, nil
 }
 
@@ -30,7 +40,7 @@ func (d *noOpDeleteRequestsStore) GetAllDeleteRequestsForUser(_ context.Context,
 	return nil, nil
 }
 
-func (d *noOpDeleteRequestsStore) UpdateStatus(_ context.Context, _ DeleteRequest, _ DeleteRequestStatus) error {
+func (d *noOpDeleteRequestsStore) MarkShardAsProcessed(ctx context.Context, req DeleteRequest) error {
 	return nil
 }
 
@@ -38,7 +48,7 @@ func (d *noOpDeleteRequestsStore) GetDeleteRequestGroup(_ context.Context, _, _ 
 	return nil, nil
 }
 
-func (d *noOpDeleteRequestsStore) RemoveDeleteRequests(_ context.Context, _ []DeleteRequest) error {
+func (d *noOpDeleteRequestsStore) RemoveDeleteRequest(ctx context.Context, userID string, requestID string) error {
 	return nil
 }
 

--- a/pkg/compactor/deletion/noop_delete_requests_store.go
+++ b/pkg/compactor/deletion/noop_delete_requests_store.go
@@ -3,7 +3,7 @@ package deletion
 import (
 	"context"
 	"time"
-	
+
 	"github.com/prometheus/common/model"
 )
 

--- a/pkg/compactor/deletion/noop_delete_requests_store.go
+++ b/pkg/compactor/deletion/noop_delete_requests_store.go
@@ -2,8 +2,9 @@ package deletion
 
 import (
 	"context"
-	"github.com/prometheus/common/model"
 	"time"
+	
+	"github.com/prometheus/common/model"
 )
 
 func NewNoOpDeleteRequestsStore() DeleteRequestsStore {
@@ -12,7 +13,7 @@ func NewNoOpDeleteRequestsStore() DeleteRequestsStore {
 
 type noOpDeleteRequestsStore struct{}
 
-func (d *noOpDeleteRequestsStore) GetDeleteRequest(ctx context.Context, userID, requestID string) (DeleteRequest, error) {
+func (d *noOpDeleteRequestsStore) GetDeleteRequest(_ context.Context, _, _ string) (DeleteRequest, error) {
 	return DeleteRequest{}, nil
 }
 
@@ -20,7 +21,7 @@ func (d *noOpDeleteRequestsStore) GetAllRequests(_ context.Context) ([]DeleteReq
 	return nil, nil
 }
 
-func (d *noOpDeleteRequestsStore) GetAllShards(ctx context.Context) ([]DeleteRequest, error) {
+func (d *noOpDeleteRequestsStore) GetAllShards(_ context.Context) ([]DeleteRequest, error) {
 	return nil, nil
 }
 
@@ -28,7 +29,7 @@ func (d *noOpDeleteRequestsStore) MergeShardedRequests(_ context.Context) error 
 	return nil
 }
 
-func (d *noOpDeleteRequestsStore) AddDeleteRequest(ctx context.Context, userID, query string, startTime, endTime model.Time, shardByInterval time.Duration) (string, error) {
+func (d *noOpDeleteRequestsStore) AddDeleteRequest(_ context.Context, _, _ string, _, _ model.Time, _ time.Duration) (string, error) {
 	return "", nil
 }
 
@@ -40,7 +41,7 @@ func (d *noOpDeleteRequestsStore) GetAllDeleteRequestsForUser(_ context.Context,
 	return nil, nil
 }
 
-func (d *noOpDeleteRequestsStore) MarkShardAsProcessed(ctx context.Context, req DeleteRequest) error {
+func (d *noOpDeleteRequestsStore) MarkShardAsProcessed(_ context.Context, _ DeleteRequest) error {
 	return nil
 }
 
@@ -48,7 +49,7 @@ func (d *noOpDeleteRequestsStore) GetDeleteRequestGroup(_ context.Context, _, _ 
 	return nil, nil
 }
 
-func (d *noOpDeleteRequestsStore) RemoveDeleteRequest(ctx context.Context, userID string, requestID string) error {
+func (d *noOpDeleteRequestsStore) RemoveDeleteRequest(_ context.Context, _ string, _ string) error {
 	return nil
 }
 

--- a/pkg/compactor/deletion/request_handler.go
+++ b/pkg/compactor/deletion/request_handler.go
@@ -27,14 +27,17 @@ type DeleteRequestHandler struct {
 	deleteRequestsStore DeleteRequestsStore
 	metrics             *deleteRequestHandlerMetrics
 	maxInterval         time.Duration
+
+	deleteRequestCancelPeriod time.Duration
 }
 
 // NewDeleteRequestHandler creates a DeleteRequestHandler
-func NewDeleteRequestHandler(deleteStore DeleteRequestsStore, maxInterval time.Duration, registerer prometheus.Registerer) *DeleteRequestHandler {
+func NewDeleteRequestHandler(deleteStore DeleteRequestsStore, maxInterval, deleteRequestCancelPeriod time.Duration, registerer prometheus.Registerer) *DeleteRequestHandler {
 	deleteMgr := DeleteRequestHandler{
-		deleteRequestsStore: deleteStore,
-		maxInterval:         maxInterval,
-		metrics:             newDeleteRequestHandlerMetrics(registerer),
+		deleteRequestsStore:       deleteStore,
+		maxInterval:               maxInterval,
+		deleteRequestCancelPeriod: deleteRequestCancelPeriod,
+		metrics:                   newDeleteRequestHandlerMetrics(registerer),
 	}
 
 	return &deleteMgr
@@ -79,23 +82,16 @@ func (dm *DeleteRequestHandler) AddDeleteRequestHandler(w http.ResponseWriter, r
 		}
 	}
 
-	deleteRequests := buildRequests(shardByInterval, query, userID, startTime, endTime)
-	createdDeleteRequests, err := dm.deleteRequestsStore.AddDeleteRequestGroup(ctx, deleteRequests)
+	requestID, err := dm.deleteRequestsStore.AddDeleteRequest(ctx, userID, query, startTime, endTime, shardByInterval)
 	if err != nil {
 		level.Error(util_log.Logger).Log("msg", "error adding delete request to the store", "err", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
-	if len(createdDeleteRequests) == 0 {
-		level.Error(util_log.Logger).Log("msg", "zero delete requests created", "user", userID, "query", query)
-		http.Error(w, "Zero delete requests were created due to an internal error. Please contact support.", http.StatusInternalServerError)
-		return
-	}
-
 	level.Info(util_log.Logger).Log(
 		"msg", "delete request for user added",
-		"delete_request_id", createdDeleteRequests[0].RequestID,
+		"delete_request_id", requestID,
 		"user", userID,
 		"query", query,
 		"interval", shardByInterval.String(),
@@ -184,6 +180,33 @@ func mergeDeletes(reqs []DeleteRequest) []DeleteRequest {
 	return mergedRequests
 }
 
+func mergeDeletes2(reqs []DeleteRequest) []DeleteRequest {
+	if len(reqs) <= 1 {
+		return reqs
+	}
+	slices.SortFunc(reqs, func(a, b DeleteRequest) int {
+		return strings.Compare(a.RequestID, b.RequestID)
+	})
+	mergedRequests := []DeleteRequest{} // Declare this way so the return value is [] rather than null
+	// find the start and end of shards of same request and merge them
+	i := 0
+	for j := 0; j < len(reqs); j++ {
+		// if this is not the last request in the list and the next request belongs to same shard then keep looking further
+		if j < len(reqs)-1 && reqs[i].RequestID == reqs[j+1].RequestID {
+			continue
+		}
+		startTime, endTime, status := mergeData(reqs[i : j+1])
+		newDelete := reqs[i]
+		newDelete.StartTime = startTime
+		newDelete.EndTime = endTime
+		newDelete.Status = status
+
+		mergedRequests = append(mergedRequests, newDelete)
+		i = j + 1
+	}
+	return mergedRequests
+}
+
 func mergeData(deletes []DeleteRequest) (model.Time, model.Time, DeleteRequestStatus) {
 	var (
 		startTime    = model.Time(math.MaxInt64)
@@ -232,7 +255,7 @@ func (dm *DeleteRequestHandler) CancelDeleteRequestHandler(w http.ResponseWriter
 
 	params := r.URL.Query()
 	requestID := params.Get("request_id")
-	deleteRequests, err := dm.deleteRequestsStore.GetDeleteRequestGroup(ctx, userID, requestID)
+	deleteRequest, err := dm.deleteRequestsStore.GetDeleteRequest(ctx, userID, requestID)
 	if err != nil {
 		if errors.Is(err, ErrDeleteRequestNotFound) {
 			http.Error(w, "could not find delete request with given id", http.StatusNotFound)
@@ -244,18 +267,17 @@ func (dm *DeleteRequestHandler) CancelDeleteRequestHandler(w http.ResponseWriter
 		return
 	}
 
-	toDelete := filterProcessed(deleteRequests)
-	if len(toDelete) == 0 {
+	if deleteRequest.Status == StatusProcessed {
 		http.Error(w, "deletion of request which is in process or already processed is not allowed", http.StatusBadRequest)
 		return
 	}
 
-	if len(toDelete) != len(deleteRequests) && params.Get("force") != "true" {
-		http.Error(w, "Unable to cancel partially completed delete request. To force, use the ?force query parameter", http.StatusBadRequest)
+	if (deleteRequest.Status != StatusReceived || deleteRequest.CreatedAt.Add(dm.deleteRequestCancelPeriod).Before(model.Now())) && params.Get("force") != "true" {
+		http.Error(w, fmt.Sprintf("Cancellation of partially completed delete request or delete request past the deadline of %s since its creation is not allowed. To force, use the ?force query parameter", dm.deleteRequestCancelPeriod.String()), http.StatusBadRequest)
 		return
 	}
 
-	if err := dm.deleteRequestsStore.RemoveDeleteRequests(ctx, toDelete); err != nil {
+	if err := dm.deleteRequestsStore.RemoveDeleteRequest(ctx, userID, requestID); err != nil {
 		level.Error(util_log.Logger).Log("msg", "error cancelling the delete request", "err", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/pkg/compactor/deletion/request_handler.go
+++ b/pkg/compactor/deletion/request_handler.go
@@ -180,33 +180,6 @@ func mergeDeletes(reqs []DeleteRequest) []DeleteRequest {
 	return mergedRequests
 }
 
-func mergeDeletes2(reqs []DeleteRequest) []DeleteRequest {
-	if len(reqs) <= 1 {
-		return reqs
-	}
-	slices.SortFunc(reqs, func(a, b DeleteRequest) int {
-		return strings.Compare(a.RequestID, b.RequestID)
-	})
-	mergedRequests := []DeleteRequest{} // Declare this way so the return value is [] rather than null
-	// find the start and end of shards of same request and merge them
-	i := 0
-	for j := 0; j < len(reqs); j++ {
-		// if this is not the last request in the list and the next request belongs to same shard then keep looking further
-		if j < len(reqs)-1 && reqs[i].RequestID == reqs[j+1].RequestID {
-			continue
-		}
-		startTime, endTime, status := mergeData(reqs[i : j+1])
-		newDelete := reqs[i]
-		newDelete.StartTime = startTime
-		newDelete.EndTime = endTime
-		newDelete.Status = status
-
-		mergedRequests = append(mergedRequests, newDelete)
-		i = j + 1
-	}
-	return mergedRequests
-}
-
 func mergeData(deletes []DeleteRequest) (model.Time, model.Time, DeleteRequestStatus) {
 	var (
 		startTime    = model.Time(math.MaxInt64)


### PR DESCRIPTION
**What this PR does / why we need it**:
We currently use botldb to store delete requests. However, because it is a key/value store that requires us to craft the KVs to store all the details, it is difficult to add more details. I am working on replacing boltdb with SQLite to store the delete requests, which would let us add more details to the requests and optimize intensive queries that cause the compactor to use too many resources.

Here is how the delete requests store interface will look:
```
type DeleteRequestsStore interface {
	AddDeleteRequest(ctx context.Context, userID, query string, startTime, endTime model.Time, shardByInterval time.Duration) (string, error)
	GetAllRequests(ctx context.Context) ([]DeleteRequest, error)
	GetAllDeleteRequestsForUser(ctx context.Context, userID string) ([]DeleteRequest, error)
	RemoveDeleteRequest(ctx context.Context, userID string, requestID string) error
	GetDeleteRequest(ctx context.Context, userID, requestID string) (DeleteRequest, error)
	GetCacheGenerationNumber(ctx context.Context, userID string) (string, error)
	MergeShardedRequests(ctx context.Context) error

	// ToDo(Sandeep): To keep changeset smaller, below 2 methods treat a single shard as individual request. This can be refactored later in a separate PR.
	MarkShardAsProcessed(ctx context.Context, req DeleteRequest) error
	GetUnprocessedShards(ctx context.Context) ([]DeleteRequest, error)
	GetAllShards(ctx context.Context) ([]DeleteRequest, error)

	Stop()
	Name() string
}
```

**Special notes for your reviewer**:
The thing to note here is that both stores will have different mechanisms to store the shards, so I have tried to abstract it away where possible. 

**Checklist**
- [x] Tests updated
