### PR TITLE
chore: rename All and ForTenant to Iter and IterTenant

### DIFF
--- a/pkg/limits/consumer_test.go
+++ b/pkg/limits/consumer_test.go
@@ -53,7 +53,7 @@ func TestConsumer_ProcessRecords(t *testing.T) {
 		require.NoError(t, c.pollFetches(ctx))
 		// Check that the record was stored.
 		var n int
-		u.All(func(_ string, _ int32, _ streamUsage) { n++ })
+		u.Iter(func(_ string, _ int32, _ streamUsage) { n++ })
 		require.Equal(t, 1, n)
 	})
 
@@ -97,7 +97,7 @@ func TestConsumer_ProcessRecords(t *testing.T) {
 		require.NoError(t, c.pollFetches(ctx))
 		// Check that the record was discarded.
 		var n int
-		u.All(func(_ string, _ int32, _ streamUsage) { n++ })
+		u.Iter(func(_ string, _ int32, _ streamUsage) { n++ })
 		require.Equal(t, 0, n)
 	})
 }
@@ -175,7 +175,7 @@ func TestConsumer_ReadinessCheck(t *testing.T) {
 	require.Equal(t, partitionReplaying, state)
 	// Check that the record was stored.
 	var n int
-	u.All(func(_ string, _ int32, _ streamUsage) { n++ })
+	u.Iter(func(_ string, _ int32, _ streamUsage) { n++ })
 	require.Equal(t, 1, n)
 	// The second poll should fetch the second (and last) record.
 	require.NoError(t, c.pollFetches(ctx))
@@ -186,6 +186,6 @@ func TestConsumer_ReadinessCheck(t *testing.T) {
 	require.Equal(t, partitionReady, state)
 	// Check that the record was stored.
 	n = 0
-	u.All(func(_ string, _ int32, _ streamUsage) { n++ })
+	u.Iter(func(_ string, _ int32, _ streamUsage) { n++ })
 	require.Equal(t, 2, n)
 }

--- a/pkg/limits/http.go
+++ b/pkg/limits/http.go
@@ -38,7 +38,7 @@ func (s *Service) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		response      httpTenantLimitsResponse
 	)
 
-	s.usage.ForTenant(tenant, func(_ string, _ int32, stream streamUsage) {
+	s.usage.IterTenant(tenant, func(_ string, _ int32, stream streamUsage) {
 		if stream.lastSeenAt >= cutoff {
 			activeStreams++
 

--- a/pkg/limits/service.go
+++ b/pkg/limits/service.go
@@ -227,7 +227,7 @@ func (s *Service) Collect(m chan<- prometheus.Metric) {
 	active := make(map[string]int)
 	// total counts the total number of streams per tenant.
 	total := make(map[string]int)
-	s.usage.All(func(tenant string, _ int32, stream streamUsage) {
+	s.usage.Iter(func(tenant string, _ int32, stream streamUsage) {
 		total[tenant]++
 		if stream.lastSeenAt >= cutoff {
 			active[tenant]++

--- a/pkg/limits/store.go
+++ b/pkg/limits/store.go
@@ -77,10 +77,9 @@ func newUsageStore(activeWindow, rateWindow, bucketSize time.Duration, numPartit
 	return s
 }
 
-// All iterates all streams, and calls the [iterateFunc] closure for each
-// iterated stream. As [All] acquires a read lock, the closure must not
-// make blocking calls while iterating streams.
-func (s *usageStore) All(fn iterateFunc) {
+// Iter iterates all active streams and calls f for each iterated stream.
+// As this method acquires a read lock, f must not block.
+func (s *usageStore) Iter(fn iterateFunc) {
 	s.forEachRLock(func(i int) {
 		for tenant, partitions := range s.stripes[i] {
 			for partition, streams := range partitions {
@@ -92,10 +91,10 @@ func (s *usageStore) All(fn iterateFunc) {
 	})
 }
 
-// ForTenant iterates all streams for the tenant, and calls the [iterateFunc]
-// closure for each iterated stream. As [ForTenant] aquires a read lock, the
-// closure must not make blocking calls while iterating streams.
-func (s *usageStore) ForTenant(tenant string, fn iterateFunc) {
+// IterTenant iterates all active streams for the tenant and calls f for
+// each iterated stream. As this method acquires a read lock, f must not
+// block.
+func (s *usageStore) IterTenant(tenant string, fn iterateFunc) {
 	s.withRLock(tenant, func(i int) {
 		for partition, streams := range s.stripes[i][tenant] {
 			for _, stream := range streams {

--- a/pkg/limits/store_test.go
+++ b/pkg/limits/store_test.go
@@ -23,7 +23,7 @@ func TestUsageStore_All(t *testing.T) {
 	// Check that we can iterate all stored streams.
 	expected := []uint64{0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9}
 	actual := make([]uint64, 0, len(expected))
-	s.All(func(_ string, _ int32, s streamUsage) {
+	s.Iter(func(_ string, _ int32, s streamUsage) {
 		actual = append(actual, s.hash)
 	})
 	require.ElementsMatch(t, expected, actual)
@@ -46,13 +46,13 @@ func TestUsageStore_ForTenant(t *testing.T) {
 	// Check we can iterate just the streams for each tenant.
 	expected1 := []uint64{0x0, 0x1, 0x2, 0x3, 0x4}
 	actual1 := make([]uint64, 0, 5)
-	s.ForTenant("tenant1", func(_ string, _ int32, stream streamUsage) {
+	s.IterTenant("tenant1", func(_ string, _ int32, stream streamUsage) {
 		actual1 = append(actual1, stream.hash)
 	})
 	require.ElementsMatch(t, expected1, actual1)
 	expected2 := []uint64{0x5, 0x6, 0x7, 0x8, 0x9}
 	actual2 := make([]uint64, 0, 5)
-	s.ForTenant("tenant2", func(_ string, _ int32, stream streamUsage) {
+	s.IterTenant("tenant2", func(_ string, _ int32, stream streamUsage) {
 		actual2 = append(actual2, stream.hash)
 	})
 	require.ElementsMatch(t, expected2, actual2)
@@ -188,7 +188,7 @@ func TestUsageStore_Evict(t *testing.T) {
 	// Evict all streams older than the window size.
 	s.Evict()
 	actual := make(map[string][]streamUsage)
-	s.All(func(tenant string, _ int32, stream streamUsage) {
+	s.Iter(func(tenant string, _ int32, stream streamUsage) {
 		actual[tenant] = append(actual[tenant], stream)
 	})
 	// We can't use require.Equal as [All] iterates streams in a non-deterministic
@@ -218,7 +218,7 @@ func TestUsageStore_EvictPartitions(t *testing.T) {
 	// The last 5 partitions should still have data.
 	expected := []int32{5, 6, 7, 8, 9}
 	actual := make([]int32, 0, len(expected))
-	s.All(func(_ string, partition int32, _ streamUsage) {
+	s.Iter(func(_ string, partition int32, _ streamUsage) {
 		actual = append(actual, partition)
 	})
 	require.ElementsMatch(t, expected, actual)


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request renames `All` and `ForTenant` to `Iter` and `IterTenant`. It is part of a larger clean up of `store.go`.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
