### PR TITLE
docs: Add links to learning journeys

### DIFF
--- a/docs/sources/send-data/alloy/_index.md
+++ b/docs/sources/send-data/alloy/_index.md
@@ -52,6 +52,10 @@ Here is a non-exhaustive list of components that can be used to build a log pipe
 | Writer     | [loki.write](https://grafana.com/docs/alloy/latest/reference/components/loki.write/)                |
 | Writer     | [otelcol.exporter.loki](https://grafana.com/docs/alloy/latest/reference/components/otelcol.exporter.loki/) |
 
+## Learning journey
+
+{{< docs/learning-journeys title="Send logs to Grafana Cloud using Alloy" url="https://grafana.com/docs/learning-journeys/send-logs-alloy-loki/" >}}
+
 ## Interactive Tutorials
 
 To learn more about how to configure Alloy to send logs to Loki within different scenarios, follow these interactive tutorials:

--- a/docs/sources/visualize/grafana.md
+++ b/docs/sources/visualize/grafana.md
@@ -35,6 +35,8 @@ Grafana Logs Drilldown lets you automatically visualize and explore logs. Logs D
 Starting with Grafana v11.3, the plugin for the Logs Drilldown app is installed in Grafana by default.
 {{< /admonition >}}
 
+{{< docs/learning-journeys title="Explore logs using Logs Drilldown" url="https://grafana.com/docs/learning-journeys/drilldown-logs/" >}}
+
 ## Grafana Explore
 
 [Grafana Explore](https://grafana.com/docs/grafana/latest/explore/) helps you build and iterate on a LogQL query outside of the dashboard user interface. If you just want to explore your data and do not want to create a dashboard, then Explore makes this much easier.
@@ -71,3 +73,5 @@ Because Loki can be used as a built-in data source, you can use LogQL queries ba
 To configure Loki as a data source via provisioning, refer to the documentation for [Loki data source](https://grafana.com/docs/grafana/latest/datasources/loki/#configure-the-datasource-with-provisioning).
 
 Read more about how to build Grafana Dashboards in [build your first dashboard](https://grafana.com/docs/grafana/latest/getting-started/build-first-dashboard/).
+
+{{< docs/learning-journeys title="Visualize logs in a Grafana Cloud dashboard" url="https://grafana.com/docs/learning-journeys/visualization-logs/" >}}


### PR DESCRIPTION
**What this PR does / why we need it**:
Add links to the three new learning journeys related to logs.