### PR TITLE
fix: dont panic when schema_config does not exist in the config file

### DIFF
--- a/pkg/loki/config_test.go
+++ b/pkg/loki/config_test.go
@@ -8,9 +8,11 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/dskit/server"
 	"github.com/grafana/loki/v3/pkg/ingester"
 	"github.com/grafana/loki/v3/pkg/storage/config"
 	"github.com/grafana/loki/v3/pkg/storage/types"
+	"github.com/grafana/loki/v3/pkg/validation"
 )
 
 func TestCrossComponentValidation(t *testing.T) {
@@ -83,6 +85,20 @@ func TestCrossComponentValidation(t *testing.T) {
 							},
 						},
 					},
+				},
+			},
+			err: true,
+		},
+		{
+			desc: "no schema_config",
+			base: &Config{
+				AuthEnabled: false,
+				Server: server.Config{
+					HTTPListenPort: 3100,
+				},
+				LimitsConfig: validation.Limits{
+					RejectOldSamples:       true,
+					RejectOldSamplesMaxAge: model.Duration(1),
 				},
 			},
 			err: true,

--- a/pkg/loki/validation.go
+++ b/pkg/loki/validation.go
@@ -23,6 +23,9 @@ func validateBackendAndLegacyReadMode(c *Config) []error {
 }
 
 func validateSchemaRequirements(c *Config) []error {
+	if len(c.SchemaConfig.Configs) == 0 {
+		return []error{}
+	}
 	var errs []error
 	p := config.ActivePeriodConfig(c.SchemaConfig.Configs)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
initial startup should not panic

**Which issue(s) this PR fixes**:
Fixes #16698 

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
