### PR TITLE
chore: Remove lookback from stats in unsupported sections 

### DIFF
--- a/pkg/dataobj/sections/indexpointers/stats.go
+++ b/pkg/dataobj/sections/indexpointers/stats.go
@@ -120,25 +120,5 @@ func ReadStats(ctx context.Context, section *Section) (Stats, error) {
 		stats.Columns = append(stats.Columns, columnStats)
 	}
 
-	if stats.MinTimestamp.IsZero() || stats.MaxTimestamp.IsZero() {
-		// Short sircuit if there's no timestamps.
-		return stats, nil
-	}
-
-	width := int(stats.MaxTimestamp.Add(1 * time.Hour).Truncate(time.Hour).Sub(stats.MinTimestamp.Truncate(time.Hour)).Hours())
-	counts := make([]uint64, width)
-	for indexPointerVal := range IterSection(ctx, section) {
-		indexPointer, err := indexPointerVal.Value()
-		if err != nil {
-			return stats, err
-		}
-		for i := indexPointer.StartTs; !i.After(indexPointer.EndTs); i = i.Add(time.Hour) {
-			hoursBeforeMax := int(stats.MaxTimestamp.Sub(i).Hours())
-			counts[hoursBeforeMax]++
-		}
-	}
-
-	stats.TimestampDistribution = counts
-
 	return stats, nil
 }

--- a/pkg/dataobj/sections/pointers/stats.go
+++ b/pkg/dataobj/sections/pointers/stats.go
@@ -120,10 +120,5 @@ func ReadStats(ctx context.Context, section *Section) (Stats, error) {
 		stats.Columns = append(stats.Columns, columnStats)
 	}
 
-	if stats.MinTimestamp.IsZero() || stats.MaxTimestamp.IsZero() {
-		// Short sircuit if there's no timestamps.
-		return stats, nil
-	}
-
 	return stats, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
* Removes a calculation from the stats that doesn't work or make sense in the new section types.
