### PR TITLE
chore(dataobj): fix regression in allocations of row readers

### DIFF
--- a/pkg/dataobj/consumer/logsobj/builder.go
+++ b/pkg/dataobj/consumer/logsobj/builder.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"sort"
 	"time"
-	"unsafe"
 
 	"github.com/grafana/dskit/flagext"
 	lru "github.com/hashicorp/golang-lru/v2"
@@ -272,29 +271,18 @@ func streamSizeEstimate(stream logproto.Stream) int {
 	return size
 }
 
-func convertMetadata(md push.LabelsAdapter) []logs.RecordMetadata {
-	l := make([]logs.RecordMetadata, 0, len(md))
+func convertMetadata(md push.LabelsAdapter) labels.Labels {
+	l := make(labels.Labels, 0, len(md))
 	for _, label := range md {
-		l = append(l, logs.RecordMetadata{Name: label.Name, Value: unsafeSlice(label.Value, 0)})
+		l = append(l, labels.Label{Name: label.Name, Value: label.Value})
 	}
 	sort.Slice(l, func(i, j int) bool {
 		if l[i].Name == l[j].Name {
-			return cmp.Compare(unsafeString(l[i].Value), unsafeString(l[j].Value)) < 0
+			return cmp.Compare(l[i].Value, l[j].Value) < 0
 		}
 		return cmp.Compare(l[i].Name, l[j].Name) < 0
 	})
 	return l
-}
-
-func unsafeSlice(data string, capacity int) []byte {
-	if capacity <= 0 {
-		capacity = len(data)
-	}
-	return unsafe.Slice(unsafe.StringData(data), capacity)
-}
-
-func unsafeString(data []byte) string {
-	return unsafe.String(unsafe.SliceData(data), len(data))
 }
 
 func (b *Builder) estimatedSize() int {

--- a/pkg/dataobj/sections/logs/builder.go
+++ b/pkg/dataobj/sections/logs/builder.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/klauspost/compress/zstd"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/prometheus/model/labels"
 
 	"github.com/grafana/loki/v3/pkg/dataobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/dataset"
@@ -19,14 +20,8 @@ import (
 type Record struct {
 	StreamID  int64
 	Timestamp time.Time
-	Metadata  []RecordMetadata
+	Metadata  labels.Labels
 	Line      []byte
-}
-
-// A Labels-like type that holds byte buffers instead of strings.
-type RecordMetadata struct {
-	Name  string
-	Value []byte
 }
 
 // BuilderOptions configures the behavior of the logs section.

--- a/pkg/dataobj/sections/logs/builder_test.go
+++ b/pkg/dataobj/sections/logs/builder_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/loki/v3/pkg/dataobj"
@@ -23,13 +24,13 @@ func Test(t *testing.T) {
 		{
 			StreamID:  2,
 			Timestamp: time.Unix(100, 0),
-			Metadata:  []logs.RecordMetadata{{Name: "cluster", Value: []byte("test")}, {Name: "app", Value: []byte("bar")}},
+			Metadata:  []labels.Label{{Name: "cluster", Value: "test"}, {Name: "app", Value: "bar"}},
 			Line:      []byte("goodbye world"),
 		},
 		{
 			StreamID:  1,
 			Timestamp: time.Unix(5, 0),
-			Metadata:  []logs.RecordMetadata{{Name: "cluster", Value: []byte("test")}, {Name: "app", Value: []byte("foo")}},
+			Metadata:  []labels.Label{{Name: "cluster", Value: "test"}, {Name: "app", Value: "foo"}},
 			Line:      []byte("foo bar"),
 		},
 	}
@@ -54,19 +55,19 @@ func Test(t *testing.T) {
 		{
 			StreamID:  1,
 			Timestamp: time.Unix(5, 0),
-			Metadata:  []logs.RecordMetadata{{Name: "app", Value: []byte("foo")}, {Name: "cluster", Value: []byte("test")}},
+			Metadata:  []labels.Label{{Name: "app", Value: "foo"}, {Name: "cluster", Value: "test"}},
 			Line:      []byte("foo bar"),
 		},
 		{
 			StreamID:  1,
 			Timestamp: time.Unix(10, 0),
-			Metadata:  []logs.RecordMetadata{},
+			Metadata:  []labels.Label{},
 			Line:      []byte("hello world"),
 		},
 		{
 			StreamID:  2,
 			Timestamp: time.Unix(100, 0),
-			Metadata:  []logs.RecordMetadata{{Name: "app", Value: []byte("bar")}, {Name: "cluster", Value: []byte("test")}},
+			Metadata:  []labels.Label{{Name: "app", Value: "bar"}, {Name: "cluster", Value: "test"}},
 			Line:      []byte("goodbye world"),
 		},
 	}

--- a/pkg/dataobj/sections/logs/iter_test.go
+++ b/pkg/dataobj/sections/logs/iter_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/dataset"
@@ -40,7 +41,7 @@ func TestDecode(t *testing.T) {
 			expected: Record{
 				StreamID:  123,
 				Timestamp: time.Unix(0, 1234567890000000000),
-				Metadata:  []RecordMetadata{{Name: "app", Value: []byte("test-app")}, {Name: "env", Value: []byte("prod")}},
+				Metadata:  []labels.Label{{Name: "app", Value: "test-app"}, {Name: "env", Value: "prod"}},
 				Line:      []byte("test message"),
 			},
 		},
@@ -63,7 +64,7 @@ func TestDecode(t *testing.T) {
 			expected: Record{
 				StreamID:  123,
 				Timestamp: time.Unix(0, 1234567890000000000),
-				Metadata:  []RecordMetadata{},
+				Metadata:  []labels.Label{},
 				Line:      []byte("test message"),
 			},
 		},
@@ -120,7 +121,7 @@ func TestDecode(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			record := Record{}
-			err := decodeRow(tt.columns, tt.row, &record)
+			err := decodeRow(tt.columns, tt.row, &record, nil)
 			if tt.wantErr {
 				require.Error(t, err)
 				return

--- a/pkg/dataobj/sections/logs/table_build.go
+++ b/pkg/dataobj/sections/logs/table_build.go
@@ -30,8 +30,10 @@ func buildTable(buf *tableBuffer, pageSize int, compressionOpts dataset.Compress
 		_ = messageBuilder.Append(i, dataset.ByteArrayValue(record.Line))
 
 		for _, md := range record.Metadata {
+			// Passing around md.Value as an unsafe slice is safe here: appending
+			// values is always read-only and the byte slice will never be mutated.
 			metadataBuilder := buf.Metadata(md.Name, pageSize, compressionOpts)
-			_ = metadataBuilder.Append(i, dataset.ByteArrayValue(md.Value))
+			_ = metadataBuilder.Append(i, dataset.ByteArrayValue(unsafeSlice(md.Value, 0)))
 		}
 	}
 

--- a/pkg/dataobj/sections/streams/builder.go
+++ b/pkg/dataobj/sections/streams/builder.go
@@ -38,8 +38,6 @@ type Stream struct {
 
 	// Total number of log records in the stream.
 	Rows int
-
-	LbValueCaps []int // Capacities for each label value's byte array
 }
 
 // Reset zeroes all values in the stream struct so it can be reused.

--- a/pkg/dataobj/sections/streams/builder_test.go
+++ b/pkg/dataobj/sections/streams/builder_test.go
@@ -63,7 +63,6 @@ func Test(t *testing.T) {
 		stream, err := result.Value()
 		require.NoError(t, err)
 		stream.Labels = copyLabels(stream.Labels)
-		stream.LbValueCaps = nil
 		actual = append(actual, stream)
 	}
 

--- a/pkg/dataobj/sections/streams/row_reader_test.go
+++ b/pkg/dataobj/sections/streams/row_reader_test.go
@@ -31,9 +31,9 @@ var streamsTestdata = []struct {
 
 func TestRowReader(t *testing.T) {
 	expect := []streams.Stream{
-		{1, unixTime(10), unixTime(15), 25, labels.FromStrings("cluster", "test", "app", "foo"), 2, nil},
-		{2, unixTime(5), unixTime(20), 45, labels.FromStrings("cluster", "test", "app", "bar"), 2, nil},
-		{3, unixTime(25), unixTime(30), 35, labels.FromStrings("cluster", "test", "app", "baz"), 2, nil},
+		{1, unixTime(10), unixTime(15), 25, labels.FromStrings("cluster", "test", "app", "foo"), 2},
+		{2, unixTime(5), unixTime(20), 45, labels.FromStrings("cluster", "test", "app", "bar"), 2},
+		{3, unixTime(25), unixTime(30), 35, labels.FromStrings("cluster", "test", "app", "baz"), 2},
 	}
 
 	dec := buildStreamsDecoder(t, 1) // Many pages
@@ -45,7 +45,7 @@ func TestRowReader(t *testing.T) {
 
 func TestRowReader_AddLabelMatcher(t *testing.T) {
 	expect := []streams.Stream{
-		{2, unixTime(5), unixTime(20), 45, labels.FromStrings("cluster", "test", "app", "bar"), 2, nil},
+		{2, unixTime(5), unixTime(20), 45, labels.FromStrings("cluster", "test", "app", "bar"), 2},
 	}
 
 	dec := buildStreamsDecoder(t, 1) // Many pages
@@ -59,8 +59,8 @@ func TestRowReader_AddLabelMatcher(t *testing.T) {
 
 func TestRowReader_AddLabelFilter(t *testing.T) {
 	expect := []streams.Stream{
-		{2, unixTime(5), unixTime(20), 45, labels.FromStrings("cluster", "test", "app", "bar"), 2, nil},
-		{3, unixTime(25), unixTime(30), 35, labels.FromStrings("cluster", "test", "app", "baz"), 2, nil},
+		{2, unixTime(5), unixTime(20), 45, labels.FromStrings("cluster", "test", "app", "bar"), 2},
+		{3, unixTime(25), unixTime(30), 35, labels.FromStrings("cluster", "test", "app", "baz"), 2},
 	}
 
 	dec := buildStreamsDecoder(t, 1) // Many pages

--- a/pkg/engine/executor/dataobjscan.go
+++ b/pkg/engine/executor/dataobjscan.go
@@ -526,7 +526,7 @@ func (s *dataobjScan) appendToBuilder(builder array.Builder, field *arrow.Field,
 		}
 
 	case types.ColumnTypeMetadata.String():
-		val := getMetadataValue(record.Metadata, field.Name)
+		val := record.Metadata.Get(field.Name)
 		if val == "" {
 			builder.(*array.StringBuilder).AppendNull()
 		} else {
@@ -549,15 +549,6 @@ func (s *dataobjScan) appendToBuilder(builder array.Builder, field *arrow.Field,
 		// This shouldn't happen; we control the metadata here on the fields.
 		panic(fmt.Sprintf("unsupported column type %s", columnType))
 	}
-}
-
-func getMetadataValue(md []logs.RecordMetadata, name string) string {
-	for _, m := range md {
-		if m.Name == name {
-			return string(m.Value)
-		}
-	}
-	return ""
 }
 
 // Value returns the current [arrow.Record] retrieved by the previous call to


### PR DESCRIPTION
PR #17762 temporarily introduced an allocation regression in `logs.RowReader` by adding extra conversions from byte slices to strings and back.

This PR undoes that regression by pushing down usage of the string symbolizer. This allows us to use strings for metadata values all the way down the path before the `dataset.Reader` boundary. 

To be consistent with `logs.RowReader`, `streams.RowReader` now also does the same pattern. As a bonus, this removes the need for `streams.Stream` to track capacities used by the pointers backing strings. 
