### PR TITLE
chore(dataobj): add predicate type for reading logs and streams

### DIFF
--- a/pkg/dataobj/logs_reader.go
+++ b/pkg/dataobj/logs_reader.go
@@ -17,26 +17,6 @@ import (
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/sections/logs"
 )
 
-// Predicates for reading logs.
-type (
-	// MetadataMatcher is a predicate for matching metadata in a logs section.
-	// MetadataMatcher predicates assert that a metadata entry named Name exists
-	// and its value is set to Value.
-	//
-	// For equality matches, MetadataMatcher should always be used;
-	// MetadataMatchers can translate into more efficient filter operations than
-	// a [MetadataFilter] can.
-	MetadataMatcher struct{ Name, Value string }
-
-	// MetadataFilter is a predicate for matching metadata in a logs section.
-	// MetadataFilter predicates return a true value when the combination of the
-	// provided metadata entry name and value should be included in the result.
-	//
-	// MetadataFilter predicates should be only used for more complex filtering;
-	// for equality matches, [MetadataMatcher]s are more efficient.
-	MetadataFilter func(name, value string) bool
-)
-
 // A Record is an individual log record in a data object.
 type Record struct {
 	StreamID  int64         // StreamID associated with the log record.
@@ -50,9 +30,8 @@ type LogsReader struct {
 	obj *Object
 	idx int
 
-	matchers map[string]string
-	filters  map[string]MetadataFilter
-	matchIDs map[int64]struct{}
+	matchIDs  map[int64]struct{}
+	predicate Predicate
 
 	next func() (result.Result[logs.Record], bool)
 	stop func()
@@ -87,40 +66,37 @@ func (r *LogsReader) MatchStreams(ids iter.Seq[int64]) error {
 	return nil
 }
 
-// AddMetadataMatcher adds a metadata matcher to the LogsReader.
-// [LogsReader.Read] will only return logs for which the metadata matcher
-// predicate passes.
+// SetPredicate sets the predicate to use for filtering logs. [LogsReader.Read]
+// will only return logs for which the predicate passes.
 //
-// AddMetadataMatcher may only be called before reading begins or after a call
-// to [LogsReader.Reset].
-func (r *LogsReader) AddMetadataMatcher(m MetadataMatcher) error {
-	if r.next != nil {
-		return fmt.Errorf("cannot add metadata matcher after reading has started")
-	}
-
-	if r.matchers == nil {
-		r.matchers = make(map[string]string)
-	}
-	r.matchers[m.Name] = m.Value
-	return nil
-}
-
-// AddMetadataFilter adds a metadata filter to the LogsReader.
-// [LogsReader.Read] will only return records for which the metadata filter
-// predicate passes. The filter f will be called with the provided key to allow
-// the same function to be reused for multiple keys.
+// SetPredicate returns an error if the predicate is not supported by
+// LogsReader.
 //
-// AddMetadataFilter may only be called before reading begins or after a call
-// to [LogsReader.Reset].
-func (r *LogsReader) AddMetadataFilter(key string, f MetadataFilter) error {
+// A predicate may only be set before reading begins or after a call to
+// [LogsReader.Reset].
+func (r *LogsReader) SetPredicate(p Predicate) error {
 	if r.next != nil {
-		return fmt.Errorf("cannot add metadata filter after reading has started")
+		return fmt.Errorf("cannot change predicate after reading has started")
 	}
 
-	if r.filters == nil {
-		r.filters = make(map[string]MetadataFilter)
+	var err error
+
+	walkPredicate(p, func(p Predicate) bool {
+		switch p.(type) {
+		case nil, AndPredicate, OrPredicate, NotPredicate, TimeRangePredicate, MetadataMatcherPredicate, MetadataFilterPredicate:
+			return true // Supported predicates.
+		case LabelMatcherPredicate, LabelFilterPredicate:
+			err = fmt.Errorf("unsupported predicate type %T", p)
+			return false // Unsupported predicates.
+		default:
+			panic(fmt.Sprintf("unrecognized predicate type %T", p))
+		}
+	})
+	if err != nil {
+		return err
 	}
-	r.filters[key] = f
+
+	r.predicate = p
 	return nil
 }
 
@@ -239,19 +215,36 @@ NextRow:
 		}
 	}
 
-	for key, value := range r.matchers {
-		if getMetadata(record.Metadata, key) != value {
-			goto NextRow
-		}
-	}
-
-	for key, filter := range r.filters {
-		if !filter(key, getMetadata(record.Metadata, key)) {
-			goto NextRow
-		}
+	if !matchLogsPredicate(r.predicate, record) {
+		goto NextRow
 	}
 
 	return res, true
+}
+
+func matchLogsPredicate(p Predicate, record logs.Record) bool {
+	if p == nil {
+		return true
+	}
+
+	switch p := p.(type) {
+	case AndPredicate:
+		return matchLogsPredicate(p.Left, record) && matchLogsPredicate(p.Right, record)
+	case OrPredicate:
+		return matchLogsPredicate(p.Left, record) || matchLogsPredicate(p.Right, record)
+	case NotPredicate:
+		return !matchLogsPredicate(p.Inner, record)
+	case TimeRangePredicate:
+		return matchTimestamp(p, record.Timestamp)
+	case MetadataMatcherPredicate:
+		return getMetadata(record.Metadata, p.Key) == p.Value
+	case MetadataFilterPredicate:
+		return p.Keep(p.Key, getMetadata(record.Metadata, p.Key))
+	default:
+		// Unsupported predicates should already be caught by
+		// [LogsReader.SetPredicate].
+		panic(fmt.Sprintf("unsupported predicate type %T", p))
+	}
 }
 
 func getMetadata(md push.LabelsAdapter, key string) string {
@@ -276,6 +269,8 @@ func convertMetadata(md push.LabelsAdapter) labels.Labels {
 // Reset resets the LogsReader with a new object and section index to read
 // from. Reset allows reusing a LogsReader without allocating a new one.
 //
+// Any set predicate is cleared when Reset is called.
+//
 // Reset may be called with a nil object and a negative section index to clear
 // the LogsReader without needing a new object.
 func (r *LogsReader) Reset(obj *Object, sectionIndex int) {
@@ -288,7 +283,6 @@ func (r *LogsReader) Reset(obj *Object, sectionIndex int) {
 	r.next = nil
 	r.stop = nil
 
-	clear(r.matchers)
-	clear(r.filters)
 	clear(r.matchIDs)
+	r.predicate = nil
 }

--- a/pkg/dataobj/logs_reader_test.go
+++ b/pkg/dataobj/logs_reader_test.go
@@ -109,7 +109,7 @@ func TestLogsReader_AddMetadataMatcher(t *testing.T) {
 	require.Equal(t, 1, md.LogsSections)
 
 	r := dataobj.NewLogsReader(obj, 0)
-	require.NoError(t, r.AddMetadataMatcher(dataobj.MetadataMatcher{"trace_id", "123"}))
+	require.NoError(t, r.SetPredicate(dataobj.MetadataMatcherPredicate{"trace_id", "123"}))
 
 	actual, err := readAllRecords(context.Background(), r)
 	require.NoError(t, err)
@@ -133,9 +133,12 @@ func TestLogsReader_AddMetadataFilter(t *testing.T) {
 	require.Equal(t, 1, md.LogsSections)
 
 	r := dataobj.NewLogsReader(obj, 0)
-	err = r.AddMetadataFilter("user", func(name, value string) bool {
-		require.Equal(t, "user", name)
-		return strings.HasPrefix(value, "1")
+	err = r.SetPredicate(dataobj.MetadataFilterPredicate{
+		Key: "user",
+		Keep: func(key, value string) bool {
+			require.Equal(t, "user", key)
+			return strings.HasPrefix(value, "1")
+		},
 	})
 	require.NoError(t, err)
 

--- a/pkg/dataobj/predicate.go
+++ b/pkg/dataobj/predicate.go
@@ -1,112 +1,103 @@
 package dataobj
 
 import (
-	"fmt"
 	"time"
 )
 
-// Predicate is an expression used to filter entries in a [LogsReader] or
-// [StreamsReader].
-type Predicate interface{ isPredicate() }
+type (
+	// Predicate is an expression used to filter entries in a data object.
+	Predicate interface {
+		isPredicate()
+	}
+
+	// StreamsPredicate is a [Predicate] that can be used to filter streams in a
+	// [StreamsReader].
+	StreamsPredicate interface {
+		Predicate
+		predicateKind(StreamsPredicate)
+	}
+
+	// LogsPredicate is a [Predicate] that can be used to filter logs in a
+	// [LogsReader].
+	LogsPredicate interface {
+		Predicate
+		predicateKind(LogsPredicate)
+	}
+)
 
 // Supported predicates.
 type (
 	// An AndPredicate is a Predicate which requires both its Left and Right
 	// predicate to be true.
-	AndPredicate struct{ Left, Right Predicate }
+	AndPredicate[P Predicate] struct{ Left, Right P }
 
 	// An OrPredicate is a Predicate which requires either its Left or Right
 	// predicate to be true.
-	OrPredicate struct{ Left, Right Predicate }
+	OrPredicate[P Predicate] struct{ Left, Right P }
 
 	// A NotPredicate is a Predicate which requires its Inner predicate to be
 	// false.
-	NotPredicate struct{ Inner Predicate }
+	NotPredicate[P Predicate] struct{ Inner P }
 
 	// A TimeRangePredicate is a Predicate which requires the timestamp of the
 	// entry to be within the range of StartTime and EndTime.
-	TimeRangePredicate struct {
+	TimeRangePredicate[P Predicate] struct {
 		StartTime, EndTime time.Time
 		IncludeStart       bool // Whether StartTime is inclusive.
 		IncludeEnd         bool // Whether EndTime is inclusive.
 	}
 
-	// A LabelMatcherPredicate requires a label named Name to exist with a value
-	// of Value.
-	//
-	// LabelMatcherPredicate can only be used with [StreamsReader].
+	// A LabelMatcherPredicate is a [StreamsPredicate] which requires a label
+	// named Name to exist with a value of Value.
 	LabelMatcherPredicate struct{ Name, Value string }
 
-	// A LabelFilterPredicate requires that labels with the provided name pass a
-	// Keep function.
+	// A LabelFilterPredicate is a [StreamsPredicate] that requires that labels
+	// with the provided name pass a Keep function.
 	//
 	// The name is is provided to the keep function to allow the same function to
 	// be used for multiple filter predicates.
 	//
-	// LabelFilterPredicate can only be used with [StreamsReader].
+	// Uses of LabelFilterPredicate are not eligible for page filtering and
+	// should only be used when a condition cannot be expressed by other basic
+	// predicates.
 	LabelFilterPredicate struct {
 		Name string
 		Keep func(name, value string) bool
 	}
 
-	// A MetadataMatcherPredicate requires a metadata key named Key to exist with
-	// a value of Value.
-	//
-	// MetadataMatcherPredicate can only be used with [LogsReader].
+	// A MetadataMatcherPredicate is a [LogsPredicae] that requires a metadata
+	// key named Key to exist with a value of Value.
 	MetadataMatcherPredicate struct{ Key, Value string }
 
-	// A MetadataFilterPredicate requires that metadata with the provided key pass a
-	// Keep function.
+	// A MetadataFilterPredicate is a [LogsPredicate] that requires that metadata
+	// with the provided key pass a Keep function.
 	//
 	// The key is provided to the keep function to allow the same function to be used
 	// for multiple filter predicates.
 	//
-	// MetadataFilterPredicate can only be used with [LogsReader].
+	// Uses of MetadataFilterPredicate are not eligible for page filtering and
+	// should only be used when a condition cannot be expressed by other basic
+	// predicates.
 	MetadataFilterPredicate struct {
 		Key  string
 		Keep func(key, value string) bool
 	}
 )
 
-func (AndPredicate) isPredicate()             {}
-func (OrPredicate) isPredicate()              {}
-func (NotPredicate) isPredicate()             {}
-func (TimeRangePredicate) isPredicate()       {}
+func (AndPredicate[P]) isPredicate()          {}
+func (OrPredicate[P]) isPredicate()           {}
+func (NotPredicate[P]) isPredicate()          {}
+func (TimeRangePredicate[P]) isPredicate()    {}
 func (LabelMatcherPredicate) isPredicate()    {}
 func (LabelFilterPredicate) isPredicate()     {}
 func (MetadataMatcherPredicate) isPredicate() {}
 func (MetadataFilterPredicate) isPredicate()  {}
 
-// walkPredicate traverses a predicate in depth-first order: it starts by
-// calling fn(p). If fn(p) returns true, walkPredicate is invoked recursively
-// with fn for each of the non-nil children of p, followed by a call of
-// fn(nil).
-func walkPredicate(p Predicate, fn func(p Predicate) bool) {
-	if p == nil || !fn(p) {
-		return
-	}
-
-	switch p := p.(type) {
-	case AndPredicate:
-		walkPredicate(p.Left, fn)
-		walkPredicate(p.Right, fn)
-
-	case OrPredicate:
-		walkPredicate(p.Left, fn)
-		walkPredicate(p.Right, fn)
-
-	case NotPredicate:
-		walkPredicate(p.Inner, fn)
-
-	case TimeRangePredicate: // No children.
-	case LabelMatcherPredicate: // No children.
-	case LabelFilterPredicate: // No children.
-	case MetadataMatcherPredicate: // No children.
-	case MetadataFilterPredicate: // No children.
-
-	default:
-		panic(fmt.Sprintf("dataobj.walkPredicate: unsupported predicate type %T", p))
-	}
-
-	fn(nil)
-}
+func (AndPredicate[P]) predicateKind(P)                      {}
+func (OrPredicate[P]) predicateKind(P)                       {}
+func (NotPredicate[P]) predicateKind(P)                      {}
+func (TimeRangePredicate[P]) predicateKind(P)                {}
+func (LabelMatcherPredicate) predicateKind(StreamsPredicate) {}
+func (LabelFilterPredicate) predicateKind(StreamsPredicate)  {}
+func (MetadataMatcherPredicate) predicateKind(LogsPredicate) {}
+func (MetadataFilterPredicate) predicateKind(LogsPredicate)  {}

--- a/pkg/dataobj/predicate.go
+++ b/pkg/dataobj/predicate.go
@@ -1,0 +1,112 @@
+package dataobj
+
+import (
+	"fmt"
+	"time"
+)
+
+// Predicate is an expression used to filter entries in a [LogsReader] or
+// [StreamsReader].
+type Predicate interface{ isPredicate() }
+
+// Supported predicates.
+type (
+	// An AndPredicate is a Predicate which requires both its Left and Right
+	// predicate to be true.
+	AndPredicate struct{ Left, Right Predicate }
+
+	// An OrPredicate is a Predicate which requires either its Left or Right
+	// predicate to be true.
+	OrPredicate struct{ Left, Right Predicate }
+
+	// A NotPredicate is a Predicate which requires its Inner predicate to be
+	// false.
+	NotPredicate struct{ Inner Predicate }
+
+	// A TimeRangePredicate is a Predicate which requires the timestamp of the
+	// entry to be within the range of StartTime and EndTime.
+	TimeRangePredicate struct {
+		StartTime, EndTime time.Time
+		IncludeStart       bool // Whether StartTime is inclusive.
+		IncludeEnd         bool // Whether EndTime is inclusive.
+	}
+
+	// A LabelMatcherPredicate requires a label named Name to exist with a value
+	// of Value.
+	//
+	// LabelMatcherPredicate can only be used with [StreamsReader].
+	LabelMatcherPredicate struct{ Name, Value string }
+
+	// A LabelFilterPredicate requires that labels with the provided name pass a
+	// Keep function.
+	//
+	// The name is is provided to the keep function to allow the same function to
+	// be used for multiple filter predicates.
+	//
+	// LabelFilterPredicate can only be used with [StreamsReader].
+	LabelFilterPredicate struct {
+		Name string
+		Keep func(name, value string) bool
+	}
+
+	// A MetadataMatcherPredicate requires a metadata key named Key to exist with
+	// a value of Value.
+	//
+	// MetadataMatcherPredicate can only be used with [LogsReader].
+	MetadataMatcherPredicate struct{ Key, Value string }
+
+	// A MetadataFilterPredicate requires that metadata with the provided key pass a
+	// Keep function.
+	//
+	// The key is provided to the keep function to allow the same function to be used
+	// for multiple filter predicates.
+	//
+	// MetadataFilterPredicate can only be used with [LogsReader].
+	MetadataFilterPredicate struct {
+		Key  string
+		Keep func(key, value string) bool
+	}
+)
+
+func (AndPredicate) isPredicate()             {}
+func (OrPredicate) isPredicate()              {}
+func (NotPredicate) isPredicate()             {}
+func (TimeRangePredicate) isPredicate()       {}
+func (LabelMatcherPredicate) isPredicate()    {}
+func (LabelFilterPredicate) isPredicate()     {}
+func (MetadataMatcherPredicate) isPredicate() {}
+func (MetadataFilterPredicate) isPredicate()  {}
+
+// walkPredicate traverses a predicate in depth-first order: it starts by
+// calling fn(p). If fn(p) returns true, walkPredicate is invoked recursively
+// with fn for each of the non-nil children of p, followed by a call of
+// fn(nil).
+func walkPredicate(p Predicate, fn func(p Predicate) bool) {
+	if p == nil || !fn(p) {
+		return
+	}
+
+	switch p := p.(type) {
+	case AndPredicate:
+		walkPredicate(p.Left, fn)
+		walkPredicate(p.Right, fn)
+
+	case OrPredicate:
+		walkPredicate(p.Left, fn)
+		walkPredicate(p.Right, fn)
+
+	case NotPredicate:
+		walkPredicate(p.Inner, fn)
+
+	case TimeRangePredicate: // No children.
+	case LabelMatcherPredicate: // No children.
+	case LabelFilterPredicate: // No children.
+	case MetadataMatcherPredicate: // No children.
+	case MetadataFilterPredicate: // No children.
+
+	default:
+		panic(fmt.Sprintf("dataobj.walkPredicate: unsupported predicate type %T", p))
+	}
+
+	fn(nil)
+}

--- a/pkg/dataobj/streams_reader.go
+++ b/pkg/dataobj/streams_reader.go
@@ -224,16 +224,16 @@ func matchStreamsPredicate(p Predicate, stream streams.Stream) bool {
 
 func matchTimestamp(p TimeRangePredicate, ts time.Time) bool {
 	switch {
-	case p.IncludeStart && ts.Before(p.StartTime):
-		return false
-	case !p.IncludeStart && ts.Equal(p.StartTime):
-		return false
-	case p.IncludeEnd && ts.After(p.EndTime):
-		return false
-	case !p.IncludeEnd && ts.Equal(p.EndTime):
-		return false
+	case p.IncludeStart && p.IncludeEnd: // start <= ts <= end
+		return (p.StartTime.Before(ts) || p.StartTime.Equal(ts)) && (ts.Before(p.EndTime) || ts.Equal(p.EndTime))
+	case p.IncludeStart && !p.IncludeEnd: // start <= ts < end
+		return (p.StartTime.Before(ts) || p.StartTime.Equal(ts)) && ts.Before(p.EndTime)
+	case !p.IncludeStart && p.IncludeEnd: // start < ts <= end
+		return p.StartTime.Before(ts) && (ts.Before(p.EndTime) || ts.Equal(p.EndTime))
+	case !p.IncludeStart && !p.IncludeEnd: // start < ts < end
+		return p.StartTime.Before(ts) && ts.Before(p.EndTime)
 	default:
-		return true
+		panic("unreachable")
 	}
 }
 

--- a/pkg/dataobj/streams_reader_test.go
+++ b/pkg/dataobj/streams_reader_test.go
@@ -58,7 +58,7 @@ func TestStreamsReader_AddLabelMatcher(t *testing.T) {
 	require.Equal(t, 1, md.StreamsSections)
 
 	r := dataobj.NewStreamsReader(obj, 0)
-	require.NoError(t, r.AddLabelMatcher(dataobj.LabelMatcher{Name: "app", Value: "bar"}))
+	require.NoError(t, r.SetPredicate(dataobj.LabelMatcherPredicate{Name: "app", Value: "bar"}))
 
 	actual, err := readAllStreams(context.Background(), r)
 	require.NoError(t, err)
@@ -77,9 +77,12 @@ func TestStreamsReader_AddLabelFilter(t *testing.T) {
 	require.Equal(t, 1, md.StreamsSections)
 
 	r := dataobj.NewStreamsReader(obj, 0)
-	err = r.AddLabelFilter("app", func(key string, value string) bool {
-		require.Equal(t, "app", key)
-		return strings.HasPrefix(value, "b")
+	err = r.SetPredicate(dataobj.LabelFilterPredicate{
+		Name: "app",
+		Keep: func(name, value string) bool {
+			require.Equal(t, "app", name)
+			return strings.HasPrefix(value, "b")
+		},
 	})
 	require.NoError(t, err)
 


### PR DESCRIPTION
dataobj.Predicate represents some condition for filtering entries in the streams and logs sections.

The Predicate type is shared for simplicity, though some implementations of Predicate can only be used with certain readers:

* LabelMatcherPredicate and LabelFilterPredicate can only be used with StreamsReader.

* MetadataMatcherPredicate and MetadataFilterPredicate can only be used with LogsReader.

All other implementations of Predicate can be used in both Reader types.

This replaces the older API for filtering, which didn't permit doing logical ORs across labels (or timestamp ranges).