### PR TITLE
feat: add delete commands to logcli

### DIFF
--- a/pkg/logcli/client/file.go
+++ b/pkg/logcli/client/file.go
@@ -217,6 +217,18 @@ func (f *FileClient) GetDetectedFields(
 	return nil, ErrNotSupported
 }
 
+func (f *FileClient) CreateDeleteRequest(_ DeleteRequestParams, _ bool) error {
+	return ErrNotSupported
+}
+
+func (f *FileClient) ListDeleteRequests(_ bool) ([]DeleteRequest, error) {
+	return nil, ErrNotSupported
+}
+
+func (f *FileClient) CancelDeleteRequest(_ string, _ bool, _ bool) error {
+	return ErrNotSupported
+}
+
 type limiter struct {
 	n int
 }

--- a/pkg/logcli/delete/delete.go
+++ b/pkg/logcli/delete/delete.go
@@ -1,0 +1,103 @@
+package delete
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/grafana/loki/v3/pkg/logcli/client"
+)
+
+// Query contains all necessary fields to execute delete requests
+type Query struct {
+	QueryString string
+	Start       time.Time
+	End         time.Time
+	MaxInterval string
+	Quiet       bool
+	RequestID   string
+	Force       bool
+}
+
+// CreateQuery executes a delete request creation
+func (q *Query) CreateQuery(c client.Client) error {
+	params := client.DeleteRequestParams{
+		Query: q.QueryString,
+	}
+
+	// Convert times to Unix timestamps as strings
+	if !q.Start.IsZero() {
+		params.Start = strconv.FormatInt(q.Start.Unix(), 10)
+	}
+	if !q.End.IsZero() {
+		params.End = strconv.FormatInt(q.End.Unix(), 10)
+	}
+	if q.MaxInterval != "" {
+		params.MaxInterval = q.MaxInterval
+	}
+
+	err := c.CreateDeleteRequest(params, q.Quiet)
+	if err != nil {
+		return err
+	}
+
+	if !q.Quiet {
+		fmt.Println("Delete request created successfully")
+	}
+	return nil
+}
+
+// ListQuery executes a delete request listing
+func (q *Query) ListQuery(client client.Client) error {
+	deleteRequests, err := client.ListDeleteRequests(q.Quiet)
+	if err != nil {
+		return err
+	}
+
+	if !q.Quiet {
+		fmt.Printf("Found %d delete requests:\n", len(deleteRequests))
+	}
+
+	// Pretty print the results
+	for _, req := range deleteRequests {
+		q.printDeleteRequest(req)
+	}
+
+	return nil
+}
+
+// CancelQuery executes a delete request cancellation
+func (q *Query) CancelQuery(client client.Client, requestID string, force bool) error {
+	err := client.CancelDeleteRequest(requestID, force, q.Quiet)
+	if err != nil {
+		return err
+	}
+
+	if !q.Quiet {
+		fmt.Printf("Delete request %s cancelled successfully\n", requestID)
+	}
+	return nil
+}
+
+// printDeleteRequest prints a single delete request in a formatted way
+func (q *Query) printDeleteRequest(req client.DeleteRequest) {
+	fmt.Printf("Query: %s\n", req.Query)
+	fmt.Printf("Start Time: %s\n", time.Unix(req.StartTime, 0).Format(time.RFC3339))
+	fmt.Printf("End Time: %s\n", time.Unix(req.EndTime, 0).Format(time.RFC3339))
+	fmt.Printf("Status: %s\n", req.Status)
+	fmt.Println("---")
+}
+
+// ListQueryJSON executes a delete request listing with JSON output
+func (q *Query) ListQueryJSON(client client.Client) error {
+	deleteRequests, err := client.ListDeleteRequests(q.Quiet)
+	if err != nil {
+		return err
+	}
+
+	encoder := json.NewEncoder(os.Stdout)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(deleteRequests)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds delete commands to `logcli` to interact with Loki's delete endpoints.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
