### PR TITLE
ci: bump release lib to create branch on release

### DIFF
--- a/.github/jsonnetfile.json
+++ b/.github/jsonnetfile.json
@@ -8,7 +8,7 @@
           "subdir": "workflows"
         }
       },
-      "version": "965213a0fe2632438ab0524d606cb71d414e2388"
+      "version": "8c7c51b23d9d13078a8c44740e3eb6983f7bb667"
     }
   ],
   "legacyImports": true

--- a/.github/jsonnetfile.lock.json
+++ b/.github/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "workflows"
         }
       },
-      "version": "965213a0fe2632438ab0524d606cb71d414e2388",
-      "sum": "DXmqwVyytIhA0tHlMQUCLD8buVjjCb04YcIxJ3BLFqM="
+      "version": "8c7c51b23d9d13078a8c44740e3eb6983f7bb667",
+      "sum": "42ZmTP0NyLXxS/c79suH/xT9EMSmp4L20f4vTzRlYoY="
     }
   ],
   "legacyImports": false

--- a/.github/release-workflows.jsonnet
+++ b/.github/release-workflows.jsonnet
@@ -180,6 +180,7 @@ local lambdaPromtailJob =
       imagePrefix='grafana',
       releaseLibRef=releaseLibRef,
       pluginBuildDir=dockerPluginDir,
+      releaseBranchTemplate='release-\\${major}.\\${minor}.x',
       releaseRepo='grafana/loki',
       useGitHubAppToken=true,
     ), false, false

--- a/.github/vendor/github.com/grafana/loki-release/workflows/build.libsonnet
+++ b/.github/vendor/github.com/grafana/loki-release/workflows/build.libsonnet
@@ -294,6 +294,7 @@ local runner = import 'runner.libsonnet',
       common.fetchReleaseRepo,
       common.googleAuth,
       common.setupGoogleCloudSdk,
