### PR TITLE
fix(logql): Fix inconsistency with parsed field short circuiting

### DIFF
--- a/pkg/logql/log/labels.go
+++ b/pkg/logql/log/labels.go
@@ -385,9 +385,15 @@ func (b *LabelsBuilder) Set(category LabelCategory, n, v string) *LabelsBuilder 
 	}
 	b.add[category] = append(b.add[category], labels.Label{Name: n, Value: v})
 
-	// Sometimes labels are set and later modified. Only record
-	// each label once
-	b.parserKeyHints.RecordExtracted(n)
+	if category == ParsedLabel {
+		// We record parsed labels as extracted so that future parse stages can
+		// quickly bypass any existing extracted fields.
+		//
+		// Note that because this is used for bypassing extracted fields, and
+		// because parsed labels always take precedence over structured metadata
+		// and stream labels, we must only call RecordExtracted for parsed labels.
+		b.parserKeyHints.RecordExtracted(n)
+	}
 	return b
 }
 


### PR DESCRIPTION
PR #8724 originally changed the behaviour of LogQL so that the first extracted field takes precedence over any later extracted field with the same name.

However, this PR had two subtle issues due to the caching that parse stages perform for key lookups:

* The precedence logic did not always apply to duplicate fields within the same parse stage (notably for logfmt).

* The caching behaviour could incorrectly cause stages to permanently ignore fields for future log lines where that stage should otherwise perform extraction.

Additionally, once structured metadata was introduced, it was incorrectly being flagged as an "extracted field." Combined with the caching behaviour described above, this means that parsed fields only take precedence over structured metadata if the first log line encountered by the engine doesn't have that field also set as structured metadata.

This can be demonstrated with the following scenario:

1. A log line from a stream that uses structured metadata for `trace_id` is encountered first. This (incorrectly) causes the trace_id field to be ignored in all parse stages.

2. All later log lines from streams without structured metadata can no longer extract or filter on a parsed `trace_id` for the lifetime of the query, due to the caching from step 1.

The fix is two-fold:

* Decouple skipping previously extracted fields from the logic which caches interned keys.

* Only mark parsed labels as extracted fields (previously all labels).

Because the check for whether a field is already extracted is now called more times, the list of extracted fields has been updated to a map to allow for faster checks.
