### PR TITLE
fix(push): Add guard clauses to prevent negative counter values

### DIFF
--- a/pkg/distributor/http.go
+++ b/pkg/distributor/http.go
@@ -68,6 +68,11 @@ func (d *Distributor) pushHandler(w http.ResponseWriter, r *http.Request, pushRe
 				// Add empty values for retention_hours and policy labels since we don't have
 				// that information for request body too large errors
 				validation.DiscardedBytes.WithLabelValues(validation.RequestBodyTooLarge, tenantID, "", "").Add(float64(r.ContentLength))
+			} else {
+				level.Error(logger).Log(
+					"msg", "negative content length observed",
+					"tenantID", tenantID,
+					"contentLength", r.ContentLength)
 			}
 			errorWriter(w, err.Error(), http.StatusRequestEntityTooLarge, logger)
 			return

--- a/pkg/loghttp/push/push.go
+++ b/pkg/loghttp/push/push.go
@@ -159,8 +159,11 @@ func ParseRequest(logger log.Logger, userID string, maxRecvMsgSize int, r *http.
 	for policyName, retentionToSizeMapping := range pushStats.LogLinesBytes {
 		for retentionPeriod, size := range retentionToSizeMapping {
 			retentionHours := RetentionPeriodToString(retentionPeriod)
-			bytesIngested.WithLabelValues(userID, retentionHours, isAggregatedMetric, policyName).Add(float64(size))
-			bytesReceivedStats.Inc(size)
+			// Add guard clause to prevent negative values from being passed to Prometheus counters
+			if size > 0 {
+				bytesIngested.WithLabelValues(userID, retentionHours, isAggregatedMetric, policyName).Add(float64(size))
+				bytesReceivedStats.Inc(size)
+			}
 			entriesSize += size
 		}
 	}
@@ -169,10 +172,13 @@ func ParseRequest(logger log.Logger, userID string, maxRecvMsgSize int, r *http.
 		for retentionPeriod, size := range retentionToSizeMapping {
 			retentionHours := RetentionPeriodToString(retentionPeriod)
 
-			structuredMetadataBytesIngested.WithLabelValues(userID, retentionHours, isAggregatedMetric, policyName).Add(float64(size))
-			bytesIngested.WithLabelValues(userID, retentionHours, isAggregatedMetric, policyName).Add(float64(size))
-			bytesReceivedStats.Inc(size)
-			structuredMetadataBytesReceivedStats.Inc(size)
+			// Add guard clause to prevent negative values from being passed to Prometheus counters
+			if size > 0 {
+				structuredMetadataBytesIngested.WithLabelValues(userID, retentionHours, isAggregatedMetric, policyName).Add(float64(size))
+				bytesIngested.WithLabelValues(userID, retentionHours, isAggregatedMetric, policyName).Add(float64(size))
+				bytesReceivedStats.Inc(size)
+				structuredMetadataBytesReceivedStats.Inc(size)
+			}
 
 			entriesSize += size
 			structuredMetadataSize += size

--- a/pkg/loghttp/push/push.go
+++ b/pkg/loghttp/push/push.go
@@ -163,6 +163,14 @@ func ParseRequest(logger log.Logger, userID string, maxRecvMsgSize int, r *http.
 			if size > 0 {
 				bytesIngested.WithLabelValues(userID, retentionHours, isAggregatedMetric, policyName).Add(float64(size))
 				bytesReceivedStats.Inc(size)
+			} else {
+				level.Error(logger).Log(
+					"msg", "negative log lines bytes received",
+					"userID", userID,
+					"retentionHours", retentionHours,
+					"isAggregatedMetric", isAggregatedMetric,
+					"policyName", policyName,
+					"size", size)
 			}
 			entriesSize += size
 		}
@@ -178,6 +186,14 @@ func ParseRequest(logger log.Logger, userID string, maxRecvMsgSize int, r *http.
 				bytesIngested.WithLabelValues(userID, retentionHours, isAggregatedMetric, policyName).Add(float64(size))
 				bytesReceivedStats.Inc(size)
 				structuredMetadataBytesReceivedStats.Inc(size)
+			} else {
+				level.Error(logger).Log(
+					"msg", "negative structured metadata bytes received",
+					"userID", userID,
+					"retentionHours", retentionHours,
+					"isAggregatedMetric", isAggregatedMetric,
+					"policyName", policyName,
+					"size", size)
 			}
 
 			entriesSize += size

--- a/pkg/loghttp/push/push_test.go
+++ b/pkg/loghttp/push/push_test.go
@@ -584,7 +584,7 @@ func TestNegativeSizeHandling(t *testing.T) {
 	linesIngested.Reset()
 
 	// Create a custom request parser that will generate negative sizes
-	var mockParser RequestParser = func(userID string, r *http.Request, limits Limits, maxRecvMsgSize int, tracker UsageTracker, streamResolver StreamResolver, logPushRequestStreams bool, logger kitlog.Logger) (*logproto.PushRequest, *Stats, error) {
+	var mockParser RequestParser = func(_ string, r *http.Request, limits Limits, maxRecvMsgSize int, tracker UsageTracker, streamResolver StreamResolver, logPushRequestStreams bool, logger kitlog.Logger) (*logproto.PushRequest, *Stats, error) {
 		// Create a minimal valid request
 		req := &logproto.PushRequest{
 			Streams: []logproto.Stream{

--- a/pkg/loghttp/push/push_test.go
+++ b/pkg/loghttp/push/push_test.go
@@ -7,13 +7,14 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/go-kit/log"
+	kitlog "github.com/go-kit/log"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/assert"
@@ -32,10 +33,10 @@ func gzipString(source string) string {
 	var buf bytes.Buffer
 	zw := gzip.NewWriter(&buf)
 	if _, err := zw.Write([]byte(source)); err != nil {
-		panic(err)
+		log.Fatal(err)
 	}
 	if err := zw.Close(); err != nil {
-		panic(err)
+		log.Fatal(err)
 	}
 	return buf.String()
 }
@@ -45,10 +46,10 @@ func deflateString(source string) string {
 	var buf bytes.Buffer
 	zw, _ := flate.NewWriter(&buf, 6)
 	if _, err := zw.Write([]byte(source)); err != nil {
-		panic(err)
+		log.Fatal(err)
 	}
 	if err := zw.Close(); err != nil {
-		panic(err)
+		log.Fatal(err)
 	}
 	return buf.String()
 }
@@ -583,7 +584,7 @@ func TestNegativeSizeHandling(t *testing.T) {
 	linesIngested.Reset()
 	
 	// Create a custom request parser that will generate negative sizes
-	var mockParser RequestParser = func(userID string, r *http.Request, limits Limits, maxRecvMsgSize int, tracker UsageTracker, streamResolver StreamResolver, logPushRequestStreams bool, logger log.Logger) (*logproto.PushRequest, *Stats, error) {
+	var mockParser RequestParser = func(userID string, r *http.Request, limits Limits, maxRecvMsgSize int, tracker UsageTracker, streamResolver StreamResolver, logPushRequestStreams bool, logger kitlog.Logger) (*logproto.PushRequest, *Stats, error) {
 		// Create a minimal valid request
 		req := &logproto.PushRequest{
 			Streams: []logproto.Stream{

--- a/pkg/loghttp/push/push_test.go
+++ b/pkg/loghttp/push/push_test.go
@@ -23,7 +23,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/plog"
 
 	"github.com/grafana/dskit/flagext"
-	
+
 	"github.com/grafana/loki/v3/pkg/logproto"
 	util_log "github.com/grafana/loki/v3/pkg/util/log"
 )
@@ -582,7 +582,7 @@ func TestNegativeSizeHandling(t *testing.T) {
 	structuredMetadataBytesIngested.Reset()
 	bytesIngested.Reset()
 	linesIngested.Reset()
-	
+
 	// Create a custom request parser that will generate negative sizes
 	var mockParser RequestParser = func(userID string, r *http.Request, limits Limits, maxRecvMsgSize int, tracker UsageTracker, streamResolver StreamResolver, logPushRequestStreams bool, logger kitlog.Logger) (*logproto.PushRequest, *Stats, error) {
 		// Create a minimal valid request
@@ -599,29 +599,29 @@ func TestNegativeSizeHandling(t *testing.T) {
 				},
 			},
 		}
-		
+
 		// Create stats with negative sizes to test our guard clauses
 		stats := NewPushStats()
 		policy := ""
 		retention := time.Hour
-		
+
 		// Set up negative sizes in both maps
 		stats.LogLinesBytes[policy] = make(map[time.Duration]int64)
 		stats.LogLinesBytes[policy][retention] = -100
-		
+
 		stats.StructuredMetadataBytes[policy] = make(map[time.Duration]int64)
 		stats.StructuredMetadataBytes[policy][retention] = -200
-		
+
 		return req, stats, nil
 	}
-	
+
 	// Create a mock request
 	request := httptest.NewRequest("POST", "/loki/api/v1/push", strings.NewReader("{}"))
 	request.Header.Add("Content-Type", "application/json")
-	
+
 	// Use a mock stream resolver to ensure consistent results
 	streamResolver := newMockStreamResolver("fake", &fakeLimits{})
-	
+
 	// This should not panic with our guard clauses in place
 	_, err := ParseRequest(
 		util_log.Logger,
@@ -634,15 +634,15 @@ func TestNegativeSizeHandling(t *testing.T) {
 		streamResolver,
 		false,
 	)
-	
+
 	// No error should be returned
 	require.NoError(t, err)
-	
+
 	// Check that the metrics were not incremented for negative values
 	userID := "fake"
 	isAggregatedMetric := "false"
 	policy := ""
-	
+
 	// Verify no counters were incremented since all sizes were negative
 	// This test passes if no panic occurred and the counters remain at 0
 	require.Equal(t, float64(0), testutil.ToFloat64(bytesIngested.WithLabelValues(userID, "1", isAggregatedMetric, policy)))

--- a/pkg/loghttp/push/push_test.go
+++ b/pkg/loghttp/push/push_test.go
@@ -584,7 +584,7 @@ func TestNegativeSizeHandling(t *testing.T) {
 	linesIngested.Reset()
 
 	// Create a custom request parser that will generate negative sizes
-	var mockParser RequestParser = func(_ string, r *http.Request, limits Limits, maxRecvMsgSize int, tracker UsageTracker, streamResolver StreamResolver, logPushRequestStreams bool, logger kitlog.Logger) (*logproto.PushRequest, *Stats, error) {
+	var mockParser RequestParser = func(_ string, _ *http.Request, _ Limits, _ int, _ UsageTracker, _ StreamResolver, _ bool, _ kitlog.Logger) (*logproto.PushRequest, *Stats, error) {
 		// Create a minimal valid request
 		req := &logproto.PushRequest{
 			Streams: []logproto.Stream{


### PR DESCRIPTION
**What this PR does / why we need it**:

Prevents panics in `push` Prometheus counters when negative values are passed to Add(). Added guard clauses to both LogLinesBytes and StructuredMetadataBytes processing in ParseRequest, plus a test case that verifies the fix.

The issue can arise when processing X-Forwarded-For header, which might cause negative size calculations in certain cases.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

N/A

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
