### PR TITLE
chore(engine): Add basic metrics for next generation execution engine

### DIFF
--- a/pkg/engine/metrics.go
+++ b/pkg/engine/metrics.go
@@ -1,0 +1,49 @@
+package engine
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	"github.com/grafana/loki/v3/pkg/util/constants"
+)
+
+var (
+	status               = "status"
+	statusSuccess        = "success"
+	statusFailure        = "failure"
+	statusNotImplemented = "notimplemented"
+)
+
+// NOTE: Metrics are subject to rapid change!
+type metrics struct {
+	subqueries       *prometheus.CounterVec
+	logicalPlanning  prometheus.Histogram
+	physicalPlanning prometheus.Histogram
+	execution        prometheus.Histogram
+}
+
+func newMetrics(r prometheus.Registerer) *metrics {
+	subsystem := "engine_v2"
+	return &metrics{
+		subqueries: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
+			Namespace: constants.Loki,
+			Subsystem: subsystem,
+			Name:      "subqueries",
+		}, []string{status}),
+		logicalPlanning: promauto.With(r).NewHistogram(prometheus.HistogramOpts{
+			Namespace: constants.Loki,
+			Subsystem: subsystem,
+			Name:      "logical_planning",
+		}),
+		physicalPlanning: promauto.With(r).NewHistogram(prometheus.HistogramOpts{
+			Namespace: constants.Loki,
+			Subsystem: subsystem,
+			Name:      "physical_planning",
+		}),
+		execution: promauto.With(r).NewHistogram(prometheus.HistogramOpts{
+			Namespace: constants.Loki,
+			Subsystem: subsystem,
+			Name:      "execution",
+		}),
+	}
+}

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -622,7 +622,7 @@ func (t *Loki) initQuerier() (services.Service, error) {
 		ms = metastore.NewObjectMetastore(store)
 	}
 
-	t.querierAPI = querier.NewQuerierAPI(t.Cfg.Querier, t.Querier, t.Overrides, ms, logger)
+	t.querierAPI = querier.NewQuerierAPI(t.Cfg.Querier, t.Querier, t.Overrides, ms, prometheus.DefaultRegisterer, logger)
 
 	indexStatsHTTPMiddleware := querier.WrapQuerySpanAndTimeout("query.IndexStats", t.Overrides)
 	indexShardsHTTPMiddleware := querier.WrapQuerySpanAndTimeout("query.IndexShards", t.Overrides)

--- a/pkg/querier/http.go
+++ b/pkg/querier/http.go
@@ -55,13 +55,13 @@ type QuerierAPI struct {
 }
 
 // NewQuerierAPI returns an instance of the QuerierAPI.
-func NewQuerierAPI(cfg Config, querier Querier, limits querier_limits.Limits, metastore metastore.Metastore, logger log.Logger) *QuerierAPI {
+func NewQuerierAPI(cfg Config, querier Querier, limits querier_limits.Limits, metastore metastore.Metastore, reg prometheus.Registerer, logger log.Logger) *QuerierAPI {
 	return &QuerierAPI{
 		cfg:      cfg,
 		limits:   limits,
 		querier:  querier,
 		engineV1: logql.NewEngine(cfg.Engine, querier, limits, logger),
-		engineV2: engine.New(cfg.Engine, metastore, limits, logger),
+		engineV2: engine.New(cfg.Engine, metastore, limits, reg, logger),
 		logger:   logger,
 	}
 }

--- a/pkg/querier/http_test.go
+++ b/pkg/querier/http_test.go
@@ -30,7 +30,7 @@ func TestInstantQueryHandler(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("log selector expression not allowed for instant queries", func(t *testing.T) {
-		api := NewQuerierAPI(mockQuerierConfig(), nil, limits, nil, log.NewNopLogger())
+		api := NewQuerierAPI(mockQuerierConfig(), nil, limits, nil, nil, log.NewNopLogger())
 
 		ctx := user.InjectOrgID(context.Background(), "user")
 		req, err := http.NewRequestWithContext(ctx, "GET", `/api/v1/query`, nil)
@@ -359,6 +359,6 @@ func setupAPI(t *testing.T, querier *querierMock, enableMetricAggregation bool) 
 	limits, err := validation.NewOverrides(defaultLimits, nil)
 	require.NoError(t, err)
 
-	api := NewQuerierAPI(Config{}, querier, limits, nil, log.NewNopLogger())
+	api := NewQuerierAPI(Config{}, querier, limits, nil, nil, log.NewNopLogger())
 	return api
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds basic metrics for observe the duration of the different phases of the new execution engine.

Note, these metrics are subject to change.