### PR TITLE
feat(tools): Add stream generator

### DIFF
--- a/tools/stream-generator/Dockerfile
+++ b/tools/stream-generator/Dockerfile
@@ -13,9 +13,9 @@ COPY --from=build /src/loki/stream-generator /usr/bin/stream-generator
 
 SHELL [ "/busybox/sh", "-c" ]
 
-RUN addgroup -g 10001 -S streammetagen && \
-    adduser -u 10001 -S streammetagen -G streammetagen && \
-    chown -R streammetagen:streammetagen /usr/bin/stream-generator && \
+RUN addgroup -g 10001 -S streamgenerator && \
+    adduser -u 10001 -S streamgenerator -G streamgenerator && \
+    chown -R streamgenerator:streamgenerator /usr/bin/stream-generator && \
     ln -s /busybox/sh /bin/sh
 
 USER 10001

--- a/tools/stream-generator/Dockerfile
+++ b/tools/stream-generator/Dockerfile
@@ -1,0 +1,23 @@
+ARG GO_VERSION=1.24
+
+# Go build stage
+FROM golang:${GO_VERSION} AS build
+COPY . /src/loki
+WORKDIR /src/loki
+RUN CGO_ENABLED=0 go build -o stream-generator ./tools/stream-generator/main.go
+
+# Final stage
+FROM gcr.io/distroless/static:debug
+
+COPY --from=build /src/loki/stream-generator /usr/bin/stream-generator
+
+SHELL [ "/busybox/sh", "-c" ]
+
+RUN addgroup -g 10001 -S streammetagen && \
+    adduser -u 10001 -S streammetagen -G streammetagen && \
+    chown -R streammetagen:streammetagen /usr/bin/stream-generator && \
+    ln -s /busybox/sh /bin/sh
+
+USER 10001
+EXPOSE 9090
+ENTRYPOINT [ "/usr/bin/stream-generator" ] 

--- a/tools/stream-generator/README.md
+++ b/tools/stream-generator/README.md
@@ -1,0 +1,108 @@
+# Stream Generator
+
+A utility to generate streams (full or metadata) and send them to loki. This tool is useful for testing and benchmarking Loki's Kafka-based ingestion path.
+
+## Building
+
+From the root of the Loki repository:
+
+```bash
+docker build -t grafana/stream-generator -f tools/stream-generator/Dockerfile .
+```
+
+## Usage
+
+The stream generator supports various configuration options through command-line flags:
+
+### Basic Configuration
+
+- `--tenants.total`: Number of tenants to generate streams or stream-metadata for (default: 1)
+- `--tenants.streams.desired-rate`: Desired ingestion rate in bytes per second (default: 1MB/s)
+- `--tenants.streams.total`: Number of streams per tenant (default: 100)
+- `--tenants.qps`: Number of queries per second per tenant (default: 10)
+- `--http-listen-port`: HTTP server listen address for metrics (default: ":9090")
+
+### Kafka Configuration
+
+- `--kafka.addresses`: The addresses of the Kafka brokers (comma separated) (default: "localhost:9092")
+- `--kafka.topic`: The name of the Kafka topic to write to (default: "loki")
+- `--kafka.client-id`: The client ID to use when connecting to Kafka (default: "stream-generator")
+- `--kafka.version`: The version of the Kafka protocol to use (default: "2.3.0")
+- `--kafka.timeout`: The timeout to use when connecting to Kafka (default: "10s")
+- `--kafka.sasl.enabled`: Enable SASL authentication (default: false)
+- `--kafka.sasl.mechanism`: SASL mechanism to use (default: "PLAIN")
+- `--kafka.sasl.username`: SASL username for authentication (default: "")
+- `--kafka.sasl.password`: SASL password for authentication (default: "")
+
+### Ring Configuration
+
+- `--ring.store`: The backend storage to use for the ring (supported: consul, etcd, inmemory, memberlist) (default: "inmemory")
+- `--ring.replication-factor`: The number of replicas to write to (default: 3)
+- `--ring.kvstore.store`: The backing store to use for the KVStore (default: "inmemory")
+- `--ring.heartbeat-timeout`: The heartbeat timeout after which ingesters are considered unhealthy (default: "1m")
+
+## Example Usage
+
+### Basic Example
+
+Run with default settings (1 tenant, 100 streams per tenant, 10 QPS):
+
+```bash
+docker run -p 9090:9090 grafana/stream-generator
+```
+
+### Full Example
+
+Run with custom settings:
+
+```bash
+docker run -p 9091:9090 \
+  grafana/stream-generator \
+  --tenants.total=5 \
+  --tenants.streams.total=1000 \
+  --tenants.qps=100 \
+  --http-listen-port=3100 \
+  --kafka.address=kafka-1:9092 \
+  --kafka.topic=loki \
+  --kafka.client-id=stream-meta-gen-1 \
+  --kafka.sasl.enabled=true \
+  --kafka.sasl.mechanism=PLAIN \
+  --kafka.sasl.username=loki \
+  --kafka.sasl.password=secret123 \
+  --stream-metadata-generator.store=consul \
+  --stream-metadata-generator.replication-factor=3 \
+  --stream-metadata-generator.kvstore.consul.hostname=consul:8500
+```
+
+### Local Development Example
+
+For local development with the provided docker-compose setup:
+
+```bash
+docker run --network=host \
+  grafana/stream-metadata-generator \
+  --tenants.total=2 \
+  --tenants.streams.total=500 \
+  --tenants.qps=50 \
+  --kafka.address=localhost:9092 \
+  --kafka.topic=loki \
+  --kafka.sasl.enabled=true \
+  --kafka.sasl.mechanism=PLAIN \
+  --kafka.sasl.username=loki \
+  --kafka.sasl.password=secret123 \
+  --stream-metadata-generator.store=inmemory
+```
+
+## Metrics
+
+The generator exposes Prometheus metrics at `/metrics` on port 3100. When running with Docker, make sure to expose this port with the `-p` flag if you need to access the metrics from outside the container.
+
+## Labels
+
+The generator creates streams with the following labels:
+- `cluster`
+- `namespace`
+- `job`
+- `instance`
+
+Each label value is generated using a pattern that ensures uniqueness across streams. 

