### PR TITLE
feat: add ReasonFailed

### DIFF
--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -2459,10 +2459,10 @@ func TestDistributor_PushIngestLimits(t *testing.T) {
 		limitsResponse: &limitsproto.ExceedsLimitsResponse{
 			Results: []*limitsproto.ExceedsLimitsResult{{
 				StreamHash: 0x90eb45def17f924,
-				Reason:     uint32(limits.ReasonExceedsMaxStreams),
+				Reason:     uint32(limits.ReasonMaxStreams),
 			}},
 		},
-		expectedErr: "rpc error: code = Code(429) desc = request exceeded limits: max streams exceeded",
+		expectedErr: "rpc error: code = Code(429) desc = request exceeded limits: max streams",
 	}, {
 		name:                "one of two streams exceed max stream limit, request is accepted",
 		ingestLimitsEnabled: true,
@@ -2496,7 +2496,7 @@ func TestDistributor_PushIngestLimits(t *testing.T) {
 		limitsResponse: &limitsproto.ExceedsLimitsResponse{
 			Results: []*limitsproto.ExceedsLimitsResult{{
 				StreamHash: 1,
-				Reason:     uint32(limits.ReasonExceedsMaxStreams),
+				Reason:     uint32(limits.ReasonMaxStreams),
 			}},
 		},
 	}, {
@@ -2524,7 +2524,7 @@ func TestDistributor_PushIngestLimits(t *testing.T) {
 		limitsResponse: &limitsproto.ExceedsLimitsResponse{
 			Results: []*limitsproto.ExceedsLimitsResult{{
 				StreamHash: 1,
-				Reason:     uint32(limits.ReasonExceedsMaxStreams),
+				Reason:     uint32(limits.ReasonMaxStreams),
 			}},
 		},
 	}, {

--- a/pkg/distributor/ingest_limits_test.go
+++ b/pkg/distributor/ingest_limits_test.go
@@ -112,11 +112,11 @@ func TestIngestLimits_EnforceLimits(t *testing.T) {
 		response: &proto.ExceedsLimitsResponse{
 			Results: []*proto.ExceedsLimitsResult{{
 				StreamHash: 1,
-				Reason:     uint32(limits.ReasonExceedsMaxStreams),
+				Reason:     uint32(limits.ReasonMaxStreams),
 			}},
 		},
 		expectedStreams: []KeyedStream{},
-		expectedReasons: map[uint64][]string{1: {"max streams exceeded"}},
+		expectedReasons: map[uint64][]string{1: {"max streams"}},
 	}, {
 		name:   "one of two streams exceeds limits",
 		tenant: "test",
@@ -138,14 +138,14 @@ func TestIngestLimits_EnforceLimits(t *testing.T) {
 		response: &proto.ExceedsLimitsResponse{
 			Results: []*proto.ExceedsLimitsResult{{
 				StreamHash: 1,
-				Reason:     uint32(limits.ReasonExceedsMaxStreams),
+				Reason:     uint32(limits.ReasonMaxStreams),
 			}},
 		},
 		expectedStreams: []KeyedStream{{
 			HashKey:        2000, // Should not be used.
 			HashKeyNoShard: 2,
 		}},
-		expectedReasons: map[uint64][]string{1: {"max streams exceeded"}},
+		expectedReasons: map[uint64][]string{1: {"max streams"}},
 	}, {
 		name:   "does not exceed limits",
 		tenant: "test",
@@ -246,11 +246,11 @@ func TestIngestLimits_ExceedsLimits(t *testing.T) {
 		response: &proto.ExceedsLimitsResponse{
 			Results: []*proto.ExceedsLimitsResult{{
 				StreamHash: 1,
-				Reason:     uint32(limits.ReasonExceedsMaxStreams),
+				Reason:     uint32(limits.ReasonMaxStreams),
 			}},
 		},
 		expectedExceedsLimits: true,
-		expectedReasons:       map[uint64][]string{1: {"max streams exceeded"}},
+		expectedReasons:       map[uint64][]string{1: {"max streams"}},
 	}, {
 		name:   "does not exceed limits",
 		tenant: "test",

--- a/pkg/limits/frontend/frontend_test.go
+++ b/pkg/limits/frontend/frontend_test.go
@@ -38,13 +38,13 @@ func TestFrontend_ExceedsLimits(t *testing.T) {
 		exceedsLimitsResponses: []*proto.ExceedsLimitsResponse{{
 			Results: []*proto.ExceedsLimitsResult{{
 				StreamHash: 0x1,
-				Reason:     uint32(limits.ReasonExceedsMaxStreams),
+				Reason:     uint32(limits.ReasonMaxStreams),
 			}},
 		}},
 		expected: &proto.ExceedsLimitsResponse{
 			Results: []*proto.ExceedsLimitsResult{{
 				StreamHash: 0x1,
-				Reason:     uint32(limits.ReasonExceedsMaxStreams),
+				Reason:     uint32(limits.ReasonMaxStreams),
 			}},
 		},
 	}, {
@@ -77,19 +77,19 @@ func TestFrontend_ExceedsLimits(t *testing.T) {
 		exceedsLimitsResponses: []*proto.ExceedsLimitsResponse{{
 			Results: []*proto.ExceedsLimitsResult{{
 				StreamHash: 0x1,
-				Reason:     uint32(limits.ReasonExceedsMaxStreams),
+				Reason:     uint32(limits.ReasonMaxStreams),
 			}, {
 				StreamHash: 0x4,
-				Reason:     uint32(limits.ReasonExceedsMaxStreams),
+				Reason:     uint32(limits.ReasonMaxStreams),
 			}},
 		}},
 		expected: &proto.ExceedsLimitsResponse{
 			Results: []*proto.ExceedsLimitsResult{{
 				StreamHash: 0x1,
-				Reason:     uint32(limits.ReasonExceedsMaxStreams),
+				Reason:     uint32(limits.ReasonMaxStreams),
 			}, {
 				StreamHash: 0x4,
-				Reason:     uint32(limits.ReasonExceedsMaxStreams),
+				Reason:     uint32(limits.ReasonMaxStreams),
 			}},
 		},
 	}, {
@@ -107,21 +107,21 @@ func TestFrontend_ExceedsLimits(t *testing.T) {
 		exceedsLimitsResponses: []*proto.ExceedsLimitsResponse{{
 			Results: []*proto.ExceedsLimitsResult{{
 				StreamHash: 0x1,
-				Reason:     uint32(limits.ReasonExceedsMaxStreams),
+				Reason:     uint32(limits.ReasonMaxStreams),
 			}},
 		}, {
 			Results: []*proto.ExceedsLimitsResult{{
 				StreamHash: 0x4,
-				Reason:     uint32(limits.ReasonExceedsMaxStreams),
+				Reason:     uint32(limits.ReasonMaxStreams),
 			}},
 		}},
 		expected: &proto.ExceedsLimitsResponse{
 			Results: []*proto.ExceedsLimitsResult{{
 				StreamHash: 0x1,
-				Reason:     uint32(limits.ReasonExceedsMaxStreams),
+				Reason:     uint32(limits.ReasonMaxStreams),
 			}, {
 				StreamHash: 0x4,
-				Reason:     uint32(limits.ReasonExceedsMaxStreams),
+				Reason:     uint32(limits.ReasonMaxStreams),
 			}},
 		},
 	}}

--- a/pkg/limits/frontend/http_test.go
+++ b/pkg/limits/frontend/http_test.go
@@ -51,7 +51,7 @@ func TestFrontend_ServeHTTP(t *testing.T) {
 		exceedsLimitsResponses: []*proto.ExceedsLimitsResponse{{
 			Results: []*proto.ExceedsLimitsResult{{
 				StreamHash: 0x1,
-				Reason:     uint32(limits.ReasonExceedsMaxStreams),
+				Reason:     uint32(limits.ReasonMaxStreams),
 			}},
 		}},
 		request: httpExceedsLimitsRequest{
@@ -64,7 +64,7 @@ func TestFrontend_ServeHTTP(t *testing.T) {
 		expected: httpExceedsLimitsResponse{
 			Results: []*proto.ExceedsLimitsResult{{
 				StreamHash: 0x1,
-				Reason:     uint32(limits.ReasonExceedsMaxStreams),
+				Reason:     uint32(limits.ReasonMaxStreams),
 			}},
 		},
 	}}

--- a/pkg/limits/frontend/ring_test.go
+++ b/pkg/limits/frontend/ring_test.go
@@ -93,14 +93,14 @@ func TestRingGatherer_ExceedsLimits(t *testing.T) {
 		exceedsLimitsResponses: [][]*proto.ExceedsLimitsResponse{{{
 			Results: []*proto.ExceedsLimitsResult{{
 				StreamHash: 0x1,
-				Reason:     uint32(limits.ReasonExceedsMaxStreams),
+				Reason:     uint32(limits.ReasonMaxStreams),
 			}},
 		}}},
 		exceedsLimitsResponseErrs: [][]error{{nil}},
 		expected: []*proto.ExceedsLimitsResponse{{
 			Results: []*proto.ExceedsLimitsResult{{
 				StreamHash: 0x1,
-				Reason:     uint32(limits.ReasonExceedsMaxStreams),
+				Reason:     uint32(limits.ReasonMaxStreams),
 			}},
 		}},
 	}, {
@@ -145,7 +145,7 @@ func TestRingGatherer_ExceedsLimits(t *testing.T) {
 			nil, {{
 				Results: []*proto.ExceedsLimitsResult{{
 					StreamHash: 0x1,
-					Reason:     uint32(limits.ReasonExceedsMaxStreams),
+					Reason:     uint32(limits.ReasonMaxStreams),
 				}},
 			}},
 		},
@@ -153,7 +153,7 @@ func TestRingGatherer_ExceedsLimits(t *testing.T) {
 		expected: []*proto.ExceedsLimitsResponse{{
 			Results: []*proto.ExceedsLimitsResult{{
 				StreamHash: 0x1,
-				Reason:     uint32(limits.ReasonExceedsMaxStreams),
+				Reason:     uint32(limits.ReasonMaxStreams),
 			}},
 		}},
 	}, {
@@ -203,7 +203,7 @@ func TestRingGatherer_ExceedsLimits(t *testing.T) {
 			nil, {{
 				Results: []*proto.ExceedsLimitsResult{{
 					StreamHash: 0x1,
-					Reason:     uint32(limits.ReasonExceedsMaxStreams),
+					Reason:     uint32(limits.ReasonMaxStreams),
 				}},
 			}},
 		},
@@ -211,7 +211,7 @@ func TestRingGatherer_ExceedsLimits(t *testing.T) {
 		expected: []*proto.ExceedsLimitsResponse{{
 			Results: []*proto.ExceedsLimitsResult{{
 				StreamHash: 0x1,
-				Reason:     uint32(limits.ReasonExceedsMaxStreams),
+				Reason:     uint32(limits.ReasonMaxStreams),
 			}},
 		}},
 	}, {
@@ -261,24 +261,24 @@ func TestRingGatherer_ExceedsLimits(t *testing.T) {
 		exceedsLimitsResponses: [][]*proto.ExceedsLimitsResponse{{{
 			Results: []*proto.ExceedsLimitsResult{{
 				StreamHash: 0x2,
-				Reason:     uint32(limits.ReasonExceedsMaxStreams),
+				Reason:     uint32(limits.ReasonMaxStreams),
 			}},
 		}}, {{
 			Results: []*proto.ExceedsLimitsResult{{
 				StreamHash: 0x1,
-				Reason:     uint32(limits.ReasonExceedsMaxStreams),
+				Reason:     uint32(limits.ReasonMaxStreams),
 			}},
 		}}},
 		exceedsLimitsResponseErrs: [][]error{{nil}, {nil}},
 		expected: []*proto.ExceedsLimitsResponse{{
 			Results: []*proto.ExceedsLimitsResult{{
 				StreamHash: 0x1,
-				Reason:     uint32(limits.ReasonExceedsMaxStreams),
+				Reason:     uint32(limits.ReasonMaxStreams),
 			}},
 		}, {
 			Results: []*proto.ExceedsLimitsResult{{
 				StreamHash: 0x2,
-				Reason:     uint32(limits.ReasonExceedsMaxStreams),
+				Reason:     uint32(limits.ReasonMaxStreams),
 			}},
 		}},
 	}, {
@@ -327,7 +327,7 @@ func TestRingGatherer_ExceedsLimits(t *testing.T) {
 		exceedsLimitsResponses: [][]*proto.ExceedsLimitsResponse{{{
 			Results: []*proto.ExceedsLimitsResult{{
 				StreamHash: 0x2,
-				Reason:     uint32(limits.ReasonExceedsMaxStreams),
+				Reason:     uint32(limits.ReasonMaxStreams),
 			}},
 		}}, nil},
 		exceedsLimitsResponseErrs: [][]error{{nil}, {
@@ -336,7 +336,7 @@ func TestRingGatherer_ExceedsLimits(t *testing.T) {
 		expected: []*proto.ExceedsLimitsResponse{{
 			Results: []*proto.ExceedsLimitsResult{{
 				StreamHash: 0x2,
-				Reason:     uint32(limits.ReasonExceedsMaxStreams),
+				Reason:     uint32(limits.ReasonMaxStreams),
 			}},
 		}},
 	}, {
@@ -386,7 +386,7 @@ func TestRingGatherer_ExceedsLimits(t *testing.T) {
 		exceedsLimitsResponses: [][]*proto.ExceedsLimitsResponse{{nil}, {{
 			Results: []*proto.ExceedsLimitsResult{{
 				StreamHash: 0x1,
-				Reason:     uint32(limits.ReasonExceedsMaxStreams),
+				Reason:     uint32(limits.ReasonMaxStreams),
 			}},
 		}}},
 		exceedsLimitsResponseErrs: [][]error{{
@@ -397,7 +397,7 @@ func TestRingGatherer_ExceedsLimits(t *testing.T) {
 		expected: []*proto.ExceedsLimitsResponse{{
 			Results: []*proto.ExceedsLimitsResult{{
 				StreamHash: 0x1,
-				Reason:     uint32(limits.ReasonExceedsMaxStreams),
+				Reason:     uint32(limits.ReasonMaxStreams),
 			}},
 		}},
 	}}

--- a/pkg/limits/limit.go
+++ b/pkg/limits/limit.go
@@ -95,7 +95,7 @@ func (c *limitsChecker) ExceedsLimits(ctx context.Context, req *proto.ExceedsLim
 	for _, stream := range rejected {
 		results = append(results, &proto.ExceedsLimitsResult{
 			StreamHash: stream.StreamHash,
-			Reason:     uint32(ReasonExceedsMaxStreams),
+			Reason:     uint32(ReasonMaxStreams),
 		})
 	}
 

--- a/pkg/limits/reason.go
+++ b/pkg/limits/reason.go
@@ -3,15 +3,21 @@ package limits
 type Reason int
 
 const (
-	// ReasonExceedsMaxStreams is returned when a tenant exceeds the maximum
-	// number of active streams as per their per-tenant limit.
-	ReasonExceedsMaxStreams Reason = iota
+	// ReasonFailed is the reason returned when a stream cannot be checked
+	// against limits due to an error.
+	ReasonFailed Reason = iota + 1
+
+	// ReasonMaxStreams is returned when a stream cannot be accepted because
+	// the tenant has either reached or exceeded their maximum stream limit.
+	ReasonMaxStreams
 )
 
 func (r Reason) String() string {
 	switch r {
-	case ReasonExceedsMaxStreams:
-		return "max streams exceeded"
+	case ReasonFailed:
+		return "failed"
+	case ReasonMaxStreams:
+		return "max streams"
 	default:
 		return "unknown reason"
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request adds a new reason called `ReasonFailed`. It is used in `proto.ExceedsLimitsResult` when a stream cannot be checked against a tenant's limits due to an error. It allows this information to be fed back to the distributors which can then make a decision whether to accept or reject the streams (for example, having a per-tenant toggle).

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
