### PR TITLE
refactor(stringlabels): Support stringlabels in querier tests

### DIFF
--- a/pkg/querier/multi_tenant_querier_test.go
+++ b/pkg/querier/multi_tenant_querier_test.go
@@ -245,7 +245,7 @@ type mockEntryIterator struct {
 }
 
 func newMockEntryIterator(numLabels int) mockEntryIterator {
-	builder := labels.NewBuilder(nil)
+	builder := labels.NewBuilder(labels.EmptyLabels())
 	for i := 1; i <= numLabels; i++ {
 		builder.Set(fmt.Sprintf("label_%d", i), strconv.Itoa(i))
 	}

--- a/pkg/querier/queryrange/codec_test.go
+++ b/pkg/querier/queryrange/codec_test.go
@@ -695,30 +695,18 @@ func Test_codec_DecodeProtobufResponseParity(t *testing.T) {
 				{
 					T: 1568404331324,
 					F: 0.013333333333333334,
-					Metric: []labels.Label{
-						{
-							Name:  "filename",
-							Value: `/var/hostlog/apport.log`,
-						},
-						{
-							Name:  "job",
-							Value: "varlogs",
-						},
-					},
+					Metric: labels.FromStrings(
+						"filename", `/var/hostlog/apport.log`,
+						"job", "varlogs",
+					),
 				},
 				{
 					T: 1568404331324,
 					F: 3.45,
-					Metric: []labels.Label{
-						{
-							Name:  "filename",
-							Value: `/var/hostlog/syslog`,
-						},
-						{
-							Name:  "job",
-							Value: "varlogs",
-						},
-					},
+					Metric: labels.FromStrings(
+						"filename", `/var/hostlog/syslog`,
+						"job", "varlogs",
+					),
 				},
 			},
 			`{
@@ -762,16 +750,10 @@ func Test_codec_DecodeProtobufResponseParity(t *testing.T) {
 							F: 0.013333333333333334,
 						},
 					},
-					Metric: []labels.Label{
-						{
-							Name:  "filename",
-							Value: `/var/hostlog/apport.log`,
-						},
-						{
-							Name:  "job",
-							Value: "varlogs",
-						},
-					},
+					Metric: labels.FromStrings(
+						"filename", `/var/hostlog/apport.log`,
+						"job", "varlogs",
+					),
 				},
 				{
 					Floats: []promql.FPoint{
@@ -784,16 +766,10 @@ func Test_codec_DecodeProtobufResponseParity(t *testing.T) {
 							F: 4.45,
 						},
 					},
-					Metric: []labels.Label{
-						{
-							Name:  "filename",
-							Value: `/var/hostlog/syslog`,
-						},
-						{
-							Name:  "job",
-							Value: "varlogs",
-						},
-					},
+					Metric: labels.FromStrings(
+						"filename", `/var/hostlog/syslog`,
+						"job", "varlogs",
+					),
 				},
 			},
 			`{

--- a/pkg/querier/queryrange/limits_test.go
+++ b/pkg/querier/queryrange/limits_test.go
@@ -66,9 +66,7 @@ func TestMetricQueryCacheKey(t *testing.T) {
 		ingesterQueryWindow = defaultSplit * 3
 	)
 
-	var (
-		step = (15 * time.Second).Milliseconds()
-	)
+	step := (15 * time.Second).Milliseconds()
 
 	l := fakeLimits{
 		splitDuration:         map[string]time.Duration{defaultTenant: defaultSplit, alternateTenant: defaultSplit},
@@ -205,16 +203,10 @@ func Test_seriesLimiter(t *testing.T) {
 						F: 0.013333333333333334,
 					},
 				},
-				Metric: []labels.Label{
-					{
-						Name:  "filename",
-						Value: `/var/hostlog/apport.log`,
-					},
-					{
-						Name:  "job",
-						Value: "anotherjob",
-					},
-				},
+				Metric: labels.FromStrings(
+					"filename", `/var/hostlog/apport.log`,
+					"job", "anotherjob",
+				),
 			},
 		}
 		params, err := ParamsFromRequest(req)
@@ -755,7 +747,6 @@ func Test_WeightedParallelism(t *testing.T) {
 			})
 		}
 	}
-
 }
 
 func Test_WeightedParallelism_DivideByZeroError(t *testing.T) {
@@ -971,7 +962,6 @@ func Test_MaxQuerySize(t *testing.T) {
 			require.Equal(t, tc.expectedQuerierStatsHits, *querierStatsHits)
 		})
 	}
