### PR TITLE
chore: change codeowners of `expr.y` to `grafana/oss-big-tent`

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -10,7 +10,7 @@
 
 # Logql grammar
 # The observability logs team is listed as co-codeowner for grammar file. This is to receive notifications about updates, so these can be implemented in https://github.com/grafana/lezer-logql
-/pkg/logql/syntax/expr.y @grafana/observability-logs @grafana/loki-team
+/pkg/logql/syntax/expr.y @grafana/oss-big-tent @grafana/loki-team
 
 # Nix
 /nix/ @trevorwhitney


### PR DESCRIPTION
**What this PR does / why we need it**:

The Loki data source is handed over to `@grafana/oss-big-tent`