### PR TITLE
chore: enforce max-query-series when returning shard results

### DIFF
--- a/pkg/logql/accumulator.go
+++ b/pkg/logql/accumulator.go
@@ -9,12 +9,13 @@ import (
 	"sort"
 	"time"
 
+	"github.com/prometheus/prometheus/promql"
+
 	"github.com/grafana/loki/v3/pkg/logproto"
 	"github.com/grafana/loki/v3/pkg/logqlmodel"
 	"github.com/grafana/loki/v3/pkg/logqlmodel/metadata"
 	"github.com/grafana/loki/v3/pkg/logqlmodel/stats"
 	"github.com/grafana/loki/v3/pkg/querier/queryrange/queryrangebase/definitions"
-	"github.com/prometheus/prometheus/promql"
 )
 
 // NewBufferedAccumulator returns an accumulator which aggregates all query

--- a/pkg/logql/accumulator.go
+++ b/pkg/logql/accumulator.go
@@ -14,6 +14,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/logqlmodel/metadata"
 	"github.com/grafana/loki/v3/pkg/logqlmodel/stats"
 	"github.com/grafana/loki/v3/pkg/querier/queryrange/queryrangebase/definitions"
+	"github.com/prometheus/prometheus/promql"
 )
 
 // NewBufferedAccumulator returns an accumulator which aggregates all query
@@ -502,4 +503,44 @@ func (acc *AccumulatedStreams) Accumulate(_ context.Context, x logqlmodel.Result
 		return fmt.Errorf("unexpected response type during response result accumulation. Got (%T), wanted %s", got, logqlmodel.ValueTypeStreams)
 	}
 	return nil
+}
+
+// LimitingAccumulator wraps another Accumulator and enforces a total series/stream limit.
+type LimitingAccumulator struct {
+	inner Accumulator
+	limit int
+	count int
+}
+
+func NewLimitingAccumulator(inner Accumulator, limit int) *LimitingAccumulator {
+	return &LimitingAccumulator{
+		inner: inner,
+		limit: limit,
+	}
+}
+
+func (a *LimitingAccumulator) Accumulate(ctx context.Context, res logqlmodel.Result, idx int) error {
+	// If the result contains a matrix or vector, count the number of series/streams.
+	// We do a simple series/stream count here because our sharding dispatches unique streams to each shard,
+	// while this doesn't actually guarantee the results from each shard will have unique streams I believe
+	// this to be good enough for approximation and enforcing the stream limit per query sooner to avoid
+	// allocationg all the memory for a query only then to find out it exceeds the limit.
+	var n int
+	switch data := res.Data.(type) {
+	case promql.Matrix:
+		n = len(data)
+	case promql.Vector:
+		n = len(data)
+	default:
+		n = 0
+	}
+	a.count += n
+	if a.limit > 0 && a.count > a.limit {
+		return logqlmodel.NewSeriesLimitError(a.limit)
+	}
+	return a.inner.Accumulate(ctx, res, idx)
+}
+
+func (a *LimitingAccumulator) Result() []logqlmodel.Result {
+	return a.inner.Result()
 }

--- a/pkg/querier/queryrange/downstreamer.go
+++ b/pkg/querier/queryrange/downstreamer.go
@@ -94,6 +94,7 @@ func (h DownstreamHandler) Downstreamer(ctx context.Context) logql.Downstreamer 
 		locks:       locks,
 		handler:     h.next,
 		splitAlign:  h.splitAlign,
+		limits:      h.limits,
 	}
 }
 
@@ -104,6 +105,7 @@ type instance struct {
 	handler     queryrangebase.Handler
 
 	splitAlign bool
+	limits     Limits
 }
 
 // withoutOffset returns the given query string with offsets removed and timestamp adjusted accordingly. If no offset is present in original query, it will be returned as is.
@@ -134,6 +136,16 @@ func withoutOffset(query logql.DownstreamQuery) (string, time.Time, time.Time) {
 }
 
 func (in instance) Downstream(ctx context.Context, queries []logql.DownstreamQuery, acc logql.Accumulator) ([]logqlmodel.Result, error) {
+	// Get the user/tenant ID from context
+	user, _ := tenant.TenantID(ctx)
+	// Get the max_query_series limit from the instance's limits
+	maxSeries := 0
+	if in.limits != nil {
+		maxSeries = in.limits.MaxQuerySeries(ctx, user)
+	}
+	if maxSeries > 0 {
+		acc = logql.NewLimitingAccumulator(acc, maxSeries)
+	}
 	return in.For(ctx, queries, acc, func(qry logql.DownstreamQuery) (logqlmodel.Result, error) {
 		var req queryrangebase.Request
 		if in.splitAlign {
@@ -207,7 +219,10 @@ func (in instance) For(
 	for {
 		select {
 		case <-ctx.Done():
-			// Return early if the context is canceled
+			// Prefer returning the accumulator error if it exists
+			if err != nil {
+				return acc.Result(), err
+			}
 			return acc.Result(), ctx.Err()
 		case resp, ok := <-ch:
 			if !ok {
@@ -222,6 +237,10 @@ func (in instance) For(
 				continue
 			}
 			err = acc.Accumulate(ctx, resp.Res, resp.I)
+			if err != nil {
+				cancel() // Cancel all workers immediately
+				continue
+			}
 		}
 	}
 }

--- a/pkg/querier/queryrange/roundtrip_test.go
+++ b/pkg/querier/queryrange/roundtrip_test.go
@@ -354,7 +354,7 @@ func TestInstantQueryTripperwareResultCaching(t *testing.T) {
 		maxQueryBytesRead:       1000,
 		maxQuerierBytesRead:     100,
 		queryTimeout:            1 * time.Minute,
-		maxSeries:               1,
+		maxSeries:               10,
 	}
 	tpw, stopper, err := NewMiddleware(testLocal, testEngineOpts, nil, util_log.Logger, l, config.SchemaConfig{Configs: testSchemasTSDB}, nil, false, nil, constants.Loki)
 	if stopper != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

In the frontend we process queries via the Downstreamer which handles sharding of a query, this creates the situation where a query could be heavily sharded and each shard result is appened to a result set before being returned to the engine via the StepEvaluator, after this point the engine would check to see if there were too many series in the result and if there are, fail the query.

The problem though is all the memory was already allocated to handle the responses from all the subqueries, this PR introduces a check to incrementally count the series from each downstreamed shard and will fail the query as soon as we exceed the max_query_series limit

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
