### PR TITLE
feat(Dataobj executor limit)

### DIFF
--- a/pkg/engine/executor/executor.go
+++ b/pkg/engine/executor/executor.go
@@ -68,7 +68,7 @@ func (c *Context) executeSortMerge(_ context.Context, _ *physical.SortMerge, inp
 	return errorPipeline(errNotImplemented)
 }
 
-func (c *Context) executeLimit(_ context.Context, _ *physical.Limit, inputs []Pipeline) Pipeline {
+func (c *Context) executeLimit(_ context.Context, limit *physical.Limit, inputs []Pipeline) Pipeline {
 	if len(inputs) == 0 {
 		return emptyPipeline()
 	}
@@ -77,7 +77,7 @@ func (c *Context) executeLimit(_ context.Context, _ *physical.Limit, inputs []Pi
 		return errorPipeline(fmt.Errorf("limit expects exactly one input, got %d", len(inputs)))
 	}
 
-	return errorPipeline(errNotImplemented)
+	return NewLimitPipeline(inputs[0], limit.Skip, limit.Fetch)
 }
 
 func (c *Context) executeFilter(_ context.Context, _ *physical.Filter, inputs []Pipeline) Pipeline {

--- a/pkg/engine/executor/executor_test.go
+++ b/pkg/engine/executor/executor_test.go
@@ -49,29 +49,6 @@ func TestExecutor_SortMerge(t *testing.T) {
 	})
 }
 
