### PR TITLE
fix: only allow aggregated metric queries from logs drilldown app

### DIFF
--- a/pkg/querier/limits/validation.go
+++ b/pkg/querier/limits/validation.go
@@ -2,7 +2,9 @@ package limits
 
 import (
 	"context"
+	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/go-kit/log/level"
@@ -10,12 +12,17 @@ import (
 	"github.com/grafana/dskit/tenant"
 	"github.com/prometheus/common/model"
 
+	"github.com/grafana/loki/v3/pkg/loghttp/push"
 	"github.com/grafana/loki/v3/pkg/logql"
+	"github.com/grafana/loki/v3/pkg/util/httpreq"
 	"github.com/grafana/loki/v3/pkg/util/spanlogger"
 	util_validation "github.com/grafana/loki/v3/pkg/util/validation"
 )
 
+const logsDrilldownAppName = "grafana-lokiexplore-app"
+
 var nowFunc = func() time.Time { return time.Now() }
+var ErrAggMetricsDrilldownOnly = fmt.Errorf("aggregated metric queries can only be accessed from Logs Drilldown")
 
 func ValidateQueryRequest(ctx context.Context, req logql.QueryParams, limits Limits) (time.Time, time.Time, error) {
 	userID, err := tenant.TenantID(ctx)
@@ -36,6 +43,52 @@ func ValidateQueryRequest(ctx context.Context, req logql.QueryParams, limits Lim
 	}
 
 	return ValidateQueryTimeRangeLimits(ctx, userID, limits, req.GetStart(), req.GetEnd())
+}
+
+// ValidateAggregatedMetricQuery checks if the query is accessing __aggregated_metric__ streams
+// and ensures that only queries from Grafana Explore Logs can access them.
+func ValidateAggregatedMetricQuery(ctx context.Context, req logql.QueryParams) error {
+	selector, err := req.LogSelector()
+	if err != nil {
+		return err
+	}
+
+	// Check if the query targets aggregated metrics
+	isAggregatedMetricQuery := false
+	matchers := selector.Matchers()
+
+	for _, matcher := range matchers {
+		if matcher.Name == push.AggregatedMetricLabel {
+			isAggregatedMetricQuery = true
+			break
+		}
+	}
+
+	if !isAggregatedMetricQuery {
+		return nil
+	}
+
+	tags := httpreq.ExtractQueryTagsFromContext(ctx)
+	kvs := httpreq.TagsToKeyValues(tags)
+
+	// KVs is an []interface{} of key value pairs, so iterate by keys
+	for i := 0; i < len(kvs); i += 2 {
+		current, ok := kvs[i].(string)
+		if !ok {
+			continue
+		}
+
+		next, ok := kvs[i+1].(string)
+		if !ok {
+			continue
+		}
+
+		if current == "source" && strings.EqualFold(next, logsDrilldownAppName) {
+			isAggregatedMetricQuery = true
+			return nil
+		}
+	}
+	return ErrAggMetricsDrilldownOnly
 }
 
 func ValidateQueryTimeRangeLimits(ctx context.Context, userID string, limits TimeRangeLimits, from, through time.Time) (time.Time, time.Time, error) {

--- a/pkg/querier/limits/validation_test.go
+++ b/pkg/querier/limits/validation_test.go
@@ -6,6 +6,12 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/logproto"
+	"github.com/grafana/loki/v3/pkg/logql"
+	"github.com/grafana/loki/v3/pkg/logql/syntax"
+	"github.com/grafana/loki/v3/pkg/querier/plan"
+	"github.com/grafana/loki/v3/pkg/util/httpreq"
 )
 
 type fakeTimeLimits struct {
@@ -48,6 +54,121 @@ func Test_validateQueryTimeRangeLimits(t *testing.T) {
 			}
 			require.Equal(t, tt.wantFrom, from, "wanted (%s) got (%s)", tt.wantFrom, from)
 			require.Equal(t, tt.wantThrough, through)
+		})
+	}
+}
+
+func TestValidateAggregatedMetricQuery(t *testing.T) {
+	makeReqAndAST := func(queryStr string) logql.QueryParams {
+		now := time.Now()
+		expr, err := syntax.ParseExpr(queryStr)
+		if err != nil {
+			panic(err)
+		}
+		switch expr.(type) {
+		case syntax.SampleExpr:
+			return logql.SelectSampleParams{SampleQueryRequest: &logproto.SampleQueryRequest{
+				Selector: queryStr,
+				Start:    now.Add(-time.Hour),
+				End:      now,
+				Plan:     &plan.QueryPlan{AST: expr},
+			},
+			}
+		default:
+			return logql.SelectLogParams{QueryRequest: &logproto.QueryRequest{
+				Selector:  queryStr,
+				Start:     now.Add(-time.Hour),
+				End:       now,
+				Direction: logproto.BACKWARD,
+				Plan: &plan.QueryPlan{
+					AST: expr,
+				},
+			},
+			}
+		}
+	}
+
+	tcs := []struct {
+		desc          string
+		req           logql.QueryParams
+		queryTags     string
+		expectedError error
+	}{
+		{
+			desc:          "normal query, no error",
+			req:           makeReqAndAST(`{foo="bar"}`),
+			queryTags:     "",
+			expectedError: nil,
+		},
+		{
+			desc:          "aggregated metric query from explore, no error",
+			req:           makeReqAndAST(`{__aggregated_metric__="service-name"}`),
+			queryTags:     "source=" + logsDrilldownAppName,
+			expectedError: nil,
+		},
+		{
+			desc:          "query tags are case insensitive",
+			req:           makeReqAndAST(`{__aggregated_metric__="service-name"}`),
+			queryTags:     "Source=" + logsDrilldownAppName,
+			expectedError: nil,
+		},
+		{
+			desc:          "aggregated metric query from explore, multipe selectors, no error",
+			req:           makeReqAndAST(`{app="service-name", __aggregated_metric__="true"}`),
+			queryTags:     "source=" + logsDrilldownAppName,
+			expectedError: nil,
+		},
+		{
+			desc:          "aggregated metric query from explore, multipe selectors, filter, no error",
+			req:           makeReqAndAST(`{app="service-name", __aggregated_metric__="true"} |= "test"`),
+			queryTags:     "source=" + logsDrilldownAppName,
+			expectedError: nil,
+		},
+		{
+			desc:          "aggregated metrics metric query from explore, multipe selectors, filter, no error",
+			req:           makeReqAndAST(`sum by (service_name)(count_over_time({app="service-name", __aggregated_metric__="true"} |= "test" [5m]))`),
+			queryTags:     "source=" + logsDrilldownAppName,
+			expectedError: nil,
+		},
+		{
+			desc:          "aggregated metric query from other source, blocked",
+			req:           makeReqAndAST(`{__aggregated_metric__="service-name"}`),
+			queryTags:     "source=other-app",
+			expectedError: ErrAggMetricsDrilldownOnly,
+		},
+		{
+			desc:          "aggregated metric query with no source, blocked",
+			req:           makeReqAndAST(`{__aggregated_metric__="service-name"}`),
+			queryTags:     "",
+			expectedError: ErrAggMetricsDrilldownOnly,
+		},
+		{
+			desc:          "aggregated metric query with no source, multipe selectors, blocked",
+			req:           makeReqAndAST(`{app="service-name", __aggregated_metric__="true"}`),
+			queryTags:     "",
+			expectedError: ErrAggMetricsDrilldownOnly,
+		},
+		{
+			desc:          "aggregated metrics metric query with no source, multipe selectors, filter, blocked",
+			req:           makeReqAndAST(`sum by (service_name)(count_over_time({app="service-name", __aggregated_metric__="true"} |= "test" [5m]))`),
+			queryTags:     "",
+			expectedError: ErrAggMetricsDrilldownOnly,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.desc, func(t *testing.T) {
+			ctx := context.Background()
+			if tc.queryTags != "" {
+				ctx = httpreq.InjectQueryTags(ctx, tc.queryTags)
+			}
+
+			err := ValidateAggregatedMetricQuery(ctx, tc.req)
+			if tc.expectedError != nil {
+				require.ErrorIs(t, err, tc.expectedError)
+			} else {
+				require.NoError(t, err)
+			}
 		})
 	}
 }

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -154,6 +154,15 @@ func (q *SingleTenantQuerier) SelectLogs(ctx context.Context, params logql.Selec
 		return nil, err
 	}
 
+	err = querier_limits.ValidateAggregatedMetricQuery(ctx, params)
+	if err != nil {
+		if errors.Is(err, querier_limits.ErrAggMetricsDrilldownOnly) {
+			return iter.NoopEntryIterator, nil
+		} else {
+			return nil, err
+		}
+	}
+
 	params.QueryRequest.Deletes, err = deletion.DeletesForUserQuery(ctx, params.Start, params.End, q.deleteGetter)
 	if err != nil {
 		level.Error(spanlogger.FromContext(ctx)).Log("msg", "failed loading deletes for user", "err", err)


### PR DESCRIPTION
**What this PR does / why we need it**:

Aggregated metrics are stored as regular log streams in Loki, but are only used by the Logs Drilldown app. Requests from this app already identify themselves by setting the `X-Query-Tags: Source=grafana-lokiexplore-app` header. This change validates aggregated metric queries to look for this header, and return an empty iterator if not found. This will obfuscate the aggregated metric queries, which will prevent the confusion that has resulted in multiple issues/support requests around where these streams come from.

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [X] Documentation added
- [X] Tests updated
- [X] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [X] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [X] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
