### PR TITLE
chore(ui): update ckit dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -50,7 +50,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/mux v1.8.1
 	github.com/gorilla/websocket v1.5.3
-	github.com/grafana/ckit v0.0.0-20250226083311-4f9f4aacabb5
+	github.com/grafana/ckit v0.0.0-20250514165824-dd4adf36ad34
 	github.com/grafana/cloudflare-go v0.0.0-20230110200409-c627cf6792f2
 	github.com/grafana/dskit v0.0.0-20250414072521-7b78bfe441ed
 	github.com/grafana/go-gelf/v2 v2.0.1

--- a/go.sum
+++ b/go.sum
@@ -659,8 +659,8 @@ github.com/gorilla/sessions v1.2.1/go.mod h1:dk2InVEVJ0sfLlnXv9EAgkf6ecYs/i80K/z
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
-github.com/grafana/ckit v0.0.0-20250226083311-4f9f4aacabb5 h1:EkW+rjr8zqiB4Jd7Gn5BmUhDz6PsZ0w33/4osKRd5x8=
-github.com/grafana/ckit v0.0.0-20250226083311-4f9f4aacabb5/go.mod h1:izhHi8mZ16lxMxsdlFjPHzkopbjKNdorTtitYyzAejY=
+github.com/grafana/ckit v0.0.0-20250514165824-dd4adf36ad34 h1:t1Nfp9udkvbYiCwNEz4THAR8C74jgR5jHuHPvabr1rM=
+github.com/grafana/ckit v0.0.0-20250514165824-dd4adf36ad34/go.mod h1:THPMJBdU2XgYUsYCG/PvtaYj1/NH4uNjw7U5kNohrLY=
 github.com/grafana/cloudflare-go v0.0.0-20230110200409-c627cf6792f2 h1:qhugDMdQ4Vp68H0tp/0iN17DM2ehRo1rLEdOFe/gB8I=
 github.com/grafana/cloudflare-go v0.0.0-20230110200409-c627cf6792f2/go.mod h1:w/aiO1POVIeXUQyl0VQSZjl5OAGDTL5aX+4v0RA1tcw=
 github.com/grafana/dskit v0.0.0-20250414072521-7b78bfe441ed h1:+D5CM2IictIjZTNhUaw/bLAdVZOwph85Cs+bUFKnXTU=

--- a/vendor/github.com/grafana/ckit/internal/gossiphttp/transport.go
+++ b/vendor/github.com/grafana/ckit/internal/gossiphttp/transport.go
@@ -256,6 +256,10 @@ func (t *Transport) run(ctx context.Context) {
 				return
 			}
 
+			// TODO(rfratto): allowing for multiple workers to process outgoing packets
+			// can help minimize latency. grafana/dskit permits for 3 workers by default,
+			// but to tolerate unhealthy peers we should probably allow for twice the
+			// number of gossip peers.
 			pkt := v.(*outPacket)
 			t.metrics.packetTxTotal.Inc()
 			t.metrics.packetTxBytesTotal.Add(float64(len(pkt.Data)))
@@ -576,7 +580,17 @@ func (t *Transport) writeToSync(b []byte, addr string) {
 	req.Header.Set("Content-Type", ckitContentType)
 	resp, err := t.opts.Client.Do(req)
 	if err != nil || resp.StatusCode != http.StatusOK {
-		level.Debug(t.log).Log("msg", "failed to send message", "err", err)
+		level.Debug(t.log).Log("msg", "failed to send message", "err", err, "status_code", statusCodeValue(resp))
 		t.metrics.packetTxFailedTotal.Inc()
 	}
+}
+
+// statusCodeValue returns the value to use when logging an HTTP status code.
+// if resp is nil, statusCodeValue returns a string of "<no response>".
+// Otherwise, it returns the numeric status code.
+func statusCodeValue(resp *http.Response) any {
+	if resp == nil {
+		return "<no response>"
+	}
+	return resp.StatusCode
 }

--- a/vendor/github.com/grafana/ckit/internal/messages/broadcast.go
+++ b/vendor/github.com/grafana/ckit/internal/messages/broadcast.go
@@ -6,6 +6,10 @@ import "github.com/hashicorp/memberlist"
 // being converted into a Broadcast.
 //
 // onDone will be called once the message has been broadcasted or invalidated.
