### PR TITLE
fix(helm): Correct typo in reference to global values.

### DIFF
--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -13,6 +13,7 @@ Entries should include a reference to the pull request that introduced the chang
 
 [//]: # (<AUTOMATED_UPDATES_LOCATOR> : do not remove this line. This locator is used by the CI pipeline to automatically create a changelog entry for each new Loki release. Add other chart versions and respective changelog entries bellow this line.)
 
+- [BUGFIX] Fixed mismatch in reference to global value `extraEnvFrom` in Helm chart.
 - [FEATURE] Added support for the rules sidecar in the ruler pods in distributed mode
 
 ## 6.29.0

--- a/production/helm/loki/templates/backend/statefulset-backend.yaml
+++ b/production/helm/loki/templates/backend/statefulset-backend.yaml
@@ -168,7 +168,7 @@ spec:
           env:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with (concat .Values.global.extraEnv .Values.backend.extraEnvFrom) | uniq }}
+          {{- with (concat .Values.global.extraEnvFrom .Values.backend.extraEnvFrom) | uniq }}
           envFrom:
             {{- toYaml . | nindent 12 }}
           {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixed mismatch in reference to global value `extraEnvFrom` in Helm chart.
