### PR TITLE
fix(operator): Select non-zero delete worker count for all sizes

### DIFF
--- a/operator/internal/manifests/config.go
+++ b/operator/internal/manifests/config.go
@@ -367,11 +367,13 @@ func remoteWriteConfig(s *lokiv1.RemoteWriteSpec, rs *RulerSecret) *config.Remot
 	return c
 }
 
-var deleteWorkerCountMap = map[lokiv1.LokiStackSizeType]uint{
-	lokiv1.SizeOneXDemo:       10,
-	lokiv1.SizeOneXExtraSmall: 10,
-	lokiv1.SizeOneXSmall:      150,
-	lokiv1.SizeOneXMedium:     150,
+func deleteWorkerCount(size lokiv1.LokiStackSizeType) uint {
+	switch size {
+	case lokiv1.SizeOneXSmall, lokiv1.SizeOneXMedium:
+		return 150
+	default:
+		return 10
+	}
 }
 
 func retentionConfig(ls *lokiv1.LokiStackSpec) config.RetentionOptions {
@@ -394,7 +396,7 @@ func retentionConfig(ls *lokiv1.LokiStackSpec) config.RetentionOptions {
 
 	return config.RetentionOptions{
 		Enabled:           true,
-		DeleteWorkerCount: deleteWorkerCountMap[ls.Size],
+		DeleteWorkerCount: deleteWorkerCount(ls.Size),
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This change restructures the code used to select the amount of delete workers in the operator-generated configuration, so that there is always a non-zero number of workers.

**Which issue(s) this PR fixes**:

Fixes #16466 / [LOG-6781](https://issues.redhat.com/browse/LOG-6781)

**Special notes for your reviewer**:

- [ ] Still a draft until we have decided into which release this goes

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
