### PR TITLE
chore(ingest-limits): Remove sticky-balancer

### DIFF
--- a/pkg/limits/ingest_limits.go
+++ b/pkg/limits/ingest_limits.go
@@ -173,15 +173,7 @@ func NewIngestLimits(cfg Config, logger log.Logger, reg prometheus.Registerer) (
 	s.client, err = client.NewReaderClient(kCfg, metrics, logger,
 		kgo.ConsumerGroup(consumerGroup),
 		kgo.ConsumeTopics(kCfg.Topic),
-		// TODO(periklis): Remove the sticky balancer once we rolled out
-		// the cooperative sticky balancer. According to KIP-429, once a
-		// group is using cooperative sticky balancing, it is unsafe to have
-		// a member join the group that does not support cooperative balancing.
-		// See group_balancer.go:CooperativeStickyBalancer() for more details.
-		kgo.Balancers(
-			kgo.StickyBalancer(),
-			kgo.CooperativeStickyBalancer(),
-		),
+		kgo.Balancers(kgo.CooperativeStickyBalancer()),
 		kgo.ConsumeResetOffset(kgo.NewOffset().AfterMilli(time.Now().Add(-s.cfg.WindowSize).UnixMilli())),
 		kgo.OnPartitionsAssigned(s.onPartitionsAssigned),
 		kgo.OnPartitionsRevoked(s.onPartitionsRevoked),


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes the original `StickyBalancer` from list of ingest-limits balancers.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:
* This PR is a follow-up of: #17085 
* We will merge this once the previous PR is cut in the next k-branch.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
