### PR TITLE
docs: Embed LogQL video in docs

### DIFF
--- a/docs/sources/query/_index.md
+++ b/docs/sources/query/_index.md
@@ -13,6 +13,8 @@ When you want to look for certain logs stored in Loki, you specify a set of [lab
 
 There are several ways to query Loki, but all of them use LogQL, Loki's query language, under the hood.
 
+{{< youtube id="57dQwcmqkpQ" >}}
+
 Loki does not have a user interface, so most users [install Grafana](https://grafana.com/docs/grafana/latest/setup-grafana/) in order to visualize their log data. From Grafana, you can use:
 - [Grafana Logs Drilldown](https://grafana.com/docs/grafana-cloud/visualizations/simplified-exploration/logs/) to automatically visualize your log data. Logs Drilldown uses default queries to provide a set of initial visualizations that display information we think you'll find relevant to get you started viewing your logs without having to write queries.
 - [Grafana Explore](https://grafana.com/docs/grafana/latest/explore/) helps you examine your data ad-hoc or build and refine a LogQL query for inclusion within a dashboard.


### PR DESCRIPTION
**What this PR does / why we need it**: I just published a video on LogQL basics. In this PR, I embed it into the main Query page of the docs.