### PR TITLE
chore(engine): Prefetch inputs of SortMerge operator

### DIFF
--- a/pkg/compactor/deletion/job_runner_test.go
+++ b/pkg/compactor/deletion/job_runner_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/loki/pkg/push"
 	"github.com/grafana/loki/v3/pkg/chunkenc"
 	"github.com/grafana/loki/v3/pkg/compactor/client/grpc"
 	"github.com/grafana/loki/v3/pkg/compactor/retention"
@@ -20,6 +19,8 @@ import (
 	"github.com/grafana/loki/v3/pkg/logql/syntax"
 	storage_chunk "github.com/grafana/loki/v3/pkg/storage/chunk"
 	"github.com/grafana/loki/v3/pkg/storage/chunk/client"
+
+	"github.com/grafana/loki/pkg/push"
 )
 
 type mockChunkClient struct {

--- a/pkg/engine/executor/pipeline.go
+++ b/pkg/engine/executor/pipeline.go
@@ -1,6 +1,7 @@
 package executor
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -119,4 +120,103 @@ func emptyPipeline() Pipeline {
 	return newGenericPipeline(Local, func(_ []Pipeline) state {
 		return Exhausted
 	})
+}
+
+// prefetchWrapper wraps a [Pipeline] with pre-fetching capability,
+// reading data in a separate goroutine to enable concurrent processing.
+type prefetchWrapper struct {
+	Pipeline // the pipeline that is wrapped
+
+	initialized bool // internal state to indicate whether the pre-fetching goroutine is running
+
+	ch    chan state // the results channel for pre-fetched items
+	state state      // internal state representing the last pre-fetched item
+
+	ctx    context.Context         // context to control lifecycle
+	cancel context.CancelCauseFunc // cancellation function for the context
+}
+
+var _ Pipeline = (*prefetchWrapper)(nil)
+
+// newPrefetchingPipeline creates a new prefetching pipeline wrapper that reads data from the underlying pipeline
+// in a separate goroutine. This allows for concurrent processing where data can be fetched ahead of time
+// while the consumer is processing the current batch.
+//
+// The prefetching pipeline maintains a buffered channel with capacity 1 to store the next batch,
+// enabling pipeline parallelism and potentially improving throughput.
+//
+// The function accepts a [context.Context] `ctx` and a [Pipeline] `p`, which is the underlying pipeline to wrap
+// with pre-fetching capability.
+//
+// Returns a [prefetchWrapper] that implements the [Pipeline] interface.
+func newPrefetchingPipeline(ctx context.Context, p Pipeline) *prefetchWrapper {
+	ctx, cancel := context.WithCancelCause(ctx)
+	return &prefetchWrapper{
+		Pipeline: p,
+		ch:       make(chan state),
+		ctx:      ctx,
+		cancel:   cancel,
+	}
+}
+
+// Read implements [Pipeline].
+func (p *prefetchWrapper) Read() error {
+	p.init()
+	return p.read()
+}
+
+func (p *prefetchWrapper) init() {
+	if p.initialized {
+		return
+	}
+
+	p.initialized = true
+	go p.prefetch(p.ctx) // nolint:errcheck
+}
+
+func (p prefetchWrapper) prefetch(ctx context.Context) error {
+	// Close channel on exit
+	defer close(p.ch)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			var s state
+			s.err = p.Pipeline.Read()
+			if s.err != nil {
+				p.ch <- s
+				return s.err
+			}
+			s.batch, _ = p.Pipeline.Value()
+			s.batch.Retain()
+			// sending to channel will block until the batch is read by the parent pipeline
+			p.ch <- s
+		}
+	}
+}
+
+func (p *prefetchWrapper) read() error {
+	// Release previously retained batch
+	if p.state.batch != nil {
+		p.state.batch.Release()
+	}
+	p.state = <-p.ch
+	return p.state.err
+}
+
+// Value implements [Pipeline].
+func (p *prefetchWrapper) Value() (arrow.Record, error) {
+	return p.state.batch, p.state.err
+}
+
+// Close implements [Pipeline].
+func (p *prefetchWrapper) Close() {
+	// Cancel internal context so the goroutine can exit
+	p.cancel(errors.New("pipeline is closed"))
+	// Clear already pre-fetched, but unused items from channel
+	for range p.ch { // nolint:revive
+	}
+	p.Pipeline.Close()
 }

--- a/pkg/engine/executor/pipeline_test.go
+++ b/pkg/engine/executor/pipeline_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/csv"
@@ -11,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/loki/v3/pkg/engine/internal/datatype"
+	"github.com/grafana/loki/v3/pkg/util/arrowtest"
 )
 
 // CSVToArrow converts a CSV string to an Arrow record based on the provided schema.
@@ -106,4 +108,113 @@ func TestCSVPipeline(t *testing.T) {
 		_, err = pipeline.Value()
 		require.Equal(t, EOF, err)
 	})
