### PR TITLE
ci: update release-workflows.jsonnet to extract env vars

### DIFF
--- a/.github/release-workflows.jsonnet
+++ b/.github/release-workflows.jsonnet
@@ -280,12 +280,12 @@ local lambdaPromtailJob =
             echo 'linux/arm64 $IMAGE_DIGEST_ARM64'
             echo 'linux/amd64 $IMAGE_DIGEST_AMD64'
             echo 'linux/arm   $IMAGE_DIGEST_ARM'
-            IMAGE=${IMAGE_NAME}:${IMAGE_TAG}
+            IMAGE=${OUTPUTS_IMAGE_NAME}:${OUTPUTS_IMAGE_TAG}
             echo "Create multi-arch manifest for $IMAGE"
             docker buildx imagetools create -t $IMAGE \
-              ${IMAGE_NAME}@${IMAGE_DIGEST_ARM64} \
-              ${IMAGE_NAME}@${IMAGE_DIGEST_AMD64} \
-              ${IMAGE_NAME}@${IMAGE_DIGEST_ARM}
+              ${OUTPUTS_IMAGE_NAME}@${IMAGE_DIGEST_ARM64} \
+              ${OUTPUTS_IMAGE_NAME}@${IMAGE_DIGEST_AMD64} \
+              ${OUTPUTS_IMAGE_NAME}@${IMAGE_DIGEST_ARM}
             docker buildx imagetools inspect $IMAGE
           ||| % { name: '%s-image' % name }),
         ])

--- a/.github/release-workflows.jsonnet
+++ b/.github/release-workflows.jsonnet
@@ -117,12 +117,12 @@ local lambdaPromtailJob =
     + { id: 'prepare-tag' }
     + step.withEnv({
         MATRIX_ARCH: '${{ matrix.arch }}',
-        IMAGE_NAME: '${{ steps.weekly-version.outputs.image_name }}',
-        IMAGE_VERSION: '${{ steps.weekly-version.outputs.image_version }}',
+        OUTPUTS_IMAGE_NAME: '${{ steps.weekly-version.outputs.image_name }}',
+        OUTPUTS_IMAGE_VERSION: '${{ steps.weekly-version.outputs.image_version }}',
     })
     + step.withRun(|||
       arch=$(echo $MATRIX_ARCH | cut -d'/' -f2)
-      echo "IMAGE_TAG=${$IMAGE_NAME}:${IMAGE_VERSION}-${arch}" >> $GITHUB_OUTPUT
+      echo "IMAGE_TAG=${$OUTPUTS_IMAGE_NAME}:${OUTPUTS_IMAGE_VERSION}-${arch}" >> $GITHUB_OUTPUT
     |||),
     step.new('Build and push', 'docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1') // v6
     + { id: 'build-push' }

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -45,7 +45,7 @@
       "uses": "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
     - "id": "get-secrets"
       "name": "get-secrets"
-      "uses": "grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets-v1.1.0"
+      "uses": "grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760"
       "with":
         "repo_secrets": |
           ECR_ACCESS_KEY=aws-credentials:access_key_id
@@ -68,11 +68,15 @@
         echo "image_name=${{ env.IMAGE_PREFIX }}/lambda-promtail" >> $GITHUB_OUTPUT
         echo "image_full_name=${{ env.IMAGE_PREFIX }}/lambda-promtail:$version" >> $GITHUB_OUTPUT
       "working-directory": "release"
-    - "id": "prepare-tag"
+    - "env":
+        "IMAGE_NAME": "${{ steps.weekly-version.outputs.image_name }}"
+        "IMAGE_VERSION": "${{ steps.weekly-version.outputs.image_version }}"
+        "MATRIX_ARCH": "${{ matrix.arch }}"
+      "id": "prepare-tag"
       "name": "Prepare tag name"
       "run": |
