### PR TITLE
docs: fix typo

### DIFF
--- a/docs/sources/send-data/fluentbit/fluent-bit-loki-tutorial.md
+++ b/docs/sources/send-data/fluentbit/fluent-bit-loki-tutorial.md
@@ -22,7 +22,6 @@ killercoda:
 
 In this tutorial, you will learn how to send logs to Loki using Fluent Bit. Fluent Bit is a lightweight and fast log processor and forwarder that can collect, process, and deliver logs to various destinations. We will use the official Fluent Bit Loki output plugin to send logs to Loki.
 
-
 <!-- INTERACTIVE ignore START -->
 
 ## Dependencies
@@ -67,23 +66,25 @@ Each service has been instrumented with the Fluent Bit logging framework to gene
 In this step, we will set up our environment by cloning the repository that contains our demo application and spinning up our observability stack using Docker Compose.
 
 1. To get started, clone the repository that contains our demo application:
-   
+
     ```bash
     git clone -b fluentbit-official  https://github.com/grafana/loki-fundamentals.git
     ```
 
-1.  Next we will spin up our observability stack using Docker Compose:
+1. Next we will spin up our observability stack using Docker Compose:
 
     ```bash
     docker compose -f loki-fundamentals/docker-compose.yml up -d
     ```
 
     This will spin up the following services:
+
     ```console
     ✔ Container loki-fundamentals-grafana-1       Started                                                        
     ✔ Container loki-fundamentals-loki-1          Started                        
     ✔ Container loki-fundamentals-fluent-bit-1    Started
     ```
+
 Once we have finished configuring the Fluent Bit agent and sending logs to Loki, we will be able to view the logs in Grafana. To check if Grafana is up and running, navigate to the following URL: [http://localhost:3000](http://localhost:3000)
 <!-- INTERACTIVE page step1.md END -->
 
@@ -99,6 +100,7 @@ Fluent Bit requires a configuration file to define the components and their rela
 
 {{< docs/ignore >}}
 > Note: Killercoda has an inbuilt Code editor which can be accessed via the `Editor` tab.
+
 1. Expand the `loki-fundamentals` directory in the file explorer of the `Editor` tab.
 1. Locate the `fluent-bit.conf` file in the top level directory, `loki-fundamentals`.
 1. Click on the `fluent-bit.conf` file to open it in the code editor.
@@ -112,11 +114,12 @@ Fluent Bit requires a configuration file to define the components and their rela
 
 You will copy all of the configuration snippets into the `fluent-bit.conf` file.
 
-### Receiving Fluent Bit protocal logs
+### Receiving Fluent Bit protocol logs
 
 The first step is to configure Fluent Bit to receive logs from the Carnivorous Greenhouse application. Since the application is instrumented with Fluent Bit logging framework, it will send logs using the forward protocol (unique to Fluent Bit). We will use the `forward` input plugin to receive logs from the application.
 
 Now add the following configuration to the `fluent-bit.conf` file:
+
 ```conf
 [INPUT]
     Name              forward
@@ -125,19 +128,19 @@ Now add the following configuration to the `fluent-bit.conf` file:
 ```
 
 In this configuration:
+
 - `Name`: The name of the input plugin. In this case, we are using the `forward` input plugin.
 - `Listen`: The IP address to listen on. In this case, we are listening on all IP addresses.
 - `Port`: The port to listen on. In this case, we are listening on port `24224`.
 
 For more information on the `forward` input plugin, see the [Fluent Bit Forward documentation](https://docs.fluentbit.io/manual/pipeline/inputs/forward).
 
-
-
 ### Export logs to Loki using the official Loki output plugin
 
 Lastly, we will configure Fluent Bit to export logs to Loki using the official Loki output plugin. The Loki output plugin allows you to send logs or events to a Loki service. It supports data enrichment with Kubernetes labels, custom label keys, and structured metadata.
 
 Add the following configuration to the `fluent-bit.conf` file:
+
 ```conf
 [OUTPUT]
     name   loki
@@ -149,6 +152,7 @@ Add the following configuration to the `fluent-bit.conf` file:
 ```
 
 In this configuration:
+
 - `name`: The name of the output plugin. In this case, we are using the `loki` output plugin.
 - `match`: The tag to match. In this case, we are matching all logs with the tag `service.**`.
 - `host`: The hostname of the Loki service. In this case, we are using the hostname `loki`.
@@ -161,14 +165,15 @@ For more information on the `loki` output plugin, see the [Fluent Bit Loki docum
 #### `logmap.json` file
 
 The `logmap.json` file is used to map the log fields to the Loki labels. In this tutorial we have pre-filled the `logmap.json` file with the following configuration:
+
 ```json
 {
 "service": "service_name",
 "instance_id": "instance_id"
  }
 ```
-This configuration maps the `service` field to the Loki label `service_name` and the `instance_id` field to the Loki label `instance_id`.
 
+This configuration maps the `service` field to the Loki label `service_name` and the `instance_id` field to the Loki label `instance_id`.
 
 ### Reload the Fluent Bit configuration
 
@@ -177,6 +182,7 @@ After adding the configuration to the `fluent-bit.conf` file, you will need to r
 ```bash
 docker restart loki-fundamentals-fluent-bit-1
 ```
+
 To verify that the configuration has been loaded successfully, you can check the Fluent Bit logs by running the following command:
 
 ```bash
@@ -216,6 +222,7 @@ docker compose -f loki-fundamentals/greenhouse/docker-compose-micro.yml up -d --
 ```
 
 This will start the following services:
+
 ```bash
  ✔ Container greenhouse-db-1                 Started                                                         
  ✔ Container greenhouse-websocket_service-1  Started 
@@ -235,7 +242,6 @@ Once started, you can access the Carnivorous Greenhouse application at [http://l
 
 Finally to view the logs in Loki, navigate to the Loki Logs Explore view in Grafana at [http://localhost:3000/a/grafana-lokiexplore-app/explore](http://localhost:3000/a/grafana-lokiexplore-app/explore).
 
-
 <!-- INTERACTIVE page step3.md END -->
 
 <!-- INTERACTIVE page finish.md START -->
@@ -247,14 +253,15 @@ In this tutorial, you learned how to send logs to Loki using Fluent Bit. You con
 {{< docs/ignore >}}
 
 ### Back to Docs
+
 Head back to where you started from to continue with the [Loki documentation](https://grafana.com/docs/loki/latest/send-data/alloy).
 
 {{< /docs/ignore >}}
 
-
 ## Further reading
 
 For more information on Fluent Bit, refer to the following resources:
+
 - [Fluent Bit documentation](https://docs.fluentbit.io/manual/)
 - [Other examples of Fluent Bit configurations](https://grafana.com/docs/loki/latest/send-data/fluentbit/)
 
@@ -263,6 +270,5 @@ For more information on Fluent Bit, refer to the following resources:
 If you would like to use a demo that includes Mimir, Loki, Tempo, and Grafana, you can use [Introduction to Metrics, Logs, Traces, and Profiling in Grafana](https://github.com/grafana/intro-to-mlt). `Intro-to-mltp` provides a self-contained environment for learning about Mimir, Loki, Tempo, and Grafana.
 
 The project includes detailed explanations of each component and annotated configurations for a single-instance deployment. Data from `intro-to-mltp` can also be pushed to Grafana Cloud.
-
 
 <!-- INTERACTIVE page finish.md END -->


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes typo in headed reported via Docs @ granfana email.
Also fixes some Linting issues regarding spaces for code blocks, lists etc.