### PR TITLE
chore: remove unused context from partition_manager.go

### DIFF
--- a/pkg/limits/consumer_test.go
+++ b/pkg/limits/consumer_test.go
@@ -40,12 +40,11 @@ func TestConsumer_ProcessRecords(t *testing.T) {
 				}},
 			}}},
 		}
-		ctx := context.Background()
 		reg := prometheus.NewRegistry()
 		// Need to assign the partition and set it to ready.
 		m, err := newPartitionManager(reg)
 		require.NoError(t, err)
-		m.Assign(ctx, []int32{1})
+		m.Assign([]int32{1})
 		m.SetReplaying(1, 1000)
 		// Create a usage store, we will use this to check if the record
 		// was stored.
@@ -53,6 +52,7 @@ func TestConsumer_ProcessRecords(t *testing.T) {
 		require.NoError(t, err)
 		c := newConsumer(&k, m, u, newOffsetReadinessCheck(m), "zone1",
 			log.NewNopLogger(), prometheus.NewRegistry())
+		ctx := context.Background()
 		require.NoError(t, c.pollFetches(ctx))
 		// Check that the record was stored.
 		var n int
@@ -87,12 +87,11 @@ func TestConsumer_ProcessRecords(t *testing.T) {
 				}},
 			}}},
 		}
-		ctx := context.Background()
 		reg := prometheus.NewRegistry()
 		// Need to assign the partition and set it to ready.
 		m, err := newPartitionManager(reg)
 		require.NoError(t, err)
-		m.Assign(ctx, []int32{1})
+		m.Assign([]int32{1})
 		m.SetReady(1)
 		// Create a usage store, we will use this to check if the record
 		// was discarded.
@@ -100,6 +99,7 @@ func TestConsumer_ProcessRecords(t *testing.T) {
 		require.NoError(t, err)
 		c := newConsumer(&k, m, u, newOffsetReadinessCheck(m), "zone1",
 			log.NewNopLogger(), prometheus.NewRegistry())
+		ctx := context.Background()
 		require.NoError(t, c.pollFetches(ctx))
 		// Check that the record was discarded.
 		var n int
@@ -161,12 +161,11 @@ func TestConsumer_ReadinessCheck(t *testing.T) {
 			}},
 		}}},
 	}
-	ctx := context.Background()
 	reg := prometheus.NewRegistry()
 	// Need to assign the partition and set it to replaying.
 	m, err := newPartitionManager(reg)
 	require.NoError(t, err)
-	m.Assign(ctx, []int32{1})
+	m.Assign([]int32{1})
 	// The partition should be marked ready when the second record
 	// has been consumed.
 	m.SetReplaying(1, 2)
