### PR TITLE
chore(engine): Fix regression introduced with merging PR #17456

### DIFF
--- a/pkg/engine/executor/dataobjscan.go
+++ b/pkg/engine/executor/dataobjscan.go
@@ -388,7 +388,7 @@ func schemaFromColumns(columns []physical.ColumnExpression) (*arrow.Schema, erro
 		}
 
 		md := arrow.MetadataFrom(map[string]string{
-			types.ColumnTypeMetadataKey: columnExpr.Ref.Type.String(),
+			types.MetadataKeyColumnType: columnExpr.Ref.Type.String(),
 		})
 
 		switch columnExpr.Ref.Type {
@@ -452,13 +452,13 @@ func schemaFromColumns(columns []physical.ColumnExpression) (*arrow.Schema, erro
 				Name:     columnExpr.Ref.Column,
 				Type:     arrow.BinaryTypes.String,
 				Nullable: true,
-				Metadata: arrow.MetadataFrom(map[string]string{types.ColumnTypeMetadataKey: types.ColumnTypeLabel.String()}),
+				Metadata: arrow.MetadataFrom(map[string]string{types.MetadataKeyColumnType: types.ColumnTypeLabel.String()}),
 			})
 			addField(arrow.Field{
 				Name:     columnExpr.Ref.Column,
 				Type:     arrow.BinaryTypes.String,
 				Nullable: true,
-				Metadata: arrow.MetadataFrom(map[string]string{types.ColumnTypeMetadataKey: types.ColumnTypeMetadata.String()}),
+				Metadata: arrow.MetadataFrom(map[string]string{types.MetadataKeyColumnType: types.ColumnTypeMetadata.String()}),
 			})
 
 		case types.ColumnTypeParsed:
@@ -489,7 +489,7 @@ func builtinColumnType(ref types.ColumnRef) arrow.DataType {
 // appendToBuilder panics if the type of field does not match the datatype of
 // builder.
 func (s *dataobjScan) appendToBuilder(builder array.Builder, field *arrow.Field, record *dataobj.Record) {
-	columnType, ok := field.Metadata.GetValue(types.ColumnTypeMetadataKey)
+	columnType, ok := field.Metadata.GetValue(types.MetadataKeyColumnType)
 	if !ok {
 		// This shouldn't happen; we control the metadata here on the fields.
 		panic(fmt.Sprintf("missing column type in field %s", field.Name))

--- a/pkg/engine/executor/dataobjscan_test.go
+++ b/pkg/engine/executor/dataobjscan_test.go
@@ -25,7 +25,7 @@ var (
 
 func buildMetadata(ty types.ColumnType) arrow.Metadata {
 	return arrow.MetadataFrom(map[string]string{
-		types.ColumnTypeMetadataKey: ty.String(),
+		types.MetadataKeyColumnType: ty.String(),
 	})
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

`types.ColumnTypeMetadataKey` was renamed to `types.MetadataKeyColumnType` in https://github.com/grafana/loki/pull/17456 
However, https://github.com/grafana/loki/pull/17568 was merged before that, which still used the old name.