### PR TITLE
feat: Add s2 compression

### DIFF
--- a/cmd/chunks-inspect/loki.go
+++ b/cmd/chunks-inspect/loki.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/golang/snappy"
 	"github.com/klauspost/compress/flate"
+	"github.com/klauspost/compress/s2"
 	"github.com/klauspost/compress/zstd"
 	"github.com/pierrec/lz4"
 )
@@ -50,8 +51,9 @@ var (
 		}
 		return r, nil
 	}}
+	encS2 = Encoding{code: 10, name: "s2", readerFn: func(reader io.Reader) (io.Reader, error) { return s2.NewReader(reader), nil }}
 
-	Encodings = []Encoding{encNone, encGZIP, encDumb, encLZ4, encSnappy, enclz4_256k, enclz4_1M, enclz4_4M, encFlate, encZstd}
+	Encodings = []Encoding{encNone, encGZIP, encDumb, encLZ4, encSnappy, enclz4_256k, enclz4_1M, enclz4_4M, encFlate, encZstd, encS2}
 )
 
 const (

--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -3976,7 +3976,7 @@ flush_op_backoff:
 [chunk_target_size: <int> | default = 1572864]
 
 # The algorithm to use for compressing chunk. (none, gzip, lz4-64k, snappy,
-# lz4-256k, lz4-1M, lz4, flate, zstd)
+# lz4-256k, lz4-1M, lz4, flate, zstd, s2)
 # CLI flag: -ingester.chunk-encoding
 [chunk_encoding: <string> | default = "gzip"]
 

--- a/pkg/chunkenc/memchunk_test.go
+++ b/pkg/chunkenc/memchunk_test.go
@@ -45,6 +45,7 @@ var testEncodings = []compression.Codec{
 	compression.Snappy,
 	compression.Flate,
 	compression.Zstd,
+	compression.S2,
 }
 
 var (

--- a/pkg/compression/codec.go
+++ b/pkg/compression/codec.go
@@ -23,6 +23,7 @@ const (
 	LZ4_4M
 	Flate
 	Zstd
+	S2
 )
 
 var supportedCodecs = []Codec{
@@ -35,6 +36,7 @@ var supportedCodecs = []Codec{
 	LZ4_4M,
 	Flate,
 	Zstd,
+	S2,
 }
 
 func (e Codec) String() string {
@@ -57,6 +59,8 @@ func (e Codec) String() string {
 		return "flate"
 	case Zstd:
 		return "zstd"
+	case S2:
+		return "s2"
 	default:
 		return "unknown"
 	}

--- a/pkg/compression/fileext.go
+++ b/pkg/compression/fileext.go
@@ -9,6 +9,7 @@ const (
 	ExtLZ4    = ".lz4"
 	ExtFlate  = ".zz"
 	ExtZstd   = ".zst"
+	ExtS2     = ".s2"
 )
 
 func ToFileExtension(e Codec) string {
@@ -25,6 +26,8 @@ func ToFileExtension(e Codec) string {
 		return ExtFlate
 	case Zstd:
 		return ExtZstd
+	case S2:
+		return ExtS2
 	default:
 		panic(fmt.Sprintf("invalid codec: %d, supported: %s", e, SupportedCodecs()))
 	}
@@ -44,6 +47,8 @@ func FromFileExtension(ext string) Codec {
 		return Flate
 	case ExtZstd:
 		return Zstd
+	case ExtS2:
+		return S2
 	default:
 		panic(fmt.Sprintf("invalid file extension: %s", ext))
 	}

--- a/pkg/dataobj/internal/dataset/page.go
+++ b/pkg/dataobj/internal/dataset/page.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 
 	"github.com/golang/snappy"
+	"github.com/klauspost/compress/s2"
 	"github.com/klauspost/compress/zstd"
 
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/metadata/datasetmd"
@@ -168,6 +169,15 @@ func (p *MemPage) open(compression datasetmd.CompressionType) (openedPage, io.Cl
 			ValueData:    buf,
 		}, closer, nil
 
+	case datasetmd.COMPRESSION_TYPE_S2:
+		sr := s2Pool.Get().(*s2.Reader)
+		sr.Reset(compressedValuesReader)
+		return bitmapReader, &closerFunc{Reader: sr, onClose: func() error {
+			sr.Reset(nil) // Allow releasing the buffer.
+			s2Pool.Put(sr)
+			return nil
+		}}, nil
+
 	default:
 		// We do *not* want to panic here, as we may be trying to read a page from
 		// a newer format.
@@ -194,6 +204,12 @@ func (p *MemPage) reader(compression datasetmd.CompressionType) (presence io.Rea
 var snappyPool = sync.Pool{
 	New: func() any {
 		return snappy.NewReader(nil)
+	},
+}
+
+var s2Pool = sync.Pool{
+	New: func() any {
+		return s2.NewReader(nil)
 	},
 }
 

--- a/pkg/dataobj/internal/metadata/datasetmd/datasetmd.pb.go
+++ b/pkg/dataobj/internal/metadata/datasetmd/datasetmd.pb.go
@@ -71,6 +71,8 @@ const (
 	COMPRESSION_TYPE_SNAPPY CompressionType = 2
 	// Zstd compression.
 	COMPRESSION_TYPE_ZSTD CompressionType = 3
+	// S2 compression.
+	COMPRESSION_TYPE_S2 CompressionType = 4
 )
 
 var CompressionType_name = map[int32]string{
@@ -78,6 +80,7 @@ var CompressionType_name = map[int32]string{
 	1: "COMPRESSION_TYPE_NONE",
 	2: "COMPRESSION_TYPE_SNAPPY",
 	3: "COMPRESSION_TYPE_ZSTD",
+	4: "COMPRESSION_TYPE_S2",
 }
 
 var CompressionType_value = map[string]int32{
@@ -85,6 +88,7 @@ var CompressionType_value = map[string]int32{
 	"COMPRESSION_TYPE_NONE":        1,
 	"COMPRESSION_TYPE_SNAPPY":      2,
 	"COMPRESSION_TYPE_ZSTD":        3,
+	"COMPRESSION_TYPE_S2":          4,
 }
 
 func (CompressionType) EnumDescriptor() ([]byte, []int) {

--- a/pkg/dataobj/internal/metadata/datasetmd/datasetmd.proto
+++ b/pkg/dataobj/internal/metadata/datasetmd/datasetmd.proto
@@ -143,6 +143,9 @@ enum CompressionType {
 
   // Zstd compression.
   COMPRESSION_TYPE_ZSTD = 3;
+
+  // S2 compression.
+  COMPRESSION_TYPE_S2 = 4;
 }
 
 // ColumnMetadata holds additional metadata for an individual column.

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -772,7 +772,7 @@ func TestValidate(t *testing.T) {
 				FlushOpTimeout: 15 * time.Second,
 				IndexShards:    index.DefaultIndexShards,
 			},
-			expectedErr: "invalid encoding: bad-enc, supported: none, gzip, lz4-64k, snappy, lz4-256k, lz4-1M, lz4, flate, zstd",
+			expectedErr: "invalid encoding: bad-enc, supported: none, gzip, lz4-64k, snappy, lz4-256k, lz4-1M, lz4, flate, zstd, s2",
 		},
 		{
 			in: Config{

--- a/pkg/storage/bloom/v1/archive_test.go
+++ b/pkg/storage/bloom/v1/archive_test.go
@@ -90,6 +90,7 @@ func TestArchiveCompression(t *testing.T) {
 		{compression.LZ4_4M},
 		{compression.Flate},
 		{compression.Zstd},
+		{compression.S2},
 	} {
 		t.Run(tc.enc.String(), func(t *testing.T) {
 			// for writing files to two dirs for comparison and ensuring they're equal

--- a/pkg/storage/bloom/v1/builder_test.go
+++ b/pkg/storage/bloom/v1/builder_test.go
@@ -22,6 +22,7 @@ var blockEncodings = []compression.Codec{
 	compression.Snappy,
 	compression.LZ4_256k,
 	compression.Zstd,
+	compression.S2,
 }
 
 func TestBlockOptions_BloomPageSize(t *testing.T) {

--- a/pkg/storage/stores/shipper/bloomshipper/client_test.go
+++ b/pkg/storage/stores/shipper/bloomshipper/client_test.go
@@ -31,6 +31,7 @@ var supportedCompressions = []compression.Codec{
 	compression.LZ4_4M,
 	compression.Flate,
 	compression.Zstd,
+	compression.S2,
 }
 
 func parseTime(s string) model.Time {

--- a/pkg/storage/stores/shipper/bloomshipper/resolver_test.go
+++ b/pkg/storage/stores/shipper/bloomshipper/resolver_test.go
@@ -44,6 +44,7 @@ func TestResolver_ParseBlockKey(t *testing.T) {
 		{compression.LZ4_4M, compression.LZ4_4M},
 		{compression.Flate, compression.Flate},
 		{compression.Zstd, compression.Zstd},
+		{compression.S2, compression.S2},
 	} {
 		t.Run(tc.srcEnc.String(), func(t *testing.T) {
 			r := defaultKeyResolver{}


### PR DESCRIPTION
**What this PR does / why we need it**:
Add s2 compression support to the existing compression algorithms.

It seems to behave well enough in some of the benchmarks, for example, when it comes to throughput:
```
BenchmarkWrite/unordered_with_structured_metadata-gzip
BenchmarkWrite/unordered_with_structured_metadata-gzip-8                                              12          96074707 ns/op         234.72 MB/s             6.810 %compressed      25223773 B/op     422987 allocs/op
BenchmarkWrite/unordered_with_structured_metadata-gzip-withStructuredMetadata
BenchmarkWrite/unordered_with_structured_metadata-gzip-withStructuredMetadata-8                       10         105996356 ns/op         212.75 MB/s             6.811 %compressed      31570157 B/op     675036 allocs/op
BenchmarkWrite/unordered_with_structured_metadata-lz4-64k
BenchmarkWrite/unordered_with_structured_metadata-lz4-64k-8                                           34          32075720 ns/op         480.21 MB/s             9.971 %compressed      17714196 B/op     288890 allocs/op
BenchmarkWrite/unordered_with_structured_metadata-lz4-64k-withStructuredMetadata
BenchmarkWrite/unordered_with_structured_metadata-lz4-64k-withStructuredMetadata-8                    30          45929844 ns/op         335.89 MB/s             9.956 %compressed      21284389 B/op     461812 allocs/op
BenchmarkWrite/unordered_with_structured_metadata-lz4-256k
BenchmarkWrite/unordered_with_structured_metadata-lz4-256k-8                                          36          37343397 ns/op         435.39 MB/s             9.446 %compressed      18922264 B/op     304836 allocs/op
BenchmarkWrite/unordered_with_structured_metadata-lz4-256k-withStructuredMetadata
BenchmarkWrite/unordered_with_structured_metadata-lz4-256k-withStructuredMetadata-8                   26          48902601 ns/op         332.47 MB/s             9.446 %compressed      22907188 B/op     486564 allocs/op
BenchmarkWrite/unordered_with_structured_metadata-lz4-1M
BenchmarkWrite/unordered_with_structured_metadata-lz4-1M-8                                            32          35505973 ns/op         465.40 MB/s             9.295 %compressed      18160601 B/op     309751 allocs/op
BenchmarkWrite/unordered_with_structured_metadata-lz4-1M-withStructuredMetadata
BenchmarkWrite/unordered_with_structured_metadata-lz4-1M-withStructuredMetadata-8                     24          49703508 ns/op         332.46 MB/s             9.295 %compressed      22607666 B/op     494462 allocs/op
BenchmarkWrite/unordered_with_structured_metadata-lz4
BenchmarkWrite/unordered_with_structured_metadata-lz4-8                                               26          41058616 ns/op         402.46 MB/s             9.294 %compressed      20405406 B/op     309726 allocs/op
BenchmarkWrite/unordered_with_structured_metadata-lz4-withStructuredMetadata
BenchmarkWrite/unordered_with_structured_metadata-lz4-withStructuredMetadata-8                        24          47171637 ns/op         350.31 MB/s             9.295 %compressed      25637208 B/op     494429 allocs/op
BenchmarkWrite/unordered_with_structured_metadata-snappy
BenchmarkWrite/unordered_with_structured_metadata-snappy-8                                            61          18608137 ns/op         619.87 MB/s            13.32 %compressed       14523152 B/op     216158 allocs/op
BenchmarkWrite/unordered_with_structured_metadata-snappy-withStructuredMetadata
BenchmarkWrite/unordered_with_structured_metadata-snappy-withStructuredMetadata-8                     54          25425725 ns/op         453.66 MB/s            13.32 %compressed       17043793 B/op     345081 allocs/op
BenchmarkWrite/unordered_with_structured_metadata-flate
BenchmarkWrite/unordered_with_structured_metadata-flate-8                                             12          84537068 ns/op         266.78 MB/s             6.811 %compressed      24086459 B/op     422894 allocs/op
BenchmarkWrite/unordered_with_structured_metadata-flate-withStructuredMetadata
BenchmarkWrite/unordered_with_structured_metadata-flate-withStructuredMetadata-8                      13          96308705 ns/op         234.17 MB/s             6.810 %compressed      30653589 B/op     675052 allocs/op
BenchmarkWrite/unordered_with_structured_metadata-zstd
BenchmarkWrite/unordered_with_structured_metadata-zstd-8                                              15          75541777 ns/op         323.84 MB/s             6.278 %compressed      40193129 B/op     459432 allocs/op
BenchmarkWrite/unordered_with_structured_metadata-zstd-withStructuredMetadata
BenchmarkWrite/unordered_with_structured_metadata-zstd-withStructuredMetadata-8                       14          77918388 ns/op         314.03 MB/s             6.277 %compressed      63738900 B/op     733084 allocs/op
BenchmarkWrite/unordered_with_structured_metadata-s2
BenchmarkWrite/unordered_with_structured_metadata-s2-8                                                62          21293105 ns/op         692.60 MB/s            10.41 %compressed       18602644 B/op     276336 allocs/op
BenchmarkWrite/unordered_with_structured_metadata-s2-withStructuredMetadata
BenchmarkWrite/unordered_with_structured_metadata-s2-withStructuredMetadata-8                         39          29392004 ns/op         502.08 MB/s            10.41 %compressed       22944435 B/op     441475 allocs/op
```

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/loki/issues/17835

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
