### PR TITLE
fix(otlp): calculate entry metadata size before adding resource/scope attributes

### DIFF
--- a/pkg/loghttp/push/otlp_test.go
+++ b/pkg/loghttp/push/otlp_test.go
@@ -1024,10 +1024,10 @@ func TestOTLPStructuredMetadataCalculation(t *testing.T) {
 		generateLogs(),
 		"test-user",
 		DefaultOTLPConfig(defaultGlobalOTLPConfig),
-		[]string{},
+		nil,        // tenantConfigs
+		[]string{}, // discoverServiceName
 		tracker,
 		stats,
-		false,
 		log.NewNopLogger(),
 		streamResolver,
 	)
@@ -1078,11 +1078,11 @@ func TestNegativeMetadataScenarioExplicit(t *testing.T) {
 	}
 
 	scopeMeta := push.LabelsAdapter{
-		{Name: "scope_key", Value: "scope_value"}, // 21 bytes
+		{Name: "scope_key", Value: "scope_value"}, // 20 bytes
 	}
 
 	entryMeta := push.LabelsAdapter{
-		{Name: "entry_key", Value: "entry_value"}, // 21 bytes
+		{Name: "entry_key", Value: "entry_value"}, // 20 bytes
 	}
 
 	// ExcludedStructuredMetadataLabels would exclude certain labels
@@ -1100,8 +1100,8 @@ func TestNegativeMetadataScenarioExplicit(t *testing.T) {
 
 	// Calculate sizes with simulated exclusions
 	resourceSize := calculateSize(resourceMeta) // 27 bytes (excluded_label not counted)
-	scopeSize := calculateSize(scopeMeta)       // 21 bytes
-	entrySize := calculateSize(entryMeta)       // 21 bytes
+	scopeSize := calculateSize(scopeMeta)       // 20 bytes
+	entrySize := calculateSize(entryMeta)       // 20 bytes
 
 	// The original approach:
 	// 1. Add resource and scope attributes to entry metadata
@@ -1111,13 +1111,13 @@ func TestNegativeMetadataScenarioExplicit(t *testing.T) {
 	combined = append(combined, scopeMeta...)
 
 	// 2. Calculate combined size (with certain labels excluded)
-	combinedSize := calculateSize(combined) // Should be 27 + 21 + 21 = 69 bytes
+	combinedSize := calculateSize(combined) // Should be 27 + 20 + 20 = 67 bytes
 
 	// 3. Calculate entry-specific metadata by subtraction
 	//    metadataSize := int64(combinedSize - resourceSize - scopeSize)
 	oldCalculation := combinedSize - resourceSize - scopeSize
 
-	// Should be: 69 - 27 - 21 = 21 bytes, which equals entrySize
+	// Should be: 67 - 27 - 20 = 20 bytes, which equals entrySize
 
 	t.Logf("Resource size: %d bytes", resourceSize)
 	t.Logf("Scope size: %d bytes", scopeSize)
@@ -1132,7 +1132,7 @@ func TestNegativeMetadataScenarioExplicit(t *testing.T) {
 
 	// Using the original calculation method:
 	simulatedRealCalculation := simulatedRealCombinedSize - resourceSize - scopeSize
-	// This will be: (27 + 21 - 5) - 27 - 21 = 43 - 48 = -5 bytes
+	// This will be: (27 + 20 - 5) - 27 - 20 = 42 - 47 = -5 bytes
 
 	t.Logf("Simulated real combined size: %d bytes", simulatedRealCombinedSize)
 	t.Logf("Simulated real calculation (old method): %d bytes", simulatedRealCalculation)


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the issue where "negative structured metadata bytes received" errors were being logged in Loki when processing OTLP logs.

  ### Problem
  The OTLP processing code was calculating entry-specific metadata size by subtracting resource and scope attribute sizes from the total metadata size after they were already combined. This calculation could result in negative values, which were caught by guard clauses and logged as errors.

  ### Solution
  This PR changes the approach to calculate the entry's metadata size *before* adding resource and scope attributes. This preserves the original intent (tracking entry-specific metadata separately) while ensuring the values are always positive.

  The change maintains the same accounting logic but eliminates the possibility of negative values being passed to Prometheus counters.

  ### Testing
  - Updated tests to reflect the new calculation method
  - Added a specific test case `TestOTLPStructuredMetadataCalculation` to verify structured metadata bytes are always positive

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

N/A

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
