### PR TITLE
ci(helm-diff): add single binary scenario

### DIFF
--- a/.github/workflows/helm-diff-ci.yml
+++ b/.github/workflows/helm-diff-ci.yml
@@ -21,6 +21,9 @@ jobs:
           - name: Distributed Scenario
             values_file: default-distributed-values.yaml
             use_k3d: true
+          - name: Single Binary Scenario
+            values_file: default-single-binary-values.yaml
+            use_k3d: true
           - name: Default Values Scenario
             values_file: default-values.yaml
             use_k3d: true

--- a/production/helm/loki/scenarios/default-single-binary-values.yaml
+++ b/production/helm/loki/scenarios/default-single-binary-values.yaml
@@ -1,0 +1,19 @@
+---
+loki:
+  commonConfig:
+    replication_factor: 1
+  useTestSchema: true
+  storage:
+    bucketNames:
+      chunks: chunks
+      ruler: ruler
+      admin: admin
+deploymentMode: SingleBinary
+singleBinary:
+  replicas: 1
+read:
+  replicas: 0
+write:
+  replicas: 0
+backend:
+  replicas: 0


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds the single binary scenario to Helm diff CI. It makes sense since there are templates only rendered for it.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

Discussed on https://github.com/grafana/loki/pull/16930


**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
