### PR TITLE
fix: better fix integer overrun when calculating parallelism for very long time range queries

### DIFF
--- a/pkg/querier/queryrange/limits_test.go
+++ b/pkg/querier/queryrange/limits_test.go
@@ -667,7 +667,7 @@ func Test_GenerateCacheKey_NoDivideZero(t *testing.T) {
 
 func Test_WeightedParallelism(t *testing.T) {
 	limits := &fakeLimits{
-		tsdbMaxQueryParallelism: 100,
+		tsdbMaxQueryParallelism: 2048,
 		maxQueryParallelism:     10,
 	}
 
@@ -727,25 +727,25 @@ func Test_WeightedParallelism(t *testing.T) {
 				desc:  "50% each",
 				start: borderTime.Add(-time.Hour),
 				end:   borderTime.Add(time.Hour),
-				exp:   55,
+				exp:   1029,
 			},
 			{
 				desc:  "75/25 split",
 				start: borderTime.Add(-3 * time.Hour),
 				end:   borderTime.Add(time.Hour),
-				exp:   32,
+				exp:   519,
 			},
 			{
 				desc:  "start==end",
 				start: borderTime.Add(time.Hour),
 				end:   borderTime.Add(time.Hour),
-				exp:   100,
+				exp:   2048,
 			},
 			{
-				desc:  "huge range which previously overflowed int",
-				start: model.Now().Add(-24 * 60 * time.Hour),
-				end:   model.Now(),
-				exp:   100,
+				desc:  "huge range to make sure we don't int overflow in the calculations.",
+				start: borderTime,
+				end:   borderTime.Add(24 * time.Hour * 365 * 20),
+				exp:   2048,
 			},
 		} {
 			t.Run(cfgs.desc+tc.desc, func(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

#17428 didn't actually fix the issue, I had modified the test parallelism to 2048 when debugging but reverted it to the previous value in the test when cleaning up my PR.

Thanks to @rfratto for being curious here and digging a bit deeper.

The overflow was actually happening in the multiplication of the nanosecond duration of the query length and the query parallelism value.

This PR hopefully really fixes the issue by reducing the precision we use in this calculation, we don't need nanosecond precision for determining an approx weighed parallelism 👍 

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
