### PR TITLE
docs: Update RN for 3.4.5

### DIFF
--- a/docs/sources/release-notes/v3-4.md
+++ b/docs/sources/release-notes/v3-4.md
@@ -67,6 +67,10 @@ Other improvements include the following:
 - **storage:** Allow TSDB index creation in memory only ([#14732](https://github.com/grafana/loki/issues/14732)) ([831c0d5](https://github.com/grafana/loki/commit/831c0d56b805318e95ed366a22605a4804dae1c8)).
 - **structured metadata:** Sanitize structured metadata during ingestion in the distributor ([#15141](https://github.com/grafana/loki/issues/15141)) ([be4f17e](https://github.com/grafana/loki/commit/be4f17eefe3df81dae060bf86890fe1054aeb2f2)).
 
+### 3.4.5 (2025-07-11)
+
+* **storage:** Add a configuration option for custom GCS endpoints ([#16419](https://github.com/grafana/loki/issues/16419)) ([#18419](https://github.com/grafana/loki/issues/18419)) ([b2c87ba](https://github.com/grafana/loki/commit/b2c87ba6b68ddcad2f9284df5821a4ce299a3c56)).
+
 ## Deprecations
 
 One of the focuses of Loki 3.0 was cleaning up unused code and old features that had been previously deprecated but not removed. Loki 3.0 removed a number of previous deprecations and introduces some new deprecations. Some of the main areas with changes include:
@@ -90,6 +94,12 @@ For important upgrade guidance, refer to the [Upgrade Guide](https://grafana.com
 - **BREAKING CHANGE - Docker image:** Remove `wget` from Promtail docker image ([#15101](https://github.com/grafana/loki/issues/15101)).
 
 ## Bug fixes
+
+### 3.4.5 (2025-07-11)
+
+* **frontend:** Allow resolution of v6 addresses. (backport release-3.4.x) ([#18260](https://github.com/grafana/loki/issues/18260)) ([93e0880](https://github.com/grafana/loki/commit/93e088034d871cbce5d479413a8fd16f04a02ebe)).
+* **memberlist:** Allow resolution of advertise address from IPv6  interfaces defined in common `instance_interface_names`.(backport release-3.4.x) ([#18256](https://github.com/grafana/loki/issues/18256)) ([640cd33](https://github.com/grafana/loki/commit/640cd331fe89bbd020e8c2359e1403a85d1f441d)).
+* **WAL:** Handle WAL corruption properly on startup (backport release-3.4.x) ([#18410](https://github.com/grafana/loki/issues/18410)) ([1ecc9e4](https://github.com/grafana/loki/commit/1ecc9e4315d5bb223525b4101c409a169fe8413e)).
 
 ### 3.4.4 (2025-06-09)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the 3.4 release notes for 3.4.5 patch.