### PR TITLE
chore: rename WindowSize to ActiveWindow

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -893,9 +893,11 @@ ingest_limits:
   # CLI flag: -ingest-limits.enabled
   [enabled: <boolean> | default = false]
 
-  # The time window for which stream metadata is considered active.
-  # CLI flag: -ingest-limits.window-size
-  [window_size: <duration> | default = 1h]
+  # The duration for which which streams are considered active. Streams that
+  # have not been updated within this window are considered inactive and not
+  # counted towards limits.
+  # CLI flag: -ingest-limits.active-window
+  [active_window: <duration> | default = 1h]
 
   # The time window for rate calculation. This should match the window used in
   # Prometheus rate() queries for consistency.

--- a/pkg/limits/http.go
+++ b/pkg/limits/http.go
@@ -26,7 +26,7 @@ func (s *IngestLimits) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Get the cutoff time for active streams
-	cutoff := time.Now().Add(-s.cfg.WindowSize).UnixNano()
+	cutoff := time.Now().Add(-s.cfg.ActiveWindow).UnixNano()
 
 	// Get the rate window cutoff for rate calculations
 	rateWindowCutoff := time.Now().Add(-s.cfg.BucketDuration).UnixNano()
@@ -56,7 +56,7 @@ func (s *IngestLimits) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	})
 
 	// Calculate rate using only data from within the rate window