+
       step.new('get nfpm signing keys', 'grafana/shared-workflows/actions/get-vault-secrets@main')
       + step.withId('get-secrets')
       + step.with({
@@ -334,9 +335,12 @@ local runner = import 'runner.libsonnet',
             --entrypoint /bin/sh "%s"
             git config --global --add safe.directory /src/loki
             echo "${NFPM_SIGNING_KEY}" > $NFPM_SIGNING_KEY_FILE
+            if echo "%s" | grep -q "golang"; then
+              /src/loki/.github/vendor/github.com/grafana/loki-release/workflows/install_workflow_dependencies.sh dist
+            fi
             make %s
           EOF
-        ||| % [buildImage, std.join(' ', makeTargets)]
+        ||| % [buildImage, buildImage, std.join(' ', makeTargets)]
       ),
 
       step.new('upload artifacts', 'google-github-actions/upload-cloud-storage@v2')

--- a/.github/vendor/github.com/grafana/loki-release/workflows/install_workflow_dependencies.sh
+++ b/.github/vendor/github.com/grafana/loki-release/workflows/install_workflow_dependencies.sh
@@ -1,0 +1,59 @@
+#!/bin/sh
+set -e
+
+# This script is used to install the dependencies for the workflows.
+# It is intended to be run in a containerized environment, specifically in a
+# "golang" container.
+# It houses all of the dependencies for the workflows, as well as the dependencies
+# needed for the make release-workflows target.
+
+# Set default source directory to GitHub workspace if not provided
+SRC_DIR=${SRC_DIR:-${GITHUB_WORKSPACE}}
+
+install_dist_dependencies() {
+    # Install Ruby and development dependencies needed for FPM
+    apt-get install -y ruby ruby-dev rubygems build-essential
+
+    # Install FPM using gem
+    gem install --no-document fpm
+
+    # Install RPM build tools
+    apt-get install -y rpm
+}
+
+# Update package lists
+apt-get update -qq
+
+# Install tar and xz-utils
+apt-get install -qy tar xz-utils
+
+# Install docker
+install -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+chmod a+r /etc/apt/keyrings/docker.gpg
+# Get codename for Debian - default to "bookworm" if /etc/os-release doesn't exist or VERSION_CODENAME isn't set
+CODENAME="bookworm"
+if [ -f /etc/os-release ]; then
+    # shellcheck source=/dev/null
+    . /etc/os-release
+    if [ -n "${VERSION_CODENAME:-}" ]; then
+        CODENAME="${VERSION_CODENAME}"
+    fi
+fi
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian ${CODENAME} stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
+apt-get update
+apt-get install -y docker-ce-cli docker-buildx-plugin
+
+# Install jsonnet
+apt-get install -qq -y jsonnet
+
+# Install jsonnet-bundler
+go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@latest
+
+# Update jsonnet bundles
+cd "${SRC_DIR}/.github" && jb update -q
+
+# Check if "dist" parameter is passed
+if [ "$1" = "dist" ]; then
+    install_dist_dependencies
+fi

--- a/.github/vendor/github.com/grafana/loki-release/workflows/main.jsonnet
+++ b/.github/vendor/github.com/grafana/loki-release/workflows/main.jsonnet
@@ -88,8 +88,10 @@
     publishToGCS=false,
     releaseLibRef='main',
     releaseRepo='grafana/loki-release',
+    releaseBranchTemplate='release-\\${major}.\\${minor}.x',
     useGitHubAppToken=true,
     dockerPluginPath='clients/cmd/docker-driver',
+    publishDockerPlugins=true,
                   ) {
     name: 'create release',
     on: {
@@ -121,8 +123,13 @@
       shouldRelease: $.release.shouldRelease,
       createRelease: $.release.createRelease,
       publishImages: $.release.publishImages(getDockerCredsFromVault, dockerUsername),
-      publishDockerPlugins: $.release.publishDockerPlugins(pluginBuildDir, getDockerCredsFromVault, dockerUsername),
-      publishRelease: $.release.publishRelease(['createRelease', 'publishImages', 'publishDockerPlugins']),
+    } + (if publishDockerPlugins then {
+           publishDockerPlugins: $.release.publishDockerPlugins(pluginBuildDir, getDockerCredsFromVault, dockerUsername),
+           publishRelease: $.release.publishRelease(['createRelease', 'publishImages', 'publishDockerPlugins']),
+         } else {
+           publishRelease: $.release.publishRelease(['createRelease', 'publishImages']),
+         }) + {
+      createReleaseBranch: $.release.createReleaseBranch(releaseBranchTemplate),
     },
   },
   check: {

--- a/.github/vendor/github.com/grafana/loki-release/workflows/validate-gel.libsonnet
+++ b/.github/vendor/github.com/grafana/loki-release/workflows/validate-gel.libsonnet
@@ -10,10 +10,7 @@ local setupValidationDeps = function(job) job {
     common.fixDubiousOwnership,
     step.new('install dependencies')
     + step.withIf('${{ !fromJSON(env.SKIP_VALIDATION) }}')
-    + step.withRun(|||
-      apt update
-      apt install -qy tar xz-utils
-    |||),
+    + step.withRun('lib/workflows/install_workflow_dependencies.sh'),
     step.new('install shellcheck', './lib/actions/install-binary')
     + step.withIf('${{ !fromJSON(env.SKIP_VALIDATION) }}')
     + step.with({
@@ -36,7 +33,7 @@ local setupValidationDeps = function(job) job {
   ] + job.steps,
 };
 
-local validationJob = _validationJob(true);
+local validationJob = _validationJob(false);
 
 
 {

--- a/.github/vendor/github.com/grafana/loki-release/workflows/validate.libsonnet
+++ b/.github/vendor/github.com/grafana/loki-release/workflows/validate.libsonnet
@@ -5,7 +5,7 @@ local _validationJob = common.validationJob;
 
 local setupValidationDeps = function(job) job {
   steps: [
-    common.checkout,
+    common.fetchReleaseRepo,
     common.fetchReleaseLib,
     common.fixDubiousOwnership,
     step.new('install tar')
@@ -33,7 +33,8 @@ local validationJob = _validationJob(false);
   local validationMakeStep = function(name, target)
     step.new(name)
     + step.withIf('${{ !fromJSON(env.SKIP_VALIDATION) }}')
-    + step.withRun(common.makeTarget(target)),
+    + step.withRun(common.makeTarget(target))
+    + step.withWorkingDirectory('release'),
 
   // Test jobs
   collectPackages: job.new()
@@ -57,7 +58,7 @@ local validationJob = _validationJob(false);
 
   integration: validationJob
                + job.withSteps([
-                 common.checkout,
+                 common.fetchReleaseRepo,
                  common.fixDubiousOwnership,
                  validationMakeStep('integration', 'test-integration'),
                ]),
@@ -70,38 +71,41 @@ local validationJob = _validationJob(false);
                   },
                 })
                 + job.withSteps([
-                  common.checkout,
+                  common.fetchReleaseRepo,
                   common.fixDubiousOwnership,
                   step.new('test ${{ matrix.package }}')
                   + step.withIf('${{ !fromJSON(env.SKIP_VALIDATION) }}')
                   + step.withRun(|||
                     gotestsum -- -covermode=atomic -coverprofile=coverage.txt -p=4 ./${{ matrix.package }}/...
-                  |||),
+                  |||)
+                  + step.withWorkingDirectory('release'),
                 ]),
 
 
   testLambdaPromtail: validationJob
                       + job.withSteps([
-                        common.checkout,
+                        common.fetchReleaseRepo,
                         common.fixDubiousOwnership,
                         step.new('test push package')
                         + step.withIf('${{ !fromJSON(env.SKIP_VALIDATION) }}')
                         + step.withWorkingDirectory('tools/lambda-promtail')
                         + step.withRun(|||
                           gotestsum -- -covermode=atomic -coverprofile=coverage.txt -p=4 ./...
-                        |||),
+                        |||)
+                        + step.withWorkingDirectory('release'),
                       ]),
 
   testPushPackage: validationJob
                    + job.withSteps([
-                     common.checkout,
+                     common.fetchReleaseRepo,
                      common.fixDubiousOwnership,
                      step.new('test push package')
                      + step.withIf('${{ !fromJSON(env.SKIP_VALIDATION) }}')
                      + step.withWorkingDirectory('pkg/push')
                      + step.withRun(|||
                        gotestsum -- -covermode=atomic -coverprofile=coverage.txt -p=4 ./...
-                     |||),
+                     |||)
+                     + step.withWorkingDirectory('release'),
                    ]),
 
   // Check / lint jobs
