### PR TITLE
feat(helm): Make helm labels more specific for antiaffinity

### DIFF
--- a/production/helm/loki/templates/backend/_helpers-backend.tpl
+++ b/production/helm/loki/templates/backend/_helpers-backend.tpl
@@ -11,6 +11,8 @@ backend common labels
 {{- define "loki.backendLabels" -}}
 {{ include "loki.labels" . }}
 app.kubernetes.io/component: backend
+app.kubernetes.io/instance: loki
+app.kubernetes.io/name: loki
 {{- end }}
 
 {{/*

--- a/production/helm/loki/templates/bloom-builder/_helpers-bloom-builder.tpl
+++ b/production/helm/loki/templates/bloom-builder/_helpers-bloom-builder.tpl
@@ -11,6 +11,8 @@ bloom-builder common labels
 {{- define "loki.bloomBuilderLabels" -}}
 {{ include "loki.labels" . }}
 app.kubernetes.io/component: bloom-builder
+app.kubernetes.io/instance: loki
+app.kubernetes.io/name: loki
 {{- end }}
 
 {{/*

--- a/production/helm/loki/templates/bloom-gateway/_helpers-bloom-gateway.tpl
+++ b/production/helm/loki/templates/bloom-gateway/_helpers-bloom-gateway.tpl
@@ -11,6 +11,8 @@ bloom gateway common labels
 {{- define "loki.bloomGatewayLabels" -}}
 {{ include "loki.labels" . }}
 app.kubernetes.io/component: bloom-gateway
+app.kubernetes.io/instance: loki
+app.kubernetes.io/name: loki
 {{- end }}
 
 {{/*

--- a/production/helm/loki/templates/bloom-planner/_helpers-bloom-planner.tpl
+++ b/production/helm/loki/templates/bloom-planner/_helpers-bloom-planner.tpl
@@ -11,6 +11,8 @@ bloom planner common labels
 {{- define "loki.bloomPlannerLabels" -}}
 {{ include "loki.labels" . }}
 app.kubernetes.io/component: bloom-planner
+app.kubernetes.io/instance: loki
+app.kubernetes.io/name: loki
 {{- end }}
 
 {{/*

--- a/production/helm/loki/templates/compactor/_helpers-compactor.tpl
+++ b/production/helm/loki/templates/compactor/_helpers-compactor.tpl
@@ -11,6 +11,8 @@ compactor common labels
 {{- define "loki.compactorLabels" -}}
 {{ include "loki.labels" . }}
 app.kubernetes.io/component: compactor
+app.kubernetes.io/instance: loki
+app.kubernetes.io/name: loki
 {{- end }}
 
 {{/*

--- a/production/helm/loki/templates/distributor/_helpers-distributor.tpl
+++ b/production/helm/loki/templates/distributor/_helpers-distributor.tpl
@@ -11,6 +11,8 @@ distributor common labels
 {{- define "loki.distributorLabels" -}}
 {{ include "loki.labels" . }}
 app.kubernetes.io/component: distributor
+app.kubernetes.io/instance: loki
+app.kubernetes.io/name: loki
 {{- end }}
 
 {{/*

--- a/production/helm/loki/templates/gateway/_helpers-gateway.tpl
+++ b/production/helm/loki/templates/gateway/_helpers-gateway.tpl
@@ -11,6 +11,8 @@ gateway common labels
 {{- define "loki.gatewayLabels" -}}
 {{ include "loki.labels" . }}
 app.kubernetes.io/component: gateway
+app.kubernetes.io/instance: loki
+app.kubernetes.io/name: loki
 {{- end }}
 
 {{/*

--- a/production/helm/loki/templates/index-gateway/_helpers-index-gateway.tpl
+++ b/production/helm/loki/templates/index-gateway/_helpers-index-gateway.tpl
@@ -11,6 +11,8 @@ index-gateway common labels
 {{- define "loki.indexGatewayLabels" -}}
 {{ include "loki.labels" . }}
 app.kubernetes.io/component: index-gateway
+app.kubernetes.io/instance: loki
+app.kubernetes.io/name: loki
 {{- end }}
 
 {{/*

--- a/production/helm/loki/templates/ingester/_helpers-ingester.tpl
+++ b/production/helm/loki/templates/ingester/_helpers-ingester.tpl
@@ -11,6 +11,8 @@ ingester common labels
 {{- define "loki.ingesterLabels" -}}
 {{ include "loki.labels" . }}
 app.kubernetes.io/component: ingester
+app.kubernetes.io/instance: loki
+app.kubernetes.io/name: loki
 {{- end }}
 
 {{/*

--- a/production/helm/loki/templates/loki-canary/_helpers.tpl
+++ b/production/helm/loki/templates/loki-canary/_helpers.tpl
@@ -11,6 +11,8 @@ canary common labels
 {{- define "loki-canary.labels" -}}
 {{ include "loki.labels" . }}
 app.kubernetes.io/component: canary
+app.kubernetes.io/instance: loki
+app.kubernetes.io/name: loki
 {{- end }}
 
 {{/*

--- a/production/helm/loki/templates/pattern-ingester/_helpers-pattern-ingester.tpl
+++ b/production/helm/loki/templates/pattern-ingester/_helpers-pattern-ingester.tpl
@@ -11,6 +11,8 @@ pattern ingester common labels
 {{- define "loki.patternIngesterLabels" -}}
 {{ include "loki.labels" . }}
 app.kubernetes.io/component: pattern-ingester
+app.kubernetes.io/instance: loki
+app.kubernetes.io/name: loki
 {{- end }}
 
 {{/*

--- a/production/helm/loki/templates/provisioner/_helpers.yaml
+++ b/production/helm/loki/templates/provisioner/_helpers.yaml
@@ -11,6 +11,8 @@ provisioner common labels
 {{- define "enterprise-logs.provisionerLabels" -}}
 {{ include "loki.labels" . }}
 app.kubernetes.io/component: provisioner
+app.kubernetes.io/instance: loki
+app.kubernetes.io/name: loki
 {{- end }}
 
 {{/*

--- a/production/helm/loki/templates/querier/_helpers-querier.tpl
+++ b/production/helm/loki/templates/querier/_helpers-querier.tpl
@@ -11,6 +11,8 @@ querier common labels
 {{- define "loki.querierLabels" -}}
 {{ include "loki.labels" . }}
 app.kubernetes.io/component: querier
+app.kubernetes.io/instance: loki
+app.kubernetes.io/name: loki
 {{- end }}
 
 {{/*

--- a/production/helm/loki/templates/query-frontend/_helpers-query-frontend.tpl
+++ b/production/helm/loki/templates/query-frontend/_helpers-query-frontend.tpl
@@ -11,6 +11,8 @@ query-frontend common labels
 {{- define "loki.queryFrontendLabels" -}}
 {{ include "loki.labels" . }}
 app.kubernetes.io/component: query-frontend
+app.kubernetes.io/instance: loki
+app.kubernetes.io/name: loki
 {{- end }}
 
 {{/*

--- a/production/helm/loki/templates/query-scheduler/_helpers-query-scheduler.tpl
+++ b/production/helm/loki/templates/query-scheduler/_helpers-query-scheduler.tpl
@@ -11,6 +11,8 @@ query-scheduler common labels
 {{- define "loki.querySchedulerLabels" -}}
 {{ include "loki.labels" . }}
 app.kubernetes.io/component: query-scheduler
+app.kubernetes.io/instance: loki
+app.kubernetes.io/name: loki
 {{- end }}
 
 {{/*

--- a/production/helm/loki/templates/read/_helpers-read.tpl
+++ b/production/helm/loki/templates/read/_helpers-read.tpl
@@ -11,6 +11,8 @@ read common labels
 {{- define "loki.readLabels" -}}
 {{ include "loki.labels" . }}
 app.kubernetes.io/component: read
+app.kubernetes.io/instance: loki
+app.kubernetes.io/name: loki
 {{- end }}
 
 {{/*

--- a/production/helm/loki/templates/ruler/_helpers-ruler.tpl
+++ b/production/helm/loki/templates/ruler/_helpers-ruler.tpl
@@ -11,6 +11,8 @@ ruler common labels
 {{- define "loki.rulerLabels" -}}
 {{ include "loki.labels" . }}
 app.kubernetes.io/component: ruler
+app.kubernetes.io/instance: loki
+app.kubernetes.io/name: loki
 {{- end }}
 
 {{/*

--- a/production/helm/loki/templates/single-binary/_helpers-single-binary.tpl
+++ b/production/helm/loki/templates/single-binary/_helpers-single-binary.tpl
@@ -11,6 +11,8 @@ app.kubernetes.io/component: single-binary
 {{- define "loki.singleBinarySelectorLabels" -}}
 {{ include "loki.selectorLabels" . }}
 app.kubernetes.io/component: single-binary
+app.kubernetes.io/instance: loki
+app.kubernetes.io/name: loki
 {{- end }}
 
 {{/*

--- a/production/helm/loki/templates/table-manager/_helpers-table-manager.tpl
+++ b/production/helm/loki/templates/table-manager/_helpers-table-manager.tpl
@@ -11,6 +11,8 @@ table-manager common labels
 {{- define "loki.tableManagerLabels" -}}
 {{ include "loki.labels" . }}
 app.kubernetes.io/component: table-manager
+app.kubernetes.io/instance: loki
+app.kubernetes.io/name: loki
 {{- end }}
 
 {{/*

--- a/production/helm/loki/templates/tokengen/_helpers.yaml
+++ b/production/helm/loki/templates/tokengen/_helpers.yaml
@@ -11,6 +11,8 @@ tokengen common labels
 {{- define "enterprise-logs.tokengenLabels" -}}
 {{ include "loki.labels" . }}
 app.kubernetes.io/component: tokengen
+app.kubernetes.io/instance: loki
+app.kubernetes.io/name: loki
 {{- end }}
 
 {{/*

--- a/production/helm/loki/templates/write/_helpers-write.tpl
+++ b/production/helm/loki/templates/write/_helpers-write.tpl
@@ -11,6 +11,8 @@ write common labels
 {{- define "loki.writeLabels" -}}
 {{ include "loki.labels" . }}
 app.kubernetes.io/component: write
+app.kubernetes.io/instance: loki
+app.kubernetes.io/name: loki
 {{- end }}
 
 {{/*

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -1075,6 +1075,8 @@ gateway:
         - labelSelector:
             matchLabels:
               app.kubernetes.io/component: gateway
+              app.kubernetes.io/instance: loki
+              app.kubernetes.io/name: loki
           topologyKey: kubernetes.io/hostname
   # -- DNS config for gateway pods
   dnsConfig: {}
@@ -1411,6 +1413,8 @@ singleBinary:
         - labelSelector:
             matchLabels:
               app.kubernetes.io/component: single-binary
+              app.kubernetes.io/instance: loki
+              app.kubernetes.io/name: loki
           topologyKey: kubernetes.io/hostname
   # -- DNS config for single binary pods
   dnsConfig: {}
@@ -1533,6 +1537,8 @@ write:
         - labelSelector:
             matchLabels:
               app.kubernetes.io/component: write
+              app.kubernetes.io/instance: loki
+              app.kubernetes.io/name: loki
           topologyKey: kubernetes.io/hostname
   # -- DNS config for write pods
   dnsConfig: {}
@@ -1647,6 +1653,8 @@ read:
         - labelSelector:
             matchLabels:
               app.kubernetes.io/component: read
+              app.kubernetes.io/instance: loki
+              app.kubernetes.io/name: loki
           topologyKey: kubernetes.io/hostname
   # -- DNS config for read pods
   dnsConfig: {}
@@ -1755,6 +1763,8 @@ backend:
         - labelSelector:
             matchLabels:
               app.kubernetes.io/component: backend
+              app.kubernetes.io/instance: loki
+              app.kubernetes.io/name: loki
           topologyKey: kubernetes.io/hostname
   # -- DNS config for backend pods
   dnsConfig: {}
@@ -1889,6 +1899,8 @@ ingester:
         - labelSelector:
             matchLabels:
               app.kubernetes.io/component: ingester
+              app.kubernetes.io/instance: loki
+              app.kubernetes.io/name: loki
           topologyKey: kubernetes.io/hostname
   # -- Pod Disruption Budget maxUnavailable
   maxUnavailable: 1
@@ -2064,6 +2076,8 @@ distributor:
         - labelSelector:
             matchLabels:
               app.kubernetes.io/component: distributor
+              app.kubernetes.io/instance: loki
+              app.kubernetes.io/name: loki
           topologyKey: kubernetes.io/hostname
   # -- Pod Disruption Budget maxUnavailable
   maxUnavailable: null
@@ -2169,6 +2183,8 @@ querier:
         - labelSelector:
             matchLabels:
               app.kubernetes.io/component: querier
+              app.kubernetes.io/instance: loki
+              app.kubernetes.io/name: loki
           topologyKey: kubernetes.io/hostname
   # -- Pod Disruption Budget maxUnavailable
   maxUnavailable: null
@@ -2276,6 +2292,8 @@ queryFrontend:
         - labelSelector:
             matchLabels:
               app.kubernetes.io/component: query-frontend
+              app.kubernetes.io/instance: loki
+              app.kubernetes.io/name: loki
           topologyKey: kubernetes.io/hostname
   # -- Pod Disruption Budget maxUnavailable
   maxUnavailable: null
@@ -2341,6 +2359,8 @@ queryScheduler:
         - labelSelector:
             matchLabels:
               app.kubernetes.io/component: query-scheduler
+              app.kubernetes.io/instance: loki
+              app.kubernetes.io/name: loki
           topologyKey: kubernetes.io/hostname
   # -- Pod Disruption Budget maxUnavailable
   maxUnavailable: 1
@@ -2407,6 +2427,8 @@ indexGateway:
         - labelSelector:
             matchLabels:
               app.kubernetes.io/component: index-gateway
+              app.kubernetes.io/instance: loki
+              app.kubernetes.io/name: loki
           topologyKey: kubernetes.io/hostname
   # -- Pod Disruption Budget maxUnavailable
   maxUnavailable: null
@@ -2477,6 +2499,8 @@ compactor:
         - labelSelector:
             matchLabels:
               app.kubernetes.io/component: compactor
+              app.kubernetes.io/instance: loki
+              app.kubernetes.io/name: loki
           topologyKey: kubernetes.io/hostname
   # -- Labels for compactor service
   serviceLabels: {}
@@ -2585,6 +2609,8 @@ bloomGateway:
         - labelSelector:
             matchLabels:
               app.kubernetes.io/component: bloom-gateway
+              app.kubernetes.io/instance: loki
+              app.kubernetes.io/name: loki
           topologyKey: kubernetes.io/hostname
   # -- Labels for bloom-gateway service
   serviceLabels: {}
@@ -2684,6 +2710,8 @@ bloomPlanner:
         - labelSelector:
             matchLabels:
               app.kubernetes.io/component: bloom-planner
+              app.kubernetes.io/instance: loki
+              app.kubernetes.io/name: loki
           topologyKey: kubernetes.io/hostname
   # -- Labels for bloom-planner service
   serviceLabels: {}
@@ -2830,6 +2858,8 @@ bloomBuilder:
         - labelSelector:
             matchLabels:
               app.kubernetes.io/component: bloom-builder
+              app.kubernetes.io/instance: loki
+              app.kubernetes.io/name: loki
           topologyKey: kubernetes.io/hostname
   # -- Pod Disruption Budget maxUnavailable
   maxUnavailable: null
@@ -2873,6 +2903,8 @@ patternIngester:
         - labelSelector:
             matchLabels:
               app.kubernetes.io/component: pattern-ingester
+              app.kubernetes.io/instance: loki
+              app.kubernetes.io/name: loki
           topologyKey: kubernetes.io/hostname
   # -- Labels for pattern ingester service
   serviceLabels: {}
@@ -3007,6 +3039,8 @@ ruler:
         - labelSelector:
             matchLabels:
               app.kubernetes.io/component: ruler
+              app.kubernetes.io/instance: loki
+              app.kubernetes.io/name: loki
           topologyKey: kubernetes.io/hostname
   # -- Pod Disruption Budget maxUnavailable
   maxUnavailable: null
@@ -3157,6 +3191,8 @@ overridesExporter:
         - labelSelector:
             matchLabels:
               app.kubernetes.io/component: overrides-exporter
+              app.kubernetes.io/instance: loki
+              app.kubernetes.io/name: loki
           topologyKey: kubernetes.io/hostname
   # -- Pod Disruption Budget maxUnavailable
   maxUnavailable: null
@@ -3780,6 +3816,8 @@ tableManager:
         - labelSelector:
             matchLabels:
               app.kubernetes.io/component: table-manager
+              app.kubernetes.io/instance: loki
+              app.kubernetes.io/name: loki
           topologyKey: kubernetes.io/hostname
   # -- DNS config table-manager pods
   dnsConfig: {}


### PR DESCRIPTION
**What this PR does / why we need it**:
Makes the labels for loki pods more specific so as to not cause issues when using with mimir.

**Which issue(s) this PR fixes**:
Fixes #17404 

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
