### PR TITLE
chore: move Config struct out of PlaybackManager

### DIFF
--- a/pkg/limits/partition_lifecycler.go
+++ b/pkg/limits/partition_lifecycler.go
@@ -14,26 +14,26 @@ import (
 
 // PartitionLifecycler manages assignment and revocation of partitions.
 type PartitionLifecycler struct {
-	cfg              Config
 	partitionManager *PartitionManager
 	offsetManager    kafka_partition.OffsetManager
 	usage            *UsageStore
+	activeWindow     time.Duration
 	logger           log.Logger
 }
 
 // NewPartitionLifecycler returns a new PartitionLifecycler.
 func NewPartitionLifecycler(
-	cfg Config,
 	partitionManager *PartitionManager,
 	offsetManager kafka_partition.OffsetManager,
 	usage *UsageStore,
+	activeWindow time.Duration,
 	logger log.Logger,
 ) *PartitionLifecycler {
 	return &PartitionLifecycler{
-		cfg:              cfg,
 		partitionManager: partitionManager,
 		offsetManager:    offsetManager,
 		usage:            usage,
+		activeWindow:     activeWindow,
 		logger:           logger,
 	}
 }
@@ -90,7 +90,7 @@ func (l *PartitionLifecycler) determineStateFromOffsets(ctx context.Context, par
 	// Get the first offset produced within the window. This can be the same
 	// offset as the last produced offset if no records have been produced
 	// within that time.
-	nextOffset, err := l.offsetManager.NextOffset(ctx, partition, time.Now().Add(-l.cfg.ActiveWindow))
+	nextOffset, err := l.offsetManager.NextOffset(ctx, partition, time.Now().Add(-l.activeWindow))
 	if err != nil {
 		return fmt.Errorf("failed to get next offset: %w", err)
 	}

--- a/pkg/limits/service.go
+++ b/pkg/limits/service.go
@@ -161,7 +161,13 @@ func NewIngestLimits(cfg Config, lims Limits, logger log.Logger, reg prometheus.
 	if err != nil {
 		return nil, fmt.Errorf("failed to create offset manager: %w", err)
 	}
-	s.partitionLifecycler = NewPartitionLifecycler(cfg, s.partitionManager, offsetManager, s.usage, logger)
+	s.partitionLifecycler = NewPartitionLifecycler(
+		s.partitionManager,
+		offsetManager,
+		s.usage,
+		cfg.ActiveWindow,
+		logger,
+	)
 
 	s.clientReader, err = client.NewReaderClient("ingest-limits-reader", kCfg, logger, reg,
 		kgo.ConsumerGroup(consumerGroup),


### PR DESCRIPTION
**What this PR does / why we need it**:

As per https://github.com/grafana/loki/pull/17760.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
