### PR TITLE
chore(engine): Add framework for function evaluation

### DIFF
--- a/pkg/engine/executor/expressions.go
+++ b/pkg/engine/executor/expressions.go
@@ -35,23 +35,37 @@ func (e expressionEvaluator) eval(expr physical.Expression, input arrow.Record) 
 		return nil, fmt.Errorf("unknown column %s: %w", expr.Ref.String(), errors.ErrKey)
 
 	case *physical.UnaryExpr:
-		_, err := e.eval(expr.Left, input)
+		lhr, err := e.eval(expr.Left, input)
 		if err != nil {
 			return nil, err
 		}
-		return nil, fmt.Errorf("failed to evaluate unary expression: %w", errors.ErrNotImplemented)
+
+		fn, err := unaryFunctions.GetForSignature(expr.Op, lhr.Type())
+		if err != nil {
+			return nil, fmt.Errorf("failed to lookup unary function: %w", err)
+		}
+		return fn.Evaluate(lhr)
 
 	case *physical.BinaryExpr:
-		_, err := e.eval(expr.Left, input)
+		lhs, err := e.eval(expr.Left, input)
 		if err != nil {
 			return nil, err
 		}
-		_, err = e.eval(expr.Right, input)
+		rhs, err := e.eval(expr.Right, input)
 		if err != nil {
 			return nil, err
 		}
-		return nil, fmt.Errorf("failed to evaluate binary expression: %w", errors.ErrNotImplemented)
 
+		// At the moment we only support functions that accept the same input types.
+		if lhs.Type().ID() != rhs.Type().ID() {
+			return nil, fmt.Errorf("failed to lookup binary function for signature %v(%v,%v): types do not match", expr.Op, lhs.Type(), rhs.Type())
+		}
+
+		fn, err := binaryFunctions.GetForSignature(expr.Op, lhs.Type())
+		if err != nil {
+			return nil, fmt.Errorf("failed to lookup binary function for signature %v(%v,%v): %w", expr.Op, lhs.Type(), rhs.Type(), err)
+		}
+		return fn.Evaluate(lhs, rhs)
 	}
 
 	return nil, fmt.Errorf("unknown expression: %v", expr)
@@ -71,9 +85,11 @@ type ColumnVector interface {
 	// ToArray returns the underlying Arrow array representation of the column vector.
 	ToArray() arrow.Array
 	// Value returns the value at the specified index position in the column vector.
-	Value(i int64) any
+	Value(i int) any
 	// Type returns the Arrow data type of the column vector.
 	Type() arrow.DataType
+	// Len returns the length of the vector
+	Len() int64
 }
 
 // Scalar represents a single value repeated any number of times.
@@ -111,7 +127,7 @@ func (v *Scalar) ToArray() arrow.Array {
 }
 
 // Value implements ColumnVector.
-func (v *Scalar) Value(_ int64) any {
+func (v *Scalar) Value(_ int) any {
 	return v.value.Value
 }
 
@@ -133,11 +149,18 @@ func (v Scalar) Type() arrow.DataType {
 	}
 }
 
+// Len implements ColumnVector.
+func (v Scalar) Len() int64 {
+	return v.rows
+}
+
 // Array represents a column of data, stored as an [arrow.Array].
 type Array struct {
 	array arrow.Array
 	rows  int64
 }