-        arch=$(echo ${{ matrix.arch }} | cut -d'/' -f2)
-        echo "IMAGE_TAG=${{ steps.weekly-version.outputs.image_name }}:${{ steps.weekly-version.outputs.image_version }}-${arch}" >> $GITHUB_OUTPUT
+        arch=$(echo $MATRIX_ARCH | cut -d'/' -f2)
+        echo "IMAGE_TAG=${$IMAGE_NAME}:${IMAGE_VERSION}-${arch}" >> $GITHUB_OUTPUT
     - "id": "build-push"
       "name": "Build and push"
       "timeout-minutes": "${{ fromJSON(env.BUILD_TIMEOUT) }}"
@@ -188,6 +192,11 @@
   "loki-canary-boringcrypto-manifest":
     "env":
       "BUILD_TIMEOUT": 60
+      "IMAGE_DIGEST_AMD64": "${{ needs.loki-canary-boringcrypto.outputs.image_digest_linux_amd64 }}"
+      "IMAGE_DIGEST_ARM": "${{ needs.loki-canary-boringcrypto.outputs.image_digest_linux_arm }}"
+      "IMAGE_DIGEST_ARM64": "${{ needs.loki-canary-boringcrypto.outputs.image_digest_linux_arm64 }}"
+      "OUTPUTS_IMAGE_NAME": "${{ needs.loki-canary-boringcrypto.outputs.image_name }}"
+      "OUTPUTS_IMAGE_TAG": "${{ needs.loki-canary-boringcrypto.outputs.image_tag }}"
     "needs":
     - "loki-canary-boringcrypto-image"
     "runs-on": "ubuntu-latest"
@@ -195,19 +204,19 @@
     - "name": "Set up Docker buildx"
       "uses": "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
     - "name": "Login to DockerHub (from Vault)"
-      "uses": "grafana/shared-workflows/actions/dockerhub-login@main"
+      "uses": "grafana/shared-workflows/actions/dockerhub-login@75804962c1ba608148988c1e2dc35fbb0ee21746"
     - "name": "Publish multi-arch manifest"
       "run": |
         # Unfortunately there is no better way atm than having a separate named output for each digest
-        echo 'linux/arm64 ${{ needs.loki-canary-boringcrypto-image.outputs.image_digest_linux_amd64 }}'
-        echo 'linux/amd64 ${{ needs.loki-canary-boringcrypto-image.outputs.image_digest_linux_arm64 }}'
-        echo 'linux/arm   ${{ needs.loki-canary-boringcrypto-image.outputs.image_digest_linux_arm }}'
-        IMAGE=${{ needs.loki-canary-boringcrypto-image.outputs.image_name }}:${{ needs.loki-canary-boringcrypto-image.outputs.image_tag }}
+        echo 'linux/arm64 $IMAGE_DIGEST_ARM64'
+        echo 'linux/amd64 $IMAGE_DIGEST_AMD64'
+        echo 'linux/arm   $IMAGE_DIGEST_ARM'
+        IMAGE=${IMAGE_NAME}:${IMAGE_TAG}
         echo "Create multi-arch manifest for $IMAGE"
         docker buildx imagetools create -t $IMAGE \
-          ${{ needs.loki-canary-boringcrypto-image.outputs.image_name }}@${{ needs.loki-canary-boringcrypto-image.outputs.image_digest_linux_amd64 }} \
-          ${{ needs.loki-canary-boringcrypto-image.outputs.image_name }}@${{ needs.loki-canary-boringcrypto-image.outputs.image_digest_linux_arm64 }} \
-          ${{ needs.loki-canary-boringcrypto-image.outputs.image_name }}@${{ needs.loki-canary-boringcrypto-image.outputs.image_digest_linux_arm }}
+          ${IMAGE_NAME}@${IMAGE_DIGEST_ARM64} \
+          ${IMAGE_NAME}@${IMAGE_DIGEST_AMD64} \
+          ${IMAGE_NAME}@${IMAGE_DIGEST_ARM}
         docker buildx imagetools inspect $IMAGE
   "loki-canary-image":
     "env":
