### PR TITLE
chore: convert multi-variant queries from global to per-tenant config

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -3501,6 +3501,12 @@ The `limits_config` block configures global and per-tenant limits in Loki. The v
 # CLI flag: -limits.simulated-push-latency
 [simulated_push_latency: <duration> | default = 0s]
 
+# Enable experimental support for running multiple query variants over the same
+# underlying data. For example, running both a rate() and count_over_time()
+# query over the same range selector.
+# CLI flag: -limits.enable-multi-variant-queries
+[enable_multi_variant_queries: <boolean> | default = false]
+
 # Experimental: Detect fields from stream labels, structured metadata, or
 # json/logfmt formatted log line and put them into structured metadata of the
 # log entry.
@@ -4441,12 +4447,6 @@ engine:
   # sketch can track.
   # CLI flag: -querier.engine.max-count-min-sketch-heap-size
   [max_count_min_sketch_heap_size: <int> | default = 10000]
-
-  # Enable experimental support for running multiple query variants over the
-  # same underlying data. For example, running both a rate() and
-  # count_over_time() query over the same range selector.
-  # CLI flag: -querier.engine.enable-multi-variant-queries
-  [enable_multi_variant_queries: <boolean> | default = false]
 
 # The maximum number of queries that can be simultaneously processed by the
 # querier.

--- a/pkg/logcli/client/file.go
+++ b/pkg/logcli/client/file.go
@@ -241,6 +241,10 @@ func (l *limiter) RequiredLabels(_ context.Context, _ string) []string {
 	return nil
 }
 
+func (l *limiter) EnableMultiVariantQueries(_ string) bool {
+	return false // Multi-variant queries disabled by default for file client
+}
+
 type querier struct {
 	r      io.Reader
 	labels labels.Labels

--- a/pkg/logql/engine.go
+++ b/pkg/logql/engine.go
@@ -151,10 +151,6 @@ type EngineOpts struct {
 	// MaxCountMinSketchHeapSize is the maximum number of labels the heap for a topk query using a count min sketch
 	// can track. This impacts the memory usage and accuracy of a sharded probabilistic topk query.
 	MaxCountMinSketchHeapSize int `yaml:"max_count_min_sketch_heap_size"`
-
-	// EnableMutiVariantQueries enables support for running multiple query variants over the same underlying data.
-	// For example, running both a rate() and count_over_time() query over the same range selector.
-	EnableMutiVariantQueries bool `yaml:"enable_multi_variant_queries"`
 }
 
 func (opts *EngineOpts) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
@@ -169,12 +165,6 @@ func (opts *EngineOpts) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) 
 		prefix+".engine.max-count-min-sketch-heap-size",
 		10_000,
 		"The maximum number of labels the heap of a topk query using a count min sketch can track.",
-	)
-	f.BoolVar(
-		&opts.EnableMutiVariantQueries,
-		prefix+".engine.enable-multi-variant-queries",
-		false,
-		"Enable experimental support for running multiple query variants over the same underlying data. For example, running both a rate() and count_over_time() query over the same range selector.",
 	)
 	// Log executing query by default
 	opts.LogExecutingQuery = true
@@ -217,7 +207,6 @@ func (ng *Engine) Query(params Params) Query {
 		record:       true,
 		logExecQuery: ng.opts.LogExecutingQuery,
 		limits:       ng.limits,
-		multiVariant: ng.opts.EnableMutiVariantQueries,
 	}
 }
 
