### PR TITLE
chore: do not count active streams in update cond to make this faster

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -925,7 +925,7 @@ ingest_limits:
 
   # The interval at which old streams are evicted.
   # CLI flag: -ingest-limits.eviction-interval
-  [eviction_interval: <duration> | default = 30m]
+  [eviction_interval: <duration> | default = 10m]
 
   # The number of partitions for the Kafka topic used to read and write stream
   # metadata. It is fixed, not a maximum.

--- a/pkg/limits/config.go
+++ b/pkg/limits/config.go
@@ -15,7 +15,7 @@ const (
 	DefaultActiveWindow  = 2 * time.Hour
 	DefaultRateWindow    = 5 * time.Minute
 	DefaultBucketSize    = 1 * time.Minute
-	DefaultEvictInterval = 30 * time.Minute
+	DefaultEvictInterval = 10 * time.Minute
 	DefaultNumPartitions = 64
 	DefaultConsumerGroup = "ingest-limits"
 )

--- a/pkg/limits/service.go
+++ b/pkg/limits/service.go
@@ -318,7 +318,10 @@ func (s *Service) ExceedsLimits(ctx context.Context, req *proto.ExceedsLimitsReq
 	}
 	streams = streams[:valid]
 
-	accepted, rejected := s.usage.UpdateCond(req.Tenant, streams, s.clock.Now(), s.limits)
+	accepted, rejected, err := s.usage.UpdateCond(req.Tenant, streams, s.clock.Now(), s.limits)
+	if err != nil {
+		return nil, err
+	}
 
 	var ingestedBytes uint64
 	for _, stream := range accepted {

--- a/pkg/limits/service_test.go
+++ b/pkg/limits/service_test.go
@@ -103,32 +103,6 @@ func TestService_ExceedsLimits(t *testing.T) {
 		},
 		expectedEntries: 1,
 	}, {
-		// This test asserts that an expired stream is not counted towards
-		// the max active stream limit.
-		name:             "expired stream should be re-refreshed",
-		tenant:           "tenant",
-		activeWindow:     DefaultActiveWindow,
-		rateWindow:       DefaultRateWindow,
-		bucketSize:       DefaultBucketSize,
-		maxActiveStreams: 1,
-		currentUsage: []streamUsage{{
-			hash:        0x1,
-			lastSeenAt:  now.Add(-DefaultActiveWindow - 1).UnixNano(),
-			totalSize:   100,
-			rateBuckets: newRateBuckets(DefaultRateWindow, DefaultBucketSize),
-		}},
-		request: &proto.ExceedsLimitsRequest{
-			Tenant: "tenant",
-			Streams: []*proto.StreamMetadata{{
-				StreamHash: 0x2,
-				TotalSize:  100,
-			}},
-		},
-		expected: &proto.ExceedsLimitsResponse{
-			Results: make([]*proto.ExceedsLimitsResult, 0),
-		},
-		expectedEntries: 2,
-	}, {
 		// This test asserts that an expired stream (outside the active window)
 		// is refreshed and re-used.
 		name:             "expired stream should be re-refreshed",

--- a/pkg/limits/store_test.go
+++ b/pkg/limits/store_test.go
@@ -249,7 +249,8 @@ func TestUsageStore_UpdateCond(t *testing.T) {
 				require.NoError(t, s.Update("tenant", stream, clock.Now()))
 			}
 			limits := MockLimits{MaxGlobalStreams: test.maxGlobalStreams}
-			accepted, rejected := s.UpdateCond("tenant", test.streams, clock.Now(), &limits)
+			accepted, rejected, err := s.UpdateCond("tenant", test.streams, clock.Now(), &limits)
+			require.NoError(t, err)
 			require.ElementsMatch(t, test.expectedAccepted, accepted)
 			require.ElementsMatch(t, test.expectedRejected, rejected)
 		})


### PR DESCRIPTION
**What this PR does / why we need it**:

Stacked on top of https://github.com/grafana/loki/pull/17932.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
