### PR TITLE
chore(engine): add implementation for performing topk across streams of Arrow records

### DIFF
--- a/pkg/engine/executor/arrow_scalar_compare.go
+++ b/pkg/engine/executor/arrow_scalar_compare.go
@@ -1,0 +1,138 @@
+package executor
+
+import (
+	"bytes"
+	"cmp"
+	"errors"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/scalar"
+)
+
+// compareScalars compares two rows from the given arrays and indices, returning:
+//
+// - -1 if left < right
+// - 0 if left == right
+// - 1 if left > right
+//
+// If nullsFirst is true, then null values are considered to sort before
+// non-null values.
+//
+// compareScalars returns an error if the two scalars are of different types,
+// or if the scalar type is not supported for comparison.
+func compareScalars(left, right scalar.Scalar, nullsFirst bool) (int, error) {
+	leftNull := left == nil || !left.IsValid()
+	rightNull := right == nil || !right.IsValid()
+
+	// First, handle one or both of the scalars being null.
+	switch {
+	case leftNull && rightNull:
+		return 0, nil
+
+	case leftNull && !rightNull: // left < right if b.NullsFirst is true
+		if nullsFirst {
+			return -1, nil
+		}
+		return 1, nil
+
+	case !leftNull && rightNull: // left > right if b.NullsFirst is true
+		if nullsFirst {
+			return 1, nil
+		}
+		return -1, nil
+	}
+
+	if !arrow.TypeEqual(left.DataType(), right.DataType()) {
+		// We should never hit this, since compareRow is only called for two arrays
+		// coming from the same [arrow.Field].
+		return 0, errors.New("received scalars of different types")
+	}
+
+	// Fast-path: check the builtin support for scalar equality.
+	if scalar.Equals(left, right) {
+		return 0, nil
+	}
+
+	// Switch on the scalar type to compare the values. This is only composed of
+	// types we know the query engine uses, and types that we know have clear
+	// sorting semantics.
+	//
+	// Unsupported scalar types are treated as equal for consistent sorting, but
+	// otherwise it's up to the caller to detect unexpected sort types and reject
+	// the query.
+	switch left.(type) {
+	case *scalar.Binary:
+		left, right := left.(*scalar.Binary), right.(*scalar.Binary)
+		return bytes.Compare(left.Data(), right.Data()), nil
+
+	case *scalar.Dictionary:
+		left, right := left.(*scalar.Dictionary), right.(*scalar.Dictionary)
+
+		leftValue, _ := left.GetEncodedValue()
+		rightValue, _ := right.GetEncodedValue()
+
+		return compareScalars(leftValue, rightValue, nullsFirst)
+
+	case *scalar.Duration:
+		left, right := left.(*scalar.Duration), right.(*scalar.Duration)
+		return cmp.Compare(left.Value, right.Value), nil
+
+	case *scalar.Float16:
+		left, right := left.(*scalar.Float16), right.(*scalar.Float16)
+		return left.Value.Cmp(right.Value), nil
+
+	case *scalar.Float32:
+		left, right := left.(*scalar.Float32), right.(*scalar.Float32)
+		return cmp.Compare(left.Value, right.Value), nil
+
+	case *scalar.Float64:
+		left, right := left.(*scalar.Float64), right.(*scalar.Float64)
+		return cmp.Compare(left.Value, right.Value), nil
+
+	case *scalar.Int8:
+		left, right := left.(*scalar.Int8), right.(*scalar.Int8)
+		return cmp.Compare(left.Value, right.Value), nil
+
+	case *scalar.Int16:
+		left, right := left.(*scalar.Int16), right.(*scalar.Int16)
+		return cmp.Compare(left.Value, right.Value), nil
+
+	case *scalar.Int32:
+		left, right := left.(*scalar.Int32), right.(*scalar.Int32)
+		return cmp.Compare(left.Value, right.Value), nil
+
+	case *scalar.Int64:
+		left, right := left.(*scalar.Int64), right.(*scalar.Int64)
+		return cmp.Compare(left.Value, right.Value), nil
+
+	case *scalar.RunEndEncoded:
+		left, right := left.(*scalar.RunEndEncoded), right.(*scalar.RunEndEncoded)
+		return compareScalars(left.Value, right.Value, nullsFirst)
+
+	case *scalar.String:
+		left, right := left.(*scalar.String), right.(*scalar.String)
+		return bytes.Compare(left.Data(), right.Data()), nil
+
+	case *scalar.Timestamp:
+		left, right := left.(*scalar.Timestamp), right.(*scalar.Timestamp)
+		return cmp.Compare(left.Value, right.Value), nil
+
+	case *scalar.Uint8:
+		left, right := left.(*scalar.Uint8), right.(*scalar.Uint8)
+		return cmp.Compare(left.Value, right.Value), nil
+
+	case *scalar.Uint16:
+		left, right := left.(*scalar.Uint16), right.(*scalar.Uint16)
+		return cmp.Compare(left.Value, right.Value), nil
+
+	case *scalar.Uint32:
+		left, right := left.(*scalar.Uint32), right.(*scalar.Uint32)
+		return cmp.Compare(left.Value, right.Value), nil
+
+	case *scalar.Uint64:
+		left, right := left.(*scalar.Uint64), right.(*scalar.Uint64)
+		return cmp.Compare(left.Value, right.Value), nil
+	}
+
+	return 0, nil
+}