@@ -234,7 +223,6 @@ type query struct {
 	evaluator    EvaluatorFactory
 	record       bool
 	logExecQuery bool
-	multiVariant bool
 }
 
 func (q *query) resultLength(res promql_parser.Value) int {
@@ -330,7 +318,16 @@ func (q *query) Eval(ctx context.Context) (promql_parser.Value, error) {
 	switch e := q.params.GetExpression().(type) {
 	// A VariantsExpr is a specific type of SampleExpr, so make sure this case is evaulated first
 	case syntax.VariantsExpr:
-		if !q.multiVariant {
+		tenants, _ := tenant.TenantIDs(ctx)
+		multiVariantEnabled := false
+		for _, t := range tenants {
+			if q.limits.EnableMultiVariantQueries(t) {
+				multiVariantEnabled = true
+				break
+			}
+		}
+
+		if !multiVariantEnabled {
 			return nil, logqlmodel.ErrVariantsDisabled
 		}
 

--- a/pkg/logql/engine_test.go
+++ b/pkg/logql/engine_test.go
@@ -2317,7 +2317,7 @@ func TestEngine_Variants_InstantQuery(t *testing.T) {
 	// Create a custom fakeLimits to enable multi-variant queries
 	customLimits := &fakeLimits{
 		maxSeries:               math.MaxInt32,
-		timeout:                 math.MaxInt32,
+		timeout:                 time.Hour,
 		multiVariantQueryEnable: true,
 	}
 
@@ -2487,7 +2487,7 @@ func TestEngine_Variants_RangeQuery(t *testing.T) {
 	// Create a custom fakeLimits to enable multi-variant queries
 	customLimits := &fakeLimits{
 		maxSeries:               math.MaxInt32,
-		timeout:                 math.MaxInt32,
+		timeout:                 time.Hour,
 		multiVariantQueryEnable: true,
 	}
 
@@ -2790,7 +2790,7 @@ func TestMultiVariantQueries_Limits(t *testing.T) {
 		// Create limits with multi-variant queries disabled
 		limitsDisabled := &fakeLimits{
 			maxSeries:               math.MaxInt32,
-			timeout:                 math.MaxInt32,
+			timeout:                 time.Hour,
 			multiVariantQueryEnable: false,
 		}
 
@@ -2818,7 +2818,7 @@ func TestMultiVariantQueries_Limits(t *testing.T) {
 		// Create limits with multi-variant queries enabled
 		limitsEnabled := &fakeLimits{
 			maxSeries:               math.MaxInt32,
-			timeout:                 math.MaxInt32,
+			timeout:                 time.Hour,
 			multiVariantQueryEnable: true,
 		}
 

--- a/pkg/logql/engine_test.go
+++ b/pkg/logql/engine_test.go
@@ -2313,6 +2313,14 @@ func TestEngine_RangeQuery(t *testing.T) {
 
 func TestEngine_Variants_InstantQuery(t *testing.T) {
 	t.Parallel()
+
+	// Create a custom fakeLimits to enable multi-variant queries
+	customLimits := &fakeLimits{
+		maxSeries:               math.MaxInt32,
+		timeout:                 math.MaxInt32,
+		multiVariantQueryEnable: true,
+	}
+
 	for _, test := range []struct {
 		qs        string
 		ts        time.Time
@@ -2441,11 +2449,9 @@ func TestEngine_Variants_InstantQuery(t *testing.T) {
 	} {
 		t.Run(fmt.Sprintf("%s %s", test.qs, test.direction), func(t *testing.T) {
 			eng := NewEngine(
-				EngineOpts{
-					EnableMutiVariantQueries: true,
-				},
+				EngineOpts{},
 				newQuerierRecorder(t, test.data, test.params),
-				NoLimits,
+				customLimits,
 				log.NewNopLogger(),
 			)
 
@@ -2477,6 +2483,14 @@ func TestEngine_Variants_InstantQuery(t *testing.T) {
 
 func TestEngine_Variants_RangeQuery(t *testing.T) {
 	t.Parallel()
+
+	// Create a custom fakeLimits to enable multi-variant queries
+	customLimits := &fakeLimits{
+		maxSeries:               math.MaxInt32,
+		timeout:                 math.MaxInt32,
+		multiVariantQueryEnable: true,
+	}
+
 	for _, test := range []struct {
 		qs        string
 		start     time.Time
@@ -2635,11 +2649,9 @@ func TestEngine_Variants_RangeQuery(t *testing.T) {
 			t.Parallel()
 
 			eng := NewEngine(
-				EngineOpts{
-					EnableMutiVariantQueries: true,
-				},
+				EngineOpts{},
 				newQuerierRecorder(t, test.data, test.params),
-				NoLimits,
+				customLimits,
 				log.NewNopLogger(),
 			)
 
@@ -2768,6 +2780,92 @@ func (e errorIteratorQuerier) SelectLogs(_ context.Context, p SelectLogParams) (
 
 func (e errorIteratorQuerier) SelectSamples(_ context.Context, _ SelectSampleParams) (iter.SampleIterator, error) {
 	return iter.NewSortSampleIterator(e.samples()), nil
+}
+
+func TestMultiVariantQueries_Limits(t *testing.T) {
+	variantQuery := `variants(bytes_over_time({app="foo"}[1m]), count_over_time({app="foo"}[1m])) of ({app="foo"}[1m])`
+	testTime := time.Unix(60, 0)
+
+	t.Run("disabled", func(t *testing.T) {
+		// Create limits with multi-variant queries disabled
+		limitsDisabled := &fakeLimits{
+			maxSeries:               math.MaxInt32,
+			timeout:                 math.MaxInt32,
+			multiVariantQueryEnable: false,
+		}
+
+		eng := NewEngine(EngineOpts{}, &statsQuerier{}, limitsDisabled, log.NewNopLogger())
+		params, err := NewLiteralParams(
+			variantQuery,
+			testTime,
+			testTime,
+			0,
+			0,
+			logproto.BACKWARD,
+			0,
+			nil,
+			nil,
+		)
+		require.NoError(t, err)
+
+		// Query should fail with variants disabled error
+		q := eng.Query(params)
+		_, err = q.Exec(user.InjectOrgID(context.Background(), "fake"))
+		require.ErrorIs(t, err, logqlmodel.ErrVariantsDisabled)
+	})
+
+	t.Run("enabled", func(t *testing.T) {
+		// Create limits with multi-variant queries enabled
+		limitsEnabled := &fakeLimits{
+			maxSeries:               math.MaxInt32,
+			timeout:                 math.MaxInt32,
+			multiVariantQueryEnable: true,
+		}
+
+		// Use a fake series for the query
+		series := []logproto.Series{
+			{
+				Labels: `{app="foo"}`,
+				Samples: []logproto.Sample{
+					{Timestamp: testTime.UnixNano(), Hash: 1, Value: 5},
+				},
+			},
+		}
+
+		plan := &plan.QueryPlan{
+			AST: syntax.MustParseExpr(variantQuery),
+		}
+
+		sampleReq := &logproto.SampleQueryRequest{
+			Start:    time.Unix(0, 0),
+			End:      testTime,
+			Selector: variantQuery,
+			Plan:     plan,
+		}
+
+		data := [][]logproto.Series{series}
+		params := []SelectSampleParams{{sampleReq}}
+
+		eng := NewEngine(EngineOpts{}, newQuerierRecorder(t, data, params), limitsEnabled, log.NewNopLogger())
+		queryParams, err := NewLiteralParams(
+			variantQuery,
+			testTime,
+			testTime,
+			0,
+			0,
+			logproto.BACKWARD,
+			0,
+			nil,
+			nil,
+		)
+		require.NoError(t, err)
+
+		// Query should succeed with multi-variant enabled
+		q := eng.Query(queryParams)
+		result, err := q.Exec(user.InjectOrgID(context.Background(), "fake"))
+		require.NoError(t, err)
+		require.NotNil(t, result.Data)
+	})
 }
 
 func TestStepEvaluator_Error(t *testing.T) {

--- a/pkg/logql/limits.go
+++ b/pkg/logql/limits.go
@@ -19,14 +19,16 @@ type Limits interface {
 	MaxQueryRange(ctx context.Context, userID string) time.Duration
 	QueryTimeout(context.Context, string) time.Duration
 	BlockedQueries(context.Context, string) []*validation.BlockedQuery
+	EnableMultiVariantQueries(string) bool
 }
 
 type fakeLimits struct {
-	maxSeries      int
-	timeout        time.Duration
-	blockedQueries []*validation.BlockedQuery
-	rangeLimit     time.Duration
-	requiredLabels []string
+	maxSeries               int
+	timeout                 time.Duration
+	blockedQueries          []*validation.BlockedQuery
+	rangeLimit              time.Duration
+	requiredLabels          []string
+	multiVariantQueryEnable bool
 }
 
 func (f fakeLimits) MaxQuerySeries(_ context.Context, _ string) int {
@@ -47,4 +49,8 @@ func (f fakeLimits) BlockedQueries(_ context.Context, _ string) []*validation.Bl
 
 func (f fakeLimits) RequiredLabels(_ context.Context, _ string) []string {
 	return f.requiredLabels
+}
+
+func (f fakeLimits) EnableMultiVariantQueries(_ string) bool {
+	return f.multiVariantQueryEnable
 }

--- a/pkg/logql/limits.go
+++ b/pkg/logql/limits.go
@@ -9,8 +9,9 @@ import (
 )
 
 var NoLimits = &fakeLimits{
-	maxSeries: math.MaxInt32,
-	timeout:   time.Hour,
+	maxSeries:               math.MaxInt32,
+	timeout:                 time.Hour,
+	multiVariantQueryEnable: false, // Multi-variant queries disabled by default
 }
 
 // Limits allow the engine to fetch limits for a given users.

--- a/pkg/querier/queryrange/roundtrip_test.go
+++ b/pkg/querier/queryrange/roundtrip_test.go
@@ -1412,6 +1412,7 @@ type fakeLimits struct {
 	maxStatsCacheFreshness      time.Duration
 	maxMetadataCacheFreshness   time.Duration
 	volumeEnabled               bool
+	enableMultiVariantQueries   bool
 }
 
 func (f fakeLimits) QuerySplitDuration(key string) time.Duration {
@@ -1541,6 +1542,9 @@ func (f fakeLimits) TSDBShardingStrategy(string) string {
 
 func (f fakeLimits) ShardAggregations(string) []string {
 	return nil
+}
+func (f fakeLimits) EnableMultiVariantQueries(_ string) bool {
+	return f.enableMultiVariantQueries
 }
 
 type ingesterQueryOpts struct {

--- a/pkg/querier/testutil/limits.go
+++ b/pkg/querier/testutil/limits.go
@@ -17,6 +17,11 @@ type MockLimits struct {
 	MaxConcurrentTailRequestsVal  int
 	MaxEntriesLimitPerQueryVal    int
 	MaxStreamsMatchersPerQueryVal int
+	EnableMultiVariantQueriesVal  bool
+}
+
+func (m *MockLimits) EnableMultiVariantQueries(_ string) bool {
+	return m.EnableMultiVariantQueriesVal
 }
 
 func (m *MockLimits) MaxQueryLookback(_ context.Context, _ string) time.Duration {

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -86,6 +86,9 @@ type Limits struct {
 	IncrementDuplicateTimestamp bool             `yaml:"increment_duplicate_timestamp" json:"increment_duplicate_timestamp"`
 	SimulatedPushLatency        time.Duration    `yaml:"simulated_push_latency" json:"simulated_push_latency" doc:"description=Simulated latency to add to push requests. Used for testing. Set to 0s to disable."`
 
+	// LogQL engine options
+	EnableMultiVariantQueries bool `yaml:"enable_multi_variant_queries" json:"enable_multi_variant_queries"`
+
 	// Metadata field extraction
 	DiscoverGenericFields    FieldDetectorConfig `yaml:"discover_generic_fields" json:"discover_generic_fields" doc:"description=Experimental: Detect fields from stream labels, structured metadata, or json/logfmt formatted log line and put them into structured metadata of the log entry."`
 	DiscoverServiceName      []string            `yaml:"discover_service_name" json:"discover_service_name"`
@@ -465,6 +468,13 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 		"Enable metric aggregation. When enabled, pushed streams will be sampled for bytes and count, and these metric will be written back into Loki as a special __aggregated_metric__ stream, which can be queried for faster histogram queries.",
 	)
 	f.DurationVar(&l.SimulatedPushLatency, "limits.simulated-push-latency", 0, "Simulated latency to add to push requests. This is used to test the performance of the write path under different latency conditions.")
+
+	f.BoolVar(
+		&l.EnableMultiVariantQueries,
+		"limits.enable-multi-variant-queries",
+		false,
+		"Enable experimental support for running multiple query variants over the same underlying data. For example, running both a rate() and count_over_time() query over the same range selector.",
+	)
 }
 
 // SetGlobalOTLPConfig set GlobalOTLPConfig which is used while unmarshaling per-tenant otlp config to use the default list of resource attributes picked as index labels.
@@ -1195,6 +1205,10 @@ func (o *Overrides) PatternIngesterTokenizableJSONFieldsDelete(userID string) []
 
 func (o *Overrides) MetricAggregationEnabled(userID string) bool {
 	return o.getOverridesForUser(userID).MetricAggregationEnabled
+}
+
+func (o *Overrides) EnableMultiVariantQueries(userID string) bool {
+	return o.getOverridesForUser(userID).EnableMultiVariantQueries
 }
 
 // S3SSEType returns the per-tenant S3 SSE type.


### PR DESCRIPTION
**What this PR does / why we need it**:

This allows different tenants to have different settings for multi-variant queries support, rather than a global setting.

- Removed EnableMutiVariantQueries from engine options
- Added EnableMultiVariantQueries to tenant limits config
- Updated logql Limits interface to include the new setting
- Updated query evaluation to use tenant-specific setting
- Added tests for the tenant-specific setting

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [X] Documentation added
- [X] Tests updated
- [X] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [X] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [X] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
