### PR TITLE
ci: skip flaky analytics test

### DIFF
--- a/pkg/analytics/seed_test.go
+++ b/pkg/analytics/seed_test.go
@@ -58,6 +58,7 @@ func createMemberlist(t *testing.T, port, memberID int) *memberlist.KV {
 }
 
 func Test_Memberlist(t *testing.T) {
+  t.Skip("Skipping flaky test")
 	stabilityCheckInterval = time.Second
 
 	objectClient, err := local.NewFSObjectClient(local.FSConfig{

--- a/pkg/analytics/seed_test.go
+++ b/pkg/analytics/seed_test.go
@@ -58,7 +58,7 @@ func createMemberlist(t *testing.T, port, memberID int) *memberlist.KV {
 }
 
 func Test_Memberlist(t *testing.T) {
-  t.Skip("Skipping flaky test")
+	t.Skip("Skipping flaky test")
 	stabilityCheckInterval = time.Second
 
 	objectClient, err := local.NewFSObjectClient(local.FSConfig{


### PR DESCRIPTION
**What this PR does / why we need it**:

This test has flaked on me not [1](https://github.com/grafana/loki/actions/runs/14222770309/job/39854780985?pr=17003), not [2](https://github.com/grafana/loki/actions/runs/14202511042/job/39792537244), but [3](https://github.com/grafana/loki/actions/runs/14225082296/job/39862597619) times just today.
