### PR TITLE
feat: Prevent lambda-promtail from recompiling on every plan

### DIFF
--- a/tools/lambda-promtail/README.md
+++ b/tools/lambda-promtail/README.md
@@ -71,6 +71,28 @@ aws cloudformation create-stack --stack-name lambda-promtail-stack --template-bo
 
 # Appendix
 
+## Importing this Terraform module into your own Terraform workspace
+
+Rather than running `terraform apply` from this repo, you can refer to this repo as a `module`. Here's an example:
+
+```hcl
+locals {
+  # This should match a git tag in the grafana/loki repo
+  module_version = "v3.5.1"
+}
+module "lambda_promtail" {
+  source        = "github.com/grafana/loki//tools/lambda-promtail?ref=${local.module_version}"
+  # This will ensure the code is only recompiled if the version changes
+  lambda_code_version = local.module_version
+  write_address       = "https://loki.example.com/loki/api/v1/push"
+  # This example shows pulling the credentials from Vault
+  username            = data.vault_generic_secret.loki_creds.data["username"]
+  password            = data.vault_generic_secret.loki_creds.data["password"]
+
+  log_group_names = ["/aws/lambda/some-lambda1", "/aws/lambda/some-lambda2"]
+}
+```
+
 ## Golang installation
 
 Please ensure Go 1.x (where 'x' is the latest version) is installed as per the instructions on the official golang website: https://golang.org/doc/install

--- a/tools/lambda-promtail/main.tf
+++ b/tools/lambda-promtail/main.tf
@@ -156,7 +156,7 @@ locals {
 resource "null_resource" "function_binary" {
   count = var.lambda_promtail_image == "" ? 1 : 0
   triggers = {
-    always_run = timestamp()
+    rebuild_if_changed = var.lambda_code_version != "" ? var.lambda_code_version : timestamp()
   }
 
   provisioner "local-exec" {

--- a/tools/lambda-promtail/variables.tf
+++ b/tools/lambda-promtail/variables.tf
@@ -40,6 +40,12 @@ variable "lambda_promtail_image" {
   default     = ""
 }
 
+variable "lambda_code_version" {
+  type        = string
+  description = "A version string used to determine if the lambda-promtail binary needs to be rebuilt. If not provided, the binary will be rebuilt on every plan/apply run."
+  default     = ""
+}
+
 variable "username" {
   type        = string
   description = "The basic auth username, necessary if writing directly to Grafana Cloud Loki."


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, if you deploy lambda-promtail using the provided Terraform code, every time you run `terraform plan`, the golang binary will be recompiled and you will never have a clean plan. Ideally, the binary should only be recompiled if the code actually changes compared to the last `apply`.

If the code was just a single file, we could use a hash of the script as the `trigger`, but we have too many files to make hashing feasible. Terraform won't let you hash every file in a folder natively, you'd have to add a third-party module or write a script yourself.

So instead, I've added a new variable, `lambda_code_version`, which if set, will be used as the `trigger` for determining when the code should be recompiled. I've added an example to the README.

**Special notes for your reviewer**:

n/a

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
