### PR TITLE
Goldfish UI

### DIFF
--- a/pkg/ui/config.go
+++ b/pkg/ui/config.go
@@ -23,6 +23,7 @@ type Config struct {
 	ClusterName         string        `yaml:"cluster_name"`           // Name to prevent nodes without this identifier from joining the cluster.
 	EnableIPv6          bool          `yaml:"enable_ipv6"`
 	Debug               bool          `yaml:"debug"`
+	EnableGoldfish      bool          `yaml:"enable_goldfish"`                    // Whether to enable the Goldfish query comparison feature.
 	Discovery           struct {
 		JoinPeers []string `yaml:"join_peers"`
 	} `yaml:"discovery"`
@@ -51,6 +52,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&cfg.EnableIPv6, "ui.enable-ipv6", false, "Enable using a IPv6 instance address.")
 	f.Var((*flagext.StringSlice)(&cfg.Discovery.JoinPeers), "ui.discovery.join-peers", "List of peers to join the cluster. Supports multiple values separated by commas. Each value can be a hostname, an IP address, or a DNS name (A/AAAA and SRV records).")
 	f.BoolVar(&cfg.Debug, "ui.debug", false, "Enable debug logging for the UI.")
+	f.BoolVar(&cfg.EnableGoldfish, "ui.enable-goldfish", false, "Enable the Goldfish query comparison feature.")
 }
 
 func (cfg Config) Validate() error {

--- a/pkg/ui/frontend/.env.development
+++ b/pkg/ui/frontend/.env.development
@@ -1,0 +1,7 @@
+# Development environment variables
+# Set this to true to enable Goldfish feature in development
+VITE_ENABLE_GOLDFISH=true
+
+# Set this to true to use mock features instead of calling the backend
+# Useful when running frontend without backend
+VITE_MOCK_FEATURES=true

--- a/pkg/ui/frontend/.gitignore
+++ b/pkg/ui/frontend/.gitignore
@@ -1,0 +1,1 @@
+.env.local

--- a/pkg/ui/frontend/README.md
+++ b/pkg/ui/frontend/README.md
@@ -112,6 +112,22 @@ src/
    npm run lint
    ```
 
+## Feature Flags
+
+The UI supports feature flags to control experimental features. In development:
+
+- Copy `.env.development` to `.env.local` to customize feature flags
+- Set `VITE_ENABLE_GOLDFISH=true` to enable the Goldfish query comparison feature
+- Set `VITE_MOCK_FEATURES=true` to use local overrides without a backend
+
+In production, feature flags are controlled by Loki configuration:
+
+```yaml
+ui:
+  enabled: true
+  enable_goldfish: true  # Enable Goldfish feature
+```
+
 ## Contributing
 
 1. Follow the folder structure

--- a/pkg/ui/frontend/src/App.tsx
+++ b/pkg/ui/frontend/src/App.tsx
@@ -3,25 +3,45 @@ import { AppLayout } from "./layout/layout";
 import { ThemeProvider } from "./features/theme/components/theme-provider";
 import { QueryProvider } from "./providers/query-provider";
 import { ClusterProvider } from "./contexts/cluster-provider";
+import { FeatureFlagsProvider, useFeatureFlags } from "./contexts/feature-flags";
 import { routes } from "./config/routes";
+
+function AppRoutes() {
+  const { features } = useFeatureFlags();
+  
+  // Filter routes based on feature flags
+  const availableRoutes = routes.filter(route => {
+    // Only filter out goldfish route if feature is disabled
+    if (route.path === '/goldfish' && !features.goldfish) {
+      return false;
+    }
+    return true;
+  });
+  
+  return (
+    <Routes>
+      {availableRoutes.map((route) => (
+        <Route
+          key={route.path}
+          path={route.path}
+          element={route.element}
+        />
+      ))}
+    </Routes>
+  );
+}
 
 export default function App() {
   return (
     <QueryProvider>
       <ThemeProvider defaultTheme="dark" storageKey="loki-ui-theme">
-        <ClusterProvider>
-          <AppLayout>
-            <Routes>
-              {routes.map((route) => (
-                <Route
-                  key={route.path}
-                  path={route.path}
-                  element={route.element}
-                />
-              ))}
-            </Routes>
-          </AppLayout>
-        </ClusterProvider>
+        <FeatureFlagsProvider>
+          <ClusterProvider>
+            <AppLayout>
+              <AppRoutes />
+            </AppLayout>
+          </ClusterProvider>
+        </FeatureFlagsProvider>
       </ThemeProvider>
     </QueryProvider>
   );

--- a/pkg/ui/frontend/src/components/goldfish/query-diff-view.tsx
+++ b/pkg/ui/frontend/src/components/goldfish/query-diff-view.tsx
@@ -1,0 +1,322 @@
+import { useState } from "react";
+import { SampledQuery } from "@/types/goldfish";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Separator } from "@/components/ui/separator";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import { CheckCircle2, XCircle, Clock, Database, Zap, FileText, Hash, AlertCircle, ChevronDown } from "lucide-react";
+import { formatDistanceToNow } from "date-fns";
+import { cn } from "@/lib/utils";
+
+interface MetricComparison {
+  label: string;
+  icon?: React.ReactNode;
+  valueA: number | null;
+  valueB: number | null;
+  formatter: (value: number | null) => string;
+  lowerIsBetter: boolean;
+  unit?: string;
+}
+
+function formatBytes(bytes: number | null): string {
+  if (bytes === null) return "N/A";
+  if (bytes === 0) return "0 B";
+  
+  const k = 1024;
+  const sizes = ["B", "KB", "MB", "GB", "TB"];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  
+  return `${parseFloat((bytes / Math.pow(k, i)).toFixed(2))} ${sizes[i]}`;
+}
+
+function formatNumber(num: number | null): string {
+  if (num === null) return "N/A";
+  return new Intl.NumberFormat().format(num);
+}
+
+function formatDuration(ms: number | null): string {
+  if (ms === null) return "N/A";
+  if (ms < 1000) return `${ms}ms`;
+  return `${(ms / 1000).toFixed(2)}s`;
+}
+
+function getComparisonClass(valueA: number | null, valueB: number | null, lowerIsBetter: boolean): {
+  classA: string;
+  classB: string;
+  winner: "A" | "B" | "tie" | null;
+} {
+  if (valueA === null || valueB === null) {
+    return { classA: "", classB: "", winner: null };
+  }
+  
+  const percentDiff = Math.abs((valueB - valueA) / valueA) * 100;
+  const threshold = 5; // 5% threshold for significant difference
+  
+  if (percentDiff < threshold) {
+    return { 
+      classA: "text-muted-foreground", 
+      classB: "text-muted-foreground", 
+      winner: "tie" 
+    };
+  }
+  
+  if (lowerIsBetter) {
+    if (valueA < valueB) {
+      return { 
+        classA: "text-green-600 font-semibold", 
+        classB: "text-red-600", 
+        winner: "A" 
+      };
+    } else {
+      return { 
+        classA: "text-red-600", 
+        classB: "text-green-600 font-semibold", 
+        winner: "B" 
+      };
+    }
+  } else {
+    if (valueA > valueB) {
+      return { 
+        classA: "text-green-600 font-semibold", 
+        classB: "text-red-600", 
+        winner: "A" 
+      };
+    } else {
+      return { 
+        classA: "text-red-600", 
+        classB: "text-green-600 font-semibold", 
+        winner: "B" 
+      };
+    }
+  }
+}
+
+function MetricRow({ metric }: { metric: MetricComparison }) {
+  const comparison = getComparisonClass(metric.valueA, metric.valueB, metric.lowerIsBetter);
+  
+  return (
+    <div className="grid grid-cols-7 gap-4 py-3 items-center">
+      <div className="col-span-2 flex items-center gap-2 text-sm text-muted-foreground">
+        {metric.icon}
+        <span>{metric.label}</span>
+      </div>
+      <div className={cn("col-span-2 text-right font-mono text-sm", comparison.classA)}>
+        {metric.formatter(metric.valueA)}
+      </div>
+      <div className="col-span-1 text-center">
+        {comparison.winner === "A" && <div className="text-green-600">◀</div>}
+        {comparison.winner === "B" && <div className="text-green-600">▶</div>}
+        {comparison.winner === "tie" && <div className="text-muted-foreground">≈</div>}
+      </div>
+      <div className={cn("col-span-2 text-left font-mono text-sm", comparison.classB)}>
+        {metric.formatter(metric.valueB)}
+      </div>
+    </div>
+  );
+}
+
+export function QueryDiffView({ query }: { query: SampledQuery }) {
+  const [isOpen, setIsOpen] = useState(false);
+  
+  const performanceMetrics: MetricComparison[] = [
+    {
+      label: "Execution Time",
+      icon: <Clock className="h-4 w-4" />,
+      valueA: query.cellAExecTimeMs,
+      valueB: query.cellBExecTimeMs,
+      formatter: formatDuration,
+      lowerIsBetter: true,
+    },
+    {
+      label: "Queue Time",
+      icon: <Clock className="h-4 w-4" />,
+      valueA: query.cellAQueueTimeMs,
+      valueB: query.cellBQueueTimeMs,
+      formatter: formatDuration,
+      lowerIsBetter: true,
+    },
+    {
+      label: "Bytes Processed",
+      icon: <Database className="h-4 w-4" />,
+      valueA: query.cellABytesProcessed,
+      valueB: query.cellBBytesProcessed,
+      formatter: formatBytes,
+      lowerIsBetter: false, // More bytes processed is generally better (higher throughput)
+    },
+    {
+      label: "Lines Processed",
+      icon: <FileText className="h-4 w-4" />,
+      valueA: query.cellALinesProcessed,
+      valueB: query.cellBLinesProcessed,
+      formatter: formatNumber,
+      lowerIsBetter: false,
+    },
+    {
+      label: "Bytes/Second",
+      icon: <Zap className="h-4 w-4" />,
+      valueA: query.cellABytesPerSecond,
+      valueB: query.cellBBytesPerSecond,
+      formatter: formatBytes,
+      lowerIsBetter: false, // Higher throughput is better
+    },
+    {
+      label: "Lines/Second",
+      icon: <Zap className="h-4 w-4" />,
+      valueA: query.cellALinesPerSecond,
+      valueB: query.cellBLinesPerSecond,
+      formatter: formatNumber,
+      lowerIsBetter: false,
+    },
+    {
+      label: "Entries Returned",
+      icon: <FileText className="h-4 w-4" />,
+      valueA: query.cellAEntriesReturned,
+      valueB: query.cellBEntriesReturned,
+      formatter: formatNumber,
+      lowerIsBetter: false,
+    },
+    {
+      label: "Splits",
+      valueA: query.cellASplits,
+      valueB: query.cellBSplits,
+      formatter: formatNumber,
+      lowerIsBetter: true, // Fewer splits is generally better
+    },
+    {
+      label: "Shards",
+      valueA: query.cellAShards,
+      valueB: query.cellBShards,
+      formatter: formatNumber,
+      lowerIsBetter: false,
+    },
+  ];
+
+  const responseMatch = query.cellAResponseHash === query.cellBResponseHash;
+  const statusMatch = query.cellAStatusCode === query.cellBStatusCode;
+  const bothSuccessful = 
+    query.cellAStatusCode !== null && 
+    query.cellBStatusCode !== null &&
+    query.cellAStatusCode >= 200 && 
+    query.cellAStatusCode < 300 &&
+    query.cellBStatusCode >= 200 && 
+    query.cellBStatusCode < 300;
+
+  return (
+    <Card>
+      <Collapsible open={isOpen} onOpenChange={setIsOpen}>
+        <CollapsibleTrigger asChild>
+          <div className="cursor-pointer hover:bg-muted/50 transition-colors">
+            <div className="p-4 space-y-2">
+              {/* Query as main header */}
+              <div className="flex items-start gap-2">
+                <ChevronDown 
+                  className={cn(
+                    "h-4 w-4 mt-0.5 transition-transform text-muted-foreground",
+                    isOpen && "rotate-180"
+                  )} 
+                />
+                <code className="flex-1 text-xs font-mono break-all line-clamp-2">
+                  {query.query}
+                </code>
+              </div>
+              
+              {/* Key info bar */}
+              <div className="flex items-center justify-between pl-6">
+                <div className="flex items-center gap-3 text-sm text-muted-foreground">
+                  <span>{formatDistanceToNow(new Date(query.sampledAt), { addSuffix: true })}</span>
+                  <Badge variant="outline" className="text-xs">{query.tenantId}</Badge>
+                  <Badge variant="secondary" className="text-xs">{query.queryType}</Badge>
+                </div>
+                <div className="flex items-center gap-2">
+                  {responseMatch && bothSuccessful ? (
+                    <div className="flex items-center gap-1 text-green-600 text-sm">
+                      <CheckCircle2 className="h-4 w-4" />
+                      <span>Match</span>
+                    </div>
+                  ) : !bothSuccessful ? (
+                    <div className="flex items-center gap-1 text-orange-600 text-sm">
+                      <AlertCircle className="h-4 w-4" />
+                      <span>Error</span>
+                    </div>
+                  ) : (
+                    <div className="flex items-center gap-1 text-red-600 text-sm">
+                      <XCircle className="h-4 w-4" />
+                      <span>Mismatch</span>
+                    </div>
+                  )}
+                </div>
+              </div>
+            </div>
+          </div>
+        </CollapsibleTrigger>
+        
+        <CollapsibleContent>
+          <Separator />
+          <CardContent className="pt-4 space-y-6">
+            {/* Response Status */}
+            <div className="space-y-3">
+              <h4 className="text-sm font-medium">Response Status</h4>
+              <div className="grid grid-cols-7 gap-4">
+                <div className="col-span-2 text-sm text-muted-foreground">HTTP Status</div>
+                <div className="col-span-2 text-right">
+                  <Badge variant={query.cellAStatusCode === 200 ? "default" : "destructive"}>
+                    {query.cellAStatusCode || "N/A"}
+                  </Badge>
+                </div>
+                <div className="col-span-1 text-center">
+                  {statusMatch ? (
+                    <CheckCircle2 className="h-4 w-4 text-green-600 mx-auto" />
+                  ) : (
+                    <AlertCircle className="h-4 w-4 text-orange-600 mx-auto" />
+                  )}
+                </div>
+                <div className="col-span-2 text-left">
+                  <Badge variant={query.cellBStatusCode === 200 ? "default" : "destructive"}>
+                    {query.cellBStatusCode || "N/A"}
+                  </Badge>
+                </div>
+              </div>
+              
+              <div className="grid grid-cols-7 gap-4">
+                <div className="col-span-2 text-sm text-muted-foreground flex items-center gap-2">
+                  <Hash className="h-4 w-4" />
+                  Response Hash
+                </div>
+                <div className="col-span-2 text-right font-mono text-xs text-muted-foreground">
+                  {query.cellAResponseHash ? `${query.cellAResponseHash.substring(0, 8)}...` : "N/A"}
+                </div>
+                <div className="col-span-1 text-center">
+                  {responseMatch && bothSuccessful ? (
+                    <CheckCircle2 className="h-4 w-4 text-green-600 mx-auto" />
+                  ) : !bothSuccessful ? (
+                    <AlertCircle className="h-4 w-4 text-orange-600 mx-auto" />
+                  ) : (
+                    <XCircle className="h-4 w-4 text-red-600 mx-auto" />
+                  )}
+                </div>
+                <div className="col-span-2 text-left font-mono text-xs text-muted-foreground">
+                  {query.cellBResponseHash ? `${query.cellBResponseHash.substring(0, 8)}...` : "N/A"}
+                </div>
+              </div>
+            </div>
+
+            <Separator />
+
+            {/* Performance Metrics */}
+            <div className="space-y-1">
+              <div className="grid grid-cols-7 gap-4 pb-2">
+                <div className="col-span-2 text-sm font-medium">Metric</div>
+                <div className="col-span-2 text-right text-sm font-medium">Cell A</div>
+                <div className="col-span-1"></div>
+                <div className="col-span-2 text-left text-sm font-medium">Cell B</div>
+              </div>
+              {performanceMetrics.map((metric, i) => (
+                <MetricRow key={i} metric={metric} />
+              ))}
+            </div>
+          </CardContent>
+        </CollapsibleContent>
+      </Collapsible>
+    </Card>
+  );
+}

--- a/pkg/ui/frontend/src/config/routes.tsx
+++ b/pkg/ui/frontend/src/config/routes.tsx
@@ -14,6 +14,7 @@ import ComingSoon from "@/pages/coming-soon";
 import DeletesPage from "@/pages/deletes";
 import NewDeleteRequest from "@/pages/new-delete";
 import AnalyzeLabels from "@/pages/analyze-labels";
+import GoldfishPage from "@/pages/goldfish";
 
 type RouteObjectWithBreadcrumb = Omit<RouteObject, "children"> & {
   breadcrumb: string | BreadcrumbComponentType;
@@ -105,6 +106,11 @@ export const routes: RouteObjectWithBreadcrumb[] = [
     path: "/rules",
     breadcrumb: "Rules",
     element: <ComingSoon />,
+  },
+  {
+    path: "/goldfish",
+    breadcrumb: "Goldfish",
+    element: <GoldfishPage />,
   },
   {
     path: "/404",

--- a/pkg/ui/frontend/src/contexts/feature-flags.tsx
+++ b/pkg/ui/frontend/src/contexts/feature-flags.tsx
@@ -1,0 +1,77 @@
+import React, { createContext, useContext, useEffect, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+
+interface FeatureFlags {
+  goldfish: boolean;
+}
+
+interface FeatureFlagsContextType {
+  features: FeatureFlags;
+  isLoading: boolean;
+  error: Error | null;
+}
+
+const defaultFeatures: FeatureFlags = {
+  goldfish: false,
+};
+
+const FeatureFlagsContext = createContext<FeatureFlagsContextType>({
+  features: defaultFeatures,
+  isLoading: true,
+  error: null,
+});
+
+export function useFeatureFlags() {
+  return useContext(FeatureFlagsContext);
+}
+
+// For development mode, check if we have an override
+function getDevOverrides(): Partial<FeatureFlags> {
+  if (import.meta.env.DEV) {
+    const overrides: Partial<FeatureFlags> = {};
+    
+    // Check for VITE_ENABLE_GOLDFISH environment variable
+    if (import.meta.env.VITE_ENABLE_GOLDFISH === 'true') {
+      overrides.goldfish = true;
+    }
+    
+    return overrides;
+  }
+  return {};
+}
+
+async function fetchFeatures(): Promise<FeatureFlags> {
+  // In development mode with no backend, use defaults with overrides
+  if (import.meta.env.DEV && import.meta.env.VITE_MOCK_FEATURES === 'true') {
+    return { ...defaultFeatures, ...getDevOverrides() };
+  }
+  
+  const response = await fetch('/ui/api/v1/features');
+  if (!response.ok) {
+    throw new Error(`Failed to fetch features: ${response.statusText}`);
+  }
+  
+  const data = await response.json();
+  return { ...defaultFeatures, ...data, ...getDevOverrides() };
+}
+
+export function FeatureFlagsProvider({ children }: { children: React.ReactNode }) {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['feature-flags'],
+    queryFn: fetchFeatures,
+    staleTime: Infinity, // Feature flags don't change during runtime
+    retry: 1,
+  });
+  
+  const value: FeatureFlagsContextType = {
+    features: data || defaultFeatures,
+    isLoading,
+    error: error as Error | null,
+  };
+  
+  return (
+    <FeatureFlagsContext.Provider value={value}>
+      {children}
+    </FeatureFlagsContext.Provider>
+  );
+}

--- a/pkg/ui/frontend/src/layout/sidebar.tsx
+++ b/pkg/ui/frontend/src/layout/sidebar.tsx
@@ -15,6 +15,7 @@ import {
 } from "lucide-react";
 import { useCluster } from "@/contexts/use-cluster";
 import { getAvailableRings } from "@/lib/ring-utils";
+import { useFeatureFlags } from "@/contexts/feature-flags";
 
 import {
   Sidebar,
@@ -227,6 +228,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
   const basename = getBasename();
   const location = useLocation();
   const { cluster } = useCluster();
+  const { features } = useFeatureFlags();
   const currentPath = location.pathname.replace(basename, "/");
 
   // Initialize state from localStorage or default to all sections open
@@ -258,6 +260,17 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
 
   // Use the stable nav items hook
   const navItems = useNavItems(cluster, baseNavItems);
+  
+  // Filter nav items based on feature flags
+  const filteredNavItems = React.useMemo(() => {
+    return navItems.filter(item => {
+      // Hide Goldfish if feature is disabled
+      if (item.title === "Goldfish" && !features.goldfish) {
+        return false;
+      }
+      return true;
+    });
+  }, [navItems, features.goldfish]);
 
   const isActive = React.useCallback(
     (url: string) => {
@@ -307,7 +320,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
         <SidebarContent>
           <SidebarGroup>
             <SidebarMenu>
-              {navItems.map((item) => (
+              {filteredNavItems.map((item) => (
                 <React.Fragment key={item.title}>
                   <NavItemComponent
                     item={item}

--- a/pkg/ui/frontend/src/layout/sidebar.tsx
+++ b/pkg/ui/frontend/src/layout/sidebar.tsx
@@ -11,6 +11,7 @@ import {
   LayoutDashboard,
   Users,
   BookOpen,
+  Fish,
 } from "lucide-react";
 import { useCluster } from "@/contexts/use-cluster";
 import { getAvailableRings } from "@/lib/ring-utils";
@@ -135,6 +136,12 @@ const baseNavItems: NavItem[] = [
     title: "Rules",
     url: "/rules",
     icon: <GaugeCircle className="h-4 w-4" />,
+    items: [],
+  },
+  {
+    title: "Goldfish",
+    url: "/goldfish",
+    icon: <Fish className="h-4 w-4" />,
     items: [],
   },
   {

--- a/pkg/ui/frontend/src/lib/goldfish-api.ts
+++ b/pkg/ui/frontend/src/lib/goldfish-api.ts
@@ -1,0 +1,112 @@
+import { SampledQuery, GoldfishApiResponse } from "@/types/goldfish";
+
+// Mock data generator for development
+function generateMockSampledQuery(index: number): SampledQuery {
+  const baseTime = new Date();
+  baseTime.setMinutes(baseTime.getMinutes() - index * 5);
+  
+  const queryTypes = ["range", "instant", "series", "labels"];
+  const statusCodes = [200, 200, 200, 200, 500, 429]; // Mostly successful
+  
+  const sampleQueries = [
+    `{app="loki", level="error"} |= "timeout" | json | line_format "{{.message}}"`,
+    `{job="varlogs"} |~ "error|ERROR" | json | unwrap duration | __error__=""`,
+    `sum by (level) (count_over_time({job="grafana"}[5m]))`,
+    `{namespace="production"} | pattern "<_> <level> <_>" | level="error"`,
+    `rate({app="frontend"} |= "failed to" [1m])`,
+    `{cluster="us-central1", job="ingester"} | logfmt | duration > 10s`,
+  ];
+  
+  // Generate somewhat realistic performance differences
+  const cellAExecTime = Math.floor(Math.random() * 2000) + 500; // 500-2500ms
+  const cellBExecTime = Math.floor(cellAExecTime * (0.5 + Math.random() * 1)); // 50%-150% of A
+  
+  const bytesProcessed = Math.floor(Math.random() * 1000000000) + 1000000; // 1MB-1GB
+  const linesProcessed = Math.floor(bytesProcessed / 100);
+  const entriesReturned = Math.floor(Math.random() * 10000);
+  
+  // Determine if this query should match (60% match rate)
+  const shouldMatch = Math.random() > 0.4;
+  const responseHash = Math.random().toString(36).substr(2, 16);
+  
+  // Most queries should succeed
+  const isSuccessful = Math.random() > 0.15;
+  const statusCode = isSuccessful ? 200 : statusCodes[Math.floor(Math.random() * statusCodes.length)];
+  
+  return {
+    correlationId: `corr-${Math.random().toString(36).substr(2, 9)}`,
+    tenantId: `tenant-${Math.floor(Math.random() * 10) + 1}`,
+    query: sampleQueries[index % sampleQueries.length],
+    queryType: queryTypes[index % queryTypes.length],
+    startTime: new Date(baseTime.getTime() - 3600000).toISOString(), // 1 hour before
+    endTime: baseTime.toISOString(),
+    stepDuration: index % 3 === 0 ? 60000 : null, // Some queries have steps
+    
+    cellAExecTimeMs: cellAExecTime,
+    cellBExecTimeMs: cellBExecTime,
+    cellAQueueTimeMs: Math.floor(Math.random() * 100),
+    cellBQueueTimeMs: Math.floor(Math.random() * 100),
+    cellABytesProcessed: bytesProcessed,
+    cellBBytesProcessed: shouldMatch ? bytesProcessed : Math.floor(bytesProcessed * (0.9 + Math.random() * 0.2)),
+    cellALinesProcessed: linesProcessed,
+    cellBLinesProcessed: shouldMatch ? linesProcessed : Math.floor(linesProcessed * (0.9 + Math.random() * 0.2)),
+    cellABytesPerSecond: Math.floor(bytesProcessed / (cellAExecTime / 1000)),
+    cellBBytesPerSecond: Math.floor(bytesProcessed / (cellBExecTime / 1000)),
+    cellALinesPerSecond: Math.floor(linesProcessed / (cellAExecTime / 1000)),
+    cellBLinesPerSecond: Math.floor(linesProcessed / (cellBExecTime / 1000)),
+    cellAEntriesReturned: entriesReturned,
+    cellBEntriesReturned: shouldMatch ? entriesReturned : Math.floor(Math.random() * 10000),
+    cellASplits: Math.floor(Math.random() * 20) + 1,
+    cellBSplits: Math.floor(Math.random() * 20) + 1,
+    cellAShards: Math.floor(Math.random() * 64) + 1,
+    cellBShards: Math.floor(Math.random() * 64) + 1,
+    
+    cellAResponseHash: responseHash,
+    cellBResponseHash: shouldMatch ? responseHash : Math.random().toString(36).substr(2, 16),
+    cellAResponseSize: Math.floor(Math.random() * 100000) + 1000,
+    cellBResponseSize: Math.floor(Math.random() * 100000) + 1000,
+    cellAStatusCode: statusCode,
+    cellBStatusCode: shouldMatch ? statusCode : (isSuccessful ? 200 : statusCodes[Math.floor(Math.random() * statusCodes.length)]),
+    
+    sampledAt: baseTime.toISOString(),
+    createdAt: baseTime.toISOString(),
+  };
+}
+
+// Mock API function - will be replaced with real API call later
+export async function fetchSampledQueries(
+  page: number = 1,
+  pageSize: number = 20
+): Promise<GoldfishApiResponse> {
+  // Simulate API delay
+  await new Promise(resolve => setTimeout(resolve, 500));
+  
+  const total = 100; // Total mock queries
+  const queries: SampledQuery[] = [];
+  
+  const startIndex = (page - 1) * pageSize;
+  const endIndex = Math.min(startIndex + pageSize, total);
+  
+  for (let i = startIndex; i < endIndex; i++) {
+    queries.push(generateMockSampledQuery(i));
+  }
+  
+  return {
+    queries,
+    total,
+    page,
+    pageSize,
+  };
+}
+
+// Future real API implementation would look like:
+// export async function fetchSampledQueries(
+//   page: number = 1,
+//   pageSize: number = 20
+// ): Promise<GoldfishApiResponse> {
+//   const response = await fetch(`/ui/api/v1/goldfish/queries?page=${page}&pageSize=${pageSize}`);
+//   if (!response.ok) {
+//     throw new Error(`Failed to fetch sampled queries: ${response.statusText}`);
+//   }
+//   return response.json();
+// }

--- a/pkg/ui/frontend/src/pages/goldfish.tsx
+++ b/pkg/ui/frontend/src/pages/goldfish.tsx
@@ -1,0 +1,160 @@
+import { useState, useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { fetchSampledQueries } from "@/lib/goldfish-api";
+import { QueryDiffView } from "@/components/goldfish/query-diff-view";
+import { Button } from "@/components/ui/button";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { RefreshCw, AlertCircle } from "lucide-react";
+
+
+export default function GoldfishPage() {
+  const [selectedTab, setSelectedTab] = useState<"all" | "range" | "instant">("all");
+  const [selectedTenant, setSelectedTenant] = useState<string>("all");
+  const [page, setPage] = useState(1);
+  const pageSize = 10; // Reduced since we're showing more detail per query
+  
+  const { data, isLoading, error, refetch } = useQuery({
+    queryKey: ["goldfish-queries", page, pageSize],
+    queryFn: () => fetchSampledQueries(page, pageSize),
+    refetchInterval: 30000, // Refresh every 30 seconds
+  });
+  
+  const allQueries = data?.queries || [];
+  
+  // Extract unique tenants from queries
+  const uniqueTenants = useMemo(() => {
+    const tenants = new Set(allQueries.map(q => q.tenantId));
+    return Array.from(tenants).sort();
+  }, [allQueries]);
+  
+  // Filter queries based on selected tab and tenant
+  const filteredQueries = allQueries.filter(query => {
+    const matchesTab = selectedTab === "all" || query.queryType === selectedTab;
+    const matchesTenant = selectedTenant === "all" || query.tenantId === selectedTenant;
+    return matchesTab && matchesTenant;
+  });
+  
+  const totalPages = data ? Math.ceil(data.total / pageSize) : 0;
+  
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-3xl font-bold">Goldfish - Query Comparison</h1>
+          <p className="text-muted-foreground mt-1">
+            Side-by-side performance comparison between Cell A and Cell B
+          </p>
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => refetch()}
+          disabled={isLoading}
+        >
+          <RefreshCw className={`h-4 w-4 mr-2 ${isLoading ? "animate-spin" : ""}`} />
+          Refresh
+        </Button>
+      </div>
+      
+      <Tabs value={selectedTab} onValueChange={(v) => setSelectedTab(v as any)}>
+        <div className="flex items-center justify-between gap-4">
+          <TabsList className="grid w-full max-w-md grid-cols-3">
+            <TabsTrigger value="all">All Queries</TabsTrigger>
+            <TabsTrigger value="range">Range</TabsTrigger>
+            <TabsTrigger value="instant">Instant</TabsTrigger>
+          </TabsList>
+          
+          <Select
+            value={selectedTenant}
+            onValueChange={setSelectedTenant}
+            disabled={isLoading || uniqueTenants.length === 0}
+          >
+            <SelectTrigger className="w-[200px]">
+              <SelectValue placeholder="Filter by tenant" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All Tenants</SelectItem>
+              {uniqueTenants.map(tenant => (
+                <SelectItem key={tenant} value={tenant}>
+                  {tenant}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        
+        <TabsContent value={selectedTab} className="mt-6 space-y-4">
+          {error && (
+            <Alert variant="destructive">
+              <AlertCircle className="h-4 w-4" />
+              <AlertDescription>
+                Failed to load queries: {(error as Error).message}
+              </AlertDescription>
+            </Alert>
+          )}
+          
+          {isLoading ? (
+            // Loading skeletons
+            <div className="space-y-4">
+              {Array.from({ length: 3 }).map((_, i) => (
+                <Skeleton key={i} className="h-96 w-full" />
+              ))}
+            </div>
+          ) : filteredQueries.length === 0 ? (
+            <div className="text-center py-12 text-muted-foreground">
+              No {selectedTab === "all" ? "" : selectedTab} queries found
+              {selectedTenant !== "all" && ` for tenant ${selectedTenant}`}
+            </div>
+          ) : (
+            <div className="space-y-4">
+              {filteredQueries.map((query) => (
+                <QueryDiffView key={query.correlationId} query={query} />
+              ))}
+            </div>
+          )}
+          
+          {totalPages > 1 && !isLoading && (
+            <div className="flex items-center justify-between pt-4">
+              <div className="text-sm text-muted-foreground">
+                Page {page} of {totalPages}
+              </div>
+              <div className="flex gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => {
+                    setPage(p => Math.max(1, p - 1));
+                    window.scrollTo({ top: 0, behavior: 'smooth' });
+                  }}
+                  disabled={page === 1}
+                >
+                  Previous
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => {
+                    setPage(p => Math.min(totalPages, p + 1));
+                    window.scrollTo({ top: 0, behavior: 'smooth' });
+                  }}
+                  disabled={page === totalPages}
+                >
+                  Next
+                </Button>
+              </div>
+            </div>
+          )}
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/pkg/ui/frontend/src/types/goldfish.ts
+++ b/pkg/ui/frontend/src/types/goldfish.ts
@@ -1,0 +1,47 @@
+export interface SampledQuery {
+  correlationId: string;
+  tenantId: string;
+  query: string;
+  queryType: string;
+  startTime: string;
+  endTime: string;
+  stepDuration: number | null;
+  
+  // Performance statistics
+  cellAExecTimeMs: number | null;
+  cellBExecTimeMs: number | null;
+  cellAQueueTimeMs: number | null;
+  cellBQueueTimeMs: number | null;
+  cellABytesProcessed: number | null;
+  cellBBytesProcessed: number | null;
+  cellALinesProcessed: number | null;
+  cellBLinesProcessed: number | null;
+  cellABytesPerSecond: number | null;
+  cellBBytesPerSecond: number | null;
+  cellALinesPerSecond: number | null;
+  cellBLinesPerSecond: number | null;
+  cellAEntriesReturned: number | null;
+  cellBEntriesReturned: number | null;
+  cellASplits: number | null;
+  cellBSplits: number | null;
+  cellAShards: number | null;
+  cellBShards: number | null;
+  
+  // Response metadata
+  cellAResponseHash: string | null;
+  cellBResponseHash: string | null;
+  cellAResponseSize: number | null;
+  cellBResponseSize: number | null;
+  cellAStatusCode: number | null;
+  cellBStatusCode: number | null;
+  
+  sampledAt: string;
+  createdAt: string;
+}
+
+export interface GoldfishApiResponse {
+  queries: SampledQuery[];
+  total: number;
+  page: number;
+  pageSize: number;
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Once https://github.com/grafana/loki/pull/17959 is merged, we'll be able to send data comparing the results and statistics from 2 different Loki cells to a database from the query tee. This PR introduces a new page in the Loki frontend UI for examining that data. This page is off by default and will only be enabled in our goldfish cells.


https://github.com/user-attachments/assets/c9c1d530-0b7f-4757-91e6-ea2b08c1973d


**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