--- a/pkg/engine/executor/topk_batch.go
+++ b/pkg/engine/executor/topk_batch.go
@@ -1,0 +1,261 @@
+package executor
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/apache/arrow-go/v18/arrow/scalar"
+
+	"github.com/grafana/loki/v3/pkg/engine/internal/arrowagg"
+	"github.com/grafana/loki/v3/pkg/util/topk"
+)
+
+// topkBatch calculates the top K rows from a stream of [arrow.Record]s, where
+// rows are sorted by the specified Fields.
+//
+// Rows with equal values for all sort fields are sorted by the order in which
+// they were appended.
+type topkBatch struct {
+	// Fields holds the list of fields to sort by, in order of precedence. If an
+	// incoming record is missing one of these fields, the value for that field
+	// is treated as null.
+	Fields []arrow.Field
+
+	// Ascending indicates whether to store the top K rows in ascending order. If
+	// true, the smallest K rows will be retained.
+	Ascending bool
+
+	// NullsFirst determines how to sort null values in the top K rows. If
+	// NullsFirst is true, null values will be treated as less than non-null
+	// values.
+	NullsFirst bool
+
+	// K holds the number of top rows to compute.
+	K int
+
+	// MaxUnused determines the maximum number of "unused" rows to retain. An
+	// unused row is any row from a retained record that does not contribute to
+	// the top K.
+	//
+	// After the number of unused rows exceeds MaxUnused, topkBatch will compact
+	// retained records into a new record only containing the current top K rows.
+	MaxUnused int
+
+	ready     bool // True if all fields below are initialized.
+	nextID    int
+	mapper    *arrowagg.Mapper
+	heap      *topk.Heap[*topkReference]
+	usedCount map[arrow.Record]int
+}
+
+// topkReference is a reference to a row in a record that is part of the
+// current set of top K rows.
+type topkReference struct {
+	// ID is a per-row unique ID across all records, used for comparing rows that
+	// are otherwise equal in the sort order.
+	ID int
+
+	Record arrow.Record // Record contributing to the top K.
+	Row    int
+}
+
+// Put adds rows from rec into b. If rec contains at least one row that belongs
+// in the current top K rows, rec is retained until a compaction occurs or it
+// is pushed out of the top K.
+//
+// When rec is retained, the number of rows that do not contribute to the top K
+// contribute towards the total unused rows in b. Once the number of unused
+// rows exceeds MaxUnused, Put calls [topkBatch.Compact] to clean up record
+// references.
+func (b *topkBatch) Put(alloc memory.Allocator, rec arrow.Record) {
+	b.put(rec)
+
+	// Compact if adding this record pushed us over the limit of unused rows.
+	if _, unused := b.Size(); unused > b.MaxUnused {
+		compacted := b.Compact(alloc)
+		b.put(compacted)
+		compacted.Release()
+	}
+}
+
+// put adds rows from rec into b without checking the number of unused rows.
+func (b *topkBatch) put(rec arrow.Record) {
+	if !b.ready {
+		b.init()
+	}
+
+	// Iterate over the rows in the record and attempt to push each of them onto
+	// the heap. For simplicity, we retain the record per row in the heap, and
+	// track that count in a map for being able to compute the number of unused
+	// rows.
+	for i := range int(rec.NumRows()) {
+		ref := &topkReference{
+			ID:     b.nextID,
+			Record: rec,
+			Row:    i,
+		}
+		b.nextID++
+
+		res, prev := b.heap.Push(ref)
+		switch res {
+		case topk.PushResultPushed:
+			b.usedCount[rec]++
+			rec.Retain()
+
+		case topk.PushResultReplaced:
+			b.usedCount[rec]++
+			rec.Retain()
+
+			b.usedCount[prev.Record]--
+			if b.usedCount[prev.Record] == 0 {
+				delete(b.usedCount, prev.Record)
+			}
+			prev.Record.Release()
+		}
+	}
+}
+
+func (b *topkBatch) init() {
+	b.heap = &topk.Heap[*topkReference]{
+		Limit: b.K,
+		Less: func(left, right *topkReference) bool {
+			if b.Ascending {
+				// If we're looking for the top K in ascending order, we need to switch
+				// over to a max-heap and return true if left > right.
+				return !b.less(left, right)
+			}
+			return b.less(left, right)
+		},
+	}
+	b.mapper = arrowagg.NewMapper(b.Fields)
+	b.usedCount = make(map[arrow.Record]int)
+	b.ready = true
+}
+
+func (b *topkBatch) less(left, right *topkReference) bool {
+	for fieldIndex := range b.Fields {
+		leftArray := b.findRecordArray(left.Record, b.mapper, fieldIndex)
+		rightArray := b.findRecordArray(right.Record, b.mapper, fieldIndex)
+
+		var leftScalar, rightScalar scalar.Scalar
+
+		if leftArray != nil {
+			leftScalar, _ = scalar.GetScalar(leftArray, left.Row)
+		}
+		if rightArray != nil {
+			rightScalar, _ = scalar.GetScalar(rightArray, right.Row)
+		}
+
+		res, err := compareScalars(leftScalar, rightScalar, b.NullsFirst)
+		if err != nil {
+			// Treat failure to compare scalars as equal, so that the sort order is
+			// consistent. This should only happen when given invalid values to
+			// compare, as we know leftScalar and rightScalar are of the same type.
+			continue
+		}
+		switch res {
+		case 0: // left == right
+			// Continue to the next field if two scalars are equal.
+			continue
+		case -1: // left < right
+			return true
+		case 1: // left > right
+			return false
+		}
+	}
+
+	// Fall back to sorting by ID to have consistent ordering, so that no two
+	// rows are ever equal.
+	switch {
+	case b.Ascending:
+		return left.ID > right.ID
+	default:
+		return left.ID < right.ID
+	}
+}
+
+// findRecordArray finds the array for the given [b.Fields] field index from
+// the mapper cache. findRecordArray returns nil if the field is not present in
+// rec.
+func (b *topkBatch) findRecordArray(rec arrow.Record, mapper *arrowagg.Mapper, fieldIndex int) arrow.Array {
+	columnIndex := mapper.FieldIndex(rec.Schema(), fieldIndex)
+	if columnIndex < 0 || columnIndex >= int(rec.NumCols()) {
+		return nil // No such field in the record.
+	}
+	return rec.Column(columnIndex)
+}
+
+// Size returns the current number of rows in the top K (<= K) and the number
+// of unused rows that are retained from records (<= MaxUnused).
+func (b *topkBatch) Size() (rows int, unused int) {
+	if b.heap == nil {
+		return 0, 0
+	}
+
+	rows = b.heap.Len()
+
+	for rec, used := range b.usedCount {
+		// The number of unused rows per record is its total number of rows minus
+		// the number of references to it, as each reference corresponds to one
+		// value in the heap.
+		unused += int(rec.NumRows()) - used
+	}
+
+	return rows, unused
+}
+
+// Compact compacts all retained records into a single record containing just
+// the current top K rows.
+//
+// The returned record will have a combined schema from all of the input
+// records. The sort order of fields in the returned record is not guaranteed.
+// Rows that did not have one of the combined fields will be filled with null
+// values for those fields.
+//
+// Compact returns nil if no rows are in the top K.
+//
+// The returned record should be Release'd by the caller when it is no longer
+// needed.
+func (b *topkBatch) Compact(alloc memory.Allocator) arrow.Record {
+	if len(b.usedCount) == 0 {
+		return nil
+	}
+	defer b.Reset() // Reset the batch after compaction to free references.
+
+	// Get all row references to compact.
+	rowRefs := b.heap.PopAll()
+	slices.Reverse(rowRefs)
+
+	compactor := arrowagg.NewRecords(alloc)
+	for _, ref := range rowRefs {
+		compactor.AppendSlice(ref.Record, int64(ref.Row), int64(ref.Row)+1)
+	}
+
+	compacted, err := compactor.Aggregate()
+	if err != nil {
+		// Aggregate should only fail if we didn't aggregate anything, which we
+		// know we have above.
+		panic(fmt.Sprintf("topkBatch.Compact: unexpected error aggregating records: %s", err))
+	}
+	return compacted
+}
+
+// Reset releases all resources held by the topkBatch.
+func (b *topkBatch) Reset() {
+	if !b.ready {
+		return
+	}
+
+	b.nextID = 0
+	b.mapper.Reset()
+	b.heap.PopAll()
+
+	for rec, count := range b.usedCount {
+		for range count {
+			rec.Release()
+		}
+	}
+	clear(b.usedCount)
+}

