### PR TITLE
fix(push): fix guard clauses to prevent error spam in logs

### DIFF
--- a/pkg/loghttp/push/push.go
+++ b/pkg/loghttp/push/push.go
@@ -160,7 +160,7 @@ func ParseRequest(logger log.Logger, userID string, maxRecvMsgSize int, r *http.
 		for retentionPeriod, size := range retentionToSizeMapping {
 			retentionHours := RetentionPeriodToString(retentionPeriod)
 			// Add guard clause to prevent negative values from being passed to Prometheus counters
-			if size > 0 {
+			if size >= 0 {
 				bytesIngested.WithLabelValues(userID, retentionHours, isAggregatedMetric, policyName).Add(float64(size))
 				bytesReceivedStats.Inc(size)
 			} else {
@@ -181,7 +181,7 @@ func ParseRequest(logger log.Logger, userID string, maxRecvMsgSize int, r *http.
 			retentionHours := RetentionPeriodToString(retentionPeriod)
 
 			// Add guard clause to prevent negative values from being passed to Prometheus counters
-			if size > 0 {
+			if size >= 0 {
 				structuredMetadataBytesIngested.WithLabelValues(userID, retentionHours, isAggregatedMetric, policyName).Add(float64(size))
 				bytesIngested.WithLabelValues(userID, retentionHours, isAggregatedMetric, policyName).Add(float64(size))
 				bytesReceivedStats.Inc(size)


### PR DESCRIPTION
**What this PR does / why we need it**: 
loki write logs are littered with this error now because we are not sending any structured metadata through.
This was introduced through this change: [https://github.com/grafana/loki/pull/17056/](https://github.com/grafana/loki/pull/17056/files)

**Which issue(s) this PR fixes**:
Fixes #17371

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
