### PR TITLE
chore(engine): Map line filter expressions to data object predicates

### DIFF
--- a/pkg/engine/executor/dataobjscan_predicate.go
+++ b/pkg/engine/executor/dataobjscan_predicate.go
@@ -1,8 +1,10 @@
 package executor
 
 import (
+	"bytes"
 	"fmt"
 	"math"
+	"regexp"
 	"time"
 
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/logs"
@@ -10,6 +12,10 @@ import (
 	"github.com/grafana/loki/v3/pkg/engine/internal/types"
 	"github.com/grafana/loki/v3/pkg/engine/planner/physical"
 )
+
+var matchAllFilter = logs.LogMessageFilterRowPredicate{
+	Keep: func(_ []byte) bool { return true },
+}
 
 // buildLogsPredicate builds a logs predicate from an expression.
 func buildLogsPredicate(expr physical.Expression) (logs.RowPredicate, error) {
@@ -64,6 +70,9 @@ func mapInitiallySupportedPredicates(expr physical.Expression) (logs.RowPredicat
 		case types.ColumnTypeBuiltin:
 			if left.Ref.Column == types.ColumnNameBuiltinTimestamp {
 				return mapTimestampPredicate(e)
+			}
+			if left.Ref.Column == types.ColumnNameBuiltinMessage {
+				return mapMessagePredicate(e)
 			}
 			return nil, fmt.Errorf("unsupported builtin column in predicate (only timestamp is supported for now): %s", left.Ref.Column)
 		case types.ColumnTypeMetadata:
@@ -346,4 +355,133 @@ func mapMetadataPredicate(expr physical.Expression) (logs.RowPredicate, error) {
 	default:
 		return nil, fmt.Errorf("unsupported expression type (%T) for metadata predicate, expected BinaryExpr or UnaryExpr", expr)
 	}
+}
+
+func mapMessagePredicate(expr physical.Expression) (logs.RowPredicate, error) {
+	switch e := expr.(type) {
+	case *physical.BinaryExpr:
+		switch e.Op {
+
+		case types.BinaryOpMatchSubstr, types.BinaryOpNotMatchSubstr, types.BinaryOpMatchRe, types.BinaryOpNotMatchRe:
+			return match(e)
+
+		case types.BinaryOpMatchPattern, types.BinaryOpNotMatchPattern:
+			return nil, fmt.Errorf("unsupported binary operator (%s) for string predicate", e.Op)
+
+		case types.BinaryOpAnd:
+			leftPredicate, err := mapMessagePredicate(e.Left)
+			if err != nil {
+				return nil, fmt.Errorf("failed to map left operand of AND: %w", err)
+			}
+			rightPredicate, err := mapMessagePredicate(e.Right)
+			if err != nil {
+				return nil, fmt.Errorf("failed to map right operand of AND: %w", err)
+			}
+			return logs.AndRowPredicate{
+				Left:  leftPredicate,
+				Right: rightPredicate,
+			}, nil
+
+		case types.BinaryOpOr:
+			leftPredicate, err := mapMessagePredicate(e.Left)
+			if err != nil {
+				return nil, fmt.Errorf("failed to map left operand of OR: %w", err)
+			}
+			rightPredicate, err := mapMessagePredicate(e.Right)
+			if err != nil {
+				return nil, fmt.Errorf("failed to map right operand of OR: %w", err)
+			}
+			return logs.OrRowPredicate{
+				Left:  leftPredicate,
+				Right: rightPredicate,
+			}, nil
+
+		default:
+			return nil, fmt.Errorf("unsupported binary operator (%s) for metadata predicate, expected MATCH_STR, NOT_MATCH_STR, MATCH_RE, NOT_MATCH_RE, AND, or OR", e.Op)
+		}
+
+	case *physical.UnaryExpr:
+		if e.Op != types.UnaryOpNot {
+			return nil, fmt.Errorf("unsupported unary operator (%s) for metadata predicate, expected NOT", e.Op)
+		}
+		innerPredicate, err := mapMessagePredicate(e.Left)
+		if err != nil {
+			return nil, fmt.Errorf("failed to map inner expression of NOT: %w", err)
+		}
+		return logs.NotRowPredicate{
+			Inner: innerPredicate,
+		}, nil
+
+	default:
+		return nil, fmt.Errorf("unsupported expression type (%T) for metadata predicate, expected BinaryExpr or UnaryExpr", expr)
+	}
+}
+
+func match(e *physical.BinaryExpr) (logs.RowPredicate, error) {
+	val, err := rhsValue(e)
+	if err != nil {
+		return nil, err
+	}
+
+	switch e.Op {
+
+	case types.BinaryOpMatchSubstr:
+		return logs.LogMessageFilterRowPredicate{
+			Keep: func(line []byte) bool { return bytes.Contains(line, []byte(val)) },
+		}, nil
+
+	case types.BinaryOpNotMatchSubstr:
+		return logs.LogMessageFilterRowPredicate{
+			Keep: func(line []byte) bool { return !bytes.Contains(line, []byte(val)) },
+		}, nil
+
+	case types.BinaryOpMatchRe:
+		re, err := regexp.Compile(val)
+		if err != nil {
+			return nil, err
+		}
+		return logs.LogMessageFilterRowPredicate{
+			Keep: func(line []byte) bool { return re.Match(line) },
+		}, nil
+
+	case types.BinaryOpNotMatchRe:
+		re, err := regexp.Compile(val)
+		if err != nil {
+			return nil, err
+		}
+		return logs.LogMessageFilterRowPredicate{
+			Keep: func(line []byte) bool { return !re.Match(line) },
+		}, nil
+
+	default:
+		return nil, fmt.Errorf("unsupported binary operator (%s) for string predicate", e.Op)
+	}
+}
+
+func rhsValue(e *physical.BinaryExpr) (string, error) {
+	op := e.Op.String()
+
+	if e.Left.Type() != physical.ExprTypeColumn {
+		return "", fmt.Errorf("unsupported LHS type (%v) for %s message predicate, expected ColumnExpr", e.Left.Type(), op)
+	}
+	leftColumn, ok := e.Left.(*physical.ColumnExpr)
+	if !ok { // Should not happen due to Type() check but defensive
+		return "", fmt.Errorf("LHS of %s message predicate failed to cast to ColumnExpr", op)
+	}
+	if leftColumn.Ref.Type != types.ColumnTypeBuiltin {
+		return "", fmt.Errorf("unsupported LHS column type (%v) for %s message predicate, expected ColumnTypeBuiltin", leftColumn.Ref.Type, op)
+	}
+
+	if e.Right.Type() != physical.ExprTypeLiteral {
+		return "", fmt.Errorf("unsupported RHS type (%v) for %s message predicate, expected LiteralExpr", e.Right.Type(), op)
+	}
+	rightLiteral, ok := e.Right.(*physical.LiteralExpr)
+	if !ok { // Should not happen
+		return "", fmt.Errorf("RHS of %s message predicate failed to cast to LiteralExpr", op)
+	}
+	if rightLiteral.ValueType() != datatype.String {
+		return "", fmt.Errorf("unsupported RHS literal type (%v) for %s message predicate, expected ValueTypeStr", rightLiteral.ValueType(), op)
+	}
+
+	return rightLiteral.Literal.(*datatype.StringLiteral).Value(), nil
 }

--- a/pkg/engine/executor/dataobjscan_predicate.go
+++ b/pkg/engine/executor/dataobjscan_predicate.go
@@ -366,7 +366,7 @@ func mapMessagePredicate(expr physical.Expression) (logs.RowPredicate, error) {
 			return match(e)
 
 		case types.BinaryOpMatchPattern, types.BinaryOpNotMatchPattern:
-			return nil, fmt.Errorf("unsupported binary operator (%s) for string predicate", e.Op)
+			return nil, fmt.Errorf("unsupported binary operator (%s) for log message predicate", e.Op)
 
 		case types.BinaryOpAnd:
 			leftPredicate, err := mapMessagePredicate(e.Left)
@@ -397,7 +397,7 @@ func mapMessagePredicate(expr physical.Expression) (logs.RowPredicate, error) {
 			}, nil
 
 		default:
-			return nil, fmt.Errorf("unsupported binary operator (%s) for metadata predicate, expected MATCH_STR, NOT_MATCH_STR, MATCH_RE, NOT_MATCH_RE, AND, or OR", e.Op)
+			return nil, fmt.Errorf("unsupported binary operator (%s) for log message predicate, expected MATCH_STR, NOT_MATCH_STR, MATCH_RE, NOT_MATCH_RE, AND, or OR", e.Op)
 		}
 
 	case *physical.UnaryExpr:
@@ -413,7 +413,7 @@ func mapMessagePredicate(expr physical.Expression) (logs.RowPredicate, error) {
 		}, nil
 
 	default:
-		return nil, fmt.Errorf("unsupported expression type (%T) for metadata predicate, expected BinaryExpr or UnaryExpr", expr)
+		return nil, fmt.Errorf("unsupported expression type (%T) for log message predicate, expected BinaryExpr or UnaryExpr", expr)
 	}
 }
 

