### PR TITLE
feat: Use the event emitter for errors in the fluentd output plugin

### DIFF
--- a/clients/cmd/fluentd/.rubocop.yml
+++ b/clients/cmd/fluentd/.rubocop.yml
@@ -1,17 +1,17 @@
-require: rubocop-rspec
+plugins: rubocop-rspec
 
 AllCops:
   TargetRubyVersion: 2.7
   NewCops: disable
   Exclude:
-    - 'bin/**'
-    - 'test/**/*.rb'
+    - "bin/**"
+    - "test/**/*.rb"
 
 Metrics/BlockLength:
   Exclude:
-    - 'Rakefile'
-    - '**/*.rake'
-    - 'spec/**/*.rb'
+    - "Rakefile"
+    - "**/*.rake"
+    - "spec/**/*.rb"
   Max: 60
 Metrics/MethodLength:
   Max: 50

--- a/clients/cmd/fluentd/Makefile
+++ b/clients/cmd/fluentd/Makefile
@@ -13,7 +13,7 @@ clean:
 .bundle:
 	ruby --version
 	@echo ""
-	ruby -S gem install bundler --version 2.3.4
+	ruby -S gem install bundler --version 2.6.9
 	ruby -S bundle config silence_root_warning true
 	ruby -S bundle config set --local path ./vendor/bundle
 

--- a/clients/cmd/fluentd/bin/setup
+++ b/clients/cmd/fluentd/bin/setup
@@ -4,6 +4,6 @@ set -euo pipefail
 
 ruby --version
 echo ""
-ruby -S gem install bundler --version 2.3.4
+ruby -S gem install bundler --version 2.6.9
 ruby -S bundle config set --local path $(pwd)/vendor/bundle
 ruby -S bundle install

--- a/clients/cmd/fluentd/docker/conf/loki.conf
+++ b/clients/cmd/fluentd/docker/conf/loki.conf
@@ -2,8 +2,22 @@
   @type loki
   url "#{ENV['LOKI_URL']}"
   extra_labels {"job":"fluentd"}
-  <buffer>
+  <buffer tag>
     flush_interval 10s
     flush_at_shutdown true
   </buffer>
 </match>
+
+<label @ERROR>
+  <filter **>
+    @type         record_transformer
+    enable_ruby   false
+    <record>
+      from_error  "hell yes"
+    </record>
+  </filter>
+
+  <match **>
+    @type stdout
+  </match>
+</label>

--- a/clients/cmd/fluentd/docker/docker-compose.yml
+++ b/clients/cmd/fluentd/docker/docker-compose.yml
@@ -5,9 +5,7 @@ services:
       dockerfile: ./cmd/loki/Dockerfile
     image: grafana/loki:main
     ports:
-      - 3100
-    volumes:
-    - ./fluentd.conf:/fluentd/etc/fluent.conf
+      - 3100:3100
 
   # Receive forwarded logs and send to /fluentd/logs/data.log and loki
   fluentd:
@@ -15,12 +13,16 @@ services:
       context: ../../../../
       dockerfile: ./clients/cmd/fluentd/Dockerfile
     image: grafana/fluent-plugin-loki:main
+    ports:
+      - 8080:8080
     volumes:
-    - ./fluentd.conf:/fluentd/etc/fluent.conf
+      - ./fluentd.conf:/fluentd/etc/fluent.conf
+      - ./conf/loki.conf:/fluentd/etc/loki.conf
+      - ../lib/fluent/plugin/out_loki.rb:/fluentd/plugins/out_loki.rb
     environment:
-      - LOKI_URL
+      - LOKI_URL=http://loki:3100
     depends_on:
-    - loki
+      - loki
 
   # Read /var/log/syslog and send it to fluentd
   fluentbit:
@@ -28,8 +30,8 @@ services:
     command: "/fluent-bit/bin/fluent-bit -c /srv/fluent-bit.conf"
     user: root
     volumes:
-    - ./fluent-bit.conf:/srv/fluent-bit.conf
-    - /var/log/syslog:/var/log/syslog:ro
+      - ./fluent-bit.conf:/srv/fluent-bit.conf
+      - /var/log/syslog:/var/log/syslog:ro
     depends_on:
-    - fluentd
-    - loki
+      - fluentd
+      - loki

--- a/clients/cmd/fluentd/docker/fluentd.conf
+++ b/clients/cmd/fluentd/docker/fluentd.conf
@@ -1,8 +1,20 @@
+<system>
+  log_level debug
+</system>
+
 <source>
-    @type forward
-    port 24224
+  @type forward
+  port 24224
 </source>
-<filter **>
-    @type stdout
-</filter>
+
+<source>
+  @type http
+  port 8080
+  bind 0.0.0.0
+  <parse>
+    @type json
+    time_format %iso8601
+  </parse>
+</source>
+
 @include loki.conf

--- a/clients/cmd/fluentd/lib/fluent/plugin/out_loki.rb
+++ b/clients/cmd/fluentd/lib/fluent/plugin/out_loki.rb
@@ -323,6 +323,10 @@ module Fluent
       end
       # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
+      def current_thread_label
+        Thread.current[:_fluentd_plugin_helper_thread_title].to_s
+      end
+
       # convert a line to loki line with labels
       # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
       def line_to_loki(record)
@@ -359,7 +363,7 @@ module Fluent
         # note that flush thread != fluentd worker. if you use multiple workers you still need to
         # add the worker id as a label
         if @include_thread_label && @buffer_config.flush_thread_count > 1
-          chunk_labels['fluentd_thread'] = Thread.current[:_fluentd_plugin_helper_thread_title].to_s
+          chunk_labels['fluentd_thread'] = current_thread_label
         end
 
         # return both the line content plus the labels found in the record


### PR DESCRIPTION
This update extends the fluentd output plugin to send logs that have failed to be sent to loki into the fluentd `@error` label, thus allowing users to decide what they would like to do with them.

Fixes #6547

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
