### PR TITLE
chore: Fixup metric names for dataobj-consumer and histogram bucket

### DIFF
--- a/pkg/dataobj/uploader/metrics.go
+++ b/pkg/dataobj/uploader/metrics.go
@@ -29,17 +29,17 @@ func newMetrics(shaPrefixSize int) *metrics {
 			Help: "Total number of uploads to object storage.",
 		}),
 		uploadTime: prometheus.NewHistogram(prometheus.HistogramOpts{
-			Name:    "loki_dataobj_uploader_upload_time_seconds",
+			Name:    "loki_dataobj_consumer_upload_time_seconds",
 			Help:    "Time taken writing data objects to object storage.",
-			Buckets: prometheus.DefBuckets,
+			Buckets: prometheus.ExponentialBuckets(1.0, 1.5, 10), // 1s, 1.5s, 2.25s, ... -> 57.67s
 		}),
 		uploadSize: prometheus.NewHistogramVec(prometheus.HistogramOpts{
-			Name:    "loki_dataobj_uploader_upload_size_bytes",
+			Name:    "loki_dataobj_consumer_upload_size_bytes",
 			Help:    "Size of data objects uploaded to object storage in bytes grouped by status.",
 			Buckets: prometheus.LinearBuckets(128<<20, 128<<20, 10), // 128MB, 256MB, ... -> 1280MB
 		}, []string{labelStatus}),
 		shaPrefixSize: prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: "loki_dataobj_uploader_sha_prefix_size",
+			Name: "loki_dataobj_consumer_sha_prefix_size",
 			Help: "The size of the SHA prefix used for object storage keys.",
 		}),
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:


Use `loki_dataobj_consumer_` prefix for all uploader metrics.

Also change the default buckets for the upload time histogram metric to something more reasonable (problem see screenshot).

![screenshot_20250701_141634](https://github.com/user-attachments/assets/92cfa62e-641b-4995-8990-f6aff7a68a04)