### PR TITLE
refactor(stringlabels): Support stringlabels in querier

### DIFF
--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -1193,13 +1193,13 @@ func parseEntry(entry push.Entry, lbls *logql_log.LabelsBuilder) (map[string][]s
 	}
 
 	lblsResult := lbls.LabelsResult().Parsed()
-	for _, lbl := range lblsResult {
+	lblsResult.Range(func(lbl labels.Label) {
 		if values, ok := parsedLabels[lbl.Name]; ok {
 			values[lbl.Value] = struct{}{}
 		} else {
 			parsedLabels[lbl.Name] = map[string]struct{}{lbl.Value: {}}
 		}
-	}
+	})
 
 	result := make(map[string][]string, len(parsedLabels))
 	for lbl, values := range parsedLabels {

--- a/pkg/querier/queryrange/detected_fields.go
+++ b/pkg/querier/queryrange/detected_fields.go
@@ -434,13 +434,13 @@ func parseEntry(entry push.Entry, lbls *logql_log.LabelsBuilder) (map[string][]s
 	}
 
 	lblsResult := lblBuilder.LabelsResult().Parsed()
-	for _, lbl := range lblsResult {
+	lblsResult.Range(func(lbl labels.Label) {
 		if values, ok := parsedLabels[lbl.Name]; ok {
 			values[lbl.Value] = struct{}{}
 		} else {
 			parsedLabels[lbl.Name] = map[string]struct{}{lbl.Value: {}}
 		}
-	}
+	})
 
 	result := make(map[string][]string, len(parsedLabels))
 	for lbl, values := range parsedLabels {

--- a/pkg/querier/queryrange/downstreamer.go
+++ b/pkg/querier/queryrange/downstreamer.go
@@ -223,10 +223,11 @@ func sampleStreamToMatrix(streams []queryrangebase.SampleStream) parser.Value {
 	xs := make(promql.Matrix, 0, len(streams))
 	for _, stream := range streams {
 		x := promql.Series{}
-		x.Metric = make(labels.Labels, 0, len(stream.Labels))
+		lblsBuilder := labels.NewScratchBuilder(len(stream.Labels))
 		for _, l := range stream.Labels {
-			x.Metric = append(x.Metric, labels.Label(l))
+			lblsBuilder.Add(l.Name, l.Value)
 		}
+		x.Metric = lblsBuilder.Labels()
 
 		x.Floats = make([]promql.FPoint, 0, len(stream.Samples))
 		for _, sample := range stream.Samples {
@@ -245,10 +246,11 @@ func sampleStreamToVector(streams []queryrangebase.SampleStream) parser.Value {
 	xs := make(promql.Vector, 0, len(streams))
 	for _, stream := range streams {
 		x := promql.Sample{}
-		x.Metric = make(labels.Labels, 0, len(stream.Labels))
+		lblsBuilder := labels.NewScratchBuilder(len(stream.Labels))
 		for _, l := range stream.Labels {
-			x.Metric = append(x.Metric, labels.Label(l))
+			lblsBuilder.Add(l.Name, l.Value)
 		}
+		x.Metric = lblsBuilder.Labels()
 
 		x.T = stream.Samples[0].TimestampMs
 		x.F = stream.Samples[0].Value

--- a/pkg/querier/queryrange/parquet.go
+++ b/pkg/querier/queryrange/parquet.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/parquet-go/parquet-go"
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
 
 	serverutil "github.com/grafana/loki/v3/pkg/util/server"
@@ -92,9 +93,9 @@ func encodeLogsParquetTo(response *LokiResponse, w io.Writer) error {
 			return err
 		}
 		lblsMap := make(map[string]string)
-		for _, keyValue := range lbls {
-			lblsMap[keyValue.Name] = keyValue.Value
-		}
+		lbls.Range(func(lbl labels.Label) {
+			lblsMap[lbl.Name] = lbl.Value
+		})
 
 		for _, entry := range stream.Entries {
 			row := LogStreamRowType{

--- a/pkg/querier/queryrange/queryrangebase/value.go
+++ b/pkg/querier/queryrange/queryrangebase/value.go
@@ -68,10 +68,10 @@ func FromValue(value parser.Value) ([]SampleStream, error) {
 }
 
 func mapLabels(ls labels.Labels) []logproto.LabelAdapter {
-	result := make([]logproto.LabelAdapter, 0, len(ls))
-	for _, l := range ls {
+	result := make([]logproto.LabelAdapter, 0, ls.Len())
+	ls.Range(func(l labels.Label) {
 		result = append(result, logproto.LabelAdapter(l))
-	}
+	})
 
 	return result
 }
@@ -125,11 +125,11 @@ func NewSeriesSet(results []SampleStream) storage.SeriesSet {
 			})
 		}
 
-		ls := make([]labels.Label, 0, len(stream.Labels))
+		lsBuilder := labels.NewScratchBuilder(len(stream.Labels))
 		for _, l := range stream.Labels {
-			ls = append(ls, labels.Label(l))
+			lsBuilder.Add(l.Name, l.Value)
 		}
-		set = append(set, series.NewConcreteSeries(ls, samples))
+		set = append(set, series.NewConcreteSeries(lsBuilder.Labels(), samples))
 	}
 	return series.NewConcreteSeriesSet(set)
 }

--- a/pkg/querier/queryrange/volume.go
+++ b/pkg/querier/queryrange/volume.go
@@ -170,10 +170,7 @@ func toPrometheusData(series map[string][]logproto.LegacySample, aggregateBySeri
 		if aggregateBySeries {
 			lbls, err = syntax.ParseLabels(name)
 		} else {
-			lbls = labels.Labels{{
-				Name:  name,
-				Value: "",
-			}}
+			lbls = labels.FromStrings(name, "")
 		}
 
 		if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a next step of support Prometheus `stringlabels` implementation in Loki. It adds support in the `querier` package.

**Special notes for your reviewer**:
The tests should compile with build tag `stringlabels`.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
