### PR TITLE
fix(config_wrapper): apply `instance_enable_ipv6` from common to all components

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -2931,6 +2931,10 @@ The `frontend` block configures the Loki query-frontend.
 # CLI flag: -frontend.instance-interface-names
 [instance_interface_names: <list of strings> | default = [<private network interfaces>]]
 
+# Enable using a IPv6 instance address (default false).
+# CLI flag: -frontend.instance-enable-ipv6
+[instance_enable_ipv6: <boolean> | default = false]
+
 # Defines the encoding for requests to and responses from the scheduler and
 # querier. Can be 'json' or 'protobuf' (defaults to 'json').
 # CLI flag: -frontend.encoding

--- a/pkg/loki/config_wrapper.go
+++ b/pkg/loki/config_wrapper.go
@@ -244,6 +244,7 @@ func applyConfigToRings(r, defaults *ConfigWrapper, rc lokiring.RingConfig, merg
 		r.Ingester.LifecyclerConfig.Zone = rc.InstanceZone
 		r.Ingester.LifecyclerConfig.ListenPort = rc.ListenPort
 		r.Ingester.LifecyclerConfig.ObservePeriod = rc.ObservePeriod
+		r.Ingester.LifecyclerConfig.EnableInet6 = rc.EnableIPv6
 		r.Ingester.KafkaIngestion.PartitionRingConfig.KVStore = rc.KVStore
 	}
 
@@ -260,6 +261,7 @@ func applyConfigToRings(r, defaults *ConfigWrapper, rc lokiring.RingConfig, merg
 		r.Pattern.LifecyclerConfig.Zone = rc.InstanceZone
 		r.Pattern.LifecyclerConfig.ListenPort = rc.ListenPort
 		r.Pattern.LifecyclerConfig.ObservePeriod = rc.ObservePeriod
+		r.Pattern.LifecyclerConfig.EnableInet6 = rc.EnableIPv6
 	}
 
 	// IngestLimits
@@ -276,6 +278,7 @@ func applyConfigToRings(r, defaults *ConfigWrapper, rc lokiring.RingConfig, merg
 		r.IngestLimits.LifecyclerConfig.Zone = rc.InstanceZone
 		r.IngestLimits.LifecyclerConfig.ListenPort = rc.ListenPort
 		r.IngestLimits.LifecyclerConfig.ObservePeriod = rc.ObservePeriod
+		r.IngestLimits.LifecyclerConfig.EnableInet6 = rc.EnableIPv6
 	}
 
 	// IngestLimitsFrontend
@@ -292,6 +295,7 @@ func applyConfigToRings(r, defaults *ConfigWrapper, rc lokiring.RingConfig, merg
 		r.IngestLimitsFrontend.LifecyclerConfig.Zone = rc.InstanceZone
 		r.IngestLimitsFrontend.LifecyclerConfig.ListenPort = rc.ListenPort
 		r.IngestLimitsFrontend.LifecyclerConfig.ObservePeriod = rc.ObservePeriod
+		r.IngestLimitsFrontend.LifecyclerConfig.EnableInet6 = rc.EnableIPv6
 	}
 
 	// Distributor
@@ -303,6 +307,7 @@ func applyConfigToRings(r, defaults *ConfigWrapper, rc lokiring.RingConfig, merg
 		r.Distributor.DistributorRing.InstanceID = rc.InstanceID
 		r.Distributor.DistributorRing.InstanceInterfaceNames = rc.InstanceInterfaceNames
 		r.Distributor.DistributorRing.KVStore = rc.KVStore
+		r.Distributor.DistributorRing.EnableIPv6 = rc.EnableIPv6
 	}
 
 	// Ruler
@@ -314,6 +319,7 @@ func applyConfigToRings(r, defaults *ConfigWrapper, rc lokiring.RingConfig, merg
 		r.Ruler.Ring.InstanceID = rc.InstanceID
 		r.Ruler.Ring.InstanceInterfaceNames = rc.InstanceInterfaceNames
 		r.Ruler.Ring.KVStore = rc.KVStore
+		r.Ruler.Ring.EnableIPv6 = rc.EnableIPv6
 	}
 
 	// Query Scheduler
