### PR TITLE
feat(compactor HS): add a job runner for processing of deletion jobs

### DIFF
--- a/pkg/compactor/deletion/job_runner.go
+++ b/pkg/compactor/deletion/job_runner.go
@@ -1,0 +1,186 @@
+package deletion
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/go-kit/log/level"
+	"github.com/pkg/errors"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+
+	"github.com/grafana/loki/v3/pkg/chunkenc"
+	"github.com/grafana/loki/v3/pkg/compactor/jobqueue"
+	"github.com/grafana/loki/v3/pkg/compactor/retention"
+	"github.com/grafana/loki/v3/pkg/storage/chunk"
+	"github.com/grafana/loki/v3/pkg/storage/chunk/client"
+	"github.com/grafana/loki/v3/pkg/util"
+	"github.com/grafana/loki/v3/pkg/util/filter"
+	util_log "github.com/grafana/loki/v3/pkg/util/log"
+)
+
+type GetChunkClientForTableFunc func(ctx context.Context, table string) (client.Client, error)
+
+type JobRunner struct {
+	getChunkClientForTableFunc GetChunkClientForTableFunc
+}
+
+type Chunk struct {
+	From, Through model.Time
+	Fingerprint   uint64
+	Checksum      uint32
+	KB, Entries   uint32
+}
+
+// JobResult holds details of chunks to be deleted from index and new chunk entries to be added to it.
+// ToDo(Sandeep): Use proto for encoding instead of json for better performance and resource usage.
+type JobResult struct {
+	ChunksToDelete  []string // List of chunks to be deleted from object storage and removed from the index of the current table
+	ChunksToDeIndex []string // List of chunks only to be removed from the index of the current table
+	ChunksToIndex   []Chunk  // List of chunks to be indexed in the current table
+}
+
+func NewJobRunner(getStorageClientForTableFunc GetChunkClientForTableFunc) *JobRunner {
+	return &JobRunner{
+		getChunkClientForTableFunc: getStorageClientForTableFunc,
+	}
+}
+
+func (jr *JobRunner) Run(ctx context.Context, job jobqueue.Job) (*JobResult, error) {
+	var deletionJob deletionJob
+	var jobResult JobResult
+
+	if err := json.Unmarshal(job.Payload, &deletionJob); err != nil {
+		return nil, err
+	}
+
+	chunkClient, err := jr.getChunkClientForTableFunc(ctx, deletionJob.TableName)
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range deletionJob.DeleteRequests {
+		req := &deletionJob.DeleteRequests[i]
+		if err := req.SetQuery(req.Query); err != nil {
+			return nil, err
+		}
+		if !req.logSelectorExpr.HasFilter() {
+			return nil, errors.New("deletion query does not contain filter")
+		}
+		// ToDo(Sandeep): set it to proper metrics
+		req.Metrics = newDeleteRequestsManagerMetrics(nil)
+	}
+
+	var prevFingerprint uint64
+	var filterFuncs []filter.Func
+
+	tableInterval := retention.ExtractIntervalFromTableName(deletionJob.TableName)
+	for _, chunkID := range deletionJob.ChunkIDs {
+		chk, err := chunk.ParseExternalKey(deletionJob.UserID, chunkID)
+		if err != nil {
+			return nil, err
+		}
+
+		// get the chunk from storage
+		chks, err := chunkClient.GetChunks(context.Background(), []chunk.Chunk{chk})
+		if err != nil {
+			return nil, err
+		}
+
+		if len(chks) != 1 {
+			return nil, fmt.Errorf("expected 1 entry for chunk %s but found %d in storage", chunkID, len(chks))
+		}
+
+		// Build a chain of filters to apply on the chunk to remove data requested for deletion.
+		// If we are processing chunk of the same stream then reuse the same filterFuncs as earlier
+		if prevFingerprint != chks[0].Fingerprint {
+			filterFuncs = filterFuncs[:0]
+			prevFingerprint = chks[0].Fingerprint
+
+			for _, req := range deletionJob.DeleteRequests {
+				filterFunc, err := req.FilterFunction(chks[0].Metric)
+				if err != nil {
+					return nil, err
+				}
+
+				filterFuncs = append(filterFuncs, filterFunc)
+			}
+		}
+
+		// rebuild the chunk and see if we excluded any of the lines from the existing chunk
+		var linesDeleted bool
+		newChunkData, err := chks[0].Data.Rebound(chk.From, chk.Through, func(ts time.Time, s string, structuredMetadata labels.Labels) bool {
+			for _, filterFunc := range filterFuncs {
+				if filterFunc(ts, s, structuredMetadata) {
+					linesDeleted = true
+					return true
+				}
+			}
+
+			return false
+		})
+		if err != nil {
+			if errors.Is(err, chunk.ErrSliceNoDataInRange) {
+				level.Info(util_log.Logger).Log("msg", "Delete request filterFunc leaves an empty chunk", "chunk ref", chunkID)
+				jobResult.ChunksToDelete = append(jobResult.ChunksToDelete, chunkID)
+				continue
+			}
+			return nil, err
+		}
+
+		// if no lines were deleted then there is nothing to do
+		if !linesDeleted {
+			continue
+		}
+
+		facade, ok := newChunkData.(*chunkenc.Facade)
+		if !ok {
+			return nil, errors.New("invalid chunk type")
+		}
+
+		newChunkStart, newChunkEnd := util.RoundToMilliseconds(facade.Bounds())
+
+		// the new chunk is out of range for the table in process, so don't upload and index it
+		if newChunkStart > tableInterval.End || newChunkEnd < tableInterval.Start {
+			// only remove the index entry from the current table since the new chunk is out of its range
+			jobResult.ChunksToDeIndex = append(jobResult.ChunksToDeIndex, chunkID)
+			continue
+		}
+
+		// upload the new chunk to object storage
+		newChunk := chunk.NewChunk(
+			deletionJob.UserID, chks[0].FingerprintModel(), chks[0].Metric,
+			facade,
+			newChunkStart,
+			newChunkEnd,
+		)
+
+		err = newChunk.Encode()
+		if err != nil {
+			return nil, err
+		}
+
+		err = chunkClient.PutChunks(ctx, []chunk.Chunk{newChunk})
+		if err != nil {
+			return nil, err
+		}
+
+		// add the new chunk details to the list of chunks to index
+		jobResult.ChunksToIndex = append(jobResult.ChunksToIndex, Chunk{
+			From:        newChunk.From,
+			Through:     newChunk.Through,
+			Fingerprint: newChunk.Fingerprint,
+			Checksum:    newChunk.Checksum,
+			KB:          uint32(math.Round(float64(newChunk.Data.UncompressedSize()) / float64(1<<10))),
+			Entries:     uint32(newChunk.Data.Entries()),
+		})
+
+		// Add the ID of original chunk to the list of ChunksToDelete
+		jobResult.ChunksToDelete = append(jobResult.ChunksToDelete, chunkID)
+	}
+
+	return &jobResult, nil
+}

