### PR TITLE
fix: make helm use grpc for compactor address

### DIFF
--- a/production/helm/loki/templates/_helpers.tpl
+++ b/production/helm/loki/templates/_helpers.tpl
@@ -1043,7 +1043,7 @@ enableServiceLinks: false
 {{- else if $isDistributed -}}
 {{- $compactorAddress = include "loki.compactorFullname" . -}}
 {{- end -}}
-{{- printf "http://%s:%s" $compactorAddress (.Values.loki.server.http_listen_port | toString) }}
+{{- printf "%s.%s.svc.%s:%s" $compactorAddress .Release.Namespace .Values.global.clusterDomain (.Values.loki.server.grpc_listen_port | toString) }}
 {{- end }}
 
 {{/* Determine query-scheduler address */}}


### PR DESCRIPTION
**What this PR does / why we need it**:
Align the computation logic of the compactor address with how other address are computed.
Moreover, it makes use of grpc, as according to the Loki codebase, it's the preferred way :
https://github.com/grafana/loki/blob/46b2271aacd26734979667da61d5c9d24a8efb2b/pkg/loki/modules.go#L1256C1-L1274C2

**Which issue(s) this PR fixes**:
Kind of fixes #17100, as using the full hostname of the service rather than the short name helps comply with the no_proxy instruction, even if not mandatory

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)