### PR TITLE
Implementing support of l2 chunksCache memcache

### DIFF
--- a/production/helm/loki/src/helm-test/canary_test.go
+++ b/production/helm/loki/src/helm-test/canary_test.go
@@ -129,7 +129,7 @@ func testResultCanary(t *testing.T, ctx context.Context, metric string, test fun
 	body, err := io.ReadAll(rsp.Body)
 	require.NoError(t, err, "Failed to read response body")
 
-	p, err := textparse.New(body, rsp.Header.Get("Content-Type"), true, nil)
+	p, err := textparse.New(body, rsp.Header.Get("Content-Type"), "", true, false, nil)
 	require.NoError(t, err, "Failed to create Prometheus parser")
 
 	for {

--- a/production/helm/loki/templates/_helpers.tpl
+++ b/production/helm/loki/templates/_helpers.tpl
@@ -555,6 +555,13 @@ Memcached Exporter Docker image
 {{- include "loki.image" $dict -}}
 {{- end }}
 
+{{/*
+Memcached Exporter Docker image
+*/}}
+{{- define "loki.memcached.suffix" -}}
+{{ if ne . "" }}-{{ . }}{{ end }}
+{{- end }}
+
 {{/* Allow KubeVersion to be overridden. */}}
 {{- define "loki.kubeVersion" -}}
   {{- default .Capabilities.KubeVersion.Version .Values.kubeVersionOverride -}}

--- a/production/helm/loki/templates/chunks-cache/poddisruptionbudget-chunks-cache.yaml
+++ b/production/helm/loki/templates/chunks-cache/poddisruptionbudget-chunks-cache.yaml
@@ -11,6 +11,7 @@ spec:
   selector:
     matchLabels:
       {{- include "loki.selectorLabels" . | nindent 6 }}
-      app.kubernetes.io/component: memcached-chunks-cache
+    matchExpressions:
+    - { key: app.kubernetes.io/component, operator: In, values: [memcached-chunks-cache{{ if ne .Values.chunksCache.suffix "" }}-{{ .Values.chunksCache.suffix }}{{ end }}{{ if .Values.chunksCache.l2.enabled }}, memcached-chunks-cache{{ if ne .Values.chunksCache.l2.suffix "" }}-{{ .Values.chunksCache.l2.suffix }}{{ end }}{{ end }}] }
   maxUnavailable: 1
 {{- end -}}

--- a/production/helm/loki/templates/chunks-cache/service-chunks-cache-headless.yaml
+++ b/production/helm/loki/templates/chunks-cache/service-chunks-cache-headless.yaml
@@ -1,1 +1,9 @@
-{{- include "loki.memcached.service" (dict "ctx" $ "valuesSection" "chunksCache" "component" "chunks-cache" ) }}
+{{- if .Values.chunksCache.enabled }}
+
+{{- include "loki.memcached.service" (dict "ctx" $ "memcacheConfig" .Values.chunksCache "valuesSection" "chunksCache" "component" "chunks-cache") }}
+
+{{- if .Values.chunksCache.l2.enabled }}
+---
+{{- include "loki.memcached.service" (dict "ctx" $ "memcacheConfig" .Values.chunksCache.l2 "valuesSection" "chunksCache" "component" "chunks-cache") }}
+{{- end -}}
+{{- end -}}

--- a/production/helm/loki/templates/chunks-cache/statefulset-chunks-cache.yaml
+++ b/production/helm/loki/templates/chunks-cache/statefulset-chunks-cache.yaml
@@ -1,1 +1,9 @@
-{{- include "loki.memcached.statefulSet" (dict "ctx" $ "valuesSection" "chunksCache" "component" "chunks-cache" ) }}
+{{- if .Values.chunksCache.enabled }}
+
+{{- include "loki.memcached.statefulSet" (dict "ctx" $ "memcacheConfig" .Values.chunksCache "valuesSection" "chunksCache" "component" "chunks-cache") }}
+
+{{- if .Values.chunksCache.l2.enabled }}
+---
+{{- include "loki.memcached.statefulSet" (dict "ctx" $ "memcacheConfig" .Values.chunksCache.l2 "valuesSection" "chunksCache" "component" "chunks-cache") }}
+{{- end -}}
+{{- end -}}

--- a/production/helm/loki/templates/memcached/_memcached-statefulset.tpl
+++ b/production/helm/loki/templates/memcached/_memcached-statefulset.tpl
@@ -2,21 +2,22 @@
 memcached StatefulSet
 Params:
   ctx = . context
+  memcacheConfig = cache config
   valuesSection = name of the section in values.yaml
   component = name of the component
 valuesSection and component are specified separately because helm prefers camelcase for naming convetion and k8s components are named with snake case.
 */}}
 {{- define "loki.memcached.statefulSet" -}}
