### PR TITLE
chore: Add indexes to LogQL benchmarks

### DIFF
--- a/pkg/dataobj/index/builder.go
+++ b/pkg/dataobj/index/builder.go
@@ -248,7 +248,7 @@ func (p *Builder) processRecord(record *kgo.Record) {
 			p.bufferedEvents[event.Tenant] = p.bufferedEvents[event.Tenant][:0]
 			return
 		}
-		err := p.BuildIndex(p.bufferedEvents[event.Tenant][:len(p.bufferedEvents[event.Tenant])])
+		err := p.buildIndex(p.bufferedEvents[event.Tenant][:len(p.bufferedEvents[event.Tenant])])
 		if err != nil {
 			// TODO(benclive): Improve error handling for failed index builds.
 			panic(err)
@@ -262,7 +262,7 @@ func (p *Builder) processRecord(record *kgo.Record) {
 	}
 }
 
-func (p *Builder) BuildIndex(events []metastore.ObjectWrittenEvent) error {
+func (p *Builder) buildIndex(events []metastore.ObjectWrittenEvent) error {
 	indexStorageBucket := objstore.NewPrefixedBucket(p.bucket, p.cfg.IndexStoragePrefix)
 	level.Info(p.logger).Log("msg", "building index", "events", len(events), "tenant", events[0].Tenant)
 	start := time.Now()

--- a/pkg/dataobj/index/builder.go
+++ b/pkg/dataobj/index/builder.go
@@ -316,7 +316,7 @@ func (p *Builder) buildIndex(events []metastore.ObjectWrittenEvent) error {
 
 	size := p.flushBuffer.Len()
 
-	key := IndexObjectKey(events[0].Tenant, p.flushBuffer)
+	key := ObjectKey(events[0].Tenant, p.flushBuffer)
 	if err := indexStorageBucket.Upload(p.ctx, key, p.flushBuffer); err != nil {
 		return fmt.Errorf("failed to upload index: %w", err)
 	}
@@ -334,7 +334,7 @@ func (p *Builder) buildIndex(events []metastore.ObjectWrittenEvent) error {
 }
 
 // getKey determines the key in object storage to upload the object to, based on our path scheme.
-func IndexObjectKey(tenantID string, object *bytes.Buffer) string {
+func ObjectKey(tenantID string, object *bytes.Buffer) string {
 	sum := sha256.Sum224(object.Bytes())
 	sumStr := hex.EncodeToString(sum[:])
 

--- a/pkg/dataobj/index/builder.go
+++ b/pkg/dataobj/index/builder.go
@@ -333,7 +333,7 @@ func (p *Builder) buildIndex(events []metastore.ObjectWrittenEvent) error {
 	return nil
 }
 
-// getKey determines the key in object storage to upload the object to, based on our path scheme.
+// ObjectKey determines the key in object storage to upload the object to, based on our path scheme.
 func ObjectKey(tenantID string, object *bytes.Buffer) string {
 	sum := sha256.Sum224(object.Bytes())
 	sumStr := hex.EncodeToString(sum[:])

--- a/pkg/dataobj/index/builder.go
+++ b/pkg/dataobj/index/builder.go
@@ -9,12 +9,10 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"runtime"
 	"slices"
 	"sync"
 	"time"
 
-	"github.com/bits-and-blooms/bloom/v3"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/backoff"
@@ -22,16 +20,12 @@ import (
 	"github.com/grafana/dskit/multierror"
 	"github.com/grafana/dskit/services"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/prometheus/model/labels"
 	"github.com/thanos-io/objstore"
 	"github.com/twmb/franz-go/pkg/kgo"
-	"golang.org/x/sync/errgroup"
 
 	"github.com/grafana/loki/v3/pkg/dataobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/index/indexobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/metastore"
-	"github.com/grafana/loki/v3/pkg/dataobj/sections/logs"
-	"github.com/grafana/loki/v3/pkg/dataobj/sections/streams"
 	"github.com/grafana/loki/v3/pkg/kafka"
 	"github.com/grafana/loki/v3/pkg/kafka/client"
 )
@@ -61,7 +55,6 @@ type downloadedObject struct {
 }
 
 const (
-	indexEventTopic    = "loki.metastore-events"
 	indexConsumerGroup = "metastore-event-reader"
 )
 
@@ -78,7 +71,7 @@ type Builder struct {
 	// Processing pipeline
 	downloadQueue     chan metastore.ObjectWrittenEvent
 	downloadedObjects chan downloadedObject
-	builder           *indexobj.Builder
+	calculator        *Calculator
 
 	bufferedEvents map[string][]metastore.ObjectWrittenEvent
 
@@ -91,11 +84,10 @@ type Builder struct {
 	metrics *indexBuilderMetrics
 
 	// Control and coordination
-	ctx        context.Context
-	cancel     context.CancelCauseFunc
-	wg         sync.WaitGroup
-	logger     log.Logger
-	builderMtx sync.Mutex
+	ctx    context.Context
+	cancel context.CancelCauseFunc
+	wg     sync.WaitGroup
+	logger log.Logger
 }
 
 func NewIndexBuilder(
@@ -114,7 +106,7 @@ func NewIndexBuilder(
 		kafkaCfg,
 		logger,
 		reg,
-		kgo.ConsumeTopics(indexEventTopic),
+		kgo.ConsumeTopics(kafkaCfg.Topic),
 		kgo.InstanceID(instanceID),
 		kgo.SessionTimeout(3*time.Minute),
 		kgo.ConsumerGroup(indexConsumerGroup),
@@ -126,7 +118,7 @@ func NewIndexBuilder(
 	}
 
 	reg = prometheus.WrapRegistererWith(prometheus.Labels{
-		"topic":     indexEventTopic,
+		"topic":     kafkaCfg.Topic,
 		"component": "index_builder",
 	}, reg)
 
@@ -139,6 +131,7 @@ func NewIndexBuilder(
 	if err != nil {
 		return nil, fmt.Errorf("failed to create index builder: %w", err)
 	}
+	calculator := NewCalculator(builder)
 
 	if err := builder.RegisterMetrics(reg); err != nil {
 		return nil, fmt.Errorf("failed to register metrics for index builder: %w", err)
@@ -157,15 +150,13 @@ func NewIndexBuilder(
 		mCfg:              mCfg,
 		client:            eventConsumerClient,
 		logger:            logger,
-		builder:           builder,
 		bucket:            bucket,
 		flushBuffer:       flushBuffer,
-		builderMtx:        sync.Mutex{},
 		downloadedObjects: downloadedObjects,
 		downloadQueue:     downloadQueue,
 		metrics:           metrics,
-
-		bufferedEvents: make(map[string][]metastore.ObjectWrittenEvent),
+		calculator:        calculator,
+		bufferedEvents:    make(map[string][]metastore.ObjectWrittenEvent),
 	}
 
 	s.Service = services.NewBasicService(nil, s.run, s.stopping)
@@ -257,7 +248,7 @@ func (p *Builder) processRecord(record *kgo.Record) {
 			p.bufferedEvents[event.Tenant] = p.bufferedEvents[event.Tenant][:0]
 			return
 		}
-		err := p.buildIndex(p.bufferedEvents[event.Tenant][:len(p.bufferedEvents[event.Tenant])])
+		err := p.BuildIndex(p.bufferedEvents[event.Tenant][:len(p.bufferedEvents[event.Tenant])])
 		if err != nil {
 			// TODO(benclive): Improve error handling for failed index builds.
 			panic(err)
@@ -271,7 +262,7 @@ func (p *Builder) processRecord(record *kgo.Record) {
 	}
 }
 
-func (p *Builder) buildIndex(events []metastore.ObjectWrittenEvent) error {
+func (p *Builder) BuildIndex(events []metastore.ObjectWrittenEvent) error {
 	indexStorageBucket := objstore.NewPrefixedBucket(p.bucket, p.cfg.IndexStoragePrefix)
 	level.Info(p.logger).Log("msg", "building index", "events", len(events), "tenant", events[0].Tenant)
 	start := time.Now()
@@ -307,32 +298,8 @@ func (p *Builder) buildIndex(events []metastore.ObjectWrittenEvent) error {
 			continue
 		}
 
-		// Streams Section: process this section first to ensure all streams have been added to the builder and are given new IDs.
-		for i, section := range reader.Sections().Filter(streams.CheckSection) {
-			level.Debug(objLogger).Log("msg", "processing streams section", "index", i)
-			if err := p.processStreamsSection(section, obj.event.ObjectPath); err != nil {
-				processingErrors.Add(fmt.Errorf("failed to process stream section: %w", err))
-				continue
-			}
-		}
-
-		// Logs Section: these can be processed in parallel once we have the stream IDs. This work is heavily CPU bound so is limited to GOMAXPROCS parallelism.
-		g, ctx := errgroup.WithContext(p.ctx)
-		g.SetLimit(runtime.GOMAXPROCS(0))
-		for i, section := range reader.Sections().Filter(logs.CheckSection) {
-			g.Go(func() error {
-				sectionLogger := log.With(objLogger, "section", i)
-				level.Debug(sectionLogger).Log("msg", "processing logs section")
-				// 1. A bloom filter for each column in the logs section.
-				// 2. A per-section stream time-range index using min/max of each stream in the logs section. StreamIDs will reference the aggregate stream section.
-				if err := p.processLogsSection(ctx, sectionLogger, obj.event.ObjectPath, section, int64(i)); err != nil {
-					return fmt.Errorf("failed to process logs section path=%s section=%d: %w", obj.event.ObjectPath, i, err)
-				}
-				return nil
-			})
-		}
-		if err := g.Wait(); err != nil {
-			processingErrors.Add(fmt.Errorf("failed to process logs sections: %w", err))
+		if err := p.calculator.Calculate(p.ctx, objLogger, reader, obj.event.ObjectPath); err != nil {
+			processingErrors.Add(fmt.Errorf("failed to calculate index: %w", err))
 			continue
 		}
 	}
@@ -342,14 +309,14 @@ func (p *Builder) buildIndex(events []metastore.ObjectWrittenEvent) error {
 	}
 
 	p.flushBuffer.Reset()
-	stats, err := p.builder.Flush(p.flushBuffer)
+	stats, err := p.calculator.Flush(p.flushBuffer)
 	if err != nil {
 		return fmt.Errorf("failed to flush builder: %w", err)
 	}
 
 	size := p.flushBuffer.Len()
 
-	key := p.getKey(events[0].Tenant, p.flushBuffer)
+	key := IndexObjectKey(events[0].Tenant, p.flushBuffer)
 	if err := indexStorageBucket.Upload(p.ctx, key, p.flushBuffer); err != nil {
 		return fmt.Errorf("failed to upload index: %w", err)
 	}
@@ -367,128 +334,11 @@ func (p *Builder) buildIndex(events []metastore.ObjectWrittenEvent) error {
 }
 
 // getKey determines the key in object storage to upload the object to, based on our path scheme.
-func (p *Builder) getKey(tenantID string, object *bytes.Buffer) string {
+func IndexObjectKey(tenantID string, object *bytes.Buffer) string {
 	sum := sha256.Sum224(object.Bytes())
 	sumStr := hex.EncodeToString(sum[:])
 
 	return fmt.Sprintf("tenant-%s/indexes/%s/%s", tenantID, sumStr[:2], sumStr[2:])
-}
-
-func (p *Builder) processStreamsSection(section *dataobj.Section, objectPath string) /*map[int64]streams.Stream, map[uint64]int64,*/ error {
-	streamSection, err := streams.Open(p.ctx, section)
-	if err != nil {
-		return fmt.Errorf("failed to open stream section: %w", err)
-	}
-
-	streamBuf := make([]streams.Stream, 2048)
-	rowReader := streams.NewRowReader(streamSection)
-	for {
-		n, err := rowReader.Read(p.ctx, streamBuf)
-		if err != nil && err != io.EOF {
-			return fmt.Errorf("failed to read stream section: %w", err)
-		}
-		if n == 0 && err == io.EOF {
-			break
-		}
-		for _, stream := range streamBuf[:n] {
-			newStreamID, err := p.builder.AppendStream(stream)
-			if err != nil {
-				return fmt.Errorf("failed to append to stream: %w", err)
-			}
-			p.builder.RecordStreamRef(objectPath, stream.ID, newStreamID)
-		}
-	}
-	return nil
-}
-
-// processLogsSection reads information from the logs section in order to build index information in a new object.
-func (p *Builder) processLogsSection(ctx context.Context, sectionLogger log.Logger, objectPath string, section *dataobj.Section, sectionIdx int64) error {
-	logsBuf := make([]logs.Record, 1024)
-	type logInfo struct {
-		objectPath string
-		sectionIdx int64
-		streamID   int64
-		timestamp  time.Time
-		length     int64
-	}
-	logsInfo := make([]logInfo, len(logsBuf))
-
-	logsSection, err := logs.Open(ctx, section)
-	if err != nil {
-		return fmt.Errorf("failed to open logs section: %w", err)
-	}
-
-	// Fetch the column statistics in order to init the bloom filters for each column
-	stats, err := logs.ReadStats(ctx, logsSection)
-	if err != nil {
-		return fmt.Errorf("failed to read log section stats: %w", err)
-	}
-
-	columnBloomBuilders := make(map[string]*bloom.BloomFilter)
-	columnIndexes := make(map[string]int64)
-	for _, column := range stats.Columns {
-		if !logs.IsMetadataColumn(column.Type) {
-			continue
-		}
-		columnBloomBuilders[column.Name] = bloom.NewWithEstimates(uint(column.Cardinality), 1.0/128.0)
-		columnIndexes[column.Name] = column.ColumnIndex
-	}
-
-	// Read the whole logs section to extract all the column values.
-	cnt := 0
-	// TODO(benclive): Switch to a columnar reader instead of row based
-	// This is also likely to be more performant, especially if we don't need to read the whole log line.
-	// Note: the source object would need a new column storing just the length to avoid reading the log line itself.
-	rowReader := logs.NewRowReader(logsSection)
-	for {
-		n, err := rowReader.Read(p.ctx, logsBuf)
-		if err != nil && err != io.EOF {
-			return fmt.Errorf("failed to read logs section: %w", err)
-		}
-		if n == 0 && err == io.EOF {
-			break
-		}
-
-		for i, log := range logsBuf[:n] {
-			cnt++
-			log.Metadata.Range(func(md labels.Label) {
-				columnBloomBuilders[md.Name].Add([]byte(md.Value))
-			})
-			logsInfo[i].objectPath = objectPath
-			logsInfo[i].sectionIdx = sectionIdx
-			logsInfo[i].streamID = log.StreamID
-			logsInfo[i].timestamp = log.Timestamp
-			logsInfo[i].length = int64(len(log.Line))
-		}
-
-		// Lock the mutex once per read for perf reasons.
-		p.builderMtx.Lock()
-		for _, log := range logsInfo[:n] {
-			err = p.builder.ObserveLogLine(log.objectPath, log.sectionIdx, log.streamID, log.timestamp, log.length)
-			if err != nil {
-				p.builderMtx.Unlock()
-				return fmt.Errorf("failed to observe log line: %w", err)
-			}
-		}
-		p.builderMtx.Unlock()
-	}
-
-	// Write the indexes (bloom filters) to the new index object.
-	for columnName, bloom := range columnBloomBuilders {
-		bloomBytes, err := bloom.MarshalBinary()
-		if err != nil {
-			return fmt.Errorf("failed to marshal bloom filter: %w", err)
-		}
-		p.builderMtx.Lock()
-		err = p.builder.AppendColumnIndex(objectPath, sectionIdx, columnName, columnIndexes[columnName], bloomBytes)
-		p.builderMtx.Unlock()
-		if err != nil {
-			return fmt.Errorf("failed to append column index: %w", err)
-		}
-	}
-
-	level.Info(sectionLogger).Log("msg", "finished processing logs section", "rowsProcessed", cnt)
-	return nil
 }
 
 func (p *Builder) commitRecords(record *kgo.Record) error {

--- a/pkg/dataobj/index/calculate.go
+++ b/pkg/dataobj/index/calculate.go
@@ -3,6 +3,7 @@ package index
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"runtime"
@@ -76,10 +77,10 @@ func (c *Calculator) processStreamsSection(ctx context.Context, section *dataobj
 	rowReader := streams.NewRowReader(streamSection)
 	for {
 		n, err := rowReader.Read(ctx, streamBuf)
-		if err != nil && err != io.EOF {
+		if err != nil && !errors.Is(err, io.EOF) {
 			return fmt.Errorf("failed to read stream section: %w", err)
 		}
-		if n == 0 && err == io.EOF {
+		if n == 0 && errors.Is(err, io.EOF) {
 			break
 		}
 		for _, stream := range streamBuf[:n] {
@@ -134,10 +135,10 @@ func (c *Calculator) processLogsSection(ctx context.Context, sectionLogger log.L
 	rowReader := logs.NewRowReader(logsSection)
 	for {
 		n, err := rowReader.Read(ctx, logsBuf)
-		if err != nil && err != io.EOF {
+		if err != nil && !errors.Is(err, io.EOF) {
 			return fmt.Errorf("failed to read logs section: %w", err)
 		}
-		if n == 0 && err == io.EOF {
+		if n == 0 && errors.Is(err, io.EOF) {
 			break
 		}
 

--- a/pkg/dataobj/index/calculate.go
+++ b/pkg/dataobj/index/calculate.go
@@ -21,6 +21,8 @@ import (
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/streams"
 )
 
+// Calculator is used to calculate the indexes for a logs object and write them to the builder.
+// It reads data from the logs object in order to build bloom filters and per-section stream metadata.
 type Calculator struct {
 	indexobjBuilder *indexobj.Builder
 	builderMtx      sync.Mutex
@@ -38,6 +40,7 @@ func (c *Calculator) Flush(buffer *bytes.Buffer) (indexobj.FlushStats, error) {
 	return c.indexobjBuilder.Flush(buffer)
 }
 
+// Calculate reads the log data from the input logs object and appends the resulting indexes to calculator's builder.
 func (c *Calculator) Calculate(ctx context.Context, logger log.Logger, reader *dataobj.Object, objectPath string) error {
 	// Streams Section: process this section first to ensure all streams have been added to the builder and are given new IDs.
 	for i, section := range reader.Sections().Filter(streams.CheckSection) {

--- a/pkg/dataobj/index/calculate.go
+++ b/pkg/dataobj/index/calculate.go
@@ -1,0 +1,184 @@
+package index
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"runtime"
+	"sync"
+	"time"
+
+	"github.com/bits-and-blooms/bloom/v3"
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/grafana/loki/v3/pkg/dataobj"
+	"github.com/grafana/loki/v3/pkg/dataobj/index/indexobj"
+	"github.com/grafana/loki/v3/pkg/dataobj/sections/logs"
+	"github.com/grafana/loki/v3/pkg/dataobj/sections/streams"
+	"golang.org/x/sync/errgroup"
+)
+
+type Calculator struct {
+	indexobjBuilder *indexobj.Builder
+	builderMtx      sync.Mutex
+}
+
+func NewCalculator(indexobjBuilder *indexobj.Builder) *Calculator {
+	return &Calculator{indexobjBuilder: indexobjBuilder, builderMtx: sync.Mutex{}}
+}
+
+func (c *Calculator) Reset() {
+	c.indexobjBuilder.Reset()
+}
+
+func (c *Calculator) Flush(buffer *bytes.Buffer) (indexobj.FlushStats, error) {
+	return c.indexobjBuilder.Flush(buffer)
+}
+
+func (c *Calculator) Calculate(ctx context.Context, logger log.Logger, reader *dataobj.Object, objectPath string) error {
+	// Streams Section: process this section first to ensure all streams have been added to the builder and are given new IDs.
+	for i, section := range reader.Sections().Filter(streams.CheckSection) {
+		level.Debug(logger).Log("msg", "processing streams section", "index", i)
+		if err := c.processStreamsSection(ctx, section, objectPath); err != nil {
+			return fmt.Errorf("failed to process stream section: %w", err)
+		}
+	}
+
+	// Logs Section: these can be processed in parallel once we have the stream IDs. This work is heavily CPU bound so is limited to GOMAXPROCS parallelism.
+	g, ctx := errgroup.WithContext(ctx)
+	g.SetLimit(runtime.GOMAXPROCS(0))
+	for i, section := range reader.Sections().Filter(logs.CheckSection) {
+		g.Go(func() error {
+			sectionLogger := log.With(logger, "section", i)
+			level.Debug(sectionLogger).Log("msg", "processing logs section")
+			// 1. A bloom filter for each column in the logs section.
+			// 2. A per-section stream time-range index using min/max of each stream in the logs section. StreamIDs will reference the aggregate stream section.
+			if err := c.processLogsSection(ctx, sectionLogger, objectPath, section, int64(i)); err != nil {
+				return fmt.Errorf("failed to process logs section path=%s section=%d: %w", objectPath, i, err)
+			}
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return fmt.Errorf("failed to process logs sections: %w", err)
+	}
+	return nil
+}
+
+func (c *Calculator) processStreamsSection(ctx context.Context, section *dataobj.Section, objectPath string) /*map[int64]streams.Stream, map[uint64]int64,*/ error {
+	streamSection, err := streams.Open(ctx, section)
+	if err != nil {
+		return fmt.Errorf("failed to open stream section: %w", err)
+	}
+
+	streamBuf := make([]streams.Stream, 2048)
+	rowReader := streams.NewRowReader(streamSection)
+	for {
+		n, err := rowReader.Read(ctx, streamBuf)
+		if err != nil && err != io.EOF {
+			return fmt.Errorf("failed to read stream section: %w", err)
+		}
+		if n == 0 && err == io.EOF {
+			break
+		}
+		for _, stream := range streamBuf[:n] {
+			newStreamID, err := c.indexobjBuilder.AppendStream(stream)
+			if err != nil {
+				return fmt.Errorf("failed to append to stream: %w", err)
+			}
+			c.indexobjBuilder.RecordStreamRef(objectPath, stream.ID, newStreamID)
+		}
+	}
+	return nil
+}
+
+// processLogsSection reads information from the logs section in order to build index information in a new object.
+func (c *Calculator) processLogsSection(ctx context.Context, sectionLogger log.Logger, objectPath string, section *dataobj.Section, sectionIdx int64) error {
+	logsBuf := make([]logs.Record, 1024)
+	type logInfo struct {
+		objectPath string
+		sectionIdx int64
+		streamID   int64
+		timestamp  time.Time
+		length     int64
+	}
+	logsInfo := make([]logInfo, len(logsBuf))
+
+	logsSection, err := logs.Open(ctx, section)
+	if err != nil {
+		return fmt.Errorf("failed to open logs section: %w", err)
+	}
+
+	// Fetch the column statistics in order to init the bloom filters for each column
+	stats, err := logs.ReadStats(ctx, logsSection)
+	if err != nil {
+		return fmt.Errorf("failed to read log section stats: %w", err)
+	}
+
+	columnBloomBuilders := make(map[string]*bloom.BloomFilter)
+	columnIndexes := make(map[string]int64)
+	for _, column := range stats.Columns {
+		if !logs.IsMetadataColumn(column.Type) {
+			continue
+		}
+		columnBloomBuilders[column.Name] = bloom.NewWithEstimates(uint(column.Cardinality), 1.0/128.0)
+		columnIndexes[column.Name] = column.ColumnIndex
+	}
+
+	// Read the whole logs section to extract all the column values.
+	cnt := 0
+	// TODO(benclive): Switch to a columnar reader instead of row based
+	// This is also likely to be more performant, especially if we don't need to read the whole log line.
+	// Note: the source object would need a new column storing just the length to avoid reading the log line itself.
+	rowReader := logs.NewRowReader(logsSection)
+	for {
+		n, err := rowReader.Read(ctx, logsBuf)
+		if err != nil && err != io.EOF {
+			return fmt.Errorf("failed to read logs section: %w", err)
+		}
+		if n == 0 && err == io.EOF {
+			break
+		}
+
+		for i, log := range logsBuf[:n] {
+			cnt++
+			for _, md := range log.Metadata {
+				columnBloomBuilders[md.Name].Add([]byte(md.Value))
+			}
+			logsInfo[i].objectPath = objectPath
+			logsInfo[i].sectionIdx = sectionIdx
+			logsInfo[i].streamID = log.StreamID
+			logsInfo[i].timestamp = log.Timestamp
+			logsInfo[i].length = int64(len(log.Line))
+		}
+
+		// Lock the mutex once per read for perf reasons.
+		c.builderMtx.Lock()
+		for _, log := range logsInfo[:n] {
+			err = c.indexobjBuilder.ObserveLogLine(log.objectPath, log.sectionIdx, log.streamID, log.timestamp, log.length)
+			if err != nil {
+				c.builderMtx.Unlock()
+				return fmt.Errorf("failed to observe log line: %w", err)
+			}
+		}
+		c.builderMtx.Unlock()
+	}
+
+	// Write the indexes (bloom filters) to the new index object.
+	for columnName, bloom := range columnBloomBuilders {
+		bloomBytes, err := bloom.MarshalBinary()
+		if err != nil {
+			return fmt.Errorf("failed to marshal bloom filter: %w", err)
+		}
+		c.builderMtx.Lock()
+		err = c.indexobjBuilder.AppendColumnIndex(objectPath, sectionIdx, columnName, columnIndexes[columnName], bloomBytes)
+		c.builderMtx.Unlock()
+		if err != nil {
+			return fmt.Errorf("failed to append column index: %w", err)
+		}
+	}
+
+	level.Info(sectionLogger).Log("msg", "finished processing logs section", "rowsProcessed", cnt)
+	return nil
+}

--- a/pkg/dataobj/internal/dataset/page_builder.go
+++ b/pkg/dataobj/internal/dataset/page_builder.go
@@ -291,7 +291,6 @@ func (b *pageBuilder) buildStats() *datasetmd.Statistics {
 }
 
 func (b *pageBuilder) buildRangeStats(dst *datasetmd.Statistics) {
-
 	minValueBytes, err := b.minValue.MarshalBinary()
 	if err != nil {
 		panic(fmt.Sprintf("pageBuilder.buildStats: failed to marshal min value: %s", err))

--- a/pkg/dataobj/metastore/object.go
+++ b/pkg/dataobj/metastore/object.go
@@ -586,7 +586,7 @@ func (m *ObjectMetastore) estimateSectionsForPredicates(ctx context.Context, pat
 	defer timer.ObserveDuration()
 
 	g, ctx := errgroup.WithContext(ctx)
-	g.SetLimit(1)
+	g.SetLimit(m.parallelism)
 
 	var sectionDescriptors []*DataobjSectionDescriptor
 	var sectionDescriptorsMutex sync.Mutex

--- a/pkg/dataobj/metastore/object.go
+++ b/pkg/dataobj/metastore/object.go
@@ -411,9 +411,7 @@ func pointerPredicateFromMatchers(matchers ...*labels.Matcher) pointers.RowPredi
 		}
 	}
 
-	current := pointers.AndRowPredicate{
-		Left: predicates[0],
-	}
+	current := predicates[0]
 
 	for _, predicate := range predicates[1:] {
 		and := pointers.AndRowPredicate{
@@ -588,7 +586,7 @@ func (m *ObjectMetastore) estimateSectionsForPredicates(ctx context.Context, pat
 	defer timer.ObserveDuration()
 
 	g, ctx := errgroup.WithContext(ctx)
-	g.SetLimit(m.parallelism)
+	g.SetLimit(1)
 
 	var sectionDescriptors []*DataobjSectionDescriptor
 	var sectionDescriptorsMutex sync.Mutex

--- a/pkg/dataobj/sections/pointers/iter.go
+++ b/pkg/dataobj/sections/pointers/iter.go
@@ -79,13 +79,13 @@ func IterSection(ctx context.Context, section *Section) result.Seq[SectionPointe
 				return nil
 			}
 
-			var stream SectionPointer
+			var pointer SectionPointer
 			for _, row := range rows[:n] {
-				if err := decodeRow(streamsColumns, row, &stream, sym); err != nil {
+				if err := decodeRow(streamsColumns, row, &pointer, sym); err != nil {
 					return err
 				}
 
-				if !yield(stream) {
+				if !yield(pointer) {
 					return nil
 				}
 			}
@@ -100,6 +100,8 @@ func IterSection(ctx context.Context, section *Section) result.Seq[SectionPointe
 // The sym argument is used for reusing label values between calls to
 // decodeRow. If sym is nil, label value strings are always allocated.
 func decodeRow(columns []*pointersmd.ColumnDesc, row dataset.Row, pointer *SectionPointer, sym *symbolizer.Symbolizer) error {
+	pointer.Reset()
+
 	for columnIndex, columnValue := range row.Values {
 		if columnValue.IsNil() || columnValue.IsZero() {
 			continue

--- a/pkg/dataobj/sections/pointers/row_reader.go
+++ b/pkg/dataobj/sections/pointers/row_reader.go
@@ -250,6 +250,12 @@ func translatePointersPredicate(p RowPredicate, columns []dataset.Column, column
 }
 
 func convertBloomExistenceRowPredicate(p BloomExistenceRowPredicate, nameColumn, bloomColumn dataset.Column) dataset.Predicate {
+	if nameColumn == nil && bloomColumn == nil {
+		// If there are no name or bloom columns present, it means this section doesn't have any relevant columns for this predicate.
+		// This can happen if a whole section only contains pointers of a different Kind.
+		return dataset.FalsePredicate{}
+	}
+
 	// TODO: Make this more efficient by not re-allocating the bloom filter each time
 	return dataset.AndPredicate{
 		Left: dataset.EqualPredicate{

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -99,7 +99,6 @@ func (e *QueryEngine) Execute(ctx context.Context, params logql.Params) (logqlmo
 	if e.opts.CataloguePath != "" {
 		catalogueType = physical.CatalogueTypeIndex
 	}
-
 	catalog := physical.NewMetastoreCatalog(ctx, e.metastore, catalogueType)
 	planner := physical.NewPlanner(physical.NewContext(params.Start(), params.End()), catalog)
 	plan, err := planner.Build(logicalPlan)

--- a/pkg/logql/bench/bench_test.go
+++ b/pkg/logql/bench/bench_test.go
@@ -32,12 +32,13 @@ var slowTests = flag.Bool("slow-tests", false, "run slow tests")
 const testTenant = "test-tenant"
 
 const (
-	StoreDataObj         = "dataobj"
-	StoreDataObjV2Engine = "dataobj-engine"
-	StoreChunk           = "chunk"
+	StoreDataObj                    = "dataobj"
+	StoreDataObjV2Engine            = "dataobj-engine"
+	StoreDataObjV2EngineWithIndexes = "dataobj-engine-with-indexes"
+	StoreChunk                      = "chunk"
 )
 
-var allStores = []string{StoreDataObj, StoreDataObjV2Engine, StoreChunk}
+var allStores = []string{StoreDataObj, StoreDataObjV2Engine, StoreDataObjV2EngineWithIndexes, StoreChunk}
 
 //go:generate go run ./cmd/generate/main.go -size 2147483648 -dir ./data -tenant test-tenant
 
@@ -64,6 +65,12 @@ func setupBenchmarkWithStore(tb testing.TB, storeType string) (logql.Engine, *Ge
 			tb.Fatal(err)
 		}
 
+		return store.engine, config
+	case StoreDataObjV2EngineWithIndexes:
+		store, err := NewDataObjV2EngineWithIndexesStore(DefaultDataDir, testTenant)
+		if err != nil {
+			tb.Fatal(err)
+		}
 		return store.engine, config
 	case StoreDataObj:
 		store, err := NewDataObjStore(DefaultDataDir, testTenant)
@@ -240,7 +247,6 @@ func TestLogQLQueries(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(fmt.Sprintf("query=%s/kind=%s/store=%s", c.Name(), c.Kind(), store), func(t *testing.T) {
-
 			// Uncomment this to run only log queries
 			// if c.Kind() != "log" {
 			// 	continue

--- a/pkg/logql/bench/store_dataobj.go
+++ b/pkg/logql/bench/store_dataobj.go
@@ -177,13 +177,13 @@ func (s *DataObjStore) Close() error {
 
 func (s *DataObjStore) buildIndex() error {
 	flushAndUpload := func(calculator *index.Calculator) error {
-		buffer := bytes.NewBuffer(make([]byte, 0, 128*1024*1024))
-		stats, err := calculator.Flush(buffer)
+		s.buf.Reset()
+		stats, err := calculator.Flush(s.buf)
 		if err != nil {
 			return fmt.Errorf("failed to flush index: %w", err)
 		}
-		key := index.ObjectKey(s.tenantID, buffer)
-		err = s.indexWriterBucket.Upload(context.Background(), key, buffer)
+		key := index.ObjectKey(s.tenantID, s.buf)
+		err = s.indexWriterBucket.Upload(context.Background(), key, s.buf)
 		if err != nil {
 			return fmt.Errorf("failed to upload index: %w", err)
 		}

--- a/pkg/logql/bench/store_dataobj.go
+++ b/pkg/logql/bench/store_dataobj.go
@@ -182,7 +182,7 @@ func (s *DataObjStore) buildIndex() error {
 		if err != nil {
 			return fmt.Errorf("failed to flush index: %w", err)
 		}
-		key := index.IndexObjectKey(s.tenantID, buffer)
+		key := index.ObjectKey(s.tenantID, buffer)
 		err = s.indexWriterBucket.Upload(context.Background(), key, buffer)
 		if err != nil {
 			return fmt.Errorf("failed to upload index: %w", err)

--- a/pkg/logql/bench/store_dataobj_v2_engine.go
+++ b/pkg/logql/bench/store_dataobj_v2_engine.go
@@ -58,3 +58,40 @@ func NewDataObjV2EngineStore(dataDir string, tenantID string) (*DataObjV2EngineS
 		dataDir:  dataDir,
 	}, nil
 }
+
+// NewDataObjV2EngineStore creates a new store that uses the v2 dataobj engine.
+func NewDataObjV2EngineWithIndexesStore(dataDir string, tenantID string) (*DataObjV2EngineStore, error) {
+	logger := log.NewNopLogger()
+
+	// Setup filesystem client as objstore.Bucket
+	// This assumes the engine is configured to read its specific data format (e.g., Parquet)
+	// from this directory structure. The existing benchmark data generation might need adjustments
+	// if it doesn't produce this format.
+	// Use NewBucket from thanos-io/objstore/providers/filesystem, similar to store_dataobj.go
+	storeDir := filepath.Join(dataDir, "dataobj")
+	bucketClient, err := filesystem.NewBucket(storeDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create filesystem bucket for DataObjV2EngineStore: %w", err)
+	}
+
+	// Default EngineOpts. Adjust if specific configurations are needed.
+	engineOpts := logql.EngineOpts{
+		EnableV2Engine: true,
+		BatchSize:      512,
+		CataloguePath:  "index/v0",
+	}
+
+	// Instantiate the new engine
+	// Note: The tenantID is not directly passed to engine.New here.
+	// The engine might expect tenant information to be part of the query context
+	// or derived from the bucket structure if it's multi-tenant aware.
+	// This might require adjustment based on how pkg/engine/engine actually handles multi-tenancy
+	// with a generic objstore.Bucket.
+	queryEngine := engine.New(engineOpts, bucketClient, logql.NoLimits, nil, logger)
+
+	return &DataObjV2EngineStore{
+		engine:   queryEngine,
+		tenantID: tenantID, // Store for context or if querier needs it
+		dataDir:  dataDir,
+	}, nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Builds & utilitises indexes in the LogQL benchmark suite.
* Fixes a correctness bug which stopped them passing (reset the Pointer object on reads, espcially for `0` int64s.)
* I decided to add the indexed store as a separate store so we can compare with the engine without indexes (and potentially rule out any issues earlier). I happy to just have one store if we want.
* Note: all of calculate.go is extracted from builder.go, and hasn't changed otherwise.

Interesting observation: The benchmark suite doesn't have enough data to make the indexes worthwhile. We correctly resolve less sections but the additional lines & data read from the index tends to make it do more work than without. I don't think this is a problem as it'll make a bigger difference on more data.

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/loki-private/issues/1768