### PR TITLE
feat(helm): allow custom PV/PVC configuration in StatefulSet

### DIFF
--- a/production/helm/loki/templates/single-binary/statefulset.yaml
+++ b/production/helm/loki/templates/single-binary/statefulset.yaml
@@ -251,28 +251,34 @@ spec:
         {{- with .Values.singleBinary.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-  {{- if .Values.singleBinary.persistence.enabled }}
-  volumeClaimTemplates:
-    - apiVersion: v1
-      kind: PersistentVolumeClaim
-      metadata:
-        name: storage
-        {{- with .Values.singleBinary.persistence.annotations }}
-        annotations:
-          {{- toYaml . | nindent 10 }}
+        {{- if .Values.singleBinary.persistence.enabled }}
+        {{- if .Values.singleBinary.persistence.existingClaim }}
+        - name: storage
+          persistentVolumeClaim:
+            claimName: {{ .Values.singleBinary.persistence.existingClaim }}
+        {{- else }}
+        volumeClaimTemplates:
+          - apiVersion: v1
+            kind: PersistentVolumeClaim
+            metadata:
+              name: storage
+              {{- with .Values.singleBinary.persistence.annotations }}
+              annotations:
+                {{- toYaml . | nindent 10 }}
+              {{- end }}
+            spec:
+              accessModes:
+                - ReadWriteOnce
+              {{- with .Values.singleBinary.persistence.storageClass }}
+              storageClassName: {{ if (eq "-" .) }}""{{ else }}{{ . }}{{ end }}
+              {{- end }}
+              resources:
+                requests:
+                  storage: {{ .Values.singleBinary.persistence.size | quote }}
+              {{- with .Values.singleBinary.persistence.selector }}
+              selector:
+                {{- toYaml . | nindent 10 }}
+              {{- end }}
+          {{- end }}
         {{- end }}
-      spec:
-        accessModes:
-          - ReadWriteOnce
-        {{- with .Values.singleBinary.persistence.storageClass }}
-        storageClassName: {{ if (eq "-" .) }}""{{ else }}{{ . }}{{ end }}
-        {{- end }}
-        resources:
-          requests:
-            storage: {{ .Values.singleBinary.persistence.size | quote }}
-        {{- with .Values.singleBinary.persistence.selector }}
-        selector:
-          {{- toYaml . | nindent 10 }}
-        {{- end }}
-  {{- end }}
 {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it:**

This PR modifies the StatefulSet configuration in the single-binary Loki Helm chart to allow users to specify custom Persistent Volumes (PV) and Persistent Volume Claims (PVC) instead of the default automatic PV/PVC creation. This enhancement is particularly useful for environments like Amazon EKS, where custom storage classes or predefined PV/PVC configurations are required. Currently, the Helm chart automatically creates a PV/PVC, which may not meet the needs of all users, especially in environments that require custom storage configurations. This change adds the flexibility to specify user-defined PV/PVC, while maintaining the default behavior if no custom values are provided.
--------------------------------------

**Notes:**
- This update modifies the StatefulSet file to allow the customization of PV/PVC.
- It doesn’t require changes in values.yaml, but users can now specify their own PV/PVC by modifying the appropriate StatefulSet configuration.
- The default behavior (automatic PV/PVC creation) remains intact if users don’t specify custom values.
- **This change has been verified and tested in Amazon EKS, ensuring the PV/PVC customization works as expected in cloud environments like EKS.**
---------------------------------------



