### PR TITLE
fix: revert remove colons from level detection

### DIFF
--- a/pkg/distributor/field_detection.go
+++ b/pkg/distributor/field_detection.go
@@ -309,21 +309,22 @@ func isJSON(line string) bool {
 }
 
 func detectLevelFromLogLine(log string) string {
-	if strings.Contains(log, "info") || strings.Contains(log, "INFO") {
+	if strings.Contains(log, "info:") || strings.Contains(log, "INFO:") ||
+		strings.Contains(log, "info") || strings.Contains(log, "INFO") {
 		return constants.LogLevelInfo
 	}
-	if strings.Contains(log, "err") || strings.Contains(log, "ERR") ||
+	if strings.Contains(log, "err:") || strings.Contains(log, "ERR:") ||
 		strings.Contains(log, "error") || strings.Contains(log, "ERROR") {
 		return constants.LogLevelError
 	}
-	if strings.Contains(log, "warn") || strings.Contains(log, "WARN") ||
+	if strings.Contains(log, "warn:") || strings.Contains(log, "WARN:") ||
 		strings.Contains(log, "warning") || strings.Contains(log, "WARNING") {
 		return constants.LogLevelWarn
 	}
-	if strings.Contains(log, "CRITICAL") || strings.Contains(log, "critical") {
+	if strings.Contains(log, "CRITICAL:") || strings.Contains(log, "critical:") {
 		return constants.LogLevelCritical
 	}
-	if strings.Contains(log, "debug") || strings.Contains(log, "DEBUG") {
+	if strings.Contains(log, "debug:") || strings.Contains(log, "DEBUG:") {
 		return constants.LogLevelDebug
 	}
 	return constants.LogLevelUnknown

--- a/pkg/distributor/field_detection_test.go
+++ b/pkg/distributor/field_detection_test.go
@@ -277,41 +277,6 @@ func Test_detectLogLevelFromLogEntry(t *testing.T) {
 			},
 			expectedLogLevel: constants.LogLevelInfo,
 		},
-		{
-			name: "unstructured info log line",
-			entry: logproto.Entry{
-				Line: `[INFO] unstructured info log line`,
-			},
-			expectedLogLevel: constants.LogLevelInfo,
-		},
-		{
-			name: "unstructured error log line",
-			entry: logproto.Entry{
-				Line: `[ERROR] unstructured error log line`,
-			},
-			expectedLogLevel: constants.LogLevelError,
-		},
-		{
-			name: "unstructured warn log line",
-			entry: logproto.Entry{
-				Line: `[WARN] unstructured warn log line`,
-			},
-			expectedLogLevel: constants.LogLevelWarn,
-		},
-		{
-			name: "unstructured critical log line",
-			entry: logproto.Entry{
-				Line: `[CRITICAL] unstructured critical log line`,
-			},
-			expectedLogLevel: constants.LogLevelCritical,
-		},
-		{
-			name: "unstructured debug log line",
-			entry: logproto.Entry{
-				Line: `[DEBUG] unstructured debug log line`,
-			},
-			expectedLogLevel: constants.LogLevelDebug,
-		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			detectedLogLevel := ld.detectLogLevelFromLogEntry(tc.entry, logproto.FromLabelAdaptersToLabels(tc.entry.StructuredMetadata))


### PR DESCRIPTION
Reverts grafana/loki#16764

This does detect all loglines containing `referrer` as `error` log lines.