### PR TITLE
chore(ci): Fix logstash build

### DIFF
--- a/clients/cmd/logstash/Dockerfile
+++ b/clients/cmd/logstash/Dockerfile
@@ -1,12 +1,12 @@
 FROM logstash:9.0.2
 
 USER logstash
-ENV PATH /usr/share/logstash/vendor/jruby/bin:/usr/share/logstash/vendor/bundle/jruby/2.5.0/bin:/usr/share/logstash/jdk/bin:$PATH
+ENV PATH /usr/share/logstash/vendor/jruby/bin:/usr/share/logstash/vendor/bundle/jruby/3.1.0/bin:/usr/share/logstash/jdk/bin:$PATH
 ENV LOGSTASH_PATH /usr/share/logstash
-ENV GEM_PATH /usr/share/logstash/vendor/bundle/jruby/2.5.0
-ENV GEM_HOME /usr/share/logstash/vendor/bundle/jruby/2.5.0
+ENV GEM_PATH /usr/share/logstash/vendor/bundle/jruby/3.1.0
+ENV GEM_HOME /usr/share/logstash/vendor/bundle/jruby/3.1.0
 
-RUN gem install bundler:2.3.6
+RUN gem install bundler -v 2.6.9
 
 COPY --chown=logstash:logstash ./clients/cmd/logstash/ /home/logstash/
 WORKDIR /home/logstash/

--- a/clients/cmd/logstash/Gemfile
+++ b/clients/cmd/logstash/Gemfile
@@ -12,3 +12,6 @@ else
 end
 
 gem "webmock", "~> 3.8"
+# I could not find the reason why the `cgi` gem is required after the upgrade of jruby inside the logstash bash Docker image.
+# However, the build fails without this dependency.
+gem "cgi"


### PR DESCRIPTION
**What this PR does / why we need it**:

The logstash plugin build step in Github workflows failed https://github.com/grafana/loki/actions/runs/15814913050/job/44576897829

```
#7 [2/7] RUN gem install bundler:2.3.6
#7 4.152 ERROR:  Loading command: install (Gem::MissingSpecError)
#7 4.152 	Gem::MissingSpecError
#7 4.155 	/usr/share/logstash/vendor/jruby/lib/ruby/stdlib/rubygems/specification.rb:1453:in `block in activate_dependencies'
#7 4.155 	org/jruby/RubyArray.java:1981:in `each'
#7 4.155 	/usr/share/logstash/vendor/jruby/lib/ruby/stdlib/rubygems/specification.rb:1439:in `activate_dependencies'
#7 4.155 	/usr/share/logstash/vendor/jruby/lib/ruby/stdlib/rubygems/specification.rb:1421:in `activate'
#7 4.155 	/usr/share/logstash/vendor/jruby/lib/ruby/stdlib/rubygems/core_ext/kernel_gem.rb:68:in `block in gem'
#7 4.155 	org/jruby/ext/thread/Mutex.java:174:in `synchronize'
#7 4.155 	/usr/share/logstash/vendor/jruby/lib/ruby/stdlib/rubygems/core_ext/kernel_gem.rb:68:in `gem'
#7 4.155 	/usr/share/logstash/vendor/jruby/lib/ruby/stdlib/rubygems/core_ext/kernel_require.rb:73:in `require'
#7 4.155 	/usr/share/logstash/vendor/jruby/lib/ruby/stdlib/rubygems/request.rb:2:in `<main>'
#7 4.155 	org/jruby/RubyKernel.java:1187:in `require'
#7 4.155 	org/jruby/RubyKernel.java:1216:in `require_relative'
#7 4.155 	/usr/share/logstash/vendor/jruby/lib/ruby/stdlib/rubygems/remote_fetcher.rb:3:in `<main>'
#7 4.155 	org/jruby/RubyKernel.java:1187:in `require'
#7 4.155 	org/jruby/RubyKernel.java:1216:in `require_relative'
#7 4.155 	/usr/share/logstash/vendor/jruby/lib/ruby/stdlib/rubygems/spec_fetcher.rb:2:in `<main>'
#7 4.155 	org/jruby/RubyKernel.java:1187:in `require'
#7 4.155 	org/jruby/RubyKernel.java:1216:in `require_relative'
#7 4.155 	/usr/share/logstash/vendor/jruby/lib/ruby/stdlib/rubygems/dependency_installer.rb:6:in `<main>'
#7 4.155 	org/jruby/RubyKernel.java:1187:in `require'
#7 4.155 	org/jruby/RubyKernel.java:1216:in `require_relative'
#7 4.155 	/usr/share/logstash/vendor/jruby/lib/ruby/stdlib/rubygems/commands/install_command.rb:4:in `<main>'
#7 4.155 	org/jruby/RubyKernel.java:1187:in `require'
#7 4.155 	/usr/share/logstash/vendor/jruby/lib/ruby/stdlib/rubygems/core_ext/kernel_require.rb:85:in `require'
#7 4.155 	/usr/share/logstash/vendor/jruby/lib/ruby/stdlib/rubygems/command_manager.rb:228:in `load_and_instantiate'
#7 4.155 	/usr/share/logstash/vendor/jruby/lib/ruby/stdlib/rubygems/command_manager.rb:135:in `[]'
#7 4.155 	/usr/share/logstash/vendor/jruby/lib/ruby/stdlib/rubygems/command_manager.rb:201:in `find_command'
#7 4.155 	/usr/share/logstash/vendor/jruby/lib/ruby/stdlib/rubygems/command_manager.rb:183:in `process_args'
#7 4.155 	/usr/share/logstash/vendor/jruby/lib/ruby/stdlib/rubygems/command_manager.rb:149:in `run'
#7 4.155 	/usr/share/logstash/vendor/jruby/lib/ruby/stdlib/rubygems/gem_runner.rb:51:in `run'
#7 4.155 	/usr/share/logstash/vendor/jruby/bin/jgem:21:in `<main>'
#7 4.155 	org/jruby/RubyKernel.java:1223:in `load'
#7 4.155 	/usr/share/logstash/vendor/jruby/bin/gem:4:in `<main>'
#7 4.248 ERROR:  While executing gem ... (NoMethodError)
#7 4.248     undefined method `deprecated?' for nil:NilClass
#7 4.251 	/usr/share/logstash/vendor/jruby/lib/ruby/stdlib/rubygems/command_manager.rb:184:in `process_args'
#7 4.251 	/usr/share/logstash/vendor/jruby/lib/ruby/stdlib/rubygems/command_manager.rb:149:in `run'
#7 4.251 	/usr/share/logstash/vendor/jruby/lib/ruby/stdlib/rubygems/gem_runner.rb:51:in `run'
#7 4.251 	/usr/share/logstash/vendor/jruby/bin/jgem:21:in `<main>'
#7 4.251 	org/jruby/RubyKernel.java:1223:in `load'
#7 4.251 	/usr/share/logstash/vendor/jruby/bin/gem:4:in `<main>'
#7 ERROR: process "/bin/sh -c gem install bundler:2.3.6" did not complete successfully: exit code: 1
```