--- a/pkg/engine/executor/topk_batch_test.go
+++ b/pkg/engine/executor/topk_batch_test.go
@@ -1,0 +1,219 @@
+package executor
+
+import (
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/util/arrowtest"
+)
+
+var (
+	records = []arrowtest.Rows{
+		{
+			{"ts": int64(10), "table": "A", "line": "line A"},
+			{"ts": int64(15), "table": "A", "line": "line B"},
+			{"ts": int64(5), "table": "A", "line": "line C"},
+			{"ts": int64(20), "table": "A", "line": "line D"},
+		},
+		{
+			{"ts": int64(1), "table": "A", "line": "line A"},
+			{"ts": int64(50), "table": "A", "line": "line B"},
+		},
+		{
+			// This record contains an additional column not found in the other
+			// records; this tests to make sure topkBatch properly merges schemas.
+			{"ts": int64(100), "table": "B", "app": "loki", "line": "line A"},
+			{"ts": int64(75), "table": "B", "app": "loki", "line": "line B"},
+			{"ts": int64(25), "table": "B", "app": "loki", "line": "line C"},
+		},
+		{
+			{"ts": int64(13), "table": "C", "line": "line A"},
+			{"ts": int64(15), "table": "C", "line": "line B"},
+			{"ts": int64(17), "table": "C", "line": "line C"},
+			{"ts": int64(19), "table": "C", "line": "line D"},
+		},
+		{
+			// This record contains a nil sort key to test the behaviour of
+			// NullsFirst.
+			{"ts": nil, "table": "D", "line": "line A"},
+		},
+	}
+)
+
+func Test_topkBatch(t *testing.T) {
+	tt := []struct {
+		name       string
+		ascending  bool
+		nullsFirst bool
+		expect     arrowtest.Rows
+	}{
+		{
+			name: "Default",
+			expect: arrowtest.Rows{
+				{"ts": nil, "table": "D", "app": nil, "line": "line A"},
+				{"ts": int64(100), "table": "B", "app": "loki", "line": "line A"},
+				{"ts": int64(75), "table": "B", "app": "loki", "line": "line B"},
+				{"ts": int64(50), "table": "A", "app": nil, "line": "line B"},
+				{"ts": int64(25), "table": "B", "app": "loki", "line": "line C"},
+			},
+		},
+
+		{
+			name:      "Ascending",
+			ascending: true,
+			expect: arrowtest.Rows{
+				// No app column because none of the rows used have it.
+				{"ts": int64(1), "table": "A", "line": "line A"},
+				{"ts": int64(5), "table": "A", "line": "line C"},
+				{"ts": int64(10), "table": "A", "line": "line A"},
+				{"ts": int64(13), "table": "C", "line": "line A"},
+				{"ts": int64(15), "table": "C", "line": "line B"},
+			},
+		},
+
+		{
+			name:       "NullsFirst",
+			nullsFirst: true,
+			expect: arrowtest.Rows{
+				{"ts": int64(100), "table": "B", "app": "loki", "line": "line A"},
+				{"ts": int64(75), "table": "B", "app": "loki", "line": "line B"},
+				{"ts": int64(50), "table": "A", "app": nil, "line": "line B"},
+				{"ts": int64(25), "table": "B", "app": "loki", "line": "line C"},
+				{"ts": int64(20), "table": "A", "app": nil, "line": "line D"},
+			},
+		},
+
+		{
+			name:       "NullsFirst Ascending",
+			nullsFirst: true,
+			ascending:  true,
+			expect: arrowtest.Rows{
+				// No app column because none of the rows used have it.
+				{"ts": nil, "table": "D", "line": "line A"},
+				{"ts": int64(1), "table": "A", "line": "line A"},
+				{"ts": int64(5), "table": "A", "line": "line C"},
+				{"ts": int64(10), "table": "A", "line": "line A"},
+				{"ts": int64(13), "table": "C", "line": "line A"},
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			alloc := memory.NewCheckedAllocator(memory.DefaultAllocator)
+			defer alloc.AssertSize(t, 0)
+
+			b := topkBatch{
+				Fields:     []arrow.Field{{Name: "ts", Type: arrow.PrimitiveTypes.Int64, Nullable: true}},
+				K:          5,
+				MaxUnused:  5,
+				Ascending:  tc.ascending,
+				NullsFirst: tc.nullsFirst,
+			}
+			defer b.Reset()
+
+			for _, rows := range records {
+				rec := rows.Record(alloc, rows.Schema())
+				b.Put(alloc, rec)
+				rec.Release()
+			}
+
+			output := b.Compact(alloc)
+			defer output.Release()
+
+			actual, err := arrowtest.RecordRows(output)
+			require.NoError(t, err)
+			require.Equal(t, tc.expect, actual)
+		})
+	}
+}
+
+// Test_topkBatch_MaxUnused ensures that compaction is automatically triggered
+// upon appending a record when the number of unused rows gets too high.
+func Test_topkBatch_MaxUnused(t *testing.T) {
+	alloc := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer alloc.AssertSize(t, 0)
+
+	// TopK 2, descending order.
+	b := topkBatch{
+		Fields:    []arrow.Field{{Name: "ts", Type: arrow.PrimitiveTypes.Int64, Nullable: true}},
+		K:         2,
+		MaxUnused: 5,
+	}
+	defer b.Reset()
+
+	// seq tracks a sequence of Put operations into b. Each time we Put a record,
+	// the number of unused records should account for any record that still has
+	// rows contributing to the topk.
+	//
+	// Records that get fully pushed out of the topk do not contribute to this
+	// count.
+	seq := []struct {
+		rows         arrowtest.Rows
+		expectUsed   int
+		expectUnused int
+	}{
+		{
+			rows: arrowtest.Rows{
+				{"ts": int64(100)},
+				{"ts": int64(10)},
+				{"ts": int64(9)},
+				{"ts": int64(8)},
+				{"ts": int64(7)},
+			},
+			expectUsed:   2,
+			expectUnused: 3, // 3 unused from this initial record.
+		},
+
+		{
+			rows: arrowtest.Rows{
+				{"ts": int64(50)},
+				{"ts": int64(6)},
+			},
+			expectUsed:   2,
+			expectUnused: 5, // 4 from previous record, 1 from this record.
+		},
+
+		{
+			rows: arrowtest.Rows{
+				{"ts": int64(75)},
+				{"ts": int64(5)},
+				{"ts": int64(4)},
+				{"ts": int64(3)},
+			},
+			expectUsed:   2,
+			expectUnused: 0, // Expect compaction here, since 5/4/3 would be unused put us above the limit.
+		},
+
+		{
+			rows: arrowtest.Rows{
+				{"ts": int64(90)},
+				{"ts": int64(2)},
+				{"ts": int64(1)},
+				{"ts": int64(0)},
+			},
+			expectUsed:   2,
+			expectUnused: 4, // 3 from this record and 1 from the previous compacted record
+		},
+	}
+
+	for i, tc := range seq {
+		rec := tc.rows.Record(alloc, tc.rows.Schema())
+		b.Put(alloc, rec)
+		rec.Release()
+
+		used, unused := b.Size()
+		assert.Equal(t, tc.expectUsed, used, "unexpected number of used rows after record %d", i)
+		assert.Equal(t, tc.expectUnused, unused, "unexpected number of unused rows after record %d", i)
+	}
+
+	for _, rows := range records {
+		rec := rows.Record(alloc, rows.Schema())
+		b.Put(alloc, rec)
+		rec.Release()
+	}
+}