@@ -176,6 +175,7 @@ func TestConsumer_ReadinessCheck(t *testing.T) {
 	c := newConsumer(&k, m, u, newOffsetReadinessCheck(m), "zone1",
 		log.NewNopLogger(), prometheus.NewRegistry())
 	// The first poll should fetch the first record.
+	ctx := context.Background()
 	require.NoError(t, c.pollFetches(ctx))
 	// The partition should still be replaying as we have not read up to
 	// the target offset.

--- a/pkg/limits/partition_lifecycler.go
+++ b/pkg/limits/partition_lifecycler.go
@@ -48,7 +48,7 @@ func (l *partitionLifecycler) Assign(ctx context.Context, _ *kgo.Client, topics 
 	// We expect the client to just consume one topic.
 	// TODO(grobinson): Figure out what to do if this is not the case.
 	for _, partitions := range topics {
-		l.partitionManager.Assign(ctx, partitions)
+		l.partitionManager.Assign(partitions)
 		for _, partition := range partitions {
 			if err := l.determineStateFromOffsets(ctx, partition); err != nil {
 				level.Error(l.logger).Log(
@@ -64,11 +64,11 @@ func (l *partitionLifecycler) Assign(ctx context.Context, _ *kgo.Client, topics 
 }
 
 // Revoke implements kgo.OnPartitionsRevoked.
-func (l *partitionLifecycler) Revoke(ctx context.Context, _ *kgo.Client, topics map[string][]int32) {
+func (l *partitionLifecycler) Revoke(_ context.Context, _ *kgo.Client, topics map[string][]int32) {
 	// We expect the client to just consume one topic.
 	// TODO(grobinson): Figure out what to do if this is not the case.
 	for _, partitions := range topics {
-		l.partitionManager.Revoke(ctx, partitions)
+		l.partitionManager.Revoke(partitions)
 		l.usage.EvictPartitions(partitions)
 		return
 	}

--- a/pkg/limits/partition_manager.go
+++ b/pkg/limits/partition_manager.go
@@ -1,7 +1,6 @@
 package limits
 
 import (
-	"context"
 	"fmt"
 	"strconv"
 	"sync"
@@ -74,7 +73,7 @@ func newPartitionManager(reg prometheus.Registerer) (*partitionManager, error) {
 }
 
 // Assign assigns the partitions.
-func (m *partitionManager) Assign(_ context.Context, partitions []int32) {
+func (m *partitionManager) Assign(partitions []int32) {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
 	for _, partition := range partitions {
@@ -170,7 +169,7 @@ func (m *partitionManager) SetReady(partition int32) bool {
 }
 
 // Revoke deletes the partitions.
-func (m *partitionManager) Revoke(_ context.Context, partitions []int32) {
+func (m *partitionManager) Revoke(partitions []int32) {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
 	for _, partition := range partitions {

--- a/pkg/limits/partition_manager_test.go
+++ b/pkg/limits/partition_manager_test.go
@@ -1,7 +1,6 @@
 package limits
 
 import (
-	"context"
 	"reflect"
 	"testing"
 
@@ -18,7 +17,7 @@ func TestPartitionManager_Assign(t *testing.T) {
 	// Advance the clock so we compare with a time that is not the default
 	// value.
 	c.Advance(1)
-	m.Assign(context.Background(), []int32{1, 2, 3})
+	m.Assign([]int32{1, 2, 3})
 	// Assert that the partitions were assigned and the timestamps are set to
 	// the current time.
 	now := c.Now().UnixNano()
@@ -40,7 +39,7 @@ func TestPartitionManager_Assign(t *testing.T) {
 	// partition #4. We expect the updated timestamp is equal to the advanced
 	// time.
 	c.Advance(1)
-	m.Assign(context.Background(), []int32{3, 4})
+	m.Assign([]int32{3, 4})
 	later := c.Now().UnixNano()
 	require.Equal(t, map[int32]partitionEntry{
 		1: {
@@ -67,7 +66,7 @@ func TestPartitionManager_GetState(t *testing.T) {
 	require.NoError(t, err)
 	c := quartz.NewMock(t)
 	m.clock = c
-	m.Assign(context.Background(), []int32{1, 2, 3})
+	m.Assign([]int32{1, 2, 3})
 	// Getting the state for an assigned partition should return true.
 	state, ok := m.GetState(1)
 	require.True(t, ok)
@@ -82,7 +81,7 @@ func TestPartitionManager_TargetOffsetReached(t *testing.T) {
 	require.NoError(t, err)
 	c := quartz.NewMock(t)
 	m.clock = c
-	m.Assign(context.Background(), []int32{1})
+	m.Assign([]int32{1})
 	// Target offset cannot be reached for pending partition.
 	require.False(t, m.TargetOffsetReached(1, 0))
 	// Target offset has not been reached.
@@ -101,7 +100,7 @@ func TestPartitionManager_Has(t *testing.T) {
 	require.NoError(t, err)
 	c := quartz.NewMock(t)
 	m.clock = c
-	m.Assign(context.Background(), []int32{1, 2, 3})
+	m.Assign([]int32{1, 2, 3})
 	require.True(t, m.Has(1))
 	require.True(t, m.Has(2))
 	require.True(t, m.Has(3))
@@ -116,7 +115,7 @@ func TestPartitionManager_List(t *testing.T) {
 	// Advance the clock so we compare with a time that is not the default
 	// value.
 	c.Advance(1)
-	m.Assign(context.Background(), []int32{1, 2, 3})
+	m.Assign([]int32{1, 2, 3})
 	now := c.Now().UnixNano()
 	result := m.List()
 	require.Equal(t, map[int32]int64{
@@ -139,7 +138,7 @@ func TestPartitionManager_ListByState(t *testing.T) {
 	// Advance the clock so we compare with a time that is not the default
 	// value.
 	c.Advance(1)
-	m.Assign(context.Background(), []int32{1, 2, 3})
+	m.Assign([]int32{1, 2, 3})
 	now := c.Now().UnixNano()
 	result := m.ListByState(partitionPending)
 	require.Equal(t, map[int32]int64{
@@ -166,7 +165,7 @@ func TestPartitionManager_SetReplaying(t *testing.T) {
 	require.NoError(t, err)
 	c := quartz.NewMock(t)
 	m.clock = c
-	m.Assign(context.Background(), []int32{1, 2, 3})
+	m.Assign([]int32{1, 2, 3})
 	// Setting an assigned partition to replaying should return true.
 	require.True(t, m.SetReplaying(1, 10))
 	state, ok := m.GetState(1)
@@ -181,7 +180,7 @@ func TestPartitionManager_SetReady(t *testing.T) {
 	require.NoError(t, err)
 	c := quartz.NewMock(t)
 	m.clock = c
-	m.Assign(context.Background(), []int32{1, 2, 3})
+	m.Assign([]int32{1, 2, 3})
 	// Setting an assigned partition to ready should return true.
 	require.True(t, m.SetReady(1))
 	state, ok := m.GetState(1)
@@ -196,7 +195,7 @@ func TestPartitionManager_Revoke(t *testing.T) {
 	require.NoError(t, err)
 	c := quartz.NewMock(t)
 	m.clock = c
-	m.Assign(context.Background(), []int32{1, 2, 3})
+	m.Assign([]int32{1, 2, 3})
 	// Assert that the partitions were assigned and the timestamps are set to
 	// the current time.
 	now := c.Now().UnixNano()
@@ -215,7 +214,7 @@ func TestPartitionManager_Revoke(t *testing.T) {
 		},
 	}, m.partitions)
 	// Revoke partitions 2 and 3.
-	m.Revoke(context.Background(), []int32{2, 3})
+	m.Revoke([]int32{2, 3})
 	require.Equal(t, map[int32]partitionEntry{
 		1: {
 			assignedAt: now,

--- a/pkg/limits/service_test.go
+++ b/pkg/limits/service_test.go
@@ -341,7 +341,7 @@ func TestService_ExceedsLimits(t *testing.T) {
 			}
 
 			// Assign the Partition IDs.
-			s.partitionManager.Assign(context.Background(), tt.assignedPartitions)
+			s.partitionManager.Assign(tt.assignedPartitions)
 
 			// Call ExceedsLimits.
 			req := &proto.ExceedsLimitsRequest{
@@ -433,7 +433,7 @@ func TestIngestLimits_ExceedsLimits_Concurrent(t *testing.T) {
 	}
 
 	// Assign the Partition IDs.
-	s.partitionManager.Assign(context.Background(), []int32{0})
+	s.partitionManager.Assign([]int32{0})
 
 	// Run concurrent requests
 	concurrency := 10


### PR DESCRIPTION
**What this PR does / why we need it**:

Remove unused context from `partition_manager.go`.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
