### PR TITLE
refactor(stringlabels): Support stringlabels ingester tests

### DIFF
--- a/pkg/ingester/checkpoint_test.go
+++ b/pkg/ingester/checkpoint_test.go
@@ -421,7 +421,7 @@ func buildStreams() []logproto.Stream {
 
 var (
 	stream1 = logproto.Stream{
-		Labels: labels.Labels{labels.Label{Name: "stream", Value: "1"}}.String(),
+		Labels: labels.FromStrings("stream", "1").String(),
 		Entries: []logproto.Entry{
 			{
 				Timestamp: time.Unix(0, 1),
@@ -434,7 +434,7 @@ var (
 		},
 	}
 	stream2 = logproto.Stream{
-		Labels: labels.Labels{labels.Label{Name: "stream", Value: "2"}}.String(),
+		Labels: labels.FromStrings("stream", "2").String(),
 		Entries: []logproto.Entry{
 			{
 				Timestamp: time.Unix(0, 1),
@@ -482,7 +482,7 @@ func Test_SeriesIterator(t *testing.T) {
 			assert.Equal(t, fmt.Sprintf("%d", i), iter.Stream().UserID)
 			memchunk, err := chunkenc.MemchunkFromCheckpoint(iter.Stream().Chunks[0].Data, iter.Stream().Chunks[0].Head, chunkenc.UnorderedHeadBlockFmt, 0, 0)
 			require.NoError(t, err)
-			it, err := memchunk.Iterator(context.Background(), time.Unix(0, 0), time.Unix(0, 100), logproto.FORWARD, log.NewNoopPipeline().ForStream(nil))
+			it, err := memchunk.Iterator(context.Background(), time.Unix(0, 0), time.Unix(0, 100), logproto.FORWARD, log.NewNoopPipeline().ForStream(labels.EmptyLabels()))
 			require.NoError(t, err)
 			stream := logproto.Stream{
 				Labels: logproto.FromLabelAdaptersToLabels(iter.Stream().Labels).String(),
@@ -550,7 +550,7 @@ func Benchmark_CheckpointWrite(b *testing.B) {
 		metrics:       NilMetrics,
 		checkpointWAL: noOpWalLogger{},
 	}
-	lbs := labels.Labels{labels.Label{Name: "foo", Value: "bar"}}
+	lbs := labels.FromStrings("foo", "bar")
 	chunks := buildChunks(b, 10)
 	b.ReportAllocs()
 	b.ResetTimer()

--- a/pkg/ingester/flush_test.go
+++ b/pkg/ingester/flush_test.go
@@ -444,10 +444,17 @@ func (s *testStore) Put(ctx context.Context, chunks []chunk.Chunk) error {
 		return err
 	}
 	for ix, chunk := range chunks {
-		for _, label := range chunk.Metric {
-			if label.Value == "" {
-				return fmt.Errorf("Chunk has blank label %q", label.Name)
+		var err error
+		chunk.Metric.Range(func(l labels.Label) {
+			if err != nil {
+				return
 			}
+			if l.Value == "" {
+				err = fmt.Errorf("Chunk has blank label %q", l.Name)
+			}
+		})
+		if err != nil {
+			return err
 		}
 
 		// remove __name__ label

--- a/pkg/ingester/instance_test.go
+++ b/pkg/ingester/instance_test.go
@@ -316,13 +316,13 @@ func setupTestStreams(t *testing.T) (*instance, time.Time, int) {
 		{Labels: "{app=\"test\",job=\"varlogs2\"}", Entries: entries(5, currentTime.Add(12*time.Nanosecond))},
 	}
 
-	retentionHours := util.RetentionHours(tenantsRetention.RetentionPeriodFor("test", nil))
+	retentionHours := util.RetentionHours(tenantsRetention.RetentionPeriodFor("test", labels.EmptyLabels()))
 	for _, testStream := range testStreams {
 		stream, err := instance.getOrCreateStream(context.Background(), testStream, recordPool.GetRecord())
 		require.NoError(t, err)
 		chunkfmt, headfmt, err := instance.chunkFormatAt(minTs(&testStream))
 		require.NoError(t, err)
-		chunk := newStream(chunkfmt, headfmt, cfg, limiter.rateLimitStrategy, "fake", 0, nil, true, NewStreamRateCalculator(), NilMetrics, nil, nil, retentionHours).NewChunk()
+		chunk := newStream(chunkfmt, headfmt, cfg, limiter.rateLimitStrategy, "fake", 0, labels.EmptyLabels(), true, NewStreamRateCalculator(), NilMetrics, nil, nil, retentionHours).NewChunk()
 		for _, entry := range testStream.Entries {
 			dup, err := chunk.Append(&entry)
 			require.False(t, dup)
@@ -504,7 +504,7 @@ func entries(n int, t time.Time) []logproto.Entry {
 var labelNames = []string{"app", "instance", "namespace", "user", "cluster", ShardLbName}
 
 func makeRandomLabels() labels.Labels {
-	ls := labels.NewBuilder(nil)
+	ls := labels.NewBuilder(labels.EmptyLabels())
 	for _, ln := range labelNames {
 		ls.Set(ln, fmt.Sprintf("%d", rand.Int31()))
 	}

--- a/pkg/ingester/kafka_consumer_test.go
+++ b/pkg/ingester/kafka_consumer_test.go
@@ -22,7 +22,7 @@ import (
 var (
 	tenantID  = "foo"
 	streamBar = logproto.Stream{
-		Labels: labels.Labels{labels.Label{Name: "stream", Value: "1"}}.String(),
+		Labels: labels.FromStrings("stream", "1").String(),
 		Entries: []logproto.Entry{
 			{
 				Timestamp: time.Unix(0, 1).UTC(),
@@ -35,7 +35,7 @@ var (
 		},
 	}
 	streamFoo = logproto.Stream{
-		Labels: labels.Labels{labels.Label{Name: "stream", Value: "2"}}.String(),
+		Labels: labels.FromStrings("stream", "2").String(),
 		Entries: []logproto.Entry{
 			{
 				Timestamp: time.Unix(0, 1).UTC(),

--- a/pkg/ingester/mapper_test.go
+++ b/pkg/ingester/mapper_test.go
@@ -1,7 +1,6 @@
 package ingester
 
 import (
-	"sort"
 	"testing"
 
 	"github.com/prometheus/common/model"
@@ -18,41 +17,17 @@ var (
 	fp1  = model.Fingerprint(maxMappedFP + 1)
 	fp2  = model.Fingerprint(maxMappedFP + 2)
 	fp3  = model.Fingerprint(1)
-	cm11 = []labels.Label{
-		{Name: "dings", Value: "bumms"},
-		{Name: "foo", Value: "bar"},
-	}
-	cm12 = []labels.Label{
-		{Name: "bar", Value: "foo"},
-	}
-	cm13 = []labels.Label{
-		{Name: "foo", Value: "bar"},
-	}
-	cm21 = []labels.Label{
-		{Name: "dings", Value: "bar"},
-		{Name: "foo", Value: "bumms"},
-	}
-	cm22 = []labels.Label{
-		{Name: "bar", Value: "bumms"},
-		{Name: "dings", Value: "foo"},
-	}
-	cm31 = []labels.Label{
-		{Name: "bumms", Value: "dings"},
-	}
-	cm32 = []labels.Label{
-		{Name: "bar", Value: "foo"},
-		{Name: "bumms", Value: "dings"},
-	}
+	cm11 = labels.FromStrings("dings", "bumms", "foo", "bar")
+	cm12 = labels.FromStrings("bar", "foo")
+	cm13 = labels.FromStrings("foo", "bar")
+	cm21 = labels.FromStrings("dings", "bar", "foo", "bumms")
+	cm22 = labels.FromStrings("bar", "bumms", "dings", "foo")
+	cm31 = labels.FromStrings("bumms", "dings")
+	cm32 = labels.FromStrings("bar", "foo", "bumms", "dings")
 )
 
-func copyValuesAndSort(a []labels.Label) labels.Labels {
-	c := make(labels.Labels, len(a))
-	for i, pair := range a {
-		c[i].Name = pair.Name
-		c[i].Value = pair.Value
-	}
-	sort.Sort(c)
-	return c
+func copyValuesAndSort(a labels.Labels) labels.Labels {
+	return a.Copy()
 }
 
 func TestFPMapper(t *testing.T) {

--- a/pkg/ingester/recalculate_owned_streams_test.go
+++ b/pkg/ingester/recalculate_owned_streams_test.go
@@ -240,7 +240,7 @@ func Test_ownedStreamsPartitionStrategy_isOwnedStream(t *testing.T) {
 }
 
 func createStream(t *testing.T, inst *instance, fingerprint int) *stream {
-	lbls := labels.Labels{labels.Label{Name: "mock", Value: strconv.Itoa(fingerprint)}}
+	lbls := labels.FromStrings("mock", strconv.Itoa(fingerprint))
 
 	stream, _, err := inst.streams.LoadOrStoreNew(lbls.String(), func() (*stream, error) {
 		return inst.createStreamByFP(lbls, model.Fingerprint(fingerprint))

--- a/pkg/ingester/recovery_test.go
+++ b/pkg/ingester/recovery_test.go
@@ -288,7 +288,7 @@ func TestSeriesRecoveryNoDuplicates(t *testing.T) {
 	require.NoError(t, err)
 	// We always send an empty batch to make sure stats are sent, so there will always be one empty response.
 	require.Len(t, result.resps, 2)
-	lbls := labels.Labels{{Name: "bar", Value: "baz1"}, {Name: "foo", Value: "bar"}}
+	lbls := labels.FromStrings("bar", "baz1", "foo", "bar")
 	expected := []logproto.Stream{
 		{
 			Labels: lbls.String(),

--- a/pkg/ingester/stream_test.go
+++ b/pkg/ingester/stream_test.go
@@ -73,9 +73,7 @@ func TestMaxReturnedStreamsErrors(t *testing.T) {
 				limiter.rateLimitStrategy,
 				"fake",
 				model.Fingerprint(0),
-				labels.Labels{
-					{Name: "foo", Value: "bar"},
-				},
+				labels.FromStrings("foo", "bar"),
 				true,
 				NewStreamRateCalculator(),
 				NilMetrics,
@@ -128,9 +126,7 @@ func TestPushDeduplication(t *testing.T) {
 		limiter.rateLimitStrategy,
 		"fake",
 		model.Fingerprint(0),
-		labels.Labels{
-			{Name: "foo", Value: "bar"},
-		},
+		labels.FromStrings("foo", "bar"),
 		true,
 		NewStreamRateCalculator(),
 		NilMetrics,
@@ -189,9 +185,7 @@ func TestPushDeduplicationExtraMetrics(t *testing.T) {
 		limiter.rateLimitStrategy,
 		"fake",
 		model.Fingerprint(0),
-		labels.Labels{
-			{Name: "foo", Value: "bar"},
-		},
+		labels.FromStrings("foo", "bar"),
 		true,
 		NewStreamRateCalculator(),
 		metrics,
@@ -236,9 +230,7 @@ func TestPushRejectOldCounter(t *testing.T) {
 		limiter.rateLimitStrategy,
 		"fake",
 		model.Fingerprint(0),
-		labels.Labels{
-			{Name: "foo", Value: "bar"},
-		},
+		labels.FromStrings("foo", "bar"),
 		true,
 		NewStreamRateCalculator(),
 		NilMetrics,
@@ -345,9 +337,7 @@ func TestEntryErrorCorrectlyReported(t *testing.T) {
 		limiter.rateLimitStrategy,
 		"fake",
 		model.Fingerprint(0),
-		labels.Labels{
-			{Name: "foo", Value: "bar"},
-		},
+		labels.FromStrings("foo", "bar"),
 		true,
 		NewStreamRateCalculator(),
 		NilMetrics,
@@ -385,9 +375,7 @@ func TestUnorderedPush(t *testing.T) {
 		limiter.rateLimitStrategy,
 		"fake",
 		model.Fingerprint(0),
-		labels.Labels{
-			{Name: "foo", Value: "bar"},
-		},
+		labels.FromStrings("foo", "bar"),
 		true,
 		NewStreamRateCalculator(),
 		NilMetrics,
@@ -489,9 +477,7 @@ func TestPushRateLimit(t *testing.T) {
 		limiter.rateLimitStrategy,
 		"fake",
 		model.Fingerprint(0),
-		labels.Labels{
-			{Name: "foo", Value: "bar"},
-		},
+		labels.FromStrings("foo", "bar"),
 		true,
 		NewStreamRateCalculator(),
 		NilMetrics,
@@ -531,9 +517,7 @@ func TestPushRateLimitAllOrNothing(t *testing.T) {
 		limiter.rateLimitStrategy,
 		"fake",
 		model.Fingerprint(0),
-		labels.Labels{
-			{Name: "foo", Value: "bar"},
-		},
+		labels.FromStrings("foo", "bar"),
 		true,
 		NewStreamRateCalculator(),
 		NilMetrics,
@@ -572,9 +556,7 @@ func TestReplayAppendIgnoresValidityWindow(t *testing.T) {
 		limiter.rateLimitStrategy,
 		"fake",
 		model.Fingerprint(0),
-		labels.Labels{
-			{Name: "foo", Value: "bar"},
-		},
+		labels.FromStrings("foo", "bar"),
 		true,
 		NewStreamRateCalculator(),
 		NilMetrics,
@@ -619,12 +601,12 @@ func iterEq(t *testing.T, exp []logproto.Entry, got iter.EntryIterator) {
 }
 
 func Benchmark_PushStream(b *testing.B) {
-	ls := labels.Labels{
-		labels.Label{Name: "namespace", Value: "loki-dev"},
-		labels.Label{Name: "cluster", Value: "dev-us-central1"},
-		labels.Label{Name: "job", Value: "loki-dev/ingester"},
-		labels.Label{Name: "container", Value: "ingester"},
-	}
+	ls := labels.FromStrings(
+		"namespace", "loki-dev",
+		"cluster", "dev-us-central1",
+		"job", "loki-dev/ingester",
+		"container", "ingester",
+	)
 
 	limits, err := validation.NewOverrides(defaultLimitsTestConfig(), nil)
 	require.NoError(b, err)

--- a/pkg/ingester/streams_map_test.go
+++ b/pkg/ingester/streams_map_test.go
@@ -26,9 +26,7 @@ func TestStreamsMap(t *testing.T) {
 			limiter.rateLimitStrategy,
 			"fake",
 			model.Fingerprint(1),
-			labels.Labels{
-				{Name: "foo", Value: "bar"},
-			},
+			labels.FromStrings("foo", "bar"),
 			true,
 			NewStreamRateCalculator(),
 			NilMetrics,
@@ -43,9 +41,7 @@ func TestStreamsMap(t *testing.T) {
 			limiter.rateLimitStrategy,
 			"fake",
 			model.Fingerprint(2),
-			labels.Labels{
-				{Name: "bar", Value: "foo"},
-			},
+			labels.FromStrings("bar", "foo"),
 			true,
 			NewStreamRateCalculator(),
 			NilMetrics,

--- a/pkg/ingester/tailer_test.go
+++ b/pkg/ingester/tailer_test.go
@@ -91,7 +91,7 @@ func TestTailer_sendRaceConditionOnSendWhileClosing(t *testing.T) {
 		go assert.NotPanics(t, func() {
 			defer routines.Done()
 			time.Sleep(time.Duration(rand.Intn(1000)) * time.Microsecond)
-			tailer.send(stream, labels.Labels{{Name: "type", Value: "test"}})
+			tailer.send(stream, labels.FromStrings("type", "test"))
 		})
 
 		go assert.NotPanics(t, func() {
@@ -234,9 +234,9 @@ func Test_IsMatching(t *testing.T) {
 		matchers []*labels.Matcher
 		matches  bool
 	}{
-		{"not in lbs", labels.Labels{{Name: "job", Value: "foo"}}, []*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}, false},
-		{"equal", labels.Labels{{Name: "job", Value: "foo"}}, []*labels.Matcher{{Type: labels.MatchEqual, Name: "job", Value: "foo"}}, true},
-		{"regex", labels.Labels{{Name: "job", Value: "foo"}}, []*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, "job", ".+oo")}, true},
+		{"not in lbs", labels.FromStrings("job", "foo"), []*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}, false},
+		{"equal", labels.FromStrings("job", "foo"), []*labels.Matcher{{Type: labels.MatchEqual, Name: "job", Value: "foo"}}, true},
+		{"regex", labels.FromStrings("job", "foo"), []*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, "job", ".+oo")}, true},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			require.Equal(t, tt.matches, isMatching(tt.lbs, tt.matchers))


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a next step of support Prometheus `stringlabels` implementation in Loki. It adds support in `ingester` tests.

**Special notes for your reviewer**:
The tests should compile with build tag `stringlabels`.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
