### PR TITLE
chore: MockLimits should be package private

### DIFF
--- a/pkg/limits/mock_test.go
+++ b/pkg/limits/mock_test.go
@@ -7,20 +7,20 @@ import (
 	"github.com/twmb/franz-go/pkg/kgo"
 )
 
-type MockLimits struct {
+type mockLimits struct {
 	MaxGlobalStreams int
 	IngestionRate    float64
 }
 
-func (m *MockLimits) MaxGlobalStreamsPerUser(_ string) int {
+func (m *mockLimits) MaxGlobalStreamsPerUser(_ string) int {
 	return m.MaxGlobalStreams
 }
 
-func (m *MockLimits) IngestionRateBytes(_ string) float64 {
+func (m *mockLimits) IngestionRateBytes(_ string) float64 {
 	return m.IngestionRate
 }
 
-func (m *MockLimits) IngestionBurstSizeBytes(_ string) int {
+func (m *mockLimits) IngestionBurstSizeBytes(_ string) int {
 	return 1000
 }
 

--- a/pkg/limits/service_test.go
+++ b/pkg/limits/service_test.go
@@ -165,7 +165,7 @@ func TestService_ExceedsLimits(t *testing.T) {
 				BucketSize:    test.bucketSize,
 				NumPartitions: 1,
 			}
-			limits := MockLimits{
+			limits := mockLimits{
 				MaxGlobalStreams: test.maxActiveStreams,
 			}
 			store, err := newUsageStore(cfg.ActiveWindow, cfg.RateWindow, cfg.BucketSize, cfg.NumPartitions, reg)


### PR DESCRIPTION
**What this PR does / why we need it**:

`MockLimits` should be `mockLimits`.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
