### PR TITLE
chore(dataobj): correct version and error messages for logs metadata decoder

### DIFF
--- a/pkg/dataobj/internal/encoding/decoder_metadata.go
+++ b/pkg/dataobj/internal/encoding/decoder_metadata.go
@@ -78,14 +78,14 @@ func decodeStreamsColumnMetadata(r streamio.Reader) (*streamsmd.ColumnMetadata, 
 func decodeLogsMetadata(r streamio.Reader) (*logsmd.Metadata, error) {
 	gotVersion, err := streamio.ReadUvarint(r)
 	if err != nil {
-		return nil, fmt.Errorf("read streams section format version: %w", err)
-	} else if gotVersion != streamsFormatVersion {
-		return nil, fmt.Errorf("unexpected streams section format version: got=%d want=%d", gotVersion, streamsFormatVersion)
+		return nil, fmt.Errorf("read logs section format version: %w", err)
+	} else if gotVersion != logsFormatVersion {
+		return nil, fmt.Errorf("unexpected logs section format version: got=%d want=%d", gotVersion, logsFormatVersion)
 	}
 
 	var md logsmd.Metadata
 	if err := decodeProto(r, &md); err != nil {
-		return nil, fmt.Errorf("streams section metadata: %w", err)
+		return nil, fmt.Errorf("logs section metadata: %w", err)
 	}
 	return &md, nil
 }
@@ -94,7 +94,7 @@ func decodeLogsMetadata(r streamio.Reader) (*logsmd.Metadata, error) {
 func decodeLogsColumnMetadata(r streamio.Reader) (*logsmd.ColumnMetadata, error) {
 	var metadata logsmd.ColumnMetadata
 	if err := decodeProto(r, &metadata); err != nil {
-		return nil, fmt.Errorf("streams column metadata: %w", err)
+		return nil, fmt.Errorf("logs column metadata: %w", err)
 	}
 	return &metadata, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

corrects misleading error messages and version check in logs metadata decoder

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
