### PR TITLE
feat(lambda-promtail): allow setting Lambda reserved concurrency

### DIFF
--- a/tools/lambda-promtail/main.tf
+++ b/tools/lambda-promtail/main.tf
@@ -189,6 +189,8 @@ resource "aws_lambda_function" "this" {
   memory_size  = 128
   package_type = var.lambda_promtail_image == "" ? "Zip" : "Image"
 
+  reserved_concurrent_executions = var.lambda_reserved_concurrent_executions
+
   # From the Terraform AWS Lambda docs: If both subnet_ids and security_group_ids are empty then vpc_config is considered to be empty or unset.
   vpc_config {
     # Every subnet should be able to reach an EFS mount target in the same Availability Zone. Cross-AZ mounts are not permitted.

--- a/tools/lambda-promtail/variables.tf
+++ b/tools/lambda-promtail/variables.tf
@@ -102,6 +102,12 @@ variable "batch_size" {
   default     = ""
 }
 
+variable "lambda_reserved_concurrent_executions" {
+  type        = number
+  description = "Amount of reserved concurrent executions for the Lambda function. A value of -1 removes any concurrency limitations. A value of 0 prevents the Lambda function from being triggered at all."
+  default     = -1
+}
+
 variable "lambda_vpc_subnets" {
   type        = list(string)
   description = "List of subnet IDs associated with the Lambda function."


### PR DESCRIPTION
**What this PR does / why we need it**:

_TLDR: We were running into issues with lambda-promtail eating up all of our Lambda function concurrency and adding reserved concurrency will mitigate that._

For the uninitiated, from https://docs.aws.amazon.com/lambda/latest/dg/configuration-concurrency.html

> Reserved concurrency – This represents the maximum number of
> concurrent instances allocated to your function. When a function has
> reserved concurrency, no other function can use that concurrency.
> Reserved concurrency is useful for ensuring that your most critical
> functions always have enough concurrency to handle incoming requests.
> Configuring reserved concurrency for a function incurs no additional
> charges.

Given this, being able to configure reserved concurrency will help in AWS accounts that utilize Lambda heavily (not just for lambda-promtail) in a few ways. Since reserved concurrency is the max concurrency a function can run, it means that a deluge of events being sent to lambda-promtail won't exhaust all of the Lambda concurrency for the entire AWS account's region. On the other hand, since setting reserved concurrency means that function will always have that amount of concurrency reserved just for it, it can mitigate issues with delayed log messages during periods of heavily Lambda usage since the lambda-promtail function will be guaranteed to be able to handle N number of events (N being the reserved concurrency) number of events at any given time. My company was mainly having issues with the former where lambda-promtail would eat up all of our Lambda function concurrency and causing Lambda invokes to fail causing error rates for our entire platform to spike (not good!).

The default behavior in the Terraform AWS provider is to _not_ set any reserved concurrency. It uses the `-1` value to denote this. To preserve that behavior, the default value for the new input variable is `-1`.

For the keen-eyed, _provisioned_ concurrency is a different thing to _reserved_ concurrency. _Reserved_ concurrency is configured on the `aws_lambda_function` resource, but _provisioned_ concurrency is configured via a separate resource
`aws_lambda_provisioned_concurrency_config`. That distinction is the main reason this PR exists, since the Terraform module in this repo manages the `aws_lambda_function` resource and currently does not expose the `reserved_concurrent_executions` attribute. 

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
