### PR TITLE
docs: remove deployment.environment from list of otel resource attrs …

### DIFF
--- a/docs/sources/send-data/otel/_index.md
+++ b/docs/sources/send-data/otel/_index.md
@@ -78,7 +78,7 @@ Since the OpenTelemetry protocol differs from the Loki storage model, here is ho
   - cloud.availability_zone
   - cloud.region
   - container.name
-  - deployment.environment
+  - deployment.environment.name
   - k8s.cluster.name
   - k8s.container.name
   - k8s.cronjob.name


### PR DESCRIPTION
**What this PR does / why we need it**:

manual backport of #16427 to the 3.3 branch