### PR TITLE
feat(compactor HS): store index updates per processed segment in the manifest to the object storage

### DIFF
--- a/pkg/compactor/deletion/deletion_manifest_builder.go
+++ b/pkg/compactor/deletion/deletion_manifest_builder.go
@@ -235,3 +235,7 @@ func (d *deletionManifestBuilder) flushCurrentBatch(ctx context.Context) error {
 func (d *deletionManifestBuilder) buildObjectKey(filename string) string {
 	return path.Join(fmt.Sprint(d.creationTime.UnixNano()), filename)
 }
+
+func (d *deletionManifestBuilder) path() string {
+	return fmt.Sprint(d.creationTime.UnixNano())
+}

--- a/pkg/compactor/deletion/deletion_manifest_builder.go
+++ b/pkg/compactor/deletion/deletion_manifest_builder.go
@@ -229,7 +229,7 @@ func (d *deletionManifestBuilder) flushCurrentBatch(ctx context.Context) error {
 	d.segmentsCount++
 	d.overallChunksCount += d.currentSegmentChunksCount
 	d.currentSegmentChunksCount = 0
-	return d.deleteStoreClient.PutObject(ctx, d.buildObjectKey(fmt.Sprintf("%d.json", d.segmentsCount)), strings.NewReader(unsafeGetString(batchJSON)))
+	return d.deleteStoreClient.PutObject(ctx, d.buildObjectKey(fmt.Sprintf("%d.json", d.segmentsCount-1)), strings.NewReader(unsafeGetString(batchJSON)))
 }
 
 func (d *deletionManifestBuilder) buildObjectKey(filename string) string {

--- a/pkg/compactor/deletion/deletion_manifest_builder_test.go
+++ b/pkg/compactor/deletion/deletion_manifest_builder_test.go
@@ -586,7 +586,7 @@ func TestDeletionManifestBuilder(t *testing.T) {
 			require.Equal(t, tc.expectedManifest, manifest)
 
 			for i := 0; i < tc.expectedManifest.SegmentsCount; i++ {
-				reader, _, err := builder.deleteStoreClient.GetObject(context.Background(), builder.buildObjectKey(fmt.Sprintf("%d.json", i+1)))
+				reader, _, err := builder.deleteStoreClient.GetObject(context.Background(), builder.buildObjectKey(fmt.Sprintf("%d.json", i)))
 				require.NoError(t, err)
 
 				segmentJSON, err := io.ReadAll(reader)

--- a/pkg/compactor/deletion/job_builder.go
+++ b/pkg/compactor/deletion/job_builder.go
@@ -178,12 +178,12 @@ func (b *JobBuilder) processManifest(ctx context.Context, manifestPath string, j
 
 // uploadIndexUpdateForCurrentSegment uploads the index updates for the currently processed segment to the object storage
 func (b *JobBuilder) uploadIndexUpdateForCurrentSegment(ctx context.Context, path string) error {
-	indexUpdatesJson, err := b.currSegmentIndexUpdates.encode()
+	indexUpdatesJSON, err := b.currSegmentIndexUpdates.encode()
 	if err != nil {
 		return err
 	}
 
-	return b.deleteStoreClient.PutObject(ctx, path, bytes.NewReader(indexUpdatesJson))
+	return b.deleteStoreClient.PutObject(ctx, path, bytes.NewReader(indexUpdatesJSON))
 }
 
 func (b *JobBuilder) waitForSegmentCompletion(ctx context.Context) error {

--- a/pkg/compactor/deletion/job_builder.go
+++ b/pkg/compactor/deletion/job_builder.go
@@ -102,7 +102,7 @@ func (b *JobBuilder) processManifest(ctx context.Context, manifestPath string, j
 	b.currentManifestMtx.Unlock()
 
 	// Process segments sequentially
-	for segmentNum := 1; ctx.Err() == nil && segmentNum <= manifest.SegmentsCount; segmentNum++ {
+	for segmentNum := 0; ctx.Err() == nil && segmentNum < manifest.SegmentsCount; segmentNum++ {
 		level.Info(util_log.Logger).Log("msg", "starting segment processing",
 			"manifest", manifestPath,
 			"segment", segmentNum)

--- a/pkg/compactor/deletion/job_builder_test.go
+++ b/pkg/compactor/deletion/job_builder_test.go
@@ -339,7 +339,7 @@ func TestJobBuilder_ProcessManifest(t *testing.T) {
 			}
 			segmentData, err := json.Marshal(segment)
 			require.NoError(t, err)
-			err = objectClient.PutObject(context.Background(), "test-manifest/1.json", bytes.NewReader(segmentData))
+			err = objectClient.PutObject(context.Background(), "test-manifest/0.json", bytes.NewReader(segmentData))
 			require.NoError(t, err)
 
 			jobsChan := make(chan *grpc.Job)

--- a/pkg/compactor/deletion/job_builder_test.go
+++ b/pkg/compactor/deletion/job_builder_test.go
@@ -304,7 +304,7 @@ func TestJobBuilder_buildJobs(t *testing.T) {
 				cnt := 0
 				for job := range jobsChan {
 					jobsBuilt = append(jobsBuilt, *job)
-					err = builder.OnJobResponse(&grpc.JobResult{
+					err := builder.OnJobResponse(&grpc.JobResult{
 						JobId:   job.Id,
 						JobType: job.Type,
 						Result:  mustMarshal(t, buildDeletionJobResult(cnt)),

--- a/pkg/compactor/jobqueue/queue_test.go
+++ b/pkg/compactor/jobqueue/queue_test.go
@@ -24,12 +24,14 @@ type mockBuilder struct {
 	jobsFailed    atomic.Int32
 }
 
-func (m *mockBuilder) OnJobResponse(res *compactor_grpc.JobResult) {
+func (m *mockBuilder) OnJobResponse(res *compactor_grpc.JobResult) error {
 	if res.Error != "" {
 		m.jobsFailed.Inc()
 	} else {
 		m.jobsSucceeded.Inc()
 	}
+
+	return nil
 }
 
 func (m *mockBuilder) BuildJobs(ctx context.Context, jobsChan chan<- *compactor_grpc.Job) {


### PR DESCRIPTION
**What this PR does / why we need it**:
With this PR, we are adding support to persist index updates we need to make to the index files once we are done processing all the segments in the deletion manifest. Index updates are stored per segment since the manifest processing is resumable on the segment level.

**Checklist**
- [x] Tests updated