@@ -300,6 +309,11 @@
   "loki-canary-manifest":
     "env":
       "BUILD_TIMEOUT": 60
+      "IMAGE_DIGEST_AMD64": "${{ needs.loki-canary.outputs.image_digest_linux_amd64 }}"
+      "IMAGE_DIGEST_ARM": "${{ needs.loki-canary.outputs.image_digest_linux_arm }}"
+      "IMAGE_DIGEST_ARM64": "${{ needs.loki-canary.outputs.image_digest_linux_arm64 }}"
+      "OUTPUTS_IMAGE_NAME": "${{ needs.loki-canary.outputs.image_name }}"
+      "OUTPUTS_IMAGE_TAG": "${{ needs.loki-canary.outputs.image_tag }}"
     "needs":
     - "loki-canary-image"
     "runs-on": "ubuntu-latest"
@@ -307,19 +321,19 @@
     - "name": "Set up Docker buildx"
       "uses": "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
     - "name": "Login to DockerHub (from Vault)"
-      "uses": "grafana/shared-workflows/actions/dockerhub-login@main"
+      "uses": "grafana/shared-workflows/actions/dockerhub-login@75804962c1ba608148988c1e2dc35fbb0ee21746"
     - "name": "Publish multi-arch manifest"
       "run": |
         # Unfortunately there is no better way atm than having a separate named output for each digest
-        echo 'linux/arm64 ${{ needs.loki-canary-image.outputs.image_digest_linux_amd64 }}'
-        echo 'linux/amd64 ${{ needs.loki-canary-image.outputs.image_digest_linux_arm64 }}'
-        echo 'linux/arm   ${{ needs.loki-canary-image.outputs.image_digest_linux_arm }}'
-        IMAGE=${{ needs.loki-canary-image.outputs.image_name }}:${{ needs.loki-canary-image.outputs.image_tag }}
+        echo 'linux/arm64 $IMAGE_DIGEST_ARM64'
+        echo 'linux/amd64 $IMAGE_DIGEST_AMD64'
+        echo 'linux/arm   $IMAGE_DIGEST_ARM'
+        IMAGE=${IMAGE_NAME}:${IMAGE_TAG}
         echo "Create multi-arch manifest for $IMAGE"
         docker buildx imagetools create -t $IMAGE \
-          ${{ needs.loki-canary-image.outputs.image_name }}@${{ needs.loki-canary-image.outputs.image_digest_linux_amd64 }} \
-          ${{ needs.loki-canary-image.outputs.image_name }}@${{ needs.loki-canary-image.outputs.image_digest_linux_arm64 }} \
-          ${{ needs.loki-canary-image.outputs.image_name }}@${{ needs.loki-canary-image.outputs.image_digest_linux_arm }}
+          ${IMAGE_NAME}@${IMAGE_DIGEST_ARM64} \
+          ${IMAGE_NAME}@${IMAGE_DIGEST_AMD64} \
+          ${IMAGE_NAME}@${IMAGE_DIGEST_ARM}
         docker buildx imagetools inspect $IMAGE
   "loki-image":
     "env":
@@ -412,6 +426,11 @@
   "loki-manifest":
     "env":
       "BUILD_TIMEOUT": 60
+      "IMAGE_DIGEST_AMD64": "${{ needs.loki.outputs.image_digest_linux_amd64 }}"
+      "IMAGE_DIGEST_ARM": "${{ needs.loki.outputs.image_digest_linux_arm }}"
+      "IMAGE_DIGEST_ARM64": "${{ needs.loki.outputs.image_digest_linux_arm64 }}"
+      "OUTPUTS_IMAGE_NAME": "${{ needs.loki.outputs.image_name }}"
+      "OUTPUTS_IMAGE_TAG": "${{ needs.loki.outputs.image_tag }}"
     "needs":
     - "loki-image"
     "runs-on": "ubuntu-latest"
