### PR TITLE
chore: move Config struct out of UsageStore

### DIFF
--- a/pkg/limits/playback_manager_test.go
+++ b/pkg/limits/playback_manager_test.go
@@ -3,7 +3,6 @@ package limits
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/go-kit/log"
 	"github.com/prometheus/client_golang/prometheus"
@@ -48,10 +47,7 @@ func TestPlaybackManager_ProcessRecords(t *testing.T) {
 		m.SetReplaying(1, 1000)
 		// Create a usage store, we will use this to check if the record
 		// was stored.
-		u := NewUsageStore(Config{
-			ActiveWindow:  time.Hour,
-			NumPartitions: 1,
-		})
+		u := NewUsageStore(DefaultActiveWindow, DefaultRateWindow, DefaultBucketSize, 1)
 		p := NewPlaybackManager(&k, m, u, NewOffsetReadinessCheck(m), "zone1",
 			log.NewNopLogger(), prometheus.NewRegistry())
 		require.NoError(t, p.pollFetches(ctx))
@@ -95,10 +91,7 @@ func TestPlaybackManager_ProcessRecords(t *testing.T) {
 		m.SetReady(1)
 		// Create a usage store, we will use this to check if the record
 		// was discarded.
-		u := NewUsageStore(Config{
-			ActiveWindow:  time.Hour,
-			NumPartitions: 1,
-		})
+		u := NewUsageStore(DefaultActiveWindow, DefaultRateWindow, DefaultBucketSize, 1)
 		p := NewPlaybackManager(&k, m, u, NewOffsetReadinessCheck(m), "zone1",
 			log.NewNopLogger(), prometheus.NewRegistry())
 		require.NoError(t, p.pollFetches(ctx))
@@ -170,10 +163,7 @@ func TestPlaybackmanager_ReadinessCheck(t *testing.T) {
 	// has been consumed.
 	m.SetReplaying(1, 2)
 	// We don't need the usage store for this test.
-	u := NewUsageStore(Config{
-		ActiveWindow:  time.Hour,
-		NumPartitions: 1,
-	})
+	u := NewUsageStore(DefaultActiveWindow, DefaultRateWindow, DefaultBucketSize, 1)
 	p := NewPlaybackManager(&k, m, u, NewOffsetReadinessCheck(m), "zone1",
 		log.NewNopLogger(), prometheus.NewRegistry())
 	// The first poll should fetch the first record.

--- a/pkg/limits/service.go
+++ b/pkg/limits/service.go
@@ -124,7 +124,7 @@ func NewIngestLimits(cfg Config, lims Limits, logger log.Logger, reg prometheus.
 	s := &IngestLimits{
 		cfg:              cfg,
 		logger:           logger,
-		usage:            NewUsageStore(cfg),
+		usage:            NewUsageStore(cfg.ActiveWindow, cfg.RateWindow, cfg.BucketSize, cfg.NumPartitions),
 		partitionManager: NewPartitionManager(),
 		metrics:          newMetrics(reg),
 		limits:           lims,

--- a/pkg/limits/service_test.go
+++ b/pkg/limits/service_test.go
@@ -48,7 +48,7 @@ func TestIngestLimits_ExceedsLimits(t *testing.T) {
 			assignedPartitions: []int32{0},
 			numPartitions:      1,
 			usage: &UsageStore{
-				cfg: Config{NumPartitions: 1},
+				numPartitions: 1,
 				stripes: []map[string]tenantUsage{
 					{
 						"tenant1": {
@@ -83,7 +83,7 @@ func TestIngestLimits_ExceedsLimits(t *testing.T) {
 			assignedPartitions: []int32{0},
 			numPartitions:      1,
 			usage: &UsageStore{
-				cfg: Config{NumPartitions: 1},
+				numPartitions: 1,
 				stripes: []map[string]tenantUsage{
 					{
 						"tenant1": {
@@ -120,7 +120,7 @@ func TestIngestLimits_ExceedsLimits(t *testing.T) {
 			assignedPartitions: []int32{0},
 			numPartitions:      1,
 			usage: &UsageStore{
-				cfg: Config{NumPartitions: 1},
+				numPartitions: 1,
 				stripes: []map[string]tenantUsage{
 					{
 						"tenant1": {
@@ -157,7 +157,7 @@ func TestIngestLimits_ExceedsLimits(t *testing.T) {
 			assignedPartitions: []int32{0},
 			numPartitions:      1,
 			usage: &UsageStore{
-				cfg: Config{NumPartitions: 1},
+				numPartitions: 1,
 				stripes: []map[string]tenantUsage{
 					{
 						"tenant1": {
@@ -198,7 +198,7 @@ func TestIngestLimits_ExceedsLimits(t *testing.T) {
 			assignedPartitions: []int32{0},
 			numPartitions:      1,
 			usage: &UsageStore{
-				cfg: Config{NumPartitions: 1},
+				numPartitions: 1,
 				stripes: []map[string]tenantUsage{
 					{
 						"tenant1": {
@@ -237,8 +237,8 @@ func TestIngestLimits_ExceedsLimits(t *testing.T) {
 			assignedPartitions: []int32{0, 1},
 			numPartitions:      2,
 			usage: &UsageStore{
-				cfg:   Config{NumPartitions: 2},
-				locks: make([]stripeLock, 2),
+				numPartitions: 2,
+				locks:         make([]stripeLock, 2),
 				stripes: []map[string]tenantUsage{
 					make(map[string]tenantUsage),
 					make(map[string]tenantUsage),
@@ -270,8 +270,8 @@ func TestIngestLimits_ExceedsLimits(t *testing.T) {
 			assignedPartitions: []int32{0},
 			numPartitions:      2,
 			usage: &UsageStore{
-				cfg:   Config{NumPartitions: 1},
-				locks: make([]stripeLock, 2),
+				numPartitions: 1,
+				locks:         make([]stripeLock, 2),
 				stripes: []map[string]tenantUsage{
 					make(map[string]tenantUsage),
 					make(map[string]tenantUsage),
@@ -379,7 +379,7 @@ func TestIngestLimits_ExceedsLimits_Concurrent(t *testing.T) {
 
 	// Setup test data with a mix of active and expired streams>
 	usage := &UsageStore{
-		cfg: Config{NumPartitions: 1},
+		numPartitions: 1,
 		stripes: []map[string]tenantUsage{
 			{
 				"tenant1": {

--- a/pkg/limits/store.go
+++ b/pkg/limits/store.go
@@ -23,9 +23,12 @@ type CondFunc func(acc float64, stream *proto.StreamMetadata) bool
 
 // UsageStore stores per-tenant stream usage data.
 type UsageStore struct {
-	cfg     Config
-	stripes []map[string]tenantUsage
-	locks   []stripeLock
+	activeWindow  time.Duration
+	rateWindow    time.Duration
+	bucketSize    time.Duration
+	numPartitions int
+	stripes       []map[string]tenantUsage
+	locks         []stripeLock
 
 	// Used for tests.
 	clock quartz.Clock
@@ -58,12 +61,15 @@ type stripeLock struct {
 }
 
 // NewUsageStore returns a new UsageStore.
-func NewUsageStore(cfg Config) *UsageStore {
+func NewUsageStore(activeWindow, rateWindow, bucketSize time.Duration, numPartitions int) *UsageStore {
 	s := &UsageStore{
-		cfg:     cfg,
-		stripes: make([]map[string]tenantUsage, numStripes),
-		locks:   make([]stripeLock, numStripes),
-		clock:   quartz.NewReal(),
+		activeWindow:  activeWindow,
+		rateWindow:    rateWindow,
+		bucketSize:    bucketSize,
+		numPartitions: numPartitions,
+		stripes:       make([]map[string]tenantUsage, numStripes),
+		locks:         make([]stripeLock, numStripes),
+		clock:         quartz.NewReal(),
 	}
 	for i := range s.stripes {
 		s.stripes[i] = make(map[string]tenantUsage)
@@ -102,11 +108,11 @@ func (s *UsageStore) ForTenant(tenant string, fn IterateFunc) {
 func (s *UsageStore) Update(tenant string, streams []*proto.StreamMetadata, lastSeenAt time.Time, cond CondFunc) ([]*proto.StreamMetadata, []*proto.StreamMetadata) {
 	var (
 		// Calculate the cutoff for the window size
-		cutoff = lastSeenAt.Add(-s.cfg.ActiveWindow).UnixNano()
+		cutoff = lastSeenAt.Add(-s.activeWindow).UnixNano()
 		// Get the bucket for this timestamp using the configured interval duration
-		bucketStart = lastSeenAt.Truncate(s.cfg.BucketSize).UnixNano()
+		bucketStart = lastSeenAt.Truncate(s.bucketSize).UnixNano()
 		// Calculate the rate window cutoff for cleaning up old buckets
-		bucketCutoff = lastSeenAt.Add(-s.cfg.RateWindow).UnixNano()
+		bucketCutoff = lastSeenAt.Add(-s.rateWindow).UnixNano()
 		stored       = make([]*proto.StreamMetadata, 0, len(streams))
 		rejected     = make([]*proto.StreamMetadata, 0, len(streams))
 	)
@@ -118,7 +124,7 @@ func (s *UsageStore) Update(tenant string, streams []*proto.StreamMetadata, last
 		activeStreams := make(map[int32]int)
 
 		for _, stream := range streams {
-			partition := int32(stream.StreamHash % uint64(s.cfg.NumPartitions))
+			partition := int32(stream.StreamHash % uint64(s.numPartitions))
 
 			if _, ok := s.stripes[i][tenant][partition]; !ok {
 				s.stripes[i][tenant][partition] = make(map[uint64]Stream)
@@ -162,7 +168,7 @@ func (s *UsageStore) Update(tenant string, streams []*proto.StreamMetadata, last
 
 // Evict evicts all streams that have not been seen within the window.
 func (s *UsageStore) Evict() map[string]int {
-	cutoff := s.clock.Now().Add(-s.cfg.ActiveWindow).UnixNano()
+	cutoff := s.clock.Now().Add(-s.activeWindow).UnixNano()
 	evicted := make(map[string]int)
 	s.forEachLock(func(i int) {
 		for tenant, partitions := range s.stripes[i] {
@@ -291,7 +297,7 @@ func (s *UsageStore) getStripe(tenant string) int {
 
 // Used in tests.
 func (s *UsageStore) set(tenant string, stream Stream) {
-	partition := int32(stream.Hash % uint64(s.cfg.NumPartitions))
+	partition := int32(stream.Hash % uint64(s.numPartitions))
 	s.withLock(tenant, func(i int) {
 		if _, ok := s.stripes[i][tenant]; !ok {
 			s.stripes[i][tenant] = make(tenantUsage)

--- a/pkg/limits/store_bench_test.go
+++ b/pkg/limits/store_bench_test.go
@@ -42,13 +42,7 @@ func BenchmarkUsageStore_Store(b *testing.B) {
 	}
 
 	for _, bm := range benchmarks {
-		s := NewUsageStore(Config{
-			NumPartitions: bm.numPartitions,
-			ActiveWindow:  time.Hour,
-			RateWindow:    5 * time.Minute,
-			BucketSize:    time.Minute,
-		})
-
+		s := NewUsageStore(DefaultActiveWindow, DefaultRateWindow, DefaultBucketSize, bm.numPartitions)
 		b.Run(fmt.Sprintf("%s_create", bm.name), func(b *testing.B) {
 			now := time.Now()
 
@@ -87,7 +81,7 @@ func BenchmarkUsageStore_Store(b *testing.B) {
 			}
 		})
 
-		s = NewUsageStore(Config{NumPartitions: bm.numPartitions})
+		s = NewUsageStore(DefaultActiveWindow, DefaultRateWindow, DefaultBucketSize, bm.numPartitions)
 
 		// Run parallel benchmark
 		b.Run(bm.name+"_create_parallel", func(b *testing.B) {

--- a/pkg/limits/store_test.go
+++ b/pkg/limits/store_test.go
@@ -12,10 +12,7 @@ import (
 
 func TestUsageStore_All(t *testing.T) {
 	// Create a store with 10 partitions.
-	s := NewUsageStore(Config{
-		NumPartitions: 10,
-		ActiveWindow:  time.Minute,
-	})
+	s := NewUsageStore(DefaultActiveWindow, DefaultRateWindow, DefaultBucketSize, 10)
 	clock := quartz.NewMock(t)
 	s.clock = clock
 	// Create 10 streams. Since we use i as the hash, we can expect the
@@ -34,10 +31,7 @@ func TestUsageStore_All(t *testing.T) {
 
 func TestUsageStore_ForTenant(t *testing.T) {
 	// Create a store with 10 partitions.
-	s := NewUsageStore(Config{
-		NumPartitions: 10,
-		ActiveWindow:  time.Minute,
-	})
+	s := NewUsageStore(DefaultActiveWindow, DefaultRateWindow, DefaultBucketSize, 10)
 	clock := quartz.NewMock(t)
 	s.clock = clock
 	// Create 10 streams. Since we use i as the hash, we can expect the
@@ -167,10 +161,7 @@ func TestUsageStore_Store(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			s := NewUsageStore(Config{
-				NumPartitions: test.numPartitions,
-				ActiveWindow:  time.Minute,
-			})
+			s := NewUsageStore(DefaultActiveWindow, DefaultRateWindow, DefaultBucketSize, test.numPartitions)
 			clock := quartz.NewMock(t)
 			s.clock = clock
 			s.Update("tenant", test.seed, clock.Now(), nil)
@@ -183,10 +174,7 @@ func TestUsageStore_Store(t *testing.T) {
 }
 
 func TestUsageStore_Evict(t *testing.T) {
-	s := NewUsageStore(Config{
-		NumPartitions: 1,
-		ActiveWindow:  time.Hour,
-	})
+	s := NewUsageStore(DefaultActiveWindow, DefaultRateWindow, DefaultBucketSize, 1)
 	clock := quartz.NewMock(t)
 	s.clock = clock
 	s1 := Stream{Hash: 0x1, LastSeenAt: clock.Now().UnixNano()}
@@ -217,10 +205,7 @@ func TestUsageStore_Evict(t *testing.T) {
 
 func TestUsageStore_EvictPartitions(t *testing.T) {
 	// Create a store with 10 partitions.
-	s := NewUsageStore(Config{
-		NumPartitions: 10,
-		ActiveWindow:  time.Minute,
-	})
+	s := NewUsageStore(DefaultActiveWindow, DefaultRateWindow, DefaultBucketSize, 10)
 	clock := quartz.NewMock(t)
 	s.clock = clock
 	// Create 10 streams. Since we use i as the hash, we can expect the


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit moves the Config struct out of the UsageStore. As the config becomes more complicated over time, it becomes harder to track which fields are used in the UsageStore and which are not. As discussed with @rfratto, this fixes that problem.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
