### PR TITLE
chore(planner): Convert AST into logical plan

### DIFF
--- a/pkg/engine/internal/types/column.go
+++ b/pkg/engine/internal/types/column.go
@@ -10,9 +10,17 @@ const (
 	// ColumnTypeInvalid indicates an invalid column type.
 	ColumnTypeInvalid ColumnType = iota
 
-	ColumnTypeBuiltin  // ColumnTypeBuiltin represents a builtin column (such as timestamp).
-	ColumnTypeLabel    // ColumnTypeLabel represents a column from a stream label.
-	ColumnTypeMetadata // ColumnTypeMetadata represents a column from a log metadata.
+	ColumnTypeBuiltin   // ColumnTypeBuiltin represents a builtin column (such as timestamp).
+	ColumnTypeLabel     // ColumnTypeLabel represents a column from a stream label.
+	ColumnTypeMetadata  // ColumnTypeMetadata represents a column from a log metadata.
+	ColumnTypeParsed    // ColumnTypeParsed represents a parsed column from a parser stage.
+	ColumnTypeAmbiguous // ColumnTypeAmbiguous represents a column that can either be a builtin, label, metadata, or parsed.
+)
+
+// Names of the builtin columns.
+const (
+	ColumnNameBuiltinTimestamp = "timestamp"
+	ColumnNameBuiltinLog       = "log"
 )
 
 // String returns a human-readable representation of the column type.
@@ -26,6 +34,10 @@ func (ct ColumnType) String() string {
 		return "label"
 	case ColumnTypeMetadata:
 		return "metadata"
+	case ColumnTypeParsed:
+		return "parsed"
+	case ColumnTypeAmbiguous:
+		return "ambiguous"
 	default:
 		return fmt.Sprintf("ColumnType(%d)", ct)
 	}

--- a/pkg/engine/internal/types/operators.go
+++ b/pkg/engine/internal/types/operators.go
@@ -53,10 +53,12 @@ const (
 	BinaryOpDiv // Division operation (/).
 	BinaryOpMod // Modulo operation (%).
 
-	BinaryOpMatchStr    // String matching operation (|=).
-	BinaryOpNotMatchStr // String non-matching operation (!=).
-	BinaryOpMatchRe     // Regular expression matching operation (|~).
-	BinaryOpNotMatchRe  // Regular expression non-matching operation (!~).
+	BinaryOpMatchStr        // String matching operation (|=).
+	BinaryOpNotMatchStr     // String non-matching operation (!=).
+	BinaryOpMatchRe         // Regular expression matching operation (|~).
+	BinaryOpNotMatchRe      // Regular expression non-matching operation (!~).
+	BinaryOpMatchPattern    // Pattern matching operation (|>).
+	BinaryOpNotMatchPattern // Pattern non-matching operation (!>).
 )
 
 // String returns a human-readable representation of the binary operation kind.

--- a/pkg/engine/planner/logical/builder.go
+++ b/pkg/engine/planner/logical/builder.go
@@ -26,7 +26,7 @@ func (b *Builder) Select(predicate Value) *Builder {
 }
 
 // Limit applies a [Limit] operation to the Builder.
