### PR TITLE
chore(tailer): fix a flaky tests in tail/querier_test.go

### DIFF
--- a/pkg/querier/tail/querier_test.go
+++ b/pkg/querier/tail/querier_test.go
@@ -60,6 +60,7 @@ func TestQuerier_Tail_QueryTimeoutConfigFlag(t *testing.T) {
 	}
 	ingester.On("Tail", mock.Anything, &request).Return(clients, nil)
 	ingester.On("TailersCount", mock.Anything).Return([]uint32{0}, nil)
+	ingester.On("TailDisconnectedIngesters", mock.Anything, mock.Anything, mock.Anything).Return(map[string]logproto.Querier_TailClient{}, nil).Maybe()
 
 	// Setup log selector mock
 	logSelector := newMockTailLogSelector()
@@ -153,6 +154,7 @@ func TestQuerier_concurrentTailLimits(t *testing.T) {
 			}
 			ingester.On("Tail", mock.Anything, &request).Return(clients, testData.ingesterError)
 			ingester.On("TailersCount", mock.Anything).Return([]uint32{testData.tailersCount}, testData.ingesterError)
+			ingester.On("TailDisconnectedIngesters", mock.Anything, mock.Anything, mock.Anything).Return(map[string]logproto.Querier_TailClient{}, nil).Maybe()
 
 			// Setup log selector mock
 			logSelector := newMockTailLogSelector()

--- a/pkg/querier/tail/tail_mock_test.go
+++ b/pkg/querier/tail/tail_mock_test.go
@@ -6,6 +6,7 @@ import (
 
 	grpc_metadata "google.golang.org/grpc/metadata"
 
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/mock"
 
 	"github.com/grafana/loki/v3/pkg/compactor/deletion"
@@ -103,7 +104,9 @@ func (c *tailClientMock) RecvMsg(_ interface{}) error {
 }
 
 func (c *tailClientMock) mockRecvWithTrigger(response *logproto.TailResponse) *tailClientMock {
-	c.On("Recv").WaitUntil(c.recvTrigger).Return(response, nil)
+	c.On("Recv").WaitUntil(c.recvTrigger).Return(response, nil).Times(1)
+	// return error on subsequent calls to break the tailer client loop
+	c.On("Recv").Return((*logproto.TailResponse)(nil), errors.New("connection closed"))
 	return c
 }
 

--- a/pkg/querier/tail/tail_mock_test.go
+++ b/pkg/querier/tail/tail_mock_test.go
@@ -6,7 +6,6 @@ import (
 
 	grpc_metadata "google.golang.org/grpc/metadata"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/mock"
 
 	"github.com/grafana/loki/v3/pkg/compactor/deletion"
@@ -104,9 +103,7 @@ func (c *tailClientMock) RecvMsg(_ interface{}) error {
 }
 
 func (c *tailClientMock) mockRecvWithTrigger(response *logproto.TailResponse) *tailClientMock {
-	c.On("Recv").WaitUntil(c.recvTrigger).Return(response, nil).Times(1)
-	// return error on subsequent calls to break the tailer client loop
-	c.On("Recv").Return((*logproto.TailResponse)(nil), errors.New("connection closed"))
+	c.On("Recv").WaitUntil(c.recvTrigger).Return(response, nil)
 	return c
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Mock `TailDisconnectedIngesters` calls to return empty clients map. This func gets called periodically from the tailer's loop, not implementing it could result in a panic

```
TestQuerier_concurrentTailLimits/ring_containing_one_active_ingester_and_0_active_tailers (0.00s)
panic:
        assert: mock: I don't know what to return because the method call was unexpected.
                Either do Mock.On("TailDisconnectedIngesters").Return(...) first, or remove the TailDisconnectedIngesters() call.
                This method was unexpected:
                        TailDisconnectedIngesters(*context.valueCtx,*logproto.TailRequest,[]string)
                        0: &context.valueCtx{Context:context.backgroundCtx{emptyCtx:context.emptyCtx{}}, key:0, val:"test"}
                        1: &logproto.TailRequest{Query: "{type=\"test\"}",
        DelayFor: 0x0,
        Limit: 0xa,
        Start: time.Date(2025, time.June, 30, 13, 10, 45, 569837000, time.Local),
        Plan: &plan.QueryPlan{AST:(*syntax.MatchersExpr)(0x14000e00c48)},
        }
                        2: []string{"ingester-1"}
                at: [/Users/grafana/Workspace/loki/pkg/querier/tail/tail_mock_test.go:29 /Users/grafana/Workspace/loki/pkg/querier/tail/querier.go:134 /Users/grafana/Workspace/loki/pkg/querier/tail/tail.go:189 /Users/grafana/Workspace/loki/pkg/querier/tail/tail.go:94 /opt/homebrew/Cellar/go/1.24.1/libexec/src/runtime/asm_arm64.s:1223]

```

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
