### PR TITLE
docs: Fix navigation for drilldown

### DIFF
--- a/docs/sources/visualize/grafana.md
+++ b/docs/sources/visualize/grafana.md
@@ -18,7 +18,7 @@ Grafana Loki does not have its own user interface. Most users [install Grafana](
 
 There are several different options for how to visualize your log data in Grafana:
 
-- [Logs Drilldown](https://grafana.com/docs/grafana-cloud/visualizations/simplified-exploration/logs/) lets you explore logs from your Loki data source without writing LogQL queries.
+- [Logs Drilldown](https://grafana.com/docs/grafana-cloud/visualizations/simplified-exploration/logs/) lets you automatically visualize and explore your logs from your Loki data source without having to write LogQL queries.
 - [Grafana Explore](https://grafana.com/docs/grafana/latest/explore/logs-integration/) helps you build and iterate on queries written in LogQL. Once you have a query that finds the data you're looking for, you can consider using your query in a Grafana dashboard.
 - [Loki Mixins](https://grafana.com/docs/loki/latest/operations/observability/#mixins) include a pre-built set of dashboards, recording rules, and alerts for monitoring Loki.
 - [Grafana Dashboards](https://grafana.com/docs/grafana/latest/dashboards/) let you query, transform, visualize, and understand your log data. You can create your own custom dashboards, or import and modify public dashboards shared by the community.
@@ -27,7 +27,7 @@ There are several different options for how to visualize your log data in Grafan
 
 Grafana Logs Drilldown lets you automatically visualize and explore logs. Logs Drilldown makes assumptions about what data you might want to see to help you quickly get started viewing your logs without having to learn LogQL and write queries.
 
-- If you are a Grafana Cloud user, you can access Logs Drilldown from the Grafana Cloud main navigation menu: select **Explore** > **Logs**.
+- If you are a Grafana Cloud user, you can access Logs Drilldown from the Grafana Cloud main navigation menu: select **Drilldown** > **Logs**.
 
 - If you are an open source or Grafana Enterprise Logs user, you can install the [Logs Drilldown plugin](https://grafana.com/docs/grafana-cloud/visualizations/simplified-exploration/logs/access/). For more information, refer to the [Logs Drilldown documentation](https://grafana.com/docs/grafana-cloud/visualizations/simplified-exploration/logs/).
 
@@ -36,6 +36,10 @@ Starting with Grafana v11.3, the plugin for the Logs Drilldown app is installed 
 {{< /admonition >}}
 
 {{< docs/learning-journeys title="Explore logs using Logs Drilldown" url="https://grafana.com/docs/learning-journeys/drilldown-logs/" >}}
+
+{{< admonition type="tip" >}}
+There is a link to Grafana Explore available on every panel in Logs Drilldown. Click the menu icon (three stacked dots) to access the link to Explore.  
+{{< /admonition >}}
 
 ## Grafana Explore
 


### PR DESCRIPTION
**What this PR does / why we need it**:

When I was reading the Visualize topic today, I spotted that the navigation had not been changed from Explore to Drilldown when the app name changed.
Also added a tip based on a Slack conversation.