### PR TITLE
refactor(stringlabels): Support stringlabels in bloombuild, chunkenc, compactor, distributor tests

### DIFF
--- a/pkg/bloombuild/common/tsdb_test.go
+++ b/pkg/bloombuild/common/tsdb_test.go
@@ -35,7 +35,7 @@ func (f forSeriesTestImpl) ForSeries(
 			})
 		}
 
-		fn(nil, f[i].Fingerprint, unmapped)
+		fn(labels.EmptyLabels(), f[i].Fingerprint, unmapped)
 	}
 	return nil
 }

--- a/pkg/chunkenc/memchunk_test.go
+++ b/pkg/chunkenc/memchunk_test.go
@@ -962,11 +962,11 @@ func BenchmarkWrite(b *testing.B) {
 type nomatchPipeline struct{}
 
 func (nomatchPipeline) BaseLabels() log.LabelsResult { return log.EmptyLabelsResult }
-func (nomatchPipeline) Process(_ int64, line []byte, _ ...labels.Label) ([]byte, log.LabelsResult, bool) {
+func (nomatchPipeline) Process(_ int64, line []byte, _ labels.Labels) ([]byte, log.LabelsResult, bool) {
 	return line, nil, false
 }
 
-func (nomatchPipeline) ProcessString(_ int64, line string, _ ...labels.Label) (string, log.LabelsResult, bool) {
+func (nomatchPipeline) ProcessString(_ int64, line string, _ labels.Labels) (string, log.LabelsResult, bool) {
 	return line, nil, false
 }
 
@@ -1031,11 +1031,11 @@ func BenchmarkRead(b *testing.B) {
 type noopTestPipeline struct{}
 
 func (noopTestPipeline) BaseLabels() log.LabelsResult { return log.EmptyLabelsResult }
-func (noopTestPipeline) Process(_ int64, line []byte, _ ...labels.Label) ([]byte, log.LabelsResult, bool) {
+func (noopTestPipeline) Process(_ int64, line []byte, _ labels.Labels) ([]byte, log.LabelsResult, bool) {
 	return line, nil, false
 }
 
-func (noopTestPipeline) ProcessString(_ int64, line string, _ ...labels.Label) (string, log.LabelsResult, bool) {
+func (noopTestPipeline) ProcessString(_ int64, line string, _ labels.Labels) (string, log.LabelsResult, bool) {
 	return line, nil, false
 }
 
@@ -1102,7 +1102,7 @@ func BenchmarkHeadBlockIterator(b *testing.B) {
 
 				var structuredMetadata labels.Labels
 				if withStructuredMetadata {
-					structuredMetadata = labels.Labels{{Name: "foo", Value: "foo"}}
+					structuredMetadata = labels.FromStrings("foo", "foo")
 				}
 
 				for i := 0; i < j; i++ {
@@ -1134,7 +1134,7 @@ func BenchmarkHeadBlockSampleIterator(b *testing.B) {
 
 				var structuredMetadata labels.Labels
 				if withStructuredMetadata {
-					structuredMetadata = labels.Labels{{Name: "foo", Value: "foo"}}
+					structuredMetadata = labels.FromStrings("foo", "foo")
 				}
 
 				for i := 0; i < j; i++ {
@@ -1166,7 +1166,7 @@ func BenchmarkHeadBlockSampleIterator_WithMultipleExtractors(b *testing.B) {
 
 				var structuredMetadata labels.Labels
 				if withStructuredMetadata {
-					structuredMetadata = labels.Labels{{Name: "foo", Value: "foo"}}
+					structuredMetadata = labels.FromStrings("foo", "foo")
 				}
 
 				for i := 0; i < j; i++ {
@@ -1380,24 +1380,24 @@ func BenchmarkBufferedIteratorLabels(b *testing.B) {
 			_ = fillChunk(c)
 
 			labelsSet := []labels.Labels{
-				{
-					{Name: "cluster", Value: "us-central1"},
-					{Name: "stream", Value: "stdout"},
-					{Name: "filename", Value: "/var/log/pods/loki-prod_query-frontend-6894f97b98-89q2n_eac98024-f60f-44af-a46f-d099bc99d1e7/query-frontend/0.log"},
-					{Name: "namespace", Value: "loki-dev"},
-					{Name: "job", Value: "loki-prod/query-frontend"},
-					{Name: "container", Value: "query-frontend"},
-					{Name: "pod", Value: "query-frontend-6894f97b98-89q2n"},
-				},
-				{
-					{Name: "cluster", Value: "us-central2"},
-					{Name: "stream", Value: "stderr"},
-					{Name: "filename", Value: "/var/log/pods/loki-prod_querier-6894f97b98-89q2n_eac98024-f60f-44af-a46f-d099bc99d1e7/query-frontend/0.log"},
-					{Name: "namespace", Value: "loki-dev"},
-					{Name: "job", Value: "loki-prod/querier"},
-					{Name: "container", Value: "querier"},
-					{Name: "pod", Value: "querier-6894f97b98-89q2n"},
-				},
+				labels.FromStrings(
+					"cluster", "us-central1",
+					"stream", "stdout",
+					"filename", "/var/log/pods/loki-prod_query-frontend-6894f97b98-89q2n_eac98024-f60f-44af-a46f-d099bc99d1e7/query-frontend/0.log",
+					"namespace", "loki-dev",
+					"job", "loki-prod/query-frontend",
+					"container", "query-frontend",
+					"pod", "query-frontend-6894f97b98-89q2n",
+				),
+				labels.FromStrings(
+					"cluster", "us-central2",
+					"stream", "stderr",
+					"filename", "/var/log/pods/loki-prod_querier-6894f97b98-89q2n_eac98024-f60f-44af-a46f-d099bc99d1e7/query-frontend/0.log",
+					"namespace", "loki-dev",
+					"job", "loki-prod/querier",
+					"container", "querier",
+					"pod", "querier-6894f97b98-89q2n",
+				),
 			}
 			for _, test := range []string{
 				`{app="foo"}`,
@@ -1507,7 +1507,7 @@ func Test_HeadIteratorReverse(t *testing.T) {
 				require.NoError(t, err)
 				p, err := expr.Pipeline()
 				require.NoError(t, err)
-				it, err := c.Iterator(context.TODO(), time.Unix(0, 0), time.Unix(0, i), logproto.BACKWARD, p.ForStream(labels.Labels{{Name: "app", Value: "foo"}}))
+				it, err := c.Iterator(context.TODO(), time.Unix(0, 0), time.Unix(0, i), logproto.BACKWARD, p.ForStream(labels.FromStrings("app", "foo")))
 				require.NoError(t, err)
 				for it.Next() {
 					total--
@@ -1632,7 +1632,7 @@ func TestMemChunk_ReboundAndFilter_with_filter(t *testing.T) {
 		{
 			name:         "no matches",
 			testMemChunk: buildFilterableTestMemChunk(t, chkFrom, chkThrough, nil, nil, false),
-			filterFunc: func(_ time.Time, in string, _ ...labels.Label) bool {
+			filterFunc: func(_ time.Time, in string, _ labels.Labels) bool {
 				return strings.HasPrefix(in, "matching")
 			},
 			nrMatching:    0,
@@ -1641,7 +1641,7 @@ func TestMemChunk_ReboundAndFilter_with_filter(t *testing.T) {
 		{
 			name:         "some lines removed",
 			testMemChunk: buildFilterableTestMemChunk(t, chkFrom, chkThrough, &chkFrom, &chkFromPlus5, false),
-			filterFunc: func(_ time.Time, in string, _ ...labels.Label) bool {
+			filterFunc: func(_ time.Time, in string, _ labels.Labels) bool {
 				return strings.HasPrefix(in, "matching")
 			},
 			nrMatching:    5,
@@ -1650,7 +1650,7 @@ func TestMemChunk_ReboundAndFilter_with_filter(t *testing.T) {
 		{
 			name:         "all lines match",
 			testMemChunk: buildFilterableTestMemChunk(t, chkFrom, chkThrough, &chkFrom, &chkThroughPlus1, false),
-			filterFunc: func(_ time.Time, in string, _ ...labels.Label) bool {
+			filterFunc: func(_ time.Time, in string, _ labels.Labels) bool {
 				return strings.HasPrefix(in, "matching")
 			},
 			err: chunk.ErrSliceNoDataInRange,
@@ -1660,8 +1660,8 @@ func TestMemChunk_ReboundAndFilter_with_filter(t *testing.T) {
 		{
 			name:         "no matches - chunk without structured metadata",
 			testMemChunk: buildFilterableTestMemChunk(t, chkFrom, chkThrough, &chkFrom, &chkThroughPlus1, false),
-			filterFunc: func(_ time.Time, _ string, structuredMetadata ...labels.Label) bool {
-				return labels.Labels(structuredMetadata).Get(lblPing) == lblPong
+			filterFunc: func(_ time.Time, _ string, structuredMetadata labels.Labels) bool {
+				return structuredMetadata.Get(lblPing) == lblPong
 			},
 			nrMatching:    0,
 			nrNotMatching: 10,
@@ -1669,8 +1669,8 @@ func TestMemChunk_ReboundAndFilter_with_filter(t *testing.T) {
 		{
 			name:         "structured metadata not matching",
 			testMemChunk: buildFilterableTestMemChunk(t, chkFrom, chkThrough, &chkFrom, &chkThroughPlus1, true),
-			filterFunc: func(_ time.Time, _ string, structuredMetadata ...labels.Label) bool {
-				return labels.Labels(structuredMetadata).Get("ding") == "dong"
+			filterFunc: func(_ time.Time, _ string, structuredMetadata labels.Labels) bool {
+				return structuredMetadata.Get("ding") == "dong"
 			},
 			nrMatching:    0,
 			nrNotMatching: 10,
@@ -1678,8 +1678,8 @@ func TestMemChunk_ReboundAndFilter_with_filter(t *testing.T) {
 		{
 			name:         "some lines removed - with structured metadata",
 			testMemChunk: buildFilterableTestMemChunk(t, chkFrom, chkThrough, &chkFrom, &chkFromPlus5, true),
-			filterFunc: func(_ time.Time, _ string, structuredMetadata ...labels.Label) bool {
-				return labels.Labels(structuredMetadata).Get(lblPing) == lblPong
+			filterFunc: func(_ time.Time, _ string, structuredMetadata labels.Labels) bool {
+				return structuredMetadata.Get(lblPing) == lblPong
 			},
 			nrMatching:    5,
 			nrNotMatching: 5,
@@ -1687,8 +1687,8 @@ func TestMemChunk_ReboundAndFilter_with_filter(t *testing.T) {
 		{
 			name:         "all lines match -  with structured metadata",
 			testMemChunk: buildFilterableTestMemChunk(t, chkFrom, chkThrough, &chkFrom, &chkThroughPlus1, true),
-			filterFunc: func(_ time.Time, in string, structuredMetadata ...labels.Label) bool {
-				return labels.Labels(structuredMetadata).Get(lblPing) == lblPong && strings.HasPrefix(in, "matching")
+			filterFunc: func(_ time.Time, in string, structuredMetadata labels.Labels) bool {
+				return structuredMetadata.Get(lblPing) == lblPong && strings.HasPrefix(in, "matching")
 			},
 			err: chunk.ErrSliceNoDataInRange,
 		},
@@ -1878,7 +1878,7 @@ func TestMemChunk_SpaceFor(t *testing.T) {
 					chk.blocks = make([]block, tc.nBlocks)
 					chk.cutBlockSize = tc.cutBlockSize
 					for i := 0; i < tc.headSize; i++ {
-						dup, err := chk.head.Append(int64(i), "a", nil)
+						dup, err := chk.head.Append(int64(i), "a", labels.EmptyLabels())
 						require.False(t, dup)
 						require.NoError(t, err)
 					}
@@ -1898,9 +1898,7 @@ func TestMemChunk_SpaceFor(t *testing.T) {
 func TestMemChunk_IteratorWithStructuredMetadata(t *testing.T) {
 	for _, enc := range testEncodings {
 		t.Run(enc.String(), func(t *testing.T) {
-			streamLabels := labels.Labels{
-				{Name: "job", Value: "fake"},
-			}
+			streamLabels := labels.FromStrings("job", "fake")
 			chk := newMemChunkWithFormat(ChunkFormatV4, enc, UnorderedWithStructuredMetadataHeadBlockFmt, testBlockSize, testTargetSize)
 			dup, err := chk.Append(logprotoEntryWithStructuredMetadata(1, "lineA", []logproto.LabelAdapter{
 				{Name: "traceID", Value: "123"},

--- a/pkg/chunkenc/unordered_test.go
+++ b/pkg/chunkenc/unordered_test.go
@@ -36,7 +36,7 @@ func iterEq(t *testing.T, exp []entry, got iter.EntryIterator) {
 func Test_forEntriesEarlyReturn(t *testing.T) {
 	hb := newUnorderedHeadBlock(UnorderedHeadBlockFmt, newSymbolizer())
 	for i := 0; i < 10; i++ {
-		dup, err := hb.Append(int64(i), fmt.Sprint(i), labels.Labels{{Name: "i", Value: fmt.Sprint(i)}})
+		dup, err := hb.Append(int64(i), fmt.Sprint(i), labels.FromStrings("i", fmt.Sprint(i)))
 		require.False(t, dup)
 		require.Nil(t, err)
 	}
@@ -94,67 +94,67 @@ func Test_Unordered_InsertRetrieval(t *testing.T) {
 		{
 			desc: "simple forward",
 			input: []entry{
-				{0, "a", nil}, {1, "b", nil}, {2, "c", labels.Labels{{Name: "a", Value: "b"}}},
+				{0, "a", labels.EmptyLabels()}, {1, "b", labels.EmptyLabels()}, {2, "c", labels.FromStrings("a", "b")},
 			},
 			exp: []entry{
-				{0, "a", nil}, {1, "b", nil}, {2, "c", labels.Labels{{Name: "a", Value: "b"}}},
+				{0, "a", labels.EmptyLabels()}, {1, "b", labels.EmptyLabels()}, {2, "c", labels.FromStrings("a", "b")},
 			},
 		},
 		{
 			desc: "simple backward",
 			input: []entry{
-				{0, "a", nil}, {1, "b", nil}, {2, "c", labels.Labels{{Name: "a", Value: "b"}}},
+				{0, "a", labels.EmptyLabels()}, {1, "b", labels.EmptyLabels()}, {2, "c", labels.FromStrings("a", "b")},
 			},
 			exp: []entry{
-				{2, "c", labels.Labels{{Name: "a", Value: "b"}}}, {1, "b", nil}, {0, "a", nil},
+				{2, "c", labels.FromStrings("a", "b")}, {1, "b", labels.EmptyLabels()}, {0, "a", labels.EmptyLabels()},
 			},
 			dir: logproto.BACKWARD,
 		},
 		{
 			desc: "unordered forward",
 			input: []entry{
-				{1, "b", nil}, {0, "a", nil}, {2, "c", labels.Labels{{Name: "a", Value: "b"}}},
+				{1, "b", labels.EmptyLabels()}, {0, "a", labels.EmptyLabels()}, {2, "c", labels.FromStrings("a", "b")},
 			},
 			exp: []entry{
-				{0, "a", nil}, {1, "b", nil}, {2, "c", labels.Labels{{Name: "a", Value: "b"}}},
+				{0, "a", labels.EmptyLabels()}, {1, "b", labels.EmptyLabels()}, {2, "c", labels.FromStrings("a", "b")},
 			},
 		},
 		{
 			desc: "unordered backward",
 			input: []entry{
-				{1, "b", nil}, {0, "a", nil}, {2, "c", labels.Labels{{Name: "a", Value: "b"}}},
+				{1, "b", labels.EmptyLabels()}, {0, "a", labels.EmptyLabels()}, {2, "c", labels.FromStrings("a", "b")},
 			},
 			exp: []entry{
-				{2, "c", labels.Labels{{Name: "a", Value: "b"}}}, {1, "b", nil}, {0, "a", nil},
+				{2, "c", labels.FromStrings("a", "b")}, {1, "b", labels.EmptyLabels()}, {0, "a", labels.EmptyLabels()},
 			},
 			dir: logproto.BACKWARD,
 		},
 		{
 			desc: "ts collision forward",
 			input: []entry{
-				{0, "a", labels.Labels{{Name: "a", Value: "b"}}}, {0, "b", labels.Labels{{Name: "a", Value: "b"}}}, {1, "c", nil},
+				{0, "a", labels.FromStrings("a", "b")}, {0, "b", labels.FromStrings("a", "b")}, {1, "c", labels.EmptyLabels()},
 			},
 			exp: []entry{
-				{0, "a", labels.Labels{{Name: "a", Value: "b"}}}, {0, "b", labels.Labels{{Name: "a", Value: "b"}}}, {1, "c", nil},
+				{0, "a", labels.FromStrings("a", "b")}, {0, "b", labels.FromStrings("a", "b")}, {1, "c", labels.EmptyLabels()},
 			},
 		},
 		{
 			desc: "ts collision backward",
 			input: []entry{
-				{0, "a", labels.Labels{{Name: "a", Value: "b"}}}, {0, "b", nil}, {1, "c", nil},
+				{0, "a", labels.FromStrings("a", "b")}, {0, "b", labels.EmptyLabels()}, {1, "c", labels.EmptyLabels()},
 			},
 			exp: []entry{
-				{1, "c", nil}, {0, "b", nil}, {0, "a", labels.Labels{{Name: "a", Value: "b"}}},
+				{1, "c", labels.EmptyLabels()}, {0, "b", labels.EmptyLabels()}, {0, "a", labels.FromStrings("a", "b")},
 			},
 			dir: logproto.BACKWARD,
 		},
 		{
 			desc: "ts remove exact dupe forward",
 			input: []entry{
-				{0, "a", nil}, {0, "b", nil}, {1, "c", nil}, {0, "b", labels.Labels{{Name: "a", Value: "b"}}},
+				{0, "a", labels.EmptyLabels()}, {0, "b", labels.EmptyLabels()}, {1, "c", labels.EmptyLabels()}, {0, "b", labels.FromStrings("a", "b")},
 			},
 			exp: []entry{
-				{0, "a", nil}, {0, "b", nil}, {1, "c", nil},
+				{0, "a", labels.EmptyLabels()}, {0, "b", labels.EmptyLabels()}, {1, "c", labels.EmptyLabels()},
 			},
 			dir:    logproto.FORWARD,
 			hasDup: true,
@@ -162,10 +162,10 @@ func Test_Unordered_InsertRetrieval(t *testing.T) {
 		{
 			desc: "ts remove exact dupe backward",
 			input: []entry{
-				{0, "a", nil}, {0, "b", nil}, {1, "c", nil}, {0, "b", labels.Labels{{Name: "a", Value: "b"}}},
+				{0, "a", labels.EmptyLabels()}, {0, "b", labels.EmptyLabels()}, {1, "c", labels.EmptyLabels()}, {0, "b", labels.FromStrings("a", "b")},
 			},
 			exp: []entry{
-				{1, "c", nil}, {0, "b", nil}, {0, "a", nil},
+				{1, "c", labels.EmptyLabels()}, {0, "b", labels.EmptyLabels()}, {0, "a", labels.EmptyLabels()},
 			},
 			dir:    logproto.BACKWARD,
 			hasDup: true,
@@ -202,7 +202,7 @@ func Test_Unordered_InsertRetrieval(t *testing.T) {
 					copy(expected, tc.exp)
 					if format < UnorderedWithStructuredMetadataHeadBlockFmt {
 						for i := range expected {
-							expected[i].structuredMetadata = nil
+							expected[i].structuredMetadata = labels.EmptyLabels()
 						}
 					}
 
@@ -226,10 +226,10 @@ func Test_UnorderedBoundedIter(t *testing.T) {
 			mint: 1,
 			maxt: 4,
 			input: []entry{
-				{0, "a", nil}, {1, "b", labels.Labels{{Name: "a", Value: "b"}}}, {2, "c", nil}, {3, "d", nil}, {4, "e", nil},
+				{0, "a", labels.EmptyLabels()}, {1, "b", labels.FromStrings("a", "b")}, {2, "c", labels.EmptyLabels()}, {3, "d", labels.EmptyLabels()}, {4, "e", labels.EmptyLabels()},
 			},
 			exp: []entry{
-				{1, "b", labels.Labels{{Name: "a", Value: "b"}}}, {2, "c", nil}, {3, "d", nil},
+				{1, "b", labels.FromStrings("a", "b")}, {2, "c", labels.EmptyLabels()}, {3, "d", labels.EmptyLabels()},
 			},
 		},
 		{
@@ -237,10 +237,10 @@ func Test_UnorderedBoundedIter(t *testing.T) {
 			mint: 1,
 			maxt: 4,
 			input: []entry{
-				{0, "a", nil}, {1, "b", labels.Labels{{Name: "a", Value: "b"}}}, {2, "c", nil}, {3, "d", nil}, {4, "e", nil},
+				{0, "a", labels.EmptyLabels()}, {1, "b", labels.FromStrings("a", "b")}, {2, "c", labels.EmptyLabels()}, {3, "d", labels.EmptyLabels()}, {4, "e", labels.EmptyLabels()},
 			},
 			exp: []entry{
-				{3, "d", nil}, {2, "c", nil}, {1, "b", labels.Labels{{Name: "a", Value: "b"}}},
+				{3, "d", labels.EmptyLabels()}, {2, "c", labels.EmptyLabels()}, {1, "b", labels.FromStrings("a", "b")},
 			},
 			dir: logproto.BACKWARD,
 		},
@@ -249,10 +249,10 @@ func Test_UnorderedBoundedIter(t *testing.T) {
 			mint: 1,
 			maxt: 4,
 			input: []entry{
-				{0, "a", nil}, {2, "c", nil}, {1, "b", labels.Labels{{Name: "a", Value: "b"}}}, {4, "e", nil}, {3, "d", nil},
+				{0, "a", labels.EmptyLabels()}, {2, "c", labels.EmptyLabels()}, {1, "b", labels.FromStrings("a", "b")}, {4, "e", labels.EmptyLabels()}, {3, "d", labels.EmptyLabels()},
 			},
 			exp: []entry{
-				{1, "b", labels.Labels{{Name: "a", Value: "b"}}}, {2, "c", nil}, {3, "d", nil},
+				{1, "b", labels.FromStrings("a", "b")}, {2, "c", labels.EmptyLabels()}, {3, "d", labels.EmptyLabels()},
 			},
 		},
 	} {
@@ -281,7 +281,7 @@ func Test_UnorderedBoundedIter(t *testing.T) {
 					copy(expected, tc.exp)
 					if format < UnorderedWithStructuredMetadataHeadBlockFmt {
 						for i := range expected {
-							expected[i].structuredMetadata = nil
+							expected[i].structuredMetadata = labels.EmptyLabels()
 						}
 					}
 
@@ -296,14 +296,14 @@ func TestHeadBlockInterop(t *testing.T) {
 	unordered, ordered := newUnorderedHeadBlock(UnorderedHeadBlockFmt, nil), &headBlock{}
 	unorderedWithStructuredMetadata := newUnorderedHeadBlock(UnorderedWithStructuredMetadataHeadBlockFmt, newSymbolizer())
 	for i := 0; i < 100; i++ {
-		metaLabels := labels.Labels{{Name: "foo", Value: fmt.Sprint(99 - i)}}
+		metaLabels := labels.FromStrings("foo", fmt.Sprint(99-i))
 		dup, err := unordered.Append(int64(99-i), fmt.Sprint(99-i), metaLabels)
 		require.False(t, dup)
 		require.Nil(t, err)
 		dup, err = unorderedWithStructuredMetadata.Append(int64(99-i), fmt.Sprint(99-i), metaLabels)
 		require.False(t, dup)
 		require.Nil(t, err)
-		dup, err = ordered.Append(int64(i), fmt.Sprint(i), labels.Labels{{Name: "foo", Value: fmt.Sprint(i)}})
+		dup, err = ordered.Append(int64(i), fmt.Sprint(i), labels.FromStrings("foo", fmt.Sprint(i)))
 		require.False(t, dup)
 		require.Nil(t, err)
 	}
@@ -424,7 +424,7 @@ func BenchmarkHeadBlockWrites(b *testing.B) {
 
 				var structuredMetadata labels.Labels
 				if withStructuredMetadata {
-					structuredMetadata = labels.Labels{{Name: "foo", Value: fmt.Sprint(ts)}}
+					structuredMetadata = labels.FromStrings("foo", fmt.Sprint(ts))
 				}
 
 				writes = append(writes, entry{
@@ -706,7 +706,7 @@ func TestReorderAcrossBlocks(t *testing.T) {
 	from, to := c.Bounds()
 	require.Nil(t, c.Close())
 
-	itr, err := c.Iterator(context.Background(), from, to.Add(time.Nanosecond), logproto.FORWARD, log.NewNoopPipeline().ForStream(nil))
+	itr, err := c.Iterator(context.Background(), from, to.Add(time.Nanosecond), logproto.FORWARD, log.NewNoopPipeline().ForStream(labels.EmptyLabels()))
 	require.Nil(t, err)
 
 	exp := []entry{
@@ -731,7 +731,7 @@ func TestReorderAcrossBlocks(t *testing.T) {
 }
 
 func Test_HeadIteratorHash(t *testing.T) {
-	lbs := labels.Labels{labels.Label{Name: "foo", Value: "bar"}}
+	lbs := labels.FromStrings("foo", "bar")
 	countEx, err := log.NewLineSampleExtractor(log.CountExtractor, nil, nil, false, false)
 	require.NoError(t, err)
 	bytesEx, err := log.NewLineSampleExtractor(log.BytesExtractor, nil, nil, false, false)
@@ -743,7 +743,7 @@ func Test_HeadIteratorHash(t *testing.T) {
 		"ordered":                            &headBlock{},
 	} {
 		t.Run(fmt.Sprintf("%s SampleIterator", name), func(t *testing.T) {
-			dup, err := b.Append(1, "foo", labels.Labels{{Name: "foo", Value: "bar"}})
+			dup, err := b.Append(1, "foo", labels.FromStrings("foo", "bar"))
 			require.False(t, dup)
 			require.NoError(t, err)
 			eit := b.Iterator(context.Background(), logproto.BACKWARD, 0, 2, log.NewNoopPipeline().ForStream(lbs))
@@ -759,7 +759,7 @@ func Test_HeadIteratorHash(t *testing.T) {
 		})
 
 		t.Run(fmt.Sprintf("%s SampleIterator with multiple extractors", name), func(t *testing.T) {
-			dup, err := b.Append(1, "bar", labels.Labels{{Name: "bar", Value: "foo"}})
+			dup, err := b.Append(1, "bar", labels.FromStrings("bar", "foo"))
 			require.False(t, dup)
 			require.NoError(t, err)
 			eit := b.Iterator(

--- a/pkg/compactor/deletion/delete_request_test.go
+++ b/pkg/compactor/deletion/delete_request_test.go
@@ -70,7 +70,7 @@ func TestDeleteRequest_IsDeleted(t *testing.T) {
 			},
 			expectedResp: resp{
 				isDeleted: true,
-				expectedFilter: func(ts time.Time, s string, _ ...labels.Label) bool {
+				expectedFilter: func(ts time.Time, s string, _ labels.Labels) bool {
 					tsUnixNano := ts.UnixNano()
 					if strings.Contains(s, "filter") && now.Add(-3*time.Hour).UnixNano() <= tsUnixNano && tsUnixNano <= now.Add(-time.Hour).UnixNano() {
 						return true
@@ -89,9 +89,9 @@ func TestDeleteRequest_IsDeleted(t *testing.T) {
 			},
 			expectedResp: resp{
 				isDeleted: true,
-				expectedFilter: func(ts time.Time, _ string, structuredMetadata ...labels.Label) bool {
+				expectedFilter: func(ts time.Time, _ string, structuredMetadata labels.Labels) bool {
 					tsUnixNano := ts.UnixNano()
-					if labels.Labels(structuredMetadata).Get(lblPing) == lblPong && now.Add(-3*time.Hour).UnixNano() <= tsUnixNano && tsUnixNano <= now.Add(-time.Hour).UnixNano() {
+					if structuredMetadata.Get(lblPing) == lblPong && now.Add(-3*time.Hour).UnixNano() <= tsUnixNano && tsUnixNano <= now.Add(-time.Hour).UnixNano() {
 						return true
 					}
 					return false
@@ -108,9 +108,9 @@ func TestDeleteRequest_IsDeleted(t *testing.T) {
 			},
 			expectedResp: resp{
 				isDeleted: true,
-				expectedFilter: func(ts time.Time, s string, structuredMetadata ...labels.Label) bool {
+				expectedFilter: func(ts time.Time, s string, structuredMetadata labels.Labels) bool {
 					tsUnixNano := ts.UnixNano()
-					if strings.Contains(s, "filter") && labels.Labels(structuredMetadata).Get(lblPing) == lblPong && now.Add(-3*time.Hour).UnixNano() <= tsUnixNano && tsUnixNano <= now.Add(-time.Hour).UnixNano() {
+					if strings.Contains(s, "filter") && structuredMetadata.Get(lblPing) == lblPong && now.Add(-3*time.Hour).UnixNano() <= tsUnixNano && tsUnixNano <= now.Add(-time.Hour).UnixNano() {
 						return true
 					}
 					return false
@@ -127,7 +127,7 @@ func TestDeleteRequest_IsDeleted(t *testing.T) {
 			},
 			expectedResp: resp{
 				isDeleted: true,
-				expectedFilter: func(ts time.Time, _ string, _ ...labels.Label) bool {
+				expectedFilter: func(ts time.Time, _ string, _ labels.Labels) bool {
 					tsUnixNano := ts.UnixNano()
 					if now.Add(-3*time.Hour).UnixNano() <= tsUnixNano && tsUnixNano <= now.Add(-2*time.Hour).UnixNano() {
 						return true
@@ -146,7 +146,7 @@ func TestDeleteRequest_IsDeleted(t *testing.T) {
 			},
 			expectedResp: resp{
 				isDeleted: true,
-				expectedFilter: func(ts time.Time, _ string, _ ...labels.Label) bool {
+				expectedFilter: func(ts time.Time, _ string, _ labels.Labels) bool {
 					tsUnixNano := ts.UnixNano()
 					if now.Add(-2*time.Hour).UnixNano() <= tsUnixNano && tsUnixNano <= now.UnixNano() {
 						return true
@@ -165,7 +165,7 @@ func TestDeleteRequest_IsDeleted(t *testing.T) {
 			},
 			expectedResp: resp{
 				isDeleted: true,
-				expectedFilter: func(ts time.Time, s string, _ ...labels.Label) bool {
+				expectedFilter: func(ts time.Time, s string, _ labels.Labels) bool {
 					tsUnixNano := ts.UnixNano()
 					if strings.Contains(s, "filter") && now.Add(-2*time.Hour).UnixNano() <= tsUnixNano && tsUnixNano <= now.UnixNano() {
 						return true
@@ -184,9 +184,9 @@ func TestDeleteRequest_IsDeleted(t *testing.T) {
 			},
 			expectedResp: resp{
 				isDeleted: true,
-				expectedFilter: func(ts time.Time, _ string, structuredMetadata ...labels.Label) bool {
+				expectedFilter: func(ts time.Time, _ string, structuredMetadata labels.Labels) bool {
 					tsUnixNano := ts.UnixNano()
-					if labels.Labels(structuredMetadata).Get(lblPing) == lblPong && now.Add(-2*time.Hour).UnixNano() <= tsUnixNano && tsUnixNano <= now.UnixNano() {
+					if structuredMetadata.Get(lblPing) == lblPong && now.Add(-2*time.Hour).UnixNano() <= tsUnixNano && tsUnixNano <= now.UnixNano() {
 						return true
 					}
 					return false
@@ -203,9 +203,9 @@ func TestDeleteRequest_IsDeleted(t *testing.T) {
 			},
 			expectedResp: resp{
 				isDeleted: true,
-				expectedFilter: func(ts time.Time, s string, structuredMetadata ...labels.Label) bool {
+				expectedFilter: func(ts time.Time, s string, structuredMetadata labels.Labels) bool {
 					tsUnixNano := ts.UnixNano()
-					if strings.Contains(s, "filter") && labels.Labels(structuredMetadata).Get(lblPing) == lblPong && now.Add(-2*time.Hour).UnixNano() <= tsUnixNano && tsUnixNano <= now.UnixNano() {
+					if strings.Contains(s, "filter") && structuredMetadata.Get(lblPing) == lblPong && now.Add(-2*time.Hour).UnixNano() <= tsUnixNano && tsUnixNano <= now.UnixNano() {
 						return true
 					}
 					return false
@@ -222,7 +222,7 @@ func TestDeleteRequest_IsDeleted(t *testing.T) {
 			},
 			expectedResp: resp{
 				isDeleted: true,
-				expectedFilter: func(ts time.Time, _ string, _ ...labels.Label) bool {
+				expectedFilter: func(ts time.Time, _ string, _ labels.Labels) bool {
 					tsUnixNano := ts.UnixNano()
 					if now.Add(-(2*time.Hour+30*time.Minute)).UnixNano() <= tsUnixNano && tsUnixNano <= now.Add(-(time.Hour+30*time.Minute)).UnixNano() {
 						return true
@@ -286,13 +286,13 @@ func TestDeleteRequest_IsDeleted(t *testing.T) {
 				}
 
 				// mix of empty, ding=dong and ping=pong as structured metadata
-				var structuredMetadata []labels.Label
+				var structuredMetadata labels.Labels
 				if start.Time().Minute()%3 == 0 {
-					structuredMetadata = []labels.Label{{Name: lblPing, Value: lblPong}}
+					structuredMetadata = labels.FromStrings(lblPing, lblPong)
 				} else if start.Time().Minute()%2 == 0 {
-					structuredMetadata = []labels.Label{{Name: "ting", Value: "tong"}}
+					structuredMetadata = labels.FromStrings("ting", "tong")
 				}
-				require.Equal(t, tc.expectedResp.expectedFilter(start.Time(), line, structuredMetadata...), filterFunc(start.Time(), line, structuredMetadata...), "line", line, "time", start.Time(), "now", now.Time())
+				require.Equal(t, tc.expectedResp.expectedFilter(start.Time(), line, structuredMetadata), filterFunc(start.Time(), line, structuredMetadata), "line", line, "time", start.Time(), "now", now.Time())
 			}
 		})
 	}
@@ -324,9 +324,9 @@ func TestDeleteRequest_FilterFunction(t *testing.T) {
 		f, err := dr.FilterFunction(lbls)
 		require.NoError(t, err)
 
-		require.True(t, f(time.Now(), `some line`))
-		require.False(t, f(time.Now(), ""))
-		require.False(t, f(time.Now(), "other line"))
+		require.True(t, f(time.Now(), `some line`, labels.EmptyLabels()))
+		require.False(t, f(time.Now(), "", labels.EmptyLabels()))
+		require.False(t, f(time.Now(), "other line", labels.EmptyLabels()))
 		require.Equal(t, int32(1), dr.DeletedLines)
 		require.Equal(t, float64(1), testutil.ToFloat64(dr.Metrics.deletedLinesTotal))
 	})
@@ -347,9 +347,9 @@ func TestDeleteRequest_FilterFunction(t *testing.T) {
 		f, err := dr.FilterFunction(lbls)
 		require.NoError(t, err)
 
-		require.True(t, f(time.Now(), `some line`, labels.Label{Name: lblPing, Value: lblPong}))
-		require.False(t, f(time.Now(), ""))
-		require.False(t, f(time.Now(), "some line"))
+		require.True(t, f(time.Now(), `some line`, labels.FromStrings(lblPing, lblPong)))
+		require.False(t, f(time.Now(), "", labels.EmptyLabels()))
+		require.False(t, f(time.Now(), "some line", labels.EmptyLabels()))
 		require.Equal(t, int32(1), dr.DeletedLines)
 		require.Equal(t, float64(1), testutil.ToFloat64(dr.Metrics.deletedLinesTotal))
 	})
@@ -370,10 +370,10 @@ func TestDeleteRequest_FilterFunction(t *testing.T) {
 		f, err := dr.FilterFunction(lbls)
 		require.NoError(t, err)
 
-		require.True(t, f(time.Now(), `some line`, labels.Label{Name: lblPing, Value: lblPong}))
-		require.False(t, f(time.Now(), ""))
-		require.False(t, f(time.Now(), "some line"))
-		require.False(t, f(time.Now(), "other line", labels.Label{Name: lblPing, Value: lblPong}))
+		require.True(t, f(time.Now(), `some line`, labels.FromStrings(lblPing, lblPong)))
+		require.False(t, f(time.Now(), "", labels.EmptyLabels()))
+		require.False(t, f(time.Now(), "some line", labels.EmptyLabels()))
+		require.False(t, f(time.Now(), "other line", labels.FromStrings(lblPing, lblPong)))
 		require.Equal(t, int32(1), dr.DeletedLines)
 		require.Equal(t, float64(1), testutil.ToFloat64(dr.Metrics.deletedLinesTotal))
 	})
@@ -393,9 +393,9 @@ func TestDeleteRequest_FilterFunction(t *testing.T) {
 		f, err := dr.FilterFunction(lbls)
 		require.NoError(t, err)
 
-		require.False(t, f(time.Time{}, ""))
-		require.False(t, f(time.Time{}, "other line"))
-		require.False(t, f(time.Time{}, "some line"))
+		require.False(t, f(time.Time{}, "", labels.EmptyLabels()))
+		require.False(t, f(time.Time{}, "other line", labels.EmptyLabels()))
+		require.False(t, f(time.Time{}, "some line", labels.EmptyLabels()))
 		require.Equal(t, int32(0), dr.DeletedLines)
 		// testutil.ToFloat64 panics when there are 0 metrics
 		require.Panics(t, func() { testutil.ToFloat64(dr.Metrics.deletedLinesTotal) })
@@ -419,9 +419,9 @@ func TestDeleteRequest_FilterFunction(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, f)
 
-		require.True(t, f(now.Time(), `some line`))
-		require.False(t, f(now.Time().Add(-2*time.Hour), `some line`))
-		require.True(t, f(now.Time(), "other line"))
+		require.True(t, f(now.Time(), `some line`, labels.EmptyLabels()))
+		require.False(t, f(now.Time().Add(-2*time.Hour), `some line`, labels.EmptyLabels()))
+		require.True(t, f(now.Time(), "other line", labels.EmptyLabels()))
 
 		require.Equal(t, int32(0), dr.DeletedLines)
 		// testutil.ToFloat64 panics when there are 0 metrics

--- a/pkg/compactor/deletion/delete_requests_manager_test.go
+++ b/pkg/compactor/deletion/delete_requests_manager_test.go
@@ -166,7 +166,7 @@ func TestDeleteRequestsManager_Expired(t *testing.T) {
 			},
 			expectedResp: resp{
 				isExpired: true,
-				expectedFilter: func(_ time.Time, s string, _ ...labels.Label) bool {
+				expectedFilter: func(_ time.Time, s string, _ labels.Labels) bool {
 					return strings.Contains(s, "fizz")
 				},
 			},
@@ -193,8 +193,8 @@ func TestDeleteRequestsManager_Expired(t *testing.T) {
 			},
 			expectedResp: resp{
 				isExpired: true,
-				expectedFilter: func(_ time.Time, _ string, structuredMetadata ...labels.Label) bool {
-					return labels.Labels(structuredMetadata).Get(lblPing) == lblPong
+				expectedFilter: func(_ time.Time, _ string, structuredMetadata labels.Labels) bool {
+					return structuredMetadata.Get(lblPing) == lblPong
 				},
 			},
 			expectedDeletionRangeByUser: map[string]model.Interval{
@@ -220,8 +220,8 @@ func TestDeleteRequestsManager_Expired(t *testing.T) {
 			},
 			expectedResp: resp{
 				isExpired: true,
-				expectedFilter: func(_ time.Time, s string, structuredMetadata ...labels.Label) bool {
-					return labels.Labels(structuredMetadata).Get(lblPing) == lblPong && strings.Contains(s, "fizz")
+				expectedFilter: func(_ time.Time, s string, structuredMetadata labels.Labels) bool {
+					return structuredMetadata.Get(lblPing) == lblPong && strings.Contains(s, "fizz")
 				},
 			},
 			expectedDeletionRangeByUser: map[string]model.Interval{
@@ -344,7 +344,7 @@ func TestDeleteRequestsManager_Expired(t *testing.T) {
 			},
 			expectedResp: resp{
 				isExpired: true,
-				expectedFilter: func(_ time.Time, s string, _ ...labels.Label) bool {
+				expectedFilter: func(_ time.Time, s string, _ labels.Labels) bool {
 					return strings.Contains(s, "fizz")
 				},
 			},
@@ -378,8 +378,8 @@ func TestDeleteRequestsManager_Expired(t *testing.T) {
 			},
 			expectedResp: resp{
 				isExpired: true,
-				expectedFilter: func(_ time.Time, _ string, structuredMetadata ...labels.Label) bool {
-					return labels.Labels(structuredMetadata).Get(lblPing) == lblPong
+				expectedFilter: func(_ time.Time, _ string, structuredMetadata labels.Labels) bool {
+					return structuredMetadata.Get(lblPing) == lblPong
 				},
 			},
 			expectedDeletionRangeByUser: map[string]model.Interval{
@@ -426,7 +426,7 @@ func TestDeleteRequestsManager_Expired(t *testing.T) {
 			},
 			expectedResp: resp{
 				isExpired: true,
-				expectedFilter: func(ts time.Time, _ string, _ ...labels.Label) bool {
+				expectedFilter: func(ts time.Time, _ string, _ labels.Labels) bool {
 					tsUnixNano := ts.UnixNano()
 					if (now.Add(-13*time.Hour).UnixNano() <= tsUnixNano && tsUnixNano <= now.Add(-11*time.Hour).UnixNano()) ||
 						(now.Add(-10*time.Hour).UnixNano() <= tsUnixNano && tsUnixNano <= now.Add(-8*time.Hour).UnixNano()) ||
@@ -467,7 +467,7 @@ func TestDeleteRequestsManager_Expired(t *testing.T) {
 			},
 			expectedResp: resp{
 				isExpired: true,
-				expectedFilter: func(_ time.Time, _ string, _ ...labels.Label) bool {
+				expectedFilter: func(_ time.Time, _ string, _ labels.Labels) bool {
 					return true
 				},
 			},
@@ -501,7 +501,7 @@ func TestDeleteRequestsManager_Expired(t *testing.T) {
 			},
 			expectedResp: resp{
 				isExpired: true,
-				expectedFilter: func(_ time.Time, s string, _ ...labels.Label) bool {
+				expectedFilter: func(_ time.Time, s string, _ labels.Labels) bool {
 					return strings.Contains(s, "fizz")
 				},
 			},
@@ -535,8 +535,8 @@ func TestDeleteRequestsManager_Expired(t *testing.T) {
 			},
 			expectedResp: resp{
 				isExpired: true,
-				expectedFilter: func(_ time.Time, _ string, structuredMetadata ...labels.Label) bool {
-					return labels.Labels(structuredMetadata).Get(lblPing) == lblPong
+				expectedFilter: func(_ time.Time, _ string, structuredMetadata labels.Labels) bool {
+					return structuredMetadata.Get(lblPing) == lblPong
 				},
 			},
 			expectedDeletionRangeByUser: map[string]model.Interval{
@@ -576,7 +576,7 @@ func TestDeleteRequestsManager_Expired(t *testing.T) {
 			},
 			expectedResp: resp{
 				isExpired: true,
-				expectedFilter: func(_ time.Time, _ string, _ ...labels.Label) bool {
+				expectedFilter: func(_ time.Time, _ string, _ labels.Labels) bool {
 					return true
 				},
 			},
@@ -617,7 +617,7 @@ func TestDeleteRequestsManager_Expired(t *testing.T) {
 			},
 			expectedResp: resp{
 				isExpired: true,
-				expectedFilter: func(_ time.Time, s string, _ ...labels.Label) bool {
+				expectedFilter: func(_ time.Time, s string, _ labels.Labels) bool {
 					return strings.Contains(s, "fizz")
 				},
 			},
@@ -658,8 +658,8 @@ func TestDeleteRequestsManager_Expired(t *testing.T) {
 			},
 			expectedResp: resp{
 				isExpired: true,
-				expectedFilter: func(_ time.Time, _ string, structuredMetadata ...labels.Label) bool {
-					return labels.Labels(structuredMetadata).Get(lblPing) == lblPong
+				expectedFilter: func(_ time.Time, _ string, structuredMetadata labels.Labels) bool {
+					return structuredMetadata.Get(lblPing) == lblPong
 				},
 			},
 			expectedDeletionRangeByUser: map[string]model.Interval{
@@ -782,7 +782,7 @@ func TestDeleteRequestsManager_Expired(t *testing.T) {
 			},
 			expectedResp: resp{
 				isExpired: true,
-				expectedFilter: func(ts time.Time, _ string, _ ...labels.Label) bool {
+				expectedFilter: func(ts time.Time, _ string, _ labels.Labels) bool {
 					tsUnixNano := ts.UnixNano()
 					if (now.Add(-13*time.Hour).UnixNano() <= tsUnixNano && tsUnixNano <= now.Add(-11*time.Hour).UnixNano()) ||
 						(now.Add(-10*time.Hour).UnixNano() <= tsUnixNano && tsUnixNano <= now.Add(-8*time.Hour).UnixNano()) {
@@ -850,7 +850,7 @@ func TestDeleteRequestsManager_Expired(t *testing.T) {
 			},
 			expectedResp: resp{
 				isExpired: true,
-				expectedFilter: func(ts time.Time, _ string, _ ...labels.Label) bool {
+				expectedFilter: func(ts time.Time, _ string, _ labels.Labels) bool {
 					tsUnixNano := ts.UnixNano()
 					if (now.Add(-13*time.Hour).UnixNano() <= tsUnixNano && tsUnixNano <= now.Add(-11*time.Hour).UnixNano()) ||
 						(now.Add(-10*time.Hour).UnixNano() <= tsUnixNano && tsUnixNano <= now.Add(-8*time.Hour).UnixNano()) {
@@ -917,7 +917,7 @@ func TestDeleteRequestsManager_Expired(t *testing.T) {
 			},
 			expectedResp: resp{
 				isExpired: true,
-				expectedFilter: func(_ time.Time, s string, _ ...labels.Label) bool {
+				expectedFilter: func(_ time.Time, s string, _ labels.Labels) bool {
 					return strings.Contains(s, "fizz")
 				},
 			},
@@ -959,13 +959,13 @@ func TestDeleteRequestsManager_Expired(t *testing.T) {
 						line = "fizz buzz"
 					}
 					// mix of empty, ding=dong and ping=pong as structured metadata
-					var structuredMetadata []labels.Label
+					var structuredMetadata labels.Labels
 					if start.Time().Minute()%3 == 0 {
-						structuredMetadata = []labels.Label{{Name: lblPing, Value: lblPong}}
+						structuredMetadata = labels.FromStrings(lblPing, lblPong)
 					} else if start.Time().Minute()%2 == 0 {
-						structuredMetadata = []labels.Label{{Name: "ting", Value: "tong"}}
+						structuredMetadata = labels.FromStrings("ting", "tong")
 					}
-					require.Equal(t, tc.expectedResp.expectedFilter(start.Time(), line, structuredMetadata...), filterFunc(start.Time(), line, structuredMetadata...), "line", line, "time", start.Time(), "now", now.Time())
+					require.Equal(t, tc.expectedResp.expectedFilter(start.Time(), line, structuredMetadata), filterFunc(start.Time(), line, structuredMetadata), "line", line, "time", start.Time(), "now", now.Time())
 				}
 
 				require.Equal(t, len(tc.expectedDeletionRangeByUser), len(mgr.deleteRequestsToProcess))

--- a/pkg/compactor/retention/expiration_test.go
+++ b/pkg/compactor/retention/expiration_test.go
@@ -163,8 +163,8 @@ func TestTenantsRetention_RetentionPeriodFor(t *testing.T) {
 		},
 	})
 
-	require.Equal(t, time.Duration(sevenDays), tr.RetentionPeriodFor("1", nil))
-	require.Equal(t, time.Duration(oneDay), tr.RetentionPeriodFor("1", labels.Labels{labels.Label{Name: "foo", Value: "bar"}}))
+	require.Equal(t, time.Duration(sevenDays), tr.RetentionPeriodFor("1", labels.EmptyLabels()))
+	require.Equal(t, time.Duration(oneDay), tr.RetentionPeriodFor("1", labels.FromStrings("foo", "bar")))
 }
 
 func Test_expirationChecker_Expired_zeroValue(t *testing.T) {

--- a/pkg/compactor/retention/retention_test.go
+++ b/pkg/compactor/retention/retention_test.go
@@ -102,8 +102,8 @@ func Test_Retention(t *testing.T) {
 				},
 			},
 			[]chunk.Chunk{
-				createChunk(t, "1", labels.Labels{labels.Label{Name: "foo", Value: "bar"}}, start, start.Add(1*time.Hour)),
-				createChunk(t, "2", labels.Labels{labels.Label{Name: "foo", Value: "buzz"}}, start.Add(26*time.Hour), start.Add(27*time.Hour)),
+				createChunk(t, "1", labels.FromStrings("foo", "bar"), start, start.Add(1*time.Hour)),
+				createChunk(t, "2", labels.FromStrings("foo", "buzz"), start.Add(26*time.Hour), start.Add(27*time.Hour)),
 			},
 			[]bool{
 				true,
@@ -119,8 +119,8 @@ func Test_Retention(t *testing.T) {
 				},
 			},
 			[]chunk.Chunk{
-				createChunk(t, "1", labels.Labels{labels.Label{Name: "foo", Value: "bar"}}, start, start.Add(1*time.Hour)),
-				createChunk(t, "2", labels.Labels{labels.Label{Name: "foo", Value: "buzz"}}, start.Add(26*time.Hour), start.Add(27*time.Hour)),
+				createChunk(t, "1", labels.FromStrings("foo", "bar"), start, start.Add(1*time.Hour)),
+				createChunk(t, "2", labels.FromStrings("foo", "buzz"), start.Add(26*time.Hour), start.Add(27*time.Hour)),
 			},
 			[]bool{
 				false,
@@ -141,10 +141,10 @@ func Test_Retention(t *testing.T) {
 				},
 			},
 			[]chunk.Chunk{
-				createChunk(t, "1", labels.Labels{labels.Label{Name: "foo", Value: "bar"}}, start, start.Add(1*time.Hour)),
-				createChunk(t, "2", labels.Labels{labels.Label{Name: "foo", Value: "fuzz"}}, start.Add(26*time.Hour), start.Add(27*time.Hour)),
-				createChunk(t, "1", labels.Labels{labels.Label{Name: "foo", Value: "buzz"}}, model.Now().Add(-2*time.Hour), model.Now().Add(-1*time.Hour)),
-				createChunk(t, "1", labels.Labels{labels.Label{Name: "foo", Value: "buzz"}}, model.Now().Add(-7*time.Hour), model.Now().Add(-6*time.Hour)),
+				createChunk(t, "1", labels.FromStrings("foo", "bar"), start, start.Add(1*time.Hour)),
+				createChunk(t, "2", labels.FromStrings("foo", "fuzz"), start.Add(26*time.Hour), start.Add(27*time.Hour)),
+				createChunk(t, "1", labels.FromStrings("foo", "buzz"), model.Now().Add(-2*time.Hour), model.Now().Add(-1*time.Hour)),
+				createChunk(t, "1", labels.FromStrings("foo", "buzz"), model.Now().Add(-7*time.Hour), model.Now().Add(-6*time.Hour)),
 			},
 			[]bool{
 				false,
@@ -247,9 +247,9 @@ func (n *noopWriter) Close() error { return nil }
 func Test_EmptyTable(t *testing.T) {
 	schema := allSchemas[0]
 	store := newTestStore(t)
-	c1 := createChunk(t, "1", labels.Labels{labels.Label{Name: "foo", Value: "bar"}}, schema.from, schema.from.Add(1*time.Hour))
-	c2 := createChunk(t, "2", labels.Labels{labels.Label{Name: "foo", Value: "buzz"}, labels.Label{Name: "bar", Value: "foo"}}, schema.from, schema.from.Add(1*time.Hour))
-	c3 := createChunk(t, "2", labels.Labels{labels.Label{Name: "foo", Value: "buzz"}, labels.Label{Name: "bar", Value: "buzz"}}, schema.from, schema.from.Add(1*time.Hour))
+	c1 := createChunk(t, "1", labels.FromStrings("foo", "bar"), schema.from, schema.from.Add(1*time.Hour))
+	c2 := createChunk(t, "2", labels.FromStrings("foo", "buzz", "bar", "foo"), schema.from, schema.from.Add(1*time.Hour))
+	c3 := createChunk(t, "2", labels.FromStrings("foo", "buzz", "bar", "buzz"), schema.from, schema.from.Add(1*time.Hour))
 
 	require.NoError(t, store.Put(context.TODO(), []chunk.Chunk{
 		c1, c2, c3,
@@ -319,7 +319,7 @@ func encodeBase64Bytes(bytes []byte) []byte {
 // Backwards-compatible with model.Metric.String()
 func labelsString(ls labels.Labels) string {
 	metricName := ls.Get(labels.MetricName)
-	if metricName != "" && len(ls) == 1 {
+	if metricName != "" && ls.Len() == 1 {
 		return metricName
 	}
 	var b strings.Builder
@@ -328,9 +328,9 @@ func labelsString(ls labels.Labels) string {
 	b.WriteString(metricName)
 	b.WriteByte('{')
 	i := 0
-	for _, l := range ls {
+	ls.Range(func(l labels.Label) {
 		if l.Name == labels.MetricName {
-			continue
+			return
 		}
 		if i > 0 {
 			b.WriteByte(',')
@@ -341,7 +341,7 @@ func labelsString(ls labels.Labels) string {
 		var buf [1000]byte
 		b.Write(strconv.AppendQuote(buf[:0], l.Value))
 		i++
-	}
+	})
 	b.WriteByte('}')
 
 	return b.String()
@@ -366,8 +366,8 @@ func TestChunkRewriter(t *testing.T) {
 	}{
 		{
 			name:  "no rewrites",
-			chunk: createChunk(t, "1", labels.Labels{labels.Label{Name: "foo", Value: "bar"}}, todaysTableInterval.Start, todaysTableInterval.Start.Add(time.Hour)),
-			filterFunc: func(_ time.Time, _ string, _ ...labels.Label) bool {
+			chunk: createChunk(t, "1", labels.FromStrings("foo", "bar"), todaysTableInterval.Start, todaysTableInterval.Start.Add(time.Hour)),
+			filterFunc: func(_ time.Time, _ string, _ labels.Labels) bool {
 				return false
 			},
 			expectedRespByTables: map[string]tableResp{
@@ -376,8 +376,8 @@ func TestChunkRewriter(t *testing.T) {
 		},
 		{
 			name:  "no rewrites with chunk spanning multiple tables",
-			chunk: createChunk(t, "1", labels.Labels{labels.Label{Name: "foo", Value: "bar"}}, todaysTableInterval.End.Add(-48*time.Hour), todaysTableInterval.End),
-			filterFunc: func(_ time.Time, _ string, _ ...labels.Label) bool {
+			chunk: createChunk(t, "1", labels.FromStrings("foo", "bar"), todaysTableInterval.End.Add(-48*time.Hour), todaysTableInterval.End),
+			filterFunc: func(_ time.Time, _ string, _ labels.Labels) bool {
 				return false
 			},
 			expectedRespByTables: map[string]tableResp{
@@ -388,8 +388,8 @@ func TestChunkRewriter(t *testing.T) {
 		},
 		{
 			name:  "rewrite first half",
-			chunk: createChunk(t, "1", labels.Labels{labels.Label{Name: "foo", Value: "bar"}}, todaysTableInterval.Start, todaysTableInterval.Start.Add(2*time.Hour)),
-			filterFunc: func(ts time.Time, _ string, _ ...labels.Label) bool {
+			chunk: createChunk(t, "1", labels.FromStrings("foo", "bar"), todaysTableInterval.Start, todaysTableInterval.Start.Add(2*time.Hour)),
+			filterFunc: func(ts time.Time, _ string, _ labels.Labels) bool {
 				tsUnixNano := ts.UnixNano()
 				if todaysTableInterval.Start.UnixNano() <= tsUnixNano && tsUnixNano <= todaysTableInterval.Start.Add(time.Hour).UnixNano() {
 					return true
@@ -412,8 +412,8 @@ func TestChunkRewriter(t *testing.T) {
 		},
 		{
 			name:  "rewrite first half using structured metadata",
-			chunk: createChunk(t, "1", labels.Labels{labels.Label{Name: "foo", Value: "bar"}}, todaysTableInterval.Start, todaysTableInterval.Start.Add(2*time.Hour)),
-			filterFunc: func(ts time.Time, _ string, structuredMetadata ...labels.Label) bool {
+			chunk: createChunk(t, "1", labels.FromStrings("foo", "bar"), todaysTableInterval.Start, todaysTableInterval.Start.Add(2*time.Hour)),
+			filterFunc: func(ts time.Time, _ string, structuredMetadata labels.Labels) bool {
 				tsUnixNano := ts.UnixNano()
 				if labels.Labels(structuredMetadata).Get("foo") == model.TimeFromUnixNano(ts.UnixNano()).String() &&
 					todaysTableInterval.Start.UnixNano() <= tsUnixNano &&
@@ -438,8 +438,8 @@ func TestChunkRewriter(t *testing.T) {
 		},
 		{
 			name:  "rewrite second half",
-			chunk: createChunk(t, "1", labels.Labels{labels.Label{Name: "foo", Value: "bar"}}, todaysTableInterval.Start, todaysTableInterval.Start.Add(2*time.Hour)),
-			filterFunc: func(ts time.Time, _ string, _ ...labels.Label) bool {
+			chunk: createChunk(t, "1", labels.FromStrings("foo", "bar"), todaysTableInterval.Start, todaysTableInterval.Start.Add(2*time.Hour)),
+			filterFunc: func(ts time.Time, _ string, _ labels.Labels) bool {
 				tsUnixNano := ts.UnixNano()
 				if todaysTableInterval.Start.Add(time.Hour).UnixNano() <= tsUnixNano && tsUnixNano <= todaysTableInterval.Start.Add(2*time.Hour).UnixNano() {
 					return true
@@ -462,8 +462,8 @@ func TestChunkRewriter(t *testing.T) {
 		},
 		{
 			name:  "rewrite multiple intervals",
-			chunk: createChunk(t, "1", labels.Labels{labels.Label{Name: "foo", Value: "bar"}}, todaysTableInterval.Start, todaysTableInterval.Start.Add(12*time.Hour)),
-			filterFunc: func(ts time.Time, _ string, _ ...labels.Label) bool {
+			chunk: createChunk(t, "1", labels.FromStrings("foo", "bar"), todaysTableInterval.Start, todaysTableInterval.Start.Add(12*time.Hour)),
+			filterFunc: func(ts time.Time, _ string, _ labels.Labels) bool {
 				tsUnixNano := ts.UnixNano()
 				if (todaysTableInterval.Start.UnixNano() <= tsUnixNano && tsUnixNano <= todaysTableInterval.Start.Add(2*time.Hour).UnixNano()) ||
 					(todaysTableInterval.Start.Add(5*time.Hour).UnixNano() <= tsUnixNano && tsUnixNano <= todaysTableInterval.Start.Add(9*time.Hour).UnixNano()) ||
@@ -492,8 +492,8 @@ func TestChunkRewriter(t *testing.T) {
 		},
 		{
 			name:  "rewrite chunk spanning multiple days with multiple intervals - delete partially for each day",
-			chunk: createChunk(t, "1", labels.Labels{labels.Label{Name: "foo", Value: "bar"}}, todaysTableInterval.End.Add(-72*time.Hour), todaysTableInterval.End),
-			filterFunc: func(ts time.Time, _ string, _ ...labels.Label) bool {
+			chunk: createChunk(t, "1", labels.FromStrings("foo", "bar"), todaysTableInterval.End.Add(-72*time.Hour), todaysTableInterval.End),
+			filterFunc: func(ts time.Time, _ string, _ labels.Labels) bool {
 				tsUnixNano := ts.UnixNano()
 				if (todaysTableInterval.End.Add(-71*time.Hour).UnixNano() <= tsUnixNano && tsUnixNano <= todaysTableInterval.End.Add(-47*time.Hour).UnixNano()) ||
 					(todaysTableInterval.End.Add(-40*time.Hour).UnixNano() <= tsUnixNano && tsUnixNano <= todaysTableInterval.End.Add(-30*time.Hour).UnixNano()) ||
@@ -538,8 +538,8 @@ func TestChunkRewriter(t *testing.T) {
 		},
 		{
 			name:  "rewrite chunk spanning multiple days with multiple intervals - delete just one whole day",
-			chunk: createChunk(t, "1", labels.Labels{labels.Label{Name: "foo", Value: "bar"}}, todaysTableInterval.End.Add(-72*time.Hour), todaysTableInterval.End),
-			filterFunc: func(ts time.Time, _ string, _ ...labels.Label) bool {
+			chunk: createChunk(t, "1", labels.FromStrings("foo", "bar"), todaysTableInterval.End.Add(-72*time.Hour), todaysTableInterval.End),
+			filterFunc: func(ts time.Time, _ string, _ labels.Labels) bool {
 				tsUnixNano := ts.UnixNano()
 				if todaysTableInterval.Start.UnixNano() <= tsUnixNano && tsUnixNano <= todaysTableInterval.End.UnixNano() {
 					return true
@@ -724,7 +724,7 @@ func TestMarkForDelete_SeriesCleanup(t *testing.T) {
 		{
 			name: "no chunk and series deleted",
 			chunks: []chunk.Chunk{
-				createChunk(t, userID, labels.Labels{labels.Label{Name: "foo", Value: "1"}}, todaysTableInterval.Start, todaysTableInterval.Start.Add(30*time.Minute)),
+				createChunk(t, userID, labels.FromStrings("foo", "1"), todaysTableInterval.Start, todaysTableInterval.Start.Add(30*time.Minute)),
 			},
 			expiry: []chunkExpiry{
 				{
@@ -748,12 +748,12 @@ func TestMarkForDelete_SeriesCleanup(t *testing.T) {
 		{
 			name: "chunk deleted with filter but no lines matching",
 			chunks: []chunk.Chunk{
-				createChunk(t, userID, labels.Labels{labels.Label{Name: "foo", Value: "1"}}, todaysTableInterval.Start, todaysTableInterval.Start.Add(30*time.Minute)),
+				createChunk(t, userID, labels.FromStrings("foo", "1"), todaysTableInterval.Start, todaysTableInterval.Start.Add(30*time.Minute)),
 			},
 			expiry: []chunkExpiry{
 				{
 					isExpired: true,
-					filterFunc: func(_ time.Time, _ string, _ ...labels.Label) bool {
+					filterFunc: func(_ time.Time, _ string, _ labels.Labels) bool {
 						return false
 					},
 				},
@@ -775,7 +775,7 @@ func TestMarkForDelete_SeriesCleanup(t *testing.T) {
 		{
 			name: "only one chunk in store which gets deleted",
 			chunks: []chunk.Chunk{
-				createChunk(t, userID, labels.Labels{labels.Label{Name: "foo", Value: "1"}}, todaysTableInterval.Start, todaysTableInterval.Start.Add(30*time.Minute)),
+				createChunk(t, userID, labels.FromStrings("foo", "1"), todaysTableInterval.Start, todaysTableInterval.Start.Add(30*time.Minute)),
 			},
 			expiry: []chunkExpiry{
 				{
@@ -799,12 +799,12 @@ func TestMarkForDelete_SeriesCleanup(t *testing.T) {
 		{
 			name: "only one chunk in store which gets partially deleted",
 			chunks: []chunk.Chunk{
-				createChunk(t, userID, labels.Labels{labels.Label{Name: "foo", Value: "1"}}, todaysTableInterval.Start, todaysTableInterval.Start.Add(30*time.Minute)),
+				createChunk(t, userID, labels.FromStrings("foo", "1"), todaysTableInterval.Start, todaysTableInterval.Start.Add(30*time.Minute)),
 			},
 			expiry: []chunkExpiry{
 				{
 					isExpired: true,
-					filterFunc: func(ts time.Time, _ string, _ ...labels.Label) bool {
+					filterFunc: func(ts time.Time, _ string, _ labels.Labels) bool {
 						tsUnixNano := ts.UnixNano()
 						if todaysTableInterval.Start.UnixNano() <= tsUnixNano && tsUnixNano <= todaysTableInterval.Start.Add(15*time.Minute).UnixNano() {
 							return true
@@ -831,8 +831,8 @@ func TestMarkForDelete_SeriesCleanup(t *testing.T) {
 		{
 			name: "one of two chunks deleted",
 			chunks: []chunk.Chunk{
-				createChunk(t, userID, labels.Labels{labels.Label{Name: "foo", Value: "1"}}, todaysTableInterval.Start, todaysTableInterval.Start.Add(30*time.Minute)),
-				createChunk(t, userID, labels.Labels{labels.Label{Name: "foo", Value: "2"}}, todaysTableInterval.Start, todaysTableInterval.Start.Add(30*time.Minute)),
+				createChunk(t, userID, labels.FromStrings("foo", "1"), todaysTableInterval.Start, todaysTableInterval.Start.Add(30*time.Minute)),
+				createChunk(t, userID, labels.FromStrings("foo", "2"), todaysTableInterval.Start, todaysTableInterval.Start.Add(30*time.Minute)),
 			},
 			expiry: []chunkExpiry{
 				{
@@ -843,7 +843,7 @@ func TestMarkForDelete_SeriesCleanup(t *testing.T) {
 				},
 			},
 			expectedDeletedSeries: []map[uint64]struct{}{
-				{labels.Labels{labels.Label{Name: "foo", Value: "2"}}.Hash(): struct{}{}},
+				{labels.FromStrings("foo", "2").Hash(): struct{}{}},
 			},
 			expectedEmpty: []bool{
 				false,
@@ -859,8 +859,8 @@ func TestMarkForDelete_SeriesCleanup(t *testing.T) {
 		{
 			name: "one of two series skipped",
 			chunks: []chunk.Chunk{
-				createChunk(t, userID, labels.Labels{labels.Label{Name: "foo", Value: "1"}}, todaysTableInterval.Start, todaysTableInterval.Start.Add(30*time.Minute)),
-				createChunk(t, userID, labels.Labels{labels.Label{Name: "foo", Value: "2"}}, todaysTableInterval.Start, todaysTableInterval.Start.Add(30*time.Minute)),
+				createChunk(t, userID, labels.FromStrings("foo", "1"), todaysTableInterval.Start, todaysTableInterval.Start.Add(30*time.Minute)),
+				createChunk(t, userID, labels.FromStrings("foo", "2"), todaysTableInterval.Start, todaysTableInterval.Start.Add(30*time.Minute)),
 			},
 			skipSeries: map[string]bool{`{foo="1"}`: true},
 			expiry: []chunkExpiry{
@@ -872,7 +872,7 @@ func TestMarkForDelete_SeriesCleanup(t *testing.T) {
 				},
 			},
 			expectedDeletedSeries: []map[uint64]struct{}{
-				{labels.Labels{labels.Label{Name: "foo", Value: "2"}}.Hash(): struct{}{}},
+				{labels.FromStrings("foo", "2").Hash(): struct{}{}},
 			},
 			expectedEmpty: []bool{
 				false,
@@ -888,8 +888,8 @@ func TestMarkForDelete_SeriesCleanup(t *testing.T) {
 		{
 			name: "all series skipped",
 			chunks: []chunk.Chunk{
-				createChunk(t, userID, labels.Labels{labels.Label{Name: "foo", Value: "1"}}, todaysTableInterval.Start, todaysTableInterval.Start.Add(30*time.Minute)),
-				createChunk(t, userID, labels.Labels{labels.Label{Name: "foo", Value: "2"}}, todaysTableInterval.Start, todaysTableInterval.Start.Add(30*time.Minute)),
+				createChunk(t, userID, labels.FromStrings("foo", "1"), todaysTableInterval.Start, todaysTableInterval.Start.Add(30*time.Minute)),
+				createChunk(t, userID, labels.FromStrings("foo", "2"), todaysTableInterval.Start, todaysTableInterval.Start.Add(30*time.Minute)),
 			},
 			skipSeries: map[string]bool{`{foo="1"}`: true, `{foo="2"}`: true},
 			expiry: []chunkExpiry{
@@ -917,8 +917,8 @@ func TestMarkForDelete_SeriesCleanup(t *testing.T) {
 		{
 			name: "one of two chunks partially deleted",
 			chunks: []chunk.Chunk{
-				createChunk(t, userID, labels.Labels{labels.Label{Name: "foo", Value: "1"}}, todaysTableInterval.Start, todaysTableInterval.Start.Add(30*time.Minute)),
-				createChunk(t, userID, labels.Labels{labels.Label{Name: "foo", Value: "2"}}, todaysTableInterval.Start, todaysTableInterval.Start.Add(30*time.Minute)),
+				createChunk(t, userID, labels.FromStrings("foo", "1"), todaysTableInterval.Start, todaysTableInterval.Start.Add(30*time.Minute)),
+				createChunk(t, userID, labels.FromStrings("foo", "2"), todaysTableInterval.Start, todaysTableInterval.Start.Add(30*time.Minute)),
 			},
 			expiry: []chunkExpiry{
 				{
@@ -926,7 +926,7 @@ func TestMarkForDelete_SeriesCleanup(t *testing.T) {
 				},
 				{
 					isExpired: true,
-					filterFunc: func(ts time.Time, _ string, _ ...labels.Label) bool {
+					filterFunc: func(ts time.Time, _ string, _ labels.Labels) bool {
 						tsUnixNano := ts.UnixNano()
 						if todaysTableInterval.Start.UnixNano() <= tsUnixNano && tsUnixNano <= todaysTableInterval.Start.Add(15*time.Minute).UnixNano() {
 							return true
@@ -953,12 +953,12 @@ func TestMarkForDelete_SeriesCleanup(t *testing.T) {
 		{
 			name: "one big chunk partially deleted for yesterdays table without rewrite",
 			chunks: []chunk.Chunk{
-				createChunk(t, userID, labels.Labels{labels.Label{Name: "foo", Value: "1"}}, todaysTableInterval.Start.Add(-time.Hour), now),
+				createChunk(t, userID, labels.FromStrings("foo", "1"), todaysTableInterval.Start.Add(-time.Hour), now),
 			},
 			expiry: []chunkExpiry{
 				{
 					isExpired: true,
-					filterFunc: func(ts time.Time, _ string, _ ...labels.Label) bool {
+					filterFunc: func(ts time.Time, _ string, _ labels.Labels) bool {
 						return ts.UnixNano() < todaysTableInterval.Start.UnixNano()
 					},
 				},
@@ -980,12 +980,12 @@ func TestMarkForDelete_SeriesCleanup(t *testing.T) {
 		{
 			name: "one big chunk partially deleted for yesterdays table with rewrite",
 			chunks: []chunk.Chunk{
-				createChunk(t, userID, labels.Labels{labels.Label{Name: "foo", Value: "1"}}, todaysTableInterval.Start.Add(-time.Hour), now),
+				createChunk(t, userID, labels.FromStrings("foo", "1"), todaysTableInterval.Start.Add(-time.Hour), now),
 			},
 			expiry: []chunkExpiry{
 				{
 					isExpired: true,
-					filterFunc: func(ts time.Time, _ string, _ ...labels.Label) bool {
+					filterFunc: func(ts time.Time, _ string, _ labels.Labels) bool {
 						return ts.UnixNano() < todaysTableInterval.Start.Add(-30*time.Minute).UnixNano()
 					},
 				},
@@ -1042,8 +1042,8 @@ func TestMarkForDelete_SeriesCleanup(t *testing.T) {
 
 func TestDeleteTimeout(t *testing.T) {
 	chunks := []chunk.Chunk{
-		createChunk(t, "user", labels.Labels{labels.Label{Name: "foo", Value: "1"}}, model.Now(), model.Now().Add(270*time.Hour)),
-		createChunk(t, "user", labels.Labels{labels.Label{Name: "foo", Value: "2"}}, model.Now(), model.Now().Add(270*time.Hour)),
+		createChunk(t, "user", labels.FromStrings("foo", "1"), model.Now(), model.Now().Add(270*time.Hour)),
+		createChunk(t, "user", labels.FromStrings("foo", "2"), model.Now(), model.Now().Add(270*time.Hour)),
 	}
 
 	for _, tc := range []struct {
@@ -1089,13 +1089,13 @@ func TestMarkForDelete_DropChunkFromIndex(t *testing.T) {
 	retentionPeriod := now.Sub(todaysTableInterval.Start) / 2
 
 	// chunks in retention
-	c1 := createChunk(t, "1", labels.Labels{labels.Label{Name: "foo", Value: "1"}}, todaysTableInterval.Start, now)
-	c2 := createChunk(t, "1", labels.Labels{labels.Label{Name: "foo", Value: "2"}}, todaysTableInterval.Start.Add(-7*24*time.Hour), now)
+	c1 := createChunk(t, "1", labels.FromStrings("foo", "1"), todaysTableInterval.Start, now)
+	c2 := createChunk(t, "1", labels.FromStrings("foo", "2"), todaysTableInterval.Start.Add(-7*24*time.Hour), now)
 
 	// chunks out of retention
-	c3 := createChunk(t, "1", labels.Labels{labels.Label{Name: "foo", Value: "1"}}, todaysTableInterval.Start, now.Add(-retentionPeriod))
-	c4 := createChunk(t, "1", labels.Labels{labels.Label{Name: "foo", Value: "3"}}, todaysTableInterval.Start.Add(-12*time.Hour), todaysTableInterval.Start.Add(-10*time.Hour))
-	c5 := createChunk(t, "1", labels.Labels{labels.Label{Name: "foo", Value: "4"}}, todaysTableInterval.Start, now.Add(-retentionPeriod))
+	c3 := createChunk(t, "1", labels.FromStrings("foo", "1"), todaysTableInterval.Start, now.Add(-retentionPeriod))
+	c4 := createChunk(t, "1", labels.FromStrings("foo", "3"), todaysTableInterval.Start.Add(-12*time.Hour), todaysTableInterval.Start.Add(-10*time.Hour))
+	c5 := createChunk(t, "1", labels.FromStrings("foo", "4"), todaysTableInterval.Start, now.Add(-retentionPeriod))
 
 	require.NoError(t, store.Put(context.TODO(), []chunk.Chunk{
 		c1, c2, c3, c4, c5,

--- a/pkg/compactor/retention/series_test.go
+++ b/pkg/compactor/retention/series_test.go
@@ -4,18 +4,19 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
 )
 
 func Test_UserSeries(t *testing.T) {
 	m := newUserSeriesMap()
 
-	m.Add([]byte(`series1`), []byte(`user1`), nil)
-	m.Add([]byte(`series1`), []byte(`user1`), nil)
-	m.Add([]byte(`series1`), []byte(`user2`), nil)
-	m.Add([]byte(`series2`), []byte(`user1`), nil)
-	m.Add([]byte(`series2`), []byte(`user1`), nil)
-	m.Add([]byte(`series2`), []byte(`user2`), nil)
+	m.Add([]byte(`series1`), []byte(`user1`), labels.EmptyLabels())
+	m.Add([]byte(`series1`), []byte(`user1`), labels.EmptyLabels())
+	m.Add([]byte(`series1`), []byte(`user2`), labels.EmptyLabels())
+	m.Add([]byte(`series2`), []byte(`user1`), labels.EmptyLabels())
+	m.Add([]byte(`series2`), []byte(`user1`), labels.EmptyLabels())
+	m.Add([]byte(`series2`), []byte(`user2`), labels.EmptyLabels())
 
 	keys := []string{}
 

--- a/pkg/compactor/retention/util_test.go
+++ b/pkg/compactor/retention/util_test.go
@@ -201,9 +201,9 @@ func (t *table) Put(chk chunk.Chunk) {
 func (t *table) GetChunks(userID string, from, through model.Time, metric labels.Labels) []chunk.Chunk {
 	var chunks []chunk.Chunk
 	var matchers []*labels.Matcher
-	for _, l := range metric {
+	metric.Range(func(l labels.Label) {
 		matchers = append(matchers, labels.MustNewMatcher(labels.MatchEqual, l.Name, l.Value))
-	}
+	})
 
 	for seriesID := range t.chunks[userID] {
 		for _, chk := range t.chunks[userID][seriesID] {

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -900,7 +900,7 @@ func TestStreamShardAcrossCalls(t *testing.T) {
 			lbls, err := syntax.ParseLabels(s.Stream.Labels)
 			require.NoError(t, err)
 
-			require.Equal(t, lbls[0].Value, fmt.Sprint(i))
+			require.Equal(t, lbls.Get(ingester.ShardLbName), fmt.Sprint(i))
 		}
 
 		derivedStreams = d.shardStream(baseStream, streamRate, "fake")
@@ -911,7 +911,7 @@ func TestStreamShardAcrossCalls(t *testing.T) {
 			lbls, err := syntax.ParseLabels(s.Stream.Labels)
 			require.NoError(t, err)
 
-			require.Equal(t, lbls[0].Value, fmt.Sprint(i+2))
+			require.Equal(t, lbls.Get(ingester.ShardLbName), fmt.Sprint(i+2))
 		}
 	})
 }
@@ -1305,16 +1305,10 @@ func TestParseStreamLabels(t *testing.T) {
 				limits.MaxLabelNamesPerSeries = 1
 				return limits
 			},
-			expectedLabels: labels.Labels{
-				{
-					Name:  "foo",
-					Value: "bar",
-				},
-				{
-					Name:  loghttp_push.LabelServiceName,
-					Value: loghttp_push.ServiceUnknown,
-				},
-			},
+			expectedLabels: labels.FromStrings(
+				"foo", "bar",
+				loghttp_push.LabelServiceName, loghttp_push.ServiceUnknown,
+			),
 		},
 	} {
 		limits := tc.generateLimits()

--- a/pkg/distributor/field_detection_test.go
+++ b/pkg/distributor/field_detection_test.go
@@ -542,9 +542,9 @@ func Test_DetectGenericFields(t *testing.T) {
 	}{
 		{
 			name: "no match",
-			labels: labels.Labels{
-				{Name: "env", Value: "prod"},
-			},
+			labels: labels.FromStrings(
+				"env", "prod",
+			),
 			entry: push.Entry{
 				Line:               "log line does not match",
 				StructuredMetadata: push.LabelsAdapter{},
@@ -553,10 +553,10 @@ func Test_DetectGenericFields(t *testing.T) {
 		},
 		{
 			name: "stream label matches",
-			labels: labels.Labels{
-				{Name: "trace_id", Value: "8c5f2ecbade6f01d"},
-				{Name: "tenant_id", Value: "fake"},
-			},
+			labels: labels.FromStrings(
+				"trace_id", "8c5f2ecbade6f01d",
+				"tenant_id", "fake",
+			),
 			entry: push.Entry{
 				Line:               "log line does not match",
 				StructuredMetadata: push.LabelsAdapter{},
@@ -568,9 +568,9 @@ func Test_DetectGenericFields(t *testing.T) {
 		},
 		{
 			name: "metadata matches",
-			labels: labels.Labels{
-				{Name: "env", Value: "prod"},
-			},
+			labels: labels.FromStrings(
+				"env", "prod",
+			),
 			entry: push.Entry{
 				Line: "log line does not match",
 				StructuredMetadata: push.LabelsAdapter{
@@ -585,9 +585,9 @@ func Test_DetectGenericFields(t *testing.T) {
 		},
 		{
 			name: "logline (logfmt) matches",
-			labels: labels.Labels{
-				{Name: "env", Value: "prod"},
-			},
+			labels: labels.FromStrings(
+				"env", "prod",
+			),
 			entry: push.Entry{
 				Line:               `msg="this log line matches" trace_id="8c5f2ecbade6f01d" org_id=fake duration=1h`,
 				StructuredMetadata: push.LabelsAdapter{},
@@ -599,9 +599,9 @@ func Test_DetectGenericFields(t *testing.T) {
 		},
 		{
 			name: "logline (logfmt) matches multiple fields",
-			labels: labels.Labels{
-				{Name: "env", Value: "prod"},
-			},
+			labels: labels.FromStrings(
+				"env", "prod",
+			),
 			entry: push.Entry{
 				Line:               `msg="this log line matches" tenant_id="fake_a" org_id=fake_b duration=1h`,
 				StructuredMetadata: push.LabelsAdapter{},
@@ -612,9 +612,9 @@ func Test_DetectGenericFields(t *testing.T) {
 		},
 		{
 			name: "logline (json) matches",
-			labels: labels.Labels{
-				{Name: "env", Value: "prod"},
-			},
+			labels: labels.FromStrings(
+				"env", "prod",
+			),
 			entry: push.Entry{
 				Line:               `{"msg": "this log line matches", "trace_id": "8c5f2ecbade6f01d", "org_id": "fake", "duration": "1s"}`,
 				StructuredMetadata: push.LabelsAdapter{},
@@ -626,9 +626,9 @@ func Test_DetectGenericFields(t *testing.T) {
 		},
 		{
 			name: "logline (json) matches multiple fields",
-			labels: labels.Labels{
-				{Name: "env", Value: "prod"},
-			},
+			labels: labels.FromStrings(
+				"env", "prod",
+			),
 			entry: push.Entry{
 				Line:               `{"msg": "this log line matches", "tenant_id": "fake_a", "org_id": "fake_b", "duration": "1s"}`,
 				StructuredMetadata: push.LabelsAdapter{},
@@ -639,9 +639,9 @@ func Test_DetectGenericFields(t *testing.T) {
 		},
 		{
 			name: "logline matches jsonpath",
-			labels: labels.Labels{
-				{Name: "env", Value: "prod"},
-			},
+			labels: labels.FromStrings(
+				"env", "prod",
+			),
 			entry: push.Entry{
 				Line:               `{"product": {"details": "product details", "id": "P2024/01"}}`,
 				StructuredMetadata: push.LabelsAdapter{},

--- a/pkg/distributor/validator_test.go
+++ b/pkg/distributor/validator_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 var (
-	testStreamLabels       = labels.Labels{{Name: "my", Value: "label"}}
+	testStreamLabels       = labels.FromStrings("my", "label")
 	testStreamLabelsString = testStreamLabels.String()
 	testTime               = time.Now()
 )

--- a/pkg/indexgateway/gateway_test.go
+++ b/pkg/indexgateway/gateway_test.go
@@ -465,7 +465,7 @@ func TestAccumulateChunksToShards(t *testing.T) {
 						})
 					}
 
-					if stop := fn(nil, s[0].ref.FingerprintModel(), chks); stop {
+					if stop := fn(labels.EmptyLabels(), s[0].ref.FingerprintModel(), chks); stop {
 						return nil
 					}
 				}

--- a/pkg/kafka/encoding_test.go
+++ b/pkg/kafka/encoding_test.go
@@ -54,7 +54,7 @@ func TestEncoderDecoder(t *testing.T) {
 				stream, ls, err := decoder.Decode(record.Value)
 				require.NoError(t, err)
 				decodedEntries = append(decodedEntries, stream.Entries...)
-				if decodedLabels == nil {
+				if decodedLabels.IsEmpty() {
 					decodedLabels = ls
 				} else {
 					require.Equal(t, decodedLabels, ls)

--- a/pkg/logproto/compat_test.go
+++ b/pkg/logproto/compat_test.go
@@ -80,7 +80,7 @@ func testUnmarshalling(t *testing.T, unmarshalFn func(data []byte, v interface{}
 
 func TestFromLabelAdaptersToLabels(t *testing.T) {
 	input := []LabelAdapter{{Name: "hello", Value: "world"}}
-	expected := labels.Labels{labels.Label{Name: "hello", Value: "world"}}
+	expected := labels.FromStrings("hello", "world")
 	actual := FromLabelAdaptersToLabels(input)
 
 	assert.Equal(t, expected, actual)

--- a/pkg/util/marshal/marshal_test.go
+++ b/pkg/util/marshal/marshal_test.go
@@ -302,30 +302,18 @@ var queryTests = []struct {
 			{
 				T: 1568404331324,
 				F: 0.013333333333333334,
-				Metric: []labels.Label{
-					{
-						Name:  "filename",
-						Value: `/var/hostlog/apport.log`,
-					},
-					{
-						Name:  "job",
-						Value: "varlogs",
-					},
-				},
+				Metric: labels.FromStrings(
+					"filename", `/var/hostlog/apport.log`,
+					"job", "varlogs",
+				),
 			},
 			{
 				T: 1568404331324,
 				F: 3.45,
-				Metric: []labels.Label{
-					{
-						Name:  "filename",
-						Value: `/var/hostlog/syslog`,
-					},
-					{
-						Name:  "job",
-						Value: "varlogs",
-					},
-				},
+				Metric: labels.FromStrings(
+					"filename", `/var/hostlog/syslog`,
+					"job", "varlogs",
+				),
 			},
 		},
 		fmt.Sprintf(`{
@@ -369,16 +357,10 @@ var queryTests = []struct {
 						F: 0.013333333333333334,
 					},
 				},
-				Metric: []labels.Label{
-					{
-						Name:  "filename",
-						Value: `/var/hostlog/apport.log`,
-					},
-					{
-						Name:  "job",
-						Value: "varlogs",
-					},
-				},
+				Metric: labels.FromStrings(
+					"filename", `/var/hostlog/apport.log`,
+					"job", "varlogs",
+				),
 			},
 			{
 				Floats: []promql.FPoint{
@@ -391,16 +373,10 @@ var queryTests = []struct {
 						F: 4.45,
 					},
 				},
-				Metric: []labels.Label{
-					{
-						Name:  "filename",
-						Value: `/var/hostlog/syslog`,
-					},
-					{
-						Name:  "job",
-						Value: "varlogs",
-					},
-				},
+				Metric: labels.FromStrings(
+					"filename", `/var/hostlog/syslog`,
+					"job", "varlogs",
+				),
 			},
 		},
 		fmt.Sprintf(`{
@@ -987,11 +963,13 @@ func randLabel(rand *rand.Rand) labels.Label {
 }
 
 func randLabels(rand *rand.Rand) labels.Labels {
-	var labels labels.Labels
+	builder := labels.NewBuilder(labels.EmptyLabels())
 	nLabels := rand.Intn(100)
 	for i := 0; i < nLabels; i++ {
-		labels = append(labels, randLabel(rand))
+		label := randLabel(rand)
+		builder.Set(label.Name, label.Value)
 	}
+	labels := builder.Labels()
 
 	return labels
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a next step of support Prometheus `stringlabels` implementation in Loki. It adds support in tests of `bloombuild`, `chunkenc`, `compactor` and `distributor`.

**Special notes for your reviewer**:
The tests should compile with build tag `stringlabels`.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
