### PR TITLE
fix: Implement package to create custom WAL and use it to fake a torn last

### DIFF
--- a/docs/wal-segment-format.md
+++ b/docs/wal-segment-format.md
@@ -1,0 +1,131 @@
+# WAL Segment Format Documentation
+
+## Overview
+
+A WAL (Write-Ahead Log) segment is a file containing a sequence of records. Each segment is divided into 32KB pages, and records can span multiple pages but never cross segment boundaries. This document describes the binary format of WAL segment files as used in Prometheus TSDB.
+
+## Segment Structure
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                        WAL SEGMENT FILE                         │
+├─────────────────────────────────────────────────────────────────┤
+│                         PAGE 0 (32KB)                          │
+├─────────────────────────────────────────────────────────────────┤
+│  RECORD 1  │  RECORD 2  │  RECORD 3  │     ...     │  PADDING  │
+├─────────────────────────────────────────────────────────────────┤
+│                         PAGE 1 (32KB)                          │
+├─────────────────────────────────────────────────────────────────┤
+│  RECORD N  │  RECORD N+1 │     ...     │           │  PADDING  │
+├─────────────────────────────────────────────────────────────────┤
+│                           ...                                   │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Record Structure
+
+Every record in a WAL segment follows this structure:
+
+```
+┌─────────────┬─────────────────────────────────────────────────────┐
+│   HEADER    │                    DATA                             │
+│   (7 bytes) │                (variable length)                    │
+└─────────────┴─────────────────────────────────────────────────────┘
+```
+
+### Header Format (7 bytes total)
+
+```
+ Byte 0      Bytes 1-2        Bytes 3-6
+┌─────────┬─────────────────┬─────────────────────────────────────┐
+│  TYPE   │      LENGTH     │               CRC32                 │
+│(1 byte) │   (2 bytes)     │            (4 bytes)                │
+└─────────┴─────────────────┴─────────────────────────────────────┘
+```
+
+#### Byte 0 - Record Type and Compression Flags
+
+```
+Bit:  7   6   5   4   3   2   1   0
+     ┌───┬───┬───┬───┬───┬───┬───┬───┐
+     │ - │ - │ - │ Z │ S │ T │ T │ T │
+     └───┴───┴───┴───┴───┴───┴───┴───┘
+      │   │   │   │   │   └───┴───┴───┘
+      │   │   │   │   │       └─ Record Type (3 bits)
+      │   │   │   │   └─ Snappy Compression Flag (1 bit)
+      │   │   │   └─ Zstd Compression Flag (1 bit)  
+      └───┴───┴─ Unallocated (3 bits)
+```
+
+**Record Types:**
+- `0` (recPageTerm): Rest of page is empty
+- `1` (recFull): Complete record fits in current page
+- `2` (recFirst): First fragment of a record spanning multiple pages
+- `3` (recMiddle): Middle fragment of a record spanning multiple pages
+- `4` (recLast): Final fragment of a record spanning multiple pages
+
+**Compression Flags:**
+- Bit 3 (snappyMask = 0x08): Set if data is Snappy compressed
+- Bit 4 (zstdMask = 0x10): Set if data is Zstd compressed
+
+#### Bytes 1-2 - Data Length
+Big-endian 16-bit unsigned integer representing the length of the data portion in bytes.
+
+#### Bytes 3-6 - CRC32 Checksum
+Big-endian 32-bit CRC32 checksum (Castagnoli polynomial) of the data portion only.
+
+## Record Fragmentation
+
+When a record is larger than the remaining space in a page, it gets fragmented:
+
+```
+Page N                           Page N+1
+┌─────────────────────────────┐  ┌─────────────────────────────────┐
+│ [HEADER] [DATA PART 1]      │  │ [HEADER] [DATA PART 2] [HEADER] │
+│ Type: recFirst              │  │ Type: recLast      Type: recFull│
+│ Length: 1024                │  │ Length: 512        Length: 256  │
+│ CRC: 0x12345678             │  │ CRC: 0x87654321    CRC: 0xABCD  │
+└─────────────────────────────┘  └─────────────────────────────────┘
+```
+
+## Page Boundaries
+
+- Each page is exactly 32KB (32,768 bytes)
+- Records never span across segment boundaries
+- Unused space at the end of pages is zero-padded
+- A `recPageTerm` record type indicates the rest of the page is empty
+
+## Data Format
+
+The data portion contains the actual record payload. The format depends on the application using the WAL:
+
+- **Series Records**: Encoded series labels and references
+- **Sample Records**: Encoded time series samples  
+- **Tombstone Records**: Encoded deletion markers
+- **Custom Records**: Application-specific data
+
+## Compression
+
+When compression is enabled:
+1. The data is compressed before writing
+2. The appropriate compression flag is set in the header
+3. The CRC is calculated on the compressed data
+4. The length field reflects the compressed data size
+
+## Error Handling
+
+- **Corruption Detection**: CRC32 mismatch indicates data corruption
+- **Torn Writes**: Incomplete records at segment end are detected during replay
+- **Invalid Types**: Unknown record types should be treated as corruption
+
+## Implementation Notes
+
+- All multi-byte integers are stored in big-endian format
+- CRC32 uses the Castagnoli polynomial (0x82F63B78)
+- Segments should be read sequentially from start to end
+- Writers must ensure atomic page writes to prevent corruption
+
+## References
+
+- [Prometheus TSDB WAL and Checkpoint](https://ganeshvernekar.com/blog/prometheus-tsdb-wal-and-checkpoint/)
+- [Prometheus Storage Documentation](https://prometheus.io/docs/prometheus/latest/storage/) 

--- a/pkg/tsdbwalsegment/README.md
+++ b/pkg/tsdbwalsegment/README.md
@@ -1,0 +1,183 @@
+# WAL Segment Package
+
+This package provides functionality to read and write individual WAL (Write-Ahead Log) segment files according to the [Prometheus TSDB WAL format specification](./wal-segment-format.md).
+
+This package is mainly used to create custom WAL segments for test purposes (i.e., create corrupted segments).
+
+## Overview
+
+The package supports:
+- Reading and writing WAL segment files
+- Automatic record fragmentation across 32KB pages
+- Compression support (Snappy and Zstd)
+- Fine-grained control over record types for testing
+
+## Usage
+
+### Basic Writing with WriteRecord
+
+The `WriteRecord` method automatically handles record fragmentation and determines the appropriate record types:
+
+```go
+import "github.com/grafana/loki/v3/pkg/tsdbwalsegment"
+
+// Create a new segment writer
+writer, err := tsdbwalsegment.NewSegmentWriter("segment_000001")
+if err != nil {
+    log.Fatal(err)
+}
+defer writer.Close()
+
+// Write raw data with automatic fragmentation
+data := []byte("Hello, WAL!")
+err = writer.WriteRecord(data, false, false) // no compression
+if err != nil {
+    log.Fatal(err)
+}
+
+// Write compressed data
+compressedData := []byte("This will be compressed")
+err = writer.WriteRecord(compressedData, true, false) // Snappy compression
+if err != nil {
+    log.Fatal(err)
+}
+
+// Write with Zstd compression
+zstdData := []byte("This will be Zstd compressed")
+err = writer.WriteRecord(zstdData, false, true) // Zstd compression
+if err != nil {
+    log.Fatal(err)
+}
+```
+
+### Precise Control with WriteFullRecord
+
+The `WriteFullRecord` method gives you complete control over the record type and compression flags. This is particularly useful for testing scenarios where you need specific record fragmentation:
+
+```go
+// Create a record with specific type and compression settings
+record := &tsdbwalsegment.Record{
+    Type:         tsdbwalsegment.RecordFirst, // Exact type will be preserved
+    Data:         []byte("First part of a fragmented record"),
+    IsCompressed: true,
+    IsSnappy:     true,
+    IsZstd:       false,
+}
+
+// Write the record directly with the exact type specified
+err := writer.WriteFullRecord(record)
+if err != nil {
+    log.Fatal(err)
+}
+
+// Write the corresponding last fragment
+lastRecord := &tsdbwalsegment.Record{
+    Type:         tsdbwalsegment.RecordLast,
+    Data:         []byte(" and this completes the record."),
+    IsCompressed: true,
+    IsSnappy:     true,
+    IsZstd:       false,
+}
+
+err = writer.WriteFullRecord(lastRecord)
+if err != nil {
+    log.Fatal(err)
+}
+```
+
+### Reading Records
+
+```go
+// Open a segment for reading
+reader, err := tsdbwalsegment.NewSegmentReader("segment_000001")
+if err != nil {
+    log.Fatal(err)
+}
+defer reader.Close()
+
+// Read all records (fragmented records are automatically assembled)
+for reader.Next() {
+    record := reader.Record()
+    fmt.Printf("Type: %s, TSDB Type: %s, Length: %d, Data: %s\n", 
+        record.Type.String(), 
+        record.TSDBType.String(),
+        record.Length, 
+        string(record.Data))
+}
+
+if err := reader.Err(); err != nil {
+    log.Fatal(err)
+}
+```
+### Header Manipulation
+
+```go
+// Parse a header byte
+recordType, isSnappy, isZstd := tsdbwalsegment.ParseHeader(0x09)
+fmt.Printf("Type: %s, Snappy: %t, Zstd: %t\n", recordType.String(), isSnappy, isZstd)
+
+// Create a header byte
+headerByte := tsdbwalsegment.EncodeHeader(tsdbwalsegment.RecordFull, true, false)
+fmt.Printf("Header byte: 0x%02X\n", headerByte)
+```
+
+
+## Key Differences Between Methods
+
+### WriteRecord vs WriteFullRecord
+
+- **WriteRecord**: Automatically determines record types based on data size and page boundaries. Best for normal usage.
+- **WriteFullRecord**: Uses the exact `Type` field from the Record struct. Essential for testing scenarios where you need specific fragmentation patterns.
+
+Example of the difference:
+
+```go
+// WriteRecord: Automatically fragments large data
+largeData := make([]byte, 50000) // 50KB
+err := writer.WriteRecord(largeData, false, false)
+// This will create RecordFirst + RecordMiddle + RecordLast fragments automatically
+
+// WriteFullRecord: Uses exact type specified
+record := &tsdbwalsegment.Record{
+    Type: tsdbwalsegment.RecordFirst, // This exact type will be used
+    Data: largeData,
+}
+err := writer.WriteFullRecord(record)
+// This will create exactly one RecordFirst record (may be invalid if data is too large)
+```
+
+## WAL Segment Format
+
+Each WAL segment consists of:
+- 32KB pages containing records
+- 7-byte headers per record: [Type+Flags][Length][CRC32]
+- Variable-length data following each header
+- Automatic fragmentation for records spanning multiple pages
+
+### Record Header Format
+```
+Byte 0: [Type (3 bits)] [Compression flags (5 bits)]
+Bytes 1-2: Data length (big-endian uint16)
+Bytes 3-6: CRC32 checksum (big-endian uint32)
+```
+
+### Compression Flags
+- Bit 3: Snappy compression flag
+- Bit 4: Zstd compression flag
+
+## Testing and Corruption Scenarios
+
+This package is particularly useful for creating test scenarios:
+
+```go
+tornRecord := &tsdbwalsegment.Record{
+    Type: tsdbwalsegment.RecordFirst, // Indicates more fragments follow
+    Data: []byte("This record will never be completed"),
+}
+writer.WriteFullRecord(tornRecord)
+writer.Close() // Close without writing RecordLast
+
+```
+
+
+

--- a/pkg/tsdbwalsegment/wal-segment-format.md
+++ b/pkg/tsdbwalsegment/wal-segment-format.md
@@ -1,0 +1,119 @@
+# WAL Segment Format Documentation
+
+## Overview
+
+A WAL (Write-Ahead Log) segment is a file containing a sequence of records. Each segment is divided into 32KB pages, and records can span multiple pages but never cross segment boundaries. This document describes the binary format of WAL segment files as used in Prometheus TSDB.
+
+## Segment Structure
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                        WAL SEGMENT FILE                         │
+├─────────────────────────────────────────────────────────────────┤
+│                         PAGE 0 (32KB)                          │
+├─────────────────────────────────────────────────────────────────┤
+│  RECORD 1  │  RECORD 2  │  RECORD 3  │     ...     │  PADDING  │
+├─────────────────────────────────────────────────────────────────┤
+│                         PAGE 1 (32KB)                          │
+├─────────────────────────────────────────────────────────────────┤
+│  RECORD N  │  RECORD N+1 │     ...     │           │  PADDING  │
+├─────────────────────────────────────────────────────────────────┤
+│                           ...                                   │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Record Structure
+
+Every record in a WAL segment follows this structure:
+
+```
+┌─────────────┬─────────────────────────────────────────────────────┐
+│   HEADER    │                    DATA                             │
+│   (7 bytes) │                (variable length)                    │
+└─────────────┴─────────────────────────────────────────────────────┘
+```
+
+### Header Format (7 bytes total)
+
+```
+ Byte 0      Bytes 1-2        Bytes 3-6
+┌─────────┬─────────────────┬─────────────────────────────────────┐
+│  TYPE   │      LENGTH     │               CRC32                 │
+│(1 byte) │   (2 bytes)     │            (4 bytes)                │
+└─────────┴─────────────────┴─────────────────────────────────────┘
+```
+
+#### Byte 0 - Record Type and Compression Flags
+
+```
+Bit:  7   6   5   4   3   2   1   0
+     ┌───┬───┬───┬───┬───┬───┬───┬───┐
+     │ - │ - │ - │ Z │ S │ T │ T │ T │
+     └───┴───┴───┴───┴───┴───┴───┴───┘
+      │   │   │   │   │   └───┴───┴───┘
+      │   │   │   │   │       └─ Record Type (3 bits)
+      │   │   │   │   └─ Snappy Compression Flag (1 bit)
+      │   │   │   └─ Zstd Compression Flag (1 bit)  
+      └───┴───┴─ Unallocated (3 bits)
+```
+
+**Record Types:**
+- `0` (recPageTerm): Rest of page is empty
+- `1` (recFull): Complete record fits in current page
+- `2` (recFirst): First fragment of a record spanning multiple pages
+- `3` (recMiddle): Middle fragment of a record spanning multiple pages
+- `4` (recLast): Final fragment of a record spanning multiple pages
+
+**Compression Flags:**
+- Bit 3 (snappyMask = 0x08): Set if data is Snappy compressed
+- Bit 4 (zstdMask = 0x10): Set if data is Zstd compressed
+
+#### Bytes 1-2 - Data Length
+Big-endian 16-bit unsigned integer representing the length of the data portion in bytes.
+
+#### Bytes 3-6 - CRC32 Checksum
+Big-endian 32-bit CRC32 checksum (Castagnoli polynomial) of the data portion only.
+
+## Record Fragmentation
+
+When a record is larger than the remaining space in a page, it gets fragmented:
+
+```
+Page N                           Page N+1
+┌─────────────────────────────┐  ┌─────────────────────────────────┐
+│ [HEADER] [DATA PART 1]      │  │ [HEADER] [DATA PART 2] [HEADER] │
+│ Type: recFirst              │  │ Type: recLast      Type: recFull│
+│ Length: 1024                │  │ Length: 512        Length: 256  │
+│ CRC: 0x12345678             │  │ CRC: 0x87654321    CRC: 0xABCD  │
+└─────────────────────────────┘  └─────────────────────────────────┘
+```
+
+## Page Boundaries
+
+- Each page is exactly 32KB (32,768 bytes)
+- Records never span across segment boundaries
+- Unused space at the end of pages is zero-padded
+- A `recPageTerm` record type indicates the rest of the page is empty
+
+## Data Format
+
+The data portion contains the actual record payload. The format depends on the application using the WAL:
+
+- **Series Records**: Encoded series labels and references
+- **Sample Records**: Encoded time series samples  
+- **Tombstone Records**: Encoded deletion markers
+- **Custom Records**: Application-specific data
+
+## Compression
+
+When compression is enabled:
+1. The data is compressed before writing
+2. The appropriate compression flag is set in the header
+3. The CRC is calculated on the compressed data
+4. The length field reflects the compressed data size
+
+
+## References
+
+- [Prometheus WAL Disk Format](https://github.com/prometheus/prometheus/blob/main/tsdb/docs/format/wal.md)
+- [Prometheus TSDB WAL and Checkpoint](https://ganeshvernekar.com/blog/prometheus-tsdb-wal-and-checkpoint/)

--- a/pkg/tsdbwalsegment/walsegment.go
+++ b/pkg/tsdbwalsegment/walsegment.go
@@ -1,0 +1,451 @@
+// Package walsegment provides functionality to read and write individual WAL segment files.
+// A WAL segment is a file containing a sequence of records, where each record has a 7-byte header
+// followed by data. Records can be fragmented across 32KB pages but never across segment boundaries.
+package tsdbwalsegment
+
+import (
+	"bufio"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"hash/crc32"
+	"io"
+	"os"
+)
+
+const (
+	// PageSize is the size of each page in a WAL segment (32KB)
+	PageSize = 32 * 1024
+	// RecordHeaderSize is the size of each record header in bytes
+	RecordHeaderSize = 7
+	// SegmentSize is the default size for a WAL segment (128MB)
+	SegmentSize = 128 * 1024 * 1024 // (128MB)
+)
+
+// RecordType represents the type of a WAL record (low-level fragmentation)
+type RecordType uint8
+
+const (
+	// RecordPageTerm indicates the rest of the page is empty
+	RecordPageTerm RecordType = 0
+	// RecordFull indicates a complete record that fits in the current page
+	RecordFull RecordType = 1
+	// RecordFirst indicates the first fragment of a record spanning multiple pages
+	RecordFirst RecordType = 2
+	// RecordMiddle indicates a middle fragment of a record spanning multiple pages
+	RecordMiddle RecordType = 3
+	// RecordLast indicates the final fragment of a record spanning multiple pages
+	RecordLast RecordType = 4
+)
+
+// Compression flags
+const (
+	snappyMask  = 1 << 3
+	zstdMask    = 1 << 4
+	recTypeMask = snappyMask - 1
+)
+
+// String returns a string representation of the record type
+func (rt RecordType) String() string {
+	switch rt {
+	case RecordPageTerm:
+		return "PAGE_TERM"
+	case RecordFull:
+		return "FULL"
+	case RecordFirst:
+		return "FIRST"
+	case RecordMiddle:
+		return "MIDDLE"
+	case RecordLast:
+		return "LAST"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+// Record represents a single WAL record with its header information
+type Record struct {
+	// Header
+	Type         RecordType // Low-level fragmentation type (Full, First, Middle, Last)
+	Length       uint16
+	CRC          uint32
+	IsCompressed bool
+	IsSnappy     bool
+	IsZstd       bool
+
+	// Data
+	Data []byte
+}
+
+// ParseHeader extracts record type and compression flags from the header byte
+func ParseHeader(headerByte byte) (RecordType, bool, bool) {
+	recType := RecordType(headerByte & recTypeMask)
+	isSnappy := (headerByte & snappyMask) != 0
+	isZstd := (headerByte & zstdMask) != 0
+	return recType, isSnappy, isZstd
+}
+
+// EncodeHeader creates a header byte from record type and compression flags
+func EncodeHeader(recType RecordType, isSnappy, isZstd bool) byte {
+	header := byte(recType)
+	if isSnappy {
+		header |= snappyMask
+	}
+	if isZstd {
+		header |= zstdMask
+	}
+	return header
+}
+
+// SegmentReader reads records from a WAL segment file
+type SegmentReader struct {
+	file          *os.File
+	reader        *bufio.Reader
+	offset        int64
+	err           error
+	currentRecord *Record
+}
+
+// NewSegmentReader creates a new segment reader for the given file
+func NewSegmentReader(filename string) (*SegmentReader, error) {
+	file, err := os.Open(filename)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open segment file: %w", err)
+	}
+
+	return &SegmentReader{
+		file:   file,
+		reader: bufio.NewReader(file),
+		offset: 0,
+	}, nil
+}
+
+// Close closes the segment reader
+func (sr *SegmentReader) Close() error {
+	if sr.file != nil {
+		return sr.file.Close()
+	}
+	return nil
+}
+
+// Offset returns the current read offset in the segment
+func (sr *SegmentReader) Offset() int64 {
+	return sr.offset
+}
+
+// Err returns the last error encountered
+func (sr *SegmentReader) Err() error {
+	return sr.err
+}
+
+// Next reads the next complete record from the segment
+func (sr *SegmentReader) Next() bool {
+	if sr.err != nil {
+		return false
+	}
+
+	record, err := sr.readRecord()
+	if err != nil {
+		if errors.Is(err, io.EOF) {
+			return false
+		}
+		sr.err = err
+		return false
+	}
+
+	sr.currentRecord = record
+	return true
+}
+
+// Record returns the current record
+func (sr *SegmentReader) Record() *Record {
+	return sr.currentRecord
+}
+
+var castagnoliTable = crc32.MakeTable(crc32.Castagnoli)
+
+// readRecord reads a complete record, handling fragmentation across pages
+func (sr *SegmentReader) readRecord() (*Record, error) {
+	var recordData []byte
+	var recordType RecordType
+	var isSnappy, isZstd bool
+	var firstFragment = true
+
+	for {
+		// Read record header
+		header := make([]byte, RecordHeaderSize)
+		n, err := io.ReadFull(sr.reader, header)
+		if err != nil {
+			return nil, err
+		}
+		sr.offset += int64(n)
+
+		// Parse header
+		recType, snappy, zstd := ParseHeader(header[0])
+		length := binary.BigEndian.Uint16(header[1:3])
+		crc := binary.BigEndian.Uint32(header[3:7])
+
+		// Handle page termination
+		if recType == RecordPageTerm {
+			// Skip to next page boundary
+			pageOffset := sr.offset % PageSize
+			if pageOffset != 0 {
+				skipBytes := PageSize - pageOffset
+				_, err := sr.reader.Discard(int(skipBytes))
+				if err != nil {
+					return nil, err
+				}
+				sr.offset += skipBytes
+			}
+			continue
+		}
+
+		// Read record data
+		data := make([]byte, length)
+		n, err = io.ReadFull(sr.reader, data)
+		if err != nil {
+			return nil, err
+		}
+		sr.offset += int64(n)
+
+		// Verify CRC
+		if crc32.Checksum(data, castagnoliTable) != crc {
+			return nil, fmt.Errorf("CRC mismatch at offset %d", sr.offset-int64(len(data)))
+		}
+
+		// Store compression info from first fragment
+		if firstFragment {
+			recordType = recType
+			isSnappy = snappy
+			isZstd = zstd
+			firstFragment = false
+		}
+
+		// Append data to record
+		recordData = append(recordData, data...)
+
+		// Check if record is complete
+		switch recType {
+		case RecordFull:
+			return &Record{
+				Type:         recordType,
+				Length:       uint16(len(recordData)),
+				Data:         recordData,
+				IsCompressed: isSnappy || isZstd,
+				IsSnappy:     isSnappy,
+				IsZstd:       isZstd,
+			}, nil
+		case RecordLast:
+			return &Record{
+				Type:         recordType,
+				Length:       uint16(len(recordData)),
+				Data:         recordData,
+				IsCompressed: isSnappy || isZstd,
+				IsSnappy:     isSnappy,
+				IsZstd:       isZstd,
+			}, nil
+		case RecordFirst, RecordMiddle:
+			// Continue reading fragments
+			continue
+		default:
+			return nil, fmt.Errorf("invalid record type: %d", recType)
+		}
+	}
+}
+
+// SegmentWriter writes records to a WAL segment file
+type SegmentWriter struct {
+	file       *os.File
+	writer     *bufio.Writer
+	offset     int64
+	pageOffset int64
+}
+
+// NewSegmentWriter creates a new segment writer for the given file
+func NewSegmentWriter(filename string) (*SegmentWriter, error) {
+
+	file, err := os.Create(filename)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create segment file: %w", err)
+	}
+
+	return &SegmentWriter{
+		file:       file,
+		writer:     bufio.NewWriter(file),
+		offset:     0,
+		pageOffset: 0,
+	}, nil
+}
+
+// Close closes the segment writer and flushes any buffered data
+func (sw *SegmentWriter) Close() error {
+	if err := sw.writer.Flush(); err != nil {
+		return err
+	}
+	if sw.file != nil {
+		return sw.file.Close()
+	}
+	return nil
+}
+
+// Offset returns the current write offset in the segment
+func (sw *SegmentWriter) Offset() int64 {
+	return sw.offset
+}
+
+// WriteRecord writes a record to the segment, handling fragmentation if necessary
+func (sw *SegmentWriter) WriteRecord(data []byte, isSnappy, isZstd bool) error {
+	if len(data) == 0 {
+		return nil
+	}
+
+	// Check if record would exceed segment size
+	totalSize := int64(len(data)) + RecordHeaderSize
+	if sw.offset+totalSize > SegmentSize {
+		return fmt.Errorf("record would exceed segment size")
+	}
+
+	// Calculate available space in current page
+	availableInPage := PageSize - (sw.pageOffset % PageSize)
+
+	// If record fits entirely in current page
+	if int64(len(data))+RecordHeaderSize <= availableInPage {
+		return sw.writeRecordPart(data, RecordFull, isSnappy, isZstd)
+	}
+
+	// Fragment the record across pages
+	remaining := data
+	isFirst := true
+
+	for len(remaining) > 0 {
+		availableInPage = PageSize - (sw.pageOffset % PageSize)
+		availableForData := availableInPage - RecordHeaderSize
+
+		if availableForData <= 0 {
+			// Fill rest of page with zeros and move to next page
+			if err := sw.padToNextPage(); err != nil {
+				return err
+			}
+			continue
+		}
+
+		// Determine how much data to write in this fragment
+		fragmentSize := int64(len(remaining))
+		if fragmentSize > availableForData {
+			fragmentSize = availableForData
+		}
+
+		fragment := remaining[:fragmentSize]
+		remaining = remaining[fragmentSize:]
+
+		// Determine record type
+		var recType RecordType
+		switch {
+		case isFirst && len(remaining) == 0:
+			recType = RecordFull
+		case isFirst:
+			recType = RecordFirst
+			isFirst = false
+		case len(remaining) == 0:
+			recType = RecordLast
+		default:
+			recType = RecordMiddle
+		}
+
+		if err := sw.writeRecordPart(fragment, recType, isSnappy, isZstd); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// WriteFullRecord writes a complete Record struct to the segment exactly as specified.
+// This method honors the Type field from the Record struct and writes the record
+// with the exact fragmentation type specified by the user.
+func (sw *SegmentWriter) WriteFullRecord(record *Record) error {
+	if record == nil {
+		return fmt.Errorf("record cannot be nil")
+	}
+
+	if len(record.Data) == 0 {
+		return nil
+	}
+
+	// Check if record would exceed segment size
+	totalSize := int64(len(record.Data)) + RecordHeaderSize
+	if sw.offset+totalSize > SegmentSize {
+		return fmt.Errorf("record would exceed segment size")
+	}
+
+	// Write the record part with the exact type specified by the user
+	return sw.writeRecordPart(record.Data, record.Type, record.IsSnappy, record.IsZstd)
+}
+
+// writeRecordPart writes a single record part with the given type
+func (sw *SegmentWriter) writeRecordPart(data []byte, recType RecordType, isSnappy, isZstd bool) error {
+	// Create header
+	header := make([]byte, RecordHeaderSize)
+	header[0] = EncodeHeader(recType, isSnappy, isZstd)
+	binary.BigEndian.PutUint16(header[1:3], uint16(len(data)))
+	binary.BigEndian.PutUint32(header[3:7], crc32.Checksum(data, castagnoliTable))
+
+	// Write header
+	if _, err := sw.writer.Write(header); err != nil {
+		return err
+	}
+
+	// Write data
+	if _, err := sw.writer.Write(data); err != nil {
+		return err
+	}
+
+	// Update offsets
+	written := int64(RecordHeaderSize + len(data))
+	sw.offset += written
+	sw.pageOffset += written
+
+	return nil
+}
+
+// padToNextPage fills the remaining space in the current page with zeros
+func (sw *SegmentWriter) padToNextPage() error {
+	remainingInPage := PageSize - (sw.pageOffset % PageSize)
+	if remainingInPage == PageSize {
+		return nil // Already at page boundary
+	}
+
+	// Write page termination record
+	header := make([]byte, RecordHeaderSize)
+	header[0] = byte(RecordPageTerm)
+	// Length and CRC are zero for page termination
+
+	if _, err := sw.writer.Write(header); err != nil {
+		return err
+	}
+
+	// Fill rest of page with zeros
+	padding := make([]byte, remainingInPage-RecordHeaderSize)
+	if _, err := sw.writer.Write(padding); err != nil {
+		return err
+	}
+
+	// Update offsets
+	sw.offset += remainingInPage
+	sw.pageOffset = (sw.pageOffset + remainingInPage) % PageSize
+
+	return nil
+}
+
+// Flush flushes any buffered data to disk
+func (sw *SegmentWriter) Flush() error {
+	return sw.writer.Flush()
+}
+
+// Sync flushes buffered data and syncs to disk
+func (sw *SegmentWriter) Sync() error {
+	if err := sw.writer.Flush(); err != nil {
+		return err
+	}
+	return sw.file.Sync()
+}

--- a/pkg/tsdbwalsegment/walsegment_test.go
+++ b/pkg/tsdbwalsegment/walsegment_test.go
@@ -1,0 +1,174 @@
+package tsdbwalsegment
+
+import (
+	"encoding/binary"
+	"hash/crc32"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Test_Write tests writing a record using the segment writer and verifies
+// the binary content of the file to ensure the header bytes and data are correct
+func Test_Write(t *testing.T) {
+	// Create a temporary directory for the test
+	tmpDir, err := os.MkdirTemp("", "wal_write_test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	segmentFile := filepath.Join(tmpDir, "000000")
+
+	writer, err := NewSegmentWriter(segmentFile)
+	require.NoError(t, err)
+
+	// Test data
+	testData := []byte("WAL")
+	isSnappy := true
+	isZstd := false
+
+	// Write the record
+	err = writer.WriteRecord(testData, isSnappy, isZstd)
+	require.NoError(t, err)
+
+	// Close the writer to flush data
+	err = writer.Close()
+	require.NoError(t, err)
+
+	// Read the file content as binary
+	fileContent, err := os.ReadFile(segmentFile)
+	require.NoError(t, err)
+
+	// Verify the file has the expected minimum size (header + data)
+	expectedMinSize := RecordHeaderSize + len(testData)
+	require.GreaterOrEqual(t, len(fileContent), expectedMinSize,
+		"File size too small: got %d, expected at least %d", len(fileContent), expectedMinSize)
+
+	// Parse and verify the header (first 7 bytes)
+	header := fileContent[:RecordHeaderSize]
+
+	// Byte 0: Record type and compression flags
+	headerByte := header[0]
+	recordType, snappy, zstd := ParseHeader(headerByte)
+
+	require.Equal(t, RecordFull, recordType,
+		"Expected record type RecordFull (%d), got %s (%d)", RecordFull, recordType.String(), recordType)
+	require.Equal(t, isSnappy, snappy,
+		"Expected Snappy flag %t, got %t", isSnappy, snappy)
+	require.Equal(t, isZstd, zstd,
+		"Expected Zstd flag %t, got %t", isZstd, zstd)
+
+	// Bytes 1-2: Data length (big-endian uint16)
+	dataLength := binary.BigEndian.Uint16(header[1:3])
+	require.Equal(t, uint16(len(testData)), dataLength,
+		"Expected data length %d, got %d", len(testData), dataLength)
+
+	// Bytes 3-6: CRC32 checksum (big-endian uint32)
+	expectedCRC := crc32.Checksum(testData, crc32.MakeTable(crc32.Castagnoli))
+	actualCRC := binary.BigEndian.Uint32(header[3:7])
+	require.Equal(t, expectedCRC, actualCRC,
+		"Expected CRC32 %d, got %d", expectedCRC, actualCRC)
+
+	// Verify the data content
+	actualData := fileContent[RecordHeaderSize : RecordHeaderSize+len(testData)]
+	require.Equal(t, string(testData), string(actualData),
+		"Expected data %q, got %q", string(testData), string(actualData))
+}
+
+// Test_WriteFullRecordAndRead tests writing a full record using WriteFullRecord
+// and then reading it back using the segment reader to ensure round-trip consistency
+func Test_WriteFullRecordAndRead(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "wal_full_record_test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	segmentFile := filepath.Join(tmpDir, "000002")
+
+	writer, err := NewSegmentWriter(segmentFile)
+	require.NoError(t, err)
+
+	// Create test records with different types and compression settings
+	testRecords := []*Record{
+		{
+			Type:         RecordFull,
+			Data:         []byte("Uncompressed full record"),
+			IsCompressed: false,
+			IsSnappy:     false,
+			IsZstd:       false,
+		},
+		{
+			Type:         RecordFull,
+			Data:         []byte("Snappy compressed record"),
+			IsCompressed: true,
+			IsSnappy:     true,
+			IsZstd:       false,
+		},
+		{
+			Type:         RecordFull,
+			Data:         []byte("Zstd compressed record"),
+			IsCompressed: true,
+			IsSnappy:     false,
+			IsZstd:       true,
+		},
+	}
+
+	// Write all test records
+	for i, record := range testRecords {
+		err := writer.WriteFullRecord(record)
+		require.NoError(t, err, "Failed to write full record %d", i)
+	}
+
+	err = writer.Close()
+	require.NoError(t, err)
+
+	// Create a reader to read back the records
+	reader, err := NewSegmentReader(segmentFile)
+	require.NoError(t, err)
+	defer reader.Close()
+
+	// Read back and verify each record
+	recordIndex := 0
+	for reader.Next() {
+		require.Less(t, recordIndex, len(testRecords),
+			"Read more records than expected: got record %d", recordIndex)
+
+		actualRecord := reader.Record()
+		expectedRecord := testRecords[recordIndex]
+
+		// Verify record type
+		require.Equal(t, expectedRecord.Type, actualRecord.Type,
+			"Record %d: Expected type %s, got %s",
+			recordIndex, expectedRecord.Type.String(), actualRecord.Type.String())
+
+		// Verify compression flags
+		require.Equal(t, expectedRecord.IsCompressed, actualRecord.IsCompressed,
+			"Record %d: Expected IsCompressed %t, got %t",
+			recordIndex, expectedRecord.IsCompressed, actualRecord.IsCompressed)
+		require.Equal(t, expectedRecord.IsSnappy, actualRecord.IsSnappy,
+			"Record %d: Expected IsSnappy %t, got %t",
+			recordIndex, expectedRecord.IsSnappy, actualRecord.IsSnappy)
+		require.Equal(t, expectedRecord.IsZstd, actualRecord.IsZstd,
+			"Record %d: Expected IsZstd %t, got %t",
+			recordIndex, expectedRecord.IsZstd, actualRecord.IsZstd)
+
+		// Verify data length
+		require.Equal(t, uint16(len(expectedRecord.Data)), actualRecord.Length,
+			"Record %d: Expected length %d, got %d",
+			recordIndex, len(expectedRecord.Data), actualRecord.Length)
+
+		// Verify data content
+		require.Equal(t, string(expectedRecord.Data), string(actualRecord.Data),
+			"Record %d: Expected data %q, got %q",
+			recordIndex, string(expectedRecord.Data), string(actualRecord.Data))
+
+		recordIndex++
+	}
+
+	// Check for reading errors
+	require.NoError(t, reader.Err(), "Error reading segment")
+
+	// Verify we read the expected number of records
+	require.Equal(t, len(testRecords), recordIndex,
+		"Expected to read %d records, but read %d", len(testRecords), recordIndex)
+}


### PR DESCRIPTION
Closed in favor of: https://github.com/grafana/loki/pull/18175 

**What this PR does / why we need it**:

This PR introduces a new `pkg/tsdbwalsegment` package that provides functionality to read and write individual WAL (Write-Ahead Log) segment files according to the [Prometheus TSDB WAL format specification](./docs/wal-segment-format.md). The primary purpose of this package is to enable creation of custom WAL segments for testing corruption scenarios, particularly the "last record is torn" error.

## Background

Currently a WAL corruption  lead to endless restart loops, as reported in [issue #12583](https://github.com/grafana/loki/issues/12583). Users experience crashes with errors like:

```
corruption in segment /var/loki/tsdb-shipper-active/wal/s3_2024-01-02/1712203235/00000004 at 65536: last record is torn
error recovering from TSDB WAL
```

This causes loki to crashloop indefinitely, repeatedly reading the WAL and updating object storage, which can be costly for large WALs. 

## What This PR Adds

### 1. WAL Segment Package (`pkg/tsdbwalsegment`)

- **Read/Write WAL segments**: Create and parse individual WAL segment files
- **Fine-grained control**: Precise control over record types for testing scenarios
- **Automatic fragmentation**: Handle records spanning multiple 32KB pages

### 2. Comprehensive Documentation

- Detailed ASCII art diagrams showing WAL record structure
- Complete API documentation with examples
- WAL format specification based on Prometheus TSDB implementation

References:
- [Prometheus WAL Disk Format](https://github.com/prometheus/prometheus/blob/main/tsdb/docs/format/wal.md)
- [Prometheus TSDB WAL and Checkpoint](https://ganeshvernekar.com/blog/prometheus-tsdb-wal-and-checkpoint/)

### 3. Test Coverage for "Last Record is Torn" Scenario

We now have a unit test (`Test_HeadManager_RecoverHead_CorruptedWAL`) that successfully replicates the exact corruption scenario customers are experiencing:

```go
// Creates a WAL segment ending with RecordFirst (incomplete fragmentation)
err = writer.WriteFullRecord(&tsdbwalsegment.Record{
    Type: tsdbwalsegment.RecordFirst, // Indicates more fragments should follow
    Data: tornData,
})
// File ends without corresponding RecordLast, creating "torn" condition
```

This test produces the same error message as seen in production:

```
corruption in segment /var/folders/.../00000000 at 32768: last record is torn
```

This exactly matches the customer error pattern from [issue #12583](https://github.com/grafana/loki/issues/12583), confirming we can reliably reproduce the corruption scenario.

## Key Features

The ability to reproduce the "last record is torn" error from [issue #12583](https://github.com/grafana/loki/issues/12583) is particularly valuable for developing a proper fix for the endless restart loop problem.


**Which issue(s) this PR fixes**:
Fixes #12583

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
