### PR TITLE
feat(helm): Integrate the enterprise-provisioner into Loki helm chart

### DIFF
--- a/docs/sources/setup/install/helm/reference.md
+++ b/docs/sources/setup/install/helm/reference.md
@@ -3097,7 +3097,7 @@ null
     "env": [],
     "extraVolumeMounts": [],
     "extraVolumes": [],
-    "hookType": "post-install,post-upgrade",
+    "hookType": "post-install",
     "image": {
       "digest": null,
       "pullPolicy": "IfNotPresent",
@@ -3118,7 +3118,7 @@ null
     "tolerations": []
   },
   "tokengen": {
-    "adminTokenSecret": "admin-token",
+    "adminTokenSecret": null,
     "affinity": {},
     "annotations": {},
     "enabled": true,
@@ -3289,7 +3289,7 @@ null
   "env": [],
   "extraVolumeMounts": [],
   "extraVolumes": [],
-  "hookType": "post-install,post-upgrade",
+  "hookType": "post-install",
   "image": {
     "digest": null,
     "pullPolicy": "IfNotPresent",
@@ -3389,7 +3389,7 @@ true
 			<td>string</td>
 			<td>Hook type(s) to customize when the job runs.  defaults to post-install</td>
 			<td><pre lang="json">
-"post-install,post-upgrade"
+"post-install"
 </pre>
 </td>
 		</tr>
@@ -3518,7 +3518,7 @@ null
 			<td>Configuration for `tokengen` target</td>
 			<td><pre lang="json">
 {
-  "adminTokenSecret": "admin-token",
+  "adminTokenSecret": null,
   "affinity": {},
   "annotations": {},
   "enabled": true,
@@ -3547,7 +3547,7 @@ null
 			<td>string</td>
 			<td>Name of the secret to store the admin token.</td>
 			<td><pre lang="json">
-"admin-token"
+null
 </pre>
 </td>
 		</tr>

--- a/docs/sources/setup/install/helm/reference.md
+++ b/docs/sources/setup/install/helm/reference.md
@@ -3092,16 +3092,18 @@ null
     "additionalTenants": [],
     "affinity": {},
     "annotations": {},
+    "apiUrl": "{{ include \"loki.address\" . }}",
     "enabled": true,
     "env": [],
     "extraVolumeMounts": [],
-    "hookType": "post-install",
+    "extraVolumes": [],
+    "hookType": "post-install,post-upgrade",
     "image": {
       "digest": null,
       "pullPolicy": "IfNotPresent",
-      "registry": "docker.io",
-      "repository": "grafana/enterprise-logs-provisioner",
-      "tag": null
+      "registry": "us-docker.pkg.dev",
+      "repository": "grafanalabs-global/docker-enterprise-provisioner-prod/enterprise-provisioner",
+      "tag": "latest"
     },
     "labels": {},
     "nodeSelector": {},
@@ -3116,6 +3118,7 @@ null
     "tolerations": []
   },
   "tokengen": {
+    "adminTokenSecret": "admin-token",
     "affinity": {},
     "annotations": {},
     "enabled": true,
@@ -3275,22 +3278,24 @@ null
 		<tr>
 			<td>enterprise.provisioner</td>
 			<td>object</td>
-			<td>Configuration for `provisioner` target</td>
+			<td>Configuration for `provisioner` target Note: Uses tokengenJob.adminTokenSecret value to mount the admin token used to call the admin api.</td>
 			<td><pre lang="json">
 {
   "additionalTenants": [],
   "affinity": {},
   "annotations": {},
+  "apiUrl": "{{ include \"loki.address\" . }}",
   "enabled": true,
   "env": [],
   "extraVolumeMounts": [],
-  "hookType": "post-install",
+  "extraVolumes": [],
+  "hookType": "post-install,post-upgrade",
   "image": {
     "digest": null,
     "pullPolicy": "IfNotPresent",
-    "registry": "docker.io",
-    "repository": "grafana/enterprise-logs-provisioner",
-    "tag": null
+    "registry": "us-docker.pkg.dev",
+    "repository": "grafanalabs-global/docker-enterprise-provisioner-prod/enterprise-provisioner",
+    "tag": "latest"
   },
   "labels": {},
   "nodeSelector": {},
@@ -3335,6 +3340,15 @@ null
 </td>
 		</tr>
 		<tr>
+			<td>enterprise.provisioner.apiUrl</td>
+			<td>string</td>
+			<td>url of the admin api to use for the provisioner</td>
+			<td><pre lang="json">
+"{{ include \"loki.address\" . }}"
+</pre>
+</td>
+		</tr>
+		<tr>
 			<td>enterprise.provisioner.enabled</td>
 			<td>bool</td>
 			<td>Whether the job should be part of the deployment</td>
@@ -3362,11 +3376,20 @@ true
 </td>
 		</tr>
 		<tr>
+			<td>enterprise.provisioner.extraVolumes</td>
+			<td>list</td>
+			<td>Additional volumes for Pods</td>
+			<td><pre lang="json">
+[]
+</pre>
+</td>
+		</tr>
+		<tr>
 			<td>enterprise.provisioner.hookType</td>
 			<td>string</td>
 			<td>Hook type(s) to customize when the job runs.  defaults to post-install</td>
 			<td><pre lang="json">
-"post-install"
+"post-install,post-upgrade"
 </pre>
 </td>
 		</tr>
@@ -3378,9 +3401,9 @@ true
 {
   "digest": null,
   "pullPolicy": "IfNotPresent",
-  "registry": "docker.io",
-  "repository": "grafana/enterprise-logs-provisioner",
-  "tag": null
+  "registry": "us-docker.pkg.dev",
+  "repository": "grafanalabs-global/docker-enterprise-provisioner-prod/enterprise-provisioner",
+  "tag": "latest"
 }
 </pre>
 </td>
@@ -3408,7 +3431,7 @@ null
 			<td>string</td>
 			<td>The Docker registry</td>
 			<td><pre lang="json">
-"docker.io"
+"us-docker.pkg.dev"
 </pre>
 </td>
 		</tr>
@@ -3417,7 +3440,7 @@ null
 			<td>string</td>
 			<td>Docker image repository</td>
 			<td><pre lang="json">
-"grafana/enterprise-logs-provisioner"
+"grafanalabs-global/docker-enterprise-provisioner-prod/enterprise-provisioner"
 </pre>
 </td>
 		</tr>
@@ -3426,7 +3449,7 @@ null
 			<td>string</td>
 			<td>Overrides the image tag whose default is the chart's appVersion</td>
 			<td><pre lang="json">
-null
+"latest"
 </pre>
 </td>
 		</tr>
@@ -3495,6 +3518,7 @@ null
 			<td>Configuration for `tokengen` target</td>
 			<td><pre lang="json">
 {
+  "adminTokenSecret": "admin-token",
   "affinity": {},
   "annotations": {},
   "enabled": true,
@@ -3515,6 +3539,15 @@ null
   "targetModule": "tokengen",
   "tolerations": []
 }
+</pre>
+</td>
+		</tr>
+		<tr>
+			<td>enterprise.tokengen.adminTokenSecret</td>
+			<td>string</td>
+			<td>Name of the secret to store the admin token.</td>
+			<td><pre lang="json">
+"admin-token"
 </pre>
 </td>
 		</tr>

--- a/production/helm/loki/templates/_helpers.tpl
+++ b/production/helm/loki/templates/_helpers.tpl
@@ -724,7 +724,11 @@ Create the service endpoint including port for MinIO.
 
 {{/* Name of kubernetes secret to persist GEL admin token to */}}
 {{- define "enterprise-logs.adminTokenSecret" }}
+{{- if .Values.enterprise.tokengen.adminTokenSecret }}
+{{- .Values.enterprise.tokengen.adminTokenSecret -}}
+{{- else }}
 {{- .Values.enterprise.adminToken.secret | default (printf "%s-admin-token" (include "loki.name" . )) -}}
+{{- end -}}
 {{- end -}}
 
 {{/* Prefix for provisioned secrets created for each provisioned tenant */}}

--- a/production/helm/loki/templates/provisioner/job-provisioner.yaml
+++ b/production/helm/loki/templates/provisioner/job-provisioner.yaml
@@ -14,7 +14,7 @@ metadata:
     {{- with .Values.enterprise.provisioner.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-    "helm.sh/hook": {{ .Values.enterprise.provisioner.hookType | default "post-install" | quote }}
+    "helm.sh/hook": {{ .Values.enterprise.provisioner.hookType | quote }}
     "helm.sh/hook-weight": "15"
 spec:
   backoffLimit: 6
@@ -50,11 +50,11 @@ spec:
             - -exuc
             - |
               {{- range .Values.enterprise.provisioner.additionalTenants }}
-              /usr/bin/enterprise-logs-provisioner \
+              /usr/bin/provisioner \
                 -bootstrap-path=/bootstrap \
                 -cluster-name={{ include "loki.clusterName" $ }} \
-                -gel-url={{ include "loki.address" $ }} \
-                -instance={{ .name }} \
+                -api-url={{ tpl $.Values.enterprise.provisioner.apiUrl $ }} \
+                -tenant={{ .name }} \
                 -access-policy=write-{{ .name }}:{{ .name }}:logs:write \
                 -access-policy=read-{{ .name }}:{{ .name }}:logs:read \
                 -token=write-{{ .name }} \
@@ -62,11 +62,11 @@ spec:
               {{- end -}}
 
               {{- with .Values.monitoring.selfMonitoring.tenant }}
-              /usr/bin/enterprise-logs-provisioner \
+              /usr/bin/provisioner \
                 -bootstrap-path=/bootstrap \
                 -cluster-name={{ include "loki.clusterName" $ }} \
-                -gel-url={{ include "loki.address" $ }} \
-                -instance={{ .name }} \
+                -api-url={{ tpl $.Values.enterprise.provisioner.apiUrl $ }} \
+                -tenant={{ .name }} \
                 -access-policy=self-monitoring:{{ .name }}:logs:write,logs:read \
                 -token=self-monitoring
               {{- end }}
@@ -83,13 +83,14 @@ spec:
           env:
             {{ toYaml . | nindent 12 }}
           {{- end }}
+          securityContext: {{- toYaml .Values.enterprise.provisioner.containerSecurityContext | nindent 12 }}
       containers:
         - name: create-secret
           image: {{ include "loki.kubectlImage" . }}
           imagePullPolicy: {{ .Values.kubectlImage.pullPolicy }}
           command:
             - /bin/bash
-            - -exuc
+            - -euc
             - |
               # In case, the admin resources have already been created, the provisioner job
               # does not write the token files to the bootstrap mount.
@@ -99,7 +100,7 @@ spec:
               # or-operation is successful.
               {{- range .Values.enterprise.provisioner.additionalTenants }}
               ! test -s /bootstrap/token-write-{{ .name }} || \
-                kubectl --namespace "{{ .secretNamespace }}" create secret generic "{{ include "enterprise-logs.provisionedSecretPrefix" $ }}-{{ .name }}" \
+                kubectl --namespace "{{ .secretNamespace }}" create secret generic "{{ tpl $.Values.enterprise.provisioner.provisionedSecretPrefix $ }}-{{ .name }}" \
                   --from-literal=token-write="$(cat /bootstrap/token-write-{{ .name }})" \
                   --from-literal=token-read="$(cat /bootstrap/token-read-{{ .name }})"
               {{- end }}
@@ -123,6 +124,7 @@ spec:
             {{- end }}
             - name: bootstrap
               mountPath: /bootstrap
+          securityContext: {{- toYaml .Values.enterprise.provisioner.containerSecurityContext | nindent 12 }}
       {{- with .Values.enterprise.provisioner.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
@@ -144,4 +146,10 @@ spec:
             secretName: "{{ include "enterprise-logs.adminTokenSecret" . }}"
         - name: bootstrap
           emptyDir: {}
+        {{- if .Values.enterprise.provisioner.extraVolumes }}
+        {{- toYaml .Values.enterprise.provisioner.extraVolumes | nindent 8 }}
+        {{- end }}
+        {{- if .Values.global.extraVolumes }}
+        {{- toYaml .Values.global.extraVolumes | nindent 8 }}
+        {{- end }}
 {{- end }}

--- a/production/helm/loki/templates/provisioner/job-provisioner.yaml
+++ b/production/helm/loki/templates/provisioner/job-provisioner.yaml
@@ -98,9 +98,10 @@ spec:
               # Note: the following bash commands should always return a success status code. 
               # Therefore, in case the token file does not exist, the first clause of the 
               # or-operation is successful.
+              {{- $prefix := tpl (default "" $.Values.enterprise.provisioner.provisionedSecretPrefix) $ -}}  // defaults to empty string in case the value is not set in a deployed config
               {{- range .Values.enterprise.provisioner.additionalTenants }}
               ! test -s /bootstrap/token-write-{{ .name }} || \
-                kubectl --namespace "{{ .secretNamespace }}" create secret generic "{{ tpl $.Values.enterprise.provisioner.provisionedSecretPrefix $ }}-{{ .name }}" \
+                kubectl --namespace "{{ .secretNamespace }}" create secret generic "{{- if $prefix }}{{ $prefix }}-{{ end }}{{ .name }}" \
                   --from-literal=token-write="$(cat /bootstrap/token-write-{{ .name }})" \
                   --from-literal=token-read="$(cat /bootstrap/token-read-{{ .name }})"
               {{- end }}

--- a/production/helm/loki/templates/provisioner/role-provisioner.yaml
+++ b/production/helm/loki/templates/provisioner/role-provisioner.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- with .Values.enterprise.provisioner.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-    "helm.sh/hook": post-install
+    "helm.sh/hook": {{ .Values.enterprise.provisioner.hookType | quote }}
 rules:
   - apiGroups: [""]
     resources: ["secrets"]

--- a/production/helm/loki/templates/provisioner/rolebinding-provisioner.yaml
+++ b/production/helm/loki/templates/provisioner/rolebinding-provisioner.yaml
@@ -1,7 +1,7 @@
 {{ if and .Values.enterprise.provisioner.enabled .Values.enterprise.enabled}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: {{ if not .Values.rbac.namespaced }}Cluster{{ else }}Role{{ end }}Binding
+kind: {{ if not .Values.rbac.namespaced }}Cluster{{ end }}RoleBinding
 metadata:
   name: {{ template "enterprise-logs.provisionerFullname" . }}
   namespace: {{ $.Release.Namespace }}

--- a/production/helm/loki/templates/provisioner/rolebinding-provisioner.yaml
+++ b/production/helm/loki/templates/provisioner/rolebinding-provisioner.yaml
@@ -14,7 +14,7 @@ metadata:
     {{- with .Values.enterprise.provisioner.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-    "helm.sh/hook": post-install
+    "helm.sh/hook": {{ .Values.enterprise.provisioner.hookType | quote }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: {{ if not .Values.rbac.namespaced }}Cluster{{ end }}Role

--- a/production/helm/loki/templates/provisioner/serviceaccount-provisioner.yaml
+++ b/production/helm/loki/templates/provisioner/serviceaccount-provisioner.yaml
@@ -14,5 +14,5 @@ metadata:
     {{- with .Values.enterprise.provisioner.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-    "helm.sh/hook": post-install
+    "helm.sh/hook": {{ .Values.enterprise.provisioner.hookType | quote }}
 {{- end }}

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -621,7 +621,7 @@ enterprise:
     # -- Comma-separated list of Loki modules to load for tokengen
     targetModule: "tokengen"
     # -- Name of the secret to store the admin token.
-    adminTokenSecret: "admin-token"
+    adminTokenSecret: null
     # -- Additional CLI arguments for the `tokengen` target
     extraArgs: []
     # -- Additional Kubernetes environment
@@ -658,7 +658,7 @@ enterprise:
     # -- Name of the secret to store provisioned tokens in
     provisionedSecretPrefix: null
     # -- Hook type(s) to customize when the job runs.  defaults to post-install
-    hookType: "post-install,post-upgrade"
+    hookType: "post-install"
     # -- url of the admin api to use for the provisioner
     apiUrl: '{{ include "loki.address" . }}'
     # -- Additional tenants to be created. Each tenant will get a read and write policy

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -620,6 +620,8 @@ enterprise:
     enabled: true
     # -- Comma-separated list of Loki modules to load for tokengen
     targetModule: "tokengen"
+    # -- Name of the secret to store the admin token.
+    adminTokenSecret: "admin-token"
     # -- Additional CLI arguments for the `tokengen` target
     extraArgs: []
     # -- Additional Kubernetes environment
@@ -649,13 +651,16 @@ enterprise:
     # -- The name of the PriorityClass for tokengen Pods
     priorityClassName: ""
   # -- Configuration for `provisioner` target
+  # Note: Uses tokengenJob.adminTokenSecret value to mount the admin token used to call the admin api.
   provisioner:
     # -- Whether the job should be part of the deployment
     enabled: true
     # -- Name of the secret to store provisioned tokens in
     provisionedSecretPrefix: null
     # -- Hook type(s) to customize when the job runs.  defaults to post-install
-    hookType: "post-install"
+    hookType: "post-install,post-upgrade"
+    # -- url of the admin api to use for the provisioner
+    apiUrl: '{{ include "loki.address" . }}'
     # -- Additional tenants to be created. Each tenant will get a read and write policy
     # and associated token. Tenant must have a name and a namespace for the secret containting
     # the token to be created in. For example
@@ -686,17 +691,19 @@ enterprise:
     # -- Provisioner image to Utilize
     image:
       # -- The Docker registry
-      registry: docker.io
+      registry: us-docker.pkg.dev
       # -- Docker image repository
-      repository: grafana/enterprise-logs-provisioner
+      repository: grafanalabs-global/docker-enterprise-provisioner-prod/enterprise-provisioner
       # -- Overrides the image tag whose default is the chart's appVersion
-      tag: null
+      tag: latest
       # -- Overrides the image tag with an image digest
       digest: null
       # -- Docker image pull policy
       pullPolicy: IfNotPresent
     # -- Volume mounts to add to the provisioner pods
     extraVolumeMounts: []
+    # -- Additional volumes for Pods
+    extraVolumes: []
 # -- kubetclImage is used in the enterprise provisioner and tokengen jobs
 kubectlImage:
   # -- The Docker registry


### PR DESCRIPTION
**What this PR does / why we need it**:

As previously discussed in `#databases`, Loki, Mimir, and Tempo maintained separate, nearly identical provisioner tools. To streamline maintenance and support Grafana's Federal Cloud (where the admin API cannot be exposed externally), these were consolidated into a new, unified `enterprise-provisioner` tool in a dedicated repository. This new tool has been refactored, tested (dev, staging, prod on Federal Cloud), and already integrated into Mimir and Tempo.

This PR completes the migration initiative by transitioning the `enterprise-logs-provisioner` to utilize the new, centralized `enterprise-provisioner`.


Key Changes:

- Updates `values.yaml` to incorporate new configuration values required by the `enterprise-provisioner`.
- Modifies the template helper for `enterprise-logs.adminTokenSecret` to ensure backwards compatibility with current deployments
- Adjusts the `job-provisioner` definition, updating the binary path and argument names (for `apiURL` and `tenant`) to align with the `enterprise-provisioner`.
- Adds `securityContext` to the provisioner job to support environments with stricter security requirements.
- Includes `extraVolumes` to allow for the proper mounting of TLS certificates.

**Which issue(s) this PR fixes**:
Fixes #17614

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