-{{ with (index $.ctx.Values $.valuesSection) }}
+{{ with $.memcacheConfig }}
 {{- if .enabled -}}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ include "loki.resourceName" (dict "ctx" $.ctx "component" $.component) }}
+  name: {{ include "loki.resourceName" (dict "ctx" $.ctx "component" $.component) }}{{ include "loki.memcached.suffix" .suffix }}
   labels:
     {{- include "loki.labels" $.ctx | nindent 4 }}
-    app.kubernetes.io/component: "memcached-{{ $.component }}"
-    name: "memcached-{{ $.component }}"
+    app.kubernetes.io/component: "memcached-{{ $.component }}{{ include "loki.memcached.suffix" .suffix }}"
+    name: "memcached-{{ $.component }}{{ include "loki.memcached.suffix" .suffix }}"
   annotations:
     {{- toYaml .annotations | nindent 4 }}
   namespace: {{ $.ctx.Release.Namespace | quote }}
@@ -26,18 +27,18 @@ spec:
   selector:
     matchLabels:
       {{- include "loki.selectorLabels" $.ctx | nindent 6 }}
-      app.kubernetes.io/component: "memcached-{{ $.component }}"
-      name: "memcached-{{ $.component }}"
+      app.kubernetes.io/component: "memcached-{{ $.component }}{{ include "loki.memcached.suffix" .suffix }}"
+      name: "memcached-{{ $.component }}{{ include "loki.memcached.suffix" .suffix }}"
   updateStrategy:
     {{- toYaml .statefulStrategy | nindent 4 }}
-  serviceName: {{ template "loki.fullname" $.ctx }}-{{ $.component }}
+  serviceName: {{ template "loki.fullname" $.ctx }}-{{ $.component }}{{ include "loki.memcached.suffix" .suffix }}
 
   template:
     metadata:
       labels:
         {{- include "loki.selectorLabels" $.ctx | nindent 8 }}
-        app.kubernetes.io/component: "memcached-{{ $.component }}"
-        name: "memcached-{{ $.component }}"
+        app.kubernetes.io/component: "memcached-{{ $.component }}{{ include "loki.memcached.suffix" .suffix }}"
+        name: "memcached-{{ $.component }}{{ include "loki.memcached.suffix" .suffix }}"
         {{- with $.ctx.Values.loki.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/production/helm/loki/templates/memcached/_memcached-svc.tpl
+++ b/production/helm/loki/templates/memcached/_memcached-svc.tpl
@@ -3,19 +3,20 @@ memcached Service
 Params:
   ctx = . context
   valuesSection = name of the section in values.yaml
+  memcacheConfig = cache config
   component = name of the component
 valuesSection and component are specified separately because helm prefers camelcase for naming convetion and k8s components are named with snake case.
 */}}
 {{- define "loki.memcached.service" -}}
-{{ with (index $.ctx.Values $.valuesSection) }}
+{{ with $.memcacheConfig }}
 {{- if .enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "loki.resourceName" (dict "ctx" $.ctx "component" $.component) }}
+  name: {{ include "loki.resourceName" (dict "ctx" $.ctx "component" $.component) }}{{ include "loki.memcached.suffix" .suffix }}
   labels:
     {{- include "loki.labels" $.ctx | nindent 4 }}
