### PR TITLE
docs: backport shortcode addition to 3.5 branch

### DIFF
--- a/docs/sources/query/log_queries/_index.md
+++ b/docs/sources/query/log_queries/_index.md
@@ -33,6 +33,8 @@ This is specially useful when writing a regular expression which contains multip
 
 ## Log stream selector
 
+{{< shared id="log-stream-selector" >}}
+
 The stream selector determines which log streams to include in a query's results.
 A log stream is a unique source of log content, such as a file.
 A more granular log stream selector then reduces the number of searched streams to a manageable volume.
@@ -40,6 +42,8 @@ This means that the labels passed to the log stream selector will affect the rel
 
 The log stream selector is specified by one or more comma-separated key-value pairs. Each key is a log label and each value is that label's value.
 Curly braces (`{` and `}`) delimit the stream selector.
+
+{{< /shared >}}
 
 Consider this stream selector:
 

--- a/docs/sources/query/metric_queries.md
+++ b/docs/sources/query/metric_queries.md
@@ -9,6 +9,8 @@ weight: 400
 
 # Metric queries
 
+{{< shared id="metric-queries" >}}
+
 Metric queries extend log queries by applying a function to log query results.
 This powerful feature creates metrics from logs.
 
@@ -16,6 +18,8 @@ Metric queries can be used to calculate the rate of error messages or the top N 
 
 Combined with parsers, metric queries can also be used to calculate metrics from a sample value within the log line, such as latency or request size.
 All labels, including extracted ones, will be available for aggregations and generation of new series.
+
+{{< /shared >}}
 
 ## Range Vector aggregation
 
@@ -155,6 +159,10 @@ Examples:
     ```
 
 ## Probabilistic aggregation
+
+{{< admonition type="note" >}}
+Probabilistic aggregation is an experimental feature. Engineering and on-call support is not available. Documentation is either limited or not provided outside of code comments. No SLA is provided. To use this feature, set `limits_config.shard_aggregations:approx_topk` in your [Loki configuration](https://grafana.com/docs/loki/<LOKI_VERSION>/configure/#limits_config). To enable this feature in Grafana Cloud, contact Grafana Support.
+{{< /admonition >}}
 
 LogQL's `approx_topk` function provides a probabilistic approximation of `topk`. It is a drop-in replacement for `topk` that is great for when `topk` queries time out or hit the maximum series limit. This tends to happen when the list of values that you're sorting through in order to find the most frequent values is very large. `approx_topk` is also great in cases where a faster, approximate answer is preferred to a slower, more accurate one. 
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Manual backport of #18025 to the 3.5 branch
Adds shortcodes to content used in learning journeys.