### PR TITLE
test: fix flaky multi extractor

### DIFF
--- a/pkg/chunkenc/memchunk_test.go
+++ b/pkg/chunkenc/memchunk_test.go
@@ -248,25 +248,54 @@ func TestBlock(t *testing.T) {
 				require.NoError(t, sampleIt.Close())
 				require.Equal(t, len(cases), idx)
 				t.Run("multi-extractor", func(t *testing.T) {
-					t.Skip("TODO(trevor): fix this")
-					extractors := []log.StreamSampleExtractor{countExtractor, bytesExtractor}
+					// Wrap extractors in variant extractors so they get a variant index we can use later for differentiating counts and bytes
+					extractors := []log.StreamSampleExtractor{
+						log.NewVariantsStreamSampleExtractorWrapper(0, countExtractor),
+						log.NewVariantsStreamSampleExtractorWrapper(1, bytesExtractor),
+					}
 					sampleIt = chk.SampleIterator(context.Background(), time.Unix(0, 0), time.Unix(0, math.MaxInt64), extractors...)
 					idx = 0
+
+					// variadic arguments can't guarantee order, so we're going to store the expected and actual values
+					// and do an ElementsMatch on them.
+					var actualCounts = make([]float64, 0, len(cases))
+					var actualBytes = make([]float64, 0, len(cases))
+
+					var expectedCounts = make([]float64, 0, len(cases))
+					var expectedBytes = make([]float64, 0, len(cases))
+					for _, c := range cases {
+						expectedCounts = append(expectedCounts, 1.)
+						expectedBytes = append(expectedBytes, c.bytes)
+					}
 
 					// 2 extractors, expect 2 samples per original timestamp
 					for sampleIt.Next() {
 						s := sampleIt.At()
 						require.Equal(t, cases[idx].ts, s.Timestamp)
-						require.Equal(t, 1., s.Value)
 						require.NotEmpty(t, s.Hash)
+						lbls := sampleIt.Labels()
+						if strings.Contains(lbls, `__variant__="0"`) {
+							actualCounts = append(actualCounts, s.Value)
+						} else {
+							actualBytes = append(actualBytes, s.Value)
+						}
 
 						require.True(t, sampleIt.Next())
 						s = sampleIt.At()
 						require.Equal(t, cases[idx].ts, s.Timestamp)
-						require.Equal(t, cases[idx].bytes, s.Value)
 						require.NotEmpty(t, s.Hash)
+						lbls = sampleIt.Labels()
+						if strings.Contains(lbls, `__variant__="0"`) {
+							actualCounts = append(actualCounts, s.Value)
+						} else {
+							actualBytes = append(actualBytes, s.Value)
+						}
+
 						idx++
 					}
+
+					require.ElementsMatch(t, expectedCounts, actualCounts)
+					require.ElementsMatch(t, expectedBytes, actualBytes)
 
 					require.NoError(t, sampleIt.Err())
 					require.NoError(t, sampleIt.Close())


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the flaky test skipped in https://github.com/grafana/loki/pull/16474

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [X] Documentation added
- [X] Tests updated
- [X] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [X] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [X] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
