### PR TITLE
feat: quick fix to produce a stream once per minute

### DIFF
--- a/pkg/limits/store_bench_test.go
+++ b/pkg/limits/store_bench_test.go
@@ -62,7 +62,7 @@ func BenchmarkUsageStore_Store(b *testing.B) {
 					TotalSize:  1500,
 				}}
 
-				_, _, err := s.UpdateCond(tenant, metadata, updateTime, nil)
+				_, _, _, err := s.UpdateCond(tenant, metadata, updateTime, nil)
 				require.NoError(b, err)
 			}
 		})
@@ -82,7 +82,7 @@ func BenchmarkUsageStore_Store(b *testing.B) {
 					TotalSize:  1500,
 				}}
 
-				_, _, err := s.UpdateCond(tenant, metadata, updateTime, nil)
+				_, _, _, err := s.UpdateCond(tenant, metadata, updateTime, nil)
 				require.NoError(b, err)
 			}
 		})
@@ -106,7 +106,7 @@ func BenchmarkUsageStore_Store(b *testing.B) {
 						TotalSize:  1500,
 					}}
 
-					_, _, err := s.UpdateCond(tenant, metadata, updateTime, nil)
+					_, _, _, err := s.UpdateCond(tenant, metadata, updateTime, nil)
 					require.NoError(b, err)
 					i++
 				}
@@ -128,7 +128,7 @@ func BenchmarkUsageStore_Store(b *testing.B) {
 						TotalSize:  1500,
 					}}
 
-					_, _, err := s.UpdateCond(tenant, metadata, updateTime, nil)
+					_, _, _, err := s.UpdateCond(tenant, metadata, updateTime, nil)
 					require.NoError(b, err)
 					i++
 				}


### PR DESCRIPTION
**What this PR does / why we need it**:

We decided that producing a record on each update was too much, and created a lot of records to replay on start up on partition rebalance. Instead, what if we produce a record for a stream if it has been 1 minute or longer since it was last produced. This commit makes the absolute minimum changes required to validate this. It accepts that rate buckets will be incorrect as not all sizes are produced, which will be solved in the next phase of the limits service.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
