### PR TITLE
feat: add enforceLimits to ingest_limits.go

### DIFF
--- a/pkg/distributor/ingest_limits_test.go
+++ b/pkg/distributor/ingest_limits_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/coder/quartz"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 
@@ -27,6 +28,177 @@ func (c *mockIngestLimitsFrontendClient) exceedsLimits(_ context.Context, r *log
 		return nil, c.responseErr
 	}
 	return c.response, nil
+}
+
+func TestIngestLimits_EnforceLimits(t *testing.T) {
+	clock := quartz.NewMock(t)
+	clock.Set(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+
+	tests := []struct {
+		name            string
+		tenant          string
+		streams         []KeyedStream
+		expectedRequest *logproto.ExceedsLimitsRequest
+		response        *logproto.ExceedsLimitsResponse
+		responseErr     error
+		expectedStreams []KeyedStream
+		expectedReasons map[uint64][]string
+		expectedErr     string
+	}{{
+		// This test also asserts that streams are returned unmodified.
+		name:   "error should be returned if limits cannot be checked",
+		tenant: "test",
+		streams: []KeyedStream{{
+			HashKey:        1000, // Should not be used.
+			HashKeyNoShard: 1,
+			Stream: logproto.Stream{
+				Labels: "foo",
+				Entries: []logproto.Entry{{
+					Timestamp: clock.Now(),
+					Line:      "bar",
+					StructuredMetadata: []logproto.LabelAdapter{{
+						Name:  "baz",
+						Value: "qux",
+					}},
+				}},
+			},
+		}, {
+			HashKey:        2000, // Should not be used.
+			HashKeyNoShard: 2,
+			Stream: logproto.Stream{
+				Labels: "bar",
+				Entries: []logproto.Entry{{
+					Timestamp: clock.Now(),
+					Line:      "baz",
+					StructuredMetadata: []logproto.LabelAdapter{{
+						Name:  "qux",
+						Value: "corge",
+					}},
+				}},
+			},
+		}},
+		expectedRequest: &logproto.ExceedsLimitsRequest{
+			Tenant: "test",
+			Streams: []*logproto.StreamMetadata{{
+				StreamHash:             1,
+				EntriesSize:            0x3,
+				StructuredMetadataSize: 0x6,
+			}, {
+				StreamHash:             2,
+				EntriesSize:            0x3,
+				StructuredMetadataSize: 0x8,
+			}},
+		},
+		responseErr: errors.New("failed to check limits"),
+		expectedErr: "failed to check limits",
+	}, {
+		name:   "exceeds limits",
+		tenant: "test",
+		streams: []KeyedStream{{
+			HashKey:        1000, // Should not be used.
+			HashKeyNoShard: 1,
+		}},
+		expectedRequest: &logproto.ExceedsLimitsRequest{
+			Tenant: "test",
+			Streams: []*logproto.StreamMetadata{{
+				StreamHash: 1,
+			}},
+		},
+		response: &logproto.ExceedsLimitsResponse{
+			Tenant: "test",
+			Results: []*logproto.ExceedsLimitsResult{{
+				StreamHash: 1,
+				Reason:     "test",
+			}},
+		},
+		expectedStreams: []KeyedStream{},
+		expectedReasons: map[uint64][]string{1: {"test"}},
+	}, {
+		name:   "one of two streams exceeds limits",
+		tenant: "test",
+		streams: []KeyedStream{{
+			HashKey:        1000, // Should not be used.
+			HashKeyNoShard: 1,
+		}, {
+			HashKey:        2000, // Should not be used.
+			HashKeyNoShard: 2,
+		}},
+		expectedRequest: &logproto.ExceedsLimitsRequest{
+			Tenant: "test",
+			Streams: []*logproto.StreamMetadata{{
+				StreamHash: 1,
+			}, {
+				StreamHash: 2,
+			}},
+		},
+		response: &logproto.ExceedsLimitsResponse{
+			Tenant: "test",
+			Results: []*logproto.ExceedsLimitsResult{{
+				StreamHash: 1,
+				Reason:     "test",
+			}},
+		},
+		expectedStreams: []KeyedStream{{
+			HashKey:        2000, // Should not be used.
+			HashKeyNoShard: 2,
+		}},
+		expectedReasons: map[uint64][]string{1: {"test"}},
+	}, {
+		name:   "does not exceed limits",
+		tenant: "test",
+		streams: []KeyedStream{{
+			HashKey:        1000, // Should not be used.
+			HashKeyNoShard: 1,
+		}, {
+			HashKey:        2000, // Should not be used.
+			HashKeyNoShard: 2,
+		}},
+		expectedRequest: &logproto.ExceedsLimitsRequest{
+			Tenant: "test",
+			Streams: []*logproto.StreamMetadata{{
+				StreamHash: 1,
+			}, {
+				StreamHash: 2,
+			}},
+		},
+		response: &logproto.ExceedsLimitsResponse{
+			Tenant:  "test",
+			Results: []*logproto.ExceedsLimitsResult{},
+		},
+		expectedStreams: []KeyedStream{{
+			HashKey:        1000, // Should not be used.
+			HashKeyNoShard: 1,
+		}, {
+			HashKey:        2000, // Should not be used.
+			HashKeyNoShard: 2,
+		}},
+		expectedReasons: nil,
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mockClient := mockIngestLimitsFrontendClient{
+				t:               t,
+				expectedRequest: test.expectedRequest,
+				response:        test.response,
+				responseErr:     test.responseErr,
+			}
+			l := newIngestLimits(&mockClient, prometheus.NewRegistry())
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			streams, reasons, err := l.enforceLimits(ctx, test.tenant, test.streams)
+			if test.expectedErr != "" {
+				require.EqualError(t, err, test.expectedErr)
+				// The streams should be returned unmodified.
+				require.Equal(t, test.streams, streams)
+				require.Nil(t, reasons)
+			} else {
+				require.Nil(t, err)
+				require.Equal(t, test.expectedStreams, streams)
+				require.Equal(t, test.expectedReasons, reasons)
+			}
+		})
+	}
 }
 
 // This test asserts that when checking ingest limits the expected proto


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request adds a new method to ingest_limits.go to enforce limits against a slice of streams. It returns the streams within the limits, and in the case where one or more streams exceed per-tenant limits, the reasons those streams were not included in the result.

This pull request is stacked on top of https://github.com/grafana/loki/pull/17112.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
