### PR TITLE
chore: Implement basic skeleton for a physical plan

### DIFF
--- a/pkg/dataobj/planner/physical/dataobjscan.go
+++ b/pkg/dataobj/planner/physical/dataobjscan.go
@@ -16,12 +16,12 @@ const (
 type DataObjScan struct {
 	id string
 
-	Location   DataObjLocation
-	StreamIDs  []int64
-	Projection []ColumnExpression
-	Predicates []Expression
-	Direction  Direction
-	Limit      uint32
+	Location    DataObjLocation
+	StreamIDs   []int64
+	Projections []ColumnExpression
+	Predicates  []Expression
+	Direction   Direction
+	Limit       uint32
 }
 
 func (s *DataObjScan) ID() string {

--- a/pkg/dataobj/planner/physical/dataobjscan.go
+++ b/pkg/dataobj/planner/physical/dataobjscan.go
@@ -1,27 +1,37 @@
 package physical
 
-import "github.com/grafana/loki/v3/pkg/dataobj/planner/schema"
+type DataObjLocation string
 
+type Direction int8
+
+const (
+	Forward Direction = iota
+	Backwards
+)
+
+// DataObjScan represents a physical plan operation for reading data objects.
+// It contains information about the object location, stream IDs, projections,
+// predicates, scan direction, and result limit for reading data from a data
+// object.
 type DataObjScan struct {
-	name    string
-	sources []string
-	schema  schema.Schema
+	id string
+
+	Location   DataObjLocation
+	StreamIDs  []int64
+	Projection []ColumnExpression
+	Predicates []Expression
+	Direction  Direction
+	Limit      uint32
 }
 
-func (*DataObjScan) ID() NodeType {
+func (s *DataObjScan) ID() string {
+	return s.id
+}
+
+func (*DataObjScan) Type() NodeType {
 	return NodeTypeDataObjScan
 }
 
-func (s *DataObjScan) Children() []Node {
-	return nil
-}
-
-func (s *DataObjScan) Schema() schema.Schema {
-	return s.schema
-}
-
-func (*DataObjScan) isNode() {}
-
-func (s *DataObjScan) Accept(v Visitor) (bool, error) {
+func (s *DataObjScan) Accept(v Visitor) error {
 	return v.VisitDataObjScan(s)
 }

--- a/pkg/dataobj/planner/physical/dataobjscan.go
+++ b/pkg/dataobj/planner/physical/dataobjscan.go
@@ -1,7 +1,11 @@
 package physical
 
+// DataObjLocation is a string that uniquely indentifies a data object location in
+// object storage.
 type DataObjLocation string
 
+// Direction defines the order in which the data object is read, which is
+// either forward (ascending timestamps) or backwards (descending timestamps).
 type Direction int8
 
 const (
@@ -16,22 +20,40 @@ const (
 type DataObjScan struct {
 	id string
 
-	Location    DataObjLocation
-	StreamIDs   []int64
+	// Location is the unique name of the data object that is used as source for
+	// reading streams.
+	Location DataObjLocation
+	// StreamIDs is a set of stream IDs inside the data object. These IDs are
+	// only unique in the context of a single data object.
+	StreamIDs []int64
+	// Projections are used to limit the columns that are read to the ones
+	// provided in the column expressions to reduce the amount of data that needs
+	// to be processed.
 	Projections []ColumnExpression
-	Predicates  []Expression
-	Direction   Direction
-	Limit       uint32
+	// Predicates are used to filter rows to reduce the amount of rows that are
+	// returned. Predicates would almost always contain a time range filter to
+	// only read the logs for the requested time range.
+	Predicates []Expression
+	// Direction defines in what order columns are read.
+	Direction Direction
+	// Limit is used to stop scanning the data object once it is reached.
+	Limit uint32
 }
 
+// ID implements the [Node] interface.
+// Returns a string that uniquely identifies the node in the plan.
 func (s *DataObjScan) ID() string {
 	return s.id
 }
 
+// Type implements the [Node] interface.
+// Returns the type of the node.
 func (*DataObjScan) Type() NodeType {
 	return NodeTypeDataObjScan
 }
 
+// Accept implements the [Node] interface.
+// Dispatches itself to the provided [Visitor] v
 func (s *DataObjScan) Accept(v Visitor) error {
 	return v.VisitDataObjScan(s)
 }

--- a/pkg/dataobj/planner/physical/dataobjscan.go
+++ b/pkg/dataobj/planner/physical/dataobjscan.go
@@ -1,0 +1,27 @@
+package physical
+
+import "github.com/grafana/loki/v3/pkg/dataobj/planner/schema"
+
+type DataObjScan struct {
+	name    string
+	sources []string
+	schema  schema.Schema
+}
+
+func (*DataObjScan) ID() NodeType {
+	return NodeTypeDataObjScan
+}
+
+func (s *DataObjScan) Children() []Node {
+	return nil
+}
+
+func (s *DataObjScan) Schema() schema.Schema {
+	return s.schema
+}
+
+func (*DataObjScan) isNode() {}
+
+func (s *DataObjScan) Accept(v Visitor) (bool, error) {
+	return v.VisitDataObjScan(s)
+}

--- a/pkg/dataobj/planner/physical/expressions.go
+++ b/pkg/dataobj/planner/physical/expressions.go
@@ -1,0 +1,181 @@
+package physical
+
+import "fmt"
+
+type ExpressionType uint32
+
+const (
+	EXPR_TYPE_UNARY ExpressionType = iota
+	EXPR_TYPE_BINARY
+	EXPR_TYPE_LITERAL
+	EXPR_TYPE_COLUMN
+)
+
+func (t ExpressionType) String() string {
+	switch t {
+	case EXPR_TYPE_UNARY:
+		return "UnaryExpression"
+	case EXPR_TYPE_BINARY:
+		return "BinaryExpression"
+	case EXPR_TYPE_LITERAL:
+		return "LiteralExpression"
+	case EXPR_TYPE_COLUMN:
+		return "ColumnExpression"
+	default:
+		return fmt.Sprintf("unknown expression type %d", t)
+	}
+}
+
+type UnaryOpType uint32
+
+const (
+	UNARY_OP_NOT UnaryOpType = iota
+	UNARY_OP_ABS
+)
+
+func (t UnaryOpType) String() string {
+	switch t {
+	case UNARY_OP_NOT:
+		return "NOT"
+	case UNARY_OP_ABS:
+		return "ABS"
+	default:
+		return fmt.Sprintf("unknown unary operator type %d", t)
+	}
+}
+
+type BinaryOpType uint32
+
+const (
+	BINARY_OP_EQ BinaryOpType = iota
+	BINARY_OP_NEQ
+	BINARY_OP_GT
+	BINARY_OP_GTE
+	BINARY_OP_LT
+	BINARY_OP_LTE
+	BINARY_OP_AND
+	BINARY_OP_OR
+	BINARY_OP_XOR
+	BINARY_OP_NOT
+	BINARY_OP_ADD
+	BINARY_OP_SUB
+	BINARY_OP_MUL
+	BINARY_OP_DIV
+	BINARY_OP_MOD
+	BINARY_OP_MATCH_STR
+	BINARY_OP_NMATCH_STR
+	BINARY_OP_MATCH_RE
+	BINARY_OP_NMATCH_RE
+)
+
+func (t BinaryOpType) String() string {
+	switch t {
+	case BINARY_OP_EQ:
+		return "EQ"
+	case BINARY_OP_NEQ:
+		return "NEQ" // convenience for NOT(EQ(expr))
+	case BINARY_OP_GT:
+		return "GT"
+	case BINARY_OP_GTE:
+		return "GTE"
+	case BINARY_OP_LT:
+		return "LT" // convenience for NOT(GTE(expr))
+	case BINARY_OP_LTE:
+		return "LTE" // convenience for NOT(GT(expr))
+	case BINARY_OP_AND:
+		return "AND"
+	case BINARY_OP_OR:
+		return "OR"
+	case BINARY_OP_XOR:
+		return "XOR"
+	case BINARY_OP_NOT:
+		return "NOT"
+	case BINARY_OP_ADD:
+		return "ADD"
+	case BINARY_OP_SUB:
+		return "SUB"
+	case BINARY_OP_MUL:
+		return "MUL"
+	case BINARY_OP_DIV:
+		return "DIV"
+	case BINARY_OP_MOD:
+		return "MOD"
+	case BINARY_OP_MATCH_STR:
+		return "MATCH_STR"
+	case BINARY_OP_NMATCH_STR:
+		return "NMATCH_STR" // convenience for NOT(MATCH_STR(...))
+	case BINARY_OP_MATCH_RE:
+		return "MATCH_RE"
+	case BINARY_OP_NMATCH_RE:
+		return "NMATCH_RE" // convenience for NOT(MATCH_RE(...))
+	default:
+		return fmt.Sprintf("unknown binary operator type %d", t)
+	}
+}
+
+type Expression interface {
+	ID() ExpressionType
+	isExpr()
+}
+
+type UnaryExpression interface {
+	Expression
+	isUnaryExpr()
+}
+
+type BinaryExpression interface {
+	Expression
+	isBinaryExpr()
+}
+
+type LiteralExpression interface {
+	Expression
+	isLiteralExpr()
+}
+
+type ColumnExpression interface {
+	Expression
+	isColumnExpr()
+}
+
+type UnaryExpr[T UnaryOpType] struct {
+	Left Expression
+	Op   T
+}
+
+func (*UnaryExpr[T]) isExpr()      {}
+func (*UnaryExpr[T]) isUnaryExpr() {}
+func (*UnaryExpr[T]) ID() ExpressionType {
+	return EXPR_TYPE_UNARY
+}
+
+type BinaryExpr[T BinaryOpType] struct {
+	Left, Right Expression
+	Op          T
+}
+
+func (*BinaryExpr[T]) isExpr()       {}
+func (*BinaryExpr[T]) isBinaryExpr() {}
+func (*BinaryExpr[T]) ID() ExpressionType {
+	return EXPR_TYPE_BINARY
+}
+
+type LiteralExpr[T any] struct {
+	value T
+}
+
+func (*LiteralExpr[T]) isExpr()        {}
+func (*LiteralExpr[T]) isLiteralExpr() {}
+func (*LiteralExpr[T]) ID() ExpressionType {
+	return EXPR_TYPE_LITERAL
+}
+
+type ColumnExpr struct {
+	name string
+}
+
+func (e *ColumnExpr) isExpr()       {}
+func (e *ColumnExpr) isColumnExpr() {}
+func (e *ColumnExpr) ID() ExpressionType {
+	return EXPR_TYPE_COLUMN
+}

--- a/pkg/dataobj/planner/physical/expressions.go
+++ b/pkg/dataobj/planner/physical/expressions.go
@@ -8,7 +8,7 @@ type ValueType uint32
 const (
 	_ ValueType = iota // zero-value is an invalid type
 	ValueTypeBool
-	ValueTypeUint64
+	ValueTypeInt64
 	ValueTypeTimestamp
 	ValueTypeString
 )
@@ -157,6 +157,7 @@ type BinaryExpression interface {
 // physcial plan.
 type LiteralExpression interface {
 	Expression
+	ValueType() ValueType
 	isLiteralExpr()
 }
 
@@ -198,9 +199,9 @@ func (*BinaryExpr) Type() ExpressionType {
 }
 
 // LiteralExpr is an expression that implements the [LiteralExpression] interface.
-type LiteralExpr[T bool | uint64 | string] struct {
+type LiteralExpr[T bool | int64 | uint64 | string] struct {
 	Value T
-	Ty    ValueType
+	ty    ValueType
 }
 
 func (*LiteralExpr[T]) isExpr()        {}
@@ -209,6 +210,43 @@ func (*LiteralExpr[T]) isLiteralExpr() {}
 // ID returns the type of the [LiteralExpr].
 func (*LiteralExpr[T]) Type() ExpressionType {
 	return ExprTypeLiteral
+}
+
+// ValueType returns the type of the literal value.
+func (e *LiteralExpr[T]) ValueType() ValueType {
+	return e.ty
+}
+
+// newBooleanLiteral is a convenience function for creating boolean literals.
+func newBooleanLiteral(value bool) *LiteralExpr[bool] {
+	return &LiteralExpr[bool]{
+		Value: value,
+		ty:    ValueTypeBool,
+	}
+}
+
+// newInt64Literal is a convenience function for creating int64 literals.
+func newInt64Literal(value int64) *LiteralExpr[int64] {
+	return &LiteralExpr[int64]{
+		Value: value,
+		ty:    ValueTypeInt64,
+	}
+}
+
+// newTimestampLiteral is a convenience function for creating timestamp literals.
+func newTimestampLiteral(value uint64) *LiteralExpr[uint64] {
+	return &LiteralExpr[uint64]{
+		Value: value,
+		ty:    ValueTypeTimestamp,
+	}
+}
+
+// newStringLiteral is a convenience function for creating string literals.
+func newStringLiteral(value string) *LiteralExpr[string] {
+	return &LiteralExpr[string]{
+		Value: value,
+		ty:    ValueTypeString,
+	}
 }
 
 // ColumnExpr is an expression that implements the [ColumnExpr] interface.

--- a/pkg/dataobj/planner/physical/expressions.go
+++ b/pkg/dataobj/planner/physical/expressions.go
@@ -5,21 +5,21 @@ import "fmt"
 type ExpressionType uint32
 
 const (
-	EXPR_TYPE_UNARY ExpressionType = iota
-	EXPR_TYPE_BINARY
-	EXPR_TYPE_LITERAL
-	EXPR_TYPE_COLUMN
+	ExprTypeUnary ExpressionType = iota
+	ExprTypeBinary
+	ExprTypeLiteral
+	ExprTypeColumn
 )
 
 func (t ExpressionType) String() string {
 	switch t {
-	case EXPR_TYPE_UNARY:
+	case ExprTypeUnary:
 		return "UnaryExpression"
-	case EXPR_TYPE_BINARY:
+	case ExprTypeBinary:
 		return "BinaryExpression"
-	case EXPR_TYPE_LITERAL:
+	case ExprTypeLiteral:
 		return "LiteralExpression"
-	case EXPR_TYPE_COLUMN:
+	case ExprTypeColumn:
 		return "ColumnExpression"
 	default:
 		return fmt.Sprintf("unknown expression type %d", t)
@@ -29,15 +29,15 @@ func (t ExpressionType) String() string {
 type UnaryOpType uint32
 
 const (
-	UNARY_OP_NOT UnaryOpType = iota
-	UNARY_OP_ABS
+	UnaryOpNot UnaryOpType = iota
+	UnaryOpAbs
 )
 
 func (t UnaryOpType) String() string {
 	switch t {
-	case UNARY_OP_NOT:
+	case UnaryOpNot:
 		return "NOT"
-	case UNARY_OP_ABS:
+	case UnaryOpAbs:
 		return "ABS"
 	default:
 		return fmt.Sprintf("unknown unary operator type %d", t)
@@ -47,66 +47,66 @@ func (t UnaryOpType) String() string {
 type BinaryOpType uint32
 
 const (
-	BINARY_OP_EQ BinaryOpType = iota
-	BINARY_OP_NEQ
-	BINARY_OP_GT
-	BINARY_OP_GTE
-	BINARY_OP_LT
-	BINARY_OP_LTE
-	BINARY_OP_AND
-	BINARY_OP_OR
-	BINARY_OP_XOR
-	BINARY_OP_NOT
-	BINARY_OP_ADD
-	BINARY_OP_SUB
-	BINARY_OP_MUL
-	BINARY_OP_DIV
-	BINARY_OP_MOD
-	BINARY_OP_MATCH_STR
-	BINARY_OP_NMATCH_STR
-	BINARY_OP_MATCH_RE
-	BINARY_OP_NMATCH_RE
+	BinaryOpEq BinaryOpType = iota
+	BinaryOpNeq
+	BinaryOpGt
+	BinaryOpGte
+	BinaryOpLt
+	BinaryOpLte
+	BinaryOpAnd
+	BinaryOpOr
+	BinaryOpXor
+	BinaryOpNot
+	BinaryOpAdd
+	BinaryOpSub
+	BinaryOpMul
+	BinaryOpDiv
+	BinaryOpMod
+	BinaryOpMatchStr
+	BinaryOpNmatchStr
+	BinaryOpMatchRe
+	BinaryOpNmatchRe
 )
 
 func (t BinaryOpType) String() string {
 	switch t {
-	case BINARY_OP_EQ:
+	case BinaryOpEq:
 		return "EQ"
-	case BINARY_OP_NEQ:
+	case BinaryOpNeq:
 		return "NEQ" // convenience for NOT(EQ(expr))
-	case BINARY_OP_GT:
+	case BinaryOpGt:
 		return "GT"
-	case BINARY_OP_GTE:
+	case BinaryOpGte:
 		return "GTE"
-	case BINARY_OP_LT:
+	case BinaryOpLt:
 		return "LT" // convenience for NOT(GTE(expr))
-	case BINARY_OP_LTE:
+	case BinaryOpLte:
 		return "LTE" // convenience for NOT(GT(expr))
-	case BINARY_OP_AND:
+	case BinaryOpAnd:
 		return "AND"
-	case BINARY_OP_OR:
+	case BinaryOpOr:
 		return "OR"
-	case BINARY_OP_XOR:
+	case BinaryOpXor:
 		return "XOR"
-	case BINARY_OP_NOT:
+	case BinaryOpNot:
 		return "NOT"
-	case BINARY_OP_ADD:
+	case BinaryOpAdd:
 		return "ADD"
-	case BINARY_OP_SUB:
+	case BinaryOpSub:
 		return "SUB"
-	case BINARY_OP_MUL:
+	case BinaryOpMul:
 		return "MUL"
-	case BINARY_OP_DIV:
+	case BinaryOpDiv:
 		return "DIV"
-	case BINARY_OP_MOD:
+	case BinaryOpMod:
 		return "MOD"
-	case BINARY_OP_MATCH_STR:
+	case BinaryOpMatchStr:
 		return "MATCH_STR"
-	case BINARY_OP_NMATCH_STR:
+	case BinaryOpNmatchStr:
 		return "NMATCH_STR" // convenience for NOT(MATCH_STR(...))
-	case BINARY_OP_MATCH_RE:
+	case BinaryOpMatchRe:
 		return "MATCH_RE"
-	case BINARY_OP_NMATCH_RE:
+	case BinaryOpNmatchRe:
 		return "NMATCH_RE" // convenience for NOT(MATCH_RE(...))
 	default:
 		return fmt.Sprintf("unknown binary operator type %d", t)
@@ -146,7 +146,7 @@ type UnaryExpr[T UnaryOpType] struct {
 func (*UnaryExpr[T]) isExpr()      {}
 func (*UnaryExpr[T]) isUnaryExpr() {}
 func (*UnaryExpr[T]) ID() ExpressionType {
-	return EXPR_TYPE_UNARY
+	return ExprTypeUnary
 }
 
 type BinaryExpr[T BinaryOpType] struct {
@@ -157,7 +157,7 @@ type BinaryExpr[T BinaryOpType] struct {
 func (*BinaryExpr[T]) isExpr()       {}
 func (*BinaryExpr[T]) isBinaryExpr() {}
 func (*BinaryExpr[T]) ID() ExpressionType {
-	return EXPR_TYPE_BINARY
+	return ExprTypeBinary
 }
 
 type LiteralExpr[T any] struct {
@@ -167,7 +167,7 @@ type LiteralExpr[T any] struct {
 func (*LiteralExpr[T]) isExpr()        {}
 func (*LiteralExpr[T]) isLiteralExpr() {}
 func (*LiteralExpr[T]) ID() ExpressionType {
-	return EXPR_TYPE_LITERAL
+	return ExprTypeLiteral
 }
 
 type ColumnExpr struct {
@@ -177,5 +177,5 @@ type ColumnExpr struct {
 func (e *ColumnExpr) isExpr()       {}
 func (e *ColumnExpr) isColumnExpr() {}
 func (e *ColumnExpr) ID() ExpressionType {
-	return EXPR_TYPE_COLUMN
+	return ExprTypeColumn
 }

--- a/pkg/dataobj/planner/physical/expressions_test.go
+++ b/pkg/dataobj/planner/physical/expressions_test.go
@@ -52,3 +52,38 @@ func TestExpressionTypes(t *testing.T) {
 		})
 	}
 }
+
+func TestLiteralExpr(t *testing.T) {
+
+	t.Run("bool", func(t *testing.T) {
+		var expr Expression = newBooleanLiteral(true)
+		require.Equal(t, ExprTypeLiteral, expr.Type())
+		literal, ok := expr.(LiteralExpression)
+		require.True(t, ok)
+		require.Equal(t, ValueTypeBool, literal.ValueType())
+	})
+
+	t.Run("int64", func(t *testing.T) {
+		var expr Expression = newInt64Literal(123456789)
+		require.Equal(t, ExprTypeLiteral, expr.Type())
+		literal, ok := expr.(LiteralExpression)
+		require.True(t, ok)
+		require.Equal(t, ValueTypeInt64, literal.ValueType())
+	})
+
+	t.Run("timestamp", func(t *testing.T) {
+		var expr Expression = newTimestampLiteral(1741882435000000000)
+		require.Equal(t, ExprTypeLiteral, expr.Type())
+		literal, ok := expr.(LiteralExpression)
+		require.True(t, ok)
+		require.Equal(t, ValueTypeTimestamp, literal.ValueType())
+	})
+
+	t.Run("string", func(t *testing.T) {
+		var expr Expression = newStringLiteral("loki")
+		require.Equal(t, ExprTypeLiteral, expr.Type())
+		literal, ok := expr.(LiteralExpression)
+		require.True(t, ok)
+		require.Equal(t, ValueTypeString, literal.ValueType())
+	})
+}

--- a/pkg/dataobj/planner/physical/expressions_test.go
+++ b/pkg/dataobj/planner/physical/expressions_test.go
@@ -1,0 +1,61 @@
+package physical
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestExpressionTypes(t *testing.T) {
+	tests := []struct {
+		name     string
+		expr     Expression
+		expected ExpressionType
+	}{
+		{
+			name: "UnaryExpression",
+			expr: &UnaryExpr{
+				Op:   UnaryOpNot,
+				Left: &LiteralExpr[bool]{Value: true},
+			},
+			expected: ExprTypeUnary,
+		},
+		{
+			name: "BinaryExpression",
+			expr: &BinaryExpr{
+				Op:    BinaryOpEq,
+				Left:  &ColumnExpr{Name: "col"},
+				Right: &LiteralExpr[string]{Value: "foo"},
+			},
+			expected: ExprTypeBinary,
+		},
+		{
+			name: "LiteralExpression",
+			expr: &LiteralExpr[string]{
+				Value: "col",
+			},
+			expected: ExprTypeLiteral,
+		},
+		{
+			name: "ColumnExpression",
+			expr: &ColumnExpr{
+				Name: "log",
+			},
+			expected: ExprTypeColumn,
+		},
+		{
+			name: "ColumnExpression",
+			expr: &ColumnExpr{
+				Name: "log",
+			},
+			expected: ExprTypeColumn,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, tt.expr.Type())
+			require.Equal(t, tt.name, tt.expr.Type().String())
+		})
+	}
+}

--- a/pkg/dataobj/planner/physical/expressions_test.go
+++ b/pkg/dataobj/planner/physical/expressions_test.go
@@ -43,13 +43,6 @@ func TestExpressionTypes(t *testing.T) {
 			},
 			expected: ExprTypeColumn,
 		},
-		{
-			name: "ColumnExpression",
-			expr: &ColumnExpr{
-				Name: "log",
-			},
-			expected: ExprTypeColumn,
-		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/dataobj/planner/physical/filter.go
+++ b/pkg/dataobj/planner/physical/filter.go
@@ -1,27 +1,24 @@
 package physical
 
-import "github.com/grafana/loki/v3/pkg/dataobj/planner/schema"
-
+// Filter represents a filtering operation in the physical plan.
+// It contains a list of predicates (conditional expressions) that are later
+// evaluated against the input columns and produce a result that only contains
+// rows that match the given conditions. The list of expressions are chained
+// with a logical AND.
 type Filter struct {
-	input Node
-	expr  Expression // filter predicate
-	proj  []string
+	id string
+
+	Predicates []Expression // filter predicate
 }
 
-func (*Filter) ID() NodeType {
+func (f *Filter) ID() string {
+	return f.id
+}
+
+func (*Filter) Type() NodeType {
 	return NodeTypeFilter
 }
 
-func (f *Filter) Children() []Node {
-	return []Node{f.input}
-}
-
-func (f *Filter) Schema() schema.Schema {
-	return f.input.Schema()
-}
-
-func (*Filter) isNode() {}
-
-func (f *Filter) Accept(v Visitor) (bool, error) {
+func (f *Filter) Accept(v Visitor) error {
 	return v.VisitFilter(f)
 }

--- a/pkg/dataobj/planner/physical/filter.go
+++ b/pkg/dataobj/planner/physical/filter.go
@@ -1,0 +1,27 @@
+package physical
+
+import "github.com/grafana/loki/v3/pkg/dataobj/planner/schema"
+
+type Filter struct {
+	input Node
+	expr  Expression // filter predicate
+	proj  []string
+}
+
+func (*Filter) ID() NodeType {
+	return NodeTypeFilter
+}
+
+func (f *Filter) Children() []Node {
+	return []Node{f.input}
+}
+
+func (f *Filter) Schema() schema.Schema {
+	return f.input.Schema()
+}
+
+func (*Filter) isNode() {}
+
+func (f *Filter) Accept(v Visitor) (bool, error) {
+	return v.VisitFilter(f)
+}

--- a/pkg/dataobj/planner/physical/filter.go
+++ b/pkg/dataobj/planner/physical/filter.go
@@ -8,17 +8,25 @@ package physical
 type Filter struct {
 	id string
 
-	Predicates []Expression // filter predicate
+	// Predicates is a list of filter expressions that are used to discard not
+	// matching rows during execution.
+	Predicates []Expression
 }
 
+// ID implements the [Node] interface.
+// Returns a string that uniquely identifies the node in the plan.
 func (f *Filter) ID() string {
 	return f.id
 }
 
+// Type implements the [Node] interface.
+// Returns the type of the node.
 func (*Filter) Type() NodeType {
 	return NodeTypeFilter
 }
 
+// Accept implements the [Node] interface.
+// Dispatches itself to the provided [Visitor] v
 func (f *Filter) Accept(v Visitor) error {
 	return v.VisitFilter(f)
 }

--- a/pkg/dataobj/planner/physical/limit.go
+++ b/pkg/dataobj/planner/physical/limit.go
@@ -7,18 +7,26 @@ package physical
 type Limit struct {
 	id string
 
+	// Offset specifies how many initial rows should be skipped.
 	Offset uint32
-	Limit  uint32
+	// Limit specifies how many rows should be returned in total.
+	Limit uint32
 }
 
+// ID implements the [Node] interface.
+// Returns a string that uniquely identifies the node in the plan.
 func (l *Limit) ID() string {
 	return l.id
 }
 
+// Type implements the [Node] interface.
+// Returns the type of the node.
 func (*Limit) Type() NodeType {
 	return NodeTypeLimit
 }
 
+// Accept implements the [Node] interface.
+// Dispatches itself to the provided [Visitor] v
 func (l *Limit) Accept(v Visitor) error {
 	return v.VisitLimit(l)
 }

--- a/pkg/dataobj/planner/physical/limit.go
+++ b/pkg/dataobj/planner/physical/limit.go
@@ -1,0 +1,26 @@
+package physical
+
+import "github.com/grafana/loki/v3/pkg/dataobj/planner/schema"
+
+type Limit struct {
+	input         Node
+	offset, limit uint32
+}
+
+func (*Limit) ID() NodeType {
+	return NodeTypeLimit
+}
+
+func (l *Limit) Children() []Node {
+	return []Node{l.input}
+}
+
+func (l *Limit) Schema() schema.Schema {
+	panic("unimplemented")
+}
+
+func (*Limit) isNode() {}
+
+func (l *Limit) Accept(v Visitor) (bool, error) {
+	return v.VisitLimit(l)
+}

--- a/pkg/dataobj/planner/physical/limit.go
+++ b/pkg/dataobj/planner/physical/limit.go
@@ -1,26 +1,24 @@
 package physical
 
-import "github.com/grafana/loki/v3/pkg/dataobj/planner/schema"
-
+// Limit represents a limiting operation in the physical plan that applies
+// offset and limit to the result set. The offset specifies how many rows to
+// skip before starting to return results, while limit specifies the maximum
+// number of rows to return.
 type Limit struct {
-	input         Node
-	offset, limit uint32
+	id string
+
+	Offset uint32
+	Limit  uint32
 }
 
-func (*Limit) ID() NodeType {
+func (l *Limit) ID() string {
+	return l.id
+}
+
+func (*Limit) Type() NodeType {
 	return NodeTypeLimit
 }
 
-func (l *Limit) Children() []Node {
-	return []Node{l.input}
-}
-
-func (l *Limit) Schema() schema.Schema {
-	panic("unimplemented")
-}
-
-func (*Limit) isNode() {}
-
-func (l *Limit) Accept(v Visitor) (bool, error) {
+func (l *Limit) Accept(v Visitor) error {
 	return v.VisitLimit(l)
 }

--- a/pkg/dataobj/planner/physical/plan.go
+++ b/pkg/dataobj/planner/physical/plan.go
@@ -123,8 +123,8 @@ func (s nodeSet) sorted() []Node {
 // retrieving nodes by ID, retrieving parents and children of nodes, and
 // walking the graph in different orders using the depth-first-search algorithm.
 type Plan struct {
-	// nodesById maps node IDs to their corresponding Node instances for quick lookups
-	nodesById map[string]Node
+	// nodesByID maps node IDs to their corresponding Node instances for quick lookups
+	nodesByID map[string]Node
 	// nodes is a set containing all nodes in the plan
 	nodes nodeSet
 	// parents maps each node to a set of its parent nodes in the execution graph
@@ -134,8 +134,8 @@ type Plan struct {
 }
 
 func (p *Plan) init() {
-	if p.nodesById == nil {
-		p.nodesById = make(map[string]Node)
+	if p.nodesByID == nil {
+		p.nodesByID = make(map[string]Node)
 	}
 	if p.nodes == nil {
 		p.nodes = make(nodeSet)
@@ -159,7 +159,7 @@ func (p *Plan) AddNode(n Node) Node {
 		return n
 	}
 	p.nodes.add(n)
-	p.nodesById[n.ID()] = n
+	p.nodesByID[n.ID()] = n
 
 	if _, ok := p.parents[n]; !ok {
 		p.parents[n] = make(nodeSet)
@@ -199,7 +199,7 @@ func (p *Plan) Len() int {
 
 // NodeByID returns the node with the given identifier
 func (p *Plan) NodeByID(id string) Node {
-	return p.nodesById[id]
+	return p.nodesByID[id]
 }
 
 // Parents returns all parent nodes of the given node

--- a/pkg/dataobj/planner/physical/plan.go
+++ b/pkg/dataobj/planner/physical/plan.go
@@ -1,6 +1,10 @@
 package physical
 
-import "github.com/grafana/loki/v3/pkg/dataobj/planner/schema"
+import (
+	"errors"
+	"fmt"
+	"slices"
+)
 
 type NodeType uint32
 
@@ -29,13 +33,21 @@ func (t NodeType) String() string {
 	}
 }
 
+// Node represents a single operation in a physical execution plan.
+// It defines the core interface that all physical plan nodes must implement.
+// Each node represents a specific operation like scanning, filtering, or
+// transforming data.
+// Nodes can be connected to form a directed acyclic graph (DAG) representing
+// the complete execution plan.
 type Node interface {
+	// Traversable accepts a node to be visited by the Visitor
 	Traversable
-
-	ID() NodeType
-	Schema() schema.Schema
-	Children() []Node
-
+	// ID returns a string that uniquely identifies a node in the plan
+	ID() string
+	// Type returns the node type
+	Type() NodeType
+	// isNode is a marker interface to denote a node, and only allows it to be
+	// implemented within this package
 	isNode()
 }
 
@@ -44,3 +56,242 @@ var _ Node = (*SortMerge)(nil)
 var _ Node = (*Projection)(nil)
 var _ Node = (*Limit)(nil)
 var _ Node = (*Filter)(nil)
+
+func (*DataObjScan) isNode() {}
+func (*SortMerge) isNode()   {}
+func (*Projection) isNode()  {}
+func (*Limit) isNode()       {}
+func (*Filter) isNode()      {}
+
+// Edge is a directed connection (parent-child relation) between a two nodes.
+type Edge struct {
+	Parent, Child Node
+}
+
+type WalkOrder uint8
+
+const (
+	PreOrderWalk  WalkOrder = iota // Pre-order: Process the current vertex before visiting any of its children.
+	PostOrderWalk                  // Post-order: Process the current vertex after visiting all of its children.
+)
+
+type nodeSet map[Node]struct{}
+
+func (s nodeSet) add(node Node) {
+	if node == nil {
+		return
+	}
+	s[node] = struct{}{}
+}
+
+func (s nodeSet) remove(node Node) {
+	if s.contains(node) {
+		delete(s, node)
+	}
+}
+
+func (s nodeSet) contains(node Node) bool {
+	if node == nil {
+		return false
+	}
+	_, ok := s[node]
+	return ok
+}
+
+func (s nodeSet) sorted() []Node {
+	nodes := make([]Node, 0, len(s))
+	for node := range s {
+		nodes = append(nodes, node)
+	}
+	slices.SortFunc(nodes, func(a, b Node) int {
+		if a.ID() > b.ID() {
+			return 1
+		}
+		if a.ID() < b.ID() {
+			return -1
+		}
+		return 0
+	})
+	return nodes
+}
+
+// Plan represents a physical execution plan as a directed acyclic graph (DAG).
+// It maintains the relationships between nodes, tracking parent-child connections
+// and providing methods for graph traversal and manipulation.
+//
+// The plan structure supports operations like adding nodes and edges,
+// retrieving nodes by ID, retrieving parents and children of nodes, and
+// walking the graph in different orders using the depth-first-search algorithm.
+type Plan struct {
+	// nodesById maps node IDs to their corresponding Node instances for quick lookups
+	nodesById map[string]Node
+	// nodes is a set containing all nodes in the plan
+	nodes nodeSet
+	// parents maps each node to a set of its parent nodes in the execution graph
+	parents map[Node]nodeSet
+	// children maps each node to a set of its child nodes in the execution graph
+	children map[Node]nodeSet
+}
+
+func (p *Plan) init() {
+	if p.nodesById == nil {
+		p.nodesById = make(map[string]Node)
+	}
+	if p.nodes == nil {
+		p.nodes = make(nodeSet)
+	}
+	if p.parents == nil {
+		p.parents = make(map[Node]nodeSet)
+	}
+	if p.children == nil {
+		p.children = make(map[Node]nodeSet)
+	}
+}
+
+// AddNode adds a new node to the plan if it doesn't already exist. For
+// convenience, the function returns the input node without modification.
+func (p *Plan) AddNode(n Node) Node {
+	p.init()
+	if n == nil {
+		return nil
+	}
+	if p.nodes.contains(n) {
+		return n
+	}
+	p.nodes.add(n)
+	p.nodesById[n.ID()] = n
+
+	if _, ok := p.parents[n]; !ok {
+		p.parents[n] = make(nodeSet)
+	}
+	if _, ok := p.children[n]; !ok {
+		p.children[n] = make(nodeSet)
+	}
+	return n
+}
+
+// AddEdge creates a directed edge between two nodes in the plan.
+// It establishes a parent-child relationship between the nodes where
+// e.Parent becomes a parent of e.Child. Both nodes must already exist
+// in the plan. Returns an error if either node is nil or doesn't exist
+// in the plan.
+// The order of addition of edges is not preserved.
+func (p *Plan) AddEdge(e Edge) error {
+	if e.Parent == nil || e.Child == nil {
+		return fmt.Errorf("parent and child nodes must not be nil")
+	}
+	if !p.nodes.contains(e.Parent) {
+		return fmt.Errorf("node %s does not exist in graph", e.Parent.ID())
+	}
+	if !p.nodes.contains(e.Child) {
+		return fmt.Errorf("node %s does not exist in graph", e.Child.ID())
+	}
+
+	p.children[e.Parent].add(e.Child)
+	p.parents[e.Child].add(e.Parent)
+	return nil
+}
+
+// Len returns the number of nodes in the graph
+func (p *Plan) Len() int {
+	return len(p.nodes)
+}
+
+// NodeByID returns the node with the given identifier
+func (p *Plan) NodeByID(id string) Node {
+	return p.nodesById[id]
+}
+
+// Parents returns all parent nodes of the given node
+func (p *Plan) Parents(n Node) []Node {
+	if _, ok := p.parents[n]; !ok {
+		return nil
+	}
+	return p.parents[n].sorted()
+}
+
+// Children returns all child nodes of the given node
+func (p *Plan) Children(n Node) []Node {
+	if _, ok := p.children[n]; !ok {
+		return nil
+	}
+	return p.children[n].sorted()
+}
+
+// Roots returns all nodes that have no parents
+func (p *Plan) Roots() []Node {
+	if len(p.nodes) == 0 {
+		return nil
+	}
+
+	var roots []Node
+	for node := range p.nodes {
+		if len(p.parents[node]) == 0 {
+			roots = append(roots, node)
+		}
+	}
+	return roots
+}
+
+// Leaves returns all nodes that have no children
+func (p *Plan) Leaves() []Node {
+	if len(p.nodes) == 0 {
+		return nil
+	}
+
+	var leaves []Node
+	for node := range p.nodes {
+		if len(p.children[node]) == 0 {
+			leaves = append(leaves, node)
+		}
+	}
+	return leaves
+}
+
+// DFSWalk performs a depth-first traversal of the plan starting from node n.
+// It applies the visitor v to each node according to the specified walk order.
+// The order parameter determines if nodes are visited before their children (PreOrderWalk)
+// or after their children (PostOrderWalk).
+func (p *Plan) DFSWalk(n Node, v Visitor, order WalkOrder) error {
+	visited := make(nodeSet)
+	switch order {
+	case PreOrderWalk:
+		return p.preOrderWalk(n, v, visited)
+	case PostOrderWalk:
+		return p.postOrderWalk(n, v, visited)
+	default:
+		return errors.New("unsupported walk order. must be one of PreOrderWalk and PostOrderWalk")
+	}
+}
+
+func (p *Plan) preOrderWalk(n Node, v Visitor, visited nodeSet) error {
+	if visited.contains(n) {
+		return nil
+	}
+	visited.add(n)
+
+	if err := n.Accept(v); err != nil {
+		return err
+	}
+
+	for _, child := range p.Children(n) {
+		if err := p.preOrderWalk(child, v, visited); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (p *Plan) postOrderWalk(n Node, v Visitor, visited nodeSet) error {
+	if visited.contains(n) {
+		return nil
+	}
+	visited.add(n)
+
+	for _, child := range p.Children(n) {
+		if err := p.postOrderWalk(child, v, visited); err != nil {
+			return err
+		}
+	}
+	return n.Accept(v)
+}

--- a/pkg/dataobj/planner/physical/plan.go
+++ b/pkg/dataobj/planner/physical/plan.go
@@ -1,0 +1,46 @@
+package physical
+
+import "github.com/grafana/loki/v3/pkg/dataobj/planner/schema"
+
+type NodeType uint32
+
+const (
+	NodeTypeDataObjScan NodeType = iota
+	NodeTypeSortMerge
+	NodeTypeProjection
+	NodeTypeFilter
+	NodeTypeLimit
+)
+
+func (t NodeType) String() string {
+	switch t {
+	case NodeTypeDataObjScan:
+		return "DataObjScan"
+	case NodeTypeSortMerge:
+		return "SortMerge"
+	case NodeTypeProjection:
+		return "Projection"
+	case NodeTypeFilter:
+		return "Filter"
+	case NodeTypeLimit:
+		return "Limit"
+	default:
+		return "Undefined"
+	}
+}
+
+type Node interface {
+	Traversable
+
+	ID() NodeType
+	Schema() schema.Schema
+	Children() []Node
+
+	isNode()
+}
+
+var _ Node = (*DataObjScan)(nil)
+var _ Node = (*SortMerge)(nil)
+var _ Node = (*Projection)(nil)
+var _ Node = (*Limit)(nil)
+var _ Node = (*Filter)(nil)

--- a/pkg/dataobj/planner/physical/plan_test.go
+++ b/pkg/dataobj/planner/physical/plan_test.go
@@ -1,0 +1,1 @@
+package physical

--- a/pkg/dataobj/planner/physical/plan_test.go
+++ b/pkg/dataobj/planner/physical/plan_test.go
@@ -16,7 +16,7 @@ func TestPlan(t *testing.T) {
 
 	t.Run("adding a single node makes it both root and leave node", func(t *testing.T) {
 		p := &Plan{}
-		p.AddNode(&DataObjScan{
+		p.addNode(&DataObjScan{
 			id: "scan",
 		})
 		require.Len(t, p.Roots(), 1)
@@ -25,7 +25,7 @@ func TestPlan(t *testing.T) {
 
 	t.Run("adding an edge for nodes that do no exist fails", func(t *testing.T) {
 		p := &Plan{}
-		err := p.AddEdge(Edge{
+		err := p.addEdge(Edge{
 			Parent: &SortMerge{id: "merge"},
 			Child:  &DataObjScan{id: "scan"},
 		})
@@ -34,23 +34,23 @@ func TestPlan(t *testing.T) {
 
 	t.Run("adding an edge for nil nodes fails", func(t *testing.T) {
 		p := &Plan{}
-		err := p.AddEdge(Edge{})
+		err := p.addEdge(Edge{})
 		require.ErrorContains(t, err, "parent and child nodes must not be nil")
 	})
 
 	t.Run("test roots and leaves", func(t *testing.T) {
 		p := &Plan{}
-		scan1 := p.AddNode(&DataObjScan{
+		scan1 := p.addNode(&DataObjScan{
 			id: "scan1",
 		})
-		scan2 := p.AddNode(&DataObjScan{
+		scan2 := p.addNode(&DataObjScan{
 			id: "scan2",
 		})
-		merge := p.AddNode(&SortMerge{
+		merge := p.addNode(&SortMerge{
 			id: "merge",
 		})
-		_ = p.AddEdge(Edge{Parent: merge, Child: scan1})
-		_ = p.AddEdge(Edge{Parent: merge, Child: scan2})
+		_ = p.addEdge(Edge{Parent: merge, Child: scan1})
+		_ = p.addEdge(Edge{Parent: merge, Child: scan2})
 
 		require.Equal(t, p.Len(), 3)
 		require.Len(t, p.Roots(), 1)
@@ -59,17 +59,17 @@ func TestPlan(t *testing.T) {
 
 	t.Run("get node by id", func(t *testing.T) {
 		p := &Plan{}
-		scan1 := p.AddNode(&DataObjScan{
+		scan1 := p.addNode(&DataObjScan{
 			id: "scan1",
 		})
-		scan2 := p.AddNode(&DataObjScan{
+		scan2 := p.addNode(&DataObjScan{
 			id: "scan2",
 		})
-		merge := p.AddNode(&SortMerge{
+		merge := p.addNode(&SortMerge{
 			id: "merge",
 		})
-		_ = p.AddEdge(Edge{Parent: merge, Child: scan1})
-		_ = p.AddEdge(Edge{Parent: merge, Child: scan2})
+		_ = p.addEdge(Edge{Parent: merge, Child: scan1})
+		_ = p.addEdge(Edge{Parent: merge, Child: scan2})
 
 		n := p.NodeByID("merge")
 		require.Len(t, p.Parents(n), 0)  // no parents
@@ -80,25 +80,25 @@ func TestPlan(t *testing.T) {
 		// Graph can be inspected as SVG under the following URL:
 		// https://dreampuf.github.io/GraphvizOnline/?engine=dot#digraph%20G%20%7B%0A%20%20%20%20limit1%20-%3Emerge1%3B%0A%20%20%20%20merge1%20-%3E%20filter1%3B%0A%20%20%20%20merge1%20-%3E%20merge2%3B%0A%20%20%20%20merge1%20-%3E%20proj3%3B%0A%20%20%20%20filter1%20-%3E%20proj1%3B%0A%20%20%20%20merge2%20-%3E%20proj1%3B%0A%20%20%20%20merge2%20-%3E%20proj2%3B%0A%20%20%20%20proj1%20-%3E%20scan1%3B%0A%20%20%20%20proj2%20-%3E%20scan1%3B%0A%20%20%20%20proj3%20-%3E%20scan1%3B%0A%7D
 		p := &Plan{}
-		limit1 := p.AddNode(&Limit{id: "limit1"})
-		merge1 := p.AddNode(&SortMerge{id: "merge1"})
-		filter1 := p.AddNode(&Filter{id: "filter1"})
-		merge2 := p.AddNode(&SortMerge{id: "merge2"})
-		proj1 := p.AddNode(&Projection{id: "projection1"})
-		proj2 := p.AddNode(&Projection{id: "projection2"})
-		proj3 := p.AddNode(&Projection{id: "projection3"})
-		scan1 := p.AddNode(&DataObjScan{id: "scan1"})
+		limit1 := p.addNode(&Limit{id: "limit1"})
+		merge1 := p.addNode(&SortMerge{id: "merge1"})
+		filter1 := p.addNode(&Filter{id: "filter1"})
+		merge2 := p.addNode(&SortMerge{id: "merge2"})
+		proj1 := p.addNode(&Projection{id: "projection1"})
+		proj2 := p.addNode(&Projection{id: "projection2"})
+		proj3 := p.addNode(&Projection{id: "projection3"})
+		scan1 := p.addNode(&DataObjScan{id: "scan1"})
 
-		_ = p.AddEdge(Edge{Parent: limit1, Child: merge1})
-		_ = p.AddEdge(Edge{Parent: merge1, Child: filter1})
-		_ = p.AddEdge(Edge{Parent: merge1, Child: merge2})
-		_ = p.AddEdge(Edge{Parent: merge1, Child: proj3})
-		_ = p.AddEdge(Edge{Parent: filter1, Child: proj1})
-		_ = p.AddEdge(Edge{Parent: merge2, Child: proj1})
-		_ = p.AddEdge(Edge{Parent: merge2, Child: proj2})
-		_ = p.AddEdge(Edge{Parent: proj1, Child: scan1})
-		_ = p.AddEdge(Edge{Parent: proj2, Child: scan1})
-		_ = p.AddEdge(Edge{Parent: proj3, Child: scan1})
+		_ = p.addEdge(Edge{Parent: limit1, Child: merge1})
+		_ = p.addEdge(Edge{Parent: merge1, Child: filter1})
+		_ = p.addEdge(Edge{Parent: merge1, Child: merge2})
+		_ = p.addEdge(Edge{Parent: merge1, Child: proj3})
+		_ = p.addEdge(Edge{Parent: filter1, Child: proj1})
+		_ = p.addEdge(Edge{Parent: merge2, Child: proj1})
+		_ = p.addEdge(Edge{Parent: merge2, Child: proj2})
+		_ = p.addEdge(Edge{Parent: proj1, Child: scan1})
+		_ = p.addEdge(Edge{Parent: proj2, Child: scan1})
+		_ = p.addEdge(Edge{Parent: proj3, Child: scan1})
 
 		roots := p.Roots()
 		require.Len(t, roots, 1)

--- a/pkg/dataobj/planner/physical/plan_test.go
+++ b/pkg/dataobj/planner/physical/plan_test.go
@@ -1,1 +1,140 @@
 package physical
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPlan(t *testing.T) {
+
+	t.Run("empty plan does not have roots and leaves", func(t *testing.T) {
+		p := &Plan{}
+		require.Len(t, p.Roots(), 0)
+		require.Len(t, p.Leaves(), 0)
+	})
+
+	t.Run("adding a single node makes it both root and leave node", func(t *testing.T) {
+		p := &Plan{}
+		p.AddNode(&DataObjScan{
+			id: "scan",
+		})
+		require.Len(t, p.Roots(), 1)
+		require.Len(t, p.Leaves(), 1)
+	})
+
+	t.Run("adding an edge for nodes that do no exist fails", func(t *testing.T) {
+		p := &Plan{}
+		err := p.AddEdge(Edge{
+			Parent: &SortMerge{id: "merge"},
+			Child:  &DataObjScan{id: "scan"},
+		})
+		require.ErrorContains(t, err, "node merge does not exist in graph")
+	})
+
+	t.Run("adding an edge for nil nodes fails", func(t *testing.T) {
+		p := &Plan{}
+		err := p.AddEdge(Edge{})
+		require.ErrorContains(t, err, "parent and child nodes must not be nil")
+	})
+
+	t.Run("test roots and leaves", func(t *testing.T) {
+		p := &Plan{}
+		scan1 := p.AddNode(&DataObjScan{
+			id: "scan1",
+		})
+		scan2 := p.AddNode(&DataObjScan{
+			id: "scan2",
+		})
+		merge := p.AddNode(&SortMerge{
+			id: "merge",
+		})
+		p.AddEdge(Edge{Parent: merge, Child: scan1})
+		p.AddEdge(Edge{Parent: merge, Child: scan2})
+
+		require.Equal(t, p.Len(), 3)
+		require.Len(t, p.Roots(), 1)
+		require.Len(t, p.Leaves(), 2)
+	})
+
+	t.Run("get node by id", func(t *testing.T) {
+		p := &Plan{}
+		scan1 := p.AddNode(&DataObjScan{
+			id: "scan1",
+		})
+		scan2 := p.AddNode(&DataObjScan{
+			id: "scan2",
+		})
+		merge := p.AddNode(&SortMerge{
+			id: "merge",
+		})
+		p.AddEdge(Edge{Parent: merge, Child: scan1})
+		p.AddEdge(Edge{Parent: merge, Child: scan2})
+
+		n := p.NodeByID("merge")
+		require.Len(t, p.Parents(n), 0)  // no parents
+		require.Len(t, p.Children(n), 2) // both scan nodes
+	})
+
+	t.Run("graph can be walked in pre-order and post-order", func(t *testing.T) {
+		// Graph can be inspected as SVG under the following URL:
+		// https://dreampuf.github.io/GraphvizOnline/?engine=dot#digraph%20G%20%7B%0A%20%20%20%20limit1%20-%3Emerge1%3B%0A%20%20%20%20merge1%20-%3E%20filter1%3B%0A%20%20%20%20merge1%20-%3E%20merge2%3B%0A%20%20%20%20merge1%20-%3E%20proj3%3B%0A%20%20%20%20filter1%20-%3E%20proj1%3B%0A%20%20%20%20merge2%20-%3E%20proj1%3B%0A%20%20%20%20merge2%20-%3E%20proj2%3B%0A%20%20%20%20proj1%20-%3E%20scan1%3B%0A%20%20%20%20proj2%20-%3E%20scan1%3B%0A%20%20%20%20proj3%20-%3E%20scan1%3B%0A%7D
+		p := &Plan{}
+		limit1 := p.AddNode(&Limit{id: "limit1"})
+		merge1 := p.AddNode(&SortMerge{id: "merge1"})
+		filter1 := p.AddNode(&Filter{id: "filter1"})
+		merge2 := p.AddNode(&SortMerge{id: "merge2"})
+		proj1 := p.AddNode(&Projection{id: "projection1"})
+		proj2 := p.AddNode(&Projection{id: "projection2"})
+		proj3 := p.AddNode(&Projection{id: "projection3"})
+		scan1 := p.AddNode(&DataObjScan{id: "scan1"})
+
+		p.AddEdge(Edge{Parent: limit1, Child: merge1})
+		p.AddEdge(Edge{Parent: merge1, Child: filter1})
+		p.AddEdge(Edge{Parent: merge1, Child: merge2})
+		p.AddEdge(Edge{Parent: merge1, Child: proj3})
+		p.AddEdge(Edge{Parent: filter1, Child: proj1})
+		p.AddEdge(Edge{Parent: merge2, Child: proj1})
+		p.AddEdge(Edge{Parent: merge2, Child: proj2})
+		p.AddEdge(Edge{Parent: proj1, Child: scan1})
+		p.AddEdge(Edge{Parent: proj2, Child: scan1})
+		p.AddEdge(Edge{Parent: proj3, Child: scan1})
+
+		roots := p.Roots()
+		require.Len(t, roots, 1)
+
+		t.Run("pre-order", func(t *testing.T) {
+			visitor := &nodeCollectVisitor{}
+			err := p.DFSWalk(roots[0], visitor, PreOrderWalk)
+			require.NoError(t, err)
+			require.Len(t, visitor.visited, 8)
+			require.Equal(t, []string{
+				"Limit.limit1",
+				"SortMerge.merge1",
+				"Filter.filter1",
+				"Projection.projection1",
+				"DataObjScan.scan1",
+				"SortMerge.merge2",
+				"Projection.projection2",
+				"Projection.projection3",
+			}, visitor.visited)
+		})
+
+		t.Run("post-order", func(t *testing.T) {
+			visitor := &nodeCollectVisitor{}
+			err := p.DFSWalk(roots[0], visitor, PostOrderWalk)
+			require.NoError(t, err)
+			require.Len(t, visitor.visited, 8)
+			require.Equal(t, []string{
+				"DataObjScan.scan1",
+				"Projection.projection1",
+				"Filter.filter1",
+				"Projection.projection2",
+				"SortMerge.merge2",
+				"Projection.projection3",
+				"SortMerge.merge1",
+				"Limit.limit1",
+			}, visitor.visited)
+		})
+	})
+}

--- a/pkg/dataobj/planner/physical/plan_test.go
+++ b/pkg/dataobj/planner/physical/plan_test.go
@@ -49,8 +49,8 @@ func TestPlan(t *testing.T) {
 		merge := p.AddNode(&SortMerge{
 			id: "merge",
 		})
-		p.AddEdge(Edge{Parent: merge, Child: scan1})
-		p.AddEdge(Edge{Parent: merge, Child: scan2})
+		_ = p.AddEdge(Edge{Parent: merge, Child: scan1})
+		_ = p.AddEdge(Edge{Parent: merge, Child: scan2})
 
 		require.Equal(t, p.Len(), 3)
 		require.Len(t, p.Roots(), 1)
@@ -68,8 +68,8 @@ func TestPlan(t *testing.T) {
 		merge := p.AddNode(&SortMerge{
 			id: "merge",
 		})
-		p.AddEdge(Edge{Parent: merge, Child: scan1})
-		p.AddEdge(Edge{Parent: merge, Child: scan2})
+		_ = p.AddEdge(Edge{Parent: merge, Child: scan1})
+		_ = p.AddEdge(Edge{Parent: merge, Child: scan2})
 
 		n := p.NodeByID("merge")
 		require.Len(t, p.Parents(n), 0)  // no parents
@@ -89,16 +89,16 @@ func TestPlan(t *testing.T) {
 		proj3 := p.AddNode(&Projection{id: "projection3"})
 		scan1 := p.AddNode(&DataObjScan{id: "scan1"})
 
-		p.AddEdge(Edge{Parent: limit1, Child: merge1})
-		p.AddEdge(Edge{Parent: merge1, Child: filter1})
-		p.AddEdge(Edge{Parent: merge1, Child: merge2})
-		p.AddEdge(Edge{Parent: merge1, Child: proj3})
-		p.AddEdge(Edge{Parent: filter1, Child: proj1})
-		p.AddEdge(Edge{Parent: merge2, Child: proj1})
-		p.AddEdge(Edge{Parent: merge2, Child: proj2})
-		p.AddEdge(Edge{Parent: proj1, Child: scan1})
-		p.AddEdge(Edge{Parent: proj2, Child: scan1})
-		p.AddEdge(Edge{Parent: proj3, Child: scan1})
+		_ = p.AddEdge(Edge{Parent: limit1, Child: merge1})
+		_ = p.AddEdge(Edge{Parent: merge1, Child: filter1})
+		_ = p.AddEdge(Edge{Parent: merge1, Child: merge2})
+		_ = p.AddEdge(Edge{Parent: merge1, Child: proj3})
+		_ = p.AddEdge(Edge{Parent: filter1, Child: proj1})
+		_ = p.AddEdge(Edge{Parent: merge2, Child: proj1})
+		_ = p.AddEdge(Edge{Parent: merge2, Child: proj2})
+		_ = p.AddEdge(Edge{Parent: proj1, Child: scan1})
+		_ = p.AddEdge(Edge{Parent: proj2, Child: scan1})
+		_ = p.AddEdge(Edge{Parent: proj3, Child: scan1})
 
 		roots := p.Roots()
 		require.Len(t, roots, 1)

--- a/pkg/dataobj/planner/physical/planner.go
+++ b/pkg/dataobj/planner/physical/planner.go
@@ -2,15 +2,15 @@ package physical
 
 import "github.com/grafana/loki/v3/pkg/dataobj/planner/logical"
 
-// Context holds information about
+// Context holds meta information needed to create a physical plan.
 type Context struct{}
 
-// Planner creates a executable physical plan from a logical plan.
+// Planner creates an executable physical plan from a logical plan.
 type Planner struct {
 	ctx Context
 }
 
-// NewPlanner create a new planner instance with the given context.
+// NewPlanner creates a new planner instance with the given context.
 func NewPlanner(ctx Context) *Planner {
 	return &Planner{ctx: ctx}
 }
@@ -18,8 +18,7 @@ func NewPlanner(ctx Context) *Planner {
 // Convert transforms a logical plan into a physical plan.
 func (p *Planner) Convert(_ *logical.Plan) (*Plan, error) {
 	pp := &Plan{}
-	// TODO
-	// The logical plan implementation is not traversible yet.
+	// TODO: The logical plan implementation is not traversible yet.
 	// Convert MAKETABLE
 	// Convert SELECT
 	// Convert SORT

--- a/pkg/dataobj/planner/physical/planner.go
+++ b/pkg/dataobj/planner/physical/planner.go
@@ -1,0 +1,44 @@
+package physical
+
+import "github.com/grafana/loki/v3/pkg/dataobj/planner/logical"
+
+// Context holds information about
+type Context struct{}
+
+// Planner creates a executable physical plan from a logical plan.
+type Planner struct {
+	ctx Context
+}
+
+// NewPlanner create a new planner instance with the given context.
+func NewPlanner(ctx Context) *Planner {
+	return &Planner{ctx: ctx}
+}
+
+// Convert transforms a logical plan into a physical plan.
+func (p *Planner) Convert(_ *logical.Plan) (*Plan, error) {
+	pp := &Plan{}
+	// TODO
+	// The logical plan implementation is not traversible yet.
+	// Convert MAKETABLE
+	// Convert SELECT
+	// Convert SORT
+	// Convert LIMIT
+	return pp, nil
+}
+
+func (p *Planner) processMakeTable(_ *logical.MakeTable) error {
+	return nil
+}
+
+func (p *Planner) processSelect(_ *logical.Filter) error {
+	return nil
+}
+
+func (p *Planner) processSort(_ *logical.Sort) error {
+	return nil
+}
+
+func (p *Planner) processLimit(_ *logical.Limit) error {
+	return nil
+}

--- a/pkg/dataobj/planner/physical/projection.go
+++ b/pkg/dataobj/planner/physical/projection.go
@@ -1,26 +1,23 @@
 package physical
 
-import "github.com/grafana/loki/v3/pkg/dataobj/planner/schema"
-
+// Projection represents a column selection operation in the physical plan.
+// It contains a list of columns (column expressions) that are later
+// evaluated against the input columns to remove unnecessary colums from the
+// intermediate result.
 type Projection struct {
-	input   Node
-	columns []Expression
+	id string
+
+	Columns []ColumnExpression
 }
 
-func (*Projection) ID() NodeType {
+func (p *Projection) ID() string {
+	return p.id
+}
+
+func (*Projection) Type() NodeType {
 	return NodeTypeProjection
 }
 
-func (p *Projection) Children() []Node {
-	return []Node{p.input}
-}
-
-func (p *Projection) Schema() schema.Schema {
-	panic("unimplemented")
-}
-
-func (*Projection) isNode() {}
-
-func (p *Projection) Accept(v Visitor) (bool, error) {
+func (p *Projection) Accept(v Visitor) error {
 	return v.VisitProjection(p)
 }

--- a/pkg/dataobj/planner/physical/projection.go
+++ b/pkg/dataobj/planner/physical/projection.go
@@ -7,17 +7,25 @@ package physical
 type Projection struct {
 	id string
 
+	// Columns is a set of column expressions that are used to drop not needed
+	// columns that do not match the expression evaluation.
 	Columns []ColumnExpression
 }
 
+// ID implements the [Node] interface.
+// Returns a string that uniquely identifies the node in the plan.
 func (p *Projection) ID() string {
 	return p.id
 }
 
+// Type implements the [Node] interface.
+// Returns the type of the node.
 func (*Projection) Type() NodeType {
 	return NodeTypeProjection
 }
 
+// Accept implements the [Node] interface.
+// Dispatches itself to the provided [Visitor] v
 func (p *Projection) Accept(v Visitor) error {
 	return v.VisitProjection(p)
 }

--- a/pkg/dataobj/planner/physical/projection.go
+++ b/pkg/dataobj/planner/physical/projection.go
@@ -1,0 +1,26 @@
+package physical
+
+import "github.com/grafana/loki/v3/pkg/dataobj/planner/schema"
+
+type Projection struct {
+	input   Node
+	columns []Expression
+}
+
+func (*Projection) ID() NodeType {
+	return NodeTypeProjection
+}
+
+func (p *Projection) Children() []Node {
+	return []Node{p.input}
+}
+
+func (p *Projection) Schema() schema.Schema {
+	panic("unimplemented")
+}
+
+func (*Projection) isNode() {}
+
+func (p *Projection) Accept(v Visitor) (bool, error) {
+	return v.VisitProjection(p)
+}

--- a/pkg/dataobj/planner/physical/sortmerge.go
+++ b/pkg/dataobj/planner/physical/sortmerge.go
@@ -1,7 +1,5 @@
 package physical
 
-import "github.com/grafana/loki/v3/pkg/dataobj/planner/schema"
-
 type SortOrder int8
 
 const (
@@ -10,26 +8,23 @@ const (
 	ASC
 )
 
+// SortMerge represents a sort+merge operation in the physical plan. It
+// performs sorting of data based on the specified Column and Order direction.
 type SortMerge struct {
-	inputs []Node
-	expr   Expression
-	order  SortOrder
+	id string
+
+	Column ColumnExpression
+	Order  SortOrder
 }
 
-func (*SortMerge) ID() NodeType {
+func (m *SortMerge) ID() string {
+	return m.id
+}
+
+func (*SortMerge) Type() NodeType {
 	return NodeTypeSortMerge
 }
 
-func (m *SortMerge) Children() []Node {
-	return m.inputs
-}
-
-func (m *SortMerge) Schema() schema.Schema {
-	panic("unimplemented")
-}
-
-func (*SortMerge) isNode() {}
-
-func (m *SortMerge) Accept(v Visitor) (bool, error) {
+func (m *SortMerge) Accept(v Visitor) error {
 	return v.VisitSortMerge(m)
 }

--- a/pkg/dataobj/planner/physical/sortmerge.go
+++ b/pkg/dataobj/planner/physical/sortmerge.go
@@ -1,13 +1,13 @@
 package physical
 
-type SortOrder int8
+type SortOrder uint8
 
 const (
-	DESC SortOrder = iota - 1
-	_
-	ASC
+	ASC SortOrder = iota
+	DESC
 )
 
+// String returns the string representation of the [SortOrder].
 func (o SortOrder) String() string {
 	switch o {
 	case DESC:
@@ -24,18 +24,32 @@ func (o SortOrder) String() string {
 type SortMerge struct {
 	id string
 
+	// Column defines the column expression by which the rows should be sorted.
+	// This is almost always the timestamp column, because it is the column
+	// by which the results of the DataObjScan node are sorted. This allows
+	// for sorting and merging multiple already sorted inputs from the DataObjScan
+	// without being a pipeline breaker.
 	Column ColumnExpression
-	Order  SortOrder
+	// Order defines whether the column should be sorted in ascending or
+	// descending order. Must match the read direction of the DataObjScan that
+	// feeds into the SortMerge.
+	Order SortOrder
 }
 
+// ID implements the [Node] interface.
+// Returns a string that uniquely identifies the node in the plan.
 func (m *SortMerge) ID() string {
 	return m.id
 }
 
+// Type implements the [Node] interface.
+// Returns the type of the node.
 func (*SortMerge) Type() NodeType {
 	return NodeTypeSortMerge
 }
 
+// Accept implements the [Node] interface.
+// Dispatches itself to the provided [Visitor] v
 func (m *SortMerge) Accept(v Visitor) error {
 	return v.VisitSortMerge(m)
 }

--- a/pkg/dataobj/planner/physical/sortmerge.go
+++ b/pkg/dataobj/planner/physical/sortmerge.go
@@ -1,0 +1,35 @@
+package physical
+
+import "github.com/grafana/loki/v3/pkg/dataobj/planner/schema"
+
+type SortOrder int8
+
+const (
+	DESC SortOrder = iota - 1
+	_
+	ASC
+)
+
+type SortMerge struct {
+	inputs []Node
+	expr   Expression
+	order  SortOrder
+}
+
+func (*SortMerge) ID() NodeType {
+	return NodeTypeSortMerge
+}
+
+func (m *SortMerge) Children() []Node {
+	return m.inputs
+}
+
+func (m *SortMerge) Schema() schema.Schema {
+	panic("unimplemented")
+}
+
+func (*SortMerge) isNode() {}
+
+func (m *SortMerge) Accept(v Visitor) (bool, error) {
+	return v.VisitSortMerge(m)
+}

--- a/pkg/dataobj/planner/physical/sortmerge.go
+++ b/pkg/dataobj/planner/physical/sortmerge.go
@@ -8,6 +8,17 @@ const (
 	ASC
 )
 
+func (o SortOrder) String() string {
+	switch o {
+	case DESC:
+		return "DESC"
+	case ASC:
+		return "ASC"
+	default:
+		return "UNDEFINED"
+	}
+}
+
 // SortMerge represents a sort+merge operation in the physical plan. It
 // performs sorting of data based on the specified Column and Order direction.
 type SortMerge struct {

--- a/pkg/dataobj/planner/physical/visitor.go
+++ b/pkg/dataobj/planner/physical/visitor.go
@@ -1,0 +1,63 @@
+package physical
+
+type Traversable interface {
+	Accept(Visitor) (bool, error)
+}
+
+type Visitor interface {
+	VisitDataObjScan(*DataObjScan) (bool, error)
+	VisitSortMerge(*SortMerge) (bool, error)
+	VisitProjection(*Projection) (bool, error)
+	VisitFilter(*Filter) (bool, error)
+	VisitLimit(*Limit) (bool, error)
+}
+
+var _ Visitor = (*DepthFirstTraversal)(nil)
+
+type DepthFirstTraversal struct {
+	impl Visitor
+}
+
+func (v *DepthFirstTraversal) visitChildren(plan Node) (bool, error) {
+	for _, child := range plan.Children() {
+		if _, err := child.Accept(v); err != nil {
+			return false, err
+		}
+	}
+	return true, nil
+}
+
+func (v *DepthFirstTraversal) VisitDataObjScan(plan *DataObjScan) (bool, error) {
+	if _, err := v.visitChildren(plan); err != nil {
+		return false, err
+	}
+	return v.impl.VisitDataObjScan(plan)
+}
+
+func (v *DepthFirstTraversal) VisitSortMerge(plan *SortMerge) (bool, error) {
+	if _, err := v.visitChildren(plan); err != nil {
+		return false, err
+	}
+	return v.impl.VisitSortMerge(plan)
+}
+
+func (v *DepthFirstTraversal) VisitProjection(plan *Projection) (bool, error) {
+	if _, err := v.visitChildren(plan); err != nil {
+		return false, err
+	}
+	return v.impl.VisitProjection(plan)
+}
+
+func (v *DepthFirstTraversal) VisitFilter(plan *Filter) (bool, error) {
+	if _, err := v.visitChildren(plan); err != nil {
+		return false, err
+	}
+	return v.impl.VisitFilter(plan)
+}
+
+func (v *DepthFirstTraversal) VisitLimit(plan *Limit) (bool, error) {
+	if _, err := v.visitChildren(plan); err != nil {
+		return false, err
+	}
+	return v.impl.VisitLimit(plan)
+}

--- a/pkg/dataobj/planner/physical/visitor.go
+++ b/pkg/dataobj/planner/physical/visitor.go
@@ -1,63 +1,13 @@
 package physical
 
 type Traversable interface {
-	Accept(Visitor) (bool, error)
+	Accept(Visitor) error
 }
 
 type Visitor interface {
-	VisitDataObjScan(*DataObjScan) (bool, error)
-	VisitSortMerge(*SortMerge) (bool, error)
-	VisitProjection(*Projection) (bool, error)
-	VisitFilter(*Filter) (bool, error)
-	VisitLimit(*Limit) (bool, error)
-}
-
-var _ Visitor = (*DepthFirstTraversal)(nil)
-
-type DepthFirstTraversal struct {
-	impl Visitor
-}
-
-func (v *DepthFirstTraversal) visitChildren(plan Node) (bool, error) {
-	for _, child := range plan.Children() {
-		if _, err := child.Accept(v); err != nil {
-			return false, err
-		}
-	}
-	return true, nil
-}
-
-func (v *DepthFirstTraversal) VisitDataObjScan(plan *DataObjScan) (bool, error) {
-	if _, err := v.visitChildren(plan); err != nil {
-		return false, err
-	}
-	return v.impl.VisitDataObjScan(plan)
-}
-
-func (v *DepthFirstTraversal) VisitSortMerge(plan *SortMerge) (bool, error) {
-	if _, err := v.visitChildren(plan); err != nil {
-		return false, err
-	}
-	return v.impl.VisitSortMerge(plan)
-}
-
-func (v *DepthFirstTraversal) VisitProjection(plan *Projection) (bool, error) {
-	if _, err := v.visitChildren(plan); err != nil {
-		return false, err
-	}
-	return v.impl.VisitProjection(plan)
-}
-
-func (v *DepthFirstTraversal) VisitFilter(plan *Filter) (bool, error) {
-	if _, err := v.visitChildren(plan); err != nil {
-		return false, err
-	}
-	return v.impl.VisitFilter(plan)
-}
-
-func (v *DepthFirstTraversal) VisitLimit(plan *Limit) (bool, error) {
-	if _, err := v.visitChildren(plan); err != nil {
-		return false, err
-	}
-	return v.impl.VisitLimit(plan)
+	VisitDataObjScan(*DataObjScan) error
+	VisitSortMerge(*SortMerge) error
+	VisitProjection(*Projection) error
+	VisitFilter(*Filter) error
+	VisitLimit(*Limit) error
 }

--- a/pkg/dataobj/planner/physical/visitor.go
+++ b/pkg/dataobj/planner/physical/visitor.go
@@ -1,9 +1,9 @@
 package physical
 
-type Traversable interface {
-	Accept(Visitor) error
-}
-
+// Visitor defines the interface for objects that can visit each type of
+// physical plan node. It implements the Visitor pattern, providing
+// type-specific visit methods for each concrete node type in the physical
+// plan.
 type Visitor interface {
 	VisitDataObjScan(*DataObjScan) error
 	VisitSortMerge(*SortMerge) error

--- a/pkg/dataobj/planner/physical/visitor_test.go
+++ b/pkg/dataobj/planner/physical/visitor_test.go
@@ -1,0 +1,57 @@
+package physical
+
+import (
+	"fmt"
+)
+
+// A visitor implementation that collects nodes during traversal and optionally
+// executes custom functions for each node type. Used primarily for testing
+// traversal behavior.
+type nodeCollectVisitor struct {
+	visited            []string
+	onVisitDataObjScan func(*DataObjScan) error
+	onVisitFilter      func(*Filter) error
+	onVisitLimit       func(*Limit) error
+	onVisitSortMerge   func(*SortMerge) error
+	onVisitProjection  func(*Projection) error
+}
+
+func (v *nodeCollectVisitor) VisitDataObjScan(n *DataObjScan) error {
+	if v.onVisitDataObjScan != nil {
+		return v.onVisitDataObjScan(n)
+	}
+	v.visited = append(v.visited, fmt.Sprintf("%s.%s", n.Type().String(), n.ID()))
+	return nil
+}
+
+func (v *nodeCollectVisitor) VisitFilter(n *Filter) error {
+	if v.onVisitFilter != nil {
+		return v.onVisitFilter(n)
+	}
+	v.visited = append(v.visited, fmt.Sprintf("%s.%s", n.Type().String(), n.ID()))
+	return nil
+}
+
+func (v *nodeCollectVisitor) VisitLimit(n *Limit) error {
+	if v.onVisitLimit != nil {
+		return v.onVisitLimit(n)
+	}
+	v.visited = append(v.visited, fmt.Sprintf("%s.%s", n.Type().String(), n.ID()))
+	return nil
+}
+
+func (v *nodeCollectVisitor) VisitProjection(n *Projection) error {
+	if v.onVisitProjection != nil {
+		return v.onVisitProjection(n)
+	}
+	v.visited = append(v.visited, fmt.Sprintf("%s.%s", n.Type().String(), n.ID()))
+	return nil
+}
+
+func (v *nodeCollectVisitor) VisitSortMerge(n *SortMerge) error {
+	if v.onVisitSortMerge != nil {
+		return v.onVisitSortMerge(n)
+	}
+	v.visited = append(v.visited, fmt.Sprintf("%s.%s", n.Type().String(), n.ID()))
+	return nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds the basic components of a physical plan. For the first iteration of the new execution engine, we need to support nodes to represent limited and filter queries (with only label/line filters). These nodes are:

* DataObjScan
* SortMerge
* Projection
* Filter
* Limit

The physical plan is implemented as a [directed acyclic graph](https://en.wikipedia.org/wiki/Directed_acyclic_graph) (DAG). It has convenience functions for adding nodes (vertices) and edges, getting parents and children of a node, as well as for traversing the graph using the [depth-first-search](https://en.wikipedia.org/wiki/Depth-first_search) algorithm.

Additionally to the node types, the PR also contains the basic types of expressions, which can be properties of the nodes.