### PR TITLE
chore: remove loki annotations from gateway nginx deployment

### DIFF
--- a/production/helm/loki/scenarios/ingress-values.yaml
+++ b/production/helm/loki/scenarios/ingress-values.yaml
@@ -12,6 +12,9 @@ loki:
   commonConfig:
     replication_factor: 1
   useTestSchema: true
+  podAnnotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "3100"
   storage:
     bucketNames:
       chunks: chunks

--- a/production/helm/loki/scenarios/legacy-monitoring-values.yaml
+++ b/production/helm/loki/scenarios/legacy-monitoring-values.yaml
@@ -8,6 +8,9 @@ loki:
       chunks: chunks
       ruler: ruler
       admin: admin
+  podAnnotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "3100"
 read:
   replicas: 1
 write:

--- a/production/helm/loki/templates/gateway/deployment-gateway-nginx.yaml
+++ b/production/helm/loki/templates/gateway/deployment-gateway-nginx.yaml
@@ -31,9 +31,6 @@ spec:
     metadata:
       annotations:
         checksum/config: {{ include "loki.configMapOrSecretContentHash" (dict "ctx" . "name" "/gateway/configmap-gateway.yaml") }}
-        {{- with .Values.loki.podAnnotations }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
         {{- with .Values.gateway.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:

The gateway nginx deployment was applying the loki annotation values and the gateway values.
This can cause a configuration error since the gateway container is not a loki container with the same ports.

Inside Enterprise gateway we already use only the gateway annotations.

**Which issue(s) this PR fixes**:
Fixes #16918 

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
