### PR TITLE
fix: counter variables should not have total at the end

### DIFF
--- a/pkg/limits/frontend/ring.go
+++ b/pkg/limits/frontend/ring.go
@@ -41,9 +41,9 @@ type ringGatherer struct {
 	zoneCmp                 func(a, b string) int
 
 	// Metrics.
-	streams                prometheus.Counter
-	streamsFailed          prometheus.Counter
-	partitionsMissingTotal *prometheus.CounterVec
+	streams           prometheus.Counter
+	streamsFailed     prometheus.Counter
+	partitionsMissing *prometheus.CounterVec
 }
 
 // newRingGatherer returns a new ringGatherer.
@@ -74,7 +74,7 @@ func newRingGatherer(
 				Help: "The total number of received streams that could not be checked.",
 			},
 		),
-		partitionsMissingTotal: promauto.With(reg).NewCounterVec(
+		partitionsMissing: promauto.With(reg).NewCounterVec(
 			prometheus.CounterOpts{
 				Name: "loki_ingest_limits_frontend_partitions_missing_total",
 				Help: "The total number of times an instance was missing for a requested partition.",
@@ -154,7 +154,7 @@ func (g *ringGatherer) doExceedsLimitsRPCs(ctx context.Context, tenant string, s
 		partition := int32(stream.StreamHash % uint64(g.numPartitions))
 		addr, ok := partitions[partition]
 		if !ok {
-			g.partitionsMissingTotal.WithLabelValues(zone).Inc()
+			g.partitionsMissing.WithLabelValues(zone).Inc()
 			continue
 		}
 		instancesForStreams[addr] = append(instancesForStreams[addr], stream)


### PR DESCRIPTION
**What this PR does / why we need it**:

The variables for counters should not have `total` at the end (as per examples in https://pkg.go.dev/github.com/prometheus/client_golang/prometheus).

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
