### PR TITLE
chore: refactor how distributor enforces limits

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -696,12 +696,12 @@ func (d *Distributor) PushWithResolver(ctx context.Context, req *logproto.PushRe
 	}
 
 	if d.cfg.IngestLimitsEnabled {
-		exceedsLimits, reasons, err := d.exceedsLimits(ctx, tenantID, streams)
+		exceedsLimits, _, err := d.exceedsLimits(ctx, tenantID, streams)
 		if err != nil {
 			level.Error(d.logger).Log("msg", "failed to check if request exceeds limits, request has been accepted", "err", err)
 		}
 		if exceedsLimits {
-			level.Info(d.logger).Log("msg", "request exceeded limits", "tenant", tenantID, "reasons", strings.Join(reasons, ","))
+			level.Info(d.logger).Log("msg", "request exceeded limits", "tenant", tenantID)
 		}
 	}
 

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -696,13 +696,12 @@ func (d *Distributor) PushWithResolver(ctx context.Context, req *logproto.PushRe
 	}
 
 	if d.cfg.IngestLimitsEnabled {
-		exceedsLimits, err := d.exceedsLimits(ctx, tenantID, streams)
+		exceedsLimits, reasons, err := d.exceedsLimits(ctx, tenantID, streams)
 		if err != nil {
 			level.Error(d.logger).Log("msg", "failed to check if request exceeds limits, request has been accepted", "err", err)
-		} else if len(exceedsLimits.RejectedStreams) > 0 {
-			level.Error(d.logger).Log("msg", "request exceeded limits", "tenant", tenantID)
-		} else {
-			level.Debug(d.logger).Log("msg", "request accepted", "tenant", tenantID)
+		}
+		if exceedsLimits {
+			level.Info(d.logger).Log("msg", "request exceeded limits", "tenant", tenantID, "reasons", strings.Join(reasons, ","))
 		}
 	}
 
@@ -1152,7 +1151,46 @@ func (d *Distributor) sendStreams(task pushIngesterTask) {
 	}
 }
 
-func (d *Distributor) exceedsLimits(ctx context.Context, tenantID string, streams []KeyedStream) (*logproto.ExceedsLimitsResponse, error) {
+// exceedsLimits returns true if the request exceeds the per-tenant limits,
+// otherwise false. If the request does exceed per-tenant limits, a list of
+// reasons are returned explaining which limits were exceeded. An error is
+// returned if the limits could not be checked.
+func (d *Distributor) exceedsLimits(
+	ctx context.Context,
+	tenantID string,
+	streams []KeyedStream,
+) (bool, []string, error) {
+	if !d.cfg.IngestLimitsEnabled {
+		return false, nil, nil
+	}
+	resp, err := d.doExceedsLimitsRPC(ctx, tenantID, streams)
+	if err != nil {
+		return false, nil, err
+	}
+	if len(resp.RejectedStreams) == 0 {
+		return false, nil, nil
+	}
+	reasons := make([]string, 0, len(resp.RejectedStreams))
+	for _, rejection := range resp.RejectedStreams {
+		reasons = append(reasons, fmt.Sprintf(
+			"stream %x was rejected because %q",
+			rejection.StreamHash,
+			rejection.Reason,
+		))
+	}
+	return true, reasons, nil
+}
+
+// doExceedsLimitsRPC executes an RPC to the limits-frontend service to check
+// if per-tenant limits have been exceeded. If an RPC call returns an error,
+// it failsover to the next limits-frontend service. The failover is repeated
+// until there are no more replicas remaining or the context is canceled,
+// whichever happens first.
+func (d *Distributor) doExceedsLimitsRPC(
+	ctx context.Context,
+	tenantID string,
+	streams []KeyedStream,
+) (*logproto.ExceedsLimitsResponse, error) {
 	// We use an FNV-1 of all stream hashes in the request to load balance requests
 	// to limits-frontends instances.
 	h := fnv.New32()
@@ -1195,6 +1233,12 @@ func (d *Distributor) exceedsLimits(ctx context.Context, tenantID string, stream
 	// Send the request to the limits-frontend to see if it exceeds the tenant
 	// limits. If the RPC fails, failover to the next instance in the ring.
 	for _, instance := range rs.Instances {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+
 		c, err := d.limitsFrontends.GetClientFor(instance.Addr)
 		if err != nil {
 			lastErr = err


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit refactors how the distributor enforces limits to make it easier to add a dry-run mode in a subsequent PR, and also restore stream labels from stream hashes to improve error messages.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
