### PR TITLE
fix: prevent panic when ContentLength is negative in Distributor RequestBodyTooLarge metrics (#17054)

### DIFF
--- a/pkg/distributor/http.go
+++ b/pkg/distributor/http.go
@@ -47,7 +47,32 @@ func (d *Distributor) pushHandler(w http.ResponseWriter, r *http.Request, pushRe
 	logPushRequestStreams := d.tenantConfigs.LogPushRequestStreams(tenantID)
 	req, err := push.ParseRequest(logger, tenantID, r, d.validator.Limits, pushRequestParser, d.usageTracker, streamResolver, logPushRequestStreams)
 	if err != nil {
-		if !errors.Is(err, push.ErrAllLogsFiltered) {
+		switch {
+		case errors.Is(err, push.ErrRequestBodyTooLarge):
+			if d.tenantConfigs.LogPushRequest(tenantID) {
+				level.Debug(logger).Log(
+					"msg", "push request failed",
+					"code", http.StatusRequestEntityTooLarge,
+					"err", err,
+				)
+			}
+			d.writeFailuresManager.Log(tenantID, fmt.Errorf("couldn't decompress push request: %w", err))
+
+			// We count the compressed request body size here
+			// because the request body could not be decompressed
+			// and thus we don't know the uncompressed size.
+			// In addition we don't add the metric label values for
+			// `retention_hours` and `policy` because we don't know the labels.
+			// Ensure ContentLength is positive to avoid counter panic
+			if r.ContentLength > 0 {
+				// Add empty values for retention_hours and policy labels since we don't have
+				// that information for request body too large errors
+				validation.DiscardedBytes.WithLabelValues(validation.RequestBodyTooLarge, tenantID, "", "").Add(float64(r.ContentLength))
+			}
+			errorWriter(w, err.Error(), http.StatusRequestEntityTooLarge, logger)
+			return
+
+		case !errors.Is(err, push.ErrAllLogsFiltered):
 			if d.tenantConfigs.LogPushRequest(tenantID) {
 				level.Debug(logger).Log(
 					"msg", "push request failed",


### PR DESCRIPTION
**What this PR does / why we need it**:

Cherry-picks 9e9f534460527f25d28fa3f3e17cd1eb4148b39d onto `k248` from `main`.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

N/A

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
