### PR TITLE
chore: the number of stripes should be independent of the number of partitions

### DIFF
--- a/pkg/limits/store.go
+++ b/pkg/limits/store.go
@@ -7,6 +7,9 @@ import (
 	"github.com/grafana/loki/v3/pkg/limits/proto"
 )
 
+// The number of stripe locks.
+const numStripes = 64
+
 // IterateFunc is a closure called for each stream.
 type IterateFunc func(tenant string, partitionID int32, stream Stream)
 
@@ -52,8 +55,8 @@ type stripeLock struct {
 func NewUsageStore(numPartitions int) *UsageStore {
 	s := &UsageStore{
 		numPartitions: numPartitions,
-		stripes:       make([]map[string]tenantUsage, numPartitions),
-		locks:         make([]stripeLock, numPartitions),
+		stripes:       make([]map[string]tenantUsage, numStripes),
+		locks:         make([]stripeLock, numStripes),
 	}
 	for i := range s.stripes {
 		s.stripes[i] = make(map[string]tenantUsage)


### PR DESCRIPTION
**What this PR does / why we need it**:

The number of stripes should be independent of the number of partitions, as stripes work on tenants rather than partitions.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
