### PR TITLE
chore: Estimate builder size when using multiple sections

### DIFF
--- a/pkg/dataobj/consumer/logsobj/builder.go
+++ b/pkg/dataobj/consumer/logsobj/builder.go
@@ -171,6 +171,10 @@ func NewBuilder(cfg BuilderConfig) (*Builder, error) {
 	}, nil
 }
 
+func (b *Builder) GetEstimatedSize() int {
+	return b.currentSizeEstimate
+}
+
 // Append buffers a stream to be written to a data object. Append returns an
 // error if the stream labels cannot be parsed or [ErrBuilderFull] if the
 // builder is full.
@@ -289,6 +293,7 @@ func (b *Builder) estimatedSize() int {
 	var size int
 	size += b.streams.EstimatedSize()
 	size += b.logs.EstimatedSize()
+	size += b.builder.Bytes()
 	b.metrics.sizeEstimate.Set(float64(size))
 	return size
 }

--- a/pkg/dataobj/consumer/logsobj/builder_test.go
+++ b/pkg/dataobj/consumer/logsobj/builder_test.go
@@ -21,7 +21,7 @@ import (
 var testBuilderConfig = BuilderConfig{
 	TargetPageSize:    2048,
 	TargetObjectSize:  1 << 22, // 4 MiB
-	TargetSectionSize: 1 << 22, // 4 MiB
+	TargetSectionSize: 1 << 21, // 2 MiB
 
 	BufferSize: 2048 * 8,
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Correctly estimates total builder size when section size is smaller than object size
* Previously we would restart the counter when a section was flushed, as we didn't account for existing data in the buffer.
* I updated the test accordingly. It fails without my fix.
