### PR TITLE
chore: remove unused metric

### DIFF
--- a/pkg/kafka/partition/reader.go
+++ b/pkg/kafka/partition/reader.go
@@ -47,13 +47,12 @@ type Reader interface {
 
 // ReaderMetrics contains metrics specific to Kafka reading operations
 type ReaderMetrics struct {
-	recordsPerFetch     prometheus.Histogram
-	fetchesErrors       prometheus.Counter
-	fetchesTotal        prometheus.Counter
-	fetchWaitDuration   prometheus.Histogram
-	receiveDelay        *prometheus.HistogramVec
-	lastCommittedOffset prometheus.Gauge
-	kprom               *kprom.Metrics
+	recordsPerFetch   prometheus.Histogram
+	fetchesErrors     prometheus.Counter
+	fetchesTotal      prometheus.Counter
+	fetchWaitDuration prometheus.Histogram
+	receiveDelay      *prometheus.HistogramVec
+	kprom             *kprom.Metrics
 }
 
 func NewReaderMetrics(r prometheus.Registerer) *ReaderMetrics {


### PR DESCRIPTION
**What this PR does / why we need it**:

The `lastCommittedOffset` metric wasn't even registered, should be removed from `readerMetrics`.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
