### PR TITLE
docs: Clarify thanos storage behaviour

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -171,16 +171,28 @@ ui:
 [ruler: <ruler>]
 
 ruler_storage:
+  # Configure ruler storage when thanos client is enabled, replacing
+  # the .ruler.storage block.
+  #
   # The thanos_object_store_config block configures the connection to object
   # storage backend using thanos-io/objstore clients. This will become the
   # default way of configuring object store clients in future releases.
-  # Currently this is opt-in and takes effect only when `-use-thanos-objstore`
-  # is set to true.
+  #
+  # Currently this is opt-in and takes effect only when object_store.use_thanos_objstore
+  # (flag `-use-thanos-objstore`) is set to true. The .ruler.storage block's
+  # contents will then be ignored by Ruler, but due to bug #16543 it must still
+  # be present and have a valid configuration if ruler is being started as part of
+  # combined target.
+  #
+  # Named stores are NOT supported here.
+  #
   # The CLI flags prefix for this block configuration is: ruler-storage
   [<thanos_object_store_config>]
 
   # Backend storage to use. Supported backends are: local, s3, gcs, azure,
-  # swift, filesystem, alibabacloud, bos
+  # swift, filesystem, alibabacloud, bos.
+  # This does NOT support named stores from the storage_config.object_store
+  # block, it can only refer to provider names.
   # CLI flag: -ruler-storage.backend
   [backend: <string> | default = "filesystem"]
 
@@ -915,6 +927,8 @@ The `alibabacloud_storage_config` block configures the connection to Alibaba Clo
 - `common.storage`
 - `ruler.storage`
 
+*Ignored* when `storage_config.use_thanos_objstore` is true.
+
 &nbsp;
 
 ```yaml
@@ -986,6 +1000,8 @@ Define actions for matching OpenTelemetry (OTEL) attributes.
 ### aws_storage_config
 
 The `aws_storage_config` block configures the connection to dynamoDB and S3 object storage. Either one of them or both can be configured.
+
+*Ignored* when `storage_config.use_thanos_objstore` is true.
 
 ```yaml
 # Deprecated: Configures storing indexes in DynamoDB.
@@ -1078,6 +1094,8 @@ The `azure_storage_config` block configures the connection to Azure object stora
 
 - `common.storage`
 - `ruler.storage`
+
+*Ignored* when `storage_config.use_thanos_objstore` is true.
 
 &nbsp;
 
@@ -1302,6 +1320,8 @@ The `bos_storage_config` block configures the connection to Baidu Object Storage
 
 - `common.storage`
 - `ruler.storage`
+
+*Ignored* when `storage_config.use_thanos_objstore` is true.
 
 &nbsp;
 
@@ -1551,6 +1571,11 @@ The `chunk_store_config` block configures how chunks will be cached and how long
 
 Common configuration to be shared between multiple modules. If a more specific configuration is given in other sections, the related configuration within this section will be ignored.
 
