### PR TITLE
fix(limits): Adapt defaults and expose evict interval

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -924,8 +924,8 @@ ingest_limits:
   [bucket_size: <duration> | default = 1m]
 
   # The interval at which old streams are evicted.
-  # CLI flag: -ingest-limits.evict-interval
-  [evict_interval: <duration> | default = 30m]
+  # CLI flag: -ingest-limits.eviction-interval
+  [eviction_interval: <duration> | default = 30m]
 
   # The number of partitions for the Kafka topic used to read and write stream
   # metadata. It is fixed, not a maximum.

--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -911,7 +911,7 @@ ingest_limits:
   # have not been updated within this window are considered inactive and not
   # counted towards limits.
   # CLI flag: -ingest-limits.active-window
-  [active_window: <duration> | default = 1h]
+  [active_window: <duration> | default = 2h]
 
   # The time window for rate calculation. This should match the window used in
   # Prometheus rate() queries for consistency.
@@ -922,6 +922,10 @@ ingest_limits:
   # provide more precise rates but require more memory.
   # CLI flag: -ingest-limits.bucket-size
   [bucket_size: <duration> | default = 1m]
+
+  # The interval at which old streams are evicted.
+  # CLI flag: -ingest-limits.evict-interval
+  [evict_interval: <duration> | default = 30m]
 
   # The number of partitions for the Kafka topic used to read and write stream
   # metadata. It is fixed, not a maximum.

