### PR TITLE
fix: fix integer overrun when calculating parallelism for very long time range queries

### DIFF
--- a/pkg/querier/queryrange/limits.go
+++ b/pkg/querier/queryrange/limits.go
@@ -679,7 +679,7 @@ func WeightedParallelism(
 		}
 	}
 
-	totalDur := int(tsdbDur + otherDur)
+	totalDur := int64(tsdbDur + otherDur)
 	// If totalDur is 0, the query likely does not overlap any of the schema configs so just use parallelism of 1 and
 	// let the downstream code handle it.
 	if totalDur == 0 {
@@ -688,11 +688,11 @@ func WeightedParallelism(
 		return 1
 	}
 
-	tsdbPart := int(tsdbDur) * tsdbMaxQueryParallelism / totalDur
-	regPart := int(otherDur) * regMaxQueryParallelism / totalDur
+	tsdbPart := int64(tsdbDur) * int64(tsdbMaxQueryParallelism) / totalDur
+	regPart := int64(otherDur) * int64(regMaxQueryParallelism) / totalDur
 
 	if combined := regPart + tsdbPart; combined > 0 {
-		return combined
+		return int(combined)
 	}
 
 	// As long as the actual config is not zero,

--- a/pkg/querier/queryrange/limits_test.go
+++ b/pkg/querier/queryrange/limits_test.go
@@ -741,6 +741,12 @@ func Test_WeightedParallelism(t *testing.T) {
 				end:   borderTime.Add(time.Hour),
 				exp:   100,
 			},
+			{
+				desc:  "huge range which previously overflowed int",
+				start: model.Now().Add(-24 * 60 * time.Hour),
+				end:   model.Now(),
+				exp:   100,
+			},
 		} {
 			t.Run(cfgs.desc+tc.desc, func(t *testing.T) {
 				require.Equal(t, tc.exp, WeightedParallelism(context.Background(), confs, "fake", limits, tc.start, tc.end))


### PR DESCRIPTION
**What this PR does / why we need it**:

Discovered that the code we use to calculate the max parallelism can overrun the int type leading to a max parallelism chosen of 1 instead of the correct value. 

Only affects a query somewhere longer than 40 days. (40 days doesn't have this problem, 60 days does).

Interestingly I'm not sure I can exactly explain the overflow behavior here, the `int` type is supposed to be signed 32 bit, and a time.Duration is a nanosecond value, so seems like this should have overflowed way sooner?

At any rate the behavior was easy to see in a debugger and using 64bit types fixes the problem, added a test to confirm.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
