### PR TITLE
chore: move config struct to it's own file

### DIFF
--- a/pkg/limits/frontend/config.go
+++ b/pkg/limits/frontend/config.go
@@ -1,0 +1,32 @@
+package frontend
+
+import (
+	"flag"
+	"fmt"
+	"time"
+
+	"github.com/grafana/dskit/ring"
+
+	limits_client "github.com/grafana/loki/v3/pkg/limits/client"
+	util_log "github.com/grafana/loki/v3/pkg/util/log"
+)
+
+// Config contains the config for an ingest-limits-frontend.
+type Config struct {
+	ClientConfig     limits_client.Config  `yaml:"client_config"`
+	LifecyclerConfig ring.LifecyclerConfig `yaml:"lifecycler,omitempty"`
+	RecheckPeriod    time.Duration         `yaml:"recheck_period"`
+}
+
+func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
+	cfg.ClientConfig.RegisterFlagsWithPrefix("ingest-limits-frontend", f)
+	cfg.LifecyclerConfig.RegisterFlagsWithPrefix("ingest-limits-frontend.", f, util_log.Logger)
+	f.DurationVar(&cfg.RecheckPeriod, "ingest-limits-frontend.recheck-period", 10*time.Second, "The period to recheck per tenant ingestion rate limit configuration.")
+}
+
+func (cfg *Config) Validate() error {
+	if err := cfg.ClientConfig.GRPCClientConfig.Validate(); err != nil {
+		return fmt.Errorf("invalid gRPC client config: %w", err)
+	}
+	return nil
+}

--- a/pkg/limits/frontend/frontend.go
+++ b/pkg/limits/frontend/frontend.go
@@ -7,9 +7,7 @@ package frontend
 
 import (
 	"context"
-	"flag"
 	"fmt"
-	"time"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
@@ -20,33 +18,12 @@ import (
 
 	limits_client "github.com/grafana/loki/v3/pkg/limits/client"
 	"github.com/grafana/loki/v3/pkg/logproto"
-	util_log "github.com/grafana/loki/v3/pkg/util/log"
 )
 
 const (
 	RingKey  = "ingest-limits-frontend"
 	RingName = "ingest-limits-frontend"
 )
-
-// Config contains the config for an ingest-limits-frontend.
-type Config struct {
-	ClientConfig     limits_client.Config  `yaml:"client_config"`
-	LifecyclerConfig ring.LifecyclerConfig `yaml:"lifecycler,omitempty"`
-	RecheckPeriod    time.Duration         `yaml:"recheck_period"`
-}
-
-func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
-	cfg.ClientConfig.RegisterFlagsWithPrefix("ingest-limits-frontend", f)
-	cfg.LifecyclerConfig.RegisterFlagsWithPrefix("ingest-limits-frontend.", f, util_log.Logger)
-	f.DurationVar(&cfg.RecheckPeriod, "ingest-limits-frontend.recheck-period", 10*time.Second, "The period to recheck per tenant ingestion rate limit configuration.")
-}
-
-func (cfg *Config) Validate() error {
-	if err := cfg.ClientConfig.GRPCClientConfig.Validate(); err != nil {
-		return fmt.Errorf("invalid gRPC client config: %w", err)
-	}
-	return nil
-}
 
 // Frontend is the limits-frontend service, and acts a service wrapper for
 // all components needed to run the limits-frontend.


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
