### PR TITLE
fix: fix a panic in ServeHTTP where stream was nil

### DIFF
--- a/pkg/limits/frontend/http.go
+++ b/pkg/limits/frontend/http.go
@@ -33,7 +33,7 @@ func (f *Frontend) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	streams := make([]*logproto.StreamMetadata, len(req.StreamHashes))
+	streams := make([]*logproto.StreamMetadata, 0, len(req.StreamHashes))
 	for _, streamHash := range req.StreamHashes {
 		streams = append(streams, &logproto.StreamMetadata{
 			StreamHash: streamHash,

--- a/pkg/limits/frontend/http_test.go
+++ b/pkg/limits/frontend/http_test.go
@@ -1,0 +1,109 @@
+package frontend
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/grafana/dskit/limiter"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/logproto"
+)
+
+func TestFrontend_ServeHTTP(t *testing.T) {
+	tests := []struct {
+		name                          string
+		limits                        Limits
+		expectedGetStreamUsageRequest *GetStreamUsageRequest
+		getStreamUsageResponses       []GetStreamUsageResponse
+		request                       exceedsLimitsRequest
+		expected                      exceedsLimitsResponse
+	}{{
+		name: "within limits",
+		limits: &mockLimits{
+			maxGlobalStreams: 1,
+			ingestionRate:    100,
+		},
+		expectedGetStreamUsageRequest: &GetStreamUsageRequest{
+			Tenant:       "test",
+			StreamHashes: []uint64{0x1},
+		},
+		getStreamUsageResponses: []GetStreamUsageResponse{{
+			Response: &logproto.GetStreamUsageResponse{
+				Tenant:        "test",
+				ActiveStreams: 1,
+				Rate:          10,
+			},
+		}},
+		request: exceedsLimitsRequest{
+			TenantID:     "test",
+			StreamHashes: []uint64{0x1},
+		},
+		// expected should be default value (no rejected streams).
+	}, {
+		name: "exceeds limits",
+		limits: &mockLimits{
+			maxGlobalStreams: 1,
+			ingestionRate:    100,
+		},
+		expectedGetStreamUsageRequest: &GetStreamUsageRequest{
+			Tenant:       "test",
+			StreamHashes: []uint64{0x1},
+		},
+		getStreamUsageResponses: []GetStreamUsageResponse{{
+			Response: &logproto.GetStreamUsageResponse{
+				Tenant:        "test",
+				ActiveStreams: 2,
+				Rate:          200,
+			},
+		}},
+		request: exceedsLimitsRequest{
+			TenantID:     "test",
+			StreamHashes: []uint64{0x1},
+		},
+		expected: exceedsLimitsResponse{
+			RejectedStreams: []*logproto.RejectedStream{{
+				StreamHash: 0x1,
+				Reason:     "exceeds_rate_limit",
+			}},
+		},
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			f := Frontend{
+				limits:      test.limits,
+				rateLimiter: limiter.NewRateLimiter(newRateLimitsAdapter(test.limits), time.Second),
+				streamUsage: &mockStreamUsageGatherer{
+					t:               t,
+					expectedRequest: test.expectedGetStreamUsageRequest,
+					responses:       test.getStreamUsageResponses,
+				},
+				metrics: newMetrics(prometheus.NewRegistry()),
+			}
+			ts := httptest.NewServer(&f)
+			defer ts.Close()
+
+			b, err := json.Marshal(test.request)
+			require.NoError(t, err)
+
+			resp, err := http.Post(ts.URL, "application/json", bytes.NewReader(b))
+			require.NoError(t, err)
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+
+			defer resp.Body.Close()
+			b, err = io.ReadAll(resp.Body)
+			require.NoError(t, err)
+
+			var actual exceedsLimitsResponse
+			require.NoError(t, json.Unmarshal(b, &actual))
+			require.Equal(t, test.expected, actual)
+		})
+	}
+}

--- a/pkg/limits/frontend/mock_test.go
+++ b/pkg/limits/frontend/mock_test.go
@@ -16,6 +16,22 @@ import (
 	"github.com/grafana/loki/v3/pkg/logproto"
 )
 
+// mockStreamUsageGatherer mocks a StreamUsageGatherer. It avoids having to
+// set up a mock ring to test the frontend.
+type mockStreamUsageGatherer struct {
+	t *testing.T
+
+	expectedRequest *GetStreamUsageRequest
+	responses       []GetStreamUsageResponse
+}
+
+func (g *mockStreamUsageGatherer) GetStreamUsage(_ context.Context, r GetStreamUsageRequest) ([]GetStreamUsageResponse, error) {
+	if expected := g.expectedRequest; expected != nil {
+		require.Equal(g.t, *expected, r)
+	}
+	return g.responses, nil
+}
+
 // mockIngestLimitsClient mocks logproto.IngestLimitsClient.
 type mockIngestLimitsClient struct {
 	logproto.IngestLimitsClient


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request fixes a panic in `ServeHTTP` where nil was appended to a slice by mistake.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
