### PR TITLE
docs: adding Promtail deprecation banners

### DIFF
--- a/docs/sources/send-data/_index.md
+++ b/docs/sources/send-data/_index.md
@@ -20,13 +20,13 @@ The following clients are developed and supported (for those customers who have 
 
 - [Grafana Alloy](https://grafana.com/docs/alloy/latest/) - Grafana Alloy is a vendor-neutral distribution of the OpenTelemetry (OTel) Collector. Alloy offers native pipelines for OTel, Prometheus, Pyroscope, Loki, and many other metrics, logs, traces, and profile tools. In addition, you can use Alloy pipelines to do different tasks, such as configure alert rules in Loki and Mimir. Alloy is fully compatible with the OTel Collector, Prometheus Agent, and Promtail. You can use Alloy as an alternative to either of these solutions or combine it into a hybrid system of multiple collectors and agents. You can deploy Alloy anywhere within your IT infrastructure and pair it with your Grafana LGTM stack, a telemetry backend from Grafana Cloud, or any other compatible backend from any other vendor.
  {{< docs/shared source="alloy" lookup="agent-deprecation.md" version="next" >}}
-- [Grafana Agent](/docs/agent/latest/) - The Grafana Agent is a client for the Grafana stack. It can collect telemetry data for metrics, logs, traces, and continuous profiles and is fully compatible with the Prometheus, OpenTelemetry, and Grafana open source ecosystems.
-- [Promtail](https://grafana.com/docs/loki/<LOKI_VERSION>/send-data/promtail/) - Promtail can be configured to automatically scrape logs from Kubernetes pods running on the same node that Promtail runs on. Promtail and Prometheus running together in Kubernetes enables powerful debugging: if Prometheus and Promtail use the same labels, users can use tools like Grafana to switch between metrics and logs based on the label set. Promtail can be configured to tail logs from all files given a host path. It is the easiest way to send logs to Loki from plain-text files (for example, things that log to `/var/log/*.log`).
-Promtail works well if you want to extract metrics from logs such as counting the occurrences of a particular message.
-{{< admonition type="note" >}}
-Promtail is feature complete. All future feature development will occur in Grafana Alloy.
-{{< /admonition >}}
 - [xk6-loki extension](https://github.com/grafana/xk6-loki) - The k6-loki extension lets you perform [load testing on Loki](https://grafana.com/docs/loki/<LOKI_VERSION>/send-data/k6/).
+- [Grafana Agent](/docs/agent/latest/) (DEPRECATED) - The Grafana Agent is a client for the Grafana stack. It can collect telemetry data for metrics, logs, traces, and continuous profiles and is fully compatible with the Prometheus, OpenTelemetry, and Grafana open source ecosystems.
+- [Promtail](https://grafana.com/docs/loki/<LOKI_VERSION>/send-data/promtail/) (DEPRECATED) - Promtail can be configured to automatically scrape logs from Kubernetes pods running on the same node that Promtail runs on. 
+{{< admonition type="caution" >}}
+Promtail is deprecated. If you are currently using Promtail, you should plan your [migration to Alloy](https://grafana.com/docs/loki/<LOKI_VERSION>/setup/migrate/migrate-to-alloy/). All future feature development will occur in Grafana Alloy.
+{{< /admonition >}}
+
 
 ## OpenTelemetry Collector
 

--- a/docs/sources/send-data/promtail/_index.md
+++ b/docs/sources/send-data/promtail/_index.md
@@ -8,13 +8,15 @@ weight:  300
 ---
 # Promtail agent
 
+{{< admonition type="caution" >}}
+Promtail is now deprecated and will enter into Long-Term Support (LTS) beginning Feb. 13, 2025. This means that Promtail will no longer receive any new feature updates, but it will receive critical bug fixes and security fixes. Commercial support will end after the LTS phase, which we anticipate will extend for about 12 months until February 28, 2026. End-of-Life (EOL) phase for Promtail will begin once LTS ends. Promtail is expected to reach EOL on March 2, 2026, afterwards no future support or updates will be provided. All future feature development will occur in Grafana Alloy.
+
+If you are currently using Promtail, you should plan your [migration to Alloy](https://grafana.com/docs/loki/<LOKI_VERSION>/setup/migrate/migrate-to-alloy/). The Alloy migration documentation includes a migration tool for converting your Promtail configuration to an Alloy configuration with a single command.
+{{< /admonition >}}
+
 Promtail is an agent which ships the contents of local logs to a private Grafana Loki
 instance or [Grafana Cloud](/oss/loki). It is usually
 deployed to every machine that runs applications which need to be monitored.
-
-{{< admonition type="note" >}}
-Promtail is feature complete.  All future feature development will occur in Grafana Alloy.
-{{< /admonition >}}
 
 It primarily:
 
@@ -74,12 +76,13 @@ scrape_configs:
 ```
 
 Important details are:
-* It relies on the `\n` character to separate the data into different log lines.
-* The max expected log line is 2MB within the compressed file.
-* The data is decompressed in blocks of 4096 bytes. i.e: it first fetches a block of 4096 bytes
+
+- It relies on the `\n` character to separate the data into different log lines.
+- The max expected log line is 2MB within the compressed file.
+- The data is decompressed in blocks of 4096 bytes. i.e: it first fetches a block of 4096 bytes
   from the compressed file and processes it. After processing this block and pushing the data to Loki,
   it fetches the following 4096 bytes, and so on.
-* It supports the following extensions:
+- It supports the following extensions:
   - `.gz`: Data will be decompressed with the native Gunzip Golang pkg (`pkg/compress/gzip`)
   - `.z`: Data will be decompressed with the native Zlib Golang pkg (`pkg/compress/zlib`)
   - `.bz2`: Data will be decompressed with the native Bzip2 Golang pkg (`pkg/compress/bzip2`)
@@ -88,25 +91,20 @@ Important details are:
       compressed file, **the first parsed line will contains metadata together with
       your log line**. It is illustrated at
       `./clients/pkg/promtail/targets/file/decompresser_test.go`.
-* `.zip` extension isn't supported as of now because it doesn't support some of the interfaces
-  Promtail requires. We have plans to add support for it in the near future.
-* The decompression is quite CPU intensive and a lot of allocations are expected
+- `.zip` extension isn't supported as of now because it doesn't support some of the interfaces
+  Promtail requires.
+- The decompression is quite CPU intensive and a lot of allocations are expected
   to occur, especially depending on the size of the file. You can expect the number
   of garbage collection runs and the CPU usage to skyrocket, but no memory leak is
   expected.
-* Positions are supported. That means that, if you interrupt Promtail after
+- Positions are supported. That means that, if you interrupt Promtail after
   parsing and pushing (for example) 45% of your compressed file data, you can expect Promtail
   to resume work from the last scraped line and process the rest of the remaining 55%.
-* Since decompression and pushing can be very fast, depending on the size
+- Since decompression and pushing can be very fast, depending on the size
   of your compressed file Loki will rate-limit your ingestion. In that case you
   might configure Promtail's [`limits` stage](https://grafana.com/docs/loki/<LOKI_VERSION>/send-data/promtail/configuration/#limits_config) to slow the pace or increase [ingestion limits](https://grafana.com/docs/loki/<LOKI_VERSION>/configure/#limits_config) on Loki.
-
-* Log rotations on compressed files **are not supported as of now** (log rotation is fully supported for normal files), mostly because it requires us modifying Promtail to
-  rely on file inodes instead of file names. If you'd like to see support for it, create a new
-  issue on Github asking for it and explaining your use case.
-* If you compress a file under a folder being scraped, Promtail might try to ingest your file before you finish compressing it. To avoid it, pick a `initial_delay` that is enough to avoid it.
-* If you would like to see support for a compression protocol that isn't listed here, create a new issue on Github asking for it and explaining your use case.
-
+- Log rotations on compressed files are not supported (log rotation is fully supported for normal files), mostly because it requires us modifying Promtail to rely on file inodes instead of file names.
+- If you compress a file under a folder being scraped, Promtail might try to ingest your file before you finish compressing it. To avoid it, pick a `initial_delay` that is enough to avoid it.
 
 ## Loki Push API
 

--- a/docs/sources/send-data/promtail/cloud/_index.md
+++ b/docs/sources/send-data/promtail/cloud/_index.md
@@ -8,6 +8,8 @@ weight: 300
 
 # Sending logs from the cloud
 
+{{< docs/shared source="loki" lookup="promtail-deprecation.md" version="<LOKI_VERSION>" >}}
+
 Sending logs from cloud services to Grafana Loki is a little different depending on the AWS service you are using. The following tutorials walk you through configuring cloud services to send logs to Loki.
 
 - [Amazon Elastic Compute Cloud (EC2)]({{< relref "./ec2" >}})

--- a/docs/sources/send-data/promtail/cloud/ec2/_index.md
+++ b/docs/sources/send-data/promtail/cloud/ec2/_index.md
@@ -11,6 +11,8 @@ weight: 100
 
 In this tutorial we're going to setup [Promtail]({{< relref "../../../../send-data/promtail" >}}) on an AWS EC2 instance and configure it to sends all its logs to a Grafana Loki instance.
 
+{{< docs/shared source="loki" lookup="promtail-deprecation.md" version="<LOKI_VERSION>" >}}
+
 ## Requirements
 
 Before you start you'll need:

--- a/docs/sources/send-data/promtail/cloud/ecs/_index.md
+++ b/docs/sources/send-data/promtail/cloud/ecs/_index.md
@@ -11,6 +11,8 @@ weight: 100
 
 [ECS][ECS] is the fully managed container orchestration service by Amazon. Combined with [Fargate][Fargate] you can run your container workload without the need to provision your own compute resources. In this tutorial we will see how you can leverage [Firelens][Firelens] an AWS log router to forward all your logs and your workload metadata to a Grafana Loki instance.
 
+{{< docs/shared source="loki" lookup="promtail-deprecation.md" version="<LOKI_VERSION>" >}}
+
 After this tutorial you will able to query all your logs in one place using Grafana.
 
 ## Requirements

--- a/docs/sources/send-data/promtail/cloud/eks/_index.md
+++ b/docs/sources/send-data/promtail/cloud/eks/_index.md
@@ -11,6 +11,8 @@ weight: 100
 
 In this tutorial we'll see how to set up Promtail on [EKS][eks]. Amazon Elastic Kubernetes Service (Amazon [EKS][eks]) is a fully managed Kubernetes service, using Promtail we'll get full visibility into our cluster logs. We'll start by forwarding pods logs then nodes services and finally Kubernetes events.
 
+{{< docs/shared source="loki" lookup="promtail-deprecation.md" version="<LOKI_VERSION>" >}}
+
 After this tutorial you will able to query all your logs in one place using Grafana.
 
 ## Requirements

--- a/docs/sources/send-data/promtail/cloud/gcp/_index.md
+++ b/docs/sources/send-data/promtail/cloud/gcp/_index.md
@@ -11,6 +11,8 @@ weight:
 
 This document explains how one can setup Google Cloud Platform to forward its cloud resource logs from a particular GCP project into Google Pubsub topic so that is available for Promtail to consume.
 
+{{< docs/shared source="loki" lookup="promtail-deprecation.md" version="<LOKI_VERSION>" >}}
+
 This document assumes, that reader have `gcloud` installed and have the required permissions (as mentioned in [Roles and Permission](#roles-and-permission) section).
 
 There are two flavours of how to configure this:

--- a/docs/sources/send-data/promtail/configuration.md
+++ b/docs/sources/send-data/promtail/configuration.md
@@ -9,6 +9,8 @@ weight:  200
 
 # Configure Promtail
 
+{{< docs/shared source="loki" lookup="promtail-deprecation.md" version="<LOKI_VERSION>" >}}
+
 Promtail is configured in a YAML file (usually referred to as `config.yaml`)
 which contains information on the Promtail server, where positions are stored,
 and how to scrape logs from files.

--- a/docs/sources/send-data/promtail/installation.md
+++ b/docs/sources/send-data/promtail/installation.md
@@ -9,9 +9,7 @@ weight:  100
 
 # Install Promtail
 
-{{< admonition type="note" >}}
-Promtail is feature complete.  All future feature development will occur in Grafana Alloy.
-{{< /admonition >}}
+{{< docs/shared source="loki" lookup="promtail-deprecation.md" version="<LOKI_VERSION>" >}}
 
 Promtail is distributed as a binary, in a Docker container,
 or there is a Helm chart to install it in a Kubernetes cluster.

--- a/docs/sources/send-data/promtail/logrotation/_index.md
+++ b/docs/sources/send-data/promtail/logrotation/_index.md
@@ -9,6 +9,8 @@ weight:  500
 
 # Promtail and Log Rotation
 
+{{< docs/shared source="loki" lookup="promtail-deprecation.md" version="<LOKI_VERSION>" >}}
+
 ## Why does log rotation matter?
 
 At any point in time, there may be three processes working on a log file as shown in the image below.

--- a/docs/sources/send-data/promtail/pipelines.md
+++ b/docs/sources/send-data/promtail/pipelines.md
@@ -9,6 +9,8 @@ weight:  600
 
 # Pipelines
 
+{{< docs/shared source="loki" lookup="promtail-deprecation.md" version="<LOKI_VERSION>" >}}
+
 A detailed look at how to set up Promtail to process your log lines, including
 extracting metrics and labels.
 

--- a/docs/sources/send-data/promtail/scraping.md
+++ b/docs/sources/send-data/promtail/scraping.md
@@ -9,6 +9,8 @@ weight:  400
 
 # Configuring Promtail for service discovery
 
+{{< docs/shared source="loki" lookup="promtail-deprecation.md" version="<LOKI_VERSION>" >}}
+
 Promtail currently supports scraping from the following sources:
 
 - [Azure event hubs]({{< relref "#azure-event-hubs" >}})

--- a/docs/sources/send-data/promtail/stages/_index.md
+++ b/docs/sources/send-data/promtail/stages/_index.md
@@ -9,6 +9,8 @@ weight:  700
 
 # Promtail pipeline stages
 
+{{< docs/shared source="loki" lookup="promtail-deprecation.md" version="<LOKI_VERSION>" >}}
+
 This section is a collection of all stages Promtail supports in a
 [Pipeline]({{< relref "../pipelines" >}}).
 

--- a/docs/sources/send-data/promtail/stages/cri.md
+++ b/docs/sources/send-data/promtail/stages/cri.md
@@ -9,6 +9,8 @@ weight:
 
 # cri
 
+{{< docs/shared source="loki" lookup="promtail-deprecation.md" version="<LOKI_VERSION>" >}}
+
 The `cri` stage is a parsing stage that reads the log line using the standard CRI logging format.
 
 ## Schema

--- a/docs/sources/send-data/promtail/stages/decolorize.md
+++ b/docs/sources/send-data/promtail/stages/decolorize.md
@@ -9,6 +9,8 @@ weight:
 
 # decolorize
 
+{{< docs/shared source="loki" lookup="promtail-deprecation.md" version="<LOKI_VERSION>" >}}
+
 The `decolorize` stage is a transform stage that lets you strip
 ANSI color codes from the log line, thus making it easier to
 parse logs further.

--- a/docs/sources/send-data/promtail/stages/docker.md
+++ b/docs/sources/send-data/promtail/stages/docker.md
@@ -9,6 +9,8 @@ weight:
 
 # docker
 
+{{< docs/shared source="loki" lookup="promtail-deprecation.md" version="<LOKI_VERSION>" >}}
+
 The `docker` stage is a parsing stage that reads log lines in the standard
 format of Docker log files.
 

--- a/docs/sources/send-data/promtail/stages/drop.md
+++ b/docs/sources/send-data/promtail/stages/drop.md
@@ -9,6 +9,8 @@ weight:
 
 # drop
 
+{{< docs/shared source="loki" lookup="promtail-deprecation.md" version="<LOKI_VERSION>" >}}
+
 The `drop` stage is a filtering stage that lets you drop logs based on several options.
 
 It's important to note that if you provide multiple options they will be treated like an AND clause,

--- a/docs/sources/send-data/promtail/stages/eventlogmessage.md
+++ b/docs/sources/send-data/promtail/stages/eventlogmessage.md
@@ -9,6 +9,8 @@ weight:
 
 # eventlogmessage
 
+{{< docs/shared source="loki" lookup="promtail-deprecation.md" version="<LOKI_VERSION>" >}}
+
 The `eventlogmessage` stage is a parsing stage that extracts data from the Message string that appears in the Windows Event Log.
 
 ## Schema

--- a/docs/sources/send-data/promtail/stages/geoip.md
+++ b/docs/sources/send-data/promtail/stages/geoip.md
@@ -9,6 +9,8 @@ weight:
 
 # geoip
 
+{{< docs/shared source="loki" lookup="promtail-deprecation.md" version="<LOKI_VERSION>" >}}
+
 The `geoip` stage is a parsing stage that reads an ip address and populates the labelset with geoip fields. [Maxmind's GeoIP2 database](https://www.maxmind.com/en/home) is used for the lookup.
 
 Populated fields for City db:

--- a/docs/sources/send-data/promtail/stages/json.md
+++ b/docs/sources/send-data/promtail/stages/json.md
@@ -9,6 +9,8 @@ weight:
 
 # json
 
+{{< docs/shared source="loki" lookup="promtail-deprecation.md" version="<LOKI_VERSION>" >}}
+
 The `json` stage is a parsing stage that reads the log line as JSON and accepts
 [JMESPath](http://jmespath.org/) expressions to extract data.
 

--- a/docs/sources/send-data/promtail/stages/labelallow.md
+++ b/docs/sources/send-data/promtail/stages/labelallow.md
@@ -9,6 +9,8 @@ weight:
 
 # labelallow
 
+{{< docs/shared source="loki" lookup="promtail-deprecation.md" version="<LOKI_VERSION>" >}}
+
 The labelallow stage is an action stage that allows only the provided labels 
 to be included in the label set that is sent to Loki with the log entry.
 

--- a/docs/sources/send-data/promtail/stages/labeldrop.md
+++ b/docs/sources/send-data/promtail/stages/labeldrop.md
@@ -9,6 +9,8 @@ weight:
 
 # labeldrop
 
+{{< docs/shared source="loki" lookup="promtail-deprecation.md" version="<LOKI_VERSION>" >}}
+
 The labeldrop stage is an action stage that drops labels from
 the label set that is sent to Loki with the log entry.
 

--- a/docs/sources/send-data/promtail/stages/labels.md
+++ b/docs/sources/send-data/promtail/stages/labels.md
@@ -9,6 +9,8 @@ weight:
 
 # labels
 
+{{< docs/shared source="loki" lookup="promtail-deprecation.md" version="<LOKI_VERSION>" >}}
+
 The labels stage is an action stage that takes data from the extracted map and
 modifies the label set that is sent to Loki with the log entry.
 

--- a/docs/sources/send-data/promtail/stages/limit.md
+++ b/docs/sources/send-data/promtail/stages/limit.md
@@ -9,6 +9,8 @@ weight:
 
 # limit
 
+{{< docs/shared source="loki" lookup="promtail-deprecation.md" version="<LOKI_VERSION>" >}}
+
 The `limit` stage is a rate-limiting stage that throttles logs based on several options. 
 
 ## Limit stage schema

--- a/docs/sources/send-data/promtail/stages/logfmt.md
+++ b/docs/sources/send-data/promtail/stages/logfmt.md
@@ -9,6 +9,8 @@ weight:
 
 # logfmt
 
+{{< docs/shared source="loki" lookup="promtail-deprecation.md" version="<LOKI_VERSION>" >}}
+
 The `logfmt` stage is a parsing stage that reads the log line as [logfmt](https://brandur.org/logfmt) and allows extraction of data into labels.
 
 ## Schema

--- a/docs/sources/send-data/promtail/stages/match.md
+++ b/docs/sources/send-data/promtail/stages/match.md
@@ -9,6 +9,8 @@ weight:
 
 # match
 
+{{< docs/shared source="loki" lookup="promtail-deprecation.md" version="<LOKI_VERSION>" >}}
+
 The match stage is a filtering stage that conditionally applies a set of stages
 or drop entries when a log entry matches a configurable LogQL
 [stream selector]({{< relref "../../../query/log_queries#log-stream-selector" >}}) and

--- a/docs/sources/send-data/promtail/stages/metrics.md
+++ b/docs/sources/send-data/promtail/stages/metrics.md
@@ -9,6 +9,8 @@ weight:
 
 # metrics
 
+{{< docs/shared source="loki" lookup="promtail-deprecation.md" version="<LOKI_VERSION>" >}}
+
 The `metrics` stage is an action stage that allows for defining and updating
 metrics based on data from the extracted map. Note that created metrics are not
 pushed to Loki and are instead exposed via Promtail's `/metrics` endpoint.

--- a/docs/sources/send-data/promtail/stages/multiline.md
+++ b/docs/sources/send-data/promtail/stages/multiline.md
@@ -9,6 +9,8 @@ weight:
 
 # multiline
 
+{{< docs/shared source="loki" lookup="promtail-deprecation.md" version="<LOKI_VERSION>" >}}
+
 The `multiline` stage merges multiple lines into a multiline block before passing it on to the next stage in the pipeline.
 
 A new block is identified by the `firstline` regular expression. Any line that does *not* match the expression is considered to be part of the block of the previous match.

--- a/docs/sources/send-data/promtail/stages/output.md
+++ b/docs/sources/send-data/promtail/stages/output.md
@@ -9,6 +9,8 @@ weight:
 
 # output
 
+{{< docs/shared source="loki" lookup="promtail-deprecation.md" version="<LOKI_VERSION>" >}}
+
 The `output` stage is an action stage that takes data from the extracted map and
 changes the log line that will be sent to Loki.
 

--- a/docs/sources/send-data/promtail/stages/pack.md
+++ b/docs/sources/send-data/promtail/stages/pack.md
@@ -9,6 +9,8 @@ weight:
 
 # pack
 
+{{< docs/shared source="loki" lookup="promtail-deprecation.md" version="<LOKI_VERSION>" >}}
+
 The `pack` stage is a transform stage which lets you embed extracted values and labels into the log line by packing the log line and labels inside a JSON object.
 
 For example, if you wanted to remove the labels `container` and `pod` but still wanted to keep their values you could use this stage to create the following output:

--- a/docs/sources/send-data/promtail/stages/regex.md
+++ b/docs/sources/send-data/promtail/stages/regex.md
@@ -9,6 +9,8 @@ weight:
 
 # regex
 
+{{< docs/shared source="loki" lookup="promtail-deprecation.md" version="<LOKI_VERSION>" >}}
+
 The `regex` stage is a parsing stage that parses a log line using a regular
 expression. Named capture groups in the regex support adding data into the
 extracted map.

--- a/docs/sources/send-data/promtail/stages/replace.md
+++ b/docs/sources/send-data/promtail/stages/replace.md
@@ -9,6 +9,8 @@ weight:
 
 # replace
 
+{{< docs/shared source="loki" lookup="promtail-deprecation.md" version="<LOKI_VERSION>" >}}
+
 The `replace` stage is a parsing stage that parses a log line using a regular
 expression and replaces the log line. Named capture groups in the regex support adding data into the
 extracted map.

--- a/docs/sources/send-data/promtail/stages/sampling.md
+++ b/docs/sources/send-data/promtail/stages/sampling.md
@@ -9,6 +9,8 @@ weight:
 
 # sampling
 
+{{< docs/shared source="loki" lookup="promtail-deprecation.md" version="<LOKI_VERSION>" >}}
+
 The `sampling` stage is a stage that sampling logs. 
 
 ## Sampling stage schema

--- a/docs/sources/send-data/promtail/stages/static_labels.md
+++ b/docs/sources/send-data/promtail/stages/static_labels.md
@@ -9,6 +9,8 @@ weight:
 
 # static_labels
 
+{{< docs/shared source="loki" lookup="promtail-deprecation.md" version="<LOKI_VERSION>" >}}
+
 The static_labels stage is an action stage that adds static-labels to the label set that is sent to Loki with the log entry.
 
 ## Schema

--- a/docs/sources/send-data/promtail/stages/structured_metadata.md
+++ b/docs/sources/send-data/promtail/stages/structured_metadata.md
@@ -5,6 +5,8 @@ description: The 'structured_metadata' Promtail pipeline stage
 
 # structured_metadata
 
+{{< docs/shared source="loki" lookup="promtail-deprecation.md" version="<LOKI_VERSION>" >}}
+
 The `structured_metadata` stage is an action stage that takes data from the extracted map and
 modifies the [structured metadata]({{< relref "../../../get-started/labels/structured-metadata" >}}) that is sent to Loki with the log entry.
 

--- a/docs/sources/send-data/promtail/stages/template.md
+++ b/docs/sources/send-data/promtail/stages/template.md
@@ -9,6 +9,8 @@ weight:
 
 # template
 
+{{< docs/shared source="loki" lookup="promtail-deprecation.md" version="<LOKI_VERSION>" >}}
+
 The `template` stage is a transform stage that lets use manipulate the values in
 the extracted map using [Go's template
 syntax](https://golang.org/pkg/text/template/).

--- a/docs/sources/send-data/promtail/stages/tenant.md
+++ b/docs/sources/send-data/promtail/stages/tenant.md
@@ -9,6 +9,8 @@ weight:
 
 # tenant
 
+{{< docs/shared source="loki" lookup="promtail-deprecation.md" version="<LOKI_VERSION>" >}}
+
 The tenant stage is an action stage that sets the tenant ID for the log entry
 picking it from a field in the extracted data map. If the field is missing, the
 default promtail client [`tenant_id`]({{< relref "../configuration#clients" >}}) will

--- a/docs/sources/send-data/promtail/stages/timestamp.md
+++ b/docs/sources/send-data/promtail/stages/timestamp.md
@@ -9,6 +9,8 @@ weight:
 
 # timestamp
 
+{{< docs/shared source="loki" lookup="promtail-deprecation.md" version="<LOKI_VERSION>" >}}
+
 The `timestamp` stage is an action stage that can change the timestamp of a log
 line before it is sent to Loki. When a `timestamp` stage is not present, the
 timestamp of a log line defaults to the time when the log entry is scraped.

--- a/docs/sources/send-data/promtail/troubleshooting/_index.md
+++ b/docs/sources/send-data/promtail/troubleshooting/_index.md
@@ -8,8 +8,9 @@ weight:  800
 ---
 # Troubleshooting Promtail
 
-This document describes known failure modes of Promtail on edge cases and the
-adopted trade-offs.
+This document describes known failure modes of Promtail on edge cases and the adopted trade-offs.
+
+{{< docs/shared source="loki" lookup="promtail-deprecation.md" version="<LOKI_VERSION>" >}}
 
 ## Dry running
 

--- a/docs/sources/shared/promtail-deprecation.md
+++ b/docs/sources/shared/promtail-deprecation.md
@@ -1,0 +1,13 @@
+---
+headless: true
+labels:
+  products:
+    - enterprise
+    - oss
+---
+
+[//]: # 'This file provides an admonition caution for the deprecation of Promtail.'
+
+{{< admonition type="caution" >}}
+Promtail has been deprecated and is in Long-Term Support (LTS) through February 28, 2026. Promtail will reach an End-of-Life (EOL) on March 2, 2026. You can find migration resources [here](https://grafana.com/docs/alloy/latest/set-up/migrate/from-promtail/).
+{{< /admonition >}}

--- a/docs/sources/shared/promtail-deprecation.md
+++ b/docs/sources/shared/promtail-deprecation.md
@@ -1,4 +1,5 @@
 ---
+description: Deprecation notice for Promtail.
 headless: true
 labels:
   products:


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a shared file with the text of the Deprecation notice.
Adds deprecation cautions to all the Promtail pages in the Send Data directory (in one or two places there is a custom caution).
Rearranges the clients list to move the Deprecated clients to the bottom of the list.
Removes "feature complete" note.
