### PR TITLE
chore: improve ring_test.go

### DIFF
--- a/pkg/limits/frontend/frontend_test.go
+++ b/pkg/limits/frontend/frontend_test.go
@@ -313,11 +313,11 @@ func TestFrontend_ExceedsLimits(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			// Set up the mock clients, one for each pair of mock RPC responses.
-			clients := make([]logproto.IngestLimitsClient, len(test.getAssignedPartitionsResponses))
-			instances := make([]ring.InstanceDesc, len(clients))
+			mockClients := make([]*mockIngestLimitsClient, len(test.getAssignedPartitionsResponses))
+			instances := make([]ring.InstanceDesc, len(mockClients))
 
 			for i := range test.getAssignedPartitionsResponses {
-				clients[i] = &mockIngestLimitsClient{
+				mockClients[i] = &mockIngestLimitsClient{
 					getAssignedPartitionsResponse: test.getAssignedPartitionsResponses[i],
 					expectedStreamUsageRequest:    test.expectedStreamUsageRequest[i],
 					getStreamUsageResponse:        test.getStreamUsageResponses[i],
@@ -329,7 +329,7 @@ func TestFrontend_ExceedsLimits(t *testing.T) {
 			}
 
 			// Set up the mocked ring and client pool for the tests.
-			readRing, clientPool := newMockRingWithClientPool(t, "test", clients, instances)
+			readRing, clientPool := newMockRingWithClientPool(t, "test", mockClients, instances)
 			l := &mockLimits{
 				maxGlobalStreams: test.maxGlobalStreams,
 				ingestionRate:    test.ingestionRate,

--- a/pkg/limits/frontend/mock_test.go
+++ b/pkg/limits/frontend/mock_test.go
@@ -47,16 +47,20 @@ type mockIngestLimitsClient struct {
 	getStreamUsageResponse           *logproto.GetStreamUsageResponse
 	getStreamUsageResponseErr        error
 
-	// The call count.
-	assignedPartitionsCallCount int
-	streamUsageCallCount        int
+	// The expected request counts.
+	expectedNumAssignedPartitionsRequests int
+	expectedNumStreamUsageRequests        int
+
+	// The actual request counts.
+	numAssignedPartitionsRequests int
+	numStreamUsageRequests        int
 }
 
 func (m *mockIngestLimitsClient) GetAssignedPartitions(_ context.Context, r *logproto.GetAssignedPartitionsRequest, _ ...grpc.CallOption) (*logproto.GetAssignedPartitionsResponse, error) {
 	if expected := m.expectedAssignedPartitionsRequest; expected != nil {
 		require.Equal(m.t, expected, r)
 	}
-	m.assignedPartitionsCallCount++
+	m.numAssignedPartitionsRequests++
 	if err := m.getAssignedPartitionsResponseErr; err != nil {
 		return nil, err
 	}
@@ -67,11 +71,16 @@ func (m *mockIngestLimitsClient) GetStreamUsage(_ context.Context, r *logproto.G
 	if expected := m.expectedStreamUsageRequest; expected != nil {
 		require.Equal(m.t, expected, r)
 	}
-	m.streamUsageCallCount++
+	m.numStreamUsageRequests++
 	if err := m.getStreamUsageResponseErr; err != nil {
 		return nil, err
 	}
 	return m.getStreamUsageResponse, nil
+}
+
+func (m *mockIngestLimitsClient) AssertExpectedNumRequests() {
+	require.Equal(m.t, m.expectedNumAssignedPartitionsRequests, m.numAssignedPartitionsRequests)
+	require.Equal(m.t, m.expectedNumStreamUsageRequests, m.numStreamUsageRequests)
 }
 
 func (m *mockIngestLimitsClient) Close() error {
@@ -129,7 +138,7 @@ func (m *mockLimits) IngestionBurstSizeBytes(_ string) int {
 	return 1000
 }
 
-func newMockRingWithClientPool(_ *testing.T, name string, clients []logproto.IngestLimitsClient, instances []ring.InstanceDesc) (ring.ReadRing, *ring_client.Pool) {
+func newMockRingWithClientPool(_ *testing.T, name string, clients []*mockIngestLimitsClient, instances []ring.InstanceDesc) (ring.ReadRing, *ring_client.Pool) {
 	// Set up the mock ring.
 	ring := &mockReadRing{
 		rs: ring.ReplicationSet{


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request improves the unit tests in `ring_test.go` to check the expected number of requests against the actual number of requests.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
