### PR TITLE
fix(ingest-limits): Fix wal appender constructor

### DIFF
--- a/pkg/limits/ingest_limits.go
+++ b/pkg/limits/ingest_limits.go
@@ -176,7 +176,7 @@ func NewIngestLimits(cfg Config, lims Limits, logger log.Logger, reg prometheus.
 	if err != nil {
 		return nil, fmt.Errorf("failed to create kafka client: %w", err)
 	}
-	s.wal = NewKafkaWAL(s.writer, s.cfg.KafkaConfig.Topic, uint64(s.cfg.NumPartitions), logger)
+	s.wal = NewKafkaWAL(s.writer, kCfg.Topic, uint64(s.cfg.NumPartitions), logger)
 
 	s.Service = services.NewBasicService(s.starting, s.running, s.stopping)
 	return s, nil

--- a/tools/dev/kafka/loki-local-config.debug.yaml
+++ b/tools/dev/kafka/loki-local-config.debug.yaml
@@ -27,6 +27,7 @@ querier:
 ingest_limits:
   enabled: true
   window_size: 1h
+  num_partitions: 1
   lifecycler:
     ring:
       kvstore:
@@ -34,6 +35,7 @@ ingest_limits:
       replication_factor: 1
 
 ingest_limits_frontend:
+  num_partitions: 1
   lifecycler:
     ring:
       kvstore:

--- a/tools/dev/kafka/loki-local-config.debug.yaml
+++ b/tools/dev/kafka/loki-local-config.debug.yaml
@@ -24,6 +24,22 @@ kafka_config:
 querier:
   query_partition_ingesters: true
 
+ingest_limits:
+  enabled: true
+  window_size: 1h
+  lifecycler:
+    ring:
+      kvstore:
+        store: inmemory
+      replication_factor: 1
+
+ingest_limits_frontend:
+  lifecycler:
+    ring:
+      kvstore:
+        store: inmemory
+      replication_factor: 1
+
 ingester:
   kafka_ingestion:
     enabled: true
@@ -31,6 +47,8 @@ ingester:
 distributor:
   kafka_writes_enabled: true
   ingester_writes_enabled: false
+  ingest_limits_enabled: true
+  ingest_limits_dry_run_enabled: true
 
 query_range:
   results_cache:
@@ -41,6 +59,7 @@ query_range:
 
 limits_config:
   metric_aggregation_enabled: true
+  max_global_streams_per_user: 1000
 
 schema_config:
   configs:


### PR DESCRIPTION
**What this PR does / why we need it**:
This pull request provides a small fix in the ingest limits Kafka-WAL constructor to use the correct topic.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
