### PR TITLE
refactor(stringlabels): Support stringlabels in loghttp, pattern and ruler tests.

### DIFF
--- a/pkg/loghttp/query_test.go
+++ b/pkg/loghttp/query_test.go
@@ -154,21 +154,14 @@ func TestStreams_ToProto(t *testing.T) {
 					Labels: map[string]string{"job": "fake"},
 					Entries: []Entry{
 						{Timestamp: time.Unix(0, 1), Line: "1"},
-						{Timestamp: time.Unix(0, 2), Line: "2", StructuredMetadata: labels.Labels{
-							{Name: "foo", Value: "a"},
-							{Name: "bar", Value: "b"},
-						}},
+						{Timestamp: time.Unix(0, 2), Line: "2", StructuredMetadata: labels.FromStrings("foo", "a", "bar", "b")},
 					},
 				},
 				{
 					Labels: map[string]string{"job": "fake", "lvl": "error"},
 					Entries: []Entry{
 						{Timestamp: time.Unix(0, 3), Line: "3"},
-						{Timestamp: time.Unix(0, 4), Line: "4",
-							StructuredMetadata: labels.Labels{
-								{Name: "foo", Value: "a"},
-								{Name: "bar", Value: "b"},
-							}},
+						{Timestamp: time.Unix(0, 4), Line: "4", StructuredMetadata: labels.FromStrings("foo", "a", "bar", "b")},
 					},
 				},
 			},
@@ -178,8 +171,8 @@ func TestStreams_ToProto(t *testing.T) {
 					Entries: []logproto.Entry{
 						{Timestamp: time.Unix(0, 1), Line: "1"},
 						{Timestamp: time.Unix(0, 2), Line: "2", StructuredMetadata: []logproto.LabelAdapter{
-							{Name: "foo", Value: "a"},
 							{Name: "bar", Value: "b"},
+							{Name: "foo", Value: "a"},
 						}},
 					},
 				},
@@ -188,8 +181,8 @@ func TestStreams_ToProto(t *testing.T) {
 					Entries: []logproto.Entry{
 						{Timestamp: time.Unix(0, 3), Line: "3"},
 						{Timestamp: time.Unix(0, 4), Line: "4", StructuredMetadata: []logproto.LabelAdapter{
-							{Name: "foo", Value: "a"},
 							{Name: "bar", Value: "b"},
+							{Name: "foo", Value: "a"},
 						}},
 					},
 				},
@@ -224,10 +217,7 @@ func Test_QueryResponseUnmarshal(t *testing.T) {
 						Labels: LabelSet{"foo": "bar"},
 						Entries: []Entry{
 							{Timestamp: time.Unix(0, 1), Line: "1"},
-							{Timestamp: time.Unix(0, 2), Line: "2", StructuredMetadata: labels.Labels{
-								{Name: "foo", Value: "a"},
-								{Name: "bar", Value: "b"},
-							}},
+							{Timestamp: time.Unix(0, 2), Line: "2", StructuredMetadata: labels.FromStrings("foo", "a", "bar", "b")},
 						},
 					},
 				},
@@ -247,10 +237,7 @@ func Test_QueryResponseUnmarshal(t *testing.T) {
 						Labels: LabelSet{"foo": "bar"},
 						Entries: []Entry{
 							{Timestamp: time.Unix(0, 1), Line: "log line 1"},
-							{Timestamp: time.Unix(0, 2), Line: "some log line 2", StructuredMetadata: labels.Labels{
-								{Name: "foo", Value: "a"},
-								{Name: "bar", Value: "b"},
-							}},
+							{Timestamp: time.Unix(0, 2), Line: "some log line 2", StructuredMetadata: labels.FromStrings("foo", "a", "bar", "b")},
 						},
 					},
 					Stream{
@@ -260,10 +247,7 @@ func Test_QueryResponseUnmarshal(t *testing.T) {
 							{Timestamp: time.Unix(0, 2), Line: "2"},
 							{Timestamp: time.Unix(0, 2), Line: "2"},
 							{Timestamp: time.Unix(0, 2), Line: "2"},
-							{Timestamp: time.Unix(0, 2), Line: "2", StructuredMetadata: labels.Labels{
-								{Name: "foo", Value: "a"},
-								{Name: "bar", Value: "b"},
-							}},
+							{Timestamp: time.Unix(0, 2), Line: "2", StructuredMetadata: labels.FromStrings("foo", "a", "bar", "b")},
 						},
 					},
 				},

