### PR TITLE
chore: update the HTTP debug routes for ingest-limits

### DIFF
--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -456,7 +456,7 @@ func (t *Loki) initIngestLimits() (services.Service, error) {
 	logproto.RegisterIngestLimitsServer(t.Server.GRPC, ingestLimits)
 
 	// Register HTTP handler for metadata
-	t.Server.HTTP.Path("/ingest/limits").Methods("GET").Handler(ingestLimits)
+	t.Server.HTTP.Path("/ingest-limits/usage/{tenant}").Methods("GET").Handler(ingestLimits)
 
 	return ingestLimits, nil
 }
@@ -516,7 +516,7 @@ func (t *Loki) initIngestLimitsFrontend() (services.Service, error) {
 	// Register HTTP handler to check if a tenant exceeds limits
 	// Returns a JSON response for the frontend to display which
 	// streams are rejected.
-	t.Server.HTTP.Path("/ingest/exceeds-limits").Methods("POST").Handler(ingestLimitsFrontend)
+	t.Server.HTTP.Path("/ingest-limits/exceeds-limits").Methods("POST").Handler(ingestLimitsFrontend)
 
 	return ingestLimitsFrontend, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Use `ingest-limits` as the prefix to match other services where the service name is used, and use path variables instead of query strings to get the tenant.


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
