### PR TITLE
chore(metastore): Fix stream read condition

### DIFF
--- a/pkg/dataobj/metastore/object.go
+++ b/pkg/dataobj/metastore/object.go
@@ -276,7 +276,7 @@ func forEachStream(ctx context.Context, object *dataobj.Object, predicate dataob
 		}
 		for {
 			num, err := reader.Read(ctx, streams)
-			if err != io.EOF {
+			if err != nil && err != io.EOF {
 				return err
 			}
 			if num == 0 && err == io.EOF {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes iteration condition so the stream reader does not exit early 