### PR TITLE
chore: reduce ingest_limits.go to single mutex

### DIFF
--- a/pkg/limits/ingest_limits.go
+++ b/pkg/limits/ingest_limits.go
@@ -210,8 +210,6 @@ func (s *IngestLimits) Describe(descs chan<- *prometheus.Desc) {
 }
 
 func (s *IngestLimits) Collect(m chan<- prometheus.Metric) {
-	s.mtxAssingedPartitions.RLock()
-	defer s.mtxAssingedPartitions.RUnlock()
 	s.mtx.RLock()
 	defer s.mtx.RUnlock()
 
@@ -244,8 +242,8 @@ func (s *IngestLimits) Collect(m chan<- prometheus.Metric) {
 }
 
 func (s *IngestLimits) onPartitionsAssigned(_ context.Context, _ *kgo.Client, partitions map[string][]int32) {
-	s.mtxAssingedPartitions.Lock()
-	defer s.mtxAssingedPartitions.Unlock()
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
 
 	if s.assingedPartitions == nil {
 		s.assingedPartitions = make(map[int32]int64)
@@ -273,9 +271,6 @@ func (s *IngestLimits) onPartitionsLost(_ context.Context, _ *kgo.Client, partit
 }
 
 func (s *IngestLimits) removePartitions(partitions map[string][]int32) {
-	s.mtxAssingedPartitions.Lock()
-	defer s.mtxAssingedPartitions.Unlock()
-
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
 
@@ -437,8 +432,6 @@ func (s *IngestLimits) evictOldStreams(ctx context.Context) {
 // updateMetadata updates the metadata map with the provided StreamMetadata.
 // It uses the provided lastSeenAt timestamp as the last seen time.
 func (s *IngestLimits) updateMetadata(rec *logproto.StreamMetadata, tenant string, partition int32, lastSeenAt time.Time) {
-	s.mtxAssingedPartitions.RLock()
-	defer s.mtxAssingedPartitions.RUnlock()
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request reduces `ingest_limits.go` to a single mutex `mtx`. We don't think we need separate mutexes at this time. We can explore this again at a later time if we find this causes contention.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
