### PR TITLE
chore(dataobj): pass down line filters to logs reader

### DIFF
--- a/pkg/dataobj/logs_reader.go
+++ b/pkg/dataobj/logs_reader.go
@@ -296,7 +296,7 @@ func translateLogsPredicate(p LogsPredicate, columns []dataset.Column, columnDes
 		}
 		return convertLogsTimePredicate(p, timeColumn)
 
-	case LogLineFilterPredicate:
+	case LogMessageFilterPredicate:
 		messageColumn := findColumnFromDesc(columns, columnDesc, func(desc *logsmd.ColumnDesc) bool {
 			return desc.Type == logsmd.COLUMN_TYPE_MESSAGE
 		})

--- a/pkg/dataobj/logs_reader.go
+++ b/pkg/dataobj/logs_reader.go
@@ -296,6 +296,21 @@ func translateLogsPredicate(p LogsPredicate, columns []dataset.Column, columnDes
 		}
 		return convertLogsTimePredicate(p, timeColumn)
 
+	case LogLineFilterPredicate:
+		messageColumn := findColumnFromDesc(columns, columnDesc, func(desc *logsmd.ColumnDesc) bool {
+			return desc.Type == logsmd.COLUMN_TYPE_MESSAGE
+		})
+		if messageColumn == nil {
+			return dataset.FalsePredicate{}
+		}
+
+		return dataset.FuncPredicate{
+			Column: messageColumn,
+			Keep: func(_ dataset.Column, value dataset.Value) bool {
+				return p.Keep(valueToString(value))
+			},
+		}
+
 	case MetadataMatcherPredicate:
 		metadataColumn := findColumnFromDesc(columns, columnDesc, func(desc *logsmd.ColumnDesc) bool {
 			return desc.Type == logsmd.COLUMN_TYPE_METADATA && desc.Info.Name == p.Key

--- a/pkg/dataobj/logs_reader.go
+++ b/pkg/dataobj/logs_reader.go
@@ -307,7 +307,12 @@ func translateLogsPredicate(p LogsPredicate, columns []dataset.Column, columnDes
 		return dataset.FuncPredicate{
 			Column: messageColumn,
 			Keep: func(_ dataset.Column, value dataset.Value) bool {
-				return p.Keep(valueToString(value))
+				if value.Type() == datasetmd.VALUE_TYPE_STRING {
+					// To handle older dataobjs that still use string type for message column. This can be removed in future.
+					return p.Keep([]byte(value.String()))
+				}
+
+				return p.Keep(value.ByteArray())
 			},
 		}
 

--- a/pkg/dataobj/predicate.go
+++ b/pkg/dataobj/predicate.go
@@ -90,22 +90,22 @@ type (
 	}
 )
 
-func (AndPredicate[P]) isPredicate()          {}
-func (OrPredicate[P]) isPredicate()           {}
-func (NotPredicate[P]) isPredicate()          {}
-func (TimeRangePredicate[P]) isPredicate()    {}
-func (LabelMatcherPredicate) isPredicate()    {}
-func (LabelFilterPredicate) isPredicate()     {}
-func (MetadataMatcherPredicate) isPredicate() {}
-func (MetadataFilterPredicate) isPredicate()  {}
-func (LogMessageFilterPredicate) isPredicate()   {}
+func (AndPredicate[P]) isPredicate()           {}
+func (OrPredicate[P]) isPredicate()            {}
+func (NotPredicate[P]) isPredicate()           {}
+func (TimeRangePredicate[P]) isPredicate()     {}
+func (LabelMatcherPredicate) isPredicate()     {}
+func (LabelFilterPredicate) isPredicate()      {}
+func (MetadataMatcherPredicate) isPredicate()  {}
+func (MetadataFilterPredicate) isPredicate()   {}
+func (LogMessageFilterPredicate) isPredicate() {}
 
-func (AndPredicate[P]) predicateKind(P)                      {}
-func (OrPredicate[P]) predicateKind(P)                       {}
-func (NotPredicate[P]) predicateKind(P)                      {}
-func (TimeRangePredicate[P]) predicateKind(P)                {}
-func (LabelMatcherPredicate) predicateKind(StreamsPredicate) {}
-func (LabelFilterPredicate) predicateKind(StreamsPredicate)  {}
-func (MetadataMatcherPredicate) predicateKind(LogsPredicate) {}
-func (MetadataFilterPredicate) predicateKind(LogsPredicate)  {}
-func (LogMessageFilterPredicate) predicateKind(LogsPredicate)   {}
+func (AndPredicate[P]) predicateKind(P)                       {}
+func (OrPredicate[P]) predicateKind(P)                        {}
+func (NotPredicate[P]) predicateKind(P)                       {}
+func (TimeRangePredicate[P]) predicateKind(P)                 {}
+func (LabelMatcherPredicate) predicateKind(StreamsPredicate)  {}
+func (LabelFilterPredicate) predicateKind(StreamsPredicate)   {}
+func (MetadataMatcherPredicate) predicateKind(LogsPredicate)  {}
+func (MetadataFilterPredicate) predicateKind(LogsPredicate)   {}
+func (LogMessageFilterPredicate) predicateKind(LogsPredicate) {}

--- a/pkg/dataobj/predicate.go
+++ b/pkg/dataobj/predicate.go
@@ -68,7 +68,7 @@ type (
 	// A LogMessageFilterPredicate is a [LogsPredicate] that requires the log message
 	// of the entry to pass a Keep function.
 	LogMessageFilterPredicate struct {
-		Keep func(line string) bool
+		Keep func(line []byte) bool
 	}
 
 	// A MetadataMatcherPredicate is a [LogsPredicate] that requires a metadata

--- a/pkg/dataobj/predicate.go
+++ b/pkg/dataobj/predicate.go
@@ -65,6 +65,12 @@ type (
 		Keep func(name, value string) bool
 	}
 
+	// A LogLineFilterPredicate is a [LogsPredicate] that requires that log line
+	// of the entry to pass the Keep function.
+	LogLineFilterPredicate struct {
+		Keep func(line string) bool
+	}
+
 	// A MetadataMatcherPredicate is a [LogsPredicate] that requires a metadata
 	// key named Key to exist with a value of Value.
 	MetadataMatcherPredicate struct{ Key, Value string }
@@ -92,6 +98,7 @@ func (LabelMatcherPredicate) isPredicate()    {}
 func (LabelFilterPredicate) isPredicate()     {}
 func (MetadataMatcherPredicate) isPredicate() {}
 func (MetadataFilterPredicate) isPredicate()  {}
+func (LogLineFilterPredicate) isPredicate()   {}
 
 func (AndPredicate[P]) predicateKind(P)                      {}
 func (OrPredicate[P]) predicateKind(P)                       {}
@@ -101,3 +108,4 @@ func (LabelMatcherPredicate) predicateKind(StreamsPredicate) {}
 func (LabelFilterPredicate) predicateKind(StreamsPredicate)  {}
 func (MetadataMatcherPredicate) predicateKind(LogsPredicate) {}
 func (MetadataFilterPredicate) predicateKind(LogsPredicate)  {}
+func (LogLineFilterPredicate) predicateKind(LogsPredicate)   {}

--- a/pkg/dataobj/predicate.go
+++ b/pkg/dataobj/predicate.go
@@ -65,8 +65,8 @@ type (
 		Keep func(name, value string) bool
 	}
 
-	// A LogMessageFilterPredicate is a [LogsPredicate] that requires that log line
-	// of the entry to pass the Keep function.
+	// A LogMessageFilterPredicate is a [LogsPredicate] that requires the log message
+	// of the entry to pass a Keep function.
 	LogMessageFilterPredicate struct {
 		Keep func(line string) bool
 	}

--- a/pkg/dataobj/predicate.go
+++ b/pkg/dataobj/predicate.go
@@ -65,9 +65,9 @@ type (
 		Keep func(name, value string) bool
 	}
 
-	// A LogLineFilterPredicate is a [LogsPredicate] that requires that log line
+	// A LogMessageFilterPredicate is a [LogsPredicate] that requires that log line
 	// of the entry to pass the Keep function.
-	LogLineFilterPredicate struct {
+	LogMessageFilterPredicate struct {
 		Keep func(line string) bool
 	}
 
@@ -98,7 +98,7 @@ func (LabelMatcherPredicate) isPredicate()    {}
 func (LabelFilterPredicate) isPredicate()     {}
 func (MetadataMatcherPredicate) isPredicate() {}
 func (MetadataFilterPredicate) isPredicate()  {}
-func (LogLineFilterPredicate) isPredicate()   {}
+func (LogMessageFilterPredicate) isPredicate()   {}
 
 func (AndPredicate[P]) predicateKind(P)                      {}
 func (OrPredicate[P]) predicateKind(P)                       {}
@@ -108,4 +108,4 @@ func (LabelMatcherPredicate) predicateKind(StreamsPredicate) {}
 func (LabelFilterPredicate) predicateKind(StreamsPredicate)  {}
 func (MetadataMatcherPredicate) predicateKind(LogsPredicate) {}
 func (MetadataFilterPredicate) predicateKind(LogsPredicate)  {}
-func (LogLineFilterPredicate) predicateKind(LogsPredicate)   {}
+func (LogMessageFilterPredicate) predicateKind(LogsPredicate)   {}

--- a/pkg/dataobj/querier/store.go
+++ b/pkg/dataobj/querier/store.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"sync"
 	"time"
-	"unsafe"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
@@ -715,8 +714,8 @@ Outer:
 
 			// Create a line filter predicate
 			appendPredicate(dataobj.LogMessageFilterPredicate{
-				Keep: func(line string) bool {
-					return f.Filter(unsafeGetBytes(line))
+				Keep: func(line []byte) bool {
+					return f.Filter(line)
 				},
 			})
 
@@ -731,9 +730,4 @@ Outer:
 	pipelineExpr.MultiStages = remainingStages
 
 	return predicate, pipelineExpr
-}
-
-// we may not need this once https://github.com/grafana/loki/pull/16747/ is merged
-func unsafeGetBytes(s string) []byte {
-	return unsafe.Slice(unsafe.StringData(s), len(s))
 }

--- a/pkg/dataobj/querier/store.go
+++ b/pkg/dataobj/querier/store.go
@@ -278,8 +278,7 @@ func buildLogsPredicateFromSampleExpr(expr syntax.SampleExpr) (dataobj.LogsPredi
 	expr.Walk(func(e syntax.Expr) {
 		switch e := e.(type) {
 		case *syntax.BinOpExpr:
-			// TODO: we may need to use different predicates for either sides of the binary operation
-			// It should be easy to support binary op with a literal on one side. skip applying predicates for now
+			// we might not encounter BinOpExpr at this point since the lhs and rhs are evaluated separately?
 			skip = true
 			return
 		case *syntax.RangeAggregationExpr:
@@ -352,8 +351,9 @@ Outer:
 	return predicate, pipelineExpr
 }
 
+// we may not need this once https://github.com/grafana/loki/pull/16747/ is merged
 func unsafeGetBytes(s string) []byte {
-	return unsafe.Slice(unsafe.StringData(s), len(s)) // #nosec G103 -- we know the string is not mutated
+	return unsafe.Slice(unsafe.StringData(s), len(s))
 }
 
 func selectSamples(ctx context.Context, objects []object, shard logql.Shard, expr syntax.SampleExpr, start, end time.Time, logger log.Logger) (iter.SampleIterator, error) {

--- a/pkg/dataobj/querier/store.go
+++ b/pkg/dataobj/querier/store.go
@@ -24,7 +24,6 @@ import (
 	"github.com/grafana/loki/v3/pkg/iter"
 	"github.com/grafana/loki/v3/pkg/logproto"
 	"github.com/grafana/loki/v3/pkg/logql"
-	logqllog "github.com/grafana/loki/v3/pkg/logql/log"
 	"github.com/grafana/loki/v3/pkg/logql/syntax"
 	"github.com/grafana/loki/v3/pkg/querier"
 	"github.com/grafana/loki/v3/pkg/storage/chunk"
@@ -230,13 +229,22 @@ func selectLogs(ctx context.Context, objects []object, shard logql.Shard, req lo
 		}
 	}()
 	streamsPredicate := streamPredicate(selector.Matchers(), req.Start, req.End)
-	// TODO: support more predicates and combine with log.Pipeline.
-	logsPredicate := dataobj.TimeRangePredicate[dataobj.LogsPredicate]{
+	var logsPredicate dataobj.LogsPredicate = dataobj.TimeRangePredicate[dataobj.LogsPredicate]{
 		StartTime:    req.Start,
 		EndTime:      req.End,
 		IncludeStart: true,
 		IncludeEnd:   false,
 	}
+
+	p, expr := buildLogsPredicateFromPipeline(selector)
+	if p != nil {
+		logsPredicate = dataobj.AndPredicate[dataobj.LogsPredicate]{
+			Left:  logsPredicate,
+			Right: p,
+		}
+	}
+	req.Plan.AST = expr
+
 	g, ctx := errgroup.WithContext(ctx)
 	iterators := make([]iter.EntryIterator, len(shardedObjects))
 
@@ -262,163 +270,86 @@ func selectLogs(ctx context.Context, objects []object, shard logql.Shard, req lo
 	return iter.NewSortEntryIterator(iterators, req.Direction), nil
 }
 
-func buildPredicate(expr syntax.LogSelectorExpr) (dataobj.Predicate, syntax.LogSelectorExpr, error) {
-	var predicate dataobj.Predicate
+func buildLogsPredicateFromSampleExpr(expr syntax.SampleExpr) (dataobj.LogsPredicate, syntax.SampleExpr) {
+	var (
+		predicate dataobj.LogsPredicate
+		skip      bool
+	)
+	expr.Walk(func(e syntax.Expr) {
+		switch e := e.(type) {
+		case *syntax.BinOpExpr:
+			// TODO: we may need to use different predicates for either sides of the binary operation
+			// It should be easy to support binary op with a literal on one side. skip applying predicates for now
+			skip = true
+			return
+		case *syntax.RangeAggregationExpr:
+			if skip {
+				return
+			}
 
-	// Check if the expression is a PipelineExpr, other implementations use a NoopPipeline
+			predicate, e.Left.Left = buildLogsPredicateFromPipeline(e.Left.Left)
+		}
+	})
+
+	return predicate, expr
+}
+
+func buildLogsPredicateFromPipeline(expr syntax.LogSelectorExpr) (dataobj.LogsPredicate, syntax.LogSelectorExpr) {
+	// Check if expr is a PipelineExpr, other implementations have no stages
 	pipelineExpr, ok := expr.(*syntax.PipelineExpr)
 	if !ok {
-		return predicate, expr, nil
+		return nil, expr
 	}
 
-	// Keep track of whether we've seen stages that modify lines or labels
-	var seenLineFmt bool
-	var seenLabelFmt bool
-
-	// Iterate through the stages
-	var remainingStages []syntax.StageExpr
-	for _, stage := range pipelineExpr.MultiStages {
-		switch s := stage.(type) {
-		// Stages that modify the log line
-		case *syntax.LineFmtExpr:
-			seenLineFmt = true
-			remainingStages = append(remainingStages, s)
-		// Stages that modify labels
-		case *syntax.LabelFmtExpr, *syntax.LineParserExpr, *syntax.LogfmtParserExpr,
-			*syntax.LogfmtExpressionParserExpr, *syntax.JSONExpressionParserExpr,
-			*syntax.KeepLabelsExpr, *syntax.DropLabelsExpr:
-			seenLabelFmt = true
-			remainingStages = append(remainingStages, s)
-
-		// Label filter stages
-		case *syntax.LabelFilterExpr:
-			if seenLabelFmt {
-				// If we've seen a label format stage, we can't apply this filter as a predicate
-				remainingStages = append(remainingStages, s)
-				continue
-			}
-
-			// Convert the label filter to a predicate
-			lf := createLabelFilterPredicate(s.LabelFilterer)
-			if lf == nil {
-				// If we couldn't convert it, keep it in the stages
-				remainingStages = append(remainingStages, s)
-				continue
-			}
-
-			// Add the predicate
+	var (
+		predicate       dataobj.LogsPredicate
+		remainingStages = make([]syntax.StageExpr, 0, len(pipelineExpr.MultiStages))
+		appendPredicate = func(p dataobj.LogsPredicate) {
 			if predicate == nil {
-				predicate = lf
+				predicate = p
 			} else {
-				predicate = dataobj.AndPredicate[dataobj.Predicate]{
+				predicate = dataobj.AndPredicate[dataobj.LogsPredicate]{
 					Left:  predicate,
-					Right: lf,
+					Right: p,
 				}
 			}
-		// Line filter stages
-		case *syntax.LineFilterExpr:
-			if seenLineFmt {
-				// If we've seen a line format stage, we can't apply this filter as a predicate
-				remainingStages = append(remainingStages, s)
-				continue
-			}
+		}
+	)
 
+Outer:
+	for i, stage := range pipelineExpr.MultiStages {
+		switch s := stage.(type) {
+		case *syntax.LineFmtExpr:
+			// modifies the log line, break early as we cannot apply any more predicates
+			remainingStages = append(remainingStages, pipelineExpr.MultiStages[i:]...)
+			break Outer
+
+		case *syntax.LineFilterExpr:
 			// Convert the line filter to a predicate
 			f, err := s.Filter()
 			if err != nil {
-				// If there's an error, keep it in the stages
 				remainingStages = append(remainingStages, s)
 				continue
 			}
 
 			// Create a line filter predicate
-			lf := dataobj.LogLineFilterPredicate{
+			appendPredicate(dataobj.LogMessageFilterPredicate{
 				Keep: func(line string) bool {
 					return f.Filter(unsafeGetBytes(line))
 				},
-			}
+			})
 
-			// Add the predicate
-			if predicate == nil {
-				predicate = lf
-			} else {
-				predicate = dataobj.AndPredicate[dataobj.Predicate]{
-					Left:  predicate,
-					Right: lf,
-				}
-			}
-
-		// Any other stage types
 		default:
 			remainingStages = append(remainingStages, s)
 		}
 	}
 
+	if len(remainingStages) == 0 {
+		return predicate, pipelineExpr.Left // return MatchersExpr
+	}
 	pipelineExpr.MultiStages = remainingStages
 
-	if len(pipelineExpr.MultiStages) == 0 {
-		return predicate, pipelineExpr.Left, nil
-	}
-
-	return predicate, pipelineExpr, nil
-}
-
-// createLabelFilterPredicate creates a dataobj.LogsPredicate from a log.LabelFilterer.
-func createLabelFilterPredicate(lf logqllog.LabelFilterer) dataobj.Predicate {
-	if lf == nil {
-		return nil
-	}
-
-	switch lf := lf.(type) {
-	case *logqllog.StringLabelFilter:
-		return dataobj.LabelFilterPredicate{
-			Name: lf.Name,
-			Keep: func(name, value string) bool {
-				if name != lf.Name {
-					return true // Only filter the specified label
-				}
-				return lf.Matcher.Matches(value)
-			},
-		}
-	case *logqllog.LineFilterLabelFilter:
-		return dataobj.LabelFilterPredicate{
-			Name: lf.Name,
-			Keep: func(name, value string) bool {
-				if name != lf.Name {
-					return true // Only filter the specified label
-				}
-				return lf.Filter.Filter(unsafeGetBytes(value))
-			},
-		}
-	case *logqllog.BinaryLabelFilter:
-		// Handle binary label filter (AND/OR)
-		// Recursively create predicates for left and right sides
-		leftPred := createLabelFilterPredicate(lf.Left)
-		rightPred := createLabelFilterPredicate(lf.Right)
-
-		if leftPred == nil && rightPred == nil {
-			return nil
-		} else if leftPred == nil {
-			return rightPred
-		} else if rightPred == nil {
-			return leftPred
-		}
-
-		if lf.And {
-			return dataobj.AndPredicate[dataobj.Predicate]{
-				Left:  leftPred,
-				Right: rightPred,
-			}
-		} else {
-			return dataobj.OrPredicate[dataobj.Predicate]{
-				Left:  leftPred,
-				Right: rightPred,
-			}
-		}
-	default:
-		// Unsupported label filter type for this iteration
-		return nil
-	}
+	return predicate, pipelineExpr
 }
 
 func unsafeGetBytes(s string) []byte {
@@ -443,11 +374,20 @@ func selectSamples(ctx context.Context, objects []object, shard logql.Shard, exp
 
 	streamsPredicate := streamPredicate(selector.Matchers(), start, end)
 	// TODO: support more predicates and combine with log.Pipeline.
-	logsPredicate := dataobj.TimeRangePredicate[dataobj.LogsPredicate]{
+	var logsPredicate dataobj.LogsPredicate = dataobj.TimeRangePredicate[dataobj.LogsPredicate]{
 		StartTime:    start,
 		EndTime:      end,
 		IncludeStart: true,
 		IncludeEnd:   false,
+	}
+
+	var predicateFromExpr dataobj.LogsPredicate
+	predicateFromExpr, expr = buildLogsPredicateFromSampleExpr(expr)
+	if predicateFromExpr != nil {
+		logsPredicate = dataobj.AndPredicate[dataobj.LogsPredicate]{
+			Left:  logsPredicate,
+			Right: predicateFromExpr,
+		}
 	}
 
 	g, ctx := errgroup.WithContext(ctx)

--- a/pkg/dataobj/querier/store_test.go
+++ b/pkg/dataobj/querier/store_test.go
@@ -818,8 +818,8 @@ func TestShardSections(t *testing.T) {
 }
 
 func TestBuildLogsPredicateFromPipeline(t *testing.T) {
-	var evalPredicate func(p dataobj.Predicate, item string) bool
-	evalPredicate = func(p dataobj.Predicate, line string) bool {
+	var evalPredicate func(p dataobj.Predicate, item []byte) bool
+	evalPredicate = func(p dataobj.Predicate, line []byte) bool {
 		switch p := p.(type) {
 		case dataobj.LogMessageFilterPredicate:
 			return p.Keep(line)
@@ -832,7 +832,7 @@ func TestBuildLogsPredicateFromPipeline(t *testing.T) {
 	}
 
 	// helper function to test predicates against sample data
-	testPredicate := func(t *testing.T, pred dataobj.Predicate, testData []string, expected []bool) {
+	testPredicate := func(t *testing.T, pred dataobj.Predicate, testData [][]byte, expected []bool) {
 		t.Helper()
 		require.Equal(t, len(testData), len(expected), "test data and expected results must have the same length")
 
@@ -843,11 +843,11 @@ func TestBuildLogsPredicateFromPipeline(t *testing.T) {
 	}
 
 	// Create test data sets
-	testData := []string{
-		"this is an error message",
-		"this is a critical error",
-		"this is a success message",
-		"this is a warning message",
+	testData := [][]byte{
+		[]byte("this is an error message"),
+		[]byte("this is a critical error"),
+		[]byte("this is a success message"),
+		[]byte("this is a warning message"),
 	}
 
 	for _, tt := range []struct {

--- a/pkg/engine/planner/internal/tree/printer.go
+++ b/pkg/engine/planner/internal/tree/printer.go
@@ -52,7 +52,7 @@ type Node struct {
 	Children []*Node
 	// Comments, like Children, are child nodes of the node, with the difference
 	// that comments are indented a level deeper than children. A common use-case
-	// for comments are tree-style properies of a node, such as expressions of a
+	// for comments are tree-style properties of a node, such as expressions of a
 	// physical plan node.
 	Comments []*Node
 }

--- a/pkg/engine/planner/physical/expressions.go
+++ b/pkg/engine/planner/physical/expressions.go
@@ -133,28 +133,28 @@ func (t BinaryOpType) String() string {
 	}
 }
 
-// Expression is the common interface for all expressions in a physcial plan.
+// Expression is the common interface for all expressions in a physical plan.
 type Expression interface {
 	Type() ExpressionType
 	isExpr()
 }
 
 // UnaryExpression is the common interface for all unary expressions in a
-// physcial plan.
+// physical plan.
 type UnaryExpression interface {
 	Expression
 	isUnaryExpr()
 }
 
 // BinaryExpression is the common interface for all binary expressions in a
-// physcial plan.
+// physical plan.
 type BinaryExpression interface {
 	Expression
 	isBinaryExpr()
 }
 
 // LiteralExpression is the common interface for all literal expressions in a
-// physcial plan.
+// physical plan.
 type LiteralExpression interface {
 	Expression
 	ValueType() ValueType
@@ -162,7 +162,7 @@ type LiteralExpression interface {
 }
 
 // ColumnExpression is the common interface for all column expressions in a
-// physcial plan.
+// physical plan.
 type ColumnExpression interface {
 	Expression
 	isColumnExpr()

--- a/pkg/limits/ingest_limits_test.go
+++ b/pkg/limits/ingest_limits_test.go
@@ -994,9 +994,7 @@ func TestIngestLimits_evictOldStreams(t *testing.T) {
 			// Assign the Partition IDs.
 			partitions := make(map[string][]int32)
 			partitions["test"] = make([]int32, 0, len(tt.assignedPartitionIDs))
-			for _, partitionID := range tt.assignedPartitionIDs {
-				partitions["test"] = append(partitions["test"], partitionID)
-			}
+			partitions["test"] = append(partitions["test"], tt.assignedPartitionIDs...)
 			s.partitionManager.Assign(context.Background(), nil, partitions)
 
 			// Call evictOldStreams


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently we configure `TimeRangePredicate` on the logs reader to  only process log lines for the desired time range. 
We can further save compute by configuring line and label filters as predicates to only process the matching log lines. This PR adds support to configure `LogMessageFilterPredicate` based on line filter expressions. It also removes the applied filter from the original query plan to avoid the redundant work. Line filters appearing after `line_format` stage are not configured as predicates as it modifies the resulting log line.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:


**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
