### PR TITLE
feat(kafka): Support multiple kafka clients in component

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -748,17 +748,9 @@ compactor_grpc_client:
 [memberlist: <memberlist>]
 
 kafka_config:
-  # The Kafka backend address.
-  # CLI flag: -kafka.address
-  [address: <string> | default = "localhost:9092"]
-
   # The Kafka topic name.
   # CLI flag: -kafka.topic
   [topic: <string> | default = ""]
-
-  # The Kafka client ID.
-  # CLI flag: -kafka.client-id
-  [client_id: <string> | default = ""]
 
   # The maximum time allowed to open a connection to a Kafka broker.
   # CLI flag: -kafka.dial-timeout
@@ -768,6 +760,24 @@ kafka_config:
   # to the Kafka backend.
   # CLI flag: -kafka.write-timeout
   [write_timeout: <duration> | default = 10s]
+
+  reader_config:
+    # The Kafka backend address.
+    # CLI flag: -kafka.reader.address
+    [address: <string> | default = "localhost:9092"]
+
+    # The Kafka client ID.
+    # CLI flag: -kafka.reader.client-id
+    [client_id: <string> | default = ""]
+
+  writer_config:
+    # The Kafka backend address.
+    # CLI flag: -kafka.writer.address
+    [address: <string> | default = "localhost:9092"]
+
+    # The Kafka client ID.
+    # CLI flag: -kafka.writer.client-id
+    [client_id: <string> | default = ""]
 
   # The SASL username for authentication to Kafka using the PLAIN mechanism.
   # Both username and password must be set.

--- a/pkg/kafka/client/reader_client.go
+++ b/pkg/kafka/client/reader_client.go
@@ -25,7 +25,15 @@ func NewReaderClient(component string, kafkaCfg kafka.Config, logger log.Logger,
 	const fetchMaxBytes = 100_000_000
 
 	opts = append(opts, commonKafkaClientOptions(kafkaCfg, metrics, logger)...)
-	opts = append(opts,
+
+	if kafkaCfg.ReaderConfig.Address != "" && kafkaCfg.ReaderConfig.ClientID != "" {
+		opts = append(opts, kgo.ClientID(kafkaCfg.ReaderConfig.ClientID), kgo.SeedBrokers(kafkaCfg.ReaderConfig.Address))
+	} else {
+		opts = append(opts, kgo.ClientID(kafkaCfg.ClientID), kgo.SeedBrokers(kafkaCfg.Address))
+	}
+
+	opts = append(
+		opts,
 		kgo.FetchMinBytes(1),
 		kgo.FetchMaxBytes(fetchMaxBytes),
 		kgo.FetchMaxWait(5*time.Second),

--- a/pkg/kafka/client/reader_client_test.go
+++ b/pkg/kafka/client/reader_client_test.go
@@ -35,6 +35,19 @@ func TestNewReaderClient(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "valid config with reader config",
+			config: kafka.Config{
+				Topic:        "abcd",
+				SASLUsername: "user",
+				SASLPassword: flagext.SecretWithValue("password"),
+				ReaderConfig: kafka.ClientConfig{
+					Address:  addr,
+					ClientID: "reader",
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name: "wrong password",
 			config: kafka.Config{
 				Address:      addr,

--- a/pkg/kafka/client/writer_client_test.go
+++ b/pkg/kafka/client/writer_client_test.go
@@ -33,6 +33,18 @@ func TestNewWriterClient(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "valid config with writer config",
+			config: kafka.Config{
+				Topic:        "abcd",
+				WriteTimeout: time.Second,
+				WriterConfig: kafka.ClientConfig{
+					Address:  addr,
+					ClientID: "writer",
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name: "wrong password",
 			config: kafka.Config{
 				Address:      addr,

--- a/pkg/kafka/config_test.go
+++ b/pkg/kafka/config_test.go
@@ -37,3 +37,25 @@ func TestBothSASLParamsMustBeSet(t *testing.T) {
 	err = cfg.Validate()
 	require.NoError(t, err)
 }
+
+func TestAmbiguousKafkaAddress(t *testing.T) {
+	cfg := Config{
+		Address:      "localhost:9092",
+		ReaderConfig: ClientConfig{Address: "localhost:9092"},
+		WriterConfig: ClientConfig{Address: "localhost:9092"},
+	}
+	err := cfg.Validate()
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrAmbiguousKafkaAddress)
+}
+
+func TestAmbiguousKafkaClientID(t *testing.T) {
+	cfg := Config{
+		ClientID:     "abcd",
+		ReaderConfig: ClientConfig{Address: "reader:9092", ClientID: "abcd"},
+		WriterConfig: ClientConfig{Address: "writer:9092", ClientID: "abcd"},
+	}
+	err := cfg.Validate()
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrAmbiguousKafkaClientID)
+}

--- a/tools/deprecated-config-checker/deprecated-config.yaml
+++ b/tools/deprecated-config-checker/deprecated-config.yaml
@@ -43,6 +43,10 @@ storage_config:
 chunk_store_config:
   write_dedupe_cache_config: "Write dedupe cache is deprecated along with deprecated index types. Consider using TSDB index which does not require a write dedupe cache."
 
+kafka_config:
+  address: "Use reader_config.address or writer_config.address instead."
+  client_id: "Use reader_config.client_id or writer_config.client_id instead."
+
 ## NOTE: This will also be used to validate per-tenant overrides.
 limits_config:
   unordered_writes: "Will be eventually removed."


### PR DESCRIPTION
**What this PR does / why we need it**:
This pull request enables Loki components to use separate reader and writer clients in parallel. The separation of reader/writer address and client ID is required for kafka-compatible implementations that provide different endpoints for writes and reads.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
