### PR TITLE
chore: backport ingest-limits fixes to k250

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -721,6 +721,7 @@ func (d *Distributor) PushWithResolver(ctx context.Context, req *logproto.PushRe
 		return &logproto.PushResponse{}, validationErr
 	}
 
+	var skipMetadataHashes map[uint64]struct{}
 	if d.cfg.IngestLimitsEnabled {
 		streamsAfterLimits, reasonsForHashes, err := d.ingestLimits.enforceLimits(ctx, tenantID, streams)
 		if err != nil {
@@ -736,6 +737,18 @@ func (d *Distributor) PushWithResolver(ctx context.Context, req *logproto.PushRe
 			level.Debug(d.logger).Log("msg", "request exceeded limits, some streams will be dropped", "tenant", tenantID)
 			if !d.cfg.IngestLimitsDryRunEnabled {
 				streams = streamsAfterLimits
+			}
+		}
+
+		if len(reasonsForHashes) > 0 && d.cfg.IngestLimitsDryRunEnabled {
+			// When IngestLimitsDryRunEnabled is true, we need to stop stream hashes
+			// that exceed the stream limit from being written to the metadata topic.
+			// If we don't do this, the stream hashes that should have been rejected
+			// will instead being counted as a known stream, causing a disagreement
+			// in metrics between the limits service and ingesters.
+			skipMetadataHashes = make(map[uint64]struct{})
+			for streamHash := range reasonsForHashes {
+				skipMetadataHashes[streamHash] = struct{}{}
 			}
 		}
 	}
@@ -778,7 +791,7 @@ func (d *Distributor) PushWithResolver(ctx context.Context, req *logproto.PushRe
 			return nil, err
 		}
 		// We don't need to create a new context like the ingester writes, because we don't return unless all writes have succeeded.
-		d.sendStreamsToKafka(ctx, streams, tenantID, &tracker, subring)
+		d.sendStreamsToKafka(ctx, streams, skipMetadataHashes, tenantID, &tracker, subring)
 	}
 
 	if d.cfg.IngesterEnabled {
@@ -1213,10 +1226,10 @@ func (d *Distributor) sendStreamsErr(ctx context.Context, ingester ring.Instance
 	return err
 }
 
-func (d *Distributor) sendStreamsToKafka(ctx context.Context, streams []KeyedStream, tenant string, tracker *pushTracker, subring *ring.PartitionRing) {
+func (d *Distributor) sendStreamsToKafka(ctx context.Context, streams []KeyedStream, skipMetadataHashes map[uint64]struct{}, tenant string, tracker *pushTracker, subring *ring.PartitionRing) {
 	for _, s := range streams {
 		go func(s KeyedStream) {
-			err := d.sendStreamToKafka(ctx, s, tenant, subring)
+			err := d.sendStreamToKafka(ctx, s, skipMetadataHashes, tenant, subring)
 			if err != nil {
 				err = fmt.Errorf("failed to write stream to kafka: %w", err)
 			}
@@ -1225,7 +1238,7 @@ func (d *Distributor) sendStreamsToKafka(ctx context.Context, streams []KeyedStr
 	}
 }
 
-func (d *Distributor) sendStreamToKafka(ctx context.Context, stream KeyedStream, tenant string, subring *ring.PartitionRing) error {
+func (d *Distributor) sendStreamToKafka(ctx context.Context, stream KeyedStream, skipMetadataHashes map[uint64]struct{}, tenant string, subring *ring.PartitionRing) error {
 	if len(stream.Stream.Entries) == 0 {
 		return nil
 	}
@@ -1255,25 +1268,26 @@ func (d *Distributor) sendStreamToKafka(ctx context.Context, stream KeyedStream,
 
 	entriesSize, structuredMetadataSize := calculateStreamSizes(stream.Stream)
 
-	// However, unlike stream records, the distributor writes stream metadata
-	// records to one of a fixed number of partitions, the size of which is
-	// determined ahead of time. It does not use a ring. The reason for this
-	// is that we want to be able to scale components that consume metadata
-	// records independent of ingesters.
-	metadataPartitionID := int32(stream.HashKeyNoShard % uint64(d.numMetadataPartitions))
-	metadata, err := kafka.EncodeStreamMetadata(
-		metadataPartitionID,
-		d.cfg.KafkaConfig.Topic,
-		tenant,
-		stream.HashKeyNoShard,
-		entriesSize,
-		structuredMetadataSize,
-	)
-	if err != nil {
-		return fmt.Errorf("failed to marshal metadata: %w", err)
+	if _, ok := skipMetadataHashes[stream.HashKeyNoShard]; !ok {
+		// However, unlike stream records, the distributor writes stream metadata
+		// records to one of a fixed number of partitions, the size of which is
+		// determined ahead of time. It does not use a ring. The reason for this
+		// is that we want to be able to scale components that consume metadata
+		// records independent of ingesters.
+		metadataPartitionID := int32(stream.HashKeyNoShard % uint64(d.numMetadataPartitions))
+		metadata, err := kafka.EncodeStreamMetadata(
+			metadataPartitionID,
+			d.cfg.KafkaConfig.Topic,
+			tenant,
+			stream.HashKeyNoShard,
+			entriesSize,
+			structuredMetadataSize,
+		)
+		if err != nil {
+			return fmt.Errorf("failed to marshal metadata: %w", err)
+		}
+		records = append(records, metadata)
 	}
-
-	records = append(records, metadata)
 
 	d.kafkaRecordsPerRequest.Observe(float64(len(records)))
 

--- a/pkg/distributor/ingest_limits.go
+++ b/pkg/distributor/ingest_limits.go
@@ -11,6 +11,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
+	limits_frontend "github.com/grafana/loki/v3/pkg/limits/frontend"
 	limits_frontend_client "github.com/grafana/loki/v3/pkg/limits/frontend/client"
 	"github.com/grafana/loki/v3/pkg/logproto"
 )
@@ -154,4 +155,24 @@ func newExceedsLimitsRequest(tenant string, streams []KeyedStream) (*logproto.Ex
 		Tenant:  tenant,
 		Streams: streamMetadata,
 	}, nil
+}
+
+func firstReasonForHashes(reasonsForHashes map[uint64][]string) string {
+	for _, reasons := range reasonsForHashes {
+		return humanizeReasonForHash(reasons[0])
+	}
+	return "unknown reason"
+}
+
+// TODO(grobinson): Move this to the same place where the consts
+// are defined.
+func humanizeReasonForHash(s string) string {
+	switch s {
+	case limits_frontend.ReasonExceedsMaxStreams:
+		return "max streams exceeded"
+	case limits_frontend.ReasonExceedsRateLimit:
+		return "rate limit exceeded"
+	default:
+		return s
+	}
 }

--- a/pkg/distributor/ingest_limits_test.go
+++ b/pkg/distributor/ingest_limits_test.go
@@ -26,7 +26,9 @@ type mockIngestLimitsFrontendClient struct {
 // Implements the ingestLimitsFrontendClient interface.
 func (c *mockIngestLimitsFrontendClient) exceedsLimits(_ context.Context, r *logproto.ExceedsLimitsRequest) (*logproto.ExceedsLimitsResponse, error) {
 	c.calls.Add(1)
-	require.Equal(c.t, c.expectedRequest, r)
+	if c.expectedRequest != nil {
+		require.Equal(c.t, c.expectedRequest, r)
+	}
 	if c.responseErr != nil {
 		return nil, c.responseErr
 	}

--- a/pkg/distributor/ingest_limits_test.go
+++ b/pkg/distributor/ingest_limits_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/coder/quartz"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
 
 	"github.com/grafana/loki/v3/pkg/logproto"
 )
@@ -16,6 +17,7 @@ import (
 // mockIngestLimitsFrontendClient mocks the RPC calls for tests.
 type mockIngestLimitsFrontendClient struct {
 	t               *testing.T
+	calls           atomic.Uint64
 	expectedRequest *logproto.ExceedsLimitsRequest
 	response        *logproto.ExceedsLimitsResponse
 	responseErr     error
@@ -23,6 +25,7 @@ type mockIngestLimitsFrontendClient struct {
 
 // Implements the ingestLimitsFrontendClient interface.
 func (c *mockIngestLimitsFrontendClient) exceedsLimits(_ context.Context, r *logproto.ExceedsLimitsRequest) (*logproto.ExceedsLimitsResponse, error) {
+	c.calls.Add(1)
 	require.Equal(c.t, c.expectedRequest, r)
 	if c.responseErr != nil {
 		return nil, c.responseErr

--- a/pkg/limits/frontend/frontend.go
+++ b/pkg/limits/frontend/frontend.go
@@ -191,25 +191,12 @@ func (f *Frontend) ExceedsLimits(ctx context.Context, req *logproto.ExceedsLimit
 	// Check if max streams limit would be exceeded.
 	maxGlobalStreams := f.limits.MaxGlobalStreamsPerUser(req.Tenant)
 	if activeStreamsTotal >= uint64(maxGlobalStreams) {
-		// Take the intersection of unknown streams from all responses by counting
-		// the number of occurrences. If the number of occurrences matches the
-		// number of responses, we know the stream was unknown to all instances.
-		unknownStreams := make(map[uint64]int)
 		for _, resp := range resps {
 			for _, unknownStream := range resp.Response.UnknownStreams {
-				unknownStreams[unknownStream]++
-			}
-		}
-		for _, resp := range resps {
-			for _, unknownStream := range resp.Response.UnknownStreams {
-				// If the stream is unknown to all instances, it must be a new
-				// stream.
-				if unknownStreams[unknownStream] == len(resps) {
-					results = append(results, &logproto.ExceedsLimitsResult{
-						StreamHash: unknownStream,
-						Reason:     ReasonExceedsMaxStreams,
-					})
-				}
+				results = append(results, &logproto.ExceedsLimitsResult{
+					StreamHash: unknownStream,
+					Reason:     ReasonExceedsMaxStreams,
+				})
 			}
 		}
 	}

--- a/pkg/limits/frontend/frontend_test.go
+++ b/pkg/limits/frontend/frontend_test.go
@@ -152,9 +152,9 @@ func TestFrontend_ExceedsLimits(t *testing.T) {
 	}, {
 		// This test checks the case where a tenant's streams are sharded over
 		// two instances, each holding one each stream. Each instance will
-		// return an response stating that it doesn't know about the other
-		// stream. The frontend is responsible for taking the intersection of
-		// the two responses and calculating the actual set of unknown streams.
+		// receive a request for just the streams in its assigned partitions.
+		// The frontend is responsible for taking the union of the two responses
+		// and calculating the actual set of unknown streams.
 		name: "exceeds max streams limit, streams sharded over two instances",
 		exceedsLimitsRequest: &logproto.ExceedsLimitsRequest{
 			Tenant: "test",
@@ -182,14 +182,16 @@ func TestFrontend_ExceedsLimits(t *testing.T) {
 			Tenant:       "test",
 			StreamHashes: []uint64{0x1},
 		}},
-		// Each instance will respond stating that it doesn't know about the
-		// other stream.
 		getStreamUsageResponses: []*logproto.GetStreamUsageResponse{{
 			Tenant:         "test",
 			ActiveStreams:  1,
 			Rate:           5,
-			UnknownStreams: []uint64{0x2},
+			UnknownStreams: nil,
 		}, {
+			// Instance 1 responds that it does not know about stream
+			// 0x1. Since 0x1 shards to partition 1, and partition 1
+			// is consumed by instance 1, the frontend knows that 0x1
+			// is an unknown stream.
 			Tenant:         "test",
 			ActiveStreams:  1,
 			Rate:           5,
@@ -197,8 +199,9 @@ func TestFrontend_ExceedsLimits(t *testing.T) {
 		}},
 		maxGlobalStreams: 1,
 		ingestionRate:    100,
-		// No streams should be returned.
-		expected: nil,
+		expected: []*logproto.ExceedsLimitsResult{
+			{StreamHash: 0x1, Reason: ReasonExceedsMaxStreams},
+		},
 	}, {
 		name: "exceeds rate limits, returns all streams",
 		exceedsLimitsRequest: &logproto.ExceedsLimitsRequest{


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request backports a number of PRs to k250:

```
2cde9b12e fix: skip streams over limits in dry-run mode (#17114)
805125c70 fix: fix a bug where limits were incorrect after grafana/loki#16937 (#17224)
d106042f0 fix: fix bug where expectedStreamUsageRequest was not used (#17223)
69aeda1bb feat: add tests for enforcing limits in distributors (#17124)
```

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
