### PR TITLE
chore: expose partition ring for consumption by GEL

### DIFF
--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -13,6 +13,8 @@ import (
 
 	"go.uber.org/atomic"
 
+	"google.golang.org/grpc/health/grpc_health_v1"
+
 	"github.com/fatih/color"
 	"github.com/felixge/fgprof"
 	"github.com/go-kit/log/level"
@@ -28,7 +30,6 @@ import (
 	"github.com/grafana/dskit/signals"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
-	"google.golang.org/grpc/health/grpc_health_v1"
 
 	"github.com/grafana/loki/v3/pkg/analytics"
 	blockbuilder "github.com/grafana/loki/v3/pkg/blockbuilder/builder"
@@ -422,7 +423,7 @@ type Loki struct {
 	usageReport               *analytics.Reporter
 	indexGatewayRingManager   *lokiring.RingManager
 	partitionRingWatcher      *ring.PartitionRingWatcher
-	partitionRing             *ring.PartitionInstanceRing
+	PartitionRing             *ring.PartitionInstanceRing
 	blockBuilder              *blockbuilder.BlockBuilder
 	blockScheduler            *blockscheduler.BlockScheduler
 	dataObjConsumer           *consumer.Service


### PR DESCRIPTION
This PR exports the the partition ring so it can be used in codebases like GEL that consume Loki as a library