### PR TITLE
fix: period_config table prefix key schema check

### DIFF
--- a/pkg/storage/config/schema_config_test.go
+++ b/pkg/storage/config/schema_config_test.go
@@ -170,6 +170,22 @@ func TestSchemaConfig_Validate(t *testing.T) {
 			},
 			err: nil,
 		},
+		"should fail on index table prefix ending in path delimiter": {
+			config: &SchemaConfig{
+				Configs: []PeriodConfig{
+					{
+						Schema: "v13",
+						IndexTables: IndexPeriodicTableConfig{
+							PathPrefix: "index/",
+							PeriodicTableConfig: PeriodicTableConfig{
+								Prefix: "v13/key_",
+							},
+						},
+					},
+				},
+			},
+			err: errInvalidTablePrefixValue,
+		},
 		"should pass on index and chunk table period set to zero (no period tables)": {
 			config: &SchemaConfig{
 				Configs: []PeriodConfig{


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds tests and a schema check to prevent a user from setting the [prefix](https://grafana.com/docs/loki/v3.4.x/configure/#period_config) key on the `period_config` to a value containing a path delimiter

**Which issue(s) this PR fixes**:
Fixes #17232

**Special notes for your reviewer**:

I updated this buildCache block to be more readable to myself, if you don't like my change, I can revert with no functionality loss
https://github.com/grafana/loki/blob/6818c90011627b83c50eb9f23c53e1769abb46a7/pkg/storage/stores/shipper/indexshipper/storage/cached_client.go#L300-L320 

**Other**:

1. I could only find examples using `some_prefix_term_` in the [schema_config_test.go](https://github.com/grafana/loki/blob/f691cdf0e499a87f937466d5c4d027b573b1d321/pkg/storage/config/schema_config_test.go) file and could not determine if it is intentional that this field contain a path delimiter, the cache client won't be able to deal with it either way.
2. This will effect the `chunks.prefix` as well. If this is intended to contain a delimiter, let me know, I can move the check to the `IndexPeriodicTableConfig` which should not effect the `chunks.prefix`
3. Should I update the documentation as well? Will it be auto generated or do I need to update it there too?
4. should I update the upgrade doc for this?

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
