### PR TITLE
fix: include LogLevel to field detection

### DIFF
--- a/pkg/distributor/field_detection.go
+++ b/pkg/distributor/field_detection.go
@@ -40,6 +40,7 @@ var (
 		"LEVEL",
 		"Level",
 		"log.level",
+		"LogLevel",
 		"severity",
 		"SEVERITY",
 		"Severity",


### PR DESCRIPTION
The default logging library to the .Net runtime outputs log levels to the json field `LogLevel`.

Include it as a default field in the field detection.

**What this PR does / why we need it**:

The default logging library to the .Net runtime outputs log levels to
the json field `LogLevel`.

Include it as a default field in the field detection.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
