### PR TITLE
chore: move adapter to limits.go

### DIFF
--- a/pkg/limits/frontend/frontend.go
+++ b/pkg/limits/frontend/frontend.go
@@ -75,7 +75,7 @@ func New(cfg Config, ringName string, limitsRing ring.ReadRing, limits Limits, l
 
 	factory := limits_client.NewPoolFactory(cfg.ClientConfig)
 	pool := limits_client.NewPool(ringName, cfg.ClientConfig.PoolConfig, limitsRing, factory, logger)
-	rateLimiter := limiter.NewRateLimiter(newIngestionRateStrategy(limits), cfg.RecheckPeriod)
+	rateLimiter := limiter.NewRateLimiter(newRateLimitsAdapter(limits), cfg.RecheckPeriod)
 	limitsSrv := NewRingIngestLimitsService(limitsRing, pool, limits, rateLimiter, logger, reg)
 
 	f := &Frontend{

--- a/pkg/limits/frontend/limits.go
+++ b/pkg/limits/frontend/limits.go
@@ -1,0 +1,28 @@
+package frontend
+
+// Limits contains all limits enforced by the limits frontend.
+type Limits interface {
+	IngestionRateBytes(userID string) float64
+	IngestionBurstSizeBytes(userID string) int
+	MaxGlobalStreamsPerUser(userID string) int
+}
+
+// rateLimitsAdapter implements the dskit.RateLimiterStrategy interface. We use
+// it to load per-tenant rate limits into dskit.RateLimiter.
+type rateLimitsAdapter struct {
+	limits Limits
+}
+
+func newRateLimitsAdapter(limits Limits) *rateLimitsAdapter {
+	return &rateLimitsAdapter{limits: limits}
+}
+
+// Limit implements dskit.RateLimiterStrategy.
+func (s *rateLimitsAdapter) Limit(tenantID string) float64 {
+	return s.limits.IngestionRateBytes(tenantID)
+}
+
+// Burst implements dskit.RateLimiterStrategy.
+func (s *rateLimitsAdapter) Burst(tenantID string) int {
+	return s.limits.IngestionBurstSizeBytes(tenantID)
+}

--- a/pkg/limits/frontend/service.go
+++ b/pkg/limits/frontend/service.go
@@ -28,30 +28,6 @@ const (
 	RejectedStreamReasonRateLimited = "rate_limited"
 )
 
-// Limits is the interface of the limits configuration
-// builder to be passed to the frontend service.
-type Limits interface {
-	MaxGlobalStreamsPerUser(userID string) int
-	IngestionRateBytes(userID string) float64
-	IngestionBurstSizeBytes(userID string) int
-}
-
-type ingestionRateStrategy struct {
-	limits Limits
-}
-
-func newIngestionRateStrategy(limits Limits) *ingestionRateStrategy {
-	return &ingestionRateStrategy{limits: limits}
-}
-
-func (s *ingestionRateStrategy) Limit(tenantID string) float64 {
-	return s.limits.IngestionRateBytes(tenantID)
-}
-
-func (s *ingestionRateStrategy) Burst(tenantID string) int {
-	return s.limits.IngestionBurstSizeBytes(tenantID)
-}
-
 // IngestLimitsService is responsible for receiving, processing and
 // validating requests, forwarding them to individual limits backends,
 // gathering and aggregating their responses (where required), and returning

--- a/pkg/limits/frontend/service_test.go
+++ b/pkg/limits/frontend/service_test.go
@@ -403,7 +403,7 @@ func TestRingIngestLimitsService_ExceedsLimits(t *testing.T) {
 				ingestionRate:    tt.ingestionRate,
 			}
 
-			rateLimiter := limiter.NewRateLimiter(newIngestionRateStrategy(mockLimits), 10*time.Second)
+			rateLimiter := limiter.NewRateLimiter(newRateLimitsAdapter(mockLimits), 10*time.Second)
 
 			service := NewRingIngestLimitsService(mockRing, mockPool, mockLimits, rateLimiter, log.NewNopLogger(), prometheus.NewRegistry())
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Move the `Limits` interface and adapter code to it's own file.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
