### PR TITLE
chore: move enable_multi_variant_queries to the correct config section

### DIFF
--- a/cmd/loki/loki-local-config.yaml
+++ b/cmd/loki/loki-local-config.yaml
@@ -27,6 +27,7 @@ query_range:
 
 limits_config:
   metric_aggregation_enabled: true
+  enable_multi_variant_queries: true
 
 schema_config:
   configs:
@@ -48,10 +49,6 @@ ruler:
 
 frontend:
   encoding: protobuf
-
-querier:
-  engine:
-    enable_multi_variant_queries: true
 
 
 # By default, Loki will send anonymous, but uniquely-identifiable usage and configuration


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes the default local config loki uses. This PR https://github.com/grafana/loki/pull/16718 moved `enable_multi_variant_queries` from a global querier config to the limits_config section but the default local config is still using the old structure. 



**Special notes for your reviewer**:

This is my first PR 🎉 


**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
