### PR TITLE
chore: write unit tests for ServeHTTP in limits service

### DIFF
--- a/pkg/limits/http_test.go
+++ b/pkg/limits/http_test.go
@@ -1,0 +1,70 @@
+package limits
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIngestLimits_ServeHTTP(t *testing.T) {
+	l := IngestLimits{
+		cfg: Config{
+			WindowSize:     time.Minute,
+			RateWindow:     time.Minute,
+			BucketDuration: 30 * time.Second,
+		},
+		metadata: map[string]map[int32][]streamMetadata{
+			"tenant": {
+				0: {{
+					hash:      0x1,
+					totalSize: 100,
+					rateBuckets: []rateBucket{{
+						timestamp: time.Now().UnixNano(),
+						size:      1,
+					}},
+					lastSeenAt: time.Now().UnixNano(),
+				}},
+			},
+		},
+		logger: log.NewNopLogger(),
+	}
+
+	// Set up a mux router for the test server otherwise mux.Vars() won't work.
+	r := mux.NewRouter()
+	r.Path("/{tenant}").Methods("GET").Handler(&l)
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	// Unknown tenant should have no usage.
+	resp, err := http.Get(ts.URL + "/unknown_tenant")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	b, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	var data httpTenantLimitsResponse
+	require.NoError(t, json.Unmarshal(b, &data))
+	require.Equal(t, "unknown_tenant", data.Tenant)
+	require.Equal(t, uint64(0), data.ActiveStreams)
+	require.Equal(t, 0.0, data.Rate)
+
+	// Known tenant should return current usage.
+	resp, err = http.Get(ts.URL + "/tenant")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	b, err = io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(b, &data))
+	require.Equal(t, "tenant", data.Tenant)
+	require.Equal(t, uint64(1), data.ActiveStreams)
+	require.Greater(t, data.Rate, 0.0)
+	require.Less(t, data.Rate, 1.0)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Added unit tests for `ServeHTTP` in limits service.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
