### PR TITLE
fix: do not try to merge the already consolidated delete requests while listing them

### DIFF
--- a/pkg/compactor/deletion/grpc_request_handler.go
+++ b/pkg/compactor/deletion/grpc_request_handler.go
@@ -39,13 +39,11 @@ func (g *GRPCRequestHandler) GetDeleteRequests(ctx context.Context, req *grpc.Ge
 		return nil, errors.New(deletionNotAvailableMsg)
 	}
 
-	deleteGroups, err := g.deleteRequestsStore.GetAllDeleteRequestsForUser(ctx, userID, req.ForQuerytimeFiltering)
+	deleteRequests, err := g.deleteRequestsStore.GetAllDeleteRequestsForUser(ctx, userID, req.ForQuerytimeFiltering)
 	if err != nil {
 		level.Error(util_log.Logger).Log("msg", "error getting delete requests from the store", "err", err)
 		return nil, err
 	}
-
-	deleteRequests := mergeDeletes(deleteGroups)
 
 	sort.Slice(deleteRequests, func(i, j int) bool {
 		return deleteRequests[i].CreatedAt < deleteRequests[j].CreatedAt

--- a/pkg/compactor/deletion/request_handler.go
+++ b/pkg/compactor/deletion/request_handler.go
@@ -143,14 +143,13 @@ func (dm *DeleteRequestHandler) GetAllDeleteRequestsHandler(w http.ResponseWrite
 	}
 
 	forQuerytimeFiltering := r.URL.Query().Get(ForQuerytimeFilteringQueryParam) == "true"
-	deleteGroups, err := dm.deleteRequestsStore.GetAllDeleteRequestsForUser(ctx, userID, forQuerytimeFiltering)
+	deleteRequests, err := dm.deleteRequestsStore.GetAllDeleteRequestsForUser(ctx, userID, forQuerytimeFiltering)
 	if err != nil {
 		level.Error(util_log.Logger).Log("msg", "error getting delete requests from the store", "err", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
-	deleteRequests := mergeDeletes(deleteGroups)
 	// We have to retain UserID and SequenceNum in json encoding of deletion manifests.
 	// However, we do not want to return these to the users since they are not relevant.
 	// ToDo(Sandeep): See if we can avoid doing it when we move to proto encoding for deletion manifests.


### PR DESCRIPTION
**What this PR does / why we need it**:
Before introducing SQLite, BoltDB used to return sharded delete requests for the `GetAllDeleteRequestsForUser` operation. The delete request handler would then merge the shards to return consolidated requests to the user.

With the introduction of SQLite as an alternative store, the sharding logic was abstracted as much as possible since both handled shards differently. We made `GetAllDeleteRequestsForUser` return consolidated requests instead of shards.

However, I had missed removing the code for consolidating requests in the request handler. With this PR, I am removing that code and updating the tests to ensure things work as expected.

**Checklist**
- [X] Tests updated