### PR TITLE
ci: remove weekly k-version of helm release

### DIFF
--- a/.github/workflows/helm-weekly-release-pr.yaml
+++ b/.github/workflows/helm-weekly-release-pr.yaml
@@ -35,22 +35,6 @@ jobs:
 
       - uses: imjasonh/setup-crane@v0.4
 
-      - name: Update/regenerate files for k release
-        id: update-k
-        run: |
-          bash .github/workflows/scripts/helm-weekly-release.sh -k
-
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7
-        with:
-          token: ${{ steps.get_github_app_token.outputs.token }}
-          title: "chore: release loki helm chart ${{ steps.update-k.outputs.new_chart_version }}"
-          body: Automated PR created by [helm-weekly-release-pr.yaml](https://github.com/grafana/loki/blob/main/.github/workflows/helm-weekly-release-pr.yaml)
-          commit-message: Update loki chart to ${{ steps.update-k.outputs.new_chart_version }}
-          branch: helm-chart-weekly-${{ steps.update-k.outputs.new_chart_version }}
-          base: ${{ steps.update-k.outputs.weekly }}
-          labels: helm
-
       - name: Update/regenerate files for standard release
         id: update
         run: |


### PR DESCRIPTION
**What this PR does / why we need it**:

No one is using the weekly version of the helm chart. If people want the weekly, they can just override the image value in the standard release anyway.

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [X] Documentation added
- [X] Tests updated
- [X] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [X] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [X] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
