### PR TITLE
chore(dataobj): Sort rows by [timestamp DESC, streamID ASC] when building data objects

### DIFF
--- a/pkg/dataobj/sections/logs/table_build.go
+++ b/pkg/dataobj/sections/logs/table_build.go
@@ -48,9 +48,9 @@ func buildTable(buf *tableBuffer, pageSize int, compressionOpts dataset.Compress
 // sortRecords sorts the set of records by stream ID and timestamp.
 func sortRecords(records []Record) {
 	slices.SortFunc(records, func(a, b Record) int {
-		if res := cmp.Compare(a.StreamID, b.StreamID); res != 0 {
+		if res := b.Timestamp.Compare(a.Timestamp); res != 0 {
 			return res
 		}
-		return a.Timestamp.Compare(b.Timestamp)
+		return cmp.Compare(a.StreamID, b.StreamID)
 	})
 }

--- a/pkg/dataobj/sections/logs/table_merge.go
+++ b/pkg/dataobj/sections/logs/table_merge.go
@@ -212,5 +212,5 @@ func compareRows(a, b dataset.Row) int {
 	if res := cmp.Compare(bTimestamp, aTimestamp); res != 0 {
 		return res
 	}
-	return cmp.Compare(bStreamID, aStreamID)
+	return cmp.Compare(aStreamID, bStreamID)
 }

--- a/pkg/dataobj/sections/logs/table_merge.go
+++ b/pkg/dataobj/sections/logs/table_merge.go
@@ -209,8 +209,8 @@ func compareRows(a, b dataset.Row) int {
 		bTimestamp = b.Values[1].Int64()
 	)
 
-	if res := cmp.Compare(aStreamID, bStreamID); res != 0 {
+	if res := cmp.Compare(bTimestamp, aTimestamp); res != 0 {
 		return res
 	}
-	return cmp.Compare(aTimestamp, bTimestamp)
+	return cmp.Compare(bStreamID, aStreamID)
 }

--- a/pkg/engine/compat_test.go
+++ b/pkg/engine/compat_test.go
@@ -17,8 +17,9 @@ import (
 	"github.com/grafana/loki/v3/pkg/logproto"
 	"github.com/grafana/loki/v3/pkg/logqlmodel"
 
-	"github.com/grafana/loki/pkg/push"
 	"github.com/prometheus/prometheus/promql"
+
+	"github.com/grafana/loki/pkg/push"
 )
 
 func createRecord(t *testing.T, schema *arrow.Schema, data [][]interface{}) arrow.Record {

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -36,6 +36,10 @@ func New(opts logql.EngineOpts, bucket objstore.Bucket, limits logql.Limits, reg
 		ms = metastore.NewObjectMetastore(bucket, logger)
 	}
 
+	if opts.BatchSize <= 0 {
+		panic(fmt.Sprintf("invalid batch size for query engine. must be greater than 0, got %d", opts.BatchSize))
+	}
+
 	return &QueryEngine{
 		logger:    logger,
 		metrics:   newMetrics(reg),

--- a/pkg/engine/executor/dataobjscan.go
+++ b/pkg/engine/executor/dataobjscan.go
@@ -230,7 +230,6 @@ func (s *dataobjScan) read() (arrow.Record, error) {
 			heapMut.Unlock()
 
 			return nil
-
 		})
 	}
 

--- a/pkg/engine/executor/dataobjscan.go
+++ b/pkg/engine/executor/dataobjscan.go
@@ -50,6 +50,8 @@ type dataobjScanOptions struct {
 
 	Direction physical.SortOrder // Order of timestamps to return (ASC=Forward, DESC=Backward)
 	Limit     uint32             // A limit on the number of rows to return (0=unlimited).
+
+	batchSize int64
 }
 
 var _ Pipeline = (*dataobjScan)(nil)
@@ -211,7 +213,7 @@ func (s *dataobjScan) read() (arrow.Record, error) {
 	for _, reader := range s.readers {
 		g.Go(func() error {
 
-			buf := make([]logs.Record, 100) // use engine batch size
+			buf := make([]logs.Record, s.opts.batchSize)
 			n, err := reader.Read(ctx, buf)
 			if n == 0 && errors.Is(err, io.EOF) {
 				return nil

--- a/pkg/engine/executor/dataobjscan.go
+++ b/pkg/engine/executor/dataobjscan.go
@@ -200,7 +200,7 @@ func (s *dataobjScan) read() (arrow.Record, error) {
 	var (
 		heapMut sync.Mutex
 		heap    = topk.Heap[logs.Record]{
-			Limit: int(s.opts.Limit),
+			Limit: 0, // unlimited
 			Less:  s.getLessFunc(s.opts.Direction),
 		}
 	)

--- a/pkg/engine/executor/dataobjscan_test.go
+++ b/pkg/engine/executor/dataobjscan_test.go
@@ -62,7 +62,7 @@ func Test_dataobjScan(t *testing.T) {
 		pipeline := newDataobjScanPipeline(t.Context(), dataobjScanOptions{
 			Object:      obj,
 			StreamIDs:   []int64{1, 2}, // All streams
-			Sections:    []int{0},      // All sections (there is only a single one)
+			Section:     0,             // First section.
 			Projections: nil,           // All columns
 			Direction:   physical.ASC,
 			Limit:       0, // No limit
@@ -93,7 +93,7 @@ prod,loki,eeee-ffff-aaaa-bbbb,NULL,1970-01-01 00:00:10,goodbye world`
 		pipeline := newDataobjScanPipeline(t.Context(), dataobjScanOptions{
 			Object:    obj,
 			StreamIDs: []int64{1, 2}, // All streams
-			Sections:  []int{0},      // All sections (there is only a single one)
+			Section:   0,             // First section.
 			Projections: []physical.ColumnExpression{
 				&physical.ColumnExpr{Ref: types.ColumnRef{Column: "timestamp", Type: types.ColumnTypeBuiltin}},
 				&physical.ColumnExpr{Ref: types.ColumnRef{Column: "env", Type: types.ColumnTypeLabel}},
@@ -125,7 +125,7 @@ prod,loki,eeee-ffff-aaaa-bbbb,NULL,1970-01-01 00:00:10,goodbye world`
 		pipeline := newDataobjScanPipeline(t.Context(), dataobjScanOptions{
 			Object:    obj,
 			StreamIDs: []int64{1, 2}, // All streams
-			Sections:  []int{0},      // All sections (there is only a single one)
+			Section:   0,             // First section.
 			Projections: []physical.ColumnExpression{
 				&physical.ColumnExpr{Ref: types.ColumnRef{Column: "env", Type: types.ColumnTypeAmbiguous}},
 			},
@@ -190,7 +190,7 @@ func Test_dataobjScan_DuplicateColumns(t *testing.T) {
 		pipeline := newDataobjScanPipeline(t.Context(), dataobjScanOptions{
 			Object:      obj,
 			StreamIDs:   []int64{1, 2, 3}, // All streams
-			Sections:    []int{0},         // All sections (there is only a single one)
+			Section:     0,                // First section.
 			Projections: nil,              // All columns
 			Direction:   physical.ASC,
 			Limit:       0, // No limit
@@ -224,7 +224,7 @@ prod,namespace-2,NULL,loki,NULL,NULL,1970-01-01 00:00:03,message 3`
 		pipeline := newDataobjScanPipeline(t.Context(), dataobjScanOptions{
 			Object:    obj,
 			StreamIDs: []int64{1, 2, 3}, // All streams
-			Sections:  []int{0},         // All sections (there is only a single one)
+			Section:   0,                // First section.
 			Projections: []physical.ColumnExpression{
 				&physical.ColumnExpr{Ref: types.ColumnRef{Column: "pod", Type: types.ColumnTypeAmbiguous}},
 			},
@@ -252,7 +252,7 @@ NULL,NULL`
 		pipeline := newDataobjScanPipeline(t.Context(), dataobjScanOptions{
 			Object:    obj,
 			StreamIDs: []int64{1, 2, 3}, // All streams
-			Sections:  []int{0},         // All sections (there is only a single one)
+			Section:   0,
 			Projections: []physical.ColumnExpression{
 				&physical.ColumnExpr{Ref: types.ColumnRef{Column: "namespace", Type: types.ColumnTypeAmbiguous}},
 			},

--- a/pkg/engine/executor/executor.go
+++ b/pkg/engine/executor/executor.go
@@ -91,7 +91,7 @@ func (c *Context) executeDataObjScan(ctx context.Context, node *physical.DataObj
 	return newDataobjScanPipeline(ctx, dataobjScanOptions{
 		Object:      obj,
 		StreamIDs:   node.StreamIDs,
-		Sections:    node.Sections,
+		Section:     node.Section,
 		Predicates:  predicates,
 		Projections: node.Projections,
 

--- a/pkg/engine/executor/executor.go
+++ b/pkg/engine/executor/executor.go
@@ -97,6 +97,8 @@ func (c *Context) executeDataObjScan(ctx context.Context, node *physical.DataObj
 
 		Direction: node.Direction,
 		Limit:     node.Limit,
+
+		batchSize: c.batchSize,
 	})
 }
 

--- a/pkg/engine/executor/pipeline_utils_test.go
+++ b/pkg/engine/executor/pipeline_utils_test.go
@@ -83,7 +83,7 @@ func AssertPipelinesEqual(t testing.TB, left, right Pipeline) {
 
 		// Check schema compatibility
 		require.True(t, leftBatch.Schema().Equal(rightBatch.Schema()),
-			"Pipelines have incompatible schemas: %v vs %v",
+			"Pipelines have incompatible schemas:\nleft %v\nright %v",
 			leftBatch.Schema(), rightBatch.Schema())
 
 		// Compare rows until one of the batches is exhausted

--- a/pkg/engine/executor/sortmerge.go
+++ b/pkg/engine/executor/sortmerge.go
@@ -113,10 +113,11 @@ start:
 	timestamps := make([]int64, 0, len(p.inputs))
 	inputIndexes := make([]int, 0, len(p.inputs))
 
+loop:
 	for i := range len(p.inputs) {
 		// Skip exhausted inputs
 		if p.exhausted[i] {
-			continue
+			continue loop
 		}
 
 		// Load next batch if it hasn't been loaded yet, or if current one is already fully consumed
@@ -130,7 +131,7 @@ start:
 				if errors.Is(err, EOF) {
 					p.exhausted[i] = true
 					p.batches[i] = nil // remove reference to arrow.Record from slice
-					continue
+					continue loop
 				}
 				return err
 			}

--- a/pkg/engine/planner/physical/dataobjscan.go
+++ b/pkg/engine/planner/physical/dataobjscan.go
@@ -16,11 +16,11 @@ type DataObjScan struct {
 	// Location is the unique name of the data object that is used as source for
 	// reading streams.
 	Location DataObjLocation
+	// Section is the section index inside the data object to scan.
+	Section int
 	// StreamIDs is a set of stream IDs inside the data object. These IDs are
 	// only unique in the context of a single data object.
 	StreamIDs []int64
-	// Sections is a set of section indexes inside the data object.
-	Sections []int
 	// Projections are used to limit the columns that are read to the ones
 	// provided in the column expressions to reduce the amount of data that needs
 	// to be processed.

--- a/pkg/engine/planner/physical/planner.go
+++ b/pkg/engine/planner/physical/planner.go
@@ -166,6 +166,7 @@ func (p *Planner) processMakeTable(lp *logical.MakeTable, ctx *Context) ([]Node,
 
 	nodes := make([]Node, 0, len(objects))
 	for i := range objects {
+
 		node := &SortMerge{
 			Column: newColumnExpr(types.ColumnNameBuiltinTimestamp, types.ColumnTypeBuiltin),
 			Order:  ctx.direction, // apply direction from previously visited Sort node
@@ -176,8 +177,8 @@ func (p *Planner) processMakeTable(lp *logical.MakeTable, ctx *Context) ([]Node,
 			scan := &DataObjScan{
 				Location:  objects[i],
 				StreamIDs: streams[i],
-				Sections:  []int{section}, // process only 1 section per DataObjScan
-				Direction: ctx.direction,  // apply direction from previously visited Sort node
+				Section:   section,
+				Direction: ctx.direction, // apply direction from previously visited Sort node
 			}
 			p.plan.addNode(scan)
 			if err := p.plan.addEdge(Edge{Parent: node, Child: scan}); err != nil {

--- a/pkg/engine/planner/physical/planner.go
+++ b/pkg/engine/planner/physical/planner.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/grafana/loki/v3/pkg/engine/internal/types"
 	"github.com/grafana/loki/v3/pkg/engine/planner/logical"
 )
 
@@ -165,13 +166,25 @@ func (p *Planner) processMakeTable(lp *logical.MakeTable, ctx *Context) ([]Node,
 
 	nodes := make([]Node, 0, len(objects))
 	for i := range objects {
-		node := &DataObjScan{
-			Location:  objects[i],
-			StreamIDs: streams[i],
-			Sections:  sections[i],
-			Direction: ctx.direction, // apply direction from previously visited Sort node
+		node := &SortMerge{
+			Column: newColumnExpr(types.ColumnNameBuiltinTimestamp, types.ColumnTypeBuiltin),
+			Order:  ctx.direction, // apply direction from previously visited Sort node
 		}
 		p.plan.addNode(node)
+
+		for _, section := range sections[i] {
+			scan := &DataObjScan{
+				Location:  objects[i],
+				StreamIDs: streams[i],
+				Sections:  []int{section}, // process only 1 section per DataObjScan
+				Direction: ctx.direction,  // apply direction from previously visited Sort node
+			}
+			p.plan.addNode(scan)
+			if err := p.plan.addEdge(Edge{Parent: node, Child: scan}); err != nil {
+				return nil, err
+			}
+		}
+
 		nodes = append(nodes, node)
 	}
 	return nodes, nil

--- a/pkg/engine/planner/physical/planner_test.go
+++ b/pkg/engine/planner/physical/planner_test.go
@@ -130,7 +130,7 @@ func sections(t *testing.T, plan *Plan, nodes []Node) [][]int {
 			if !ok {
 				t.Fatalf("failed to cast Node to DataObjScan, got %T", n)
 			}
-			res = append(res, obj.Sections)
+			res = append(res, []int{obj.Section})
 		}
 	}
 	return res
@@ -160,8 +160,12 @@ func TestPlanner_ConvertMaketable(t *testing.T) {
 		expSections [][]int
 	}{
 		{
-			shard:       logical.NewShard(0, 1), // no sharding
-			expPaths:    []string{"obj1", "obj1", "obj2", "obj2", "obj3", "obj3", "obj4", "obj4", "obj5", "obj5"},
+			shard: logical.NewShard(0, 1), // no sharding
+			expPaths: []string{
+				// Each section gets its own DataObjScan node, so objects here are
+				// repeated once per section to scan.
+				"obj1", "obj1", "obj2", "obj2", "obj3", "obj3", "obj4", "obj4", "obj5", "obj5",
+			},
 			expSections: [][]int{{0}, {1}, {0}, {1}, {0}, {1}, {0}, {1}, {0}, {1}},
 		},
 		{

--- a/pkg/engine/planner/physical/printer.go
+++ b/pkg/engine/planner/physical/printer.go
@@ -31,7 +31,7 @@ func toTreeNode(n Node) *tree.Node {
 		treeNode.Properties = []tree.Property{
 			tree.NewProperty("location", false, node.Location),
 			tree.NewProperty("stream_ids", true, toAnySlice(node.StreamIDs)...),
-			tree.NewProperty("section_ids", true, toAnySlice(node.Sections)...),
+			tree.NewProperty("section_id", true, node.Section),
 			tree.NewProperty("projections", true, toAnySlice(node.Projections)...),
 			tree.NewProperty("direction", false, node.Direction),
 			tree.NewProperty("limit", false, node.Limit),

--- a/pkg/logql/bench/Makefile
+++ b/pkg/logql/bench/Makefile
@@ -1,8 +1,10 @@
-.PHONY: generate bench list run run-debug stream
+.PHONY: all generate bench list run run-debug stream
 
 # Default size for data generation (2GB)
 SIZE ?= 2147483648
 TENANT ?= test-tenant
+
+all: clean generate prepare-for-local-testing
 
 generate:
 	@echo "Generating benchmark data..."
@@ -23,3 +25,12 @@ run-debug:
 
 stream:
 	@go run ./cmd/stream/main.go | less
+
+clean:
+	@echo "Clean data directory..."
+	@rm -rf data/
+
+prepare-for-local-testing:
+	@echo "Prepare file structure for local Loki setup..."
+	@mv data/chunks/* data/
+	@mv data/index_* data/index/

--- a/pkg/logql/bench/Makefile
+++ b/pkg/logql/bench/Makefile
@@ -28,9 +28,9 @@ stream:
 
 clean:
 	@echo "Clean data directory..."
-	@rm -rf data/
+	rm -rf data/
 
 prepare-for-local-testing:
 	@echo "Prepare file structure for local Loki setup..."
-	@mv data/chunks/* data/
-	@mv data/index_* data/index/
+	mv data/chunks/* data/
+	mv data/index_19723 data/index_cache

--- a/pkg/logql/bench/bench_test.go
+++ b/pkg/logql/bench/bench_test.go
@@ -297,13 +297,13 @@ func BenchmarkLogQL(b *testing.B) {
 	// Run benchmarks for both storage types
 	for _, storeType := range allStores {
 		engine, config := setupBenchmarkWithStore(b, storeType)
-		ctx := user.InjectOrgID(context.Background(), testTenant)
 
 		// Generate test cases using the loaded config
 		cases := config.GenerateTestCases()
 
 		for _, c := range cases {
 			b.Run(fmt.Sprintf("query=%s/kind=%s/store=%s", c.Name(), c.Kind(), storeType), func(b *testing.B) {
+				ctx := user.InjectOrgID(context.Background(), testTenant)
 				params, err := logql.NewLiteralParams(
 					c.Query,
 					c.Start,
@@ -321,6 +321,8 @@ func BenchmarkLogQL(b *testing.B) {
 
 				b.ResetTimer()
 				for i := 0; i < b.N; i++ {
+					ctx, cancel := context.WithTimeout(ctx, time.Minute)
+					defer cancel()
 					r, err := q.Exec(ctx)
 					require.NoError(b, err)
 					b.ReportMetric(float64(r.Statistics.Summary.TotalLinesProcessed), "linesProcessed")

--- a/pkg/logql/bench/store_dataobj.go
+++ b/pkg/logql/bench/store_dataobj.go
@@ -56,11 +56,10 @@ func NewDataObjStore(dir, tenantID string) (*DataObjStore, error) {
 	}
 
 	builder, err := logsobj.NewBuilder(logsobj.BuilderConfig{
-		TargetPageSize:    512 * 1024,        // 2MB
-		TargetObjectSize:  512 * 1024 * 1024, // 128MB
-		TargetSectionSize: 32 * 1024 * 1024,  // 16MB
-		BufferSize:        32 * 1024 * 1024,  // 16MB
-
+		TargetPageSize:          2 * 1024 * 1024,   // 2MB
+		TargetObjectSize:        128 * 1024 * 1024, // 128MB
+		TargetSectionSize:       16 * 1024 * 1024,  // 16MB
+		BufferSize:              16 * 1024 * 1024,  // 16MB
 		SectionStripeMergeLimit: 2,
 	})
 	if err != nil {

--- a/pkg/logql/bench/store_dataobj.go
+++ b/pkg/logql/bench/store_dataobj.go
@@ -56,10 +56,10 @@ func NewDataObjStore(dir, tenantID string) (*DataObjStore, error) {
 	}
 
 	builder, err := logsobj.NewBuilder(logsobj.BuilderConfig{
-		TargetPageSize:    2 * 1024 * 1024,   // 2MB
-		TargetObjectSize:  128 * 1024 * 1024, // 128MB
-		TargetSectionSize: 16 * 1024 * 1024,  // 16MB
-		BufferSize:        16 * 1024 * 1024,  // 16MB
+		TargetPageSize:    512 * 1024,        // 2MB
+		TargetObjectSize:  512 * 1024 * 1024, // 128MB
+		TargetSectionSize: 32 * 1024 * 1024,  // 16MB
+		BufferSize:        32 * 1024 * 1024,  // 16MB
 
 		SectionStripeMergeLimit: 2,
 	})

--- a/pkg/logql/bench/store_dataobj_v2_engine.go
+++ b/pkg/logql/bench/store_dataobj_v2_engine.go
@@ -41,6 +41,7 @@ func NewDataObjV2EngineStore(dataDir string, tenantID string) (*DataObjV2EngineS
 	// Default EngineOpts. Adjust if specific configurations are needed.
 	engineOpts := logql.EngineOpts{
 		EnableV2Engine: true,
+		BatchSize:      512,
 	}
 
 	// Instantiate the new engine


### PR DESCRIPTION
**What this PR does / why we need it**:

Sorting sections by `timestamp DESC` first and `streamID ASC` allows for more efficient reading (by section) for BACKWARD log queries.

This PR breaks FORWARD log queries.