### PR TITLE
fix: pattern ingester pushes detected level as structured metadata

### DIFF
--- a/pkg/pattern/aggregation/push_test.go
+++ b/pkg/pattern/aggregation/push_test.go
@@ -34,7 +34,7 @@ const (
 func Test_Push(t *testing.T) {
 	lbls := labels.New(labels.Label{Name: "test", Value: "test"})
 	structuredMetadata := []logproto.LabelAdapter{
-		logproto.LabelAdapter{Name: constants.LevelLabel, Value: "info"},
+		{Name: constants.LevelLabel, Value: "info"},
 	}
 
 	// create dummy loki server
@@ -146,37 +146,37 @@ func Test_Push(t *testing.T) {
 			wayBack,
 			AggregatedMetricEntry(model.TimeFromUnix(wayBack.Unix()), 1, 1, "test_service", lbls1),
 			lbls1,
-      structuredMetadata,
+			structuredMetadata,
 		)
 		p.WriteEntry(
 			then,
 			AggregatedMetricEntry(model.TimeFromUnix(then.Unix()), 2, 2, "test_service", lbls1),
 			lbls1,
-      structuredMetadata,
+			structuredMetadata,
 		)
 		p.WriteEntry(
 			now,
 			AggregatedMetricEntry(model.TimeFromUnix(now.Unix()), 3, 3, "test_service", lbls1),
 			lbls1,
-      structuredMetadata,
+			structuredMetadata,
 		)
 		p.WriteEntry(
 			wayBack,
 			AggregatedMetricEntry(model.TimeFromUnix(wayBack.Unix()), 1, 1, "test2_service", lbls2),
 			lbls2,
-      structuredMetadata,
+			structuredMetadata,
 		)
 		p.WriteEntry(
 			then,
 			AggregatedMetricEntry(model.TimeFromUnix(then.Unix()), 2, 2, "test2_service", lbls2),
 			lbls2,
-      structuredMetadata,
+			structuredMetadata,
 		)
 		p.WriteEntry(
 			now,
 			AggregatedMetricEntry(model.TimeFromUnix(now.Unix()), 3, 3, "test2_service", lbls2),
 			lbls2,
-      structuredMetadata,
+			structuredMetadata,
 		)
 
 		p.running.Add(1)

--- a/pkg/pattern/aggregation/push_test.go
+++ b/pkg/pattern/aggregation/push_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/grafana/loki/v3/pkg/logproto"
 	"github.com/grafana/loki/v3/pkg/util"
+	"github.com/grafana/loki/v3/pkg/util/constants"
 )
 
 const (
@@ -32,6 +33,9 @@ const (
 
 func Test_Push(t *testing.T) {
 	lbls := labels.New(labels.Label{Name: "test", Value: "test"})
+	structuredMetadata := []logproto.LabelAdapter{
+		logproto.LabelAdapter{Name: constants.LevelLabel, Value: "info"},
+	}
 
 	// create dummy loki server
 	responses := make(chan response, 1) // buffered not to block the response handler
@@ -62,7 +66,7 @@ func Test_Push(t *testing.T) {
 		)
 		require.NoError(t, err)
 		ts, payload := testPayload()
-		push.WriteEntry(ts, payload, lbls)
+		push.WriteEntry(ts, payload, lbls, structuredMetadata)
 		resp := <-responses
 		assertResponse(t, resp, false, labelSet("test", "test"), ts, payload)
 	})
@@ -87,7 +91,7 @@ func Test_Push(t *testing.T) {
 		)
 		require.NoError(t, err)
 		ts, payload := testPayload()
-		push.WriteEntry(ts, payload, lbls)
+		push.WriteEntry(ts, payload, lbls, structuredMetadata)
 		resp := <-responses
 		assertResponse(t, resp, true, labelSet("test", "test"), ts, payload)
 	})
