### PR TITLE
fix(pattern): Fix feature flag for enabling pattern persistence

### DIFF
--- a/pkg/pattern/ingester.go
+++ b/pkg/pattern/ingester.go
@@ -398,12 +398,12 @@ func (i *Ingester) GetOrCreateInstance(instanceID string) (*instance, error) { /
 	inst, ok = i.instances[instanceID]
 	if !ok {
 		var err error
-		var writer aggregation.EntryWriter
+		metricAggregationMetrics := aggregation.NewMetrics(i.registerer)
 
+		var metricWriter aggregation.EntryWriter
 		aggCfg := i.cfg.MetricAggregation
 		if i.limits.MetricAggregationEnabled(instanceID) {
-			metricAggregationMetrics := aggregation.NewMetrics(i.registerer)
-			writer, err = aggregation.NewPush(
+			metricWriter, err = aggregation.NewPush(
 				aggCfg.LokiAddr,
 				instanceID,
 				aggCfg.WriteTimeout,
@@ -413,13 +413,35 @@ func (i *Ingester) GetOrCreateInstance(instanceID string) (*instance, error) { /
 				string(aggCfg.BasicAuth.Password),
 				aggCfg.UseTLS,
 				&aggCfg.BackoffConfig,
-				i.logger,
+				log.With(i.logger, "writer", "metric-aggregation"),
 				metricAggregationMetrics,
 			)
 			if err != nil {
 				return nil, err
 			}
 		}
+
+		var patternWriter aggregation.EntryWriter
+		patternCfg := i.cfg.PatternPersistence
+		if patternCfg.Enabled && i.limits.PatternPersistenceEnabled(instanceID) {
+			metricWriter, err = aggregation.NewPush(
+				patternCfg.LokiAddr,
+				instanceID,
+				patternCfg.WriteTimeout,
+				patternCfg.PushPeriod,
+				patternCfg.HTTPClientConfig,
+				patternCfg.BasicAuth.Username,
+				string(patternCfg.BasicAuth.Password),
+				patternCfg.UseTLS,
+				&patternCfg.BackoffConfig,
+				log.With(i.logger, "writer", "pattern"),
+				metricAggregationMetrics,
+			)
+			if err != nil {
+				return nil, err
+			}
+		}
+
 		inst, err = newInstance(
 			instanceID,
 			i.logger,
@@ -428,7 +450,8 @@ func (i *Ingester) GetOrCreateInstance(instanceID string) (*instance, error) { /
 			i.limits,
 			i.ringClient,
 			i.lifecycler.ID,
-			writer,
+			metricWriter,
+			patternWriter,
 		)
 		if err != nil {
 			return nil, err
@@ -461,8 +484,8 @@ func (i *Ingester) stopWriters() {
 	instances := i.getInstances()
 
 	for _, instance := range instances {
-		if instance.writer != nil {
-			instance.writer.Stop()
+		if instance.metricWriter != nil {
+			instance.metricWriter.Stop()
 		}
 	}
 }

--- a/pkg/pattern/ingester_test.go
+++ b/pkg/pattern/ingester_test.go
@@ -59,6 +59,7 @@ func TestInstancePushQuery(t *testing.T) {
 		ringClient,
 		ingesterID,
 		mockWriter,
+		mockWriter,
 	)
 	require.NoError(t, err)
 
@@ -244,6 +245,7 @@ func TestInstancePushAggregateMetrics(t *testing.T) {
 			&fakeLimits{},
 			ringClient,
 			ingesterID,
+			mockWriter,
 			mockWriter,
 		)
 		require.NoError(t, err)


### PR DESCRIPTION
**What this PR does / why we need it**:

PR https://github.com/grafana/loki/pull/17737 introduced a feature to persist detected patterns on the pattern ingesters. And while there is a dedicated global config `PatternPersistence` and a per-tenant config `PatternPersistenceEnabled`, none of these were honoured, because for writing the patterns to the distributor, the same writer (and its config) as for persisting aggregated metrics is used. So, when aggregated metrics is enabled, also patterns were automatically written/persisted as well.