### PR TITLE
chore: flush idle dataobjects after X seconds

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -847,10 +847,10 @@ dataobj:
       # CLI flag: -dataobj-consumer.sha-prefix-size
       [shaprefixsize: <int> | default = 2]
 
-    # The maximum amount of time to wait in seconds before flushing the buffer
-    # to a data object.
+    # The maximum amount of time to wait in seconds before flushing an object
+    # that is no longer receiving new writes
     # CLI flag: -dataobj-consumer.idle-flush-timeout
-    [idle_flush_timeout: <duration> | default = 0s]
+    [idle_flush_timeout: <duration> | default = 1h]
 
   querier:
     # Enable the dataobj querier.

--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -847,6 +847,11 @@ dataobj:
       # CLI flag: -dataobj-consumer.sha-prefix-size
       [shaprefixsize: <int> | default = 2]
 
+    # The maximum amount of time to wait in seconds before flushing the buffer
+    # to a data object.
+    # CLI flag: -dataobj-consumer.idle-flush-timeout
+    [idle_flush_timeout: <duration> | default = 0s]
+
   querier:
     # Enable the dataobj querier.
     # CLI flag: -dataobj-querier-enabled

--- a/pkg/dataobj/builder.go
+++ b/pkg/dataobj/builder.go
@@ -52,6 +52,10 @@ type BuilderConfig struct {
 	// BufferSize configures the size of the buffer used to accumulate
 	// uncompressed logs in memory prior to sorting.
 	BufferSize flagext.Bytes `yaml:"buffer_size"`
+
+	// TargetIdleSeconds configures the maximum amount of time to wait in seconds
+	// before flushing the buffer to a data object.
+	TargetIdleSeconds time.Duration `yaml:"target_idle_seconds"`
 }
 
 // RegisterFlagsWithPrefix registers flags with the given prefix.
@@ -65,6 +69,7 @@ func (cfg *BuilderConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet
 	f.Var(&cfg.TargetObjectSize, prefix+"target-object-size", "The size of the target object to use for the data object builder.")
 	f.Var(&cfg.TargetSectionSize, prefix+"target-section-size", "Configures a maximum size for sections, for sections that support it.")
 	f.Var(&cfg.BufferSize, prefix+"buffer-size", "The size of the buffer to use for sorting logs.")
+	f.DurationVar(&cfg.TargetIdleSeconds, prefix+"target-idle-seconds", 60*time.Second, "The maximum amount of time to wait in seconds before flushing the buffer to a data object.")
 }
 
 // Validate validates the BuilderConfig.
@@ -87,6 +92,10 @@ func (cfg *BuilderConfig) Validate() error {
 
 	if cfg.TargetSectionSize <= 0 || cfg.TargetSectionSize > cfg.TargetObjectSize {
 		errs = append(errs, errors.New("SectionSize must be greater than 0 and less than or equal to TargetObjectSize"))
+	}
+
+	if cfg.TargetIdleSeconds <= 0 {
+		errs = append(errs, errors.New("TargetIdlePeriod must be greater than 0"))
 	}
 
 	return errors.Join(errs...)

--- a/pkg/dataobj/builder.go
+++ b/pkg/dataobj/builder.go
@@ -52,10 +52,6 @@ type BuilderConfig struct {
 	// BufferSize configures the size of the buffer used to accumulate
 	// uncompressed logs in memory prior to sorting.
 	BufferSize flagext.Bytes `yaml:"buffer_size"`
-
-	// TargetIdleSeconds configures the maximum amount of time to wait in seconds
-	// before flushing the buffer to a data object.
-	TargetIdleSeconds time.Duration `yaml:"target_idle_seconds"`
 }
 
 // RegisterFlagsWithPrefix registers flags with the given prefix.
@@ -69,7 +65,6 @@ func (cfg *BuilderConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet
 	f.Var(&cfg.TargetObjectSize, prefix+"target-object-size", "The size of the target object to use for the data object builder.")
 	f.Var(&cfg.TargetSectionSize, prefix+"target-section-size", "Configures a maximum size for sections, for sections that support it.")
 	f.Var(&cfg.BufferSize, prefix+"buffer-size", "The size of the buffer to use for sorting logs.")
-	f.DurationVar(&cfg.TargetIdleSeconds, prefix+"target-idle-seconds", 60*time.Second, "The maximum amount of time to wait in seconds before flushing the buffer to a data object.")
 }
 
 // Validate validates the BuilderConfig.
@@ -92,10 +87,6 @@ func (cfg *BuilderConfig) Validate() error {
 
 	if cfg.TargetSectionSize <= 0 || cfg.TargetSectionSize > cfg.TargetObjectSize {
 		errs = append(errs, errors.New("SectionSize must be greater than 0 and less than or equal to TargetObjectSize"))
-	}
-
-	if cfg.TargetIdleSeconds <= 0 {
-		errs = append(errs, errors.New("TargetIdlePeriod must be greater than 0"))
 	}
 
 	return errors.Join(errs...)

--- a/pkg/dataobj/consumer/config.go
+++ b/pkg/dataobj/consumer/config.go
@@ -34,5 +34,5 @@ func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 		cfg.IdleFlushTimeout = 60 * 60 * time.Second // default to 1 hour
 	}
 
-	f.DurationVar(&cfg.IdleFlushTimeout, prefix+"idle-flush-timeout", cfg.IdleFlushTimeout, "The maximum amount of time to wait in seconds before flushing the buffer to a data object.")
+	f.DurationVar(&cfg.IdleFlushTimeout, prefix+"idle-flush-timeout", cfg.IdleFlushTimeout, "The maximum amount of time to wait in seconds before flushing an object that is no longer receiving new writes")
 }

