### PR TITLE
chore(engine): Filter by unknown column

### DIFF
--- a/pkg/compactor/deletion/job_runner_test.go
+++ b/pkg/compactor/deletion/job_runner_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/loki/pkg/push"
 	"github.com/grafana/loki/v3/pkg/chunkenc"
 	"github.com/grafana/loki/v3/pkg/compactor/client/grpc"
 	"github.com/grafana/loki/v3/pkg/compactor/retention"
@@ -20,6 +19,8 @@ import (
 	"github.com/grafana/loki/v3/pkg/logql/syntax"
 	"github.com/grafana/loki/v3/pkg/storage/chunk"
 	"github.com/grafana/loki/v3/pkg/storage/chunk/client"
+
+	"github.com/grafana/loki/pkg/push"
 )
 
 type mockChunkClient struct {

--- a/pkg/engine/executor/dataobjscan_test.go
+++ b/pkg/engine/executor/dataobjscan_test.go
@@ -20,15 +20,9 @@ import (
 )
 
 var (
-	labelMD    = buildMetadata(types.ColumnTypeLabel)
-	metadataMD = buildMetadata(types.ColumnTypeMetadata)
+	labelMD    = datatype.ColumnMetadata(types.ColumnTypeLabel, datatype.String)
+	metadataMD = datatype.ColumnMetadata(types.ColumnTypeMetadata, datatype.String)
 )
-
-func buildMetadata(ty types.ColumnType) arrow.Metadata {
-	return arrow.MetadataFrom(map[string]string{
-		types.MetadataKeyColumnType: ty.String(),
-	})
-}
 
 func Test_dataobjScan(t *testing.T) {
 	obj := buildDataobj(t, []logproto.Stream{

--- a/pkg/engine/executor/expressions.go
+++ b/pkg/engine/executor/expressions.go
@@ -8,7 +8,6 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/memory"
 
 	"github.com/grafana/loki/v3/pkg/engine/internal/datatype"
-	"github.com/grafana/loki/v3/pkg/engine/internal/errors"
 	"github.com/grafana/loki/v3/pkg/engine/internal/types"
 	"github.com/grafana/loki/v3/pkg/engine/planner/physical"
 )
@@ -46,7 +45,13 @@ func (e expressionEvaluator) eval(expr physical.Expression, input arrow.Record) 
 				}, nil
 			}
 		}
-		return nil, fmt.Errorf("unknown column %s: %w", expr.Ref.String(), errors.ErrKey)
+		// A non-existent column is represented as a string scalar with zero-byte values.
+		// TODO(chaudum): Change value to NullLiteral?
+		return &Scalar{
+			value: datatype.NewStringLiteral(string([]byte{0})), // xero-byte string does not match any "regular" string
+			rows:  input.NumRows(),
+			ct:    types.ColumnTypeGenerated,
+		}, nil
 
 	case *physical.UnaryExpr:
 		lhr, err := e.eval(expr.Left, input)

--- a/pkg/engine/executor/expressions.go
+++ b/pkg/engine/executor/expressions.go
@@ -45,10 +45,10 @@ func (e expressionEvaluator) eval(expr physical.Expression, input arrow.Record) 
 				}, nil
 			}
 		}
-		// A non-existent column is represented as a string scalar with zero-byte values.
-		// TODO(chaudum): Change value to NullLiteral?
+		// A non-existent column is represented as a string scalar with zero-value.
+		// This reflects current behaviour, where a label filter `| foo=""` would match all if `foo` is not defined.
 		return &Scalar{
-			value: datatype.NewStringLiteral(string([]byte{0})), // xero-byte string does not match any "regular" string
+			value: datatype.NewStringLiteral(""),
 			rows:  input.NumRows(),
 			ct:    types.ColumnTypeGenerated,
 		}, nil

--- a/pkg/engine/executor/filter.go
+++ b/pkg/engine/executor/filter.go
@@ -86,6 +86,7 @@ func filterBatch(batch arrow.Record, include func(int) bool) arrow.Record {
 	additions := make([]func(int), len(fields))
 
 	for i, field := range fields {
+
 		switch field.Type.ID() {
 		case arrow.BOOL:
 			builder := array.NewBooleanBuilder(mem)
@@ -124,6 +125,14 @@ func filterBatch(batch arrow.Record, include func(int) bool) arrow.Record {
 			builders[i] = builder
 			additions[i] = func(offset int) {
 				src := batch.Column(i).(*array.Float64)
+				builder.Append(src.Value(offset))
+			}
+
+		case arrow.TIMESTAMP:
+			builder := array.NewTimestampBuilder(mem, &arrow.TimestampType{Unit: arrow.Nanosecond, TimeZone: "UTC"})
+			builders[i] = builder
+			additions[i] = func(offset int) {
+				src := batch.Column(i).(*array.Timestamp)
 				builder.Append(src.Value(offset))
 			}
 

--- a/pkg/engine/executor/sortmerge_test.go
+++ b/pkg/engine/executor/sortmerge_test.go
@@ -24,7 +24,7 @@ func TestSortMerge(t *testing.T) {
 		merge := &physical.SortMerge{
 			Column: &physical.ColumnExpr{
 				Ref: types.ColumnRef{
-					Column: "invalid",
+					Column: "not_a_timestamp_column",
 					Type:   types.ColumnTypeBuiltin,
 				},
 			},
@@ -40,7 +40,7 @@ func TestSortMerge(t *testing.T) {
 		require.NoError(t, err)
 
 		err = pipeline.Read()
-		require.ErrorContains(t, err, "key error")
+		require.ErrorContains(t, err, "column is not a timestamp column")
 	})
 
 	t.Run("ascending timestamp", func(t *testing.T) {

--- a/pkg/engine/planner/logical/planner.go
+++ b/pkg/engine/planner/logical/planner.go
@@ -182,9 +182,9 @@ func lineColumnRef() *ColumnRef {
 func convertLabelMatchType(op labels.MatchType) types.BinaryOp {
 	switch op {
 	case labels.MatchEqual:
-		return types.BinaryOpMatchSubstr
+		return types.BinaryOpEq
 	case labels.MatchNotEqual:
-		return types.BinaryOpNotMatchSubstr
+		return types.BinaryOpNeq
 	case labels.MatchRegexp:
 		return types.BinaryOpMatchRe
 	case labels.MatchNotRegexp:

--- a/pkg/engine/planner/logical/planner_test.go
+++ b/pkg/engine/planner/logical/planner_test.go
@@ -98,8 +98,8 @@ func TestConvertAST_Success(t *testing.T) {
 %7 = SELECT %5 [predicate=%6]
 %8 = LT builtin.timestamp 1970-01-01T02:00:00Z
 %9 = SELECT %7 [predicate=%8]
-%10 = MATCH_STR ambiguous.foo "bar"
-%11 = MATCH_STR ambiguous.bar "baz"
+%10 = EQ ambiguous.foo "bar"
+%11 = EQ ambiguous.bar "baz"
 %12 = OR %10 %11
 %13 = SELECT %9 [predicate=%12]
 %14 = MATCH_STR builtin.message "metric.go"


### PR DESCRIPTION
**What this PR does / why we need it**:

The new engine fails to execute a query when an `arrow.Record` (batch) does not contain the column on which a label filter is used, e.g. `| foo="bar"` where `foo` is neither a label nor a structured metadata.

This change also fixed an incorrect conversion of the label filter operator `=`, which was converted to `MATCH_STR`, but requires to be `EQ`.