### PR TITLE
chore: stop using gatherer as a name

### DIFF
--- a/pkg/limits/frontend/client.go
+++ b/pkg/limits/frontend/client.go
@@ -6,9 +6,8 @@ import (
 	"github.com/grafana/loki/v3/pkg/limits/proto"
 )
 
-type exceedsLimitsGatherer interface {
+type limitsClient interface {
 	// ExceedsLimits checks if the streams in the request have exceeded their
-	// per-partition limits. It returns more than one response when the
-	// requested streams are sharded over two or more limits instances.
+	// per-partition limits.
 	ExceedsLimits(context.Context, *proto.ExceedsLimitsRequest) ([]*proto.ExceedsLimitsResponse, error)
 }

--- a/pkg/limits/frontend/frontend_test.go
+++ b/pkg/limits/frontend/frontend_test.go
@@ -168,7 +168,7 @@ func TestFrontend_ExceedsLimits(t *testing.T) {
 			}, "test", readRing, log.NewNopLogger(), prometheus.NewRegistry())
 			require.NoError(t, err)
 			// Replace with our mock.
-			f.gatherer = &mockExceedsLimitsGatherer{
+			f.limitsClient = &mockLimitsClient{
 				t:                            t,
 				expectedExceedsLimitsRequest: test.exceedsLimitsRequest,
 				exceedsLimitsResponses:       test.exceedsLimitsResponses,

--- a/pkg/limits/frontend/http_test.go
+++ b/pkg/limits/frontend/http_test.go
@@ -86,7 +86,7 @@ func TestFrontend_ServeHTTP(t *testing.T) {
 				},
 			}, "test", readRing, log.NewNopLogger(), prometheus.NewRegistry())
 			require.NoError(t, err)
