### PR TITLE
chore: Make oss big tent codeowners of grammar file to be notified about new grammar

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -9,7 +9,7 @@
 /.github/workflows/operator* @grafana/loki-team @periklis @xperimental @JoaoBraveCoding
 
 # Logql grammar
-# The OSS big ten team is listed as co-codeowner for grammar file. This is to receive notifications about updates, so these can be implemented in https://github.com/grafana/lezer-logql
+# The OSS big tent team is listed as co-codeowner for grammar file. This is to receive notifications about updates, so these can be implemented in https://github.com/grafana/lezer-logql
 pkg/logql/syntax/syntax.y @grafana/oss-big-tent @grafana/loki-team
 
 # Nix


### PR DESCRIPTION
This PR changes co-codowners of syntax.y file from Observability Logs to OSS Big Tent as the data source changed the ownership.
 
There is a warning, but it is okay, because we don't need write access to this repository. We just use it to be notified about changes in grammar that need to be implemented in https://github.com/grafana/lezer-logql.
<img width="1911" alt="image" src="https://github.com/user-attachments/assets/39a92fa8-4397-4110-943f-447abce1b161" />
