### PR TITLE
fix: query

### DIFF
--- a/pkg/logql/syntax/parser_test.go
+++ b/pkg/logql/syntax/parser_test.go
@@ -357,6 +357,10 @@ var ParseTestCases = []struct {
 		}, nil),
 	},
 	{
+		in:  "{ foo = \"bar\" } | logfmt | msg =~ \"`.`\" ",
+		err: logqlmodel.NewParseError("syntax error: unexpected .", 1, 39),
+	},
+	{
 		in:  `unk({ foo = "bar" }[5m])`,
 		err: logqlmodel.NewParseError("syntax error: unexpected IDENTIFIER", 1, 1),
 	},
@@ -3713,5 +3717,12 @@ func TestParseSampleExpr_String(t *testing.T) {
 
 		// escaping is hard: the result is {cluster="beep", namespace="boop"} | msg=~`\w.*` which is equivalent to the original
 		require.Equal(t, "{cluster=\"beep\", namespace=\"boop\"} | msg=~`\\w.*`", expr.String())
+	})
+
+	t.Run("it correctly surrounds regex containing backticks with double quotes", func(t *testing.T) {
+		query := "{foo=\"bar\"} | logfmt | msg=~\"`.`\""
+		expr, err := ParseExpr(query)
+		require.NoError(t, err)
+		require.Equal(t, "{foo=\"bar\"} | logfmt | msg=~\"`.`\"", expr.String())
 	})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
When the querysharder executes, it [converts a query into an AST representation](https://github.com/grafana/loki/blob/main/pkg/querier/queryrange/querysharding.go#L230) before forwarding it on to the queriers. Unfortunately, when this AST representation is converted back into a string, it does not handle the case where a regexp can contain backticks - it tries to wrap it in backticks, which can lead to parser errors. This PR is to demonstrate the issue and hopefully fix it!

**Which issue(s) this PR fixes**:
Fixes #16674 (eventually)

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
