### PR TITLE
feat(compactor HS): Wire things up and add some metrics

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -2537,6 +2537,32 @@ compactor_ring:
 # -compactor.tables-to-compact, this is useful when clearing compactor backlogs.
 # CLI flag: -compactor.skip-latest-n-tables
 [skip_latest_n_tables: <int> | default = 0]
+
+# Supported modes - [disabled]: Keeps the horizontal scaling mode disabled.
+# Locally runs all the functions of the compactor.[main]: Runs all functions of
+# the compactor. Distributes work to workers where possible.[worker]: Runs the
+# compactor in worker mode, only working on jobs built by the main compactor.
+# CLI flag: -compactor.horizontal-scaling-mode
+[horizontal_scaling_mode: <string> | default = "disabled"]
+
+worker_config:
+  # Number of workers to run for concurrent processing of jobs.
+  # CLI flag: -compactor.worker.num-workers
+  [num_workers: <int> | default = 4]
+
+jobs_config:
+  deletion:
+    # Maximum number of chunks to process concurrently in each worker.
+    # CLI flag: -compactor.jobs.deletion.chunk-processing-concurrency
+    [chunkprocessingconcurrency: <int> | default = 5]
+
+    # Maximum time to wait for a job before considering it failed and retrying.
+    # CLI flag: -compactor.jobs.deletion.timeout
+    [timeout: <duration> | default = 15m]
+
+    # Maximum number of times to retry a failed or timed out job.
+    # CLI flag: -compactor.jobs.deletion.max-retries
+    [max_retries: <int> | default = 3]
 ```
 
 ### consul

--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -2552,9 +2552,13 @@ worker_config:
 
 jobs_config:
   deletion:
+    # Object storage path prefix for storing deletion manifests.
+    # CLI flag: -compactor.jobs.deletion.deletion-manifest-store-prefix
+    [deletion_manifest_store_prefix: <string> | default = "__deletion_manifest__/"]
+
     # Maximum number of chunks to process concurrently in each worker.
     # CLI flag: -compactor.jobs.deletion.chunk-processing-concurrency
-    [chunkprocessingconcurrency: <int> | default = 5]
+    [chunk_processing_concurrency: <int> | default = 5]
 
     # Maximum time to wait for a job before considering it failed and retrying.
     # CLI flag: -compactor.jobs.deletion.timeout

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -2,18 +2,14 @@ package compactor
 
 import (
 	"context"
-	"flag"
 	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
-	"strings"
 	"sync"
 	"time"
-	"unsafe"
 
 	"github.com/go-kit/log/level"
-	"github.com/grafana/dskit/backoff"
 	"github.com/grafana/dskit/kv"
 	"github.com/grafana/dskit/ring"
 	"github.com/grafana/dskit/services"
@@ -23,7 +19,9 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 
 	"github.com/grafana/loki/v3/pkg/analytics"
+	"github.com/grafana/loki/v3/pkg/compactor/client/grpc"
 	"github.com/grafana/loki/v3/pkg/compactor/deletion"
+	"github.com/grafana/loki/v3/pkg/compactor/jobqueue"
 	"github.com/grafana/loki/v3/pkg/compactor/retention"
 	"github.com/grafana/loki/v3/pkg/storage/chunk/client"
 	"github.com/grafana/loki/v3/pkg/storage/chunk/client/local"
@@ -32,7 +30,6 @@ import (
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/storage"
 	"github.com/grafana/loki/v3/pkg/util/filter"
 	util_log "github.com/grafana/loki/v3/pkg/util/log"
-	lokiring "github.com/grafana/loki/v3/pkg/util/ring"
 	"github.com/grafana/loki/v3/pkg/validation"
 )
 
@@ -67,105 +64,18 @@ const (
 	ringNumTokens = 1
 )
 
+const (
+	HorizontalScalingModeDisabled = "disabled"
+	HorizontalScalingModeMain     = "main"
+	HorizontalScalingModeWorker   = "worker"
+)
+
 var (
 	retentionEnabledStats = analytics.NewString("compactor_retention_enabled")
 	defaultRetentionStats = analytics.NewString("compactor_default_retention")
 
 	errSchemaForTableNotFound = errors.New("schema for table not found")
 )
-
-type Config struct {
-	WorkingDirectory               string              `yaml:"working_directory"`
-	CompactionInterval             time.Duration       `yaml:"compaction_interval"`
-	ApplyRetentionInterval         time.Duration       `yaml:"apply_retention_interval"`
-	RetentionEnabled               bool                `yaml:"retention_enabled"`
-	RetentionDeleteDelay           time.Duration       `yaml:"retention_delete_delay"`
-	RetentionDeleteWorkCount       int                 `yaml:"retention_delete_worker_count"`
-	RetentionTableTimeout          time.Duration       `yaml:"retention_table_timeout"`
-	RetentionBackoffConfig         backoff.Config      `yaml:"retention_backoff_config"`
-	DeleteRequestStore             string              `yaml:"delete_request_store"`
-	DeleteRequestStoreKeyPrefix    string              `yaml:"delete_request_store_key_prefix"`
-	DeleteRequestStoreDBType       string              `yaml:"delete_request_store_db_type"`
-	BackupDeleteRequestStoreDBType string              `yaml:"backup_delete_request_store_db_type"`
-	DeleteBatchSize                int                 `yaml:"delete_batch_size"`
-	DeleteRequestCancelPeriod      time.Duration       `yaml:"delete_request_cancel_period"`
-	DeleteMaxInterval              time.Duration       `yaml:"delete_max_interval"`
-	MaxCompactionParallelism       int                 `yaml:"max_compaction_parallelism"`
-	UploadParallelism              int                 `yaml:"upload_parallelism"`
-	CompactorRing                  lokiring.RingConfig `yaml:"compactor_ring,omitempty" doc:"description=The hash ring configuration used by compactors to elect a single instance for running compactions. The CLI flags prefix for this block config is: compactor.ring"`
-	RunOnce                        bool                `yaml:"_" doc:"hidden"`
-	TablesToCompact                int                 `yaml:"tables_to_compact"`
-	SkipLatestNTables              int                 `yaml:"skip_latest_n_tables"`
-}
-
-// RegisterFlags registers flags.
-func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
-	f.StringVar(&cfg.WorkingDirectory, "compactor.working-directory", "/var/loki/compactor", "Directory where files can be downloaded for compaction.")
-	f.DurationVar(&cfg.CompactionInterval, "compactor.compaction-interval", 10*time.Minute, "Interval at which to re-run the compaction operation.")
-	f.DurationVar(&cfg.ApplyRetentionInterval, "compactor.apply-retention-interval", 0, "Interval at which to apply/enforce retention. 0 means run at same interval as compaction. If non-zero, it should always be a multiple of compaction interval.")
-	f.DurationVar(&cfg.RetentionDeleteDelay, "compactor.retention-delete-delay", 2*time.Hour, "Delay after which chunks will be fully deleted during retention.")
-	f.BoolVar(&cfg.RetentionEnabled, "compactor.retention-enabled", false, "Activate custom (per-stream,per-tenant) retention.")
-	f.IntVar(&cfg.RetentionDeleteWorkCount, "compactor.retention-delete-worker-count", 150, "The total amount of worker to use to delete chunks.")
-	f.StringVar(&cfg.DeleteRequestStore, "compactor.delete-request-store", "", "Store used for managing delete requests.")
-	f.StringVar(&cfg.DeleteRequestStoreKeyPrefix, "compactor.delete-request-store.key-prefix", "index/", "Path prefix for storing delete requests.")
-	f.StringVar(&cfg.DeleteRequestStoreDBType, "compactor.delete-request-store.db-type", string(deletion.DeleteRequestsStoreDBTypeBoltDB), fmt.Sprintf("Type of DB to use for storing delete requests. Supported types: %s", strings.Join(*(*[]string)(unsafe.Pointer(&deletion.SupportedDeleteRequestsStoreDBTypes)), ", ")))
-	f.StringVar(&cfg.BackupDeleteRequestStoreDBType, "compactor.delete-request-store.backup-db-type", "", fmt.Sprintf("Type of DB to use as backup for storing delete requests. Backup DB should ideally be used while migrating from one DB type to another. Supported type(s): %s", deletion.DeleteRequestsStoreDBTypeBoltDB))
-	f.IntVar(&cfg.DeleteBatchSize, "compactor.delete-batch-size", 70, "The max number of delete requests to run per compaction cycle.")
-	f.DurationVar(&cfg.DeleteRequestCancelPeriod, "compactor.delete-request-cancel-period", 24*time.Hour, "Allow cancellation of delete request until duration after they are created. Data would be deleted only after delete requests have been older than this duration. Ideally this should be set to at least 24h.")
-	f.DurationVar(&cfg.DeleteMaxInterval, "compactor.delete-max-interval", 24*time.Hour, "Constrain the size of any single delete request with line filters. When a delete request > delete_max_interval is input, the request is sharded into smaller requests of no more than delete_max_interval")
-	f.DurationVar(&cfg.RetentionTableTimeout, "compactor.retention-table-timeout", 0, "The maximum amount of time to spend running retention and deletion on any given table in the index.")
-	f.IntVar(&cfg.MaxCompactionParallelism, "compactor.max-compaction-parallelism", 1, "Maximum number of tables to compact in parallel. While increasing this value, please make sure compactor has enough disk space allocated to be able to store and compact as many tables.")
-	f.IntVar(&cfg.UploadParallelism, "compactor.upload-parallelism", 10, "Number of upload/remove operations to execute in parallel when finalizing a compaction. NOTE: This setting is per compaction operation, which can be executed in parallel. The upper bound on the number of concurrent uploads is upload_parallelism * max_compaction_parallelism.")
-	f.BoolVar(&cfg.RunOnce, "compactor.run-once", false, "Run the compactor one time to cleanup and compact index files only (no retention applied)")
-	f.IntVar(&cfg.TablesToCompact, "compactor.tables-to-compact", 0, "Number of tables that compactor will try to compact. Newer tables are chosen when this is less than the number of tables available.")
-	f.IntVar(&cfg.SkipLatestNTables, "compactor.skip-latest-n-tables", 0, "Do not compact N latest tables. Together with -compactor.run-once and -compactor.tables-to-compact, this is useful when clearing compactor backlogs.")
-
-	cfg.RetentionBackoffConfig.RegisterFlagsWithPrefix("compactor.retention-backoff-config", f)
-	// Ring
-	skipFlags := []string{
-		"compactor.ring.num-tokens",
-		"compactor.ring.replication-factor",
-	}
-	cfg.CompactorRing.RegisterFlagsWithPrefix("compactor.", "collectors/", f, skipFlags...)
-	f.IntVar(&cfg.CompactorRing.NumTokens, "compactor.ring.num-tokens", ringNumTokens, fmt.Sprintf("IGNORED: Num tokens is fixed to %d", ringNumTokens))
-	f.IntVar(&cfg.CompactorRing.ReplicationFactor, "compactor.ring.replication-factor", ringReplicationFactor, fmt.Sprintf("IGNORED: Replication factor is fixed to %d", ringReplicationFactor))
-}
-
-// Validate verifies the config does not contain inappropriate values
-func (cfg *Config) Validate() error {
-	if cfg.MaxCompactionParallelism < 1 {
-		return errors.New("max compaction parallelism must be >= 1")
-	}
-
-	if cfg.CompactorRing.NumTokens != ringNumTokens {
-		return errors.New("Num tokens must not be changed as it will not take effect")
-	}
-
-	if cfg.CompactorRing.ReplicationFactor != ringReplicationFactor {
-		return errors.New("Replication factor must not be changed as it will not take effect")
-	}
-
-	if cfg.RetentionEnabled {
-		if cfg.DeleteRequestStore == "" {
-			return fmt.Errorf("compactor.delete-request-store should be configured when retention is enabled")
-		}
-
-		if cfg.ApplyRetentionInterval == 0 {
-			cfg.ApplyRetentionInterval = cfg.CompactionInterval
-		}
-
-		if cfg.ApplyRetentionInterval == cfg.CompactionInterval {
-			// add some jitter to avoid running retention and compaction at same time
-			cfg.ApplyRetentionInterval += min(10*time.Minute, cfg.ApplyRetentionInterval/2)
-		}
-
-		if err := config.ValidatePathPrefix(cfg.DeleteRequestStoreKeyPrefix); err != nil {
-			return fmt.Errorf("validate delete store path prefix: %w", err)
-		}
-	}
-
-	return nil
-}
 
 type Compactor struct {
 	services.Service
@@ -185,6 +95,7 @@ type Compactor struct {
 	indexCompactors           map[string]IndexCompactor
 	schemaConfig              config.SchemaConfig
 	limits                    Limits
+	JobQueue                  *jobqueue.Queue
 
 	tablesManager *tablesManager
 	// Ring used for running a single compactor
@@ -389,6 +300,15 @@ func (c *Compactor) init(
 		}
 	}
 
+	if c.cfg.HorizontalScalingMode == HorizontalScalingModeMain {
+		c.JobQueue = jobqueue.NewQueue()
+		if c.cfg.RetentionEnabled {
+			if err := c.JobQueue.RegisterBuilder(grpc.JOB_TYPE_DELETION, c.deleteRequestsManager.JobBuilder(), c.cfg.JobsConfig.Deletion.Timeout, c.cfg.JobsConfig.Deletion.MaxRetries); err != nil {
+				return err
+			}
+		}
+	}
+
 	return nil
 }
 
@@ -551,6 +471,14 @@ func (c *Compactor) loop(ctx context.Context) error {
 						go func() {
 							defer wg.Done()
 							c.deleteRequestsManager.Start(runningCtx)
+						}()
+					}
+
+					if c.cfg.HorizontalScalingMode == HorizontalScalingModeMain {
+						wg.Add(1)
+						go func() {
+							defer wg.Done()
+							c.JobQueue.Start(runningCtx)
 						}()
 					}
 

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -301,7 +301,7 @@ func (c *Compactor) init(
 	}
 
 	if c.cfg.HorizontalScalingMode == HorizontalScalingModeMain {
-		c.JobQueue = jobqueue.NewQueue()
+		c.JobQueue = jobqueue.NewQueue(r)
 		if c.cfg.RetentionEnabled {
 			if err := c.JobQueue.RegisterBuilder(grpc.JOB_TYPE_DELETION, c.deleteRequestsManager.JobBuilder(), c.cfg.JobsConfig.Deletion.Timeout, c.cfg.JobsConfig.Deletion.MaxRetries); err != nil {
 				return err

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -343,8 +343,8 @@ func (c *Compactor) initDeletes(objectClient client.ObjectClient, indexUpdatePro
 		c.cfg.DeleteRequestCancelPeriod,
 		c.cfg.DeleteBatchSize,
 		limits,
-		false,
-		objectClient,
+		c.cfg.HorizontalScalingMode == HorizontalScalingModeMain,
+		client.NewPrefixedObjectClient(objectClient, c.cfg.JobsConfig.Deletion.DeletionManifestStorePrefix),
 		r,
 	)
 	if err != nil {

--- a/pkg/compactor/config.go
+++ b/pkg/compactor/config.go
@@ -132,12 +132,14 @@ func (c *JobsConfig) RegisterFlags(f *flag.FlagSet) {
 }
 
 type DeletionJobsConfig struct {
-	ChunkProcessingConcurrency int           `json:"chunk_processing_concurrency"`
-	Timeout                    time.Duration `yaml:"timeout"`
-	MaxRetries                 int           `yaml:"max_retries"`
+	DeletionManifestStorePrefix string        `yaml:"deletion_manifest_store_prefix"`
+	ChunkProcessingConcurrency  int           `yaml:"chunk_processing_concurrency"`
+	Timeout                     time.Duration `yaml:"timeout"`
+	MaxRetries                  int           `yaml:"max_retries"`
 }
 
 func (c *DeletionJobsConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
+	f.StringVar(&c.DeletionManifestStorePrefix, prefix+"deletion-manifest-store-prefix", "__deletion_manifest__/", "Object storage path prefix for storing deletion manifests.")
 	f.IntVar(&c.ChunkProcessingConcurrency, prefix+"chunk-processing-concurrency", 5, "Maximum number of chunks to process concurrently in each worker.")
 	f.DurationVar(&c.Timeout, prefix+"timeout", 15*time.Minute, "Maximum time to wait for a job before considering it failed and retrying.")
 	f.IntVar(&c.MaxRetries, prefix+"max-retries", 3, "Maximum number of times to retry a failed or timed out job.")

--- a/pkg/compactor/config.go
+++ b/pkg/compactor/config.go
@@ -1,0 +1,148 @@
+package compactor
+
+import (
+	"flag"
+	"fmt"
+	"strings"
+	"time"
+	"unsafe"
+
+	"github.com/grafana/dskit/backoff"
+	"github.com/pkg/errors"
+
+	"github.com/grafana/loki/v3/pkg/compactor/deletion"
+	"github.com/grafana/loki/v3/pkg/compactor/jobqueue"
+	"github.com/grafana/loki/v3/pkg/storage/config"
+	lokiring "github.com/grafana/loki/v3/pkg/util/ring"
+)
+
+type Config struct {
+	WorkingDirectory               string                `yaml:"working_directory"`
+	CompactionInterval             time.Duration         `yaml:"compaction_interval"`
+	ApplyRetentionInterval         time.Duration         `yaml:"apply_retention_interval"`
+	RetentionEnabled               bool                  `yaml:"retention_enabled"`
+	RetentionDeleteDelay           time.Duration         `yaml:"retention_delete_delay"`
+	RetentionDeleteWorkCount       int                   `yaml:"retention_delete_worker_count"`
+	RetentionTableTimeout          time.Duration         `yaml:"retention_table_timeout"`
+	RetentionBackoffConfig         backoff.Config        `yaml:"retention_backoff_config"`
+	DeleteRequestStore             string                `yaml:"delete_request_store"`
+	DeleteRequestStoreKeyPrefix    string                `yaml:"delete_request_store_key_prefix"`
+	DeleteRequestStoreDBType       string                `yaml:"delete_request_store_db_type"`
+	BackupDeleteRequestStoreDBType string                `yaml:"backup_delete_request_store_db_type"`
+	DeleteBatchSize                int                   `yaml:"delete_batch_size"`
+	DeleteRequestCancelPeriod      time.Duration         `yaml:"delete_request_cancel_period"`
+	DeleteMaxInterval              time.Duration         `yaml:"delete_max_interval"`
+	MaxCompactionParallelism       int                   `yaml:"max_compaction_parallelism"`
+	UploadParallelism              int                   `yaml:"upload_parallelism"`
+	CompactorRing                  lokiring.RingConfig   `yaml:"compactor_ring,omitempty" doc:"description=The hash ring configuration used by compactors to elect a single instance for running compactions. The CLI flags prefix for this block config is: compactor.ring"`
+	RunOnce                        bool                  `yaml:"_" doc:"hidden"`
+	TablesToCompact                int                   `yaml:"tables_to_compact"`
+	SkipLatestNTables              int                   `yaml:"skip_latest_n_tables"`
+	HorizontalScalingMode          string                `yaml:"horizontal_scaling_mode"`
+	WorkerConfig                   jobqueue.WorkerConfig `yaml:"worker_config"`
+	JobsConfig                     JobsConfig            `yaml:"jobs_config"`
+}
+
+// RegisterFlags registers flags.
+func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
+	f.StringVar(&cfg.WorkingDirectory, "compactor.working-directory", "/var/loki/compactor", "Directory where files can be downloaded for compaction.")
+	f.DurationVar(&cfg.CompactionInterval, "compactor.compaction-interval", 10*time.Minute, "Interval at which to re-run the compaction operation.")
+	f.DurationVar(&cfg.ApplyRetentionInterval, "compactor.apply-retention-interval", 0, "Interval at which to apply/enforce retention. 0 means run at same interval as compaction. If non-zero, it should always be a multiple of compaction interval.")
+	f.DurationVar(&cfg.RetentionDeleteDelay, "compactor.retention-delete-delay", 2*time.Hour, "Delay after which chunks will be fully deleted during retention.")
+	f.BoolVar(&cfg.RetentionEnabled, "compactor.retention-enabled", false, "Activate custom (per-stream,per-tenant) retention.")
+	f.IntVar(&cfg.RetentionDeleteWorkCount, "compactor.retention-delete-worker-count", 150, "The total amount of worker to use to delete chunks.")
+	f.StringVar(&cfg.DeleteRequestStore, "compactor.delete-request-store", "", "Store used for managing delete requests.")
+	f.StringVar(&cfg.DeleteRequestStoreKeyPrefix, "compactor.delete-request-store.key-prefix", "index/", "Path prefix for storing delete requests.")
+	f.StringVar(&cfg.DeleteRequestStoreDBType, "compactor.delete-request-store.db-type", string(deletion.DeleteRequestsStoreDBTypeBoltDB), fmt.Sprintf("Type of DB to use for storing delete requests. Supported types: %s", strings.Join(*(*[]string)(unsafe.Pointer(&deletion.SupportedDeleteRequestsStoreDBTypes)), ", ")))
+	f.StringVar(&cfg.BackupDeleteRequestStoreDBType, "compactor.delete-request-store.backup-db-type", "", fmt.Sprintf("Type of DB to use as backup for storing delete requests. Backup DB should ideally be used while migrating from one DB type to another. Supported type(s): %s", deletion.DeleteRequestsStoreDBTypeBoltDB))
+	f.IntVar(&cfg.DeleteBatchSize, "compactor.delete-batch-size", 70, "The max number of delete requests to run per compaction cycle.")
+	f.DurationVar(&cfg.DeleteRequestCancelPeriod, "compactor.delete-request-cancel-period", 24*time.Hour, "Allow cancellation of delete request until duration after they are created. Data would be deleted only after delete requests have been older than this duration. Ideally this should be set to at least 24h.")
+	f.DurationVar(&cfg.DeleteMaxInterval, "compactor.delete-max-interval", 24*time.Hour, "Constrain the size of any single delete request with line filters. When a delete request > delete_max_interval is input, the request is sharded into smaller requests of no more than delete_max_interval")
+	f.DurationVar(&cfg.RetentionTableTimeout, "compactor.retention-table-timeout", 0, "The maximum amount of time to spend running retention and deletion on any given table in the index.")
+	f.IntVar(&cfg.MaxCompactionParallelism, "compactor.max-compaction-parallelism", 1, "Maximum number of tables to compact in parallel. While increasing this value, please make sure compactor has enough disk space allocated to be able to store and compact as many tables.")
+	f.IntVar(&cfg.UploadParallelism, "compactor.upload-parallelism", 10, "Number of upload/remove operations to execute in parallel when finalizing a compaction. NOTE: This setting is per compaction operation, which can be executed in parallel. The upper bound on the number of concurrent uploads is upload_parallelism * max_compaction_parallelism.")
+	f.BoolVar(&cfg.RunOnce, "compactor.run-once", false, "Run the compactor one time to cleanup and compact index files only (no retention applied)")
+	f.IntVar(&cfg.TablesToCompact, "compactor.tables-to-compact", 0, "Number of tables that compactor will try to compact. Newer tables are chosen when this is less than the number of tables available.")
+	f.IntVar(&cfg.SkipLatestNTables, "compactor.skip-latest-n-tables", 0, "Do not compact N latest tables. Together with -compactor.run-once and -compactor.tables-to-compact, this is useful when clearing compactor backlogs.")
+
+	cfg.RetentionBackoffConfig.RegisterFlagsWithPrefix("compactor.retention-backoff-config", f)
+	// Ring
+	skipFlags := []string{
+		"compactor.ring.num-tokens",
+		"compactor.ring.replication-factor",
+	}
+	cfg.CompactorRing.RegisterFlagsWithPrefix("compactor.", "collectors/", f, skipFlags...)
+	f.IntVar(&cfg.CompactorRing.NumTokens, "compactor.ring.num-tokens", ringNumTokens, fmt.Sprintf("IGNORED: Num tokens is fixed to %d", ringNumTokens))
+	f.IntVar(&cfg.CompactorRing.ReplicationFactor, "compactor.ring.replication-factor", ringReplicationFactor, fmt.Sprintf("IGNORED: Replication factor is fixed to %d", ringReplicationFactor))
+	f.StringVar(&cfg.HorizontalScalingMode, "compactor.horizontal-scaling-mode", HorizontalScalingModeDisabled, fmt.Sprintf("Supported modes - "+
+		"[%s]: Keeps the horizontal scaling mode disabled. Locally runs all the functions of the compactor."+
+		"[%s]: Runs all functions of the compactor. Distributes work to workers where possible."+
+		"[%s]: Runs the compactor in worker mode, only working on jobs built by the main compactor.",
+		HorizontalScalingModeDisabled, HorizontalScalingModeMain, HorizontalScalingModeWorker))
+	cfg.WorkerConfig.RegisterFlagsWithPrefix("compactor.worker.", f)
+	cfg.JobsConfig.RegisterFlagsWithPrefix("compactor.jobs.", f)
+}
+
+// Validate verifies the config does not contain inappropriate values
+func (cfg *Config) Validate() error {
+	if cfg.MaxCompactionParallelism < 1 {
+		return errors.New("max compaction parallelism must be >= 1")
+	}
+
+	if cfg.CompactorRing.NumTokens != ringNumTokens {
+		return errors.New("Num tokens must not be changed as it will not take effect")
+	}
+
+	if cfg.CompactorRing.ReplicationFactor != ringReplicationFactor {
+		return errors.New("Replication factor must not be changed as it will not take effect")
+	}
+
+	if cfg.RetentionEnabled {
+		if cfg.DeleteRequestStore == "" {
+			return fmt.Errorf("compactor.delete-request-store should be configured when retention is enabled")
+		}
+
+		if cfg.ApplyRetentionInterval == 0 {
+			cfg.ApplyRetentionInterval = cfg.CompactionInterval
+		}
+
+		if cfg.ApplyRetentionInterval == cfg.CompactionInterval {
+			// add some jitter to avoid running retention and compaction at same time
+			cfg.ApplyRetentionInterval += min(10*time.Minute, cfg.ApplyRetentionInterval/2)
+		}
+
+		if err := config.ValidatePathPrefix(cfg.DeleteRequestStoreKeyPrefix); err != nil {
+			return fmt.Errorf("validate delete store path prefix: %w", err)
+		}
+	}
+
+	return nil
+}
+
+type JobsConfig struct {
+	Deletion DeletionJobsConfig `yaml:"deletion"`
+}
+
+func (c *JobsConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
+	c.Deletion.RegisterFlagsWithPrefix(prefix+"deletion.", f)
+}
+
+func (c *JobsConfig) RegisterFlags(f *flag.FlagSet) {
+	c.Deletion.RegisterFlagsWithPrefix("deletion.", f)
+}
+
+type DeletionJobsConfig struct {
+	ChunkProcessingConcurrency int           `json:"chunk_processing_concurrency"`
+	Timeout                    time.Duration `yaml:"timeout"`
+	MaxRetries                 int           `yaml:"max_retries"`
+}
+
+func (c *DeletionJobsConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
+	f.IntVar(&c.ChunkProcessingConcurrency, prefix+"chunk-processing-concurrency", 5, "Maximum number of chunks to process concurrently in each worker.")
+	f.DurationVar(&c.Timeout, prefix+"timeout", 15*time.Minute, "Maximum time to wait for a job before considering it failed and retrying.")
+	f.IntVar(&c.MaxRetries, prefix+"max-retries", 3, "Maximum number of times to retry a failed or timed out job.")
+}
+
+func (c *DeletionJobsConfig) RegisterFlags(f *flag.FlagSet) {
+	c.RegisterFlagsWithPrefix("", f)
+}

--- a/pkg/compactor/deletion/delete_requests_manager.go
+++ b/pkg/compactor/deletion/delete_requests_manager.go
@@ -169,6 +169,10 @@ func (d *DeleteRequestsManager) loop(ctx context.Context) {
 }
 
 func (d *DeleteRequestsManager) buildDeletionManifestLoop(ctx context.Context) {
+	if err := cleanupInvalidManifests(ctx, d.deletionStoreClient); err != nil {
+		level.Error(util_log.Logger).Log("msg", "failed to cleanup invalid delete manifests", "err", err)
+	}
+
 	ticker := time.NewTicker(5 * time.Minute)
 	defer ticker.Stop()
 

--- a/pkg/compactor/deletion/delete_requests_manager.go
+++ b/pkg/compactor/deletion/delete_requests_manager.go
@@ -142,6 +142,10 @@ func (d *DeleteRequestsManager) Start(ctx context.Context) {
 	}
 }
 
+func (d *DeleteRequestsManager) JobBuilder() *JobBuilder {
+	return d.jobBuilder
+}
+
 func (d *DeleteRequestsManager) loop(ctx context.Context) {
 	ticker := time.NewTicker(5 * time.Minute)
 	defer ticker.Stop()

--- a/pkg/compactor/deletion/delete_requests_manager.go
+++ b/pkg/compactor/deletion/delete_requests_manager.go
@@ -196,6 +196,17 @@ func (d *DeleteRequestsManager) buildDeletionManifest(ctx context.Context) error
 		return nil
 	}
 
+	// Do not build another manifest if one already exists since we do not know which requests are already added to it for processing.
+	// There is anyway no benefit in building multiple manifests since we process one manifest at a time.
+	manifestExists, err := storageHasValidManifest(ctx, d.deletionStoreClient)
+	if err != nil {
+		return err
+	}
+
+	if manifestExists {
+		return nil
+	}
+
 	deletionManifestBuilder, err := newDeletionManifestBuilder(d.deletionStoreClient, deleteRequestsBatch)
 	if err != nil {
 		return err

--- a/pkg/compactor/deletion/delete_requests_manager.go
+++ b/pkg/compactor/deletion/delete_requests_manager.go
@@ -215,11 +215,14 @@ func (d *DeleteRequestsManager) buildDeletionManifest(ctx context.Context) error
 		return nil
 	}
 
+	level.Info(util_log.Logger).Log("msg", "building deletion manifest")
+
 	deletionManifestBuilder, err := newDeletionManifestBuilder(d.deletionManifestStoreClient, deleteRequestsBatch)
 	if err != nil {
 		return err
 	}
 
+	level.Info(deletionManifestBuilder.logger).Log("msg", "adding series to deletion manifest")
 	userIDs := deleteRequestsBatch.userIDs()
 	if err := d.tablesManager.IterateTables(ctx, func(tableName string, table Table) error {
 		for _, userID := range userIDs {
@@ -240,6 +243,7 @@ func (d *DeleteRequestsManager) buildDeletionManifest(ctx context.Context) error
 		return err
 	}
 
+	level.Info(util_log.Logger).Log("msg", "done adding series to deletion manifest")
 	err = deletionManifestBuilder.Finish(ctx)
 	if err != nil {
 		return err

--- a/pkg/compactor/deletion/deletion_manifest_builder.go
+++ b/pkg/compactor/deletion/deletion_manifest_builder.go
@@ -58,8 +58,8 @@ type manifest struct {
 // deletionManifestBuilder helps with building the manifest for listing out which chunks to process for a batch of delete requests.
 // It is not meant to be used concurrently.
 type deletionManifestBuilder struct {
-	deletionStoreClient client.ObjectClient
-	deleteRequestBatch  *deleteRequestBatch
+	deletionManifestStoreClient client.ObjectClient
+	deleteRequestBatch          *deleteRequestBatch
 
 	currentSegment            map[uint64]ChunksGroup
 	currentSegmentChunksCount int
@@ -73,7 +73,7 @@ type deletionManifestBuilder struct {
 	logger             log.Logger
 }
 
-func newDeletionManifestBuilder(deletionStoreClient client.ObjectClient, deleteRequestBatch *deleteRequestBatch) (*deletionManifestBuilder, error) {
+func newDeletionManifestBuilder(deletionManifestStoreClient client.ObjectClient, deleteRequestBatch *deleteRequestBatch) (*deletionManifestBuilder, error) {
 	requestCount := 0
 	for _, userRequests := range deleteRequestBatch.deleteRequestsToProcess {
 		requestCount += len(userRequests.requests)
@@ -88,11 +88,11 @@ func newDeletionManifestBuilder(deletionStoreClient client.ObjectClient, deleteR
 	now := time.Now()
 
 	builder := &deletionManifestBuilder{
-		deletionStoreClient: deletionStoreClient,
-		deleteRequestBatch:  deleteRequestBatch,
-		currentSegment:      make(map[uint64]ChunksGroup),
-		creationTime:        now,
-		logger:              log.With(util_log.Logger, "manifest", now.UnixNano()),
+		deletionManifestStoreClient: deletionManifestStoreClient,
+		deleteRequestBatch:          deleteRequestBatch,
+		currentSegment:              make(map[uint64]ChunksGroup),
+		creationTime:                now,
+		logger:                      log.With(util_log.Logger, "manifest", now.UnixNano()),
 	}
 
 	return builder, nil
@@ -212,7 +212,7 @@ func (d *deletionManifestBuilder) Finish(ctx context.Context) error {
 		return err
 	}
 
-	return d.deletionStoreClient.PutObject(ctx, d.buildObjectKey(manifestFileName), strings.NewReader(unsafeGetString(manifestJSON)))
+	return d.deletionManifestStoreClient.PutObject(ctx, d.buildObjectKey(manifestFileName), strings.NewReader(unsafeGetString(manifestJSON)))
 }
 
 func (d *deletionManifestBuilder) flushCurrentBatch(ctx context.Context) error {
@@ -255,7 +255,7 @@ func (d *deletionManifestBuilder) flushCurrentBatch(ctx context.Context) error {
 	d.overallChunksCount += d.currentSegmentChunksCount
 	d.currentSegmentChunksCount = 0
 
-	return d.deletionStoreClient.PutObject(ctx, d.buildObjectKey(fmt.Sprintf("%d.json", d.segmentsCount-1)), strings.NewReader(unsafeGetString(batchJSON)))
+	return d.deletionManifestStoreClient.PutObject(ctx, d.buildObjectKey(fmt.Sprintf("%d.json", d.segmentsCount-1)), strings.NewReader(unsafeGetString(batchJSON)))
 }
 
 func (d *deletionManifestBuilder) buildObjectKey(filename string) string {
@@ -266,9 +266,9 @@ func (d *deletionManifestBuilder) path() string {
 	return fmt.Sprint(d.creationTime.UnixNano())
 }
 
-func storageHasValidManifest(ctx context.Context, deletionStoreClient client.ObjectClient) (bool, error) {
+func storageHasValidManifest(ctx context.Context, deletionManifestStoreClient client.ObjectClient) (bool, error) {
 	// List all directories in the deletion store
-	_, commonPrefixes, err := deletionStoreClient.List(ctx, "", "/")
+	_, commonPrefixes, err := deletionManifestStoreClient.List(ctx, "", "/")
 	if err != nil {
 		return false, err
 	}
@@ -281,7 +281,7 @@ func storageHasValidManifest(ctx context.Context, deletionStoreClient client.Obj
 
 		// Check if manifest.json exists in this directory
 		manifestPath := path.Join(string(commonPrefix), manifestFileName)
-		exists, err := deletionStoreClient.ObjectExists(ctx, manifestPath)
+		exists, err := deletionManifestStoreClient.ObjectExists(ctx, manifestPath)
 		if err != nil {
 			return false, err
 		}
@@ -297,9 +297,9 @@ func storageHasValidManifest(ctx context.Context, deletionStoreClient client.Obj
 	return false, nil
 }
 
-func cleanupInvalidManifests(ctx context.Context, deletionStoreClient client.ObjectClient) error {
+func cleanupInvalidManifests(ctx context.Context, deletionManifestStoreClient client.ObjectClient) error {
 	// List all directories in the deletion store
-	_, commonPrefixes, err := deletionStoreClient.List(ctx, "", "/")
+	_, commonPrefixes, err := deletionManifestStoreClient.List(ctx, "", "/")
 	if err != nil {
 		return err
 	}
@@ -314,7 +314,7 @@ func cleanupInvalidManifests(ctx context.Context, deletionStoreClient client.Obj
 
 		// manifest without manifest.json is considered invalid
 		manifestPath := path.Join(string(commonPrefix), manifestFileName)
-		exists, err := deletionStoreClient.ObjectExists(ctx, manifestPath)
+		exists, err := deletionManifestStoreClient.ObjectExists(ctx, manifestPath)
 		if err != nil {
 			return err
 		}
@@ -327,14 +327,14 @@ func cleanupInvalidManifests(ctx context.Context, deletionStoreClient client.Obj
 		level.Info(util_log.Logger).Log("msg", "cleaning up invalid manifest", "manifest", commonPrefix)
 
 		// delete all the contents of the manifest to clean it up
-		objects, _, err := deletionStoreClient.List(ctx, string(commonPrefix), "/")
+		objects, _, err := deletionManifestStoreClient.List(ctx, string(commonPrefix), "/")
 		if err != nil {
 			return err
 		}
 
 		// delete all the remaining objects
 		for _, object := range objects {
-			if err := deletionStoreClient.DeleteObject(ctx, object.Key); err != nil {
+			if err := deletionManifestStoreClient.DeleteObject(ctx, object.Key); err != nil {
 				level.Error(util_log.Logger).Log("msg", "failed to delete object", "object", object.Key)
 				if firstErr == nil {
 					firstErr = err

--- a/pkg/compactor/deletion/deletion_manifest_builder_test.go
+++ b/pkg/compactor/deletion/deletion_manifest_builder_test.go
@@ -611,7 +611,7 @@ func TestDeletionManifestBuilder(t *testing.T) {
 			require.Equal(t, tc.expectedManifest.SegmentsCount, builder.segmentsCount)
 			require.Equal(t, tc.expectedManifest.ChunksCount, builder.overallChunksCount)
 
-			reader, _, err := builder.deletionStoreClient.GetObject(context.Background(), builder.buildObjectKey(manifestFileName))
+			reader, _, err := builder.deletionManifestStoreClient.GetObject(context.Background(), builder.buildObjectKey(manifestFileName))
 			require.NoError(t, err)
 
 			manifestJSON, err := io.ReadAll(reader)
@@ -627,7 +627,7 @@ func TestDeletionManifestBuilder(t *testing.T) {
 			require.Equal(t, tc.expectedManifest, manifest)
 
 			for i := 0; i < tc.expectedManifest.SegmentsCount; i++ {
-				reader, _, err := builder.deletionStoreClient.GetObject(context.Background(), builder.buildObjectKey(fmt.Sprintf("%d.json", i)))
+				reader, _, err := builder.deletionManifestStoreClient.GetObject(context.Background(), builder.buildObjectKey(fmt.Sprintf("%d.json", i)))
 				require.NoError(t, err)
 
 				segmentJSON, err := io.ReadAll(reader)
@@ -735,7 +735,7 @@ func TestCleanupInvalidManifest(t *testing.T) {
 	require.True(t, manifestExists)
 
 	// ensure that manifest has the expected number of files
-	reader, _, err := builder.deletionStoreClient.GetObject(context.Background(), builder.buildObjectKey(manifestFileName))
+	reader, _, err := builder.deletionManifestStoreClient.GetObject(context.Background(), builder.buildObjectKey(manifestFileName))
 	require.NoError(t, err)
 
 	manifestJSON, err := io.ReadAll(reader)
@@ -750,7 +750,7 @@ func TestCleanupInvalidManifest(t *testing.T) {
 	require.Len(t, objects, manifest.SegmentsCount+1)
 
 	// remove the manifest.json file to make the manifest invalid
-	require.NoError(t, builder.deletionStoreClient.DeleteObject(ctx, builder.buildObjectKey(manifestFileName)))
+	require.NoError(t, builder.deletionManifestStoreClient.DeleteObject(ctx, builder.buildObjectKey(manifestFileName)))
 
 	// ensure that storageHasValidManifest returns true since we just deliberately made the manifest invalid
 	manifestExists, err = storageHasValidManifest(ctx, objectClient)

--- a/pkg/compactor/deletion/deletion_manifest_builder_test.go
+++ b/pkg/compactor/deletion/deletion_manifest_builder_test.go
@@ -685,3 +685,83 @@ func TestDeletionManifestBuilder_Errors(t *testing.T) {
 	err = builder.Finish(ctx)
 	require.EqualError(t, err, ErrNoChunksSelectedForDeletion.Error())
 }
+
+func TestCleanupInvalidManifest(t *testing.T) {
+	tempDir := t.TempDir()
+	ctx := context.Background()
+	objectClient, err := local.NewFSObjectClient(local.FSConfig{
+		Directory: tempDir,
+	})
+	require.NoError(t, err)
+
+	// Create delete request batch
+	batch := newDeleteRequestBatch(nil)
+	batch.addDeleteRequest(&DeleteRequest{
+		UserID:    user1,
+		RequestID: req1,
+		Query:     lblFooBar,
+		StartTime: 0,
+		EndTime:   100,
+	})
+
+	// ensure that storageHasValidManifest returns false since we have not built any manifests yet
+	manifestExists, err := storageHasValidManifest(ctx, objectClient)
+	require.NoError(t, err)
+	require.False(t, manifestExists)
+
+	// build a manifest
+	builder, err := newDeletionManifestBuilder(objectClient, batch)
+	require.NoError(t, err)
+
+	err = builder.AddSeries(ctx, table1, &mockSeries{
+		userID: user1,
+		labels: mustParseLabel(lblFooBar),
+		chunks: buildRetentionChunks(0, 25),
+	})
+	require.NoError(t, err)
+
+	err = builder.Finish(ctx)
+	require.NoError(t, err)
+
+	// ensure that storageHasValidManifest returns true since we just built a manifest
+	manifestExists, err = storageHasValidManifest(ctx, objectClient)
+	require.NoError(t, err)
+	require.True(t, manifestExists)
+
+	// cleanupInvalidManifests should not clean up the manifest we built
+	require.NoError(t, cleanupInvalidManifests(ctx, objectClient))
+	manifestExists, err = storageHasValidManifest(ctx, objectClient)
+	require.NoError(t, err)
+	require.True(t, manifestExists)
+
+	// ensure that manifest has the expected number of files
+	reader, _, err := builder.deletionStoreClient.GetObject(context.Background(), builder.buildObjectKey(manifestFileName))
+	require.NoError(t, err)
+
+	manifestJSON, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	require.NoError(t, reader.Close())
+
+	var manifest manifest
+	require.NoError(t, json.Unmarshal(manifestJSON, &manifest))
+
+	objects, _, err := objectClient.List(ctx, builder.buildObjectKey(""), "/")
+	require.NoError(t, err)
+	require.Len(t, objects, manifest.SegmentsCount+1)
+
+	// remove the manifest.json file to make the manifest invalid
+	require.NoError(t, builder.deletionStoreClient.DeleteObject(ctx, builder.buildObjectKey(manifestFileName)))
+
+	// ensure that storageHasValidManifest returns true since we just deliberately made the manifest invalid
+	manifestExists, err = storageHasValidManifest(ctx, objectClient)
+	require.NoError(t, err)
+	require.False(t, manifestExists)
+
+	// cleanupInvalidManifests should cleanup all the files for the manifest
+	require.NoError(t, cleanupInvalidManifests(ctx, objectClient))
+
+	// ensure that we are left with no manifest directories in the storage
+	_, commonPrefixes, err := objectClient.List(ctx, "", "/")
+	require.NoError(t, err)
+	require.Len(t, commonPrefixes, 0)
+}

--- a/pkg/compactor/deletion/job_builder.go
+++ b/pkg/compactor/deletion/job_builder.go
@@ -53,7 +53,7 @@ type ApplyStorageUpdatesFunc func(ctx context.Context, iterator StorageUpdatesIt
 type markRequestsAsProcessedFunc func(requests []DeleteRequest)
 
 type JobBuilder struct {
-	deletionStoreClient         client.ObjectClient
+	deletionManifestStoreClient client.ObjectClient
 	applyStorageUpdatesFunc     ApplyStorageUpdatesFunc
 	markRequestsAsProcessedFunc markRequestsAsProcessedFunc
 
@@ -64,9 +64,9 @@ type JobBuilder struct {
 	currSegmentStorageUpdates *storageUpdatesCollection
 }
 
-func NewJobBuilder(deletionStoreClient client.ObjectClient, applyStorageUpdatesFunc ApplyStorageUpdatesFunc, markRequestsAsProcessedFunc markRequestsAsProcessedFunc) *JobBuilder {
+func NewJobBuilder(deletionManifestStoreClient client.ObjectClient, applyStorageUpdatesFunc ApplyStorageUpdatesFunc, markRequestsAsProcessedFunc markRequestsAsProcessedFunc) *JobBuilder {
 	return &JobBuilder{
-		deletionStoreClient:         deletionStoreClient,
+		deletionManifestStoreClient: deletionManifestStoreClient,
 		applyStorageUpdatesFunc:     applyStorageUpdatesFunc,
 		markRequestsAsProcessedFunc: markRequestsAsProcessedFunc,
 		currSegmentStorageUpdates: &storageUpdatesCollection{
@@ -147,7 +147,7 @@ func (b *JobBuilder) processManifest(ctx context.Context, manifest *manifest, ma
 
 		segmentPath := path.Join(manifestPath, fmt.Sprintf("%d.json", segmentNum))
 
-		manifestExists, err := b.deletionStoreClient.ObjectExists(ctx, segmentPath)
+		manifestExists, err := b.deletionManifestStoreClient.ObjectExists(ctx, segmentPath)
 		if err != nil {
 			return err
 		}
@@ -191,7 +191,7 @@ func (b *JobBuilder) processManifest(ctx context.Context, manifest *manifest, ma
 		}
 
 		// Delete the processed segment
-		if err := b.deletionStoreClient.DeleteObject(ctx, segmentPath); err != nil {
+		if err := b.deletionManifestStoreClient.DeleteObject(ctx, segmentPath); err != nil {
 			level.Warn(util_log.Logger).Log("msg", "failed to delete processed segment",
 				"segment", segmentPath,
 				"error", err)
@@ -213,7 +213,7 @@ func (b *JobBuilder) uploadStorageUpdatesForCurrentSegment(ctx context.Context, 
 		return err
 	}
 
-	return b.deletionStoreClient.PutObject(ctx, path, bytes.NewReader(storageUpdatesJSON))
+	return b.deletionManifestStoreClient.PutObject(ctx, path, bytes.NewReader(storageUpdatesJSON))
 }
 
 func (b *JobBuilder) waitForSegmentCompletion(ctx context.Context) error {
@@ -237,7 +237,7 @@ func (b *JobBuilder) waitForSegmentCompletion(ctx context.Context) error {
 
 func (b *JobBuilder) listManifests(ctx context.Context) ([]string, error) {
 	// List all directories in the deletion store
-	_, commonPrefixes, err := b.deletionStoreClient.List(ctx, "", "/")
+	_, commonPrefixes, err := b.deletionManifestStoreClient.List(ctx, "", "/")
 	if err != nil {
 		return nil, err
 	}
@@ -252,7 +252,7 @@ func (b *JobBuilder) listManifests(ctx context.Context) ([]string, error) {
 
 		// Check if manifest.json exists in this directory
 		manifestPath := path.Join(string(commonPrefix), manifestFileName)
-		exists, err := b.deletionStoreClient.ObjectExists(ctx, manifestPath)
+		exists, err := b.deletionManifestStoreClient.ObjectExists(ctx, manifestPath)
 		if err != nil {
 			return nil, err
 		}
@@ -269,7 +269,7 @@ func (b *JobBuilder) listManifests(ctx context.Context) ([]string, error) {
 
 func (b *JobBuilder) readManifest(ctx context.Context, manifestPath string) (*manifest, error) {
 	// Read manifest file
-	reader, _, err := b.deletionStoreClient.GetObject(ctx, path.Join(manifestPath, manifestFileName))
+	reader, _, err := b.deletionManifestStoreClient.GetObject(ctx, path.Join(manifestPath, manifestFileName))
 	if err != nil {
 		return nil, err
 	}
@@ -355,7 +355,7 @@ func (b *JobBuilder) OnJobResponse(response *grpc.JobResult) error {
 
 // applyStorageUpdates applies all the storage updates accumulated while processing of the given manifest
 func (b *JobBuilder) applyStorageUpdates(ctx context.Context, manifest *manifest, manifestPath string) error {
-	storageUpdatesIterator := newStorageUpdatesIterator(ctx, manifestPath, manifest, b.deletionStoreClient)
+	storageUpdatesIterator := newStorageUpdatesIterator(ctx, manifestPath, manifest, b.deletionManifestStoreClient)
 	return b.applyStorageUpdatesFunc(ctx, storageUpdatesIterator)
 }
 
@@ -368,18 +368,18 @@ func (b *JobBuilder) cleanupManifest(ctx context.Context, manifest *manifest, ma
 
 	// delete the manifest file first so that even if we fail to remove other objects,
 	// the current manifest won't get processed again and should get cleaned up in the routine cleanup operation.
-	if err := b.deletionStoreClient.DeleteObject(ctx, path.Join(manifestPath, manifestFileName)); err != nil {
+	if err := b.deletionManifestStoreClient.DeleteObject(ctx, path.Join(manifestPath, manifestFileName)); err != nil {
 		return err
 	}
 
-	objects, _, err := b.deletionStoreClient.List(ctx, manifestPath, "/")
+	objects, _, err := b.deletionManifestStoreClient.List(ctx, manifestPath, "/")
 	if err != nil {
 		return err
 	}
 
 	// delete all the remaining objects
 	for _, object := range objects {
-		if err := b.deletionStoreClient.DeleteObject(ctx, object.Key); err != nil {
+		if err := b.deletionManifestStoreClient.DeleteObject(ctx, object.Key); err != nil {
 			level.Error(util_log.Logger).Log("msg", "failed to delete object", "object", object.Key)
 		}
 	}
@@ -388,7 +388,7 @@ func (b *JobBuilder) cleanupManifest(ctx context.Context, manifest *manifest, ma
 }
 
 func (b *JobBuilder) getSegment(ctx context.Context, segmentPath string) (*segment, error) {
-	reader, _, err := b.deletionStoreClient.GetObject(ctx, segmentPath)
+	reader, _, err := b.deletionManifestStoreClient.GetObject(ctx, segmentPath)
 	if err != nil {
 		return nil, err
 	}
@@ -449,23 +449,23 @@ func (i *storageUpdatesCollection) encode() ([]byte, error) {
 
 // storageUpdatesIterator helps with iterating through all the storage updates files built while processing of each segment in a manifest
 type storageUpdatesIterator struct {
-	ctx               context.Context
-	manifestPath      string
-	manifest          *manifest
-	deleteStoreClient client.ObjectClient
+	ctx                         context.Context
+	manifestPath                string
+	manifest                    *manifest
+	deletionManifestStoreClient client.ObjectClient
 
 	currSegmentNum        int
 	currUpdatesCollection *storageUpdatesCollection
 	err                   error
 }
 
-func newStorageUpdatesIterator(ctx context.Context, manifestPath string, manifest *manifest, deleteStoreClient client.ObjectClient) *storageUpdatesIterator {
+func newStorageUpdatesIterator(ctx context.Context, manifestPath string, manifest *manifest, deletionManifestStoreClient client.ObjectClient) *storageUpdatesIterator {
 	return &storageUpdatesIterator{
-		ctx:               ctx,
-		manifestPath:      manifestPath,
-		manifest:          manifest,
-		deleteStoreClient: deleteStoreClient,
-		currSegmentNum:    -1,
+		ctx:                         ctx,
+		manifestPath:                manifestPath,
+		manifest:                    manifest,
+		deletionManifestStoreClient: deletionManifestStoreClient,
+		currSegmentNum:              -1,
 	}
 }
 
@@ -505,7 +505,7 @@ func (i *storageUpdatesIterator) TableName() string {
 }
 
 func (i *storageUpdatesIterator) getStorageUpdates(filepath string) (*storageUpdatesCollection, error) {
-	reader, _, err := i.deleteStoreClient.GetObject(i.ctx, filepath)
+	reader, _, err := i.deletionManifestStoreClient.GetObject(i.ctx, filepath)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/compactor/deletion/job_builder.go
+++ b/pkg/compactor/deletion/job_builder.go
@@ -9,7 +9,6 @@ import (
 	"strconv"
 	"sync"
 	"time"
-	"unsafe"
 
 	"github.com/go-kit/log/level"
 	"github.com/pkg/errors"
@@ -536,7 +535,11 @@ func (i *storageUpdatesIterator) Err() error {
 // It passes the labels for the series and updates to apply to the storage.
 func (i *storageUpdatesIterator) ForEachSeries(callback func(labels string, chunksToDelete []string, chunksToDeIndex []string, chunksToIndex []Chunk) error) error {
 	for labels, updates := range i.currUpdatesCollection.StorageUpdates {
-		if err := callback(labels, updates.ChunksToDelete, updates.ChunksToDeIndex, *(*[]Chunk)(unsafe.Pointer(&updates.ChunksToIndex))); err != nil {
+		chunksToIndex := make([]Chunk, 0, len(updates.ChunksToIndex))
+		for i := range updates.ChunksToIndex {
+			chunksToIndex = append(chunksToIndex, updates.ChunksToIndex[i])
+		}
+		if err := callback(labels, updates.ChunksToDelete, updates.ChunksToDeIndex, chunksToIndex); err != nil {
 			return err
 		}
 	}

--- a/pkg/compactor/deletion/job_runner.go
+++ b/pkg/compactor/deletion/job_runner.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/prometheus/client_golang/prometheus"
 	"math"
 	"sync"
 	"time"
@@ -12,6 +11,7 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/concurrency"
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 
@@ -25,7 +25,7 @@ import (
 	util_log "github.com/grafana/loki/v3/pkg/util/log"
 )
 
-type GetChunkClientForTableFunc func(ctx context.Context, table string) (client.Client, error)
+type GetChunkClientForTableFunc func(table string) (client.Client, error)
 
 type Chunk interface {
 	GetFrom() model.Time
@@ -89,7 +89,7 @@ func (jr *JobRunner) Run(ctx context.Context, job *grpc.Job) ([]byte, error) {
 		return nil, err
 	}
 
-	chunkClient, err := jr.getChunkClientForTableFunc(ctx, deletionJob.TableName)
+	chunkClient, err := jr.getChunkClientForTableFunc(deletionJob.TableName)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/compactor/deletion/job_runner.go
+++ b/pkg/compactor/deletion/job_runner.go
@@ -5,9 +5,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"sync"
 	"time"
 
 	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/concurrency"
 	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
@@ -25,6 +27,7 @@ import (
 type GetChunkClientForTableFunc func(ctx context.Context, table string) (client.Client, error)
 
 type JobRunner struct {
+	chunkProcessingConcurrency int
 	getChunkClientForTableFunc GetChunkClientForTableFunc
 }
 
@@ -68,8 +71,9 @@ func (c chunk) GetEntriesCount() uint32 {
 	return c.Entries
 }
 
-func NewJobRunner(getStorageClientForTableFunc GetChunkClientForTableFunc) *JobRunner {
+func NewJobRunner(chunkProcessingConcurrency int, getStorageClientForTableFunc GetChunkClientForTableFunc) *JobRunner {
 	return &JobRunner{
+		chunkProcessingConcurrency: chunkProcessingConcurrency,
 		getChunkClientForTableFunc: getStorageClientForTableFunc,
 	}
 }
@@ -103,21 +107,22 @@ func (jr *JobRunner) Run(ctx context.Context, job *grpc.Job) ([]byte, error) {
 	var filterFuncs []filter.Func
 
 	tableInterval := retention.ExtractIntervalFromTableName(deletionJob.TableName)
-	// ToDo(Sandeep): Make chunk processing concurrent with a reasonable concurrency.
-	for _, chunkID := range deletionJob.ChunkIDs {
+	updatesMtx := sync.Mutex{}
+	err = concurrency.ForEachJob(ctx, len(deletionJob.ChunkIDs), jr.chunkProcessingConcurrency, func(ctx context.Context, idx int) error {
+		chunkID := deletionJob.ChunkIDs[idx]
 		chk, err := storage_chunk.ParseExternalKey(deletionJob.UserID, chunkID)
 		if err != nil {
-			return nil, err
+			return err
 		}
 
 		// get the chunk from storage
 		chks, err := chunkClient.GetChunks(ctx, []storage_chunk.Chunk{chk})
 		if err != nil {
-			return nil, err
+			return err
 		}
 
 		if len(chks) != 1 {
-			return nil, fmt.Errorf("expected 1 entry for chunk %s but found %d in storage", chunkID, len(chks))
+			return fmt.Errorf("expected 1 entry for chunk %s but found %d in storage", chunkID, len(chks))
 		}
 
 		// Build a chain of filters to apply on the chunk to remove data requested for deletion.
@@ -129,7 +134,7 @@ func (jr *JobRunner) Run(ctx context.Context, job *grpc.Job) ([]byte, error) {
 			for _, req := range deletionJob.DeleteRequests {
 				filterFunc, err := req.FilterFunction(chks[0].Metric)
 				if err != nil {
-					return nil, err
+					return err
 				}
 
 				filterFuncs = append(filterFuncs, filterFunc)
@@ -151,20 +156,22 @@ func (jr *JobRunner) Run(ctx context.Context, job *grpc.Job) ([]byte, error) {
 		if err != nil {
 			if errors.Is(err, storage_chunk.ErrSliceNoDataInRange) {
 				level.Info(util_log.Logger).Log("msg", "Delete request filterFunc leaves an empty chunk", "chunk ref", chunkID)
+				updatesMtx.Lock()
+				defer updatesMtx.Unlock()
 				updates.ChunksToDelete = append(updates.ChunksToDelete, chunkID)
-				continue
+				return nil
 			}
-			return nil, err
+			return err
 		}
 
 		// if no lines were deleted then there is nothing to do
 		if !linesDeleted {
-			continue
+			return nil
 		}
 
 		facade, ok := newChunkData.(*chunkenc.Facade)
 		if !ok {
-			return nil, errors.New("invalid chunk type")
+			return errors.New("invalid chunk type")
 		}
 
 		newChunkStart, newChunkEnd := util.RoundToMilliseconds(facade.Bounds())
@@ -172,8 +179,10 @@ func (jr *JobRunner) Run(ctx context.Context, job *grpc.Job) ([]byte, error) {
 		// the new chunk is out of range for the table in process, so don't upload and index it
 		if newChunkStart > tableInterval.End || newChunkEnd < tableInterval.Start {
 			// only remove the index entry from the current table since the new chunk is out of its range
+			updatesMtx.Lock()
+			defer updatesMtx.Unlock()
 			updates.ChunksToDeIndex = append(updates.ChunksToDeIndex, chunkID)
-			continue
+			return nil
 		}
 
 		// upload the new chunk to object storage
@@ -186,15 +195,17 @@ func (jr *JobRunner) Run(ctx context.Context, job *grpc.Job) ([]byte, error) {
 
 		err = newChunk.Encode()
 		if err != nil {
-			return nil, err
+			return err
 		}
 
 		err = chunkClient.PutChunks(ctx, []storage_chunk.Chunk{newChunk})
 		if err != nil {
-			return nil, err
+			return err
 		}
 
 		// add the new chunk details to the list of chunks to index
+		updatesMtx.Lock()
+		defer updatesMtx.Unlock()
 		updates.ChunksToIndex = append(updates.ChunksToIndex, chunk{
 			From:        newChunk.From,
 			Through:     newChunk.Through,
@@ -206,6 +217,10 @@ func (jr *JobRunner) Run(ctx context.Context, job *grpc.Job) ([]byte, error) {
 
 		// Add the ID of original chunk to the list of ChunksToDelete
 		updates.ChunksToDelete = append(updates.ChunksToDelete, chunkID)
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	jobResultJSON, err := json.Marshal(updates)

--- a/pkg/compactor/deletion/job_runner_test.go
+++ b/pkg/compactor/deletion/job_runner_test.go
@@ -276,7 +276,7 @@ func TestJobRunner_Run(t *testing.T) {
 			}
 
 			// Create job runner
-			runner := NewJobRunner(1, func(_ context.Context, _ string) (client.Client, error) {
+			runner := NewJobRunner(1, func(_ string) (client.Client, error) {
 				return mockClient, nil
 			}, nil)
 
@@ -425,7 +425,7 @@ func TestJobRunner_Run_ConcurrentChunkProcessing(t *testing.T) {
 	}
 
 	// Create job runner with chunk processing concurrency of 2
-	runner := NewJobRunner(2, func(_ context.Context, _ string) (client.Client, error) {
+	runner := NewJobRunner(2, func(_ string) (client.Client, error) {
 		return mockClient, nil
 	}, nil)
 

--- a/pkg/compactor/deletion/job_runner_test.go
+++ b/pkg/compactor/deletion/job_runner_test.go
@@ -275,7 +275,7 @@ func TestJobRunner_Run(t *testing.T) {
 			}
 
 			// Create job runner
-			runner := NewJobRunner(func(_ context.Context, _ string) (client.Client, error) {
+			runner := NewJobRunner(1, func(_ context.Context, _ string) (client.Client, error) {
 				return mockClient, nil
 			})
 
@@ -318,6 +318,144 @@ func TestJobRunner_Run(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestJobRunner_Run_ConcurrentChunkProcessing(t *testing.T) {
+	now := model.Now()
+	userID := "test-user"
+	yesterdaysTableNumber := (now.Unix() / 86400) - 1
+	tableName := fmt.Sprintf("table_%d", yesterdaysTableNumber)
+	yesterdaysTableInterval := retention.ExtractIntervalFromTableName(tableName)
+
+	// Create test labels
+	lblFoo, err := syntax.ParseLabels(`{foo="bar"}`)
+	require.NoError(t, err)
+
+	var chks []storage_chunk.Chunk
+
+	for i := 0; i < 24; i++ {
+		chkStart := yesterdaysTableInterval.Start.Add(time.Duration(i) * time.Hour)
+		chkEnd := chkStart.Add(time.Hour)
+		chk := createTestChunk(t, userID, lblFoo, chkStart, chkEnd, "test data", toLabelsAdapter(labels.FromStrings("foo", "bar")), time.Minute)
+		chks = append(chks, chk)
+	}
+
+	overlappingChunk := createTestChunk(t, userID, lblFoo, yesterdaysTableInterval.End.Add(-30*time.Minute), yesterdaysTableInterval.End.Add(30*time.Minute), "test data overlapping multiple tables", toLabelsAdapter(labels.FromStrings("foo", "bar")), time.Minute)
+	chks = append(chks, overlappingChunk)
+
+	chunksMap := map[string]storage_chunk.Chunk{}
+	var chunkIDs []string
+	for _, chk := range chks {
+		chunkID := chunkKey(chk)
+		chunksMap[chunkID] = chk
+		chunkIDs = append(chunkIDs, chunkID)
+	}
+
+	// Setup mock chunk client
+	mockClient := &mockChunkClient{
+		chunks: chunksMap,
+	}
+
+	deleteRequests := []DeleteRequest{
+		{
+			// partially delete the first chunk
+			RequestID: "test-request-0",
+			Query:     lblFoo.String() + ` |= "test"`,
+			StartTime: yesterdaysTableInterval.Start,
+			EndTime:   yesterdaysTableInterval.Start.Add(30 * time.Minute),
+		},
+		{
+			// Delete 4 complete chunks in the middle.
+			// Since the chunks overlap by a minute, it would also cause deletion of one log line from the adjoining chunk on both ends.
+			RequestID: "test-request-1",
+			Query:     lblFoo.String() + ` |= "test"`,
+			StartTime: yesterdaysTableInterval.Start.Add(6 * time.Hour),
+			EndTime:   yesterdaysTableInterval.Start.Add(10 * time.Hour),
+		},
+		{
+			// Delete the whole part of chunk which overlaps the yesterdays table which would cause chunk to get de-indexed
+			RequestID: "test-request-2",
+			Query:     lblFoo.String() + ` |= "overlapping"`,
+			StartTime: yesterdaysTableInterval.End.Add(-30 * time.Minute),
+			EndTime:   yesterdaysTableInterval.End,
+		},
+	}
+
+	expectedStorageUpdates := &storageUpdates{
+		ChunksToDelete: []string{
+			chunkKey(chks[0]), // first partially deleted chunk to get removed by test-request-0
+			chunkKey(chks[5]), // adjoining chunk to a bunch of chunks selected for deletion by test-request-1\
+
+			chunkKey(chks[6]), ///////////////////////////////////////////////////////
+			chunkKey(chks[7]), //   chunks selected for deletion by test-request-1	//
+			chunkKey(chks[8]), //													//
+			chunkKey(chks[9]), ///////////////////////////////////////////////////////
+
+			chunkKey(chks[10]), // adjoining chunk to a bunch of chunks selected for deletion by test-request-1
+		},
+		ChunksToIndex: []chunk{
+			{
+				// chunk recreated by test-request-0
+				From:        yesterdaysTableInterval.Start.Add(31 * time.Minute),
+				Through:     yesterdaysTableInterval.Start.Add(time.Hour),
+				Fingerprint: lblFoo.Hash(),
+			},
+			{
+				// chunk recreated by test-request-1, removing just last line
+				From:        chks[5].From,
+				Through:     chks[5].Through.Add(-time.Minute),
+				Fingerprint: lblFoo.Hash(),
+			},
+			{
+				// chunk recreated by test-request-1, removing just first line
+				From:        chks[10].From.Add(time.Minute),
+				Through:     chks[10].Through,
+				Fingerprint: lblFoo.Hash(),
+			},
+		},
+		ChunksToDeIndex: []string{
+			chunkKey(overlappingChunk), // chunk de-indexed by test-request-2
+		},
+	}
+
+	// Ensure Metrics is set for each DeleteRequest
+	for i := range deleteRequests {
+		deleteRequests[i].Metrics = newDeleteRequestsManagerMetrics(nil)
+	}
+
+	// Create job runner with chunk processing concurrency of 2
+	runner := NewJobRunner(2, func(_ context.Context, _ string) (client.Client, error) {
+		return mockClient, nil
+	})
+
+	// Create the job
+	job := grpc.Job{
+		Id: "test-job",
+		Payload: mustMarshal(t, deletionJob{
+			UserID:         userID,
+			TableName:      tableName,
+			ChunkIDs:       chunkIDs,
+			DeleteRequests: deleteRequests,
+		}),
+	}
+
+	// Run the job
+	resultJSON, err := runner.Run(context.Background(), &job)
+	require.NoError(t, err)
+
+	require.NoError(t, err)
+	result := &storageUpdates{}
+	require.NoError(t, json.Unmarshal(resultJSON, result))
+
+	// verify we got the expected storage updates
+	require.Equal(t, len(expectedStorageUpdates.ChunksToIndex), len(result.ChunksToIndex))
+	for i := range expectedStorageUpdates.ChunksToIndex {
+		require.Equal(t, expectedStorageUpdates.ChunksToIndex[i].From, result.ChunksToIndex[i].From)
+		require.Equal(t, expectedStorageUpdates.ChunksToIndex[i].Through, result.ChunksToIndex[i].Through)
+		require.Equal(t, expectedStorageUpdates.ChunksToIndex[i].Fingerprint, result.ChunksToIndex[i].Fingerprint)
+	}
+	require.Equal(t, expectedStorageUpdates.ChunksToDelete, result.ChunksToDelete)
+	require.Equal(t, expectedStorageUpdates.ChunksToDeIndex, result.ChunksToDeIndex)
 }
 
 func mustMarshal(t *testing.T, v interface{}) []byte {

--- a/pkg/compactor/deletion/job_runner_test.go
+++ b/pkg/compactor/deletion/job_runner_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"testing"
 	"time"
 
@@ -449,11 +450,30 @@ func TestJobRunner_Run_ConcurrentChunkProcessing(t *testing.T) {
 
 	// verify we got the expected storage updates
 	require.Equal(t, len(expectedStorageUpdates.ChunksToIndex), len(result.ChunksToIndex))
+
+	slices.SortFunc(result.ChunksToIndex, func(a, b chunk) int {
+		if a.From < b.From {
+			return -1
+		} else if a.From > b.From {
+			return 1
+		}
+
+		return 0
+	})
 	for i := range expectedStorageUpdates.ChunksToIndex {
 		require.Equal(t, expectedStorageUpdates.ChunksToIndex[i].From, result.ChunksToIndex[i].From)
 		require.Equal(t, expectedStorageUpdates.ChunksToIndex[i].Through, result.ChunksToIndex[i].Through)
 		require.Equal(t, expectedStorageUpdates.ChunksToIndex[i].Fingerprint, result.ChunksToIndex[i].Fingerprint)
 	}
+	slices.SortFunc(result.ChunksToDelete, func(a, b string) int {
+		if a < b {
+			return -1
+		} else if a > b {
+			return 1
+		}
+
+		return 0
+	})
 	require.Equal(t, expectedStorageUpdates.ChunksToDelete, result.ChunksToDelete)
 	require.Equal(t, expectedStorageUpdates.ChunksToDeIndex, result.ChunksToDeIndex)
 }

--- a/pkg/compactor/deletion/job_runner_test.go
+++ b/pkg/compactor/deletion/job_runner_test.go
@@ -278,7 +278,7 @@ func TestJobRunner_Run(t *testing.T) {
 			// Create job runner
 			runner := NewJobRunner(1, func(_ context.Context, _ string) (client.Client, error) {
 				return mockClient, nil
-			})
+			}, nil)
 
 			// Create job
 			job := grpc.Job{
@@ -427,7 +427,7 @@ func TestJobRunner_Run_ConcurrentChunkProcessing(t *testing.T) {
 	// Create job runner with chunk processing concurrency of 2
 	runner := NewJobRunner(2, func(_ context.Context, _ string) (client.Client, error) {
 		return mockClient, nil
-	})
+	}, nil)
 
 	// Create the job
 	job := grpc.Job{

--- a/pkg/compactor/deletion/metrics.go
+++ b/pkg/compactor/deletion/metrics.go
@@ -59,6 +59,9 @@ type deleteRequestsManagerMetrics struct {
 	oldestPendingDeleteRequestAgeSeconds prometheus.Gauge
 	pendingDeleteRequestsCount           prometheus.Gauge
 	deletedLinesTotal                    *prometheus.CounterVec
+
+	manifestBuildAttemptsTotal *prometheus.CounterVec
+	chunksSelectedTotal        prometheus.Counter
 }
 
 func newDeleteRequestsManagerMetrics(r prometheus.Registerer) *deleteRequestsManagerMetrics {
@@ -99,6 +102,33 @@ func newDeleteRequestsManagerMetrics(r prometheus.Registerer) *deleteRequestsMan
 		Name:      "compactor_deleted_lines",
 		Help:      "Number of deleted lines per user",
 	}, []string{"user"})
+
+	m.manifestBuildAttemptsTotal = promauto.With(r).NewCounterVec(prometheus.CounterOpts{
+		Namespace: constants.Loki,
+		Name:      "compactor_manifest_build_attempts_total",
+		Help:      "Number of attempts made to build manifest with their outcome",
+	}, []string{"status"})
+	m.chunksSelectedTotal = promauto.With(r).NewCounter(prometheus.CounterOpts{
+		Namespace: constants.Loki,
+		Name:      "compactor_manifest_chunks_selected_total",
+		Help:      "Number of chunks selected while building manifest",
+	})
+
+	return &m
+}
+
+type deletionJobRunnerMetrics struct {
+	chunksProcessedTotal prometheus.Counter
+}
+
+func newDeletionJobRunnerMetrics(r prometheus.Registerer) *deletionJobRunnerMetrics {
+	m := deletionJobRunnerMetrics{}
+
+	m.chunksProcessedTotal = promauto.With(r).NewCounter(prometheus.CounterOpts{
+		Namespace: constants.Loki,
+		Name:      "compactor_deletion_job_runner_chunks_processed_total",
+		Help:      "Number of chunks processed",
+	})
 
 	return &m
 }

--- a/pkg/compactor/jobqueue/metrics.go
+++ b/pkg/compactor/jobqueue/metrics.go
@@ -1,0 +1,59 @@
+package jobqueue
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	"github.com/grafana/loki/v3/pkg/util/constants"
+)
+
+type queueMetrics struct {
+	jobsSent      prometheus.Counter
+	jobsDeQueued  prometheus.Counter
+	jobsProcessed prometheus.Counter
+	jobRetries    *prometheus.CounterVec
+	jobsDropped   prometheus.Counter
+}
+
+func newQueueMetrics(r prometheus.Registerer) *queueMetrics {
+	m := queueMetrics{}
+
+	m.jobsSent = promauto.With(r).NewCounter(prometheus.CounterOpts{
+		Namespace: constants.Loki,
+		Name:      "compactor_jobs_queued_total",
+		Help:      "Number of jobs sent to the worker for processing",
+	})
+	m.jobsProcessed = promauto.With(r).NewCounter(prometheus.CounterOpts{
+		Namespace: constants.Loki,
+		Name:      "compactor_jobs_processed_total",
+		Help:      "Total number of jobs successfully processed",
+	})
+	m.jobRetries = promauto.With(r).NewCounterVec(prometheus.CounterOpts{
+		Namespace: constants.Loki,
+		Name:      "compactor_job_retries_total",
+		Help:      "Total number of job retries due to various reasons",
+	}, []string{"reason"})
+	m.jobsDropped = promauto.With(r).NewCounter(prometheus.CounterOpts{
+		Namespace: constants.Loki,
+		Name:      "compactor_jobs_dropped_total",
+		Help:      "Total number of jobs dropped after running out of retry attempts",
+	})
+
+	return &m
+}
+
+type workerMetrics struct {
+	jobsProcessed *prometheus.CounterVec
+}
+
+func newWorkerMetrics(r prometheus.Registerer) *workerMetrics {
+	m := workerMetrics{}
+
+	m.jobsProcessed = promauto.With(r).NewCounterVec(prometheus.CounterOpts{
+		Namespace: constants.Loki,
+		Name:      "compactor_worker_job_processed_attempts",
+		Help:      "Number of jobs processed by worker with their processing status",
+	}, []string{"status"})
+
+	return &m
+}

--- a/pkg/compactor/jobqueue/metrics.go
+++ b/pkg/compactor/jobqueue/metrics.go
@@ -8,11 +8,12 @@ import (
 )
 
 type queueMetrics struct {
-	jobsSent      prometheus.Counter
-	jobsDeQueued  prometheus.Counter
-	jobsProcessed prometheus.Counter
-	jobRetries    *prometheus.CounterVec
-	jobsDropped   prometheus.Counter
+	jobsSent               prometheus.Counter
+	jobsDeQueued           prometheus.Counter
+	jobsProcessed          prometheus.Counter
+	jobRetries             *prometheus.CounterVec
+	jobsDropped            prometheus.Counter
+	jobsProcessingDuration prometheus.Histogram
 }
 
 func newQueueMetrics(r prometheus.Registerer) *queueMetrics {
@@ -38,15 +39,21 @@ func newQueueMetrics(r prometheus.Registerer) *queueMetrics {
 		Name:      "compactor_jobs_dropped_total",
 		Help:      "Total number of jobs dropped after running out of retry attempts",
 	})
+	m.jobsProcessingDuration = promauto.With(r).NewHistogram(prometheus.HistogramOpts{
+		Namespace: constants.Loki,
+		Name:      "compactor_jobs_processing_duration_seconds",
+		Help:      "Duration of job processing in seconds",
+	})
 
 	return &m
 }
 
 type workerMetrics struct {
-	jobsProcessed *prometheus.CounterVec
+	jobsProcessed              *prometheus.CounterVec
+	workerConnectedToCompactor prometheus.GaugeFunc
 }
 
-func newWorkerMetrics(r prometheus.Registerer) *workerMetrics {
+func newWorkerMetrics(r prometheus.Registerer, allWorkersConnectedToCompactor func() bool) *workerMetrics {
 	m := workerMetrics{}
 
 	m.jobsProcessed = promauto.With(r).NewCounterVec(prometheus.CounterOpts{
@@ -54,6 +61,16 @@ func newWorkerMetrics(r prometheus.Registerer) *workerMetrics {
 		Name:      "compactor_worker_job_processed_attempts",
 		Help:      "Number of jobs processed by worker with their processing status",
 	}, []string{"status"})
+	m.workerConnectedToCompactor = promauto.With(r).NewGaugeFunc(prometheus.GaugeOpts{
+		Namespace: constants.Loki,
+		Name:      "compactor_worker_connected_to_compactor",
+		Help:      "Tracks whether all compactor workers are connected to the compactor",
+	}, func() float64 {
+		if allWorkersConnectedToCompactor() {
+			return 1
+		}
+		return 0
+	})
 
 	return &m
 }

--- a/pkg/compactor/jobqueue/queue.go
+++ b/pkg/compactor/jobqueue/queue.go
@@ -3,11 +3,11 @@ package jobqueue
 import (
 	"context"
 	"errors"
-	"github.com/prometheus/client_golang/prometheus"
 	"sync"
 	"time"
 
 	"github.com/go-kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 

--- a/pkg/compactor/jobqueue/queue_test.go
+++ b/pkg/compactor/jobqueue/queue_test.go
@@ -83,7 +83,7 @@ func setupGRPC(t *testing.T, q *Queue) (*grpc.ClientConn, func()) {
 }
 
 func TestQueue_RegisterBuilder(t *testing.T) {
-	q := NewQueue()
+	q := NewQueue(nil)
 	builder := &mockBuilder{}
 
 	// Register builder successfully
@@ -96,7 +96,7 @@ func TestQueue_RegisterBuilder(t *testing.T) {
 }
 
 func TestQueue_Loop(t *testing.T) {
-	q := NewQueue()
+	q := NewQueue(nil)
 
 	conn, closer := setupGRPC(t, q)
 	defer closer()
@@ -184,7 +184,7 @@ func TestQueue_Loop(t *testing.T) {
 }
 
 func TestQueue_ReportJobResult(t *testing.T) {
-	q := newQueue(time.Second)
+	q := newQueue(time.Second, nil)
 	require.NoError(t, q.RegisterBuilder(compactor_grpc.JOB_TYPE_DELETION, &mockBuilder{}, jobTimeout, jobRetries))
 
 	// Create a test job
@@ -249,7 +249,7 @@ func TestQueue_ReportJobResult(t *testing.T) {
 }
 
 func TestQueue_JobTimeout(t *testing.T) {
-	q := newQueue(50 * time.Millisecond)
+	q := newQueue(50*time.Millisecond, nil)
 	// Short job timeout for testing
 	require.NoError(t, q.RegisterBuilder(compactor_grpc.JOB_TYPE_DELETION, &mockBuilder{}, 100*time.Millisecond, jobRetries))
 
@@ -288,7 +288,7 @@ func TestQueue_JobTimeout(t *testing.T) {
 }
 
 func TestQueue_Close(t *testing.T) {
-	q := NewQueue()
+	q := NewQueue(nil)
 
 	require.NoError(t, q.RegisterBuilder(compactor_grpc.JOB_TYPE_DELETION, &mockBuilder{}, jobTimeout, jobRetries))
 

--- a/pkg/compactor/jobqueue/queue_test.go
+++ b/pkg/compactor/jobqueue/queue_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"sync"
 	"testing"
 	"time"
 
@@ -14,6 +15,11 @@ import (
 	"google.golang.org/grpc/test/bufconn"
 
 	compactor_grpc "github.com/grafana/loki/v3/pkg/compactor/client/grpc"
+)
+
+const (
+	jobTimeout = 5 * time.Minute
+	jobRetries = 3
 )
 
 // mockBuilder implements the Builder interface for testing
@@ -81,11 +87,11 @@ func TestQueue_RegisterBuilder(t *testing.T) {
 	builder := &mockBuilder{}
 
 	// Register builder successfully
-	err := q.RegisterBuilder(compactor_grpc.JOB_TYPE_DELETION, builder)
+	err := q.RegisterBuilder(compactor_grpc.JOB_TYPE_DELETION, builder, jobTimeout, jobRetries)
 	require.NoError(t, err)
 
 	// Try to register same builder type again
-	err = q.RegisterBuilder(compactor_grpc.JOB_TYPE_DELETION, builder)
+	err = q.RegisterBuilder(compactor_grpc.JOB_TYPE_DELETION, builder, jobTimeout, jobRetries)
 	require.ErrorIs(t, err, ErrJobTypeAlreadyRegistered)
 }
 
@@ -108,8 +114,8 @@ func TestQueue_Loop(t *testing.T) {
 		jobsToBuild: jobs,
 	}
 
-	require.NoError(t, q.RegisterBuilder(compactor_grpc.JOB_TYPE_DELETION, builder))
-	require.NoError(t, q.Start(context.Background()))
+	require.NoError(t, q.RegisterBuilder(compactor_grpc.JOB_TYPE_DELETION, builder, jobTimeout, jobRetries))
+	go q.Start(context.Background())
 
 	// Dequeue the job
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
@@ -127,7 +133,7 @@ func TestQueue_Loop(t *testing.T) {
 	q.processingJobsMtx.RLock()
 	require.Equal(t, 1, len(q.processingJobs))
 	require.Equal(t, jobs[0], q.processingJobs[jobs[0].Id].job)
-	require.Equal(t, 2, q.processingJobs[jobs[0].Id].attemptsLeft)
+	require.Equal(t, 3, q.processingJobs[jobs[0].Id].attemptsLeft)
 	q.processingJobsMtx.RUnlock()
 
 	// another Recv call on client1Stream without calling the Send call should get blocked
@@ -152,9 +158,9 @@ func TestQueue_Loop(t *testing.T) {
 	q.processingJobsMtx.RLock()
 	require.Equal(t, 2, len(q.processingJobs))
 	require.Equal(t, jobs[0], q.processingJobs[jobs[0].Id].job)
-	require.Equal(t, 2, q.processingJobs[jobs[0].Id].attemptsLeft)
+	require.Equal(t, 3, q.processingJobs[jobs[0].Id].attemptsLeft)
 	require.Equal(t, jobs[1], q.processingJobs[jobs[1].Id].job)
-	require.Equal(t, 2, q.processingJobs[jobs[1].Id].attemptsLeft)
+	require.Equal(t, 3, q.processingJobs[jobs[1].Id].attemptsLeft)
 	q.processingJobsMtx.RUnlock()
 
 	// sending a response on client1Stream should get it unblocked to Recv the next job
@@ -171,15 +177,15 @@ func TestQueue_Loop(t *testing.T) {
 	q.processingJobsMtx.RLock()
 	require.Equal(t, 2, len(q.processingJobs))
 	require.Equal(t, jobs[1], q.processingJobs[jobs[1].Id].job)
-	require.Equal(t, 2, q.processingJobs[jobs[1].Id].attemptsLeft)
+	require.Equal(t, 3, q.processingJobs[jobs[1].Id].attemptsLeft)
 	require.Equal(t, jobs[2], q.processingJobs[jobs[2].Id].job)
-	require.Equal(t, 2, q.processingJobs[jobs[2].Id].attemptsLeft)
+	require.Equal(t, 3, q.processingJobs[jobs[2].Id].attemptsLeft)
 	q.processingJobsMtx.RUnlock()
 }
 
 func TestQueue_ReportJobResult(t *testing.T) {
 	q := newQueue(time.Second)
-	require.NoError(t, q.RegisterBuilder(compactor_grpc.JOB_TYPE_DELETION, &mockBuilder{}))
+	require.NoError(t, q.RegisterBuilder(compactor_grpc.JOB_TYPE_DELETION, &mockBuilder{}, jobTimeout, jobRetries))
 
 	// Create a test job
 	job := &compactor_grpc.Job{
@@ -244,7 +250,8 @@ func TestQueue_ReportJobResult(t *testing.T) {
 
 func TestQueue_JobTimeout(t *testing.T) {
 	q := newQueue(50 * time.Millisecond)
-	q.jobTimeout = 100 * time.Millisecond // Short timeout for testing
+	// Short job timeout for testing
+	require.NoError(t, q.RegisterBuilder(compactor_grpc.JOB_TYPE_DELETION, &mockBuilder{}, 100*time.Millisecond, jobRetries))
 
 	// Create a test job
 	job := &compactor_grpc.Job{
@@ -283,13 +290,23 @@ func TestQueue_JobTimeout(t *testing.T) {
 func TestQueue_Close(t *testing.T) {
 	q := NewQueue()
 
-	// Close the queue
-	q.Close()
+	require.NoError(t, q.RegisterBuilder(compactor_grpc.JOB_TYPE_DELETION, &mockBuilder{}, jobTimeout, jobRetries))
 
-	// Verify queue is closed
-	require.True(t, q.closed.Load())
+	wg := sync.WaitGroup{}
+	ctx, cancel := context.WithCancel(context.Background())
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		q.Start(ctx)
+	}()
 
-	// Verify channel is closed
+	// cancel the context to stop all the builders and close the queue
+	cancel()
+
+	// wait for everything to stop before we check for closed channel
+	wg.Wait()
+
+	// Verify queue channel is closed
 	select {
 	case _, ok := <-q.queue:
 		require.False(t, ok)

--- a/pkg/compactor/jobqueue/worker.go
+++ b/pkg/compactor/jobqueue/worker.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"github.com/prometheus/client_golang/prometheus"
 	"sync"
 	"time"
 
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/backoff"
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/grafana/loki/v3/pkg/compactor/client/grpc"
 	util_log "github.com/grafana/loki/v3/pkg/util/log"

--- a/pkg/compactor/jobqueue/worker.go
+++ b/pkg/compactor/jobqueue/worker.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"go.uber.org/atomic"
 	"sync"
 	"time"
 
@@ -12,6 +11,7 @@ import (
 	"github.com/grafana/dskit/backoff"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
+	"go.uber.org/atomic"
 
 	"github.com/grafana/loki/v3/pkg/compactor/client/grpc"
 	util_log "github.com/grafana/loki/v3/pkg/util/log"

--- a/pkg/compactor/jobqueue/worker_test.go
+++ b/pkg/compactor/jobqueue/worker_test.go
@@ -136,7 +136,9 @@ func TestWorker_ProcessJob(t *testing.T) {
 
 	go newWorker(mockCompactorClient{conn: conn}, map[compactor_grpc.JobType]JobRunner{
 		compactor_grpc.JOB_TYPE_DELETION: jobRunner,
-	}, newWorkerMetrics(nil)).Start(ctx)
+	}, newWorkerMetrics(nil, func() bool {
+		return true
+	})).Start(ctx)
 
 	// verify that the job builder got to send all 3 jobs and that both the valid jobs got processed
 	require.Eventually(t, func() bool {
@@ -169,7 +171,9 @@ func TestWorker_StreamClosure(t *testing.T) {
 	// build a worker
 	worker := newWorker(mockCompactorClient{conn: conn}, map[compactor_grpc.JobType]JobRunner{
 		compactor_grpc.JOB_TYPE_DELETION: &mockJobRunner{},
-	}, newWorkerMetrics(nil))
+	}, newWorkerMetrics(nil, func() bool {
+		return true
+	}))
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/pkg/compactor/worker.go
+++ b/pkg/compactor/worker.go
@@ -1,0 +1,57 @@
+package compactor
+
+import (
+	"context"
+
+	"github.com/grafana/dskit/services"
+
+	"github.com/grafana/loki/v3/pkg/compactor/client/grpc"
+	"github.com/grafana/loki/v3/pkg/compactor/deletion"
+	"github.com/grafana/loki/v3/pkg/compactor/jobqueue"
+	"github.com/grafana/loki/v3/pkg/storage/chunk/client"
+	"github.com/grafana/loki/v3/pkg/storage/chunk/client/local"
+	"github.com/grafana/loki/v3/pkg/storage/config"
+)
+
+func NewWorkerManager(cfg Config, grpcClient jobqueue.CompactorClient, schemaConfig config.SchemaConfig, objectStoreClients map[config.DayTime]client.ObjectClient) (services.Service, error) {
+	wm := jobqueue.NewWorkerManager(cfg.WorkerConfig, grpcClient)
+
+	if cfg.RetentionEnabled {
+		deletionJobRunner := initDeletionJobRunner(cfg.JobsConfig.Deletion.ChunkProcessingConcurrency, schemaConfig, objectStoreClients)
+		err := wm.RegisterJobRunner(grpc.JOB_TYPE_DELETION, deletionJobRunner)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return services.NewBasicService(nil, wm.Start, nil), nil
+}
+
+func initDeletionJobRunner(chunkProcessingConcurrency int, schemaConfig config.SchemaConfig, objectStoreClients map[config.DayTime]client.ObjectClient) jobqueue.JobRunner {
+	chunkClients := make(map[config.DayTime]client.Client, len(objectStoreClients))
+	for from, objectClient := range objectStoreClients {
+		var (
+			raw     client.ObjectClient
+			encoder client.KeyEncoder
+		)
+
+		if casted, ok := objectClient.(client.PrefixedObjectClient); ok {
+			raw = casted.GetDownstream()
+		} else {
+			raw = objectClient
+		}
+		if _, ok := raw.(*local.FSObjectClient); ok {
+			encoder = client.FSEncoder
+		}
+		chunkClients[from] = client.NewClient(objectClient, encoder, schemaConfig)
+	}
+
+	return deletion.NewJobRunner(chunkProcessingConcurrency, func(ctx context.Context, table string) (client.Client, error) {
+		schemaCfg, ok := SchemaPeriodForTable(schemaConfig, table)
+		if !ok {
+			return nil, errSchemaForTableNotFound
+		}
+
+		return chunkClients[schemaCfg.From], nil
+	})
+}

--- a/pkg/compactor/worker.go
+++ b/pkg/compactor/worker.go
@@ -1,10 +1,8 @@
 package compactor
 
 import (
-	"context"
-	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/grafana/dskit/services"
+	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/grafana/loki/v3/pkg/compactor/client/grpc"
 	"github.com/grafana/loki/v3/pkg/compactor/deletion"
@@ -58,7 +56,7 @@ func initDeletionJobRunner(
 		chunkClients[from] = client.NewClient(objectClient, encoder, schemaConfig)
 	}
 
-	return deletion.NewJobRunner(chunkProcessingConcurrency, func(ctx context.Context, table string) (client.Client, error) {
+	return deletion.NewJobRunner(chunkProcessingConcurrency, func(table string) (client.Client, error) {
 		schemaCfg, ok := SchemaPeriodForTable(schemaConfig, table)
 		if !ok {
 			return nil, errSchemaForTableNotFound

--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -474,6 +474,7 @@ func (t *Loki) setupAuthMiddleware() {
 			"/blockbuilder.types.SchedulerService/GetJob",
 			"/blockbuilder.types.SchedulerService/CompleteJob",
 			"/blockbuilder.types.SchedulerService/SyncJob",
+			"/grpc.JobQueue/Loop",
 		})
 }
 

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -1692,7 +1692,7 @@ func (t *Loki) initCompactorWorkerMode() (services.Service, error) {
 		objectClients[periodConfig.From] = objectClient
 	}
 
-	return compactor.NewWorkerManager(t.Cfg.CompactorConfig, compactorClient, t.Cfg.SchemaConfig, objectClients)
+	return compactor.NewWorkerManager(t.Cfg.CompactorConfig, compactorClient, t.Cfg.SchemaConfig, objectClients, prometheus.DefaultRegisterer)
 }
 
 func (t *Loki) initCompactor() (services.Service, error) {

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -1658,7 +1658,48 @@ func (t *Loki) initMemberlistKV() (services.Service, error) {
 	return t.MemberlistKV, nil
 }
 
+func (t *Loki) initCompactorWorkerMode() (services.Service, error) {
+	err := t.Cfg.SchemaConfig.Load()
+	if err != nil {
+		return nil, err
+	}
+
+	if !config.UsingObjectStorageIndex(t.Cfg.SchemaConfig.Configs) {
+		return nil, errors.New("for running the compactor in worker mode, the schema must have a tsdb or boltdb-shipper index type")
+	}
+
+	if t.Cfg.Common.CompactorGRPCAddress == "" {
+		return nil, errors.New("for running compactor in worker mode, compactor_grpc_address must be configured to grpc address of the main compactor")
+	}
+
+	reg := prometheus.WrapRegistererWith(prometheus.Labels{"for": "job_queue", "client_type": "compactor_worker"}, prometheus.DefaultRegisterer)
+	compactorClient, err := compactorclient.NewGRPCClient(t.Cfg.Common.CompactorGRPCAddress, t.Cfg.CompactorGRPCClient, reg)
+	if err != nil {
+		return nil, err
+	}
+
+	objectClients := make(map[config.DayTime]client.ObjectClient)
+	for _, periodConfig := range t.Cfg.SchemaConfig.Configs {
+		if !config.IsObjectStorageIndex(periodConfig.IndexType) {
+			continue
+		}
+
+		objectClient, err := storage.NewObjectClient(periodConfig.ObjectType, "compactor", t.Cfg.StorageConfig, t.ClientMetrics)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create object client: %w", err)
+		}
+
+		objectClients[periodConfig.From] = objectClient
+	}
+
+	return compactor.NewWorkerManager(t.Cfg.CompactorConfig, compactorClient, t.Cfg.SchemaConfig, objectClients)
+}
+
 func (t *Loki) initCompactor() (services.Service, error) {
+	if t.Cfg.CompactorConfig.HorizontalScalingMode == compactor.HorizontalScalingModeWorker {
+		return t.initCompactorWorkerMode()
+	}
+
 	// Set some config sections from other config sections in the config struct
 	t.Cfg.CompactorConfig.CompactorRing.ListenPort = t.Cfg.Server.GRPCListenPort
 
@@ -1728,6 +1769,10 @@ func (t *Loki) initCompactor() (services.Service, error) {
 		t.Server.HTTP.Path("/loki/api/v1/delete").Methods("DELETE").Handler(t.addCompactorMiddleware(t.compactor.DeleteRequestsHandler.CancelDeleteRequestHandler))
 		t.Server.HTTP.Path("/loki/api/v1/cache/generation_numbers").Methods("GET").Handler(t.addCompactorMiddleware(t.compactor.DeleteRequestsHandler.GetCacheGenerationNumberHandler))
 		grpc.RegisterCompactorServer(t.Server.GRPC, t.compactor.DeleteRequestsGRPCHandler)
+	}
+
+	if t.Cfg.CompactorConfig.HorizontalScalingMode == compactor.HorizontalScalingModeMain {
+		grpc.RegisterJobQueueServer(t.Server.GRPC, t.compactor.JobQueue)
 	}
 
 	return t.compactor, nil


### PR DESCRIPTION
**What this PR does / why we need it**:
It includes the following changes:
1. Add relevant configs
2. Wire things up end-to-end
3. Avoid building a new manifest when one already exists. The reason is that we mark delete requests as processed after processing a manifest, so trying to build a new manifest would require us to check if the requests are already included in one of the existing manifests. It is not worth the complexity since we process a single manifest at a time.
4. Clean up any invalid manifests during startup. 
5. Add some logs and metrics for visibility.

**Checklist**
- [X] Tests updated