--- a/pkg/dataobj/consumer/config.go
+++ b/pkg/dataobj/consumer/config.go
@@ -30,5 +30,9 @@ func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	cfg.BuilderConfig.RegisterFlagsWithPrefix(prefix, f)
 	cfg.UploaderConfig.RegisterFlagsWithPrefix(prefix, f)
 
+	if cfg.IdleFlushTimeout <= 0 {
+		cfg.IdleFlushTimeout = 60 * 60 * time.Second // default to 1 hour
+	}
+
 	f.DurationVar(&cfg.IdleFlushTimeout, prefix+"idle-flush-timeout", cfg.IdleFlushTimeout, "The maximum amount of time to wait in seconds before flushing the buffer to a data object.")
 }

--- a/pkg/dataobj/consumer/config.go
+++ b/pkg/dataobj/consumer/config.go
@@ -2,6 +2,7 @@ package consumer
 
 import (
 	"flag"
+	"time"
 
 	"github.com/grafana/loki/v3/pkg/dataobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/uploader"
@@ -9,7 +10,8 @@ import (
 
 type Config struct {
 	dataobj.BuilderConfig
-	UploaderConfig uploader.Config `yaml:"uploader"`
+	UploaderConfig   uploader.Config `yaml:"uploader"`
+	IdleFlushTimeout time.Duration   `yaml:"idle_flush_timeout"`
 }
 
 func (cfg *Config) Validate() error {
@@ -27,4 +29,6 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	cfg.BuilderConfig.RegisterFlagsWithPrefix(prefix, f)
 	cfg.UploaderConfig.RegisterFlagsWithPrefix(prefix, f)
+
+	f.DurationVar(&cfg.IdleFlushTimeout, prefix+"idle-flush-timeout", cfg.IdleFlushTimeout, "The maximum amount of time to wait in seconds before flushing the buffer to a data object.")
 }

--- a/pkg/dataobj/consumer/partition_processor.go
+++ b/pkg/dataobj/consumer/partition_processor.go
@@ -290,7 +290,7 @@ func (p *partitionProcessor) commitRecords(record *kgo.Record) error {
 	return lastErr
 }
 
-// idleFlush flushes the builder if it has been idle for too long.
+// idleFlush flushes the file if it has been idle for too long.
 // This is used to avoid holding on to memory for too long.
 // We compare the current time with the last flush time to determine if the builder has been idle.
 func (p *partitionProcessor) idleFlush() {

--- a/pkg/dataobj/consumer/service.go
+++ b/pkg/dataobj/consumer/service.go
@@ -100,7 +100,7 @@ func (s *Service) handlePartitionsAssigned(ctx context.Context, client *kgo.Clie
 		}
 
 		for _, partition := range parts {
-			processor := newPartitionProcessor(ctx, client, s.cfg.BuilderConfig, s.cfg.UploaderConfig, s.bucket, tenant, virtualShard, topic, partition, s.logger, s.reg, s.bufPool)
+			processor := newPartitionProcessor(ctx, client, s.cfg.BuilderConfig, s.cfg.UploaderConfig, s.bucket, tenant, virtualShard, topic, partition, s.logger, s.reg, s.bufPool, s.cfg.IdleFlushTimeout)
 			s.partitionHandlers[topic][partition] = processor
 			processor.start()
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

We need an idle check for our objects to be flushed, since there are cases that objects are in memory until reach the configurable size.

If we stop receiving data the size won't increase and it is not flushed.

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/loki-private/issues/1359

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
