### PR TITLE
chore: cleanup exported types in `pkg/limits`

### DIFF
--- a/pkg/limits/consumer.go
+++ b/pkg/limits/consumer.go
@@ -27,7 +27,7 @@ type kafkaConsumer interface {
 type consumer struct {
 	client           kafkaConsumer
 	partitionManager *partitionManager
-	usage            *UsageStore
+	usage            *usageStore
 	// readinessCheck checks if a waiting or replaying partition can be
 	// switched to ready.
 	readinessCheck partitionReadinessCheck
@@ -49,7 +49,7 @@ type consumer struct {
 func newConsumer(
 	client kafkaConsumer,
 	partitionManager *partitionManager,
-	usage *UsageStore,
+	usage *usageStore,
 	readinessCheck partitionReadinessCheck,
 	zone string,
 	logger log.Logger,
@@ -177,7 +177,7 @@ func (c *consumer) processRecord(_ context.Context, state partitionState, r *kgo
 		c.recordsDiscarded.Inc()
 		return nil
 	}
-	c.usage.Update(s.Tenant, []*proto.StreamMetadata{s.Metadata}, r.Timestamp, nil)
+	c.usage.update(s.Tenant, []*proto.StreamMetadata{s.Metadata}, r.Timestamp, nil)
 	return nil
 }
 

--- a/pkg/limits/consumer.go
+++ b/pkg/limits/consumer.go
@@ -17,20 +17,20 @@ import (
 	"github.com/grafana/loki/v3/pkg/limits/proto"
 )
 
-// KafkaConsumer allows mocking of certain [kgo.Client] methods in tests.
-type KafkaConsumer interface {
+// kafkaConsumer allows mocking of certain [kgo.Client] methods in tests.
+type kafkaConsumer interface {
 	PollFetches(context.Context) kgo.Fetches
 }
 
-// Consumer processes records from the metadata topic. It is responsible for
+// consumer processes records from the metadata topic. It is responsible for
 // replaying newly assigned partitions and merging records from other zones.
-type Consumer struct {
-	client           KafkaConsumer
-	partitionManager *PartitionManager
+type consumer struct {
+	client           kafkaConsumer
+	partitionManager *partitionManager
 	usage            *UsageStore
 	// readinessCheck checks if a waiting or replaying partition can be
 	// switched to ready.
-	readinessCheck PartitionReadinessCheck
+	readinessCheck partitionReadinessCheck
 	// zone is used to discard our own records.
 	zone   string
 	logger log.Logger
@@ -45,17 +45,17 @@ type Consumer struct {
 	clock quartz.Clock
 }
 
-// NewConsumer returns a new Consumer.
-func NewConsumer(
-	client KafkaConsumer,
-	partitionManager *PartitionManager,
+// newConsumer returns a new Consumer.
+func newConsumer(
+	client kafkaConsumer,
+	partitionManager *partitionManager,
 	usage *UsageStore,
-	readinessCheck PartitionReadinessCheck,
+	readinessCheck partitionReadinessCheck,
 	zone string,
 	logger log.Logger,
 	reg prometheus.Registerer,
-) *Consumer {
-	return &Consumer{
+) *consumer {
+	return &consumer{
 		client:           client,
 		partitionManager: partitionManager,
 		usage:            usage,
@@ -94,7 +94,7 @@ func NewConsumer(
 	}
 }
 
-func (c *Consumer) Run(ctx context.Context) {
+func (c *consumer) run(ctx context.Context) {
 	b := backoff.New(ctx, backoff.Config{
 		MinBackoff: 100 * time.Millisecond,
 		MaxBackoff: time.Second,
@@ -116,7 +116,7 @@ func (c *Consumer) Run(ctx context.Context) {
 	}
 }
 
-func (c *Consumer) pollFetches(ctx context.Context) error {
+func (c *consumer) pollFetches(ctx context.Context) error {
 	fetches := c.client.PollFetches(ctx)
 	if err := fetches.Err(); err != nil {
 		return err
@@ -125,7 +125,7 @@ func (c *Consumer) pollFetches(ctx context.Context) error {
 	return nil
 }
 
-func (c *Consumer) processFetchTopicPartition(ctx context.Context) func(kgo.FetchTopicPartition) {
+func (c *consumer) processFetchTopicPartition(ctx context.Context) func(kgo.FetchTopicPartition) {
 	return func(p kgo.FetchTopicPartition) {
 		// When used with [kgo.EachPartition], this function is called once
 		// for each partition in a fetch, including partitions that have not
@@ -140,7 +140,7 @@ func (c *Consumer) processFetchTopicPartition(ctx context.Context) func(kgo.Fetc
 		// We need the state of the partition so we can discard any records
 		// that we produced (unless replaying) and mark a replaying partition
 		// as ready once it has finished replaying.
-		state, ok := c.partitionManager.GetState(p.Partition)
+		state, ok := c.partitionManager.getState(p.Partition)
 		if !ok {
 			c.recordsDiscarded.Add(float64(len(p.Records)))
 			level.Warn(logger).Log("msg", "discarding records for partition as the partition is not assigned to this client")
@@ -154,25 +154,25 @@ func (c *Consumer) processFetchTopicPartition(ctx context.Context) func(kgo.Fetc
 		// Get the last record (has the latest offset and timestamp).
 		lastRecord := p.Records[len(p.Records)-1]
 		c.lag.Observe(c.clock.Since(lastRecord.Timestamp).Seconds())
-		if state == PartitionReplaying {
+		if state == partitionReplaying {
 			passed, err := c.readinessCheck(p.Partition, lastRecord)
 			if err != nil {
 				level.Error(logger).Log("msg", "failed to run readiness check", "err", err.Error())
 			} else if passed {
 				level.Debug(logger).Log("msg", "passed readiness check, partition is ready")
-				c.partitionManager.SetReady(p.Partition)
+				c.partitionManager.setReady(p.Partition)
 			}
 		}
 	}
 }
 
-func (c *Consumer) processRecord(_ context.Context, state PartitionState, r *kgo.Record) error {
+func (c *consumer) processRecord(_ context.Context, state partitionState, r *kgo.Record) error {
 	s := proto.StreamMetadataRecord{}
 	if err := s.Unmarshal(r.Value); err != nil {
 		c.recordsInvalid.Inc()
 		return fmt.Errorf("corrupted record: %w", err)
 	}
-	if state == PartitionReady && c.zone == s.Zone {
+	if state == partitionReady && c.zone == s.Zone {
 		// Discard our own records so we don't count the same streams twice.
 		c.recordsDiscarded.Inc()
 		return nil
@@ -181,12 +181,12 @@ func (c *Consumer) processRecord(_ context.Context, state PartitionState, r *kgo
 	return nil
 }
 
-type PartitionReadinessCheck func(partition int32, r *kgo.Record) (bool, error)
+type partitionReadinessCheck func(partition int32, r *kgo.Record) (bool, error)
 
-// NewOffsetReadinessCheck marks a partition as ready if the target offset
+// newOffsetReadinessCheck marks a partition as ready if the target offset
 // has been reached.
-func NewOffsetReadinessCheck(partitionManager *PartitionManager) PartitionReadinessCheck {
+func newOffsetReadinessCheck(partitionManager *partitionManager) partitionReadinessCheck {
 	return func(partition int32, r *kgo.Record) (bool, error) {
-		return partitionManager.TargetOffsetReached(partition, r.Offset), nil
+		return partitionManager.targetOffsetReached(partition, r.Offset), nil
 	}
 }

--- a/pkg/limits/consumer_test.go
+++ b/pkg/limits/consumer_test.go
@@ -53,7 +53,7 @@ func TestConsumer_ProcessRecords(t *testing.T) {
 		require.NoError(t, c.pollFetches(ctx))
 		// Check that the record was stored.
 		var n int
-		u.all(func(_ string, _ int32, _ Stream) { n++ })
+		u.all(func(_ string, _ int32, _ streamUsage) { n++ })
 		require.Equal(t, 1, n)
 	})
 
@@ -97,7 +97,7 @@ func TestConsumer_ProcessRecords(t *testing.T) {
 		require.NoError(t, c.pollFetches(ctx))
 		// Check that the record was discarded.
 		var n int
-		u.all(func(_ string, _ int32, _ Stream) { n++ })
+		u.all(func(_ string, _ int32, _ streamUsage) { n++ })
 		require.Equal(t, 0, n)
 	})
 }
@@ -175,7 +175,7 @@ func TestConsumer_ReadinessCheck(t *testing.T) {
 	require.Equal(t, partitionReplaying, state)
 	// Check that the record was stored.
 	var n int
-	u.all(func(_ string, _ int32, _ Stream) { n++ })
+	u.all(func(_ string, _ int32, _ streamUsage) { n++ })
 	require.Equal(t, 1, n)
 	// The second poll should fetch the second (and last) record.
 	require.NoError(t, c.pollFetches(ctx))
@@ -186,6 +186,6 @@ func TestConsumer_ReadinessCheck(t *testing.T) {
 	require.Equal(t, partitionReady, state)
 	// Check that the record was stored.
 	n = 0
-	u.all(func(_ string, _ int32, _ Stream) { n++ })
+	u.all(func(_ string, _ int32, _ streamUsage) { n++ })
 	require.Equal(t, 2, n)
 }

--- a/pkg/limits/consumer_test.go
+++ b/pkg/limits/consumer_test.go
@@ -47,13 +47,13 @@ func TestConsumer_ProcessRecords(t *testing.T) {
 		m.setReplaying(1, 1000)
 		// Create a usage store, we will use this to check if the record
 		// was stored.
-		u := NewUsageStore(DefaultActiveWindow, DefaultRateWindow, DefaultBucketSize, 1)
+		u := newUsageStore(DefaultActiveWindow, DefaultRateWindow, DefaultBucketSize, 1)
 		c := newConsumer(&k, m, u, newOffsetReadinessCheck(m), "zone1",
 			log.NewNopLogger(), prometheus.NewRegistry())
 		require.NoError(t, c.pollFetches(ctx))
 		// Check that the record was stored.
 		var n int
-		u.All(func(_ string, _ int32, _ Stream) { n++ })
+		u.all(func(_ string, _ int32, _ Stream) { n++ })
 		require.Equal(t, 1, n)
 	})
 
@@ -91,13 +91,13 @@ func TestConsumer_ProcessRecords(t *testing.T) {
 		m.setReady(1)
 		// Create a usage store, we will use this to check if the record
 		// was discarded.
-		u := NewUsageStore(DefaultActiveWindow, DefaultRateWindow, DefaultBucketSize, 1)
+		u := newUsageStore(DefaultActiveWindow, DefaultRateWindow, DefaultBucketSize, 1)
 		c := newConsumer(&k, m, u, newOffsetReadinessCheck(m), "zone1",
 			log.NewNopLogger(), prometheus.NewRegistry())
 		require.NoError(t, c.pollFetches(ctx))
 		// Check that the record was discarded.
 		var n int
-		u.All(func(_ string, _ int32, _ Stream) { n++ })
+		u.all(func(_ string, _ int32, _ Stream) { n++ })
 		require.Equal(t, 0, n)
 	})
 }
@@ -163,7 +163,7 @@ func TestConsumer_ReadinessCheck(t *testing.T) {
 	// has been consumed.
 	m.setReplaying(1, 2)
 	// We don't need the usage store for this test.
-	u := NewUsageStore(DefaultActiveWindow, DefaultRateWindow, DefaultBucketSize, 1)
+	u := newUsageStore(DefaultActiveWindow, DefaultRateWindow, DefaultBucketSize, 1)
 	c := newConsumer(&k, m, u, newOffsetReadinessCheck(m), "zone1",
 		log.NewNopLogger(), prometheus.NewRegistry())
 	// The first poll should fetch the first record.
@@ -175,7 +175,7 @@ func TestConsumer_ReadinessCheck(t *testing.T) {
 	require.Equal(t, partitionReplaying, state)
 	// Check that the record was stored.
 	var n int
-	u.All(func(_ string, _ int32, _ Stream) { n++ })
+	u.all(func(_ string, _ int32, _ Stream) { n++ })
 	require.Equal(t, 1, n)
 	// The second poll should fetch the second (and last) record.
 	require.NoError(t, c.pollFetches(ctx))
@@ -186,6 +186,6 @@ func TestConsumer_ReadinessCheck(t *testing.T) {
 	require.Equal(t, partitionReady, state)
 	// Check that the record was stored.
 	n = 0
-	u.All(func(_ string, _ int32, _ Stream) { n++ })
+	u.all(func(_ string, _ int32, _ Stream) { n++ })
 	require.Equal(t, 2, n)
 }

--- a/pkg/limits/consumer_test.go
+++ b/pkg/limits/consumer_test.go
@@ -42,13 +42,13 @@ func TestConsumer_ProcessRecords(t *testing.T) {
 		}
 		ctx := context.Background()
 		// Need to assign the partition and set it to ready.
-		m := NewPartitionManager()
-		m.Assign(ctx, []int32{1})
-		m.SetReplaying(1, 1000)
+		m := newPartitionManager()
+		m.assign(ctx, []int32{1})
+		m.setReplaying(1, 1000)
 		// Create a usage store, we will use this to check if the record
 		// was stored.
 		u := NewUsageStore(DefaultActiveWindow, DefaultRateWindow, DefaultBucketSize, 1)
-		c := NewConsumer(&k, m, u, NewOffsetReadinessCheck(m), "zone1",
+		c := newConsumer(&k, m, u, newOffsetReadinessCheck(m), "zone1",
 			log.NewNopLogger(), prometheus.NewRegistry())
 		require.NoError(t, c.pollFetches(ctx))
 		// Check that the record was stored.
@@ -86,13 +86,13 @@ func TestConsumer_ProcessRecords(t *testing.T) {
 		}
 		ctx := context.Background()
 		// Need to assign the partition and set it to ready.
-		m := NewPartitionManager()
-		m.Assign(ctx, []int32{1})
-		m.SetReady(1)
+		m := newPartitionManager()
+		m.assign(ctx, []int32{1})
+		m.setReady(1)
 		// Create a usage store, we will use this to check if the record
 		// was discarded.
 		u := NewUsageStore(DefaultActiveWindow, DefaultRateWindow, DefaultBucketSize, 1)
-		c := NewConsumer(&k, m, u, NewOffsetReadinessCheck(m), "zone1",
+		c := newConsumer(&k, m, u, newOffsetReadinessCheck(m), "zone1",
 			log.NewNopLogger(), prometheus.NewRegistry())
 		require.NoError(t, c.pollFetches(ctx))
 		// Check that the record was discarded.
@@ -157,22 +157,22 @@ func TestConsumer_ReadinessCheck(t *testing.T) {
 	}
 	ctx := context.Background()
 	// Need to assign the partition and set it to replaying.
-	m := NewPartitionManager()
-	m.Assign(ctx, []int32{1})
+	m := newPartitionManager()
+	m.assign(ctx, []int32{1})
 	// The partition should be marked ready when the second record
 	// has been consumed.
-	m.SetReplaying(1, 2)
+	m.setReplaying(1, 2)
 	// We don't need the usage store for this test.
 	u := NewUsageStore(DefaultActiveWindow, DefaultRateWindow, DefaultBucketSize, 1)
-	c := NewConsumer(&k, m, u, NewOffsetReadinessCheck(m), "zone1",
+	c := newConsumer(&k, m, u, newOffsetReadinessCheck(m), "zone1",
 		log.NewNopLogger(), prometheus.NewRegistry())
 	// The first poll should fetch the first record.
 	require.NoError(t, c.pollFetches(ctx))
 	// The partition should still be replaying as we have not read up to
 	// the target offset.
-	state, ok := m.GetState(1)
+	state, ok := m.getState(1)
 	require.True(t, ok)
-	require.Equal(t, PartitionReplaying, state)
+	require.Equal(t, partitionReplaying, state)
 	// Check that the record was stored.
 	var n int
 	u.All(func(_ string, _ int32, _ Stream) { n++ })
@@ -181,9 +181,9 @@ func TestConsumer_ReadinessCheck(t *testing.T) {
 	require.NoError(t, c.pollFetches(ctx))
 	// The partition should still be ready as we have read up to the target
 	// offset.
-	state, ok = m.GetState(1)
+	state, ok = m.getState(1)
 	require.True(t, ok)
-	require.Equal(t, PartitionReady, state)
+	require.Equal(t, partitionReady, state)
 	// Check that the record was stored.
 	n = 0
 	u.All(func(_ string, _ int32, _ Stream) { n++ })

--- a/pkg/limits/evict_test.go
+++ b/pkg/limits/evict_test.go
@@ -15,7 +15,7 @@ type mockEvictable struct {
 	clock quartz.Clock
 }
 
-func (m *mockEvictable) Evict(_ context.Context) error {
+func (m *mockEvictable) evict(_ context.Context) error {
 	m.calls = append(m.calls, m.clock.Now())
 	return nil
 }
@@ -27,7 +27,7 @@ func TestEvictor(t *testing.T) {
 
 	clock := quartz.NewMock(t)
 	m := mockEvictable{clock: clock}
-	e, err := NewEvictor(ctx, time.Second, &m, log.NewNopLogger())
+	e, err := newEvictor(ctx, time.Second, &m, log.NewNopLogger())
 	require.NoError(t, err)
 	e.clock = clock
 

--- a/pkg/limits/frontend/cache_test.go
+++ b/pkg/limits/frontend/cache_test.go
@@ -9,114 +9,114 @@ import (
 )
 
 func TestTTLCache_Get(t *testing.T) {
-	c := NewTTLCache[string, string](time.Minute)
+	c := newTTLCache[string, string](time.Minute)
 	clock := quartz.NewMock(t)
 	c.clock = clock
 	// The value should be absent.
-	value, ok := c.Get("foo")
+	value, ok := c.get("foo")
 	require.Equal(t, "", value)
 	require.False(t, ok)
 	// Set the value and it should be present.
-	c.Set("foo", "bar")
-	value, ok = c.Get("foo")
+	c.set("foo", "bar")
+	value, ok = c.get("foo")
 	require.Equal(t, "bar", value)
 	require.True(t, ok)
 	// Advance the time to be 1 second before the expiration time.
 	clock.Advance(59 * time.Second)
-	value, ok = c.Get("foo")
+	value, ok = c.get("foo")
 	require.Equal(t, "bar", value)
 	require.True(t, ok)
 	// Advance the time to be equal to the expiration time, the value should
 	// be absent.
 	clock.Advance(time.Second)
-	value, ok = c.Get("foo")
+	value, ok = c.get("foo")
 	require.Equal(t, "", value)
 	require.False(t, ok)
 	// Advance the time past the expiration time, the value should still be
 	// absent.
 	clock.Advance(time.Second)
-	value, ok = c.Get("foo")
+	value, ok = c.get("foo")
 	require.Equal(t, "", value)
 	require.False(t, ok)
 }
 
 func TestTTLCache_Set(t *testing.T) {
-	c := NewTTLCache[string, string](time.Minute)
+	c := newTTLCache[string, string](time.Minute)
 	clock := quartz.NewMock(t)
 	c.clock = clock
-	c.Set("foo", "bar")
+	c.set("foo", "bar")
 	item1, ok := c.items["foo"]
 	require.True(t, ok)
 	require.Equal(t, c.clock.Now().Add(time.Minute), item1.expiresAt)
 	// Set should refresh the expiration time.
 	clock.Advance(time.Second)
-	c.Set("foo", "bar")
+	c.set("foo", "bar")
 	item2, ok := c.items["foo"]
 	require.True(t, ok)
 	require.Greater(t, item2.expiresAt, item1.expiresAt)
 	require.Equal(t, item2.expiresAt, item1.expiresAt.Add(time.Second))
 	// Set should replace the value.
-	c.Set("foo", "baz")
-	value, ok := c.Get("foo")
+	c.set("foo", "baz")
+	value, ok := c.get("foo")
 	require.True(t, ok)
 	require.Equal(t, "baz", value)
 }
 
 func TestTTLCache_Delete(t *testing.T) {
-	c := NewTTLCache[string, string](time.Minute)
+	c := newTTLCache[string, string](time.Minute)
 	clock := quartz.NewMock(t)
 	c.clock = clock
 	// Set the value and it should be present.
-	c.Set("foo", "bar")
-	value, ok := c.Get("foo")
+	c.set("foo", "bar")
+	value, ok := c.get("foo")
 	require.True(t, ok)
 	require.Equal(t, "bar", value)
 	// Delete the value, it should be absent.
-	c.Delete("foo")
-	value, ok = c.Get("foo")
+	c.delete("foo")
+	value, ok = c.get("foo")
 	require.False(t, ok)
 	require.Equal(t, "", value)
 }
 
 func TestTTLCache_Reset(t *testing.T) {
-	c := NewTTLCache[string, string](time.Minute)
+	c := newTTLCache[string, string](time.Minute)
 	clock := quartz.NewMock(t)
 	c.clock = clock
 	// Set two values, both should be present.
-	c.Set("foo", "bar")
-	value, ok := c.Get("foo")
+	c.set("foo", "bar")
+	value, ok := c.get("foo")
 	require.True(t, ok)
 	require.Equal(t, "bar", value)
-	c.Set("bar", "baz")
-	value, ok = c.Get("bar")
+	c.set("bar", "baz")
+	value, ok = c.get("bar")
 	require.True(t, ok)
 	require.Equal(t, "baz", value)
 	// Reset the cache, all should be absent.
-	c.Reset()
-	value, ok = c.Get("foo")
+	c.reset()
+	value, ok = c.get("foo")
 	require.False(t, ok)
 	require.Equal(t, "", value)
-	value, ok = c.Get("bar")
+	value, ok = c.get("bar")
 	require.False(t, ok)
 	require.Equal(t, "", value)
 	// Should be able to set values following a reset.
-	c.Set("baz", "qux")
-	value, ok = c.Get("baz")
+	c.set("baz", "qux")
+	value, ok = c.get("baz")
 	require.True(t, ok)
 	require.Equal(t, "qux", value)
 }
 
 func TestTTLCache_EvictExpired(t *testing.T) {
-	c := NewTTLCache[string, string](time.Minute)
+	c := newTTLCache[string, string](time.Minute)
 	clock := quartz.NewMock(t)
 	c.clock = clock
-	c.Set("foo", "bar")
+	c.set("foo", "bar")
 	_, ok := c.items["foo"]
 	require.True(t, ok)
 	// Advance the clock and update foo, it should not be evicted as its
 	// expiration time should be refreshed.
 	clock.Advance(time.Minute)
-	c.Set("foo", "bar")
+	c.set("foo", "bar")
 	_, ok = c.items["foo"]
 	require.True(t, ok)
 	eviction1 := clock.Now()
@@ -125,7 +125,7 @@ func TestTTLCache_EvictExpired(t *testing.T) {
 	// the TTL (30 seconds) since the last eviction, no eviction should
 	// be run.
 	clock.Advance(15 * time.Second)
-	c.Set("bar", "baz")
+	c.set("bar", "baz")
 	_, ok = c.items["foo"]
 	require.True(t, ok)
 	_, ok = c.items["bar"]
@@ -135,7 +135,7 @@ func TestTTLCache_EvictExpired(t *testing.T) {
 	// since the last eviction, an eviction should be run, but no items should
 	// be evicted.
 	clock.Advance(16 * time.Second)
-	c.Set("baz", "qux")
+	c.set("baz", "qux")
 	_, ok = c.items["foo"]
 	require.True(t, ok)
 	_, ok = c.items["bar"]
@@ -148,7 +148,7 @@ func TestTTLCache_EvictExpired(t *testing.T) {
 	// than half the TTL (seconds) since the last eviction, no eviction should
 	// be run.
 	clock.Advance(15 * time.Second)
-	c.Set("qux", "corge")
+	c.set("qux", "corge")
 	_, ok = c.items["foo"]
 	require.True(t, ok)
 	_, ok = c.items["bar"]
@@ -162,7 +162,7 @@ func TestTTLCache_EvictExpired(t *testing.T) {
 	// half the TTL since the last eviction, an eviction should be run and
 	// this time foo should be evicted as it has expired.
 	clock.Advance(16 * time.Second)
-	c.Set("corge", "jorge")
+	c.set("corge", "jorge")
 	_, ok = c.items["foo"]
 	require.False(t, ok)
 	_, ok = c.items["bar"]
@@ -177,7 +177,7 @@ func TestTTLCache_EvictExpired(t *testing.T) {
 	require.Equal(t, eviction3, c.lastEvictedAt)
 	// Advance the clock one whole minute. All items should be expired.
 	clock.Advance(time.Minute)
-	c.Set("foo", "bar")
+	c.set("foo", "bar")
 	_, ok = c.items["foo"]
 	require.True(t, ok)
 	_, ok = c.items["bar"]
@@ -193,14 +193,14 @@ func TestTTLCache_EvictExpired(t *testing.T) {
 }
 
 func TestNopCache(t *testing.T) {
-	c := NewNopCache[string, string]()
+	c := newNopCache[string, string]()
 	// The value should be absent.
-	value, ok := c.Get("foo")
+	value, ok := c.get("foo")
 	require.Equal(t, "", value)
 	require.False(t, ok)
 	// Despite setting the value, it should still be absent.
-	c.Set("foo", "bar")
-	value, ok = c.Get("foo")
+	c.set("foo", "bar")
+	value, ok = c.get("foo")
 	require.Equal(t, "", value)
 	require.False(t, ok)
 }

--- a/pkg/limits/frontend/frontend.go
+++ b/pkg/limits/frontend/frontend.go
@@ -26,7 +26,7 @@ type Frontend struct {
 	services.Service
 	cfg                     Config
 	logger                  log.Logger
-	gatherer                ExceedsLimitsGatherer
+	gatherer                exceedsLimitsGatherer
 	assignedPartitionsCache cache[string, *proto.GetAssignedPartitionsResponse]
 	subservices             *services.Manager
 	subservicesWatcher      *services.FailureWatcher
@@ -55,7 +55,7 @@ func New(cfg Config, ringName string, limitsRing ring.ReadRing, logger log.Logge
 	} else {
 		assignedPartitionsCache = newTTLCache[string, *proto.GetAssignedPartitionsResponse](cfg.AssignedPartitionsCacheTTL)
 	}
-	gatherer := NewRingGatherer(limitsRing, clientPool, cfg.NumPartitions, assignedPartitionsCache, logger)
+	gatherer := newRingGatherer(limitsRing, clientPool, cfg.NumPartitions, assignedPartitionsCache, logger)
 
 	f := &Frontend{
 		cfg:                     cfg,
@@ -89,7 +89,7 @@ func New(cfg Config, ringName string, limitsRing ring.ReadRing, logger log.Logge
 
 // ExceedsLimits implements proto.IngestLimitsFrontendClient.
 func (f *Frontend) ExceedsLimits(ctx context.Context, req *proto.ExceedsLimitsRequest) (*proto.ExceedsLimitsResponse, error) {
-	resps, err := f.gatherer.ExceedsLimits(ctx, req)
+	resps, err := f.gatherer.exceedsLimits(ctx, req)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/limits/frontend/frontend.go
+++ b/pkg/limits/frontend/frontend.go
@@ -27,7 +27,7 @@ type Frontend struct {
 	cfg                     Config
 	logger                  log.Logger
 	gatherer                ExceedsLimitsGatherer
-	assignedPartitionsCache Cache[string, *proto.GetAssignedPartitionsResponse]
+	assignedPartitionsCache cache[string, *proto.GetAssignedPartitionsResponse]
 	subservices             *services.Manager
 	subservicesWatcher      *services.FailureWatcher
 	lifecycler              *ring.Lifecycler
@@ -48,12 +48,12 @@ func New(cfg Config, ringName string, limitsRing ring.ReadRing, logger log.Logge
 	)
 
 	// Set up the assigned partitions cache.
-	var assignedPartitionsCache Cache[string, *proto.GetAssignedPartitionsResponse]
+	var assignedPartitionsCache cache[string, *proto.GetAssignedPartitionsResponse]
 	if cfg.AssignedPartitionsCacheTTL == 0 {
 		// When the TTL is 0, the cache is disabled.
-		assignedPartitionsCache = NewNopCache[string, *proto.GetAssignedPartitionsResponse]()
+		assignedPartitionsCache = newNopCache[string, *proto.GetAssignedPartitionsResponse]()
 	} else {
-		assignedPartitionsCache = NewTTLCache[string, *proto.GetAssignedPartitionsResponse](cfg.AssignedPartitionsCacheTTL)
+		assignedPartitionsCache = newTTLCache[string, *proto.GetAssignedPartitionsResponse](cfg.AssignedPartitionsCacheTTL)
 	}
 	gatherer := NewRingGatherer(limitsRing, clientPool, cfg.NumPartitions, assignedPartitionsCache, logger)
 

--- a/pkg/limits/frontend/gather.go
+++ b/pkg/limits/frontend/gather.go
@@ -6,9 +6,9 @@ import (
 	"github.com/grafana/loki/v3/pkg/limits/proto"
 )
 
-type ExceedsLimitsGatherer interface {
-	// ExceedsLimits checks if the streams in the request have exceeded their
+type exceedsLimitsGatherer interface {
+	// exceedsLimits checks if the streams in the request have exceeded their
 	// per-partition limits. It returns more than one response when the
 	// requested streams are sharded over two or more limits instances.
-	ExceedsLimits(context.Context, *proto.ExceedsLimitsRequest) ([]*proto.ExceedsLimitsResponse, error)
+	exceedsLimits(context.Context, *proto.ExceedsLimitsRequest) ([]*proto.ExceedsLimitsResponse, error)
 }

--- a/pkg/limits/frontend/mock_test.go
+++ b/pkg/limits/frontend/mock_test.go
@@ -25,7 +25,7 @@ type mockExceedsLimitsGatherer struct {
 	exceedsLimitsResponses       []*proto.ExceedsLimitsResponse
 }
 
-func (g *mockExceedsLimitsGatherer) ExceedsLimits(_ context.Context, req *proto.ExceedsLimitsRequest) ([]*proto.ExceedsLimitsResponse, error) {
+func (g *mockExceedsLimitsGatherer) exceedsLimits(_ context.Context, req *proto.ExceedsLimitsRequest) ([]*proto.ExceedsLimitsResponse, error) {
 	if expected := g.expectedExceedsLimitsRequest; expected != nil {
 		require.Equal(g.t, expected, req)
 	}

--- a/pkg/limits/frontend/ring.go
+++ b/pkg/limits/frontend/ring.go
@@ -21,8 +21,8 @@ var (
 	LimitsRead = ring.NewOp([]ring.InstanceState{ring.ACTIVE}, nil)
 )
 
-// RingGatherer uses a ring to find limits instances.
-type RingGatherer struct {
+// ringGatherer uses a ring to find limits instances.
+type ringGatherer struct {
 	logger                  log.Logger
 	ring                    ring.ReadRing
 	pool                    *ring_client.Pool
@@ -30,15 +30,15 @@ type RingGatherer struct {
 	assignedPartitionsCache cache[string, *proto.GetAssignedPartitionsResponse]
 }
 
-// NewRingGatherer returns a new RingGatherer.
-func NewRingGatherer(
+// newRingGatherer returns a new ringGatherer.
+func newRingGatherer(
 	ring ring.ReadRing,
 	pool *ring_client.Pool,
 	numPartitions int,
 	assignedPartitionsCache cache[string, *proto.GetAssignedPartitionsResponse],
 	logger log.Logger,
-) *RingGatherer {
-	return &RingGatherer{
+) *ringGatherer {
+	return &ringGatherer{
 		logger:                  logger,
 		ring:                    ring,
 		pool:                    pool,
@@ -47,8 +47,8 @@ func NewRingGatherer(
 	}
 }
 
-// ExceedsLimits implements ExceedsLimitsGatherer.
-func (g *RingGatherer) ExceedsLimits(ctx context.Context, req *proto.ExceedsLimitsRequest) ([]*proto.ExceedsLimitsResponse, error) {
+// ExceedsLimits implements the [exceedsLimitsGatherer] interface.
+func (g *ringGatherer) exceedsLimits(ctx context.Context, req *proto.ExceedsLimitsRequest) ([]*proto.ExceedsLimitsResponse, error) {
 	if len(req.Streams) == 0 {
 		return nil, nil
 	}
@@ -112,7 +112,7 @@ type zonePartitionConsumersResult struct {
 // zone will still be returned but its partition consumers will be nil.
 // If ZoneAwarenessEnabled is false, it returns all partition consumers under
 // a pseudo-zone ("").
-func (g *RingGatherer) getZoneAwarePartitionConsumers(ctx context.Context, instances []ring.InstanceDesc) (map[string]map[int32]string, error) {
+func (g *ringGatherer) getZoneAwarePartitionConsumers(ctx context.Context, instances []ring.InstanceDesc) (map[string]map[int32]string, error) {
 	zoneDescs := make(map[string][]ring.InstanceDesc)
 	for _, instance := range instances {
 		zoneDescs[instance.Zone] = append(zoneDescs[instance.Zone], instance)
@@ -165,7 +165,7 @@ type getAssignedPartitionsResponse struct {
 // should be called once for each zone, and instances should be filtered to
 // the respective zone. Alternatively, you can pass all instances for all zones
 // to find the most up to date consumer for each partition across all zones.
-func (g *RingGatherer) getPartitionConsumers(ctx context.Context, instances []ring.InstanceDesc) (map[int32]string, error) {
+func (g *ringGatherer) getPartitionConsumers(ctx context.Context, instances []ring.InstanceDesc) (map[int32]string, error) {
 	errg, ctx := errgroup.WithContext(ctx)
 	responseCh := make(chan getAssignedPartitionsResponse, len(instances))
 	for _, instance := range instances {

--- a/pkg/limits/frontend/ring.go
+++ b/pkg/limits/frontend/ring.go
@@ -27,7 +27,7 @@ type RingGatherer struct {
 	ring                    ring.ReadRing
 	pool                    *ring_client.Pool
 	numPartitions           int
-	assignedPartitionsCache Cache[string, *proto.GetAssignedPartitionsResponse]
+	assignedPartitionsCache cache[string, *proto.GetAssignedPartitionsResponse]
 }
 
 // NewRingGatherer returns a new RingGatherer.
@@ -35,7 +35,7 @@ func NewRingGatherer(
 	ring ring.ReadRing,
 	pool *ring_client.Pool,
 	numPartitions int,
-	assignedPartitionsCache Cache[string, *proto.GetAssignedPartitionsResponse],
+	assignedPartitionsCache cache[string, *proto.GetAssignedPartitionsResponse],
 	logger log.Logger,
 ) *RingGatherer {
 	return &RingGatherer{
@@ -173,7 +173,7 @@ func (g *RingGatherer) getPartitionConsumers(ctx context.Context, instances []ri
 			// We use a cache to eliminate redundant gRPC requests for
 			// GetAssignedPartitions as the set of assigned partitions is
 			// expected to be stable outside consumer rebalances.
-			if resp, ok := g.assignedPartitionsCache.Get(instance.Addr); ok {
+			if resp, ok := g.assignedPartitionsCache.get(instance.Addr); ok {
 				responseCh <- getAssignedPartitionsResponse{
 					addr:     instance.Addr,
 					response: resp,
@@ -190,7 +190,7 @@ func (g *RingGatherer) getPartitionConsumers(ctx context.Context, instances []ri
 				level.Error(g.logger).Log("failed to get assigned partitions for instance", "instance", instance.Addr, "err", err.Error())
 				return nil
 			}
-			g.assignedPartitionsCache.Set(instance.Addr, resp)
+			g.assignedPartitionsCache.set(instance.Addr, resp)
 			responseCh <- getAssignedPartitionsResponse{
 				addr:     instance.Addr,
 				response: resp,

--- a/pkg/limits/frontend/ring_test.go
+++ b/pkg/limits/frontend/ring_test.go
@@ -339,13 +339,13 @@ func TestRingGatherer_ExceedsLimits(t *testing.T) {
 			}
 			readRing, clientPool := newMockRingWithClientPool(t, "test", mockClients, test.instances)
 			cache := newNopCache[string, *proto.GetAssignedPartitionsResponse]()
-			g := NewRingGatherer(readRing, clientPool, test.numPartitions, cache, log.NewNopLogger())
+			g := newRingGatherer(readRing, clientPool, test.numPartitions, cache, log.NewNopLogger())
 
 			// Set a maximum upper bound on the test execution time.
 			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 			defer cancel()
 
-			actual, err := g.ExceedsLimits(ctx, test.request)
+			actual, err := g.exceedsLimits(ctx, test.request)
 			if test.expectedErr != "" {
 				require.EqualError(t, err, test.expectedErr)
 				require.Nil(t, actual)
@@ -518,7 +518,7 @@ func TestRingStreamUsageGatherer_GetZoneAwarePartitionConsumers(t *testing.T) {
 			// Set up the mocked ring and client pool for the tests.
 			readRing, clientPool := newMockRingWithClientPool(t, "test", clients, test.instances)
 			cache := newNopCache[string, *proto.GetAssignedPartitionsResponse]()
-			g := NewRingGatherer(readRing, clientPool, 2, cache, log.NewNopLogger())
+			g := newRingGatherer(readRing, clientPool, 2, cache, log.NewNopLogger())
 
 			// Set a maximum upper bound on the test execution time.
 			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
@@ -667,7 +667,7 @@ func TestRingStreamUsageGatherer_GetPartitionConsumers(t *testing.T) {
 			// Set up the mocked ring and client pool for the tests.
 			readRing, clientPool := newMockRingWithClientPool(t, "test", mockClients, test.instances)
 			cache := newNopCache[string, *proto.GetAssignedPartitionsResponse]()
-			g := NewRingGatherer(readRing, clientPool, 1, cache, log.NewNopLogger())
+			g := newRingGatherer(readRing, clientPool, 1, cache, log.NewNopLogger())
 
 			// Set a maximum upper bound on the test execution time.
 			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
@@ -711,7 +711,7 @@ func TestRingStreamUsageGatherer_GetPartitionConsumers_IsCached(t *testing.T) {
 	// Set the cache TTL large enough that entries cannot expire (flake)
 	// during slow test runs.
 	cache := newTTLCache[string, *proto.GetAssignedPartitionsResponse](time.Minute)
-	g := NewRingGatherer(readRing, clientPool, 2, cache, log.NewNopLogger())
+	g := newRingGatherer(readRing, clientPool, 2, cache, log.NewNopLogger())
 
 	// Set a maximum upper bound on the test execution time.
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)

--- a/pkg/limits/frontend/ring_test.go
+++ b/pkg/limits/frontend/ring_test.go
@@ -338,7 +338,7 @@ func TestRingGatherer_ExceedsLimits(t *testing.T) {
 				t.Cleanup(mockClients[i].AssertExpectedNumRequests)
 			}
 			readRing, clientPool := newMockRingWithClientPool(t, "test", mockClients, test.instances)
-			cache := NewNopCache[string, *proto.GetAssignedPartitionsResponse]()
+			cache := newNopCache[string, *proto.GetAssignedPartitionsResponse]()
 			g := NewRingGatherer(readRing, clientPool, test.numPartitions, cache, log.NewNopLogger())
 
 			// Set a maximum upper bound on the test execution time.
@@ -517,7 +517,7 @@ func TestRingStreamUsageGatherer_GetZoneAwarePartitionConsumers(t *testing.T) {
 			}
 			// Set up the mocked ring and client pool for the tests.
 			readRing, clientPool := newMockRingWithClientPool(t, "test", clients, test.instances)
-			cache := NewNopCache[string, *proto.GetAssignedPartitionsResponse]()
+			cache := newNopCache[string, *proto.GetAssignedPartitionsResponse]()
 			g := NewRingGatherer(readRing, clientPool, 2, cache, log.NewNopLogger())
 
 			// Set a maximum upper bound on the test execution time.
@@ -666,7 +666,7 @@ func TestRingStreamUsageGatherer_GetPartitionConsumers(t *testing.T) {
 			}
 			// Set up the mocked ring and client pool for the tests.
 			readRing, clientPool := newMockRingWithClientPool(t, "test", mockClients, test.instances)
-			cache := NewNopCache[string, *proto.GetAssignedPartitionsResponse]()
+			cache := newNopCache[string, *proto.GetAssignedPartitionsResponse]()
 			g := NewRingGatherer(readRing, clientPool, 1, cache, log.NewNopLogger())
 
 			// Set a maximum upper bound on the test execution time.
@@ -710,7 +710,7 @@ func TestRingStreamUsageGatherer_GetPartitionConsumers_IsCached(t *testing.T) {
 
 	// Set the cache TTL large enough that entries cannot expire (flake)
 	// during slow test runs.
-	cache := NewTTLCache[string, *proto.GetAssignedPartitionsResponse](time.Minute)
+	cache := newTTLCache[string, *proto.GetAssignedPartitionsResponse](time.Minute)
 	g := NewRingGatherer(readRing, clientPool, 2, cache, log.NewNopLogger())
 
 	// Set a maximum upper bound on the test execution time.
@@ -739,7 +739,7 @@ func TestRingStreamUsageGatherer_GetPartitionConsumers_IsCached(t *testing.T) {
 	require.Equal(t, 1, client1.numAssignedPartitionsRequests)
 
 	// Expire the cache, it should be a cache miss.
-	cache.Reset()
+	cache.reset()
 
 	// The third call should be a cache miss.
 	actual, err = g.getPartitionConsumers(ctx, instances)

--- a/pkg/limits/http.go
+++ b/pkg/limits/http.go
@@ -38,7 +38,7 @@ func (s *Service) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		response      httpTenantLimitsResponse
 	)
 
-	s.usage.ForTenant(tenant, func(_ string, _ int32, stream Stream) {
+	s.usage.forTenant(tenant, func(_ string, _ int32, stream Stream) {
 		if stream.LastSeenAt >= cutoff {
 			activeStreams++
 

--- a/pkg/limits/http.go
+++ b/pkg/limits/http.go
@@ -38,7 +38,7 @@ func (s *Service) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		response      httpTenantLimitsResponse
 	)
 
-	s.usage.forTenant(tenant, func(_ string, _ int32, stream Stream) {
+	s.usage.forTenant(tenant, func(_ string, _ int32, stream streamUsage) {
 		if stream.lastSeenAt >= cutoff {
 			activeStreams++
 

--- a/pkg/limits/http.go
+++ b/pkg/limits/http.go
@@ -44,8 +44,8 @@ func (s *Service) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 			// Calculate size only within the rate window
 			for _, bucket := range stream.RateBuckets {
-				if bucket.Timestamp >= rateWindowCutoff {
-					totalSize += bucket.Size
+				if bucket.timestamp >= rateWindowCutoff {
+					totalSize += bucket.size
 				}
 			}
 		}

--- a/pkg/limits/http.go
+++ b/pkg/limits/http.go
@@ -39,11 +39,11 @@ func (s *Service) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	)
 
 	s.usage.forTenant(tenant, func(_ string, _ int32, stream Stream) {
-		if stream.LastSeenAt >= cutoff {
+		if stream.lastSeenAt >= cutoff {
 			activeStreams++
 
 			// Calculate size only within the rate window
-			for _, bucket := range stream.RateBuckets {
+			for _, bucket := range stream.rateBuckets {
 				if bucket.timestamp >= rateWindowCutoff {
 					totalSize += bucket.size
 				}

--- a/pkg/limits/http_test.go
+++ b/pkg/limits/http_test.go
@@ -26,13 +26,13 @@ func TestIngestLimits_ServeHTTP(t *testing.T) {
 					"tenant": {
 						0: {
 							0x1: {
-								Hash:      0x1,
-								TotalSize: 100,
-								RateBuckets: []rateBucket{{
+								hash:      0x1,
+								totalSize: 100,
+								rateBuckets: []rateBucket{{
 									timestamp: time.Now().UnixNano(),
 									size:      1,
 								}},
-								LastSeenAt: time.Now().UnixNano(),
+								lastSeenAt: time.Now().UnixNano(),
 							},
 						},
 					},

--- a/pkg/limits/http_test.go
+++ b/pkg/limits/http_test.go
@@ -20,7 +20,7 @@ func TestIngestLimits_ServeHTTP(t *testing.T) {
 			RateWindow:   time.Minute,
 			BucketSize:   30 * time.Second,
 		},
-		usage: &UsageStore{
+		usage: &usageStore{
 			stripes: []map[string]tenantUsage{
 				{
 					"tenant": {

--- a/pkg/limits/http_test.go
+++ b/pkg/limits/http_test.go
@@ -28,9 +28,9 @@ func TestIngestLimits_ServeHTTP(t *testing.T) {
 							0x1: {
 								Hash:      0x1,
 								TotalSize: 100,
-								RateBuckets: []RateBucket{{
-									Timestamp: time.Now().UnixNano(),
-									Size:      1,
+								RateBuckets: []rateBucket{{
+									timestamp: time.Now().UnixNano(),
+									size:      1,
 								}},
 								LastSeenAt: time.Now().UnixNano(),
 							},

--- a/pkg/limits/http_test.go
+++ b/pkg/limits/http_test.go
@@ -41,7 +41,7 @@ func TestIngestLimits_ServeHTTP(t *testing.T) {
 			locks: make([]stripeLock, 1),
 		},
 		logger: log.NewNopLogger(),
-		partitionManager: &PartitionManager{
+		partitionManager: &partitionManager{
 			partitions: map[int32]partitionEntry{
 				0: {
 					assignedAt: time.Now().UnixNano(),

--- a/pkg/limits/partition_lifecycler.go
+++ b/pkg/limits/partition_lifecycler.go
@@ -39,7 +39,7 @@ func newPartitionLifecycler(
 }
 
 // Assign implements kgo.OnPartitionsAssigned.
-func (l *partitionLifecycler) Assign(ctx context.Context, _ *kgo.Client, topics map[string][]int32) {
+func (l *partitionLifecycler) assign(ctx context.Context, _ *kgo.Client, topics map[string][]int32) {
 	// We expect the client to just consume one topic.
 	// TODO(grobinson): Figure out what to do if this is not the case.
 	for _, partitions := range topics {
@@ -59,7 +59,7 @@ func (l *partitionLifecycler) Assign(ctx context.Context, _ *kgo.Client, topics 
 }
 
 // Revoke implements kgo.OnPartitionsRevoked.
-func (l *partitionLifecycler) Revoke(ctx context.Context, _ *kgo.Client, topics map[string][]int32) {
+func (l *partitionLifecycler) revoke(ctx context.Context, _ *kgo.Client, topics map[string][]int32) {
 	// We expect the client to just consume one topic.
 	// TODO(grobinson): Figure out what to do if this is not the case.
 	for _, partitions := range topics {

--- a/pkg/limits/partition_lifecycler.go
+++ b/pkg/limits/partition_lifecycler.go
@@ -16,7 +16,7 @@ import (
 type partitionLifecycler struct {
 	partitionManager *partitionManager
 	offsetManager    kafka_partition.OffsetManager
-	usage            *UsageStore
+	usage            *usageStore
 	activeWindow     time.Duration
 	logger           log.Logger
 }
@@ -25,7 +25,7 @@ type partitionLifecycler struct {
 func newPartitionLifecycler(
 	partitionManager *partitionManager,
 	offsetManager kafka_partition.OffsetManager,
-	usage *UsageStore,
+	usage *usageStore,
 	activeWindow time.Duration,
 	logger log.Logger,
 ) *partitionLifecycler {
@@ -64,7 +64,7 @@ func (l *partitionLifecycler) Revoke(ctx context.Context, _ *kgo.Client, topics 
 	// TODO(grobinson): Figure out what to do if this is not the case.
 	for _, partitions := range topics {
 		l.partitionManager.revoke(ctx, partitions)
-		l.usage.EvictPartitions(partitions)
+		l.usage.evictPartitions(partitions)
 		return
 	}
 }

--- a/pkg/limits/partition_lifecycler.go
+++ b/pkg/limits/partition_lifecycler.go
@@ -12,24 +12,24 @@ import (
 	kafka_partition "github.com/grafana/loki/v3/pkg/kafka/partition"
 )
 
-// PartitionLifecycler manages assignment and revocation of partitions.
-type PartitionLifecycler struct {
-	partitionManager *PartitionManager
+// partitionLifecycler manages assignment and revocation of partitions.
+type partitionLifecycler struct {
+	partitionManager *partitionManager
 	offsetManager    kafka_partition.OffsetManager
 	usage            *UsageStore
 	activeWindow     time.Duration
 	logger           log.Logger
 }
 
-// NewPartitionLifecycler returns a new PartitionLifecycler.
-func NewPartitionLifecycler(
-	partitionManager *PartitionManager,
+// newPartitionLifecycler returns a new partitionLifecycler.
+func newPartitionLifecycler(
+	partitionManager *partitionManager,
 	offsetManager kafka_partition.OffsetManager,
 	usage *UsageStore,
 	activeWindow time.Duration,
 	logger log.Logger,
-) *PartitionLifecycler {
-	return &PartitionLifecycler{
+) *partitionLifecycler {
+	return &partitionLifecycler{
 		partitionManager: partitionManager,
 		offsetManager:    offsetManager,
 		usage:            usage,
@@ -39,11 +39,11 @@ func NewPartitionLifecycler(
 }
 
 // Assign implements kgo.OnPartitionsAssigned.
-func (l *PartitionLifecycler) Assign(ctx context.Context, _ *kgo.Client, topics map[string][]int32) {
+func (l *partitionLifecycler) Assign(ctx context.Context, _ *kgo.Client, topics map[string][]int32) {
 	// We expect the client to just consume one topic.
 	// TODO(grobinson): Figure out what to do if this is not the case.
 	for _, partitions := range topics {
-		l.partitionManager.Assign(ctx, partitions)
+		l.partitionManager.assign(ctx, partitions)
 		for _, partition := range partitions {
 			if err := l.determineStateFromOffsets(ctx, partition); err != nil {
 				level.Error(l.logger).Log(
@@ -51,7 +51,7 @@ func (l *PartitionLifecycler) Assign(ctx context.Context, _ *kgo.Client, topics 
 					"partition", partition,
 					"err", err,
 				)
-				l.partitionManager.SetReady(partition)
+				l.partitionManager.setReady(partition)
 			}
 		}
 		return
@@ -59,17 +59,17 @@ func (l *PartitionLifecycler) Assign(ctx context.Context, _ *kgo.Client, topics 
 }
 
 // Revoke implements kgo.OnPartitionsRevoked.
-func (l *PartitionLifecycler) Revoke(ctx context.Context, _ *kgo.Client, topics map[string][]int32) {
+func (l *partitionLifecycler) Revoke(ctx context.Context, _ *kgo.Client, topics map[string][]int32) {
 	// We expect the client to just consume one topic.
 	// TODO(grobinson): Figure out what to do if this is not the case.
 	for _, partitions := range topics {
-		l.partitionManager.Revoke(ctx, partitions)
+		l.partitionManager.revoke(ctx, partitions)
 		l.usage.EvictPartitions(partitions)
 		return
 	}
 }
 
-func (l *PartitionLifecycler) determineStateFromOffsets(ctx context.Context, partition int32) error {
+func (l *partitionLifecycler) determineStateFromOffsets(ctx context.Context, partition int32) error {
 	logger := log.With(l.logger, "partition", partition)
 	// Get the start offset for the partition. This can be greater than zero
 	// if a retention period has deleted old records.
@@ -105,18 +105,18 @@ func (l *PartitionLifecycler) determineStateFromOffsets(ctx context.Context, par
 		// partition has never produced a record, or all records that have
 		// been produced have been deleted due to the retention period.
 		level.Debug(logger).Log("msg", "no records in partition, partition is ready")
-		l.partitionManager.SetReady(partition)
+		l.partitionManager.setReady(partition)
 		return nil
 	}
 	if nextOffset == lastProducedOffset {
 		level.Debug(logger).Log("msg", "no records within window size, partition is ready")
-		l.partitionManager.SetReady(partition)
+		l.partitionManager.setReady(partition)
 		return nil
 	}
 	// Since we want to fetch all records up to and including the last
 	// produced record, we must fetch all records up to and including the
 	// last produced offset - 1.
 	level.Debug(logger).Log("msg", "partition is replaying")
-	l.partitionManager.SetReplaying(partition, lastProducedOffset-1)
+	l.partitionManager.setReplaying(partition, lastProducedOffset-1)
 	return nil
 }

--- a/pkg/limits/partition_manager_test.go
+++ b/pkg/limits/partition_manager_test.go
@@ -10,109 +10,109 @@ import (
 )
 
 func TestPartitionManager_Assign(t *testing.T) {
-	m := NewPartitionManager()
+	m := newPartitionManager()
 	c := quartz.NewMock(t)
 	m.clock = c
 	// Advance the clock so we compare with a time that is not the default
 	// value.
 	c.Advance(1)
-	m.Assign(context.Background(), []int32{1, 2, 3})
+	m.assign(context.Background(), []int32{1, 2, 3})
 	// Assert that the partitions were assigned and the timestamps are set to
 	// the current time.
 	now := c.Now().UnixNano()
 	require.Equal(t, map[int32]partitionEntry{
 		1: {
 			assignedAt: now,
-			state:      PartitionPending,
+			state:      partitionPending,
 		},
 		2: {
 			assignedAt: now,
-			state:      PartitionPending,
+			state:      partitionPending,
 		},
 		3: {
 			assignedAt: now,
-			state:      PartitionPending,
+			state:      partitionPending,
 		},
 	}, m.partitions)
 	// Advance the clock again, re-assign partition #3 and assign a new
 	// partition #4. We expect the updated timestamp is equal to the advanced
 	// time.
 	c.Advance(1)
-	m.Assign(context.Background(), []int32{3, 4})
+	m.assign(context.Background(), []int32{3, 4})
 	later := c.Now().UnixNano()
 	require.Equal(t, map[int32]partitionEntry{
 		1: {
 			assignedAt: now,
-			state:      PartitionPending,
+			state:      partitionPending,
 		},
 		2: {
 			assignedAt: now,
-			state:      PartitionPending,
+			state:      partitionPending,
 		},
 		3: {
 			assignedAt: later,
-			state:      PartitionPending,
+			state:      partitionPending,
 		},
 		4: {
 			assignedAt: later,
-			state:      PartitionPending,
+			state:      partitionPending,
 		},
 	}, m.partitions)
 }
 
 func TestPartitionManager_GetState(t *testing.T) {
-	m := NewPartitionManager()
+	m := newPartitionManager()
 	c := quartz.NewMock(t)
 	m.clock = c
-	m.Assign(context.Background(), []int32{1, 2, 3})
+	m.assign(context.Background(), []int32{1, 2, 3})
 	// Getting the state for an assigned partition should return true.
-	state, ok := m.GetState(1)
+	state, ok := m.getState(1)
 	require.True(t, ok)
-	require.Equal(t, PartitionPending, state)
+	require.Equal(t, partitionPending, state)
 	// Getting the state for an unknown partition should return false.
-	_, ok = m.GetState(4)
+	_, ok = m.getState(4)
 	require.False(t, ok)
 }
 
 func TestPartitionManager_TargetOffsetReached(t *testing.T) {
-	m := NewPartitionManager()
+	m := newPartitionManager()
 	c := quartz.NewMock(t)
 	m.clock = c
-	m.Assign(context.Background(), []int32{1})
+	m.assign(context.Background(), []int32{1})
 	// Target offset cannot be reached for pending partition.
-	require.False(t, m.TargetOffsetReached(1, 0))
+	require.False(t, m.targetOffsetReached(1, 0))
 	// Target offset has not been reached.
-	require.True(t, m.SetReplaying(1, 10))
-	require.False(t, m.TargetOffsetReached(1, 9))
+	require.True(t, m.setReplaying(1, 10))
+	require.False(t, m.targetOffsetReached(1, 9))
 	// Target offset has been reached.
-	require.True(t, m.SetReplaying(1, 10))
-	require.True(t, m.TargetOffsetReached(1, 10))
+	require.True(t, m.setReplaying(1, 10))
+	require.True(t, m.targetOffsetReached(1, 10))
 	// Target offset cannot be reached for ready partition.
-	require.True(t, m.SetReady(1))
-	require.False(t, m.TargetOffsetReached(1, 10))
+	require.True(t, m.setReady(1))
+	require.False(t, m.targetOffsetReached(1, 10))
 }
 
 func TestPartitionManager_Has(t *testing.T) {
-	m := NewPartitionManager()
+	m := newPartitionManager()
 	c := quartz.NewMock(t)
 	m.clock = c
-	m.Assign(context.Background(), []int32{1, 2, 3})
-	require.True(t, m.Has(1))
-	require.True(t, m.Has(2))
-	require.True(t, m.Has(3))
-	require.False(t, m.Has(4))
+	m.assign(context.Background(), []int32{1, 2, 3})
+	require.True(t, m.has(1))
+	require.True(t, m.has(2))
+	require.True(t, m.has(3))
+	require.False(t, m.has(4))
 }
 
 func TestPartitionManager_List(t *testing.T) {
-	m := NewPartitionManager()
+	m := newPartitionManager()
 	c := quartz.NewMock(t)
 	m.clock = c
 	// Advance the clock so we compare with a time that is not the default
 	// value.
 	c.Advance(1)
-	m.Assign(context.Background(), []int32{1, 2, 3})
+	m.assign(context.Background(), []int32{1, 2, 3})
 	now := c.Now().UnixNano()
-	result := m.List()
+	result := m.list()
 	require.Equal(t, map[int32]int64{
 		1: now,
 		2: now,
@@ -126,15 +126,15 @@ func TestPartitionManager_List(t *testing.T) {
 }
 
 func TestPartitionManager_ListByState(t *testing.T) {
-	m := NewPartitionManager()
+	m := newPartitionManager()
 	c := quartz.NewMock(t)
 	m.clock = c
 	// Advance the clock so we compare with a time that is not the default
 	// value.
 	c.Advance(1)
-	m.Assign(context.Background(), []int32{1, 2, 3})
+	m.assign(context.Background(), []int32{1, 2, 3})
 	now := c.Now().UnixNano()
-	result := m.ListByState(PartitionPending)
+	result := m.listByState(partitionPending)
 	require.Equal(t, map[int32]int64{
 		1: now,
 		2: now,
@@ -146,70 +146,70 @@ func TestPartitionManager_ListByState(t *testing.T) {
 	p2 := reflect.ValueOf(m.partitions).Pointer()
 	require.NotEqual(t, p1, p2)
 	// Get all ready partitions.
-	result = m.ListByState(PartitionReady)
+	result = m.listByState(partitionReady)
 	require.Empty(t, result)
 	// Mark a partition as ready and then repeat the test.
-	require.True(t, m.SetReady(1))
-	result = m.ListByState(PartitionReady)
+	require.True(t, m.setReady(1))
+	result = m.listByState(partitionReady)
 	require.Equal(t, map[int32]int64{1: now}, result)
 }
 
 func TestPartitionManager_SetReplaying(t *testing.T) {
-	m := NewPartitionManager()
+	m := newPartitionManager()
 	c := quartz.NewMock(t)
 	m.clock = c
-	m.Assign(context.Background(), []int32{1, 2, 3})
+	m.assign(context.Background(), []int32{1, 2, 3})
 	// Setting an assigned partition to replaying should return true.
-	require.True(t, m.SetReplaying(1, 10))
-	state, ok := m.GetState(1)
+	require.True(t, m.setReplaying(1, 10))
+	state, ok := m.getState(1)
 	require.True(t, ok)
-	require.Equal(t, PartitionReplaying, state)
+	require.Equal(t, partitionReplaying, state)
 	// Setting an unknown partition to replaying should return false.
-	require.False(t, m.SetReplaying(4, 10))
+	require.False(t, m.setReplaying(4, 10))
 }
 
 func TestPartitionManager_SetReady(t *testing.T) {
-	m := NewPartitionManager()
+	m := newPartitionManager()
 	c := quartz.NewMock(t)
 	m.clock = c
-	m.Assign(context.Background(), []int32{1, 2, 3})
+	m.assign(context.Background(), []int32{1, 2, 3})
 	// Setting an assigned partition to ready should return true.
-	require.True(t, m.SetReady(1))
-	state, ok := m.GetState(1)
+	require.True(t, m.setReady(1))
+	state, ok := m.getState(1)
 	require.True(t, ok)
-	require.Equal(t, PartitionReady, state)
+	require.Equal(t, partitionReady, state)
 	// Setting an unknown partition to ready should return false.
-	require.False(t, m.SetReady(4))
+	require.False(t, m.setReady(4))
 }
 
 func TestPartitionManager_Revoke(t *testing.T) {
-	m := NewPartitionManager()
+	m := newPartitionManager()
 	c := quartz.NewMock(t)
 	m.clock = c
-	m.Assign(context.Background(), []int32{1, 2, 3})
+	m.assign(context.Background(), []int32{1, 2, 3})
 	// Assert that the partitions were assigned and the timestamps are set to
 	// the current time.
 	now := c.Now().UnixNano()
 	require.Equal(t, map[int32]partitionEntry{
 		1: {
 			assignedAt: now,
-			state:      PartitionPending,
+			state:      partitionPending,
 		},
 		2: {
 			assignedAt: now,
-			state:      PartitionPending,
+			state:      partitionPending,
 		},
 		3: {
 			assignedAt: now,
-			state:      PartitionPending,
+			state:      partitionPending,
 		},
 	}, m.partitions)
 	// Revoke partitions 2 and 3.
-	m.Revoke(context.Background(), []int32{2, 3})
+	m.revoke(context.Background(), []int32{2, 3})
 	require.Equal(t, map[int32]partitionEntry{
 		1: {
 			assignedAt: now,
-			state:      PartitionPending,
+			state:      partitionPending,
 		},
 	}, m.partitions)
 }

--- a/pkg/limits/producer_test.go
+++ b/pkg/limits/producer_test.go
@@ -15,14 +15,14 @@ import (
 
 func TestProducer_Produce(t *testing.T) {
 	kafka := mockKafka{}
-	p := NewProducer(&kafka, "topic", 1, "zone1", log.NewNopLogger(), prometheus.NewRegistry())
+	p := newProducer(&kafka, "topic", 1, "zone1", log.NewNopLogger(), prometheus.NewRegistry())
 	// Record should be produced.
 	metadata := &proto.StreamMetadata{
 		StreamHash: 0x1,
 		TotalSize:  100,
 	}
 	ctx := context.Background()
-	require.NoError(t, p.Produce(ctx, "tenant", metadata))
+	require.NoError(t, p.produce(ctx, "tenant", metadata))
 	expectedMetadataRecord := proto.StreamMetadataRecord{
 		Zone:     "zone1",
 		Tenant:   "tenant",
@@ -41,6 +41,6 @@ func TestProducer_Produce(t *testing.T) {
 	kafka.produceFailer = func(_ *kgo.Record) error {
 		return errors.New("failed to produce record")
 	}
-	require.NoError(t, p.Produce(ctx, "tenant", metadata))
+	require.NoError(t, p.produce(ctx, "tenant", metadata))
 	require.Equal(t, []*kgo.Record{}, kafka.produced)
 }

--- a/pkg/limits/service.go
+++ b/pkg/limits/service.go
@@ -91,8 +91,8 @@ type Service struct {
 	lifecycler        *ring.Lifecycler
 	lifecyclerWatcher *services.FailureWatcher
 
-	partitionManager    *PartitionManager
-	partitionLifecycler *PartitionLifecycler
+	partitionManager    *partitionManager
+	partitionLifecycler *partitionLifecycler
 
 	// metrics
 	metrics *metrics
@@ -102,8 +102,8 @@ type Service struct {
 
 	// Track stream metadata
 	usage    *UsageStore
-	consumer *Consumer
-	producer *Producer
+	consumer *consumer
+	producer *producer
 
 	// Used for tests.
 	clock quartz.Clock
@@ -125,7 +125,7 @@ func New(cfg Config, lims Limits, logger log.Logger, reg prometheus.Registerer) 
 		cfg:              cfg,
 		logger:           logger,
 		usage:            NewUsageStore(cfg.ActiveWindow, cfg.RateWindow, cfg.BucketSize, cfg.NumPartitions),
-		partitionManager: NewPartitionManager(),
+		partitionManager: newPartitionManager(),
 		metrics:          newMetrics(reg),
 		limits:           lims,
 		clock:            quartz.NewReal(),
@@ -161,7 +161,7 @@ func New(cfg Config, lims Limits, logger log.Logger, reg prometheus.Registerer) 
 	if err != nil {
 		return nil, fmt.Errorf("failed to create offset manager: %w", err)
 	}
-	s.partitionLifecycler = NewPartitionLifecycler(
+	s.partitionLifecycler = newPartitionLifecycler(
 		s.partitionManager,
 		offsetManager,
 		s.usage,
@@ -187,16 +187,16 @@ func New(cfg Config, lims Limits, logger log.Logger, reg prometheus.Registerer) 
 		return nil, fmt.Errorf("failed to create kafka client: %w", err)
 	}
 
-	s.consumer = NewConsumer(
+	s.consumer = newConsumer(
 		s.clientReader,
 		s.partitionManager,
 		s.usage,
-		NewOffsetReadinessCheck(s.partitionManager),
+		newOffsetReadinessCheck(s.partitionManager),
 		cfg.LifecyclerConfig.Zone,
 		logger,
 		reg,
 	)
-	s.producer = NewProducer(
+	s.producer = newProducer(
 		s.clientWriter,
 		kCfg.Topic,
 		s.cfg.NumPartitions,
@@ -245,9 +245,9 @@ func (s *Service) Collect(m chan<- prometheus.Metric) {
 			"expired",
 		)
 	}
-	partitions := s.partitionManager.List()
+	partitions := s.partitionManager.list()
 	for partition := range partitions {
-		state, ok := s.partitionManager.GetState(partition)
+		state, ok := s.partitionManager.getState(partition)
 		if ok {
 			m <- prometheus.MustNewConstMetric(
 				partitionsDesc,
@@ -301,7 +301,7 @@ func (s *Service) starting(ctx context.Context) (err error) {
 func (s *Service) running(ctx context.Context) error {
 	// Start the eviction goroutine
 	go s.evictOldStreamsPeriodic(ctx)
-	go s.consumer.Run(ctx)
+	go s.consumer.run(ctx)
 
 	for {
 		select {
@@ -357,7 +357,7 @@ func (s *Service) stopping(failureCase error) error {
 // It returns the partitions that the tenant is assigned to and the instance still owns.
 func (s *Service) GetAssignedPartitions(_ context.Context, _ *proto.GetAssignedPartitionsRequest) (*proto.GetAssignedPartitionsResponse, error) {
 	resp := proto.GetAssignedPartitionsResponse{
-		AssignedPartitions: s.partitionManager.ListByState(PartitionReady),
+		AssignedPartitions: s.partitionManager.listByState(partitionReady),
 	}
 	return &resp, nil
 }
@@ -377,7 +377,7 @@ func (s *Service) ExceedsLimits(ctx context.Context, req *proto.ExceedsLimitsReq
 		partition := int32(stream.StreamHash % uint64(s.cfg.NumPartitions))
 
 		// TODO(periklis): Do we need to report this as an error to the frontend?
-		if assigned := s.partitionManager.Has(partition); !assigned {
+		if assigned := s.partitionManager.has(partition); !assigned {
 			level.Warn(s.logger).Log("msg", "stream assigned partition not owned by instance", "stream_hash", stream.StreamHash, "partition", partition)
 			continue
 		}
@@ -394,7 +394,7 @@ func (s *Service) ExceedsLimits(ctx context.Context, req *proto.ExceedsLimitsReq
 	for _, stream := range accepted {
 		ingestedBytes += stream.TotalSize
 
-		err := s.producer.Produce(context.WithoutCancel(ctx), req.Tenant, stream)
+		err := s.producer.produce(context.WithoutCancel(ctx), req.Tenant, stream)
 		if err != nil {
 			level.Error(s.logger).Log("msg", "failed to send streams", "error", err)
 		}

--- a/pkg/limits/service.go
+++ b/pkg/limits/service.go
@@ -220,8 +220,8 @@ func (s *Service) Collect(m chan<- prometheus.Metric) {
 	active := make(map[string]int)
 	// expired counts the number of expired streams (outside the window) per tenant.
 	expired := make(map[string]int)
-	s.usage.all(func(tenant string, _ int32, stream Stream) {
-		if stream.LastSeenAt < cutoff {
+	s.usage.all(func(tenant string, _ int32, stream streamUsage) {
+		if stream.lastSeenAt < cutoff {
 			expired[tenant]++
 		} else {
 			active[tenant]++

--- a/pkg/limits/service.go
+++ b/pkg/limits/service.go
@@ -175,8 +175,8 @@ func New(cfg Config, lims Limits, logger log.Logger, reg prometheus.Registerer) 
 		kgo.Balancers(kgo.CooperativeStickyBalancer()),
 		kgo.ConsumeResetOffset(kgo.NewOffset().AfterMilli(s.clock.Now().Add(-s.cfg.ActiveWindow).UnixMilli())),
 		kgo.DisableAutoCommit(),
-		kgo.OnPartitionsAssigned(s.partitionLifecycler.Assign),
-		kgo.OnPartitionsRevoked(s.partitionLifecycler.Revoke),
+		kgo.OnPartitionsAssigned(s.partitionLifecycler.assign),
+		kgo.OnPartitionsRevoked(s.partitionLifecycler.revoke),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create kafka client: %w", err)

--- a/pkg/limits/service_test.go
+++ b/pkg/limits/service_test.go
@@ -27,7 +27,7 @@ func TestService_ExceedsLimits(t *testing.T) {
 		// Setup data.
 		assignedPartitions []int32
 		numPartitions      int
-		usage              *UsageStore
+		usage              *usageStore
 		ActiveWindow       time.Duration
 		rateWindow         time.Duration
 		BucketSize         time.Duration
@@ -47,7 +47,7 @@ func TestService_ExceedsLimits(t *testing.T) {
 			// setup data
 			assignedPartitions: []int32{0},
 			numPartitions:      1,
-			usage: &UsageStore{
+			usage: &usageStore{
 				numPartitions: 1,
 				stripes: []map[string]tenantUsage{
 					{
@@ -82,7 +82,7 @@ func TestService_ExceedsLimits(t *testing.T) {
 			// setup data
 			assignedPartitions: []int32{0},
 			numPartitions:      1,
-			usage: &UsageStore{
+			usage: &usageStore{
 				numPartitions: 1,
 				stripes: []map[string]tenantUsage{
 					{
@@ -119,7 +119,7 @@ func TestService_ExceedsLimits(t *testing.T) {
 			// setup data
 			assignedPartitions: []int32{0},
 			numPartitions:      1,
-			usage: &UsageStore{
+			usage: &usageStore{
 				numPartitions: 1,
 				stripes: []map[string]tenantUsage{
 					{
@@ -156,7 +156,7 @@ func TestService_ExceedsLimits(t *testing.T) {
 			// setup data
 			assignedPartitions: []int32{0},
 			numPartitions:      1,
-			usage: &UsageStore{
+			usage: &usageStore{
 				numPartitions: 1,
 				stripes: []map[string]tenantUsage{
 					{
@@ -197,7 +197,7 @@ func TestService_ExceedsLimits(t *testing.T) {
 			// setup data
 			assignedPartitions: []int32{0},
 			numPartitions:      1,
-			usage: &UsageStore{
+			usage: &usageStore{
 				numPartitions: 1,
 				stripes: []map[string]tenantUsage{
 					{
@@ -236,7 +236,7 @@ func TestService_ExceedsLimits(t *testing.T) {
 			// setup data
 			assignedPartitions: []int32{0, 1},
 			numPartitions:      2,
-			usage: &UsageStore{
+			usage: &usageStore{
 				numPartitions: 2,
 				locks:         make([]stripeLock, 2),
 				stripes: []map[string]tenantUsage{
@@ -269,7 +269,7 @@ func TestService_ExceedsLimits(t *testing.T) {
 			// setup data
 			assignedPartitions: []int32{0},
 			numPartitions:      2,
-			usage: &UsageStore{
+			usage: &usageStore{
 				numPartitions: 1,
 				locks:         make([]stripeLock, 2),
 				stripes: []map[string]tenantUsage{
@@ -378,7 +378,7 @@ func TestIngestLimits_ExceedsLimits_Concurrent(t *testing.T) {
 	kafkaClient := mockKafka{}
 
 	// Setup test data with a mix of active and expired streams>
-	usage := &UsageStore{
+	usage := &usageStore{
 		numPartitions: 1,
 		stripes: []map[string]tenantUsage{
 			{

--- a/pkg/limits/service_test.go
+++ b/pkg/limits/service_test.go
@@ -332,13 +332,13 @@ func TestService_ExceedsLimits(t *testing.T) {
 				metrics:          newMetrics(reg),
 				limits:           limits,
 				usage:            tt.usage,
-				partitionManager: NewPartitionManager(),
+				partitionManager: newPartitionManager(),
 				clock:            clock,
-				producer:         NewProducer(&kafkaClient, "test", tt.numPartitions, "", log.NewNopLogger(), reg),
+				producer:         newProducer(&kafkaClient, "test", tt.numPartitions, "", log.NewNopLogger(), reg),
 			}
 
 			// Assign the Partition IDs.
-			s.partitionManager.Assign(context.Background(), tt.assignedPartitions)
+			s.partitionManager.assign(context.Background(), tt.assignedPartitions)
 
 			// Call ExceedsLimits.
 			req := &proto.ExceedsLimitsRequest{
@@ -419,15 +419,15 @@ func TestIngestLimits_ExceedsLimits_Concurrent(t *testing.T) {
 		},
 		logger:           log.NewNopLogger(),
 		usage:            usage,
-		partitionManager: NewPartitionManager(),
+		partitionManager: newPartitionManager(),
 		metrics:          newMetrics(reg),
 		limits:           limits,
 		clock:            clock,
-		producer:         NewProducer(&kafkaClient, "test", 1, "", log.NewNopLogger(), reg),
+		producer:         newProducer(&kafkaClient, "test", 1, "", log.NewNopLogger(), reg),
 	}
 
 	// Assign the Partition IDs.
-	s.partitionManager.Assign(context.Background(), []int32{0})
+	s.partitionManager.assign(context.Background(), []int32{0})
 
 	// Run concurrent requests
 	concurrency := 10

--- a/pkg/limits/service_test.go
+++ b/pkg/limits/service_test.go
@@ -53,8 +53,8 @@ func TestService_ExceedsLimits(t *testing.T) {
 					{
 						"tenant1": {
 							0: {
-								0x4: {Hash: 0x4, LastSeenAt: now.UnixNano(), TotalSize: 1000, RateBuckets: []RateBucket{{Timestamp: now.UnixNano(), Size: 1000}}},
-								0x5: {Hash: 0x5, LastSeenAt: now.UnixNano(), TotalSize: 2000, RateBuckets: []RateBucket{{Timestamp: now.UnixNano(), Size: 2000}}},
+								0x4: {Hash: 0x4, LastSeenAt: now.UnixNano(), TotalSize: 1000, RateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 1000}}},
+								0x5: {Hash: 0x5, LastSeenAt: now.UnixNano(), TotalSize: 2000, RateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 2000}}},
 							},
 						},
 					},
@@ -88,10 +88,10 @@ func TestService_ExceedsLimits(t *testing.T) {
 					{
 						"tenant1": {
 							0: {
-								1: {Hash: 1, LastSeenAt: now.UnixNano(), TotalSize: 1000, RateBuckets: []RateBucket{{Timestamp: now.UnixNano(), Size: 1000}}},
-								2: {Hash: 2, LastSeenAt: now.UnixNano(), TotalSize: 2000, RateBuckets: []RateBucket{{Timestamp: now.UnixNano(), Size: 2000}}},
-								3: {Hash: 3, LastSeenAt: now.UnixNano(), TotalSize: 3000, RateBuckets: []RateBucket{{Timestamp: now.UnixNano(), Size: 3000}}},
-								4: {Hash: 4, LastSeenAt: now.UnixNano(), TotalSize: 4000, RateBuckets: []RateBucket{{Timestamp: now.UnixNano(), Size: 4000}}},
+								1: {Hash: 1, LastSeenAt: now.UnixNano(), TotalSize: 1000, RateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 1000}}},
+								2: {Hash: 2, LastSeenAt: now.UnixNano(), TotalSize: 2000, RateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 2000}}},
+								3: {Hash: 3, LastSeenAt: now.UnixNano(), TotalSize: 3000, RateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 3000}}},
+								4: {Hash: 4, LastSeenAt: now.UnixNano(), TotalSize: 4000, RateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 4000}}},
 							},
 						},
 					},
@@ -125,9 +125,9 @@ func TestService_ExceedsLimits(t *testing.T) {
 					{
 						"tenant1": {
 							0: {
-								0x1: {Hash: 0x1, LastSeenAt: now.UnixNano(), TotalSize: 1000, RateBuckets: []RateBucket{{Timestamp: now.UnixNano(), Size: 1000}}},
-								0x3: {Hash: 0x3, LastSeenAt: now.UnixNano(), TotalSize: 3000, RateBuckets: []RateBucket{{Timestamp: now.UnixNano(), Size: 3000}}},
-								0x5: {Hash: 0x5, LastSeenAt: now.UnixNano(), TotalSize: 5000, RateBuckets: []RateBucket{{Timestamp: now.UnixNano(), Size: 5000}}},
+								0x1: {Hash: 0x1, LastSeenAt: now.UnixNano(), TotalSize: 1000, RateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 1000}}},
+								0x3: {Hash: 0x3, LastSeenAt: now.UnixNano(), TotalSize: 3000, RateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 3000}}},
+								0x5: {Hash: 0x5, LastSeenAt: now.UnixNano(), TotalSize: 5000, RateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 5000}}},
 							},
 						},
 					},
@@ -162,9 +162,9 @@ func TestService_ExceedsLimits(t *testing.T) {
 					{
 						"tenant1": {
 							0: {
-								0x1: {Hash: 0x1, LastSeenAt: now.UnixNano(), TotalSize: 1000, RateBuckets: []RateBucket{{Timestamp: now.UnixNano(), Size: 1000}}},
-								0x3: {Hash: 0x3, LastSeenAt: now.UnixNano(), TotalSize: 3000, RateBuckets: []RateBucket{{Timestamp: now.UnixNano(), Size: 3000}}},
-								0x5: {Hash: 0x5, LastSeenAt: now.UnixNano(), TotalSize: 5000, RateBuckets: []RateBucket{{Timestamp: now.UnixNano(), Size: 5000}}},
+								0x1: {Hash: 0x1, LastSeenAt: now.UnixNano(), TotalSize: 1000, RateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 1000}}},
+								0x3: {Hash: 0x3, LastSeenAt: now.UnixNano(), TotalSize: 3000, RateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 3000}}},
+								0x5: {Hash: 0x5, LastSeenAt: now.UnixNano(), TotalSize: 5000, RateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 5000}}},
 							},
 						},
 					},
@@ -203,11 +203,11 @@ func TestService_ExceedsLimits(t *testing.T) {
 					{
 						"tenant1": {
 							0: {
-								0x1: {Hash: 0x1, LastSeenAt: now.UnixNano(), TotalSize: 1000, RateBuckets: []RateBucket{{Timestamp: now.UnixNano(), Size: 1000}}},
-								0x2: {Hash: 0x2, LastSeenAt: now.Add(-120 * time.Minute).UnixNano(), TotalSize: 2000, RateBuckets: []RateBucket{{Timestamp: now.UnixNano(), Size: 2000}}},
-								0x3: {Hash: 0x3, LastSeenAt: now.UnixNano(), TotalSize: 3000, RateBuckets: []RateBucket{{Timestamp: now.UnixNano(), Size: 3000}}},
-								0x4: {Hash: 0x4, LastSeenAt: now.Add(-120 * time.Minute).UnixNano(), TotalSize: 4000, RateBuckets: []RateBucket{{Timestamp: now.UnixNano(), Size: 4000}}},
-								0x5: {Hash: 0x5, LastSeenAt: now.UnixNano(), TotalSize: 5000, RateBuckets: []RateBucket{{Timestamp: now.UnixNano(), Size: 5000}}},
+								0x1: {Hash: 0x1, LastSeenAt: now.UnixNano(), TotalSize: 1000, RateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 1000}}},
+								0x2: {Hash: 0x2, LastSeenAt: now.Add(-120 * time.Minute).UnixNano(), TotalSize: 2000, RateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 2000}}},
+								0x3: {Hash: 0x3, LastSeenAt: now.UnixNano(), TotalSize: 3000, RateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 3000}}},
+								0x4: {Hash: 0x4, LastSeenAt: now.Add(-120 * time.Minute).UnixNano(), TotalSize: 4000, RateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 4000}}},
+								0x5: {Hash: 0x5, LastSeenAt: now.UnixNano(), TotalSize: 5000, RateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 5000}}},
 							},
 						},
 					},
@@ -384,10 +384,10 @@ func TestIngestLimits_ExceedsLimits_Concurrent(t *testing.T) {
 			{
 				"tenant1": {
 					0: {
-						1: {Hash: 1, LastSeenAt: now.UnixNano(), TotalSize: 1000, RateBuckets: []RateBucket{{Timestamp: now.UnixNano(), Size: 1000}}},                        // active
-						2: {Hash: 2, LastSeenAt: now.Add(-30 * time.Minute).UnixNano(), TotalSize: 2000, RateBuckets: []RateBucket{{Timestamp: now.UnixNano(), Size: 2000}}}, // active
+						1: {Hash: 1, LastSeenAt: now.UnixNano(), TotalSize: 1000, RateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 1000}}},                        // active
+						2: {Hash: 2, LastSeenAt: now.Add(-30 * time.Minute).UnixNano(), TotalSize: 2000, RateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 2000}}}, // active
 						3: {Hash: 3, LastSeenAt: now.Add(-2 * time.Hour).UnixNano(), TotalSize: 3000},                                                                        // expired
-						4: {Hash: 4, LastSeenAt: now.Add(-45 * time.Minute).UnixNano(), TotalSize: 4000, RateBuckets: []RateBucket{{Timestamp: now.UnixNano(), Size: 4000}}}, // active
+						4: {Hash: 4, LastSeenAt: now.Add(-45 * time.Minute).UnixNano(), TotalSize: 4000, RateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 4000}}}, // active
 						5: {Hash: 5, LastSeenAt: now.Add(-3 * time.Hour).UnixNano(), TotalSize: 5000},                                                                        // expired
 					},
 				},

--- a/pkg/limits/service_test.go
+++ b/pkg/limits/service_test.go
@@ -53,8 +53,8 @@ func TestService_ExceedsLimits(t *testing.T) {
 					{
 						"tenant1": {
 							0: {
-								0x4: {Hash: 0x4, LastSeenAt: now.UnixNano(), TotalSize: 1000, RateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 1000}}},
-								0x5: {Hash: 0x5, LastSeenAt: now.UnixNano(), TotalSize: 2000, RateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 2000}}},
+								0x4: {hash: 0x4, lastSeenAt: now.UnixNano(), totalSize: 1000, rateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 1000}}},
+								0x5: {hash: 0x5, lastSeenAt: now.UnixNano(), totalSize: 2000, rateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 2000}}},
 							},
 						},
 					},
@@ -88,10 +88,10 @@ func TestService_ExceedsLimits(t *testing.T) {
 					{
 						"tenant1": {
 							0: {
-								1: {Hash: 1, LastSeenAt: now.UnixNano(), TotalSize: 1000, RateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 1000}}},
-								2: {Hash: 2, LastSeenAt: now.UnixNano(), TotalSize: 2000, RateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 2000}}},
-								3: {Hash: 3, LastSeenAt: now.UnixNano(), TotalSize: 3000, RateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 3000}}},
-								4: {Hash: 4, LastSeenAt: now.UnixNano(), TotalSize: 4000, RateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 4000}}},
+								1: {hash: 1, lastSeenAt: now.UnixNano(), totalSize: 1000, rateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 1000}}},
+								2: {hash: 2, lastSeenAt: now.UnixNano(), totalSize: 2000, rateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 2000}}},
+								3: {hash: 3, lastSeenAt: now.UnixNano(), totalSize: 3000, rateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 3000}}},
+								4: {hash: 4, lastSeenAt: now.UnixNano(), totalSize: 4000, rateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 4000}}},
 							},
 						},
 					},
@@ -125,9 +125,9 @@ func TestService_ExceedsLimits(t *testing.T) {
 					{
 						"tenant1": {
 							0: {
-								0x1: {Hash: 0x1, LastSeenAt: now.UnixNano(), TotalSize: 1000, RateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 1000}}},
-								0x3: {Hash: 0x3, LastSeenAt: now.UnixNano(), TotalSize: 3000, RateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 3000}}},
-								0x5: {Hash: 0x5, LastSeenAt: now.UnixNano(), TotalSize: 5000, RateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 5000}}},
+								0x1: {hash: 0x1, lastSeenAt: now.UnixNano(), totalSize: 1000, rateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 1000}}},
+								0x3: {hash: 0x3, lastSeenAt: now.UnixNano(), totalSize: 3000, rateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 3000}}},
+								0x5: {hash: 0x5, lastSeenAt: now.UnixNano(), totalSize: 5000, rateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 5000}}},
 							},
 						},
 					},
@@ -162,9 +162,9 @@ func TestService_ExceedsLimits(t *testing.T) {
 					{
 						"tenant1": {
 							0: {
-								0x1: {Hash: 0x1, LastSeenAt: now.UnixNano(), TotalSize: 1000, RateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 1000}}},
-								0x3: {Hash: 0x3, LastSeenAt: now.UnixNano(), TotalSize: 3000, RateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 3000}}},
-								0x5: {Hash: 0x5, LastSeenAt: now.UnixNano(), TotalSize: 5000, RateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 5000}}},
+								0x1: {hash: 0x1, lastSeenAt: now.UnixNano(), totalSize: 1000, rateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 1000}}},
+								0x3: {hash: 0x3, lastSeenAt: now.UnixNano(), totalSize: 3000, rateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 3000}}},
+								0x5: {hash: 0x5, lastSeenAt: now.UnixNano(), totalSize: 5000, rateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 5000}}},
 							},
 						},
 					},
@@ -203,11 +203,11 @@ func TestService_ExceedsLimits(t *testing.T) {
 					{
 						"tenant1": {
 							0: {
-								0x1: {Hash: 0x1, LastSeenAt: now.UnixNano(), TotalSize: 1000, RateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 1000}}},
-								0x2: {Hash: 0x2, LastSeenAt: now.Add(-120 * time.Minute).UnixNano(), TotalSize: 2000, RateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 2000}}},
-								0x3: {Hash: 0x3, LastSeenAt: now.UnixNano(), TotalSize: 3000, RateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 3000}}},
-								0x4: {Hash: 0x4, LastSeenAt: now.Add(-120 * time.Minute).UnixNano(), TotalSize: 4000, RateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 4000}}},
-								0x5: {Hash: 0x5, LastSeenAt: now.UnixNano(), TotalSize: 5000, RateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 5000}}},
+								0x1: {hash: 0x1, lastSeenAt: now.UnixNano(), totalSize: 1000, rateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 1000}}},
+								0x2: {hash: 0x2, lastSeenAt: now.Add(-120 * time.Minute).UnixNano(), totalSize: 2000, rateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 2000}}},
+								0x3: {hash: 0x3, lastSeenAt: now.UnixNano(), totalSize: 3000, rateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 3000}}},
+								0x4: {hash: 0x4, lastSeenAt: now.Add(-120 * time.Minute).UnixNano(), totalSize: 4000, rateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 4000}}},
+								0x5: {hash: 0x5, lastSeenAt: now.UnixNano(), totalSize: 5000, rateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 5000}}},
 							},
 						},
 					},
@@ -384,11 +384,11 @@ func TestIngestLimits_ExceedsLimits_Concurrent(t *testing.T) {
 			{
 				"tenant1": {
 					0: {
-						1: {Hash: 1, LastSeenAt: now.UnixNano(), TotalSize: 1000, RateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 1000}}},                        // active
-						2: {Hash: 2, LastSeenAt: now.Add(-30 * time.Minute).UnixNano(), TotalSize: 2000, RateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 2000}}}, // active
-						3: {Hash: 3, LastSeenAt: now.Add(-2 * time.Hour).UnixNano(), TotalSize: 3000},                                                                        // expired
-						4: {Hash: 4, LastSeenAt: now.Add(-45 * time.Minute).UnixNano(), TotalSize: 4000, RateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 4000}}}, // active
-						5: {Hash: 5, LastSeenAt: now.Add(-3 * time.Hour).UnixNano(), TotalSize: 5000},                                                                        // expired
+						1: {hash: 1, lastSeenAt: now.UnixNano(), totalSize: 1000, rateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 1000}}},                        // active
+						2: {hash: 2, lastSeenAt: now.Add(-30 * time.Minute).UnixNano(), totalSize: 2000, rateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 2000}}}, // active
+						3: {hash: 3, lastSeenAt: now.Add(-2 * time.Hour).UnixNano(), totalSize: 3000},                                                                        // expired
+						4: {hash: 4, lastSeenAt: now.Add(-45 * time.Minute).UnixNano(), totalSize: 4000, rateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 4000}}}, // active
+						5: {hash: 5, lastSeenAt: now.Add(-3 * time.Hour).UnixNano(), totalSize: 5000},                                                                        // expired
 					},
 				},
 			},

--- a/pkg/limits/store_bench_test.go
+++ b/pkg/limits/store_bench_test.go
@@ -42,7 +42,7 @@ func BenchmarkUsageStore_Store(b *testing.B) {
 	}
 
 	for _, bm := range benchmarks {
-		s := NewUsageStore(DefaultActiveWindow, DefaultRateWindow, DefaultBucketSize, bm.numPartitions)
+		s := newUsageStore(DefaultActiveWindow, DefaultRateWindow, DefaultBucketSize, bm.numPartitions)
 		b.Run(fmt.Sprintf("%s_create", bm.name), func(b *testing.B) {
 			now := time.Now()
 
@@ -58,7 +58,7 @@ func BenchmarkUsageStore_Store(b *testing.B) {
 					TotalSize:  1500,
 				}}
 
-				s.Update(tenant, metadata, updateTime, nil)
+				s.update(tenant, metadata, updateTime, nil)
 			}
 		})
 
@@ -77,11 +77,11 @@ func BenchmarkUsageStore_Store(b *testing.B) {
 					TotalSize:  1500,
 				}}
 
-				s.Update(tenant, metadata, updateTime, nil)
+				s.update(tenant, metadata, updateTime, nil)
 			}
 		})
 
-		s = NewUsageStore(DefaultActiveWindow, DefaultRateWindow, DefaultBucketSize, bm.numPartitions)
+		s = newUsageStore(DefaultActiveWindow, DefaultRateWindow, DefaultBucketSize, bm.numPartitions)
 
 		// Run parallel benchmark
 		b.Run(bm.name+"_create_parallel", func(b *testing.B) {
@@ -99,7 +99,7 @@ func BenchmarkUsageStore_Store(b *testing.B) {
 						TotalSize:  1500,
 					}}
 
-					s.Update(tenant, metadata, updateTime, nil)
+					s.update(tenant, metadata, updateTime, nil)
 					i++
 				}
 			})
@@ -120,7 +120,7 @@ func BenchmarkUsageStore_Store(b *testing.B) {
 						TotalSize:  1500,
 					}}
 
-					s.Update(tenant, metadata, updateTime, nil)
+					s.update(tenant, metadata, updateTime, nil)
 					i++
 				}
 			})

--- a/pkg/limits/store_test.go
+++ b/pkg/limits/store_test.go
@@ -18,13 +18,13 @@ func TestUsageStore_All(t *testing.T) {
 	// Create 10 streams. Since we use i as the hash, we can expect the
 	// streams to be sharded over all 10 partitions.
 	for i := 0; i < 10; i++ {
-		s.set("tenant", Stream{Hash: uint64(i)})
+		s.set("tenant", streamUsage{hash: uint64(i)})
 	}
 	// Check that we can iterate all stored streams.
 	expected := []uint64{0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9}
 	actual := make([]uint64, 0, len(expected))
-	s.all(func(_ string, _ int32, s Stream) {
-		actual = append(actual, s.Hash)
+	s.all(func(_ string, _ int32, s streamUsage) {
+		actual = append(actual, s.hash)
 	})
 	require.ElementsMatch(t, expected, actual)
 }
@@ -41,19 +41,19 @@ func TestUsageStore_ForTenant(t *testing.T) {
 		if i >= 5 {
 			tenant = "tenant2"
 		}
-		s.set(tenant, Stream{Hash: uint64(i)})
+		s.set(tenant, streamUsage{hash: uint64(i)})
 	}
 	// Check we can iterate just the streams for each tenant.
 	expected1 := []uint64{0x0, 0x1, 0x2, 0x3, 0x4}
 	actual1 := make([]uint64, 0, 5)
-	s.forTenant("tenant1", func(_ string, _ int32, stream Stream) {
-		actual1 = append(actual1, stream.Hash)
+	s.forTenant("tenant1", func(_ string, _ int32, stream streamUsage) {
+		actual1 = append(actual1, stream.hash)
 	})
 	require.ElementsMatch(t, expected1, actual1)
 	expected2 := []uint64{0x5, 0x6, 0x7, 0x8, 0x9}
 	actual2 := make([]uint64, 0, 5)
-	s.forTenant("tenant2", func(_ string, _ int32, stream Stream) {
-		actual2 = append(actual2, stream.Hash)
+	s.forTenant("tenant2", func(_ string, _ int32, stream streamUsage) {
+		actual2 = append(actual2, stream.hash)
 	})
 	require.ElementsMatch(t, expected2, actual2)
 }
@@ -177,23 +177,23 @@ func TestUsageStore_Evict(t *testing.T) {
 	s := newUsageStore(DefaultActiveWindow, DefaultRateWindow, DefaultBucketSize, 1)
 	clock := quartz.NewMock(t)
 	s.clock = clock
-	s1 := Stream{Hash: 0x1, LastSeenAt: clock.Now().UnixNano()}
+	s1 := streamUsage{hash: 0x1, lastSeenAt: clock.Now().UnixNano()}
 	s.set("tenant1", s1)
-	s2 := Stream{Hash: 0x2, LastSeenAt: clock.Now().Add(-61 * time.Minute).UnixNano()}
+	s2 := streamUsage{hash: 0x2, lastSeenAt: clock.Now().Add(-61 * time.Minute).UnixNano()}
 	s.set("tenant1", s2)
-	s3 := Stream{Hash: 0x3, LastSeenAt: clock.Now().UnixNano()}
+	s3 := streamUsage{hash: 0x3, lastSeenAt: clock.Now().UnixNano()}
 	s.set("tenant2", s3)
-	s4 := Stream{Hash: 0x4, LastSeenAt: clock.Now().Add(-59 * time.Minute).UnixNano()}
+	s4 := streamUsage{hash: 0x4, lastSeenAt: clock.Now().Add(-59 * time.Minute).UnixNano()}
 	s.set("tenant2", s4)
 	// Evict all streams older than the window size.
 	s.evict()
-	actual := make(map[string][]Stream)
-	s.all(func(tenant string, _ int32, stream Stream) {
+	actual := make(map[string][]streamUsage)
+	s.all(func(tenant string, _ int32, stream streamUsage) {
 		actual[tenant] = append(actual[tenant], stream)
 	})
 	// We can't use require.Equal as [All] iterates streams in a non-deterministic
 	// order. Instead use ElementsMatch for each expected tenant.
-	expected := map[string][]Stream{
+	expected := map[string][]streamUsage{
 		"tenant1": {s1},
 		"tenant2": {s3, s4},
 	}
@@ -211,14 +211,14 @@ func TestUsageStore_EvictPartitions(t *testing.T) {
 	// Create 10 streams. Since we use i as the hash, we can expect the
 	// streams to be sharded over all 10 partitions.
 	for i := 0; i < 10; i++ {
-		s.set("tenant", Stream{Hash: uint64(i)})
+		s.set("tenant", streamUsage{hash: uint64(i)})
 	}
 	// Evict the first 5 partitions.
 	s.evictPartitions([]int32{0, 1, 2, 3, 4})
 	// The last 5 partitions should still have data.
 	expected := []int32{5, 6, 7, 8, 9}
 	actual := make([]int32, 0, len(expected))
-	s.all(func(_ string, partition int32, _ Stream) {
+	s.all(func(_ string, partition int32, _ streamUsage) {
 		actual = append(actual, partition)
 	})
 	require.ElementsMatch(t, expected, actual)

--- a/pkg/limits/store_test.go
+++ b/pkg/limits/store_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestUsageStore_All(t *testing.T) {
 	// Create a store with 10 partitions.
-	s := NewUsageStore(DefaultActiveWindow, DefaultRateWindow, DefaultBucketSize, 10)
+	s := newUsageStore(DefaultActiveWindow, DefaultRateWindow, DefaultBucketSize, 10)
 	clock := quartz.NewMock(t)
 	s.clock = clock
 	// Create 10 streams. Since we use i as the hash, we can expect the
@@ -23,7 +23,7 @@ func TestUsageStore_All(t *testing.T) {
 	// Check that we can iterate all stored streams.
 	expected := []uint64{0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9}
 	actual := make([]uint64, 0, len(expected))
-	s.All(func(_ string, _ int32, s Stream) {
+	s.all(func(_ string, _ int32, s Stream) {
 		actual = append(actual, s.Hash)
 	})
 	require.ElementsMatch(t, expected, actual)
@@ -31,7 +31,7 @@ func TestUsageStore_All(t *testing.T) {
 
 func TestUsageStore_ForTenant(t *testing.T) {
 	// Create a store with 10 partitions.
-	s := NewUsageStore(DefaultActiveWindow, DefaultRateWindow, DefaultBucketSize, 10)
+	s := newUsageStore(DefaultActiveWindow, DefaultRateWindow, DefaultBucketSize, 10)
 	clock := quartz.NewMock(t)
 	s.clock = clock
 	// Create 10 streams. Since we use i as the hash, we can expect the
@@ -46,13 +46,13 @@ func TestUsageStore_ForTenant(t *testing.T) {
 	// Check we can iterate just the streams for each tenant.
 	expected1 := []uint64{0x0, 0x1, 0x2, 0x3, 0x4}
 	actual1 := make([]uint64, 0, 5)
-	s.ForTenant("tenant1", func(_ string, _ int32, stream Stream) {
+	s.forTenant("tenant1", func(_ string, _ int32, stream Stream) {
 		actual1 = append(actual1, stream.Hash)
 	})
 	require.ElementsMatch(t, expected1, actual1)
 	expected2 := []uint64{0x5, 0x6, 0x7, 0x8, 0x9}
 	actual2 := make([]uint64, 0, 5)
-	s.ForTenant("tenant2", func(_ string, _ int32, stream Stream) {
+	s.forTenant("tenant2", func(_ string, _ int32, stream Stream) {
 		actual2 = append(actual2, stream.Hash)
 	})
 	require.ElementsMatch(t, expected2, actual2)
@@ -161,12 +161,12 @@ func TestUsageStore_Store(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			s := NewUsageStore(DefaultActiveWindow, DefaultRateWindow, DefaultBucketSize, test.numPartitions)
+			s := newUsageStore(DefaultActiveWindow, DefaultRateWindow, DefaultBucketSize, test.numPartitions)
 			clock := quartz.NewMock(t)
 			s.clock = clock
-			s.Update("tenant", test.seed, clock.Now(), nil)
+			s.update("tenant", test.seed, clock.Now(), nil)
 			streamLimitCond := streamLimitExceeded(test.maxGlobalStreams)
-			accepted, rejected := s.Update("tenant", test.streams, clock.Now(), streamLimitCond)
+			accepted, rejected := s.update("tenant", test.streams, clock.Now(), streamLimitCond)
 			require.ElementsMatch(t, test.expectedAccepted, accepted)
 			require.ElementsMatch(t, test.expectedRejected, rejected)
 		})
@@ -174,7 +174,7 @@ func TestUsageStore_Store(t *testing.T) {
 }
 
 func TestUsageStore_Evict(t *testing.T) {
-	s := NewUsageStore(DefaultActiveWindow, DefaultRateWindow, DefaultBucketSize, 1)
+	s := newUsageStore(DefaultActiveWindow, DefaultRateWindow, DefaultBucketSize, 1)
 	clock := quartz.NewMock(t)
 	s.clock = clock
 	s1 := Stream{Hash: 0x1, LastSeenAt: clock.Now().UnixNano()}
@@ -186,9 +186,9 @@ func TestUsageStore_Evict(t *testing.T) {
 	s4 := Stream{Hash: 0x4, LastSeenAt: clock.Now().Add(-59 * time.Minute).UnixNano()}
 	s.set("tenant2", s4)
 	// Evict all streams older than the window size.
-	s.Evict()
+	s.evict()
 	actual := make(map[string][]Stream)
-	s.All(func(tenant string, _ int32, stream Stream) {
+	s.all(func(tenant string, _ int32, stream Stream) {
 		actual[tenant] = append(actual[tenant], stream)
 	})
 	// We can't use require.Equal as [All] iterates streams in a non-deterministic
@@ -205,7 +205,7 @@ func TestUsageStore_Evict(t *testing.T) {
 
 func TestUsageStore_EvictPartitions(t *testing.T) {
 	// Create a store with 10 partitions.
-	s := NewUsageStore(DefaultActiveWindow, DefaultRateWindow, DefaultBucketSize, 10)
+	s := newUsageStore(DefaultActiveWindow, DefaultRateWindow, DefaultBucketSize, 10)
 	clock := quartz.NewMock(t)
 	s.clock = clock
 	// Create 10 streams. Since we use i as the hash, we can expect the
@@ -214,11 +214,11 @@ func TestUsageStore_EvictPartitions(t *testing.T) {
 		s.set("tenant", Stream{Hash: uint64(i)})
 	}
 	// Evict the first 5 partitions.
-	s.EvictPartitions([]int32{0, 1, 2, 3, 4})
+	s.evictPartitions([]int32{0, 1, 2, 3, 4})
 	// The last 5 partitions should still have data.
 	expected := []int32{5, 6, 7, 8, 9}
 	actual := make([]int32, 0, len(expected))
-	s.All(func(_ string, partition int32, _ Stream) {
+	s.all(func(_ string, partition int32, _ Stream) {
 		actual = append(actual, partition)
 	})
 	require.ElementsMatch(t, expected, actual)


### PR DESCRIPTION
**What this PR does / why we need it**:

I have been exporting all types in `pkg/limits` as package public, which means other packages, or anyone using Loki as a Go module, can use these types. That isn't what we want. This fixes all of that, and makes the absolute bare minimum public instead.

For example, before:

```
package limits // import "github.com/grafana/loki/v3/pkg/limits"

const DefaultActiveWindow = 1 * time.Hour ...
const RingKey = "ingest-limits" ...
func MetadataTopic(topic string) string
type CondFunc func(acc float64, stream *proto.StreamMetadata) bool
type Config struct{ ... }
type Consumer struct{ ... }
    func NewConsumer(client KafkaConsumer, partitionManager *PartitionManager, usage *UsageStore, ...) *Consumer
type Evictable interface{ ... }
type Evictor struct{ ... }
    func NewEvictor(ctx context.Context, interval time.Duration, target Evictable, ...) (*Evictor, error)
type IngestLimits struct{ ... }
    func NewIngestLimits(cfg Config, lims Limits, logger log.Logger, reg prometheus.Registerer) (*IngestLimits, error)
type IterateFunc func(tenant string, partition int32, stream Stream)
type KafkaConsumer interface{ ... }
type KafkaProducer interface{ ... }
type Limits interface{ ... }
type PartitionLifecycler struct{ ... }
    func NewPartitionLifecycler(partitionManager *PartitionManager, ...) *PartitionLifecycler
type PartitionManager struct{ ... }
    func NewPartitionManager() *PartitionManager
type PartitionReadinessCheck func(partition int32, r *kgo.Record) (bool, error)
    func NewOffsetReadinessCheck(partitionManager *PartitionManager) PartitionReadinessCheck
type PartitionState int
    const PartitionPending PartitionState = iota ...
type Producer struct{ ... }
    func NewProducer(client KafkaProducer, topic string, numPartitions int, zone string, ...) *Producer
type RateBucket struct{ ... }
type RateLimitsAdapter struct{ ... }
    func NewRateLimitsAdapter(limits Limits) *RateLimitsAdapter
type Reason int
    const ReasonExceedsMaxStreams Reason = iota ...
type Stream struct{ ... }
type UsageStore struct{ ... }
    func NewUsageStore(activeWindow, rateWindow, bucketSize time.Duration, numPartitions int) *UsageStore
```

and after:

```
package limits // import "github.com/grafana/loki/v3/pkg/limits"

const DefaultActiveWindow = 1 * time.Hour ...
const RingKey = "ingest-limits" ...
func MetadataTopic(topic string) string
type Config struct{ ... }
type IngestLimits struct{ ... }
    func NewIngestLimits(cfg Config, lims Limits, logger log.Logger, reg prometheus.Registerer) (*IngestLimits, error)
type Limits interface{ ... }
type RateLimitsAdapter struct{ ... }
    func NewRateLimitsAdapter(limits Limits) *RateLimitsAdapter
type Reason int
    const ReasonExceedsMaxStreams Reason = iota ...
```

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
