### PR TITLE
chore: fix manifest and env var issue in images.yml github workflow

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -79,7 +79,7 @@
       "name": "Prepare tag name"
       "run": |
         arch=$(echo $MATRIX_ARCH | cut -d'/' -f2)
-        echo "IMAGE_TAG=${OUTPUTS_IMAGE_NAME}:${OUTPUTS_IMAGE_VERSION}-${arch}" >> $GITHUB_OUTPUT
+        echo "IMAGE_TAG=${$OUTPUTS_IMAGE_NAME}:${OUTPUTS_IMAGE_VERSION}-${arch}" >> $GITHUB_OUTPUT
     - "id": "build-push"
       "name": "Build and push"
       "timeout-minutes": "${{ fromJSON(env.BUILD_TIMEOUT) }}"
@@ -198,11 +198,11 @@
   "loki-canary-boringcrypto-manifest":
     "env":
       "BUILD_TIMEOUT": 60
-      "IMAGE_DIGEST_AMD64": "${{ needs.loki-canary-boringcrypto.outputs.image_digest_linux_amd64 }}"
-      "IMAGE_DIGEST_ARM": "${{ needs.loki-canary-boringcrypto.outputs.image_digest_linux_arm }}"
-      "IMAGE_DIGEST_ARM64": "${{ needs.loki-canary-boringcrypto.outputs.image_digest_linux_arm64 }}"
-      "OUTPUTS_IMAGE_NAME": "${{ needs.loki-canary-boringcrypto.outputs.image_name }}"
-      "OUTPUTS_IMAGE_TAG": "${{ needs.loki-canary-boringcrypto.outputs.image_tag }}"
+      "IMAGE_DIGEST_AMD64": "${{ needs.loki-canary-boringcrypto-image.outputs.image_digest_linux_amd64 }}"
+      "IMAGE_DIGEST_ARM": "${{ needs.loki-canary-boringcrypto-image.outputs.image_digest_linux_arm }}"
+      "IMAGE_DIGEST_ARM64": "${{ needs.loki-canary-boringcrypto-image.outputs.image_digest_linux_arm64 }}"
+      "OUTPUTS_IMAGE_NAME": "${{ needs.loki-canary-boringcrypto-image.outputs.image_name }}"
+      "OUTPUTS_IMAGE_TAG": "${{ needs.loki-canary-boringcrypto-image.outputs.image_tag }}"
     "needs":
     - "loki-canary-boringcrypto-image"
     "permissions":
@@ -217,10 +217,10 @@
     - "name": "Publish multi-arch manifest"
       "run": |
         # Unfortunately there is no better way atm than having a separate named output for each digest
-        echo 'linux/arm64 $IMAGE_DIGEST_ARM64'
-        echo 'linux/amd64 $IMAGE_DIGEST_AMD64'
-        echo 'linux/arm   $IMAGE_DIGEST_ARM'
-        IMAGE=${OUTPUTS_IMAGE_NAME}:${OUTPUTS_IMAGE_TAG}
+        echo "linux/arm64 $IMAGE_DIGEST_ARM64"
+        echo "linux/amd64 $IMAGE_DIGEST_AMD64"
+        echo "linux/arm   $IMAGE_DIGEST_ARM"
+        IMAGE="${OUTPUTS_IMAGE_NAME}:${OUTPUTS_IMAGE_TAG}"
         echo "Create multi-arch manifest for $IMAGE"
         docker buildx imagetools create -t $IMAGE \
           ${OUTPUTS_IMAGE_NAME}@${IMAGE_DIGEST_ARM64} \
@@ -321,11 +321,11 @@
   "loki-canary-manifest":
     "env":
       "BUILD_TIMEOUT": 60
