### PR TITLE
feat: Optionally enable kafka histograms for read/write latency

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -826,6 +826,11 @@ kafka_config:
   # CLI flag: -kafka.max-consumer-lag-at-startup
   [max_consumer_lag_at_startup: <duration> | default = 15s]
 
+  # Enable collection of the following kafka latency histograms: read-wait,
+  # read-timing, write-wait, write-timing
+  # CLI flag: -kafka.enable-kafka-histograms
+  [enable_kafka_histograms: <boolean> | default = false]
+
 dataobj:
   consumer:
     builderconfig:

--- a/pkg/blockbuilder/builder/builder.go
+++ b/pkg/blockbuilder/builder/builder.go
@@ -626,7 +626,7 @@ func withBackoff[T any](
 ) (T, error) {
 	var zero T
 
-	boff := backoff.New(ctx, config)
+	var boff = backoff.New(ctx, config)
 	for boff.Ongoing() {
 		res, err := fn()
 		if err != nil {

--- a/pkg/blockbuilder/builder/builder.go
+++ b/pkg/blockbuilder/builder/builder.go
@@ -139,7 +139,8 @@ func NewBlockBuilder(
 	logger log.Logger,
 	registerer prometheus.Registerer,
 ) (*BlockBuilder,
-	error) {
+	error,
+) {
 	decoder, err := kafka.NewDecoder()
 	if err != nil {
 		return nil, err
@@ -176,7 +177,7 @@ func (i *BlockBuilder) running(ctx context.Context) error {
 		errgrp.Go(func() error {
 			c, err := client.NewReaderClient(
 				i.kafkaCfg,
-				client.NewReaderClientMetrics(workerID, i.registerer),
+				client.NewReaderClientMetrics(workerID, i.registerer, false),
 				log.With(i.logger, "component", workerID),
 			)
 			if err != nil {
@@ -202,7 +203,6 @@ func (i *BlockBuilder) running(ctx context.Context) error {
 					}
 				}
 			}
-
 		})
 	}
 
@@ -351,7 +351,6 @@ func (i *BlockBuilder) processJob(ctx context.Context, c *kgo.Client, job *types
 		"appender",
 		i.cfg.ConcurrentWriters,
 		func(ctx context.Context) error {
-
 			for {
 				select {
 				case <-ctx.Done():
@@ -627,7 +626,7 @@ func withBackoff[T any](
 ) (T, error) {
 	var zero T
 
-	var boff = backoff.New(ctx, config)
+	boff := backoff.New(ctx, config)
 	for boff.Ongoing() {
 		res, err := fn()
 		if err != nil {

--- a/pkg/dataobj/consumer/service.go
+++ b/pkg/dataobj/consumer/service.go
@@ -63,7 +63,7 @@ func New(kafkaCfg kafka.Config, cfg Config, topicPrefix string, bucket objstore.
 		kafkaCfg,
 		partitionRing,
 		groupName,
-		client.NewReaderClientMetrics(groupName, reg),
+		client.NewReaderClientMetrics(groupName, reg, kafkaCfg.EnableKafkaHistograms),
 		logger,
 		kgo.InstanceID(instanceID),
 		kgo.SessionTimeout(3*time.Minute),

--- a/pkg/kafka/client/writer_client.go
+++ b/pkg/kafka/client/writer_client.go
@@ -38,7 +38,9 @@ func NewWriterClient(kafkaCfg kafka.Config, maxInflightProduceRequests int, logg
 	metrics := kprom.NewMetrics(
 		"", // No prefix. We expect the input prometheus.Registered to be wrapped with a prefix.
 		kprom.Registerer(reg),
-		kprom.FetchAndProduceDetail(kprom.Batches, kprom.Records, kprom.CompressedBytes, kprom.UncompressedBytes))
+		kprom.FetchAndProduceDetail(kprom.Batches, kprom.Records, kprom.CompressedBytes, kprom.UncompressedBytes),
+		enableKafkaHistogramMetrics(kafkaCfg.EnableKafkaHistograms),
+	)
 
 	opts := append(
 		commonKafkaClientOptions(kafkaCfg, metrics, logger),

--- a/pkg/kafka/config.go
+++ b/pkg/kafka/config.go
@@ -56,6 +56,8 @@ type Config struct {
 	ProducerMaxBufferedBytes   int64 `yaml:"producer_max_buffered_bytes"`
 
 	MaxConsumerLagAtStartup time.Duration `yaml:"max_consumer_lag_at_startup"`
+
+	EnableKafkaHistograms bool `yaml:"enable_kafka_histograms"`
 }
 
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
@@ -85,6 +87,8 @@ func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 
 	consumerLagUsage := fmt.Sprintf("Set -%s to 0 to disable waiting for maximum consumer lag being honored at startup.", prefix+".max-consumer-lag-at-startup")
 	f.DurationVar(&cfg.MaxConsumerLagAtStartup, prefix+".max-consumer-lag-at-startup", 15*time.Second, "The guaranteed maximum lag before a consumer is considered to have caught up reading from a partition at startup, becomes ACTIVE in the hash ring and passes the readiness check. "+consumerLagUsage)
+
+	f.BoolVar(&cfg.EnableKafkaHistograms, prefix+".enable-kafka-histograms", false, "Enable collection of the following kafka latency histograms: read-wait, read-timing, write-wait, write-timing")
 }
 
 func (cfg *Config) Validate() error {

--- a/pkg/kafka/partition/offset_manager.go
+++ b/pkg/kafka/partition/offset_manager.go
@@ -92,7 +92,7 @@ func NewKafkaOffsetManager(
 	reg prometheus.Registerer,
 ) (*KafkaOffsetManager, error) {
 	// Create a new Kafka client for the partition manager.
-	clientMetrics := client.NewReaderClientMetrics("partition-manager", reg)
+	clientMetrics := client.NewReaderClientMetrics("partition-manager", reg, false)
 	c, err := client.NewReaderClient(
 		cfg,
 		clientMetrics,

--- a/pkg/kafka/partition/offset_manager.go
+++ b/pkg/kafka/partition/offset_manager.go
@@ -92,7 +92,7 @@ func NewKafkaOffsetManager(
 	reg prometheus.Registerer,
 ) (*KafkaOffsetManager, error) {
 	// Create a new Kafka client for the partition manager.
-	clientMetrics := client.NewReaderClientMetrics("partition-manager", reg, false)
+	clientMetrics := client.NewReaderClientMetrics("partition-manager", reg, cfg.EnableKafkaHistograms)
 	c, err := client.NewReaderClient(
 		cfg,
 		clientMetrics,

--- a/pkg/kafka/partition/reader.go
+++ b/pkg/kafka/partition/reader.go
@@ -55,7 +55,7 @@ type ReaderMetrics struct {
 	kprom             *kprom.Metrics
 }
 
-func NewReaderMetrics(r prometheus.Registerer) *ReaderMetrics {
+func NewReaderMetrics(r prometheus.Registerer, enableKafkaHistograms bool) *ReaderMetrics {
 	return &ReaderMetrics{
 		consumptionLag: promauto.With(r).NewHistogramVec(prometheus.HistogramOpts{
 			Name:                            "loki_kafka_reader_consumption_lag_seconds",
@@ -84,7 +84,7 @@ func NewReaderMetrics(r prometheus.Registerer) *ReaderMetrics {
 			Name: "loki_kafka_reader_fetches_total",
 			Help: "Total number of Kafka fetches performed.",
 		}),
-		kprom: client.NewReaderClientMetrics("partition-reader", r),
+		kprom: client.NewReaderClientMetrics("partition-reader", r, enableKafkaHistograms),
 	}
 }
 

--- a/pkg/kafka/partition/reader_service.go
+++ b/pkg/kafka/partition/reader_service.go
@@ -75,7 +75,7 @@ func NewReaderService(
 	logger log.Logger,
 	reg prometheus.Registerer,
 ) (*ReaderService, error) {
-	readerMetrics := NewReaderMetrics(reg, false)
+	readerMetrics := NewReaderMetrics(reg, kafkaCfg.EnableKafkaHistograms)
 	reader, err := NewKafkaReader(
 		kafkaCfg,
 		partitionID,

--- a/pkg/kafka/partition/reader_service.go
+++ b/pkg/kafka/partition/reader_service.go
@@ -75,7 +75,7 @@ func NewReaderService(
 	logger log.Logger,
 	reg prometheus.Registerer,
 ) (*ReaderService, error) {
-	readerMetrics := NewReaderMetrics(reg)
+	readerMetrics := NewReaderMetrics(reg, false)
 	reader, err := NewKafkaReader(
 		kafkaCfg,
 		partitionID,

--- a/pkg/limits/ingest_limits.go
+++ b/pkg/limits/ingest_limits.go
@@ -162,7 +162,7 @@ func NewIngestLimits(cfg Config, logger log.Logger, reg prometheus.Registerer) (
 	s.lifecyclerWatcher = services.NewFailureWatcher()
 	s.lifecyclerWatcher.WatchService(s.lifecycler)
 
-	metrics := client.NewReaderClientMetrics("ingest-limits", reg)
+	metrics := client.NewReaderClientMetrics("ingest-limits", reg, cfg.KafkaConfig.EnableKafkaHistograms)
 
 	// Create a copy of the config to modify the topic
 	kCfg := cfg.KafkaConfig


### PR DESCRIPTION
**What this PR does / why we need it**:
Introduces a new config option for kafka clients to enable (or disable) read/write wait and timing histograms.  These are not enabled by default, so this change introduces a new CLI flag and YAML opt which configures the collected metrics to include/exclude historgams.

This PR includes updating the dataobj, blockbuilder (deprecated), and ingest limits so they can take advantage of these collected metrics and monitor latency when reading from and writing to kafka.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
