### PR TITLE
feat: add a fast path for consuming records from Kafka

### DIFF
--- a/pkg/limits/service.go
+++ b/pkg/limits/service.go
@@ -328,7 +328,7 @@ func (s *Service) ExceedsLimits(ctx context.Context, req *proto.ExceedsLimitsReq
 	streams = streams[:valid]
 
 	cond := streamLimitExceeded(maxActiveStreams)
-	accepted, rejected := s.usage.Update(req.Tenant, streams, lastSeenAt, cond)
+	accepted, rejected := s.usage.UpdateCond(req.Tenant, streams, lastSeenAt, cond)
 
 	var ingestedBytes uint64
 	for _, stream := range accepted {

--- a/pkg/limits/store_bench_test.go
+++ b/pkg/limits/store_bench_test.go
@@ -62,7 +62,7 @@ func BenchmarkUsageStore_Store(b *testing.B) {
 					TotalSize:  1500,
 				}}
 
-				s.Update(tenant, metadata, updateTime, nil)
+				s.UpdateCond(tenant, metadata, updateTime, nil)
 			}
 		})
 
@@ -81,7 +81,7 @@ func BenchmarkUsageStore_Store(b *testing.B) {
 					TotalSize:  1500,
 				}}
 
-				s.Update(tenant, metadata, updateTime, nil)
+				s.UpdateCond(tenant, metadata, updateTime, nil)
 			}
 		})
 
@@ -104,7 +104,7 @@ func BenchmarkUsageStore_Store(b *testing.B) {
 						TotalSize:  1500,
 					}}
 
-					s.Update(tenant, metadata, updateTime, nil)
+					s.UpdateCond(tenant, metadata, updateTime, nil)
 					i++
 				}
 			})
@@ -125,7 +125,7 @@ func BenchmarkUsageStore_Store(b *testing.B) {
 						TotalSize:  1500,
 					}}
 
-					s.Update(tenant, metadata, updateTime, nil)
+					s.UpdateCond(tenant, metadata, updateTime, nil)
 					i++
 				}
 			})


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request adds a fast path for consuming records from Kafka. We had this before but I removed it thinking we could use the same method, but I think on reflection that was a mistake.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
