### PR TITLE
chore(operator): fix .golangci.yaml config file

### DIFF
--- a/operator/.golangci.yaml
+++ b/operator/.golangci.yaml
@@ -1,6 +1,6 @@
 ---
 # golangci.com configuration
-# https://github.com/golangci/golangci/wiki/Configuration
+# https://golangci-lint.run/usage/configuration/
 linters-settings:
   copyloopvar:
     check-alias: true
@@ -12,9 +12,8 @@ linters-settings:
     - blank
     - dot
   govet:
-    shadow: true
-  maligned:
-    suggest-new: true
+    enable:
+    - shadow
   misspell:
     locale: US
   revive:
@@ -43,8 +42,3 @@ linters:
 
 issues:
   exclude-use-default: false
-  exclude-rules:
-    # - text: "could be of size"
-    #   path: api/v1beta1/lokistack_types.go
-    #   linters:
-    #     - maligned

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -177,6 +177,7 @@ scorecard: generate go-generate bundle-all ## Run scorecard tests for all bundle
 
 .PHONY: lint
 lint: $(GOLANGCI_LINT) | generate ## Run golangci-lint on source code.
+	$(GOLANGCI_LINT) config verify
 	$(GOLANGCI_LINT) run --timeout=5m ./...
 
 .PHONY: lint-fix


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix linter config see https://github.com/grafana/loki/actions/runs/13397383118/job/37419714676?pr=16360
Changes:
- removed `maligned` as is deprecated https://golangci-lint.run/usage/configuration/#linters-configuration
- govet correctly enable shadow https://golangci-lint.run/usage/linters/#govet
- removed `exclude-rules`

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
