### PR TITLE
feat(dataobj executor): project node

### DIFF
--- a/pkg/engine/executor/executor.go
+++ b/pkg/engine/executor/executor.go
@@ -31,6 +31,7 @@ func Run(ctx context.Context, cfg Config, plan *physical.Plan) Pipeline {
 type Context struct {
 	batchSize int64
 	plan      *physical.Plan
+	evaluator expressionEvaluator
 }
 
 func (c *Context) execute(ctx context.Context, node physical.Node) Pipeline {
@@ -98,6 +99,7 @@ func (c *Context) executeProjection(_ context.Context, proj *physical.Projection
 	}
 
 	if len(inputs) > 1 {
+		// unsupported for now
 		return errorPipeline(fmt.Errorf("projection expects exactly one input, got %d", len(inputs)))
 	}
 
@@ -105,5 +107,9 @@ func (c *Context) executeProjection(_ context.Context, proj *physical.Projection
 		return errorPipeline(fmt.Errorf("projection expects at least one column, got 0"))
 	}
 
-	return errorPipeline(errNotImplemented)
+	p, err := NewProjectPipeline(inputs[0], proj.Columns, &c.evaluator)
+	if err != nil {
+		return errorPipeline(err)
+	}
+	return p
 }

--- a/pkg/engine/executor/executor_test.go
+++ b/pkg/engine/executor/executor_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/loki/v3/pkg/engine/internal/types"
 	"github.com/grafana/loki/v3/pkg/engine/planner/physical"
 )
 
