### PR TITLE
chore: fix a panic in stream generator

### DIFF
--- a/tools/stream-metadata-generator/main.go
+++ b/tools/stream-metadata-generator/main.go
@@ -349,6 +349,7 @@ func (s *generator) running(ctx context.Context) error {
 						resp, err := client.ExceedsLimits(userCtx, req)
 						if err != nil {
 							level.Error(s.logger).Log("msg", "Stream exceeds limits", "tenant", tenantID, "stream", streamIdx, "error", err)
+							continue
 						}
 
 						if len(resp.RejectedStreams) > 0 {


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request fixes a panic in the stream generator when `err` is non-nil.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
