### PR TITLE
ci: update docs workflows for zizmor

### DIFF
--- a/.github/workflows/add-to-docs-project.yml
+++ b/.github/workflows/add-to-docs-project.yml
@@ -12,4 +12,4 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     steps:
-      - uses: grafana/writers-toolkit/add-to-docs-project@add-to-docs-project/v1
+      - uses: grafana/writers-toolkit/add-to-docs-project@add-to-docs-project/v1  # zizmor: ignore[unpinned-uses]

--- a/.github/workflows/publish-technical-documentation-release.yml
+++ b/.github/workflows/publish-technical-documentation-release.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: grafana/writers-toolkit/publish-technical-documentation-release@publish-technical-documentation-release/v1
+      - uses: grafana/writers-toolkit/publish-technical-documentation-release@publish-technical-documentation-release/v1 # zizmor: ignore[unpinned-uses]
         with:
           release_tag_regexp: "^v(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$"
           release_branch_regexp: "^release-(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.x$"


### PR DESCRIPTION
**What this PR does / why we need it**:

adding comment to allow zizmor checks to pass the docs workflows on the 3.4 branch (these are copied from `main` and `3.5.x` which are passing these checks)