### PR TITLE
docs: Remove unmatched quote in logfmt.md

### DIFF
--- a/docs/sources/send-data/promtail/stages/logfmt.md
+++ b/docs/sources/send-data/promtail/stages/logfmt.md
@@ -54,7 +54,7 @@ For the given pipeline:
 Given the following log line:
 
 ```
-time=2012-11-01T22:08:41+00:00 app=loki level=WARN duration=125 message="this is a log line" extra="user=foo""
+time=2012-11-01T22:08:41+00:00 app=loki level=WARN duration=125 message="this is a log line" extra="user=foo"
 ```
 
 The following key-value pairs would be created in the set of extracted data:


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix syntax of example log line in document

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
None

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
