### PR TITLE
chore(engine): Unify name and type of builtin columns

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -185,14 +185,14 @@ func collectRow(rec arrow.Record, i int, result *resultBuilder) {
 		}
 
 		// Extract line
-		if colName == types.ColumnNameBuiltinLine && colType == types.ColumnTypeBuiltin.String() {
+		if colName == types.ColumnNameBuiltinMessage && colType == types.ColumnTypeBuiltin.String() {
 			entry.Line = col.(*array.String).Value(i)
 			continue
 		}
 
 		// Extract timestamp
 		if colName == types.ColumnNameBuiltinTimestamp && colType == types.ColumnTypeBuiltin.String() {
-			entry.Timestamp = time.Unix(0, int64(col.(*array.Uint64).Value(i)))
+			entry.Timestamp = time.Unix(0, int64(col.(*array.Timestamp).Value(i)))
 			continue
 		}
 

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -43,6 +43,8 @@ func createRecord(t *testing.T, schema *arrow.Schema, data [][]interface{}) arro
 				builder.Field(j).(*array.Int64Builder).Append(val.(int64))
 			case *array.Float64Builder:
 				builder.Field(j).(*array.Float64Builder).Append(val.(float64))
+			case *array.TimestampBuilder:
+				builder.Field(j).(*array.TimestampBuilder).Append(val.(arrow.Timestamp))
 			default:
 				t.Fatal("invalid field type")
 			}
