### PR TITLE
feat: Add agent IPs to distributor log

### DIFF
--- a/pkg/loghttp/push/push.go
+++ b/pkg/loghttp/push/push.go
@@ -205,7 +205,6 @@ func ParseRequest(logger log.Logger, userID string, maxRecvMsgSize int, r *http.
 		"structuredMetadataSize", humanize.Bytes(uint64(structuredMetadataSize)),
 		"totalSize", humanize.Bytes(uint64(entriesSize + pushStats.StreamLabelsSize)),
 		"presumedAgentIp", strings.TrimSpace(agentIP),
-		"xForwardedForHeader", strings.TrimSpace(forwardedHeader),
 		"mostRecentLagMs", time.Since(pushStats.MostRecentEntryTimestamp).Milliseconds(),
 	}
 	logValues = append(logValues, pushStats.Extra...)

--- a/pkg/loghttp/push/push.go
+++ b/pkg/loghttp/push/push.go
@@ -204,7 +204,7 @@ func ParseRequest(logger log.Logger, userID string, maxRecvMsgSize int, r *http.
 		"mostRecentLagMs", time.Since(pushStats.MostRecentEntryTimestamp).Milliseconds(),
 	}
 
-	// X-Forwarded-For header may have 2 (comma-separated) addresses: the 2nd appears to be infrastructure-related.
+	// X-Forwarded-For header may have 2 or more comma-separated addresses: the 2nd (and additional) are typically appended by proxies which handled the traffic.
 	// Therefore, if the header is included, only log the first address
 	agentIP := strings.Split(r.Header.Get("X-Forwarded-For"), ",")[0]
 	if agentIP != "" {

--- a/pkg/loghttp/push/push.go
+++ b/pkg/loghttp/push/push.go
@@ -202,7 +202,7 @@ func ParseRequest(logger log.Logger, userID string, r *http.Request, limits Limi
 		"entriesSize", humanize.Bytes(uint64(entriesSize)),
 		"structuredMetadataSize", humanize.Bytes(uint64(structuredMetadataSize)),
 		"totalSize", humanize.Bytes(uint64(entriesSize + pushStats.StreamLabelsSize)),
-		"agentIpAddress", strings.TrimSpace(agentIp),
+		"presumedAgentIp", strings.TrimSpace(agentIp),
 		"xForwardedForHeader", strings.TrimSpace(forwardedHeader),
 		"mostRecentLagMs", time.Since(pushStats.MostRecentEntryTimestamp).Milliseconds(),
 	}

--- a/pkg/loghttp/push/push.go
+++ b/pkg/loghttp/push/push.go
@@ -190,10 +190,7 @@ func ParseRequest(logger log.Logger, userID string, maxRecvMsgSize int, r *http.
 	linesReceivedStats.Inc(totalNumLines)
 
 	forwardedHeader := r.Header.Get("X-Forwarded-For")
-	agentIP := forwardedHeader
-	if strings.Contains(forwardedHeader, ",") {
-		agentIP = strings.Split(forwardedHeader, ",")[0]
-	}
+	agentIP = strings.Split(forwardedHeader, ",")[0]
 
 	logValues := []interface{}{
 		"msg", "push request parsed",

--- a/pkg/loghttp/push/push.go
+++ b/pkg/loghttp/push/push.go
@@ -190,7 +190,7 @@ func ParseRequest(logger log.Logger, userID string, maxRecvMsgSize int, r *http.
 	linesReceivedStats.Inc(totalNumLines)
 
 	forwardedHeader := r.Header.Get("X-Forwarded-For")
-	agentIP = strings.Split(forwardedHeader, ",")[0]
+	agentIP := strings.Split(forwardedHeader, ",")[0]
 
 	logValues := []interface{}{
 		"msg", "push request parsed",

--- a/pkg/loghttp/push/push.go
+++ b/pkg/loghttp/push/push.go
@@ -185,9 +185,9 @@ func ParseRequest(logger log.Logger, userID string, r *http.Request, limits Limi
 	linesReceivedStats.Inc(totalNumLines)
 
 	forwardedHeader := r.Header.Get("X-Forwarded-For")
-	agentIp := forwardedHeader
+	agentIP := forwardedHeader
 	if strings.Contains(forwardedHeader, ",") {
-		agentIp = forwardedHeader[0:strings.Index(forwardedHeader, ",")]
+		agentIP = strings.Split(forwardedHeader, ",")[0]
 	}
 
 	logValues := []interface{}{
@@ -202,7 +202,7 @@ func ParseRequest(logger log.Logger, userID string, r *http.Request, limits Limi
 		"entriesSize", humanize.Bytes(uint64(entriesSize)),
 		"structuredMetadataSize", humanize.Bytes(uint64(structuredMetadataSize)),
 		"totalSize", humanize.Bytes(uint64(entriesSize + pushStats.StreamLabelsSize)),
-		"presumedAgentIp", strings.TrimSpace(agentIp),
+		"presumedAgentIp", strings.TrimSpace(agentIP),
 		"xForwardedForHeader", strings.TrimSpace(forwardedHeader),
 		"mostRecentLagMs", time.Since(pushStats.MostRecentEntryTimestamp).Milliseconds(),
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
To assist with tracking push agent latency, we have a mostRecentLagMs logged message in distributors which includes the difference of timestamps (in millis) between when a push request is received and the most recent timestamp of the log content being pushed.

The logged message, however, doesn't include the IP address of the agent. As a result, it's difficult to correlate increased latency for a given agent.

This commit extracts IP addresses from the `X-Forwarded-For` HTTP header in the distributor.ParseRequest function.  The value is appended to the push request log line, along with the first agent IP address parsed from the header.


**Which issue(s) this PR fixes**:
Provides better identification of agents w/their lag times in the distributor logging

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
