### PR TITLE
chore: adds a simple noop object client

### DIFF
--- a/pkg/storage/chunk/client/noop/noop_object_client.go
+++ b/pkg/storage/chunk/client/noop/noop_object_client.go
@@ -1,0 +1,70 @@
+package noop
+
+import (
+	"context"
+	"io"
+	"time"
+
+	"github.com/pkg/errors"
+
+	"github.com/grafana/loki/v3/pkg/storage/chunk/client"
+)
+
+// NoopObjectClient holds config for filesystem as object store
+type NoopObjectClient struct {
+}
+
+// NewNoopObjectClient makes a chunk.Client which stores chunks as files in the local filesystem.
+func NewNoopObjectClient() (*NoopObjectClient, error) {
+	return &NoopObjectClient{}, nil
+}
+
+// Stop implements ObjectClient
+func (NoopObjectClient) Stop() {}
+
+// GetObject from the store
+func (f *NoopObjectClient) GetObject(_ context.Context, objectKey string) (io.ReadCloser, int64, error) {
+	return nil, 0, errors.New("noop storage cannot return any objects")
+}
+
+func (f *NoopObjectClient) GetObjectRange(_ context.Context, _ string, _, _ int64) (io.ReadCloser, error) {
+	return nil, errors.New("noop storage cannot return any objects")
+}
+
+// PutObject into the store
+func (f *NoopObjectClient) PutObject(_ context.Context, objectKey string, object io.Reader) error {
+	return nil
+}
+
+// List implements chunk.ObjectClient.
+// NoopObjectClient assumes that prefix is a directory, and only supports "" and "/" delimiters.
+func (f *NoopObjectClient) List(ctx context.Context, prefix, delimiter string) ([]client.StorageObject, []client.StorageCommonPrefix, error) {
+	return []client.StorageObject{}, []client.StorageCommonPrefix{}, nil
+}
+
+func (f *NoopObjectClient) DeleteObject(ctx context.Context, objectKey string) error {
+	return nil
+}
+
+// DeleteChunksBefore implements BucketClient
+func (f *NoopObjectClient) DeleteChunksBefore(ctx context.Context, ts time.Time) error {
+	return nil
+}
+
+// IsObjectNotFoundErr returns true if error means that object is not found. Relevant to GetObject and DeleteObject operations.
+func (f *NoopObjectClient) IsObjectNotFoundErr(err error) bool {
+	return true
+}
+
+func (f *NoopObjectClient) ObjectExists(ctx context.Context, objectKey string) (bool, error) {
+	return false, nil
+}
+
+func (f *NoopObjectClient) IsRetryableErr(err error) bool {
+	return false
+}
+
+// GetAttributes implements ObjectClient
+func (f *NoopObjectClient) GetAttributes(_ context.Context, _ string) (client.ObjectAttributes, error) {
+	return client.ObjectAttributes{}, nil
+}

--- a/pkg/storage/chunk/client/noop/noop_object_client.go
+++ b/pkg/storage/chunk/client/noop/noop_object_client.go
@@ -10,61 +10,61 @@ import (
 	"github.com/grafana/loki/v3/pkg/storage/chunk/client"
 )
 
