### PR TITLE
fix: fix readiness check

### DIFF
--- a/pkg/limits/frontend/frontend.go
+++ b/pkg/limits/frontend/frontend.go
@@ -198,13 +198,12 @@ func (f *Frontend) ExceedsLimits(ctx context.Context, req *logproto.ExceedsLimit
 }
 
 func (f *Frontend) CheckReady(ctx context.Context) error {
-	if f.State() != services.Running && f.State() != services.Stopping {
-		return fmt.Errorf("ingest limits frontend not ready: %v", f.State())
+	if f.State() != services.Running {
+		return fmt.Errorf("service is not running: %v", f.State())
 	}
 	err := f.lifecycler.CheckReady(ctx)
 	if err != nil {
-		level.Error(f.logger).Log("msg", "ingest limits frontend not ready", "err", err)
-		return err
+		return fmt.Errorf("lifecycler not ready: %w", err)
 	}
 	return nil
 }

--- a/pkg/limits/ingest_limits.go
+++ b/pkg/limits/ingest_limits.go
@@ -230,16 +230,13 @@ func (s *IngestLimits) onPartitionsRevoked(ctx context.Context, client *kgo.Clie
 }
 
 func (s *IngestLimits) CheckReady(ctx context.Context) error {
-	if s.State() != services.Running && s.State() != services.Stopping {
-		return fmt.Errorf("ingest limits not ready: %v", s.State())
+	if s.State() != services.Running {
+		return fmt.Errorf("service is not running: %v", s.State())
 	}
-
 	err := s.lifecycler.CheckReady(ctx)
 	if err != nil {
-		level.Error(s.logger).Log("msg", "ingest limits not ready", "err", err)
-		return err
+		return fmt.Errorf("lifecycler not ready: %w", err)
 	}
-
 	return nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix readiness check passing for a limits-frontend and limits service that is shutting down. It also fixes the error messages to prevent the same message being logged twice in readyHandler in pkg/loki/loki.go.

What happens is we get the following error in `/ready`:

```
Ingest Limits Frontend not ready: ingest limits frontend not ready: starting
```

when instead we want:

```
Ingest Limits Frontend not ready: service is not running: starting
```

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