--- a/pkg/engine/executor/topk_batch_test.go
+++ b/pkg/engine/executor/topk_batch_test.go
@@ -210,10 +210,4 @@ func Test_topkBatch_MaxUnused(t *testing.T) {
 		assert.Equal(t, tc.expectUsed, used, "unexpected number of used rows after record %d", i)
 		assert.Equal(t, tc.expectUnused, unused, "unexpected number of unused rows after record %d", i)
 	}
-
-	for _, rows := range records {
-		rec := rows.Record(alloc, rows.Schema())
-		b.Put(alloc, rec)
-		rec.Release()
-	}
 }

--- a/pkg/engine/internal/arrowagg/arrays.go
+++ b/pkg/engine/internal/arrowagg/arrays.go
@@ -18,20 +18,21 @@ type Arrays struct {
 
 // NewArrays creates a new [Arrays] that aggregates a set of arrays of the same
 // data type. The data type of incoming arrays is not checked until calling
-// [Arrays.Flush].
+// [Arrays.Aggregate].
 func NewArrays(mem memory.Allocator, dt arrow.DataType) *Arrays {
 	return &Arrays{mem: mem, dt: dt}
 }
 
 // Append appends the entirety of the given array to the builder. The data type
-// of arr is not checked until calling [arrayBuilder.Flush].
+// of arr is not checked until calling [Arrays.Aggregate].
 func (a *Arrays) Append(arr arrow.Array) {
 	arr.Retain()
+	a.nrows++
 	a.in = append(a.in, arr)
 }
 
 // AppendSlice appends a slice of the given array to the builder. The data type
-// of arr is not checked until calling [arrayBuilder.Flush].
+// of arr is not checked until calling [Arrays.Aggregate].
 func (a *Arrays) AppendSlice(arr arrow.Array, i, j int64) {
 	a.nrows += max(0, int(j-i))
 	a.in = append(a.in, array.NewSlice(arr, i, j))

--- a/pkg/engine/internal/arrowagg/arrays.go
+++ b/pkg/engine/internal/arrowagg/arrays.go
@@ -1,0 +1,75 @@
+package arrowagg
+
+import (
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+)
+
+// Arrays allows for aggregating a set of [arrow.Array]s together into a new,
+// combined array.
+type Arrays struct {
+	mem memory.Allocator
+	dt  arrow.DataType
+
+	in    []arrow.Array
+	nrows int // Total number of rows in the builder.
+}
+
+// NewArrays creates a new [Arrays] that aggregates a set of arrays of the same
+// data type. The data type of incoming arrays is not checked until calling
+// [Arrays.Flush].
+func NewArrays(mem memory.Allocator, dt arrow.DataType) *Arrays {
+	return &Arrays{mem: mem, dt: dt}
+}
+
+// Append appends the entirety of the given array to the builder. The data type
+// of arr is not checked until calling [arrayBuilder.Flush].
+func (a *Arrays) Append(arr arrow.Array) {
+	arr.Retain()
+	a.in = append(a.in, arr)
+}
+
+// AppendSlice appends a slice of the given array to the builder. The data type
+// of arr is not checked until calling [arrayBuilder.Flush].
+func (a *Arrays) AppendSlice(arr arrow.Array, i, j int64) {
+	a.nrows += max(0, int(j-i))
+	a.in = append(a.in, array.NewSlice(arr, i, j))
+}
+
+// AppendNulls appends n null values to the builer.
+func (a *Arrays) AppendNulls(n int) {
+	a.nrows += n
+	a.in = append(a.in, array.MakeArrayOfNull(a.mem, a.dt, n))
+}
+
+// Len returns the total number of rows currently appended to the builder.
+func (a *Arrays) Len() int { return a.nrows }
+
+// Aggregate all appended arrays into a single array. The returned array must
+// be Release'd after use. If no arrays have been appended, Aggregate returns a
+// zero-length array.
+//
+// Aggregate returns an error if any of the appended arrays do not match the
+// data type passed to [NewArrays].
+//
+// After calling Aggregate, a is reset and can be reused to append more arrays.
+// This reset is done even if Aggregate returns an error.
+func (a *Arrays) Aggregate() (arrow.Array, error) {
+	if len(a.in) == 0 {
+		return array.MakeArrayOfNull(a.mem, a.dt, 0), nil
+	}
+
+	defer a.Reset()
+	return array.Concatenate(a.in, a.mem)
+}
+
+// Reset releases all arrays currently appended to a and resets it for reuse.
+func (a *Arrays) Reset() {
+	for _, arr := range a.in {
+		arr.Release()
+	}
+	clear(a.in)
+	a.in = a.in[:0]
+	a.nrows = 0
+}

--- a/pkg/engine/internal/arrowagg/arrowagg.go
+++ b/pkg/engine/internal/arrowagg/arrowagg.go
@@ -1,0 +1,3 @@
+// Package arrowagg provides utilities for aggregating Apache Arrow data
+// structures.
+package arrowagg

--- a/pkg/engine/internal/arrowagg/hash.go
+++ b/pkg/engine/internal/arrowagg/hash.go
@@ -1,0 +1,44 @@
+package arrowagg
+
+import (
+	"hash/maphash"
+
+	"github.com/apache/arrow-go/v18/arrow"
+)
+
+// hashSchema hashes the schema into h.
+func hashSchema(h *maphash.Hash, schema *arrow.Schema) {
+	_, _ = h.WriteString(schema.Endianness().String())
+
+	// [arrow.Schema.Fields] creates a copy of the fields slice, so we want to
+	// iterate over indices instead to avoid unnecessary allocations.
+	for i := range schema.NumFields() {
+		hashField(h, schema.Field(i))
+	}
+
+	hashMetadata(h, schema.Metadata())
+}
+
+// hashField hashes a field into h.
+func hashField(h *maphash.Hash, field arrow.Field) {
+	_, _ = h.WriteString(field.Name)
+	_, _ = h.WriteString(field.Type.Fingerprint())
+
+	if field.Nullable {
+		_ = h.WriteByte(1)
+	} else {
+		_ = h.WriteByte(0)
+	}
+
+	hashMetadata(h, field.Metadata)
+}
+
+// hashMetadata hashes Arrow metadata into h.
+func hashMetadata(h *maphash.Hash, md arrow.Metadata) {
+	for _, key := range md.Keys() {
+		value, _ := md.GetValue(key)
+
+		_, _ = h.WriteString(key)
+		_, _ = h.WriteString(value)
+	}
+}

--- a/pkg/engine/internal/arrowagg/mapper.go
+++ b/pkg/engine/internal/arrowagg/mapper.go
@@ -1,0 +1,161 @@
+package arrowagg
+
+import (
+	"hash/maphash"
+	"runtime"
+	"sync"
+	"weak"
+
+	"github.com/apache/arrow-go/v18/arrow"
+)
+
+// Mapper is a utility for quickly finding the index of common fields in a
+// schema.
+//
+// Mapper caches mappings to speed up repeated lookups. Caches are cleared as
+// input [*arrow.Schema]s are garbage collected, or when calling
+// [Mapping.Reset].
+type Mapper struct {
+	target   []arrow.Field
+	hash     maphash.Hash
+	mappings sync.Map // map[uint64]weak.Pointer[mapping]
+}
+
+// NewMapper creates a new Mapper that locates the target fields in a schema.
+func NewMapper(target []arrow.Field) *Mapper {
+	return &Mapper{target: target}
+}
+
+// FieldIndex returns the index of the targetIndex'd field in the schema, or -1
+// if it doesn't exist. targetIndex corresponds to the index of the field in
+// the target slice passed to [NewMapper].
+//
+// FieldIndex returns -1 if targetIndex is out of bounds for the target slice
+// passed to [NewMapper].
+//
+// FieldIndex panics if encountering an unlikely hash collision between two
+// different schemas.
+func (m *Mapper) FieldIndex(schema *arrow.Schema, targetIndex int) int {
+	if targetIndex < 0 || targetIndex >= len(m.target) {
+		return -1
+	}
+
+	mapping := m.getMapper(schema)
+	if len(mapping.lookups) <= targetIndex {
+		return -1
+	}
+	return mapping.lookups[targetIndex]
+}
+
+func (m *Mapper) getMapper(schema *arrow.Schema) *mapping {
+	hash := m.hashSchema(schema)
+
+	var created *mapping
+
+Retry:
+	cached, ok := m.mappings.Load(hash)
+	if ok {
+		found := cached.(weak.Pointer[mapping]).Value()
+		if found == nil {
+			// The weak pointer was nil, so the cache entry is awaiting cleanup. To
+			// move forward, we'll delete it now and retry.
+			m.mappings.CompareAndDelete(hash, cached)
+			goto Retry
+		}
+
+		// [maphash] says that it's "collision resistant." If we believe that, then
+		// the birthday paradox tells us there's 50% of a collision when we have
+		// 2^32 cached schemas.
+		//
+		// It seems extremely unlikely for us to have anywhere close to 4.3 billion
+		// schemas in practice, so for now we panic on detecting a collision.
+		//
+		// If we ever hit this, we can consider using a more complex structure to
+		// allow for multiple mappings per hash.
+		if !found.Validate(schema) {
+			panic("arrowagg.Mapper: detected hash collision between two schemas")
+		}
+		return found
+	}
+
+	// Lazily initialize created to defer allocating anything until we know we
+	// might need it.
+	if created == nil {
+		created = newMapping(schema, m.target)
+	}
+
+	wp := weak.Make(created)
+
+	if _, loaded := m.mappings.LoadOrStore(hash, wp); loaded {
+		// Someone else stored a mapping before us; return to Retry.
+		goto Retry
+	}
+
+	// We successfully stored the mapping; add a cleanup to remove the entry when
+	// the schema is garbage collected.
+	runtime.AddCleanup(schema, func(hash uint64) {
+		// We use CompareAndDelete here to ensure that we're only deleting the weak
+		// pointer we contributed. Another goroutine may have already deleted our
+		// entry and replaced it with a new one.
+		m.mappings.CompareAndDelete(hash, wp)
+	}, hash)
+
+	return created
+}
+
+func (m *Mapper) hashSchema(schema *arrow.Schema) uint64 {
+	m.hash.Reset()
+	hashSchema(&m.hash, schema)
+	return m.hash.Sum64()
+}
+
+// Reset resets the mapper, immediately clearing any cached mappings.
+func (m *Mapper) Reset() {
+	m.mappings.Clear()
+}
+
+type mapping struct {
+	schema  *arrow.Schema
+	checked map[*arrow.Schema]struct{} // schemas that have been checked for equality against this mapping.
+	lookups []int                      // lookups[i] -> index of the i'th "to" field in schema.
+}
+
+func newMapping(schema *arrow.Schema, to []arrow.Field) *mapping {
+	// Create a new mapping for the schema, and store it in the mappings map.
+	mapping := &mapping{
+		schema:  schema,
+		lookups: make([]int, len(to)),
+		checked: make(map[*arrow.Schema]struct{}),
+	}
+
+	for i, field := range to {
+		// Default to -1 for fields that are not found in the schema.
+		mapping.lookups[i] = -1
+
+		for j, schemaField := range schema.Fields() {
+			if field.Equal(schemaField) {
+				mapping.lookups[i] = j
+				break
+			}
+		}
+	}
+
+	return mapping
+}
+
+// Validate checks if m is valid for the given schema. This is used to cheaply
+// detect hash collisions.
+func (m *mapping) Validate(other *arrow.Schema) bool {
+	// Check if we've already checked this schema against the mapping.
+	if _, ok := m.checked[other]; ok {
+		return true
+	}
+
+	// If we haven't checked it yet, do so now.
+	if m.schema.Equal(other) {
+		m.checked[other] = struct{}{}
+		return true
+	}
+
+	return false
+}

--- a/pkg/engine/internal/arrowagg/records.go
+++ b/pkg/engine/internal/arrowagg/records.go
@@ -1,0 +1,177 @@
+package arrowagg
+
+import (
+	"fmt"
+	"hash/maphash"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+)
+
+// Records allows for aggregating a set of [arrow.Record]s together into a
+// single, combined record with a combined schema.
+//
+// The returned record will have a schema composed of the union of all fields
+// from the input records. Fields will be placed in the order in which they are
+// first seen. When aggregating records, fields that do not exist in the source
+// record will be filled with null values in the output record.
+type Records struct {
+	mem memory.Allocator
+
+	fields  []arrow.Field
+	records []arrow.Record
+	rows    int64
+
+	hash        maphash.Hash
+	seenFields  map[uint64]arrow.Field   // Maps seen field hashes
+	seenSchemas map[uint64]*arrow.Schema // Maps seen schema hashes
+}
+
+// NewRecords creates a new [Records] that aggregates a set of records.
+func NewRecords(mem memory.Allocator) *Records {
+	return &Records{
+		mem:         mem,
+		seenFields:  make(map[uint64]arrow.Field),
+		seenSchemas: make(map[uint64]*arrow.Schema),
+	}
+}
+
+// Append appends the entirety of rec to r. If record contains a field that has
+// not been seen before, it will be added to the schema of r.
+//
+// Fields are compared based on endianness, name, type, and metadata; two
+// fields that are equal except for metadata are treated as different.
+//
+// Any metadata from rec.Schema().Metadata() is ignored when computing the
+// combined schema for r.
+//
+// rec is Retaine'd by this method until calling [Records.Aggregate].
+//
+// Append panics if encountering an unlikely hash collision between two
+// different schemas.
+func (r *Records) Append(rec arrow.Record) {
+	r.processSchema(rec.Schema())
+
+	rec.Retain()
+	r.records = append(r.records, rec)
+	r.rows += rec.NumRows()
+}
+
+func (r *Records) processSchema(schema *arrow.Schema) {
+	schemaHash := r.hashSchema(schema)
+	if seen, ok := r.seenSchemas[schemaHash]; ok {
+		// See the comment in [Mapper.getMapper] for the likelihood of hash
+		// collisions.
+		if !seen.Equal(schema) {
+			panic("arrowagg.Records: detected hash collision between two schemas")
+		}
+
+		return
+	}
+
+	for i := range schema.NumFields() {
+		field := schema.Field(i)
+		fieldHash := r.hashField(field)
+
+		if seen, ok := r.seenFields[fieldHash]; ok {
+			if !seen.Equal(field) {
+				panic(fmt.Sprintf("arrowagg.Records: unexpected field hash %X collision between %s and %s", fieldHash, field, seen))
+			}
+			continue
+		}
+
+		r.fields = append(r.fields, field)
+		r.seenFields[fieldHash] = field
+	}
+
+	r.seenSchemas[schemaHash] = schema
+}
+
+func (r *Records) hashSchema(schema *arrow.Schema) uint64 {
+	r.hash.Reset()
+	hashSchema(&r.hash, schema)
+	return r.hash.Sum64()
+}
+
+func (r *Records) hashField(field arrow.Field) uint64 {
+	r.hash.Reset()
+	hashField(&r.hash, field)
+	return r.hash.Sum64()
+}
+
+// AppendSlice behaves like [Records.Append] but instead appends a slice of the
+// input record from i to j.
+func (r *Records) AppendSlice(rec arrow.Record, i, j int64) {
+	slice := rec.NewSlice(i, j)
+	defer slice.Release()
+	r.Append(slice)
+}
+
+// Aggregate all appended records into a single record. The returned record
+// must be Release'd after use. If no records have been appended, Aggregate
+// returns an error.
+//
+// The returned record will have a schema composed of the union of all fields
+// from the input records, sorted by the order in which each field was first
+// seen.
+//
+// Fields that do not exist in source records will be filled with null values
+// in the output record.
+//
+// After calling Aggregate, r is reset and can be reused to append more arrays.
+// This reset is done even if Aggregate returns an error.
+func (r *Records) Aggregate() (arrow.Record, error) {
+	if len(r.records) == 0 {
+		return nil, fmt.Errorf("no records to flush")
+	}
+	defer r.Reset()
+
+	mapper := NewMapper(r.fields)
+	defer mapper.Reset() // Allow immediately freeing memory used by the mapper.
+
+	var columns []arrow.Array
+	defer func() {
+		for _, column := range columns {
+			column.Release()
+		}
+	}()
+
+	for fieldIndex, field := range r.fields {
+		columnAgg := NewArrays(r.mem, field.Type)
+
+		for _, rec := range r.records {
+			columnIndex := mapper.FieldIndex(rec.Schema(), fieldIndex)
+			if columnIndex == -1 {
+				columnAgg.AppendNulls(int(rec.NumRows()))
+				continue
+			}
+			columnAgg.Append(rec.Column(columnIndex))
+		}
+
+		arr, err := columnAgg.Aggregate()
+		if err != nil {
+			return nil, fmt.Errorf("failed to flush array builder for field %d: %w", fieldIndex, err)
+		}
+		columns = append(columns, arr)
+	}
+
+	combinedSchema := arrow.NewSchema(r.fields, nil)
+	return array.NewRecord(combinedSchema, columns, r.rows), nil
+}
+
+// Reset releases all resources held by r and clears its state, allowing it to
+// be reused for aggregating new records.
+func (r *Records) Reset() {
+	for _, rec := range r.records {
+		rec.Release()
+	}
+	clear(r.records)
+
+	r.records = r.records[:0]
+	r.fields = r.fields[:0]
+	r.rows = 0
+
+	clear(r.seenFields)
+	clear(r.seenSchemas)
+}

--- a/pkg/util/topk/topk_test.go
+++ b/pkg/util/topk/topk_test.go
@@ -82,3 +82,25 @@ func TestHeap_Range_Empty(t *testing.T) {
 		}
 	})
 }
