### PR TITLE
fix: force the use of the 127.0.0.1 loopback address when computing the compactor address for SingleBinary and SimpleScalable deployments

### DIFF
--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -1258,8 +1258,12 @@ func (t *Loki) supportIndexDeleteRequest() bool {
 func (t *Loki) compactorAddress() (string, bool, error) {
 	legacyReadMode := t.Cfg.LegacyReadTarget && t.Cfg.isTarget(Read)
 	if t.Cfg.isTarget(All) || legacyReadMode || t.Cfg.isTarget(Backend) {
+		listenAddress := "127.0.0.1"
+		if t.Cfg.Server.GRPCListenAddress != "" {
+			listenAddress = t.Cfg.Server.GRPCListenAddress
+		}
 		// In single binary or read modes, this module depends on Server
-		return net.JoinHostPort(t.Cfg.Server.GRPCListenAddress, strconv.Itoa(t.Cfg.Server.GRPCListenPort)), true, nil
+		return net.JoinHostPort(listenAddress, strconv.Itoa(t.Cfg.Server.GRPCListenPort)), true, nil
 	}
 
 	if t.Cfg.Common.CompactorAddress == "" && t.Cfg.Common.CompactorGRPCAddress == "" {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix a bug where GRPC calls to ":9095" address, which target localhost, ignores the no_proxy instruction.
This is a common go issue (https://github.com/golang/go/issues/48325), it gets fixed by changing the ":9095" address by "127.0.0.1:9095" when required.

The fix logic is similar to the one used by the querier to determine the address of the frontend/scheduler address here : 
https://github.com/grafana/loki/blob/46b2271aacd26734979667da61d5c9d24a8efb2b/pkg/querier/worker_service.go#L90C2-L94C4

**Which issue(s) this PR fixes**:
Fixes #17100 

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
