### PR TITLE
chore: fix flush process for dataobj

### DIFF
--- a/pkg/dataobj/consumer/partition_processor.go
+++ b/pkg/dataobj/consumer/partition_processor.go
@@ -42,6 +42,7 @@ type partitionProcessor struct {
 	// Idle stream handling
 	idleFlushTimeout time.Duration
 	lastFlush        time.Time
+	lastModified     time.Time
 
 	// Metrics
 	metrics *partitionOffsetMetrics
@@ -115,6 +116,7 @@ func newPartitionProcessor(
 		bufPool:          bufPool,
 		idleFlushTimeout: idleFlushTimeout,
 		lastFlush:        time.Now(),
+		lastModified:     time.Now(),
 	}
 }
 
@@ -261,6 +263,8 @@ func (p *partitionProcessor) processRecord(record *kgo.Record) {
 			level.Error(p.logger).Log("msg", "failed to append stream after flushing", "err", err)
 			p.metrics.incAppendFailures()
 		}
+
+		p.lastModified = time.Now()
 	}
 }
 
@@ -294,7 +298,7 @@ func (p *partitionProcessor) idleFlush() {
 		return
 	}
 
-	if time.Since(p.lastFlush) < p.idleFlushTimeout {
+	if time.Since(p.lastFlush) < p.idleFlushTimeout || time.Since(p.lastModified) < p.idleFlushTimeout {
 		return // Avoid checking too frequently
 	}
 

--- a/pkg/dataobj/consumer/partition_processor.go
+++ b/pkg/dataobj/consumer/partition_processor.go
@@ -263,9 +263,9 @@ func (p *partitionProcessor) processRecord(record *kgo.Record) {
 			level.Error(p.logger).Log("msg", "failed to append stream after flushing", "err", err)
 			p.metrics.incAppendFailures()
 		}
-
-		p.lastModified = time.Now()
 	}
