### PR TITLE
chore: add PartitionLifecycler to manage assignment and revocation

### DIFF
--- a/pkg/limits/partition_lifecycler.go
+++ b/pkg/limits/partition_lifecycler.go
@@ -1,0 +1,45 @@
+package limits
+
+import (
+	"context"
+
+	"github.com/go-kit/log"
+	"github.com/twmb/franz-go/pkg/kgo"
+)
+
+// PartitionLifecycler manages assignment and revocation of partitions.
+type PartitionLifecycler struct {
+	partitionManager *PartitionManager
+	usage            *UsageStore
+	logger           log.Logger
+}
+
+// NewPartitionLifecycler returns a new PartitionLifecycler.
+func NewPartitionLifecycler(partitionManager *PartitionManager, usage *UsageStore, logger log.Logger) *PartitionLifecycler {
+	return &PartitionLifecycler{
+		partitionManager: partitionManager,
+		usage:            usage,
+		logger:           log.With(logger, "component", "limits.PartitionLifecycler"),
+	}
+}
+
+// Assign implements kgo.OnPartitionsAssigned.
+func (l *PartitionLifecycler) Assign(ctx context.Context, _ *kgo.Client, topics map[string][]int32) {
+	// We expect the client to just consume one topic.
+	// TODO(grobinson): Figure out what to do if this is not the case.
+	for _, partitions := range topics {
+		l.partitionManager.Assign(ctx, partitions)
+		return
+	}
+}
+
+// Revoke implements kgo.OnPartitionsRevoked.
+func (l *PartitionLifecycler) Revoke(ctx context.Context, _ *kgo.Client, topics map[string][]int32) {
+	// We expect the client to just consume one topic.
+	// TODO(grobinson): Figure out what to do if this is not the case.
+	for _, partitions := range topics {
+		l.partitionManager.Revoke(ctx, partitions)
+		l.usage.EvictPartitions(partitions)
+		return
+	}
+}

--- a/pkg/limits/partition_manager_test.go
+++ b/pkg/limits/partition_manager_test.go
@@ -17,9 +17,7 @@ func TestPartitionManager_Assign(t *testing.T) {
 	// Advance the clock so we compare with a time that is not the default
 	// value.
 	c.Advance(1)
-	m.Assign(context.Background(), nil, map[string][]int32{
-		"foo": {1, 2, 3},
-	})
+	m.Assign(context.Background(), []int32{1, 2, 3})
 	// Assert that the partitions were assigned and the timestamps are set to
 	// the current time.
 	now := c.Now().UnixNano()
@@ -32,9 +30,7 @@ func TestPartitionManager_Assign(t *testing.T) {
 	// partition #4. We expect the updated timestamp is equal to the advanced
 	// time.
 	c.Advance(1)
-	m.Assign(context.Background(), nil, map[string][]int32{
-		"foo": {3, 4},
-	})
+	m.Assign(context.Background(), []int32{3, 4})
 	later := c.Now().UnixNano()
 	require.Equal(t, map[int32]int64{
 		1: now,
@@ -48,9 +44,7 @@ func TestPartitionManager_Has(t *testing.T) {
 	m := NewPartitionManager(log.NewNopLogger())
 	c := quartz.NewMock(t)
 	m.clock = c
-	m.Assign(context.Background(), nil, map[string][]int32{
-		"foo": {1, 2, 3},
-	})
+	m.Assign(context.Background(), []int32{1, 2, 3})
 	require.True(t, m.Has(1))
 	require.True(t, m.Has(2))
 	require.True(t, m.Has(3))
@@ -64,9 +58,7 @@ func TestPartitionManager_List(t *testing.T) {
 	// Advance the clock so we compare with a time that is not the default
 	// value.
 	c.Advance(1)
-	m.Assign(context.Background(), nil, map[string][]int32{
-		"foo": {1, 2, 3},
-	})
+	m.Assign(context.Background(), []int32{1, 2, 3})
 	now := c.Now().UnixNano()
 	result := m.List()
 	require.Equal(t, map[int32]int64{
@@ -81,13 +73,11 @@ func TestPartitionManager_List(t *testing.T) {
 	require.NotEqual(t, p1, p2)
 }
 
-func TestPartitionManager_Remove(t *testing.T) {
+func TestPartitionManager_Revoke(t *testing.T) {
 	m := NewPartitionManager(log.NewNopLogger())
 	c := quartz.NewMock(t)
 	m.clock = c
-	m.Assign(context.Background(), nil, map[string][]int32{
-		"foo": {1, 2, 3},
-	})
+	m.Assign(context.Background(), []int32{1, 2, 3})
 	// Assert that the partitions were assigned and the timestamps are set to
 	// the current time.
 	now := c.Now().UnixNano()
@@ -96,10 +86,8 @@ func TestPartitionManager_Remove(t *testing.T) {
 		2: now,
 		3: now,
 	}, m.partitions)
-	// Remove partitions 2 and 3.
-	m.Remove(context.Background(), nil, map[string][]int32{
-		"foo": {2, 3},
-	})
+	// Revoke partitions 2 and 3.
+	m.Revoke(context.Background(), []int32{2, 3})
 	require.Equal(t, map[int32]int64{
 		1: now,
 	}, m.partitions)

--- a/pkg/limits/service_test.go
+++ b/pkg/limits/service_test.go
@@ -338,10 +338,7 @@ func TestIngestLimits_ExceedsLimits(t *testing.T) {
 			}
 
 			// Assign the Partition IDs.
-			partitions := make(map[string][]int32)
-			partitions["test"] = make([]int32, 0, len(tt.assignedPartitions))
-			partitions["test"] = append(partitions["test"], tt.assignedPartitions...)
-			s.partitionManager.Assign(context.Background(), nil, partitions)
+			s.partitionManager.Assign(context.Background(), tt.assignedPartitions)
 
 			// Call ExceedsLimits.
 			req := &proto.ExceedsLimitsRequest{
@@ -429,8 +426,7 @@ func TestIngestLimits_ExceedsLimits_Concurrent(t *testing.T) {
 	}
 
 	// Assign the Partition IDs.
-	partitions := map[string][]int32{"tenant1": {0}}
-	s.partitionManager.Assign(context.Background(), nil, partitions)
+	s.partitionManager.Assign(context.Background(), []int32{0})
 
 	// Run concurrent requests
 	concurrency := 10


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a new `PartitionLifecycler` to manage assignment and revocation of partitions. This will be used in future to also check offsets.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