+}
+
+func newInstrumentedPipeline(inner Pipeline) *instrumentedPipeline {
+	return &instrumentedPipeline{
+		inner:     inner,
+		callCount: make(map[string]int),
+	}
+}
+
+type instrumentedPipeline struct {
+	inner     Pipeline
+	callCount map[string]int
+}
+
+// Inputs implements Pipeline.
+func (i *instrumentedPipeline) Inputs() []Pipeline {
+	i.callCount["Inputs"]++
+	return i.inner.Inputs()
+}
+
+// Close implements Pipeline.
+func (i *instrumentedPipeline) Close() {
+	i.callCount["Close"]++
+	i.inner.Close()
+}
+
+// Read implements Pipeline.
+func (i *instrumentedPipeline) Read() error {
+	i.callCount["Read"]++
+	return i.inner.Read()
+}
+
+// Transport implements Pipeline.
+func (i *instrumentedPipeline) Transport() Transport {
+	i.callCount["Transport"]++
+	return i.inner.Transport()
+}
+
+// Value implements Pipeline.
+func (i *instrumentedPipeline) Value() (arrow.Record, error) {
+	i.callCount["Value"]++
+	return i.inner.Value()
+}
+
+var _ Pipeline = (*instrumentedPipeline)(nil)
+
+func Test_prefetchWrapper_Read(t *testing.T) {
+	alloc := memory.NewCheckedAllocator(memory.NewGoAllocator())
+
+	batch1 := arrowtest.Rows{
+		{"message": "log line 1"},
+		{"message": "log line 2"},
+	}
+	batch2 := arrowtest.Rows{
+		{"message": "log line 3"},
+		{"message": "log line 4"},
+	}
+	batch3 := arrowtest.Rows{
+		{"message": "log line 5"},
+	}
+
+	pipeline := NewBufferedPipeline(
+		batch1.Record(alloc, batch1.Schema()),
+		batch2.Record(alloc, batch2.Schema()),
+		batch3.Record(alloc, batch3.Schema()),
+	)
+
+	instrumentedPipeline := newInstrumentedPipeline(pipeline)
+	prefetchingPipeline := newPrefetchingPipeline(t.Context(), instrumentedPipeline)
+
+	require.Equal(t, 0, instrumentedPipeline.callCount["Read"])
+
+	// Read first batch
+	err := prefetchingPipeline.Read()
+	require.NoError(t, err)
+	v, _ := prefetchingPipeline.Value()
+	require.Equal(t, int64(2), v.NumRows())
+
+	time.Sleep(10 * time.Millisecond)                           // ensure that next batch has been prefetched
+	require.Equal(t, 2, instrumentedPipeline.callCount["Read"]) // 1 record consumed + 1 record pre-fetched
+
+	// Read second batch
+	err = prefetchingPipeline.Read()
+	require.NoError(t, err)
+	v, _ = prefetchingPipeline.Value()
+	require.Equal(t, int64(2), v.NumRows())
+
+	time.Sleep(10 * time.Millisecond)                           // ensure that next batch has been prefetched
+	require.Equal(t, 3, instrumentedPipeline.callCount["Read"]) // 2 records consumed + 1 record pre-fetched
+
+	// Read third/last batch
+	err = prefetchingPipeline.Read()
+	require.NoError(t, err)
+	v, _ = prefetchingPipeline.Value()
+	require.Equal(t, int64(1), v.NumRows())
+
+	time.Sleep(10 * time.Millisecond)                           // ensure that next batch has been prefetched
+	require.Equal(t, 4, instrumentedPipeline.callCount["Read"]) // 3 records consumed + 1 EOF pre-fetched
+
+	// Read EOF
+	err = prefetchingPipeline.Read()
+	require.ErrorContains(t, err, EOF.Error())
+
+	time.Sleep(10 * time.Millisecond)                           // ensure that next batch has been prefetched
+	require.Equal(t, 4, instrumentedPipeline.callCount["Read"]) // 3 records + 1 EOF consumed
+
+	// Assert that records are released
+	prefetchingPipeline.Close()
+	alloc.AssertSize(t, 0)
 }

--- a/pkg/engine/executor/sortmerge.go
+++ b/pkg/engine/executor/sortmerge.go
@@ -102,6 +102,14 @@ func (p *KWayMerge) init() {
 	p.exhausted = make([]bool, n)
 	p.offsets = make([]int64, n)
 
+	// Initialize pre-fetching on inputs
+	for i := range p.inputs {
+		inp, ok := p.inputs[i].(*prefetchWrapper)
+		if ok {
+			inp.init()
+		}
+	}
+
 	if p.compare == nil {
 		p.compare = func(a, b int64) bool { return a <= b }
 	}

--- a/pkg/engine/executor/sortmerge.go
+++ b/pkg/engine/executor/sortmerge.go
@@ -27,15 +27,17 @@ func NewSortMergePipeline(inputs []Pipeline, order physical.SortOrder, column ph
 		return nil, fmt.Errorf("invalid sort order %v", order)
 	}
 
-	// TODO(chaudum): Pass context from execution engine
-	ctx, cancel := context.WithCancel(context.Background())
+	// TODO(chaudum): Pass context from execution context
+	ctx := context.Background()
+
+	for i := range inputs {
+		inputs[i] = newPrefetchingPipeline(ctx, inputs[i])
+	}
 
 	return &KWayMerge{
 		inputs:     inputs,
 		columnEval: evaluator.newFunc(column),
 		compare:    lessFunc,
-		ctx:        ctx,
-		cancel:     cancel,
 	}, nil
 }
 
