### PR TITLE
chore: log X-Query-Tags in the frontend executing query log message

### DIFF
--- a/pkg/logql/engine.go
+++ b/pkg/logql/engine.go
@@ -276,7 +276,7 @@ func (q *query) Exec(ctx context.Context) (logqlmodel.Result, error) {
 			"query_hash", queryHash,
 		}
 		tags := httpreq.ExtractQueryTagsFromContext(ctx)
-		tagValues := tagsToKeyValues(tags)
+		tagValues := httpreq.TagsToKeyValues(tags)
 		if GetRangeType(q.params) == InstantType {
 			logValues = append(logValues, "type", "instant")
 		} else {

--- a/pkg/logql/metrics.go
+++ b/pkg/logql/metrics.go
@@ -219,7 +219,7 @@ func RecordRangeAndInstantQueryMetrics(
 		"index_shard_resolver_duration", time.Duration(stats.Index.ShardsDuration),
 	}...)
 
-	logValues = append(logValues, tagsToKeyValues(queryTags)...)
+	logValues = append(logValues, httpreq.TagsToKeyValues(queryTags)...)
 
 	if httpreq.ExtractHeader(ctx, httpreq.LokiDisablePipelineWrappersHeader) == "true" {
 		logValues = append(logValues, "disable_pipeline_wrappers", "true")
@@ -561,37 +561,6 @@ func QueryType(expr syntax.Expr) (string, error) {
 	default:
 		return "", nil
 	}
-}
-
-// tagsToKeyValues converts QueryTags to form that is easy to log.
-// e.g: `Source=foo,Feature=beta` -> []interface{}{"source", "foo", "feature", "beta"}
-// so that we could log nicely!
-// If queryTags is not in canonical form then its completely ignored (e.g: `key1=value1,key2=value`)
-func tagsToKeyValues(queryTags string) []interface{} {
-	toks := strings.FieldsFunc(queryTags, func(r rune) bool {
-		return r == ','
-	})
-
-	vals := make([]string, 0)
-
-	for _, tok := range toks {
-		val := strings.FieldsFunc(tok, func(r rune) bool {
-			return r == '='
-		})
-
-		if len(val) != 2 {
-			continue
-		}
-		vals = append(vals, strings.ToLower(val[0]), val[1])
-	}
-
-	res := make([]interface{}, 0, len(vals))
-
-	for _, val := range vals {
-		res = append(res, val)
-	}
-
-	return res
 }
 
 func extractShard(shards []string) *astmapper.ShardAnnotation {

--- a/pkg/logql/metrics_test.go
+++ b/pkg/logql/metrics_test.go
@@ -160,52 +160,6 @@ func TestLogSeriesQuery(t *testing.T) {
 	util_log.Logger = log.NewNopLogger()
 }
 
-func Test_testToKeyValues(t *testing.T) {
-	cases := []struct {
-		name string
-		in   string
-		exp  []interface{}
-	}{
-		{
-			name: "canonical-form",
-			in:   "Source=logvolhist",
-			exp: []interface{}{
-				"source",
-				"logvolhist",
-			},
-		},
-		{
-			name: "canonical-form-multiple-values",
-			in:   "Source=logvolhist,Feature=beta,User=Jinx@grafana.com",
-			exp: []interface{}{
-				"source",
-				"logvolhist",
-				"feature",
-				"beta",
-				"user",
-				"Jinx@grafana.com",
-			},
-		},
-		{
-			name: "empty",
-			in:   "",
-			exp:  []interface{}{},
-		},
-		{
-			name: "non-canonical form",
-			in:   "abc",
-			exp:  []interface{}{},
-		},
-	}
-
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			got := tagsToKeyValues(c.in)
-			assert.Equal(t, c.exp, got)
-		})
-	}
-}
-
 func TestQueryHashing(t *testing.T) {
 	h1 := util.HashedQuery(`{app="myapp",env="myenv"} |= "error" |= "metrics.go" |= logfmt`)
 	h2 := util.HashedQuery(`{app="myapp",env="myenv"} |= "error" |= logfmt |= "metrics.go"`)

--- a/pkg/querier/queryrange/roundtrip.go
+++ b/pkg/querier/queryrange/roundtrip.go
@@ -393,7 +393,7 @@ func newRoundTripper(
 }
 
 // Helper function to create and log query execution details
-func logQueryExecution(logger log.Logger, ctx context.Context, values ...interface{}) {
+func logQueryExecution(ctx context.Context, logger log.Logger, values ...interface{}) {
 	logValues := append([]interface{}{"msg", "executing query"}, values...)
 
 	// Extract and append tags from context
@@ -409,7 +409,7 @@ func (r roundTripper) Do(ctx context.Context, req base.Request) (base.Response, 
 	switch op := req.(type) {
 	case *LokiRequest:
 		queryHash := util.HashedQuery(op.Query)
-		logQueryExecution(logger, ctx,
+		logQueryExecution(ctx, logger,
 			"type", "range",
 			"query", op.Query,
 			"start", op.StartTs.Format(time.RFC3339Nano),
@@ -483,14 +483,14 @@ func (r roundTripper) Do(ctx context.Context, req base.Request) (base.Response, 
 			return r.next.Do(ctx, req)
 		}
 	case *LokiSeriesRequest:
-		logQueryExecution(logger, ctx,
+		logQueryExecution(ctx, logger,
 			"type", "series",
 			"match", logql.PrintMatches(op.Match),
 			"length", op.EndTs.Sub(op.StartTs),
 		)
 		return r.series.Do(ctx, req)
 	case *LabelRequest:
-		logQueryExecution(logger, ctx,
+		logQueryExecution(ctx, logger,
 			"type", "labels",
 			"label", op.Name,
 			"length", op.LabelRequest.End.Sub(*op.LabelRequest.Start),
@@ -499,7 +499,7 @@ func (r roundTripper) Do(ctx context.Context, req base.Request) (base.Response, 
 		return r.labels.Do(ctx, req)
 	case *LokiInstantRequest:
 		queryHash := util.HashedQuery(op.Query)
-		logQueryExecution(logger, ctx,
+		logQueryExecution(ctx, logger,
 			"type", "instant",
 			"query", op.Query,
 			"query_hash", queryHash,
@@ -511,14 +511,14 @@ func (r roundTripper) Do(ctx context.Context, req base.Request) (base.Response, 
 			return r.next.Do(ctx, req)
 		}
 	case *logproto.IndexStatsRequest:
-		logQueryExecution(logger, ctx,
+		logQueryExecution(ctx, logger,
 			"type", "stats",
 			"query", op.Matchers,
 			"length", op.Through.Sub(op.From),
 		)
 		return r.indexStats.Do(ctx, req)
 	case *logproto.VolumeRequest:
-		logQueryExecution(logger, ctx,
+		logQueryExecution(ctx, logger,
 			"type", "volume_range",
 			"query", op.Matchers,
 			"length", op.Through.Sub(op.From),
@@ -528,7 +528,7 @@ func (r roundTripper) Do(ctx context.Context, req base.Request) (base.Response, 
 		)
 		return r.seriesVolume.Do(ctx, req)
 	case *DetectedFieldsRequest:
-		logQueryExecution(logger, ctx,
+		logQueryExecution(ctx, logger,
 			"type", "detected_fields",
 			"end", op.End,
 			"field_limit", op.Limit,
@@ -540,7 +540,7 @@ func (r roundTripper) Do(ctx context.Context, req base.Request) (base.Response, 
 		)
 		return r.detectedFields.Do(ctx, req)
 	case *DetectedLabelsRequest:
-		logQueryExecution(logger, ctx,
+		logQueryExecution(ctx, logger,
 			"type", "detected_label",
 			"end", op.End,
 			"length", op.End.Sub(op.Start),

--- a/pkg/querier/queryrange/roundtrip.go
+++ b/pkg/querier/queryrange/roundtrip.go
@@ -392,14 +392,24 @@ func newRoundTripper(
 	}
 }
 
+// Helper function to create and log query execution details
+func logQueryExecution(logger log.Logger, ctx context.Context, values ...interface{}) {
+	logValues := append([]interface{}{"msg", "executing query"}, values...)
+
+	// Extract and append tags from context
+	tags := httpreq.ExtractQueryTagsFromContext(ctx)
+	tagValues := httpreq.TagsToKeyValues(tags)
+	logValues = append(logValues, tagValues...)
+	level.Info(logger).Log(logValues...)
+}
+
 func (r roundTripper) Do(ctx context.Context, req base.Request) (base.Response, error) {
 	logger := logutil.WithContext(ctx, r.logger)
 
 	switch op := req.(type) {
 	case *LokiRequest:
 		queryHash := util.HashedQuery(op.Query)
-		level.Info(logger).Log(
-			"msg", "executing query",
+		logQueryExecution(logger, ctx,
 			"type", "range",
 			"query", op.Query,
 			"start", op.StartTs.Format(time.RFC3339Nano),
@@ -473,17 +483,27 @@ func (r roundTripper) Do(ctx context.Context, req base.Request) (base.Response, 
 			return r.next.Do(ctx, req)
 		}
 	case *LokiSeriesRequest:
-		level.Info(logger).Log("msg", "executing query", "type", "series", "match", logql.PrintMatches(op.Match), "length", op.EndTs.Sub(op.StartTs))
-
+		logQueryExecution(logger, ctx,
+			"type", "series",
+			"match", logql.PrintMatches(op.Match),
+			"length", op.EndTs.Sub(op.StartTs),
+		)
 		return r.series.Do(ctx, req)
 	case *LabelRequest:
-		level.Info(logger).Log("msg", "executing query", "type", "labels", "label", op.Name, "length", op.LabelRequest.End.Sub(*op.LabelRequest.Start), "query", op.Query)
-
+		logQueryExecution(logger, ctx,
+			"type", "labels",
+			"label", op.Name,
+			"length", op.LabelRequest.End.Sub(*op.LabelRequest.Start),
+			"query", op.Query,
+		)
 		return r.labels.Do(ctx, req)
 	case *LokiInstantRequest:
 		queryHash := util.HashedQuery(op.Query)
-		level.Info(logger).Log("msg", "executing query", "type", "instant", "query", op.Query, "query_hash", queryHash)
-
+		logQueryExecution(logger, ctx,
+			"type", "instant",
+			"query", op.Query,
+			"query_hash", queryHash,
+		)
 		switch op.Plan.AST.(type) {
 		case syntax.SampleExpr:
 			return r.instantMetric.Do(ctx, req)
@@ -491,12 +511,14 @@ func (r roundTripper) Do(ctx context.Context, req base.Request) (base.Response, 
 			return r.next.Do(ctx, req)
 		}
 	case *logproto.IndexStatsRequest:
-		level.Info(logger).Log("msg", "executing query", "type", "stats", "query", op.Matchers, "length", op.Through.Sub(op.From))
-
+		logQueryExecution(logger, ctx,
+			"type", "stats",
+			"query", op.Matchers,
+			"length", op.Through.Sub(op.From),
+		)
 		return r.indexStats.Do(ctx, req)
 	case *logproto.VolumeRequest:
-		level.Info(logger).Log(
-			"msg", "executing query",
+		logQueryExecution(logger, ctx,
 			"type", "volume_range",
 			"query", op.Matchers,
 			"length", op.Through.Sub(op.From),
@@ -504,11 +526,9 @@ func (r roundTripper) Do(ctx context.Context, req base.Request) (base.Response, 
 			"limit", op.Limit,
 			"aggregate_by", op.AggregateBy,
 		)
-
 		return r.seriesVolume.Do(ctx, req)
 	case *DetectedFieldsRequest:
-		level.Info(logger).Log(
-			"msg", "executing query",
+		logQueryExecution(logger, ctx,
 			"type", "detected_fields",
 			"end", op.End,
 			"field_limit", op.Limit,
@@ -518,11 +538,9 @@ func (r roundTripper) Do(ctx context.Context, req base.Request) (base.Response, 
 			"start", op.Start,
 			"step", op.Step,
 		)
-
 		return r.detectedFields.Do(ctx, req)
 	case *DetectedLabelsRequest:
-		level.Info(logger).Log(
-			"msg", "executing query",
+		logQueryExecution(logger, ctx,
 			"type", "detected_label",
 			"end", op.End,
 			"length", op.End.Sub(op.Start),

--- a/pkg/util/httpreq/tags.go
+++ b/pkg/util/httpreq/tags.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/grafana/dskit/middleware"
@@ -68,4 +69,35 @@ func ExtractQueryMetricsMiddleware() middleware.Interface {
 			next.ServeHTTP(w, req)
 		})
 	})
+}
+
+// TagsToKeyValues converts QueryTags to form that is easy to log.
+// e.g: `Source=foo,Feature=beta` -> []interface{}{"source", "foo", "feature", "beta"}
+// so that we could log nicely!
+// If queryTags is not in canonical form then its completely ignored (e.g: `key1=value1,key2=value`)
+func TagsToKeyValues(queryTags string) []interface{} {
+	toks := strings.FieldsFunc(queryTags, func(r rune) bool {
+		return r == ','
+	})
+
+	vals := make([]string, 0)
+
+	for _, tok := range toks {
+		val := strings.FieldsFunc(tok, func(r rune) bool {
+			return r == '='
+		})
+
+		if len(val) != 2 {
+			continue
+		}
+		vals = append(vals, strings.ToLower(val[0]), val[1])
+	}
+
+	res := make([]interface{}, 0, len(vals))
+
+	for _, val := range vals {
+		res = append(res, val)
+	}
+
+	return res
 }

--- a/pkg/util/httpreq/tags_test.go
+++ b/pkg/util/httpreq/tags_test.go
@@ -96,3 +96,49 @@ func TestQueryMetrics(t *testing.T) {
 		})
 	}
 }
+
+func Test_testToKeyValues(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		exp  []interface{}
+	}{
+		{
+			name: "canonical-form",
+			in:   "Source=logvolhist",
+			exp: []interface{}{
+				"source",
+				"logvolhist",
+			},
+		},
+		{
+			name: "canonical-form-multiple-values",
+			in:   "Source=logvolhist,Feature=beta,User=Jinx@grafana.com",
+			exp: []interface{}{
+				"source",
+				"logvolhist",
+				"feature",
+				"beta",
+				"user",
+				"Jinx@grafana.com",
+			},
+		},
+		{
+			name: "empty",
+			in:   "",
+			exp:  []interface{}{},
+		},
+		{
+			name: "non-canonical form",
+			in:   "abc",
+			exp:  []interface{}{},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := TagsToKeyValues(c.in)
+			assert.Equal(t, c.exp, got)
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

X-Query-Tags are used to convey source information about queries, we log these values in several places already like our metrics.go lines, not too long ago we added this info to the `executing query` log line but only in the queriers and not in the frontend, this PR adds this to the frontend.

I also refactored a helper function to a different package to make it reusable in the frontend code.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
