### PR TITLE
chore: remove MetadataTopic as it is unused

### DIFF
--- a/pkg/limits/service.go
+++ b/pkg/limits/service.go
@@ -28,11 +28,6 @@ const (
 	RingName = "ingest-limits"
 )
 
-// MetadataTopic returns the metadata topic name for the given topic.
-func MetadataTopic(topic string) string {
-	return topic + ".metadata"
-}
-
 type metrics struct {
 	tenantStreamEvictionsTotal *prometheus.CounterVec
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit removes `MetadataTopic` as it is no longer used.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