@@ -50,11 +52,8 @@ type KWayMerge struct {
 	batches     []arrow.Record
 	exhausted   []bool
 	offsets     []int64
-	fetchers    []chan state
 	columnEval  evalFunc
 	compare     compareFunc[int64]
-	ctx         context.Context
-	cancel      context.CancelFunc
 }
 
 var _ Pipeline = (*KWayMerge)(nil)
@@ -65,14 +64,6 @@ func (p *KWayMerge) Close() {
 	if p.state.batch != nil {
 		p.state.batch.Release()
 	}
-	// Stop pending prefetchers
-	p.cancel()
-	for _, fetcher := range p.fetchers {
-		for range fetcher {
-			// pull remaining items from channel so the goroutine can exit
-		}
-	}
-	// Close child operators
 	for _, input := range p.inputs {
 		input.Close()
 	}
@@ -110,37 +101,9 @@ func (p *KWayMerge) init() {
 	p.batches = make([]arrow.Record, n)
 	p.exhausted = make([]bool, n)
 	p.offsets = make([]int64, n)
-	p.fetchers = make([]chan state, n)
-
-	for i := range n {
-		p.fetchers[i] = make(chan state, 1)
-		go p.prefetch(p.ctx, i) // nolint:errcheck
-	}
 
 	if p.compare == nil {
 		p.compare = func(a, b int64) bool { return a <= b }
-	}
-}
-
-func (p *KWayMerge) prefetch(ctx context.Context, i int) error {
-	// Close channel on exit
-	defer close(p.fetchers[i])
-
-	for {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
-			var s state
-			s.err = p.inputs[i].Read()
-			if s.err != nil {
-				p.fetchers[i] <- s
-				return s.err
-			}
-			s.batch, _ = p.inputs[i].Value()
-			s.batch.Retain()
-			p.fetchers[i] <- s
-		}
 	}
 }
 
@@ -158,38 +121,33 @@ start:
 	timestamps := make([]int64, 0, len(p.inputs))
 	inputIndexes := make([]int, 0, len(p.inputs))
 
