### PR TITLE
fix: move the check for duplicate series up the call stack to fix an issue when retention is enabled

### DIFF
--- a/pkg/compactor/deletion/delete_requests_manager.go
+++ b/pkg/compactor/deletion/delete_requests_manager.go
@@ -438,9 +438,6 @@ func (d *DeleteRequestsManager) MarkSeriesAsProcessed(userID, seriesID []byte, l
 			continue
 		}
 		processedSeriesKey := buildProcessedSeriesKey(req.RequestID, req.StartTime, req.EndTime, seriesID, tableName)
-		if _, ok := d.processedSeries[processedSeriesKey]; ok {
-			return fmt.Errorf("series already marked as processed: [table: %s, user: %s, req_id: %s, start: %d, end: %d, series: %s]", tableName, userID, req.RequestID, req.StartTime, req.EndTime, seriesID)
-		}
 		d.processedSeries[processedSeriesKey] = struct{}{}
 	}
 

--- a/pkg/compactor/retention/retention.go
+++ b/pkg/compactor/retention/retention.go
@@ -216,7 +216,13 @@ func markForDelete(
 	iterCtx, cancel := ctxForTimeout(timeout)
 	defer cancel()
 
+	seriesSeen := map[string]struct{}{}
 	err := indexFile.ForEachSeries(iterCtx, func(s Series) error {
+		seriesIDStr := string(s.SeriesID())
+		if _, ok := seriesMap[seriesIDStr]; ok {
+			return fmt.Errorf("series should not be repeated. Series %s already seen earlier", seriesIDStr)
+		}
+		seriesSeen[seriesIDStr] = struct{}{}
 		chunks := s.Chunks()
 		if len(chunks) == 0 {
 			// add the series to series map so that it gets cleaned up


### PR DESCRIPTION
**What this PR does / why we need it**:
Deletion supports saving the progress of a series to be able to skip series which are already been processed. However, it requires all the chunks for a series to be sent at once to make it easier to save the progress.

Since both retention and deletion implement the same interfaces, the table iterator asks them to decide whether a series should be skipped. So, if retention is enabled and it says no to skipping the series while deletion has already processed it, we have to iterate through the chunks in that series again. While deletion still efficiently handles it, at the end, we again try to mark the series as processed, which then triggers the check for duplicate series and fails the operation.

This PR fixes the issue by moving the code to see a series only once in a table up the stack without persisting it. We just want a single series to be seen only once with all its chunks instead of a partial stream seen multiple times.