### PR TITLE
feat: adds User-Agent to distributor push logging

### DIFF
--- a/pkg/loghttp/push/push.go
+++ b/pkg/loghttp/push/push.go
@@ -238,6 +238,11 @@ func ParseRequest(logger log.Logger, userID string, maxRecvMsgSize int, r *http.
 		logValues = append(logValues, "presumedAgentIp", strings.TrimSpace(agentIP))
 	}
 
+	userAgent := r.Header.Get("User-Agent")
+	if userAgent != "" {
+		logValues = append(logValues, "userAgent", strings.TrimSpace(userAgent))
+	}
+
 	logValues = append(logValues, pushStats.Extra...)
 	level.Debug(logger).Log(logValues...)
 


### PR DESCRIPTION
When capturing statistics regarding the most recent push request, extract the `User-Agent` header value from the request headers.  If this value is included, strip off the trailing '/.*' content and include the agent value in the log line.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Adds User-Agent to the distributor logging so we can track agent types along with lag metrics.

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