--- a/tools/stream-generator/distributor/client/client.go
+++ b/tools/stream-generator/distributor/client/client.go
@@ -60,8 +60,8 @@ type Client struct {
 	io.Closer
 }
 
-// NewClient returns a new Client for the specified ingest-limits.
-func NewClient(cfg Config) (*Client, error) {
+// New returns a new Client for the specified ingest-limits.
+func New(cfg Config) (*Client, error) {
 	opts := []grpc.DialOption{
 		grpc.WithDefaultCallOptions(cfg.GRPCClientConfig.CallOptions()...),
 	}

--- a/tools/stream-generator/distributor/client/client.go
+++ b/tools/stream-generator/distributor/client/client.go
@@ -1,0 +1,127 @@
+// Package client provides gRPC client implementation for distributor service.
+package client
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/grafana/dskit/grpcclient"
+	"github.com/grafana/dskit/middleware"
+	"github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc"
+	"github.com/opentracing/opentracing-go"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/keepalive"
+
+	"github.com/grafana/loki/v3/pkg/logproto"
+	"github.com/grafana/loki/v3/pkg/util/server"
+)
+
+const (
+	GRPCLoadBalancingPolicyRoundRobin = "round_robin"
+
+	grpcServiceConfigTemplate = `{"loadBalancingPolicy":"%s"}`
+)
+
+var (
+	requestDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "loki_distributor_client_request_duration_seconds",
+		Help:    "Time spent doing distributor requests.",
+		Buckets: prometheus.ExponentialBuckets(0.001, 4, 6),
+	}, []string{"operation", "status_code"})
+)
+
+// Config contains the config for an ingest-limits client.
+type Config struct {
+	Addr                         string                         `yaml:"addr"`
+	GRPCClientConfig             grpcclient.Config              `yaml:"grpc_client_config"`
+	GRPCUnaryClientInterceptors  []grpc.UnaryClientInterceptor  `yaml:"-"`
+	GRCPStreamClientInterceptors []grpc.StreamClientInterceptor `yaml:"-"`
+
+	// Internal is used to indicate that this client communicates on behalf of
+	// a machine and not a user. When Internal = true, the client won't attempt
+	// to inject an userid into the context.
+	Internal bool `yaml:"-"`
+}
+
+func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
+	f.StringVar(&cfg.Addr, prefix+".addr", "", "The address of the distributor. Preferred 'dns:///distributor.namespace.svc.cluster.local:3100'")
+	cfg.GRPCClientConfig.RegisterFlagsWithPrefix(prefix, f)
+}
+
+// Client is a gRPC client for the distributor.
+type Client struct {
+	logproto.PusherClient
+	grpc_health_v1.HealthClient
+	io.Closer
+}
+
+// NewClient returns a new Client for the specified ingest-limits.
+func NewClient(cfg Config) (*Client, error) {
+	opts := []grpc.DialOption{
+		grpc.WithDefaultCallOptions(cfg.GRPCClientConfig.CallOptions()...),
+	}
+	unaryInterceptors, streamInterceptors := getGRPCInterceptors(&cfg)
+	dialOpts, err := cfg.GRPCClientConfig.DialOption(unaryInterceptors, streamInterceptors, middleware.NoOpInvalidClusterValidationReporter)
+	if err != nil {
+		return nil, err
+	}
+
+	serviceConfig := fmt.Sprintf(grpcServiceConfigTemplate, GRPCLoadBalancingPolicyRoundRobin)
+
+	dialOpts = append(dialOpts,
+		grpc.WithBlock(), // nolint:staticcheck // grpc.WithBlock() has been deprecated; we'll address it before upgrading to gRPC 2
+		grpc.WithKeepaliveParams(
+			keepalive.ClientParameters{
+				Time:                time.Second * 10,
+				Timeout:             time.Second * 5,
+				PermitWithoutStream: true,
+			},
+		),
+		grpc.WithDefaultServiceConfig(serviceConfig),
+	)
+
+	opts = append(opts, dialOpts...)
+	// nolint:staticcheck // grpc.Dial() has been deprecated; we'll address it before upgrading to gRPC 2.
+	conn, err := grpc.Dial(cfg.Addr, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return &Client{
+		PusherClient: logproto.NewPusherClient(conn),
+		HealthClient: grpc_health_v1.NewHealthClient(conn),
+		Closer:       conn,
+	}, nil
+}
+
+// getInterceptors returns the gRPC interceptors for the given ClientConfig.
+func getGRPCInterceptors(cfg *Config) ([]grpc.UnaryClientInterceptor, []grpc.StreamClientInterceptor) {
+	var (
+		unaryInterceptors  []grpc.UnaryClientInterceptor
+		streamInterceptors []grpc.StreamClientInterceptor
+	)
+
+	unaryInterceptors = append(unaryInterceptors, cfg.GRPCUnaryClientInterceptors...)
+	unaryInterceptors = append(unaryInterceptors, server.UnaryClientQueryTagsInterceptor)
+	unaryInterceptors = append(unaryInterceptors, server.UnaryClientHTTPHeadersInterceptor)
+	unaryInterceptors = append(unaryInterceptors, otgrpc.OpenTracingClientInterceptor(opentracing.GlobalTracer()))
+	if !cfg.Internal {
+		unaryInterceptors = append(unaryInterceptors, middleware.ClientUserHeaderInterceptor)
+	}
+	unaryInterceptors = append(unaryInterceptors, middleware.UnaryClientInstrumentInterceptor(requestDuration))
+
+	streamInterceptors = append(streamInterceptors, cfg.GRCPStreamClientInterceptors...)
+	streamInterceptors = append(streamInterceptors, server.StreamClientQueryTagsInterceptor)
+	streamInterceptors = append(streamInterceptors, server.StreamClientHTTPHeadersInterceptor)
+	streamInterceptors = append(streamInterceptors, otgrpc.OpenTracingStreamClientInterceptor(opentracing.GlobalTracer()))
+	if !cfg.Internal {
+		streamInterceptors = append(streamInterceptors, middleware.StreamClientUserHeaderInterceptor)
+	}
+	streamInterceptors = append(streamInterceptors, middleware.StreamClientInstrumentInterceptor(requestDuration))
+
+	return unaryInterceptors, streamInterceptors
+}

--- a/tools/stream-generator/docker-compose.yaml
+++ b/tools/stream-generator/docker-compose.yaml
@@ -1,0 +1,106 @@
+services:
+  kafka-ui:
+    image: provectuslabs/kafka-ui:latest
+    hostname: kafka-ui
+    container_name: kafka-ui
+    ports:
+      - 8080:8080
+    environment:
+      KAFKA_CLUSTERS_0_NAME: local
+      KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: broker:29092
+      KAFKA_CLUSTERS_0_METRICS_PORT: 9997
+    depends_on:
+      - broker
+    networks:
+      - loki
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
+  broker:
+    image: apache/kafka:latest
+    hostname: broker
+    container_name: broker
+    ports:
+      - 9092:9092
+      - 29092:29092
+      - 29093:29093
+      - 29094:29094
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT,CONTROLLER:PLAINTEXT,STREAMETAGEN:PLAINTEXT
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://broker:29092,PLAINTEXT_HOST://localhost:9092,STREAMETAGEN://broker:29094
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_NODE_ID: 1
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@broker:29093
+      KAFKA_LISTENERS: PLAINTEXT://broker:29092,CONTROLLER://broker:29093,PLAINTEXT_HOST://0.0.0.0:9092,STREAMETAGEN://0.0.0.0:29094
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_LOG_DIRS: /tmp/kraft-combined-logs
+      CLUSTER_ID: MkU3OEVBNTcwNTJENDM2Qk
+    networks:
+      - loki
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
+  loki:
+    image: theperiklis/loki:feat-usage-tracker-293aed8
+    hostname: loki
+    container_name: loki
+    user: root
+    ports:
+      - 3100:3100
+      - 9096:9096
+      - 7946:7946
+    volumes:
+      - ./loki-local-config.debug.yaml:/etc/loki/local-config.yaml
+      - ./entrypoint.sh:/entrypoint.sh
+      - loki-data:/tmp/loki
+    entrypoint: ["/entrypoint.sh"]
+    depends_on:
+      - broker
+    networks:
+      - loki
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
+  generator:
+    image: theperiklis/stream-generator:latest
+    hostname: generator
+    container_name: generator
+    build:
+      context: ../..
+      dockerfile: tools/stream-generator/Dockerfile
+    ports:
+      - 3101:3100
+      - 7947:7947
+    command:
+      - --log.level=debug
+      - --tenants.total=2
+      - --tenants.streams.total=500
+      - --tenants.qps=50
+      - --memberlist.bind-port=7947
+      - --memberlist.advertise-port=7947
+      - --memberlist.join=loki:7946
+      - --kafka.address=broker:29094
+      - --kafka.topic=loki
+      - --kafka.auto-create-topic-default-partitions=1000
+      - --stream-generator.store=memberlist
+      - --stream-generator.push-target=metadata-topic-only
+    depends_on:
+      - broker
+      - loki
+    networks:
+      - loki
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
+networks:
+  loki:
+    driver: bridge
+
+volumes:
+  loki-data:

--- a/tools/stream-generator/entrypoint.sh
+++ b/tools/stream-generator/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# Create required directories
+mkdir -p /tmp/loki/chunks /tmp/loki/rules
+
+# Set proper permissions
+chown -R nobody:nobody /tmp/loki
+chmod -R 777 /tmp/loki
+
+# Start Loki
+exec loki --config.file=/etc/loki/local-config.yaml 

--- a/tools/stream-generator/generator/config.go
+++ b/tools/stream-generator/generator/config.go
@@ -1,0 +1,117 @@
+package generator
+
+import (
+	"flag"
+	"fmt"
+	"strings"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/dskit/kv/memberlist"
+	dskit_log "github.com/grafana/dskit/log"
+	"github.com/grafana/dskit/ring"
+
+	"github.com/grafana/loki/v3/pkg/kafka"
+	frontend_client "github.com/grafana/loki/v3/pkg/limits/frontend/client"
+	distributor_client "github.com/grafana/loki/v3/tools/stream-generator/distributor/client"
+)
+
+// Define default sizes for generated streams
+const (
+	normalLogSize    = 100 // 100 bytes for normal log lines
+	entriesPerStream = 5   // 5 entries per stream
+)
+
+const (
+	MetricsNamespace    = "loki_stream_generator_"
+	distributorRingName = "distributor"
+	distributorRingKey  = "distributor"
+)
+
+type PushModeType string
+
+const (
+	PushStreamMetadataOnly PushModeType = "stream-metadata"
+	PushStream             PushModeType = "stream"
+)
+
+type Config struct {
+	NumPartitions             int          `yaml:"num_partitions"`
+	NumTenants                int          `yaml:"num_tenants"`
+	TenantPrefix              string       `yaml:"tenant_prefix"`
+	QPSPerTenant              int          `yaml:"qps_per_tenant"`
+	BatchSize                 int          `yaml:"batch_size"`
+	StreamsPerTenant          int          `yaml:"streams_per_tenant"`
+	StreamLabels              []string     `yaml:"stream_labels"`
+	MaxGlobalStreamsPerTenant int          `yaml:"max_global_streams_per_tenant"`
+	PushMode                  PushModeType `yaml:"push_mode"`
+	pushModeRaw               string
+
+	// Stream size control parameter
+	DesiredRate int `yaml:"desired_rate"`
+
+	LogLevel       dskit_log.Level `yaml:"log_level,omitempty"`
+	HTTPListenPort int             `yaml:"http_listen_port,omitempty"`
+
+	// Memberlist config
+	MemberlistKV memberlist.KVConfig `yaml:"memberlist,omitempty"`
+
+	// Kafka config
+	Kafka kafka.Config `yaml:"kafka,omitempty"`
+
+	// Lifecycler config
+	LifecyclerConfig ring.LifecyclerConfig `yaml:"lifecycler,omitempty"`
+
+	// Client configs
+	DistributorClientConfig distributor_client.Config `yaml:"distributor_client,omitempty"`
+	FrontendClientConfig    frontend_client.Config    `yaml:"frontend_client,omitempty"`
+}
+
+type streamLabelsFlag []string
+
+func (s *streamLabelsFlag) String() string {
+	return strings.Join(*s, ",")
+}
+
+func (s *streamLabelsFlag) Set(value string) error {
+	*s = strings.Split(value, ",")
+	return nil
+}
+
+func (c *Config) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
+	f.IntVar(&c.NumPartitions, "partitions.total", 64, "Number of partitions to generate metadata for")
+	f.IntVar(&c.NumTenants, "tenants.total", 1, "Number of tenants to generate metadata for")
+	f.StringVar(&c.TenantPrefix, "tenants.prefix", "", "Prefix for tenant IDs")
+	f.IntVar(&c.QPSPerTenant, "tenants.qps", 10, "Number of QPS per tenant")
+	f.IntVar(&c.BatchSize, "tenants.streams.batch-size", 100, "Number of streams to send to Kafka per tick")
+	f.IntVar(&c.StreamsPerTenant, "tenants.streams.total", 100, "Number of streams per tenant")
+	f.IntVar(&c.MaxGlobalStreamsPerTenant, "tenants.max-global-streams", 1000, "Maximum number of global streams per tenant")
+	f.IntVar(&c.HTTPListenPort, "http-listen-port", 3100, "HTTP Listener port")
+	f.StringVar(&c.pushModeRaw, "push-mode", string(PushStreamMetadataOnly), "Push mode (values: stream-metadata (default), stream)")
+
+	// Add ingestion rate control parameter
+	f.IntVar(&c.DesiredRate, "tenants.streams.desired-rate", 1048576, "Desired ingestion rate in bytes per second (default: 1MB/s)")
+
+	// Set default stream labels
+	defaultLabels := []string{"cluster", "namespace", "job", "instance"}
+	c.StreamLabels = defaultLabels
+
+	// Create a custom flag for stream labels
+	streamLabels := (*streamLabelsFlag)(&c.StreamLabels)
+	f.Var(streamLabels, "stream.labels", fmt.Sprintf("The labels to generate for each stream (comma-separated) (default: %s)", strings.Join(defaultLabels, ",")))
+
+	c.LogLevel.RegisterFlags(f)
+	c.Kafka.RegisterFlags(f)
+	c.LifecyclerConfig.RegisterFlagsWithPrefix("ring.", f, logger)
+	c.DistributorClientConfig.RegisterFlagsWithPrefix("distributor-client", f)
+	c.FrontendClientConfig.RegisterFlagsWithPrefix("ingest-limits-frontend-client", f)
+	c.MemberlistKV.RegisterFlags(f)
+}
+
+func (c *Config) Validate() error {
+	if c.pushModeRaw != string(PushStreamMetadataOnly) && c.pushModeRaw != string(PushStream) {
+		return fmt.Errorf("invalid push mode: %s", c.pushModeRaw)
+	}
+	c.PushMode = PushModeType(c.pushModeRaw)
+
+	return nil
+}

