### PR TITLE
chore(metastore): Simplify conversion of `MatchNotRegexp` label matcher

### DIFF
--- a/pkg/dataobj/metastore/metastore.go
+++ b/pkg/dataobj/metastore/metastore.go
@@ -9,7 +9,7 @@ import (
 
 type Metastore interface {
 	// Streams returns all streams corresponding to the given matchers between [start,end]
-	Streams(ctx context.Context, start, end time.Time, matchers ...*labels.Matcher) ([]*labels.Labels, error)
+	Streams(ctx context.Context, start, end time.Time, matchers ...*labels.Matcher) ([]labels.Labels, error)
 
 	// DataObjects returns paths to all matching the given matchers between [start,end]
 	// TODO(chaudum); The comment is not correct, because the implementation does not filter by matchers, only by [start, end].

--- a/pkg/dataobj/metastore/object_test.go
+++ b/pkg/dataobj/metastore/object_test.go
@@ -164,9 +164,9 @@ func TestStreamsRegexMatcher(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, matchedLabels, 3)
 		require.ElementsMatch(t, matchedLabels, []labels.Labels{
-			labels.Labels{{Name: "app", Value: "foo"}, {Name: "env", Value: "prod"}},
-			labels.Labels{{Name: "app", Value: "bar"}, {Name: "env", Value: "prod"}},
-			labels.Labels{{Name: "app", Value: "baz"}, {Name: "env", Value: "prod"}, {Name: "team", Value: "a"}},
+			{{Name: "app", Value: "foo"}, {Name: "env", Value: "prod"}},
+			{{Name: "app", Value: "bar"}, {Name: "env", Value: "prod"}},
+			{{Name: "app", Value: "baz"}, {Name: "env", Value: "prod"}, {Name: "team", Value: "a"}},
 		})
 	})
 }
@@ -180,9 +180,9 @@ func TestStreamsNotRegexMatcher(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, matchedLabels, 3)
 		require.ElementsMatch(t, matchedLabels, []labels.Labels{
-			labels.Labels{{Name: "app", Value: "foo"}, {Name: "env", Value: "prod"}},
-			labels.Labels{{Name: "app", Value: "bar"}, {Name: "env", Value: "prod"}},
-			labels.Labels{{Name: "app", Value: "baz"}, {Name: "env", Value: "prod"}, {Name: "team", Value: "a"}},
+			{{Name: "app", Value: "foo"}, {Name: "env", Value: "prod"}},
+			{{Name: "app", Value: "bar"}, {Name: "env", Value: "prod"}},
+			{{Name: "app", Value: "baz"}, {Name: "env", Value: "prod"}, {Name: "team", Value: "a"}},
 		})
 	})
 }

--- a/pkg/dataobj/metastore/object_test.go
+++ b/pkg/dataobj/metastore/object_test.go
@@ -151,9 +151,39 @@ func TestLabelsSingleMatcher(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Len(t, matchedLabels, 3)
-		for _, expectedLabel := range []string{"env", "team", "app"} {
-			require.NotEqual(t, slices.Index(matchedLabels, expectedLabel), -1)
-		}
+		require.ElementsMatch(t, matchedLabels, []string{"env", "team", "app"})
+	})
+}
+
+func TestStreamsRegexMatcher(t *testing.T) {
+	matchers := []*labels.Matcher{
+		labels.MustNewMatcher(labels.MatchRegexp, "env", "p.+"),
+	}
+	queryMetastore(t, tenantID, func(ctx context.Context, start, end time.Time, mstore Metastore) {
+		matchedLabels, err := mstore.Streams(ctx, start, end, matchers...)
+		require.NoError(t, err)
+		require.Len(t, matchedLabels, 3)
+		require.ElementsMatch(t, matchedLabels, []labels.Labels{
+			labels.Labels{{Name: "app", Value: "foo"}, {Name: "env", Value: "prod"}},
+			labels.Labels{{Name: "app", Value: "bar"}, {Name: "env", Value: "prod"}},
+			labels.Labels{{Name: "app", Value: "baz"}, {Name: "env", Value: "prod"}, {Name: "team", Value: "a"}},
+		})
+	})
+}
+
+func TestStreamsNotRegexMatcher(t *testing.T) {
+	matchers := []*labels.Matcher{
+		labels.MustNewMatcher(labels.MatchNotRegexp, "env", "d.+"),
+	}
+	queryMetastore(t, tenantID, func(ctx context.Context, start, end time.Time, mstore Metastore) {
+		matchedLabels, err := mstore.Streams(ctx, start, end, matchers...)
+		require.NoError(t, err)
+		require.Len(t, matchedLabels, 3)
+		require.ElementsMatch(t, matchedLabels, []labels.Labels{
+			labels.Labels{{Name: "app", Value: "foo"}, {Name: "env", Value: "prod"}},
+			labels.Labels{{Name: "app", Value: "bar"}, {Name: "env", Value: "prod"}},
+			labels.Labels{{Name: "app", Value: "baz"}, {Name: "env", Value: "prod"}, {Name: "team", Value: "a"}},
+		})
 	})
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Remove double-negating predicate for MatchNotRegexp
