### PR TITLE
fix backend envFrom typo

### DIFF
--- a/production/helm/loki/templates/backend/statefulset-backend.yaml
+++ b/production/helm/loki/templates/backend/statefulset-backend.yaml
@@ -168,7 +168,7 @@ spec:
           env:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with (concat .Values.global.extraEnv .Values.backend.extraEnvFrom) | uniq }}
+          {{- with (concat .Values.global.extraEnvFrom .Values.backend.extraEnvFrom) | uniq }}
           envFrom:
             {{- toYaml . | nindent 12 }}
           {{- end }}


### PR DESCRIPTION
looks like this is typo, cause using `global.extraEnv` and `backend.extraEnvFrom` in values simultaneously causes wrong behavior.

Thx!