### PR TITLE
Limit patterns

### DIFF
--- a/pkg/pattern/drain/drain.go
+++ b/pkg/pattern/drain/drain.go
@@ -32,8 +32,6 @@ import (
 	"github.com/hashicorp/golang-lru/v2/simplelru"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
-	"github.com/prometheus/prometheus/model/labels"
-
 )
 
 type Config struct {
@@ -204,8 +202,7 @@ func (d *Drain) Clusters() []*LogCluster {
 	return d.idToCluster.Values()
 }
 
-
-func (d *Drain) Train(lvl, content string, ts int64, lbls labels.Labels) *LogCluster {
+func (d *Drain) Train(content string, ts int64) *LogCluster {
 	if !d.limiter.Allow() {
 		return nil
 	}
@@ -218,10 +215,14 @@ func (d *Drain) Train(lvl, content string, ts int64, lbls labels.Labels) *LogClu
 		return nil
 	}
 
-	return d.train(lvl, d.tokens, d.state, ts, lbls)
+	var (
+		tokens = d.tokens
+		state  = d.state
+	)
+	return d.train(tokens, state, ts)
 }
 
-func (d *Drain) train(lvl string, tokens []string, state interface{}, ts int64, lbls labels.Labels) *LogCluster {
+func (d *Drain) train(tokens []string, state any, ts int64) *LogCluster {
 	if len(tokens) < 4 {
 		if d.metrics != nil && d.metrics.LinesSkipped != nil {
 			d.metrics.LinesSkipped.WithLabelValues(TooFewTokens).Inc()

--- a/pkg/pattern/drain/drain_benchmark_test.go
+++ b/pkg/pattern/drain/drain_benchmark_test.go
@@ -40,8 +40,7 @@ func BenchmarkDrain_TrainExtractsPatterns(b *testing.B) {
 				line := scanner.Text()
 				lines = append(lines, line)
 			}
-			mockWriter := &mockEntryWriter{}
-			drain := New("", DefaultConfig(), &fakeLimits{}, DetectLogFormat(lines[0]), mockWriter, nil)
+			drain := New("", DefaultConfig(), &fakeLimits{}, DetectLogFormat(lines[0]), nil)
 
 			b.ReportAllocs()
 			b.ResetTimer()

--- a/pkg/pattern/drain/drain_benchmark_test.go
+++ b/pkg/pattern/drain/drain_benchmark_test.go
@@ -46,7 +46,7 @@ func BenchmarkDrain_TrainExtractsPatterns(b *testing.B) {
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				for _, line := range lines {
-					drain.Train(info, line, 0, labels.EmptyLabels())
+					drain.Train(line, 0)
 				}
 			}
 		})

--- a/pkg/pattern/drain/drain_test.go
+++ b/pkg/pattern/drain/drain_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/prometheus/prometheus/model/labels"
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/loki/v3/pkg/logql/log/pattern"
@@ -26,7 +25,6 @@ func TestDrain_TrainExtractsPatterns(t *testing.T) {
 
 	// Set this so the test will print the patterns found, in string slice format for easy copy-paste
 	outputPatternsForTestUpdate := false
-	mockWriter := &mockEntryWriter{}
 	tests := []struct {
 		drain         *Drain
 		inputFile     string
@@ -35,7 +33,7 @@ func TestDrain_TrainExtractsPatterns(t *testing.T) {
 		format        string
 	}{
 		{
-			drain:     New(testTenant, DefaultConfig(), &fakeLimits{}, "", mockWriter, nil),
+			drain:     New(testTenant, DefaultConfig(), &fakeLimits{}, "", nil),
 			inputFile: `testdata/agent-logfmt.txt`,
 			format:    FormatLogfmt,
 			patterns: []string{
@@ -66,7 +64,7 @@ func TestDrain_TrainExtractsPatterns(t *testing.T) {
 			},
 		},
 		{
-			drain:     New(testTenant, DefaultConfig(), &fakeLimits{}, "", mockWriter, nil),
+			drain:     New(testTenant, DefaultConfig(), &fakeLimits{}, "", nil),
 			inputFile: `testdata/ingester-logfmt.txt`,
 			format:    FormatLogfmt,
 			patterns: []string{
@@ -77,7 +75,7 @@ func TestDrain_TrainExtractsPatterns(t *testing.T) {
 			tooManyTokens: []string{},
 		},
 		{
-			drain:     New(testTenant, DefaultConfig(), &fakeLimits{}, "", mockWriter, nil),
+			drain:     New(testTenant, DefaultConfig(), &fakeLimits{}, "", nil),
 			inputFile: `testdata/drone-json.txt`,
 			format:    FormatJSON,
 			patterns: []string{
@@ -92,7 +90,7 @@ func TestDrain_TrainExtractsPatterns(t *testing.T) {
 			},
 		},
 		{
-			drain:     New(testTenant, DefaultConfig(), &fakeLimits{}, "", mockWriter, nil),
+			drain:     New(testTenant, DefaultConfig(), &fakeLimits{}, "", nil),
 			inputFile: "testdata/distributor-logfmt.txt",
 			format:    FormatLogfmt,
 			patterns: []string{
@@ -106,7 +104,7 @@ func TestDrain_TrainExtractsPatterns(t *testing.T) {
 			},
 		},
 		{
-			drain:     New(testTenant, DefaultConfig(), &fakeLimits{}, "", mockWriter, nil),
+			drain:     New(testTenant, DefaultConfig(), &fakeLimits{}, "", nil),
 			inputFile: "testdata/journald.txt",
 			format:    FormatUnknown,
 			patterns: []string{
@@ -228,7 +226,7 @@ func TestDrain_TrainExtractsPatterns(t *testing.T) {
 			},
 		},
 		{
-			drain:     New(testTenant, DefaultConfig(), &fakeLimits{}, "", mockWriter, nil),
+			drain:     New(testTenant, DefaultConfig(), &fakeLimits{}, "", nil),
 			inputFile: "testdata/kafka.txt",
 			format:    FormatUnknown,
 			patterns: []string{
@@ -251,7 +249,7 @@ func TestDrain_TrainExtractsPatterns(t *testing.T) {
 			},
 		},
 		{
-			drain:     New(testTenant, DefaultConfig(), &fakeLimits{}, "", mockWriter, nil),
+			drain:     New(testTenant, DefaultConfig(), &fakeLimits{}, "", nil),
 			inputFile: "testdata/kubernetes.txt",
 			format:    FormatUnknown,
 			patterns: []string{
@@ -292,7 +290,7 @@ func TestDrain_TrainExtractsPatterns(t *testing.T) {
 			},
 		},
 		{
-			drain:     New(testTenant, DefaultConfig(), &fakeLimits{}, "", mockWriter, nil),
+			drain:     New(testTenant, DefaultConfig(), &fakeLimits{}, "", nil),
 			inputFile: "testdata/vault.txt",
 			format:    FormatUnknown,
 			patterns: []string{
@@ -300,7 +298,7 @@ func TestDrain_TrainExtractsPatterns(t *testing.T) {
 			},
 		},
 		{
-			drain:     New(testTenant, DefaultConfig(), &fakeLimits{}, "", mockWriter, nil),
+			drain:     New(testTenant, DefaultConfig(), &fakeLimits{}, "", nil),
 			inputFile: "testdata/calico.txt",
 			format:    FormatUnknown,
 			tooManyTokens: []string{
@@ -395,7 +393,7 @@ func TestDrain_TrainExtractsPatterns(t *testing.T) {
 			},
 		},
 		{
-			drain:     New(testTenant, DefaultConfig(), &fakeLimits{}, "", mockWriter, nil),
+			drain:     New(testTenant, DefaultConfig(), &fakeLimits{}, "", nil),
 			inputFile: "testdata/grafana-ruler.txt",
 			format:    FormatLogfmt,
 			patterns: []string{
@@ -489,7 +487,6 @@ func TestDrain_TrainExtractsPatterns(t *testing.T) {
 
 func TestDrain_TrainGeneratesPatternsMatchableByLokiPatternFilter(t *testing.T) {
 	t.Parallel()
-	mockWriter := &mockEntryWriter{}
 	tests := []struct {
 		name       string
 		drain      *Drain
@@ -497,7 +494,7 @@ func TestDrain_TrainGeneratesPatternsMatchableByLokiPatternFilter(t *testing.T) 
 	}{
 		{
 			name:  "should extract patterns that all lines match",
-			drain: New(testTenant, DefaultConfig(), &fakeLimits{}, "", mockWriter, nil),
+			drain: New(testTenant, DefaultConfig(), &fakeLimits{}, "", nil),
 			inputLines: []string{
 				"test 1 test test",
 				"test 2 test test",
@@ -507,7 +504,7 @@ func TestDrain_TrainGeneratesPatternsMatchableByLokiPatternFilter(t *testing.T) 
 		},
 		{
 			name:  "should extract patterns that match if line ends with newlines",
-			drain: New(testTenant, DefaultConfig(), &fakeLimits{}, "", mockWriter, nil),
+			drain: New(testTenant, DefaultConfig(), &fakeLimits{}, "", nil),
 			inputLines: []string{
 				`test 1 test test
 `,
@@ -521,7 +518,7 @@ func TestDrain_TrainGeneratesPatternsMatchableByLokiPatternFilter(t *testing.T) 
 		},
 		{
 			name:  "should extract patterns that match if line ends with empty space",
-			drain: New(testTenant, DefaultConfig(), &fakeLimits{}, "", mockWriter, nil),
+			drain: New(testTenant, DefaultConfig(), &fakeLimits{}, "", nil),
 			inputLines: []string{
 				`test 1 test test			`,
 				`test 2 test test			`,
@@ -531,7 +528,7 @@ func TestDrain_TrainGeneratesPatternsMatchableByLokiPatternFilter(t *testing.T) 
 		},
 		{
 			name:  "should extract patterns that match if line starts with empty space",
-			drain: New(testTenant, DefaultConfig(), &fakeLimits{}, "", mockWriter, nil),
+			drain: New(testTenant, DefaultConfig(), &fakeLimits{}, "", nil),
 			inputLines: []string{
 				`			test 1 test test`,
 				`			test 2 test test`,
@@ -541,7 +538,7 @@ func TestDrain_TrainGeneratesPatternsMatchableByLokiPatternFilter(t *testing.T) 
 		},
 		{
 			name:  "Scheduler patterns are matchable",
-			drain: New(testTenant, DefaultConfig(), &fakeLimits{}, "", mockWriter, nil),
+			drain: New(testTenant, DefaultConfig(), &fakeLimits{}, "", nil),
 			inputLines: []string{
 				`ts=2024-05-30T12:50:36.648377186Z caller=scheduler_processor.go:143 level=warn msg="error contacting scheduler" err="rpc error: code = Unavailable desc = connection error: desc = \"error reading server preface: EOF\"" addr=10.0.151.101:9095`,
 				`ts=2024-05-30T12:50:36.350575929Z caller=scheduler_processor.go:143 level=warn msg="error contacting scheduler" err="rpc error: code = Unavailable desc = connection error: desc = \"error reading server preface: EOF\"" addr=10.0.151.101:9095`,
@@ -633,8 +630,6 @@ var info = constants.LogLevelInfo
 
 func TestDrain_PruneTreeClearsOldBranches(t *testing.T) {
 	t.Parallel()
-	mockWriter := &mockEntryWriter{}
-	mockWriter.On("WriteEntry", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 
 	tests := []struct {
 		name       string
@@ -643,7 +638,7 @@ func TestDrain_PruneTreeClearsOldBranches(t *testing.T) {
 	}{
 		{
 			name:  "should prune old branches",
-			drain: New(testTenant, DefaultConfig(), &fakeLimits{}, "", mockWriter, nil),
+			drain: New(testTenant, DefaultConfig(), &fakeLimits{}, "", nil),
 			inputLines: []string{
 				"test test test A",
 				"test test test B",

--- a/pkg/pattern/drain/drain_test.go
+++ b/pkg/pattern/drain/drain_test.go
@@ -9,11 +9,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/loki/v3/pkg/logql/log/pattern"
-	"github.com/grafana/loki/v3/pkg/util/constants"
 )
 
 const (
@@ -454,7 +452,7 @@ func TestDrain_TrainExtractsPatterns(t *testing.T) {
 			scanner := bufio.NewScanner(file)
 			for scanner.Scan() {
 				line := scanner.Text()
-				tt.drain.Train(info, line, 0, labels.EmptyLabels())
+				tt.drain.Train(line, 0)
 				if !detectedFormat {
 					require.Equal(t, tt.format, DetectLogFormat(line))
 					detectedFormat = true
@@ -554,7 +552,7 @@ func TestDrain_TrainGeneratesPatternsMatchableByLokiPatternFilter(t *testing.T) 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			for _, line := range tt.inputLines {
-				tt.drain.Train(info, line, 0, labels.EmptyLabels())
+				tt.drain.Train(line, 0)
 			}
 			require.Equal(t, 1, len(tt.drain.Clusters()))
 			cluster := tt.drain.Clusters()[0]
@@ -626,8 +624,6 @@ func TestDeduplicatePlaceholders(b *testing.T) {
 	}
 }
 
-var info = constants.LogLevelInfo
-
 func TestDrain_PruneTreeClearsOldBranches(t *testing.T) {
 	t.Parallel()
 
@@ -662,7 +658,7 @@ func TestDrain_PruneTreeClearsOldBranches(t *testing.T) {
 				if i < 7 {
 					ts = ts.Add(-time.Duration(7-i) * time.Minute)
 				}
-				tt.drain.Train(info, line, ts.UnixNano(), labels.EmptyLabels())
+				tt.drain.Train(line, ts.UnixNano())
 			}
 
 			require.Len(t, tt.drain.Clusters(), 2)

--- a/pkg/pattern/drain/log_cluster.go
+++ b/pkg/pattern/drain/log_cluster.go
@@ -45,9 +45,10 @@ func (c *LogCluster) Samples() []*logproto.PatternSample {
 	return c.Chunks.samples()
 }
 
-func (c *LogCluster) Prune(olderThan time.Duration) {
-	c.Chunks.prune(olderThan)
+func (c *LogCluster) Prune(olderThan time.Duration) []*logproto.PatternSample {
+	prunedSamples := c.Chunks.prune(olderThan)
 	c.Size = c.Chunks.size()
+	return prunedSamples
 }
 
 func sumSize(samples []*logproto.PatternSample) int64 {

--- a/pkg/pattern/ingester_test.go
+++ b/pkg/pattern/ingester_test.go
@@ -145,61 +145,6 @@ func TestInstancePushQuery(t *testing.T) {
 		"foo=baz num=<_>",
 		"ts=<_> msg=hello",
 	}, patterns)
-
-	mockWriter.AssertCalled(
-		t,
-		"WriteEntry",
-		now.Time(),
-		aggregation.PatternEntry(
-			now.Time(),
-			1,
-			"ts=<_> msg=hello",
-			lbs,
-		),
-		labels.New(
-			labels.Label{Name: constants.PatternLabel, Value: "test_service"},
-		),
-		[]logproto.LabelAdapter{
-			{Name: constants.LevelLabel, Value: constants.LogLevelInfo},
-		},
-	)
-
-	mockWriter.AssertCalled(
-		t,
-		"WriteEntry",
-		now.Time(),
-		aggregation.PatternEntry(
-			now.Time(),
-			5,
-			"foo=bar num=<_>",
-			lbs,
-		),
-		labels.New(
-			labels.Label{Name: constants.PatternLabel, Value: "test_service"},
-		),
-		[]logproto.LabelAdapter{
-			{Name: constants.LevelLabel, Value: constants.LogLevelUnknown},
-		},
-	)
-
-	// writes a sample every 10s
-	mockWriter.AssertCalled(
-		t,
-		"WriteEntry",
-		now.Add(10*time.Second).Time(),
-		aggregation.PatternEntry(
-			now.Add(10*time.Second).Time(),
-			5,
-			"foo=bar num=<_>",
-			lbs,
-		),
-		labels.New(
-			labels.Label{Name: constants.PatternLabel, Value: "test_service"},
-		),
-		[]logproto.LabelAdapter{
-			{Name: constants.LevelLabel, Value: constants.LogLevelUnknown},
-		},
-	)
 }
 
 func TestInstancePushAggregateMetrics(t *testing.T) {

--- a/pkg/pattern/instance.go
+++ b/pkg/pattern/instance.go
@@ -265,6 +265,14 @@ func (i *instance) removeStream(s *stream) {
 	}
 }
 
+// flushPatterns flushes all patterns from all streams in this instance.
+func (i *instance) flushPatterns() {
+	_ = i.streams.ForEach(func(s *stream) (bool, error) {
+		s.flush()
+		return true, nil
+	})
+}
+
 func (i *instance) Observe(ctx context.Context, stream string, entries []logproto.Entry) {
 	i.aggMetricsLock.Lock()
 	defer i.aggMetricsLock.Unlock()

--- a/pkg/pattern/stream.go
+++ b/pkg/pattern/stream.go
@@ -93,10 +93,10 @@ func (s *stream) Push(
 
 		//TODO(twhitney): Can we reduce lock contention by locking by level rather than for the entire stream?
 		if pattern, ok := s.patterns[lvl]; ok {
-			pattern.Train(lvl, entry.Line, entry.Timestamp.UnixNano(), s.labels)
+			pattern.Train(entry.Line, entry.Timestamp.UnixNano())
 		} else {
 			// since we're defaulting the level to unknown above, we should never get here.
-			s.patterns[constants.LogLevelUnknown].Train(constants.LogLevelUnknown, entry.Line, entry.Timestamp.UnixNano(), s.labels)
+			s.patterns[constants.LogLevelUnknown].Train(entry.Line, entry.Timestamp.UnixNano())
 		}
 	}
 	return nil
@@ -153,6 +153,11 @@ func (s *stream) prune(olderThan time.Duration) bool {
 	}
 
 	return totalClusters == 0
+}
+
+func (s *stream) flush() {
+	// Flush all patterns by pruning everything older than 0 (i.e., everything)
+	s.prune(0)
 }
 
 func (s *stream) writePattern(

--- a/pkg/pattern/stream_test.go
+++ b/pkg/pattern/stream_test.go
@@ -8,10 +8,14 @@ import (
 	"github.com/go-kit/log"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/loki/v3/pkg/logproto"
+	"github.com/grafana/loki/v3/pkg/pattern/aggregation"
 	"github.com/grafana/loki/v3/pkg/pattern/drain"
 	"github.com/grafana/loki/v3/pkg/pattern/iter"
+	"github.com/grafana/loki/v3/pkg/util/constants"
 
 	"github.com/grafana/loki/pkg/push"
 )
@@ -48,6 +52,7 @@ func TestAddStream(t *testing.T) {
 func TestPruneStream(t *testing.T) {
 	lbs := labels.New(labels.Label{Name: "test", Value: "test"})
 	mockWriter := &mockEntryWriter{}
+	mockWriter.On("WriteEntry", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 	stream, err := newStream(model.Fingerprint(lbs.Hash()), lbs, newIngesterMetrics(nil, "test"), log.NewNopLogger(), drain.FormatUnknown, "123", drain.DefaultConfig(), &fakeLimits{}, mockWriter)
 	require.NoError(t, err)
 
@@ -78,4 +83,59 @@ func TestPruneStream(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, len(res.Series))
 	require.Equal(t, int64(1), res.Series[0].Samples[0].Value)
+}
+
+func TestStreamPatternPersistenceOnPrune(t *testing.T) {
+	lbs := labels.New(
+		labels.Label{Name: "test", Value: "test"},
+		labels.Label{Name: "service_name", Value: "test_service"},
+	)
+	mockWriter := &mockEntryWriter{}
+	stream, err := newStream(model.Fingerprint(lbs.Hash()), lbs, newIngesterMetrics(nil, "test"), log.NewNopLogger(), drain.FormatUnknown, "123", drain.DefaultConfig(), &fakeLimits{}, mockWriter)
+	require.NoError(t, err)
+
+	// Push entries with old timestamps that will be pruned
+	now := drain.TruncateTimestamp(model.TimeFromUnixNano(time.Now().UnixNano()), drain.TimeResolution).Time()
+	oldTime := now.Add(-2 * time.Hour)
+	err = stream.Push(context.Background(), []push.Entry{
+		{
+			Timestamp: oldTime,
+			Line:      "ts=1 msg=hello",
+		},
+		{
+			Timestamp: oldTime.Add(time.Minute),
+			Line:      "ts=2 msg=hello",
+		},
+		{
+			Timestamp: oldTime.Add(5 * time.Minute),
+			Line:      "ts=3 msg=hello",
+		},
+	})
+	require.NoError(t, err)
+
+	// Push a newer entry to ensure the stream isn't completely pruned
+	err = stream.Push(context.Background(), []push.Entry{
+		{
+			Timestamp: now,
+			Line:      "ts=4 msg=hello",
+		},
+	})
+	require.NoError(t, err)
+
+	// We expect one pattern entry with aggregated count (3) and latest timestamp
+	mockWriter.On("WriteEntry",
+		oldTime.Add(5*time.Minute),
+		aggregation.PatternEntry(oldTime.Add(5*time.Minute), 3, "ts=<_> msg=hello", lbs),
+		labels.New(labels.Label{Name: constants.PatternLabel, Value: "test_service"}),
+		[]logproto.LabelAdapter{
+			{Name: constants.LevelLabel, Value: constants.LogLevelUnknown},
+		},
+	)
+
+	// Prune old data - this should trigger pattern writing
+	isEmpty := stream.prune(time.Hour)
+	require.False(t, isEmpty) // Stream should not be empty due to newer entry
+
+	// Verify the pattern was written
+	mockWriter.AssertExpectations(t)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR addresses the volume of persisted patterns by delaying persistence until they are flushed from the ingesters. Previously we were persisting patterns during training. This method is ok for logs that are well structured and have few patterns, but is untenable for poorly structured logs with lots of patterns, as it produces far too much volume.

The pattern ingesters already have logic for handling high pattern churn, such as temporarily disabling detection of new patterns, and evicting infrequently used patterns. By delaying persistence until chunks are flushed, we're able to leverage all of this logic.

The downside, of course, is data durability. Patterns are stored in memory, and by default not flushed until 3hr. This PR will flush patterns on graceful shutdown, however unexpected container kills will cause data loss. Since we're just dealing with patterns that should be acceptable for now.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
