### PR TITLE
fix: remove colons from level detection

### DIFF
--- a/pkg/distributor/field_detection.go
+++ b/pkg/distributor/field_detection.go
@@ -306,22 +306,21 @@ func isJSON(line string) bool {
 }
 
 func detectLevelFromLogLine(log string) string {
-	if strings.Contains(log, "info:") || strings.Contains(log, "INFO:") ||
-		strings.Contains(log, "info") || strings.Contains(log, "INFO") {
+	if strings.Contains(log, "info") || strings.Contains(log, "INFO") {
 		return constants.LogLevelInfo
 	}
-	if strings.Contains(log, "err:") || strings.Contains(log, "ERR:") ||
+	if strings.Contains(log, "err") || strings.Contains(log, "ERR") ||
 		strings.Contains(log, "error") || strings.Contains(log, "ERROR") {
 		return constants.LogLevelError
 	}
-	if strings.Contains(log, "warn:") || strings.Contains(log, "WARN:") ||
+	if strings.Contains(log, "warn") || strings.Contains(log, "WARN") ||
 		strings.Contains(log, "warning") || strings.Contains(log, "WARNING") {
 		return constants.LogLevelWarn
 	}
-	if strings.Contains(log, "CRITICAL:") || strings.Contains(log, "critical:") {
+	if strings.Contains(log, "CRITICAL") || strings.Contains(log, "critical") {
 		return constants.LogLevelCritical
 	}
-	if strings.Contains(log, "debug:") || strings.Contains(log, "DEBUG:") {
+	if strings.Contains(log, "debug") || strings.Contains(log, "DEBUG") {
 		return constants.LogLevelDebug
 	}
 	return constants.LogLevelUnknown

--- a/pkg/distributor/field_detection_test.go
+++ b/pkg/distributor/field_detection_test.go
@@ -277,6 +277,41 @@ func Test_detectLogLevelFromLogEntry(t *testing.T) {
 			},
 			expectedLogLevel: constants.LogLevelInfo,
 		},
+		{
+			name: "unstructured info log line",
+			entry: logproto.Entry{
+				Line: `[INFO] unstructured info log line`,
+			},
+			expectedLogLevel: constants.LogLevelInfo,
+		},
+		{
+			name: "unstructured error log line",
+			entry: logproto.Entry{
+				Line: `[ERROR] unstructured error log line`,
+			},
+			expectedLogLevel: constants.LogLevelError,
+		},
+		{
+			name: "unstructured warn log line",
+			entry: logproto.Entry{
+				Line: `[WARN] unstructured warn log line`,
+			},
+			expectedLogLevel: constants.LogLevelWarn,
+		},
+		{
+			name: "unstructured critical log line",
+			entry: logproto.Entry{
+				Line: `[CRITICAL] unstructured critical log line`,
+			},
+			expectedLogLevel: constants.LogLevelCritical,
+		},
+		{
+			name: "unstructured debug log line",
+			entry: logproto.Entry{
+				Line: `[DEBUG] unstructured debug log line`,
+			},
+			expectedLogLevel: constants.LogLevelDebug,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			detectedLogLevel := ld.detectLogLevelFromLogEntry(tc.entry, logproto.FromLabelAdaptersToLabels(tc.entry.StructuredMetadata))


### PR DESCRIPTION
**What this PR does / why we need it**:

Log lines such as `[DEBUG] foo bar baz` were not getting detected as debug log lines because the current detection expected a `:`. This seems unnecessarily specific, as putting the level in brackets is a common enough practice for unstructured logs.

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [X] Documentation added
- [X] Tests updated
- [X] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [X] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [X] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
