### PR TITLE
docs: add redirect to fix broken links

### DIFF
--- a/docs/sources/get-started/_index.md
+++ b/docs/sources/get-started/_index.md
@@ -3,6 +3,8 @@ title: Get started with Grafana Loki
 menuTitle: Get started
 weight: 200
 description: Provides an overview of the steps for implementing Grafana Loki to collect and view logs.
+aliases:
+  - /getting-started/
 ---
 
 # Get started with Grafana Loki


### PR DESCRIPTION
**What this PR does / why we need it**:
Adding an alias to the Get Started topic to generate a redirect for Grafana topics that point to Getting Started.  Should fix at least five broken links in the Grafana docs, according to the broken links dashboard.