### PR TITLE
chore: Report allocations in logql benchmarks

### DIFF
--- a/pkg/logql/bench/bench_test.go
+++ b/pkg/logql/bench/bench_test.go
@@ -319,7 +319,9 @@ func BenchmarkLogQL(b *testing.B) {
 
 				q := engine.Query(params)
 
+				b.ReportAllocs()
 				b.ResetTimer()
+
 				for i := 0; i < b.N; i++ {
 					r, err := q.Exec(ctx)
 					require.NoError(b, err)


### PR DESCRIPTION
### Summary

Quite self-explanatory. Reporting allocs allows for comparing allocation count/size across different benchmark runs.