### PR TITLE
#18482 Fix tail_proxy_url to use headless querier service

### DIFF
--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -14,6 +14,7 @@ Entries should include a reference to the pull request that introduced the chang
 [//]: # (<AUTOMATED_UPDATES_LOCATOR> : do not remove this line. This locator is used by the CI pipeline to automatically create a changelog entry for each new Loki release. Add other chart versions and respective changelog entries bellow this line.)
 ## 6.33.0
 
+- [BUGFIX] Fix tail_proxy_url to use headless querier service for proper log tailing functionality. [#18482](https://github.com/grafana/loki/issues/18482)
 - [FEATURE] Allow passing tenant password hash instead of password. [#17049](https://github.com/grafana/loki/pull/17049)
 - [ENHANCEMENT] Add possibility to configure location snippet in nginx config [#18105](https://github.com/grafana/loki/pull/18105)
 - [ENHANCEMENT] Improve health probe helper templates [#18347](https://github.com/grafana/loki/pull/18347)

--- a/production/helm/loki/templates/_helpers.tpl
+++ b/production/helm/loki/templates/_helpers.tpl
@@ -1183,6 +1183,18 @@ enableServiceLinks: false
 {{- printf "%s" $querierAddress }}
 {{- end }}
 
+{{/* Determine headless querier address for tail proxy */}}
+{{- define "loki.querierHeadlessAddress" -}}
+{{- $querierAddress := "" }}
+{{- $isDistributed := eq (include "loki.deployment.isDistributed" .) "true" -}}
+{{- if $isDistributed -}}
+{{- $querierHost := include "loki.querierFullname" .}}
+{{- $querierUrl := printf "http://%s-headless.%s.svc.%s:3100" $querierHost .Release.Namespace .Values.global.clusterDomain }}
+{{- $querierAddress = $querierUrl }}
+{{- end -}}
+{{- printf "%s" $querierAddress }}
+{{- end }}
+
 {{/* Determine index-gateway address */}}
 {{- define "loki.indexGatewayAddress" -}}
 {{- $idxGatewayAddress := ""}}

--- a/production/helm/loki/templates/querier/service-querier-headless.yaml
+++ b/production/helm/loki/templates/querier/service-querier-headless.yaml
@@ -1,0 +1,37 @@
+{{- $isDistributed := eq (include "loki.deployment.isDistributed" .) "true" -}}
+{{- if $isDistributed -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "loki.querierFullname" . }}-headless
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "loki.querierLabels" . | nindent 4 }}
+    {{- with .Values.querier.serviceLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- with .Values.loki.serviceAnnotations }}
+    {{- toYaml . | nindent 4}}
+    {{- end }}
+    {{- with .Values.querier.serviceAnnotations }}
+    {{- toYaml . | nindent 4}}
+    {{- end }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: http-metrics
+      port: 3100
+      targetPort: http-metrics
+      protocol: TCP
+    - name: grpc
+      port: 9095
+      targetPort: grpc
+      protocol: TCP
+      {{- if .Values.querier.appProtocol.grpc }}
+      appProtocol: {{ .Values.querier.appProtocol.grpc }}
+      {{- end }}
+  selector:
+    {{- include "loki.querierSelectorLabels" . | nindent 4 }}
+{{- end -}}

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -560,7 +560,7 @@ loki:
     mode: simple
   frontend:
     scheduler_address: '{{ include "loki.querySchedulerAddress" . }}'
-    tail_proxy_url: '{{ include "loki.querierAddress" . }}'
+    tail_proxy_url: '{{ include "loki.querierHeadlessAddress" . }}'
   frontend_worker:
     scheduler_address: '{{ include "loki.querySchedulerAddress" . }}'
   # -- Optional distributor configuration


### PR DESCRIPTION
**What this PR does / why we need it**:

Creates headless querier service, updates `tail_proxy_url` configuration to use headless service

**Which issue(s) this PR fixes**:
Fixes #18482

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
