### PR TITLE
fix: avoid copying label values from tsdb unless required

### DIFF
--- a/pkg/storage/stores/shipper/indexshipper/tsdb/head_read.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/head_read.go
@@ -55,18 +55,6 @@ func (h *headIndexReader) Symbols() index.StringIter {
 	return h.head.postings.Symbols()
 }
 
-// SortedLabelValues returns label values present in the head for the
-// specific label name that are within the time range mint to maxt.
-// If matchers are specified the returned result set is reduced
-// to label values of metrics matching the matchers.
-func (h *headIndexReader) SortedLabelValues(name string, matchers ...*labels.Matcher) ([]string, error) {
-	values, err := h.LabelValues(name, matchers...)
-	if err == nil {
-		sort.Strings(values)
-	}
-	return values, err
-}
-
 // LabelValues returns label values present in the head for the
 // specific label name that are within the time range mint to maxt.
 // If matchers are specified the returned result set is reduced

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/index.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/index.go
@@ -1617,15 +1617,6 @@ func (r *Reader) SymbolTableSize() uint64 {
 	return uint64(r.symbols.Size())
 }
 
-// SortedLabelValues returns value tuples that exist for the given label name.
-func (r *Reader) SortedLabelValues(name string, matchers ...*labels.Matcher) ([]string, error) {
-	values, err := r.LabelValues(name, matchers...)
-	if err == nil && r.version == FormatV1 {
-		sort.Strings(values)
-	}
-	return values, err
-}
-
 // LabelValues returns value tuples that exist for the given label name.
 // The returned values should be copied if they need to be used beyond the current tsdb read operation, including sending back as response.
 // TODO(replay): Support filtering by matchers

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/index.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/index.go
@@ -1627,6 +1627,7 @@ func (r *Reader) SortedLabelValues(name string, matchers ...*labels.Matcher) ([]
 }
 
 // LabelValues returns value tuples that exist for the given label name.
+// The returned values should be copied if they need to be used beyond the current tsdb read operation, including sending back as response.
 // TODO(replay): Support filtering by matchers
 func (r *Reader) LabelValues(name string, matchers ...*labels.Matcher) ([]string, error) {
 	if len(matchers) > 0 {
@@ -1670,7 +1671,7 @@ func (r *Reader) LabelValues(name string, matchers ...*labels.Matcher) ([]string
 		} else {
 			d.Skip(skip)
 		}
-		s := string(d.UvarintBytes()) // Label value.
+		s := yoloString(d.UvarintBytes()) // Label value.
 		values = append(values, s)
 		if s == lastVal {
 			break

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/index_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/index_test.go
@@ -449,9 +449,10 @@ func TestPersistence_index_e2e(t *testing.T) {
 	for k, v := range labelPairs {
 		sort.Strings(v)
 
-		res, err := ir.SortedLabelValues(k)
+		res, err := ir.LabelValues(k)
 		require.NoError(t, err)
 
+		sort.Strings(res)
 		require.Equal(t, len(v), len(res))
 		for i := 0; i < len(v); i++ {
 			require.Equal(t, v[i], res[i])

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/querier.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/querier.go
@@ -51,9 +51,6 @@ type IndexReader interface {
 	// beyond the lifetime of the index reader.
 	Symbols() index.StringIter
 
-	// SortedLabelValues returns sorted possible label values.
-	SortedLabelValues(name string, matchers ...*labels.Matcher) ([]string, error)
-
 	// LabelValues returns possible label values which may not be sorted.
 	LabelValues(name string, matchers ...*labels.Matcher) ([]string, error)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
We are seeing OOMKills on index gateways due to a huge amount of allocations from [LabelValues](https://github.com/grafana/loki/blob/5625464332fc0b3371b744d60d36acaf2600665a/pkg/storage/stores/shipper/indexshipper/tsdb/index/index.go#L1631) method of tsdb index reader. It happens due to copying all the label values read from the tsdb. [This problem arises when the label matchers have any negative matchers](https://github.com/grafana/loki/blob/5625464332fc0b3371b744d60d36acaf2600665a/pkg/storage/stores/shipper/indexshipper/tsdb/querier.go#L175-L191).

I have changed the code to avoid making a copy of the label values unless we want to send it back as a response. I have checked all the usages of that method, and the only place we need to copy the values is when the `LabelValues` method is called explicitly to get all the values.

Here is the benchmark showing the difference in performance:
```
benchmark                              old ns/op      new ns/op     delta
BenchmarkTSDBIndex_GetChunkRefs-10     875881104      927752604     +5.92%
BenchmarkTSDBIndex_GetChunkRefs-10     879311146      862689354     -1.89%
BenchmarkTSDBIndex_GetChunkRefs-10     881187479      926149750     +5.10%
BenchmarkTSDBIndex_GetChunkRefs-10     910079084      899049584     -1.21%
BenchmarkTSDBIndex_GetChunkRefs-10     1014711583     911985770     -10.12%

benchmark                              old allocs     new allocs     delta
BenchmarkTSDBIndex_GetChunkRefs-10     2000140        1000154        -50.00%
BenchmarkTSDBIndex_GetChunkRefs-10     2000139        1000151        -50.00%
BenchmarkTSDBIndex_GetChunkRefs-10     2000141        1000150        -50.00%
BenchmarkTSDBIndex_GetChunkRefs-10     2000141        1000149        -50.00%
BenchmarkTSDBIndex_GetChunkRefs-10     2000146        1000153        -50.00%

benchmark                              old bytes     new bytes     delta
BenchmarkTSDBIndex_GetChunkRefs-10     176039840     168119396     -4.50%
BenchmarkTSDBIndex_GetChunkRefs-10     176039752     168118520     -4.50%
BenchmarkTSDBIndex_GetChunkRefs-10     176039944     168118504     -4.50%
BenchmarkTSDBIndex_GetChunkRefs-10     176039952     168118408     -4.50%
BenchmarkTSDBIndex_GetChunkRefs-10     176057848     168119296     -4.51%
```

**Special notes for your reviewer**:
I introduced the copying of label values in PR https://github.com/grafana/loki/pull/7502 to avoid corruption of values when the underlying tsdb is closed.