### PR TITLE
feat(helm): add support for custom image commands in missing components

### DIFF
--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -15,8 +15,8 @@ Entries should include a reference to the pull request that introduced the chang
 
 ## 6.30.0
 
-- [BUGFIX] Added missing `command` spec definition for the `ruler`, `querier` and `tableManager`
-- [CHANGE] Added support for `command` spec definition for the `query-scheduler`, `backend`, `read`, `write`, `table-manager` or single binary
+- [BUGFIX] Added missing `command` spec definition for the `ruler`, `querier` and `table-manager`
+- [CHANGE] Added support for `command` spec definition for the `query-scheduler`, `backend`, `read`, `write` or single binary
 
 ## 6.29.0
 

--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -13,6 +13,11 @@ Entries should include a reference to the pull request that introduced the chang
 
 [//]: # (<AUTOMATED_UPDATES_LOCATOR> : do not remove this line. This locator is used by the CI pipeline to automatically create a changelog entry for each new Loki release. Add other chart versions and respective changelog entries bellow this line.)
 
+## 6.30.0
+
+- [BUGFIX] Added missing `command` spec definition for the `ruler`, `querier` and `tableManager`
+- [CHANGE] Added support for `command` spec definition for the `query-scheduler`, `backend`, `read`, `write`, `table-manager` or single binary
+
 ## 6.29.0
 
 - [FEATURE] Added support to copy the following headers into X-Query-Tags as key/value pairs:, X-Grafana-User, X-Dashboard-Uid, X-Dashboard-Title, X-Panel-Id, X-Panel-Title, X-Rule-Uid, X-Rule-Name, X-Rule-Folder, X-Rule-Version, X-Rule-Source, X-Rule-Type

--- a/production/helm/loki/templates/backend/statefulset-backend.yaml
+++ b/production/helm/loki/templates/backend/statefulset-backend.yaml
@@ -147,6 +147,10 @@ spec:
         - name: loki
           image: {{ include "loki.image" . }}
           imagePullPolicy: {{ .Values.loki.image.pullPolicy }}
+          {{- if or .Values.loki.command .Values.backend.command }}
+          command:
+            - {{ coalesce .Values.backend.command .Values.loki.command | quote }}
+          {{- end }}
           args:
             - -config.file=/etc/loki/config/config.yaml
             - -target={{ .Values.backend.targetModule }}

--- a/production/helm/loki/templates/index-gateway/statefulset-index-gateway.yaml
+++ b/production/helm/loki/templates/index-gateway/statefulset-index-gateway.yaml
@@ -71,6 +71,10 @@ spec:
         - name: index-gateway
           image: {{ include "loki.image" . }}
           imagePullPolicy: {{ .Values.loki.image.pullPolicy }}
+          {{- if or .Values.loki.command .Values.indexGateway.command }}
+          command:
+            - {{ coalesce .Values.indexGateway.command .Values.loki.command | quote }}
+          {{- end }}
           args:
             - -config.file=/etc/loki/config/config.yaml
             - -target=index-gateway

--- a/production/helm/loki/templates/querier/deployment-querier.yaml
+++ b/production/helm/loki/templates/querier/deployment-querier.yaml
@@ -68,6 +68,10 @@ spec:
         - name: querier
           image: {{ include "loki.image" . }}
           imagePullPolicy: {{ .Values.loki.image.pullPolicy }}
+          {{- if or .Values.loki.command .Values.querier.command }}
+          command:
+            - {{ coalesce .Values.querier.command .Values.loki.command | quote }}
+          {{- end }}
           args:
             - -config.file=/etc/loki/config/config.yaml
             - -target=querier

--- a/production/helm/loki/templates/query-scheduler/deployment-query-scheduler.yaml
+++ b/production/helm/loki/templates/query-scheduler/deployment-query-scheduler.yaml
@@ -61,6 +61,10 @@ spec:
         - name: query-scheduler
           image: {{ include "loki.image" . }}
           imagePullPolicy: {{ .Values.loki.image.pullPolicy }}
+          {{- if or .Values.loki.command .Values.queryScheduler.command }}
+          command:
+            - {{ coalesce .Values.queryScheduler.command .Values.loki.command | quote }}
+          {{- end }}
           args:
             - -config.file=/etc/loki/config/config.yaml
             - -target=query-scheduler

--- a/production/helm/loki/templates/read/statefulset-read.yaml
+++ b/production/helm/loki/templates/read/statefulset-read.yaml
@@ -76,6 +76,10 @@ spec:
         - name: loki
           image: {{ include "loki.image" . }}
           imagePullPolicy: {{ .Values.loki.image.pullPolicy }}
+          {{- if or .Values.loki.command .Values.read.command }}
+          command:
+            - {{ coalesce .Values.read.command .Values.loki.command | quote }}
+          {{- end }}
           args:
             - -config.file=/etc/loki/config/config.yaml
             - -target={{ .Values.read.targetModule }}

--- a/production/helm/loki/templates/ruler/statefulset-ruler.yaml
+++ b/production/helm/loki/templates/ruler/statefulset-ruler.yaml
@@ -63,6 +63,10 @@ spec:
         - name: ruler
           image: {{ include "loki.image" . }}
           imagePullPolicy: {{ .Values.loki.image.pullPolicy }}
+          {{- if or .Values.loki.command .Values.ruler.command }}
+          command:
+            - {{ coalesce .Values.ruler.command .Values.loki.command | quote }}
+          {{- end }}
           args:
             - -config.file=/etc/loki/config/config.yaml
             - -target=ruler

--- a/production/helm/loki/templates/single-binary/statefulset.yaml
+++ b/production/helm/loki/templates/single-binary/statefulset.yaml
@@ -151,6 +151,10 @@ spec:
         - name: loki
           image: {{ include "loki.image" . }}
           imagePullPolicy: {{ .Values.loki.image.pullPolicy }}
+          {{- if or .Values.loki.command .Values.singleBinary.command }}
+          command:
+            - {{ coalesce .Values.singleBinary.command .Values.loki.command | quote }}
+          {{- end }}
           args:
             - -config.file=/etc/loki/config/config.yaml
             - -target={{ .Values.singleBinary.targetModule }}

--- a/production/helm/loki/templates/table-manager/deployment-table-manager.yaml
+++ b/production/helm/loki/templates/table-manager/deployment-table-manager.yaml
@@ -50,6 +50,10 @@ spec:
         - name: table-manager
           image: {{ include "loki.image" . }}
           imagePullPolicy: {{ .Values.loki.image.pullPolicy }}
+          {{- if or .Values.loki.command .Values.tableManager.command }}
+          command:
+            - {{ coalesce .Values.tableManager.command .Values.loki.command | quote }}
+          {{- end }}
           args:
             - -config.file=/etc/loki/config/config.yaml
             - -target=table-manager

--- a/production/helm/loki/templates/write/statefulset-write.yaml
+++ b/production/helm/loki/templates/write/statefulset-write.yaml
@@ -82,6 +82,10 @@ spec:
         - name: loki
           image: {{ include "loki.image" . }}
           imagePullPolicy: {{ .Values.loki.image.pullPolicy }}
+          {{- if or .Values.loki.command .Values.write.command }}
+          command:
+            - {{ coalesce .Values.write.command .Values.loki.command | quote }}
+          {{- end }}
           args:
             - -config.file=/etc/loki/config/config.yaml
             - -target={{ .Values.write.targetModule }}

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -1368,6 +1368,8 @@ singleBinary:
     repository: null
     # -- Docker image tag for the single binary image. Overrides `loki.image.tag`
     tag: null
+  # -- Command to execute instead of defined in Docker image
+  command: null
   # -- The name of the PriorityClass for single binary pods
   priorityClassName: null
   # -- Annotations for single binary StatefulSet
@@ -1479,6 +1481,8 @@ write:
     repository: null
     # -- Docker image tag for the write image. Overrides `loki.image.tag`
     tag: null
+  # -- Command to execute instead of defined in Docker image
+  command: null
   # -- The name of the PriorityClass for write pods
   priorityClassName: null
   # -- Annotations for write StatefulSet
@@ -1600,6 +1604,8 @@ read:
     repository: null
     # -- Docker image tag for the read image. Overrides `loki.image.tag`
     tag: null
+  # -- Command to execute instead of defined in Docker image
+  command: null
   # -- The name of the PriorityClass for read pods
   priorityClassName: null
   # -- Annotations for read deployment
@@ -1710,6 +1716,8 @@ backend:
     repository: null
     # -- Docker image tag for the backend image. Overrides `loki.image.tag`
     tag: null
+  # -- Command to execute instead of defined in Docker image
+  command: null
   # -- The name of the PriorityClass for backend pods
   priorityClassName: null
   # -- Annotations for backend StatefulSet
@@ -2307,6 +2315,8 @@ queryScheduler:
     repository: null
     # -- Docker image tag for the query-scheduler image. Overrides `loki.image.tag`
     tag: null
+  # -- Command to execute instead of defined in Docker image
+  command: null
   # -- The name of the PriorityClass for query-scheduler pods
   priorityClassName: null
   # -- Labels for query-scheduler pods
@@ -2371,6 +2381,8 @@ indexGateway:
     repository: null
     # -- Docker image tag for the index-gateway image. Overrides `loki.image.tag`
     tag: null
+  # -- Command to execute instead of defined in Docker image
+  command: null
   # -- The name of the PriorityClass for index-gateway pods
   priorityClassName: null
   # -- Labels for index-gateway pods


### PR DESCRIPTION
**What this PR does / why we need it**:

Some components like `ruler` and `querier` have custom command support on `values.yaml`, however the manifest template is not loading it.
Also other components like `query-scheduler`, `backend`, `read`, and `write` is not even supporting custom commands for the image, so this PR adds support for it.

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [X] Documentation added
- [X] Tests updated
- [X] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [X] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [X] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
