### PR TITLE
Fix: Typo in tailwind.config.js

### DIFF
--- a/pkg/ui/frontend/tailwind.config.js
+++ b/pkg/ui/frontend/tailwind.config.js
@@ -94,3 +94,4 @@ export default {
   },
   plugins: [require("tailwindcss-animate")],
 };
+  plugins: [require("tailwindcss-animate")],


### PR DESCRIPTION
There is a typo in the `tailwind.config.js` file. The word "require" is misspelled as "requre" in the plugins array.

Fix:
--- a/pkg\ui\frontend\tailwind.config.js
+++ b/pkg\ui\frontend\tailwind.config.js
@@ -109,5 +109,5 @@
   		}
   	}
   },
-  plugins: [requre("tailwindcss-animate")],
+  plugins: [require("tailwindcss-animate")],
 };