### PR TITLE
chore(ci): Renovate turn off automerge/approve

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -95,8 +95,8 @@
     "addLabels": [
       "area/security"
     ],
-    "automerge": true, 
-    "autoApprove": true
+    "automerge": false, 
+    "autoApprove": false
   },
   "osvVulnerabilityAlerts": true,
   "prConcurrentLimit": 15,


### PR DESCRIPTION
**What this PR does / why we need it**:
Turns off automerge/approve for security updates.  This is because a security [update](https://github.com/grafana/loki/pull/16556/) impacted the operator `go.mod` file.  The security updates get a high precedence than individual rulesets in the renovate configuration

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
