### PR TITLE
fix: forgot to reset gauge on phase change

### DIFF
--- a/pkg/kafka/partition/reader.go
+++ b/pkg/kafka/partition/reader.go
@@ -131,6 +131,10 @@ func (r *KafkaReader) Partition() int32 {
 // SetPhase sets the phase for the reader. This is used to differentiate between different phases of the reader.
 // For example, we can use this to differentiate between the startup phase and the running phase.
 func (r *KafkaReader) SetPhase(phase string) {
+	if prev := r.phase; prev != "" {
+		// Reset the consumption lag metric for the previous phase.
+		r.metrics.consumptionLag.WithLabelValues(prev).Set(0)
+	}
 	r.phase = phase
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request fixes a bug where the gauge for the previous phase would still be emitted.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