+
+var _ ColumnVector = (*Array)(nil)
 
 // ToArray implements ColumnVector.
 func (a *Array) ToArray() arrow.Array {
@@ -145,8 +168,25 @@ func (a *Array) ToArray() arrow.Array {
 }
 
 // Value implements ColumnVector.
-func (a *Array) Value(i int64) any {
-	return a.array.ValueStr(int(i))
+func (a *Array) Value(i int) any {
+	if a.array.IsNull(i) || !a.array.IsValid(i) {
+		return nil
+	}
+
+	switch arr := a.array.(type) {
+	case *array.Boolean:
+		return arr.Value(i)
+	case *array.String:
+		return arr.Value(i)
+	case *array.Int64:
+		return arr.Value(i)
+	case *array.Uint64:
+		return arr.Value(i)
+	case *array.Float64:
+		return arr.Value(i)
+	default:
+		return nil
+	}
 }
 
 // Type implements ColumnVector.
@@ -154,4 +194,7 @@ func (a *Array) Type() arrow.DataType {
 	return a.array.DataType()
 }
 
-var _ ColumnVector = (*Array)(nil)
+// Len implements ColumnVector.
+func (a *Array) Len() int64 {
+	return int64(a.array.Len())
+}

--- a/pkg/engine/executor/expressions_test.go
+++ b/pkg/engine/executor/expressions_test.go
@@ -14,6 +14,25 @@ import (
 	"github.com/grafana/loki/v3/pkg/engine/planner/physical"
 )
 
+var (
+	fields = []arrow.Field{
+		{Name: "name", Type: arrow.BinaryTypes.String},
+		{Name: "timestamp", Type: arrow.PrimitiveTypes.Uint64},
+		{Name: "value", Type: arrow.PrimitiveTypes.Float64},
+		{Name: "valid", Type: arrow.FixedWidthTypes.Boolean},
+	}
+	sampledata = `Alice,1745487598764058205,0.2586284611568047,false
+Bob,1745487598764058305,0.7823145698741236,true
+Charlie,1745487598764058405,0.3451289756123478,false
+David,1745487598764058505,0.9217834561278945,true
+Eve,1745487598764058605,0.1245789632145789,false
+Frank,1745487598764058705,0.5678912345678912,true
+Grace,1745487598764058805,0.8912345678912345,false
+Hannah,1745487598764058905,0.2345678912345678,true
+Ian,1745487598764059005,0.6789123456789123,false
+Julia,1745487598764059105,0.4123456789123456,true`
+)
+
 func TestEvaluateLiteralExpression(t *testing.T) {
 	for _, tt := range []struct {
 		name      string
@@ -62,7 +81,7 @@ func TestEvaluateLiteralExpression(t *testing.T) {
 			require.Equalf(t, tt.arrowType, colVec.Type().ID(), "expected: %v got: %v", tt.arrowType.String(), colVec.Type().ID().String())
 
 			for i := range n {
-				val := colVec.Value(int64(i))
+				val := colVec.Value(i)
 				require.Equal(t, tt.value, val)
 			}
 		})
@@ -101,10 +120,91 @@ func TestEvaluateColumnExpression(t *testing.T) {
 		require.Equal(t, arrow.STRING, colVec.Type().ID())
 
 		for i := range n {
-			val := colVec.Value(int64(i))
+			val := colVec.Value(i)
 			require.Equal(t, words[i%len(words)], val)
 		}
 	})
+}
+
+func TestEvaluateBinaryExpression(t *testing.T) {
+	rec, err := CSVToArrow(fields, sampledata)
+	require.NoError(t, err)
+	defer rec.Release()
+
+	e := expressionEvaluator{}
+
+	t.Run("error if types do not match", func(t *testing.T) {
+		expr := &physical.BinaryExpr{
+			Left: &physical.ColumnExpr{
+				Ref: types.ColumnRef{Column: "name", Type: types.ColumnTypeBuiltin},
+			},
+			Right: &physical.ColumnExpr{
+				Ref: types.ColumnRef{Column: "timestamp", Type: types.ColumnTypeBuiltin},
+			},
+			Op: types.BinaryOpEq,
+		}
+
+		_, err := e.eval(expr, rec)
+		require.ErrorContains(t, err, "failed to lookup binary function for signature EQ(utf8,uint64): types do not match")
+	})
+
+	t.Run("error if function for signature is not registered", func(t *testing.T) {
+		expr := &physical.BinaryExpr{
+			Left: &physical.ColumnExpr{
+				Ref: types.ColumnRef{Column: "name", Type: types.ColumnTypeBuiltin},
+			},
+			Right: &physical.ColumnExpr{
+				Ref: types.ColumnRef{Column: "name", Type: types.ColumnTypeBuiltin},
+			},
+			Op: types.BinaryOpInvalid,
+		}
+
+		_, err := e.eval(expr, rec)
+		require.ErrorContains(t, err, "failed to lookup binary function for signature invalid(utf8,utf8): not implemented")
+	})
+
+	t.Run("EQ(string,string)", func(t *testing.T) {
+		expr := &physical.BinaryExpr{
+			Left: &physical.ColumnExpr{
+				Ref: types.ColumnRef{Column: "name", Type: types.ColumnTypeBuiltin},
+			},
+			Right: &physical.LiteralExpr{
+				Value: types.Literal{Value: "Charlie"},
+			},
+			Op: types.BinaryOpEq,
+		}
+
+		res, err := e.eval(expr, rec)
+		require.NoError(t, err)
+		result := collectBooleanColumnVector(res)
+		require.Equal(t, []bool{false, false, true, false, false, false, false, false, false, false}, result)
+	})
+
+	t.Run("GT(float,float)", func(t *testing.T) {
+		expr := &physical.BinaryExpr{
+			Left: &physical.ColumnExpr{
+				Ref: types.ColumnRef{Column: "value", Type: types.ColumnTypeBuiltin},
+			},
+			Right: &physical.LiteralExpr{
+				Value: types.Literal{Value: 0.5},
+			},
+			Op: types.BinaryOpGt,
+		}
+
+		res, err := e.eval(expr, rec)
+		require.NoError(t, err)
+		result := collectBooleanColumnVector(res)
+		require.Equal(t, []bool{false, true, false, true, false, true, true, false, true, false}, result)
+	})
+}
+
+func collectBooleanColumnVector(vec ColumnVector) []bool {
+	res := make([]bool, 0, vec.Len())
+	arr := vec.ToArray().(*array.Boolean)
+	for i := range int(vec.Len()) {
+		res = append(res, arr.Value(i))
+	}
+	return res
 }
 
 var words = []string{"one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten"}
@@ -123,7 +223,6 @@ func batch(n int, now time.Time) arrow.Record {
 	)
 
 	// 3. Create builders for each column
-
 	logBuilder := array.NewStringBuilder(mem)
 	defer logBuilder.Release()
 

--- a/pkg/engine/executor/functions.go
+++ b/pkg/engine/executor/functions.go
@@ -1,0 +1,282 @@
+package executor
+
+import (
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+
+	"github.com/grafana/loki/v3/pkg/engine/internal/errors"
+	"github.com/grafana/loki/v3/pkg/engine/internal/types"
+)
+
+var (
+	unaryFunctions  UnaryFunctionRegistry  = &unaryFuncReg{}
+	binaryFunctions BinaryFunctionRegistry = &binaryFuncReg{}
+)
+
+func init() {
+	// Functions for [types.BinaryOpEq]
+	binaryFunctions.register(types.BinaryOpEq, arrow.FixedWidthTypes.Boolean, &boolCompareFunction{cmp: func(a, b bool) bool { return a == b }})
+	binaryFunctions.register(types.BinaryOpEq, arrow.BinaryTypes.String, &strCompareFunction{cmp: func(a, b string) bool { return a == b }})
+	binaryFunctions.register(types.BinaryOpEq, arrow.PrimitiveTypes.Int64, &intCompareFunction{cmp: func(a, b int64) bool { return a == b }})
+	binaryFunctions.register(types.BinaryOpEq, arrow.PrimitiveTypes.Uint64, &timestampCompareFunction{cmp: func(a, b uint64) bool { return a == b }})
+	binaryFunctions.register(types.BinaryOpEq, arrow.PrimitiveTypes.Float64, &floatCompareFunction{cmp: func(a, b float64) bool { return a == b }})
+	// Functions for [types.BinaryOpNeq]
+	binaryFunctions.register(types.BinaryOpNeq, arrow.FixedWidthTypes.Boolean, &boolCompareFunction{cmp: func(a, b bool) bool { return a != b }})
+	binaryFunctions.register(types.BinaryOpNeq, arrow.BinaryTypes.String, &strCompareFunction{cmp: func(a, b string) bool { return a != b }})
+	binaryFunctions.register(types.BinaryOpNeq, arrow.PrimitiveTypes.Int64, &intCompareFunction{cmp: func(a, b int64) bool { return a != b }})
+	binaryFunctions.register(types.BinaryOpNeq, arrow.PrimitiveTypes.Uint64, &timestampCompareFunction{cmp: func(a, b uint64) bool { return a != b }})
+	binaryFunctions.register(types.BinaryOpNeq, arrow.PrimitiveTypes.Float64, &floatCompareFunction{cmp: func(a, b float64) bool { return a != b }})
+	// Functions for [types.BinaryOpGt]
+	binaryFunctions.register(types.BinaryOpGt, arrow.FixedWidthTypes.Boolean, &boolCompareFunction{cmp: func(a, b bool) bool { return boolToInt(a) > boolToInt(b) }})
+	binaryFunctions.register(types.BinaryOpGt, arrow.BinaryTypes.String, &strCompareFunction{cmp: func(a, b string) bool { return a > b }})
+	binaryFunctions.register(types.BinaryOpGt, arrow.PrimitiveTypes.Int64, &intCompareFunction{cmp: func(a, b int64) bool { return a > b }})
+	binaryFunctions.register(types.BinaryOpGt, arrow.PrimitiveTypes.Uint64, &timestampCompareFunction{cmp: func(a, b uint64) bool { return a > b }})
+	binaryFunctions.register(types.BinaryOpGt, arrow.PrimitiveTypes.Float64, &floatCompareFunction{cmp: func(a, b float64) bool { return a > b }})
+	// Functions for [types.BinaryOpGte]
+	binaryFunctions.register(types.BinaryOpGte, arrow.FixedWidthTypes.Boolean, &boolCompareFunction{cmp: func(a, b bool) bool { return boolToInt(a) >= boolToInt(b) }})
+	binaryFunctions.register(types.BinaryOpGte, arrow.BinaryTypes.String, &strCompareFunction{cmp: func(a, b string) bool { return a >= b }})
+	binaryFunctions.register(types.BinaryOpGte, arrow.PrimitiveTypes.Int64, &intCompareFunction{cmp: func(a, b int64) bool { return a >= b }})
+	binaryFunctions.register(types.BinaryOpGte, arrow.PrimitiveTypes.Uint64, &timestampCompareFunction{cmp: func(a, b uint64) bool { return a >= b }})
+	binaryFunctions.register(types.BinaryOpGte, arrow.PrimitiveTypes.Float64, &floatCompareFunction{cmp: func(a, b float64) bool { return a >= b }})
+	// Functions for [types.BinaryOpLt]
+	binaryFunctions.register(types.BinaryOpLt, arrow.FixedWidthTypes.Boolean, &boolCompareFunction{cmp: func(a, b bool) bool { return boolToInt(a) < boolToInt(b) }})
+	binaryFunctions.register(types.BinaryOpLt, arrow.BinaryTypes.String, &strCompareFunction{cmp: func(a, b string) bool { return a < b }})
+	binaryFunctions.register(types.BinaryOpLt, arrow.PrimitiveTypes.Int64, &intCompareFunction{cmp: func(a, b int64) bool { return a < b }})
+	binaryFunctions.register(types.BinaryOpLt, arrow.PrimitiveTypes.Uint64, &timestampCompareFunction{cmp: func(a, b uint64) bool { return a < b }})
+	binaryFunctions.register(types.BinaryOpLt, arrow.PrimitiveTypes.Float64, &floatCompareFunction{cmp: func(a, b float64) bool { return a < b }})
+	// Functions for [types.BinaryOpLte]
+	binaryFunctions.register(types.BinaryOpLte, arrow.FixedWidthTypes.Boolean, &boolCompareFunction{cmp: func(a, b bool) bool { return boolToInt(a) <= boolToInt(b) }})
+	binaryFunctions.register(types.BinaryOpLte, arrow.BinaryTypes.String, &strCompareFunction{cmp: func(a, b string) bool { return a <= b }})
+	binaryFunctions.register(types.BinaryOpLte, arrow.PrimitiveTypes.Int64, &intCompareFunction{cmp: func(a, b int64) bool { return a <= b }})
+	binaryFunctions.register(types.BinaryOpLte, arrow.PrimitiveTypes.Uint64, &timestampCompareFunction{cmp: func(a, b uint64) bool { return a <= b }})
+	binaryFunctions.register(types.BinaryOpLte, arrow.PrimitiveTypes.Float64, &floatCompareFunction{cmp: func(a, b float64) bool { return a <= b }})
+}
+
+type UnaryFunctionRegistry interface {
+	register(types.UnaryOp, arrow.DataType, UnaryFunction)
+	GetForSignature(types.UnaryOp, arrow.DataType) (UnaryFunction, error)
+}
+
+type UnaryFunction interface {
+	Evaluate(lhs ColumnVector) (ColumnVector, error)
+}
+
+type unaryFuncReg struct {
+	reg map[types.UnaryOp]map[arrow.DataType]UnaryFunction
+}
+
+// register implements UnaryFunctionRegistry.
+func (u *unaryFuncReg) register(op types.UnaryOp, ltype arrow.DataType, f UnaryFunction) {
+	if u.reg == nil {
+		u.reg = make(map[types.UnaryOp]map[arrow.DataType]UnaryFunction)
+	}
+	if _, ok := u.reg[op]; !ok {
+		u.reg[op] = make(map[arrow.DataType]UnaryFunction)
+	}
+	// TODO(chaudum): Should the function panic when duplicate keys are registered?
+	u.reg[op][ltype] = f
+}
+
+// GetForSignature implements UnaryFunctionRegistry.
+func (u *unaryFuncReg) GetForSignature(types.UnaryOp, arrow.DataType) (UnaryFunction, error) {
+	return nil, errors.ErrNotImplemented
+}
+
+type BinaryFunctionRegistry interface {
+	register(types.BinaryOp, arrow.DataType, BinaryFunction)
+	GetForSignature(types.BinaryOp, arrow.DataType) (BinaryFunction, error)
+}
+
+// TODO(chaudum): Make BinaryFunction typed:
+//
+//	type BinaryFunction[L, R arrow.DataType] interface {
+//		Evaluate(lhs ColumnVector[L], rhs ColumnVector[R]) (ColumnVector[arrow.BOOL], error)
+//	}
+type BinaryFunction interface {
+	Evaluate(lhs, rhs ColumnVector) (ColumnVector, error)
+}
+
+type binaryFuncReg struct {
+	reg map[types.BinaryOp]map[arrow.DataType]BinaryFunction
+}
+
+// register implements BinaryFunctionRegistry.
+func (b *binaryFuncReg) register(op types.BinaryOp, ty arrow.DataType, f BinaryFunction) {
+	if b.reg == nil {
+		b.reg = make(map[types.BinaryOp]map[arrow.DataType]BinaryFunction)
+	}
+	if _, ok := b.reg[op]; !ok {
+		b.reg[op] = make(map[arrow.DataType]BinaryFunction)
+	}
+	// TODO(chaudum): Should the function panic when duplicate keys are registered?
+	b.reg[op][ty] = f
+}
+
+// GetForSignature implements BinaryFunctionRegistry.
+func (b *binaryFuncReg) GetForSignature(op types.BinaryOp, ltype arrow.DataType) (BinaryFunction, error) {
+	// Get registered functions for the specific operation
+	reg, ok := b.reg[op]
+	if !ok {
+		return nil, errors.ErrNotImplemented
+	}
+	// Get registered function for the specific data type
+	fn, ok := reg[ltype]
+	if !ok {
+		return nil, errors.ErrNotImplemented
+	}
+	return fn, nil
+}
+
+type boolCompareFunction struct {
+	cmp func(a, b bool) bool
+}
+
+// Evaluate implements BinaryFunction.
+func (f *boolCompareFunction) Evaluate(lhs ColumnVector, rhs ColumnVector) (ColumnVector, error) {
+	lhsArr := lhs.ToArray().(*array.Boolean)
+	rhsArr := rhs.ToArray().(*array.Boolean)
+
+	if lhsArr.Len() != rhsArr.Len() {
+		return nil, errors.ErrIndex
+	}
+
+	mem := memory.NewGoAllocator()
+	builder := array.NewBooleanBuilder(mem)
+	defer builder.Release()
+
+	for i := 0; i < lhs.ToArray().Len(); i++ {
+		if lhsArr.IsNull(i) || rhsArr.IsNull(i) {
+			builder.Append(false)
+			continue
+		}
+		builder.Append(f.cmp(lhsArr.Value(i), rhsArr.Value(i)))
+	}
+
+	return &Array{array: builder.NewArray()}, nil
+}
+
+type strCompareFunction struct {
+	cmp func(a, b string) bool
+}
+
+// Evaluate implements BinaryFunction.
+func (f *strCompareFunction) Evaluate(lhs ColumnVector, rhs ColumnVector) (ColumnVector, error) {
+	if lhs.Len() != rhs.Len() {
+		return nil, arrow.ErrIndex
+	}
+
+	lhsArr := lhs.ToArray().(*array.String)
+	rhsArr := rhs.ToArray().(*array.String)
+
+	mem := memory.NewGoAllocator()
+	builder := array.NewBooleanBuilder(mem)
+	defer builder.Release()
+
+	for i := 0; i < lhs.ToArray().Len(); i++ {
+		if lhsArr.IsNull(i) || rhsArr.IsNull(i) {
+			builder.Append(false)
+			continue
+		}
+		builder.Append(f.cmp(lhsArr.Value(i), rhsArr.Value(i)))
+	}
+
+	return &Array{array: builder.NewArray()}, nil
+}
+
+type intCompareFunction struct {
+	cmp func(a, b int64) bool
+}
+
+// Evaluate implements BinaryFunction.
+func (f *intCompareFunction) Evaluate(lhs ColumnVector, rhs ColumnVector) (ColumnVector, error) {
+	if lhs.Len() != rhs.Len() {
+		return nil, arrow.ErrIndex
+	}
+
+	lhsArr := lhs.ToArray().(*array.Int64)
+	rhsArr := rhs.ToArray().(*array.Int64)
+
+	mem := memory.NewGoAllocator()
+	builder := array.NewBooleanBuilder(mem)
+	defer builder.Release()
+
+	for i := 0; i < lhs.ToArray().Len(); i++ {
+		if lhsArr.IsNull(i) || rhsArr.IsNull(i) {
+			builder.Append(false)
+			continue
+		}
+		builder.Append(f.cmp(lhsArr.Value(i), rhsArr.Value(i)))
+	}
+
+	return &Array{array: builder.NewArray()}, nil
+}
+
+type timestampCompareFunction struct {
+	cmp func(a, b uint64) bool
+}
+
+// Evaluate implements BinaryFunction.
+func (f *timestampCompareFunction) Evaluate(lhs ColumnVector, rhs ColumnVector) (ColumnVector, error) {
+	if lhs.Len() != rhs.Len() {
+		return nil, arrow.ErrIndex
+	}
+
+	lhsArr := lhs.ToArray().(*array.Uint64)
+	rhsArr := rhs.ToArray().(*array.Uint64)
+
+	mem := memory.NewGoAllocator()
+	builder := array.NewBooleanBuilder(mem)
+	defer builder.Release()
+
+	for i := 0; i < lhs.ToArray().Len(); i++ {
+		if lhsArr.IsNull(i) || rhsArr.IsNull(i) {
+			builder.Append(false)
+			continue
+		}
+		builder.Append(f.cmp(lhsArr.Value(i), rhsArr.Value(i)))
+	}
+
+	return &Array{array: builder.NewArray()}, nil
+}
+
+type floatCompareFunction struct {
+	cmp func(a, b float64) bool
+}
+
+// Evaluate implements BinaryFunction.
+func (f *floatCompareFunction) Evaluate(lhs ColumnVector, rhs ColumnVector) (ColumnVector, error) {
+	if lhs.Len() != rhs.Len() {
+		return nil, arrow.ErrIndex
+	}
+
+	lhsArr := lhs.ToArray().(*array.Float64)
+	rhsArr := rhs.ToArray().(*array.Float64)
+
+	mem := memory.NewGoAllocator()
+	builder := array.NewBooleanBuilder(mem)
+	defer builder.Release()
+
+	for i := 0; i < lhs.ToArray().Len(); i++ {
+		if lhsArr.IsNull(i) || rhsArr.IsNull(i) {
+			builder.Append(false)
+			continue
+		}
+		builder.Append(f.cmp(lhsArr.Value(i), rhsArr.Value(i)))
+	}
+
+	return &Array{array: builder.NewArray()}, nil
+}
+
+// Compiler optimized version of converting boolean b into an integer of value 0 or 1
+// https://github.com/golang/go/issues/6011#issuecomment-323144578
+func boolToInt(b bool) int {
+	var i int
+	if b {
+		i = 1
+	} else {
+		i = 0
+	}
+	return i
+
+}

--- a/pkg/engine/internal/types/operators.go
+++ b/pkg/engine/internal/types/operators.go
@@ -42,6 +42,7 @@ const (
 	BinaryOpGte // Greater than or equal comparison (>=).
 	BinaryOpLt  // Less than comparison (<).
 	BinaryOpLte // Less than or equal comparison (<=).
+
 	BinaryOpAnd // Logical AND operation (&&).
 	BinaryOpOr  // Logical OR operation (||).
 	BinaryOpXor // Logical XOR operation (^).


### PR DESCRIPTION
## Using a function registry

On startup, functions (evaluators of ColumnVectors) for binary expressions can be registered using their signature consisting of the operation, left, and right hand side data type.

The left and right hand side of the binary expressions are evaluated recursively and then the results of the left and right side are compared/resolved with the function that matches the signature.