### PR TITLE
feat(helm): allow external memcached setup

### DIFF
--- a/docs/sources/setup/install/helm/reference.md
+++ b/docs/sources/setup/install/helm/reference.md
@@ -1893,6 +1893,15 @@ null
 </td>
 		</tr>
 		<tr>
+			<td>chunksCache.addresses</td>
+			<td>string</td>
+			<td>Comma separated addresses list in DNS Service Discovery format</td>
+			<td><pre lang="json">
+"dnssrvnoa+_memcached-client._tcp.{{ template \"loki.fullname\" $ }}-chunks-cache.{{ $.Release.Namespace }}.svc"
+</pre>
+</td>
+		</tr>
+		<tr>
 			<td>chunksCache.affinity</td>
 			<td>object</td>
 			<td>Affinity for chunks-cache pods</td>
@@ -6252,30 +6261,6 @@ null
 </td>
 		</tr>
 		<tr>
-			<td>loki.memcached</td>
-			<td>object</td>
-			<td>Configure memcached as an external cache for chunk and results cache. Disabled by default must enable and specify a host for each cache you would like to use.</td>
-			<td><pre lang="json">
-{
-  "chunk_cache": {
-    "batch_size": 256,
-    "enabled": false,
-    "host": "",
-    "parallelism": 10,
-    "service": "memcached-client"
-  },
-  "results_cache": {
-    "default_validity": "12h",
-    "enabled": false,
-    "host": "",
-    "service": "memcached-client",
-    "timeout": "500ms"
-  }
-}
-</pre>
-</td>
-		</tr>
-		<tr>
 			<td>loki.pattern_ingester</td>
 			<td>object</td>
 			<td>Optional pattern ingester configuration</td>
@@ -6871,6 +6856,15 @@ false
   },
   "readOnlyRootFilesystem": true
 }
+</pre>
+</td>
+		</tr>
+		<tr>
+			<td>memcached.enabled</td>
+			<td>bool</td>
+			<td>Enable the built in memcached server provided by the chart</td>
+			<td><pre lang="json">
+true
 </pre>
 </td>
 		</tr>
@@ -10165,6 +10159,15 @@ null
 			<td>Topology Spread Constraints for read pods</td>
 			<td><pre lang="json">
 []
+</pre>
+</td>
+		</tr>
+		<tr>
+			<td>resultsCache.addresses</td>
+			<td>string</td>
+			<td>Comma separated addresses list in DNS Service Discovery format</td>
+			<td><pre lang="json">
+"dnssrvnoa+_memcached-client._tcp.{{ template \"loki.fullname\" $ }}-results-cache.{{ $.Release.Namespace }}.svc"
 </pre>
 </td>
 		</tr>

--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -26,6 +26,13 @@ Entries should include a reference to the pull request that introduced the chang
 - [BUGFIX] Ensure global.extraEnv and global.extraEnvFrom applied to all resources consistently ([#16828](https://github.com/grafana/loki/pull/16828))
 - [BUGFIX] Fixed statement logic to enable annotations for deployment-gateway, deployment-read, and statefulset-write
 - [BUGFIX] Fix `extraArgs`, `extraVolumes`, `extraVolumeMounts` global values.
+- [FEATURE] Add config support for external memcache cluster by setting the following config:
+    memcached:
+        enabled: false # <- setting false here
+    resultsCache:
+        addresses: 'my-resultsCache-memcached-address' # <- setting results cache address here
+    chunksCache:
+        addresses: 'my-chunksCache-memcached-address' # <- setting chunks cache address here
 
 ## 6.29.0
 

--- a/production/helm/loki/templates/chunks-cache/poddisruptionbudget-chunks-cache.yaml
+++ b/production/helm/loki/templates/chunks-cache/poddisruptionbudget-chunks-cache.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.chunksCache.enabled }}
+{{- if and .Values.chunksCache.enabled (.Values.memcached.enabled) }}
 apiVersion: {{ include "loki.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:

--- a/production/helm/loki/templates/memcached/_memcached-statefulset.tpl
+++ b/production/helm/loki/templates/memcached/_memcached-statefulset.tpl
@@ -8,7 +8,7 @@ valuesSection and component are specified separately because helm prefers camelc
 */}}
 {{- define "loki.memcached.statefulSet" -}}
 {{ with (index $.ctx.Values $.valuesSection) }}
-{{- if .enabled -}}
+{{- if and .enabled ($.ctx.Values.memcached.enabled) -}}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -181,4 +181,3 @@ spec:
 {{- end -}}
 {{- end -}}
 {{- end -}}
-

