### PR TITLE
chore(dataobj): avoid reading a predicate column more than once

### DIFF
--- a/pkg/dataobj/internal/dataset/reader.go
+++ b/pkg/dataobj/internal/dataset/reader.go
@@ -860,17 +860,18 @@ func (r *Reader) predicateColumns(p Predicate, keep func(c Column) bool) ([]Colu
 	ret := make([]Column, 0, len(columns))
 	idxs := make([]int, 0, len(columns))
 	for c := range columns {
-		if !keep(c) {
-			continue
-		}
-
 		idx, ok := r.origColumnLookup[c]
 		if !ok {
 			panic(fmt.Errorf("predicateColumns: column %v not found in Reader columns", c))
 		}
 
+		c := r.dl.AllColumns()[idx]
+		if !keep(c) {
+			continue
+		}
+
 		idxs = append(idxs, idx)
-		ret = append(ret, r.dl.AllColumns()[idx])
+		ret = append(ret, c)
 	}
 
 	return ret, idxs, nil


### PR DESCRIPTION
**What this PR does / why we need it**:

This fixes an issue where a predicate column was being read more than once. We have a check to avoid this, but the look-up was being done using wrong column instance

```
goos: darwin
goarch: arm64
pkg: github.com/grafana/loki/v3/pkg/logql/bench
cpu: Apple M1 Pro
                                                                                                                             │ stats.txt  │           stats_new.txt            │
                                                                                                                             │   sec/op   │   sec/op    vs base                │
LogQL/query=sum_by_(detected_level)_(count_over_time({region="ap-southeast-1"}[24h0m0s]))/kind=metric/store=dataobj-engine-8   7.340 ± 4%   4.737 ± 5%  -35.46% (p=0.000 n=20)
                                                                                                                             │     stats.txt      │               stats_new.txt               │
                                                                                                                             │ kilobytesProcessed │ kilobytesProcessed  vs base               │
LogQL/query=sum_by_(detected_level)_(count_over_time({region="ap-southeast-1"}[24h0m0s]))/kind=metric/store=dataobj-engine-8          443.5k ± 0%          430.7k ± 0%  -2.90% (p=0.000 n=20)
                                                                                                                             │  stats.txt   │         stats_new.txt          │
                                                                                                                             │     B/op     │     B/op      vs base          │
LogQL/query=sum_by_(detected_level)_(count_over_time({region="ap-southeast-1"}[24h0m0s]))/kind=metric/store=dataobj-engine-8   4.777Gi ± 1%   4.737Gi ± 1%  ~ (p=0.134 n=20)
                                                                                                                             │  stats.txt  │           stats_new.txt            │
                                                                                                                             │  allocs/op  │  allocs/op   vs base               │
LogQL/query=sum_by_(detected_level)_(count_over_time({region="ap-southeast-1"}[24h0m0s]))/kind=metric/store=dataobj-engine-8   20.58M ± 0%   20.56M ± 0%  -0.06% (p=0.000 n=20)

```

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
