### PR TITLE
chore(dataobj): Decode values in batches

### DIFF
--- a/pkg/dataobj/internal/dataset/page_iter.go
+++ b/pkg/dataobj/internal/dataset/page_iter.go
@@ -50,7 +50,7 @@ func iterMemPage(p *MemPage, valueType datasetmd.ValueType, compressionType data
 				iB++
 			}
 
-			if bufB[iB].Uint64() == 0 {
+			if bufB[iB].Uint64() == 0 { //nolint:revive
 				// If the presence bitmap says our row has no value, we need to yield a
 				// nil value, so do nothing.
 			} else if bufB[iB].Uint64() == 1 {

--- a/pkg/dataobj/internal/dataset/page_iter.go
+++ b/pkg/dataobj/internal/dataset/page_iter.go
@@ -10,6 +10,9 @@ import (
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/result"
 )
 
+// TODO: What is a good batch size?
+const decodeBufferSize = 128
+
 func iterMemPage(p *MemPage, valueType datasetmd.ValueType, compressionType datasetmd.CompressionType) result.Seq[Value] {
 	return result.Iter(func(yield func(Value) bool) error {
 		presenceReader, valuesReader, err := p.reader(compressionType)
@@ -24,25 +27,50 @@ func iterMemPage(p *MemPage, valueType datasetmd.ValueType, compressionType data
 			return fmt.Errorf("no decoder available for %s/%s", valueType, p.Info.Encoding)
 		}
 
+		var iB, iV = decodeBufferSize, decodeBufferSize                                // current index of buffers for precence values and values
+		var nB, nV = decodeBufferSize, decodeBufferSize                                // size of buffers for precence values and values
+		bufB, bufV := make([]Value, decodeBufferSize), make([]Value, decodeBufferSize) // buffers for precence values and values
+
 		for {
 			var value Value
 
-			present, err := presenceDec.Decode()
-			if errors.Is(err, io.EOF) {
-				return nil
-			} else if err != nil {
-				return fmt.Errorf("decoding presence bitmap: %w", err)
-			} else if present.Type() != datasetmd.VALUE_TYPE_UINT64 {
-				return fmt.Errorf("unexpected presence type %s", present.Type())
+			// There are not decoded presence values in the buffer, so read a new
+			// batch up to decodeBufferSize values and reset the current index of the
+			// value inside the buffer.
+			if iB >= nB-1 {
+				nB, err = presenceDec.Decode(bufB[:decodeBufferSize])
+				bufB = bufB[:nB]
+				iB = 0
+				if nB == 0 || errors.Is(err, io.EOF) {
+					return nil
+				} else if err != nil {
+					return fmt.Errorf("decoding presence bitmap: %w", err)
+				}
+			} else {
+				iB++
 			}
 
-			// value is currently nil. If the presence bitmap says our row has a
-			// value, we decode it into value.
-			if present.Uint64() == 1 {
-				value, err = valuesDec.Decode()
-				if err != nil {
-					return fmt.Errorf("decoding value: %w", err)
+			if bufB[iB].Uint64() == 0 {
+				// If the presence bitmap says our row has no value, we need to yield a
+				// nil value, so do nothing.
+			} else if bufB[iB].Uint64() == 1 {
+				// If the presence bitmap says our row has a value, we decode it.
+
+				// There are no decoded values in the buffer, so read a new batch up to
+				// decodeBufferSize values and reset the current index of the value inside the buffer.
+				if iV >= nV-1 {
+					nV, err = valuesDec.Decode(bufV[:decodeBufferSize])
+					bufV = bufV[:nV]
+					iV = 0
+					if nV == 0 || errors.Is(err, io.EOF) {
+						return fmt.Errorf("too few values to decode: expected at least %d, got %d", len(bufB), nV)
+					} else if err != nil {
+						return fmt.Errorf("decoding value: %w", err)
+					}
+				} else {
+					iV++
 				}
+				value = bufV[iV]
 			}
 
 			if !yield(value) {

--- a/pkg/dataobj/internal/dataset/page_iter.go
+++ b/pkg/dataobj/internal/dataset/page_iter.go
@@ -10,7 +10,6 @@ import (
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/result"
 )
 
-// TODO: What is a good batch size?
 const decodeBufferSize = 128
 
 func iterMemPage(p *MemPage, valueType datasetmd.ValueType, compressionType datasetmd.CompressionType) result.Seq[Value] {

--- a/pkg/dataobj/internal/dataset/page_test.go
+++ b/pkg/dataobj/internal/dataset/page_test.go
@@ -26,7 +26,7 @@ func Benchmark_page_Decode(b *testing.B) {
 	}
 
 	opts := BuilderOptions{
-		PageSizeHint: 1 << 30,
+		PageSizeHint: 1 << 30, // 1GiB
 		Value:        datasetmd.VALUE_TYPE_STRING,
 		Compression:  datasetmd.COMPRESSION_TYPE_ZSTD,
 		Encoding:     datasetmd.ENCODING_TYPE_PLAIN,
@@ -34,7 +34,7 @@ func Benchmark_page_Decode(b *testing.B) {
 	builder, err := newPageBuilder(opts)
 	require.NoError(b, err)
 
-	for i := range b.N {
+	for i := range 1_000_000 {
 		s := in[i%len(in)]
 		require.True(b, builder.Append(StringValue(s)))
 	}
@@ -45,15 +45,16 @@ func Benchmark_page_Decode(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 
-	_, values, err := page.reader(datasetmd.COMPRESSION_TYPE_ZSTD)
-	if err != nil {
-		b.Fatal()
-	}
-
-	if _, err := io.Copy(io.Discard, values); err != nil {
-		b.Fatal(err)
-	} else if err := values.Close(); err != nil {
-		b.Fatal(err)
+	for range b.N {
+		_, values, err := page.reader(datasetmd.COMPRESSION_TYPE_ZSTD)
+		if err != nil {
+			b.Fatal()
+		}
+		if _, err := io.Copy(io.Discard, values); err != nil {
+			b.Fatal(err)
+		} else if err := values.Close(); err != nil {
+			b.Fatal(err)
+		}
 	}
 
 }

--- a/pkg/dataobj/internal/dataset/value_encoding.go
+++ b/pkg/dataobj/internal/dataset/value_encoding.go
@@ -40,9 +40,10 @@ type valueDecoder interface {
 	// EncodingType returns the encoding type used by the valueDecoder.
 	EncodingType() datasetmd.EncodingType
 
-	// Decode decodes an individual [Value]. Decode returns an error if decoding
-	// fails.
-	Decode() (Value, error)
+	// Decode decodes up to len(s) values, storing the results into s. The
+	// number of decoded values is returned, followed by an error (if any).
+	// At the end of the stream, Decode returns 0, [io.EOF].
+	Decode(s []Value) (int, error)
 
 	// Reset discards any state and resets the valueDecoder to read from r. This
 	// permits reusing a valueDecoder rather than allocating a new one.

--- a/pkg/dataobj/internal/dataset/value_encoding_bitmap.go
+++ b/pkg/dataobj/internal/dataset/value_encoding_bitmap.go
@@ -501,7 +501,7 @@ func (dec *bitmapDecoder) EncodingType() datasetmd.EncodingType {
 }
 
 // Decode reads the next uint64 value from the stream.
-func (dec *bitmapDecoder) Decode() (Value, error) {
+func (dec *bitmapDecoder) Decode(s []Value) (int, error) {
 	// See comment inside [bitmapDecoder] for the state machine details.
 
 NextState:

--- a/pkg/dataobj/internal/dataset/value_encoding_bitmap.go
+++ b/pkg/dataobj/internal/dataset/value_encoding_bitmap.go
@@ -1,6 +1,7 @@
 package dataset
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"math/bits"
@@ -500,8 +501,34 @@ func (dec *bitmapDecoder) EncodingType() datasetmd.EncodingType {
 	return datasetmd.ENCODING_TYPE_BITMAP
 }
 
-// Decode reads the next uint64 value from the stream.
+// Decode decodes up to len(s) values, storing the results into s. The
+// number of decoded values is returned, followed by an error (if any).
+// At the end of the stream, Decode returns 0, [io.EOF].
 func (dec *bitmapDecoder) Decode(s []Value) (int, error) {
+	if len(s) == 0 {
+		return 0, nil
+	}
+
+	var err error
+	var v Value
+
+	for i := range s {
+		v, err = dec.decode()
+		if errors.Is(err, io.EOF) {
+			if i == 0 {
+				return 0, io.EOF
+			}
+			return i, nil
+		} else if err != nil {
+			return i, err
+		}
+		s[i] = v
+	}
+	return len(s), nil
+}
+
+// decode reads the next uint64 value from the stream.
+func (dec *bitmapDecoder) decode() (Value, error) {
 	// See comment inside [bitmapDecoder] for the state machine details.
 
 NextState:

--- a/pkg/dataobj/internal/dataset/value_encoding_delta.go
+++ b/pkg/dataobj/internal/dataset/value_encoding_delta.go
@@ -93,7 +93,7 @@ func (dec *deltaDecoder) EncodingType() datasetmd.EncodingType {
 }
 
 // Decode decodes the next value.
-func (dec *deltaDecoder) Decode() (Value, error) {
+func (dec *deltaDecoder) Decode(s []Value) (int, error) {
 	delta, err := streamio.ReadVarint(dec.r)
 	if err != nil {
 		return Int64Value(dec.prev), err

--- a/pkg/dataobj/internal/dataset/value_encoding_delta.go
+++ b/pkg/dataobj/internal/dataset/value_encoding_delta.go
@@ -1,7 +1,9 @@
 package dataset
 
 import (
+	"errors"
 	"fmt"
+	"io"
 
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/metadata/datasetmd"
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/streamio"
@@ -92,8 +94,34 @@ func (dec *deltaDecoder) EncodingType() datasetmd.EncodingType {
 	return datasetmd.ENCODING_TYPE_DELTA
 }
 
-// Decode decodes the next value.
+// Decode decodes up to len(s) values, storing the results into s. The
+// number of decoded values is returned, followed by an error (if any).
+// At the end of the stream, Decode returns 0, [io.EOF].
 func (dec *deltaDecoder) Decode(s []Value) (int, error) {
+	if len(s) == 0 {
+		return 0, nil
+	}
+
+	var err error
+	var v Value
+
+	for i := range s {
+		v, err = dec.decode()
+		if errors.Is(err, io.EOF) {
+			if i == 0 {
+				return 0, io.EOF
+			}
+			return i, nil
+		} else if err != nil {
+			return i, err
+		}
+		s[i] = v
+	}
+	return len(s), nil
+}
+
+// decode reads the next uint64 value from the stream.
+func (dec *deltaDecoder) decode() (Value, error) {
 	delta, err := streamio.ReadVarint(dec.r)
 	if err != nil {
 		return Int64Value(dec.prev), err

--- a/pkg/dataobj/internal/dataset/value_encoding_plain.go
+++ b/pkg/dataobj/internal/dataset/value_encoding_plain.go
@@ -2,6 +2,7 @@ package dataset
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"unsafe"
@@ -95,8 +96,34 @@ func (dec *plainDecoder) EncodingType() datasetmd.EncodingType {
 	return datasetmd.ENCODING_TYPE_PLAIN
 }
 
-// Decode decodes a string.
+// Decode decodes up to len(s) values, storing the results into s. The
+// number of decoded values is returned, followed by an error (if any).
+// At the end of the stream, Decode returns 0, [io.EOF].
 func (dec *plainDecoder) Decode(s []Value) (int, error) {
+	if len(s) == 0 {
+		return 0, nil
+	}
+
+	var err error
+	var v Value
+
+	for i := range s {
+		v, err = dec.decode()
+		if errors.Is(err, io.EOF) {
+			if i == 0 {
+				return 0, io.EOF
+			}
+			return i, nil
+		} else if err != nil {
+			return i, err
+		}
+		s[i] = v
+	}
+	return len(s), nil
+}
+
+// decode decodes a string.
+func (dec *plainDecoder) decode() (Value, error) {
 	sz, err := binary.ReadUvarint(dec.r)
 	if err != nil {
 		return StringValue(""), err

--- a/pkg/dataobj/internal/dataset/value_encoding_plain.go
+++ b/pkg/dataobj/internal/dataset/value_encoding_plain.go
@@ -96,7 +96,7 @@ func (dec *plainDecoder) EncodingType() datasetmd.EncodingType {
 }
 
 // Decode decodes a string.
-func (dec *plainDecoder) Decode() (Value, error) {
+func (dec *plainDecoder) Decode(s []Value) (int, error) {
 	sz, err := binary.ReadUvarint(dec.r)
 	if err != nil {
 		return StringValue(""), err


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

```console
$ benchstat bench_bitmapdecoder_old.txt bench_bitmapdecoder_new.txt 
goos: linux
goarch: amd64
pkg: github.com/grafana/loki/v3/pkg/dataobj/internal/dataset
cpu: 11th Gen Intel(R) Core(TM) i7-1185G7 @ 3.00GHz
                                               │ bench_bitmapdecoder_old.txt │      bench_bitmapdecoder_new.txt      │
                                               │           sec/op            │    sec/op      vs base                │
_bitmapDecoder/width=1/variance=none-8                          1.674n ±  5%    1.557n ±  6%   -6.99% (p=0.001 n=10)
_bitmapDecoder/width=1/variance=alternating-8                   1.528n ±  2%    1.727n ±  6%  +13.02% (p=0.001 n=10)
_bitmapDecoder/width=1/variance=random-8                        1.722n ±  5%    1.560n ±  6%   -9.35% (p=0.000 n=10)
_bitmapDecoder/width=3/variance=none-8                          1.766n ± 15%    1.604n ±  5%   -9.20% (p=0.000 n=10)
_bitmapDecoder/width=3/variance=alternating-8                   9.068n ±  6%    9.236n ±  3%        ~ (p=0.631 n=10)
_bitmapDecoder/width=3/variance=random-8                        9.223n ±  6%   12.115n ± 28%        ~ (p=0.063 n=10)
_bitmapDecoder/width=5/variance=none-8                          1.801n ±  5%    1.506n ±  6%  -16.38% (p=0.000 n=10)
_bitmapDecoder/width=5/variance=alternating-8                   11.67n ±  6%    11.76n ±  3%        ~ (p=0.985 n=10)
_bitmapDecoder/width=5/variance=random-8                        12.36n ± 36%    12.94n ± 33%        ~ (p=0.645 n=10)
_bitmapDecoder/width=8/variance=none-8                          1.830n ± 41%    1.564n ±  7%  -14.51% (p=0.000 n=10)
_bitmapDecoder/width=8/variance=alternating-8                   11.44n ±  7%    11.63n ±  6%        ~ (p=0.470 n=10)
_bitmapDecoder/width=8/variance=random-8                        11.88n ± 46%    13.84n ± 31%        ~ (p=0.255 n=10)
_bitmapDecoder/width=32/variance=none-8                         2.544n ± 29%    1.518n ±  9%  -40.30% (p=0.000 n=10)
_bitmapDecoder/width=32/variance=alternating-8                  16.95n ±  5%    17.05n ± 86%        ~ (p=0.631 n=10)
_bitmapDecoder/width=32/variance=random-8                       17.37n ± 34%    19.29n ± 25%        ~ (p=0.225 n=10)
_bitmapDecoder/width=64/variance=none-8                         1.835n ±  3%    1.584n ± 43%        ~ (p=0.137 n=10)
_bitmapDecoder/width=64/variance=alternating-8                  21.66n ± 26%    19.30n ± 33%        ~ (p=0.143 n=10)
_bitmapDecoder/width=64/variance=random-8                       20.79n ± 32%    22.02n ± 21%        ~ (p=0.684 n=10)
geomean                                                         5.562n          5.387n         -3.15%
```

```console
$ benchstat bench_deltadecoder_old.txt bench_deltadecoder_new.txt
goos: linux
goarch: amd64
pkg: github.com/grafana/loki/v3/pkg/dataobj/internal/dataset
cpu: 11th Gen Intel(R) Core(TM) i7-1185G7 @ 3.00GHz
                                     │ bench_deltadecoder_old.txt │     bench_deltadecoder_new.txt      │
                                     │           sec/op           │    sec/op     vs base               │
_deltaDecoder_Decode/Sequential-8                    6.743n ±  5%   6.645n ±  5%       ~ (p=0.404 n=10)
_deltaDecoder_Decode/Largest_delta-8                 29.61n ± 44%   29.07n ±  2%       ~ (p=0.183 n=10)
_deltaDecoder_Decode/Random-8                        32.15n ± 25%   31.26n ± 42%       ~ (p=0.796 n=10)
geomean                                              18.58n         18.21n        -2.01%
```

```console
$ benchstat bench_plaindecoder_old.txt bench_plaindecoder_new.txt
goos: linux
goarch: amd64
pkg: github.com/grafana/loki/v3/pkg/dataobj/internal/dataset
cpu: 11th Gen Intel(R) Core(TM) i7-1185G7 @ 3.00GHz
                       │ bench_plaindecoder_old.txt │     bench_plaindecoder_new.txt      │
                       │           sec/op           │   sec/op     vs base                │
_plainDecoder_Decode-8                  10.38n ± 5%   18.62n ± 4%  +79.47% (p=0.000 n=10)
```