--- a/pkg/limits/config.go
+++ b/pkg/limits/config.go
@@ -108,8 +108,8 @@ func (cfg *Config) Validate() error {
 	if cfg.RateWindow < cfg.BucketSize {
 		return errors.New("rate-window must be greater than or equal to bucket-size")
 	}
-	if cfg.ActiveWindow%cfg.EvictionInterval != 0 {
-		return errors.New("active-window must be a multiple of evict-interval")
+	if cfg.EvictionInterval <= 0 {
+		return errors.New("eviction-interval must be greater than 0")
 	}
 	if cfg.NumPartitions <= 0 {
 		return errors.New("num-partitions must be greater than 0")

--- a/pkg/limits/config.go
+++ b/pkg/limits/config.go
@@ -12,9 +12,10 @@ import (
 )
 
 const (
-	DefaultActiveWindow  = 1 * time.Hour
+	DefaultActiveWindow  = 2 * time.Hour
 	DefaultRateWindow    = 5 * time.Minute
 	DefaultBucketSize    = 1 * time.Minute
+	DefaultEvictInterval = 30 * time.Minute
 	DefaultNumPartitions = 64
 )
 
@@ -37,6 +38,9 @@ type Config struct {
 	// rates. Smaller buckets provide more precise rates but require more
 	// memory.
 	BucketSize time.Duration `yaml:"bucket_size"`
+
+	// EvictInterval defines the interval at which old streams are evicted.
+	EvictInterval time.Duration `yaml:"evict_interval"`
 
 	// The number of partitions for the Kafka topic used to read and write stream metadata.
 	// It is fixed, not a maximum.
@@ -77,6 +81,12 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 		DefaultBucketSize,
 		"The size of the buckets used to calculate stream rates. Smaller buckets provide more precise rates but require more memory.",
 	)
+	f.DurationVar(
+		&cfg.EvictInterval,
+		"ingest-limits.evict-interval",
+		DefaultEvictInterval,
+		"The interval at which old streams are evicted.",
+	)
 	f.IntVar(
 		&cfg.NumPartitions,
 		"ingest-limits.num-partitions",
@@ -97,6 +107,9 @@ func (cfg *Config) Validate() error {
 	}
 	if cfg.RateWindow < cfg.BucketSize {
 		return errors.New("rate-window must be greater than or equal to bucket-size")
+	}
+	if cfg.ActiveWindow%cfg.EvictInterval != 0 {
+		return errors.New("active-window must be a multiple of evict-interval")
 	}
 	if cfg.NumPartitions <= 0 {
 		return errors.New("num-partitions must be greater than 0")

--- a/pkg/limits/config.go
+++ b/pkg/limits/config.go
@@ -39,8 +39,8 @@ type Config struct {
 	// memory.
 	BucketSize time.Duration `yaml:"bucket_size"`
 
-	// EvictInterval defines the interval at which old streams are evicted.
-	EvictInterval time.Duration `yaml:"evict_interval"`
+	// EvictionInterval defines the interval at which old streams are evicted.
+	EvictionInterval time.Duration `yaml:"eviction_interval"`
 
 	// The number of partitions for the Kafka topic used to read and write stream metadata.
 	// It is fixed, not a maximum.
@@ -82,8 +82,8 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 		"The size of the buckets used to calculate stream rates. Smaller buckets provide more precise rates but require more memory.",
 	)
 	f.DurationVar(
-		&cfg.EvictInterval,
-		"ingest-limits.evict-interval",
+		&cfg.EvictionInterval,
+		"ingest-limits.eviction-interval",
 		DefaultEvictInterval,
 		"The interval at which old streams are evicted.",
 	)
@@ -108,7 +108,7 @@ func (cfg *Config) Validate() error {
 	if cfg.RateWindow < cfg.BucketSize {
 		return errors.New("rate-window must be greater than or equal to bucket-size")
 	}
-	if cfg.ActiveWindow%cfg.EvictInterval != 0 {
+	if cfg.ActiveWindow%cfg.EvictionInterval != 0 {
 		return errors.New("active-window must be a multiple of evict-interval")
 	}
 	if cfg.NumPartitions <= 0 {

--- a/pkg/limits/service.go
+++ b/pkg/limits/service.go
@@ -321,7 +321,7 @@ func (s *Service) running(ctx context.Context) error {
 // evictOldStreamsPeriodic runs a periodic job that evicts old streams.
 // It runs two evictions per window size.
 func (s *Service) evictOldStreamsPeriodic(ctx context.Context) {
-	ticker := time.NewTicker(s.cfg.ActiveWindow / 2)
+	ticker := time.NewTicker(s.cfg.EvictInterval)
 	defer ticker.Stop()
 	for {
 		select {

--- a/pkg/limits/service.go
+++ b/pkg/limits/service.go
@@ -321,7 +321,7 @@ func (s *Service) running(ctx context.Context) error {
 // evictOldStreamsPeriodic runs a periodic job that evicts old streams.
 // It runs two evictions per window size.
 func (s *Service) evictOldStreamsPeriodic(ctx context.Context) {
-	ticker := time.NewTicker(s.cfg.EvictInterval)
+	ticker := time.NewTicker(s.cfg.EvictionInterval)
 	defer ticker.Stop()
 	for {
 		select {

--- a/pkg/limits/store_test.go
+++ b/pkg/limits/store_test.go
@@ -179,7 +179,7 @@ func TestUsageStore_Evict(t *testing.T) {
 	s.clock = clock
 	s1 := streamUsage{hash: 0x1, lastSeenAt: clock.Now().UnixNano()}
 	s.set("tenant1", s1)
-	s2 := streamUsage{hash: 0x2, lastSeenAt: clock.Now().Add(-61 * time.Minute).UnixNano()}
+	s2 := streamUsage{hash: 0x2, lastSeenAt: clock.Now().Add(-121 * time.Minute).UnixNano()}
 	s.set("tenant1", s2)
 	s3 := streamUsage{hash: 0x3, lastSeenAt: clock.Now().UnixNano()}
 	s.set("tenant2", s3)


### PR DESCRIPTION
**What this PR does / why we need it**:
This pull request adapts the default active window for the ingest-limits service from `1h` to `2h`. With the redesign to synchronous ingest-limits writes the new default represents the same length of active streams in classic ingesters. In addition the evict internal is exposed as a custom config decoupled from the choice of the active window.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
