### PR TITLE
chore(engine): Add tests for predicate pushdown for ambiguous columns

### DIFF
--- a/pkg/engine/planner/physical/optimizer.go
+++ b/pkg/engine/planner/physical/optimizer.go
@@ -66,7 +66,7 @@ func (r *predicatePushdown) applyPredicatePushdown(node Node, predicate Expressi
 	}
 	for _, child := range r.plan.Children(node) {
 		if ok := r.applyPredicatePushdown(child, predicate); !ok {
-			return ok
+			return false
 		}
 	}
 	return true


### PR DESCRIPTION
### Summary

Ambiguous columns (columns that can either be a label or structured metadata) cannot be pushed down to the dataobjscan, because the dataobj reader lacks the capability of handling the precedence of metadata over labels.

This change adds test cases that ensure that predicates with ambiguous columns are not pushed down in the optimizer.
