### PR TITLE
docs: Update versions in docs

### DIFF
--- a/docs/sources/operations/caching.md
+++ b/docs/sources/operations/caching.md
@@ -17,7 +17,7 @@ cache is configured to be in-memory by default.
 ## Before you begin
 
 - It is recommended to deploy three, or in the case of the Helm chart two, dedicated Memcached clusters.
-- As of 2023-02-01, the `memcached:1.6.17-alpine` version of the library is recommended.
+- As of 2025-02-06, the `memcached:1.6.35-alpine` version of the library is recommended.
 - Consult the Loki ksonnet [memcached](https://github.com/grafana/loki/blob/main/production/ksonnet/loki/memcached.libsonnet) deployment and the ksonnet [memcached library](https://github.com/grafana/jsonnet-libs/tree/master/memcached).
 
 ## Steps

--- a/docs/sources/operations/query-fairness/_index.md
+++ b/docs/sources/operations/query-fairness/_index.md
@@ -18,7 +18,7 @@ different users, because they all share the same resources for a tenant.
 In that case, as an operator, you would also want to ensure some sort of query
 fairness across these actors within the tenants. An actor could be a Grafana user,
 a CLI user, or an application accessing the API. To achieve that, Loki
-introduces hierarchical scheduler queues in version 2.9 based on
+introduced hierarchical scheduler queues in version 2.9 based on
 [LID 0003: Query fairness across users within tenants]({{< relref "../../community/lids/0003-QueryFairnessInScheduler.md" >}})
 and they are enabled by default.
 

--- a/docs/sources/setup/install/docker.md
+++ b/docs/sources/setup/install/docker.md
@@ -30,15 +30,15 @@ The configuration files associated with these installation instructions run Loki
 1. Copy and paste the following commands into your command line to download `loki-local-config.yaml` and `promtail-docker-config.yaml` to your `loki` directory.
 
     ```bash
-    wget https://raw.githubusercontent.com/grafana/loki/v3.3.2/cmd/loki/loki-local-config.yaml -O loki-config.yaml
-    wget https://raw.githubusercontent.com/grafana/loki/v3.3.2/clients/cmd/promtail/promtail-docker-config.yaml -O promtail-config.yaml
+    wget https://raw.githubusercontent.com/grafana/loki/v3.4.1/cmd/loki/loki-local-config.yaml -O loki-config.yaml
+    wget https://raw.githubusercontent.com/grafana/loki/v3.4.1/clients/cmd/promtail/promtail-docker-config.yaml -O promtail-config.yaml
     ```
 
 1. Copy and paste the following commands into your command line to start the Docker containers using the configuration files you downloaded in the previous step.
 
     ```bash
-    docker run --name loki -d -v $(pwd):/mnt/config -p 3100:3100 grafana/loki:3.3.2 -config.file=/mnt/config/loki-config.yaml
-    docker run --name promtail -d -v $(pwd):/mnt/config -v /var/log:/var/log --link loki grafana/promtail:3.3.2 -config.file=/mnt/config/promtail-config.yaml
+    docker run --name loki -d -v $(pwd):/mnt/config -p 3100:3100 grafana/loki:3.4.1 -config.file=/mnt/config/loki-config.yaml
+    docker run --name promtail -d -v $(pwd):/mnt/config -v /var/log:/var/log --link loki grafana/promtail:3.4.1 -config.file=/mnt/config/promtail-config.yaml
     ```
 
     {{< admonition type="note" >}}
@@ -56,8 +56,8 @@ The configuration files associated with these installation instructions run Loki
     ```bash
 
     CONTAINER ID   IMAGE                    COMMAND                  CREATED              STATUS              PORTS                                       NAMES
-    9485de9ad351   grafana/promtail:3.3.2   "/usr/bin/promtail -…"   About a minute ago   Up About a minute                                               promtail
-    cece1df84519   grafana/loki:3.3.2       "/usr/bin/loki -conf…"   About a minute ago   Up About a minute   0.0.0.0:3100->3100/tcp, :::3100->3100/tcp   loki
+    9485de9ad351   grafana/promtail:3.4.1   "/usr/bin/promtail -…"   About a minute ago   Up About a minute                                               promtail
+    cece1df84519   grafana/loki:3.4.1       "/usr/bin/loki -conf…"   About a minute ago   Up About a minute   0.0.0.0:3100->3100/tcp, :::3100->3100/tcp   loki
     ```
 
 1. Verify that Loki is up and running.
@@ -71,15 +71,15 @@ The configuration files associated with these installation instructions run Loki
 
 ```bash
 cd "<local-path>"
-wget https://raw.githubusercontent.com/grafana/loki/v3.3.2/cmd/loki/loki-local-config.yaml -O loki-config.yaml
-wget https://raw.githubusercontent.com/grafana/loki/v3.3.2/clients/cmd/promtail/promtail-docker-config.yaml -O promtail-config.yaml
+wget https://raw.githubusercontent.com/grafana/loki/v3.4.1/cmd/loki/loki-local-config.yaml -O loki-config.yaml
+wget https://raw.githubusercontent.com/grafana/loki/v3.4.1/clients/cmd/promtail/promtail-docker-config.yaml -O promtail-config.yaml
 ```
 
 1. Copy and paste the following commands into your command line to start the Docker containers using the configuration files you downloaded in the previous step. Note that you will need to replace the `<local-path>` in the commands with your local path.
 
 ```bash
-docker run --name loki -v <local-path>:/mnt/config -p 3100:3100 grafana/loki:3.3.2 --config.file=/mnt/config/loki-config.yaml
-docker run -v <local-path>:/mnt/config -v /var/log:/var/log --link loki grafana/promtail:3.3.2 --config.file=/mnt/config/promtail-config.yaml
+docker run --name loki -v <local-path>:/mnt/config -p 3100:3100 grafana/loki:3.4.1 --config.file=/mnt/config/loki-config.yaml
+docker run -v <local-path>:/mnt/config -v /var/log:/var/log --link loki grafana/promtail:3.4.1 --config.file=/mnt/config/promtail-config.yaml
 ```
 
 1. Verify that Loki is up and running.
@@ -101,7 +101,7 @@ Run the following commands in your command line. They work for Windows or Linux 
 1. Copy and paste the following command into your command line to download the `docker-compose` file.
 
     ```bash
-    wget https://raw.githubusercontent.com/grafana/loki/v3.3.2/production/docker-compose.yaml -O docker-compose.yaml
+    wget https://raw.githubusercontent.com/grafana/loki/v3.4.1/production/docker-compose.yaml -O docker-compose.yaml
     ```
 
 1. With `loki` as the current working directory, run the following 'docker-compose` command:

--- a/docs/sources/setup/install/install-from-source.md
+++ b/docs/sources/setup/install/install-from-source.md
@@ -13,7 +13,7 @@ to build Loki from source.
 
 ## Prerequisites
 
-- [Go](https://golang.org/), version 1.22 or later;
+- [Go](https://golang.org/), version 1.23 or later;
 set your `$GOPATH` environment variable
 - `make`
 - Docker (for updating protobuf and yacc files)

--- a/docs/sources/setup/install/local.md
+++ b/docs/sources/setup/install/local.md
@@ -47,7 +47,7 @@ The configuration runs Loki as a single binary.
    Copy and paste the following commands into your command line to download generic configuration files.
 
    Use the Git references that match your downloaded Loki version to get the correct configuration file.
-   For example, if you are using Loki version 3.3.2, you need to use the `https://raw.githubusercontent.com/grafana/loki/v3.3.2/cmd/loki/loki-local-config.yaml` URL to download the configuration file.
+   For example, if you are using Loki version 3.4.1, you need to use the `https://raw.githubusercontent.com/grafana/loki/v3.4.1/cmd/loki/loki-local-config.yaml` URL to download the configuration file.
 
    ```
    wget https://raw.githubusercontent.com/grafana/loki/main/cmd/loki/loki-local-config.yaml

--- a/docs/sources/setup/install/tanka.md
+++ b/docs/sources/setup/install/tanka.md
@@ -16,7 +16,7 @@ The Tanka installation runs the Loki cluster in microservices mode.
 
 ## Prerequisites
 
-Install the latest version of Tanka (version v0.29.0 or a more recent version) for the `tk env`
+Install the latest version of Tanka (version v0.31.0 or a more recent version) for the `tk env`
 commands. Prebuilt binaries for Tanka can be found at the [Tanka releases
 URL](https://github.com/grafana/tanka/releases).
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates the Loki version number in installation docs, and version numbers of other various components (modeled after #15808 which last updated these files).