### PR TITLE
fix: avoid memory allocations when loading symbolizer from a flushed chunk

### DIFF
--- a/pkg/chunkenc/symbols.go
+++ b/pkg/chunkenc/symbols.go
@@ -38,7 +38,7 @@ type symbols []symbol
 // symbols are actually index numbers assigned based on when the entry is seen for the first time.
 type symbolizer struct {
 	mtx            sync.RWMutex
-	symbolsMap     map[string]uint32
+	symbolsMap     map[string]uint32 // symbolsMap is only used on the write path for deduping symbol writes
 	labels         []string
 	size           int
 	compressedSize int

--- a/pkg/chunkenc/unordered.go
+++ b/pkg/chunkenc/unordered.go
@@ -140,24 +140,18 @@ func (hb *unorderedHeadBlock) Append(ts int64, line string, structuredMetadata l
 				return true, nil
 			}
 		}
-		var symbols symbols
-		if !structuredMetadata.IsEmpty() {
-			var err error
-			symbols, err = hb.symbolizer.Add(structuredMetadata)
-			if err != nil {
-				return false, err
-			}
+		symbols, err := hb.symbolizer.Add(structuredMetadata)
+		if err != nil {
+			return false, err
 		}
+
 		e.entries = append(displaced[0].(*nsEntries).entries, nsEntry{line, symbols})
 	} else {
-		var symbols symbols
-		if !structuredMetadata.IsEmpty() {
-			var err error
-			symbols, err = hb.symbolizer.Add(structuredMetadata)
-			if err != nil {
-				return false, err
-			}
+		symbols, err := hb.symbolizer.Add(structuredMetadata)
+		if err != nil {
+			return false, err
 		}
+
 		e.entries = []nsEntry{{line, symbols}}
 	}
 
@@ -661,7 +655,7 @@ func HeadFromCheckpoint(b []byte, desiredIfNotUnordered HeadBlockFmt, symbolizer
 	}
 
 	if decodedBlock.Format() < UnorderedHeadBlockFmt && decodedBlock.Format() != desiredIfNotUnordered {
-		return decodedBlock.Convert(desiredIfNotUnordered, nil)
+		return decodedBlock.Convert(desiredIfNotUnordered, symbolizer)
 	}
 	return decodedBlock, nil
 }

--- a/pkg/chunkenc/unordered.go
+++ b/pkg/chunkenc/unordered.go
@@ -140,9 +140,25 @@ func (hb *unorderedHeadBlock) Append(ts int64, line string, structuredMetadata l
 				return true, nil
 			}
 		}
-		e.entries = append(displaced[0].(*nsEntries).entries, nsEntry{line, hb.symbolizer.Add(structuredMetadata)})
+		var symbols symbols
+		if !structuredMetadata.IsEmpty() {
+			var err error
+			symbols, err = hb.symbolizer.Add(structuredMetadata)
+			if err != nil {
+				return false, err
+			}
+		}
+		e.entries = append(displaced[0].(*nsEntries).entries, nsEntry{line, symbols})
 	} else {
-		e.entries = []nsEntry{{line, hb.symbolizer.Add(structuredMetadata)}}
+		var symbols symbols
+		if !structuredMetadata.IsEmpty() {
+			var err error
+			symbols, err = hb.symbolizer.Add(structuredMetadata)
+			if err != nil {
+				return false, err
+			}
+		}
+		e.entries = []nsEntry{{line, symbols}}
 	}
 
 	// Update hb metdata

