### PR TITLE
fix(helm): fix that `priorityClassName` of Loki Canary had lower precedence than the global setting

### DIFF
--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -13,6 +13,8 @@ Entries should include a reference to the pull request that introduced the chang
 
 [//]: # (<AUTOMATED_UPDATES_LOCATOR> : do not remove this line. This locator is used by the CI pipeline to automatically create a changelog entry for each new Loki release. Add other chart versions and respective changelog entries bellow this line.)
 
+- [BUGFIX] Fix that `priorityClassName` of Loki Canary had lower precedence than the global setting [#18366](https://github.com/grafana/loki/pull/18366)
+
 ## 6.31.0
 
 - [FEATURE] Added readiness probe for memcached [#15609](https://github.com/grafana/loki/pull/15609)

--- a/production/helm/loki/templates/loki-canary/_helpers.tpl
+++ b/production/helm/loki/templates/loki-canary/_helpers.tpl
@@ -33,7 +33,7 @@ Docker image name for loki-canary
 canary priority class name
 */}}
 {{- define "loki-canary.priorityClassName" -}}
-{{- $pcn := coalesce .Values.global.priorityClassName .Values.lokiCanary.priorityClassName .Values.read.priorityClassName -}}
+{{- $pcn := coalesce .Values.lokiCanary.priorityClassName .Values.global.priorityClassName .Values.read.priorityClassName -}}
 {{- if $pcn }}
 priorityClassName: {{ $pcn }}
 {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:

When having the following settings in the Loki Helm Chart

```
global:
  priorityClassName: important

lokiCanary:
  priorityClassName: less-important
```

the Loki Canary pods get the `important` priorityClassName, even though most users would expect (citation needed) the more specific setting in `lokiCanary` to have a stronger precedence than the default setting in `global`.

**Special notes for your reviewer**:

Not sure if this is considered a breaking change. I could not find anything in the code, that indicates the decision to have the precedence _this_ way was intentional.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