-	calculatedRate := float64(totalSize) / s.cfg.WindowSize.Seconds()
+	calculatedRate := float64(totalSize) / s.cfg.ActiveWindow.Seconds()
 
 	if activeStreams > 0 {
 		response = httpTenantLimitsResponse{

--- a/pkg/limits/http_test.go
+++ b/pkg/limits/http_test.go
@@ -16,7 +16,7 @@ import (
 func TestIngestLimits_ServeHTTP(t *testing.T) {
 	l := IngestLimits{
 		cfg: Config{
-			WindowSize:     time.Minute,
+			ActiveWindow:   time.Minute,
 			RateWindow:     time.Minute,
 			BucketDuration: 30 * time.Second,
 		},

--- a/pkg/limits/partition_lifecycler.go
+++ b/pkg/limits/partition_lifecycler.go
@@ -90,7 +90,7 @@ func (l *PartitionLifecycler) determineStateFromOffsets(ctx context.Context, par
 	// Get the first offset produced within the window. This can be the same
 	// offset as the last produced offset if no records have been produced
 	// within that time.
-	nextOffset, err := l.offsetManager.NextOffset(ctx, partition, time.Now().Add(-l.cfg.WindowSize))
+	nextOffset, err := l.offsetManager.NextOffset(ctx, partition, time.Now().Add(-l.cfg.ActiveWindow))
 	if err != nil {
 		return fmt.Errorf("failed to get next offset: %w", err)
 	}

--- a/pkg/limits/playback_manager_test.go
+++ b/pkg/limits/playback_manager_test.go
@@ -49,7 +49,7 @@ func TestPlaybackManager_ProcessRecords(t *testing.T) {
 		// Create a usage store, we will use this to check if the record
 		// was stored.
 		u := NewUsageStore(Config{
-			WindowSize:    time.Hour,
+			ActiveWindow:  time.Hour,
 			NumPartitions: 1,
 		})
 		p := NewPlaybackManager(&k, m, u, NewOffsetReadinessCheck(m), "zone1",
@@ -96,7 +96,7 @@ func TestPlaybackManager_ProcessRecords(t *testing.T) {
 		// Create a usage store, we will use this to check if the record
 		// was discarded.
 		u := NewUsageStore(Config{
-			WindowSize:    time.Hour,
+			ActiveWindow:  time.Hour,
 			NumPartitions: 1,
 		})
 		p := NewPlaybackManager(&k, m, u, NewOffsetReadinessCheck(m), "zone1",
@@ -171,7 +171,7 @@ func TestPlaybackmanager_ReadinessCheck(t *testing.T) {
 	m.SetReplaying(1, 2)
 	// We don't need the usage store for this test.
 	u := NewUsageStore(Config{
-		WindowSize:    time.Hour,
+		ActiveWindow:  time.Hour,
 		NumPartitions: 1,
 	})
 	p := NewPlaybackManager(&k, m, u, NewOffsetReadinessCheck(m), "zone1",

--- a/pkg/limits/service_test.go
+++ b/pkg/limits/service_test.go
@@ -28,7 +28,7 @@ func TestIngestLimits_ExceedsLimits(t *testing.T) {
 		assignedPartitions []int32
 		numPartitions      int
 		usage              *UsageStore
-		windowSize         time.Duration
+		ActiveWindow       time.Duration
 		rateWindow         time.Duration
 		bucketDuration     time.Duration
 		maxActiveStreams   int
@@ -61,7 +61,7 @@ func TestIngestLimits_ExceedsLimits(t *testing.T) {
 				},
 				locks: make([]stripeLock, 1),
 			},
-			windowSize:       time.Hour,
+			ActiveWindow:     time.Hour,
 			rateWindow:       5 * time.Minute,
 			bucketDuration:   time.Minute,
 			maxActiveStreams: 10,
@@ -98,7 +98,7 @@ func TestIngestLimits_ExceedsLimits(t *testing.T) {
 				},
 				locks: make([]stripeLock, 1),
 			},
-			windowSize:     time.Hour,
+			ActiveWindow:   time.Hour,
 			rateWindow:     5 * time.Minute,
 			bucketDuration: time.Minute,
 			// request data
@@ -134,7 +134,7 @@ func TestIngestLimits_ExceedsLimits(t *testing.T) {
 				},
 				locks: make([]stripeLock, 1),
 			},
-			windowSize:       time.Hour,
+			ActiveWindow:     time.Hour,
 			rateWindow:       5 * time.Minute,
 			bucketDuration:   time.Minute,
 			maxActiveStreams: 3,
@@ -171,7 +171,7 @@ func TestIngestLimits_ExceedsLimits(t *testing.T) {
 				},
 				locks: make([]stripeLock, 1),
 			},
-			windowSize:       time.Hour,
+			ActiveWindow:     time.Hour,
 			rateWindow:       5 * time.Minute,
 			bucketDuration:   time.Minute,
 			maxActiveStreams: 3,
@@ -214,7 +214,7 @@ func TestIngestLimits_ExceedsLimits(t *testing.T) {
 				},
 				locks: make([]stripeLock, 1),
 			},
-			windowSize:       time.Hour,
+			ActiveWindow:     time.Hour,
 			rateWindow:       5 * time.Minute,
 			bucketDuration:   time.Minute,
 			maxActiveStreams: 5,
@@ -244,7 +244,7 @@ func TestIngestLimits_ExceedsLimits(t *testing.T) {
 					make(map[string]tenantUsage),
 				},
 			},
-			windowSize:       time.Hour,
+			ActiveWindow:     time.Hour,
 			rateWindow:       5 * time.Minute,
 			bucketDuration:   time.Minute,
 			maxActiveStreams: 3,
@@ -277,7 +277,7 @@ func TestIngestLimits_ExceedsLimits(t *testing.T) {
 					make(map[string]tenantUsage),
 				},
 			},
-			windowSize:       time.Hour,
+			ActiveWindow:     time.Hour,
 			rateWindow:       5 * time.Minute,
 			bucketDuration:   time.Minute,
 			maxActiveStreams: 3,
@@ -310,7 +310,7 @@ func TestIngestLimits_ExceedsLimits(t *testing.T) {
 			s := &IngestLimits{
 				cfg: Config{
 					NumPartitions:  tt.numPartitions,
-					WindowSize:     tt.windowSize,
+					ActiveWindow:   tt.ActiveWindow,
 					RateWindow:     tt.rateWindow,
 					BucketDuration: tt.bucketDuration,
 					LifecyclerConfig: ring.LifecyclerConfig{
@@ -399,7 +399,7 @@ func TestIngestLimits_ExceedsLimits_Concurrent(t *testing.T) {
 	s := &IngestLimits{
 		cfg: Config{
 			NumPartitions:  1,
-			WindowSize:     time.Hour,
+			ActiveWindow:   time.Hour,
 			RateWindow:     5 * time.Minute,
 			BucketDuration: time.Minute,
 			LifecyclerConfig: ring.LifecyclerConfig{
@@ -460,7 +460,7 @@ func TestNewIngestLimits(t *testing.T) {
 			Topic:        "test-topic",
 			WriteTimeout: 10 * time.Second,
 		},
-		WindowSize: time.Hour,
+		ActiveWindow: time.Hour,
 		LifecyclerConfig: ring.LifecyclerConfig{
 			RingConfig: ring.Config{
 				KVStore: kv.Config{

--- a/pkg/limits/store.go
+++ b/pkg/limits/store.go
@@ -102,7 +102,7 @@ func (s *UsageStore) ForTenant(tenant string, fn IterateFunc) {
 func (s *UsageStore) Update(tenant string, streams []*proto.StreamMetadata, lastSeenAt time.Time, cond CondFunc) ([]*proto.StreamMetadata, []*proto.StreamMetadata) {
 	var (
 		// Calculate the cutoff for the window size
-		cutoff = lastSeenAt.Add(-s.cfg.WindowSize).UnixNano()
+		cutoff = lastSeenAt.Add(-s.cfg.ActiveWindow).UnixNano()
 		// Get the bucket for this timestamp using the configured interval duration
 		bucketStart = lastSeenAt.Truncate(s.cfg.BucketDuration).UnixNano()
 		// Calculate the rate window cutoff for cleaning up old buckets
@@ -162,7 +162,7 @@ func (s *UsageStore) Update(tenant string, streams []*proto.StreamMetadata, last
 
 // Evict evicts all streams that have not been seen within the window.
 func (s *UsageStore) Evict() map[string]int {
-	cutoff := s.clock.Now().Add(-s.cfg.WindowSize).UnixNano()
+	cutoff := s.clock.Now().Add(-s.cfg.ActiveWindow).UnixNano()
 	evicted := make(map[string]int)
 	s.forEachLock(func(i int) {
 		for tenant, partitions := range s.stripes[i] {

--- a/pkg/limits/store_bench_test.go
+++ b/pkg/limits/store_bench_test.go
@@ -44,7 +44,7 @@ func BenchmarkUsageStore_Store(b *testing.B) {
 	for _, bm := range benchmarks {
 		s := NewUsageStore(Config{
 			NumPartitions:  bm.numPartitions,
-			WindowSize:     time.Hour,
+			ActiveWindow:   time.Hour,
 			RateWindow:     5 * time.Minute,
 			BucketDuration: time.Minute,
 		})

--- a/pkg/limits/store_test.go
+++ b/pkg/limits/store_test.go
@@ -14,7 +14,7 @@ func TestUsageStore_All(t *testing.T) {
 	// Create a store with 10 partitions.
 	s := NewUsageStore(Config{
 		NumPartitions: 10,
-		WindowSize:    time.Minute,
+		ActiveWindow:  time.Minute,
 	})
 	clock := quartz.NewMock(t)
 	s.clock = clock
@@ -36,7 +36,7 @@ func TestUsageStore_ForTenant(t *testing.T) {
 	// Create a store with 10 partitions.
 	s := NewUsageStore(Config{
 		NumPartitions: 10,
-		WindowSize:    time.Minute,
+		ActiveWindow:  time.Minute,
 	})
 	clock := quartz.NewMock(t)
 	s.clock = clock
@@ -169,7 +169,7 @@ func TestUsageStore_Store(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			s := NewUsageStore(Config{
 				NumPartitions: test.numPartitions,
-				WindowSize:    time.Minute,
+				ActiveWindow:  time.Minute,
 			})
 			clock := quartz.NewMock(t)
 			s.clock = clock
@@ -185,7 +185,7 @@ func TestUsageStore_Store(t *testing.T) {
 func TestUsageStore_Evict(t *testing.T) {
 	s := NewUsageStore(Config{
 		NumPartitions: 1,
-		WindowSize:    time.Hour,
+		ActiveWindow:  time.Hour,
 	})
 	clock := quartz.NewMock(t)
 	s.clock = clock
@@ -219,7 +219,7 @@ func TestUsageStore_EvictPartitions(t *testing.T) {
 	// Create a store with 10 partitions.
 	s := NewUsageStore(Config{
 		NumPartitions: 10,
-		WindowSize:    time.Minute,
+		ActiveWindow:  time.Minute,
 	})
 	clock := quartz.NewMock(t)
 	s.clock = clock


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit renames `WindowSize` to `ActiveWindow`. It does so for the following reasons:

  1. We have two windows: `WindowSize` and `RateWindow`. The first window is the time window for active streams, the second window is the time window for calculating rates. As both are windows, I think they should be named consistently to `ActiveWindow` and `RateWindow`.

  2. When taking about `WindowSize`, which window are we sizing? The active stream window or the rate calculation window. It is unclear, so this change attempts to avoid such confusion.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
