### PR TITLE
docs: Fix the error 404 URL on `operator/docs/prologue/quickstart.md`

### DIFF
--- a/operator/docs/prologue/quickstart.md
+++ b/operator/docs/prologue/quickstart.md
@@ -16,7 +16,7 @@ One page summary on how to start with Loki Operator and LokiStack.
 
 ## Requirements
 
-The easiest way to start with the Loki Operator is to use Kubernetes [kind](sigs.k8s.io/kind).
+The easiest way to start with the Loki Operator is to use Kubernetes [kind](https://github.com/kubernetes-sigs/kind).
 
 ## Deploy from Github repository
 
@@ -26,7 +26,7 @@ The simplest form to deploy the Loki Operator and a LokiStack for demo purposes 
 make quickstart
 ```
 
-If you want to test local changes from your repository fork, you need to provide an image registry organization that you own that has an image repository name `loki-operator`, e.g. `quay.io/my-company-org/loki-operator`. The command to use your custom images is:
+If you want to test local changes from your repository fork, you need to provide an image registry organization that you own that has an image repository name `loki-operator`(e.g., `quay.io/my-company-org/loki-operator`). The command to use your custom images is:
 
 ```shell
 make quickstart REGISTRY_BASE=quay.io/my-company-org


### PR DESCRIPTION
**What this PR does / why we need it**:
- Updated the hyperlink for Kubernetes `kind` to use the full URL (`https://github.com/kubernetes-sigs/kind`) for better accessibility.
- Improved the readability of instructions for testing local changes by adding clarifying punctuation and formatting adjustments.'

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
None

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
