### PR TITLE
feat(compactor HS): add jsonnet for deploying horizontally scalable compactor

### DIFF
--- a/production/ksonnet/loki/images.libsonnet
+++ b/production/ksonnet/loki/images.libsonnet
@@ -14,6 +14,7 @@
     query_scheduler:: self.loki,
     ruler:: self.loki,
     compactor:: self.loki,
+    compactor_worker:: self.loki,
     index_gateway:: self.loki,
     overrides_exporter:: self.loki,
     bloom_gateway:: self.loki,


### PR DESCRIPTION
**What this PR does / why we need it**:
Add jsonnet for deploying horizontally scalable compactor. By setting `enable_horizontally_scalable_compactor` config to `true`, it would take care of setting the command line argument on the singleton statefulset replica to run in `main` mode and create a deployment for compactors to run in `worker` mode.
