### PR TITLE
chore: update go & delve in dev.dockerfile to 1.24

### DIFF
--- a/tools/dev/loki-tsdb-storage-s3/dev.dockerfile
+++ b/tools/dev/loki-tsdb-storage-s3/dev.dockerfile
@@ -1,6 +1,6 @@
-FROM golang:1.23
+FROM golang:1.24
 ENV CGO_ENABLED=0
-RUN go install github.com/go-delve/delve/cmd/dlv@v1.23.1
+RUN go install github.com/go-delve/delve/cmd/dlv@v1.24.2
 
 FROM alpine:3.21.3
 


### PR DESCRIPTION
**What this PR does / why we need it**:

I tried running local dev env and it failed with:

```
API server listening at: [::]:18004
2025-05-28T15:59:03Z warning layer=rpc Listening for remote connections (connections are not authenticated nor encrypted)
Version of Delve is too old for Go version go1.24.3 (maximum supported version 1.23, suppress this error with --check-go-version=false)
```

I figured out that's because we're building the image with a newer Go version than dev container is built with.

**Which issue(s) this PR fixes**:

Fixes dev env

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
