### PR TITLE
chore: remove unused recheck period

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -1239,10 +1239,6 @@ ingest_limits_frontend:
     # CLI flag: -ingest-limits-frontend.lifecycler.ID
     [id: <string> | default = "<hostname>"]
 
-  # The period to recheck per tenant ingestion rate limit configuration.
-  # CLI flag: -ingest-limits-frontend.recheck-period
-  [recheck_period: <duration> | default = 10s]
-
   # The number of partitions to use for the ring.
   # CLI flag: -ingest-limits-frontend.num-partitions
   [num_partitions: <int> | default = 64]

--- a/pkg/limits/frontend/config.go
+++ b/pkg/limits/frontend/config.go
@@ -15,7 +15,6 @@ import (
 type Config struct {
 	ClientConfig               limits_client.Config  `yaml:"client_config"`
 	LifecyclerConfig           ring.LifecyclerConfig `yaml:"lifecycler,omitempty"`
-	RecheckPeriod              time.Duration         `yaml:"recheck_period"`
 	NumPartitions              int                   `yaml:"num_partitions"`
 	AssignedPartitionsCacheTTL time.Duration         `yaml:"assigned_partitions_cache_ttl"`
 }
@@ -23,7 +22,6 @@ type Config struct {
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	cfg.ClientConfig.RegisterFlagsWithPrefix("ingest-limits-frontend", f)
 	cfg.LifecyclerConfig.RegisterFlagsWithPrefix("ingest-limits-frontend.", f, util_log.Logger)
-	f.DurationVar(&cfg.RecheckPeriod, "ingest-limits-frontend.recheck-period", 10*time.Second, "The period to recheck per tenant ingestion rate limit configuration.")
 	f.IntVar(&cfg.NumPartitions, "ingest-limits-frontend.num-partitions", 64, "The number of partitions to use for the ring.")
 	f.DurationVar(&cfg.AssignedPartitionsCacheTTL, "ingest-limits-frontend.assigned-partitions-cache-ttl", 1*time.Minute, "The TTL for the assigned partitions cache. 0 disables the cache.")
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request removes a flag that is no longer used.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
