### PR TITLE
feat(promtail): add encoding for syslog

### DIFF
--- a/clients/pkg/promtail/targets/syslog/metrics.go
+++ b/clients/pkg/promtail/targets/syslog/metrics.go
@@ -6,9 +6,10 @@ import "github.com/prometheus/client_golang/prometheus"
 type Metrics struct {
 	reg prometheus.Registerer
 
-	syslogEntries       prometheus.Counter
-	syslogParsingErrors prometheus.Counter
-	syslogEmptyMessages prometheus.Counter
+	syslogEntries          prometheus.Counter
+	syslogParsingErrors    prometheus.Counter
+	syslogEmptyMessages    prometheus.Counter
+	syslogEncodingFailures prometheus.Counter
 }
 
 // NewMetrics creates a new set of syslog metrics. If reg is non-nil, the
@@ -32,12 +33,18 @@ func NewMetrics(reg prometheus.Registerer) *Metrics {
 		Name:      "syslog_empty_messages_total",
 		Help:      "Total number of empty messages receiving from syslog",
 	})
+	m.syslogEncodingFailures = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "promtail",
+		Name:      "syslog_encoding_failures_total",
+		Help:      "Total number of encoding failures while receiving syslog messages",
+	})
 
 	if reg != nil {
 		reg.MustRegister(
 			m.syslogEntries,
 			m.syslogParsingErrors,
 			m.syslogEmptyMessages,
+			m.syslogEncodingFailures,
 		)
 	}
 

--- a/clients/pkg/promtail/targets/syslog/syslogtarget.go
+++ b/clients/pkg/promtail/targets/syslog/syslogtarget.go
@@ -76,8 +76,6 @@ func NewSyslogTarget(
 			return nil, errors.Wrap(err, "failed to identify character set")
 		}
 		textDecoder = encoder
-	} else {
-		textDecoder = encoding.Nop
 	}
 
 	decoder := textDecoder.NewDecoder()
@@ -258,9 +256,7 @@ func (t *SyslogTarget) handleMessage(connLabels labels.Labels, msg syslog.Messag
 
 func (t *SyslogTarget) messageSender(entries chan<- api.Entry) {
 	for msg := range t.messages {
-		var line string
-		var err error
-		line, err = t.convertToUTF8(msg.message)
+		line, err := t.convertToUTF8(msg.message)
 		if err != nil {
 			level.Debug(t.logger).Log("msg", "failed to convert encoding", "error", err)
 			t.metrics.syslogEncodingFailures.Inc()

--- a/clients/pkg/promtail/targets/syslog/syslogtarget_test.go
+++ b/clients/pkg/promtail/targets/syslog/syslogtarget_test.go
@@ -316,7 +316,7 @@ func Benchmark_SyslogTarget(b *testing.B) {
 				Labels: model.LabelSet{
 					"test": "syslog_target",
 				},
-			})
+			}, "")
 			b.Cleanup(func() {
 				require.NoError(b, tgt.Stop())
 			})
@@ -379,7 +379,7 @@ func TestSyslogTarget(t *testing.T) {
 				Labels: model.LabelSet{
 					"test": "syslog_target",
 				},
-			})
+			}, "")
 			require.NoError(t, err)
 
 			require.Eventually(t, tgt.Ready, time.Second, 10*time.Millisecond)
@@ -493,7 +493,7 @@ func TestSyslogTarget_RFC5424Messages(t *testing.T) {
 					"test": "syslog_target",
 				},
 				UseRFC5424Message: true,
-			})
+			}, "")
 			require.NoError(t, err)
 			require.Eventually(t, tgt.Ready, time.Second, 10*time.Millisecond)
 			defer func() {
@@ -540,7 +540,7 @@ func TestSyslogTarget_TLSConfigWithoutServerCertificate(t *testing.T) {
 		TLSConfig: promconfig.TLSConfig{
 			KeyFile: "foo",
 		},
-	})
+	}, "")
 	require.Error(t, err, "error setting up syslog target: certificate and key files are required")
 }
 
