### PR TITLE
docs: backport storage fix 3.4

### DIFF
--- a/docs/sources/configure/storage.md
+++ b/docs/sources/configure/storage.md
@@ -281,7 +281,7 @@ schema_config:
   configs:
     - from: 2020-07-01
       store: tsdb
-      object_store: aws
+      object_store: s3
       schema: v13
       index:
         prefix: index_


### PR DESCRIPTION
**What this PR does / why we need it**:

Manual backport of https://github.com/grafana/loki/pull/18203 to 3.4 branch.

