### PR TITLE
chore(dataobj): correct stats calculation for prepredicate bytes read

### DIFF
--- a/pkg/dataobj/internal/dataset/dataset.go
+++ b/pkg/dataobj/internal/dataset/dataset.go
@@ -88,10 +88,20 @@ type Row struct {
 	Values []Value // Values for the row, one per [Column].
 }
 
+// Size returns the size of all values in the row.
 func (r Row) Size() int64 {
 	var size int64
 	for _, v := range r.Values {
 		size += int64(v.Size())
+	}
+	return size
+}
+
+// SizeOfColumns returns the size of values in the row for the given column indices.
+func (r Row) SizeOfColumns(idxs []int) int64 {
+	var size int64
+	for _, idx := range idxs {
+		size += int64(r.Values[idx].Size())
 	}
 	return size
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Calling `Size()` on a row calculates the total size of all values in it. But we cannot call this to calculate the size of reads for primary columns since the rest of the column values are not guaranteed to be nil as we reuse the `Values` slice in a row across reads. This pr updates the stats calculation to only read the size of primary columns. Also adds a test to check the stats and updated some names for clarity.

I could spot a difference in bytes processed when running benchmarks, but it does not show up in the unit test since the buffer gets reset on each run

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
