### PR TITLE
feat: use stream labels instead of hash in rate limit reasons

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -1170,11 +1170,17 @@ func (d *Distributor) exceedsLimits(
 	if len(resp.RejectedStreams) == 0 {
 		return false, nil, nil
 	}
+	// hashesToLabels memoizes the labels for a stream hash so we can add
+	// it to the reason.
+	hashesToLabels := make(map[uint64]string)
+	for _, s := range streams {
+		hashesToLabels[s.HashKeyNoShard] = s.Stream.Labels
+	}
 	reasons := make([]string, 0, len(resp.RejectedStreams))
 	for _, rejection := range resp.RejectedStreams {
 		reasons = append(reasons, fmt.Sprintf(
-			"stream %x was rejected because %q",
-			rejection.StreamHash,
+			"stream %s was rejected because %q",
+			hashesToLabels[rejection.StreamHash],
 			rejection.Reason,
 		))
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request updates the reasons when a request is rate limited to use the stream labels instead of the stream hash. This is so we can return more meaningful error messages to clients.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
