### PR TITLE
docs: remove deployment.environment from list of otel resource attrs …

### DIFF
--- a/docs/sources/send-data/otel/_index.md
+++ b/docs/sources/send-data/otel/_index.md
@@ -78,7 +78,7 @@ Since the OpenTelemetry protocol differs from the Loki storage model, here is ho
   - cloud.availability_zone
   - cloud.region
   - container.name
-  - deployment.environment
+  - deployment.environment.name
   - k8s.cluster.name
   - k8s.container.name
   - k8s.cronjob.name


### PR DESCRIPTION
…stored as labels (#16427)

Signed-off-by: Marshall Ford <inbox@marshallford.me>
Co-authored-by: J Stickler <julie.stickler@grafana.com>
(cherry picked from commit 49064aed64b99d57980866269888b05203256527)

**What this PR does / why we need it**:

manual backport of https://github.com/grafana/loki/pull/16427 to the 3.2 branch