### PR TITLE
chore: Rename distributor lag counter to end in _total

### DIFF
--- a/pkg/loghttp/push/push.go
+++ b/pkg/loghttp/push/push.go
@@ -66,7 +66,7 @@ var (
 
 	distributorLagByUserAgent = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: constants.Loki,
-		Name:      "distributor_most_recent_lag_ms",
+		Name:      "distributor_lag_ms_total",
 		Help:      "The difference in time (in millis) between when a distributor receives a push request and the most recent log timestamp in that request",
 	}, []string{"tenant", "userAgent"})
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Grafana is confused by the naming of the existing metric, and it is not standard, as this is a counter, which traditionally ends in `_total`.  With the current name, it is often thought to be a Gauge.

This PR just renames (and condenses) the metric name to end in `_total`.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
