### PR TITLE
fix: Fix nil pointer dereference in Volume method of the composite store

### DIFF
--- a/pkg/storage/stores/composite_store_entry.go
+++ b/pkg/storage/stores/composite_store_entry.go
@@ -169,10 +169,14 @@ func (c *storeEntry) Volume(ctx context.Context, userID string, from, through mo
 		attribute.String("from", from.Time().String()),
 		attribute.String("through", through.Time().String()),
 		attribute.String("matchers", syntax.MatchersString(matchers)),
-		attribute.String("err", err.Error()),
 		attribute.Int("limit", int(limit)),
 		attribute.String("aggregateBy", aggregateBy),
 	)
+	if err != nil {
+		sp.SetAttributes(
+			attribute.String("err", err.Error()),
+		)
+	}
 
 	return c.indexReader.Volume(ctx, userID, from, through, limit, targetLabels, aggregateBy, matchers...)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

If `err` is nil then calling the method `Error()` on it causes a nil pointer dereference.
