### PR TITLE
chore: Improve error message for `maximum of series (%d) reached`

### DIFF
--- a/pkg/logqlmodel/error.go
+++ b/pkg/logqlmodel/error.go
@@ -93,7 +93,7 @@ type LimitError struct {
 
 func NewSeriesLimitError(limit int) *LimitError {
 	return &LimitError{
-		error: fmt.Errorf("maximum of series (%d) reached for a single query", limit),
+		error: fmt.Errorf("maximum number of series (%d) reached for a single query; consider reducing query cardinality by adding more specific stream selectors, reducing the time range, or aggregating results with functions like sum(), count() or topk()", limit),
 	}
 }
 

--- a/pkg/querier/queryrange/limits.go
+++ b/pkg/querier/queryrange/limits.go
@@ -41,7 +41,7 @@ import (
 )
 
 const (
-	limitErrTmpl                             = "maximum of series (%d) reached for a single query"
+	limitErrTmpl                             = "maximum number of series (%d) reached for a single query; consider reducing query cardinality by adding more specific stream selectors, reducing the time range, or aggregating results with functions like sum(), count() or topk()"
 	maxSeriesErrTmpl                         = "max entries limit per query exceeded, limit > max_entries_limit_per_query (%d > %d)"
 	requiredLabelsErrTmpl                    = "stream selector is missing required matchers [%s], labels present in the query were [%s]"
 	requiredNumberLabelsErrTmpl              = "stream selector has less label matchers than required: (present: [%s], number_present: %d, required_number_label_matchers: %d)"


### PR DESCRIPTION
This PR improves error message for `maximum of series (%d) reached` error. It provides guidance on how to fix it. This is a common error that users encounter with. 

Fixes https://github.com/grafana/grafana/issues/80210