### PR TITLE
chore(ci): Add more oidc perms for image publishing jobs

### DIFF
--- a/.github/release-workflows.jsonnet
+++ b/.github/release-workflows.jsonnet
@@ -247,6 +247,10 @@ local lambdaPromtailJob =
       ['%s-image' % name]:
         weeklyImageJobs[name]
         + job.withNeeds(['check'])
+        + job.withPermissions({
+          contents: 'read',
+          'id-token': 'write',
+        })
         + job.withEnv({
           BUILD_TIMEOUT: imageBuildTimeoutMin,
           RELEASE_REPO: 'grafana/loki',

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -116,6 +116,9 @@
       "image_digest_linux_arm64": "${{ steps.digest.outputs.digest_linux_arm64 }}"
       "image_name": "${{ steps.weekly-version.outputs.image_name }}"
       "image_tag": "${{ steps.weekly-version.outputs.image_version }}"
+    "permissions":
+      "contents": "read"
+      "id-token": "write"
     "runs-on": "${{ matrix.runs_on }}"
     "steps":
     - "name": "pull release library code"
@@ -236,6 +239,9 @@
       "image_digest_linux_arm64": "${{ steps.digest.outputs.digest_linux_arm64 }}"
       "image_name": "${{ steps.weekly-version.outputs.image_name }}"
       "image_tag": "${{ steps.weekly-version.outputs.image_version }}"
+    "permissions":
+      "contents": "read"
+      "id-token": "write"
     "runs-on": "${{ matrix.runs_on }}"
     "steps":
     - "name": "pull release library code"
@@ -356,6 +362,9 @@
       "image_digest_linux_arm64": "${{ steps.digest.outputs.digest_linux_arm64 }}"
       "image_name": "${{ steps.weekly-version.outputs.image_name }}"
       "image_tag": "${{ steps.weekly-version.outputs.image_version }}"
+    "permissions":
+      "contents": "read"
+      "id-token": "write"
     "runs-on": "${{ matrix.runs_on }}"
     "steps":
     - "name": "pull release library code"
@@ -476,6 +485,9 @@
       "image_digest_linux_arm64": "${{ steps.digest.outputs.digest_linux_arm64 }}"
       "image_name": "${{ steps.weekly-version.outputs.image_name }}"
       "image_tag": "${{ steps.weekly-version.outputs.image_version }}"
+    "permissions":
+      "contents": "read"
+      "id-token": "write"
     "runs-on": "${{ matrix.runs_on }}"
     "steps":
     - "name": "pull release library code"


### PR DESCRIPTION
**What this PR does / why we need it**:
failing run: https://github.com/grafana/loki/actions/runs/14754548797/workflow

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
