### PR TITLE
feat: store details of processed streams while processing delete requests

### DIFF
--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -13,14 +13,14 @@ import (
 	"unsafe"
 
 	"github.com/go-kit/log/level"
-	"github.com/pkg/errors"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/common/model"
-
 	"github.com/grafana/dskit/backoff"
 	"github.com/grafana/dskit/kv"
 	"github.com/grafana/dskit/ring"
 	"github.com/grafana/dskit/services"
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
 
 	"github.com/grafana/loki/v3/pkg/analytics"
 	"github.com/grafana/loki/v3/pkg/compactor/deletion"
@@ -853,12 +853,12 @@ func newExpirationChecker(retentionExpiryChecker, deletionExpiryChecker retentio
 	return &expirationChecker{retentionExpiryChecker, deletionExpiryChecker}
 }
 
-func (e *expirationChecker) Expired(ref retention.ChunkEntry, now model.Time) (bool, filter.Func) {
-	if expired, nonDeletedIntervals := e.retentionExpiryChecker.Expired(ref, now); expired {
+func (e *expirationChecker) Expired(userID []byte, chk retention.Chunk, lbls labels.Labels, now model.Time) (bool, filter.Func) {
+	if expired, nonDeletedIntervals := e.retentionExpiryChecker.Expired(userID, chk, lbls, now); expired {
 		return expired, nonDeletedIntervals
 	}
 
-	return e.deletionExpiryChecker.Expired(ref, now)
+	return e.deletionExpiryChecker.Expired(userID, chk, lbls, now)
 }
 
 func (e *expirationChecker) MarkPhaseStarted() {
@@ -885,8 +885,8 @@ func (e *expirationChecker) IntervalMayHaveExpiredChunks(interval model.Interval
 	return e.retentionExpiryChecker.IntervalMayHaveExpiredChunks(interval, userID) || e.deletionExpiryChecker.IntervalMayHaveExpiredChunks(interval, userID)
 }
 
-func (e *expirationChecker) DropFromIndex(ref retention.ChunkEntry, tableEndTime model.Time, now model.Time) bool {
-	return e.retentionExpiryChecker.DropFromIndex(ref, tableEndTime, now) || e.deletionExpiryChecker.DropFromIndex(ref, tableEndTime, now)
+func (e *expirationChecker) DropFromIndex(userID []byte, chk retention.Chunk, labels labels.Labels, tableEndTime model.Time, now model.Time) bool {
+	return e.retentionExpiryChecker.DropFromIndex(userID, chk, labels, tableEndTime, now) || e.deletionExpiryChecker.DropFromIndex(userID, chk, labels, tableEndTime, now)
 }
 
 func (c *Compactor) OnRingInstanceRegister(_ *ring.BasicLifecycler, ringDesc ring.Desc, instanceExists bool, _ string, instanceDesc ring.InstanceDesc) (ring.InstanceState, ring.Tokens) {

--- a/pkg/compactor/deletion/delete_request.go
+++ b/pkg/compactor/deletion/delete_request.go
@@ -109,14 +109,14 @@ func allMatch(matchers []*labels.Matcher, labels labels.Labels) bool {
 // IsDeleted checks if the given ChunkEntry will be deleted by this DeleteRequest.
 // It returns a filter.Func if the chunk is supposed to be deleted partially or the delete request contains line filters.
 // If the filter.Func is nil, the whole chunk is supposed to be deleted.
-func (d *DeleteRequest) IsDeleted(entry retention.ChunkEntry) (bool, filter.Func) {
-	if d.UserID != unsafeGetString(entry.UserID) {
+func (d *DeleteRequest) IsDeleted(userID []byte, lbls labels.Labels, chunk retention.Chunk) (bool, filter.Func) {
+	if d.UserID != unsafeGetString(userID) {
 		return false, nil
 	}
 
 	if !intervalsOverlap(model.Interval{
-		Start: entry.From,
-		End:   entry.Through,
+		Start: chunk.From,
+		End:   chunk.Through,
 	}, model.Interval{
 		Start: d.StartTime,
 		End:   d.EndTime,
@@ -137,16 +137,16 @@ func (d *DeleteRequest) IsDeleted(entry retention.ChunkEntry) (bool, filter.Func
 		}
 	}
 
-	if !labels.Selector(d.matchers).Matches(entry.Labels) {
+	if !labels.Selector(d.matchers).Matches(lbls) {
 		return false, nil
 	}
 
-	if d.StartTime <= entry.From && d.EndTime >= entry.Through && !d.logSelectorExpr.HasFilter() {
+	if d.StartTime <= chunk.From && d.EndTime >= chunk.Through && !d.logSelectorExpr.HasFilter() {
 		// Delete request covers the whole chunk and there are no line filters in the logSelectorExpr so the whole chunk will be deleted
 		return true, nil
 	}
 
-	ff, err := d.FilterFunction(entry.Labels)
+	ff, err := d.FilterFunction(lbls)
 	if err != nil {
 		// The query in the delete request is checked when added to the table.
 		// So this error should not occur.

--- a/pkg/compactor/deletion/delete_request_test.go
+++ b/pkg/compactor/deletion/delete_request_test.go
@@ -33,13 +33,9 @@ func TestDeleteRequest_IsDeleted(t *testing.T) {
 	lblWithStructuredMetadataFilter := `{foo="bar", fizz="buzz"} | ping="pong"`
 	lblWithLineAndStructuredMetadataFilter := `{foo="bar", fizz="buzz"} | ping="pong" |= "filter"`
 
-	chunkEntry := retention.ChunkEntry{
-		ChunkRef: retention.ChunkRef{
-			UserID:  []byte(user1),
-			From:    now.Add(-3 * time.Hour),
-			Through: now.Add(-time.Hour),
-		},
-		Labels: mustParseLabel(lbl),
+	chunkEntry := retention.Chunk{
+		From:    now.Add(-3 * time.Hour),
+		Through: now.Add(-time.Hour),
 	}
 
 	type resp struct {
@@ -275,7 +271,7 @@ func TestDeleteRequest_IsDeleted(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			require.NoError(t, tc.deleteRequest.SetQuery(tc.deleteRequest.Query))
 			tc.deleteRequest.Metrics = newDeleteRequestsManagerMetrics(nil)
-			isExpired, filterFunc := tc.deleteRequest.IsDeleted(chunkEntry)
+			isExpired, filterFunc := tc.deleteRequest.IsDeleted([]byte(user1), mustParseLabel(lbl), chunkEntry)
 			require.Equal(t, tc.expectedResp.isDeleted, isExpired)
 			if tc.expectedResp.expectedFilter == nil {
 				require.Nil(t, filterFunc)

--- a/pkg/compactor/deletion/delete_requests_manager_test.go
+++ b/pkg/compactor/deletion/delete_requests_manager_test.go
@@ -31,13 +31,9 @@ func TestDeleteRequestsManager_Expired(t *testing.T) {
 	streamSelectorWithStructuredMetadataFilters := lblFoo.String() + `| ping="pong"`
 	streamSelectorWithLineAndStructuredMetadataFilters := lblFoo.String() + `| ping="pong" |= "fizz"`
 
-	chunkEntry := retention.ChunkEntry{
-		ChunkRef: retention.ChunkRef{
-			UserID:  []byte(testUserID),
-			From:    now.Add(-12 * time.Hour),
-			Through: now.Add(-time.Hour),
-		},
-		Labels: lblFoo,
+	chunkEntry := retention.Chunk{
+		From:    now.Add(-12 * time.Hour),
+		Through: now.Add(-time.Hour),
 	}
 
 	for _, tc := range []struct {
@@ -948,7 +944,7 @@ func TestDeleteRequestsManager_Expired(t *testing.T) {
 				}
 			}
 
-			isExpired, filterFunc := mgr.Expired(chunkEntry, model.Now())
+			isExpired, filterFunc := mgr.Expired([]byte(testUserID), chunkEntry, lblFoo, model.Now())
 			require.Equal(t, tc.expectedResp.isExpired, isExpired)
 			if tc.expectedResp.expectedFilter == nil {
 				require.Nil(t, filterFunc)

--- a/pkg/compactor/retention/expiration_test.go
+++ b/pkg/compactor/retention/expiration_test.go
@@ -108,20 +108,22 @@ func Test_expirationChecker_Expired(t *testing.T) {
 
 	e := NewExpirationChecker(o)
 	tests := []struct {
-		name string
-		ref  ChunkEntry
-		want bool
+		name   string
+		userID string
+		labels string
+		chunk  Chunk
+		want   bool
 	}{
-		{"expired tenant", newChunkEntry("1", `{foo="buzz"}`, model.Now().Add(-3*time.Hour), model.Now().Add(-2*time.Hour)), true},
-		{"just expired tenant", newChunkEntry("1", `{foo="buzz"}`, model.Now().Add(-3*time.Hour), model.Now().Add(-1*time.Hour+(10*time.Millisecond))), false},
-		{"not expired tenant", newChunkEntry("1", `{foo="buzz"}`, model.Now().Add(-3*time.Hour), model.Now().Add(-30*time.Minute)), false},
-		{"not expired tenant by far", newChunkEntry("2", `{foo="buzz"}`, model.Now().Add(-72*time.Hour), model.Now().Add(-3*time.Hour)), false},
-		{"expired stream override", newChunkEntry("2", `{foo="bar"}`, model.Now().Add(-12*time.Hour), model.Now().Add(-10*time.Hour)), true},
-		{"non expired stream override", newChunkEntry("1", `{foo="bar"}`, model.Now().Add(-3*time.Hour), model.Now().Add(-90*time.Minute)), false},
+		{"expired tenant", "1", `{foo="buzz"}`, Chunk{From: model.Now().Add(-3 * time.Hour), Through: model.Now().Add(-2 * time.Hour)}, true},
+		{"just expired tenant", "1", `{foo="buzz"}`, Chunk{From: model.Now().Add(-3 * time.Hour), Through: model.Now().Add(-1*time.Hour + (10 * time.Millisecond))}, false},
+		{"not expired tenant", "1", `{foo="buzz"}`, Chunk{From: model.Now().Add(-3 * time.Hour), Through: model.Now().Add(-30 * time.Minute)}, false},
+		{"not expired tenant by far", "2", `{foo="buzz"}`, Chunk{From: model.Now().Add(-72 * time.Hour), Through: model.Now().Add(-3 * time.Hour)}, false},
+		{"expired stream override", "2", `{foo="bar"}`, Chunk{From: model.Now().Add(-12 * time.Hour), Through: model.Now().Add(-10 * time.Hour)}, true},
+		{"non expired stream override", "1", `{foo="bar"}`, Chunk{From: model.Now().Add(-3 * time.Hour), Through: model.Now().Add(-90 * time.Minute)}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			actual, nonDeletedIntervalFilters := e.Expired(tt.ref, model.Now())
+			actual, nonDeletedIntervalFilters := e.Expired([]byte(tt.userID), tt.chunk, mustParseLabels(tt.labels), model.Now())
 			require.Equal(t, tt.want, actual)
 			require.Nil(t, nonDeletedIntervalFilters)
 		})
@@ -183,18 +185,20 @@ func Test_expirationChecker_Expired_zeroValue(t *testing.T) {
 	require.NoError(t, err)
 	e := NewExpirationChecker(o)
 	tests := []struct {
-		name string
-		ref  ChunkEntry
-		want bool
+		name   string
+		userID string
+		labels string
+		chunk  Chunk
+		want   bool
 	}{
-		{"tenant with no override should not delete", newChunkEntry("1", `{foo="buzz"}`, model.Now().Add(-3*time.Hour), model.Now().Add(-2*time.Hour)), false},
-		{"tenant with no override, REALLY old chunk should not delete", newChunkEntry("1", `{foo="buzz"}`, model.Now().Add(-10000*time.Hour+(1*time.Hour)), model.Now().Add(-10000*time.Hour)), false},
-		{"tenant with override chunk less than retention should not delete", newChunkEntry("2", `{foo="buzz"}`, model.Now().Add(-3*time.Hour), model.Now().Add(-2*time.Hour)), false},
-		{"tenant with override should delete", newChunkEntry("2", `{foo="buzz"}`, model.Now().Add(-31*time.Hour), model.Now().Add(-30*time.Hour)), true},
+		{"tenant with no override should not delete", "1", `{foo="buzz"}`, Chunk{From: model.Now().Add(-3 * time.Hour), Through: model.Now().Add(-2 * time.Hour)}, false},
+		{"tenant with no override, REALLY old chunk should not delete", "1", `{foo="buzz"}`, Chunk{From: model.Now().Add(-10000*time.Hour + (1 * time.Hour)), Through: model.Now().Add(-10000 * time.Hour)}, false},
+		{"tenant with override chunk less than retention should not delete", "2", `{foo="buzz"}`, Chunk{From: model.Now().Add(-3 * time.Hour), Through: model.Now().Add(-2 * time.Hour)}, false},
+		{"tenant with override should delete", "2", `{foo="buzz"}`, Chunk{From: model.Now().Add(-31 * time.Hour), Through: model.Now().Add(-30 * time.Hour)}, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			actual, nonDeletedIntervalFilters := e.Expired(tt.ref, model.Now())
+			actual, nonDeletedIntervalFilters := e.Expired([]byte(tt.userID), tt.chunk, mustParseLabels(tt.labels), model.Now())
 			require.Equal(t, tt.want, actual)
 			require.Nil(t, nonDeletedIntervalFilters)
 		})
@@ -229,17 +233,19 @@ func Test_expirationChecker_Expired_zeroValueOverride(t *testing.T) {
 
 	e := NewExpirationChecker(o)
 	tests := []struct {
-		name string
-		ref  ChunkEntry
-		want bool
+		name   string
+		userID string
+		labels string
+		chunk  Chunk
+		want   bool
 	}{
-		{"tenant with no override should delete", newChunkEntry("1", `{foo="buzz"}`, model.Now().Add(-31*time.Hour), model.Now().Add(-30*time.Hour)), true},
-		{"tenant with override should not delete", newChunkEntry("2", `{foo="buzz"}`, model.Now().Add(-31*time.Hour), model.Now().Add(-30*time.Hour)), false},
-		{"tenant with zero value without unit should not delete", newChunkEntry("3", `{foo="buzz"}`, model.Now().Add(-31*time.Hour), model.Now().Add(-30*time.Hour)), false},
+		{"tenant with no override should delete", "1", `{foo="buzz"}`, Chunk{From: model.Now().Add(-31 * time.Hour), Through: model.Now().Add(-30 * time.Hour)}, true},
+		{"tenant with override should not delete", "2", `{foo="buzz"}`, Chunk{From: model.Now().Add(-31 * time.Hour), Through: model.Now().Add(-30 * time.Hour)}, false},
+		{"tenant with zero value without unit should not delete", "3", `{foo="buzz"}`, Chunk{From: model.Now().Add(-31 * time.Hour), Through: model.Now().Add(-30 * time.Hour)}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			actual, nonDeletedIntervalFilters := e.Expired(tt.ref, model.Now())
+			actual, nonDeletedIntervalFilters := e.Expired([]byte(tt.userID), tt.chunk, mustParseLabels(tt.labels), model.Now())
 			require.Equal(t, tt.want, actual)
 			require.Nil(t, nonDeletedIntervalFilters)
 		})
@@ -267,17 +273,19 @@ func Test_expirationChecker_DropFromIndex_zeroValue(t *testing.T) {
 	chunkThrough := model.Now().Add(-2 * time.Hour)
 	tests := []struct {
 		name         string
-		ref          ChunkEntry
+		userID       string
+		labels       string
+		chunk        Chunk
 		tableEndTime model.Time
 		want         bool
 	}{
-		{"tenant with no override should not delete", newChunkEntry("1", `{foo="buzz"}`, chunkFrom, chunkThrough), model.Now().Add(-48 * time.Hour), false},
-		{"tenant with override tableEndTime within retention period should not delete", newChunkEntry("2", `{foo="buzz"}`, chunkFrom, chunkThrough), model.Now().Add(-1 * time.Hour), false},
-		{"tenant with override should delete", newChunkEntry("2", `{foo="buzz"}`, chunkFrom, chunkThrough), model.Now().Add(-48 * time.Hour), true},
+		{"tenant with no override should not delete", "1", `{foo="buzz"}`, Chunk{From: chunkFrom, Through: chunkThrough}, model.Now().Add(-48 * time.Hour), false},
+		{"tenant with override tableEndTime within retention period should not delete", "2", `{foo="buzz"}`, Chunk{From: chunkFrom, Through: chunkThrough}, model.Now().Add(-1 * time.Hour), false},
+		{"tenant with override should delete", "2", `{foo="buzz"}`, Chunk{From: chunkFrom, Through: chunkThrough}, model.Now().Add(-48 * time.Hour), true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			actual := e.DropFromIndex(tt.ref, tt.tableEndTime, model.Now())
+			actual := e.DropFromIndex([]byte(tt.userID), tt.chunk, mustParseLabels(tt.labels), tt.tableEndTime, model.Now())
 			require.Equal(t, tt.want, actual)
 		})
 	}

--- a/pkg/compactor/retention/retention.go
+++ b/pkg/compactor/retention/retention.go
@@ -31,30 +31,57 @@ const (
 	MarkersFolder = "markers"
 )
 
-type ChunkRef struct {
-	UserID   []byte
-	SeriesID []byte
-	ChunkID  []byte
-	From     model.Time
-	Through  model.Time
+type Chunk struct {
+	ChunkID []byte
+	From    model.Time
+	Through model.Time
 }
 
-func (c ChunkRef) String() string {
-	return fmt.Sprintf("UserID: %s , SeriesID: %s , Time: [%s,%s]", c.UserID, c.SeriesID, c.From, c.Through)
+func (c Chunk) String() string {
+	return fmt.Sprintf("ChunkID: %s", c.ChunkID)
 }
 
-type ChunkEntry struct {
-	ChunkRef
-	Labels labels.Labels
+type Series struct {
+	seriesID, userID []byte
+	labels           labels.Labels
+	chunks           []Chunk
 }
 
-type ChunkEntryCallback func(ChunkEntry) (deleteChunk bool, err error)
-
-type ChunkIterator interface {
-	ForEachChunk(ctx context.Context, callback ChunkEntryCallback) error
+func (s *Series) SeriesID() []byte {
+	return s.seriesID
 }
 
-type SeriesCleaner interface {
+func (s *Series) UserID() []byte {
+	return s.userID
+}
+
+func (s *Series) Labels() labels.Labels {
+	return s.labels
+}
+
+func (s *Series) Chunks() []Chunk {
+	return s.chunks
+}
+
+func (s *Series) Reset(seriesID, userID []byte, labels labels.Labels) {
+	s.seriesID = seriesID
+	s.userID = userID
+	s.labels = labels
+	s.chunks = s.chunks[:0]
+}
+
+func (s *Series) AppendChunks(ref ...Chunk) {
+	s.chunks = append(s.chunks, ref...)
+}
+
+type SeriesCallback func(series Series) (err error)
+
+type SeriesIterator interface {
+	ForEachSeries(ctx context.Context, callback SeriesCallback) error
+}
+
+type IndexCleaner interface {
+	RemoveChunk(from, through model.Time, userID []byte, labels labels.Labels, chunkID []byte) error
 	// CleanupSeries is for cleaning up the series that do have any chunks left in the index.
 	// It would only be called for the series that have all their chunks deleted without adding new ones.
 	CleanupSeries(userID []byte, lbls labels.Labels) error
@@ -70,9 +97,9 @@ type chunkIndexer interface {
 }
 
 type IndexProcessor interface {
-	ChunkIterator
+	SeriesIterator
 	chunkIndexer
-	SeriesCleaner
+	IndexCleaner
 }
 
 var errNoChunksFound = errors.New("no chunks found in table, please check if there are really no chunks and manually drop the table or " +
@@ -176,57 +203,67 @@ func markForDelete(
 	iterCtx, cancel := ctxForTimeout(timeout)
 	defer cancel()
 
-	err := indexFile.ForEachChunk(iterCtx, func(c ChunkEntry) (bool, error) {
+	err := indexFile.ForEachSeries(iterCtx, func(s Series) error {
 		chunksFound = true
-		seriesMap.Add(c.SeriesID, c.UserID, c.Labels)
+		seriesMap.Add(s.SeriesID(), s.UserID(), s.Labels())
+		chunks := s.Chunks()
 
-		// see if the chunk is deleted completely or partially
-		if expired, filterFunc := expiration.Expired(c, now); expired {
-			linesDeleted := true // tracks whether we deleted at least some data from the chunk
-			if filterFunc != nil {
-				wroteChunks := false
-				var err error
-				wroteChunks, linesDeleted, err = chunkRewriter.rewriteChunk(ctx, c, tableInterval, filterFunc)
-				if err != nil {
-					return false, fmt.Errorf("failed to rewrite chunk %s with error %s", c.ChunkID, err)
-				}
+		for i := 0; i < len(chunks) && iterCtx.Err() == nil; i++ {
+			c := chunks[i]
+			// see if the chunk is deleted completely or partially
+			if expired, filterFunc := expiration.Expired(s.UserID(), c, s.Labels(), now); expired {
+				linesDeleted := true // tracks whether we deleted at least some data from the chunk
+				if filterFunc != nil {
+					wroteChunks := false
+					var err error
+					wroteChunks, linesDeleted, err = chunkRewriter.rewriteChunk(ctx, s.UserID(), c, tableInterval, filterFunc)
+					if err != nil {
+						return fmt.Errorf("failed to rewrite chunk %s with error %s", c.ChunkID, err)
+					}
 
-				if wroteChunks {
-					// we have re-written chunk to the storage so the table won't be empty and the series are still being referred.
-					empty = false
-					seriesMap.MarkSeriesNotDeleted(c.SeriesID, c.UserID)
-				}
-			}
-
-			if linesDeleted {
-				modified = true
-
-				// Mark the chunk for deletion only if it is completely deleted, or this is the last table that the chunk is index in.
-				// For a partially deleted chunk, if we delete the source chunk before all the tables which index it are processed then
-				// the retention would fail because it would fail to find it in the storage.
-				if filterFunc == nil || c.From >= tableInterval.Start {
-					if err := marker.Put(c.ChunkID); err != nil {
-						return false, err
+					if wroteChunks {
+						// we have re-written chunk to the storage so the table won't be empty and the series are still being referred.
+						empty = false
+						seriesMap.MarkSeriesNotDeleted(s.SeriesID(), s.UserID())
 					}
 				}
-				return true, nil
-			}
-		}
 
-		// The chunk is not deleted, now see if we can drop its index entry based on end time from tableInterval.
-		// If chunk end time is after the end time of tableInterval, it means the chunk would also be indexed in the next table.
-		// We would now check if the end time of the tableInterval is out of retention period so that
-		// we can drop the chunk entry from this table without removing the chunk from the store.
-		if c.Through.After(tableInterval.End) {
-			if expiration.DropFromIndex(c, tableInterval.End, now) {
-				modified = true
-				return true, nil
-			}
-		}
+				if linesDeleted {
+					modified = true
 
-		empty = false
-		seriesMap.MarkSeriesNotDeleted(c.SeriesID, c.UserID)
-		return false, nil
+					// Mark the chunk for deletion only if it is completely deleted, or this is the last table that the chunk is index in.
+					// For a partially deleted chunk, if we delete the source chunk before all the tables which index it are processed then
+					// the retention would fail because it would fail to find it in the storage.
+					if filterFunc == nil || c.From >= tableInterval.Start {
+						if err := marker.Put(c.ChunkID); err != nil {
+							return err
+						}
+					}
+					if err := indexFile.RemoveChunk(c.From, c.Through, s.UserID(), s.Labels(), c.ChunkID); err != nil {
+						return fmt.Errorf("failed to remove chunk %s from index with error %s", c.ChunkID, err)
+					}
+					continue
+				}
+			}
+
+			// The chunk is not deleted, now see if we can drop its index entry based on end time from tableInterval.
+			// If chunk end time is after the end time of tableInterval, it means the chunk would also be indexed in the next table.
+			// We would now check if the end time of the tableInterval is out of retention period so that
+			// we can drop the chunk entry from this table without removing the chunk from the store.
+			if c.Through.After(tableInterval.End) {
+				if expiration.DropFromIndex(s.UserID(), c, nil, tableInterval.End, now) {
+					modified = true
+					if err := indexFile.RemoveChunk(c.From, c.Through, s.UserID(), s.Labels(), c.ChunkID); err != nil {
+						return fmt.Errorf("failed to remove chunk %s from index with error %s", c.ChunkID, err)
+					}
+					continue
+				}
+			}
+
+			empty = false
+			seriesMap.MarkSeriesNotDeleted(s.SeriesID(), s.UserID())
+		}
+		return iterCtx.Err()
 	})
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) && errors.Is(iterCtx.Err(), context.DeadlineExceeded) {
@@ -366,11 +403,11 @@ func newChunkRewriter(chunkClient client.Client, tableName string, chunkIndexer 
 // If the newChunk is different, linesDeleted would be true.
 // The newChunk is indexed and uploaded only if it belongs to the current index table being processed,
 // the status of which is set to wroteChunks.
-func (c *chunkRewriter) rewriteChunk(ctx context.Context, ce ChunkEntry, tableInterval model.Interval, filterFunc filter.Func) (wroteChunks bool, linesDeleted bool, err error) {
-	userID := unsafeGetString(ce.UserID)
+func (c *chunkRewriter) rewriteChunk(ctx context.Context, userID []byte, ce Chunk, tableInterval model.Interval, filterFunc filter.Func) (wroteChunks bool, linesDeleted bool, err error) {
+	userIDStr := unsafeGetString(userID)
 	chunkID := unsafeGetString(ce.ChunkID)
 
-	chk, err := chunk.ParseExternalKey(userID, chunkID)
+	chk, err := chunk.ParseExternalKey(userIDStr, chunkID)
 	if err != nil {
 		return false, false, err
 	}
@@ -381,7 +418,7 @@ func (c *chunkRewriter) rewriteChunk(ctx context.Context, ce ChunkEntry, tableIn
 	}
 
 	if len(chks) != 1 {
-		return false, false, fmt.Errorf("expected 1 entry for chunk %s but found %d in storage", chunkID, len(chks))
+		return false, false, fmt.Errorf("expected 1 entry for chunk %s but found %d in storage", ce.ChunkID, len(chks))
 	}
 
 	newChunkData, err := chks[0].Data.Rebound(ce.From, ce.Through, func(ts time.Time, s string, structuredMetadata ...labels.Label) bool {
@@ -394,7 +431,7 @@ func (c *chunkRewriter) rewriteChunk(ctx context.Context, ce ChunkEntry, tableIn
 	})
 	if err != nil {
 		if errors.Is(err, chunk.ErrSliceNoDataInRange) {
-			level.Info(util_log.Logger).Log("msg", "Delete request filterFunc leaves an empty chunk", "chunk ref", string(ce.ChunkRef.ChunkID))
+			level.Info(util_log.Logger).Log("msg", "Delete request filterFunc leaves an empty chunk", "chunk ref", string(ce.ChunkID))
 			return false, true, nil
 		}
 		return false, false, err
@@ -418,7 +455,7 @@ func (c *chunkRewriter) rewriteChunk(ctx context.Context, ce ChunkEntry, tableIn
 	}
 
 	newChunk := chunk.NewChunk(
-		userID, chks[0].FingerprintModel(), chks[0].Metric,
+		userIDStr, chks[0].FingerprintModel(), chks[0].Metric,
 		facade,
 		newChunkStart,
 		newChunkEnd,

--- a/pkg/compactor/retention/series.go
+++ b/pkg/compactor/retention/series.go
@@ -9,7 +9,7 @@ type userSeries struct {
 	seriesIDLen int
 }
 
-func newUserSeries(seriesID []byte, userID []byte) userSeries {
+func newUserSeries(seriesID, userID []byte) userSeries {
 	key := make([]byte, 0, len(seriesID)+len(userID))
 	key = append(key, seriesID...)
 	key = append(key, userID...)
@@ -31,16 +31,6 @@ func (us userSeries) UserID() []byte {
 	return us.key[us.seriesIDLen:]
 }
 
-func (us *userSeries) Reset(seriesID []byte, userID []byte) {
-	if us.key == nil {
-		us.key = make([]byte, 0, len(seriesID)+len(userID))
-	}
-	us.key = us.key[:0]
-	us.key = append(us.key, seriesID...)
-	us.key = append(us.key, userID...)
-	us.seriesIDLen = len(seriesID)
-}
-
 type userSeriesInfo struct {
 	userSeries
 	isDeleted bool
@@ -53,7 +43,7 @@ func newUserSeriesMap() userSeriesMap {
 	return make(userSeriesMap)
 }
 
-func (u userSeriesMap) Add(seriesID []byte, userID []byte, lbls labels.Labels) {
+func (u userSeriesMap) Add(seriesID, userID []byte, lbls labels.Labels) {
 	us := newUserSeries(seriesID, userID)
 	if _, ok := u[us.Key()]; ok {
 		return
@@ -67,7 +57,7 @@ func (u userSeriesMap) Add(seriesID []byte, userID []byte, lbls labels.Labels) {
 }
 
 // MarkSeriesNotDeleted is used to mark series not deleted when it still has some chunks left in the store
-func (u userSeriesMap) MarkSeriesNotDeleted(seriesID []byte, userID []byte) {
+func (u userSeriesMap) MarkSeriesNotDeleted(seriesID, userID []byte) {
 	us := newUserSeries(seriesID, userID)
 	usi := u[us.Key()]
 	usi.isDeleted = false

--- a/pkg/compactor/retention/util_test.go
+++ b/pkg/compactor/retention/util_test.go
@@ -117,51 +117,50 @@ var (
 	sweepMetrics = newSweeperMetrics(prometheus.DefaultRegisterer)
 )
 
-func newChunkEntry(userID, labels string, from, through model.Time) ChunkEntry {
+func mustParseLabels(labels string) labels.Labels {
 	lbs, err := syntax.ParseLabels(labels)
 	if err != nil {
 		panic(err)
 	}
-	return ChunkEntry{
-		ChunkRef: ChunkRef{
-			UserID:   []byte(userID),
-			SeriesID: labelsSeriesID(lbs),
-			From:     from,
-			Through:  through,
-		},
-		Labels: lbs,
-	}
+
+	return lbs
 }
 
 type table struct {
 	name   string
-	chunks map[string][]chunk.Chunk
+	chunks map[string]map[string][]chunk.Chunk
 }
 
-func (t *table) ForEachChunk(ctx context.Context, callback ChunkEntryCallback) error {
-	for userID, chks := range t.chunks {
-		i := 0
-		for j := 0; j < len(chks) && ctx.Err() == nil; j++ {
-			chk := chks[j]
-			deleteChunk, err := callback(entryFromChunk(chk))
-			if err != nil {
+func (t *table) ForEachSeries(ctx context.Context, callback SeriesCallback) error {
+	for userID := range t.chunks {
+		for seriesID := range t.chunks[userID] {
+			chunks := make([]Chunk, 0, len(t.chunks[userID][seriesID]))
+			for _, chk := range t.chunks[userID][seriesID] {
+				chunks = append(chunks, Chunk{
+					ChunkID: []byte(getChunkID(chk.ChunkRef)),
+					From:    chk.From,
+					Through: chk.Through,
+				})
+			}
+			series := Series{}
+			series.Reset(
+				[]byte(seriesID),
+				[]byte(userID),
+				labels.NewBuilder(t.chunks[userID][seriesID][0].Metric).Del(labels.MetricName).Labels(),
+			)
+			series.AppendChunks(chunks...)
+			if err := callback(series); err != nil {
 				return err
 			}
-
-			if !deleteChunk {
-				t.chunks[userID][i] = chk
-				i++
-			}
 		}
-
-		t.chunks[userID] = t.chunks[userID][:i]
 	}
 
 	return ctx.Err()
 }
 
 func (t *table) IndexChunk(chunk chunk.Chunk) (bool, error) {
-	t.chunks[chunk.UserID] = append(t.chunks[chunk.UserID], chunk)
+	seriesID := string(labelsSeriesID(chunk.Metric))
+	t.chunks[chunk.UserID][seriesID] = append(t.chunks[chunk.UserID][seriesID], chunk)
 	return true, nil
 }
 
@@ -169,19 +168,34 @@ func (t *table) CleanupSeries(_ []byte, _ labels.Labels) error {
 	return nil
 }
 
+func (t *table) RemoveChunk(_, _ model.Time, userID []byte, lbls labels.Labels, chunkID []byte) error {
+	seriesID := string(labelsSeriesID(labels.NewBuilder(lbls).Set(labels.MetricName, "logs").Labels()))
+	for i, chk := range t.chunks[string(userID)][seriesID] {
+		if getChunkID(chk.ChunkRef) == string(chunkID) {
+			t.chunks[string(userID)][seriesID] = append(t.chunks[string(userID)][seriesID][:i], t.chunks[string(userID)][seriesID][i+1:]...)
+		}
+	}
+
+	return nil
+}
+
 func newTable(name string) *table {
 	return &table{
 		name:   name,
-		chunks: map[string][]chunk.Chunk{},
+		chunks: map[string]map[string][]chunk.Chunk{},
 	}
 }
 
 func (t *table) Put(chk chunk.Chunk) {
 	if _, ok := t.chunks[chk.UserID]; !ok {
-		t.chunks[chk.UserID] = []chunk.Chunk{}
+		t.chunks[chk.UserID] = make(map[string][]chunk.Chunk)
+	}
+	seriesID := string(labelsSeriesID(chk.Metric))
+	if _, ok := t.chunks[chk.UserID][seriesID]; !ok {
+		t.chunks[chk.UserID][seriesID] = []chunk.Chunk{}
 	}
 
-	t.chunks[chk.UserID] = append(t.chunks[chk.UserID], chk)
+	t.chunks[chk.UserID][seriesID] = append(t.chunks[chk.UserID][seriesID], chk)
 }
 
 func (t *table) GetChunks(userID string, from, through model.Time, metric labels.Labels) []chunk.Chunk {
@@ -191,11 +205,13 @@ func (t *table) GetChunks(userID string, from, through model.Time, metric labels
 		matchers = append(matchers, labels.MustNewMatcher(labels.MatchEqual, l.Name, l.Value))
 	}
 
-	for _, chk := range t.chunks[userID] {
-		if chk.From > through || chk.Through < from || !allMatch(matchers, chk.Metric) {
-			continue
+	for seriesID := range t.chunks[userID] {
+		for _, chk := range t.chunks[userID][seriesID] {
+			if chk.From > through || chk.Through < from || !allMatch(matchers, chk.Metric) {
+				continue
+			}
+			chunks = append(chunks, chk)
 		}
-		chunks = append(chunks, chk)
 	}
 
 	return chunks
@@ -309,19 +325,6 @@ func (t *testStore) GetChunks(userID string, from, through model.Time, metric la
 	}
 
 	return fetchedChunk
-}
-
-func entryFromChunk(c chunk.Chunk) ChunkEntry {
-	return ChunkEntry{
-		ChunkRef: ChunkRef{
-			UserID:   []byte(c.UserID),
-			SeriesID: labelsSeriesID(c.Metric),
-			ChunkID:  []byte(getChunkID(c.ChunkRef)),
-			From:     c.From,
-			Through:  c.Through,
-		},
-		Labels: labels.NewBuilder(c.Metric).Del(labels.MetricName).Labels(),
-	}
 }
 
 func getChunkID(c logproto.ChunkRef) string {

--- a/pkg/compactor/testutil.go
+++ b/pkg/compactor/testutil.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/klauspost/compress/gzip"
+	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
 
@@ -159,7 +160,7 @@ func openCompactedIndex(path string) (*compactedIndex, error) {
 	return &compactedIndex{indexFile: idxFile}, nil
 }
 
-func (c compactedIndex) ForEachChunk(_ context.Context, _ retention.ChunkEntryCallback) error {
+func (c compactedIndex) ForEachSeries(_ context.Context, _ retention.SeriesCallback) error {
 	return nil
 }
 
@@ -168,6 +169,10 @@ func (c compactedIndex) IndexChunk(_ chunk.Chunk) (bool, error) {
 }
 
 func (c compactedIndex) CleanupSeries(_ []byte, _ labels.Labels) error {
+	return nil
+}
+
+func (c compactedIndex) RemoveChunk(_, _ model.Time, _ []byte, _ labels.Labels, _ []byte) error {
 	return nil
 }
 

--- a/pkg/storage/stores/shipper/indexshipper/boltdb/compactor/compacted_index.go
+++ b/pkg/storage/stores/shipper/indexshipper/boltdb/compactor/compacted_index.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"go.etcd.io/bbolt"
 
@@ -136,7 +137,7 @@ func (c *CompactedIndex) setupIndexProcessors() error {
 	return nil
 }
 
-func (c *CompactedIndex) ForEachChunk(ctx context.Context, callback retention.ChunkEntryCallback) error {
+func (c *CompactedIndex) ForEachSeries(ctx context.Context, callback retention.SeriesCallback) error {
 	if err := c.setupIndexProcessors(); err != nil {
 		return err
 	}
@@ -146,7 +147,7 @@ func (c *CompactedIndex) ForEachChunk(ctx context.Context, callback retention.Ch
 		return fmt.Errorf("required boltdb bucket not found")
 	}
 
-	return ForEachChunk(ctx, bucket, c.periodConfig, callback)
+	return ForEachSeries(ctx, bucket, c.periodConfig, callback)
 }
 
 func (c *CompactedIndex) IndexChunk(chunk chunk.Chunk) (bool, error) {
@@ -163,6 +164,14 @@ func (c *CompactedIndex) CleanupSeries(userID []byte, lbls labels.Labels) error 
 	}
 
 	return c.seriesCleaner.CleanupSeries(userID, lbls)
+}
+
+func (c *CompactedIndex) RemoveChunk(from, through model.Time, userID []byte, labels labels.Labels, chunkID []byte) error {
+	if err := c.setupIndexProcessors(); err != nil {
+		return err
+	}
+
+	return c.seriesCleaner.RemoveChunk(from, through, userID, labels, chunkID)
 }
 
 func (c *CompactedIndex) ToIndexFile() (shipperindex.Index, error) {

--- a/pkg/storage/stores/shipper/indexshipper/boltdb/compactor/iterator.go
+++ b/pkg/storage/stores/shipper/indexshipper/boltdb/compactor/iterator.go
@@ -1,6 +1,7 @@
 package compactor
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 
@@ -19,17 +20,17 @@ const (
 )
 
 var (
-	_ retention.SeriesCleaner = &seriesCleaner{}
+	_ retention.IndexCleaner = &seriesCleaner{}
 )
 
-func ForEachChunk(ctx context.Context, bucket *bbolt.Bucket, config config.PeriodConfig, callback retention.ChunkEntryCallback) error {
+func ForEachSeries(ctx context.Context, bucket *bbolt.Bucket, config config.PeriodConfig, callback retention.SeriesCallback) error {
 	labelsMapper, err := newSeriesLabelsMapper(bucket, config)
 	if err != nil {
 		return err
 	}
 
 	cursor := bucket.Cursor()
-	var current retention.ChunkEntry
+	var current retention.Series
 
 	for key, _ := cursor.First(); key != nil && ctx.Err() == nil; key, _ = cursor.Next() {
 		ref, ok, err := parseChunkRef(decodeKey(key))
@@ -40,17 +41,32 @@ func ForEachChunk(ctx context.Context, bucket *bbolt.Bucket, config config.Perio
 		if !ok {
 			continue
 		}
-		current.ChunkRef = ref
-		current.Labels = labelsMapper.Get(ref.SeriesID, ref.UserID)
-		deleteChunk, err := callback(current)
-		if err != nil {
-			return err
-		}
 
-		if deleteChunk {
-			if err := cursor.Delete(); err != nil {
+		if len(current.Chunks()) == 0 {
+			current.Reset(ref.SeriesID, ref.UserID, labelsMapper.Get(ref.SeriesID, ref.UserID))
+		} else if bytes.Compare(current.UserID(), ref.UserID) != 0 || bytes.Compare(current.SeriesID(), ref.SeriesID) != 0 {
+			err = callback(current)
+			if err != nil {
 				return err
 			}
+
+			current.Reset(ref.SeriesID, ref.UserID, labelsMapper.Get(ref.SeriesID, ref.UserID))
+		}
+
+		current.AppendChunks(retention.Chunk{
+			ChunkID: ref.ChunkID,
+			From:    ref.From,
+			Through: ref.Through,
+		})
+	}
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
+	if len(current.Chunks()) != 0 {
+		err = callback(current)
+		if err != nil {
+			return err
 		}
 	}
 
@@ -112,6 +128,35 @@ func (s *seriesCleaner) CleanupSeries(userID []byte, lbls labels.Labels) error {
 			if err != nil {
 				return err
 			}
+		}
+	}
+
+	return nil
+}
+
+func (s *seriesCleaner) RemoveChunk(from, through model.Time, userID []byte, lbls labels.Labels, chunkID []byte) error {
+	// We need to add metric name label as well if it is missing since the series ids are calculated including that.
+	if lbls.Get(labels.MetricName) == "" {
+		lbls = append(lbls, labels.Label{
+			Name:  labels.MetricName,
+			Value: logMetricName,
+		})
+	}
+
+	indexEntries, err := s.schema.GetChunkWriteEntries(from, through, string(userID), logMetricName, lbls, string(chunkID))
+	if err != nil {
+		return err
+	}
+
+	for _, indexEntry := range indexEntries {
+		key := make([]byte, 0, len(indexEntry.HashValue)+len(separator)+len(indexEntry.RangeValue))
+		key = append(key, []byte(indexEntry.HashValue)...)
+		key = append(key, []byte(separator)...)
+		key = append(key, indexEntry.RangeValue...)
+
+		err := s.bucket.Delete(key)
+		if err != nil {
+			return err
 		}
 	}
 

--- a/pkg/storage/stores/shipper/indexshipper/boltdb/compactor/iterator_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/boltdb/compactor/iterator_test.go
@@ -42,30 +42,34 @@ func Test_ChunkIterator(t *testing.T) {
 
 			tables := store.indexTables()
 			require.Len(t, tables, 1)
-			var actual []retention.ChunkEntry
+			var actual []retention.Chunk
 			err = tables[0].DB.Update(func(tx *bbolt.Tx) error {
-				return ForEachChunk(context.Background(), tx.Bucket(local.IndexBucketName), tt.config, func(entry retention.ChunkEntry) (deleteChunk bool, err error) {
-					actual = append(actual, entry)
-					return len(actual) == 2, nil
+				seriesCleaner := newSeriesCleaner(tx.Bucket(local.IndexBucketName), tt.config, tables[0].name)
+				return ForEachSeries(context.Background(), tx.Bucket(local.IndexBucketName), tt.config, func(series retention.Series) (err error) {
+					actual = append(actual, series.Chunks()...)
+					if string(series.UserID()) == c2.UserID {
+						return seriesCleaner.RemoveChunk(actual[1].From, actual[1].Through, series.UserID(), series.Labels(), actual[1].ChunkID)
+					}
+					return nil
 				})
 			})
 			require.NoError(t, err)
-			require.Equal(t, []retention.ChunkEntry{
-				entryFromChunk(store.schemaCfg, c1),
-				entryFromChunk(store.schemaCfg, c2),
+			require.Equal(t, []retention.Chunk{
+				retentionChunkFromChunk(store.schemaCfg, c1),
+				retentionChunkFromChunk(store.schemaCfg, c2),
 			}, actual)
 
 			// second pass we delete c2
 			actual = actual[:0]
 			err = tables[0].DB.Update(func(tx *bbolt.Tx) error {
-				return ForEachChunk(context.Background(), tx.Bucket(local.IndexBucketName), tt.config, func(entry retention.ChunkEntry) (deleteChunk bool, err error) {
-					actual = append(actual, entry)
-					return false, nil
+				return ForEachSeries(context.Background(), tx.Bucket(local.IndexBucketName), tt.config, func(series retention.Series) (err error) {
+					actual = append(actual, series.Chunks()...)
+					return nil
 				})
 			})
 			require.NoError(t, err)
-			require.Equal(t, []retention.ChunkEntry{
-				entryFromChunk(store.schemaCfg, c1),
+			require.Equal(t, []retention.Chunk{
+				retentionChunkFromChunk(store.schemaCfg, c1),
 			}, actual)
 		})
 	}
@@ -92,12 +96,12 @@ func Test_ChunkIteratorContextCancelation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	var actual []retention.ChunkEntry
+	var actual []retention.Chunk
 	err = tables[0].DB.Update(func(tx *bbolt.Tx) error {
-		return ForEachChunk(ctx, tx.Bucket(local.IndexBucketName), schemaCfg.Configs[0], func(entry retention.ChunkEntry) (deleteChunk bool, err error) {
-			actual = append(actual, entry)
+		return ForEachSeries(ctx, tx.Bucket(local.IndexBucketName), schemaCfg.Configs[0], func(series retention.Series) (err error) {
+			actual = append(actual, series.Chunks()...)
 			cancel()
-			return len(actual) == 2, nil
+			return nil
 		})
 	})
 
@@ -110,7 +114,6 @@ func Test_SeriesCleaner(t *testing.T) {
 		t.Run(tt.schema, func(t *testing.T) {
 			cm := storage.NewClientMetrics()
 			defer cm.Unregister()
-			testSchema := config.SchemaConfig{Configs: []config.PeriodConfig{tt.config}}
 			store := newTestStore(t, cm)
 			chunkfmt, headfmt, err := tt.config.ChunkFormat()
 			require.NoError(t, err)
@@ -129,27 +132,33 @@ func Test_SeriesCleaner(t *testing.T) {
 			require.Len(t, tables, 1)
 			// remove c1, c2 chunk
 			err = tables[0].DB.Update(func(tx *bbolt.Tx) error {
-				return ForEachChunk(context.Background(), tx.Bucket(local.IndexBucketName), tt.config, func(entry retention.ChunkEntry) (deleteChunk bool, err error) {
-					return entry.Labels.Get("bar") == "foo", nil
+				seriesCleaner := newSeriesCleaner(tx.Bucket(local.IndexBucketName), tt.config, tables[0].name)
+				return ForEachSeries(context.Background(), tx.Bucket(local.IndexBucketName), tt.config, func(series retention.Series) (err error) {
+					if series.Labels().Get("bar") == "foo" {
+						for _, chk := range series.Chunks() {
+							require.NoError(t, seriesCleaner.RemoveChunk(chk.From, chk.Through, series.UserID(), series.Labels(), chk.ChunkID))
+						}
+					}
+					return nil
 				})
 			})
 			require.NoError(t, err)
 
 			err = tables[0].DB.Update(func(tx *bbolt.Tx) error {
 				cleaner := newSeriesCleaner(tx.Bucket(local.IndexBucketName), tt.config, tables[0].name)
-				if err := cleaner.CleanupSeries(entryFromChunk(testSchema, c2).UserID, c2.Metric); err != nil {
+				if err := cleaner.CleanupSeries([]byte(c2.UserID), c2.Metric); err != nil {
 					return err
 				}
 
 				// remove series for c1 without __name__ label, which should work just fine
-				return cleaner.CleanupSeries(entryFromChunk(testSchema, c1).UserID, labels.NewBuilder(c1.Metric).Del(labels.MetricName).Labels())
+				return cleaner.CleanupSeries([]byte(c1.UserID), labels.NewBuilder(c1.Metric).Del(labels.MetricName).Labels())
 			})
 			require.NoError(t, err)
 
 			err = tables[0].DB.View(func(tx *bbolt.Tx) error {
 				return tx.Bucket(local.IndexBucketName).ForEach(func(k, _ []byte) error {
-					c1SeriesID := entryFromChunk(testSchema, c1).SeriesID
-					c2SeriesID := entryFromChunk(testSchema, c2).SeriesID
+					c1SeriesID := labelsSeriesID(c1.Metric)
+					c2SeriesID := labelsSeriesID(c2.Metric)
 					series, ok, err := parseLabelIndexSeriesID(decodeKey(k))
 					if !ok {
 						return nil
@@ -215,20 +224,13 @@ func labelsString(ls labels.Labels) string {
 	return b.String()
 }
 
-func entryFromChunk(s config.SchemaConfig, c chunk.Chunk) retention.ChunkEntry {
-	return retention.ChunkEntry{
-		ChunkRef: retention.ChunkRef{
-			UserID:   []byte(c.UserID),
-			SeriesID: labelsSeriesID(c.Metric),
-			ChunkID:  []byte(s.ExternalKey(c.ChunkRef)),
-			From:     c.From,
-			Through:  c.Through,
-		},
-		Labels: labels.NewBuilder(c.Metric).Del(labels.MetricName).Labels(),
+func retentionChunkFromChunk(s config.SchemaConfig, c chunk.Chunk) retention.Chunk {
+	return retention.Chunk{
+		ChunkID: []byte(s.ExternalKey(c.ChunkRef)),
+		From:    c.From,
+		Through: c.Through,
 	}
 }
-
-var chunkEntry retention.ChunkEntry
 
 func Benchmark_ChunkIterator(b *testing.B) {
 	cm := storage.NewClientMetrics()
@@ -249,14 +251,13 @@ func Benchmark_ChunkIterator(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 
-	var total int64
+	var total int
 	_ = store.indexTables()[0].Update(func(tx *bbolt.Tx) error {
 		bucket := tx.Bucket(local.IndexBucketName)
 		for n := 0; n < b.N; n++ {
-			err := ForEachChunk(context.Background(), bucket, allSchemas[0].config, func(entry retention.ChunkEntry) (deleteChunk bool, err error) {
-				chunkEntry = entry
-				total++
-				return true, nil
+			err := ForEachSeries(context.Background(), bucket, allSchemas[0].config, func(series retention.Series) (err error) {
+				total += len(series.Chunks())
+				return nil
 			})
 			require.NoError(b, err)
 		}

--- a/pkg/storage/stores/shipper/indexshipper/boltdb/compactor/series.go
+++ b/pkg/storage/stores/shipper/indexshipper/boltdb/compactor/series.go
@@ -22,15 +22,15 @@ func newUserSeries(seriesID []byte, userID []byte) userSeries {
 	}
 }
 
-func (us userSeries) Key() string {
+func (us *userSeries) Key() string {
 	return unsafeGetString(us.key)
 }
 
-func (us userSeries) SeriesID() []byte {
+func (us *userSeries) SeriesID() []byte {
 	return us.key[:us.seriesIDLen]
 }
 
-func (us userSeries) UserID() []byte {
+func (us *userSeries) UserID() []byte {
 	return us.key[us.seriesIDLen:]
 }
 

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/compactor.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/compactor.go
@@ -288,24 +288,23 @@ func newCompactedIndex(ctx context.Context, tableName, userID, workingDir string
 	}
 }
 
-// ForEachChunk iterates over all the chunks in the builder and calls the callback function.
-func (c *compactedIndex) ForEachChunk(ctx context.Context, callback retention.ChunkEntryCallback) error {
+// ForEachSeries iterates over all the chunks in the builder and calls the callback function.
+func (c *compactedIndex) ForEachSeries(ctx context.Context, callback retention.SeriesCallback) error {
 	schemaCfg := config.SchemaConfig{
 		Configs: []config.PeriodConfig{c.periodConfig},
 	}
 
-	chunkEntry := retention.ChunkEntry{
-		ChunkRef: retention.ChunkRef{
-			UserID: getUnsafeBytes(c.userID),
-		},
-	}
 	logprotoChunkRef := logproto.ChunkRef{
 		UserID: c.userID,
 	}
+	var series retention.Series
 	for seriesID, stream := range c.builder.streams {
+		series.Reset(
+			getUnsafeBytes(seriesID),
+			getUnsafeBytes(c.userID),
+			withoutTenantLabel(stream.labels),
+		)
 		logprotoChunkRef.Fingerprint = uint64(stream.fp)
-		chunkEntry.SeriesID = getUnsafeBytes(seriesID)
-		chunkEntry.Labels = withoutTenantLabel(stream.labels)
 
 		for i := 0; i < len(stream.chunks) && ctx.Err() == nil; i++ {
 			chk := stream.chunks[i]
@@ -313,19 +312,19 @@ func (c *compactedIndex) ForEachChunk(ctx context.Context, callback retention.Ch
 			logprotoChunkRef.Through = chk.Through()
 			logprotoChunkRef.Checksum = chk.Checksum
 
-			chunkEntry.ChunkID = getUnsafeBytes(schemaCfg.ExternalKey(logprotoChunkRef))
-			chunkEntry.From = logprotoChunkRef.From
-			chunkEntry.Through = logprotoChunkRef.Through
+			series.AppendChunks(retention.Chunk{
+				ChunkID: getUnsafeBytes(schemaCfg.ExternalKey(logprotoChunkRef)),
+				From:    logprotoChunkRef.From,
+				Through: logprotoChunkRef.Through,
+			})
+		}
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
 
-			deleteChunk, err := callback(chunkEntry)
-			if err != nil {
-				return err
-			}
-
-			if deleteChunk {
-				// add the chunk to the list of chunks to delete which would be taken care of while building the index.
-				c.deleteChunks[seriesID] = append(c.deleteChunks[seriesID], chk)
-			}
+		err := callback(series)
+		if err != nil {
+			return err
 		}
 	}
 
@@ -365,6 +364,22 @@ func (c *compactedIndex) CleanupSeries(_ []byte, lbls labels.Labels) error {
 	}
 	delete(c.builder.streams, seriesID)
 	delete(c.deleteChunks, seriesID)
+	return nil
+}
+
+func (c *compactedIndex) RemoveChunk(from, through model.Time, userID []byte, labels labels.Labels, chunkID []byte) error {
+	chk, err := chunk.ParseExternalKey(string(userID), string(chunkID))
+	if err != nil {
+		return err
+	}
+
+	seriesID := labels.String()
+	c.deleteChunks[seriesID] = append(c.deleteChunks[seriesID], tsdbindex.ChunkMeta{
+		Checksum: chk.Checksum,
+		MinTime:  int64(from),
+		MaxTime:  int64(through),
+	})
+
 	return nil
 }
 

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/chunk.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/chunk.go
@@ -151,7 +151,7 @@ func (c ChunkMetas) Drop(chk ChunkMeta) (ChunkMetas, bool) {
 		return ichk.Checksum >= chk.Checksum
 	})
 
-	if j >= len(c) || c[j] != chk {
+	if j >= len(c) || c[j].Checksum != chk.Checksum || c[j].MinTime != chk.MinTime || c[j].MaxTime != chk.MaxTime {
 		return c, false
 	}
 

--- a/pkg/tool/audit/audit_test.go
+++ b/pkg/tool/audit/audit_test.go
@@ -44,28 +44,25 @@ func (t testObjClient) GetAttributes(_ context.Context, object string) (client.O
 type testCompactedIdx struct {
 	compactor.CompactedIndex
 
-	chunks []retention.ChunkEntry
+	chunks []retention.Chunk
 }
 
-func (t testCompactedIdx) ForEachChunk(_ context.Context, f retention.ChunkEntryCallback) error {
-	for _, chunk := range t.chunks {
-		if _, err := f(chunk); err != nil {
-			return err
-		}
-	}
-	return nil
+func (t testCompactedIdx) ForEachSeries(_ context.Context, f retention.SeriesCallback) error {
+	var series retention.Series
+	series.AppendChunks(t.chunks...)
+	return f(series)
 }
 
 func TestAuditIndex(t *testing.T) {
 	ctx := context.Background()
 	objClient := testObjClient{}
 	compactedIdx := testCompactedIdx{
-		chunks: []retention.ChunkEntry{
-			{ChunkRef: retention.ChunkRef{ChunkID: []byte("found-1")}},
-			{ChunkRef: retention.ChunkRef{ChunkID: []byte("found-2")}},
-			{ChunkRef: retention.ChunkRef{ChunkID: []byte("found-3")}},
-			{ChunkRef: retention.ChunkRef{ChunkID: []byte("found-4")}},
-			{ChunkRef: retention.ChunkRef{ChunkID: []byte("missing-1")}},
+		chunks: []retention.Chunk{
+			{ChunkID: []byte("found-1")},
+			{ChunkID: []byte("found-2")},
+			{ChunkID: []byte("found-3")},
+			{ChunkID: []byte("found-4")},
+			{ChunkID: []byte("missing-1")},
 		},
 	}
 	logger := log.NewNopLogger()

--- a/tools/tsdb/tsdb-map/main.go
+++ b/tools/tsdb/tsdb-map/main.go
@@ -78,15 +78,19 @@ func main() {
 
 	// loads everything into memory.
 	if err := db.View(func(t *bbolt.Tx) error {
-		return boltdbcompactor.ForEachChunk(context.Background(), t.Bucket([]byte("index")), periodConfig, func(entry retention.ChunkEntry) (bool, error) {
-			builder.AddSeries(entry.Labels, model.Fingerprint(entry.Labels.Hash()), []index.ChunkMeta{{
-				Checksum: extractChecksumFromChunkID(entry.ChunkID),
-				MinTime:  int64(entry.From),
-				MaxTime:  int64(entry.Through),
-				KB:       ((3 << 20) / 4) / 1024, // guess: 0.75mb, 1/2 of the max size, rounded to KB
-				Entries:  10000,                  // guess: 10k entries
-			}})
-			return false, nil
+		return boltdbcompactor.ForEachSeries(context.Background(), t.Bucket([]byte("index")), periodConfig, func(s retention.Series) error {
+			chunkMetas := make([]index.ChunkMeta, 0, len(s.Chunks()))
+			for _, chunk := range s.Chunks() {
+				chunkMetas = append(chunkMetas, index.ChunkMeta{
+					Checksum: extractChecksumFromChunkID(chunk.ChunkID),
+					MinTime:  int64(chunk.From),
+					MaxTime:  int64(chunk.Through),
+					KB:       ((3 << 20) / 4) / 1024, // guess: 0.75mb, 1/2 of the max size, rounded to KB
+					Entries:  10000,                  // guess: 10k entries
+				})
+			}
+			builder.AddSeries(s.Labels(), model.Fingerprint(s.Labels().Hash()), chunkMetas)
+			return nil
 		})
 	}); err != nil {
 		panic(err)


### PR DESCRIPTION
**What this PR does / why we need it**:
An intensive delete request can take too long to process, which can hold the table for too long and lead to compaction being blocked. To avoid that, we have a config limiting how much time retention/deletion can work on a table. When the timeout is hit, we stop processing the delete request to let it attempt again in the next retention run. However, since we did not have any saved progress, it would start processing all the chunks again which were already processed during the previous run. This led to an endless loop, causing delete request processing to get stuck and an unnecessary waste of resources.

This PR supports storing the details of already processed streams in the delete requests manager. Using this progress, we can easily skip the streams that have already been processed in an earlier attempt. We will also retain the progress on the disk so that the compactor can pick it up when it gets restarted.

**Checklist**
- [x] Tests updated