### PR TITLE
chore(metastore): Use constants for label names

### DIFF
--- a/pkg/dataobj/metastore/metastore_test.go
+++ b/pkg/dataobj/metastore/metastore_test.go
@@ -408,9 +408,9 @@ func TestObjectOverlapsRange(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Create labels with timestamps in nanoseconds
 			lbs := labels.Labels{
-				{Name: "__start__", Value: strconv.FormatInt(tt.objStart.UnixNano(), 10)},
-				{Name: "__end__", Value: strconv.FormatInt(tt.objEnd.UnixNano(), 10)},
-				{Name: "__path__", Value: testPath},
+				{Name: labelNameStart, Value: strconv.FormatInt(tt.objStart.UnixNano(), 10)},
+				{Name: labelNameEnd, Value: strconv.FormatInt(tt.objEnd.UnixNano(), 10)},
+				{Name: labelNamePath, Value: testPath},
 			}
 
 			gotMatch, gotPath := objectOverlapsRange(lbs, tt.queryStart, tt.queryEnd)

--- a/pkg/dataobj/metastore/object.go
+++ b/pkg/dataobj/metastore/object.go
@@ -415,21 +415,21 @@ func objectOverlapsRange(lbs labels.Labels, start, end time.Time) (bool, string)
 		objPath          string
 	)
 	for _, lb := range lbs {
-		if lb.Name == "__start__" {
+		if lb.Name == labelNameStart {
 			tsNano, err := strconv.ParseInt(lb.Value, 10, 64)
 			if err != nil {
 				panic(err)
 			}
 			objStart = time.Unix(0, tsNano).UTC()
 		}
-		if lb.Name == "__end__" {
+		if lb.Name == labelNameEnd {
 			tsNano, err := strconv.ParseInt(lb.Value, 10, 64)
 			if err != nil {
 				panic(err)
 			}
 			objEnd = time.Unix(0, tsNano).UTC()
 		}
-		if lb.Name == "__path__" {
+		if lb.Name == labelNamePath {
 			objPath = lb.Value
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR contains improvements for:
1. Make label names contants
2. Use `strconv.FormatInt` for encoding timestamp into label value (equivalent to `strconv.ParseInt` when decoding)
3. Use `labels.New` to construct labels, rather then string formatting
