### PR TITLE
feat: add Gateway API Route CR to loki-gateway

### DIFF
--- a/docs/sources/setup/install/helm/reference.md
+++ b/docs/sources/setup/install/helm/reference.md
@@ -4500,6 +4500,62 @@ null
 </td>
 		</tr>
 		<tr>
+			<td>gateway.route</td>
+			<td>object</td>
+			<td>Gateway API Routes configuration</td>
+			<td><pre lang="json">
+{
+  "main": {
+    "additionalRules": [],
+    "annotations": {},
+    "apiVersion": "gateway.networking.k8s.io/v1",
+    "enabled": false,
+    "filters": [],
+    "hostnames": [],
+    "kind": "HTTPRoute",
+    "labels": {},
+    "matches": [
+      {
+        "path": {
+          "type": "PathPrefix",
+          "value": "/"
+        }
+      }
+    ],
+    "parentRefs": []
+  }
+}
+</pre>
+</td>
+		</tr>
+		<tr>
+			<td>gateway.route.main.apiVersion</td>
+			<td>string</td>
+			<td>Set the route apiVersion, e.g. gateway.networking.k8s.io/v1 or gateway.networking.k8s.io/v1alpha2</td>
+			<td><pre lang="json">
+"gateway.networking.k8s.io/v1"
+</pre>
+</td>
+		</tr>
+		<tr>
+			<td>gateway.route.main.enabled</td>
+			<td>bool</td>
+			<td>Enables or disables the route</td>
+			<td><pre lang="json">
+false
+</pre>
+</td>
+		</tr>
+		<tr>
+			<td>gateway.route.main.kind</td>
+			<td>string</td>
+			<td>Set the route kind Valid options are GRPCRoute, HTTPRoute, TCPRoute, TLSRoute, UDPRoute</td>
+			<td><pre lang="json">
+"HTTPRoute"
+</pre>
+</td>
+		</tr>
+		<tr>
 			<td>gateway.service.annotations</td>
 			<td>object</td>
 			<td>Annotations for the gateway service</td>

--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -13,6 +13,8 @@ Entries should include a reference to the pull request that introduced the chang
 
 [//]: # (<AUTOMATED_UPDATES_LOCATOR> : do not remove this line. This locator is used by the CI pipeline to automatically create a changelog entry for each new Loki release. Add other chart versions and respective changelog entries bellow this line.)
 
+- [FEATURE] Add Gateway API Route CR support for Loki Gateway
+
 ## 6.28.0
 
 - [CHANGE] Add extraContainers parameter for the backend pod

--- a/production/helm/loki/templates/gateway/route-gateway.yaml
+++ b/production/helm/loki/templates/gateway/route-gateway.yaml
@@ -1,0 +1,45 @@
+{{- if .Values.gateway.enabled -}}
+{{- range $name, $route := .Values.gateway.route }}
+  {{- if $route.enabled -}}
+---
+apiVersion: {{ $route.apiVersion | default "gateway.networking.k8s.io/v1" }}
+kind: {{ $route.kind | default "HTTPRoute" }}
+metadata:
+  name: {{ include "loki.gatewayFullname" $ }}{{ if ne $name "main" }}-{{ $name }}{{ end }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "loki.gatewayLabels" $ | nindent 4 }}
+    {{- with $route.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with $route.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with $route.parentRefs }}
+  parentRefs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $route.hostnames }}
+  hostnames:
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- if $route.additionalRules }}
+    {{- tpl (toYaml $route.additionalRules) $ | nindent 4 }}
+    {{- end }}
+    - backendRefs:
+        - name: {{ include "loki.gatewayFullname" $ }}
+          port: {{ $.Values.service.port }}
+      {{- with $route.filters }}
+      filters:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $route.matches }}
+      matches:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -1122,6 +1122,36 @@ gateway:
       - secretName: loki-gateway-tls
         hosts:
           - gateway.loki.example.com
+  # -- Gateway API Routes configuration
+  route:
+    main:
+      # -- Enables or disables the route
+      enabled: false
+
+      # -- Set the route apiVersion, e.g. gateway.networking.k8s.io/v1 or gateway.networking.k8s.io/v1alpha2
+      apiVersion: gateway.networking.k8s.io/v1
+      # -- Set the route kind
+      # Valid options are GRPCRoute, HTTPRoute, TCPRoute, TLSRoute, UDPRoute
+      kind: HTTPRoute
+
+      annotations: {}
+      labels: {}
+
+      hostnames: []
+      # - my-filter.example.com
+      parentRefs: []
+      # - name: acme-gw
+
+      matches:
+        - path:
+            type: PathPrefix
+            value: /
+
+      ## Filters define the filters that are applied to requests that match this rule.
+      filters: []
+
+      ## Additional custom rules that can be added to the route
+      additionalRules: []
   # Basic auth configuration
   basicAuth:
     # -- Enables basic authentication for the gateway


### PR DESCRIPTION
**What this PR does / why we need it**:

Add support for Gateway API Routes to loki's helm chart. The implementation is similar to grafana's own [route](https://github.com/grafana/helm-charts/blob/main/charts/grafana/templates/route.yaml).

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
