### PR TITLE
chore: fix inconsistent variable names in store.go

### DIFF
--- a/pkg/limits/frontend/ring.go
+++ b/pkg/limits/frontend/ring.go
@@ -62,11 +62,11 @@ func (g *RingGatherer) ExceedsLimits(ctx context.Context, req *proto.ExceedsLimi
 	}
 	ownedStreams := make(map[string][]*proto.StreamMetadata)
 	for _, s := range req.Streams {
-		partitionID := int32(s.StreamHash % uint64(g.numPartitions))
-		addr, ok := partitionConsumers[partitionID]
+		partition := int32(s.StreamHash % uint64(g.numPartitions))
+		addr, ok := partitionConsumers[partition]
 		if !ok {
 			// TODO(grobinson): Drop streams when ok is false.
-			level.Warn(g.logger).Log("msg", "no instance found for partition", "partition", partitionID)
+			level.Warn(g.logger).Log("msg", "no instance found for partition", "partition", partition)
 			continue
 		}
 		ownedStreams[addr] = append(ownedStreams[addr], s)

--- a/pkg/limits/ingest_limits.go
+++ b/pkg/limits/ingest_limits.go
@@ -360,11 +360,11 @@ func (s *IngestLimits) ExceedsLimits(ctx context.Context, req *proto.ExceedsLimi
 	streams := req.Streams
 	valid := 0
 	for _, stream := range streams {
-		partitionID := int32(stream.StreamHash % uint64(s.cfg.NumPartitions))
+		partition := int32(stream.StreamHash % uint64(s.cfg.NumPartitions))
 
 		// TODO(periklis): Do we need to report this as an error to the frontend?
-		if assigned := s.partitionManager.Has(partitionID); !assigned {
-			level.Warn(s.logger).Log("msg", "stream assigned partition not owned by instance", "stream_hash", stream.StreamHash, "partition_id", partitionID)
+		if assigned := s.partitionManager.Has(partition); !assigned {
+			level.Warn(s.logger).Log("msg", "stream assigned partition not owned by instance", "stream_hash", stream.StreamHash, "partition", partition)
 			continue
 		}
 

--- a/pkg/limits/ingest_limits_test.go
+++ b/pkg/limits/ingest_limits_test.go
@@ -25,13 +25,13 @@ func TestIngestLimits_ExceedsLimits(t *testing.T) {
 		name string
 
 		// Setup data.
-		assignedPartitionIDs []int32
-		numPartitions        int
-		usage                *UsageStore
-		windowSize           time.Duration
-		rateWindow           time.Duration
-		bucketDuration       time.Duration
-		maxActiveStreams     int
+		assignedPartitions []int32
+		numPartitions      int
+		usage              *UsageStore
+		windowSize         time.Duration
+		rateWindow         time.Duration
+		bucketDuration     time.Duration
+		maxActiveStreams   int
 
 		// Request data for ExceedsLimits.
 		tenantID string
@@ -45,8 +45,8 @@ func TestIngestLimits_ExceedsLimits(t *testing.T) {
 		{
 			name: "tenant not found",
 			// setup data
-			assignedPartitionIDs: []int32{0},
-			numPartitions:        1,
+			assignedPartitions: []int32{0},
+			numPartitions:      1,
 			usage: &UsageStore{
 				numPartitions: 1,
 				stripes: []map[string]tenantUsage{
@@ -80,8 +80,8 @@ func TestIngestLimits_ExceedsLimits(t *testing.T) {
 		{
 			name: "all existing streams still active",
 			// setup data
-			assignedPartitionIDs: []int32{0},
-			numPartitions:        1,
+			assignedPartitions: []int32{0},
+			numPartitions:      1,
 			usage: &UsageStore{
 				numPartitions: 1,
 				stripes: []map[string]tenantUsage{
@@ -117,8 +117,8 @@ func TestIngestLimits_ExceedsLimits(t *testing.T) {
 		{
 			name: "keep existing active streams and drop new streams",
 			// setup data
-			assignedPartitionIDs: []int32{0},
-			numPartitions:        1,
+			assignedPartitions: []int32{0},
+			numPartitions:      1,
 			usage: &UsageStore{
 				numPartitions: 1,
 				stripes: []map[string]tenantUsage{
@@ -154,8 +154,8 @@ func TestIngestLimits_ExceedsLimits(t *testing.T) {
 		{
 			name: "update existing active streams and drop new streams",
 			// setup data
-			assignedPartitionIDs: []int32{0},
-			numPartitions:        1,
+			assignedPartitions: []int32{0},
+			numPartitions:      1,
 			usage: &UsageStore{
 				numPartitions: 1,
 				stripes: []map[string]tenantUsage{
@@ -195,8 +195,8 @@ func TestIngestLimits_ExceedsLimits(t *testing.T) {
 		{
 			name: "update active streams and re-activate expired streams",
 			// setup data
-			assignedPartitionIDs: []int32{0},
-			numPartitions:        1,
+			assignedPartitions: []int32{0},
+			numPartitions:      1,
 			usage: &UsageStore{
 				numPartitions: 1,
 				stripes: []map[string]tenantUsage{
@@ -234,8 +234,8 @@ func TestIngestLimits_ExceedsLimits(t *testing.T) {
 		{
 			name: "drop streams per partition limit",
 			// setup data
-			assignedPartitionIDs: []int32{0, 1},
-			numPartitions:        2,
+			assignedPartitions: []int32{0, 1},
+			numPartitions:      2,
 			usage: &UsageStore{
 				numPartitions: 2,
 				locks:         make([]stripeLock, 2),
@@ -267,8 +267,8 @@ func TestIngestLimits_ExceedsLimits(t *testing.T) {
 		{
 			name: "skip streams assigned to partitions not owned by instance but enforce limit",
 			// setup data
-			assignedPartitionIDs: []int32{0},
-			numPartitions:        2,
+			assignedPartitions: []int32{0},
+			numPartitions:      2,
 			usage: &UsageStore{
 				numPartitions: 2,
 				locks:         make([]stripeLock, 2),
@@ -339,8 +339,8 @@ func TestIngestLimits_ExceedsLimits(t *testing.T) {
 
 			// Assign the Partition IDs.
 			partitions := make(map[string][]int32)
-			partitions["test"] = make([]int32, 0, len(tt.assignedPartitionIDs))
-			partitions["test"] = append(partitions["test"], tt.assignedPartitionIDs...)
+			partitions["test"] = make([]int32, 0, len(tt.assignedPartitions))
+			partitions["test"] = append(partitions["test"], tt.assignedPartitions...)
 			s.partitionManager.Assign(context.Background(), nil, partitions)
 
 			// Call ExceedsLimits.

--- a/pkg/limits/partition_manager.go
+++ b/pkg/limits/partition_manager.go
@@ -32,21 +32,21 @@ func NewPartitionManager(logger log.Logger) *PartitionManager {
 
 // Assign assigns the partitions and sets the last updated timestamp for each
 // partition to the current time.
-func (m *PartitionManager) Assign(_ context.Context, _ *kgo.Client, partitions map[string][]int32) {
+func (m *PartitionManager) Assign(_ context.Context, _ *kgo.Client, topicPartitions map[string][]int32) {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
-	for _, partitionIDs := range partitions {
-		for _, partitionID := range partitionIDs {
-			m.partitions[partitionID] = m.clock.Now().UnixNano()
+	for _, partitions := range topicPartitions {
+		for _, partition := range partitions {
+			m.partitions[partition] = m.clock.Now().UnixNano()
 		}
 	}
 }
 
 // Has returns true if the partition is assigned, otherwise false.
-func (m *PartitionManager) Has(partitionID int32) bool {
+func (m *PartitionManager) Has(partition int32) bool {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
-	_, ok := m.partitions[partitionID]
+	_, ok := m.partitions[partition]
 	return ok
 }
 
@@ -55,18 +55,18 @@ func (m *PartitionManager) List() map[int32]int64 {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
 	v := make(map[int32]int64)
-	for partitionID, lastUpdated := range m.partitions {
-		v[partitionID] = lastUpdated
+	for partition, lastUpdated := range m.partitions {
+		v[partition] = lastUpdated
 	}
 	return v
 }
 
-func (m *PartitionManager) Remove(_ context.Context, _ *kgo.Client, partitions map[string][]int32) {
+func (m *PartitionManager) Remove(_ context.Context, _ *kgo.Client, topicPartitions map[string][]int32) {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
-	for _, partitionIDs := range partitions {
-		for _, partitionID := range partitionIDs {
-			delete(m.partitions, partitionID)
+	for _, partitions := range topicPartitions {
+		for _, partition := range partitions {
+			delete(m.partitions, partition)
 		}
 	}
 }

--- a/pkg/limits/store.go
+++ b/pkg/limits/store.go
@@ -11,7 +11,7 @@ import (
 const numStripes = 64
 
 // IterateFunc is a closure called for each stream.
-type IterateFunc func(tenant string, partitionID int32, stream Stream)
+type IterateFunc func(tenant string, partition int32, stream Stream)
 
 // CondFunc is a function that is called for each stream passed to StoreCond,
 // and is often used to check if a stream can be stored (for example, with
@@ -70,9 +70,9 @@ func NewUsageStore(numPartitions int) *UsageStore {
 func (s *UsageStore) All(fn IterateFunc) {
 	s.forEachRLock(func(i int) {
 		for tenant, partitions := range s.stripes[i] {
-			for partitionID, partition := range partitions {
-				for _, stream := range partition {
-					fn(tenant, partitionID, stream)
+			for partition, streams := range partitions {
+				for _, stream := range streams {
+					fn(tenant, partition, stream)
 				}
 			}
 		}
@@ -84,9 +84,9 @@ func (s *UsageStore) All(fn IterateFunc) {
 // closure must not make blocking calls while iterating streams.
 func (s *UsageStore) ForTenant(tenant string, fn IterateFunc) {
 	s.withRLock(tenant, func(i int) {
-		for partitionID, partition := range s.stripes[i][tenant] {
-			for _, stream := range partition {
-				fn(tenant, partitionID, stream)
+		for partition, streams := range s.stripes[i][tenant] {
+			for _, stream := range streams {
+				fn(tenant, partition, stream)
 			}
 		}
 	})
@@ -104,40 +104,40 @@ func (s *UsageStore) Update(tenant string, streams []*proto.StreamMetadata, last
 		activeStreams := make(map[int32]int)
 
 		for _, stream := range streams {
-			partitionID := int32(stream.StreamHash % uint64(s.numPartitions))
+			partition := int32(stream.StreamHash % uint64(s.numPartitions))
 
-			if _, ok := s.stripes[i][tenant][partitionID]; !ok {
-				s.stripes[i][tenant][partitionID] = make(map[uint64]Stream)
+			if _, ok := s.stripes[i][tenant][partition]; !ok {
+				s.stripes[i][tenant][partition] = make(map[uint64]Stream)
 			}
 
 			// Count as active streams all streams that are not expired.
-			if _, ok := activeStreams[partitionID]; !ok {
-				for _, stored := range s.stripes[i][tenant][partitionID] {
+			if _, ok := activeStreams[partition]; !ok {
+				for _, stored := range s.stripes[i][tenant][partition] {
 					if stored.LastSeenAt >= cutoff {
-						activeStreams[partitionID]++
+						activeStreams[partition]++
 					}
 				}
 			}
 
-			recorded, found := s.stripes[i][tenant][partitionID][stream.StreamHash]
+			recorded, found := s.stripes[i][tenant][partition][stream.StreamHash]
 
 			// If the stream is new or expired, check if it exceeds the limit.
 			// If limit is not exceeded and the stream is expired, reset the stream.
 			if !found || (recorded.LastSeenAt < cutoff) {
-				activeStreams[partitionID]++
+				activeStreams[partition]++
 
-				if cond != nil && !cond(float64(activeStreams[partitionID]), stream) {
+				if cond != nil && !cond(float64(activeStreams[partition]), stream) {
 					rejected = append(rejected, stream)
 					continue
 				}
 
 				// If the stream is stored and expired, reset the stream
 				if found && recorded.LastSeenAt < cutoff {
-					s.stripes[i][tenant][partitionID][stream.StreamHash] = Stream{Hash: stream.StreamHash, LastSeenAt: lastSeenAt}
+					s.stripes[i][tenant][partition][stream.StreamHash] = Stream{Hash: stream.StreamHash, LastSeenAt: lastSeenAt}
 				}
 			}
 
-			s.storeStream(i, tenant, partitionID, stream.StreamHash, stream.TotalSize, lastSeenAt, bucketStart, bucketCutOff)
+			s.storeStream(i, tenant, partition, stream.StreamHash, stream.TotalSize, lastSeenAt, bucketStart, bucketCutOff)
 
 			stored = append(stored, stream)
 		}
@@ -150,11 +150,11 @@ func (s *UsageStore) Update(tenant string, streams []*proto.StreamMetadata, last
 func (s *UsageStore) Evict(cutoff int64) map[string]int {
 	evicted := make(map[string]int)
 	s.forEachLock(func(i int) {
-		for tenant, streams := range s.stripes[i] {
-			for partitionID, partition := range streams {
-				for streamHash, stream := range partition {
+		for tenant, partitions := range s.stripes[i] {
+			for partition, streams := range partitions {
+				for streamHash, stream := range streams {
 					if stream.LastSeenAt < cutoff {
-						delete(s.stripes[i][tenant][partitionID], streamHash)
+						delete(s.stripes[i][tenant][partition], streamHash)
 						evicted[tenant]++
 					}
 				}
@@ -165,26 +165,26 @@ func (s *UsageStore) Evict(cutoff int64) map[string]int {
 }
 
 // EvictPartitions deletes the usage data for the specified partitions.
-func (s *UsageStore) EvictPartitions(partitions []int32) {
+func (s *UsageStore) EvictPartitions(partitionsToEvict []int32) {
 	s.forEachLock(func(i int) {
-		for tenant, tenantPartitions := range s.stripes[i] {
-			for _, deleteID := range partitions {
-				delete(tenantPartitions, deleteID)
+		for tenant, partitions := range s.stripes[i] {
+			for _, partitionToEvict := range partitionsToEvict {
+				delete(partitions, partitionToEvict)
 			}
-			if len(tenantPartitions) == 0 {
+			if len(partitions) == 0 {
 				delete(s.stripes[i], tenant)
 			}
 		}
 	})
 }
 
-func (s *UsageStore) storeStream(i int, tenant string, partitionID int32, streamHash, recTotalSize uint64, recordTime, bucketStart, bucketCutOff int64) {
+func (s *UsageStore) storeStream(i int, tenant string, partition int32, streamHash, recTotalSize uint64, recordTime, bucketStart, bucketCutOff int64) {
 	// Check if the stream already exists in the metadata
-	recorded, ok := s.stripes[i][tenant][partitionID][streamHash]
+	recorded, ok := s.stripes[i][tenant][partition][streamHash]
 
 	// Create new stream metadata with the initial interval
 	if !ok {
-		s.stripes[i][tenant][partitionID][streamHash] = Stream{
+		s.stripes[i][tenant][partition][streamHash] = Stream{
 			Hash:        streamHash,
 			LastSeenAt:  recordTime,
 			TotalSize:   recTotalSize,
@@ -230,7 +230,7 @@ func (s *UsageStore) storeStream(i int, tenant string, partitionID int32, stream
 
 	recorded.TotalSize = totalSize
 	recorded.RateBuckets = sb
-	s.stripes[i][tenant][partitionID][streamHash] = recorded
+	s.stripes[i][tenant][partition][streamHash] = recorded
 }
 
 // forEachRLock executes fn with a shared lock for each stripe.


### PR DESCRIPTION
**What this PR does / why we need it**:

Got rid of `partitionID` as a variable name, it's not correct.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
