### PR TITLE
fix(ci): Fix workflow timeout added in wrong format

### DIFF
--- a/.github/workflows/operator-release-please.yml
+++ b/.github/workflows/operator-release-please.yml
@@ -66,7 +66,7 @@ jobs:
       - name: "Login to DockerHub (from vault)"
         uses: "grafana/shared-workflows/actions/dockerhub-login@75804962c1ba608148988c1e2dc35fbb0ee21746"
       - name: "Build and push"
-        timeout-minutes: ${{ env.BUILD_TIMEOUT }}
+        timeout-minutes: "${{ fromJSON(env.BUILD_TIMEOUT) }}"
         uses: "docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1" # v6
         with:
           context: "operator"


### PR DESCRIPTION
**What this PR does / why we need it**:

It looks like the format for the `timeout-minutes` is given in the wrong format, because runs keep erroring on that line. I have not dug much deeper just compared with the other configuration files and adjusted the configuration accordingly.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
