### PR TITLE
fix(distributor): Disable metadata topic writes

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -1268,7 +1268,7 @@ func (d *Distributor) sendStreamToKafka(ctx context.Context, stream KeyedStream,
 
 	entriesSize, structuredMetadataSize := calculateStreamSizes(stream.Stream)
 
-	if _, ok := skipMetadataHashes[stream.HashKeyNoShard]; !ok {
+	if _, ok := skipMetadataHashes[stream.HashKeyNoShard]; !ok && d.cfg.IngestLimitsEnabled {
 		// However, unlike stream records, the distributor writes stream metadata
 		// records to one of a fixed number of partitions, the size of which is
 		// determined ahead of time. It does not use a ring. The reason for this

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -2645,9 +2645,7 @@ func TestDistributor_SkipMetadataHashes(t *testing.T) {
 				}},
 			}},
 		},
-		// For now, metadata records are still written when
-		// limits are disabled in distributors.
-		expectedMetadataRecords: 1,
+		expectedMetadataRecords: 0,
 	}, {
 		name:                "limits are enabled",
 		ingestLimitsEnabled: true,


### PR DESCRIPTION
**What this PR does / why we need it**:
This pull requests disables writes to the metadata topic when the configuration options `IngestLimitsEnabled` is false.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
