### PR TITLE
fix: remove unused variable in delete requests store code

### DIFF
--- a/pkg/compactor/deletion/delete_requests_store.go
+++ b/pkg/compactor/deletion/delete_requests_store.go
@@ -97,14 +97,12 @@ func (ds *deleteRequestsStore) AddDeleteRequest(ctx context.Context, userID, que
 		return "", err
 	}
 
-	var results []DeleteRequest
 	for i, req := range reqs {
 		newReq, err := newRequest(req, requestID, createdAt, i)
 		if err != nil {
 			return "", err
 		}
 
-		results = append(results, newReq)
 		ds.writeDeleteRequest(newReq, writeBatch)
 	}
 	ds.updateCacheGen(reqs[0].UserID, writeBatch)


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove an unused variable in the delete requests store code.