### PR TITLE
chore(dataobj): Use pooled buffers when decoding pages

### DIFF
--- a/pkg/dataobj/internal/dataset/page_reader.go
+++ b/pkg/dataobj/internal/dataset/page_reader.go
@@ -296,6 +296,13 @@ func (pr *pageReader) Close() error {
 		pr.closer = nil
 		return err
 	}
+
+	// After closing the reader, we reset the valuesReader to make sure it isn't
+	// holding onto the reference to pr.closer.
+	if pr.valuesReader != nil {
+		pr.valuesReader.Reset(nil)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
This follows up on the work started in #17841, where pages are immediately decompressed on opening a reader, rather than streaming decompression as values are read.

Allocating a new buffer for every page dramatically increased the number of allocations needed for a query by 273%.

While upfront decompression will always require more allocations, pooling buffers reduces the allocation overhead from 273% down to 13%.

      goos: darwin
      goarch: arm64
      pkg: github.com/grafana/loki/v3/pkg/logql/bench
      cpu: Apple M1 Max
                                                                                                                                              │  streaming   │                upfront                │            upfront-pooled             │
                                                                                                                                              │    sec/op    │    sec/op      vs base                │    sec/op      vs base                │
      sum_by_(cluster,_namespace)_(rate({region="ap-southeast-1",_env="dev"}_|_detected_level=~"error|warn"_[5m]))                               1.159 ±  4%     1.232 ±  6%   +6.24% (p=0.009 n=10)     1.181 ±  5%        ~ (p=0.190 n=10)
      sum_by_(cluster,_namespace)_(rate({region="ap-southeast-1"}_|_detected_level=~"error|warn"_[5m]))                                          1.824 ± 17%     1.808 ±  2%        ~ (p=0.247 n=10)     1.791 ±  2%        ~ (p=0.063 n=10)
      sum_by_(cluster,_namespace)_(rate({service_name="grafana",_env="prod",_region="us-west-2"}_|_detected_level=~"error|warn"_[5m]))          315.2m ±  3%    341.6m ±  4%   +8.37% (p=0.000 n=10)    338.0m ±  2%   +7.24% (p=0.000 n=10)
      sum_by_(cluster,_namespace)_(rate({service_name="kubernetes"}_|_detected_level=~"error|warn"_[5m]))                                        1.031 ±  1%     1.076 ±  2%   +4.34% (p=0.000 n=10)     1.037 ±  1%        ~ (p=0.190 n=10)
      sum_by_(component)_(rate({region="ap-southeast-1",_env="dev"}_|_detected_level="error"_[5m]))                                              1.105 ±  2%     1.156 ±  2%   +4.64% (p=0.000 n=10)     1.116 ±  1%        ~ (p=0.063 n=10)
      sum_by_(component)_(rate({region="ap-southeast-1",_env="dev"}_|_detected_level="warn"_[5m]))                                               1.112 ±  2%     1.161 ±  2%   +4.44% (p=0.000 n=10)     1.126 ±  1%        ~ (p=0.105 n=10)
      sum_by_(component)_(rate({region="ap-southeast-1"}_|_detected_level="error"_[5m]))                                                         1.674 ±  4%     1.691 ±  3%        ~ (p=0.247 n=10)     1.658 ±  1%   -0.92% (p=0.004 n=10)
      sum_by_(component)_(rate({region="ap-southeast-1"}_|_detected_level="warn"_[5m]))                                                          1.653 ±  1%     1.690 ±  2%   +2.21% (p=0.000 n=10)     1.645 ±  1%        ~ (p=0.123 n=10)
      sum_by_(component)_(rate({service_name="grafana",_env="prod",_region="us-west-2"}_|_detected_level="error"_[5m]))                         315.0m ±  2%    347.3m ±  4%  +10.26% (p=0.002 n=10)    333.4m ±  1%   +5.82% (p=0.002 n=10)
      sum_by_(component)_(rate({service_name="grafana",_env="prod",_region="us-west-2"}_|_detected_level="warn"_[5m]))                          314.0m ±  1%    350.5m ±  4%  +11.63% (p=0.000 n=10)    333.9m ±  1%   +6.33% (p=0.002 n=10)
      sum_by_(component)_(rate({service_name="kubernetes"}_|_detected_level="error"_[5m]))                                                      989.4m ±  1%   1085.0m ±  3%   +9.66% (p=0.000 n=10)   1008.8m ±  1%   +1.96% (p=0.002 n=10)
      sum_by_(component)_(rate({service_name="kubernetes"}_|_detected_level="warn"_[5m]))                                                       998.0m ±  2%   1081.6m ±  3%   +8.38% (p=0.000 n=10)   1011.0m ±  1%   +1.30% (p=0.035 n=10)
      sum_by_(component,_detected_level)_(rate({region="ap-southeast-1",_env="dev"}_|_detected_level=~"error|warn"_[5m]))                        1.145 ±  1%     1.221 ±  6%   +6.67% (p=0.000 n=10)     1.164 ±  1%   +1.71% (p=0.000 n=10)
      sum_by_(component,_detected_level)_(rate({region="ap-southeast-1"}_|_detected_level=~"error|warn"_[5m]))                                   1.837 ±  1%     1.865 ±  3%   +1.56% (p=0.001 n=10)     1.805 ±  1%   -1.71% (p=0.001 n=10)
      sum_by_(component,_detected_level)_(rate({region="ap-southeast-1"}[1m]))                                                                   1.525 ±  1%     1.566 ±  1%   +2.68% (p=0.002 n=10)     1.521 ±  2%        ~ (p=0.089 n=10)
      sum_by_(component,_detected_level)_(rate({service_name="grafana",_env="prod",_region="us-west-2"}_|_detected_level=~"error|warn"_[5m]))   316.6m ±  2%    350.2m ±  2%  +10.62% (p=0.000 n=10)    338.6m ±  1%   +6.93% (p=0.000 n=10)
      sum_by_(component,_detected_level)_(rate({service_name="kubernetes"}_|_detected_level=~"error|warn"_[5m]))                                 1.026 ±  2%     1.094 ±  2%   +6.69% (p=0.000 n=10)     1.083 ±  3%   +5.58% (p=0.000 n=10)
      sum_by_(env)_(rate({region="ap-southeast-1",_env="dev"}_|_detected_level=~"error|warn"_[5m]))                                              1.138 ±  1%     1.209 ±  3%   +6.21% (p=0.000 n=10)     1.173 ±  4%   +3.08% (p=0.000 n=10)
      sum_by_(env)_(rate({region="ap-southeast-1"}_|_detected_level=~"error|warn"_[5m]))                                                         1.799 ±  1%     1.844 ±  1%   +2.49% (p=0.000 n=10)     1.792 ±  1%        ~ (p=0.247 n=10)
      sum_by_(env)_(rate({service_name="grafana",_env="prod",_region="us-west-2"}_|_detected_level=~"error|warn"_[5m]))                         318.3m ±  1%    350.9m ±  4%  +10.23% (p=0.000 n=10)    337.8m ±  1%   +6.12% (p=0.000 n=10)
      sum_by_(env)_(rate({service_name="kubernetes"}_|_detected_level=~"error|warn"_[5m]))                                                       1.022 ±  1%     1.118 ±  3%   +9.38% (p=0.000 n=10)     1.047 ±  1%   +2.44% (p=0.000 n=10)
      sum_by_(env,_component)_(rate({region="ap-southeast-1",_env="dev"}_|_detected_level=~"error|warn"_[5m]))                                   1.134 ±  1%     1.223 ±  2%   +7.89% (p=0.000 n=10)     1.163 ±  1%   +2.58% (p=0.000 n=10)
      sum_by_(env,_component)_(rate({region="ap-southeast-1"}_|_detected_level=~"error|warn"_[5m]))                                              1.807 ±  1%     1.861 ±  2%   +3.00% (p=0.000 n=10)     1.789 ±  1%   -0.98% (p=0.007 n=10)
      sum_by_(env,_component)_(rate({service_name="grafana",_env="prod",_region="us-west-2"}_|_detected_level=~"error|warn"_[5m]))              320.0m ±  2%    352.0m ±  7%   +9.98% (p=0.000 n=10)    338.1m ±  1%   +5.63% (p=0.000 n=10)
      sum_by_(env,_component)_(rate({service_name="kubernetes"}_|_detected_level=~"error|warn"_[5m]))                                            1.027 ±  2%     1.106 ±  4%   +7.66% (p=0.000 n=10)     1.055 ±  2%   +2.68% (p=0.000 n=10)
      sum_by_(namespace)_(rate({region="ap-southeast-1",_env="dev"}_|_detected_level=~"error|warn"_[5m]))                                        1.142 ±  1%     1.231 ±  2%   +7.84% (p=0.000 n=10)     1.166 ±  1%   +2.08% (p=0.000 n=10)
      sum_by_(namespace)_(rate({region="ap-southeast-1"}_|_detected_level=~"error|warn"_[5m]))                                                   1.830 ±  2%     1.844 ±  1%        ~ (p=0.247 n=10)     1.790 ±  2%   -2.19% (p=0.023 n=10)
      sum_by_(namespace)_(rate({service_name="grafana",_env="prod",_region="us-west-2"}_|_detected_level=~"error|warn"_[5m]))                   321.1m ±  1%    357.6m ±  3%  +11.38% (p=0.000 n=10)    339.4m ±  3%   +5.71% (p=0.000 n=10)
      sum_by_(namespace)_(rate({service_name="kubernetes"}_|_detected_level=~"error|warn"_[5m]))                                                 1.033 ±  1%     1.112 ±  3%   +7.72% (p=0.000 n=10)     1.062 ±  1%   +2.85% (p=0.000 n=10)
      sum_by_(pod)_(rate({region="ap-southeast-1",_env="dev"}_|_detected_level=~"error|warn"_[5m]))                                              1.147 ±  2%     1.224 ±  3%   +6.69% (p=0.002 n=10)     1.179 ±  1%   +2.77% (p=0.004 n=10)
      sum_by_(pod)_(rate({region="ap-southeast-1"}_|_detected_level=~"error|warn"_[5m]))                                                         1.801 ±  1%     1.845 ±  1%   +2.42% (p=0.000 n=10)     1.790 ±  1%        ~ (p=0.165 n=10)
      sum_by_(pod)_(rate({service_name="grafana",_env="prod",_region="us-west-2"}_|_detected_level=~"error|warn"_[5m]))                         320.4m ±  1%    354.9m ±  4%  +10.77% (p=0.000 n=10)    337.5m ±  3%   +5.32% (p=0.000 n=10)
      sum_by_(pod)_(rate({service_name="kubernetes"}_|_detected_level=~"error|warn"_[5m]))                                                       1.030 ±  1%     1.103 ±  4%   +7.06% (p=0.000 n=10)     1.095 ±  6%   +6.30% (p=0.000 n=10)
      {region="ap-southeast-1",_env="dev"}_[BACKWARD]                                                                                            1.194 ±  1%     1.271 ±  2%   +6.40% (p=0.000 n=10)     1.262 ±  6%   +5.64% (p=0.000 n=10)
      {region="ap-southeast-1",_env="dev"}_[FORWARD]                                                                                             1.213 ±  3%     1.297 ±  2%   +7.00% (p=0.001 n=10)     1.351 ± 24%  +11.41% (p=0.000 n=10)
      {region="ap-southeast-1",_env="dev"}_|_detected_level="error"_[BACKWARD]                                                                   1.175 ±  5%     1.199 ±  4%        ~ (p=0.089 n=10)     1.193 ±  9%        ~ (p=0.218 n=10)
      {region="ap-southeast-1",_env="dev"}_|_detected_level="error"_[FORWARD]                                                                    1.169 ±  6%     1.202 ±  2%        ~ (p=0.143 n=10)     1.191 ±  3%        ~ (p=0.280 n=10)
      {region="ap-southeast-1",_env="dev"}_|_detected_level="warn"_[BACKWARD]                                                                    1.204 ±  4%     1.214 ±  3%        ~ (p=0.393 n=10)     1.156 ±  4%        ~ (p=0.089 n=10)
      {region="ap-southeast-1",_env="dev"}_|_detected_level="warn"_[FORWARD]                                                                     1.172 ±  3%     1.232 ±  3%   +5.08% (p=0.007 n=10)     1.300 ± 10%  +10.89% (p=0.011 n=10)
      {region="ap-southeast-1",_env="dev"}_|_json_|_duration_seconds_>_0.1_|_detected_level!="debug"_[BACKWARD]                                  1.240 ±  9%     1.211 ±  3%        ~ (p=0.280 n=10)     1.191 ±  3%        ~ (p=0.052 n=10)
      {region="ap-southeast-1",_env="dev"}_|_json_|_duration_seconds_>_0.1_|_detected_level!="debug"_[FORWARD]                                   1.224 ±  4%     1.207 ±  3%        ~ (p=0.393 n=10)     1.192 ±  3%        ~ (p=0.123 n=10)
      {region="ap-southeast-1",_env="dev"}_|_logfmt_|_level="error"_|_detected_level="error"_[BACKWARD]                                          1.268 ±  4%     1.271 ±  3%        ~ (p=0.579 n=10)     1.318 ± 11%   +3.94% (p=0.035 n=10)
      {region="ap-southeast-1",_env="dev"}_|_logfmt_|_level="error"_|_detected_level="error"_[FORWARD]                                           1.309 ±  9%     1.292 ±  2%        ~ (p=0.684 n=10)     1.270 ±  4%        ~ (p=0.393 n=10)
      {region="ap-southeast-1",_env="dev"}_|~_"error|exception"_|_detected_level="error"_[BACKWARD]                                              1.358 ± 21%     1.369 ±  5%        ~ (p=0.739 n=10)     1.383 ±  5%        ~ (p=0.631 n=10)
      {region="ap-southeast-1",_env="dev"}_|~_"error|exception"_|_detected_level="error"_[FORWARD]                                               1.323 ±  9%     1.350 ±  2%        ~ (p=0.315 n=10)     1.325 ±  4%        ~ (p=0.971 n=10)
      {region="ap-southeast-1"}_[BACKWARD]                                                                                                       1.902 ±  2%     2.051 ±  2%   +7.84% (p=0.000 n=10)     1.992 ±  4%   +4.73% (p=0.002 n=10)
      {region="ap-southeast-1"}_[FORWARD]                                                                                                        1.948 ±  3%     1.972 ±  3%        ~ (p=0.393 n=10)     1.990 ±  7%        ~ (p=0.315 n=10)
      {region="ap-southeast-1"}_|_detected_level="error"_[BACKWARD]                                                                              1.753 ±  6%     1.707 ±  2%        ~ (p=0.280 n=10)     1.730 ±  4%        ~ (p=0.579 n=10)
      {region="ap-southeast-1"}_|_detected_level="error"_[FORWARD]                                                                               1.677 ±  5%     1.814 ±  4%   +8.15% (p=0.000 n=10)     1.781 ±  5%   +6.18% (p=0.007 n=10)
      {region="ap-southeast-1"}_|_detected_level="warn"_[BACKWARD]                                                                               1.701 ±  4%     1.759 ±  4%   +3.43% (p=0.019 n=10)     1.709 ±  2%        ~ (p=0.796 n=10)
      {region="ap-southeast-1"}_|_detected_level="warn"_[FORWARD]                                                                                1.710 ±  5%     1.713 ±  2%        ~ (p=0.579 n=10)     1.835 ±  6%   +7.27% (p=0.007 n=10)
      {region="ap-southeast-1"}_|_detected_level=~"error|warn"_[BACKWARD]                                                                        1.472 ±  6%     1.528 ±  4%   +3.81% (p=0.011 n=10)     1.531 ± 14%   +4.00% (p=0.023 n=10)
      {region="ap-southeast-1"}_|_detected_level=~"error|warn"_[FORWARD]                                                                         1.507 ±  3%     1.526 ±  2%        ~ (p=0.353 n=10)     1.544 ±  6%        ~ (p=0.052 n=10)
      {region="ap-southeast-1"}_|_json_|_duration_seconds_>_0.1_|_detected_level!="debug"_[BACKWARD]                                             1.715 ±  3%     1.749 ±  2%        ~ (p=0.063 n=10)     1.792 ±  4%   +4.50% (p=0.005 n=10)
      {region="ap-southeast-1"}_|_json_|_duration_seconds_>_0.1_|_detected_level!="debug"_[FORWARD]                                              1.756 ±  4%     1.750 ±  5%        ~ (p=0.796 n=10)     1.745 ±  1%        ~ (p=0.436 n=10)
      {region="ap-southeast-1"}_|_logfmt_|_level="error"_|_detected_level="error"_[BACKWARD]                                                     1.797 ±  4%     1.951 ±  9%   +8.61% (p=0.000 n=10)     1.844 ±  2%        ~ (p=0.052 n=10)
      {region="ap-southeast-1"}_|_logfmt_|_level="error"_|_detected_level="error"_[FORWARD]                                                      1.922 ±  4%     1.901 ±  3%        ~ (p=0.089 n=10)     1.909 ±  9%        ~ (p=0.853 n=10)
      {region="ap-southeast-1"}_|~_"error|exception"_|_detected_level="error"_[BACKWARD]                                                         1.877 ±  3%     1.913 ±  7%        ~ (p=0.123 n=10)     1.838 ±  3%        ~ (p=0.218 n=10)
      {region="ap-southeast-1"}_|~_"error|exception"_|_detected_level="error"_[FORWARD]                                                          1.825 ±  7%     1.884 ±  6%   +3.26% (p=0.035 n=10)     1.874 ±  7%        ~ (p=0.063 n=10)
      {service_name="grafana",_env="prod",_region="us-west-2"}_[BACKWARD]                                                                       328.5m ±  4%    365.9m ±  8%  +11.41% (p=0.000 n=10)    364.0m ±  4%  +10.83% (p=0.000 n=10)
      {service_name="grafana",_env="prod",_region="us-west-2"}_[FORWARD]                                                                        352.0m ±  5%    363.1m ±  3%        ~ (p=0.089 n=10)    359.7m ±  2%        ~ (p=0.529 n=10)
      {service_name="grafana",_env="prod",_region="us-west-2"}_|_detected_level="error"_[BACKWARD]                                              338.6m ±  4%    352.0m ±  5%   +3.94% (p=0.015 n=10)    354.0m ±  5%   +4.52% (p=0.005 n=10)
      {service_name="grafana",_env="prod",_region="us-west-2"}_|_detected_level="error"_[FORWARD]                                               341.2m ±  6%    356.2m ±  4%   +4.40% (p=0.043 n=10)    361.5m ± 11%   +5.97% (p=0.007 n=10)
      {service_name="grafana",_env="prod",_region="us-west-2"}_|_detected_level="warn"_[BACKWARD]                                               325.3m ±  2%    359.1m ±  3%  +10.40% (p=0.000 n=10)    351.1m ±  4%   +7.93% (p=0.000 n=10)
      {service_name="grafana",_env="prod",_region="us-west-2"}_|_detected_level="warn"_[FORWARD]                                                324.0m ±  2%    358.7m ±  4%  +10.71% (p=0.000 n=10)    353.7m ±  5%   +9.16% (p=0.000 n=10)
      {service_name="grafana",_env="prod",_region="us-west-2"}_|_json_|_duration_seconds_>_0.1_|_detected_level!="debug"_[BACKWARD]             324.8m ±  1%    372.0m ±  6%  +14.53% (p=0.000 n=10)    358.0m ± 15%  +10.20% (p=0.000 n=10)
      {service_name="grafana",_env="prod",_region="us-west-2"}_|_json_|_duration_seconds_>_0.1_|_detected_level!="debug"_[FORWARD]              324.1m ±  1%    363.2m ± 41%  +12.05% (p=0.000 n=10)    343.2m ±  2%   +5.90% (p=0.000 n=10)
      {service_name="grafana",_env="prod",_region="us-west-2"}_|_logfmt_|_level="error"_|_detected_level="error"_[BACKWARD]                     329.6m ±  1%    382.8m ±  5%  +16.14% (p=0.000 n=10)    373.4m ± 13%  +13.30% (p=0.000 n=10)
      {service_name="grafana",_env="prod",_region="us-west-2"}_|_logfmt_|_level="error"_|_detected_level="error"_[FORWARD]                      328.6m ±  1%    351.2m ±  1%   +6.85% (p=0.000 n=10)    350.9m ± 96%   +6.78% (p=0.000 n=10)
      {service_name="grafana",_env="prod",_region="us-west-2"}_|~_"error|exception"_|_detected_level="error"_[BACKWARD]                         354.5m ±  2%    393.0m ±  5%  +10.84% (p=0.000 n=10)    377.2m ±  1%   +6.40% (p=0.000 n=10)
      {service_name="grafana",_env="prod",_region="us-west-2"}_|~_"error|exception"_|_detected_level="error"_[FORWARD]                          352.0m ±  2%    387.7m ±  5%  +10.12% (p=0.000 n=10)    377.3m ± 11%   +7.17% (p=0.000 n=10)
      {service_name="kubernetes"}_[BACKWARD]                                                                                                     1.098 ±  1%     1.171 ±  3%   +6.66% (p=0.000 n=10)     1.124 ±  2%   +2.33% (p=0.000 n=10)
      {service_name="kubernetes"}_[FORWARD]                                                                                                      1.102 ±  1%     1.207 ±  4%   +9.50% (p=0.000 n=10)     1.113 ±  1%   +0.95% (p=0.005 n=10)
      {service_name="kubernetes"}_|_detected_level="error"_[BACKWARD]                                                                            1.033 ±  1%     1.100 ±  3%   +6.52% (p=0.000 n=10)     1.046 ±  1%   +1.24% (p=0.004 n=10)
      {service_name="kubernetes"}_|_detected_level="error"_[FORWARD]                                                                             1.036 ± 11%     1.091 ±  2%        ~ (p=0.218 n=10)     1.077 ±  2%        ~ (p=0.315 n=10)
      {service_name="kubernetes"}_|_detected_level="warn"_[BACKWARD]                                                                             1.033 ±  2%     1.116 ±  2%   +7.96% (p=0.000 n=10)     1.266 ± 18%  +22.53% (p=0.000 n=10)
      {service_name="kubernetes"}_|_detected_level="warn"_[FORWARD]                                                                              1.034 ±  1%     1.125 ±  5%   +8.82% (p=0.000 n=10)     1.061 ±  4%   +2.61% (p=0.003 n=10)
      {service_name="kubernetes"}_|_json_|_duration_seconds_>_0.1_|_detected_level!="debug"_[BACKWARD]                                           1.021 ±  4%     1.057 ±  4%   +3.55% (p=0.011 n=10)     1.067 ±  5%   +4.57% (p=0.007 n=10)
      {service_name="kubernetes"}_|_json_|_duration_seconds_>_0.1_|_detected_level!="debug"_[FORWARD]                                            1.013 ±  1%     1.067 ±  3%   +5.31% (p=0.000 n=10)     1.044 ±  3%   +3.08% (p=0.000 n=10)
      {service_name="kubernetes"}_|_logfmt_|_level="error"_|_detected_level="error"_[BACKWARD]                                                   1.063 ±  1%     1.104 ±  2%   +3.86% (p=0.000 n=10)     1.093 ±  5%   +2.79% (p=0.000 n=10)
      {service_name="kubernetes"}_|_logfmt_|_level="error"_|_detected_level="error"_[FORWARD]                                                    1.061 ±  2%     1.126 ±  3%   +6.08% (p=0.000 n=10)     1.080 ±  5%   +1.72% (p=0.043 n=10)
      {service_name="kubernetes"}_|~_"error|exception"_|_detected_level="error"_[BACKWARD]                                                       1.179 ±  1%     1.288 ±  3%   +9.19% (p=0.000 n=10)     1.199 ±  1%   +1.69% (p=0.002 n=10)
      {service_name="kubernetes"}_|~_"error|exception"_|_detected_level="error"_[FORWARD]                                                        1.186 ±  2%     1.284 ±  3%   +8.33% (p=0.000 n=10)     1.221 ±  7%   +2.99% (p=0.023 n=10)
      geomean                                                                                                                                   942.4m          994.5m         +5.53%                   973.0m         +3.25%

                                                                                                                                              │    streaming    │                 upfront                 │             upfront-pooled             │
                                                                                                                                              │      B/op       │      B/op       vs base                 │      B/op       vs base                │
      sum_by_(cluster,_namespace)_(rate({region="ap-southeast-1",_env="dev"}_|_detected_level=~"error|warn"_[5m]))                               700.7Mi ± 553%   2672.5Mi ± 15%         ~ (p=0.105 n=10)    971.9Mi ± 39%        ~ (p=0.436 n=10)
      sum_by_(cluster,_namespace)_(rate({region="ap-southeast-1"}_|_detected_level=~"error|warn"_[5m]))                                          550.7Mi ±   4%   2692.4Mi ±  5%  +388.92% (p=0.000 n=10)    876.8Mi ± 16%  +59.22% (p=0.000 n=10)
      sum_by_(cluster,_namespace)_(rate({service_name="grafana",_env="prod",_region="us-west-2"}_|_detected_level=~"error|warn"_[5m]))           271.4Mi ±   1%    810.8Mi ± 24%  +198.73% (p=0.000 n=10)    409.6Mi ± 28%  +50.90% (p=0.000 n=10)
      sum_by_(cluster,_namespace)_(rate({service_name="kubernetes"}_|_detected_level=~"error|warn"_[5m]))                                        505.7Mi ±   7%   2428.9Mi ± 16%  +380.29% (p=0.000 n=10)    669.5Mi ±  5%  +32.39% (p=0.002 n=10)
      sum_by_(component)_(rate({region="ap-southeast-1",_env="dev"}_|_detected_level="error"_[5m]))                                              515.6Mi ±   3%   2594.0Mi ±  8%  +403.11% (p=0.000 n=10)    720.9Mi ±  5%  +39.82% (p=0.000 n=10)
      sum_by_(component)_(rate({region="ap-southeast-1",_env="dev"}_|_detected_level="warn"_[5m]))                                               518.9Mi ±   3%   2597.9Mi ±  8%  +400.67% (p=0.000 n=10)    685.0Mi ±  7%  +32.02% (p=0.000 n=10)
      sum_by_(component)_(rate({region="ap-southeast-1"}_|_detected_level="error"_[5m]))                                                         537.6Mi ±   2%   2541.6Mi ± 15%  +372.75% (p=0.000 n=10)    728.7Mi ±  9%  +35.54% (p=0.000 n=10)
      sum_by_(component)_(rate({region="ap-southeast-1"}_|_detected_level="warn"_[5m]))                                                          533.9Mi ±   2%   2685.2Mi ± 12%  +402.93% (p=0.000 n=10)    688.6Mi ±  7%  +28.98% (p=0.000 n=10)
      sum_by_(component)_(rate({service_name="grafana",_env="prod",_region="us-west-2"}_|_detected_level="error"_[5m]))                          268.9Mi ±   1%    813.7Mi ± 34%  +202.55% (p=0.000 n=10)    387.8Mi ± 26%  +44.18% (p=0.000 n=10)
      sum_by_(component)_(rate({service_name="grafana",_env="prod",_region="us-west-2"}_|_detected_level="warn"_[5m]))                           270.5Mi ±   1%    796.1Mi ± 29%  +194.27% (p=0.000 n=10)    367.1Mi ± 19%  +35.68% (p=0.000 n=10)
      sum_by_(component)_(rate({service_name="kubernetes"}_|_detected_level="error"_[5m]))                                                       504.8Mi ±   6%   2504.8Mi ± 10%  +396.21% (p=0.000 n=10)    607.5Mi ± 11%  +20.34% (p=0.002 n=10)
      sum_by_(component)_(rate({service_name="kubernetes"}_|_detected_level="warn"_[5m]))                                                        500.6Mi ±   1%   2419.7Mi ± 18%  +383.38% (p=0.000 n=10)    598.6Mi ±  3%  +19.58% (p=0.000 n=10)
      sum_by_(component,_detected_level)_(rate({region="ap-southeast-1",_env="dev"}_|_detected_level=~"error|warn"_[5m]))                        526.5Mi ±   2%   2655.2Mi ± 15%  +404.28% (p=0.000 n=10)    644.9Mi ±  6%  +22.49% (p=0.000 n=10)
      sum_by_(component,_detected_level)_(rate({region="ap-southeast-1"}_|_detected_level=~"error|warn"_[5m]))                                   551.1Mi ±   2%   2799.5Mi ±  7%  +407.95% (p=0.000 n=10)    643.2Mi ±  9%  +16.70% (p=0.001 n=10)
      sum_by_(component,_detected_level)_(rate({region="ap-southeast-1"}[1m]))                                                                   453.6Mi ±   1%   2790.2Mi ±  5%  +515.16% (p=0.000 n=10)    537.6Mi ±  7%  +18.53% (p=0.001 n=10)
      sum_by_(component,_detected_level)_(rate({service_name="grafana",_env="prod",_region="us-west-2"}_|_detected_level=~"error|warn"_[5m]))    270.2Mi ±   1%    836.8Mi ± 30%  +209.63% (p=0.000 n=10)    299.6Mi ± 32%  +10.86% (p=0.000 n=10)
      sum_by_(component,_detected_level)_(rate({service_name="kubernetes"}_|_detected_level=~"error|warn"_[5m]))                                 506.1Mi ±   1%   2551.8Mi ± 16%  +404.18% (p=0.000 n=10)    568.7Mi ±  3%  +12.36% (p=0.002 n=10)
      sum_by_(env)_(rate({region="ap-southeast-1",_env="dev"}_|_detected_level=~"error|warn"_[5m]))                                              521.1Mi ±   2%   2535.0Mi ± 12%  +386.46% (p=0.000 n=10)    592.5Mi ±  4%  +13.70% (p=0.000 n=10)
      sum_by_(env)_(rate({region="ap-southeast-1"}_|_detected_level=~"error|warn"_[5m]))                                                         547.4Mi ±   2%   2614.3Mi ± 14%  +377.61% (p=0.000 n=10)    585.8Mi ± 20%   +7.03% (p=0.001 n=10)
      sum_by_(env)_(rate({service_name="grafana",_env="prod",_region="us-west-2"}_|_detected_level=~"error|warn"_[5m]))                          269.4Mi ±   1%    832.0Mi ± 26%  +208.88% (p=0.000 n=10)    341.8Mi ± 16%  +26.91% (p=0.000 n=10)
      sum_by_(env)_(rate({service_name="kubernetes"}_|_detected_level=~"error|warn"_[5m]))                                                       509.5Mi ±   3%   2485.4Mi ± 17%  +387.84% (p=0.000 n=10)    570.7Mi ± 11%  +12.02% (p=0.002 n=10)
      sum_by_(env,_component)_(rate({region="ap-southeast-1",_env="dev"}_|_detected_level=~"error|warn"_[5m]))                                   521.8Mi ±   4%   2576.0Mi ±  9%  +393.71% (p=0.000 n=10)    597.7Mi ±  7%  +14.56% (p=0.000 n=10)
      sum_by_(env,_component)_(rate({region="ap-southeast-1"}_|_detected_level=~"error|warn"_[5m]))                                              543.7Mi ±   3%   2698.9Mi ±  8%  +396.42% (p=0.000 n=10)    604.0Mi ±  8%  +11.10% (p=0.001 n=10)
      sum_by_(env,_component)_(rate({service_name="grafana",_env="prod",_region="us-west-2"}_|_detected_level=~"error|warn"_[5m]))               270.2Mi ±   0%    872.2Mi ± 17%  +222.81% (p=0.000 n=10)    356.4Mi ± 22%  +31.89% (p=0.000 n=10)
      sum_by_(env,_component)_(rate({service_name="kubernetes"}_|_detected_level=~"error|warn"_[5m]))                                            508.1Mi ±   7%   2478.4Mi ±  6%  +387.79% (p=0.000 n=10)    585.7Mi ±  6%  +15.27% (p=0.002 n=10)
      sum_by_(namespace)_(rate({region="ap-southeast-1",_env="dev"}_|_detected_level=~"error|warn"_[5m]))                                        516.1Mi ±   4%   2586.1Mi ±  4%  +401.08% (p=0.000 n=10)    600.5Mi ±  5%  +16.35% (p=0.000 n=10)
      sum_by_(namespace)_(rate({region="ap-southeast-1"}_|_detected_level=~"error|warn"_[5m]))                                                   549.9Mi ±   4%   2705.3Mi ± 14%  +391.98% (p=0.000 n=10)    578.8Mi ± 17%   +5.26% (p=0.002 n=10)
      sum_by_(namespace)_(rate({service_name="grafana",_env="prod",_region="us-west-2"}_|_detected_level=~"error|warn"_[5m]))                    270.3Mi ±   0%    831.3Mi ± 16%  +207.52% (p=0.000 n=10)    318.6Mi ± 13%  +17.86% (p=0.000 n=10)
      sum_by_(namespace)_(rate({service_name="kubernetes"}_|_detected_level=~"error|warn"_[5m]))                                                 504.5Mi ±   6%   2476.6Mi ±  7%  +390.93% (p=0.000 n=10)    568.6Mi ±  5%  +12.71% (p=0.002 n=10)
      sum_by_(pod)_(rate({region="ap-southeast-1",_env="dev"}_|_detected_level=~"error|warn"_[5m]))                                              523.0Mi ±   2%   2567.8Mi ±  8%  +390.99% (p=0.000 n=10)    620.0Mi ±  8%  +18.56% (p=0.000 n=10)
      sum_by_(pod)_(rate({region="ap-southeast-1"}_|_detected_level=~"error|warn"_[5m]))                                                         550.0Mi ±   4%   2719.0Mi ±  4%  +394.40% (p=0.000 n=10)    633.1Mi ±  7%  +15.12% (p=0.001 n=10)
      sum_by_(pod)_(rate({service_name="grafana",_env="prod",_region="us-west-2"}_|_detected_level=~"error|warn"_[5m]))                          269.3Mi ±   1%    866.9Mi ± 22%  +221.93% (p=0.000 n=10)    337.2Mi ± 14%  +25.23% (p=0.000 n=10)
      sum_by_(pod)_(rate({service_name="kubernetes"}_|_detected_level=~"error|warn"_[5m]))                                                       505.9Mi ±   4%   2398.2Mi ± 21%  +374.04% (p=0.000 n=10)    578.0Mi ±  8%  +14.24% (p=0.002 n=10)
      {region="ap-southeast-1",_env="dev"}_[BACKWARD]                                                                                            1.257Gi ±   1%    3.169Gi ±  6%  +152.06% (p=0.000 n=10)    1.353Gi ±  3%   +7.64% (p=0.000 n=10)
      {region="ap-southeast-1",_env="dev"}_[FORWARD]                                                                                             1.246Gi ±   0%    3.130Gi ±  5%  +151.17% (p=0.000 n=10)    1.303Gi ±  1%   +4.53% (p=0.000 n=10)
      {region="ap-southeast-1",_env="dev"}_|_detected_level="error"_[BACKWARD]                                                                   724.4Mi ±   1%   2767.2Mi ±  6%  +281.98% (p=0.000 n=10)    767.7Mi ±  4%   +5.98% (p=0.000 n=10)
      {region="ap-southeast-1",_env="dev"}_|_detected_level="error"_[FORWARD]                                                                    729.2Mi ±   2%   2734.7Mi ±  9%  +275.01% (p=0.000 n=10)    759.3Mi ±  3%   +4.13% (p=0.000 n=10)
      {region="ap-southeast-1",_env="dev"}_|_detected_level="warn"_[BACKWARD]                                                                    724.1Mi ±   1%   2738.4Mi ±  9%  +278.20% (p=0.000 n=10)    756.8Mi ±  4%   +4.52% (p=0.000 n=10)
      {region="ap-southeast-1",_env="dev"}_|_detected_level="warn"_[FORWARD]                                                                     728.0Mi ±   1%   2690.3Mi ±  4%  +269.57% (p=0.000 n=10)    763.6Mi ±  3%   +4.90% (p=0.000 n=10)
      {region="ap-southeast-1",_env="dev"}_|_json_|_duration_seconds_>_0.1_|_detected_level!="debug"_[BACKWARD]                                  541.7Mi ±   2%   2567.4Mi ±  8%  +373.94% (p=0.000 n=10)    577.6Mi ±  6%   +6.62% (p=0.000 n=10)
      {region="ap-southeast-1",_env="dev"}_|_json_|_duration_seconds_>_0.1_|_detected_level!="debug"_[FORWARD]                                   541.6Mi ±   2%   2592.3Mi ±  5%  +378.63% (p=0.000 n=10)    560.0Mi ±  6%   +3.39% (p=0.000 n=10)
      {region="ap-southeast-1",_env="dev"}_|_logfmt_|_level="error"_|_detected_level="error"_[BACKWARD]                                          985.3Mi ±   1%   2966.4Mi ±  6%  +201.07% (p=0.000 n=10)   1001.9Mi ±  1%   +1.69% (p=0.000 n=10)
      {region="ap-southeast-1",_env="dev"}_|_logfmt_|_level="error"_|_detected_level="error"_[FORWARD]                                           985.8Mi ±   1%   2951.3Mi ±  4%  +199.40% (p=0.000 n=10)   1007.3Mi ±  3%   +2.18% (p=0.000 n=10)
      {region="ap-southeast-1",_env="dev"}_|~_"error|exception"_|_detected_level="error"_[BACKWARD]                                              609.8Mi ±   0%   2624.1Mi ±  6%  +330.32% (p=0.000 n=10)    637.3Mi ±  2%   +4.51% (p=0.000 n=10)
      {region="ap-southeast-1",_env="dev"}_|~_"error|exception"_|_detected_level="error"_[FORWARD]                                               608.0Mi ±   1%   2609.4Mi ±  7%  +329.14% (p=0.000 n=10)    664.1Mi ±  2%   +9.21% (p=0.000 n=10)
      {region="ap-southeast-1"}_[BACKWARD]                                                                                                       2.325Gi ±   1%    4.576Gi ±  7%   +96.87% (p=0.000 n=10)    2.374Gi ±  2%   +2.11% (p=0.002 n=10)
      {region="ap-southeast-1"}_[FORWARD]                                                                                                        2.316Gi ±   0%    4.319Gi ±  6%   +86.51% (p=0.000 n=10)    2.351Gi ±  2%   +1.52% (p=0.000 n=10)
      {region="ap-southeast-1"}_|_detected_level="error"_[BACKWARD]                                                                              1.002Gi ±   1%    2.924Gi ±  6%  +191.72% (p=0.000 n=10)    1.042Gi ±  3%   +3.96% (p=0.000 n=10)
      {region="ap-southeast-1"}_|_detected_level="error"_[FORWARD]                                                                               1.002Gi ±   1%    2.965Gi ±  8%  +195.96% (p=0.000 n=10)    1.050Gi ±  4%   +4.82% (p=0.000 n=10)
      {region="ap-southeast-1"}_|_detected_level="warn"_[BACKWARD]                                                                              1017.1Mi ±   1%   2991.3Mi ±  7%  +194.12% (p=0.000 n=10)   1052.7Mi ±  2%   +3.50% (p=0.000 n=10)
      {region="ap-southeast-1"}_|_detected_level="warn"_[FORWARD]                                                                               1017.3Mi ±   1%   3030.8Mi ±  3%  +197.91% (p=0.000 n=10)   1047.3Mi ±  8%   +2.94% (p=0.000 n=10)
      {region="ap-southeast-1"}_|_detected_level=~"error|warn"_[BACKWARD]                                                                        715.3Mi ±   1%   2697.6Mi ± 10%  +277.14% (p=0.000 n=10)    768.0Mi ±  4%   +7.37% (p=0.000 n=10)
      {region="ap-southeast-1"}_|_detected_level=~"error|warn"_[FORWARD]                                                                         713.6Mi ±   1%   2718.5Mi ±  7%  +280.97% (p=0.000 n=10)    751.3Mi ±  8%   +5.28% (p=0.000 n=10)
      {region="ap-southeast-1"}_|_json_|_duration_seconds_>_0.1_|_detected_level!="debug"_[BACKWARD]                                             612.4Mi ±   3%   2681.8Mi ±  9%  +337.90% (p=0.000 n=10)    645.4Mi ±  6%   +5.39% (p=0.002 n=10)
      {region="ap-southeast-1"}_|_json_|_duration_seconds_>_0.1_|_detected_level!="debug"_[FORWARD]                                              616.9Mi ±   2%   2685.0Mi ±  6%  +335.27% (p=0.000 n=10)    669.0Mi ±  6%   +8.45% (p=0.000 n=10)
      {region="ap-southeast-1"}_|_logfmt_|_level="error"_|_detected_level="error"_[BACKWARD]                                                     1.486Gi ±   0%    3.415Gi ±  6%  +129.76% (p=0.000 n=10)    1.533Gi ±  4%   +3.14% (p=0.000 n=10)
      {region="ap-southeast-1"}_|_logfmt_|_level="error"_|_detected_level="error"_[FORWARD]                                                      1.491Gi ±   1%    3.350Gi ±  9%  +124.65% (p=0.000 n=10)    1.522Gi ±  1%   +2.07% (p=0.000 n=10)
      {region="ap-southeast-1"}_|~_"error|exception"_|_detected_level="error"_[BACKWARD]                                                         871.6Mi ±   0%   2805.4Mi ± 12%  +221.88% (p=0.000 n=10)    909.6Mi ±  2%   +4.36% (p=0.000 n=10)
      {region="ap-southeast-1"}_|~_"error|exception"_|_detected_level="error"_[FORWARD]                                                          868.5Mi ±   0%   2873.7Mi ±  4%  +230.89% (p=0.000 n=10)    913.7Mi ±  3%   +5.21% (p=0.000 n=10)
      {service_name="grafana",_env="prod",_region="us-west-2"}_[BACKWARD]                                                                        305.7Mi ±   0%    961.9Mi ± 14%  +214.68% (p=0.000 n=10)    355.7Mi ± 18%  +16.36% (p=0.000 n=10)
      {service_name="grafana",_env="prod",_region="us-west-2"}_[FORWARD]                                                                         306.5Mi ±   0%    839.1Mi ± 15%  +173.78% (p=0.000 n=10)    398.3Mi ± 16%  +29.96% (p=0.000 n=10)
      {service_name="grafana",_env="prod",_region="us-west-2"}_|_detected_level="error"_[BACKWARD]                                               279.9Mi ±   1%    791.1Mi ± 16%  +182.69% (p=0.000 n=10)    334.7Mi ± 28%  +19.59% (p=0.000 n=10)
      {service_name="grafana",_env="prod",_region="us-west-2"}_|_detected_level="error"_[FORWARD]                                                280.6Mi ±   1%    849.5Mi ± 10%  +202.78% (p=0.000 n=10)    327.9Mi ± 21%  +16.87% (p=0.000 n=10)
      {service_name="grafana",_env="prod",_region="us-west-2"}_|_detected_level="warn"_[BACKWARD]                                                279.5Mi ±   1%    904.1Mi ± 17%  +223.54% (p=0.000 n=10)    323.3Mi ± 21%  +15.67% (p=0.000 n=10)
      {service_name="grafana",_env="prod",_region="us-west-2"}_|_detected_level="warn"_[FORWARD]                                                 278.8Mi ±   1%    876.9Mi ± 34%  +214.53% (p=0.000 n=10)    317.4Mi ± 16%  +13.84% (p=0.000 n=10)
      {service_name="grafana",_env="prod",_region="us-west-2"}_|_json_|_duration_seconds_>_0.1_|_detected_level!="debug"_[BACKWARD]              269.7Mi ±   1%    893.7Mi ± 20%  +231.39% (p=0.000 n=10)    302.1Mi ± 44%  +12.01% (p=0.000 n=10)
      {service_name="grafana",_env="prod",_region="us-west-2"}_|_json_|_duration_seconds_>_0.1_|_detected_level!="debug"_[FORWARD]               268.6Mi ±   1%    849.7Mi ± 13%  +216.34% (p=0.000 n=10)    307.2Mi ± 13%  +14.38% (p=0.000 n=10)
      {service_name="grafana",_env="prod",_region="us-west-2"}_|_logfmt_|_level="error"_|_detected_level="error"_[BACKWARD]                      296.7Mi ±   0%    922.6Mi ± 12%  +210.94% (p=0.000 n=10)    363.0Mi ± 19%  +22.35% (p=0.000 n=10)
      {service_name="grafana",_env="prod",_region="us-west-2"}_|_logfmt_|_level="error"_|_detected_level="error"_[FORWARD]                       298.0Mi ±   1%    863.2Mi ± 10%  +189.63% (p=0.000 n=10)    363.0Mi ± 14%  +21.79% (p=0.000 n=10)
      {service_name="grafana",_env="prod",_region="us-west-2"}_|~_"error|exception"_|_detected_level="error"_[BACKWARD]                          315.4Mi ±   1%    919.0Mi ± 14%  +191.36% (p=0.000 n=10)    385.0Mi ± 23%  +22.07% (p=0.000 n=10)
      {service_name="grafana",_env="prod",_region="us-west-2"}_|~_"error|exception"_|_detected_level="error"_[FORWARD]                           315.4Mi ±   1%    964.0Mi ± 18%  +205.59% (p=0.000 n=10)    356.3Mi ± 30%  +12.94% (p=0.000 n=10)
      {service_name="kubernetes"}_[BACKWARD]                                                                                                     1.055Gi ±   4%    2.947Gi ±  6%  +179.38% (p=0.000 n=10)    1.104Gi ±  2%   +4.68% (p=0.009 n=10)
      {service_name="kubernetes"}_[FORWARD]                                                                                                      1.045Gi ±   0%    2.972Gi ±  5%  +184.33% (p=0.000 n=10)    1.090Gi ±  3%   +4.30% (p=0.000 n=10)
      {service_name="kubernetes"}_|_detected_level="error"_[BACKWARD]                                                                            662.4Mi ±   1%   2655.9Mi ±  6%  +300.93% (p=0.000 n=10)    695.8Mi ±  1%   +5.04% (p=0.000 n=10)
      {service_name="kubernetes"}_|_detected_level="error"_[FORWARD]                                                                             660.9Mi ±   1%   2610.7Mi ± 13%  +295.01% (p=0.000 n=10)    698.5Mi ±  1%   +5.69% (p=0.000 n=10)
      {service_name="kubernetes"}_|_detected_level="warn"_[BACKWARD]                                                                             664.6Mi ±   1%   2670.7Mi ±  9%  +301.83% (p=0.000 n=10)    689.0Mi ±  2%   +3.66% (p=0.000 n=10)
      {service_name="kubernetes"}_|_detected_level="warn"_[FORWARD]                                                                              660.7Mi ±   1%   2626.3Mi ±  6%  +297.50% (p=0.000 n=10)    685.6Mi ±  3%   +3.77% (p=0.000 n=10)
      {service_name="kubernetes"}_|_json_|_duration_seconds_>_0.1_|_detected_level!="debug"_[BACKWARD]                                           493.4Mi ±   1%   2515.4Mi ±  6%  +409.75% (p=0.000 n=10)    521.4Mi ±  7%   +5.67% (p=0.000 n=10)
      {service_name="kubernetes"}_|_json_|_duration_seconds_>_0.1_|_detected_level!="debug"_[FORWARD]                                            499.0Mi ±   1%   2542.4Mi ±  3%  +409.49% (p=0.000 n=10)    527.5Mi ±  4%   +5.71% (p=0.000 n=10)
      {service_name="kubernetes"}_|_logfmt_|_level="error"_|_detected_level="error"_[BACKWARD]                                                   720.1Mi ±   1%   2709.6Mi ± 10%  +276.28% (p=0.000 n=10)    753.2Mi ±  3%   +4.60% (p=0.000 n=10)
      {service_name="kubernetes"}_|_logfmt_|_level="error"_|_detected_level="error"_[FORWARD]                                                    716.1Mi ±   1%   2701.4Mi ±  7%  +277.26% (p=0.000 n=10)    755.3Mi ±  3%   +5.48% (p=0.000 n=10)
      {service_name="kubernetes"}_|~_"error|exception"_|_detected_level="error"_[BACKWARD]                                                       569.2Mi ±   1%   2541.3Mi ±  7%  +346.50% (p=0.000 n=10)    634.2Mi ±  4%  +11.44% (p=0.000 n=10)
      {service_name="kubernetes"}_|~_"error|exception"_|_detected_level="error"_[FORWARD]                                                        568.8Mi ±   1%   2540.6Mi ± 14%  +346.68% (p=0.000 n=10)    614.3Mi ±  4%   +8.00% (p=0.000 n=10)
      geomean                                                                                                                                    558.8Mi           2.036Gi        +273.15%                   635.0Mi        +13.64%

                                                                                                                                              │  streaming  │              upfront               │           upfront-pooled           │
                                                                                                                                              │  allocs/op  │  allocs/op   vs base               │  allocs/op   vs base               │
      sum_by_(cluster,_namespace)_(rate({region="ap-southeast-1",_env="dev"}_|_detected_level=~"error|warn"_[5m]))                              12.69M ± 0%   12.71M ± 0%       ~ (p=0.165 n=10)   12.67M ± 0%  -0.20% (p=0.002 n=10)
      sum_by_(cluster,_namespace)_(rate({region="ap-southeast-1"}_|_detected_level=~"error|warn"_[5m]))                                         14.25M ± 0%   14.29M ± 0%  +0.28% (p=0.000 n=10)   14.24M ± 0%  -0.11% (p=0.011 n=10)
      sum_by_(cluster,_namespace)_(rate({service_name="grafana",_env="prod",_region="us-west-2"}_|_detected_level=~"error|warn"_[5m]))          5.735M ± 0%   5.730M ± 0%  -0.09% (p=0.029 n=10)   5.720M ± 0%  -0.26% (p=0.000 n=10)
      sum_by_(cluster,_namespace)_(rate({service_name="kubernetes"}_|_detected_level=~"error|warn"_[5m]))                                       12.18M ± 0%   12.20M ± 0%  +0.16% (p=0.003 n=10)   12.17M ± 0%  -0.12% (p=0.015 n=10)
      sum_by_(component)_(rate({region="ap-southeast-1",_env="dev"}_|_detected_level="error"_[5m]))                                             12.51M ± 0%   12.54M ± 0%  +0.27% (p=0.002 n=10)   12.49M ± 0%  -0.14% (p=0.001 n=10)
      sum_by_(component)_(rate({region="ap-southeast-1",_env="dev"}_|_detected_level="warn"_[5m]))                                              12.52M ± 0%   12.54M ± 0%  +0.19% (p=0.000 n=10)   12.49M ± 0%  -0.21% (p=0.000 n=10)
      sum_by_(component)_(rate({region="ap-southeast-1"}_|_detected_level="error"_[5m]))                                                        13.82M ± 0%   13.87M ± 0%  +0.33% (p=0.002 n=10)   13.81M ± 0%  -0.11% (p=0.000 n=10)
      sum_by_(component)_(rate({region="ap-southeast-1"}_|_detected_level="warn"_[5m]))                                                         13.82M ± 0%   13.86M ± 0%  +0.30% (p=0.000 n=10)   13.81M ± 0%  -0.08% (p=0.000 n=10)
      sum_by_(component)_(rate({service_name="grafana",_env="prod",_region="us-west-2"}_|_detected_level="error"_[5m]))                         5.726M ± 0%   5.723M ± 0%       ~ (p=0.280 n=10)   5.714M ± 0%  -0.20% (p=0.000 n=10)
      sum_by_(component)_(rate({service_name="grafana",_env="prod",_region="us-west-2"}_|_detected_level="warn"_[5m]))                          5.729M ± 0%   5.723M ± 0%       ~ (p=0.190 n=10)   5.714M ± 0%  -0.26% (p=0.000 n=10)
      sum_by_(component)_(rate({service_name="kubernetes"}_|_detected_level="error"_[5m]))                                                      12.07M ± 0%   12.08M ± 0%       ~ (p=0.089 n=10)   12.05M ± 0%  -0.21% (p=0.000 n=10)
      sum_by_(component)_(rate({service_name="kubernetes"}_|_detected_level="warn"_[5m]))                                                       12.06M ± 0%   12.08M ± 0%       ~ (p=0.105 n=10)   12.04M ± 0%  -0.15% (p=0.000 n=10)
      sum_by_(component,_detected_level)_(rate({region="ap-southeast-1",_env="dev"}_|_detected_level=~"error|warn"_[5m]))                       12.69M ± 0%   12.71M ± 0%  +0.18% (p=0.003 n=10)   12.67M ± 0%  -0.20% (p=0.001 n=10)
      sum_by_(component,_detected_level)_(rate({region="ap-southeast-1"}_|_detected_level=~"error|warn"_[5m]))                                  14.26M ± 0%   14.31M ± 0%  +0.30% (p=0.002 n=10)   14.24M ± 0%  -0.16% (p=0.004 n=10)
      sum_by_(component,_detected_level)_(rate({region="ap-southeast-1"}[1m]))                                                                  6.859M ± 0%   6.881M ± 0%  +0.32% (p=0.000 n=10)   6.845M ± 0%  -0.20% (p=0.000 n=10)
      sum_by_(component,_detected_level)_(rate({service_name="grafana",_env="prod",_region="us-west-2"}_|_detected_level=~"error|warn"_[5m]))   5.734M ± 0%   5.731M ± 0%       ~ (p=0.218 n=10)   5.723M ± 0%  -0.20% (p=0.000 n=10)
      sum_by_(component,_detected_level)_(rate({service_name="kubernetes"}_|_detected_level=~"error|warn"_[5m]))                                12.19M ± 0%   12.21M ± 0%  +0.16% (p=0.011 n=10)   12.17M ± 0%  -0.13% (p=0.001 n=10)
      sum_by_(env)_(rate({region="ap-southeast-1",_env="dev"}_|_detected_level=~"error|warn"_[5m]))                                             12.67M ± 0%   12.71M ± 0%  +0.28% (p=0.000 n=10)   12.66M ± 0%  -0.13% (p=0.000 n=10)
      sum_by_(env)_(rate({region="ap-southeast-1"}_|_detected_level=~"error|warn"_[5m]))                                                        14.24M ± 0%   14.26M ± 0%  +0.19% (p=0.015 n=10)   14.22M ± 0%  -0.11% (p=0.000 n=10)
      sum_by_(env)_(rate({service_name="grafana",_env="prod",_region="us-west-2"}_|_detected_level=~"error|warn"_[5m]))                         5.733M ± 0%   5.729M ± 0%       ~ (p=0.089 n=10)   5.720M ± 0%  -0.22% (p=0.000 n=10)
      sum_by_(env)_(rate({service_name="kubernetes"}_|_detected_level=~"error|warn"_[5m]))                                                      12.18M ± 0%   12.20M ± 0%  +0.14% (p=0.029 n=10)   12.16M ± 0%  -0.12% (p=0.005 n=10)
      sum_by_(env,_component)_(rate({region="ap-southeast-1",_env="dev"}_|_detected_level=~"error|warn"_[5m]))                                  12.67M ± 0%   12.70M ± 0%  +0.19% (p=0.000 n=10)   12.65M ± 0%  -0.14% (p=0.001 n=10)
      sum_by_(env,_component)_(rate({region="ap-southeast-1"}_|_detected_level=~"error|warn"_[5m]))                                             14.23M ± 0%   14.29M ± 0%  +0.42% (p=0.000 n=10)   14.22M ± 0%  -0.09% (p=0.000 n=10)
      sum_by_(env,_component)_(rate({service_name="grafana",_env="prod",_region="us-west-2"}_|_detected_level=~"error|warn"_[5m]))              5.735M ± 0%   5.732M ± 0%       ~ (p=0.218 n=10)   5.723M ± 0%  -0.21% (p=0.000 n=10)
      sum_by_(env,_component)_(rate({service_name="kubernetes"}_|_detected_level=~"error|warn"_[5m]))                                           12.18M ± 0%   12.20M ± 0%  +0.14% (p=0.043 n=10)   12.16M ± 0%  -0.12% (p=0.002 n=10)
      sum_by_(namespace)_(rate({region="ap-southeast-1",_env="dev"}_|_detected_level=~"error|warn"_[5m]))                                       12.68M ± 0%   12.71M ± 0%  +0.27% (p=0.000 n=10)   12.66M ± 0%  -0.13% (p=0.000 n=10)
      sum_by_(namespace)_(rate({region="ap-southeast-1"}_|_detected_level=~"error|warn"_[5m]))                                                  14.24M ± 0%   14.30M ± 0%  +0.40% (p=0.003 n=10)   14.23M ± 0%       ~ (p=0.089 n=10)
      sum_by_(namespace)_(rate({service_name="grafana",_env="prod",_region="us-west-2"}_|_detected_level=~"error|warn"_[5m]))                   5.735M ± 0%   5.729M ± 0%       ~ (p=0.105 n=10)   5.722M ± 0%  -0.22% (p=0.000 n=10)
      sum_by_(namespace)_(rate({service_name="kubernetes"}_|_detected_level=~"error|warn"_[5m]))                                                12.18M ± 0%   12.20M ± 0%  +0.15% (p=0.035 n=10)   12.17M ± 0%  -0.12% (p=0.001 n=10)
      sum_by_(pod)_(rate({region="ap-southeast-1",_env="dev"}_|_detected_level=~"error|warn"_[5m]))                                             12.68M ± 0%   12.72M ± 0%  +0.32% (p=0.000 n=10)   12.66M ± 0%  -0.12% (p=0.000 n=10)
      sum_by_(pod)_(rate({region="ap-southeast-1"}_|_detected_level=~"error|warn"_[5m]))                                                        14.25M ± 0%   14.31M ± 0%  +0.42% (p=0.000 n=10)   14.24M ± 0%  -0.08% (p=0.000 n=10)
      sum_by_(pod)_(rate({service_name="grafana",_env="prod",_region="us-west-2"}_|_detected_level=~"error|warn"_[5m]))                         5.733M ± 0%   5.730M ± 0%       ~ (p=0.218 n=10)   5.721M ± 0%  -0.21% (p=0.000 n=10)
      sum_by_(pod)_(rate({service_name="kubernetes"}_|_detected_level=~"error|warn"_[5m]))                                                      12.18M ± 0%   12.20M ± 0%  +0.17% (p=0.007 n=10)   12.17M ± 0%  -0.08% (p=0.035 n=10)
      {region="ap-southeast-1",_env="dev"}_[BACKWARD]                                                                                           16.26M ± 0%   16.28M ± 0%  +0.12% (p=0.015 n=10)   16.25M ± 0%  -0.09% (p=0.000 n=10)
      {region="ap-southeast-1",_env="dev"}_[FORWARD]                                                                                            16.21M ± 0%   16.23M ± 0%  +0.10% (p=0.002 n=10)   16.20M ± 0%  -0.09% (p=0.000 n=10)
      {region="ap-southeast-1",_env="dev"}_|_detected_level="error"_[BACKWARD]                                                                  13.39M ± 0%   13.44M ± 0%  +0.32% (p=0.000 n=10)   13.39M ± 0%  -0.02% (p=0.001 n=10)
      {region="ap-southeast-1",_env="dev"}_|_detected_level="error"_[FORWARD]                                                                   13.40M ± 0%   13.42M ± 0%  +0.19% (p=0.002 n=10)   13.38M ± 0%  -0.13% (p=0.002 n=10)
      {region="ap-southeast-1",_env="dev"}_|_detected_level="warn"_[BACKWARD]                                                                   13.41M ± 0%   13.42M ± 0%  +0.15% (p=0.000 n=10)   13.39M ± 0%  -0.12% (p=0.000 n=10)
      {region="ap-southeast-1",_env="dev"}_|_detected_level="warn"_[FORWARD]                                                                    13.40M ± 0%   13.43M ± 0%  +0.18% (p=0.004 n=10)   13.38M ± 0%  -0.16% (p=0.000 n=10)
      {region="ap-southeast-1",_env="dev"}_|_json_|_duration_seconds_>_0.1_|_detected_level!="debug"_[BACKWARD]                                 14.67M ± 0%   14.70M ± 0%  +0.16% (p=0.023 n=10)   14.65M ± 0%  -0.18% (p=0.000 n=10)
      {region="ap-southeast-1",_env="dev"}_|_json_|_duration_seconds_>_0.1_|_detected_level!="debug"_[FORWARD]                                  14.66M ± 0%   14.69M ± 0%  +0.15% (p=0.001 n=10)   14.65M ± 0%  -0.12% (p=0.000 n=10)
      {region="ap-southeast-1",_env="dev"}_|_logfmt_|_level="error"_|_detected_level="error"_[BACKWARD]                                         18.46M ± 0%   18.48M ± 0%  +0.10% (p=0.007 n=10)   18.45M ± 0%  -0.10% (p=0.000 n=10)
      {region="ap-southeast-1",_env="dev"}_|_logfmt_|_level="error"_|_detected_level="error"_[FORWARD]                                          18.45M ± 0%   18.48M ± 0%  +0.14% (p=0.000 n=10)   18.44M ± 0%  -0.10% (p=0.000 n=10)
      {region="ap-southeast-1",_env="dev"}_|~_"error|exception"_|_detected_level="error"_[BACKWARD]                                             4.333M ± 0%   4.340M ± 0%  +0.16% (p=0.023 n=10)   4.319M ± 0%  -0.32% (p=0.000 n=10)
      {region="ap-southeast-1",_env="dev"}_|~_"error|exception"_|_detected_level="error"_[FORWARD]                                              4.321M ± 0%   4.332M ± 0%  +0.24% (p=0.043 n=10)   4.311M ± 0%  -0.24% (p=0.000 n=10)
      {region="ap-southeast-1"}_[BACKWARD]                                                                                                      22.81M ± 0%   22.87M ± 0%  +0.28% (p=0.000 n=10)   22.79M ± 0%  -0.08% (p=0.000 n=10)
      {region="ap-southeast-1"}_[FORWARD]                                                                                                       22.75M ± 0%   22.76M ± 0%  +0.06% (p=0.004 n=10)   22.74M ± 0%  -0.04% (p=0.015 n=10)
      {region="ap-southeast-1"}_|_detected_level="error"_[BACKWARD]                                                                             15.89M ± 0%   15.91M ± 0%  +0.10% (p=0.019 n=10)   15.88M ± 0%  -0.04% (p=0.023 n=10)
      {region="ap-southeast-1"}_|_detected_level="error"_[FORWARD]                                                                              15.88M ± 0%   15.91M ± 0%  +0.15% (p=0.002 n=10)   15.87M ± 0%  -0.06% (p=0.002 n=10)
      {region="ap-southeast-1"}_|_detected_level="warn"_[BACKWARD]                                                                              15.90M ± 0%   15.92M ± 0%  +0.14% (p=0.015 n=10)   15.89M ± 0%       ~ (p=0.052 n=10)
      {region="ap-southeast-1"}_|_detected_level="warn"_[FORWARD]                                                                               15.89M ± 0%   15.93M ± 0%  +0.24% (p=0.000 n=10)   15.88M ± 0%  -0.09% (p=0.001 n=10)
      {region="ap-southeast-1"}_|_detected_level=~"error|warn"_[BACKWARD]                                                                       7.793M ± 0%   7.792M ± 0%       ~ (p=0.912 n=10)   7.779M ± 0%  -0.17% (p=0.001 n=10)
      {region="ap-southeast-1"}_|_detected_level=~"error|warn"_[FORWARD]                                                                        7.789M ± 0%   7.794M ± 0%       ~ (p=0.739 n=10)   7.775M ± 0%  -0.17% (p=0.000 n=10)
      {region="ap-southeast-1"}_|_json_|_duration_seconds_>_0.1_|_detected_level!="debug"_[BACKWARD]                                            20.44M ± 0%   20.49M ± 0%  +0.21% (p=0.000 n=10)   20.43M ± 0%  -0.06% (p=0.000 n=10)
      {region="ap-southeast-1"}_|_json_|_duration_seconds_>_0.1_|_detected_level!="debug"_[FORWARD]                                             20.44M ± 0%   20.46M ± 0%  +0.08% (p=0.001 n=10)   20.43M ± 0%  -0.05% (p=0.000 n=10)
      {region="ap-southeast-1"}_|_logfmt_|_level="error"_|_detected_level="error"_[BACKWARD]                                                    28.58M ± 0%   28.60M ± 0%  +0.10% (p=0.029 n=10)   28.57M ± 0%  -0.03% (p=0.002 n=10)
      {region="ap-southeast-1"}_|_logfmt_|_level="error"_|_detected_level="error"_[FORWARD]                                                     28.57M ± 0%   28.57M ± 0%       ~ (p=0.353 n=10)   28.55M ± 0%  -0.06% (p=0.000 n=10)
      {region="ap-southeast-1"}_|~_"error|exception"_|_detected_level="error"_[BACKWARD]                                                        6.385M ± 0%   6.381M ± 0%       ~ (p=0.481 n=10)   6.366M ± 0%  -0.29% (p=0.000 n=10)
      {region="ap-southeast-1"}_|~_"error|exception"_|_detected_level="error"_[FORWARD]                                                         6.371M ± 0%   6.370M ± 0%       ~ (p=0.631 n=10)   6.355M ± 0%  -0.25% (p=0.000 n=10)
      {service_name="grafana",_env="prod",_region="us-west-2"}_[BACKWARD]                                                                       5.882M ± 0%   5.881M ± 0%       ~ (p=0.481 n=10)   5.868M ± 0%  -0.23% (p=0.000 n=10)
      {service_name="grafana",_env="prod",_region="us-west-2"}_[FORWARD]                                                                        5.885M ± 0%   5.876M ± 0%  -0.15% (p=0.000 n=10)   5.868M ± 0%  -0.29% (p=0.000 n=10)
      {service_name="grafana",_env="prod",_region="us-west-2"}_|_detected_level="error"_[BACKWARD]                                              5.764M ± 0%   5.755M ± 0%  -0.15% (p=0.001 n=10)   5.749M ± 0%  -0.25% (p=0.000 n=10)
      {service_name="grafana",_env="prod",_region="us-west-2"}_|_detected_level="error"_[FORWARD]                                               5.768M ± 0%   5.758M ± 0%  -0.18% (p=0.000 n=10)   5.748M ± 0%  -0.35% (p=0.000 n=10)
      {service_name="grafana",_env="prod",_region="us-west-2"}_|_detected_level="warn"_[BACKWARD]                                               5.764M ± 0%   5.760M ± 0%       ~ (p=0.529 n=10)   5.749M ± 0%  -0.26% (p=0.000 n=10)
      {service_name="grafana",_env="prod",_region="us-west-2"}_|_detected_level="warn"_[FORWARD]                                                5.761M ± 0%   5.756M ± 0%       ~ (p=0.481 n=10)   5.750M ± 0%  -0.19% (p=0.000 n=10)
      {service_name="grafana",_env="prod",_region="us-west-2"}_|_json_|_duration_seconds_>_0.1_|_detected_level!="debug"_[BACKWARD]             5.722M ± 0%   5.719M ± 0%       ~ (p=0.436 n=10)   5.707M ± 0%  -0.26% (p=0.000 n=10)
      {service_name="grafana",_env="prod",_region="us-west-2"}_|_json_|_duration_seconds_>_0.1_|_detected_level!="debug"_[FORWARD]              5.719M ± 0%   5.717M ± 0%       ~ (p=0.218 n=10)   5.709M ± 0%  -0.18% (p=0.000 n=10)
      {service_name="grafana",_env="prod",_region="us-west-2"}_|_logfmt_|_level="error"_|_detected_level="error"_[BACKWARD]                     5.931M ± 0%   5.928M ± 0%       ~ (p=0.218 n=10)   5.920M ± 0%  -0.20% (p=0.000 n=10)
      {service_name="grafana",_env="prod",_region="us-west-2"}_|_logfmt_|_level="error"_|_detected_level="error"_[FORWARD]                      5.933M ± 0%   5.926M ± 0%  -0.12% (p=0.004 n=10)   5.921M ± 0%  -0.21% (p=0.000 n=10)
      {service_name="grafana",_env="prod",_region="us-west-2"}_|~_"error|exception"_|_detected_level="error"_[BACKWARD]                         4.349M ± 0%   4.337M ± 0%  -0.29% (p=0.002 n=10)   4.329M ± 0%  -0.46% (p=0.000 n=10)
      {service_name="grafana",_env="prod",_region="us-west-2"}_|~_"error|exception"_|_detected_level="error"_[FORWARD]                          4.350M ± 0%   4.338M ± 0%  -0.26% (p=0.003 n=10)   4.327M ± 0%  -0.51% (p=0.000 n=10)
      {service_name="kubernetes"}_[BACKWARD]                                                                                                    15.00M ± 0%   15.01M ± 0%       ~ (p=0.529 n=10)   14.98M ± 0%  -0.11% (p=0.000 n=10)
      {service_name="kubernetes"}_[FORWARD]                                                                                                     14.95M ± 0%   14.95M ± 0%       ~ (p=0.739 n=10)   14.94M ± 0%  -0.10% (p=0.000 n=10)
      {service_name="kubernetes"}_|_detected_level="error"_[BACKWARD]                                                                           12.76M ± 0%   12.78M ± 0%  +0.16% (p=0.019 n=10)   12.75M ± 0%  -0.06% (p=0.000 n=10)
      {service_name="kubernetes"}_|_detected_level="error"_[FORWARD]                                                                            12.75M ± 0%   12.77M ± 0%  +0.15% (p=0.004 n=10)   12.75M ± 0%  -0.06% (p=0.002 n=10)
      {service_name="kubernetes"}_|_detected_level="warn"_[BACKWARD]                                                                            12.76M ± 0%   12.79M ± 0%       ~ (p=0.123 n=10)   12.75M ± 0%  -0.12% (p=0.000 n=10)
      {service_name="kubernetes"}_|_detected_level="warn"_[FORWARD]                                                                             12.76M ± 0%   12.77M ± 0%  +0.11% (p=0.000 n=10)   12.74M ± 0%  -0.12% (p=0.000 n=10)
      {service_name="kubernetes"}_|_json_|_duration_seconds_>_0.1_|_detected_level!="debug"_[BACKWARD]                                          11.92M ± 0%   11.95M ± 0%  +0.23% (p=0.000 n=10)   11.92M ± 0%  -0.07% (p=0.001 n=10)
      {service_name="kubernetes"}_|_json_|_duration_seconds_>_0.1_|_detected_level!="debug"_[FORWARD]                                           11.94M ± 0%   11.95M ± 0%       ~ (p=0.052 n=10)   11.92M ± 0%  -0.18% (p=0.000 n=10)
      {service_name="kubernetes"}_|_logfmt_|_level="error"_|_detected_level="error"_[BACKWARD]                                                  14.25M ± 0%   14.26M ± 0%       ~ (p=0.247 n=10)   14.24M ± 0%  -0.11% (p=0.000 n=10)
      {service_name="kubernetes"}_|_logfmt_|_level="error"_|_detected_level="error"_[FORWARD]                                                   14.24M ± 0%   14.25M ± 0%  +0.12% (p=0.011 n=10)   14.23M ± 0%  -0.06% (p=0.000 n=10)
      {service_name="kubernetes"}_|~_"error|exception"_|_detected_level="error"_[BACKWARD]                                                      3.782M ± 0%   3.779M ± 0%       ~ (p=0.123 n=10)   3.765M ± 0%  -0.46% (p=0.000 n=10)
      {service_name="kubernetes"}_|~_"error|exception"_|_detected_level="error"_[FORWARD]                                                       3.780M ± 1%   3.767M ± 0%       ~ (p=0.280 n=10)   3.757M ± 0%  -0.60% (p=0.000 n=10)
      geomean                                                                                                                                   10.40M        10.41M       +0.10%                  10.38M       -0.16%