### PR TITLE
chore(engine): Extend histogram buckets for metrics for the new query engine

### DIFF
--- a/pkg/engine/metrics.go
+++ b/pkg/engine/metrics.go
@@ -33,10 +33,18 @@ func newMetrics(r prometheus.Registerer) *metrics {
 		physicalPlanning: promauto.With(r).NewHistogram(prometheus.HistogramOpts{
 			Name: "loki_engine_v2_physical_planning",
 			Help: "Duration of physical planning in seconds",
+			Buckets: append(
+				prometheus.DefBuckets,                    // 0.005s -> 10s
+				prometheus.LinearBuckets(15, 5.0, 10)..., // 15s -> 60s
+			),
 		}),
 		execution: promauto.With(r).NewHistogram(prometheus.HistogramOpts{
 			Name: "loki_engine_v2_execution",
 			Help: "Duration of execution in seconds",
+			Buckets: append(
+				prometheus.DefBuckets,                    // 0.005s -> 10s
+				prometheus.LinearBuckets(15, 5.0, 10)..., // 15s -> 60s
+			),
 		}),
 	}
 }

--- a/pkg/engine/metrics.go
+++ b/pkg/engine/metrics.go
@@ -23,24 +23,24 @@ type metrics struct {
 func newMetrics(r prometheus.Registerer) *metrics {
 	return &metrics{
 		subqueries: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
-			Name: "loki_engine_v2_subqueries",
+			Name: "loki_engine_v2_subqueries_total",
 			Help: "Total number of subqueries executed with the new engine",
 		}, []string{status}),
 		logicalPlanning: promauto.With(r).NewHistogram(prometheus.HistogramOpts{
-			Name: "loki_engine_v2_logical_planning",
-			Help: "Duration of logical planning in seconds",
+			Name: "loki_engine_v2_logical_planning_duration_seconds",
+			Help: "Duration of logical query planning in seconds",
 		}),
 		physicalPlanning: promauto.With(r).NewHistogram(prometheus.HistogramOpts{
-			Name: "loki_engine_v2_physical_planning",
-			Help: "Duration of physical planning in seconds",
+			Name: "loki_engine_v2_physical_planning_duration_seconds",
+			Help: "Duration of physical query planning in seconds",
 			Buckets: append(
 				prometheus.DefBuckets,                    // 0.005s -> 10s
 				prometheus.LinearBuckets(15, 5.0, 10)..., // 15s -> 60s
 			),
 		}),
 		execution: promauto.With(r).NewHistogram(prometheus.HistogramOpts{
-			Name: "loki_engine_v2_execution",
-			Help: "Duration of execution in seconds",
+			Name: "loki_engine_v2_execution_duration_seconds",
+			Help: "Duration of query execution in seconds",
 			Buckets: append(
 				prometheus.DefBuckets,                    // 0.005s -> 10s
 				prometheus.LinearBuckets(15, 5.0, 10)..., // 15s -> 60s

--- a/pkg/engine/metrics.go
+++ b/pkg/engine/metrics.go
@@ -3,8 +3,6 @@ package engine
 import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-
-	"github.com/grafana/loki/v3/pkg/util/constants"
 )
 
 var (
@@ -23,27 +21,22 @@ type metrics struct {
 }
 
 func newMetrics(r prometheus.Registerer) *metrics {
-	subsystem := "engine_v2"
 	return &metrics{
 		subqueries: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
-			Namespace: constants.Loki,
-			Subsystem: subsystem,
-			Name:      "subqueries",
+			Name: "loki_engine_v2_subqueries",
+			Help: "Total number of subqueries executed with the new engine",
 		}, []string{status}),
 		logicalPlanning: promauto.With(r).NewHistogram(prometheus.HistogramOpts{
-			Namespace: constants.Loki,
-			Subsystem: subsystem,
-			Name:      "logical_planning",
+			Name: "loki_engine_v2_logical_planning",
+			Help: "Duration of logical planning in seconds",
 		}),
 		physicalPlanning: promauto.With(r).NewHistogram(prometheus.HistogramOpts{
-			Namespace: constants.Loki,
-			Subsystem: subsystem,
-			Name:      "physical_planning",
+			Name: "loki_engine_v2_physical_planning",
+			Help: "Duration of physical planning in seconds",
 		}),
 		execution: promauto.With(r).NewHistogram(prometheus.HistogramOpts{
-			Namespace: constants.Loki,
-			Subsystem: subsystem,
-			Name:      "execution",
+			Name: "loki_engine_v2_execution",
+			Help: "Duration of execution in seconds",
 		}),
 	}
 }


### PR DESCRIPTION
### Summary

This PR extends the default buckets (that only range to 10s) to 60s.
It also inlines the fully qualified name of the metric, rather than using Namespace/Subsystem/Name. This is for easier searchability of the metric name