### PR TITLE
chore(engine): append structured metadata to stream labels in log query response

### DIFF
--- a/pkg/engine/compat.go
+++ b/pkg/engine/compat.go
@@ -107,11 +107,15 @@ func (b *streamsResultBuilder) collectRow(rec arrow.Record, i int) (labels.Label
 			switch arr := col.(type) {
 			case *array.String:
 				metadata.Set(colName, arr.Value(i))
+				// include structured metadata in stream labels
+				lbs.Set(colName, arr.Value(i))
 			}
 			continue
 		}
 	}
 	entry.StructuredMetadata = logproto.FromLabelsToLabelAdapters(metadata.Labels())
+	// set to a non-nil value to match with existing engine.
+	entry.Parsed = logproto.FromLabelsToLabelAdapters(labels.Labels{})
 
 	return lbs.Labels(), entry
 }
@@ -121,6 +125,7 @@ func (b *streamsResultBuilder) SetStats(s stats.Result) {
 }
 
 func (b *streamsResultBuilder) Build() logqlmodel.Result {
+	sort.Sort(b.data)
 	return logqlmodel.Result{
 		Data:       b.data,
 		Statistics: b.stats,


### PR DESCRIPTION
**What this PR does / why we need it**:

Contains changes to the new engine compat layer for log query response to match with the existing engine:
- Append append structured metadata to stream labels in log query response
- Sort stream entries
- Return empty parsed labels instead of null

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