@@ -59,17 +61,17 @@ func TestConvertArrowRecordsToLokiResult(t *testing.T) {
 	t.Run("rows without log line, timestamp, or labels are ignored", func(t *testing.T) {
 		schema := arrow.NewSchema(
 			[]arrow.Field{
-				{Name: types.ColumnNameBuiltinTimestamp, Type: arrow.PrimitiveTypes.Uint64, Metadata: datatype.ColumnMetadataBuiltinTimestamp},
-				{Name: types.ColumnNameBuiltinLine, Type: arrow.BinaryTypes.String, Metadata: datatype.ColumnMetadataBuiltinLine},
+				{Name: types.ColumnNameBuiltinTimestamp, Type: arrow.FixedWidthTypes.Timestamp_ns, Metadata: datatype.ColumnMetadataBuiltinTimestamp},
+				{Name: types.ColumnNameBuiltinMessage, Type: arrow.BinaryTypes.String, Metadata: datatype.ColumnMetadataBuiltinMessage},
 				{Name: "env", Type: arrow.BinaryTypes.String, Metadata: mdTypeLabel},
 			},
 			nil,
 		)
 
 		data := [][]interface{}{
-			{uint64(1620000000000000001), nil, "prod"},
+			{arrow.Timestamp(1620000000000000001), nil, "prod"},
 			{nil, "log line", "prod"},
-			{uint64(1620000000000000003), "log line", nil},
+			{arrow.Timestamp(1620000000000000003), "log line", nil},
 		}
 
 		record := createRecord(t, schema, data)
@@ -88,17 +90,17 @@ func TestConvertArrowRecordsToLokiResult(t *testing.T) {
 	t.Run("fields without metadata are ignored", func(t *testing.T) {
 		schema := arrow.NewSchema(
 			[]arrow.Field{
-				{Name: types.ColumnNameBuiltinTimestamp, Type: arrow.PrimitiveTypes.Uint64},
-				{Name: types.ColumnNameBuiltinLine, Type: arrow.BinaryTypes.String},
+				{Name: types.ColumnNameBuiltinTimestamp, Type: arrow.FixedWidthTypes.Timestamp_ns},
+				{Name: types.ColumnNameBuiltinMessage, Type: arrow.BinaryTypes.String},
 				{Name: "env", Type: arrow.BinaryTypes.String},
 			},
 			nil,
 		)
 
 		data := [][]interface{}{
-			{uint64(1620000000000000001), "log line 1", "prod"},
-			{uint64(1620000000000000002), "log line 2", "prod"},
-			{uint64(1620000000000000003), "log line 3", "prod"},
+			{arrow.Timestamp(1620000000000000001), "log line 1", "prod"},
+			{arrow.Timestamp(1620000000000000002), "log line 2", "prod"},
+			{arrow.Timestamp(1620000000000000003), "log line 3", "prod"},
 		}
 
 		record := createRecord(t, schema, data)
@@ -117,8 +119,8 @@ func TestConvertArrowRecordsToLokiResult(t *testing.T) {
 	t.Run("successful conversion of labels, log line, timestamp, and structured metadata ", func(t *testing.T) {
 		schema := arrow.NewSchema(
 			[]arrow.Field{
-				{Name: types.ColumnNameBuiltinTimestamp, Type: arrow.PrimitiveTypes.Uint64, Metadata: datatype.ColumnMetadataBuiltinTimestamp},
-				{Name: types.ColumnNameBuiltinLine, Type: arrow.BinaryTypes.String, Metadata: datatype.ColumnMetadataBuiltinLine},
+				{Name: types.ColumnNameBuiltinTimestamp, Type: arrow.FixedWidthTypes.Timestamp_ns, Metadata: datatype.ColumnMetadataBuiltinTimestamp},
+				{Name: types.ColumnNameBuiltinMessage, Type: arrow.BinaryTypes.String, Metadata: datatype.ColumnMetadataBuiltinMessage},
 				{Name: "env", Type: arrow.BinaryTypes.String, Metadata: mdTypeLabel},
 				{Name: "namespace", Type: arrow.BinaryTypes.String, Metadata: mdTypeLabel},
 				{Name: "traceID", Type: arrow.BinaryTypes.String, Metadata: mdTypeMetadata},
@@ -127,11 +129,11 @@ func TestConvertArrowRecordsToLokiResult(t *testing.T) {
 		)
 
 		data := [][]interface{}{
-			{uint64(1620000000000000001), "log line 1", "dev", "loki-dev-001", "860e403fcf754312"},
-			{uint64(1620000000000000002), "log line 2", "prod", "loki-prod-001", "46ce02549441e41c"},
-			{uint64(1620000000000000003), "log line 3", "dev", "loki-dev-002", "61330481e1e59b18"},
-			{uint64(1620000000000000004), "log line 4", "prod", "loki-prod-001", "40e50221e284b9d2"},
-			{uint64(1620000000000000005), "log line 5", "dev", "loki-dev-002", "0cf883f112ad239b"},
+			{arrow.Timestamp(1620000000000000001), "log line 1", "dev", "loki-dev-001", "860e403fcf754312"},
+			{arrow.Timestamp(1620000000000000002), "log line 2", "prod", "loki-prod-001", "46ce02549441e41c"},
+			{arrow.Timestamp(1620000000000000003), "log line 3", "dev", "loki-dev-002", "61330481e1e59b18"},
+			{arrow.Timestamp(1620000000000000004), "log line 4", "prod", "loki-prod-001", "40e50221e284b9d2"},
+			{arrow.Timestamp(1620000000000000005), "log line 5", "dev", "loki-dev-002", "0cf883f112ad239b"},
 		}
 
 		record := createRecord(t, schema, data)

--- a/pkg/engine/executor/dataobjscan.go
+++ b/pkg/engine/executor/dataobjscan.go
@@ -353,8 +353,8 @@ func (s *dataobjScan) effectiveProjections(h *topk.Heap[dataobj.Record]) ([]phys
 	})
 
 	// Add fixed columns at the end.
-	addColumn("timestamp", types.ColumnTypeBuiltin)
-	addColumn("message", types.ColumnTypeBuiltin)
+	addColumn(types.ColumnNameBuiltinTimestamp, types.ColumnTypeBuiltin)
+	addColumn(types.ColumnNameBuiltinMessage, types.ColumnTypeBuiltin)
 
 	return columns, nil
 }
@@ -475,9 +475,9 @@ func builtinColumnType(ref types.ColumnRef) arrow.DataType {
 	}
 
 	switch ref.Column {
-	case "timestamp":
+	case types.ColumnNameBuiltinTimestamp:
 		return arrow.FixedWidthTypes.Timestamp_ns
-	case "message":
+	case types.ColumnNameBuiltinMessage:
 		return arrow.BinaryTypes.String
 	default:
 		panic(fmt.Sprintf("unsupported builtin column type %s", ref))
@@ -518,10 +518,10 @@ func (s *dataobjScan) appendToBuilder(builder array.Builder, field *arrow.Field,
 		}
 
 	case types.ColumnTypeBuiltin.String():
-		if field.Name == "timestamp" {
+		if field.Name == types.ColumnNameBuiltinTimestamp {
 			ts, _ := arrow.TimestampFromTime(record.Timestamp, arrow.Nanosecond)
 			builder.(*array.TimestampBuilder).Append(ts)
-		} else if field.Name == "message" {
+		} else if field.Name == types.ColumnNameBuiltinMessage {
 			// Use the inner BinaryBuilder to avoid converting record.Line to a
 			// string and back.
 			builder.(*array.StringBuilder).BinaryBuilder.Append(record.Line)

--- a/pkg/engine/executor/expressions_test.go
+++ b/pkg/engine/executor/expressions_test.go
@@ -116,10 +116,10 @@ func TestEvaluateColumnExpression(t *testing.T) {
 		require.ErrorContains(t, err, errors.ErrKey.Error())
 	})
 
-	t.Run("string(line)", func(t *testing.T) {
+	t.Run("string(message)", func(t *testing.T) {
 		colExpr := &physical.ColumnExpr{
 			Ref: types.ColumnRef{
-				Column: "line",
+				Column: "message",
 				Type:   types.ColumnTypeBuiltin,
 			},
 		}
@@ -223,7 +223,7 @@ func batch(n int, now time.Time) arrow.Record {
 	// 2. Define the schema
 	schema := arrow.NewSchema(
 		[]arrow.Field{
-			{Name: "line", Type: arrow.BinaryTypes.String, Metadata: datatype.ColumnMetadataBuiltinLine},
+			{Name: "message", Type: arrow.BinaryTypes.String, Metadata: datatype.ColumnMetadataBuiltinMessage},
 			{Name: "timestamp", Type: arrow.PrimitiveTypes.Uint64, Metadata: datatype.ColumnMetadataBuiltinTimestamp},
 		},
 		nil, // No metadata

--- a/pkg/engine/internal/datatype/util.go
+++ b/pkg/engine/internal/datatype/util.go
@@ -7,7 +7,7 @@ import (
 )
 
 var (
-	ColumnMetadataBuiltinLine      = ColumnMetadata(types.ColumnTypeBuiltin, String)
+	ColumnMetadataBuiltinMessage   = ColumnMetadata(types.ColumnTypeBuiltin, String)
 	ColumnMetadataBuiltinTimestamp = ColumnMetadata(types.ColumnTypeBuiltin, Timestamp)
 )
 

--- a/pkg/engine/internal/types/column.go
+++ b/pkg/engine/internal/types/column.go
@@ -22,7 +22,7 @@ const (
 // Names of the builtin columns.
 const (
 	ColumnNameBuiltinTimestamp = "timestamp"
-	ColumnNameBuiltinLine      = "line"
+	ColumnNameBuiltinMessage   = "message"
 	MetadataKeyColumnType      = "column_type"
 	MetadataKeyColumnDataType  = "column_datatype"
 )

--- a/pkg/engine/planner/logical/planner.go
+++ b/pkg/engine/planner/logical/planner.go
@@ -176,7 +176,7 @@ func timestampColumnRef() *ColumnRef {
 }
 
 func lineColumnRef() *ColumnRef {
-	return NewColumnRef(types.ColumnNameBuiltinLine, types.ColumnTypeBuiltin)
+	return NewColumnRef(types.ColumnNameBuiltinMessage, types.ColumnTypeBuiltin)
 }
 
 func convertLabelMatchType(op labels.MatchType) types.BinaryOp {

--- a/pkg/engine/planner/logical/planner_test.go
+++ b/pkg/engine/planner/logical/planner_test.go
@@ -102,10 +102,10 @@ func TestConvertAST_Success(t *testing.T) {
 %11 = MATCH_STR ambiguous.bar "baz"
 %12 = OR %10 %11
 %13 = SELECT %9 [predicate=%12]
-%14 = MATCH_STR builtin.line "metric.go"
-%15 = MATCH_STR builtin.line "foo"
+%14 = MATCH_STR builtin.message "metric.go"
+%15 = MATCH_STR builtin.message "foo"
 %16 = AND %14 %15
-%17 = NOT_MATCH_RE builtin.line "(a|b|c)"
+%17 = NOT_MATCH_RE builtin.message "(a|b|c)"
 %18 = AND %16 %17
 %19 = SELECT %13 [predicate=%18]
 %20 = LIMIT %19 [skip=0, fetch=1000]


### PR DESCRIPTION
**What this PR does / why we need it**:

* `Entry.Line` maps to `builtin.message` of type `arrow.BinaryTypes.String`
* `Entry.Timestamp` maps to `builin.timestamp` of type `arrow.FixedWidthTypes.Timestamp_ns`

Names and types used when creating and collecting records need to match.