### PR TITLE
chore(kafka): Cleanup deprecated fields address and client-id

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -936,7 +936,7 @@ kafka_config:
   reader_config:
     # The Kafka backend address.
     # CLI flag: -kafka.reader.address
-    [address: <string> | default = ""]
+    [address: <string> | default = "localhost:9092"]
 
     # The Kafka client ID.
     # CLI flag: -kafka.reader.client-id
@@ -945,7 +945,7 @@ kafka_config:
   writer_config:
     # The Kafka backend address.
     # CLI flag: -kafka.writer.address
-    [address: <string> | default = ""]
+    [address: <string> | default = "localhost:9092"]
 
     # The Kafka client ID.
     # CLI flag: -kafka.writer.client-id

--- a/pkg/kafka/client/reader_client.go
+++ b/pkg/kafka/client/reader_client.go
@@ -26,17 +26,10 @@ func NewReaderClient(component string, kafkaCfg kafka.Config, logger log.Logger,
 
 	opts = append(opts, commonKafkaClientOptions(kafkaCfg, metrics, logger)...)
 
-	address := kafkaCfg.Address
-	clientID := kafkaCfg.ClientID
-	if kafkaCfg.ReaderConfig.Address != "" {
-		address = kafkaCfg.ReaderConfig.Address
-		clientID = kafkaCfg.ReaderConfig.ClientID
-	}
-
 	opts = append(
 		opts,
-		kgo.ClientID(clientID),
-		kgo.SeedBrokers(address),
+		kgo.ClientID(kafkaCfg.ReaderConfig.ClientID),
+		kgo.SeedBrokers(kafkaCfg.ReaderConfig.Address),
 		kgo.FetchMinBytes(1),
 		kgo.FetchMaxBytes(fetchMaxBytes),
 		kgo.FetchMaxWait(5*time.Second),

--- a/pkg/kafka/client/reader_client_test.go
+++ b/pkg/kafka/client/reader_client_test.go
@@ -27,16 +27,6 @@ func TestNewReaderClient(t *testing.T) {
 		{
 			name: "valid config",
 			config: kafka.Config{
-				Address:      addr,
-				Topic:        "abcd",
-				SASLUsername: "user",
-				SASLPassword: flagext.SecretWithValue("password"),
-			},
-			wantErr: false,
-		},
-		{
-			name: "valid config with reader config",
-			config: kafka.Config{
 				Topic:        "abcd",
 				SASLUsername: "user",
 				SASLPassword: flagext.SecretWithValue("password"),
@@ -50,7 +40,10 @@ func TestNewReaderClient(t *testing.T) {
 		{
 			name: "wrong password",
 			config: kafka.Config{
-				Address:      addr,
+				ReaderConfig: kafka.ClientConfig{
+					Address:  addr,
+					ClientID: "reader",
+				},
 				Topic:        "abcd",
 				SASLUsername: "user",
 				SASLPassword: flagext.SecretWithValue("wrong wrong wrong"),
@@ -60,7 +53,10 @@ func TestNewReaderClient(t *testing.T) {
 		{
 			name: "wrong username",
 			config: kafka.Config{
-				Address:      addr,
+				ReaderConfig: kafka.ClientConfig{
+					Address:  addr,
+					ClientID: "reader",
+				},
 				Topic:        "abcd",
 				SASLUsername: "wrong wrong wrong",
 				SASLPassword: flagext.SecretWithValue("password"),
@@ -92,7 +88,10 @@ func TestSetDefaultNumberOfPartitionsForAutocreatedTopics(t *testing.T) {
 	require.Len(t, addrs, 1)
 
 	cfg := kafka.Config{
-		Address:                          addrs[0],
+		ReaderConfig: kafka.ClientConfig{
+			Address:  addrs[0],
+			ClientID: "reader",
+		},
 		AutoCreateTopicDefaultPartitions: 100,
 	}
 

--- a/pkg/kafka/client/writer_client.go
+++ b/pkg/kafka/client/writer_client.go
@@ -41,17 +41,10 @@ func NewWriterClient(component string, kafkaCfg kafka.Config, maxInflightProduce
 	// Do not export the client ID, because we use it to specify options to the backend.
 	metrics := NewClientMetrics(component, reg, kafkaCfg.EnableKafkaHistograms)
 
-	address := kafkaCfg.Address
-	clientID := kafkaCfg.ClientID
-	if kafkaCfg.WriterConfig.Address != "" {
-		address = kafkaCfg.WriterConfig.Address
-		clientID = kafkaCfg.WriterConfig.ClientID
-	}
-
 	opts := append(
 		commonKafkaClientOptions(kafkaCfg, metrics, logger),
-		kgo.ClientID(clientID),
-		kgo.SeedBrokers(address),
+		kgo.ClientID(kafkaCfg.WriterConfig.ClientID),
+		kgo.SeedBrokers(kafkaCfg.WriterConfig.Address),
 		kgo.RequiredAcks(kgo.AllISRAcks()),
 		kgo.DefaultProduceTopic(kafkaCfg.Topic),
 

--- a/pkg/kafka/client/writer_client_test.go
+++ b/pkg/kafka/client/writer_client_test.go
@@ -24,17 +24,6 @@ func TestNewWriterClient(t *testing.T) {
 		{
 			name: "valid config",
 			config: kafka.Config{
-				Address:      addr,
-				Topic:        "abcd",
-				WriteTimeout: time.Second,
-				SASLUsername: "user",
-				SASLPassword: flagext.SecretWithValue("password"),
-			},
-			wantErr: false,
-		},
-		{
-			name: "valid config with writer config",
-			config: kafka.Config{
 				Topic:        "abcd",
 				WriteTimeout: time.Second,
 				WriterConfig: kafka.ClientConfig{
@@ -47,7 +36,10 @@ func TestNewWriterClient(t *testing.T) {
 		{
 			name: "wrong password",
 			config: kafka.Config{
-				Address:      addr,
+				WriterConfig: kafka.ClientConfig{
+					Address:  addr,
+					ClientID: "writer",
+				},
 				Topic:        "abcd",
 				WriteTimeout: time.Second,
 				SASLUsername: "user",
@@ -58,7 +50,10 @@ func TestNewWriterClient(t *testing.T) {
 		{
 			name: "wrong username",
 			config: kafka.Config{
-				Address:      addr,
+				WriterConfig: kafka.ClientConfig{
+					Address:  addr,
+					ClientID: "writer",
+				},
 				Topic:        "abcd",
 				WriteTimeout: time.Second,
 				SASLUsername: "wrong wrong wrong",

--- a/pkg/kafka/config_test.go
+++ b/pkg/kafka/config_test.go
@@ -10,7 +10,10 @@ import (
 func TestBothSASLParamsMustBeSet(t *testing.T) {
 	cfg := Config{
 		// Other required params
-		Address:                    "abcd",
+		ReaderConfig: ClientConfig{
+			Address:  "abcd",
+			ClientID: "reader",
+		},
 		Topic:                      "abcd",
 		ProducerMaxRecordSizeBytes: 1048576,
 	}
@@ -36,61 +39,4 @@ func TestBothSASLParamsMustBeSet(t *testing.T) {
 	cfg.SASLPassword = flagext.SecretWithValue("abcd")
 	err = cfg.Validate()
 	require.NoError(t, err)
-}
-
-func TestAmbiguousKafkaAddress(t *testing.T) {
-	cfg := Config{
-		Address:      "localhost:9092",
-		ReaderConfig: ClientConfig{Address: "localhost:9092"},
-		WriterConfig: ClientConfig{Address: "localhost:9092"},
-	}
-	err := cfg.Validate()
-	require.Error(t, err)
-	require.ErrorIs(t, err, ErrAmbiguousKafkaAddress)
-}
-
-func TestAmbiguousKafkaClientID(t *testing.T) {
-	// Disallow defining in both places
-	cfg := Config{
-		ClientID:     "abcd",
-		ReaderConfig: ClientConfig{Address: "reader:9092", ClientID: "abcd"},
-		WriterConfig: ClientConfig{Address: "writer:9092", ClientID: "abcd"},
-	}
-	err := cfg.Validate()
-	require.Error(t, err)
-	require.ErrorIs(t, err, ErrAmbiguousKafkaClientID)
-}
-
-func TestMixingOldAndNewClientConfig(t *testing.T) {
-	cfg := Config{
-		Address:      "localhost:9092",
-		ReaderConfig: ClientConfig{ClientID: "reader"},
-	}
-	err := cfg.Validate()
-	require.Error(t, err)
-	require.ErrorIs(t, err, ErrMixingOldAndNewClientConfig)
-
-	cfg = Config{
-		Address:      "localhost:9092",
-		WriterConfig: ClientConfig{ClientID: "reader"},
-	}
-	err = cfg.Validate()
-	require.Error(t, err)
-	require.ErrorIs(t, err, ErrMixingOldAndNewClientConfig)
-
-	cfg = Config{
-		ClientID:     "abcd",
-		ReaderConfig: ClientConfig{Address: "localhost:9092"},
-	}
-	err = cfg.Validate()
-	require.Error(t, err)
-	require.ErrorIs(t, err, ErrMixingOldAndNewClientConfig)
-
-	cfg = Config{
-		ClientID:     "abcd",
-		WriterConfig: ClientConfig{Address: "localhost:9092"},
-	}
-	err = cfg.Validate()
-	require.Error(t, err)
-	require.ErrorIs(t, err, ErrMixingOldAndNewClientConfig)
 }

--- a/pkg/kafka/partitionring/consumer/client_test.go
+++ b/pkg/kafka/partitionring/consumer/client_test.go
@@ -50,8 +50,10 @@ func TestPartitionMonitorRebalancing(t *testing.T) {
 	// Create two consumers using our Client wrapper
 	createConsumer := func(id string) *Client {
 		cfg := kafka.Config{
-			Address: addrs[0],
-			Topic:   "test-topic",
+			ReaderConfig: kafka.ClientConfig{
+				Address: addrs[0],
+			},
+			Topic: "test-topic",
 		}
 
 		// Track partition assignments for this consumer
@@ -222,8 +224,10 @@ func TestPartitionContinuityDuringRebalance(t *testing.T) {
 
 	createConsumer := func(id string) *Client {
 		cfg := kafka.Config{
-			Address: addrs[0],
-			Topic:   "test-topic",
+			ReaderConfig: kafka.ClientConfig{
+				Address: addrs[0],
+			},
+			Topic: "test-topic",
 		}
 
 		client, err := NewGroupClient(cfg, mockReader, "test-group", log.NewNopLogger(),

--- a/pkg/kafka/testkafka/cluster.go
+++ b/pkg/kafka/testkafka/cluster.go
@@ -27,9 +27,12 @@ func createTestKafkaConfig(clusterAddr, topicName string) kafka.Config {
 	cfg := kafka.Config{}
 	flagext.DefaultValues(&cfg)
 
-	cfg.Address = clusterAddr
+	cfg.WriterConfig.Address = clusterAddr
+	cfg.WriterConfig.ClientID = "test-writer"
 	cfg.Topic = topicName
 	cfg.WriteTimeout = 2 * time.Second
+	cfg.ReaderConfig.Address = clusterAddr
+	cfg.ReaderConfig.ClientID = "test-reader"
 
 	return cfg
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This pull request removes the deprecated `kafka.address` and `kafka.client-id` fields. These fields have been replaced by `kafka.{reader,writer}` config blocks.

**Which issue(s) this PR fixes**:
Fixes #grafana/loki-private/issues/1663

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
