### PR TITLE
fix: guard against non-schedulerRequest in scheduler.dequeue

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -443,9 +443,9 @@ func (s *Scheduler) QuerierLoop(querier schedulerpb.SchedulerForQuerier_QuerierL
 			level.Error(s.log).Log("msg", "dequeue() call resulted in nil response", "querier", querierID)
 		}
 		r, ok := req.(*schedulerRequest)
-    if !ok {
-      level.Error(s.log).Log("msg", "dequeue() call returned a non-schedulerRequest request", "querier", querierID)
-    }
+		if !ok {
+			level.Error(s.log).Log("msg", "dequeue() call returned a non-schedulerRequest request", "querier", querierID)
+		}
 
 		reqQueueTime := time.Since(r.queueTime)
 		s.queueDuration.Observe(reqQueueTime.Seconds())

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -442,7 +442,10 @@ func (s *Scheduler) QuerierLoop(querier schedulerpb.SchedulerForQuerier_QuerierL
 		if req == nil {
 			level.Error(s.log).Log("msg", "dequeue() call resulted in nil response", "querier", querierID)
 		}
-		r := req.(*schedulerRequest)
+		r, ok := req.(*schedulerRequest)
+    if !ok {
+      level.Error(s.log).Log("msg", "dequeue() call returned a non-schedulerRequest request", "querier", querierID)
+    }
 
 		reqQueueTime := time.Since(r.queueTime)
 		s.queueDuration.Observe(reqQueueTime.Seconds())


### PR DESCRIPTION
**What this PR does / why we need it**:

We saw some panics regarding a failed conversion here. While we nil check it just above, we were still getting in that case. This smells like a data race, but until we find that race is this guard worth having?

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
