### PR TITLE
feat(planning): adds physical and logical nodes for range aggregation

### DIFF
--- a/pkg/engine/internal/types/aggregations.go
+++ b/pkg/engine/internal/types/aggregations.go
@@ -1,0 +1,18 @@
+package types
+
+type RangeAggregationType int
+
+const (
+	RangeAggregationTypeInvalid RangeAggregationType = iota
+
+	RangeAggregationTypeCount // Represents count_over_time range aggregation
+)
+
+func (op RangeAggregationType) String() string {
+	switch op {
+	case RangeAggregationTypeCount:
+		return "count"
+	default:
+		return "invalid"
+	}
+}

--- a/pkg/engine/planner/logical/builder.go
+++ b/pkg/engine/planner/logical/builder.go
@@ -1,6 +1,9 @@
 package logical
 
 import (
+	"time"
+
+	"github.com/grafana/loki/v3/pkg/engine/internal/types"
 	"github.com/grafana/loki/v3/pkg/engine/planner/schema"
 )
 
@@ -45,6 +48,27 @@ func (b *Builder) Sort(column ColumnRef, ascending, nullsFirst bool) *Builder {
 			Column:     column,
 			Ascending:  ascending,
 			NullsFirst: nullsFirst,
+		},
+	}
+}
+
+func (b *Builder) RangeAggregation(
+	partitionBy []ColumnRef,
+	operation types.RangeAggregationType,
+	startTS, endTS time.Time,
+	step *time.Duration,
+	rangeInterval time.Duration,
+) *Builder {
+	return &Builder{
+		val: &RangeAggregation{
+			Table: b.val,
+
+			Operation:     operation,
+			PartitionBy:   partitionBy,
+			Start:         startTS,
+			End:           endTS,
+			Step:          step,
+			RangeInterval: rangeInterval,
 		},
 	}
 }

