### PR TITLE
fix: update crc64nvme to fix build issues with arm images

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -185,7 +185,7 @@ require (
 	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/mdlayher/socket v0.5.1 // indirect
 	github.com/mdlayher/vsock v1.2.1 // indirect
-	github.com/minio/crc64nvme v1.0.0 // indirect
+	github.com/minio/crc64nvme v1.0.1 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
 	github.com/moby/sys/userns v0.1.0 // indirect
 	github.com/ncw/swift v1.0.53 // indirect

--- a/go.sum
+++ b/go.sum
@@ -864,8 +864,8 @@ github.com/miekg/dns v1.1.26/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKju
 github.com/miekg/dns v1.1.41/go.mod h1:p6aan82bvRIyn+zDIv9xYNUpwa73JcSh9BKwknJysuI=
 github.com/miekg/dns v1.1.63 h1:8M5aAw6OMZfFXTT7K5V0Eu5YiiL8l7nUAkyN6C9YwaY=
 github.com/miekg/dns v1.1.63/go.mod h1:6NGHfjhpmr5lt3XPLuyfDJi5AXbNIPM9PY6H6sF1Nfs=
-github.com/minio/crc64nvme v1.0.0 h1:MeLcBkCTD4pAoU7TciAfwsfxgkhM2u5hCe48hSEVFr0=
-github.com/minio/crc64nvme v1.0.0/go.mod h1:eVfm2fAzLlxMdUGc0EEBGSMmPwmXD5XiNRpnu9J3bvg=
+github.com/minio/crc64nvme v1.0.1 h1:DHQPrYPdqK7jQG/Ls5CTBZWeex/2FMS3G5XGkycuFrY=
+github.com/minio/crc64nvme v1.0.1/go.mod h1:eVfm2fAzLlxMdUGc0EEBGSMmPwmXD5XiNRpnu9J3bvg=
 github.com/minio/md5-simd v1.1.2 h1:Gdi1DZK69+ZVMoNHRXJyNcxrMA4dSxoYHZSQbirFg34=
 github.com/minio/md5-simd v1.1.2/go.mod h1:MzdKDxYpY2BT9XQFocsiZf/NKVtR7nkE4RoEpN+20RM=
 github.com/minio/minio-go/v7 v7.0.86 h1:DcgQ0AUjLJzRH6y/HrxiZ8CXarA70PAIufXHodP4s+k=

--- a/vendor/github.com/minio/crc64nvme/crc64_amd64.s
+++ b/vendor/github.com/minio/crc64nvme/crc64_amd64.s
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a license that can be
 // found in the LICENSE file.
 
+//go:build !noasm && !appengine && !gccgo
+
 #include "textflag.h"
 
 TEXT ·updateAsm(SB), $0-40

--- a/vendor/github.com/minio/crc64nvme/crc64_arm64.s
+++ b/vendor/github.com/minio/crc64nvme/crc64_arm64.s
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a license that can be
 // found in the LICENSE file.
 
+//go:build !noasm && !appengine && !gccgo
+
 #include "textflag.h"
 
 TEXT ·updateAsm(SB), $0-40

--- a/vendor/github.com/minio/crc64nvme/crc64_other.go
+++ b/vendor/github.com/minio/crc64nvme/crc64_other.go
@@ -7,3 +7,5 @@
 package crc64nvme
 
 var hasAsm = false
+
+func updateAsm(crc uint64, p []byte) (checksum uint64) { panic("should not be reached") }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1291,7 +1291,7 @@ github.com/mdlayher/vsock
 # github.com/miekg/dns v1.1.63
 ## explicit; go 1.19
 github.com/miekg/dns
-# github.com/minio/crc64nvme v1.0.0
+# github.com/minio/crc64nvme v1.0.1
 ## explicit; go 1.22
 github.com/minio/crc64nvme
 # github.com/minio/md5-simd v1.1.2


### PR DESCRIPTION
**What this PR does / why we need it**:
The `arm` build has been failing, which I could trace to [PR adding an indirect dependency to github.com/minio/crc64nvme](https://github.com/grafana/loki/pull/16334). However, it did not properly handle non-asm builds. There has been a new release with a fix for this build issue. This PR updates the lib from 1.0.0 to 1.0.1 to get the fix.