### PR TITLE
fix(helm): allow loki to use hostPath volumes

### DIFF
--- a/production/helm/loki/templates/securitycontextconstraints.yaml
+++ b/production/helm/loki/templates/securitycontextconstraints.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "loki.name" . }}
   labels:
     {{- include "loki.labels" . | nindent 4 }}
-allowHostDirVolumePlugin: false
+allowHostDirVolumePlugin: true
 allowHostIPC: false
 allowHostNetwork: false
 allowHostPID: false


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the `SecurityContextConstraints` helm template. It allows Loki to use HostPath volumes in an OpenShift Environment.

**Which issue(s) this PR fixes**:
Fixes #17679 

**Special notes for your reviewer**:
Feel free to suggest any change!

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