--- a/pkg/engine/planner/logical/builder_convert.go
+++ b/pkg/engine/planner/logical/builder_convert.go
@@ -41,6 +41,8 @@ func (b *ssaBuilder) process(value Value) (Value, error) {
 		return b.processLimitPlan(value)
 	case *Sort:
 		return b.processSortPlan(value)
+	case *RangeAggregation:
+		return b.processRangeAggregate(value)
 
 	case *UnaryOp:
 		return b.processUnaryOp(value)
@@ -109,6 +111,16 @@ func (b *ssaBuilder) processUnaryOp(value *UnaryOp) (Value, error) {
 	value.id = fmt.Sprintf("%%%d", b.getID())
 	b.instructions = append(b.instructions, value)
 	return value, nil
+}
+
+func (b *ssaBuilder) processRangeAggregate(plan *RangeAggregation) (Value, error) {
+	if _, err := b.process(plan.Table); err != nil {
+		return nil, err
+	}
+
+	plan.id = fmt.Sprintf("%%%d", b.getID())
+	b.instructions = append(b.instructions, plan)
+	return plan, nil
 }
 
 func (b *ssaBuilder) processBinOp(expr *BinOp) (Value, error) {

--- a/pkg/engine/planner/logical/format_tree.go
+++ b/pkg/engine/planner/logical/format_tree.go
@@ -28,6 +28,8 @@ func (t *treeFormatter) convert(value Value) *tree.Node {
 		return t.convertLimit(value)
 	case *Sort:
 		return t.convertSort(value)
+	case *RangeAggregation:
+		return t.convertRangeAggregation(value)
 
 	case *UnaryOp:
 		return t.convertUnaryOp(value)
@@ -125,4 +127,35 @@ func (t *treeFormatter) convertLiteral(expr *Literal) *tree.Node {
 		tree.NewProperty("value", false, expr.String()),
 		tree.NewProperty("kind", false, expr.Kind()),
 	)
+}
+
+func (t *treeFormatter) convertRangeAggregation(r *RangeAggregation) *tree.Node {
+	properties := []tree.Property{
+		tree.NewProperty("table", false, r.Table.Name()),
+		tree.NewProperty("operation", false, r.Operation),
+		tree.NewProperty("start_ts", false, r.Start),
+		tree.NewProperty("end_ts", false, r.End),
+		tree.NewProperty("range", false, r.RangeInterval),
+	}
+
+	if r.Step != nil {
+		properties = append(properties, tree.NewProperty("step", false, r.Step))
+	}
+
+	if len(r.PartitionBy) > 0 {
+		partitionBy := make([]any, len(r.PartitionBy))
+		for i := range r.PartitionBy {
+			partitionBy[i] = r.PartitionBy[i].Name()
+		}
+
+		properties = append(properties, tree.NewProperty("partition_by", true, partitionBy...))
+	}
+
+	node := tree.NewNode("RangeAggregation", r.Name(), properties...)
+	for _, columnRef := range r.PartitionBy {
+		node.Comments = append(node.Comments, t.convert(&columnRef))
+	}
+	node.Children = append(node.Children, t.convert(r.Table))
+
+	return node
 }

--- a/pkg/engine/planner/logical/format_tree_test.go
+++ b/pkg/engine/planner/logical/format_tree_test.go
@@ -3,6 +3,7 @@ package logical
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -101,5 +102,59 @@ SORT <%5> table=%4 column=metadata.age direction=asc nulls=last
                 ├── ColumnRef column=app type=label
                 └── Literal value="users" kind=string
 `
+	require.Equal(t, expected, actual)
+}
+
+func TestFormatRangeAggregate(t *testing.T) {
+	// Build a query plan for a simple range aggregation query:
+	//
+	// count_over_time({ app="users" } | age > 51[5m])
+	b := NewBuilder(
+		&MakeTable{
+			Selector: &BinOp{
+				Left:  NewColumnRef("app", types.ColumnTypeLabel),
+				Right: NewLiteral("users"),
+				Op:    types.BinaryOpEq,
+			},
+		},
+	).Select(
+		&BinOp{
+			Left:  NewColumnRef("age", types.ColumnTypeMetadata),
+			Right: NewLiteral(21),
+			Op:    types.BinaryOpGt,
+		},
+	).RangeAggregation(
+		[]ColumnRef{*NewColumnRef("label1", types.ColumnTypeAmbiguous), *NewColumnRef("label2", types.ColumnTypeAmbiguous)},
+		types.RangeAggregationTypeCount,
+		time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC), // Start Time
+		time.Date(1970, 1, 1, 1, 0, 0, 0, time.UTC), // End Time
+		nil,
+		time.Minute*5, // Range
+	)
+
+	// Convert to plan so that node IDs get populated
+	plan, err := b.ToPlan()
+	require.NoError(t, err)
+
+	var sb strings.Builder
+	PrintTree(&sb, plan.Value())
+
+	actual := "\n" + sb.String()
+	t.Logf("Actual output:\n%s", actual)
+
+	expected := `
+RangeAggregation <%5> table=%4 operation=count start_ts=1970-01-01 00:00:00 +0000 UTC end_ts=1970-01-01 01:00:00 +0000 UTC range=5m0s partition_by=(ambiguous.label1, ambiguous.label2)
+│   ├── ColumnRef column=label1 type=ambiguous
+│   └── ColumnRef column=label2 type=ambiguous
+└── SELECT <%4> table=%2 predicate=%3
+    │   └── BinOp <%3> op=GT left=metadata.age right=21
+    │       ├── ColumnRef column=age type=metadata
+    │       └── Literal value=21 kind=integer
+    └── MAKETABLE <%2> selector=EQ label.app "users"
+            └── BinOp <%1> op=EQ left=label.app right="users"
+                ├── ColumnRef column=app type=label
+                └── Literal value="users" kind=string
+`
+
 	require.Equal(t, expected, actual)
 }

--- a/pkg/engine/planner/logical/node_range_aggregate.go
+++ b/pkg/engine/planner/logical/node_range_aggregate.go
@@ -1,0 +1,109 @@
+package logical
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/grafana/loki/v3/pkg/engine/internal/types"
+	"github.com/grafana/loki/v3/pkg/engine/planner/schema"
+)
+
+// RangeAggregation represents a logical plan node that performs aggregations over a time window.
+// It is similar to window functions in SQL with a few important distinctions:
+// 1. It evaluates the aggregation at step intervals unlike traditional window functions which are evaluated for each row.
+// 2. It uses a time window defined by query [$range].
+// 3. It partitions by query-time streams if no partition by is specified.
+type RangeAggregation struct {
+	id string
+
+	Table       Value       // The table relation to aggregate.
+	PartitionBy []ColumnRef // The columns to partition by.
+
+	Operation     types.RangeAggregationType // The type of aggregation operation to perform.
+	Start         time.Time
+	End           time.Time
+	Step          *time.Duration // optional for instant queries
+	RangeInterval time.Duration
+}
+
+var (
+	_ Value       = (*RangeAggregation)(nil)
+	_ Instruction = (*RangeAggregation)(nil)
+)
+
+// Name returns an identifier for the RangeAggregation operation.
+func (r *RangeAggregation) Name() string {
+	if r.id != "" {
+		return r.id
+	}
+	return fmt.Sprintf("%p", r)
+}
+
+// String returns the disassembled SSA form of the RangeAggregation instruction.
+func (r *RangeAggregation) String() string {
+	props := fmt.Sprintf("operation=%s, start_ts=%s, end_ts=%s, range=%s", r.Operation, r.Start, r.End, r.RangeInterval)
+	if r.Step != nil {
+		props += fmt.Sprintf(", step=%s", r.Step)
+	}
+
+	if len(r.PartitionBy) > 0 {
+		partitionBy := ""
+		for i, columnRef := range r.PartitionBy {
+			if i > 0 {
+				partitionBy += ", "
+			}
+			partitionBy += columnRef.String()
+		}
+
+		return fmt.Sprintf("RANGE_AGGREGATION %s [partition_by=(%s), %s]", r.Table.Name(), partitionBy, props)
+	}
+
+	return fmt.Sprintf("RANGE_AGGREGATION %s [%s]", r.Table.Name(), props)
+}
+
+// Schema returns the schema of the sort plan.
+func (r *RangeAggregation) Schema() *schema.Schema {
+	// When partition by is specified, Schema is comprised of partition columns, timestamp and the aggregated value.
+	if len(r.PartitionBy) > 0 {
+		outputSchema := schema.Schema{
+			Columns: make([]schema.ColumnSchema, 0, len(r.PartitionBy)+2),
+		}
+
+		for _, columnRef := range r.PartitionBy {
+			outputSchema.Columns = append(outputSchema.Columns,
+				schema.ColumnSchema{Name: columnRef.Ref.Column, Type: schema.ValueTypeString},
+			)
+		}
+
+		outputSchema.Columns = append(outputSchema.Columns, schema.ColumnSchema{
+			Name: types.ColumnNameBuiltinMessage,
+			Type: schema.ValueTypeTimestamp,
+		})
+		// Using int64 since only count_over_time is supported.
+		outputSchema.Columns = append(outputSchema.Columns, schema.ColumnSchema{
+			Name: "value",
+			Type: schema.ValueTypeInt64,
+		})
+	}
+
+	// If partition by is empty, we aggregate by query-time series.
+	// Schema is then comprised of:
+	// - input columns excluding message Column
+	// - aggregated value column
+	outputSchema := schema.Schema{
+		Columns: make([]schema.ColumnSchema, 0, len(r.Table.Schema().Columns)),
+	}
+	for _, col := range r.Table.Schema().Columns {
+		if col.Name != types.ColumnNameBuiltinMessage { // Exclude message column
+			outputSchema.Columns = append(outputSchema.Columns, col)
+		}
+	}
+	outputSchema.Columns = append(outputSchema.Columns, schema.ColumnSchema{
+		Name: "value",
+		Type: schema.ValueTypeInt64,
+	})
+	return &outputSchema
+}
+
+func (r *RangeAggregation) isInstruction() {}
+func (r *RangeAggregation) isValue()       {}

--- a/pkg/engine/planner/physical/plan.go
+++ b/pkg/engine/planner/physical/plan.go
@@ -14,6 +14,7 @@ const (
 	NodeTypeProjection
 	NodeTypeFilter
 	NodeTypeLimit
+	NodeTypeRangeAggreation
 )
 
 func (t NodeType) String() string {
@@ -28,6 +29,8 @@ func (t NodeType) String() string {
 		return "Filter"
 	case NodeTypeLimit:
 		return "Limit"
+	case NodeTypeRangeAggreation:
+		return "RangeAggregation"
 	default:
 		return "Undefined"
 	}
@@ -58,12 +61,14 @@ var _ Node = (*SortMerge)(nil)
 var _ Node = (*Projection)(nil)
 var _ Node = (*Limit)(nil)
 var _ Node = (*Filter)(nil)
+var _ Node = (*RangeAggregation)(nil)
 
-func (*DataObjScan) isNode() {}
-func (*SortMerge) isNode()   {}
-func (*Projection) isNode()  {}
-func (*Limit) isNode()       {}
-func (*Filter) isNode()      {}
+func (*DataObjScan) isNode()      {}
+func (*SortMerge) isNode()        {}
+func (*Projection) isNode()       {}
+func (*Limit) isNode()            {}
+func (*Filter) isNode()           {}
+func (*RangeAggregation) isNode() {}
 
 // Edge is a directed connection (parent-child relation) between a two nodes.
 type Edge struct {

--- a/pkg/engine/planner/physical/printer.go
+++ b/pkg/engine/planner/physical/printer.go
@@ -56,6 +56,23 @@ func toTreeNode(n Node) *tree.Node {
 			tree.NewProperty("offset", false, node.Skip),
 			tree.NewProperty("limit", false, node.Fetch),
 		}
+	case *RangeAggregation:
+		properties := []tree.Property{
+			tree.NewProperty("operation", false, node.Operation),
+			tree.NewProperty("start", false, node.Start),
+			tree.NewProperty("end", false, node.End),
+			tree.NewProperty("range", false, node.Range),
+		}
+
+		if node.Step != nil {
+			properties = append(properties, tree.NewProperty("step", false, node.Step))
+		}
+
+		if len(node.PartitionBy) > 0 {
+			properties = append(properties, tree.NewProperty("partition_by", true, toAnySlice(node.PartitionBy)...))
+		}
+
+		treeNode.Properties = properties
 	}
 	return treeNode
 }

--- a/pkg/engine/planner/physical/range_aggregate.go
+++ b/pkg/engine/planner/physical/range_aggregate.go
@@ -1,0 +1,37 @@
+package physical
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/grafana/loki/v3/pkg/engine/internal/types"
+)
+
+// TODO: Rename based on the actual implementation.
+type RangeAggregation struct {
+	id string
+
+	PartitionBy []ColumnExpression // Columns to partition the data by.
+
+	Operation types.RangeAggregationType
+	Start     time.Time
+	End       time.Time
+	Step      *time.Duration // optional for instant queries
+	Range     time.Duration
+}
+
+func (r *RangeAggregation) ID() string {
+	if r.id == "" {
+		return fmt.Sprintf("%p", r)
+	}
+
+	return r.id
+}
+
+func (r *RangeAggregation) Type() NodeType {
+	return NodeTypeRangeAggreation
+}
+
+func (r *RangeAggregation) Accept(v Visitor) error {
+	return v.VisitRangeAggregation(r)
+}

--- a/pkg/engine/planner/physical/visitor.go
+++ b/pkg/engine/planner/physical/visitor.go
@@ -8,6 +8,7 @@ type Visitor interface {
 	VisitDataObjScan(*DataObjScan) error
 	VisitSortMerge(*SortMerge) error
 	VisitProjection(*Projection) error
+	VisitRangeAggregation(*RangeAggregation) error
 	VisitFilter(*Filter) error
 	VisitLimit(*Limit) error
 }

--- a/pkg/engine/planner/physical/visitor_test.go
+++ b/pkg/engine/planner/physical/visitor_test.go
@@ -8,12 +8,13 @@ import (
 // executes custom functions for each node type. Used primarily for testing
 // traversal behavior.
 type nodeCollectVisitor struct {
-	visited            []string
-	onVisitDataObjScan func(*DataObjScan) error
-	onVisitFilter      func(*Filter) error
-	onVisitLimit       func(*Limit) error
-	onVisitSortMerge   func(*SortMerge) error
-	onVisitProjection  func(*Projection) error
+	visited                 []string
+	onVisitDataObjScan      func(*DataObjScan) error
+	onVisitFilter           func(*Filter) error
+	onVisitLimit            func(*Limit) error
+	onVisitSortMerge        func(*SortMerge) error
+	onVisitProjection       func(*Projection) error
+	onVisitRangeAggregation func(*RangeAggregation) error
 }
 
 func (v *nodeCollectVisitor) VisitDataObjScan(n *DataObjScan) error {
@@ -52,6 +53,15 @@ func (v *nodeCollectVisitor) VisitSortMerge(n *SortMerge) error {
 	if v.onVisitSortMerge != nil {
 		return v.onVisitSortMerge(n)
 	}
+	v.visited = append(v.visited, fmt.Sprintf("%s.%s", n.Type().String(), n.ID()))
+	return nil
+}
+
+func (v *nodeCollectVisitor) VisitRangeAggregation(n *RangeAggregation) error {
+	if v.onVisitRangeAggregation != nil {
+		return v.onVisitRangeAggregation(n)
+	}
+
 	v.visited = append(v.visited, fmt.Sprintf("%s.%s", n.Type().String(), n.ID()))
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds the physical and logical plan nodes for range aggregation. We could have each operation represented as a different node but this feels like a good starting point.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
