### PR TITLE
docs: Add GCP to links, 3.4 branch

### DIFF
--- a/docs/sources/setup/install/helm/_index.md
+++ b/docs/sources/setup/install/helm/_index.md
@@ -38,6 +38,7 @@ The following guides provide step-by-step instructions for deploying Loki on clo
 
 - [Amazon EKS](https://grafana.com/docs/loki/<LOKI_VERSION>/setup/install/helm/deployment-guides/aws/)
 - [Azure AKS](https://grafana.com/docs/loki/<LOKI_VERSION>/setup/install/helm/deployment-guides/azure/)
+- [Google GKE](https://grafana.com/docs/loki/<LOKI_VERSION>/setup/install/helm/deployment-guides/gcp/)
 
 ## Reference
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Manual backport to add https://github.com/grafana/loki/pull/18160 to 3.4 branch

