### PR TITLE
chore: Integrate indexes with the new query engine

### DIFF
--- a/pkg/dataobj/metastore/metastore.go
+++ b/pkg/dataobj/metastore/metastore.go
@@ -18,6 +18,9 @@ type Metastore interface {
 	// StreamsIDs returns object store paths and stream IDs for all matching objects for the given matchers between [start,end]
 	StreamIDs(ctx context.Context, start, end time.Time, matchers ...*labels.Matcher) ([]string, [][]int64, []int, error)
 
+	// StreamIDsBySections returns a list of dataobj sections & their stream IDs for all matching objects for the given matchers between [start,end]
+	StreamIDsBySections(ctx context.Context, start, end time.Time, matchers ...*labels.Matcher) ([]DataobjSectionDescriptor, error)
+
 	// Labels returns all possible labels from matching streams between [start,end]
 	Labels(ctx context.Context, start, end time.Time, matchers ...*labels.Matcher) ([]string, error) // Used to get possible labels for a given stream
 

--- a/pkg/dataobj/metastore/metastore.go
+++ b/pkg/dataobj/metastore/metastore.go
@@ -18,8 +18,8 @@ type Metastore interface {
 	// StreamsIDs returns object store paths and stream IDs for all matching objects for the given matchers between [start,end]
 	StreamIDs(ctx context.Context, start, end time.Time, matchers ...*labels.Matcher) ([]string, [][]int64, []int, error)
 
-	// StreamIDsBySections returns a list of dataobj sections & their stream IDs for all matching objects for the given matchers between [start,end]
-	StreamIDsBySections(ctx context.Context, start, end time.Time, matchers ...*labels.Matcher) ([]DataobjSectionDescriptor, error)
+	// Sections returns a list of SectionDescriptors, including metadata (stream IDs, start & end times, bytes), for the given matchers & predicates between [start,end]
+	Sections(ctx context.Context, start, end time.Time, matchers []*labels.Matcher, predicates []*labels.Matcher) ([]*DataobjSectionDescriptor, error)
 
 	// Labels returns all possible labels from matching streams between [start,end]
 	Labels(ctx context.Context, start, end time.Time, matchers ...*labels.Matcher) ([]string, error) // Used to get possible labels for a given stream

--- a/pkg/dataobj/metastore/metastore_test.go
+++ b/pkg/dataobj/metastore/metastore_test.go
@@ -245,7 +245,7 @@ func TestDataObjectsPaths(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	ms := NewObjectMetastore(bucket, log.NewNopLogger())
+	ms := NewObjectMetastore(bucket, log.NewNopLogger(), nil)
 
 	t.Run("finds objects within current window", func(t *testing.T) {
 		paths, err := ms.DataObjects(ctx, now.Add(-1*time.Hour), now)

--- a/pkg/dataobj/metastore/metrics.go
+++ b/pkg/dataobj/metastore/metrics.go
@@ -107,3 +107,108 @@ func (p *metastoreMetrics) observeMetastoreProcessing(recordTimestamp time.Time)
 		p.metastoreProcessingTime.Observe(time.Since(recordTimestamp).Seconds())
 	}
 }
+
+type objectMetastoreMetrics struct {
+	streamLookupTotalDuration          prometheus.Histogram
+	streamLookupPaths                  prometheus.Histogram
+	streamLookupSections               prometheus.Histogram
+	streamLookupStreamReadDuration     prometheus.Histogram
+	streamLookupPointerReadDuration    prometheus.Histogram
+	checkMembershipTotalDuration       prometheus.Histogram
+	checkMembershipPointerReadDuration prometheus.Histogram
+	checkMembershipPaths               prometheus.Histogram
+	checkMembershipSections            prometheus.Histogram
+	resolvedSections                   prometheus.Histogram
+	resolvedSectionsRatio              prometheus.Histogram
+}
+
+func newObjectMetastoreMetrics(reg prometheus.Registerer) *objectMetastoreMetrics {
+	metrics := &objectMetastoreMetrics{
+		streamLookupTotalDuration: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Name:                            "loki_metastore_stream_lookup_total_duration_seconds",
+			Help:                            "Total time taken to lookup streams for a Metastore query in seconds",
+			Buckets:                         prometheus.DefBuckets,
+			NativeHistogramBucketFactor:     1.1,
+			NativeHistogramMaxBucketNumber:  100,
+			NativeHistogramMinResetDuration: 0,
+		}),
+		streamLookupPaths: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Name:                            "loki_metastore_stream_lookup_paths_total",
+			Help:                            "Total number of paths to be searched for a Metastore query",
+			Buckets:                         prometheus.DefBuckets,
+			NativeHistogramBucketFactor:     1.1,
+			NativeHistogramMaxBucketNumber:  100,
+			NativeHistogramMinResetDuration: 0,
+		}),
+		streamLookupStreamReadDuration: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Name:                            "loki_metastore_stream_lookup_stream_read_duration_seconds",
+			Help:                            "Total time taken to read one streams section during a Metastore query when listing sections from stream matchers in seconds",
+			Buckets:                         prometheus.DefBuckets,
+			NativeHistogramBucketFactor:     1.1,
+			NativeHistogramMaxBucketNumber:  100,
+			NativeHistogramMinResetDuration: 0,
+		}),
+		streamLookupPointerReadDuration: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Name:                            "loki_metastore_stream_lookup_pointer_read_duration_seconds",
+			Help:                            "Total time taken to read one pointers section during a Metastore query when listing sections from stream matchers in seconds",
+			Buckets:                         prometheus.DefBuckets,
+			NativeHistogramBucketFactor:     1.1,
+			NativeHistogramMaxBucketNumber:  100,
+			NativeHistogramMinResetDuration: 0,
+		}),
+		checkMembershipTotalDuration: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Name:                            "loki_metastore_check_membership_total_duration_seconds",
+			Help:                            "Total time taken to check section membership for a Metastore query when listing sections from AMQ filters in seconds",
+			Buckets:                         prometheus.DefBuckets,
+			NativeHistogramBucketFactor:     1.1,
+			NativeHistogramMaxBucketNumber:  100,
+			NativeHistogramMinResetDuration: 0,
+		}),
+		checkMembershipPointerReadDuration: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Name:                            "loki_metastore_check_membership_pointer_read_duration_seconds",
+			Help:                            "Total time taken to read one pointers section during a Metastore query when listing sections from AMQ filters in seconds",
+			Buckets:                         prometheus.DefBuckets,
+			NativeHistogramBucketFactor:     1.1,
+			NativeHistogramMaxBucketNumber:  100,
+			NativeHistogramMinResetDuration: 0,
+		}),
+		checkMembershipSections: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Name:                            "loki_metastore_check_membership_sections_total",
+			Help:                            "Total number of sections resolved for a Metastore query when listing sections from AMQ filters",
+			Buckets:                         prometheus.DefBuckets,
+			NativeHistogramBucketFactor:     1.1,
+			NativeHistogramMaxBucketNumber:  100,
+			NativeHistogramMinResetDuration: 0,
+		}),
+		resolvedSections: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Name:                            "loki_metastore_resolved_sections_total",
+			Help:                            "Total number of sections resolved for a Metastore query",
+			Buckets:                         prometheus.DefBuckets,
+			NativeHistogramBucketFactor:     1.1,
+			NativeHistogramMaxBucketNumber:  100,
+			NativeHistogramMinResetDuration: 0,
+		}),
+		resolvedSectionsRatio: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Name:                            "loki_metastore_predicate_amq_ratio",
+			Help:                            "Ratio of sections resolved for a Metastore query between stream selectors and then intersecting with AMQ filters",
+			Buckets:                         []float64{0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0},
+			NativeHistogramBucketFactor:     1.1,
+			NativeHistogramMaxBucketNumber:  100,
+			NativeHistogramMinResetDuration: 0,
+		}),
+	}
+
+	return metrics
+}
+
+func (p *objectMetastoreMetrics) register(reg prometheus.Registerer) {
+	reg.MustRegister(p.streamLookupTotalDuration)
+	reg.MustRegister(p.streamLookupPaths)
+	reg.MustRegister(p.streamLookupStreamReadDuration)
+	reg.MustRegister(p.streamLookupPointerReadDuration)
+	reg.MustRegister(p.checkMembershipTotalDuration)
+	reg.MustRegister(p.checkMembershipPointerReadDuration)
+	reg.MustRegister(p.checkMembershipSections)
+	reg.MustRegister(p.resolvedSections)
+	reg.MustRegister(p.resolvedSectionsRatio)
+}

