### PR TITLE
chore: move metrics into partition_manager.go and store.go

### DIFF
--- a/pkg/limits/consumer_test.go
+++ b/pkg/limits/consumer_test.go
@@ -41,13 +41,16 @@ func TestConsumer_ProcessRecords(t *testing.T) {
 			}}},
 		}
 		ctx := context.Background()
+		reg := prometheus.NewRegistry()
 		// Need to assign the partition and set it to ready.
-		m := newPartitionManager()
+		m, err := newPartitionManager(reg)
+		require.NoError(t, err)
 		m.Assign(ctx, []int32{1})
 		m.SetReplaying(1, 1000)
 		// Create a usage store, we will use this to check if the record
 		// was stored.
-		u := newUsageStore(DefaultActiveWindow, DefaultRateWindow, DefaultBucketSize, 1)
+		u, err := newUsageStore(DefaultActiveWindow, DefaultRateWindow, DefaultBucketSize, 1, reg)
+		require.NoError(t, err)
 		c := newConsumer(&k, m, u, newOffsetReadinessCheck(m), "zone1",
 			log.NewNopLogger(), prometheus.NewRegistry())
 		require.NoError(t, c.pollFetches(ctx))
@@ -85,13 +88,16 @@ func TestConsumer_ProcessRecords(t *testing.T) {
 			}}},
 		}
 		ctx := context.Background()
+		reg := prometheus.NewRegistry()
 		// Need to assign the partition and set it to ready.
-		m := newPartitionManager()
+		m, err := newPartitionManager(reg)
+		require.NoError(t, err)
 		m.Assign(ctx, []int32{1})
 		m.SetReady(1)
 		// Create a usage store, we will use this to check if the record
 		// was discarded.
-		u := newUsageStore(DefaultActiveWindow, DefaultRateWindow, DefaultBucketSize, 1)
+		u, err := newUsageStore(DefaultActiveWindow, DefaultRateWindow, DefaultBucketSize, 1, reg)
+		require.NoError(t, err)
 		c := newConsumer(&k, m, u, newOffsetReadinessCheck(m), "zone1",
 			log.NewNopLogger(), prometheus.NewRegistry())
 		require.NoError(t, c.pollFetches(ctx))
@@ -156,14 +162,17 @@ func TestConsumer_ReadinessCheck(t *testing.T) {
 		}}},
 	}
 	ctx := context.Background()
+	reg := prometheus.NewRegistry()
 	// Need to assign the partition and set it to replaying.
-	m := newPartitionManager()
+	m, err := newPartitionManager(reg)
+	require.NoError(t, err)
 	m.Assign(ctx, []int32{1})
 	// The partition should be marked ready when the second record
 	// has been consumed.
 	m.SetReplaying(1, 2)
 	// We don't need the usage store for this test.
-	u := newUsageStore(DefaultActiveWindow, DefaultRateWindow, DefaultBucketSize, 1)
+	u, err := newUsageStore(DefaultActiveWindow, DefaultRateWindow, DefaultBucketSize, 1, reg)
+	require.NoError(t, err)
 	c := newConsumer(&k, m, u, newOffsetReadinessCheck(m), "zone1",
 		log.NewNopLogger(), prometheus.NewRegistry())
 	// The first poll should fetch the first record.

--- a/pkg/limits/partition_manager.go
+++ b/pkg/limits/partition_manager.go
@@ -2,9 +2,24 @@ package limits
 
 import (
 	"context"
+	"fmt"
+	"strconv"
 	"sync"
 
 	"github.com/coder/quartz"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	// partitionsDesc is a gauge which tracks the state of the partitions
+	// in the partitionManager. The value of the gauge is set to the value of
+	// the partitionState enum.
+	partitionsDesc = prometheus.NewDesc(
+		"loki_ingest_limits_partitions",
+		"The state of each partition.",
+		[]string{"partition"},
+		nil,
+	)
 )
 
 type partitionState int