+
+	p.lastModified = time.Now()
 }
 
 func (p *partitionProcessor) commitRecords(record *kgo.Record) error {
@@ -298,7 +298,7 @@ func (p *partitionProcessor) idleFlush() {
 		return
 	}
 
-	if time.Since(p.lastFlush) < p.idleFlushTimeout || time.Since(p.lastModified) < p.idleFlushTimeout {
+	if time.Since(p.lastModified) < p.idleFlushTimeout {
 		return // Avoid checking too frequently
 	}
 

--- a/pkg/dataobj/consumer/partition_processor_test.go
+++ b/pkg/dataobj/consumer/partition_processor_test.go
@@ -112,13 +112,13 @@ func TestIdleFlush(t *testing.T) {
 		{
 			name:          "should not flush before idle timeout",
 			idleTimeout:   1 * time.Second,
-			sleepDuration: 500 * time.Millisecond,
+			sleepDuration: 100 * time.Millisecond,
 			expectFlush:   false,
 			initBuilder:   true,
 		},
 		{
 			name:          "should flush after idle timeout",
-			idleTimeout:   500 * time.Millisecond,
+			idleTimeout:   100 * time.Millisecond,
 			sleepDuration: 1 * time.Second,
 			expectFlush:   true,
 			initBuilder:   true,
@@ -126,14 +126,14 @@ func TestIdleFlush(t *testing.T) {
 		{
 			name:          "should not flush if builder is nil",
 			idleTimeout:   100 * time.Millisecond,
-			sleepDuration: 200 * time.Millisecond,
+			sleepDuration: 100 * time.Millisecond,
 			expectFlush:   false,
 			initBuilder:   false,
 		},
 		{
 			name:          "should not flush if last modified is less than idle timeout",
 			idleTimeout:   1 * time.Second,
-			sleepDuration: 500 * time.Millisecond,
+			sleepDuration: 100 * time.Millisecond,
 			expectFlush:   false,
 			initBuilder:   true,
 		},
@@ -171,6 +171,9 @@ func TestIdleFlush(t *testing.T) {
 				defer p.stop()
 			}
 
+			// Record initial flush time
+			initialFlushTime := p.lastFlush
+
 			stream := logproto.Stream{
 				Labels: `{cluster="test",app="foo"}`,
 				Entries: []push.Entry{{
@@ -187,9 +190,6 @@ func TestIdleFlush(t *testing.T) {
 				Value: streamBytes,
 				Key:   []byte("test-tenant"),
 			}
-
-			// Record initial flush time
-			initialFlushTime := p.lastFlush
 
 			// Wait for specified duration
 			time.Sleep(tc.sleepDuration)

--- a/pkg/dataobj/consumer/partition_processor_test.go
+++ b/pkg/dataobj/consumer/partition_processor_test.go
@@ -1,0 +1,310 @@
+package consumer
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+	"github.com/thanos-io/objstore"
+	"github.com/twmb/franz-go/pkg/kgo"
+
+	"github.com/grafana/loki/v3/pkg/dataobj"
+	"github.com/grafana/loki/v3/pkg/dataobj/uploader"
+	"github.com/grafana/loki/v3/pkg/logproto"
+
+	"github.com/grafana/loki/pkg/push"
+)
+
+// mockBucket implements objstore.Bucket interface for testing
+type mockBucket struct {
+	uploads map[string][]byte
+	mu      sync.Mutex
+}
+
+func newMockBucket() *mockBucket {
+	return &mockBucket{
+		uploads: make(map[string][]byte),
+	}
+}
+
+func (m *mockBucket) Close() error                                  { return nil }
+func (m *mockBucket) Delete(ctx context.Context, name string) error { return nil }
+func (m *mockBucket) Exists(ctx context.Context, name string) (bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	_, exists := m.uploads[name]
+	return exists, nil
+}
+func (m *mockBucket) Get(ctx context.Context, name string) (io.ReadCloser, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	data, exists := m.uploads[name]
+	if !exists {
+		return nil, errors.New("object not found")
+	}
+	return io.NopCloser(bytes.NewReader(data)), nil
+}
+func (m *mockBucket) GetRange(ctx context.Context, name string, off, length int64) (io.ReadCloser, error) {
+	return nil, nil
+}
+func (m *mockBucket) Upload(ctx context.Context, name string, r io.Reader) error {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return err
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.uploads[name] = data
+	return nil
+}
+func (m *mockBucket) Iter(ctx context.Context, dir string, f func(string) error, _ ...objstore.IterOption) error {
+	return nil
+}
+func (m *mockBucket) Name() string { return "mock" }
+func (m *mockBucket) Attributes(ctx context.Context, name string) (objstore.ObjectAttributes, error) {
+	return objstore.ObjectAttributes{}, nil
+}
+func (m *mockBucket) GetAndReplace(ctx context.Context, name string, f func(io.Reader) (io.Reader, error)) error {
+	// Simple implementation that doesn't use the transform function
+	return m.Upload(ctx, name, bytes.NewReader([]byte{}))
+}
+func (m *mockBucket) IsAccessDeniedErr(err error) bool {
+	return false
+}
+func (m *mockBucket) IsObjNotFoundErr(err error) bool {
+	return err != nil && err.Error() == "object not found"
+}
+func (m *mockBucket) IterWithAttributes(ctx context.Context, dir string, f func(objstore.IterObjectAttributes) error, _ ...objstore.IterOption) error {
+	return nil
+}
+func (m *mockBucket) Provider() objstore.ObjProvider {
+	return objstore.ObjProvider("MOCK")
+}
+func (m *mockBucket) SupportedIterOptions() []objstore.IterOptionType {
+	return nil
+}
+
+var testBuilderConfig = dataobj.BuilderConfig{
+	TargetPageSize:    2048,
+	TargetObjectSize:  4096,
+	TargetSectionSize: 4096,
+
+	BufferSize: 2048 * 8,
+}
+
+func TestIdleFlush(t *testing.T) {
+	tests := []struct {
+		name          string
+		idleTimeout   time.Duration
+		sleepDuration time.Duration
+		expectFlush   bool
+		initBuilder   bool
+	}{
+		{
+			name:          "should not flush before idle timeout",
+			idleTimeout:   1 * time.Second,
+			sleepDuration: 500 * time.Millisecond,
+			expectFlush:   false,
+			initBuilder:   true,
+		},
+		{
+			name:          "should flush after idle timeout",
+			idleTimeout:   500 * time.Millisecond,
+			sleepDuration: 1 * time.Second,
+			expectFlush:   true,
+			initBuilder:   true,
+		},
+		{
+			name:          "should not flush if builder is nil",
+			idleTimeout:   100 * time.Millisecond,
+			sleepDuration: 200 * time.Millisecond,
+			expectFlush:   false,
+			initBuilder:   false,
+		},
+		{
+			name:          "should not flush if last modified is less than idle timeout",
+			idleTimeout:   1 * time.Second,
+			sleepDuration: 500 * time.Millisecond,
+			expectFlush:   false,
+			initBuilder:   true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Setup test dependencies
+			bucket := newMockBucket()
+			bufPool := &sync.Pool{
+				New: func() interface{} {
+					return bytes.NewBuffer(make([]byte, 0, 1024))
+				},
+			}
+
+			// Create processor with test configuration
+			p := newPartitionProcessor(
+				context.Background(),
+				&kgo.Client{},
+				testBuilderConfig,
+				uploader.Config{},
+				bucket,
+				"test-tenant",
+				0,
+				"test-topic",
+				0,
+				log.NewNopLogger(),
+				prometheus.NewRegistry(),
+				bufPool,
+				tc.idleTimeout,
+			)
+
+			if tc.initBuilder {
+				require.NoError(t, p.initBuilder())
+				p.start()
+				defer p.stop()
+			}
+
+			stream := logproto.Stream{
+				Labels: `{cluster="test",app="foo"}`,
+				Entries: []push.Entry{{
+					Timestamp: time.Now().UTC(),
+					Line:      strings.Repeat("a", 1024),
+				}},
+			}
+
+			streamBytes, err := stream.Marshal()
+			require.NoError(t, err)
+
+			// Send a record to the processor
+			p.records <- &kgo.Record{
+				Value: streamBytes,
+				Key:   []byte("test-tenant"),
+			}
+
+			// Record initial flush time
+			initialFlushTime := p.lastFlush
+
+			// Wait for specified duration
+			time.Sleep(tc.sleepDuration)
+
+			// Trigger idle flush check
+			p.idleFlush()
+
+			if tc.expectFlush {
+				require.True(t, p.lastFlush.After(initialFlushTime), "expected flush to occur")
+			} else {
+				require.Equal(t, initialFlushTime, p.lastFlush, "expected no flush to occur")
+			}
+		})
+	}
+}
+
+func TestIdleFlushWithActiveProcessing(t *testing.T) {
+	// Setup test dependencies
+	bucket := newMockBucket()
+	bufPool := &sync.Pool{
+		New: func() interface{} {
+			return bytes.NewBuffer(make([]byte, 0, 1024))
+		},
+	}
+
+	p := newPartitionProcessor(
+		context.Background(),
+		&kgo.Client{},
+		testBuilderConfig,
+		uploader.Config{},
+		bucket,
+		"test-tenant",
+		0,
+		"test-topic",
+		0,
+		log.NewNopLogger(),
+		prometheus.NewRegistry(),
+		bufPool,
+		200*time.Millisecond,
+	)
+
+	require.NoError(t, p.initBuilder())
+
+	// Start the processor
+	p.start()
+	defer p.stop()
+
+	stream := logproto.Stream{
+		Labels: `{cluster="test",app="foo"}`,
+		Entries: []push.Entry{{
+			Timestamp: time.Now().UTC(),
+			Line:      strings.Repeat("a", 1024),
+		}},
+	}
+
+	streamBytes, err := stream.Marshal()
+	require.NoError(t, err)
+
+	// Send a record to the processor
+	p.records <- &kgo.Record{
+		Value: streamBytes,
+		Key:   []byte("test-tenant"),
+	}
+
+	// Record initial flush time
+	initialFlushTime := p.lastFlush
+
+	// Wait longer than idle timeout
+	time.Sleep(300 * time.Millisecond)
+
+	fmt.Println("lastFlush", p.lastFlush, initialFlushTime)
+
+	// Verify that idle flush occurred
+	require.True(t, p.lastFlush.After(initialFlushTime)) // "expected idle flush to occur while processor is running"
+}
+
+func TestIdleFlushWithEmptyData(t *testing.T) {
+	// Setup test dependencies
+	bucket := newMockBucket()
+	bufPool := &sync.Pool{
+		New: func() interface{} {
+			return bytes.NewBuffer(make([]byte, 0, 1024))
+		},
+	}
+
+	p := newPartitionProcessor(
+		context.Background(),
+		&kgo.Client{},
+		testBuilderConfig,
+		uploader.Config{},
+		bucket,
+		"test-tenant",
+		0,
+		"test-topic",
+		0,
+		log.NewNopLogger(),
+		prometheus.NewRegistry(),
+		bufPool,
+		200*time.Millisecond,
+	)
+
+	require.NoError(t, p.initBuilder())
+
+	// Start the processor
+	p.start()
+	defer p.stop()
+
+	// Record initial flush time
+	initialFlushTime := p.lastFlush
+
+	// Wait longer than idle timeout
+	time.Sleep(300 * time.Millisecond)
+
+	fmt.Println("lastFlush", p.lastFlush, initialFlushTime)
+
+	// Verify that idle flush occurred
+	require.True(t, p.lastFlush.Equal(initialFlushTime)) // "expected idle flush to occur while processor is running"
+}

--- a/pkg/dataobj/consumer/partition_processor_test.go
+++ b/pkg/dataobj/consumer/partition_processor_test.go
@@ -38,13 +38,13 @@ func newMockBucket() *mockBucket {
 
 func (m *mockBucket) Close() error                                  { return nil }
 func (m *mockBucket) Delete(ctx context.Context, name string) error { return nil }
-func (m *mockBucket) Exists(ctx context.Context, name string) (bool, error) {
+func (m *mockBucket) Exists(_ context.Context, name string) (bool, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	_, exists := m.uploads[name]
 	return exists, nil
 }
-func (m *mockBucket) Get(ctx context.Context, name string) (io.ReadCloser, error) {
+func (m *mockBucket) Get(_ context.Context, name string) (io.ReadCloser, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	data, exists := m.uploads[name]

--- a/pkg/dataobj/consumer/partition_processor_test.go
+++ b/pkg/dataobj/consumer/partition_processor_test.go
@@ -140,6 +140,7 @@ func TestIdleFlush(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			// Setup test dependencies
 			bucket := newMockBucket()
 			bufPool := &sync.Pool{
@@ -209,6 +210,7 @@ func TestIdleFlush(t *testing.T) {
 // TestIdleFlushWithActiveProcessing tests the idle flush behavior
 // while the processor is actively processing records.
 func TestIdleFlushWithActiveProcessing(t *testing.T) {
+	t.Parallel()
 	// Setup test dependencies
 	bucket := newMockBucket()
 	bufPool := &sync.Pool{
@@ -269,6 +271,7 @@ func TestIdleFlushWithActiveProcessing(t *testing.T) {
 // TestIdleFlushWithEmptyData tests the idle flush behavior
 // when no data has been processed.
 func TestIdleFlushWithEmptyData(t *testing.T) {
+	t.Parallel()
 	// Setup test dependencies
 	bucket := newMockBucket()
 	bufPool := &sync.Pool{

--- a/pkg/dataobj/internal/sections/streams/streams.go
+++ b/pkg/dataobj/internal/sections/streams/streams.go
@@ -31,7 +31,7 @@ type Stream struct {
 	Labels           labels.Labels // Stream labels.
 	MinTimestamp     time.Time     // Minimum timestamp in the stream.
 	MaxTimestamp     time.Time     // Maximum timestamp in the stream.
-	UncompressedSize int64         // Uncompressed size of the log lines and stuctured metadata values in the stream.
+	UncompressedSize int64         // Uncompressed size of the log lines and structured metadata values in the stream.
 	Rows             int           // Number of rows in the stream.
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The previous implementation was flushing all data that we have every X seconds, we would like to have the flush every X seconds if the stream is idle for that period.

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
