### PR TITLE
chore(ci): Move to openshift credentials in vault

### DIFF
--- a/.github/workflows/operator-images.yaml
+++ b/.github/workflows/operator-images.yaml
@@ -33,13 +33,20 @@ jobs:
      - name: Set up Docker Buildx
        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3
 
+     - name: "fetch openshift credentials from vault"
+       uses: "grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760"
+       with:
+        repo_secrets: |
+           OPENSHIFT_USER=openshift-credentials:username
+           OPENSHIFT_PASS=openshift-credentials:password  
+
      - name: Login to Quay.io
        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
        with:
          registry: quay.io
          logout: true
-         username: ${{ secrets.OPENSHIFT_LOGGING_USER }}
-         password: ${{ secrets.OPENSHIFT_LOGGING_PASS }}
+         username: ${{ env.OPENSHIFT_USER }}
+         password: ${{ env.OPENSHIFT_PASS }}
 
      - name: Get image tags
        id: image_tags
@@ -77,13 +84,20 @@ jobs:
      - name: Set up Docker Buildx
        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3
 
+     - name: "fetch openshift credentials from vault"
+       uses: "grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760"
+       with:
+        repo_secrets: |
+           OPENSHIFT_USER=openshift-credentials:username
+           OPENSHIFT_PASS=openshift-credentials:password  
+
      - name: Login to Quay.io
        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
        with:
          registry: quay.io
          logout: true
-         username: ${{ secrets.OPENSHIFT_LOGGING_USER }}
-         password: ${{ secrets.OPENSHIFT_LOGGING_PASS }}
+         username: ${{ env.OPENSHIFT_USER }}
+         password: ${{ env.OPENSHIFT_PASS }}
 
      - name: Get image tags
        id: image_tags
@@ -122,13 +136,20 @@ jobs:
      - name: Set up Docker Buildx
        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3
 
+     - name: "fetch openshift credentials from vault"
+       uses: "grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760"
+       with:
+        repo_secrets: |
+           OPENSHIFT_USER=openshift-credentials:username
+           OPENSHIFT_PASS=openshift-credentials:password
+
      - name: Login to Quay.io
        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
        with:
          registry: quay.io
          logout: true
-         username: ${{ secrets.OPENSHIFT_LOGGING_USER }}
-         password: ${{ secrets.OPENSHIFT_LOGGING_PASS }}
+         username: ${{ env.OPENSHIFT_USER }}
+         password: ${{ env.OPENSHIFT_PASS }}
 
      - name: Get image tags
        id: image_tags


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is to migrate away from repo secrets related to openshift, and adopts the vault methodology used in other workflows.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
