### PR TITLE
chore: rename structs to use http prefix to differentiate from logproto

### DIFF
--- a/pkg/limits/frontend/http.go
+++ b/pkg/limits/frontend/http.go
@@ -11,18 +11,18 @@ import (
 	"github.com/grafana/loki/v3/pkg/util"
 )
 
-type exceedsLimitsRequest struct {
+type httpExceedsLimitsRequest struct {
 	TenantID     string   `json:"tenantID"`
 	StreamHashes []uint64 `json:"streamHashes"`
 }
 
-type exceedsLimitsResponse struct {
+type httpExceedsLimitsResponse struct {
 	RejectedStreams []*logproto.RejectedStream `json:"rejectedStreams,omitempty"`
 }
 
 // ServeHTTP implements http.Handler.
 func (f *Frontend) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	var req exceedsLimitsRequest
+	var req httpExceedsLimitsRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, "JSON is invalid or does not match expected schema", http.StatusBadRequest)
 		return
@@ -57,7 +57,7 @@ func (f *Frontend) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	util.WriteJSONResponse(w, exceedsLimitsResponse{
+	util.WriteJSONResponse(w, httpExceedsLimitsResponse{
 		RejectedStreams: resp.RejectedStreams,
 	})
 }

--- a/pkg/limits/frontend/http_test.go
+++ b/pkg/limits/frontend/http_test.go
@@ -22,8 +22,8 @@ func TestFrontend_ServeHTTP(t *testing.T) {
 		limits                        Limits
 		expectedGetStreamUsageRequest *GetStreamUsageRequest
 		getStreamUsageResponses       []GetStreamUsageResponse
-		request                       exceedsLimitsRequest
-		expected                      exceedsLimitsResponse
+		request                       httpExceedsLimitsRequest
+		expected                      httpExceedsLimitsResponse
 	}{{
 		name: "within limits",
 		limits: &mockLimits{
@@ -41,7 +41,7 @@ func TestFrontend_ServeHTTP(t *testing.T) {
 				Rate:          10,
 			},
 		}},
-		request: exceedsLimitsRequest{
+		request: httpExceedsLimitsRequest{
 			TenantID:     "test",
 			StreamHashes: []uint64{0x1},
 		},
@@ -63,11 +63,11 @@ func TestFrontend_ServeHTTP(t *testing.T) {
 				Rate:          200,
 			},
 		}},
-		request: exceedsLimitsRequest{
+		request: httpExceedsLimitsRequest{
 			TenantID:     "test",
 			StreamHashes: []uint64{0x1},
 		},
-		expected: exceedsLimitsResponse{
+		expected: httpExceedsLimitsResponse{
 			RejectedStreams: []*logproto.RejectedStream{{
 				StreamHash: 0x1,
 				Reason:     "exceeds_rate_limit",
@@ -101,7 +101,7 @@ func TestFrontend_ServeHTTP(t *testing.T) {
 			b, err = io.ReadAll(resp.Body)
 			require.NoError(t, err)
 
-			var actual exceedsLimitsResponse
+			var actual httpExceedsLimitsResponse
 			require.NoError(t, json.Unmarshal(b, &actual))
 			require.Equal(t, test.expected, actual)
 		})


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
