### PR TITLE
fix(push): Add guard clauses to prevent negative counter values (backport k249)

### DIFF
--- a/pkg/loghttp/push/push_test.go
+++ b/pkg/loghttp/push/push_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	kitlog "github.com/go-kit/log"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/assert"
@@ -23,6 +24,7 @@ import (
 
 	"github.com/grafana/dskit/flagext"
 
+	"github.com/grafana/loki/v3/pkg/logproto"
 	util_log "github.com/grafana/loki/v3/pkg/util/log"
 )
 
@@ -571,6 +573,80 @@ func TestRetentionPeriodToString(t *testing.T) {
 			assert.Equal(t, tc.expected, actual)
 		})
 	}
+}
+
+// TestNegativeSizeHandling tests that the code handles negative size values
+// properly without causing a panic when incrementing Prometheus counters.
+func TestNegativeSizeHandling(t *testing.T) {
+	// Reset metrics for accurate testing
+	structuredMetadataBytesIngested.Reset()
+	bytesIngested.Reset()
+	linesIngested.Reset()
+
+	// Create a custom request parser that will generate negative sizes
+	var mockParser RequestParser = func(_ string, _ *http.Request, _ Limits, _ int, _ UsageTracker, _ StreamResolver, _ bool, _ kitlog.Logger) (*logproto.PushRequest, *Stats, error) {
+		// Create a minimal valid request
+		req := &logproto.PushRequest{
+			Streams: []logproto.Stream{
+				{
+					Labels: `{foo="bar"}`,
+					Entries: []logproto.Entry{
+						{
+							Timestamp: time.Now(),
+							Line:      "test line",
+						},
+					},
+				},
+			},
+		}
+
+		// Create stats with negative sizes to test our guard clauses
+		stats := NewPushStats()
+		policy := ""
+		retention := time.Hour
+
+		// Set up negative sizes in both maps
+		stats.LogLinesBytes[policy] = make(map[time.Duration]int64)
+		stats.LogLinesBytes[policy][retention] = -100
+
+		stats.StructuredMetadataBytes[policy] = make(map[time.Duration]int64)
+		stats.StructuredMetadataBytes[policy][retention] = -200
+
+		return req, stats, nil
+	}
+
+	// Create a mock request
+	request := httptest.NewRequest("POST", "/loki/api/v1/push", strings.NewReader("{}"))
+	request.Header.Add("Content-Type", "application/json")
+
+	// Use a mock stream resolver to ensure consistent results
+	streamResolver := newMockStreamResolver("fake", &fakeLimits{})
+
+	// This should not panic with our guard clauses in place
+	_, err := ParseRequest(
+		util_log.Logger,
+		"fake",
+		100<<20,
+		request,
+		&fakeLimits{},
+		mockParser,
+		NewMockTracker(),
+		streamResolver,
+		false,
+	)
+
+	// No error should be returned
+	require.NoError(t, err)
+
+	// Check that the metrics were not incremented for negative values
+	userID := "fake"
+	isAggregatedMetric := "false"
+	policy := ""
+
+	// Verify no counters were incremented since all sizes were negative
+	// This test passes if no panic occurred and the counters remain at 0
+	require.Equal(t, float64(0), testutil.ToFloat64(bytesIngested.WithLabelValues(userID, "1", isAggregatedMetric, policy)))
+	require.Equal(t, float64(0), testutil.ToFloat64(structuredMetadataBytesIngested.WithLabelValues(userID, "1", isAggregatedMetric, policy)))
 }
 
 type fakeLimits struct {


### PR DESCRIPTION
Backport 9000de1aa7a6508234ee58adb346549ac3df2648 from #17056

---

**What this PR does / why we need it**:

Prevents panics in `push` Prometheus counters when negative values are passed to Add(). Added guard clauses to both LogLinesBytes and StructuredMetadataBytes processing in ParseRequest, plus a test case that verifies the fix.

The issue can arise when processing X-Forwarded-For header, which might cause negative size calculations in certain cases.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

N/A

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
