### PR TITLE
chore: lint fix for queue.go

### DIFF
--- a/pkg/compactor/jobqueue/queue.go
+++ b/pkg/compactor/jobqueue/queue.go
@@ -245,13 +245,13 @@ func (q *Queue) reportJobResult(result *grpc.JobResult) error {
 
 			pj.lastAttemptFailed = true
 			return nil
-		} else {
-			level.Error(util_log.Logger).Log(
-				"msg", "job failed after max attempts",
-				"job_id", result.JobId,
-				"job_type", result.JobType,
-			)
 		}
+
+		level.Error(util_log.Logger).Log(
+			"msg", "job failed after max attempts",
+			"job_id", result.JobId,
+			"job_type", result.JobType,
+		)
 	} else {
 		level.Debug(util_log.Logger).Log(
 			"msg", "job execution succeeded",


### PR DESCRIPTION
**What this PR does / why we need it**:
[This PR](https://github.com/grafana/loki/pull/18165) was merged today, and now `main` is [complaining](https://github.com/grafana/loki/actions/runs/15784906069/job/44499074030) of a linter error.  

This PR just addresses the linter error. Since the `if` block has a `return` clause, the `else` block can be out-dented.
**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
