### PR TITLE
feat: add tests for enforcing limits in distributors

### DIFF
--- a/pkg/distributor/ingest_limits.go
+++ b/pkg/distributor/ingest_limits.go
@@ -11,6 +11,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
+	limits_frontend "github.com/grafana/loki/v3/pkg/limits/frontend"
 	limits_frontend_client "github.com/grafana/loki/v3/pkg/limits/frontend/client"
 	"github.com/grafana/loki/v3/pkg/logproto"
 )
@@ -154,4 +155,24 @@ func newExceedsLimitsRequest(tenant string, streams []KeyedStream) (*logproto.Ex
 		Tenant:  tenant,
 		Streams: streamMetadata,
 	}, nil
+}
+
+func firstReasonForHashes(reasonsForHashes map[uint64][]string) string {
+	for _, reasons := range reasonsForHashes {
+		return humanizeReasonForHash(reasons[0])
+	}
+	return "unknown reason"
+}
+
+// TODO(grobinson): Move this to the same place where the consts
+// are defined.
+func humanizeReasonForHash(s string) string {
+	switch s {
+	case limits_frontend.ReasonExceedsMaxStreams:
+		return "max streams exceeded"
+	case limits_frontend.ReasonExceedsRateLimit:
+		return "rate limit exceeded"
+	default:
+		return s
+	}
 }

--- a/pkg/distributor/ingest_limits_test.go
+++ b/pkg/distributor/ingest_limits_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/coder/quartz"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
 
 	"github.com/grafana/loki/v3/pkg/logproto"
 )
@@ -16,6 +17,7 @@ import (
 // mockIngestLimitsFrontendClient mocks the RPC calls for tests.
 type mockIngestLimitsFrontendClient struct {
 	t               *testing.T
+	calls           atomic.Uint64
 	expectedRequest *logproto.ExceedsLimitsRequest
 	response        *logproto.ExceedsLimitsResponse
 	responseErr     error
@@ -23,6 +25,7 @@ type mockIngestLimitsFrontendClient struct {
 
 // Implements the ingestLimitsFrontendClient interface.
 func (c *mockIngestLimitsFrontendClient) exceedsLimits(_ context.Context, r *logproto.ExceedsLimitsRequest) (*logproto.ExceedsLimitsResponse, error) {
+	c.calls.Add(1)
 	require.Equal(c.t, c.expectedRequest, r)
 	if c.responseErr != nil {
 		return nil, c.responseErr


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request adds missing tests for `distributor.Push` to make sure requests are rejected as expected when limits are exceeded.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
