### PR TITLE
chore(bench_test): Correctly integrate new query engine + misc changes

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -88,6 +88,7 @@ func (e *QueryEngine) Execute(ctx context.Context, params logql.Params) (logqlmo
 	e.metrics.logicalPlanning.Observe(time.Since(t).Seconds())
 	durLogicalPlanning := time.Since(t)
 
+	statsCtx, ctx := stats.NewContext(ctx)
 	t = time.Now() // start stopwatch for physical planning
 	executionContext := physical.NewContext(ctx, e.metastore, params.Start(), params.End())
 	planner := physical.NewPlanner(executionContext)
@@ -121,7 +122,6 @@ func (e *QueryEngine) Execute(ctx context.Context, params logql.Params) (logqlmo
 		return builder.empty(), err
 	}
 
-	statsCtx := stats.FromContext(ctx)
 	builder.setStats(statsCtx.Result(time.Since(start), 0, builder.len()))
 
 	e.metrics.subqueries.WithLabelValues(statusSuccess).Inc()


### PR DESCRIPTION
**What this PR does / why we need it**:

- For `StoreDataObjV2Engine` we are additionally implementing [Querier interface](https://github.com/grafana/loki/blob/665a5a05fd45594640b5b56050127913970a676b/pkg/logql/engine.go#L142) in bench test and passing that to the `logql.Engine` for comparing results, but the [new engine](https://github.com/grafana/loki/blob/main/pkg/engine/engine.go) can directly Exec queries and returns results in loki response format. This PR updates bench test to use the new engine directly.
- Consistent naming for all tests `query=%s/kind=%s`
- Adds new base tests for `count_over_time`
- Inits stats context correctly in new engine

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
