### PR TITLE
fix: short circuit level detection when already detected

### DIFF
--- a/pkg/distributor/field_detection.go
+++ b/pkg/distributor/field_detection.go
@@ -94,6 +94,11 @@ func (l *FieldDetector) shouldDiscoverGenericFields() bool {
 }
 
 func (l *FieldDetector) extractLogLevel(labels labels.Labels, structuredMetadata labels.Labels, entry logproto.Entry) (logproto.LabelAdapter, bool) {
+	// If the level is already set in the structured metadata, we don't need to do anything.
+	if structuredMetadata.Has(constants.LevelLabel) {
+		return logproto.LabelAdapter{}, false
+	}
+
 	levelFromLabel, hasLevelLabel := labelsContainAny(labels, l.allowedLevelLabels)
 	var logLevel string
 	if hasLevelLabel {

--- a/pkg/distributor/field_detection_test.go
+++ b/pkg/distributor/field_detection_test.go
@@ -118,6 +118,55 @@ func Test_DetectLogLevels(t *testing.T) {
 			},
 		}, sm)
 	})
+
+	t.Run("detected_level structured metadata takes precedence over other level detection methods", func(t *testing.T) {
+		limits, ingester := setup(true)
+		distributors, _ := prepare(t, 1, 5, limits, func(_ string) (ring_client.PoolClient, error) { return ingester, nil })
+
+		// Create a write request with multiple potential level sources:
+		// 1. A JSON log line with level=error
+		// 2. A log level in stream labels (level=debug)
+		// 3. OTLP severity number in structured metadata
+		// 4. A severity field in structured metadata
+		// 5. The detected_level field in structured metadata (should take precedence)
+		writeReq := makeWriteRequestWithLabels(1, 10, []string{`{foo="bar", level="debug"}`}, false, false, false)
+		writeReq.Streams[0].Entries[0].Line = `{"msg":"this is a test message", "level":"error"}`
+		writeReq.Streams[0].Entries[0].StructuredMetadata = push.LabelsAdapter{
+			{
+				Name:  loghttp_push.OTLPSeverityNumber,
+				Value: fmt.Sprintf("%d", plog.SeverityNumberWarn),
+			},
+			{
+				Name:  "severity",
+				Value: constants.LogLevelCritical,
+			},
+			{
+				Name:  constants.LevelLabel, // detected_level
+				Value: constants.LogLevelTrace,
+			},
+		}
+
+		_, err := distributors[0].Push(ctx, writeReq)
+		require.NoError(t, err)
+		topVal := ingester.Peek()
+		require.Equal(t, `{foo="bar", level="debug"}`, topVal.Streams[0].Labels)
+
+		// Verify that detected_level from structured metadata is preserved and used
+		sm := topVal.Streams[0].Entries[0].StructuredMetadata
+
+		detectedLevelLbls := make([]logproto.LabelAdapter, 0, len(sm))
+		for _, sm := range sm {
+			if sm.Name == constants.LevelLabel {
+				detectedLevelLbls = append(detectedLevelLbls, sm)
+			}
+		}
+
+		require.Len(t, detectedLevelLbls, 1)
+		require.Contains(t, detectedLevelLbls, logproto.LabelAdapter{
+			Name:  constants.LevelLabel,
+			Value: constants.LogLevelTrace,
+		})
+	})
 }
 
 func Test_detectLogLevelFromLogEntry(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

https://github.com/grafana/loki/pull/16924 changed how the pattern ingester sends the detected level back into the distributors for aggregated metrics. However, the distributors weren't actually checking if `detected_level` was already set in structured metadata, and therefore was still trying to do it's own level detection. This worked against my test data locally, as the original services had indexed level fields that showed up in the aggregated metric log line, but this very much didn't work in many other places :(

For example, I broke our ops environment real good. See all the unknown levels, and when I started running the custom image on distrubtors to test my change.

<img width="523" alt="Screenshot 2025-04-03 at 15 38 45" src="https://github.com/user-attachments/assets/cacbe6ae-aa30-4005-a82a-5ec2fc038ff2" />


**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
