### PR TITLE
chore: add back deprecated config to avoid possible rollout issue

### DIFF
--- a/pkg/limits/config.go
+++ b/pkg/limits/config.go
@@ -45,6 +45,10 @@ type Config struct {
 	// LifecyclerConfig is the config to build a ring lifecycler.
 	LifecyclerConfig ring.LifecyclerConfig `yaml:"lifecycler,omitempty"`
 	KafkaConfig      kafka.Config          `yaml:"-"`
+
+	// Deprecated.
+	WindowSize     time.Duration `yaml:"window_size" doc:"hidden|deprecated"`
+	BucketDuration time.Duration `yaml:"bucket_duration" doc:"hidden|deprecated"`
 }
 
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit adds back the window_size and bucket_duration fields as no-ops. This is to avoid a possible problem we might have next week with the releases where the ConfigMap is updated, and some pods on the previous release start crash looping before they can be rolled out to the new image.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
