### PR TITLE
feat: Re-implement ExceedsLimits in ingest-limits-frontend

### DIFF
--- a/pkg/limits/frontend/frontend.go
+++ b/pkg/limits/frontend/frontend.go
@@ -19,16 +19,6 @@ import (
 	"github.com/grafana/loki/v3/pkg/logproto"
 )
 
-const (
-	// ReasonExceedsMaxStreams is returned when a tenant exceeds the maximum
-	// number of active streams as per their per-tenant limit.
-	ReasonExceedsMaxStreams = "exceeds_max_streams"
-
-	// ReasonExceedsRateLimit is returned when a tenant exceeds their maximum
-	// rate limit as per their per-tenant limit.
-	ReasonExceedsRateLimit = "exceeds_rate_limit"
-)
-
 // Frontend is the limits-frontend service, and acts a service wrapper for
 // all components needed to run the limits-frontend.
 type Frontend struct {

--- a/pkg/limits/frontend/mock_test.go
+++ b/pkg/limits/frontend/mock_test.go
@@ -39,21 +39,21 @@ type mockIngestLimitsClient struct {
 
 	// The requests expected to be received.
 	expectedAssignedPartitionsRequest *logproto.GetAssignedPartitionsRequest
-	expectedStreamUsageRequest        *logproto.GetStreamUsageRequest
+	expectedExceedsLimitsRequest      *logproto.ExceedsLimitsRequest
 
 	// The mocked responses.
 	getAssignedPartitionsResponse    *logproto.GetAssignedPartitionsResponse
 	getAssignedPartitionsResponseErr error
-	getStreamUsageResponse           *logproto.GetStreamUsageResponse
-	getStreamUsageResponseErr        error
+	exceedsLimitsResponse            *logproto.ExceedsLimitsResponse
+	exceedsLimitsResponseErr         error
 
 	// The expected request counts.
 	expectedNumAssignedPartitionsRequests int
-	expectedNumStreamUsageRequests        int
+	expectedNumExceedsLimitsRequests      int
 
 	// The actual request counts.
 	numAssignedPartitionsRequests int
-	numStreamUsageRequests        int
+	numExceedsLimitsRequests      int
 }
 
 func (m *mockIngestLimitsClient) GetAssignedPartitions(_ context.Context, r *logproto.GetAssignedPartitionsRequest, _ ...grpc.CallOption) (*logproto.GetAssignedPartitionsResponse, error) {
@@ -67,20 +67,20 @@ func (m *mockIngestLimitsClient) GetAssignedPartitions(_ context.Context, r *log
 	return m.getAssignedPartitionsResponse, nil
 }
 
-func (m *mockIngestLimitsClient) GetStreamUsage(_ context.Context, r *logproto.GetStreamUsageRequest, _ ...grpc.CallOption) (*logproto.GetStreamUsageResponse, error) {
-	if expected := m.expectedStreamUsageRequest; expected != nil {
+func (m *mockIngestLimitsClient) ExceedsLimits(_ context.Context, r *logproto.ExceedsLimitsRequest, _ ...grpc.CallOption) (*logproto.ExceedsLimitsResponse, error) {
+	if expected := m.expectedExceedsLimitsRequest; expected != nil {
 		require.Equal(m.t, expected, r)
 	}
-	m.numStreamUsageRequests++
-	if err := m.getStreamUsageResponseErr; err != nil {
+	m.numExceedsLimitsRequests++
+	if err := m.exceedsLimitsResponseErr; err != nil {
 		return nil, err
 	}
-	return m.getStreamUsageResponse, nil
+	return m.exceedsLimitsResponse, nil
 }
 
 func (m *mockIngestLimitsClient) AssertExpectedNumRequests() {
 	require.Equal(m.t, m.expectedNumAssignedPartitionsRequests, m.numAssignedPartitionsRequests)
-	require.Equal(m.t, m.expectedNumStreamUsageRequests, m.numStreamUsageRequests)
+	require.Equal(m.t, m.expectedNumExceedsLimitsRequests, m.numExceedsLimitsRequests)
 }
 
 func (m *mockIngestLimitsClient) Close() error {

--- a/pkg/limits/frontend/ring_test.go
+++ b/pkg/limits/frontend/ring_test.go
@@ -10,227 +10,368 @@ import (
 	"github.com/grafana/dskit/ring"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/loki/v3/pkg/limits"
 	"github.com/grafana/loki/v3/pkg/logproto"
 )
 
-// func TestRingStreamUsageGatherer_GetStreamUsage(t *testing.T) {
-// 	tests := []struct {
-// 		name                  string
-// 		getStreamUsageRequest GetStreamUsageRequest
-// 		// Instances contains the complete set of instances that should be mocked.
-// 		// For example, if a test case is expected to make RPC calls to one instance,
-// 		// then just one InstanceDesc is required.
-// 		instances     []ring.InstanceDesc
-// 		numPartitions int
-// 		// The size of the following slices must match len(instances), where each
-// 		// value contains the expected request/response for the instance at the
-// 		// same index in the instances slice. If a request/response is not expected,
-// 		// the value can be set to nil.
-// 		expectedAssignedPartitionsRequest []*logproto.GetAssignedPartitionsRequest
-// 		getAssignedPartitionsResponses    []*logproto.GetAssignedPartitionsResponse
-// 		expectedStreamUsageRequests       []*logproto.GetStreamUsageRequest
-// 		getStreamUsageResponses           []*logproto.GetStreamUsageResponse
-// 		expectedResponses                 []GetStreamUsageResponse
-// 	}{{
-// 		// When there are no streams, no RPCs should be sent.
-// 		name: "no streams",
-// 		getStreamUsageRequest: GetStreamUsageRequest{
-// 			Tenant:       "test",
-// 			StreamHashes: []uint64{},
-// 		},
-// 		instances:                         []ring.InstanceDesc{{Addr: "instance-0"}},
-// 		numPartitions:                     1,
-// 		expectedAssignedPartitionsRequest: []*logproto.GetAssignedPartitionsRequest{nil},
-// 		getAssignedPartitionsResponses:    []*logproto.GetAssignedPartitionsResponse{nil},
-// 		expectedStreamUsageRequests:       []*logproto.GetStreamUsageRequest{nil},
-// 		getStreamUsageResponses:           []*logproto.GetStreamUsageResponse{nil},
-// 	}, {
-// 		// When there is one stream, and one instance, the stream usage for that
-// 		// stream should be queried from that instance.
-// 		name: "one stream",
-// 		getStreamUsageRequest: GetStreamUsageRequest{
-// 			Tenant:       "test",
-// 			StreamHashes: []uint64{0x1}, // Hash 0x1 maps to partition 0.
-// 		},
-// 		instances: []ring.InstanceDesc{{
-// 			Addr: "instance-0",
-// 		}},
-// 		numPartitions:                     1,
-// 		expectedAssignedPartitionsRequest: []*logproto.GetAssignedPartitionsRequest{{}},
-// 		getAssignedPartitionsResponses: []*logproto.GetAssignedPartitionsResponse{{
-// 			AssignedPartitions: map[int32]int64{
-// 				0: time.Now().UnixNano(),
-// 			},
-// 		}},
-// 		expectedStreamUsageRequests: []*logproto.GetStreamUsageRequest{{
-// 			Tenant:       "test",
-// 			StreamHashes: []uint64{0x1},
-// 		}},
-// 		getStreamUsageResponses: []*logproto.GetStreamUsageResponse{{
-// 			Tenant:        "test",
-// 			ActiveStreams: 1,
-// 			Rate:          10,
-// 		}},
-// 		expectedResponses: []GetStreamUsageResponse{{
-// 			Addr: "instance-0",
-// 			Response: &logproto.GetStreamUsageResponse{
-// 				Tenant:        "test",
-// 				ActiveStreams: 1,
-// 				Rate:          10,
-// 			},
-// 		}},
-// 	}, {
-// 		// When there is one stream, and two instances each owning separate
-// 		// partitions, all instances should be queried. However, only the
-// 		// instance owning the partition for the stream hash should be queried
-// 		// for the requested stream hashes.
-// 		name: "one stream two instances",
-// 		getStreamUsageRequest: GetStreamUsageRequest{
-// 			Tenant:       "test",
-// 			StreamHashes: []uint64{0x1}, // Hash 1 maps to partition 1.
-// 		},
-// 		instances: []ring.InstanceDesc{{
-// 			Addr: "instance-0",
-// 		}, {
-// 			Addr: "instance-1",
-// 		}},
-// 		numPartitions:                     2,
-// 		expectedAssignedPartitionsRequest: []*logproto.GetAssignedPartitionsRequest{{}, {}},
-// 		getAssignedPartitionsResponses: []*logproto.GetAssignedPartitionsResponse{{
-// 			AssignedPartitions: map[int32]int64{
-// 				0: time.Now().UnixNano(),
-// 			},
-// 		}, {
-// 			AssignedPartitions: map[int32]int64{
-// 				1: time.Now().UnixNano(),
-// 			},
-// 		}},
-// 		expectedStreamUsageRequests: []*logproto.GetStreamUsageRequest{{
-// 			Tenant: "test",
-// 		}, {
-// 			Tenant:       "test",
-// 			StreamHashes: []uint64{0x1},
-// 		}},
-// 		getStreamUsageResponses: []*logproto.GetStreamUsageResponse{{
-// 			Tenant:        "test",
-// 			ActiveStreams: 1,
-// 			Rate:          10,
-// 		}, {
-// 			Tenant:        "test",
-// 			ActiveStreams: 1,
-// 			Rate:          10,
-// 		}},
-// 		expectedResponses: []GetStreamUsageResponse{{
-// 			Addr: "instance-0",
-// 			Response: &logproto.GetStreamUsageResponse{
-// 				Tenant:        "test",
-// 				ActiveStreams: 1,
-// 				Rate:          10,
-// 			},
-// 		}, {
-// 			Addr: "instance-1",
-// 			Response: &logproto.GetStreamUsageResponse{
-// 				Tenant:        "test",
-// 				ActiveStreams: 1,
-// 				Rate:          10,
-// 			},
-// 		}},
-// 	}, {
-// 		// When there is one stream, and two instances owning overlapping
-// 		// partitions, only the instance with the latest timestamp for the relevant
-// 		// partition should be queried with the requested stream hash.
-// 		name: "one stream two instances, overlapping partition ownership",
-// 		getStreamUsageRequest: GetStreamUsageRequest{
-// 			Tenant:       "test",
-// 			StreamHashes: []uint64{0x1}, // Hash 0x1 maps to partition 1.
-// 		},
-// 		instances: []ring.InstanceDesc{{
-// 			Addr: "instance-0",
-// 		}, {
-// 			Addr: "instance-1",
-// 		}},
-// 		numPartitions:                     2,
-// 		expectedAssignedPartitionsRequest: []*logproto.GetAssignedPartitionsRequest{{}, {}},
-// 		getAssignedPartitionsResponses: []*logproto.GetAssignedPartitionsResponse{{
-// 			AssignedPartitions: map[int32]int64{
-// 				1: time.Now().Add(-time.Second).UnixNano(),
-// 			},
-// 		}, {
-// 			AssignedPartitions: map[int32]int64{
-// 				1: time.Now().UnixNano(),
-// 			},
-// 		}},
-// 		expectedStreamUsageRequests: []*logproto.GetStreamUsageRequest{{
-// 			Tenant: "test",
-// 		}, {
-// 			Tenant:       "test",
-// 			StreamHashes: []uint64{0x1},
-// 		}},
-// 		getStreamUsageResponses: []*logproto.GetStreamUsageResponse{{
-// 			Tenant:        "test",
-// 			ActiveStreams: 1,
-// 			Rate:          10,
-// 		}, {
-// 			Tenant:        "test",
-// 			ActiveStreams: 1,
-// 			Rate:          10,
-// 		}},
-// 		expectedResponses: []GetStreamUsageResponse{{
-// 			Addr: "instance-0",
-// 			Response: &logproto.GetStreamUsageResponse{
-// 				Tenant:        "test",
-// 				ActiveStreams: 1,
-// 				Rate:          10,
-// 			},
-// 		}, {
-// 			Addr: "instance-1",
-// 			Response: &logproto.GetStreamUsageResponse{
-// 				Tenant:        "test",
-// 				ActiveStreams: 1,
-// 				Rate:          10,
-// 			},
-// 		}},
-// 	}}
+func TestRingGatherer_ExceedsLimits(t *testing.T) {
+	tests := []struct {
+		name    string
+		request *logproto.ExceedsLimitsRequest
+		// Instances contains the complete set of instances that should be mocked.
+		// For example, if a test case is expected to make RPC calls to one instance,
+		// then just one InstanceDesc is required.
+		instances     []ring.InstanceDesc
+		numPartitions int
+		// The size of the following slices must match len(instances), where each
+		// value contains the expected request/response for the instance at the
+		// same index in the instances slice. If a request/response is not expected,
+		// the value can be set to nil.
+		expectedAssignedPartitionsRequest []*logproto.GetAssignedPartitionsRequest
+		getAssignedPartitionsResponses    []*logproto.GetAssignedPartitionsResponse
+		expectedExceedsLimitsRequests     []*logproto.ExceedsLimitsRequest
+		exceedsLimitsResponses            []*logproto.ExceedsLimitsResponse
+		exceedsLimitsResponseErrs         []error
+		expected                          []*logproto.ExceedsLimitsResponse
+		expectedErr                       string
+	}{{
+		// When there are no streams, no RPCs should be sent.
+		name: "no streams",
+		request: &logproto.ExceedsLimitsRequest{
+			Tenant:  "test",
+			Streams: nil,
+		},
+		instances:                         []ring.InstanceDesc{{Addr: "instance-0"}},
+		numPartitions:                     1,
+		expectedAssignedPartitionsRequest: []*logproto.GetAssignedPartitionsRequest{nil},
+		getAssignedPartitionsResponses:    []*logproto.GetAssignedPartitionsResponse{nil},
+		expectedExceedsLimitsRequests:     []*logproto.ExceedsLimitsRequest{nil},
+		exceedsLimitsResponses:            []*logproto.ExceedsLimitsResponse{nil},
+		exceedsLimitsResponseErrs:         []error{nil},
+	}, {
+		// When there is one instance owning all partitions, that instance is
+		// responsible for enforcing limits of all streams.
+		name: "one stream one instance",
+		request: &logproto.ExceedsLimitsRequest{
+			Tenant: "test",
+			Streams: []*logproto.StreamMetadata{{
+				StreamHash:             0x1, // 0x1 is assigned to partition 0.
+				EntriesSize:            0x2,
+				StructuredMetadataSize: 0x3,
+			}},
+		},
+		instances: []ring.InstanceDesc{{
+			Addr: "instance-0",
+		}},
+		numPartitions:                     1,
+		expectedAssignedPartitionsRequest: []*logproto.GetAssignedPartitionsRequest{{}},
+		getAssignedPartitionsResponses: []*logproto.GetAssignedPartitionsResponse{{
+			AssignedPartitions: map[int32]int64{
+				0: time.Now().UnixNano(),
+			},
+		}},
+		expectedExceedsLimitsRequests: []*logproto.ExceedsLimitsRequest{{
+			Tenant: "test",
+			Streams: []*logproto.StreamMetadata{{
+				StreamHash:             0x1,
+				EntriesSize:            0x2,
+				StructuredMetadataSize: 0x3,
+			}},
+		}},
+		exceedsLimitsResponses: []*logproto.ExceedsLimitsResponse{{
+			Results: []*logproto.ExceedsLimitsResult{{
+				StreamHash: 0x1,
+				Reason:     uint32(limits.ReasonExceedsMaxStreams),
+			}},
+		}},
+		exceedsLimitsResponseErrs: []error{nil},
+		expected: []*logproto.ExceedsLimitsResponse{{
+			Results: []*logproto.ExceedsLimitsResult{{
+				StreamHash: 0x1,
+				Reason:     uint32(limits.ReasonExceedsMaxStreams),
+			}},
+		}},
+	}, {
+		// When there are two instances, each instance is responsible for
+		// enforcing limits on just the streams that shard to its consumed
+		// partitions. But when we have one stream, just one instance
+		// should be called to enforce limits.
+		name: "one stream two instances",
+		request: &logproto.ExceedsLimitsRequest{
+			Tenant: "test",
+			Streams: []*logproto.StreamMetadata{{
+				StreamHash:             0x1, // 0x1 is assigned to partition 1.
+				EntriesSize:            0x2,
+				StructuredMetadataSize: 0x3,
+			}},
+		},
+		instances: []ring.InstanceDesc{{
+			Addr: "instance-0",
+		}, {
+			Addr: "instance-1",
+		}},
+		numPartitions:                     2,
+		expectedAssignedPartitionsRequest: []*logproto.GetAssignedPartitionsRequest{{}, {}},
+		getAssignedPartitionsResponses: []*logproto.GetAssignedPartitionsResponse{{
+			AssignedPartitions: map[int32]int64{
+				0: time.Now().UnixNano(),
+			},
+		}, {
+			AssignedPartitions: map[int32]int64{
+				1: time.Now().UnixNano(),
+			},
+		}},
+		expectedExceedsLimitsRequests: []*logproto.ExceedsLimitsRequest{nil, {
+			Tenant: "test",
+			Streams: []*logproto.StreamMetadata{{
+				StreamHash:             0x1,
+				EntriesSize:            0x2,
+				StructuredMetadataSize: 0x3,
+			}},
+		}},
+		exceedsLimitsResponses: []*logproto.ExceedsLimitsResponse{nil, {
+			Results: []*logproto.ExceedsLimitsResult{{
+				StreamHash: 0x1,
+				Reason:     uint32(limits.ReasonExceedsMaxStreams),
+			}},
+		}},
+		exceedsLimitsResponseErrs: []error{nil, nil},
+		expected: []*logproto.ExceedsLimitsResponse{{
+			Results: []*logproto.ExceedsLimitsResult{{
+				StreamHash: 0x1,
+				Reason:     uint32(limits.ReasonExceedsMaxStreams),
+			}},
+		}},
+	}, {
+		// When there are two streams and two instances, but all streams
+		// shard to one partition, just the instance that consumes that
+		// partition should be called to enforce limits.
+		name: "two streams, two instances, all streams to one partition",
+		request: &logproto.ExceedsLimitsRequest{
+			Tenant: "test",
+			Streams: []*logproto.StreamMetadata{{
+				StreamHash:             0x1, // 0x1 is assigned to partition 1.
+				EntriesSize:            0x2,
+				StructuredMetadataSize: 0x3,
+			}, {
+				StreamHash:             0x3, // 0x3 is also assigned to partition 1.
+				EntriesSize:            0x4,
+				StructuredMetadataSize: 0x5,
+			}},
+		},
+		instances: []ring.InstanceDesc{{
+			Addr: "instance-0",
+		}, {
+			Addr: "instance-1",
+		}},
+		numPartitions:                     2,
+		expectedAssignedPartitionsRequest: []*logproto.GetAssignedPartitionsRequest{{}, {}},
+		getAssignedPartitionsResponses: []*logproto.GetAssignedPartitionsResponse{{
+			AssignedPartitions: map[int32]int64{
+				0: time.Now().UnixNano(),
+			},
+		}, {
+			AssignedPartitions: map[int32]int64{
+				1: time.Now().UnixNano(),
+			},
+		}},
+		expectedExceedsLimitsRequests: []*logproto.ExceedsLimitsRequest{nil, {
+			Tenant: "test",
+			Streams: []*logproto.StreamMetadata{{
+				StreamHash:             0x1,
+				EntriesSize:            0x2,
+				StructuredMetadataSize: 0x3,
+			}, {
+				StreamHash:             0x3,
+				EntriesSize:            0x4,
+				StructuredMetadataSize: 0x5,
+			}},
+		}},
+		exceedsLimitsResponses: []*logproto.ExceedsLimitsResponse{nil, {
+			Results: []*logproto.ExceedsLimitsResult{{
+				StreamHash: 0x1,
+				Reason:     uint32(limits.ReasonExceedsMaxStreams),
+			}},
+		}},
+		exceedsLimitsResponseErrs: []error{nil, nil},
+		expected: []*logproto.ExceedsLimitsResponse{{
+			Results: []*logproto.ExceedsLimitsResult{{
+				StreamHash: 0x1,
+				Reason:     uint32(limits.ReasonExceedsMaxStreams),
+			}},
+		}},
+	}, {
+		// When there are two streams and two instances, and each stream
+		// shards to different partitions, all instances should be called
+		// called to enforce limits.
+		name: "two streams, two instances, one stream each",
+		request: &logproto.ExceedsLimitsRequest{
+			Tenant: "test",
+			Streams: []*logproto.StreamMetadata{{
+				StreamHash:             0x1, // 0x1 is assigned to partition 1.
+				EntriesSize:            0x2,
+				StructuredMetadataSize: 0x3,
+			}, {
+				StreamHash:             0x2, // 0x2 is also assigned to partition 0.
+				EntriesSize:            0x4,
+				StructuredMetadataSize: 0x5,
+			}},
+		},
+		instances: []ring.InstanceDesc{{
+			Addr: "instance-0",
+		}, {
+			Addr: "instance-1",
+		}},
+		numPartitions:                     2,
+		expectedAssignedPartitionsRequest: []*logproto.GetAssignedPartitionsRequest{{}, {}},
+		getAssignedPartitionsResponses: []*logproto.GetAssignedPartitionsResponse{{
+			AssignedPartitions: map[int32]int64{
+				0: time.Now().UnixNano(),
+			},
+		}, {
+			AssignedPartitions: map[int32]int64{
+				1: time.Now().UnixNano(),
+			},
+		}},
+		expectedExceedsLimitsRequests: []*logproto.ExceedsLimitsRequest{{
+			Tenant: "test",
+			Streams: []*logproto.StreamMetadata{{
+				StreamHash:             0x2,
+				EntriesSize:            0x4,
+				StructuredMetadataSize: 0x5,
+			}},
+		}, {
+			Tenant: "test",
+			Streams: []*logproto.StreamMetadata{{
+				StreamHash:             0x1,
+				EntriesSize:            0x2,
+				StructuredMetadataSize: 0x3,
+			}},
+		}},
+		exceedsLimitsResponses: []*logproto.ExceedsLimitsResponse{{
+			Results: []*logproto.ExceedsLimitsResult{{
+				StreamHash: 0x2,
+				Reason:     uint32(limits.ReasonExceedsMaxStreams),
+			}},
+		}, {
+			Results: []*logproto.ExceedsLimitsResult{{
+				StreamHash: 0x1,
+				Reason:     uint32(limits.ReasonExceedsMaxStreams),
+			}},
+		}},
+		exceedsLimitsResponseErrs: []error{nil, nil},
+		expected: []*logproto.ExceedsLimitsResponse{{
+			Results: []*logproto.ExceedsLimitsResult{{
+				StreamHash: 0x1,
+				Reason:     uint32(limits.ReasonExceedsMaxStreams),
+			}},
+		}, {
+			Results: []*logproto.ExceedsLimitsResult{{
+				StreamHash: 0x2,
+				Reason:     uint32(limits.ReasonExceedsMaxStreams),
+			}},
+		}},
+	}, {
+		// When one instance returns an error, the entire request is failed.
+		name: "two streams, two instances, one instance returns error",
+		request: &logproto.ExceedsLimitsRequest{
+			Tenant: "test",
+			Streams: []*logproto.StreamMetadata{{
+				StreamHash:             0x1, // 0x1 is assigned to partition 1.
+				EntriesSize:            0x2,
+				StructuredMetadataSize: 0x3,
+			}, {
+				StreamHash:             0x2, // 0x2 is also assigned to partition 0.
+				EntriesSize:            0x4,
+				StructuredMetadataSize: 0x5,
+			}},
+		},
+		instances: []ring.InstanceDesc{{
+			Addr: "instance-0",
+		}, {
+			Addr: "instance-1",
+		}},
+		numPartitions:                     2,
+		expectedAssignedPartitionsRequest: []*logproto.GetAssignedPartitionsRequest{{}, {}},
+		getAssignedPartitionsResponses: []*logproto.GetAssignedPartitionsResponse{{
+			AssignedPartitions: map[int32]int64{
+				0: time.Now().UnixNano(),
+			},
+		}, {
+			AssignedPartitions: map[int32]int64{
+				1: time.Now().UnixNano(),
+			},
+		}},
+		expectedExceedsLimitsRequests: []*logproto.ExceedsLimitsRequest{{
+			Tenant: "test",
+			Streams: []*logproto.StreamMetadata{{
+				StreamHash:             0x2,
+				EntriesSize:            0x4,
+				StructuredMetadataSize: 0x5,
+			}},
+		}, {
+			Tenant: "test",
+			Streams: []*logproto.StreamMetadata{{
+				StreamHash:             0x1,
+				EntriesSize:            0x2,
+				StructuredMetadataSize: 0x3,
+			}},
+		}},
+		exceedsLimitsResponses: []*logproto.ExceedsLimitsResponse{{
+			Results: []*logproto.ExceedsLimitsResult{{
+				StreamHash: 0x2,
+				Reason:     uint32(limits.ReasonExceedsMaxStreams),
+			}},
+		}, nil},
+		exceedsLimitsResponseErrs: []error{nil, errors.New("an unexpected error occurred")},
+		expectedErr:               "an unexpected error occurred",
+	}}
 
-// 	for _, test := range tests {
-// 		t.Run(test.name, func(t *testing.T) {
-// 			// Set up the mock clients, one for each set of mock RPC responses.
-// 			mockClients := make([]*mockIngestLimitsClient, len(test.instances))
-// 			for i := 0; i < len(test.instances); i++ {
-// 				// These test cases assume one request/response per instance.
-// 				expectedNumAssignedPartitionsRequests := 0
-// 				if test.expectedAssignedPartitionsRequest[i] != nil {
-// 					expectedNumAssignedPartitionsRequests = 1
-// 				}
-// 				expectedNumStreamUsageRequests := 0
-// 				if test.expectedStreamUsageRequests[i] != nil {
-// 					expectedNumStreamUsageRequests = 1
-// 				}
-// 				mockClients[i] = &mockIngestLimitsClient{
-// 					t:                                     t,
-// 					expectedAssignedPartitionsRequest:     test.expectedAssignedPartitionsRequest[i],
-// 					getAssignedPartitionsResponse:         test.getAssignedPartitionsResponses[i],
-// 					expectedStreamUsageRequest:            test.expectedStreamUsageRequests[i],
-// 					getStreamUsageResponse:                test.getStreamUsageResponses[i],
-// 					expectedNumAssignedPartitionsRequests: expectedNumAssignedPartitionsRequests,
-// 					expectedNumStreamUsageRequests:        expectedNumStreamUsageRequests,
-// 				}
-// 				t.Cleanup(mockClients[i].AssertExpectedNumRequests)
-// 			}
-// 			readRing, clientPool := newMockRingWithClientPool(t, "test", mockClients, test.instances)
-// 			cache := NewNopCache[string, *logproto.GetAssignedPartitionsResponse]()
-// 			g := NewRingStreamUsageGatherer(readRing, clientPool, test.numPartitions, cache, log.NewNopLogger())
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Set up the mock clients, one for each set of mock RPC responses.
+			mockClients := make([]*mockIngestLimitsClient, len(test.instances))
+			for i := 0; i < len(test.instances); i++ {
+				// These test cases assume one request/response per instance.
+				expectedNumAssignedPartitionsRequests := 0
+				if test.expectedAssignedPartitionsRequest[i] != nil {
+					expectedNumAssignedPartitionsRequests = 1
+				}
+				expectedNumExceedsLimitsRequests := 0
+				if test.expectedExceedsLimitsRequests[i] != nil {
+					expectedNumExceedsLimitsRequests = 1
+				}
+				mockClients[i] = &mockIngestLimitsClient{
+					t:                                     t,
+					expectedAssignedPartitionsRequest:     test.expectedAssignedPartitionsRequest[i],
+					getAssignedPartitionsResponse:         test.getAssignedPartitionsResponses[i],
+					expectedExceedsLimitsRequest:          test.expectedExceedsLimitsRequests[i],
+					exceedsLimitsResponse:                 test.exceedsLimitsResponses[i],
+					exceedsLimitsResponseErr:              test.exceedsLimitsResponseErrs[i],
+					expectedNumAssignedPartitionsRequests: expectedNumAssignedPartitionsRequests,
+					expectedNumExceedsLimitsRequests:      expectedNumExceedsLimitsRequests,
+				}
+				t.Cleanup(mockClients[i].AssertExpectedNumRequests)
+			}
+			readRing, clientPool := newMockRingWithClientPool(t, "test", mockClients, test.instances)
+			cache := NewNopCache[string, *logproto.GetAssignedPartitionsResponse]()
+			g := NewRingGatherer(readRing, clientPool, test.numPartitions, cache, log.NewNopLogger())
 
-// 			// Set a maximum upper bound on the test execution time.
-// 			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-// 			defer cancel()
+			// Set a maximum upper bound on the test execution time.
+			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+			defer cancel()
 
-// 			resps, err := g.GetStreamUsage(ctx, test.getStreamUsageRequest)
-// 			require.NoError(t, err)
-// 			require.Equal(t, test.expectedResponses, resps)
-// 		})
-// 	}
-// }
+			actual, err := g.ExceedsLimits(ctx, test.request)
+			if test.expectedErr != "" {
+				require.EqualError(t, err, test.expectedErr)
+				require.Nil(t, actual)
+			} else {
+				require.NoError(t, err)
+				require.ElementsMatch(t, test.expected, actual)
+			}
+		})
+	}
+}
 
 func TestRingStreamUsageGatherer_GetZoneAwarePartitionConsumers(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request re-implements `ExceedsLimits` in the `ingest-limits-frontend` to use the new `ExceedsLimits` RPC call instead of `GetStreamUsage`.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
