### PR TITLE
feat: Assert for bad `max_query_lookback` config

### DIFF
--- a/production/ksonnet/loki/common.libsonnet
+++ b/production/ksonnet/loki/common.libsonnet
@@ -44,6 +44,19 @@ local k = import 'ksonnet-util/kausal.libsonnet';
       container.mixin.readinessProbe.httpGet.withPort($._config.http_listen_port) +
       container.mixin.readinessProbe.withInitialDelaySeconds(15) +
       container.mixin.readinessProbe.withTimeoutSeconds(1),
+
+
+    parseDuration(duration)::
+      if std.endsWith(duration, 's') then
+        std.parseInt(std.substr(duration, 0, std.length(duration) - 1))
+      else if std.endsWith(duration, 'm') then
+        std.parseInt(std.substr(duration, 0, std.length(duration) - 1)) * 60
+      else if std.endsWith(duration, 'h') then
+        std.parseInt(std.substr(duration, 0, std.length(duration) - 1)) * 3600
+      else if std.endsWith(duration, 'd') then
+        std.parseInt(std.substr(duration, 0, std.length(duration) - 1)) * 86400
+      else
+        error 'unable to parse duration %s' % duration,
   },
 
   // functions for k8s objects


### PR DESCRIPTION
**What this PR does / why we need it**:
Add a new assert to our jsonnet manifest that checks that there's no tenant with a retention period that can't be queried (due to low max_query_lookback) 

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