@@ -327,6 +333,7 @@ func applyConfigToRings(r, defaults *ConfigWrapper, rc lokiring.RingConfig, merg
 		r.QueryScheduler.SchedulerRing.InstanceZone = rc.InstanceZone
 		r.QueryScheduler.SchedulerRing.ZoneAwarenessEnabled = rc.ZoneAwarenessEnabled
 		r.QueryScheduler.SchedulerRing.KVStore = rc.KVStore
+		r.QueryScheduler.SchedulerRing.EnableIPv6 = rc.EnableIPv6
 	}
 
 	// Compactor
@@ -340,6 +347,7 @@ func applyConfigToRings(r, defaults *ConfigWrapper, rc lokiring.RingConfig, merg
 		r.CompactorConfig.CompactorRing.InstanceZone = rc.InstanceZone
 		r.CompactorConfig.CompactorRing.ZoneAwarenessEnabled = rc.ZoneAwarenessEnabled
 		r.CompactorConfig.CompactorRing.KVStore = rc.KVStore
+		r.CompactorConfig.CompactorRing.EnableIPv6 = rc.EnableIPv6
 	}
 
 	// IndexGateway
@@ -353,6 +361,7 @@ func applyConfigToRings(r, defaults *ConfigWrapper, rc lokiring.RingConfig, merg
 		r.IndexGateway.Ring.InstanceZone = rc.InstanceZone
 		r.IndexGateway.Ring.ZoneAwarenessEnabled = rc.ZoneAwarenessEnabled
 		r.IndexGateway.Ring.KVStore = rc.KVStore
+		r.IndexGateway.Ring.EnableIPv6 = rc.EnableIPv6
 	}
 }
 

--- a/pkg/loki/config_wrapper_test.go
+++ b/pkg/loki/config_wrapper_test.go
@@ -2297,6 +2297,24 @@ common:
 		assert.Equal(t, []string{"ringsshouldntusethis"}, config.Frontend.FrontendV2.InfNames) // not a ring.
 		assert.Equal(t, []string{"ringsshouldusethis"}, config.CompactorConfig.CompactorRing.InstanceInterfaceNames)
 	})
