### PR TITLE
chore(engine): Minor logging cleanup in new query engine

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -2,7 +2,6 @@ package engine
 
 import (
 	"context"
-	"encoding/base64"
 	"fmt"
 	"strings"
 	"time"
@@ -89,7 +88,7 @@ func (e *QueryEngine) Execute(ctx context.Context, params logql.Params) (logqlmo
 
 	level.Info(logger).Log(
 		"msg", "finished logical planning",
-		"plan", base64.StdEncoding.EncodeToString([]byte(logicalPlan.String())),
+		"plan", logicalPlan.String(),
 		"duration", durLogicalPlanning.Seconds(),
 	)
 
@@ -118,7 +117,7 @@ func (e *QueryEngine) Execute(ctx context.Context, params logql.Params) (logqlmo
 
 	level.Info(logger).Log(
 		"msg", "finished physical planning",
-		"plan", base64.StdEncoding.EncodeToString([]byte(physical.PrintAsTree(plan))),
+		"plan", physical.PrintAsTree(plan),
 		"duration", durLogicalPlanning.Seconds(),
 	)
 

--- a/pkg/engine/planner/physical/printer.go
+++ b/pkg/engine/planner/physical/printer.go
@@ -32,7 +32,7 @@ func toTreeNode(n Node) *tree.Node {
 		treeNode.Properties = []tree.Property{
 			tree.NewProperty("location", false, node.Location),
 			tree.NewProperty("streams", false, len(node.StreamIDs)),
-			tree.NewProperty("section_id", true, node.Section),
+			tree.NewProperty("section_id", false, node.Section),
 			tree.NewProperty("projections", true, toAnySlice(node.Projections)...),
 			tree.NewProperty("direction", false, node.Direction),
 			tree.NewProperty("limit", false, node.Limit),

--- a/pkg/engine/planner/physical/printer.go
+++ b/pkg/engine/planner/physical/printer.go
@@ -31,7 +31,7 @@ func toTreeNode(n Node) *tree.Node {
 	case *DataObjScan:
 		treeNode.Properties = []tree.Property{
 			tree.NewProperty("location", false, node.Location),
-			tree.NewProperty("stream_ids", true, toAnySlice(node.StreamIDs)...),
+			tree.NewProperty("streams", false, len(node.StreamIDs)),
 			tree.NewProperty("section_id", true, node.Section),
 			tree.NewProperty("projections", true, toAnySlice(node.Projections)...),
 			tree.NewProperty("direction", false, node.Direction),


### PR DESCRIPTION
### Summary

The change makes the logical and physical plans easier to read when they are logged. The physical decreases massively in size when not logging individual stream IDs (which are hardly relevant).