### PR TITLE
docs: Patch release notes 2.9.12

### DIFF
--- a/docs/sources/release-notes/v2-9.md
+++ b/docs/sources/release-notes/v2-9.md
@@ -36,6 +36,10 @@ For a full list of all changes and fixes, refer to the [CHANGELOG](https://githu
 
 ## Bug fixes
 
+### 2.9.12 (2025-03-12)
+
+* **deps:** Loki 2.9.x Bump Alpine and Go versions ([#16294](https://github.com/grafana/loki/issues/16294)) ([f2deeb7](https://github.com/grafana/loki/commit/f2deeb76ac39e835bffe61e1e4f78b980afdc0c0))
+
 ### 2.9.11 (2024-12-04)
 
 - **docker:** Update Docker to 23.0.15 ([#](https://github.com/grafana/loki/issues/)).


### PR DESCRIPTION
**What this PR does / why we need it**:

Release Notes for Loki 2.9.12 patch release.