### PR TITLE
chore: update github workflow run blocks to use env variables

### DIFF
--- a/.github/workflows/operator-check-prepare-release-commit.yml
+++ b/.github/workflows/operator-check-prepare-release-commit.yml
@@ -45,12 +45,13 @@ jobs:
         id: check_commit
         env:
           GH_TOKEN: ${{ steps.get_github_app_token.outputs.token }}
+          OUTPUTS_SEMVER: ${{ steps.pr_semver.outputs.semver }}
         working-directory: "release"
         run: |
-          COMMIT=$(gh search commits "chore(operator): prepare community release v${{ steps.pr_semver.outputs.semver }}")
+          COMMIT=$(gh search commits "chore(operator): prepare community release v${OUTPUTS_SEMVER}")
           if [ -n "$COMMIT" ]; then
             echo "Prepare release commit found."
           else
-            echo "No prepare release commit found for the release version ${{ steps.pr_semver.outputs.semver }}"
+            echo "No prepare release commit found for the release version $OUTPUTS_SEMVER"
             exit 1
           fi

--- a/.github/workflows/operator-release-please.yml
+++ b/.github/workflows/operator-release-please.yml
@@ -89,6 +89,7 @@ jobs:
       - name: "publish release"
         env:
           GH_TOKEN: ${{ steps.get_github_app_token.outputs.token }}
+          RELEASE_NAME: ${{ needs.releasePlease.outputs.release_name }}
         working-directory: "release"
         run: |
-          gh release edit "${{ needs.releasePlease.outputs.release_name }}" --draft=false --latest=false
+          gh release edit "$RELEASE_NAME" --draft=false --latest=false

--- a/.github/workflows/operator-reusable-hub-release.yml
+++ b/.github/workflows/operator-reusable-hub-release.yml
@@ -51,12 +51,14 @@ jobs:
       - name: Sync fork
         env:
           GH_TOKEN: ${{ steps.get_github_app_token.outputs.token }}
+          INPUTS_ORG: ${{ inputs.org }}
+          INPUTS_REPO: ${{ inputs.repo }}
         run: |
           # synchronizing the fork is fast, and avoids the need to fetch the full upstream repo
           # (fetching the upstream repo with "--depth 1" would lead to "shallow update not allowed"
           #  error when pushing back to the origin repo)
-          gh repo sync grafanabot/${{ inputs.repo }} \
-              --source ${{ inputs.org }}/${{ inputs.repo }} \
+          gh repo sync grafanabot/$INPUTS_REPO \
+              --source ${INPUTS_ORG}/$INPUTS_REPO \
               --force
 
       - name: Checkout operatorhub repo
@@ -101,6 +103,8 @@ jobs:
         env:
           VERSION: ${{ env.version }}
           GH_TOKEN: ${{ steps.get_github_app_token.outputs.token }}
+          INPUTS_ORG: ${{ inputs.org }}
+          INPUTS_REPO: ${{ inputs.repo }}
         run: |
           message="Update the loki-operator to $VERSION"
           body="Release loki-operator \`$VERSION\`.
@@ -119,5 +123,5 @@ jobs:
           git push -f --set-upstream origin $branch
           gh pr create --title "$message" \
                        --body "$body" \
-                       --repo ${{ inputs.org }}/${{ inputs.repo }} \
+                       --repo ${INPUTS_ORG}/${INPUTS_REPO}\
                        --base main


### PR DESCRIPTION
Updates the .github/workflows/operator-*.yml files, extracting variables used in the Github `run` blocks into environment variables.

**What this PR does / why we need it**:


**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