@@ -109,21 +108,6 @@ func TestExecutor_Projection(t *testing.T) {
 		pipeline := c.executeProjection(context.TODO(), &physical.Projection{Columns: cols}, []Pipeline{emptyPipeline()})
 		err := pipeline.Read()
 		require.ErrorContains(t, err, "projection expects at least one column, got 0")
-	})
-
-	t.Run("is not implemented", func(t *testing.T) {
-		cols := []physical.ColumnExpression{
-			&physical.ColumnExpr{
-				Ref: types.ColumnRef{
-					Column: "a",
-					Type:   types.ColumnTypeBuiltin,
-				},
-			},
-		}
-		c := &Context{}
-		pipeline := c.executeProjection(context.TODO(), &physical.Projection{Columns: cols}, []Pipeline{emptyPipeline()})
-		err := pipeline.Read()
-		require.ErrorContains(t, err, errNotImplemented.Error())
 	})
 
 	t.Run("multiple inputs result in error", func(t *testing.T) {

--- a/pkg/engine/executor/pipeline_test.go
+++ b/pkg/engine/executor/pipeline_test.go
@@ -20,6 +20,9 @@ func CSVToArrow(fields []arrow.Field, csvData string) (arrow.Record, error) {
 // CSVToArrowWithAllocator converts a CSV string to an Arrow record based on the provided schema
 // using the specified memory allocator. It reads all rows from the CSV into a single record.
 func CSVToArrowWithAllocator(allocator memory.Allocator, fields []arrow.Field, csvData string) (arrow.Record, error) {
+	// first, trim the csvData to remove any preceding and trailing whitespace/line breaks
+	csvData = strings.TrimSpace(csvData)
+
 	// Create schema
 	schema := arrow.NewSchema(fields, nil)
 

--- a/pkg/engine/executor/project.go
+++ b/pkg/engine/executor/project.go
@@ -1,0 +1,55 @@
+package executor
+
+import (
+	"fmt"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+
+	"github.com/grafana/loki/v3/pkg/engine/planner/physical"
+)
+
+func NewProjectPipeline(input Pipeline, columns []physical.ColumnExpression, evaluator *expressionEvaluator) (*GenericPipeline, error) {
+	// Get the column names from the projection expressions
+	columnNames := make([]string, len(columns))
+	for i, col := range columns {
+		if colExpr, ok := col.(*physical.ColumnExpr); ok {
+			columnNames[i] = colExpr.Ref.Column
+		} else {
+			return nil, fmt.Errorf("projection column %d is not a column expression", i)
+		}
+	}
+
+	return newGenericPipeline(Local, func(inputs []Pipeline) state {
+		// Pull the next item from the input pipeline
+		input := inputs[0]
+		err := input.Read()
+		if err != nil {
+			return failureState(err)
+		}
+
+		batch, err := input.Value()
+		if err != nil {
+			return failureState(err)
+		}
+
+		projected := make([]arrow.Array, 0, len(columns))
+		fields := make([]arrow.Field, 0, len(columns))
+
+		for i := range columns {
+			vec, err := evaluator.eval(columns[i], batch)
+			if err != nil {
+				return failureState(err)
+			}
+			fields = append(fields, arrow.Field{Name: columnNames[i], Type: vec.Type()})
+			projected = append(projected, vec.ToArray())
+		}
+
+		schema := arrow.NewSchema(fields, nil)
+		// Create a new record with only the projected columns
+		// retain the projected columns in a new batch then release the original record.
+		projectedRecord := array.NewRecord(schema, projected, batch.NumRows())
+		batch.Release()
+		return successState(projectedRecord)
+	}, input), nil
+}

--- a/pkg/engine/executor/project_test.go
+++ b/pkg/engine/executor/project_test.go
@@ -1,0 +1,206 @@
+package executor
+
+import (
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/engine/internal/types"
+	"github.com/grafana/loki/v3/pkg/engine/planner/physical"
+)
+
+func TestNewProjectPipeline(t *testing.T) {
+	fields := []arrow.Field{
+		{Name: "name", Type: arrow.BinaryTypes.String},
+		{Name: "age", Type: arrow.PrimitiveTypes.Int32},
+		{Name: "city", Type: arrow.BinaryTypes.String},
+	}
+
+	t.Run("project single column", func(t *testing.T) {
+		// Create input data
+		inputCSV := "Alice,30,New York\nBob,25,Boston\nCharlie,35,Seattle"
+		inputRecord, err := CSVToArrow(fields, inputCSV)
+		require.NoError(t, err)
+		defer inputRecord.Release()
+
+		// Create input pipeline
+		inputPipeline := NewBufferedPipeline(inputRecord)
+
+		// Create projection columns (just the "name" column)
+		columns := []physical.ColumnExpression{
+			&physical.ColumnExpr{
+				Ref: createColumnRef("name"),
+			},
+		}
+
+		// Create project pipeline
+		projectPipeline, err := NewProjectPipeline(inputPipeline, columns, &expressionEvaluator{})
+		require.NoError(t, err)
+
+		// Create expected output
+		expectedCSV := "Alice\nBob\nCharlie"
+		expectedFields := []arrow.Field{
+			{Name: "name", Type: arrow.BinaryTypes.String},
+		}
+		expectedRecord, err := CSVToArrow(expectedFields, expectedCSV)
+		require.NoError(t, err)
+		defer expectedRecord.Release()
+
+		expectedPipeline := NewBufferedPipeline(expectedRecord)
+
+		// Assert that the pipelines produce equal results
+		AssertPipelinesEqual(t, projectPipeline, expectedPipeline)
+	})
+
+	t.Run("project multiple columns", func(t *testing.T) {
+		// Create input data
+		inputCSV := "Alice,30,New York\nBob,25,Boston\nCharlie,35,Seattle"
+		inputRecord, err := CSVToArrow(fields, inputCSV)
+		require.NoError(t, err)
+		defer inputRecord.Release()
+
+		// Create input pipeline
+		inputPipeline := NewBufferedPipeline(inputRecord)
+
+		// Create projection columns (both "name" and "city" columns)
+		columns := []physical.ColumnExpression{
+			&physical.ColumnExpr{
+				Ref: createColumnRef("name"),
+			},
+			&physical.ColumnExpr{
+				Ref: createColumnRef("city"),
+			},
+		}
+
+		// Create project pipeline
+		projectPipeline, err := NewProjectPipeline(inputPipeline, columns, &expressionEvaluator{})
+		require.NoError(t, err)
+
+		// Create expected output
+		expectedCSV := "Alice,New York\nBob,Boston\nCharlie,Seattle"
+		expectedFields := []arrow.Field{
+			{Name: "name", Type: arrow.BinaryTypes.String},
+			{Name: "city", Type: arrow.BinaryTypes.String},
+		}
+		expectedRecord, err := CSVToArrow(expectedFields, expectedCSV)
+		require.NoError(t, err)
+		defer expectedRecord.Release()
+
+		expectedPipeline := NewBufferedPipeline(expectedRecord)
+
+		// Assert that the pipelines produce equal results
+		AssertPipelinesEqual(t, projectPipeline, expectedPipeline)
+	})
+
+	t.Run("project columns in different order", func(t *testing.T) {
+		// Create input data
+		inputCSV := "Alice,30,New York\nBob,25,Boston\nCharlie,35,Seattle"
+		inputRecord, err := CSVToArrow(fields, inputCSV)
+		require.NoError(t, err)
+		defer inputRecord.Release()
+
+		// Create input pipeline
+		inputPipeline := NewBufferedPipeline(inputRecord)
+
+		// Create projection columns (reordering columns)
+		columns := []physical.ColumnExpression{
+			&physical.ColumnExpr{
+				Ref: createColumnRef("city"),
+			},
+			&physical.ColumnExpr{
+				Ref: createColumnRef("age"),
+			},
+			&physical.ColumnExpr{
+				Ref: createColumnRef("name"),
+			},
+		}
+
+		// Create project pipeline
+		projectPipeline, err := NewProjectPipeline(inputPipeline, columns, &expressionEvaluator{})
+		require.NoError(t, err)
+
+		// Create expected output
+		expectedCSV := "New York,30,Alice\nBoston,25,Bob\nSeattle,35,Charlie"
+		expectedFields := []arrow.Field{
+			{Name: "city", Type: arrow.BinaryTypes.String},
+			{Name: "age", Type: arrow.PrimitiveTypes.Int32},
+			{Name: "name", Type: arrow.BinaryTypes.String},
+		}
+		expectedRecord, err := CSVToArrow(expectedFields, expectedCSV)
+		require.NoError(t, err)
+		defer expectedRecord.Release()
+
+		expectedPipeline := NewBufferedPipeline(expectedRecord)
+
+		// Assert that the pipelines produce equal results
+		AssertPipelinesEqual(t, projectPipeline, expectedPipeline)
+	})
+
+	t.Run("project with multiple input batches", func(t *testing.T) {
+		// Create input data split across multiple records
+		inputCSV1 := "Alice,30,New York\nBob,25,Boston"
+		inputCSV2 := "Charlie,35,Seattle\nDave,40,Portland"
+
+		inputRecord1, err := CSVToArrow(fields, inputCSV1)
+		require.NoError(t, err)
+		defer inputRecord1.Release()
+
+		inputRecord2, err := CSVToArrow(fields, inputCSV2)
+		require.NoError(t, err)
+		defer inputRecord2.Release()
+
+		// Create input pipeline with multiple batches
+		inputPipeline := NewBufferedPipeline(inputRecord1, inputRecord2)
+
+		// Create projection columns
+		columns := []physical.ColumnExpression{
+			&physical.ColumnExpr{
+				Ref: createColumnRef("name"),
+			},
+			&physical.ColumnExpr{
+				Ref: createColumnRef("age"),
+			},
+		}
+
+		// Create project pipeline
+		projectPipeline, err := NewProjectPipeline(inputPipeline, columns, &expressionEvaluator{})
+		require.NoError(t, err)
+
+		// Create expected output also split across multiple records
+		expectedFields := []arrow.Field{
+			{Name: "name", Type: arrow.BinaryTypes.String},
+			{Name: "age", Type: arrow.PrimitiveTypes.Int32},
+		}
+
+		expected := `
+Alice,30
+Bob,25
+Charlie,35
+Dave,40
+		`
+
+		expectedRecord, err := CSVToArrow(expectedFields, expected)
+		require.NoError(t, err)
+		defer expectedRecord.Release()
+
+		expectedPipeline := NewBufferedPipeline(expectedRecord)
+
+		// Assert that the pipelines produce equal results
+		AssertPipelinesEqual(t, projectPipeline, expectedPipeline)
+	})
+
+}
+
+// Helper to create a column reference
+func createColumnRef(name string) types.ColumnRef {
+	return types.ColumnRef{
+		Column: name,
+		Type:   types.ColumnTypeBuiltin,
+	}
+}
+
+// Helper to create a literal value
+func createLiteral(val any) types.Literal {
+	return types.Literal{Value: val}
+}


### PR DESCRIPTION
Dependent on / followup to https://github.com/grafana/loki/pull/17311

# Implement Projection Pipeline in Engine Executor

## Changes

This PR adds projection support to the Loki query engine executor, allowing queries to select specific columns from record batches. Key changes include:

- Add `NewProjectPipeline` function for creating projection pipelines
- Implement the previously unimplemented `executeProjection` method
- Add `evaluator` field to the `Context` struct for expression evaluation
- Improve CSV to Arrow conversion by trimming whitespace
- Add comprehensive test cases for projections

## Test Coverage

The implementation includes thorough tests that verify:
- Single column projection
- Multiple column projection
- Column reordering
- Processing multiple input batches
