### PR TITLE
feat(dataobj): Ensure constant sharding for the dataobj querier

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -821,6 +821,10 @@ dataobj:
     # CLI flag: -dataobj-querier-from
     [from: <daytime> | default = 1970-01-01]
 
+    # The number of shards to use for the dataobj querier.
+    # CLI flag: -dataobj-querier-shard-factor
+    [shard_factor: <int> | default = 32]
+
   # The prefix to use for the storage bucket.
   # CLI flag: -dataobj-storage-bucket-prefix
   [storage_bucket_prefix: <string> | default = "dataobj/"]

--- a/pkg/querier/queryrange/limits.go
+++ b/pkg/querier/queryrange/limits.go
@@ -649,7 +649,7 @@ func WeightedParallelism(
 	return 0
 }
 
-func minMaxModelTime(a, b model.Time) (min, max model.Time) {
+func minMaxModelTime(a, b model.Time) (model.Time, model.Time) {
 	if a.Before(b) {
 		return a, b
 	}

--- a/pkg/querier/queryrange/roundtrip.go
+++ b/pkg/querier/queryrange/roundtrip.go
@@ -239,7 +239,6 @@ func NewMiddleware(
 
 	detectedFieldsTripperware, err := NewDetectedFieldsTripperware(
 		limits,
-		schema,
 		limitedTripperware,
 		logFilterTripperware,
 	)
@@ -1222,7 +1221,6 @@ func sharedIndexTripperware(
 // NewDetectedFieldsTripperware creates a new frontend tripperware responsible for handling detected field requests, which are basically log filter requests with a bit more processing.
 func NewDetectedFieldsTripperware(
 	limits Limits,
-	_ config.SchemaConfig,
 	limitedTripperware base.Middleware,
 	logTripperware base.Middleware,
 ) (base.Middleware, error) {

--- a/pkg/storage/config/schema_config.go
+++ b/pkg/storage/config/schema_config.go
@@ -278,6 +278,13 @@ type SchemaConfig struct {
 	fileName string
 }
 
+func (cfg *SchemaConfig) Clone() SchemaConfig {
+	clone := *cfg
+	clone.Configs = make([]PeriodConfig, len(cfg.Configs))
+	copy(clone.Configs, cfg.Configs)
+	return clone
+}
+
 // RegisterFlags adds the flags required to config this to the given FlagSet.
 func (cfg *SchemaConfig) RegisterFlags(f *flag.FlagSet) {
 	f.StringVar(&cfg.fileName, "schema-config-file", "", "The path to the schema config file. The schema config is used only when running Cortex with the chunks storage.")


### PR DESCRIPTION
This is a bit of hack that inject a PeriodConfig in the query frontend middleware to ensure we use constant sharding for the dataobj querier when it's in use.