### PR TITLE
feat: add loki_ingest_limits_kafka_consumption_lag_seconds metric

### DIFF
--- a/pkg/limits/ingest_limits.go
+++ b/pkg/limits/ingest_limits.go
@@ -64,7 +64,7 @@ var (
 type metrics struct {
 	tenantStreamEvictionsTotal *prometheus.CounterVec
 
-	kafkaReadLatency    prometheus.Histogram
+	kafkaConsumptionLag prometheus.Histogram
 	kafkaReadBytesTotal prometheus.Counter
 }
 
@@ -75,10 +75,9 @@ func newMetrics(reg prometheus.Registerer) *metrics {
 			Name:      "ingest_limits_stream_evictions_total",
 			Help:      "The total number of streams evicted due to age per tenant. This is not a global total, as tenants can be sharded over multiple pods.",
 		}, []string{"tenant"}),
-		kafkaReadLatency: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
-			Namespace:                       constants.Loki,
-			Name:                            "ingest_limits_kafka_read_latency_seconds",
-			Help:                            "Latency to read stream metadata from Kafka.",
+		kafkaConsumptionLag: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
+			Name:                            "loki_ingest_limits_kafka_consumption_lag_seconds",
+			Help:                            "The estimated consumption lag in seconds, measured as the difference between the current time and the timestamp of the record.",
 			NativeHistogramBucketFactor:     1.1,
 			NativeHistogramMinResetDuration: 1 * time.Hour,
 			NativeHistogramMaxBucketNumber:  100,
@@ -320,8 +319,6 @@ func (s *IngestLimits) running(ctx context.Context) error {
 		case err := <-s.lifecyclerWatcher.Chan():
 			return fmt.Errorf("lifecycler failed: %w", err)
 		default:
-			startTime := time.Now()
-
 			fetches := s.client.PollRecords(ctx, 100)
 			if fetches.IsClientClosed() {
 				return nil
@@ -334,9 +331,6 @@ func (s *IngestLimits) running(ctx context.Context) error {
 				continue
 			}
 
-			// Record the latency of successful fetches
-			s.metrics.kafkaReadLatency.Observe(time.Since(startTime).Seconds())
-
 			// Process the fetched records
 			var sizeBytes int
 
@@ -344,6 +338,9 @@ func (s *IngestLimits) running(ctx context.Context) error {
 			for !iter.Done() {
 				record := iter.Next()
 				sizeBytes += len(record.Value)
+
+				// Update the estimated consumption lag.
+				s.metrics.kafkaConsumptionLag.Observe(time.Since(record.Timestamp).Seconds())
 
 				metadata, err := kafka.DecodeStreamMetadata(record)
 				if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request adds a new metric to the ingest-limits service to track consumption lag in seconds.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
