### PR TITLE
fix(memberlist): allow resolution of advertise address from v6 interf…

### DIFF
--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -1624,6 +1624,8 @@ func (t *Loki) initMemberlistKV() (services.Service, error) {
 	)
 	dnsProvider := dns.NewProvider(util_log.Logger, dnsProviderReg, dns.GolangResolverType)
 
+	// TODO(ashwanth): This is not considering component specific overrides for InstanceInterfaceNames.
+	// This should be fixed in the future.
 	var err error
 	t.Cfg.MemberlistKV.AdvertiseAddr, err = ring.GetInstanceAddr(
 		t.Cfg.MemberlistKV.AdvertiseAddr,


### PR DESCRIPTION
**What this PR does / why we need it**:

https://github.com/grafana/loki/pull/13940 introduced a change for memberlist to pick address from the interfaces defined  in common `instance_interface_names` (previously it iterated over all available interfaces), but the method used only resolves v4 addresses.

This breaks memberlist for anyone using v6 only interfaces. This PR updates memberlist to look-up `t.Cfg.Common.Ring.EnableIPv6` flag to enable the resolution of v6 addresses.

Note: Individual components are allowed to specify their own list of interfaces using `<component_name>.ring.instance-interface-names` but memberlist does not consider the component specific setting yet. This should be fixed in the long term.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
