### PR TITLE
feat: add kafkav2 client

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -1044,6 +1044,14 @@ ingest_limits:
     # CLI flag: -ingest-limits.lifecycler.ID
     [id: <string> | default = "<hostname>"]
 
+  # The address of the seed broker for the Kafka read client.
+  # CLI flag: -ingest-limits.kafka-read-address
+  [kafka_read_address: <string> | default = ""]
+
+  # The address of the seed broker for the Kafka write client.
+  # CLI flag: -ingest-limits.kafka-write-address
+  [kafka_write_address: <string> | default = ""]
+
   # The number of partitions for the Kafka topic used to read and write stream
   # metadata. It is fixed, not a maximum.
   # CLI flag: -ingest-limits.num-partitions

--- a/pkg/kafka/clientv2/client.go
+++ b/pkg/kafka/clientv2/client.go
@@ -1,0 +1,202 @@
+package clientv2
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/twmb/franz-go/pkg/kadm"
+	"github.com/twmb/franz-go/pkg/kgo"
+	"github.com/twmb/franz-go/pkg/kmsg"
+	"github.com/twmb/franz-go/pkg/sasl/plain"
+	"github.com/twmb/franz-go/plugin/kotel"
+	"github.com/twmb/franz-go/plugin/kprom"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/grafana/loki/v3/pkg/kafka"
+)
+
+// New returns a new Kafka client or an error. Refer to client_test.go for
+// examples of how to create different clients.
+func New(cfg kafka.Config, metrics *kprom.Metrics, logger log.Logger, opts ...kgo.Opt) (*kgo.Client, error) {
+	opts = append(newCommonOpts(cfg, metrics, logger), opts...)
+	client, err := kgo.NewClient(opts...)
+	if err != nil {
+		return nil, err
+	}
+	if cfg.AutoCreateTopicEnabled {
+		setDefaultNumberOfPartitionsForAutocreatedTopics(cfg, client, logger)
+	}
+	return client, nil
+}
+
+// NewConsumerOpts returns the opts for a client that consumes from Kafka.
+func NewConsumerOpts() []kgo.Opt {
+	fetchMaxBytes := int32(100_000_000)
+	return []kgo.Opt{
+		kgo.FetchMinBytes(1),
+		kgo.FetchMaxBytes(fetchMaxBytes),
+		kgo.FetchMaxWait(5 * time.Second),
+		kgo.FetchMaxPartitionBytes(50_000_000),
+		kgo.BrokerMaxReadBytes(2 * fetchMaxBytes),
+	}
+}
+
+// NewProducerOpts returns the opts for a client that produces to Kafka.
+func NewProducerOpts(cfg kafka.Config, maxInflightProduceRequests int) []kgo.Opt {
+	return []kgo.Opt{
+		kgo.RequiredAcks(kgo.AllISRAcks()),
+		kgo.DefaultProduceTopic(cfg.Topic),
+
+		// We set the partition field in each record.
+		kgo.RecordPartitioner(kgo.ManualPartitioner()),
+
+		// Set the upper bounds the size of a record batch.
+		kgo.ProducerBatchMaxBytes(kafka.ProducerBatchMaxBytes),
+
+		// By default, the Kafka client allows 1 Produce in-flight request per broker. Disabling write idempotency
+		// (which we don't need), we can increase the max number of in-flight Produce requests per broker. A higher
+		// number of in-flight requests, in addition to short buffering ("linger") in client side before firing the
+		// next Produce request allows us to reduce the end-to-end latency.
+		//
+		// The result of the multiplication of producer linger and max in-flight requests should match the maximum
+		// Produce latency expected by the Kafka backend in a steady state. For example, 50ms * 20 requests = 1s,
+		// which means the Kafka client will keep issuing a Produce request every 50ms as far as the Kafka backend
+		// doesn't take longer than 1s to process them (if it takes longer, the client will buffer data and stop
+		// issuing new Produce requests until some previous ones complete).
+		kgo.DisableIdempotentWrite(),
+		kgo.ProducerLinger(50 * time.Millisecond),
+		kgo.MaxProduceRequestsInflightPerBroker(maxInflightProduceRequests),
+
+		// Unlimited number of Produce retries but a deadline on the max time a record can take to be delivered.
+		// With the default config it would retry infinitely.
+		//
+		// Details of the involved timeouts:
+		// - RecordDeliveryTimeout: how long a Kafka client Produce() call can take for a given record. The overhead
+		//   timeout is NOT applied.
+		// - ProduceRequestTimeout: how long to wait for the response to the Produce request (the Kafka protocol message)
+		//   after being sent on the network. The actual timeout is increased by the configured overhead.
+		//
+		// When a Produce request to Kafka fail, the client will retry up until the RecordDeliveryTimeout is reached.
+		// Once the timeout is reached, the Produce request will fail and all other buffered requests in the client
+		// (for the same partition) will fail too. See kgo.RecordDeliveryTimeout() documentation for more info.
+		kgo.RecordRetries(math.MaxInt),
+		kgo.RecordDeliveryTimeout(cfg.WriteTimeout),
+		kgo.ProduceRequestTimeout(cfg.WriteTimeout),
+		kgo.RequestTimeoutOverhead(2 * time.Second),
+
+		// Unlimited number of buffered records because we limit on bytes in Writer. The reason why we don't use
+		// kgo.MaxBufferedBytes() is because it suffers a deadlock issue:
+		// https://github.com/twmb/franz-go/issues/777
+		kgo.MaxBufferedRecords(math.MaxInt), // Use a high value to set it as unlimited, because the client doesn't support "0 as unlimited".
+		kgo.MaxBufferedBytes(0),
+	}
+}
+
+// newCommonOpts returns the common opts for both produce and consume clients.
+func newCommonOpts(cfg kafka.Config, metrics *kprom.Metrics, logger log.Logger) []kgo.Opt {
+	opts := []kgo.Opt{
+		kgo.ClientID(cfg.ClientID),
+		kgo.SeedBrokers(cfg.Address),
+		kgo.DialTimeout(cfg.DialTimeout),
+
+		// A cluster metadata update is a request sent to a broker and getting
+		// back the map of partitions and the leader broker for each partition.
+		// The cluster metadata can be updated (a) periodically or (b) when
+		// some events occur (e.g. backoff due to errors).
+		//
+		// MetadataMinAge() sets the minimum time between two cluster metadata
+		// updates due to events. MetadataMaxAge() sets how frequently the
+		// periodic update should occur.
+		//
+		// It's important to note that the periodic update is also used to
+		// discover new brokers (e.g. during a rolling update or after a scale
+		// up). For this reason, it's important to run the update frequently.
+		//
+		// The other two side effects of frequently updating the cluster
+		// metadata:
+		//
+		//   1. The "metadata" request may be expensive to run on the Kafka
+		//      backend.
+		//   2. If the backend returns each time a different authoritative
+		//      owner for a partition, then each time the cluster metadata is
+		//      updated the Kafka client will create a new connection for each
+		//      partition, leading to a high connections churn rate.
+		//
+		// We currently set min and max age to the same value to have constant
+		// load on the Kafka backend: regardless there are errors or not, the
+		// metadata requests frequency doesn't change.
+		kgo.MetadataMinAge(10 * time.Second),
+		kgo.MetadataMaxAge(10 * time.Second),
+		kgo.WithLogger(newLogger(logger)),
+		kgo.RetryTimeoutFn(func(key int16) time.Duration {
+			switch key {
+			case ((*kmsg.ListOffsetsRequest)(nil)).Key():
+				return cfg.LastProducedOffsetRetryTimeout
+			}
+			return 30 * time.Second // 30s is the default timeout.
+		}),
+	}
+	// SASL plain auth.
+	if cfg.SASLUsername != "" && cfg.SASLPassword.String() != "" {
+		opts = append(opts, kgo.SASL(plain.Plain(func(_ context.Context) (plain.Auth, error) {
+			return plain.Auth{
+				User: cfg.SASLUsername,
+				Pass: cfg.SASLPassword.String(),
+			}, nil
+		})))
+	}
+	if cfg.AutoCreateTopicEnabled {
+		opts = append(opts, kgo.AllowAutoTopicCreation())
+	}
+	tracer := kotel.NewTracer(
+		kotel.TracerPropagator(
+			propagation.NewCompositeTextMapPropagator(
+				onlySampledTraces{propagation.TraceContext{}},
+			),
+		),
+	)
+	opts = append(opts, kgo.WithHooks(kotel.NewKotel(kotel.WithTracer(tracer)).Hooks()...))
+	if metrics != nil {
+		opts = append(opts, kgo.WithHooks(metrics))
+	}
+	return opts
+}
+
+// setDefaultNumberOfPartitionsForAutocreatedTopics makes a best-effort
+// attempt to set the `num.partitions` config option on brokers.
+func setDefaultNumberOfPartitionsForAutocreatedTopics(cfg kafka.Config, client *kgo.Client, logger log.Logger) {
+	if cfg.AutoCreateTopicDefaultPartitions <= 0 {
+		return
+	}
+	// Note: the admin client doesn't need to be closed as it just wraps the
+	// existing client.
+	adm := kadm.NewClient(client)
+	defaultNumberOfPartitions := fmt.Sprintf("%d", cfg.AutoCreateTopicDefaultPartitions)
+	_, err := adm.AlterBrokerConfigsState(context.Background(), []kadm.AlterConfig{{
+		Op:    kadm.SetConfig,
+		Name:  "num.partitions",
+		Value: &defaultNumberOfPartitions,
+	}})
+	if err != nil {
+		level.Error(logger).Log("msg", "failed to set num.partitions on brokers", "err", err)
+		return
+	}
+	level.Info(logger).Log("msg", "set num.partitions on brokers", "value", cfg.AutoCreateTopicDefaultPartitions)
+}
+
+type onlySampledTraces struct {
+	propagation.TextMapPropagator
+}
+
+func (o onlySampledTraces) Inject(ctx context.Context, carrier propagation.TextMapCarrier) {
+	sc := trace.SpanContextFromContext(ctx)
+	if !sc.IsSampled() {
+		return
+	}
+	o.TextMapPropagator.Inject(ctx, carrier)
+}