+//
+// Queueing the resulting Broadcast will invalidate all previous broadcasts
+// for messages with the same name; this means that callers should only queue
+// newer messages.
 func Broadcast(m Message, onDone func()) (memberlist.Broadcast, error) {
 	bb, err := Encode(m)
 	if err != nil {
@@ -21,16 +25,32 @@ type broadcastWrapper struct {
 	onDone func()
 }
 
+// We want to implement [memberlist.NamedBroadcast] because it goes through a
+// fast path when queueing messages for broadcasting, where the Name is
+// stored in a map to immediately invalidate older messages with the same
+// Name.
+//
+// Without this, each time we queue a message, we call Invalidates on all
+// previously queued messages, for a total of N(N + 1) / 2 calls.
+var (
+	_ memberlist.Broadcast      = (*broadcastWrapper)(nil)
+	_ memberlist.NamedBroadcast = (*broadcastWrapper)(nil)
+)
+
 func (bw *broadcastWrapper) Invalidates(b memberlist.Broadcast) bool {
 	other, ok := b.(*broadcastWrapper)
 	if !ok {
 		return false
 	}
-	return bw.inner.Invalidates(other.inner)
+	return bw.inner.Name() == other.inner.Name()
 }
 
 func (bw *broadcastWrapper) Message() []byte {
 	return bw.data
+}
+
+func (bw *broadcastWrapper) Name() string {
+	return bw.inner.Name()
 }
 
 func (bw *broadcastWrapper) Finished() {

--- a/vendor/github.com/grafana/ckit/internal/messages/messages.go
+++ b/vendor/github.com/grafana/ckit/internal/messages/messages.go
@@ -42,13 +42,10 @@ type Message interface {
 	// Type returns the Type of the message. Type must be a known, valid type.
 	Type() Type
 
-	// Invalidates should return true if this message takes precedence over m.
-	Invalidates(m Message) bool
-
-	// Cache should return true if this Message should be cached into the local
-	// state. Messages in the local state will be synchronized with peers over
-	// time, and is useful for anti-entropy.
-	Cache() bool
+	// Name returns the name of the node this message is for. When queueing Messages
+	// for broadcast, newer messages immediately invalidate older messages with
+	// the same Name.
+	Name() string
 }
 
 // Encode encodes m into a byte slice that can be broadcast to other peers.

--- a/vendor/github.com/grafana/ckit/internal/messages/state.go
+++ b/vendor/github.com/grafana/ckit/internal/messages/state.go
@@ -27,14 +27,8 @@ var _ Message = (*State)(nil)
 // Type implements Message.
 func (s *State) Type() Type { return TypeState }
 
-// Invalidates implements Message.
-func (s *State) Invalidates(m Message) bool {
-	other, ok := m.(*State)
-	if !ok {
-		return false
-	}
-	return s.NodeName == other.NodeName && s.Time > other.Time
-}
+// Name implements Message.
+func (s *State) Name() string { return s.NodeName }
 
 // Cache implements Message.
 func (s *State) Cache() bool { return true }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1062,8 +1062,8 @@ github.com/gorilla/mux
 # github.com/gorilla/websocket v1.5.3
 ## explicit; go 1.12
 github.com/gorilla/websocket
-# github.com/grafana/ckit v0.0.0-20250226083311-4f9f4aacabb5
-## explicit; go 1.20
+# github.com/grafana/ckit v0.0.0-20250514165824-dd4adf36ad34
+## explicit; go 1.23.0
 github.com/grafana/ckit
 github.com/grafana/ckit/internal/chash
 github.com/grafana/ckit/internal/gossiphttp


### PR DESCRIPTION
This pulls in grafana/ckit#84 to reduce the CPU overhead when a lot of nodes are actively joining or leaving the cluster. 

Additionally, we update the service to only set our state after the cluster has been joined. ckit [recommends](https://pkg.go.dev/github.com/grafana/ckit#Node.ChangeState) doing this so that lamport clock synchronization has already happened when the state change messaged is broadcasted. 

If a node restarts and it changes state before joining the cluster, it typically will see a state change from the previous instance of that node, and "correct" it by rebroadcasting the current state. Changing state after joining ensures that the new state change takes precedence over state changes from previous instances of that node. 