### PR TITLE
chore(deps): Remove unused consul dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -435,8 +435,6 @@ replace github.com/Azure/azure-sdk-for-go => github.com/Azure/azure-sdk-for-go v
 
 replace github.com/Azure/azure-storage-blob-go => github.com/MasslessParticle/azure-storage-blob-go v0.14.1-0.20240322194317-344980fda573
 
-replace github.com/hashicorp/consul => github.com/hashicorp/consul v1.21.0
-
 // Use fork of gocql that has gokit logs and Prometheus metrics.
 replace github.com/gocql/gocql => github.com/grafana/gocql v0.0.0-20200605141915-ba5dc39ece85
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -2813,7 +2813,6 @@ zombiezen.com/go/sqlite
 zombiezen.com/go/sqlite/sqlitex
 # github.com/Azure/azure-sdk-for-go => github.com/Azure/azure-sdk-for-go v68.0.0+incompatible
 # github.com/Azure/azure-storage-blob-go => github.com/MasslessParticle/azure-storage-blob-go v0.14.1-0.20240322194317-344980fda573
-# github.com/hashicorp/consul => github.com/hashicorp/consul v1.21.0
 # github.com/gocql/gocql => github.com/grafana/gocql v0.0.0-20200605141915-ba5dc39ece85
 # github.com/hashicorp/memberlist => github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe
 # github.com/grafana/regexp => github.com/grafana/regexp v0.0.0-20240518133315-a468a5bfb3bc


### PR DESCRIPTION
**What this PR does / why we need it**:

It looks to me like the `github.com/hashicorp/consul` module is not actually used by Loki but it is still present in the `go.mod` as a replace and so is still added to the vendor directory (just `modules.txt` though).

This PR removes the `replaces` from the `go.mod` file. I've also regenerated vendor using `go mod vendor`.

The module actually used seems to be `github.com/hashicorp/consul/api` which is not affected by this change.

**Which issue(s) this PR fixes**:

n/a

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
