### PR TITLE
fix(ci): do not disable CGO in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,6 @@ GOHOSTOS           ?= $(shell go env GOHOSTOS)
 GOARCH             ?= $(shell go env GOARCH)
 GOARM              ?= $(shell go env GOARM)
 GOEXPERIMENT       ?= $(shell go env GOEXPERIMENT)
-CGO_ENABLED        := 0
-GO_ENV             := GOEXPERIMENT=$(GOEXPERIMENT) GOOS=$(GOOS) GOARCH=$(GOARCH) GOARM=$(GOARM) CGO_ENABLED=$(CGO_ENABLED)
 
 GOTEST             ?= go test
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Cleans up unused vars. Also fixes an issue that is preventing promtail builds from running with CGO_ENABLED

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/loki/issues/16220

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
