### PR TITLE
chore: add CLAUDE.md with development guide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,35 @@
+# Loki Development Guide
+
+## Build & Test Commands
+```bash
+make all                      # build all binaries
+make loki                     # build loki only
+make logcli                   # build logcli only
+make test                     # run all unit tests
+make test-integration         # run integration tests
+go test ./...                 # run all tests with Go directly
+go test -v ./pkg/logql/...    # run tests in specific package
+go test -run TestName ./pkg/path  # run a specific test
+make lint                     # run all linters
+make format                   # format code (gofmt and goimports)
+```
+
+## Code Style Guidelines
+- Follow standard Go formatting (gofmt/goimports)
+- Import order: standard lib, external packages, then Loki packages
+- Error handling: Always check errors with `if err != nil { return ... }`
+- Use structured logging with leveled logging (go-kit/log)
+- Use CamelCase for exported identifiers, camelCase for non-exported 
+- Document all exported functions, types, and variables
+- Use table-driven tests when appropriate
+- Follow Conventional Commits format: `<change type>: Your change`
+- For frontend: use TypeScript, functional components, component composition
+- Frontend naming: lowercase with dashes for directories (components/auth-wizard)
+
+## Documentation Standards
+- Follow the Grafana [Writers' Toolkit](https://grafana.com/docs/writers-toolkit/) Style Guide
+- Use CommonMark flavor of markdown for documentation
+- Create LIDs (Loki Improvement Documents) for large functionality changes
+- Document upgrading steps in `docs/sources/setup/upgrade/_index.md`
+- Preview docs locally with `make docs` from the `/docs` directory
+- Include examples and clear descriptions for public APIs


### PR DESCRIPTION
**What this PR does / why we need it**:

This adds a CLAUDE.md file with build commands, code style guidelines, and documentation standards for agentic tools working with the Loki codebase. This is similar to `.cursor/rules` but is what is used by the `claude-code` tool. Obviously there could be an endless list of these types of files, but I would argue we add this in addition to cursor rules and stop there, with my reasoning being both cursor and claude-code use the claude API (so we're standardizing on a single LLM), but one is an IDE while the other can be used from the command line.

I'm also fine with push back here if we want to remove all these types of rules files and just keep them locally and gitignored for whatever tool we're using.

🤖 Generated with Claude Code
Co-Authored-By: Claude <noreply@anthropic.com>

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [X] Documentation added
- [X] Tests updated
- [X] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [X] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [X] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