--- a/pkg/compactor/deletion/job_runner.go
+++ b/pkg/compactor/deletion/job_runner.go
@@ -78,6 +78,7 @@ func (jr *JobRunner) Run(ctx context.Context, job jobqueue.Job) (*JobResult, err
 	var filterFuncs []filter.Func
 
 	tableInterval := retention.ExtractIntervalFromTableName(deletionJob.TableName)
+	// ToDo(Sandeep): Make chunk processing concurrent with a reasonable concurrency.
 	for _, chunkID := range deletionJob.ChunkIDs {
 		chk, err := chunk.ParseExternalKey(deletionJob.UserID, chunkID)
 		if err != nil {
@@ -85,7 +86,7 @@ func (jr *JobRunner) Run(ctx context.Context, job jobqueue.Job) (*JobResult, err
 		}
 
 		// get the chunk from storage
-		chks, err := chunkClient.GetChunks(context.Background(), []chunk.Chunk{chk})
+		chks, err := chunkClient.GetChunks(ctx, []chunk.Chunk{chk})
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/compactor/deletion/job_runner_test.go
+++ b/pkg/compactor/deletion/job_runner_test.go
@@ -1,0 +1,325 @@
+package deletion
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/pkg/push"
+	"github.com/grafana/loki/v3/pkg/chunkenc"
+	"github.com/grafana/loki/v3/pkg/compactor/jobqueue"
+	"github.com/grafana/loki/v3/pkg/compactor/retention"
+	"github.com/grafana/loki/v3/pkg/compression"
+	"github.com/grafana/loki/v3/pkg/logproto"
+	"github.com/grafana/loki/v3/pkg/logql/syntax"
+	"github.com/grafana/loki/v3/pkg/storage/chunk"
+	"github.com/grafana/loki/v3/pkg/storage/chunk/client"
+)
+
+type mockChunkClient struct {
+	client.Client
+	chunks map[string]chunk.Chunk
+}
+
+func (m *mockChunkClient) GetChunks(_ context.Context, chunks []chunk.Chunk) ([]chunk.Chunk, error) {
+	var result []chunk.Chunk
+	for _, chk := range chunks {
+		if storedChk, ok := m.chunks[chunkKey(chk)]; ok {
+			result = append(result, storedChk)
+		}
+	}
+	return result, nil
+}
+
+func (m *mockChunkClient) PutChunks(_ context.Context, chunks []chunk.Chunk) error {
+	for _, chk := range chunks {
+		m.chunks[chunkKey(chk)] = chk
+	}
+	return nil
+}
+
+// Helper to convert prometheus labels.Labels to push.LabelsAdapter
+func toLabelsAdapter(lbls labels.Labels) push.LabelsAdapter {
+	out := make(push.LabelsAdapter, 0, len(lbls))
+	for _, l := range lbls {
+		out = append(out, push.LabelAdapter{Name: l.Name, Value: l.Value})
+	}
+	return out
+}
+
+// Helper to generate a unique key for a chunk (for test map)
+func chunkKey(c chunk.Chunk) string {
+	return fmt.Sprintf("%s/%x/%x:%x:%x", c.UserID, c.Fingerprint, int64(c.From), int64(c.Through), c.Checksum)
+}
+
+// Helper to create a test chunk with data
+func createTestChunk(t *testing.T, userID string, lbs labels.Labels, from, through model.Time, logLine string, structuredMetadata push.LabelsAdapter, logInterval time.Duration) chunk.Chunk {
+	t.Helper()
+	const (
+		targetSize = 1500 * 1024
+		blockSize  = 256 * 1024
+	)
+	labelsBuilder := labels.NewBuilder(lbs)
+	labelsBuilder.Set(labels.MetricName, "logs")
+	metric := labelsBuilder.Labels()
+	fp := model.Fingerprint(lbs.Hash())
+	chunkEnc := chunkenc.NewMemChunk(chunkenc.ChunkFormatV4, compression.None, chunkenc.UnorderedWithStructuredMetadataHeadBlockFmt, blockSize, targetSize)
+
+	for ts := from; !ts.After(through); ts = ts.Add(logInterval) {
+		dup, err := chunkEnc.Append(&logproto.Entry{
+			Timestamp:          ts.Time(),
+			Line:               logLine,
+			StructuredMetadata: structuredMetadata,
+		})
+		require.False(t, dup)
+		require.NoError(t, err)
+	}
+
+	require.NoError(t, chunkEnc.Close())
+	c := chunk.NewChunk(userID, fp, metric, chunkenc.NewFacade(chunkEnc, blockSize, targetSize), from, through)
+	require.NoError(t, c.Encode())
+	return c
+}
+
+func TestJobRunner_Run(t *testing.T) {
+	now := model.Now()
+	userID := "test-user"
+	yesterdaysTableNumber := (now.Unix() / 86400) - 1
+	tableName := fmt.Sprintf("table_%d", yesterdaysTableNumber)
+	yesterdaysTableInterval := retention.ExtractIntervalFromTableName(tableName)
+
+	// Create test labels
+	lblFoo, err := syntax.ParseLabels(`{foo="bar"}`)
+	require.NoError(t, err)
+
+	chk := createTestChunk(t, userID, lblFoo, yesterdaysTableInterval.Start.Add(-6*time.Hour), yesterdaysTableInterval.Start.Add(6*time.Hour), "test data", toLabelsAdapter(labels.FromStrings("foo", "bar")), time.Minute)
+
+	for _, tc := range []struct {
+		name           string
+		deleteRequests []DeleteRequest
+		expectedResult *JobResult
+		expectError    bool
+	}{
+		{
+			name: "delete request without line filter should fail",
+			deleteRequests: []DeleteRequest{
+				{
+					RequestID: "test-request-5",
+					Query:     lblFoo.String(),
+					StartTime: yesterdaysTableInterval.Start.Add(-7 * time.Hour),
+					EndTime:   yesterdaysTableInterval.Start.Add(time.Hour),
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "delete request not matching any data",
+			deleteRequests: []DeleteRequest{
+				{
+					RequestID: "test-request-1",
+					Query:     `{foo="different"} |= "test"`,
+					StartTime: yesterdaysTableInterval.Start.Add(-12 * time.Hour),
+					EndTime:   now,
+				},
+			},
+			expectedResult: &JobResult{},
+		},
+		{
+			name: "single delete request deleting some data",
+			deleteRequests: []DeleteRequest{
+				{
+					RequestID: "test-request-2",
+					Query:     lblFoo.String() + ` |= "test"`,
+					StartTime: yesterdaysTableInterval.Start.Add(-7 * time.Hour),
+					EndTime:   yesterdaysTableInterval.Start.Add(time.Hour),
+				},
+			},
+			expectedResult: &JobResult{
+				ChunksToDelete: []string{chunkKey(chk)},
+				ChunksToIndex: []Chunk{
+					{
+						From:        yesterdaysTableInterval.Start.Add(time.Hour).Add(time.Minute),
+						Through:     yesterdaysTableInterval.Start.Add(6 * time.Hour),
+						Fingerprint: lblFoo.Hash(),
+					},
+				},
+			},
+		},
+		{
+			name: "multiple delete requests deleting data",
+			deleteRequests: []DeleteRequest{
+				{
+					RequestID: "test-request-3",
+					Query:     lblFoo.String() + ` |= "test"`,
+					StartTime: yesterdaysTableInterval.Start.Add(-7 * time.Hour),
+					EndTime:   yesterdaysTableInterval.Start,
+				},
+				{
+					RequestID: "test-request-4",
+					Query:     lblFoo.String() + ` |= "data"`,
+					StartTime: yesterdaysTableInterval.Start,
+					EndTime:   yesterdaysTableInterval.Start.Add(time.Hour),
+				},
+			},
+			expectedResult: &JobResult{
+				ChunksToDelete: []string{chunkKey(chk)},
+				ChunksToIndex: []Chunk{
+					{
+						From:        yesterdaysTableInterval.Start.Add(time.Hour).Add(time.Minute),
+						Through:     yesterdaysTableInterval.Start.Add(6 * time.Hour),
+						Fingerprint: lblFoo.Hash(),
+					},
+				},
+			},
+		},
+		{
+			name: "delete request with time range outside chunk time range",
+			deleteRequests: []DeleteRequest{
+				{
+					RequestID: "test-request-6",
+					Query:     lblFoo.String() + ` |= "test"`,
+					StartTime: yesterdaysTableInterval.Start.Add(-24 * time.Hour),
+					EndTime:   yesterdaysTableInterval.Start.Add(-23 * time.Hour),
+				},
+			},
+			expectedResult: &JobResult{},
+		},
+		{
+			name: "delete request with structured metadata filter",
+			deleteRequests: []DeleteRequest{
+				{
+					RequestID: "test-request-7",
+					Query:     lblFoo.String() + ` | foo="bar"`,
+					StartTime: yesterdaysTableInterval.Start.Add(-7 * time.Hour),
+					EndTime:   yesterdaysTableInterval.Start.Add(2 * time.Hour),
+				},
+			},
+			expectedResult: &JobResult{
+				ChunksToDelete: []string{chunkKey(chk)},
+				ChunksToIndex: []Chunk{
+					{
+						From:        yesterdaysTableInterval.Start.Add(2 * time.Hour).Add(time.Minute),
+						Through:     yesterdaysTableInterval.Start.Add(6 * time.Hour),
+						Fingerprint: lblFoo.Hash(),
+					},
+				},
+			},
+		},
+		{
+			name: "delete request with line and structured metadata filters",
+			deleteRequests: []DeleteRequest{
+				{
+					RequestID: "test-request-8",
+					Query:     lblFoo.String() + ` | foo="bar" |= "test"`,
+					StartTime: yesterdaysTableInterval.Start.Add(-7 * time.Hour),
+					EndTime:   yesterdaysTableInterval.Start.Add(3 * time.Hour),
+				},
+			},
+			expectedResult: &JobResult{
+				ChunksToDelete: []string{chunkKey(chk)},
+				ChunksToIndex: []Chunk{
+					{
+						From:        yesterdaysTableInterval.Start.Add(3 * time.Hour).Add(time.Minute),
+						Through:     yesterdaysTableInterval.Start.Add(6 * time.Hour),
+						Fingerprint: lblFoo.Hash(),
+					},
+				},
+			},
+		},
+		{
+			name: "delete request deleting the whole chunk",
+			deleteRequests: []DeleteRequest{
+				{
+					RequestID: "test-request-8",
+					Query:     lblFoo.String() + ` |= "test"`,
+					StartTime: yesterdaysTableInterval.Start.Add(-7 * time.Hour),
+					EndTime:   yesterdaysTableInterval.Start.Add(7 * time.Hour),
+				},
+			},
+			expectedResult: &JobResult{
+				ChunksToDelete: []string{chunkKey(chk)},
+			},
+		},
+		{
+			name: "old chunk to be de-indexed when new chunk wont belong to the current table",
+			deleteRequests: []DeleteRequest{
+				{
+					RequestID: "test-request-8",
+					Query:     lblFoo.String() + ` |= "test"`,
+					StartTime: yesterdaysTableInterval.Start,
+					EndTime:   yesterdaysTableInterval.Start.Add(7 * time.Hour),
+				},
+			},
+			expectedResult: &JobResult{
+				ChunksToDeIndex: []string{chunkKey(chk)},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// Setup mock chunk client
+			mockClient := &mockChunkClient{
+				chunks: map[string]chunk.Chunk{
+					chunkKey(chk): chk,
+				},
+			}
+
+			// Ensure Metrics is set for each DeleteRequest
+			for i := range tc.deleteRequests {
+				tc.deleteRequests[i].Metrics = newDeleteRequestsManagerMetrics(nil)
+			}
+
+			// Create job runner
+			runner := NewJobRunner(func(_ context.Context, _ string) (client.Client, error) {
+				return mockClient, nil
+			})
+
+			// Create job
+			job := jobqueue.Job{
+				Id: "test-job",
+				Payload: mustMarshal(t, deletionJob{
+					UserID:         userID,
+					TableName:      tableName,
+					ChunkIDs:       []string{chunkKey(chk)},
+					DeleteRequests: tc.deleteRequests,
+				}),
+			}
+
+			// Run job
+			result, err := runner.Run(context.Background(), job)
+
+			if tc.expectError {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+
+			// For test cases where we expect no changes
+			if len(tc.expectedResult.ChunksToDelete) == 0 && len(tc.expectedResult.ChunksToIndex) == 0 {
+				require.Equal(t, tc.expectedResult, result)
+				return
+			}
+
+			// For test cases where we expect changes
+			require.Equal(t, tc.expectedResult.ChunksToDelete, result.ChunksToDelete)
+			require.Equal(t, len(tc.expectedResult.ChunksToIndex), len(result.ChunksToIndex))
+			if len(result.ChunksToIndex) > 0 {
+				require.Equal(t, tc.expectedResult.ChunksToIndex[0].From, result.ChunksToIndex[0].From)
+				require.Equal(t, tc.expectedResult.ChunksToIndex[0].Through, result.ChunksToIndex[0].Through)
+				require.Equal(t, tc.expectedResult.ChunksToIndex[0].Fingerprint, result.ChunksToIndex[0].Fingerprint)
+			}
+		})
+	}
+}
+
+func mustMarshal(t *testing.T, v interface{}) []byte {
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	return b
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
As a follow-up to work on making Compactor horizontally scalable for processing delete requests, this PR adds a job runner that executes the deletion jobs. The Deletion Job runner would download the chunks from the object storage, apply the filters from the given delete requests, upload any newly built chunks with deleted lines filtered out and build a job response which includes:
1. List of chunk IDs to delete from storage and the index.
2. List of chunk IDs to de-index from the index.
3. List of new chunks to be added to the index.

**Checklist**
- [X] Tests updated
