### PR TITLE
chore(otlp): Fix OTLP exporter metric 

### DIFF
--- a/pkg/loghttp/push/otlp.go
+++ b/pkg/loghttp/push/otlp.go
@@ -112,9 +112,6 @@ func otlpToLokiPushRequest(ctx context.Context, ld plog.Logs, userID string, otl
 	rls := ld.ResourceLogs()
 	pushRequestsByStream := make(map[string]logproto.Stream, rls.Len())
 
-	// Track if request used the Loki OTLP exporter label
-	var usingLokiExporter bool
-
 	for i := 0; i < rls.Len(); i++ {
 		sls := rls.At(i).ScopeLogs()
 		res := rls.At(i).Resource()
@@ -208,12 +205,6 @@ func otlpToLokiPushRequest(ctx context.Context, ld plog.Logs, userID string, otl
 		resourceAttributesAsStructuredMetadataSize := loki_util.StructuredMetadataSize(resourceAttributesAsStructuredMetadata)
 		retentionPeriodForUser := streamResolver.RetentionPeriodFor(lbs)
 		policy := streamResolver.PolicyFor(lbs)
-
-		// Check if the stream has the exporter=OTLP label; set flag instead of incrementing per stream
-		if value, ok := streamLabels[model.LabelName("exporter")]; ok && value == "OTLP" {
-			usingLokiExporter = true
-		}
-
 		if _, ok := stats.StructuredMetadataBytes[policy]; !ok {
 			stats.StructuredMetadataBytes[policy] = make(map[time.Duration]int64)
 		}
@@ -375,11 +366,6 @@ func otlpToLokiPushRequest(ctx context.Context, ld plog.Logs, userID string, otl
 		if len(stream.Entries) > 0 || len(stream.Labels) > 0 {
 			pr.Streams = append(pr.Streams, stream)
 		}
-	}
-
-	// Increment exporter streams metric once per request if seen
-	if usingLokiExporter {
-		otlpExporterStreams.WithLabelValues(userID).Inc()
 	}
 
 	return pr

--- a/pkg/loghttp/push/push.go
+++ b/pkg/loghttp/push/push.go
@@ -328,6 +328,11 @@ func ParseLokiRequest(userID string, r *http.Request, limits Limits, maxRecvMsgS
 			return nil, nil, fmt.Errorf("couldn't parse labels: %w", err)
 		}
 
+		// Increment OTLP exporter streams metric if exporter=OTLP label is present
+		if lbs.Has("exporter") && lbs.Get("exporter") == "OTLP" {
+			otlpExporterStreams.WithLabelValues(userID).Inc()
+		}
+
 		if lbs.Has(constants.AggregatedMetricLabel) {
 			pushStats.IsAggregatedMetric = true
 		}


### PR DESCRIPTION
The previous PR added this metric to OTLP endpoint which is incorrect. Loki exporter uses the normal push endpoint which is where the metric should be incremented.