### PR TITLE
fix: detect "Information" log level as "info"

### DIFF
--- a/pkg/distributor/field_detection.go
+++ b/pkg/distributor/field_detection.go
@@ -27,6 +27,7 @@ var (
 	debugAbbrv = []byte("dbg")
 	info       = []byte("info")
 	infoAbbrv  = []byte("inf")
+	infoFull   = []byte("information")
 	warn       = []byte("warn")
 	warnAbbrv  = []byte("wrn")
 	warning    = []byte("warning")
@@ -200,7 +201,7 @@ func (l *FieldDetector) extractLogLevelFromLogLine(log string) string {
 		return constants.LogLevelTrace
 	case bytes.EqualFold(v, debug), bytes.EqualFold(v, debugAbbrv):
 		return constants.LogLevelDebug
-	case bytes.EqualFold(v, info), bytes.EqualFold(v, infoAbbrv):
+	case bytes.EqualFold(v, info), bytes.EqualFold(v, infoAbbrv), bytes.EqualFold(v, infoFull):
 		return constants.LogLevelInfo
 	case bytes.EqualFold(v, warn), bytes.EqualFold(v, warnAbbrv), bytes.EqualFold(v, warning):
 		return constants.LogLevelWarn

--- a/pkg/distributor/field_detection_test.go
+++ b/pkg/distributor/field_detection_test.go
@@ -326,6 +326,20 @@ func Test_detectLogLevelFromLogEntry(t *testing.T) {
 			},
 			expectedLogLevel: constants.LogLevelInfo,
 		},
+		{
+			name: "logfmt log line with a info with short level",
+			entry: logproto.Entry{
+				Line: `FOO=bar MSG="message that should qualify to unknown when there is no level defined" LEVEL=Inf`,
+			},
+			expectedLogLevel: constants.LogLevelInfo,
+		},
+		{
+			name: "logfmt log line with a info with full level",
+			entry: logproto.Entry{
+				Line: `FOO=bar MSG="message that should qualify to unknown when there is no level defined" LEVEL=Information`,
+			},
+			expectedLogLevel: constants.LogLevelInfo,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			detectedLogLevel := ld.detectLogLevelFromLogEntry(tc.entry, logproto.FromLabelAdaptersToLabels(tc.entry.StructuredMetadata))


### PR DESCRIPTION
**What this PR does / why we need it**:
Support for parsing "Information" log level from .NET libraries

**Which issue(s) this PR fixes**:
Fixes #17833

**Special notes for your reviewer**:
Added an extra unit test for "inf" level, since we don't seem to be testing for that

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
