### PR TITLE
chore(engine): Add printer for Mermaid diagram format

### DIFF
--- a/pkg/engine/planner/internal/tree/mermaid.go
+++ b/pkg/engine/planner/internal/tree/mermaid.go
@@ -1,0 +1,95 @@
+package tree
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+type MermaidDiagram struct {
+	w io.Writer
+}
+
+func NewMermaid(w io.Writer) *MermaidDiagram {
+	return &MermaidDiagram{w: w}
+}
+
+func (m *MermaidDiagram) Write(node *Node) error {
+	if node == nil {
+		return nil
+	}
+
+	// Write the Mermaid graph header
+	if _, err := io.WriteString(m.w, "graph TB\n"); err != nil {
+		return err
+	}
+
+	// Start traversal from the root
+	return m.traverse(node, "", "==>")
+}
+
+func (m *MermaidDiagram) traverse(n *Node, parentID string, connector string) error {
+	// Use a recursive function to traverse the tree
+	if n == nil {
+		return nil
+	}
+
+	// Create a node ID
+	nodeID := uuid.NewString()
+	if nodeID == "" {
+		nodeID = fmt.Sprintf("%p", n)
+	}
+
+	// Write the node definition
+	nodeDef := fmt.Sprintf("  %s[\"<b>%s</b> <i>%s</i> <br>%s\"]\n", nodeID, safeString(n.Name), safeString(n.ID), formatProperties(n.Properties))
+	if _, err := io.WriteString(m.w, nodeDef); err != nil {
+		return err
+	}
+
+	for _, comment := range n.Comments {
+		if err := m.traverse(comment, nodeID, "-.-"); err != nil {
+			return err
+		}
+	}
+
+	// If there's a parent, create an edge
+	if parentID != "" {
+		edge := fmt.Sprintf("  %s %s %s\n", parentID, connector, nodeID)
+		if _, err := io.WriteString(m.w, edge); err != nil {
+			return err
+		}
+	}
+
+	// Traverse children
+	for _, child := range n.Children {
+		if err := m.traverse(child, nodeID, connector); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func formatProperties(properties []Property) string {
+	var sb strings.Builder
+	for i, prop := range properties {
+		_, _ = sb.WriteString(prop.Key)
+		_, _ = sb.WriteString("=")
+		for ii, val := range prop.Values {
+			fmt.Fprintf(&sb, "%s", safeString(fmt.Sprintf("%v", val)))
+			if ii < len(prop.Values)-1 {
+				_, _ = sb.WriteString(",")
+			}
+		}
+		if i < len(properties)-1 {
+			_, _ = sb.WriteString("<br>")
+		}
+	}
+	return sb.String()
+}
+
+func safeString(s string) string {
+	return strings.ReplaceAll(s, `"`, `&quot;`)
+}

--- a/pkg/engine/planner/internal/tree/mermaid_test.go
+++ b/pkg/engine/planner/internal/tree/mermaid_test.go
@@ -1,0 +1,19 @@
+package tree
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMermaidDiagram_Write(t *testing.T) {
+	root := dummyPlan()
+
+	var sb strings.Builder
+	m := NewMermaid(&sb)
+	err := m.Write(root)
+	require.NoError(t, err)
+
+	t.Logf("\n%s\n", sb.String())
+}

--- a/pkg/engine/planner/internal/tree/printer.go
+++ b/pkg/engine/planner/internal/tree/printer.go
@@ -12,75 +12,6 @@ const (
 	symLastConn = "└── "
 )
 
-// Property represents a property of a [Node]. It is a key-value-pair, where
-// the value is either a single value or a list of values.
-// When the value is a multi-value, the field IsMultiValue needs to be set to
-// `true`.
-// A single-value property is represented as `key=value` and a multi-value
-// property as `key=(value1, value2, ...)`.
-type Property struct {
-	// Key is the name of the property.
-	Key string
-	// Values holds the value(s) of the property.
-	Values []any
-	// IsMultiValue marks whether the property is a multi-value property.
-	IsMultiValue bool
-}
-
-// NewProperty creates a new Property with the specified key, multi-value flag, and values.
-// The multi parameter determines if the property should be treated as a multi-value property.
-func NewProperty(key string, multi bool, values ...any) Property {
-	return Property{
-		Key:          key,
-		Values:       values,
-		IsMultiValue: multi,
-	}
-}
-
-// Node represents a node in a tree structure that can be traversed and printed
-// by the [Printer].
-// It allows for building hierarchical representations of data where each node
-// can have multiple properties and multiple children.
-type Node struct {
-	// ID is a unique identifier for the node.
-	ID string
-	// Name is the display name of the node.
-	Name string
-	// Properties contains a list of key-value properties associated with the node.
-	Properties []Property
-	// Children are child nodes of the node.
-	Children []*Node
-	// Comments, like Children, are child nodes of the node, with the difference
-	// that comments are indented a level deeper than children. A common use-case
-	// for comments are tree-style properties of a node, such as expressions of a
-	// physical plan node.
-	Comments []*Node
-}
-
-// NewNode creates a new node with the given name, unique identifier and
-// properties.
-func NewNode(name, id string, properties ...Property) *Node {
-	return &Node{
-		ID:         id,
-		Name:       name,
-		Properties: properties,
-	}
-}
-
-// AddChild creates a new node with the given name, unique identifier, and properties
-// and adds it to the parent node.
-func (n *Node) AddChild(name, id string, properties []Property) *Node {
-	child := NewNode(name, id, properties...)
-	n.Children = append(n.Children, child)
-	return child
-}
-
-func (n *Node) AddComment(name, id string, properties []Property) *Node {
-	node := NewNode(name, id, properties...)
-	n.Comments = append(n.Comments, node)
-	return node
-}
-
 // Printer is used for writing the hierarchical representation of a tree
 // of [Node]s.
 type Printer struct {
@@ -111,8 +42,9 @@ func (tp *Printer) printNode(node *Node) {
 	tp.w.WriteString(node.Name)
 
 	if node.ID != "" {
-		tp.w.WriteString(" #")
+		tp.w.WriteString(" <")
 		tp.w.WriteString(node.ID)
+		tp.w.WriteString(">")
 	}
 
 	if len(node.Properties) == 0 {

--- a/pkg/engine/planner/internal/tree/printer_test.go
+++ b/pkg/engine/planner/internal/tree/printer_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestPrinter(t *testing.T) {
+func dummyPlan() *Node {
 	root := NewNode("Root", "")
 	lvl1 := root.AddChild("Merge", "foo", []Property{
 		{Key: "key_a", Values: []any{"value_a"}, IsMultiValue: true},
@@ -28,6 +28,11 @@ func TestPrinter(t *testing.T) {
 		{Key: "selector", Values: []any{`{env="dev", region=".+"}`}},
 	})
 	_ = lvl1.AddChild("Scan", "baz", []Property{})
+	return root
+}
+
+func TestPrinter(t *testing.T) {
+	root := dummyPlan()
 
 	b := &strings.Builder{}
 	p := NewPrinter(b)
@@ -36,16 +41,16 @@ func TestPrinter(t *testing.T) {
 	t.Log("\n" + b.String())
 	expected := `
 Root
-└── Merge #foo key_a=(value_a) key_b=(value_b, value_c)
-    ├── Product #foobar relations=(foo, bar)
-    │   │   ├── Relation #foo
-    │   │   │   ├── Shard #0
-    │   │   │   ├── Shard #1
-    │   │   │   └── Shard #2
-    │   │   └── Relation #bar
-    │   ├── Scan #foo selector={env="prod", region=".+"}
-    │   └── Scan #bar selector={env="dev", region=".+"}
-    └── Scan #baz
+└── Merge <foo> key_a=(value_a) key_b=(value_b, value_c)
+    ├── Product <foobar> relations=(foo, bar)
+    │   │   ├── Relation <foo>
+    │   │   │   ├── Shard <0>
+    │   │   │   ├── Shard <1>
+    │   │   │   └── Shard <2>
+    │   │   └── Relation <bar>
+    │   ├── Scan <foo> selector={env="prod", region=".+"}
+    │   └── Scan <bar> selector={env="dev", region=".+"}
+    └── Scan <baz>
 `
 	require.Equal(t, expected, "\n"+b.String())
 }

--- a/pkg/engine/planner/internal/tree/tree.go
+++ b/pkg/engine/planner/internal/tree/tree.go
@@ -1,0 +1,70 @@
+package tree
+
+// Property represents a property of a [Node]. It is a key-value-pair, where
+// the value is either a single value or a list of values.
+// When the value is a multi-value, the field IsMultiValue needs to be set to
+// `true`.
+// A single-value property is represented as `key=value` and a multi-value
+// property as `key=(value1, value2, ...)`.
+type Property struct {
+	// Key is the name of the property.
+	Key string
+	// Values holds the value(s) of the property.
+	Values []any
+	// IsMultiValue marks whether the property is a multi-value property.
+	IsMultiValue bool
+}
+
+// NewProperty creates a new Property with the specified key, multi-value flag, and values.
+// The multi parameter determines if the property should be treated as a multi-value property.
+func NewProperty(key string, multi bool, values ...any) Property {
+	return Property{
+		Key:          key,
+		Values:       values,
+		IsMultiValue: multi,
+	}
+}
+
+// Node represents a node in a tree structure that can be traversed and printed
+// by the [Printer].
+// It allows for building hierarchical representations of data where each node
+// can have multiple properties and multiple children.
+type Node struct {
+	// ID is a unique identifier for the node.
+	ID string
+	// Name is the display name of the node.
+	Name string
+	// Properties contains a list of key-value properties associated with the node.
+	Properties []Property
+	// Children are child nodes of the node.
+	Children []*Node
+	// Comments, like Children, are child nodes of the node, with the difference
+	// that comments are indented a level deeper than children. A common use-case
+	// for comments are tree-style properties of a node, such as expressions of a
+	// physical plan node.
+	Comments []*Node
+}
+
+// NewNode creates a new node with the given name, unique identifier and
+// properties.
+func NewNode(name, id string, properties ...Property) *Node {
+	return &Node{
+		ID:         id,
+		Name:       name,
+		Properties: properties,
+	}
+}
+
+// AddChild creates a new node with the given name, unique identifier, and properties
+// and adds it to the parent node.
+func (n *Node) AddChild(name, id string, properties []Property) *Node {
+	child := NewNode(name, id, properties...)
+	n.Children = append(n.Children, child)
+	return child
+}
+
+func (n *Node) AddComment(name, id string, properties []Property) *Node {
+	node := NewNode(name, id, properties...)
+	n.Comments = append(n.Comments, node)
+	return node
+}

--- a/pkg/engine/planner/logical/format_tree.go
+++ b/pkg/engine/planner/logical/format_tree.go
@@ -44,20 +44,26 @@ func (t *treeFormatter) convert(value Value) *tree.Node {
 }
 
 func (t *treeFormatter) convertMakeTable(ast *MakeTable) *tree.Node {
-	node := tree.NewNode("MakeTable", "")
+	node := tree.NewNode("MAKETABLE", ast.Name(),
+		tree.NewProperty("selector", false, ast.Selector.String()),
+	)
 	node.Comments = append(node.Children, t.convert(ast.Selector))
 	return node
 }
 
 func (t *treeFormatter) convertSelect(ast *Select) *tree.Node {
-	node := tree.NewNode("Select", "")
+	node := tree.NewNode("SELECT", ast.Name(),
+		tree.NewProperty("table", false, ast.Table.Name()),
+		tree.NewProperty("predicate", false, ast.Predicate.Name()),
+	)
 	node.Comments = append(node.Comments, t.convert(ast.Predicate))
 	node.Children = append(node.Children, t.convert(ast.Table))
 	return node
 }
 
 func (t *treeFormatter) convertLimit(ast *Limit) *tree.Node {
-	node := tree.NewNode("Limit", "",
+	node := tree.NewNode("LIMIT", ast.Name(),
+		tree.NewProperty("table", false, ast.Table.Name()),
 		tree.NewProperty("offset", false, ast.Skip),
 		tree.NewProperty("fetch", false, ast.Fetch),
 	)
@@ -76,7 +82,9 @@ func (t *treeFormatter) convertSort(ast *Sort) *tree.Node {
 		nullsPosition = "first"
 	}
 
-	node := tree.NewNode("Sort", "",
+	node := tree.NewNode("SORT", ast.Name(),
+		tree.NewProperty("table", false, ast.Table.Name()),
+		tree.NewProperty("column", false, ast.Column.Name()),
 		tree.NewProperty("direction", false, direction),
 		tree.NewProperty("nulls", false, nullsPosition),
 	)
@@ -86,20 +94,30 @@ func (t *treeFormatter) convertSort(ast *Sort) *tree.Node {
 }
 
 func (t *treeFormatter) convertUnaryOp(expr *UnaryOp) *tree.Node {
-	node := tree.NewNode("UnaryOp", "", tree.NewProperty("op", false, expr.Op.String()))
+	node := tree.NewNode("UnaryOp", expr.Name(),
+		tree.NewProperty("op", false, expr.Op.String()),
+		tree.NewProperty("left", false, expr.Value.Name()),
+	)
 	node.Children = append(node.Children, t.convert(expr.Value))
 	return node
 }
 
 func (t *treeFormatter) convertBinOp(expr *BinOp) *tree.Node {
-	node := tree.NewNode("BinOp", "", tree.NewProperty("op", false, expr.Op.String()))
+	node := tree.NewNode("BinOp", expr.Name(),
+		tree.NewProperty("op", false, expr.Op.String()),
+		tree.NewProperty("left", false, expr.Left.Name()),
+		tree.NewProperty("right", false, expr.Right.Name()),
+	)
 	node.Children = append(node.Children, t.convert(expr.Left))
 	node.Children = append(node.Children, t.convert(expr.Right))
 	return node
 }
 
 func (t *treeFormatter) convertColumnRef(expr *ColumnRef) *tree.Node {
-	return tree.NewNode("ColumnRef", expr.Name())
+	return tree.NewNode("ColumnRef", "",
+		tree.NewProperty("column", false, expr.Ref().Column),
+		tree.NewProperty("type", false, expr.Ref().Type),
+	)
 }
 
 func (t *treeFormatter) convertLiteral(expr *Literal) *tree.Node {

--- a/pkg/engine/planner/logical/logical_test.go
+++ b/pkg/engine/planner/logical/logical_test.go
@@ -39,9 +39,9 @@ func TestPlan_String(t *testing.T) {
 
 	// Define expected output
 	exp := `
-%1 = EQ label.app, "users" 
-%2 = MAKE_TABLE [selector=%1] 
-%3 = GT metadata.age, 21 
+%1 = EQ label.app "users" 
+%2 = MAKETABLE [selector=%1] 
+%3 = GT metadata.age 21 
 %4 = SELECT %2 [predicate=%3] 
 %5 = SORT %4 [column=metadata.age, asc=true, nulls_first=false]
 RETURN %5 

--- a/pkg/engine/planner/logical/node_binop.go
+++ b/pkg/engine/planner/logical/node_binop.go
@@ -26,12 +26,12 @@ func (b *BinOp) Name() string {
 	if b.id != "" {
 		return b.id
 	}
-	return fmt.Sprintf("<%p>", b)
+	return fmt.Sprintf("%p", b)
 }
 
 // String returns the disassembled SSA form of the BinOp instruction.
 func (b *BinOp) String() string {
-	return fmt.Sprintf("%s %s, %s", b.Op, b.Left.Name(), b.Right.Name())
+	return fmt.Sprintf("%s %s %s", b.Op, b.Left.Name(), b.Right.Name())
 }
 
 // Schema returns the schema of the BinOp operation.

--- a/pkg/engine/planner/logical/node_limit.go
+++ b/pkg/engine/planner/logical/node_limit.go
@@ -32,14 +32,14 @@ func (l *Limit) Name() string {
 	if l.id != "" {
 		return l.id
 	}
-	return fmt.Sprintf("<%p>", l)
+	return fmt.Sprintf("%p", l)
 }
 
 // String returns the disassembled SSA form of the Limit instruction.
 func (l *Limit) String() string {
 	// TODO(rfratto): change the type of l.Input to [Value] so we can use
 	// s.Value.Name here.
-	return fmt.Sprintf("limit %v [skip=%d, fetch=%d]", l.Table.Name(), l.Skip, l.Fetch)
+	return fmt.Sprintf("LIMIT %v [skip=%d, fetch=%d]", l.Table.Name(), l.Skip, l.Fetch)
 }
 
 // Schema returns the schema of the limit operation.

--- a/pkg/engine/planner/logical/node_maketable.go
+++ b/pkg/engine/planner/logical/node_maketable.go
@@ -29,12 +29,12 @@ func (t *MakeTable) Name() string {
 	if t.id != "" {
 		return t.id
 	}
-	return fmt.Sprintf("<%p>", t)
+	return fmt.Sprintf("%p", t)
 }
 
 // String returns the disassembled SSA form of the MakeTable instruction.
 func (t *MakeTable) String() string {
-	return fmt.Sprintf("MAKE_TABLE [selector=%s]", t.Selector.Name())
+	return fmt.Sprintf("MAKETABLE [selector=%s]", t.Selector.Name())
 }
 
 // Schema returns the schema of the table.

--- a/pkg/engine/planner/logical/node_return.go
+++ b/pkg/engine/planner/logical/node_return.go
@@ -1,5 +1,7 @@
 package logical
 
+import "fmt"
+
 // The Return instruction yields a value to return from a plan. Return
 // implements [Instruction].
 type Return struct {
@@ -8,7 +10,7 @@ type Return struct {
 
 // String returns the disassembled SSA form of r.
 func (r *Return) String() string {
-	return "RETURN " + r.Value.Name()
+	return fmt.Sprintf("RETURN %s", r.Value.Name())
 }
 
 func (r *Return) isInstruction() {}

--- a/pkg/engine/planner/logical/node_select.go
+++ b/pkg/engine/planner/logical/node_select.go
@@ -29,7 +29,7 @@ func (s *Select) Name() string {
 	if s.id != "" {
 		return s.id
 	}
-	return fmt.Sprintf("<%p>", s)
+	return fmt.Sprintf("%p", s)
 }
 
 // String returns the disassembled SSA form of the Select instruction.

--- a/pkg/engine/planner/logical/node_sort.go
+++ b/pkg/engine/planner/logical/node_sort.go
@@ -32,7 +32,7 @@ func (s *Sort) Name() string {
 	if s.id != "" {
 		return s.id
 	}
-	return fmt.Sprintf("<%p>", s)
+	return fmt.Sprintf("%p", s)
 }
 
 // String returns the disassembled SSA form of the Sort instruction.

--- a/pkg/engine/planner/logical/node_unaryop.go
+++ b/pkg/engine/planner/logical/node_unaryop.go
@@ -26,7 +26,7 @@ func (u *UnaryOp) Name() string {
 	if u.id != "" {
 		return u.id
 	}
-	return fmt.Sprintf("<%p>", u)
+	return fmt.Sprintf("%p", u)
 }
 
 // String returns the disassembled SSA form of the UnaryOp instruction.

--- a/pkg/engine/planner/logical/planner_test.go
+++ b/pkg/engine/planner/logical/planner_test.go
@@ -89,26 +89,26 @@ func TestConvertAST_Success(t *testing.T) {
 	require.NoError(t, err)
 	t.Logf("\n%s\n", logicalPlan.String())
 
-	expected := `%1 = EQ label.cluster, "prod"
-%2 = MATCH_RE label.namespace, "loki-.*"
-%3 = AND %1, %2
-%4 = MAKE_TABLE [selector=%3]
+	expected := `%1 = EQ label.cluster "prod"
+%2 = MATCH_RE label.namespace "loki-.*"
+%3 = AND %1 %2
+%4 = MAKETABLE [selector=%3]
 %5 = SORT %4 [column=builtin.timestamp, asc=true, nulls_first=false]
-%6 = GTE builtin.timestamp, 1000
+%6 = GTE builtin.timestamp 1000
 %7 = SELECT %5 [predicate=%6]
-%8 = LT builtin.timestamp, 2000
+%8 = LT builtin.timestamp 2000
 %9 = SELECT %7 [predicate=%8]
-%10 = MATCH_STR ambiguous.foo, "bar"
-%11 = MATCH_STR ambiguous.bar, "baz"
-%12 = OR %10, %11
+%10 = MATCH_STR ambiguous.foo "bar"
+%11 = MATCH_STR ambiguous.bar "baz"
+%12 = OR %10 %11
 %13 = SELECT %9 [predicate=%12]
-%14 = MATCH_STR builtin.log, "metric.go"
-%15 = MATCH_STR builtin.log, "foo"
-%16 = AND %14, %15
-%17 = NOT_MATCH_RE builtin.log, "(a|b|c)"
-%18 = AND %16, %17
+%14 = MATCH_STR builtin.log "metric.go"
+%15 = MATCH_STR builtin.log "foo"
+%16 = AND %14 %15
+%17 = NOT_MATCH_RE builtin.log "(a|b|c)"
+%18 = AND %16 %17
 %19 = SELECT %13 [predicate=%18]
-%20 = limit %19 [skip=0, fetch=1000]
+%20 = LIMIT %19 [skip=0, fetch=1000]
 RETURN %20
 `
 

--- a/pkg/engine/planner/logical/printer.go
+++ b/pkg/engine/planner/logical/printer.go
@@ -1,0 +1,22 @@
+package logical
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/grafana/loki/v3/pkg/engine/planner/internal/tree"
+)
+
+func WriteMermaidFormat(w io.Writer, p *Plan) {
+	var t treeFormatter
+	for _, inst := range p.Instructions {
+		switch inst := inst.(type) {
+		case *Return:
+			node := t.convert(inst.Value)
+			printer := tree.NewMermaid(w)
+			_ = printer.Write(node)
+
+			fmt.Fprint(w, "\n\n")
+		}
+	}
+}


### PR DESCRIPTION
This allows to return a [Mermaid](https://mermaid.js.org) diagram of the logical and physical plan via an API endpoint.

Example output visualised by a JS engine:

![screenshot_20250402_153054](https://github.com/user-attachments/assets/56610505-7304-4a51-a76e-cc4095b51b25)