### PR TITLE
feat(helm): add image registry value for memcached and memcached-exporter

### DIFF
--- a/docs/sources/setup/install/helm/reference.md
+++ b/docs/sources/setup/install/helm/reference.md
@@ -6813,6 +6813,15 @@ false
 </td>
 		</tr>
 		<tr>
+			<td>memcached.image.registry</td>
+			<td>string</td>
+			<td>The Docker registry</td>
+			<td><pre lang="json">
+"docker.io"
+</pre>
+</td>
+		</tr>
+		<tr>
 			<td>memcached.image.repository</td>
 			<td>string</td>
 			<td>Memcached Docker image repository</td>
@@ -6894,6 +6903,15 @@ true
 			<td></td>
 			<td><pre lang="json">
 "IfNotPresent"
+</pre>
+</td>
+		</tr>
+		<tr>
+			<td>memcachedExporter.image.registry</td>
+			<td>string</td>
+			<td>The Docker registry</td>
+			<td><pre lang="json">
+"docker.io"
 </pre>
 </td>
 		</tr>

--- a/docs/sources/setup/install/helm/reference.md
+++ b/docs/sources/setup/install/helm/reference.md
@@ -6900,7 +6900,7 @@ true
 		<tr>
 			<td>memcachedExporter.image.pullPolicy</td>
 			<td>string</td>
-			<td></td>
+			<td>Docker image pull policy</td>
 			<td><pre lang="json">
 "IfNotPresent"
 </pre>
@@ -6918,7 +6918,7 @@ true
 		<tr>
 			<td>memcachedExporter.image.repository</td>
 			<td>string</td>
-			<td></td>
+			<td>Docker image repository</td>
 			<td><pre lang="json">
 "prom/memcached-exporter"
 </pre>
@@ -6927,7 +6927,7 @@ true
 		<tr>
 			<td>memcachedExporter.image.tag</td>
 			<td>string</td>
-			<td></td>
+			<td>Docker image tag</td>
 			<td><pre lang="json">
 "v0.15.1"
 </pre>

--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -13,6 +13,8 @@ Entries should include a reference to the pull request that introduced the chang
 
 [//]: # (<AUTOMATED_UPDATES_LOCATOR> : do not remove this line. This locator is used by the CI pipeline to automatically create a changelog entry for each new Loki release. Add other chart versions and respective changelog entries bellow this line.)
 
+- [FEATURE] Added Docker image registry value for memcached and memcached-exporter
+
 ## 6.27.0
 
 - [FEATURE] Added support for globals: `extraArgs`, `extraEnv`, `extraEnvFrom`, `extraVolumes`, `extraVolumeMounts` ([#16062](https://github.com/grafana/loki/pull/16062)) relates to ([#12652](https://github.com/grafana/loki/pull/12652))

--- a/production/helm/loki/templates/memcached/_memcached-statefulset.tpl
+++ b/production/helm/loki/templates/memcached/_memcached-statefulset.tpl
@@ -84,7 +84,7 @@ spec:
         {{- end }}
         - name: memcached
           {{- with $.ctx.Values.memcached.image }}
-          image: {{ .repository }}:{{ .tag }}
+          image: {{ .registry }}/{{ .repository }}:{{ .tag }}
           imagePullPolicy: {{ .pullPolicy }}
           {{- end }}
           resources:
@@ -138,7 +138,7 @@ spec:
       {{- if $.ctx.Values.memcachedExporter.enabled }}
         - name: exporter
           {{- with $.ctx.Values.memcachedExporter.image }}
-          image: {{ .repository}}:{{ .tag }}
+          image: {{ .registry }}/{{ .repository }}:{{ .tag }}
           imagePullPolicy: {{ .pullPolicy }}
           {{- end }}
           ports:

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -3170,6 +3170,8 @@ overridesExporter:
 
 memcached:
   image:
+    # -- The Docker registry
+    registry: docker.io
     # -- Memcached Docker image repository
     repository: memcached
     # -- Memcached Docker image tag
@@ -3194,6 +3196,8 @@ memcachedExporter:
   # -- Whether memcached metrics should be exported
   enabled: true
   image:
+    # -- The Docker registry
+    registry: docker.io
     repository: prom/memcached-exporter
     tag: v0.15.1
     pullPolicy: IfNotPresent

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -3198,8 +3198,11 @@ memcachedExporter:
   image:
     # -- The Docker registry
     registry: docker.io
+    # -- Docker image repository
     repository: prom/memcached-exporter
+    # -- Docker image tag
     tag: v0.15.1
+    # -- Docker image pull policy
     pullPolicy: IfNotPresent
   resources:
     requests: {}


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds Docker image registry value for memcached and memcached-exporter. This is done to be able to specify custom registries for memcached and memcached-exporter.

Also adds some missing reference descriptions for memcached-exporter image values.

**Which issue(s) this PR fixes**:
Fixes #16197

**Special notes for your reviewer**:

First time contributing, so sorry if anything is missing. :)

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
