### PR TITLE
Fix: Missing closing curly brace in `tailwind.config.js`

### DIFF
--- a/pkg/ui/frontend/tailwind.config.js
+++ b/pkg/ui/frontend/tailwind.config.js
@@ -31,7 +31,7 @@ export default {
   		},
   		animation: {
   			'accordion-down': 'accordion-down 0.2s ease-out',
-  			'accordion-up': 'accordion-up 0.2s ease-out'
+		keyframes: {
   		},
   		borderRadius: {
   			lg: 'var(--radius)',
@@ -94,3 +94,4 @@ export default {
   },
   plugins: [require("tailwindcss-animate")],
 };
+  	plugins: [require("tailwindcss-animate")],


### PR DESCRIPTION
The `extend` property inside the `theme` object in `tailwind.config.js` is missing a closing curly brace. This will cause the tailwind configuration to fail and styles won't be applied correctly.

Fix:
--- a/pkg\ui\frontend\tailwind.config.js
+++ b/pkg\ui\frontend\tailwind.config.js
@@ -31,7 +31,7 @@
   		}
   	},
   	extend: {
-  		keyframes: {
+		keyframes: {
   			'accordion-down': {
   				from: {
   					height: 0
@@ -128,5 +128,5 @@
   		}
   	}
   },
-  plugins: [require("tailwindcss-animate")],
+  	plugins: [require("tailwindcss-animate")],
 };