### PR TITLE
feat(disble fmt): Allow disabling logfmt parsing

### DIFF
--- a/pkg/distributor/field_detection_test.go
+++ b/pkg/distributor/field_detection_test.go
@@ -759,3 +759,138 @@ func TestGetLevelUsingJsonParser(t *testing.T) {
 		})
 	}
 }
+
+func TestDisableLogfmtAutoDetection(t *testing.T) {
+	tests := []struct {
+		name                       string
+		disableLogfmtAutoDetection bool
+		logLine                    string
+		expectedLevelDetected      bool
+		expectedGenericDetected    bool
+	}{
+		{
+			name:                       "logfmt auto detection enabled - false positive case avoided",
+			disableLogfmtAutoDetection: false,
+			logLine:                    `1.2.3.4 - - [29/Apr/2025:17:35:43 +0000] "GET /statistics/resources?timespan=6 HTTP/2.0" 200 453 "-" "Go-http-client/2.0" 190645 "example@file" "http://1.2.3.4:1234" 2ms`,
+			expectedLevelDetected:      true,
+			expectedGenericDetected:    false,
+		},
+		{
+			name:                       "logfmt auto detection disabled - prevents logfmt parsing but allows fallback",
+			disableLogfmtAutoDetection: true,
+			logLine:                    `level=info msg="test message" user=john`,
+			expectedLevelDetected:      true,
+			expectedGenericDetected:    false, // Should not detect generic fields when logfmt disabled
+		},
+		{
+			name:                       "logfmt auto detection enabled - valid logfmt",
+			disableLogfmtAutoDetection: false,
+			logLine:                    `level=info msg="test message" user=john`,
+			expectedLevelDetected:      true, // Should detect level in valid logfmt
+			expectedGenericDetected:    true, // Should detect generic fields in valid logfmt
+		},
+		{
+			name:                       "logfmt auto detection disabled - fallback to regex detection",
+			disableLogfmtAutoDetection: true,
+			logLine:                    `This is an INFO message about something`,
+			expectedLevelDetected:      true,
+			expectedGenericDetected:    false,
+		},
+		{
+			name:                       "improved regex prevents false positive logfmt detection",
+			disableLogfmtAutoDetection: false,
+			logLine:                    `key=value user=john level=debug`, // This is valid logfmt and would be parsed correctly
+			expectedLevelDetected:      true,                              // Should detect level via logfmt parsing
+			expectedGenericDetected:    true,                              // Should detect user field via logfmt parsing
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ld := newFieldDetector(
+				validationContext{
+					discoverLogLevels:          true,
+					disableLogfmtAutoDetection: tt.disableLogfmtAutoDetection,
+					logLevelFields:             []string{"level"},
+					discoverGenericFields:      map[string][]string{"user": {"user"}},
+					allowStructuredMetadata:    true,
+				},
+			)
+
+			// Test log level detection
+			entry := logproto.Entry{Line: tt.logLine}
+			_, levelDetected := ld.extractLogLevel(
+				labels.EmptyLabels(),
+				labels.EmptyLabels(),
+				entry,
+			)
+			require.Equal(t, tt.expectedLevelDetected, levelDetected, "level detection mismatch")
+
+			// Test generic field detection
+			_, genericDetected := ld.extractGenericField(
+				"user",
+				[]string{"user"},
+				labels.EmptyLabels(),
+				labels.EmptyLabels(),
+				entry,
+			)
+			require.Equal(t, tt.expectedGenericDetected, genericDetected, "generic field detection mismatch")
+		})
+	}
+}
+
+func TestImprovedLogfmtDetection(t *testing.T) {
+	tests := []struct {
+		name     string
+		logLine  string
+		expected bool
+	}{
+		{
+			name:     "valid logfmt",
+			logLine:  `level=info msg="test message" user=john`,
+			expected: true,
+		},
+		{
+			name:     "apache log - false positive with old logic",
+			logLine:  `1.2.3.4 - - [29/Apr/2025:17:35:43 +0000] "GET /statistics/resources?timespan=6 HTTP/2.0" 200 453 "-" "Go-http-client/2.0" 190645 "example@file" "http://1.2.3.4:1234" 2ms`,
+			expected: false,
+		},
+		{
+			name:     "nginx log",
+			logLine:  `127.0.0.1 - - [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.0" 200 2326`,
+			expected: false,
+		},
+		{
+			name:     "json log",
+			logLine:  `{"level": "info", "message": "test"}`,
+			expected: false,
+		},
+		{
+			name:     "logfmt with quotes",
+			logLine:  `level=info msg="quoted message with spaces" timestamp=2023-01-01`,
+			expected: true,
+		},
+		{
+			name:     "empty line",
+			logLine:  ``,
+			expected: false,
+		},
+		{
+			name:     "single key=value",
+			logLine:  `key=value`,
+			expected: true,
+		},
+		{
+			name:     "equals sign but not logfmt",
+			logLine:  `This is a message with = signs but not key=value format`,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isLogFmt([]byte(tt.logLine))
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/pkg/distributor/limits.go
+++ b/pkg/distributor/limits.go
@@ -25,6 +25,7 @@ type Limits interface {
 	DiscoverServiceName(userID string) []string
 	DiscoverGenericFields(userID string) map[string][]string
 	DiscoverLogLevels(userID string) bool
+	DisableLogfmtAutoDetection(userID string) bool
 	LogLevelFields(userID string) []string
 	LogLevelFromJSONMaxDepth(userID string) int
 

--- a/pkg/distributor/validator.go
+++ b/pkg/distributor/validator.go
@@ -48,6 +48,7 @@ type validationContext struct {
 	discoverServiceName          []string
 	discoverGenericFields        map[string][]string
 	discoverLogLevels            bool
+	disableLogfmtAutoDetection   bool
 	logLevelFields               []string
 	logLevelFromJSONMaxDepth     int
 
@@ -80,6 +81,7 @@ func (v Validator) getValidationContextForTime(now time.Time, userID string) val
 		incrementDuplicateTimestamps: v.IncrementDuplicateTimestamps(userID),
 		discoverServiceName:          v.DiscoverServiceName(userID),
 		discoverLogLevels:            v.DiscoverLogLevels(userID),
+		disableLogfmtAutoDetection:   v.DisableLogfmtAutoDetection(userID),
 		logLevelFields:               v.LogLevelFields(userID),
 		logLevelFromJSONMaxDepth:     v.LogLevelFromJSONMaxDepth(userID),
 		discoverGenericFields:        v.DiscoverGenericFields(userID),

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -258,6 +258,9 @@ type Limits struct {
 
 type FieldDetectorConfig struct {
 	Fields map[string][]string `yaml:"fields,omitempty" json:"fields,omitempty"`
+	// DisableLogfmtAutoDetection completely disables automatic logfmt parsing to prevent false positives
+	// When enabled, logs will not be automatically parsed as logfmt format during field detection
+	DisableLogfmtAutoDetection bool `yaml:"disable_logfmt_auto_detection,omitempty" json:"disable_logfmt_auto_detection,omitempty"`
 }
 
 type StreamRetention struct {
@@ -308,6 +311,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	l.LogLevelFields = []string{"level", "LEVEL", "Level", "Severity", "severity", "SEVERITY", "lvl", "LVL", "Lvl", "severity_text", "Severity_Text", "SEVERITY_TEXT"}
 	f.Var((*dskit_flagext.StringSlice)(&l.LogLevelFields), "validation.log-level-fields", "Field name to use for log levels. If not set, log level would be detected based on pre-defined labels as mentioned above.")
 	f.IntVar(&l.LogLevelFromJSONMaxDepth, "validation.log-level-from-json-max-depth", 2, "Maximum depth to search for log level fields in JSON logs. A value of 0 or less means unlimited depth. Default is 2 which searches the first 2 levels of the JSON object.")
+	f.BoolVar(&l.DiscoverGenericFields.DisableLogfmtAutoDetection, "validation.disable-logfmt-auto-detection", false, "Disable automatic logfmt parsing during field detection to prevent false positives. When enabled, logs will not be automatically parsed as logfmt format.")
 
 	_ = l.RejectOldSamplesMaxAge.Set("7d")
 	f.Var(&l.RejectOldSamplesMaxAge, "validation.reject-old-samples.max-age", "Maximum accepted sample age before rejecting.")
@@ -1041,6 +1045,10 @@ func (o *Overrides) IncrementDuplicateTimestamps(userID string) bool {
 
 func (o *Overrides) DiscoverGenericFields(userID string) map[string][]string {
 	return o.getOverridesForUser(userID).DiscoverGenericFields.Fields
+}
+
+func (o *Overrides) DisableLogfmtAutoDetection(userID string) bool {
+	return o.getOverridesForUser(userID).DiscoverGenericFields.DisableLogfmtAutoDetection
 }
 
 func (o *Overrides) DiscoverServiceName(userID string) []string {


### PR DESCRIPTION
**What this PR does / why we need it**:
Allow completely disabling logfmt parsing.

**Which issue(s) this PR fixes**:
Fixes #17507 

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [X] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
