### PR TITLE
chore(mk): fix section headers length

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -211,18 +211,18 @@ loki-canary: cmd/loki-canary/loki-canary ## build loki-canary executable
 cmd/loki-canary/loki-canary:
 	CGO_ENABLED=0 go build $(GO_FLAGS) -o $@ ./$(@D)
 
-###############
+#############################
 # Loki-Canary (BoringCrypto)#
-###############
+#############################
 .PHONY: cmd/loki-canary-boringcrypto/loki-canary-boringcrypto
 loki-canary-boringcrypto: cmd/loki-canary-boringcrypto/loki-canary-boringcrypto ## build loki-canary (BoringCrypto) executable
 
 cmd/loki-canary-boringcrypto/loki-canary-boringcrypto:
 	CGO_ENABLED=1 GOOS=linux GOARCH=$(GOARCH) GOEXPERIMENT=boringcrypto go build $(GO_FLAGS) -o $@ ./$(@D)/../loki-canary
 
-###############
+########
 # Helm #
-###############
+########
 .PHONY: production/helm/loki/src/helm-test/helm-test
 helm-test: production/helm/loki/src/helm-test/helm-test ## run helm tests
 
@@ -319,9 +319,9 @@ loki-mixin-check: loki-mixin ## check the loki mixin is up to date
 	@git diff --exit-code -- $(MIXIN_OUT_PATH) || (echo "Please build mixin by running 'make loki-mixin'" && false)
 	@git diff --exit-code -- $(MIXIN_OUT_PATH_SSD) || (echo "Please build mixin by running 'make loki-mixin'" && false)
 
-###############
+###########
 # Migrate #
-###############
+###########
 .PHONY: cmd/migrate/migrate
 migrate: cmd/migrate/migrate
 
@@ -428,9 +428,9 @@ else
 	goyacc -l -p $(basename $(notdir $<)) -o $@ $<
 endif
 
-#########
+##########
 # Ragels #
-#########
+##########
 
 ragel: $(RAGEL_GOS)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes invalid header separator length in Makefile. 

**Which issue(s) this PR fixes**:

It's a trivial fix there is not issue for it.

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
