### PR TITLE
docs: add redirect to LogCLI topic

### DIFF
--- a/docs/sources/query/logcli/_index.md
+++ b/docs/sources/query/logcli/_index.md
@@ -4,6 +4,7 @@ menuTItle: LogCLI
 description: "LogCLI is a command-line tool for querying and exploring logs in Grafana Loki."
 aliases: 
 - ./logcli
+- ./tools/logcli/   
 weight: 600
 ---
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adding an alias to create a redirect for the LogCLI topic.