@@ -142,32 +146,37 @@ func Test_Push(t *testing.T) {
 			wayBack,
 			AggregatedMetricEntry(model.TimeFromUnix(wayBack.Unix()), 1, 1, "test_service", lbls1),
 			lbls1,
+      structuredMetadata,
 		)
 		p.WriteEntry(
 			then,
 			AggregatedMetricEntry(model.TimeFromUnix(then.Unix()), 2, 2, "test_service", lbls1),
 			lbls1,
+      structuredMetadata,
 		)
 		p.WriteEntry(
 			now,
 			AggregatedMetricEntry(model.TimeFromUnix(now.Unix()), 3, 3, "test_service", lbls1),
 			lbls1,
+      structuredMetadata,
 		)
-
 		p.WriteEntry(
 			wayBack,
 			AggregatedMetricEntry(model.TimeFromUnix(wayBack.Unix()), 1, 1, "test2_service", lbls2),
 			lbls2,
+      structuredMetadata,
 		)
 		p.WriteEntry(
 			then,
 			AggregatedMetricEntry(model.TimeFromUnix(then.Unix()), 2, 2, "test2_service", lbls2),
 			lbls2,
+      structuredMetadata,
 		)
 		p.WriteEntry(
 			now,
 			AggregatedMetricEntry(model.TimeFromUnix(now.Unix()), 3, 3, "test2_service", lbls2),
 			lbls2,
+      structuredMetadata,
 		)
 
 		p.running.Add(1)

--- a/pkg/pattern/ingester_test.go
+++ b/pkg/pattern/ingester_test.go
@@ -287,7 +287,7 @@ func TestInstancePushAggregateMetrics(t *testing.T) {
 				labels.Label{Name: loghttp_push.AggregatedMetricLabel, Value: "test_service"},
 			),
 			[]logproto.LabelAdapter{
-				logproto.LabelAdapter{Name: constants.LevelLabel, Value: constants.LogLevelInfo},
+				{Name: constants.LevelLabel, Value: constants.LogLevelInfo},
 			},
 		)
 
@@ -306,7 +306,7 @@ func TestInstancePushAggregateMetrics(t *testing.T) {
 				labels.Label{Name: loghttp_push.AggregatedMetricLabel, Value: "foo_service"},
 			),
 			[]logproto.LabelAdapter{
-				logproto.LabelAdapter{Name: constants.LevelLabel, Value: constants.LogLevelError},
+				{Name: constants.LevelLabel, Value: constants.LogLevelError},
 			},
 		)
 