--- a/tools/stream-generator/generator/distributor.go
+++ b/tools/stream-generator/generator/distributor.go
@@ -1,0 +1,39 @@
+package generator
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/user"
+	"github.com/grafana/loki/v3/pkg/distributor"
+	"github.com/grafana/loki/v3/pkg/logproto"
+)
+
+func (s *Generator) sendStreams(ctx context.Context, batch []distributor.KeyedStream, streamIdx int, batchSize int, tenant string, errCh chan error) {
+	userCtx, err := user.InjectIntoGRPCRequest(user.InjectOrgID(ctx, tenant))
+	if err != nil {
+		errCh <- fmt.Errorf("failed to inject user context (tenant: %s, stream_idx: %d, batch_size: %d): %w", tenant, streamIdx, batchSize, err)
+		return
+	}
+
+	pushStreams := make([]logproto.Stream, len(batch))
+	for i, stream := range batch {
+		pushStreams[i] = logproto.Stream{
+			Labels:  stream.Stream.Labels,
+			Entries: stream.Stream.Entries,
+		}
+	}
+
+	pushReq := &logproto.PushRequest{
+		Streams: pushStreams,
+	}
+
+	_, err = s.distributorClient.Push(userCtx, pushReq)
+	if err != nil {
+		errCh <- fmt.Errorf("failed to push streams to distributor (tenant: %s, stream_idx: %d, batch_size: %d): %w", tenant, streamIdx, batchSize, err)
+		return
+	}
+
+	level.Debug(s.logger).Log("msg", "Sent streams to distributor", "tenant", tenant, "batch_size", batchSize, "stream_idx", streamIdx)
+}

