### PR TITLE
chore(helm): Fix setting X-Scope-OrgID header for ws

### DIFF
--- a/production/helm/loki/templates/_helpers.tpl
+++ b/production/helm/loki/templates/_helpers.tpl
@@ -962,11 +962,17 @@ http {
       proxy_pass       {{ $queryFrontendUrl }}$request_uri;
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection "upgrade";
+      {{- if .Values.loki.tenants }}
+      proxy_set_header X-Scope-OrgID $remote_user;
+      {{- end }}
     }
     location = /loki/api/v1/tail {
       proxy_pass       {{ $queryFrontendUrl }}$request_uri;
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection "upgrade";
+      {{- if .Values.loki.tenants }}
+      proxy_set_header X-Scope-OrgID $remote_user;
+      {{- end }}
     }
     location ^~ /api/prom/ {
       proxy_pass       {{ $queryFrontendUrl }}$request_uri;


### PR DESCRIPTION
**What this PR does / why we need it**: helm nginx config: fix setting X-Scope-OrgID from basic auth for websocket endpoints

**Which issue(s) this PR fixes**: probably related #9756

**Special notes for your reviewer**:

Current production/helm/loki chart includes the gateway component (nginx proxy). In multi-tenant mode with auth_enabled it uses HTTP basic auth to determine the tenant (by username). After authentication it sets the X-Scope-OrgID header with proxy_set_header directive in http{} scope. 

Per proxy_set_header [documentation](http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_set_header):
> These directives are inherited from the previous configuration level if and only if there are no proxy_set_header directives defined on the current level

, which is the case: the nested location{} blocks for websocket endpoints use the directive to enable websocket connection upgrade. So, in nested locations the http block-scoped proxy_set_header directive is ignored. 

This leads to two issues:
1. Valid requests to websocket endpoints that include valid  basic auth don't get the X-Scope-OrgID header populated, which leads to 401 errors, as observed earlier in the linked issue;
2. Requests by tenant X that include their valid basic auth may include client-provided X-Scope-OrgID header that is neither sanitized nor overriden by proxy_set_header, which might allow tenant X to access another tenant's logs in some configurations. 

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