+
+func TestHeap_Push(t *testing.T) {
+	heap := &topk.Heap[int]{
+		Limit: 2,
+		Less:  func(a, b int) bool { return a < b },
+	}
+
+	// Fill the heap.
+	res, _ := heap.Push(50)
+	require.Equal(t, topk.PushResultPushed, res, "should push the first value into the heap")
+	res, _ = heap.Push(100)
+	require.Equal(t, topk.PushResultPushed, res, "should push the second value into the heap")
+
+	// Try adding a value that is smaller than the values in the heap.
+	res, _ = heap.Push(10)
+	require.Equal(t, topk.PushResultNone, res, "should not push a value smaller than the current heap values")
+
+	// Push a value that is larger than the smallest value in the heap.
+	res, prev := heap.Push(1000)
+	require.Equal(t, topk.PushResultReplaced, res, "should replace the smallest value in the heap")
+	require.Equal(t, 50, prev, "should return the previous smallest value that was replaced")
+}


### PR DESCRIPTION
This commit adds a `engine.topkBatch` type, which can be used by the implementation of execution nodes to perform compute the set of topk rows from a stream of records. This is needed as part of #17976, and more generally for efficiently sorting rows when a limit is also used. 

Implementing this required quite a few helper utilities in the new `arrowagg` package. The `arrowagg` package provides utilities for aggregating various Arrow types:

* `arrowagg.Arrays` to concatenate a stream of `arrow.Array`s 
* `arrayagg.Records` to concatenate a stream of `arrow.Record`s, creating a merged schema.
* `arrowagg.Mapper` for quickly finding fields in incoming schemas, since arrow-go can return false when comparing two identical schemas/fields.

The end result should be capable of performing topk with reasonable efficiency, including from a stream of wide records with little or no schema overlap. 

Due to the size of the code, I'm opening this as its own PR before switching over DataObjScan to use the columnar reading APIs.