@@ -419,19 +438,19 @@
     - "name": "Set up Docker buildx"
       "uses": "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
     - "name": "Login to DockerHub (from Vault)"
-      "uses": "grafana/shared-workflows/actions/dockerhub-login@main"
+      "uses": "grafana/shared-workflows/actions/dockerhub-login@75804962c1ba608148988c1e2dc35fbb0ee21746"
     - "name": "Publish multi-arch manifest"
       "run": |
         # Unfortunately there is no better way atm than having a separate named output for each digest
-        echo 'linux/arm64 ${{ needs.loki-image.outputs.image_digest_linux_amd64 }}'
-        echo 'linux/amd64 ${{ needs.loki-image.outputs.image_digest_linux_arm64 }}'
-        echo 'linux/arm   ${{ needs.loki-image.outputs.image_digest_linux_arm }}'
-        IMAGE=${{ needs.loki-image.outputs.image_name }}:${{ needs.loki-image.outputs.image_tag }}
+        echo 'linux/arm64 $IMAGE_DIGEST_ARM64'
+        echo 'linux/amd64 $IMAGE_DIGEST_AMD64'
+        echo 'linux/arm   $IMAGE_DIGEST_ARM'
+        IMAGE=${IMAGE_NAME}:${IMAGE_TAG}
         echo "Create multi-arch manifest for $IMAGE"
         docker buildx imagetools create -t $IMAGE \
-          ${{ needs.loki-image.outputs.image_name }}@${{ needs.loki-image.outputs.image_digest_linux_amd64 }} \
-          ${{ needs.loki-image.outputs.image_name }}@${{ needs.loki-image.outputs.image_digest_linux_arm64 }} \
-          ${{ needs.loki-image.outputs.image_name }}@${{ needs.loki-image.outputs.image_digest_linux_arm }}
+          ${IMAGE_NAME}@${IMAGE_DIGEST_ARM64} \
+          ${IMAGE_NAME}@${IMAGE_DIGEST_AMD64} \
+          ${IMAGE_NAME}@${IMAGE_DIGEST_ARM}
         docker buildx imagetools inspect $IMAGE
   "promtail-image":
     "env":
@@ -524,6 +543,11 @@
   "promtail-manifest":
     "env":
       "BUILD_TIMEOUT": 60
+      "IMAGE_DIGEST_AMD64": "${{ needs.promtail.outputs.image_digest_linux_amd64 }}"
+      "IMAGE_DIGEST_ARM": "${{ needs.promtail.outputs.image_digest_linux_arm }}"
+      "IMAGE_DIGEST_ARM64": "${{ needs.promtail.outputs.image_digest_linux_arm64 }}"
+      "OUTPUTS_IMAGE_NAME": "${{ needs.promtail.outputs.image_name }}"
+      "OUTPUTS_IMAGE_TAG": "${{ needs.promtail.outputs.image_tag }}"
     "needs":
     - "promtail-image"
     "runs-on": "ubuntu-latest"
@@ -531,19 +555,19 @@
     - "name": "Set up Docker buildx"
       "uses": "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
     - "name": "Login to DockerHub (from Vault)"
-      "uses": "grafana/shared-workflows/actions/dockerhub-login@main"
+      "uses": "grafana/shared-workflows/actions/dockerhub-login@75804962c1ba608148988c1e2dc35fbb0ee21746"
     - "name": "Publish multi-arch manifest"
       "run": |
         # Unfortunately there is no better way atm than having a separate named output for each digest
