### PR TITLE
fix: trim whitespace in bucketnames to allow multi-bucket configuration

### DIFF
--- a/pkg/storage/chunk/client/aws/s3_storage_client.go
+++ b/pkg/storage/chunk/client/aws/s3_storage_client.go
@@ -291,15 +291,25 @@ func buildS3Client(cfg S3Config, hedgingCfg hedging.Config, hedging bool) (*s3.S
 	return s3Client, nil
 }
 
+// buckets returns a list of S3 bucket names parsed from either cfg.S3.URL.Path or cfg.BucketNames.
+// If cfg.BucketNames is set, it takes precedence. Bucket names are split on commas, trimmed of
+// whitespace, and empty entries are ignored.
 func buckets(cfg S3Config) ([]string, error) {
-	// bucketnames
 	var bucketNames []string
+
 	if cfg.S3.URL != nil {
 		bucketNames = []string{strings.TrimPrefix(cfg.S3.URL.Path, "/")}
 	}
 
 	if cfg.BucketNames != "" {
-		bucketNames = strings.Split(cfg.BucketNames, ",") // comma separated list of bucket names
+		rawBuckets := strings.Split(cfg.BucketNames, ",")
+		bucketNames = make([]string, 0, len(rawBuckets))
+		for _, b := range rawBuckets {
+			trimmed := strings.TrimSpace(b)
+			if trimmed != "" {
+				bucketNames = append(bucketNames, trimmed)
+			}
+		}
 	}
 
 	if len(bucketNames) == 0 {


### PR DESCRIPTION

**What this PR does / why we need it**:

This PR fixes a bug in the AWS storage configuration where specifying multiple comma-separated S3 bucket names in `bucketnames` would fail if any value contained whitespace (and all the doc examples tell users to include whitespace). 

For example:

```yaml
storage_config:
  aws:
    bucketnames: bucket-1, bucket-2, bucket-3
```

was parsed as:

- `"bucket-1"`
- `" bucket-2"` ← invalid due to leading space
- `" bucket-3"`

This change trims whitespace around each bucket name and skips empty values, allowing users to configure multiple buckets as expected.

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:

- This bug caused confusing errors at startup when configuring multiple buckets for chunk storage.
- The change aligns actual behavior with user expectations **and current documentation**.
- The parsing logic is now stricter and more resilient but still backward-compatible.

**Checklist**

- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added *(not required — this matches existing documented behavior but let me know if you want a doc tweak)*
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md` *(N/A — no upgrade required)*
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively *(N/A — not deprecating anything)*
