### PR TITLE
docs: add note about lambda-promtail

### DIFF
--- a/docs/sources/release-notes/v3-4.md
+++ b/docs/sources/release-notes/v3-4.md
@@ -71,7 +71,7 @@ Other improvements include the following:
 
 One of the focuses of Loki 3.0 was cleaning up unused code and old features that had been previously deprecated but not removed. Loki 3.0 removed a number of previous deprecations and introduces some new deprecations. Some of the main areas with changes include:
 
-- [Promtail](https://grafana.com/docs/loki/<LOKI_VERSION>/send-data/promtail/) is deprecated, as the code has been merged into Grafana Alloy. You can find migration documentation and a utility to convert your Promtail configuration to Alloy configuration in the [Alloy documentation](https://grafana.com/docs/alloy/latest/set-up/migrate/from-promtail/).
+- [Promtail](https://grafana.com/docs/loki/<LOKI_VERSION>/send-data/promtail/) is deprecated, as the code has been merged into Grafana Alloy. You can find migration documentation and a utility to convert your Promtail configuration to Alloy configuration in the [Alloy documentation](https://grafana.com/docs/alloy/latest/set-up/migrate/from-promtail/).  Note that this deprecation does NOT include the lambda-promtail client.
 
 - [Deprecated storage options](https://grafana.com/docs/loki/<LOKI_VERSION>/storage/) including the deprecation of the BoltDB store.
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Add clarification that the Promtail deprecation does not include lambda-promtail.