### PR TITLE
feat(lambda-promtail): support fetching credentials from secrets manager or parameter store

### DIFF
--- a/tools/lambda-promtail/go.mod
+++ b/tools/lambda-promtail/go.mod
@@ -7,6 +7,8 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.36.3
 	github.com/aws/aws-sdk-go-v2/config v1.29.14
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.79.3
+	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.35.4
+	github.com/aws/aws-sdk-go-v2/service/ssm v1.59.0
 	github.com/go-kit/log v0.2.1
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang/snappy v1.0.0

--- a/tools/lambda-promtail/go.sum
+++ b/tools/lambda-promtail/go.sum
@@ -83,6 +83,10 @@ github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.18.15 h1:moLQUoVq91Liq
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.18.15/go.mod h1:ZH34PJUc8ApjBIfgQCFvkWcUDBtl/WTD+uiYHjd8igA=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.79.3 h1:BRXS0U76Z8wfF+bnkilA2QwpIch6URlm++yPUt9QPmQ=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.79.3/go.mod h1:bNXKFFyaiVvWuR6O16h/I1724+aXe/tAkA9/QS01t5k=
+github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.35.4 h1:EKXYJ8kgz4fiqef8xApu7eH0eae2SrVG+oHCLFybMRI=
+github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.35.4/go.mod h1:yGhDiLKguA3iFJYxbrQkQiNzuy+ddxesSZYWVeeEH5Q=
+github.com/aws/aws-sdk-go-v2/service/ssm v1.59.0 h1:KWArCwA/WkuHWKfygkNz0B6YS6OvdgoJUaJHX0Qby1s=
+github.com/aws/aws-sdk-go-v2/service/ssm v1.59.0/go.mod h1:PUWUl5MDiYNQkUHN9Pyd9kgtA/YhbxnSnHP+yQqzrM8=
 github.com/aws/aws-sdk-go-v2/service/sso v1.25.3 h1:1Gw+9ajCV1jogloEv1RRnvfRFia2cL6c9cuKV2Ps+G8=
 github.com/aws/aws-sdk-go-v2/service/sso v1.25.3/go.mod h1:qs4a9T5EMLl/Cajiw2TcbNt2UNo/Hqlyp+GiuG4CFDI=
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.30.1 h1:hXmVKytPfTy5axZ+fYbR5d0cFmC3JvwLm5kM83luako=

--- a/tools/lambda-promtail/lambda-promtail/env.go
+++ b/tools/lambda-promtail/lambda-promtail/env.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+	"github.com/aws/aws-sdk-go-v2/service/ssm"
+	"github.com/aws/smithy-go/ptr"
+	"os"
+)
+
+func loadEnv(ctx context.Context, name string) (string, error) {
+	envValue, ok := os.LookupEnv(name)
+	if !ok {
+		return "", fmt.Errorf("environment variable %s not found", name)
+	}
+
+	if arn.IsARN(envValue) {
+		cfg, err := config.LoadDefaultConfig(ctx)
+		if err != nil {
+			return "", fmt.Errorf("error loading aws config: %w", err)
+		}
+
+		parsedArn, err := arn.Parse(envValue)
+		if err != nil {
+			return "", fmt.Errorf("error parsing arn: %w", err)
+		}
+
+		switch parsedArn.Service {
+		case "secretsmanager":
+			client := secretsmanager.NewFromConfig(cfg)
+			out, err := client.GetSecretValue(ctx, &secretsmanager.GetSecretValueInput{
+				SecretId: &envValue,
+			})
+			if err != nil {
+				return "", fmt.Errorf("error fetching secret %s: %w", envValue, err)
+			}
+
+			return *out.SecretString, nil
+		case "ssm":
+			client := ssm.NewFromConfig(cfg)
+			out, err := client.GetParameter(ctx, &ssm.GetParameterInput{
+				Name:           &envValue,
+				WithDecryption: ptr.Bool(true),
+			})
+			if err != nil {
+				return "", fmt.Errorf("error fetching parameter %s: %w", envValue, err)
+			}
+
+			return *out.Parameter.Value, nil
+		default:
+			return "", fmt.Errorf("environment variable %s set to an invalid ARN (unsupported service %s)", name, parsedArn.Service)
+		}
+	}
+
+	return envValue, nil
+}

--- a/tools/lambda-promtail/lambda-promtail/main.go
+++ b/tools/lambda-promtail/lambda-promtail/main.go
@@ -43,7 +43,7 @@ var (
 	relabelConfigs                                                           []*relabel.Config
 )
 
-func setupArguments() {
+func setupArguments(ctx context.Context) {
 	addr := os.Getenv("WRITE_ADDRESS")
 	if addr == "" {
 		panic(errors.New("required environmental variable WRITE_ADDRESS not present, format: https://<hostname>/loki/api/v1/push"))
@@ -69,14 +69,23 @@ func setupArguments() {
 		panic(err)
 	}
 
-	username = os.Getenv("USERNAME")
-	password = os.Getenv("PASSWORD")
+	username, err := loadEnv(ctx, "USERNAME")
+	if err != nil {
+		panic(err)
+	}
+	password, err := loadEnv(ctx, "PASSWORD")
+	if err != nil {
+		panic(err)
+	}
 	// If either username or password is set then both must be.
 	if (username != "" && password == "") || (username == "" && password != "") {
 		panic("both username and password must be set if either one is set")
 	}
 
-	bearerToken = os.Getenv("BEARER_TOKEN")
+	bearerToken, err := loadEnv(ctx, "BEARER_TOKEN")
+	if err != nil {
+		panic(err)
+	}
 	// If username and password are set, bearer token is not allowed
 	if username != "" && bearerToken != "" {
 		panic("both username and bearerToken are not allowed")
@@ -291,6 +300,6 @@ func handler(ctx context.Context, ev map[string]interface{}) error {
 }
 
 func main() {
-	setupArguments()
+	setupArguments(context.Background())
 	lambda.Start(handler)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, lambda-promtail requires that you provide the username/password or bearer token as an environment variable; as these are stored in plaintext this is a security vulnerability.

This PR proposes a way to auto-load these from AWS Secrets Manager or SSM Parameter Store, so that these can be encrypted and rotated without needing to update the lambda deployment directly. Instead of expecting explicit extra env variables (eg, USERNAME_SECRET_ARN) I'm proposing that lambda-promtail just supports setting the existing environment variable to an ARN and it will simply resolve that value.

This is a proof-of-concept; if this is a desired change I can add some unit tests and update the relevant documentation.

**Which issue(s) this PR fixes**:
Fixes #12643

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
