### PR TITLE
chore(spanlogger): force all usages to provide a logger

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -373,7 +373,14 @@ else
 	go version
 	golangci-lint version
 	GO111MODULE=on golangci-lint run -v --timeout 15m --build-tags linux,promtail_journal_enabled
-	faillint -paths "sync/atomic=go.uber.org/atomic" ./...
+	faillint \
+		-paths "sync/atomic=go.uber.org/atomic" \
+		./...
+
+	# Use our spanlogger implementation instead of the one in dskit to make sure we use the correct tracing lib.
+	faillint \
+		-paths "github.com/grafana/dskit/spanlogger=github.com/grafana/loki/pkg/util/spanlogger" \
+		./...
 endif
 
 ########

--- a/pkg/bloomgateway/bloomgateway.go
+++ b/pkg/bloomgateway/bloomgateway.go
@@ -207,7 +207,7 @@ func (g *Gateway) FilterChunkRefs(ctx context.Context, req *logproto.FilterChunk
 
 	sp, ctx := opentracing.StartSpanFromContext(ctx, "bloomgateway.FilterChunkRefs")
 	stats, ctx := ContextWithEmptyStats(ctx)
-	logger := spanlogger.FromContextWithFallback(
+	logger := spanlogger.FromContext(
 		ctx,
 		utillog.WithContext(ctx, g.logger),
 	)

--- a/pkg/bloomgateway/querier.go
+++ b/pkg/bloomgateway/querier.go
@@ -108,7 +108,7 @@ func (bq *BloomQuerier) FilterChunkRefs(ctx context.Context, tenant string, from
 		return chunkRefs, false, nil
 	}
 
-	logger, ctx := spanlogger.NewWithLogger(ctx, bq.logger, "bloomquerier.FilterChunkRefs")
+	logger, ctx := spanlogger.New(ctx, bq.logger, "bloomquerier.FilterChunkRefs")
 	defer logger.Finish()
 
 	grouped := groupedChunksRefPool.Get(len(chunkRefs))

--- a/pkg/indexgateway/gateway.go
+++ b/pkg/indexgateway/gateway.go
@@ -106,7 +106,7 @@ func NewIndexGateway(cfg Config, limits Limits, log log.Logger, r prometheus.Reg
 }
 
 func (g *Gateway) QueryIndex(request *logproto.QueryIndexRequest, server logproto.IndexGateway_QueryIndexServer) error {
-	log, _ := spanlogger.New(context.Background(), "IndexGateway.QueryIndex")
+	log, _ := spanlogger.New(context.Background(), g.log, "IndexGateway.QueryIndex")
 	defer log.Finish()
 
 	var outerErr, innerErr error

--- a/pkg/pattern/tee_service.go
+++ b/pkg/pattern/tee_service.go
@@ -302,7 +302,7 @@ func (ts *TeeService) sendBatch(ctx context.Context, clientRequest clientRequest
 			ts.sendDuration,
 			instrument.ErrorCode,
 			func(ctx context.Context) error {
-				sp := spanlogger.FromContext(ctx)
+				sp := spanlogger.FromContext(ctx, ts.logger)
 				client, err := ts.ringClient.GetClientFor(clientRequest.ingesterAddr)
 				if err != nil {
 					return err

--- a/pkg/querier/http.go
+++ b/pkg/querier/http.go
@@ -370,7 +370,7 @@ func (q *QuerierAPI) DetectedFieldsHandler(ctx context.Context, req *logproto.De
 		return nil, err
 	}
 	if resp == nil { // Some stores don't implement this
-		level.Debug(spanlogger.FromContext(ctx)).Log(
+		level.Debug(spanlogger.FromContext(ctx, q.logger)).Log(
 			"msg", "queried store for detected fields that does not support it, no response from querier.DetectedFields",
 		)
 		return &logproto.DetectedFieldsResponse{
@@ -431,7 +431,7 @@ func WrapQuerySpanAndTimeout(call string, limits querier_limits.Limits) middlewa
 		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 			sp, ctx := opentracing.StartSpanFromContext(req.Context(), call)
 			defer sp.Finish()
-			log := spanlogger.FromContext(req.Context())
+			log := spanlogger.FromContext(req.Context(), utillog.Logger)
 			defer log.Finish()
 
 			tenants, err := tenant.TenantIDs(ctx)

--- a/pkg/querier/limits/validation.go
+++ b/pkg/querier/limits/validation.go
@@ -15,6 +15,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/logql"
 	"github.com/grafana/loki/v3/pkg/util/constants"
 	"github.com/grafana/loki/v3/pkg/util/httpreq"
+	util_log "github.com/grafana/loki/v3/pkg/util/log"
 	"github.com/grafana/loki/v3/pkg/util/spanlogger"
 	util_validation "github.com/grafana/loki/v3/pkg/util/validation"
 )
@@ -98,7 +99,7 @@ func ValidateQueryTimeRangeLimits(ctx context.Context, userID string, limits Tim
 		origStartTime := from
 		from = now.Add(-maxQueryLookback)
 
-		level.Debug(spanlogger.FromContext(ctx)).Log(
+		level.Debug(spanlogger.FromContext(ctx, util_log.Logger)).Log(
 			"msg", "the start time of the query has been manipulated because of the 'max query lookback' setting",
 			"original", origStartTime,
 			"updated", from)

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -168,7 +168,7 @@ func (q *SingleTenantQuerier) SelectLogs(ctx context.Context, params logql.Selec
 
 	params.QueryRequest.Deletes, err = deletion.DeletesForUserQuery(ctx, params.Start, params.End, q.deleteGetter)
 	if err != nil {
-		level.Error(spanlogger.FromContext(ctx)).Log("msg", "failed loading deletes for user", "err", err)
+		level.Error(spanlogger.FromContext(ctx, q.logger)).Log("msg", "failed loading deletes for user", "err", err)
 	}
 
 	ingesterQueryInterval, storeQueryInterval := q.buildQueryIntervals(params.Start, params.End)
@@ -230,7 +230,7 @@ func (q *SingleTenantQuerier) SelectSamples(ctx context.Context, params logql.Se
 
 	params.SampleQueryRequest.Deletes, err = deletion.DeletesForUserQuery(ctx, params.Start, params.End, q.deleteGetter)
 	if err != nil {
-		level.Error(spanlogger.FromContext(ctx)).Log("msg", "failed loading deletes for user", "err", err)
+		level.Error(spanlogger.FromContext(ctx, q.logger)).Log("msg", "failed loading deletes for user", "err", err)
 	}
 
 	ingesterQueryInterval, storeQueryInterval := q.buildQueryIntervals(params.Start, params.End)

--- a/pkg/querier/queryrange/limits.go
+++ b/pkg/querier/queryrange/limits.go
@@ -152,7 +152,7 @@ func NewLimitsMiddleware(l Limits) queryrangebase.Middleware {
 func (l limitsMiddleware) Do(ctx context.Context, r queryrangebase.Request) (queryrangebase.Response, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "limits")
 	defer span.Finish()
-	log := spanlogger.FromContext(ctx)
+	log := spanlogger.FromContext(ctx, util_log.Logger)
 	defer log.Finish()
 
 	tenantIDs, err := tenant.TenantIDs(ctx)
@@ -339,7 +339,7 @@ func (q *querySizeLimiter) guessLimitName() string {
 }
 
 func (q *querySizeLimiter) Do(ctx context.Context, r queryrangebase.Request) (queryrangebase.Response, error) {
-	log := spanlogger.FromContext(ctx)
+	log := spanlogger.FromContext(ctx, q.logger)
 
 	// Only support TSDB
 	schemaCfg, err := q.getSchemaCfg(r)

--- a/pkg/querier/queryrange/querysharding.go
+++ b/pkg/querier/queryrange/querysharding.go
@@ -152,7 +152,7 @@ func (ast *astMapperware) checkQuerySizeLimit(ctx context.Context, bytesPerShard
 
 func (ast *astMapperware) Do(ctx context.Context, r queryrangebase.Request) (queryrangebase.Response, error) {
 	logger := util_log.WithContext(ctx, ast.logger)
-	spLogger := spanlogger.FromContextWithFallback(
+	spLogger := spanlogger.FromContext(
 		ctx,
 		logger,
 	)

--- a/pkg/querier/queryrange/shard_resolver.go
+++ b/pkg/querier/queryrange/shard_resolver.go
@@ -185,7 +185,7 @@ func (r *dynamicShardResolver) GetStats(e syntax.Expr) (stats.Stats, error) {
 func (r *dynamicShardResolver) Shards(e syntax.Expr) (int, uint64, error) {
 	sp, ctx := opentracing.StartSpanFromContext(r.ctx, "dynamicShardResolver.Shards")
 	defer sp.Finish()
-	log := spanlogger.FromContext(ctx)
+	log := spanlogger.FromContext(ctx, r.logger)
 	defer log.Finish()
 
 	combined, err := r.GetStats(e)
@@ -223,7 +223,7 @@ func (r *dynamicShardResolver) ShardingRanges(expr syntax.Expr, targetBytesPerSh
 	[]logproto.ChunkRefGroup,
 	error,
 ) {
-	log := spanlogger.FromContext(r.ctx)
+	log := spanlogger.FromContext(r.ctx, r.logger)
 
 	var (
 		adjustedFrom    = r.from

--- a/pkg/querier/queryrange/stats.go
+++ b/pkg/querier/queryrange/stats.go
@@ -122,7 +122,7 @@ func statsHTTPMiddleware(recorder metricRecorder) middleware.Interface {
 func StatsCollectorMiddleware() queryrangebase.Middleware {
 	return queryrangebase.MiddlewareFunc(func(next queryrangebase.Handler) queryrangebase.Handler {
 		return queryrangebase.HandlerFunc(func(ctx context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
-			logger := spanlogger.FromContext(ctx)
+			logger := spanlogger.FromContext(ctx, util_log.Logger)
 			start := time.Now()
 
 			// start a new statistics context to be used by middleware, which we will merge with the response's statistics

--- a/pkg/querier/tail/querier.go
+++ b/pkg/querier/tail/querier.go
@@ -80,7 +80,7 @@ func (q *Querier) Tail(ctx context.Context, req *logproto.TailRequest, categoriz
 
 	deletes, err := deletion.DeletesForUserQuery(ctx, req.Start, time.Now(), q.deleteGetter)
 	if err != nil {
-		level.Error(spanlogger.FromContext(ctx)).Log("msg", "failed loading deletes for user", "err", err)
+		level.Error(spanlogger.FromContext(ctx, q.logger)).Log("msg", "failed loading deletes for user", "err", err)
 	}
 
 	histReq := logql.SelectLogParams{

--- a/pkg/ruler/evaluator_remote.go
+++ b/pkg/ruler/evaluator_remote.go
@@ -210,7 +210,7 @@ type Middleware func(ctx context.Context, req *httpgrpc.HTTPRequest) error
 
 // Query performs a query for the given time.
 func (r *RemoteEvaluator) Query(ctx context.Context, ch chan<- queryResponse, orgID, qs string, t time.Time) {
-	logger, ctx := spanlogger.NewWithLogger(ctx, r.logger, "ruler.remoteEvaluation.Query")
+	logger, ctx := spanlogger.New(ctx, r.logger, "ruler.remoteEvaluation.Query")
 	defer logger.Finish()
 
 	res, err := r.query(ctx, orgID, qs, t, logger)

--- a/pkg/storage/bloom/v1/fuse.go
+++ b/pkg/storage/bloom/v1/fuse.go
@@ -68,7 +68,7 @@ func (r *BloomRecorder) Merge(other *BloomRecorder) {
 }
 
 func (r *BloomRecorder) Report(logger log.Logger, metrics *Metrics) {
-	logger = spanlogger.FromContextWithFallback(r.ctx, logger)
+	logger = spanlogger.FromContext(r.ctx, logger)
 
 	var (
 		seriesFound     = r.seriesFound.Load()

--- a/pkg/storage/chunk/client/aws/dynamodb_storage_client.go
+++ b/pkg/storage/chunk/client/aws/dynamodb_storage_client.go
@@ -371,7 +371,7 @@ type chunksPlusError struct {
 
 // GetChunks implements chunk.Client.
 func (a dynamoDBStorageClient) GetChunks(ctx context.Context, chunks []chunk.Chunk) ([]chunk.Chunk, error) {
-	log, ctx := spanlogger.New(ctx, "GetChunks.DynamoDB", ot.Tag{Key: "numChunks", Value: len(chunks)})
+	log, ctx := spanlogger.New(ctx, log.Logger, "GetChunks.DynamoDB", ot.Tag{Key: "numChunks", Value: len(chunks)})
 	defer log.Finish()
 	level.Debug(log).Log("chunks requested", len(chunks))
 
@@ -420,7 +420,7 @@ var placeholder = []byte{'c'}
 // Structure is identical to BatchWrite(), but operating on different datatypes
 // so cannot share implementation.  If you fix a bug here fix it there too.
 func (a dynamoDBStorageClient) getDynamoDBChunks(ctx context.Context, chunks []chunk.Chunk) ([]chunk.Chunk, error) {
-	log, ctx := spanlogger.New(ctx, "getDynamoDBChunks", ot.Tag{Key: "numChunks", Value: len(chunks)})
+	log, ctx := spanlogger.New(ctx, log.Logger, "getDynamoDBChunks", ot.Tag{Key: "numChunks", Value: len(chunks)})
 	defer log.Finish()
 	outstanding := dynamoDBReadRequest{}
 	chunksByKey := map[string]chunk.Chunk{}

--- a/pkg/storage/chunk/client/gcp/bigtable_index_client.go
+++ b/pkg/storage/chunk/client/gcp/bigtable_index_client.go
@@ -19,6 +19,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/storage/chunk/client/util"
 	"github.com/grafana/loki/v3/pkg/storage/config"
 	"github.com/grafana/loki/v3/pkg/storage/stores/series/index"
+	util_log "github.com/grafana/loki/v3/pkg/util/log"
 	"github.com/grafana/loki/v3/pkg/util/spanlogger"
 )
 
@@ -332,7 +333,7 @@ func (s *storageClientV1) QueryPages(ctx context.Context, queries []index.Query,
 func (s *storageClientV1) query(ctx context.Context, query index.Query, callback index.QueryPagesCallback) error {
 	const null = string('\xff')
 
-	log, ctx := spanlogger.New(ctx, "QueryPages", ot.Tag{Key: "tableName", Value: query.TableName}, ot.Tag{Key: "hashValue", Value: query.HashValue})
+	log, ctx := spanlogger.New(ctx, util_log.Logger, "QueryPages", ot.Tag{Key: "tableName", Value: query.TableName}, ot.Tag{Key: "hashValue", Value: query.HashValue})
 	defer log.Finish()
 
 	table := s.client.Open(query.TableName)

--- a/pkg/storage/chunk/fetcher/fetcher.go
+++ b/pkg/storage/chunk/fetcher/fetcher.go
@@ -129,7 +129,7 @@ func (c *Fetcher) FetchChunks(ctx context.Context, chunks []chunk.Chunk) ([]chun
 	}
 	sp, ctx := opentracing.StartSpanFromContext(ctx, "ChunkStore.FetchChunks")
 	defer sp.Finish()
-	log := spanlogger.FromContext(ctx)
+	log := spanlogger.FromContext(ctx, util_log.Logger)
 	defer log.Finish()
 
 	// Extend the extendedHandoff to be 10% larger to allow for some overlap because this is a sliding window

--- a/pkg/storage/stores/series_store_write.go
+++ b/pkg/storage/stores/series_store_write.go
@@ -14,6 +14,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/storage/config"
 	"github.com/grafana/loki/v3/pkg/storage/stores/index"
 	"github.com/grafana/loki/v3/pkg/util/constants"
+	util_log "github.com/grafana/loki/v3/pkg/util/log"
 	"github.com/grafana/loki/v3/pkg/util/spanlogger"
 )
 
@@ -69,7 +70,7 @@ func (c *Writer) Put(ctx context.Context, chunks []chunk.Chunk) error {
 func (c *Writer) PutOne(ctx context.Context, from, through model.Time, chk chunk.Chunk) error {
 	sp, ctx := opentracing.StartSpanFromContext(ctx, "SeriesStore.PutOne")
 	defer sp.Finish()
-	log := spanlogger.FromContext(ctx)
+	log := spanlogger.FromContext(ctx, util_log.Logger)
 	defer log.Finish()
 
 	var (

--- a/pkg/storage/stores/shipper/bloomshipper/fetcher.go
+++ b/pkg/storage/stores/shipper/bloomshipper/fetcher.go
@@ -128,7 +128,7 @@ func (f *Fetcher) Close() {
 
 // FetchMetas implements fetcher
 func (f *Fetcher) FetchMetas(ctx context.Context, refs []MetaRef) ([]Meta, error) {
-	logger := spanlogger.FromContextWithFallback(ctx, f.logger)
+	logger := spanlogger.FromContext(ctx, f.logger)
 
 	if ctx.Err() != nil {
 		return nil, errors.Wrap(ctx.Err(), "fetch Metas")

--- a/pkg/storage/stores/shipper/bloomshipper/store.go
+++ b/pkg/storage/stores/shipper/bloomshipper/store.go
@@ -21,6 +21,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/storage/chunk/client/util"
 	"github.com/grafana/loki/v3/pkg/storage/config"
 	"github.com/grafana/loki/v3/pkg/util/constants"
+	util_log "github.com/grafana/loki/v3/pkg/util/log"
 	"github.com/grafana/loki/v3/pkg/util/mempool"
 	"github.com/grafana/loki/v3/pkg/util/spanlogger"
 )
@@ -139,7 +140,7 @@ func FilterMetasOverlappingBounds(metas []Meta, bounds v1.FingerprintBounds) []M
 
 // FetchMetas implements store.
 func (b *bloomStoreEntry) FetchMetas(ctx context.Context, params MetaSearchParams) ([]Meta, error) {
-	logger := spanlogger.FromContext(ctx)
+	logger := spanlogger.FromContext(ctx, util_log.Logger)
 
 	resolverStart := time.Now()
 	metaRefs, fetchers, err := b.ResolveMetas(ctx, params)

--- a/pkg/storage/stores/shipper/indexshipper/downloads/index_set.go
+++ b/pkg/storage/stores/shipper/indexshipper/downloads/index_set.go
@@ -183,7 +183,7 @@ func (t *indexSet) ForEach(ctx context.Context, callback index.ForEachIndexCallb
 	}
 	defer t.indexMtx.rUnlock()
 
-	logger := spanlogger.FromContextWithFallback(ctx, t.logger)
+	logger := spanlogger.FromContext(ctx, t.logger)
 	level.Debug(logger).Log("index-files-count", len(t.index))
 
 	for _, idx := range t.index {
@@ -202,7 +202,7 @@ func (t *indexSet) ForEachConcurrent(ctx context.Context, callback index.ForEach
 	}
 	defer t.indexMtx.rUnlock()
 
-	logger := spanlogger.FromContextWithFallback(ctx, t.logger)
+	logger := spanlogger.FromContext(ctx, t.logger)
 	level.Debug(logger).Log("index-files-count", len(t.index))
 
 	if len(t.index) == 0 {

--- a/pkg/storage/stores/shipper/indexshipper/downloads/table.go
+++ b/pkg/storage/stores/shipper/indexshipper/downloads/table.go
@@ -303,7 +303,7 @@ func (t *table) Sync(ctx context.Context) error {
 // forQuerying must be set to true only getting the index for querying since
 // it captures the amount of time it takes to download the index at query time.
 func (t *table) getOrCreateIndexSet(ctx context.Context, id string, forQuerying bool) (IndexSet, error) {
-	logger := spanlogger.FromContextWithFallback(ctx, loggerWithUserID(t.logger, id))
+	logger := spanlogger.FromContext(ctx, loggerWithUserID(t.logger, id))
 
 	t.indexSetsMtx.RLock()
 	indexSet, ok := t.indexSets[id]

--- a/pkg/util/spanlogger/spanlogger.go
+++ b/pkg/util/spanlogger/spanlogger.go
@@ -4,10 +4,8 @@ import (
 	"context"
 
 	"github.com/go-kit/log"
-	"github.com/grafana/dskit/spanlogger"
+	"github.com/grafana/dskit/spanlogger" //lint:ignore faillint // This package is the wrapper that should be used.
 	"github.com/grafana/dskit/tenant"
-
-	util_log "github.com/grafana/loki/v3/pkg/util/log"
 )
 
 const (
@@ -34,27 +32,14 @@ type SpanLogger = spanlogger.SpanLogger
 
 // New makes a new SpanLogger with a log.Logger to send logs to. The provided context will have the logger attached
 // to it and can be retrieved with FromContext.
-func New(ctx context.Context, method string, kvps ...interface{}) (*SpanLogger, context.Context) {
-	return spanlogger.New(ctx, util_log.Logger, method, resolver, kvps...)
-}
-
-// NewWithLogger is like New but allows to pass a logger.
-func NewWithLogger(ctx context.Context, logger log.Logger, method string, kvps ...interface{}) (*SpanLogger, context.Context) {
+func New(ctx context.Context, logger log.Logger, method string, kvps ...interface{}) (*SpanLogger, context.Context) {
 	return spanlogger.New(ctx, logger, method, resolver, kvps...)
 }
 
-// FromContext returns a SpanLogger using the current parent span.
+// FromContext returns a span logger using the current parent span.
 // If there is no parent span, the SpanLogger will only log to the logger
-// within the context. If the context doesn't have a logger, the global
-// logger is used.
-func FromContext(ctx context.Context) *SpanLogger {
-	return spanlogger.FromContext(ctx, util_log.Logger, resolver)
-}
-
-// FromContextWithFallback returns a span logger using the current parent span.
-// IF there is no parent span, the SpanLogger will only log to the logger
 // within the context. If the context doesn't have a logger, the fallback
 // logger is used.
-func FromContextWithFallback(ctx context.Context, fallback log.Logger) *SpanLogger {
+func FromContext(ctx context.Context, fallback log.Logger) *SpanLogger {
 	return spanlogger.FromContext(ctx, fallback, resolver)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

**This is mostly a noop in terms of logic**, except that in some cases logging now will have the correct component's KVs instead of just using a global one.

This tidies the usages of spanlogger package forcing everyone to provide a logger: if they don't have one, they should explicitly use the global logger instead.

Most of the callers already had their own logger anyway, and for the callers that didn't have one now it's more obvious that they aren't logging with their component's context.

Also added a faillint check to ensure all packages use the util/spanlogger instead of dskit/spanlogger, to make sure nobody uses OpenTracing version anymore once we migrate util/spanlogger to OTel.

**Which issue(s) this PR fixes**:

Ref: https://github.com/grafana/loki/issues/6812

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
