### PR TITLE
chore: update tools configurations to change window_size to active_window

### DIFF
--- a/tools/dev/kafka/loki-local-config.debug.yaml
+++ b/tools/dev/kafka/loki-local-config.debug.yaml
@@ -26,7 +26,7 @@ querier:
 
 ingest_limits:
   enabled: true
-  window_size: 1h
+  active_window: 1h
   num_partitions: 1
   lifecycler:
     ring:

--- a/tools/stream-generator/loki-local-config.debug.yaml
+++ b/tools/stream-generator/loki-local-config.debug.yaml
@@ -25,7 +25,7 @@ kafka_config:
 
 ingest_limits:
   enabled: true
-  window_size: 1m
+  active_window: 1m
   lifecycler:
     ring:
       kvstore:


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates a number of committed configurations to use the renamed configuration option.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
