### PR TITLE
chore: Remove `slicelabels` build tag from Makefiles

### DIFF
--- a/pkg/logql/bench/Makefile
+++ b/pkg/logql/bench/Makefile
@@ -6,20 +6,20 @@ TENANT ?= test-tenant
 
 generate:
 	@echo "Generating benchmark data..."
-	@go run -tags slicelabels ./cmd/generate/main.go -size $(SIZE) -tenant $(TENANT)
+	@go run ./cmd/generate/main.go -size $(SIZE) -tenant $(TENANT)
 
 bench:
 	@echo "Running all benchmarks..."
-	@go test -tags slicelabels -bench=. -benchmem -count=1 -timeout=1h
+	@go test -bench=. -benchmem -count=1 -timeout=1h
 
 list:
-	@go run -tags slicelabels ./cmd/bench/main.go list
+	@go run ./cmd/bench/main.go list
 
 run:
-	@go run -tags slicelabels ./cmd/bench/main.go run
+	@go run ./cmd/bench/main.go run
 
 run-debug:
-	@DEBUG=1 go run -tags slicelabels ./cmd/bench/main.go run
+	@DEBUG=1 go run ./cmd/bench/main.go run
 
 stream:
-	@go run -tags slicelabels ./cmd/stream/main.go | less
+	@go run ./cmd/stream/main.go | less


### PR DESCRIPTION
### Summary

Since the codebase now consistently uses the new stringlabels API after merging https://github.com/grafana/loki/pull/18490 the build tags in the Makefile can safely be removed again.