-func (b *Builder) Limit(skip uint64, fetch uint64) *Builder {
+func (b *Builder) Limit(skip uint32, fetch uint32) *Builder {
 	return &Builder{
 		val: &Limit{
 			Table: b.val,

--- a/pkg/engine/planner/logical/logical.go
+++ b/pkg/engine/planner/logical/logical.go
@@ -92,3 +92,14 @@ func (p Plan) String() string {
 
 	return sb.String()
 }
+
+// Value returns the value of the RETURN instruction.
+func (p Plan) Value() Value {
+	for _, inst := range p.Instructions {
+		switch inst := inst.(type) {
+		case *Return:
+			return inst.Value
+		}
+	}
+	return nil
+}

--- a/pkg/engine/planner/logical/node_limit.go
+++ b/pkg/engine/planner/logical/node_limit.go
@@ -15,11 +15,11 @@ type Limit struct {
 
 	// Skip is the number of rows to skip before returning results. A value of 0
 	// means no rows are skipped.
-	Skip uint64
+	Skip uint32
 
 	// Fetch is the maximum number of rows to return. A value of 0 means all rows
 	// are returned (after applying Skip).
-	Fetch uint64
+	Fetch uint32
 }
 
 var (

--- a/pkg/engine/planner/logical/planner.go
+++ b/pkg/engine/planner/logical/planner.go
@@ -1,0 +1,228 @@
+package logical
+
+import (
+	"fmt"
+
+	"github.com/prometheus/prometheus/model/labels"
+
+	"github.com/grafana/loki/v3/pkg/engine/internal/types"
+	"github.com/grafana/loki/v3/pkg/logproto"
+	"github.com/grafana/loki/v3/pkg/logql"
+	"github.com/grafana/loki/v3/pkg/logql/log"
+	"github.com/grafana/loki/v3/pkg/logql/syntax"
+)
+
+func timestampColumnRef() *ColumnRef {
+	return &ColumnRef{Column: types.ColumnNameBuiltinTimestamp, Type: types.ColumnTypeBuiltin}
+}
+
+func logColumnRef() *ColumnRef {
+	return &ColumnRef{Column: types.ColumnNameBuiltinLog, Type: types.ColumnTypeBuiltin}
+}
+
+func convertMatcherType(t labels.MatchType) types.BinaryOp {
+	switch t {
+	case labels.MatchEqual:
+		return types.BinaryOpEq
+	case labels.MatchNotEqual:
+		return types.BinaryOpNeq
+	case labels.MatchRegexp:
+		return types.BinaryOpMatchRe
+	case labels.MatchNotRegexp:
+		return types.BinaryOpNotMatchRe
+	}
+	return types.BinaryOpInvalid
+}
+
+func convertLabelMatchers(matchers []*labels.Matcher) Value {
+	var value *BinOp
+
+	for i, matcher := range matchers {
+		expr := &BinOp{
+			Left:  &ColumnRef{Column: matcher.Name, Type: types.ColumnTypeLabel},
+			Right: LiteralString(matcher.Value),
+			Op:    convertMatcherType(matcher.Type),
+		}
+		if i == 0 {
+			value = expr
+			continue
+		}
+		value = &BinOp{
+			Left:  value,
+			Right: expr,
+			Op:    types.BinaryOpAnd,
+		}
+	}
+
+	return value
+}
+
+func convertLabelMatchType(op labels.MatchType) types.BinaryOp {
+	switch op {
+	case labels.MatchEqual:
+		return types.BinaryOpMatchStr
+	case labels.MatchNotEqual:
+		return types.BinaryOpNotMatchStr
+	case labels.MatchRegexp:
+		return types.BinaryOpMatchRe
+	case labels.MatchNotRegexp:
+		return types.BinaryOpNotMatchRe
+	default:
+		panic("invalid match type")
+	}
+}
+
+func convertLineMatchType(op log.LineMatchType) types.BinaryOp {
+	switch op {
+	case log.LineMatchEqual:
+		return types.BinaryOpMatchStr
+	case log.LineMatchNotEqual:
+		return types.BinaryOpNotMatchStr
+	case log.LineMatchRegexp:
+		return types.BinaryOpMatchRe
+	case log.LineMatchNotRegexp:
+		return types.BinaryOpNotMatchRe
+	case log.LineMatchPattern:
+		return types.BinaryOpMatchPattern
+	case log.LineMatchNotPattern:
+		return types.BinaryOpNotMatchPattern
+	default:
+		panic("invalid match type")
+	}
+}
+
+func convertLineFilter(filter syntax.LineFilter) Value {
+	return &BinOp{
+		Left:  logColumnRef(),
+		Right: LiteralString(filter.Match),
+		Op:    convertLineMatchType(filter.Ty),
+	}
+}
+
+func convertLineFilterExpr(expr *syntax.LineFilterExpr) Value {
+	if expr.Left != nil {
+		op := types.BinaryOpAnd
+		if expr.IsOrChild {
+			op = types.BinaryOpOr
+		}
+		return &BinOp{
+			Left:  convertLineFilterExpr(expr.Left),
+			Right: convertLineFilter(expr.LineFilter),
+			Op:    op,
+		}
+	}
+	return convertLineFilter(expr.LineFilter)
+}
+
+func convertLabelFilter(expr log.LabelFilterer) (Value, error) {
+	switch e := expr.(type) {
+	case *log.BinaryLabelFilter:
+		op := types.BinaryOpOr
+		if e.And == true {
+			op = types.BinaryOpAnd
+		}
+		left, err := convertLabelFilter(e.Left)
+		if err != nil {
+			return nil, err
+		}
+		right, err := convertLabelFilter(e.Right)
+		if err != nil {
+			return nil, err
+		}
+		return &BinOp{Left: left, Right: right, Op: op}, nil
+	case *log.BytesLabelFilter:
+		return nil, fmt.Errorf("not implemented: %T", e)
+	case *log.NumericLabelFilter:
+		return nil, fmt.Errorf("not implemented: %T", e)
+	case *log.DurationLabelFilter:
+		return nil, fmt.Errorf("not implemented: %T", e)
+	case *log.NoopLabelFilter:
+		return nil, fmt.Errorf("not implemented: %T", e)
+	case *log.StringLabelFilter:
+		m := e.Matcher
+		return &BinOp{
+			Left:  &ColumnRef{Column: m.Name, Type: types.ColumnTypeAmbiguous},
+			Right: LiteralString(m.Value),
+			Op:    convertLabelMatchType(m.Type),
+		}, nil
+	case *log.LineFilterLabelFilter:
+		m := e.Matcher
+		return &BinOp{
+			Left:  &ColumnRef{Column: m.Name, Type: types.ColumnTypeAmbiguous},
+			Right: LiteralString(m.Value),
+			Op:    convertLabelMatchType(m.Type),
+		}, nil
+	}
+	return nil, fmt.Errorf("invalid label filter %T", expr)
+}
+
+func convertQueryRangeToPredicate(start, end int64) Value {
+	left := &BinOp{
+		Left:  timestampColumnRef(),
+		Right: LiteralUint64(uint64(start)),
+		Op:    types.BinaryOpGte,
+	}
+	right := &BinOp{
+		Left:  timestampColumnRef(),
+		Right: LiteralUint64(uint64(end)),
+		Op:    types.BinaryOpLt,
+	}
+	return &BinOp{
+		Left:  left,
+		Right: right,
+		Op:    types.BinaryOpAnd,
+	}
+}
+
+func ConvertToLogicalPlan(params logql.Params) (*Plan, error) {
+	expr := params.GetExpression()
+
+	var selector Value
+	var predicates []Value
+
+	// TODO(chaudum): Implement a Walk function that can return an error
+	var err error
+
+	expr.Walk(func(e syntax.Expr) {
+		switch e := e.(type) {
+		case *syntax.MatchersExpr:
+			selector = convertLabelMatchers(e.Matchers())
+		case *syntax.LineFilterExpr:
+			predicates = append(predicates, convertLineFilterExpr(e))
+		case *syntax.LabelFilterExpr:
+			if val, innerErr := convertLabelFilter(e.LabelFilterer); innerErr != nil {
+				err = innerErr
+			} else {
+				predicates = append(predicates, val)
+			}
+		}
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert AST into logical plan: %w", err)
+	}
+
+	builder := NewBuilder(
+		&MakeTable{
+			Selector: selector,
+		},
+	)
+
+	for i := range predicates {
+		builder = builder.Select(predicates[i])
+	}
+
+	start := params.Start().UnixNano()
+	end := params.End().UnixNano()
+	builder = builder.Select(convertQueryRangeToPredicate(start, end))
+
+	direction := params.Direction()
+	ascending := direction == logproto.FORWARD
+	builder = builder.Sort(*timestampColumnRef(), ascending, false)
+
+	limit := params.Limit()
+	builder = builder.Limit(0, limit)
+
+	plan, err := builder.ToPlan()
+	return plan, err
+}

--- a/pkg/engine/planner/logical/planner_test.go
+++ b/pkg/engine/planner/logical/planner_test.go
@@ -1,0 +1,128 @@
+package logical
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/logproto"
+	"github.com/grafana/loki/v3/pkg/logql"
+	"github.com/grafana/loki/v3/pkg/logql/syntax"
+	"github.com/grafana/loki/v3/pkg/storage/chunk/cache/resultscache"
+)
+
+type query struct {
+	statement  string
+	start, end int64
+	direction  logproto.Direction
+	limit      uint32
+}
+
+// Direction implements logql.Params.
+func (q *query) Direction() logproto.Direction {
+	return q.direction
+}
+
+// End implements logql.Params.
+func (q *query) End() time.Time {
+	return time.Unix(0, q.end)
+}
+
+// Start implements logql.Params.
+func (q *query) Start() time.Time {
+	return time.Unix(0, q.start)
+}
+
+// Limit implements logql.Params.
+func (q *query) Limit() uint32 {
+	return q.limit
+}
+
+// QueryString implements logql.Params.
+func (q *query) QueryString() string {
+	return q.statement
+}
+
+// GetExpression implements logql.Params.
+func (q *query) GetExpression() syntax.Expr {
+	return syntax.MustParseExpr(q.statement)
+}
+
+// CachingOptions implements logql.Params.
+func (q *query) CachingOptions() resultscache.CachingOptions {
+	panic("unimplemented")
+}
+
+// GetStoreChunks implements logql.Params.
+func (q *query) GetStoreChunks() *logproto.ChunkRefGroup {
+	panic("unimplemented")
+}
+
+// Interval implements logql.Params.
+func (q *query) Interval() time.Duration {
+	panic("unimplemented")
+}
+
+// Shards implements logql.Params.
+func (q *query) Shards() []string {
+	panic("unimplemented")
+}
+
+// Step implements logql.Params.
+func (q *query) Step() time.Duration {
+	panic("unimplemented")
+}
+
+var _ logql.Params = (*query)(nil)
+
+func TestConvertAST_Success(t *testing.T) {
+	q := &query{
+		statement: `{cluster="prod", namespace=~"loki-.*"} | foo="bar" or bar="baz" |= "metric.go" |= "foo" or "bar" !~ "(a|b|c)" `,
+		start:     1000,
+		end:       2000,
+		direction: logproto.FORWARD,
+		limit:     1000,
+	}
+	logicalPlan, err := ConvertToLogicalPlan(q)
+	require.NoError(t, err)
+	t.Logf("\n%s\n", logicalPlan.String())
+
+	expected := `%1 = EQ label.cluster, "prod"
+%2 = MATCH_RE label.namespace, "loki-.*"
+%3 = AND %1, %2
+%4 = MAKE_TABLE [selector=%3]
+%5 = MATCH_STR ambiguous.foo, "bar"
+%6 = MATCH_STR ambiguous.bar, "baz"
+%7 = OR %5, %6
+%8 = SELECT %4 [predicate=%7]
+%9 = MATCH_STR builtin.log, "metric.go"
+%10 = MATCH_STR builtin.log, "foo"
+%11 = AND %9, %10
+%12 = NOT_MATCH_RE builtin.log, "(a|b|c)"
+%13 = AND %11, %12
+%14 = SELECT %8 [predicate=%13]
+%15 = GTE builtin.timestamp, 1000
+%16 = LT builtin.timestamp, 2000
+%17 = AND %15, %16
+%18 = SELECT %14 [predicate=%17]
+%19 = SORT %18 [column=builtin.timestamp, asc=true, nulls_first=false]
+%20 = limit %19 [skip=0, fetch=1000]
+RETURN %20
+`
+
+	require.Equal(t, expected, logicalPlan.String())
+}
+
+func TestConvertAST_UnsupportedFeature(t *testing.T) {
+	q := &query{
+		statement: `{cluster="prod", namespace=~"loki-.*"} |= "metric.go" | retry > 2`,
+		start:     1000,
+		end:       2000,
+		direction: logproto.FORWARD,
+		limit:     1000,
+	}
+	logicalPlan, err := ConvertToLogicalPlan(q)
+	require.Nil(t, logicalPlan)
+	require.ErrorContains(t, err, "failed to convert AST into logical plan: not implemented: *log.NumericLabelFilter")
+}

--- a/pkg/engine/planner/logical/planner_test.go
+++ b/pkg/engine/planner/logical/planner_test.go
@@ -85,7 +85,7 @@ func TestConvertAST_Success(t *testing.T) {
 		direction: logproto.FORWARD,
 		limit:     1000,
 	}
-	logicalPlan, err := ConvertToLogicalPlan(q)
+	logicalPlan, err := BuildPlan(q)
 	require.NoError(t, err)
 	t.Logf("\n%s\n", logicalPlan.String())
 
@@ -128,7 +128,7 @@ func TestConvertAST_UnsupportedFeature(t *testing.T) {
 		direction: logproto.FORWARD,
 		limit:     1000,
 	}
-	logicalPlan, err := ConvertToLogicalPlan(q)
+	logicalPlan, err := BuildPlan(q)
 	require.Nil(t, logicalPlan)
 	require.ErrorContains(t, err, "failed to convert AST into logical plan: not implemented: *log.NumericLabelFilter")
 }

--- a/pkg/engine/planner/logical/planner_test.go
+++ b/pkg/engine/planner/logical/planner_test.go
@@ -1,6 +1,7 @@
 package logical
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -92,26 +93,31 @@ func TestConvertAST_Success(t *testing.T) {
 %2 = MATCH_RE label.namespace, "loki-.*"
 %3 = AND %1, %2
 %4 = MAKE_TABLE [selector=%3]
-%5 = MATCH_STR ambiguous.foo, "bar"
-%6 = MATCH_STR ambiguous.bar, "baz"
-%7 = OR %5, %6
-%8 = SELECT %4 [predicate=%7]
-%9 = MATCH_STR builtin.log, "metric.go"
-%10 = MATCH_STR builtin.log, "foo"
-%11 = AND %9, %10
-%12 = NOT_MATCH_RE builtin.log, "(a|b|c)"
-%13 = AND %11, %12
-%14 = SELECT %8 [predicate=%13]
-%15 = GTE builtin.timestamp, 1000
-%16 = LT builtin.timestamp, 2000
-%17 = AND %15, %16
-%18 = SELECT %14 [predicate=%17]
-%19 = SORT %18 [column=builtin.timestamp, asc=true, nulls_first=false]
+%5 = SORT %4 [column=builtin.timestamp, asc=true, nulls_first=false]
+%6 = GTE builtin.timestamp, 1000
+%7 = SELECT %5 [predicate=%6]
+%8 = LT builtin.timestamp, 2000
+%9 = SELECT %7 [predicate=%8]
+%10 = MATCH_STR ambiguous.foo, "bar"
+%11 = MATCH_STR ambiguous.bar, "baz"
+%12 = OR %10, %11
+%13 = SELECT %9 [predicate=%12]
+%14 = MATCH_STR builtin.log, "metric.go"
+%15 = MATCH_STR builtin.log, "foo"
+%16 = AND %14, %15
+%17 = NOT_MATCH_RE builtin.log, "(a|b|c)"
+%18 = AND %16, %17
+%19 = SELECT %13 [predicate=%18]
 %20 = limit %19 [skip=0, fetch=1000]
 RETURN %20
 `
 
 	require.Equal(t, expected, logicalPlan.String())
+
+	var sb strings.Builder
+	PrintTree(&sb, logicalPlan.Value())
+
+	t.Logf("\n%s\n", sb.String())
 }
 
 func TestConvertAST_UnsupportedFeature(t *testing.T) {

--- a/pkg/engine/planner/physical/limit.go
+++ b/pkg/engine/planner/physical/limit.go
@@ -10,9 +10,9 @@ type Limit struct {
 	id string
 
 	// Offset specifies how many initial rows should be skipped.
-	Offset uint64
+	Offset uint32
 	// Limit specifies how many rows should be returned in total.
-	Limit uint64
+	Limit uint32
 }
 
 // ID implements the [Node] interface.


### PR DESCRIPTION
**What this PR does / why we need it**:

Minimal implementation of the logical planner that converts a parsed LogQL statement in AST form into a logical plan in SSA form.

**Special notes for your reviewer**:

The branch of this PR is based off `chaudum/physical-planner-v2` (#16891).


**Example**

The LogQL query

```
{cluster="prod", namespace=~"loki-.*"} | foo="bar" or bar="baz" |= "metric.go" |= "foo" or "bar" !~ "(a|b|c)"
```

gets converted into the logical plan

```
        %1 = EQ label.cluster, "prod"
        %2 = MATCH_RE label.namespace, "loki-.*"
        %3 = AND %1, %2
        %4 = MAKE_TABLE [selector=%3]
        %5 = SORT %4 [column=builtin.timestamp, asc=true, nulls_first=false]
        %6 = GTE builtin.timestamp, 1000
        %7 = SELECT %5 [predicate=%6]
        %8 = LT builtin.timestamp, 2000
        %9 = SELECT %7 [predicate=%8]
        %10 = MATCH_STR ambiguous.foo, "bar"
        %11 = MATCH_STR ambiguous.bar, "baz"
        %12 = OR %10, %11
        %13 = SELECT %9 [predicate=%12]
        %14 = MATCH_STR builtin.log, "metric.go"
        %15 = MATCH_STR builtin.log, "foo"
        %16 = AND %14, %15
        %17 = NOT_MATCH_RE builtin.log, "(a|b|c)"
        %18 = AND %16, %17
        %19 = SELECT %13 [predicate=%18]
        %20 = limit %19 [skip=0, fetch=1000]
        RETURN %20
```
