### PR TITLE
chore(dataobj): make copy of pages from downloaded window

### DIFF
--- a/pkg/dataobj/sections/indexpointers/decoder.go
+++ b/pkg/dataobj/sections/indexpointers/decoder.go
@@ -139,10 +139,13 @@ func (rd *decoder) ReadPages(ctx context.Context, pages []*indexpointersmd.PageD
 			if err != nil {
 				return fmt.Errorf("reading page data: %w", err)
 			}
-			data, err := readAndClose(rc, windowSize)
-			if err != nil {
+
+			buffer := bufpool.Get(int(windowSize))
+			if err := copyAndClose(buffer, rc); err != nil {
+				bufpool.Put(buffer)
 				return fmt.Errorf("read page data: %w", err)
 			}
+			data := buffer.Bytes()
 
 			for _, wp := range window {
 				// Find the slice in the data for this page.
@@ -153,8 +156,13 @@ func (rd *decoder) ReadPages(ctx context.Context, pages []*indexpointersmd.PageD
 
 				// wp.Index is the position of the page in the original pages slice;
 				// this retains the proper order of data in results.
-				results[wp.Index] = dataset.PageData(data[dataOffset : dataOffset+wp.Data.GetInfo().DataSize])
+				//
+				// We need to make a copy here of the slice since data is pooled (and
+				// we don't want to hold on to the entire window if we don't need to).
+				results[wp.Index] = dataset.PageData(bytes.Clone(data[dataOffset : dataOffset+wp.Data.GetInfo().DataSize]))
 			}
+
+			bufpool.Put(buffer)
 		}
 
 		for _, data := range results {
@@ -165,4 +173,15 @@ func (rd *decoder) ReadPages(ctx context.Context, pages []*indexpointersmd.PageD
 
 		return nil
 	})
+}
+
+// copyAndClose copies the data from rc into the destination writer w and then
+// closes rc.
+func copyAndClose(dst io.Writer, rc io.ReadCloser) error {
+	defer rc.Close()
+
+	if _, err := io.Copy(dst, rc); err != nil {
+		return fmt.Errorf("copying data: %w", err)
+	}
+	return nil
 }

--- a/pkg/dataobj/sections/logs/decoder.go
+++ b/pkg/dataobj/sections/logs/decoder.go
@@ -139,10 +139,13 @@ func (rd *decoder) ReadPages(ctx context.Context, pages []*logsmd.PageDesc) resu
 			if err != nil {
 				return fmt.Errorf("reading page data: %w", err)
 			}
-			data, err := readAndClose(rc, windowSize)
-			if err != nil {
+
+			buffer := bufpool.Get(int(windowSize))
+			if err := copyAndClose(buffer, rc); err != nil {
+				bufpool.Put(buffer)
 				return fmt.Errorf("read page data: %w", err)
 			}
+			data := buffer.Bytes()
 
 			for _, wp := range window {
 				// Find the slice in the data for this page.
@@ -153,8 +156,13 @@ func (rd *decoder) ReadPages(ctx context.Context, pages []*logsmd.PageDesc) resu
 
 				// wp.Index is the position of the page in the original pages slice;
 				// this retains the proper order of data in results.
-				results[wp.Index] = dataset.PageData(data[dataOffset : dataOffset+wp.Data.GetInfo().DataSize])
+				//
+				// We need to make a copy here of the slice since data is pooled (and
+				// we don't want to hold on to the entire window if we don't need to).
+				results[wp.Index] = dataset.PageData(bytes.Clone(data[dataOffset : dataOffset+wp.Data.GetInfo().DataSize]))
 			}
+
+			bufpool.Put(buffer)
 		}
 
 		for _, data := range results {
@@ -165,4 +173,15 @@ func (rd *decoder) ReadPages(ctx context.Context, pages []*logsmd.PageDesc) resu
 
 		return nil
 	})
+}
+
+// copyAndClose copies the data from rc into the destination writer w and then
+// closes rc.
+func copyAndClose(dst io.Writer, rc io.ReadCloser) error {
+	defer rc.Close()
+
+	if _, err := io.Copy(dst, rc); err != nil {
+		return fmt.Errorf("copying data: %w", err)
+	}
+	return nil
 }

