### PR TITLE
docs: correctly tag upgrade notes

### DIFF
--- a/docs/sources/setup/upgrade/_index.md
+++ b/docs/sources/setup/upgrade/_index.md
@@ -46,9 +46,9 @@ Before upgrading, we recommend deleting all the existing bloom blocks in the obj
 metas inside the `bloom` path in the configured object store. To get rid of all the bloom blocks, delete all the objects
 inside the `bloom` path in the object store.
 
-## 3.3.2
+## 3.2.0
 
-### Loki 3.3.2
+### Loki 3.2.0
 
 ### HTTP API
 

--- a/docs/sources/setup/upgrade/_index.md
+++ b/docs/sources/setup/upgrade/_index.md
@@ -35,6 +35,21 @@ The output is incredibly verbose as it shows the entire internal config struct u
 
 ## Main / Unreleased
 
+## 3.3.0
+
+### Loki 3.3.0
+
+#### Experimental Bloom Filters
+
+With Loki 3.3.0, the bloom block format changed and any previously created block is incompatible with the new format.
+Before upgrading, we recommend deleting all the existing bloom blocks in the object store. We store bloom blocks and
+metas inside the `bloom` path in the configured object store. To get rid of all the bloom blocks, delete all the objects
+inside the `bloom` path in the object store.
+
+## 3.3.2
+
+### Loki 3.3.2
+
 ### HTTP API
 
 The API endpoint for instant queries `/api/v1/query` now returns a HTTP status 400 (Bad Request) when the provided `query`
@@ -75,16 +90,6 @@ Their YAML counterparts in the `limits_config` block are kept identical.
 
 All other CLI arguments (and their YAML counterparts) prefixed with `-bloom-compactor.` have been removed.
 
-## 3.3.0
-
-### Loki 3.3.0
-
-#### Experimental Bloom Filters
-
-With Loki 3.3.0, the bloom block format changed and any previously created block is incompatible with the new format.
-Before upgrading, we recommend deleting all the existing bloom blocks in the object store. We store bloom blocks and
-metas inside the `bloom` path in the configured object store. To get rid of all the bloom blocks, delete all the objects
-inside the `bloom` path in the object store.
 
 ## 3.0.0
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Loki 3.2.x upgrade notes are incorrectly placed under `Unreleased` section

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