--- a/tools/stream-generator/generator/kafka.go
+++ b/tools/stream-generator/generator/kafka.go
@@ -1,0 +1,165 @@
+package generator
+
+import (
+	"context"
+	"fmt"
+	"math/rand/v2"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/ring"
+	"github.com/grafana/dskit/user"
+	"github.com/grafana/loki/v3/pkg/distributor"
+	"github.com/grafana/loki/v3/pkg/kafka"
+	"github.com/grafana/loki/v3/pkg/kafka/client"
+	frontend_client "github.com/grafana/loki/v3/pkg/limits/frontend/client"
+	"github.com/grafana/loki/v3/pkg/logproto"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/twmb/franz-go/pkg/kgo"
+)
+
+func (s *Generator) sendStreamMetadata(ctx context.Context, streamsBatch []distributor.KeyedStream, streamIdx int, batchSize int, tenant string, errCh chan error) {
+	client, err := s.getFrontendClient()
+	if err != nil {
+		errCh <- fmt.Errorf("failed to get ingest limits frontend client (tenant: %s, stream_idx: %d, batch_size: %d): %w", tenant, streamIdx, batchSize, err)
+		return
+	}
+
+	userCtx, err := user.InjectIntoGRPCRequest(user.InjectOrgID(ctx, tenant))
+	if err != nil {
+		errCh <- fmt.Errorf("failed to inject user context (tenant: %s, stream_idx: %d, batch_size: %d): %w", tenant, streamIdx, batchSize, err)
+		return
+	}
+
+	var streamMetadata []*logproto.StreamMetadata
+	for _, stream := range streamsBatch {
+		streamMetadata = append(streamMetadata, &logproto.StreamMetadata{
+			StreamHash: stream.HashKeyNoShard,
+		})
+	}
+
+	req := &logproto.ExceedsLimitsRequest{
+		Tenant:  tenant,
+		Streams: streamMetadata,
+	}
+
+	// Check if the stream exceeds limits
+	if client == nil {
+		errCh <- fmt.Errorf("no ingest limits frontend client (tenant: %s, stream_idx: %d, batch_size: %d)", tenant, streamIdx, batchSize)
+		return
+	}
+
+	resp, err := client.ExceedsLimits(userCtx, req)
+	if err != nil {
+		errCh <- fmt.Errorf("failed to check if stream exceeds limits (tenant: %s, stream_idx: %d, batch_size: %d): %w", tenant, streamIdx, batchSize, err)
+		return
+	}
+
+	switch {
+	case len(resp.Results) > 0:
+		var results string
+		reasonCounts := make(map[string]int)
+		for _, rejectedStream := range resp.Results {
+			reasonCounts[rejectedStream.Reason]++
+		}
+		for reason, count := range reasonCounts {
+			results += fmt.Sprintf("%s: %d, ", reason, count)
+		}
+
+		level.Info(s.logger).Log("msg", "Stream exceeds limits", "tenant", tenant, "batch_size", batchSize, "stream_idx", streamIdx, "rejected", results)
+		return
+	case len(resp.Results) == 0:
+		level.Debug(s.logger).Log("msg", "Stream accepted", "tenant", tenant, "batch_size", batchSize, "stream_idx", streamIdx)
+	}
+
+	// Send single stream to Kafka
+	s.sendStreamsToKafka(ctx, streamsBatch, tenant, errCh)
+	level.Debug(s.logger).Log("msg", "Sent streams to Kafka", "tenant", tenant, "batch_size", batchSize, "stream_idx", streamIdx)
+}
+
+func (s *Generator) sendStreamsToKafka(ctx context.Context, streams []distributor.KeyedStream, tenant string, errCh chan error) {
+	for _, stream := range streams {
+		go func(stream distributor.KeyedStream) {
+			partitionID := int32(stream.HashKeyNoShard % uint64(s.cfg.NumPartitions))
+
+			startTime := time.Now()
+
+			// Calculate log size from actual entries
+			var logSize uint64
+			for _, entry := range stream.Stream.Entries {
+				logSize += uint64(len(entry.Line))
+			}
+
+			// Add metadata record
+			metadataRecord, err := kafka.EncodeStreamMetadata(partitionID, s.cfg.Kafka.Topic, tenant, stream.HashKeyNoShard, logSize, 0)
+			if err != nil {
+				errCh <- fmt.Errorf("failed to encode stream metadata: %w", err)
+				return
+			}
+
+			// Send to Kafka
+			produceResults := s.writer.ProduceSync(ctx, []*kgo.Record{metadataRecord})
+
+			if count, sizeBytes := successfulProduceRecordsStats(produceResults); count > 0 {
+				s.metrics.kafkaWriteLatency.Observe(time.Since(startTime).Seconds())
+				s.metrics.kafkaWriteBytesTotal.Add(float64(sizeBytes))
+			}
+
+			// Check for errors
+			for _, result := range produceResults {
+				if result.Err != nil {
+					errCh <- fmt.Errorf("failed to write stream metadata to kafka: %w", result.Err)
+					return
+				}
+			}
+		}(stream)
+	}
+}
+
+func successfulProduceRecordsStats(results kgo.ProduceResults) (count, sizeBytes int) {
+	for _, res := range results {
+		if res.Err == nil && res.Record != nil {
+			count++
+			sizeBytes += len(res.Record.Value)
+		}
+	}
+
+	return
+}
+
+var frontendReadOp = ring.NewOp([]ring.InstanceState{ring.ACTIVE}, nil)
+
+func (s *Generator) getFrontendClient() (*frontend_client.Client, error) {
+	instances, err := s.frontendRing.GetAllHealthy(frontendReadOp)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get ingest limits frontend instances: %w", err)
+	}
+
+	rand.Shuffle(len(instances.Instances), func(i, j int) {
+		instances.Instances[i], instances.Instances[j] = instances.Instances[j], instances.Instances[i]
+	})
+
+	client, err := s.frontentClientPool.GetClientForInstance(instances.Instances[0])
+	if err != nil {
+		return nil, fmt.Errorf("failed to get ingest limits frontend client: %w", err)
+	}
+
+	return client.(*frontend_client.Client), nil
+}
+
+func newKafkaWriter(cfg kafka.Config, logger log.Logger, reg prometheus.Registerer) (*client.Producer, error) {
+	// Create a new Kafka client with writer configuration
+	// Using same settings as distributor for max inflight requests
+	maxInflightProduceRequests := 20
+
+	// Create the Kafka client
+	kafkaClient, err := client.NewWriterClient(cfg, maxInflightProduceRequests, logger, reg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create kafka client: %w", err)
+	}
+
+	// Create a producer with 100MB buffer limit
+	producer := client.NewProducer(kafkaClient, cfg.ProducerMaxBufferedBytes, reg)
+	return producer, nil
+}