@@ -119,6 +123,7 @@ local validationJob = _validationJob(false);
       steps+: [
         step.new('build docs website')
         + step.withIf('${{ !fromJSON(env.SKIP_VALIDATION) }}')
+        + step.withWorkingDirectory('release')
         + step.withRun(|||
           cat <<EOF | docker run \
             --interactive \
@@ -141,20 +146,21 @@ local validationJob = _validationJob(false);
   faillint:
     validationJob
     + job.withSteps([
-      common.checkout,
+      common.fetchReleaseRepo,
       common.fixDubiousOwnership,
       step.new('faillint')
       + step.withIf('${{ !fromJSON(env.SKIP_VALIDATION) }}')
       + step.withRun(|||
         faillint -paths "sync/atomic=go.uber.org/atomic" ./...
-
-      |||),
+      |||)
+      + step.withWorkingDirectory('release'),
     ]),
 
   golangciLint: setupValidationDeps(
     validationJob
     + job.withSteps(
       [
+        common.checkout,
         step.new('golangci-lint', 'golangci/golangci-lint-action@08e2f20817b15149a52b5b3ebe7de50aff2ba8c5')
         + step.withIf('${{ !fromJSON(env.SKIP_VALIDATION) }}')
         + step.with({
@@ -176,7 +182,8 @@ local validationJob = _validationJob(false);
         + step.withRun(|||
           git fetch origin
           make check-format
-        |||),
+        |||)
+        + step.withWorkingDirectory('release'),
       ]
     )
   ),
@@ -197,7 +204,6 @@ local validationJob = _validationJob(false);
              })
              + job.withIf("${{ !fromJSON(inputs.skip_validation) && (cancelled() || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure')) }}")
              + job.withSteps([
-               common.checkout,
                step.new('verify checks passed')
                + step.withRun(|||
                  echo "Some checks have failed!"
@@ -220,7 +226,6 @@ local validationJob = _validationJob(false);
            SKIP_VALIDATION: '${{ inputs.skip_validation }}',
          })
          + job.withSteps([
-           common.checkout,
            step.new('checks passed')
            + step.withIf('${{ !fromJSON(env.SKIP_VALIDATION) }}')
            + step.withRun(|||

--- a/.github/workflows/minor-release-pr.yml
+++ b/.github/workflows/minor-release-pr.yml
@@ -147,6 +147,9 @@ jobs:
           --entrypoint /bin/sh "grafana/loki-build-image:0.34.6"
           git config --global --add safe.directory /src/loki
           echo "${NFPM_SIGNING_KEY}" > $NFPM_SIGNING_KEY_FILE
+          if echo "grafana/loki-build-image:0.34.6" | grep -q "golang"; then
+            /src/loki/.github/vendor/github.com/grafana/loki-release/workflows/install_workflow_dependencies.sh dist
+          fi
           make dist packages
         EOF
       working-directory: "release"

--- a/.github/workflows/patch-release-pr.yml
+++ b/.github/workflows/patch-release-pr.yml
@@ -147,6 +147,9 @@ jobs:
           --entrypoint /bin/sh "grafana/loki-build-image:0.34.6"
           git config --global --add safe.directory /src/loki
           echo "${NFPM_SIGNING_KEY}" > $NFPM_SIGNING_KEY_FILE
+          if echo "grafana/loki-build-image:0.34.6" | grep -q "golang"; then
+            /src/loki/.github/vendor/github.com/grafana/loki-release/workflows/install_workflow_dependencies.sh dist
+          fi
           make dist packages
         EOF
       working-directory: "release"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,6 +110,87 @@ jobs:
         parent: false
         path: "release/dist"
         process_gcloudignore: false
+  createReleaseBranch:
+    needs:
+    - "publishRelease"
+    outputs:
+      branchExists: "${{ steps.create_branch.outputs.branch_exists }}"
+      branchName: "${{ steps.create_branch.outputs.branch_name }}"
+    runs-on: "ubuntu-latest"
+    steps:
+    - name: "pull code to release"
+      uses: "actions/checkout@v4"
+      with:
+        path: "release"
+        repository: "${{ env.RELEASE_REPO }}"
+    - id: "extract_branch"
+      name: "extract branch name"
+      run: |
+        echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
+      working-directory: "release"
+    - id: "get_github_app_token"
+      if: "${{ fromJSON(env.USE_GITHUB_APP_TOKEN) }}"
+      name: "get github app token"
+      uses: "actions/create-github-app-token@v1"
+      with:
+        app-id: "${{ secrets.APP_ID }}"
+        owner: "${{ github.repository_owner }}"
+        private-key: "${{ secrets.APP_PRIVATE_KEY }}"
+    - id: "github_app_token"
+      name: "set github token"
+      run: |
+        if [[ "${USE_GITHUB_APP_TOKEN}" == "true" ]]; then
+          echo "token=${{ steps.get_github_app_token.outputs.token }}" >> $GITHUB_OUTPUT
+        else
+          echo "token=${{ secrets.GH_TOKEN }}" >> $GITHUB_OUTPUT
+        fi
+    - env:
+        GH_TOKEN: "${{ steps.github_app_token.outputs.token }}"
+        VERSION: "${{ needs.publishRelease.outputs.name }}"
+      id: "create_branch"
+      name: "create release branch"
+      run: |
+        # Debug and clean the version variable
+        echo "Original VERSION: $VERSION"
+        
+        # Remove all quotes (both single and double)
+        VERSION=$(echo $VERSION | tr -d '"' | tr -d "'")
+        echo "After removing quotes: $VERSION"
+        
+        # Extract version without the 'v' prefix if it exists
+        VERSION="${VERSION#v}"
+        echo "After removing v prefix: $VERSION"
+        
+        # Extract major and minor versions
+        MAJOR=$(echo $VERSION | cut -d. -f1)
+        MINOR=$(echo $VERSION | cut -d. -f2)
+        echo "MAJOR: $MAJOR, MINOR: $MINOR"
+        
+        # Create branch name from template
+        BRANCH_TEMPLATE="release-\${major}.\${minor}.x"
+        BRANCH_NAME=${BRANCH_TEMPLATE//\$\{major\}/$MAJOR}
+        BRANCH_NAME=${BRANCH_NAME//\$\{minor\}/$MINOR}
+        
+        echo "Checking if branch already exists: $BRANCH_NAME"
+        
+        # Check if branch exists
+        if git ls-remote --heads origin $BRANCH_NAME | grep -q $BRANCH_NAME; then
+          echo "Branch $BRANCH_NAME already exists, skipping creation"
+          echo "branch_exists=true" >> $GITHUB_OUTPUT
+          echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
+        else
+          echo "Creating branch: $BRANCH_NAME from tag: ${{ needs.publishRelease.outputs.name }}"
+          
+          # Create branch from the tag
+          git fetch --tags
+          git checkout "${{ steps.extract_branch.outputs.branch }}"
+          git checkout -b $BRANCH_NAME
+          git push -u origin $BRANCH_NAME
+          
+          echo "branch_exists=false" >> $GITHUB_OUTPUT
+          echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
+        fi
+      working-directory: "release"
   publishDockerPlugins:
     needs:
     - "createRelease"
@@ -193,6 +274,8 @@ jobs:
     - "createRelease"
     - "publishImages"
     - "publishDockerPlugins"
+    outputs:
+      name: "${{ needs.createRelease.outputs.name }}"
     runs-on: "ubuntu-latest"
     steps:
     - name: "pull code to release"


### PR DESCRIPTION
**What this PR does / why we need it**:

Pulls in https://github.com/grafana/loki-release/pull/230 which will create the release branch if it doesn't exist for major and minor releases after publishing the release.

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [X] Documentation added
- [X] Tests updated
- [X] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [X] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [X] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
