### PR TITLE
feat(ruler): add per-tenant configuration to disable WAL replay

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -3750,6 +3750,11 @@ discover_generic_fields:
 # CLI flag: -ruler.tenant-shard-size
 [ruler_tenant_shard_size: <int> | default = 0]
 
+# Enable WAL replay on ruler startup. Disabling this can reduce memory usage on
+# startup at the cost of not recovering in-memory WAL metrics on restart.
+# CLI flag: -ruler.enable-wal-replay
+[ruler_enable_wal_replay: <boolean> | default = true]
+
 # Disable recording rules remote-write.
 [ruler_remote_write_disabled: <boolean>]
 

--- a/pkg/ruler/base/compat.go
+++ b/pkg/ruler/base/compat.go
@@ -135,6 +135,7 @@ type RulesLimits interface {
 	RulerMaxRuleGroupsPerTenant(userID string) int
 	RulerMaxRulesPerRuleGroup(userID string) int
 	RulerAlertManagerConfig(userID string) *config.AlertManagerConfig
+	RulerEnableWALReplay(userID string) bool
 }
 
 func MetricsQueryFunc(qf rules.QueryFunc, queries, failedQueries prometheus.Counter) rules.QueryFunc {

--- a/pkg/ruler/base/ruler_test.go
+++ b/pkg/ruler/base/ruler_test.go
@@ -89,6 +89,7 @@ type ruleLimits struct {
 	maxRulesPerRuleGroup int
 	maxRuleGroups        int
 	alertManagerConfig   map[string]*config.AlertManagerConfig
+	enableWALReplay      bool
 }
 
 func (r ruleLimits) RulerTenantShardSize(_ string) int {
@@ -105,6 +106,10 @@ func (r ruleLimits) RulerMaxRulesPerRuleGroup(_ string) int {
 
 func (r ruleLimits) RulerAlertManagerConfig(tenantID string) *config.AlertManagerConfig {
 	return r.alertManagerConfig[tenantID]
+}
+
+func (r ruleLimits) RulerEnableWALReplay(_ string) bool {
+	return r.enableWALReplay
 }
 
 func testQueryableFunc(q storage.Querier) storage.QueryableFunc {
@@ -140,7 +145,7 @@ func testSetup(t *testing.T, q storage.Querier) (*promql.Engine, storage.Queryab
 	reg := prometheus.NewRegistry()
 	queryable := testQueryableFunc(q)
 
-	return engine, queryable, pusher, l, ruleLimits{maxRuleGroups: 20, maxRulesPerRuleGroup: 15}, reg
+	return engine, queryable, pusher, l, ruleLimits{maxRuleGroups: 20, maxRulesPerRuleGroup: 15, enableWALReplay: true}, reg
 }
 
 func newManager(t *testing.T, cfg Config, q storage.Querier) *DefaultMultiTenantManager {

--- a/pkg/ruler/registry_test.go
+++ b/pkg/ruler/registry_test.go
@@ -168,11 +168,11 @@ func newFakeLimitsBackwardCompat() fakeLimits {
 		limits: map[string]*validation.Limits{
 			enabledRWTenant: {
 				RulerRemoteWriteQueueCapacity: 987,
-				RulerEnableWALReplay: true,
+				RulerEnableWALReplay:          true,
 			},
 			disabledRWTenant: {
 				RulerRemoteWriteDisabled: true,
-				RulerEnableWALReplay: false,
+				RulerEnableWALReplay:     false,
 			},
 			additionalHeadersRWTenant: {
 				RulerRemoteWriteHeaders: validation.NewOverwriteMarshalingStringMap(map[string]string{
@@ -237,7 +237,7 @@ func newFakeLimits() fakeLimits {
 			},
 			disabledRWTenant: {
 				RulerRemoteWriteDisabled: true,
-				RulerEnableWALReplay: false,
+				RulerEnableWALReplay:     false,
 			},
 			additionalHeadersRWTenant: {
 				RulerRemoteWriteConfig: map[string]config.RemoteWriteConfig{

--- a/pkg/ruler/registry_test.go
+++ b/pkg/ruler/registry_test.go
@@ -168,9 +168,11 @@ func newFakeLimitsBackwardCompat() fakeLimits {
 		limits: map[string]*validation.Limits{
 			enabledRWTenant: {
 				RulerRemoteWriteQueueCapacity: 987,
+				RulerEnableWALReplay: true,
 			},
 			disabledRWTenant: {
 				RulerRemoteWriteDisabled: true,
+				RulerEnableWALReplay: false,
 			},
 			additionalHeadersRWTenant: {
 				RulerRemoteWriteHeaders: validation.NewOverwriteMarshalingStringMap(map[string]string{
@@ -231,9 +233,11 @@ func newFakeLimits() fakeLimits {
 						QueueConfig: config.QueueConfig{Capacity: 987},
 					},
 				},
+				RulerEnableWALReplay: true,
 			},
 			disabledRWTenant: {
 				RulerRemoteWriteDisabled: true,
+				RulerEnableWALReplay: false,
 			},
 			additionalHeadersRWTenant: {
 				RulerRemoteWriteConfig: map[string]config.RemoteWriteConfig{

--- a/pkg/ruler/storage/instance/instance.go
+++ b/pkg/ruler/storage/instance/instance.go
@@ -179,13 +179,13 @@ type Instance struct {
 
 // New creates a new Instance with a directory for storing the WAL. The instance
 // will not start until Run is called on the instance.
-func New(reg prometheus.Registerer, cfg Config, metrics *wal.Metrics, logger log.Logger) (*Instance, error) {
+func New(reg prometheus.Registerer, cfg Config, metrics *wal.Metrics, logger log.Logger, enableReplay bool) (*Instance, error) {
 	logger = log.With(logger, "instance", cfg.Name)
 
 	instWALDir := filepath.Join(cfg.Dir, cfg.Tenant)
 
 	newWal := func(reg prometheus.Registerer) (walStorage, error) {
-		return wal.NewStorage(logger, metrics, reg, instWALDir)
+		return wal.NewStorage(logger, metrics, reg, instWALDir, enableReplay)
 	}
 
 	return newInstance(cfg, reg, logger, newWal, cfg.Tenant)

--- a/pkg/ruler/storage/wal/wal_test.go
+++ b/pkg/ruler/storage/wal/wal_test.go
@@ -24,7 +24,7 @@ import (
 
 func newTestStorage(walDir string) (*Storage, error) {
 	metrics := NewMetrics(prometheus.DefaultRegisterer)
-	return NewStorage(log.NewNopLogger(), metrics, nil, walDir)
+	return NewStorage(log.NewNopLogger(), metrics, nil, walDir, true)
 }
 
 func TestStorage_InvalidSeries(t *testing.T) {
@@ -321,6 +321,53 @@ func TestStorage_TruncateAfterClose(t *testing.T) {
 
 	require.NoError(t, s.Close())
 	require.Error(t, ErrWALClosed, s.Truncate(0))
+}
+
+func TestStorage_DisableReplay(t *testing.T) {
+	walDir := t.TempDir()
+
+	// Create a WAL and write some data to it
+	metrics := NewMetrics(prometheus.DefaultRegisterer)
+	s, err := NewStorage(log.NewNopLogger(), metrics, nil, walDir, true)
+	require.NoError(t, err)
+
+	app := s.Appender(context.Background())
+	
+	// Write some samples
+	payload := buildSeries([]string{"foo", "bar", "baz"})
+	for _, metric := range payload {
+		metric.Write(t, app)
+	}
+	
+	require.NoError(t, app.Commit())
+	require.NoError(t, s.Close())
+
+	// Create a new WAL with replay disabled
+	s, err = NewStorage(log.NewNopLogger(), metrics, nil, walDir, false)
+	require.NoError(t, err)
+	
+	// Verify that no series were loaded (replay didn't happen)
+	count := 0
+	for range s.series.iterator().Channel() {
+		count++
+	}
+	require.Equal(t, 0, count, "no series should have been loaded with replay disabled")
+	
+	require.NoError(t, s.Close())
+
+	// Create a new WAL with replay enabled
+	s, err = NewStorage(log.NewNopLogger(), metrics, nil, walDir, true)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, s.Close())
+	}()
+	
+	// Verify that series were loaded (replay happened)
+	count = 0
+	for range s.series.iterator().Channel() {
+		count++
+	}
+	require.Equal(t, len(payload), count, "series should have been loaded with replay enabled")
 }
 
 type sample struct {

--- a/pkg/ruler/storage/wal/wal_test.go
+++ b/pkg/ruler/storage/wal/wal_test.go
@@ -332,27 +332,27 @@ func TestStorage_DisableReplay(t *testing.T) {
 	require.NoError(t, err)
 
 	app := s.Appender(context.Background())
-	
+
 	// Write some samples
 	payload := buildSeries([]string{"foo", "bar", "baz"})
 	for _, metric := range payload {
 		metric.Write(t, app)
 	}
-	
+
 	require.NoError(t, app.Commit())
 	require.NoError(t, s.Close())
 
 	// Create a new WAL with replay disabled
 	s, err = NewStorage(log.NewNopLogger(), metrics, nil, walDir, false)
 	require.NoError(t, err)
-	
+
 	// Verify that no series were loaded (replay didn't happen)
 	count := 0
 	for range s.series.iterator().Channel() {
 		count++
 	}
 	require.Equal(t, 0, count, "no series should have been loaded with replay disabled")
-	
+
 	require.NoError(t, s.Close())
 
 	// Create a new WAL with replay enabled
@@ -361,7 +361,7 @@ func TestStorage_DisableReplay(t *testing.T) {
 	defer func() {
 		require.NoError(t, s.Close())
 	}()
-	
+
 	// Verify that series were loaded (replay happened)
 	count = 0
 	for range s.series.iterator().Channel() {

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -141,6 +141,7 @@ type Limits struct {
 	RulerMaxRuleGroupsPerTenant int                              `yaml:"ruler_max_rule_groups_per_tenant" json:"ruler_max_rule_groups_per_tenant"`
 	RulerAlertManagerConfig     *ruler_config.AlertManagerConfig `yaml:"ruler_alertmanager_config" json:"ruler_alertmanager_config" doc:"hidden"`
 	RulerTenantShardSize        int                              `yaml:"ruler_tenant_shard_size" json:"ruler_tenant_shard_size"`
+	RulerEnableWALReplay        bool                             `yaml:"ruler_enable_wal_replay" json:"ruler_enable_wal_replay" doc:"description=Enable WAL replay on ruler startup. Disabling this can reduce memory usage on startup at the cost of not recovering in-memory WAL metrics on restart."`
 
 	// TODO(dannyk): add HTTP client overrides (basic auth / tls config, etc)
 	// Ruler remote-write limits.
@@ -375,6 +376,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&l.RulerMaxRulesPerRuleGroup, "ruler.max-rules-per-rule-group", 0, "Maximum number of rules per rule group per-tenant. 0 to disable.")
 	f.IntVar(&l.RulerMaxRuleGroupsPerTenant, "ruler.max-rule-groups-per-tenant", 0, "Maximum number of rule groups per-tenant. 0 to disable.")
 	f.IntVar(&l.RulerTenantShardSize, "ruler.tenant-shard-size", 0, "The default tenant's shard size when shuffle-sharding is enabled in the ruler. When this setting is specified in the per-tenant overrides, a value of 0 disables shuffle sharding for the tenant.")
+	f.BoolVar(&l.RulerEnableWALReplay, "ruler.enable-wal-replay", true, "Enable WAL replay on ruler startup. Disabling this can reduce memory usage on startup at the cost of not recovering in-memory WAL metrics on restart.")
 
 	f.StringVar(&l.PerTenantOverrideConfig, "limits.per-user-override-config", "", "Feature renamed to 'runtime configuration', flag deprecated in favor of -runtime-config.file (runtime_config.file in YAML).")
 	_ = l.RetentionPeriod.Set("0s")
@@ -833,6 +835,11 @@ func (o *Overrides) MaxQueryLookback(_ context.Context, userID string) time.Dura
 // RulerTenantShardSize returns shard size (number of rulers) used by this tenant when using shuffle-sharding strategy.
 func (o *Overrides) RulerTenantShardSize(userID string) int {
 	return o.getOverridesForUser(userID).RulerTenantShardSize
+}
+
+// RulerEnableWALReplay returns whether WAL replay is enabled for a given user.
+func (o *Overrides) RulerEnableWALReplay(userID string) bool {
+	return o.getOverridesForUser(userID).RulerEnableWALReplay
 }
 
 func (o *Overrides) IngestionPartitionsTenantShardSize(userID string) int {


### PR DESCRIPTION
**What this PR does / why we need it**:

This change adds the ability to disable WAL replay for specific tenants through ruler_enable_wal_replay tenant override. Disabling WAL replay helps prevent OOM crashes for tenants with large WALs, as it skips loading all series into memory during startup. We are currently only replaying the WAL so we can reuse the series ID, we are not actually replaying any metrics into the remote write target. Having the WAL is still beneficial to handle periods when the remote write server cannot be reached, but the benefit we're gaining from replaying the WAL is minimal considering it frequently causes the rulers to OOMs.

- Added ruler_enable_wal_replay flag to Limits and Overrides
- Modified WAL storage to accept enableReplay parameter
- Updated ruler registry to use tenant-specific setting when creating instances
- Added tests to verify WAL replay can be disabled

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [X] Documentation added
- [X] Tests updated
- [X] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [X] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [X] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
