### PR TITLE
fix(config): remove deprecated fields no longer supported in latest Loki

### DIFF
--- a/cmd/loki/loki-local-config.yaml
+++ b/cmd/loki/loki-local-config.yaml
@@ -25,8 +25,6 @@ query_range:
         enabled: true
         max_size_mb: 100
 
-limits_config:
-  metric_aggregation_enabled: true
 
 schema_config:
   configs:
@@ -40,8 +38,6 @@ schema_config:
 
 pattern_ingester:
   enabled: true
-  metric_aggregation:
-    loki_address: localhost:3100
 
 ruler:
   alertmanager_url: http://localhost:9093
@@ -49,9 +45,6 @@ ruler:
 frontend:
   encoding: protobuf
 
-querier:
-  engine:
-    enable_multi_variant_queries: true
 
 
 # By default, Loki will send anonymous, but uniquely-identifiable usage and configuration


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes configuration fields that are no longer valid in recent versions of Loki. These fields caused startup failures due to YAML unmarshal errors. Removing them improves compatibility and avoids confusion for users.

Specifically, this PR removes:
- `limits_config.metric_aggregation_enabled`
- `pattern_ingester.metric_aggregation`
- `querier.engine.enable_multi_variant_queries`

**Which issue(s) this PR fixes**:
Fixes #16990 

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