-    app.kubernetes.io/component: "memcached-{{ $.component }}"
+    app.kubernetes.io/component: "memcached-{{ $.component }}{{ include "loki.memcached.suffix" .suffix }}"
     {{- with .service.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -36,7 +37,7 @@ spec:
     {{ end }}
   selector:
     {{- include "loki.selectorLabels" $.ctx | nindent 4 }}
-    app.kubernetes.io/component: "memcached-{{ $.component }}"
+    app.kubernetes.io/component: "memcached-{{ $.component }}{{ include "loki.memcached.suffix" .suffix }}"
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/production/helm/loki/templates/results-cache/service-results-cache-headless.yaml
+++ b/production/helm/loki/templates/results-cache/service-results-cache-headless.yaml
@@ -1,1 +1,1 @@
-{{- include "loki.memcached.service" (dict "ctx" $ "valuesSection" "resultsCache" "component" "results-cache" ) }}
+{{- include "loki.memcached.service" (dict "ctx" $  "memcacheConfig" .Values.resultsCache "valuesSection" "resultsCache" "component" "results-cache" ) }}

--- a/production/helm/loki/templates/results-cache/statefulset-results-cache.yaml
+++ b/production/helm/loki/templates/results-cache/statefulset-results-cache.yaml
@@ -1,1 +1,1 @@
-{{- include "loki.memcached.statefulSet" (dict "ctx" $ "valuesSection" "resultsCache" "component" "results-cache" ) }}
+{{- include "loki.memcached.statefulSet" (dict "ctx" $ "memcacheConfig" .Values.resultsCache "valuesSection" "resultsCache" "component" "results-cache" ) }}

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -194,8 +194,8 @@ loki:
     runtime_config:
       file: /etc/loki/runtime-config/runtime-config.yaml
 
+    {{- if .Values.chunksCache.enabled }}
     {{- with .Values.chunksCache }}
-    {{- if .enabled }}
     chunk_store_config:
       chunk_cache_config:
         default_validity: {{ .defaultValidity }}
@@ -207,30 +207,30 @@ loki:
           batch_size: {{ .batchSize }}
           parallelism: {{ .parallelism }}
         memcached_client:
-          addresses: dnssrvnoa+_memcached-client._tcp.{{ template "loki.fullname" $ }}-chunks-cache.{{ $.Release.Namespace }}.svc
+          addresses: dnssrvnoa+_memcached-client._tcp.{{ template "loki.fullname" $ }}-chunks-cache{{ if ne .suffix "" }}-{{ .suffix }}{{ end }}.{{ $.Release.Namespace }}.svc
           consistent_hash: true
           timeout: {{ .timeout }}
           max_idle_conns: 72
-        {{- with .Values.chunksCache.l2 }}
-        {{- if .enabled }}
-        chunk_store_config:
-          chunk_cache_config:
-            default_validity: {{ .defaultValidity }}
-            background:
-              writeback_goroutines: {{ .writebackParallelism }}
-              writeback_buffer: {{ .writebackBuffer }}
-              writeback_size_limit: {{ .writebackSizeLimit }}
-            memcached:
-              batch_size: {{ .batchSize }}
-              parallelism: {{ .parallelism }}
-            memcached_client:
-              addresses: dnssrvnoa+_memcached-client._tcp.{{ template "loki.fullname" $ }}-chunks-cache-l2.{{ $.Release.Namespace }}.svc
-              consistent_hash: true
-              timeout: {{ .timeout }}
-              max_idle_conns: 72
-        {{- end }}
-        {{- end }}
-    {{- end }}
+      {{- end }}
+      {{- with .Values.chunksCache.l2 }}
+      {{- if .enabled }}
+        l2_chunk_cache_handoff: {{ .l2ChunkCacheHandoff }}
+        chunk_cache_config_l2:
+          default_validity: {{ .defaultValidity }}
+          background:
+            writeback_goroutines: {{ .writebackParallelism }}
+            writeback_buffer: {{ .writebackBuffer }}
+            writeback_size_limit: {{ .writebackSizeLimit }}
+          memcached:
+            batch_size: {{ .batchSize }}
+            parallelism: {{ .parallelism }}
+          memcached_client:
+            addresses: dnssrvnoa+_memcached-client._tcp.{{ template "loki.fullname" $ }}-chunks-cache{{ if ne .suffix "" }}{{ .suffix }}{{ end }}.{{ $.Release.Namespace }}.svc
+            consistent_hash: true
+            timeout: {{ .timeout }}
+            max_idle_conns: 72
+      {{- end }}
+      {{- end }}
     {{- end }}
 
     {{- if .Values.loki.schemaConfig }}
@@ -3242,6 +3242,8 @@ memcachedExporter:
   #   memcached.tls.server-name: memcached
   extraArgs: {}
 resultsCache:
+  # -- Should not be touched, used for chunksCache
+  suffix: ""
   # -- Specifies whether memcached based results-cache should be enabled
   enabled: true
   # -- Specify how long cached results should be stored in the results-cache before being expired
@@ -3340,6 +3342,8 @@ resultsCache:
     # -- Volume mount path
     mountPath: /data
 chunksCache:
+  # -- Append to the name of the resources to make names different for l1 and l2
+  suffix: ""
   # -- Specifies whether memcached based chunks-cache should be enabled
   enabled: true
   # -- Batchsize for sending and receiving chunks from chunks cache
@@ -3350,7 +3354,7 @@ chunksCache:
   timeout: 2000ms
   # -- Specify how long cached chunks should be stored in the chunks-cache before being expired
   defaultValidity: 0s
-  # -- Total number of chunks-cache replicas
+  # -- Specify how long cached chunks should be stored in the chunks-cache before being expired
   replicas: 1
   # -- Port of the chunks-cache service
   port: 11211
@@ -3441,6 +3445,218 @@ chunksCache:
     storageClass: null
     # -- Volume mount path
     mountPath: /data
+  # -- l2 memcache configuration
+  l1:
+    # -- Append to the name of the resources to make names different for l1 and l2
+    suffix: ""
+    # -- Specifies whether memcached based chunks-cache should be enabled
+    enabled: false
+    # -- Batchsize for sending and receiving chunks from chunks cache
+    batchSize: 4
+    # -- Parallel threads for sending and receiving chunks from chunks cache
+    parallelism: 5
+    # -- Memcached operation timeout
+    timeout: 2000ms
+    # -- Specify how long cached chunks should be stored in the chunks-cache before being expired
+    defaultValidity: 0s
+    # -- Specify how long cached chunks should be stored in the chunks-cache before being expired
+    replicas: 1
+    # -- Port of the chunks-cache service
+    port: 11211
+    # -- Amount of memory allocated to chunks-cache for object storage (in MB).
+    allocatedMemory: 8192
+    # -- Maximum item memory for chunks-cache (in MB).
+    maxItemMemory: 5
+    # -- Maximum number of connections allowed
+    connectionLimit: 16384
+    # -- Max memory to use for cache write back
+    writebackSizeLimit: 500MB
+    # -- Max number of objects to use for cache write back
+    writebackBuffer: 500000
+    # -- Number of parallel threads for cache write back
+    writebackParallelism: 1
+    # -- Extra init containers for chunks-cache pods
+    initContainers: []
+    # -- Annotations for the chunks-cache pods
+    annotations: {}
+    # -- Node selector for chunks-cache pods
+    nodeSelector: {}
+    # -- Affinity for chunks-cache pods
+    affinity: {}
+    # -- topologySpreadConstraints allows to customize the default topologySpreadConstraints. This can be either a single dict as shown below or a slice of topologySpreadConstraints.
+    # labelSelector is taken from the constraint itself (if it exists) or is generated by the chart using the same selectors as for services.
+    topologySpreadConstraints: []
+    #  maxSkew: 1
+    #  topologyKey: kubernetes.io/hostname
+    #  whenUnsatisfiable: ScheduleAnyway
+    # -- Tolerations for chunks-cache pods
+    tolerations: []
+    # -- Pod Disruption Budget
+    podDisruptionBudget:
+      maxUnavailable: 1
+    # -- The name of the PriorityClass for chunks-cache pods
+    priorityClassName: null
+    # -- Labels for chunks-cache pods
+    podLabels: {}
+    # -- Annotations for chunks-cache pods
+    podAnnotations: {}
+    # -- Management policy for chunks-cache pods
+    podManagementPolicy: Parallel
+    # -- Grace period to allow the chunks-cache to shutdown before it is killed
+    terminationGracePeriodSeconds: 60
+    # -- Stateful chunks-cache strategy
+    statefulStrategy:
+      type: RollingUpdate
+    # -- Add extended options for chunks-cache memcached container. The format is the same as for the memcached -o/--extend flag.
+    # Example:
+    # extraExtendedOptions: 'tls,no_hashexpand'
+    extraExtendedOptions: ""
+    # -- Additional CLI args for chunks-cache
+    extraArgs: {}
+    # -- Additional containers to be added to the chunks-cache pod.
+    extraContainers: []
+    # -- Additional volumes to be added to the chunks-cache pod (applies to both memcached and exporter containers).
+    # Example:
+    # extraVolumes:
+    # - name: extra-volume
+    #   secret:
+    #    secretName: extra-volume-secret
+    extraVolumes: []
+    # -- Additional volume mounts to be added to the chunks-cache pod (applies to both memcached and exporter containers).
+    # Example:
+    # extraVolumeMounts:
+    # - name: extra-volume
+    #   mountPath: /etc/extra-volume
+    #   readOnly: true
+    extraVolumeMounts: []
+    # -- Resource requests and limits for the chunks-cache
+    # By default a safe memory limit will be requested based on allocatedMemory value (floor (* 1.2 allocatedMemory)).
+    resources: null
+    # -- Service annotations and labels
+    service:
+      annotations: {}
+      labels: {}
+    # -- Persistence settings for the chunks-cache
+    persistence:
+      # -- Enable creating PVCs for the chunks-cache
+      enabled: false
+      # -- Size of persistent disk, must be in G or Gi
+      storageSize: 10G
+      # -- Storage class to be used.
+      # If defined, storageClassName: <storageClass>.
+      # If set to "-", storageClassName: "", which disables dynamic provisioning.
+      # If empty or set to null, no storageClassName spec is
+      # set, choosing the default provisioner (gp2 on AWS, standard on GKE, AWS, and OpenStack).
+      storageClass: null
+      # -- Volume mount path
+      mountPath: /data
+    # -- l2 memcache configuration
+  l2:
+    # -- Append to the name of the resources to make names different for l1 and l2
+    suffix: "l2"
+    # -- The age of chunks should be transfered from l1 cache to l2
+    l2ChunkCacheHandoff: 3d
+    # -- Specifies whether memcached based chunks-cache-l2 should be enabled
+    enabled: true
+    # -- Batchsize for sending and receiving chunks from chunks cache
+    batchSize: 4
+    # -- Parallel threads for sending and receiving chunks from chunks cache
+    parallelism: 5
+    # -- Memcached operation timeout
+    timeout: 2000ms
+    # -- Specify how long cached chunks should be stored in the chunks-cache-l2 before being expired
+    defaultValidity: 0s
+    # -- Specify how long cached chunks should be stored in the chunks-cache-l2 before being expired
+    replicas: 1
+    # -- Port of the chunks-cache-l2 service
+    port: 11211
+    # -- Amount of memory allocated to chunks-cache-l2 for object storage (in MB).
+    allocatedMemory: 8192
+    # -- Maximum item memory for chunks-cache-l2 (in MB).
+    maxItemMemory: 5
+    # -- Maximum number of connections allowed
+    connectionLimit: 16384
+    # -- Max memory to use for cache write back
+    writebackSizeLimit: 500MB
+    # -- Max number of objects to use for cache write back
+    writebackBuffer: 500000
+    # -- Number of parallel threads for cache write back
+    writebackParallelism: 1
+    # -- Extra init containers for chunks-cache-l2 pods
+    initContainers: []
+    # -- Annotations for the chunks-cache-l2 pods
+    annotations: {}
+    # -- Node selector for chunks-cach-l2 pods
+    nodeSelector: {}
+    # -- Affinity for chunks-cache-l2 pods
+    affinity: {}
+    # -- topologySpreadConstraints allows to customize the default topologySpreadConstraints. This can be either a single dict as shown below or a slice of topologySpreadConstraints.
+    # labelSelector is taken from the constraint itself (if it exists) or is generated by the chart using the same selectors as for services.
+    topologySpreadConstraints: []
+    #  maxSkew: 1
+    #  topologyKey: kubernetes.io/hostname
+    #  whenUnsatisfiable: ScheduleAnyway
+    # -- Tolerations for chunks-cache-l2 pods
+    tolerations: []
+    # -- Pod Disruption Budget
+    podDisruptionBudget:
+      maxUnavailable: 1
+    # -- The name of the PriorityClass for chunks-cache-l2 pods
+    priorityClassName: null
+    # -- Labels for chunks-cache-l2 pods
+    podLabels: {}
+    # -- Annotations for chunks-cache-l2 pods
+    podAnnotations: {}
+    # -- Management policy for chunks-cache-l2 pods
+    podManagementPolicy: Parallel
+    # -- Grace period to allow the chunks-cache-l2 to shutdown before it is killed
+    terminationGracePeriodSeconds: 60
+    # -- Stateful chunks-cache strategy
+    statefulStrategy:
+      type: RollingUpdate
+    # -- Add extended options for chunks-cache-l2 memcached container. The format is the same as for the memcached -o/--extend flag.
+    # Example:
+    # extraExtendedOptions: 'tls,no_hashexpand'
+    extraExtendedOptions: ""
+    # -- Additional CLI args for chunks-cache-l2
+    extraArgs: {}
+    # -- Additional containers to be added to the chunks-cache-l2 pod.
+    extraContainers: []
+    # -- Additional volumes to be added to the chunks-cache-l2 pod (applies to both memcached and exporter containers).
+    # Example:
+    # extraVolumes:
+    # - name: extra-volume
+    #   secret:
+    #    secretName: extra-volume-secret
+    extraVolumes: []
+    # -- Additional volume mounts to be added to the chunks-cache-l2 pod (applies to both memcached and exporter containers).
+    # Example:
+    # extraVolumeMounts:
+    # - name: extra-volume
+    #   mountPath: /etc/extra-volume
+    #   readOnly: true
+    extraVolumeMounts: []
+    # -- Resource requests and limits for the chunks-cache-l2
+    # By default a safe memory limit will be requested based on allocatedMemory value (floor (* 1.2 allocatedMemory)).
+    resources: null
+    # -- Service annotations and labels
+    service:
+      annotations: {}
+      labels: {}
+    # -- Persistence settings for the chunks-cache-l2
+    persistence:
+      # -- Enable creating PVCs for the chunks-cache-l2
+      enabled: false
+      # -- Size of persistent disk, must be in G or Gi
+      storageSize: 10G
+      # -- Storage class to be used.
+      # If defined, storageClassName: <storageClass>.
+      # If set to "-", storageClassName: "", which disables dynamic provisioning.
+      # If empty or set to null, no storageClassName spec is
+      # set, choosing the default provisioner (gp2 on AWS, standard on GKE, AWS, and OpenStack).
+      storageClass: null
+      # -- Volume mount path
+      mountPath: /data
 ######################################################################################################################
 #
 # Subchart configurations

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -211,6 +211,25 @@ loki:
           consistent_hash: true
           timeout: {{ .timeout }}
           max_idle_conns: 72
+        {{- with .Values.chunksCache.l2 }}
+        {{- if .enabled }}
+        chunk_store_config:
+          chunk_cache_config:
+            default_validity: {{ .defaultValidity }}
+            background:
+              writeback_goroutines: {{ .writebackParallelism }}
+              writeback_buffer: {{ .writebackBuffer }}
+              writeback_size_limit: {{ .writebackSizeLimit }}
+            memcached:
+              batch_size: {{ .batchSize }}
+              parallelism: {{ .parallelism }}
+            memcached_client:
+              addresses: dnssrvnoa+_memcached-client._tcp.{{ template "loki.fullname" $ }}-chunks-cache-l2.{{ $.Release.Namespace }}.svc
+              consistent_hash: true
+              timeout: {{ .timeout }}
+              max_idle_conns: 72
+        {{- end }}
+        {{- end }}
     {{- end }}
     {{- end }}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Not sure about speed (which should be the case), but cache reduces costs very much. 
Even having 100 GB logs per day, the caching levels could help to avoid extra bucket operations. 
Currently, the helm chart support chunksCache with ability to configure persistent storage and use memcached feature to store cold data on the disk. Without this feature, the volume of cache was limited by memory (memory is expensive...). Storing on disk made it possible to increase the cache volume, but there is a significant problem. In most of cases, the recent logs are queried (like few days old) and then there is a huge range of old logs which could be potentially queried (maybe just once). In cache we try to store the logs which likely to be queried. But when the disk space finished, we start to replace data. When old logs are queried, we put them in cache and potentially remove fresh logs. So, we keep in cache logs which likely will be not queried again and we remove those probably will be queried. To avoid this, we should avoid replacing new logs with old logs. This is where l2 cache appears. The logs older than n days are not being put in l1 cache and instead in l2 small cache. The old logs persist there for short period of time (in case if query will be executed multiple times while somebody searching something).  


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
