### PR TITLE
chore: add metrics

### DIFF
--- a/pkg/dataobj/consumer/service.go
+++ b/pkg/dataobj/consumer/service.go
@@ -173,6 +173,15 @@ func (s *Service) run(ctx context.Context) error {
 				return
 			}
 
+			// Calculate total bytes in this batch
+			var totalBytes int64
+			for _, record := range records {
+				totalBytes += int64(len(record.Value))
+			}
+
+			// Update metrics
+			processor.metrics.addBytesProcessed(totalBytes)
+
 			_ = processor.Append(records)
 		})
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Add more metrics for dataobj-consumer to monitor our consumption by partitions and tenants.

Looking to investigations about our current state, we would like to have a better view about the amount of data that we are sending/processing for each tenant per topic.

These new metrics would help us to build a better visualisation about the operational work of dataobj-consumer.

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