-			f.gatherer = &mockExceedsLimitsGatherer{
+			f.limitsClient = &mockLimitsClient{
 				t:                            t,
 				expectedExceedsLimitsRequest: test.expectedExceedsLimitsRequest,
 				exceedsLimitsResponses:       test.exceedsLimitsResponses,

--- a/pkg/limits/frontend/mock_test.go
+++ b/pkg/limits/frontend/mock_test.go
@@ -17,9 +17,9 @@ import (
 	"github.com/grafana/loki/v3/pkg/limits/proto"
 )
 
-// mockExceedsLimitsGatherer mocks an ExeceedsLimitsGatherer. It avoids having
-// to set up a mock ring to test the frontend.
-type mockExceedsLimitsGatherer struct {
+// mockLimitsClient mocks a limitsClient. It avoids having to set up a mock
+// ring to test the frontend.
+type mockLimitsClient struct {
 	t *testing.T
 
 	expectedExceedsLimitsRequest *proto.ExceedsLimitsRequest
@@ -27,15 +27,15 @@ type mockExceedsLimitsGatherer struct {
 	err                          error
 }
 
-func (m *mockExceedsLimitsGatherer) ExceedsLimits(_ context.Context, req *proto.ExceedsLimitsRequest) ([]*proto.ExceedsLimitsResponse, error) {
+func (m *mockLimitsClient) ExceedsLimits(_ context.Context, req *proto.ExceedsLimitsRequest) ([]*proto.ExceedsLimitsResponse, error) {
 	if expected := m.expectedExceedsLimitsRequest; expected != nil {
 		require.Equal(m.t, expected, req)
 	}
 	return m.exceedsLimitsResponses, m.err
 }
 
-// mockIngestLimitsClient mocks proto.IngestLimitsClient.
-type mockIngestLimitsClient struct {
+// mockLimitsProtoClient mocks proto.IngestLimitsClient.
+type mockLimitsProtoClient struct {
 	proto.IngestLimitsClient
 	t *testing.T
 
@@ -58,7 +58,7 @@ type mockIngestLimitsClient struct {
 	numExceedsLimitsRequests      int
 }
 
-func (m *mockIngestLimitsClient) GetAssignedPartitions(_ context.Context, _ *proto.GetAssignedPartitionsRequest, _ ...grpc.CallOption) (*proto.GetAssignedPartitionsResponse, error) {
+func (m *mockLimitsProtoClient) GetAssignedPartitions(_ context.Context, _ *proto.GetAssignedPartitionsRequest, _ ...grpc.CallOption) (*proto.GetAssignedPartitionsResponse, error) {
 	idx := m.numAssignedPartitionsRequests
 	// Check that we haven't received more requests than we have mocked
 	// responses.
@@ -72,7 +72,7 @@ func (m *mockIngestLimitsClient) GetAssignedPartitions(_ context.Context, _ *pro
 	return m.getAssignedPartitionsResponses[idx], nil
 }
 
-func (m *mockIngestLimitsClient) ExceedsLimits(_ context.Context, req *proto.ExceedsLimitsRequest, _ ...grpc.CallOption) (*proto.ExceedsLimitsResponse, error) {
+func (m *mockLimitsProtoClient) ExceedsLimits(_ context.Context, req *proto.ExceedsLimitsRequest, _ ...grpc.CallOption) (*proto.ExceedsLimitsResponse, error) {
 	idx := m.numExceedsLimitsRequests
 	// Check that we haven't received more requests than we have mocked
 	// responses.
@@ -89,26 +89,26 @@ func (m *mockIngestLimitsClient) ExceedsLimits(_ context.Context, req *proto.Exc
 	return m.exceedsLimitsResponses[idx], nil
 }
 
-func (m *mockIngestLimitsClient) Finished() {
+func (m *mockLimitsProtoClient) Finished() {
 	require.Equal(m.t, len(m.getAssignedPartitionsResponses), m.numAssignedPartitionsRequests)
 	require.Equal(m.t, len(m.exceedsLimitsResponses), m.numExceedsLimitsRequests)
 }
 
-func (m *mockIngestLimitsClient) Close() error {
+func (m *mockLimitsProtoClient) Close() error {
 	return nil
 }
 
-func (m *mockIngestLimitsClient) Check(_ context.Context, _ *grpc_health_v1.HealthCheckRequest, _ ...grpc.CallOption) (*grpc_health_v1.HealthCheckResponse, error) {
+func (m *mockLimitsProtoClient) Check(_ context.Context, _ *grpc_health_v1.HealthCheckRequest, _ ...grpc.CallOption) (*grpc_health_v1.HealthCheckResponse, error) {
 	return &grpc_health_v1.HealthCheckResponse{
 		Status: grpc_health_v1.HealthCheckResponse_SERVING,
 	}, nil
 }
 
-func (m *mockIngestLimitsClient) List(_ context.Context, _ *grpc_health_v1.HealthListRequest, _ ...grpc.CallOption) (*grpc_health_v1.HealthListResponse, error) {
+func (m *mockLimitsProtoClient) List(_ context.Context, _ *grpc_health_v1.HealthListRequest, _ ...grpc.CallOption) (*grpc_health_v1.HealthListResponse, error) {
 	return &grpc_health_v1.HealthListResponse{}, nil
 }
 
-func (m *mockIngestLimitsClient) Watch(_ context.Context, _ *grpc_health_v1.HealthCheckRequest, _ ...grpc.CallOption) (grpc_health_v1.Health_WatchClient, error) {
+func (m *mockLimitsProtoClient) Watch(_ context.Context, _ *grpc_health_v1.HealthCheckRequest, _ ...grpc.CallOption) (grpc_health_v1.Health_WatchClient, error) {
 	return nil, nil
 }
 
@@ -136,7 +136,7 @@ func (m *mockReadRing) GetAllHealthy(_ ring.Operation) (ring.ReplicationSet, err
 	return m.rs, nil
 }
 
-func newMockRingWithClientPool(_ *testing.T, name string, clients []*mockIngestLimitsClient, instances []ring.InstanceDesc) (ring.ReadRing, *ring_client.Pool) {
+func newMockRingWithClientPool(_ *testing.T, name string, clients []*mockLimitsProtoClient, instances []ring.InstanceDesc) (ring.ReadRing, *ring_client.Pool) {
 	// Set up the mock ring.
 	ring := &mockReadRing{
 		rs: ring.ReplicationSet{

--- a/pkg/limits/frontend/ring_test.go
+++ b/pkg/limits/frontend/ring_test.go
@@ -410,9 +410,9 @@ func TestRingGatherer_ExceedsLimits(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			// Set up the mock clients, one for each set of mock RPC responses.
-			mockClients := make([]*mockIngestLimitsClient, len(test.instances))
+			mockClients := make([]*mockLimitsProtoClient, len(test.instances))
 			for i := 0; i < len(test.instances); i++ {
-				mockClients[i] = &mockIngestLimitsClient{
+				mockClients[i] = &mockLimitsProtoClient{
 					t:                                 t,
 					getAssignedPartitionsResponses:    test.getAssignedPartitionsResponses[i],
 					getAssignedPartitionsResponseErrs: test.getAssignedPartitionsResponseErrs[i],
@@ -424,13 +424,13 @@ func TestRingGatherer_ExceedsLimits(t *testing.T) {
 			}
 			readRing, clientPool := newMockRingWithClientPool(t, "test", mockClients, test.instances)
 			cache := newNopCache[string, *proto.GetAssignedPartitionsResponse]()
-			g := newRingGatherer(readRing, clientPool, test.numPartitions, cache, log.NewNopLogger(), prometheus.NewRegistry())
+			r := newRingLimitsClient(readRing, clientPool, test.numPartitions, cache, log.NewNopLogger(), prometheus.NewRegistry())
 
 			// Set a maximum upper bound on the test execution time.
 			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 			defer cancel()
 
-			actual, err := g.ExceedsLimits(ctx, test.request)
+			actual, err := r.ExceedsLimits(ctx, test.request)
 			if test.expectedErr != "" {
 				require.EqualError(t, err, test.expectedErr)
 				require.Nil(t, actual)
@@ -577,10 +577,10 @@ func TestRingStreamUsageGatherer_GetZoneAwarePartitionConsumers(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			// Set up the mock clients, one for each pair of mock RPC responses.
-			mockClients := make([]*mockIngestLimitsClient, len(test.instances))
+			mockClients := make([]*mockLimitsProtoClient, len(test.instances))
 			for i := range test.instances {
 				// These test cases assume one request/response per instance.
-				mockClients[i] = &mockIngestLimitsClient{
+				mockClients[i] = &mockLimitsProtoClient{
 					t:                                 t,
 					getAssignedPartitionsResponses:    []*proto.GetAssignedPartitionsResponse{test.getAssignedPartitionsResponses[i]},
 					getAssignedPartitionsResponseErrs: []error{test.getAssignedPartitionsResponseErrs[i]},
@@ -590,13 +590,13 @@ func TestRingStreamUsageGatherer_GetZoneAwarePartitionConsumers(t *testing.T) {
 			// Set up the mocked ring and client pool for the tests.
 			readRing, clientPool := newMockRingWithClientPool(t, "test", mockClients, test.instances)
 			cache := newNopCache[string, *proto.GetAssignedPartitionsResponse]()
-			g := newRingGatherer(readRing, clientPool, 2, cache, log.NewNopLogger(), prometheus.NewRegistry())
+			r := newRingLimitsClient(readRing, clientPool, 2, cache, log.NewNopLogger(), prometheus.NewRegistry())
 
 			// Set a maximum upper bound on the test execution time.
 			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 			defer cancel()
 
-			result, err := g.getZoneAwarePartitionConsumers(ctx, test.instances)
+			result, err := r.getZoneAwarePartitionConsumers(ctx, test.instances)
 			require.NoError(t, err)
 			require.Equal(t, test.expected, result)
 		})
@@ -714,10 +714,10 @@ func TestRingStreamUsageGatherer_GetPartitionConsumers(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			// Set up the mock clients, one for each pair of mock RPC responses.
-			mockClients := make([]*mockIngestLimitsClient, len(test.instances))
+			mockClients := make([]*mockLimitsProtoClient, len(test.instances))
 			for i := range test.instances {
 				// These test cases assume one request/response per instance.
-				mockClients[i] = &mockIngestLimitsClient{
+				mockClients[i] = &mockLimitsProtoClient{
 					t:                                 t,
 					getAssignedPartitionsResponses:    []*proto.GetAssignedPartitionsResponse{test.getAssignedPartitionsResponses[i]},
 					getAssignedPartitionsResponseErrs: []error{test.getAssignedPartitionsResponseErrs[i]},
@@ -727,13 +727,13 @@ func TestRingStreamUsageGatherer_GetPartitionConsumers(t *testing.T) {
 			// Set up the mocked ring and client pool for the tests.
 			readRing, clientPool := newMockRingWithClientPool(t, "test", mockClients, test.instances)
 			cache := newNopCache[string, *proto.GetAssignedPartitionsResponse]()
-			g := newRingGatherer(readRing, clientPool, 1, cache, log.NewNopLogger(), prometheus.NewRegistry())
+			r := newRingLimitsClient(readRing, clientPool, 1, cache, log.NewNopLogger(), prometheus.NewRegistry())
 
 			// Set a maximum upper bound on the test execution time.
 			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 			defer cancel()
 
-			result, err := g.getPartitionConsumers(ctx, test.instances)
+			result, err := r.getPartitionConsumers(ctx, test.instances)
 			require.NoError(t, err)
 			require.Equal(t, test.expected, result)
 		})
@@ -747,7 +747,7 @@ func TestRingStreamUsageGatherer_GetPartitionConsumers_Caching(t *testing.T) {
 			0: time.Now().UnixNano(),
 		},
 	}
-	client0 := mockIngestLimitsClient{
+	client0 := mockLimitsProtoClient{
 		t: t,
 		// Expect the same request twice. The first time on the first
 		// cache miss, and the second time on the second cache miss after
@@ -761,14 +761,14 @@ func TestRingStreamUsageGatherer_GetPartitionConsumers_Caching(t *testing.T) {
 			1: time.Now().UnixNano(),
 		},
 	}
-	client1 := mockIngestLimitsClient{
+	client1 := mockLimitsProtoClient{
 		t: t,
 		// Expect the same request twice too for the same reasons.
 		getAssignedPartitionsResponses:    []*proto.GetAssignedPartitionsResponse{&req1, &req1},
 		getAssignedPartitionsResponseErrs: []error{nil, nil},
 	}
 	t.Cleanup(client1.Finished)
-	mockClients := []*mockIngestLimitsClient{&client0, &client1}
+	mockClients := []*mockLimitsProtoClient{&client0, &client1}
 	instances := []ring.InstanceDesc{{Addr: "instance-0"}, {Addr: "instance-1"}}
 
 	// Set up the mocked ring and client pool for the tests.
@@ -777,7 +777,7 @@ func TestRingStreamUsageGatherer_GetPartitionConsumers_Caching(t *testing.T) {
 	// Set the cache TTL large enough that entries cannot expire (flake)
 	// during slow test runs.
 	cache := newTTLCache[string, *proto.GetAssignedPartitionsResponse](time.Minute)
-	g := newRingGatherer(readRing, clientPool, 2, cache, log.NewNopLogger(), prometheus.NewRegistry())
+	r := newRingLimitsClient(readRing, clientPool, 2, cache, log.NewNopLogger(), prometheus.NewRegistry())
 
 	// Set a maximum upper bound on the test execution time.
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
@@ -791,14 +791,14 @@ func TestRingStreamUsageGatherer_GetPartitionConsumers_Caching(t *testing.T) {
 	}
 
 	// The first call should be a cache miss.
-	actual, err := g.getPartitionConsumers(ctx, instances)
+	actual, err := r.getPartitionConsumers(ctx, instances)
 	require.NoError(t, err)
 	require.Equal(t, expected, actual)
 	require.Equal(t, 1, client0.numAssignedPartitionsRequests)
 	require.Equal(t, 1, client1.numAssignedPartitionsRequests)
 
 	// The second call should be a cache hit.
-	actual, err = g.getPartitionConsumers(ctx, instances)
+	actual, err = r.getPartitionConsumers(ctx, instances)
 	require.NoError(t, err)
 	require.Equal(t, expected, actual)
 	require.Equal(t, 1, client0.numAssignedPartitionsRequests)
@@ -808,7 +808,7 @@ func TestRingStreamUsageGatherer_GetPartitionConsumers_Caching(t *testing.T) {
 	cache.Reset()
 
 	// The third call should be a cache miss.
-	actual, err = g.getPartitionConsumers(ctx, instances)
+	actual, err = r.getPartitionConsumers(ctx, instances)
 	require.NoError(t, err)
 	require.Equal(t, expected, actual)
 	require.Equal(t, 2, client0.numAssignedPartitionsRequests)


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit stops using gatherer as a name in the limits/frontend package. It does this for two reasons:

1. Since we refactored how limits work, we no longer do what can be called as "gathering". It is more of a fanout.

2. I've spent some time going back to more simple, obvious names, and I think client here explains enough what it does without the reader having to figure out what a "gatherer" is.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