--- a/pkg/dataobj/metastore/object.go
+++ b/pkg/dataobj/metastore/object.go
@@ -126,7 +126,7 @@ func (m *ObjectMetastore) StreamIDs(ctx context.Context, start, end time.Time, m
 
 	// List objects from all stores concurrently
 	paths, err := m.listObjectsFromStores(ctx, storePaths, start, end)
-	level.Debug(m.logger).Log("msg", "got data object paths", "tenant", tenantID, "paths", strings.Join(storePaths, ","), "err", err)
+	level.Debug(m.logger).Log("msg", "got data object paths", "tenant", tenantID, "paths", strings.Join(paths, ","), "err", err)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -429,12 +429,12 @@ func (m *ObjectMetastore) listStreamIDsFromObjects(ctx context.Context, paths []
 
 func (m *ObjectMetastore) listSectionsFromIndexes(ctx context.Context, paths []string, predicate streams.RowPredicate) ([]DataobjSectionDescriptor, error) {
 	startTime := time.Now()
+	sectionPointers := make([]DataobjSectionDescriptor, 0, len(paths)*12)
 	defer func() {
-		fmt.Printf("listStreamIDsFromIndexes duration=%s paths=%d\n", time.Since(startTime), len(paths))
+		fmt.Printf("listStreamIDsFromIndexes duration=%s paths=%d pointers=%d\n", time.Since(startTime), len(paths), len(sectionPointers))
 	}()
 
 	mtx := sync.Mutex{}
-	sectionPointers := make([]DataobjSectionDescriptor, 0, len(paths)*12)
 	g, ctx := errgroup.WithContext(ctx)
 	g.SetLimit(m.parallelism)
 

--- a/pkg/dataobj/metastore/object.go
+++ b/pkg/dataobj/metastore/object.go
@@ -3,6 +3,7 @@ package metastore
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"iter"
@@ -23,6 +24,7 @@ import (
 
 	"github.com/grafana/loki/v3/pkg/dataobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/logs"
+	"github.com/grafana/loki/v3/pkg/dataobj/sections/pointers"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/streams"
 )
 
@@ -34,6 +36,16 @@ type ObjectMetastore struct {
 	bucket      objstore.Bucket
 	parallelism int
 	logger      log.Logger
+}
+
+type DataobjSectionDescriptor struct {
+	ObjectPath string
+	SectionIdx int64
+	StreamIDs  []int64
+	Lines      int
+	Size       int64
+	Start      time.Time
+	End        time.Time
 }
 
 func metastorePath(tenantID string, window time.Time) string {
@@ -127,6 +139,10 @@ func (m *ObjectMetastore) StreamIDs(ctx context.Context, start, end time.Time, m
 		return nil, nil, nil, fmt.Errorf("failed to list stream IDs and sections from objects: %w", err)
 	}
 
+	if len(streamIDs) == 0 {
+		return paths, streamIDs, sections, nil
+	}
+
 	// Remove objects that do not contain any matching streams
 	level.Debug(m.logger).Log("msg", "remove objects that do not contain any matching streams", "paths", len(paths), "streams", len(streamIDs), "sections", len(sections))
 	for i := 0; i < len(paths); i++ {
@@ -140,6 +156,35 @@ func (m *ObjectMetastore) StreamIDs(ctx context.Context, start, end time.Time, m
 	}
 
 	return paths, streamIDs, sections, nil
+}
+
+func (m *ObjectMetastore) StreamIDsBySections(ctx context.Context, start, end time.Time, matchers ...*labels.Matcher) ([]DataobjSectionDescriptor, error) {
+	tenantID, err := tenant.TenantID(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get all metastore paths for the time range
+	var storePaths []string
+	for path := range iterStorePaths(tenantID, start, end) {
+		storePaths = append(storePaths, path)
+	}
+
+	// List objects from all stores concurrently
+	paths, err := m.listObjectsFromStores(ctx, storePaths, start, end)
+	if err != nil {
+		return nil, err
+	}
+
+	// Search the stream sections of the matching objects to find matching streams
+	predicate := predicateFromMatchers(start, end, matchers...)
+	sectionPointers, err := m.listSectionsFromIndexes(ctx, paths, predicate)
+
+	if len(sectionPointers) == 0 {
+		return nil, errors.New("no relevant sections returned")
+	}
+
+	return sectionPointers, err
 }
 
 func (m *ObjectMetastore) DataObjects(ctx context.Context, start, end time.Time, _ ...*labels.Matcher) ([]string, error) {
@@ -265,6 +310,30 @@ func predicateFromMatchers(start, end time.Time, matchers ...*labels.Matcher) st
 	return current
 }
 
+func pointerPredicateFromMatchers(start, end time.Time, matchers ...*labels.Matcher) pointers.RowPredicate {
+	if len(matchers) == 0 {
+		return nil
+	}
+
+	predicates := make([]pointers.RowPredicate, 0, len(matchers)+1)
+	for _, matcher := range matchers {
+		switch matcher.Type {
+		case labels.MatchEqual:
+			predicates = append(predicates, pointers.BloomExistencePredicate{
+				Name:  matcher.Name,
+				Value: matcher.Value,
+			})
+		}
+	}
+
+	if len(predicates) == 1 {
+		return predicates[0]
+	}
+
+	panic("multiple bloom filters not implemented")
+	return nil
+}
+
 // listObjectsFromStores concurrently lists objects from multiple metastore files
 func (m *ObjectMetastore) listObjectsFromStores(ctx context.Context, storePaths []string, start, end time.Time) ([]string, error) {
 	objects := make([][]string, len(storePaths))
@@ -323,6 +392,10 @@ func (m *ObjectMetastore) listStreamsFromObjects(ctx context.Context, paths []st
 }
 
 func (m *ObjectMetastore) listStreamIDsFromObjects(ctx context.Context, paths []string, predicate streams.RowPredicate) ([][]int64, []int, error) {
+	startTime := time.Now()
+	defer func() {
+		fmt.Printf("listStreamIDsFromObjects duration=%s paths=%d\n", time.Since(startTime), len(paths))
+	}()
 	streamIDs := make([][]int64, len(paths))
 	sections := make([]int, len(paths))
 
@@ -336,6 +409,7 @@ func (m *ObjectMetastore) listStreamIDsFromObjects(ctx context.Context, paths []
 				if err != nil {
 					return fmt.Errorf("getting object from bucket: %w", err)
 				}
+
 				sections[idx] = object.Sections().Count(logs.CheckSection)
 				streamIDs[idx] = make([]int64, 0, 8)
 
@@ -351,6 +425,138 @@ func (m *ObjectMetastore) listStreamIDsFromObjects(ctx context.Context, paths []
 	}
 
 	return streamIDs, sections, nil
+}
+
+func (m *ObjectMetastore) listSectionsFromIndexes(ctx context.Context, paths []string, predicate streams.RowPredicate) ([]DataobjSectionDescriptor, error) {
+	startTime := time.Now()
+	defer func() {
+		fmt.Printf("listStreamIDsFromIndexes duration=%s paths=%d\n", time.Since(startTime), len(paths))
+	}()
+
+	mtx := sync.Mutex{}
+	sectionPointers := make([]DataobjSectionDescriptor, 0, len(paths)*12)
+	g, ctx := errgroup.WithContext(ctx)
+	g.SetLimit(m.parallelism)
+
+	for i, path := range paths {
+		func(idx int) {
+			g.Go(func() error {
+				downloadStartTime := time.Now()
+				idxFile, err := m.bucket.Get(ctx, path)
+				if err != nil {
+					return fmt.Errorf("getting object from bucket: %w", err)
+				}
+				idxBytes, err := io.ReadAll(idxFile)
+				if err != nil {
+					return fmt.Errorf("reading object from bucket: %w", err)
+				}
+				idxObject, err := dataobj.FromReaderAt(bytes.NewReader(idxBytes), int64(len(idxBytes)))
+				if err != nil {
+					return fmt.Errorf("getting object from bucket: %w", err)
+				}
+				downloadDuration := time.Since(downloadStartTime)
+
+				streamReadStartTime := time.Now()
+				var indexStreamIDs []int64
+				streamLabels := make([]*labels.Labels, 0, 1024)
+				forEachStream(ctx, idxObject, predicate, func(stream streams.Stream) {
+					indexStreamIDs = append(indexStreamIDs, stream.ID)
+					streamLabels = append(streamLabels, &stream.Labels)
+				})
+				streamReadDuration := time.Since(streamReadStartTime)
+				fmt.Printf("path=%s matching_streams=%d\n", path, len(indexStreamIDs))
+
+				// TODO: Implement time-range predicate for Pointers here too to further restrict the number of section pointers
+				sectionPointerReadStartTime := time.Now()
+				locators := map[string]*DataobjSectionDescriptor{}
+				forEachObjPointer(ctx, idxObject, nil, indexStreamIDs, func(pointer pointers.SectionPointer) {
+					key := fmt.Sprintf("%s-%d", pointer.Path, pointer.Section)
+					sectionPointer, ok := locators[key]
+					if !ok {
+						newSectionPointer := &DataobjSectionDescriptor{
+							ObjectPath: pointer.Path,
+							SectionIdx: pointer.Section,
+							StreamIDs:  []int64{pointer.StreamIDRef},
+							Lines:      int(pointer.LineCount),
+							Size:       pointer.UncompressedSize,
+							Start:      pointer.StartTs,
+							End:        pointer.EndTs,
+						}
+						locators[key] = newSectionPointer
+						return
+					}
+					sectionPointer.StreamIDs = append(sectionPointer.StreamIDs, pointer.StreamIDRef)
+					sectionPointer.Lines += int(pointer.LineCount)
+					sectionPointer.Size += pointer.UncompressedSize
+					if pointer.StartTs.Before(sectionPointer.Start) {
+						sectionPointer.Start = pointer.StartTs
+					}
+					if pointer.EndTs.After(sectionPointer.End) {
+						sectionPointer.End = pointer.EndTs
+					}
+				})
+
+				sectionPointerReadDuration := time.Since(sectionPointerReadStartTime)
+
+				mtx.Lock()
+				for _, locator := range locators {
+					sectionPointers = append(sectionPointers, *locator)
+				}
+				mtx.Unlock()
+
+				fmt.Printf("listSectionsFromIndexesSingle download=%s streamRead=%s sectionPointerRead=%s path=%s\n", downloadDuration, streamReadDuration, sectionPointerReadDuration, path)
+
+				return nil
+			})
+		}(i)
+	}
+
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+
+	return sectionPointers, nil
+}
+
+// Checks for the column key & value existing in paths
+func (m *ObjectMetastore) checkExistenceFromObjects(ctx context.Context, paths []string, predicate pointers.RowPredicate) ([][]string, error) {
+	startTime := time.Now()
+	defer func() {
+		fmt.Printf("checkExistenceFromObjects duration=%s paths=%d\n", time.Since(startTime), len(paths))
+	}()
+	pathsWithData := make([][]string, len(paths))
+
+	g, ctx := errgroup.WithContext(ctx)
+	g.SetLimit(m.parallelism)
+
+	for i, path := range paths {
+		func(idx int) {
+			g.Go(func() error {
+				idxFile, err := m.bucket.Get(ctx, path)
+				if err != nil {
+					return fmt.Errorf("getting object from bucket: %w", err)
+				}
+				idxBytes, err := io.ReadAll(idxFile)
+				if err != nil {
+					return fmt.Errorf("reading object from bucket: %w", err)
+				}
+				idxObject, err := dataobj.FromReaderAt(bytes.NewReader(idxBytes), int64(len(idxBytes)))
+				if err != nil {
+					return fmt.Errorf("getting object from bucket: %w", err)
+				}
+
+				return forEachObjPointer(ctx, idxObject, predicate, nil, func(pointer pointers.SectionPointer) {
+					pathsWithData[idx] = append(pathsWithData[idx], pointer.Path)
+				})
+			})
+		}(i)
+	}
+
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+
+	return pathsWithData, nil
 }
 
 func addLabels(mtx *sync.Mutex, streams map[uint64][]*labels.Labels, newLabels *labels.Labels) {
@@ -406,7 +612,7 @@ func forEachStream(ctx context.Context, object *dataobj.Object, predicate stream
 	var reader streams.RowReader
 	defer reader.Close()
 
-	buf := make([]streams.Stream, 1024)
+	buf := make([]streams.Stream, 2048)
 
 	for _, section := range object.Sections() {
 		if !streams.CheckSection(section) {
@@ -435,6 +641,59 @@ func forEachStream(ctx context.Context, object *dataobj.Object, predicate stream
 			}
 			for _, stream := range buf[:num] {
 				f(stream)
+			}
+		}
+	}
+	return nil
+}
+
+func sliceIter(matchIDs []int64) iter.Seq[int64] {
+	return func(yield func(int64) bool) {
+		for _, id := range matchIDs {
+			if !yield(id) {
+				return
+			}
+		}
+	}
+}
+
+func forEachObjPointer(ctx context.Context, object *dataobj.Object, predicate pointers.RowPredicate, matchIDs []int64, f func(pointers.SectionPointer)) error {
+	var reader pointers.RowReader
+	defer reader.Close()
+
+	buf := make([]pointers.SectionPointer, 1024)
+
+	for _, section := range object.Sections() {
+		if !pointers.CheckSection(section) {
+			continue
+		}
+
+		sec, err := pointers.Open(ctx, section)
+		if err != nil {
+			return fmt.Errorf("opening section: %w", err)
+		}
+
+		if len(matchIDs) > 0 {
+			reader.MatchStreams(sliceIter(matchIDs))
+		}
+
+		reader.Reset(sec)
+		if predicate != nil {
+			err := reader.SetPredicate(predicate)
+			if err != nil {
+				return err
+			}
+		}
+		for {
+			num, err := reader.Read(ctx, buf)
+			if err != nil && err != io.EOF {
+				return err
+			}
+			if num == 0 && err == io.EOF {
+				break
+			}
+			for _, pointer := range buf[:num] {
+				f(pointer)
 			}
 		}
 	}

--- a/pkg/dataobj/metastore/object.go
+++ b/pkg/dataobj/metastore/object.go
@@ -18,6 +18,7 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/tenant"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/thanos-io/objstore"
 	"golang.org/x/sync/errgroup"
@@ -36,6 +37,7 @@ type ObjectMetastore struct {
 	bucket      objstore.Bucket
 	parallelism int
 	logger      log.Logger
+	metrics     *objectMetastoreMetrics
 }
 
 type sectionKey struct {
@@ -94,12 +96,17 @@ func iterStorePaths(tenantID string, start, end time.Time) iter.Seq[string] {
 	}
 }
 
-func NewObjectMetastore(bucket objstore.Bucket, logger log.Logger) *ObjectMetastore {
-	return &ObjectMetastore{
+func NewObjectMetastore(bucket objstore.Bucket, logger log.Logger, reg prometheus.Registerer) *ObjectMetastore {
+	store := &ObjectMetastore{
 		bucket:      bucket,
 		parallelism: 64,
 		logger:      logger,
+		metrics:     newObjectMetastoreMetrics(reg),
 	}
+	if reg != nil {
+		store.metrics.register(reg)
+	}
+	return store
 }
 
 func matchersToString(matchers []*labels.Matcher) string {
@@ -215,6 +222,7 @@ func (m *ObjectMetastore) Sections(ctx context.Context, start, end time.Time, ma
 	if err != nil {
 		return nil, err
 	}
+	originalStreamSectionPointers := len(streamSectionPointers)
 
 	// Search the section AMQs to estimate sections that might match the predicates
 	// AMQs may return false positives so this is an over-estimate.
@@ -224,14 +232,13 @@ func (m *ObjectMetastore) Sections(ctx context.Context, start, end time.Time, ma
 		return nil, err
 	}
 
-	// TODO: Convert to metrics
-	level.Debug(m.logger).Log("msg", "sections checked", "sectionsFromStreams", len(streamSectionPointers), "sectionsFromAMQs", len(sectionMembershipEstimates), "ratio", float64(len(sectionMembershipEstimates))/float64(len(streamSectionPointers)))
-
 	streamSectionPointers = intersectSections(streamSectionPointers, sectionMembershipEstimates)
 	if len(streamSectionPointers) == 0 {
 		return nil, errors.New("no relevant sections returned")
 	}
 
+	m.metrics.resolvedSections.Observe(float64(len(streamSectionPointers)))
+	m.metrics.resolvedSectionsRatio.Observe(float64(len(streamSectionPointers)) / float64(originalStreamSectionPointers))
 	return streamSectionPointers, nil
 }
 
@@ -468,10 +475,6 @@ func (m *ObjectMetastore) listStreamsFromObjects(ctx context.Context, paths []st
 }
 
 func (m *ObjectMetastore) listStreamIDsFromObjects(ctx context.Context, paths []string, predicate streams.RowPredicate) ([][]int64, []int, error) {
-	startTime := time.Now()
-	defer func() {
-		fmt.Printf("listStreamIDsFromObjects duration=%s paths=%d\n", time.Since(startTime), len(paths))
-	}()
 	streamIDs := make([][]int64, len(paths))
 	sections := make([]int, len(paths))
 
@@ -505,10 +508,9 @@ func (m *ObjectMetastore) listStreamIDsFromObjects(ctx context.Context, paths []
 
 func (m *ObjectMetastore) listSectionsFromIndexes(ctx context.Context, paths []string, streamPredicate streams.RowPredicate, timeRangePredicate pointers.TimeRangePredicate) ([]*DataobjSectionDescriptor, error) {
 	startTime := time.Now()
+	defer m.metrics.streamLookupTotalDuration.Observe(time.Since(startTime).Seconds())
+
 	var sectionDescriptors []*DataobjSectionDescriptor
-	defer func() {
-		fmt.Printf("listStreamIDsFromIndexes duration=%s paths=%d pointers=%d\n", time.Since(startTime), len(paths), len(sectionDescriptors))
-	}()
 
 	sectionDescriptorsMutex := sync.Mutex{}
 	g, ctx := errgroup.WithContext(ctx)
@@ -520,12 +522,10 @@ func (m *ObjectMetastore) listSectionsFromIndexes(ctx context.Context, paths []s
 				var key sectionKey
 				var matchingStreamIDs []int64
 
-				downloadStartTime := time.Now()
 				idxObject, err := fetchObject(ctx, m.bucket, path)
 				if err != nil {
-					return fmt.Errorf("fetching object %s from bucket: %w", path, err)
+					return fmt.Errorf("fetching object '%s' from bucket: %w", path, err)
 				}
-				downloadDuration := time.Since(downloadStartTime)
 
 				streamReadStartTime := time.Now()
 				err = forEachStream(ctx, idxObject, streamPredicate, func(stream streams.Stream) {
@@ -534,7 +534,7 @@ func (m *ObjectMetastore) listSectionsFromIndexes(ctx context.Context, paths []s
 				if err != nil {
 					return fmt.Errorf("reading streams from index: %w", err)
 				}
-				streamReadDuration := time.Since(streamReadStartTime)
+				m.metrics.streamLookupStreamReadDuration.Observe(time.Since(streamReadStartTime).Seconds())
 
 				objectSectionDescriptors := make(map[sectionKey]*DataobjSectionDescriptor)
 				sectionPointerReadStartTime := time.Now()
@@ -552,7 +552,7 @@ func (m *ObjectMetastore) listSectionsFromIndexes(ctx context.Context, paths []s
 				if err != nil {
 					return fmt.Errorf("reading section pointers from index: %w", err)
 				}
-				sectionPointerReadDuration := time.Since(sectionPointerReadStartTime)
+				m.metrics.streamLookupPointerReadDuration.Observe(time.Since(sectionPointerReadStartTime).Seconds())
 
 				// Merge the section descriptors for the object into the global section descriptors in one batch
 				sectionDescriptorsMutex.Lock()
@@ -560,8 +560,6 @@ func (m *ObjectMetastore) listSectionsFromIndexes(ctx context.Context, paths []s
 					sectionDescriptors = append(sectionDescriptors, sectionDescriptor)
 				}
 				sectionDescriptorsMutex.Unlock()
-
-				fmt.Printf("listSectionsFromIndexesSingle streamRead=%s sectionPointerRead=%s download=%s path=%s\n", streamReadDuration, sectionPointerReadDuration, downloadDuration, path)
 
 				return nil
 			})
@@ -572,15 +570,15 @@ func (m *ObjectMetastore) listSectionsFromIndexes(ctx context.Context, paths []s
 		return nil, err
 	}
 
+	m.metrics.streamLookupPaths.Observe(float64(len(paths)))
+	m.metrics.streamLookupSections.Observe(float64(len(sectionDescriptors)))
 	return sectionDescriptors, nil
 }
 
 // checkSectionMembership checks the predicates against the section AMQs to determine approximate section membership.
 func (m *ObjectMetastore) checkSectionMembership(ctx context.Context, paths []string, predicate pointers.RowPredicate) ([]*DataobjSectionDescriptor, error) {
 	startTime := time.Now()
-	defer func() {
-		fmt.Printf("checkSectionMembership duration=%s paths=%d\n", time.Since(startTime), len(paths))
-	}()
+	defer m.metrics.checkMembershipTotalDuration.Observe(time.Since(startTime).Seconds())
 
 	g, ctx := errgroup.WithContext(ctx)
 	g.SetLimit(m.parallelism)
@@ -595,6 +593,7 @@ func (m *ObjectMetastore) checkSectionMembership(ctx context.Context, paths []st
 					return fmt.Errorf("fetching object from bucket: %w", err)
 				}
 
+				pointerReadStartTime := time.Now()
 				var objectSectionDescriptors []*DataobjSectionDescriptor
 				err = forEachObjPointer(ctx, idxObject, predicate, nil, func(pointer pointers.SectionPointer) {
 					objectSectionDescriptors = append(objectSectionDescriptors, &DataobjSectionDescriptor{
@@ -605,6 +604,7 @@ func (m *ObjectMetastore) checkSectionMembership(ctx context.Context, paths []st
 				if err != nil {
 					return fmt.Errorf("reading object from bucket: %w", err)
 				}
+				m.metrics.checkMembershipPointerReadDuration.Observe(time.Since(pointerReadStartTime).Seconds())
 
 				sectionDescriptorsMutex.Lock()
 				for _, section := range objectSectionDescriptors {
@@ -621,6 +621,8 @@ func (m *ObjectMetastore) checkSectionMembership(ctx context.Context, paths []st
 		return nil, err
 	}
 
+	m.metrics.checkMembershipPaths.Observe(float64(len(paths)))
+	m.metrics.checkMembershipSections.Observe(float64(len(sectionDescriptors)))
 	return sectionDescriptors, nil
 }
 
@@ -681,7 +683,7 @@ func forEachStream(ctx context.Context, object *dataobj.Object, predicate stream
 	var reader streams.RowReader
 	defer reader.Close()
 
-	buf := make([]streams.Stream, 2048)
+	buf := make([]streams.Stream, 1024)
 
 	for _, section := range object.Sections() {
 		if !streams.CheckSection(section) {
@@ -716,16 +718,6 @@ func forEachStream(ctx context.Context, object *dataobj.Object, predicate stream
 	return nil
 }
 
-func sliceIter(matchIDs []int64) iter.Seq[int64] {
-	return func(yield func(int64) bool) {
-		for _, id := range matchIDs {
-			if !yield(id) {
-				return
-			}
-		}
-	}
-}
-
 func forEachObjPointer(ctx context.Context, object *dataobj.Object, predicate pointers.RowPredicate, matchIDs []int64, f func(pointers.SectionPointer)) error {
 	var reader pointers.RowReader
 	defer reader.Close()
@@ -738,11 +730,8 @@ func forEachObjPointer(ctx context.Context, object *dataobj.Object, predicate po
 			return fmt.Errorf("opening section: %w", err)
 		}
 
-		if len(matchIDs) > 0 {
-			reader.MatchStreams(sliceIter(matchIDs))
-		}
-
 		reader.Reset(sec)
+		reader.MatchStreams(slices.Values(matchIDs))
 		if predicate != nil {
 			err := reader.SetPredicate(predicate)
 			if err != nil {

--- a/pkg/dataobj/metastore/object.go
+++ b/pkg/dataobj/metastore/object.go
@@ -38,6 +38,11 @@ type ObjectMetastore struct {
 	logger      log.Logger
 }
 
+type sectionKey struct {
+	objectPath string
+	sectionIdx int64
+}
+
 type DataobjSectionDescriptor struct {
 	ObjectPath string
 	SectionIdx int64
@@ -46,6 +51,30 @@ type DataobjSectionDescriptor struct {
 	Size       int64
 	Start      time.Time
 	End        time.Time
+}
+
+func NewSectionDescriptor(pointer pointers.SectionPointer) *DataobjSectionDescriptor {
+	return &DataobjSectionDescriptor{
+		ObjectPath: pointer.Path,
+		SectionIdx: pointer.Section,
+		StreamIDs:  []int64{pointer.StreamIDRef},
+		Lines:      int(pointer.LineCount),
+		Size:       pointer.UncompressedSize,
+		Start:      pointer.StartTs,
+		End:        pointer.EndTs,
+	}
+}
+
+func (d *DataobjSectionDescriptor) Merge(pointer pointers.SectionPointer) {
+	d.StreamIDs = append(d.StreamIDs, pointer.StreamIDRef)
+	d.Lines += int(pointer.LineCount)
+	d.Size += pointer.UncompressedSize
+	if pointer.StartTs.Before(d.Start) {
+		d.Start = pointer.StartTs
+	}
+	if pointer.EndTs.After(d.End) {
+		d.End = pointer.EndTs
+	}
 }
 
 func metastorePath(tenantID string, window time.Time) string {
@@ -106,7 +135,7 @@ func (m *ObjectMetastore) Streams(ctx context.Context, start, end time.Time, mat
 	}
 
 	// Search the stream sections of the matching objects to find matching streams
-	predicate := predicateFromMatchers(start, end, matchers...)
+	predicate := streamPredicateFromMatchers(start, end, matchers...)
 	return m.listStreamsFromObjects(ctx, paths, predicate)
 }
 
@@ -132,7 +161,7 @@ func (m *ObjectMetastore) StreamIDs(ctx context.Context, start, end time.Time, m
 	}
 
 	// Search the stream sections of the matching objects to find matching streams
-	predicate := predicateFromMatchers(start, end, matchers...)
+	predicate := streamPredicateFromMatchers(start, end, matchers...)
 	streamIDs, sections, err := m.listStreamIDsFromObjects(ctx, paths, predicate)
 	level.Debug(m.logger).Log("msg", "got streams and sections", "tenant", tenantID, "streams", len(streamIDs), "sections", len(sections), "err", err)
 	if err != nil {
@@ -158,7 +187,7 @@ func (m *ObjectMetastore) StreamIDs(ctx context.Context, start, end time.Time, m
 	return paths, streamIDs, sections, nil
 }
 
-func (m *ObjectMetastore) StreamIDsBySections(ctx context.Context, start, end time.Time, matchers ...*labels.Matcher) ([]DataobjSectionDescriptor, error) {
+func (m *ObjectMetastore) Sections(ctx context.Context, start, end time.Time, matchers []*labels.Matcher, predicates []*labels.Matcher) ([]*DataobjSectionDescriptor, error) {
 	tenantID, err := tenant.TenantID(ctx)
 	if err != nil {
 		return nil, err
@@ -177,14 +206,55 @@ func (m *ObjectMetastore) StreamIDsBySections(ctx context.Context, start, end ti
 	}
 
 	// Search the stream sections of the matching objects to find matching streams
-	predicate := predicateFromMatchers(start, end, matchers...)
-	sectionPointers, err := m.listSectionsFromIndexes(ctx, paths, predicate)
+	streamMatchers := streamPredicateFromMatchers(start, end, matchers...)
+	pointerPredicate := pointers.TimeRangePredicate{
+		Start: start,
+		End:   end,
+	}
+	streamSectionPointers, err := m.listSectionsFromIndexes(ctx, paths, streamMatchers, pointerPredicate)
+	if err != nil {
+		return nil, err
+	}
 
-	if len(sectionPointers) == 0 {
+	// Search the section AMQs to estimate sections that might match the predicates
+	// AMQs may return false positives so this is an over-estimate.
+	pointerMatchers := pointerPredicateFromMatchers(predicates...)
+	sectionMembershipEstimates, err := m.checkSectionMembership(ctx, paths, pointerMatchers)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: Convert to metrics
+	level.Debug(m.logger).Log("msg", "sections checked", "sectionsFromStreams", len(streamSectionPointers), "sectionsFromAMQs", len(sectionMembershipEstimates), "ratio", float64(len(sectionMembershipEstimates))/float64(len(streamSectionPointers)))
+
+	streamSectionPointers = intersectSections(streamSectionPointers, sectionMembershipEstimates)
+	if len(streamSectionPointers) == 0 {
 		return nil, errors.New("no relevant sections returned")
 	}
 
-	return sectionPointers, err
+	return streamSectionPointers, nil
+}
+
+func intersectSections(sectionPointers []*DataobjSectionDescriptor, sectionMembershipEstimates []*DataobjSectionDescriptor) []*DataobjSectionDescriptor {
+	existence := make(map[sectionKey]struct{}, len(sectionMembershipEstimates))
+	for _, section := range sectionMembershipEstimates {
+		existence[sectionKey{
+			objectPath: section.ObjectPath,
+			sectionIdx: section.SectionIdx,
+		}] = struct{}{}
+	}
+
+	nextEmptyIdx := 0
+	key := sectionKey{}
+	for _, section := range sectionPointers {
+		key.objectPath = section.ObjectPath
+		key.sectionIdx = section.SectionIdx
+		if _, ok := existence[key]; ok {
+			sectionPointers[nextEmptyIdx] = section
+			nextEmptyIdx++
+		}
+	}
+	return sectionPointers[:nextEmptyIdx]
 }
 
 func (m *ObjectMetastore) DataObjects(ctx context.Context, start, end time.Time, _ ...*labels.Matcher) ([]string, error) {
@@ -247,7 +317,7 @@ func (m *ObjectMetastore) forEachLabel(ctx context.Context, start, end time.Time
 	return nil
 }
 
-func predicateFromMatchers(start, end time.Time, matchers ...*labels.Matcher) streams.RowPredicate {
+func streamPredicateFromMatchers(start, end time.Time, matchers ...*labels.Matcher) streams.RowPredicate {
 	if len(matchers) == 0 {
 		return nil
 	}
@@ -310,7 +380,7 @@ func predicateFromMatchers(start, end time.Time, matchers ...*labels.Matcher) st
 	return current
 }
 
-func pointerPredicateFromMatchers(start, end time.Time, matchers ...*labels.Matcher) pointers.RowPredicate {
+func pointerPredicateFromMatchers(matchers ...*labels.Matcher) pointers.RowPredicate {
 	if len(matchers) == 0 {
 		return nil
 	}
@@ -326,12 +396,18 @@ func pointerPredicateFromMatchers(start, end time.Time, matchers ...*labels.Matc
 		}
 	}
 
-	if len(predicates) == 1 {
-		return predicates[0]
+	current := pointers.AndRowPredicate{
+		Left: predicates[0],
 	}
 
-	panic("multiple bloom filters not implemented")
-	return nil
+	for _, predicate := range predicates[1:] {
+		and := pointers.AndRowPredicate{
+			Left:  predicate,
+			Right: current,
+		}
+		current = and
+	}
+	return current
 }
 
 // listObjectsFromStores concurrently lists objects from multiple metastore files
@@ -427,84 +503,65 @@ func (m *ObjectMetastore) listStreamIDsFromObjects(ctx context.Context, paths []
 	return streamIDs, sections, nil
 }
 
-func (m *ObjectMetastore) listSectionsFromIndexes(ctx context.Context, paths []string, predicate streams.RowPredicate) ([]DataobjSectionDescriptor, error) {
+func (m *ObjectMetastore) listSectionsFromIndexes(ctx context.Context, paths []string, streamPredicate streams.RowPredicate, timeRangePredicate pointers.TimeRangePredicate) ([]*DataobjSectionDescriptor, error) {
 	startTime := time.Now()
-	sectionPointers := make([]DataobjSectionDescriptor, 0, len(paths)*12)
+	var sectionDescriptors []*DataobjSectionDescriptor
 	defer func() {
-		fmt.Printf("listStreamIDsFromIndexes duration=%s paths=%d pointers=%d\n", time.Since(startTime), len(paths), len(sectionPointers))
+		fmt.Printf("listStreamIDsFromIndexes duration=%s paths=%d pointers=%d\n", time.Since(startTime), len(paths), len(sectionDescriptors))
 	}()
 
-	mtx := sync.Mutex{}
+	sectionDescriptorsMutex := sync.Mutex{}
 	g, ctx := errgroup.WithContext(ctx)
 	g.SetLimit(m.parallelism)
 
 	for i, path := range paths {
 		func(idx int) {
 			g.Go(func() error {
+				var key sectionKey
+				var matchingStreamIDs []int64
+
 				downloadStartTime := time.Now()
-				idxFile, err := m.bucket.Get(ctx, path)
+				idxObject, err := fetchObject(ctx, m.bucket, path)
 				if err != nil {
-					return fmt.Errorf("getting object from bucket: %w", err)
-				}
-				idxBytes, err := io.ReadAll(idxFile)
-				if err != nil {
-					return fmt.Errorf("reading object from bucket: %w", err)
-				}
-				idxObject, err := dataobj.FromReaderAt(bytes.NewReader(idxBytes), int64(len(idxBytes)))
-				if err != nil {
-					return fmt.Errorf("getting object from bucket: %w", err)
+					return fmt.Errorf("fetching object %s from bucket: %w", path, err)
 				}
 				downloadDuration := time.Since(downloadStartTime)
 
 				streamReadStartTime := time.Now()
-				var indexStreamIDs []int64
-				streamLabels := make([]*labels.Labels, 0, 1024)
-				forEachStream(ctx, idxObject, predicate, func(stream streams.Stream) {
-					indexStreamIDs = append(indexStreamIDs, stream.ID)
-					streamLabels = append(streamLabels, &stream.Labels)
+				err = forEachStream(ctx, idxObject, streamPredicate, func(stream streams.Stream) {
+					matchingStreamIDs = append(matchingStreamIDs, stream.ID)
 				})
+				if err != nil {
+					return fmt.Errorf("reading streams from index: %w", err)
+				}
 				streamReadDuration := time.Since(streamReadStartTime)
-				fmt.Printf("path=%s matching_streams=%d\n", path, len(indexStreamIDs))
 
-				// TODO: Implement time-range predicate for Pointers here too to further restrict the number of section pointers
+				objectSectionDescriptors := make(map[sectionKey]*DataobjSectionDescriptor)
 				sectionPointerReadStartTime := time.Now()
-				locators := map[string]*DataobjSectionDescriptor{}
-				forEachObjPointer(ctx, idxObject, nil, indexStreamIDs, func(pointer pointers.SectionPointer) {
-					key := fmt.Sprintf("%s-%d", pointer.Path, pointer.Section)
-					sectionPointer, ok := locators[key]
+				err = forEachObjPointer(ctx, idxObject, timeRangePredicate, matchingStreamIDs, func(pointer pointers.SectionPointer) {
+					key.objectPath = pointer.Path
+					key.sectionIdx = pointer.Section
+
+					sectionDescriptor, ok := objectSectionDescriptors[key]
 					if !ok {
-						newSectionPointer := &DataobjSectionDescriptor{
-							ObjectPath: pointer.Path,
-							SectionIdx: pointer.Section,
-							StreamIDs:  []int64{pointer.StreamIDRef},
-							Lines:      int(pointer.LineCount),
-							Size:       pointer.UncompressedSize,
-							Start:      pointer.StartTs,
-							End:        pointer.EndTs,
-						}
-						locators[key] = newSectionPointer
+						objectSectionDescriptors[key] = NewSectionDescriptor(pointer)
 						return
 					}
-					sectionPointer.StreamIDs = append(sectionPointer.StreamIDs, pointer.StreamIDRef)
-					sectionPointer.Lines += int(pointer.LineCount)
-					sectionPointer.Size += pointer.UncompressedSize
-					if pointer.StartTs.Before(sectionPointer.Start) {
-						sectionPointer.Start = pointer.StartTs
-					}
-					if pointer.EndTs.After(sectionPointer.End) {
-						sectionPointer.End = pointer.EndTs
-					}
+					sectionDescriptor.Merge(pointer)
 				})
-
+				if err != nil {
+					return fmt.Errorf("reading section pointers from index: %w", err)
+				}
 				sectionPointerReadDuration := time.Since(sectionPointerReadStartTime)
 
-				mtx.Lock()
-				for _, locator := range locators {
-					sectionPointers = append(sectionPointers, *locator)
+				// Merge the section descriptors for the object into the global section descriptors in one batch
+				sectionDescriptorsMutex.Lock()
+				for _, sectionDescriptor := range objectSectionDescriptors {
+					sectionDescriptors = append(sectionDescriptors, sectionDescriptor)
 				}
-				mtx.Unlock()
+				sectionDescriptorsMutex.Unlock()
 
-				fmt.Printf("listSectionsFromIndexesSingle download=%s streamRead=%s sectionPointerRead=%s path=%s\n", downloadDuration, streamReadDuration, sectionPointerReadDuration, path)
+				fmt.Printf("listSectionsFromIndexesSingle streamRead=%s sectionPointerRead=%s download=%s path=%s\n", streamReadDuration, sectionPointerReadDuration, downloadDuration, path)
 
 				return nil
 			})
@@ -515,39 +572,47 @@ func (m *ObjectMetastore) listSectionsFromIndexes(ctx context.Context, paths []s
 		return nil, err
 	}
 
-	return sectionPointers, nil
+	return sectionDescriptors, nil
 }
 
-// Checks for the column key & value existing in paths
-func (m *ObjectMetastore) checkExistenceFromObjects(ctx context.Context, paths []string, predicate pointers.RowPredicate) ([][]string, error) {
+// checkSectionMembership checks the predicates against the section AMQs to determine approximate section membership.
+func (m *ObjectMetastore) checkSectionMembership(ctx context.Context, paths []string, predicate pointers.RowPredicate) ([]*DataobjSectionDescriptor, error) {
 	startTime := time.Now()
 	defer func() {
-		fmt.Printf("checkExistenceFromObjects duration=%s paths=%d\n", time.Since(startTime), len(paths))
+		fmt.Printf("checkSectionMembership duration=%s paths=%d\n", time.Since(startTime), len(paths))
 	}()
-	pathsWithData := make([][]string, len(paths))
 
 	g, ctx := errgroup.WithContext(ctx)
 	g.SetLimit(m.parallelism)
 
+	var sectionDescriptors []*DataobjSectionDescriptor
+	var sectionDescriptorsMutex sync.Mutex
 	for i, path := range paths {
 		func(idx int) {
 			g.Go(func() error {
-				idxFile, err := m.bucket.Get(ctx, path)
+				idxObject, err := fetchObject(ctx, m.bucket, path)
 				if err != nil {
-					return fmt.Errorf("getting object from bucket: %w", err)
+					return fmt.Errorf("fetching object from bucket: %w", err)
 				}
-				idxBytes, err := io.ReadAll(idxFile)
+
+				var objectSectionDescriptors []*DataobjSectionDescriptor
+				err = forEachObjPointer(ctx, idxObject, predicate, nil, func(pointer pointers.SectionPointer) {
+					objectSectionDescriptors = append(objectSectionDescriptors, &DataobjSectionDescriptor{
+						ObjectPath: pointer.Path,
+						SectionIdx: pointer.Section,
+					})
+				})
 				if err != nil {
 					return fmt.Errorf("reading object from bucket: %w", err)
 				}
-				idxObject, err := dataobj.FromReaderAt(bytes.NewReader(idxBytes), int64(len(idxBytes)))
-				if err != nil {
-					return fmt.Errorf("getting object from bucket: %w", err)
-				}
 
-				return forEachObjPointer(ctx, idxObject, predicate, nil, func(pointer pointers.SectionPointer) {
-					pathsWithData[idx] = append(pathsWithData[idx], pointer.Path)
-				})
+				sectionDescriptorsMutex.Lock()
+				for _, section := range objectSectionDescriptors {
+					sectionDescriptors = append(sectionDescriptors, section)
+				}
+				sectionDescriptorsMutex.Unlock()
+
+				return nil
 			})
 		}(i)
 	}
@@ -556,7 +621,11 @@ func (m *ObjectMetastore) checkExistenceFromObjects(ctx context.Context, paths [
 		return nil, err
 	}
 
-	return pathsWithData, nil
+	return sectionDescriptors, nil
+}
+
+func fetchObject(ctx context.Context, bucket objstore.Bucket, path string) (*dataobj.Object, error) {
+	return dataobj.FromBucket(ctx, bucket, path)
 }
 
 func addLabels(mtx *sync.Mutex, streams map[uint64][]*labels.Labels, newLabels *labels.Labels) {
@@ -663,11 +732,7 @@ func forEachObjPointer(ctx context.Context, object *dataobj.Object, predicate po
 
 	buf := make([]pointers.SectionPointer, 1024)
 
-	for _, section := range object.Sections() {
-		if !pointers.CheckSection(section) {
-			continue
-		}
-
+	for _, section := range object.Sections().Filter(pointers.CheckSection) {
 		sec, err := pointers.Open(ctx, section)
 		if err != nil {
 			return fmt.Errorf("opening section: %w", err)

--- a/pkg/dataobj/metastore/object_test.go
+++ b/pkg/dataobj/metastore/object_test.go
@@ -254,7 +254,7 @@ func queryMetastore(t *testing.T, tenantID string, mfunc func(context.Context, t
 		builder.addStreamAndFlush(stream)
 	}
 
-	mstore := NewObjectMetastore(builder.bucket, log.NewNopLogger())
+	mstore := NewObjectMetastore(builder.bucket, log.NewNopLogger(), nil)
 	defer func() {
 		require.NoError(t, mstore.bucket.Close())
 	}()

--- a/pkg/dataobj/metastore/updater.go
+++ b/pkg/dataobj/metastore/updater.go
@@ -3,6 +3,7 @@ package metastore
 import (
 	"bytes"
 	"context"
+	fmt "fmt"
 	"io"
 	"strconv"
 	"sync"
@@ -40,6 +41,7 @@ var metastoreBuilderCfg = logsobj.BuilderConfig{
 
 type Updater struct {
 	metastoreBuilder *logsobj.Builder
+	prefix           string
 	tenantID         string
 	metrics          *metastoreMetrics
 	bucket           objstore.Bucket
@@ -102,6 +104,9 @@ func (m *Updater) Update(ctx context.Context, dataobjPath string, minTimestamp, 
 	// Work our way through the metastore objects window by window, updating & creating them as needed.
 	// Each one handles its own retries in order to keep making progress in the event of a failure.
 	for metastorePath := range iterStorePaths(m.tenantID, minTimestamp, maxTimestamp) {
+		if m.prefix != "" {
+			metastorePath = fmt.Sprintf("%s/%s", m.prefix, metastorePath)
+		}
 		m.backoff.Reset()
 		for m.backoff.Ongoing() {
 			err = m.bucket.GetAndReplace(ctx, metastorePath, func(existing io.Reader) (io.Reader, error) {

--- a/pkg/dataobj/metastore/updater.go
+++ b/pkg/dataobj/metastore/updater.go
@@ -3,7 +3,6 @@ package metastore
 import (
 	"bytes"
 	"context"
-	fmt "fmt"
 	"io"
 	"strconv"
 	"sync"
@@ -41,7 +40,6 @@ var metastoreBuilderCfg = logsobj.BuilderConfig{
 
 type Updater struct {
 	metastoreBuilder *logsobj.Builder
-	prefix           string
 	tenantID         string
 	metrics          *metastoreMetrics
 	bucket           objstore.Bucket
@@ -104,9 +102,6 @@ func (m *Updater) Update(ctx context.Context, dataobjPath string, minTimestamp, 
 	// Work our way through the metastore objects window by window, updating & creating them as needed.
 	// Each one handles its own retries in order to keep making progress in the event of a failure.
 	for metastorePath := range iterStorePaths(m.tenantID, minTimestamp, maxTimestamp) {
-		if m.prefix != "" {
-			metastorePath = fmt.Sprintf("%s/%s", m.prefix, metastorePath)
-		}
 		m.backoff.Reset()
 		for m.backoff.Ongoing() {
 			err = m.bucket.GetAndReplace(ctx, metastorePath, func(existing io.Reader) (io.Reader, error) {

--- a/pkg/dataobj/querier/metadata_test.go
+++ b/pkg/dataobj/querier/metadata_test.go
@@ -24,7 +24,7 @@ func TestStore_SelectSeries(t *testing.T) {
 
 	// Setup test data
 	now := setupTestData(t, builder)
-	meta := metastore.NewObjectMetastore(builder.bucket, log.NewNopLogger())
+	meta := metastore.NewObjectMetastore(builder.bucket, log.NewNopLogger(), nil)
 	store := NewStore(builder.bucket, log.NewNopLogger(), meta)
 	ctx := user.InjectOrgID(context.Background(), testTenant)
 
@@ -167,7 +167,7 @@ func TestStore_LabelNamesForMetricName(t *testing.T) {
 
 	// Setup test data
 	now := setupTestData(t, builder)
-	meta := metastore.NewObjectMetastore(builder.bucket, log.NewNopLogger())
+	meta := metastore.NewObjectMetastore(builder.bucket, log.NewNopLogger(), nil)
 	store := NewStore(builder.bucket, log.NewNopLogger(), meta)
 	ctx := user.InjectOrgID(context.Background(), testTenant)
 
@@ -235,7 +235,7 @@ func TestStore_LabelValuesForMetricName(t *testing.T) {
 
 	// Setup test data
 	now := setupTestData(t, builder)
-	meta := metastore.NewObjectMetastore(builder.bucket, log.NewNopLogger())
+	meta := metastore.NewObjectMetastore(builder.bucket, log.NewNopLogger(), nil)
 	store := NewStore(builder.bucket, log.NewNopLogger(), meta)
 	ctx := user.InjectOrgID(context.Background(), testTenant)
 

--- a/pkg/dataobj/querier/store_test.go
+++ b/pkg/dataobj/querier/store_test.go
@@ -42,7 +42,7 @@ func TestStore_SelectSamples(t *testing.T) {
 
 	// Setup test data
 	now := setupTestData(t, builder)
-	meta := metastore.NewObjectMetastore(builder.bucket, log.NewNopLogger())
+	meta := metastore.NewObjectMetastore(builder.bucket, log.NewNopLogger(), nil)
 	store := NewStore(builder.bucket, log.NewNopLogger(), meta)
 	ctx := user.InjectOrgID(context.Background(), testTenant)
 
@@ -230,7 +230,7 @@ func TestStore_SelectLogs(t *testing.T) {
 
 	// Setup test data
 	now := setupTestData(t, builder)
-	meta := metastore.NewObjectMetastore(builder.bucket, log.NewNopLogger())
+	meta := metastore.NewObjectMetastore(builder.bucket, log.NewNopLogger(), nil)
 	store := NewStore(builder.bucket, log.NewLogfmtLogger(os.Stdout), meta)
 	ctx := user.InjectOrgID(context.Background(), testTenant)
 

--- a/pkg/dataobj/sections/pointers/row_predicate.go
+++ b/pkg/dataobj/sections/pointers/row_predicate.go
@@ -1,5 +1,7 @@
 package pointers
 
+import "time"
+
 type (
 	// RowPredicate is an expression used to filter rows in a data object.
 	RowPredicate interface{ isRowPredicate() }
@@ -7,9 +9,19 @@ type (
 
 // Supported predicates.
 type (
+	// An AndRowPredicate is a RowPredicate which requires both its Left and
+	// Right predicate to be true.
+	AndRowPredicate struct{ Left, Right RowPredicate }
+
 	// A BloomExistencePredicate is a RowPredicate which requires a bloom filter column named
 	// Name to exist, and for the Value to pass the bloom filter.
 	BloomExistencePredicate struct{ Name, Value string }
+
+	// A TimeRangePredicate is a RowPredicate which requires the timestamp of
+	// the entry to be within the range of StartTime and EndTime.
+	TimeRangePredicate struct{ Start, End time.Time }
 )
 
+func (AndRowPredicate) isRowPredicate()         {}
 func (BloomExistencePredicate) isRowPredicate() {}
+func (TimeRangePredicate) isRowPredicate()      {}

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -13,6 +13,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/thanos-io/objstore"
 
+	"github.com/grafana/loki/v3/pkg/dataobj/cachingbucket"
 	"github.com/grafana/loki/v3/pkg/dataobj/metastore"
 	"github.com/grafana/loki/v3/pkg/engine/executor"
 	"github.com/grafana/loki/v3/pkg/engine/planner/logical"
@@ -30,6 +31,10 @@ var (
 
 // New creates a new instance of the query engine that implements the [logql.Engine] interface.
 func New(opts logql.EngineOpts, bucket objstore.Bucket, limits logql.Limits, reg prometheus.Registerer, logger log.Logger) *QueryEngine {
+
+	// nocommit
+	// just testing
+	bucket = cachingbucket.New(bucket, "dataobj-dev")
 
 	var ms metastore.Metastore
 	if bucket != nil {

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -38,8 +38,7 @@ func New(opts logql.EngineOpts, bucket objstore.Bucket, limits logql.Limits, reg
 
 	var ms metastore.Metastore
 	if bucket != nil {
-		// TODO(benclive): Grab this from config instead of hardcoding it
-		metastoreBucket := objstore.NewPrefixedBucket(bucket, "indexing-v0/")
+		metastoreBucket := objstore.NewPrefixedBucket(bucket, opts.CataloguePath)
 		ms = metastore.NewObjectMetastore(metastoreBucket, logger)
 	}
 
@@ -99,7 +98,7 @@ func (e *QueryEngine) Execute(ctx context.Context, params logql.Params) (logqlmo
 
 	t = time.Now() // start stopwatch for physical planning
 	statsCtx, ctx := stats.NewContext(ctx)
-	catalog := physical.NewMetastoreCatalog(ctx, e.metastore)
+	catalog := physical.NewMetastoreCatalog(ctx, e.metastore, e.opts.CatalogueType)
 	planner := physical.NewPlanner(physical.NewContext(params.Start(), params.End()), catalog)
 	plan, err := planner.Build(logicalPlan)
 	if err != nil {

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -13,7 +13,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/thanos-io/objstore"
 
-	"github.com/grafana/loki/v3/pkg/dataobj/cachingbucket"
 	"github.com/grafana/loki/v3/pkg/dataobj/metastore"
 	"github.com/grafana/loki/v3/pkg/engine/executor"
 	"github.com/grafana/loki/v3/pkg/engine/planner/logical"
@@ -25,21 +24,14 @@ import (
 	utillog "github.com/grafana/loki/v3/pkg/util/log"
 )
 
-var (
-	ErrNotSupported = errors.New("feature not supported in new query engine")
-)
+var ErrNotSupported = errors.New("feature not supported in new query engine")
 
 // New creates a new instance of the query engine that implements the [logql.Engine] interface.
 func New(opts logql.EngineOpts, bucket objstore.Bucket, limits logql.Limits, reg prometheus.Registerer, logger log.Logger) *QueryEngine {
-
-	// nocommit
-	// just testing
-	bucket = cachingbucket.New(bucket, "dataobj-dev")
-
 	var ms metastore.Metastore
 	if bucket != nil {
 		metastoreBucket := objstore.NewPrefixedBucket(bucket, opts.CataloguePath)
-		ms = metastore.NewObjectMetastore(metastoreBucket, logger)
+		ms = metastore.NewObjectMetastore(metastoreBucket, logger, reg)
 	}
 
 	return &QueryEngine{
@@ -77,6 +69,7 @@ func (e *QueryEngine) Query(params logql.Params) logql.Query {
 //  3. Evaluate the physical plan with the executor.
 func (e *QueryEngine) Execute(ctx context.Context, params logql.Params) (logqlmodel.Result, error) {
 	start := time.Now()
+
 	logger := utillog.WithContext(ctx, e.logger)
 	logger = log.With(logger, "query", params.QueryString(), "shard", strings.Join(params.Shards(), ","), "engine", "v2")
 

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -33,7 +33,9 @@ func New(opts logql.EngineOpts, bucket objstore.Bucket, limits logql.Limits, reg
 
 	var ms metastore.Metastore
 	if bucket != nil {
-		ms = metastore.NewObjectMetastore(bucket, logger)
+		// TODO(benclive): Grab this from config instead of hardcoding it
+		metastoreBucket := objstore.NewPrefixedBucket(bucket, "indexing-v0/")
+		ms = metastore.NewObjectMetastore(metastoreBucket, logger)
 	}
 
 	return &QueryEngine{
@@ -71,7 +73,6 @@ func (e *QueryEngine) Query(params logql.Params) logql.Query {
 //  3. Evaluate the physical plan with the executor.
 func (e *QueryEngine) Execute(ctx context.Context, params logql.Params) (logqlmodel.Result, error) {
 	start := time.Now()
-
 	logger := utillog.WithContext(ctx, e.logger)
 	logger = log.With(logger, "query", params.QueryString(), "shard", strings.Join(params.Shards(), ","), "engine", "v2")
 

--- a/pkg/engine/executor/executor.go
+++ b/pkg/engine/executor/executor.go
@@ -1,9 +1,11 @@
 package executor
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"io"
 
 	"github.com/thanos-io/objstore"
 
@@ -83,7 +85,18 @@ func (c *Context) executeDataObjScan(ctx context.Context, node *physical.DataObj
 		predicates = append(predicates, conv)
 	}
 
-	obj, err := dataobj.FromBucket(ctx, c.bucket, string(node.Location))
+	// TODO(benclive): Do not merge Get & ReaderAt, it's just for testing without having to download whole objects constantly, as I have a FS cache in place.
+	// nocommit
+	objReader, err := c.bucket.Get(ctx, string(node.Location))
+	if err != nil {
+		return errorPipeline(fmt.Errorf("getting data object: %w", err))
+	}
+	buf, err := io.ReadAll(objReader)
+	if err != nil {
+		return errorPipeline(fmt.Errorf("reading data object: %w", err))
+	}
+
+	obj, err := dataobj.FromReaderAt(bytes.NewReader(buf), int64(len(buf)))
 	if err != nil {
 		return errorPipeline(fmt.Errorf("creating data object: %w", err))
 	}

--- a/pkg/engine/executor/executor.go
+++ b/pkg/engine/executor/executor.go
@@ -1,11 +1,9 @@
 package executor
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
-	"io"
 
 	"github.com/thanos-io/objstore"
 
@@ -85,18 +83,7 @@ func (c *Context) executeDataObjScan(ctx context.Context, node *physical.DataObj
 		predicates = append(predicates, conv)
 	}
 
-	// TODO(benclive): Do not merge Get & ReaderAt, it's just for testing without having to download whole objects constantly, as I have a FS cache in place.
-	// nocommit
-	objReader, err := c.bucket.Get(ctx, string(node.Location))
-	if err != nil {
-		return errorPipeline(fmt.Errorf("getting data object: %w", err))
-	}
-	buf, err := io.ReadAll(objReader)
-	if err != nil {
-		return errorPipeline(fmt.Errorf("reading data object: %w", err))
-	}
-
-	obj, err := dataobj.FromReaderAt(bytes.NewReader(buf), int64(len(buf)))
+	obj, err := dataobj.FromBucket(ctx, c.bucket, string(node.Location))
 	if err != nil {
 		return errorPipeline(fmt.Errorf("creating data object: %w", err))
 	}

--- a/pkg/engine/planner/logical/logical_test.go
+++ b/pkg/engine/planner/logical/logical_test.go
@@ -41,7 +41,7 @@ func TestPlan_String(t *testing.T) {
 	// Define expected output
 	exp := `
 %1 = EQ label.app "users"
-%2 = MAKETABLE [selector=%1, shard=0_of_1]
+%2 = MAKETABLE [selector=%1, predicates=[], shard=0_of_1]
 %3 = GT metadata.age 21
 %4 = SELECT %2 [predicate=%3]
 %5 = SORT %4 [column=metadata.age, asc=true, nulls_first=false]

--- a/pkg/engine/planner/logical/planner.go
+++ b/pkg/engine/planner/logical/planner.go
@@ -93,8 +93,9 @@ func buildPlanForLogQuery(expr syntax.LogSelectorExpr, params logql.Params, isMe
 	// MAKETABLE -> DataObjScan
 	builder := NewBuilder(
 		&MakeTable{
-			Selector: selector,
-			Shard:    shard,
+			Selector:   selector,
+			Predicates: predicates,
+			Shard:      shard,
 		},
 	)
 

--- a/pkg/engine/planner/logical/planner_test.go
+++ b/pkg/engine/planner/logical/planner_test.go
@@ -93,7 +93,7 @@ func TestConvertAST_Success(t *testing.T) {
 	expected := `%1 = EQ label.cluster "prod"
 %2 = MATCH_RE label.namespace "loki-.*"
 %3 = AND %1 %2
-%4 = MAKETABLE [selector=%3, shard=0_of_1]
+%4 = MAKETABLE [selector=%3, predicates=[%12, %18], shard=0_of_1]
 %5 = SORT %4 [column=builtin.timestamp, asc=true, nulls_first=false]
 %6 = GTE builtin.timestamp 1970-01-01T01:00:00Z
 %7 = SELECT %5 [predicate=%6]
@@ -136,7 +136,7 @@ func TestConvertAST_MetricQuery_Success(t *testing.T) {
 	expected := `%1 = EQ label.cluster "prod"
 %2 = MATCH_RE label.namespace "loki-.*"
 %3 = AND %1 %2
-%4 = MAKETABLE [selector=%3, shard=0_of_1]
+%4 = MAKETABLE [selector=%3, predicates=[%9], shard=0_of_1]
 %5 = GTE builtin.timestamp 1970-01-01T00:55:00Z
 %6 = SELECT %4 [predicate=%5]
 %7 = LT builtin.timestamp 1970-01-01T02:00:00Z

--- a/pkg/engine/planner/physical/catalog.go
+++ b/pkg/engine/planner/physical/catalog.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"time"
 
 	"github.com/prometheus/prometheus/model/labels"
@@ -77,12 +78,37 @@ func (c *MetastoreCatalog) ResolveDataObjWithShard(selector Expression, shard Sh
 		return nil, nil, nil, fmt.Errorf("failed to convert selector expression into matchers: %w", err)
 	}
 
+<<<<<<< HEAD:pkg/engine/planner/physical/catalog.go
 	paths, streamIDs, numSections, err := c.metastore.StreamIDs(c.ctx, from, through, matchers...)
+=======
+	sections, err := c.metastore.StreamIDsBySections(c.ctx, c.from, c.through, matchers...)
+>>>>>>> 98d7d9dc9d (WIP):pkg/engine/planner/physical/context.go
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to resolve data object locations: %w", err)
 	}
+	fmt.Printf("sections=%d\n", len(sections))
 
-	return filterForShard(shard, paths, streamIDs, numSections)
+	return filterDescriptorsForShard(shard, sections)
+
+	/*
+		 	paths, streamIDs, numSections, err := c.metastore.StreamIDs(c.ctx, c.from, c.through, matchers...)
+			if err != nil {
+				return nil, nil, nil, fmt.Errorf("failed to resolve data object locations: %w", err)
+			}
+
+			locations, streams, objectSections, err := filterForShard(shard, paths, streamIDs, numSections)
+			if err != nil {
+				return nil, nil, nil, fmt.Errorf("failed to filter for shard: %w", err)
+			}
+
+			sectionsCount := 0
+			for _, section := range objectSections {
+				sectionsCount += len(section)
+			}
+			fmt.Printf("StreamIDs: sectionsCount=%d\n", sectionsCount)
+
+			return locations, streams, objectSections, nil
+	*/
 }
 
 func filterForShard(shard ShardInfo, paths []string, streamIDs [][]int64, numSections []int) ([]DataObjLocation, [][]int64, [][]int, error) {
@@ -105,12 +131,6 @@ func filterForShard(shard ShardInfo, paths []string, streamIDs [][]int64, numSec
 			locations = append(locations, DataObjLocation(paths[i]))
 			streams = append(streams, streamIDs[i])
 			sections = append(sections, sec)
-
-			// {
-			//   location: "path/abcd/object"
-			//   streamIDs: [1, 2, 3]
-			//   sections: [1, 3, 5]
-			// }
 		}
 	}
 
@@ -120,14 +140,14 @@ func filterForShard(shard ShardInfo, paths []string, streamIDs [][]int64, numSec
 // ResolveDataObj resolves DataObj locations and streams IDs based on a given
 // [Expression]. The expression is required to be a (tree of) [BinaryExpression]
 // with a [ColumnExpression] on the left and a [LiteralExpression] on the right.
-func (c *Context) ResolveSections(selector Expression, tableHint Expression) ([]metastore.DataobjSectionDescriptor, error) {
+func (c *Context) ResolveSections(selector Expression, shard ShardInfo) ([]DataObjLocation, [][]int64, [][]int, error) {
 	if c.metastore == nil {
-		return nil, errors.New("no metastore to resolve objects")
+		return nil, nil, nil, errors.New("no metastore to resolve objects")
 	}
 
 	matchers, err := expressionToMatchers(selector)
 	if err != nil {
-		return nil, fmt.Errorf("failed to convert selector expression into matchers: %w", err)
+		return nil, nil, nil, fmt.Errorf("failed to convert selector expression into matchers: %w", err)
 	}
 
 	/* 	// TODO(benclive): Handle these ambiguous column cases in a less hacky way
@@ -138,10 +158,68 @@ func (c *Context) ResolveSections(selector Expression, tableHint Expression) ([]
 
 	sectionDescriptors, err := c.metastore.StreamIDsBySections(c.ctx, c.from, c.through, matchers...)
 	if err != nil {
-		return nil, fmt.Errorf("failed to resolve data object locations: %w", err)
+		return nil, nil, nil, fmt.Errorf("failed to resolve data object locations: %w", err)
 	}
 
-	return sectionDescriptors, err
+	return filterDescriptorsForShard(shard, sectionDescriptors)
+}
+
+// filterDescriptorsForShard filters the section descriptors for a given shard.
+// It returns the locations, streams, and sections for the shard.
+// It loses information because it doesn't map streamIDs to sections.
+func filterDescriptorsForShard(shard ShardInfo, sectionDescriptors []metastore.DataobjSectionDescriptor) ([]DataObjLocation, [][]int64, [][]int, error) {
+	index := make(map[DataObjLocation]int)
+
+	locations := make([]DataObjLocation, 0, len(sectionDescriptors))
+	streams := make([][]int64, 0, len(sectionDescriptors))
+	sections := make([][]int, 0, len(sectionDescriptors))
+
+	for _, desc := range sectionDescriptors {
+		idx, ok := index[DataObjLocation(desc.ObjectPath)]
+		if !ok {
+			idx = len(index)
+			index[DataObjLocation(desc.ObjectPath)] = idx
+			locations = append(locations, DataObjLocation(desc.ObjectPath))
+			streams = append(streams, []int64{})
+			sections = append(sections, []int{})
+		}
+
+		if int(desc.SectionIdx)%int(shard.Of) == int(shard.Shard) {
+			streams[idx] = append(streams[idx], desc.StreamIDs...)
+			sections[idx] = append(sections[idx], int(desc.SectionIdx))
+		}
+	}
+
+	for i := range streams {
+		sort.Slice(streams[i], func(j, k int) bool { return streams[i][j] < streams[i][k] })
+		sort.Slice(sections[i], func(j, k int) bool { return sections[i][j] < sections[i][k] })
+		streams[i] = uniquelong(streams[i])
+		sections[i] = uniqueint(sections[i])
+	}
+
+	return locations, streams, sections, nil
+}
+
+func uniqueint(s []int) []int {
+	next := 0
+	for i := range s {
+		if s[i] != s[next] {
+			next++
+			s[next] = s[i]
+		}
+	}
+	return s[:next+1]
+}
+
+func uniquelong(s []int64) []int64 {
+	next := 0
+	for i := range s {
+		if s[i] != s[next] {
+			next++
+			s[next] = s[i]
+		}
+	}
+	return s[:next+1]
 }
 
 func expressionToMatchers(selector Expression) ([]*labels.Matcher, error) {

--- a/pkg/engine/planner/physical/catalog_test.go
+++ b/pkg/engine/planner/physical/catalog_test.go
@@ -96,7 +96,7 @@ func TestCatalog_ConvertColumnRef(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.expr.String(), func(t *testing.T) {
-			got, err := convertColumnRef(tt.expr)
+			got, err := convertColumnRef(tt.expr, false)
 			if tt.wantErr {
 				require.Error(t, err)
 				t.Log(err)
@@ -154,7 +154,7 @@ func TestCatalog_ExpressionToMatchers(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.expr.String(), func(t *testing.T) {
-			got, err := expressionToMatchers(tt.expr)
+			got, err := expressionToMatchers(tt.expr, false)
 			if tt.wantErr {
 				require.Error(t, err)
 				t.Log(err)

--- a/pkg/engine/planner/physical/planner.go
+++ b/pkg/engine/planner/physical/planner.go
@@ -157,8 +157,14 @@ func (p *Planner) processMakeTable(lp *logical.MakeTable, ctx *Context) ([]Node,
 		return nil, fmt.Errorf("invalid shard, got %T", lp.Shard)
 	}
 
+	predicates := make([]Expression, len(lp.Predicates))
+	for i, predicate := range lp.Predicates {
+		predicates[i] = p.convertPredicate(predicate)
+	}
+
 	from, through := ctx.GetResolveTimeRange()
-	objects, streams, sections, err := p.catalog.ResolveDataObjWithShard(p.convertPredicate(lp.Selector), ShardInfo(*shard), from, through)
+
+	objects, streams, sections, err := p.catalog.ResolveDataObjWithShard(p.convertPredicate(lp.Selector), predicates, ShardInfo(*shard), from, through)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/engine/planner/physical/planner_test.go
+++ b/pkg/engine/planner/physical/planner_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/loki/v3/pkg/dataobj/metastore"
 	"github.com/grafana/loki/v3/pkg/engine/internal/types"
 	"github.com/grafana/loki/v3/pkg/engine/planner/logical"
 )
@@ -49,6 +50,11 @@ func (c *catalog) ResolveDataObjWithShard(_ Expression, shard ShardInfo, _, _ ti
 	})
 
 	return filterForShard(shard, paths, streams, sections)
+}
+
+// ResolveSections implements Catalog.
+func (c *catalog) ResolveSections(expr, tableHint Expression) ([]metastore.DataobjSectionDescriptor, error) {
+	return c.ResolveSections(expr, tableHint)
 }
 
 var _ Catalog = (*catalog)(nil)

--- a/pkg/engine/planner/physical/planner_test.go
+++ b/pkg/engine/planner/physical/planner_test.go
@@ -23,11 +23,11 @@ type catalog struct {
 
 // ResolveDataObj implements Catalog.
 func (c *catalog) ResolveDataObj(e Expression, from, through time.Time) ([]DataObjLocation, [][]int64, [][]int, error) {
-	return c.ResolveDataObjWithShard(e, noShard, from, through)
+	return c.ResolveDataObjWithShard(e, nil, noShard, from, through)
 }
 
 // ResolveDataObjForShard implements Catalog.
-func (c *catalog) ResolveDataObjWithShard(_ Expression, shard ShardInfo, _, _ time.Time) ([]DataObjLocation, [][]int64, [][]int, error) {
+func (c *catalog) ResolveDataObjWithShard(_ Expression, _ []Expression, shard ShardInfo, _, _ time.Time) ([]DataObjLocation, [][]int64, [][]int, error) {
 	paths := make([]string, 0, len(c.streamsByObject))
 	streams := make([][]int64, 0, len(c.streamsByObject))
 	sections := make([]int, 0, len(c.streamsByObject))
@@ -105,7 +105,7 @@ func TestMockCatalog(t *testing.T) {
 		},
 	} {
 		t.Run("shard "+tt.shard.String(), func(t *testing.T) {
-			paths, streams, sections, _ := catalog.ResolveDataObjWithShard(nil, tt.shard, time.Now(), time.Now())
+			paths, streams, sections, _ := catalog.ResolveDataObjWithShard(nil, nil, tt.shard, time.Now(), time.Now())
 			require.Equal(t, tt.expPaths, paths)
 			require.Equal(t, tt.expStreams, streams)
 			require.Equal(t, tt.expSections, sections)

--- a/pkg/logql/bench/store_dataobj.go
+++ b/pkg/logql/bench/store_dataobj.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/thanos-io/objstore"
 	"github.com/thanos-io/objstore/providers/filesystem"
 
@@ -103,7 +104,7 @@ func (s *DataObjStore) Write(_ context.Context, streams []logproto.Stream) error
 }
 
 func (s *DataObjStore) Querier() (logql.Querier, error) {
-	return querier.NewStore(s.bucket, s.logger, metastore.NewObjectMetastore(s.bucket, s.logger)), nil
+	return querier.NewStore(s.bucket, s.logger, metastore.NewObjectMetastore(s.bucket, s.logger, prometheus.DefaultRegisterer)), nil
 }
 
 func (s *DataObjStore) flush() error {

--- a/pkg/logql/engine.go
+++ b/pkg/logql/engine.go
@@ -166,6 +166,11 @@ type EngineOpts struct {
 
 	// Batch size of the v2 execution engine.
 	BatchSize int `yaml:"batch_size" category:"experimental"`
+
+	// CataloguePath is the path to the catalogue in the object store.
+	CataloguePath string `yaml:"catalogue_path"`
+	// CatalogueType is the type of catalogue files at the catalogue path. Possible values are: direct, index
+	CatalogueType string `yaml:"catalogue_type"`
 }
 
 func (opts *EngineOpts) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
@@ -173,6 +178,8 @@ func (opts *EngineOpts) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) 
 	f.IntVar(&opts.MaxCountMinSketchHeapSize, prefix+"max-count-min-sketch-heap-size", 10_000, "The maximum number of labels the heap of a topk query using a count min sketch can track.")
 	f.BoolVar(&opts.EnableV2Engine, prefix+"enable-v2-engine", false, "Experimental: Enable next generation query engine for supported queries.")
 	f.IntVar(&opts.BatchSize, prefix+"batch-size", 100, "Experimental: Batch size of the next generation query engine.")
+	f.StringVar(&opts.CataloguePath, prefix+"catalogue-path", "index/v0/", "The path to the catalogue in the object store.")
+	f.StringVar(&opts.CatalogueType, prefix+"catalogue-type", "direct", "The type of the catalogue at the path. Possible values are: direct, index")
 	// Log executing query by default
 	opts.LogExecutingQuery = true
 }

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -547,7 +547,7 @@ func (t *Loki) getQuerierStore() (querier.Store, error) {
 	logger := log.With(util_log.Logger, "component", "dataobj-querier")
 	storeCombiner := querier.NewStoreCombiner([]querier.StoreConfig{
 		{
-			Store: dataobjquerier.NewStore(store, logger, metastore.NewObjectMetastore(store, logger)),
+			Store: dataobjquerier.NewStore(store, logger, metastore.NewObjectMetastore(store, logger, prometheus.DefaultRegisterer)),
 			From:  t.Cfg.DataObj.Querier.From.Time,
 		},
 		{


### PR DESCRIPTION
**What this PR does / why we need it**:
Integrates the new indexes with the query engine via the catalogue.

The bulk of the changes are in `object.go`

This is the first pass so it is missing a few things:
* The Sections() call to the metastore returns a list of section descriptors including a lot of information: start/end times of matching data in the section, total bytes, total lines and stream IDs within the section. Most of this information is unused when returning from the catalogue - this will be part of a follow up PR.
* DataobjScan probably needs to be updated to use the information. Again, this will be a follow up.
* I added a flag to switch between a metastore that contains indexes (what this PR adds support for) and a metastore that just contains log objects (what we have now). I intend to remove this distinction later once everything is merged and running.
* I do not return a list of unused predicates for the query engine to make use of yet.