### PR TITLE
fix(helm): Configuring Loki to start UI when setting loki.ui.enabled in Helm values

### DIFF
--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -284,6 +284,7 @@ loki:
 
     {{- if .Values.loki.ui.enabled }}
     ui:
+      enabled: true
       discovery:
         join_peers:
           - '{{ include "loki.queryFrontendFullname" . }}.{{ $.Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}'


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, the Loki production charts has `loki.ui.enabled` to configure memberlist and proxy/gateway settings, but it doesn't actually set `ui.enabled = true` in the Loki config.
Requests are proxied to distributor, but no UI module is running to accept requests, leading to 404 responses.

This PR enables the UI when the UI is enabled.

**Which issue(s) this PR fixes**:
Haven't created one

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