--- a/pkg/chunkenc/unordered_test.go
+++ b/pkg/chunkenc/unordered_test.go
@@ -297,7 +297,7 @@ func Test_UnorderedBoundedIter(t *testing.T) {
 }
 
 func TestHeadBlockInterop(t *testing.T) {
-	unordered, ordered := newUnorderedHeadBlock(UnorderedHeadBlockFmt, nil), &headBlock{}
+	unordered, ordered := newUnorderedHeadBlock(UnorderedHeadBlockFmt, newSymbolizer()), &headBlock{}
 	unorderedWithStructuredMetadata := newUnorderedHeadBlock(UnorderedWithStructuredMetadataHeadBlockFmt, newSymbolizer())
 	for i := 0; i < 100; i++ {
 		metaLabels := labels.FromStrings("foo", fmt.Sprint(99-i))
@@ -326,29 +326,31 @@ func TestHeadBlockInterop(t *testing.T) {
 	require.Equal(t, ordered, recovered)
 
 	// Ensure we can recover ordered checkpoint into unordered headblock
-	recovered, err = HeadFromCheckpoint(orderedCheckpointBytes, UnorderedHeadBlockFmt, nil)
+	recovered, err = HeadFromCheckpoint(orderedCheckpointBytes, UnorderedHeadBlockFmt, newSymbolizer())
 	require.Nil(t, err)
 	require.Equal(t, unordered, recovered)
 
 	// Ensure we can recover ordered checkpoint into unordered headblock with structured metadata
-	recovered, err = HeadFromCheckpoint(orderedCheckpointBytes, UnorderedWithStructuredMetadataHeadBlockFmt, nil)
+	symbolizer := newSymbolizer()
+	recovered, err = HeadFromCheckpoint(orderedCheckpointBytes, UnorderedWithStructuredMetadataHeadBlockFmt, symbolizer)
 	require.NoError(t, err)
 	require.Equal(t, &unorderedHeadBlock{
-		format: UnorderedWithStructuredMetadataHeadBlockFmt,
-		rt:     unordered.rt,
-		lines:  unordered.lines,
-		size:   unordered.size,
-		mint:   unordered.mint,
-		maxt:   unordered.maxt,
+		format:     UnorderedWithStructuredMetadataHeadBlockFmt,
+		rt:         unordered.rt,
+		lines:      unordered.lines,
+		size:       unordered.size,
+		mint:       unordered.mint,
+		maxt:       unordered.maxt,
+		symbolizer: symbolizer,
 	}, recovered)
 
 	// Ensure we can recover unordered checkpoint into unordered headblock
-	recovered, err = HeadFromCheckpoint(unorderedCheckpointBytes, UnorderedHeadBlockFmt, nil)
+	recovered, err = HeadFromCheckpoint(unorderedCheckpointBytes, UnorderedHeadBlockFmt, newSymbolizer())
 	require.Nil(t, err)
 	require.Equal(t, unordered, recovered)
 
 	// Ensure trying to recover unordered checkpoint into unordered with structured metadata keeps it in unordered format
-	recovered, err = HeadFromCheckpoint(unorderedCheckpointBytes, UnorderedWithStructuredMetadataHeadBlockFmt, nil)
+	recovered, err = HeadFromCheckpoint(unorderedCheckpointBytes, UnorderedWithStructuredMetadataHeadBlockFmt, newSymbolizer())
 	require.NoError(t, err)
 	require.Equal(t, unordered, recovered)
 
@@ -754,7 +756,7 @@ func Test_HeadIteratorHash(t *testing.T) {
 	require.NoError(t, err)
 
 	for name, b := range map[string]HeadBlock{
-		"unordered":                          newUnorderedHeadBlock(UnorderedHeadBlockFmt, nil),
+		"unordered":                          newUnorderedHeadBlock(UnorderedHeadBlockFmt, newSymbolizer()),
 		"unordered with structured metadata": newUnorderedHeadBlock(UnorderedWithStructuredMetadataHeadBlockFmt, newSymbolizer()),
 		"ordered":                            &headBlock{},
 	} {


### PR DESCRIPTION
**What this PR does / why we need it**:
When loading a symbolizer from a flushed chunk, we unnecessarily allocate a map that holds entries only to dedupe the data while writing to a chunk. This PR fixes the issue by removing those unwanted allocations and rejecting any writes when the symbolizer is loaded from a flushed chunk. 

**Checklist**
- [x] Tests updated