### PR TITLE
chore: remove unused rate limit adapter

### DIFF
--- a/pkg/limits/limit.go
+++ b/pkg/limits/limit.go
@@ -29,23 +29,3 @@ type Limits interface {
 	IngestionBurstSizeBytes(userID string) int
 	MaxGlobalStreamsPerUser(userID string) int
 }
-
-// RateLimitsAdapter implements the dskit.RateLimiterStrategy interface. We use
-// it to load per-tenant rate limits into dskit.RateLimiter.
-type RateLimitsAdapter struct {
-	limits Limits
-}
-
-func NewRateLimitsAdapter(limits Limits) *RateLimitsAdapter {
-	return &RateLimitsAdapter{limits: limits}
-}
-
-// Limit implements dskit.RateLimiterStrategy.
-func (s *RateLimitsAdapter) Limit(tenantID string) float64 {
-	return s.limits.IngestionRateBytes(tenantID)
-}
-
-// Burst implements dskit.RateLimiterStrategy.
-func (s *RateLimitsAdapter) Burst(tenantID string) int {
-	return s.limits.IngestionBurstSizeBytes(tenantID)
-}


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes the unused `RateLimitAdapter` in `limit.go`.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
