### PR TITLE
chore: make the default value (iota) an unknown

### DIFF
--- a/pkg/limits/partition_manager.go
+++ b/pkg/limits/partition_manager.go
@@ -24,7 +24,9 @@ var (
 type partitionState int
 
 const (
-	partitionPending partitionState = iota
+	// partitionUnknown is the zero value.
+	paritionUnknown partitionState = iota
+	partitionPending
 	partitionReplaying
 	partitionReady
 )

--- a/pkg/limits/reason.go
+++ b/pkg/limits/reason.go
@@ -3,10 +3,11 @@ package limits
 type Reason int
 
 const (
+	// ReasonUnknown is the zero value.
+	ReasonUnknown Reason = iota
 	// ReasonFailed is the reason returned when a stream cannot be checked
 	// against limits due to an error.
-	ReasonFailed Reason = iota + 1
-
+	ReasonFailed
 	// ReasonMaxStreams is returned when a stream cannot be accepted because
 	// the tenant has either reached or exceeded their maximum stream limit.
 	ReasonMaxStreams


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request prevents future bugs where the default value of an enum (read: uninitialized) is a valid enum value.

**Which issue(s) this PR fixes**:

Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