@@ -324,8 +324,8 @@ func TestInstancePushAggregateMetrics(t *testing.T) {
 			labels.New(
 				labels.Label{Name: loghttp_push.AggregatedMetricLabel, Value: "baz_service"},
 			),
-      []logproto.LabelAdapter{
-				logproto.LabelAdapter{Name: constants.LevelLabel, Value: constants.LogLevelError},
+			[]logproto.LabelAdapter{
+				{Name: constants.LevelLabel, Value: constants.LogLevelError},
 			},
 		)
 

--- a/pkg/pattern/ingester_test.go
+++ b/pkg/pattern/ingester_test.go
@@ -47,7 +47,7 @@ func TestInstancePushQuery(t *testing.T) {
 	}
 
 	mockWriter := &mockEntryWriter{}
-	mockWriter.On("WriteEntry", mock.Anything, mock.Anything, mock.Anything)
+	mockWriter.On("WriteEntry", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 
 	inst, err := newInstance(
 		"foo",
@@ -135,7 +135,7 @@ func TestInstancePushAggregateMetrics(t *testing.T) {
 		}
 
 		mockWriter := &mockEntryWriter{}
-		mockWriter.On("WriteEntry", mock.Anything, mock.Anything, mock.Anything)
+		mockWriter.On("WriteEntry", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 
 		inst, err := newInstance(
 			"foo",
@@ -285,8 +285,10 @@ func TestInstancePushAggregateMetrics(t *testing.T) {
 			),
 			labels.New(
 				labels.Label{Name: loghttp_push.AggregatedMetricLabel, Value: "test_service"},
-				labels.Label{Name: "level", Value: "info"},
 			),
+			[]logproto.LabelAdapter{
+				logproto.LabelAdapter{Name: constants.LevelLabel, Value: constants.LogLevelInfo},
+			},
 		)
 
 		mockWriter.AssertCalled(
@@ -302,8 +304,10 @@ func TestInstancePushAggregateMetrics(t *testing.T) {
 			),
 			labels.New(
 				labels.Label{Name: loghttp_push.AggregatedMetricLabel, Value: "foo_service"},
-				labels.Label{Name: "level", Value: "error"},
 			),
+			[]logproto.LabelAdapter{
+				logproto.LabelAdapter{Name: constants.LevelLabel, Value: constants.LogLevelError},
+			},
 		)
 
 		mockWriter.AssertCalled(
@@ -319,8 +323,10 @@ func TestInstancePushAggregateMetrics(t *testing.T) {
 			),
 			labels.New(
 				labels.Label{Name: loghttp_push.AggregatedMetricLabel, Value: "baz_service"},
-				labels.Label{Name: "level", Value: "error"},
 			),
+      []logproto.LabelAdapter{
+				logproto.LabelAdapter{Name: constants.LevelLabel, Value: constants.LogLevelError},
+			},
 		)
 
 		require.Equal(t, 0, len(inst.aggMetricsByStreamAndLevel))
@@ -331,8 +337,8 @@ type mockEntryWriter struct {
 	mock.Mock
 }
 
-func (m *mockEntryWriter) WriteEntry(ts time.Time, entry string, lbls labels.Labels) {
-	_ = m.Called(ts, entry, lbls)
+func (m *mockEntryWriter) WriteEntry(ts time.Time, entry string, lbls labels.Labels, structuredMetadata []logproto.LabelAdapter) {
+	_ = m.Called(ts, entry, lbls, structuredMetadata)
 }
 
 func (m *mockEntryWriter) Stop() {

--- a/pkg/pattern/instance.go
+++ b/pkg/pattern/instance.go
@@ -328,7 +328,10 @@ func (i *instance) writeAggregatedMetrics(
 
 	newLbls := labels.Labels{
 		labels.Label{Name: push.AggregatedMetricLabel, Value: service},
-		labels.Label{Name: "level", Value: level},
+	}
+
+	sturcturedMetadata := []logproto.LabelAdapter{
+		logproto.LabelAdapter{Name: constants.LevelLabel, Value: level},
 	}
 
 	if i.writer != nil {
@@ -336,6 +339,7 @@ func (i *instance) writeAggregatedMetrics(
 			now.Time(),
 			aggregation.AggregatedMetricEntry(now, totalBytes, totalCount, service, streamLbls),
 			newLbls,
+			sturcturedMetadata,
 		)
 
 		i.metrics.samples.WithLabelValues(service).Inc()

--- a/pkg/pattern/instance.go
+++ b/pkg/pattern/instance.go
@@ -331,7 +331,7 @@ func (i *instance) writeAggregatedMetrics(
 	}
 
 	sturcturedMetadata := []logproto.LabelAdapter{
-		logproto.LabelAdapter{Name: constants.LevelLabel, Value: level},
+		{Name: constants.LevelLabel, Value: level},
 	}
 
 	if i.writer != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Before this change, the pattern ingester pushed aggregated metrics as an indexed label. This is unnecessary as drilldown assumes all detected levels will be in structured metadata (which the indexed label will be stored as during level detection in the distributor). This is also problematic, as levels used for aggregated metrics will show up in the `/label/level/values` endpoint. For users who enforce policies around level, like all caps, then the values added by aggregated metric will be confusing. Finally, indexing the level also increases the cardinality of these streams unecessarily.

This PR changes the pattern ingester to send the detected level as structured metadata, which fixes all the problems listed above.

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [X] Documentation added
- [X] Tests updated
- [X] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [X] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [X] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