-        echo 'linux/arm64 ${{ needs.promtail-image.outputs.image_digest_linux_amd64 }}'
-        echo 'linux/amd64 ${{ needs.promtail-image.outputs.image_digest_linux_arm64 }}'
-        echo 'linux/arm   ${{ needs.promtail-image.outputs.image_digest_linux_arm }}'
-        IMAGE=${{ needs.promtail-image.outputs.image_name }}:${{ needs.promtail-image.outputs.image_tag }}
+        echo 'linux/arm64 $IMAGE_DIGEST_ARM64'
+        echo 'linux/amd64 $IMAGE_DIGEST_AMD64'
+        echo 'linux/arm   $IMAGE_DIGEST_ARM'
+        IMAGE=${IMAGE_NAME}:${IMAGE_TAG}
         echo "Create multi-arch manifest for $IMAGE"
         docker buildx imagetools create -t $IMAGE \
-          ${{ needs.promtail-image.outputs.image_name }}@${{ needs.promtail-image.outputs.image_digest_linux_amd64 }} \
-          ${{ needs.promtail-image.outputs.image_name }}@${{ needs.promtail-image.outputs.image_digest_linux_arm64 }} \
-          ${{ needs.promtail-image.outputs.image_name }}@${{ needs.promtail-image.outputs.image_digest_linux_arm }}
+          ${IMAGE_NAME}@${IMAGE_DIGEST_ARM64} \
+          ${IMAGE_NAME}@${IMAGE_DIGEST_AMD64} \
+          ${IMAGE_NAME}@${IMAGE_DIGEST_ARM}
         docker buildx imagetools inspect $IMAGE
 "name": "Publish images"
 "on":

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -69,14 +69,14 @@
         echo "image_full_name=${{ env.IMAGE_PREFIX }}/lambda-promtail:$version" >> $GITHUB_OUTPUT
       "working-directory": "release"
     - "env":
-        "IMAGE_NAME": "${{ steps.weekly-version.outputs.image_name }}"
-        "IMAGE_VERSION": "${{ steps.weekly-version.outputs.image_version }}"
         "MATRIX_ARCH": "${{ matrix.arch }}"
+        "OUTPUTS_IMAGE_NAME": "${{ steps.weekly-version.outputs.image_name }}"
+        "OUTPUTS_IMAGE_VERSION": "${{ steps.weekly-version.outputs.image_version }}"
       "id": "prepare-tag"
       "name": "Prepare tag name"
       "run": |
         arch=$(echo $MATRIX_ARCH | cut -d'/' -f2)
-        echo "IMAGE_TAG=${$IMAGE_NAME}:${IMAGE_VERSION}-${arch}" >> $GITHUB_OUTPUT
+        echo "IMAGE_TAG=${$OUTPUTS_IMAGE_NAME}:${OUTPUTS_IMAGE_VERSION}-${arch}" >> $GITHUB_OUTPUT
     - "id": "build-push"
       "name": "Build and push"
       "timeout-minutes": "${{ fromJSON(env.BUILD_TIMEOUT) }}"

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -211,12 +211,12 @@
         echo 'linux/arm64 $IMAGE_DIGEST_ARM64'
         echo 'linux/amd64 $IMAGE_DIGEST_AMD64'
         echo 'linux/arm   $IMAGE_DIGEST_ARM'
-        IMAGE=${IMAGE_NAME}:${IMAGE_TAG}
+        IMAGE=${OUTPUTS_IMAGE_NAME}:${OUTPUTS_IMAGE_TAG}
         echo "Create multi-arch manifest for $IMAGE"
         docker buildx imagetools create -t $IMAGE \
-          ${IMAGE_NAME}@${IMAGE_DIGEST_ARM64} \
-          ${IMAGE_NAME}@${IMAGE_DIGEST_AMD64} \
-          ${IMAGE_NAME}@${IMAGE_DIGEST_ARM}
+          ${OUTPUTS_IMAGE_NAME}@${IMAGE_DIGEST_ARM64} \
+          ${OUTPUTS_IMAGE_NAME}@${IMAGE_DIGEST_AMD64} \
+          ${OUTPUTS_IMAGE_NAME}@${IMAGE_DIGEST_ARM}
         docker buildx imagetools inspect $IMAGE
   "loki-canary-image":
     "env":
