### PR TITLE
chore: expose tables manager interface from compactor

### DIFF
--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -580,6 +580,10 @@ func (c *Compactor) RegisterIndexCompactor(indexType string, indexCompactor Inde
 	c.indexCompactors[indexType] = indexCompactor
 }
 
+func (c *Compactor) TablesManager() TablesManager {
+	return c.tablesManager
+}
+
 type expirationChecker struct {
 	retentionExpiryChecker retention.ExpirationChecker
 	deletionExpiryChecker  retention.ExpirationChecker


### PR DESCRIPTION
**What this PR does / why we need it**:
Exposing the tables manager interface from the compactor to expose compaction functionality to external tools.