### PR TITLE
chore(stream-generator): Support batch interval config

### DIFF
--- a/tools/stream-generator/generator/config.go
+++ b/tools/stream-generator/generator/config.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/kv/memberlist"
@@ -35,15 +36,16 @@ const (
 )
 
 type Config struct {
-	NumPartitions             int          `yaml:"num_partitions"`
-	NumTenants                int          `yaml:"num_tenants"`
-	TenantPrefix              string       `yaml:"tenant_prefix"`
-	QPSPerTenant              int          `yaml:"qps_per_tenant"`
-	BatchSize                 int          `yaml:"batch_size"`
-	StreamsPerTenant          int          `yaml:"streams_per_tenant"`
-	StreamLabels              []string     `yaml:"stream_labels"`
-	MaxGlobalStreamsPerTenant int          `yaml:"max_global_streams_per_tenant"`
-	PushMode                  PushModeType `yaml:"push_mode"`
+	NumPartitions             int           `yaml:"num_partitions"`
+	NumTenants                int           `yaml:"num_tenants"`
+	TenantPrefix              string        `yaml:"tenant_prefix"`
+	QPSPerTenant              int           `yaml:"qps_per_tenant"`
+	BatchSize                 int           `yaml:"batch_size"`
+	BatchInterval             time.Duration `yaml:"batch_interval"`
+	StreamsPerTenant          int           `yaml:"streams_per_tenant"`
+	StreamLabels              []string      `yaml:"stream_labels"`
+	MaxGlobalStreamsPerTenant int           `yaml:"max_global_streams_per_tenant"`
+	PushMode                  PushModeType  `yaml:"push_mode"`
 	pushModeRaw               string
 
 	// Stream size control parameter
@@ -83,6 +85,7 @@ func (c *Config) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 	f.StringVar(&c.TenantPrefix, "tenants.prefix", "", "Prefix for tenant IDs")
 	f.IntVar(&c.QPSPerTenant, "tenants.qps", 10, "Number of QPS per tenant")
 	f.IntVar(&c.BatchSize, "tenants.streams.batch-size", 100, "Number of streams to send to Kafka per tick")
+	f.DurationVar(&c.BatchInterval, "tenants.streams.batch-interval", 1*time.Minute, "Number of milliseconds to wait between batches. If set to 0, it will be calculated based on QPSPerTenant.")
 	f.IntVar(&c.StreamsPerTenant, "tenants.streams.total", 100, "Number of streams per tenant")
 	f.IntVar(&c.MaxGlobalStreamsPerTenant, "tenants.max-global-streams", 1000, "Maximum number of global streams per tenant")
 	f.IntVar(&c.HTTPListenPort, "http-listen-port", 3100, "HTTP Listener port")
@@ -112,6 +115,10 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("invalid push mode: %s", c.pushModeRaw)
 	}
 	c.PushMode = PushModeType(c.pushModeRaw)
+
+	if c.BatchInterval <= 0 {
+		c.BatchInterval = time.Second / time.Duration(c.QPSPerTenant)
+	}
 
 	return nil
 }

--- a/tools/stream-generator/generator/service.go
+++ b/tools/stream-generator/generator/service.go
@@ -168,7 +168,7 @@ func (s *Generator) running(ctx context.Context) error {
 			defer s.wg.Done()
 
 			// Create a ticker for rate limiting based on QPSPerTenant
-			ticker := time.NewTicker(time.Second / time.Duration(s.cfg.QPSPerTenant))
+			ticker := time.NewTicker(s.cfg.BatchInterval)
 			defer ticker.Stop()
 
 			// Keep track of current stream index and whether we've completed first pass


### PR DESCRIPTION
**What this PR does / why we need it**:
This pull request adds support for a configurable batching interval for push requests. Previously it was calculated based on the request QPS per tenant.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
