### PR TITLE
fix(stream-generator): Split active stream locks per tenant

### DIFF
--- a/tools/stream-generator/generator/service.go
+++ b/tools/stream-generator/generator/service.go
@@ -249,7 +249,7 @@ func (s *Generator) create(ctx context.Context, tenant string, lockIdx int, stre
 				batch := streams[activeStreams : activeStreams+batchSize]
 				s.pushStreams(ctx, tenant, batch, errCh)
 
-				s.metrics.streamsCreatedTotal.WithLabelValues(tenant).Add(float64(batchSize))
+				s.metrics.streamsCreatedTotal.WithLabelValues(tenant).Inc()
 				s.activeStreams[lockIdx] += batchSize
 			}()
 		}

--- a/tools/stream-generator/generator/service.go
+++ b/tools/stream-generator/generator/service.go
@@ -184,14 +184,15 @@ func (s *Generator) running(ctx context.Context) error {
 	}
 
 	// Wait for context cancellation, subservice failure, or tenant error
-	select {
-	case <-ctx.Done():
-		return nil
-	case err := <-s.subservicesWatcher.Chan():
-		return errors.Wrap(err, "stream-generator subservice failed")
-	case err := <-errCh:
-		level.Error(s.logger).Log("msg", "stream-generator error", "err", err)
-		return err
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case err := <-s.subservicesWatcher.Chan():
+			return errors.Wrap(err, "stream-generator subservice failed")
+		case err := <-errCh:
+			level.Error(s.logger).Log("msg", "stream-generator error", "err", err)
+		}
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This pull request will split the active streams counter used in the stream generator to become per tenant. This fixes a bug when the counter was used across streams and the batch size was higher than the total streams per tenant, results in only streams created only by the first tenant winning the race.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
