### PR TITLE
chore(ci): Add ignored paths for renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -6,6 +6,10 @@
   "labels": [
     "dependencies"
   ],
+  "ignorePaths": [
+    ".github/**",
+    "vendor/**"
+  ],
   "prHourlyLimit": 4,
   "baseBranches": [
     "main",


### PR DESCRIPTION
**What this PR does / why we need it**:

We don't want Renovate to bump versions on Dockerfiles etc in vendored libraries.