+
+	t.Run("enable_ipv6 setting is propagated from common ring to all component rings", func(t *testing.T) {
+		yamlContent := `common:
+  ring:
+    instance_enable_ipv6: true`
+
+		config, _, err := configWrapperFromYAML(t, yamlContent, nil)
+		assert.NoError(t, err)
+		assert.True(t, config.Distributor.DistributorRing.EnableIPv6)
+		assert.True(t, config.Ingester.LifecyclerConfig.EnableInet6)
+		assert.True(t, config.IngestLimits.LifecyclerConfig.EnableInet6)
+		assert.True(t, config.IngestLimitsFrontend.LifecyclerConfig.EnableInet6)
+		assert.True(t, config.Ruler.Ring.EnableIPv6)
+		assert.True(t, config.QueryScheduler.SchedulerRing.EnableIPv6)
+		assert.True(t, config.CompactorConfig.CompactorRing.EnableIPv6)
+		assert.True(t, config.IndexGateway.Ring.EnableIPv6)
+		assert.True(t, config.Pattern.LifecyclerConfig.EnableInet6)
+	})
 }
 
 func TestNamedStores_applyDefaults(t *testing.T) {

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -24,7 +24,6 @@ import (
 	"github.com/grafana/dskit/kv/codec"
 	"github.com/grafana/dskit/kv/memberlist"
 	"github.com/grafana/dskit/middleware"
-	"github.com/grafana/dskit/netutil"
 	"github.com/grafana/dskit/ring"
 	"github.com/grafana/dskit/runtimeconfig"
 	"github.com/grafana/dskit/server"
@@ -1626,10 +1625,11 @@ func (t *Loki) initMemberlistKV() (services.Service, error) {
 	dnsProvider := dns.NewProvider(util_log.Logger, dnsProviderReg, dns.GolangResolverType)
 
 	var err error
-	t.Cfg.MemberlistKV.AdvertiseAddr, err = GetInstanceAddr(
+	t.Cfg.MemberlistKV.AdvertiseAddr, err = ring.GetInstanceAddr(
 		t.Cfg.MemberlistKV.AdvertiseAddr,
-		t.Cfg.Common.InstanceInterfaceNames,
+		t.Cfg.Common.Ring.InstanceInterfaceNames,
 		util_log.Logger,
+		t.Cfg.Common.Ring.EnableIPv6,
 	)
 	if err != nil {
 		return nil, err
@@ -2372,12 +2372,4 @@ func schemaHasBoltDBShipperConfig(scfg config.SchemaConfig) bool {
 	}
 
 	return false
-}
-
-func GetInstanceAddr(addr string, netInterfaces []string, logger log.Logger) (string, error) {
-	if addr != "" {
-		return addr, nil
-	}
-
-	return netutil.GetFirstAddressOf(netInterfaces, logger, false)
 }

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -1624,6 +1624,8 @@ func (t *Loki) initMemberlistKV() (services.Service, error) {
 	)
 	dnsProvider := dns.NewProvider(util_log.Logger, dnsProviderReg, dns.GolangResolverType)
 
+	// TODO(ashwanth): This is not considering component specific overrides for InstanceInterfaceNames.
+	// This should be fixed in the future.
 	var err error
 	t.Cfg.MemberlistKV.AdvertiseAddr, err = ring.GetInstanceAddr(
 		t.Cfg.MemberlistKV.AdvertiseAddr,

--- a/pkg/lokifrontend/frontend/config.go
+++ b/pkg/lokifrontend/frontend/config.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/go-kit/log"
+	"github.com/grafana/dskit/netutil"
 	"github.com/grafana/dskit/ring"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
@@ -13,7 +14,6 @@ import (
 	v1 "github.com/grafana/loki/v3/pkg/lokifrontend/frontend/v1"
 	v2 "github.com/grafana/loki/v3/pkg/lokifrontend/frontend/v2"
 	"github.com/grafana/loki/v3/pkg/querier/queryrange/queryrangebase"
-	"github.com/grafana/loki/v3/pkg/util"
 )
 
 // This struct combines several configuration options together to preserve backwards compatibility.
@@ -48,7 +48,7 @@ func InitFrontend(cfg CombinedFrontendConfig, ring ring.ReadRing, limits v1.Limi
 	case cfg.FrontendV2.SchedulerAddress != "" || ring != nil:
 		// If query-scheduler address is configured, use Frontend.
 		if cfg.FrontendV2.Addr == "" {
-			addr, err := util.GetFirstAddressOf(cfg.FrontendV2.InfNames, log)
+			addr, err := netutil.GetFirstAddressOf(cfg.FrontendV2.InfNames, log, cfg.FrontendV2.EnableIPv6)
 			if err != nil {
 				return nil, nil, nil, errors.Wrap(err, "failed to get frontend address")
 			}

--- a/pkg/lokifrontend/frontend/v2/frontend.go
+++ b/pkg/lokifrontend/frontend/v2/frontend.go
@@ -51,7 +51,8 @@ type Config struct {
 	GracefulShutdownTimeout time.Duration     `yaml:"graceful_shutdown_timeout"`
 
 	// Used to find local IP address, that is sent to scheduler and querier-worker.
-	InfNames []string `yaml:"instance_interface_names" doc:"default=[<private network interfaces>]"`
+	InfNames   []string `yaml:"instance_interface_names" doc:"default=[<private network interfaces>]"`
+	EnableIPv6 bool     `yaml:"instance_enable_ipv6"`
 
 	// If set, address is not computed from interfaces.
 	Addr string `yaml:"address" doc:"hidden"`
@@ -69,6 +70,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 
 	cfg.InfNames = netutil.PrivateNetworkInterfacesWithFallback([]string{"eth0", "en0"}, util_log.Logger)
 	f.Var((*flagext.StringSlice)(&cfg.InfNames), "frontend.instance-interface-names", "Name of network interface to read address from. This address is sent to query-scheduler and querier, which uses it to send the query response back to query-frontend.")
+	f.BoolVar(&cfg.EnableIPv6, "frontend.instance-enable-ipv6", false, "Enable using a IPv6 instance address (default false).")
 	f.StringVar(&cfg.Addr, "frontend.instance-addr", "", "IP address to advertise to querier (via scheduler) (resolved via interfaces by default).")
 	f.IntVar(&cfg.Port, "frontend.instance-port", 0, "Port to advertise to querier (via scheduler) (defaults to server.grpc-listen-port).")
 


### PR DESCRIPTION
**What this PR does / why we need it**:

`instance_enable_ipv6` ring setting from common config is not being applied to component rings. Updated to apply this same as other ring settings.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