-      "IMAGE_DIGEST_AMD64": "${{ needs.loki-canary.outputs.image_digest_linux_amd64 }}"
-      "IMAGE_DIGEST_ARM": "${{ needs.loki-canary.outputs.image_digest_linux_arm }}"
-      "IMAGE_DIGEST_ARM64": "${{ needs.loki-canary.outputs.image_digest_linux_arm64 }}"
-      "OUTPUTS_IMAGE_NAME": "${{ needs.loki-canary.outputs.image_name }}"
-      "OUTPUTS_IMAGE_TAG": "${{ needs.loki-canary.outputs.image_tag }}"
+      "IMAGE_DIGEST_AMD64": "${{ needs.loki-canary-image.outputs.image_digest_linux_amd64 }}"
+      "IMAGE_DIGEST_ARM": "${{ needs.loki-canary-image.outputs.image_digest_linux_arm }}"
+      "IMAGE_DIGEST_ARM64": "${{ needs.loki-canary-image.outputs.image_digest_linux_arm64 }}"
+      "OUTPUTS_IMAGE_NAME": "${{ needs.loki-canary-image.outputs.image_name }}"
+      "OUTPUTS_IMAGE_TAG": "${{ needs.loki-canary-image.outputs.image_tag }}"
     "needs":
     - "loki-canary-image"
     "permissions":
@@ -340,10 +340,10 @@
     - "name": "Publish multi-arch manifest"
       "run": |
         # Unfortunately there is no better way atm than having a separate named output for each digest
-        echo 'linux/arm64 $IMAGE_DIGEST_ARM64'
-        echo 'linux/amd64 $IMAGE_DIGEST_AMD64'
-        echo 'linux/arm   $IMAGE_DIGEST_ARM'
-        IMAGE=${OUTPUTS_IMAGE_NAME}:${OUTPUTS_IMAGE_TAG}
+        echo "linux/arm64 $IMAGE_DIGEST_ARM64"
+        echo "linux/amd64 $IMAGE_DIGEST_AMD64"
+        echo "linux/arm   $IMAGE_DIGEST_ARM"
+        IMAGE="${OUTPUTS_IMAGE_NAME}:${OUTPUTS_IMAGE_TAG}"
         echo "Create multi-arch manifest for $IMAGE"
         docker buildx imagetools create -t $IMAGE \
           ${OUTPUTS_IMAGE_NAME}@${IMAGE_DIGEST_ARM64} \
@@ -444,11 +444,11 @@
   "loki-manifest":
     "env":
       "BUILD_TIMEOUT": 60
-      "IMAGE_DIGEST_AMD64": "${{ needs.loki.outputs.image_digest_linux_amd64 }}"
-      "IMAGE_DIGEST_ARM": "${{ needs.loki.outputs.image_digest_linux_arm }}"
-      "IMAGE_DIGEST_ARM64": "${{ needs.loki.outputs.image_digest_linux_arm64 }}"
-      "OUTPUTS_IMAGE_NAME": "${{ needs.loki.outputs.image_name }}"
-      "OUTPUTS_IMAGE_TAG": "${{ needs.loki.outputs.image_tag }}"
+      "IMAGE_DIGEST_AMD64": "${{ needs.loki-image.outputs.image_digest_linux_amd64 }}"
+      "IMAGE_DIGEST_ARM": "${{ needs.loki-image.outputs.image_digest_linux_arm }}"
+      "IMAGE_DIGEST_ARM64": "${{ needs.loki-image.outputs.image_digest_linux_arm64 }}"
+      "OUTPUTS_IMAGE_NAME": "${{ needs.loki-image.outputs.image_name }}"
+      "OUTPUTS_IMAGE_TAG": "${{ needs.loki-image.outputs.image_tag }}"
     "needs":
     - "loki-image"
     "permissions":
@@ -463,10 +463,10 @@
     - "name": "Publish multi-arch manifest"
       "run": |
         # Unfortunately there is no better way atm than having a separate named output for each digest
