### PR TITLE
feat: helm log headers nginx config

### DIFF
--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -13,6 +13,10 @@ Entries should include a reference to the pull request that introduced the chang
 
 [//]: # (<AUTOMATED_UPDATES_LOCATOR> : do not remove this line. This locator is used by the CI pipeline to automatically create a changelog entry for each new Loki release. Add other chart versions and respective changelog entries bellow this line.)
 
+## 6.29.0
+
+- [FEATURE] Added support to copy the following headers into X-Query-Tags as key/value pairs:, X-Grafana-User, X-Dashboard-Uid, X-Dashboard-Title, X-Panel-Id, X-Panel-Title, X-Rule-Uid, X-Rule-Name, X-Rule-Folder, X-Rule-Version, X-Rule-Source, X-Rule-Type
+
 ## 6.28.0
 
 - [CHANGE] Add extraContainers parameter for the backend pod


### PR DESCRIPTION
**What this PR does / why we need it**:

The following headers are only logged with Grafana Enterprise Logs: 

The following headers are available and what they map to in the log line if present: 

- `X-Grafana-User`
- `X-Dashboard-Uid`
- `X-Dashboard-Title`
- `X-Panel-Id`
- `X-Panel-Title`
- `X-Rule-Uid`
- `X-Rule-Name`
- `X-Rule-Folder`
- `X-Rule-Version`
- `X-Rule-Source`
- `X-Rule-Type`

This changes adds support to log these headers if they are present in the request by adding them to the `X-Query-Tags` header as key/value pairs, which will automatically log them with `metrics.go` log messages, which is very useful for debugging/troubleshooting queries. 

The keys are mapped as follows:

- `X-Grafana-User` -> `user`
- `X-Dashboard-Uid` -> `dashboard_id`
- `X-Dashboard-Title` -> `dashboard_title`
- `X-Panel-Id` -> `panel_id`
- `X-Panel-Title` -> `panel_title`
- `X-Rule-Uid` -> `source_rule_uid`
- `X-Rule-Name` -> `rule_name`
- `X-Rule-Folder` -> `rule_folder`
- `X-Rule-Version` -> `rule_version`
- `X-Rule-Source` -> `rule_source`
- `X-Rule-Type` -> `rule_type`

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [X] Documentation added
- [X] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
