### PR TITLE
fix: improve structured metadata label normalization performance

### DIFF
--- a/pkg/chunkenc/symbols.go
+++ b/pkg/chunkenc/symbols.go
@@ -367,6 +367,7 @@ func symbolizerFromEnc(b []byte, pool compression.ReaderPool) (*symbolizer, erro
 		labels: make([]string, 0, numLabels),
 		// Same as symbolizerFromCheckpoint
 		normalizedNames: make(map[uint32]string, numLabels/2),
+		symbolsMap:      make(map[string]uint32, numLabels),
 		compressedSize:  len(b),
 	}
 
@@ -428,7 +429,9 @@ func symbolizerFromEnc(b []byte, pool compression.ReaderPool) (*symbolizer, erro
 				return nil, err
 			}
 		}
-		s.labels = append(s.labels, string(buf))
+		label := string(buf)
+		s.symbolsMap[label] = uint32(len(s.labels))
+		s.labels = append(s.labels, label)
 		s.size += len(buf)
 	}
 

--- a/pkg/chunkenc/symbols.go
+++ b/pkg/chunkenc/symbols.go
@@ -335,7 +335,7 @@ func symbolizerFromCheckpoint(b []byte) *symbolizer {
 	s := symbolizer{
 		symbolsMap: make(map[string]uint32, numLabels),
 		labels:     make([]string, 0, numLabels),
-		// If labels are pairs, preallocate to half the number to store just the keys,
+		// Labels are key-value pairs, preallocate to half the number to store just the keys,
 		// likely less memory than the exponential growth Go will do.
 		normalizedNames: make(map[uint32]string, numLabels/2),
 	}

--- a/pkg/chunkenc/symbols.go
+++ b/pkg/chunkenc/symbols.go
@@ -364,9 +364,9 @@ func symbolizerFromEnc(b []byte, pool compression.ReaderPool) (*symbolizer, erro
 	defer pool.PutReader(reader)
 
 	s := symbolizer{
-		labels:          make([]string, 0, numLabels),
-		symbolsMap:      make(map[string]uint32),
-		normalizedNames: make(map[uint32]string),
+		labels: make([]string, 0, numLabels),
+		// Same as symbolizerFromCheckpoint
+		normalizedNames: make(map[uint32]string, numLabels/2),
 		compressedSize:  len(b),
 	}
 
@@ -428,9 +428,7 @@ func symbolizerFromEnc(b []byte, pool compression.ReaderPool) (*symbolizer, erro
 				return nil, err
 			}
 		}
-		label := string(buf)
-		s.labels = append(s.labels, label)
-		s.symbolsMap[label] = uint32(i)
+		s.labels = append(s.labels, string(buf))
 		s.size += len(buf)
 	}
 

--- a/pkg/chunkenc/symbols_test.go
+++ b/pkg/chunkenc/symbols_test.go
@@ -175,3 +175,206 @@ func TestSymbolizer(t *testing.T) {
 		}
 	}
 }
