### PR TITLE
docs: fix localhost link in logcli getting-started 

### DIFF
--- a/docs/sources/query/logcli/getting-started.md
+++ b/docs/sources/query/logcli/getting-started.md
@@ -68,7 +68,7 @@ Once you have installed logcli, you can run it in the following way:
 
 `logcli <command> [<flags>, <args> ...]`
 
-`<command>` points to one of the commands, detailed in the [command reference](http://localhost:3002/docs/loki/<LOKI_VERSION>/query/logcli/getting-started/#logcli-command-reference) below.
+`<command>` points to one of the commands, detailed in the [command reference](https://grafana.com/docs/loki/<LOKI_VERSION>/query/logcli/getting-started/#logcli-command-reference) below.
 
 `<flags>` is one of the subcommands available for each command.
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix logcli docs linking to localhost

**Which issue(s) this PR fixes**
-
**Special notes for your reviewer**:
-

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
