### PR TITLE
docs: Update Release Notes for 3.5.3

### DIFF
--- a/docs/sources/release-notes/v3-5.md
+++ b/docs/sources/release-notes/v3-5.md
@@ -66,6 +66,11 @@ For important upgrade guidance, refer to the [Upgrade Guide](https://grafana.com
 
 ## Bug fixes
 
+### 3.5.3 (2025-07-23)
+
+* **deps:** Move to Go 1.24.5 ([#18412](https://github.com/grafana/loki/issues/18412)) ([2aa4680](https://github.com/grafana/loki/commit/2aa468065721587d0db829ff6b3cce9b73c10699)).
+* ***WAL:** Handle WAL corruption properly on startup (backport release-3.5.x) ([#18408](https://github.com/grafana/loki/issues/18408)) ([5b8ee9a](https://github.com/grafana/loki/commit/5b8ee9a582d168cbde2cb5a0bad48283069351d6)).
+
 ### 3.5.2 (2025-04-22)
 
 * **ci:** Update release code 3.5 ([#18014](https://github.com/grafana/loki/issues/18014)) ([b1b28b0](https://github.com/grafana/loki/commit/b1b28b0970b437a071050abd8d1391a037cc3ac5)).


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the Release Notes for the 3.5.3 patch.