### PR TITLE
chore: Update default `VERSION` in `tools/promtail.sh` to latest

### DIFF
--- a/tools/promtail.sh
+++ b/tools/promtail.sh
@@ -6,7 +6,7 @@ INSTANCEURL="${3:-}"
 NAMESPACE="${4:-default}"
 CONTAINERROOT="${5:-/var/lib/docker}"
 PARSER="${6:-- cri: {}}"
-VERSION="${PROMTAIL_VERSION:-2.7.1}"
+VERSION="${PROMTAIL_VERSION:-3.4.2}"
 
 if [ -z "${INSTANCEID}" ] || [ -z "${APIKEY}" ] || [ -z "${INSTANCEURL}" ] || [ -z "${NAMESPACE}" ] || [ -z "${CONTAINERROOT}" ] || [ -z "${PARSER}" ]; then
     echo "usage: $0 <instanceId> <apiKey> <url> [<namespace>[<container_root_path>[<parser>]]]"


### PR DESCRIPTION
**What this PR does / why we need it**:

While it is possible to override the version using the `PROMTAIL_VERSION` environment variable, the default should point to the latest release.