### PR TITLE
chore: consistently use new labels.Labels API

### DIFF
--- a/clients/pkg/promtail/client/client_writeto_test.go
+++ b/clients/pkg/promtail/client/client_writeto_test.go
@@ -52,13 +52,8 @@ func TestClientWriter_LogEntriesAreReconstructedAndForwardedCorrectly(t *testing
 	testAppLabelsRef := chunks.HeadSeriesRef(1)
 	writeTo.StoreSeries([]record.RefSeries{
 		{
-			Ref: testAppLabelsRef,
-			Labels: []labels.Label{
-				{
-					Name:  "app",
-					Value: "test",
-				},
-			},
+			Ref:    testAppLabelsRef,
+			Labels: labels.FromStrings("app", "test"),
 		},
 	}, 1)
 
@@ -112,13 +107,8 @@ func TestClientWriter_LogEntriesWithoutMatchingSeriesAreIgnored(t *testing.T) {
 	testAppLabelsRef := chunks.HeadSeriesRef(1)
 	writeTo.StoreSeries([]record.RefSeries{
 		{
-			Ref: testAppLabelsRef,
-			Labels: []labels.Label{
-				{
-					Name:  "app",
-					Value: "test",
-				},
-			},
+			Ref:    testAppLabelsRef,
+			Labels: labels.FromStrings("app", "test"),
 		},
 	}, 1)
 
@@ -193,10 +183,8 @@ func bench(numWriters, totalLines int, b *testing.B) {
 			// run as writing from segment n+w, and after finishing reset series up to n. That way we are only causing blocking,
 			// and not deleting actually used series
 			startWriter(numWriters+n, n, writeTo, totalLines/numWriters, record.RefSeries{
-				Ref: chunks.HeadSeriesRef(n),
-				Labels: labels.Labels{
-					{Name: "n", Value: fmt.Sprint(n)},
-				},
+				Ref:    chunks.HeadSeriesRef(n),
+				Labels: labels.FromStrings("app", fmt.Sprint(n)),
 			}, time.Millisecond*500)
 		}(n)
 	}

--- a/clients/pkg/promtail/promtail_test.go
+++ b/clients/pkg/promtail/promtail_test.go
@@ -481,13 +481,7 @@ func (h *testServerHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			h.t.Error("Failed to parse incoming labels", err)
 			return
 		}
-		file := ""
-		for _, label := range parsedLabels {
-			if label.Name == file2.FilenameLabel {
-				file = label.Value
-				continue
-			}
-		}
+		file := parsedLabels.Get(file2.FilenameLabel)
 		if file == "" {
 			h.t.Error("Expected to find a label with name `filename` but did not!")
 			return

--- a/clients/pkg/promtail/targets/azureeventhubs/parser.go
+++ b/clients/pkg/promtail/targets/azureeventhubs/parser.go
@@ -195,12 +195,10 @@ func (e *messageParser) getTime(messageTime time.Time, useIncomingTimestamp bool
 }
 
 func (e *messageParser) getLabels(logRecord *azureMonitorResourceLog, relabelConfig []*relabel.Config) model.LabelSet {
-	lbs := labels.Labels{
-		{
-			Name:  "__azure_event_hubs_category",
-			Value: logRecord.Category,
-		},
-	}
+	lbs := labels.New(labels.Label{
+		Name:  "__azure_event_hubs_category",
+		Value: logRecord.Category,
+	})
 
 	var processed labels.Labels
 	// apply relabeling
@@ -212,17 +210,18 @@ func (e *messageParser) getLabels(logRecord *azureMonitorResourceLog, relabelCon
 
 	// final labelset that will be sent to loki
 	resultLabels := make(model.LabelSet)
-	for _, lbl := range processed {
+
+	processed.Range(func(lbl labels.Label) {
 		// ignore internal labels
 		if strings.HasPrefix(lbl.Name, "__") {
-			continue
+			return // (continue, not abort)
 		}
 		// ignore invalid labels
 		if !model.LabelName(lbl.Name).IsValid() || !model.LabelValue(lbl.Value).IsValid() {
-			continue
+			return // (continue, not abort)
 		}
 		resultLabels[model.LabelName(lbl.Name)] = model.LabelValue(lbl.Value)
-	}
+	})
 
 	return resultLabels
 }

--- a/clients/pkg/promtail/targets/docker/target.go
+++ b/clients/pkg/promtail/targets/docker/target.go
@@ -239,7 +239,7 @@ func (t *Target) process(frames chan []byte, logStream string) {
 
 func (t *Target) handleOutput(logStream string, ts time.Time, payload string) {
 	// Add all labels from the config, relabel and filter them.
-	lb := labels.NewBuilder(nil)
+	lb := labels.NewBuilder(labels.EmptyLabels())
 	for k, v := range t.labels {
 		lb.Set(string(k), string(v))
 	}
@@ -247,12 +247,12 @@ func (t *Target) handleOutput(logStream string, ts time.Time, payload string) {
 	processed, _ := relabel.Process(lb.Labels(), t.relabelConfig...)
 
 	filtered := make(model.LabelSet)
-	for _, lbl := range processed {
+	processed.Range(func(lbl labels.Label) {
 		if strings.HasPrefix(lbl.Name, "__") {
-			continue
+			return // (continue, not abort)
 		}
 		filtered[model.LabelName(lbl.Name)] = model.LabelValue(lbl.Value)
-	}
+	})
 
 	t.handler.Chan() <- api.Entry{
 		Labels: filtered,

--- a/clients/pkg/promtail/targets/gcplog/formatter_test.go
+++ b/clients/pkg/promtail/targets/gcplog/formatter_test.go
@@ -6,6 +6,7 @@ import (
 
 	"cloud.google.com/go/pubsub"
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/relabel"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -160,7 +161,7 @@ func TestFormat(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			got, err := parseGCPLogsEntry(c.msg.Data, c.labels, nil, c.useIncomingTimestamp, c.useFullLine, c.relabel)
+			got, err := parseGCPLogsEntry(c.msg.Data, c.labels, labels.EmptyLabels(), c.useIncomingTimestamp, c.useFullLine, c.relabel)
 
 			require.NoError(t, err)
 

--- a/clients/pkg/promtail/targets/gcplog/pull_target.go
+++ b/clients/pkg/promtail/targets/gcplog/pull_target.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/backoff"
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/relabel"
 	"google.golang.org/api/option"
 
@@ -108,7 +109,7 @@ func (t *pullTarget) run() error {
 		case <-t.ctx.Done():
 			return t.ctx.Err()
 		case m := <-t.msgs:
-			entry, err := parseGCPLogsEntry(m.Data, t.config.Labels, nil, t.config.UseIncomingTimestamp, t.config.UseFullLine, t.relabelConfig)
+			entry, err := parseGCPLogsEntry(m.Data, t.config.Labels, labels.EmptyLabels(), t.config.UseIncomingTimestamp, t.config.UseFullLine, t.relabelConfig)
 			if err != nil {
 				level.Error(t.logger).Log("event", "error formating log entry", "cause", err)
 				m.Ack()

--- a/clients/pkg/promtail/targets/gcplog/push_translation.go
+++ b/clients/pkg/promtail/targets/gcplog/push_translation.go
@@ -44,7 +44,7 @@ func (pm PushMessage) Validate() error {
 func translate(m PushMessage, other model.LabelSet, useIncomingTimestamp, useFullLine bool, relabelConfigs []*relabel.Config, xScopeOrgID string) (api.Entry, error) {
 	// Collect all push-specific labels. Every one of them is first configured as optional, and the user
 	// can relabel it if needed. The relabeling and internal drop is handled in parseGCPLogsEntry.
-	lbs := labels.NewBuilder(nil)
+	lbs := labels.NewBuilder(labels.EmptyLabels())
 	lbs.Set("__gcp_message_id", m.Message.ID)
 	lbs.Set("__gcp_subscription_name", m.Subscription)
 	for k, v := range m.Message.Attributes {

--- a/clients/pkg/promtail/targets/gelf/gelftarget.go
+++ b/clients/pkg/promtail/targets/gelf/gelftarget.go
@@ -111,7 +111,7 @@ func (t *Target) run() {
 }
 
 func (t *Target) handleMessage(msg *gelf.Message) {
-	lb := labels.NewBuilder(nil)
+	lb := labels.NewBuilder(labels.EmptyLabels())
 
 	// Add all labels from the config.
 	for k, v := range t.config.Labels {
@@ -125,12 +125,12 @@ func (t *Target) handleMessage(msg *gelf.Message) {
 	processed, _ := relabel.Process(lb.Labels(), t.relabelConfig...)
 
 	filtered := make(model.LabelSet)
-	for _, lbl := range processed {
+	processed.Range(func(lbl labels.Label) {
 		if strings.HasPrefix(lbl.Name, "__") {
-			continue
+			return // (continue, not abort)
 		}
 		filtered[model.LabelName(lbl.Name)] = model.LabelValue(lbl.Value)
-	}
+	})
 
 	var timestamp time.Time
 	if t.config.UseIncomingTimestamp && msg.TimeUnix != 0 {

--- a/clients/pkg/promtail/targets/heroku/target.go
+++ b/clients/pkg/promtail/targets/heroku/target.go
@@ -106,7 +106,7 @@ func (h *Target) drain(w http.ResponseWriter, r *http.Request) {
 	for herokuScanner.Scan() {
 		ts := time.Now()
 		message := herokuScanner.Message()
-		lb := labels.NewBuilder(nil)
+		lb := labels.NewBuilder(labels.EmptyLabels())
 		lb.Set("__heroku_drain_host", message.Hostname)
 		lb.Set("__heroku_drain_app", message.Application)
 		lb.Set("__heroku_drain_proc", message.Process)
@@ -132,12 +132,12 @@ func (h *Target) drain(w http.ResponseWriter, r *http.Request) {
 
 		// Start with the set of labels fixed in the configuration
 		filtered := h.Labels().Clone()
-		for _, lbl := range processed {
+		processed.Range(func(lbl labels.Label) {
 			if strings.HasPrefix(lbl.Name, "__") {
-				continue
+				return // (continue, not abort)
 			}
 			filtered[model.LabelName(lbl.Name)] = model.LabelValue(lbl.Value)
-		}
+		})
 
 		// Then, inject it as the reserved label, so it's used by the remote write client
 		if tenantIDHeaderValue != "" {

--- a/clients/pkg/promtail/targets/kafka/formatter.go
+++ b/clients/pkg/promtail/targets/kafka/formatter.go
@@ -11,7 +11,7 @@ import (
 )
 
 func format(lbs labels.Labels, cfg []*relabel.Config) model.LabelSet {
-	if len(lbs) == 0 {
+	if lbs.IsEmpty() {
 		return nil
 	}
 	processed, _ := relabel.Process(lbs, cfg...)

--- a/clients/pkg/promtail/targets/kafka/target.go
+++ b/clients/pkg/promtail/targets/kafka/target.go
@@ -81,10 +81,10 @@ func (t *Target) run() {
 
 		// TODO: Possibly need to format after merging with discovered labels because we can specify multiple labels in source labels
 		// https://github.com/grafana/loki/pull/4745#discussion_r750022234
-		lbs := format([]labels.Label{{
+		lbs := format(labels.New(labels.Label{
 			Name:  labelKeyKafkaMessageKey,
 			Value: mk,
-		}}, t.relabelConfig)
+		}), t.relabelConfig)
 
 		out := t.lbs.Clone()
 		if len(lbs) > 0 {

--- a/clients/pkg/promtail/targets/lokipush/pushtarget.go
+++ b/clients/pkg/promtail/targets/lokipush/pushtarget.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"sort"
 	"strings"
 	"time"
 
@@ -129,7 +128,6 @@ func (t *PushTarget) handleLoki(w http.ResponseWriter, r *http.Request) {
 			lastErr = err
 			continue
 		}
-		sort.Sort(ls)
 
 		lb := labels.NewBuilder(ls)
 
@@ -140,19 +138,19 @@ func (t *PushTarget) handleLoki(w http.ResponseWriter, r *http.Request) {
 
 		// Apply relabeling
 		processed, keep := relabel.Process(lb.Labels(), t.relabelConfig...)
-		if !keep || len(processed) == 0 {
+		if !keep || processed.IsEmpty() {
 			w.WriteHeader(http.StatusNoContent)
 			return
 		}
 
 		// Convert to model.LabelSet
 		filtered := model.LabelSet{}
-		for i := range processed {
-			if strings.HasPrefix(processed[i].Name, "__") {
-				continue
+		processed.Range(func(lbl labels.Label) {
+			if strings.HasPrefix(lbl.Name, "__") {
+				return // (continue, not abort)
 			}
-			filtered[model.LabelName(processed[i].Name)] = model.LabelValue(processed[i].Value)
-		}
+			filtered[model.LabelName(lbl.Name)] = model.LabelValue(lbl.Value)
+		})
 
 		for _, entry := range stream.Entries {
 			e := api.Entry{

--- a/clients/pkg/promtail/targets/syslog/syslogtarget.go
+++ b/clients/pkg/promtail/targets/syslog/syslogtarget.go
@@ -152,12 +152,12 @@ func (t *SyslogTarget) handleMessageRFC5424(connLabels labels.Labels, msg syslog
 	processed, _ := relabel.Process(lb.Labels(), t.relabelConfig...)
 
 	filtered := make(model.LabelSet)
-	for _, lbl := range processed {
+	processed.Range(func(lbl labels.Label) {
 		if strings.HasPrefix(lbl.Name, "__") {
-			continue
+			return // (continue, not abort)
 		}
 		filtered[model.LabelName(lbl.Name)] = model.LabelValue(lbl.Value)
-	}
+	})
 
 	var timestamp time.Time
 	if t.config.UseIncomingTimestamp && rfc5424Msg.Timestamp != nil {
@@ -209,12 +209,12 @@ func (t *SyslogTarget) handleMessageRFC3164(connLabels labels.Labels, msg syslog
 	processed, _ := relabel.Process(lb.Labels(), t.relabelConfig...)
 
 	filtered := make(model.LabelSet)
-	for _, lbl := range processed {
+	processed.Range(func(lbl labels.Label) {
 		if strings.HasPrefix(lbl.Name, "__") {
-			continue
+			return // (continue, not abort)
 		}
 		filtered[model.LabelName(lbl.Name)] = model.LabelValue(lbl.Value)
-	}
+	})
 
 	var timestamp time.Time
 	if t.config.UseIncomingTimestamp && rfc3164Msg.Timestamp != nil {

--- a/clients/pkg/promtail/targets/syslog/transport.go
+++ b/clients/pkg/promtail/targets/syslog/transport.go
@@ -78,7 +78,7 @@ func (t *baseTransport) maxMessageLength() int {
 }
 
 func (t *baseTransport) connectionLabels(ip string) labels.Labels {
-	lb := labels.NewBuilder(nil)
+	lb := labels.NewBuilder(labels.EmptyLabels())
 	for k, v := range t.config.Labels {
 		lb.Set(string(k), string(v))
 	}

--- a/clients/pkg/promtail/wal/writer.go
+++ b/clients/pkg/promtail/wal/writer.go
@@ -247,7 +247,6 @@ func (ew *entryWriter) WriteEntry(entry api.Entry, wl WAL, _ log.Logger) error {
 
 	var fp uint64
 	lbs := labels.FromMap(util.ModelLabelSetToMap(entry.Labels))
-	sort.Sort(lbs)
 	fp, _ = lbs.HashWithoutLabels(nil, []string(nil)...)
 
 	// Append the entry to an already existing stream (if any)

--- a/pkg/bloombuild/builder/batch.go
+++ b/pkg/bloombuild/builder/batch.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/grafana/dskit/multierror"
+	"github.com/prometheus/prometheus/model/labels"
 
 	"github.com/grafana/loki/v3/pkg/chunkenc"
 	iter "github.com/grafana/loki/v3/pkg/iter/v2"
@@ -133,7 +134,7 @@ func newBatchedChunkLoader(
 			time.Unix(0, 0),
 			time.Unix(0, math.MaxInt64),
 			logproto.FORWARD,
-			logql_log.NewNoopPipeline().ForStream(nil),
+			logql_log.NewNoopPipeline().ForStream(labels.EmptyLabels()),
 		)
 
 		if err != nil {

--- a/pkg/bloombuild/common/tsdb_test.go
+++ b/pkg/bloombuild/common/tsdb_test.go
@@ -35,7 +35,7 @@ func (f forSeriesTestImpl) ForSeries(
 			})
 		}
 
-		fn(nil, f[i].Fingerprint, unmapped)
+		fn(labels.EmptyLabels(), f[i].Fingerprint, unmapped)
 	}
 	return nil
 }

--- a/pkg/bloomgateway/querier_test.go
+++ b/pkg/bloomgateway/querier_test.go
@@ -158,33 +158,33 @@ func TestGroupChunkRefs(t *testing.T) {
 	}
 	seriesMap := make(map[uint64]labels.Labels)
 	for _, s := range series {
-		seriesMap[s.Hash()] = s
+		seriesMap[labels.StableHash(s)] = s
 	}
 
 	chunkRefs := []*logproto.ChunkRef{
-		{Fingerprint: series[0].Hash(), UserID: "tenant", From: mktime("2024-04-20 00:00"), Through: mktime("2024-04-20 00:59")},
-		{Fingerprint: series[0].Hash(), UserID: "tenant", From: mktime("2024-04-20 01:00"), Through: mktime("2024-04-20 01:59")},
-		{Fingerprint: series[1].Hash(), UserID: "tenant", From: mktime("2024-04-20 00:00"), Through: mktime("2024-04-20 00:59")},
-		{Fingerprint: series[1].Hash(), UserID: "tenant", From: mktime("2024-04-20 01:00"), Through: mktime("2024-04-20 01:59")},
-		{Fingerprint: series[2].Hash(), UserID: "tenant", From: mktime("2024-04-20 00:00"), Through: mktime("2024-04-20 00:59")},
-		{Fingerprint: series[2].Hash(), UserID: "tenant", From: mktime("2024-04-20 01:00"), Through: mktime("2024-04-20 01:59")},
+		{Fingerprint: labels.StableHash(series[0]), UserID: "tenant", From: mktime("2024-04-20 00:00"), Through: mktime("2024-04-20 00:59")},
+		{Fingerprint: labels.StableHash(series[0]), UserID: "tenant", From: mktime("2024-04-20 01:00"), Through: mktime("2024-04-20 01:59")},
+		{Fingerprint: labels.StableHash(series[1]), UserID: "tenant", From: mktime("2024-04-20 00:00"), Through: mktime("2024-04-20 00:59")},
+		{Fingerprint: labels.StableHash(series[1]), UserID: "tenant", From: mktime("2024-04-20 01:00"), Through: mktime("2024-04-20 01:59")},
+		{Fingerprint: labels.StableHash(series[2]), UserID: "tenant", From: mktime("2024-04-20 00:00"), Through: mktime("2024-04-20 00:59")},
+		{Fingerprint: labels.StableHash(series[2]), UserID: "tenant", From: mktime("2024-04-20 01:00"), Through: mktime("2024-04-20 01:59")},
 	}
 
 	result := groupChunkRefs(seriesMap, chunkRefs, nil)
 	require.Equal(t, []*logproto.GroupedChunkRefs{
-		{Fingerprint: series[0].Hash(), Tenant: "tenant", Refs: []*logproto.ShortRef{
+		{Fingerprint: labels.StableHash(series[0]), Tenant: "tenant", Refs: []*logproto.ShortRef{
 			{From: mktime("2024-04-20 00:00"), Through: mktime("2024-04-20 00:59")},
 			{From: mktime("2024-04-20 01:00"), Through: mktime("2024-04-20 01:59")},
 		}, Labels: &logproto.IndexSeries{
 			Labels: logproto.FromLabelsToLabelAdapters(series[0]),
 		}},
-		{Fingerprint: series[1].Hash(), Tenant: "tenant", Refs: []*logproto.ShortRef{
+		{Fingerprint: labels.StableHash(series[1]), Tenant: "tenant", Refs: []*logproto.ShortRef{
 			{From: mktime("2024-04-20 00:00"), Through: mktime("2024-04-20 00:59")},
 			{From: mktime("2024-04-20 01:00"), Through: mktime("2024-04-20 01:59")},
 		}, Labels: &logproto.IndexSeries{
 			Labels: logproto.FromLabelsToLabelAdapters(series[1]),
 		}},
-		{Fingerprint: series[2].Hash(), Tenant: "tenant", Refs: []*logproto.ShortRef{
+		{Fingerprint: labels.StableHash(series[2]), Tenant: "tenant", Refs: []*logproto.ShortRef{
 			{From: mktime("2024-04-20 00:00"), Through: mktime("2024-04-20 00:59")},
 			{From: mktime("2024-04-20 01:00"), Through: mktime("2024-04-20 01:59")},
 		}, Labels: &logproto.IndexSeries{
@@ -203,7 +203,7 @@ func BenchmarkGroupChunkRefs(b *testing.B) {
 
 	for i := 0; i < n; i++ {
 		s := labels.FromStrings("app", fmt.Sprintf("%d", i))
-		sFP := s.Hash()
+		sFP := labels.StableHash(s)
 		series[sFP] = s
 		for j := 0; j < m; j++ {
 			chunkRefs = append(chunkRefs, &logproto.ChunkRef{

--- a/pkg/chunkenc/memchunk.go
+++ b/pkg/chunkenc/memchunk.go
@@ -1401,13 +1401,12 @@ func newBufferedIterator(ctx context.Context, pool compression.ReaderPool, b []b
 	stats := stats.FromContext(ctx)
 	stats.AddCompressedBytes(int64(len(b)))
 	return &bufferedIterator{
-		stats:                  stats,
-		origBytes:              b,
-		reader:                 nil, // will be initialized later
-		pool:                   pool,
-		format:                 format,
-		symbolizer:             symbolizer,
-		currStructuredMetadata: structuredMetadataPool.Get().(labels.Labels),
+		stats:      stats,
+		origBytes:  b,
+		reader:     nil, // will be initialized later
+		pool:       pool,
+		format:     format,
+		symbolizer: symbolizer,
 	}
 }
 
@@ -1622,8 +1621,7 @@ func (si *bufferedIterator) moveNext() (int64, []byte, labels.Labels, bool) {
 	si.stats.AddDecompressedStructuredMetadataBytes(decompressedStructuredMetadataBytes)
 	si.stats.AddDecompressedBytes(decompressedBytes + decompressedStructuredMetadataBytes)
 
-	labelsBuilder := log.NewBufferedLabelsBuilder(si.currStructuredMetadata)
-	return ts, si.buf[:lineSize], si.symbolizer.Lookup(si.symbolsBuf[:nSymbols], labelsBuilder), true
+	return ts, si.buf[:lineSize], si.symbolizer.Lookup(si.symbolsBuf[:nSymbols], nil), true
 }
 
 func (si *bufferedIterator) Err() error { return si.err }
@@ -1653,7 +1651,6 @@ func (si *bufferedIterator) close() {
 	}
 
 	if !si.currStructuredMetadata.IsEmpty() {
-		structuredMetadataPool.Put(si.currStructuredMetadata) // nolint:staticcheck
 		si.currStructuredMetadata = labels.EmptyLabels()
 	}
 

--- a/pkg/chunkenc/symbols_test.go
+++ b/pkg/chunkenc/symbols_test.go
@@ -230,13 +230,6 @@ func TestSymbolizerLabelNormalization(t *testing.T) {
 	}
 }
 
-func TestSymbolizerNormalizationCache(t *testing.T) {
-	// NOTE(rfratto): Caching normalized strings can no longer be consistently
-	// tested; when stringlabels are used (the default), normalization is
-	// impossible due to storing the labels as a single string.
-	t.Skip()
-}
-
 func TestSymbolizerLabelNormalizationAfterCheckpointing(t *testing.T) {
 	s := newSymbolizer()
 
@@ -288,6 +281,8 @@ func TestSymbolizerLabelNormalizationSameNameValue(t *testing.T) {
 	result := s.Lookup(originalSymbols, nil)
 	require.Equal(t, "foo-bar", result.Get("foo_bar"), "metric should have been normalized")
 	require.Equal(t, "test-label", result.Get("test_label"), "metric should have been normalized")
+	require.False(t, result.Has("foo-bar"), "metric should not contain unnormalized label")
+	require.False(t, result.Has("test-label"), "metric should not contain unnormalized label")
 
 	// Serialize the symbolizer
 	buf := bytes.NewBuffer(nil)
@@ -307,6 +302,8 @@ func TestSymbolizerLabelNormalizationSameNameValue(t *testing.T) {
 	result = loaded.Lookup(originalSymbols, nil)
 	require.Equal(t, "foo-bar", result.Get("foo_bar"), "metric should have been normalized after deserialization")
 	require.Equal(t, "test-label", result.Get("test_label"), "metric should have been normalized after deserialization")
+	require.False(t, result.Has("foo-bar"), "metric should not contain unnormalized label")
+	require.False(t, result.Has("test-label"), "metric should not contain unnormalized label")
 
 	// Also test with checkpoint serialization
 	buf.Reset()
@@ -317,4 +314,6 @@ func TestSymbolizerLabelNormalizationSameNameValue(t *testing.T) {
 	result = loadedFromCheckpoint.Lookup(originalSymbols, nil)
 	require.Equal(t, "foo-bar", result.Get("foo_bar"), "metric should have been normalized after checkpoint")
 	require.Equal(t, "test-label", result.Get("test_label"), "metric should have been normalized after checkpoint")
+	require.False(t, result.Has("foo-bar"), "metric should not contain unnormalized label")
+	require.False(t, result.Has("test-label"), "metric should not contain unnormalized label")
 }

--- a/pkg/chunkenc/symbols_test.go
+++ b/pkg/chunkenc/symbols_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"testing"
-	"unsafe"
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
@@ -232,34 +231,10 @@ func TestSymbolizerLabelNormalization(t *testing.T) {
 }
 
 func TestSymbolizerNormalizationCache(t *testing.T) {
-	s := newSymbolizer()
-
-	// Add a label with a name that needs normalization
-	labels1 := labels.FromStrings("foo-bar", "value1")
-	symbols1, err := s.Add(labels1)
-	require.NoError(t, err)
-
-	// Look up the label multiple times
-	for i := 0; i < 3; i++ {
-		result := s.Lookup(symbols1, nil)
-		require.Equal(t, "value1", result.Get("foo_bar"), "value should remain unchanged")
-	}
-
-	// Add the same label name with a different value
-	labels2 := labels.FromStrings("foo-bar", "value2")
-	symbols2, err := s.Add(labels2)
-	require.NoError(t, err)
-
-	// The normalized name should be reused
-	result := s.Lookup(symbols1, nil)
-	firstPtr := unsafe.StringData(result[0].Name)
-	result = s.Lookup(symbols2, nil)
-	secondPtr := unsafe.StringData(result[0].Name)
-	require.Equal(t, firstPtr, secondPtr, "normalized name string data pointers should be identical")
-	require.Equal(t, "value2", result[0].Value, "new value should be used")
-
-	// Check that we have only one entry in normalizedNames for this label name
-	require.Equal(t, 1, len(s.normalizedNames), "should have only one normalized name entry")
+	// NOTE(rfratto): Caching normalized strings can no longer be consistently
+	// tested; when stringlabels are used (the default), normalization is
+	// impossible due to storing the labels as a single string.
+	t.Skip()
 }
 
 func TestSymbolizerLabelNormalizationAfterCheckpointing(t *testing.T) {
@@ -302,19 +277,17 @@ func TestSymbolizerLabelNormalizationSameNameValue(t *testing.T) {
 	s := newSymbolizer()
 
 	// Add labels where the name and value are the same string
-	originalLabels := labels.Labels{
-		{Name: "foo-bar", Value: "foo-bar"},
-		{Name: "test-label", Value: "test-label"},
-	}
+	originalLabels := labels.New(
+		labels.Label{Name: "foo-bar", Value: "foo-bar"},
+		labels.Label{Name: "test-label", Value: "test-label"},
+	)
 	originalSymbols, err := s.Add(originalLabels)
 	require.NoError(t, err)
 
 	// Verify initial state
 	result := s.Lookup(originalSymbols, nil)
-	require.Equal(t, "foo_bar", result[0].Name, "name should be normalized")
-	require.Equal(t, "foo-bar", result[0].Value, "value should remain unchanged")
-	require.Equal(t, "test_label", result[1].Name, "name should be normalized")
-	require.Equal(t, "test-label", result[1].Value, "value should remain unchanged")
+	require.Equal(t, "foo-bar", result.Get("foo_bar"), "metric should have been normalized")
+	require.Equal(t, "test-label", result.Get("test_label"), "metric should have been normalized")
 
 	// Serialize the symbolizer
 	buf := bytes.NewBuffer(nil)
@@ -327,15 +300,13 @@ func TestSymbolizerLabelNormalizationSameNameValue(t *testing.T) {
 	require.True(t, loaded.readOnly)
 
 	// trying to add values to symbolizer loaded from serialized data should throw an error
-	_, err = loaded.Add(labels.Labels{{Name: "foo-bar2", Value: "foo-bar2"}})
+	_, err = loaded.Add(labels.New(labels.Label{Name: "foo-bar2", Value: "foo-bar2"}))
 	require.EqualError(t, err, errSymbolizerReadOnly.Error())
 
 	// Look up using the original symbols without re-adding the labels
 	result = loaded.Lookup(originalSymbols, nil)
-	require.Equal(t, "foo_bar", result[0].Name, "name should be normalized after deserialization")
-	require.Equal(t, "foo-bar", result[0].Value, "value should remain unchanged after deserialization")
-	require.Equal(t, "test_label", result[1].Name, "name should be normalized after deserialization")
-	require.Equal(t, "test-label", result[1].Value, "value should remain unchanged after deserialization")
+	require.Equal(t, "foo-bar", result.Get("foo_bar"), "metric should have been normalized after deserialization")
+	require.Equal(t, "test-label", result.Get("test_label"), "metric should have been normalized after deserialization")
 
 	// Also test with checkpoint serialization
 	buf.Reset()
@@ -344,8 +315,6 @@ func TestSymbolizerLabelNormalizationSameNameValue(t *testing.T) {
 
 	loadedFromCheckpoint := symbolizerFromCheckpoint(buf.Bytes())
 	result = loadedFromCheckpoint.Lookup(originalSymbols, nil)
-	require.Equal(t, "foo_bar", result[0].Name, "name should be normalized after checkpoint")
-	require.Equal(t, "foo-bar", result[0].Value, "value should remain unchanged after checkpoint")
-	require.Equal(t, "test_label", result[1].Name, "name should be normalized after checkpoint")
-	require.Equal(t, "test-label", result[1].Value, "value should remain unchanged after checkpoint")
+	require.Equal(t, "foo-bar", result.Get("foo_bar"), "metric should have been normalized after checkpoint")
+	require.Equal(t, "test-label", result.Get("test_label"), "metric should have been normalized after checkpoint")
 }

--- a/pkg/chunkenc/unordered_test.go
+++ b/pkg/chunkenc/unordered_test.go
@@ -769,12 +769,12 @@ func Test_HeadIteratorHash(t *testing.T) {
 			eit := b.Iterator(context.Background(), logproto.BACKWARD, 0, 2, log.NewNoopPipeline().ForStream(lbs))
 
 			for eit.Next() {
-				require.Equal(t, lbs.Hash(), eit.StreamHash())
+				require.Equal(t, labels.StableHash(lbs), eit.StreamHash())
 			}
 
 			sit := b.SampleIterator(context.TODO(), 0, 2, countEx.ForStream(lbs))
 			for sit.Next() {
-				require.Equal(t, lbs.Hash(), sit.StreamHash())
+				require.Equal(t, labels.StableHash(lbs), sit.StreamHash())
 			}
 		})
 
@@ -791,7 +791,7 @@ func Test_HeadIteratorHash(t *testing.T) {
 			)
 
 			for eit.Next() {
-				require.Equal(t, lbs.Hash(), eit.StreamHash())
+				require.Equal(t, labels.StableHash(lbs), eit.StreamHash())
 			}
 
 			sit := b.SampleIterator(
@@ -802,7 +802,7 @@ func Test_HeadIteratorHash(t *testing.T) {
 				bytesEx.ForStream(lbs),
 			)
 			for sit.Next() {
-				require.Equal(t, lbs.Hash(), sit.StreamHash())
+				require.Equal(t, labels.StableHash(lbs), sit.StreamHash())
 			}
 		})
 	}

--- a/pkg/compactor/deletion/job_runner_test.go
+++ b/pkg/compactor/deletion/job_runner_test.go
@@ -78,7 +78,7 @@ func createTestChunk(t *testing.T, userID string, lbs labels.Labels, from, throu
 	labelsBuilder := labels.NewBuilder(lbs)
 	labelsBuilder.Set(labels.MetricName, "logs")
 	metric := labelsBuilder.Labels()
-	fp := model.Fingerprint(lbs.Hash())
+	fp := model.Fingerprint(labels.StableHash(lbs))
 	chunkEnc := chunkenc.NewMemChunk(chunkenc.ChunkFormatV4, compression.None, chunkenc.UnorderedWithStructuredMetadataHeadBlockFmt, blockSize, targetSize)
 
 	for ts := from; !ts.After(through); ts = ts.Add(logInterval) {
@@ -156,7 +156,7 @@ func TestJobRunner_Run(t *testing.T) {
 					{
 						From:        yesterdaysTableInterval.Start.Add(time.Hour).Add(time.Minute),
 						Through:     yesterdaysTableInterval.Start.Add(6 * time.Hour),
-						Fingerprint: lblFoo.Hash(),
+						Fingerprint: labels.StableHash(lblFoo),
 					},
 				},
 			},
@@ -183,7 +183,7 @@ func TestJobRunner_Run(t *testing.T) {
 					{
 						From:        yesterdaysTableInterval.Start.Add(time.Hour).Add(time.Minute),
 						Through:     yesterdaysTableInterval.Start.Add(6 * time.Hour),
-						Fingerprint: lblFoo.Hash(),
+						Fingerprint: labels.StableHash(lblFoo),
 					},
 				},
 			},
@@ -216,7 +216,7 @@ func TestJobRunner_Run(t *testing.T) {
 					{
 						From:        yesterdaysTableInterval.Start.Add(2 * time.Hour).Add(time.Minute),
 						Through:     yesterdaysTableInterval.Start.Add(6 * time.Hour),
-						Fingerprint: lblFoo.Hash(),
+						Fingerprint: labels.StableHash(lblFoo),
 					},
 				},
 			},
@@ -237,7 +237,7 @@ func TestJobRunner_Run(t *testing.T) {
 					{
 						From:        yesterdaysTableInterval.Start.Add(3 * time.Hour).Add(time.Minute),
 						Through:     yesterdaysTableInterval.Start.Add(6 * time.Hour),
-						Fingerprint: lblFoo.Hash(),
+						Fingerprint: labels.StableHash(lblFoo),
 					},
 				},
 			},
@@ -408,19 +408,19 @@ func TestJobRunner_Run_ConcurrentChunkProcessing(t *testing.T) {
 				// chunk recreated by test-request-0
 				From:        yesterdaysTableInterval.Start.Add(31 * time.Minute),
 				Through:     yesterdaysTableInterval.Start.Add(time.Hour),
-				Fingerprint: lblFoo.Hash(),
+				Fingerprint: labels.StableHash(lblFoo),
 			},
 			{
 				// chunk recreated by test-request-1, removing just last line
 				From:        chks[5].From,
 				Through:     chks[5].Through.Add(-time.Minute),
-				Fingerprint: lblFoo.Hash(),
+				Fingerprint: labels.StableHash(lblFoo),
 			},
 			{
 				// chunk recreated by test-request-1, removing just first line
 				From:        chks[10].From.Add(time.Minute),
 				Through:     chks[10].Through,
-				Fingerprint: lblFoo.Hash(),
+				Fingerprint: labels.StableHash(lblFoo),
 			},
 		},
 		ChunksToDeIndex: []string{

--- a/pkg/compactor/index_set_test.go
+++ b/pkg/compactor/index_set_test.go
@@ -149,13 +149,7 @@ func TestIndexSet_ApplyIndexUpdates(t *testing.T) {
 		},
 	}
 
-	lblFoo := labels.Labels{
-		{
-			Name:  "foo",
-			Value: "bar",
-		},
-	}
-
+	lblFoo := labels.FromStrings("foo", "bar")
 	err := indexSet.applyUpdates(lblFoo.String(), chunksToDelete, chunksToDeIndex, chunksToIndex)
 	require.NoError(t, err)
 

--- a/pkg/compactor/retention/retention_test.go
+++ b/pkg/compactor/retention/retention_test.go
@@ -659,7 +659,7 @@ func newSeriesCleanRecorder(indexProcessor IndexProcessor) *seriesCleanedRecorde
 }
 
 func (s *seriesCleanedRecorder) CleanupSeries(userID []byte, lbls labels.Labels) error {
-	s.deletedSeries[string(userID)] = map[uint64]struct{}{lbls.Hash(): {}}
+	s.deletedSeries[string(userID)] = map[uint64]struct{}{labels.StableHash(lbls): {}}
 	return s.IndexProcessor.CleanupSeries(userID, lbls)
 }
 
@@ -844,7 +844,7 @@ func TestMarkForDelete_SeriesCleanup(t *testing.T) {
 				},
 			},
 			expectedDeletedSeries: []map[uint64]struct{}{
-				{labels.FromStrings("foo", "2").Hash(): struct{}{}},
+				{labels.StableHash(labels.FromStrings("foo", "2")): struct{}{}},
 			},
 			expectedEmpty: []bool{
 				false,
@@ -873,7 +873,7 @@ func TestMarkForDelete_SeriesCleanup(t *testing.T) {
 				},
 			},
 			expectedDeletedSeries: []map[uint64]struct{}{
-				{labels.FromStrings("foo", "2").Hash(): struct{}{}},
+				{labels.StableHash(labels.FromStrings("foo", "2")): struct{}{}},
 			},
 			expectedEmpty: []bool{
 				false,

--- a/pkg/dataobj/index/builder.go
+++ b/pkg/dataobj/index/builder.go
@@ -22,6 +22,7 @@ import (
 	"github.com/grafana/dskit/multierror"
 	"github.com/grafana/dskit/services"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/thanos-io/objstore"
 	"github.com/twmb/franz-go/pkg/kgo"
 	"golang.org/x/sync/errgroup"
@@ -450,9 +451,9 @@ func (p *Builder) processLogsSection(ctx context.Context, sectionLogger log.Logg
 
 		for i, log := range logsBuf[:n] {
 			cnt++
-			for _, md := range log.Metadata {
+			log.Metadata.Range(func(md labels.Label) {
 				columnBloomBuilders[md.Name].Add([]byte(md.Value))
-			}
+			})
 			logsInfo[i].objectPath = objectPath
 			logsInfo[i].sectionIdx = sectionIdx
 			logsInfo[i].streamID = log.StreamID

--- a/pkg/dataobj/index/indexobj/builder.go
+++ b/pkg/dataobj/index/indexobj/builder.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"sort"
 	"time"
 
 	"github.com/grafana/dskit/flagext"
@@ -209,7 +208,6 @@ func (b *Builder) AppendStream(stream streams.Stream) (int64, error) {
 
 	// Record the stream in the stream section.
 	// Once to capture the min timestamp and uncompressed size, again to record the max timestamp.
-	sort.Sort(stream.Labels)
 	streamID := b.streams.Record(stream.Labels, stream.MinTimestamp, stream.UncompressedSize)
 	_ = b.streams.Record(stream.Labels, stream.MaxTimestamp, 0)
 
@@ -235,10 +233,10 @@ func labelsEstimate(ls labels.Labels) int {
 		valuesSize int
 	)
 
-	for _, l := range ls {
+	ls.Range(func(l labels.Label) {
 		keysSize += len(l.Name)
 		valuesSize += len(l.Value)
-	}
+	})
 
 	// Keys are stored as columns directly, while values get compressed. We'll
 	// underestimate a 2x compression ratio.

--- a/pkg/dataobj/index/indexobj/builder_test.go
+++ b/pkg/dataobj/index/indexobj/builder_test.go
@@ -34,10 +34,10 @@ func TestBuilder(t *testing.T) {
 	testStreams := []streams.Stream{
 		{
 			ID: 1,
-			Labels: labels.Labels{
-				{Name: "cluster", Value: "test"},
-				{Name: "app", Value: "foo"},
-			},
+			Labels: labels.New(
+				labels.Label{Name: "cluster", Value: "test"},
+				labels.Label{Name: "app", Value: "foo"},
+			),
 			Rows:             2,
 			MinTimestamp:     time.Unix(10, 0).UTC(),
 			MaxTimestamp:     time.Unix(20, 0).UTC(),
@@ -45,10 +45,10 @@ func TestBuilder(t *testing.T) {
 		},
 		{
 			ID: 2,
-			Labels: labels.Labels{
-				{Name: "cluster", Value: "test"},
-				{Name: "app", Value: "bar"},
-			},
+			Labels: labels.New(
+				labels.Label{Name: "cluster", Value: "test"},
+				labels.Label{Name: "app", Value: "bar"},
+			),
 			Rows:             3,
 			MinTimestamp:     time.Unix(15, 0).UTC(),
 			MaxTimestamp:     time.Unix(25, 0).UTC(),
@@ -133,11 +133,11 @@ func TestBuilder_Append(t *testing.T) {
 
 		_, err := builder.AppendStream(streams.Stream{
 			ID: 1,
-			Labels: labels.Labels{
-				{Name: "cluster", Value: "test"},
-				{Name: "app", Value: "foo"},
-				{Name: "i", Value: fmt.Sprintf("%d", i)},
-			},
+			Labels: labels.New(
+				labels.Label{Name: "cluster", Value: "test"},
+				labels.Label{Name: "app", Value: "foo"},
+				labels.Label{Name: "i", Value: fmt.Sprintf("%d", i)},
+			),
 			Rows:         2,
 			MinTimestamp: time.Unix(10, 0).UTC(),
 			MaxTimestamp: time.Unix(20, 0).UTC(),

--- a/pkg/dataobj/metastore/metastore_test.go
+++ b/pkg/dataobj/metastore/metastore_test.go
@@ -445,11 +445,11 @@ func TestObjectOverlapsRange(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Create labels with timestamps in nanoseconds
-			lbs := labels.Labels{
-				{Name: labelNameStart, Value: strconv.FormatInt(tt.objStart.UnixNano(), 10)},
-				{Name: labelNameEnd, Value: strconv.FormatInt(tt.objEnd.UnixNano(), 10)},
-				{Name: labelNamePath, Value: testPath},
-			}
+			lbs := labels.New(
+				labels.Label{Name: labelNameStart, Value: strconv.FormatInt(tt.objStart.UnixNano(), 10)},
+				labels.Label{Name: labelNameEnd, Value: strconv.FormatInt(tt.objEnd.UnixNano(), 10)},
+				labels.Label{Name: labelNamePath, Value: testPath},
+			)
 
 			gotMatch, gotPath := objectOverlapsRange(lbs, tt.queryStart, tt.queryEnd)
 			require.Equal(t, tt.wantMatch, gotMatch, "overlap match failed for %s", tt.desc)

--- a/pkg/dataobj/metastore/object.go
+++ b/pkg/dataobj/metastore/object.go
@@ -324,9 +324,9 @@ func (m *ObjectMetastore) forEachLabel(ctx context.Context, start, end time.Time
 			continue
 		}
 
-		for _, streamLabel := range *streamLabels {
+		streamLabels.Range(func(streamLabel labels.Label) {
 			foreach(streamLabel)
-		}
+		})
 	}
 
 	return nil
@@ -639,8 +639,6 @@ func addLabels(mtx *sync.Mutex, streams map[uint64][]*labels.Labels, newLabels *
 	mtx.Lock()
 	defer mtx.Unlock()
 
-	sort.Sort(newLabels)
-
 	key := labels.StableHash(*newLabels)
 	matches, ok := streams[key]
 	if !ok {
@@ -836,7 +834,8 @@ func objectOverlapsRange(lbs labels.Labels, start, end time.Time) (bool, string)
 		objStart, objEnd time.Time
 		objPath          string
 	)
-	for _, lb := range lbs {
+
+	lbs.Range(func(lb labels.Label) {
 		if lb.Name == labelNameStart {
 			tsNano, err := strconv.ParseInt(lb.Value, 10, 64)
 			if err != nil {
@@ -854,7 +853,8 @@ func objectOverlapsRange(lbs labels.Labels, start, end time.Time) (bool, string)
 		if lb.Name == labelNamePath {
 			objPath = lb.Value
 		}
-	}
+	})
+
 	if objStart.IsZero() || objEnd.IsZero() {
 		return false, ""
 	}

--- a/pkg/dataobj/metastore/object.go
+++ b/pkg/dataobj/metastore/object.go
@@ -641,7 +641,7 @@ func addLabels(mtx *sync.Mutex, streams map[uint64][]*labels.Labels, newLabels *
 
 	sort.Sort(newLabels)
 
-	key := newLabels.Hash()
+	key := labels.StableHash(*newLabels)
 	matches, ok := streams[key]
 	if !ok {
 		streams[key] = append(streams[key], newLabels)

--- a/pkg/dataobj/querier/metadata_test.go
+++ b/pkg/dataobj/querier/metadata_test.go
@@ -2,7 +2,6 @@ package querier
 
 import (
 	"context"
-	"sort"
 	"testing"
 	"time"
 
@@ -316,10 +315,10 @@ func TestStore_LabelValuesForMetricName(t *testing.T) {
 }
 
 func labelsFromSeriesID(id logproto.SeriesIdentifier) string {
-	ls := make(labels.Labels, 0, len(id.Labels))
+	builder := labels.NewScratchBuilder(len(id.Labels))
 	for _, l := range id.Labels {
-		ls = append(ls, labels.Label{Name: l.Key, Value: l.Value})
+		builder.Add(l.Key, l.Value)
 	}
-	sort.Sort(ls)
-	return ls.String()
+	builder.Sort()
+	return builder.Labels().String()
 }

--- a/pkg/dataobj/sections/logs/builder.go
+++ b/pkg/dataobj/sections/logs/builder.go
@@ -107,9 +107,9 @@ func recordSize(record Record) int {
 
 	size++    // One byte per stream ID (for uvarint).
 	size += 8 // Eight bytes for timestamp.
-	for _, metadata := range record.Metadata {
+	record.Metadata.Range(func(metadata labels.Label) {
 		size += len(metadata.Value)
-	}
+	})
 	size += len(record.Line)
 
 	return size

--- a/pkg/dataobj/sections/logs/builder_test.go
+++ b/pkg/dataobj/sections/logs/builder_test.go
@@ -18,19 +18,19 @@ func Test(t *testing.T) {
 		{
 			StreamID:  2,
 			Timestamp: time.Unix(10, 0),
-			Metadata:  []labels.Label{{Name: "cluster", Value: "test"}, {Name: "app", Value: "foo"}},
+			Metadata:  labels.New(labels.Label{Name: "cluster", Value: "test"}, labels.Label{Name: "app", Value: "foo"}),
 			Line:      []byte("foo bar"),
 		},
 		{
 			StreamID:  1,
 			Timestamp: time.Unix(10, 0),
-			Metadata:  nil,
+			Metadata:  labels.EmptyLabels(),
 			Line:      []byte("hello world"),
 		},
 		{
 			StreamID:  2,
 			Timestamp: time.Unix(100, 0),
-			Metadata:  []labels.Label{{Name: "cluster", Value: "test"}, {Name: "app", Value: "bar"}},
+			Metadata:  labels.New(labels.Label{Name: "cluster", Value: "test"}, labels.Label{Name: "app", Value: "bar"}),
 			Line:      []byte("goodbye world"),
 		},
 	}
@@ -55,19 +55,19 @@ func Test(t *testing.T) {
 		{
 			StreamID:  2,
 			Timestamp: time.Unix(100, 0),
-			Metadata:  []labels.Label{{Name: "app", Value: "bar"}, {Name: "cluster", Value: "test"}},
+			Metadata:  labels.New(labels.Label{Name: "app", Value: "bar"}, labels.Label{Name: "cluster", Value: "test"}),
 			Line:      []byte("goodbye world"),
 		},
 		{
 			StreamID:  1,
 			Timestamp: time.Unix(10, 0),
-			Metadata:  []labels.Label{},
+			Metadata:  labels.EmptyLabels(),
 			Line:      []byte("hello world"),
 		},
 		{
 			StreamID:  2,
 			Timestamp: time.Unix(10, 0),
-			Metadata:  []labels.Label{{Name: "app", Value: "foo"}, {Name: "cluster", Value: "test"}},
+			Metadata:  labels.New(labels.Label{Name: "app", Value: "foo"}, labels.Label{Name: "cluster", Value: "test"}),
 			Line:      []byte("foo bar"),
 		},
 	}

--- a/pkg/dataobj/sections/logs/iter.go
+++ b/pkg/dataobj/sections/logs/iter.go
@@ -5,11 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"slices"
-	"strings"
 	"time"
-
-	"github.com/prometheus/prometheus/model/labels"
 
 	"github.com/grafana/loki/v3/pkg/dataobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/dataset"
@@ -18,6 +14,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/result"
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/util/slicegrow"
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/util/symbolizer"
+	"github.com/grafana/loki/v3/pkg/util/labelpool"
 )
 
 // Iter iterates over records in the provided decoder. All logs sections are
@@ -98,10 +95,8 @@ func IterSection(ctx context.Context, section *Section) result.Seq[Record] {
 // The sym argument is used for reusing metadata strings between calls to
 // decodeRow. If sym is nil, metadata strings are always allocated.
 func decodeRow(columns []*logsmd.ColumnDesc, row dataset.Row, record *Record, sym *symbolizer.Symbolizer) error {
-	metadataColumns := metadataColumns(columns)
-	record.Metadata = slicegrow.GrowToCap(record.Metadata, metadataColumns)
-	record.Metadata = record.Metadata[:metadataColumns]
-	nextMetadataIdx := 0
+	labelBuilder := labelpool.Get()
+	defer labelpool.Put(labelBuilder)
 
 	for columnIndex, columnValue := range row.Values {
 		if columnValue.IsNil() || columnValue.IsZero() {
@@ -127,15 +122,11 @@ func decodeRow(columns []*logsmd.ColumnDesc, row dataset.Row, record *Record, sy
 				return fmt.Errorf("invalid type %s for %s", ty, column.Type)
 			}
 
-			record.Metadata[nextMetadataIdx].Name = column.Info.Name
-
 			if sym != nil {
-				record.Metadata[nextMetadataIdx].Value = sym.Get(unsafeString(columnValue.ByteArray()))
+				labelBuilder.Add(column.Info.Name, sym.Get(unsafeString(columnValue.ByteArray())))
 			} else {
-				record.Metadata[nextMetadataIdx].Value = string(columnValue.ByteArray())
+				labelBuilder.Add(column.Info.Name, string(columnValue.ByteArray()))
 			}
-
-			nextMetadataIdx++
 
 		case logsmd.COLUMN_TYPE_MESSAGE:
 			if ty := columnValue.Type(); ty != datasetmd.VALUE_TYPE_BYTE_ARRAY {
@@ -146,19 +137,9 @@ func decodeRow(columns []*logsmd.ColumnDesc, row dataset.Row, record *Record, sy
 		}
 	}
 
-	// Truncate the metadata slice to the number of metadata columns we found.
-	record.Metadata = record.Metadata[:nextMetadataIdx]
-
-	// Metadata is originally sorted in received order; we sort it by key
-	// per-record since it might not be obvious why keys appear in a certain
-	// order.
-	slices.SortFunc(record.Metadata, func(a, b labels.Label) int {
-		if res := strings.Compare(a.Name, b.Name); res != 0 {
-			return res
-		}
-		return strings.Compare(a.Value, b.Value)
-	})
-
+	// Commit the final metadata to the record.
+	labelBuilder.Sort()
+	record.Metadata = labelBuilder.Labels()
 	return nil
 }
 

--- a/pkg/dataobj/sections/logs/iter_test.go
+++ b/pkg/dataobj/sections/logs/iter_test.go
@@ -41,7 +41,7 @@ func TestDecode(t *testing.T) {
 			expected: Record{
 				StreamID:  123,
 				Timestamp: time.Unix(0, 1234567890000000000),
-				Metadata:  []labels.Label{{Name: "app", Value: "test-app"}, {Name: "env", Value: "prod"}},
+				Metadata:  labels.New(labels.Label{Name: "app", Value: "test-app"}, labels.Label{Name: "env", Value: "prod"}),
 				Line:      []byte("test message"),
 			},
 		},
@@ -64,7 +64,7 @@ func TestDecode(t *testing.T) {
 			expected: Record{
 				StreamID:  123,
 				Timestamp: time.Unix(0, 1234567890000000000),
-				Metadata:  []labels.Label{},
+				Metadata:  labels.EmptyLabels(),
 				Line:      []byte("test message"),
 			},
 		},

--- a/pkg/dataobj/sections/logs/reader_test.go
+++ b/pkg/dataobj/sections/logs/reader_test.go
@@ -29,7 +29,7 @@ func TestReader(t *testing.T) {
 		{StreamID: 2, Timestamp: unixTime(40), Metadata: labels.FromStrings("trace_id", "789012"), Line: []byte("baz qux")},
 		{StreamID: 2, Timestamp: unixTime(30), Metadata: labels.FromStrings("trace_id", "123456"), Line: []byte("foo bar")},
 		{StreamID: 1, Timestamp: unixTime(20), Metadata: labels.FromStrings("trace_id", "abcdef"), Line: []byte("goodbye, world!")},
-		{StreamID: 1, Timestamp: unixTime(10), Metadata: nil, Line: []byte("hello, world!")},
+		{StreamID: 1, Timestamp: unixTime(10), Metadata: labels.EmptyLabels(), Line: []byte("hello, world!")},
 	})
 
 	var (

--- a/pkg/dataobj/sections/streams/builder.go
+++ b/pkg/dataobj/sections/streams/builder.go
@@ -164,7 +164,7 @@ func (b *Builder) EstimatedSize() int {
 }
 
 func (b *Builder) getOrAddStream(streamLabels labels.Labels) *Stream {
-	hash := streamLabels.Hash()
+	hash := labels.StableHash(streamLabels)
 	matches, ok := b.lookup[hash]
 	if !ok {
 		return b.addStream(hash, streamLabels)
@@ -202,7 +202,7 @@ func (b *Builder) addStream(hash uint64, streamLabels labels.Labels) *Stream {
 // StreamID returns the stream ID for the provided streamLabels. If the stream
 // has not been recorded, StreamID returns 0.
 func (b *Builder) StreamID(streamLabels labels.Labels) int64 {
-	hash := streamLabels.Hash()
+	hash := labels.StableHash(streamLabels)
 	matches, ok := b.lookup[hash]
 	if !ok {
 		return 0

--- a/pkg/dataobj/sections/streams/builder_test.go
+++ b/pkg/dataobj/sections/streams/builder_test.go
@@ -70,14 +70,14 @@ func Test(t *testing.T) {
 }
 
 func copyLabels(in labels.Labels) labels.Labels {
-	lb := make(labels.Labels, len(in))
-	for i, label := range in {
-		lb[i] = labels.Label{
-			Name:  strings.Clone(label.Name),
-			Value: strings.Clone(label.Value),
-		}
-	}
-	return lb
+	builder := labels.NewScratchBuilder(in.Len())
+
+	in.Range(func(l labels.Label) {
+		builder.Add(strings.Clone(l.Name), strings.Clone(l.Value))
+	})
+
+	builder.Sort()
+	return builder.Labels()
 }
 
 func buildObject(st *streams.Builder) ([]byte, error) {

--- a/pkg/dataobj/sections/streams/iter.go
+++ b/pkg/dataobj/sections/streams/iter.go
@@ -13,8 +13,8 @@ import (
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/metadata/datasetmd"
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/metadata/streamsmd"
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/result"
-	"github.com/grafana/loki/v3/pkg/dataobj/internal/util/slicegrow"
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/util/symbolizer"
+	"github.com/grafana/loki/v3/pkg/util/labelpool"
 )
 
 // Iter iterates over streams in the provided decoder. All streams sections are
@@ -98,10 +98,8 @@ func IterSection(ctx context.Context, section *Section) result.Seq[Stream] {
 // The sym argument is used for reusing label values between calls to
 // decodeRow. If sym is nil, label value strings are always allocated.
 func decodeRow(columns []*streamsmd.ColumnDesc, row dataset.Row, stream *Stream, sym *symbolizer.Symbolizer) error {
-	labelColumns := labelColumns(columns)
-	stream.Labels = slicegrow.GrowToCap(stream.Labels, labelColumns)
-	stream.Labels = stream.Labels[:labelColumns]
-	nextLabelIdx := 0
+	labelBuilder := labelpool.Get()
+	defer labelpool.Put(labelBuilder)
 
 	for columnIndex, columnValue := range row.Values {
 		if columnValue.IsNil() || columnValue.IsZero() {
@@ -145,15 +143,11 @@ func decodeRow(columns []*streamsmd.ColumnDesc, row dataset.Row, stream *Stream,
 				return fmt.Errorf("invalid type %s for %s", ty, column.Type)
 			}
 
-			stream.Labels[nextLabelIdx].Name = column.Info.Name
-
 			if sym != nil {
-				stream.Labels[nextLabelIdx].Value = sym.Get(unsafeString(columnValue.ByteArray()))
+				labelBuilder.Add(column.Info.Name, sym.Get(unsafeString(columnValue.ByteArray())))
 			} else {
-				stream.Labels[nextLabelIdx].Value = string(columnValue.ByteArray())
+				labelBuilder.Add(column.Info.Name, string(columnValue.ByteArray()))
 			}
-
-			nextLabelIdx++
 
 		default:
 			// TODO(rfratto): We probably don't want to return an error on unexpected
@@ -162,19 +156,10 @@ func decodeRow(columns []*streamsmd.ColumnDesc, row dataset.Row, stream *Stream,
 		}
 	}
 
-	stream.Labels = stream.Labels[:nextLabelIdx]
-
+	// Commit the final set of labels to the stream.
+	labelBuilder.Sort()
+	stream.Labels = labelBuilder.Labels()
 	return nil
-}
-
-func labelColumns(columns []*streamsmd.ColumnDesc) int {
-	var count int
-	for _, column := range columns {
-		if column.Type == streamsmd.COLUMN_TYPE_LABEL {
-			count++
-		}
-	}
-	return count
 }
 
 func unsafeSlice(data string, capacity int) []byte {

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -958,7 +958,7 @@ func shardStreamByTime(stream logproto.Stream, lbls labels.Labels, timeShardLen 
 		result = append(result, streamWithTimeShard{
 			Stream: logproto.Stream{
 				Labels:  shardLbls.String(),
-				Hash:    shardLbls.Hash(),
+				Hash:    labels.StableHash(shardLbls),
 				Entries: stream.Entries[startIdx:endIdx],
 			},
 			linesTotalLen: linesTotalLen,
@@ -1093,7 +1093,7 @@ func (d *Distributor) createShard(lbls labels.Labels, streamPattern string, shar
 
 	return logproto.Stream{
 		Labels:  strings.Replace(streamPattern, ingester.ShardLbPlaceholder, shardLabel, 1),
-		Hash:    lbls.Hash(),
+		Hash:    labels.StableHash(lbls),
 		Entries: make([]logproto.Entry, 0, numOfEntries),
 	}
 }
@@ -1309,7 +1309,7 @@ func (d *Distributor) parseStreamLabels(vContext validationContext, key string, 
 		return nil, "", 0, retentionHours, policy, err
 	}
 
-	lsHash := ls.Hash()
+	lsHash := labels.StableHash(ls)
 
 	d.labelCache.Add(key, labelData{ls, lsHash})
 	return ls, ls.String(), lsHash, retentionHours, policy, nil

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -776,7 +776,7 @@ func TestStreamShard(t *testing.T) {
 	baseLabels := "{app='myapp'}"
 	lbs, err := syntax.ParseLabels(baseLabels)
 	require.NoError(t, err)
-	baseStream.Hash = lbs.Hash()
+	baseStream.Hash = labels.StableHash(lbs)
 	baseStream.Labels = lbs.String()
 
 	totalEntries := generateEntries(100)
@@ -871,7 +871,7 @@ func TestStreamShard(t *testing.T) {
 				lbls, err := syntax.ParseLabels(s.Stream.Labels)
 				require.NoError(t, err)
 
-				require.Equal(t, lbls.Hash(), s.Stream.Hash)
+				require.Equal(t, labels.StableHash(lbls), s.Stream.Hash)
 				require.Equal(t, lbls.String(), s.Stream.Labels)
 			}
 		})
@@ -884,7 +884,7 @@ func TestStreamShardAcrossCalls(t *testing.T) {
 	baseLabels := "{app='myapp'}"
 	lbs, err := syntax.ParseLabels(baseLabels)
 	require.NoError(t, err)
-	baseStream.Hash = lbs.Hash()
+	baseStream.Hash = labels.StableHash(lbs)
 	baseStream.Labels = lbs.String()
 	baseStream.Entries = generateEntries(2)
 
@@ -1175,7 +1175,7 @@ func TestStreamShardByTime(t *testing.T) {
 			require.NoError(t, err)
 			stream := logproto.Stream{
 				Labels:  tc.labels,
-				Hash:    lbls.Hash(),
+				Hash:    labels.StableHash(lbls),
 				Entries: tc.entries,
 			}
 
@@ -1210,10 +1210,9 @@ func generateEntries(n int) []logproto.Entry {
 
 func BenchmarkShardStream(b *testing.B) {
 	stream := logproto.Stream{}
-	labels := "{app='myapp', job='fizzbuzz'}"
-	lbs, err := syntax.ParseLabels(labels)
+	lbs, err := syntax.ParseLabels("{app='myapp', job='fizzbuzz'}")
 	require.NoError(b, err)
-	stream.Hash = lbs.Hash()
+	stream.Hash = labels.StableHash(lbs)
 	stream.Labels = lbs.String()
 
 	allEntries := generateEntries(25000)
@@ -1344,7 +1343,7 @@ func TestParseStreamLabels(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, tc.expectedLabels.String(), lbsString)
 			require.Equal(t, tc.expectedLabels, lbs)
-			require.Equal(t, tc.expectedLabels.Hash(), hash)
+			require.Equal(t, labels.StableHash(tc.expectedLabels), hash)
 		})
 	}
 }

--- a/pkg/engine/compat.go
+++ b/pkg/engine/compat.go
@@ -46,7 +46,7 @@ func (b *streamsResultBuilder) CollectRecord(rec arrow.Record) {
 		stream, entry := b.collectRow(rec, row)
 
 		// Ignore rows that don't have stream labels, log line, or timestamp
-		if stream.Len() == 0 || entry.Line == "" || entry.Timestamp.Equal(time.Time{}) {
+		if stream.IsEmpty() || entry.Line == "" || entry.Timestamp.Equal(time.Time{}) {
 			continue
 		}
 

--- a/pkg/engine/executor/dataobjscan.go
+++ b/pkg/engine/executor/dataobjscan.go
@@ -171,7 +171,7 @@ func (s *dataobjScan) initStreams(ctx context.Context) error {
 					continue
 				}
 
-				s.streams[stream.ID] = stream.Labels
+				s.streams[stream.ID] = stream.Labels.Copy()
 
 				// Zero out the stream entry from the slice so the next call to sr.Read
 				// doesn't overwrite any memory we just moved to s.streams.

--- a/pkg/indexgateway/gateway.go
+++ b/pkg/indexgateway/gateway.go
@@ -269,7 +269,7 @@ func (g *Gateway) GetChunkRef(ctx context.Context, req *logproto.GetChunkRefRequ
 	series, err := g.indexQuerier.GetSeries(ctx, instanceID, req.From, req.Through, matchers...)
 	seriesMap := make(map[uint64]labels.Labels, len(series))
 	for _, s := range series {
-		seriesMap[s.Hash()] = s
+		seriesMap[labels.StableHash(s)] = s
 	}
 	sp.AddEvent("indexQuerier.GetSeries", trace.WithAttributes(
 		attribute.String("duration", time.Since(start).String()),

--- a/pkg/indexgateway/gateway_test.go
+++ b/pkg/indexgateway/gateway_test.go
@@ -465,7 +465,7 @@ func TestAccumulateChunksToShards(t *testing.T) {
 						})
 					}
 
-					if stop := fn(nil, s[0].ref.FingerprintModel(), chks); stop {
+					if stop := fn(labels.EmptyLabels(), s[0].ref.FingerprintModel(), chks); stop {
 						return nil
 					}
 				}

--- a/pkg/ingester/checkpoint_test.go
+++ b/pkg/ingester/checkpoint_test.go
@@ -566,7 +566,7 @@ func Benchmark_CheckpointWrite(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		require.NoError(b, writer.Write(&Series{
 			UserID:      "foo",
-			Fingerprint: lbs.Hash(),
+			Fingerprint: labels.StableHash(lbs),
 			Labels:      logproto.FromLabelsToLabelAdapters(lbs),
 			Chunks:      chunks,
 		}))

--- a/pkg/ingester/index/bitprefix_test.go
+++ b/pkg/ingester/index/bitprefix_test.go
@@ -166,12 +166,12 @@ func Test_BitPrefixCreation(t *testing.T) {
 func Test_BitPrefixDeleteAddLoopkup(t *testing.T) {
 	index, err := NewBitPrefixWithShards(DefaultIndexShards)
 	require.Nil(t, err)
-	lbs := []logproto.LabelAdapter{
-		{Name: "foo", Value: "foo"},
-		{Name: "bar", Value: "bar"},
-		{Name: "buzz", Value: "buzz"},
-	}
-	sort.Sort(logproto.FromLabelAdaptersToLabels(lbs))
+
+	lbs := logproto.FromLabelsToLabelAdapters(labels.New(
+		labels.Label{Name: "foo", Value: "foo"},
+		labels.Label{Name: "bar", Value: "bar"},
+		labels.Label{Name: "buzz", Value: "buzz"},
+	))
 
 	index.Add(lbs, model.Fingerprint(labels.StableHash(logproto.FromLabelAdaptersToLabels(lbs))))
 	index.Delete(logproto.FromLabelAdaptersToLabels(lbs), model.Fingerprint(labels.StableHash(logproto.FromLabelAdaptersToLabels(lbs))))

--- a/pkg/ingester/index/bitprefix_test.go
+++ b/pkg/ingester/index/bitprefix_test.go
@@ -173,8 +173,8 @@ func Test_BitPrefixDeleteAddLoopkup(t *testing.T) {
 	}
 	sort.Sort(logproto.FromLabelAdaptersToLabels(lbs))
 
-	index.Add(lbs, model.Fingerprint((logproto.FromLabelAdaptersToLabels(lbs).Hash())))
-	index.Delete(logproto.FromLabelAdaptersToLabels(lbs), model.Fingerprint(logproto.FromLabelAdaptersToLabels(lbs).Hash()))
+	index.Add(lbs, model.Fingerprint(labels.StableHash(logproto.FromLabelAdaptersToLabels(lbs))))
+	index.Delete(logproto.FromLabelAdaptersToLabels(lbs), model.Fingerprint(labels.StableHash(logproto.FromLabelAdaptersToLabels(lbs))))
 	ids, err := index.Lookup([]*labels.Matcher{
 		labels.MustNewMatcher(labels.MatchEqual, "foo", "foo"),
 	}, nil)
@@ -200,11 +200,11 @@ func Test_BitPrefix_hash_mapping(t *testing.T) {
 
 			requestedFactor := 16
 
-			fp := model.Fingerprint(lbs.Hash())
+			fp := model.Fingerprint(labels.StableHash(lbs))
 			ii.Add(logproto.FromLabelsToLabelAdapters(lbs), fp)
 
 			requiredBits := index.NewShard(0, uint32(requestedFactor)).RequiredBits()
-			expShard := uint32(lbs.Hash() >> (64 - requiredBits))
+			expShard := uint32(labels.StableHash(lbs) >> (64 - requiredBits))
 
 			res, err := ii.Lookup(
 				[]*labels.Matcher{{Type: labels.MatchEqual,
@@ -230,7 +230,7 @@ func Test_BitPrefixNoMatcherLookup(t *testing.T) {
 	// with no shard param
 	ii, err := NewBitPrefixWithShards(16)
 	require.Nil(t, err)
-	fp := model.Fingerprint(lbs.Hash())
+	fp := model.Fingerprint(labels.StableHash(lbs))
 	ii.Add(logproto.FromLabelsToLabelAdapters(lbs), fp)
 	ids, err := ii.Lookup(nil, nil)
 	require.Nil(t, err)
@@ -258,7 +258,7 @@ func Test_BitPrefixConsistentMapping(t *testing.T) {
 			"hi", fmt.Sprint(i),
 		)
 
-		fp := model.Fingerprint(lbs.Hash())
+		fp := model.Fingerprint(labels.StableHash(lbs))
 		a.Add(logproto.FromLabelsToLabelAdapters(lbs), fp)
 		b.Add(logproto.FromLabelsToLabelAdapters(lbs), fp)
 	}

--- a/pkg/ingester/index/index_test.go
+++ b/pkg/ingester/index/index_test.go
@@ -87,8 +87,8 @@ func TestDeleteAddLoopkup(t *testing.T) {
 	require.Equal(t, uint32(26), labelsSeriesIDHash(logproto.FromLabelAdaptersToLabels(lbs))%32)
 	// make sure we consistent
 	require.Equal(t, uint32(26), labelsSeriesIDHash(logproto.FromLabelAdaptersToLabels(lbs))%32)
-	index.Add(lbs, model.Fingerprint((logproto.FromLabelAdaptersToLabels(lbs).Hash())))
-	index.Delete(logproto.FromLabelAdaptersToLabels(lbs), model.Fingerprint(logproto.FromLabelAdaptersToLabels(lbs).Hash()))
+	index.Add(lbs, model.Fingerprint(labels.StableHash(logproto.FromLabelAdaptersToLabels(lbs))))
+	index.Delete(logproto.FromLabelAdaptersToLabels(lbs), model.Fingerprint(labels.StableHash(logproto.FromLabelAdaptersToLabels(lbs))))
 	ids, err := index.Lookup([]*labels.Matcher{
 		labels.MustNewMatcher(labels.MatchEqual, "foo", "foo"),
 	}, nil)

--- a/pkg/ingester/index/index_test.go
+++ b/pkg/ingester/index/index_test.go
@@ -77,12 +77,12 @@ func BenchmarkHash(b *testing.B) {
 
 func TestDeleteAddLoopkup(t *testing.T) {
 	index := NewWithShards(DefaultIndexShards)
-	lbs := []logproto.LabelAdapter{
-		{Name: "foo", Value: "foo"},
-		{Name: "bar", Value: "bar"},
-		{Name: "buzz", Value: "buzz"},
-	}
-	sort.Sort(logproto.FromLabelAdaptersToLabels(lbs))
+
+	lbs := logproto.FromLabelsToLabelAdapters(labels.New(
+		labels.Label{Name: "foo", Value: "foo"},
+		labels.Label{Name: "bar", Value: "bar"},
+		labels.Label{Name: "buzz", Value: "buzz"},
+	))
 
 	require.Equal(t, uint32(26), labelsSeriesIDHash(logproto.FromLabelAdaptersToLabels(lbs))%32)
 	// make sure we consistent

--- a/pkg/ingester/index/multi_test.go
+++ b/pkg/ingester/index/multi_test.go
@@ -1,7 +1,6 @@
 package index
 
 import (
-	"sort"
 	"testing"
 	"time"
 
@@ -112,12 +111,11 @@ func TestMultiIndex(t *testing.T) {
 	multi, err := NewMultiInvertedIndex(testPeriodConfigs, factor)
 	require.Nil(t, err)
 
-	lbs := []logproto.LabelAdapter{
-		{Name: "foo", Value: "foo"},
-		{Name: "bar", Value: "bar"},
-		{Name: "buzz", Value: "buzz"},
-	}
-	sort.Sort(logproto.FromLabelAdaptersToLabels(lbs))
+	lbs := logproto.FromLabelsToLabelAdapters(labels.New(
+		labels.Label{Name: "foo", Value: "foo"},
+		labels.Label{Name: "bar", Value: "bar"},
+		labels.Label{Name: "buzz", Value: "buzz"},
+	))
 	fp := model.Fingerprint(labels.StableHash(logproto.FromLabelAdaptersToLabels(lbs)))
 
 	ls := multi.Add(lbs, fp)

--- a/pkg/ingester/index/multi_test.go
+++ b/pkg/ingester/index/multi_test.go
@@ -118,7 +118,7 @@ func TestMultiIndex(t *testing.T) {
 		{Name: "buzz", Value: "buzz"},
 	}
 	sort.Sort(logproto.FromLabelAdaptersToLabels(lbs))
-	fp := model.Fingerprint((logproto.FromLabelAdaptersToLabels(lbs).Hash()))
+	fp := model.Fingerprint(labels.StableHash(logproto.FromLabelAdaptersToLabels(lbs)))
 
 	ls := multi.Add(lbs, fp)
 

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -1020,7 +1020,7 @@ func Test_DedupeIngester(t *testing.T) {
 	for i := int64(0); i < streamCount; i++ {
 		s := labels.FromStrings("foo", "bar", "bar", fmt.Sprintf("baz%d", i))
 		streams = append(streams, s)
-		streamHashes = append(streamHashes, s.Hash())
+		streamHashes = append(streamHashes, labels.StableHash(s))
 	}
 	sort.Slice(streamHashes, func(i, j int) bool { return streamHashes[i] < streamHashes[j] })
 

--- a/pkg/ingester/instance.go
+++ b/pkg/ingester/instance.go
@@ -897,7 +897,7 @@ func (i *instance) getVolume(ctx context.Context, req *logproto.VolumeRequest) (
 			// If the labels are < 1k, this does not alloc
 			// https://github.com/prometheus/prometheus/pull/8025
 			seriesLabels := seriesLabelsBuilder.Labels()
-			hash := seriesLabels.Hash()
+			hash := labels.StableHash(seriesLabels)
 			if _, ok := seriesNames[hash]; !ok {
 				seriesNames[hash] = seriesLabels.String()
 			}

--- a/pkg/ingester/instance_test.go
+++ b/pkg/ingester/instance_test.go
@@ -184,7 +184,7 @@ func TestGetStreamRates(t *testing.T) {
 			l = makeRandomLabels()
 		}
 		uniqueLabels[l.String()] = true
-		labelsByHash[l.Hash()] = l
+		labelsByHash[labels.StableHash(l)] = l
 
 		wg.Add(1)
 		go func(labels string) {

--- a/pkg/ingester/recovery_test.go
+++ b/pkg/ingester/recovery_test.go
@@ -300,7 +300,7 @@ func TestSeriesRecoveryNoDuplicates(t *testing.T) {
 					Parsed:             logproto.EmptyLabelAdapters(),
 				},
 			},
-			Hash: lbls.Hash(),
+			Hash: labels.StableHash(lbls),
 		},
 	}
 	require.Equal(t, expected, result.resps[0].Streams)

--- a/pkg/ingester/stream.go
+++ b/pkg/ingester/stream.go
@@ -110,7 +110,7 @@ func newStream(
 	limits RateLimiterStrategy,
 	tenant string,
 	fp model.Fingerprint,
-	labels labels.Labels,
+	ls labels.Labels,
 	unorderedWrites bool,
 	streamRateCalculator *StreamRateCalculator,
 	metrics *ingesterMetrics,
@@ -118,14 +118,14 @@ func newStream(
 	configs *runtime.TenantConfigs,
 	retentionHours string,
 ) *stream {
-	hashNoShard, _ := labels.HashWithoutLabels(make([]byte, 0, 1024), ShardLbName)
+	hashNoShard, _ := ls.HashWithoutLabels(make([]byte, 0, 1024), ShardLbName)
 	return &stream{
 		limiter:              NewStreamRateLimiter(limits, tenant, 10*time.Second),
 		cfg:                  cfg,
 		fp:                   fp,
-		labels:               labels,
-		labelsString:         labels.String(),
-		labelHash:            labels.Hash(),
+		labels:               ls,
+		labelsString:         ls.String(),
+		labelHash:            labels.StableHash(ls),
 		labelHashNoShard:     hashNoShard,
 		tailers:              map[uint32]*tailer{},
 		metrics:              metrics,

--- a/pkg/iter/categorized_labels_iterator.go
+++ b/pkg/iter/categorized_labels_iterator.go
@@ -52,7 +52,7 @@ func (c *categorizeLabelsIterator) Next() bool {
 
 	newLabels := builder.Labels()
 	c.currStreamLabels = newLabels.String()
-	c.currHash = newLabels.Hash()
+	c.currHash = labels.StableHash(newLabels)
 
 	return true
 }

--- a/pkg/kafka/encoding.go
+++ b/pkg/kafka/encoding.go
@@ -157,7 +157,7 @@ func NewDecoder() (*Decoder, error) {
 func (d *Decoder) Decode(data []byte) (logproto.Stream, labels.Labels, error) {
 	d.stream.Entries = d.stream.Entries[:0]
 	if err := d.stream.Unmarshal(data); err != nil {
-		return logproto.Stream{}, nil, fmt.Errorf("failed to unmarshal stream: %w", err)
+		return logproto.Stream{}, labels.EmptyLabels(), fmt.Errorf("failed to unmarshal stream: %w", err)
 	}
 
 	var ls labels.Labels
@@ -167,7 +167,7 @@ func (d *Decoder) Decode(data []byte) (logproto.Stream, labels.Labels, error) {
 		var err error
 		ls, err = syntax.ParseLabels(d.stream.Labels)
 		if err != nil {
-			return logproto.Stream{}, nil, fmt.Errorf("failed to parse labels: %w", err)
+			return logproto.Stream{}, labels.EmptyLabels(), fmt.Errorf("failed to parse labels: %w", err)
 		}
 		d.cache.Add(d.stream.Labels, ls)
 	}

--- a/pkg/logcli/client/file.go
+++ b/pkg/logcli/client/file.go
@@ -47,12 +47,9 @@ type FileClient struct {
 
 // NewFileClient returns the new instance of FileClient for the given `io.ReadCloser`
 func NewFileClient(r io.ReadCloser) *FileClient {
-	lbs := []labels.Label{
-		{
-			Name:  defaultLabelKey,
-			Value: defaultLabelValue,
-		},
-	}
+	lbs := labels.New(
+		labels.Label{Name: defaultLabelKey, Value: defaultLabelValue},
+	)
 
 	eng := logql.NewEngine(logql.EngineOpts{}, &querier{r: r, labels: lbs}, &limiter{n: defaultMetricSeriesLimit}, log.Logger)
 	return &FileClient{

--- a/pkg/loghttp/push/otlp.go
+++ b/pkg/loghttp/push/otlp.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"sort"
 	"strings"
 	"time"
 
@@ -576,14 +575,10 @@ func labelsSize(lbls push.LabelsAdapter) int {
 }
 
 func modelLabelsSetToLabelsList(m model.LabelSet) labels.Labels {
-	l := make(labels.Labels, 0, len(m))
+	builder := labels.NewScratchBuilder(len(m))
 	for lName, lValue := range m {
-		l = append(l, labels.Label{
-			Name:  string(lName),
-			Value: string(lValue),
-		})
+		builder.Add(string(lName), string(lValue))
 	}
-
-	sort.Sort(l)
-	return l
+	builder.Sort()
+	return builder.Labels()
 }

--- a/pkg/loghttp/query.go
+++ b/pkg/loghttp/query.go
@@ -319,7 +319,6 @@ func (s *Stream) UnmarshalJSON(data []byte) error {
 				if ty == jsonparser.Null {
 					return
 				}
-				// Initialize fields to known values for consistent decoding.
 				var entry Entry
 				if err := entry.UnmarshalJSON(value); err != nil {
 					parseError = err

--- a/pkg/loghttp/query.go
+++ b/pkg/loghttp/query.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"strings"
 	"time"
-	"unsafe"
 
 	"github.com/c2h5oh/datasize"
 	"github.com/gorilla/mux"
@@ -271,13 +270,25 @@ func (s Streams) ToProto() []logproto.Stream {
 	}
 	result := make([]logproto.Stream, 0, len(s))
 	for _, s := range s {
-		entries := *(*[]logproto.Entry)(unsafe.Pointer(&s.Entries)) // #nosec G103 -- we know the string is not mutated
 		result = append(result, logproto.Stream{
 			Labels:  s.Labels.String(),
-			Entries: entries,
+			Entries: protoEntries(s.Entries),
 		})
 	}
 	return result
+}
+
+func protoEntries(in []Entry) []logproto.Entry {
+	out := make([]logproto.Entry, 0, len(in))
+	for _, ent := range in {
+		out = append(out, logproto.Entry{
+			Timestamp:          ent.Timestamp,
+			Line:               ent.Line,
+			StructuredMetadata: logproto.FromLabelsToLabelAdapters(ent.StructuredMetadata),
+			Parsed:             logproto.FromLabelsToLabelAdapters(ent.Parsed),
+		})
+	}
+	return out
 }
 
 // Stream represents a log stream.  It includes a set of log entries and their labels.
@@ -308,6 +319,7 @@ func (s *Stream) UnmarshalJSON(data []byte) error {
 				if ty == jsonparser.Null {
 					return
 				}
+				// Initialize fields to known values for consistent decoding.
 				var entry Entry
 				if err := entry.UnmarshalJSON(value); err != nil {
 					parseError = err

--- a/pkg/logproto/compat_test.go
+++ b/pkg/logproto/compat_test.go
@@ -7,13 +7,10 @@ import (
 	"math"
 	"testing"
 	"time"
-	"unsafe"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/prometheus/common/model"
-	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/timestamp"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/attribute"
 	tracesdk "go.opentelemetry.io/otel/sdk/trace"
@@ -79,18 +76,6 @@ func testUnmarshalling(t *testing.T, unmarshalFn func(data []byte, v interface{}
 	require.NoError(t, err)
 	require.Equal(t, int64(0), sample.TimestampMs)
 	require.True(t, math.IsNaN(sample.Value))
-}
-
-func TestFromLabelAdaptersToLabels(t *testing.T) {
-	input := []LabelAdapter{{Name: "hello", Value: "world"}}
-	expected := labels.Labels{labels.Label{Name: "hello", Value: "world"}}
-	actual := FromLabelAdaptersToLabels(input)
-
-	assert.Equal(t, expected, actual)
-
-	// All strings must NOT be copied.
-	assert.Equal(t, uintptr(unsafe.Pointer(&input[0].Name)), uintptr(unsafe.Pointer(&actual[0].Name)))
-	assert.Equal(t, uintptr(unsafe.Pointer(&input[0].Value)), uintptr(unsafe.Pointer(&actual[0].Value)))
 }
 
 func TestLegacySampleCompatibilityMarshalling(t *testing.T) {

--- a/pkg/logproto/extensions.go
+++ b/pkg/logproto/extensions.go
@@ -77,11 +77,11 @@ func SeriesIdentifierFromMap(in map[string]string) SeriesIdentifier {
 
 func SeriesIdentifierFromLabels(in labels.Labels) SeriesIdentifier {
 	id := SeriesIdentifier{
-		Labels: make([]SeriesIdentifier_LabelsEntry, len(in)),
+		Labels: make([]SeriesIdentifier_LabelsEntry, 0, in.Len()),
 	}
-	for i, l := range in {
-		id.Labels[i] = SeriesIdentifier_LabelsEntry{Key: l.Name, Value: l.Value}
-	}
+	in.Range(func(l labels.Label) {
+		id.Labels = append(id.Labels, SeriesIdentifier_LabelsEntry{Key: l.Name, Value: l.Value})
+	})
 	return id
 }
 

--- a/pkg/logql/engine.go
+++ b/pkg/logql/engine.go
@@ -451,7 +451,7 @@ func vectorsToSeriesWithLimit(vec promql.Vector, sm map[uint64]promql.Series, ma
 	for _, p := range vec {
 		var (
 			series promql.Series
-			hash   = p.Metric.Hash()
+			hash   = labels.StableHash(p.Metric)
 			ok     bool
 		)
 
@@ -487,7 +487,7 @@ func multiVariantVectorsToSeries(ctx context.Context, maxSeries int, vec promql.
 	for _, p := range vec {
 		var (
 			series promql.Series
-			hash   = p.Metric.Hash()
+			hash   = labels.StableHash(p.Metric)
 			ok     bool
 		)
 

--- a/pkg/logql/evaluator.go
+++ b/pkg/logql/evaluator.go
@@ -942,12 +942,12 @@ func (e *BinOpStepEvaluator) Error() error {
 
 func matchingSignature(sample promql.Sample, opts *syntax.BinOpOptions) uint64 {
 	if opts == nil || opts.VectorMatching == nil {
-		return sample.Metric.Hash()
+		return labels.StableHash(sample.Metric)
 	} else if opts.VectorMatching.On {
-		return labels.NewBuilder(sample.Metric).Keep(opts.VectorMatching.MatchingLabels...).Labels().Hash()
+		return labels.StableHash(labels.NewBuilder(sample.Metric).Keep(opts.VectorMatching.MatchingLabels...).Labels())
 	}
 
-	return labels.NewBuilder(sample.Metric).Del(opts.VectorMatching.MatchingLabels...).Labels().Hash()
+	return labels.StableHash(labels.NewBuilder(sample.Metric).Del(opts.VectorMatching.MatchingLabels...).Labels())
 }
 
 func vectorBinop(op string, opts *syntax.BinOpOptions, lhs, rhs promql.Vector, lsigs, rsigs []uint64) (promql.Vector, error) {
@@ -997,7 +997,7 @@ func vectorBinop(op string, opts *syntax.BinOpOptions, lhs, rhs promql.Vector, l
 				}
 				matchedSigs[sig] = nil
 			} else {
-				insertSig := metric.Hash()
+				insertSig := labels.StableHash(metric)
 				if !exists {
 					insertedSigs = map[uint64]struct{}{}
 					matchedSigs[sig] = insertedSigs

--- a/pkg/logql/log/consolidated_variant_extractor.go
+++ b/pkg/logql/log/consolidated_variant_extractor.go
@@ -84,7 +84,7 @@ func appendVariantLabel(lbls LabelsResult, variantIndex int) LabelsResult {
 	newLblsBuilder.Sort()
 	newLbls := newLblsBuilder.Labels()
 
-	builder := NewBaseLabelsBuilder().ForLabels(newLbls, newLbls.Hash())
+	builder := NewBaseLabelsBuilder().ForLabels(newLbls, labels.StableHash(newLbls))
 	builder.Add(StructuredMetadataLabel, lbls.StructuredMetadata())
 	builder.Add(ParsedLabel, lbls.Parsed())
 	return builder.LabelsResult()

--- a/pkg/logql/log/consolidated_variant_extractor_test.go
+++ b/pkg/logql/log/consolidated_variant_extractor_test.go
@@ -79,7 +79,7 @@ func (m *MockCommonPipeline) Reset() {
 }
 
 func (m *MockCommonPipeline) ForStream(lbls labels.Labels) StreamPipeline {
-	lblsResult := NewLabelsResult(lbls.String(), lbls.Hash(), lbls, labels.EmptyLabels(), labels.EmptyLabels())
+	lblsResult := NewLabelsResult(lbls.String(), labels.StableHash(lbls), lbls, labels.EmptyLabels(), labels.EmptyLabels())
 	return &MockCommonStreamPipeline{
 		counter:       m.counter,
 		shouldPass:    m.shouldPass,
@@ -121,7 +121,7 @@ type MockVariantSpecificExtractor struct {
 }
 
 func (m *MockVariantSpecificExtractor) ForStream(lbls labels.Labels) StreamSampleExtractor {
-	lblsResult := NewLabelsResult(lbls.String(), lbls.Hash(), lbls, labels.EmptyLabels(), labels.EmptyLabels())
+	lblsResult := NewLabelsResult(lbls.String(), labels.StableHash(lbls), lbls, labels.EmptyLabels(), labels.EmptyLabels())
 	return &mockVariantSpecificStreamExtractor{
 		valueToExtract: m.valueToExtract,
 		shouldExtract:  m.shouldExtract,

--- a/pkg/logql/log/drop_labels_test.go
+++ b/pkg/logql/log/drop_labels_test.go
@@ -137,7 +137,7 @@ func Test_DropLabels(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
 			dropLabels := NewDropLabels(tt.dropLabels)
-			lbls := NewBaseLabelsBuilder().ForLabels(tt.lbs, tt.lbs.Hash())
+			lbls := NewBaseLabelsBuilder().ForLabels(tt.lbs, labels.StableHash(tt.lbs))
 			lbls.Reset()
 			lbls.SetErr(tt.err)
 			lbls.SetErrorDetails(tt.errDetails)

--- a/pkg/logql/log/fmt_test.go
+++ b/pkg/logql/log/fmt_test.go
@@ -509,7 +509,7 @@ func Test_lineFormatter_Format(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			builder := NewBaseLabelsBuilder().ForLabels(tt.lbs, tt.lbs.Hash())
+			builder := NewBaseLabelsBuilder().ForLabels(tt.lbs, labels.StableHash(tt.lbs))
 			builder.Reset()
 			outLine, _ := tt.fmter.Process(tt.ts, tt.in, builder)
 			require.Equal(t, tt.want, outLine)
@@ -757,7 +757,7 @@ func Test_labelsFormatter_Format(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			builder := NewBaseLabelsBuilder().ForLabels(tt.in, tt.in.Hash())
+			builder := NewBaseLabelsBuilder().ForLabels(tt.in, labels.StableHash(tt.in))
 			builder.Reset()
 			_, _ = tt.fmter.Process(1661518453244672570, []byte("test line"), builder)
 			require.Equal(t, tt.want, builder.LabelsResult().Labels())
@@ -974,7 +974,7 @@ func TestMapPoolPanic(_ *testing.T) {
 	wgFinished := sync.WaitGroup{}
 
 	ls := labels.FromStrings("cluster", "us-central-0")
-	builder := NewBaseLabelsBuilder().ForLabels(ls, ls.Hash())
+	builder := NewBaseLabelsBuilder().ForLabels(ls, labels.StableHash(ls))
 	// this specific line format was part of the query that first alerted us to the panic caused by map pooling in the label/line formatter Process functions
 	tmpl := `[1m{{if .level }}{{alignRight 5 .level}}{{else if .severity}}{{alignRight 5 .severity}}{{end}}[0m [90m[{{alignRight 10 .resources_service_instance_id}}{{if .attributes_thread_name}}/{{alignRight 20 .attributes_thread_name}}{{else if eq "java" .resources_telemetry_sdk_language }}                    {{end}}][0m [36m{{if .instrumentation_scope_name }}{{alignRight 40 .instrumentation_scope_name}}{{end}}[0m {{.body}} {{if .traceid}} [37m[3m[traceid={{.traceid}}]{{end}}`
 	a := newMustLineFormatter(tmpl)

--- a/pkg/logql/log/ip_test.go
+++ b/pkg/logql/log/ip_test.go
@@ -173,7 +173,7 @@ func Test_IPLabelFilterTy(t *testing.T) {
 			lf := NewIPLabelFilter(c.pat, c.label, c.ty)
 
 			lbs := labels.FromStrings(c.label, string(c.val))
-			lbb := NewBaseLabelsBuilder().ForLabels(lbs, lbs.Hash())
+			lbb := NewBaseLabelsBuilder().ForLabels(lbs, labels.StableHash(lbs))
 			_, ok := lf.Process(0, []byte("x"), lbb)
 			if c.fail {
 				assert.Error(t, lf.patError)

--- a/pkg/logql/log/keep_labels_test.go
+++ b/pkg/logql/log/keep_labels_test.go
@@ -111,7 +111,7 @@ func Test_KeepLabels(t *testing.T) {
 	} {
 		t.Run(tc.Name, func(t *testing.T) {
 			keepLabels := NewKeepLabels(tc.keepLabels)
-			lbls := NewBaseLabelsBuilder().ForLabels(tc.lbs, tc.lbs.Hash())
+			lbls := NewBaseLabelsBuilder().ForLabels(tc.lbs, labels.StableHash(tc.lbs))
 			lbls.Reset()
 			keepLabels.Process(0, []byte(""), lbls)
 			require.Equal(t, tc.want, lbls.LabelsResult().Labels())

--- a/pkg/logql/log/label_filter_test.go
+++ b/pkg/logql/log/label_filter_test.go
@@ -171,7 +171,7 @@ func TestBinary_Filter(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.f.String(), func(t *testing.T) {
-			b := NewBaseLabelsBuilder().ForLabels(tt.lbs, tt.lbs.Hash())
+			b := NewBaseLabelsBuilder().ForLabels(tt.lbs, labels.StableHash(tt.lbs))
 			b.Reset()
 			_, got := tt.f.Process(0, nil, b)
 			require.Equal(t, tt.want, got)
@@ -204,7 +204,7 @@ func TestBytes_Filter(t *testing.T) {
 		f := NewBytesLabelFilter(LabelFilterEqual, "bar", tt.expectedBytes)
 		lbs := labels.FromStrings("bar", tt.label)
 		t.Run(f.String(), func(t *testing.T) {
-			b := NewBaseLabelsBuilder().ForLabels(lbs, lbs.Hash())
+			b := NewBaseLabelsBuilder().ForLabels(lbs, labels.StableHash(lbs))
 			b.Reset()
 			_, got := f.Process(0, nil, b)
 			require.Equal(t, tt.want, got)
@@ -272,7 +272,7 @@ func TestErrorFiltering(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.f.String(), func(t *testing.T) {
-			b := NewBaseLabelsBuilder().ForLabels(tt.lbs, tt.lbs.Hash())
+			b := NewBaseLabelsBuilder().ForLabels(tt.lbs, labels.StableHash(tt.lbs))
 			b.Reset()
 			b.SetErr(tt.err)
 			_, got := tt.f.Process(0, nil, b)
@@ -410,7 +410,7 @@ func TestStringLabelFilter(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			_, ok := tc.filter.Process(0, []byte("sample log line"), NewBaseLabelsBuilder().ForLabels(tc.labels, tc.labels.Hash()))
+			_, ok := tc.filter.Process(0, []byte("sample log line"), NewBaseLabelsBuilder().ForLabels(tc.labels, labels.StableHash(tc.labels)))
 			assert.Equal(t, tc.shouldMatch, ok)
 		})
 	}

--- a/pkg/logql/log/labels.go
+++ b/pkg/logql/log/labels.go
@@ -11,7 +11,7 @@ import (
 
 const MaxInternedStrings = 1024
 
-var EmptyLabelsResult = NewLabelsResult(labels.EmptyLabels().String(), labels.EmptyLabels().Hash(), labels.EmptyLabels(), labels.EmptyLabels(), labels.EmptyLabels())
+var EmptyLabelsResult = NewLabelsResult(labels.EmptyLabels().String(), labels.StableHash(labels.EmptyLabels()), labels.EmptyLabels(), labels.EmptyLabels(), labels.EmptyLabels())
 
 // LabelsResult is a computed labels result that contains the labels set with associated string and hash.
 // The is mainly used for caching and returning labels computations out of pipelines and stages.
@@ -775,7 +775,7 @@ func (b *LabelsBuilder) toBaseGroup() LabelsResult {
 	} else {
 		lbs = labels.NewBuilder(b.base).Keep(b.groups...).Labels()
 	}
-	res := NewLabelsResult(lbs.String(), lbs.Hash(), lbs, labels.EmptyLabels(), labels.EmptyLabels())
+	res := NewLabelsResult(lbs.String(), labels.StableHash(lbs), lbs, labels.EmptyLabels(), labels.EmptyLabels())
 	b.groupedResult = res
 	return res
 }

--- a/pkg/logql/log/labels_slicelabels.go
+++ b/pkg/logql/log/labels_slicelabels.go
@@ -1,4 +1,4 @@
-//go:build !stringlabels && !dedupelabels
+//go:build slicelabels
 
 package log
 
@@ -21,27 +21,4 @@ func (h *hasher) Hash(lbs labels.Labels) uint64 {
 	var hash uint64
 	hash, h.buf = lbs.HashWithoutLabels(h.buf, []string(nil)...)
 	return hash
-}
-
-// BufferedLabelsBuilder is a simple builder that uses a label buffer passed in.
-// It is used to avoid allocations when building labels.
-type BufferedLabelsBuilder struct {
-	buf labels.Labels
-}
-
-func NewBufferedLabelsBuilder(labels labels.Labels) *BufferedLabelsBuilder {
-	return &BufferedLabelsBuilder{buf: labels[:0]}
-}
-
-func (b *BufferedLabelsBuilder) Reset() {
-	b.buf = b.buf[:0]
-}
-
-func (b *BufferedLabelsBuilder) Add(label labels.Label) {
-	b.buf = append(b.buf, label)
-}
-
-func (b *BufferedLabelsBuilder) Labels() labels.Labels {
-	//slices.SortFunc(b.buf, func(a, b labels.Label) int { return strings.Compare(a.Name, b.Name) })
-	return b.buf
 }

--- a/pkg/logql/log/labels_stringlabels.go
+++ b/pkg/logql/log/labels_stringlabels.go
@@ -17,7 +17,7 @@ func (h *hasher) Hash(lbs labels.Labels) uint64 {
 	// We use Hash() here because there's no performance advantage to using HashWithoutLabels() with stringlabels.
 	// The results from Hash(l) and HashWithoutLabels(l, []string{}) are different with stringlabels, so using Hash
 	// here also simplifies our tests.
-	return lbs.Hash()
+	return labels.StableHash(lbs)
 }
 
 // BufferedLabelsBuilder is a simple builder that uses a label buffer passed in.

--- a/pkg/logql/log/labels_stringlabels.go
+++ b/pkg/logql/log/labels_stringlabels.go
@@ -1,4 +1,4 @@
-//go:build stringlabels
+//go:build !slicelabels && !dedupelabels
 
 package log
 
@@ -18,26 +18,4 @@ func (h *hasher) Hash(lbs labels.Labels) uint64 {
 	// The results from Hash(l) and HashWithoutLabels(l, []string{}) are different with stringlabels, so using Hash
 	// here also simplifies our tests.
 	return labels.StableHash(lbs)
-}
-
-// BufferedLabelsBuilder is a simple builder that uses a label buffer passed in.
-// It is used to avoid allocations when building labels.
-type BufferedLabelsBuilder struct {
-	builder *labels.Builder
-}
-
-func NewBufferedLabelsBuilder(l labels.Labels) *BufferedLabelsBuilder {
-	return &BufferedLabelsBuilder{builder: labels.NewBuilder(l)}
-}
-
-func (b *BufferedLabelsBuilder) Reset() {
-	b.builder.Reset(labels.EmptyLabels())
-}
-
-func (b *BufferedLabelsBuilder) Add(label labels.Label) {
-	b.builder.Set(label.Name, label.Value)
-}
-
-func (b *BufferedLabelsBuilder) Labels() labels.Labels {
-	return b.builder.Labels()
 }

--- a/pkg/logql/log/labels_test.go
+++ b/pkg/logql/log/labels_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestLabelsBuilder_Get(t *testing.T) {
 	lbs := labels.FromStrings("already", "in")
-	b := NewBaseLabelsBuilder().ForLabels(lbs, lbs.Hash())
+	b := NewBaseLabelsBuilder().ForLabels(lbs, labels.StableHash(lbs))
 	b.Reset()
 	b.Set(StructuredMetadataLabel, "foo", "bar")
 	b.Set(ParsedLabel, "bar", "buzz")
@@ -52,7 +52,7 @@ func TestLabelsBuilder_Get(t *testing.T) {
 
 func TestLabelsBuilder_LabelsError(t *testing.T) {
 	lbs := labels.FromStrings("already", "in")
-	b := NewBaseLabelsBuilder().ForLabels(lbs, lbs.Hash())
+	b := NewBaseLabelsBuilder().ForLabels(lbs, labels.StableHash(lbs))
 	b.Reset()
 	b.SetErr("err")
 	lbsWithErr := b.LabelsResult()
@@ -63,7 +63,7 @@ func TestLabelsBuilder_LabelsError(t *testing.T) {
 	)
 	require.Equal(t, expectedLbs, lbsWithErr.Labels())
 	require.Equal(t, expectedLbs.String(), lbsWithErr.String())
-	require.Equal(t, expectedLbs.Hash(), lbsWithErr.Hash())
+	require.Equal(t, labels.StableHash(expectedLbs), lbsWithErr.Hash())
 	require.Equal(t, labels.FromStrings("already", "in"), lbsWithErr.Stream())
 	require.Equal(t, labels.EmptyLabels(), lbsWithErr.StructuredMetadata())
 	require.Equal(t, labels.FromStrings(logqlmodel.ErrorLabel, "err"), lbsWithErr.Parsed())
@@ -74,7 +74,7 @@ func TestLabelsBuilder_LabelsError(t *testing.T) {
 
 func TestLabelsBuilder_LabelsErrorFromAdd(t *testing.T) {
 	lbs := labels.FromStrings("already", "in")
-	b := NewBaseLabelsBuilder().ForLabels(lbs, lbs.Hash())
+	b := NewBaseLabelsBuilder().ForLabels(lbs, labels.StableHash(lbs))
 	b.Reset()
 
 	// This works for any category
@@ -88,7 +88,7 @@ func TestLabelsBuilder_LabelsErrorFromAdd(t *testing.T) {
 	)
 	require.Equal(t, expectedLbs, lbsWithErr.Labels())
 	require.Equal(t, expectedLbs.String(), lbsWithErr.String())
-	require.Equal(t, expectedLbs.Hash(), lbsWithErr.Hash())
+	require.Equal(t, labels.StableHash(expectedLbs), lbsWithErr.Hash())
 	require.Equal(t, labels.FromStrings("already", "in"), lbsWithErr.Stream())
 	require.Equal(t, labels.EmptyLabels(), lbsWithErr.StructuredMetadata())
 	require.Equal(t, labels.FromStrings(logqlmodel.ErrorLabel, "test error", logqlmodel.ErrorDetailsLabel, "test details"), lbsWithErr.Parsed())
@@ -107,7 +107,7 @@ func TestLabelsBuilder_IntoMap(t *testing.T) {
 	lbs := labels.FromStrings(strs...)
 
 	t.Run("it still copies the map after a Reset", func(t *testing.T) {
-		b := NewBaseLabelsBuilder().ForLabels(lbs, lbs.Hash())
+		b := NewBaseLabelsBuilder().ForLabels(lbs, labels.StableHash(lbs))
 
 		m := map[string]string{}
 		b.IntoMap(m)
@@ -132,7 +132,7 @@ func TestLabelsBuilder_IntoMap(t *testing.T) {
 	})
 
 	t.Run("it can copy the map several times", func(t *testing.T) {
-		b := NewBaseLabelsBuilder().ForLabels(lbs, lbs.Hash())
+		b := NewBaseLabelsBuilder().ForLabels(lbs, labels.StableHash(lbs))
 
 		m := map[string]string{}
 		b.IntoMap(m)
@@ -163,7 +163,7 @@ func TestLabelsBuilder_LabelsResult(t *testing.T) {
 		"ToReplace", "text",
 	}
 	lbs := labels.FromStrings(strs...)
-	b := NewBaseLabelsBuilder().ForLabels(lbs, lbs.Hash())
+	b := NewBaseLabelsBuilder().ForLabels(lbs, labels.StableHash(lbs))
 	b.Reset()
 	assertLabelResult(t, lbs, b.LabelsResult())
 	b.SetErr("err")
@@ -235,7 +235,7 @@ func TestLabelsBuilder_Set(t *testing.T) {
 		"toreplace", "fuzz",
 	}
 	lbs := labels.FromStrings(strs...)
-	b := NewBaseLabelsBuilder().ForLabels(lbs, lbs.Hash())
+	b := NewBaseLabelsBuilder().ForLabels(lbs, labels.StableHash(lbs))
 
 	// test duplicating stream label with parsed label
 	b.Set(StructuredMetadataLabel, "stzz", "stvzz")
@@ -330,7 +330,7 @@ func TestLabelsBuilder_UnsortedLabels(t *testing.T) {
 		"toreplace", "fuzz",
 	}
 	lbs := labels.FromStrings(strs...)
-	b := NewBaseLabelsBuilder().ForLabels(lbs, lbs.Hash())
+	b := NewBaseLabelsBuilder().ForLabels(lbs, labels.StableHash(lbs))
 	b.add[StructuredMetadataLabel] = []labels.Label{{Name: "toreplace", Value: "buzz"}, {Name: "fzz", Value: "bzz"}}
 	b.add[ParsedLabel] = []labels.Label{{Name: "pzz", Value: "pvzz"}}
 	expected := []labels.Label{{Name: "cluster", Value: "us-central1"}, {Name: "namespace", Value: "loki"}, {Name: "fzz", Value: "bzz"}, {Name: "toreplace", Value: "buzz"}, {Name: "pzz", Value: "pvzz"}}
@@ -367,7 +367,7 @@ func TestLabelsBuilder_GroupedLabelsResult(t *testing.T) {
 		"job", "us-central1/loki",
 		"cluster", "us-central1"}
 	lbs := labels.FromStrings(strs...)
-	b := NewBaseLabelsBuilderWithGrouping([]string{"namespace"}, nil, false, false).ForLabels(lbs, lbs.Hash())
+	b := NewBaseLabelsBuilderWithGrouping([]string{"namespace"}, nil, false, false).ForLabels(lbs, labels.StableHash(lbs))
 	b.Reset()
 	assertLabelResult(t, labels.FromStrings("namespace", "loki"), b.GroupedLabels())
 	b.SetErr("err")
@@ -384,7 +384,7 @@ func TestLabelsBuilder_GroupedLabelsResult(t *testing.T) {
 	// cached.
 	assertLabelResult(t, expected, b.GroupedLabels())
 
-	b = NewBaseLabelsBuilderWithGrouping([]string{"job"}, nil, false, false).ForLabels(lbs, lbs.Hash())
+	b = NewBaseLabelsBuilderWithGrouping([]string{"job"}, nil, false, false).ForLabels(lbs, labels.StableHash(lbs))
 	assertLabelResult(t, labels.FromStrings("job", "us-central1/loki"), b.GroupedLabels())
 	assertLabelResult(t, labels.FromStrings("job", "us-central1/loki"), b.GroupedLabels())
 	b.Del("job")
@@ -394,12 +394,12 @@ func TestLabelsBuilder_GroupedLabelsResult(t *testing.T) {
 	assertLabelResult(t, labels.FromStrings("job", "us-central1/loki"), b.GroupedLabels())
 	require.False(t, b.referencedStructuredMetadata)
 
-	b = NewBaseLabelsBuilderWithGrouping([]string{"foo"}, nil, false, false).ForLabels(lbs, lbs.Hash())
+	b = NewBaseLabelsBuilderWithGrouping([]string{"foo"}, nil, false, false).ForLabels(lbs, labels.StableHash(lbs))
 	b.Set(StructuredMetadataLabel, "foo", "bar")
 	assertLabelResult(t, labels.FromStrings("foo", "bar"), b.GroupedLabels())
 	require.True(t, b.referencedStructuredMetadata)
 
-	b = NewBaseLabelsBuilderWithGrouping([]string{"job"}, nil, true, false).ForLabels(lbs, lbs.Hash())
+	b = NewBaseLabelsBuilderWithGrouping([]string{"job"}, nil, true, false).ForLabels(lbs, labels.StableHash(lbs))
 	b.Del("job")
 	b.Set(StructuredMetadataLabel, "foo", "bar")
 	b.Set(StreamLabel, "job", "something")
@@ -410,7 +410,7 @@ func TestLabelsBuilder_GroupedLabelsResult(t *testing.T) {
 	assertLabelResult(t, expected, b.GroupedLabels())
 	require.False(t, b.referencedStructuredMetadata)
 
-	b = NewBaseLabelsBuilderWithGrouping([]string{"foo"}, nil, true, false).ForLabels(lbs, lbs.Hash())
+	b = NewBaseLabelsBuilderWithGrouping([]string{"foo"}, nil, true, false).ForLabels(lbs, labels.StableHash(lbs))
 	b.Set(StructuredMetadataLabel, "foo", "bar")
 	expected = labels.FromStrings("namespace", "loki",
 		"job", "us-central1/loki",
@@ -419,7 +419,7 @@ func TestLabelsBuilder_GroupedLabelsResult(t *testing.T) {
 	assertLabelResult(t, expected, b.GroupedLabels())
 	require.True(t, b.referencedStructuredMetadata)
 
-	b = NewBaseLabelsBuilderWithGrouping(nil, nil, false, false).ForLabels(lbs, lbs.Hash())
+	b = NewBaseLabelsBuilderWithGrouping(nil, nil, false, false).ForLabels(lbs, labels.StableHash(lbs))
 	b.Set(StructuredMetadataLabel, "foo", "bar")
 	b.Set(StreamLabel, "job", "something")
 	expected = labels.FromStrings("namespace", "loki",
@@ -437,7 +437,7 @@ func assertLabelResult(t *testing.T, lbs labels.Labels, res LabelsResult) {
 		res.Labels(),
 	)
 	require.Equal(t,
-		lbs.Hash(),
+		labels.StableHash(lbs),
 		res.Hash(),
 	)
 	require.Equal(t,
@@ -511,7 +511,7 @@ func BenchmarkLabelsBuilder_Add(b *testing.B) {
 			newLabels := newB.Labels()
 
 			lbs := labels.FromStrings("already", "in")
-			builder := NewBaseLabelsBuilder().ForLabels(lbs, lbs.Hash())
+			builder := NewBaseLabelsBuilder().ForLabels(lbs, labels.StableHash(lbs))
 
 			b.ResetTimer()
 			b.ReportAllocs()

--- a/pkg/logql/log/parser_test.go
+++ b/pkg/logql/log/parser_test.go
@@ -216,7 +216,7 @@ func Test_jsonParser_Parse(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			origLine := string(tt.line)
 
-			b := NewBaseLabelsBuilderWithGrouping(nil, tt.hints, false, false).ForLabels(tt.lbs, tt.lbs.Hash())
+			b := NewBaseLabelsBuilderWithGrouping(nil, tt.hints, false, false).ForLabels(tt.lbs, labels.StableHash(tt.lbs))
 			b.Reset()
 			_, _ = j.Process(0, tt.line, b)
 			labels := b.LabelsResult().Labels()
@@ -670,7 +670,7 @@ func TestJSONExpressionParser(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			j, err := NewJSONExpressionParser(tt.expressions)
 			require.NoError(t, err, "cannot create JSON expression parser")
-			b := NewBaseLabelsBuilderWithGrouping(nil, tt.hints, false, false).ForLabels(tt.lbs, tt.lbs.Hash())
+			b := NewBaseLabelsBuilderWithGrouping(nil, tt.hints, false, false).ForLabels(tt.lbs, labels.StableHash(tt.lbs))
 			b.Reset()
 			_, _ = j.Process(0, tt.line, b)
 			require.Equal(t, tt.want, b.LabelsResult().Labels())
@@ -756,7 +756,7 @@ func Benchmark_Parser(b *testing.B) {
 			line := []byte(tt.line)
 			b.Run("no labels hints", func(b *testing.B) {
 				b.ReportAllocs()
-				builder := NewBaseLabelsBuilder().ForLabels(lbs, lbs.Hash())
+				builder := NewBaseLabelsBuilder().ForLabels(lbs, labels.StableHash(lbs))
 				for n := 0; n < b.N; n++ {
 					builder.Reset()
 					_, _ = tt.s.Process(0, line, builder)
@@ -766,7 +766,7 @@ func Benchmark_Parser(b *testing.B) {
 
 			b.Run("labels hints", func(b *testing.B) {
 				b.ReportAllocs()
-				builder := NewBaseLabelsBuilder().ForLabels(lbs, lbs.Hash())
+				builder := NewBaseLabelsBuilder().ForLabels(lbs, labels.StableHash(lbs))
 				builder.parserKeyHints = NewParserHint(tt.LabelParseHints, tt.LabelParseHints, false, false, "", nil)
 
 				for n := 0; n < b.N; n++ {
@@ -779,7 +779,7 @@ func Benchmark_Parser(b *testing.B) {
 			b.Run("inline stages", func(b *testing.B) {
 				b.ReportAllocs()
 				stages := []Stage{NewStringLabelFilter(tt.LabelFilterParseHint)}
-				builder := NewBaseLabelsBuilder().ForLabels(lbs, lbs.Hash())
+				builder := NewBaseLabelsBuilder().ForLabels(lbs, labels.StableHash(lbs))
 				builder.parserKeyHints = NewParserHint(nil, nil, false, false, ", nil", stages)
 				for n := 0; n < b.N; n++ {
 					builder.Reset()
@@ -843,7 +843,7 @@ func Benchmark_Parser_JSONPath(b *testing.B) {
 			line := []byte(tt.line)
 			b.Run("no labels hints", func(b *testing.B) {
 				b.ReportAllocs()
-				builder := NewBaseLabelsBuilder().ForLabels(lbs, lbs.Hash())
+				builder := NewBaseLabelsBuilder().ForLabels(lbs, labels.StableHash(lbs))
 				for n := 0; n < b.N; n++ {
 					builder.Reset()
 					_, _ = tt.s.Process(0, line, builder)
@@ -881,7 +881,7 @@ func Benchmark_Parser_JSONPath(b *testing.B) {
 
 			b.Run("labels hints", func(b *testing.B) {
 				b.ReportAllocs()
-				builder := NewBaseLabelsBuilder().ForLabels(lbs, lbs.Hash())
+				builder := NewBaseLabelsBuilder().ForLabels(lbs, labels.StableHash(lbs))
 				builder.parserKeyHints = NewParserHint(tt.LabelParseHints, tt.LabelParseHints, false, false, "", nil)
 
 				for n := 0; n < b.N; n++ {
@@ -915,7 +915,7 @@ func Benchmark_Parser_JSONPath(b *testing.B) {
 			b.Run("inline stages", func(b *testing.B) {
 				b.ReportAllocs()
 				stages := []Stage{NewStringLabelFilter(tt.LabelFilterParseHint)}
-				builder := NewBaseLabelsBuilder().ForLabels(lbs, lbs.Hash())
+				builder := NewBaseLabelsBuilder().ForLabels(lbs, labels.StableHash(lbs))
 				builder.parserKeyHints = NewParserHint(nil, nil, false, false, ", nil", stages)
 				for n := 0; n < b.N; n++ {
 					builder.Reset()
@@ -1054,7 +1054,7 @@ func Test_regexpParser_Parse(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			b := NewBaseLabelsBuilder().ForLabels(tt.lbs, tt.lbs.Hash())
+			b := NewBaseLabelsBuilder().ForLabels(tt.lbs, labels.StableHash(tt.lbs))
 			b.Reset()
 			_, _ = tt.parser.Process(0, tt.line, b)
 			require.Equal(t, tt.want, b.LabelsResult().Labels())
@@ -1275,7 +1275,7 @@ func TestLogfmtParser_parse(t *testing.T) {
 		p := NewLogfmtParser(false, false)
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
-				b := NewBaseLabelsBuilderWithGrouping(nil, tt.hints, false, false).ForLabels(tt.lbs, tt.lbs.Hash())
+				b := NewBaseLabelsBuilderWithGrouping(nil, tt.hints, false, false).ForLabels(tt.lbs, labels.StableHash(tt.lbs))
 				b.Reset()
 				_, _ = p.Process(0, tt.line, b)
 				require.Equal(t, tt.want, b.LabelsResult().Labels())
@@ -1287,7 +1287,7 @@ func TestLogfmtParser_parse(t *testing.T) {
 		p := NewLogfmtParser(true, false)
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
-				b := NewBaseLabelsBuilderWithGrouping(nil, tt.hints, false, false).ForLabels(tt.lbs, tt.lbs.Hash())
+				b := NewBaseLabelsBuilderWithGrouping(nil, tt.hints, false, false).ForLabels(tt.lbs, labels.StableHash(tt.lbs))
 				b.Reset()
 				_, _ = p.Process(0, tt.line, b)
 
@@ -1354,7 +1354,7 @@ func TestLogfmtParser_keepEmpty(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			for _, tt := range tests {
 				t.Run(tt.name, func(t *testing.T) {
-					b := NewBaseLabelsBuilderWithGrouping(nil, nil, false, false).ForLabels(tt.lbs, tt.lbs.Hash())
+					b := NewBaseLabelsBuilderWithGrouping(nil, nil, false, false).ForLabels(tt.lbs, labels.StableHash(tt.lbs))
 					b.Reset()
 
 					p := NewLogfmtParser(strict, tt.keepEmpty)
@@ -1545,7 +1545,7 @@ func TestLogfmtExpressionParser(t *testing.T) {
 			if err != nil {
 				t.Fatalf("cannot create logfmt expression parser: %s", err.Error())
 			}
-			b := NewBaseLabelsBuilder().ForLabels(tt.lbs, tt.lbs.Hash())
+			b := NewBaseLabelsBuilder().ForLabels(tt.lbs, labels.StableHash(tt.lbs))
 			b.Reset()
 			_, _ = l.Process(0, tt.line, b)
 			require.Equal(t, tt.want, b.LabelsResult().Labels())
@@ -1689,7 +1689,7 @@ func Test_unpackParser_Parse(t *testing.T) {
 	for _, tt := range tests {
 		j := NewUnpackParser()
 		t.Run(tt.name, func(t *testing.T) {
-			b := NewBaseLabelsBuilderWithGrouping(nil, tt.hints, false, false).ForLabels(tt.lbs, tt.lbs.Hash())
+			b := NewBaseLabelsBuilderWithGrouping(nil, tt.hints, false, false).ForLabels(tt.lbs, labels.StableHash(tt.lbs))
 			b.Reset()
 			cp := string(tt.line)
 			l, _ := j.Process(0, tt.line, b)
@@ -1744,7 +1744,7 @@ func Test_PatternParser(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.pattern, func(t *testing.T) {
 			t.Parallel()
-			b := NewBaseLabelsBuilder().ForLabels(tt.lbs, tt.lbs.Hash())
+			b := NewBaseLabelsBuilder().ForLabels(tt.lbs, labels.StableHash(tt.lbs))
 			b.Reset()
 			pp, err := NewPatternParser(tt.pattern)
 			require.NoError(t, err)

--- a/pkg/logql/log/pipeline_test.go
+++ b/pkg/logql/log/pipeline_test.go
@@ -16,15 +16,15 @@ func TestNoopPipeline(t *testing.T) {
 
 	l, lbr, matches := pipeline.ForStream(lbs).Process(0, []byte(""), labels.EmptyLabels())
 	require.Equal(t, []byte(""), l)
-	require.Equal(t, NewLabelsResult(lbs.String(), lbs.Hash(), lbs, labels.EmptyLabels(), labels.EmptyLabels()), lbr)
-	require.Equal(t, lbs.Hash(), lbr.Hash())
+	require.Equal(t, NewLabelsResult(lbs.String(), labels.StableHash(lbs), lbs, labels.EmptyLabels(), labels.EmptyLabels()), lbr)
+	require.Equal(t, labels.StableHash(lbs), lbr.Hash())
 	require.Equal(t, lbs.String(), lbr.String())
 	require.Equal(t, true, matches)
 
 	ls, lbr, matches := pipeline.ForStream(lbs).ProcessString(0, "", labels.EmptyLabels())
 	require.Equal(t, "", ls)
-	require.Equal(t, NewLabelsResult(lbs.String(), lbs.Hash(), lbs, labels.EmptyLabels(), labels.EmptyLabels()), lbr)
-	require.Equal(t, lbs.Hash(), lbr.Hash())
+	require.Equal(t, NewLabelsResult(lbs.String(), labels.StableHash(lbs), lbs, labels.EmptyLabels(), labels.EmptyLabels()), lbr)
+	require.Equal(t, labels.StableHash(lbs), lbr.Hash())
 	require.Equal(t, lbs.String(), lbr.String())
 	require.Equal(t, true, matches)
 
@@ -32,15 +32,15 @@ func TestNoopPipeline(t *testing.T) {
 	expectedLabelsResults := appendLabels(lbs, structuredMetadata)
 	l, lbr, matches = pipeline.ForStream(lbs).Process(0, []byte(""), structuredMetadata)
 	require.Equal(t, []byte(""), l)
-	require.Equal(t, NewLabelsResult(expectedLabelsResults.String(), expectedLabelsResults.Hash(), lbs, structuredMetadata, labels.EmptyLabels()), lbr)
-	require.Equal(t, expectedLabelsResults.Hash(), lbr.Hash())
+	require.Equal(t, NewLabelsResult(expectedLabelsResults.String(), labels.StableHash(expectedLabelsResults), lbs, structuredMetadata, labels.EmptyLabels()), lbr)
+	require.Equal(t, labels.StableHash(expectedLabelsResults), lbr.Hash())
 	require.Equal(t, expectedLabelsResults.String(), lbr.String())
 	require.Equal(t, true, matches)
 
 	ls, lbr, matches = pipeline.ForStream(lbs).ProcessString(0, "", structuredMetadata)
 	require.Equal(t, "", ls)
-	require.Equal(t, NewLabelsResult(expectedLabelsResults.String(), expectedLabelsResults.Hash(), lbs, structuredMetadata, labels.EmptyLabels()), lbr)
-	require.Equal(t, expectedLabelsResults.Hash(), lbr.Hash())
+	require.Equal(t, NewLabelsResult(expectedLabelsResults.String(), labels.StableHash(expectedLabelsResults), lbs, structuredMetadata, labels.EmptyLabels()), lbr)
+	require.Equal(t, labels.StableHash(expectedLabelsResults), lbr.Hash())
 	require.Equal(t, expectedLabelsResults.String(), lbr.String())
 	require.Equal(t, true, matches)
 
@@ -49,8 +49,8 @@ func TestNoopPipeline(t *testing.T) {
 	expectedLabelsResults = labels.FromStrings("foo", "bar", "foo_extracted", "baz", "y", "1", "z", "2")
 	l, lbr, matches = pipeline.ForStream(lbs).Process(0, []byte(""), labels.NewBuilder(structuredMetadata).Set("foo", "baz").Labels())
 	require.Equal(t, []byte(""), l)
-	require.Equal(t, NewLabelsResult(expectedLabelsResults.String(), expectedLabelsResults.Hash(), lbs, expectedNonIndexedLabels, labels.EmptyLabels()), lbr)
-	require.Equal(t, expectedLabelsResults.Hash(), lbr.Hash())
+	require.Equal(t, NewLabelsResult(expectedLabelsResults.String(), labels.StableHash(expectedLabelsResults), lbs, expectedNonIndexedLabels, labels.EmptyLabels()), lbr)
+	require.Equal(t, labels.StableHash(expectedLabelsResults), lbr.Hash())
 	require.Equal(t, expectedLabelsResults.String(), lbr.String())
 	require.Equal(t, true, matches)
 
@@ -67,15 +67,15 @@ func TestPipeline(t *testing.T) {
 
 	l, lbr, matches := p.ForStream(lbs).Process(0, []byte("line"), labels.EmptyLabels())
 	require.Equal(t, []byte("lbs bar"), l)
-	require.Equal(t, NewLabelsResult(lbs.String(), lbs.Hash(), lbs, labels.EmptyLabels(), labels.EmptyLabels()), lbr)
-	require.Equal(t, lbs.Hash(), lbr.Hash())
+	require.Equal(t, NewLabelsResult(lbs.String(), labels.StableHash(lbs), lbs, labels.EmptyLabels(), labels.EmptyLabels()), lbr)
+	require.Equal(t, labels.StableHash(lbs), lbr.Hash())
 	require.Equal(t, lbs.String(), lbr.String())
 	require.Equal(t, true, matches)
 
 	ls, lbr, matches := p.ForStream(lbs).ProcessString(0, "line", labels.EmptyLabels())
 	require.Equal(t, "lbs bar", ls)
-	require.Equal(t, NewLabelsResult(lbs.String(), lbs.Hash(), lbs, labels.EmptyLabels(), labels.EmptyLabels()), lbr)
-	require.Equal(t, lbs.Hash(), lbr.Hash())
+	require.Equal(t, NewLabelsResult(lbs.String(), labels.StableHash(lbs), lbs, labels.EmptyLabels(), labels.EmptyLabels()), lbr)
+	require.Equal(t, labels.StableHash(lbs), lbr.Hash())
 	require.Equal(t, lbs.String(), lbr.String())
 	require.Equal(t, true, matches)
 
@@ -115,15 +115,15 @@ func TestPipelineWithStructuredMetadata(t *testing.T) {
 
 	l, lbr, matches := p.ForStream(lbs).Process(0, []byte("line"), structuredMetadata)
 	require.Equal(t, []byte("lbs bar bob"), l)
-	require.Equal(t, NewLabelsResult(expectedLabelsResults.String(), expectedLabelsResults.Hash(), lbs, structuredMetadata, labels.EmptyLabels()), lbr)
-	require.Equal(t, expectedLabelsResults.Hash(), lbr.Hash())
+	require.Equal(t, NewLabelsResult(expectedLabelsResults.String(), labels.StableHash(expectedLabelsResults), lbs, structuredMetadata, labels.EmptyLabels()), lbr)
+	require.Equal(t, labels.StableHash(expectedLabelsResults), lbr.Hash())
 	require.Equal(t, expectedLabelsResults.String(), lbr.String())
 	require.Equal(t, true, matches)
 
 	ls, lbr, matches := p.ForStream(lbs).ProcessString(0, "line", structuredMetadata)
 	require.Equal(t, "lbs bar bob", ls)
-	require.Equal(t, NewLabelsResult(expectedLabelsResults.String(), expectedLabelsResults.Hash(), lbs, structuredMetadata, labels.EmptyLabels()), lbr)
-	require.Equal(t, expectedLabelsResults.Hash(), lbr.Hash())
+	require.Equal(t, NewLabelsResult(expectedLabelsResults.String(), labels.StableHash(expectedLabelsResults), lbs, structuredMetadata, labels.EmptyLabels()), lbr)
+	require.Equal(t, labels.StableHash(expectedLabelsResults), lbr.Hash())
 	require.Equal(t, expectedLabelsResults.String(), lbr.String())
 	require.Equal(t, true, matches)
 
@@ -133,15 +133,15 @@ func TestPipelineWithStructuredMetadata(t *testing.T) {
 	expectedLabelsResults = appendLabels(expectedLabelsResults, structuredMetadata)
 	l, lbr, matches = p.ForStream(lbs).Process(0, []byte("line"), labels.NewBuilder(structuredMetadata).Set("foo", "baz").Labels())
 	require.Equal(t, []byte("lbs bar bob"), l)
-	require.Equal(t, NewLabelsResult(expectedLabelsResults.String(), expectedLabelsResults.Hash(), lbs, expectedNonIndexedLabels, labels.EmptyLabels()), lbr)
-	require.Equal(t, expectedLabelsResults.Hash(), lbr.Hash())
+	require.Equal(t, NewLabelsResult(expectedLabelsResults.String(), labels.StableHash(expectedLabelsResults), lbs, expectedNonIndexedLabels, labels.EmptyLabels()), lbr)
+	require.Equal(t, labels.StableHash(expectedLabelsResults), lbr.Hash())
 	require.Equal(t, expectedLabelsResults.String(), lbr.String())
 	require.Equal(t, true, matches)
 
 	ls, lbr, matches = p.ForStream(lbs).ProcessString(0, "line", labels.NewBuilder(structuredMetadata).Set("foo", "baz").Labels())
 	require.Equal(t, "lbs bar bob", ls)
-	require.Equal(t, NewLabelsResult(expectedLabelsResults.String(), expectedLabelsResults.Hash(), lbs, expectedNonIndexedLabels, labels.EmptyLabels()), lbr)
-	require.Equal(t, expectedLabelsResults.Hash(), lbr.Hash())
+	require.Equal(t, NewLabelsResult(expectedLabelsResults.String(), labels.StableHash(expectedLabelsResults), lbs, expectedNonIndexedLabels, labels.EmptyLabels()), lbr)
+	require.Equal(t, labels.StableHash(expectedLabelsResults), lbr.Hash())
 	require.Equal(t, expectedLabelsResults.String(), lbr.String())
 	require.Equal(t, true, matches)
 
@@ -393,7 +393,7 @@ func TestDropLabelsPipeline(t *testing.T) {
 			require.Equal(t, labels.EmptyLabels(), finalLbs.Stream())
 			require.Equal(t, labels.EmptyLabels(), finalLbs.StructuredMetadata())
 			require.Equal(t, tt.wantLabels[i], finalLbs.Parsed())
-			require.Equal(t, tt.wantLabels[i].Hash(), finalLbs.Hash())
+			require.Equal(t, labels.StableHash(tt.wantLabels[i]), finalLbs.Hash())
 		}
 	}
 
@@ -515,7 +515,7 @@ func TestKeepLabelsPipeline(t *testing.T) {
 				require.Equal(t, labels.EmptyLabels(), finalLbs.Stream())
 				require.Equal(t, labels.EmptyLabels(), finalLbs.StructuredMetadata())
 				require.Equal(t, tt.wantLabels[i], finalLbs.Parsed())
-				require.Equal(t, tt.wantLabels[i].Hash(), finalLbs.Hash())
+				require.Equal(t, labels.StableHash(tt.wantLabels[i]), finalLbs.Hash())
 				require.Equal(t, tt.wantLabels[i].String(), finalLbs.String())
 			}
 		})

--- a/pkg/logql/quantile_over_time_sketch.go
+++ b/pkg/logql/quantile_over_time_sketch.go
@@ -37,11 +37,11 @@ func (q ProbabilisticQuantileVector) Merge(right ProbabilisticQuantileVector) (P
 		streamHashPool.Put(groups)
 	}()
 	for i, sample := range q {
-		groups[sample.Metric.Hash()] = i
+		groups[labels.StableHash(sample.Metric)] = i
 	}
 
 	for _, sample := range right {
-		i, ok := groups[sample.Metric.Hash()]
+		i, ok := groups[labels.StableHash(sample.Metric)]
 		if !ok {
 			q = append(q, sample)
 			continue

--- a/pkg/logql/range_vector_test.go
+++ b/pkg/logql/range_vector_test.go
@@ -44,12 +44,12 @@ func newSampleIterator(samples []logproto.Sample) iter.SampleIterator {
 		iter.NewSeriesIterator(logproto.Series{
 			Labels:     labelFoo.String(),
 			Samples:    samples,
-			StreamHash: labelFoo.Hash(),
+			StreamHash: labels.StableHash(labelFoo),
 		}),
 		iter.NewSeriesIterator(logproto.Series{
 			Labels:     labelBar.String(),
 			Samples:    samples,
-			StreamHash: labelBar.Hash(),
+			StreamHash: labels.StableHash(labelBar),
 		}),
 	})
 }
@@ -564,7 +564,7 @@ func sampleIter(negative bool) iter.PeekingSampleIterator {
 					{Timestamp: 3, Hash: 2, Value: value(2., negative)},
 					{Timestamp: 4, Hash: 3, Value: value(3., negative)},
 				},
-				StreamHash: labelFoo.Hash(),
+				StreamHash: labels.StableHash(labelFoo),
 			}),
 		}),
 	)

--- a/pkg/logql/test_utils.go
+++ b/pkg/logql/test_utils.go
@@ -78,7 +78,7 @@ outer:
 		ls := mustParseLabels(stream.Labels)
 
 		// filter by shard if requested
-		if shard != nil && ls.Hash()%uint64(shard.Of) != uint64(shard.Shard) {
+		if shard != nil && labels.StableHash(ls)%uint64(shard.Of) != uint64(shard.Shard) {
 			continue
 		}
 
@@ -215,7 +215,7 @@ outer:
 		ls := mustParseLabels(stream.Labels)
 
 		// filter by shard if requested
-		if shard != nil && ls.Hash()%uint64(shard.Of) != uint64(shard.Shard) {
+		if shard != nil && labels.StableHash(ls)%uint64(shard.Of) != uint64(shard.Shard) {
 			continue
 		}
 
@@ -276,10 +276,10 @@ func randomStreams(nStreams, nEntries, nShards int, labelNames []string, valueFi
 		for _, lName := range labelNames {
 			// I needed a way to hash something to uint64
 			// in order to get some form of random label distribution
-			shard := labels.New(append(ls, labels.Label{
+			shard := labels.StableHash(labels.New(append(ls, labels.Label{
 				Name:  lName,
 				Value: fmt.Sprintf("%d", i),
-			})...).Hash() % uint64(nShards)
+			})...)) % uint64(nShards)
 
 			ls = append(ls, labels.Label{
 				Name:  lName,
@@ -300,7 +300,7 @@ func randomStreams(nStreams, nEntries, nShards int, labelNames []string, valueFi
 
 		r := labels.New(ls...)
 		stream.Labels = r.String()
-		stream.Hash = r.Hash()
+		stream.Hash = labels.StableHash(r)
 		streams = append(streams, stream)
 	}
 	return streams

--- a/pkg/logqlanalyzer/analyzer.go
+++ b/pkg/logqlanalyzer/analyzer.go
@@ -75,9 +75,9 @@ func mapAllToLineResult(originLine string, analysisRecords []StageAnalysisRecord
 	return LineResult{originLine, stageRecords}
 }
 
-func mapAllToLabelsResponse(labels labels.Labels) []Label {
-	result := make([]Label, 0, len(labels))
-	for _, label := range labels {
+func mapAllToLabelsResponse(lbls []labels.Label) []Label {
+	result := make([]Label, 0, len(lbls))
+	for _, label := range lbls {
 		result = append(result, Label{Name: label.Name, Value: label.Value})
 	}
 	return result
@@ -152,8 +152,8 @@ func (s StageAnalysisRecorder) RequiredLabelNames() []string {
 type StageAnalysisRecord struct {
 	Processed    bool
 	LineBefore   string
-	LabelsBefore labels.Labels
+	LabelsBefore []labels.Label
 	LineAfter    string
-	LabelsAfter  labels.Labels
+	LabelsAfter  []labels.Label
 	FilteredOut  bool
 }

--- a/pkg/logqlanalyzer/analyzer.go
+++ b/pkg/logqlanalyzer/analyzer.go
@@ -117,7 +117,7 @@ func (p streamPipelineAnalyzer) AnalyzeLine(line string) []StageAnalysisRecord {
 			stageIndex: i,
 		})
 	}
-	stream := log.NewStreamPipeline(stageRecorders, p.origin.LabelsBuilder().ForLabels(p.streamLabels, p.streamLabels.Hash()))
+	stream := log.NewStreamPipeline(stageRecorders, p.origin.LabelsBuilder().ForLabels(p.streamLabels, labels.StableHash(p.streamLabels)))
 	_, _, _ = stream.ProcessString(time.Now().UnixMilli(), line, labels.EmptyLabels())
 	return records
 }

--- a/pkg/pattern/aggregation/push.go
+++ b/pkg/pattern/aggregation/push.go
@@ -409,9 +409,9 @@ func internalEntry(
 	base string,
 	lbls labels.Labels,
 ) string {
-	for _, l := range lbls {
+	lbls.Range(func(l labels.Label) {
 		base += fmt.Sprintf(" %s=\"%s\"", l.Name, l.Value)
-	}
+	})
 
 	return base
 }

--- a/pkg/pattern/aggregation/push.go
+++ b/pkg/pattern/aggregation/push.go
@@ -216,7 +216,7 @@ func (p *Push) buildPayload(ctx context.Context) ([]byte, error) {
 		streams = append(streams, logproto.Stream{
 			Labels:  s,
 			Entries: entries,
-			Hash:    lbls.Hash(),
+			Hash:    labels.StableHash(lbls),
 		})
 	}
 

--- a/pkg/pattern/aggregation/push_test.go
+++ b/pkg/pattern/aggregation/push_test.go
@@ -253,7 +253,7 @@ func Test_Push(t *testing.T) {
 
 // Test helpers
 
-func assertResponse(t *testing.T, resp response, testAuth bool, labels labels.Labels, ts time.Time, payload string) {
+func assertResponse(t *testing.T, resp response, testAuth bool, ls labels.Labels, ts time.Time, payload string) {
 	t.Helper()
 
 	// assert metadata
@@ -273,8 +273,8 @@ func assertResponse(t *testing.T, resp response, testAuth bool, labels labels.La
 
 	// assert stream labels
 	require.Len(t, resp.pushReq.Streams, 1)
-	assert.Equal(t, labels.String(), resp.pushReq.Streams[0].Labels)
-	assert.Equal(t, labels.Hash(), resp.pushReq.Streams[0].Hash)
+	assert.Equal(t, ls.String(), resp.pushReq.Streams[0].Labels)
+	assert.Equal(t, labels.StableHash(ls), resp.pushReq.Streams[0].Hash)
 
 	// assert log entry
 	require.Len(t, resp.pushReq.Streams, 1)

--- a/pkg/pattern/drain/drain.go
+++ b/pkg/pattern/drain/drain.go
@@ -305,9 +305,9 @@ func (d *Drain) writePattern(
 		service = push.ServiceUnknown
 	}
 
-	newLbls := labels.Labels{
+	newLbls := labels.New(
 		labels.Label{Name: constants.PatternLabel, Value: service},
-	}
+	)
 
 	newStructuredMetadata := []logproto.LabelAdapter{
 		{Name: constants.LevelLabel, Value: lvl},

--- a/pkg/pattern/instance.go
+++ b/pkg/pattern/instance.go
@@ -253,7 +253,7 @@ func (i *instance) getHashForLabels(ls labels.Labels) model.Fingerprint {
 func (i *instance) getLabelsFromFingerprint(fp model.Fingerprint) labels.Labels {
 	s, ok := i.streams.LoadByFP(fp)
 	if !ok {
-		return nil
+		return labels.EmptyLabels()
 	}
 	return s.labels
 }
@@ -334,9 +334,9 @@ func (i *instance) writeAggregatedMetrics(
 		service = push.ServiceUnknown
 	}
 
-	newLbls := labels.Labels{
+	newLbls := labels.New(
 		labels.Label{Name: constants.AggregatedMetricLabel, Value: service},
-	}
+	)
 
 	sturcturedMetadata := []logproto.LabelAdapter{
 		{Name: constants.LevelLabel, Value: level},

--- a/pkg/pattern/stream.go
+++ b/pkg/pattern/stream.go
@@ -33,7 +33,7 @@ type stream struct {
 
 func newStream(
 	fp model.Fingerprint,
-	labels labels.Labels,
+	ls labels.Labels,
 	metrics *ingesterMetrics,
 	logger log.Logger,
 	guessedFormat string,
@@ -61,9 +61,9 @@ func newStream(
 
 	return &stream{
 		fp:           fp,
-		labels:       labels,
-		labelsString: labels.String(),
-		labelHash:    labels.Hash(),
+		labels:       ls,
+		labelsString: ls.String(),
+		labelHash:    labels.StableHash(ls),
 		logger:       logger,
 		patterns:     patterns,
 	}, nil

--- a/pkg/pattern/stream_test.go
+++ b/pkg/pattern/stream_test.go
@@ -19,7 +19,7 @@ import (
 func TestAddStream(t *testing.T) {
 	lbs := labels.New(labels.Label{Name: "test", Value: "test"})
 	mockWriter := &mockEntryWriter{}
-	stream, err := newStream(model.Fingerprint(lbs.Hash()), lbs, newIngesterMetrics(nil, "test"), log.NewNopLogger(), drain.FormatUnknown, "123", drain.DefaultConfig(), &fakeLimits{}, mockWriter)
+	stream, err := newStream(model.Fingerprint(labels.StableHash(lbs)), lbs, newIngesterMetrics(nil, "test"), log.NewNopLogger(), drain.FormatUnknown, "123", drain.DefaultConfig(), &fakeLimits{}, mockWriter)
 	require.NoError(t, err)
 
 	err = stream.Push(context.Background(), []push.Entry{
@@ -48,7 +48,7 @@ func TestAddStream(t *testing.T) {
 func TestPruneStream(t *testing.T) {
 	lbs := labels.New(labels.Label{Name: "test", Value: "test"})
 	mockWriter := &mockEntryWriter{}
-	stream, err := newStream(model.Fingerprint(lbs.Hash()), lbs, newIngesterMetrics(nil, "test"), log.NewNopLogger(), drain.FormatUnknown, "123", drain.DefaultConfig(), &fakeLimits{}, mockWriter)
+	stream, err := newStream(model.Fingerprint(labels.StableHash(lbs)), lbs, newIngesterMetrics(nil, "test"), log.NewNopLogger(), drain.FormatUnknown, "123", drain.DefaultConfig(), &fakeLimits{}, mockWriter)
 	require.NoError(t, err)
 
 	err = stream.Push(context.Background(), []push.Entry{

--- a/pkg/querier/multi_tenant_querier_test.go
+++ b/pkg/querier/multi_tenant_querier_test.go
@@ -220,12 +220,12 @@ func newSampleIterator() iter.SampleIterator {
 		iter.NewSeriesIterator(logproto.Series{
 			Labels:     labelFoo.String(),
 			Samples:    samples,
-			StreamHash: labelFoo.Hash(),
+			StreamHash: labels.StableHash(labelFoo),
 		}),
 		iter.NewSeriesIterator(logproto.Series{
 			Labels:     labelBar.String(),
 			Samples:    samples,
-			StreamHash: labelBar.Hash(),
+			StreamHash: labels.StableHash(labelBar),
 		}),
 	})
 }

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -1024,7 +1024,7 @@ func parseDetectedFields(limit uint32, streams logqlmodel.Streams) map[string]*p
 				}
 			}
 
-			streamLbls := logql_log.NewBaseLabelsBuilder().ForLabels(streamLbls, streamLbls.Hash())
+			streamLbls := logql_log.NewBaseLabelsBuilder().ForLabels(streamLbls, labels.StableHash(streamLbls))
 			parsedLabels, parsers := parseEntry(entry, streamLbls)
 			for k, vals := range parsedLabels {
 				df, ok := detectedFields[k]

--- a/pkg/querier/querier_mock_test.go
+++ b/pkg/querier/querier_mock_test.go
@@ -837,10 +837,10 @@ func newMockEngineWithPatterns(patterns []string) logql.Engine {
 	matrix := promql.Matrix{}
 	for _, pattern := range patterns {
 		matrix = append(matrix, promql.Series{
-			Metric: labels.Labels{
-				{Name: "service_name", Value: "test-service"},
-				{Name: "decoded_pattern", Value: pattern},
-			},
+			Metric: labels.New(
+				labels.Label{Name: "service_name", Value: "test-service"},
+				labels.Label{Name: "decoded_pattern", Value: pattern},
+			),
 			Floats: []promql.FPoint{
 				{T: time.Now().UnixMilli(), F: 100},
 			},
@@ -865,10 +865,10 @@ func newMockEngineWithPatternsAndTimestamps(patternSamples []patternSample) logq
 	matrix := promql.Matrix{}
 	for _, ps := range patternSamples {
 		matrix = append(matrix, promql.Series{
-			Metric: labels.Labels{
-				{Name: "service_name", Value: "test-service"},
-				{Name: "decoded_pattern", Value: ps.pattern},
-			},
+			Metric: labels.New(
+				labels.Label{Name: "service_name", Value: "test-service"},
+				labels.Label{Name: "decoded_pattern", Value: ps.pattern},
+			),
 			Floats: []promql.FPoint{
 				{T: ps.timestamp, F: float64(ps.value)},
 			},

--- a/pkg/querier/querier_mock_test.go
+++ b/pkg/querier/querier_mock_test.go
@@ -607,7 +607,7 @@ func mockLogfmtStreamWithLabels(_ int, quantity int, lbls string) logproto.Strea
 		streamLabels = labels.EmptyLabels()
 	}
 
-	lblBuilder := log.NewBaseLabelsBuilder().ForLabels(streamLabels, streamLabels.Hash())
+	lblBuilder := log.NewBaseLabelsBuilder().ForLabels(streamLabels, labels.StableHash(streamLabels))
 	logFmtParser := log.NewLogfmtParser(false, false)
 
 	// used for detected fields queries which are always BACKWARD
@@ -667,7 +667,7 @@ func mockLogfmtStreamWithLabelsAndStructuredMetadata(
 		streamLabels = labels.EmptyLabels()
 	}
 
-	lblBuilder := log.NewBaseLabelsBuilder().ForLabels(streamLabels, streamLabels.Hash())
+	lblBuilder := log.NewBaseLabelsBuilder().ForLabels(streamLabels, labels.StableHash(streamLabels))
 	logFmtParser := log.NewLogfmtParser(false, false)
 
 	for i := quantity; i > 0; i-- {

--- a/pkg/querier/queryrange/detected_fields.go
+++ b/pkg/querier/queryrange/detected_fields.go
@@ -151,7 +151,7 @@ func parseDetectedFieldValues(limit uint32, streams []push.Stream, name string) 
 				}
 			}
 
-			entryLbls := logql_log.NewBaseLabelsBuilder().ForLabels(streamLbls, streamLbls.Hash())
+			entryLbls := logql_log.NewBaseLabelsBuilder().ForLabels(streamLbls, labels.StableHash(streamLbls))
 			parsedLabels, _ := parseEntry(entry, entryLbls)
 			if vals, ok := parsedLabels[name]; ok {
 				for _, v := range vals {
@@ -317,7 +317,7 @@ func parseDetectedFields(limit uint32, streams logqlmodel.Streams) map[string]*p
 				}
 			}
 
-			entryLbls := logql_log.NewBaseLabelsBuilder().ForLabels(streamLbls, streamLbls.Hash())
+			entryLbls := logql_log.NewBaseLabelsBuilder().ForLabels(streamLbls, labels.StableHash(streamLbls))
 			parsedLabels, parsers := parseEntry(entry, entryLbls)
 			for k, vals := range parsedLabels {
 				df, ok := detectedFields[k]
@@ -392,7 +392,7 @@ func parseEntry(entry push.Entry, lbls *logql_log.LabelsBuilder) (map[string][]s
 		lbls.Del(name)
 	}
 	streamLbls := lbls.LabelsResult().Stream()
-	lblBuilder := lbls.ForLabels(streamLbls, streamLbls.Hash())
+	lblBuilder := lbls.ForLabels(streamLbls, labels.StableHash(streamLbls))
 
 	parsed := make(map[string][]string, len(origParsed))
 	for lbl, values := range origParsed {

--- a/pkg/querier/queryrange/detected_fields_test.go
+++ b/pkg/querier/queryrange/detected_fields_test.go
@@ -60,7 +60,7 @@ func Test_parseDetectedFields(t *testing.T) {
 		rulerStream := push.Stream{
 			Labels:  rulerLbls,
 			Entries: rulerLines,
-			Hash:    rulerMetric.Hash(),
+			Hash:    labels.StableHash(rulerMetric),
 		}
 
 		debugDetectedFieldMetadata := []push.LabelAdapter{
@@ -95,7 +95,7 @@ func Test_parseDetectedFields(t *testing.T) {
 		nginxStream := push.Stream{
 			Labels:  nginxLbls,
 			Entries: nginxJSONLines,
-			Hash:    nginxMetric.Hash(),
+			Hash:    labels.StableHash(nginxMetric),
 		}
 
 		t.Run("detects logfmt fields", func(t *testing.T) {
@@ -191,7 +191,7 @@ func Test_parseDetectedFields(t *testing.T) {
 			rulerStream := push.Stream{
 				Labels:  rulerLbls,
 				Entries: rulerLines,
-				Hash:    rulerMetric.Hash(),
+				Hash:    labels.StableHash(rulerMetric),
 			}
 
 			df := parseDetectedFields(uint32(15), logqlmodel.Streams([]push.Stream{rulerStream}))
@@ -220,7 +220,7 @@ func Test_parseDetectedFields(t *testing.T) {
 			rulerStream := push.Stream{
 				Labels:  rulerLbls,
 				Entries: rulerLines,
-				Hash:    rulerMetric.Hash(),
+				Hash:    labels.StableHash(rulerMetric),
 			}
 
 			nginxLbls := `{ cluster="eu-west-1", level="debug", namespace="gateway", pod="nginx-json-oghco", service_name="nginx-json", host="localhost"}`
@@ -230,7 +230,7 @@ func Test_parseDetectedFields(t *testing.T) {
 			nginxStream := push.Stream{
 				Labels:  nginxLbls,
 				Entries: nginxJSONLines,
-				Hash:    nginxMetric.Hash(),
+				Hash:    labels.StableHash(nginxMetric),
 			}
 
 			df := parseDetectedFields(
@@ -322,7 +322,7 @@ func Test_parseDetectedFields(t *testing.T) {
 		)
 
 		rulerStreams := []push.Stream{}
-		streamLbls := logql_log.NewBaseLabelsBuilder().ForLabels(rulerLbls, rulerLbls.Hash())
+		streamLbls := logql_log.NewBaseLabelsBuilder().ForLabels(rulerLbls, labels.StableHash(rulerLbls))
 
 		for _, rulerFields := range [][]push.LabelAdapter{
 			parsedRulerFields(
@@ -435,7 +435,7 @@ func Test_parseDetectedFields(t *testing.T) {
 		)
 
 		nginxStreams := []push.Stream{}
-		nginxStreamLbls := logql_log.NewBaseLabelsBuilder().ForLabels(nginxLbls, nginxLbls.Hash())
+		nginxStreamLbls := logql_log.NewBaseLabelsBuilder().ForLabels(nginxLbls, labels.StableHash(nginxLbls))
 
 		for _, nginxFields := range [][]push.LabelAdapter{
 			parsedNginxFields(
@@ -658,7 +658,7 @@ func Test_parseDetectedFields(t *testing.T) {
 						},
 					},
 				},
-				Hash: rulerMetric.Hash(),
+				Hash: labels.StableHash(rulerMetric),
 			}
 
 			df := parseDetectedFields(uint32(15), logqlmodel.Streams([]push.Stream{rulerStream}))
@@ -723,7 +723,7 @@ func Test_parseDetectedFields(t *testing.T) {
 						},
 					},
 				},
-				Hash: rulerMetric.Hash(),
+				Hash: labels.StableHash(rulerMetric),
 			}
 
 			nginxLbls := `{ cluster="eu-west-1", level="debug", namespace="gateway", pod="nginx-json-oghco", service_name="nginx-json", host="localhost"}`
@@ -777,7 +777,7 @@ func Test_parseDetectedFields(t *testing.T) {
 						},
 					},
 				},
-				Hash: nginxMetric.Hash(),
+				Hash: labels.StableHash(nginxMetric),
 			}
 
 			df := parseDetectedFields(
@@ -845,7 +845,7 @@ func Test_parseDetectedFields(t *testing.T) {
 					},
 				},
 			},
-			Hash: rulerMetric.Hash(),
+			Hash: labels.StableHash(rulerMetric),
 		}
 
 		df := parseDetectedFields(
@@ -871,7 +871,7 @@ func mockLogfmtStreamWithLabels(_ int, quantity int, lbls string) logproto.Strea
 		streamLabels = labels.EmptyLabels()
 	}
 
-	lblBuilder := logql_log.NewBaseLabelsBuilder().ForLabels(streamLabels, streamLabels.Hash())
+	lblBuilder := logql_log.NewBaseLabelsBuilder().ForLabels(streamLabels, labels.StableHash(streamLabels))
 	logFmtParser := logql_log.NewLogfmtParser(false, false)
 
 	// used for detected fields queries which are always BACKWARD
@@ -928,7 +928,7 @@ func mockLogfmtStreamWithLabelsAndStructuredMetadata(
 		streamLabels = labels.EmptyLabels()
 	}
 
-	lblBuilder := logql_log.NewBaseLabelsBuilder().ForLabels(streamLabels, streamLabels.Hash())
+	lblBuilder := logql_log.NewBaseLabelsBuilder().ForLabels(streamLabels, labels.StableHash(streamLabels))
 	logFmtParser := logql_log.NewLogfmtParser(false, false)
 
 	// used for detected fields queries which are always BACKWARD
@@ -1352,7 +1352,7 @@ func TestQuerier_DetectedFields(t *testing.T) {
 		stream := push.Stream{
 			Labels:  lbls,
 			Entries: lines,
-			Hash:    metric.Hash(),
+			Hash:    labels.StableHash(metric),
 		}
 
 		handler := NewDetectedFieldsHandler(
@@ -1504,7 +1504,7 @@ func TestNestedJSONFieldDetection(t *testing.T) {
 		nestedJSONStream := push.Stream{
 			Labels:  nestedJSONLbls,
 			Entries: nestedJSONLines,
-			Hash:    nestedJSONMetric.Hash(),
+			Hash:    labels.StableHash(nestedJSONMetric),
 		}
 
 		df := parseDetectedFields(uint32(20), logqlmodel.Streams([]push.Stream{nestedJSONStream}))
@@ -1602,7 +1602,7 @@ func TestNestedJSONFieldDetection(t *testing.T) {
 		nestedJSONStream := push.Stream{
 			Labels:  nestedJSONLbls,
 			Entries: nestedJSONLines,
-			Hash:    nestedJSONMetric.Hash(),
+			Hash:    labels.StableHash(nestedJSONMetric),
 		}
 
 		df := parseDetectedFields(uint32(20), logqlmodel.Streams([]push.Stream{nestedJSONStream}))

--- a/pkg/ruler/memstore.go
+++ b/pkg/ruler/memstore.go
@@ -185,7 +185,7 @@ type memStoreQuerier struct {
 // Select implements storage.Querier but takes advantage of the fact that it's only called when restoring for state
 // in order to lookup & cache previous rule evaluations. This results in a sort of synthetic metric store.
 func (m *memStoreQuerier) Select(ctx context.Context, _ bool, _ *storage.SelectHints, matchers ...*labels.Matcher) storage.SeriesSet {
-	b := labels.NewBuilder(nil)
+	b := labels.NewBuilder(labels.EmptyLabels())
 	var ruleKey string
 	for _, matcher := range matchers {
 		// Since Select is only called to restore the for state of an alert, we can deduce two things:

--- a/pkg/ruler/memstore.go
+++ b/pkg/ruler/memstore.go
@@ -332,7 +332,7 @@ func (c *RuleCache) Set(ts time.Time, vec promql.Vector) {
 	}
 
 	for _, sample := range vec {
-		tsMap[sample.Metric.Hash()] = sample
+		tsMap[labels.StableHash(sample.Metric)] = sample
 	}
 	c.metrics.samples.Add(float64(len(vec)))
 }
@@ -347,7 +347,7 @@ func (c *RuleCache) Get(ts time.Time, ls labels.Labels) (*promql.Sample, bool) {
 		return nil, false
 	}
 
-	smp, ok := match[ls.Hash()]
+	smp, ok := match[labels.StableHash(ls)]
 	if !ok {
 		return nil, true
 	}

--- a/pkg/ruler/storage/instance/instance_test.go
+++ b/pkg/ruler/storage/instance/instance_test.go
@@ -268,7 +268,7 @@ func (a *mockAppender) Add(l labels.Labels, _ int64, _ float64) (storage.SeriesR
 	a.s.mut.Lock()
 	defer a.s.mut.Unlock()
 
-	hash := l.Hash()
+	hash := labels.StableHash(l)
 	a.s.series[storage.SeriesRef(hash)] = 1
 	return storage.SeriesRef(hash), nil
 }

--- a/pkg/ruler/storage/wal/series.go
+++ b/pkg/ruler/storage/wal/series.go
@@ -144,7 +144,7 @@ func (s *stripeSeries) gc(mint int64) map[chunks.HeadSeriesRef]struct{} {
 
 		for _, series := range s.series[i] {
 			series.Lock()
-			seriesHash := series.lset.Hash()
+			seriesHash := labels.StableHash(series.lset)
 
 			// If the series has received a write after mint, there's still
 			// data and it's not completely gone yet.
@@ -239,7 +239,7 @@ func (it *stripeSeriesIterator) Channel() <-chan *memSeries {
 			for _, series := range it.s.series[i] {
 				series.Lock()
 
-				j := int(series.lset.Hash()) & (it.s.size - 1)
+				j := int(labels.StableHash(series.lset)) & (it.s.size - 1)
 				if i != j {
 					it.s.locks[j].RLock()
 				}

--- a/pkg/ruler/storage/wal/wal.go
+++ b/pkg/ruler/storage/wal/wal.go
@@ -566,7 +566,7 @@ func (a *appender) Append(ref storage.SeriesRef, l labels.Labels, t int64, v flo
 		// Ensure no empty or duplicate labels have gotten through. This mirrors the
 		// equivalent validation code in the TSDB's headAppender.
 		l = l.WithoutEmpty()
-		if l.Len() == 0 {
+		if l.IsEmpty() {
 			return 0, errors.Wrap(tsdb.ErrInvalidSample, "empty labelset")
 		}
 

--- a/pkg/ruler/storage/wal/wal.go
+++ b/pkg/ruler/storage/wal/wal.go
@@ -267,7 +267,7 @@ func (w *Storage) loadWAL(r *wlog.Reader) (err error) {
 				// the truncation is performed.
 				if w.series.getByID(s.Ref) == nil {
 					series := &memSeries{ref: s.Ref, lset: s.Labels, lastTs: 0}
-					w.series.set(s.Labels.Hash(), series)
+					w.series.set(labels.StableHash(s.Labels), series)
 
 					w.metrics.NumActiveSeries.Inc()
 					w.metrics.TotalCreatedSeries.Inc()
@@ -605,7 +605,7 @@ func (a *appender) Append(ref storage.SeriesRef, l labels.Labels, t int64, v flo
 }
 
 func (a *appender) getOrCreate(l labels.Labels) (series *memSeries, created bool) {
-	hash := l.Hash()
+	hash := labels.StableHash(l)
 
 	series = a.w.series.getByHash(hash, l)
 	if series != nil {
@@ -613,7 +613,7 @@ func (a *appender) getOrCreate(l labels.Labels) (series *memSeries, created bool
 	}
 
 	series = &memSeries{ref: chunks.HeadSeriesRef(a.w.ref.Inc()), lset: l}
-	a.w.series.set(l.Hash(), series)
+	a.w.series.set(labels.StableHash(l), series)
 	return series, true
 }
 

--- a/pkg/storage/batch_test.go
+++ b/pkg/storage/batch_test.go
@@ -1658,7 +1658,7 @@ func TestBuildHeapIterator(t *testing.T) {
 				ctx:      ctx,
 				pipeline: log.NewNoopPipeline(),
 			}
-			it, err := b.buildMergeIterator(tc.input, from, from.Add(6*time.Millisecond), b.pipeline.ForStream(labels.Labels{labels.Label{Name: "foo", Value: "bar"}}), nil)
+			it, err := b.buildMergeIterator(tc.input, from, from.Add(6*time.Millisecond), b.pipeline.ForStream(labels.New(labels.Label{Name: "foo", Value: "bar"})), nil)
 			if err != nil {
 				t.Errorf("buildMergeIterator error = %v", err)
 				return

--- a/pkg/storage/bloom/v1/bloom_tester.go
+++ b/pkg/storage/bloom/v1/bloom_tester.go
@@ -182,7 +182,7 @@ func (kvm keyValueMatcherTest) MatchesWithPrefixBuf(series labels.Labels, bloom 
 func (kvm keyValueMatcherTest) match(series labels.Labels, bloom filter.Checker, combined []byte) bool {
 	// If we don't have the series labels, we cannot disambiguate which labels come from the series in which case
 	// we may filter out chunks for queries like `{env="prod"} | env="prod"` if env=prod is not structured metadata
-	if len(series) == 0 {
+	if series.IsEmpty() {
 		level.Warn(util_log.Logger).Log("msg", "series has no labels, cannot filter out chunks")
 		return true
 	}
@@ -243,7 +243,7 @@ func (km keyMatcherTest) MatchesWithPrefixBuf(series labels.Labels, bloom filter
 func (km keyMatcherTest) match(series labels.Labels, bloom filter.Checker, key []byte) bool {
 	// If we don't have the series labels, we cannot disambiguate which labels come from the series in which case
 	// we may filter out chunks for queries like `{env="prod"} | env="prod"` if env=prod is not structured metadata
-	if len(series) == 0 {
+	if series.IsEmpty() {
 		level.Warn(util_log.Logger).Log("msg", "series has no labels, cannot filter out chunks")
 		return true
 	}

--- a/pkg/storage/bloom/v1/bloom_tokenizer_test.go
+++ b/pkg/storage/bloom/v1/bloom_tokenizer_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/storage/bloom/v1/filter"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/prometheus/model/labels"
 )
 
 var metrics = NewMetrics(prometheus.DefaultRegisterer)
@@ -49,7 +50,7 @@ func TestTokenizerPopulate(t *testing.T) {
 		time.Unix(0, 0), // TODO: Parameterize/better handle the timestamps?
 		time.Unix(0, math.MaxInt64),
 		logproto.FORWARD,
-		log.NewNoopPipeline().ForStream(nil),
+		log.NewNoopPipeline().ForStream(labels.EmptyLabels()),
 	)
 	require.Nil(t, err)
 
@@ -94,7 +95,7 @@ func TestBloomTokenizerPopulateWithoutPreexistingBloom(t *testing.T) {
 		time.Unix(0, 0), // TODO: Parameterize/better handle the timestamps?
 		time.Unix(0, math.MaxInt64),
 		logproto.FORWARD,
-		log.NewNoopPipeline().ForStream(nil),
+		log.NewNoopPipeline().ForStream(labels.EmptyLabels()),
 	)
 	require.Nil(t, err)
 
@@ -136,7 +137,7 @@ func chunkRefItrFromMetadata(metadata ...push.LabelsAdapter) (iter.EntryIterator
 		time.Unix(0, 0), // TODO: Parameterize/better handle the timestamps?
 		time.Unix(0, math.MaxInt64),
 		logproto.FORWARD,
-		log.NewNoopPipeline().ForStream(nil),
+		log.NewNoopPipeline().ForStream(labels.EmptyLabels()),
 	)
 	return itr, err
 }
@@ -219,7 +220,7 @@ func BenchmarkPopulateSeriesWithBloom(b *testing.B) {
 			time.Unix(0, 0), // TODO: Parameterize/better handle the timestamps?
 			time.Unix(0, math.MaxInt64),
 			logproto.FORWARD,
-			log.NewNoopPipeline().ForStream(nil),
+			log.NewNoopPipeline().ForStream(labels.EmptyLabels()),
 		)
 		require.Nil(b, err)
 

--- a/pkg/storage/chunk/cache/cache_test.go
+++ b/pkg/storage/chunk/cache/cache_test.go
@@ -45,10 +45,10 @@ func fillCache(t *testing.T, scfg config.SchemaConfig, cache cache.Cache) ([]str
 		c := chunk.NewChunk(
 			userID,
 			model.Fingerprint(1),
-			labels.Labels{
-				{Name: model.MetricNameLabel, Value: "foo"},
-				{Name: "bar", Value: "baz"},
-			},
+			labels.New(
+				labels.Label{Name: model.MetricNameLabel, Value: "foo"},
+				labels.Label{Name: "bar", Value: "baz"},
+			),
 			chunkenc.NewFacade(cs, 0, 0),
 			ts,
 			ts.Add(chunkLen),

--- a/pkg/storage/chunk/chunk_test.go
+++ b/pkg/storage/chunk/chunk_test.go
@@ -16,11 +16,11 @@ import (
 
 const userID = "userID"
 
-var labelsForDummyChunks = labels.Labels{
-	{Name: labels.MetricName, Value: "foo"},
-	{Name: "bar", Value: "baz"},
-	{Name: "toms", Value: "code"},
-}
+var labelsForDummyChunks = labels.New(
+	labels.Label{Name: labels.MetricName, Value: "foo"},
+	labels.Label{Name: "bar", Value: "baz"},
+	labels.Label{Name: "toms", Value: "code"},
+)
 
 // Deprecated
 func dummyChunkFor(now model.Time, metric labels.Labels) Chunk {
@@ -160,25 +160,25 @@ func TestParseExternalKey(t *testing.T) {
 }
 
 // BenchmarkLabels is a real example from Kubernetes' embedded cAdvisor metrics, lightly obfuscated
-var BenchmarkLabels = labels.Labels{
-	{Name: model.MetricNameLabel, Value: "container_cpu_usage_seconds_total"},
-	{Name: "beta_kubernetes_io_arch", Value: "amd64"},
-	{Name: "beta_kubernetes_io_instance_type", Value: "c3.somesize"},
-	{Name: "beta_kubernetes_io_os", Value: "linux"},
-	{Name: "container_name", Value: "some-name"},
-	{Name: "cpu", Value: "cpu01"},
-	{Name: "failure_domain_beta_kubernetes_io_region", Value: "somewhere-1"},
-	{Name: "failure_domain_beta_kubernetes_io_zone", Value: "somewhere-1b"},
-	{Name: "id", Value: "/kubepods/burstable/pod6e91c467-e4c5-11e7-ace3-0a97ed59c75e/a3c8498918bd6866349fed5a6f8c643b77c91836427fb6327913276ebc6bde28"},
-	{Name: "image", Value: "registry/organisation/name@sha256:dca3d877a80008b45d71d7edc4fd2e44c0c8c8e7102ba5cbabec63a374d1d506"},
-	{Name: "instance", Value: "ip-111-11-1-11.ec2.internal"},
-	{Name: "job", Value: "kubernetes-cadvisor"},
-	{Name: "kubernetes_io_hostname", Value: "ip-111-11-1-11"},
-	{Name: "monitor", Value: "prod"},
-	{Name: "name", Value: "k8s_some-name_some-other-name-5j8s8_kube-system_6e91c467-e4c5-11e7-ace3-0a97ed59c75e_0"},
-	{Name: "namespace", Value: "kube-system"},
-	{Name: "pod_name", Value: "some-other-name-5j8s8"},
-}
+var BenchmarkLabels = labels.New(
+	labels.Label{Name: model.MetricNameLabel, Value: "container_cpu_usage_seconds_total"},
+	labels.Label{Name: "beta_kubernetes_io_arch", Value: "amd64"},
+	labels.Label{Name: "beta_kubernetes_io_instance_type", Value: "c3.somesize"},
+	labels.Label{Name: "beta_kubernetes_io_os", Value: "linux"},
+	labels.Label{Name: "container_name", Value: "some-name"},
+	labels.Label{Name: "cpu", Value: "cpu01"},
+	labels.Label{Name: "failure_domain_beta_kubernetes_io_region", Value: "somewhere-1"},
+	labels.Label{Name: "failure_domain_beta_kubernetes_io_zone", Value: "somewhere-1b"},
+	labels.Label{Name: "id", Value: "/kubepods/burstable/pod6e91c467-e4c5-11e7-ace3-0a97ed59c75e/a3c8498918bd6866349fed5a6f8c643b77c91836427fb6327913276ebc6bde28"},
+	labels.Label{Name: "image", Value: "registry/organisation/name@sha256:dca3d877a80008b45d71d7edc4fd2e44c0c8c8e7102ba5cbabec63a374d1d506"},
+	labels.Label{Name: "instance", Value: "ip-111-11-1-11.ec2.internal"},
+	labels.Label{Name: "job", Value: "kubernetes-cadvisor"},
+	labels.Label{Name: "kubernetes_io_hostname", Value: "ip-111-11-1-11"},
+	labels.Label{Name: "monitor", Value: "prod"},
+	labels.Label{Name: "name", Value: "k8s_some-name_some-other-name-5j8s8_kube-system_6e91c467-e4c5-11e7-ace3-0a97ed59c75e_0"},
+	labels.Label{Name: "namespace", Value: "kube-system"},
+	labels.Label{Name: "pod_name", Value: "some-other-name-5j8s8"},
+)
 
 func BenchmarkEncode(b *testing.B) {
 	chunk := dummyChunkFor(model.Now(), labelsForDummyChunks)
@@ -212,7 +212,7 @@ func benchmarkDecode(b *testing.B, batchSize int) {
 		// Copy across the metadata so the check works out ok
 		for j := 0; j < batchSize; j++ {
 			chunks[j] = chunk
-			chunks[j].Metric = nil
+			chunks[j].Metric = labels.EmptyLabels()
 			chunks[j].Data = nil
 		}
 		b.StartTimer()

--- a/pkg/storage/chunk/client/grpc/grpc_client_test.go
+++ b/pkg/storage/chunk/client/grpc/grpc_client_test.go
@@ -95,20 +95,20 @@ func TestGrpcStore(t *testing.T) {
 				Through:     1587997054298,
 				Checksum:    3651208117,
 			},
-			Metric: labels.Labels{
-				{
+			Metric: labels.New(
+				labels.Label{
 					Name:  "_name_",
 					Value: "prometheus_sd_file_scan_duration_seconds_sum",
 				},
-				{
+				labels.Label{
 					Name:  "instance",
 					Value: "localhost:9090",
 				},
-				{
+				labels.Label{
 					Name:  "job",
 					Value: "prometheus",
 				},
-			},
+			),
 			Encoding: chunkenc.LogChunk,
 			Data:     newChunkData(),
 		},
@@ -125,20 +125,20 @@ func TestGrpcStore(t *testing.T) {
 				Through:     1587997054298,
 				Checksum:    3651208117,
 			},
-			Metric: labels.Labels{
-				{
+			Metric: labels.New(
+				labels.Label{
 					Name:  "_name_",
 					Value: "prometheus_sd_file_scan_duration_seconds_sum",
 				},
-				{
+				labels.Label{
 					Name:  "instance",
 					Value: "localhost:9090",
 				},
-				{
+				labels.Label{
 					Name:  "job",
 					Value: "prometheus",
 				},
-			},
+			),
 			Encoding: chunkenc.LogChunk,
 			Data:     newChunkData(),
 		},

--- a/pkg/storage/chunk/client/testutils/testutils.go
+++ b/pkg/storage/chunk/client/testutils/testutils.go
@@ -76,10 +76,10 @@ func CreateChunks(scfg config.SchemaConfig, startIndex, batchSize int, from mode
 	keys := []string{}
 	chunks := []chunk.Chunk{}
 	for j := 0; j < batchSize; j++ {
-		chunk := DummyChunkFor(from, through, labels.Labels{
-			{Name: model.MetricNameLabel, Value: "foo"},
-			{Name: "index", Value: strconv.Itoa(startIndex*batchSize + j)},
-		})
+		chunk := DummyChunkFor(from, through, labels.New(
+			labels.Label{Name: model.MetricNameLabel, Value: "foo"},
+			labels.Label{Name: "index", Value: strconv.Itoa(startIndex*batchSize + j)},
+		))
 		chunks = append(chunks, chunk)
 		keys = append(keys, scfg.ExternalKey(chunk.ChunkRef))
 	}

--- a/pkg/storage/chunk/fetcher/fetcher_test.go
+++ b/pkg/storage/chunk/fetcher/fetcher_test.go
@@ -342,7 +342,7 @@ func makeChunks(now time.Time, tpls ...c) []chunk.Chunk {
 				From:    model.TimeFromUnix(now.Add(-chk.from).UTC().Unix()),
 				Through: model.TimeFromUnix(now.Add(-chk.through).UTC().Unix()),
 			},
-			Metric:   labels.Labels{labels.Label{Name: "start", Value: strconv.Itoa(from)}},
+			Metric:   labels.New(labels.Label{Name: "start", Value: strconv.Itoa(from)}),
 			Data:     data,
 			Encoding: data.Encoding(),
 		}

--- a/pkg/storage/chunk/json_helpers.go
+++ b/pkg/storage/chunk/json_helpers.go
@@ -59,7 +59,7 @@ func encodeLabels(ptr unsafe.Pointer, stream *jsoniter.Stream) {
 
 func labelsIsEmpty(ptr unsafe.Pointer) bool {
 	labelsPtr := (*labels.Labels)(ptr)
-	return labelsPtr.Len() == 0
+	return labelsPtr.IsEmpty()
 }
 
 // Decode via jsoniter's float64 routine is faster than getting the string data and decoding as two integers

--- a/pkg/storage/config/schema_config_test.go
+++ b/pkg/storage/config/schema_config_test.go
@@ -1117,11 +1117,11 @@ const (
 )
 
 var (
-	labelsForDummyChunks = labels.Labels{
-		{Name: labels.MetricName, Value: "foo"},
-		{Name: "bar", Value: "baz"},
-		{Name: "toms", Value: "code"},
-	}
+	labelsForDummyChunks = labels.New(
+		labels.Label{Name: labels.MetricName, Value: "foo"},
+		labels.Label{Name: "bar", Value: "baz"},
+		labels.Label{Name: "toms", Value: "code"},
+	)
 )
 
 func TestChunkKeys(t *testing.T) {

--- a/pkg/storage/lazy_chunk_test.go
+++ b/pkg/storage/lazy_chunk_test.go
@@ -49,7 +49,7 @@ func TestLazyChunkIterator(t *testing.T) {
 			{
 				newLazyChunk(chunkfmt, headfmt, logproto.Stream{
 					Labels: fooLabelsWithName.String(),
-					Hash:   fooLabelsWithName.Hash(),
+					Hash:   labels.StableHash(fooLabelsWithName),
 					Entries: []logproto.Entry{
 						{
 							Timestamp:          from,
@@ -62,7 +62,7 @@ func TestLazyChunkIterator(t *testing.T) {
 				[]logproto.Stream{
 					{
 						Labels: fooLabels.String(),
-						Hash:   fooLabels.Hash(),
+						Hash:   labels.StableHash(fooLabels),
 						Entries: []logproto.Entry{
 							{
 								Timestamp:          from,

--- a/pkg/storage/lazy_chunk_test.go
+++ b/pkg/storage/lazy_chunk_test.go
@@ -76,7 +76,7 @@ func TestLazyChunkIterator(t *testing.T) {
 			},
 		} {
 			t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-				it, err := tc.chunk.Iterator(context.Background(), time.Unix(0, 0), time.Unix(1000, 0), logproto.FORWARD, log.NewNoopPipeline().ForStream(labels.Labels{labels.Label{Name: "foo", Value: "bar"}}), nil)
+				it, err := tc.chunk.Iterator(context.Background(), time.Unix(0, 0), time.Unix(1000, 0), logproto.FORWARD, log.NewNoopPipeline().ForStream(labels.New(labels.Label{Name: "foo", Value: "bar"})), nil)
 				require.Nil(t, err)
 				streams, _, err := iter.ReadBatch(it, 1000)
 				require.Nil(t, err)

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -1591,10 +1591,10 @@ func parseDate(in string) time.Time {
 	return t
 }
 
-func buildTestStreams(labels labels.Labels, tr timeRange) logproto.Stream {
+func buildTestStreams(ls labels.Labels, tr timeRange) logproto.Stream {
 	stream := logproto.Stream{
-		Labels:  labels.String(),
-		Hash:    labels.Hash(),
+		Labels:  ls.String(),
+		Hash:    labels.StableHash(ls),
 		Entries: []logproto.Entry{},
 	}
 

--- a/pkg/storage/stores/composite_store.go
+++ b/pkg/storage/stores/composite_store.go
@@ -121,9 +121,10 @@ func (c CompositeStore) GetSeries(ctx context.Context, userID string, from, thro
 			return err
 		}
 		for _, s := range series {
-			if _, ok := found[s.Hash()]; !ok {
+			hash := labels.StableHash(s)
+			if _, ok := found[hash]; !ok {
 				results = append(results, s)
-				found[s.Hash()] = struct{}{}
+				found[hash] = struct{}{}
 			}
 		}
 		return nil

--- a/pkg/storage/stores/series/index/schema.go
+++ b/pkg/storage/stores/series/index/schema.go
@@ -291,8 +291,8 @@ type seriesStoreEntries interface {
 // v9Entries adds a layer of indirection between labels -> series -> chunks.
 type v9Entries struct{}
 
-func (v9Entries) GetLabelWriteEntries(bucket Bucket, metricName string, labels labels.Labels, _ string) ([]Entry, error) {
-	seriesID := labelsSeriesID(labels)
+func (v9Entries) GetLabelWriteEntries(bucket Bucket, metricName string, lbls labels.Labels, _ string) ([]Entry, error) {
+	seriesID := labelsSeriesID(lbls)
 
 	entries := []Entry{
 		// Entry for metricName -> seriesID
@@ -306,9 +306,9 @@ func (v9Entries) GetLabelWriteEntries(bucket Bucket, metricName string, labels l
 
 	// Entries for metricName:labelName -> hash(value):seriesID
 	// We use a hash of the value to limit its length.
-	for _, v := range labels {
+	lbls.Range(func(v labels.Label) {
 		if v.Name == model.MetricNameLabel {
-			continue
+			return // (continue, not abort)
 		}
 		valueHash := sha256bytes(v.Value)
 		entries = append(entries, Entry{
@@ -317,7 +317,7 @@ func (v9Entries) GetLabelWriteEntries(bucket Bucket, metricName string, labels l
 			RangeValue: encodeRangeKey(labelSeriesRangeKeyV1, valueHash, seriesID, nil),
 			Value:      []byte(v.Value),
 		})
-	}
+	})
 
 	return entries, nil
 }
@@ -392,8 +392,8 @@ type v10Entries struct {
 	rowShards uint32
 }
 
-func (s v10Entries) GetLabelWriteEntries(bucket Bucket, metricName string, labels labels.Labels, _ string) ([]Entry, error) {
-	seriesID := labelsSeriesID(labels)
+func (s v10Entries) GetLabelWriteEntries(bucket Bucket, metricName string, lbls labels.Labels, _ string) ([]Entry, error) {
+	seriesID := labelsSeriesID(lbls)
 
 	// read first 32 bits of the hash and use this to calculate the shard
 	shard := binary.BigEndian.Uint32(seriesID) % s.rowShards
@@ -410,9 +410,9 @@ func (s v10Entries) GetLabelWriteEntries(bucket Bucket, metricName string, label
 
 	// Entries for metricName:labelName -> hash(value):seriesID
 	// We use a hash of the value to limit its length.
-	for _, v := range labels {
+	lbls.Range(func(v labels.Label) {
 		if v.Name == model.MetricNameLabel {
-			continue
+			return // (continue, not abort)
 		}
 		valueHash := sha256bytes(v.Value)
 		entries = append(entries, Entry{
@@ -421,7 +421,7 @@ func (s v10Entries) GetLabelWriteEntries(bucket Bucket, metricName string, label
 			RangeValue: encodeRangeKey(labelSeriesRangeKeyV1, valueHash, seriesID, nil),
 			Value:      []byte(v.Value),
 		})
-	}
+	})
 
 	return entries, nil
 }
@@ -526,19 +526,20 @@ type v11Entries struct {
 	v10Entries
 }
 
-func (s v11Entries) GetLabelWriteEntries(bucket Bucket, metricName string, labels labels.Labels, _ string) ([]Entry, error) {
-	seriesID := labelsSeriesID(labels)
+func (s v11Entries) GetLabelWriteEntries(bucket Bucket, metricName string, lbls labels.Labels, _ string) ([]Entry, error) {
+	seriesID := labelsSeriesID(lbls)
 
 	// read first 32 bits of the hash and use this to calculate the shard
 	shard := binary.BigEndian.Uint32(seriesID) % s.rowShards
 
-	labelNames := make([]string, 0, len(labels))
-	for _, l := range labels {
+	labelNames := make([]string, 0, lbls.Len())
+	lbls.Range(func(l labels.Label) {
 		if l.Name == model.MetricNameLabel {
-			continue
+			return // (continue, not abort)
 		}
 		labelNames = append(labelNames, l.Name)
-	}
+	})
+
 	data, err := jsoniter.ConfigFastest.Marshal(labelNames)
 	if err != nil {
 		return nil, err
@@ -562,9 +563,9 @@ func (s v11Entries) GetLabelWriteEntries(bucket Bucket, metricName string, label
 
 	// Entries for metricName:labelName -> hash(value):seriesID
 	// We use a hash of the value to limit its length.
-	for _, v := range labels {
+	lbls.Range(func(v labels.Label) {
 		if v.Name == model.MetricNameLabel {
-			continue
+			return // (continue, not abort)
 		}
 		valueHash := sha256bytes(v.Value)
 		entries = append(entries, Entry{
@@ -573,7 +574,7 @@ func (s v11Entries) GetLabelWriteEntries(bucket Bucket, metricName string, label
 			RangeValue: encodeRangeKey(labelSeriesRangeKeyV1, valueHash, seriesID, nil),
 			Value:      []byte(v.Value),
 		})
-	}
+	})
 
 	return entries, nil
 }

--- a/pkg/storage/stores/series/index/schema_util.go
+++ b/pkg/storage/stores/series/index/schema_util.go
@@ -19,7 +19,7 @@ import (
 // Backwards-compatible with model.Metric.String()
 func labelsString(ls labels.Labels) string {
 	metricName := ls.Get(labels.MetricName)
-	if metricName != "" && len(ls) == 1 {
+	if metricName != "" && ls.Len() == 1 {
 		return metricName
 	}
 	var b strings.Builder
@@ -28,9 +28,9 @@ func labelsString(ls labels.Labels) string {
 	b.WriteString(metricName)
 	b.WriteByte('{')
 	i := 0
-	for _, l := range ls {
+	ls.Range(func(l labels.Label) {
 		if l.Name == labels.MetricName {
-			continue
+			return // (continue, not abort)
 		}
 		if i > 0 {
 			b.WriteByte(',')
@@ -41,7 +41,7 @@ func labelsString(ls labels.Labels) string {
 		var buf [1000]byte
 		b.Write(strconv.AppendQuote(buf[:0], l.Value))
 		i++
-	}
+	})
 	b.WriteByte('}')
 
 	return b.String()

--- a/pkg/storage/stores/series/index/schema_util_test.go
+++ b/pkg/storage/stores/series/index/schema_util_test.go
@@ -22,20 +22,20 @@ func TestLabelSeriesID(t *testing.T) {
 		expected string
 	}{
 		{
-			labels.Labels{{Name: model.MetricNameLabel, Value: "foo"}},
+			labels.New(labels.Label{Name: model.MetricNameLabel, Value: "foo"}),
 			"LCa0a2j/xo/5m0U8HTBBNBNCLXBkg7+g+YpeiGJm564",
 		},
 		{
-			labels.Labels{
-				{Name: model.MetricNameLabel, Value: "foo"},
-				{Name: "bar", Value: "baz"},
-				{Name: "flip", Value: "flop"},
-				{Name: "toms", Value: "code"},
-			},
+			labels.New(
+				labels.Label{Name: model.MetricNameLabel, Value: "foo"},
+				labels.Label{Name: "bar", Value: "baz"},
+				labels.Label{Name: "flip", Value: "flop"},
+				labels.Label{Name: "toms", Value: "code"},
+			),
 			"KrbXMezYneba+o7wfEdtzOdAWhbfWcDrlVfs1uOCX3M",
 		},
 		{
-			labels.Labels{},
+			labels.EmptyLabels(),
 			"RBNvo1WzZ4oRRq0W9+hknpT7T8If536DEMBg9hyq/4o",
 		},
 	} {

--- a/pkg/storage/stores/series/series_store_utils.go
+++ b/pkg/storage/stores/series/series_store_utils.go
@@ -5,6 +5,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
 
 	"github.com/grafana/loki/v3/pkg/logproto"
 	"github.com/grafana/loki/v3/pkg/storage/chunk"
@@ -36,13 +37,12 @@ func filterChunkRefsByTime(from, through model.Time, chunks []logproto.ChunkRef)
 func labelNamesFromChunks(chunks []chunk.Chunk) []string {
 	var result util.UniqueStrings
 	for _, c := range chunks {
-		for _, l := range c.Metric {
+		c.Metric.Range(func(l labels.Label) {
 			if l.Name == model.MetricNameLabel {
-				continue
+				return // (continue, not abort)
 			}
-
 			result.Add(l.Name)
-		}
+		})
 	}
 	return result.Strings()
 }

--- a/pkg/storage/stores/series_store_write_test.go
+++ b/pkg/storage/stores/series_store_write_test.go
@@ -94,7 +94,7 @@ func TestChunkWriter_PutOne(t *testing.T) {
 	require.NoError(t, err)
 
 	memchk := chunkenc.NewMemChunk(chunkfmt, compression.GZIP, headfmt, 256*1024, 0)
-	chk := chunk.NewChunk("fake", model.Fingerprint(0), []labels.Label{{Name: "foo", Value: "bar"}}, chunkenc.NewFacade(memchk, 0, 0), 100, 400)
+	chk := chunk.NewChunk("fake", model.Fingerprint(0), labels.New(labels.Label{Name: "foo", Value: "bar"}), chunkenc.NewFacade(memchk, 0, 0), 100, 400)
 
 	for name, tc := range map[string]struct {
 		from, through                                                             model.Time

--- a/pkg/storage/stores/shipper/indexshipper/boltdb/compactor/compacted_index_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/boltdb/compactor/compacted_index_test.go
@@ -31,9 +31,9 @@ func TestCompactedIndex_IndexProcessor(t *testing.T) {
 			store := newTestStore(t, cm)
 			chunkfmt, headfmt, err := tt.config.ChunkFormat()
 			require.NoError(t, err)
-			c1 := createChunk(t, chunkfmt, headfmt, "1", labels.Labels{labels.Label{Name: "foo", Value: "bar"}}, tt.from, tt.from.Add(1*time.Hour))
-			c2 := createChunk(t, chunkfmt, headfmt, "2", labels.Labels{labels.Label{Name: "foo", Value: "bar"}, labels.Label{Name: "fizz", Value: "buzz"}}, tt.from, tt.from.Add(1*time.Hour))
-			c3 := createChunk(t, chunkfmt, headfmt, "2", labels.Labels{labels.Label{Name: "foo", Value: "buzz"}, labels.Label{Name: "bar", Value: "buzz"}}, tt.from, tt.from.Add(1*time.Hour))
+			c1 := createChunk(t, chunkfmt, headfmt, "1", labels.New(labels.Label{Name: "foo", Value: "bar"}), tt.from, tt.from.Add(1*time.Hour))
+			c2 := createChunk(t, chunkfmt, headfmt, "2", labels.New(labels.Label{Name: "foo", Value: "bar"}, labels.Label{Name: "fizz", Value: "buzz"}), tt.from, tt.from.Add(1*time.Hour))
+			c3 := createChunk(t, chunkfmt, headfmt, "2", labels.New(labels.Label{Name: "foo", Value: "buzz"}, labels.Label{Name: "bar", Value: "buzz"}), tt.from, tt.from.Add(1*time.Hour))
 
 			require.NoError(t, store.Put(context.TODO(), []chunk.Chunk{
 				c1, c2, c3,
@@ -47,7 +47,7 @@ func TestCompactedIndex_IndexProcessor(t *testing.T) {
 			compactedIndex := newCompactedIndex(tables[0].DB, tables[0].name, t.TempDir(), tt.config, util_log.Logger)
 
 			// remove c1, c2 chunk and index c4 with same labels as c2
-			c4 := createChunk(t, chunkfmt, headfmt, "2", labels.Labels{labels.Label{Name: "foo", Value: "bar"}, labels.Label{Name: "fizz", Value: "buzz"}}, tt.from, tt.from.Add(30*time.Minute))
+			c4 := createChunk(t, chunkfmt, headfmt, "2", labels.New(labels.Label{Name: "foo", Value: "bar"}, labels.Label{Name: "fizz", Value: "buzz"}), tt.from, tt.from.Add(30*time.Minute))
 			err = compactedIndex.ForEachSeries(context.Background(), func(series retention.Series) (err error) {
 				if series.Labels().Get("fizz") == "buzz" {
 					approxKB := math.Round(float64(c4.Data.UncompressedSize()) / float64(1<<10))

--- a/pkg/storage/stores/shipper/indexshipper/boltdb/compactor/iterator.go
+++ b/pkg/storage/stores/shipper/indexshipper/boltdb/compactor/iterator.go
@@ -106,12 +106,12 @@ func newSeriesCleaner(bucket *bbolt.Bucket, config config.PeriodConfig, tableNam
 
 func (s *seriesCleaner) CleanupSeries(userID []byte, lbls labels.Labels) error {
 	// We need to add metric name label as well if it is missing since the series ids are calculated including that.
-	if lbls.Get(labels.MetricName) == "" {
-		lbls = append(lbls, labels.Label{
-			Name:  labels.MetricName,
-			Value: logMetricName,
-		})
+	builder := labels.NewBuilder(lbls)
+	if builder.Get(labels.MetricName) == "" {
+		builder.Set(labels.MetricName, logMetricName)
 	}
+	lbls = builder.Labels()
+
 	_, indexEntries, err := s.schema.GetCacheKeysAndLabelWriteEntries(s.tableInterval.Start, s.tableInterval.End, string(userID), logMetricName, lbls, "")
 	if err != nil {
 		return err
@@ -136,12 +136,11 @@ func (s *seriesCleaner) CleanupSeries(userID []byte, lbls labels.Labels) error {
 
 func (s *seriesCleaner) RemoveChunk(from, through model.Time, userID []byte, lbls labels.Labels, chunkID string) error {
 	// We need to add metric name label as well if it is missing since the series ids are calculated including that.
-	if lbls.Get(labels.MetricName) == "" {
-		lbls = append(lbls, labels.Label{
-			Name:  labels.MetricName,
-			Value: logMetricName,
-		})
+	builder := labels.NewBuilder(lbls)
+	if builder.Get(labels.MetricName) == "" {
+		builder.Set(labels.MetricName, logMetricName)
 	}
+	lbls = builder.Labels()
 
 	indexEntries, err := s.schema.GetChunkWriteEntries(from, through, string(userID), logMetricName, lbls, chunkID)
 	if err != nil {

--- a/pkg/storage/stores/shipper/indexshipper/boltdb/compactor/iterator_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/boltdb/compactor/iterator_test.go
@@ -31,8 +31,8 @@ func Test_ChunkIterator(t *testing.T) {
 			chunkfmt, headfmt, err := tt.config.ChunkFormat()
 			require.NoError(t, err)
 
-			c1 := createChunk(t, chunkfmt, headfmt, "1", labels.Labels{labels.Label{Name: "foo", Value: "bar"}}, tt.from, tt.from.Add(1*time.Hour))
-			c2 := createChunk(t, chunkfmt, headfmt, "2", labels.Labels{labels.Label{Name: "foo", Value: "buzz"}, labels.Label{Name: "bar", Value: "foo"}}, tt.from, tt.from.Add(1*time.Hour))
+			c1 := createChunk(t, chunkfmt, headfmt, "1", labels.New(labels.Label{Name: "foo", Value: "bar"}), tt.from, tt.from.Add(1*time.Hour))
+			c2 := createChunk(t, chunkfmt, headfmt, "2", labels.New(labels.Label{Name: "foo", Value: "buzz"}, labels.Label{Name: "bar", Value: "foo"}), tt.from, tt.from.Add(1*time.Hour))
 
 			require.NoError(t, store.Put(context.TODO(), []chunk.Chunk{
 				c1, c2,
@@ -84,8 +84,8 @@ func Test_ChunkIteratorContextCancelation(t *testing.T) {
 	chunkfmt, headfmt, err := schemaCfg.Configs[0].ChunkFormat()
 	require.NoError(t, err)
 
-	c1 := createChunk(t, chunkfmt, headfmt, "1", labels.Labels{labels.Label{Name: "foo", Value: "bar"}}, from, from.Add(1*time.Hour))
-	c2 := createChunk(t, chunkfmt, headfmt, "2", labels.Labels{labels.Label{Name: "foo", Value: "buzz"}, labels.Label{Name: "bar", Value: "foo"}}, from, from.Add(1*time.Hour))
+	c1 := createChunk(t, chunkfmt, headfmt, "1", labels.New(labels.Label{Name: "foo", Value: "bar"}), from, from.Add(1*time.Hour))
+	c2 := createChunk(t, chunkfmt, headfmt, "2", labels.New(labels.Label{Name: "foo", Value: "buzz"}, labels.Label{Name: "bar", Value: "foo"}), from, from.Add(1*time.Hour))
 
 	require.NoError(t, store.Put(context.TODO(), []chunk.Chunk{c1, c2}))
 	store.Stop()
@@ -118,9 +118,9 @@ func Test_SeriesCleaner(t *testing.T) {
 			chunkfmt, headfmt, err := tt.config.ChunkFormat()
 			require.NoError(t, err)
 
-			c1 := createChunk(t, chunkfmt, headfmt, "1", labels.Labels{labels.Label{Name: "foo", Value: "bar"}}, tt.from, tt.from.Add(1*time.Hour))
-			c2 := createChunk(t, chunkfmt, headfmt, "2", labels.Labels{labels.Label{Name: "foo", Value: "buzz"}, labels.Label{Name: "bar", Value: "foo"}}, tt.from, tt.from.Add(1*time.Hour))
-			c3 := createChunk(t, chunkfmt, headfmt, "2", labels.Labels{labels.Label{Name: "foo", Value: "buzz"}, labels.Label{Name: "bar", Value: "buzz"}}, tt.from, tt.from.Add(1*time.Hour))
+			c1 := createChunk(t, chunkfmt, headfmt, "1", labels.New(labels.Label{Name: "foo", Value: "bar"}), tt.from, tt.from.Add(1*time.Hour))
+			c2 := createChunk(t, chunkfmt, headfmt, "2", labels.New(labels.Label{Name: "foo", Value: "buzz"}, labels.Label{Name: "bar", Value: "foo"}), tt.from, tt.from.Add(1*time.Hour))
+			c3 := createChunk(t, chunkfmt, headfmt, "2", labels.New(labels.Label{Name: "foo", Value: "buzz"}, labels.Label{Name: "bar", Value: "buzz"}), tt.from, tt.from.Add(1*time.Hour))
 
 			require.NoError(t, store.Put(context.TODO(), []chunk.Chunk{
 				c1, c2, c3,
@@ -196,7 +196,7 @@ func encodeBase64Bytes(bytes []byte) []byte {
 // Backwards-compatible with model.Metric.String()
 func labelsString(ls labels.Labels) string {
 	metricName := ls.Get(labels.MetricName)
-	if metricName != "" && len(ls) == 1 {
+	if metricName != "" && ls.Len() == 1 {
 		return metricName
 	}
 	var b strings.Builder
@@ -205,9 +205,9 @@ func labelsString(ls labels.Labels) string {
 	b.WriteString(metricName)
 	b.WriteByte('{')
 	i := 0
-	for _, l := range ls {
+	ls.Range(func(l labels.Label) {
 		if l.Name == labels.MetricName {
-			continue
+			return // (continue, not abort)
 		}
 		if i > 0 {
 			b.WriteByte(',')
@@ -218,7 +218,7 @@ func labelsString(ls labels.Labels) string {
 		var buf [1000]byte
 		b.Write(strconv.AppendQuote(buf[:0], l.Value))
 		i++
-	}
+	})
 	b.WriteByte('}')
 
 	return b.String()
@@ -242,7 +242,7 @@ func Benchmark_ChunkIterator(b *testing.B) {
 		require.NoError(b, store.Put(context.TODO(),
 			[]chunk.Chunk{
 				createChunk(b, chunkfmt, headfmt, "1",
-					labels.Labels{labels.Label{Name: "foo", Value: "bar"}, labels.Label{Name: "i", Value: fmt.Sprintf("%d", i)}},
+					labels.New(labels.Label{Name: "foo", Value: "bar"}, labels.Label{Name: "i", Value: fmt.Sprintf("%d", i)}),
 					allSchemas[0].from, allSchemas[0].from.Add(1*time.Hour)),
 			},
 		))

--- a/pkg/storage/stores/shipper/indexshipper/boltdb/compactor/util_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/boltdb/compactor/util_test.go
@@ -173,9 +173,9 @@ func (t *testStore) HasChunk(c chunk.Chunk) bool {
 func (t *testStore) GetChunks(userID string, from, through model.Time, metric labels.Labels) []chunk.Chunk {
 	t.t.Helper()
 	var matchers []*labels.Matcher
-	for _, l := range metric {
+	metric.Range(func(l labels.Label) {
 		matchers = append(matchers, labels.MustNewMatcher(labels.MatchEqual, l.Name, l.Value))
-	}
+	})
 	ctx := user.InjectOrgID(context.Background(), userID)
 	chunks, fetchers, err := t.Store.GetChunks(ctx, userID, from, through, chunk.NewPredicate(matchers, nil), nil)
 	require.NoError(t.t, err)

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/builder.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/builder.go
@@ -175,10 +175,10 @@ func (b *Builder) build(
 	// Build symbols
 	symbolsMap := make(map[string]struct{})
 	for _, s := range streams {
-		for _, l := range s.labels {
+		s.labels.Range(func(l labels.Label) {
 			symbolsMap[l.Name] = struct{}{}
 			symbolsMap[l.Value] = struct{}{}
-		}
+		})
 	}
 
 	// Sort symbols

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/builder_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/builder_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb/index"
@@ -21,7 +22,7 @@ func Test_Build(t *testing.T) {
 
 		stream := stream{
 			labels: lbls1,
-			fp:     model.Fingerprint(lbls1.Hash()),
+			fp:     model.Fingerprint(labels.StableHash(lbls1)),
 			chunks: buildChunkMetas(1, 5),
 		}
 

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/compactor_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/compactor_test.go
@@ -188,7 +188,7 @@ func buildStream(lbls labels.Labels, chunks index.ChunkMetas, userLabel string) 
 	}
 	return stream{
 		labels: lbls,
-		fp:     model.Fingerprint(lbls.Hash()),
+		fp:     model.Fingerprint(labels.StableHash(lbls)),
 		chunks: chunks,
 	}
 }
@@ -641,7 +641,7 @@ func chunkMetasToRetentionChunk(schemaCfg config.SchemaConfig, userID string, lb
 
 func chunkMetaToChunkRef(userID string, chunkMeta index.ChunkMeta, lbls labels.Labels) logproto.ChunkRef {
 	return logproto.ChunkRef{
-		Fingerprint: lbls.Hash(),
+		Fingerprint: labels.StableHash(lbls),
 		UserID:      userID,
 		From:        chunkMeta.From(),
 		Through:     chunkMeta.Through(),

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/head.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/head.go
@@ -264,7 +264,7 @@ func (s *stripeSeries) Append(
 	chks index.ChunkMetas,
 	createFn func() *memSeries,
 ) (created bool, refID uint64) {
-	fp := ls.Hash()
+	fp := labels.StableHash(ls)
 	hashes := s.hashes[fp&uint64(s.shards-1)]
 	hashes.Lock()
 	series := hashes.get(fp, ls)

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/head_manager.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/head_manager.go
@@ -577,7 +577,7 @@ func recoverHead(name, dir string, heads *tenantHeads, wals []WALIdentifier, leg
 				}
 
 				// labels are always written to the WAL before corresponding chunks
-				if len(rec.Series.Labels) > 0 {
+				if !rec.Series.Labels.IsEmpty() {
 					tenant, ok := seriesMap[rec.UserID]
 					if !ok {
 						tenant = make(map[uint64]*labelsWithFp)

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/head_manager_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/head_manager_test.go
@@ -144,17 +144,11 @@ func Test_TenantHeads_MultiRead(t *testing.T) {
 	}{
 		{
 			user: "tenant1",
-			ls: append(ls.Copy(), labels.Label{
-				Name:  "tenant",
-				Value: "tenant1",
-			}),
+			ls:   labels.NewBuilder(ls).Set("tenant", "tenant1").Labels(),
 		},
 		{
 			user: "tenant2",
-			ls: append(ls.Copy(), labels.Label{
-				Name:  "tenant",
-				Value: "tenant2",
-			}),
+			ls:   labels.NewBuilder(ls).Set("tenant", "tenant2").Labels(),
 		},
 	}
 

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/head_wal.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/head_wal.go
@@ -230,7 +230,7 @@ func (w *headWAL) Log(record *WALRecord) error {
 	var buf []byte
 
 	// Always write series before chunks
-	if len(record.Series.Labels) > 0 {
+	if !record.Series.Labels.IsEmpty() {
 		buf = record.encodeSeriesWithFingerprint(buf[:0])
 		if err := w.wal.Log(buf); err != nil {
 			return err

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/head_wal_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/head_wal_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/tsdb/chunks"
 	"github.com/prometheus/prometheus/tsdb/record"
 	"github.com/stretchr/testify/require"
@@ -31,7 +32,7 @@ func Test_Encoding_Series(t *testing.T) {
 func Test_Encoding_SeriesWithFingerprint(t *testing.T) {
 	record := &WALRecord{
 		UserID:      "foo",
-		Fingerprint: mustParseLabels(`{foo="bar"}`).Hash(),
+		Fingerprint: labels.StableHash(mustParseLabels(`{foo="bar"}`)),
 		Series: record.RefSeries{
 			Ref:    chunks.HeadSeriesRef(1),
 			Labels: mustParseLabels(`{foo="bar"}`),

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/index.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/index.go
@@ -40,6 +40,7 @@ import (
 	"github.com/grafana/dskit/multierror"
 
 	"github.com/grafana/loki/v3/pkg/util/encoding"
+	"github.com/grafana/loki/v3/pkg/util/labelpool"
 )
 
 const (
@@ -416,11 +417,11 @@ func (w *Creator) AddSeries(ref storage.SeriesRef, lset labels.Labels, fp model.
 
 	lastHash := w.lastSeriesHash
 	// Ensure series are sorted by the priorities: [`hash(labels)`, `labels`]
-	if (labelHash < lastHash && len(w.lastSeries) > 0) || labelHash == lastHash && labels.Compare(lset, w.lastSeries) < 0 {
+	if (labelHash < lastHash && w.lastSeries.Len() > 0) || labelHash == lastHash && labels.Compare(lset, w.lastSeries) < 0 {
 		return errors.Errorf("out-of-order series added with label set %q", lset)
 	}
 
-	if ref < w.lastRef && len(w.lastSeries) != 0 {
+	if ref < w.lastRef && w.lastSeries.Len() != 0 {
 		return errors.Errorf("series with reference greater than %d already added", ref)
 	}
 	// We add padding to 16 bytes to increase the addressable space we get through 4 byte
@@ -435,9 +436,9 @@ func (w *Creator) AddSeries(ref storage.SeriesRef, lset labels.Labels, fp model.
 
 	w.buf2.Reset()
 	w.buf2.PutBE64(labelHash)
-	w.buf2.PutUvarint(len(lset))
+	w.buf2.PutUvarint(lset.Len())
 
-	for _, l := range lset {
+	err := lset.Validate(func(l labels.Label) error {
 		var err error
 		cacheEntry, ok := w.symbolCache[l.Name]
 		nameIndex := cacheEntry.index
@@ -463,6 +464,10 @@ func (w *Creator) AddSeries(ref storage.SeriesRef, lset labels.Labels, fp model.
 			}
 		}
 		w.buf2.PutUvarint32(valueIndex)
+		return nil
+	})
+	if err != nil {
+		return err
 	}
 
 	w.addChunks(chunks, &w.buf2, &w.buf1, ChunkPageSize)
@@ -472,7 +477,7 @@ func (w *Creator) AddSeries(ref storage.SeriesRef, lset labels.Labels, fp model.
 
 	w.buf2.PutHash(w.crc32)
 
-	w.lastSeries = append(w.lastSeries[:0], lset...)
+	w.lastSeries.CopyFrom(lset)
 	w.lastSeriesHash = labelHash
 	w.lastRef = ref
 
@@ -2131,7 +2136,9 @@ func buildChunkSamples(d encoding.Decbuf, numChunks int, info *chunkSamples) err
 }
 
 func (dec *Decoder) prepSeries(b []byte, lbls *labels.Labels, chks *[]ChunkMeta) (*encoding.Decbuf, uint64, error) {
-	*lbls = (*lbls)[:0]
+	builder := labelpool.Get()
+	defer labelpool.Put(builder)
+
 	if chks != nil {
 		*chks = (*chks)[:0]
 	}
@@ -2158,8 +2165,13 @@ func (dec *Decoder) prepSeries(b []byte, lbls *labels.Labels, chks *[]ChunkMeta)
 			return nil, 0, errors.Wrap(err, "lookup label value")
 		}
 
-		*lbls = append(*lbls, labels.Label{Name: ln, Value: lv})
+		builder.Add(ln, lv)
 	}
+
+	// Commit built labels.
+	builder.Sort()
+	*lbls = builder.Labels()
+
 	return &d, fprint, nil
 }
 
@@ -2169,7 +2181,10 @@ func (dec *Decoder) prepSeriesBy(b []byte, lbls *labels.Labels, chks *[]ChunkMet
 	if by == nil {
 		return dec.prepSeries(b, lbls, chks)
 	}
-	*lbls = (*lbls)[:0]
+
+	builder := labelpool.Get()
+	defer labelpool.Put(builder)
+
 	if chks != nil {
 		*chks = (*chks)[:0]
 	}
@@ -2200,8 +2215,13 @@ func (dec *Decoder) prepSeriesBy(b []byte, lbls *labels.Labels, chks *[]ChunkMet
 			return nil, 0, errors.Wrap(err, "lookup label value")
 		}
 
-		*lbls = append(*lbls, labels.Label{Name: ln, Value: lv})
+		builder.Add(ln, lv)
 	}
+
+	// Commit built labels.
+	builder.Sort()
+	*lbls = builder.Labels()
+
 	return &d, fprint, nil
 }
 

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/index.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/index.go
@@ -417,11 +417,11 @@ func (w *Creator) AddSeries(ref storage.SeriesRef, lset labels.Labels, fp model.
 
 	lastHash := w.lastSeriesHash
 	// Ensure series are sorted by the priorities: [`hash(labels)`, `labels`]
-	if (labelHash < lastHash && w.lastSeries.Len() > 0) || labelHash == lastHash && labels.Compare(lset, w.lastSeries) < 0 {
+	if (labelHash < lastHash && !w.lastSeries.IsEmpty()) || labelHash == lastHash && labels.Compare(lset, w.lastSeries) < 0 {
 		return errors.Errorf("out-of-order series added with label set %q", lset)
 	}
 
-	if ref < w.lastRef && w.lastSeries.Len() != 0 {
+	if ref < w.lastRef && !w.lastSeries.IsEmpty() {
 		return errors.Errorf("series with reference greater than %d already added", ref)
 	}
 	// We add padding to 16 bytes to increase the addressable space we get through 4 byte

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/index_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/index_test.go
@@ -174,10 +174,10 @@ func TestIndexRW_Postings(t *testing.T) {
 
 	// Postings lists are only written if a series with the respective
 	// reference was added before.
-	require.NoError(t, iw.AddSeries(1, series[0], model.Fingerprint(series[0].Hash())))
-	require.NoError(t, iw.AddSeries(2, series[1], model.Fingerprint(series[1].Hash())))
-	require.NoError(t, iw.AddSeries(3, series[2], model.Fingerprint(series[2].Hash())))
-	require.NoError(t, iw.AddSeries(4, series[3], model.Fingerprint(series[3].Hash())))
+	require.NoError(t, iw.AddSeries(1, series[0], model.Fingerprint(labels.StableHash(series[0]))))
+	require.NoError(t, iw.AddSeries(2, series[1], model.Fingerprint(labels.StableHash(series[1]))))
+	require.NoError(t, iw.AddSeries(3, series[2], model.Fingerprint(labels.StableHash(series[2]))))
+	require.NoError(t, iw.AddSeries(4, series[3], model.Fingerprint(labels.StableHash(series[3]))))
 
 	_, err = iw.Close(false)
 	require.NoError(t, err)
@@ -262,11 +262,11 @@ func TestPostingsMany(t *testing.T) {
 	}
 
 	sort.Slice(series, func(i, j int) bool {
-		return series[i].Hash() < series[j].Hash()
+		return labels.StableHash(series[i]) < labels.StableHash(series[j])
 	})
 
 	for i, s := range series {
-		require.NoError(t, iw.AddSeries(storage.SeriesRef(i), s, model.Fingerprint(s.Hash())))
+		require.NoError(t, iw.AddSeries(storage.SeriesRef(i), s, model.Fingerprint(labels.StableHash(s))))
 	}
 	_, err = iw.Close(false)
 	require.NoError(t, err)
@@ -328,7 +328,7 @@ func TestPostingsMany(t *testing.T) {
 
 		// sort expected values by label hash instead of lexicographically by labelset
 		sort.Slice(exp, func(i, j int) bool {
-			return labels.FromStrings("i", exp[i], "foo", "bar").Hash() < labels.FromStrings("i", exp[j], "foo", "bar").Hash()
+			return labels.StableHash(labels.FromStrings("i", exp[i], "foo", "bar")) < labels.StableHash(labels.FromStrings("i", exp[j], "foo", "bar"))
 		})
 
 		require.Equal(t, exp, got, fmt.Sprintf("input: %v", c.in))
@@ -343,7 +343,7 @@ func TestPersistence_index_e2e(t *testing.T) {
 
 	// Sort labels as the index writer expects series in sorted order by fingerprint.
 	sort.Slice(lbls, func(i, j int) bool {
-		return lbls[i].Hash() < lbls[j].Hash()
+		return labels.StableHash(lbls[i]) < labels.StableHash(lbls[j])
 	})
 
 	symbols := map[string]struct{}{}
@@ -394,7 +394,7 @@ func TestPersistence_index_e2e(t *testing.T) {
 	mi := newMockIndex()
 
 	for i, s := range input {
-		err = iw.AddSeries(storage.SeriesRef(i), s.labels, model.Fingerprint(s.labels.Hash()), s.chunks...)
+		err = iw.AddSeries(storage.SeriesRef(i), s.labels, model.Fingerprint(labels.StableHash(s.labels)), s.chunks...)
 		require.NoError(t, err)
 		require.NoError(t, mi.AddSeries(storage.SeriesRef(i), s.labels, s.chunks...))
 
@@ -741,7 +741,7 @@ func TestDecoder_ChunkSamples(t *testing.T) {
 			}
 
 			for i, l := range lbls {
-				err = iw.AddSeries(storage.SeriesRef(i), l, model.Fingerprint(l.Hash()), tc.chunkMetas...)
+				err = iw.AddSeries(storage.SeriesRef(i), l, model.Fingerprint(labels.StableHash(l)), tc.chunkMetas...)
 				require.NoError(t, err)
 			}
 
@@ -957,7 +957,7 @@ func BenchmarkInitReader_ReadOffsetTable(b *testing.B) {
 
 	// Sort labels as the index writer expects series in sorted order by fingerprint.
 	sort.Slice(lbls, func(i, j int) bool {
-		return lbls[i].Hash() < lbls[j].Hash()
+		return labels.StableHash(lbls[i]) < labels.StableHash(lbls[j])
 	})
 
 	symbols := map[string]struct{}{}
@@ -997,7 +997,7 @@ func BenchmarkInitReader_ReadOffsetTable(b *testing.B) {
 	}
 
 	for i, s := range input {
-		err = iw.AddSeries(storage.SeriesRef(i), s.labels, model.Fingerprint(s.labels.Hash()), s.chunks...)
+		err = iw.AddSeries(storage.SeriesRef(i), s.labels, model.Fingerprint(labels.StableHash(s.labels)), s.chunks...)
 		require.NoError(b, err)
 	}
 

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/postings.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/postings.go
@@ -349,9 +349,9 @@ func (p *MemPostings) Iter(f func(labels.Label, Postings) error) error {
 func (p *MemPostings) Add(id storage.SeriesRef, lset labels.Labels) {
 	p.mtx.Lock()
 
-	for _, l := range lset {
+	lset.Range(func(l labels.Label) {
 		p.addFor(id, l)
-	}
+	})
 	p.addFor(id, allPostingsKey)
 
 	p.mtx.Unlock()

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/multi_file_index_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/multi_file_index_test.go
@@ -73,28 +73,28 @@ func TestMultiIndex(t *testing.T) {
 		expected := []ChunkRef{
 			{
 				User:        "fake",
-				Fingerprint: model.Fingerprint(mustParseLabels(`{foo="bar"}`).Hash()),
+				Fingerprint: model.Fingerprint(labels.StableHash(mustParseLabels(`{foo="bar"}`))),
 				Start:       0,
 				End:         3,
 				Checksum:    0,
 			},
 			{
 				User:        "fake",
-				Fingerprint: model.Fingerprint(mustParseLabels(`{foo="bar"}`).Hash()),
+				Fingerprint: model.Fingerprint(labels.StableHash(mustParseLabels(`{foo="bar"}`))),
 				Start:       1,
 				End:         4,
 				Checksum:    1,
 			},
 			{
 				User:        "fake",
-				Fingerprint: model.Fingerprint(mustParseLabels(`{foo="bar"}`).Hash()),
+				Fingerprint: model.Fingerprint(labels.StableHash(mustParseLabels(`{foo="bar"}`))),
 				Start:       2,
 				End:         5,
 				Checksum:    2,
 			},
 			{
 				User:        "fake",
-				Fingerprint: model.Fingerprint(mustParseLabels(`{foo="bar", bazz="buzz"}`).Hash()),
+				Fingerprint: model.Fingerprint(labels.StableHash(mustParseLabels(`{foo="bar", bazz="buzz"}`))),
 				Start:       1,
 				End:         10,
 				Checksum:    3,
@@ -109,11 +109,11 @@ func TestMultiIndex(t *testing.T) {
 		expected := []Series{
 			{
 				Labels:      mustParseLabels(`{foo="bar"}`),
-				Fingerprint: model.Fingerprint(mustParseLabels(`{foo="bar"}`).Hash()),
+				Fingerprint: model.Fingerprint(labels.StableHash(mustParseLabels(`{foo="bar"}`))),
 			},
 			{
 				Labels:      mustParseLabels(`{foo="bar", bazz="buzz"}`),
-				Fingerprint: model.Fingerprint(mustParseLabels(`{foo="bar", bazz="buzz"}`).Hash()),
+				Fingerprint: model.Fingerprint(labels.StableHash(mustParseLabels(`{foo="bar", bazz="buzz"}`))),
 			},
 		}
 

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/multitenant.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/multitenant.go
@@ -34,13 +34,7 @@ func withTenantLabelMatcher(userID string, matchers []*labels.Matcher) []*labels
 }
 
 func withoutTenantLabel(ls labels.Labels) labels.Labels {
-	for i, l := range ls {
-		if l.Name == TenantLabel {
-			ls = append(ls[:i], ls[i+1:]...)
-			break
-		}
-	}
-	return ls
+	return ls.DropReserved(func(name string) bool { return name == TenantLabel })
 }
 
 func (m *MultiTenantIndex) Bounds() (model.Time, model.Time) { return m.idx.Bounds() }

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/querier_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/querier_test.go
@@ -88,7 +88,7 @@ func TestQueryIndex(t *testing.T) {
 		},
 	}
 	for _, s := range cases {
-		b.AddSeries(s.labels, model.Fingerprint(s.labels.Hash()), s.chunks)
+		b.AddSeries(s.labels, model.Fingerprint(labels.StableHash(s.labels)), s.chunks)
 	}
 
 	dst, err := b.Build(context.Background(), dir, func(from, through model.Time, checksum uint32) Identifier {

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/single_file_index.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/single_file_index.go
@@ -371,7 +371,7 @@ func (i *TSDBIndex) Volume(
 	labelsToMatch, matchers, includeAll := util.PrepareLabelsAndMatchers(targetLabels, matchers, TenantLabel)
 
 	seriesNames := make(map[uint64]string)
-	seriesLabels := labels.Labels(make([]labels.Label, 0, len(labelsToMatch)))
+	seriesLabelsBuilder := labels.NewScratchBuilder(len(labelsToMatch))
 
 	aggregateBySeries := seriesvolume.AggregateBySeries(aggregateBy) || aggregateBy == ""
 	var by map[string]struct{}
@@ -414,17 +414,17 @@ func (i *TSDBIndex) Volume(
 				var labelVolumes map[string]uint64
 
 				if aggregateBySeries {
-					seriesLabels = seriesLabels[:0]
-					for _, l := range ls {
+					seriesLabelsBuilder.Reset()
+					ls.Range(func(l labels.Label) {
 						if _, ok := labelsToMatch[l.Name]; l.Name != TenantLabel && includeAll || ok {
-							seriesLabels = append(seriesLabels, l)
+							seriesLabelsBuilder.Add(l.Name, l.Value)
 						}
-					}
+					})
 				} else {
 					// when aggregating by labels, capture sizes for target labels if provided,
 					// otherwise for all intersecting labels
-					labelVolumes = make(map[string]uint64, len(ls))
-					for _, l := range ls {
+					labelVolumes = make(map[string]uint64, ls.Len())
+					ls.Range(func(l labels.Label) {
 						if len(targetLabels) > 0 {
 							if _, ok := labelsToMatch[l.Name]; l.Name != TenantLabel && includeAll || ok {
 								labelVolumes[l.Name] += stats.KB << 10
@@ -434,8 +434,11 @@ func (i *TSDBIndex) Volume(
 								labelVolumes[l.Name] += stats.KB << 10
 							}
 						}
-					}
+					})
 				}
+
+				seriesLabelsBuilder.Sort()
+				seriesLabels := seriesLabelsBuilder.Labels()
 
 				// If the labels are < 1k, this does not alloc
 				// https://github.com/prometheus/prometheus/pull/8025

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/single_file_index.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/single_file_index.go
@@ -439,7 +439,7 @@ func (i *TSDBIndex) Volume(
 
 				// If the labels are < 1k, this does not alloc
 				// https://github.com/prometheus/prometheus/pull/8025
-				hash := seriesLabels.Hash()
+				hash := labels.StableHash(seriesLabels)
 				if _, ok := seriesNames[hash]; !ok {
 					seriesNames[hash] = seriesLabels.String()
 				}

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/single_file_index_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/single_file_index_test.go
@@ -79,7 +79,7 @@ func TestSingleIdx(t *testing.T) {
 			fn: func() Index {
 				head := NewHead("fake", NewMetrics(nil), log.NewNopLogger())
 				for _, x := range cases {
-					_, _ = head.Append(x.Labels, x.Labels.Hash(), x.Chunks)
+					_, _ = head.Append(x.Labels, labels.StableHash(x.Labels), x.Chunks)
 				}
 				reader := head.Index()
 				return NewTSDBIndex(reader)
@@ -95,28 +95,28 @@ func TestSingleIdx(t *testing.T) {
 				expected := []ChunkRef{
 					{
 						User:        "fake",
-						Fingerprint: model.Fingerprint(mustParseLabels(`{foo="bar"}`).Hash()),
+						Fingerprint: model.Fingerprint(labels.StableHash(mustParseLabels(`{foo="bar"}`))),
 						Start:       0,
 						End:         3,
 						Checksum:    0,
 					},
 					{
 						User:        "fake",
-						Fingerprint: model.Fingerprint(mustParseLabels(`{foo="bar"}`).Hash()),
+						Fingerprint: model.Fingerprint(labels.StableHash(mustParseLabels(`{foo="bar"}`))),
 						Start:       1,
 						End:         4,
 						Checksum:    1,
 					},
 					{
 						User:        "fake",
-						Fingerprint: model.Fingerprint(mustParseLabels(`{foo="bar"}`).Hash()),
+						Fingerprint: model.Fingerprint(labels.StableHash(mustParseLabels(`{foo="bar"}`))),
 						Start:       2,
 						End:         5,
 						Checksum:    2,
 					},
 					{
 						User:        "fake",
-						Fingerprint: model.Fingerprint(mustParseLabels(`{foo="bar", bazz="buzz"}`).Hash()),
+						Fingerprint: model.Fingerprint(labels.StableHash(mustParseLabels(`{foo="bar", bazz="buzz"}`))),
 						Start:       1,
 						End:         10,
 						Checksum:    3,
@@ -136,7 +136,7 @@ func TestSingleIdx(t *testing.T) {
 
 				require.Equal(t, []ChunkRef{{
 					User:        "fake",
-					Fingerprint: model.Fingerprint(mustParseLabels(`{foo="bar", bazz="buzz"}`).Hash()),
+					Fingerprint: model.Fingerprint(labels.StableHash(mustParseLabels(`{foo="bar", bazz="buzz"}`))),
 					Start:       1,
 					End:         10,
 					Checksum:    3,
@@ -150,7 +150,7 @@ func TestSingleIdx(t *testing.T) {
 				expected := []Series{
 					{
 						Labels:      mustParseLabels(`{foo="bar", bazz="buzz"}`),
-						Fingerprint: model.Fingerprint(mustParseLabels(`{foo="bar", bazz="buzz"}`).Hash()),
+						Fingerprint: model.Fingerprint(labels.StableHash(mustParseLabels(`{foo="bar", bazz="buzz"}`))),
 					},
 				}
 				require.Equal(t, expected, xs)
@@ -168,7 +168,7 @@ func TestSingleIdx(t *testing.T) {
 				expected := []Series{
 					{
 						Labels:      mustParseLabels(`{foo="bar"}`),
-						Fingerprint: model.Fingerprint(mustParseLabels(`{foo="bar"}`).Hash()),
+						Fingerprint: model.Fingerprint(labels.StableHash(mustParseLabels(`{foo="bar"}`))),
 					},
 				}
 				require.Equal(t, expected, xs)

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/util_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/util_test.go
@@ -21,7 +21,7 @@ func BuildIndex(t testing.TB, dir string, cases []LoadableSeries) *TSDBFile {
 	b := NewBuilder(index.FormatV3)
 
 	for _, s := range cases {
-		b.AddSeries(s.Labels, model.Fingerprint(s.Labels.Hash()), s.Chunks)
+		b.AddSeries(s.Labels, model.Fingerprint(labels.StableHash(s.Labels)), s.Chunks)
 	}
 
 	dst, err := b.Build(context.Background(), dir, func(from, through model.Time, checksum uint32) Identifier {

--- a/pkg/storage/util_test.go
+++ b/pkg/storage/util_test.go
@@ -33,8 +33,8 @@ import (
 )
 
 var (
-	fooLabelsWithName = labels.Labels{{Name: "foo", Value: "bar"}, {Name: "__name__", Value: "logs"}}
-	fooLabels         = labels.Labels{{Name: "foo", Value: "bar"}}
+	fooLabelsWithName = labels.New(labels.Label{Name: "foo", Value: "bar"}, labels.Label{Name: "__name__", Value: "logs"})
+	fooLabels         = labels.New(labels.Label{Name: "foo", Value: "bar"})
 )
 
 var from = time.Unix(0, time.Millisecond.Nanoseconds())

--- a/pkg/util/labelpool/labelpool.go
+++ b/pkg/util/labelpool/labelpool.go
@@ -1,0 +1,29 @@
+package labelpool
+
+import (
+	"sync"
+
+	"github.com/prometheus/prometheus/model/labels"
+)
+
+var scratchPool = &sync.Pool{
+	New: func() any {
+		b := labels.NewScratchBuilder(8)
+		return &b
+	},
+}
+
+// Get returns a [labels.ScratchBuilder] from the pool, or creates one of if
+// the pool is empty. The returned builder is always in a fresh state.
+//
+// [labels.ScratchBuilder.Overwrite] is only valid to use with pooled builders
+// if the all references to the overwritten labels end before the builder is
+// returned to the pool.
+func Get() *labels.ScratchBuilder {
+	b := scratchPool.Get().(*labels.ScratchBuilder)
+	b.Reset()
+	return b
+}
+
+// Put returns a [labels.ScratchBuilder] back to the pool.
+func Put(b *labels.ScratchBuilder) { scratchPool.Put(b) }

--- a/pkg/util/marshal/marshal_test.go
+++ b/pkg/util/marshal/marshal_test.go
@@ -11,6 +11,7 @@ import (
 
 	json "github.com/json-iterator/go"
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/promql/parser"
@@ -689,7 +690,6 @@ func Test_QueryResponseMarshalLoop(t *testing.T) {
 
 		err = json.Unmarshal(bytes, &expected)
 		require.NoError(t, err)
-
 		require.Equalf(t, q, expected, "Query Marshal Loop %d failed", i)
 	}
 }
@@ -932,17 +932,14 @@ func (w wrappedValue) Generate(rand *rand.Rand, _ int) reflect.Value {
 
 	switch t {
 	case loghttp.ResultTypeMatrix:
-		s, _ := quick.Value(reflect.TypeOf(promql.Series{}), rand)
-		series, _ := s.Interface().(promql.Series)
-
-		l, _ := quick.Value(reflect.TypeOf(labels.Labels{}), rand)
-		series.Metric = l.Interface().(labels.Labels)
-
+		series := randSeries(rand)
 		matrix := promql.Matrix{series}
 		return reflect.ValueOf(wrappedValue{matrix})
+
 	case loghttp.ResultTypeScalar:
 		q, _ := quick.Value(reflect.TypeOf(promql.Scalar{}), rand)
 		return reflect.ValueOf(wrappedValue{q.Interface().(parser.Value)})
+
 	case loghttp.ResultTypeStream:
 		var streams logqlmodel.Streams
 		for i := 0; i < rand.Intn(100); i++ {
@@ -955,14 +952,11 @@ func (w wrappedValue) Generate(rand *rand.Rand, _ int) reflect.Value {
 			streams = append(streams, stream)
 		}
 		return reflect.ValueOf(wrappedValue{streams})
+
 	case loghttp.ResultTypeVector:
 		var vector promql.Vector
 		for i := 0; i < rand.Intn(100); i++ {
-			v, _ := quick.Value(reflect.TypeOf(promql.Sample{}), rand)
-			sample, _ := v.Interface().(promql.Sample)
-
-			l, _ := quick.Value(reflect.TypeOf(labels.Labels{}), rand)
-			sample.Metric = l.Interface().(labels.Labels)
+			sample := randSample(rand)
 			vector = append(vector, sample)
 		}
 		return reflect.ValueOf(wrappedValue{vector})
@@ -991,6 +985,22 @@ func randLabel(rand *rand.Rand) labels.Label {
 	return label
 }
 
+func randSeries(rand *rand.Rand) promql.Series {
+	var (
+		seriesMetric      = randLabels(rand)
+		seriesFPoints, _  = quick.Value(reflect.TypeOf([]promql.FPoint{}), rand)
+		seriesHPoints, _  = quick.Value(reflect.TypeOf([]promql.HPoint{}), rand)
+		seriesDropName, _ = quick.Value(reflect.TypeOf(bool(false)), rand)
+	)
+
+	return promql.Series{
+		Metric:     seriesMetric,
+		Floats:     seriesFPoints.Interface().([]promql.FPoint),
+		Histograms: seriesHPoints.Interface().([]promql.HPoint),
+		DropName:   seriesDropName.Interface().(bool),
+	}
+}
+
 func randLabels(rand *rand.Rand) labels.Labels {
 	nLabels := rand.Intn(100)
 	b := labels.NewScratchBuilder(nLabels)
@@ -1011,6 +1021,25 @@ func randEntries(rand *rand.Rand) []logproto.Entry {
 	}
 
 	return entries
+}
+
+func randSample(rand *rand.Rand) promql.Sample {
+	var (
+		sampleT, _        = quick.Value(reflect.TypeOf(int64(0)), rand)
+		sampleF, _        = quick.Value(reflect.TypeOf(float64(0)), rand)
+		sampleH, _        = quick.Value(reflect.TypeOf((*histogram.FloatHistogram)(nil)), rand)
+		sampleMetric      = randLabels(rand)
+		sampleDropName, _ = quick.Value(reflect.TypeOf(bool(false)), rand)
+	)
+
+	return promql.Sample{
+		T: sampleT.Interface().(int64),
+		F: sampleF.Interface().(float64),
+		H: sampleH.Interface().(*histogram.FloatHistogram),
+
+		Metric:   sampleMetric,
+		DropName: sampleDropName.Interface().(bool),
+	}
 }
 
 func Test_EncodeResult_And_ResultValue_Parity(t *testing.T) {

--- a/pkg/util/marshal/query.go
+++ b/pkg/util/marshal/query.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 	"strings"
 	"unicode/utf8"
-	"unsafe"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
@@ -110,10 +109,17 @@ func NewStream(s logproto.Stream) (loghttp.Stream, error) {
 		return loghttp.Stream{}, errors.Wrapf(err, "err while creating labelset for %s", s.Labels)
 	}
 
-	// Avoid a nil entries slice to be consistent with the decoding
-	entries := []loghttp.Entry{}
-	if len(s.Entries) > 0 {
-		entries = *(*[]loghttp.Entry)(unsafe.Pointer(&s.Entries)) //#nosec G103 -- Just preventing an allocation, safe. Entry types are the same.
+	// Always use a non-nil slice (even if it's length 0) to be consistent with
+	// the decoding.
+	entries := make([]loghttp.Entry, 0, len(s.Entries))
+	for _, ent := range s.Entries {
+		conv := loghttp.Entry{
+			Timestamp:          ent.Timestamp,
+			Line:               ent.Line,
+			StructuredMetadata: logproto.FromLabelAdaptersToLabels(ent.StructuredMetadata),
+			Parsed:             logproto.FromLabelAdaptersToLabels(ent.Parsed),
+		}
+		entries = append(entries, conv)
 	}
 
 	ret := loghttp.Stream{

--- a/tools/stream-generator/generator/service.go
+++ b/tools/stream-generator/generator/service.go
@@ -328,6 +328,7 @@ func generateStreamsForTenant(tenantID string, streamsPerTenant int, streamLabel
 		for j, label := range streamLabels {
 			builder.Add(label, fmt.Sprintf("%s-%d-%d", label, i, j))
 		}
+		builder.Sort()
 		lbs := builder.Labels()
 
 		// Create the stream with multiple entries

--- a/tools/stream-generator/generator/service.go
+++ b/tools/stream-generator/generator/service.go
@@ -334,7 +334,7 @@ func generateStreamsForTenant(tenantID string, streamsPerTenant int, streamLabel
 		// Create the stream with multiple entries
 		stream := logproto.Stream{
 			Labels:  labelsStr,
-			Hash:    lbs.Hash(),
+			Hash:    labels.StableHash(lbs),
 			Entries: make([]logproto.Entry, 0, entriesPerStream),
 		}
 

--- a/tools/stream-generator/generator/service.go
+++ b/tools/stream-generator/generator/service.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -325,11 +324,11 @@ func generateStreamsForTenant(tenantID string, streamsPerTenant int, streamLabel
 		labelsStr := fmt.Sprintf("{%s}", strings.Join(labelValues, ","))
 
 		// Parse the labels to get the hash
-		lbs := labels.FromMap(map[string]string{})
+		builder := labels.NewScratchBuilder(len(streamLabels))
 		for j, label := range streamLabels {
-			lbs = append(lbs, labels.Label{Name: label, Value: fmt.Sprintf("%s-%d-%d", label, i, j)})
+			builder.Add(label, fmt.Sprintf("%s-%d-%d", label, i, j))
 		}
-		sort.Sort(lbs)
+		lbs := builder.Labels()
 
 		// Create the stream with multiple entries
 		stream := logproto.Stream{

--- a/tools/tsdb/migrate-versions/main_test.go
+++ b/tools/tsdb/migrate-versions/main_test.go
@@ -63,12 +63,12 @@ func TestMigrateTables(t *testing.T) {
 	// setup some tables
 	for i := currTableNum - 5; i <= currTableNum; i++ {
 		b := tsdb.NewBuilder(index.FormatV2)
-		b.AddSeries(labels.Labels{
-			{
+		b.AddSeries(labels.New(
+			labels.Label{
 				Name:  "table_name",
 				Value: currTableName,
 			},
-		}, 1, []index.ChunkMeta{
+		), 1, []index.ChunkMeta{
 			{
 				Checksum: 1,
 				MinTime:  0,

--- a/tools/tsdb/tsdb-map/main.go
+++ b/tools/tsdb/tsdb-map/main.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
 	"go.etcd.io/bbolt"
 	"gopkg.in/yaml.v2"
 
@@ -89,7 +90,7 @@ func main() {
 					Entries:  10000,                  // guess: 10k entries
 				})
 			}
-			builder.AddSeries(s.Labels(), model.Fingerprint(s.Labels().Hash()), chunkMetas)
+			builder.AddSeries(s.Labels(), model.Fingerprint(labels.StableHash(s.Labels())), chunkMetas)
 			return nil
 		})
 	}); err != nil {


### PR DESCRIPTION
A while ago, Prometheus introduced a new API for `labels.Labels` to help migrate users for the eventual shift over to a new `labels.Labels` implementation which uses a single string rather than a slice of labels. 

Loki used the new API in some places, but not everywhere. Now that the default implementation in Prometheus is the string-based one (previously called `stringlabels`), Loki can't be built unless explicitly providing `-tags slicelabels` to use the old verison. 

This PR updates all code to consistently use the new labels.Labels API, so Loki can be built using either labels.Labels implementation. 

This change comes at some cost:

* Creating `labels.Labels` will almost _always_ allocate, given how it uses a single string to represent an entire set of labels. 
* It's no longer "free" to cast between `[]logproto.LabelAdapter` to `labels.Labels`.  

I've tried to avoid some of this cost by introducing a shared pool of `labels.ScratchBuilder` in `pkg/util/labelpool`. Using these builders will reduce some of the allocations (for gradually building a string), though the allocation of exchanging the builder for the final set of labels still allocates. 

I've split up this PR into multiple commits per package to make it mildly easier to review.

Closes #17122.