--- a/pkg/pattern/aggregation/push_test.go
+++ b/pkg/pattern/aggregation/push_test.go
@@ -334,13 +334,13 @@ func labelSet(keyVals ...string) labels.Labels {
 		panic("not matching key-value pairs")
 	}
 
-	lbls := labels.Labels{}
+	lbls := labels.NewBuilder(labels.EmptyLabels())
 
 	for i := 0; i < len(keyVals)-1; i += 2 {
-		lbls = append(lbls, labels.Label{Name: keyVals[i], Value: keyVals[i+1]})
+		lbls.Set(keyVals[i], keyVals[i+1])
 	}
 
-	return lbls
+	return lbls.Labels()
 }
 
 func testPayload() (time.Time, string) {

--- a/pkg/ruler/base/notifier_test.go
+++ b/pkg/ruler/base/notifier_test.go
@@ -319,9 +319,7 @@ func TestBuildNotifierConfig(t *testing.T) {
 				AlertManagerConfig: ruler_config.AlertManagerConfig{
 					AlertmanagerURL: "http://alertmanager.default.svc.cluster.local/alertmanager",
 				},
-				ExternalLabels: []labels.Label{
-					{Name: "region", Value: "us-east-1"},
-				},
+				ExternalLabels: labels.FromStrings("region", "us-east-1"),
 			},
 			ncfg: &config.Config{
 				AlertingConfig: config.AlertingConfig{
@@ -341,9 +339,7 @@ func TestBuildNotifierConfig(t *testing.T) {
 					},
 				},
 				GlobalConfig: config.GlobalConfig{
-					ExternalLabels: []labels.Label{
-						{Name: "region", Value: "us-east-1"},
-					},
+					ExternalLabels: labels.FromStrings("region", "us-east-1"),
 				},
 			},
 		},
@@ -361,9 +357,7 @@ func TestBuildNotifierConfig(t *testing.T) {
 						},
 					},
 				},
-				ExternalLabels: []labels.Label{
-					{Name: "region", Value: "us-east-1"},
-				},
+				ExternalLabels: labels.FromStrings("region", "us-east-1"),
 			},
 			ncfg: &config.Config{
 				AlertingConfig: config.AlertingConfig{
@@ -391,9 +385,7 @@ func TestBuildNotifierConfig(t *testing.T) {
 					},
 				},
 				GlobalConfig: config.GlobalConfig{
-					ExternalLabels: []labels.Label{
-						{Name: "region", Value: "us-east-1"},
-					},
+					ExternalLabels: labels.FromStrings("region", "us-east-1"),
 				},
 			},
 		},

--- a/pkg/ruler/base/ruler_test.go
+++ b/pkg/ruler/base/ruler_test.go
@@ -275,7 +275,7 @@ func TestNotifierSendsUserIDHeader(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 	}
 	n.Send(&notifier.Alert{
-		Labels: labels.Labels{labels.Label{Name: "alertname", Value: "testalert"}},
+		Labels: labels.FromStrings("alertname", "testalert"),
 	})
 
 	wg.Wait()
@@ -361,11 +361,11 @@ func TestMultiTenantsNotifierSendsUserIDHeader(t *testing.T) {
 	}
 
 	n1.Send(&notifier.Alert{
-		Labels: labels.Labels{labels.Label{Name: "alertname1", Value: "testalert1"}},
+		Labels: labels.FromStrings("alertname1", "testalert1"),
 	})
 
 	n2.Send(&notifier.Alert{
-		Labels: labels.Labels{labels.Label{Name: "alertname2", Value: "testalert2"}},
+		Labels: labels.FromStrings("alertname2", "testalert2"),
 	})
 
 	// Wait for notifications with a timeout
