### PR TITLE
chore: stop updating rate limits and remove reason as implementation is deferred

### DIFF
--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -2464,34 +2464,6 @@ func TestDistributor_PushIngestLimits(t *testing.T) {
 		},
 		expectedErr: "rpc error: code = Code(429) desc = request exceeded limits: max streams exceeded",
 	}, {
-		name:                "rate limit is exceeded",
-		ingestLimitsEnabled: true,
-		tenant:              "test",
-		streams: logproto.PushRequest{
-			Streams: []logproto.Stream{{
-				Labels: "{foo=\"bar\"}",
-				Entries: []logproto.Entry{{
-					Timestamp: time.Now(),
-					Line:      "baz",
-				}},
-			}},
-		},
-		expectedLimitsCalls: 1,
-		expectedLimitsRequest: &limitsproto.ExceedsLimitsRequest{
-			Tenant: "test",
-			Streams: []*limitsproto.StreamMetadata{{
-				StreamHash: 0x90eb45def17f924,
-				TotalSize:  0x3,
-			}},
-		},
-		limitsResponse: &limitsproto.ExceedsLimitsResponse{
-			Results: []*limitsproto.ExceedsLimitsResult{{
-				StreamHash: 0x90eb45def17f924,
-				Reason:     uint32(limits.ReasonExceedsRateLimit),
-			}},
-		},
-		expectedErr: "rpc error: code = Code(429) desc = request exceeded limits: rate limit exceeded",
-	}, {
 		name:                "one of two streams exceed max stream limit, request is accepted",
 		ingestLimitsEnabled: true,
 		tenant:              "test",

--- a/pkg/distributor/ingest_limits_test.go
+++ b/pkg/distributor/ingest_limits_test.go
@@ -112,11 +112,11 @@ func TestIngestLimits_EnforceLimits(t *testing.T) {
 		response: &proto.ExceedsLimitsResponse{
 			Results: []*proto.ExceedsLimitsResult{{
 				StreamHash: 1,
-				Reason:     uint32(limits.ReasonExceedsRateLimit),
+				Reason:     uint32(limits.ReasonExceedsMaxStreams),
 			}},
 		},
 		expectedStreams: []KeyedStream{},
-		expectedReasons: map[uint64][]string{1: {"rate limit exceeded"}},
+		expectedReasons: map[uint64][]string{1: {"max streams exceeded"}},
 	}, {
 		name:   "one of two streams exceeds limits",
 		tenant: "test",
@@ -138,14 +138,14 @@ func TestIngestLimits_EnforceLimits(t *testing.T) {
 		response: &proto.ExceedsLimitsResponse{
 			Results: []*proto.ExceedsLimitsResult{{
 				StreamHash: 1,
-				Reason:     uint32(limits.ReasonExceedsRateLimit),
+				Reason:     uint32(limits.ReasonExceedsMaxStreams),
 			}},
 		},
 		expectedStreams: []KeyedStream{{
 			HashKey:        2000, // Should not be used.
 			HashKeyNoShard: 2,
 		}},
-		expectedReasons: map[uint64][]string{1: {"rate limit exceeded"}},
+		expectedReasons: map[uint64][]string{1: {"max streams exceeded"}},
 	}, {
 		name:   "does not exceed limits",
 		tenant: "test",
@@ -246,11 +246,11 @@ func TestIngestLimits_ExceedsLimits(t *testing.T) {
 		response: &proto.ExceedsLimitsResponse{
 			Results: []*proto.ExceedsLimitsResult{{
 				StreamHash: 1,
-				Reason:     uint32(limits.ReasonExceedsRateLimit),
+				Reason:     uint32(limits.ReasonExceedsMaxStreams),
 			}},
 		},
 		expectedExceedsLimits: true,
-		expectedReasons:       map[uint64][]string{1: {"rate limit exceeded"}},
+		expectedReasons:       map[uint64][]string{1: {"max streams exceeded"}},
 	}, {
 		name:   "does not exceed limits",
 		tenant: "test",

--- a/pkg/limits/frontend/frontend_test.go
+++ b/pkg/limits/frontend/frontend_test.go
@@ -80,7 +80,7 @@ func TestFrontend_ExceedsLimits(t *testing.T) {
 				Reason:     uint32(limits.ReasonExceedsMaxStreams),
 			}, {
 				StreamHash: 0x4,
-				Reason:     uint32(limits.ReasonExceedsRateLimit),
+				Reason:     uint32(limits.ReasonExceedsMaxStreams),
 			}},
 		}},
 		expected: &proto.ExceedsLimitsResponse{
@@ -89,7 +89,7 @@ func TestFrontend_ExceedsLimits(t *testing.T) {
 				Reason:     uint32(limits.ReasonExceedsMaxStreams),
 			}, {
 				StreamHash: 0x4,
-				Reason:     uint32(limits.ReasonExceedsRateLimit),
+				Reason:     uint32(limits.ReasonExceedsMaxStreams),
 			}},
 		},
 	}, {
@@ -112,7 +112,7 @@ func TestFrontend_ExceedsLimits(t *testing.T) {
 		}, {
 			Results: []*proto.ExceedsLimitsResult{{
 				StreamHash: 0x4,
-				Reason:     uint32(limits.ReasonExceedsRateLimit),
+				Reason:     uint32(limits.ReasonExceedsMaxStreams),
 			}},
 		}},
 		expected: &proto.ExceedsLimitsResponse{
@@ -121,7 +121,7 @@ func TestFrontend_ExceedsLimits(t *testing.T) {
 				Reason:     uint32(limits.ReasonExceedsMaxStreams),
 			}, {
 				StreamHash: 0x4,
-				Reason:     uint32(limits.ReasonExceedsRateLimit),
+				Reason:     uint32(limits.ReasonExceedsMaxStreams),
 			}},
 		},
 	}}

