### PR TITLE
fix(ruler): Preserve credentials when loading remote write config

### DIFF
--- a/pkg/ruler/config.go
+++ b/pkg/ruler/config.go
@@ -102,6 +102,10 @@ func (c *RemoteWriteConfig) Clone() (*RemoteWriteConfig, error) {
 		if n.Clients[id].HTTPClientConfig.BasicAuth != nil {
 			n.Clients[id].HTTPClientConfig.BasicAuth.Password = c.Clients[id].HTTPClientConfig.BasicAuth.Password
 		}
+
+		if n.Clients[id].HTTPClientConfig.Authorization != nil {
+			n.Clients[id].HTTPClientConfig.Authorization.Credentials = c.Clients[id].HTTPClientConfig.Authorization.Credentials
+		}
 	}
 
 	return n, nil

--- a/pkg/ruler/config_test.go
+++ b/pkg/ruler/config_test.go
@@ -2,7 +2,12 @@ package ruler
 
 import (
 	"flag"
+	"net/url"
 	"testing"
+
+	common_config "github.com/prometheus/common/config"
+	"github.com/prometheus/prometheus/config"
+	"github.com/stretchr/testify/require"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -16,4 +21,25 @@ func TestRemoteWriteConfig(t *testing.T) {
 	// assert new multi clients config is backward compatible if with single tenant.
 	// if not provided
 	assert.NotNil(t, r.Clients)
+}
+
+func TestCloneRemoteWriteConfigWithCredentials(t *testing.T) {
+	var remoteURL, _ = url.Parse("http://remote-write")
+
+	r := RemoteWriteConfig{
+		Clients: map[string]config.RemoteWriteConfig{
+			"default": {
+				URL: &common_config.URL{URL: remoteURL},
+				HTTPClientConfig: common_config.HTTPClientConfig{
+					Authorization: &common_config.Authorization{
+						Credentials: "1234",
+					},
+				},
+			},
+		},
+	}
+
+	c, err := r.Clone()
+	require.NoError(t, err)
+	assert.Equal(t, "1234", string(c.Clients["default"].HTTPClientConfig.Authorization.Credentials))
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

As a result of Ruler copying remote write configs through marshalling and unmarshalling, authorization credentials are automatically overwritten with `<secret>`, preventing their use. This fix manually copies the credentials from the source config to the target config.

**Which issue(s) this PR fixes**:
Fixes #17050 

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
