### PR TITLE
fix: the "empty ring" error in quick-start guide for docker-compose.yaml

### DIFF
--- a/examples/getting-started/docker-compose.yaml
+++ b/examples/getting-started/docker-compose.yaml
@@ -5,7 +5,7 @@ networks:
 services:
   read:
     image: grafana/loki:latest
-    command: "-config.file=/etc/loki/config.yaml -target=read"
+    command: "-config.file=/etc/loki/config.yaml -target=read -query-scheduler.use-scheduler-ring=false"
     ports:
       - 3101:3100
       - 7946
@@ -26,7 +26,7 @@ services:
 
   write:
     image: grafana/loki:latest
-    command: "-config.file=/etc/loki/config.yaml -target=write"
+    command: "-config.file=/etc/loki/config.yaml -target=write -query-scheduler.use-scheduler-ring=false"
     ports:
       - 3102:3100
       - 7946


### PR DESCRIPTION
**What this PR does / why we need it**:
During the deployment of the quick-start example, I found that the loki (reader and writer) didn't work: I received a 504 error. 

In the logs I found the following errors:
```
component=querier component=querier-scheduler-worker msg="error getting addresses from ring" err="empty ring"
```

And I found the resolution here: https://github.com/grafana/loki/issues/12138

Just to add `-query-scheduler.use-scheduler-ring=false`, and everything is working since I added the argument

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
