### PR TITLE
feat: optimize rate buckets to avoid re-allocating slice

### DIFF
--- a/pkg/limits/config.go
+++ b/pkg/limits/config.go
@@ -120,8 +120,8 @@ func (cfg *Config) Validate() error {
 	if cfg.BucketSize <= 0 {
 		return errors.New("bucket-size must be greater than 0")
 	}
-	if cfg.RateWindow < cfg.BucketSize {
-		return errors.New("rate-window must be greater than or equal to bucket-size")
+	if cfg.RateWindow%cfg.BucketSize != 0 {
+		return errors.New("rate-window must be a multiple of bucket-size")
 	}
 	if cfg.EvictionInterval <= 0 {
 		return errors.New("eviction-interval must be greater than 0")

--- a/pkg/limits/consumer_test.go
+++ b/pkg/limits/consumer_test.go
@@ -85,8 +85,9 @@ func TestConsumer_ProcessRecords(t *testing.T) {
 					Partitions: []kgo.FetchPartition{{
 						Partition: 1,
 						Records: []*kgo.Record{{
-							Key:   []byte("tenant"),
-							Value: b,
+							Key:       []byte("tenant"),
+							Value:     b,
+							Timestamp: clock.Now(),
 						}},
 					}},
 				}},

--- a/pkg/limits/service_test.go
+++ b/pkg/limits/service_test.go
@@ -2,501 +2,204 @@ package limits
 
 import (
 	"context"
-	"sync"
 	"testing"
 	"time"
 
 	"github.com/coder/quartz"
 	"github.com/go-kit/log"
-	"github.com/grafana/dskit/kv"
-	"github.com/grafana/dskit/ring"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/loki/v3/pkg/kafka"
 	"github.com/grafana/loki/v3/pkg/limits/proto"
 )
 
 func TestService_ExceedsLimits(t *testing.T) {
 	clock := quartz.NewMock(t)
 	now := clock.Now()
-
 	tests := []struct {
-		name string
+		name             string
+		tenant           string
+		activeWindow     time.Duration
+		rateWindow       time.Duration
+		bucketSize       time.Duration
+		maxActiveStreams int
+		currentUsage     []streamUsage
+		request          *proto.ExceedsLimitsRequest
+		expected         *proto.ExceedsLimitsResponse
+		expectedEntries  int
+	}{{
+		// This case asserts that a tenant with no active streams is within
+		// their limits.
+		name:             "stream should be accepted",
+		tenant:           "tenant",
+		activeWindow:     DefaultActiveWindow,
+		rateWindow:       DefaultRateWindow,
+		bucketSize:       DefaultBucketSize,
+		maxActiveStreams: 1,
+		request: &proto.ExceedsLimitsRequest{
+			Tenant: "tenant",
+			Streams: []*proto.StreamMetadata{{
+				StreamHash: 0x1,
+				TotalSize:  100,
+			}},
+		},
+		expected: &proto.ExceedsLimitsResponse{
+			Results: make([]*proto.ExceedsLimitsResult, 0),
+		},
+		expectedEntries: 1,
+	}, {
+		// This test asserts that a tenant with 1 maximum active stream can
+		// push the same stream again without exceeding their limits.
+		name:             "existing stream should be updated",
+		tenant:           "tenant",
+		activeWindow:     DefaultActiveWindow,
+		rateWindow:       DefaultRateWindow,
+		bucketSize:       DefaultBucketSize,
+		maxActiveStreams: 1,
+		currentUsage: []streamUsage{{
+			hash:        0x1,
+			lastSeenAt:  now.UnixNano(),
+			totalSize:   100,
+			rateBuckets: newRateBuckets(DefaultRateWindow, DefaultBucketSize),
+		}},
+		request: &proto.ExceedsLimitsRequest{
+			Tenant: "tenant",
+			Streams: []*proto.StreamMetadata{{
+				StreamHash: 0x1,
+				TotalSize:  100,
+			}},
+		},
+		expected: &proto.ExceedsLimitsResponse{
+			Results: make([]*proto.ExceedsLimitsResult, 0),
+		},
+		expectedEntries: 1,
+	}, {
+		// This test asserts that a tenant that has reached their maximum
+		// number of active streams cannot push new streams.
+		name:             "new stream over limit should be rejected",
+		tenant:           "tenant",
+		activeWindow:     DefaultActiveWindow,
+		rateWindow:       DefaultRateWindow,
+		bucketSize:       DefaultBucketSize,
+		maxActiveStreams: 1,
+		currentUsage: []streamUsage{{
+			hash:        0x1,
+			lastSeenAt:  now.UnixNano(),
+			totalSize:   100,
+			rateBuckets: newRateBuckets(DefaultRateWindow, DefaultBucketSize),
+		}},
+		request: &proto.ExceedsLimitsRequest{
+			Tenant: "tenant",
+			Streams: []*proto.StreamMetadata{{
+				StreamHash: 0x2,
+				TotalSize:  100,
+			}},
+		},
+		expected: &proto.ExceedsLimitsResponse{
+			Results: []*proto.ExceedsLimitsResult{{
+				StreamHash: 0x2,
+				Reason:     uint32(ReasonExceedsMaxStreams),
+			}},
+		},
+		expectedEntries: 1,
+	}, {
+		// This test asserts that an expired stream is not counted towards
+		// the max active stream limit.
+		name:             "expired stream should be re-refreshed",
+		tenant:           "tenant",
+		activeWindow:     DefaultActiveWindow,
+		rateWindow:       DefaultRateWindow,
+		bucketSize:       DefaultBucketSize,
+		maxActiveStreams: 1,
+		currentUsage: []streamUsage{{
+			hash:        0x1,
+			lastSeenAt:  now.Add(-DefaultActiveWindow - 1).UnixNano(),
+			totalSize:   100,
+			rateBuckets: newRateBuckets(DefaultRateWindow, DefaultBucketSize),
+		}},
+		request: &proto.ExceedsLimitsRequest{
+			Tenant: "tenant",
+			Streams: []*proto.StreamMetadata{{
+				StreamHash: 0x2,
+				TotalSize:  100,
+			}},
+		},
+		expected: &proto.ExceedsLimitsResponse{
+			Results: make([]*proto.ExceedsLimitsResult, 0),
+		},
+		expectedEntries: 2,
+	}, {
+		// This test asserts that an expired stream (outside the active window)
+		// is refreshed and re-used.
+		name:             "expired stream should be re-refreshed",
+		tenant:           "tenant",
+		activeWindow:     DefaultActiveWindow,
+		rateWindow:       DefaultRateWindow,
+		bucketSize:       DefaultBucketSize,
+		maxActiveStreams: 1,
+		currentUsage: []streamUsage{{
+			hash:        0x1,
+			lastSeenAt:  now.Add(-DefaultActiveWindow - 1).UnixNano(),
+			totalSize:   100,
+			rateBuckets: newRateBuckets(DefaultRateWindow, DefaultBucketSize),
+		}},
+		request: &proto.ExceedsLimitsRequest{
+			Tenant: "tenant",
+			Streams: []*proto.StreamMetadata{{
+				StreamHash: 0x1,
+				TotalSize:  100,
+			}},
+		},
+		expected: &proto.ExceedsLimitsResponse{
+			Results: make([]*proto.ExceedsLimitsResult, 0),
+		},
+		expectedEntries: 1,
+	}}
 
-		// Setup data.
-		assignedPartitions []int32
-		numPartitions      int
-		usage              *usageStore
-		ActiveWindow       time.Duration
-		rateWindow         time.Duration
-		BucketSize         time.Duration
-		maxActiveStreams   int
-
-		// Request data for ExceedsLimits.
-		tenantID string
-		streams  []*proto.StreamMetadata
-
-		// Expectations.
-		expectedIngestedBytes float64
-		expectedResults       []*proto.ExceedsLimitsResult
-		expectedNumRecords    int
-	}{
-		{
-			name: "tenant not found",
-			// setup data
-			assignedPartitions: []int32{0},
-			numPartitions:      1,
-			usage: &usageStore{
-				numPartitions: 1,
-				stripes: []map[string]tenantUsage{
-					{
-						"tenant1": {
-							0: {
-								0x4: {hash: 0x4, lastSeenAt: now.UnixNano(), totalSize: 1000, rateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 1000}}},
-								0x5: {hash: 0x5, lastSeenAt: now.UnixNano(), totalSize: 2000, rateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 2000}}},
-							},
-						},
-					},
-				},
-				locks: make([]stripeLock, 1),
-			},
-			ActiveWindow:     time.Hour,
-			rateWindow:       5 * time.Minute,
-			BucketSize:       time.Minute,
-			maxActiveStreams: 10,
-			// request data
-			tenantID: "tenant2",
-			streams: []*proto.StreamMetadata{
-				{
-					StreamHash: 0x2,
-					TotalSize:  1010,
-				},
-			},
-			// expect data
-			expectedIngestedBytes: 1010,
-			expectedNumRecords:    1,
-		},
-		{
-			name: "all existing streams still active",
-			// setup data
-			assignedPartitions: []int32{0},
-			numPartitions:      1,
-			usage: &usageStore{
-				numPartitions: 1,
-				stripes: []map[string]tenantUsage{
-					{
-						"tenant1": {
-							0: {
-								1: {hash: 1, lastSeenAt: now.UnixNano(), totalSize: 1000, rateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 1000}}},
-								2: {hash: 2, lastSeenAt: now.UnixNano(), totalSize: 2000, rateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 2000}}},
-								3: {hash: 3, lastSeenAt: now.UnixNano(), totalSize: 3000, rateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 3000}}},
-								4: {hash: 4, lastSeenAt: now.UnixNano(), totalSize: 4000, rateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 4000}}},
-							},
-						},
-					},
-				},
-				locks: make([]stripeLock, 1),
-			},
-			ActiveWindow: time.Hour,
-			rateWindow:   5 * time.Minute,
-			BucketSize:   time.Minute,
-			// request data
-			tenantID:         "tenant1",
-			maxActiveStreams: 10,
-			streams: []*proto.StreamMetadata{
-				{StreamHash: 0x1, TotalSize: 1010},
-				{StreamHash: 0x2, TotalSize: 1010},
-				{StreamHash: 0x3, TotalSize: 1010},
-				{StreamHash: 0x4, TotalSize: 1010},
-			},
-			// expect data
-			expectedIngestedBytes: 4040,
-			expectedNumRecords:    4,
-		},
-		{
-			name: "keep existing active streams and drop new streams",
-			// setup data
-			assignedPartitions: []int32{0},
-			numPartitions:      1,
-			usage: &usageStore{
-				numPartitions: 1,
-				stripes: []map[string]tenantUsage{
-					{
-						"tenant1": {
-							0: {
-								0x1: {hash: 0x1, lastSeenAt: now.UnixNano(), totalSize: 1000, rateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 1000}}},
-								0x3: {hash: 0x3, lastSeenAt: now.UnixNano(), totalSize: 3000, rateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 3000}}},
-								0x5: {hash: 0x5, lastSeenAt: now.UnixNano(), totalSize: 5000, rateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 5000}}},
-							},
-						},
-					},
-				},
-				locks: make([]stripeLock, 1),
-			},
-			ActiveWindow:     time.Hour,
-			rateWindow:       5 * time.Minute,
-			BucketSize:       time.Minute,
-			maxActiveStreams: 3,
-			// request data
-			tenantID: "tenant1",
-			streams: []*proto.StreamMetadata{
-				{StreamHash: 0x2, TotalSize: 1010},
-				{StreamHash: 0x4, TotalSize: 1010},
-			},
-			// expect data
-			expectedIngestedBytes: 0,
-			expectedResults: []*proto.ExceedsLimitsResult{
-				{StreamHash: 0x2, Reason: uint32(ReasonExceedsMaxStreams)},
-				{StreamHash: 0x4, Reason: uint32(ReasonExceedsMaxStreams)},
-			},
-		},
-		{
-			name: "update existing active streams and drop new streams",
-			// setup data
-			assignedPartitions: []int32{0},
-			numPartitions:      1,
-			usage: &usageStore{
-				numPartitions: 1,
-				stripes: []map[string]tenantUsage{
-					{
-						"tenant1": {
-							0: {
-								0x1: {hash: 0x1, lastSeenAt: now.UnixNano(), totalSize: 1000, rateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 1000}}},
-								0x3: {hash: 0x3, lastSeenAt: now.UnixNano(), totalSize: 3000, rateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 3000}}},
-								0x5: {hash: 0x5, lastSeenAt: now.UnixNano(), totalSize: 5000, rateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 5000}}},
-							},
-						},
-					},
-				},
-				locks: make([]stripeLock, 1),
-			},
-			ActiveWindow:     time.Hour,
-			rateWindow:       5 * time.Minute,
-			BucketSize:       time.Minute,
-			maxActiveStreams: 3,
-			// request data
-			tenantID: "tenant1",
-			streams: []*proto.StreamMetadata{
-				{StreamHash: 0x1, TotalSize: 1010},
-				{StreamHash: 0x2, TotalSize: 1010},
-				{StreamHash: 0x3, TotalSize: 1010},
-				{StreamHash: 0x4, TotalSize: 1010},
-				{StreamHash: 0x5, TotalSize: 1010},
-			},
-			// expect data
-			expectedIngestedBytes: 3030,
-			expectedResults: []*proto.ExceedsLimitsResult{
-				{StreamHash: 0x2, Reason: uint32(ReasonExceedsMaxStreams)},
-				{StreamHash: 0x4, Reason: uint32(ReasonExceedsMaxStreams)},
-			},
-			expectedNumRecords: 3,
-		},
-		{
-			name: "update active streams and re-activate expired streams",
-			// setup data
-			assignedPartitions: []int32{0},
-			numPartitions:      1,
-			usage: &usageStore{
-				numPartitions: 1,
-				stripes: []map[string]tenantUsage{
-					{
-						"tenant1": {
-							0: {
-								0x1: {hash: 0x1, lastSeenAt: now.UnixNano(), totalSize: 1000, rateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 1000}}},
-								0x2: {hash: 0x2, lastSeenAt: now.Add(-120 * time.Minute).UnixNano(), totalSize: 2000, rateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 2000}}},
-								0x3: {hash: 0x3, lastSeenAt: now.UnixNano(), totalSize: 3000, rateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 3000}}},
-								0x4: {hash: 0x4, lastSeenAt: now.Add(-120 * time.Minute).UnixNano(), totalSize: 4000, rateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 4000}}},
-								0x5: {hash: 0x5, lastSeenAt: now.UnixNano(), totalSize: 5000, rateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 5000}}},
-							},
-						},
-					},
-				},
-				locks: make([]stripeLock, 1),
-			},
-			ActiveWindow:     time.Hour,
-			rateWindow:       5 * time.Minute,
-			BucketSize:       time.Minute,
-			maxActiveStreams: 5,
-			// request data
-			tenantID: "tenant1",
-			streams: []*proto.StreamMetadata{
-				{StreamHash: 0x1, TotalSize: 1010},
-				{StreamHash: 0x2, TotalSize: 1010},
-				{StreamHash: 0x3, TotalSize: 1010},
-				{StreamHash: 0x4, TotalSize: 1010},
-				{StreamHash: 0x5, TotalSize: 1010},
-			},
-			// expect data
-			expectedIngestedBytes: 5050,
-			expectedNumRecords:    5,
-		},
-		{
-			name: "drop streams per partition limit",
-			// setup data
-			assignedPartitions: []int32{0, 1},
-			numPartitions:      2,
-			usage: &usageStore{
-				numPartitions: 2,
-				locks:         make([]stripeLock, 2),
-				stripes: []map[string]tenantUsage{
-					make(map[string]tenantUsage),
-					make(map[string]tenantUsage),
-				},
-			},
-			ActiveWindow:     time.Hour,
-			rateWindow:       5 * time.Minute,
-			BucketSize:       time.Minute,
-			maxActiveStreams: 3,
-			// request data
-			tenantID: "tenant1",
-			streams: []*proto.StreamMetadata{
-				{StreamHash: 0x1, TotalSize: 1010},
-				{StreamHash: 0x2, TotalSize: 1010},
-				{StreamHash: 0x3, TotalSize: 1010},
-				{StreamHash: 0x4, TotalSize: 1010},
-			},
-			// expect data
-			expectedIngestedBytes: 2020,
-			expectedResults: []*proto.ExceedsLimitsResult{
-				{StreamHash: 0x3, Reason: uint32(ReasonExceedsMaxStreams)},
-				{StreamHash: 0x4, Reason: uint32(ReasonExceedsMaxStreams)},
-			},
-			expectedNumRecords: 2,
-		},
-		{
-			name: "skip streams assigned to partitions not owned by instance but enforce limit",
-			// setup data
-			assignedPartitions: []int32{0},
-			numPartitions:      2,
-			usage: &usageStore{
-				numPartitions: 1,
-				locks:         make([]stripeLock, 2),
-				stripes: []map[string]tenantUsage{
-					make(map[string]tenantUsage),
-					make(map[string]tenantUsage),
-				},
-			},
-			ActiveWindow:     time.Hour,
-			rateWindow:       5 * time.Minute,
-			BucketSize:       time.Minute,
-			maxActiveStreams: 3,
-			// request data
-			tenantID: "tenant1",
-			streams: []*proto.StreamMetadata{
-				{StreamHash: 0x1, TotalSize: 1010}, // Unassigned
-				{StreamHash: 0x2, TotalSize: 1010}, // Assigned
-				{StreamHash: 0x3, TotalSize: 1010}, // Unassigned
-				{StreamHash: 0x4, TotalSize: 1010}, // Assigned  but exceeds stream limit
-			},
-			// expect data
-			expectedIngestedBytes: 1010,
-			expectedResults: []*proto.ExceedsLimitsResult{
-				{StreamHash: 0x4, Reason: uint32(ReasonExceedsMaxStreams)},
-			},
-			expectedNumRecords: 1,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
 			reg := prometheus.NewRegistry()
-			limits := &MockLimits{
-				MaxGlobalStreams: tt.maxActiveStreams,
+			cfg := Config{
+				ActiveWindow:  test.activeWindow,
+				RateWindow:    test.rateWindow,
+				BucketSize:    test.bucketSize,
+				NumPartitions: 1,
 			}
-
-			kafkaClient := mockKafka{}
-
+			limits := MockLimits{
+				MaxGlobalStreams: test.maxActiveStreams,
+			}
+			store, err := newUsageStore(cfg.ActiveWindow, cfg.RateWindow, cfg.BucketSize, cfg.NumPartitions, reg)
+			require.NoError(t, err)
+			store.clock = clock
+			for _, stream := range test.currentUsage {
+				store.set(test.tenant, stream)
+			}
 			m, err := newPartitionManager(reg)
 			require.NoError(t, err)
-
-			s := &Service{
-				cfg: Config{
-					NumPartitions: tt.numPartitions,
-					ActiveWindow:  tt.ActiveWindow,
-					RateWindow:    tt.rateWindow,
-					BucketSize:    tt.BucketSize,
-					LifecyclerConfig: ring.LifecyclerConfig{
-						RingConfig: ring.Config{
-							KVStore: kv.Config{
-								Store: "inmemory",
-							},
-							ReplicationFactor: 1,
-						},
-						NumTokens:       1,
-						ID:              "test",
-						Zone:            "test",
-						FinalSleep:      0,
-						HeartbeatPeriod: 100 * time.Millisecond,
-						ObservePeriod:   100 * time.Millisecond,
-					},
-				},
+			for i := 0; i < cfg.NumPartitions; i++ {
+				m.Assign([]int32{int32(i)})
+			}
+			m.clock = clock
+			service := &Service{
+				cfg:              cfg,
+				limits:           &limits,
+				usage:            store,
+				partitionManager: m,
+				producer:         newProducer(&mockKafka{}, "test", cfg.NumPartitions, "", log.NewNopLogger(), reg),
 				logger:           log.NewNopLogger(),
 				metrics:          newMetrics(reg),
-				limits:           limits,
-				usage:            tt.usage,
-				partitionManager: m,
 				clock:            clock,
-				producer:         newProducer(&kafkaClient, "test", tt.numPartitions, "", log.NewNopLogger(), reg),
 			}
 
-			// Assign the Partition IDs.
-			s.partitionManager.Assign(tt.assignedPartitions)
-
-			// Call ExceedsLimits.
-			req := &proto.ExceedsLimitsRequest{
-				Tenant:  tt.tenantID,
-				Streams: tt.streams,
-			}
-
-			resp, err := s.ExceedsLimits(context.Background(), req)
+			resp, err := service.ExceedsLimits(context.Background(), test.request)
 			require.NoError(t, err)
-			require.NotNil(t, resp)
-			require.ElementsMatch(t, tt.expectedResults, resp.Results)
+			require.Equal(t, test.expected, resp)
 
-			metrics, err := reg.Gather()
-			require.NoError(t, err)
-
-			for _, metric := range metrics {
-				if metric.GetName() == "loki_ingest_limits_tenant_ingested_bytes_total" {
-					require.Equal(t, tt.expectedIngestedBytes, metric.GetMetric()[0].GetCounter().GetValue())
-					break
-				}
-			}
-
-			require.Equal(t, tt.expectedNumRecords, len(kafkaClient.produced))
+			actualEntries := 0
+			store.IterTenant(test.tenant, func(_ string, _ int32, _ streamUsage) {
+				actualEntries++
+			})
+			require.Equal(t, test.expectedEntries, actualEntries)
 		})
 	}
