### PR TITLE
chore: Add support for indexpointers section

### DIFF
--- a/pkg/dataobj/explorer/inspect.go
+++ b/pkg/dataobj/explorer/inspect.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/grafana/loki/v3/pkg/dataobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/metadata/datasetmd"
+	"github.com/grafana/loki/v3/pkg/dataobj/sections/indexpointers"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/logs"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/pointers"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/streams"
@@ -160,10 +161,75 @@ func inspectFile(ctx context.Context, bucket objstore.BucketReader, path string)
 				}
 			}
 			result.Sections = append(result.Sections, meta)
+		case indexpointers.CheckSection(section):
+			indexPointersSection, err := indexpointers.Open(ctx, section)
+			if err != nil {
+				return FileMetadata{
+					Error: fmt.Sprintf("failed to open index pointers section: %v", err),
+				}
+			}
+			meta, err := inspectIndexPointersSection(ctx, section.Type, indexPointersSection)
+			if err != nil {
+				return FileMetadata{
+					Error: fmt.Sprintf("failed to inspect index pointers section: %v", err),
+				}
+			}
+			result.Sections = append(result.Sections, meta)
 		}
 	}
 
 	return result
+}
+
+func inspectIndexPointersSection(ctx context.Context, ty dataobj.SectionType, sec *indexpointers.Section) (SectionMetadata, error) {
+	stats, err := indexpointers.ReadStats(ctx, sec)
+	if err != nil {
+		return SectionMetadata{}, err
+	}
+
+	meta := SectionMetadata{
+		Type:                  ty.String(),
+		TotalCompressedSize:   stats.CompressedSize,
+		TotalUncompressedSize: stats.UncompressedSize,
+		ColumnCount:           len(stats.Columns),
+		Distribution:          stats.TimestampDistribution,
+		MinTimestamp:          stats.MinTimestamp,
+		MaxTimestamp:          stats.MaxTimestamp,
+	}
+
+	for _, col := range stats.Columns {
+		colMeta := ColumnWithPages{
+			Name:             col.Name,
+			Type:             col.Type,
+			ValueType:        strings.TrimPrefix(col.ValueType, "VALUE_TYPE_"),
+			RowsCount:        col.RowsCount,
+			Compression:      strings.TrimPrefix(col.Compression, "COMPRESSION_TYPE_"),
+			UncompressedSize: col.UncompressedSize,
+			CompressedSize:   col.CompressedSize,
+			MetadataOffset:   col.MetadataOffset,
+			MetadataSize:     col.MetadataSize,
+			ValuesCount:      col.ValuesCount,
+			Statistics:       Statistics{CardinalityCount: col.Cardinality},
+		}
+
+		for _, page := range col.Pages {
+
+			colMeta.Pages = append(colMeta.Pages, PageInfo{
+				UncompressedSize: page.UncompressedSize,
+				CompressedSize:   page.CompressedSize,
+				CRC32:            page.CRC32,
+				RowsCount:        page.RowsCount,
+				Encoding:         strings.TrimPrefix(page.Encoding, "ENCODING_TYPE_"),
+				DataOffset:       page.DataOffset,
+				DataSize:         page.DataSize,
+				ValuesCount:      page.ValuesCount,
+			})
+		}
+
+		meta.Columns = append(meta.Columns, colMeta)
+	}
+
+	return meta, nil
 }
 
 func inspectPointersSection(ctx context.Context, ty dataobj.SectionType, sec *pointers.Section) (SectionMetadata, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:
This pull request adds support for inspecting dataobj files containing `indexpointer` sections.

**Which issue(s) this PR fixes**:
Part of https://github.com/grafana/loki-private/issues/1805

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
