### PR TITLE
feat(dataobj/querier): Add logging and improve stream processing metrics

### DIFF
--- a/pkg/dataobj/querier/metadata_test.go
+++ b/pkg/dataobj/querier/metadata_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-kit/log"
 	"github.com/grafana/dskit/user"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
@@ -23,7 +24,7 @@ func TestStore_SelectSeries(t *testing.T) {
 	// Setup test data
 	now := setupTestData(t, builder)
 
-	store := NewStore(builder.bucket)
+	store := NewStore(builder.bucket, log.NewNopLogger())
 	ctx := user.InjectOrgID(context.Background(), testTenant)
 
 	tests := []struct {
@@ -166,7 +167,7 @@ func TestStore_LabelNamesForMetricName(t *testing.T) {
 	// Setup test data
 	now := setupTestData(t, builder)
 
-	store := NewStore(builder.bucket)
+	store := NewStore(builder.bucket, log.NewNopLogger())
 	ctx := user.InjectOrgID(context.Background(), testTenant)
 
 	tests := []struct {
@@ -234,7 +235,7 @@ func TestStore_LabelValuesForMetricName(t *testing.T) {
 	// Setup test data
 	now := setupTestData(t, builder)
 
-	store := NewStore(builder.bucket)
+	store := NewStore(builder.bucket, log.NewNopLogger())
 	ctx := user.InjectOrgID(context.Background(), testTenant)
 
 	tests := []struct {

--- a/pkg/dataobj/querier/store_test.go
+++ b/pkg/dataobj/querier/store_test.go
@@ -38,7 +38,7 @@ func TestStore_SelectSamples(t *testing.T) {
 
 	// Setup test data
 	now := setupTestData(t, builder)
-	store := NewStore(builder.bucket)
+	store := NewStore(builder.bucket, log.NewNopLogger())
 	ctx := user.InjectOrgID(context.Background(), testTenant)
 
 	tests := []struct {
@@ -191,7 +191,7 @@ func TestStore_SelectLogs(t *testing.T) {
 
 	// Setup test data
 	now := setupTestData(t, builder)
-	store := NewStore(builder.bucket)
+	store := NewStore(builder.bucket, log.NewNopLogger())
 	ctx := user.InjectOrgID(context.Background(), testTenant)
 
 	tests := []struct {

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -422,7 +422,7 @@ func (t *Loki) getQuerierStore() (querier.Store, error) {
 
 	storeCombiner := querier.NewStoreCombiner([]querier.StoreConfig{
 		{
-			Store: dataobjquerier.NewStore(store),
+			Store: dataobjquerier.NewStore(store, log.With(util_log.Logger, "component", "dataobj-querier")),
 			From:  t.Cfg.DataObj.Querier.From.Time,
 		},
 		{


### PR DESCRIPTION
This change introduces logging and metrics tracking for stream processing in the dataobj querier. Key modifications include:
- Adding a logger parameter to Store and related methods
- Implementing debug logging for stream processing duration and counts
- Adding an atomic counter to track processed streams
- Enhancing logging in object selection and sharding processes