-func TestExecutor_Limit(t *testing.T) {
-	t.Run("no inputs result in empty pipeline", func(t *testing.T) {
-		c := &Context{}
-		pipeline := c.executeLimit(context.TODO(), &physical.Limit{}, nil)
-		err := pipeline.Read()
-		require.ErrorContains(t, err, EOF.Error())
-	})
-
-	t.Run("is not implemented", func(t *testing.T) {
-		c := &Context{}
-		pipeline := c.executeLimit(context.TODO(), &physical.Limit{}, []Pipeline{emptyPipeline()})
-		err := pipeline.Read()
-		require.ErrorContains(t, err, errNotImplemented.Error())
-	})
-
-	t.Run("multiple inputs result in error", func(t *testing.T) {
-		c := &Context{}
-		pipeline := c.executeLimit(context.TODO(), &physical.Limit{}, []Pipeline{emptyPipeline(), emptyPipeline()})
-		err := pipeline.Read()
-		require.ErrorContains(t, err, "limit expects exactly one input, got 2")
-	})
-}
-
 func TestExecutor_Filter(t *testing.T) {
 	t.Run("no inputs result in empty pipeline", func(t *testing.T) {
 		c := &Context{}

--- a/pkg/engine/executor/limit.go
+++ b/pkg/engine/executor/limit.go
@@ -1,0 +1,135 @@
+package executor
+
+import (
+	"github.com/apache/arrow-go/v18/arrow"
+)
+
+// LimitPipeline implements a pipeline that limits the number of rows it returns.
+// It applies skip (offset) and fetch (limit) to its input pipeline.
+type LimitPipeline struct {
+	input      Pipeline
+	skip       uint32 // Number of rows to skip
+	fetch      uint32 // Max number of rows to fetch
+	state      state
+	rowsOutput int64 // Rows output so far
+}
+
+// NewLimitPipeline creates a new LimitPipeline with the given input, skip, and fetch values.
+func NewLimitPipeline(input Pipeline, skip, fetch uint32) *LimitPipeline {
+	return &LimitPipeline{
+		input:      input,
+		skip:       skip,
+		fetch:      fetch,
+		rowsOutput: 0,
+		state:      failureState(EOF),
+	}
+}
+
+// Read implements Pipeline.
+// It reads from the input pipeline, skipping rows as necessary and stopping when the fetch limit is reached.
+func (p *LimitPipeline) Read() error {
+	// If we've already fetched the requested number of rows, return EOF
+	if p.fetch > 0 && p.rowsOutput >= int64(p.fetch) {
+		p.state = failureState(EOF)
+		return EOF
+	}
+
+	// Release previous record if exists
+	if p.state.batch != nil {
+		p.state.batch.Release()
+		p.state.batch = nil
+	}
+
+	// Read from input
+	err := p.input.Read()
+	if err != nil {
+		p.state = failureState(err)
+		return err
+	}
+
+	// Get batch from input
+	batch, err := p.input.Value()
+	if err != nil {
+		p.state = failureState(err)
+		return err
+	}
+
+	numRows := batch.NumRows()
+
+	// If we still need to skip rows
+	if p.skip > 0 {
+		// If we need to skip more rows than in this batch, skip the whole batch
+		if p.skip >= uint32(numRows) {
+			p.skip -= uint32(numRows)
+			batch.Release()
+			return p.Read()
+		}
+
+		// Skip partial batch
+		startIdx := int64(p.skip)
+		endIdx := numRows
+
+		// Apply fetch limit if needed
+		if p.fetch > 0 {
+			remaining := int64(p.fetch) - p.rowsOutput
+			if remaining < (endIdx - startIdx) {
+				endIdx = startIdx + remaining
+			}
+		}
+
+		// Slice the record
+		sliced := batch.NewSlice(startIdx, endIdx)
+		batch.Release()
+
+		p.skip = 0
+		p.rowsOutput += (endIdx - startIdx)
+		p.state = successState(sliced)
+		return nil
+	}
+
+	// If we have a fetch limit and need to limit this batch
+	if p.fetch > 0 {
+		remaining := int64(p.fetch) - p.rowsOutput
+		if remaining < numRows {
+			// We'll hit our fetch limit with this batch - slice it
+			sliced := batch.NewSlice(0, remaining)
+			batch.Release()
+
+			p.rowsOutput += remaining
+			p.state = successState(sliced)
+			return nil
+		}
+	}
+
+	// Return the full batch
+	p.rowsOutput += numRows
+	p.state = successState(batch)
+	return nil
+}
+
+// Value implements Pipeline.
+func (p *LimitPipeline) Value() (arrow.Record, error) {
+	return p.state.Value()
+}
+
+// Close implements Pipeline.
+func (p *LimitPipeline) Close() {
+	if p.input != nil {
+		p.input.Close()
+	}
+
+	if p.state.batch != nil {
+		p.state.batch.Release()
+		p.state.batch = nil
+	}
+}
+
+// Inputs implements Pipeline.
+func (p *LimitPipeline) Inputs() []Pipeline {
+	return []Pipeline{p.input}
+}
+
+// Transport implements Pipeline.
+func (p *LimitPipeline) Transport() Transport {
+	return p.input.Transport()
+}

--- a/pkg/engine/executor/limit_test.go
+++ b/pkg/engine/executor/limit_test.go
@@ -1,0 +1,198 @@
+package executor
+
+import (
+	"context"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/engine/planner/physical"
+)
+
+func TestExecuteLimit(t *testing.T) {
+	// Simple test to verify the Context.executeLimit method
+	ctx := context.Background()
+	c := &Context{}
+
+	t.Run("with no inputs", func(t *testing.T) {
+		pipeline := c.executeLimit(ctx, &physical.Limit{}, nil)
+		err := pipeline.Read()
+		require.Equal(t, EOF, err)
+	})
+
+	t.Run("with multiple inputs", func(t *testing.T) {
+		pipeline := c.executeLimit(ctx, &physical.Limit{}, []Pipeline{emptyPipeline(), emptyPipeline()})
+		err := pipeline.Read()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "limit expects exactly one input, got 2")
+	})
+
+	t.Run("with valid input", func(t *testing.T) {
+		// Create test data
+		fields := []arrow.Field{
+			{Name: "name", Type: arrow.BinaryTypes.String},
+		}
+		csvData := "Alice\nBob\nCharlie"
+		record, err := CSVToArrow(fields, csvData)
+		require.NoError(t, err)
+		defer record.Release()
+
+		record.Retain()
+		source := NewBufferedPipeline(record)
+
+		// Execute limit with skip=1 and fetch=1
+		limit := &physical.Limit{Skip: 1, Fetch: 1}
+		pipeline := c.executeLimit(ctx, limit, []Pipeline{source})
+		defer pipeline.Close()
+
+		// Read from the pipeline
+		err = pipeline.Read()
+		require.NoError(t, err)
+
+		batch, err := pipeline.Value()
+		require.NoError(t, err)
+		require.NotNil(t, batch)
+
+		// Should have returned only the second row
+		require.Equal(t, int64(1), batch.NumRows())
+		require.Equal(t, int64(1), batch.NumCols())
+		require.Equal(t, "name", batch.ColumnName(0))
+		require.Equal(t, "Bob", batch.Column(0).ValueStr(0))
+
+		// Next read should return EOF
+		err = pipeline.Read()
+		require.Equal(t, EOF, err)
+	})
+
+	// Test with desired rows split across 2 batches
+	t.Run("with rows split across batches", func(t *testing.T) {
+		// Create schema with a single string column
+		fields := []arrow.Field{
+			{Name: "letter", Type: arrow.BinaryTypes.String},
+		}
+
+		// Create first batch with letters A-C
+		batch1Data := "A\nB\nC"
+		batch1, err := CSVToArrow(fields, batch1Data)
+		require.NoError(t, err)
+		defer batch1.Release()
+
+		// Create second batch with letters D-F
+		batch2Data := "D\nE\nF"
+		batch2, err := CSVToArrow(fields, batch2Data)
+		require.NoError(t, err)
+		defer batch2.Release()
+
+		// Create source pipeline with both batches
+		batch1.Retain()
+		batch2.Retain()
+		source := NewBufferedPipeline(batch1, batch2)
+
+		// Create limit pipeline that skips 2 and fetches 3
+		// Should return C from batch1, and D,E from batch2
+		limit := &physical.Limit{Skip: 2, Fetch: 3}
+		pipeline := c.executeLimit(ctx, limit, []Pipeline{source})
+		defer pipeline.Close()
+
+		// First read should give us C from batch1
+		expectedFields := []arrow.Field{
+			{Name: "letter", Type: arrow.BinaryTypes.String},
+		}
+
+		expectedData := "C\nD\nE"
+		expectedRecord, err := CSVToArrow(expectedFields, expectedData)
+		require.NoError(t, err)
+		defer expectedRecord.Release()
+
+		expectedPipeline := NewBufferedPipeline(expectedRecord)
+		defer expectedPipeline.Close()
+
+		AssertPipelinesEqual(t, pipeline, expectedPipeline)
+	})
+}
+
+func TestLimitPipeline_Skip_Fetch(t *testing.T) {
+	// Create test pipeline with known data
+	fields := []arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int32},
+	}
+
+	// Create a pipeline with numbers 1-10
+	var data string
+	for i := 1; i <= 10; i++ {
+		data += string(rune('0'+i)) + "\n"
+	}
+
+	record, err := CSVToArrow(fields, data)
+	require.NoError(t, err)
+	defer record.Release()
+
+	record.Retain()
+	source := NewBufferedPipeline(record)
+
+	// Test with skip=3, fetch=4 (should return 4,5,6,7)
+	limit := NewLimitPipeline(source, 3, 4)
+	defer limit.Close()
+
+	// Test first read
+	err = limit.Read()
+	require.NoError(t, err)
+
+	batch, err := limit.Value()
+	require.NoError(t, err)
+	require.NotNil(t, batch)
+	require.Equal(t, int64(4), batch.NumRows())
+
+	// Check values to ensure we got the right rows
+	for i := 0; i < 4; i++ {
+		expectedVal := string(rune('0' + 4 + i))
+		actualVal := batch.Column(0).ValueStr(i)
+		require.Equal(t, expectedVal, actualVal)
+	}
+
+	// Next read should be EOF
+	err = limit.Read()
+	require.Equal(t, EOF, err)
+}
+
+func TestLimitPipeline_MultipleBatches(t *testing.T) {
+	// Create test pipeline with multiple batches
+	fields := []arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int32},
+	}
+
+	// First batch: 1-5
+	data1 := "1\n2\n3\n4\n5\n"
+	record1, err := CSVToArrow(fields, data1)
+	require.NoError(t, err)
+	defer record1.Release()
+
+	// Second batch: 6-10
+	data2 := "6\n7\n8\n9\n10\n"
+	record2, err := CSVToArrow(fields, data2)
+	require.NoError(t, err)
+	defer record2.Release()
+
+	record1.Retain()
+	record2.Retain()
+	source := NewBufferedPipeline(record1, record2)
+
+	// Test with skip=3, fetch=5 (should return 4,5,6,7,8)
+	limit := NewLimitPipeline(source, 3, 5)
+	defer limit.Close()
+
+	expectedFields := []arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int32},
+	}
+
+	expectedData := "4\n5\n6\n7\n8\n"
+	expectedRecord, err := CSVToArrow(expectedFields, expectedData)
+	require.NoError(t, err)
+	defer expectedRecord.Release()
+
+	expectedPipeline := NewBufferedPipeline(expectedRecord)
+	defer expectedPipeline.Close()
+
+	AssertPipelinesEqual(t, limit, expectedPipeline)
+}

