### PR TITLE
feat: parameterise the IAMRoleName  for lambda-promtail CloudFormation template-eventbridge

### DIFF
--- a/tools/lambda-promtail/template-eventbridge.yaml
+++ b/tools/lambda-promtail/template-eventbridge.yaml
@@ -55,6 +55,10 @@ Parameters:
     Description: The S3 bucket to listen event notifications from.
     Type: String
     Default: ""
+  IAMRoleName:
+    Description: Name of the LambdaPromtailRole IAM Role.
+    Type: String
+    Default: "iam_for_lambda"
 
 Resources:
   LambdaPromtailRole:
@@ -89,7 +93,7 @@ Resources:
                 Action:
                   - s3:GetObject
                 Resource: !Sub 'arn:aws:s3:::${EventSourceS3Bucket}/*'
-      RoleName: iam_for_lambda
+      RoleName: !Ref IAMRoleName
   LambdaPromtailFunction:
     Type: AWS::Lambda::Function
     Properties:


### PR DESCRIPTION
**What this PR does / why we need it**:
In our project, when attempting to create multiple lambda-promtail instances using tools/lambda-promtail/template-eventbridge.yaml, we encountered an issue with duplicate IAM role names. This modification is necessary to resolve that problem.

**Which issue(s) this PR fixes**:
Adds a parameter to specify the IAMRoleName in the lambda-promtail template-eventbridge template.

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
