### PR TITLE
chore: use exported methods to differentiate internal methods

### DIFF
--- a/pkg/limits/consumer.go
+++ b/pkg/limits/consumer.go
@@ -94,7 +94,7 @@ func newConsumer(
 	}
 }
 
-func (c *consumer) run(ctx context.Context) {
+func (c *consumer) Run(ctx context.Context) {
 	b := backoff.New(ctx, backoff.Config{
 		MinBackoff: 100 * time.Millisecond,
 		MaxBackoff: time.Second,
@@ -140,7 +140,7 @@ func (c *consumer) processFetchTopicPartition(ctx context.Context) func(kgo.Fetc
 		// We need the state of the partition so we can discard any records
 		// that we produced (unless replaying) and mark a replaying partition
 		// as ready once it has finished replaying.
-		state, ok := c.partitionManager.getState(p.Partition)
+		state, ok := c.partitionManager.GetState(p.Partition)
 		if !ok {
 			c.recordsDiscarded.Add(float64(len(p.Records)))
 			level.Warn(logger).Log("msg", "discarding records for partition as the partition is not assigned to this client")
@@ -160,7 +160,7 @@ func (c *consumer) processFetchTopicPartition(ctx context.Context) func(kgo.Fetc
 				level.Error(logger).Log("msg", "failed to run readiness check", "err", err.Error())
 			} else if passed {
 				level.Debug(logger).Log("msg", "passed readiness check, partition is ready")
-				c.partitionManager.setReady(p.Partition)
+				c.partitionManager.SetReady(p.Partition)
 			}
 		}
 	}
@@ -177,7 +177,7 @@ func (c *consumer) processRecord(_ context.Context, state partitionState, r *kgo
 		c.recordsDiscarded.Inc()
 		return nil
 	}
-	c.usage.update(s.Tenant, []*proto.StreamMetadata{s.Metadata}, r.Timestamp, nil)
+	c.usage.Update(s.Tenant, []*proto.StreamMetadata{s.Metadata}, r.Timestamp, nil)
 	return nil
 }
 
@@ -185,8 +185,8 @@ type partitionReadinessCheck func(partition int32, r *kgo.Record) (bool, error)
 
 // newOffsetReadinessCheck marks a partition as ready if the target offset
 // has been reached.
-func newOffsetReadinessCheck(partitionManager *partitionManager) partitionReadinessCheck {
+func newOffsetReadinessCheck(m *partitionManager) partitionReadinessCheck {
 	return func(partition int32, r *kgo.Record) (bool, error) {
-		return partitionManager.targetOffsetReached(partition, r.Offset), nil
+		return m.TargetOffsetReached(partition, r.Offset), nil
 	}
 }

--- a/pkg/limits/consumer_test.go
+++ b/pkg/limits/consumer_test.go
@@ -43,8 +43,8 @@ func TestConsumer_ProcessRecords(t *testing.T) {
 		ctx := context.Background()
 		// Need to assign the partition and set it to ready.
 		m := newPartitionManager()
-		m.assign(ctx, []int32{1})
-		m.setReplaying(1, 1000)
+		m.Assign(ctx, []int32{1})
+		m.SetReplaying(1, 1000)
 		// Create a usage store, we will use this to check if the record
 		// was stored.
 		u := newUsageStore(DefaultActiveWindow, DefaultRateWindow, DefaultBucketSize, 1)
@@ -53,7 +53,7 @@ func TestConsumer_ProcessRecords(t *testing.T) {
 		require.NoError(t, c.pollFetches(ctx))
 		// Check that the record was stored.
 		var n int
-		u.all(func(_ string, _ int32, _ streamUsage) { n++ })
+		u.All(func(_ string, _ int32, _ streamUsage) { n++ })
 		require.Equal(t, 1, n)
 	})
 
@@ -87,8 +87,8 @@ func TestConsumer_ProcessRecords(t *testing.T) {
 		ctx := context.Background()
 		// Need to assign the partition and set it to ready.
 		m := newPartitionManager()
-		m.assign(ctx, []int32{1})
-		m.setReady(1)
+		m.Assign(ctx, []int32{1})
+		m.SetReady(1)
 		// Create a usage store, we will use this to check if the record
 		// was discarded.
 		u := newUsageStore(DefaultActiveWindow, DefaultRateWindow, DefaultBucketSize, 1)
@@ -97,7 +97,7 @@ func TestConsumer_ProcessRecords(t *testing.T) {
 		require.NoError(t, c.pollFetches(ctx))
 		// Check that the record was discarded.
 		var n int
-		u.all(func(_ string, _ int32, _ streamUsage) { n++ })
+		u.All(func(_ string, _ int32, _ streamUsage) { n++ })
 		require.Equal(t, 0, n)
 	})
 }
@@ -158,10 +158,10 @@ func TestConsumer_ReadinessCheck(t *testing.T) {
 	ctx := context.Background()
 	// Need to assign the partition and set it to replaying.
 	m := newPartitionManager()
-	m.assign(ctx, []int32{1})
+	m.Assign(ctx, []int32{1})
 	// The partition should be marked ready when the second record
 	// has been consumed.
-	m.setReplaying(1, 2)
+	m.SetReplaying(1, 2)
 	// We don't need the usage store for this test.
 	u := newUsageStore(DefaultActiveWindow, DefaultRateWindow, DefaultBucketSize, 1)
 	c := newConsumer(&k, m, u, newOffsetReadinessCheck(m), "zone1",
@@ -170,22 +170,22 @@ func TestConsumer_ReadinessCheck(t *testing.T) {
 	require.NoError(t, c.pollFetches(ctx))
 	// The partition should still be replaying as we have not read up to
 	// the target offset.
-	state, ok := m.getState(1)
+	state, ok := m.GetState(1)
 	require.True(t, ok)
 	require.Equal(t, partitionReplaying, state)
 	// Check that the record was stored.
 	var n int
-	u.all(func(_ string, _ int32, _ streamUsage) { n++ })
+	u.All(func(_ string, _ int32, _ streamUsage) { n++ })
 	require.Equal(t, 1, n)
 	// The second poll should fetch the second (and last) record.
 	require.NoError(t, c.pollFetches(ctx))
 	// The partition should still be ready as we have read up to the target
 	// offset.
-	state, ok = m.getState(1)
+	state, ok = m.GetState(1)
 	require.True(t, ok)
 	require.Equal(t, partitionReady, state)
 	// Check that the record was stored.
 	n = 0
-	u.all(func(_ string, _ int32, _ streamUsage) { n++ })
+	u.All(func(_ string, _ int32, _ streamUsage) { n++ })
 	require.Equal(t, 2, n)
 }

--- a/pkg/limits/frontend/cache.go
+++ b/pkg/limits/frontend/cache.go
@@ -10,14 +10,14 @@ import (
 type cache[K comparable, V any] interface {
 	// get returns the value for the key. It returns true if the key exists,
 	// otherwise false.
-	get(K) (V, bool)
+	Get(K) (V, bool)
 	// set stores the value for the key.
-	set(K, V)
+	Set(K, V)
 	// delete removes the key. If the key does not exist, the operation is a
 	// no-op.
-	delete(K)
+	Delete(K)
 	// reset removes all keys.
-	reset()
+	Reset()
 }
 
 // item contains the value and expiration time for a key.
@@ -50,7 +50,7 @@ func newTTLCache[K comparable, V any](ttl time.Duration) *ttlcache[K, V] {
 }
 
 // Get implements the [cache] interface.
-func (c *ttlcache[K, V]) get(key K) (V, bool) {
+func (c *ttlcache[K, V]) Get(key K) (V, bool) {
 	var (
 		value  V
 		exists bool
@@ -66,7 +66,7 @@ func (c *ttlcache[K, V]) get(key K) (V, bool) {
 }
 
 // Set implements the [cache] interface.
-func (c *ttlcache[K, V]) set(key K, value V) {
+func (c *ttlcache[K, V]) Set(key K, value V) {
 	now := c.clock.Now()
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -81,14 +81,14 @@ func (c *ttlcache[K, V]) set(key K, value V) {
 }
 
 // Delete implements the [cache] interface.
-func (c *ttlcache[K, V]) delete(key K) {
+func (c *ttlcache[K, V]) Delete(key K) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	delete(c.items, key)
 }
 
 // Reset implements the [cache] interface.
-func (c *ttlcache[K, V]) reset() {
+func (c *ttlcache[K, V]) Reset() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.items = make(map[K]item[V])
@@ -110,10 +110,10 @@ type nopcache[K comparable, V any] struct{}
 func newNopCache[K comparable, V any]() *nopcache[K, V] {
 	return &nopcache[K, V]{}
 }
-func (c *nopcache[K, V]) get(_ K) (V, bool) {
+func (c *nopcache[K, V]) Get(_ K) (V, bool) {
 	var value V
 	return value, false
 }
-func (c *nopcache[K, V]) set(_ K, _ V) {}
-func (c *nopcache[K, V]) delete(_ K)   {}
-func (c *nopcache[K, V]) reset()       {}
+func (c *nopcache[K, V]) Set(_ K, _ V) {}
+func (c *nopcache[K, V]) Delete(_ K)   {}
+func (c *nopcache[K, V]) Reset()       {}

--- a/pkg/limits/frontend/frontend.go
+++ b/pkg/limits/frontend/frontend.go
@@ -89,7 +89,7 @@ func New(cfg Config, ringName string, limitsRing ring.ReadRing, logger log.Logge
 
 // ExceedsLimits implements proto.IngestLimitsFrontendClient.
 func (f *Frontend) ExceedsLimits(ctx context.Context, req *proto.ExceedsLimitsRequest) (*proto.ExceedsLimitsResponse, error) {
-	resps, err := f.gatherer.exceedsLimits(ctx, req)
+	resps, err := f.gatherer.ExceedsLimits(ctx, req)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/limits/frontend/gather.go
+++ b/pkg/limits/frontend/gather.go
@@ -7,8 +7,8 @@ import (
 )
 
 type exceedsLimitsGatherer interface {
-	// exceedsLimits checks if the streams in the request have exceeded their
+	// ExceedsLimits checks if the streams in the request have exceeded their
 	// per-partition limits. It returns more than one response when the
 	// requested streams are sharded over two or more limits instances.
-	exceedsLimits(context.Context, *proto.ExceedsLimitsRequest) ([]*proto.ExceedsLimitsResponse, error)
+	ExceedsLimits(context.Context, *proto.ExceedsLimitsRequest) ([]*proto.ExceedsLimitsResponse, error)
 }

--- a/pkg/limits/frontend/mock_test.go
+++ b/pkg/limits/frontend/mock_test.go
@@ -26,7 +26,7 @@ type mockExceedsLimitsGatherer struct {
 	exceedsLimitsResponses       []*proto.ExceedsLimitsResponse
 }
 
-func (g *mockExceedsLimitsGatherer) exceedsLimits(_ context.Context, req *proto.ExceedsLimitsRequest) ([]*proto.ExceedsLimitsResponse, error) {
+func (g *mockExceedsLimitsGatherer) ExceedsLimits(_ context.Context, req *proto.ExceedsLimitsRequest) ([]*proto.ExceedsLimitsResponse, error) {
 	if expected := g.expectedExceedsLimitsRequest; expected != nil {
 		require.Equal(g.t, expected, req)
 	}

--- a/pkg/limits/frontend/ring.go
+++ b/pkg/limits/frontend/ring.go
@@ -57,8 +57,8 @@ func newRingGatherer(
 	}
 }
 
-// exceedsLimits implements the [exceedsLimitsGatherer] interface.
-func (g *ringGatherer) exceedsLimits(ctx context.Context, req *proto.ExceedsLimitsRequest) ([]*proto.ExceedsLimitsResponse, error) {
+// ExceedsLimits implements the [exceedsLimitsGatherer] interface.
+func (g *ringGatherer) ExceedsLimits(ctx context.Context, req *proto.ExceedsLimitsRequest) ([]*proto.ExceedsLimitsResponse, error) {
 	if len(req.Streams) == 0 {
 		return nil, nil
 	}
@@ -244,7 +244,7 @@ func (g *ringGatherer) getPartitionConsumers(ctx context.Context, instances []ri
 			// We use a cache to eliminate redundant gRPC requests for
 			// GetAssignedPartitions as the set of assigned partitions is
 			// expected to be stable outside consumer rebalances.
-			if resp, ok := g.assignedPartitionsCache.get(instance.Addr); ok {
+			if resp, ok := g.assignedPartitionsCache.Get(instance.Addr); ok {
 				responseCh <- getAssignedPartitionsResponse{
 					addr:     instance.Addr,
 					response: resp,
@@ -261,7 +261,7 @@ func (g *ringGatherer) getPartitionConsumers(ctx context.Context, instances []ri
 				level.Error(g.logger).Log("failed to get assigned partitions for instance", "instance", instance.Addr, "err", err.Error())
 				return nil
 			}
-			g.assignedPartitionsCache.set(instance.Addr, resp)
+			g.assignedPartitionsCache.Set(instance.Addr, resp)
 			responseCh <- getAssignedPartitionsResponse{
 				addr:     instance.Addr,
 				response: resp,

--- a/pkg/limits/frontend/ring_test.go
+++ b/pkg/limits/frontend/ring_test.go
@@ -424,7 +424,7 @@ func TestRingGatherer_ExceedsLimits(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 			defer cancel()
 
-			actual, err := g.exceedsLimits(ctx, test.request)
+			actual, err := g.ExceedsLimits(ctx, test.request)
 			if test.expectedErr != "" {
 				require.EqualError(t, err, test.expectedErr)
 				require.Nil(t, actual)
@@ -799,7 +799,7 @@ func TestRingStreamUsageGatherer_GetPartitionConsumers_Caching(t *testing.T) {
 	require.Equal(t, 1, client1.numAssignedPartitionsRequests)
 
 	// Expire the cache, it should be a cache miss.
-	cache.reset()
+	cache.Reset()
 
 	// The third call should be a cache miss.
 	actual, err = g.getPartitionConsumers(ctx, instances)

--- a/pkg/limits/http.go
+++ b/pkg/limits/http.go
@@ -38,7 +38,7 @@ func (s *Service) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		response      httpTenantLimitsResponse
 	)
 
-	s.usage.forTenant(tenant, func(_ string, _ int32, stream streamUsage) {
+	s.usage.ForTenant(tenant, func(_ string, _ int32, stream streamUsage) {
 		if stream.lastSeenAt >= cutoff {
 			activeStreams++
 

--- a/pkg/limits/partition_lifecycler.go
+++ b/pkg/limits/partition_lifecycler.go
@@ -44,11 +44,11 @@ func newPartitionLifecycler(
 }
 
 // Assign implements kgo.OnPartitionsAssigned.
-func (l *partitionLifecycler) assign(ctx context.Context, _ *kgo.Client, topics map[string][]int32) {
+func (l *partitionLifecycler) Assign(ctx context.Context, _ *kgo.Client, topics map[string][]int32) {
 	// We expect the client to just consume one topic.
 	// TODO(grobinson): Figure out what to do if this is not the case.
 	for _, partitions := range topics {
-		l.partitionManager.assign(ctx, partitions)
+		l.partitionManager.Assign(ctx, partitions)
 		for _, partition := range partitions {
 			if err := l.determineStateFromOffsets(ctx, partition); err != nil {
 				level.Error(l.logger).Log(
@@ -56,7 +56,7 @@ func (l *partitionLifecycler) assign(ctx context.Context, _ *kgo.Client, topics 
 					"partition", partition,
 					"err", err,
 				)
-				l.partitionManager.setReady(partition)
+				l.partitionManager.SetReady(partition)
 			}
 		}
 		return
@@ -64,12 +64,12 @@ func (l *partitionLifecycler) assign(ctx context.Context, _ *kgo.Client, topics 
 }
 
 // Revoke implements kgo.OnPartitionsRevoked.
-func (l *partitionLifecycler) revoke(ctx context.Context, _ *kgo.Client, topics map[string][]int32) {
+func (l *partitionLifecycler) Revoke(ctx context.Context, _ *kgo.Client, topics map[string][]int32) {
 	// We expect the client to just consume one topic.
 	// TODO(grobinson): Figure out what to do if this is not the case.
 	for _, partitions := range topics {
-		l.partitionManager.revoke(ctx, partitions)
-		l.usage.evictPartitions(partitions)
+		l.partitionManager.Revoke(ctx, partitions)
+		l.usage.EvictPartitions(partitions)
 		return
 	}
 }
@@ -110,18 +110,18 @@ func (l *partitionLifecycler) determineStateFromOffsets(ctx context.Context, par
 		// partition has never produced a record, or all records that have
 		// been produced have been deleted due to the retention period.
 		level.Debug(logger).Log("msg", "no records in partition, partition is ready")
-		l.partitionManager.setReady(partition)
+		l.partitionManager.SetReady(partition)
 		return nil
 	}
 	if nextOffset == lastProducedOffset {
 		level.Debug(logger).Log("msg", "no records within window size, partition is ready")
-		l.partitionManager.setReady(partition)
+		l.partitionManager.SetReady(partition)
 		return nil
 	}
 	// Since we want to fetch all records up to and including the last
 	// produced record, we must fetch all records up to and including the
 	// last produced offset - 1.
 	level.Debug(logger).Log("msg", "partition is replaying")
-	l.partitionManager.setReplaying(partition, lastProducedOffset-1)
+	l.partitionManager.SetReplaying(partition, lastProducedOffset-1)
 	return nil
 }

--- a/pkg/limits/partition_manager.go
+++ b/pkg/limits/partition_manager.go
@@ -54,8 +54,8 @@ func newPartitionManager() *partitionManager {
 	}
 }
 
-// assign assigns the partitions.
-func (m *partitionManager) assign(_ context.Context, partitions []int32) {
+// Assign assigns the partitions.
+func (m *partitionManager) Assign(_ context.Context, partitions []int32) {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
 	for _, partition := range partitions {
@@ -66,18 +66,18 @@ func (m *partitionManager) assign(_ context.Context, partitions []int32) {
 	}
 }
 
-// getState returns the current state of the partition. It returns false
+// GetState returns the current state of the partition. It returns false
 // if the partition does not exist.
-func (m *partitionManager) getState(partition int32) (partitionState, bool) {
+func (m *partitionManager) GetState(partition int32) (partitionState, bool) {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
 	entry, ok := m.partitions[partition]
 	return entry.state, ok
 }
 
-// targetOffsetReached returns true if the partition is replaying and the
+// TargetOffsetReached returns true if the partition is replaying and the
 // target offset has been reached.
-func (m *partitionManager) targetOffsetReached(partition int32, offset int64) bool {
+func (m *partitionManager) TargetOffsetReached(partition int32, offset int64) bool {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
 	entry, ok := m.partitions[partition]
@@ -87,17 +87,17 @@ func (m *partitionManager) targetOffsetReached(partition int32, offset int64) bo
 	return false
 }
 
-// has returns true if the partition is assigned, otherwise false.
-func (m *partitionManager) has(partition int32) bool {
+// Has returns true if the partition is assigned, otherwise false.
+func (m *partitionManager) Has(partition int32) bool {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
 	_, ok := m.partitions[partition]
 	return ok
 }
 
-// list returns a map of all assigned partitions and the timestamp of when
+// List returns a map of all assigned partitions and the timestamp of when
 // each partition was assigned.
-func (m *partitionManager) list() map[int32]int64 {
+func (m *partitionManager) List() map[int32]int64 {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
 	result := make(map[int32]int64)
@@ -107,9 +107,9 @@ func (m *partitionManager) list() map[int32]int64 {
 	return result
 }
 
-// listByState returns all partitions with the specified state and their last
+// ListByState returns all partitions with the specified state and their last
 // updated timestamps.
-func (m *partitionManager) listByState(state partitionState) map[int32]int64 {
+func (m *partitionManager) ListByState(state partitionState) map[int32]int64 {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
 	result := make(map[int32]int64)
@@ -121,10 +121,10 @@ func (m *partitionManager) listByState(state partitionState) map[int32]int64 {
 	return result
 }
 
-// setReplaying sets the partition as replaying and the offset that must
+// SetReplaying sets the partition as replaying and the offset that must
 // be consumed for it to become ready. It returns false if the partition
 // does not exist.
-func (m *partitionManager) setReplaying(partition int32, offset int64) bool {
+func (m *partitionManager) SetReplaying(partition int32, offset int64) bool {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
 	entry, ok := m.partitions[partition]
@@ -136,9 +136,9 @@ func (m *partitionManager) setReplaying(partition int32, offset int64) bool {
 	return ok
 }
 
-// setReady sets the partition as ready. It returns false if the partition
+// SetReady sets the partition as ready. It returns false if the partition
 // does not exist.
-func (m *partitionManager) setReady(partition int32) bool {
+func (m *partitionManager) SetReady(partition int32) bool {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
 	entry, ok := m.partitions[partition]
@@ -150,8 +150,8 @@ func (m *partitionManager) setReady(partition int32) bool {
 	return ok
 }
 
-// revoke deletes the partitions.
-func (m *partitionManager) revoke(_ context.Context, partitions []int32) {
+// Revoke deletes the partitions.
+func (m *partitionManager) Revoke(_ context.Context, partitions []int32) {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
 	for _, partition := range partitions {

--- a/pkg/limits/partition_manager_test.go
+++ b/pkg/limits/partition_manager_test.go
@@ -16,7 +16,7 @@ func TestPartitionManager_Assign(t *testing.T) {
 	// Advance the clock so we compare with a time that is not the default
 	// value.
 	c.Advance(1)
-	m.assign(context.Background(), []int32{1, 2, 3})
+	m.Assign(context.Background(), []int32{1, 2, 3})
 	// Assert that the partitions were assigned and the timestamps are set to
 	// the current time.
 	now := c.Now().UnixNano()
@@ -38,7 +38,7 @@ func TestPartitionManager_Assign(t *testing.T) {
 	// partition #4. We expect the updated timestamp is equal to the advanced
 	// time.
 	c.Advance(1)
-	m.assign(context.Background(), []int32{3, 4})
+	m.Assign(context.Background(), []int32{3, 4})
 	later := c.Now().UnixNano()
 	require.Equal(t, map[int32]partitionEntry{
 		1: {
@@ -64,13 +64,13 @@ func TestPartitionManager_GetState(t *testing.T) {
 	m := newPartitionManager()
 	c := quartz.NewMock(t)
 	m.clock = c
-	m.assign(context.Background(), []int32{1, 2, 3})
+	m.Assign(context.Background(), []int32{1, 2, 3})
 	// Getting the state for an assigned partition should return true.
-	state, ok := m.getState(1)
+	state, ok := m.GetState(1)
 	require.True(t, ok)
 	require.Equal(t, partitionPending, state)
 	// Getting the state for an unknown partition should return false.
-	_, ok = m.getState(4)
+	_, ok = m.GetState(4)
 	require.False(t, ok)
 }
 
@@ -78,29 +78,29 @@ func TestPartitionManager_TargetOffsetReached(t *testing.T) {
 	m := newPartitionManager()
 	c := quartz.NewMock(t)
 	m.clock = c
-	m.assign(context.Background(), []int32{1})
+	m.Assign(context.Background(), []int32{1})
 	// Target offset cannot be reached for pending partition.
-	require.False(t, m.targetOffsetReached(1, 0))
+	require.False(t, m.TargetOffsetReached(1, 0))
 	// Target offset has not been reached.
-	require.True(t, m.setReplaying(1, 10))
-	require.False(t, m.targetOffsetReached(1, 9))
+	require.True(t, m.SetReplaying(1, 10))
+	require.False(t, m.TargetOffsetReached(1, 9))
 	// Target offset has been reached.
-	require.True(t, m.setReplaying(1, 10))
-	require.True(t, m.targetOffsetReached(1, 10))
+	require.True(t, m.SetReplaying(1, 10))
+	require.True(t, m.TargetOffsetReached(1, 10))
 	// Target offset cannot be reached for ready partition.
-	require.True(t, m.setReady(1))
-	require.False(t, m.targetOffsetReached(1, 10))
+	require.True(t, m.SetReady(1))
+	require.False(t, m.TargetOffsetReached(1, 10))
 }
 
 func TestPartitionManager_Has(t *testing.T) {
 	m := newPartitionManager()
 	c := quartz.NewMock(t)
 	m.clock = c
-	m.assign(context.Background(), []int32{1, 2, 3})
-	require.True(t, m.has(1))
-	require.True(t, m.has(2))
-	require.True(t, m.has(3))
-	require.False(t, m.has(4))
+	m.Assign(context.Background(), []int32{1, 2, 3})
+	require.True(t, m.Has(1))
+	require.True(t, m.Has(2))
+	require.True(t, m.Has(3))
+	require.False(t, m.Has(4))
 }
 
 func TestPartitionManager_List(t *testing.T) {
@@ -110,9 +110,9 @@ func TestPartitionManager_List(t *testing.T) {
 	// Advance the clock so we compare with a time that is not the default
 	// value.
 	c.Advance(1)
-	m.assign(context.Background(), []int32{1, 2, 3})
+	m.Assign(context.Background(), []int32{1, 2, 3})
 	now := c.Now().UnixNano()
-	result := m.list()
+	result := m.List()
 	require.Equal(t, map[int32]int64{
 		1: now,
 		2: now,
@@ -132,9 +132,9 @@ func TestPartitionManager_ListByState(t *testing.T) {
 	// Advance the clock so we compare with a time that is not the default
 	// value.
 	c.Advance(1)
-	m.assign(context.Background(), []int32{1, 2, 3})
+	m.Assign(context.Background(), []int32{1, 2, 3})
 	now := c.Now().UnixNano()
-	result := m.listByState(partitionPending)
+	result := m.ListByState(partitionPending)
 	require.Equal(t, map[int32]int64{
 		1: now,
 		2: now,
@@ -146,11 +146,11 @@ func TestPartitionManager_ListByState(t *testing.T) {
 	p2 := reflect.ValueOf(m.partitions).Pointer()
 	require.NotEqual(t, p1, p2)
 	// Get all ready partitions.
-	result = m.listByState(partitionReady)
+	result = m.ListByState(partitionReady)
 	require.Empty(t, result)
 	// Mark a partition as ready and then repeat the test.
-	require.True(t, m.setReady(1))
-	result = m.listByState(partitionReady)
+	require.True(t, m.SetReady(1))
+	result = m.ListByState(partitionReady)
 	require.Equal(t, map[int32]int64{1: now}, result)
 }
 
@@ -158,35 +158,35 @@ func TestPartitionManager_SetReplaying(t *testing.T) {
 	m := newPartitionManager()
 	c := quartz.NewMock(t)
 	m.clock = c
-	m.assign(context.Background(), []int32{1, 2, 3})
+	m.Assign(context.Background(), []int32{1, 2, 3})
 	// Setting an assigned partition to replaying should return true.
-	require.True(t, m.setReplaying(1, 10))
-	state, ok := m.getState(1)
+	require.True(t, m.SetReplaying(1, 10))
+	state, ok := m.GetState(1)
 	require.True(t, ok)
 	require.Equal(t, partitionReplaying, state)
 	// Setting an unknown partition to replaying should return false.
-	require.False(t, m.setReplaying(4, 10))
+	require.False(t, m.SetReplaying(4, 10))
 }
 
 func TestPartitionManager_SetReady(t *testing.T) {
 	m := newPartitionManager()
 	c := quartz.NewMock(t)
 	m.clock = c
-	m.assign(context.Background(), []int32{1, 2, 3})
+	m.Assign(context.Background(), []int32{1, 2, 3})
 	// Setting an assigned partition to ready should return true.
-	require.True(t, m.setReady(1))
-	state, ok := m.getState(1)
+	require.True(t, m.SetReady(1))
+	state, ok := m.GetState(1)
 	require.True(t, ok)
 	require.Equal(t, partitionReady, state)
 	// Setting an unknown partition to ready should return false.
-	require.False(t, m.setReady(4))
+	require.False(t, m.SetReady(4))
 }
 
 func TestPartitionManager_Revoke(t *testing.T) {
 	m := newPartitionManager()
 	c := quartz.NewMock(t)
 	m.clock = c
-	m.assign(context.Background(), []int32{1, 2, 3})
+	m.Assign(context.Background(), []int32{1, 2, 3})
 	// Assert that the partitions were assigned and the timestamps are set to
 	// the current time.
 	now := c.Now().UnixNano()
@@ -205,7 +205,7 @@ func TestPartitionManager_Revoke(t *testing.T) {
 		},
 	}, m.partitions)
 	// Revoke partitions 2 and 3.
-	m.revoke(context.Background(), []int32{2, 3})
+	m.Revoke(context.Background(), []int32{2, 3})
 	require.Equal(t, map[int32]partitionEntry{
 		1: {
 			assignedAt: now,

--- a/pkg/limits/producer.go
+++ b/pkg/limits/producer.go
@@ -56,10 +56,10 @@ func newProducer(client kafkaProducer, topic string, numPartitions int, zone str
 	}
 }
 
-// produce encodes the metadata in a [proto.StreamMetadataRecord] record
+// Produce encodes the metadata in a [proto.StreamMetadataRecord] record
 // and pushes it to the metadata topic. It does not wait for the push to
 // complete.
-func (p *producer) produce(ctx context.Context, tenant string, metadata *proto.StreamMetadata) error {
+func (p *producer) Produce(ctx context.Context, tenant string, metadata *proto.StreamMetadata) error {
 	v := proto.StreamMetadataRecord{
 		Zone:     p.zone,
 		Tenant:   tenant,

--- a/pkg/limits/producer_test.go
+++ b/pkg/limits/producer_test.go
@@ -22,7 +22,7 @@ func TestProducer_Produce(t *testing.T) {
 		TotalSize:  100,
 	}
 	ctx := context.Background()
-	require.NoError(t, p.produce(ctx, "tenant", metadata))
+	require.NoError(t, p.Produce(ctx, "tenant", metadata))
 	expectedMetadataRecord := proto.StreamMetadataRecord{
 		Zone:     "zone1",
 		Tenant:   "tenant",
@@ -41,6 +41,6 @@ func TestProducer_Produce(t *testing.T) {
 	kafka.produceFailer = func(_ *kgo.Record) error {
 		return errors.New("failed to produce record")
 	}
-	require.NoError(t, p.produce(ctx, "tenant", metadata))
+	require.NoError(t, p.Produce(ctx, "tenant", metadata))
 	require.Equal(t, []*kgo.Record{}, kafka.produced)
 }

--- a/pkg/limits/service_test.go
+++ b/pkg/limits/service_test.go
@@ -338,7 +338,7 @@ func TestService_ExceedsLimits(t *testing.T) {
 			}
 
 			// Assign the Partition IDs.
-			s.partitionManager.assign(context.Background(), tt.assignedPartitions)
+			s.partitionManager.Assign(context.Background(), tt.assignedPartitions)
 
 			// Call ExceedsLimits.
 			req := &proto.ExceedsLimitsRequest{
@@ -427,7 +427,7 @@ func TestIngestLimits_ExceedsLimits_Concurrent(t *testing.T) {
 	}
 
 	// Assign the Partition IDs.
-	s.partitionManager.assign(context.Background(), []int32{0})
+	s.partitionManager.Assign(context.Background(), []int32{0})
 
 	// Run concurrent requests
 	concurrency := 10

--- a/pkg/limits/store.go
+++ b/pkg/limits/store.go
@@ -77,10 +77,10 @@ func newUsageStore(activeWindow, rateWindow, bucketSize time.Duration, numPartit
 	return s
 }
 
-// all iterates all streams, and calls the [iterateFunc] closure for each
-// iterated stream. As [all] acquires a read lock, the closure must not
+// All iterates all streams, and calls the [iterateFunc] closure for each
+// iterated stream. As [All] acquires a read lock, the closure must not
 // make blocking calls while iterating streams.
-func (s *usageStore) all(fn iterateFunc) {
+func (s *usageStore) All(fn iterateFunc) {
 	s.forEachRLock(func(i int) {
 		for tenant, partitions := range s.stripes[i] {
 			for partition, streams := range partitions {
@@ -92,10 +92,10 @@ func (s *usageStore) all(fn iterateFunc) {
 	})
 }
 
-// forTenant iterates all streams for the tenant, and calls the [iterateFunc]
-// closure for each iterated stream. As [forTenant] aquires a read lock, the
+// ForTenant iterates all streams for the tenant, and calls the [iterateFunc]
+// closure for each iterated stream. As [ForTenant] aquires a read lock, the
 // closure must not make blocking calls while iterating streams.
-func (s *usageStore) forTenant(tenant string, fn iterateFunc) {
+func (s *usageStore) ForTenant(tenant string, fn iterateFunc) {
 	s.withRLock(tenant, func(i int) {
 		for partition, streams := range s.stripes[i][tenant] {
 			for _, stream := range streams {
@@ -105,7 +105,7 @@ func (s *usageStore) forTenant(tenant string, fn iterateFunc) {
 	})
 }
 
-func (s *usageStore) update(tenant string, streams []*proto.StreamMetadata, lastSeenAt time.Time, cond condFunc) ([]*proto.StreamMetadata, []*proto.StreamMetadata) {
+func (s *usageStore) Update(tenant string, streams []*proto.StreamMetadata, lastSeenAt time.Time, cond condFunc) ([]*proto.StreamMetadata, []*proto.StreamMetadata) {
 	var (
 		// Calculate the cutoff for the window size
 		cutoff = lastSeenAt.Add(-s.activeWindow).UnixNano()
@@ -166,8 +166,8 @@ func (s *usageStore) update(tenant string, streams []*proto.StreamMetadata, last
 	return stored, rejected
 }
 
-// evict evicts all streams that have not been seen within the window.
-func (s *usageStore) evict() map[string]int {
+// Evict evicts all streams that have not been seen within the window.
+func (s *usageStore) Evict() map[string]int {
 	cutoff := s.clock.Now().Add(-s.activeWindow).UnixNano()
 	evicted := make(map[string]int)
 	s.forEachLock(func(i int) {
@@ -185,8 +185,8 @@ func (s *usageStore) evict() map[string]int {
 	return evicted
 }
 
-// evictPartitions evicts all streams for the specified partitions.
-func (s *usageStore) evictPartitions(partitionsToEvict []int32) {
+// EvictPartitions evicts all streams for the specified partitions.
+func (s *usageStore) EvictPartitions(partitionsToEvict []int32) {
 	s.forEachLock(func(i int) {
 		for tenant, partitions := range s.stripes[i] {
 			for _, partitionToEvict := range partitionsToEvict {

--- a/pkg/limits/store_bench_test.go
+++ b/pkg/limits/store_bench_test.go
@@ -58,7 +58,7 @@ func BenchmarkUsageStore_Store(b *testing.B) {
 					TotalSize:  1500,
 				}}
 
-				s.update(tenant, metadata, updateTime, nil)
+				s.Update(tenant, metadata, updateTime, nil)
 			}
 		})
 
@@ -77,7 +77,7 @@ func BenchmarkUsageStore_Store(b *testing.B) {
 					TotalSize:  1500,
 				}}
 
-				s.update(tenant, metadata, updateTime, nil)
+				s.Update(tenant, metadata, updateTime, nil)
 			}
 		})
 
@@ -99,7 +99,7 @@ func BenchmarkUsageStore_Store(b *testing.B) {
 						TotalSize:  1500,
 					}}
 
-					s.update(tenant, metadata, updateTime, nil)
+					s.Update(tenant, metadata, updateTime, nil)
 					i++
 				}
 			})
@@ -120,7 +120,7 @@ func BenchmarkUsageStore_Store(b *testing.B) {
 						TotalSize:  1500,
 					}}
 
-					s.update(tenant, metadata, updateTime, nil)
+					s.Update(tenant, metadata, updateTime, nil)
 					i++
 				}
 			})

--- a/pkg/limits/store_test.go
+++ b/pkg/limits/store_test.go
@@ -23,7 +23,7 @@ func TestUsageStore_All(t *testing.T) {
 	// Check that we can iterate all stored streams.
 	expected := []uint64{0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9}
 	actual := make([]uint64, 0, len(expected))
-	s.all(func(_ string, _ int32, s streamUsage) {
+	s.All(func(_ string, _ int32, s streamUsage) {
 		actual = append(actual, s.hash)
 	})
 	require.ElementsMatch(t, expected, actual)
@@ -46,13 +46,13 @@ func TestUsageStore_ForTenant(t *testing.T) {
 	// Check we can iterate just the streams for each tenant.
 	expected1 := []uint64{0x0, 0x1, 0x2, 0x3, 0x4}
 	actual1 := make([]uint64, 0, 5)
-	s.forTenant("tenant1", func(_ string, _ int32, stream streamUsage) {
+	s.ForTenant("tenant1", func(_ string, _ int32, stream streamUsage) {
 		actual1 = append(actual1, stream.hash)
 	})
 	require.ElementsMatch(t, expected1, actual1)
 	expected2 := []uint64{0x5, 0x6, 0x7, 0x8, 0x9}
 	actual2 := make([]uint64, 0, 5)
-	s.forTenant("tenant2", func(_ string, _ int32, stream streamUsage) {
+	s.ForTenant("tenant2", func(_ string, _ int32, stream streamUsage) {
 		actual2 = append(actual2, stream.hash)
 	})
 	require.ElementsMatch(t, expected2, actual2)
@@ -164,9 +164,9 @@ func TestUsageStore_Store(t *testing.T) {
 			s := newUsageStore(DefaultActiveWindow, DefaultRateWindow, DefaultBucketSize, test.numPartitions)
 			clock := quartz.NewMock(t)
 			s.clock = clock
-			s.update("tenant", test.seed, clock.Now(), nil)
+			s.Update("tenant", test.seed, clock.Now(), nil)
 			streamLimitCond := streamLimitExceeded(test.maxGlobalStreams)
-			accepted, rejected := s.update("tenant", test.streams, clock.Now(), streamLimitCond)
+			accepted, rejected := s.Update("tenant", test.streams, clock.Now(), streamLimitCond)
 			require.ElementsMatch(t, test.expectedAccepted, accepted)
 			require.ElementsMatch(t, test.expectedRejected, rejected)
 		})
@@ -186,9 +186,9 @@ func TestUsageStore_Evict(t *testing.T) {
 	s4 := streamUsage{hash: 0x4, lastSeenAt: clock.Now().Add(-59 * time.Minute).UnixNano()}
 	s.set("tenant2", s4)
 	// Evict all streams older than the window size.
-	s.evict()
+	s.Evict()
 	actual := make(map[string][]streamUsage)
-	s.all(func(tenant string, _ int32, stream streamUsage) {
+	s.All(func(tenant string, _ int32, stream streamUsage) {
 		actual[tenant] = append(actual[tenant], stream)
 	})
 	// We can't use require.Equal as [All] iterates streams in a non-deterministic
@@ -214,11 +214,11 @@ func TestUsageStore_EvictPartitions(t *testing.T) {
 		s.set("tenant", streamUsage{hash: uint64(i)})
 	}
 	// Evict the first 5 partitions.
-	s.evictPartitions([]int32{0, 1, 2, 3, 4})
+	s.EvictPartitions([]int32{0, 1, 2, 3, 4})
 	// The last 5 partitions should still have data.
 	expected := []int32{5, 6, 7, 8, 9}
 	actual := make([]int32, 0, len(expected))
-	s.all(func(_ string, partition int32, _ streamUsage) {
+	s.All(func(_ string, partition int32, _ streamUsage) {
 		actual = append(actual, partition)
 	})
 	require.ElementsMatch(t, expected, actual)


### PR DESCRIPTION
**What this PR does / why we need it**:

As discussed with @rfratto.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
