### PR TITLE
test: Introduce the Helm Chart Toolbox integration tests

### DIFF
--- a/.github/workflows/helm-ci.yml
+++ b/.github/workflows/helm-ci.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   CT_CONFIGFILE: production/helm/ct.yaml
+  INTEGRARION_TESTS_DIR: production/helm/loki/test/integration
 
 jobs:
 # Temporarily disabled linting because this step doesn't easily support passing GO tags yet.
@@ -88,3 +89,69 @@ jobs:
             exit 0
           fi
           ct install --config "${CT_CONFIGFILE}"
+
+  list-integration-tests:
+    name: List integration tests
+    runs-on: ubuntu-latest
+    outputs:
+      tests: ${{ steps.list_tests.outputs.tests }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          persist-credentials: 'false'
+
+      - name: List tests
+        id: list_tests
+        working-directory: "${{ env.INTEGRARION_TESTS_DIR }}"
+        env:
+          LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
+        run: |
+          tests=$(find . -name test-plan.yaml -exec dirname {} \; | sed -e "s/^\.\///g")
+          echo "Tests: ${tests}"
+          echo "tests=$(echo "${tests}" | jq --raw-input --slurp --compact-output 'split("\n") | map(select(. != ""))')" >> "${GITHUB_OUTPUT}"
+
+  run-integration-tests:
+    name: Integration Test
+    needs: list-integration-tests
+    runs-on: ubuntu-latest
+    if: needs.list-integration-tests.outputs.tests != '[]'
+    strategy:
+      matrix:
+        test: ${{ fromJson(needs.list-integration-tests.outputs.tests) }}
+      fail-fast: false
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          path: source
+          persist-credentials: 'false'
+
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          path: helm-chart-toolbox
+          repository: grafana/helm-chart-toolbox
+          persist-credentials: 'false'
+
+      - name: Set up Helm
+        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112  # v4.3.0
+
+      - name: Install Flux CLI
+        uses: fluxcd/flux2/action@6bf37f6a560fd84982d67f853162e4b3c2235edb  # v2.6.4
+
+      - name: Install Kind CLI
+        uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3  # v1.12.0
+        with:
+          install_only: true
+
+      - name: Install Minikube CLI
+        uses: medyagh/setup-minikube@e3c7f79eb1e997eabccc536a6cf318a2b0fe19d9  # v0.0.20
+        with:
+          start: false
+
+      - name: Run test
+        run: helm-chart-toolbox/tools/helm-test/helm-test "${TEST_DIRECTORY}"
+        env:
+          TEST_DIRECTORY: "source/${{ env.INTEGRARION_TESTS_DIR }}/${{ matrix.test }}"
+          DELETE_CLUSTER: true

--- a/production/helm/loki/test/integration/ingress/test-plan.yaml
+++ b/production/helm/loki/test/integration/ingress/test-plan.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: helm-chart-toolbox.grafana.com/v1
 kind: TestPlan
-name: legacy-monitoring
+name: ingress
 subject:
   releaseName: loki
   namespace: loki

--- a/production/helm/loki/test/integration/ingress/test-plan.yaml
+++ b/production/helm/loki/test/integration/ingress/test-plan.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: helm-chart-toolbox.grafana.com/v1
+kind: TestPlan
+name: legacy-monitoring
+subject:
+  releaseName: loki
+  namespace: loki
+  path: ../../..
+  valuesFile: ../../../ci/ingress-values.yaml
+  extraArgs:
+    - --dependency-update
+    - --set
+    - "chunksCache.allocatedMemory=1024"
+
+cluster:
+  type: kind
+
+tests:
+  - type: kubernetes-objects-test
+    values:
+      checks:
+        - kind: Ingress
+          name: loki-gateway
+          namespace: loki

--- a/production/helm/loki/test/integration/single-binary/log-generator.yaml
+++ b/production/helm/loki/test/integration/single-binary/log-generator.yaml
@@ -1,0 +1,50 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: grafana
+  namespace: default
+spec:
+  interval: 1m
+  url: https://grafana.github.io/helm-charts
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: log-generator
+  namespace: default
+spec:
+  interval: 1m
+  chart:
+    spec:
+      chart: alloy
+      sourceRef:
+        kind: HelmRepository
+        name: grafana
+        namespace: default
+      interval: 1m
+  values:
+    controller:
+      type: deployment
+    alloy:
+      configMap:
+        content: |
+          logging {
+            level = "debug"
+            write_to = [loki.relabel.default.receiver]
+          }
+
+          loki.relabel "default" {
+            rule {
+              target_label = "source"
+              replacement = "log-generator"
+            }
+            forward_to = [loki.write.default.receiver]
+          }
+
+          loki.write "default" {
+            endpoint {
+              url = "http://loki.loki.svc:3100/loki/api/v1/push"
+              tenant_id = "1"
+            }
+          }

--- a/production/helm/loki/test/integration/single-binary/test-plan.yaml
+++ b/production/helm/loki/test/integration/single-binary/test-plan.yaml
@@ -1,0 +1,80 @@
+---
+apiVersion: helm-chart-toolbox.grafana.com/v1
+kind: TestPlan
+name: single-binary
+subject:
+  releaseName: loki
+  namespace: loki
+  path: ../../..
+  valuesFile: ../../../ci/default-single-binary-values.yaml
+  extraArgs:
+    - --dependency-update
+    - --set
+    - "chunksCache.allocatedMemory=1024"
+
+cluster:
+  type: kind
+
+dependencies:
+  - file: log-generator.yaml
+  - preset: grafana
+    overrides:
+      datasources:
+        datasources.yaml:
+          apiVersion: 1
+          datasources:
+            - name: Loki
+              type: loki
+              url: http://loki.loki.svc:3100/
+              isDefault: true
+              jsonData:
+                httpHeaderName1: X-Scope-OrgID
+              secureJsonData:
+                httpHeaderValue1: "1"
+
+tests:
+  - type: kubernetes-objects-test
+    values:
+      checks:
+        - kind: StatefulSet
+          name: loki
+          namespace: loki
+        - kind: StatefulSet
+          name: loki-chunks-cache
+          namespace: loki
+        - kind: StatefulSet
+          name: loki-results-cache
+          namespace: loki
+
+        # Loki services
+        - kind: Service
+          name: loki
+          namespace: loki
+        - kind: Service
+          name: loki-canary
+          namespace: loki
+        - kind: Service
+          name: loki-chunks-cache
+          namespace: loki
+        - kind: Service
+          name: loki-gateway
+          namespace: loki
+        - kind: Service
+          name: loki-headless
+          namespace: loki
+        - kind: Service
+          name: loki-memberlist
+          namespace: loki
+        - kind: Service
+          name: loki-results-cache
+          namespace: loki
+
+  - type: query-test
+    values:
+      tests:
+        - env:
+            LOKI_URL: http://loki.loki.svc:3100/loki/api/v1/query
+            LOKI_TENANTID: 1
+          queries:
+            - query: count_over_time({source="log-generator"}[1h])
+              type: logql


### PR DESCRIPTION
Use the [Helm Chart Toolbox](https://github.com/grafana/helm-chart-toolbox) to run Helm chart integration tests in parallel. Starting with two tests that I found in the `ci` directory.

Where I'd take this next:
1. Copy the `abc_values.yaml` files from the `ci` directory into the individual test directories. This will keep them in the text directory and "associated" with that test.
2. Create new tests at least to cover the existing tests run in `ci`
3. Stop using chart-testing (aka `ct`), which is what runs tests sequentially and takes a long time.

At this point, you should see the `helm-ci` GitHub Action take ~5 minutes, rather than 20+ minutes.

4. Long-term phase: Split the tests to focus on individual features, rather than packing lots of things into a small amount of tests. Since Helm Chart Toolbox tests will run in parallel, a larger count of smaller tests is better than a handful of complicated tests.
6. Create more tests!