### PR TITLE
chore: Use correct TimeRange predicate for indexpointers

### DIFF
--- a/pkg/dataobj/sections/indexpointers/row_predicate_test.go
+++ b/pkg/dataobj/sections/indexpointers/row_predicate_test.go
@@ -116,10 +116,8 @@ func evaluateTimeRangePredicate(p dataset.Predicate, s IndexPointer) bool {
 
 func evaluateStartPredicate(p dataset.Predicate, s IndexPointer) bool {
 	switch p := p.(type) {
-	case dataset.NotPredicate:
-		return !evaluateStartPredicate(p.Inner, s)
-	case dataset.LessThanPredicate:
-		return s.StartTs.UnixNano() < p.Value.Int64()
+	case dataset.GreaterThanPredicate:
+		return s.StartTs.UnixNano() >= p.Value.Int64()
 
 	default:
 		panic(fmt.Sprintf("unexpected row predicate type %T", p))
@@ -128,11 +126,8 @@ func evaluateStartPredicate(p dataset.Predicate, s IndexPointer) bool {
 
 func evaluateEndPredicate(p dataset.Predicate, s IndexPointer) bool {
 	switch p := p.(type) {
-	case dataset.NotPredicate:
-		return !evaluateEndPredicate(p.Inner, s)
-	case dataset.GreaterThanPredicate:
-		return s.EndTs.UnixNano() > p.Value.Int64()
-
+	case dataset.LessThanPredicate:
+		return s.EndTs.UnixNano() <= p.Value.Int64()
 	default:
 		panic(fmt.Sprintf("unexpected row predicate type %T", p))
 	}

--- a/pkg/dataobj/sections/indexpointers/row_reader.go
+++ b/pkg/dataobj/sections/indexpointers/row_reader.go
@@ -185,18 +185,13 @@ func translateIndexPointersPredicate(p RowPredicate, columns []dataset.Column) d
 
 func convertTimeRangePredicate(p TimeRangeRowPredicate, minTimestampColumn, maxTimestampColumn dataset.Column) dataset.Predicate {
 	return dataset.AndPredicate{
-		Left: dataset.NotPredicate{
-			Inner: dataset.LessThanPredicate{
-				Column: minTimestampColumn,
-				Value:  dataset.Int64Value(p.Start.UnixNano()),
-			},
+		Left: dataset.GreaterThanPredicate{
+			Column: maxTimestampColumn,
+			Value:  dataset.Int64Value(p.Start.UnixNano() - 1),
 		},
-		Right: dataset.NotPredicate{
-			Inner: dataset.GreaterThanPredicate{
-				Column: maxTimestampColumn,
-				Value:  dataset.Int64Value(p.End.UnixNano()),
-			},
+		Right: dataset.LessThanPredicate{
+			Column: minTimestampColumn,
+			Value:  dataset.Int64Value(p.End.UnixNano() + 1),
 		},
 	}
-
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates the timestamp predicate so the target is overlapping instead of completely inside the range.

We want to return any values that are overlapping with the min/max timestamps of the indexpointers:
e.g. 
An indexpointer with range 01:00 to 02:00 should overlap with query range of 0000-0130 and 0145-0200