-// NoopObjectClient holds config for filesystem as object store
-type NoopObjectClient struct {
+// ObjectClient holds config for filesystem as object store
+type ObjectClient struct {
 }
 
 // NewNoopObjectClient makes a chunk.Client which stores chunks as files in the local filesystem.
-func NewNoopObjectClient() (*NoopObjectClient, error) {
-	return &NoopObjectClient{}, nil
+func NewNoopObjectClient() (*ObjectClient, error) {
+	return &ObjectClient{}, nil
 }
 
 // Stop implements ObjectClient
-func (NoopObjectClient) Stop() {}
+func (ObjectClient) Stop() {}
 
 // GetObject from the store
-func (f *NoopObjectClient) GetObject(_ context.Context, objectKey string) (io.ReadCloser, int64, error) {
+func (f *ObjectClient) GetObject(_ context.Context, _ string) (io.ReadCloser, int64, error) {
 	return nil, 0, errors.New("noop storage cannot return any objects")
 }
 
-func (f *NoopObjectClient) GetObjectRange(_ context.Context, _ string, _, _ int64) (io.ReadCloser, error) {
+func (f *ObjectClient) GetObjectRange(_ context.Context, _ string, _, _ int64) (io.ReadCloser, error) {
 	return nil, errors.New("noop storage cannot return any objects")
 }
 
 // PutObject into the store
-func (f *NoopObjectClient) PutObject(_ context.Context, objectKey string, object io.Reader) error {
+func (f *ObjectClient) PutObject(_ context.Context, _ string, _ io.Reader) error {
 	return nil
 }
 
 // List implements chunk.ObjectClient.
-// NoopObjectClient assumes that prefix is a directory, and only supports "" and "/" delimiters.
-func (f *NoopObjectClient) List(ctx context.Context, prefix, delimiter string) ([]client.StorageObject, []client.StorageCommonPrefix, error) {
+// ObjectClient assumes that prefix is a directory, and only supports "" and "/" delimiters.
+func (f *ObjectClient) List(_ context.Context, _, _ string) ([]client.StorageObject, []client.StorageCommonPrefix, error) {
 	return []client.StorageObject{}, []client.StorageCommonPrefix{}, nil
 }
 
-func (f *NoopObjectClient) DeleteObject(ctx context.Context, objectKey string) error {
+func (f *ObjectClient) DeleteObject(_ context.Context, _ string) error {
 	return nil
 }
 
 // DeleteChunksBefore implements BucketClient
-func (f *NoopObjectClient) DeleteChunksBefore(ctx context.Context, ts time.Time) error {
+func (f *ObjectClient) DeleteChunksBefore(_ context.Context, _ time.Time) error {
 	return nil
 }
 
 // IsObjectNotFoundErr returns true if error means that object is not found. Relevant to GetObject and DeleteObject operations.
-func (f *NoopObjectClient) IsObjectNotFoundErr(err error) bool {
+func (f *ObjectClient) IsObjectNotFoundErr(_ error) bool {
 	return true
 }
 
-func (f *NoopObjectClient) ObjectExists(ctx context.Context, objectKey string) (bool, error) {
+func (f *ObjectClient) ObjectExists(_ context.Context, _ string) (bool, error) {
 	return false, nil
 }
 
-func (f *NoopObjectClient) IsRetryableErr(err error) bool {
+func (f *ObjectClient) IsRetryableErr(_ error) bool {
 	return false
 }
 
 // GetAttributes implements ObjectClient
-func (f *NoopObjectClient) GetAttributes(_ context.Context, _ string) (client.ObjectAttributes, error) {
+func (f *ObjectClient) GetAttributes(_ context.Context, _ string) (client.ObjectAttributes, error) {
 	return client.ObjectAttributes{}, nil
 }

--- a/pkg/storage/factory.go
+++ b/pkg/storage/factory.go
@@ -29,6 +29,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/storage/chunk/client/hedging"
 	"github.com/grafana/loki/v3/pkg/storage/chunk/client/ibmcloud"
 	"github.com/grafana/loki/v3/pkg/storage/chunk/client/local"
+	"github.com/grafana/loki/v3/pkg/storage/chunk/client/noop"
 	"github.com/grafana/loki/v3/pkg/storage/chunk/client/openstack"
 	"github.com/grafana/loki/v3/pkg/storage/chunk/client/testutils"
 	"github.com/grafana/loki/v3/pkg/storage/config"
@@ -544,6 +545,10 @@ func NewChunkClient(name, component string, cfg Config, schemaCfg config.SchemaC
 			if cfg.CongestionControl.Enabled {
 				c = cc.Wrap(c)
 			}
+			return client.NewClientWithMaxParallel(c, nil, cfg.MaxParallelGetChunk, schemaCfg), nil
+
+		case types.StorageTypeNoop:
+			c, _ := noop.NewNoopObjectClient()
 			return client.NewClientWithMaxParallel(c, nil, cfg.MaxParallelGetChunk, schemaCfg), nil
 		}
 

--- a/pkg/storage/types/types.go
+++ b/pkg/storage/types/types.go
@@ -29,6 +29,7 @@ var SupportedStorageTypes = []string{
 	StorageTypeGCS,
 	StorageTypeS3,
 	StorageTypeSwift,
+	StorageTypeNoop,
 }
 
 var DeprecatedStorageTypes = []string{
@@ -65,6 +66,7 @@ const (
 	StorageTypeS3             = "s3"
 	StorageTypeSwift          = "swift"
 	StorageTypeCOS            = "cos"
+	StorageTypeNoop           = "noop"
 
 	BoltDBShipperType = "boltdb-shipper"
 	TSDBType          = "tsdb"


### PR DESCRIPTION
**What this PR does / why we need it**:

Not a very useful object client, but can be nice for some less common use cases/testing of Loki.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
