### PR TITLE
chore(engine): Add simple plan optimizer

### DIFF
--- a/pkg/engine/planner/physical/expressions.go
+++ b/pkg/engine/planner/physical/expressions.go
@@ -142,6 +142,15 @@ type ColumnExpr struct {
 	ref types.ColumnRef
 }
 
+func newColumnExpr(column string, ty types.ColumnType) *ColumnExpr {
+	return &ColumnExpr{
+		ref: types.ColumnRef{
+			Column: column,
+			Type:   ty,
+		},
+	}
+}
+
 func (e *ColumnExpr) isExpr()       {}
 func (e *ColumnExpr) isColumnExpr() {}
 

--- a/pkg/engine/planner/physical/limit.go
+++ b/pkg/engine/planner/physical/limit.go
@@ -9,10 +9,10 @@ import "fmt"
 type Limit struct {
 	id string
 
-	// Offset specifies how many initial rows should be skipped.
-	Offset uint32
-	// Limit specifies how many rows should be returned in total.
-	Limit uint32
+	// Skip specifies how many initial rows should be skipped.
+	Skip uint32
+	// Fetch specifies how many rows should be returned in total.
+	Fetch uint32
 }
 
 // ID implements the [Node] interface.

--- a/pkg/engine/planner/physical/optimizer.go
+++ b/pkg/engine/planner/physical/optimizer.go
@@ -1,0 +1,86 @@
+package physical
+
+import "github.com/grafana/loki/v3/pkg/engine/internal/types"
+
+type optimizer struct {
+	plan *Plan
+}
+
+var _ Visitor = (*optimizer)(nil)
+
+// VisitDataObjScan implements Visitor.
+func (o *optimizer) VisitDataObjScan(*DataObjScan) error {
+	return nil
+}
+
+// VisitFilter implements Visitor.
+func (o *optimizer) VisitFilter(node *Filter) error {
+	for i := 0; i < len(node.Predicates); i++ {
+		if ok := o.applyPredicatePushdown(node, node.Predicates[i]); ok {
+			// remove predicates that have been pushed down
+			node.Predicates = append(node.Predicates[:i], node.Predicates[i+1:]...)
+			i--
+		}
+	}
+	return nil
+}
+
+// VisitLimit implements Visitor.
+func (o *optimizer) VisitLimit(node *Limit) error {
+	o.applyLimitPushdown(node, node.Limit)
+	return nil
+}
+
+// VisitProjection implements Visitor.
+func (o *optimizer) VisitProjection(*Projection) error {
+	return nil
+}
+
+// VisitSortMerge implements Visitor.
+func (o *optimizer) VisitSortMerge(*SortMerge) error {
+	return nil
+}
+
+func (o *optimizer) applyLimitPushdown(node Node, limit uint32) bool {
+	switch node := node.(type) {
+	case *DataObjScan:
+		node.Limit = max(node.Limit, limit)
+		return true
+	}
+	for _, child := range o.plan.Children(node) {
+		if ok := o.applyLimitPushdown(child, limit); !ok {
+			return ok
+		}
+	}
+	return true
+}
+
+func (o *optimizer) applyPredicatePushdown(node Node, predicate Expression) bool {
+	switch node := node.(type) {
+	case *DataObjScan:
+		if o.canApplyPredicate(predicate) {
+			node.Predicates = append(node.Predicates, predicate)
+			return true
+		}
+		return false
+	}
+	for _, child := range o.plan.Children(node) {
+		if ok := o.applyPredicatePushdown(child, predicate); !ok {
+			return ok
+		}
+	}
+	return true
+}
+
+func (o *optimizer) canApplyPredicate(predicate Expression) bool {
+	switch pred := predicate.(type) {
+	case *BinaryExpr:
+		return o.canApplyPredicate(pred.Left) && o.canApplyPredicate(pred.Right)
+	case *ColumnExpr:
+		return pred.ColumnType == types.ColumnTypeBuiltin || pred.ColumnType == types.ColumnTypeMetadata
+	case *LiteralExpr:
+		return true
+	default:
+		return false
+	}
+}

--- a/pkg/engine/planner/physical/optimizer.go
+++ b/pkg/engine/planner/physical/optimizer.go
@@ -4,74 +4,71 @@ import (
 	"github.com/grafana/loki/v3/pkg/engine/internal/types"
 )
 
