### PR TITLE
chore: add missing tests for sender.go

### DIFF
--- a/pkg/limits/sender_test.go
+++ b/pkg/limits/sender_test.go
@@ -1,0 +1,46 @@
+package limits
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/go-kit/log"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/kgo"
+
+	"github.com/grafana/loki/v3/pkg/limits/proto"
+)
+
+func TestSender_Produce(t *testing.T) {
+	kafka := mockKafka{}
+	s := NewSender(&kafka, "topic", 1, "zone1", log.NewNopLogger(), prometheus.NewRegistry())
+	// Record should be produced.
+	metadata := &proto.StreamMetadata{
+		StreamHash: 0x1,
+		TotalSize:  100,
+	}
+	ctx := context.Background()
+	require.NoError(t, s.Produce(ctx, "tenant", metadata))
+	expectedMetadataRecord := proto.StreamMetadataRecord{
+		Zone:     "zone1",
+		Tenant:   "tenant",
+		Metadata: metadata,
+	}
+	b, err := expectedMetadataRecord.Marshal()
+	require.NoError(t, err)
+	expectedRecords := []*kgo.Record{{
+		Topic: "topic",
+		Key:   []byte("tenant"),
+		Value: b,
+	}}
+	require.Equal(t, expectedRecords, kafka.produced)
+	// Record should fail to be produced.
+	kafka.produced = []*kgo.Record{}
+	kafka.produceFailer = func(_ *kgo.Record) error {
+		return errors.New("failed to produce record")
+	}
+	require.NoError(t, s.Produce(ctx, "tenant", metadata))
+	require.Equal(t, []*kgo.Record{}, kafka.produced)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds missing tests for sender.go.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
