### PR TITLE
fix: Improve timestamp parsing

### DIFF
--- a/pkg/loghttp/params.go
+++ b/pkg/loghttp/params.go
@@ -175,24 +175,24 @@ func parseTimestamp(value string, def time.Time) (time.Time, error) {
 	// 1 to 9-digit numbers are considered second precision
 	// 10 to 18-digit numbers are considered nanosecond precision
 	if strings.Contains(value, ".") {
-		if t, err := strconv.ParseFloat(value, 64); err != nil {
+		t, err := strconv.ParseFloat(value, 64)
+		if err != nil {
 			return time.Time{}, err
-		} else {
-			if math.IsNaN(t) || math.IsInf(t, 0) {
-				return time.Time{}, fmt.Errorf("floating point timestamp is NaN or Inf")
-			}
-			high, low := math.Modf(t)
-			if high > math.MaxInt64 || high < math.MinInt64 {
-				return time.Time{}, fmt.Errorf("floating point timestamp exceeds integer range")
-			}
-			// treat high as seconds
-			if high <= 1e10 {
-				low = math.Round(low*1000) / 1000
-				return time.Unix(int64(high), int64(low*float64(time.Second))), nil
-			}
-			// treat high as nanoseconds and discard low
-			return time.Unix(0, int64(high)), nil
 		}
+		if math.IsNaN(t) || math.IsInf(t, 0) {
+			return time.Time{}, fmt.Errorf("floating point timestamp is NaN or Inf")
+		}
+		high, low := math.Modf(t)
+		if high > math.MaxInt64 || high < math.MinInt64 {
+			return time.Time{}, fmt.Errorf("floating point timestamp exceeds integer range")
+		}
+		// treat high as seconds
+		if high <= 1e10 {
+			low = math.Round(low*1000) / 1000
+			return time.Unix(int64(high), int64(low*float64(time.Second))), nil
+		}
+		// treat high as nanoseconds and discard low
+		return time.Unix(0, int64(high)), nil
 	}
 
 	// Parse an integer value string, can be either regular or scientific notation.

--- a/pkg/loghttp/params.go
+++ b/pkg/loghttp/params.go
@@ -158,31 +158,56 @@ func parseInt(value string, def int) (int, error) {
 	return strconv.Atoi(value)
 }
 
-// parseTimestamp parses a ns unix timestamp from a string
-// if the value is empty it returns a default value passed as second parameter
+// parseTimestamp parses a string into a unix nanosecond timestamp.
+// If the value is empty it returns a default value passed as second parameter.
+// The function returns an error if the string cannot be parsed.
 func parseTimestamp(value string, def time.Time) (time.Time, error) {
 	if value == "" {
 		return def, nil
 	}
 
+	// Try parsing a datetime string in RFC3339Nano format
+	if ts, err := time.Parse(time.RFC3339Nano, value); err == nil {
+		return ts, nil
+	}
+
+	// Parse a float value string, can be either regular or scientific notation.
+	// 1 to 9-digit numbers are considered second precision
+	// 10 to 18-digit numbers are considered nanosecond precision
 	if strings.Contains(value, ".") {
-		if t, err := strconv.ParseFloat(value, 64); err == nil {
-			s, ns := math.Modf(t)
-			ns = math.Round(ns*1000) / 1000
-			return time.Unix(int64(s), int64(ns*float64(time.Second))), nil
+		if t, err := strconv.ParseFloat(value, 64); err != nil {
+			return time.Time{}, err
+		} else {
+			if math.IsNaN(t) || math.IsInf(t, 0) {
+				return time.Time{}, fmt.Errorf("floating point timestamp is NaN or Inf")
+			}
+			high, low := math.Modf(t)
+			if high > math.MaxInt64 || high < math.MinInt64 {
+				return time.Time{}, fmt.Errorf("floating point timestamp exceeds integer range")
+			}
+			// treat high as seconds
+			if high <= 1e10 {
+				low = math.Round(low*1000) / 1000
+				return time.Unix(int64(high), int64(low*float64(time.Second))), nil
+			}
+			// treat high as nanoseconds and discard low
+			return time.Unix(0, int64(high)), nil
 		}
 	}
-	nanos, err := strconv.ParseInt(value, 10, 64)
+
+	// Parse an integer value string, can be either regular or scientific notation.
+	// 1 to 9-digit numbers are considered second precision
+	// 10 to 18-digit numbers are considered nanosecond precision
+	val, err := strconv.ParseInt(value, 10, 64)
 	if err != nil {
-		if ts, err := time.Parse(time.RFC3339Nano, value); err == nil {
-			return ts, nil
-		}
 		return time.Time{}, err
 	}
-	if len(value) <= 10 {
-		return time.Unix(nanos, 0), nil
+	// treat val as seconds
+	if val <= 1e10 {
+		return time.Unix(val, 0), nil
 	}
-	return time.Unix(0, nanos), nil
+	// treat val as nanoseconds
+	return time.Unix(0, val), nil
 }
 
 // parseDirection parses a logproto.Direction from a string

--- a/pkg/loghttp/params_test.go
+++ b/pkg/loghttp/params_test.go
@@ -200,10 +200,14 @@ func Test_parseTimestamp(t *testing.T) {
 		{"default", "", now, now, false},
 		{"unix timestamp", "1571332130", now, time.Unix(1571332130, 0), false},
 		{"unix nano timestamp", "1571334162051000000", now, time.Unix(0, 1571334162051000000), false},
-		{"unix timestamp with subseconds", "1571332130.934", now, time.Unix(1571332130, 934*1e6), false},
+		{"floating point timestamp", "1571332130.934", now, time.Unix(1571332130, 934*1e6), false},
+		{"floating point nano timestamp", "1571332130934000000.123", now, time.Unix(1571332130, 934000128), false},
 		{"RFC3339 format", "2002-10-02T15:00:00Z", now, time.Date(2002, 10, 02, 15, 0, 0, 0, time.UTC), false},
 		{"RFC3339nano format", "2009-11-10T23:00:00.000000001Z", now, time.Date(2009, 11, 10, 23, 0, 0, 1, time.UTC), false},
+		{"invalid RFC3339 format", "12999-10-02T15:00:00Z", now, time.Time{}, true},
 		{"invalid", "we", now, time.Time{}, true},
+		{"scientific timestamp", "1.57133416201e+9", now, time.Unix(1571334162, 10000000), false},
+		{"scientific nano timestamp", "1.57133416201e+18", now, time.Unix(0, 1571334162009999872), false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

The timestamp parsing is now able to handle scientific notation of floating point string representations correctly.

While integers with more than 10 digits were already handled correctly as nanoseconds, floating point numbers were not.