### PR TITLE
refactor(stringlabels): Support stringlabels in ingester

### DIFF
--- a/pkg/ingester/client/compat.go
+++ b/pkg/ingester/client/compat.go
@@ -37,13 +37,13 @@ func FastFingerprint(ls []logproto.LabelAdapter) model.Fingerprint {
 }
 
 // Fingerprint runs the same algorithm as Prometheus labelSetToFingerprint()
-func Fingerprint(labels labels.Labels) model.Fingerprint {
+func Fingerprint(lbls labels.Labels) model.Fingerprint {
 	sum := hashNew()
-	for _, label := range labels {
+	lbls.Range(func(label labels.Label) {
 		sum = hashAddString(sum, label.Name)
 		sum = hashAddByte(sum, model.SeparatorByte)
 		sum = hashAddString(sum, label.Value)
 		sum = hashAddByte(sum, model.SeparatorByte)
-	}
+	})
 	return model.Fingerprint(sum)
 }

--- a/pkg/ingester/flush.go
+++ b/pkg/ingester/flush.go
@@ -320,7 +320,7 @@ func (i *Ingester) collectChunksToFlush(instance *instance, fp model.Fingerprint
 	stream, ok = instance.streams.LoadByFP(fp)
 
 	if !ok {
-		return nil, nil, nil
+		return nil, labels.EmptyLabels(), nil
 	}
 
 	stream.chunkMtx.Lock()

--- a/pkg/ingester/index/bitprefix_test.go
+++ b/pkg/ingester/index/bitprefix_test.go
@@ -183,14 +183,14 @@ func Test_BitPrefixDeleteAddLoopkup(t *testing.T) {
 }
 
 func Test_BitPrefix_hash_mapping(t *testing.T) {
-	lbs := labels.Labels{
-		labels.Label{Name: "compose_project", Value: "loki-tsdb-storage-s3"},
-		labels.Label{Name: "compose_service", Value: "ingester-2"},
-		labels.Label{Name: "container_name", Value: "loki-tsdb-storage-s3_ingester-2_1"},
-		labels.Label{Name: "filename", Value: "/var/log/docker/790fef4c6a587c3b386fe85c07e03f3a1613f4929ca3abaa4880e14caadb5ad1/json.log"},
-		labels.Label{Name: "host", Value: "docker-desktop"},
-		labels.Label{Name: "source", Value: "stderr"},
-	}
+	lbs := labels.FromStrings(
+		"compose_project", "loki-tsdb-storage-s3",
+		"compose_service", "ingester-2",
+		"container_name", "loki-tsdb-storage-s3_ingester-2_1",
+		"filename", "/var/log/docker/790fef4c6a587c3b386fe85c07e03f3a1613f4929ca3abaa4880e14caadb5ad1/json.log",
+		"host", "docker-desktop",
+		"source", "stderr",
+	)
 
 	// for _, shard := range []uint32{2, 4, 8, 16, 32, 64, 128} {
 	for _, shard := range []uint32{2} {
@@ -223,10 +223,10 @@ func Test_BitPrefix_hash_mapping(t *testing.T) {
 }
 
 func Test_BitPrefixNoMatcherLookup(t *testing.T) {
-	lbs := labels.Labels{
-		labels.Label{Name: "foo", Value: "bar"},
-		labels.Label{Name: "hi", Value: "hello"},
-	}
+	lbs := labels.FromStrings(
+		"foo", "bar",
+		"hi", "hello",
+	)
 	// with no shard param
 	ii, err := NewBitPrefixWithShards(16)
 	require.Nil(t, err)
@@ -253,10 +253,10 @@ func Test_BitPrefixConsistentMapping(t *testing.T) {
 	require.Nil(t, err)
 
 	for i := 0; i < 100; i++ {
-		lbs := labels.Labels{
-			labels.Label{Name: "foo", Value: "bar"},
-			labels.Label{Name: "hi", Value: fmt.Sprint(i)},
-		}
+		lbs := labels.FromStrings(
+			"foo", "bar",
+			"hi", fmt.Sprint(i),
+		)
 
 		fp := model.Fingerprint(lbs.Hash())
 		a.Add(logproto.FromLabelsToLabelAdapters(lbs), fp)

--- a/pkg/ingester/index/index_test.go
+++ b/pkg/ingester/index/index_test.go
@@ -97,14 +97,14 @@ func TestDeleteAddLoopkup(t *testing.T) {
 }
 
 func Test_hash_mapping(t *testing.T) {
-	lbs := labels.Labels{
-		labels.Label{Name: "compose_project", Value: "loki-tsdb-storage-s3"},
-		labels.Label{Name: "compose_service", Value: "ingester-2"},
-		labels.Label{Name: "container_name", Value: "loki-tsdb-storage-s3_ingester-2_1"},
-		labels.Label{Name: "filename", Value: "/var/log/docker/790fef4c6a587c3b386fe85c07e03f3a1613f4929ca3abaa4880e14caadb5ad1/json.log"},
-		labels.Label{Name: "host", Value: "docker-desktop"},
-		labels.Label{Name: "source", Value: "stderr"},
-	}
+	lbs := labels.FromStrings(
+		"compose_project", "loki-tsdb-storage-s3",
+		"compose_service", "ingester-2",
+		"container_name", "loki-tsdb-storage-s3_ingester-2_1",
+		"filename", "/var/log/docker/790fef4c6a587c3b386fe85c07e03f3a1613f4929ca3abaa4880e14caadb5ad1/json.log",
+		"host", "docker-desktop",
+		"source", "stderr",
+	)
 
 	for _, shard := range []uint32{16, 32, 64, 128} {
 		t.Run(fmt.Sprintf("%d", shard), func(t *testing.T) {
@@ -121,10 +121,10 @@ func Test_hash_mapping(t *testing.T) {
 }
 
 func Test_NoMatcherLookup(t *testing.T) {
-	lbs := labels.Labels{
-		labels.Label{Name: "foo", Value: "bar"},
-		labels.Label{Name: "hi", Value: "hello"},
-	}
+	lbs := labels.FromStrings(
+		"foo", "bar",
+		"hi", "hello",
+	)
 	// with no shard param
 	ii := NewWithShards(16)
 	ii.Add(logproto.FromLabelsToLabelAdapters(lbs), 1)
@@ -146,10 +146,10 @@ func Test_ConsistentMapping(t *testing.T) {
 	b := NewWithShards(32)
 
 	for i := 0; i < 100; i++ {
-		lbs := labels.Labels{
-			labels.Label{Name: "foo", Value: "bar"},
-			labels.Label{Name: "hi", Value: fmt.Sprint(i)},
-		}
+		lbs := labels.FromStrings(
+			"foo", "bar",
+			"hi", fmt.Sprint(i),
+		)
 		a.Add(logproto.FromLabelsToLabelAdapters(lbs), model.Fingerprint(i))
 		b.Add(logproto.FromLabelsToLabelAdapters(lbs), model.Fingerprint(i))
 	}

--- a/pkg/ingester/index/multi.go
+++ b/pkg/ingester/index/multi.go
@@ -107,7 +107,7 @@ func (m *Multi) indexFor(t time.Time) Interface {
 type noopInvertedIndex struct{}
 
 func (noopInvertedIndex) Add(_ []logproto.LabelAdapter, _ model.Fingerprint) labels.Labels {
-	return nil
+	return labels.EmptyLabels()
 }
 
 func (noopInvertedIndex) Delete(_ labels.Labels, _ model.Fingerprint) {}

--- a/pkg/ingester/mapper.go
+++ b/pkg/ingester/mapper.go
@@ -59,7 +59,7 @@ func (m *FpMapper) MapFP(fp model.Fingerprint, metric labels.Labels) model.Finge
 	// Then check the most likely case: This fp belongs to a series that is
 	// already in memory.
 	s := m.fpToLabels(fp)
-	if s != nil {
+	if !s.IsEmpty() {
 		// FP exists in memory, but is it for the same metric?
 		if labels.Equal(metric, s) {
 			// Yupp. We are done.
@@ -143,10 +143,10 @@ func (m *FpMapper) nextMappedFP() model.Fingerprint {
 // and indexes as it might become really large, causing a lot of hashing effort
 // in maps and a lot of storage overhead in indexes.
 func metricToUniqueString(m labels.Labels) string {
-	parts := make([]string, 0, len(m))
-	for _, pair := range m {
-		parts = append(parts, pair.Name+separatorString+pair.Value)
-	}
+	parts := make([]string, 0, m.Len())
+	m.Range(func(l labels.Label) {
+		parts = append(parts, l.Name+separatorString+l.Value)
+	})
 	sort.Strings(parts)
 	return strings.Join(parts, separatorString)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a next step of support Prometheus `stringlabels` implementation in Loki. It adds support in the `ingester` package.

**Special notes for your reviewer**:
The tests should compile with build tag `stringlabels`.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
