### PR TITLE
chore(engine): Add framework for query executor

### DIFF
--- a/pkg/engine/executor/executor.go
+++ b/pkg/engine/executor/executor.go
@@ -1,0 +1,109 @@
+package executor
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/grafana/loki/v3/pkg/engine/planner/physical"
+)
+
+type Config struct {
+	BatchSize int64 `yaml:"batch_size"`
+}
+
+func Run(ctx context.Context, cfg Config, plan *physical.Plan) Pipeline {
+	c := &Context{
+		plan:      plan,
+		batchSize: cfg.BatchSize,
+	}
+	if plan == nil {
+		return errorPipeline(errors.New("plan is nil"))
+	}
+	node, err := plan.Root()
+	if err != nil {
+		return errorPipeline(err)
+	}
+	return c.execute(ctx, node)
+}
+
+// Context is the execution context
+type Context struct {
+	batchSize int64
+	plan      *physical.Plan
+}
+
+func (c *Context) execute(ctx context.Context, node physical.Node) Pipeline {
+	children := c.plan.Children(node)
+	inputs := make([]Pipeline, 0, len(children))
+	for _, child := range children {
+		inputs = append(inputs, c.execute(ctx, child))
+	}
+
+	switch n := node.(type) {
+	case *physical.DataObjScan:
+		return c.executeDataObjScan(ctx, n)
+	case *physical.SortMerge:
+		return c.executeSortMerge(ctx, n, inputs)
+	case *physical.Limit:
+		return c.executeLimit(ctx, n, inputs)
+	case *physical.Filter:
+		return c.executeFilter(ctx, n, inputs)
+	case *physical.Projection:
+		return c.executeProjection(ctx, n, inputs)
+	default:
+		return errorPipeline(fmt.Errorf("invalid node type: %T", node))
+	}
+}
+
+func (c *Context) executeDataObjScan(_ context.Context, _ *physical.DataObjScan) Pipeline {
+	return errorPipeline(errNotImplemented)
+}
+
+func (c *Context) executeSortMerge(_ context.Context, _ *physical.SortMerge, inputs []Pipeline) Pipeline {
+	if len(inputs) == 0 {
+		return emptyPipeline()
+	}
+
+	return errorPipeline(errNotImplemented)
+}
+
+func (c *Context) executeLimit(_ context.Context, _ *physical.Limit, inputs []Pipeline) Pipeline {
+	if len(inputs) == 0 {
+		return emptyPipeline()
+	}
+
+	if len(inputs) > 1 {
+		return errorPipeline(fmt.Errorf("limit expects exactly one input, got %d", len(inputs)))
+	}
+
+	return errorPipeline(errNotImplemented)
+}
+
+func (c *Context) executeFilter(_ context.Context, _ *physical.Filter, inputs []Pipeline) Pipeline {
+	if len(inputs) == 0 {
+		return emptyPipeline()
+	}
+
+	if len(inputs) > 1 {
+		return errorPipeline(fmt.Errorf("filter expects exactly one input, got %d", len(inputs)))
+	}
+
+	return errorPipeline(errNotImplemented)
+}
+
+func (c *Context) executeProjection(_ context.Context, proj *physical.Projection, inputs []Pipeline) Pipeline {
+	if len(inputs) == 0 {
+		return emptyPipeline()
+	}
+
+	if len(inputs) > 1 {
+		return errorPipeline(fmt.Errorf("projection expects exactly one input, got %d", len(inputs)))
+	}
+
+	if len(proj.Columns) == 0 {
+		return errorPipeline(fmt.Errorf("projection expects at least one column, got 0"))
+	}
+
+	return errorPipeline(errNotImplemented)
+}

