### PR TITLE
chore(engine): Pass context to Pipeline's Read() function

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -165,9 +165,9 @@ func (e *QueryEngine) Execute(ctx context.Context, params logql.Params) (logqlmo
 	return builder.Build(), nil
 }
 
-func collectResult(_ context.Context, pipeline executor.Pipeline, builder ResultBuilder) error {
+func collectResult(ctx context.Context, pipeline executor.Pipeline, builder ResultBuilder) error {
 	for {
-		if err := pipeline.Read(); err != nil {
+		if err := pipeline.Read(ctx); err != nil {
 			if errors.Is(err, executor.EOF) {
 				break
 			}

--- a/pkg/engine/executor/dataobjscan_test.go
+++ b/pkg/engine/executor/dataobjscan_test.go
@@ -59,7 +59,7 @@ func Test_dataobjScan(t *testing.T) {
 	})
 
 	t.Run("All columns", func(t *testing.T) {
-		pipeline := newDataobjScanPipeline(t.Context(), dataobjScanOptions{
+		pipeline := newDataobjScanPipeline(dataobjScanOptions{
 			Object:      obj,
 			StreamIDs:   []int64{1, 2}, // All streams
 			Section:     0,             // First section.
@@ -91,7 +91,7 @@ prod,notloki,NULL,notloki-pod-1,1970-01-01 00:00:02,hello world`
 	})
 
 	t.Run("Column subset", func(t *testing.T) {
-		pipeline := newDataobjScanPipeline(t.Context(), dataobjScanOptions{
+		pipeline := newDataobjScanPipeline(dataobjScanOptions{
 			Object:    obj,
 			StreamIDs: []int64{1, 2}, // All streams
 			Section:   0,             // First section.
@@ -124,7 +124,7 @@ prod,notloki,NULL,notloki-pod-1,1970-01-01 00:00:02,hello world`
 	t.Run("Unknown column", func(t *testing.T) {
 		// Here, we'll check for a column which only exists once in the dataobj but is
 		// ambiguous from the perspective of the caller.
-		pipeline := newDataobjScanPipeline(t.Context(), dataobjScanOptions{
+		pipeline := newDataobjScanPipeline(dataobjScanOptions{
 			Object:    obj,
 			StreamIDs: []int64{1, 2}, // All streams
 			Section:   0,             // First section.
@@ -190,7 +190,7 @@ func Test_dataobjScan_DuplicateColumns(t *testing.T) {
 	})
 
 	t.Run("All columns", func(t *testing.T) {
-		pipeline := newDataobjScanPipeline(t.Context(), dataobjScanOptions{
+		pipeline := newDataobjScanPipeline(dataobjScanOptions{
 			Object:      obj,
 			StreamIDs:   []int64{1, 2, 3}, // All streams
 			Section:     0,                // First section.
@@ -225,7 +225,7 @@ prod,NULL,pod-1,loki,NULL,override,1970-01-01 00:00:01,message 1`
 	})
 
 	t.Run("Ambiguous pod", func(t *testing.T) {
-		pipeline := newDataobjScanPipeline(t.Context(), dataobjScanOptions{
+		pipeline := newDataobjScanPipeline(dataobjScanOptions{
 			Object:    obj,
 			StreamIDs: []int64{1, 2, 3}, // All streams
 			Section:   0,                // First section.
@@ -254,7 +254,7 @@ pod-1,override`
 	})
 
 	t.Run("Ambiguous namespace", func(t *testing.T) {
-		pipeline := newDataobjScanPipeline(t.Context(), dataobjScanOptions{
+		pipeline := newDataobjScanPipeline(dataobjScanOptions{
 			Object:    obj,
 			StreamIDs: []int64{1, 2, 3}, // All streams
 			Section:   0,

--- a/pkg/engine/executor/executor.go
+++ b/pkg/engine/executor/executor.go
@@ -88,7 +88,7 @@ func (c *Context) executeDataObjScan(ctx context.Context, node *physical.DataObj
 		return errorPipeline(fmt.Errorf("creating data object: %w", err))
 	}
 
-	return newDataobjScanPipeline(ctx, dataobjScanOptions{
+	return newDataobjScanPipeline(dataobjScanOptions{
 		Object:      obj,
 		StreamIDs:   node.StreamIDs,
 		Section:     node.Section,

--- a/pkg/engine/executor/executor_test.go
+++ b/pkg/engine/executor/executor_test.go
@@ -1,7 +1,6 @@
 package executor
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -11,79 +10,89 @@ import (
 
 func TestExecutor(t *testing.T) {
 	t.Run("pipeline fails if plan is nil", func(t *testing.T) {
-		pipeline := Run(context.TODO(), Config{}, nil)
-		err := pipeline.Read()
+		ctx := t.Context()
+		pipeline := Run(ctx, Config{}, nil)
+		err := pipeline.Read(ctx)
 		require.ErrorContains(t, err, "failed to execute pipeline: plan is nil")
 	})
 
 	t.Run("pipeline fails if plan has no root node", func(t *testing.T) {
-		pipeline := Run(context.TODO(), Config{}, &physical.Plan{})
-		err := pipeline.Read()
+		ctx := t.Context()
+		pipeline := Run(ctx, Config{}, &physical.Plan{})
+		err := pipeline.Read(ctx)
 		require.ErrorContains(t, err, "failed to execute pipeline: plan has no root node")
 	})
 }
 
 func TestExecutor_SortMerge(t *testing.T) {
 	t.Run("no inputs result in empty pipeline", func(t *testing.T) {
+		ctx := t.Context()
 		c := &Context{}
-		pipeline := c.executeSortMerge(context.TODO(), &physical.SortMerge{}, nil)
-		err := pipeline.Read()
+		pipeline := c.executeSortMerge(ctx, &physical.SortMerge{}, nil)
+		err := pipeline.Read(ctx)
 		require.ErrorContains(t, err, EOF.Error())
 	})
 }
 
 func TestExecutor_Limit(t *testing.T) {
 	t.Run("no inputs result in empty pipeline", func(t *testing.T) {
+		ctx := t.Context()
 		c := &Context{}
-		pipeline := c.executeLimit(context.TODO(), &physical.Limit{}, nil)
-		err := pipeline.Read()
+		pipeline := c.executeLimit(ctx, &physical.Limit{}, nil)
+		err := pipeline.Read(ctx)
 		require.ErrorContains(t, err, EOF.Error())
 	})
 
 	t.Run("multiple inputs result in error", func(t *testing.T) {
+		ctx := t.Context()
 		c := &Context{}
-		pipeline := c.executeLimit(context.TODO(), &physical.Limit{}, []Pipeline{emptyPipeline(), emptyPipeline()})
-		err := pipeline.Read()
+		pipeline := c.executeLimit(ctx, &physical.Limit{}, []Pipeline{emptyPipeline(), emptyPipeline()})
+		err := pipeline.Read(ctx)
 		require.ErrorContains(t, err, "limit expects exactly one input, got 2")
 	})
 }
 
 func TestExecutor_Filter(t *testing.T) {
 	t.Run("no inputs result in empty pipeline", func(t *testing.T) {
+		ctx := t.Context()
 		c := &Context{}
-		pipeline := c.executeFilter(context.TODO(), &physical.Filter{}, nil)
-		err := pipeline.Read()
+		pipeline := c.executeFilter(ctx, &physical.Filter{}, nil)
+		err := pipeline.Read(ctx)
 		require.ErrorContains(t, err, EOF.Error())
 	})
 
 	t.Run("multiple inputs result in error", func(t *testing.T) {
+		ctx := t.Context()
 		c := &Context{}
-		pipeline := c.executeFilter(context.TODO(), &physical.Filter{}, []Pipeline{emptyPipeline(), emptyPipeline()})
-		err := pipeline.Read()
+		pipeline := c.executeFilter(ctx, &physical.Filter{}, []Pipeline{emptyPipeline(), emptyPipeline()})
+		err := pipeline.Read(ctx)
 		require.ErrorContains(t, err, "filter expects exactly one input, got 2")
 	})
 }
 
 func TestExecutor_Projection(t *testing.T) {
 	t.Run("no inputs result in empty pipeline", func(t *testing.T) {
+		ctx := t.Context()
 		c := &Context{}
-		pipeline := c.executeProjection(context.TODO(), &physical.Projection{}, nil)
-		err := pipeline.Read()
+		pipeline := c.executeProjection(ctx, &physical.Projection{}, nil)
+		err := pipeline.Read(ctx)
 		require.ErrorContains(t, err, EOF.Error())
 	})
 
 	t.Run("missing column expression results in error", func(t *testing.T) {
+		ctx := t.Context()
 		cols := []physical.ColumnExpression{}
 		c := &Context{}
-		pipeline := c.executeProjection(context.TODO(), &physical.Projection{Columns: cols}, []Pipeline{emptyPipeline()})
-		err := pipeline.Read()
+		pipeline := c.executeProjection(ctx, &physical.Projection{Columns: cols}, []Pipeline{emptyPipeline()})
+		err := pipeline.Read(ctx)
 		require.ErrorContains(t, err, "projection expects at least one column, got 0")
 	})
 
 	t.Run("multiple inputs result in error", func(t *testing.T) {
+		ctx := t.Context()
 		c := &Context{}
-		pipeline := c.executeProjection(context.TODO(), &physical.Projection{}, []Pipeline{emptyPipeline(), emptyPipeline()})
-		err := pipeline.Read()
+		pipeline := c.executeProjection(ctx, &physical.Projection{}, []Pipeline{emptyPipeline(), emptyPipeline()})
+		err := pipeline.Read(ctx)
 		require.ErrorContains(t, err, "projection expects exactly one input, got 2")
 	})
 }

--- a/pkg/engine/executor/filter.go
+++ b/pkg/engine/executor/filter.go
@@ -1,6 +1,7 @@
 package executor
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/apache/arrow-go/v18/arrow"
@@ -11,10 +12,10 @@ import (
 )
 
 func NewFilterPipeline(filter *physical.Filter, input Pipeline, evaluator expressionEvaluator) *GenericPipeline {
-	return newGenericPipeline(Local, func(inputs []Pipeline) state {
+	return newGenericPipeline(Local, func(ctx context.Context, inputs []Pipeline) state {
 		// Pull the next item from the input pipeline
 		input := inputs[0]
-		err := input.Read()
+		err := input.Read(ctx)
 		if err != nil {
 			return failureState(err)
 		}

--- a/pkg/engine/executor/limit.go
+++ b/pkg/engine/executor/limit.go
@@ -1,6 +1,8 @@
 package executor
 
 import (
+	"context"
+
 	"github.com/apache/arrow-go/v18/arrow"
 )
 
@@ -12,7 +14,7 @@ func NewLimitPipeline(input Pipeline, skip, fetch uint32) *GenericPipeline {
 		limitRemaining  = int64(fetch)
 	)
 
-	return newGenericPipeline(Local, func(inputs []Pipeline) state {
+	return newGenericPipeline(Local, func(ctx context.Context, inputs []Pipeline) state {
 		var length int64
 		var start, end int64
 		var batch arrow.Record
@@ -26,7 +28,7 @@ func NewLimitPipeline(input Pipeline, skip, fetch uint32) *GenericPipeline {
 
 			// Pull the next item from input
 			input := inputs[0]
-			err := input.Read()
+			err := input.Read(ctx)
 			if err != nil {
 				return failureState(err)
 			}

--- a/pkg/engine/executor/limit_test.go
+++ b/pkg/engine/executor/limit_test.go
@@ -13,23 +13,25 @@ import (
 
 func TestExecuteLimit(t *testing.T) {
 	// Simple test to verify the Context.executeLimit method
-	ctx := context.Background()
 	c := &Context{}
 
 	t.Run("with no inputs", func(t *testing.T) {
+		ctx := t.Context()
 		pipeline := c.executeLimit(ctx, &physical.Limit{}, nil)
-		err := pipeline.Read()
+		err := pipeline.Read(ctx)
 		require.Equal(t, EOF, err)
 	})
 
 	t.Run("with multiple inputs", func(t *testing.T) {
+		ctx := t.Context()
 		pipeline := c.executeLimit(ctx, &physical.Limit{}, []Pipeline{emptyPipeline(), emptyPipeline()})
-		err := pipeline.Read()
+		err := pipeline.Read(ctx)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "limit expects exactly one input, got 2")
 	})
 
 	t.Run("with valid input", func(t *testing.T) {
+		ctx := t.Context()
 		// Create test data
 		fields := []arrow.Field{
 			{Name: "name", Type: datatype.Arrow.String},
@@ -48,7 +50,7 @@ func TestExecuteLimit(t *testing.T) {
 		defer pipeline.Close()
 
 		// Read from the pipeline
-		err = pipeline.Read()
+		err = pipeline.Read(ctx)
 		require.NoError(t, err)
 
 		batch, err := pipeline.Value()
@@ -62,12 +64,13 @@ func TestExecuteLimit(t *testing.T) {
 		require.Equal(t, "Bob", batch.Column(0).ValueStr(0))
 
 		// Next read should return EOF
-		err = pipeline.Read()
+		err = pipeline.Read(ctx)
 		require.Equal(t, EOF, err)
 	})
 
 	// Test with desired rows split across 2 batches
 	t.Run("with rows split across batches", func(t *testing.T) {
+		ctx := t.Context()
 		// Create schema with a single string column
 		fields := []arrow.Field{
 			{Name: "letter", Type: datatype.Arrow.String},
@@ -136,8 +139,10 @@ func TestLimitPipeline_Skip_Fetch(t *testing.T) {
 	limit := NewLimitPipeline(source, 3, 4)
 	defer limit.Close()
 
+	ctx := t.Context()
+
 	// Test first read
-	err = limit.Read()
+	err = limit.Read(ctx)
 	require.NoError(t, err)
 
 	batch, err := limit.Value()
@@ -153,7 +158,7 @@ func TestLimitPipeline_Skip_Fetch(t *testing.T) {
 	}
 
 	// Next read should be EOF
-	err = limit.Read()
+	err = limit.Read(ctx)
 	require.Equal(t, EOF, err)
 }
 

--- a/pkg/engine/executor/pipeline_utils.go
+++ b/pkg/engine/executor/pipeline_utils.go
@@ -1,6 +1,10 @@
 package executor
 
-import "github.com/apache/arrow-go/v18/arrow"
+import (
+	"context"
+
+	"github.com/apache/arrow-go/v18/arrow"
+)
 
 // BufferedPipeline is a pipeline implementation that reads from a fixed set of Arrow records.
 // It implements the Pipeline interface and serves as a simple source for testing and data injection.
@@ -28,7 +32,7 @@ func NewBufferedPipeline(records ...arrow.Record) *BufferedPipeline {
 
 // Read implements Pipeline.
 // It advances to the next record and returns EOF when all records have been read.
-func (p *BufferedPipeline) Read() error {
+func (p *BufferedPipeline) Read(_ context.Context) error {
 	// Release previous record if it exists
 	if p.state.batch != nil {
 		p.state.batch.Release()

--- a/pkg/engine/executor/pipeline_utils_test.go
+++ b/pkg/engine/executor/pipeline_utils_test.go
@@ -13,6 +13,8 @@ import (
 // AssertPipelinesEqual iterates through two pipelines and ensures they contain
 // the same data, regardless of batch sizes. It compares row by row and column by column.
 func AssertPipelinesEqual(t testing.TB, left, right Pipeline) {
+	ctx := t.Context()
+
 	defer left.Close()
 	defer right.Close()
 
@@ -32,7 +34,7 @@ func AssertPipelinesEqual(t testing.TB, left, right Pipeline) {
 				leftBatch = nil
 			}
 
-			leftErr = left.Read()
+			leftErr = left.Read(ctx)
 			if leftErr == nil {
 				leftBatch, leftErr = left.Value()
 				if leftErr == nil {
@@ -48,7 +50,7 @@ func AssertPipelinesEqual(t testing.TB, left, right Pipeline) {
 				rightBatch = nil
 			}
 
-			rightErr = right.Read()
+			rightErr = right.Read(ctx)
 			if rightErr == nil {
 				rightBatch, rightErr = right.Value()
 				if rightErr == nil {

--- a/pkg/engine/executor/project.go
+++ b/pkg/engine/executor/project.go
@@ -1,6 +1,7 @@
 package executor
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/apache/arrow-go/v18/arrow"
@@ -22,10 +23,10 @@ func NewProjectPipeline(input Pipeline, columns []physical.ColumnExpression, eva
 		}
 	}
 
-	return newGenericPipeline(Local, func(inputs []Pipeline) state {
+	return newGenericPipeline(Local, func(ctx context.Context, inputs []Pipeline) state {
 		// Pull the next item from the input pipeline
 		input := inputs[0]
-		err := input.Read()
+		err := input.Read(ctx)
 		if err != nil {
 			return failureState(err)
 		}

--- a/pkg/engine/executor/range_aggregation_test.go
+++ b/pkg/engine/executor/range_aggregation_test.go
@@ -88,7 +88,7 @@ func TestRangeAggregationPipeline(t *testing.T) {
 	defer pipeline.Close()
 
 	// Read the pipeline output
-	err = pipeline.Read()
+	err = pipeline.Read(t.Context())
 	require.NoError(t, err)
 	record, err := pipeline.Value()
 	require.NoError(t, err)

--- a/pkg/engine/executor/sortmerge_test.go
+++ b/pkg/engine/executor/sortmerge_test.go
@@ -40,7 +40,8 @@ func TestSortMerge(t *testing.T) {
 		pipeline, err := NewSortMergePipeline(inputs, merge.Order, merge.Column, expressionEvaluator{})
 		require.NoError(t, err)
 
-		err = pipeline.Read()
+		ctx := t.Context()
+		err = pipeline.Read(ctx)
 		require.ErrorContains(t, err, "column is not a timestamp column")
 	})
 
@@ -64,10 +65,11 @@ func TestSortMerge(t *testing.T) {
 		pipeline, err := NewSortMergePipeline(inputs, merge.Order, merge.Column, expressionEvaluator{})
 		require.NoError(t, err)
 
+		ctx := t.Context()
 		timestamps := make([]arrow.Timestamp, 0, 30)
 		var batches, rows int64
 		for {
-			err := pipeline.Read()
+			err := pipeline.Read(ctx)
 			if err == EOF {
 				break
 			}
@@ -111,10 +113,11 @@ func TestSortMerge(t *testing.T) {
 		pipeline, err := NewSortMergePipeline(inputs, merge.Order, merge.Column, expressionEvaluator{})
 		require.NoError(t, err)
 
+		ctx := t.Context()
 		timestamps := make([]arrow.Timestamp, 0, 30)
 		var batches, rows int64
 		for {
-			err := pipeline.Read()
+			err := pipeline.Read(ctx)
 			if err == EOF {
 				break
 			}

--- a/pkg/engine/executor/util_test.go
+++ b/pkg/engine/executor/util_test.go
@@ -1,6 +1,7 @@
 package executor
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
@@ -100,7 +101,7 @@ func (p *recordGenerator) Pipeline(batchSize int64, rows int64) Pipeline {
 	var pos int64
 	return newGenericPipeline(
 		Local,
-		func(_ []Pipeline) state {
+		func(_ context.Context, _ []Pipeline) state {
 			if pos >= rows {
 				return Exhausted
 			}
@@ -114,8 +115,9 @@ func (p *recordGenerator) Pipeline(batchSize int64, rows int64) Pipeline {
 
 // collect reads all data from the pipeline until it is exhausted or returns an error.
 func collect(t *testing.T, pipeline Pipeline) (batches int64, rows int64) {
+	ctx := t.Context()
 	for {
-		err := pipeline.Read()
+		err := pipeline.Read(ctx)
 		if errors.Is(err, EOF) {
 			break
 		}

--- a/pkg/engine/executor/vector_aggregate_test.go
+++ b/pkg/engine/executor/vector_aggregate_test.go
@@ -89,7 +89,7 @@ func TestVectorAggregationPipeline(t *testing.T) {
 	defer pipeline.Close()
 
 	// Read the pipeline output
-	err = pipeline.Read()
+	err = pipeline.Read(t.Context())
 	require.NoError(t, err)
 	record, err := pipeline.Value()
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

This change unifies how the request context is passed through the execution of pipelines. Instead of storing the context on pipelines, pass them as argument to the Read() function.

This change alters the interface method of `Pipeline` from `Read() bool` to `Read(context.Context) bool`.