### PR TITLE
fix: enable ui in helm deployments

### DIFF
--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -13,6 +13,8 @@ Entries should include a reference to the pull request that introduced the chang
 
 [//]: # (<AUTOMATED_UPDATES_LOCATOR> : do not remove this line. This locator is used by the CI pipeline to automatically create a changelog entry for each new Loki release. Add other chart versions and respective changelog entries bellow this line.)
 
+- [BUGFIX] Ensure ui.enabled=true is set in loki ConfigMap when loki.ui.enabled=true is set in values.yaml to actually enable the UI
+
 - [FEATURE] Added support for the rules sidecar in the ruler pods in distributed mode
 - [BUGFIX] Ensure global.extraEnv and global.extraEnvFrom applied to all resources consistently ([#16828](https://github.com/grafana/loki/pull/16828))
 

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -284,6 +284,7 @@ loki:
 
     {{- if .Values.loki.ui.enabled }}
     ui:
+      enabled: {{ .Values.loki.ui.enabled }}
       discovery:
         join_peers:
           - '{{ include "loki.queryFrontendFullname" . }}.{{ $.Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}'


### PR DESCRIPTION
**What this PR does / why we need it**:
- Sets` ui.enabled` to `True` to Loki ConfigMap when `loki.ui.enabled` is set to `True` to enable UI on pods deployed by the chart.

**Which issue(s) this PR fixes**:
Fixes [#17561](https://github.com/grafana/loki/issues/17561)

**Special notes for your reviewer**:

**Checklist**
- [ ✅] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [✅ ] Documentation added
- [ ❌] Tests updated
- [ ✅] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ❌] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [❌ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
