### PR TITLE
chore(ci): Disable persist-credentials for operator workflows

### DIFF
--- a/.github/workflows/operator-bundle.yaml
+++ b/.github/workflows/operator-bundle.yaml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: Set up Go 1.x
       uses: actions/setup-go@v5
       with:

--- a/.github/workflows/operator-check-prepare-release-commit.yml
+++ b/.github/workflows/operator-check-prepare-release-commit.yml
@@ -35,6 +35,7 @@ jobs:
         with:
           ref: main
           path: "release"
+          persist-credentials: false
 
       - name: Check main commits for prepare release commit
         id: check_commit

--- a/.github/workflows/operator-images.yaml
+++ b/.github/workflows/operator-images.yaml
@@ -20,6 +20,8 @@ jobs:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
+       with:
+        persist-credentials: false     
 
      - name: Set up QEMU
        uses: docker/setup-qemu-action@v3

--- a/.github/workflows/operator-release-please.yml
+++ b/.github/workflows/operator-release-please.yml
@@ -76,6 +76,7 @@ jobs:
       - name: "pull code to release"
         uses: "actions/checkout@v4"
         with:
+          persist-credentials: false
           path: "release"
       - name: "publish release"
         env:

--- a/.github/workflows/operator-reusable-hub-release.yml
+++ b/.github/workflows/operator-reusable-hub-release.yml
@@ -60,6 +60,7 @@ jobs:
         with:
           repository: grafanabot/${{ inputs.repo }}
           token: ${{ steps.get_github_app_token.outputs.token }}
+          persist-credentials: false
 
       - name: Checkout loki to tmp/ directory
         uses: actions/checkout@v4
@@ -67,7 +68,7 @@ jobs:
           repository: grafana/loki
           token: ${{ steps.get_github_app_token.outputs.token }}
           path: tmp/
-
+          persist-credentials: false
       - name: Update version
         env:
           VERSION: ${{ env.version }}

--- a/.github/workflows/operator-scorecard.yaml
+++ b/.github/workflows/operator-scorecard.yaml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: Set up Go 1.x
       uses: actions/setup-go@v5
       with:

--- a/.github/workflows/operator.yaml
+++ b/.github/workflows/operator.yaml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: Set up Go 1.x
       uses: actions/setup-go@v5
       with:
@@ -30,6 +32,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: Set up Go 1.x
       uses: actions/setup-go@v5
       with:
@@ -49,6 +53,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: Set up Go 1.x
       uses: actions/setup-go@v5
       with:
@@ -64,6 +70,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: Set up Go 1.x
       uses: actions/setup-go@v5
       with:
@@ -78,6 +86,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: Set up Go 1.x
       uses: actions/setup-go@v5
       with:


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #grafana/loki-private/issues/1618


**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
