### PR TITLE
fix(ci): Provide correct build info for release builds (#15939)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -617,8 +617,11 @@ loki-image-cross:
 loki-debug-image: ## build the debug loki docker image
 	$(SUDO) $(BUILD_OCI) --build-arg=GO_VERSION=$(GO_VERSION) -t $(IMAGE_PREFIX)/loki:$(IMAGE_TAG)-debug -f cmd/loki/Dockerfile.debug .
 
-loki-push: loki-image-cross
-	$(call push-image,loki)
+# Canary image
+loki-canary-image: ## build the canary docker image
+	$(OCI_BUILD) -t $(CANARY_IMAGE) -f cmd/loki-canary/Dockerfile .
+loki-canary-boringcrypto-image:
+	$(OCI_BUILD) -t $(IMAGE_PREFIX)/loki-canary-boringcrypto:$(IMAGE_TAG) -f cmd/loki-canary-boringcrypto/Dockerfile .
 
 # loki-canary
 loki-canary-image: ## build the loki canary docker image

--- a/Makefile
+++ b/Makefile
@@ -617,11 +617,8 @@ loki-image-cross:
 loki-debug-image: ## build the debug loki docker image
 	$(SUDO) $(BUILD_OCI) --build-arg=GO_VERSION=$(GO_VERSION) -t $(IMAGE_PREFIX)/loki:$(IMAGE_TAG)-debug -f cmd/loki/Dockerfile.debug .
 
-# Canary image
-loki-canary-image: ## build the canary docker image
-	$(OCI_BUILD) -t $(CANARY_IMAGE) -f cmd/loki-canary/Dockerfile .
-loki-canary-boringcrypto-image:
-	$(OCI_BUILD) -t $(IMAGE_PREFIX)/loki-canary-boringcrypto:$(IMAGE_TAG) -f cmd/loki-canary-boringcrypto/Dockerfile .
+loki-push: loki-image-cross
+	$(call push-image,loki)
 
 # loki-canary
 loki-canary-image: ## build the loki canary docker image

--- a/clients/cmd/promtail/Dockerfile
+++ b/clients/cmd/promtail/Dockerfile
@@ -1,7 +1,7 @@
 ARG GO_VERSION=1.23
-ARG IMAGE_TAG
 
 FROM golang:${GO_VERSION}-bookworm as build
+ARG IMAGE_TAG
 
 COPY . /src/loki
 WORKDIR /src/loki

--- a/clients/cmd/promtail/Dockerfile
+++ b/clients/cmd/promtail/Dockerfile
@@ -1,5 +1,6 @@
 ARG GO_VERSION=1.23
 ARG IMAGE_TAG
+
 FROM golang:${GO_VERSION}-bookworm as build
 
 COPY . /src/loki

--- a/cmd/loki-canary-boringcrypto/Dockerfile
+++ b/cmd/loki-canary-boringcrypto/Dockerfile
@@ -1,6 +1,6 @@
 ARG GO_VERSION=1.23
-ARG IMAGE_TAG
 FROM golang:${GO_VERSION} as build
+ARG IMAGE_TAG
 
 COPY . /src/loki
 WORKDIR /src/loki

--- a/cmd/loki-canary/Dockerfile
+++ b/cmd/loki-canary/Dockerfile
@@ -1,6 +1,6 @@
 ARG GO_VERSION=1.23
-ARG IMAGE_TAG
 FROM golang:${GO_VERSION} AS build
+ARG IMAGE_TAG
 
 COPY . /src/loki
 WORKDIR /src/loki

--- a/cmd/loki/Dockerfile
+++ b/cmd/loki/Dockerfile
@@ -1,7 +1,7 @@
 ARG GO_VERSION=1.23
-ARG IMAGE_TAG
-FROM golang:${GO_VERSION} AS build
 
+FROM golang:${GO_VERSION} AS build
+ARG IMAGE_TAG
 COPY . /src/loki
 WORKDIR /src/loki
 RUN make clean && make BUILD_IN_CONTAINER=false IMAGE_TAG=${IMAGE_TAG} loki

--- a/cmd/querytee/Dockerfile
+++ b/cmd/querytee/Dockerfile
@@ -1,9 +1,10 @@
 ARG GO_VERSION=1.23
 FROM golang:${GO_VERSION} as build
+ARG IMAGE_TAG
 
 COPY . /src/loki
 WORKDIR /src/loki
-RUN make clean && make BUILD_IN_CONTAINER=false loki-querytee
+RUN make clean && make BUILD_IN_CONTAINER=false IMAGE_TAG=${IMAGE_TAG} loki-querytee
 
 FROM gcr.io/distroless/static:debug
 COPY --from=build /src/loki/cmd/querytee/querytee /usr/bin/querytee


### PR DESCRIPTION
Then building a binary or image release for an upcoming version from a release branch, we provide the version using `--build-arg IMAGE_TAG=...` in the Docker build step of the CI workflow ([ref](https://github.com/grafana/loki/blob/3df08bd39f45bbf8314f31a59f35b955b9a31a5e/.github/workflows/minor-release-pr.yml#L456)).

However, this argument was ignored in the Dockerfile and not further passed down to the `make ...` command inside build phase of the Dockerfile.

Signed-off-by: Christian Haudum <christian.haudum@gmail.com>
(cherry picked from commit 625bdabce91f1043065b582052b2c3558c9af0e6)

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