@@ -1748,8 +1748,8 @@ func TestSendAlerts(t *testing.T) {
 		{
 			in: []*promRules.Alert{
 				{
-					Labels:      []labels.Label{{Name: "l1", Value: "v1"}},
-					Annotations: []labels.Label{{Name: "a2", Value: "v2"}},
+					Labels:      labels.FromStrings("l1", "v1"),
+					Annotations: labels.FromStrings("a2", "v2"),
 					ActiveAt:    time.Unix(1, 0),
 					FiredAt:     time.Unix(2, 0),
 					ValidUntil:  time.Unix(3, 0),
@@ -1757,8 +1757,8 @@ func TestSendAlerts(t *testing.T) {
 			},
 			exp: []*notifier.Alert{
 				{
-					Labels:       []labels.Label{{Name: "l1", Value: "v1"}},
-					Annotations:  []labels.Label{{Name: "a2", Value: "v2"}},
+					Labels:       labels.FromStrings("l1", "v1"),
+					Annotations:  labels.FromStrings("a2", "v2"),
 					StartsAt:     time.Unix(2, 0),
 					EndsAt:       time.Unix(3, 0),
 					GeneratorURL: fmt.Sprintf("http://localhost:8080/explore?left=%%7B%%22queries%%22%%3A%%5B%s%%5D%%7D", escapedExpression),
@@ -1768,8 +1768,8 @@ func TestSendAlerts(t *testing.T) {
 		{
 			in: []*promRules.Alert{
 				{
-					Labels:      []labels.Label{{Name: "l1", Value: "v1"}},
-					Annotations: []labels.Label{{Name: "a2", Value: "v2"}},
+					Labels:      labels.FromStrings("l1", "v1"),
+					Annotations: labels.FromStrings("a2", "v2"),
 					ActiveAt:    time.Unix(1, 0),
 					FiredAt:     time.Unix(2, 0),
 					ResolvedAt:  time.Unix(4, 0),
@@ -1777,8 +1777,8 @@ func TestSendAlerts(t *testing.T) {
 			},
 			exp: []*notifier.Alert{
 				{
-					Labels:       []labels.Label{{Name: "l1", Value: "v1"}},
-					Annotations:  []labels.Label{{Name: "a2", Value: "v2"}},
+					Labels:       labels.FromStrings("l1", "v1"),
+					Annotations:  labels.FromStrings("a2", "v2"),
 					StartsAt:     time.Unix(2, 0),
 					EndsAt:       time.Unix(4, 0),
 					GeneratorURL: fmt.Sprintf("http://localhost:8080/explore?left=%%7B%%22queries%%22%%3A%%5B%s%%5D%%7D", escapedExpression),
@@ -1866,10 +1866,7 @@ func TestRecoverAlertsPostOutage(t *testing.T) {
 		fn: func(_ bool, _ *storage.SelectHints, _ ...*labels.Matcher) storage.SeriesSet {
 			return series.NewConcreteSeriesSet([]storage.Series{
 				series.NewConcreteSeries(
-					labels.Labels{
-						{Name: labels.MetricName, Value: "ALERTS_FOR_STATE"},
-						{Name: labels.AlertName, Value: mockRules["user1"][0].GetRules()[0].Alert},
-					},
+					labels.FromStrings(labels.MetricName, "ALERTS_FOR_STATE", labels.AlertName, mockRules["user1"][0].GetRules()[0].Alert),
 					[]model.SamplePair{{Timestamp: model.Time(downAtTimeMs), Value: model.SampleValue(downAtActiveSec)}},
 				),
 			})
@@ -2008,20 +2005,14 @@ func TestRuleGroupAlertsAndSeriesLimit(t *testing.T) {
 				fn: func(_ bool, _ *storage.SelectHints, _ ...*labels.Matcher) storage.SeriesSet {
 					return series.NewConcreteSeriesSet([]storage.Series{
 						series.NewConcreteSeries(
-							labels.Labels{
-								{Name: labels.MetricName, Value: "http_requests"},
-								{Name: labels.InstanceName, Value: "server1"},
-							},
+							labels.FromStrings(labels.MetricName, "http_requests", labels.InstanceName, "server1"),
 							[]model.SamplePair{
 								{Timestamp: model.Time(seriesStartTime.Add(sampleTimeDiff).UnixMilli()), Value: 100},
 								{Timestamp: model.Time(currentTime.UnixMilli()), Value: 100},
 							},
 						),
 						series.NewConcreteSeries(
-							labels.Labels{
-								{Name: labels.MetricName, Value: "http_requests"},
-								{Name: labels.InstanceName, Value: "server2"},
-							},
+							labels.FromStrings(labels.MetricName, "http_requests", labels.InstanceName, "server2"),
 							[]model.SamplePair{
 								{Timestamp: model.Time(seriesStartTime.Add(sampleTimeDiff).UnixMilli()), Value: 100},
 								{Timestamp: model.Time(currentTime.UnixMilli()), Value: 100},

--- a/pkg/ruler/memstore_test.go
+++ b/pkg/ruler/memstore_test.go
@@ -21,9 +21,9 @@ import (
 const ruleName = "testrule"
 
 func labelsToMatchers(ls labels.Labels) (res []*labels.Matcher) {
-	for _, l := range ls {
+	ls.Range(func(l labels.Label) {
 		res = append(res, labels.MustNewMatcher(labels.MatchEqual, l.Name, l.Value))
-	}
+	})
 	return res
 }
 

--- a/pkg/ruler/storage/instance/instance_test.go
+++ b/pkg/ruler/storage/instance/instance_test.go
@@ -198,10 +198,7 @@ func TestInstance(t *testing.T) {
 
 	count := 3
 	for i := 0; i < count; i++ {
-		_, err := app.Append(0, labels.Labels{
-			labels.Label{Name: "__name__", Value: "test"},
-			labels.Label{Name: "iter", Value: fmt.Sprintf("%v", i)},
-		}, refTime-int64(i), float64(i))
+		_, err := app.Append(0, labels.FromStrings("__name__", "test", "iter", fmt.Sprintf("%v", i)), refTime-int64(i), float64(i))
 
 		require.NoError(t, err)
 	}

--- a/pkg/util/conv.go
+++ b/pkg/util/conv.go
@@ -41,9 +41,9 @@ func RoundToMilliseconds(from, through time.Time) (model.Time, model.Time) {
 // LabelsToMetric converts a Labels to Metric
 // Don't do this on any performance sensitive paths.
 func LabelsToMetric(ls labels.Labels) model.Metric {
-	m := make(model.Metric, len(ls))
-	for _, l := range ls {
+	m := make(model.Metric, ls.Len())
+	ls.Range(func(l labels.Label) {
 		m[model.LabelName(l.Name)] = model.LabelValue(l.Value)
-	}
+	})
 	return m
 }

--- a/pkg/util/metrics_helper.go
+++ b/pkg/util/metrics_helper.go
@@ -727,7 +727,7 @@ func (r *UserRegistries) BuildMetricFamiliesPerUser(labelTransformFn MetricLabel
 
 // FromLabelPairsToLabels converts dto.LabelPair into labels.Labels.
 func FromLabelPairsToLabels(pairs []*dto.LabelPair) labels.Labels {
-	builder := labels.NewBuilder(nil)
+	builder := labels.NewBuilder(labels.EmptyLabels())
 	for _, pair := range pairs {
 		builder.Set(pair.GetName(), pair.GetValue())
 	}
@@ -774,7 +774,7 @@ func GetLabels(c prometheus.Collector, filter map[string]string) ([]labels.Label
 	errs := tsdb_errors.NewMulti()
 	var result []labels.Labels
 	dtoMetric := &dto.Metric{}
-	lbls := labels.NewBuilder(nil)
+	lbls := labels.NewBuilder(labels.EmptyLabels())
 
 nextMetric:
 	for m := range ch {
@@ -785,7 +785,7 @@ nextMetric:
 			continue
 		}
 
-		lbls.Reset(nil)
+		lbls.Reset(labels.EmptyLabels())
 		for _, lp := range dtoMetric.Label {
 			n := lp.GetName()
 			v := lp.GetValue()


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a next step of support Prometheus `stringlabels` implementation in Loki. It adds support in tests of `loghttp`, `pattern` and `ruler`.

**Special notes for your reviewer**:
The tests should compile with build tag `stringlabels`.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
