### PR TITLE
chore(logql/bench): Fix bug in bench data generation and update naming conventions

### DIFF
--- a/pkg/logql/bench/bench_test.go
+++ b/pkg/logql/bench/bench_test.go
@@ -132,7 +132,7 @@ func BenchmarkLogQL(b *testing.B) {
 		cases := config.GenerateTestCases()
 
 		for _, c := range cases {
-			b.Run(fmt.Sprintf("query=%s/store=%s", c.Name(), storeType), func(b *testing.B) {
+			b.Run(fmt.Sprintf("query=%s/kind=%s/store=%s", c.Name(), c.Kind(), storeType), func(b *testing.B) {
 				params, err := logql.NewLiteralParams(
 					c.Query,
 					c.Start,

--- a/pkg/logql/bench/cmd/bench/views/run.go
+++ b/pkg/logql/bench/cmd/bench/views/run.go
@@ -530,10 +530,10 @@ func buildTestRegex(tests []string, storageType string) string {
 		// If no tests are selected, match all tests
 		if storageType == "" {
 			// Match any storage type
-			return "^BenchmarkLogQL/.+/.*$"
+			return "^BenchmarkLogQL/query=.+/kind=.+/store=.+$"
 		}
 		// Match specific storage type
-		return fmt.Sprintf("^BenchmarkLogQL/%s/.*$", storageType)
+		return fmt.Sprintf("^BenchmarkLogQL/query=.+/kind=.+/store=%s$", storageType)
 	}
 
 	formatted := []string{}
@@ -542,10 +542,10 @@ func buildTestRegex(tests []string, storageType string) string {
 		var escaped string
 		if storageType == "" {
 			// When no storage type is specified, match any storage type
-			escaped = strings.ReplaceAll(fmt.Sprintf("BenchmarkLogQL/.+/%s", t), "{", "\\{")
+			escaped = strings.ReplaceAll(fmt.Sprintf("BenchmarkLogQL/query=%s/kind=.+/store=.+", t), "{", "\\{")
 		} else {
 			// When a storage type is specified, match only that storage type
-			escaped = strings.ReplaceAll(fmt.Sprintf("BenchmarkLogQL/%s/%s", storageType, t), "{", "\\{")
+			escaped = strings.ReplaceAll(fmt.Sprintf("BenchmarkLogQL/query=%s/kind=.+/store=%s", t, storageType), "{", "\\{")
 		}
 		escaped = strings.ReplaceAll(escaped, "}", "\\}")
 		escaped = strings.ReplaceAll(escaped, "\"", "\\\"")

--- a/pkg/logql/bench/generator_query.go
+++ b/pkg/logql/bench/generator_query.go
@@ -33,6 +33,18 @@ func (c TestCase) Name() string {
 	return fmt.Sprintf("%s [%v]", c.Query, c.Direction)
 }
 
+// Kind returns the kind of the test case based on the query type.
+func (c TestCase) Kind() string {
+	expr, err := syntax.ParseExpr(c.Query)
+	if err != nil {
+		return "invalid"
+	}
+	if _, ok := expr.(syntax.SampleExpr); ok {
+		return "metric"
+	}
+	return "log"
+}
+
 // Description returns a detailed description of the test case including time range
 func (c TestCase) Description() string {
 	var b strings.Builder

--- a/pkg/logql/bench/store_chunk.go
+++ b/pkg/logql/bench/store_chunk.go
@@ -125,6 +125,10 @@ func newMemChunk() *chunkenc.MemChunk {
 }
 
 func (s *ChunkStore) flushChunk(ctx context.Context, memChunk *chunkenc.MemChunk, labelsString string) error {
+	if err := memChunk.Close(); err != nil {
+		return err
+	}
+
 	lbs, err := syntax.ParseLabels(labelsString)
 	if err != nil {
 		return err


### PR DESCRIPTION
This PR fixes a bug found in generating test data for chunks: `MemChunks` weren't being closed properly before flushing, which caused the last block of every chunk to be omitted from the flush. As a result, benchmark tests against chunks were inaccurate, causing many metric queries to appear 5-10x faster with chunks than they actually are. 

Additionally, this PR expands on #17006 with another naming convention change: the type of query is now included in the benchmark name to allow developers to only run benchmarks of a specific query type (metric, log). 

PR #17006 neglected to reflect the naming convention change in the benchmark TUI, which stopped it from working. This is now fixed to match the latest naming convention introduced in this PR, and the TUI will now work again.