### PR TITLE
chore: rename struct back to Service

### DIFF
--- a/pkg/limits/http.go
+++ b/pkg/limits/http.go
@@ -18,7 +18,7 @@ type httpTenantLimitsResponse struct {
 
 // ServeHTTP implements the http.Handler interface.
 // It returns the current stream counts and status per tenant as a JSON response.
-func (s *IngestLimits) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+func (s *Service) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	tenant := mux.Vars(r)["tenant"]
 	if tenant == "" {
 		http.Error(w, "invalid tenant", http.StatusBadRequest)

--- a/pkg/limits/http_test.go
+++ b/pkg/limits/http_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestIngestLimits_ServeHTTP(t *testing.T) {
-	l := IngestLimits{
+	s := Service{
 		cfg: Config{
 			ActiveWindow: time.Minute,
 			RateWindow:   time.Minute,
@@ -52,7 +52,7 @@ func TestIngestLimits_ServeHTTP(t *testing.T) {
 
 	// Set up a mux router for the test server otherwise mux.Vars() won't work.
 	r := mux.NewRouter()
-	r.Path("/{tenant}").Methods("GET").Handler(&l)
+	r.Path("/{tenant}").Methods("GET").Handler(&s)
 	ts := httptest.NewServer(r)
 	defer ts.Close()
 

--- a/pkg/limits/service_test.go
+++ b/pkg/limits/service_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/limits/proto"
 )
 
-func TestIngestLimits_ExceedsLimits(t *testing.T) {
+func TestService_ExceedsLimits(t *testing.T) {
 	clock := quartz.NewMock(t)
 	now := clock.Now()
 
@@ -307,7 +307,7 @@ func TestIngestLimits_ExceedsLimits(t *testing.T) {
 
 			kafkaClient := mockKafka{}
 
-			s := &IngestLimits{
+			s := &Service{
 				cfg: Config{
 					NumPartitions: tt.numPartitions,
 					ActiveWindow:  tt.ActiveWindow,
@@ -396,7 +396,7 @@ func TestIngestLimits_ExceedsLimits_Concurrent(t *testing.T) {
 		locks: make([]stripeLock, 1),
 	}
 
-	s := &IngestLimits{
+	s := &Service{
 		cfg: Config{
 			NumPartitions: 1,
 			ActiveWindow:  time.Hour,
@@ -454,7 +454,7 @@ func TestIngestLimits_ExceedsLimits_Concurrent(t *testing.T) {
 	require.Equal(t, 50, len(kafkaClient.produced))
 }
 
-func TestNewIngestLimits(t *testing.T) {
+func TestNew(t *testing.T) {
 	cfg := Config{
 		KafkaConfig: kafka.Config{
 			Topic:        "test-topic",
@@ -482,7 +482,7 @@ func TestNewIngestLimits(t *testing.T) {
 		IngestionRate:    1000,
 	}
 
-	s, err := NewIngestLimits(cfg, limits, log.NewNopLogger(), prometheus.NewRegistry())
+	s, err := New(cfg, limits, log.NewNopLogger(), prometheus.NewRegistry())
 	require.NoError(t, err)
 	require.NotNil(t, s)
 	require.NotNil(t, s.clientReader)

--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -391,7 +391,7 @@ type Loki struct {
 	tenantConfigs             *runtime.TenantConfigs
 	TenantLimits              validation.TenantLimits
 	distributor               *distributor.Distributor
-	ingestLimits              *limits.IngestLimits
+	ingestLimits              *limits.Service
 	ingestLimitsRing          *ring.Ring
 	ingestLimitsFrontend      *limits_frontend.Frontend
 	ingestLimitsFrontendRing  *ring.Ring

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -444,7 +444,7 @@ func (t *Loki) initIngestLimits() (services.Service, error) {
 	t.Cfg.IngestLimits.LifecyclerConfig.ListenPort = t.Cfg.Server.GRPCListenPort
 	t.Cfg.IngestLimits.KafkaConfig = t.Cfg.KafkaConfig
 
-	ingestLimits, err := limits.NewIngestLimits(
+	ingestLimits, err := limits.New(
 		t.Cfg.IngestLimits,
 		t.Overrides,
 		util_log.Logger,


### PR DESCRIPTION
**What this PR does / why we need it**:

Renames `IngestLimits` back to `Service` so we have the following exported types/functions:

```
type Service struct{ ... }
    func New(cfg Config, lims Limits, logger log.Logger, reg prometheus.Registerer) (*Service, error)
```

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