--- a/tools/stream-generator/generator/metrics.go
+++ b/tools/stream-generator/generator/metrics.go
@@ -1,0 +1,35 @@
+package generator
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+type metrics struct {
+	activeStreamsTotal   *prometheus.CounterVec
+	kafkaWriteLatency    prometheus.Histogram
+	kafkaWriteBytesTotal prometheus.Counter
+}
+
+func newMetrics(reg prometheus.Registerer) *metrics {
+	return &metrics{
+		activeStreamsTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "active_streams_total",
+			Help: "The total number of active streams",
+		}, []string{"tenant"}),
+		kafkaWriteLatency: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
+			Name:                            "kafka_write_latency_seconds",
+			Help:                            "Latency to write stream metadata records to Kafka.",
+			NativeHistogramBucketFactor:     1.1,
+			NativeHistogramMinResetDuration: 1 * time.Hour,
+			NativeHistogramMaxBucketNumber:  100,
+			Buckets:                         prometheus.DefBuckets,
+		}),
+		kafkaWriteBytesTotal: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Name: "kafka_write_bytes_total",
+			Help: "Total number of bytes sent to Kafka.",
+		}),
+	}
+}

--- a/tools/stream-generator/generator/service.go
+++ b/tools/stream-generator/generator/service.go
@@ -1,0 +1,336 @@
+package generator
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/dns"
+	"github.com/grafana/dskit/kv/codec"
+	"github.com/grafana/dskit/kv/memberlist"
+	"github.com/grafana/dskit/netutil"
+	"github.com/grafana/dskit/ring"
+	ringclient "github.com/grafana/dskit/ring/client"
+	"github.com/grafana/dskit/services"
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/prometheus/model/labels"
+
+	"github.com/grafana/loki/v3/pkg/analytics"
+	"github.com/grafana/loki/v3/pkg/distributor"
+	"github.com/grafana/loki/v3/pkg/kafka/client"
+	"github.com/grafana/loki/v3/pkg/limits/frontend"
+	frontend_client "github.com/grafana/loki/v3/pkg/limits/frontend/client"
+	"github.com/grafana/loki/v3/pkg/logproto"
+	lokiring "github.com/grafana/loki/v3/pkg/util/ring"
+	distributor_client "github.com/grafana/loki/v3/tools/stream-generator/distributor/client"
+)
+
+type Generator struct {
+	services.Service
+
+	cfg     Config
+	logger  log.Logger
+	metrics *metrics
+
+	// payload
+	streams map[string][]distributor.KeyedStream
+
+	// kafka
+	writer *client.Producer
+
+	// ring
+	memberlistKV       *memberlist.KVInitService
+	frontendRing       *ring.Ring
+	frontentClientPool *ringclient.Pool
+
+	distributorClient *distributor_client.Client
+
+	// service
+	subservices        *services.Manager
+	subservicesWatcher *services.FailureWatcher
+
+	// Service internals
+	wg     sync.WaitGroup
+	ctx    context.Context
+	cancel context.CancelFunc
+}
+
+func New(cfg Config, logger log.Logger, reg prometheus.Registerer) (*Generator, error) {
+	s := &Generator{
+		cfg:     cfg,
+		logger:  logger,
+		metrics: newMetrics(reg),
+	}
+
+	var err error
+
+	cfg.MemberlistKV.Codecs = []codec.Codec{
+		ring.GetCodec(),
+		analytics.JSONCodec,
+		ring.GetPartitionRingCodec(),
+	}
+
+	provider := dns.NewProvider(logger, reg, dns.GolangResolverType)
+	cfg.MemberlistKV.AdvertiseAddr, err = netutil.GetFirstAddressOf(cfg.LifecyclerConfig.InfNames, logger, false)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get instance address: %w", err)
+	}
+
+	s.memberlistKV = memberlist.NewKVInitService(&cfg.MemberlistKV, logger, provider, reg)
+	cfg.LifecyclerConfig.RingConfig.KVStore.MemberlistKV = s.memberlistKV.GetMemberlistKV
+
+	srvs := []services.Service{
+		s.memberlistKV,
+	}
+
+	switch cfg.PushMode {
+	// Setup services for push mode via the kafka topic
+	case PushStreamMetadataOnly:
+		s.writer, err = newKafkaWriter(cfg.Kafka, logger, reg)
+		if err != nil {
+			return nil, fmt.Errorf("error creating Kafka writer: %w", err)
+		}
+
+		// Init Frontend Ring
+		s.frontendRing, err = ring.New(cfg.LifecyclerConfig.RingConfig, frontend.RingName, frontend.RingKey, logger, reg)
+		if err != nil {
+			return nil, fmt.Errorf("creating ingest limits frontend ring: %w", err)
+		}
+
+		factory := ringclient.PoolAddrFunc(func(addr string) (ringclient.PoolClient, error) {
+			return frontend_client.NewClient(cfg.FrontendClientConfig, addr)
+		})
+
+		s.frontentClientPool = frontend_client.NewPool(frontend.RingName, cfg.FrontendClientConfig.PoolConfig, s.frontendRing, factory, logger)
+		srvs = append(srvs, s.frontendRing, s.frontentClientPool)
+
+	// Setup services for push mode via distributor
+	case PushStream:
+		// Do nothing here as per distributor clients are not
+		// discovered through the ring.
+		s.distributorClient, err = distributor_client.NewClient(cfg.DistributorClientConfig)
+		if err != nil {
+			return nil, fmt.Errorf("error creating distributor client: %w", err)
+		}
+	}
+
+	// Init services
+	s.subservices, err = services.NewManager(srvs...)
+	if err != nil {
+		return nil, fmt.Errorf("creating subservices: %w", err)
+	}
+
+	s.subservicesWatcher = services.NewFailureWatcher()
+	s.subservicesWatcher.WatchManager(s.subservices)
+
+	s.Service = services.NewBasicService(s.starting, s.running, s.stopping)
+	return s, nil
+}
+
+func (s *Generator) starting(ctx context.Context) error {
+	s.ctx, s.cancel = context.WithCancel(ctx)
+
+	// Calculate optimal QPS to match the desired rate
+	s.cfg.QPSPerTenant = calculateOptimalQPS(s.cfg.DesiredRate, s.cfg.BatchSize, s.logger)
+	level.Info(s.logger).Log("msg", fmt.Sprintf("Adjusted QPS per tenant to %d to match desired rate of %d bytes/s",
+		s.cfg.QPSPerTenant, s.cfg.DesiredRate))
+
+	// Generate streams for each tenant
+	s.streams = make(map[string][]distributor.KeyedStream)
+	for i := range s.cfg.NumTenants {
+		tenantID := fmt.Sprintf("tenant-%d", i)
+
+		if s.cfg.TenantPrefix != "" {
+			tenantID = fmt.Sprintf("%s-%d", s.cfg.TenantPrefix, i)
+		}
+
+		s.streams[tenantID] = generateStreamsForTenant(tenantID, s.cfg.StreamsPerTenant, s.cfg.StreamLabels)
+	}
+
+	return services.StartManagerAndAwaitHealthy(s.ctx, s.subservices)
+}
+
+func (s *Generator) running(ctx context.Context) error {
+	// Create error channel to collect errors from goroutines
+	errCh := make(chan error, s.cfg.NumTenants)
+
+	// Start a goroutine for each tenant
+	for tenant, streams := range s.streams {
+		s.wg.Add(1)
+		go func(tenant string, streams []distributor.KeyedStream) {
+			defer s.wg.Done()
+
+			// Create a ticker for rate limiting based on QPSPerTenant
+			ticker := time.NewTicker(time.Second / time.Duration(s.cfg.QPSPerTenant))
+			defer ticker.Stop()
+
+			// Keep track of current stream index and whether we've completed first pass
+			streamIdx := 0
+			firstPassComplete := false
+
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case <-ticker.C:
+					if streamIdx >= len(streams) {
+						streamIdx = 0
+						firstPassComplete = true
+					}
+
+					batchSize := s.cfg.BatchSize
+					if streamIdx+batchSize > len(streams) {
+						batchSize = len(streams) - streamIdx
+					}
+
+					streamsBatch := streams[streamIdx : streamIdx+batchSize]
+
+					switch s.cfg.PushMode {
+					case PushStreamMetadataOnly:
+						s.sendStreamMetadata(ctx, streamsBatch, streamIdx, batchSize, tenant, errCh)
+					case PushStream:
+						s.sendStreams(ctx, streamsBatch, streamIdx, batchSize, tenant, errCh)
+					}
+
+					// Only increment during the first pass
+					if !firstPassComplete {
+						s.metrics.activeStreamsTotal.WithLabelValues(tenant).Add(float64(batchSize))
+					}
+
+					streamIdx += batchSize
+				}
+			}
+		}(tenant, streams)
+	}
+
+	// Wait for context cancellation, subservice failure, or tenant error
+	select {
+	case <-ctx.Done():
+		return nil
+	case err := <-s.subservicesWatcher.Chan():
+		return errors.Wrap(err, "stream-generator subservice failed")
+	case err := <-errCh:
+		level.Error(s.logger).Log("msg", "stream-generator error", "err", err)
+		return err
+	}
+}
+
+func (s *Generator) stopping(_ error) error {
+	s.cancel()
+	s.wg.Wait()
+
+	if s.writer != nil {
+		s.writer.Close()
+	}
+
+	if s.distributorClient != nil {
+		s.distributorClient.Close()
+	}
+
+	return services.StopManagerAndAwaitStopped(context.Background(), s.subservices)
+}
+
+func (s *Generator) GetMemberlist() *memberlist.KVInitService {
+	return s.memberlistKV
+}
+
+func (s *Generator) GetFrontendRing() *ring.Ring {
+	return s.frontendRing
+}
+
+// calculateOptimalQPS calculates the optimal QPS to achieve the desired ingestion rate
+func calculateOptimalQPS(desiredRate, batchSize int, logger log.Logger) int {
+	// Calculate bytes per stream for normal streams
+	normalStreamRate := normalLogSize * entriesPerStream
+
+	// First, calculate QPS assuming all normal streams
+	var optimalQPS int
+	if batchSize > 0 {
+		// Calculate QPS needed if all streams are normal size
+		optimalQPS = int(math.Ceil(float64(desiredRate) / (float64(batchSize) * float64(normalStreamRate))))
+
+		// Check if this QPS would exceed the desired rate
+		normalRate := optimalQPS * batchSize * normalStreamRate
+
+		for normalRate > desiredRate && optimalQPS > 1 {
+			optimalQPS--
+			normalRate = optimalQPS * batchSize * normalStreamRate
+		}
+	}
+
+	// Calculate the expected rate with this QPS
+	expectedRate := optimalQPS * batchSize * normalStreamRate
+
+	level.Info(logger).Log("msg", "Calculated optimal QPS", "optimalQPS", optimalQPS, "desiredRate", desiredRate, "expectedRate", expectedRate)
+
+	return optimalQPS
+}
+
+func generateStreamsForTenant(tenantID string, streamsPerTenant int, streamLabels []string) []distributor.KeyedStream {
+	streams := make([]distributor.KeyedStream, streamsPerTenant)
+
+	for i := range streamsPerTenant {
+		// Generate static label values for this stream
+		labelValues := make([]string, len(streamLabels))
+		for j, label := range streamLabels {
+			labelValues[j] = fmt.Sprintf("%s=\"%s-%d-%d\"", label, label, i, j)
+		}
+
+		// Create the labels string in the format {label1="value1",label2="value2"}
+		labelsStr := fmt.Sprintf("{%s}", strings.Join(labelValues, ","))
+
+		// Parse the labels to get the hash
+		lbs := labels.FromMap(map[string]string{})
+		for j, label := range streamLabels {
+			lbs = append(lbs, labels.Label{Name: label, Value: fmt.Sprintf("%s-%d-%d", label, i, j)})
+		}
+		sort.Sort(lbs)
+
+		// Create the stream with multiple entries
+		stream := logproto.Stream{
+			Labels:  labelsStr,
+			Hash:    lbs.Hash(),
+			Entries: make([]logproto.Entry, 0, entriesPerStream),
+		}
+
+		// Generate entries for this stream
+		for j := range entriesPerStream {
+			// Generate log line with the specified size
+			logLine := generateLogLine(i, j, normalLogSize)
+
+			// Add entry to stream
+			stream.Entries = append(stream.Entries, logproto.Entry{
+				Timestamp: time.Now(),
+				Line:      logLine,
+			})
+		}
+
+		// Create the keyed stream
+		streams[i] = distributor.KeyedStream{
+			HashKey:        lokiring.TokenFor(tenantID, labelsStr),
+			HashKeyNoShard: stream.Hash,
+			Stream:         stream,
+		}
+	}
+
+	return streams
+}
+
+// generateLogLine creates a log line of approximately the specified size
+func generateLogLine(streamIdx, entryIdx, size int) string {
+	base := fmt.Sprintf("stream-%d entry-%d ", streamIdx, entryIdx)
+	if len(base) >= size {
+		return base[:size]
+	}
+
+	// Pad with repeating characters to reach desired size
+	padding := strings.Repeat("x", size-len(base))
+	return base + padding
+}

