### PR TITLE
fix(networking): Re-enable IPv6 for memberlist address discovery

### DIFF
--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -2193,5 +2193,5 @@ func GetInstanceAddr(addr string, netInterfaces []string, logger log.Logger) (st
 		return addr, nil
 	}
 
-	return netutil.GetFirstAddressOf(netInterfaces, logger, false)
+	return netutil.GetFirstAddressOf(netInterfaces, logger, true)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR restores the capability for memberlist to discover an IPv6 address.

* Memberlist used to discover and use an IPv6 address if there was one available, but a recent fix for a different issue accidentally removed this capability. This PR adds it back.