### PR TITLE
chore(ci): Do not run triage workflow when PR comes from a fork

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -10,7 +10,7 @@ jobs:
     # We don't run the backporting for PRs from forks because those can't access "loki-github-bot" secrets in vault.
     # We don't use GitHub actions app (secrets.GITHUB_TOKEN) because PRs created by the bot don't trigger CI.
     # Also only run if the PR is merged, as an extra safe-guard.
-    if: ${{ ! github.event.pull_request.head.repo.fork && github.event.pull_request.merged == true }}  
+    if: ${{ ! github.event.pull_request.head.repo.fork && github.event.pull_request.merged == true }}
 
     runs-on: ubuntu-latest
     permissions:
@@ -35,7 +35,7 @@ jobs:
         with:
           repo_secrets: |
             APP_ID=loki-gh-app:app-id
-            PRIVATE_KEY=loki-gh-app:private-key            
+            PRIVATE_KEY=loki-gh-app:private-key
 
       - name: Generate GitHub App Token
         id: app-token

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -4,10 +4,15 @@ on:
 
 jobs:
   triage:
+    # We don't run the triaging for PRs from forks because those can't access "loki-github-bot" secrets in vault.
+    # We don't use GitHub actions app (secrets.GITHUB_TOKEN) because PRs created by the bot don't trigger CI.
+    # Also only run if the PR is merged, as an extra safe-guard.
+    if: ${{ ! github.event.pull_request.head.repo.fork && github.event.pull_request.merged == true }}
+
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write       
+      pull-requests: write
       id-token: write
     steps:
     - name: Checkout Actions
@@ -27,7 +32,7 @@ jobs:
       with:
         repo_secrets: |
           APP_ID=loki-gh-app:app-id
-          PRIVATE_KEY=loki-gh-app:private-key            
+          PRIVATE_KEY=loki-gh-app:private-key
 
     - name: Generate GitHub App Token
       id: app-token


### PR DESCRIPTION
**What this PR does / why we need it**:

This makes the `triage` workflow only run when the PR is not coming from a forked repository.

PTAL @periklis 

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
