### PR TITLE
fix: fix a bug where limits were incorrect after grafana/loki#16937

### DIFF
--- a/pkg/limits/frontend/frontend.go
+++ b/pkg/limits/frontend/frontend.go
@@ -191,25 +191,12 @@ func (f *Frontend) ExceedsLimits(ctx context.Context, req *logproto.ExceedsLimit
 	// Check if max streams limit would be exceeded.
 	maxGlobalStreams := f.limits.MaxGlobalStreamsPerUser(req.Tenant)
 	if activeStreamsTotal >= uint64(maxGlobalStreams) {
-		// Take the intersection of unknown streams from all responses by counting
-		// the number of occurrences. If the number of occurrences matches the
-		// number of responses, we know the stream was unknown to all instances.
-		unknownStreams := make(map[uint64]int)
 		for _, resp := range resps {
 			for _, unknownStream := range resp.Response.UnknownStreams {
-				unknownStreams[unknownStream]++
-			}
-		}
-		for _, resp := range resps {
-			for _, unknownStream := range resp.Response.UnknownStreams {
-				// If the stream is unknown to all instances, it must be a new
-				// stream.
-				if unknownStreams[unknownStream] == len(resps) {
-					results = append(results, &logproto.ExceedsLimitsResult{
-						StreamHash: unknownStream,
-						Reason:     ReasonExceedsMaxStreams,
-					})
-				}
+				results = append(results, &logproto.ExceedsLimitsResult{
+					StreamHash: unknownStream,
+					Reason:     ReasonExceedsMaxStreams,
+				})
 			}
 		}
 	}

--- a/pkg/limits/frontend/frontend_test.go
+++ b/pkg/limits/frontend/frontend_test.go
@@ -152,9 +152,9 @@ func TestFrontend_ExceedsLimits(t *testing.T) {
 	}, {
 		// This test checks the case where a tenant's streams are sharded over
 		// two instances, each holding one each stream. Each instance will
-		// return an response stating that it doesn't know about the other
-		// stream. The frontend is responsible for taking the intersection of
-		// the two responses and calculating the actual set of unknown streams.
+		// receive a request for just the streams in its assigned partitions.
+		// The frontend is responsible for taking the union of the two responses
+		// and calculating the actual set of unknown streams.
 		name: "exceeds max streams limit, streams sharded over two instances",
 		exceedsLimitsRequest: &logproto.ExceedsLimitsRequest{
 			Tenant: "test",


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request fixes a bug where limits were incorrect after the change in grafana/loki#16937. This bug occurred because we stopped asking each limit instance if it knew about all stream hashes, and instead starting asking each limit instance if it knew about the stream hashes for its assigned partitions. This broke the logic in the frontend that was taking the intersection of all responses to calculate if a stream was unknown. It should now take the union instead.

This pull request is stacked on top of https://github.com/grafana/loki/pull/17223.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
