### PR TITLE
feat(helm): add option to use deployment type instead of daemonset in canary

### DIFF
--- a/docs/sources/setup/install/helm/reference.md
+++ b/docs/sources/setup/install/helm/reference.md
@@ -6754,6 +6754,15 @@ null
 </td>
 		</tr>
 		<tr>
+			<td>lokiCanary.kind</td>
+			<td>string</td>
+			<td>The type of the loki canary k8s rollout. This can be a DaemonSet or Deployment.</td>
+			<td><pre lang="json">
+"DaemonSet"
+</pre>
+</td>
+		</tr>
+		<tr>
 			<td>lokiCanary.labelname</td>
 			<td>string</td>
 			<td>The name of the label to look for at loki when doing the checks.</td>

--- a/production/helm/loki/ci/non-default-values.yaml
+++ b/production/helm/loki/ci/non-default-values.yaml
@@ -36,3 +36,5 @@ queryFrontend:
   replicas: 1
 queryScheduler:
   replicas: 1
+lokiCanary:
+  kind: Deployment

--- a/production/helm/loki/templates/loki-canary/daemonset.yaml
+++ b/production/helm/loki/templates/loki-canary/daemonset.yaml
@@ -2,7 +2,7 @@
 {{- if .enabled -}}
 ---
 apiVersion: apps/v1
-kind: DaemonSet
+kind: {{ .kind }}
 metadata:
   name: {{ include "loki-canary.fullname" $ }}
   namespace: {{ $.Release.Namespace }}
@@ -12,9 +12,18 @@ spec:
   selector:
     matchLabels:
       {{- include "loki-canary.selectorLabels" $ | nindent 6 }}
+  
+  {{- if eq .kind "Deployment" }}
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  {{- else }}
   {{- with .updateStrategy }}
   updateStrategy:
     {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- end }}
   template:
     metadata:

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -746,6 +746,8 @@ test:
 # that it's working correctly
 lokiCanary:
   enabled: true
+  # -- The type of the loki canary k8s rollout. This can be a DaemonSet or Deployment.
+  kind: DaemonSet
   # -- If true, the canary will send directly to Loki via the address configured for verification --
   # -- If false, it will write to stdout and an Agent will be needed to scrape and send the logs --
   push: true


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently lokiCananry uses the DaemonSet that end up creating 7000 pods in our cluster, since there is no possible way to limit number of containers deployed with Daemonset, I added an optional config to be able to switch to Deployment type


**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
