### PR TITLE
chore: rename dataobj consumer metrics

### DIFF
--- a/pkg/dataobj/consumer/metrics.go
+++ b/pkg/dataobj/consumer/metrics.go
@@ -24,8 +24,7 @@ type partitionOffsetMetrics struct {
 	processingDelay prometheus.Histogram
 
 	// Data volume metrics
-	bytesProcessed  prometheus.Counter
-	lastRecordBytes prometheus.Gauge
+	bytesProcessed prometheus.Counter
 }
 
 func newPartitionOffsetMetrics() *partitionOffsetMetrics {
@@ -58,10 +57,6 @@ func newPartitionOffsetMetrics() *partitionOffsetMetrics {
 			Name: "loki_dataobj_consumer_bytes_processed_total",
 			Help: "Total number of bytes processed from this partition",
 		}),
-		lastRecordBytes: prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: "loki_dataobj_consumer_last_record_bytes",
-			Help: "Last record bytes being processed from this partition",
-		}),
 	}
 
 	p.currentOffset = prometheus.NewGaugeFunc(
@@ -86,7 +81,6 @@ func (p *partitionOffsetMetrics) register(reg prometheus.Registerer) error {
 		p.currentOffset,
 		p.processingDelay,
 		p.bytesProcessed,
-		p.lastRecordBytes,
 	}
 
 	for _, collector := range collectors {
@@ -106,7 +100,6 @@ func (p *partitionOffsetMetrics) unregister(reg prometheus.Registerer) {
 		p.currentOffset,
 		p.processingDelay,
 		p.bytesProcessed,
-		p.lastRecordBytes,
 	}
 
 	for _, collector := range collectors {
@@ -143,5 +136,4 @@ func (p *partitionOffsetMetrics) observeProcessingDelay(recordTimestamp time.Tim
 
 func (p *partitionOffsetMetrics) addBytesProcessed(bytes int64) {
 	p.bytesProcessed.Add(float64(bytes))
-	p.lastRecordBytes.Set(float64(bytes))
 }

--- a/pkg/dataobj/consumer/metrics.go
+++ b/pkg/dataobj/consumer/metrics.go
@@ -24,8 +24,8 @@ type partitionOffsetMetrics struct {
 	processingDelay prometheus.Histogram
 
 	// Data volume metrics
-	bytesProcessed prometheus.Counter
-	bytesPerSecond prometheus.Gauge
+	bytesProcessed  prometheus.Counter
+	lastRecordBytes prometheus.Gauge
 }
 
 func newPartitionOffsetMetrics() *partitionOffsetMetrics {
@@ -58,9 +58,9 @@ func newPartitionOffsetMetrics() *partitionOffsetMetrics {
 			Name: "loki_dataobj_consumer_bytes_processed_total",
 			Help: "Total number of bytes processed from this partition",
 		}),
-		bytesPerSecond: prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: "loki_dataobj_consumer_bytes_per_second",
-			Help: "Current rate of bytes being processed from this partition",
+		lastRecordBytes: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "loki_dataobj_consumer_last_record_bytes",
+			Help: "Last record bytes being processed from this partition",
 		}),
 	}
 
@@ -86,7 +86,7 @@ func (p *partitionOffsetMetrics) register(reg prometheus.Registerer) error {
 		p.currentOffset,
 		p.processingDelay,
 		p.bytesProcessed,
-		p.bytesPerSecond,
+		p.lastRecordBytes,
 	}
 
 	for _, collector := range collectors {
@@ -106,7 +106,7 @@ func (p *partitionOffsetMetrics) unregister(reg prometheus.Registerer) {
 		p.currentOffset,
 		p.processingDelay,
 		p.bytesProcessed,
-		p.bytesPerSecond,
+		p.lastRecordBytes,
 	}
 
 	for _, collector := range collectors {
@@ -143,5 +143,5 @@ func (p *partitionOffsetMetrics) observeProcessingDelay(recordTimestamp time.Tim
 
 func (p *partitionOffsetMetrics) addBytesProcessed(bytes int64) {
 	p.bytesProcessed.Add(float64(bytes))
-	p.bytesPerSecond.Set(float64(bytes)) // This is a simple implementation - you might want to use a more sophisticated rate calculation
+	p.lastRecordBytes.Set(float64(bytes))
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix the metric name for last record processed bytes.

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
