### PR TITLE
chore(dataobj): Improve performance of dataset.Value API

### DIFF
--- a/pkg/dataobj/internal/dataset/column_stats.go
+++ b/pkg/dataobj/internal/dataset/column_stats.go
@@ -97,10 +97,10 @@ func (csb *columnStatsBuilder) buildRangeStats(pages []*MemPage, dst *datasetmd.
 			panic(fmt.Sprintf("ColumnStatsBuilder.buildStats: failed to unmarshal max value: %s", err))
 		}
 
-		if i == 0 || CompareValues(pageMin, minValue) < 0 {
+		if i == 0 || CompareValues(&pageMin, &minValue) < 0 {
 			minValue = pageMin
 		}
-		if i == 0 || CompareValues(pageMax, maxValue) > 0 {
+		if i == 0 || CompareValues(&pageMax, &maxValue) > 0 {
 			maxValue = pageMax
 		}
 	}

--- a/pkg/dataobj/internal/dataset/page_builder.go
+++ b/pkg/dataobj/internal/dataset/page_builder.go
@@ -175,10 +175,10 @@ func (b *pageBuilder) updateMinMax(value Value) {
 	// We'll init minValue/maxValue if this is our first non-NULL value (b.values == 0).
 	// This allows us to only avoid comparing against NULL values, which would lead to
 	// NULL always being the min.
-	if b.values == 0 || CompareValues(value, b.minValue) < 0 {
+	if b.values == 0 || CompareValues(&value, &b.minValue) < 0 {
 		b.minValue = value
 	}
-	if b.values == 0 || CompareValues(value, b.maxValue) > 0 {
+	if b.values == 0 || CompareValues(&value, &b.maxValue) > 0 {
 		b.maxValue = value
 	}
 }

--- a/pkg/dataobj/internal/dataset/reader.go
+++ b/pkg/dataobj/internal/dataset/reader.go
@@ -311,7 +311,7 @@ func checkPredicate(p Predicate, lookup map[Column]int, row Row) bool {
 		if !ok {
 			panic("checkPredicate: column not found")
 		}
-		return CompareValues(row.Values[columnIndex], p.Value) == 0
+		return CompareValues(&row.Values[columnIndex], &p.Value) == 0
 
 	case InPredicate:
 		columnIndex, ok := lookup[p.Column]
@@ -321,7 +321,7 @@ func checkPredicate(p Predicate, lookup map[Column]int, row Row) bool {
 
 		found := false
 		for _, v := range p.Values {
-			if CompareValues(row.Values[columnIndex], v) == 0 {
+			if CompareValues(&row.Values[columnIndex], &v) == 0 {
 				found = true
 				break
 			}
@@ -334,14 +334,14 @@ func checkPredicate(p Predicate, lookup map[Column]int, row Row) bool {
 		if !ok {
 			panic("checkPredicate: column not found")
 		}
-		return CompareValues(row.Values[columnIndex], p.Value) > 0
+		return CompareValues(&row.Values[columnIndex], &p.Value) > 0
 
 	case LessThanPredicate:
 		columnIndex, ok := lookup[p.Column]
 		if !ok {
 			panic("checkPredicate: column not found")
 		}
-		return CompareValues(row.Values[columnIndex], p.Value) < 0
+		return CompareValues(&row.Values[columnIndex], &p.Value) < 0
 
 	case FuncPredicate:
 		columnIndex, ok := lookup[p.Column]
@@ -789,15 +789,15 @@ func (r *Reader) buildColumnPredicateRanges(ctx context.Context, c Column, p Pre
 
 		switch p := p.(type) {
 		case EqualPredicate: // EqualPredicate may be true if p.Value is inside the range of the page.
-			include = CompareValues(p.Value, minValue) >= 0 && CompareValues(p.Value, maxValue) <= 0
+			include = CompareValues(&p.Value, &minValue) >= 0 && CompareValues(&p.Value, &maxValue) <= 0
 		case GreaterThanPredicate: // GreaterThanPredicate may be true if maxValue of a page is greater than p.Value
-			include = CompareValues(maxValue, p.Value) > 0
+			include = CompareValues(&maxValue, &p.Value) > 0
 		case LessThanPredicate: // LessThanPredicate may be true if minValue of a page is less than p.Value
-			include = CompareValues(minValue, p.Value) < 0
+			include = CompareValues(&minValue, &p.Value) < 0
 		case InPredicate:
 			// Check if any value falls within the page's range
 			for _, v := range p.Values {
-				if CompareValues(v, minValue) >= 0 && CompareValues(v, maxValue) <= 0 {
+				if CompareValues(&v, &minValue) >= 0 && CompareValues(&v, &maxValue) <= 0 {
 					include = true
 					break
 				}

--- a/pkg/dataobj/internal/dataset/value.go
+++ b/pkg/dataobj/internal/dataset/value.go
@@ -2,188 +2,176 @@ package dataset
 
 import (
 	"bytes"
-	"cmp"
 	"encoding/binary"
 	"fmt"
 	"unsafe"
 
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/metadata/datasetmd"
-	"github.com/grafana/loki/v3/pkg/dataobj/internal/util/slicegrow"
 )
 
-// Helper types
-type (
-	bytearray *byte
-)
+// InvalidTypeError is used as a panic value when using [Value] methods with
+// the incorrect type.
+type InavlidTypeError struct {
+	Expected datasetmd.ValueType
+	Actual   datasetmd.ValueType
+}
+
+// Error returns a string representation denoting the expected and actual
+// types.
+func (e *InavlidTypeError) Error() string {
+	return fmt.Sprintf("invalid type: expected %s, got %s", e.Expected, e.Actual)
+}
+
+// UnsupportedTypeError is used as a panic value when using [Value] methods with
+// an unsupported type.
+type UnsupportedTypeError struct {
+	Got datasetmd.ValueType
+}
+
+// Error returns a string representation denoting the unsupported type.
+func (e *UnsupportedTypeError) Error() string {
+	return fmt.Sprintf("unsupported type: %s", e.Got)
+}
 
 // A Value represents a single value within a dataset. Unlike [any], Values can
 // be constructed without allocations. The zero Value corresponds to nil.
 type Value struct {
-	// The internal representation of Value is based on log/slog.Value, which is
-	// also designed to avoid allocations.
+	// The internal representation of Value is designed to avoid allocations by
+	// using a fixed-size struct that can represent all supported types without
+	// needing to allocate memory for each value (such as wrapping a value into
+	// an interface).
 	//
-	// While usage of any typically causes an allocation (due to any being a fat
-	// pointer), our usage avoids it:
-	//
-	// * Go will avoid allocating integer values that can be stored in a single
-	//   byte, which applies to datasetmd.ValueType.
-	//
-	// * If any is referring to a pointer, then wrapping the poitner in an any
-	//   does not cause an allocation. This is why we use stringptr instead of a
-	//   string.
+	// As a side effect of this, Value is heavy on the stack, costing at least 28
+	// bytes for 64-bit builds. This cost is reduced by using pointer receivers
+	// wherever possible.
 
 	_ [0]func() // Disallow equality checking of two Values
 
-	// num holds the value for numeric types, or the string length for string
-	// types.
+	// kind holds the type of the value.
+	kind datasetmd.ValueType
+
+	// num holds the value for numeric kinds, or the string length for string
+	// kinds.
 	num uint64
 
-	// cap holds the capacity for byte slice pointed to by any, if applicable.
+	// cap holds the capacity of the underlying memory in data.
 	cap uint64
 
-	// If any is of type [datasetmd.ValueType], then the value is in num as
-	// described above.
+	// data optionally holds a pointer to the start of a byte slice. When data is
+	// specified, num is the length of the byte slice, and cap is the capacity.
 	//
-	// If any is of type stringptr, then the value is of type
-	// [datasetmd.VALUE_TYPE_STRING] and the string value consists of the length
-	// in num and the pointer in any.
-	any any
+	// data can be set even if kind is not [datasetmd.VALUE_TYPE_BYTE_ARRAY]. In
+	// that case, data can still be used to access the underlying memory for
+	// reuse via [Value.Buffer].
+	data *byte
 }
 
 // Int64Value rerturns a [Value] for an int64.
 func Int64Value(v int64) Value {
 	return Value{
-		num: uint64(v),
-		any: datasetmd.VALUE_TYPE_INT64,
+		kind: datasetmd.VALUE_TYPE_INT64,
+		num:  uint64(v),
 	}
 }
 
 // Uint64Value returns a [Value] for a uint64.
 func Uint64Value(v uint64) Value {
 	return Value{
-		num: v,
-		any: datasetmd.VALUE_TYPE_UINT64,
+		kind: datasetmd.VALUE_TYPE_UINT64,
+		num:  v,
 	}
 }
 
 // ByteArrayValue returns a [Value] for a byte slice representing a string.
 func ByteArrayValue(v []byte) Value {
 	return Value{
-		num: uint64(len(v)),
-		any: (bytearray)(unsafe.SliceData(v)),
-		cap: uint64(cap(v)),
+		kind: datasetmd.VALUE_TYPE_BYTE_ARRAY,
+		num:  uint64(len(v)),
+		cap:  uint64(cap(v)),
+		data: unsafe.SliceData(v),
 	}
 }
 
 // IsNil returns whether v is nil.
-func (v Value) IsNil() bool {
-	return v.any == nil
+func (v *Value) IsNil() bool {
+	return v.Type() == datasetmd.VALUE_TYPE_UNSPECIFIED
 }
 
 // IsZero reports whether v is the zero value.
-func (v Value) IsZero() bool {
-	// If Value is a numeric type, v.num == 0 checks if it's the zero value. For
-	// string types, v.num == 0 means the string is empty.
-	return v.num == 0
+func (v *Value) IsZero() bool {
+	return v.IsNil() || v.num == 0
 }
 
 // Type returns the [datasetmd.ValueType] of v. If v is nil, Type returns
 // [datasetmd.VALUE_TYPE_UNSPECIFIED].
-func (v Value) Type() datasetmd.ValueType {
-	if v.IsNil() {
+func (v *Value) Type() datasetmd.ValueType {
+	if v == nil {
 		return datasetmd.VALUE_TYPE_UNSPECIFIED
 	}
-
-	switch v := v.any.(type) {
-	case datasetmd.ValueType:
-		return v
-	case bytearray:
-		return datasetmd.VALUE_TYPE_BYTE_ARRAY
-	default:
-		panic(fmt.Sprintf("dataset.Value has unexpected type %T", v))
-	}
+	return v.kind
 }
 
 // Int64 returns v's value as an int64. It panics if v is not a
 // [datasetmd.VALUE_TYPE_INT64].
 func (v *Value) Int64() int64 {
 	if expect, actual := datasetmd.VALUE_TYPE_INT64, v.Type(); expect != actual {
-		panic(fmt.Sprintf("dataset.Value type is %s, not %s", actual, expect))
+		panic(&InavlidTypeError{expect, actual})
 	}
-	return int64(v.num)
+	return v.int64()
 }
+
+func (v *Value) int64() int64 { return int64(v.num) }
 
 // Uint64 returns v's value as a uint64. It panics if v is not a
 // [datasetmd.VALUE_TYPE_UINT64].
 func (v *Value) Uint64() uint64 {
 	if expect, actual := datasetmd.VALUE_TYPE_UINT64, v.Type(); expect != actual {
-		panic(fmt.Sprintf("dataset.Value type is %s, not %s", actual, expect))
+		panic(&InavlidTypeError{expect, actual})
 	}
-	return v.num
+	return v.uint64()
 }
+
+func (v *Value) uint64() uint64 { return v.num }
 
 // ByteSlice returns v's value as a byte slice. If v is not a string,
 // ByteSlice returns a byte slice of the form "VALUE_TYPE_T", where T is the
 // underlying type of v.
 func (v *Value) ByteArray() []byte {
-	if ba, ok := v.any.(bytearray); ok {
-		return unsafe.Slice(ba, v.num)
+	if expect, actual := datasetmd.VALUE_TYPE_BYTE_ARRAY, v.Type(); expect != actual {
+		panic(&InavlidTypeError{expect, actual})
 	}
-	panic(fmt.Sprintf("dataset.Value type is %s, not %s", v.Type(), datasetmd.VALUE_TYPE_BYTE_ARRAY))
+	return v.byteArray()
 }
 
-// Buffer returns a slice with a capacity of at least sz. Existing
-// memory pointed to by Value is reused where possible, either
-// returning the underlying memory or growing it to be at least
-// sz.
+// Buffer returns any memory that was allocated for v, even if v is currently
+// null.
 //
-// If Value does not point to any underlying memory, a new slice
-// is allocated.
+// If Value does not hold underlying memory, Buffer returns nil.
+func (v *Value) Buffer() []byte {
+	return v.byteArray()
+}
+
+func (v *Value) byteArray() []byte {
+	if v.data == nil {
+		return nil
+	}
+
+	// v.data can only be non-nil if it was previously used as a
+	// [datasetmd.VALUE_TYPE_BYTE_ARRAY].
+	//
+	// If this is the case, it's safe to interpret v.num and v.cap as the
+	// length/cap, since there's no way to change the type of a Value other than
+	// from a non-NULL type to a NULL type.
+	return unsafe.Slice(v.data, v.cap)[:v.num]
+}
+
+// Zero sets Value to its zero state while retaining any underlying memory if
+// Value was a [datasetmd.VALUE_TYPE_BYTE_ARRAY]. After calling Zero,
+// [Value.IsNil] and [Value.IsZero] will both report true.
 //
-// After calling Buffer, Value is updated to store the returned
-// slice.
-func (v *Value) Buffer(sz int) []byte {
-	if v.cap == 0 {
-		dst := make([]byte, sz)
-		v.any = (bytearray)(unsafe.SliceData(dst))
-		v.cap = uint64(cap(dst))
-		return dst
-	}
-
-	var dst []byte
-	// Depending on which type this value was previously used for dictates how we reference the memory.
-	switch v.any.(type) {
-	case bytearray:
-		dst = unsafe.Slice(v.any.(bytearray), int(v.cap))
-	default:
-		panic("unsupported value type for buffer in Value's 'any' field, got " + v.Type().String())
-	}
-
-	// Grow the buffer attached to this Value if necessary.
-	if v.cap < uint64(sz) {
-		dst = slicegrow.GrowToCap(dst, sz)
-		v.any = (bytearray)(unsafe.SliceData(dst))
-		v.cap = uint64(cap(dst))
-	}
-	return dst
-}
-
-// SetByteArrayValue updates the value to point to the provided byte slice.
-// This will overwrite any existing data stored in this Value and update it to be of type [datasetmd.VALUE_TYPE_BYTE_ARRAY].
-func (v *Value) SetByteArrayValue(b []byte) {
-	v.any = (bytearray)(unsafe.SliceData(b))
-	v.num = uint64(len(b))
-	v.cap = uint64(cap(b))
-}
-
-// Zero resets the value to its zero state while retaining pointers to any existing memory.
-// After calling Zero:
-// - The value will report as zero but not nil if it points to underlying memory
-// - The value will also report as nil only if it doesn't point to any underlying memory
-// - Any subsequent operations that read the value will treat it as empty
-// - Any subsequent operations that write to a non-nil zero value will re-use the underlying memory.
+// However, [Value.ByteArray] will continue to return the underlying memory.
 func (v *Value) Zero() {
-	v.num = 0
+	v.kind = datasetmd.VALUE_TYPE_UNSPECIFIED
 }
 
 // MarshalBinary encodes v into a binary representation. Non-NULL values encode
@@ -251,39 +239,7 @@ func (v *Value) UnmarshalBinary(data []byte) error {
 	return nil
 }
 
-// CompareValues returns -1 if a<b, 0 if a==b, or 1 if a>b. CompareValues
-// panics if a and b are not the same type.
-//
-// As a special case, either a or b may be nil. Two nil values are equal, and a
-// nil value is always less than a non-nil value.
-func CompareValues(a, b Value) int {
-	// nil handling. This must be done before the typecheck since nil has a
-	// special type.
-	switch {
-	case a.IsNil() && !b.IsNil():
-		return -1
-	case !a.IsNil() && b.IsNil():
-		return 1
-	case a.IsNil() && b.IsNil():
-		return 0
-	}
-
-	if a.Type() != b.Type() {
-		panic(fmt.Sprintf("page.CompareValues: cannot compare values of type %s and %s", a.Type(), b.Type()))
-	}
-
-	switch a.Type() {
-	case datasetmd.VALUE_TYPE_INT64:
-		return cmp.Compare(a.Int64(), b.Int64())
-	case datasetmd.VALUE_TYPE_UINT64:
-		return cmp.Compare(a.Uint64(), b.Uint64())
-	case datasetmd.VALUE_TYPE_BYTE_ARRAY:
-		return bytes.Compare(a.ByteArray(), b.ByteArray())
-	default:
-		panic(fmt.Sprintf("page.CompareValues: unsupported type %s", a.Type()))
-	}
-}
-
+// Size returns the size of v in bytes when encoded.
 func (v Value) Size() int {
 	switch v.Type() {
 	case datasetmd.VALUE_TYPE_INT64:
@@ -295,6 +251,51 @@ func (v Value) Size() int {
 	case datasetmd.VALUE_TYPE_UNSPECIFIED:
 		return 0
 	default:
-		panic(fmt.Sprintf("dataset.Value.Size: unsupported type %s", v.Type()))
+		panic(&UnsupportedTypeError{v.Type()})
 	}
+}
+
+// CompareValues returns -1 if a<b, 0 if a==b, or 1 if a>b. CompareValues
+// panics if a and b are not the same type.
+//
+// As a special case, either a or b may be nil. Two nil values are equal, and a
+// nil value is always less than a non-nil value.
+func CompareValues(a, b *Value) int {
+	var (
+		aType, bType = a.Type(), b.Type()
+		aNil, bNil   = aType == datasetmd.VALUE_TYPE_UNSPECIFIED, bType == datasetmd.VALUE_TYPE_UNSPECIFIED
+	)
+
+	// Handle nil values first to avoid the panic if the types don't match.
+	switch {
+	case aNil && !bNil:
+		return -1
+	case !aNil && bNil:
+		return 1
+	case aNil && bNil:
+		return 0
+
+	case aType != bType:
+		panic(&InavlidTypeError{aType, bType})
+
+	case aType == datasetmd.VALUE_TYPE_INT64:
+		return cmpInteger(a.int64(), b.int64())
+
+	case aType == datasetmd.VALUE_TYPE_UINT64:
+		return cmpInteger(a.uint64(), b.uint64())
+
+	case aType == datasetmd.VALUE_TYPE_BYTE_ARRAY:
+		return bytes.Compare(a.byteArray(), b.byteArray())
+	}
+
+	panic(&UnsupportedTypeError{a.Type()})
+}
+
+func cmpInteger[T int64 | uint64](a, b T) int {
+	if a < b {
+		return -1
+	} else if a > b {
+		return 1
+	}
+	return 0
 }

--- a/pkg/dataobj/internal/dataset/value.go
+++ b/pkg/dataobj/internal/dataset/value.go
@@ -11,14 +11,14 @@ import (
 
 // InvalidTypeError is used as a panic value when using [Value] methods with
 // the incorrect type.
-type InavlidTypeError struct {
+type InvalidTypeError struct {
 	Expected datasetmd.ValueType
 	Actual   datasetmd.ValueType
 }
 
 // Error returns a string representation denoting the expected and actual
 // types.
-func (e *InavlidTypeError) Error() string {
+func (e *InvalidTypeError) Error() string {
 	return fmt.Sprintf("invalid type: expected %s, got %s", e.Expected, e.Actual)
 }
 
@@ -115,7 +115,7 @@ func (v *Value) Type() datasetmd.ValueType {
 // [datasetmd.VALUE_TYPE_INT64].
 func (v *Value) Int64() int64 {
 	if expect, actual := datasetmd.VALUE_TYPE_INT64, v.Type(); expect != actual {
-		panic(&InavlidTypeError{expect, actual})
+		panic(&InvalidTypeError{expect, actual})
 	}
 	return v.int64()
 }
@@ -126,7 +126,7 @@ func (v *Value) int64() int64 { return int64(v.num) }
 // [datasetmd.VALUE_TYPE_UINT64].
 func (v *Value) Uint64() uint64 {
 	if expect, actual := datasetmd.VALUE_TYPE_UINT64, v.Type(); expect != actual {
-		panic(&InavlidTypeError{expect, actual})
+		panic(&InvalidTypeError{expect, actual})
 	}
 	return v.uint64()
 }
@@ -138,7 +138,7 @@ func (v *Value) uint64() uint64 { return v.num }
 // underlying type of v.
 func (v *Value) ByteArray() []byte {
 	if expect, actual := datasetmd.VALUE_TYPE_BYTE_ARRAY, v.Type(); expect != actual {
-		panic(&InavlidTypeError{expect, actual})
+		panic(&InvalidTypeError{expect, actual})
 	}
 	return v.byteArray()
 }
@@ -276,7 +276,7 @@ func CompareValues(a, b *Value) int {
 		return 0
 
 	case aType != bType:
-		panic(&InavlidTypeError{aType, bType})
+		panic(&InvalidTypeError{aType, bType})
 
 	case aType == datasetmd.VALUE_TYPE_INT64:
 		return cmpInteger(a.int64(), b.int64())

--- a/pkg/dataobj/internal/dataset/value_encoding_plain.go
+++ b/pkg/dataobj/internal/dataset/value_encoding_plain.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/metadata/datasetmd"
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/streamio"
+	"github.com/grafana/loki/v3/pkg/dataobj/internal/util/slicegrow"
 )
 
 func init() {
@@ -123,13 +124,13 @@ func (dec *plainBytesDecoder) decode(v *Value) error {
 		return err
 	}
 
-	dst := v.Buffer(int(sz))
+	dst := slicegrow.GrowToCap(v.Buffer(), int(sz))
 	dst = dst[:sz]
 	if _, err := io.ReadFull(dec.r, dst); err != nil {
 		return err
 	}
 
-	v.SetByteArrayValue(dst)
+	*v = ByteArrayValue(dst)
 	return nil
 }
 

--- a/pkg/dataobj/internal/dataset/value_test.go
+++ b/pkg/dataobj/internal/dataset/value_test.go
@@ -9,6 +9,99 @@ import (
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/metadata/datasetmd"
 )
 
+func BenchmarkValue_Type(b *testing.B) {
+	tt := []struct {
+		name  string
+		value dataset.Value
+	}{
+		{"Null", dataset.Value{}},
+		{"Int64Value", dataset.Int64Value(-1234)},
+		{"Uint64Value", dataset.Uint64Value(1234)},
+		{"ByteArrayValue", dataset.ByteArrayValue([]byte("hello, world!"))},
+	}
+
+	for _, tc := range tt {
+		b.Run(tc.name, func(b *testing.B) {
+			for b.Loop() {
+				tc.value.Type()
+			}
+		})
+	}
+}
+
+func BenchmarkValue_Create(b *testing.B) {
+	b.Run("Null", func(b *testing.B) {
+		for b.Loop() {
+			_ = dataset.Value{}
+		}
+	})
+
+	b.Run("Int64Value", func(b *testing.B) {
+		for b.Loop() {
+			_ = dataset.Int64Value(-1234)
+		}
+	})
+
+	b.Run("Uint64Value", func(b *testing.B) {
+		for b.Loop() {
+			_ = dataset.Uint64Value(1234)
+		}
+	})
+
+	b.Run("ByteArrayValue", func(b *testing.B) {
+		for b.Loop() {
+			_ = dataset.ByteArrayValue([]byte("hello, world!"))
+		}
+	})
+}
+
+func BenchmarkValue_Int64(b *testing.B) {
+	v := dataset.Int64Value(-1234)
+	for b.Loop() {
+		v.Int64()
+	}
+}
+
+func BenchmarkValue_Uint64(b *testing.B) {
+	v := dataset.Uint64Value(1234)
+	for b.Loop() {
+		v.Uint64()
+	}
+}
+
+func BenchmarkValue_ByteArray(b *testing.B) {
+	v := dataset.ByteArrayValue([]byte("hello, world!"))
+	for b.Loop() {
+		v.ByteArray()
+	}
+}
+
+func BenchmarkCompareValues(b *testing.B) {
+	tt := []struct {
+		name string
+		a, b dataset.Value
+	}{
+		{"two nulls", dataset.Value{}, dataset.Value{}},
+		{"int64 < int64", dataset.Int64Value(-1234), dataset.Int64Value(1234)},
+		{"int64 == int64", dataset.Int64Value(1234), dataset.Int64Value(1234)},
+		{"int64 > int64", dataset.Int64Value(1234), dataset.Int64Value(-1234)},
+		{"uint64 < uint64", dataset.Uint64Value(1234), dataset.Uint64Value(5678)},
+		{"uint64 == uint64", dataset.Uint64Value(1234), dataset.Uint64Value(1234)},
+		{"uint64 > uint64", dataset.Uint64Value(5678), dataset.Uint64Value(1234)},
+		{"bytearray < bytearray", dataset.ByteArrayValue([]byte("abc")), dataset.ByteArrayValue([]byte("def"))},
+		{"bytearray == bytearray", dataset.ByteArrayValue([]byte("abc")), dataset.ByteArrayValue([]byte("abc"))},
+		{"bytearray > bytearray", dataset.ByteArrayValue([]byte("def")), dataset.ByteArrayValue([]byte("abc"))},
+	}
+
+	for _, tc := range tt {
+		b.Run(tc.name, func(b *testing.B) {
+			for b.Loop() {
+				dataset.CompareValues(&tc.a, &tc.b)
+			}
+		})
+	}
+}
+
 func TestValue_MarshalBinary(t *testing.T) {
 	t.Run("Null", func(t *testing.T) {
 		var expect dataset.Value

--- a/pkg/dataobj/sections/logs/row_predicate_order.go
+++ b/pkg/dataobj/sections/logs/row_predicate_order.go
@@ -62,7 +62,7 @@ func getPredicateSelectivity(p dataset.Predicate) selectivityScore {
 		if info.Statistics.MinValue != nil && info.Statistics.MaxValue != nil {
 			var minValue, maxValue dataset.Value
 			if e1, e2 := minValue.UnmarshalBinary(info.Statistics.MinValue), maxValue.UnmarshalBinary(info.Statistics.MaxValue); e1 == nil && e2 == nil {
-				if dataset.CompareValues(p.Value, minValue) < 0 || dataset.CompareValues(p.Value, maxValue) > 0 {
+				if dataset.CompareValues(&p.Value, &minValue) < 0 || dataset.CompareValues(&p.Value, &maxValue) > 0 {
 					// no rows will match
 					return noMatchSelectivity
 				}
@@ -87,7 +87,7 @@ func getPredicateSelectivity(p dataset.Predicate) selectivityScore {
 				valuesInRange = 0
 
 				for _, v := range p.Values {
-					if dataset.CompareValues(v, minValue) >= 0 && dataset.CompareValues(v, maxValue) <= 0 {
+					if dataset.CompareValues(&v, &minValue) >= 0 && dataset.CompareValues(&v, &maxValue) <= 0 {
 						valuesInRange++
 					}
 				}
@@ -115,10 +115,10 @@ func getPredicateSelectivity(p dataset.Predicate) selectivityScore {
 		}
 
 		if e1, e2 := minValue.UnmarshalBinary(info.Statistics.MinValue), maxValue.UnmarshalBinary(info.Statistics.MaxValue); e1 == nil && e2 == nil {
-			if dataset.CompareValues(p.Value, minValue) < 0 {
+			if dataset.CompareValues(&p.Value, &minValue) < 0 {
 				return selectivityScore(1.0)
 			}
-			if dataset.CompareValues(p.Value, maxValue) > 0 {
+			if dataset.CompareValues(&p.Value, &maxValue) > 0 {
 				return selectivityScore(0.0)
 			}
 
@@ -140,10 +140,10 @@ func getPredicateSelectivity(p dataset.Predicate) selectivityScore {
 		}
 
 		if e1, e2 := minValue.UnmarshalBinary(info.Statistics.MinValue), maxValue.UnmarshalBinary(info.Statistics.MaxValue); e1 == nil && e2 == nil {
-			if dataset.CompareValues(p.Value, minValue) < 0 {
+			if dataset.CompareValues(&p.Value, &minValue) < 0 {
 				return selectivityScore(0.0)
 			}
-			if dataset.CompareValues(p.Value, maxValue) > 0 {
+			if dataset.CompareValues(&p.Value, &maxValue) > 0 {
 				return selectivityScore(1.0)
 			}
 


### PR DESCRIPTION
This PR makes several small changes to improve the performance of the dataset.Value API:

1. Reduce the complexity of methods so that methods can be inlined. The previous complexity of Value.Type bubbled down to all the methods, making them hard to inline.

   Using error types for panics also reduces the complexity cost of the panic lines while retaining the same error messages; the cost of both string concatenation and fmt.Sprintf bubbled up the cost, further making it difficult to inline functions.

2. Use pointer receivers wherever possible for Value methods. As each Value is 28 bytes (previously 24, but still large), copying the Value on the stack to call a non-inlined method was expensive. This was seen most prominently in CompareValues, which still can't be inlined. Using pointers for CompareValues significantly improves its performance.

3. Replace use of `any` for the final field with a plain `*byte` type. This ensures that there are absolutely no allocations for that field. Some usages of the old field have been replaced with the explicit kind field.

Additionally, smaller changes have been made:

* All methods that mutate the state of Value have been removed, with the exception of Zero. Functionality of these methods have been pushed down to the caller. This was done to reduce the complexity of the code, but also to manually inline that logic into the plain value encoder.

* Usage of cmp.Compare has been replaced with a hand-rolled compare method for integers, which is slightly less expensive due to not needing to handle the possibility of floating-point numbers.

As a result of these changes, the synthetic logql/bench benchmarks show a 10-15% speed improvement in all queries.