### PR TITLE
chore: Move pool factory for ingest-limits-frontend client into package

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -245,9 +245,7 @@ func New(
 		return nil, err
 	}
 
-	limitsFrontendClientFactory := ring_client.PoolAddrFunc(func(addr string) (ring_client.PoolClient, error) {
-		return limits_frontend_client.New(limitsFrontendCfg, addr)
-	})
+	limitsFrontendClientFactory := limits_frontend_client.NewPoolFactory(limitsFrontendCfg)
 
 	// Create the configured ingestion rate limit strategy (local or global).
 	var ingestionRateStrategy limiter.RateLimiterStrategy

--- a/pkg/limits/frontend/client/client.go
+++ b/pkg/limits/frontend/client/client.go
@@ -1,7 +1,6 @@
 // Package client provides gRPC client implementation for limits-frontend.
 // An example use case is the distributor, which needs to ask limits-frontend
 // if a push request has exceeded per-tenant limits.
-
 package client
 
 import (

--- a/pkg/limits/frontend/client/client.go
+++ b/pkg/limits/frontend/client/client.go
@@ -1,3 +1,7 @@
+// Package client provides gRPC client implementation for limits-frontend.
+// An example use case is the distributor, which needs to ask limits-frontend
+// if a push request has exceeded per-tenant limits.
+
 package client
 
 import (
@@ -142,5 +146,19 @@ func NewPool(
 		HealthCheckEnabled: cfg.HealthCheckIngestLimits,
 		HealthCheckTimeout: cfg.RemoteTimeout,
 	}
-	return ring_client.NewPool(name, poolCfg, ring_client.NewRingServiceDiscovery(ring), factory, frontendClients, logger)
+	return ring_client.NewPool(
+		name,
+		poolCfg,
+		ring_client.NewRingServiceDiscovery(ring),
+		factory,
+		frontendClients,
+		logger,
+	)
+}
+
+// NewPoolFactory returns a new factory for ingest-limits-frontend clients.
+func NewPoolFactory(cfg Config) ring_client.PoolFactory {
+	return ring_client.PoolAddrFunc(func(addr string) (ring_client.PoolClient, error) {
+		return New(cfg, addr)
+	})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
