### PR TITLE
chore: use nested if, it's much easier to reason about

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -1269,25 +1269,27 @@ func (d *Distributor) sendStreamToKafka(ctx context.Context, stream KeyedStream,
 
 	entriesSize, structuredMetadataSize := calculateStreamSizes(stream.Stream)
 
-	if _, ok := skipMetadataHashes[stream.HashKeyNoShard]; !ok && d.cfg.IngestLimitsEnabled {
-		// However, unlike stream records, the distributor writes stream metadata
-		// records to one of a fixed number of partitions, the size of which is
-		// determined ahead of time. It does not use a ring. The reason for this
-		// is that we want to be able to scale components that consume metadata
-		// records independent of ingesters.
-		metadataPartitionID := int32(stream.HashKeyNoShard % uint64(d.numMetadataPartitions))
-		metadata, err := kafka.EncodeStreamMetadata(
-			metadataPartitionID,
-			d.cfg.KafkaConfig.Topic,
-			tenant,
-			stream.HashKeyNoShard,
-			entriesSize,
-			structuredMetadataSize,
-		)
-		if err != nil {
-			return fmt.Errorf("failed to marshal metadata: %w", err)
+	if d.cfg.IngestLimitsEnabled {
+		if _, ok := skipMetadataHashes[stream.HashKeyNoShard]; !ok {
+			// However, unlike stream records, the distributor writes stream metadata
+			// records to one of a fixed number of partitions, the size of which is
+			// determined ahead of time. It does not use a ring. The reason for this
+			// is that we want to be able to scale components that consume metadata
+			// records independent of ingesters.
+			metadataPartitionID := int32(stream.HashKeyNoShard % uint64(d.numMetadataPartitions))
+			metadata, err := kafka.EncodeStreamMetadata(
+				metadataPartitionID,
+				d.cfg.KafkaConfig.Topic,
+				tenant,
+				stream.HashKeyNoShard,
+				entriesSize,
+				structuredMetadataSize,
+			)
+			if err != nil {
+				return fmt.Errorf("failed to marshal metadata: %w", err)
+			}
+			records = append(records, metadata)
 		}
-		records = append(records, metadata)
 	}
 
 	d.kafkaRecordsPerRequest.Observe(float64(len(records)))


### PR DESCRIPTION
**What this PR does / why we need it**:

I suggest we use two if statements instead of chaining the enablement flag onto the end of the existing one. It's much easier when reading the code to ignore the entire block when `d.cfg.IngestLimitsEnabled` is false. 

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