--- a/production/helm/loki/templates/memcached/_memcached-svc.tpl
+++ b/production/helm/loki/templates/memcached/_memcached-svc.tpl
@@ -8,7 +8,7 @@ valuesSection and component are specified separately because helm prefers camelc
 */}}
 {{- define "loki.memcached.service" -}}
 {{ with (index $.ctx.Values $.valuesSection) }}
-{{- if .enabled -}}
+{{- if and .enabled ($.ctx.Values.memcached.enabled) -}}
 apiVersion: v1
 kind: Service
 metadata:

--- a/production/helm/loki/templates/results-cache/poddisruptionbudget-results-cache.yaml
+++ b/production/helm/loki/templates/results-cache/poddisruptionbudget-results-cache.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.resultsCache.enabled }}
+{{- if and .Values.resultsCache.enabled (.Values.memcached.enabled) }}
 apiVersion: {{ include "loki.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -207,7 +207,7 @@ loki:
           batch_size: {{ .batchSize }}
           parallelism: {{ .parallelism }}
         memcached_client:
-          addresses: dnssrvnoa+_memcached-client._tcp.{{ template "loki.fullname" $ }}-chunks-cache.{{ $.Release.Namespace }}.svc
+          addresses: {{ .addresses }}
           consistent_hash: true
           timeout: {{ .timeout }}
           max_idle_conns: 72
@@ -255,8 +255,8 @@ loki:
             writeback_buffer: {{ .writebackBuffer }}
             writeback_size_limit: {{ .writebackSizeLimit }}
           memcached_client:
+            addresses: {{ .addresses }}
             consistent_hash: true
-            addresses: dnssrvnoa+_memcached-client._tcp.{{ template "loki.fullname" $ }}-results-cache.{{ $.Release.Namespace }}.svc
             timeout: {{ .timeout }}
             update_interval: 1m
       {{- end }}
@@ -457,21 +457,6 @@ loki:
         # Optional storage account key
         account_key: null
 
-  # -- Configure memcached as an external cache for chunk and results cache. Disabled by default
-  # must enable and specify a host for each cache you would like to use.
-  memcached:
-    chunk_cache:
-      enabled: false
-      host: ""
-      service: "memcached-client"
-      batch_size: 256
-      parallelism: 10
-    results_cache:
-      enabled: false
-      host: ""
-      service: "memcached-client"
-      timeout: "500ms"
-      default_validity: "12h"
   # -- Check https://grafana.com/docs/loki/latest/configuration/#schema_config for more info on how to configure schemas
   schemaConfig: {}
   # -- a real Loki install requires a proper schemaConfig defined above this, however for testing or playing around
@@ -3190,7 +3175,10 @@ overridesExporter:
   appProtocol:
     grpc: ""
 
+# You can use a self hosted memcached by setting enabled to false and providing addresses.
 memcached:
+  # -- Enable the built in memcached server provided by the chart
+  enabled: true
   image:
     # -- Memcached Docker image repository
     repository: memcached
@@ -3249,6 +3237,8 @@ memcachedExporter:
 resultsCache:
   # -- Specifies whether memcached based results-cache should be enabled
   enabled: true
+  # -- Comma separated addresses list in DNS Service Discovery format
+  addresses: dnssrvnoa+_memcached-client._tcp.{{ template "loki.fullname" $ }}-results-cache.{{ $.Release.Namespace }}.svc
   # -- Specify how long cached results should be stored in the results-cache before being expired
   defaultValidity: 12h
   # -- Memcached operation timeout
@@ -3347,6 +3337,8 @@ resultsCache:
 chunksCache:
   # -- Specifies whether memcached based chunks-cache should be enabled
   enabled: true
+  # -- Comma separated addresses list in DNS Service Discovery format
+  addresses: dnssrvnoa+_memcached-client._tcp.{{ template "loki.fullname" $ }}-chunks-cache.{{ $.Release.Namespace }}.svc
   # -- Batchsize for sending and receiving chunks from chunks cache
   batchSize: 4
   # -- Parallel threads for sending and receiving chunks from chunks cache


### PR DESCRIPTION
**What this PR does / why we need it**:
allow external memcached setup, with overriding addresses.

Which issue(s) this PR fixes:
Fixes #12559

**Special notes for your reviewer**:
the old config loki.memcached does't work anymore.

New way of setting up external memcache is with:
```
memcached:
    enabled: false # <- setting false here
resultsCache:
    addresses: 'my-resultsCache-memcached-address' # <- setting custom address here
chunksCache:
    addresses: 'my-chunksCache-memcached-address' # <- setting custom address here
```

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)