### PR TITLE
fix: while validating logql expression, detect and validate expression in label_replace

### DIFF
--- a/pkg/logql/syntax/parser.go
+++ b/pkg/logql/syntax/parser.go
@@ -222,6 +222,11 @@ func validateSampleExpr(expr SampleExpr) error {
 			}
 		}
 		return validateSampleExpr(e.Left)
+	case *LabelReplaceExpr:
+		if e.err != nil {
+			return e.err
+		}
+		return validateSampleExpr(e.Left)
 	default:
 		selector, err := e.Selector()
 		if err != nil {

--- a/pkg/logql/syntax/parser_test.go
+++ b/pkg/logql/syntax/parser_test.go
@@ -388,6 +388,30 @@ var ParseTestCases = []struct {
 		in:  `min({ foo = "bar" }[5m])`,
 		err: logqlmodel.NewParseError("syntax error: unexpected RANGE", 0, 20),
 	},
+	{
+		in: `avg(
+					label_replace(
+						count_over_time({ foo = "bar" }[5h]) or 0,
+						"bar",
+						"$1$2",
+						"foo",
+						"(.*).(.*)"
+					)
+				) by (bar,foo)`,
+		err: logqlmodel.NewParseError("unexpected literal for right leg of logical/set binary operation (or): 0.000000", 0, 0),
+	},
+	{
+		in: `avg(
+					label_replace(
+						count_over_time({ foo = "bar" }[5h]) or sum_over_time({ foo = "bar" }[5h]),
+						"bar",
+						"$1$2",
+						"foo",
+						"(.*).(.*)"
+					)
+				) by (bar,foo)`,
+		err: logqlmodel.NewParseError("invalid aggregation sum_over_time without unwrap", 0, 0),
+	},
 	// line filter for ip-matcher
 	{
 		in: `{foo="bar"} |= "baz" |= ip("123.123.123.123")`,


### PR DESCRIPTION
**What this PR does / why we need it**:
There was a panic due to an invalid query, which looked something like this:
`sum(label_replace(count_over_time({container="query-frontend"} |= "metrics.go" | logfmt[1m]) or 0, "tenant", "$1", "org_id", "(.*)")) by (tenant)`

Notice the `or 0` in the binary operation, which is [invalid and results in setting an error in the initialised BinOpExpr](https://github.com/grafana/loki/blob/3d2286a84067cfe616c82876e8ed514629440df7/pkg/logql/syntax/ast.go#L1877).

Now, we validate the parsed logQL query to detect any such errors and return them to the user.
[Some expressions have specific validation logic](https://github.com/grafana/loki/blob/e90db7c627352472fd387a73aa7baa33ab5fa5e6/pkg/logql/syntax/parser.go#L195), while for the remaining, we default to calling the `Selector` method on that expression to see if there is an issue.
The thing to note is that we do not have specific validation logic for `label_replace`. Which means, when the above expression is being validated, we not only miss running the validation logic for binary operation, but we also end up returning a panic [here](https://github.com/grafana/loki/blob/3d2286a84067cfe616c82876e8ed514629440df7/pkg/logql/syntax/ast.go#L2224) since [BinOpExpr](https://github.com/grafana/loki/blob/3d2286a84067cfe616c82876e8ed514629440df7/pkg/logql/syntax/ast.go#L1746) does not implement `Selector` method and relies on embedded SampleExpr, which would be nil when there is invalid binary expression like above.
