### PR TITLE
chore: remove deprecated config

### DIFF
--- a/pkg/limits/config.go
+++ b/pkg/limits/config.go
@@ -52,10 +52,6 @@ type Config struct {
 	KafkaConfig      kafka.Config          `yaml:"-"`
 	ConsumerGroup    string                `yaml:"consumer_group"`
 	Topic            string                `yaml:"topic"`
-
-	// Deprecated.
-	WindowSize     time.Duration `yaml:"window_size" doc:"hidden|deprecated"`
-	BucketDuration time.Duration `yaml:"bucket_duration" doc:"hidden|deprecated"`
 }
 
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request removes the deprecated configurations `WindowSize` and `BucketDuration`.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
