### PR TITLE
chore(dataobj): backfill sparse rows using EncodeN

### DIFF
--- a/pkg/dataobj/internal/dataset/column_builder.go
+++ b/pkg/dataobj/internal/dataset/column_builder.go
@@ -149,11 +149,8 @@ func (cb *ColumnBuilder) Backfill(row int) {
 }
 
 func (cb *ColumnBuilder) backfill(row int) bool {
-	for row > cb.rows {
-		if !cb.pageBuilder.AppendNull() {
-			return false
-		}
-		cb.rows++
+	if row > cb.rows {
+		return cb.pageBuilder.AppendNulls(uint64(row - cb.rows))
 	}
 
 	return true

--- a/pkg/dataobj/internal/dataset/column_builder.go
+++ b/pkg/dataobj/internal/dataset/column_builder.go
@@ -150,7 +150,10 @@ func (cb *ColumnBuilder) Backfill(row int) {
 
 func (cb *ColumnBuilder) backfill(row int) bool {
 	if row > cb.rows {
-		return cb.pageBuilder.AppendNulls(uint64(row - cb.rows))
+		if !cb.pageBuilder.AppendNulls(uint64(row - cb.rows)) {
+			return false
+		}
+		cb.rows = row
 	}
 
 	return true

--- a/pkg/dataobj/internal/dataset/page_builder.go
+++ b/pkg/dataobj/internal/dataset/page_builder.go
@@ -145,7 +145,7 @@ func (b *pageBuilder) AppendNulls(count uint64) bool {
 	//
 	// For N nulls:
 	// - RLE: 2-9 bytes total (1-8 byte header + 1 byte value)
-	// - Bitpacking: ~1 byte per 8 nulls + 2-8 byte header
+	// - Bitpacking: 3-9 bytes total (2-8 byte header + 1 byte per 8 nulls)
 	//
 	// Using 4 bytes as a conservative average estimate.
 	if sz := b.EstimatedSize(); sz > 0 && sz+10 > b.opts.PageSizeHint {

--- a/pkg/dataobj/internal/dataset/page_builder.go
+++ b/pkg/dataobj/internal/dataset/page_builder.go
@@ -150,7 +150,7 @@ func (b *pageBuilder) AppendNulls(n uint64) bool {
 	// - Bitpacking: 3-9 bytes total (2-8 byte header + 1 byte per 8 nulls)
 	//
 	// Using 4 bytes as a conservative average estimate.
-	if sz := b.EstimatedSize(); sz > 0 && sz+10 > b.opts.PageSizeHint {
+	if sz := b.EstimatedSize(); sz > 0 && sz+4 > b.opts.PageSizeHint {
 		return false
 	}
 

--- a/pkg/dataobj/internal/dataset/page_builder.go
+++ b/pkg/dataobj/internal/dataset/page_builder.go
@@ -140,7 +140,9 @@ func (b *pageBuilder) AppendNull() bool {
 	return true
 }
 
-func (b *pageBuilder) AppendNulls(count uint64) bool {
+// AppendNulls appends n NULL values to the Builder. AppendNulls returns true if
+// the NULLs were appended, or false if the Builder is full.
+func (b *pageBuilder) AppendNulls(n uint64) bool {
 	// This is tricky to estimate without knowing the encoder state.
 	//
 	// For N nulls:
@@ -152,11 +154,11 @@ func (b *pageBuilder) AppendNulls(count uint64) bool {
 		return false
 	}
 
-	if err := b.presenceEnc.EncodeN(Uint64Value(0), uint64(count)); err != nil {
+	if err := b.presenceEnc.EncodeN(Uint64Value(0), uint64(n)); err != nil {
 		panic(fmt.Sprintf("Builder.AppendNulls: encoding presence bitmap entries: %v", err))
 	}
 
-	b.rows += int(count)
+	b.rows += int(n)
 	return true
 }
 

--- a/pkg/dataobj/internal/dataset/page_builder.go
+++ b/pkg/dataobj/internal/dataset/page_builder.go
@@ -154,7 +154,7 @@ func (b *pageBuilder) AppendNulls(n uint64) bool {
 		return false
 	}
 
-	if err := b.presenceEnc.EncodeN(Uint64Value(0), uint64(n)); err != nil {
+	if err := b.presenceEnc.EncodeN(Uint64Value(0), n); err != nil {
 		panic(fmt.Sprintf("Builder.AppendNulls: encoding presence bitmap entries: %v", err))
 	}
 

--- a/pkg/dataobj/internal/dataset/value_encoding_bitmap.go
+++ b/pkg/dataobj/internal/dataset/value_encoding_bitmap.go
@@ -145,13 +145,7 @@ func (enc *bitmapEncoder) Encode(v Value) error {
 	case enc.runLength > 0 && uv != enc.runValue: // RLE with different value; the run ended.
 		// If the run lasted less than 8 values, we switch to the BITPACK state.
 		if enc.runLength < 8 {
-			// Copy over the existing run to the set and then add the new value.
-			enc.setSize = byte(enc.runLength)
-			for i := byte(0); i < enc.setSize; i++ {
-				enc.set[i] = enc.runValue
-			}
-
-			enc.runLength = 0
+			enc.switchToBitpack()
 			enc.set[enc.setSize] = uv
 			enc.setSize++
 
@@ -182,6 +176,78 @@ func (enc *bitmapEncoder) Encode(v Value) error {
 	default:
 		panic("dataset.bitmapEncoder: invalid state")
 	}
+}
+
+func (enc *bitmapEncoder) EncodeN(v Value, count uint64) error {
+	if v.Type() != datasetmd.VALUE_TYPE_UINT64 {
+		return fmt.Errorf("invalid value type %s", v.Type())
+	}
+	uv := v.Uint64()
+
+	switch {
+	case enc.runLength == 0 && enc.setSize == 0: // Ready; start a new run.
+		enc.runValue = uv
+		fallthrough
+	case enc.runLength > 0 && uv == enc.runValue: // RLE with matching value; continue the run.
+		if enc.runLength+count >= maxRunLength {
+			count -= (maxRunLength - enc.runLength) // remaining count
+			enc.runLength = maxRunLength
+			if err := enc.flushRLE(); err != nil {
+				return err
+			}
+
+			if count > 0 {
+				return enc.EncodeN(v, count)
+			}
+		} else {
+			enc.runLength += count
+		}
+
+		return nil
+
+	case enc.runLength > 0 && uv != enc.runValue: // RLE with different value; the run ended.
+		if enc.runLength >= 8 {
+			if err := enc.flushRLE(); err != nil {
+				return err
+			}
+
+			return enc.EncodeN(v, count)
+		}
+
+		enc.switchToBitpack()
+		fallthrough
+	case enc.setSize > 0:
+		// Fill up remaining slots with the new value
+		for count > 0 && enc.setSize < 8 {
+			enc.set[enc.setSize] = uv
+			enc.setSize++
+			count--
+		}
+
+		if enc.setSize == 8 {
+			if err := enc.flushBitpacked(); err != nil {
+				return err
+			}
+		}
+
+		if count > 0 {
+			return enc.EncodeN(v, count)
+		}
+
+		return nil
+	default:
+		panic("dataset.bitmapEncoder: invalid state")
+	}
+}
+
+func (enc *bitmapEncoder) switchToBitpack() {
+	// Copy over the existing run to the set and then add the new value.
+	enc.setSize = byte(enc.runLength)
+	for i := byte(0); i < enc.setSize; i++ {
+		enc.set[i] = enc.runValue
+	}
+
+	enc.runLength = 0
 }
 
 // Flush writes any remaining values to the underlying [streamio.Writer].

--- a/pkg/dataobj/internal/dataset/value_encoding_bitmap_test.go
+++ b/pkg/dataobj/internal/dataset/value_encoding_bitmap_test.go
@@ -85,13 +85,15 @@ func Test_bitmap_encodeN(t *testing.T) {
 	for i := range 100 {
 		require.Equal(t, uint64(2), actual[i].Uint64())
 	}
+	actual = actual[100:]
 
 	for i := range 5 {
-		require.Equal(t, uint64(3), actual[i+100].Uint64())
+		require.Equal(t, uint64(3), actual[i].Uint64())
 	}
+	actual = actual[5:]
 
 	for i := range 2 {
-		require.Equal(t, uint64(4), actual[i+100+5].Uint64())
+		require.Equal(t, uint64(4), actual[i].Uint64())
 	}
 }
 

--- a/pkg/dataobj/internal/dataset/value_encoding_bitmap_test.go
+++ b/pkg/dataobj/internal/dataset/value_encoding_bitmap_test.go
@@ -3,6 +3,7 @@ package dataset
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"io"
 	"math"
 	"math/rand"
@@ -15,28 +16,82 @@ func Test_bitmap(t *testing.T) {
 	var buf bytes.Buffer
 
 	var (
-		enc    = newBitmapEncoder(&buf)
-		dec    = newBitmapDecoder(&buf)
-		decBuf = make([]Value, batchSize)
+		enc = newBitmapEncoder(&buf)
+		dec = newBitmapDecoder(&buf)
 	)
 
 	count := 1500
-	for i := 0; i < count; i++ {
+	for range count {
 		require.NoError(t, enc.Encode(Uint64Value(uint64(1))))
 	}
 	require.NoError(t, enc.Flush())
 
 	t.Logf("Buffer size: %d", buf.Len())
 
-	for {
-		n, err := dec.Decode(decBuf[:batchSize])
-		if errors.Is(err, io.EOF) {
-			break
-		}
-		require.NoError(t, err)
-		for _, v := range decBuf[:n] {
-			require.Equal(t, uint64(1), v.Uint64())
-		}
+	actual, err := decodeValues(dec)
+	require.NoError(t, err)
+	require.Len(t, actual, count)
+	for i := range count {
+		require.Equal(t, uint64(1), actual[i].Uint64())
+	}
+}
+
+func Test_bitmap_encodeN(t *testing.T) {
+	var buf bytes.Buffer
+
+	var (
+		enc = newBitmapEncoder(&buf)
+		dec = newBitmapDecoder(&buf)
+	)
+
+	count := 1500
+	require.NoError(t, enc.EncodeN(Uint64Value(1), uint64(count)))
+	require.NoError(t, enc.Flush())
+
+	t.Logf("Buffer size: %d", buf.Len())
+
+	actual, err := decodeValues(dec)
+	require.NoError(t, err)
+	require.Len(t, actual, count)
+	for i := range count {
+		require.Equal(t, uint64(1), actual[i].Uint64())
+	}
+
+	buf.Reset()
+	enc.Reset(&buf)
+	dec.Reset(&buf)
+
+	require.NoError(t, enc.Encode(Uint64Value(2)))      // start a new RLE run
+	require.NoError(t, enc.EncodeN(Uint64Value(2), 99)) // append to the run
+
+	require.Equal(t, enc.runLength, uint64(100))
+	require.Equal(t, enc.runValue, uint64(2))
+
+	require.NoError(t, enc.EncodeN(Uint64Value(3), 5)) // flush and start a new RLE run
+	require.Equal(t, enc.runLength, uint64(5))
+	require.Equal(t, enc.runValue, uint64(3))
+
+	require.NoError(t, enc.EncodeN(Uint64Value(4), 2)) // switch to bitpacking
+	require.Equal(t, enc.setSize, byte(7))
+
+	require.NoError(t, enc.Flush())
+
+	t.Logf("Buffer size: %d", buf.Len())
+
+	actual, err = decodeValues(dec)
+	require.NoError(t, err)
+	require.Len(t, actual, 100+5+2)
+
+	for i := range 100 {
+		require.Equal(t, uint64(2), actual[i].Uint64())
+	}
+
+	for i := range 5 {
+		require.Equal(t, uint64(3), actual[i+100].Uint64())
+	}
+
+	for i := range 2 {
+		require.Equal(t, uint64(4), actual[i+100+5].Uint64())
 	}
 }
 
@@ -119,13 +174,12 @@ func Fuzz_bitmap(f *testing.F) {
 		var buf bytes.Buffer
 
 		var (
-			enc    = newBitmapEncoder(&buf)
-			dec    = newBitmapDecoder(&buf)
-			decBuf = make([]Value, batchSize)
+			enc = newBitmapEncoder(&buf)
+			dec = newBitmapDecoder(&buf)
 		)
 
 		var numbers []uint64
-		for i := 0; i < count; i++ {
+		for range count {
 			var mask uint64 = math.MaxUint64
 			if width < 64 {
 				mask = (1 << width) - 1
@@ -137,19 +191,55 @@ func Fuzz_bitmap(f *testing.F) {
 		}
 		require.NoError(t, enc.Flush())
 
-		var actual []uint64
-		for {
-			n, err := dec.Decode(decBuf[:batchSize])
-			if errors.Is(err, io.EOF) {
-				break
-			}
-			require.NoError(t, err)
-			for _, v := range decBuf[:n] {
-				actual = append(actual, v.Uint64())
-			}
+		actual, err := decodeValues(dec)
+		require.NoError(t, err)
+		require.Len(t, actual, count)
+		for i := range count {
+			require.Equal(t, numbers[i], actual[i].Uint64())
+		}
+	})
+}
+
+func Fuzz_bitmap_EncodeN(f *testing.F) {
+	f.Add(int64(775972800), 1000, 10)
+	f.Add(int64(758350800), 500, 25)
+	f.Add(int64(1734130411), 10000, 1000)
+
+	f.Fuzz(func(t *testing.T, seed int64, count int, distinct int) {
+		if count < 1 {
+			t.Skip()
+		} else if distinct < 1 || distinct*10 > count {
+			// atmost 10% of the values can be distinct
+			t.Skip()
 		}
 
-		require.Equal(t, numbers, actual)
+		var (
+			buf     bytes.Buffer
+			numbers []uint64
+
+			rnd = rand.New(rand.NewSource(seed))
+			enc = newBitmapEncoder(&buf)
+			dec = newBitmapDecoder(&buf)
+		)
+
+		for range count {
+			v := uint64(0)
+			// randomly add distinct values
+			if rnd.Intn(count) < distinct {
+				v = uint64(rnd.Int63()) + 1 // non-zero
+			}
+
+			numbers = append(numbers, v)
+			require.NoError(t, enc.Encode(Uint64Value(v)))
+		}
+		require.NoError(t, enc.Flush())
+
+		actual, err := decodeValues(dec)
+		require.NoError(t, err)
+		require.Len(t, actual, count)
+		for i := range count {
+			require.Equal(t, numbers[i], actual[i].Uint64())
+		}
 	})
 }
 
@@ -275,6 +365,39 @@ func benchmarkBitmapDecoder(b *testing.B, width int) {
 	})
 }
 
+func Benchmark_bitmap_EncodeN(b *testing.B) {
+	// Test different run lengths
+	runLengths := []int{1000, 10000, 100000, 1000000}
+
+	for _, runLength := range runLengths {
+		// Test Encode (repeated calls)
+		b.Run(fmt.Sprintf("Encode_%d_times", runLength), func(b *testing.B) {
+			var cw countingWriter
+			enc := newBitmapEncoder(&cw)
+
+			for i := 0; i < b.N; i++ {
+				// Encode the same value multiple times
+				for j := 0; j < runLength; j++ {
+					_ = enc.Encode(Uint64Value(42))
+				}
+				_ = enc.Flush()
+			}
+		})
+
+		// Test EncodeN (single call)
+		b.Run(fmt.Sprintf("EncodeN_%d_times", runLength), func(b *testing.B) {
+			var cw countingWriter
+			enc := newBitmapEncoder(&cw)
+
+			for i := 0; i < b.N; i++ {
+				// Encode the same value once with count
+				_ = enc.EncodeN(Uint64Value(42), uint64(runLength))
+				_ = enc.Flush()
+			}
+		})
+	}
+}
+
 type countingWriter struct {
 	n int64
 }
@@ -288,4 +411,24 @@ func (w *countingWriter) Write(p []byte) (n int, err error) {
 func (w *countingWriter) WriteByte(_ byte) error {
 	w.n++
 	return nil
+}
+
+func decodeValues(dec *bitmapDecoder) ([]Value, error) {
+	var (
+		all    []Value
+		decBuf = make([]Value, batchSize)
+	)
+
+	for {
+		n, err := dec.Decode(decBuf[:batchSize])
+		if n > 0 {
+			all = append(all, decBuf[:n]...)
+		}
+
+		if errors.Is(err, io.EOF) {
+			return all, nil
+		} else if err != nil {
+			return all, err
+		}
+	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

We currently backfill old rows with nulls if they have no value for a given column. We do this by calling `Encode(value)` N times, but for sparse columns we have to iterate over very large numbers to perform the backfill. This PR adds `EncodeN(value, n)` method to bitmapEncoder to allow appending a value N times - this runs in constant time unlike the existing approach which takes O(n)

```
goos: darwin
goarch: arm64
pkg: github.com/grafana/loki/v3/pkg/dataobj/internal/dataset
cpu: Apple M1 Pro
Benchmark_bitmap_EncodeN/Encode_1000_times-8              227778              5262 ns/op
Benchmark_bitmap_EncodeN/EncodeN_1000_times-8           83439080                14.29 ns/op
Benchmark_bitmap_EncodeN/Encode_10000_times-8              22904             52238 ns/op
Benchmark_bitmap_EncodeN/EncodeN_10000_times-8          74150934                16.06 ns/op
Benchmark_bitmap_EncodeN/Encode_100000_times-8              2307            526224 ns/op
Benchmark_bitmap_EncodeN/EncodeN_100000_times-8         72333274                16.34 ns/op
Benchmark_bitmap_EncodeN/Encode_1000000_times-8              226           5229343 ns/op
Benchmark_bitmap_EncodeN/EncodeN_1000000_times-8        77011526                15.92 ns/op
PASS
```

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
