### PR TITLE
refactor(stringlabels): Support stringlabels in log.StreamPipeline

### DIFF
--- a/pkg/chunkenc/memchunk.go
+++ b/pkg/chunkenc/memchunk.go
@@ -1249,7 +1249,7 @@ func (hb *headBlock) Iterator(ctx context.Context, direction logproto.Direction,
 			return
 		}
 		stats.AddHeadChunkBytes(int64(len(e.s)))
-		newLine, parsedLbs, matches := pipeline.ProcessString(e.t, e.s, e.structuredMetadata...)
+		newLine, parsedLbs, matches := pipeline.ProcessString(e.t, e.s, e.structuredMetadata)
 		if !matches {
 			return
 		}
@@ -1316,7 +1316,7 @@ func (hb *headBlock) SampleIterator(
 	for _, e := range hb.entries {
 		for _, extractor := range extractors {
 			stats.AddHeadChunkBytes(int64(len(e.s)))
-			value, lbls, ok := extractor.ProcessString(e.t, e.s, e.structuredMetadata...)
+			value, lbls, ok := extractor.ProcessString(e.t, e.s, e.structuredMetadata)
 			if !ok {
 				continue
 			}
@@ -1679,7 +1679,7 @@ func (e *entryBufferedIterator) StreamHash() uint64 { return e.pipeline.BaseLabe
 
 func (e *entryBufferedIterator) Next() bool {
 	for e.bufferedIterator.Next() {
-		newLine, lbs, matches := e.pipeline.Process(e.currTs, e.currLine, e.currStructuredMetadata...)
+		newLine, lbs, matches := e.pipeline.Process(e.currTs, e.currLine, e.currStructuredMetadata)
 		if !matches {
 			continue
 		}
@@ -1739,7 +1739,7 @@ type sampleBufferedIterator struct {
 
 func (e *sampleBufferedIterator) Next() bool {
 	for e.bufferedIterator.Next() {
-		val, labels, ok := e.extractor.Process(e.currTs, e.currLine, e.currStructuredMetadata...)
+		val, labels, ok := e.extractor.Process(e.currTs, e.currLine, e.currStructuredMetadata)
 		if !ok {
 			continue
 		}

--- a/pkg/chunkenc/memchunk_test.go
+++ b/pkg/chunkenc/memchunk_test.go
@@ -962,11 +962,11 @@ func BenchmarkWrite(b *testing.B) {
 type nomatchPipeline struct{}
 
 func (nomatchPipeline) BaseLabels() log.LabelsResult { return log.EmptyLabelsResult }
-func (nomatchPipeline) Process(_ int64, line []byte, _ ...labels.Label) ([]byte, log.LabelsResult, bool) {
+func (nomatchPipeline) Process(_ int64, line []byte, _ labels.Labels) ([]byte, log.LabelsResult, bool) {
 	return line, nil, false
 }
 
-func (nomatchPipeline) ProcessString(_ int64, line string, _ ...labels.Label) (string, log.LabelsResult, bool) {
+func (nomatchPipeline) ProcessString(_ int64, line string, _ labels.Labels) (string, log.LabelsResult, bool) {
 	return line, nil, false
 }
 
@@ -1031,11 +1031,11 @@ func BenchmarkRead(b *testing.B) {
 type noopTestPipeline struct{}
 
 func (noopTestPipeline) BaseLabels() log.LabelsResult { return log.EmptyLabelsResult }
-func (noopTestPipeline) Process(_ int64, line []byte, _ ...labels.Label) ([]byte, log.LabelsResult, bool) {
+func (noopTestPipeline) Process(_ int64, line []byte, _ labels.Labels) ([]byte, log.LabelsResult, bool) {
 	return line, nil, false
 }
 
-func (noopTestPipeline) ProcessString(_ int64, line string, _ ...labels.Label) (string, log.LabelsResult, bool) {
+func (noopTestPipeline) ProcessString(_ int64, line string, _ labels.Labels) (string, log.LabelsResult, bool) {
 	return line, nil, false
 }
 

--- a/pkg/chunkenc/unordered.go
+++ b/pkg/chunkenc/unordered.go
@@ -260,7 +260,7 @@ func (hb *unorderedHeadBlock) Iterator(ctx context.Context, direction logproto.D
 		maxt,
 		func(statsCtx *stats.Context, ts int64, line string, structuredMetadataSymbols symbols) error {
 			structuredMetadata = hb.symbolizer.Lookup(structuredMetadataSymbols, structuredMetadata)
-			newLine, parsedLbs, matches := pipeline.ProcessString(ts, line, structuredMetadata...)
+			newLine, parsedLbs, matches := pipeline.ProcessString(ts, line, structuredMetadata)
 			if !matches {
 				return nil
 			}
@@ -323,7 +323,7 @@ func (hb *unorderedHeadBlock) SampleIterator(
 			structuredMetadata = hb.symbolizer.Lookup(structuredMetadataSymbols, structuredMetadata)
 
 			for _, extractor := range extractor {
-				value, lbls, ok := extractor.ProcessString(ts, line, structuredMetadata...)
+				value, lbls, ok := extractor.ProcessString(ts, line, structuredMetadata)
 				if !ok {
 					return nil
 				}

--- a/pkg/chunkenc/variants.go
+++ b/pkg/chunkenc/variants.go
@@ -61,7 +61,7 @@ func (e *multiExtractorSampleBufferedIterator) Next() bool {
 		e.stats.AddPostFilterLines(1)
 
 		for _, extractor := range e.extractors {
-			val, lbls, ok := extractor.Process(e.currTs, e.currLine, e.currStructuredMetadata...)
+			val, lbls, ok := extractor.Process(e.currTs, e.currLine, e.currStructuredMetadata)
 			if !ok {
 				continue
 			}

--- a/pkg/compactor/deletion/delete_request.go
+++ b/pkg/compactor/deletion/delete_request.go
@@ -87,7 +87,7 @@ func (d *DeleteRequest) FilterFunction(lbls labels.Labels) (filter.Func, error) 
 			return false
 		}
 
-		result, _, skip := f(0, s, labels.Labels(structuredMetadata)) // TODO: is this a copy?
+		result, _, skip := f(0, s, labels.Labels(structuredMetadata))
 		if len(result) != 0 || skip {
 			d.Metrics.deletedLinesTotal.WithLabelValues(d.UserID).Inc()
 			d.DeletedLines++

--- a/pkg/compactor/deletion/delete_request.go
+++ b/pkg/compactor/deletion/delete_request.go
@@ -87,7 +87,7 @@ func (d *DeleteRequest) FilterFunction(lbls labels.Labels) (filter.Func, error) 
 			return false
 		}
 
-		result, _, skip := f(0, s, structuredMetadata...)
+		result, _, skip := f(0, s, labels.Labels(structuredMetadata)) // TODO: is this a copy?
 		if len(result) != 0 || skip {
 			d.Metrics.deletedLinesTotal.WithLabelValues(d.UserID).Inc()
 			d.DeletedLines++

--- a/pkg/dataobj/querier/iter.go
+++ b/pkg/dataobj/querier/iter.go
@@ -96,7 +96,7 @@ func newEntryIterator(ctx context.Context,
 			}
 
 			timestamp := record.Timestamp.UnixNano()
-			line, parsedLabels, ok := streamExtractor.Process(timestamp, record.Line, record.Metadata...)
+			line, parsedLabels, ok := streamExtractor.Process(timestamp, record.Line, record.Metadata)
 			if !ok {
 				continue
 			}
@@ -335,7 +335,7 @@ func newSampleIterator(ctx context.Context,
 				// TODO(twhitney): when iterating over multiple extractors, we need a way to pre-process as much of the line as possible
 				// In the case of multi-variant expressions, the only difference between the multiple extractors should be the final value, with all
 				// other filters and processing already done.
-				value, parsedLabels, ok := streamExtractor.Process(timestamp, record.Line, record.Metadata...)
+				value, parsedLabels, ok := streamExtractor.Process(timestamp, record.Line, record.Metadata)
 				if !ok {
 					continue
 				}

--- a/pkg/ingester/instance_test.go
+++ b/pkg/ingester/instance_test.go
@@ -828,14 +828,14 @@ func (p *mockStreamPipeline) BaseLabels() log.LabelsResult {
 	return p.wrappedSP.BaseLabels()
 }
 
-func (p *mockStreamPipeline) Process(ts int64, line []byte, lbs ...labels.Label) ([]byte, log.LabelsResult, bool) {
+func (p *mockStreamPipeline) Process(ts int64, line []byte, lbs labels.Labels) ([]byte, log.LabelsResult, bool) {
 	p.called++
-	return p.wrappedSP.Process(ts, line, lbs...)
+	return p.wrappedSP.Process(ts, line, lbs)
 }
 
-func (p *mockStreamPipeline) ProcessString(ts int64, line string, lbs ...labels.Label) (string, log.LabelsResult, bool) {
+func (p *mockStreamPipeline) ProcessString(ts int64, line string, lbs labels.Labels) (string, log.LabelsResult, bool) {
 	p.called++
-	return p.wrappedSP.ProcessString(ts, line, lbs...)
+	return p.wrappedSP.ProcessString(ts, line, lbs)
 }
 
 func Test_ExtractorWrapper(t *testing.T) {
@@ -1035,14 +1035,14 @@ func (p *mockStreamExtractor) BaseLabels() log.LabelsResult {
 	return p.wrappedSP.BaseLabels()
 }
 
-func (p *mockStreamExtractor) Process(ts int64, line []byte, lbs ...labels.Label) (float64, log.LabelsResult, bool) {
+func (p *mockStreamExtractor) Process(ts int64, line []byte, lbs labels.Labels) (float64, log.LabelsResult, bool) {
 	p.called++
-	return p.wrappedSP.Process(ts, line, lbs...)
+	return p.wrappedSP.Process(ts, line, lbs)
 }
 
-func (p *mockStreamExtractor) ProcessString(ts int64, line string, lbs ...labels.Label) (float64, log.LabelsResult, bool) {
+func (p *mockStreamExtractor) ProcessString(ts int64, line string, lbs labels.Labels) (float64, log.LabelsResult, bool) {
 	p.called++
-	return p.wrappedSP.ProcessString(ts, line, lbs...)
+	return p.wrappedSP.ProcessString(ts, line, lbs)
 }
 
 func Test_QueryWithDelete(t *testing.T) {

--- a/pkg/ingester/tailer.go
+++ b/pkg/ingester/tailer.go
@@ -194,7 +194,7 @@ func (t *tailer) processStream(stream logproto.Stream, lbs labels.Labels) []*log
 
 	sp := t.pipeline.ForStream(lbs)
 	for _, e := range stream.Entries {
-		newLine, parsedLbs, ok := sp.ProcessString(e.Timestamp.UnixNano(), e.Line, logproto.FromLabelAdaptersToLabels(e.StructuredMetadata)...)
+		newLine, parsedLbs, ok := sp.ProcessString(e.Timestamp.UnixNano(), e.Line, logproto.FromLabelAdaptersToLabels(e.StructuredMetadata))
 		if !ok {
 			continue
 		}

--- a/pkg/logcli/client/file.go
+++ b/pkg/logcli/client/file.go
@@ -289,7 +289,7 @@ func newFileIterator(
 
 	processLine := func(line string) {
 		ts := time.Now()
-		parsedLine, parsedLabels, matches := pipeline.ProcessString(ts.UnixNano(), line)
+		parsedLine, parsedLabels, matches := pipeline.ProcessString(ts.UnixNano(), line, labels.EmptyLabels())
 		if !matches {
 			return
 		}

--- a/pkg/logql/log/labels.go
+++ b/pkg/logql/log/labels.go
@@ -399,8 +399,8 @@ func (b *LabelsBuilder) Set(category LabelCategory, n, v string) *LabelsBuilder 
 
 // Add the labels to the builder. If a label with the same name
 // already exists in the base labels, a suffix is added to the name.
-func (b *LabelsBuilder) Add(category LabelCategory, labels ...labels.Label) *LabelsBuilder {
-	for _, l := range labels {
+func (b *LabelsBuilder) Add(category LabelCategory, lbs labels.Labels) *LabelsBuilder {
+	lbs.Range(func(l labels.Label) {
 		name := l.Name
 		if b.BaseHas(name) {
 			name = fmt.Sprintf("%s%s", name, duplicateSuffix)
@@ -408,16 +408,16 @@ func (b *LabelsBuilder) Add(category LabelCategory, labels ...labels.Label) *Lab
 
 		if name == logqlmodel.ErrorLabel {
 			b.err = l.Value
-			continue
+			return
 		}
 
 		if name == logqlmodel.ErrorDetailsLabel {
 			b.errDetails = l.Value
-			continue
+			return
 		}
 
 		b.Set(category, name, l.Value)
-	}
+	})
 	return b
 }
 

--- a/pkg/logql/log/labels_test.go
+++ b/pkg/logql/log/labels_test.go
@@ -1,6 +1,7 @@
 package log
 
 import (
+	"fmt"
 	"sort"
 	"testing"
 	"time"
@@ -502,3 +503,30 @@ func BenchmarkStreamLineSampleExtractor_Process(b *testing.B) {
 		_, _, _ = streamEx.Process(time.Now().UnixNano(), testLine, structuredMeta)
 	}
 }
+
+func BenchmarkLabelsBuilder_Add(b *testing.B) {
+	sizes := []int{10, 100, 1000, 10000}
+
+	for _, size := range sizes {
+		b.Run(fmt.Sprintf("size_%d", size), func(b *testing.B) {
+			// Pre-generate labels that should be added
+			newB := labels.NewScratchBuilder(size)
+			for i := 0; i < size; i++ {
+				newB.Add(fmt.Sprintf("label_%d", i), fmt.Sprintf("value_%d", i))
+			}
+			newLabels := newB.Labels()
+
+			lbs := labels.FromStrings("already", "in")
+			builder := NewBaseLabelsBuilder().ForLabels(lbs, lbs.Hash())
+
+			b.ResetTimer()
+			b.ReportAllocs()
+
+			for i := 0; i < b.N; i++ {
+				builder.Reset()
+				builder.Add(StructuredMetadataLabel, newLabels)
+			}
+		})
+	}
+}
+

--- a/pkg/logql/log/labels_test.go
+++ b/pkg/logql/log/labels_test.go
@@ -76,7 +76,7 @@ func TestLabelsBuilder_LabelsErrorFromAdd(t *testing.T) {
 	b.Reset()
 
 	// This works for any category
-	b.Add(StructuredMetadataLabel, labels.FromStrings(logqlmodel.ErrorLabel, "test error", logqlmodel.ErrorDetailsLabel, "test details")...)
+	b.Add(StructuredMetadataLabel, labels.FromStrings(logqlmodel.ErrorLabel, "test error", logqlmodel.ErrorDetailsLabel, "test details"))
 	lbsWithErr := b.LabelsResult()
 
 	expectedLbs := labels.FromStrings(
@@ -499,6 +499,6 @@ func BenchmarkStreamLineSampleExtractor_Process(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		_, _, _ = streamEx.Process(time.Now().UnixNano(), testLine, structuredMeta...)
+		_, _, _ = streamEx.Process(time.Now().UnixNano(), testLine, structuredMeta)
 	}
 }

--- a/pkg/logql/log/labels_test.go
+++ b/pkg/logql/log/labels_test.go
@@ -529,4 +529,3 @@ func BenchmarkLabelsBuilder_Add(b *testing.B) {
 		})
 	}
 }
-

--- a/pkg/logql/log/metrics_extraction_test.go
+++ b/pkg/logql/log/metrics_extraction_test.go
@@ -253,12 +253,12 @@ func Test_labelSampleExtractor_Extract(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			outval, outlbs, ok := tt.ex.ForStream(tt.in).Process(0, []byte(tt.line), tt.structuredMetadata...)
+			outval, outlbs, ok := tt.ex.ForStream(tt.in).Process(0, []byte(tt.line), tt.structuredMetadata)
 			require.Equal(t, tt.wantOk, ok)
 			require.Equal(t, tt.want, outval)
 			require.Equal(t, tt.wantLbs, outlbs.Labels())
 
-			outval, outlbs, ok = tt.ex.ForStream(tt.in).ProcessString(0, tt.line, tt.structuredMetadata...)
+			outval, outlbs, ok = tt.ex.ForStream(tt.in).ProcessString(0, tt.line, tt.structuredMetadata)
 			require.Equal(t, tt.wantOk, ok)
 			require.Equal(t, tt.want, outval)
 			require.Equal(t, tt.wantLbs, outlbs.Labels())
@@ -269,7 +269,7 @@ func Test_labelSampleExtractor_Extract(t *testing.T) {
 func Test_Extract_ExpectedLabels(t *testing.T) {
 	ex := mustSampleExtractor(LabelExtractorWithStages("duration", ConvertDuration, []string{"foo"}, false, false, []Stage{NewJSONParser(false)}, NoopStage))
 
-	f, lbs, ok := ex.ForStream(labels.FromStrings("bar", "foo")).ProcessString(0, `{"duration":"20ms","foo":"json"}`)
+	f, lbs, ok := ex.ForStream(labels.FromStrings("bar", "foo")).ProcessString(0, `{"duration":"20ms","foo":"json"}`, labels.EmptyLabels())
 	require.True(t, ok)
 	require.Equal(t, (20 * time.Millisecond).Seconds(), f)
 	require.Equal(t, labels.FromStrings("foo", "json"), lbs.Labels())
@@ -320,7 +320,7 @@ func TestLabelExtractorWithStages(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			for _, line := range tc.checkLines {
-				v, lbs, ok := tc.extractor.ForStream(labels.FromStrings("bar", "foo")).ProcessString(0, line.logLine)
+				v, lbs, ok := tc.extractor.ForStream(labels.FromStrings("bar", "foo")).ProcessString(0, line.logLine, labels.EmptyLabels())
 				skipped := !ok
 				assert.Equal(t, line.skip, skipped, "line", line.logLine)
 				if !skipped {
@@ -354,12 +354,12 @@ func TestNewLineSampleExtractor(t *testing.T) {
 	)
 
 	sse := se.ForStream(lbs)
-	f, l, ok := sse.Process(0, []byte(`foo`))
+	f, l, ok := sse.Process(0, []byte(`foo`), labels.EmptyLabels())
 	require.True(t, ok)
 	require.Equal(t, 1., f)
 	assertLabelResult(t, lbs, l)
 
-	f, l, ok = sse.ProcessString(0, `foo`)
+	f, l, ok = sse.ProcessString(0, `foo`, labels.EmptyLabels())
 	require.True(t, ok)
 	require.Equal(t, 1., f)
 	assertLabelResult(t, lbs, l)
@@ -369,13 +369,13 @@ func TestNewLineSampleExtractor(t *testing.T) {
 	require.NoError(t, err)
 
 	sse = se.ForStream(lbs)
-	f, l, ok = sse.Process(0, []byte(`foo`))
+	f, l, ok = sse.Process(0, []byte(`foo`), labels.EmptyLabels())
 	require.True(t, ok)
 	require.Equal(t, 3., f)
 	assertLabelResult(t, labels.FromStrings("namespace", "dev"), l)
 
 	sse = se.ForStream(lbs)
-	_, _, ok = sse.Process(0, []byte(`nope`))
+	_, _, ok = sse.Process(0, []byte(`nope`), labels.EmptyLabels())
 	require.False(t, ok)
 }
 
@@ -390,12 +390,12 @@ func TestNewLineSampleExtractorWithStructuredMetadata(t *testing.T) {
 	require.NoError(t, err)
 
 	sse := se.ForStream(lbs)
-	f, l, ok := sse.Process(0, []byte(`foo`), structuredMetadata...)
+	f, l, ok := sse.Process(0, []byte(`foo`), structuredMetadata)
 	require.True(t, ok)
 	require.Equal(t, 1., f)
 	assertLabelResult(t, expectedLabelsResults, l)
 
-	f, l, ok = sse.ProcessString(0, `foo`, structuredMetadata...)
+	f, l, ok = sse.ProcessString(0, `foo`, structuredMetadata)
 	require.True(t, ok)
 	require.Equal(t, 1., f)
 	assertLabelResult(t, expectedLabelsResults, l)
@@ -405,16 +405,12 @@ func TestNewLineSampleExtractorWithStructuredMetadata(t *testing.T) {
 		Name: "foo_extracted", Value: "baz",
 	})
 	expectedLabelsResults = append(expectedLabelsResults, structuredMetadata...)
-	f, l, ok = sse.Process(0, []byte(`foo`), append(structuredMetadata, labels.Label{
-		Name: "foo", Value: "baz",
-	})...)
+	f, l, ok = sse.Process(0, []byte(`foo`), labels.NewBuilder(structuredMetadata).Set("foo", "baz").Labels())
 	require.True(t, ok)
 	require.Equal(t, 1., f)
 	assertLabelResult(t, expectedLabelsResults, l)
 
-	f, l, ok = sse.ProcessString(0, `foo`, append(structuredMetadata, labels.Label{
-		Name: "foo", Value: "baz",
-	})...)
+	f, l, ok = sse.ProcessString(0, `foo`, labels.NewBuilder(structuredMetadata).Set("foo", "baz").Labels())
 	require.True(t, ok)
 	require.Equal(t, 1., f)
 	assertLabelResult(t, expectedLabelsResults, l)
@@ -427,13 +423,13 @@ func TestNewLineSampleExtractorWithStructuredMetadata(t *testing.T) {
 	require.NoError(t, err)
 
 	sse = se.ForStream(lbs)
-	f, l, ok = sse.Process(0, []byte(`foo`), structuredMetadata...)
+	f, l, ok = sse.Process(0, []byte(`foo`), structuredMetadata)
 	require.True(t, ok)
 	require.Equal(t, 3., f)
 	assertLabelResult(t, labels.FromStrings("foo", "bar"), l)
 
 	sse = se.ForStream(lbs)
-	_, _, ok = sse.Process(0, []byte(`nope`))
+	_, _, ok = sse.Process(0, []byte(`nope`), labels.EmptyLabels())
 	require.False(t, ok)
 }
 
@@ -465,10 +461,10 @@ func TestFilteringSampleExtractor(t *testing.T) {
 
 	for _, test := range tt {
 		t.Run(test.name, func(t *testing.T) {
-			_, _, ok := se.ForStream(test.labels).Process(test.ts, []byte(test.line), test.structuredMetadata...)
+			_, _, ok := se.ForStream(test.labels).Process(test.ts, []byte(test.line), test.structuredMetadata)
 			require.Equal(t, test.ok, ok)
 
-			_, _, ok = se.ForStream(test.labels).ProcessString(test.ts, test.line, test.structuredMetadata...)
+			_, _, ok = se.ForStream(test.labels).ProcessString(test.ts, test.line, test.structuredMetadata)
 			require.Equal(t, test.ok, ok)
 		})
 	}
@@ -500,20 +496,20 @@ func (p *stubStreamExtractor) BaseLabels() LabelsResult {
 func (p *stubStreamExtractor) Process(
 	_ int64,
 	_ []byte,
-	structuredMetadata ...labels.Label,
+	structuredMetadata labels.Labels,
 ) (float64, LabelsResult, bool) {
 	builder := NewBaseLabelsBuilder().ForLabels(labels.FromStrings("foo", "bar"), 0)
-	builder.Add(StructuredMetadataLabel, structuredMetadata...)
+	builder.Add(StructuredMetadataLabel, structuredMetadata)
 	return 1.0, builder.LabelsResult(), true
 }
 
 func (p *stubStreamExtractor) ProcessString(
 	_ int64,
 	_ string,
-	structuredMetadata ...labels.Label,
+	structuredMetadata labels.Labels,
 ) (float64, LabelsResult, bool) {
 	builder := NewBaseLabelsBuilder().ForLabels(labels.FromStrings("foo", "bar"), 0)
-	builder.Add(StructuredMetadataLabel, structuredMetadata...)
+	builder.Add(StructuredMetadataLabel, structuredMetadata)
 	return 1.0, builder.LabelsResult(), true
 }
 
@@ -576,13 +572,13 @@ func TestVariantsStreamSampleExtractorWrapper(t *testing.T) {
 			wrapped := NewVariantsStreamSampleExtractorWrapper(tt.index, baseExtractor)
 
 			// Test Process
-			val, lbs, ok := wrapped.Process(0, []byte(tt.input), tt.structuredMetadata...)
+			val, lbs, ok := wrapped.Process(0, []byte(tt.input), tt.structuredMetadata)
 			require.Equal(t, true, ok)
 			require.Equal(t, tt.want, val)
 			require.Equal(t, tt.wantLbs, lbs.Labels())
 
 			// Test ProcessString
-			val, lbs, ok = wrapped.ProcessString(0, tt.input, tt.structuredMetadata...)
+			val, lbs, ok = wrapped.ProcessString(0, tt.input, tt.structuredMetadata)
 			require.Equal(t, true, ok)
 			require.Equal(t, tt.want, val)
 			require.Equal(t, tt.wantLbs, lbs.Labels())

--- a/pkg/logql/log/parser_hints_test.go
+++ b/pkg/logql/log/parser_hints_test.go
@@ -234,7 +234,7 @@ func Test_ParserHints(t *testing.T) {
 			require.NoError(t, err)
 
 			for i, ex := range exs {
-				v, lbsRes, ok := ex.ForStream(lbs).Process(0, append([]byte{}, tt.line...))
+				v, lbsRes, ok := ex.ForStream(lbs).Process(0, append([]byte{}, tt.line...), labels.EmptyLabels())
 				var lbsResString string
 				if lbsRes != nil {
 					lbsResString = lbsRes.String()

--- a/pkg/logql/log/pipeline.go
+++ b/pkg/logql/log/pipeline.go
@@ -25,8 +25,8 @@ type StreamPipeline interface {
 	BaseLabels() LabelsResult
 	// Process processes a log line and returns the transformed line and the labels.
 	// The buffer returned for the log line can be reused on subsequent calls to Process and therefore must be copied.
-	Process(ts int64, line []byte, structuredMetadata ...labels.Label) (resultLine []byte, resultLabels LabelsResult, matches bool)
-	ProcessString(ts int64, line string, structuredMetadata ...labels.Label) (resultLine string, resultLabels LabelsResult, matches bool)
+	Process(ts int64, line []byte, structuredMetadata labels.Labels) (resultLine []byte, resultLabels LabelsResult, matches bool)
+	ProcessString(ts int64, line string, structuredMetadata labels.Labels) (resultLine string, resultLabels LabelsResult, matches bool)
 	ReferencedStructuredMetadata() bool
 }
 
@@ -100,17 +100,17 @@ func (n noopStreamPipeline) ReferencedStructuredMetadata() bool {
 	return false
 }
 
-func (n noopStreamPipeline) Process(_ int64, line []byte, structuredMetadata ...labels.Label) ([]byte, LabelsResult, bool) {
+func (n noopStreamPipeline) Process(_ int64, line []byte, structuredMetadata labels.Labels) ([]byte, LabelsResult, bool) {
 	n.builder.Reset()
 	for i, lb := range structuredMetadata {
 		structuredMetadata[i].Name = prometheus.NormalizeLabel(lb.Name)
 	}
-	n.builder.Add(StructuredMetadataLabel, structuredMetadata...)
+	n.builder.Add(StructuredMetadataLabel, structuredMetadata)
 	return line, n.builder.LabelsResult(), true
 }
 
-func (n noopStreamPipeline) ProcessString(ts int64, line string, structuredMetadata ...labels.Label) (string, LabelsResult, bool) {
-	_, lr, ok := n.Process(ts, unsafeGetBytes(line), structuredMetadata...)
+func (n noopStreamPipeline) ProcessString(ts int64, line string, structuredMetadata labels.Labels) (string, LabelsResult, bool) {
+	_, lr, ok := n.Process(ts, unsafeGetBytes(line), structuredMetadata)
 	return line, lr, ok
 }
 
@@ -221,7 +221,7 @@ func (p *streamPipeline) ReferencedStructuredMetadata() bool {
 	return p.builder.referencedStructuredMetadata
 }
 
-func (p *streamPipeline) Process(ts int64, line []byte, structuredMetadata ...labels.Label) ([]byte, LabelsResult, bool) {
+func (p *streamPipeline) Process(ts int64, line []byte, structuredMetadata labels.Labels) ([]byte, LabelsResult, bool) {
 	var ok bool
 	p.builder.Reset()
 
@@ -229,7 +229,7 @@ func (p *streamPipeline) Process(ts int64, line []byte, structuredMetadata ...la
 		structuredMetadata[i].Name = prometheus.NormalizeLabel(lb.Name)
 	}
 
-	p.builder.Add(StructuredMetadataLabel, structuredMetadata...)
+	p.builder.Add(StructuredMetadataLabel, structuredMetadata)
 
 	for _, s := range p.stages {
 		line, ok = s.Process(ts, line, p.builder)
@@ -240,9 +240,9 @@ func (p *streamPipeline) Process(ts int64, line []byte, structuredMetadata ...la
 	return line, p.builder.LabelsResult(), true
 }
 
-func (p *streamPipeline) ProcessString(ts int64, line string, structuredMetadata ...labels.Label) (string, LabelsResult, bool) {
+func (p *streamPipeline) ProcessString(ts int64, line string, structuredMetadata labels.Labels) (string, LabelsResult, bool) {
 	// Stages only read from the line.
-	lb, lr, ok := p.Process(ts, unsafeGetBytes(line), structuredMetadata...)
+	lb, lr, ok := p.Process(ts, unsafeGetBytes(line), structuredMetadata)
 	// but the returned line needs to be copied.
 	return string(lb), lr, ok
 }
@@ -325,34 +325,34 @@ func (sp *filteringStreamPipeline) BaseLabels() LabelsResult {
 	return sp.pipeline.BaseLabels()
 }
 
-func (sp *filteringStreamPipeline) Process(ts int64, line []byte, structuredMetadata ...labels.Label) ([]byte, LabelsResult, bool) {
+func (sp *filteringStreamPipeline) Process(ts int64, line []byte, structuredMetadata labels.Labels) ([]byte, LabelsResult, bool) {
 	for _, filter := range sp.filters {
 		if ts < filter.start || ts > filter.end {
 			continue
 		}
 
-		_, _, matches := filter.pipeline.Process(ts, line, structuredMetadata...)
+		_, _, matches := filter.pipeline.Process(ts, line, structuredMetadata)
 		if matches { // When the filter matches, don't run the next step
 			return nil, nil, false
 		}
 	}
 
-	return sp.pipeline.Process(ts, line, structuredMetadata...)
+	return sp.pipeline.Process(ts, line, structuredMetadata)
 }
 
-func (sp *filteringStreamPipeline) ProcessString(ts int64, line string, structuredMetadata ...labels.Label) (string, LabelsResult, bool) {
+func (sp *filteringStreamPipeline) ProcessString(ts int64, line string, structuredMetadata labels.Labels) (string, LabelsResult, bool) {
 	for _, filter := range sp.filters {
 		if ts < filter.start || ts > filter.end {
 			continue
 		}
 
-		_, _, matches := filter.pipeline.ProcessString(ts, line, structuredMetadata...)
+		_, _, matches := filter.pipeline.ProcessString(ts, line, structuredMetadata)
 		if matches { // When the filter matches, don't run the next step
 			return "", nil, false
 		}
 	}
 
-	return sp.pipeline.ProcessString(ts, line, structuredMetadata...)
+	return sp.pipeline.ProcessString(ts, line, structuredMetadata)
 }
 
 // ReduceStages reduces multiple stages into one.

--- a/pkg/logql/log/pipeline_test.go
+++ b/pkg/logql/log/pipeline_test.go
@@ -14,14 +14,14 @@ func TestNoopPipeline(t *testing.T) {
 	lbs := labels.FromStrings("foo", "bar")
 	pipeline := NewNoopPipeline().(*noopPipeline)
 
-	l, lbr, matches := pipeline.ForStream(lbs).Process(0, []byte(""))
+	l, lbr, matches := pipeline.ForStream(lbs).Process(0, []byte(""), labels.EmptyLabels())
 	require.Equal(t, []byte(""), l)
 	require.Equal(t, NewLabelsResult(lbs.String(), lbs.Hash(), lbs, labels.EmptyLabels(), labels.EmptyLabels()), lbr)
 	require.Equal(t, lbs.Hash(), lbr.Hash())
 	require.Equal(t, lbs.String(), lbr.String())
 	require.Equal(t, true, matches)
 
-	ls, lbr, matches := pipeline.ForStream(lbs).ProcessString(0, "")
+	ls, lbr, matches := pipeline.ForStream(lbs).ProcessString(0, "", labels.EmptyLabels())
 	require.Equal(t, "", ls)
 	require.Equal(t, NewLabelsResult(lbs.String(), lbs.Hash(), lbs, labels.EmptyLabels(), labels.EmptyLabels()), lbr)
 	require.Equal(t, lbs.Hash(), lbr.Hash())
@@ -30,14 +30,14 @@ func TestNoopPipeline(t *testing.T) {
 
 	structuredMetadata := labels.FromStrings("y", "1", "z", "2")
 	expectedLabelsResults := append(lbs, structuredMetadata...)
-	l, lbr, matches = pipeline.ForStream(lbs).Process(0, []byte(""), structuredMetadata...)
+	l, lbr, matches = pipeline.ForStream(lbs).Process(0, []byte(""), structuredMetadata)
 	require.Equal(t, []byte(""), l)
 	require.Equal(t, NewLabelsResult(expectedLabelsResults.String(), expectedLabelsResults.Hash(), lbs, structuredMetadata, labels.EmptyLabels()), lbr)
 	require.Equal(t, expectedLabelsResults.Hash(), lbr.Hash())
 	require.Equal(t, expectedLabelsResults.String(), lbr.String())
 	require.Equal(t, true, matches)
 
-	ls, lbr, matches = pipeline.ForStream(lbs).ProcessString(0, "", structuredMetadata...)
+	ls, lbr, matches = pipeline.ForStream(lbs).ProcessString(0, "", structuredMetadata)
 	require.Equal(t, "", ls)
 	require.Equal(t, NewLabelsResult(expectedLabelsResults.String(), expectedLabelsResults.Hash(), lbs, structuredMetadata, labels.EmptyLabels()), lbr)
 	require.Equal(t, expectedLabelsResults.Hash(), lbr.Hash())
@@ -47,9 +47,7 @@ func TestNoopPipeline(t *testing.T) {
 	// test duplicated structured metadata with stream labels
 	expectedNonIndexedLabels := labels.FromStrings("foo_extracted", "baz", "y", "1", "z", "2")
 	expectedLabelsResults = labels.FromStrings("foo", "bar", "foo_extracted", "baz", "y", "1", "z", "2")
-	l, lbr, matches = pipeline.ForStream(lbs).Process(0, []byte(""), append(structuredMetadata, labels.Label{
-		Name: "foo", Value: "baz",
-	})...)
+	l, lbr, matches = pipeline.ForStream(lbs).Process(0, []byte(""), labels.NewBuilder(structuredMetadata).Set("foo", "baz").Labels())
 	require.Equal(t, []byte(""), l)
 	require.Equal(t, NewLabelsResult(expectedLabelsResults.String(), expectedLabelsResults.Hash(), lbs, expectedNonIndexedLabels, labels.EmptyLabels()), lbr)
 	require.Equal(t, expectedLabelsResults.Hash(), lbr.Hash())
@@ -61,7 +59,7 @@ func TestNoopPipeline(t *testing.T) {
 	expectedStructuredMetadata := append(labels.FromStrings("y", "1", "z", "2"), labels.Label{Name: "zsomething_bad", Value: "foo"})
 	expectedLabelsResults = append(lbs, expectedStructuredMetadata...)
 
-	l, lbr, matches = pipeline.ForStream(lbs).Process(0, []byte(""), structuredMetadata...)
+	l, lbr, matches = pipeline.ForStream(lbs).Process(0, []byte(""), structuredMetadata)
 	require.Equal(t, []byte(""), l)
 	require.Equal(t, NewLabelsResult(expectedLabelsResults.String(), expectedLabelsResults.Hash(), lbs, expectedStructuredMetadata, labels.EmptyLabels()), lbr)
 	require.Equal(t, expectedLabelsResults.Hash(), lbr.Hash())
@@ -79,26 +77,26 @@ func TestPipeline(t *testing.T) {
 		newMustLineFormatter("lbs {{.foo}}"),
 	}).(*pipeline)
 
-	l, lbr, matches := p.ForStream(lbs).Process(0, []byte("line"))
+	l, lbr, matches := p.ForStream(lbs).Process(0, []byte("line"), labels.EmptyLabels())
 	require.Equal(t, []byte("lbs bar"), l)
 	require.Equal(t, NewLabelsResult(lbs.String(), lbs.Hash(), lbs, labels.EmptyLabels(), labels.EmptyLabels()), lbr)
 	require.Equal(t, lbs.Hash(), lbr.Hash())
 	require.Equal(t, lbs.String(), lbr.String())
 	require.Equal(t, true, matches)
 
-	ls, lbr, matches := p.ForStream(lbs).ProcessString(0, "line")
+	ls, lbr, matches := p.ForStream(lbs).ProcessString(0, "line", labels.EmptyLabels())
 	require.Equal(t, "lbs bar", ls)
 	require.Equal(t, NewLabelsResult(lbs.String(), lbs.Hash(), lbs, labels.EmptyLabels(), labels.EmptyLabels()), lbr)
 	require.Equal(t, lbs.Hash(), lbr.Hash())
 	require.Equal(t, lbs.String(), lbr.String())
 	require.Equal(t, true, matches)
 
-	l, lbr, matches = p.ForStream(labels.EmptyLabels()).Process(0, []byte("line"))
+	l, lbr, matches = p.ForStream(labels.EmptyLabels()).Process(0, []byte("line"), labels.EmptyLabels())
 	require.Equal(t, []byte(nil), l)
 	require.Equal(t, nil, lbr)
 	require.Equal(t, false, matches)
 
-	ls, lbr, matches = p.ForStream(labels.EmptyLabels()).ProcessString(0, "line")
+	ls, lbr, matches = p.ForStream(labels.EmptyLabels()).ProcessString(0, "line", labels.EmptyLabels())
 	require.Equal(t, "", ls)
 	require.Equal(t, nil, lbr)
 	require.Equal(t, false, matches)
@@ -127,14 +125,14 @@ func TestPipelineWithStructuredMetadata(t *testing.T) {
 		newMustLineFormatter("lbs {{.foo}} {{.user}}"),
 	}).(*pipeline)
 
-	l, lbr, matches := p.ForStream(lbs).Process(0, []byte("line"), structuredMetadata...)
+	l, lbr, matches := p.ForStream(lbs).Process(0, []byte("line"), structuredMetadata)
 	require.Equal(t, []byte("lbs bar bob"), l)
 	require.Equal(t, NewLabelsResult(expectedLabelsResults.String(), expectedLabelsResults.Hash(), lbs, structuredMetadata, labels.EmptyLabels()), lbr)
 	require.Equal(t, expectedLabelsResults.Hash(), lbr.Hash())
 	require.Equal(t, expectedLabelsResults.String(), lbr.String())
 	require.Equal(t, true, matches)
 
-	ls, lbr, matches := p.ForStream(lbs).ProcessString(0, "line", structuredMetadata...)
+	ls, lbr, matches := p.ForStream(lbs).ProcessString(0, "line", structuredMetadata)
 	require.Equal(t, "lbs bar bob", ls)
 	require.Equal(t, NewLabelsResult(expectedLabelsResults.String(), expectedLabelsResults.Hash(), lbs, structuredMetadata, labels.EmptyLabels()), lbr)
 	require.Equal(t, expectedLabelsResults.Hash(), lbr.Hash())
@@ -145,40 +143,36 @@ func TestPipelineWithStructuredMetadata(t *testing.T) {
 	expectedNonIndexedLabels := labels.FromStrings("user", "bob", "foo_extracted", "baz")
 	expectedLabelsResults = labels.FromStrings("foo", "bar", "foo_extracted", "baz")
 	expectedLabelsResults = append(expectedLabelsResults, structuredMetadata...)
-	l, lbr, matches = p.ForStream(lbs).Process(0, []byte("line"), append(structuredMetadata, labels.Label{
-		Name: "foo", Value: "baz",
-	})...)
+	l, lbr, matches = p.ForStream(lbs).Process(0, []byte("line"), labels.NewBuilder(structuredMetadata).Set("foo", "baz").Labels())
 	require.Equal(t, []byte("lbs bar bob"), l)
 	require.Equal(t, NewLabelsResult(expectedLabelsResults.String(), expectedLabelsResults.Hash(), lbs, expectedNonIndexedLabels, labels.EmptyLabels()), lbr)
 	require.Equal(t, expectedLabelsResults.Hash(), lbr.Hash())
 	require.Equal(t, expectedLabelsResults.String(), lbr.String())
 	require.Equal(t, true, matches)
 
-	ls, lbr, matches = p.ForStream(lbs).ProcessString(0, "line", append(structuredMetadata, labels.Label{
-		Name: "foo", Value: "baz",
-	})...)
+	ls, lbr, matches = p.ForStream(lbs).ProcessString(0, "line", labels.NewBuilder(structuredMetadata).Set("foo", "baz").Labels())
 	require.Equal(t, "lbs bar bob", ls)
 	require.Equal(t, NewLabelsResult(expectedLabelsResults.String(), expectedLabelsResults.Hash(), lbs, expectedNonIndexedLabels, labels.EmptyLabels()), lbr)
 	require.Equal(t, expectedLabelsResults.Hash(), lbr.Hash())
 	require.Equal(t, expectedLabelsResults.String(), lbr.String())
 	require.Equal(t, true, matches)
 
-	l, lbr, matches = p.ForStream(lbs).Process(0, []byte("line"))
+	l, lbr, matches = p.ForStream(lbs).Process(0, []byte("line"), labels.EmptyLabels())
 	require.Equal(t, []byte(nil), l)
 	require.Equal(t, nil, lbr)
 	require.Equal(t, false, matches)
 
-	ls, lbr, matches = p.ForStream(lbs).ProcessString(0, "line")
+	ls, lbr, matches = p.ForStream(lbs).ProcessString(0, "line", labels.EmptyLabels())
 	require.Equal(t, "", ls)
 	require.Equal(t, nil, lbr)
 	require.Equal(t, false, matches)
 
-	l, lbr, matches = p.ForStream(labels.EmptyLabels()).Process(0, []byte("line"), structuredMetadata...)
+	l, lbr, matches = p.ForStream(labels.EmptyLabels()).Process(0, []byte("line"), structuredMetadata)
 	require.Equal(t, []byte(nil), l)
 	require.Equal(t, nil, lbr)
 	require.Equal(t, false, matches)
 
-	ls, lbr, matches = p.ForStream(labels.EmptyLabels()).ProcessString(0, "line", structuredMetadata...)
+	ls, lbr, matches = p.ForStream(labels.EmptyLabels()).ProcessString(0, "line", structuredMetadata)
 	require.Equal(t, "", ls)
 	require.Equal(t, nil, lbr)
 	require.Equal(t, false, matches)
@@ -188,7 +182,7 @@ func TestPipelineWithStructuredMetadata(t *testing.T) {
 	expectedStructuredMetadata := append(structuredMetadata, labels.Label{Name: "zsomething_bad", Value: "foo"})
 	expectedLabelsResults = append(lbs, expectedStructuredMetadata...)
 
-	_, lbr, matches = p.ForStream(lbs).Process(0, []byte(""), withBadLabel...)
+	_, lbr, matches = p.ForStream(lbs).Process(0, []byte(""), withBadLabel)
 	require.Equal(t, NewLabelsResult(expectedLabelsResults.String(), expectedLabelsResults.Hash(), lbs, expectedStructuredMetadata, labels.EmptyLabels()), lbr)
 	require.Equal(t, expectedLabelsResults.Hash(), lbr.Hash())
 	require.Equal(t, expectedLabelsResults.String(), lbr.String())
@@ -237,10 +231,10 @@ func TestFilteringPipeline(t *testing.T) {
 		}, downstream)
 
 		t.Run(test.name, func(t *testing.T) {
-			_, _, matches := p.ForStream(test.inputStreamLabels).Process(test.ts, []byte(test.line), test.structuredMetadata...)
+			_, _, matches := p.ForStream(test.inputStreamLabels).Process(test.ts, []byte(test.line), test.structuredMetadata)
 			require.Equal(t, test.ok, matches)
 
-			_, _, matches = p.ForStream(test.inputStreamLabels).ProcessString(test.ts, test.line, test.structuredMetadata...)
+			_, _, matches = p.ForStream(test.inputStreamLabels).ProcessString(test.ts, test.line, test.structuredMetadata)
 			require.Equal(t, test.ok, matches)
 
 			p.Reset()
@@ -295,11 +289,11 @@ func (p *stubStreamPipeline) BaseLabels() LabelsResult {
 	return nil
 }
 
-func (p *stubStreamPipeline) Process(_ int64, _ []byte, _ ...labels.Label) ([]byte, LabelsResult, bool) {
+func (p *stubStreamPipeline) Process(_ int64, _ []byte, _ labels.Labels) ([]byte, LabelsResult, bool) {
 	return nil, nil, true
 }
 
-func (p *stubStreamPipeline) ProcessString(_ int64, _ string, _ ...labels.Label) (string, LabelsResult, bool) {
+func (p *stubStreamPipeline) ProcessString(_ int64, _ string, _ labels.Labels) (string, LabelsResult, bool) {
 	return "", nil, true
 }
 
@@ -407,7 +401,7 @@ func TestDropLabelsPipeline(t *testing.T) {
 		p := NewPipeline(tt.stages)
 		sp := p.ForStream(labels.EmptyLabels())
 		for i, line := range tt.lines {
-			_, finalLbs, _ := sp.Process(0, line)
+			_, finalLbs, _ := sp.Process(0, line, labels.EmptyLabels())
 			require.Equal(t, tt.wantLabels[i], finalLbs.Labels())
 			require.Nil(t, finalLbs.Stream())
 			require.Nil(t, finalLbs.StructuredMetadata())
@@ -528,7 +522,7 @@ func TestKeepLabelsPipeline(t *testing.T) {
 			p := NewPipeline(tt.stages)
 			sp := p.ForStream(labels.EmptyLabels())
 			for i, line := range tt.lines {
-				finalLine, finalLbs, _ := sp.Process(0, line)
+				finalLine, finalLbs, _ := sp.Process(0, line, labels.EmptyLabels())
 				require.Equal(t, tt.wantLine[i], finalLine)
 				require.Equal(t, tt.wantLabels[i], finalLbs.Labels())
 				require.Nil(t, finalLbs.Stream())
@@ -615,26 +609,26 @@ func Benchmark_Pipeline(b *testing.B) {
 	b.Run("pipeline bytes", func(b *testing.B) {
 		b.ResetTimer()
 		for n := 0; n < b.N; n++ {
-			resLine, resLbs, resMatches = sp.Process(0, line)
+			resLine, resLbs, resMatches = sp.Process(0, line, labels.EmptyLabels())
 		}
 	})
 	b.Run("pipeline string", func(b *testing.B) {
 		b.ResetTimer()
 		for n := 0; n < b.N; n++ {
-			resLineString, resLbs, resMatches = sp.ProcessString(0, lineString)
+			resLineString, resLbs, resMatches = sp.ProcessString(0, lineString, labels.EmptyLabels())
 		}
 	})
 
 	b.Run("pipeline bytes no invalid structured metadata", func(b *testing.B) {
 		b.ResetTimer()
 		for n := 0; n < b.N; n++ {
-			resLine, resLbs, resMatches = sp.Process(0, line, labels.Label{Name: "valid_name", Value: "foo"})
+			resLine, resLbs, resMatches = sp.Process(0, line, labels.FromStrings("valid_name", "foo"))
 		}
 	})
 	b.Run("pipeline string with invalid structured metadata", func(b *testing.B) {
 		b.ResetTimer()
 		for n := 0; n < b.N; n++ {
-			resLine, resLbs, resMatches = sp.Process(0, line, labels.Label{Name: "invalid-name", Value: "foo"}, labels.Label{Name: "other-invalid-name", Value: "foo"})
+			resLine, resLbs, resMatches = sp.Process(0, line, labels.FromStrings("valid_name", "foo"))
 		}
 	})
 
@@ -644,13 +638,13 @@ func Benchmark_Pipeline(b *testing.B) {
 	b.Run("line extractor bytes", func(b *testing.B) {
 		b.ResetTimer()
 		for n := 0; n < b.N; n++ {
-			resSample, resLbs, resMatches = ex.Process(0, line)
+			resSample, resLbs, resMatches = ex.Process(0, line, labels.EmptyLabels())
 		}
 	})
 	b.Run("line extractor string", func(b *testing.B) {
 		b.ResetTimer()
 		for n := 0; n < b.N; n++ {
-			resSample, resLbs, resMatches = ex.ProcessString(0, lineString)
+			resSample, resLbs, resMatches = ex.ProcessString(0, lineString, labels.EmptyLabels())
 		}
 	})
 
@@ -661,13 +655,13 @@ func Benchmark_Pipeline(b *testing.B) {
 	b.Run("label extractor bytes", func(b *testing.B) {
 		b.ResetTimer()
 		for n := 0; n < b.N; n++ {
-			resSample, resLbs, resMatches = ex.Process(0, line)
+			resSample, resLbs, resMatches = ex.Process(0, line, labels.EmptyLabels())
 		}
 	})
 	b.Run("label extractor string", func(b *testing.B) {
 		b.ResetTimer()
 		for n := 0; n < b.N; n++ {
-			resSample, resLbs, resMatches = ex.ProcessString(0, lineString)
+			resSample, resLbs, resMatches = ex.ProcessString(0, lineString, labels.EmptyLabels())
 		}
 	})
 }
@@ -699,7 +693,7 @@ func jsonBenchmark(b *testing.B, parser Stage) {
 	b.ResetTimer()
 	sp := p.ForStream(lbs)
 	for n := 0; n < b.N; n++ {
-		resLine, resLbs, resMatches = sp.Process(0, line)
+		resLine, resLbs, resMatches = sp.Process(0, line, labels.EmptyLabels())
 
 		if !resMatches {
 			b.Fatalf("resulting line not ok: %s\n", line)
@@ -722,7 +716,7 @@ func invalidJSONBenchmark(b *testing.B, parser Stage) {
 	b.ResetTimer()
 	sp := p.ForStream(labels.EmptyLabels())
 	for n := 0; n < b.N; n++ {
-		resLine, resLbs, resMatches = sp.Process(0, line)
+		resLine, resLbs, resMatches = sp.Process(0, line, labels.EmptyLabels())
 
 		if !resMatches {
 			b.Fatalf("resulting line not ok: %s\n", line)
@@ -780,7 +774,7 @@ func logfmtBenchmark(b *testing.B, parser Stage) {
 	b.ResetTimer()
 	sp := p.ForStream(lbs)
 	for n := 0; n < b.N; n++ {
-		resLine, resLbs, resMatches = sp.Process(0, line)
+		resLine, resLbs, resMatches = sp.Process(0, line, labels.EmptyLabels())
 
 		if !resMatches {
 			b.Fatalf("resulting line not ok: %s\n", line)

--- a/pkg/logql/syntax/ast_test.go
+++ b/pkg/logql/syntax/ast_test.go
@@ -290,7 +290,7 @@ func Test_NilFilterDoesntPanic(t *testing.T) {
 
 			p, err := expr.Pipeline()
 			require.Nil(t, err)
-			_, _, matches := p.ForStream(labelBar).Process(0, []byte("bleepbloop"))
+			_, _, matches := p.ForStream(labelBar).Process(0, []byte("bleepbloop"), labels.EmptyLabels())
 
 			require.True(t, matches)
 		})
@@ -615,7 +615,7 @@ func Test_FilterMatcher(t *testing.T) {
 			} else {
 				sp := p.ForStream(labelBar)
 				for _, lc := range tt.lines {
-					_, _, matches := sp.Process(0, []byte(lc.l))
+					_, _, matches := sp.Process(0, []byte(lc.l), labels.EmptyLabels())
 					assert.Equalf(t, lc.e, matches, "query for line '%s' was %v and not %v", lc.l, matches, lc.e)
 				}
 			}
@@ -863,7 +863,7 @@ func BenchmarkContainsFilter(b *testing.B) {
 			sp := p.ForStream(labelBar)
 			for i := 0; i < b.N; i++ {
 				for _, line := range lines {
-					sp.Process(0, line)
+					sp.Process(0, line, labels.EmptyLabels())
 				}
 			}
 		})
@@ -1070,7 +1070,7 @@ func BenchmarkReorderedPipeline(b *testing.B) {
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		_, _, result = sp.Process(0, logfmtLine)
+		_, _, result = sp.Process(0, logfmtLine, labels.EmptyLabels())
 	}
 }
 

--- a/pkg/logql/syntax/parser_test.go
+++ b/pkg/logql/syntax/parser_test.go
@@ -3443,7 +3443,7 @@ func Test_PipelineCombined(t *testing.T) {
 	p, err := expr.Pipeline()
 	require.Nil(t, err)
 	sp := p.ForStream(labels.EmptyLabels())
-	line, lbs, matches := sp.Process(0, []byte(`level=debug ts=2020-10-02T10:10:42.092268913Z caller=logging.go:66 traceID=a9d4d8a928d8db1 msg="POST /api/prom/api/v1/query_range (200) 1.5s"`))
+	line, lbs, matches := sp.Process(0, []byte(`level=debug ts=2020-10-02T10:10:42.092268913Z caller=logging.go:66 traceID=a9d4d8a928d8db1 msg="POST /api/prom/api/v1/query_range (200) 1.5s"`), labels.EmptyLabels())
 	require.True(t, matches)
 	require.Equal(
 		t,
@@ -3472,7 +3472,7 @@ func Benchmark_PipelineCombined(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		line, lbs, matches = sp.Process(0, in)
+		line, lbs, matches = sp.Process(0, in, labels.EmptyLabels())
 	}
 	require.True(b, matches)
 	require.Equal(
@@ -3505,7 +3505,7 @@ func Benchmark_MetricPipelineCombined(b *testing.B) {
 		b.ReportAllocs()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			v, lbs, matches = sp.Process(0, in)
+			v, lbs, matches = sp.Process(0, in, labels.EmptyLabels())
 		}
 		require.True(b, matches)
 		require.Equal(

--- a/pkg/logql/test_utils.go
+++ b/pkg/logql/test_utils.go
@@ -118,7 +118,7 @@ func processStream(in []logproto.Stream, pipeline log.Pipeline) []logproto.Strea
 	for _, stream := range in {
 		sp := pipeline.ForStream(mustParseLabels(stream.Labels))
 		for _, e := range stream.Entries {
-			if l, out, matches := sp.Process(e.Timestamp.UnixNano(), []byte(e.Line)); matches {
+			if l, out, matches := sp.Process(e.Timestamp.UnixNano(), []byte(e.Line), labels.EmptyLabels()); matches {
 				var s *logproto.Stream
 				var found bool
 				s, found = resByStream[out.String()]
@@ -147,7 +147,7 @@ func processSeries(in []logproto.Stream, ex []log.SampleExtractor) ([]logproto.S
 		for _, extractor := range ex {
 			exs := extractor.ForStream(mustParseLabels(stream.Labels))
 			for _, e := range stream.Entries {
-				if f, lbs, ok := exs.Process(e.Timestamp.UnixNano(), []byte(e.Line)); ok {
+				if f, lbs, ok := exs.Process(e.Timestamp.UnixNano(), []byte(e.Line), labels.EmptyLabels()); ok {
 					var s *logproto.Series
 					var found bool
 					s, found = resBySeries[lbs.String()]

--- a/pkg/logqlanalyzer/analyzer.go
+++ b/pkg/logqlanalyzer/analyzer.go
@@ -118,7 +118,7 @@ func (p streamPipelineAnalyzer) AnalyzeLine(line string) []StageAnalysisRecord {
 		})
 	}
 	stream := log.NewStreamPipeline(stageRecorders, p.origin.LabelsBuilder().ForLabels(p.streamLabels, p.streamLabels.Hash()))
-	_, _, _ = stream.ProcessString(time.Now().UnixMilli(), line)
+	_, _, _ = stream.ProcessString(time.Now().UnixMilli(), line, labels.EmptyLabels())
 	return records
 }
 

--- a/pkg/querier/queryrange/detected_fields_test.go
+++ b/pkg/querier/queryrange/detected_fields_test.go
@@ -356,7 +356,7 @@ func Test_parseDetectedFields(t *testing.T) {
 
 				streamLbls.Add(
 					logql_log.ParsedLabel,
-					labels.Label{Name: field.Name, Value: field.Value},
+					labels.FromStrings(field.Name, field.Value),
 				)
 			}
 
@@ -499,7 +499,7 @@ func Test_parseDetectedFields(t *testing.T) {
 
 				nginxStreamLbls.Add(
 					logql_log.ParsedLabel,
-					labels.Label{Name: field.Name, Value: field.Value},
+					labels.FromStrings(field.Name, field.Value),
 				)
 			}
 

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -1018,14 +1018,14 @@ func (p *mockStreamPipeline) BaseLabels() lokilog.LabelsResult {
 	return p.wrappedSP.BaseLabels()
 }
 
-func (p *mockStreamPipeline) Process(ts int64, line []byte, lbs ...labels.Label) ([]byte, lokilog.LabelsResult, bool) {
+func (p *mockStreamPipeline) Process(ts int64, line []byte, lbs labels.Labels) ([]byte, lokilog.LabelsResult, bool) {
 	p.called++
-	return p.wrappedSP.Process(ts, line, lbs...)
+	return p.wrappedSP.Process(ts, line, lbs)
 }
 
-func (p *mockStreamPipeline) ProcessString(ts int64, line string, lbs ...labels.Label) (string, lokilog.LabelsResult, bool) {
+func (p *mockStreamPipeline) ProcessString(ts int64, line string, lbs labels.Labels) (string, lokilog.LabelsResult, bool) {
 	p.called++
-	return p.wrappedSP.ProcessString(ts, line, lbs...)
+	return p.wrappedSP.ProcessString(ts, line, lbs)
 }
 
 func Test_SampleWrapper(t *testing.T) {
@@ -1133,14 +1133,14 @@ func (p *mockStreamExtractor) BaseLabels() lokilog.LabelsResult {
 	return p.wrappedSP.BaseLabels()
 }
 
-func (p *mockStreamExtractor) Process(ts int64, line []byte, lbs ...labels.Label) (float64, lokilog.LabelsResult, bool) {
+func (p *mockStreamExtractor) Process(ts int64, line []byte, lbs labels.Labels) (float64, lokilog.LabelsResult, bool) {
 	p.called++
-	return p.wrappedSP.Process(ts, line, lbs...)
+	return p.wrappedSP.Process(ts, line, lbs)
 }
 
-func (p *mockStreamExtractor) ProcessString(ts int64, line string, lbs ...labels.Label) (float64, lokilog.LabelsResult, bool) {
+func (p *mockStreamExtractor) ProcessString(ts int64, line string, lbs labels.Labels) (float64, lokilog.LabelsResult, bool) {
 	p.called++
-	return p.wrappedSP.ProcessString(ts, line, lbs...)
+	return p.wrappedSP.ProcessString(ts, line, lbs)
 }
 
 func Test_store_GetSeries(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a next step of support Prometheus `stringlabels` implementation in Loki. It adds support in `log.StreamPipeline`.

**Special notes for your reviewer**:
The tests should compile with build tag `stringlabels`.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