+
+func TestSymbolizerLabelNormalization(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		labelsToAdd    []labels.Labels
+		expectedLabels []labels.Labels
+		description    string
+	}{
+		{
+			name: "basic label normalization",
+			labelsToAdd: []labels.Labels{
+				{
+					{Name: "foo-bar", Value: "value1"},
+					{Name: "fizz_buzz", Value: "value2"},
+				},
+			},
+			expectedLabels: []labels.Labels{
+				{
+					{Name: "foo_bar", Value: "value1"},
+					{Name: "fizz_buzz", Value: "value2"},
+				},
+			},
+			description: "hyphens should be converted to underscores in label names",
+		},
+		{
+			name: "same string as name and value",
+			labelsToAdd: []labels.Labels{
+				{
+					{Name: "foo-bar", Value: "foo-bar"},
+					{Name: "fizz-buzz", Value: "fizz-buzz"},
+				},
+			},
+			expectedLabels: []labels.Labels{
+				{
+					{Name: "foo_bar", Value: "foo-bar"},
+					{Name: "fizz_buzz", Value: "fizz-buzz"},
+				},
+			},
+			description: "only normalize when string is used as a name, not as a value",
+		},
+		{
+			name: "reused normalized names",
+			labelsToAdd: []labels.Labels{
+				{
+					{Name: "foo-bar", Value: "value1"},
+				},
+				{
+					{Name: "foo-bar", Value: "value2"},
+				},
+			},
+			expectedLabels: []labels.Labels{
+				{
+					{Name: "foo_bar", Value: "value1"},
+				},
+				{
+					{Name: "foo_bar", Value: "value2"},
+				},
+			},
+			description: "normalized names should be cached and reused",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// Test direct addition
+			s := newSymbolizer()
+			for i, labels := range tc.labelsToAdd {
+				symbols := s.Add(labels)
+				result := s.Lookup(symbols, nil)
+				require.Equal(t, tc.expectedLabels[i], result, "direct addition: %s", tc.description)
+			}
+
+			// Test serialization/deserialization via checkpoint
+			buf := bytes.NewBuffer(nil)
+			_, _, err := s.CheckpointTo(buf)
+			require.NoError(t, err)
+
+			loaded := symbolizerFromCheckpoint(buf.Bytes())
+			for i, labels := range tc.labelsToAdd {
+				symbols := loaded.Add(labels)
+				result := loaded.Lookup(symbols, nil)
+				require.Equal(t, tc.expectedLabels[i], result, "after checkpoint: %s", tc.description)
+			}
+
+			// Test serialization/deserialization via compression
+			buf.Reset()
+			_, _, err = s.SerializeTo(buf, compression.GetWriterPool(compression.Snappy))
+			require.NoError(t, err)
+
+			loaded, err = symbolizerFromEnc(buf.Bytes(), compression.GetReaderPool(compression.Snappy))
+			require.NoError(t, err)
+			for i, labels := range tc.labelsToAdd {
+				symbols := loaded.Add(labels)
+				result := loaded.Lookup(symbols, nil)
+				require.Equal(t, tc.expectedLabels[i], result, "after compression: %s", tc.description)
+			}
+		})
+	}
+}
+
+func TestSymbolizerNormalizationCache(t *testing.T) {
+	s := newSymbolizer()
+
+	// Add a label with a name that needs normalization
+	labels1 := labels.Labels{{Name: "foo-bar", Value: "value1"}}
+	symbols1 := s.Add(labels1)
+
+	// Look up the label multiple times
+	for i := 0; i < 3; i++ {
+		result := s.Lookup(symbols1, nil)
+		require.Equal(t, "foo_bar", result[0].Name, "normalized name should be consistent")
+		require.Equal(t, "value1", result[0].Value, "value should remain unchanged")
+	}
+
+	// Add the same label name with a different value
+	labels2 := labels.Labels{{Name: "foo-bar", Value: "value2"}}
+	symbols2 := s.Add(labels2)
+
+	// The normalized name should be reused
+	result := s.Lookup(symbols2, nil)
+	require.Equal(t, "foo_bar", result[0].Name, "normalized name should be reused")
+	require.Equal(t, "value2", result[0].Value, "new value should be used")
+
+	// Check that we have only one entry in normalizedNames for this label name
+	require.Equal(t, 1, len(s.normalizedNames), "should have only one normalized name entry")
+}
+
+func TestSymbolizerLabelNormalizationAfterDeserialization(t *testing.T) {
+	s := newSymbolizer()
+
+	// Add some labels and serialize them
+	originalLabels := labels.Labels{
+		{Name: "foo-bar", Value: "value1"},
+		{Name: "fizz-buzz", Value: "value2"},
+	}
+	s.Add(originalLabels)
+
+	buf := bytes.NewBuffer(nil)
+	_, _, err := s.SerializeTo(buf, compression.GetWriterPool(compression.Snappy))
+	require.NoError(t, err)
+
+	// Load the serialized data
+	loaded, err := symbolizerFromEnc(buf.Bytes(), compression.GetReaderPool(compression.Snappy))
+	require.NoError(t, err)
+
+	// Add new labels with the same names but different values
+	newLabels := labels.Labels{
+		{Name: "foo-bar", Value: "new-value1"},
+		{Name: "fizz-buzz", Value: "new-value2"},
+	}
+	symbols := loaded.Add(newLabels)
+
+	// Check that the normalization is consistent
+	result := loaded.Lookup(symbols, nil)
+	require.Equal(t, "foo_bar", result[0].Name, "first label should be normalized")
+	require.Equal(t, "new-value1", result[0].Value, "first value should be unchanged")
+	require.Equal(t, "fizz_buzz", result[1].Name, "second label should be normalized")
+	require.Equal(t, "new-value2", result[1].Value, "second value should be unchanged")
+}
+
+func TestSymbolizerLabelNormalizationSameNameValue(t *testing.T) {
+	s := newSymbolizer()
+
+	// Add labels where the name and value are the same string
+	originalLabels := labels.Labels{
+		{Name: "foo-bar", Value: "foo-bar"},
+		{Name: "test-label", Value: "test-label"},
+	}
+	originalSymbols := s.Add(originalLabels)
+
+	// Verify initial state
+	result := s.Lookup(originalSymbols, nil)
+	require.Equal(t, "foo_bar", result[0].Name, "name should be normalized")
+	require.Equal(t, "foo-bar", result[0].Value, "value should remain unchanged")
+	require.Equal(t, "test_label", result[1].Name, "name should be normalized")
+	require.Equal(t, "test-label", result[1].Value, "value should remain unchanged")
+
+	// Serialize the symbolizer
+	buf := bytes.NewBuffer(nil)
+	_, _, err := s.SerializeTo(buf, compression.GetWriterPool(compression.Snappy))
+	require.NoError(t, err)
+
+	// Load the serialized data
+	loaded, err := symbolizerFromEnc(buf.Bytes(), compression.GetReaderPool(compression.Snappy))
+	require.NoError(t, err)
+
+	// Look up using the original symbols without re-adding the labels
+	result = loaded.Lookup(originalSymbols, nil)
+	require.Equal(t, "foo_bar", result[0].Name, "name should be normalized after deserialization")
+	require.Equal(t, "foo-bar", result[0].Value, "value should remain unchanged after deserialization")
+	require.Equal(t, "test_label", result[1].Name, "name should be normalized after deserialization")
+	require.Equal(t, "test-label", result[1].Value, "value should remain unchanged after deserialization")
+
+	// Also test with checkpoint serialization
+	buf.Reset()
+	_, _, err = s.CheckpointTo(buf)
+	require.NoError(t, err)
+
+	loadedFromCheckpoint := symbolizerFromCheckpoint(buf.Bytes())
+	result = loadedFromCheckpoint.Lookup(originalSymbols, nil)
+	require.Equal(t, "foo_bar", result[0].Name, "name should be normalized after checkpoint")
+	require.Equal(t, "foo-bar", result[0].Value, "value should remain unchanged after checkpoint")
+	require.Equal(t, "test_label", result[1].Name, "name should be normalized after checkpoint")
+	require.Equal(t, "test-label", result[1].Value, "value should remain unchanged after checkpoint")
+}

