### PR TITLE
chore: put noun at start of metric

### DIFF
--- a/pkg/limits/frontend/ring.go
+++ b/pkg/limits/frontend/ring.go
@@ -43,7 +43,7 @@ type ringGatherer struct {
 	// Metrics.
 	streams                prometheus.Counter
 	streamsFailed          prometheus.Counter
-	missingPartitionsTotal *prometheus.CounterVec
+	partitionsMissingTotal *prometheus.CounterVec
 }
 
 // newRingGatherer returns a new ringGatherer.
@@ -74,9 +74,9 @@ func newRingGatherer(
 				Help: "The total number of received streams that could not be checked.",
 			},
 		),
-		missingPartitionsTotal: promauto.With(reg).NewCounterVec(
+		partitionsMissingTotal: promauto.With(reg).NewCounterVec(
 			prometheus.CounterOpts{
-				Name: "loki_ingest_limits_frontend_missing_partitions_total",
+				Name: "loki_ingest_limits_frontend_partitions_missing_total",
 				Help: "The total number of times an instance was missing for a requested partition.",
 			},
 			[]string{"zone"},
@@ -154,7 +154,7 @@ func (g *ringGatherer) doExceedsLimitsRPCs(ctx context.Context, tenant string, s
 		partition := int32(stream.StreamHash % uint64(g.numPartitions))
 		addr, ok := partitions[partition]
 		if !ok {
-			g.missingPartitionsTotal.WithLabelValues(zone).Inc()
+			g.partitionsMissingTotal.WithLabelValues(zone).Inc()
 			continue
 		}
 		instancesForStreams[addr] = append(instancesForStreams[addr], stream)


### PR DESCRIPTION
**What this PR does / why we need it**:

I like to put the noun at the start of the metric so all `stream` and `partition` related metrics can be found with prefix search (i.e. `loki_ingest_limits_stream`). This fixes that.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
