### PR TITLE
fix: Implement approx-topk function on querier

### DIFF
--- a/pkg/logql/count_min_sketch.go
+++ b/pkg/logql/count_min_sketch.go
@@ -359,18 +359,18 @@ func (*CountMinSketchVectorStepEvaluator) Close() error { return nil }
 
 func (*CountMinSketchVectorStepEvaluator) Error() error { return nil }
 
-var _ StepEvaluator = (*countMinSketchEvalStepEvaluator)(nil)
+var _ StepEvaluator = (*CountMinSketchEvalStepEvaluator)(nil)
 
-// countMinSketchEvalStepEvaluator transforms a CountMinSketchEvalExpr into a CountMinSketchVector.
-type countMinSketchEvalStepEvaluator struct {
+// CountMinSketchEvalStepEvaluator transforms a CountMinSketchEvalExpr into a CountMinSketchVector.
+type CountMinSketchEvalStepEvaluator struct {
 	ctx           context.Context
 	nextEvFactory SampleEvaluatorFactory
 	expr          *CountMinSketchEvalExpr
 	params        Params
 }
 
-func NewCountMinSketchEvalStepEvaluator(ctx context.Context, nextEvFactory SampleEvaluatorFactory, expr *CountMinSketchEvalExpr, params Params) (*countMinSketchEvalStepEvaluator, error) {
-	return &countMinSketchEvalStepEvaluator{
+func NewCountMinSketchEvalStepEvaluator(ctx context.Context, nextEvFactory SampleEvaluatorFactory, expr *CountMinSketchEvalExpr, params Params) (*CountMinSketchEvalStepEvaluator, error) {
+	return &CountMinSketchEvalStepEvaluator{
 		ctx:           ctx,
 		nextEvFactory: nextEvFactory,
 		expr:          expr,
@@ -378,7 +378,7 @@ func NewCountMinSketchEvalStepEvaluator(ctx context.Context, nextEvFactory Sampl
 	}, nil
 }
 
-func (e *countMinSketchEvalStepEvaluator) Next() (bool, int64, StepResult) {
+func (e *CountMinSketchEvalStepEvaluator) Next() (bool, int64, StepResult) {
 	nextEv, err := e.nextEvFactory.NewStepEvaluator(e.ctx, e.nextEvFactory, e.expr.SampleExpr, e.params)
 	if err != nil {
 		return false, 0, CountMinSketchVector{}
@@ -395,9 +395,8 @@ func (e *countMinSketchEvalStepEvaluator) Next() (bool, int64, StepResult) {
 	return handler.Next()
 }
 
-func (*countMinSketchEvalStepEvaluator) Close() error { return nil }
+func (*CountMinSketchEvalStepEvaluator) Close() error { return nil }
 
-func (*countMinSketchEvalStepEvaluator) Error() error { return nil }
+func (*CountMinSketchEvalStepEvaluator) Error() error { return nil }
 
-func (e *countMinSketchEvalStepEvaluator) Explain(parent Node) {
-}
+func (e *CountMinSketchEvalStepEvaluator) Explain(_ Node) {}

--- a/pkg/logql/count_min_sketch.go
+++ b/pkg/logql/count_min_sketch.go
@@ -2,6 +2,7 @@ package logql
 
 import (
 	"container/heap"
+	"context"
 	"fmt"
 	"slices"
 	"strings"
@@ -322,7 +323,7 @@ type CountMinSketchVectorStepEvaluator struct {
 	buffer []byte
 }
 
-var _ StepEvaluator = NewQuantileSketchVectorStepEvaluator(nil, 0)
+var _ StepEvaluator = NewCountMinSketchVectorStepEvaluator(nil)
 
 func NewCountMinSketchVectorStepEvaluator(vec *CountMinSketchVector) *CountMinSketchVectorStepEvaluator {
 	return &CountMinSketchVectorStepEvaluator{
@@ -357,3 +358,46 @@ func (e *CountMinSketchVectorStepEvaluator) Next() (bool, int64, StepResult) {
 func (*CountMinSketchVectorStepEvaluator) Close() error { return nil }
 
 func (*CountMinSketchVectorStepEvaluator) Error() error { return nil }
+
+var _ StepEvaluator = (*countMinSketchEvalStepEvaluator)(nil)
+
+// countMinSketchEvalStepEvaluator transforms a CountMinSketchEvalExpr into a CountMinSketchVector.
+type countMinSketchEvalStepEvaluator struct {
+	ctx           context.Context
+	nextEvFactory SampleEvaluatorFactory
+	expr          *CountMinSketchEvalExpr
+	params        Params
+}
+
+func NewCountMinSketchEvalStepEvaluator(ctx context.Context, nextEvFactory SampleEvaluatorFactory, expr *CountMinSketchEvalExpr, params Params) (*countMinSketchEvalStepEvaluator, error) {
+	return &countMinSketchEvalStepEvaluator{
+		ctx:           ctx,
+		nextEvFactory: nextEvFactory,
+		expr:          expr,
+		params:        params,
+	}, nil
+}
+
+func (e *countMinSketchEvalStepEvaluator) Next() (bool, int64, StepResult) {
+	nextEv, err := e.nextEvFactory.NewStepEvaluator(e.ctx, e.nextEvFactory, e.expr.SampleExpr, e.params)
+	if err != nil {
+		return false, 0, CountMinSketchVector{}
+	}
+
+	ok, _, results := nextEv.Next()
+	if !ok {
+		return false, 0, CountMinSketchVector{}
+	}
+
+	data := results.CountMinSketchVec()
+	handler := NewCountMinSketchVectorStepEvaluator(&data)
+
+	return handler.Next()
+}
+
+func (*countMinSketchEvalStepEvaluator) Close() error { return nil }
+
+func (*countMinSketchEvalStepEvaluator) Error() error { return nil }
+
+func (e *countMinSketchEvalStepEvaluator) Explain(parent Node) {
+}

--- a/pkg/logql/downstream.go
+++ b/pkg/logql/downstream.go
@@ -414,6 +414,9 @@ func (e CountMinSketchEvalExpr) String() string {
 
 		sb.WriteString(d.String())
 	}
+	if len(e.downstreams) == 0 {
+		sb.WriteString(e.SampleExpr.String())
+	}
 	return fmt.Sprintf("CountMinSketchEval<%s>", sb.String())
 }
 

--- a/pkg/logql/evaluator.go
+++ b/pkg/logql/evaluator.go
@@ -359,6 +359,8 @@ func (ev *DefaultEvaluator) NewStepEvaluator(
 			})
 		}
 		return newVectorAggEvaluator(ctx, nextEvFactory, e, q, ev.maxCountMinSketchHeapSize)
+	case *CountMinSketchEvalExpr:
+		return NewCountMinSketchEvalStepEvaluator(ctx, nextEvFactory, e, q)
 	case *syntax.RangeAggregationExpr:
 		it, err := ev.querier.SelectSamples(ctx, SelectSampleParams{
 			&logproto.SampleQueryRequest{


### PR DESCRIPTION
**What this PR does / why we need it**:
Implements the approx_topk function on the querier directly, so it no longer requires the query-frontend to re-write it via the ShardMapper.
* It is implemented using __count_min_sketch__ as a sharded query is, but I added a step evaluator to process the samples instead of using the Downstreamer & Accumulator.
* This fixes a panic when an `approx_topk` query is not sharded (e.g. it's within the minShardingLookback, or when there aren't any shards within the data) and the raw query is simply forwarded to the querier.

Tested locally to double check it works as expected.
<img width="941" alt="image" src="https://github.com/user-attachments/assets/0549bffe-373e-4ddd-87b1-c9bc28df8343" />
