### PR TITLE
chore(ci): Add relyance scanner

### DIFF
--- a/.github/workflows/relyance.yml
+++ b/.github/workflows/relyance.yml
@@ -1,0 +1,31 @@
+name: Relyance Compliance Inspection
+on:
+  schedule:
+    - cron: '0 0 * * *' # Run daily at 00:00 UTC
+  workflow_dispatch: # Allow for manual trigger
+
+jobs:
+  relyance:
+    permissions:
+      contents: read
+      id-token: write
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          'persist-credentials': false
+
+      - name: retrieve secrets
+        id: get-secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@7d18a46aafb8b875ed76a0bc98852d74b91e7f91 # v1.0.0
+        with:
+          repo_secrets: |
+            RELYANCE_API_KEY=relyance:API_KEY
+
+      - name: Run Relyance Compliance Inspector
+        run: |
+          docker pull gcr.io/relyance-ext/compliance_inspector:release && \
+          docker run --rm -v `pwd`:/repo --env "API_KEY=${{ env.RELYANCE_API_KEY }}" gcr.io/relyance-ext/compliance_inspector:release 

--- a/relyance.yaml
+++ b/relyance.yaml
@@ -1,0 +1,68 @@
+# Relyance Compliance Inspector Configuration
+
+# TODO: Replace text in < > with actual information from your environment
+
+# Product and Repository Metadata
+# Purpose: Useful to slice/dice the Data Inventory and Data Map in Relyance
+repository: grafana/loki
+
+
+# Services and Code Relationship
+# Purpose: Configuration used to visualize the code base and relationships between microservices and code.
+# Note: Directory paths are relative to the repository's root directory. 
+# Note: Need a separate entry for each microservice. See example below.
+services:
+  - service: compactor
+    source:
+      - pkg/compactor
+  - service: distributor
+    source:
+      - pkg/distributor
+  - service: indexgateway
+    source:
+      - pkg/indexgateway
+  - service: ingester
+    source:
+      - pkg/ingester
+  - service: querier
+    source:
+      - pkg/querier
+  - service: ruler
+    source:
+      - pkg/ruler
+
+
+# Example: Services and Code Relationship 
+# Note: Do not use below. It is an example.
+# Note: Directory paths are relative to the repository's root directory
+#- service: paymentservice
+#  source:
+#     - src/payments 
+#     - src/checkout_service
+#- service: catalogservice
+#  source:
+#     - src/catalog 
+
+
+# Source Directories to Exclude
+# Purpose: Configuration is used to exclude directories from analysis such as test directories etc.
+# Note: Directory paths are relative to the repository's root directory
+exclude:
+  - .cursor
+  - .devcontainer
+  - .github
+  - clients
+  - debug
+  - docs
+  - examples
+  - loki-build-image
+  - nix
+  - operator
+  - tools
+
+
+# Excluding files and directories using patterns (enable lines as needed)
+#exclude_patterns:
+#  - "**/*_mock.*" # example of excluding file with some pattern
+#  - "**/exclude_dir/**" # example of excluding a directory regardless where the directory is
+#  - src/excluded_file.go # example of excluding a specific file


### PR DESCRIPTION
**What this PR does / why we need it**:
Adding the Relyance scanner support to Loki.  This was already done for GEL, and is copying that workflow, along with the Relyance configuration file that we've already been using internally for scans.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