--- a/pkg/dataobj/sections/pointers/decoder.go
+++ b/pkg/dataobj/sections/pointers/decoder.go
@@ -140,10 +140,13 @@ func (rd *decoder) ReadPages(ctx context.Context, pages []*pointersmd.PageDesc) 
 			if err != nil {
 				return fmt.Errorf("reading page data: %w", err)
 			}
-			data, err := readAndClose(rc, windowSize)
-			if err != nil {
+
+			buffer := bufpool.Get(int(windowSize))
+			if err := copyAndClose(buffer, rc); err != nil {
+				bufpool.Put(buffer)
 				return fmt.Errorf("read page data: %w", err)
 			}
+			data := buffer.Bytes()
 
 			for _, wp := range window {
 				// Find the slice in the data for this page.
@@ -154,8 +157,13 @@ func (rd *decoder) ReadPages(ctx context.Context, pages []*pointersmd.PageDesc) 
 
 				// wp.Index is the position of the page in the original pages slice;
 				// this retains the proper order of data in results.
-				results[wp.Index] = dataset.PageData(data[dataOffset : dataOffset+wp.Data.GetInfo().DataSize])
+				//
+				// We need to make a copy here of the slice since data is pooled (and
+				// we don't want to hold on to the entire window if we don't need to).
+				results[wp.Index] = dataset.PageData(bytes.Clone(data[dataOffset : dataOffset+wp.Data.GetInfo().DataSize]))
 			}
+
+			bufpool.Put(buffer)
 		}
 
 		for _, data := range results {
@@ -166,4 +174,15 @@ func (rd *decoder) ReadPages(ctx context.Context, pages []*pointersmd.PageDesc) 
 
 		return nil
 	})
+}
+
+// copyAndClose copies the data from rc into the destination writer w and then
+// closes rc.
+func copyAndClose(dst io.Writer, rc io.ReadCloser) error {
+	defer rc.Close()
+
+	if _, err := io.Copy(dst, rc); err != nil {
+		return fmt.Errorf("copying data: %w", err)
+	}
+	return nil
 }

--- a/pkg/dataobj/sections/streams/decoder.go
+++ b/pkg/dataobj/sections/streams/decoder.go
@@ -140,10 +140,13 @@ func (rd *decoder) ReadPages(ctx context.Context, pages []*streamsmd.PageDesc) r
 			if err != nil {
 				return fmt.Errorf("reading page data: %w", err)
 			}
-			data, err := readAndClose(rc, windowSize)
-			if err != nil {
+
+			buffer := bufpool.Get(int(windowSize))
+			if err := copyAndClose(buffer, rc); err != nil {
+				bufpool.Put(buffer)
 				return fmt.Errorf("read page data: %w", err)
 			}
+			data := buffer.Bytes()
 
 			for _, wp := range window {
 				// Find the slice in the data for this page.
@@ -154,8 +157,13 @@ func (rd *decoder) ReadPages(ctx context.Context, pages []*streamsmd.PageDesc) r
 
 				// wp.Index is the position of the page in the original pages slice;
 				// this retains the proper order of data in results.
-				results[wp.Index] = dataset.PageData(data[dataOffset : dataOffset+wp.Data.GetInfo().DataSize])
+				//
+				// We need to make a copy here of the slice since data is pooled (and
+				// we don't want to hold on to the entire window if we don't need to).
+				results[wp.Index] = dataset.PageData(bytes.Clone(data[dataOffset : dataOffset+wp.Data.GetInfo().DataSize]))
 			}
+
+			bufpool.Put(buffer)
 		}
 
 		for _, data := range results {
@@ -166,4 +174,15 @@ func (rd *decoder) ReadPages(ctx context.Context, pages []*streamsmd.PageDesc) r
 
 		return nil
 	})
+}
+
+// copyAndClose copies the data from rc into the destination writer w and then
+// closes rc.
+func copyAndClose(dst io.Writer, rc io.ReadCloser) error {
+	defer rc.Close()
+
+	if _, err := io.Copy(dst, rc); err != nil {
+		return fmt.Errorf("copying data: %w", err)
+	}
+	return nil
 }


### PR DESCRIPTION
Previously, pages were subslices of the entire download window. This meant that as long as one of those pages was still reachable, the entire window (up to 16MB) would remain active in memory.

Making copies out of the window will allow pages to be reclaimed by the GC faster when under pressure, and avoid holding onto memory for unneeded regions of the window.

To counteract the increased allocations when calling ReadPages, we now download window into a pooled slice (but still allocate the byte slices for individual pages).