--- a/pkg/engine/executor/executor_test.go
+++ b/pkg/engine/executor/executor_test.go
@@ -1,0 +1,134 @@
+package executor
+
+import (
+	"context"
+	"testing"
+
+	"github.com/grafana/loki/v3/pkg/engine/internal/types"
+	"github.com/grafana/loki/v3/pkg/engine/planner/physical"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExecutor(t *testing.T) {
+	t.Run("pipeline fails if plan is nil", func(t *testing.T) {
+		pipeline := Run(context.TODO(), Config{}, nil)
+		err := pipeline.Read()
+		require.ErrorContains(t, err, "failed to execute pipeline: plan is nil")
+	})
+
+	t.Run("pipeline fails if plan has no root node", func(t *testing.T) {
+		pipeline := Run(context.TODO(), Config{}, &physical.Plan{})
+		err := pipeline.Read()
+		require.ErrorContains(t, err, "failed to execute pipeline: plan has no root node")
+	})
+}
+
+func TestExecutor_DataObjScan(t *testing.T) {
+	t.Run("is not implemented", func(t *testing.T) {
+		c := &Context{}
+		pipeline := c.executeDataObjScan(context.TODO(), &physical.DataObjScan{})
+		err := pipeline.Read()
+		require.ErrorContains(t, err, errNotImplemented.Error())
+	})
+}
+
+func TestExecutor_SortMerge(t *testing.T) {
+	t.Run("no inputs result in empty pipeline", func(t *testing.T) {
+		c := &Context{}
+		pipeline := c.executeSortMerge(context.TODO(), &physical.SortMerge{}, nil)
+		err := pipeline.Read()
+		require.ErrorContains(t, err, EOF.Error())
+	})
+
+	t.Run("is not implemented", func(t *testing.T) {
+		c := &Context{}
+		pipeline := c.executeSortMerge(context.TODO(), &physical.SortMerge{}, []Pipeline{emptyPipeline()})
+		err := pipeline.Read()
+		require.ErrorContains(t, err, errNotImplemented.Error())
+	})
+}
+
+func TestExecutor_Limit(t *testing.T) {
+	t.Run("no inputs result in empty pipeline", func(t *testing.T) {
+		c := &Context{}
+		pipeline := c.executeLimit(context.TODO(), &physical.Limit{}, nil)
+		err := pipeline.Read()
+		require.ErrorContains(t, err, EOF.Error())
+	})
+
+	t.Run("is not implemented", func(t *testing.T) {
+		c := &Context{}
+		pipeline := c.executeLimit(context.TODO(), &physical.Limit{}, []Pipeline{emptyPipeline()})
+		err := pipeline.Read()
+		require.ErrorContains(t, err, errNotImplemented.Error())
+	})
+
+	t.Run("multiple inputs result in error", func(t *testing.T) {
+		c := &Context{}
+		pipeline := c.executeLimit(context.TODO(), &physical.Limit{}, []Pipeline{emptyPipeline(), emptyPipeline()})
+		err := pipeline.Read()
+		require.ErrorContains(t, err, "limit expects exactly one input, got 2")
+	})
+}
+
+func TestExecutor_Filter(t *testing.T) {
+	t.Run("no inputs result in empty pipeline", func(t *testing.T) {
+		c := &Context{}
+		pipeline := c.executeFilter(context.TODO(), &physical.Filter{}, nil)
+		err := pipeline.Read()
+		require.ErrorContains(t, err, EOF.Error())
+	})
+
+	t.Run("is not implemented", func(t *testing.T) {
+		c := &Context{}
+		pipeline := c.executeFilter(context.TODO(), &physical.Filter{}, []Pipeline{emptyPipeline()})
+		err := pipeline.Read()
+		require.ErrorContains(t, err, errNotImplemented.Error())
+	})
+
+	t.Run("multiple inputs result in error", func(t *testing.T) {
+		c := &Context{}
+		pipeline := c.executeFilter(context.TODO(), &physical.Filter{}, []Pipeline{emptyPipeline(), emptyPipeline()})
+		err := pipeline.Read()
+		require.ErrorContains(t, err, "filter expects exactly one input, got 2")
+	})
+}
+
+func TestExecutor_Projection(t *testing.T) {
+	t.Run("no inputs result in empty pipeline", func(t *testing.T) {
+		c := &Context{}
+		pipeline := c.executeProjection(context.TODO(), &physical.Projection{}, nil)
+		err := pipeline.Read()
+		require.ErrorContains(t, err, EOF.Error())
+	})
+
+	t.Run("missing column expression results in error", func(t *testing.T) {
+		cols := []physical.ColumnExpression{}
+		c := &Context{}
+		pipeline := c.executeProjection(context.TODO(), &physical.Projection{Columns: cols}, []Pipeline{emptyPipeline()})
+		err := pipeline.Read()
+		require.ErrorContains(t, err, "projection expects at least one column, got 0")
+	})
+
+	t.Run("is not implemented", func(t *testing.T) {
+		cols := []physical.ColumnExpression{
+			&physical.ColumnExpr{
+				Ref: types.ColumnRef{
+					Column: "a",
+					Type:   types.ColumnTypeBuiltin,
+				},
+			},
+		}
+		c := &Context{}
+		pipeline := c.executeProjection(context.TODO(), &physical.Projection{Columns: cols}, []Pipeline{emptyPipeline()})
+		err := pipeline.Read()
+		require.ErrorContains(t, err, errNotImplemented.Error())
+	})
+
+	t.Run("multiple inputs result in error", func(t *testing.T) {
+		c := &Context{}
+		pipeline := c.executeProjection(context.TODO(), &physical.Projection{}, []Pipeline{emptyPipeline(), emptyPipeline()})
+		err := pipeline.Read()
+		require.ErrorContains(t, err, "projection expects exactly one input, got 2")
+	})
+}

--- a/pkg/engine/executor/executor_test.go
+++ b/pkg/engine/executor/executor_test.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/grafana/loki/v3/pkg/engine/internal/types"
 	"github.com/grafana/loki/v3/pkg/engine/planner/physical"
-	"github.com/stretchr/testify/require"
 )
 
 func TestExecutor(t *testing.T) {

--- a/pkg/engine/executor/pipeline.go
+++ b/pkg/engine/executor/pipeline.go
@@ -1,0 +1,122 @@
+package executor
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/apache/arrow-go/v18/arrow"
+)
+
+type Transport uint8
+
+const (
+	_ Transport = iota
+	Local
+	Remote
+)
+
+// Pipeline represents a data processing pipeline that can read Arrow records.
+// It provides methods to read data, access the current record, and close resources.
+type Pipeline interface {
+	// Read reads the next value into its state.
+	// It returns an error if reading fails or when the pipeline is exhausted. In this case, the function returns EOF.
+	// The implementation must retain the returned error in its state and return it with subsequent Value() calls.
+	Read() error
+	// Value returns the current value in state.
+	Value() (arrow.Record, error)
+	// Close closes the resources of the pipeline.
+	// The implementation must close all the of the pipeline's inputs.
+	Close()
+	// Inputs returns the inputs of the pipeline.
+	Inputs() []Pipeline
+	// Transport returns the type of transport of the implementation.
+	Transport() Transport
+}
+
+var (
+	errNotImplemented = errors.New("pipeline not implemented")
+
+	EOF       = errors.New("pipeline exhausted") // nolint:revive
+	Exhausted = failureState(EOF)
+)
+
+type state struct {
+	batch arrow.Record
+	err   error
+}
+
+func (s state) Value() (arrow.Record, error) {
+	return s.batch, s.err
+}
+
+func failureState(err error) state {
+	return state{err: err}
+}
+
+func successState(batch arrow.Record) state {
+	return state{batch: batch}
+}
+
+func newState(batch arrow.Record, err error) state {
+	return state{batch: batch, err: err}
+}
+
+type GenericPipeline struct {
+	t      Transport
+	inputs []Pipeline
+	state  state
+	read   func([]Pipeline) state
+}
+
+func newGenericPipeline(t Transport, read func([]Pipeline) state, inputs ...Pipeline) *GenericPipeline {
+	return &GenericPipeline{
+		t:      t,
+		read:   read,
+		inputs: inputs,
+	}
+}
+
+var _ Pipeline = (*GenericPipeline)(nil)
+
+// Inputs implements Pipeline.
+func (p *GenericPipeline) Inputs() []Pipeline {
+	return p.inputs
+}
+
+// Value implements Pipeline.
+func (p *GenericPipeline) Value() (arrow.Record, error) {
+	return p.state.Value()
+}
+
+// Read implements Pipeline.
+func (p *GenericPipeline) Read() error {
+	if p.read == nil {
+		return EOF
+	}
+	p.state = p.read(p.inputs)
+	return p.state.err
+}
+
+// Close implements Pipeline.
+func (p *GenericPipeline) Close() {
+	for _, inp := range p.inputs {
+		inp.Close()
+	}
+}
+
+// Transport implements Pipeline.
+func (p *GenericPipeline) Transport() Transport {
+	return p.t
+}
+
+func errorPipeline(err error) Pipeline {
+	return newGenericPipeline(Local, func(_ []Pipeline) state {
+		return state{err: fmt.Errorf("failed to execute pipeline: %w", err)}
+	})
+}
+
+func emptyPipeline() Pipeline {
+	return newGenericPipeline(Local, func(_ []Pipeline) state {
+		return Exhausted
+	})
+}

