### PR TITLE
fix: ConfigMap "grafana-dashboard-loki_thanos_object_storage" is invalid

### DIFF
--- a/production/loki-mixin/dashboards/loki-object-store.libsonnet
+++ b/production/loki-mixin/dashboards/loki-object-store.libsonnet
@@ -9,7 +9,7 @@ local row = grafana.row;
         _config+:: $._config,
       }
     ),
-    'loki_thanos_object_storage.json':
+    'loki-thanos-object-storage.json':
       dashboard.dashboard('Loki / Object Store Thanos', uid='object-store')
       .addCluster()
       .addNamespace()


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes an invalid ConfigMap name by replacing underscores with hyphens in the dashboard filename. The current name loki_thanos_object_storage.json results in a ConfigMap with name grafana-dashboard-loki_thanos_object_storage, which fails Kubernetes validation as it contains underscores. The PR changes the filename to loki-thanos-object-storage.json to ensure the resulting ConfigMap name complies with Kubernetes naming requirements.

**Which issue(s) this PR fixes**:
NA

**Special notes for your reviewer**:
The error occurs because Kubernetes ConfigMap names must follow the RFC 1123 subdomain naming convention, which doesn't allow underscores. This is a simple fix to ensure dashboard deployments succeed.