### PR TITLE
refactor(stringlabels): Support stringlabels distributor tests

### DIFF
--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -900,7 +900,7 @@ func TestStreamShardAcrossCalls(t *testing.T) {
 			lbls, err := syntax.ParseLabels(s.Stream.Labels)
 			require.NoError(t, err)
 
-			require.Equal(t, lbls[0].Value, fmt.Sprint(i))
+			require.Equal(t, lbls.Get(ingester.ShardLbName), fmt.Sprint(i))
 		}
 
 		derivedStreams = d.shardStream(baseStream, streamRate, "fake")
@@ -911,7 +911,7 @@ func TestStreamShardAcrossCalls(t *testing.T) {
 			lbls, err := syntax.ParseLabels(s.Stream.Labels)
 			require.NoError(t, err)
 
-			require.Equal(t, lbls[0].Value, fmt.Sprint(i+2))
+			require.Equal(t, lbls.Get(ingester.ShardLbName), fmt.Sprint(i+2))
 		}
 	})
 }
@@ -1305,16 +1305,10 @@ func TestParseStreamLabels(t *testing.T) {
 				limits.MaxLabelNamesPerSeries = 1
 				return limits
 			},
-			expectedLabels: labels.Labels{
-				{
-					Name:  "foo",
-					Value: "bar",
-				},
-				{
-					Name:  loghttp_push.LabelServiceName,
-					Value: loghttp_push.ServiceUnknown,
-				},
-			},
+			expectedLabels: labels.FromStrings(
+				"foo", "bar",
+				loghttp_push.LabelServiceName, loghttp_push.ServiceUnknown,
+			),
 		},
 	} {
 		limits := tc.generateLimits()

--- a/pkg/distributor/field_detection_test.go
+++ b/pkg/distributor/field_detection_test.go
@@ -542,9 +542,9 @@ func Test_DetectGenericFields(t *testing.T) {
 	}{
 		{
 			name: "no match",
-			labels: labels.Labels{
-				{Name: "env", Value: "prod"},
-			},
+			labels: labels.FromStrings(
+				"env", "prod",
+			),
 			entry: push.Entry{
 				Line:               "log line does not match",
 				StructuredMetadata: push.LabelsAdapter{},
@@ -553,10 +553,10 @@ func Test_DetectGenericFields(t *testing.T) {
 		},
 		{
 			name: "stream label matches",
-			labels: labels.Labels{
-				{Name: "trace_id", Value: "8c5f2ecbade6f01d"},
-				{Name: "tenant_id", Value: "fake"},
-			},
+			labels: labels.FromStrings(
+				"trace_id", "8c5f2ecbade6f01d",
+				"tenant_id", "fake",
+			),
 			entry: push.Entry{
 				Line:               "log line does not match",
 				StructuredMetadata: push.LabelsAdapter{},
@@ -568,9 +568,9 @@ func Test_DetectGenericFields(t *testing.T) {
 		},
 		{
 			name: "metadata matches",
-			labels: labels.Labels{
-				{Name: "env", Value: "prod"},
-			},
+			labels: labels.FromStrings(
+				"env", "prod",
+			),
 			entry: push.Entry{
 				Line: "log line does not match",
 				StructuredMetadata: push.LabelsAdapter{
@@ -585,9 +585,9 @@ func Test_DetectGenericFields(t *testing.T) {
 		},
 		{
 			name: "logline (logfmt) matches",
-			labels: labels.Labels{
-				{Name: "env", Value: "prod"},
-			},
+			labels: labels.FromStrings(
+				"env", "prod",
+			),
 			entry: push.Entry{
 				Line:               `msg="this log line matches" trace_id="8c5f2ecbade6f01d" org_id=fake duration=1h`,
 				StructuredMetadata: push.LabelsAdapter{},
@@ -599,9 +599,9 @@ func Test_DetectGenericFields(t *testing.T) {
 		},
 		{
 			name: "logline (logfmt) matches multiple fields",
-			labels: labels.Labels{
-				{Name: "env", Value: "prod"},
-			},
+			labels: labels.FromStrings(
+				"env", "prod",
+			),
 			entry: push.Entry{
 				Line:               `msg="this log line matches" tenant_id="fake_a" org_id=fake_b duration=1h`,
 				StructuredMetadata: push.LabelsAdapter{},
@@ -612,9 +612,9 @@ func Test_DetectGenericFields(t *testing.T) {
 		},
 		{
 			name: "logline (json) matches",
-			labels: labels.Labels{
-				{Name: "env", Value: "prod"},
-			},
+			labels: labels.FromStrings(
+				"env", "prod",
+			),
 			entry: push.Entry{
 				Line:               `{"msg": "this log line matches", "trace_id": "8c5f2ecbade6f01d", "org_id": "fake", "duration": "1s"}`,
 				StructuredMetadata: push.LabelsAdapter{},
@@ -626,9 +626,9 @@ func Test_DetectGenericFields(t *testing.T) {
 		},
 		{
 			name: "logline (json) matches multiple fields",
-			labels: labels.Labels{
-				{Name: "env", Value: "prod"},
-			},
+			labels: labels.FromStrings(
+				"env", "prod",
+			),
 			entry: push.Entry{
 				Line:               `{"msg": "this log line matches", "tenant_id": "fake_a", "org_id": "fake_b", "duration": "1s"}`,
 				StructuredMetadata: push.LabelsAdapter{},
@@ -639,9 +639,9 @@ func Test_DetectGenericFields(t *testing.T) {
 		},
 		{
 			name: "logline matches jsonpath",
-			labels: labels.Labels{
-				{Name: "env", Value: "prod"},
-			},
+			labels: labels.FromStrings(
+				"env", "prod",
+			),
 			entry: push.Entry{
 				Line:               `{"product": {"details": "product details", "id": "P2024/01"}}`,
 				StructuredMetadata: push.LabelsAdapter{},

--- a/pkg/distributor/validator_test.go
+++ b/pkg/distributor/validator_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 var (
-	testStreamLabels       = labels.Labels{{Name: "my", Value: "label"}}
+	testStreamLabels       = labels.FromStrings("my", "label")
 	testStreamLabelsString = testStreamLabels.String()
 	testTime               = time.Now()
 )

--- a/pkg/kafka/encoding_test.go
+++ b/pkg/kafka/encoding_test.go
@@ -54,7 +54,7 @@ func TestEncoderDecoder(t *testing.T) {
 				stream, ls, err := decoder.Decode(record.Value)
 				require.NoError(t, err)
 				decodedEntries = append(decodedEntries, stream.Entries...)
-				if decodedLabels == nil {
+				if decodedLabels.IsEmpty() {
 					decodedLabels = ls
 				} else {
 					require.Equal(t, decodedLabels, ls)


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a next step of support Prometheus `stringlabels` implementation in Loki. It adds support in `distributor` tests.

**Special notes for your reviewer**:
The tests should compile with build tag `stringlabels`.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