@@ -328,12 +328,12 @@
         echo 'linux/arm64 $IMAGE_DIGEST_ARM64'
         echo 'linux/amd64 $IMAGE_DIGEST_AMD64'
         echo 'linux/arm   $IMAGE_DIGEST_ARM'
-        IMAGE=${IMAGE_NAME}:${IMAGE_TAG}
+        IMAGE=${OUTPUTS_IMAGE_NAME}:${OUTPUTS_IMAGE_TAG}
         echo "Create multi-arch manifest for $IMAGE"
         docker buildx imagetools create -t $IMAGE \
-          ${IMAGE_NAME}@${IMAGE_DIGEST_ARM64} \
-          ${IMAGE_NAME}@${IMAGE_DIGEST_AMD64} \
-          ${IMAGE_NAME}@${IMAGE_DIGEST_ARM}
+          ${OUTPUTS_IMAGE_NAME}@${IMAGE_DIGEST_ARM64} \
+          ${OUTPUTS_IMAGE_NAME}@${IMAGE_DIGEST_AMD64} \
+          ${OUTPUTS_IMAGE_NAME}@${IMAGE_DIGEST_ARM}
         docker buildx imagetools inspect $IMAGE
   "loki-image":
     "env":
@@ -445,12 +445,12 @@
         echo 'linux/arm64 $IMAGE_DIGEST_ARM64'
         echo 'linux/amd64 $IMAGE_DIGEST_AMD64'
         echo 'linux/arm   $IMAGE_DIGEST_ARM'
-        IMAGE=${IMAGE_NAME}:${IMAGE_TAG}
+        IMAGE=${OUTPUTS_IMAGE_NAME}:${OUTPUTS_IMAGE_TAG}
         echo "Create multi-arch manifest for $IMAGE"
         docker buildx imagetools create -t $IMAGE \
-          ${IMAGE_NAME}@${IMAGE_DIGEST_ARM64} \
-          ${IMAGE_NAME}@${IMAGE_DIGEST_AMD64} \
-          ${IMAGE_NAME}@${IMAGE_DIGEST_ARM}
+          ${OUTPUTS_IMAGE_NAME}@${IMAGE_DIGEST_ARM64} \
+          ${OUTPUTS_IMAGE_NAME}@${IMAGE_DIGEST_AMD64} \
+          ${OUTPUTS_IMAGE_NAME}@${IMAGE_DIGEST_ARM}
         docker buildx imagetools inspect $IMAGE
   "promtail-image":
     "env":
@@ -562,12 +562,12 @@
         echo 'linux/arm64 $IMAGE_DIGEST_ARM64'
         echo 'linux/amd64 $IMAGE_DIGEST_AMD64'
         echo 'linux/arm   $IMAGE_DIGEST_ARM'
-        IMAGE=${IMAGE_NAME}:${IMAGE_TAG}
+        IMAGE=${OUTPUTS_IMAGE_NAME}:${OUTPUTS_IMAGE_TAG}
         echo "Create multi-arch manifest for $IMAGE"
         docker buildx imagetools create -t $IMAGE \
-          ${IMAGE_NAME}@${IMAGE_DIGEST_ARM64} \
-          ${IMAGE_NAME}@${IMAGE_DIGEST_AMD64} \
-          ${IMAGE_NAME}@${IMAGE_DIGEST_ARM}
+          ${OUTPUTS_IMAGE_NAME}@${IMAGE_DIGEST_ARM64} \
+          ${OUTPUTS_IMAGE_NAME}@${IMAGE_DIGEST_AMD64} \
+          ${OUTPUTS_IMAGE_NAME}@${IMAGE_DIGEST_ARM}
         docker buildx imagetools inspect $IMAGE
 "name": "Publish images"
 "on":


### PR DESCRIPTION
Updates the release-workflows.jsonnet file so we extract variables used in `run` blocks into environment variables.  This commit also pins the dockerub-login and get-vault-secrets to an sha1 hash.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
