### PR TITLE
fix(helm): Fix PDB settings for chunksCache and resultsCache

### DIFF
--- a/docs/sources/setup/install/helm/reference.md
+++ b/docs/sources/setup/install/helm/reference.md
@@ -2028,6 +2028,15 @@ true
 </td>
 		</tr>
 		<tr>
+			<td>chunksCache.maxUnavailable</td>
+			<td>int</td>
+			<td>Pod Disruption Budget maxUnavailable</td>
+			<td><pre lang="json">
+1
+</pre>
+</td>
+		</tr>
+		<tr>
 			<td>chunksCache.nodeSelector</td>
 			<td>object</td>
 			<td>Node selector for chunks-cache pods</td>
@@ -2111,17 +2120,6 @@ null
 			<td>Annotations for chunks-cache pods</td>
 			<td><pre lang="json">
 {}
-</pre>
-</td>
-		</tr>
-		<tr>
-			<td>chunksCache.podDisruptionBudget</td>
-			<td>object</td>
-			<td>Pod Disruption Budget</td>
-			<td><pre lang="json">
-{
-  "maxUnavailable": 1
-}
 </pre>
 </td>
 		</tr>
@@ -10350,6 +10348,15 @@ true
 </td>
 		</tr>
 		<tr>
+			<td>resultsCache.maxUnavailable</td>
+			<td>int</td>
+			<td>Pod Disruption Budget maxUnavailable</td>
+			<td><pre lang="json">
+1
+</pre>
+</td>
+		</tr>
+		<tr>
 			<td>resultsCache.nodeSelector</td>
 			<td>object</td>
 			<td>Node selector for results-cache pods</td>
@@ -10424,17 +10431,6 @@ null
 			<td>Annotations for results-cache pods</td>
 			<td><pre lang="json">
 {}
-</pre>
-</td>
-		</tr>
-		<tr>
-			<td>resultsCache.podDisruptionBudget</td>
-			<td>object</td>
-			<td>Pod Disruption Budget</td>
-			<td><pre lang="json">
-{
-  "maxUnavailable": 1
-}
 </pre>
 </td>
 		</tr>

--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -18,6 +18,7 @@ Entries should include a reference to the pull request that introduced the chang
 - [BUGFIX] Gateway Ingester endpoints points to inexistent service when zone aware replication are enabled [#17362](https://github.com/grafana/loki/pull/17362)
 - [BUGFIX] add missing flush=true to preStop hook [#16063](https://github.com/grafana/loki/pull/16063)
 - [BUGFIX] Fix setting X-Scope-OrgID header [#18414](https://github.com/grafana/loki/pull/18414)
+- [BUGFIX] Fix PDB settings for chunksCache and resultsCache [#18321](https://github.com/grafana/loki/pull/18321)
 
 ## 6.31.0
 

--- a/production/helm/loki/templates/chunks-cache/poddisruptionbudget-chunks-cache.yaml
+++ b/production/helm/loki/templates/chunks-cache/poddisruptionbudget-chunks-cache.yaml
@@ -1,4 +1,5 @@
 {{- if and .Values.chunksCache.enabled (.Values.memcached.enabled) }}
+{{- if gt (int .Values.chunksCache.replicas) 1 }}
 apiVersion: {{ include "loki.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
@@ -12,5 +13,8 @@ spec:
     matchLabels:
       {{- include "loki.selectorLabels" . | nindent 6 }}
       app.kubernetes.io/component: memcached-chunks-cache
-  maxUnavailable: 1
+  {{- with .Values.chunksCache.maxUnavailable }}
+  maxUnavailable: {{ . }}
+  {{- end -}}
 {{- end -}}
+{{- end }}

--- a/production/helm/loki/templates/results-cache/poddisruptionbudget-results-cache.yaml
+++ b/production/helm/loki/templates/results-cache/poddisruptionbudget-results-cache.yaml
@@ -1,4 +1,5 @@
 {{- if and .Values.resultsCache.enabled (.Values.memcached.enabled) }}
+{{- if gt (int .Values.resultsCache.replicas) 1 }}
 apiVersion: {{ include "loki.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
@@ -12,5 +13,8 @@ spec:
     matchLabels:
       {{- include "loki.selectorLabels" . | nindent 6 }}
       app.kubernetes.io/component: memcached-results-cache
-  maxUnavailable: 1
+  {{- with .Values.resultsCache.maxUnavailable }}
+  maxUnavailable: {{ . }}
+  {{- end -}}
 {{- end -}}
+{{- end }}

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -3299,9 +3299,8 @@ resultsCache:
   #  whenUnsatisfiable: ScheduleAnyway
   # -- Tolerations for results-cache pods
   tolerations: []
-  # -- Pod Disruption Budget
-  podDisruptionBudget:
-    maxUnavailable: 1
+  # -- Pod Disruption Budget maxUnavailable
+  maxUnavailable: 1
   # -- The name of the PriorityClass for results-cache pods
   priorityClassName: null
   # -- Labels for results-cache pods
@@ -3405,9 +3404,8 @@ chunksCache:
   #  whenUnsatisfiable: ScheduleAnyway
   # -- Tolerations for chunks-cache pods
   tolerations: []
-  # -- Pod Disruption Budget
-  podDisruptionBudget:
-    maxUnavailable: 1
+  # -- Pod Disruption Budget maxUnavailable
+  maxUnavailable: 1
   # -- The name of the PriorityClass for chunks-cache pods
   priorityClassName: null
   # -- Labels for chunks-cache pods


### PR DESCRIPTION

**What this PR does / why we need it**:
Fix PDB settings for chunksCache and resultsCache

The maxUnavailable variable was not used before. This adds the mechanism that the PDB is only deployed when the replicas are >1 and it also fixes the maxUnavailable variable

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [X] Documentation added
- [X] Tests updated
- [X] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [X] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [X] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
