### PR TITLE
fix(querier): fixes panic when filtering agg metrics from nil resp

### DIFF
--- a/pkg/querier/http.go
+++ b/pkg/querier/http.go
@@ -199,7 +199,7 @@ func (q *QuerierAPI) SeriesHandler(ctx context.Context, req *logproto.SeriesRequ
 	logql.RecordSeriesQueryMetrics(ctx, utillog.Logger, req.Start, req.End, req.Groups, strconv.Itoa(status), req.GetShards(), statResult)
 
 	// filter the response to catch the empty matcher case
-	if !aggMetricsRequestedInAnyGroup && q.metricAggregationEnabled(ctx) {
+	if resp != nil && !aggMetricsRequestedInAnyGroup && q.metricAggregationEnabled(ctx) {
 		return q.filterAggregatedMetricsFromSeriesResp(resp), statResult, err
 	}
 

--- a/pkg/querier/http.go
+++ b/pkg/querier/http.go
@@ -188,6 +188,11 @@ func (q *QuerierAPI) SeriesHandler(ctx context.Context, req *logproto.SeriesRequ
 	resLength := 0
 	if resp != nil {
 		resLength = len(resp.Series)
+
+		// filter the response to catch the empty matcher case
+		if !aggMetricsRequestedInAnyGroup && q.metricAggregationEnabled(ctx) {
+			resp = q.filterAggregatedMetricsFromSeriesResp(resp)
+		}
 	}
 
 	statResult := statsCtx.Result(time.Since(start), queueTime, resLength)
@@ -197,11 +202,6 @@ func (q *QuerierAPI) SeriesHandler(ctx context.Context, req *logproto.SeriesRequ
 
 	status, _ := serverutil.ClientHTTPStatusAndError(err)
 	logql.RecordSeriesQueryMetrics(ctx, utillog.Logger, req.Start, req.End, req.Groups, strconv.Itoa(status), req.GetShards(), statResult)
-
-	// filter the response to catch the empty matcher case
-	if resp != nil && !aggMetricsRequestedInAnyGroup && q.metricAggregationEnabled(ctx) {
-		return q.filterAggregatedMetricsFromSeriesResp(resp), statResult, err
-	}
 
 	return resp, statResult, err
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

```
/src/enterprise-logs/vendor/github.com/grafana/loki/v3/pkg/querier/handler.go:58 +0xb55 |  
github.com/grafana/loki/v3/pkg/querier.(*Handler).Do(0xc0028986d8, {0x555c0a8, 0xc000aa7a40}, {0x558c8e0, 0xc0008018f0}) |  
/src/enterprise-logs/vendor/github.com/grafana/loki/v3/pkg/querier/http.go:203 +0x569 |  
github.com/grafana/loki/v3/pkg/querier.(*QuerierAPI).SeriesHandler(_, {_, _}, _) |  
/src/enterprise-logs/vendor/github.com/grafana/loki/v3/pkg/querier/http.go:341 +0x2c |  
github.com/grafana/loki/v3/pkg/querier.(*QuerierAPI).filterAggregatedMetricsFromSeriesResp(0xc0028be370?, 0x0) |  
/usr/local/go/src/runtime/panic.go:792 +0x132
```

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
