### PR TITLE
fix(err-prop): status code propagation (attempt 2)

### DIFF
--- a/pkg/querier/queryrange/queryrangebase/retry.go
+++ b/pkg/querier/queryrange/queryrangebase/retry.go
@@ -96,7 +96,12 @@ func (r retry) Do(ctx context.Context, req Request) (Response, error) {
 			return nil, ctx.Err()
 		}
 
-		code := grpcutil.ErrorToStatusCode(err)
+		var code int
+		st, ok := grpcutil.ErrorToStatus(err)
+		if ok {
+			code = int(st.Code())
+		}
+
 		// Error handling is tricky... There are many places we wrap any error and set an HTTP style status code
 		// but there are also places where we return an existing GRPC object which will use GRPC status codes
 		// If the code is < 100 it's a gRPC status code, currently we retry all of these, even codes.Canceled

--- a/pkg/util/errors.go
+++ b/pkg/util/errors.go
@@ -82,6 +82,11 @@ func (es MultiError) Is(target error) bool {
 	return true
 }
 
+// Unwrap returns the errors as a slice, enabling errors.As to work.
+func (es MultiError) Unwrap() []error {
+	return []error(es)
+}
+
 // IsDeadlineExceeded tells if all errors are either context.DeadlineExceeded or grpc codes.DeadlineExceeded.
 func (es MultiError) IsDeadlineExceeded() bool {
 	if len(es) == 0 {


### PR DESCRIPTION
## Fix error handling for MultiError with new Unwrap() method

This PR supersedes a previous approach (https://github.com/grafana/loki/pull/17950) which implements error code propagation across sharded subqueries more effectively by supporting the `Unwrap()` method which allows using `errors.{Is,As}`. Doing so unfortunately also broke the brittle and custom handling of `pkg/util/server.ClientHTTPStatusAndError`, which I refactored to account for this (some of the expected test logic felt a bit funky, but I ensured my refactor matched the current testware expectations nonetheless).

### Changes

#### 1. Enhanced MultiError (`pkg/util/errors.go`)
- Added `Unwrap() []error` method to enable `errors.As()` functionality

#### 2. Updated retry logic (`pkg/querier/queryrange/queryrangebase/retry.go`)  
- Replaced `grpcutil.ErrorToStatusCode()` with `grpcutil.ErrorToStatus()` which signals failure during status extraction

#### 3. Fixed error handling (`pkg/util/server/error.go`) to account for MultiError implementing Unwrap() and therefore being able to enumerate values inside an error chain
- Restructured `ClientHTTPStatusAndError()` to handle new `Unwrap()` behavior:
  - **Pure MultiError cases**: Use `MultiError.Is()` and `MultiError.IsDeadlineExceeded()` methods
  - **Mixed MultiError cases**: Skip `errors.Is()` checks to preserve HTTP 500 behavior  
  - **Single error cases**: Continue using `errors.Is()` as before
- Updated gRPC error handling to use `grpcutil.ErrorToStatus()`
