### PR TITLE
feat(canary): Support passing arbitrary set of labels to use for the query

### DIFF
--- a/cmd/loki-canary/main.go
+++ b/cmd/loki-canary/main.go
@@ -74,6 +74,7 @@ func main() {
 	buckets := flag.Int("buckets", 10, "Number of buckets in the response_latency histogram")
 
 	queryAppend := flag.String("query-append", "", "LogQL filters to be appended to the Canary query e.g. '| json | line_format `{{.log}}`'")
+	queryLabels := flag.String("query-labels", "", "Comma-separated string of labels for the query e.g. 'service=loki,app=canary' Overwrites labelname and streamname")
 
 	metricTestInterval := flag.Duration("metric-test-interval", 1*time.Hour, "The interval the metric test query should be run")
 	metricTestQueryRange := flag.Duration("metric-test-range", 24*time.Hour, "The range value [24h] used in the metric test instant-query."+
@@ -188,7 +189,7 @@ func main() {
 
 		c.writer = writer.NewWriter(entryWriter, sentChan, *interval, *outOfOrderMin, *outOfOrderMax, *outOfOrderPercentage, *size, logger)
 		var err error
-		c.reader, err = reader.NewReader(os.Stderr, receivedChan, *useTLS, tlsConfig, *caFile, *certFile, *keyFile, *addr, *user, *pass, *tenantID, *queryTimeout, *lName, *lVal, *sName, *sValue, *interval, *queryAppend)
+		c.reader, err = reader.NewReader(os.Stderr, receivedChan, *useTLS, tlsConfig, *caFile, *certFile, *keyFile, *addr, *user, *pass, *tenantID, *queryTimeout, *lName, *lVal, *sName, *sValue, *interval, *queryAppend, *queryLabels)
 		if err != nil {
 			_, _ = fmt.Fprintf(os.Stderr, "Unable to create reader for Loki querier, check config: %s", err)
 			os.Exit(1)

--- a/docs/sources/operations/loki-canary/_index.md
+++ b/docs/sources/operations/loki-canary/_index.md
@@ -324,6 +324,8 @@ All options:
     	Duration between log entries (default 1s)
   -key-file string
     	Client PEM encoded X.509 key for optional use with TLS connection to Loki
+  -labels string
+        Comma-separated string of labels for the query e.g. 'service=loki,app=canary' Overwrites labelname and streamname
   -labelname string
     	The label name for this instance of loki-canary to use in the log selector (default "name")
   -labelvalue string
@@ -348,6 +350,8 @@ All options:
     	Frequency to check sent vs received logs, also the frequency which queries for missing logs will be dispatched to loki (default 1m0s)
   -push
     	Push the logs directly to given Loki address
+  -query-append string
+        LogQL filters to be appended to the Canary query e.g. '| json | line_format `{{.log}}`'  	
   -query-timeout duration
     	How long to wait for a query response from Loki (default 10s)
   -size int

--- a/pkg/canary/reader/reader.go
+++ b/pkg/canary/reader/reader.go
@@ -74,6 +74,7 @@ type Reader struct {
 	shuttingDown    bool
 	done            chan struct{}
 	queryAppend     string
+	labels          string
 }
 
 func NewReader(writer io.Writer,
@@ -92,6 +93,7 @@ func NewReader(writer io.Writer,
 	streamValue string,
 	interval time.Duration,
 	queryAppend string,
+	labels string,
 ) (*Reader, error) {
 	h := http.Header{}
 
@@ -154,6 +156,7 @@ func NewReader(writer io.Writer,
 		done:            make(chan struct{}),
 		shuttingDown:    false,
 		queryAppend:     queryAppend,
+		labels:          labels,
 	}
 
 	go rd.run()
@@ -290,12 +293,25 @@ func (r *Reader) Query(start time.Time, end time.Time) ([]time.Time, error) {
 	if r.useTLS {
 		scheme = "https"
 	}
+	var labels string
+	if r.labels != "" {
+		var lbls []string
+		for _, label := range strings.Split(r.labels, ",") {
+			k := strings.Split(label, "=")[0]
+			v := strings.Split(label, "=")[1]
+			lbls = append(lbls, fmt.Sprintf("%s=\"%s\"", k, v))
+		}
+		labels = fmt.Sprintf("{%s}", strings.Join(lbls, ","))
+	} else {
+		labels = fmt.Sprintf("{%s=\"%s\",%s=\"%s\"}", r.sName, r.sValue, r.lName, r.lVal)
+	}
+
 	u := url.URL{
 		Scheme: scheme,
 		Host:   r.addr,
 		Path:   "/loki/api/v1/query_range",
 		RawQuery: fmt.Sprintf("start=%d&end=%d", start.UnixNano(), end.UnixNano()) +
-			"&query=" + url.QueryEscape(fmt.Sprintf("{%v=\"%v\",%v=\"%v\"} %v", r.sName, r.sValue, r.lName, r.lVal, r.queryAppend)) +
+			"&query=" + url.QueryEscape(fmt.Sprintf("%s %v", labels, r.queryAppend)) +
 			"&limit=1000",
 	}
 	fmt.Fprintf(r.w, "Querying loki for logs with query: %v\n", u.String())


### PR DESCRIPTION
**What this PR does / why we need it**:
Loki Canary logs are collected and parsed by logging agents whose configuration is controlled by users. Since Loki does not parse logs directly, the set of labels for each log line is up to users and extremely variable.

The current approach only allows for two labels to be used for the query sent to Loki which can impact the canary's ability to find the logs it is looking for. By adding a `-labels` flag, we are able to pass an arbitrary set of labels to be used in the query. Combined with `-query-append`, you can craft a full LogQL query to correctly and efficiently return the logs it is looking for.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
