### PR TITLE
chore(logql/bench): use benchstat naming conventions for benchmarks

### DIFF
--- a/pkg/logql/bench/bench_test.go
+++ b/pkg/logql/bench/bench_test.go
@@ -132,7 +132,7 @@ func BenchmarkLogQL(b *testing.B) {
 		cases := config.GenerateTestCases()
 
 		for _, c := range cases {
-			b.Run(fmt.Sprintf("%s/%s", storeType, c.Name()), func(b *testing.B) {
+			b.Run(fmt.Sprintf("query=%s/store=%s", c.Name(), storeType), func(b *testing.B) {
 				params, err := logql.NewLiteralParams(
 					c.Query,
 					c.Start,


### PR DESCRIPTION
benchstat supports changing the "row" and "column" based on a key=value pair naming convention, where key-value pairs are separated by slashes.

Changing the test names to match these conventions such that

    BenchmarkLogQL/QUERY/STORE

becomes

    BenchmarkLogQL/query=QUERY/store=STORE

allows for cross-store analysis of benchmark results:

    benchstat -row /query -col '/store@(chunk dataobj)' FILE