@@ -47,11 +62,15 @@ type partitionEntry struct {
 }
 
 // newPartitionManager returns a new [PartitionManager].
-func newPartitionManager() *partitionManager {
-	return &partitionManager{
+func newPartitionManager(reg prometheus.Registerer) (*partitionManager, error) {
+	m := partitionManager{
 		partitions: make(map[int32]partitionEntry),
 		clock:      quartz.NewReal(),
 	}
+	if err := reg.Register(&m); err != nil {
+		return nil, fmt.Errorf("failed to register metrics: %w", err)
+	}
+	return &m, nil
 }
 
 // Assign assigns the partitions.
@@ -156,5 +175,24 @@ func (m *partitionManager) Revoke(_ context.Context, partitions []int32) {
 	defer m.mtx.Unlock()
 	for _, partition := range partitions {
 		delete(m.partitions, partition)
+	}
+}
+
+// Describe implements [prometheus.Collector].
+func (m *partitionManager) Describe(descs chan<- *prometheus.Desc) {
+	descs <- partitionsDesc
+}
+
+// Collect implements [prometheus.Collector].
+func (m *partitionManager) Collect(metrics chan<- prometheus.Metric) {
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+	for partition, entry := range m.partitions {
+		metrics <- prometheus.MustNewConstMetric(
+			partitionsDesc,
+			prometheus.GaugeValue,
+			float64(entry.state),
+			strconv.FormatInt(int64(partition), 10),
+		)
 	}
 }

--- a/pkg/limits/partition_manager_test.go
+++ b/pkg/limits/partition_manager_test.go
@@ -6,11 +6,13 @@ import (
 	"testing"
 
 	"github.com/coder/quartz"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 )
 
 func TestPartitionManager_Assign(t *testing.T) {
-	m := newPartitionManager()
+	m, err := newPartitionManager(prometheus.NewRegistry())
+	require.NoError(t, err)
 	c := quartz.NewMock(t)
 	m.clock = c
 	// Advance the clock so we compare with a time that is not the default
@@ -61,7 +63,8 @@ func TestPartitionManager_Assign(t *testing.T) {
 }
 
 func TestPartitionManager_GetState(t *testing.T) {
-	m := newPartitionManager()
+	m, err := newPartitionManager(prometheus.NewRegistry())
+	require.NoError(t, err)
 	c := quartz.NewMock(t)
 	m.clock = c
 	m.Assign(context.Background(), []int32{1, 2, 3})
@@ -75,7 +78,8 @@ func TestPartitionManager_GetState(t *testing.T) {
 }
 
 func TestPartitionManager_TargetOffsetReached(t *testing.T) {
-	m := newPartitionManager()
+	m, err := newPartitionManager(prometheus.NewRegistry())
+	require.NoError(t, err)
 	c := quartz.NewMock(t)
 	m.clock = c
 	m.Assign(context.Background(), []int32{1})
@@ -93,7 +97,8 @@ func TestPartitionManager_TargetOffsetReached(t *testing.T) {
 }
 
 func TestPartitionManager_Has(t *testing.T) {
-	m := newPartitionManager()
+	m, err := newPartitionManager(prometheus.NewRegistry())
+	require.NoError(t, err)
 	c := quartz.NewMock(t)
 	m.clock = c
 	m.Assign(context.Background(), []int32{1, 2, 3})
@@ -104,7 +109,8 @@ func TestPartitionManager_Has(t *testing.T) {
 }
 
 func TestPartitionManager_List(t *testing.T) {
-	m := newPartitionManager()
+	m, err := newPartitionManager(prometheus.NewRegistry())
+	require.NoError(t, err)
 	c := quartz.NewMock(t)
 	m.clock = c
 	// Advance the clock so we compare with a time that is not the default
@@ -126,7 +132,8 @@ func TestPartitionManager_List(t *testing.T) {
 }
 
 func TestPartitionManager_ListByState(t *testing.T) {
-	m := newPartitionManager()
+	m, err := newPartitionManager(prometheus.NewRegistry())
+	require.NoError(t, err)
 	c := quartz.NewMock(t)
 	m.clock = c
 	// Advance the clock so we compare with a time that is not the default
@@ -155,7 +162,8 @@ func TestPartitionManager_ListByState(t *testing.T) {
 }
 
 func TestPartitionManager_SetReplaying(t *testing.T) {
-	m := newPartitionManager()
+	m, err := newPartitionManager(prometheus.NewRegistry())
+	require.NoError(t, err)
 	c := quartz.NewMock(t)
 	m.clock = c
 	m.Assign(context.Background(), []int32{1, 2, 3})
@@ -169,7 +177,8 @@ func TestPartitionManager_SetReplaying(t *testing.T) {
 }
 
 func TestPartitionManager_SetReady(t *testing.T) {
-	m := newPartitionManager()
+	m, err := newPartitionManager(prometheus.NewRegistry())
+	require.NoError(t, err)
 	c := quartz.NewMock(t)
 	m.clock = c
 	m.Assign(context.Background(), []int32{1, 2, 3})
@@ -183,7 +192,8 @@ func TestPartitionManager_SetReady(t *testing.T) {
 }
 
 func TestPartitionManager_Revoke(t *testing.T) {
-	m := newPartitionManager()
+	m, err := newPartitionManager(prometheus.NewRegistry())
+	require.NoError(t, err)
 	c := quartz.NewMock(t)
 	m.clock = c
 	m.Assign(context.Background(), []int32{1, 2, 3})

--- a/pkg/limits/service.go
+++ b/pkg/limits/service.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strconv"
 	"time"
 
 	"github.com/coder/quartz"
@@ -36,27 +35,6 @@ const (
 func MetadataTopic(topic string) string {
 	return topic + ".metadata"
 }
-
-var (
-	partitionsDesc = prometheus.NewDesc(
-		"loki_ingest_limits_partitions",
-		"The state of each partition.",
-		[]string{"partition"},
-		nil,
-	)
-	tenantStreamsDesc = prometheus.NewDesc(
-		"loki_ingest_limits_streams",
-		"The current number of streams per tenant, including streams outside the active window.",
-		[]string{"tenant"},
-		nil,
-	)
-	tenantActiveStreamsDesc = prometheus.NewDesc(
-		"loki_ingest_limits_active_streams",
-		"The current number of active streams per tenant.",
-		[]string{"tenant"},
-		nil,
-	)
-)
 
 type metrics struct {
 	tenantStreamEvictionsTotal *prometheus.CounterVec
@@ -128,18 +106,21 @@ func (s *Service) TransferOut(_ context.Context) error {
 func New(cfg Config, lims Limits, logger log.Logger, reg prometheus.Registerer) (*Service, error) {
 	var err error
 	s := &Service{
-		cfg:              cfg,
-		logger:           logger,
-		usage:            newUsageStore(cfg.ActiveWindow, cfg.RateWindow, cfg.BucketSize, cfg.NumPartitions),
-		partitionManager: newPartitionManager(),
-		metrics:          newMetrics(reg),
-		limits:           lims,
-		clock:            quartz.NewReal(),
+		cfg:     cfg,
+		logger:  logger,
+		metrics: newMetrics(reg),
+		limits:  lims,
+		clock:   quartz.NewReal(),
 	}
 
-	// Initialize internal metadata metrics
-	if err := reg.Register(s); err != nil {
-		return nil, fmt.Errorf("failed to register ingest limits internal metadata metrics: %w", err)
+	s.partitionManager, err = newPartitionManager(reg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create partition manager: %w", err)
+	}
+
+	s.usage, err = newUsageStore(cfg.ActiveWindow, cfg.RateWindow, cfg.BucketSize, cfg.NumPartitions, reg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create usage store: %w", err)
 	}
 
 	// Initialize lifecycler
@@ -213,54 +194,6 @@ func New(cfg Config, lims Limits, logger log.Logger, reg prometheus.Registerer) 
 
 	s.Service = services.NewBasicService(s.starting, s.running, s.stopping)
 	return s, nil
-}
-
-func (s *Service) Describe(descs chan<- *prometheus.Desc) {
-	descs <- partitionsDesc
-	descs <- tenantStreamsDesc
-	descs <- tenantActiveStreamsDesc
-}
-
-func (s *Service) Collect(m chan<- prometheus.Metric) {
-	cutoff := s.clock.Now().Add(-s.cfg.ActiveWindow).UnixNano()
-	// active counts the number of active streams (within the window) per tenant.
-	active := make(map[string]int)
-	// total counts the total number of streams per tenant.
-	total := make(map[string]int)
-	s.usage.Iter(func(tenant string, _ int32, stream streamUsage) {
-		total[tenant]++
-		if stream.lastSeenAt >= cutoff {
-			active[tenant]++
-		}
-	})
-	for tenant, numActiveStreams := range active {
-		m <- prometheus.MustNewConstMetric(
-			tenantActiveStreamsDesc,
-			prometheus.GaugeValue,
-			float64(numActiveStreams),
-			tenant,
-		)
-	}
-	for tenant, numStreams := range total {
-		m <- prometheus.MustNewConstMetric(
-			tenantStreamsDesc,
-			prometheus.GaugeValue,
-			float64(numStreams),
-			tenant,
-		)
-	}
-	partitions := s.partitionManager.List()
-	for partition := range partitions {
-		state, ok := s.partitionManager.GetState(partition)
-		if ok {
-			m <- prometheus.MustNewConstMetric(
-				partitionsDesc,
-				prometheus.GaugeValue,
-				float64(state),
-				strconv.FormatInt(int64(partition), 10),
-			)
-		}
-	}
 }
 
 func (s *Service) CheckReady(ctx context.Context) error {

--- a/pkg/limits/service_test.go
+++ b/pkg/limits/service_test.go
@@ -307,6 +307,9 @@ func TestService_ExceedsLimits(t *testing.T) {
 
 			kafkaClient := mockKafka{}
 
+			m, err := newPartitionManager(reg)
+			require.NoError(t, err)
+
 			s := &Service{
 				cfg: Config{
 					NumPartitions: tt.numPartitions,
@@ -332,7 +335,7 @@ func TestService_ExceedsLimits(t *testing.T) {
 				metrics:          newMetrics(reg),
 				limits:           limits,
 				usage:            tt.usage,
-				partitionManager: newPartitionManager(),
+				partitionManager: m,
 				clock:            clock,
 				producer:         newProducer(&kafkaClient, "test", tt.numPartitions, "", log.NewNopLogger(), reg),
 			}
@@ -396,6 +399,9 @@ func TestIngestLimits_ExceedsLimits_Concurrent(t *testing.T) {
 		locks: make([]stripeLock, 1),
 	}
 
+	m, err := newPartitionManager(reg)
+	require.NoError(t, err)
+
 	s := &Service{
 		cfg: Config{
 			NumPartitions: 1,
@@ -419,7 +425,7 @@ func TestIngestLimits_ExceedsLimits_Concurrent(t *testing.T) {
 		},
 		logger:           log.NewNopLogger(),
 		usage:            usage,
-		partitionManager: newPartitionManager(),
+		partitionManager: m,
 		metrics:          newMetrics(reg),
 		limits:           limits,
 		clock:            clock,

--- a/pkg/limits/store_bench_test.go
+++ b/pkg/limits/store_bench_test.go
@@ -5,6 +5,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+
 	"github.com/grafana/loki/v3/pkg/limits/proto"
 )
 
@@ -42,7 +45,8 @@ func BenchmarkUsageStore_Store(b *testing.B) {
 	}
 
 	for _, bm := range benchmarks {
-		s := newUsageStore(DefaultActiveWindow, DefaultRateWindow, DefaultBucketSize, bm.numPartitions)
+		s, err := newUsageStore(DefaultActiveWindow, DefaultRateWindow, DefaultBucketSize, bm.numPartitions, prometheus.NewRegistry())
+		require.NoError(b, err)
 		b.Run(fmt.Sprintf("%s_create", bm.name), func(b *testing.B) {
 			now := time.Now()
 
@@ -81,7 +85,8 @@ func BenchmarkUsageStore_Store(b *testing.B) {
 			}
 		})
 
-		s = newUsageStore(DefaultActiveWindow, DefaultRateWindow, DefaultBucketSize, bm.numPartitions)
+		s, err = newUsageStore(DefaultActiveWindow, DefaultRateWindow, DefaultBucketSize, bm.numPartitions, prometheus.NewRegistry())
+		require.NoError(b, err)
 
 		// Run parallel benchmark
 		b.Run(bm.name+"_create_parallel", func(b *testing.B) {

--- a/pkg/limits/store_test.go
+++ b/pkg/limits/store_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/coder/quartz"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/loki/v3/pkg/limits/proto"
@@ -12,7 +13,8 @@ import (
 
 func TestUsageStore_All(t *testing.T) {
 	// Create a store with 10 partitions.
-	s := newUsageStore(DefaultActiveWindow, DefaultRateWindow, DefaultBucketSize, 10)
+	s, err := newUsageStore(DefaultActiveWindow, DefaultRateWindow, DefaultBucketSize, 10, prometheus.NewRegistry())
+	require.NoError(t, err)
 	clock := quartz.NewMock(t)
 	s.clock = clock
 	// Create 10 streams. Since we use i as the hash, we can expect the
@@ -31,7 +33,8 @@ func TestUsageStore_All(t *testing.T) {
 
 func TestUsageStore_ForTenant(t *testing.T) {
 	// Create a store with 10 partitions.
-	s := newUsageStore(DefaultActiveWindow, DefaultRateWindow, DefaultBucketSize, 10)
+	s, err := newUsageStore(DefaultActiveWindow, DefaultRateWindow, DefaultBucketSize, 10, prometheus.NewRegistry())
+	require.NoError(t, err)
 	clock := quartz.NewMock(t)
 	s.clock = clock
 	// Create 10 streams. Since we use i as the hash, we can expect the
@@ -161,7 +164,8 @@ func TestUsageStore_Store(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			s := newUsageStore(DefaultActiveWindow, DefaultRateWindow, DefaultBucketSize, test.numPartitions)
+			s, err := newUsageStore(DefaultActiveWindow, DefaultRateWindow, DefaultBucketSize, test.numPartitions, prometheus.NewRegistry())
+			require.NoError(t, err)
 			clock := quartz.NewMock(t)
 			s.clock = clock
 			s.Update("tenant", test.seed, clock.Now(), nil)
@@ -174,7 +178,8 @@ func TestUsageStore_Store(t *testing.T) {
 }
 
 func TestUsageStore_Evict(t *testing.T) {
-	s := newUsageStore(DefaultActiveWindow, DefaultRateWindow, DefaultBucketSize, 1)
+	s, err := newUsageStore(DefaultActiveWindow, DefaultRateWindow, DefaultBucketSize, 1, prometheus.NewRegistry())
+	require.NoError(t, err)
 	clock := quartz.NewMock(t)
 	s.clock = clock
 	s1 := streamUsage{hash: 0x1, lastSeenAt: clock.Now().UnixNano()}
@@ -205,7 +210,8 @@ func TestUsageStore_Evict(t *testing.T) {
 
 func TestUsageStore_EvictPartitions(t *testing.T) {
 	// Create a store with 10 partitions.
-	s := newUsageStore(DefaultActiveWindow, DefaultRateWindow, DefaultBucketSize, 10)
+	s, err := newUsageStore(DefaultActiveWindow, DefaultRateWindow, DefaultBucketSize, 10, prometheus.NewRegistry())
+	require.NoError(t, err)
 	clock := quartz.NewMock(t)
 	s.clock = clock
 	// Create 10 streams. Since we use i as the hash, we can expect the


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request moves the metrics out of `service.go` and into the files where the data is owned.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
