### PR TITLE
feat: add method to get zone-aware partition consumers

### DIFF
--- a/pkg/limits/frontend/ring.go
+++ b/pkg/limits/frontend/ring.go
@@ -119,23 +119,81 @@ func (g *RingStreamUsageGatherer) forGivenReplicaSet(ctx context.Context, rs rin
 	return responses, nil
 }
 
-type getAssignedPartitionsResponse struct {
-	Addr     string
-	Response *logproto.GetAssignedPartitionsResponse
+type zonePartitionConsumersResult struct {
+	zone       string
+	partitions map[int32]string
 }
 
+// getZoneAwarePartitionConsumers returns partition consumers for each zone
+// in the replication set. If a zone has no active partition consumers, the
+// zone will still be returned but its partition consumers will be nil.
+// If ZoneAwarenessEnabled is false, it returns all partition consumers under
+// a psuedo-zone ("").
+func (g *RingStreamUsageGatherer) getZoneAwarePartitionConsumers(ctx context.Context, instances []ring.InstanceDesc) (map[string]map[int32]string, error) {
+	zoneDescs := make(map[string][]ring.InstanceDesc)
+	for _, instance := range instances {
+		zoneDescs[instance.Zone] = append(zoneDescs[instance.Zone], instance)
+	}
+	// Get the partition consumers for each zone.
+	resultsCh := make(chan zonePartitionConsumersResult, len(zoneDescs))
+	errg, ctx := errgroup.WithContext(ctx)
+	for zone, instances := range zoneDescs {
+		errg.Go(func() error {
+			res, err := g.getPartitionConsumers(ctx, instances)
+			if err != nil {
+				level.Error(g.logger).Log("msg", "failed to get partition consumers for zone", "zone", zone, "err", err.Error())
+			}
+			// If the consumers could not be fetched for a zone, then it is
+			// expected partitionConsumers is nil.
+			resultsCh <- zonePartitionConsumersResult{
+				zone:       zone,
+				partitions: res,
+			}
+			return nil
+		})
+	}
+	errg.Wait() //nolint
+	close(resultsCh)
+	results := make(map[string]map[int32]string)
+	for result := range resultsCh {
+		results[result.zone] = result.partitions
+	}
+	return results, nil
+}
+
+type getAssignedPartitionsResponse struct {
+	addr     string
+	response *logproto.GetAssignedPartitionsResponse
+}
+
+// getPartitionConsumers returns the consumer for each partition.
+
+// In some cases, it might not be possible to know the consumer for a
+// partition. If this happens, it returns the consumers for a subset of
+// partitions that it does know about.
+//
+// For example, if a partition does not have a consumer then the partition
+// will be absent from the result. Likewise, if an instance does not respond,
+// the partition that it consumes will be absent from the result too. This
+// also means that if no partitions are assigned consumers, or if no instances
+// respond, the result will be empty.
+//
+// This method is not zone-aware, so if ZoneAwarenessEnabled is true, it
+// should be called once for each zone, and instances should be filtered to
+// the respective zone. Alternatively, you can pass all instances for all zones
+// to find the most up to date consumer for each partition across all zones.
 func (g *RingStreamUsageGatherer) getPartitionConsumers(ctx context.Context, instances []ring.InstanceDesc) (map[int32]string, error) {
 	errg, ctx := errgroup.WithContext(ctx)
-	responses := make(chan getAssignedPartitionsResponse, len(instances))
+	responseCh := make(chan getAssignedPartitionsResponse, len(instances))
 	for _, instance := range instances {
 		errg.Go(func() error {
 			// We use a cache to eliminate redundant gRPC requests for
 			// GetAssignedPartitions as the set of assigned partitions is
 			// expected to be stable outside consumer rebalances.
 			if resp, ok := g.assignedPartitionsCache.Get(instance.Addr); ok {
-				responses <- getAssignedPartitionsResponse{
-					Addr:     instance.Addr,
-					Response: resp,
+				responseCh <- getAssignedPartitionsResponse{
+					addr:     instance.Addr,
+					response: resp,
 				}
 				return nil
 			}
@@ -150,9 +208,9 @@ func (g *RingStreamUsageGatherer) getPartitionConsumers(ctx context.Context, ins
 				return nil
 			}
 			g.assignedPartitionsCache.Set(instance.Addr, resp)
-			responses <- getAssignedPartitionsResponse{
-				Addr:     instance.Addr,
-				Response: resp,
+			responseCh <- getAssignedPartitionsResponse{
+				addr:     instance.Addr,
+				response: resp,
 			}
 			return nil
 		})
@@ -160,14 +218,14 @@ func (g *RingStreamUsageGatherer) getPartitionConsumers(ctx context.Context, ins
 	if err := errg.Wait(); err != nil {
 		return nil, err
 	}
-	close(responses)
+	close(responseCh)
 	highestTimestamp := make(map[int32]int64)
 	assigned := make(map[int32]string)
-	for resp := range responses {
-		for partition, assignedAt := range resp.Response.AssignedPartitions {
+	for resp := range responseCh {
+		for partition, assignedAt := range resp.response.AssignedPartitions {
 			if t := highestTimestamp[partition]; t < assignedAt {
 				highestTimestamp[partition] = assignedAt
-				assigned[partition] = resp.Addr
+				assigned[partition] = resp.addr
 			}
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit adds a method to get zone-aware partition consumers.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
