### PR TITLE
feat: adds partition-ingester push latency histogram

### DIFF
--- a/pkg/ingester/kafka_consumer.go
+++ b/pkg/ingester/kafka_consumer.go
@@ -123,7 +123,7 @@ func (kc *kafkaConsumer) consume(ctx context.Context, records []partition.Record
 			pushTime := time.Now()
 			_, err := kc.pusher.Push(recordCtx, req)
 
-			kc.metrics.pushLatency.Observe(float64(time.Since(pushTime).Seconds()))
+			kc.metrics.pushLatency.Observe(time.Since(pushTime).Seconds())
 
 			if err != nil {
 				level.Warn(kc.logger).Log("msg", "failed to push records", "err", err, "offset", record.Offset, "attempts", attempts)

--- a/production/terraform/modules/s3/versions.tf
+++ b/production/terraform/modules/s3/versions.tf
@@ -7,7 +7,7 @@ terraform {
 
     random = {
       source  = "hashicorp/random"
-      version = "3.7.1"
+      version = "3.7.2"
     }
   }
 


### PR DESCRIPTION
Adds a new histogram to the `ingester/kafka_consumer.go` consumer metrics to capture the amount of time taken to push a record once it has been consumed from Kafka.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