-        echo 'linux/arm64 $IMAGE_DIGEST_ARM64'
-        echo 'linux/amd64 $IMAGE_DIGEST_AMD64'
-        echo 'linux/arm   $IMAGE_DIGEST_ARM'
-        IMAGE=${OUTPUTS_IMAGE_NAME}:${OUTPUTS_IMAGE_TAG}
+        echo "linux/arm64 $IMAGE_DIGEST_ARM64"
+        echo "linux/amd64 $IMAGE_DIGEST_AMD64"
+        echo "linux/arm   $IMAGE_DIGEST_ARM"
+        IMAGE="${OUTPUTS_IMAGE_NAME}:${OUTPUTS_IMAGE_TAG}"
         echo "Create multi-arch manifest for $IMAGE"
         docker buildx imagetools create -t $IMAGE \
           ${OUTPUTS_IMAGE_NAME}@${IMAGE_DIGEST_ARM64} \
@@ -567,11 +567,11 @@
   "promtail-manifest":
     "env":
       "BUILD_TIMEOUT": 60
-      "IMAGE_DIGEST_AMD64": "${{ needs.promtail.outputs.image_digest_linux_amd64 }}"
-      "IMAGE_DIGEST_ARM": "${{ needs.promtail.outputs.image_digest_linux_arm }}"
-      "IMAGE_DIGEST_ARM64": "${{ needs.promtail.outputs.image_digest_linux_arm64 }}"
-      "OUTPUTS_IMAGE_NAME": "${{ needs.promtail.outputs.image_name }}"
-      "OUTPUTS_IMAGE_TAG": "${{ needs.promtail.outputs.image_tag }}"
+      "IMAGE_DIGEST_AMD64": "${{ needs.promtail-image.outputs.image_digest_linux_amd64 }}"
+      "IMAGE_DIGEST_ARM": "${{ needs.promtail-image.outputs.image_digest_linux_arm }}"
+      "IMAGE_DIGEST_ARM64": "${{ needs.promtail-image.outputs.image_digest_linux_arm64 }}"
+      "OUTPUTS_IMAGE_NAME": "${{ needs.promtail-image.outputs.image_name }}"
+      "OUTPUTS_IMAGE_TAG": "${{ needs.promtail-image.outputs.image_tag }}"
     "needs":
     - "promtail-image"
     "permissions":
@@ -586,10 +586,10 @@
     - "name": "Publish multi-arch manifest"
       "run": |
         # Unfortunately there is no better way atm than having a separate named output for each digest
-        echo 'linux/arm64 $IMAGE_DIGEST_ARM64'
-        echo 'linux/amd64 $IMAGE_DIGEST_AMD64'
-        echo 'linux/arm   $IMAGE_DIGEST_ARM'
-        IMAGE=${OUTPUTS_IMAGE_NAME}:${OUTPUTS_IMAGE_TAG}
+        echo "linux/arm64 $IMAGE_DIGEST_ARM64"
+        echo "linux/amd64 $IMAGE_DIGEST_AMD64"
+        echo "linux/arm   $IMAGE_DIGEST_ARM"
+        IMAGE="${OUTPUTS_IMAGE_NAME}:${OUTPUTS_IMAGE_TAG}"
         echo "Create multi-arch manifest for $IMAGE"
         docker buildx imagetools create -t $IMAGE \
           ${OUTPUTS_IMAGE_NAME}@${IMAGE_DIGEST_ARM64} \

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -79,7 +79,7 @@
       "name": "Prepare tag name"
       "run": |
         arch=$(echo $MATRIX_ARCH | cut -d'/' -f2)
-        echo "IMAGE_TAG=${$OUTPUTS_IMAGE_NAME}:${OUTPUTS_IMAGE_VERSION}-${arch}" >> $GITHUB_OUTPUT
+        echo "IMAGE_TAG=${OUTPUTS_IMAGE_NAME}:${OUTPUTS_IMAGE_VERSION}-${arch}" >> $GITHUB_OUTPUT
     - "id": "build-push"
       "name": "Build and push"
       "timeout-minutes": "${{ fromJSON(env.BUILD_TIMEOUT) }}"


### PR DESCRIPTION
Updates the images.yml workflow file with the following fixes:
* remove a rogue '$' character
* update the references to image digest steps

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
