### PR TITLE
fix: Standardise kafka (client|writer|tenant-tee) metric names

### DIFF
--- a/pkg/kafka/client/writer_client.go
+++ b/pkg/kafka/client/writer_client.go
@@ -36,7 +36,7 @@ var writerRequestTimeoutOverhead = 2 * time.Second
 func NewWriterClient(kafkaCfg kafka.Config, maxInflightProduceRequests int, logger log.Logger, reg prometheus.Registerer) (*kgo.Client, error) {
 	// Do not export the client ID, because we use it to specify options to the backend.
 	metrics := kprom.NewMetrics(
-		"", // No prefix. We expect the input prometheus.Registered to be wrapped with a prefix.
+		"kafka", // Add kafka prefix to match Kafka Producer client metrics. We expect the input Registerer to be wrapped with the usual Loki prefixes.
 		kprom.Registerer(reg),
 		kprom.FetchAndProduceDetail(kprom.Batches, kprom.Records, kprom.CompressedBytes, kprom.UncompressedBytes))
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The metric names are very inconsistent. Some of them are wrapped in `loki_distributor` and `kafka`, others are not and don't have any prefix (!)
* kafka_client.WriterClient => Now adds `loki_distributor_kafka_` prefix to metrics. These come from a lib and expect a registerer.
* kafka_client.Producer => Now adds `loki_distributor_` prefix to metrics. These are our own code so we are already adding the `kafka_` prefix but not the other bits.
* tenant_tee => These were manually adding `loki_distributor_` which I've wrapped in a registerer. It also containers a Producer client which inheririts the registerer and adds its own `kafka_` prefix (as before).

This makes it a bit easier to search for these metrics. Previously they were hard to find, as some of them were called things like `buffered_fetch_records` which are now `loki_distributor_kafka_buffered_fetch_records`.