### PR TITLE
fix(loki-distributed): add missing maxUnavailable

### DIFF
--- a/production/helm/loki/distributed-values.yaml
+++ b/production/helm/loki/distributed-values.yaml
@@ -30,6 +30,7 @@ deploymentMode: Distributed
 
 ingester:
   replicas: 3
+  maxUnavailable: 2
 querier:
   replicas: 3
   maxUnavailable: 2


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix error I got when I deploy

> FATA[0002] rpc error: code = InvalidArgument desc = application spec for production-hm-loki is invalid: InvalidSpecError: Unable to generate manifests in : rpc error: code = Unknown desc = `helm template . --name-template hm-loki --namespace production-hm-loki --kube-version 1.32 --values /tmp/3c7a94cd-ba54-4420-bae1-977c32ed8ff3 <api versions removed> --include-crds` failed exit status 1: Error: execution error at (loki-distributed/templates/ingester/poddisruptionbudget-ingester.yaml:3:4): `.Values.ingester.maxUnavailable` must be set when `.Values.ingester.replicas` is greater than 1.%0A%0AUse --debug flag to render out invalid YAML

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
