### PR TITLE
fix: fix single error prevents getting assigned partitions

### DIFF
--- a/pkg/limits/frontend/cache.go
+++ b/pkg/limits/frontend/cache.go
@@ -8,11 +8,11 @@ import (
 	"github.com/grafana/loki/v3/pkg/logproto"
 )
 
-type PartitionConsumersCache = *ttlcache.Cache[string, logproto.GetAssignedPartitionsResponse]
+type PartitionConsumersCache = ttlcache.Cache[string, *logproto.GetAssignedPartitionsResponse]
 
-func NewPartitionConsumerCache(ttl time.Duration) PartitionConsumersCache {
+func NewPartitionConsumerCache(ttl time.Duration) *PartitionConsumersCache {
 	return ttlcache.New(
-		ttlcache.WithTTL[string, logproto.GetAssignedPartitionsResponse](ttl),
-		ttlcache.WithDisableTouchOnHit[string, logproto.GetAssignedPartitionsResponse](),
+		ttlcache.WithTTL[string, *logproto.GetAssignedPartitionsResponse](ttl),
+		ttlcache.WithDisableTouchOnHit[string, *logproto.GetAssignedPartitionsResponse](),
 	)
 }

--- a/pkg/limits/frontend/frontend.go
+++ b/pkg/limits/frontend/frontend.go
@@ -61,7 +61,7 @@ type Frontend struct {
 	limits           Limits
 	rateLimiter      *limiter.RateLimiter
 	streamUsage      StreamUsageGatherer
-	partitionIDCache PartitionConsumersCache
+	partitionIDCache *PartitionConsumersCache
 	metrics          *metrics
 
 	subservices        *services.Manager

--- a/pkg/limits/frontend/http_test.go
+++ b/pkg/limits/frontend/http_test.go
@@ -111,20 +111,20 @@ func TestFrontend_ServeHTTP(t *testing.T) {
 func TestRingStreamUsageGatherer_ServeHTTP(t *testing.T) {
 	tests := []struct {
 		name           string
-		initialCache   map[string]logproto.GetAssignedPartitionsResponse
-		expectedCache  map[string]logproto.GetAssignedPartitionsResponse
+		initialCache   map[string]*logproto.GetAssignedPartitionsResponse
+		expectedCache  map[string]*logproto.GetAssignedPartitionsResponse
 		expectedStatus int
 		expectedBody   string
 	}{
 		{
 			name:           "GET with empty cache",
-			initialCache:   map[string]logproto.GetAssignedPartitionsResponse{},
+			initialCache:   map[string]*logproto.GetAssignedPartitionsResponse{},
 			expectedStatus: http.StatusOK,
 			expectedBody:   "Ring Stream Usage Cache",
 		},
 		{
 			name: "GET with populated cache",
-			initialCache: map[string]logproto.GetAssignedPartitionsResponse{
+			initialCache: map[string]*logproto.GetAssignedPartitionsResponse{
 				"instance1:8080": {
 					AssignedPartitions: map[int32]int64{
 						1: time.Now().Unix(),
@@ -178,8 +178,8 @@ func TestRingStreamUsageGatherer_PartitionConsumerCacheEvictHandler(t *testing.T
 	tests := []struct {
 		name           string
 		formData       map[string]string
-		initialCache   map[string]logproto.GetAssignedPartitionsResponse
-		expectedCache  map[string]logproto.GetAssignedPartitionsResponse
+		initialCache   map[string]*logproto.GetAssignedPartitionsResponse
+		expectedCache  map[string]*logproto.GetAssignedPartitionsResponse
 		expectedStatus int
 		expectedBody   string
 	}{
@@ -188,7 +188,7 @@ func TestRingStreamUsageGatherer_PartitionConsumerCacheEvictHandler(t *testing.T
 			formData: map[string]string{
 				"instance": "instance1:8080",
 			},
-			initialCache: map[string]logproto.GetAssignedPartitionsResponse{
+			initialCache: map[string]*logproto.GetAssignedPartitionsResponse{
 				"instance1:8080": {
 					AssignedPartitions: map[int32]int64{
 						1: time.Now().Unix(),
@@ -204,7 +204,7 @@ func TestRingStreamUsageGatherer_PartitionConsumerCacheEvictHandler(t *testing.T
 					},
 				},
 			},
-			expectedCache: map[string]logproto.GetAssignedPartitionsResponse{
+			expectedCache: map[string]*logproto.GetAssignedPartitionsResponse{
 				"instance2:8080": {
 					AssignedPartitions: map[int32]int64{
 						4: time.Now().Unix(),
@@ -217,7 +217,7 @@ func TestRingStreamUsageGatherer_PartitionConsumerCacheEvictHandler(t *testing.T
 		},
 		{
 			name: "POST clear all cache",
-			initialCache: map[string]logproto.GetAssignedPartitionsResponse{
+			initialCache: map[string]*logproto.GetAssignedPartitionsResponse{
 				"instance1:8080": {
 					AssignedPartitions: map[int32]int64{
 						1: time.Now().Unix(),
@@ -233,7 +233,7 @@ func TestRingStreamUsageGatherer_PartitionConsumerCacheEvictHandler(t *testing.T
 					},
 				},
 			},
-			expectedCache:  map[string]logproto.GetAssignedPartitionsResponse{},
+			expectedCache:  map[string]*logproto.GetAssignedPartitionsResponse{},
 			expectedStatus: http.StatusSeeOther,
 		},
 	}

--- a/pkg/limits/frontend/mock_test.go
+++ b/pkg/limits/frontend/mock_test.go
@@ -42,8 +42,10 @@ type mockIngestLimitsClient struct {
 	expectedStreamUsageRequest        *logproto.GetStreamUsageRequest
 
 	// The mocked responses.
-	getAssignedPartitionsResponse *logproto.GetAssignedPartitionsResponse
-	getStreamUsageResponse        *logproto.GetStreamUsageResponse
+	getAssignedPartitionsResponse    *logproto.GetAssignedPartitionsResponse
+	getAssignedPartitionsResponseErr error
+	getStreamUsageResponse           *logproto.GetStreamUsageResponse
+	getStreamUsageResponseErr        error
 
 	// The call count.
 	assignedPartitionsCallCount int
@@ -55,6 +57,9 @@ func (m *mockIngestLimitsClient) GetAssignedPartitions(_ context.Context, r *log
 		require.Equal(m.t, expected, r)
 	}
 	m.assignedPartitionsCallCount++
+	if err := m.getAssignedPartitionsResponseErr; err != nil {
+		return nil, err
+	}
 	return m.getAssignedPartitionsResponse, nil
 }
 
@@ -63,6 +68,9 @@ func (m *mockIngestLimitsClient) GetStreamUsage(_ context.Context, r *logproto.G
 		require.Equal(m.t, expected, r)
 	}
 	m.streamUsageCallCount++
+	if err := m.getStreamUsageResponseErr; err != nil {
+		return nil, err
+	}
 	return m.getStreamUsageResponse, nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request fixes a bug where a single error calling `GetAssignedPartitions` for one instance will prevent the frontend from getting the assigned partitions from all other instances. It also makes the code easier to read, removing the loader closure and instead opting for a more simple version of the same code.

This pull request is stacked on top of https://github.com/grafana/loki/pull/17288.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