--- a/pkg/limits/frontend/http_test.go
+++ b/pkg/limits/frontend/http_test.go
@@ -51,7 +51,7 @@ func TestFrontend_ServeHTTP(t *testing.T) {
 		exceedsLimitsResponses: []*proto.ExceedsLimitsResponse{{
 			Results: []*proto.ExceedsLimitsResult{{
 				StreamHash: 0x1,
-				Reason:     uint32(limits.ReasonExceedsRateLimit),
+				Reason:     uint32(limits.ReasonExceedsMaxStreams),
 			}},
 		}},
 		request: httpExceedsLimitsRequest{
@@ -64,7 +64,7 @@ func TestFrontend_ServeHTTP(t *testing.T) {
 		expected: httpExceedsLimitsResponse{
 			Results: []*proto.ExceedsLimitsResult{{
 				StreamHash: 0x1,
-				Reason:     uint32(limits.ReasonExceedsRateLimit),
+				Reason:     uint32(limits.ReasonExceedsMaxStreams),
 			}},
 		},
 	}}

--- a/pkg/limits/reason.go
+++ b/pkg/limits/reason.go
@@ -6,18 +6,12 @@ const (
 	// ReasonExceedsMaxStreams is returned when a tenant exceeds the maximum
 	// number of active streams as per their per-tenant limit.
 	ReasonExceedsMaxStreams Reason = iota
-
-	// ReasonExceedsRateLimit is returned when a tenant exceeds their maximum
-	// rate limit as per their per-tenant limit.
-	ReasonExceedsRateLimit
 )
 
 func (r Reason) String() string {
 	switch r {
 	case ReasonExceedsMaxStreams:
 		return "max streams exceeded"
-	case ReasonExceedsRateLimit:
-		return "rate limit exceeded"
 	default:
 		return "unknown reason"
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request stops updating rate buckets and removes the `RateLimitExceededReason` until we come back to implementing either rate limits or stream limits.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