--- a/tools/stream-generator/generator/service.go
+++ b/tools/stream-generator/generator/service.go
@@ -115,7 +115,7 @@ func New(cfg Config, logger log.Logger, reg prometheus.Registerer) (*Generator, 
 	case PushStream:
 		// Do nothing here as per distributor clients are not
 		// discovered through the ring.
-		s.distributorClient, err = distributor_client.NewClient(cfg.DistributorClientConfig)
+		s.distributorClient, err = distributor_client.New(cfg.DistributorClientConfig)
 		if err != nil {
 			return nil, fmt.Errorf("error creating distributor client: %w", err)
 		}

--- a/tools/stream-generator/loki-local-config.debug.yaml
+++ b/tools/stream-generator/loki-local-config.debug.yaml
@@ -1,0 +1,74 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9096
+  log_level: info
+  grpc_server_max_concurrent_streams: 1000
+
+common:
+  #instance_addr: 127.0.0.1
+  path_prefix: /tmp/loki
+  storage:
+    filesystem:
+      chunks_directory: /tmp/loki/chunks
+      rules_directory: /tmp/loki/rules
+  replication_factor: 1
+  ring:
+    instance_id: local
+    kvstore:
+      store: memberlist
+
+kafka_config:
+  topic: "loki"
+  address: broker:29092
+
+ingest_limits:
+  enabled: true
+  window_size: 1m
+  lifecycler:
+    ring:
+      kvstore:
+        store: memberlist
+
+querier:
+  query_partition_ingesters: true
+
+ingester:
+  kafka_ingestion:
+    enabled: true
+
+distributor:
+  kafka_writes_enabled: true
+  ingester_writes_enabled: false
+
+query_range:
+  results_cache:
+    cache:
+      embedded_cache:
+        enabled: false
+        max_size_mb: 100
+
+limits_config:
+  metric_aggregation_enabled: true
+
+schema_config:
+  configs:
+    - from: 2020-10-24
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+pattern_ingester:
+  enabled: true
+  metric_aggregation:
+    loki_address: localhost:3100
+
+ruler:
+  alertmanager_url: http://localhost:9093
+
+frontend:
+  encoding: protobuf

--- a/tools/stream-generator/main.go
+++ b/tools/stream-generator/main.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/services"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+
+	"github.com/grafana/loki/v3/pkg/util"
+	"github.com/grafana/loki/v3/tools/stream-generator/generator"
+)
+
+func main() {
+	logger := log.NewLogfmtLogger(os.Stdout)
+
+	cfg := generator.Config{}
+	cfg.RegisterFlags(flag.CommandLine, logger)
+	flag.Parse()
+
+	if err := cfg.Validate(); err != nil {
+		level.Error(logger).Log("msg", "Error validating config", "err", err)
+		os.Exit(1)
+	}
+
+	logger = level.NewFilter(logger, cfg.LogLevel.Option)
+
+	if err := util.LogConfig(&cfg); err != nil {
+		level.Error(logger).Log("msg", "Error printing config", "err", err)
+		os.Exit(1)
+	}
+
+	// Create a new registry for Kafka metrics
+	promReg := prometheus.NewRegistry()
+	reg := prometheus.WrapRegistererWithPrefix(generator.MetricsNamespace, promReg)
+
+	// Create and start the stream metadata generator service
+	gen, err := generator.New(cfg, logger, reg)
+	if err != nil {
+		level.Error(logger).Log("msg", "Error creating stream generator", "err", err)
+		os.Exit(1)
+	}
+
+	// Start the service and wait for it to be ready
+	if err := services.StartAndAwaitRunning(context.Background(), gen); err != nil {
+		level.Error(logger).Log("msg", "Error starting stream generator", "err", err)
+		os.Exit(1)
+	}
+
+	// Create HTTP server for metrics
+	httpListenAddr := fmt.Sprintf(":%d", cfg.HTTPListenPort)
+
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.HandlerFor(promReg, promhttp.HandlerOpts{}))
+
+	if cfg.PushMode == generator.PushStreamMetadataOnly {
+		mux.Handle("/memberlist", gen.GetMemberlist())
+		mux.Handle("/ingest-limit-frontend-ring", gen.GetFrontendRing())
+	}
+
+	server := &http.Server{
+		Addr:    httpListenAddr,
+		Handler: mux,
+	}
+
+	// Start HTTP server in a goroutine
+	go func() {
+		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			level.Error(logger).Log("msg", "Error starting metrics server", "err", err)
+			os.Exit(1)
+		}
+	}()
+
+	level.Info(logger).Log("msg", "Started metrics server", "addr", httpListenAddr)
+
+	// Wait for interrupt signal
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
+	<-sigChan
+
+	// Gracefully shutdown HTTP server
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := server.Shutdown(shutdownCtx); err != nil {
+		level.Error(logger).Log("msg", "Error shutting down metrics server", "err", err)
+	}
+
+	// Stop the service gracefully
+	if err := services.StopAndAwaitTerminated(context.Background(), gen); err != nil {
+		level.Error(logger).Log("msg", "Error stopping stream generator", "err", err)
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR revives the useful testing tool `stream-metadata-generator` initially developed in the `feat/usage-tracker` branch to test exclusively the new ingest-limits service. In addition the generator is revamped as a stream generator allowing to generate and push entire streams with desired parameters (number or tenants, desired rate, etc.) through the distributor.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
