### PR TITLE
chore(dataobj): cut logs section based on uncompressed size

### DIFF
--- a/pkg/dataobj/consumer/logsobj/builder.go
+++ b/pkg/dataobj/consumer/logsobj/builder.go
@@ -217,7 +217,7 @@ func (b *Builder) Append(stream logproto.Stream) error {
 
 		// If our logs section has gotten big enough, we want to flush it to the
 		// encoder and start a new section.
-		if b.logs.EstimatedSize() > int(b.cfg.TargetSectionSize) {
+		if b.logs.UncompressedSize() > int(b.cfg.TargetSectionSize) {
 			if err := b.builder.Append(b.logs); err != nil {
 				return err
 			}

--- a/pkg/dataobj/sections/logs/table.go
+++ b/pkg/dataobj/sections/logs/table.go
@@ -82,8 +82,22 @@ func (t *table) ReadPages(ctx context.Context, pages []dataset.Page) result.Seq[
 	})
 }
 
-// Size returns the total size of the table in bytes.
-func (t *table) Size() int {
+// UncompressedSize returns the total uncompressed size of the table in bytes.
+func (t *table) UncompressedSize() int {
+	var size int
+
+	size += t.StreamID.ColumnInfo().UncompressedSize
+	size += t.Timestamp.ColumnInfo().UncompressedSize
+	for _, metadata := range t.Metadatas {
+		size += metadata.ColumnInfo().UncompressedSize
+	}
+	size += t.Message.ColumnInfo().UncompressedSize
+
+	return size
+}
+
+// CompressedSize returns the total compressed size of the table in bytes.
+func (t *table) CompressedSize() int {
 	var size int
 
 	size += t.StreamID.ColumnInfo().CompressedSize


### PR DESCRIPTION
Columnar file formats like Parquet typically recommend cutting the unit of parallelism (row group in Parquet, section in dataobj) based on the uncompressed size of data within that unit.

Initially, logs sections were cut based on compressed size. While this caused fewer logs sections to scan, the CPU and memory cost of an individual section was unpredictable. Cutting the log section based on uncompressed size gives it a more predictable maximum cost to scan.

This change should help make section scanning easier to distribute and parallelize.