### PR TITLE
chore: remove cutoff etc from [UsageStore.Update]

### DIFF
--- a/pkg/limits/store_bench_test.go
+++ b/pkg/limits/store_bench_test.go
@@ -43,9 +43,9 @@ func BenchmarkUsageStore_Store(b *testing.B) {
 
 	for _, bm := range benchmarks {
 		s := NewUsageStore(Config{
-			NumPartitions: bm.numPartitions,
-			WindowSize: time.Hour,
-			RateWindow: 5 * time.Minute,
+			NumPartitions:  bm.numPartitions,
+			WindowSize:     time.Hour,
+			RateWindow:     5 * time.Minute,
 			BucketDuration: time.Minute,
 		})
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit removes cutoff and other arguments from `[UsageStore.Update]` as these are limits wide configurations (see `config.go`). This is needed for the `PlaybackManager` so it can call Update without having to pass all these extra parameters.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
