### PR TITLE
fix: bug where known streams could be rejected

### DIFF
--- a/pkg/limits/frontend/frontend_test.go
+++ b/pkg/limits/frontend/frontend_test.go
@@ -33,7 +33,29 @@ func TestFrontend_ExceedsLimits(t *testing.T) {
 		},
 		expected: nil,
 	}, {
-		name: "below the limit",
+		name: "no response",
+		exceedsLimitsRequest: &logproto.ExceedsLimitsRequest{
+			Tenant: "test",
+			Streams: []*logproto.StreamMetadata{
+				{StreamHash: 0x1},
+			},
+		},
+		getAssignedPartitionsResponses: []*logproto.GetAssignedPartitionsResponse{{
+			AssignedPartitions: map[int32]int64{
+				0: time.Now().UnixNano(),
+			},
+		}},
+		expectedStreamUsageRequest: []*logproto.GetStreamUsageRequest{{
+			Tenant:       "test",
+			StreamHashes: []uint64{0x1},
+			Partitions:   []int32{0},
+		}},
+		getStreamUsageResponses: []*logproto.GetStreamUsageResponse{{}},
+		maxGlobalStreams:        10,
+		ingestionRate:           100,
+		expected:                nil,
+	}, {
+		name: "within limits",
 		exceedsLimitsRequest: &logproto.ExceedsLimitsRequest{
 			Tenant: "test",
 			Streams: []*logproto.StreamMetadata{
@@ -60,7 +82,7 @@ func TestFrontend_ExceedsLimits(t *testing.T) {
 		ingestionRate:    100,
 		expected:         nil,
 	}, {
-		name: "exceeds limit with new streams",
+		name: "exceeds max streams limit, rejects new streams",
 		exceedsLimitsRequest: &logproto.ExceedsLimitsRequest{
 			Tenant: "test",
 			Streams: []*logproto.StreamMetadata{
@@ -91,7 +113,7 @@ func TestFrontend_ExceedsLimits(t *testing.T) {
 			{StreamHash: 0x2, Reason: ReasonExceedsMaxStreams},
 		},
 	}, {
-		name: "exceeds limit but allows existing streams and rejects new streams",
+		name: "exceeds max streams limit, allows existing streams and rejects new streams",
 		exceedsLimitsRequest: &logproto.ExceedsLimitsRequest{
 			Tenant: "test",
 			Streams: []*logproto.StreamMetadata{
@@ -127,56 +149,58 @@ func TestFrontend_ExceedsLimits(t *testing.T) {
 			{StreamHash: 7, Reason: ReasonExceedsMaxStreams},
 		},
 	}, {
-		name: "no response",
+		// This test checks the case where a tenant's streams are sharded over
+		// two instances, each holding one each stream. Each instance will
+		// return an response stating that it doesn't know about the other
+		// stream. The frontend is responsible for taking the intersection of
+		// the two responses and calculating the actual set of unknown streams.
+		name: "exceeds max streams limit, streams sharded over two instances",
 		exceedsLimitsRequest: &logproto.ExceedsLimitsRequest{
 			Tenant: "test",
 			Streams: []*logproto.StreamMetadata{
-				{StreamHash: 0x1},
+				{StreamHash: 0x1}, // Exceeds limits.
+				{StreamHash: 0x2}, // Also exceeds limits.
 			},
 		},
 		getAssignedPartitionsResponses: []*logproto.GetAssignedPartitionsResponse{{
 			AssignedPartitions: map[int32]int64{
-				0: time.Now().UnixNano(),
+				0: time.Now().UnixNano(), // Instance 0 owns partition 0.
 			},
-		}},
-		expectedStreamUsageRequest: []*logproto.GetStreamUsageRequest{{
-			Tenant:       "test",
-			StreamHashes: []uint64{0x1},
-			Partitions:   []int32{0},
-		}},
-		getStreamUsageResponses: []*logproto.GetStreamUsageResponse{{}},
-		maxGlobalStreams:        10,
-		ingestionRate:           100,
-		expected:                nil, // No rejections because activeStreamsTotal is 0
-	}, {
-		name: "rate limit not exceeded",
-		exceedsLimitsRequest: &logproto.ExceedsLimitsRequest{
-			Tenant: "test",
-			Streams: []*logproto.StreamMetadata{
-				{StreamHash: 0x1},
-				{StreamHash: 0x2},
-			},
-		},
-		getAssignedPartitionsResponses: []*logproto.GetAssignedPartitionsResponse{{
+		}, {
 			AssignedPartitions: map[int32]int64{
-				0: time.Now().UnixNano(),
+				1: time.Now().UnixNano(), // Instance 1 owns partition 1.
 			},
 		}},
+		// The frontend will ask instance 0 for the data for partition 0,
+		// and instance 1 for the data for partition 1.
 		expectedStreamUsageRequest: []*logproto.GetStreamUsageRequest{{
 			Tenant:       "test",
 			StreamHashes: []uint64{0x1, 0x2},
 			Partitions:   []int32{0},
+		}, {
+			Tenant:       "test",
+			StreamHashes: []uint64{0x1, 0x2},
+			Partitions:   []int32{1},
 		}},
+		// Each instance will respond stating that it doesn't know about the
+		// other stream.
 		getStreamUsageResponses: []*logproto.GetStreamUsageResponse{{
-			Tenant:        "test",
-			ActiveStreams: 2,
-			Rate:          50, // Below the limit of 100 bytes/sec
+			Tenant:         "test",
+			ActiveStreams:  1,
+			Rate:           5,
+			UnknownStreams: []uint64{0x2},
+		}, {
+			Tenant:         "test",
+			ActiveStreams:  1,
+			Rate:           5,
+			UnknownStreams: []uint64{0x1},
 		}},
-		maxGlobalStreams: 10,
+		maxGlobalStreams: 1,
 		ingestionRate:    100,
-		expected:         nil,
+		// No streams should be rejected.
+		expected: nil,
 	}, {
-		name: "rate limit exceeded",
+		name: "exceeds rate limits, rejects all streams",
 		exceedsLimitsRequest: &logproto.ExceedsLimitsRequest{
 			Tenant: "test",
 			Streams: []*logproto.StreamMetadata{
@@ -201,7 +225,7 @@ func TestFrontend_ExceedsLimits(t *testing.T) {
 			{StreamHash: 2, Reason: ReasonExceedsRateLimit},
 		},
 	}, {
-		name: "rate limit exceeded with multiple instances",
+		name: "exceeds rate limits, rates sharded over two instances",
 		exceedsLimitsRequest: &logproto.ExceedsLimitsRequest{
 			Tenant: "test",
 			Streams: []*logproto.StreamMetadata{
@@ -211,11 +235,11 @@ func TestFrontend_ExceedsLimits(t *testing.T) {
 		},
 		getAssignedPartitionsResponses: []*logproto.GetAssignedPartitionsResponse{{
 			AssignedPartitions: map[int32]int64{
-				0: 1,
+				0: time.Now().UnixNano(),
 			},
 		}, {
 			AssignedPartitions: map[int32]int64{
-				1: 1,
+				1: time.Now().UnixNano(),
 			},
 		}},
 		getStreamUsageResponses: []*logproto.GetStreamUsageResponse{{
@@ -234,7 +258,7 @@ func TestFrontend_ExceedsLimits(t *testing.T) {
 			{StreamHash: 2, Reason: ReasonExceedsRateLimit},
 		},
 	}, {
-		name: "both global limit and rate limit exceeded",
+		name: "exceeds both max stream limit and rate limits",
 		exceedsLimitsRequest: &logproto.ExceedsLimitsRequest{
 			Tenant: "test",
 			Streams: []*logproto.StreamMetadata{


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request fixes a bug where known streams could be rejected whenever stream limit was exceeded. The bug occurred when streams for a tenant were sharded over a number of partitions. The problem was that the frontend did not take the intersection of unknown streams from all responses, so if a stream was unknown on instance1, but known to instance2, it would still be rejected.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
