### PR TITLE
chore: faillint usage of opentracing in make lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -373,13 +373,18 @@ else
 	go version
 	golangci-lint version
 	GO111MODULE=on golangci-lint run -v --timeout 15m --build-tags linux,promtail_journal_enabled
-	faillint \
-		-paths "sync/atomic=go.uber.org/atomic" \
+	faillint -paths \
+		"sync/atomic=go.uber.org/atomic" \
 		./...
 
 	# Use our spanlogger implementation instead of the one in dskit to make sure we use the correct tracing lib.
-	faillint \
-		-paths "github.com/grafana/dskit/spanlogger=github.com/grafana/loki/pkg/util/spanlogger" \
+	faillint -paths \
+		"github.com/grafana/dskit/spanlogger=github.com/grafana/loki/pkg/util/spanlogger" \
+		./...
+
+	# We don't use opentracing anymore.
+	faillint -paths \
+		"github.com/opentracing/opentracing-go,github.com/opentracing/opentracing-go/log,github.com/uber/jaeger-client-go,github.com/opentracing-contrib/go-stdlib/nethttp" \
 		./...
 endif
 


### PR DESCRIPTION
**What this PR does / why we need it**:

We don't use OpenTracing anymore, we want to prevent anyone from accidentally creating traces with that library, the best way to do it is to have a faillint rule.

**Which issue(s) this PR fixes**:

Ref: https://github.com/grafana/loki/issues/6812

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
