### PR TITLE
feat(dataobj, executor): filter node execution

### DIFF
--- a/pkg/engine/executor/executor.go
+++ b/pkg/engine/executor/executor.go
@@ -81,16 +81,17 @@ func (c *Context) executeLimit(_ context.Context, limit *physical.Limit, inputs 
 	return NewLimitPipeline(inputs[0], limit.Skip, limit.Fetch)
 }
 
-func (c *Context) executeFilter(_ context.Context, _ *physical.Filter, inputs []Pipeline) Pipeline {
+func (c *Context) executeFilter(_ context.Context, filter *physical.Filter, inputs []Pipeline) Pipeline {
 	if len(inputs) == 0 {
 		return emptyPipeline()
 	}
 
+	// TODO: support multiple inputs
 	if len(inputs) > 1 {
 		return errorPipeline(fmt.Errorf("filter expects exactly one input, got %d", len(inputs)))
 	}
 
-	return errorPipeline(errNotImplemented)
+	return NewFilterPipeline(filter, inputs[0], &c.evaluator)
 }
 
 func (c *Context) executeProjection(_ context.Context, proj *physical.Projection, inputs []Pipeline) Pipeline {

--- a/pkg/engine/executor/executor.go
+++ b/pkg/engine/executor/executor.go
@@ -91,7 +91,7 @@ func (c *Context) executeFilter(_ context.Context, filter *physical.Filter, inpu
 		return errorPipeline(fmt.Errorf("filter expects exactly one input, got %d", len(inputs)))
 	}
 
-	return NewFilterPipeline(filter, inputs[0], &c.evaluator)
+	return NewFilterPipeline(filter, inputs[0], c.evaluator)
 }
 
 func (c *Context) executeProjection(_ context.Context, proj *physical.Projection, inputs []Pipeline) Pipeline {

--- a/pkg/engine/executor/executor_test.go
+++ b/pkg/engine/executor/executor_test.go
@@ -72,13 +72,6 @@ func TestExecutor_Filter(t *testing.T) {
 		require.ErrorContains(t, err, EOF.Error())
 	})
 
-	t.Run("is not implemented", func(t *testing.T) {
-		c := &Context{}
-		pipeline := c.executeFilter(context.TODO(), &physical.Filter{}, []Pipeline{emptyPipeline()})
-		err := pipeline.Read()
-		require.ErrorContains(t, err, errNotImplemented.Error())
-	})
-
 	t.Run("multiple inputs result in error", func(t *testing.T) {
 		c := &Context{}
 		pipeline := c.executeFilter(context.TODO(), &physical.Filter{}, []Pipeline{emptyPipeline(), emptyPipeline()})

--- a/pkg/engine/executor/filter.go
+++ b/pkg/engine/executor/filter.go
@@ -10,7 +10,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/engine/planner/physical"
 )
 
-func NewFilterPipeline(filter *physical.Filter, input Pipeline, evaluator *expressionEvaluator) *GenericPipeline {
+func NewFilterPipeline(filter *physical.Filter, input Pipeline, evaluator expressionEvaluator) *GenericPipeline {
 	return newGenericPipeline(Local, func(inputs []Pipeline) state {
 		// Pull the next item from the input pipeline
 		input := inputs[0]

--- a/pkg/engine/executor/filter.go
+++ b/pkg/engine/executor/filter.go
@@ -1,0 +1,152 @@
+package executor
+
+import (
+	"fmt"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+
+	"github.com/grafana/loki/v3/pkg/engine/planner/physical"
+)
+
+func NewFilterPipeline(filter *physical.Filter, input Pipeline, evaluator *expressionEvaluator) *GenericPipeline {
+	return newGenericPipeline(Local, func(inputs []Pipeline) state {
+		// Pull the next item from the input pipeline
+		input := inputs[0]
+		err := input.Read()
+		if err != nil {
+			return failureState(err)
+		}
+
+		batch, err := input.Value()
+		if err != nil {
+			return failureState(err)
+		}
+
+		cols := make([]*array.Boolean, 0, len(filter.Predicates))
+		defer func() {
+			for _, col := range cols {
+				// boolean filters are only used for filtering; they're not returned
+				// and must be released
+				// TODO: verify this once the evaluator implementation is fleshed out
+				col.Release()
+			}
+		}()
+
+		for i, pred := range filter.Predicates {
+			res, err := evaluator.eval(pred, batch)
+			if err != nil {
+				return failureState(err)
+			}
+			data := res.ToArray()
+			if data.DataType().ID() != arrow.BOOL {
+				return failureState(fmt.Errorf("predicate %d returned non-boolean type %s", i, data.DataType()))
+			}
+			casted := data.(*array.Boolean)
+			cols = append(cols, casted)
+		}
+
+		filtered := filterBatch(batch, func(i int) bool {
+			for _, p := range cols {
+				if !p.IsValid(i) || !p.Value(i) {
+					return false
+				}
+			}
+			return true
+		})
+
+		return successState(filtered)
+
+	}, input)
+}
+
+// This is a very inefficient approach which creates a new filtered batch from a
+// pre-existing batch. Additionally, there is not plumbing in the arrow library
+// to do this efficiently, meaning we have to do a lot of roundabout type coercion
+// to ensure we can use the arrow builders.
+//
+// NB: One saving grace is that many filters will skip this step via predicate
+// pushdown optimizations.
+//
+// We should re-think this approach.
+func filterBatch(batch arrow.Record, include func(int) bool) arrow.Record {
+	mem := memory.NewGoAllocator()
+	fields := batch.Schema().Fields()
+
+	builders := make([]array.Builder, len(fields))
+	defer func() {
+		for _, b := range builders {
+			if b != nil {
+				b.Release()
+			}
+		}
+	}()
+
+	additions := make([]func(int), len(fields))
+
+	for i, field := range fields {
+		switch field.Type.ID() {
+		case arrow.BOOL:
+			builder := array.NewBooleanBuilder(mem)
+			builders[i] = builder
+			additions[i] = func(offset int) {
+				src := batch.Column(i).(*array.Boolean)
+				builder.Append(src.Value(offset))
+			}
+
+		case arrow.STRING:
+			builder := array.NewStringBuilder(mem)
+			builders[i] = builder
+			additions[i] = func(offset int) {
+				src := batch.Column(i).(*array.String)
+				builder.Append(src.Value(offset))
+			}
+
+		case arrow.UINT64:
+			builder := array.NewUint64Builder(mem)
+			builders[i] = builder
+			additions[i] = func(offset int) {
+				src := batch.Column(i).(*array.Uint64)
+				builder.Append(src.Value(offset))
+			}
+
+		case arrow.INT64:
+			builder := array.NewInt64Builder(mem)
+			builders[i] = builder
+			additions[i] = func(offset int) {
+				src := batch.Column(i).(*array.Int64)
+				builder.Append(src.Value(offset))
+			}
+
+		case arrow.FLOAT64:
+			builder := array.NewFloat64Builder(mem)
+			builders[i] = builder
+			additions[i] = func(offset int) {
+				src := batch.Column(i).(*array.Float64)
+				builder.Append(src.Value(offset))
+			}
+
+		default:
+			panic(fmt.Sprintf("unimplemented type in filterBatch: %s", field.Type.Name()))
+		}
+	}
+
+	var ct int64
+	for i := 0; i < int(batch.NumRows()); i++ {
+		if include(i) {
+			for _, add := range additions {
+				add(i)
+			}
+			ct++
+		}
+	}
+
+	schema := arrow.NewSchema(fields, nil)
+	arrays := make([]arrow.Array, len(fields))
+	for i, builder := range builders {
+		arrays[i] = builder.NewArray()
+	}
+
+	return array.NewRecord(schema, arrays, ct)
+}

--- a/pkg/engine/executor/filter_test.go
+++ b/pkg/engine/executor/filter_test.go
@@ -38,7 +38,7 @@ func TestNewFilterPipeline(t *testing.T) {
 		}
 
 		// Create filter pipeline
-		filterPipeline := NewFilterPipeline(filter, inputPipeline, &expressionEvaluator{})
+		filterPipeline := NewFilterPipeline(filter, inputPipeline, expressionEvaluator{})
 
 		// Create expected output (should be same as input since predicate is always true)
 		expectedRecord, err := CSVToArrow(fields, inputCSV)
@@ -72,7 +72,7 @@ func TestNewFilterPipeline(t *testing.T) {
 		}
 
 		// Create filter pipeline
-		filterPipeline := NewFilterPipeline(filter, inputPipeline, &expressionEvaluator{})
+		filterPipeline := NewFilterPipeline(filter, inputPipeline, expressionEvaluator{})
 
 		// Create expected output (should be empty since predicate is always false)
 		schema := arrow.NewSchema(fields, nil)
@@ -98,7 +98,7 @@ func TestNewFilterPipeline(t *testing.T) {
 		AssertPipelinesEqual(t, filterPipeline, expectedPipeline)
 	})
 
-	t.Run("filter using valid column directly", func(t *testing.T) {
+	t.Run("filter on boolean column with column expression", func(t *testing.T) {
 		// Create input data
 		inputCSV := "Alice,true\nBob,false\nCharlie,true"
 		inputRecord, err := CSVToArrow(fields, inputCSV)
@@ -119,7 +119,7 @@ func TestNewFilterPipeline(t *testing.T) {
 		}
 
 		// Create filter pipeline
-		filterPipeline := NewFilterPipeline(filter, inputPipeline, &expressionEvaluator{})
+		filterPipeline := NewFilterPipeline(filter, inputPipeline, expressionEvaluator{})
 
 		// Create expected output (only rows where valid=true)
 		expectedCSV := "Alice,true\nCharlie,true"
@@ -166,7 +166,7 @@ func TestNewFilterPipeline(t *testing.T) {
 		}
 
 		// Create filter pipeline
-		filterPipeline := NewFilterPipeline(filter, inputPipeline, &expressionEvaluator{})
+		filterPipeline := NewFilterPipeline(filter, inputPipeline, expressionEvaluator{})
 
 		// Create expected output (also empty)
 		mem2 := memory.NewGoAllocator()
@@ -218,7 +218,7 @@ func TestNewFilterPipeline(t *testing.T) {
 		}
 
 		// Create filter pipeline
-		filterPipeline := NewFilterPipeline(filter, inputPipeline, &expressionEvaluator{})
+		filterPipeline := NewFilterPipeline(filter, inputPipeline, expressionEvaluator{})
 
 		// Create expected output (only rows where valid=true)
 		expectedCSV := `

--- a/pkg/engine/executor/filter_test.go
+++ b/pkg/engine/executor/filter_test.go
@@ -1,0 +1,237 @@
+package executor
+
+import (
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/engine/planner/physical"
+)
+
+func TestNewFilterPipeline(t *testing.T) {
+	fields := []arrow.Field{
+		{Name: "name", Type: arrow.BinaryTypes.String},
+		{Name: "valid", Type: arrow.FixedWidthTypes.Boolean},
+	}
+
+	t.Run("filter with true literal predicate", func(t *testing.T) {
+		// Create input data
+		inputCSV := "Alice,true\nBob,false\nCharlie,true"
+		inputRecord, err := CSVToArrow(fields, inputCSV)
+		require.NoError(t, err)
+		defer inputRecord.Release()
+
+		// Create input pipeline
+		inputPipeline := NewBufferedPipeline(inputRecord)
+
+		// Create a filter predicate that's always true
+		truePredicate := &physical.LiteralExpr{
+			Value: createLiteral(true),
+		}
+
+		// Create a Filter node
+		filter := &physical.Filter{
+			Predicates: []physical.Expression{truePredicate},
+		}
+
+		// Create filter pipeline
+		filterPipeline := NewFilterPipeline(filter, inputPipeline, &expressionEvaluator{})
+
+		// Create expected output (should be same as input since predicate is always true)
+		expectedRecord, err := CSVToArrow(fields, inputCSV)
+		require.NoError(t, err)
+		defer expectedRecord.Release()
+
+		expectedPipeline := NewBufferedPipeline(expectedRecord)
+
+		// Assert that the pipelines produce equal results
+		AssertPipelinesEqual(t, filterPipeline, expectedPipeline)
+	})
+
+	t.Run("filter with false literal predicate", func(t *testing.T) {
+		// Create input data
+		inputCSV := "Alice,true\nBob,false\nCharlie,true"
+		inputRecord, err := CSVToArrow(fields, inputCSV)
+		require.NoError(t, err)
+		defer inputRecord.Release()
+
+		// Create input pipeline
+		inputPipeline := NewBufferedPipeline(inputRecord)
+
+		// Create a filter predicate that's always false
+		falsePredicate := &physical.LiteralExpr{
+			Value: createLiteral(false),
+		}
+
+		// Create a Filter node
+		filter := &physical.Filter{
+			Predicates: []physical.Expression{falsePredicate},
+		}
+
+		// Create filter pipeline
+		filterPipeline := NewFilterPipeline(filter, inputPipeline, &expressionEvaluator{})
+
+		// Create expected output (should be empty since predicate is always false)
+		schema := arrow.NewSchema(fields, nil)
+		mem := memory.NewGoAllocator()
+
+		// Create empty arrays for each field
+		emptyArrays := make([]arrow.Array, len(fields))
+		emptyArrays[0] = array.NewStringBuilder(mem).NewArray()  // empty string array
+		emptyArrays[1] = array.NewBooleanBuilder(mem).NewArray() // empty boolean array
+
+		expectedRecord := array.NewRecord(schema, emptyArrays, 0)
+		defer expectedRecord.Release()
+		// Be sure to release the arrays too
+		defer func() {
+			for _, arr := range emptyArrays {
+				arr.Release()
+			}
+		}()
+
+		expectedPipeline := NewBufferedPipeline(expectedRecord)
+
+		// Assert that the pipelines produce equal results
+		AssertPipelinesEqual(t, filterPipeline, expectedPipeline)
+	})
+
+	t.Run("filter using valid column directly", func(t *testing.T) {
+		// Create input data
+		inputCSV := "Alice,true\nBob,false\nCharlie,true"
+		inputRecord, err := CSVToArrow(fields, inputCSV)
+		require.NoError(t, err)
+		defer inputRecord.Release()
+
+		// Create input pipeline
+		inputPipeline := NewBufferedPipeline(inputRecord)
+
+		// Create a filter predicate that uses the 'valid' column directly
+		validColumnPredicate := &physical.ColumnExpr{
+			Ref: createColumnRef("valid"),
+		}
+
+		// Create a Filter node
+		filter := &physical.Filter{
+			Predicates: []physical.Expression{validColumnPredicate},
+		}
+
+		// Create filter pipeline
+		filterPipeline := NewFilterPipeline(filter, inputPipeline, &expressionEvaluator{})
+
+		// Create expected output (only rows where valid=true)
+		expectedCSV := "Alice,true\nCharlie,true"
+		expectedRecord, err := CSVToArrow(fields, expectedCSV)
+		require.NoError(t, err)
+		defer expectedRecord.Release()
+
+		expectedPipeline := NewBufferedPipeline(expectedRecord)
+
+		// Assert that the pipelines produce equal results
+		AssertPipelinesEqual(t, filterPipeline, expectedPipeline)
+	})
+
+	t.Run("filter on empty batch", func(t *testing.T) {
+		// Create empty record with correct schema
+		schema := arrow.NewSchema(fields, nil)
+		mem := memory.NewGoAllocator()
+
+		// Create empty arrays for each field
+		emptyArrays := make([]arrow.Array, len(fields))
+		emptyArrays[0] = array.NewStringBuilder(mem).NewArray()  // empty string array
+		emptyArrays[1] = array.NewBooleanBuilder(mem).NewArray() // empty boolean array
+
+		emptyRecord := array.NewRecord(schema, emptyArrays, 0)
+		defer emptyRecord.Release()
+		// Be sure to release the arrays too
+		defer func() {
+			for _, arr := range emptyArrays {
+				arr.Release()
+			}
+		}()
+
+		// Create input pipeline
+		inputPipeline := NewBufferedPipeline(emptyRecord)
+
+		// Create a simple filter
+		truePredicate := &physical.LiteralExpr{
+			Value: createLiteral(true),
+		}
+
+		// Create a Filter node
+		filter := &physical.Filter{
+			Predicates: []physical.Expression{truePredicate},
+		}
+
+		// Create filter pipeline
+		filterPipeline := NewFilterPipeline(filter, inputPipeline, &expressionEvaluator{})
+
+		// Create expected output (also empty)
+		mem2 := memory.NewGoAllocator()
+
+		// Create empty arrays for each field
+		expectedArrays := make([]arrow.Array, len(fields))
+		expectedArrays[0] = array.NewStringBuilder(mem2).NewArray()  // empty string array
+		expectedArrays[1] = array.NewBooleanBuilder(mem2).NewArray() // empty boolean array
+
+		expectedRecord := array.NewRecord(schema, expectedArrays, 0)
+		defer expectedRecord.Release()
+		// Be sure to release the arrays too
+		defer func() {
+			for _, arr := range expectedArrays {
+				arr.Release()
+			}
+		}()
+
+		expectedPipeline := NewBufferedPipeline(expectedRecord)
+
+		// Assert that the pipelines produce equal results
+		AssertPipelinesEqual(t, filterPipeline, expectedPipeline)
+	})
+
+	t.Run("filter with multiple input batches", func(t *testing.T) {
+		// Create input data split across multiple records
+		inputCSV1 := "Alice,true\nBob,false"
+		inputCSV2 := "Charlie,true\nDave,false"
+
+		inputRecord1, err := CSVToArrow(fields, inputCSV1)
+		require.NoError(t, err)
+		defer inputRecord1.Release()
+
+		inputRecord2, err := CSVToArrow(fields, inputCSV2)
+		require.NoError(t, err)
+		defer inputRecord2.Release()
+
+		// Create input pipeline with multiple batches
+		inputPipeline := NewBufferedPipeline(inputRecord1, inputRecord2)
+
+		// Create a filter predicate that uses the 'valid' column directly
+		validColumnPredicate := &physical.ColumnExpr{
+			Ref: createColumnRef("valid"),
+		}
+
+		// Create a Filter node
+		filter := &physical.Filter{
+			Predicates: []physical.Expression{validColumnPredicate},
+		}
+
+		// Create filter pipeline
+		filterPipeline := NewFilterPipeline(filter, inputPipeline, &expressionEvaluator{})
+
+		// Create expected output (only rows where valid=true)
+		expectedCSV := `
+Alice,true
+Charlie,true
+		`
+		expectedRecord, err := CSVToArrow(fields, expectedCSV)
+		require.NoError(t, err)
+		defer expectedRecord.Release()
+
+		expectedPipeline := NewBufferedPipeline(expectedRecord)
+
+		// Assert that the pipelines produce equal results
+		AssertPipelinesEqual(t, filterPipeline, expectedPipeline)
+	})
+}


### PR DESCRIPTION
# Add Filter Pipeline Implementation

This PR implements a filter pipeline for Loki's engine executor component. The filter operator enables row-level filtering of Arrow record batches based on boolean expressions. This is a fundamental component for query execution.

## Changes

- Implement `NewFilterPipeline` for evaluating filter predicates on record batches
- Add `filterBatch` utility to efficiently filter Arrow records
- Update `executeFilter` in the executor to use the new implementation
- Add comprehensive test suite for the filter pipeline:
  - Basic literal predicates (true/false)
  - Column reference predicates
  - Empty batch handling
  - Multiple batch processing

## Implementation Notes

The filter implementation follows the same pattern as the project pipeline, evaluating predicates against each record and creating a new filtered record based on the results. The implementation supports compound predicates with AND logic.

This implementation provides a foundation for more advanced filtering operations as the expression evaluator is enhanced to support more complex expressions.