### PR TITLE
chore(engine): Unify `Literal` and `ColumnRef` across logical and physical plan

### DIFF
--- a/pkg/engine/internal/types/column.go
+++ b/pkg/engine/internal/types/column.go
@@ -42,3 +42,15 @@ func (ct ColumnType) String() string {
 		return fmt.Sprintf("ColumnType(%d)", ct)
 	}
 }
+
+// A ColumnRef referenes a column within a table relation.
+type ColumnRef struct {
+	Column string     // Name of the column being referenced.
+	Type   ColumnType // Type of the column being referenced.
+}
+
+// Name returns the identifier of the ColumnRef, which combines the column type
+// and column name being referenced.
+func (c *ColumnRef) String() string {
+	return fmt.Sprintf("%s.%s", c.Type, c.Column)
+}

--- a/pkg/engine/internal/types/literal.go
+++ b/pkg/engine/internal/types/literal.go
@@ -1,38 +1,90 @@
 package types
 
-import "fmt"
-
-// LiteralKind denotes the kind of [Literal] value.
-type LiteralKind int
-
-// Recognized values of [LiteralKind].
-const (
-	// LiteralKindInvalid indicates an invalid literal value.
-	LiteralKindInvalid LiteralKind = iota
-
-	LiteralKindNull      // NULL literal value.
-	LiteralKindString    // String literal value.
-	LiteralKindInt64     // 64-bit integer literal value.
-	LiteralKindUint64    // 64-bit unsigned integer literal value.
-	LiteralKindByteArray // Byte array literal value.
+import (
+	"fmt"
+	"strconv"
 )
 
-// String returns the string representation of the LiteralKind.
-func (k LiteralKind) String() string {
-	switch k {
-	case LiteralKindInvalid:
-		return typeInvalid
-	case LiteralKindNull:
-		return "null"
-	case LiteralKindString:
-		return "string"
-	case LiteralKindInt64:
-		return "int64"
-	case LiteralKindUint64:
-		return "uint64"
-	case LiteralKindByteArray:
-		return "[]byte"
+// Literal is holds a value of [ValueType].
+type Literal struct {
+	Value any
+}
+
+// String returns the string representation of the literal value.
+func (e *Literal) String() string {
+	switch v := e.Value.(type) {
+	case nil:
+		return "NULL"
+	case bool:
+		return strconv.FormatBool(v)
+	case string:
+		return fmt.Sprintf(`"%s"`, v)
+	case float64:
+		return strconv.FormatFloat(v, 'f', -1, 64)
+	case int64:
+		return strconv.FormatInt(v, 10)
+	case uint64:
+		return strconv.FormatUint(v, 10)
+	case []byte:
+		return fmt.Sprintf("%v", v)
 	default:
-		return fmt.Sprintf("LiteralKind(%d)", k)
+		return "invalid"
 	}
+}
+
+// ValueType returns the kind of value represented by the literal.
+func (e *Literal) ValueType() ValueType {
+	switch e.Value.(type) {
+	case nil:
+		return ValueTypeNull
+	case bool:
+		return ValueTypeBool
+	case string:
+		return ValueTypeStr
+	case float64:
+		return ValueTypeFloat
+	case int64:
+		return ValueTypeInt
+	case uint64:
+		return ValueTypeTimestamp
+	case []byte:
+		return ValueTypeByteArray
+	default:
+		return ValueTypeInvalid
+	}
+}
+
+// Convenience function for creating a NULL literal.
+func NullLiteral() Literal {
+	return Literal{Value: nil}
+}
+
+// Convenience function for creating a bool literal.
+func BoolLiteral(v bool) Literal {
+	return Literal{Value: v}
+}
+
+// Convenience function for creating a string literal.
+func StringLiteral(v string) Literal {
+	return Literal{Value: v}
+}
+
+// Convenience function for creating a float literal.
+func FloatLiteral(v float64) Literal {
+	return Literal{Value: v}
+}
+
+// Convenience function for creating a timestamp literal.
+func TimestampLiteral(v uint64) Literal {
+	return Literal{Value: v}
+}
+
+// Convenience function for creating an integer literal.
+func IntLiteral(v int64) Literal {
+	return Literal{Value: v}
+}
+
+// Convenience function for creating a byte array literal.
+func ByteArrayLiteral(v []byte) Literal {
+	return Literal{Value: v}
 }

--- a/pkg/engine/internal/types/literal_test.go
+++ b/pkg/engine/internal/types/literal_test.go
@@ -1,0 +1,83 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLiteralRepresentation(t *testing.T) {
+	testCases := []struct {
+		name     string
+		literal  Literal
+		expected string
+	}{
+		{
+			name:     "null literal",
+			literal:  NullLiteral(),
+			expected: "NULL",
+		},
+		{
+			name:     "bool literal - true",
+			literal:  BoolLiteral(true),
+			expected: "true",
+		},
+		{
+			name:     "bool literal - false",
+			literal:  BoolLiteral(false),
+			expected: "false",
+		},
+		{
+			name:     "string literal",
+			literal:  StringLiteral("test"),
+			expected: `"test"`,
+		},
+		{
+			name:     "string literal with quotes",
+			literal:  StringLiteral(`test "quoted" string`),
+			expected: `"test "quoted" string"`,
+		},
+		{
+			name:     "float literal - integer value",
+			literal:  FloatLiteral(42.0),
+			expected: "42",
+		},
+		{
+			name:     "float literal - decimal value",
+			literal:  FloatLiteral(3.14159),
+			expected: "3.14159",
+		},
+		{
+			name:     "int literal - positive",
+			literal:  IntLiteral(123),
+			expected: "123",
+		},
+		{
+			name:     "int literal - negative",
+			literal:  IntLiteral(-456),
+			expected: "-456",
+		},
+		{
+			name:     "timestamp literal",
+			literal:  TimestampLiteral(1625097600000),
+			expected: "1625097600000",
+		},
+		{
+			name:     "byte array literal",
+			literal:  ByteArrayLiteral([]byte("hello")),
+			expected: "[104 101 108 108 111]",
+		},
+		{
+			name:     "invalid literal",
+			literal:  Literal{Value: make(chan int)}, // channels are not supported types
+			expected: "invalid",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := tc.literal.String()
+			require.Equal(t, tc.expected, result)
+		})
+	}
+}

--- a/pkg/engine/internal/types/value.go
+++ b/pkg/engine/internal/types/value.go
@@ -12,8 +12,36 @@ const (
 
 	ValueTypeNull      // NULL value.
 	ValueTypeBool      // Boolean value
+	ValueTypeFloat     // 64bit floating point value
 	ValueTypeInt       // Signed 64bit integer value
 	ValueTypeTimestamp // Unsigned 64bit integer value (nanosecond timestamp)
 	ValueTypeStr       // String value
-	ValueTypeBytes     // Byte-slice value
+	ValueTypeByteArray // Byte-slice value
+	// ValueTypeBytes
+	// ValueTypeDate
+	// ValueTypeDuration
 )
+
+// String returns the string representation of the LiteralKind.
+func (t ValueType) String() string {
+	switch t {
+	case ValueTypeInvalid:
+		return typeInvalid
+	case ValueTypeNull:
+		return "null"
+	case ValueTypeBool:
+		return "bool"
+	case ValueTypeFloat:
+		return "float"
+	case ValueTypeInt:
+		return "int"
+	case ValueTypeTimestamp:
+		return "timestamp"
+	case ValueTypeStr:
+		return "string"
+	case ValueTypeByteArray:
+		return "[]byte"
+	default:
+		return typeInvalid
+	}
+}

--- a/pkg/engine/planner/logical/column_ref.go
+++ b/pkg/engine/planner/logical/column_ref.go
@@ -1,8 +1,6 @@
 package logical
 
 import (
-	"fmt"
-
 	"github.com/grafana/loki/v3/pkg/engine/internal/types"
 	"github.com/grafana/loki/v3/pkg/engine/planner/schema"
 )
@@ -10,8 +8,7 @@ import (
 // A ColumnRef referenes a column within a table relation. ColumnRef only
 // implements [Value].
 type ColumnRef struct {
-	Column string           // Name of the column being referenced.
-	Type   types.ColumnType // Type of the column being referenced.
+	ref types.ColumnRef
 }
 
 var (
@@ -21,11 +18,18 @@ var (
 // Name returns the identifier of the ColumnRef, which combines the column type
 // and column name being referenced.
 func (c *ColumnRef) Name() string {
-	return fmt.Sprintf("%s.%s", c.Type, c.Column)
+	return c.ref.String()
 }
 
 // String returns [ColumnRef.Name].
-func (c *ColumnRef) String() string { return c.Name() }
+func (c *ColumnRef) String() string {
+	return c.ref.String()
+}
+
+// Ref returns the wrapped [types.ColumnRef].
+func (c *ColumnRef) Ref() types.ColumnRef {
+	return c.ref
+}
 
 // Schema returns the schema of the column being referenced.
 func (c *ColumnRef) Schema() *schema.Schema {
@@ -35,3 +39,12 @@ func (c *ColumnRef) Schema() *schema.Schema {
 }
 
 func (c *ColumnRef) isValue() {}
+
+func NewColumnRef(name string, ty types.ColumnType) *ColumnRef {
+	return &ColumnRef{
+		ref: types.ColumnRef{
+			Column: name,
+			Type:   ty,
+		},
+	}
+}

--- a/pkg/engine/planner/logical/format_tree_test.go
+++ b/pkg/engine/planner/logical/format_tree_test.go
@@ -25,14 +25,14 @@ func TestFormatSimpleQuery(t *testing.T) {
 		&MakeTable{
 			Selector: &BinOp{
 				Left:  &ColumnRef{Column: "app", Type: types.ColumnTypeLabel},
-				Right: LiteralString("users"),
+				Right: NewLiteral("users"),
 				Op:    types.BinaryOpEq,
 			},
 		},
 	).Select(
 		&BinOp{
 			Left:  &ColumnRef{Column: "age", Type: types.ColumnTypeMetadata},
-			Right: LiteralInt64(21),
+			Right: NewLiteral[int64](21),
 			Op:    types.BinaryOpGt,
 		},
 	)
@@ -47,7 +47,7 @@ func TestFormatSimpleQuery(t *testing.T) {
 Select
 │   └── BinOp op=GT
 │       ├── ColumnRef #metadata.age
-│       └── Literal value=21 kind=int64
+│       └── Literal value=21 kind=int
 └── MakeTable
         └── BinOp op=EQ
             ├── ColumnRef #label.app
@@ -65,14 +65,14 @@ func TestFormatSortQuery(t *testing.T) {
 		&MakeTable{
 			Selector: &BinOp{
 				Left:  &ColumnRef{Column: "app", Type: types.ColumnTypeLabel},
-				Right: LiteralString("users"),
+				Right: NewLiteral("users"),
 				Op:    types.BinaryOpEq,
 			},
 		},
 	).Select(
 		&BinOp{
 			Left:  &ColumnRef{Column: "age", Type: types.ColumnTypeMetadata},
-			Right: LiteralInt64(21),
+			Right: NewLiteral[int64](21),
 			Op:    types.BinaryOpGt,
 		},
 	).Sort(ColumnRef{Column: "age", Type: types.ColumnTypeMetadata}, true, false)
@@ -89,7 +89,7 @@ Sort direction=asc nulls=last
 └── Select
     │   └── BinOp op=GT
     │       ├── ColumnRef #metadata.age
-    │       └── Literal value=21 kind=int64
+    │       └── Literal value=21 kind=int
     └── MakeTable
             └── BinOp op=EQ
                 ├── ColumnRef #label.app

--- a/pkg/engine/planner/logical/format_tree_test.go
+++ b/pkg/engine/planner/logical/format_tree_test.go
@@ -24,14 +24,14 @@ func TestFormatSimpleQuery(t *testing.T) {
 	b := NewBuilder(
 		&MakeTable{
 			Selector: &BinOp{
-				Left:  &ColumnRef{Column: "app", Type: types.ColumnTypeLabel},
+				Left:  NewColumnRef("app", types.ColumnTypeLabel),
 				Right: NewLiteral("users"),
 				Op:    types.BinaryOpEq,
 			},
 		},
 	).Select(
 		&BinOp{
-			Left:  &ColumnRef{Column: "age", Type: types.ColumnTypeMetadata},
+			Left:  NewColumnRef("age", types.ColumnTypeMetadata),
 			Right: NewLiteral[int64](21),
 			Op:    types.BinaryOpGt,
 		},
@@ -64,18 +64,18 @@ func TestFormatSortQuery(t *testing.T) {
 	b := NewBuilder(
 		&MakeTable{
 			Selector: &BinOp{
-				Left:  &ColumnRef{Column: "app", Type: types.ColumnTypeLabel},
+				Left:  NewColumnRef("app", types.ColumnTypeLabel),
 				Right: NewLiteral("users"),
 				Op:    types.BinaryOpEq,
 			},
 		},
 	).Select(
 		&BinOp{
-			Left:  &ColumnRef{Column: "age", Type: types.ColumnTypeMetadata},
+			Left:  NewColumnRef("age", types.ColumnTypeMetadata),
 			Right: NewLiteral[int64](21),
 			Op:    types.BinaryOpGt,
 		},
-	).Sort(ColumnRef{Column: "age", Type: types.ColumnTypeMetadata}, true, false)
+	).Sort(*NewColumnRef("age", types.ColumnTypeMetadata), true, false)
 
 	var sb strings.Builder
 	PrintTree(&sb, b.Value())

--- a/pkg/engine/planner/logical/logical_test.go
+++ b/pkg/engine/planner/logical/logical_test.go
@@ -17,18 +17,18 @@ func TestPlan_String(t *testing.T) {
 	b := NewBuilder(
 		&MakeTable{
 			Selector: &BinOp{
-				Left:  &ColumnRef{Column: "app", Type: types.ColumnTypeLabel},
+				Left:  NewColumnRef("app", types.ColumnTypeLabel),
 				Right: NewLiteral("users"),
 				Op:    types.BinaryOpEq,
 			},
 		},
 	).Select(
 		&BinOp{
-			Left:  &ColumnRef{Column: "age", Type: types.ColumnTypeMetadata},
+			Left:  NewColumnRef("age", types.ColumnTypeMetadata),
 			Right: NewLiteral[int64](21),
 			Op:    types.BinaryOpGt,
 		},
-	).Sort(ColumnRef{Column: "age", Type: types.ColumnTypeMetadata}, true, false)
+	).Sort(*NewColumnRef("age", types.ColumnTypeMetadata), true, false)
 
 	// Convert to SSA
 	ssaForm, err := b.ToPlan()

--- a/pkg/engine/planner/logical/logical_test.go
+++ b/pkg/engine/planner/logical/logical_test.go
@@ -18,14 +18,14 @@ func TestPlan_String(t *testing.T) {
 		&MakeTable{
 			Selector: &BinOp{
 				Left:  &ColumnRef{Column: "app", Type: types.ColumnTypeLabel},
-				Right: LiteralString("users"),
+				Right: NewLiteral("users"),
 				Op:    types.BinaryOpEq,
 			},
 		},
 	).Select(
 		&BinOp{
 			Left:  &ColumnRef{Column: "age", Type: types.ColumnTypeMetadata},
-			Right: LiteralInt64(21),
+			Right: NewLiteral[int64](21),
 			Op:    types.BinaryOpGt,
 		},
 	).Sort(ColumnRef{Column: "age", Type: types.ColumnTypeMetadata}, true, false)

--- a/pkg/engine/planner/logical/node_literal.go
+++ b/pkg/engine/planner/logical/node_literal.go
@@ -2,7 +2,6 @@ package logical
 
 import (
 	"fmt"
-	"strconv"
 
 	"github.com/grafana/loki/v3/pkg/engine/internal/types"
 	"github.com/grafana/loki/v3/pkg/engine/planner/schema"
@@ -13,106 +12,83 @@ import (
 //
 // The zero value of a Literal is a NULL value.
 type Literal struct {
-	val any
+	val types.Literal
 }
 
 var _ Value = (*Literal)(nil)
 
-// LiteralString creates a new Literal value from a string.
-func LiteralString(v string) *Literal { return &Literal{val: v} }
-
-// LiteralInt64 creates a new Literal value from a 64-bit integer.
-func LiteralInt64(v int64) *Literal { return &Literal{val: v} }
-
-// LiteralUint64 creates a new Literal value from a 64-bit unsigned integer.
-func LiteralUint64(v uint64) *Literal { return &Literal{val: v} }
-
-// LiteralByteArray creates a new Literal value from a byte slice.
-func LiteralByteArray(v []byte) *Literal { return &Literal{val: v} }
+func NewLiteral[T any](v T) *Literal {
+	return &Literal{
+		val: types.Literal{Value: v},
+	}
+}
 
 // Kind returns the kind of value represented by the literal.
-func (lit Literal) Kind() types.LiteralKind {
-	switch lit.val.(type) {
-	case nil:
-		return types.LiteralKindNull
-	case string:
-		return types.LiteralKindString
-	case int64:
-		return types.LiteralKindInt64
-	case uint64:
-		return types.LiteralKindUint64
-	case []byte:
-		return types.LiteralKindByteArray
-	default:
-		return types.LiteralKindInvalid
-	}
+func (l Literal) Kind() types.ValueType {
+	return l.val.ValueType()
 }
 
 // Name returns the string form of the literal.
-func (lit Literal) Name() string {
-	return lit.String()
+func (l Literal) Name() string {
+	return l.val.String()
 }
 
 // String returns a printable form of the literal, even if lit is not a
-// [LiteralKindString].
-func (lit Literal) String() string {
-	switch lit.Kind() {
-	case types.LiteralKindNull:
-		return "NULL"
-	case types.LiteralKindString:
-		return strconv.Quote(lit.val.(string))
-	case types.LiteralKindInt64:
-		return strconv.FormatInt(lit.Int64(), 10)
-	case types.LiteralKindUint64:
-		return strconv.FormatUint(lit.Uint64(), 10)
-	case types.LiteralKindByteArray:
-		return fmt.Sprintf("%v", lit.val)
-	default:
-		return fmt.Sprintf("Literal(%s)", lit.Kind())
-	}
+// [ValueTypeString].
+func (l Literal) String() string {
+	return l.val.String()
 }
 
 // Value returns lit's value as untyped interface{}.
-func (lit Literal) Value() any {
-	return lit.val
+func (l Literal) Value() any {
+	return l.val.Value
 }
 
-// IsNull returns true if lit is a [LiteralKindNull] value.
-func (lit Literal) IsNull() bool {
-	return lit.Kind() == types.LiteralKindNull
+// IsNull returns true if lit is a [ValueTypeNull] value.
+func (l Literal) IsNull() bool {
+	return l.Kind() == types.ValueTypeNull
 }
 
 // Int64 returns lit's value as an int64. It panics if lit is not a
-// [LiteralKindInt64].
-func (lit Literal) Int64() int64 {
-	if expect, actual := types.LiteralKindInt64, lit.Kind(); expect != actual {
+// [ValueTypeFloat].
+func (l Literal) Float() float64 {
+	if expect, actual := types.ValueTypeFloat, l.Kind(); expect != actual {
 		panic(fmt.Sprintf("literal type is %s, not %s", actual, expect))
 	}
-	return lit.val.(int64)
+	return l.val.Value.(float64)
 }
 
-// Uint64 returns lit's value as a uint64. It panics if lit is not a
-// [LiteralKindUint64].
-func (lit Literal) Uint64() uint64 {
-	if expect, actual := types.LiteralKindUint64, lit.Kind(); expect != actual {
+// Int returns lit's value as an int64. It panics if lit is not a
+// [ValueTypeInt].
+func (l Literal) Int() int64 {
+	if expect, actual := types.ValueTypeInt, l.Kind(); expect != actual {
 		panic(fmt.Sprintf("literal type is %s, not %s", actual, expect))
 	}
-	return lit.val.(uint64)
+	return l.val.Value.(int64)
+}
+
+// Timestamp returns lit's value as a uint64. It panics if lit is not a
+// [ValueTypeTimestamp].
+func (l Literal) Timestamp() uint64 {
+	if expect, actual := types.ValueTypeTimestamp, l.Kind(); expect != actual {
+		panic(fmt.Sprintf("literal type is %s, not %s", actual, expect))
+	}
+	return l.val.Value.(uint64)
 }
 
 // ByteArray returns lit's value as a byte slice. It panics if lit is not a
-// [LiteralKindByteArray].
-func (lit Literal) ByteArray() []byte {
-	if expect, actual := types.LiteralKindByteArray, lit.Kind(); expect != actual {
+// [ValueTypeByteArray].
+func (l Literal) ByteArray() []byte {
+	if expect, actual := types.ValueTypeByteArray, l.Kind(); expect != actual {
 		panic(fmt.Sprintf("literal type is %s, not %s", actual, expect))
 	}
-	return lit.val.([]byte)
+	return l.val.Value.([]byte)
 }
 
-func (lit *Literal) Schema() *schema.Schema {
+func (l *Literal) Schema() *schema.Schema {
 	// TODO(rfratto): schema.Schema needs to be updated to be a more general
 	// "type" instead.
 	return nil
 }
 
-func (lit *Literal) isValue() {}
+func (l *Literal) isValue() {}

--- a/pkg/engine/planner/logical/planner.go
+++ b/pkg/engine/planner/logical/planner.go
@@ -82,7 +82,7 @@ func convertLabelMatchers(matchers []*labels.Matcher) Value {
 	for i, matcher := range matchers {
 		expr := &BinOp{
 			Left:  &ColumnRef{Column: matcher.Name, Type: types.ColumnTypeLabel},
-			Right: LiteralString(matcher.Value),
+			Right: NewLiteral(matcher.Value),
 			Op:    convertMatcherType(matcher.Type),
 		}
 		if i == 0 {
@@ -131,7 +131,7 @@ func convertLineFilterExpr(expr *syntax.LineFilterExpr) Value {
 func convertLineFilter(filter syntax.LineFilter) Value {
 	return &BinOp{
 		Left:  logColumnRef(),
-		Right: LiteralString(filter.Match),
+		Right: NewLiteral(filter.Match),
 		Op:    convertLineMatchType(filter.Ty),
 	}
 }
@@ -206,14 +206,14 @@ func convertLabelFilter(expr log.LabelFilterer) (Value, error) {
 		m := e.Matcher
 		return &BinOp{
 			Left:  &ColumnRef{Column: m.Name, Type: types.ColumnTypeAmbiguous},
-			Right: LiteralString(m.Value),
+			Right: NewLiteral(m.Value),
 			Op:    convertLabelMatchType(m.Type),
 		}, nil
 	case *log.LineFilterLabelFilter:
 		m := e.Matcher
 		return &BinOp{
 			Left:  &ColumnRef{Column: m.Name, Type: types.ColumnTypeAmbiguous},
-			Right: LiteralString(m.Value),
+			Right: NewLiteral(m.Value),
 			Op:    convertLabelMatchType(m.Type),
 		}, nil
 	}
@@ -224,12 +224,12 @@ func convertQueryRangeToPredicates(start, end int64) []*BinOp {
 	return []*BinOp{
 		{
 			Left:  timestampColumnRef(),
-			Right: LiteralUint64(uint64(start)),
+			Right: NewLiteral(uint64(start)),
 			Op:    types.BinaryOpGte,
 		},
 		{
 			Left:  timestampColumnRef(),
-			Right: LiteralUint64(uint64(end)),
+			Right: NewLiteral(uint64(end)),
 			Op:    types.BinaryOpLt,
 		},
 	}

--- a/pkg/engine/planner/logical/planner.go
+++ b/pkg/engine/planner/logical/planner.go
@@ -81,7 +81,7 @@ func convertLabelMatchers(matchers []*labels.Matcher) Value {
 
 	for i, matcher := range matchers {
 		expr := &BinOp{
-			Left:  &ColumnRef{Column: matcher.Name, Type: types.ColumnTypeLabel},
+			Left:  NewColumnRef(matcher.Name, types.ColumnTypeLabel),
 			Right: NewLiteral(matcher.Value),
 			Op:    convertMatcherType(matcher.Type),
 		}
@@ -156,11 +156,11 @@ func convertLineMatchType(op log.LineMatchType) types.BinaryOp {
 }
 
 func timestampColumnRef() *ColumnRef {
-	return &ColumnRef{Column: types.ColumnNameBuiltinTimestamp, Type: types.ColumnTypeBuiltin}
+	return NewColumnRef(types.ColumnNameBuiltinTimestamp, types.ColumnTypeBuiltin)
 }
 
 func logColumnRef() *ColumnRef {
-	return &ColumnRef{Column: types.ColumnNameBuiltinLog, Type: types.ColumnTypeBuiltin}
+	return NewColumnRef(types.ColumnNameBuiltinLog, types.ColumnTypeBuiltin)
 }
 
 func convertLabelMatchType(op labels.MatchType) types.BinaryOp {
@@ -205,14 +205,14 @@ func convertLabelFilter(expr log.LabelFilterer) (Value, error) {
 	case *log.StringLabelFilter:
 		m := e.Matcher
 		return &BinOp{
-			Left:  &ColumnRef{Column: m.Name, Type: types.ColumnTypeAmbiguous},
+			Left:  NewColumnRef(m.Name, types.ColumnTypeAmbiguous),
 			Right: NewLiteral(m.Value),
 			Op:    convertLabelMatchType(m.Type),
 		}, nil
 	case *log.LineFilterLabelFilter:
 		m := e.Matcher
 		return &BinOp{
-			Left:  &ColumnRef{Column: m.Name, Type: types.ColumnTypeAmbiguous},
+			Left:  NewColumnRef(m.Name, types.ColumnTypeAmbiguous),
 			Right: NewLiteral(m.Value),
 			Op:    convertLabelMatchType(m.Type),
 		}, nil

--- a/pkg/engine/planner/physical/expressions.go
+++ b/pkg/engine/planner/physical/expressions.go
@@ -139,8 +139,7 @@ func NewLiteral(value any) *LiteralExpr {
 
 // ColumnExpr is an expression that implements the [ColumnExpr] interface.
 type ColumnExpr struct {
-	Name       string
-	ColumnType types.ColumnType
+	ref types.ColumnRef
 }
 
 func (e *ColumnExpr) isExpr()       {}
@@ -149,10 +148,15 @@ func (e *ColumnExpr) isColumnExpr() {}
 // String returns the string representation of the column expression.
 // It contains of the name of the column and its type, joined by a dot (`.`).
 func (e *ColumnExpr) String() string {
-	return fmt.Sprintf("%s.%s", e.Name, e.ColumnType)
+	return e.ref.String()
 }
 
 // ID returns the type of the [ColumnExpr].
 func (e *ColumnExpr) Type() ExpressionType {
 	return ExprTypeColumn
+}
+
+// Ref returns the wrapped [types.ColumnRef].
+func (e *ColumnExpr) Ref() types.ColumnRef {
+	return e.ref
 }

--- a/pkg/engine/planner/physical/expressions.go
+++ b/pkg/engine/planner/physical/expressions.go
@@ -2,7 +2,6 @@ package physical
 
 import (
 	"fmt"
-	"strconv"
 
 	"github.com/grafana/loki/v3/pkg/engine/internal/types"
 )
@@ -111,7 +110,7 @@ func (*BinaryExpr) Type() ExpressionType {
 
 // LiteralExpr is an expression that implements the [LiteralExpression] interface.
 type LiteralExpr struct {
-	Value any
+	Value types.Literal
 }
 
 func (*LiteralExpr) isExpr()        {}
@@ -119,22 +118,7 @@ func (*LiteralExpr) isLiteralExpr() {}
 
 // String returns the string representation of the literal value.
 func (e *LiteralExpr) String() string {
-	switch v := e.Value.(type) {
-	case nil:
-		return "NULL"
-	case bool:
-		return strconv.FormatBool(v)
-	case string:
-		return fmt.Sprintf(`"%s"`, v)
-	case int64:
-		return strconv.FormatInt(v, 10)
-	case uint64:
-		return strconv.FormatUint(v, 10)
-	case []byte:
-		return fmt.Sprintf(`"%s"`, string(v))
-	default:
-		return "invalid"
-	}
+	return e.Value.String()
 }
 
 // ID returns the type of the [LiteralExpr].
@@ -144,47 +128,13 @@ func (*LiteralExpr) Type() ExpressionType {
 
 // ValueType returns the kind of value represented by the literal.
 func (e *LiteralExpr) ValueType() types.ValueType {
-	switch e.Value.(type) {
-	case nil:
-		return types.ValueTypeNull
-	case bool:
-		return types.ValueTypeBool
-	case string:
-		return types.ValueTypeStr
-	case int64:
-		return types.ValueTypeInt
-	case uint64:
-		return types.ValueTypeTimestamp
-	case []byte:
-		return types.ValueTypeBytes
-	default:
-		return types.ValueTypeInvalid
+	return e.Value.ValueType()
+}
+
+func NewLiteral(value any) *LiteralExpr {
+	return &LiteralExpr{
+		Value: types.Literal{Value: value},
 	}
-}
-
-// Convenience function for creating a NULL literal.
-func NullLiteral() *LiteralExpr {
-	return &LiteralExpr{Value: nil}
-}
-
-// Convenience function for creating a bool literal.
-func BoolLiteral(v bool) *LiteralExpr {
-	return &LiteralExpr{Value: v}
-}
-
-// Convenience function for creating a string literal.
-func StringLiteral(v string) *LiteralExpr {
-	return &LiteralExpr{Value: v}
-}
-
-// Convenience function for creating a timestamp literal.
-func TimestampLiteral(v uint64) *LiteralExpr {
-	return &LiteralExpr{Value: v}
-}
-
-// Convenience function for creating an integer literal.
-func IntLiteral(v int64) *LiteralExpr {
-	return &LiteralExpr{Value: v}
 }
 
 // ColumnExpr is an expression that implements the [ColumnExpr] interface.

--- a/pkg/engine/planner/physical/expressions_test.go
+++ b/pkg/engine/planner/physical/expressions_test.go
@@ -18,7 +18,7 @@ func TestExpressionTypes(t *testing.T) {
 			name: "UnaryExpression",
 			expr: &UnaryExpr{
 				Op:   types.UnaryOpNot,
-				Left: &LiteralExpr{Value: true},
+				Left: &LiteralExpr{Value: types.BoolLiteral(true)},
 			},
 			expected: ExprTypeUnary,
 		},
@@ -27,15 +27,13 @@ func TestExpressionTypes(t *testing.T) {
 			expr: &BinaryExpr{
 				Op:    types.BinaryOpEq,
 				Left:  &ColumnExpr{Name: "col"},
-				Right: &LiteralExpr{Value: "foo"},
+				Right: &LiteralExpr{Value: types.StringLiteral("foo")},
 			},
 			expected: ExprTypeBinary,
 		},
 		{
-			name: "LiteralExpression",
-			expr: &LiteralExpr{
-				Value: "col",
-			},
+			name:     "LiteralExpression",
+			expr:     &LiteralExpr{Value: types.StringLiteral("col")},
 			expected: ExprTypeLiteral,
 		},
 		{
@@ -58,15 +56,23 @@ func TestExpressionTypes(t *testing.T) {
 func TestLiteralExpr(t *testing.T) {
 
 	t.Run("boolean", func(t *testing.T) {
-		var expr Expression = BoolLiteral(true)
+		var expr Expression = NewLiteral(true)
 		require.Equal(t, ExprTypeLiteral, expr.Type())
 		literal, ok := expr.(LiteralExpression)
 		require.True(t, ok)
 		require.Equal(t, types.ValueTypeBool, literal.ValueType())
 	})
 
+	t.Run("float", func(t *testing.T) {
+		var expr Expression = NewLiteral(123.456789)
+		require.Equal(t, ExprTypeLiteral, expr.Type())
+		literal, ok := expr.(LiteralExpression)
+		require.True(t, ok)
+		require.Equal(t, types.ValueTypeFloat, literal.ValueType())
+	})
+
 	t.Run("integer", func(t *testing.T) {
-		var expr Expression = IntLiteral(123456789)
+		var expr Expression = NewLiteral(int64(123456789))
 		require.Equal(t, ExprTypeLiteral, expr.Type())
 		literal, ok := expr.(LiteralExpression)
 		require.True(t, ok)
@@ -74,7 +80,7 @@ func TestLiteralExpr(t *testing.T) {
 	})
 
 	t.Run("timestamp", func(t *testing.T) {
-		var expr Expression = TimestampLiteral(1741882435000000000)
+		var expr Expression = NewLiteral(uint64(1741882435000000000))
 		require.Equal(t, ExprTypeLiteral, expr.Type())
 		literal, ok := expr.(LiteralExpression)
 		require.True(t, ok)
@@ -82,7 +88,7 @@ func TestLiteralExpr(t *testing.T) {
 	})
 
 	t.Run("string", func(t *testing.T) {
-		var expr Expression = StringLiteral("loki")
+		var expr Expression = NewLiteral("loki")
 		require.Equal(t, ExprTypeLiteral, expr.Type())
 		literal, ok := expr.(LiteralExpression)
 		require.True(t, ok)

--- a/pkg/engine/planner/physical/expressions_test.go
+++ b/pkg/engine/planner/physical/expressions_test.go
@@ -26,7 +26,7 @@ func TestExpressionTypes(t *testing.T) {
 			name: "BinaryExpression",
 			expr: &BinaryExpr{
 				Op:    types.BinaryOpEq,
-				Left:  &ColumnExpr{Name: "col"},
+				Left:  &ColumnExpr{ref: types.ColumnRef{Column: "col", Type: types.ColumnTypeBuiltin}},
 				Right: &LiteralExpr{Value: types.StringLiteral("foo")},
 			},
 			expected: ExprTypeBinary,
@@ -37,10 +37,8 @@ func TestExpressionTypes(t *testing.T) {
 			expected: ExprTypeLiteral,
 		},
 		{
-			name: "ColumnExpression",
-			expr: &ColumnExpr{
-				Name: "log",
-			},
+			name:     "ColumnExpression",
+			expr:     &ColumnExpr{ref: types.ColumnRef{Column: "col", Type: types.ColumnTypeBuiltin}},
 			expected: ExprTypeColumn,
 		},
 	}

--- a/pkg/engine/planner/physical/planner.go
+++ b/pkg/engine/planner/physical/planner.go
@@ -60,10 +60,7 @@ func (p *Planner) convertPredicate(inst logical.Value) Expression {
 			Op:    inst.Op,
 		}
 	case *logical.ColumnRef:
-		return &ColumnExpr{
-			Name:       inst.Column,
-			ColumnType: inst.Type,
-		}
+		return &ColumnExpr{ref: inst.Ref()}
 	case *logical.Literal:
 		return NewLiteral(inst.Value())
 	default:
@@ -126,11 +123,8 @@ func (p *Planner) processSort(lp *logical.Sort) ([]Node, error) {
 		order = DESC
 	}
 	node := &SortMerge{
-		Column: &ColumnExpr{
-			Name:       lp.Column.Column,
-			ColumnType: lp.Column.Type,
-		},
-		Order: order,
+		Column: &ColumnExpr{ref: lp.Column.Ref()},
+		Order:  order,
 	}
 	p.plan.addNode(node)
 	children, err := p.process(lp.Table)

--- a/pkg/engine/planner/physical/planner.go
+++ b/pkg/engine/planner/physical/planner.go
@@ -65,9 +65,7 @@ func (p *Planner) convertPredicate(inst logical.Value) Expression {
 			ColumnType: inst.Type,
 		}
 	case *logical.Literal:
-		return &LiteralExpr{
-			Value: inst.Value(),
-		}
+		return NewLiteral(inst.Value())
 	default:
 		panic(fmt.Sprintf("invalid value for predicate: %T", inst))
 	}

--- a/pkg/engine/planner/physical/planner_test.go
+++ b/pkg/engine/planner/physical/planner_test.go
@@ -33,7 +33,7 @@ func TestPlanner_Convert(t *testing.T) {
 		&logical.MakeTable{
 			Selector: &logical.BinOp{
 				Left:  &logical.ColumnRef{Column: "app", Type: types.ColumnTypeLabel},
-				Right: logical.LiteralString("users"),
+				Right: logical.NewLiteral("users"),
 				Op:    types.BinaryOpEq,
 			},
 		},
@@ -47,13 +47,13 @@ func TestPlanner_Convert(t *testing.T) {
 	).Select(
 		&logical.BinOp{
 			Left:  &logical.ColumnRef{Column: "age", Type: types.ColumnTypeMetadata},
-			Right: logical.LiteralInt64(21),
+			Right: logical.NewLiteral(int64(21)),
 			Op:    types.BinaryOpGt,
 		},
 	).Select(
 		&logical.BinOp{
 			Left:  &logical.ColumnRef{Column: "timestamp", Type: types.ColumnTypeBuiltin},
-			Right: logical.LiteralUint64(1742826126000000000),
+			Right: logical.NewLiteral(uint64(1742826126000000000)),
 			Op:    types.BinaryOpLt,
 		},
 	).Limit(0, 1000)

--- a/pkg/engine/planner/physical/planner_test.go
+++ b/pkg/engine/planner/physical/planner_test.go
@@ -32,27 +32,24 @@ func TestPlanner_Convert(t *testing.T) {
 	b := logical.NewBuilder(
 		&logical.MakeTable{
 			Selector: &logical.BinOp{
-				Left:  &logical.ColumnRef{Column: "app", Type: types.ColumnTypeLabel},
+				Left:  logical.NewColumnRef("app", types.ColumnTypeLabel),
 				Right: logical.NewLiteral("users"),
 				Op:    types.BinaryOpEq,
 			},
 		},
 	).Sort(
-		logical.ColumnRef{
-			Column: "timestamp",
-			Type:   types.ColumnTypeBuiltin,
-		},
+		*logical.NewColumnRef("timestamp", types.ColumnTypeBuiltin),
 		true,
 		false,
 	).Select(
 		&logical.BinOp{
-			Left:  &logical.ColumnRef{Column: "age", Type: types.ColumnTypeMetadata},
+			Left:  logical.NewColumnRef("age", types.ColumnTypeMetadata),
 			Right: logical.NewLiteral(int64(21)),
 			Op:    types.BinaryOpGt,
 		},
 	).Select(
 		&logical.BinOp{
-			Left:  &logical.ColumnRef{Column: "timestamp", Type: types.ColumnTypeBuiltin},
+			Left:  logical.NewColumnRef("timestamp", types.ColumnTypeBuiltin),
 			Right: logical.NewLiteral(uint64(1742826126000000000)),
 			Op:    types.BinaryOpLt,
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:

Literals and column refs are used by both the logical and physical plan. However, the interfaces they need to implement are partly private (`isValue()` and `isExpression()`).
Therefore they are wrapped in their own struct that implement these interfaces.


**Special notes for your reviewer**:

PR is based off `chaudum/convert-ast-to-logical-plan` (https://github.com/grafana/loki/pull/16916).
