### PR TITLE
chore: make the limits-frontend no-op while we refactor it

### DIFF
--- a/pkg/limits/frontend/frontend_test.go
+++ b/pkg/limits/frontend/frontend_test.go
@@ -2,14 +2,9 @@ package frontend
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
-	"github.com/go-kit/log"
-	"github.com/grafana/dskit/limiter"
-	"github.com/grafana/dskit/ring"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/loki/v3/pkg/logproto"
@@ -17,340 +12,149 @@ import (
 
 func TestFrontend_ExceedsLimits(t *testing.T) {
 	tests := []struct {
-		name                           string
-		exceedsLimitsRequest           *logproto.ExceedsLimitsRequest
-		numPartitions                  int
-		getAssignedPartitionsResponses []*logproto.GetAssignedPartitionsResponse
-		expectedStreamUsageRequest     []*logproto.GetStreamUsageRequest
-		getStreamUsageResponses        []*logproto.GetStreamUsageResponse
-		maxGlobalStreams               int
-		ingestionRate                  float64
-		expected                       []*logproto.ExceedsLimitsResult
+		name                   string
+		exceedsLimitsRequest   *logproto.ExceedsLimitsRequest
+		exceedsLimitsResponses []*logproto.ExceedsLimitsResponse
+		expected               *logproto.ExceedsLimitsResponse
 	}{{
 		name: "no streams",
 		exceedsLimitsRequest: &logproto.ExceedsLimitsRequest{
 			Tenant:  "test",
-			Streams: []*logproto.StreamMetadata{},
+			Streams: nil,
 		},
-		expected: nil,
-	}, {
-		name: "no response",
-		exceedsLimitsRequest: &logproto.ExceedsLimitsRequest{
-			Tenant: "test",
-			Streams: []*logproto.StreamMetadata{
-				{StreamHash: 0x1},
-			},
-		},
-		numPartitions: 1,
-		getAssignedPartitionsResponses: []*logproto.GetAssignedPartitionsResponse{{
-			AssignedPartitions: map[int32]int64{
-				0: time.Now().UnixNano(),
-			},
-		}},
-		expectedStreamUsageRequest: []*logproto.GetStreamUsageRequest{{
-			Tenant:       "test",
-			StreamHashes: []uint64{0x1},
-		}},
-		getStreamUsageResponses: []*logproto.GetStreamUsageResponse{{}},
-		maxGlobalStreams:        10,
-		ingestionRate:           100,
-		expected:                nil,
-	}, {
-		name: "within limits",
-		exceedsLimitsRequest: &logproto.ExceedsLimitsRequest{
-			Tenant: "test",
-			Streams: []*logproto.StreamMetadata{
-				{StreamHash: 0x1},
-				{StreamHash: 0x2},
-			},
-		},
-		numPartitions: 1,
-		getAssignedPartitionsResponses: []*logproto.GetAssignedPartitionsResponse{{
-			AssignedPartitions: map[int32]int64{
-				0: time.Now().UnixNano(),
-			},
-		}},
-		expectedStreamUsageRequest: []*logproto.GetStreamUsageRequest{{
-			Tenant:       "test",
-			StreamHashes: []uint64{0x1, 0x2},
-		}},
-		getStreamUsageResponses: []*logproto.GetStreamUsageResponse{{
-			Tenant:        "test",
-			ActiveStreams: 2,
-			Rate:          10,
-		}},
-		maxGlobalStreams: 10,
-		ingestionRate:    100,
-		expected:         nil,
-	}, {
-		name: "exceeds max streams limit, returns the new streams",
-		exceedsLimitsRequest: &logproto.ExceedsLimitsRequest{
-			Tenant: "test",
-			Streams: []*logproto.StreamMetadata{
-				{StreamHash: 0x1}, // Exceeds limits.
-				{StreamHash: 0x2}, // Also exceeds limits.
-			},
-		},
-		numPartitions: 1,
-		getAssignedPartitionsResponses: []*logproto.GetAssignedPartitionsResponse{{
-			AssignedPartitions: map[int32]int64{
-				0: time.Now().UnixNano(),
-			},
-		}},
-		expectedStreamUsageRequest: []*logproto.GetStreamUsageRequest{{
-			Tenant:       "test",
-			StreamHashes: []uint64{0x1, 0x2},
-		}},
-		getStreamUsageResponses: []*logproto.GetStreamUsageResponse{{
-			Tenant:         "test",
-			ActiveStreams:  5,
-			Rate:           10,
-			UnknownStreams: []uint64{0x1, 0x2},
-		}},
-		maxGlobalStreams: 5,
-		ingestionRate:    100,
-		expected: []*logproto.ExceedsLimitsResult{
-			{StreamHash: 0x1, Reason: ReasonExceedsMaxStreams},
-			{StreamHash: 0x2, Reason: ReasonExceedsMaxStreams},
+		expected: &logproto.ExceedsLimitsResponse{
+			Tenant:  "test",
+			Results: []*logproto.ExceedsLimitsResult{},
 		},
 	}, {
-		name: "exceeds max streams limit, allows existing streams and returns the new streams",
+		name: "one stream",
 		exceedsLimitsRequest: &logproto.ExceedsLimitsRequest{
 			Tenant: "test",
-			Streams: []*logproto.StreamMetadata{
-				{StreamHash: 0x1},
-				{StreamHash: 0x2},
-				{StreamHash: 0x3},
-				{StreamHash: 0x4},
-				{StreamHash: 0x5},
-				{StreamHash: 0x6}, // Exceeds limits.
-				{StreamHash: 0x7}, // Also exceeds limits.
-			},
+			Streams: []*logproto.StreamMetadata{{
+				StreamHash:             0x1,
+				EntriesSize:            0x2,
+				StructuredMetadataSize: 0x3,
+			}},
 		},
-		numPartitions: 1,
-		getAssignedPartitionsResponses: []*logproto.GetAssignedPartitionsResponse{{
-			AssignedPartitions: map[int32]int64{
-				0: time.Now().UnixNano(),
-			},
+		exceedsLimitsResponses: []*logproto.ExceedsLimitsResponse{{
+			Tenant: "test",
+			Results: []*logproto.ExceedsLimitsResult{{
+				StreamHash: 0x1,
+				Reason:     ReasonExceedsMaxStreams,
+			}},
 		}},
-		expectedStreamUsageRequest: []*logproto.GetStreamUsageRequest{{
-			Tenant:       "test",
-			StreamHashes: []uint64{0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7},
-		}},
-		getStreamUsageResponses: []*logproto.GetStreamUsageResponse{{
-			Tenant:         "test",
-			ActiveStreams:  5,
-			Rate:           10,
-			UnknownStreams: []uint64{6, 7},
-		}},
-		maxGlobalStreams: 5,
-		ingestionRate:    100,
-		expected: []*logproto.ExceedsLimitsResult{
-			{StreamHash: 6, Reason: ReasonExceedsMaxStreams},
-			{StreamHash: 7, Reason: ReasonExceedsMaxStreams},
+		expected: &logproto.ExceedsLimitsResponse{
+			Tenant: "test",
+			Results: []*logproto.ExceedsLimitsResult{{
+				StreamHash: 0x1,
+				Reason:     ReasonExceedsMaxStreams,
+			}},
 		},
 	}, {
-		// This test checks the case where a tenant's streams are sharded over
-		// two instances, each holding one each stream. Each instance will
-		// receive a request for just the streams in its assigned partitions.
-		// The frontend is responsible for taking the union of the two responses
-		// and calculating the actual set of unknown streams.
-		name: "exceeds max streams limit, streams sharded over two instances",
+		name: "one stream, no responses",
 		exceedsLimitsRequest: &logproto.ExceedsLimitsRequest{
 			Tenant: "test",
-			Streams: []*logproto.StreamMetadata{
-				{StreamHash: 0x1}, // Exceeds limits.
-				{StreamHash: 0x2}, // Also exceeds limits.
-			},
+			Streams: []*logproto.StreamMetadata{{
+				StreamHash:             0x1,
+				EntriesSize:            0x2,
+				StructuredMetadataSize: 0x3,
+			}},
 		},
-		numPartitions: 2,
-		getAssignedPartitionsResponses: []*logproto.GetAssignedPartitionsResponse{{
-			AssignedPartitions: map[int32]int64{
-				0: time.Now().UnixNano(), // Instance 0 owns partition 0.
-			},
+		exceedsLimitsResponses: []*logproto.ExceedsLimitsResponse{{
+			Tenant:  "test",
+			Results: []*logproto.ExceedsLimitsResult{},
+		}},
+		expected: &logproto.ExceedsLimitsResponse{
+			Tenant:  "test",
+			Results: []*logproto.ExceedsLimitsResult{},
+		},
+	}, {
+		name: "two stream, one response",
+		exceedsLimitsRequest: &logproto.ExceedsLimitsRequest{
+			Tenant: "test",
+			Streams: []*logproto.StreamMetadata{{
+				StreamHash:             0x1,
+				EntriesSize:            0x2,
+				StructuredMetadataSize: 0x3,
+			}, {
+				StreamHash:             0x4,
+				EntriesSize:            0x5,
+				StructuredMetadataSize: 0x6,
+			}},
+		},
+		exceedsLimitsResponses: []*logproto.ExceedsLimitsResponse{{
+			Tenant: "test",
+			Results: []*logproto.ExceedsLimitsResult{{
+				StreamHash: 0x1,
+				Reason:     ReasonExceedsMaxStreams,
+			}, {
+				StreamHash: 0x4,
+				Reason:     ReasonExceedsRateLimit,
+			}},
+		}},
+		expected: &logproto.ExceedsLimitsResponse{
+			Tenant: "test",
+			Results: []*logproto.ExceedsLimitsResult{{
+				StreamHash: 0x1,
+				Reason:     ReasonExceedsMaxStreams,
+			}, {
+				StreamHash: 0x4,
+				Reason:     ReasonExceedsRateLimit,
+			}},
+		},
+	}, {
+		name: "two stream, two responses",
+		exceedsLimitsRequest: &logproto.ExceedsLimitsRequest{
+			Tenant: "test",
+			Streams: []*logproto.StreamMetadata{{
+				StreamHash:             0x1,
+				EntriesSize:            0x2,
+				StructuredMetadataSize: 0x3,
+			}, {
+				StreamHash:             0x4,
+				EntriesSize:            0x5,
+				StructuredMetadataSize: 0x6,
+			}},
+		},
+		exceedsLimitsResponses: []*logproto.ExceedsLimitsResponse{{
+			Tenant: "test",
+			Results: []*logproto.ExceedsLimitsResult{{
+				StreamHash: 0x1,
+				Reason:     ReasonExceedsMaxStreams,
+			}},
 		}, {
-			AssignedPartitions: map[int32]int64{
-				1: time.Now().UnixNano(), // Instance 1 owns partition 1.
-			},
-		}},
-		// The frontend will ask instance 0 for the data for partition 0,
-		// and instance 1 for the data for partition 1.
-		expectedStreamUsageRequest: []*logproto.GetStreamUsageRequest{{
-			Tenant:       "test",
-			StreamHashes: []uint64{0x2},
-		}, {
-			Tenant:       "test",
-			StreamHashes: []uint64{0x1},
-		}},
-		getStreamUsageResponses: []*logproto.GetStreamUsageResponse{{
-			Tenant:         "test",
-			ActiveStreams:  1,
-			Rate:           5,
-			UnknownStreams: nil,
-		}, {
-			// Instance 1 responds that it does not know about stream
-			// 0x1. Since 0x1 shards to partition 1, and partition 1
-			// is consumed by instance 1, the frontend knows that 0x1
-			// is an unknown stream.
-			Tenant:         "test",
-			ActiveStreams:  1,
-			Rate:           5,
-			UnknownStreams: []uint64{0x1},
-		}},
-		maxGlobalStreams: 1,
-		ingestionRate:    100,
-		expected: []*logproto.ExceedsLimitsResult{
-			{StreamHash: 0x1, Reason: ReasonExceedsMaxStreams},
-		},
-	}, {
-		name: "exceeds rate limits, returns all streams",
-		exceedsLimitsRequest: &logproto.ExceedsLimitsRequest{
 			Tenant: "test",
-			Streams: []*logproto.StreamMetadata{
-				{StreamHash: 0x1},
-				{StreamHash: 0x2},
-			},
-		},
-		numPartitions: 1,
-		getAssignedPartitionsResponses: []*logproto.GetAssignedPartitionsResponse{{
-			AssignedPartitions: map[int32]int64{
-				0: time.Now().UnixNano(),
-			},
+			Results: []*logproto.ExceedsLimitsResult{{
+				StreamHash: 0x4,
+				Reason:     ReasonExceedsRateLimit,
+			}},
 		}},
-		expectedStreamUsageRequest: []*logproto.GetStreamUsageRequest{{
-			Tenant:       "test",
-			StreamHashes: []uint64{0x1, 0x2},
-		}},
-		getStreamUsageResponses: []*logproto.GetStreamUsageResponse{{
-			Tenant:        "test",
-			ActiveStreams: 2,
-			Rate:          1500, // Above the limit of 100 bytes/sec
-		}},
-		maxGlobalStreams: 10,
-		ingestionRate:    100,
-		expected: []*logproto.ExceedsLimitsResult{
-			{StreamHash: 1, Reason: ReasonExceedsRateLimit},
-			{StreamHash: 2, Reason: ReasonExceedsRateLimit},
-		},
-	}, {
-		name: "exceeds rate limits, rates sharded over two instances",
-		exceedsLimitsRequest: &logproto.ExceedsLimitsRequest{
+		expected: &logproto.ExceedsLimitsResponse{
 			Tenant: "test",
-			Streams: []*logproto.StreamMetadata{
-				{StreamHash: 0x1},
-				{StreamHash: 0x2},
-			},
-		},
-		numPartitions: 2,
-		getAssignedPartitionsResponses: []*logproto.GetAssignedPartitionsResponse{{
-			AssignedPartitions: map[int32]int64{
-				0: time.Now().UnixNano(),
-			},
-		}, {
-			AssignedPartitions: map[int32]int64{
-				1: time.Now().UnixNano(),
-			},
-		}},
-		// The frontend will ask instance 0 for the data for partition 0,
-		// and instance 1 for the data for partition 1.
-		expectedStreamUsageRequest: []*logproto.GetStreamUsageRequest{{
-			Tenant:       "test",
-			StreamHashes: []uint64{0x2},
-		}, {
-			Tenant:       "test",
-			StreamHashes: []uint64{0x1},
-		}},
-		getStreamUsageResponses: []*logproto.GetStreamUsageResponse{{
-			Tenant:        "test",
-			ActiveStreams: 1,
-			Rate:          600,
-		}, {
-			Tenant:        "test",
-			ActiveStreams: 1,
-			Rate:          500,
-		}},
-		maxGlobalStreams: 10,
-		ingestionRate:    100,
-		expected: []*logproto.ExceedsLimitsResult{
-			{StreamHash: 1, Reason: ReasonExceedsRateLimit},
-			{StreamHash: 2, Reason: ReasonExceedsRateLimit},
-		},
-	}, {
-		name: "exceeds both max stream limit and rate limits",
-		exceedsLimitsRequest: &logproto.ExceedsLimitsRequest{
-			Tenant: "test",
-			Streams: []*logproto.StreamMetadata{
-				{StreamHash: 0x6},
-				{StreamHash: 0x7},
-			},
-		},
-		numPartitions: 1,
-		getAssignedPartitionsResponses: []*logproto.GetAssignedPartitionsResponse{{
-			AssignedPartitions: map[int32]int64{
-				0: time.Now().UnixNano(),
-			},
-		}},
-		expectedStreamUsageRequest: []*logproto.GetStreamUsageRequest{{
-			Tenant:       "test",
-			StreamHashes: []uint64{0x6, 0x7},
-		}},
-		getStreamUsageResponses: []*logproto.GetStreamUsageResponse{{
-			Tenant:         "test",
-			ActiveStreams:  5,
-			UnknownStreams: []uint64{0x6, 0x7},
-			Rate:           1500, // Above the limit of 100 bytes/sec
-		}},
-		maxGlobalStreams: 5,
-		ingestionRate:    100,
-		expected: []*logproto.ExceedsLimitsResult{
-			{StreamHash: 0x6, Reason: ReasonExceedsMaxStreams},
-			{StreamHash: 0x7, Reason: ReasonExceedsMaxStreams},
-			{StreamHash: 0x6, Reason: ReasonExceedsRateLimit},
-			{StreamHash: 0x7, Reason: ReasonExceedsRateLimit},
+			Results: []*logproto.ExceedsLimitsResult{{
+				StreamHash: 0x1,
+				Reason:     ReasonExceedsMaxStreams,
+			}, {
+				StreamHash: 0x4,
+				Reason:     ReasonExceedsRateLimit,
+			}},
 		},
 	}}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			// Set up the mock clients, one for each pair of mock RPC responses.
-			mockClients := make([]*mockIngestLimitsClient, len(test.getAssignedPartitionsResponses))
-			instances := make([]ring.InstanceDesc, len(mockClients))
-
-			for i := range test.getAssignedPartitionsResponses {
-				mockClients[i] = &mockIngestLimitsClient{
-					getAssignedPartitionsResponse: test.getAssignedPartitionsResponses[i],
-					expectedStreamUsageRequest:    test.expectedStreamUsageRequest[i],
-					getStreamUsageResponse:        test.getStreamUsageResponses[i],
-					t:                             t,
-				}
-				instances[i] = ring.InstanceDesc{
-					Addr: fmt.Sprintf("instance-%d", i),
-				}
-			}
-
-			// Set up the mocked ring and client pool for the tests.
-			readRing, clientPool := newMockRingWithClientPool(t, "test", mockClients, instances)
-			l := &mockLimits{
-				maxGlobalStreams: test.maxGlobalStreams,
-				ingestionRate:    test.ingestionRate,
-			}
-			rl := limiter.NewRateLimiter(newRateLimitsAdapter(l), 10*time.Second)
-			cache := NewNopCache[string, *logproto.GetAssignedPartitionsResponse]()
-
 			f := Frontend{
-				limits:      l,
-				rateLimiter: rl,
-				streamUsage: NewRingStreamUsageGatherer(readRing, clientPool, test.numPartitions, cache, log.NewNopLogger()),
-				metrics:     newMetrics(prometheus.NewRegistry()),
+				gatherer: &mockExceedsLimitsGatherer{
+					t:                            t,
+					expectedExceedsLimitsRequest: test.exceedsLimitsRequest,
+					exceedsLimitsResponses:       test.exceedsLimitsResponses,
+				},
 			}
-
-			// Set a maximum upper bound on the test execution time.
 			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 			defer cancel()
-
-			resp, err := f.ExceedsLimits(ctx, test.exceedsLimitsRequest)
+			actual, err := f.ExceedsLimits(ctx, test.exceedsLimitsRequest)
 			require.NoError(t, err)
-			require.Equal(t, test.expected, resp.Results)
+			require.Equal(t, test.expected, actual)
 		})
 	}
 }

--- a/pkg/limits/frontend/gather.go
+++ b/pkg/limits/frontend/gather.go
@@ -6,20 +6,9 @@ import (
 	"github.com/grafana/loki/v3/pkg/logproto"
 )
 
-type StreamUsageGatherer interface {
-	// GetStreamUsage returns the current usage data for the stream hashes
-	// in the request. It returns multiple responses if the usage data for
-	// the requested stream hashes is partitioned over a number of limits
-	// instances.
-	GetStreamUsage(context.Context, GetStreamUsageRequest) ([]GetStreamUsageResponse, error)
-}
-
-type GetStreamUsageRequest struct {
-	Tenant       string
-	StreamHashes []uint64
-}
-
-type GetStreamUsageResponse struct {
-	Addr     string
-	Response *logproto.GetStreamUsageResponse
+type ExceedsLimitsGatherer interface {
+	// ExceedsLimits checks if the streams in the request have exceeded their
+	// per-partition limits. It returns more than one response when the
+	// requested streams are sharded over two or more limits instances.
+	ExceedsLimits(context.Context, *logproto.ExceedsLimitsRequest) ([]*logproto.ExceedsLimitsResponse, error)
 }

--- a/pkg/limits/frontend/http.go
+++ b/pkg/limits/frontend/http.go
@@ -12,8 +12,8 @@ import (
 )
 
 type httpExceedsLimitsRequest struct {
-	TenantID     string   `json:"tenantID"`
-	StreamHashes []uint64 `json:"streamHashes"`
+	Tenant  string                     `json:"tenant"`
+	Streams []*logproto.StreamMetadata `json:"streams"`
 }
 
 type httpExceedsLimitsResponse struct {
@@ -28,32 +28,24 @@ func (f *Frontend) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if req.TenantID == "" {
-		http.Error(w, "tenantID is required", http.StatusBadRequest)
+	if req.Tenant == "" {
+		http.Error(w, "tenant is required", http.StatusBadRequest)
 		return
 	}
 
-	streams := make([]*logproto.StreamMetadata, 0, len(req.StreamHashes))
-	for _, streamHash := range req.StreamHashes {
-		streams = append(streams, &logproto.StreamMetadata{
-			StreamHash: streamHash,
-		})
-	}
-	protoReq := &logproto.ExceedsLimitsRequest{
-		Tenant:  req.TenantID,
-		Streams: streams,
-	}
-
-	ctx, err := user.InjectIntoGRPCRequest(user.InjectOrgID(r.Context(), req.TenantID))
+	ctx, err := user.InjectIntoGRPCRequest(user.InjectOrgID(r.Context(), req.Tenant))
 	if err != nil {
 		http.Error(w, "failed to inject org ID", http.StatusInternalServerError)
 		return
 	}
 
-	resp, err := f.ExceedsLimits(ctx, protoReq)
+	resp, err := f.ExceedsLimits(ctx, &logproto.ExceedsLimitsRequest{
+		Tenant:  req.Tenant,
+		Streams: req.Streams,
+	})
 	if err != nil {
-		level.Error(f.logger).Log("msg", "failed to check limits", "err", err)
-		http.Error(w, "an unexpected error occurred while checking limits", http.StatusInternalServerError)
+		level.Error(f.logger).Log("msg", "failed to check if request exceeds limits", "err", err)
+		http.Error(w, "an unexpected error occurred while checking if request exceeds limits", http.StatusInternalServerError)
 		return
 	}
 

--- a/pkg/limits/frontend/http_test.go
+++ b/pkg/limits/frontend/http_test.go
@@ -7,10 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	"time"
 
-	"github.com/grafana/dskit/limiter"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/loki/v3/pkg/logproto"
@@ -18,54 +15,54 @@ import (
 
 func TestFrontend_ServeHTTP(t *testing.T) {
 	tests := []struct {
-		name                          string
-		limits                        Limits
-		expectedGetStreamUsageRequest *GetStreamUsageRequest
-		getStreamUsageResponses       []GetStreamUsageResponse
-		request                       httpExceedsLimitsRequest
-		expected                      httpExceedsLimitsResponse
+		name                         string
+		expectedExceedsLimitsRequest *logproto.ExceedsLimitsRequest
+		exceedsLimitsResponses       []*logproto.ExceedsLimitsResponse
+		request                      httpExceedsLimitsRequest
+		expected                     httpExceedsLimitsResponse
 	}{{
 		name: "within limits",
-		limits: &mockLimits{
-			maxGlobalStreams: 1,
-			ingestionRate:    100,
+		expectedExceedsLimitsRequest: &logproto.ExceedsLimitsRequest{
+			Tenant: "test",
+			Streams: []*logproto.StreamMetadata{{
+				StreamHash:             0x1,
+				EntriesSize:            0x2,
+				StructuredMetadataSize: 0x3,
+			}},
 		},
-		expectedGetStreamUsageRequest: &GetStreamUsageRequest{
-			Tenant:       "test",
-			StreamHashes: []uint64{0x1},
-		},
-		getStreamUsageResponses: []GetStreamUsageResponse{{
-			Response: &logproto.GetStreamUsageResponse{
-				Tenant:        "test",
-				ActiveStreams: 1,
-				Rate:          10,
-			},
-		}},
+		exceedsLimitsResponses: []*logproto.ExceedsLimitsResponse{{}},
 		request: httpExceedsLimitsRequest{
-			TenantID:     "test",
-			StreamHashes: []uint64{0x1},
+			Tenant: "test",
+			Streams: []*logproto.StreamMetadata{{
+				StreamHash:             0x1,
+				EntriesSize:            0x2,
+				StructuredMetadataSize: 0x3,
+			}},
 		},
 		// expected should be default value.
 	}, {
 		name: "exceeds limits",
-		limits: &mockLimits{
-			maxGlobalStreams: 1,
-			ingestionRate:    100,
+		expectedExceedsLimitsRequest: &logproto.ExceedsLimitsRequest{
+			Tenant: "test",
+			Streams: []*logproto.StreamMetadata{{
+				StreamHash:             0x1,
+				EntriesSize:            0x2,
+				StructuredMetadataSize: 0x3,
+			}},
 		},
-		expectedGetStreamUsageRequest: &GetStreamUsageRequest{
-			Tenant:       "test",
-			StreamHashes: []uint64{0x1},
-		},
-		getStreamUsageResponses: []GetStreamUsageResponse{{
-			Response: &logproto.GetStreamUsageResponse{
-				Tenant:        "test",
-				ActiveStreams: 2,
-				Rate:          200,
-			},
+		exceedsLimitsResponses: []*logproto.ExceedsLimitsResponse{{
+			Results: []*logproto.ExceedsLimitsResult{{
+				StreamHash: 0x1,
+				Reason:     "exceeds_rate_limit",
+			}},
 		}},
 		request: httpExceedsLimitsRequest{
-			TenantID:     "test",
-			StreamHashes: []uint64{0x1},
+			Tenant: "test",
+			Streams: []*logproto.StreamMetadata{{
+				StreamHash:             0x1,
+				EntriesSize:            0x2,
+				StructuredMetadataSize: 0x3,
+			}},
 		},
 		expected: httpExceedsLimitsResponse{
 			Results: []*logproto.ExceedsLimitsResult{{
@@ -78,14 +75,11 @@ func TestFrontend_ServeHTTP(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			f := Frontend{
-				limits:      test.limits,
-				rateLimiter: limiter.NewRateLimiter(newRateLimitsAdapter(test.limits), time.Second),
-				streamUsage: &mockStreamUsageGatherer{
-					t:               t,
-					expectedRequest: test.expectedGetStreamUsageRequest,
-					responses:       test.getStreamUsageResponses,
+				gatherer: &mockExceedsLimitsGatherer{
+					t:                            t,
+					expectedExceedsLimitsRequest: test.expectedExceedsLimitsRequest,
+					exceedsLimitsResponses:       test.exceedsLimitsResponses,
 				},
-				metrics: newMetrics(prometheus.NewRegistry()),
 			}
 			ts := httptest.NewServer(&f)
 			defer ts.Close()

--- a/pkg/limits/frontend/mock_test.go
+++ b/pkg/limits/frontend/mock_test.go
@@ -16,20 +16,20 @@ import (
 	"github.com/grafana/loki/v3/pkg/logproto"
 )
 
-// mockStreamUsageGatherer mocks a StreamUsageGatherer. It avoids having to
+// mockExceedsLimitsGatherer mocks an ExeceedsLimitsGatherer. It avoids having to
 // set up a mock ring to test the frontend.
-type mockStreamUsageGatherer struct {
+type mockExceedsLimitsGatherer struct {
 	t *testing.T
 
-	expectedRequest *GetStreamUsageRequest
-	responses       []GetStreamUsageResponse
+	expectedExceedsLimitsRequest *logproto.ExceedsLimitsRequest
+	exceedsLimitsResponses       []*logproto.ExceedsLimitsResponse
 }
 
-func (g *mockStreamUsageGatherer) GetStreamUsage(_ context.Context, r GetStreamUsageRequest) ([]GetStreamUsageResponse, error) {
-	if expected := g.expectedRequest; expected != nil {
-		require.Equal(g.t, *expected, r)
+func (g *mockExceedsLimitsGatherer) ExceedsLimits(_ context.Context, req *logproto.ExceedsLimitsRequest) ([]*logproto.ExceedsLimitsResponse, error) {
+	if expected := g.expectedExceedsLimitsRequest; expected != nil {
+		require.Equal(g.t, expected, req)
 	}
-	return g.responses, nil
+	return g.exceedsLimitsResponses, nil
 }
 
 // mockIngestLimitsClient mocks logproto.IngestLimitsClient.

--- a/pkg/limits/frontend/ring.go
+++ b/pkg/limits/frontend/ring.go
@@ -21,9 +21,8 @@ var (
 	LimitsRead = ring.NewOp([]ring.InstanceState{ring.ACTIVE}, nil)
 )
 
-// RingStreamUsageGatherer implements StreamUsageGatherer. It uses a ring to find
-// limits instances.
-type RingStreamUsageGatherer struct {
+// RingGatherer uses a ring to find limits instances.
+type RingGatherer struct {
 	logger                  log.Logger
 	ring                    ring.ReadRing
 	pool                    *ring_client.Pool
@@ -31,15 +30,15 @@ type RingStreamUsageGatherer struct {
 	assignedPartitionsCache Cache[string, *logproto.GetAssignedPartitionsResponse]
 }
 
-// NewRingStreamUsageGatherer returns a new RingStreamUsageGatherer.
-func NewRingStreamUsageGatherer(
+// NewRingGatherer returns a new RingGatherer.
+func NewRingGatherer(
 	ring ring.ReadRing,
 	pool *ring_client.Pool,
 	numPartitions int,
 	assignedPartitionsCache Cache[string, *logproto.GetAssignedPartitionsResponse],
 	logger log.Logger,
-) *RingStreamUsageGatherer {
-	return &RingStreamUsageGatherer{
+) *RingGatherer {
+	return &RingGatherer{
 		logger:                  logger,
 		ring:                    ring,
 		pool:                    pool,
@@ -48,77 +47,10 @@ func NewRingStreamUsageGatherer(
 	}
 }
 
-// GetStreamUsage implements StreamUsageGatherer.
-func (g *RingStreamUsageGatherer) GetStreamUsage(ctx context.Context, r GetStreamUsageRequest) ([]GetStreamUsageResponse, error) {
-	if len(r.StreamHashes) == 0 {
-		return nil, nil
-	}
-	return g.forAllBackends(ctx, r)
-}
-
-// TODO(grobinson): Need to rename this to something more accurate.
-func (g *RingStreamUsageGatherer) forAllBackends(ctx context.Context, r GetStreamUsageRequest) ([]GetStreamUsageResponse, error) {
-	rs, err := g.ring.GetAllHealthy(LimitsRead)
-	if err != nil {
-		return nil, err
-	}
-	return g.forGivenReplicaSet(ctx, rs, r)
-}
-
-func (g *RingStreamUsageGatherer) forGivenReplicaSet(ctx context.Context, rs ring.ReplicationSet, r GetStreamUsageRequest) ([]GetStreamUsageResponse, error) {
-	partitionConsumers, err := g.getPartitionConsumers(ctx, rs.Instances)
-	if err != nil {
-		return nil, err
-	}
-
-	ownedStreamHeashes := make(map[string][]uint64)
-	for _, hash := range r.StreamHashes {
-		partitionID := int32(hash % uint64(g.numPartitions))
-		addr, ok := partitionConsumers[partitionID]
-		if !ok {
-			// TODO Replace with a metric for partitions missing owners.
-			level.Warn(g.logger).Log("msg", "no instance found for partition", "partition", partitionID)
-			continue
-		}
-		ownedStreamHeashes[addr] = append(ownedStreamHeashes[addr], hash)
-	}
-
-	errg, ctx := errgroup.WithContext(ctx)
-	responses := make([]GetStreamUsageResponse, len(rs.Instances))
-
-	// Query all healthy instances in parallel,
-	// send requested stream hahes only to owning instances.
-	for i, instance := range rs.Instances {
-		errg.Go(func() error {
-			client, err := g.pool.GetClientFor(instance.Addr)
-			if err != nil {
-				return err
-			}
-
-			protoReq := &logproto.GetStreamUsageRequest{Tenant: r.Tenant}
-
-			// Only send stream hashes to the instance that owns them.
-			// This eliminates the need in downstream callers to filter
-			// duplicate unknown streams.
-			if hashes, ok := ownedStreamHeashes[instance.Addr]; ok {
-				protoReq.StreamHashes = hashes
-			}
-
-			resp, err := client.(logproto.IngestLimitsClient).GetStreamUsage(ctx, protoReq)
-			if err != nil {
-				return err
-			}
-
-			responses[i] = GetStreamUsageResponse{Addr: instance.Addr, Response: resp}
-			return nil
-		})
-	}
-
-	if err := errg.Wait(); err != nil {
-		return nil, err
-	}
-
-	return responses, nil
+// ExceedsLimits implements ExceedsLimitsGatherer.
+func (g *RingGatherer) ExceedsLimits(ctx context.Context, req *logproto.ExceedsLimitsRequest) ([]*logproto.ExceedsLimitsResponse, error) {
+	// TODO(grobinson): Implement me.
+	return nil, nil
 }
 
 type zonePartitionConsumersResult struct {
@@ -131,7 +63,7 @@ type zonePartitionConsumersResult struct {
 // zone will still be returned but its partition consumers will be nil.
 // If ZoneAwarenessEnabled is false, it returns all partition consumers under
 // a pseudo-zone ("").
-func (g *RingStreamUsageGatherer) getZoneAwarePartitionConsumers(ctx context.Context, instances []ring.InstanceDesc) (map[string]map[int32]string, error) {
+func (g *RingGatherer) getZoneAwarePartitionConsumers(ctx context.Context, instances []ring.InstanceDesc) (map[string]map[int32]string, error) {
 	zoneDescs := make(map[string][]ring.InstanceDesc)
 	for _, instance := range instances {
 		zoneDescs[instance.Zone] = append(zoneDescs[instance.Zone], instance)
@@ -184,7 +116,7 @@ type getAssignedPartitionsResponse struct {
 // should be called once for each zone, and instances should be filtered to
 // the respective zone. Alternatively, you can pass all instances for all zones
 // to find the most up to date consumer for each partition across all zones.
-func (g *RingStreamUsageGatherer) getPartitionConsumers(ctx context.Context, instances []ring.InstanceDesc) (map[int32]string, error) {
+func (g *RingGatherer) getPartitionConsumers(ctx context.Context, instances []ring.InstanceDesc) (map[int32]string, error) {
 	errg, ctx := errgroup.WithContext(ctx)
 	responseCh := make(chan getAssignedPartitionsResponse, len(instances))
 	for _, instance := range instances {

--- a/pkg/limits/frontend/ring.go
+++ b/pkg/limits/frontend/ring.go
@@ -48,7 +48,7 @@ func NewRingGatherer(
 }
 
 // ExceedsLimits implements ExceedsLimitsGatherer.
-func (g *RingGatherer) ExceedsLimits(ctx context.Context, req *logproto.ExceedsLimitsRequest) ([]*logproto.ExceedsLimitsResponse, error) {
+func (g *RingGatherer) ExceedsLimits(_ context.Context, _ *logproto.ExceedsLimitsRequest) ([]*logproto.ExceedsLimitsResponse, error) {
 	// TODO(grobinson): Implement me.
 	return nil, nil
 }

--- a/pkg/limits/frontend/ring_test.go
+++ b/pkg/limits/frontend/ring_test.go
@@ -13,224 +13,224 @@ import (
 	"github.com/grafana/loki/v3/pkg/logproto"
 )
 
-func TestRingStreamUsageGatherer_GetStreamUsage(t *testing.T) {
-	tests := []struct {
-		name                  string
-		getStreamUsageRequest GetStreamUsageRequest
-		// Instances contains the complete set of instances that should be mocked.
-		// For example, if a test case is expected to make RPC calls to one instance,
-		// then just one InstanceDesc is required.
-		instances     []ring.InstanceDesc
-		numPartitions int
-		// The size of the following slices must match len(instances), where each
-		// value contains the expected request/response for the instance at the
-		// same index in the instances slice. If a request/response is not expected,
-		// the value can be set to nil.
-		expectedAssignedPartitionsRequest []*logproto.GetAssignedPartitionsRequest
-		getAssignedPartitionsResponses    []*logproto.GetAssignedPartitionsResponse
-		expectedStreamUsageRequests       []*logproto.GetStreamUsageRequest
-		getStreamUsageResponses           []*logproto.GetStreamUsageResponse
-		expectedResponses                 []GetStreamUsageResponse
-	}{{
-		// When there are no streams, no RPCs should be sent.
-		name: "no streams",
-		getStreamUsageRequest: GetStreamUsageRequest{
-			Tenant:       "test",
-			StreamHashes: []uint64{},
-		},
-		instances:                         []ring.InstanceDesc{{Addr: "instance-0"}},
-		numPartitions:                     1,
-		expectedAssignedPartitionsRequest: []*logproto.GetAssignedPartitionsRequest{nil},
-		getAssignedPartitionsResponses:    []*logproto.GetAssignedPartitionsResponse{nil},
-		expectedStreamUsageRequests:       []*logproto.GetStreamUsageRequest{nil},
-		getStreamUsageResponses:           []*logproto.GetStreamUsageResponse{nil},
-	}, {
-		// When there is one stream, and one instance, the stream usage for that
-		// stream should be queried from that instance.
-		name: "one stream",
-		getStreamUsageRequest: GetStreamUsageRequest{
-			Tenant:       "test",
-			StreamHashes: []uint64{0x1}, // Hash 0x1 maps to partition 0.
-		},
-		instances: []ring.InstanceDesc{{
-			Addr: "instance-0",
-		}},
-		numPartitions:                     1,
-		expectedAssignedPartitionsRequest: []*logproto.GetAssignedPartitionsRequest{{}},
-		getAssignedPartitionsResponses: []*logproto.GetAssignedPartitionsResponse{{
-			AssignedPartitions: map[int32]int64{
-				0: time.Now().UnixNano(),
-			},
-		}},
-		expectedStreamUsageRequests: []*logproto.GetStreamUsageRequest{{
-			Tenant:       "test",
-			StreamHashes: []uint64{0x1},
-		}},
-		getStreamUsageResponses: []*logproto.GetStreamUsageResponse{{
-			Tenant:        "test",
-			ActiveStreams: 1,
-			Rate:          10,
-		}},
-		expectedResponses: []GetStreamUsageResponse{{
-			Addr: "instance-0",
-			Response: &logproto.GetStreamUsageResponse{
-				Tenant:        "test",
-				ActiveStreams: 1,
-				Rate:          10,
-			},
-		}},
-	}, {
-		// When there is one stream, and two instances each owning separate
-		// partitions, all instances should be queried. However, only the
-		// instance owning the partition for the stream hash should be queried
-		// for the requested stream hashes.
-		name: "one stream two instances",
-		getStreamUsageRequest: GetStreamUsageRequest{
-			Tenant:       "test",
-			StreamHashes: []uint64{0x1}, // Hash 1 maps to partition 1.
-		},
-		instances: []ring.InstanceDesc{{
-			Addr: "instance-0",
-		}, {
-			Addr: "instance-1",
-		}},
-		numPartitions:                     2,
-		expectedAssignedPartitionsRequest: []*logproto.GetAssignedPartitionsRequest{{}, {}},
-		getAssignedPartitionsResponses: []*logproto.GetAssignedPartitionsResponse{{
-			AssignedPartitions: map[int32]int64{
-				0: time.Now().UnixNano(),
-			},
-		}, {
-			AssignedPartitions: map[int32]int64{
-				1: time.Now().UnixNano(),
-			},
-		}},
-		expectedStreamUsageRequests: []*logproto.GetStreamUsageRequest{{
-			Tenant: "test",
-		}, {
-			Tenant:       "test",
-			StreamHashes: []uint64{0x1},
-		}},
-		getStreamUsageResponses: []*logproto.GetStreamUsageResponse{{
-			Tenant:        "test",
-			ActiveStreams: 1,
-			Rate:          10,
-		}, {
-			Tenant:        "test",
-			ActiveStreams: 1,
-			Rate:          10,
-		}},
-		expectedResponses: []GetStreamUsageResponse{{
-			Addr: "instance-0",
-			Response: &logproto.GetStreamUsageResponse{
-				Tenant:        "test",
-				ActiveStreams: 1,
-				Rate:          10,
-			},
-		}, {
-			Addr: "instance-1",
-			Response: &logproto.GetStreamUsageResponse{
-				Tenant:        "test",
-				ActiveStreams: 1,
-				Rate:          10,
-			},
-		}},
-	}, {
-		// When there is one stream, and two instances owning overlapping
-		// partitions, only the instance with the latest timestamp for the relevant
-		// partition should be queried with the requested stream hash.
-		name: "one stream two instances, overlapping partition ownership",
-		getStreamUsageRequest: GetStreamUsageRequest{
-			Tenant:       "test",
-			StreamHashes: []uint64{0x1}, // Hash 0x1 maps to partition 1.
-		},
-		instances: []ring.InstanceDesc{{
-			Addr: "instance-0",
-		}, {
-			Addr: "instance-1",
-		}},
-		numPartitions:                     2,
-		expectedAssignedPartitionsRequest: []*logproto.GetAssignedPartitionsRequest{{}, {}},
-		getAssignedPartitionsResponses: []*logproto.GetAssignedPartitionsResponse{{
-			AssignedPartitions: map[int32]int64{
-				1: time.Now().Add(-time.Second).UnixNano(),
-			},
-		}, {
-			AssignedPartitions: map[int32]int64{
-				1: time.Now().UnixNano(),
-			},
-		}},
-		expectedStreamUsageRequests: []*logproto.GetStreamUsageRequest{{
-			Tenant: "test",
-		}, {
-			Tenant:       "test",
-			StreamHashes: []uint64{0x1},
-		}},
-		getStreamUsageResponses: []*logproto.GetStreamUsageResponse{{
-			Tenant:        "test",
-			ActiveStreams: 1,
-			Rate:          10,
-		}, {
-			Tenant:        "test",
-			ActiveStreams: 1,
-			Rate:          10,
-		}},
-		expectedResponses: []GetStreamUsageResponse{{
-			Addr: "instance-0",
-			Response: &logproto.GetStreamUsageResponse{
-				Tenant:        "test",
-				ActiveStreams: 1,
-				Rate:          10,
-			},
-		}, {
-			Addr: "instance-1",
-			Response: &logproto.GetStreamUsageResponse{
-				Tenant:        "test",
-				ActiveStreams: 1,
-				Rate:          10,
-			},
-		}},
-	}}
+// func TestRingStreamUsageGatherer_GetStreamUsage(t *testing.T) {
+// 	tests := []struct {
+// 		name                  string
+// 		getStreamUsageRequest GetStreamUsageRequest
+// 		// Instances contains the complete set of instances that should be mocked.
+// 		// For example, if a test case is expected to make RPC calls to one instance,
+// 		// then just one InstanceDesc is required.
+// 		instances     []ring.InstanceDesc
+// 		numPartitions int
+// 		// The size of the following slices must match len(instances), where each
+// 		// value contains the expected request/response for the instance at the
+// 		// same index in the instances slice. If a request/response is not expected,
+// 		// the value can be set to nil.
+// 		expectedAssignedPartitionsRequest []*logproto.GetAssignedPartitionsRequest
+// 		getAssignedPartitionsResponses    []*logproto.GetAssignedPartitionsResponse
+// 		expectedStreamUsageRequests       []*logproto.GetStreamUsageRequest
+// 		getStreamUsageResponses           []*logproto.GetStreamUsageResponse
+// 		expectedResponses                 []GetStreamUsageResponse
+// 	}{{
+// 		// When there are no streams, no RPCs should be sent.
+// 		name: "no streams",
+// 		getStreamUsageRequest: GetStreamUsageRequest{
+// 			Tenant:       "test",
+// 			StreamHashes: []uint64{},
+// 		},
+// 		instances:                         []ring.InstanceDesc{{Addr: "instance-0"}},
+// 		numPartitions:                     1,
+// 		expectedAssignedPartitionsRequest: []*logproto.GetAssignedPartitionsRequest{nil},
+// 		getAssignedPartitionsResponses:    []*logproto.GetAssignedPartitionsResponse{nil},
+// 		expectedStreamUsageRequests:       []*logproto.GetStreamUsageRequest{nil},
+// 		getStreamUsageResponses:           []*logproto.GetStreamUsageResponse{nil},
+// 	}, {
+// 		// When there is one stream, and one instance, the stream usage for that
+// 		// stream should be queried from that instance.
+// 		name: "one stream",
+// 		getStreamUsageRequest: GetStreamUsageRequest{
+// 			Tenant:       "test",
+// 			StreamHashes: []uint64{0x1}, // Hash 0x1 maps to partition 0.
+// 		},
+// 		instances: []ring.InstanceDesc{{
+// 			Addr: "instance-0",
+// 		}},
+// 		numPartitions:                     1,
+// 		expectedAssignedPartitionsRequest: []*logproto.GetAssignedPartitionsRequest{{}},
+// 		getAssignedPartitionsResponses: []*logproto.GetAssignedPartitionsResponse{{
+// 			AssignedPartitions: map[int32]int64{
+// 				0: time.Now().UnixNano(),
+// 			},
+// 		}},
+// 		expectedStreamUsageRequests: []*logproto.GetStreamUsageRequest{{
+// 			Tenant:       "test",
+// 			StreamHashes: []uint64{0x1},
+// 		}},
+// 		getStreamUsageResponses: []*logproto.GetStreamUsageResponse{{
+// 			Tenant:        "test",
+// 			ActiveStreams: 1,
+// 			Rate:          10,
+// 		}},
+// 		expectedResponses: []GetStreamUsageResponse{{
+// 			Addr: "instance-0",
+// 			Response: &logproto.GetStreamUsageResponse{
+// 				Tenant:        "test",
+// 				ActiveStreams: 1,
+// 				Rate:          10,
+// 			},
+// 		}},
+// 	}, {
+// 		// When there is one stream, and two instances each owning separate
+// 		// partitions, all instances should be queried. However, only the
+// 		// instance owning the partition for the stream hash should be queried
+// 		// for the requested stream hashes.
+// 		name: "one stream two instances",
+// 		getStreamUsageRequest: GetStreamUsageRequest{
+// 			Tenant:       "test",
+// 			StreamHashes: []uint64{0x1}, // Hash 1 maps to partition 1.
+// 		},
+// 		instances: []ring.InstanceDesc{{
+// 			Addr: "instance-0",
+// 		}, {
+// 			Addr: "instance-1",
+// 		}},
+// 		numPartitions:                     2,
+// 		expectedAssignedPartitionsRequest: []*logproto.GetAssignedPartitionsRequest{{}, {}},
+// 		getAssignedPartitionsResponses: []*logproto.GetAssignedPartitionsResponse{{
+// 			AssignedPartitions: map[int32]int64{
+// 				0: time.Now().UnixNano(),
+// 			},
+// 		}, {
+// 			AssignedPartitions: map[int32]int64{
+// 				1: time.Now().UnixNano(),
+// 			},
+// 		}},
+// 		expectedStreamUsageRequests: []*logproto.GetStreamUsageRequest{{
+// 			Tenant: "test",
+// 		}, {
+// 			Tenant:       "test",
+// 			StreamHashes: []uint64{0x1},
+// 		}},
+// 		getStreamUsageResponses: []*logproto.GetStreamUsageResponse{{
+// 			Tenant:        "test",
+// 			ActiveStreams: 1,
+// 			Rate:          10,
+// 		}, {
+// 			Tenant:        "test",
+// 			ActiveStreams: 1,
+// 			Rate:          10,
+// 		}},
+// 		expectedResponses: []GetStreamUsageResponse{{
+// 			Addr: "instance-0",
+// 			Response: &logproto.GetStreamUsageResponse{
+// 				Tenant:        "test",
+// 				ActiveStreams: 1,
+// 				Rate:          10,
+// 			},
+// 		}, {
+// 			Addr: "instance-1",
+// 			Response: &logproto.GetStreamUsageResponse{
+// 				Tenant:        "test",
+// 				ActiveStreams: 1,
+// 				Rate:          10,
+// 			},
+// 		}},
+// 	}, {
+// 		// When there is one stream, and two instances owning overlapping
+// 		// partitions, only the instance with the latest timestamp for the relevant
+// 		// partition should be queried with the requested stream hash.
+// 		name: "one stream two instances, overlapping partition ownership",
+// 		getStreamUsageRequest: GetStreamUsageRequest{
+// 			Tenant:       "test",
+// 			StreamHashes: []uint64{0x1}, // Hash 0x1 maps to partition 1.
+// 		},
+// 		instances: []ring.InstanceDesc{{
+// 			Addr: "instance-0",
+// 		}, {
+// 			Addr: "instance-1",
+// 		}},
+// 		numPartitions:                     2,
+// 		expectedAssignedPartitionsRequest: []*logproto.GetAssignedPartitionsRequest{{}, {}},
+// 		getAssignedPartitionsResponses: []*logproto.GetAssignedPartitionsResponse{{
+// 			AssignedPartitions: map[int32]int64{
+// 				1: time.Now().Add(-time.Second).UnixNano(),
+// 			},
+// 		}, {
+// 			AssignedPartitions: map[int32]int64{
+// 				1: time.Now().UnixNano(),
+// 			},
+// 		}},
+// 		expectedStreamUsageRequests: []*logproto.GetStreamUsageRequest{{
+// 			Tenant: "test",
+// 		}, {
+// 			Tenant:       "test",
+// 			StreamHashes: []uint64{0x1},
+// 		}},
+// 		getStreamUsageResponses: []*logproto.GetStreamUsageResponse{{
+// 			Tenant:        "test",
+// 			ActiveStreams: 1,
+// 			Rate:          10,
+// 		}, {
+// 			Tenant:        "test",
+// 			ActiveStreams: 1,
+// 			Rate:          10,
+// 		}},
+// 		expectedResponses: []GetStreamUsageResponse{{
+// 			Addr: "instance-0",
+// 			Response: &logproto.GetStreamUsageResponse{
+// 				Tenant:        "test",
+// 				ActiveStreams: 1,
+// 				Rate:          10,
+// 			},
+// 		}, {
+// 			Addr: "instance-1",
+// 			Response: &logproto.GetStreamUsageResponse{
+// 				Tenant:        "test",
+// 				ActiveStreams: 1,
+// 				Rate:          10,
+// 			},
+// 		}},
+// 	}}
 
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			// Set up the mock clients, one for each set of mock RPC responses.
-			mockClients := make([]*mockIngestLimitsClient, len(test.instances))
-			for i := 0; i < len(test.instances); i++ {
-				// These test cases assume one request/response per instance.
-				expectedNumAssignedPartitionsRequests := 0
-				if test.expectedAssignedPartitionsRequest[i] != nil {
-					expectedNumAssignedPartitionsRequests = 1
-				}
-				expectedNumStreamUsageRequests := 0
-				if test.expectedStreamUsageRequests[i] != nil {
-					expectedNumStreamUsageRequests = 1
-				}
-				mockClients[i] = &mockIngestLimitsClient{
-					t:                                     t,
-					expectedAssignedPartitionsRequest:     test.expectedAssignedPartitionsRequest[i],
-					getAssignedPartitionsResponse:         test.getAssignedPartitionsResponses[i],
-					expectedStreamUsageRequest:            test.expectedStreamUsageRequests[i],
-					getStreamUsageResponse:                test.getStreamUsageResponses[i],
-					expectedNumAssignedPartitionsRequests: expectedNumAssignedPartitionsRequests,
-					expectedNumStreamUsageRequests:        expectedNumStreamUsageRequests,
-				}
-				t.Cleanup(mockClients[i].AssertExpectedNumRequests)
-			}
-			readRing, clientPool := newMockRingWithClientPool(t, "test", mockClients, test.instances)
-			cache := NewNopCache[string, *logproto.GetAssignedPartitionsResponse]()
-			g := NewRingStreamUsageGatherer(readRing, clientPool, test.numPartitions, cache, log.NewNopLogger())
+// 	for _, test := range tests {
+// 		t.Run(test.name, func(t *testing.T) {
+// 			// Set up the mock clients, one for each set of mock RPC responses.
+// 			mockClients := make([]*mockIngestLimitsClient, len(test.instances))
+// 			for i := 0; i < len(test.instances); i++ {
+// 				// These test cases assume one request/response per instance.
+// 				expectedNumAssignedPartitionsRequests := 0
+// 				if test.expectedAssignedPartitionsRequest[i] != nil {
+// 					expectedNumAssignedPartitionsRequests = 1
+// 				}
+// 				expectedNumStreamUsageRequests := 0
+// 				if test.expectedStreamUsageRequests[i] != nil {
+// 					expectedNumStreamUsageRequests = 1
+// 				}
+// 				mockClients[i] = &mockIngestLimitsClient{
+// 					t:                                     t,
+// 					expectedAssignedPartitionsRequest:     test.expectedAssignedPartitionsRequest[i],
+// 					getAssignedPartitionsResponse:         test.getAssignedPartitionsResponses[i],
+// 					expectedStreamUsageRequest:            test.expectedStreamUsageRequests[i],
+// 					getStreamUsageResponse:                test.getStreamUsageResponses[i],
+// 					expectedNumAssignedPartitionsRequests: expectedNumAssignedPartitionsRequests,
+// 					expectedNumStreamUsageRequests:        expectedNumStreamUsageRequests,
+// 				}
+// 				t.Cleanup(mockClients[i].AssertExpectedNumRequests)
+// 			}
+// 			readRing, clientPool := newMockRingWithClientPool(t, "test", mockClients, test.instances)
+// 			cache := NewNopCache[string, *logproto.GetAssignedPartitionsResponse]()
+// 			g := NewRingStreamUsageGatherer(readRing, clientPool, test.numPartitions, cache, log.NewNopLogger())
 
-			// Set a maximum upper bound on the test execution time.
-			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-			defer cancel()
+// 			// Set a maximum upper bound on the test execution time.
+// 			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+// 			defer cancel()
 
-			resps, err := g.GetStreamUsage(ctx, test.getStreamUsageRequest)
-			require.NoError(t, err)
-			require.Equal(t, test.expectedResponses, resps)
-		})
-	}
-}
+// 			resps, err := g.GetStreamUsage(ctx, test.getStreamUsageRequest)
+// 			require.NoError(t, err)
+// 			require.Equal(t, test.expectedResponses, resps)
+// 		})
+// 	}
+// }
 
 func TestRingStreamUsageGatherer_GetZoneAwarePartitionConsumers(t *testing.T) {
 	tests := []struct {
@@ -393,7 +393,7 @@ func TestRingStreamUsageGatherer_GetZoneAwarePartitionConsumers(t *testing.T) {
 			// Set up the mocked ring and client pool for the tests.
 			readRing, clientPool := newMockRingWithClientPool(t, "test", clients, test.instances)
 			cache := NewNopCache[string, *logproto.GetAssignedPartitionsResponse]()
-			g := NewRingStreamUsageGatherer(readRing, clientPool, 2, cache, log.NewNopLogger())
+			g := NewRingGatherer(readRing, clientPool, 2, cache, log.NewNopLogger())
 
 			// Set a maximum upper bound on the test execution time.
 			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
@@ -542,7 +542,7 @@ func TestRingStreamUsageGatherer_GetPartitionConsumers(t *testing.T) {
 			// Set up the mocked ring and client pool for the tests.
 			readRing, clientPool := newMockRingWithClientPool(t, "test", mockClients, test.instances)
 			cache := NewNopCache[string, *logproto.GetAssignedPartitionsResponse]()
-			g := NewRingStreamUsageGatherer(readRing, clientPool, 1, cache, log.NewNopLogger())
+			g := NewRingGatherer(readRing, clientPool, 1, cache, log.NewNopLogger())
 
 			// Set a maximum upper bound on the test execution time.
 			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
@@ -586,7 +586,7 @@ func TestRingStreamUsageGatherer_GetPartitionConsumers_IsCached(t *testing.T) {
 	// Set the cache TTL large enough that entries cannot expire (flake)
 	// during slow test runs.
 	cache := NewTTLCache[string, *logproto.GetAssignedPartitionsResponse](time.Minute)
-	g := NewRingStreamUsageGatherer(readRing, clientPool, 2, cache, log.NewNopLogger())
+	g := NewRingGatherer(readRing, clientPool, 2, cache, log.NewNopLogger())
 
 	// Set a maximum upper bound on the test execution time.
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -505,7 +505,6 @@ func (t *Loki) initIngestLimitsFrontend() (services.Service, error) {
 		t.Cfg.IngestLimitsFrontend,
 		limits.RingName,
 		t.ingestLimitsRing,
-		t.Overrides,
 		logger,
 		prometheus.DefaultRegisterer,
 	)


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request makes the limits-frontend no-op while we implement https://github.com/grafana/loki-private/issues/1632.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
