### PR TITLE
chore(arrowtest): add utilities to construct arrow.Record from test rows

### DIFF
--- a/pkg/util/arrowtest/arrowtest.go
+++ b/pkg/util/arrowtest/arrowtest.go
@@ -2,13 +2,17 @@
 package arrowtest
 
 import (
+	"cmp"
 	"encoding/base64"
+	"fmt"
+	"slices"
 	"time"
 	"unsafe"
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/apache/arrow-go/v18/arrow/scalar"
 )
 
 type (
@@ -18,6 +22,105 @@ type (
 	// Row represents a single record row as a map of column name to value.
 	Row map[string]any
 )
+
+// Schema inferrs a [arrow.Schema] from each row in Rows. Columns in rows
+// are sorted alphabetically.
+//
+// Schema panics if any of the following conditions are true:
+//
+// - A value cannot be converted into an Arrow data type.
+// - Two rows have different sets of columns.
+// - Two columns do not have the same Go type across rows.
+func (rows Rows) Schema() *arrow.Schema {
+	if len(rows) == 0 {
+		// Empty schema.
+		return arrow.NewSchema(nil, nil)
+	}
+
+	var (
+		fields        = make([]arrow.Field, 0, len(rows[0]))
+		columnToField = make(map[string]int)
+	)
+
+	// Get all the fields from the first row.
+	for key, value := range rows[0] {
+		// If value is nil, we will replace it with the first non-nil value we see
+		// in the following loop.
+		field := arrow.Field{
+			Name:     key,
+			Type:     scalar.MakeScalar(value).DataType(),
+			Nullable: true,
+		}
+
+		columnToField[key] = len(fields)
+		fields = append(fields, field)
+	}
+
+	// Check the rest of the rows for consistency.
+	for _, row := range rows[1:] {
+		for key, value := range row {
+			index, ok := columnToField[key]
+			if !ok {
+				panic(fmt.Sprintf("arrowtest.Schema: column %q not found in first row", key))
+			}
+			field := &fields[index]
+
+			gotType := scalar.MakeScalar(value).DataType()
+
+			if !arrow.TypeEqual(field.Type, gotType) {
+				// The types don't match. We need to check for nulls here:
+				//
+				// If the expected type is null, we should replace it with a concrete
+				// type. If gotType is null, we can ignore it (null scalars can be
+				// casted appropriately).
+
+				if arrow.TypeEqual(field.Type, arrow.Null) {
+					field.Type = gotType
+				} else if !arrow.TypeEqual(gotType, arrow.Null) {
+					panic(fmt.Sprintf("arrowtest.Schema: column %q has different types across rows: got=%s, want=%s", key, gotType, field.Type))
+				}
+			}
+		}
+	}
+
+	slices.SortFunc(fields, func(a, b arrow.Field) int {
+		return cmp.Compare(a.Name, b.Name)
+	})
+
+	return arrow.NewSchema(fields, nil)
+}
+
+// Record converts rows into an [arrow.Record] with the provided schema. A
+// schema can be inferred from rows by using [Rows.Schema].
+//
+// The returned record must be Release()'d after use.
+//
+// Record panics if schema references a column not found in one of the rows.
+func (rows Rows) Record(alloc memory.Allocator, schema *arrow.Schema) arrow.Record {
+	builder := array.NewRecordBuilder(alloc, schema)
+	defer builder.Release()
+
+	for i := range schema.NumFields() {
+		field := schema.Field(i)
+		fieldBuilder := builder.Field(i)
+
+		for _, row := range rows {
+			value, ok := row[field.Name]
+			if !ok {
+				panic(fmt.Sprintf("arrowtest.Record: column %q not found in row %d", field.Name, i))
+			}
+
+			if value == nil {
+				fieldBuilder.AppendNull()
+				continue
+			} else if err := scalar.Append(fieldBuilder, scalar.MakeScalar(value)); err != nil {
+				panic(fmt.Sprintf("arrowtest.Record: failed to append value %v for column %q: %v", value, field.Name, err))
+			}
+		}
+	}
+
+	return builder.NewRecord()
+}
 
 // RecordRows converts an [arrow.Record] into [Rows] for comparison in tests.
 // RecordRows requires all columns in the record to have a unique name.

--- a/pkg/util/arrowtest/arrowtest_test.go
+++ b/pkg/util/arrowtest/arrowtest_test.go
@@ -1,0 +1,84 @@
+package arrowtest_test
+
+import (
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/util/arrowtest"
+)
+
+func TestRows_Schema(t *testing.T) {
+	t.Run("Consistent types", func(t *testing.T) {
+		rows := arrowtest.Rows{
+			{"name": "Alice", "age": int64(30), "location": "Wonderland"},
+			{"name": "Bob", "age": int64(25), "location": "Builderland"},
+		}
+
+		expect := arrow.NewSchema([]arrow.Field{
+			{Name: "age", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+			{Name: "location", Type: arrow.BinaryTypes.String, Nullable: true},
+			{Name: "name", Type: arrow.BinaryTypes.String, Nullable: true},
+		}, nil)
+
+		actual := rows.Schema()
+
+		require.True(t, expect.Equal(actual), "schemas are not equal:\nexpected: %s\nactual: %s", expect, actual)
+	})
+
+	t.Run("Null at start", func(t *testing.T) {
+		rows := arrowtest.Rows{
+			{"name": "Alice", "age": int64(30), "location": nil},
+			{"name": "Bob", "age": int64(25), "location": "Builderland"},
+		}
+
+		expect := arrow.NewSchema([]arrow.Field{
+			{Name: "age", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+			{Name: "location", Type: arrow.BinaryTypes.String, Nullable: true},
+			{Name: "name", Type: arrow.BinaryTypes.String, Nullable: true},
+		}, nil)
+
+		actual := rows.Schema()
+
+		require.True(t, expect.Equal(actual), "schemas are not equal:\nexpected: %s\nactual: %s", expect, actual)
+	})
+
+	t.Run("Null at end", func(t *testing.T) {
+		rows := arrowtest.Rows{
+			{"name": "Alice", "age": int64(30), "location": "Wonderland"},
+			{"name": "Bob", "age": int64(25), "location": nil},
+		}
+
+		expect := arrow.NewSchema([]arrow.Field{
+			{Name: "age", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+			{Name: "location", Type: arrow.BinaryTypes.String, Nullable: true},
+			{Name: "name", Type: arrow.BinaryTypes.String, Nullable: true},
+		}, nil)
+
+		actual := rows.Schema()
+
+		require.True(t, expect.Equal(actual), "schemas are not equal:\nexpected: %s\nactual: %s", expect, actual)
+	})
+}
+
+func TestRows_Record(t *testing.T) {
+	expect := arrowtest.Rows{
+		{"name": "Alice", "age": int64(30), "location": "Wonderland"},
+		{"name": "Bob", "age": int64(25), "location": "Builderland"},
+		{"name": "Dennis", "age": int64(40), "location": nil},
+		{"name": "Eve", "age": int64(35), "location": "Eden"},
+	}
+
+	alloc := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer alloc.AssertSize(t, 0)
+
+	record := expect.Record(alloc, expect.Schema())
+	defer record.Release()
+
+	actual, err := arrowtest.RecordRows(record)
+	require.NoError(t, err)
+
+	require.Equal(t, expect, actual)
+}


### PR DESCRIPTION
This adds two utilities:

* `arrowtest.Rows.Schema`, which infers the Arrow Schema from a set of rows.

* `arrowtest.Rows.Record`, which converts the set of Go rows into an Arrow Record.

These two utilities mean that arrowtest can be used in both directions of testing code that uses Arrow: creating a record to use in testing, and asserting the content of a record.