### PR TITLE
feat(policies): Support global policy

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -3651,9 +3651,9 @@ otlp_config:
   [log_attributes: <list of attributes_configs>]
 
 # Block ingestion for policy until the configured date. The policy '*' is the
-# global policy, which is applied to all streams and can be overridden by other
-# policies. The time should be in RFC3339 format. The policy is based on the
-# policy_stream_mapping configuration.
+# global policy, which is applied to all streams not matching a policy and can
+# be overridden by other policies. The time should be in RFC3339 format. The
+# policy is based on the policy_stream_mapping configuration.
 [block_ingestion_policy_until: <map of string to Time>]
 
 # Block ingestion until the configured date. The time should be in RFC3339

--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -3650,9 +3650,10 @@ otlp_config:
   # drop them altogether
   [log_attributes: <list of attributes_configs>]
 
-# Block ingestion for policy until the configured date. The time should be in
-# RFC3339 format. The policy is based on the policy_stream_mapping
-# configuration.
+# Block ingestion for policy until the configured date. The policy '*' is the
+# global policy, which is applied to all streams and can be overridden by other
+# policies. The time should be in RFC3339 format. The policy is based on the
+# policy_stream_mapping configuration.
 [block_ingestion_policy_until: <map of string to Time>]
 
 # Block ingestion until the configured date. The time should be in RFC3339
@@ -3672,7 +3673,8 @@ otlp_config:
 # CLI flag: -validation.enforced-labels
 [enforced_labels: <list of strings> | default = []]
 
-# Map of policies to enforced labels. Example:
+# Map of policies to enforced labels. The policy '*' is the global policy, which
+# is applied to all streams and can be extended by other policies. Example:
 #  policy_enforced_labels: 
 #   policy1: 
 #     - label1 
@@ -3680,6 +3682,8 @@ otlp_config:
 #   policy2: 
 #     - label3 
 #     - label4
