### PR TITLE
fix: prevent panic when ContentLength is negative in Distributor RequestBodyTooLarge metrics

### DIFF
--- a/pkg/distributor/http.go
+++ b/pkg/distributor/http.go
@@ -63,7 +63,10 @@ func (d *Distributor) pushHandler(w http.ResponseWriter, r *http.Request, pushRe
 			// and thus we don't know the uncompressed size.
 			// In addition we don't add the metric label values for
 			// `retention_hours` and `policy` because we don't know the labels.
-			validation.DiscardedBytes.WithLabelValues(validation.RequestBodyTooLarge, tenantID).Add(float64(r.ContentLength))
+			// Ensure ContentLength is positive to avoid counter panic
+			if r.ContentLength > 0 {
+				validation.DiscardedBytes.WithLabelValues(validation.RequestBodyTooLarge, tenantID).Add(float64(r.ContentLength))
+			}
 			errorWriter(w, err.Error(), http.StatusRequestEntityTooLarge, logger)
 			return
 

--- a/pkg/distributor/http.go
+++ b/pkg/distributor/http.go
@@ -65,7 +65,9 @@ func (d *Distributor) pushHandler(w http.ResponseWriter, r *http.Request, pushRe
 			// `retention_hours` and `policy` because we don't know the labels.
 			// Ensure ContentLength is positive to avoid counter panic
 			if r.ContentLength > 0 {
-				validation.DiscardedBytes.WithLabelValues(validation.RequestBodyTooLarge, tenantID).Add(float64(r.ContentLength))
+				// Add empty values for retention_hours and policy labels since we don't have
+				// that information for request body too large errors
+				validation.DiscardedBytes.WithLabelValues(validation.RequestBodyTooLarge, tenantID, "", "").Add(float64(r.ContentLength))
 			}
 			errorWriter(w, err.Error(), http.StatusRequestEntityTooLarge, logger)
 			return


### PR DESCRIPTION
**What this PR does / why we need it**:

re:
- https://github.com/grafana/loki/commit/1d99f4d86d25a361fc85162fadb21a78308d65d4

We encountered an edge case where Distributors panic when trying to increment their DiscardedBytes metrics for large request bodies:

`panic: counter cannot decrease in value`

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

N/A

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
