### PR TITLE
fix(ingest-limits): Consistent lock ordering

### DIFF
--- a/pkg/limits/ingest_limits.go
+++ b/pkg/limits/ingest_limits.go
@@ -208,10 +208,10 @@ func (s *IngestLimits) Describe(descs chan<- *prometheus.Desc) {
 }
 
 func (s *IngestLimits) Collect(m chan<- prometheus.Metric) {
-	s.mtx.RLock()
-	defer s.mtx.RUnlock()
 	s.mtxAssingedPartitions.RLock()
 	defer s.mtxAssingedPartitions.RUnlock()
+	s.mtx.RLock()
+	defer s.mtx.RUnlock()
 
 	cutoff := time.Now().Add(-s.cfg.WindowSize).UnixNano()
 
@@ -435,11 +435,10 @@ func (s *IngestLimits) evictOldStreams(ctx context.Context) {
 // updateMetadata updates the metadata map with the provided StreamMetadata.
 // It uses the provided lastSeenAt timestamp as the last seen time.
 func (s *IngestLimits) updateMetadata(rec *logproto.StreamMetadata, tenant string, partition int32, lastSeenAt time.Time) {
-	s.mtx.Lock()
-	defer s.mtx.Unlock()
-
 	s.mtxAssingedPartitions.RLock()
 	defer s.mtxAssingedPartitions.RUnlock()
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
 
 	// Initialize tenant map if it doesn't exist
 	if _, ok := s.metadata[tenant]; !ok {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the lock ordering across all internal functions to be consistent so that inconsistent views are avoided. In detail all lock ordering follows the `removePartitions` method.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
