### PR TITLE
chore: Collect basic stats from dataobj queries

### DIFF
--- a/pkg/dataobj/querier/iter.go
+++ b/pkg/dataobj/querier/iter.go
@@ -14,6 +14,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/logql"
 	"github.com/grafana/loki/v3/pkg/logql/log"
 	"github.com/grafana/loki/v3/pkg/logql/syntax"
+	"github.com/grafana/loki/v3/pkg/logqlmodel/stats"
 )
 
 var (
@@ -71,6 +72,9 @@ func newEntryIterator(ctx context.Context,
 		streamHash      uint64
 		top             = newTopK(int(req.Limit), req.Direction)
 	)
+	statistics := stats.FromContext(ctx)
+	// For dataobjs, this maps to sections downloaded
+	statistics.AddChunksDownloaded(1)
 
 	for {
 		n, err := reader.Read(ctx, buf)
@@ -94,10 +98,13 @@ func newEntryIterator(ctx context.Context,
 			}
 
 			timestamp := record.Timestamp.UnixNano()
+			statistics.AddDecompressedLines(1)
 			line, parsedLabels, ok := streamExtractor.Process(timestamp, record.Line, record.Metadata...)
 			if !ok {
 				continue
 			}
+			statistics.AddPostFilterLines(1)
+
 			var metadata []logproto.LabelAdapter
 			if len(record.Metadata) > 0 {
 				metadata = logproto.FromLabelsToLabelAdapters(record.Metadata)
@@ -293,6 +300,10 @@ func newSampleIterator(ctx context.Context,
 		streamHash      uint64
 	)
 
+	statistics := stats.FromContext(ctx)
+	// For dataobjs, this maps to sections downloaded
+	statistics.AddChunksDownloaded(1)
+
 	for {
 		n, err := reader.Read(ctx, buf)
 		if err != nil && err != io.EOF {
@@ -328,10 +339,12 @@ func newSampleIterator(ctx context.Context,
 				// TODO(twhitney): when iterating over multiple extractors, we need a way to pre-process as much of the line as possible
 				// In the case of multi-variant expressions, the only difference between the multiple extractors should be the final value, with all
 				// other filters and processing already done.
+				statistics.AddDecompressedLines(1)
 				value, parsedLabels, ok := streamExtractor.Process(timestamp, record.Line, record.Metadata...)
 				if !ok {
 					continue
 				}
+				statistics.AddPostFilterLines(1)
 
 				// Get or create series for the parsed labels
 				labelString := parsedLabels.String()

--- a/pkg/logql/bench/bench_test.go
+++ b/pkg/logql/bench/bench_test.go
@@ -150,8 +150,11 @@ func BenchmarkLogQL(b *testing.B) {
 
 				b.ResetTimer()
 				for i := 0; i < b.N; i++ {
-					_, err := q.Exec(ctx)
+					r, err := q.Exec(ctx)
 					require.NoError(b, err)
+					b.ReportMetric(float64(r.Statistics.TotalDecompressedLines()), "linesScanned")
+					b.ReportMetric(float64(r.Statistics.TotalChunksDownloaded()), "chunks/dataobjSections")
+					b.ReportMetric(float64(r.Statistics.Summary.TotalPostFilterLines), "postFilterLines")
 				}
 			})
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
Connects dataobj querier to the existing stats object for a very limited set of metrics.
* I didn't modify the object at all, so ChunksDownloaded refers to Dataobj Sections accessed.
* This is quick and dirty to get an idea of whats going on - I will look to embed this into more closely into dataobjs in more iterations.
* I connected them to the benchmark as custom metrics which gives nice output for comparing between chunks & dataobjs:
```
goos: darwin
goarch: arm64
pkg: github.com/grafana/loki/v3/pkg/logql/bench
cpu: Apple M3 Max
BenchmarkLogQL
BenchmarkLogQL/query={region="ap-southeast-1"}_[FORWARD]/kind=log/store=dataobj
BenchmarkLogQL/query={region="ap-southeast-1"}_[FORWARD]/kind=log/store=dataobj-14         	       1	20510124250 ns/op	        24.00 chunks/dataobjSections	   1647563 linesScanned	   1647563 postFilterLines	19895001648 B/op	21808284 allocs/op
BenchmarkLogQL/query={region="ap-southeast-1"}_[FORWARD]/kind=log/store=dataobj-14         	       1	16630957708 ns/op	        24.00 chunks/dataobjSections	   1647563 linesScanned	   1647563 postFilterLines	4467486648 B/op	21150638 allocs/op
BenchmarkLogQL/query={region="ap-southeast-1"}_[FORWARD]/kind=log/store=dataobj-14         	       1	14495382125 ns/op	        24.00 chunks/dataobjSections	   1647563 linesScanned	   1647563 postFilterLines	3798699456 B/op	21154113 allocs/op
BenchmarkLogQL/query={region="ap-southeast-1"}_[FORWARD]/kind=log/store=chunk
BenchmarkLogQL/query={region="ap-southeast-1"}_[FORWARD]/kind=log/store=chunk-14           	      21	  63335091 ns/op	       124.0 chunks/dataobjSections	      1189 linesScanned	      1189 postFilterLines	211459729 B/op	 1041788 allocs/op
BenchmarkLogQL/query={region="ap-southeast-1"}_[FORWARD]/kind=log/store=chunk-14           	      18	  59008486 ns/op	       124.0 chunks/dataobjSections	      1189 linesScanned	      1189 postFilterLines	211451569 B/op	 1041815 allocs/op
BenchmarkLogQL/query={region="ap-southeast-1"}_[FORWARD]/kind=log/store=chunk-14           	      19	  61712952 ns/op	       124.0 chunks/dataobjSections	      1189 linesScanned	      1189 postFilterLines	211640003 B/op	 1041845 allocs/op
PASS
