### PR TITLE
docs: Manual backport patch RN

### DIFF
--- a/docs/sources/release-notes/v2-9.md
+++ b/docs/sources/release-notes/v2-9.md
@@ -5,6 +5,7 @@ weight: 600
 ---
 
 # V2.9
+
 Grafana Labs is excited to announce the release of Loki 2.9.0 Here's a summary of new enhancements and important fixes.
 
 For a full list of all changes and fixes, refer to the [CHANGELOG](https://github.com/grafana/loki/blob/release-2.9.x/CHANGELOG.md).
@@ -28,13 +29,18 @@ For a full list of all changes and fixes, refer to the [CHANGELOG](https://githu
 - **logfmt stage improvements**: logfmt parser now performs non-strict parsing by default which helps scan semi-structured log lines. [PR #9626](https://github.com/grafana/loki/pull/9626)
 
 - **Deprecations**
-  - Legacy index and chunk stores that are not "single store" (such as `tsdb`, `boltdb-shipper`) are deprecated. These storage backends are Cassandra (`cassandra`), DynamoDB (`aws`, `aws-dynamo`), BigTable (`bigtable`, `bigtable-hashed`), GCP (`gcp`, `gcp-columnkey`), and gRPC (`grpc`). See https://grafana.com/docs/loki/<LOKI_VERSION>/configure/storage.md for more information.
+  - Legacy index and chunk stores that are not "single store" (such as `tsdb`, `boltdb-shipper`) are deprecated. These storage backends are Cassandra (`cassandra`), DynamoDB (`aws`, `aws-dynamo`), BigTable (`bigtable`, `bigtable-hashed`), GCP (`gcp`, `gcp-columnkey`), and gRPC (`grpc`). See [Configure storage](https://grafana.com/docs/loki/<LOKI_VERSION>/configure/storage/) for more information.
   - The `table-manager` target is deprecated, because it is not used by "single store" implementations.
   - The `-boltdb.shipper.compactor.*` CLI flags are deprecated in favor of `-compactor.*`.
   - The `-ingester.unordered-writes` CLI flag is deprecated and will always default to `true` in the next major release.
   - For the full list of deprecations, see CHANGELOG.md
 
 ## Bug fixes
+
+### 2.9.15 (2025-06-09)
+
+- **ci:** Pull in latest 2.9-specific release code ([#18019](https://github.com/grafana/loki/issues/18019)) ([7b805ba](https://github.com/grafana/loki/commit/7b805ba7c84366e11e8571c9e8c422739bb18684)).
+- **deps:** Update module golang.org/x/net to v0.38.0 [security] (release-2.9.x) ([#17275](https://github.com/grafana/loki/issues/17275)) ([6297508](https://github.com/grafana/loki/commit/62975089e9626846673335ff5607d183a2685222)).
 
 ### 2.9.14 (2025-04-15)
 
@@ -48,7 +54,6 @@ For a full list of all changes and fixes, refer to the [CHANGELOG](https://githu
 ### 2.9.13 (2025-03-12)
 
 - **deps:**  Loki 2.9.x Bump Alpine and Go versions ([#16294](https://github.com/grafana/loki/issues/16294)) ([f2deeb7](https://github.com/grafana/loki/commit/f2deeb76ac39e835bffe61e1e4f78b980afdc0c0)).
-
 
 ### 2.9.12 (2025-02-13)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Manual backport of https://github.com/grafana/loki/pull/18041 to 3.4 release branch.