### PR TITLE
fix(limits): Set ready when all partitions ready

### DIFF
--- a/pkg/limits/partition_manager.go
+++ b/pkg/limits/partition_manager.go
@@ -141,8 +141,8 @@ func (m *partitionManager) ListByState(state partitionState) map[int32]int64 {
 
 // CheckReady returns true if all partitions are ready.
 func (m *partitionManager) CheckReady() bool {
-	m.mtx.Lock()
-	defer m.mtx.Unlock()
+	m.mtx.RLock()
+	defer m.mtx.RUnlock()
 	for _, entry := range m.partitions {
 		if entry.state != partitionReady {
 			return false

--- a/pkg/limits/partition_manager.go
+++ b/pkg/limits/partition_manager.go
@@ -84,6 +84,18 @@ func (m *partitionManager) Assign(partitions []int32) {
 	}
 }
 
+// CheckReady returns true if all partitions are ready.
+func (m *partitionManager) CheckReady() bool {
+	m.mtx.RLock()
+	defer m.mtx.RUnlock()
+	for _, entry := range m.partitions {
+		if entry.state != partitionReady {
+			return false
+		}
+	}
+	return true
+}
+
 // Count returns the number of assigned partitions.
 func (m *partitionManager) Count() int {
 	m.mtx.Lock()
@@ -144,18 +156,6 @@ func (m *partitionManager) ListByState(state partitionState) map[int32]int64 {
 		}
 	}
 	return result
-}
-
-// CheckReady returns true if all partitions are ready.
-func (m *partitionManager) CheckReady() bool {
-	m.mtx.RLock()
-	defer m.mtx.RUnlock()
-	for _, entry := range m.partitions {
-		if entry.state != partitionReady {
-			return false
-		}
-	}
-	return true
 }
 
 // SetReplaying sets the partition as replaying and the offset that must

--- a/pkg/limits/partition_manager.go
+++ b/pkg/limits/partition_manager.go
@@ -84,6 +84,13 @@ func (m *partitionManager) Assign(partitions []int32) {
 	}
 }
 
+// Count returns the number of assigned partitions.
+func (m *partitionManager) Count() int {
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+	return len(m.partitions)
+}
+
 // GetState returns the current state of the partition. It returns false
 // if the partition does not exist.
 func (m *partitionManager) GetState(partition int32) (partitionState, bool) {

--- a/pkg/limits/partition_manager_test.go
+++ b/pkg/limits/partition_manager_test.go
@@ -160,6 +160,24 @@ func TestPartitionManager_ListByState(t *testing.T) {
 	require.Equal(t, map[int32]int64{1: now}, result)
 }
 
+func TestPartitionManager_CheckReady(t *testing.T) {
+	m, err := newPartitionManager(prometheus.NewRegistry())
+	require.NoError(t, err)
+	c := quartz.NewMock(t)
+	m.clock = c
+	c.Advance(1)
+	m.Assign([]int32{1, 2})
+	require.False(t, m.CheckReady())
+	m.SetReplaying(1, 10)
+	require.False(t, m.CheckReady())
+	m.SetReady(1)
+	require.False(t, m.CheckReady())
+	m.SetReplaying(2, 10)
+	require.False(t, m.CheckReady())
+	m.SetReady(2)
+	require.True(t, m.CheckReady())
+}
+
 func TestPartitionManager_SetReplaying(t *testing.T) {
 	m, err := newPartitionManager(prometheus.NewRegistry())
 	require.NoError(t, err)

--- a/pkg/limits/partition_manager_test.go
+++ b/pkg/limits/partition_manager_test.go
@@ -61,6 +61,24 @@ func TestPartitionManager_Assign(t *testing.T) {
 	}, m.partitions)
 }
 
+func TestPartitionManager_CheckReady(t *testing.T) {
+	m, err := newPartitionManager(prometheus.NewRegistry())
+	require.NoError(t, err)
+	c := quartz.NewMock(t)
+	m.clock = c
+	c.Advance(1)
+	m.Assign([]int32{1, 2})
+	require.False(t, m.CheckReady())
+	m.SetReplaying(1, 10)
+	require.False(t, m.CheckReady())
+	m.SetReady(1)
+	require.False(t, m.CheckReady())
+	m.SetReplaying(2, 10)
+	require.False(t, m.CheckReady())
+	m.SetReady(2)
+	require.True(t, m.CheckReady())
+}
+
 func TestPartitionManager_GetState(t *testing.T) {
 	m, err := newPartitionManager(prometheus.NewRegistry())
 	require.NoError(t, err)
@@ -158,24 +176,6 @@ func TestPartitionManager_ListByState(t *testing.T) {
 	require.True(t, m.SetReady(1))
 	result = m.ListByState(partitionReady)
 	require.Equal(t, map[int32]int64{1: now}, result)
-}
-
-func TestPartitionManager_CheckReady(t *testing.T) {
-	m, err := newPartitionManager(prometheus.NewRegistry())
-	require.NoError(t, err)
-	c := quartz.NewMock(t)
-	m.clock = c
-	c.Advance(1)
-	m.Assign([]int32{1, 2})
-	require.False(t, m.CheckReady())
-	m.SetReplaying(1, 10)
-	require.False(t, m.CheckReady())
-	m.SetReady(1)
-	require.False(t, m.CheckReady())
-	m.SetReplaying(2, 10)
-	require.False(t, m.CheckReady())
-	m.SetReady(2)
-	require.True(t, m.CheckReady())
 }
 
 func TestPartitionManager_SetReplaying(t *testing.T) {

--- a/pkg/limits/service.go
+++ b/pkg/limits/service.go
@@ -198,7 +198,7 @@ func (s *Service) CheckReady(ctx context.Context) error {
 	s.partitionReadinessMtx.Lock()
 	defer s.partitionReadinessMtx.Unlock()
 	// We are ready when all of our assigned partitions have replayed the
-	// last active window of data. This is referred to as partition readiness.
+	// last active window records. This is referred to as partition readiness.
 	// Once we have passed partition readiness we never check it again as
 	// otherwise the service could become unready during a partition rebalance.
 	if !s.partitionReadinessPassed {

--- a/pkg/limits/service.go
+++ b/pkg/limits/service.go
@@ -28,8 +28,9 @@ const (
 	RingKey  = "ingest-limits"
 	RingName = "ingest-limits"
 
-	// The maximum number of checks to fail while waiting to be assigned
-	// some partitions before giving up and going ready.
+	// The maximum number of consecutive checks to [Service.CheckReady]
+	// before giving up waiting to be assigned some partitions and going
+	// ready.
 	maxPartitionReadinessWaitAssignChecks = 10
 )
 

--- a/pkg/limits/service.go
+++ b/pkg/limits/service.go
@@ -74,9 +74,9 @@ func New(cfg Config, limits Limits, logger log.Logger, reg prometheus.Registerer
 			Name:      "ingest_limits_stream_evictions_total",
 			Help:      "The total number of streams evicted due to age per tenant. This is not a global total, as tenants can be sharded over multiple pods.",
 		}, []string{"tenant"}),
-		clock:                      quartz.NewReal(),
 		partitionReadinessAttempts: atomic.NewInt32(0),
 		partitionReadinessPassed:   atomic.NewBool(false),
+		clock:                      quartz.NewReal(),
 	}
 	s.partitionManager, err = newPartitionManager(reg)
 	if err != nil {

--- a/pkg/limits/service.go
+++ b/pkg/limits/service.go
@@ -219,7 +219,7 @@ func (s *Service) CheckReady(ctx context.Context) error {
 // checkPartitionsAssigned checks if we either have been assigned some
 // partitions or the wait assign period has elapsed. It must not be called
 // without a lock on partitionReadinessMtx.
-func (s *Service) checkPartitionsAssigned(ctx context.Context) error {
+func (s *Service) checkPartitionsAssigned(_ context.Context) error {
 	if s.partitionReadinessWaitAssignSince == (time.Time{}) {
 		s.partitionReadinessWaitAssignSince = s.clock.Now()
 	}
@@ -233,7 +233,7 @@ func (s *Service) checkPartitionsAssigned(ctx context.Context) error {
 
 // checkPartitionsReady checks if all our assigned partitions are ready.
 // It must not be called without a lock on partitionReadinessMtx.
-func (s *Service) checkPartitionsReady(ctx context.Context) error {
+func (s *Service) checkPartitionsReady(_ context.Context) error {
 	// If we lose our assigned partitions while replaying them we want to
 	// wait another complete wait assign period.
 	s.partitionReadinessWaitAssignSince = time.Time{}

--- a/pkg/limits/service.go
+++ b/pkg/limits/service.go
@@ -212,9 +212,6 @@ func (s *Service) CheckReady(ctx context.Context) error {
 			return fmt.Errorf("no partitions assigned, retrying")
 		}
 
-		// reset retries on success
-		s.partitionReadinessAttempts.Store(0)
-
 		if !s.partitionManager.CheckReady() {
 			return fmt.Errorf("partitions not ready")
 		}

--- a/pkg/limits/service.go
+++ b/pkg/limits/service.go
@@ -76,6 +76,7 @@ func New(cfg Config, limits Limits, logger log.Logger, reg prometheus.Registerer
 		}, []string{"tenant"}),
 		clock:            quartz.NewReal(),
 		assigmentRetries: atomic.NewInt32(0),
+		initialized:      atomic.NewBool(false),
 	}
 	s.partitionManager, err = newPartitionManager(reg)
 	if err != nil {

--- a/pkg/limits/service.go
+++ b/pkg/limits/service.go
@@ -199,7 +199,7 @@ func (s *Service) CheckReady(ctx context.Context) error {
 	// are complete on the service startup only.
 	if !s.partitionReadinessPassed.Load() {
 		if len(s.partitionManager.List()) == 0 {
-			if s.partitionReadinessAttempts.Load() == maxPartitionReadinessAttempts {
+			if s.partitionReadinessAttempts.Load() >= maxPartitionReadinessAttempts {
 				// If no partition assigment on startup,
 				// declare the service initialized.
 				s.partitionReadinessPassed.Store(true)


### PR DESCRIPTION
**What this PR does / why we need it**:
This pull request makes the ingest-limits readiness handler to consider partition state before signaling ready. I.e. the service is considered to be ready and consume traffic when the following conditions apply:
- The partition manager assigned partitions (max retries 10)
- The partition lifecycler moved all partitions from pending/replaying to ready state.

**Which issue(s) this PR fixes**:
Fixes #grafana/loki-private/issues/1722

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
