### PR TITLE
fix: Row reader with no stream ID predicates

### DIFF
--- a/pkg/dataobj/sections/logs/row_reader.go
+++ b/pkg/dataobj/sections/logs/row_reader.go
@@ -222,6 +222,10 @@ func streamIDPredicate(ids iter.Seq[int64], columns []dataset.Column, columnDesc
 		values = append(values, dataset.Int64Value(i))
 	}
 
+	if len(values) == 0 {
+		return nil
+	}
+
 	return dataset.InPredicate{
 		Column: streamIDColumn,
 		Values: dataset.NewInt64ValueSet(values),

--- a/pkg/dataobj/sections/logs/row_reader_test.go
+++ b/pkg/dataobj/sections/logs/row_reader_test.go
@@ -1,0 +1,66 @@
+package logs
+
+import (
+	"bytes"
+	"context"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/grafana/loki/v3/pkg/dataobj"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRowReader_NoPredicates(t *testing.T) {
+	logsSection := buildSection(t)
+
+	readBuf := make([]Record, 3)
+	rowReader := NewRowReader(logsSection)
+	n, err := rowReader.Read(context.Background(), readBuf)
+	require.NoError(t, err)
+	require.Equal(t, 2, n)
+}
+
+func TestRowReader_StreamIDPredicate(t *testing.T) {
+	logsSection := buildSection(t)
+
+	readBuf := make([]Record, 3)
+	rowReader := NewRowReader(logsSection)
+
+	rowReader.MatchStreams(slices.Values([]int64{1}))
+	n, err := rowReader.Read(context.Background(), readBuf)
+	require.NoError(t, err)
+	require.Equal(t, 1, n)
+}
+
+func buildSection(t *testing.T) *Section {
+	logsBuilder := NewBuilder(nil, BuilderOptions{
+		StripeMergeLimit: 2,
+	})
+	logsBuilder.Append(Record{
+		StreamID:  1,
+		Timestamp: time.Now(),
+		Line:      []byte("test"),
+	})
+	logsBuilder.Append(Record{
+		StreamID:  2,
+		Timestamp: time.Now(),
+		Line:      []byte("test2"),
+	})
+
+	out := bytes.NewBuffer(nil)
+	b := dataobj.NewBuilder()
+	b.Append(logsBuilder)
+	_, err := b.Flush(out)
+	require.NoError(t, err)
+
+	obj, err := dataobj.FromReaderAt(bytes.NewReader(out.Bytes()), int64(out.Len()))
+	require.NoError(t, err)
+
+	var logsSection *Section
+	for _, section := range obj.Sections() {
+		logsSection, err = Open(context.Background(), section)
+		require.NoError(t, err)
+	}
+	return logsSection
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix row reader when there are no stream predicates
* I previously removed the if statement for no values, which I added back here and included a test to confirm.