### PR TITLE
chore(engine): Make literals simple types

### DIFF
--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -55,8 +55,8 @@ func createRecord(t *testing.T, schema *arrow.Schema, data [][]interface{}) arro
 }
 
 func TestConvertArrowRecordsToLokiResult(t *testing.T) {
-	mdTypeLabel := datatype.ColumnMetadata(types.ColumnTypeLabel, datatype.String)
-	mdTypeMetadata := datatype.ColumnMetadata(types.ColumnTypeMetadata, datatype.String)
+	mdTypeLabel := datatype.ColumnMetadata(types.ColumnTypeLabel, datatype.LokiType.String)
+	mdTypeMetadata := datatype.ColumnMetadata(types.ColumnTypeMetadata, datatype.LokiType.String)
 
 	t.Run("rows without log line, timestamp, or labels are ignored", func(t *testing.T) {
 		schema := arrow.NewSchema(

--- a/pkg/engine/executor/dataobjscan_predicate.go
+++ b/pkg/engine/executor/dataobjscan_predicate.go
@@ -135,7 +135,7 @@ func (m *timestampPredicateMapper) verify(expr physical.Expression) error {
 		if !okRHS {
 			return fmt.Errorf("invalid RHS for comparison: expected literal timestamp, got %T", binop.Right)
 		}
-		if rhsLit.ValueType() != datatype.Timestamp {
+		if rhsLit.ValueType() != datatype.LokiType.Timestamp {
 			return fmt.Errorf("unsupported literal type for RHS: %s, expected timestamp", rhsLit.ValueType())
 		}
 		return nil
@@ -191,11 +191,12 @@ func (m *timestampPredicateMapper) rebound(op types.BinaryOp, rightExpr physical
 		return fmt.Errorf("internal error: rebound expected LiteralExpr, got %T for: %s", rightExpr, rightExpr.String())
 	}
 
-	if literalExpr.ValueType() != datatype.Timestamp {
+	if literalExpr.ValueType() != datatype.LokiType.Timestamp {
 		// Also should be caught by verify.
 		return fmt.Errorf("internal error: unsupported literal type in rebound: %s, expected timestamp", literalExpr.ValueType())
 	}
-	val := literalExpr.Literal.(*datatype.TimestampLiteral).Value()
+	v := literalExpr.Literal.(datatype.TimestampLiteral).Value()
+	val := time.Unix(0, int64(v)).UTC()
 
 	switch op {
 	case types.BinaryOpEq: // ts == val
@@ -294,10 +295,10 @@ func mapMetadataPredicate(expr physical.Expression) (dataobj.LogsPredicate, erro
 			if !ok { // Should not happen
 				return nil, fmt.Errorf("RHS of EQ metadata predicate failed to cast to LiteralExpr")
 			}
-			if rightLiteral.ValueType() != datatype.String {
+			if rightLiteral.ValueType() != datatype.LokiType.String {
 				return nil, fmt.Errorf("unsupported RHS literal type (%v) for EQ metadata predicate, expected ValueTypeStr", rightLiteral.ValueType())
 			}
-			val := rightLiteral.Literal.(*datatype.StringLiteral).Value()
+			val := rightLiteral.Literal.(datatype.StringLiteral).Value()
 
 			return dataobj.MetadataMatcherPredicate{
 				Key:   leftColumn.Ref.Column,

--- a/pkg/engine/executor/dataobjscan_predicate_test.go
+++ b/pkg/engine/executor/dataobjscan_predicate_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/loki/v3/pkg/dataobj"
+	"github.com/grafana/loki/v3/pkg/engine/internal/datatype"
 	"github.com/grafana/loki/v3/pkg/engine/internal/types"
 	"github.com/grafana/loki/v3/pkg/engine/planner/physical"
 )
@@ -30,6 +31,10 @@ func tsColExpr() *physical.ColumnExpr {
 	return newColumnExpr(types.ColumnNameBuiltinTimestamp, types.ColumnTypeBuiltin)
 }
 
+func ts(t time.Time) datatype.Timestamp {
+	return datatype.Timestamp(t.UnixNano())
+}
+
 func TestMapTimestampPredicate(t *testing.T) {
 	time100 := time.Unix(0, 100).UTC()
 	time200 := time.Unix(0, 200).UTC()
@@ -46,7 +51,7 @@ func TestMapTimestampPredicate(t *testing.T) {
 			expr: &physical.BinaryExpr{
 				Left:  tsColExpr(),
 				Op:    types.BinaryOpEq,
-				Right: physical.NewLiteral(time100),
+				Right: physical.NewLiteral(ts(time100)),
 			},
 			want: dataobj.TimeRangePredicate[dataobj.LogsPredicate]{
 				StartTime:    time100,
@@ -60,7 +65,7 @@ func TestMapTimestampPredicate(t *testing.T) {
 			expr: &physical.BinaryExpr{
 				Left:  tsColExpr(),
 				Op:    types.BinaryOpGt,
-				Right: physical.NewLiteral(time100),
+				Right: physical.NewLiteral(ts(time100)),
 			},
 			want: dataobj.TimeRangePredicate[dataobj.LogsPredicate]{
 				StartTime:    time100,
@@ -74,7 +79,7 @@ func TestMapTimestampPredicate(t *testing.T) {
 			expr: &physical.BinaryExpr{
 				Left:  tsColExpr(),
 				Op:    types.BinaryOpGte,
-				Right: physical.NewLiteral(time100),
+				Right: physical.NewLiteral(ts(time100)),
 			},
 			want: dataobj.TimeRangePredicate[dataobj.LogsPredicate]{
 				StartTime:    time100,
@@ -88,7 +93,7 @@ func TestMapTimestampPredicate(t *testing.T) {
 			expr: &physical.BinaryExpr{
 				Left:  tsColExpr(),
 				Op:    types.BinaryOpLt,
-				Right: physical.NewLiteral(time100),
+				Right: physical.NewLiteral(ts(time100)),
 			},
 			want: dataobj.TimeRangePredicate[dataobj.LogsPredicate]{
 				StartTime:    testOpenStart,
@@ -102,7 +107,7 @@ func TestMapTimestampPredicate(t *testing.T) {
 			expr: &physical.BinaryExpr{
 				Left:  tsColExpr(),
 				Op:    types.BinaryOpLte,
-				Right: physical.NewLiteral(time100),
+				Right: physical.NewLiteral(ts(time100)),
 			},
 			want: dataobj.TimeRangePredicate[dataobj.LogsPredicate]{
 				StartTime:    testOpenStart,
@@ -119,7 +124,7 @@ func TestMapTimestampPredicate(t *testing.T) {
 				Right: &physical.BinaryExpr{
 					Left:  tsColExpr(),
 					Op:    types.BinaryOpLt,
-					Right: physical.NewLiteral(time100),
+					Right: physical.NewLiteral(ts(time100)),
 				},
 			},
 			errMatch: "invalid RHS for comparison: expected literal timestamp, got *physical.BinaryExpr",
@@ -135,7 +140,7 @@ func TestMapTimestampPredicate(t *testing.T) {
 					Right: &physical.BinaryExpr{
 						Left:  tsColExpr(),
 						Op:    types.BinaryOpLte,
-						Right: physical.NewLiteral(time200),
+						Right: physical.NewLiteral(ts(time200)),
 					},
 				},
 			},
@@ -143,15 +148,15 @@ func TestMapTimestampPredicate(t *testing.T) {
 		},
 		{
 			desc:     "input is not BinaryExpr",
-			expr:     physical.NewLiteral(time100),
+			expr:     physical.NewLiteral(ts(time100)),
 			errMatch: "unsupported expression type for timestamp predicate: *physical.LiteralExpr, expected *physical.BinaryExpr",
 		},
 		{
 			desc: "LHS of BinaryExpr is not ColumnExpr",
 			expr: &physical.BinaryExpr{
-				Left:  physical.NewLiteral(time100),
+				Left:  physical.NewLiteral(ts(time100)),
 				Op:    types.BinaryOpEq,
-				Right: physical.NewLiteral(time200),
+				Right: physical.NewLiteral(ts(time200)),
 			},
 			errMatch: "invalid LHS for comparison: expected timestamp column, got 1970-01-01T00:00:00.0000001Z",
 		},
@@ -160,7 +165,7 @@ func TestMapTimestampPredicate(t *testing.T) {
 			expr: &physical.BinaryExpr{
 				Left:  newColumnExpr("other_col", types.ColumnTypeBuiltin),
 				Op:    types.BinaryOpEq,
-				Right: physical.NewLiteral(time100),
+				Right: physical.NewLiteral(ts(time100)),
 			},
 			errMatch: "invalid LHS for comparison: expected timestamp column, got builtin.other_col",
 		},
@@ -187,7 +192,7 @@ func TestMapTimestampPredicate(t *testing.T) {
 			expr: &physical.BinaryExpr{
 				Left:  tsColExpr(),
 				Op:    types.BinaryOpAnd,
-				Right: physical.NewLiteral(time100),
+				Right: physical.NewLiteral(ts(time100)),
 			},
 			errMatch: "invalid left operand for AND: unsupported expression type for timestamp predicate: *physical.ColumnExpr, expected *physical.BinaryExpr",
 		},
@@ -199,7 +204,7 @@ func TestMapTimestampPredicate(t *testing.T) {
 				Right: &physical.BinaryExpr{
 					Left:  tsColExpr(),
 					Op:    types.BinaryOpGt,
-					Right: physical.NewLiteral(time100),
+					Right: physical.NewLiteral(ts(time100)),
 				},
 			},
 			errMatch: "unsupported operator for timestamp predicate: OR",
@@ -210,13 +215,13 @@ func TestMapTimestampPredicate(t *testing.T) {
 				Left: &physical.BinaryExpr{
 					Left:  tsColExpr(),
 					Op:    types.BinaryOpGt,
-					Right: physical.NewLiteral(time100),
+					Right: physical.NewLiteral(ts(time100)),
 				},
 				Op: types.BinaryOpAnd,
 				Right: &physical.BinaryExpr{
 					Left:  tsColExpr(),
 					Op:    types.BinaryOpLt,
-					Right: physical.NewLiteral(time200),
+					Right: physical.NewLiteral(ts(time200)),
 				},
 			},
 			want: dataobj.TimeRangePredicate[dataobj.LogsPredicate]{
@@ -232,13 +237,13 @@ func TestMapTimestampPredicate(t *testing.T) {
 				Left: &physical.BinaryExpr{
 					Left:  tsColExpr(),
 					Op:    types.BinaryOpGte,
-					Right: physical.NewLiteral(time100),
+					Right: physical.NewLiteral(ts(time100)),
 				},
 				Op: types.BinaryOpAnd,
 				Right: &physical.BinaryExpr{
 					Left:  tsColExpr(),
 					Op:    types.BinaryOpLte,
-					Right: physical.NewLiteral(time200),
+					Right: physical.NewLiteral(ts(time200)),
 				},
 			},
 			want: dataobj.TimeRangePredicate[dataobj.LogsPredicate]{
@@ -254,13 +259,13 @@ func TestMapTimestampPredicate(t *testing.T) {
 				Left: &physical.BinaryExpr{
 					Left:  tsColExpr(),
 					Op:    types.BinaryOpGte,
-					Right: physical.NewLiteral(time100),
+					Right: physical.NewLiteral(ts(time100)),
 				},
 				Op: types.BinaryOpAnd,
 				Right: &physical.BinaryExpr{
 					Left:  tsColExpr(),
 					Op:    types.BinaryOpLt,
-					Right: physical.NewLiteral(time100),
+					Right: physical.NewLiteral(ts(time100)),
 				},
 			},
 			errMatch: "impossible time range: start_time (1970-01-01 00:00:00.0000001 +0000 UTC) equals end_time (1970-01-01 00:00:00.0000001 +0000 UTC) but the range is exclusive",
@@ -271,13 +276,13 @@ func TestMapTimestampPredicate(t *testing.T) {
 				Left: &physical.BinaryExpr{
 					Left:  tsColExpr(),
 					Op:    types.BinaryOpGt,
-					Right: physical.NewLiteral(time100),
+					Right: physical.NewLiteral(ts(time100)),
 				},
 				Op: types.BinaryOpAnd,
 				Right: &physical.BinaryExpr{
 					Left:  tsColExpr(),
 					Op:    types.BinaryOpLte,
-					Right: physical.NewLiteral(time100),
+					Right: physical.NewLiteral(ts(time100)),
 				},
 			},
 			errMatch: "impossible time range: start_time (1970-01-01 00:00:00.0000001 +0000 UTC) equals end_time (1970-01-01 00:00:00.0000001 +0000 UTC) but the range is exclusive",
@@ -288,13 +293,13 @@ func TestMapTimestampPredicate(t *testing.T) {
 				Left: &physical.BinaryExpr{
 					Left:  tsColExpr(),
 					Op:    types.BinaryOpGte,
-					Right: physical.NewLiteral(time100),
+					Right: physical.NewLiteral(ts(time100)),
 				},
 				Op: types.BinaryOpAnd,
 				Right: &physical.BinaryExpr{
 					Left:  tsColExpr(),
 					Op:    types.BinaryOpLte,
-					Right: physical.NewLiteral(time100),
+					Right: physical.NewLiteral(ts(time100)),
 				},
 			},
 			want: dataobj.TimeRangePredicate[dataobj.LogsPredicate]{
@@ -310,13 +315,13 @@ func TestMapTimestampPredicate(t *testing.T) {
 				Left: &physical.BinaryExpr{
 					Left:  tsColExpr(),
 					Op:    types.BinaryOpEq,
-					Right: physical.NewLiteral(time100),
+					Right: physical.NewLiteral(ts(time100)),
 				},
 				Op: types.BinaryOpAnd,
 				Right: &physical.BinaryExpr{
 					Left:  tsColExpr(),
 					Op:    types.BinaryOpEq,
-					Right: physical.NewLiteral(time200),
+					Right: physical.NewLiteral(ts(time200)),
 				},
 			},
 			errMatch: "impossible time range: start_time (1970-01-01 00:00:00.0000002 +0000 UTC) is after end_time (1970-01-01 00:00:00.0000001 +0000 UTC)",
@@ -327,13 +332,13 @@ func TestMapTimestampPredicate(t *testing.T) {
 				Left: &physical.BinaryExpr{
 					Left:  tsColExpr(),
 					Op:    types.BinaryOpLt,
-					Right: physical.NewLiteral(time100),
+					Right: physical.NewLiteral(ts(time100)),
 				},
 				Op: types.BinaryOpAnd,
 				Right: &physical.BinaryExpr{
 					Left:  tsColExpr(),
 					Op:    types.BinaryOpGt,
-					Right: physical.NewLiteral(time200),
+					Right: physical.NewLiteral(ts(time200)),
 				},
 			},
 			errMatch: "impossible time range: start_time (1970-01-01 00:00:00.0000002 +0000 UTC) is after end_time (1970-01-01 00:00:00.0000001 +0000 UTC)",
@@ -345,20 +350,20 @@ func TestMapTimestampPredicate(t *testing.T) {
 					Left: &physical.BinaryExpr{
 						Left:  tsColExpr(),
 						Op:    types.BinaryOpGt,
-						Right: physical.NewLiteral(time100),
+						Right: physical.NewLiteral(ts(time100)),
 					},
 					Op: types.BinaryOpAnd,
 					Right: &physical.BinaryExpr{
 						Left:  tsColExpr(),
 						Op:    types.BinaryOpLt,
-						Right: physical.NewLiteral(time300),
+						Right: physical.NewLiteral(ts(time300)),
 					},
 				},
 				Op: types.BinaryOpAnd,
 				Right: &physical.BinaryExpr{
 					Left:  tsColExpr(),
 					Op:    types.BinaryOpEq,
-					Right: physical.NewLiteral(time200),
+					Right: physical.NewLiteral(ts(time200)),
 				},
 			},
 			want: dataobj.TimeRangePredicate[dataobj.LogsPredicate]{
@@ -374,13 +379,13 @@ func TestMapTimestampPredicate(t *testing.T) {
 				Left: &physical.BinaryExpr{ // Invalid: LHS not timestamp column
 					Left:  newColumnExpr("not_ts", types.ColumnTypeBuiltin),
 					Op:    types.BinaryOpGt,
-					Right: physical.NewLiteral(time100),
+					Right: physical.NewLiteral(ts(time100)),
 				},
 				Op: types.BinaryOpAnd,
 				Right: &physical.BinaryExpr{
 					Left:  tsColExpr(),
 					Op:    types.BinaryOpLt,
-					Right: physical.NewLiteral(time200),
+					Right: physical.NewLiteral(ts(time200)),
 				},
 			},
 			errMatch: "invalid left operand for AND: invalid LHS for comparison: expected timestamp column, got builtin.not_ts",
@@ -391,7 +396,7 @@ func TestMapTimestampPredicate(t *testing.T) {
 				Left: &physical.BinaryExpr{
 					Left:  tsColExpr(),
 					Op:    types.BinaryOpGt,
-					Right: physical.NewLiteral(time100),
+					Right: physical.NewLiteral(ts(time100)),
 				},
 				Op: types.BinaryOpAnd,
 				Right: &physical.BinaryExpr{ // Invalid: RHS literal not timestamp
@@ -408,13 +413,13 @@ func TestMapTimestampPredicate(t *testing.T) {
 				Left: &physical.BinaryExpr{
 					Left:  tsColExpr(),
 					Op:    types.BinaryOpLt,
-					Right: physical.NewLiteral(time100),
+					Right: physical.NewLiteral(ts(time100)),
 				},
 				Op: types.BinaryOpAnd,
 				Right: &physical.BinaryExpr{
 					Left:  tsColExpr(),
 					Op:    types.BinaryOpLt,
-					Right: physical.NewLiteral(time200),
+					Right: physical.NewLiteral(ts(time200)),
 				},
 			},
 			want: dataobj.TimeRangePredicate[dataobj.LogsPredicate]{
@@ -430,13 +435,13 @@ func TestMapTimestampPredicate(t *testing.T) {
 				Left: &physical.BinaryExpr{
 					Left:  tsColExpr(),
 					Op:    types.BinaryOpLt,
-					Right: physical.NewLiteral(time200),
+					Right: physical.NewLiteral(ts(time200)),
 				},
 				Op: types.BinaryOpAnd,
 				Right: &physical.BinaryExpr{
 					Left:  tsColExpr(),
 					Op:    types.BinaryOpLt,
-					Right: physical.NewLiteral(time100),
+					Right: physical.NewLiteral(ts(time100)),
 				},
 			},
 			want: dataobj.TimeRangePredicate[dataobj.LogsPredicate]{
@@ -619,7 +624,7 @@ func TestMapMetadataPredicate(t *testing.T) {
 			name: "error: RHS literal not string for EQ",
 			expr: &physical.BinaryExpr{
 				Left:  &physical.ColumnExpr{Ref: types.ColumnRef{Column: "foo", Type: types.ColumnTypeMetadata}},
-				Right: physical.NewLiteral(123), // Not string
+				Right: physical.NewLiteral(int64(123)), // Not string
 				Op:    types.BinaryOpEq,
 			},
 			expectedPred: nil,

--- a/pkg/engine/executor/expressions_test.go
+++ b/pkg/engine/executor/expressions_test.go
@@ -17,10 +17,10 @@ import (
 
 var (
 	fields = []arrow.Field{
-		{Name: "name", Type: arrow.BinaryTypes.String, Metadata: datatype.ColumnMetadata(types.ColumnTypeBuiltin, datatype.String)},
-		{Name: "timestamp", Type: arrow.PrimitiveTypes.Int64, Metadata: datatype.ColumnMetadata(types.ColumnTypeBuiltin, datatype.Timestamp)},
-		{Name: "value", Type: arrow.PrimitiveTypes.Float64, Metadata: datatype.ColumnMetadata(types.ColumnTypeBuiltin, datatype.Float)},
-		{Name: "valid", Type: arrow.FixedWidthTypes.Boolean, Metadata: datatype.ColumnMetadata(types.ColumnTypeBuiltin, datatype.Bool)},
+		{Name: "name", Type: arrow.BinaryTypes.String, Metadata: datatype.ColumnMetadata(types.ColumnTypeBuiltin, datatype.LokiType.String)},
+		{Name: "timestamp", Type: arrow.PrimitiveTypes.Int64, Metadata: datatype.ColumnMetadata(types.ColumnTypeBuiltin, datatype.LokiType.Timestamp)},
+		{Name: "value", Type: arrow.PrimitiveTypes.Float64, Metadata: datatype.ColumnMetadata(types.ColumnTypeBuiltin, datatype.LokiType.Float)},
+		{Name: "valid", Type: arrow.FixedWidthTypes.Boolean, Metadata: datatype.ColumnMetadata(types.ColumnTypeBuiltin, datatype.LokiType.Bool)},
 	}
 	sampledata = `Alice,1745487598764058205,0.2586284611568047,false
 Bob,1745487598764058305,0.7823145698741236,true
@@ -38,6 +38,7 @@ func TestEvaluateLiteralExpression(t *testing.T) {
 	for _, tt := range []struct {
 		name      string
 		value     any
+		want      any
 		arrowType arrow.Type
 	}{
 		{
@@ -67,17 +68,17 @@ func TestEvaluateLiteralExpression(t *testing.T) {
 		},
 		{
 			name:      "timestamp",
-			value:     time.Unix(3600, 0).UTC(),
+			value:     datatype.Timestamp(3600000000),
 			arrowType: arrow.INT64,
 		},
 		{
 			name:      "duration",
-			value:     time.Hour,
+			value:     datatype.Duration(3600000000),
 			arrowType: arrow.INT64,
 		},
 		{
 			name:      "bytes",
-			value:     int64(1024),
+			value:     datatype.Bytes(1024),
 			arrowType: arrow.INT64,
 		},
 	} {
@@ -93,7 +94,11 @@ func TestEvaluateLiteralExpression(t *testing.T) {
 
 			for i := range n {
 				val := colVec.Value(i)
-				require.Equal(t, tt.value, val)
+				if tt.want != nil {
+					require.Equal(t, tt.want, val)
+				} else {
+					require.Equal(t, tt.value, val)
+				}
 			}
 		})
 	}

--- a/pkg/engine/executor/filter_test.go
+++ b/pkg/engine/executor/filter_test.go
@@ -15,8 +15,8 @@ import (
 
 func TestNewFilterPipeline(t *testing.T) {
 	fields := []arrow.Field{
-		{Name: "name", Type: arrow.BinaryTypes.String, Metadata: datatype.ColumnMetadata(types.ColumnTypeBuiltin, datatype.String)},
-		{Name: "valid", Type: arrow.FixedWidthTypes.Boolean, Metadata: datatype.ColumnMetadata(types.ColumnTypeBuiltin, datatype.Bool)},
+		{Name: "name", Type: arrow.BinaryTypes.String, Metadata: datatype.ColumnMetadata(types.ColumnTypeBuiltin, datatype.LokiType.String)},
+		{Name: "valid", Type: arrow.FixedWidthTypes.Boolean, Metadata: datatype.ColumnMetadata(types.ColumnTypeBuiltin, datatype.LokiType.Bool)},
 	}
 
 	t.Run("filter with true literal predicate", func(t *testing.T) {

--- a/pkg/engine/executor/project_test.go
+++ b/pkg/engine/executor/project_test.go
@@ -13,9 +13,9 @@ import (
 
 func TestNewProjectPipeline(t *testing.T) {
 	fields := []arrow.Field{
-		{Name: "name", Type: arrow.BinaryTypes.String, Metadata: datatype.ColumnMetadata(types.ColumnTypeBuiltin, datatype.String)},
-		{Name: "age", Type: arrow.PrimitiveTypes.Int64, Metadata: datatype.ColumnMetadata(types.ColumnTypeBuiltin, datatype.Integer)},
-		{Name: "city", Type: arrow.BinaryTypes.String, Metadata: datatype.ColumnMetadata(types.ColumnTypeBuiltin, datatype.String)},
+		{Name: "name", Type: arrow.BinaryTypes.String, Metadata: datatype.ColumnMetadata(types.ColumnTypeBuiltin, datatype.LokiType.String)},
+		{Name: "age", Type: arrow.PrimitiveTypes.Int64, Metadata: datatype.ColumnMetadata(types.ColumnTypeBuiltin, datatype.LokiType.Integer)},
+		{Name: "city", Type: arrow.BinaryTypes.String, Metadata: datatype.ColumnMetadata(types.ColumnTypeBuiltin, datatype.LokiType.String)},
 	}
 
 	t.Run("project single column", func(t *testing.T) {
@@ -42,7 +42,7 @@ func TestNewProjectPipeline(t *testing.T) {
 		// Create expected output
 		expectedCSV := "Alice\nBob\nCharlie"
 		expectedFields := []arrow.Field{
-			{Name: "name", Type: arrow.BinaryTypes.String, Metadata: datatype.ColumnMetadata(types.ColumnTypeBuiltin, datatype.String)},
+			{Name: "name", Type: arrow.BinaryTypes.String, Metadata: datatype.ColumnMetadata(types.ColumnTypeBuiltin, datatype.LokiType.String)},
 		}
 		expectedRecord, err := CSVToArrow(expectedFields, expectedCSV)
 		require.NoError(t, err)
@@ -81,8 +81,8 @@ func TestNewProjectPipeline(t *testing.T) {
 		// Create expected output
 		expectedCSV := "Alice,New York\nBob,Boston\nCharlie,Seattle"
 		expectedFields := []arrow.Field{
-			{Name: "name", Type: arrow.BinaryTypes.String, Metadata: datatype.ColumnMetadata(types.ColumnTypeBuiltin, datatype.String)},
-			{Name: "city", Type: arrow.BinaryTypes.String, Metadata: datatype.ColumnMetadata(types.ColumnTypeBuiltin, datatype.String)},
+			{Name: "name", Type: arrow.BinaryTypes.String, Metadata: datatype.ColumnMetadata(types.ColumnTypeBuiltin, datatype.LokiType.String)},
+			{Name: "city", Type: arrow.BinaryTypes.String, Metadata: datatype.ColumnMetadata(types.ColumnTypeBuiltin, datatype.LokiType.String)},
 		}
 		expectedRecord, err := CSVToArrow(expectedFields, expectedCSV)
 		require.NoError(t, err)
@@ -124,9 +124,9 @@ func TestNewProjectPipeline(t *testing.T) {
 		// Create expected output
 		expectedCSV := "New York,30,Alice\nBoston,25,Bob\nSeattle,35,Charlie"
 		expectedFields := []arrow.Field{
-			{Name: "city", Type: arrow.BinaryTypes.String, Metadata: datatype.ColumnMetadata(types.ColumnTypeBuiltin, datatype.String)},
-			{Name: "age", Type: arrow.PrimitiveTypes.Int64, Metadata: datatype.ColumnMetadata(types.ColumnTypeBuiltin, datatype.Integer)},
-			{Name: "name", Type: arrow.BinaryTypes.String, Metadata: datatype.ColumnMetadata(types.ColumnTypeBuiltin, datatype.String)},
+			{Name: "city", Type: arrow.BinaryTypes.String, Metadata: datatype.ColumnMetadata(types.ColumnTypeBuiltin, datatype.LokiType.String)},
+			{Name: "age", Type: arrow.PrimitiveTypes.Int64, Metadata: datatype.ColumnMetadata(types.ColumnTypeBuiltin, datatype.LokiType.Integer)},
+			{Name: "name", Type: arrow.BinaryTypes.String, Metadata: datatype.ColumnMetadata(types.ColumnTypeBuiltin, datatype.LokiType.String)},
 		}
 		expectedRecord, err := CSVToArrow(expectedFields, expectedCSV)
 		require.NoError(t, err)
@@ -170,8 +170,8 @@ func TestNewProjectPipeline(t *testing.T) {
 
 		// Create expected output also split across multiple records
 		expectedFields := []arrow.Field{
-			{Name: "name", Type: arrow.BinaryTypes.String, Metadata: datatype.ColumnMetadata(types.ColumnTypeBuiltin, datatype.String)},
-			{Name: "age", Type: arrow.PrimitiveTypes.Int64, Metadata: datatype.ColumnMetadata(types.ColumnTypeBuiltin, datatype.Integer)},
+			{Name: "name", Type: arrow.BinaryTypes.String, Metadata: datatype.ColumnMetadata(types.ColumnTypeBuiltin, datatype.LokiType.String)},
+			{Name: "age", Type: arrow.PrimitiveTypes.Int64, Metadata: datatype.ColumnMetadata(types.ColumnTypeBuiltin, datatype.LokiType.Integer)},
 		}
 
 		expected := `

--- a/pkg/engine/executor/util_test.go
+++ b/pkg/engine/executor/util_test.go
@@ -16,7 +16,7 @@ import (
 var (
 	incrementingIntPipeline = newRecordGenerator(
 		arrow.NewSchema([]arrow.Field{
-			{Name: "id", Type: arrow.PrimitiveTypes.Int64, Metadata: datatype.ColumnMetadata(types.ColumnTypeBuiltin, datatype.Integer)},
+			{Name: "id", Type: arrow.PrimitiveTypes.Int64, Metadata: datatype.ColumnMetadata(types.ColumnTypeBuiltin, datatype.LokiType.Integer)},
 		}, nil),
 
 		func(offset, sz int64, schema *arrow.Schema) arrow.Record {
@@ -52,8 +52,8 @@ const (
 func timestampPipeline(start time.Time, order time.Duration) *recordGenerator {
 	return newRecordGenerator(
 		arrow.NewSchema([]arrow.Field{
-			{Name: "id", Type: arrow.PrimitiveTypes.Int64, Metadata: datatype.ColumnMetadata(types.ColumnTypeBuiltin, datatype.Integer)},
-			{Name: "timestamp", Type: arrow.FixedWidthTypes.Timestamp_ns, Metadata: datatype.ColumnMetadata(types.ColumnTypeBuiltin, datatype.Timestamp)},
+			{Name: "id", Type: arrow.PrimitiveTypes.Int64, Metadata: datatype.ColumnMetadata(types.ColumnTypeBuiltin, datatype.LokiType.Integer)},
+			{Name: "timestamp", Type: arrow.FixedWidthTypes.Timestamp_ns, Metadata: datatype.ColumnMetadata(types.ColumnTypeBuiltin, datatype.LokiType.Timestamp)},
 		}, nil),
 
 		func(offset, sz int64, schema *arrow.Schema) arrow.Record {

--- a/pkg/engine/internal/datatype/arrow.go
+++ b/pkg/engine/internal/datatype/arrow.go
@@ -13,14 +13,14 @@ var (
 		Duration  DataType
 		Bytes     DataType
 	}{
-		Null:      Null,
-		Bool:      Bool,
-		String:    String,
-		Integer:   Integer,
-		Float:     Float,
-		Timestamp: Timestamp,
-		Duration:  Duration,
-		Bytes:     Bytes,
+		Null:      tNull{},
+		Bool:      tBool{},
+		String:    tString{},
+		Integer:   tInteger{},
+		Float:     tFloat{},
+		Timestamp: tTimestamp{},
+		Duration:  tDuration{},
+		Bytes:     tBytes{},
 	}
 
 	ArrowType = struct {
@@ -38,30 +38,30 @@ var (
 		String:    arrow.BinaryTypes.String,
 		Integer:   arrow.PrimitiveTypes.Int64,
 		Float:     arrow.PrimitiveTypes.Float64,
-		Timestamp: arrow.PrimitiveTypes.Int64,
+		Timestamp: arrow.FixedWidthTypes.Timestamp_ns,
 		Duration:  arrow.PrimitiveTypes.Int64,
 		Bytes:     arrow.PrimitiveTypes.Int64,
 	}
 
-	ToArrow = map[DataType]arrow.DataType{
-		Null:      ArrowType.Null,
-		Bool:      ArrowType.Bool,
-		String:    ArrowType.String,
-		Integer:   ArrowType.Integer,
-		Float:     ArrowType.Float,
-		Timestamp: ArrowType.Timestamp,
-		Duration:  ArrowType.Duration,
-		Bytes:     ArrowType.Bytes,
-	}
+	// ToArrow = map[DataType]arrow.DataType{
+	// 	Null:      ArrowType.Null,
+	// 	Bool:      ArrowType.Bool,
+	// 	String:    ArrowType.String,
+	// 	Integer:   ArrowType.Integer,
+	// 	Float:     ArrowType.Float,
+	// 	Timestamp: ArrowType.Timestamp,
+	// 	Duration:  ArrowType.Duration,
+	// 	Bytes:     ArrowType.Bytes,
+	// }
 
-	ToLoki = map[arrow.DataType]DataType{
-		ArrowType.Null:      Null,
-		ArrowType.Bool:      Bool,
-		ArrowType.String:    String,
-		ArrowType.Integer:   Integer,
-		ArrowType.Float:     Float,
-		ArrowType.Timestamp: Timestamp,
-		ArrowType.Duration:  Duration,
-		ArrowType.Bytes:     Bytes,
-	}
+	// ToLoki = map[arrow.DataType]DataType{
+	// 	ArrowType.Null:      Null,
+	// 	ArrowType.Bool:      Bool,
+	// 	ArrowType.String:    String,
+	// 	ArrowType.Integer:   Integer,
+	// 	ArrowType.Float:     Float,
+	// 	ArrowType.Timestamp: Timestamp,
+	// 	ArrowType.Duration:  Duration,
+	// 	ArrowType.Bytes:     Bytes,
+	// }
 )

--- a/pkg/engine/internal/datatype/literal.go
+++ b/pkg/engine/internal/datatype/literal.go
@@ -4,189 +4,177 @@ import (
 	"fmt"
 	"strconv"
 	"time"
+
+	"github.com/dustin/go-humanize"
 )
 
 type NullLiteral struct {
 }
 
 // String implements Literal.
-func (n *NullLiteral) String() string {
+func (n NullLiteral) String() string {
 	return "null"
 }
 
 // Type implements Literal.
-func (n *NullLiteral) Type() DataType {
-	return Null
+func (n NullLiteral) Type() DataType {
+	return LokiType.Null
 }
 
 // Any implements Literal.
-func (n *NullLiteral) Any() any {
+func (n NullLiteral) Any() any {
 	return nil
 }
 
-func (n *NullLiteral) Value() any {
+func (n NullLiteral) Value() any {
 	return nil
 }
 
-type BoolLiteral struct {
-	v bool
-}
+type BoolLiteral bool
 
 // String implements Literal.
-func (b *BoolLiteral) String() string {
-	return strconv.FormatBool(b.v)
+func (b BoolLiteral) String() string {
+	return strconv.FormatBool(bool(b))
 }
 
 // Type implements Literal.
-func (b *BoolLiteral) Type() DataType {
-	return Bool
+func (b BoolLiteral) Type() DataType {
+	return LokiType.Bool
 }
 
 // Any implements Literal.
-func (b *BoolLiteral) Any() any {
-	return b.v
+func (b BoolLiteral) Any() any {
+	return b.Value()
 }
 
-func (b *BoolLiteral) Value() bool {
-	return b.v
+func (b BoolLiteral) Value() bool {
+	return bool(b)
 }
 
-type StringLiteral struct {
-	v string
-}
+type StringLiteral string
 
 // String implements Literal.
-func (s *StringLiteral) String() string {
-	return fmt.Sprintf(`"%s"`, s.v)
+func (s StringLiteral) String() string {
+	return fmt.Sprintf(`"%v"`, string(s))
 }
 
 // Type implements Literal.
-func (s *StringLiteral) Type() DataType {
-	return String
+func (s StringLiteral) Type() DataType {
+	return LokiType.String
 }
 
 // Any implements Literal.
-func (s *StringLiteral) Any() any {
-	return s.v
+func (s StringLiteral) Any() any {
+	return s.Value()
 }
 
-func (s *StringLiteral) Value() string {
-	return s.v
+func (s StringLiteral) Value() string {
+	return string(s)
 }
 
-type IntegerLiteral struct {
-	v int64
-}
+type IntegerLiteral int64
 
 // String implements Literal.
-func (i *IntegerLiteral) String() string {
-	return strconv.FormatInt(i.v, 10)
+func (i IntegerLiteral) String() string {
+	return strconv.FormatInt(int64(i), 10)
 }
 
 // Type implements Literal.
-func (i *IntegerLiteral) Type() DataType {
-	return Integer
+func (i IntegerLiteral) Type() DataType {
+	return LokiType.Integer
 }
 
 // Any implements Literal.
-func (i *IntegerLiteral) Any() any {
-	return i.v
+func (i IntegerLiteral) Any() any {
+	return i.Value()
 }
 
-func (i *IntegerLiteral) Value() int64 {
-	return i.v
+func (i IntegerLiteral) Value() int64 {
+	return int64(i)
 }
 
-type FloatLiteral struct {
-	v float64
-}
+type FloatLiteral float64
 
 // String implements Literal.
-func (f *FloatLiteral) String() string {
-	return strconv.FormatFloat(f.v, 'f', -1, 64)
+func (f FloatLiteral) String() string {
+	return strconv.FormatFloat(float64(f), 'f', -1, 64)
 }
 
 // Type implements Literal.
-func (f *FloatLiteral) Type() DataType {
-	return Float
+func (f FloatLiteral) Type() DataType {
+	return LokiType.Float
 }
 
 // Any implements Literal.
-func (f *FloatLiteral) Any() any {
-	return f.v
+func (f FloatLiteral) Any() any {
+	return f.Value()
 }
 
-func (f *FloatLiteral) Value() float64 {
-	return f.v
+func (f FloatLiteral) Value() float64 {
+	return float64(f)
 }
 
-type TimestampLiteral struct {
-	v int64 // unixnano, UTC
-}
+type TimestampLiteral Timestamp
 
 // String implements Literal.
-func (t *TimestampLiteral) String() string {
-	return time.Unix(0, t.v).UTC().Format(time.RFC3339Nano)
+func (t TimestampLiteral) String() string {
+	return time.Unix(0, int64(t.Value())).UTC().Format(time.RFC3339Nano)
 }
 
 // Type implements Literal.
-func (t *TimestampLiteral) Type() DataType {
-	return Timestamp
+func (t TimestampLiteral) Type() DataType {
+	return LokiType.Timestamp
 }
 
 // Any implements Literal.
-func (t *TimestampLiteral) Any() any {
+func (t TimestampLiteral) Any() any {
 	return t.Value()
 }
 
-func (t *TimestampLiteral) Value() time.Time {
-	return time.Unix(0, t.v).UTC()
+func (t TimestampLiteral) Value() Timestamp {
+	return Timestamp(t)
 }
 
-type DurationLiteral struct {
-	v time.Duration
-}
+type DurationLiteral int64
 
 // String implements Literal.
-func (d *DurationLiteral) String() string {
-	return d.v.String()
+func (d DurationLiteral) String() string {
+	return time.Duration(d).String()
 }
 
 // Type implements Literal.
-func (d *DurationLiteral) Type() DataType {
-	return Duration
+func (d DurationLiteral) Type() DataType {
+	return LokiType.Duration
 }
 
 // Any implements Literal.
-func (d *DurationLiteral) Any() any {
-	return d.v
+func (d DurationLiteral) Any() any {
+	return d.Value()
 }
 
-func (d *DurationLiteral) Value() time.Duration {
-	return d.v
+func (d DurationLiteral) Value() Duration {
+	return Duration(d)
 }
 
-type BytesLiteral struct {
-	v int64
-}
+type BytesLiteral Bytes
 
 // String implements Literal.
-func (b *BytesLiteral) String() string {
-	return fmt.Sprintf("%dB", b.v)
+func (b BytesLiteral) String() string {
+	return humanize.IBytes(uint64(b))
 }
 
 // Type implements Literal.
-func (b *BytesLiteral) Type() DataType {
-	return Bytes
+func (b BytesLiteral) Type() DataType {
+	return LokiType.Bytes
 }
 
 // Any implements Literal.
-func (b *BytesLiteral) Any() any {
-	return b.v
+func (b BytesLiteral) Any() any {
+	return b.Value()
 }
 
-func (b *BytesLiteral) Value() int64 {
-	return b.v
+func (b BytesLiteral) Value() Bytes {
+	return Bytes(b)
 }
 
 // Literal is holds a value of [any] typed as [DataType].
@@ -196,45 +184,54 @@ type Literal interface {
 	Type() DataType
 }
 
+type LiteralType interface {
+	any | bool | string | int64 | float64 | Timestamp | Duration | Bytes
+}
+
+type TypedLiteral[T LiteralType] interface {
+	Literal
+	Value() T
+}
+
 var (
-	_ Literal = (*NullLiteral)(nil)
-	_ Literal = (*BoolLiteral)(nil)
-	_ Literal = (*StringLiteral)(nil)
-	_ Literal = (*IntegerLiteral)(nil)
-	_ Literal = (*FloatLiteral)(nil)
-	_ Literal = (*TimestampLiteral)(nil)
-	_ Literal = (*DurationLiteral)(nil)
-	_ Literal = (*BytesLiteral)(nil)
+	_ Literal                 = (*NullLiteral)(nil)
+	_ TypedLiteral[any]       = (*NullLiteral)(nil)
+	_ Literal                 = (*BoolLiteral)(nil)
+	_ TypedLiteral[bool]      = (*BoolLiteral)(nil)
+	_ Literal                 = (*StringLiteral)(nil)
+	_ TypedLiteral[string]    = (*StringLiteral)(nil)
+	_ Literal                 = (*IntegerLiteral)(nil)
+	_ TypedLiteral[int64]     = (*IntegerLiteral)(nil)
+	_ Literal                 = (*FloatLiteral)(nil)
+	_ TypedLiteral[float64]   = (*FloatLiteral)(nil)
+	_ Literal                 = (*TimestampLiteral)(nil)
+	_ TypedLiteral[Timestamp] = (*TimestampLiteral)(nil)
+	_ Literal                 = (*DurationLiteral)(nil)
+	_ TypedLiteral[Duration]  = (*DurationLiteral)(nil)
+	_ Literal                 = (*BytesLiteral)(nil)
+	_ TypedLiteral[Bytes]     = (*BytesLiteral)(nil)
 )
 
-func NewNullLiteral() *NullLiteral {
-	return &NullLiteral{}
+func NewLiteral[T LiteralType](value T) Literal {
+	switch val := any(value).(type) {
+	case bool:
+		return BoolLiteral(val)
+	case string:
+		return StringLiteral(val)
+	case int64:
+		return IntegerLiteral(val)
+	case float64:
+		return FloatLiteral(val)
+	case Timestamp:
+		return TimestampLiteral(val)
+	case Duration:
+		return DurationLiteral(val)
+	case Bytes:
+		return BytesLiteral(val)
+	}
+	panic(fmt.Sprintf("invalid literal value type %T", value))
 }
 
-func NewBoolLiteral(v bool) *BoolLiteral {
-	return &BoolLiteral{v: v}
-}
-
-func NewStringLiteral(v string) *StringLiteral {
-	return &StringLiteral{v: v}
-}
-
-func NewIntegerLiteral(v int64) *IntegerLiteral {
-	return &IntegerLiteral{v: v}
-}
-
-func NewFloatLiteral(v float64) *FloatLiteral {
-	return &FloatLiteral{v: v}
-}
-
-func NewTimestampLiteral(v time.Time) *TimestampLiteral {
-	return &TimestampLiteral{v: v.UTC().UnixNano()}
-}
-
-func NewDurationLiteral(v time.Duration) *DurationLiteral {
-	return &DurationLiteral{v: v}
-}
-
-func NewBytesLiteral(v int64) *BytesLiteral {
-	return &BytesLiteral{v: v}
+func NewNullLiteral() NullLiteral {
+	return NullLiteral{}
 }

--- a/pkg/engine/internal/datatype/types.go
+++ b/pkg/engine/internal/datatype/types.go
@@ -6,6 +6,10 @@ import (
 	"github.com/apache/arrow-go/v18/arrow"
 )
 
+type Timestamp int64
+type Duration int64
+type Bytes int64
+
 type Type uint8
 
 const (
@@ -38,17 +42,6 @@ type DataType interface {
 	ID() Type
 	ArrowType() arrow.DataType
 }
-
-var (
-	Null      DataType = tNull{}
-	Bool      DataType = tBool{}
-	String    DataType = tString{}
-	Integer   DataType = tInteger{}
-	Float     DataType = tFloat{}
-	Timestamp DataType = tTimestamp{}
-	Duration  DataType = tDuration{}
-	Bytes     DataType = tBytes{}
-)
 
 type tNull struct{}
 
@@ -100,14 +93,14 @@ func (tBytes) ArrowType() arrow.DataType { return ArrowType.Integer }
 
 var (
 	names = map[string]DataType{
-		Null.String():      Null,
-		Bool.String():      Bool,
-		String.String():    String,
-		Integer.String():   Integer,
-		Float.String():     Float,
-		Timestamp.String(): Timestamp,
-		Duration.String():  Duration,
-		Bytes.String():     Bytes,
+		LokiType.Null.String():      LokiType.Null,
+		LokiType.Bool.String():      LokiType.Bool,
+		LokiType.String.String():    LokiType.String,
+		LokiType.Integer.String():   LokiType.Integer,
+		LokiType.Float.String():     LokiType.Float,
+		LokiType.Timestamp.String(): LokiType.Timestamp,
+		LokiType.Duration.String():  LokiType.Duration,
+		LokiType.Bytes.String():     LokiType.Bytes,
 	}
 )
 

--- a/pkg/engine/internal/datatype/util.go
+++ b/pkg/engine/internal/datatype/util.go
@@ -7,8 +7,8 @@ import (
 )
 
 var (
-	ColumnMetadataBuiltinMessage   = ColumnMetadata(types.ColumnTypeBuiltin, String)
-	ColumnMetadataBuiltinTimestamp = ColumnMetadata(types.ColumnTypeBuiltin, Timestamp)
+	ColumnMetadataBuiltinMessage   = ColumnMetadata(types.ColumnTypeBuiltin, LokiType.String)
+	ColumnMetadataBuiltinTimestamp = ColumnMetadata(types.ColumnTypeBuiltin, LokiType.Timestamp)
 )
 
 func ColumnMetadata(ct types.ColumnType, dt DataType) arrow.Metadata {

--- a/pkg/engine/planner/logical/format_tree_test.go
+++ b/pkg/engine/planner/logical/format_tree_test.go
@@ -32,7 +32,7 @@ func TestFormatSimpleQuery(t *testing.T) {
 	).Select(
 		&BinOp{
 			Left:  NewColumnRef("age", types.ColumnTypeMetadata),
-			Right: NewLiteral(21),
+			Right: NewLiteral(int64(21)),
 			Op:    types.BinaryOpGt,
 		},
 	)
@@ -75,7 +75,7 @@ func TestFormatSortQuery(t *testing.T) {
 	).Select(
 		&BinOp{
 			Left:  NewColumnRef("age", types.ColumnTypeMetadata),
-			Right: NewLiteral(21),
+			Right: NewLiteral(int64(21)),
 			Op:    types.BinaryOpGt,
 		},
 	).Sort(*NewColumnRef("age", types.ColumnTypeMetadata), true, false)

--- a/pkg/engine/planner/logical/logical_test.go
+++ b/pkg/engine/planner/logical/logical_test.go
@@ -25,7 +25,7 @@ func TestPlan_String(t *testing.T) {
 	).Select(
 		&BinOp{
 			Left:  NewColumnRef("age", types.ColumnTypeMetadata),
-			Right: NewLiteral(21),
+			Right: NewLiteral(int64(21)),
 			Op:    types.BinaryOpGt,
 		},
 	).Sort(*NewColumnRef("age", types.ColumnTypeMetadata), true, false)

--- a/pkg/engine/planner/logical/node_literal.go
+++ b/pkg/engine/planner/logical/node_literal.go
@@ -1,8 +1,6 @@
 package logical
 
 import (
-	"time"
-
 	"github.com/grafana/loki/v3/pkg/engine/internal/datatype"
 	"github.com/grafana/loki/v3/pkg/engine/planner/schema"
 )
@@ -17,30 +15,11 @@ type Literal struct {
 
 var _ Value = (*Literal)(nil)
 
-func NewLiteral(v any) *Literal {
-	if v == nil {
+func NewLiteral(value datatype.LiteralType) *Literal {
+	if value == nil {
 		return &Literal{Literal: datatype.NewNullLiteral()}
 	}
-
-	switch casted := v.(type) {
-	case bool:
-		return &Literal{Literal: datatype.NewBoolLiteral(casted)}
-	case string:
-		// TODO(chaudum): Try parsing bytes/timestamp/duration
-		return &Literal{Literal: datatype.NewStringLiteral(casted)}
-	case int:
-		return &Literal{Literal: datatype.NewIntegerLiteral(int64(casted))}
-	case int64:
-		return &Literal{Literal: datatype.NewIntegerLiteral(casted)}
-	case float64:
-		return &Literal{Literal: datatype.NewFloatLiteral(casted)}
-	case time.Time:
-		return &Literal{Literal: datatype.NewTimestampLiteral(casted)}
-	case time.Duration:
-		return &Literal{Literal: datatype.NewDurationLiteral(casted)}
-	default:
-		return &Literal{Literal: datatype.NewNullLiteral()}
-	}
+	return &Literal{Literal: datatype.NewLiteral(value)}
 }
 
 // Kind returns the kind of value represented by the literal.

--- a/pkg/engine/planner/logical/planner.go
+++ b/pkg/engine/planner/logical/planner.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/prometheus/prometheus/model/labels"
 
+	"github.com/grafana/loki/v3/pkg/engine/internal/datatype"
 	"github.com/grafana/loki/v3/pkg/engine/internal/types"
 	"github.com/grafana/loki/v3/pkg/logproto"
 	"github.com/grafana/loki/v3/pkg/logql"
@@ -240,12 +241,12 @@ func convertQueryRangeToPredicates(start, end time.Time) []*BinOp {
 	return []*BinOp{
 		{
 			Left:  timestampColumnRef(),
-			Right: NewLiteral(start),
+			Right: NewLiteral(datatype.Timestamp(start.UTC().UnixNano())),
 			Op:    types.BinaryOpGte,
 		},
 		{
 			Left:  timestampColumnRef(),
-			Right: NewLiteral(end),
+			Right: NewLiteral(datatype.Timestamp(end.UTC().UnixNano())),
 			Op:    types.BinaryOpLt,
 		},
 	}

--- a/pkg/engine/planner/physical/context.go
+++ b/pkg/engine/planner/physical/context.go
@@ -121,7 +121,7 @@ func convertLiteralToString(expr Expression) (string, error) {
 	if !ok {
 		return "", fmt.Errorf("expected literal expression, got %T", expr)
 	}
-	if l.ValueType() != datatype.String {
+	if l.ValueType() != datatype.LokiType.String {
 		return "", fmt.Errorf("literal type is not a string, got %v", l.ValueType())
 	}
 	return l.Any().(string), nil

--- a/pkg/engine/planner/physical/context_test.go
+++ b/pkg/engine/planner/physical/context_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/loki/v3/pkg/engine/internal/datatype"
 	"github.com/grafana/loki/v3/pkg/engine/internal/types"
 )
 
@@ -25,15 +26,15 @@ func TestContext_ConvertLiteral(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			expr:    NewLiteral(123),
+			expr:    NewLiteral(int64(123)),
 			wantErr: true,
 		},
 		{
-			expr:    NewLiteral(time.Now()),
+			expr:    NewLiteral(datatype.Timestamp(time.Now().UnixNano())),
 			wantErr: true,
 		},
 		{
-			expr:    NewLiteral(time.Hour),
+			expr:    NewLiteral(datatype.Duration(time.Hour.Nanoseconds())),
 			wantErr: true,
 		},
 		{

--- a/pkg/engine/planner/physical/expressions.go
+++ b/pkg/engine/planner/physical/expressions.go
@@ -2,7 +2,6 @@ package physical
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/grafana/loki/v3/pkg/engine/internal/datatype"
 	"github.com/grafana/loki/v3/pkg/engine/internal/types"
@@ -133,30 +132,11 @@ func (e *LiteralExpr) ValueType() datatype.DataType {
 	return e.Literal.Type()
 }
 
-func NewLiteral(value any) *LiteralExpr {
+func NewLiteral(value datatype.LiteralType) *LiteralExpr {
 	if value == nil {
 		return &LiteralExpr{Literal: datatype.NewNullLiteral()}
 	}
-
-	switch casted := value.(type) {
-	case bool:
-		return &LiteralExpr{Literal: datatype.NewBoolLiteral(casted)}
-	case string:
-		// TODO(chaudum): Try parsing bytes/timestamp/duration
-		return &LiteralExpr{Literal: datatype.NewStringLiteral(casted)}
-	case int:
-		return &LiteralExpr{Literal: datatype.NewIntegerLiteral(int64(casted))}
-	case int64:
-		return &LiteralExpr{Literal: datatype.NewIntegerLiteral(casted)}
-	case float64:
-		return &LiteralExpr{Literal: datatype.NewFloatLiteral(casted)}
-	case time.Time:
-		return &LiteralExpr{Literal: datatype.NewTimestampLiteral(casted)}
-	case time.Duration:
-		return &LiteralExpr{Literal: datatype.NewDurationLiteral(casted)}
-	default:
-		panic(fmt.Sprintf("invalid literal value type %T", value))
-	}
+	return &LiteralExpr{Literal: datatype.NewLiteral(value)}
 }
 
 // ColumnExpr is an expression that implements the [ColumnExpr] interface.

--- a/pkg/engine/planner/physical/expressions_test.go
+++ b/pkg/engine/planner/physical/expressions_test.go
@@ -2,7 +2,6 @@ package physical
 
 import (
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -60,7 +59,7 @@ func TestLiteralExpr(t *testing.T) {
 		require.Equal(t, ExprTypeLiteral, expr.Type())
 		literal, ok := expr.(LiteralExpression)
 		require.True(t, ok)
-		require.Equal(t, datatype.Bool, literal.ValueType())
+		require.Equal(t, datatype.LokiType.Bool, literal.ValueType())
 	})
 
 	t.Run("float", func(t *testing.T) {
@@ -68,7 +67,7 @@ func TestLiteralExpr(t *testing.T) {
 		require.Equal(t, ExprTypeLiteral, expr.Type())
 		literal, ok := expr.(LiteralExpression)
 		require.True(t, ok)
-		require.Equal(t, datatype.Float, literal.ValueType())
+		require.Equal(t, datatype.LokiType.Float, literal.ValueType())
 	})
 
 	t.Run("integer", func(t *testing.T) {
@@ -76,23 +75,31 @@ func TestLiteralExpr(t *testing.T) {
 		require.Equal(t, ExprTypeLiteral, expr.Type())
 		literal, ok := expr.(LiteralExpression)
 		require.True(t, ok)
-		require.Equal(t, datatype.Integer, literal.ValueType())
+		require.Equal(t, datatype.LokiType.Integer, literal.ValueType())
 	})
 
 	t.Run("timestamp", func(t *testing.T) {
-		var expr Expression = NewLiteral(time.Unix(0, 1741882435000000000))
+		var expr Expression = NewLiteral(datatype.Timestamp(1741882435000000000))
 		require.Equal(t, ExprTypeLiteral, expr.Type())
 		literal, ok := expr.(LiteralExpression)
 		require.True(t, ok)
-		require.Equal(t, datatype.Timestamp, literal.ValueType())
+		require.Equal(t, datatype.LokiType.Timestamp, literal.ValueType())
 	})
 
 	t.Run("duration", func(t *testing.T) {
-		var expr Expression = NewLiteral(time.Hour)
+		var expr Expression = NewLiteral(datatype.Duration(3600))
 		require.Equal(t, ExprTypeLiteral, expr.Type())
 		literal, ok := expr.(LiteralExpression)
 		require.True(t, ok)
-		require.Equal(t, datatype.Duration, literal.ValueType())
+		require.Equal(t, datatype.LokiType.Duration, literal.ValueType())
+	})
+
+	t.Run("bytes", func(t *testing.T) {
+		var expr Expression = NewLiteral(datatype.Bytes(1024))
+		require.Equal(t, ExprTypeLiteral, expr.Type())
+		literal, ok := expr.(LiteralExpression)
+		require.True(t, ok)
+		require.Equal(t, datatype.LokiType.Bytes, literal.ValueType())
 	})
 
 	t.Run("string", func(t *testing.T) {
@@ -100,6 +107,6 @@ func TestLiteralExpr(t *testing.T) {
 		require.Equal(t, ExprTypeLiteral, expr.Type())
 		literal, ok := expr.(LiteralExpression)
 		require.True(t, ok)
-		require.Equal(t, datatype.String, literal.ValueType())
+		require.Equal(t, datatype.LokiType.String, literal.ValueType())
 	})
 }

--- a/pkg/engine/planner/physical/optimizer_test.go
+++ b/pkg/engine/planner/physical/optimizer_test.go
@@ -2,10 +2,10 @@ package physical
 
 import (
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/loki/v3/pkg/engine/internal/datatype"
 	"github.com/grafana/loki/v3/pkg/engine/internal/types"
 )
 
@@ -15,7 +15,7 @@ func TestCanApplyPredicate(t *testing.T) {
 		want      bool
 	}{
 		{
-			predicate: NewLiteral(123),
+			predicate: NewLiteral(int64(123)),
 			want:      true,
 		},
 		{
@@ -29,7 +29,7 @@ func TestCanApplyPredicate(t *testing.T) {
 		{
 			predicate: &BinaryExpr{
 				Left:  newColumnExpr("timestamp", types.ColumnTypeBuiltin),
-				Right: NewLiteral(time.Now()),
+				Right: NewLiteral(datatype.Timestamp(3600000)),
 				Op:    types.BinaryOpGt,
 			},
 			want: true,
@@ -51,6 +51,11 @@ func TestCanApplyPredicate(t *testing.T) {
 	}
 }
 
+var (
+	time1000 = datatype.Timestamp(1000000000)
+	time2000 = datatype.Timestamp(2000000000)
+)
+
 func dummyPlan() *Plan {
 	plan := &Plan{}
 	scan1 := plan.addNode(&DataObjScan{id: "scan1"})
@@ -59,14 +64,14 @@ func dummyPlan() *Plan {
 	filter1 := plan.addNode(&Filter{id: "filter1", Predicates: []Expression{
 		&BinaryExpr{
 			Left:  newColumnExpr("timestamp", types.ColumnTypeBuiltin),
-			Right: NewLiteral(time.Unix(0, 1000000000)),
+			Right: NewLiteral(time1000),
 			Op:    types.BinaryOpGt,
 		},
 	}})
 	filter2 := plan.addNode(&Filter{id: "filter2", Predicates: []Expression{
 		&BinaryExpr{
 			Left:  newColumnExpr("timestamp", types.ColumnTypeBuiltin),
-			Right: NewLiteral(time.Unix(0, 2000000000)),
+			Right: NewLiteral(time2000),
 			Op:    types.BinaryOpLte,
 		},
 	}})
@@ -112,24 +117,24 @@ func TestOptimizer(t *testing.T) {
 		scan1 := optimized.addNode(&DataObjScan{id: "scan1", Predicates: []Expression{
 			&BinaryExpr{
 				Left:  newColumnExpr("timestamp", types.ColumnTypeBuiltin),
-				Right: NewLiteral(time.Unix(0, 1000000000)),
+				Right: NewLiteral(time1000),
 				Op:    types.BinaryOpGt,
 			},
 			&BinaryExpr{
 				Left:  newColumnExpr("timestamp", types.ColumnTypeBuiltin),
-				Right: NewLiteral(time.Unix(0, 2000000000)),
+				Right: NewLiteral(time2000),
 				Op:    types.BinaryOpLte,
 			},
 		}})
 		scan2 := optimized.addNode(&DataObjScan{id: "scan2", Predicates: []Expression{
 			&BinaryExpr{
 				Left:  newColumnExpr("timestamp", types.ColumnTypeBuiltin),
-				Right: NewLiteral(time.Unix(0, 1000000000)),
+				Right: NewLiteral(time1000),
 				Op:    types.BinaryOpGt,
 			},
 			&BinaryExpr{
 				Left:  newColumnExpr("timestamp", types.ColumnTypeBuiltin),
-				Right: NewLiteral(time.Unix(0, 2000000000)),
+				Right: NewLiteral(time2000),
 				Op:    types.BinaryOpLte,
 			},
 		}})
@@ -167,14 +172,14 @@ func TestOptimizer(t *testing.T) {
 		filter1 := optimized.addNode(&Filter{id: "filter1", Predicates: []Expression{
 			&BinaryExpr{
 				Left:  newColumnExpr("timestamp", types.ColumnTypeBuiltin),
-				Right: NewLiteral(time.Unix(0, 1000000000)),
+				Right: NewLiteral(time1000),
 				Op:    types.BinaryOpGt,
 			},
 		}})
 		filter2 := optimized.addNode(&Filter{id: "filter2", Predicates: []Expression{
 			&BinaryExpr{
 				Left:  newColumnExpr("timestamp", types.ColumnTypeBuiltin),
-				Right: NewLiteral(time.Unix(0, 2000000000)),
+				Right: NewLiteral(time2000),
 				Op:    types.BinaryOpLte,
 			},
 		}})

--- a/pkg/engine/planner/physical/planner_test.go
+++ b/pkg/engine/planner/physical/planner_test.go
@@ -2,10 +2,10 @@ package physical
 
 import (
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/loki/v3/pkg/engine/internal/datatype"
 	"github.com/grafana/loki/v3/pkg/engine/internal/types"
 	"github.com/grafana/loki/v3/pkg/engine/planner/logical"
 )
@@ -51,7 +51,7 @@ func TestPlanner_Convert(t *testing.T) {
 	).Select(
 		&logical.BinOp{
 			Left:  logical.NewColumnRef("timestamp", types.ColumnTypeBuiltin),
-			Right: logical.NewLiteral(time.Unix(0, 1742826126000000000)),
+			Right: logical.NewLiteral(datatype.Timestamp(1742826126000000000)),
 			Op:    types.BinaryOpLt,
 		},
 	).Limit(0, 1000)


### PR DESCRIPTION
**What this PR does / why we need it**:

Representing data types as simple types (`string`, `int64`, `float64`) makes them more efficient to cast without conversion.