### PR TITLE
feat(compactor HS): add support for worker for processing of jobs from the compactor's job queue

### DIFF
--- a/pkg/compactor/jobqueue/queue_test.go
+++ b/pkg/compactor/jobqueue/queue_test.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/test/bufconn"
@@ -18,10 +18,19 @@ import (
 
 // mockBuilder implements the Builder interface for testing
 type mockBuilder struct {
-	jobsToBuild []*compactor_grpc.Job
+	jobsToBuild   []*compactor_grpc.Job
+	jobsSentCount int
+	jobsSucceeded atomic.Int32
+	jobsFailed    atomic.Int32
 }
 
-func (m *mockBuilder) OnJobResponse(_ *compactor_grpc.JobResult) {}
+func (m *mockBuilder) OnJobResponse(res *compactor_grpc.JobResult) {
+	if res.Error != "" {
+		m.jobsFailed.Inc()
+	} else {
+		m.jobsSucceeded.Inc()
+	}
+}
 
 func (m *mockBuilder) BuildJobs(ctx context.Context, jobsChan chan<- *compactor_grpc.Job) {
 	for _, job := range m.jobsToBuild {
@@ -29,6 +38,7 @@ func (m *mockBuilder) BuildJobs(ctx context.Context, jobsChan chan<- *compactor_
 		case <-ctx.Done():
 			return
 		case jobsChan <- job:
+			m.jobsSentCount++
 		}
 	}
 
@@ -36,7 +46,7 @@ func (m *mockBuilder) BuildJobs(ctx context.Context, jobsChan chan<- *compactor_
 	<-ctx.Done()
 }
 
-func server(t *testing.T, q *Queue) (*grpc.ClientConn, func()) {
+func setupGRPC(t *testing.T, q *Queue) (*grpc.ClientConn, func()) {
 	buffer := 101024 * 1024
 	lis := bufconn.Listen(buffer)
 
@@ -65,7 +75,7 @@ func server(t *testing.T, q *Queue) (*grpc.ClientConn, func()) {
 }
 
 func TestQueue_RegisterBuilder(t *testing.T) {
-	q := New()
+	q := NewQueue()
 	builder := &mockBuilder{}
 
 	// Register builder successfully
@@ -78,9 +88,9 @@ func TestQueue_RegisterBuilder(t *testing.T) {
 }
 
 func TestQueue_Loop(t *testing.T) {
-	q := New()
+	q := NewQueue()
 
-	conn, closer := server(t, q)
+	conn, closer := setupGRPC(t, q)
 	defer closer()
 
 	// Create a couple of test jobs
@@ -115,7 +125,7 @@ func TestQueue_Loop(t *testing.T) {
 	q.processingJobsMtx.RLock()
 	require.Equal(t, 1, len(q.processingJobs))
 	require.Equal(t, jobs[0], q.processingJobs[jobs[0].Id].job)
-	require.Equal(t, 0, q.processingJobs[jobs[0].Id].retryCount)
+	require.Equal(t, 2, q.processingJobs[jobs[0].Id].attemptsLeft)
 	q.processingJobsMtx.RUnlock()
 
 	// another Recv call on client1Stream without calling the Send call should get blocked
@@ -140,9 +150,9 @@ func TestQueue_Loop(t *testing.T) {
 	q.processingJobsMtx.RLock()
 	require.Equal(t, 2, len(q.processingJobs))
 	require.Equal(t, jobs[0], q.processingJobs[jobs[0].Id].job)
-	require.Equal(t, 0, q.processingJobs[jobs[0].Id].retryCount)
+	require.Equal(t, 2, q.processingJobs[jobs[0].Id].attemptsLeft)
 	require.Equal(t, jobs[1], q.processingJobs[jobs[1].Id].job)
-	require.Equal(t, 0, q.processingJobs[jobs[1].Id].retryCount)
+	require.Equal(t, 2, q.processingJobs[jobs[1].Id].attemptsLeft)
 	q.processingJobsMtx.RUnlock()
 
 	// sending a response on client1Stream should get it unblocked to Recv the next job
@@ -159,15 +169,14 @@ func TestQueue_Loop(t *testing.T) {
 	q.processingJobsMtx.RLock()
 	require.Equal(t, 2, len(q.processingJobs))
 	require.Equal(t, jobs[1], q.processingJobs[jobs[1].Id].job)
-	require.Equal(t, 0, q.processingJobs[jobs[1].Id].retryCount)
+	require.Equal(t, 2, q.processingJobs[jobs[1].Id].attemptsLeft)
 	require.Equal(t, jobs[2], q.processingJobs[jobs[2].Id].job)
-	require.Equal(t, 0, q.processingJobs[jobs[2].Id].retryCount)
+	require.Equal(t, 2, q.processingJobs[jobs[2].Id].attemptsLeft)
 	q.processingJobsMtx.RUnlock()
 }
 
 func TestQueue_ReportJobResult(t *testing.T) {
-	ctx := context.Background()
-	q := New()
+	q := newQueue(time.Second)
 	require.NoError(t, q.RegisterBuilder(compactor_grpc.JOB_TYPE_DELETION, &mockBuilder{}))
 
 	// Create a test job
@@ -179,14 +188,14 @@ func TestQueue_ReportJobResult(t *testing.T) {
 	// Add job to processing jobs
 	q.processingJobsMtx.Lock()
 	q.processingJobs[job.Id] = &processingJob{
-		job:        job,
-		dequeued:   time.Now(),
-		retryCount: 0,
+		job:          job,
+		dequeued:     time.Now(),
+		attemptsLeft: 2,
 	}
 	q.processingJobsMtx.Unlock()
 
 	// Test successful response
-	err := q.reportJobResult(ctx, &compactor_grpc.JobResult{
+	err := q.reportJobResult(&compactor_grpc.JobResult{
 		JobId:   job.Id,
 		JobType: job.Type,
 	})
@@ -202,25 +211,18 @@ func TestQueue_ReportJobResult(t *testing.T) {
 	job.Id = "retry-job"
 	q.processingJobsMtx.Lock()
 	q.processingJobs[job.Id] = &processingJob{
-		job:        job,
-		dequeued:   time.Now(),
-		retryCount: 0,
+		job:          job,
+		dequeued:     time.Now(),
+		attemptsLeft: 2,
 	}
 	q.processingJobsMtx.Unlock()
 
-	var wg sync.WaitGroup
-	wg.Add(1)
-
-	go func() {
-		defer wg.Done()
-
-		err := q.reportJobResult(ctx, &compactor_grpc.JobResult{
-			JobId:   job.Id,
-			JobType: job.Type,
-			Error:   "test error",
-		})
-		require.NoError(t, err)
-	}()
+	err = q.reportJobResult(&compactor_grpc.JobResult{
+		JobId:   job.Id,
+		JobType: job.Type,
+		Error:   "test error",
+	})
+	require.NoError(t, err)
 
 	// Verify job is requeued with timeout
 	select {
@@ -230,14 +232,12 @@ func TestQueue_ReportJobResult(t *testing.T) {
 		t.Fatal("job was not requeued")
 	}
 
-	wg.Wait()
-
 	// Verify retry count is incremented
 	q.processingJobsMtx.RLock()
 	pj, exists := q.processingJobs[job.Id]
 	q.processingJobsMtx.RUnlock()
 	require.True(t, exists)
-	require.Equal(t, 1, pj.retryCount)
+	require.Equal(t, 1, pj.attemptsLeft)
 }
 
 func TestQueue_JobTimeout(t *testing.T) {
@@ -253,9 +253,9 @@ func TestQueue_JobTimeout(t *testing.T) {
 	// Add job to processing jobs with old dequeued time
 	q.processingJobsMtx.Lock()
 	q.processingJobs[job.Id] = &processingJob{
-		job:        job,
-		dequeued:   time.Now().Add(-200 * time.Millisecond),
-		retryCount: 0,
+		job:          job,
+		dequeued:     time.Now().Add(-200 * time.Millisecond),
+		attemptsLeft: 2,
 	}
 	q.processingJobsMtx.Unlock()
 
@@ -272,13 +272,14 @@ func TestQueue_JobTimeout(t *testing.T) {
 
 	// Verify job is removed from processing jobs
 	q.processingJobsMtx.RLock()
-	_, exists := q.processingJobs[job.Id]
+	pj, exists := q.processingJobs[job.Id]
 	q.processingJobsMtx.RUnlock()
-	require.False(t, exists)
+	require.True(t, exists)
+	require.Equal(t, 1, pj.attemptsLeft)
 }
 
 func TestQueue_Close(t *testing.T) {
-	q := New()
+	q := NewQueue()
 
 	// Close the queue
 	q.Close()

--- a/pkg/compactor/jobqueue/worker.go
+++ b/pkg/compactor/jobqueue/worker.go
@@ -1,0 +1,164 @@
+package jobqueue
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/backoff"
+	"github.com/pkg/errors"
+	"go.uber.org/atomic"
+
+	"github.com/grafana/loki/v3/pkg/compactor/client/grpc"
+	util_log "github.com/grafana/loki/v3/pkg/util/log"
+)
+
+var (
+	connBackoffConfig = backoff.Config{
+		MinBackoff: 500 * time.Millisecond,
+		MaxBackoff: 5 * time.Second,
+	}
+)
+
+type CompactorClient interface {
+	JobQueueClient() grpc.JobQueueClient
+}
+
+type JobRunner interface {
+	Run(ctx context.Context, job *grpc.Job) ([]byte, error)
+}
+
+type WorkerManager struct {
+	grpcClient CompactorClient
+	jobRunners map[grpc.JobType]JobRunner
+	cancel     context.CancelFunc
+	wg         sync.WaitGroup
+}
+
+func NewWorkerManager(grpcClient CompactorClient) *WorkerManager {
+	return &WorkerManager{
+		grpcClient: grpcClient,
+		jobRunners: make(map[grpc.JobType]JobRunner),
+	}
+}
+
+func (w *WorkerManager) RegisterJobRunner(jobType grpc.JobType, jobRunner JobRunner) error {
+	if _, exists := w.jobRunners[jobType]; exists {
+		return ErrJobTypeAlreadyRegistered
+	}
+
+	w.jobRunners[jobType] = jobRunner
+	return nil
+}
+
+func (w *WorkerManager) Start(ctx context.Context, numWorkers int) {
+	ctx, cancel := context.WithCancel(ctx)
+	w.cancel = cancel
+
+	for i := 0; i < numWorkers; i++ {
+		w.wg.Add(1)
+		go func() {
+			defer w.wg.Done()
+			newWorker(w.grpcClient, w.jobRunners).start(ctx)
+		}()
+	}
+}
+
+func (w *WorkerManager) Stop() {
+	if w.cancel != nil {
+		w.cancel()
+	}
+	w.wg.Wait()
+}
+
+type worker struct {
+	grpcClient CompactorClient
+	jobRunners map[grpc.JobType]JobRunner
+	running    atomic.Bool
+}
+
+func newWorker(grpcClient CompactorClient, jobRunners map[grpc.JobType]JobRunner) *worker {
+	return &worker{
+		grpcClient: grpcClient,
+		jobRunners: jobRunners,
+	}
+}
+
+func (w *worker) start(ctx context.Context) {
+	w.running.Store(true)
+	defer w.running.Store(false)
+
+	client := w.grpcClient.JobQueueClient()
+
+	backoff := backoff.New(ctx, connBackoffConfig)
+	for backoff.Ongoing() {
+		c, err := client.Loop(ctx)
+		if err != nil {
+			level.Warn(util_log.Logger).Log("msg", "error contacting compactor", "err", err)
+			backoff.Wait()
+			continue
+		}
+
+		if err := w.process(c); err != nil {
+			level.Error(util_log.Logger).Log("msg", "error running jobs", "err", err)
+			backoff.Wait()
+			continue
+		}
+
+		backoff.Reset()
+	}
+}
+
+// process pull jobs from the established stream, processes them and sends back the job result to the stream.
+func (w *worker) process(c grpc.JobQueue_LoopClient) error {
+	// Build a child context so we can cancel the job when the stream is closed.
+	ctx, cancel := context.WithCancelCause(c.Context())
+	defer cancel(errors.New("job queue stream closed"))
+
+	for {
+		job, err := c.Recv()
+		if err != nil {
+			return err
+		}
+
+		// Execute the job on a "background" goroutine, so we go back to
+		// blocking on c.Recv(). This allows us to detect the stream closing
+		// and cancel the job execution. We don't process jobs in parallel
+		// here, as we're running in a lock-step with the server - each Recv is
+		// paired with a Send.
+		go func() {
+			jobResult := &grpc.JobResult{
+				JobId:   job.Id,
+				JobType: job.Type,
+			}
+
+			jobRunner, ok := w.jobRunners[job.Type]
+			if !ok {
+				level.Error(util_log.Logger).Log("msg", "job runner for job type not registered", "jobType", job.Type)
+				jobResult.Error = fmt.Sprintf("unknown job type %s", job.Type)
+				if err := c.Send(jobResult); err != nil {
+					level.Error(util_log.Logger).Log("msg", "error sending job result", "err", err)
+				}
+				return
+			}
+
+			jobResponse, err := jobRunner.Run(ctx, job)
+			if err != nil {
+				level.Error(util_log.Logger).Log("msg", "error running job", "err", err)
+				jobResult.Error = err.Error()
+				if err := c.Send(jobResult); err != nil {
+					level.Error(util_log.Logger).Log("msg", "error sending job result", "err", err)
+				}
+				return
+			}
+
+			jobResult.Result = jobResponse
+			if err := c.Send(jobResult); err != nil {
+				level.Error(util_log.Logger).Log("msg", "error sending job result", "err", err)
+				return
+			}
+		}()
+	}
+}

--- a/pkg/compactor/jobqueue/worker_test.go
+++ b/pkg/compactor/jobqueue/worker_test.go
@@ -1,0 +1,172 @@
+package jobqueue
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+
+	compactor_grpc "github.com/grafana/loki/v3/pkg/compactor/client/grpc"
+)
+
+type mockCompactorClient struct {
+	conn *grpc.ClientConn
+}
+
+func (m mockCompactorClient) JobQueueClient() compactor_grpc.JobQueueClient {
+	return compactor_grpc.NewJobQueueClient(m.conn)
+}
+
+type mockJobRunner struct {
+	mock.Mock
+}
+
+func (m *mockJobRunner) Run(ctx context.Context, job *compactor_grpc.Job) ([]byte, error) {
+	args := m.Called(ctx, job)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]byte), args.Error(1)
+}
+
+func TestWorkerManager(t *testing.T) {
+	// create a new job queue
+	q := NewQueue()
+	conn, closer := setupGRPC(t, q)
+	defer closer()
+
+	// create a mock job builder which would build only a single job
+	mockJobBuilder := &mockBuilder{
+		jobsToBuild: []*compactor_grpc.Job{
+			{
+				Id:   "1",
+				Type: compactor_grpc.JOB_TYPE_DELETION,
+			},
+		},
+	}
+
+	// register the job builder with the queue and start the queue
+	require.NoError(t, q.RegisterBuilder(compactor_grpc.JOB_TYPE_DELETION, mockJobBuilder))
+	require.NoError(t, q.Start(context.Background()))
+	require.Equal(t, 0, mockJobBuilder.jobsSentCount)
+
+	jobRunner := &mockJobRunner{}
+	jobRunner.On("Run", mock.Anything, mock.Anything).Return(nil, nil)
+
+	// create a new worker manager and register the mock job runner
+	wm := NewWorkerManager(mockCompactorClient{conn})
+	require.NoError(t, wm.RegisterJobRunner(compactor_grpc.JOB_TYPE_DELETION, jobRunner))
+
+	// trying to register job runner for same job type should throw an error
+	require.Error(t, wm.RegisterJobRunner(compactor_grpc.JOB_TYPE_DELETION, &mockJobRunner{}))
+
+	// start two workers so only one of them would get a job
+	wm.Start(context.Background(), 2)
+
+	// verify that the job builder got to send the job and that it got processed successfully
+	require.Eventually(t, func() bool {
+		if mockJobBuilder.jobsSentCount != 1 {
+			return false
+		}
+		if mockJobBuilder.jobsSucceeded.Load() != 1 {
+			return false
+		}
+		return true
+	}, time.Second, time.Millisecond*100)
+
+	// stop the worker manager
+	wm.Stop()
+}
+
+func TestWorker_ProcessJob(t *testing.T) {
+	// create a new job queue
+	q := newQueue(50 * time.Millisecond)
+	conn, closer := setupGRPC(t, q)
+	defer closer()
+
+	// create a mock job builder which would build a couple of jobs
+	mockJobBuilder := &mockBuilder{
+		jobsToBuild: []*compactor_grpc.Job{
+			{
+				Id:   "1",
+				Type: compactor_grpc.JOB_TYPE_DELETION,
+			},
+			{
+				Id:   "2",
+				Type: compactor_grpc.JOB_TYPE_DELETION + 1, // an unknown job should not break anything in processing further valid jobs
+			},
+			{
+				Id:   "3",
+				Type: compactor_grpc.JOB_TYPE_DELETION,
+			},
+		},
+	}
+
+	jobRunner := &mockJobRunner{}
+	jobRunner.On("Run", mock.Anything, mock.Anything).Return(nil, nil).Once()
+	jobRunner.On("Run", mock.Anything, mock.Anything).Return(nil, fmt.Errorf("fail")).Times(3)
+
+	// register the job builder with the queue and start the queue
+	require.NoError(t, q.RegisterBuilder(compactor_grpc.JOB_TYPE_DELETION, mockJobBuilder))
+	require.NoError(t, q.Start(context.Background()))
+	require.Equal(t, 0, mockJobBuilder.jobsSentCount)
+
+	// build a worker and start it
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go newWorker(mockCompactorClient{conn: conn}, map[compactor_grpc.JobType]JobRunner{
+		compactor_grpc.JOB_TYPE_DELETION: jobRunner,
+	}).start(ctx)
+
+	// verify that the job builder got to send all 3 jobs and that both the valid jobs got processed
+	require.Eventually(t, func() bool {
+		if mockJobBuilder.jobsSentCount != 3 {
+			return false
+		}
+		if mockJobBuilder.jobsSucceeded.Load() != 1 {
+			return false
+		}
+		if mockJobBuilder.jobsFailed.Load() != 1 {
+			return false
+		}
+		return true
+	}, 2*time.Second, time.Millisecond*50)
+
+	jobRunner.AssertExpectations(t)
+}
+
+func TestWorker_StreamClosure(t *testing.T) {
+	// build a queue
+	q := NewQueue()
+	conn, closer := setupGRPC(t, q)
+	defer closer()
+
+	// register a builder and start the queue
+	require.NoError(t, q.RegisterBuilder(compactor_grpc.JOB_TYPE_DELETION, &mockBuilder{}))
+	require.NoError(t, q.Start(context.Background()))
+
+	// build a worker
+	worker := newWorker(mockCompactorClient{conn: conn}, map[compactor_grpc.JobType]JobRunner{
+		compactor_grpc.JOB_TYPE_DELETION: &mockJobRunner{},
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// start the worker and ensure that it is running
+	go worker.start(ctx)
+	require.Eventually(t, func() bool {
+		return worker.running.Load()
+	}, time.Second, time.Millisecond*100)
+
+	// close the queue so that it closes the stream
+	q.Close()
+
+	// sleep for a while and ensure that the worker is still running
+	time.Sleep(100 * time.Millisecond)
+	require.True(t, worker.running.Load())
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
It adds two new components related to making the compactor horizontally scalable:
1. Worker: It gets the job from the job queue over GRPC, executes the job, and sends the job response to the job queue. It keeps going while it can get jobs from the GRPC connection. If the stream gets disconnected, the worker tries to re-establish it to work on the jobs from the queue.
2. Worker Manager: It creates a specified number of workers and implements a `Stop` method to stop all the workers at once.

I have done some minor changes to the existing `Queue` code, like:
1. Retry the failed jobs in the goroutine we run for retrying the timed-out jobs.
2. Removed unused `Stop` function.
3. Close the `q.stop` channel before closing `q.queue` so that builders stop first, and they avoid writing to the queue, which otherwise would lead to panics.

**Checklist**
- [X] Tests updated
