### PR TITLE
feat: add a config option for custom GCS endpoints (#16419)

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -2323,6 +2323,10 @@ The `gcs_storage_config` block configures the connection to Google Cloud Storage
 # CLI flag: -<prefix>.gcs.bucketname
 [bucket_name: <string> | default = ""]
 
+# Custom GCS endpoint URL.
+# CLI flag: -<prefix>.gcs.endpoint
+[endpoint: <string> | default = ""]
+
 # Service account key content in JSON format, refer to
 # https://cloud.google.com/iam/docs/creating-managing-service-account-keys for
 # creation.


### PR DESCRIPTION
(cherry picked from commit f1ebd970e618326845a7d3f4181bebaaadc6f4de)

Manually backporting https://github.com/grafana/loki/pull/16419. For some reason adding the label didn't trigger the automatic backport.