-
 }
 
 func Test_MaxQuerySize_MaxLookBackPeriod(t *testing.T) {

--- a/pkg/querier/queryrange/queryrangebase/promql_test.go
+++ b/pkg/querier/queryrange/queryrangebase/promql_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -40,7 +39,7 @@ var (
 func Test_PromQL(t *testing.T) {
 	t.Parallel()
 
-	var tests = []struct {
+	tests := []struct {
 		normalQuery string
 		shardQuery  string
 		shouldEqual bool
@@ -322,7 +321,6 @@ func Test_PromQL(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.normalQuery, func(t *testing.T) {
-
 			baseQuery, err := engine.NewRangeQuery(context.Background(), shardAwareQueryable, nil, tt.normalQuery, start, end, step)
 			require.Nil(t, err)
 			shardQuery, err := engine.NewRangeQuery(context.Background(), shardAwareQueryable, nil, tt.shardQuery, start, end, step)
@@ -338,7 +336,6 @@ func Test_PromQL(t *testing.T) {
 			require.NotEqual(t, baseResult, shardResult)
 		})
 	}
-
 }
 
 func Test_FunctionParallelism(t *testing.T) {
@@ -520,7 +517,6 @@ func Test_FunctionParallelism(t *testing.T) {
 			fArgs: []string{"20"},
 		},
 	} {
-
 		t.Run(tc.fn, func(t *testing.T) {
 			baseQuery, err := engine.NewRangeQuery(
 				context.Background(),
@@ -567,18 +563,17 @@ func Test_FunctionParallelism(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 var shardAwareQueryable = storage.QueryableFunc(func(_, _ int64) (storage.Querier, error) {
 	return &testMatrix{
 		series: []*promql.StorageSeries{
-			newSeries(labels.Labels{{Name: "__name__", Value: "bar1"}, {Name: "baz", Value: "blip"}, {Name: "bar", Value: "blop"}, {Name: "foo", Value: "barr"}}, factor(5)),
-			newSeries(labels.Labels{{Name: "__name__", Value: "bar1"}, {Name: "baz", Value: "blip"}, {Name: "bar", Value: "blop"}, {Name: "foo", Value: "bazz"}}, factor(7)),
-			newSeries(labels.Labels{{Name: "__name__", Value: "bar1"}, {Name: "baz", Value: "blip"}, {Name: "bar", Value: "blap"}, {Name: "foo", Value: "buzz"}}, factor(12)),
-			newSeries(labels.Labels{{Name: "__name__", Value: "bar1"}, {Name: "baz", Value: "blip"}, {Name: "bar", Value: "blap"}, {Name: "foo", Value: "bozz"}}, factor(11)),
-			newSeries(labels.Labels{{Name: "__name__", Value: "bar1"}, {Name: "baz", Value: "blip"}, {Name: "bar", Value: "blop"}, {Name: "foo", Value: "buzz"}}, factor(8)),
-			newSeries(labels.Labels{{Name: "__name__", Value: "bar1"}, {Name: "baz", Value: "blip"}, {Name: "bar", Value: "blap"}, {Name: "foo", Value: "bazz"}}, identity),
+			newSeries(labels.FromStrings("__name__", "bar1", "baz", "blip", "bar", "blop", "foo", "barr"), factor(5)),
+			newSeries(labels.FromStrings("__name__", "bar1", "baz", "blip", "bar", "blop", "foo", "bazz"), factor(7)),
+			newSeries(labels.FromStrings("__name__", "bar1", "baz", "blip", "bar", "blap", "foo", "buzz"), factor(12)),
+			newSeries(labels.FromStrings("__name__", "bar1", "baz", "blip", "bar", "blap", "foo", "bozz"), factor(11)),
+			newSeries(labels.FromStrings("__name__", "bar1", "baz", "blip", "bar", "blop", "foo", "buzz"), factor(8)),
+			newSeries(labels.FromStrings("__name__", "bar1", "baz", "blip", "bar", "blap", "foo", "bazz"), identity),
 		},
 	}, nil
 })
@@ -620,13 +615,13 @@ func (m *testMatrix) Select(_ context.Context, _ bool, _ *storage.SelectHints, m
 func (m *testMatrix) LabelValues(_ context.Context, _ string, _ *storage.LabelHints, _ ...*labels.Matcher) ([]string, annotations.Annotations, error) {
 	return nil, nil, nil
 }
+
 func (m *testMatrix) LabelNames(_ context.Context, _ *storage.LabelHints, _ ...*labels.Matcher) ([]string, annotations.Annotations, error) {
 	return nil, nil, nil
 }
 func (m *testMatrix) Close() error { return nil }
 
 func newSeries(metric labels.Labels, generator func(float64) float64) *promql.StorageSeries {
-	sort.Sort(metric)
 	var points []promql.FPoint
 
 	for ts := start.Add(-step); ts.Unix() <= end.Unix(); ts = ts.Add(step) {
@@ -680,11 +675,10 @@ func splitByShard(shardIndex, shardTotal int, testMatrices *testMatrix) *testMat
 			})
 
 		}
-		lbs := s.Labels().Copy()
-		lbs = append(lbs, labels.Label{Name: "__cortex_shard__", Value: fmt.Sprintf("%d_of_%d", shardIndex, shardTotal)})
-		sort.Sort(lbs)
+		lbs := labels.NewBuilder(s.Labels())
+		lbs.Set("__cortex_shard__", fmt.Sprintf("%d_of_%d", shardIndex, shardTotal))
 		res.series = append(res.series, promql.NewStorageSeries(promql.Series{
-			Metric: lbs,
+			Metric: lbs.Labels(),
 			Floats: points,
 		}))
 	}

--- a/pkg/querier/queryrange/queryrangebase/test_utils.go
+++ b/pkg/querier/queryrange/queryrangebase/test_utils.go
@@ -20,26 +20,23 @@ func genLabels(
 	labelSet []string,
 	labelBuckets int,
 ) (result []labels.Labels) {
+
 	if len(labelSet) == 0 {
-		return result
+		return []labels.Labels{}
 	}
 
 	l := labelSet[0]
 	rest := genLabels(labelSet[1:], labelBuckets)
 
 	for i := 0; i < labelBuckets; i++ {
-		x := labels.Label{
-			Name:  l,
-			Value: fmt.Sprintf("%d", i),
-		}
 		if len(rest) == 0 {
-			set := labels.Labels{x}
-			result = append(result, set)
+			result = append(result, labels.FromStrings(l, fmt.Sprintf("%d", i)))
 			continue
 		}
 		for _, others := range rest {
-			set := append(others, x)
-			result = append(result, set)
+			builder := labels.NewBuilder(others)
+			builder.Set(l, fmt.Sprintf("%d", i))
+			result = append(result, builder.Labels())
 		}
 	}
 	return result
@@ -154,20 +151,17 @@ type ShardLabelSeries struct {
 
 // Labels impls storage.Series
 func (s *ShardLabelSeries) Labels() labels.Labels {
-	ls := s.Series.Labels()
+	ls := labels.NewBuilder(s.Series.Labels())
 
 	if s.name != "" {
-		ls = append(ls, labels.Label{
-			Name:  "__name__",
-			Value: s.name,
-		})
+		ls.Set("__name__", s.name)
 	}
 
 	if s.shard != nil {
-		ls = append(ls, s.shard.Label())
+		ls.Set(s.shard.Label().Name, s.shard.Label().Value)
 	}
 
-	return ls
+	return ls.Labels()
 }
 
 // LabelValues impls storage.Querier

--- a/pkg/querier/queryrange/queryrangebase/test_utils_test.go
+++ b/pkg/querier/queryrange/queryrangebase/test_utils_test.go
@@ -2,7 +2,6 @@ package queryrangebase
 
 import (
 	"math"
-	"sort"
 	"testing"
 
 	"github.com/prometheus/prometheus/model/labels"
@@ -14,50 +13,23 @@ import (
 
 func TestGenLabelsCorrectness(t *testing.T) {
 	ls := genLabels([]string{"a", "b"}, 2)
-	for _, set := range ls {
-		sort.Sort(set)
-	}
 	expected := []labels.Labels{
-		{
-			labels.Label{
-				Name:  "a",
-				Value: "0",
-			},
-			labels.Label{
-				Name:  "b",
-				Value: "0",
-			},
-		},
-		{
-			labels.Label{
-				Name:  "a",
-				Value: "0",
-			},
-			labels.Label{
-				Name:  "b",
-				Value: "1",
-			},
-		},
-		{
-			labels.Label{
-				Name:  "a",
-				Value: "1",
-			},
-			labels.Label{
-				Name:  "b",
-				Value: "0",
-			},
-		},
-		{
-			labels.Label{
-				Name:  "a",
-				Value: "1",
-			},
-			labels.Label{
-				Name:  "b",
-				Value: "1",
-			},
-		},
+		labels.FromStrings(
+			"a", "0",
+			"b", "0",
+		),
+		labels.FromStrings(
+			"a", "0",
+			"b", "1",
+		),
+		labels.FromStrings(
+			"a", "1",
+			"b", "0",
+		),
+		labels.FromStrings(
+			"a", "1",
+			"b", "1",
+		),
 	}
 	require.Equal(t, expected, ls)
 }

--- a/pkg/querier/queryrange/queryrangebase/value_test.go
+++ b/pkg/querier/queryrange/queryrangebase/value_test.go
@@ -49,18 +49,18 @@ func TestFromValue(t *testing.T) {
 					promql.Sample{
 						T: 1,
 						F: 1,
-						Metric: labels.Labels{
-							{Name: "a", Value: "a1"},
-							{Name: "b", Value: "b1"},
-						},
+						Metric: labels.FromStrings(
+							"a", "a1",
+							"b", "b1",
+						),
 					},
 					promql.Sample{
 						T: 2,
 						F: 2,
-						Metric: labels.Labels{
-							{Name: "a", Value: "a2"},
-							{Name: "b", Value: "b2"},
-						},
+						Metric: labels.FromStrings(
+							"a", "a2",
+							"b", "b2",
+						),
 					},
 				},
 			},
@@ -97,20 +97,20 @@ func TestFromValue(t *testing.T) {
 			input: &promql.Result{
 				Value: promql.Matrix{
 					{
-						Metric: labels.Labels{
-							{Name: "a", Value: "a1"},
-							{Name: "b", Value: "b1"},
-						},
+						Metric: labels.FromStrings(
+							"a", "a1",
+							"b", "b1",
+						),
 						Floats: []promql.FPoint{
 							{T: 1, F: 1},
 							{T: 2, F: 2},
 						},
 					},
 					{
-						Metric: labels.Labels{
-							{Name: "a", Value: "a2"},
-							{Name: "b", Value: "b2"},
-						},
+						Metric: labels.FromStrings(
+							"a", "a2",
+							"b", "b2",
+						),
 						Floats: []promql.FPoint{
 							{T: 1, F: 8},
 							{T: 2, F: 9},

--- a/pkg/querier/queryrange/roundtrip_test.go
+++ b/pkg/querier/queryrange/roundtrip_test.go
@@ -114,32 +114,20 @@ var (
 					F: 0.013333333333333334,
 				},
 			},
-			Metric: []labels.Label{
-				{
-					Name:  "filename",
-					Value: `/var/hostlog/apport.log`,
-				},
-				{
-					Name:  "job",
-					Value: "varlogs",
-				},
-			},
+			Metric: labels.FromStrings(
+				"filename", `/var/hostlog/apport.log`,
+				"job", "varlogs",
+			),
 		},
 	}
 	vector = promql.Vector{
 		{
 			T: toMs(testTime.Add(-4 * time.Hour)),
 			F: 0.013333333333333334,
-			Metric: []labels.Label{
-				{
-					Name:  "filename",
-					Value: `/var/hostlog/apport.log`,
-				},
-				{
-					Name:  "job",
-					Value: "varlogs",
-				},
-			},
+			Metric: labels.FromStrings(
+				"filename", `/var/hostlog/apport.log`,
+				"job", "varlogs",
+			),
 		},
 	}
 	streams = logqlmodel.Streams{

--- a/pkg/querier/queryrange/views_test.go
+++ b/pkg/querier/queryrange/views_test.go
@@ -32,7 +32,8 @@ func TestGetLokiSeriesResponse(t *testing.T) {
 						},
 					},
 				},
-			}},
+			},
+		},
 	}
 	buf, err := p.Marshal()
 	require.NoError(t, err)
@@ -73,6 +74,7 @@ func TestSeriesIdentifierViewHash(t *testing.T) {
 	expected := identifier.Hash(b)
 	require.Equal(t, expected, actual)
 }
+
 func TestSeriesIdentifierViewForEachLabel(t *testing.T) {
 	identifier := &logproto.SeriesIdentifier{
 		Labels: []logproto.SeriesIdentifier_LabelsEntry{
@@ -242,13 +244,13 @@ func TestMergedViewMaterialize(t *testing.T) {
 	require.Len(t, mat.Data, 3)
 	series := make([]string, 0)
 	for _, d := range mat.Data {
-		l := make([]labels.Label, 0, len(d.Labels))
+		l := labels.NewBuilder(labels.EmptyLabels())
 		for _, p := range d.Labels {
-			l = append(l, labels.Label{Name: p.Key, Value: p.Value})
+			l.Set(p.Key, p.Value)
 		}
-		series = append(series, labels.Labels(l).String())
+		series = append(series, l.Labels().String())
 	}
-	expected := []string{`{i="1", baz="woof"}`, `{i="3", baz="woof"}`, `{i="2", foo="bar"}`}
+	expected := []string{`{baz="woof", i="1"}`, `{baz="woof", i="3"}`, `{foo="bar", i="2"}`}
 	require.ElementsMatch(t, series, expected)
 }
 
@@ -360,5 +362,4 @@ func Benchmark_DecodeMergeEncodeCycle(b *testing.B) {
 		require.NoError(b, err)
 		require.Equal(b, "application/json; charset=UTF-8", httpRes.Header.Get("Content-Type"))
 	}
-
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This is the first step of support Prometheus `stringlabels` implementation in Loki. 

**Special notes for your reviewer**:
The tests should compile with build tag `stringlabels`.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