-}
-
-func TestIngestLimits_ExceedsLimits_Concurrent(t *testing.T) {
-	clock := quartz.NewMock(t)
-	now := clock.Now()
-
-	limits := &MockLimits{
-		MaxGlobalStreams: 5,
-	}
-
-	reg := prometheus.NewRegistry()
-	kafkaClient := mockKafka{}
-
-	// Setup test data with a mix of active and expired streams>
-	usage := &usageStore{
-		numPartitions: 1,
-		stripes: []map[string]tenantUsage{
-			{
-				"tenant1": {
-					0: {
-						1: {hash: 1, lastSeenAt: now.UnixNano(), totalSize: 1000, rateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 1000}}},                        // active
-						2: {hash: 2, lastSeenAt: now.Add(-30 * time.Minute).UnixNano(), totalSize: 2000, rateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 2000}}}, // active
-						3: {hash: 3, lastSeenAt: now.Add(-2 * time.Hour).UnixNano(), totalSize: 3000},                                                                        // expired
-						4: {hash: 4, lastSeenAt: now.Add(-45 * time.Minute).UnixNano(), totalSize: 4000, rateBuckets: []rateBucket{{timestamp: now.UnixNano(), size: 4000}}}, // active
-						5: {hash: 5, lastSeenAt: now.Add(-3 * time.Hour).UnixNano(), totalSize: 5000},                                                                        // expired
-					},
-				},
-			},
-		},
-		locks: make([]stripeLock, 1),
-	}
-
-	m, err := newPartitionManager(reg)
-	require.NoError(t, err)
-
-	s := &Service{
-		cfg: Config{
-			NumPartitions: 1,
-			ActiveWindow:  time.Hour,
-			RateWindow:    5 * time.Minute,
-			BucketSize:    time.Minute,
-			LifecyclerConfig: ring.LifecyclerConfig{
-				RingConfig: ring.Config{
-					KVStore: kv.Config{
-						Store: "inmemory",
-					},
-					ReplicationFactor: 1,
-				},
-				NumTokens:       1,
-				ID:              "test",
-				Zone:            "test",
-				FinalSleep:      0,
-				HeartbeatPeriod: 100 * time.Millisecond,
-				ObservePeriod:   100 * time.Millisecond,
-			},
-		},
-		logger:           log.NewNopLogger(),
-		usage:            usage,
-		partitionManager: m,
-		metrics:          newMetrics(reg),
-		limits:           limits,
-		clock:            clock,
-		producer:         newProducer(&kafkaClient, "test", 1, "", log.NewNopLogger(), reg),
-	}
-
-	// Assign the Partition IDs.
-	s.partitionManager.Assign([]int32{0})
-
-	// Run concurrent requests
-	concurrency := 10
-	wg := sync.WaitGroup{}
-	wg.Add(concurrency)
-
-	for range concurrency {
-		go func() {
-			defer wg.Done()
-			req := &proto.ExceedsLimitsRequest{
-				Tenant:  "tenant1",
-				Streams: []*proto.StreamMetadata{{StreamHash: 1}, {StreamHash: 2}, {StreamHash: 3}, {StreamHash: 4}, {StreamHash: 5}},
-			}
-
-			resp, err := s.ExceedsLimits(context.Background(), req)
-			require.NoError(t, err)
-			require.NotNil(t, resp)
-			require.Empty(t, resp.Results)
-		}()
-	}
-
-	// Wait for all goroutines to complete
-	wg.Wait()
-	require.Equal(t, 50, len(kafkaClient.produced))
-}
-
-func TestNew(t *testing.T) {
-	cfg := Config{
-		KafkaConfig: kafka.Config{
-			WriteTimeout: 10 * time.Second,
-		},
-		ConsumerGroup: "test-consumer-group",
-		Topic:         "test-topic.metadata",
-		ActiveWindow:  time.Hour,
-		LifecyclerConfig: ring.LifecyclerConfig{
-			RingConfig: ring.Config{
-				KVStore: kv.Config{
-					Store: "inmemory",
-				},
-				ReplicationFactor: 1,
-			},
-			NumTokens:       1,
-			ID:              "test",
-			Zone:            "test",
-			FinalSleep:      0,
-			HeartbeatPeriod: 100 * time.Millisecond,
-			ObservePeriod:   100 * time.Millisecond,
-		},
-	}
-
-	limits := &MockLimits{
-		MaxGlobalStreams: 100,
-		IngestionRate:    1000,
-	}
-
-	s, err := New(cfg, limits, log.NewNopLogger(), prometheus.NewRegistry())
-	require.NoError(t, err)
-	require.NotNil(t, s)
-	require.NotNil(t, s.clientReader)
-	require.NotNil(t, s.clientWriter)
-
-	require.Equal(t, cfg, s.cfg)
-
-	require.NotNil(t, s.usage)
-	require.NotNil(t, s.lifecycler)
 }