--- a/pkg/engine/planner/physical/plan.go
+++ b/pkg/engine/planner/physical/plan.go
@@ -264,6 +264,17 @@ func (p *Plan) Roots() []Node {
 	return roots
 }
 
+// Root returns the root node that have no parents. It returns an error if the plan has no or multiple root nodes.
+func (p *Plan) Root() (Node, error) {
+	roots := p.Roots()
+	if len(roots) == 0 {
+		return nil, errors.New("plan has no root node")
+	} else if len(roots) > 1 {
+		return nil, errors.New("plan has multiple root nodes")
+	}
+	return roots[0], nil
+}
+
 // Leaves returns all nodes that have no children
 func (p *Plan) Leaves() []Node {
 	if len(p.nodes) == 0 {


### PR DESCRIPTION
This PR implements a framework for basic local query execution using pull-based iterators. These iterators are defined by the `Pipeline` interface.

```go
// Pipeline represents a data processing pipeline that can read Arrow records.
// It provides methods to read data, access the current record, and close resources.
type Pipeline interface {
	// Read reads the next value into its state.
	// It returns an error if reading fails or when the pipeline is exhausted. In this case, the function returns EOF.
	// The implementation must retain the returned error in its state and return it with subsequent Value() calls.
	Read() error
	// Value returns the current value in state.
	Value() (arrow.Record, error)
	// Close closes the resources of the pipeline.
	// The implementation must close all the of the pipeline's inputs.
	Close()
	// Inputs returns the inputs of the pipeline.
	Inputs() []Pipeline
	// Transport returns the type of transport of the implementation.
	Transport() Transport
}
```

Pipelines can be chained and the parent pulls results from its children by calling `Read()`. 

This PR does not implement the pipelines created from physical nodes, only some basic validation.