### PR TITLE
fix(engine): Fix querier intitalisation

### DIFF
--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -617,12 +617,16 @@ func (t *Loki) initQuerier() (services.Service, error) {
 		serverutil.ResponseJSONMiddleware(),
 	}
 
-	store, err := t.createDataObjBucket("dataobj-querier")
-	if err != nil {
-		return nil, err
+	var ms metastore.Metastore
+	if t.Cfg.Querier.Engine.EnableV2Engine {
+		store, err := t.createDataObjBucket("dataobj-querier")
+		if err != nil {
+			return nil, err
+		}
+		ms = metastore.NewObjectMetastore(store)
 	}
 
-	t.querierAPI = querier.NewQuerierAPI(t.Cfg.Querier, t.Querier, t.Overrides, metastore.NewObjectMetastore(store), logger)
+	t.querierAPI = querier.NewQuerierAPI(t.Cfg.Querier, t.Querier, t.Overrides, ms, logger)
 
 	indexStatsHTTPMiddleware := querier.WrapQuerySpanAndTimeout("query.IndexStats", t.Overrides)
 	indexShardsHTTPMiddleware := querier.WrapQuerySpanAndTimeout("query.IndexShards", t.Overrides)


### PR DESCRIPTION
**What this PR does / why we need it**:

The recent wiring of the v2 query engine in the querier (https://github.com/grafana/loki/pull/17032) caused a regression in the initialisation of the querier when the Thanos object client was not configured, because the v2 engine uses DataObject and DataObjects rely on Thanos object client.

This commit fixes the problem by creating the Thanos object client only when v2 engine is enabled.