--- a/pkg/engine/executor/dataobjscan_predicate.go
+++ b/pkg/engine/executor/dataobjscan_predicate.go
@@ -88,7 +88,7 @@ func mapPredicates(expr physical.Expression) (logs.RowPredicate, error) {
 					Right: right,
 				}, nil
 			default:
-				return nil, fmt.Errorf("unsupported operator for timestamp predicate: %s", e.Op)
+				return nil, fmt.Errorf("unsupported operator in predicate: %s", e.Op)
 			}
 		}
 

--- a/pkg/engine/executor/dataobjscan_predicate_test.go
+++ b/pkg/engine/executor/dataobjscan_predicate_test.go
@@ -701,7 +701,7 @@ func TestMapMessagePredicate(t *testing.T) {
 				Right: physical.NewLiteral("<_> dataobj <_>"),
 				Op:    types.BinaryOpMatchPattern,
 			},
-			expectedErr: "unsupported binary operator (MATCH_PAT) for string predicate",
+			expectedErr: "unsupported binary operator (MATCH_PAT) for log message predicate",
 		},
 		{
 			name: "not pattern match filter",
@@ -710,7 +710,7 @@ func TestMapMessagePredicate(t *testing.T) {
 				Right: physical.NewLiteral("<_> dataobj <_>"),
 				Op:    types.BinaryOpNotMatchPattern,
 			},
-			expectedErr: "unsupported binary operator (NOT_MATCH_PAT) for string predicate",
+			expectedErr: "unsupported binary operator (NOT_MATCH_PAT) for log message predicate",
 		},
 		{
 			name: "and filter",

--- a/pkg/engine/internal/types/operators.go
+++ b/pkg/engine/internal/types/operators.go
@@ -101,6 +101,10 @@ func (t BinaryOp) String() string {
 		return "MATCH_RE"
 	case BinaryOpNotMatchRe:
 		return "NOT_MATCH_RE" // convenience for NOT(MATCH_RE(...))
+	case BinaryOpMatchPattern:
+		return "MATCH_PAT"
+	case BinaryOpNotMatchPattern:
+		return "NOT_MATCH_PAT" // convenience for NOT(MATCH_PAT(...))
 	default:
 		panic(fmt.Sprintf("unknown binary operator %d", t))
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR converts line filter expressions into message predicates for the data object scan, instead of returning an error.

**Special notes for your reviewer**:

The logic is basically the same as for the metadata predicates, except for the supported operator types.