--- a/pkg/logql/log/pipeline.go
+++ b/pkg/logql/log/pipeline.go
@@ -3,7 +3,6 @@ package log
 import (
 	"context"
 
-	"github.com/prometheus/otlptranslator"
 	"github.com/prometheus/prometheus/model/labels"
 
 	"sync"
@@ -102,9 +101,6 @@ func (n noopStreamPipeline) ReferencedStructuredMetadata() bool {
 
 func (n noopStreamPipeline) Process(_ int64, line []byte, structuredMetadata labels.Labels) ([]byte, LabelsResult, bool) {
 	n.builder.Reset()
-	for i, lb := range structuredMetadata {
-		structuredMetadata[i].Name = otlptranslator.NormalizeLabel(lb.Name)
-	}
 	n.builder.Add(StructuredMetadataLabel, structuredMetadata)
 	return line, n.builder.LabelsResult(), true
 }
@@ -224,10 +220,6 @@ func (p *streamPipeline) ReferencedStructuredMetadata() bool {
 func (p *streamPipeline) Process(ts int64, line []byte, structuredMetadata labels.Labels) ([]byte, LabelsResult, bool) {
 	var ok bool
 	p.builder.Reset()
-
-	for i, lb := range structuredMetadata {
-		structuredMetadata[i].Name = otlptranslator.NormalizeLabel(lb.Name)
-	}
 
 	p.builder.Add(StructuredMetadataLabel, structuredMetadata)
 

--- a/pkg/logql/log/pipeline_test.go
+++ b/pkg/logql/log/pipeline_test.go
@@ -54,18 +54,6 @@ func TestNoopPipeline(t *testing.T) {
 	require.Equal(t, expectedLabelsResults.String(), lbr.String())
 	require.Equal(t, true, matches)
 
-	// test structured metadata with disallowed label names
-	structuredMetadata = append(labels.FromStrings("y", "1", "z", "2"), labels.Label{Name: "zsomething-bad", Value: "foo"})
-	expectedStructuredMetadata := append(labels.FromStrings("y", "1", "z", "2"), labels.Label{Name: "zsomething_bad", Value: "foo"})
-	expectedLabelsResults = append(lbs, expectedStructuredMetadata...)
-
-	l, lbr, matches = pipeline.ForStream(lbs).Process(0, []byte(""), structuredMetadata)
-	require.Equal(t, []byte(""), l)
-	require.Equal(t, NewLabelsResult(expectedLabelsResults.String(), expectedLabelsResults.Hash(), lbs, expectedStructuredMetadata, labels.EmptyLabels()), lbr)
-	require.Equal(t, expectedLabelsResults.Hash(), lbr.Hash())
-	require.Equal(t, expectedLabelsResults.String(), lbr.String())
-	require.Equal(t, true, matches)
-
 	pipeline.Reset()
 	require.Len(t, pipeline.cache, 0)
 }
@@ -176,17 +164,6 @@ func TestPipelineWithStructuredMetadata(t *testing.T) {
 	require.Equal(t, "", ls)
 	require.Equal(t, nil, lbr)
 	require.Equal(t, false, matches)
-
-	// test structured metadata with disallowed label names
-	withBadLabel := append(structuredMetadata, labels.Label{Name: "zsomething-bad", Value: "foo"})
-	expectedStructuredMetadata := append(structuredMetadata, labels.Label{Name: "zsomething_bad", Value: "foo"})
-	expectedLabelsResults = append(lbs, expectedStructuredMetadata...)
-
-	_, lbr, matches = p.ForStream(lbs).Process(0, []byte(""), withBadLabel)
-	require.Equal(t, NewLabelsResult(expectedLabelsResults.String(), expectedLabelsResults.Hash(), lbs, expectedStructuredMetadata, labels.EmptyLabels()), lbr)
-	require.Equal(t, expectedLabelsResults.Hash(), lbr.Hash())
-	require.Equal(t, expectedLabelsResults.String(), lbr.String())
-	require.Equal(t, true, matches)
 
 	// Reset caches
 	p.baseBuilder.del = []string{"foo", "bar"}


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently we normalize all the structured metadata label names to make them prometheus safe during pipeline execution, this results in us running the normalization code again and again for the same labels.

This PR moves this normalization to when we deserialize the interned string data so it is only done one time.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