+loop:
 	for i := range len(p.inputs) {
 		// Skip exhausted inputs
 		if p.exhausted[i] {
-			continue
+			continue loop
 		}
 
 		// Load next batch if it hasn't been loaded yet, or if current one is already fully consumed
 		// Read another batch as long as the input yields zero-length batches.
-		if p.batches[i] == nil || p.offsets[i] == p.batches[i].NumRows() {
+		for p.batches[i] == nil || p.offsets[i] == p.batches[i].NumRows() {
 			// Reset offset
 			p.offsets[i] = 0
 
-			// Release previous batch
-			if p.batches[i] != nil {
-				p.batches[i].Release()
-			}
-
 			// Read from input
-			s := <-p.fetchers[i]
-
-			if s.err != nil {
-				if errors.Is(s.err, EOF) {
+			err := p.inputs[i].Read()
+			if err != nil {
+				if errors.Is(err, EOF) {
 					p.exhausted[i] = true
 					p.batches[i] = nil // remove reference to arrow.Record from slice
-					continue
+					continue loop
 				}
-				return s.err
+				return err
 			}
 
 			// It is safe to use the value from the Value() call, because the error is already checked after the Read() call.
 			// In case the input is exhausted (reached EOF), the return value is `nil`, however, since the flag `p.exhausted[i]` is set, the value will never be read.
-			p.batches[i] = s.batch
+			p.batches[i], _ = p.inputs[i].Value()
 		}
 
 		// Fetch timestamp value at current offset


### PR DESCRIPTION
### Summary

This PR changes how inputs of the `SortMerge` operator are consumed. The inputs are wrapped into the `prefetchWrapper` which consumses the next batch (arrow.Record) in the background while the current batch is processed by the parent node.

### Benchmarks

```
$ gotest -v ./pkg/logql/bench/... -count=10 -test.bench='^BenchmarkLogQL/query=.+\[BACKWARD\]/kind=log/store=dataobj-engine' -test.run=^$ -timeout=30m -benchmem
```

```console
$ benchstat bench_sortbytimestamp_without_prefetch.txt bench_sortbytimestamp_with_prefetch.txt
goos: linux
goarch: amd64
pkg: github.com/grafana/loki/v3/pkg/logql/bench
cpu: 11th Gen Intel(R) Core(TM) i7-1185G7 @ 3.00GHz
                                                                                                                                                              │ bench_sortbytimestamp_without_prefetch.txt │ bench_sortbytimestamp_with_prefetch.txt │
                                                                                                                                                              │                   sec/op                   │     sec/op       vs base                │
LogQL/query={region="ap-southeast-1",_env="dev"}_[BACKWARD]/kind=log/store=dataobj-engine-8                                                                                                   770.6m ± 67%     545.5m ± 171%        ~ (p=0.280 n=10)
LogQL/query={region="ap-southeast-1",_env="dev"}_|_detected_level="error"_[BACKWARD]/kind=log/store=dataobj-engine-8                                                                           1.872 ± 16%      1.409 ±  35%  -24.73% (p=0.004 n=10)
LogQL/query={region="ap-southeast-1",_env="dev"}_|_detected_level="warn"_[BACKWARD]/kind=log/store=dataobj-engine-8                                                                            1.776 ±  3%      1.190 ±   5%  -32.99% (p=0.000 n=10)
LogQL/query={region="ap-southeast-1",_env="dev"}_|~_"error|exception"_|_detected_level="error"_[BACKWARD]/kind=log/store=dataobj-engine-8                                                      1.576 ±  3%      1.043 ±  10%  -33.82% (p=0.000 n=10)
LogQL/query={region="ap-southeast-1"}_[BACKWARD]/kind=log/store=dataobj-engine-8                                                                                                               1.477 ±  9%      1.085 ±  16%  -26.51% (p=0.000 n=10)
LogQL/query={region="ap-southeast-1"}_|_detected_level="error"_[BACKWARD]/kind=log/store=dataobj-engine-8                                                                                      1.811 ±  3%      1.202 ±  28%  -33.61% (p=0.002 n=10)
LogQL/query={region="ap-southeast-1"}_|_detected_level="warn"_[BACKWARD]/kind=log/store=dataobj-engine-8                                                                                       1.869 ±  4%      1.225 ±   4%  -34.47% (p=0.000 n=10)
LogQL/query={region="ap-southeast-1"}_|~_"error|exception"_|_detected_level="error"_[BACKWARD]/kind=log/store=dataobj-engine-8                                                                 1.543 ± 11%      1.008 ±  15%  -34.69% (p=0.000 n=10)
LogQL/query={service_name="grafana",_env="prod",_region="us-west-2"}_[BACKWARD]/kind=log/store=dataobj-engine-8                                                                                1.712 ±  7%      1.052 ±  14%  -38.55% (p=0.000 n=10)
LogQL/query={service_name="grafana",_env="prod",_region="us-west-2"}_|_detected_level="error"_[BACKWARD]/kind=log/store=dataobj-engine-8                                                       3.420 ±  4%      2.497 ±  30%  -26.99% (p=0.000 n=10)
LogQL/query={service_name="grafana",_env="prod",_region="us-west-2"}_|_detected_level="warn"_[BACKWARD]/kind=log/store=dataobj-engine-8                                                        3.971 ± 25%      2.108 ±   5%  -46.91% (p=0.000 n=10)
LogQL/query={service_name="grafana",_env="prod",_region="us-west-2"}_|~_"error|exception"_|_detected_level="error"_[BACKWARD]/kind=log/store=dataobj-engine-8                                  3.599 ± 41%      2.181 ±  12%  -39.39% (p=0.000 n=10)
LogQL/query={service_name="kubernetes"}_[BACKWARD]/kind=log/store=dataobj-engine-8                                                                                                           1320.2m ± 37%     789.5m ±   8%  -40.19% (p=0.000 n=10)
LogQL/query={service_name="kubernetes"}_|_detected_level="error"_[BACKWARD]/kind=log/store=dataobj-engine-8                                                                                    1.577 ±  9%      1.117 ±  12%  -29.15% (p=0.000 n=10)
LogQL/query={service_name="kubernetes"}_|_detected_level="warn"_[BACKWARD]/kind=log/store=dataobj-engine-8                                                                                     1.520 ±  7%      1.045 ±   9%  -31.29% (p=0.000 n=10)
LogQL/query={service_name="kubernetes"}_|~_"error|exception"_|_detected_level="error"_[BACKWARD]/kind=log/store=dataobj-engine-8                                                             1524.1m ±  4%     904.0m ±  10%  -40.69% (p=0.000 n=10)
geomean                                                                                                                                                                                        1.804            1.187         -34.22%

                                                                                                                                                              │ bench_sortbytimestamp_without_prefetch.txt │  bench_sortbytimestamp_with_prefetch.txt   │
                                                                                                                                                              │             kilobytesProcessed             │ kilobytesProcessed  vs base                │
LogQL/query={region="ap-southeast-1",_env="dev"}_[BACKWARD]/kind=log/store=dataobj-engine-8                                                                                                    3.990k ± 0%          5.442k ± 0%  +36.39% (p=0.000 n=10)
LogQL/query={region="ap-southeast-1",_env="dev"}_|_detected_level="error"_[BACKWARD]/kind=log/store=dataobj-engine-8                                                                           3.990k ± 0%          5.442k ± 0%  +36.39% (p=0.000 n=10)
LogQL/query={region="ap-southeast-1",_env="dev"}_|_detected_level="warn"_[BACKWARD]/kind=log/store=dataobj-engine-8                                                                            4.005k ± 0%          5.458k ± 0%  +36.28% (p=0.000 n=10)
LogQL/query={region="ap-southeast-1",_env="dev"}_|~_"error|exception"_|_detected_level="error"_[BACKWARD]/kind=log/store=dataobj-engine-8                                                      4.608k ± 0%          5.874k ± 0%  +27.47% (p=0.000 n=10)
LogQL/query={region="ap-southeast-1"}_[BACKWARD]/kind=log/store=dataobj-engine-8                                                                                                               5.699k ± 0%          8.839k ± 0%  +55.10% (p=0.000 n=10)
LogQL/query={region="ap-southeast-1"}_|_detected_level="error"_[BACKWARD]/kind=log/store=dataobj-engine-8                                                                                      5.699k ± 0%          8.839k ± 0%  +55.10% (p=0.000 n=10)
LogQL/query={region="ap-southeast-1"}_|_detected_level="warn"_[BACKWARD]/kind=log/store=dataobj-engine-8                                                                                       5.699k ± 0%          8.839k ± 0%  +55.10% (p=0.000 n=10)
LogQL/query={region="ap-southeast-1"}_|~_"error|exception"_|_detected_level="error"_[BACKWARD]/kind=log/store=dataobj-engine-8                                                                 5.234k ± 0%          7.905k ± 0%  +51.03% (p=0.000 n=10)
LogQL/query={service_name="grafana",_env="prod",_region="us-west-2"}_[BACKWARD]/kind=log/store=dataobj-engine-8                                                                                5.140k ± 0%          5.571k ± 0%   +8.39% (p=0.000 n=10)
LogQL/query={service_name="grafana",_env="prod",_region="us-west-2"}_|_detected_level="error"_[BACKWARD]/kind=log/store=dataobj-engine-8                                                       11.68k ± 0%          12.11k ± 0%   +3.68% (p=0.000 n=10)
LogQL/query={service_name="grafana",_env="prod",_region="us-west-2"}_|_detected_level="warn"_[BACKWARD]/kind=log/store=dataobj-engine-8                                                        11.94k ± 0%          12.36k ± 0%   +3.56% (p=0.000 n=10)
LogQL/query={service_name="grafana",_env="prod",_region="us-west-2"}_|~_"error|exception"_|_detected_level="error"_[BACKWARD]/kind=log/store=dataobj-engine-8                                  12.09k ± 0%          13.08k ± 0%   +8.19% (p=0.000 n=10)
LogQL/query={service_name="kubernetes"}_[BACKWARD]/kind=log/store=dataobj-engine-8                                                                                                             3.368k ± 0%          4.199k ± 0%  +24.67% (p=0.000 n=10)
LogQL/query={service_name="kubernetes"}_|_detected_level="error"_[BACKWARD]/kind=log/store=dataobj-engine-8                                                                                    4.160k ± 0%          5.001k ± 0%  +20.22% (p=0.000 n=10)
LogQL/query={service_name="kubernetes"}_|_detected_level="warn"_[BACKWARD]/kind=log/store=dataobj-engine-8                                                                                     4.160k ± 0%          5.001k ± 0%  +20.22% (p=0.000 n=10)
LogQL/query={service_name="kubernetes"}_|~_"error|exception"_|_detected_level="error"_[BACKWARD]/kind=log/store=dataobj-engine-8                                                               3.864k ± 0%          4.549k ± 0%  +17.73% (p=0.000 n=10)
geomean                                                                                                                                                                                        5.421k               6.910k       +27.48%

                                                                                                                                                              │ bench_sortbytimestamp_without_prefetch.txt │ bench_sortbytimestamp_with_prefetch.txt │
                                                                                                                                                              │               linesProcessed               │ linesProcessed   vs base                │
LogQL/query={region="ap-southeast-1",_env="dev"}_[BACKWARD]/kind=log/store=dataobj-engine-8                                                                                                    68.83k ± 0%      114.39k ± 0%  +66.21% (p=0.000 n=10)
LogQL/query={region="ap-southeast-1",_env="dev"}_|_detected_level="error"_[BACKWARD]/kind=log/store=dataobj-engine-8                                                                           68.83k ± 0%      114.39k ± 0%  +66.21% (p=0.000 n=10)
LogQL/query={region="ap-southeast-1",_env="dev"}_|_detected_level="warn"_[BACKWARD]/kind=log/store=dataobj-engine-8                                                                            69.34k ± 0%      114.91k ± 0%  +65.72% (p=0.000 n=10)
LogQL/query={region="ap-southeast-1",_env="dev"}_|~_"error|exception"_|_detected_level="error"_[BACKWARD]/kind=log/store=dataobj-engine-8                                                      97.50k ± 0%      143.07k ± 0%  +46.74% (p=0.000 n=10)
LogQL/query={region="ap-southeast-1"}_[BACKWARD]/kind=log/store=dataobj-engine-8                                                                                                               68.83k ± 0%      114.39k ± 0%  +66.21% (p=0.000 n=10)
LogQL/query={region="ap-southeast-1"}_|_detected_level="error"_[BACKWARD]/kind=log/store=dataobj-engine-8                                                                                      68.83k ± 0%      114.39k ± 0%  +66.21% (p=0.000 n=10)
LogQL/query={region="ap-southeast-1"}_|_detected_level="warn"_[BACKWARD]/kind=log/store=dataobj-engine-8                                                                                       68.83k ± 0%      114.39k ± 0%  +66.21% (p=0.000 n=10)
LogQL/query={region="ap-southeast-1"}_|~_"error|exception"_|_detected_level="error"_[BACKWARD]/kind=log/store=dataobj-engine-8                                                                 68.83k ± 0%      114.39k ± 0%  +66.21% (p=0.000 n=10)
LogQL/query={service_name="grafana",_env="prod",_region="us-west-2"}_[BACKWARD]/kind=log/store=dataobj-engine-8                                                                                322.5k ± 0%       372.7k ± 0%  +15.56% (p=0.000 n=10)
LogQL/query={service_name="grafana",_env="prod",_region="us-west-2"}_|_detected_level="error"_[BACKWARD]/kind=log/store=dataobj-engine-8                                                       1.075M ± 0%       1.125M ± 0%   +4.67% (p=0.000 n=10)
LogQL/query={service_name="grafana",_env="prod",_region="us-west-2"}_|_detected_level="warn"_[BACKWARD]/kind=log/store=dataobj-engine-8                                                        1.104M ± 0%       1.153M ± 0%   +4.45% (p=0.000 n=10)
LogQL/query={service_name="grafana",_env="prod",_region="us-west-2"}_|~_"error|exception"_|_detected_level="error"_[BACKWARD]/kind=log/store=dataobj-engine-8                                  1.142M ± 0%       1.258M ± 1%  +10.18% (p=0.000 n=10)
LogQL/query={service_name="kubernetes"}_[BACKWARD]/kind=log/store=dataobj-engine-8                                                                                                             68.83k ± 0%      114.39k ± 0%  +66.21% (p=0.000 n=10)
LogQL/query={service_name="kubernetes"}_|_detected_level="error"_[BACKWARD]/kind=log/store=dataobj-engine-8                                                                                    112.3k ± 0%       157.9k ± 0%  +40.56% (p=0.000 n=10)
LogQL/query={service_name="kubernetes"}_|_detected_level="warn"_[BACKWARD]/kind=log/store=dataobj-engine-8                                                                                     112.3k ± 0%       157.9k ± 0%  +40.56% (p=0.000 n=10)
LogQL/query={service_name="kubernetes"}_|~_"error|exception"_|_detected_level="error"_[BACKWARD]/kind=log/store=dataobj-engine-8                                                               112.9k ± 0%       158.4k ± 0%  +40.38% (p=0.000 n=10)
geomean                                                                                                                                                                                        143.1k            205.5k       +43.65%

                                                                                                                                                              │ bench_sortbytimestamp_without_prefetch.txt │ bench_sortbytimestamp_with_prefetch.txt  │
                                                                                                                                                              │              postFilterLines               │ postFilterLines  vs base                 │
LogQL/query={region="ap-southeast-1",_env="dev"}_[BACKWARD]/kind=log/store=dataobj-engine-8                                                                                                   0.000 ± 0%          0.000 ± 0%       ~ (p=1.000 n=10) ¹
LogQL/query={region="ap-southeast-1",_env="dev"}_|_detected_level="error"_[BACKWARD]/kind=log/store=dataobj-engine-8                                                                          0.000 ± 0%          0.000 ± 0%       ~ (p=1.000 n=10) ¹
LogQL/query={region="ap-southeast-1",_env="dev"}_|_detected_level="warn"_[BACKWARD]/kind=log/store=dataobj-engine-8                                                                           0.000 ± 0%          0.000 ± 0%       ~ (p=1.000 n=10) ¹
LogQL/query={region="ap-southeast-1",_env="dev"}_|~_"error|exception"_|_detected_level="error"_[BACKWARD]/kind=log/store=dataobj-engine-8                                                     0.000 ± 0%          0.000 ± 0%       ~ (p=1.000 n=10) ¹
LogQL/query={region="ap-southeast-1"}_[BACKWARD]/kind=log/store=dataobj-engine-8                                                                                                              0.000 ± 0%          0.000 ± 0%       ~ (p=1.000 n=10) ¹
LogQL/query={region="ap-southeast-1"}_|_detected_level="error"_[BACKWARD]/kind=log/store=dataobj-engine-8                                                                                     0.000 ± 0%          0.000 ± 0%       ~ (p=1.000 n=10) ¹
LogQL/query={region="ap-southeast-1"}_|_detected_level="warn"_[BACKWARD]/kind=log/store=dataobj-engine-8                                                                                      0.000 ± 0%          0.000 ± 0%       ~ (p=1.000 n=10) ¹
LogQL/query={region="ap-southeast-1"}_|~_"error|exception"_|_detected_level="error"_[BACKWARD]/kind=log/store=dataobj-engine-8                                                                0.000 ± 0%          0.000 ± 0%       ~ (p=1.000 n=10) ¹
LogQL/query={service_name="grafana",_env="prod",_region="us-west-2"}_[BACKWARD]/kind=log/store=dataobj-engine-8                                                                               0.000 ± 0%          0.000 ± 0%       ~ (p=1.000 n=10) ¹
LogQL/query={service_name="grafana",_env="prod",_region="us-west-2"}_|_detected_level="error"_[BACKWARD]/kind=log/store=dataobj-engine-8                                                      0.000 ± 0%          0.000 ± 0%       ~ (p=1.000 n=10) ¹
LogQL/query={service_name="grafana",_env="prod",_region="us-west-2"}_|_detected_level="warn"_[BACKWARD]/kind=log/store=dataobj-engine-8                                                       0.000 ± 0%          0.000 ± 0%       ~ (p=1.000 n=10) ¹
LogQL/query={service_name="grafana",_env="prod",_region="us-west-2"}_|~_"error|exception"_|_detected_level="error"_[BACKWARD]/kind=log/store=dataobj-engine-8                                 0.000 ± 0%          0.000 ± 0%       ~ (p=1.000 n=10) ¹
LogQL/query={service_name="kubernetes"}_[BACKWARD]/kind=log/store=dataobj-engine-8                                                                                                            0.000 ± 0%          0.000 ± 0%       ~ (p=1.000 n=10) ¹
LogQL/query={service_name="kubernetes"}_|_detected_level="error"_[BACKWARD]/kind=log/store=dataobj-engine-8                                                                                   0.000 ± 0%          0.000 ± 0%       ~ (p=1.000 n=10) ¹
LogQL/query={service_name="kubernetes"}_|_detected_level="warn"_[BACKWARD]/kind=log/store=dataobj-engine-8                                                                                    0.000 ± 0%          0.000 ± 0%       ~ (p=1.000 n=10) ¹
LogQL/query={service_name="kubernetes"}_|~_"error|exception"_|_detected_level="error"_[BACKWARD]/kind=log/store=dataobj-engine-8                                                              0.000 ± 0%          0.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                                                                                                                                                                                                  ²                    +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                                                                                                                                                              │ bench_sortbytimestamp_without_prefetch.txt │ bench_sortbytimestamp_with_prefetch.txt │
                                                                                                                                                              │                    B/op                    │      B/op        vs base                │
LogQL/query={region="ap-southeast-1",_env="dev"}_[BACKWARD]/kind=log/store=dataobj-engine-8                                                                                                  580.3Mi ± 19%    520.2Mi ±   8%  -10.37% (p=0.002 n=10)
LogQL/query={region="ap-southeast-1",_env="dev"}_|_detected_level="error"_[BACKWARD]/kind=log/store=dataobj-engine-8                                                                         860.1Mi ±  7%    762.6Mi ±  14%  -11.34% (p=0.043 n=10)
LogQL/query={region="ap-southeast-1",_env="dev"}_|_detected_level="warn"_[BACKWARD]/kind=log/store=dataobj-engine-8                                                                          856.6Mi ±  1%    778.8Mi ±  10%   -9.08% (p=0.007 n=10)
LogQL/query={region="ap-southeast-1",_env="dev"}_|~_"error|exception"_|_detected_level="error"_[BACKWARD]/kind=log/store=dataobj-engine-8                                                    957.9Mi ± 20%    854.3Mi ± 117%        ~ (p=0.105 n=10)
LogQL/query={region="ap-southeast-1"}_[BACKWARD]/kind=log/store=dataobj-engine-8                                                                                                             609.6Mi ±  6%    589.3Mi ±  16%        ~ (p=0.481 n=10)
LogQL/query={region="ap-southeast-1"}_|_detected_level="error"_[BACKWARD]/kind=log/store=dataobj-engine-8                                                                                    900.0Mi ±  7%    802.2Mi ±   3%  -10.87% (p=0.000 n=10)
LogQL/query={region="ap-southeast-1"}_|_detected_level="warn"_[BACKWARD]/kind=log/store=dataobj-engine-8                                                                                     912.0Mi ±  1%    841.5Mi ±  10%   -7.74% (p=0.019 n=10)
LogQL/query={region="ap-southeast-1"}_|~_"error|exception"_|_detected_level="error"_[BACKWARD]/kind=log/store=dataobj-engine-8                                                               998.2Mi ± 13%    940.8Mi ± 228%        ~ (p=0.393 n=10)
LogQL/query={service_name="grafana",_env="prod",_region="us-west-2"}_[BACKWARD]/kind=log/store=dataobj-engine-8                                                                              558.2Mi ± 10%    488.6Mi ±   7%  -12.47% (p=0.000 n=10)
LogQL/query={service_name="grafana",_env="prod",_region="us-west-2"}_|_detected_level="error"_[BACKWARD]/kind=log/store=dataobj-engine-8                                                     786.5Mi ±  9%    811.2Mi ±  15%        ~ (p=0.063 n=10)
LogQL/query={service_name="grafana",_env="prod",_region="us-west-2"}_|_detected_level="warn"_[BACKWARD]/kind=log/store=dataobj-engine-8                                                      889.5Mi ±  3%    887.2Mi ±   8%        ~ (p=0.912 n=10)
LogQL/query={service_name="grafana",_env="prod",_region="us-west-2"}_|~_"error|exception"_|_detected_level="error"_[BACKWARD]/kind=log/store=dataobj-engine-8                                961.8Mi ± 23%    906.6Mi ± 106%        ~ (p=0.393 n=10)
LogQL/query={service_name="kubernetes"}_[BACKWARD]/kind=log/store=dataobj-engine-8                                                                                                           563.1Mi ±  5%    509.9Mi ±  15%   -9.45% (p=0.029 n=10)
LogQL/query={service_name="kubernetes"}_|_detected_level="error"_[BACKWARD]/kind=log/store=dataobj-engine-8                                                                                  662.0Mi ±  5%    626.1Mi ±  12%        ~ (p=0.075 n=10)
LogQL/query={service_name="kubernetes"}_|_detected_level="warn"_[BACKWARD]/kind=log/store=dataobj-engine-8                                                                                   671.2Mi ±  3%    658.1Mi ±   8%        ~ (p=0.529 n=10)
LogQL/query={service_name="kubernetes"}_|~_"error|exception"_|_detected_level="error"_[BACKWARD]/kind=log/store=dataobj-engine-8                                                             926.0Mi ± 17%    814.4Mi ±  39%  -12.05% (p=0.029 n=10)
geomean                                                                                                                                                                                      777.4Mi          721.5Mi          -7.20%

                                                                                                                                                              │ bench_sortbytimestamp_without_prefetch.txt │ bench_sortbytimestamp_with_prefetch.txt │
                                                                                                                                                              │                 allocs/op                  │    allocs/op     vs base                │
LogQL/query={region="ap-southeast-1",_env="dev"}_[BACKWARD]/kind=log/store=dataobj-engine-8                                                                                                    1.567M ± 0%       1.923M ± 0%  +22.73% (p=0.000 n=10)
LogQL/query={region="ap-southeast-1",_env="dev"}_|_detected_level="error"_[BACKWARD]/kind=log/store=dataobj-engine-8                                                                           4.794M ± 0%       5.151M ± 0%   +7.44% (p=0.000 n=10)
LogQL/query={region="ap-southeast-1",_env="dev"}_|_detected_level="warn"_[BACKWARD]/kind=log/store=dataobj-engine-8                                                                            4.867M ± 0%       5.224M ± 0%   +7.33% (p=0.000 n=10)
LogQL/query={region="ap-southeast-1",_env="dev"}_|~_"error|exception"_|_detected_level="error"_[BACKWARD]/kind=log/store=dataobj-engine-8                                                      2.296M ± 0%       2.570M ± 0%  +11.95% (p=0.000 n=10)
LogQL/query={region="ap-southeast-1"}_[BACKWARD]/kind=log/store=dataobj-engine-8                                                                                                               1.768M ± 0%       2.267M ± 0%  +28.19% (p=0.000 n=10)
LogQL/query={region="ap-southeast-1"}_|_detected_level="error"_[BACKWARD]/kind=log/store=dataobj-engine-8                                                                                      5.081M ± 0%       5.579M ± 0%   +9.81% (p=0.000 n=10)
LogQL/query={region="ap-southeast-1"}_|_detected_level="warn"_[BACKWARD]/kind=log/store=dataobj-engine-8                                                                                       5.408M ± 0%       5.906M ± 0%   +9.22% (p=0.000 n=10)
LogQL/query={region="ap-southeast-1"}_|~_"error|exception"_|_detected_level="error"_[BACKWARD]/kind=log/store=dataobj-engine-8                                                                 2.439M ± 0%       2.788M ± 0%  +14.27% (p=0.000 n=10)
LogQL/query={service_name="grafana",_env="prod",_region="us-west-2"}_[BACKWARD]/kind=log/store=dataobj-engine-8                                                                                2.238M ± 0%       2.443M ± 0%   +9.19% (p=0.000 n=10)
LogQL/query={service_name="grafana",_env="prod",_region="us-west-2"}_|_detected_level="error"_[BACKWARD]/kind=log/store=dataobj-engine-8                                                       7.181M ± 0%       7.391M ± 0%   +2.92% (p=0.000 n=10)
LogQL/query={service_name="grafana",_env="prod",_region="us-west-2"}_|_detected_level="warn"_[BACKWARD]/kind=log/store=dataobj-engine-8                                                        7.346M ± 0%       7.564M ± 0%   +2.97% (p=0.000 n=10)
LogQL/query={service_name="grafana",_env="prod",_region="us-west-2"}_|~_"error|exception"_|_detected_level="error"_[BACKWARD]/kind=log/store=dataobj-engine-8                                  5.309M ± 0%       5.727M ± 0%   +7.86% (p=0.000 n=10)
LogQL/query={service_name="kubernetes"}_[BACKWARD]/kind=log/store=dataobj-engine-8                                                                                                             1.347M ± 0%       1.631M ± 0%  +21.11% (p=0.000 n=10)
LogQL/query={service_name="kubernetes"}_|_detected_level="error"_[BACKWARD]/kind=log/store=dataobj-engine-8                                                                                    3.524M ± 0%       3.808M ± 0%   +8.05% (p=0.000 n=10)
LogQL/query={service_name="kubernetes"}_|_detected_level="warn"_[BACKWARD]/kind=log/store=dataobj-engine-8                                                                                     3.611M ± 0%       3.895M ± 0%   +7.85% (p=0.000 n=10)
LogQL/query={service_name="kubernetes"}_|~_"error|exception"_|_detected_level="error"_[BACKWARD]/kind=log/store=dataobj-engine-8                                                               1.896M ± 0%       2.129M ± 0%  +12.27% (p=0.000 n=10)
geomean                                                                                                                                                                                        3.305M            3.677M       +11.25%
```