### PR TITLE
chore: Rename Sender and PlaybackManager to Producer and Consumer

### DIFF
--- a/pkg/limits/producer_test.go
+++ b/pkg/limits/producer_test.go
@@ -13,16 +13,16 @@ import (
 	"github.com/grafana/loki/v3/pkg/limits/proto"
 )
 
-func TestSender_Produce(t *testing.T) {
+func TestProducer_Produce(t *testing.T) {
 	kafka := mockKafka{}
-	s := NewSender(&kafka, "topic", 1, "zone1", log.NewNopLogger(), prometheus.NewRegistry())
+	p := NewProducer(&kafka, "topic", 1, "zone1", log.NewNopLogger(), prometheus.NewRegistry())
 	// Record should be produced.
 	metadata := &proto.StreamMetadata{
 		StreamHash: 0x1,
 		TotalSize:  100,
 	}
 	ctx := context.Background()
-	require.NoError(t, s.Produce(ctx, "tenant", metadata))
+	require.NoError(t, p.Produce(ctx, "tenant", metadata))
 	expectedMetadataRecord := proto.StreamMetadataRecord{
 		Zone:     "zone1",
 		Tenant:   "tenant",
@@ -41,6 +41,6 @@ func TestSender_Produce(t *testing.T) {
 	kafka.produceFailer = func(_ *kgo.Record) error {
 		return errors.New("failed to produce record")
 	}
-	require.NoError(t, s.Produce(ctx, "tenant", metadata))
+	require.NoError(t, p.Produce(ctx, "tenant", metadata))
 	require.Equal(t, []*kgo.Record{}, kafka.produced)
 }

--- a/pkg/limits/service_test.go
+++ b/pkg/limits/service_test.go
@@ -334,7 +334,7 @@ func TestIngestLimits_ExceedsLimits(t *testing.T) {
 				usage:            tt.usage,
 				partitionManager: NewPartitionManager(),
 				clock:            clock,
-				sender:           NewSender(&kafkaClient, "test", tt.numPartitions, "", log.NewNopLogger(), reg),
+				producer:         NewProducer(&kafkaClient, "test", tt.numPartitions, "", log.NewNopLogger(), reg),
 			}
 
 			// Assign the Partition IDs.
@@ -423,7 +423,7 @@ func TestIngestLimits_ExceedsLimits_Concurrent(t *testing.T) {
 		metrics:          newMetrics(reg),
 		limits:           limits,
 		clock:            clock,
-		sender:           NewSender(&kafkaClient, "test", 1, "", log.NewNopLogger(), reg),
+		producer:         NewProducer(&kafkaClient, "test", 1, "", log.NewNopLogger(), reg),
 	}
 
 	// Assign the Partition IDs.


### PR DESCRIPTION
**What this PR does / why we need it**:

Stop using indirect names that people have to figure out, use more descriptive names of what it does.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