@@ -555,7 +555,7 @@ func TestSyslogTarget_TLSConfigWithoutServerKey(t *testing.T) {
 		TLSConfig: promconfig.TLSConfig{
 			CertFile: "foo",
 		},
-	})
+	}, "")
 	require.Error(t, err, "error setting up syslog target: certificate and key files are required")
 }
 
@@ -599,7 +599,7 @@ func testSyslogTargetWithTLS(t *testing.T, fmtFunc formatFunc) {
 			CertFile: serverCertFile.Name(),
 			KeyFile:  serverKeyFile.Name(),
 		},
-	})
+	}, "")
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, tgt.Stop())
@@ -732,7 +732,7 @@ func testSyslogTargetWithTLSVerifyClientCertificate(t *testing.T, fmtFunc format
 			CertFile: serverCertFile.Name(),
 			KeyFile:  serverKeyFile.Name(),
 		},
-	})
+	}, "")
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, tgt.Stop())
@@ -801,7 +801,7 @@ func TestSyslogTarget_InvalidData(t *testing.T) {
 
 	tgt, err := NewSyslogTarget(metrics, logger, client, relabelConfig(t), &scrapeconfig.SyslogTargetConfig{
 		ListenAddress: "127.0.0.1:0",
-	})
+	}, "")
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, tgt.Stop())
@@ -832,7 +832,7 @@ func TestSyslogTarget_NonUTF8Message(t *testing.T) {
 
 	tgt, err := NewSyslogTarget(metrics, logger, client, relabelConfig(t), &scrapeconfig.SyslogTargetConfig{
 		ListenAddress: "127.0.0.1:0",
-	})
+	}, "")
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, tgt.Stop())
@@ -871,7 +871,7 @@ func TestSyslogTarget_IdleTimeout(t *testing.T) {
 	tgt, err := NewSyslogTarget(metrics, logger, client, relabelConfig(t), &scrapeconfig.SyslogTargetConfig{
 		ListenAddress: "127.0.0.1:0",
 		IdleTimeout:   time.Millisecond,
-	})
+	}, "")
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, tgt.Stop())

--- a/clients/pkg/promtail/targets/syslog/syslogtargetmanager.go
+++ b/clients/pkg/promtail/targets/syslog/syslogtargetmanager.go
@@ -3,11 +3,12 @@ package syslog
 import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/grafana/loki/v3/clients/pkg/logentry/stages"
 	"github.com/grafana/loki/v3/clients/pkg/promtail/api"
 	"github.com/grafana/loki/v3/clients/pkg/promtail/scrapeconfig"
 	"github.com/grafana/loki/v3/clients/pkg/promtail/targets/target"
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 // SyslogTargetManager manages a series of SyslogTargets.

--- a/clients/pkg/promtail/targets/syslog/syslogtargetmanager.go
+++ b/clients/pkg/promtail/targets/syslog/syslogtargetmanager.go
@@ -3,12 +3,11 @@ package syslog
 import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/grafana/loki/v3/clients/pkg/logentry/stages"
 	"github.com/grafana/loki/v3/clients/pkg/promtail/api"
 	"github.com/grafana/loki/v3/clients/pkg/promtail/scrapeconfig"
 	"github.com/grafana/loki/v3/clients/pkg/promtail/targets/target"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 // SyslogTargetManager manages a series of SyslogTargets.
@@ -40,8 +39,7 @@ func NewSyslogTargetManager(
 		if err != nil {
 			return nil, err
 		}
-
-		t, err := NewSyslogTarget(metrics, logger, pipeline.Wrap(client), cfg.RelabelConfigs, cfg.SyslogConfig)
+		t, err := NewSyslogTarget(metrics, logger, pipeline.Wrap(client), cfg.RelabelConfigs, cfg.SyslogConfig, cfg.Encoding)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

Support encoding for syslog when process log content, there doesn't support decode from others like GBK now, works for non utf-8 log source.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
