### PR TITLE
chore: fix dev env tracing by pinning jaeger

### DIFF
--- a/tools/dev/loki-tsdb-storage-s3/docker-compose.yml
+++ b/tools/dev/loki-tsdb-storage-s3/docker-compose.yml
@@ -34,7 +34,8 @@ services:
   jaeger:
     logging:
       <<: *logging
-    image: jaegertracing/all-in-one
+    #  Use 1.62 specifically since 1.63 removes the agent which we depend on for now.
+    image: jaegertracing/all-in-one:1.62.0
     ports:
       - 16686:16686
       - "14268"


### PR DESCRIPTION
**What this PR does / why we need it**:

Just copying same thing we did in Mimir: 1.63 removed the agent from the image, so tracing in the docker compose dev env stopped working.

To workaround, we just pin it to 1.62.

**Which issue(s) this PR fixes**:

Fixes dev env.

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
