### PR TITLE
fix: validate timestamps set in the requests while parsing

### DIFF
--- a/pkg/loghttp/params_test.go
+++ b/pkg/loghttp/params_test.go
@@ -204,6 +204,10 @@ func Test_parseTimestamp(t *testing.T) {
 		{"RFC3339 format", "2002-10-02T15:00:00Z", now, time.Date(2002, 10, 02, 15, 0, 0, 0, time.UTC), false},
 		{"RFC3339nano format", "2009-11-10T23:00:00.000000001Z", now, time.Date(2009, 11, 10, 23, 0, 0, 1, time.UTC), false},
 		{"invalid", "we", now, time.Time{}, true},
+		{"valid with leading zeros", "0000123456", now, time.Unix(123456, 0), false},
+		{"valid with trailing zeros", "1571332130.000", now, time.Unix(1571332130, 0), false},
+		{"scientific notation", "1.5e9", now, time.Time{}, true},
+		{"multiple decimal points", "1571332130.934.123", now, time.Time{}, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:
A query timestamp with floating point(`.`) is expected to be in the format `<seconds>.<nanoseconds>`. However, the parsing logic breaks when a timestamp is passed in scientific notation(e.g. `1.5e9`). Since accepting timestamps in scientific notation is not part of our spec, this PR updates the code to reject them.

**Special notes for your reviewer**:
As per the the benchmark results below, it is faster to validate the timestamp by iterating through each character instead of using a regex:
```
BenchmarkTimestampValidation/regex/short_integer-10              8354208               144.7 ns/op             0 B/op              0 allocs/op
BenchmarkTimestampValidation/regex/long_integer-10               5127120               235.2 ns/op             0 B/op              0 allocs/op
BenchmarkTimestampValidation/regex/with_decimal-10               6714062               186.3 ns/op             0 B/op              0 allocs/op
BenchmarkTimestampValidation/regex/scientific-10                19318538                60.68 ns/op            0 B/op              0 allocs/op
BenchmarkTimestampValidation/char_by_char/short_integer-10      100000000               10.99 ns/op            0 B/op              0 allocs/op
BenchmarkTimestampValidation/char_by_char/long_integer-10       61145458                19.90 ns/op            0 B/op              0 allocs/op
BenchmarkTimestampValidation/char_by_char/with_decimal-10       78461931                14.89 ns/op            0 B/op              0 allocs/op
BenchmarkTimestampValidation/char_by_char/scientific-10         238180912                5.222 ns/op           0 B/op              0 allocs/op
```

**Checklist**
- [x] Tests updated