### PR TITLE
docs: Patch release notes 2.9.13 (backport release-2.9.x)

### DIFF
--- a/docs/sources/release-notes/v2-9.md
+++ b/docs/sources/release-notes/v2-9.md
@@ -36,6 +36,10 @@ For a full list of all changes and fixes, refer to the [CHANGELOG](https://githu
  
 ## Bug fixes
 
+### 2.9.13 (2025-03-12)
+
+* **deps:** Loki 2.9.x Bump Alpine and Go versions ([#16294](https://github.com/grafana/loki/issues/16294)) ([f2deeb7](https://github.com/grafana/loki/commit/f2deeb76ac39e835bffe61e1e4f78b980afdc0c0))
+
 ### 2.9.12 (2025-02-13)
 
 - **deps:** Dependencies updates and CVE fixes ([#15647](https://github.com/grafana/loki/issues/15647)) ([8447402](https://github.com/grafana/loki/commit/8447402c5e454928845535efba5249d62be4c7c1))


### PR DESCRIPTION
Backport 21cfa331312c2c15d833b7a7098450c329fcb92e from #16709

---

**What this PR does / why we need it**:

Release Notes for Loki 2.9.13 patch release.