+#   '*':
+#     - label5
 [policy_enforced_labels: <map of string to list of strings>]
 
 # Map of policies to stream selectors with a priority. Experimental.  Example:

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -776,16 +776,16 @@ func (d *Distributor) Push(ctx context.Context, req *logproto.PushRequest) (*log
 // It also returns the first label that is missing if any (for the case of multiple labels missing).
 func (d *Distributor) missingEnforcedLabels(lbs labels.Labels, tenantID string, policy string) (bool, []string) {
 	perPolicyEnforcedLabels := d.validator.Limits.PolicyEnforcedLabels(tenantID, policy)
-	globalEnforcedLabels := d.validator.Limits.EnforcedLabels(tenantID)
+	tenantEnforcedLabels := d.validator.Limits.EnforcedLabels(tenantID)
 
-	requiredLbs := append(globalEnforcedLabels, perPolicyEnforcedLabels...)
+	requiredLbs := append(tenantEnforcedLabels, perPolicyEnforcedLabels...)
 	if len(requiredLbs) == 0 {
 		// no enforced labels configured.
 		return false, []string{}
 	}
 
 	// Use a map to deduplicate the required labels. Duplicates may happen if the same label is configured
-	// in both global and per-policy enforced labels.
+	// in both the per-tenant and per-policy enforced labels.
 	seen := make(map[string]struct{})
 	missingLbs := []string{}
 

--- a/pkg/distributor/validator_test.go
+++ b/pkg/distributor/validator_test.go
@@ -264,8 +264,8 @@ func TestShouldBlockIngestion(t *testing.T) {
 				&validation.Limits{
 					BlockIngestionUntil: flagext.Time(testTime.Add(time.Hour)),
 					BlockIngestionPolicyUntil: map[string]flagext.Time{
-						validation.GlobalPolicy: flagext.Time(testTime.Add(time.Hour)),
-						"policy1":               flagext.Time(testTime.Add(time.Hour)),
+						validation.GlobalPolicy: flagext.Time(testTime.Add(-2 * time.Hour)),
+						"policy1":               flagext.Time(testTime.Add(-time.Hour)),
 					},
 					BlockIngestionStatusCode: 1234,
 				},
@@ -280,9 +280,9 @@ func TestShouldBlockIngestion(t *testing.T) {
 			policy: "policy1",
 			overrides: fakeLimits{
 				&validation.Limits{
-					BlockIngestionUntil: flagext.Time(testTime.Add(-time.Hour)), // Not active anymore
+					BlockIngestionUntil: flagext.Time(testTime.Add(-2 * time.Hour)), // Not active anymore
 					BlockIngestionPolicyUntil: map[string]flagext.Time{
-						validation.GlobalPolicy: flagext.Time(testTime.Add(time.Hour)),
+						validation.GlobalPolicy: flagext.Time(testTime.Add(-time.Hour)),
 						"policy1":               flagext.Time(testTime.Add(time.Hour)),
 					},
 					BlockIngestionStatusCode: 1234,

--- a/pkg/validation/ingestion_policies.go
+++ b/pkg/validation/ingestion_policies.go
@@ -9,6 +9,10 @@ import (
 	"github.com/grafana/loki/v3/pkg/logql/syntax"
 )
 
+const (
+	GlobalPolicy = "*"
+)
+
 type PriorityStream struct {
 	Priority int               `yaml:"priority" json:"priority" doc:"description=The larger the value, the higher the priority."`
 	Selector string            `yaml:"selector" json:"selector" doc:"description=Stream selector expression."`

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -227,11 +227,11 @@ type Limits struct {
 	OTLPConfig                        push.OTLPConfig       `yaml:"otlp_config" json:"otlp_config" doc:"description=OTLP log ingestion configurations"`
 	GlobalOTLPConfig                  push.GlobalOTLPConfig `yaml:"-" json:"-"`
 
-	BlockIngestionPolicyUntil map[string]dskit_flagext.Time `yaml:"block_ingestion_policy_until" json:"block_ingestion_policy_until" category:"experimental" doc:"description=Block ingestion for policy until the configured date. The time should be in RFC3339 format. The policy is based on the policy_stream_mapping configuration."`
+	BlockIngestionPolicyUntil map[string]dskit_flagext.Time `yaml:"block_ingestion_policy_until" json:"block_ingestion_policy_until" category:"experimental" doc:"description=Block ingestion for policy until the configured date. The policy '*' is the global policy, which is applied to all streams and can be overridden by other policies. The time should be in RFC3339 format. The policy is based on the policy_stream_mapping configuration."`
 	BlockIngestionUntil       dskit_flagext.Time            `yaml:"block_ingestion_until" json:"block_ingestion_until" category:"experimental"`
 	BlockIngestionStatusCode  int                           `yaml:"block_ingestion_status_code" json:"block_ingestion_status_code"`
 	EnforcedLabels            []string                      `yaml:"enforced_labels" json:"enforced_labels" category:"experimental"`
-	PolicyEnforcedLabels      map[string][]string           `yaml:"policy_enforced_labels" json:"policy_enforced_labels" category:"experimental" doc:"description=Map of policies to enforced labels. Example:\n policy_enforced_labels: \n  policy1: \n    - label1 \n    - label2 \n  policy2: \n    - label3 \n    - label4"`
+	PolicyEnforcedLabels      map[string][]string           `yaml:"policy_enforced_labels" json:"policy_enforced_labels" category:"experimental" doc:"description=Map of policies to enforced labels. The policy '*' is the global policy, which is applied to all streams and can be extended by other policies. Example:\n policy_enforced_labels: \n  policy1: \n    - label1 \n    - label2 \n  policy2: \n    - label3 \n    - label4\n  '*':\n    - label5"`
 	PolicyStreamMapping       PolicyStreamMapping           `yaml:"policy_stream_mapping" json:"policy_stream_mapping" category:"experimental" doc:"description=Map of policies to stream selectors with a priority. Experimental.  Example:\n policy_stream_mapping: \n  finance: \n    - selector: '{namespace=\"prod\", container=\"billing\"}' \n      priority: 2 \n  ops: \n    - selector: '{namespace=\"prod\", container=\"ops\"}' \n      priority: 1 \n  staging: \n    - selector: '{namespace=\"staging\"}' \n      priority: 1"`
 
 	IngestionPartitionsTenantShardSize int `yaml:"ingestion_partitions_tenant_shard_size" json:"ingestion_partitions_tenant_shard_size" category:"experimental"`
@@ -1117,15 +1117,19 @@ func (o *Overrides) BlockIngestionStatusCode(userID string) int {
 	return o.getOverridesForUser(userID).BlockIngestionStatusCode
 }
 
+// BlockIngestionPolicyUntil returns the time until the ingestion policy is blocked for a given user.
+// Order of priority is: global policy block > Per-tenant block
 func (o *Overrides) BlockIngestionPolicyUntil(userID string, policy string) time.Time {
 	limits := o.getOverridesForUser(userID)
-	if limits == nil || limits.BlockIngestionPolicyUntil == nil {
-		return time.Time{} // Zero time means no blocking
+
+	if forPolicy, ok := limits.BlockIngestionPolicyUntil[policy]; ok {
+		return time.Time(forPolicy)
 	}
 
-	if blockUntil, ok := limits.BlockIngestionPolicyUntil[policy]; ok {
-		return time.Time(blockUntil)
+	if forPolicy, ok := limits.BlockIngestionPolicyUntil[GlobalPolicy]; ok {
+		return time.Time(forPolicy)
 	}
+
 	return time.Time{} // Zero time means no blocking
 }
 
@@ -1133,8 +1137,11 @@ func (o *Overrides) EnforcedLabels(userID string) []string {
 	return o.getOverridesForUser(userID).EnforcedLabels
 }
 
+// PolicyEnforcedLabels returns the labels enforced by the policy for a given user.
+// The output is the union of the global and policy specific labels.
 func (o *Overrides) PolicyEnforcedLabels(userID string, policy string) []string {
-	return o.getOverridesForUser(userID).PolicyEnforcedLabels[policy]
+	limits := o.getOverridesForUser(userID)
+	return append(limits.PolicyEnforcedLabels[GlobalPolicy], limits.PolicyEnforcedLabels[policy]...)
 }
 
 func (o *Overrides) PoliciesStreamMapping(userID string) PolicyStreamMapping {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR implements global policies that are applied to all streams (regardless of their stream<>policy mappings).
- For enforced labels: the global policy labels is appended to the named policy label if the stream matches a named policy. Otherwise only the global policy labels will be enforced if any.
- For blocked ingestion: 
   - If the mapped policy is empty, the global policy block is applied (if exists).
   - If the mapped policy is not empty, the stream will be blocked only if there is a matching named policy block

E.g. If we have
```yaml
block_ingestion_policy_until:
   "*": <eod>
   policy1: <eod>
```

- stream not matching any policy --> will be blocked due to global policy
- stream matching policy1 --> will be blocked due to policy1 policy
- stream matching policy2 --> **won't** be blocked since there is no block entry for policy2

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