+See [#storage_config](#storage_config) for important notes on the behaviour of this configuration
+with respect to the Thanos object store client. In particular, when `use_thanos_objstore=true` in
+`storage_config`, all the provider specific fields are ignored and `common.storage.object_store`
+is used instead.
+
 ```yaml
 # prefix for the path
 # CLI flag: -common.path-prefix
@@ -1560,31 +1585,37 @@ storage:
   # The s3_storage_config block configures the connection to Amazon S3 object
   # storage backend.
   # The CLI flags prefix for this block configuration is: common.storage
+  # Ignored if use_thanos_objstore=true in storage_config.
   [s3: <s3_storage_config>]
 
   # The gcs_storage_config block configures the connection to Google Cloud
   # Storage object storage backend.
   # The CLI flags prefix for this block configuration is: common.storage
+  # Ignored if use_thanos_objstore=true in storage_config.
   [gcs: <gcs_storage_config>]
 
   # The azure_storage_config block configures the connection to Azure object
   # storage backend.
   # The CLI flags prefix for this block configuration is: common.storage
+  # Ignored if use_thanos_objstore=true in storage_config.
   [azure: <azure_storage_config>]
 
   # The alibabacloud_storage_config block configures the connection to Alibaba
   # Cloud Storage object storage backend.
   # The CLI flags prefix for this block configuration is: common.storage
+  # Ignored if use_thanos_objstore=true in storage_config.
   [alibabacloud: <alibabacloud_storage_config>]
 
   # The bos_storage_config block configures the connection to Baidu Object
   # Storage (BOS) object storage backend.
   # The CLI flags prefix for this block configuration is: common.storage
+  # Ignored if use_thanos_objstore=true in storage_config.
   [bos: <bos_storage_config>]
 
   # The swift_storage_config block configures the connection to OpenStack Object
   # Storage (Swift) object storage backend.
   # The CLI flags prefix for this block configuration is: common.storage
+  # Ignored if use_thanos_objstore=true in storage_config.
   [swift: <swift_storage_config>]
 
   filesystem:
@@ -1613,6 +1644,7 @@ storage:
   # The cos_storage_config block configures the connection to IBM Cloud Object
   # Storage (COS) backend.
   # The CLI flags prefix for this block configuration is: common.storage
+  # Ignored if use_thanos_objstore=true in storage_config.
   [cos: <cos_storage_config>]
 
   congestion_control:
@@ -1668,7 +1700,7 @@ storage:
   # storage backend using thanos-io/objstore clients. This will become the
   # default way of configuring object store clients in future releases.
   # Currently this is opt-in and takes effect only when `-use-thanos-objstore`
-  # is set to true.
+  # (object_store.use_thanos_objstore) is set to true.
   # The CLI flags prefix for this block configuration is:
   # common.storage.object-store
   [object_store: <thanos_object_store_config>]
@@ -2024,6 +2056,8 @@ The `cos_storage_config` block configures the connection to IBM Cloud Object Sto
 
 - `common.storage`
 - `ruler.storage`
+
+*Ignored* when `storage_config.use_thanos_objstore` is true.
 
 &nbsp;
 
@@ -2423,6 +2457,8 @@ The `gcs_storage_config` block configures the connection to Google Cloud Storage
 
 - `common.storage`
 - `ruler.storage`
+
+*Ignored* when `storage_config.use_thanos_objstore` is true.
 
 &nbsp;
 
@@ -3908,7 +3944,15 @@ When a memberlist config with atleast 1 join_members is defined, kvstore of type
 ### named_stores_config
 
 Configures additional object stores for a given storage provider.
-Supported stores: aws, azure, bos, filesystem, gcs, swift.
+Supported stores: aws, azure, bos, filesystem, gcs, swift. The name
+is the key under the store type.
+
+The store name is referred to by using its name in the `period_config` block's
+`object_store` field, instead of using a storage backend name like `s3`.
+
+**Warning** This block is ignored if the Thanos object store is enabled;
+use `storage_config.object_store.named_storage` instead. See [`storage_config`](#storage_config).
+
 Example:
 ```yaml
     storage_config:
@@ -3917,8 +3961,21 @@ Example:
           store-1:
             endpoint: s3://foo-bucket
             region: us-west1
+
+    schema_config:
+      configs:
+      - from: 2020-05-15   # whenever your Loki switched to v13
+        store: tsdb
+        # Use the store named store-1
+        object_store: store-1
+        schema: v13
+        index:
+          prefix: index_
+          period: 24h
 ```
-Named store from this example can be used by setting object_store to store-1 in period_config.
+
+The configuration entries are the same as the corresponding `storage_config`
+block for that provider, keyed by the name to assign to the store:
 
 ```yaml
 [aws: <map of string to aws_storage_config>]
@@ -3992,6 +4049,11 @@ The `period_config` block configures what index schemas should be used for from 
 # alibabacloud, bos, cos, swift, filesystem, or a named_store (refer to
 # named_stores_config). Following stores are deprecated: aws-dynamo, gcp,
 # gcp-columnkey, bigtable, bigtable-hashed, cassandra, grpc.
+#
+# If the thanos client is enabled, only storage in the thanos client
+# configuration under storage_config.object_store and named stores
+# under storage_config.object_store.named_stores can be used here.
+#
 [object_store: <string> | default = ""]
 
 # The schema version to use, current recommended schema is v13.
@@ -4394,11 +4456,21 @@ The `ruler` block configures the Loki ruler.
 # CLI flag: -ruler.poll-interval
 [poll_interval: <duration> | default = 1m]
 
-# Deprecated: Use -ruler-storage. CLI flags and their respective YAML config
-# options instead.
+# Configure ruler storage when the legacy (non-Thanos) object storage client is
+# in use. This configuration is ignored if the Thanos object store is enabled,
+# and should be omitted from the configuration. When -use-thanos-objstore=true,
+# use -ruler-storage CLI flags and their respective YAML config options under
+# the top-level `ruler_storage` key instead.
+#
+# A bug in 3.3.x+ releases means that this stanza may need to be present
+# and have a storage type set, even when thanos storage is enabled. The storage
+# will not get used, but must be configured. See
+# https://github.com/grafana/loki/issues/16543
+#
 storage:
   # Method to use for backend rule storage (configdb, azure, gcs, s3, swift,
-  # local, bos, cos)
+  # local, bos, cos). Does NOT support named stores defined in
+  # storage_config.named_stores or any Thanos object store client stores.
   # CLI flag: -ruler.storage.type
   [type: <string> | default = ""]
 
@@ -4725,6 +4797,8 @@ The `s3_storage_config` block configures the connection to Amazon S3 object stor
 - `common.storage`
 - `ruler.storage`
 
+*Ignored* when `storage_config.use_thanos_objstore` is true.
+
 &nbsp;
 
 ```yaml
@@ -4841,6 +4915,8 @@ Configures the chunk index schema and where it is stored.
 ```yaml
 [configs: <list of period_configs>]
 ```
+
+See [`period_config`](#period_config)
 
 ### server
 
@@ -5099,27 +5175,32 @@ grpc_tls_config:
 
 ### storage_config
 
-The `storage_config` block configures one of many possible stores for both the index and chunks. Which configuration to be picked should be defined in schema_config block.
+The `storage_config` block configures one of many possible stores for both the index and chunks. Which configuration to be picked should be defined in `schema_config`, in the `object_store` field for each configuration.
+
+**Note**: The `storage_config` block is a union of multiple storage configurations. Only one of the following storage configurations can be defined at a time, unless using `storage_config.named_stores` or `storage_config.object_store.named_stores`.
+
+**Warning**: When the Thanos object store client is enabled with `-use_thanos_objstore=true` or setting `storage_config.use_thanos_objstore` to `true`, the object-store specific parts of the `storage_config` block are ignored, and only `storage_config.object_store` is respected. `storage_config.named_stores` will be ignored, and only `storage_config.object_store.named_stores` will be read. Additionally, `ruler.storage` will be ignored, and only `ruler_storage` is used, even when the Ruler is only configured to use local storage. The reverse is true when the Thanos object store client is disabled; the Thanos client related blocks are just ignored. No warning will be logged when configuration is found and ignored.
 
 ```yaml
 # The alibabacloud_storage_config block configures the connection to Alibaba
-# Cloud Storage object storage backend.
+# Cloud Storage object storage backend. Ignored if use_thanos_objstore=true.
 [alibabacloud: <alibabacloud_storage_config>]
 
 # The aws_storage_config block configures the connection to dynamoDB and S3
-# object storage. Either one of them or both can be configured.
+# object storage. Either one of them or both can be configured. Ignored if
+# use_thanos_objstore=true.
 [aws: <aws_storage_config>]
 
 # The azure_storage_config block configures the connection to Azure object
-# storage backend.
+# storage backend. Ignored if use_thanos_objstore=true.
 [azure: <azure_storage_config>]
 
 # The bos_storage_config block configures the connection to Baidu Object Storage
-# (BOS) object storage backend.
+# (BOS) object storage backend. Ignored if use_thanos_objstore=true.
 [bos: <bos_storage_config>]
 
 # Deprecated: Configures storing indexes in Bigtable. Required fields only
-# required when bigtable is defined in config.
+# required when bigtable is defined in config. Ignored if use_thanos_objstore=true.
 bigtable:
   # Bigtable project ID.
   # CLI flag: -bigtable.project
@@ -5145,10 +5226,11 @@ bigtable:
   [table_cache_expiration: <duration> | default = 30m]
 
 # Configures storing chunks in GCS. Required fields only required when gcs is
-# defined in config.
+# defined in config. Ignored if use_thanos_objstore=true.
 [gcs: <gcs_storage_config>]
 
 # Deprecated: Configures storing chunks and/or the index in Cassandra.
+# Ignored if use_thanos_objstore=true.
 cassandra:
   # Comma-separated hostnames or IPs of Cassandra instances.
   # CLI flag: -cassandra.addresses
@@ -5267,7 +5349,7 @@ cassandra:
   [table_options: <string> | default = ""]
 
 # Deprecated: Configures storing index in BoltDB. Required fields only required
-# when boltdb is present in the configuration.
+# when boltdb is present in the configuration. Ignored if use_thanos_objstore=true.
 boltdb:
   # Location of BoltDB index files.
   # CLI flag: -boltdb.dir
@@ -5278,10 +5360,10 @@ boltdb:
 [filesystem: <local_storage_config>]
 
 # The swift_storage_config block configures the connection to OpenStack Object
-# Storage (Swift) object storage backend.
+# Storage (Swift) object storage backend. Ignored if use_thanos_objstore=true.
 [swift: <swift_storage_config>]
 
-# Deprecated:
+# Deprecated. Ignored if use_thanos_objstore=true.
 grpc_store:
   # Hostname or IP of the gRPC store instance.
   # CLI flag: -grpc-store.server-address
@@ -5301,8 +5383,10 @@ hedging:
   # CLI flag: -store.hedge-max-per-second
   [max_per_second: <int> | default = 5]
 
-# Configures additional object stores for a given storage provider.
+# Configures additional object stores for a given storage provider
+# when using the legacy (non-Thanos) storage client.
 # Supported stores: aws, azure, bos, filesystem, gcs, swift.
+# Ignored if use_thanos_objstore=true.
 # Example:
 # ```yaml
 #     storage_config:
@@ -5317,7 +5401,7 @@ hedging:
 [named_stores: <named_stores_config>]
 
 # The cos_storage_config block configures the connection to IBM Cloud Object
-# Storage (COS) backend.
+# Storage (COS) backend. Ignored if use_thanos_objstore=true.
 [cos: <cos_storage_config>]
 
 # Cache validity for active index entries. Should be no higher than
@@ -5396,7 +5480,10 @@ congestion_control:
 # Enables the use of thanos-io/objstore clients for connecting to object
 # storage. When set to true, the configuration inside
 # `storage_config.object_store` or `common.storage.object_store` block takes
-# effect.
+# effect, as does the `ruler_storage` block. When enabled, this switches OFF
+# the legacy storage client and its configuration, so `storage_config.azure`,
+# `storage_config.aws`, `storage_config.gcs`, `storage_config.named_stores`,
+# etc will be ignored, as will `ruler.storage`.
 # CLI flag: -use-thanos-objstore
 [use_thanos_objstore: <boolean> | default = false]
 
@@ -5409,6 +5496,10 @@ object_store:
   # The CLI flags prefix for this block configuration is: object-store
   [<thanos_object_store_config>]
 
+  # The thanos object store named storage block configures named stores
+  # when the thanos client is enabled, replacing the object_store.named_stores
+  # block used by the legacy client. Its entries use the Thanos client
+  # types, not the legacy types.
   named_stores:
     [azure: <map of string to NamedAzureStorageConfig>]
 
@@ -5597,6 +5688,8 @@ The `swift_storage_config` block configures the connection to OpenStack Object S
 
 - `common.storage`
 - `ruler.storage`
+
+*Ignored* when `storage_config.use_thanos_objstore` is true.
 
 &nbsp;
 
@@ -6026,11 +6119,17 @@ chunk_tables_provisioning:
 ### thanos_object_store_config
 
 The `thanos_object_store_config` block configures the connection to object storage backend using thanos-io/objstore clients. This will become the default way of configuring object store clients in future releases.
-Currently this is opt-in and takes effect only when `-use-thanos-objstore` is set to true. The supported CLI flags `<prefix>` used to reference this configuration block are:
+
+Currently this is opt-in and takes effect only when `-use-thanos-objstore` is set to true.
+
+The supported CLI flags `<prefix>` used to reference this configuration block are:
 
 - `common.storage.object-store`
 - `object-store`
 - `ruler-storage`
+
+**Note**: the Thanos client uses different data types for the storage configurations for each provider
+than the legacy client. Many keys are the same, but not all.
 
 &nbsp;
 

--- a/tools/deprecated-config-checker/deprecated-config.yaml
+++ b/tools/deprecated-config-checker/deprecated-config.yaml
@@ -1,4 +1,4 @@
-# This file should contain a list fo deprecated config options.
+# This file should contain a list of deprecated config options.
 #
 # -- Syntax --
 # The value for a deprecated option should be a message that explains why the option is deprecated and what to use instead. E.g.


### PR DESCRIPTION
**What this PR does / why we need it**:

The behaviour of the object store with the thanos client vs with the legacy client is extremely confusing, as various parts of the configuration get silently ignored depending on whether or not the thanos store client is enabled. This has surprising side effects, like changing the configuration section that ruler storage must be configured in even when the ruler is using local storage.

This PR adds warnings on on the legacy storage options to indicate that they're ignored when the thanos store is enabled. It also makes it more explicit that the thanos storage client uses different data types, so the configuration docs for the various storage clients don't apply when using the thanos store client. The ruler configuration docs are annotated to warn that `ruler.storage` is only deprecated when using the thanos client; it's otherwise still required, and that `ruler_storage` is only used (and required) when the thanos client is enabled. A note is added to warn that the Ruler storage configuration does not support named stores.

A warning is added on `.ruler.storage` that it must be defined 

Please add backport label `backport-release-3.4.x` so the latest stable docs reflect this change.

Here's a pre-rendered copy of the updated docs for easy local browsing (or you can just `cd docs && make docs` then visit `http://localhost:3002/docs/loki/latest/configure/`): 
[rendered_config_docs.zip](https://github.com/user-attachments/files/19079561/rendered_config_docs.zip)


**Which issue(s) this PR fixes**:

Relates to #16543

It doesn't fix the bug, it just provides some clarity around behaviour.

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated (N/A)
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)

**Excerpts**

Illustrating some of the changes:

![image](https://github.com/user-attachments/assets/51599444-ff7f-47c1-ba34-24599ca7079b)
![image](https://github.com/user-attachments/assets/3572d789-ca25-491a-8a14-6fbae5c8eaa9)
![image](https://github.com/user-attachments/assets/94a459f2-f4f5-435e-9ec8-a4b8d8365dad)
![image](https://github.com/user-attachments/assets/dd189d4e-b6e6-4b11-8520-c1ad4e6ed1d2)
![image](https://github.com/user-attachments/assets/e5e457b3-42be-445d-a61e-762b08efab4e)
![image](https://github.com/user-attachments/assets/11443050-5f3c-408b-8c03-92c60a0b0677)
