### PR TITLE
docs: fix broken links in quickstart

### DIFF
--- a/docs/sources/get-started/quick-start/_index.md
+++ b/docs/sources/get-started/quick-start/_index.md
@@ -9,5 +9,5 @@ weight: 200
 
 This section provides a collection of tutorials to help you get started with Loki. Our recommenation is to do the tutorials in this order:
 
-1. [Quick Start](https://grafana.com/docs/loki/<LOKI_VERSION>/get-started/quick-start/quick-start.md)
-1. [Loki tutorial](https://grafana.com/docs/loki/<LOKI_VERSION>/get-started/quick-start/tutorial.md)
+1. [Quick Start](https://grafana.com/docs/loki/<LOKI_VERSION>/get-started/quick-start/quick-start/)
+1. [Loki tutorial](https://grafana.com/docs/loki/<LOKI_VERSION>/get-started/quick-start/tutorial/)


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes broken links on Quickstart page reported via the @ docs email address.