### PR TITLE
fix: histogram could measure up to 10 seconds of consumption lag, needs exponential buckets

### DIFF
--- a/pkg/limits/ingest_limits.go
+++ b/pkg/limits/ingest_limits.go
@@ -81,7 +81,7 @@ func newMetrics(reg prometheus.Registerer) *metrics {
 			NativeHistogramBucketFactor:     1.1,
 			NativeHistogramMinResetDuration: 1 * time.Hour,
 			NativeHistogramMaxBucketNumber:  100,
-			Buckets:                         prometheus.DefBuckets,
+			Buckets:                         prometheus.ExponentialBuckets(0.125, 2, 18),
 		}),
 		kafkaReadBytesTotal: promauto.With(reg).NewCounter(prometheus.CounterOpts{
 			Namespace: constants.Loki,


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request fixes a bug where the histogram could not measure more than 10 seconds of lag, as `DefBuckets` stops at `10`. We need to use `ExponentialBuckets` like the other consumption lag metrics.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
