### PR TITLE
docs: Update RN for 3.5.2

### DIFF
--- a/docs/sources/release-notes/v3-5.md
+++ b/docs/sources/release-notes/v3-5.md
@@ -73,7 +73,7 @@ For important upgrade guidance, refer to the [Upgrade Guide](https://grafana.com
 * **deps:** Move to Go 1.24.5 (backport release-3.5.x) ([#18412](https://github.com/grafana/loki/issues/18412)) ([4642c63](https://github.com/grafana/loki/commit/4642c639da0875928295b52d1a02d9ab46725db6)).
 * **frontend:** Allow resolution of v6 addresses. (backport release-3.5.x) ([#18261](https://github.com/grafana/loki/issues/18261)) ([aed4610](https://github.com/grafana/loki/commit/aed461037b9145ac8cc89813c40cfcad091ed6bf)).
 * **jsonparser:** Fix possible JSON log line corruption caused by `json` parser on query path (backport release-3.5.x) ([#18059](https://github.com/grafana/loki/issues/18059)) ([546d456](https://github.com/grafana/loki/commit/546d456b9d1d75154d1c2e42309933e346629c2b)).
-* **memberlist:** Allow resolution of advertise address from v6  interfaces defined in common `instance_interface_names`.(backport release-3.5.x) ([#18257](https://github.com/grafana/loki/issues/18257)) ([6f878ad](https://github.com/grafana/loki/commit/6f878ad1d02427df81b6684c7cb76711d6fee46a)).
+* **memberlist:** Allow resolution of advertise address from IPv6  interfaces defined in common `instance_interface_names`.(backport release-3.5.x) ([#18257](https://github.com/grafana/loki/issues/18257)) ([6f878ad](https://github.com/grafana/loki/commit/6f878ad1d02427df81b6684c7cb76711d6fee46a)).
 * **WAL:** Handle WAL corruption properly on startup (backport release-3.5.x) ([#18408](https://github.com/grafana/loki/issues/18408)) ([5b8ee9a](https://github.com/grafana/loki/commit/5b8ee9a582d168cbde2cb5a0bad48283069351d6)).
 
 ### 3.5.1 (2025-05-19)


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the 3.5 release notes for 3.5.1 and 3.5.2 patches.