### PR TITLE
ci: upload helm chart to oci

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   call-update-helm-repo:
-    uses: grafana/helm-charts/.github/workflows/update-helm-repo.yaml@70dbbb722dee3f2ee126e12684cc0e92a20972ed
+    uses: grafana/helm-charts/.github/workflows/update-helm-repo.yaml@73fd30af9487d7c0a5d0d76975340e6c779a2f06
     with:
       charts_dir: production/helm
       cr_configfile: production/helm/cr.yaml


### PR DESCRIPTION
This bumps the helm release so it runs the following steps:

https://github.com/grafana/helm-charts/blob/73fd30af9487d7c0a5d0d76975340e6c779a2f06/.github/workflows/update-helm-repo.yaml#L232-L243