--- a/pkg/limits/store_test.go
+++ b/pkg/limits/store_test.go
@@ -72,10 +72,70 @@ func TestUsageStore_Update(t *testing.T) {
 	}
 	// Metadata outside the active time window returns an error.
 	time1 := clock.Now().Add(-DefaultActiveWindow)
-	require.EqualError(t, s.Update("tenant1", metadata, time1), "outside active time window")
+	require.EqualError(t, s.Update("tenant", metadata, time1), "outside active time window")
 	// Metadata within the active time window is accepted.
 	time2 := clock.Now()
-	require.NoError(t, s.Update("tenant1", metadata, time2))
+	require.NoError(t, s.Update("tenant", metadata, time2))
+}
+
+// This test asserts that we update the correct rate buckets, and as rate
+// buckets are implemented as a circular list, when we reach the end of
+// list the next bucket is the start of the list.
+func TestUsageStore_UpdateRateBuckets(t *testing.T) {
+	s, err := newUsageStore(15*time.Minute, 5*time.Minute, time.Minute, 1, prometheus.NewRegistry())
+	require.NoError(t, err)
+	clock := quartz.NewMock(t)
+	s.clock = clock
+	metadata := &proto.StreamMetadata{
+		StreamHash: 0x1,
+		TotalSize:  100,
+	}
+	// Metadata at clock.Now() should update the first rate bucket because
+	// the mocked clock starts at 2024-01-01T00:00:00Z.
+	time1 := clock.Now()
+	require.NoError(t, s.Update("tenant", metadata, time1))
+	stream, ok := s.Get("tenant", 0x1)
+	require.True(t, ok)
+	expected := newRateBuckets(DefaultRateWindow, time.Minute)
+	expected[0].timestamp = time1.UnixNano()
+	expected[0].size = 100
+	require.Equal(t, expected, stream.rateBuckets)
+	// Advance the clock forward to the next bucket. Should update the second
+	// bucket and leave the first bucket unmodified.
+	clock.Advance(time.Minute)
+	time2 := clock.Now()
+	require.NoError(t, s.Update("tenant", metadata, time2))
+	stream, ok = s.Get("tenant", 0x1)
+	require.True(t, ok)
+	expected[1].timestamp = time2.UnixNano()
+	expected[1].size = 100
+	require.Equal(t, expected, stream.rateBuckets)
+	// Update the second bucket again. Its size should be incremented from 100
+	// to 200.
+	require.NoError(t, s.Update("tenant", metadata, time2))
+	stream, ok = s.Get("tenant", 0x1)
+	require.True(t, ok)
+	expected[1].size = 200
+	require.Equal(t, expected, stream.rateBuckets)
+	// Advance the clock to the last bucket.
+	clock.Advance(3 * time.Minute)
+	time3 := clock.Now()
+	require.NoError(t, s.Update("tenant", metadata, time3))
+	stream, ok = s.Get("tenant", 0x1)
+	require.True(t, ok)
+	expected[4].timestamp = time3.UnixNano()
+	expected[4].size = 100
+	require.Equal(t, expected, stream.rateBuckets)
+	// Advance the clock one last one. It should wrap around to the start of
+	// the list and replace the original bucket with time1.
+	clock.Advance(time.Minute)
+	time4 := clock.Now()
+	require.NoError(t, s.Update("tenant", metadata, time4))
+	stream, ok = s.Get("tenant", 0x1)
+	require.True(t, ok)
+	expected[0].timestamp = time4.UnixNano()
+	expected[0].size = 100
+	require.Equal(t, expected, stream.rateBuckets)
 }
 
 func TestUsageStore_UpdateBulk(t *testing.T) {
@@ -245,4 +305,8 @@ func TestUsageStore_EvictPartitions(t *testing.T) {
 		actual = append(actual, partition)
 	})
 	require.ElementsMatch(t, expected, actual)
+}
+
+func newRateBuckets(rateWindow, bucketSize time.Duration) []rateBucket {
+	return make([]rateBucket, int(rateWindow/bucketSize))
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request optimizes rate buckets to avoid re-allocating the slice on each update. Instead, all rate buckets are allocated when the stream is created, and behave as a circular buffer.

This pull request is stacked on top of:

- https://github.com/grafana/loki/pull/17858
- https://github.com/grafana/loki/pull/17899

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
