### PR TITLE
chore: remove no-op code from ring tests

### DIFF
--- a/pkg/limits/frontend/ring_test.go
+++ b/pkg/limits/frontend/ring_test.go
@@ -142,21 +142,14 @@ func TestRingStreamUsageGatherer_GetStreamUsage(t *testing.T) {
 			instances := make([]ring.InstanceDesc, len(clients))
 
 			// Set up the mock clients for the assigned partitions requests.
-			// Note: Every client will return a response for its assigned partitions.
 			for i := range test.expectedAssignedPartitionsRequest {
 				clients[i] = &mockIngestLimitsClient{
 					t:                                 t,
 					expectedAssignedPartitionsRequest: test.expectedAssignedPartitionsRequest[i],
+					expectedStreamUsageRequest:        test.expectedStreamUsageRequest[i],
 					getAssignedPartitionsResponse:     test.getAssignedPartitionsResponses[i],
+					getStreamUsageResponse:            test.getStreamUsageResponses[i],
 				}
-			}
-
-			// Set up the mock clients for the stream usage requests.
-			// Note: Not every client will have a stream usage request because the
-			// requested stream hashes are owned only by a subset of partition consumers.
-			for i := range test.expectedStreamUsageRequest {
-				clients[i].(*mockIngestLimitsClient).expectedStreamUsageRequest = test.expectedStreamUsageRequest[i]
-				clients[i].(*mockIngestLimitsClient).getStreamUsageResponse = test.getStreamUsageResponses[i]
 			}
 
 			// Set up the instances for the ring.


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
