### PR TITLE
chore(engine): Add support for regex and substr filters

### DIFF
--- a/pkg/engine/executor/functions.go
+++ b/pkg/engine/executor/functions.go
@@ -19,64 +19,64 @@ var (
 
 func init() {
 	// Functions for [types.BinaryOpEq]
-	binaryFunctions.register(types.BinaryOpEq, arrow.FixedWidthTypes.Boolean, &boolCompareFunction{cmp: func(a, b bool) bool { return a == b }})
-	binaryFunctions.register(types.BinaryOpEq, arrow.BinaryTypes.String, &strCompareFunction{cmp: func(a, b string) bool { return a == b }})
-	binaryFunctions.register(types.BinaryOpEq, arrow.PrimitiveTypes.Int64, &intCompareFunction{cmp: func(a, b int64) bool { return a == b }})
-	binaryFunctions.register(types.BinaryOpEq, arrow.PrimitiveTypes.Uint64, &timestampCompareFunction{cmp: func(a, b uint64) bool { return a == b }})
-	binaryFunctions.register(types.BinaryOpEq, arrow.PrimitiveTypes.Float64, &floatCompareFunction{cmp: func(a, b float64) bool { return a == b }})
+	binaryFunctions.register(types.BinaryOpEq, arrow.FixedWidthTypes.Boolean, &genericFunction[*array.Boolean, bool]{eval: func(a, b bool) (bool, error) { return a == b, nil }})
+	binaryFunctions.register(types.BinaryOpEq, arrow.BinaryTypes.String, &genericFunction[*array.String, string]{eval: func(a, b string) (bool, error) { return a == b, nil }})
+	binaryFunctions.register(types.BinaryOpEq, arrow.PrimitiveTypes.Int64, &genericFunction[*array.Int64, int64]{eval: func(a, b int64) (bool, error) { return a == b, nil }})
+	binaryFunctions.register(types.BinaryOpEq, arrow.FixedWidthTypes.Timestamp_ns, &genericFunction[*array.Timestamp, arrow.Timestamp]{eval: func(a, b arrow.Timestamp) (bool, error) { return a == b, nil }})
+	binaryFunctions.register(types.BinaryOpEq, arrow.PrimitiveTypes.Float64, &genericFunction[*array.Float64, float64]{eval: func(a, b float64) (bool, error) { return a == b, nil }})
 	// Functions for [types.BinaryOpNeq]
-	binaryFunctions.register(types.BinaryOpNeq, arrow.FixedWidthTypes.Boolean, &boolCompareFunction{cmp: func(a, b bool) bool { return a != b }})
-	binaryFunctions.register(types.BinaryOpNeq, arrow.BinaryTypes.String, &strCompareFunction{cmp: func(a, b string) bool { return a != b }})
-	binaryFunctions.register(types.BinaryOpNeq, arrow.PrimitiveTypes.Int64, &intCompareFunction{cmp: func(a, b int64) bool { return a != b }})
-	binaryFunctions.register(types.BinaryOpNeq, arrow.PrimitiveTypes.Uint64, &timestampCompareFunction{cmp: func(a, b uint64) bool { return a != b }})
-	binaryFunctions.register(types.BinaryOpNeq, arrow.PrimitiveTypes.Float64, &floatCompareFunction{cmp: func(a, b float64) bool { return a != b }})
+	binaryFunctions.register(types.BinaryOpNeq, arrow.FixedWidthTypes.Boolean, &genericFunction[*array.Boolean, bool]{eval: func(a, b bool) (bool, error) { return a != b, nil }})
+	binaryFunctions.register(types.BinaryOpNeq, arrow.BinaryTypes.String, &genericFunction[*array.String, string]{eval: func(a, b string) (bool, error) { return a != b, nil }})
+	binaryFunctions.register(types.BinaryOpNeq, arrow.PrimitiveTypes.Int64, &genericFunction[*array.Int64, int64]{eval: func(a, b int64) (bool, error) { return a != b, nil }})
+	binaryFunctions.register(types.BinaryOpNeq, arrow.FixedWidthTypes.Timestamp_ns, &genericFunction[*array.Timestamp, arrow.Timestamp]{eval: func(a, b arrow.Timestamp) (bool, error) { return a != b, nil }})
+	binaryFunctions.register(types.BinaryOpNeq, arrow.PrimitiveTypes.Float64, &genericFunction[*array.Float64, float64]{eval: func(a, b float64) (bool, error) { return a != b, nil }})
 	// Functions for [types.BinaryOpGt]
-	binaryFunctions.register(types.BinaryOpGt, arrow.FixedWidthTypes.Boolean, &boolCompareFunction{cmp: func(a, b bool) bool { return boolToInt(a) > boolToInt(b) }})
-	binaryFunctions.register(types.BinaryOpGt, arrow.BinaryTypes.String, &strCompareFunction{cmp: func(a, b string) bool { return a > b }})
-	binaryFunctions.register(types.BinaryOpGt, arrow.PrimitiveTypes.Int64, &intCompareFunction{cmp: func(a, b int64) bool { return a > b }})
-	binaryFunctions.register(types.BinaryOpGt, arrow.PrimitiveTypes.Uint64, &timestampCompareFunction{cmp: func(a, b uint64) bool { return a > b }})
-	binaryFunctions.register(types.BinaryOpGt, arrow.PrimitiveTypes.Float64, &floatCompareFunction{cmp: func(a, b float64) bool { return a > b }})
+	binaryFunctions.register(types.BinaryOpGt, arrow.FixedWidthTypes.Boolean, &genericFunction[*array.Boolean, bool]{eval: func(a, b bool) (bool, error) { return boolToInt(a) > boolToInt(b), nil }})
+	binaryFunctions.register(types.BinaryOpGt, arrow.BinaryTypes.String, &genericFunction[*array.String, string]{eval: func(a, b string) (bool, error) { return a > b, nil }})
+	binaryFunctions.register(types.BinaryOpGt, arrow.PrimitiveTypes.Int64, &genericFunction[*array.Int64, int64]{eval: func(a, b int64) (bool, error) { return a > b, nil }})
+	binaryFunctions.register(types.BinaryOpGt, arrow.FixedWidthTypes.Timestamp_ns, &genericFunction[*array.Timestamp, arrow.Timestamp]{eval: func(a, b arrow.Timestamp) (bool, error) { return a > b, nil }})
+	binaryFunctions.register(types.BinaryOpGt, arrow.PrimitiveTypes.Float64, &genericFunction[*array.Float64, float64]{eval: func(a, b float64) (bool, error) { return a > b, nil }})
 	// Functions for [types.BinaryOpGte]
-	binaryFunctions.register(types.BinaryOpGte, arrow.FixedWidthTypes.Boolean, &boolCompareFunction{cmp: func(a, b bool) bool { return boolToInt(a) >= boolToInt(b) }})
-	binaryFunctions.register(types.BinaryOpGte, arrow.BinaryTypes.String, &strCompareFunction{cmp: func(a, b string) bool { return a >= b }})
-	binaryFunctions.register(types.BinaryOpGte, arrow.PrimitiveTypes.Int64, &intCompareFunction{cmp: func(a, b int64) bool { return a >= b }})
-	binaryFunctions.register(types.BinaryOpGte, arrow.PrimitiveTypes.Uint64, &timestampCompareFunction{cmp: func(a, b uint64) bool { return a >= b }})
-	binaryFunctions.register(types.BinaryOpGte, arrow.PrimitiveTypes.Float64, &floatCompareFunction{cmp: func(a, b float64) bool { return a >= b }})
+	binaryFunctions.register(types.BinaryOpGte, arrow.FixedWidthTypes.Boolean, &genericFunction[*array.Boolean, bool]{eval: func(a, b bool) (bool, error) { return boolToInt(a) >= boolToInt(b), nil }})
+	binaryFunctions.register(types.BinaryOpGte, arrow.BinaryTypes.String, &genericFunction[*array.String, string]{eval: func(a, b string) (bool, error) { return a >= b, nil }})
+	binaryFunctions.register(types.BinaryOpGte, arrow.PrimitiveTypes.Int64, &genericFunction[*array.Int64, int64]{eval: func(a, b int64) (bool, error) { return a >= b, nil }})
+	binaryFunctions.register(types.BinaryOpGte, arrow.FixedWidthTypes.Timestamp_ns, &genericFunction[*array.Timestamp, arrow.Timestamp]{eval: func(a, b arrow.Timestamp) (bool, error) { return a >= b, nil }})
+	binaryFunctions.register(types.BinaryOpGte, arrow.PrimitiveTypes.Float64, &genericFunction[*array.Float64, float64]{eval: func(a, b float64) (bool, error) { return a >= b, nil }})
 	// Functions for [types.BinaryOpLt]
-	binaryFunctions.register(types.BinaryOpLt, arrow.FixedWidthTypes.Boolean, &boolCompareFunction{cmp: func(a, b bool) bool { return boolToInt(a) < boolToInt(b) }})
-	binaryFunctions.register(types.BinaryOpLt, arrow.BinaryTypes.String, &strCompareFunction{cmp: func(a, b string) bool { return a < b }})
-	binaryFunctions.register(types.BinaryOpLt, arrow.PrimitiveTypes.Int64, &intCompareFunction{cmp: func(a, b int64) bool { return a < b }})
-	binaryFunctions.register(types.BinaryOpLt, arrow.PrimitiveTypes.Uint64, &timestampCompareFunction{cmp: func(a, b uint64) bool { return a < b }})
-	binaryFunctions.register(types.BinaryOpLt, arrow.PrimitiveTypes.Float64, &floatCompareFunction{cmp: func(a, b float64) bool { return a < b }})
+	binaryFunctions.register(types.BinaryOpLt, arrow.FixedWidthTypes.Boolean, &genericFunction[*array.Boolean, bool]{eval: func(a, b bool) (bool, error) { return boolToInt(a) < boolToInt(b), nil }})
+	binaryFunctions.register(types.BinaryOpLt, arrow.BinaryTypes.String, &genericFunction[*array.String, string]{eval: func(a, b string) (bool, error) { return a < b, nil }})
+	binaryFunctions.register(types.BinaryOpLt, arrow.PrimitiveTypes.Int64, &genericFunction[*array.Int64, int64]{eval: func(a, b int64) (bool, error) { return a < b, nil }})
+	binaryFunctions.register(types.BinaryOpLt, arrow.FixedWidthTypes.Timestamp_ns, &genericFunction[*array.Timestamp, arrow.Timestamp]{eval: func(a, b arrow.Timestamp) (bool, error) { return a < b, nil }})
+	binaryFunctions.register(types.BinaryOpLt, arrow.PrimitiveTypes.Float64, &genericFunction[*array.Float64, float64]{eval: func(a, b float64) (bool, error) { return a < b, nil }})
 	// Functions for [types.BinaryOpLte]
-	binaryFunctions.register(types.BinaryOpLte, arrow.FixedWidthTypes.Boolean, &boolCompareFunction{cmp: func(a, b bool) bool { return boolToInt(a) <= boolToInt(b) }})
-	binaryFunctions.register(types.BinaryOpLte, arrow.BinaryTypes.String, &strCompareFunction{cmp: func(a, b string) bool { return a <= b }})
-	binaryFunctions.register(types.BinaryOpLte, arrow.PrimitiveTypes.Int64, &intCompareFunction{cmp: func(a, b int64) bool { return a <= b }})
-	binaryFunctions.register(types.BinaryOpLte, arrow.PrimitiveTypes.Uint64, &timestampCompareFunction{cmp: func(a, b uint64) bool { return a <= b }})
-	binaryFunctions.register(types.BinaryOpLte, arrow.PrimitiveTypes.Float64, &floatCompareFunction{cmp: func(a, b float64) bool { return a <= b }})
+	binaryFunctions.register(types.BinaryOpLte, arrow.FixedWidthTypes.Boolean, &genericFunction[*array.Boolean, bool]{eval: func(a, b bool) (bool, error) { return boolToInt(a) <= boolToInt(b), nil }})
+	binaryFunctions.register(types.BinaryOpLte, arrow.BinaryTypes.String, &genericFunction[*array.String, string]{eval: func(a, b string) (bool, error) { return a <= b, nil }})
+	binaryFunctions.register(types.BinaryOpLte, arrow.PrimitiveTypes.Int64, &genericFunction[*array.Int64, int64]{eval: func(a, b int64) (bool, error) { return a <= b, nil }})
+	binaryFunctions.register(types.BinaryOpLte, arrow.FixedWidthTypes.Timestamp_ns, &genericFunction[*array.Timestamp, arrow.Timestamp]{eval: func(a, b arrow.Timestamp) (bool, error) { return a <= b, nil }})
+	binaryFunctions.register(types.BinaryOpLte, arrow.PrimitiveTypes.Float64, &genericFunction[*array.Float64, float64]{eval: func(a, b float64) (bool, error) { return a <= b, nil }})
 	// Functions for [types.BinaryOpMatchSubstr]
-	binaryFunctions.register(types.BinaryOpMatchSubstr, arrow.BinaryTypes.String, &strCompareFunction{cmp: func(a, b string) bool { return strings.Contains(a, b) }})
+	binaryFunctions.register(types.BinaryOpMatchSubstr, arrow.BinaryTypes.String, &genericFunction[*array.String, string]{eval: func(a, b string) (bool, error) { return strings.Contains(a, b), nil }})
 	// Functions for [types.BinaryOpNotMatchSubstr]
-	binaryFunctions.register(types.BinaryOpNotMatchSubstr, arrow.BinaryTypes.String, &strCompareFunction{cmp: func(a, b string) bool { return !strings.Contains(a, b) }})
+	binaryFunctions.register(types.BinaryOpNotMatchSubstr, arrow.BinaryTypes.String, &genericFunction[*array.String, string]{eval: func(a, b string) (bool, error) { return !strings.Contains(a, b), nil }})
 	// Functions for [types.BinaryOpMatchRe]
 	// TODO(chaudum): Performance of regex evaluation can be improved if RHS is a Scalar,
 	// because the regexp would only need to compiled once for the given scalar value.
 	// TODO(chaudum): Performance of regex evaluation can be improved by simplifying the regex,
 	// see pkg/logql/log/filter.go:645
-	binaryFunctions.register(types.BinaryOpMatchRe, arrow.BinaryTypes.String, &strCompareFunction{cmp: func(a, b string) bool {
+	binaryFunctions.register(types.BinaryOpMatchRe, arrow.BinaryTypes.String, &genericFunction[*array.String, string]{eval: func(a, b string) (bool, error) {
 		reg, err := regexp.Compile(b)
-		if err != nil { // TODO(chaudum): Add support for returning error when comparison fails. For now, return false.
-			return false
+		if err != nil {
+			return false, err
 		}
-		return reg.Match([]byte(a))
+		return reg.Match([]byte(a)), nil
 	}})
 	// Functions for [types.BinaryOpNotMatchRe]
-	binaryFunctions.register(types.BinaryOpNotMatchRe, arrow.BinaryTypes.String, &strCompareFunction{cmp: func(a, b string) bool {
+	binaryFunctions.register(types.BinaryOpNotMatchRe, arrow.BinaryTypes.String, &genericFunction[*array.String, string]{eval: func(a, b string) (bool, error) {
 		reg, err := regexp.Compile(b)
-		if err != nil { // TODO(chaudum): Add support for returning error when comparison fails. For now, return false.
-			return false
+		if err != nil {
+			return false, err
 		}
-		return !reg.Match([]byte(a))
+		return !reg.Match([]byte(a)), nil
 	}})
 }
 
@@ -155,46 +155,34 @@ func (b *binaryFuncReg) GetForSignature(op types.BinaryOp, ltype arrow.DataType)
 	return fn, nil
 }
 
-type boolCompareFunction struct {
-	cmp func(a, b bool) bool
+// arrayType combines the IsNull function from the [arrow.Array] interface with the
+// type specific function Value from the concrete types, such as [array.String].
+type arrayType[T comparable] interface {
+	IsNull(int) bool
+	Value(int) T
+}
+
+// genericFunction is a struct that implements the [BinaryFunction] interface methods
+// and can be used for any array type with compareable elements.
+type genericFunction[E arrayType[T], T comparable] struct {
+	eval func(a, b T) (bool, error)
 }
 
 // Evaluate implements BinaryFunction.
-func (f *boolCompareFunction) Evaluate(lhs ColumnVector, rhs ColumnVector) (ColumnVector, error) {
-	lhsArr := lhs.ToArray().(*array.Boolean)
-	rhsArr := rhs.ToArray().(*array.Boolean)
-
-	if lhsArr.Len() != rhsArr.Len() {
-		return nil, errors.ErrIndex
-	}
-
-	mem := memory.NewGoAllocator()
-	builder := array.NewBooleanBuilder(mem)
-	defer builder.Release()
-
-	for i := 0; i < lhs.ToArray().Len(); i++ {
-		if lhsArr.IsNull(i) || rhsArr.IsNull(i) {
-			builder.Append(false)
-			continue
-		}
-		builder.Append(f.cmp(lhsArr.Value(i), rhsArr.Value(i)))
-	}
-
-	return &Array{array: builder.NewArray()}, nil
-}
-
-type strCompareFunction struct {
-	cmp func(a, b string) bool
-}
-
-// Evaluate implements BinaryFunction.
-func (f *strCompareFunction) Evaluate(lhs ColumnVector, rhs ColumnVector) (ColumnVector, error) {
+func (f *genericFunction[E, T]) Evaluate(lhs ColumnVector, rhs ColumnVector) (ColumnVector, error) {
 	if lhs.Len() != rhs.Len() {
 		return nil, arrow.ErrIndex
 	}
 
-	lhsArr := lhs.ToArray().(*array.String)
-	rhsArr := rhs.ToArray().(*array.String)
+	lhsArr, ok := lhs.ToArray().(E)
+	if !ok {
+		return nil, arrow.ErrType
+	}
+
+	rhsArr, ok := rhs.ToArray().(E)
+	if !ok {
+		return nil, arrow.ErrType
+	}
 
 	mem := memory.NewGoAllocator()
 	builder := array.NewBooleanBuilder(mem)
@@ -205,91 +193,11 @@ func (f *strCompareFunction) Evaluate(lhs ColumnVector, rhs ColumnVector) (Colum
 			builder.Append(false)
 			continue
 		}
-		builder.Append(f.cmp(lhsArr.Value(i), rhsArr.Value(i)))
-	}
-
-	return &Array{array: builder.NewArray()}, nil
-}
-
-type intCompareFunction struct {
-	cmp func(a, b int64) bool
-}
-
-// Evaluate implements BinaryFunction.
-func (f *intCompareFunction) Evaluate(lhs ColumnVector, rhs ColumnVector) (ColumnVector, error) {
-	if lhs.Len() != rhs.Len() {
-		return nil, arrow.ErrIndex
-	}
-
-	lhsArr := lhs.ToArray().(*array.Int64)
-	rhsArr := rhs.ToArray().(*array.Int64)
-
-	mem := memory.NewGoAllocator()
-	builder := array.NewBooleanBuilder(mem)
-	defer builder.Release()
-
-	for i := 0; i < lhs.ToArray().Len(); i++ {
-		if lhsArr.IsNull(i) || rhsArr.IsNull(i) {
-			builder.Append(false)
-			continue
+		res, err := f.eval(lhsArr.Value(i), rhsArr.Value(i))
+		if err != nil {
+			return nil, err
 		}
-		builder.Append(f.cmp(lhsArr.Value(i), rhsArr.Value(i)))
-	}
-
-	return &Array{array: builder.NewArray()}, nil
-}
-
-type timestampCompareFunction struct {
-	cmp func(a, b uint64) bool
-}
-
-// Evaluate implements BinaryFunction.
-func (f *timestampCompareFunction) Evaluate(lhs ColumnVector, rhs ColumnVector) (ColumnVector, error) {
-	if lhs.Len() != rhs.Len() {
-		return nil, arrow.ErrIndex
-	}
-
-	lhsArr := lhs.ToArray().(*array.Uint64)
-	rhsArr := rhs.ToArray().(*array.Uint64)
-
-	mem := memory.NewGoAllocator()
-	builder := array.NewBooleanBuilder(mem)
-	defer builder.Release()
-
-	for i := 0; i < lhs.ToArray().Len(); i++ {
-		if lhsArr.IsNull(i) || rhsArr.IsNull(i) {
-			builder.Append(false)
-			continue
-		}
-		builder.Append(f.cmp(lhsArr.Value(i), rhsArr.Value(i)))
-	}
-
-	return &Array{array: builder.NewArray()}, nil
-}
-
-type floatCompareFunction struct {
-	cmp func(a, b float64) bool
-}
-
-// Evaluate implements BinaryFunction.
-func (f *floatCompareFunction) Evaluate(lhs ColumnVector, rhs ColumnVector) (ColumnVector, error) {
-	if lhs.Len() != rhs.Len() {
-		return nil, arrow.ErrIndex
-	}
-
-	lhsArr := lhs.ToArray().(*array.Float64)
-	rhsArr := rhs.ToArray().(*array.Float64)
-
-	mem := memory.NewGoAllocator()
-	builder := array.NewBooleanBuilder(mem)
-	defer builder.Release()
-
-	for i := 0; i < lhs.ToArray().Len(); i++ {
-		if lhsArr.IsNull(i) || rhsArr.IsNull(i) {
-			builder.Append(false)
-			continue
-		}
-		builder.Append(f.cmp(lhsArr.Value(i), rhsArr.Value(i)))
+		builder.Append(res)
 	}
 
 	return &Array{array: builder.NewArray()}, nil
@@ -305,5 +213,4 @@ func boolToInt(b bool) int {
 		i = 0
 	}
 	return i
-
 }

--- a/pkg/engine/executor/functions_test.go
+++ b/pkg/engine/executor/functions_test.go
@@ -1,0 +1,836 @@
+package executor
+
+import (
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/engine/internal/datatype"
+	"github.com/grafana/loki/v3/pkg/engine/internal/types"
+)
+
+// Helper function to create a boolean array
+func createBoolArray(mem memory.Allocator, values []bool, nulls []bool) *Array {
+	builder := array.NewBooleanBuilder(mem)
+	defer builder.Release()
+
+	for i, val := range values {
+		if nulls != nil && i < len(nulls) && nulls[i] {
+			builder.AppendNull()
+		} else {
+			builder.Append(val)
+		}
+	}
+
+	return &Array{
+		array: builder.NewArray(),
+		dt:    datatype.Loki.Bool,
+		ct:    types.ColumnTypeBuiltin,
+		rows:  int64(len(values)),
+	}
+}
+
+// Helper function to create a string array
+func createStringArray(mem memory.Allocator, values []string, nulls []bool) *Array {
+	builder := array.NewStringBuilder(mem)
+	defer builder.Release()
+
+	for i, val := range values {
+		if nulls != nil && i < len(nulls) && nulls[i] {
+			builder.AppendNull()
+		} else {
+			builder.Append(val)
+		}
+	}
+
+	return &Array{
+		array: builder.NewArray(),
+		dt:    datatype.Loki.String,
+		ct:    types.ColumnTypeBuiltin,
+		rows:  int64(len(values)),
+	}
+}
+
+// Helper function to create an int64 array
+func createInt64Array(mem memory.Allocator, values []int64, nulls []bool) *Array {
+	builder := array.NewInt64Builder(mem)
+	defer builder.Release()
+
+	for i, val := range values {
+		if nulls != nil && i < len(nulls) && nulls[i] {
+			builder.AppendNull()
+		} else {
+			builder.Append(val)
+		}
+	}
+
+	return &Array{
+		array: builder.NewArray(),
+		dt:    datatype.Loki.Integer,
+		ct:    types.ColumnTypeBuiltin,
+		rows:  int64(len(values)),
+	}
+}
+
+// Helper function to create a uint64 array
+func createUint64Array(mem memory.Allocator, values []uint64, nulls []bool) *Array {
+	builder := array.NewUint64Builder(mem)
+	defer builder.Release()
+
+	for i, val := range values {
+		if nulls != nil && i < len(nulls) && nulls[i] {
+			builder.AppendNull()
+		} else {
+			builder.Append(val)
+		}
+	}
+
+	return &Array{
+		array: builder.NewArray(),
+		dt:    datatype.Loki.Timestamp,
+		ct:    types.ColumnTypeBuiltin, // Uint64 is typically used for timestamps
+		rows:  int64(len(values)),
+	}
+}
+
+// Helper function to create a float64 array
+func createFloat64Array(mem memory.Allocator, values []float64, nulls []bool) *Array {
+	builder := array.NewFloat64Builder(mem)
+	defer builder.Release()
+
+	for i, val := range values {
+		if nulls != nil && i < len(nulls) && nulls[i] {
+			builder.AppendNull()
+		} else {
+			builder.Append(val)
+		}
+	}
+
+	return &Array{
+		array: builder.NewArray(),
+		dt:    datatype.Loki.Float,
+		ct:    types.ColumnTypeBuiltin,
+		rows:  int64(len(values)),
+	}
+}
+
+// Helper function to extract boolean values from result
+func extractBoolValues(result ColumnVector) []bool {
+	arr := result.ToArray().(*array.Boolean)
+	values := make([]bool, arr.Len())
+	for i := 0; i < arr.Len(); i++ {
+		if arr.IsNull(i) {
+			values[i] = false
+		} else {
+			values[i] = arr.Value(i)
+		}
+	}
+	return values
+}
+
+func TestBinaryFunctionRegistry_GetForSignature(t *testing.T) {
+	tests := []struct {
+		name        string
+		op          types.BinaryOp
+		dataType    arrow.DataType
+		expectError bool
+	}{
+		{
+			name:        "valid equality operation for boolean",
+			op:          types.BinaryOpEq,
+			dataType:    arrow.FixedWidthTypes.Boolean,
+			expectError: false,
+		},
+		{
+			name:        "valid equality operation for string",
+			op:          types.BinaryOpEq,
+			dataType:    arrow.BinaryTypes.String,
+			expectError: false,
+		},
+		{
+			name:        "valid equality operation for int64",
+			op:          types.BinaryOpEq,
+			dataType:    arrow.PrimitiveTypes.Int64,
+			expectError: false,
+		},
+		{
+			name:        "valid equality operation for uint64",
+			op:          types.BinaryOpEq,
+			dataType:    arrow.PrimitiveTypes.Uint64,
+			expectError: false,
+		},
+		{
+			name:        "valid equality operation for float64",
+			op:          types.BinaryOpEq,
+			dataType:    arrow.PrimitiveTypes.Float64,
+			expectError: false,
+		},
+		{
+			name:        "valid string contains operation",
+			op:          types.BinaryOpMatchSubstr,
+			dataType:    arrow.BinaryTypes.String,
+			expectError: false,
+		},
+		{
+			name:        "valid regex match operation",
+			op:          types.BinaryOpMatchRe,
+			dataType:    arrow.BinaryTypes.String,
+			expectError: false,
+		},
+		{
+			name:        "invalid operation",
+			op:          types.BinaryOpAdd, // Not registered
+			dataType:    arrow.PrimitiveTypes.Int64,
+			expectError: true,
+		},
+		{
+			name:        "invalid data type for operation",
+			op:          types.BinaryOpEq,
+			dataType:    arrow.PrimitiveTypes.Int32, // Not registered
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fn, err := binaryFunctions.GetForSignature(tt.op, tt.dataType)
+
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Nil(t, fn)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, fn)
+			}
+		})
+	}
+}
+
+func TestBooleanComparisonFunctions(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	tests := []struct {
+		name     string
+		op       types.BinaryOp
+		lhs      []bool
+		rhs      []bool
+		expected []bool
+	}{
+		{
+			name:     "boolean equality",
+			op:       types.BinaryOpEq,
+			lhs:      []bool{true, false, true, false},
+			rhs:      []bool{true, false, false, true},
+			expected: []bool{true, true, false, false},
+		},
+		{
+			name:     "boolean inequality",
+			op:       types.BinaryOpNeq,
+			lhs:      []bool{true, false, true, false},
+			rhs:      []bool{true, false, false, true},
+			expected: []bool{false, false, true, true},
+		},
+		{
+			name:     "boolean greater than",
+			op:       types.BinaryOpGt,
+			lhs:      []bool{true, false, true, false},
+			rhs:      []bool{false, true, true, false},
+			expected: []bool{true, false, false, false},
+		},
+		{
+			name:     "boolean greater than or equal",
+			op:       types.BinaryOpGte,
+			lhs:      []bool{true, false, true, false},
+			rhs:      []bool{false, true, true, false},
+			expected: []bool{true, false, true, true},
+		},
+		{
+			name:     "boolean less than",
+			op:       types.BinaryOpLt,
+			lhs:      []bool{true, false, true, false},
+			rhs:      []bool{false, true, true, false},
+			expected: []bool{false, true, false, false},
+		},
+		{
+			name:     "boolean less than or equal",
+			op:       types.BinaryOpLte,
+			lhs:      []bool{true, false, true, false},
+			rhs:      []bool{false, true, true, false},
+			expected: []bool{false, true, true, true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lhsArray := createBoolArray(mem, tt.lhs, nil)
+			rhsArray := createBoolArray(mem, tt.rhs, nil)
+			defer lhsArray.array.Release()
+			defer rhsArray.array.Release()
+
+			fn, err := binaryFunctions.GetForSignature(tt.op, arrow.FixedWidthTypes.Boolean)
+			require.NoError(t, err)
+
+			result, err := fn.Evaluate(lhsArray, rhsArray)
+			require.NoError(t, err)
+
+			actual := extractBoolValues(result)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestStringComparisonFunctions(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	tests := []struct {
+		name     string
+		op       types.BinaryOp
+		lhs      []string
+		rhs      []string
+		expected []bool
+	}{
+		{
+			name:     "string equality",
+			op:       types.BinaryOpEq,
+			lhs:      []string{"hello", "world", "test", ""},
+			rhs:      []string{"hello", "world", "different", ""},
+			expected: []bool{true, true, false, true},
+		},
+		{
+			name:     "string inequality",
+			op:       types.BinaryOpNeq,
+			lhs:      []string{"hello", "world", "test", ""},
+			rhs:      []string{"hello", "world", "different", ""},
+			expected: []bool{false, false, true, false},
+		},
+		{
+			name:     "string greater than",
+			op:       types.BinaryOpGt,
+			lhs:      []string{"b", "a", "z", "hello"},
+			rhs:      []string{"a", "b", "a", "world"},
+			expected: []bool{true, false, true, false},
+		},
+		{
+			name:     "string greater than or equal",
+			op:       types.BinaryOpGte,
+			lhs:      []string{"b", "a", "z", "hello"},
+			rhs:      []string{"a", "a", "a", "hello"},
+			expected: []bool{true, true, true, true},
+		},
+		{
+			name:     "string less than",
+			op:       types.BinaryOpLt,
+			lhs:      []string{"a", "b", "a", "world"},
+			rhs:      []string{"b", "a", "z", "hello"},
+			expected: []bool{true, false, true, false},
+		},
+		{
+			name:     "string less than or equal",
+			op:       types.BinaryOpLte,
+			lhs:      []string{"a", "a", "a", "hello"},
+			rhs:      []string{"b", "a", "z", "hello"},
+			expected: []bool{true, true, true, true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lhsArray := createStringArray(mem, tt.lhs, nil)
+			rhsArray := createStringArray(mem, tt.rhs, nil)
+			defer lhsArray.array.Release()
+			defer rhsArray.array.Release()
+
+			fn, err := binaryFunctions.GetForSignature(tt.op, arrow.BinaryTypes.String)
+			require.NoError(t, err)
+
+			result, err := fn.Evaluate(lhsArray, rhsArray)
+			require.NoError(t, err)
+
+			actual := extractBoolValues(result)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestIntegerComparisonFunctions(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	tests := []struct {
+		name     string
+		op       types.BinaryOp
+		lhs      []int64
+		rhs      []int64
+		expected []bool
+	}{
+		{
+			name:     "int64 equality",
+			op:       types.BinaryOpEq,
+			lhs:      []int64{1, 2, 3, 0, -1},
+			rhs:      []int64{1, 3, 3, 0, 1},
+			expected: []bool{true, false, true, true, false},
+		},
+		{
+			name:     "int64 inequality",
+			op:       types.BinaryOpNeq,
+			lhs:      []int64{1, 2, 3, 0, -1},
+			rhs:      []int64{1, 3, 3, 0, 1},
+			expected: []bool{false, true, false, false, true},
+		},
+		{
+			name:     "int64 greater than",
+			op:       types.BinaryOpGt,
+			lhs:      []int64{2, 1, 3, 0, -1},
+			rhs:      []int64{1, 2, 3, 0, -2},
+			expected: []bool{true, false, false, false, true},
+		},
+		{
+			name:     "int64 greater than or equal",
+			op:       types.BinaryOpGte,
+			lhs:      []int64{2, 1, 3, 0, -1},
+			rhs:      []int64{1, 1, 3, 0, -1},
+			expected: []bool{true, true, true, true, true},
+		},
+		{
+			name:     "int64 less than",
+			op:       types.BinaryOpLt,
+			lhs:      []int64{1, 2, 3, 0, -2},
+			rhs:      []int64{2, 1, 3, 0, -1},
+			expected: []bool{true, false, false, false, true},
+		},
+		{
+			name:     "int64 less than or equal",
+			op:       types.BinaryOpLte,
+			lhs:      []int64{1, 1, 3, 0, -1},
+			rhs:      []int64{2, 1, 3, 0, -1},
+			expected: []bool{true, true, true, true, true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lhsArray := createInt64Array(mem, tt.lhs, nil)
+			rhsArray := createInt64Array(mem, tt.rhs, nil)
+			defer lhsArray.array.Release()
+			defer rhsArray.array.Release()
+
+			fn, err := binaryFunctions.GetForSignature(tt.op, arrow.PrimitiveTypes.Int64)
+			require.NoError(t, err)
+
+			result, err := fn.Evaluate(lhsArray, rhsArray)
+			require.NoError(t, err)
+
+			actual := extractBoolValues(result)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestUint64ComparisonFunctions(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	tests := []struct {
+		name     string
+		op       types.BinaryOp
+		lhs      []uint64
+		rhs      []uint64
+		expected []bool
+	}{
+		{
+			name:     "uint64 equality",
+			op:       types.BinaryOpEq,
+			lhs:      []uint64{1, 2, 3, 0, 100},
+			rhs:      []uint64{1, 3, 3, 0, 50},
+			expected: []bool{true, false, true, true, false},
+		},
+		{
+			name:     "uint64 inequality",
+			op:       types.BinaryOpNeq,
+			lhs:      []uint64{1, 2, 3, 0, 100},
+			rhs:      []uint64{1, 3, 3, 0, 50},
+			expected: []bool{false, true, false, false, true},
+		},
+		{
+			name:     "uint64 greater than",
+			op:       types.BinaryOpGt,
+			lhs:      []uint64{2, 1, 3, 0, 100},
+			rhs:      []uint64{1, 2, 3, 0, 50},
+			expected: []bool{true, false, false, false, true},
+		},
+		{
+			name:     "uint64 greater than or equal",
+			op:       types.BinaryOpGte,
+			lhs:      []uint64{2, 1, 3, 0, 100},
+			rhs:      []uint64{1, 1, 3, 0, 100},
+			expected: []bool{true, true, true, true, true},
+		},
+		{
+			name:     "uint64 less than",
+			op:       types.BinaryOpLt,
+			lhs:      []uint64{1, 2, 3, 0, 50},
+			rhs:      []uint64{2, 1, 3, 0, 100},
+			expected: []bool{true, false, false, false, true},
+		},
+		{
+			name:     "uint64 less than or equal",
+			op:       types.BinaryOpLte,
+			lhs:      []uint64{1, 1, 3, 0, 100},
+			rhs:      []uint64{2, 1, 3, 0, 100},
+			expected: []bool{true, true, true, true, true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lhsArray := createUint64Array(mem, tt.lhs, nil)
+			rhsArray := createUint64Array(mem, tt.rhs, nil)
+			defer lhsArray.array.Release()
+			defer rhsArray.array.Release()
+
+			fn, err := binaryFunctions.GetForSignature(tt.op, arrow.PrimitiveTypes.Uint64)
+			require.NoError(t, err)
+
+			result, err := fn.Evaluate(lhsArray, rhsArray)
+			require.NoError(t, err)
+
+			actual := extractBoolValues(result)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestFloat64ComparisonFunctions(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	tests := []struct {
+		name     string
+		op       types.BinaryOp
+		lhs      []float64
+		rhs      []float64
+		expected []bool
+	}{
+		{
+			name:     "float64 equality",
+			op:       types.BinaryOpEq,
+			lhs:      []float64{1.0, 2.5, 3.14, 0.0, -1.5},
+			rhs:      []float64{1.0, 2.6, 3.14, 0.0, 1.5},
+			expected: []bool{true, false, true, true, false},
+		},
+		{
+			name:     "float64 inequality",
+			op:       types.BinaryOpNeq,
+			lhs:      []float64{1.0, 2.5, 3.14, 0.0, -1.5},
+			rhs:      []float64{1.0, 2.6, 3.14, 0.0, 1.5},
+			expected: []bool{false, true, false, false, true},
+		},
+		{
+			name:     "float64 greater than",
+			op:       types.BinaryOpGt,
+			lhs:      []float64{2.0, 1.5, 3.14, 0.0, -1.0},
+			rhs:      []float64{1.0, 2.0, 3.14, 0.0, -2.0},
+			expected: []bool{true, false, false, false, true},
+		},
+		{
+			name:     "float64 greater than or equal",
+			op:       types.BinaryOpGte,
+			lhs:      []float64{2.0, 1.5, 3.14, 0.0, -1.0},
+			rhs:      []float64{1.0, 1.5, 3.14, 0.0, -1.0},
+			expected: []bool{true, true, true, true, true},
+		},
+		{
+			name:     "float64 less than",
+			op:       types.BinaryOpLt,
+			lhs:      []float64{1.0, 2.0, 3.14, 0.0, -2.0},
+			rhs:      []float64{2.0, 1.5, 3.14, 0.0, -1.0},
+			expected: []bool{true, false, false, false, true},
+		},
+		{
+			name:     "float64 less than or equal",
+			op:       types.BinaryOpLte,
+			lhs:      []float64{1.0, 1.5, 3.14, 0.0, -1.0},
+			rhs:      []float64{2.0, 1.5, 3.14, 0.0, -1.0},
+			expected: []bool{true, true, true, true, true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lhsArray := createFloat64Array(mem, tt.lhs, nil)
+			rhsArray := createFloat64Array(mem, tt.rhs, nil)
+			defer lhsArray.array.Release()
+			defer rhsArray.array.Release()
+
+			fn, err := binaryFunctions.GetForSignature(tt.op, arrow.PrimitiveTypes.Float64)
+			require.NoError(t, err)
+
+			result, err := fn.Evaluate(lhsArray, rhsArray)
+			require.NoError(t, err)
+
+			actual := extractBoolValues(result)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestStringMatchingFunctions(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	tests := []struct {
+		name     string
+		op       types.BinaryOp
+		lhs      []string
+		rhs      []string
+		expected []bool
+	}{
+		{
+			name:     "string contains",
+			op:       types.BinaryOpMatchSubstr,
+			lhs:      []string{"hello world", "test string", "foobar", ""},
+			rhs:      []string{"world", "test", "baz", ""},
+			expected: []bool{true, true, false, true},
+		},
+		{
+			name:     "string does not contain",
+			op:       types.BinaryOpNotMatchSubstr,
+			lhs:      []string{"hello world", "test string", "foobar", ""},
+			rhs:      []string{"world", "test", "baz", ""},
+			expected: []bool{false, false, true, false},
+		},
+		{
+			name:     "regex match",
+			op:       types.BinaryOpMatchRe,
+			lhs:      []string{"hello123", "test456", "abc", ""},
+			rhs:      []string{"^hello\\d+$", "^\\d+", "^[a-z]+$", ".+"},
+			expected: []bool{true, false, true, false},
+		},
+		{
+			name:     "regex not match",
+			op:       types.BinaryOpNotMatchRe,
+			lhs:      []string{"hello123", "test456", "abc", ""},
+			rhs:      []string{"^hello\\d+$", "^\\d+", "^[a-z]+$", ".+"},
+			expected: []bool{false, true, false, true},
+		},
+		{
+			name:     "case sensitive substring matching",
+			op:       types.BinaryOpMatchSubstr,
+			lhs:      []string{"Hello World", "TEST", "CaseSensitive"},
+			rhs:      []string{"hello", "test", "Case"},
+			expected: []bool{false, false, true},
+		},
+		{
+			name:     "special characters in contains",
+			op:       types.BinaryOpMatchSubstr,
+			lhs:      []string{"hello@world.com", "test[123]", "foo.bar", ""},
+			rhs:      []string{"@world", "[123]", ".", ""},
+			expected: []bool{true, true, true, true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lhsArray := createStringArray(mem, tt.lhs, nil)
+			rhsArray := createStringArray(mem, tt.rhs, nil)
+			defer lhsArray.array.Release()
+			defer rhsArray.array.Release()
+
+			fn, err := binaryFunctions.GetForSignature(tt.op, arrow.BinaryTypes.String)
+			require.NoError(t, err)
+
+			result, err := fn.Evaluate(lhsArray, rhsArray)
+			require.NoError(t, err)
+
+			actual := extractBoolValues(result)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestNullValueHandling(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	tests := []struct {
+		name     string
+		op       types.BinaryOp
+		dataType arrow.DataType
+		setup    func() (ColumnVector, ColumnVector)
+		expected []bool
+	}{
+		{
+			name:     "boolean with nulls",
+			op:       types.BinaryOpEq,
+			dataType: arrow.FixedWidthTypes.Boolean,
+			setup: func() (ColumnVector, ColumnVector) {
+				lhs := createBoolArray(mem, []bool{true, false, true}, []bool{false, true, false})
+				rhs := createBoolArray(mem, []bool{true, false, false}, []bool{true, false, false})
+				return lhs, rhs
+			},
+			expected: []bool{false, false, false}, // nulls should result in false
+		},
+		{
+			name:     "string with nulls",
+			op:       types.BinaryOpEq,
+			dataType: arrow.BinaryTypes.String,
+			setup: func() (ColumnVector, ColumnVector) {
+				lhs := createStringArray(mem, []string{"hello", "world", "test"}, []bool{false, true, false})
+				rhs := createStringArray(mem, []string{"hello", "world", "different"}, []bool{true, false, false})
+				return lhs, rhs
+			},
+			expected: []bool{false, false, false}, // nulls should result in false
+		},
+		{
+			name:     "int64 with nulls",
+			op:       types.BinaryOpGt,
+			dataType: arrow.PrimitiveTypes.Int64,
+			setup: func() (ColumnVector, ColumnVector) {
+				lhs := createInt64Array(mem, []int64{5, 10, 15}, []bool{false, true, false})
+				rhs := createInt64Array(mem, []int64{3, 8, 20}, []bool{true, false, false})
+				return lhs, rhs
+			},
+			expected: []bool{false, false, false}, // nulls should result in false
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lhs, rhs := tt.setup()
+
+			fn, err := binaryFunctions.GetForSignature(tt.op, tt.dataType)
+			require.NoError(t, err)
+
+			result, err := fn.Evaluate(lhs, rhs)
+			require.NoError(t, err)
+
+			actual := extractBoolValues(result)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestArrayLengthMismatch(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	tests := []struct {
+		name     string
+		op       types.BinaryOp
+		dataType arrow.DataType
+		setup    func() (ColumnVector, ColumnVector)
+	}{
+		{
+			name:     "boolean length mismatch",
+			op:       types.BinaryOpEq,
+			dataType: arrow.FixedWidthTypes.Boolean,
+			setup: func() (ColumnVector, ColumnVector) {
+				lhs := createBoolArray(mem, []bool{true, false}, nil)
+				rhs := createBoolArray(mem, []bool{true, false, true}, nil)
+				return lhs, rhs
+			},
+		},
+		{
+			name:     "string length mismatch",
+			op:       types.BinaryOpEq,
+			dataType: arrow.BinaryTypes.String,
+			setup: func() (ColumnVector, ColumnVector) {
+				lhs := createStringArray(mem, []string{"hello"}, nil)
+				rhs := createStringArray(mem, []string{"hello", "world"}, nil)
+				return lhs, rhs
+			},
+		},
+		{
+			name:     "int64 length mismatch",
+			op:       types.BinaryOpGt,
+			dataType: arrow.PrimitiveTypes.Int64,
+			setup: func() (ColumnVector, ColumnVector) {
+				lhs := createInt64Array(mem, []int64{1, 2, 3}, nil)
+				rhs := createInt64Array(mem, []int64{1, 2}, nil)
+				return lhs, rhs
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lhs, rhs := tt.setup()
+
+			fn, err := binaryFunctions.GetForSignature(tt.op, tt.dataType)
+			require.NoError(t, err)
+
+			result, err := fn.Evaluate(lhs, rhs)
+			assert.Error(t, err)
+			assert.Nil(t, result)
+		})
+	}
+}
+
+func TestRegexCompileError(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	// Test with invalid regex patterns
+	lhs := createStringArray(mem, []string{"hello", "world"}, nil)
+	rhs := createStringArray(mem, []string{"[", "("}, nil) // Invalid regex patterns
+
+	fn, err := binaryFunctions.GetForSignature(types.BinaryOpMatchRe, arrow.BinaryTypes.String)
+	require.NoError(t, err)
+
+	result, err := fn.Evaluate(lhs, rhs)
+	require.NoError(t, err)
+
+	// Invalid regex should return false
+	actual := extractBoolValues(result)
+	expected := []bool{false, false}
+	assert.Equal(t, expected, actual)
+}
+
+func TestBoolToIntConversion(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    bool
+		expected int
+	}{
+		{
+			name:     "true converts to 1",
+			input:    true,
+			expected: 1,
+		},
+		{
+			name:     "false converts to 0",
+			input:    false,
+			expected: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := boolToInt(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestEmptyArrays(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	// Test with empty arrays
+	lhs := createStringArray(mem, []string{}, nil)
+	rhs := createStringArray(mem, []string{}, nil)
+
+	fn, err := binaryFunctions.GetForSignature(types.BinaryOpEq, arrow.BinaryTypes.String)
+	require.NoError(t, err)
+
+	result, err := fn.Evaluate(lhs, rhs)
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(0), result.Len())
+}


### PR DESCRIPTION
### Summary

Filters predicates on ambiguous columns (basically any label filter expression) cannot be pushed down to the DataObjScan and need to be evaluated in the Filter node.

This PR adds the evaluation functions for `MATCH_RE(string,string)` and `MATCH_SUBSTR(string, string)` and their negating equivalent.

Under the hood, the PR also replaces the type specific comparison function implementations with a generic one, which now also handle arrow.Timestamp arrays correctly.

### Note for the reviewers

These two changes can be reviewed in the individual commits.