### PR TITLE
chore: restructure some of our limits metrics

### DIFF
--- a/pkg/limits/ingest_limits.go
+++ b/pkg/limits/ingest_limits.go
@@ -32,24 +32,16 @@ const (
 )
 
 var (
-	tenantPartitionDesc = prometheus.NewDesc(
+	partitionsDesc = prometheus.NewDesc(
 		constants.Loki+"_ingest_limits_partitions",
-		"The current number of partitions per tenant.",
-		[]string{"tenant"},
+		"The current number of partitions.",
+		nil,
 		nil,
 	)
-
-	tenantRecordedStreamsDesc = prometheus.NewDesc(
-		constants.Loki+"_ingest_limits_recorded_streams",
-		"The current number of recorded streams per tenant. This is not a global total, as tenants can be sharded over multiple pods.",
-		[]string{"tenant"},
-		nil,
-	)
-
-	tenantActiveStreamsDesc = prometheus.NewDesc(
-		constants.Loki+"_ingest_limits_active_streams",
-		"The current number of active streams (seen within the window) per tenant. This is not a global total, as tenants can be sharded over multiple pods.",
-		[]string{"tenant"},
+	tenantStreamsDesc = prometheus.NewDesc(
+		constants.Loki+"_ingest_limits_streams",
+		"The current number of streams per tenant. This is not a global total, as tenants can be sharded over multiple pods.",
+		[]string{"tenant", "state"},
 		nil,
 	)
 )
@@ -179,51 +171,46 @@ func NewIngestLimits(cfg Config, lims Limits, logger log.Logger, reg prometheus.
 }
 
 func (s *IngestLimits) Describe(descs chan<- *prometheus.Desc) {
-	descs <- tenantPartitionDesc
-	descs <- tenantRecordedStreamsDesc
-	descs <- tenantActiveStreamsDesc
+	descs <- partitionsDesc
+	descs <- tenantStreamsDesc
 }
 
 func (s *IngestLimits) Collect(m chan<- prometheus.Metric) {
 	cutoff := s.clock.Now().Add(-s.cfg.WindowSize).UnixNano()
-
-	var (
-		recorded            = make(map[string]int)
-		active              = make(map[string]int)
-		partitionsPerTenant = make(map[string]map[int32]struct{})
-	)
-
+	// active counts the number of active streams (within the window) per tenant.
+	active := make(map[string]int)
+	// expired counts the number of expired streams (outside the window) per tenant.
+	expired := make(map[string]int)
 	s.metadata.All(func(tenant string, partitionID int32, stream Stream) {
-		if assigned := s.partitionManager.Has(partitionID); !assigned {
-			return
-		}
-
 		if stream.LastSeenAt < cutoff {
-			return
-		}
-
-		active[tenant]++
-
-		if _, ok := partitionsPerTenant[tenant]; !ok {
-			partitionsPerTenant[tenant] = make(map[int32]struct{})
-		}
-
-		if _, ok := partitionsPerTenant[tenant][partitionID]; !ok {
-			partitionsPerTenant[tenant][partitionID] = struct{}{}
+			expired[tenant]++
+		} else {
+			active[tenant]++
 		}
 	})
-
-	for tenant, partitions := range partitionsPerTenant {
-		m <- prometheus.MustNewConstMetric(tenantPartitionDesc, prometheus.GaugeValue, float64(len(partitions)), tenant)
+	for tenant, numActive := range active {
+		m <- prometheus.MustNewConstMetric(
+			tenantStreamsDesc,
+			prometheus.GaugeValue,
+			float64(numActive),
+			tenant,
+			"active",
+		)
 	}
-
-	for tenant, active := range active {
-		m <- prometheus.MustNewConstMetric(tenantActiveStreamsDesc, prometheus.GaugeValue, float64(active), tenant)
+	for tenant, numExpired := range expired {
+		m <- prometheus.MustNewConstMetric(
+			tenantStreamsDesc,
+			prometheus.GaugeValue,
+			float64(numExpired),
+			tenant,
+			"expired",
+		)
 	}
-
-	for tenant, recorded := range recorded {
-		m <- prometheus.MustNewConstMetric(tenantRecordedStreamsDesc, prometheus.GaugeValue, float64(recorded), tenant)
-	}
+	m <- prometheus.MustNewConstMetric(
+		partitionsDesc,
+		prometheus.GaugeValue,
+		float64(len(s.partitionManager.List())),
+	)
 }
 
 func (s *IngestLimits) onPartitionsAssigned(ctx context.Context, client *kgo.Client, partitions map[string][]int32) {


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit restructures some of our limits metrics. It removes tenant from _ingest_limits_partitions as this was redundant information. The same pod cannot consume different partitions for different tenants. It also counts the number of active and expired streams per tenant, and removes the recorded metric which was not being used.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
