### PR TITLE
fix: ensure we do not add duplicate structured metadata from stream labels and extracted map

### DIFF
--- a/clients/pkg/logentry/stages/labels.go
+++ b/clients/pkg/logentry/stages/labels.go
@@ -63,16 +63,17 @@ type labelStage struct {
 
 // Process implements Stage
 func (l *labelStage) Process(labels model.LabelSet, extracted map[string]interface{}, _ *time.Time, _ *string) {
-	processLabelsConfigs(l.logger, extracted, l.cfgs, func(labelName model.LabelName, labelValue model.LabelValue) {
+	processLabelsConfigs(l.logger, extracted, l.cfgs, func(_, labelName model.LabelName, labelValue model.LabelValue) {
 		labels[labelName] = labelValue
 	})
 }
 
-type labelsConsumer func(labelName model.LabelName, labelValue model.LabelValue)
+type labelsConsumer func(source, labelName model.LabelName, labelValue model.LabelValue)
 
 func processLabelsConfigs(logger log.Logger, extracted map[string]interface{}, configs LabelsConfig, consumer labelsConsumer) {
 	for lName, lSrc := range configs {
-		if lValue, ok := extracted[*lSrc]; ok {
+		source := *lSrc
+		if lValue, ok := extracted[source]; ok {
 			s, err := getString(lValue)
 			if err != nil {
 				if Debug {
@@ -87,7 +88,7 @@ func processLabelsConfigs(logger log.Logger, extracted map[string]interface{}, c
 				}
 				continue
 			}
-			consumer(model.LabelName(lName), labelValue)
+			consumer(model.LabelName(source), model.LabelName(lName), labelValue)
 		}
 	}
 }

--- a/clients/pkg/logentry/stages/structuredmetadata.go
+++ b/clients/pkg/logentry/stages/structuredmetadata.go
@@ -40,29 +40,31 @@ func (*structuredMetadataStage) Cleanup() {
 
 func (s *structuredMetadataStage) Run(in chan Entry) chan Entry {
 	return RunWith(in, func(e Entry) Entry {
-		processLabelsConfigs(s.logger, e.Extracted, s.cfgs, func(labelName model.LabelName, labelValue model.LabelValue) {
+		structuredMetadata := make(map[model.LabelName]model.LabelValue)
+
+		processLabelsConfigs(s.logger, e.Extracted, s.cfgs, func(source, labelName model.LabelName, labelValue model.LabelValue) {
 			e.StructuredMetadata = append(e.StructuredMetadata, logproto.LabelAdapter{Name: string(labelName), Value: string(labelValue)})
+			structuredMetadata[source] = labelValue
 		})
-		return s.extractFromLabels(e)
-	})
-}
 
-func (s *structuredMetadataStage) extractFromLabels(e Entry) Entry {
-	labels := e.Labels
-	foundLabels := []model.LabelName{}
-
-	for lName, lSrc := range s.cfgs {
-		labelKey := model.LabelName(*lSrc)
-		if lValue, ok := labels[labelKey]; ok {
-			e.StructuredMetadata = append(e.StructuredMetadata, logproto.LabelAdapter{Name: lName, Value: string(lValue)})
-			foundLabels = append(foundLabels, labelKey)
+		for lName, lSrc := range s.cfgs {
+			source := model.LabelName(*lSrc)
+			if _, ok := structuredMetadata[source]; ok {
+				continue
+			}
+			if lValue, ok := e.Labels[source]; ok {
+				e.StructuredMetadata = append(e.StructuredMetadata, logproto.LabelAdapter{Name: lName, Value: string(lValue)})
+				structuredMetadata[source] = lValue
+			}
 		}
-	}
 
-	// Remove found labels, do this after append to structure metadata
-	for _, fl := range foundLabels {
-		delete(labels, fl)
-	}
-	e.Labels = labels
-	return e
+		// Remove labels which are already added as structure metadata
+		for lName, lValue := range structuredMetadata {
+			if e.Labels[lName] != lValue {
+				continue
+			}
+			delete(e.Labels, lName)
+		}
+		return e
+	})
 }

--- a/clients/pkg/logentry/stages/structuredmetadata_test.go
+++ b/clients/pkg/logentry/stages/structuredmetadata_test.go
@@ -102,6 +102,22 @@ pipeline_stages:
     pod_name: pod
 `
 
+var pipelineStagesStructuredMetadataFromStreamLabels = `
+pipeline_stages:
+- structured_metadata:
+    pod:
+`
+
+var pipelineStagesStructuredMetadataDuplicateKeysInStreamLabelsAndExtractedMap = `
+pipeline_stages:
+- logfmt:
+    mapping:
+      pod:
+- structured_metadata:
+    pod_name: pod
+    source_name: source
+`
+
 func Test_StructuredMetadataStage(t *testing.T) {
 	tests := map[string]struct {
 		pipelineStagesYaml         string
@@ -159,6 +175,20 @@ func Test_StructuredMetadataStage(t *testing.T) {
 			logLine:                    `sample log line`,
 			expectedStructuredMetadata: push.LabelsAdapter{push.LabelAdapter{Name: "pod_name", Value: "loki-querier-664f97db8d-qhnwg"}},
 			expectedLabels:             model.LabelSet{model.LabelName("component"): model.LabelValue("querier")},
+		},
+		"expected structured metadata to be extracted from stream labels": {
+			pipelineStagesYaml:         pipelineStagesStructuredMetadataFromStreamLabels,
+			logLine:                    `app=loki component=ingester`,
+			expectedStructuredMetadata: push.LabelsAdapter{push.LabelAdapter{Name: "pod", Value: "ingester-0"}},
+			expectedLabels:             model.LabelSet{model.LabelName("source"): model.LabelValue("test")},
+			streamLabels:               model.LabelSet{model.LabelName("source"): model.LabelValue("test"), model.LabelName("pod"): model.LabelValue("ingester-0")},
+		},
+		"expected structured metadata to be extracted from extracted map first": {
+			pipelineStagesYaml:         pipelineStagesStructuredMetadataDuplicateKeysInStreamLabelsAndExtractedMap,
+			logLine:                    `app=loki pod=ingester`,
+			expectedStructuredMetadata: push.LabelsAdapter{push.LabelAdapter{Name: "pod_name", Value: "ingester"}, push.LabelAdapter{Name: "source_name", Value: "test"}},
+			expectedLabels:             model.LabelSet{model.LabelName("pod"): model.LabelValue("ingester-0")},
+			streamLabels:               model.LabelSet{model.LabelName("source"): model.LabelValue("test"), model.LabelName("pod"): model.LabelValue("ingester-0")},
 		},
 	}
 	for name, test := range tests {


### PR DESCRIPTION
**What this PR does / why we need it**:
When Structured Metadata extraction was introduced to promtail, it only picked KV pairs from the extracted map.
With PR grafana/loki#10752, promtail also started picking structured metadata from stream labels to help control the cardinality since it would also remove those labels from streams. However, [before running the pipeline stages, we add all the stream labels to the extracted map](https://github.com/grafana/loki/blob/39a7181a600e9dc848dd3c0b0163c07242a46278/clients/pkg/logentry/stages/pipeline.go#L123-L127), due to this, we are adding duplicate Structured Metadata entries.

In this PR, I fix the issue by deduping the entries before adding them to Structured Metadata.
I have ensured that it is not a breaking change by keeping the order of picking Structured Metadata from the Extracted Map before looking at Stream labels.

**Checklist**
- [X] Tests updated