--- a/pkg/kafka/clientv2/client_test.go
+++ b/pkg/kafka/clientv2/client_test.go
@@ -4,12 +4,9 @@ import (
 	"context"
 	"testing"
 
-	"github.com/go-kit/log"
 	"github.com/grafana/dskit/flagext"
 	"github.com/stretchr/testify/require"
 	"github.com/twmb/franz-go/pkg/kfake"
-	"github.com/twmb/franz-go/pkg/kgo"
-	"github.com/twmb/franz-go/pkg/kmsg"
 
 	"github.com/grafana/loki/v3/pkg/kafka"
 	"github.com/grafana/loki/v3/pkg/kafka/testkafka"
@@ -62,38 +59,4 @@ func TestNewConsumer(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestSetDefaultNumberOfPartitionsForAutocreatedTopics(t *testing.T) {
-	cluster, err := kfake.NewCluster(kfake.NumBrokers(1))
-	require.NoError(t, err)
-	t.Cleanup(cluster.Close)
-
-	addrs := cluster.ListenAddrs()
-	require.Len(t, addrs, 1)
-
-	cfg := kafka.Config{
-		Address:                          addrs[0],
-		AutoCreateTopicDefaultPartitions: 100,
-	}
-
-	cluster.ControlKey(kmsg.AlterConfigs.Int16(), func(request kmsg.Request) (kmsg.Response, error, bool) {
-		r := request.(*kmsg.AlterConfigsRequest)
-
-		require.Len(t, r.Resources, 1)
-		res := r.Resources[0]
-		require.Equal(t, kmsg.ConfigResourceTypeBroker, res.ResourceType)
-		require.Len(t, res.Configs, 1)
-		cfg := res.Configs[0]
-		require.Equal(t, "num.partitions", cfg.Name)
-		require.NotNil(t, *cfg.Value)
-		require.Equal(t, "100", *cfg.Value)
-
-		return &kmsg.AlterConfigsResponse{}, nil, true
-	})
-
-	client, err := kgo.NewClient(newCommonOpts(cfg, nil, log.NewNopLogger())...)
-	require.NoError(t, err)
-
-	setDefaultNumberOfPartitionsForAutocreatedTopics(cfg, client, log.NewNopLogger())
 }

--- a/pkg/kafka/clientv2/client_test.go
+++ b/pkg/kafka/clientv2/client_test.go
@@ -1,0 +1,99 @@
+package clientv2
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/dskit/flagext"
+	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/kfake"
+	"github.com/twmb/franz-go/pkg/kgo"
+	"github.com/twmb/franz-go/pkg/kmsg"
+
+	"github.com/grafana/loki/v3/pkg/kafka"
+	"github.com/grafana/loki/v3/pkg/kafka/testkafka"
+)
+
+func TestNewConsumer(t *testing.T) {
+	_, addr := testkafka.CreateClusterWithoutCustomConsumerGroupsSupport(
+		t, 1, "test", kfake.EnableSASL(), kfake.Superuser("PLAIN", "user", "password"))
+
+	tests := []struct {
+		name        string
+		config      kafka.Config
+		expectedErr string
+	}{{
+		name: "ok",
+		config: kafka.Config{
+			Address:      addr,
+			Topic:        "abcd",
+			SASLUsername: "user",
+			SASLPassword: flagext.SecretWithValue("password"),
+		},
+	}, {
+		name: "invalid username",
+		config: kafka.Config{
+			Address:      addr,
+			Topic:        "abcd",
+			SASLUsername: "invalid_user",
+			SASLPassword: flagext.SecretWithValue("password"),
+		},
+		expectedErr: "EOF",
+	}, {
+		name: "invalid password",
+		config: kafka.Config{
+			Address:      addr,
+			Topic:        "abcd",
+			SASLUsername: "user",
+			SASLPassword: flagext.SecretWithValue("invalid_password"),
+		},
+		expectedErr: "EOF",
+	}}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client, err := New(test.config, nil, nil, NewConsumerOpts()...)
+			require.NoError(t, err)
+			err = client.Ping(context.Background())
+			if test.expectedErr != "" {
+				require.EqualError(t, err, test.expectedErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestSetDefaultNumberOfPartitionsForAutocreatedTopics(t *testing.T) {
+	cluster, err := kfake.NewCluster(kfake.NumBrokers(1))
+	require.NoError(t, err)
+	t.Cleanup(cluster.Close)
+
+	addrs := cluster.ListenAddrs()
+	require.Len(t, addrs, 1)
+
+	cfg := kafka.Config{
+		Address:                          addrs[0],
+		AutoCreateTopicDefaultPartitions: 100,
+	}
+
+	cluster.ControlKey(kmsg.AlterConfigs.Int16(), func(request kmsg.Request) (kmsg.Response, error, bool) {
+		r := request.(*kmsg.AlterConfigsRequest)
+
+		require.Len(t, r.Resources, 1)
+		res := r.Resources[0]
+		require.Equal(t, kmsg.ConfigResourceTypeBroker, res.ResourceType)
+		require.Len(t, res.Configs, 1)
+		cfg := res.Configs[0]
+		require.Equal(t, "num.partitions", cfg.Name)
+		require.NotNil(t, *cfg.Value)
+		require.Equal(t, "100", *cfg.Value)
+
+		return &kmsg.AlterConfigsResponse{}, nil, true
+	})
+
+	client, err := kgo.NewClient(newCommonOpts(cfg, nil, log.NewNopLogger())...)
+	require.NoError(t, err)
+
+	setDefaultNumberOfPartitionsForAutocreatedTopics(cfg, client, log.NewNopLogger())
+}

--- a/pkg/kafka/clientv2/logger.go
+++ b/pkg/kafka/clientv2/logger.go
@@ -1,0 +1,39 @@
+package clientv2
+
+import (
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/twmb/franz-go/pkg/kgo"
+)
+
+// logger wraps a log.Logger to implement the lgo.Logger interface.
+type logger struct {
+	logger log.Logger
+}
+
+func newLogger(l log.Logger) *logger {
+	return &logger{
+		logger: log.With(l, "component", "kafka_client"),
+	}
+}
+
+func (l *logger) Level() kgo.LogLevel {
+	// kgo calls Level() to check if debug level logging is enabled.
+	// To keep it simple, we return Info, so kgo will never log expensive
+	// debug messages.
+	return kgo.LogLevelInfo
+}
+
+func (l *logger) Log(lev kgo.LogLevel, msg string, keyvals ...any) {
+	keyvals = append([]any{"msg", msg}, keyvals...)
+	switch lev {
+	case kgo.LogLevelDebug:
+		level.Debug(l.logger).Log(keyvals...)
+	case kgo.LogLevelInfo:
+		level.Info(l.logger).Log(keyvals...)
+	case kgo.LogLevelWarn:
+		level.Warn(l.logger).Log(keyvals...)
+	case kgo.LogLevelError:
+		level.Error(l.logger).Log(keyvals...)
+	}
+}

--- a/pkg/kafka/clientv2/metrics.go
+++ b/pkg/kafka/clientv2/metrics.go
@@ -1,0 +1,42 @@
+package clientv2
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/twmb/franz-go/plugin/kprom"
+)
+
+// NewMetrics returns a new instance of kprom.Metrics.
+func NewMetrics(namespace string, reg prometheus.Registerer, enableKafkaHistograms bool) *kprom.Metrics {
+	return kprom.NewMetrics(
+		namespace,
+		kprom.Registerer(reg),
+		kprom.FetchAndProduceDetail(
+			kprom.Batches,
+			kprom.Records,
+			kprom.CompressedBytes,
+			kprom.UncompressedBytes,
+		),
+		enableKafkaHistogramMetrics(enableKafkaHistograms),
+	)
+}
+
+func enableKafkaHistogramMetrics(enable bool) kprom.Opt {
+	histogramOpts := []kprom.HistogramOpts{}
+	if enable {
+		histogramOpts = append(histogramOpts,
+			kprom.HistogramOpts{
+				Enable:  kprom.ReadTime,
+				Buckets: prometheus.DefBuckets,
+			}, kprom.HistogramOpts{
+				Enable:  kprom.ReadWait,
+				Buckets: prometheus.DefBuckets,
+			}, kprom.HistogramOpts{
+				Enable:  kprom.WriteTime,
+				Buckets: prometheus.DefBuckets,
+			}, kprom.HistogramOpts{
+				Enable:  kprom.WriteWait,
+				Buckets: prometheus.DefBuckets,
+			})
+	}
+	return kprom.HistogramsFromOpts(histogramOpts...)
+}

--- a/pkg/limits/config.go
+++ b/pkg/limits/config.go
@@ -36,6 +36,11 @@ type Config struct {
 
 	KafkaConfig kafka.Config `yaml:"-"`
 
+	// TODO(grobinson): These will be removed when we figure out how to support
+	// different addresses for read and write clients in kafka.Config,
+	KafkaReadAddress  string `yaml:"kafka_read_address"`
+	KafkaWriteAddress string `yaml:"kafka_write_address"`
+
 	// The number of partitions for the Kafka topic used to read and write stream metadata.
 	// It is fixed, not a maximum.
 	NumPartitions int `yaml:"num_partitions"`
@@ -48,6 +53,8 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.DurationVar(&cfg.RateWindow, "ingest-limits.rate-window", 5*time.Minute, "The time window for rate calculation. This should match the window used in Prometheus rate() queries for consistency.")
 	f.DurationVar(&cfg.BucketDuration, "ingest-limits.bucket-duration", 1*time.Minute, "The granularity of time buckets used for sliding window rate calculation. Smaller buckets provide more precise rate tracking but require more memory.")
 	f.IntVar(&cfg.NumPartitions, "ingest-limits.num-partitions", 64, "The number of partitions for the Kafka topic used to read and write stream metadata. It is fixed, not a maximum.")
+	f.StringVar(&cfg.KafkaReadAddress, "ingest-limits.kafka-read-address", "", "The address of the seed broker for the Kafka read client.")
+	f.StringVar(&cfg.KafkaWriteAddress, "ingest-limits.kafka-write-address", "", "The address of the seed broker for the Kafka write client.")
 }
 
 func (cfg *Config) Validate() error {

--- a/pkg/limits/ingest_limits_test.go
+++ b/pkg/limits/ingest_limits_test.go
@@ -489,7 +489,8 @@ func TestNewIngestLimits(t *testing.T) {
 	s, err := NewIngestLimits(cfg, limits, log.NewNopLogger(), prometheus.NewRegistry())
 	require.NoError(t, err)
 	require.NotNil(t, s)
-	require.NotNil(t, s.reader)
+	require.NotNil(t, s.kafkaReader)
+	require.NotNil(t, s.kafkaWriter)
 
 	require.Equal(t, cfg, s.cfg)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit adds a new kafka client called `clientv2`. I will replace existing use of the current package over a number of subsequent PRs to make it easier to review and test changes in isolation.

The motivation for this new package is that it was hard to create a `*kgo.Client` that could both produce and consume records. To fix this, the v2 client separates creating the client from creating the options, enabling the use of clients that produce, consume, and do both.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
