### PR TITLE
chore: remove cutoff from evict

### DIFF
--- a/pkg/limits/service.go
+++ b/pkg/limits/service.go
@@ -131,7 +131,7 @@ func NewIngestLimits(cfg Config, lims Limits, logger log.Logger, reg prometheus.
 	s := &IngestLimits{
 		cfg:              cfg,
 		logger:           logger,
-		usage:            NewUsageStore(cfg.NumPartitions),
+		usage:            NewUsageStore(cfg),
 		metrics:          newMetrics(reg),
 		limits:           lims,
 		partitionManager: NewPartitionManager(logger),
@@ -301,8 +301,7 @@ func (s *IngestLimits) evictOldStreamsPeriodic(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			cutoff := s.clock.Now().Add(-s.cfg.WindowSize).UnixNano()
-			s.usage.Evict(cutoff)
+			s.usage.Evict()
 		}
 	}
 }

--- a/pkg/limits/service_test.go
+++ b/pkg/limits/service_test.go
@@ -48,7 +48,7 @@ func TestIngestLimits_ExceedsLimits(t *testing.T) {
 			assignedPartitions: []int32{0},
 			numPartitions:      1,
 			usage: &UsageStore{
-				numPartitions: 1,
+				cfg: Config{NumPartitions: 1},
 				stripes: []map[string]tenantUsage{
 					{
 						"tenant1": {
@@ -83,7 +83,7 @@ func TestIngestLimits_ExceedsLimits(t *testing.T) {
 			assignedPartitions: []int32{0},
 			numPartitions:      1,
 			usage: &UsageStore{
-				numPartitions: 1,
+				cfg: Config{NumPartitions: 1},
 				stripes: []map[string]tenantUsage{
 					{
 						"tenant1": {
@@ -120,7 +120,7 @@ func TestIngestLimits_ExceedsLimits(t *testing.T) {
 			assignedPartitions: []int32{0},
 			numPartitions:      1,
 			usage: &UsageStore{
-				numPartitions: 1,
+				cfg: Config{NumPartitions: 1},
 				stripes: []map[string]tenantUsage{
 					{
 						"tenant1": {
@@ -157,7 +157,7 @@ func TestIngestLimits_ExceedsLimits(t *testing.T) {
 			assignedPartitions: []int32{0},
 			numPartitions:      1,
 			usage: &UsageStore{
-				numPartitions: 1,
+				cfg: Config{NumPartitions: 1},
 				stripes: []map[string]tenantUsage{
 					{
 						"tenant1": {
@@ -198,7 +198,7 @@ func TestIngestLimits_ExceedsLimits(t *testing.T) {
 			assignedPartitions: []int32{0},
 			numPartitions:      1,
 			usage: &UsageStore{
-				numPartitions: 1,
+				cfg: Config{NumPartitions: 1},
 				stripes: []map[string]tenantUsage{
 					{
 						"tenant1": {
@@ -237,8 +237,8 @@ func TestIngestLimits_ExceedsLimits(t *testing.T) {
 			assignedPartitions: []int32{0, 1},
 			numPartitions:      2,
 			usage: &UsageStore{
-				numPartitions: 2,
-				locks:         make([]stripeLock, 2),
+				cfg:   Config{NumPartitions: 2},
+				locks: make([]stripeLock, 2),
 				stripes: []map[string]tenantUsage{
 					make(map[string]tenantUsage),
 					make(map[string]tenantUsage),
@@ -270,8 +270,8 @@ func TestIngestLimits_ExceedsLimits(t *testing.T) {
 			assignedPartitions: []int32{0},
 			numPartitions:      2,
 			usage: &UsageStore{
-				numPartitions: 2,
-				locks:         make([]stripeLock, 2),
+				cfg:   Config{NumPartitions: 1},
+				locks: make([]stripeLock, 2),
 				stripes: []map[string]tenantUsage{
 					make(map[string]tenantUsage),
 					make(map[string]tenantUsage),
@@ -381,7 +381,7 @@ func TestIngestLimits_ExceedsLimits_Concurrent(t *testing.T) {
 
 	// Setup test data with a mix of active and expired streams>
 	usage := &UsageStore{
-		numPartitions: 1,
+		cfg: Config{NumPartitions: 1},
 		stripes: []map[string]tenantUsage{
 			{
 				"tenant1": {

--- a/pkg/limits/store_bench_test.go
+++ b/pkg/limits/store_bench_test.go
@@ -49,7 +49,7 @@ func BenchmarkUsageStore_Store(b *testing.B) {
 	}
 
 	for _, bm := range benchmarks {
-		s := NewUsageStore(bm.numPartitions)
+		s := NewUsageStore(Config{NumPartitions: bm.numPartitions})
 
 		b.Run(fmt.Sprintf("%s_create", bm.name), func(b *testing.B) {
 			now := time.Now()
@@ -97,7 +97,7 @@ func BenchmarkUsageStore_Store(b *testing.B) {
 			}
 		})
 
-		s = NewUsageStore(bm.numPartitions)
+		s = NewUsageStore(Config{NumPartitions: bm.numPartitions})
 
 		// Run parallel benchmark
 		b.Run(bm.name+"_create_parallel", func(b *testing.B) {

--- a/pkg/limits/store_test.go
+++ b/pkg/limits/store_test.go
@@ -212,8 +212,8 @@ func TestUsageStore_Evict(t *testing.T) {
 		actual[tenant] = append(actual[tenant], stream)
 	})
 	expected := map[string][]Stream{
-		"tenant1": []Stream{s1},
-		"tenant2": []Stream{s3, s4},
+		"tenant1": {s1},
+		"tenant2": {s3, s4},
 	}
 	require.Equal(t, expected, actual)
 }

--- a/pkg/limits/store_test.go
+++ b/pkg/limits/store_test.go
@@ -211,11 +211,16 @@ func TestUsageStore_Evict(t *testing.T) {
 	s.All(func(tenant string, _ int32, stream Stream) {
 		actual[tenant] = append(actual[tenant], stream)
 	})
+	// We can't use require.Equal as [All] iterates streams in a non-deterministic
+	// order. Instead use ElementsMatch for each expected tenant.
 	expected := map[string][]Stream{
 		"tenant1": {s1},
 		"tenant2": {s3, s4},
 	}
-	require.Equal(t, expected, actual)
+	require.Len(t, actual, len(expected))
+	for tenant := range expected {
+		require.ElementsMatch(t, expected[tenant], actual[tenant])
+	}
 }
 
 func TestUsageStore_EvictPartitions(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

The `WindowSize` is a limits wide configuration (see `config.go`). The configuration should be stored in `UsageStore` instead of being passed to each method. This commit updates the `Evict` method to read from the configuration instead.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
