### PR TITLE
docs: manual backport 17007

### DIFF
--- a/docs/sources/send-data/promtail/stages/logfmt.md
+++ b/docs/sources/send-data/promtail/stages/logfmt.md
@@ -54,7 +54,7 @@ For the given pipeline:
 Given the following log line:
 
 ```
-time=2012-11-01T22:08:41+00:00 app=loki level=WARN duration=125 message="this is a log line" extra="user=foo""
+time=2012-11-01T22:08:41+00:00 app=loki level=WARN duration=125 message="this is a log line" extra="user=foo"
 ```
 
 The following key-value pairs would be created in the set of extracted data:


### PR DESCRIPTION
**What this PR does / why we need it**:

Backport https://github.com/grafana/loki/pull/18007 to 3.4 branch.