### PR TITLE
chore: improve duplicate series detection while iterating table for retention/deletion

### DIFF
--- a/pkg/compactor/retention/series.go
+++ b/pkg/compactor/retention/series.go
@@ -72,3 +72,9 @@ func (u userSeriesMap) ForEach(callback func(info userSeriesInfo) error) error {
 	}
 	return nil
 }
+
+func (u userSeriesMap) HasSeries(seriesID, userID []byte) bool {
+	us := newUserSeries(seriesID, userID)
+	_, ok := u[us.Key()]
+	return ok
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Follow up PR for #17663 
We already had a map of series we found while iterating a table, which was used to clean up the series when all its chunks were deleted. I have reused the same map to avoid additional allocations. 

I have also added relevant tests to detect any breaking changes.
