### PR TITLE
feat: Add endpoint returning tenant configured limits

### DIFF
--- a/pkg/loki/config_handler.go
+++ b/pkg/loki/config_handler.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"reflect"
 
-	"github.com/gorilla/mux"
+	"github.com/grafana/dskit/tenant"
 	"gopkg.in/yaml.v2"
 )
 
@@ -121,9 +121,9 @@ func (t *Loki) tenantLimitsHandler() func(http.ResponseWriter, *http.Request) {
 			return
 		}
 
-		user := mux.Vars(r)["tenant"]
-		if user == "" {
-			http.Error(w, "Tenant ID not provided", http.StatusBadRequest)
+		user, _, err := tenant.ExtractTenantIDFromHTTPRequest(r)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusUnauthorized)
 			return
 		}
 

--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -11,10 +11,6 @@ import (
 	rt "runtime"
 	"time"
 
-	"go.uber.org/atomic"
-
-	"google.golang.org/grpc/health/grpc_health_v1"
-
 	"github.com/fatih/color"
 	"github.com/felixge/fgprof"
 	"github.com/go-kit/log/level"
@@ -30,6 +26,8 @@ import (
 	"github.com/grafana/dskit/signals"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
+	"go.uber.org/atomic"
+	"google.golang.org/grpc/health/grpc_health_v1"
 
 	"github.com/grafana/loki/v3/pkg/analytics"
 	blockbuilder "github.com/grafana/loki/v3/pkg/blockbuilder/builder"
@@ -505,6 +503,7 @@ func (t *Loki) bindConfigEndpoint(opts RunOpts) {
 		configEndpointHandlerFn = opts.CustomConfigEndpointHandlerFn
 	}
 	t.Server.HTTP.Path("/config").Methods("GET").HandlerFunc(configEndpointHandlerFn)
+	t.Server.HTTP.Path("/config/tenant/{tenant}/limits").Methods("GET").HandlerFunc(t.tenantLimitsHandler())
 }
 
 // ListTargets prints a list of available user visible targets and their

--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -503,7 +503,7 @@ func (t *Loki) bindConfigEndpoint(opts RunOpts) {
 		configEndpointHandlerFn = opts.CustomConfigEndpointHandlerFn
 	}
 	t.Server.HTTP.Path("/config").Methods("GET").HandlerFunc(configEndpointHandlerFn)
-	t.Server.HTTP.Path("/config/tenant/{tenant}/limits").Methods("GET").HandlerFunc(t.tenantLimitsHandler())
+	t.Server.HTTP.Path("/config/tenant/v1/limits").Methods("GET").HandlerFunc(t.tenantLimitsHandler())
 }
 
 // ListTargets prints a list of available user visible targets and their


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds a new API endpoint `GET  /config/tenant/{tenant}/limits` that returns the configured limits (merged with the defaults) of a tenant.

Note, this may be useful to implement the tenants limits page in the new operator UI
https://github.com/grafana/loki/blob/dbf2befc1d888905bb7a69a96c8ba660153808eb/pkg/ui/frontend/src/config/routes.tsx#L94-L98