--- a/pkg/engine/executor/pipeline_test.go
+++ b/pkg/engine/executor/pipeline_test.go
@@ -33,7 +33,6 @@ func CSVToArrowWithAllocator(allocator memory.Allocator, fields []arrow.Field, c
 		csv.WithComma(','),
 		csv.WithChunk(-1), // Read all rows
 	)
-	defer reader.Release()
 
 	if !reader.Next() {
 		return nil, errors.New("failed to read CSV data")

--- a/pkg/engine/executor/pipeline_utils_test.go
+++ b/pkg/engine/executor/pipeline_utils_test.go
@@ -1,0 +1,178 @@
+package executor
+
+import (
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/stretchr/testify/require"
+)
+
+// AssertPipelinesEqual iterates through two pipelines and ensures they contain
+// the same data, regardless of batch sizes. It compares row by row and column by column.
+func AssertPipelinesEqual(t testing.TB, left, right Pipeline) {
+	defer left.Close()
+	defer right.Close()
+
+	var (
+		leftBatch, rightBatch   arrow.Record
+		leftPos, rightPos       int64
+		leftRemain, rightRemain int64
+		rowNum                  int64
+		leftErr, rightErr       error
+	)
+
+	for {
+		// Load batches if needed
+		if leftRemain == 0 {
+			if leftBatch != nil {
+				leftBatch.Release()
+				leftBatch = nil
+			}
+
+			leftErr = left.Read()
+			if leftErr == nil {
+				leftBatch, leftErr = left.Value()
+				if leftErr == nil {
+					leftRemain = leftBatch.NumRows()
+					leftPos = 0
+				}
+			}
+		}
+
+		if rightRemain == 0 {
+			if rightBatch != nil {
+				rightBatch.Release()
+				rightBatch = nil
+			}
+
+			rightErr = right.Read()
+			if rightErr == nil {
+				rightBatch, rightErr = right.Value()
+				if rightErr == nil {
+					rightRemain = rightBatch.NumRows()
+					rightPos = 0
+				}
+			}
+		}
+
+		// Check if both pipelines are complete
+		if leftErr == EOF && rightErr == EOF {
+			return
+		}
+
+		// If one pipeline has an error but the other doesn't, they're not equal
+		if (leftErr == EOF && rightErr != EOF) || (leftErr != EOF && rightErr == EOF) {
+			require.Fail(t, "Pipelines have different number of rows",
+				"left error: %v, right error: %v", leftErr, rightErr)
+		}
+
+		// If both pipelines have errors that aren't EOF, they fail equally
+		if leftErr != nil && rightErr != nil && leftErr != EOF && rightErr != EOF {
+			require.Equal(t, leftErr, rightErr, "Pipelines failed with different errors")
+			return
+		}
+
+		// If one pipeline has an error that's not EOF, the pipelines are not equal
+		if leftErr != nil && leftErr != EOF {
+			require.Fail(t, "Left pipeline failed", "error: %v", leftErr)
+		}
+		if rightErr != nil && rightErr != EOF {
+			require.Fail(t, "Right pipeline failed", "error: %v", rightErr)
+		}
+
+		// Check schema compatibility
+		require.True(t, leftBatch.Schema().Equal(rightBatch.Schema()),
+			"Pipelines have incompatible schemas: %v vs %v",
+			leftBatch.Schema(), rightBatch.Schema())
+
+		// Compare rows until one of the batches is exhausted
+		compareRows := min(leftRemain, rightRemain)
+		for i := int64(0); i < compareRows; i++ {
+			// Compare all columns for this row
+			for j := 0; j < int(leftBatch.NumCols()); j++ {
+				colName := leftBatch.ColumnName(j)
+				leftCol := leftBatch.Column(j)
+				rightCol := rightBatch.Column(j)
+
+				// Check if both columns are null
+				leftIsNull := leftCol.IsNull(int(leftPos))
+				rightIsNull := rightCol.IsNull(int(rightPos))
+				require.Equal(t, leftIsNull, rightIsNull,
+					"row %d, column %s: null mismatch", rowNum, colName)
+
+				if leftIsNull {
+					continue
+				}
+
+				// Check validity
+				leftIsValid := leftCol.IsValid(int(leftPos))
+				rightIsValid := rightCol.IsValid(int(rightPos))
+				require.Equal(t, leftIsValid, rightIsValid,
+					"row %d, column %s: validity mismatch", rowNum, colName)
+
+				if !leftIsValid {
+					continue
+				}
+
+				// Compare the values
+				require.Equal(t, leftCol.ValueStr(int(leftPos)), rightCol.ValueStr(int(rightPos)),
+					"row %d, column %s: value differs", rowNum, colName)
+			}
+
+			leftPos++
+			rightPos++
+			leftRemain--
+			rightRemain--
+			rowNum++
+		}
+	}
+}
+
+func TestAssertPipelinesEqual(t *testing.T) {
+	// Define test schema
+	fields := []arrow.Field{
+		{Name: "name", Type: arrow.BinaryTypes.String},
+		{Name: "age", Type: arrow.PrimitiveTypes.Int32},
+	}
+
+	// Create test data
+	csvData := "Alice,30\nBob,25\nCharlie,35\nDave,40"
+	record, err := CSVToArrow(fields, csvData)
+	require.NoError(t, err)
+	defer record.Release()
+
+	// Split the record into two smaller records
+	csvData1 := "Alice,30\nBob,25"
+	csvData2 := "Charlie,35\nDave,40"
+	record1, err := CSVToArrow(fields, csvData1)
+	require.NoError(t, err)
+	defer record1.Release()
+	record2, err := CSVToArrow(fields, csvData2)
+	require.NoError(t, err)
+	defer record2.Release()
+
+	t.Run("identical pipelines with same batch size", func(t *testing.T) {
+		// Retain records to use in multiple pipelines
+		record.Retain()
+		record.Retain()
+		p1 := NewBufferedPipeline(record)
+		p2 := NewBufferedPipeline(record)
+
+		// This should not fail
+		AssertPipelinesEqual(t, p1, p2)
+	})
+
+	t.Run("identical pipelines with different batch sizes", func(t *testing.T) {
+		// First pipeline has one batch with all data
+		record.Retain()
+		p1 := NewBufferedPipeline(record)
+
+		// Second pipeline has two smaller batches
+		record1.Retain()
+		record2.Retain()
+		p2 := NewBufferedPipeline(record1, record2)
+
+		// This should not fail despite different batch sizes
+		AssertPipelinesEqual(t, p1, p2)
+	})
+}


### PR DESCRIPTION
# Implement LimitPipeline

## Overview
This PR implements the `LimitPipeline` component for Loki's execution engine, which enables efficient OFFSET/LIMIT operations on query results. The implementation handles data streaming across multiple batches, ensuring correct behavior when the requested rows span batch boundaries.

## Changes
- Added `limit.go` with a complete `LimitPipeline` implementation
- Implemented the `executeLimit` function in `executor.go`
- Moved and expanded tests from `executor_test.go` to `limit_test.go`
- Added comprehensive test cases for all limit scenarios:
  - Basic offset and fetch operations
  - Empty input handling
  - Multiple input validation
  - Cross-batch row retrieval
  - Complex batch boundary cases

## Unrelated
- Fixes an eager `Release()` call in the `CSVToArrowWithAllocator` function
- Adds an `AssertPipelinesEqual` function to make testing pipeline equality more ergonomic. Note: This tests equality of data, not equality of internal batch sizes. 

## Key Features
- Skip (OFFSET) and Fetch (LIMIT) functionality

## Technical Details
The implementation uses Arrow's record slicing capabilities to handle partial batches. When rows need to be skipped or limited, the code creates record slices rather than copying data, optimizing memory usage and performance.