### PR TITLE
test: fix data race in TestPartitionContinuityDuringRebalance

### DIFF
--- a/pkg/kafka/partitionring/consumer/client_test.go
+++ b/pkg/kafka/partitionring/consumer/client_test.go
@@ -299,8 +299,10 @@ func TestPartitionContinuityDuringRebalance(t *testing.T) {
 
 	// Let initial setup stabilize and verify consumer1 is reading
 	time.Sleep(2 * time.Second)
+	offsetMu.Lock()
 	require.Greater(t, lastOffset, int64(0), "consumer1 should have read some records from partition 0")
 	initialOffset := lastOffset
+	offsetMu.Unlock()
 
 	// Add second consumer and change active partitions
 	t.Log("Adding consumer2 and changing active partitions from [0,1] to [0,1,2]")


### PR DESCRIPTION
**What this PR does / why we need it**:

Without this, the test fails when executed with `-race`:
```
WARNING: DATA RACE
Read at 0x00c000644e98 by goroutine 44657:
  github.com/grafana/loki/v3/pkg/kafka/partitionring/consumer.TestPartitionContinuityDuringRebalance()
      github.com/grafana/loki/v3/pkg/kafka/partitionring/consumer/client_test.go:302 +0xa91
  testing.tRunner()
      testing/testing.go:1792 +0x225
  testing.(*T).Run.gowrap1()
      testing/testing.go:1851 +0x44

Previous write at 0x00c000644e98 by goroutine 44934:
  github.com/grafana/loki/v3/pkg/kafka/partitionring/consumer.TestPartitionContinuityDuringRebalance.func1.3()
      github.com/grafana/loki/v3/pkg/kafka/partitionring/consumer/client_test.go:256 +0x2ee
```