-type optimizer struct {
+type rule interface {
+	apply(Node) (Node, bool)
+}
+
+type removeNoopPredicate struct {
 	plan *Plan
 }
 
-func newOptimizer(plan *Plan) *optimizer {
-	return &optimizer{plan: plan}
+// apply implements rule.
+func (r *removeNoopPredicate) apply(node Node) (Node, bool) {
+	changed := false
+	switch node := node.(type) {
+	case *Filter:
+		if len(node.Predicates) == 0 {
+			r.plan.removeNode(node)
+			changed = true
+		}
+	}
+	return node, changed
 }
 
-func (o *optimizer) optimize(node Node) error {
-	children := o.plan.Children(node)
+var _ rule = (*removeNoopPredicate)(nil)
+
+type predicatePushdown struct {
+	plan *Plan
+}
+
+// apply implements rule.
+func (r *predicatePushdown) apply(node Node) (Node, bool) {
+	changed := false
 	switch node := node.(type) {
 	case *Filter:
 		for i := 0; i < len(node.Predicates); i++ {
-			if ok := o.applyPredicatePushdown(node, node.Predicates[i]); ok {
+			if ok := r.applyPredicatePushdown(node, node.Predicates[i]); ok {
+				changed = true
 				// remove predicates that have been pushed down
 				node.Predicates = append(node.Predicates[:i], node.Predicates[i+1:]...)
 				i--
 			}
 		}
-		if len(node.Predicates) == 0 {
-			o.plan.removeNode(node)
-		}
-	case *Limit:
-		_ = o.applyLimitPushdown(node, node.Limit)
 	}
-	for _, child := range children {
-		if err := o.optimize(child); err != nil {
-			return err
-		}
-	}
-	return nil
+	return node, changed
 }
 
-func (o *optimizer) applyLimitPushdown(node Node, limit uint32) bool {
+func (r *predicatePushdown) applyPredicatePushdown(node Node, predicate Expression) bool {
 	switch node := node.(type) {
 	case *DataObjScan:
-		node.Limit = max(node.Limit, limit)
-		return true
-	}
-	for _, child := range o.plan.Children(node) {
-		if ok := o.applyLimitPushdown(child, limit); !ok {
-			return ok
-		}
-	}
-	return true
-}
-
-func (o *optimizer) applyPredicatePushdown(node Node, predicate Expression) bool {
-	switch node := node.(type) {
-	case *DataObjScan:
-		if o.canApplyPredicate(predicate) {
+		if canApplyPredicate(predicate) {
 			node.Predicates = append(node.Predicates, predicate)
 			return true
 		}
 		return false
 	}
-	for _, child := range o.plan.Children(node) {
-		if ok := o.applyPredicatePushdown(child, predicate); !ok {
+	for _, child := range r.plan.Children(node) {
+		if ok := r.applyPredicatePushdown(child, predicate); !ok {
 			return ok
 		}
 	}
 	return true
 }
 
-func (o *optimizer) canApplyPredicate(predicate Expression) bool {
+func canApplyPredicate(predicate Expression) bool {
 	switch pred := predicate.(type) {
 	case *BinaryExpr:
-		return o.canApplyPredicate(pred.Left) && o.canApplyPredicate(pred.Right)
+		return canApplyPredicate(pred.Left) && canApplyPredicate(pred.Right)
 	case *ColumnExpr:
 		return pred.ColumnType == types.ColumnTypeBuiltin || pred.ColumnType == types.ColumnTypeMetadata
 	case *LiteralExpr:
@@ -79,4 +76,105 @@ func (o *optimizer) canApplyPredicate(predicate Expression) bool {
 	default:
 		return false
 	}
+}
+
+var _ rule = (*predicatePushdown)(nil)
+
+type limitPushdown struct {
+	plan *Plan
+}
+
+// apply implements rule.
+func (r *limitPushdown) apply(node Node) (Node, bool) {
+	switch node := node.(type) {
+	case *Limit:
+		ok := r.applyLimitPushdown(node, node.Limit)
+		return node, ok
+	}
+	return node, false
+}
+
+func (r *limitPushdown) applyLimitPushdown(node Node, limit uint32) bool {
+	switch node := node.(type) {
+	case *DataObjScan:
+		node.Limit = max(node.Limit, limit)
+		return true
+	}
+	for _, child := range r.plan.Children(node) {
+		if ok := r.applyLimitPushdown(child, limit); !ok {
+			return ok
+		}
+	}
+	return true
+}
+
+var _ rule = (*limitPushdown)(nil)
+
+type optimization struct {
+	plan  *Plan
+	name  string
+	rules []rule
+}
+
+func newOptimization(name string, plan *Plan) *optimization {
+	return &optimization{
+		name: name,
+		plan: plan,
+	}
+}
+
+func (o *optimization) withRules(rules ...rule) *optimization {
+	o.rules = append(o.rules, rules...)
+	return o
+}
+
+func (o *optimization) optimize(node Node) Node {
+	changed := true // initialize with true, so it can be used as condition in the for-loop
+	iterations := 0
+	maxIterations := 3 // TODO(chaudum): Do we really need multiple optimization passes?
+
+	for changed && iterations < maxIterations {
+		changed = false //nolint:ineffassign
+		iterations++
+
+		node, changed = o.applyRules(node)
+	}
+
+	return node
+}
+
+func (o *optimization) applyRules(node Node) (Node, bool) {
+	anyChanged := false
+
+	for _, child := range o.plan.Children(node) {
+		_, changed := o.applyRules(child)
+		if changed {
+			anyChanged = true
+		}
+	}
+
+	for _, rule := range o.rules {
+		_, changed := rule.apply(node)
+		if changed {
+			anyChanged = true
+		}
+	}
+
+	return node, anyChanged
+}
+
+type optimizer struct {
+	plan   *Plan
+	passes []*optimization
+}
+
+func newOptimizer(plan *Plan, passes []*optimization) *optimizer {
+	return &optimizer{plan: plan, passes: passes}
+}
+
+func (o *optimizer) optimize(node Node) Node {
+	for _, pass := range o.passes {
+		node = pass.optimize(node)
+	}
+	return node
 }

--- a/pkg/engine/planner/physical/optimizer.go
+++ b/pkg/engine/planner/physical/optimizer.go
@@ -23,6 +23,9 @@ func (o *optimizer) optimize(node Node) error {
 				i--
 			}
 		}
+		if len(node.Predicates) == 0 {
+			o.plan.removeNode(node)
+		}
 	case *Limit:
 		_ = o.applyLimitPushdown(node, node.Limit)
 	}

--- a/pkg/engine/planner/physical/optimizer.go
+++ b/pkg/engine/planner/physical/optimizer.go
@@ -104,6 +104,7 @@ func (r *limitPushdown) apply(node Node) bool {
 func (r *limitPushdown) applyLimitPushdown(node Node, limit uint32) bool {
 	switch node := node.(type) {
 	case *DataObjScan:
+		// In case the scan node is reachable from multiple different limit nodes, we need to take the largest limit.
 		node.Limit = max(node.Limit, limit)
 		return true
 	}

--- a/pkg/engine/planner/physical/optimizer.go
+++ b/pkg/engine/planner/physical/optimizer.go
@@ -1,6 +1,8 @@
 package physical
 
 import (
+	"slices"
+
 	"github.com/grafana/loki/v3/pkg/engine/internal/types"
 )
 
@@ -45,7 +47,7 @@ func (r *predicatePushdown) apply(node Node) bool {
 			if ok := r.applyPredicatePushdown(node, node.Predicates[i]); ok {
 				changed = true
 				// remove predicates that have been pushed down
-				node.Predicates = append(node.Predicates[:i], node.Predicates[i+1:]...)
+				node.Predicates = slices.Delete(node.Predicates, i, i+1)
 				i--
 			}
 		}

--- a/pkg/engine/planner/physical/optimizer.go
+++ b/pkg/engine/planner/physical/optimizer.go
@@ -96,7 +96,7 @@ type limitPushdown struct {
 func (r *limitPushdown) apply(node Node) bool {
 	switch node := node.(type) {
 	case *Limit:
-		return r.applyLimitPushdown(node, node.Limit)
+		return r.applyLimitPushdown(node, node.Fetch)
 	}
 	return false
 }

--- a/pkg/engine/planner/physical/optimizer.go
+++ b/pkg/engine/planner/physical/optimizer.go
@@ -22,7 +22,7 @@ func (r *removeNoopFilter) apply(node Node) bool {
 	switch node := node.(type) {
 	case *Filter:
 		if len(node.Predicates) == 0 {
-			r.plan.removeNode(node)
+			r.plan.eliminateNode(node)
 			changed = true
 		}
 	}

--- a/pkg/engine/planner/physical/optimizer.go
+++ b/pkg/engine/planner/physical/optimizer.go
@@ -135,14 +135,15 @@ func (o *optimization) withRules(rules ...rule) *optimization {
 }
 
 func (o *optimization) optimize(node Node) {
-	changed := true // initialize with true, so it can be used as condition in the for-loop
-	iterations := 0
-	maxIterations := 3 // TODO(chaudum): Do we really need multiple optimization passes?
+	iterations, maxIterations := 0, 3
 
-	for changed && iterations < maxIterations {
+	for iterations < maxIterations {
 		iterations++
 
-		changed = o.applyRules(node) //nolint:ineffassign
+		if !o.applyRules(node) {
+			// Stop immediately if an optimization pass produced no changes.
+			break
+		}
 	}
 }
 

--- a/pkg/engine/planner/physical/optimizer.go
+++ b/pkg/engine/planner/physical/optimizer.go
@@ -77,7 +77,7 @@ func canApplyPredicate(predicate Expression) bool {
 	case *BinaryExpr:
 		return canApplyPredicate(pred.Left) && canApplyPredicate(pred.Right)
 	case *ColumnExpr:
-		return pred.ColumnType == types.ColumnTypeBuiltin || pred.ColumnType == types.ColumnTypeMetadata
+		return pred.ref.Type == types.ColumnTypeBuiltin || pred.ref.Type == types.ColumnTypeMetadata
 	case *LiteralExpr:
 		return true
 	default:

--- a/pkg/engine/planner/physical/optimizer.go
+++ b/pkg/engine/planner/physical/optimizer.go
@@ -4,10 +4,14 @@ import (
 	"github.com/grafana/loki/v3/pkg/engine/internal/types"
 )
 
+// A rule is a tranformation that can be applied on a Node.
 type rule interface {
+	// apply tries to apply the transformation on the node.
+	// It returns the node and a boolean indicating whether the transformation has been applied.
 	apply(Node) (Node, bool)
 }
 
+// removeNoopPredicate is a rule that removes Filter nodes without predicates.
 type removeNoopPredicate struct {
 	plan *Plan
 }
@@ -27,6 +31,7 @@ func (r *removeNoopPredicate) apply(node Node) (Node, bool) {
 
 var _ rule = (*removeNoopPredicate)(nil)
 
+// predicatePushdown is a rule that moves down filter predicates to the scan nodes.
 type predicatePushdown struct {
 	plan *Plan
 }
@@ -80,6 +85,7 @@ func canApplyPredicate(predicate Expression) bool {
 
 var _ rule = (*predicatePushdown)(nil)
 
+// limitPushdown is a rule that moves down the limit to the scan nodes.
 type limitPushdown struct {
 	plan *Plan
 }
@@ -110,6 +116,7 @@ func (r *limitPushdown) applyLimitPushdown(node Node, limit uint32) bool {
 
 var _ rule = (*limitPushdown)(nil)
 
+// optimization represents a single optimization pass and can hold multiple rules.
 type optimization struct {
 	plan  *Plan
 	name  string
@@ -163,6 +170,7 @@ func (o *optimization) applyRules(node Node) (Node, bool) {
 	return node, anyChanged
 }
 
+// The optimizer can optimize physical plans using the provided optimization passes.
 type optimizer struct {
 	plan   *Plan
 	passes []*optimization

--- a/pkg/engine/planner/physical/optimizer_test.go
+++ b/pkg/engine/planner/physical/optimizer_test.go
@@ -14,41 +14,29 @@ func TestCanApplyPredicate(t *testing.T) {
 		want      bool
 	}{
 		{
-			predicate: IntLiteral(123),
+			predicate: NewLiteral(123),
 			want:      true,
 		},
 		{
-			predicate: &ColumnExpr{
-				Name:       "timestamp",
-				ColumnType: types.ColumnTypeBuiltin,
-			},
-			want: true,
+			predicate: newColumnExpr("timestamp", types.ColumnTypeBuiltin),
+			want:      true,
 		},
 		{
-			predicate: &ColumnExpr{
-				Name:       "foo",
-				ColumnType: types.ColumnTypeLabel,
-			},
-			want: false,
+			predicate: newColumnExpr("foo", types.ColumnTypeLabel),
+			want:      false,
 		},
 		{
 			predicate: &BinaryExpr{
-				Left: &ColumnExpr{
-					Name:       "timestamp",
-					ColumnType: types.ColumnTypeBuiltin,
-				},
-				Right: TimestampLiteral(1743424636000000000),
+				Left:  newColumnExpr("timestamp", types.ColumnTypeBuiltin),
+				Right: NewLiteral(uint64(1743424636000000000)),
 				Op:    types.BinaryOpGt,
 			},
 			want: true,
 		},
 		{
 			predicate: &BinaryExpr{
-				Left: &ColumnExpr{
-					Name:       "foo",
-					ColumnType: types.ColumnTypeLabel,
-				},
-				Right: StringLiteral("bar"),
+				Left:  newColumnExpr("foo", types.ColumnTypeLabel),
+				Right: NewLiteral("bar"),
 				Op:    types.BinaryOpEq,
 			},
 			want: false,
@@ -69,15 +57,15 @@ func dummyPlan() *Plan {
 	merge := plan.addNode(&SortMerge{id: "merge"})
 	filter1 := plan.addNode(&Filter{id: "filter1", Predicates: []Expression{
 		&BinaryExpr{
-			Left:  &ColumnExpr{ColumnType: types.ColumnTypeBuiltin, Name: "timestamp"},
-			Right: TimestampLiteral(1000000000),
+			Left:  newColumnExpr("timestamp", types.ColumnTypeBuiltin),
+			Right: NewLiteral(uint64(1000000000)),
 			Op:    types.BinaryOpGt,
 		},
 	}})
 	filter2 := plan.addNode(&Filter{id: "filter2", Predicates: []Expression{
 		&BinaryExpr{
-			Left:  &ColumnExpr{ColumnType: types.ColumnTypeBuiltin, Name: "timestamp"},
-			Right: TimestampLiteral(2000000000),
+			Left:  newColumnExpr("timestamp", types.ColumnTypeBuiltin),
+			Right: NewLiteral(uint64(2000000000)),
 			Op:    types.BinaryOpLte,
 		},
 	}})
@@ -122,25 +110,25 @@ func TestOptimizer(t *testing.T) {
 		optimized := &Plan{}
 		scan1 := optimized.addNode(&DataObjScan{id: "scan1", Predicates: []Expression{
 			&BinaryExpr{
-				Left:  &ColumnExpr{ColumnType: types.ColumnTypeBuiltin, Name: "timestamp"},
-				Right: TimestampLiteral(1000000000),
+				Left:  newColumnExpr("timestamp", types.ColumnTypeBuiltin),
+				Right: NewLiteral(uint64(1000000000)),
 				Op:    types.BinaryOpGt,
 			},
 			&BinaryExpr{
-				Left:  &ColumnExpr{ColumnType: types.ColumnTypeBuiltin, Name: "timestamp"},
-				Right: TimestampLiteral(2000000000),
+				Left:  newColumnExpr("timestamp", types.ColumnTypeBuiltin),
+				Right: NewLiteral(uint64(2000000000)),
 				Op:    types.BinaryOpLte,
 			},
 		}})
 		scan2 := optimized.addNode(&DataObjScan{id: "scan2", Predicates: []Expression{
 			&BinaryExpr{
-				Left:  &ColumnExpr{ColumnType: types.ColumnTypeBuiltin, Name: "timestamp"},
-				Right: TimestampLiteral(1000000000),
+				Left:  newColumnExpr("timestamp", types.ColumnTypeBuiltin),
+				Right: NewLiteral(uint64(1000000000)),
 				Op:    types.BinaryOpGt,
 			},
 			&BinaryExpr{
-				Left:  &ColumnExpr{ColumnType: types.ColumnTypeBuiltin, Name: "timestamp"},
-				Right: TimestampLiteral(2000000000),
+				Left:  newColumnExpr("timestamp", types.ColumnTypeBuiltin),
+				Right: NewLiteral(uint64(2000000000)),
 				Op:    types.BinaryOpLte,
 			},
 		}})
@@ -177,15 +165,15 @@ func TestOptimizer(t *testing.T) {
 		merge := optimized.addNode(&SortMerge{id: "merge"})
 		filter1 := optimized.addNode(&Filter{id: "filter1", Predicates: []Expression{
 			&BinaryExpr{
-				Left:  &ColumnExpr{ColumnType: types.ColumnTypeBuiltin, Name: "timestamp"},
-				Right: TimestampLiteral(1000000000),
+				Left:  newColumnExpr("timestamp", types.ColumnTypeBuiltin),
+				Right: NewLiteral(uint64(1000000000)),
 				Op:    types.BinaryOpGt,
 			},
 		}})
 		filter2 := optimized.addNode(&Filter{id: "filter2", Predicates: []Expression{
 			&BinaryExpr{
-				Left:  &ColumnExpr{ColumnType: types.ColumnTypeBuiltin, Name: "timestamp"},
-				Right: TimestampLiteral(2000000000),
+				Left:  newColumnExpr("timestamp", types.ColumnTypeBuiltin),
+				Right: NewLiteral(uint64(2000000000)),
 				Op:    types.BinaryOpLte,
 			},
 		}})

--- a/pkg/engine/planner/physical/optimizer_test.go
+++ b/pkg/engine/planner/physical/optimizer_test.go
@@ -3,8 +3,9 @@ package physical
 import (
 	"testing"
 
-	"github.com/grafana/loki/v3/pkg/engine/internal/types"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/engine/internal/types"
 )
 
 func TestOptimizer_canApplyPredicate(t *testing.T) {

--- a/pkg/engine/planner/physical/optimizer_test.go
+++ b/pkg/engine/planner/physical/optimizer_test.go
@@ -1,0 +1,63 @@
+package physical
+
+import (
+	"testing"
+
+	"github.com/grafana/loki/v3/pkg/engine/internal/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOptimizer_canApplyPredicate(t *testing.T) {
+	tests := []struct {
+		predicate Expression
+		want      bool
+	}{
+		{
+			predicate: IntLiteral(123),
+			want:      true,
+		},
+		{
+			predicate: &ColumnExpr{
+				Name:       "timestamp",
+				ColumnType: types.ColumnTypeBuiltin,
+			},
+			want: true,
+		},
+		{
+			predicate: &ColumnExpr{
+				Name:       "foo",
+				ColumnType: types.ColumnTypeLabel,
+			},
+			want: false,
+		},
+		{
+			predicate: &BinaryExpr{
+				Left: &ColumnExpr{
+					Name:       "timestamp",
+					ColumnType: types.ColumnTypeBuiltin,
+				},
+				Right: TimestampLiteral(1743424636000000000),
+				Op:    types.BinaryOpGt,
+			},
+			want: true,
+		},
+		{
+			predicate: &BinaryExpr{
+				Left: &ColumnExpr{
+					Name:       "foo",
+					ColumnType: types.ColumnTypeLabel,
+				},
+				Right: StringLiteral("bar"),
+				Op:    types.BinaryOpEq,
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.predicate.String(), func(t *testing.T) {
+			var o optimizer
+			got := o.canApplyPredicate(tt.predicate)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/engine/planner/physical/optimizer_test.go
+++ b/pkg/engine/planner/physical/optimizer_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/engine/internal/types"
 )
 
-func TestOptimizer_canApplyPredicate(t *testing.T) {
+func TestCanApplyPredicate(t *testing.T) {
 	tests := []struct {
 		predicate Expression
 		want      bool
@@ -56,8 +56,7 @@ func TestOptimizer_canApplyPredicate(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.predicate.String(), func(t *testing.T) {
-			var o optimizer
-			got := o.canApplyPredicate(tt.predicate)
+			got := canApplyPredicate(tt.predicate)
 			require.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/engine/planner/physical/optimizer_test.go
+++ b/pkg/engine/planner/physical/optimizer_test.go
@@ -61,3 +61,141 @@ func TestCanApplyPredicate(t *testing.T) {
 		})
 	}
 }
+
+func dummyPlan() *Plan {
+	plan := &Plan{}
+	scan1 := plan.addNode(&DataObjScan{id: "scan1"})
+	scan2 := plan.addNode(&DataObjScan{id: "scan2"})
+	merge := plan.addNode(&SortMerge{id: "merge"})
+	filter1 := plan.addNode(&Filter{id: "filter1", Predicates: []Expression{
+		&BinaryExpr{
+			Left:  &ColumnExpr{ColumnType: types.ColumnTypeBuiltin, Name: "timestamp"},
+			Right: TimestampLiteral(1000000000),
+			Op:    types.BinaryOpGt,
+		},
+	}})
+	filter2 := plan.addNode(&Filter{id: "filter2", Predicates: []Expression{
+		&BinaryExpr{
+			Left:  &ColumnExpr{ColumnType: types.ColumnTypeBuiltin, Name: "timestamp"},
+			Right: TimestampLiteral(2000000000),
+			Op:    types.BinaryOpLte,
+		},
+	}})
+	filter3 := plan.addNode(&Filter{id: "filter3", Predicates: []Expression{}})
+
+	_ = plan.addEdge(Edge{Parent: filter3, Child: filter2})
+	_ = plan.addEdge(Edge{Parent: filter2, Child: filter1})
+	_ = plan.addEdge(Edge{Parent: filter1, Child: merge})
+	_ = plan.addEdge(Edge{Parent: merge, Child: scan1})
+	_ = plan.addEdge(Edge{Parent: merge, Child: scan2})
+
+	return plan
+}
+
+func TestOptimizer(t *testing.T) {
+	t.Run("noop", func(t *testing.T) {
+		plan := dummyPlan()
+		optimizations := []*optimization{
+			newOptimization("noop", plan),
+		}
+
+		original := PrintAsTree(plan)
+		o := newOptimizer(plan, optimizations)
+		o.optimize(plan.Roots()[0])
+
+		optimized := PrintAsTree(plan)
+		require.Equal(t, original, optimized)
+	})
+
+	t.Run("filter predicate pushdown", func(t *testing.T) {
+		plan := dummyPlan()
+		optimizations := []*optimization{
+			newOptimization("predicate pushdown", plan).withRules(
+				&predicatePushdown{plan},
+			),
+		}
+
+		o := newOptimizer(plan, optimizations)
+		o.optimize(plan.Roots()[0])
+		actual := PrintAsTree(plan)
+
+		optimized := &Plan{}
+		scan1 := optimized.addNode(&DataObjScan{id: "scan1", Predicates: []Expression{
+			&BinaryExpr{
+				Left:  &ColumnExpr{ColumnType: types.ColumnTypeBuiltin, Name: "timestamp"},
+				Right: TimestampLiteral(1000000000),
+				Op:    types.BinaryOpGt,
+			},
+			&BinaryExpr{
+				Left:  &ColumnExpr{ColumnType: types.ColumnTypeBuiltin, Name: "timestamp"},
+				Right: TimestampLiteral(2000000000),
+				Op:    types.BinaryOpLte,
+			},
+		}})
+		scan2 := optimized.addNode(&DataObjScan{id: "scan2", Predicates: []Expression{
+			&BinaryExpr{
+				Left:  &ColumnExpr{ColumnType: types.ColumnTypeBuiltin, Name: "timestamp"},
+				Right: TimestampLiteral(1000000000),
+				Op:    types.BinaryOpGt,
+			},
+			&BinaryExpr{
+				Left:  &ColumnExpr{ColumnType: types.ColumnTypeBuiltin, Name: "timestamp"},
+				Right: TimestampLiteral(2000000000),
+				Op:    types.BinaryOpLte,
+			},
+		}})
+		merge := optimized.addNode(&SortMerge{id: "merge"})
+		filter1 := optimized.addNode(&Filter{id: "filter1", Predicates: []Expression{}})
+		filter2 := optimized.addNode(&Filter{id: "filter2", Predicates: []Expression{}})
+		filter3 := optimized.addNode(&Filter{id: "filter3", Predicates: []Expression{}})
+
+		_ = optimized.addEdge(Edge{Parent: filter3, Child: filter2})
+		_ = optimized.addEdge(Edge{Parent: filter2, Child: filter1})
+		_ = optimized.addEdge(Edge{Parent: filter1, Child: merge})
+		_ = optimized.addEdge(Edge{Parent: merge, Child: scan1})
+		_ = optimized.addEdge(Edge{Parent: merge, Child: scan2})
+
+		expected := PrintAsTree(optimized)
+		require.Equal(t, expected, actual)
+	})
+
+	t.Run("filter remove", func(t *testing.T) {
+		plan := dummyPlan()
+		optimizations := []*optimization{
+			newOptimization("noop filter", plan).withRules(
+				&removeNoopFilter{plan},
+			),
+		}
+
+		o := newOptimizer(plan, optimizations)
+		o.optimize(plan.Roots()[0])
+		actual := PrintAsTree(plan)
+
+		optimized := &Plan{}
+		scan1 := optimized.addNode(&DataObjScan{id: "scan1", Predicates: []Expression{}})
+		scan2 := optimized.addNode(&DataObjScan{id: "scan2", Predicates: []Expression{}})
+		merge := optimized.addNode(&SortMerge{id: "merge"})
+		filter1 := optimized.addNode(&Filter{id: "filter1", Predicates: []Expression{
+			&BinaryExpr{
+				Left:  &ColumnExpr{ColumnType: types.ColumnTypeBuiltin, Name: "timestamp"},
+				Right: TimestampLiteral(1000000000),
+				Op:    types.BinaryOpGt,
+			},
+		}})
+		filter2 := optimized.addNode(&Filter{id: "filter2", Predicates: []Expression{
+			&BinaryExpr{
+				Left:  &ColumnExpr{ColumnType: types.ColumnTypeBuiltin, Name: "timestamp"},
+				Right: TimestampLiteral(2000000000),
+				Op:    types.BinaryOpLte,
+			},
+		}})
+
+		_ = optimized.addEdge(Edge{Parent: filter2, Child: filter1})
+		_ = optimized.addEdge(Edge{Parent: filter1, Child: merge})
+		_ = optimized.addEdge(Edge{Parent: merge, Child: scan1})
+		_ = optimized.addEdge(Edge{Parent: merge, Child: scan2})
+
+		expected := PrintAsTree(optimized)
+		require.Equal(t, expected, actual)
+	})
+}

--- a/pkg/engine/planner/physical/plan.go
+++ b/pkg/engine/planner/physical/plan.go
@@ -198,6 +198,31 @@ func (p *Plan) addEdge(e Edge) error {
 	return nil
 }
 
+// removeNode removes a node from the plan and reconnects its parents to its children.
+// This maintains the graph's connectivity by creating direct edges from each parent
+// to each child of the removed node. The function also cleans up all references to
+// the node in the plan's internal data structures.
+func (p *Plan) removeNode(node Node) {
+	for _, parent := range p.Parents(node) {
+		for _, child := range p.Children(node) {
+			_ = p.addEdge(Edge{Parent: parent, Child: child})
+		}
+	}
+
+	for _, parent := range p.Parents(node) {
+		p.children[parent].remove(node)
+		p.parents[node].remove(parent)
+	}
+
+	for _, child := range p.Children(node) {
+		p.parents[child].remove(node)
+		p.children[node].remove(child)
+	}
+
+	p.nodes.remove(node)
+	delete(p.nodesByID, node.ID())
+}
+
 // Len returns the number of nodes in the graph
 func (p *Plan) Len() int {
 	return len(p.nodes)

--- a/pkg/engine/planner/physical/plan.go
+++ b/pkg/engine/planner/physical/plan.go
@@ -198,11 +198,11 @@ func (p *Plan) addEdge(e Edge) error {
 	return nil
 }
 
-// removeNode removes a node from the plan and reconnects its parents to its children.
+// eliminateNode removes a node from the plan and reconnects its parents to its children.
 // This maintains the graph's connectivity by creating direct edges from each parent
 // to each child of the removed node. The function also cleans up all references to
 // the node in the plan's internal data structures.
-func (p *Plan) removeNode(node Node) {
+func (p *Plan) eliminateNode(node Node) {
 	for _, parent := range p.Parents(node) {
 		for _, child := range p.Children(node) {
 			_ = p.addEdge(Edge{Parent: parent, Child: child})

--- a/pkg/engine/planner/physical/planner.go
+++ b/pkg/engine/planner/physical/planner.go
@@ -166,14 +166,14 @@ func (p *Planner) Optimize(plan *Plan) (*Plan, error) {
 		optimizations := []*optimization{
 			newOptimization("PredicatePushdown", plan).withRules(
 				&predicatePushdown{plan: plan},
-				&removeNoopPredicate{plan: plan},
+				&removeNoopFilter{plan: plan},
 			),
 			newOptimization("LimitPushdown", plan).withRules(
 				&limitPushdown{plan: plan},
 			),
 		}
 		optimizer := newOptimizer(plan, optimizations)
-		_ = optimizer.optimize(root)
+		optimizer.optimize(root)
 		if i == 1 {
 			return nil, errors.New("physcial plan must only have exactly one root node")
 		}

--- a/pkg/engine/planner/physical/planner.go
+++ b/pkg/engine/planner/physical/planner.go
@@ -157,3 +157,19 @@ func (p *Planner) processLimit(lp *logical.Limit) ([]Node, error) {
 	}
 	return []Node{node}, nil
 }
+
+// Optimize tries to optimize the plan by pushing down filter predicates and limits
+// to the scan nodes.
+func (p *Planner) Optimize(plan *Plan) (*Plan, error) {
+	for i, root := range plan.Roots() {
+		optimizer := optimizer{plan: plan}
+		err := plan.DFSWalk(root, &optimizer, PreOrderWalk)
+		if err != nil {
+			return nil, fmt.Errorf("failed to optimize physical plan: %w", err)
+		}
+		if i == 1 {
+			return nil, errors.New("physcial plan must only have exactly one root node")
+		}
+	}
+	return plan, nil
+}

--- a/pkg/engine/planner/physical/planner.go
+++ b/pkg/engine/planner/physical/planner.go
@@ -162,9 +162,8 @@ func (p *Planner) processLimit(lp *logical.Limit) ([]Node, error) {
 // to the scan nodes.
 func (p *Planner) Optimize(plan *Plan) (*Plan, error) {
 	for i, root := range plan.Roots() {
-		optimizer := optimizer{plan: plan}
-		err := plan.DFSWalk(root, &optimizer, PreOrderWalk)
-		if err != nil {
+		optimizer := newOptimizer(plan)
+		if err := optimizer.optimize(root); err != nil {
 			return nil, fmt.Errorf("failed to optimize physical plan: %w", err)
 		}
 		if i == 1 {

--- a/pkg/engine/planner/physical/planner.go
+++ b/pkg/engine/planner/physical/planner.go
@@ -142,8 +142,8 @@ func (p *Planner) processSort(lp *logical.Sort) ([]Node, error) {
 // Convert [logical.Limit] into one [Limit] node.
 func (p *Planner) processLimit(lp *logical.Limit) ([]Node, error) {
 	node := &Limit{
-		Offset: lp.Skip,
-		Limit:  lp.Fetch,
+		Skip:  lp.Skip,
+		Fetch: lp.Fetch,
 	}
 	p.plan.addNode(node)
 	children, err := p.process(lp.Table)

--- a/pkg/engine/planner/physical/planner_test.go
+++ b/pkg/engine/planner/physical/planner_test.go
@@ -65,8 +65,12 @@ func TestPlanner_Convert(t *testing.T) {
 		},
 	}
 	planner := NewPlanner(catalog)
+
 	physicalPlan, err := planner.Build(logicalPlan)
 	require.NoError(t, err)
+	t.Logf("Physical plan\n%s\n", PrintAsTree(physicalPlan))
 
-	t.Logf("\n%s\n", PrintAsTree(physicalPlan))
+	physicalPlan, err = planner.Optimize(physicalPlan)
+	require.NoError(t, err)
+	t.Logf("Optimized plan\n%s\n", PrintAsTree(physicalPlan))
 }

--- a/pkg/engine/planner/physical/printer.go
+++ b/pkg/engine/planner/physical/printer.go
@@ -55,8 +55,8 @@ func toTreeNode(n Node) *tree.Node {
 		}
 	case *Limit:
 		treeNode.Properties = []tree.Property{
-			tree.NewProperty("offset", false, node.Offset),
-			tree.NewProperty("limit", false, node.Limit),
+			tree.NewProperty("offset", false, node.Skip),
+			tree.NewProperty("limit", false, node.Fetch),
 		}
 	}
 	return treeNode


### PR DESCRIPTION
### What this PR does / why we need it

This PR adds a plan optimizer that pushes down limit and filter predicates to the scan node.

### Example

Plan:
```
Limit #0xc0000110f8 offset=0 limit=1000
└── Filter #0xc00039dd10
    │   └── Predicate expr=LT(timestamp.builtin, 1742826126000000000)
    └── Filter #0xc00039ddd0
        │   └── Predicate expr=GT(age.metadata, 21)
        └── SortMerge #0xc00039de60 column=timestamp.builtin order=ASC
            ├── DataObjScan #0xc00011b420 location=obj1 stream_ids=(1, 2) projections=() direction=0 limit=0
            └── DataObjScan #0xc00011b490 location=obj2 stream_ids=(3, 4) projections=() direction=0 limit=0
```

Optimized plan:
```

Limit #0xc0000110f8 offset=0 limit=1000
└── SortMerge #0xc00039de60 column=timestamp.builtin order=ASC
    ├── DataObjScan #0xc00011b420 location=obj1 stream_ids=(1, 2) projections=() direction=0 limit=1000
    │       ├── Predicate expr=LT(timestamp.builtin, 1742826126000000000)
    │       └── Predicate expr=GT(age.metadata, 21)
    └── DataObjScan #0xc00011b490 location=obj2 stream_ids=(3, 4) projections=() direction=0 limit=1000
            ├── Predicate expr=LT(timestamp.builtin, 1742826126000000000)
            └── Predicate expr=GT(age.metadata, 21)
```