### PR TITLE
chore(logql/bench): store proper timestamps in generated chunks

### DIFF
--- a/pkg/logql/bench/store_chunk.go
+++ b/pkg/logql/bench/store_chunk.go
@@ -23,6 +23,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/storage/chunk/client/local"
 	"github.com/grafana/loki/v3/pkg/storage/config"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper"
+	"github.com/grafana/loki/v3/pkg/util"
 	util_log "github.com/grafana/loki/v3/pkg/util/log"
 	"github.com/grafana/loki/v3/pkg/validation"
 )
@@ -138,8 +139,8 @@ func (s *ChunkStore) flushChunk(ctx context.Context, memChunk *chunkenc.MemChunk
 	metric := labelsBuilder.Labels()
 	fp := client.Fingerprint(lbs)
 
-	from, to := memChunk.Bounds()
-	c := chunk.NewChunk(s.tenantID, fp, metric, chunkenc.NewFacade(memChunk, 0, 0), model.TimeFromUnixNano(from.UnixNano()), model.TimeFromUnixNano(to.UnixNano()))
+	firstTime, lastTime := util.RoundToMilliseconds(memChunk.Bounds())
+	c := chunk.NewChunk(s.tenantID, fp, metric, chunkenc.NewFacade(memChunk, 0, 0), firstTime, lastTime)
 	if err := c.Encode(); err != nil {
 		return err
 	}


### PR DESCRIPTION
The timestamp bounds of a chunk are used to update the query range bounds; the previous code always truncated the bounds down, which caused backwards queries to ignore the latest log line in a chunk if that log line was less than a millisecond beyond the truncated timestamp.

I missed this in #17104, because I previously had this fix, generated the dataset with it, and then removed the fix was removed after I thought it wasn't important.

Turns out it was important :)