### PR TITLE
feat: add evictor

### DIFF
--- a/pkg/limits/evict.go
+++ b/pkg/limits/evict.go
@@ -1,0 +1,51 @@
+package limits
+
+import (
+	"context"
+	"time"
+
+	"github.com/coder/quartz"
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+)
+
+type Evictable interface {
+	Evict(context.Context) error
+}
+
+// Evictor runs scheduled evictions.
+type Evictor struct {
+	ctx      context.Context
+	interval time.Duration
+	target   Evictable
+	logger   log.Logger
+
+	// Used for tests.
+	clock quartz.Clock
+}
+
+// NewEvictor returns a new evictor over the interval.
+func NewEvictor(ctx context.Context, interval time.Duration, target Evictable, logger log.Logger) (*Evictor, error) {
+	return &Evictor{
+		ctx:      ctx,
+		interval: interval,
+		target:   target,
+		logger:   logger,
+		clock:    quartz.NewReal(),
+	}, nil
+}
+
+// Runs the scheduler loop until the context is canceled.
+func (e *Evictor) Run() error {
+	t := e.clock.TickerFunc(e.ctx, e.interval, e.doTick)
+	return t.Wait()
+}
+
+func (e *Evictor) doTick() error {
+	ctx, cancel := context.WithTimeout(e.ctx, e.interval)
+	defer cancel()
+	if err := e.target.Evict(ctx); err != nil {
+		level.Warn(e.logger).Log("failed to run eviction", "err", err.Error())
+	}
+	return nil
+}

--- a/pkg/limits/evict_test.go
+++ b/pkg/limits/evict_test.go
@@ -1,0 +1,54 @@
+package limits
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/coder/quartz"
+	"github.com/go-kit/log"
+	"github.com/stretchr/testify/require"
+)
+
+type mockEvictable struct {
+	calls []time.Time
+	clock quartz.Clock
+}
+
+func (m *mockEvictable) Evict(_ context.Context) error {
+	m.calls = append(m.calls, m.clock.Now())
+	return nil
+}
+
+func TestEvictor(t *testing.T) {
+	// Set a timeout on the test.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	clock := quartz.NewMock(t)
+	m := mockEvictable{clock: clock}
+	e, err := NewEvictor(ctx, time.Second, &m, log.NewNopLogger())
+	require.NoError(t, err)
+	e.clock = clock
+
+	// See https://github.com/coder/quartz/blob/v0.1.3/example_test.go#L48.
+	trap := clock.Trap().TickerFunc()
+	defer trap.Close()
+	go e.Run() //nolint:errcheck
+	call, err := trap.Wait(ctx)
+	require.NoError(t, err)
+	call.Release()
+
+	// Do a tick.
+	clock.Advance(time.Second).MustWait(ctx)
+	tick1 := clock.Now()
+	require.Len(t, m.calls, 1)
+	require.Equal(t, tick1, m.calls[0])
+
+	// Do another tick.
+	clock.Advance(time.Second).MustWait(ctx)
+	tick2 := clock.Now()
+	require.Len(t, m.calls, 2)
+	require.Equal(t, tick1, m.calls[0])
+	require.Equal(t, tick2, m.calls[1])
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit adds an evictor abstraction that will run the eviction of stale streams. The reason for abstracing it is two reasons:

1. It is easier to test
2. It will allow us to parallelize eviction over shards of metadata (for example, one per partition) to increase parallelism and reduce lock contention.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
