### PR TITLE
fix: set delete request batch to empty when we load to fail requests

### DIFF
--- a/pkg/compactor/deletion/delete_requests_manager.go
+++ b/pkg/compactor/deletion/delete_requests_manager.go
@@ -333,7 +333,7 @@ func (d *DeleteRequestsManager) MarkPhaseStarted() {
 	status := statusSuccess
 	if batch, err := d.loadDeleteRequestsToProcess(DeleteRequestsAll); err != nil {
 		status = statusFail
-		d.currentBatch = nil
+		d.currentBatch = newDeleteRequestBatch(d.metrics)
 		level.Error(util_log.Logger).Log("msg", "failed to load delete requests to process", "err", err)
 	} else {
 		d.currentBatch = batch

--- a/pkg/compactor/deletion/delete_requests_manager.go
+++ b/pkg/compactor/deletion/delete_requests_manager.go
@@ -67,6 +67,7 @@ func NewDeleteRequestsManager(workingDir string, store DeleteRequestsStore, dele
 		batchSize:                 batchSize,
 		limits:                    limits,
 		processedSeries:           map[string]struct{}{},
+		currentBatch:              newDeleteRequestBatch(metrics),
 	}
 
 	var err error


### PR DESCRIPTION
**What this PR does / why we need it**:
When we fail to load delete requests, we set DeleteRequestsManager.currentBatch to `nil`, which would lead to panics when we try to do any operation on the batch.
I have changed the code to set it to an empty batch when we fail to load the delete requests.
