### PR TITLE
chore(helm): add missing check for adminAPI on enterprise

### DIFF
--- a/production/helm/loki/templates/admin-api/deployment-admin-api.yaml
+++ b/production/helm/loki/templates/admin-api/deployment-admin-api.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.enterprise.enabled }}
+{{- if and .Values.enterprise.enabled .Values.enterprise.adminApi.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/production/helm/loki/templates/admin-api/service-admin-api.yaml
+++ b/production/helm/loki/templates/admin-api/service-admin-api.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.enterprise.enabled }}
+{{- if and .Values.enterprise.enabled .Values.enterprise.adminApi.enabled }}
 apiVersion: v1
 kind: Service
 metadata:


### PR DESCRIPTION
**What this PR does / why we need it**:

While investigating the support escalation, the customer wanted to disable the adminAPI and configured enabled false but didn't work.

Looking into the helm chart, we were not checking if the enabled flag was configured and always deploying if the enterprise is enabled.

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
