### PR TITLE
chore(engine): use columnar logs.Reader for DataObjScan

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -4866,6 +4866,13 @@ engine:
   # CLI flag: -querier.engine.batch-size
   [batch_size: <int> | default = 100]
 
+  # Experimental: Maximum total size of future pages for DataObjScan to download
+  # before they are needed, for roundtrip reduction to object storage. Setting
+  # to zero disables downloading future pages. Only used in the next generation
+  # query engine.
+  # CLI flag: -querier.engine.dataobjscan-page-cache-size
+  [dataobjscan_page_cache_size: <int> | default = 0B]
+
 # The maximum number of queries that can be simultaneously processed by the
 # querier.
 # CLI flag: -querier.max-concurrent

--- a/pkg/dataobj/internal/dataset/predicate.go
+++ b/pkg/dataobj/internal/dataset/predicate.go
@@ -23,6 +23,9 @@ type (
 	// included if the inner Predicate is false.
 	NotPredicate struct{ Inner Predicate }
 
+	// TruePredicate is a [Predicate] which always returns true.
+	TruePredicate struct{}
+
 	// FalsePredicate is a [Predicate] which always returns false.
 	FalsePredicate struct{}
 
@@ -74,6 +77,7 @@ type (
 func (AndPredicate) isPredicate()         {}
 func (OrPredicate) isPredicate()          {}
 func (NotPredicate) isPredicate()         {}
+func (TruePredicate) isPredicate()        {}
 func (FalsePredicate) isPredicate()       {}
 func (EqualPredicate) isPredicate()       {}
 func (InPredicate) isPredicate()          {}
@@ -102,6 +106,7 @@ func WalkPredicate(p Predicate, fn func(p Predicate) bool) {
 	case NotPredicate:
 		WalkPredicate(p.Inner, fn)
 
+	case TruePredicate: // No children.
 	case FalsePredicate: // No children.
 	case EqualPredicate: // No children.
 	case InPredicate: // No children.

--- a/pkg/dataobj/sections/logs/predicate.go
+++ b/pkg/dataobj/sections/logs/predicate.go
@@ -19,6 +19,9 @@ type (
 	// included if the inner Predicate is false.
 	NotPredicate struct{ Inner Predicate }
 
+	// TruePredicate is a [Predicate] which always returns true.
+	TruePredicate struct{}
+
 	// FalsePredicate is a [Predicate] which always returns false.
 	FalsePredicate struct{}
 
@@ -70,6 +73,7 @@ type (
 func (AndPredicate) isPredicate()         {}
 func (OrPredicate) isPredicate()          {}
 func (NotPredicate) isPredicate()         {}
+func (TruePredicate) isPredicate()        {}
 func (FalsePredicate) isPredicate()       {}
 func (EqualPredicate) isPredicate()       {}
 func (InPredicate) isPredicate()          {}
@@ -98,6 +102,7 @@ func walkPredicate(p Predicate, fn func(Predicate) bool) {
 	case NotPredicate:
 		walkPredicate(p.Inner, fn)
 
+	case TruePredicate: // No children.
 	case FalsePredicate: // No children.
 	case EqualPredicate: // No children.
 	case InPredicate: // No children.

--- a/pkg/dataobj/sections/logs/reader.go
+++ b/pkg/dataobj/sections/logs/reader.go
@@ -251,7 +251,7 @@ func (r *Reader) init() error {
 	innerOptions := dataset.ReaderOptions{
 		Dataset:         dset,
 		Columns:         dset.Columns(),
-		Predicates:      preds,
+		Predicates:      orderPredicates(preds),
 		TargetCacheSize: r.opts.PageCacheSize,
 	}
 	if r.inner == nil {

--- a/pkg/dataobj/sections/logs/reader.go
+++ b/pkg/dataobj/sections/logs/reader.go
@@ -88,6 +88,7 @@ func (opts *ReaderOptions) Validate() error {
 			case AndPredicate: // Nothing to do.
 			case OrPredicate: // Nothing to do.
 			case NotPredicate: // Nothing to do.
+			case TruePredicate: // Nothing to do.
 			case FalsePredicate: // Nothing to do.
 
 			case EqualPredicate:
@@ -304,6 +305,9 @@ func mapPredicate(p Predicate, columnLookup map[*Column]dataset.Column) dataset.
 		return dataset.NotPredicate{
 			Inner: mapPredicate(p.Inner, columnLookup),
 		}
+
+	case TruePredicate:
+		return dataset.TruePredicate{}
 
 	case FalsePredicate:
 		return dataset.FalsePredicate{}

--- a/pkg/dataobj/sections/logs/reader.go
+++ b/pkg/dataobj/sections/logs/reader.go
@@ -29,6 +29,12 @@ type ReaderOptions struct {
 	// Allocator to use for allocating Arrow records. If nil,
 	// [memory.DefaultAllocator] is used.
 	Allocator memory.Allocator
+
+	// PageCacheSize is the total size of additional pages to prefetch into the
+	// reader that the reader may read on future calls. Pages are prefetched any
+	// time a new page is required up to this size. Setting to 0 disables
+	// prefetching additional pages.
+	PageCacheSize int
 }
 
 // Validate returns an error if the opts is not valid. ReaderOptions are only
@@ -245,7 +251,7 @@ func (r *Reader) init() error {
 		Dataset:         dset,
 		Columns:         dset.Columns(),
 		Predicates:      preds,
-		TargetCacheSize: 16_000_000, // Permit up to 16MB of cache pages.
+		TargetCacheSize: r.opts.PageCacheSize,
 	}
 	if r.inner == nil {
 		r.inner = dataset.NewReader(innerOptions)

--- a/pkg/dataobj/sections/logs/reader.go
+++ b/pkg/dataobj/sections/logs/reader.go
@@ -198,7 +198,7 @@ func (r *Reader) Read(ctx context.Context, batchSize int) (arrow.Record, error) 
 			// should align with both [columnToField] (for Arrow type) and
 			// [Builder.encodeTo] (for dataset type).
 			//
-			// Passing our byte slices to [array.BinaryBuilder.Append] are safe; it
+			// Passing our byte slices to [array.StringBuilder.BinaryBuilder.Append] are safe; it
 			// will copy the contents of the value and we can reuse the buffer on the
 			// next call to [dataset.Reader.Read].
 			columnType := r.opts.Columns[columnIndex].Type
@@ -210,7 +210,7 @@ func (r *Reader) Read(ctx context.Context, batchSize int) (arrow.Record, error) 
 			case ColumnTypeTimestamp: // Values are nanosecond timestamps as int64
 				columnBuilder.(*array.TimestampBuilder).Append(arrow.Timestamp(val.Int64()))
 			case ColumnTypeMetadata, ColumnTypeMessage: // Appends metadata and log lines as byte arrays
-				columnBuilder.(*array.BinaryBuilder).Append(val.ByteArray())
+				columnBuilder.(*array.StringBuilder).BinaryBuilder.Append(val.ByteArray())
 			default:
 				// We'll only hit this if we added a new column type but forgot to
 				// support reading it.
@@ -434,8 +434,8 @@ var columnDatatypes = map[ColumnType]arrow.DataType{
 	ColumnTypeInvalid:   arrow.Null,
 	ColumnTypeStreamID:  arrow.PrimitiveTypes.Int64,
 	ColumnTypeTimestamp: arrow.FixedWidthTypes.Timestamp_ns,
-	ColumnTypeMetadata:  arrow.BinaryTypes.Binary,
-	ColumnTypeMessage:   arrow.BinaryTypes.Binary,
+	ColumnTypeMetadata:  arrow.BinaryTypes.String,
+	ColumnTypeMessage:   arrow.BinaryTypes.String,
 }
 
 func columnToField(col *Column) arrow.Field {

--- a/pkg/dataobj/sections/logs/reader.go
+++ b/pkg/dataobj/sections/logs/reader.go
@@ -413,6 +413,15 @@ func (r *Reader) Reset(opts ReaderOptions) {
 	}
 }
 
+// Close closes the Reader and releases any resources it holds. Closed Readers
+// can be reused by calling [Reader.Reset].
+func (r *Reader) Close() error {
+	if r.inner != nil {
+		return r.inner.Close()
+	}
+	return nil
+}
+
 func columnsSchema(cols []*Column) *arrow.Schema {
 	fields := make([]arrow.Field, 0, len(cols))
 	for _, col := range cols {

--- a/pkg/dataobj/sections/logs/reader_test.go
+++ b/pkg/dataobj/sections/logs/reader_test.go
@@ -56,7 +56,7 @@ func TestReader(t *testing.T) {
 						return false
 					}
 
-					bb := value.(*scalar.Binary).Value.Bytes()
+					bb := value.(*scalar.String).Value.Bytes()
 					return bytes.Equal(bb, []byte("abcdef")) || bytes.Equal(bb, []byte("123456"))
 				},
 			},
@@ -71,8 +71,8 @@ func TestReader(t *testing.T) {
 	})
 
 	expect := arrowtest.Rows{
-		{"stream_id.int64": int64(2), "trace_id.metadata.binary": []byte("123456"), "message.binary": []byte("foo bar")},
-		{"stream_id.int64": int64(1), "trace_id.metadata.binary": []byte("abcdef"), "message.binary": []byte("goodbye, world!")},
+		{"stream_id.int64": int64(2), "trace_id.metadata.utf8": "123456", "message.utf8": "foo bar"},
+		{"stream_id.int64": int64(1), "trace_id.metadata.utf8": "abcdef", "message.utf8": "goodbye, world!"},
 	}
 
 	actualTable, err := readTable(context.Background(), r)

--- a/pkg/dataobj/sections/streams/predicate.go
+++ b/pkg/dataobj/sections/streams/predicate.go
@@ -19,6 +19,9 @@ type (
 	// included if the inner Predicate is false.
 	NotPredicate struct{ Inner Predicate }
 
+	// TruePredicate is a [Predicate] which always returns true.
+	TruePredicate struct{}
+
 	// FalsePredicate is a [Predicate] which always returns false.
 	FalsePredicate struct{}
 
@@ -70,6 +73,7 @@ type (
 func (AndPredicate) isPredicate()         {}
 func (OrPredicate) isPredicate()          {}
 func (NotPredicate) isPredicate()         {}
+func (TruePredicate) isPredicate()        {}
 func (FalsePredicate) isPredicate()       {}
 func (EqualPredicate) isPredicate()       {}
 func (InPredicate) isPredicate()          {}
@@ -98,6 +102,7 @@ func walkPredicate(p Predicate, fn func(Predicate) bool) {
 	case NotPredicate:
 		walkPredicate(p.Inner, fn)
 
+	case TruePredicate: // No children.
 	case FalsePredicate: // No children.
 	case EqualPredicate: // No children.
 	case InPredicate: // No children.

--- a/pkg/dataobj/sections/streams/reader.go
+++ b/pkg/dataobj/sections/streams/reader.go
@@ -29,6 +29,12 @@ type ReaderOptions struct {
 	// Allocator to use for allocating Arrow records. If nil,
 	// [memory.DefaultAllocator] is used.
 	Allocator memory.Allocator
+
+	// PageCacheSize is the total size of additional pages to prefetch into the
+	// reader that the reader may read on future calls. Pages are prefetched any
+	// time a new page is required up to this size. Setting to 0 disables
+	// prefetching additional pages.
+	PageCacheSize int
 }
 
 // Validate returns an error if the opts is not valid. ReaderOptions are only
@@ -249,7 +255,7 @@ func (r *Reader) init() error {
 		Dataset:         dset,
 		Columns:         dset.Columns(),
 		Predicates:      preds,
-		TargetCacheSize: 16_000_000, // Permit up to 16MB of cache pages.
+		TargetCacheSize: r.opts.PageCacheSize,
 	}
 	if r.inner == nil {
 		r.inner = dataset.NewReader(innerOptions)

--- a/pkg/dataobj/sections/streams/reader.go
+++ b/pkg/dataobj/sections/streams/reader.go
@@ -88,6 +88,7 @@ func (opts *ReaderOptions) Validate() error {
 			case AndPredicate: // Nothing to do.
 			case OrPredicate: // Nothing to do.
 			case NotPredicate: // Nothing to do.
+			case TruePredicate: // Nothing to do.
 			case FalsePredicate: // Nothing to do.
 
 			case EqualPredicate:
@@ -308,6 +309,9 @@ func mapPredicate(p Predicate, columnLookup map[*Column]dataset.Column) dataset.
 		return dataset.NotPredicate{
 			Inner: mapPredicate(p.Inner, columnLookup),
 		}
+
+	case TruePredicate:
+		return dataset.TruePredicate{}
 
 	case FalsePredicate:
 		return dataset.FalsePredicate{}

--- a/pkg/dataobj/sections/streams/reader.go
+++ b/pkg/dataobj/sections/streams/reader.go
@@ -417,6 +417,15 @@ func (r *Reader) Reset(opts ReaderOptions) {
 	}
 }
 
+// Close closes the Reader and releases any resources it holds. Closed Readers
+// can be reused by calling [Reader.Reset].
+func (r *Reader) Close() error {
+	if r.inner != nil {
+		return r.inner.Close()
+	}
+	return nil
+}
+
 func columnsSchema(cols []*Column) *arrow.Schema {
 	fields := make([]arrow.Field, 0, len(cols))
 	for _, col := range cols {

--- a/pkg/dataobj/sections/streams/reader.go
+++ b/pkg/dataobj/sections/streams/reader.go
@@ -198,7 +198,7 @@ func (r *Reader) Read(ctx context.Context, batchSize int) (arrow.Record, error) 
 			// should align with both [columnToField] (for Arrow type) and
 			// [Builder.encodeTo] (for dataset type).
 			//
-			// Passing our byte slices to [array.BinaryBuilder.Append] are safe; it
+			// Passing our byte slices to [array.StringBuilder.BinaryBuilder.Append] are safe; it
 			// will copy the contents of the value and we can reuse the buffer on the
 			// next call to [dataset.Reader.Read].
 			columnType := r.opts.Columns[columnIndex].Type
@@ -210,7 +210,7 @@ func (r *Reader) Read(ctx context.Context, batchSize int) (arrow.Record, error) 
 			case ColumnTypeMinTimestamp, ColumnTypeMaxTimestamp: // Values are nanosecond timestamps as int64
 				columnBuilder.(*array.TimestampBuilder).Append(arrow.Timestamp(val.Int64()))
 			case ColumnTypeLabel: // Appends labels as byte arrays
-				columnBuilder.(*array.BinaryBuilder).Append(val.ByteArray())
+				columnBuilder.(*array.StringBuilder).BinaryBuilder.Append(val.ByteArray())
 			case ColumnTypeRows: // Appends rows as int64
 				columnBuilder.(*array.Int64Builder).Append(val.Int64())
 			case ColumnTypeUncompressedSize: // Appends uncompressed size as int64
@@ -439,7 +439,7 @@ var columnDatatypes = map[ColumnType]arrow.DataType{
 	ColumnTypeStreamID:         arrow.PrimitiveTypes.Int64,
 	ColumnTypeMinTimestamp:     arrow.FixedWidthTypes.Timestamp_ns,
 	ColumnTypeMaxTimestamp:     arrow.FixedWidthTypes.Timestamp_ns,
-	ColumnTypeLabel:            arrow.BinaryTypes.Binary,
+	ColumnTypeLabel:            arrow.BinaryTypes.String,
 	ColumnTypeRows:             arrow.PrimitiveTypes.Int64,
 	ColumnTypeUncompressedSize: arrow.PrimitiveTypes.Int64,
 }

--- a/pkg/dataobj/sections/streams/reader_test.go
+++ b/pkg/dataobj/sections/streams/reader_test.go
@@ -24,8 +24,8 @@ func TestReader(t *testing.T) {
 	expect := arrowtest.Rows{
 		{
 			"stream_id.int64":         int64(1),
-			"app.label.binary":        []byte("foo"),
-			"cluster.label.binary":    []byte("test"),
+			"app.label.utf8":          "foo",
+			"cluster.label.utf8":      "test",
 			"min_timestamp.timestamp": time.Unix(10, 0).UTC(),
 			"max_timestamp.timestamp": time.Unix(15, 0).UTC(),
 			"rows.int64":              int64(2),
@@ -33,8 +33,8 @@ func TestReader(t *testing.T) {
 		},
 		{
 			"stream_id.int64":         int64(2),
-			"app.label.binary":        []byte("bar"),
-			"cluster.label.binary":    []byte("test"),
+			"app.label.utf8":          "bar",
+			"cluster.label.utf8":      "test",
 			"min_timestamp.timestamp": time.Unix(5, 0).UTC(),
 			"max_timestamp.timestamp": time.Unix(20, 0).UTC(),
 			"rows.int64":              int64(2),
@@ -42,8 +42,8 @@ func TestReader(t *testing.T) {
 		},
 		{
 			"stream_id.int64":         int64(3),
-			"app.label.binary":        []byte("baz"),
-			"cluster.label.binary":    []byte("test"),
+			"app.label.utf8":          "baz",
+			"cluster.label.utf8":      "test",
 			"min_timestamp.timestamp": time.Unix(25, 0).UTC(),
 			"max_timestamp.timestamp": time.Unix(30, 0).UTC(),
 			"rows.int64":              int64(2),
@@ -77,8 +77,8 @@ func TestReader_Predicate(t *testing.T) {
 	expect := arrowtest.Rows{
 		{
 			"stream_id.int64":         int64(2),
-			"app.label.binary":        []byte("bar"),
-			"cluster.label.binary":    []byte("test"),
+			"app.label.utf8":          "bar",
+			"cluster.label.utf8":      "test",
 			"min_timestamp.timestamp": time.Unix(5, 0).UTC(),
 			"max_timestamp.timestamp": time.Unix(20, 0).UTC(),
 			"rows.int64":              int64(2),
@@ -121,8 +121,8 @@ func TestReader_InPredicate(t *testing.T) {
 	expect := arrowtest.Rows{
 		{
 			"stream_id.int64":         int64(2),
-			"app.label.binary":        []byte("bar"),
-			"cluster.label.binary":    []byte("test"),
+			"app.label.utf8":          "bar",
+			"cluster.label.utf8":      "test",
 			"min_timestamp.timestamp": time.Unix(5, 0).UTC(),
 			"max_timestamp.timestamp": time.Unix(20, 0).UTC(),
 			"rows.int64":              int64(2),
@@ -166,16 +166,16 @@ func TestReader_ColumnSubset(t *testing.T) {
 
 	expect := arrowtest.Rows{
 		{
-			"stream_id.int64":  int64(1),
-			"app.label.binary": []byte("foo"),
+			"stream_id.int64": int64(1),
+			"app.label.utf8":  "foo",
 		},
 		{
-			"stream_id.int64":  int64(2),
-			"app.label.binary": []byte("bar"),
+			"stream_id.int64": int64(2),
+			"app.label.utf8":  "bar",
 		},
 		{
-			"stream_id.int64":  int64(3),
-			"app.label.binary": []byte("baz"),
+			"stream_id.int64": int64(3),
+			"app.label.utf8":  "baz",
 		},
 	}
 

--- a/pkg/dataobj/sections/streams/reader_test.go
+++ b/pkg/dataobj/sections/streams/reader_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"testing"
+	"time"
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
@@ -25,8 +26,8 @@ func TestReader(t *testing.T) {
 			"stream_id.int64":         int64(1),
 			"app.label.binary":        []byte("foo"),
 			"cluster.label.binary":    []byte("test"),
-			"min_timestamp.timestamp": arrowUnixTime(10),
-			"max_timestamp.timestamp": arrowUnixTime(15),
+			"min_timestamp.timestamp": time.Unix(10, 0).UTC(),
+			"max_timestamp.timestamp": time.Unix(15, 0).UTC(),
 			"rows.int64":              int64(2),
 			"uncompressed_size.int64": int64(25),
 		},
@@ -34,8 +35,8 @@ func TestReader(t *testing.T) {
 			"stream_id.int64":         int64(2),
 			"app.label.binary":        []byte("bar"),
 			"cluster.label.binary":    []byte("test"),
-			"min_timestamp.timestamp": arrowUnixTime(5),
-			"max_timestamp.timestamp": arrowUnixTime(20),
+			"min_timestamp.timestamp": time.Unix(5, 0).UTC(),
+			"max_timestamp.timestamp": time.Unix(20, 0).UTC(),
 			"rows.int64":              int64(2),
 			"uncompressed_size.int64": int64(45),
 		},
@@ -43,8 +44,8 @@ func TestReader(t *testing.T) {
 			"stream_id.int64":         int64(3),
 			"app.label.binary":        []byte("baz"),
 			"cluster.label.binary":    []byte("test"),
-			"min_timestamp.timestamp": arrowUnixTime(25),
-			"max_timestamp.timestamp": arrowUnixTime(30),
+			"min_timestamp.timestamp": time.Unix(25, 0).UTC(),
+			"max_timestamp.timestamp": time.Unix(30, 0).UTC(),
 			"rows.int64":              int64(2),
 			"uncompressed_size.int64": int64(35),
 		},
@@ -78,8 +79,8 @@ func TestReader_Predicate(t *testing.T) {
 			"stream_id.int64":         int64(2),
 			"app.label.binary":        []byte("bar"),
 			"cluster.label.binary":    []byte("test"),
-			"min_timestamp.timestamp": arrowUnixTime(5),
-			"max_timestamp.timestamp": arrowUnixTime(20),
+			"min_timestamp.timestamp": time.Unix(5, 0).UTC(),
+			"max_timestamp.timestamp": time.Unix(20, 0).UTC(),
 			"rows.int64":              int64(2),
 			"uncompressed_size.int64": int64(45),
 		},
@@ -122,8 +123,8 @@ func TestReader_InPredicate(t *testing.T) {
 			"stream_id.int64":         int64(2),
 			"app.label.binary":        []byte("bar"),
 			"cluster.label.binary":    []byte("test"),
-			"min_timestamp.timestamp": arrowUnixTime(5),
-			"max_timestamp.timestamp": arrowUnixTime(20),
+			"min_timestamp.timestamp": time.Unix(5, 0).UTC(),
+			"max_timestamp.timestamp": time.Unix(20, 0).UTC(),
 			"rows.int64":              int64(2),
 			"uncompressed_size.int64": int64(45),
 		},
@@ -205,10 +206,6 @@ func TestReader_ColumnSubset(t *testing.T) {
 	actual, err := arrowtest.TableRows(alloc, actualTable)
 	require.NoError(t, err, "failed to get rows from table")
 	require.Equal(t, expect, actual)
-}
-
-func arrowUnixTime(sec int64) string {
-	return arrowtest.Time(unixTime(sec).UTC())
 }
 
 func readTable(ctx context.Context, r *streams.Reader) (arrow.Table, error) {

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -131,8 +131,9 @@ func (e *QueryEngine) Execute(ctx context.Context, params logql.Params) (logqlmo
 
 	t = time.Now() // start stopwatch for execution
 	cfg := executor.Config{
-		BatchSize: int64(e.opts.BatchSize),
-		Bucket:    e.bucket,
+		BatchSize:                int64(e.opts.BatchSize),
+		Bucket:                   e.bucket,
+		DataobjScanPageCacheSize: int64(e.opts.DataobjScanPageCacheSize),
 	}
 	pipeline := executor.Run(ctx, cfg, plan, logger)
 	defer pipeline.Close()

--- a/pkg/engine/executor/dataobjscan.go
+++ b/pkg/engine/executor/dataobjscan.go
@@ -9,13 +9,10 @@ import (
 	"slices"
 
 	"github.com/apache/arrow-go/v18/arrow"
-	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/apache/arrow-go/v18/arrow/scalar"
 	"github.com/go-kit/log"
-	"github.com/go-kit/log/level"
-	"github.com/prometheus/prometheus/model/labels"
 
-	"github.com/grafana/loki/v3/pkg/dataobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/logs"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/streams"
 	"github.com/grafana/loki/v3/pkg/engine/internal/datatype"
@@ -23,52 +20,48 @@ import (
 	"github.com/grafana/loki/v3/pkg/engine/planner/physical"
 )
 
+type dataobjScanOptions struct {
+	StreamsSection *streams.Section
+	LogsSection    *logs.Section
+	StreamIDs      []int64                     // Stream IDs to match from logs sections.
+	Predicates     []logs.Predicate            // Predicate to apply to the logs.
+	Projections    []physical.ColumnExpression // Columns to include. An empty slice means all columns.
+
+	Allocator memory.Allocator // Allocator to use for reading sections and building records.
+
+	BatchSize int64 // The buffer size for reading rows, derived from the engine batch size.
+	CacheSize int   // The size of the page cache to use for reading sections.
+}
+
 type dataobjScan struct {
 	opts   dataobjScanOptions
 	logger log.Logger
 
-	initialized bool
-	reader      *logs.RowReader
-	streams     map[int64]labels.Labels
-	records     []logs.Record
+	initialized     bool
+	streams         *streamsView
+	streamsInjector *streamInjector
+	reader          *logs.Reader
+	desiredSchema   *arrow.Schema
 
 	state state
-}
-
-type dataobjScanOptions struct {
-	// TODO(rfratto): Limiting each DataObjScan to a single section is going to
-	// be critical for limiting memory overhead here; the section is intended to
-	// be the smallest unit of parallelization.
-
-	Object      *dataobj.Object             // Object to read from.
-	StreamIDs   []int64                     // Stream IDs to match from logs sections.
-	Section     int                         // Logs section to fetch.
-	Predicates  []logs.RowPredicate         // Predicate to apply to the logs.
-	Projections []physical.ColumnExpression // Columns to include. An empty slice means all columns.
-
-	Direction physical.SortOrder // Order of timestamps to return (ASC=Forward, DESC=Backward)
-	Limit     uint32             // A limit on the number of rows to return (0=unlimited).
-
-	batchSize int64 // The buffer size for reading rows, derived from the engine batch size.
 }
 
 var _ Pipeline = (*dataobjScan)(nil)
 
 // newDataobjScanPipeline creates a new Pipeline which emits a single
-// [arrow.Record] composed of all log sections in a data object. Rows in the
-// returned record are ordered by timestamp in the direction specified by
-// opts.Direction.
-func newDataobjScanPipeline(opts dataobjScanOptions, logger log.Logger) *dataobjScan {
-	if opts.Direction == physical.ASC {
-		// It's ok to panic here, because the validation of log query direction is performed in the logical planner.
-		panic("sorting by timestamp ASC is not supported by DataObjScan")
+// [arrow.Record] composed of the requested log section in a data object. Rows
+// in the returned record are ordered by timestamp in the direction specified
+// by opts.Direction.
+func newDataobjScanPipeline(opts dataobjScanOptions) *dataobjScan {
+	if opts.Allocator == nil {
+		opts.Allocator = memory.DefaultAllocator
 	}
-	return &dataobjScan{opts: opts, logger: logger}
+
+	return &dataobjScan{opts: opts}
 }
 
-// Read retrieves the next [arrow.Record] from the dataobj.
 func (s *dataobjScan) Read(ctx context.Context) error {
-	if err := s.init(ctx); err != nil {
+	if err := s.init(); err != nil {
 		return err
 	}
 
@@ -81,469 +74,331 @@ func (s *dataobjScan) Read(ctx context.Context) error {
 	return nil
 }
 
-func (s *dataobjScan) init(ctx context.Context) error {
+func (s *dataobjScan) init() error {
 	if s.initialized {
 		return nil
 	}
 
-	s.records = make([]logs.Record, 0, s.opts.batchSize)
-
-	if err := s.initStreams(ctx); err != nil {
+	// [dataobjScan.initLogs] depends on the result of [dataobjScan.initStreams]
+	// (to know whether label columns are needed), so we must initialize streams
+	// first.
+	if err := s.initStreams(); err != nil {
 		return fmt.Errorf("initializing streams: %w", err)
-	}
-
-	s.reader = nil
-
-	for idx, section := range s.opts.Object.Sections().Filter(logs.CheckSection) {
-		// Filter out sections that are not part of this shard
-		if s.opts.Section != idx {
-			continue
-		}
-
-		sec, err := logs.Open(ctx, section)
-		if err != nil {
-			return fmt.Errorf("opening logs section: %w", err)
-		}
-
-		// TODO:(ashwanth): [dataobjscan] only supports reading logs sections
-		// that are sorted primarily by timestamp in DESC order.
-		//
-		// Other sort orders should be supported by wrapping the scan with TopK
-		// either during planning or execution.
-		{
-			colType, sortOrder, err := sec.PrimarySortOrder()
-			if err != nil {
-				level.Warn(s.logger).Log("msg", "missing sort order information", "section", idx)
-			} else if colType != logs.ColumnTypeTimestamp || sortOrder != logs.SortDirectionDescending {
-				level.Warn(s.logger).Log("msg", "section is not sorted by timestamp in DESC order",
-					"dataobj", idx, "primaryColumnType", colType, "sortOrder", sortOrder)
-			}
-		}
-
-		// TODO(rfratto): There's a few problems with using LogsReader as it is:
-		//
-		// 1. LogsReader doesn't support providing a subset of columns to read
-		//    from, so we're applying projections after reading.
-		//
-		// 2. LogsReader is intended to be pooled to reduce memory, but we're
-		//    creating a new one every time here.
-		//
-		// For the sake of the initial implementation I'm ignoring these issues,
-		// but we'll absolutely need to solve this prior to production use.
-		lr := logs.NewRowReader(sec)
-
-		// The calls below can't fail because we're always using a brand new logs
-		// reader.
-		_ = lr.MatchStreams(slices.Values(s.opts.StreamIDs))
-		_ = lr.SetPredicates(s.opts.Predicates)
-
-		s.reader = lr
-		break
-	}
-
-	if s.reader == nil {
-		return fmt.Errorf("no logs section %d found", s.opts.Section)
+	} else if err := s.initLogs(); err != nil {
+		return fmt.Errorf("initializing logs: %w", err)
 	}
 
 	s.initialized = true
 	return nil
 }
 
-// initStreams retrieves all requested stream records from streams sections so
-// that emitted [arrow.Record]s can include stream labels in results.
-func (s *dataobjScan) initStreams(ctx context.Context) error {
-	var sr streams.RowReader
-	defer sr.Close()
-
-	streamsBuf := make([]streams.Stream, s.opts.batchSize)
-
-	// Initialize entries in the map so we can do a presence test in the loop
-	// below.
-	s.streams = make(map[int64]labels.Labels, len(s.opts.StreamIDs))
-	for _, id := range s.opts.StreamIDs {
-		s.streams[id] = labels.EmptyLabels()
+func (s *dataobjScan) initStreams() error {
+	if s.opts.StreamsSection == nil {
+		return fmt.Errorf("no streams section provided")
 	}
 
-	for _, section := range s.opts.Object.Sections().Filter(streams.CheckSection) {
-		sec, err := streams.Open(ctx, section)
-		if err != nil {
-			return fmt.Errorf("opening streams section: %w", err)
-		}
-
-		// TODO(rfratto): dataobj.StreamsPredicate is missing support for filtering
-		// on stream IDs when we already know them in advance; this can cause the
-		// Read here to take longer than it needs to since we're reading the
-		// entirety of every row.
-		sr.Reset(sec)
-
-		for {
-			n, err := sr.Read(ctx, streamsBuf)
-			if n == 0 && errors.Is(err, io.EOF) {
-				return nil
-			} else if err != nil && !errors.Is(err, io.EOF) {
-				return err
-			}
-
-			for i, stream := range streamsBuf[:n] {
-				if _, found := s.streams[stream.ID]; !found {
-					continue
-				}
-
-				s.streams[stream.ID] = stream.Labels.Copy()
-
-				// Zero out the stream entry from the slice so the next call to sr.Read
-				// doesn't overwrite any memory we just moved to s.streams.
-				streamsBuf[i] = streams.Stream{}
-			}
-		}
+	columnsToRead := projectedLabelColumns(s.opts.StreamsSection, s.opts.Projections)
+	if len(columnsToRead) == 0 {
+		s.streams = nil
+		s.streamsInjector = nil
+		return nil
 	}
 
-	// Check that all streams were populated.
-	var errs []error
-	for id, labels := range s.streams {
-		if labels.IsEmpty() {
-			errs = append(errs, fmt.Errorf("requested stream ID %d not found in any stream section", id))
-		}
-	}
-	return errors.Join(errs...)
-}
-
-// read reads the entire data object into memory and generates an arrow.Record
-// from the data. It returns an error upon encountering an error while reading
-// one of the sections.
-func (s *dataobjScan) read(ctx context.Context) (arrow.Record, error) {
-	var (
-		n   int   // number of rows yielded by the datobj reader
-		err error // error yielded by the dataobj reader
-	)
-
-	// Read from the dataobj until it yields at least one row, to avoid these function calls from the parent.
-	for n == 0 {
-		// Reset buffer
-		s.records = s.records[:s.opts.batchSize]
-
-		n, err = s.reader.Read(ctx, s.records)
-		if n == 0 && errors.Is(err, io.EOF) {
-			return nil, EOF
-		} else if err != nil && !errors.Is(err, io.EOF) {
-			return nil, err
-		}
-	}
-	s.records = s.records[:n]
-
-	projections, err := s.effectiveProjections(s.records)
-	if err != nil {
-		return nil, fmt.Errorf("getting effective projections: %w", err)
-	}
-
-	schema, err := schemaFromColumns(projections)
-	if err != nil {
-		return nil, fmt.Errorf("creating schema: %w", err)
-	}
-
-	// TODO(rfratto): pass allocator to builder
-	rb := array.NewRecordBuilder(memory.NewGoAllocator(), schema)
-	defer rb.Release()
-
-	for _, record := range s.records {
-		for i := 0; i < schema.NumFields(); i++ {
-			field, builder := rb.Schema().Field(i), rb.Field(i)
-			s.appendToBuilder(builder, &field, &record)
-		}
-	}
-
-	return rb.NewRecord(), nil
-}
-
-// getLessFunc returns a "less comparison" function for records for the sort heap.
-// direction determines the search order:
-// BACKWARD is a backward search starting at the end of the time range.
-// FORWARD is a forward search starting at the beginning of the time range.
-// If two records have the same timestamp, the compareStreams function is used to determine the sort order.
-func (s *dataobjScan) getLessFunc(direction physical.SortOrder) func(a, b logs.Record) bool {
-	compareStreams := func(a, b logs.Record) bool {
-		aStream, ok := s.streams[a.StreamID]
-		if !ok {
-			return false
-		}
-
-		bStream, ok := s.streams[b.StreamID]
-		if !ok {
-			return true
-		}
-
-		return labels.Compare(aStream, bStream) < 0
-	}
-
-	switch direction {
-	case physical.ASC:
-		return func(a, b logs.Record) bool {
-			if a.Timestamp.Equal(b.Timestamp) {
-				compareStreams(a, b)
-			}
-			return a.Timestamp.After(b.Timestamp)
-		}
-	case physical.DESC:
-		return func(a, b logs.Record) bool {
-			if a.Timestamp.Equal(b.Timestamp) {
-				compareStreams(a, b)
-			}
-			return a.Timestamp.Before(b.Timestamp)
-		}
-	default:
-		panic("invalid direction")
-	}
-}
-
-// effectiveProjections returns the effective projections to return for a
-// record. If s.opts.Projections is non-empty, then its column expressions are
-// used for the projections.
-//
-// Otherwise, the set of all columns found in the heap are used, in order of:
-//
-// * All stream labels (sorted by name)
-// * All metadata columns (sorted by name)
-// * Log timestamp
-// * Log message
-//
-// effectiveProjections does not mutate h.
-func (s *dataobjScan) effectiveProjections(records []logs.Record) ([]physical.ColumnExpression, error) {
-	if len(s.opts.Projections) > 0 {
-		return s.opts.Projections, nil
-	}
-
-	var (
-		columns      []physical.ColumnExpression
-		foundStreams = map[int64]struct{}{}
-		found        = map[physical.ColumnExpr]struct{}{}
-	)
-
-	addColumn := func(name string, ty types.ColumnType) {
-		expr := physical.ColumnExpr{
-			Ref: types.ColumnRef{Column: name, Type: ty},
-		}
-
-		if _, ok := found[expr]; !ok {
-			found[expr] = struct{}{}
-			columns = append(columns, &expr)
-		}
-	}
-
-	for _, rec := range records {
-		stream, ok := s.streams[rec.StreamID]
-		if !ok {
-			// If we hit this, there's a problem with either initStreams (we missed a
-			// requested stream) or the predicate application, where it returned a
-			// stream we didn't want.
-			return nil, fmt.Errorf("stream ID %d not found in stream cache", rec.StreamID)
-		}
-
-		if _, addedStream := foundStreams[rec.StreamID]; !addedStream {
-			stream.Range(func(label labels.Label) {
-				addColumn(label.Name, types.ColumnTypeLabel)
-			})
-			foundStreams[rec.StreamID] = struct{}{}
-		}
-
-		rec.Metadata.Range(func(label labels.Label) {
-			addColumn(label.Name, types.ColumnTypeMetadata)
-		})
-	}
-
-	// Sort existing columns by type (preferring labels) then name.
-	slices.SortFunc(columns, func(a, b physical.ColumnExpression) int {
-		aRef, bRef := a.(*physical.ColumnExpr).Ref, b.(*physical.ColumnExpr).Ref
-
-		if aRef.Type != bRef.Type {
-			if aRef.Type == types.ColumnTypeLabel {
-				return -1 // Labels first.
-			}
-			return 1
-		}
-
-		return cmp.Compare(aRef.Column, bRef.Column)
+	s.streams = newStreamsView(s.opts.StreamsSection, &streamsViewOptions{
+		StreamIDs:    s.opts.StreamIDs,
+		LabelColumns: columnsToRead,
 	})
 
-	// Add fixed columns at the end.
-	addColumn(types.ColumnNameBuiltinTimestamp, types.ColumnTypeBuiltin)
-	addColumn(types.ColumnNameBuiltinMessage, types.ColumnTypeBuiltin)
-
-	return columns, nil
+	s.streamsInjector = newStreamInjector(s.opts.Allocator, s.streams)
+	return nil
 }
 
-func schemaFromColumns(columns []physical.ColumnExpression) (*arrow.Schema, error) {
-	var (
-		fields       = make([]arrow.Field, 0, len(columns))
-		fingerprints = make(map[string]struct{}, len(columns))
-	)
+// projectedLabelColumns returns the label columns to read from the given
+// streams section for the provided list of projections. If projections is
+// empty, all stream label columns are returned.
+//
+// References to columns in projections that do not exist in the section are
+// ignored.
+//
+// If projections is non-empty but contains no references to labels or
+// ambiguous columns, projectedLabelColumns returns nil to indicate that no
+// label columns are needed.
+func projectedLabelColumns(sec *streams.Section, projections []physical.ColumnExpression) []*streams.Column {
+	var found []*streams.Column
 
-	addField := func(field arrow.Field) {
-		fp := field.Fingerprint()
-		if field.HasMetadata() {
-			// We differentiate column type using metadata, but the metadata isn't
-			// included in the fingerprint, so we need to manually include it here.
-			fp += field.Metadata.String()
+	// Special case: if projections is empty, we return all label columns. While
+	// [streamsView] accepts a nil list to mean "all columns," we reserve nil
+	// here to mean "we're not projecting stream labels at all."
+	if len(projections) == 0 {
+		for _, col := range sec.Columns() {
+			if col.Type != streams.ColumnTypeLabel {
+				continue
+			}
+			found = append(found, col)
 		}
-
-		if _, exist := fingerprints[fp]; exist {
-			return
-		}
-
-		fields = append(fields, field)
-		fingerprints[fp] = struct{}{}
+		return found
 	}
 
-	for _, column := range columns {
-		columnExpr, ok := column.(*physical.ColumnExpr)
+	// Inefficient search. Will we have enough columns + projections such that
+	// this needs to be optimized?
+	for _, projection := range projections {
+		expr, ok := projection.(*physical.ColumnExpr)
 		if !ok {
-			return nil, fmt.Errorf("invalid column expression type %T", column)
+			panic("invalid projection type, expected *physical.ColumnExpr")
 		}
 
-		switch columnExpr.Ref.Type {
-		case types.ColumnTypeLabel:
-			// TODO(rfratto): Switch to dictionary encoding for labels.
-			//
-			// Since labels are more likely to repeat than metadata, we could cut
-			// down on the memory overhead of a record by dictionary encoding the
-			// labels.
-			//
-			// However, the csv package we use for testing DataObjScan currently
-			// (2025-05-02) doesn't support dictionary encoding, and we would need
-			// to find a solution there.
-			//
-			// We skipped dictionary encoding for now to get the initial prototype
-			// working.
-			ty, md := arrowTypeFromColumnRef(columnExpr.Ref)
-			addField(arrow.Field{
-				Name:     columnExpr.Ref.Column,
-				Type:     ty,
-				Nullable: true,
-				Metadata: md,
-			})
+		// We're loading the sterams section for joining stream labels into
+		// records, so we only need to consider label and ambiguous columns here.
+		if expr.Ref.Type != types.ColumnTypeLabel && expr.Ref.Type != types.ColumnTypeAmbiguous {
+			continue
+		}
 
-		case types.ColumnTypeMetadata:
-			// Metadata is *not* encoded using dictionary encoding since metadata is
-			// has unconstrained cardinality. Using dictionary encoding would require
-			// tracking every encoded value in the record, which is likely to be too
-			// expensive.
-			ty, md := arrowTypeFromColumnRef(columnExpr.Ref)
-			addField(arrow.Field{
-				Name:     columnExpr.Ref.Column,
-				Type:     ty,
-				Nullable: true,
-				Metadata: md,
-			})
+		for _, col := range sec.Columns() {
+			if col.Type != streams.ColumnTypeLabel {
+				continue
+			}
 
-		case types.ColumnTypeBuiltin:
-			ty, md := arrowTypeFromColumnRef(columnExpr.Ref)
-			addField(arrow.Field{
-				Name:     columnExpr.Ref.Column,
-				Type:     ty,
-				Nullable: true,
-				Metadata: md,
-			})
-
-		case types.ColumnTypeAmbiguous:
-			// The best handling for ambiguous columns (in terms of the schema) is to
-			// explode it out into multiple columns, one for each type. (Except for
-			// parsed, which can't be emitted from DataObjScan right now).
-			//
-			// TODO(rfratto): should ambiguity be passed down like this? It's odd for
-			// the returned schema to be different than the set of columns you asked
-			// for.
-			//
-			// As an alternative, ambiguity could be handled by the planner, where it
-			// performs the explosion and propagates the ambiguity down into the
-			// predicates.
-			//
-			// If we're ok with the schema changing from what was requested, then we
-			// could update this to resolve the ambiguity at [dataobjScan.effectiveProjections]
-			// so we don't always explode out to the full set of columns.
-			addField(arrow.Field{
-				Name:     columnExpr.Ref.Column,
-				Type:     datatype.Arrow.String,
-				Nullable: true,
-				Metadata: datatype.ColumnMetadata(types.ColumnTypeLabel, datatype.Loki.String),
-			})
-			addField(arrow.Field{
-				Name:     columnExpr.Ref.Column,
-				Type:     datatype.Arrow.String,
-				Nullable: true,
-				Metadata: datatype.ColumnMetadata(types.ColumnTypeMetadata, datatype.Loki.String),
-			})
-
-		case types.ColumnTypeParsed, types.ColumnTypeGenerated:
-			return nil, fmt.Errorf("parsed column type not supported: %s", columnExpr.Ref.Type)
+			if col.Name == expr.Ref.Column {
+				found = append(found, col)
+				break
+			}
 		}
 	}
 
-	return arrow.NewSchema(fields, nil), nil
+	return found
 }
 
-func arrowTypeFromColumnRef(ref types.ColumnRef) (arrow.DataType, arrow.Metadata) {
-	if ref.Type == types.ColumnTypeBuiltin {
-		switch ref.Column {
-		case types.ColumnNameBuiltinTimestamp:
-			return arrow.FixedWidthTypes.Timestamp_ns, datatype.ColumnMetadataBuiltinTimestamp
-		case types.ColumnNameBuiltinMessage:
-			return arrow.BinaryTypes.String, datatype.ColumnMetadataBuiltinMessage
-		default:
-			panic(fmt.Sprintf("unsupported builtin column type %s", ref))
+func (s *dataobjScan) initLogs() error {
+	if s.opts.LogsSection == nil {
+		return fmt.Errorf("no logs section provided")
+	}
+
+	predicates := s.opts.Predicates
+
+	var columnsToRead []*logs.Column
+
+	if s.streams != nil || len(s.opts.StreamIDs) > 0 {
+		// We're reading sreams, so we need to include the stream ID column.
+		var streamIDColumn *logs.Column
+
+		for _, col := range s.opts.LogsSection.Columns() {
+			if col.Type == logs.ColumnTypeStreamID {
+				streamIDColumn = col
+				columnsToRead = append(columnsToRead, streamIDColumn)
+				break
+			}
+		}
+
+		if streamIDColumn == nil {
+			return fmt.Errorf("logs section does not contain stream ID column")
+		}
+
+		if len(s.opts.StreamIDs) > 0 {
+			predicates = append([]logs.Predicate{
+				logs.InPredicate{
+					Column: streamIDColumn,
+					Values: makeScalars(s.opts.StreamIDs),
+				},
+			}, predicates...)
 		}
 	}
 
-	return datatype.Arrow.String, datatype.ColumnMetadata(ref.Type, datatype.Loki.String)
-}
+	columnsToRead = append(columnsToRead, projectedLogsColumns(s.opts.LogsSection, s.opts.Projections)...)
 
-// appendToBuilder appends a the provided field from record into the given
-// builder. The metadata of field is used to determine the category of column.
-// appendToBuilder panics if the type of field does not match the datatype of
-// builder.
-func (s *dataobjScan) appendToBuilder(builder array.Builder, field *arrow.Field, record *logs.Record) {
-	columnType, ok := field.Metadata.GetValue(types.MetadataKeyColumnType)
-	if !ok {
-		// This shouldn't happen; we control the metadata here on the fields.
-		panic(fmt.Sprintf("missing column type in field %s", field.Name))
+	s.reader = logs.NewReader(logs.ReaderOptions{
+		// TODO(rfratto): is it possible to hit an edge case where len(columnsToRead)
+		// == 0, indicating that we don't need to read any logs at all? How should we
+		// handle that?
+		Columns: columnsToRead,
+
+		Predicates:    predicates,
+		Allocator:     s.opts.Allocator,
+		PageCacheSize: s.opts.CacheSize,
+	})
+
+	// Create the engine-compatible expected schema for the logs section.
+	origSchema := s.reader.Schema()
+	if got, want := origSchema.NumFields(), len(columnsToRead); got != want {
+		return fmt.Errorf("logs.Reader returned schema with %d fields, expected %d", got, want)
 	}
 
-	switch columnType {
-	case types.ColumnTypeLabel.String():
-		stream, ok := s.streams[record.StreamID]
+	var desiredFields []arrow.Field
+	for i, col := range columnsToRead {
+		if col.Type == logs.ColumnTypeStreamID {
+			// The stream ID field should be left as-is for use with the streams
+			// injector.
+			desiredFields = append(desiredFields, origSchema.Field(i))
+			continue
+		}
+
+		// Convert the logs column to an engine-compatible field.
+		field, err := logsColumnToEngineField(col)
+		if err != nil {
+			return err
+		}
+		desiredFields = append(desiredFields, field)
+	}
+
+	s.desiredSchema = arrow.NewSchema(desiredFields, nil)
+	return nil
+}
+
+func makeScalars[S ~[]E, E any](s S) []scalar.Scalar {
+	scalars := make([]scalar.Scalar, len(s))
+	for i, v := range s {
+		scalars[i] = scalar.MakeScalar(v)
+	}
+	return scalars
+}
+
+// logsColumnToEngineField gets the engine-compatible [arrow.Field] for the
+// given [logs.Column]. Returns an error if the column is not expected by the
+// engine.
+func logsColumnToEngineField(col *logs.Column) (arrow.Field, error) {
+	switch col.Type {
+	case logs.ColumnTypeTimestamp:
+		return arrow.Field{
+			Name:     types.ColumnNameBuiltinTimestamp,
+			Type:     datatype.Arrow.Timestamp,
+			Nullable: true,
+			Metadata: datatype.ColumnMetadata(types.ColumnTypeBuiltin, datatype.Loki.Timestamp),
+		}, nil
+
+	case logs.ColumnTypeMessage:
+		return arrow.Field{
+			Name:     types.ColumnNameBuiltinMessage,
+			Type:     datatype.Arrow.String,
+			Nullable: true,
+			Metadata: datatype.ColumnMetadata(types.ColumnTypeBuiltin, datatype.Loki.String),
+		}, nil
+
+	case logs.ColumnTypeMetadata:
+		return arrow.Field{
+			Name:     col.Name,
+			Type:     datatype.Arrow.String,
+			Nullable: true,
+			Metadata: datatype.ColumnMetadata(types.ColumnTypeMetadata, datatype.Loki.String),
+		}, nil
+	}
+
+	return arrow.Field{}, fmt.Errorf("unsupported logs column type %s", col.Type)
+}
+
+var logsColumnPrecedence = map[logs.ColumnType]int{
+	logs.ColumnTypeInvalid:   0,
+	logs.ColumnTypeStreamID:  1,
+	logs.ColumnTypeMetadata:  2,
+	logs.ColumnTypeTimestamp: 3,
+	logs.ColumnTypeMessage:   4,
+}
+
+// projectedLogsColumns returns the section columns to read from the given logs
+// section for the provided list of projections. If projections is empty, all
+// section columns are returned (except for stream ID).
+//
+// References to columns in projections that do not exist in the section are
+// ignored. If no projections reference any known column in the logs section,
+// projectedLogsColumns returns nil.
+//
+// projectedLogsColumns never includes the stream ID column in its results, as
+// projections can never reference a stream ID column.
+func projectedLogsColumns(sec *logs.Section, projections []physical.ColumnExpression) []*logs.Column {
+	var found []*logs.Column
+
+	defer func() {
+		// Use consistent sort order for columns. While at some point we may wish
+		// to have a consistent order based on projections, that would need to be
+		// handled at read time after we inject stream labels.
+		slices.SortFunc(found, func(a, b *logs.Column) int {
+			if a.Type != b.Type {
+				// Sort by type precedence.
+				return cmp.Compare(logsColumnPrecedence[a.Type], logsColumnPrecedence[b.Type])
+			}
+			return cmp.Compare(a.Name, b.Name)
+		})
+	}()
+
+	// Special case: if projections is empty, we return all columns. While
+	// [logs.Reader] accepts a nil list to mean "all columns," we reserve nil
+	// here to mean "we're not projecting any columns at all."
+	if len(projections) == 0 {
+		for _, col := range sec.Columns() {
+			if col.Type == logs.ColumnTypeStreamID {
+				continue
+			}
+			found = append(found, col)
+		}
+
+		return found
+	}
+
+	// Inefficient search. Will we have enough columns + projections such that
+	// this needs to be optimized?
+NextProjection:
+	for _, projection := range projections {
+		expr, ok := projection.(*physical.ColumnExpr)
 		if !ok {
-			panic(fmt.Sprintf("stream ID %d not found in stream cache", record.StreamID))
+			panic("invalid projection type, expected *physical.ColumnExpr")
 		}
 
-		val := stream.Get(field.Name)
-		if val == "" {
-			builder.(*array.StringBuilder).AppendNull()
-		} else {
-			builder.(*array.StringBuilder).Append(val)
+		// Ignore columns that cannot exist in the logs section.
+		switch expr.Ref.Type {
+		case types.ColumnTypeLabel, types.ColumnTypeParsed, types.ColumnTypeGenerated:
+			continue NextProjection
 		}
 
-	case types.ColumnTypeMetadata.String():
-		val := record.Metadata.Get(field.Name)
-		if val == "" {
-			builder.(*array.StringBuilder).AppendNull()
-		} else {
-			builder.(*array.StringBuilder).Append(val)
-		}
+		for _, col := range sec.Columns() {
+			switch {
+			case expr.Ref.Type == types.ColumnTypeBuiltin && expr.Ref.Column == types.ColumnNameBuiltinTimestamp && col.Type == logs.ColumnTypeTimestamp:
+				found = append(found, col)
+				continue NextProjection
 
-	case types.ColumnTypeBuiltin.String():
-		if field.Name == types.ColumnNameBuiltinTimestamp {
-			ts, _ := arrow.TimestampFromTime(record.Timestamp, arrow.Nanosecond)
-			builder.(*array.TimestampBuilder).Append(ts)
-		} else if field.Name == types.ColumnNameBuiltinMessage {
-			// Use the inner BinaryBuilder to avoid converting record.Line to a
-			// string and back.
-			builder.(*array.StringBuilder).BinaryBuilder.Append(record.Line)
-		} else {
-			panic(fmt.Sprintf("unsupported builtin column %s", field.Name))
-		}
+			case expr.Ref.Type == types.ColumnTypeBuiltin && expr.Ref.Column == types.ColumnNameBuiltinMessage && col.Type == logs.ColumnTypeMessage:
+				found = append(found, col)
+				continue NextProjection
 
-	default:
-		// This shouldn't happen; we control the metadata here on the fields.
-		panic(fmt.Sprintf("unsupported column type %s", columnType))
+			case expr.Ref.Type == types.ColumnTypeMetadata && col.Type == logs.ColumnTypeMetadata && col.Name == expr.Ref.Column:
+				found = append(found, col)
+				continue NextProjection
+
+			case expr.Ref.Type == types.ColumnTypeAmbiguous && col.Type == logs.ColumnTypeMetadata && col.Name == expr.Ref.Column:
+				found = append(found, col)
+				continue NextProjection
+			}
+		}
 	}
+
+	return found
+}
+
+// read reads the entire section into memory and generates an [arrow.Record]
+// from the data. It returns an error if reading a section resulted in an
+// error.
+func (s *dataobjScan) read(ctx context.Context) (arrow.Record, error) {
+	rec, err := s.reader.Read(ctx, int(s.opts.BatchSize))
+	if err != nil && !errors.Is(err, io.EOF) {
+		return nil, err
+	} else if (rec == nil || rec.NumRows() == 0) && errors.Is(err, io.EOF) {
+		return nil, EOF
+	}
+	defer rec.Release()
+
+	// Update the schema of the record to match the schema the engine expects.
+	rec, err = changeSchema(rec, s.desiredSchema)
+	if err != nil {
+		return nil, fmt.Errorf("changing schema: %w", err)
+	}
+	defer rec.Release()
+
+	if s.streamsInjector == nil {
+		// No streams injector needed, so we return the record as-is.
+		// We add an extra retain to counteract the Release() call above (for ease
+		// of readability).
+		rec.Retain()
+		return rec, nil
+	}
+
+	return s.streamsInjector.Inject(ctx, rec)
 }
 
 // Value returns the current [arrow.Record] retrieved by the previous call to
@@ -552,14 +407,24 @@ func (s *dataobjScan) Value() (arrow.Record, error) { return s.state.batch, s.st
 
 // Close closes s and releases all resources.
 func (s *dataobjScan) Close() {
+	if s.streams != nil {
+		s.streams.Close()
+	}
 	if s.reader != nil {
 		_ = s.reader.Close()
 	}
+
+	s.initialized = false
+	s.streams = nil
+	s.streamsInjector = nil
+	s.reader = nil
+
+	s.state = state{}
 }
 
-// Inputs implements Pipeline and returns nil, since DataObjScan accepts no
+// Inputs implements [Pipeline] and returns nil, since dataobjScan accepts no
 // pipelines as input.
 func (s *dataobjScan) Inputs() []Pipeline { return nil }
 
-// Transport implements Pipeline and returns [Local].
+// Transport implements [Pipeline] and returns [Local].
 func (s *dataobjScan) Transport() Transport { return Local }

--- a/pkg/engine/executor/dataobjscan_predicate.go
+++ b/pkg/engine/executor/dataobjscan_predicate.go
@@ -3,9 +3,11 @@ package executor
 import (
 	"bytes"
 	"fmt"
-	"math"
 	"regexp"
-	"time"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/apache/arrow-go/v18/arrow/scalar"
 
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/logs"
 	"github.com/grafana/loki/v3/pkg/engine/internal/datatype"
@@ -13,507 +15,360 @@ import (
 	"github.com/grafana/loki/v3/pkg/engine/planner/physical"
 )
 
-var matchAllFilter = logs.LogMessageFilterRowPredicate{
-	Keep: func(_ []byte) bool { return true },
-}
+// buildLogsPredicate builds a [logs.Predicate] from an expr. The columns slice
+// determines available columns that can be referenced by the expression.
+//
+// The returned predicate performs no filtering on stream ID; callers must use
+// [logs.AndPredicate] and manually include filters for stream IDs if desired.
+//
+// References to columns that do not exist in the columns slice map to a
+// [logs.FalsePredicate].
+//
+// buildLogsPredicate returns an error if:
+//
+//   - Expressions cannot be represented as a boolean value
+//   - An expression is not supported (such as comparing two columns or comparing
+//     two literals).
+func buildLogsPredicate(expr physical.Expression, columns []*logs.Column) (logs.Predicate, error) {
+	switch expr := expr.(type) {
+	case physical.UnaryExpression:
+		return buildLogsUnaryPredicate(expr, columns)
 
-// buildLogsRowPredicate builds a [logs.RowPredicate] from an expression.
-func buildLogsRowPredicate(expr physical.Expression) (logs.RowPredicate, error) {
-	// TODO(rfratto): implement converting expressions into logs predicates.
-	//
-	// There's a few challenges here:
-	//
-	// - Expressions do not cleanly map to [logs.RowPredicate]s. For example,
-	//   an expression may be simply a column reference, but a logs predicate is
-	//   always some expression that can evaluate to true.
-	//
-	// - Mapping expressions into [dataobj.TimeRangePredicate] is a massive pain;
-	//   since TimeRangePredicate specifies both bounds for the time range, we
-	//   would need to find and collapse multiple physical.Expressions into a
-	//   single TimeRangePredicate.
-	//
-	// - While [dataobj.MetadataMatcherPredicate] and
-	//   [dataobj.LogMessageFilterPredicate] are catch-alls for function-based
-	//   predicates, they are row-based and not column-based, so our
-	//   expressionEvaluator cannot be used here.
-	//
-	// Long term, we likely want two things:
-	//
-	// 1. Use dataset.Reader and dataset.Predicate directly instead of
-	//    dataobj.LogsReader.
-	//
-	// 2. Update dataset.Reader to be vector based instead of row-based.
-	//
-	// It's not clear if we should resolve the issues with LogsPredicate (or find
-	// hacks to make them work in the short term), or skip straight to using
-	// dataset.Reader instead.
-	//
-	// Implementing DataObjScan in the dataobj package would be a clean way to
-	// handle all of this, but that would cause cyclic dependencies. I also don't
-	// think we should start removing things from internal for this; we can probably
-	// find a way to remove the explicit dependency from the dataobj package from
-	// the physical planner instead.
-	return mapInitiallySupportedRowPredicates(expr)
-}
+	case physical.BinaryExpression:
+		return buildLogsBinaryPredicate(expr, columns)
 
-// Support for timestamp and metadata predicates has been implemented.
-// TODO(owen-d): this can go away when we use dataset.Reader & dataset.Predicate directly
-func mapInitiallySupportedRowPredicates(expr physical.Expression) (logs.RowPredicate, error) {
-	return mapRowPredicates(expr)
-}
-
-func mapRowPredicates(expr physical.Expression) (logs.RowPredicate, error) {
-	switch e := expr.(type) {
-	case *physical.BinaryExpr:
-
-		// Special case: both sides of the binary op are again binary expressions (where LHS is expected to be a column expression)
-		if e.Left.Type() == physical.ExprTypeBinary && e.Right.Type() == physical.ExprTypeBinary {
-			left, err := mapRowPredicates(e.Left)
-			if err != nil {
-				return nil, err
+	case *physical.LiteralExpr:
+		if expr.Literal.Type() == datatype.Loki.Bool {
+			val := expr.Literal.(datatype.TypedLiteral[bool]).Value()
+			if val {
+				return logs.TruePredicate{}, nil
 			}
-			right, err := mapRowPredicates(e.Right)
-			if err != nil {
-				return nil, err
-			}
-			switch e.Op {
-			case types.BinaryOpAnd:
-				return logs.AndRowPredicate{
-					Left:  left,
-					Right: right,
-				}, nil
-			case types.BinaryOpOr:
-				return logs.OrRowPredicate{
-					Left:  left,
-					Right: right,
-				}, nil
-			default:
-				return nil, fmt.Errorf("unsupported operator in predicate: %s", e.Op)
-			}
+			return logs.FalsePredicate{}, nil
 		}
 
-		if e.Left.Type() != physical.ExprTypeColumn {
-			return nil, fmt.Errorf("unsupported predicate, expected column ref on LHS: %s", expr.String())
-		}
+	case *physical.ColumnExpr:
+		// TODO(rfratto): This would add support for statements like
+		//
+		// SELECT * WHERE boolean_column
+		//
+		// (where boolean_column is a column containing boolean values). No such
+		// column type exists now, so I'm leaving it unsupported here for the time
+		// being.
+		return nil, fmt.Errorf("plain column references (%s) are unsupported for logs predicates", expr)
 
-		left := e.Left.(*physical.ColumnExpr)
-		switch left.Ref.Type {
-		case types.ColumnTypeBuiltin:
-			if left.Ref.Column == types.ColumnNameBuiltinTimestamp {
-				return mapTimestampRowPredicate(e)
-			}
-			if left.Ref.Column == types.ColumnNameBuiltinMessage {
-				return mapMessageRowPredicate(e)
-			}
-			return nil, fmt.Errorf("unsupported builtin column in predicate (only timestamp is supported for now): %s", left.Ref.Column)
-		case types.ColumnTypeMetadata:
-			return mapMetadataRowPredicate(e)
-		default:
-			return nil, fmt.Errorf("unsupported column ref type (%T) in predicate: %s", left.Ref, left.Ref.String())
-		}
 	default:
-		return nil, fmt.Errorf("unsupported expression type (%T) in predicate: %s", expr, expr.String())
+		// TODO(rfratto): This doesn't yet cover two potential future cases:
+		//
+		// * A plain boolean literal
+		// * A reference to a column containing boolean values
+		return nil, fmt.Errorf("expression %[1]s (type %[1]T) cannot be interpreted as a boolean", expr)
 	}
+
+	return nil, fmt.Errorf("expression %[1]s (type %[1]T) cannot be interpreted as a boolean", expr)
 }
 
-func mapTimestampRowPredicate(expr physical.Expression) (logs.TimeRangeRowPredicate, error) {
-	m := newTimestampRowPredicateMapper()
-	if err := m.verify(expr); err != nil {
-		return logs.TimeRangeRowPredicate{}, err
-	}
-
-	if err := m.processExpr(expr); err != nil {
-		return logs.TimeRangeRowPredicate{}, err
-	}
-
-	// Check for impossible ranges that might have been formed.
-	if m.res.StartTime.After(m.res.EndTime) {
-		return logs.TimeRangeRowPredicate{},
-			fmt.Errorf("impossible time range: start_time (%v) is after end_time (%v)", m.res.StartTime, m.res.EndTime)
-	}
-	if m.res.StartTime.Equal(m.res.EndTime) && (!m.res.IncludeStart || !m.res.IncludeEnd) {
-		return logs.TimeRangeRowPredicate{},
-			fmt.Errorf("impossible time range: start_time (%v) equals end_time (%v) but the range is exclusive", m.res.StartTime, m.res.EndTime)
-	}
-
-	return m.res, nil
-}
-
-func newTimestampRowPredicateMapper() *timestampRowPredicateMapper {
-	open := logs.TimeRangeRowPredicate{
-		StartTime:    time.Unix(0, math.MinInt64).UTC(),
-		EndTime:      time.Unix(0, math.MaxInt64).UTC(),
-		IncludeStart: true,
-		IncludeEnd:   true,
-	}
-	return &timestampRowPredicateMapper{
-		res: open,
-	}
-}
-
-type timestampRowPredicateMapper struct {
-	res logs.TimeRangeRowPredicate
-}
-
-// ensures the LHS is a timestamp column reference
-// and the RHS is either a literal or a binary expression
-func (m *timestampRowPredicateMapper) verify(expr physical.Expression) error {
-	binop, ok := expr.(*physical.BinaryExpr)
+func buildLogsUnaryPredicate(expr physical.UnaryExpression, columns []*logs.Column) (logs.Predicate, error) {
+	unaryExpr, ok := expr.(*physical.UnaryExpr)
 	if !ok {
-		return fmt.Errorf("unsupported expression type for timestamp predicate: %T, expected *physical.BinaryExpr", expr)
+		return nil, fmt.Errorf("expected physical.UnaryExpr, got %[1]T", expr)
 	}
 
-	switch binop.Op {
-	case types.BinaryOpEq, types.BinaryOpGt, types.BinaryOpGte, types.BinaryOpLt, types.BinaryOpLte:
-		lhs, okLHS := binop.Left.(*physical.ColumnExpr)
-		if !okLHS || lhs.Ref.Type != types.ColumnTypeBuiltin || lhs.Ref.Column != types.ColumnNameBuiltinTimestamp {
-			return fmt.Errorf("invalid LHS for comparison: expected timestamp column, got %s", binop.Left.String())
-		}
-
-		// RHS must be a literal timestamp for simple comparisons.
-		rhsLit, okRHS := binop.Right.(*physical.LiteralExpr)
-		if !okRHS {
-			return fmt.Errorf("invalid RHS for comparison: expected literal timestamp, got %T", binop.Right)
-		}
-		if rhsLit.ValueType() != datatype.Loki.Timestamp {
-			return fmt.Errorf("unsupported literal type for RHS: %s, expected timestamp", rhsLit.ValueType())
-		}
-		return nil
-
-	case types.BinaryOpAnd:
-		if err := m.verify(binop.Left); err != nil {
-			return fmt.Errorf("invalid left operand for AND: %w", err)
-		}
-		if err := m.verify(binop.Right); err != nil {
-			return fmt.Errorf("invalid right operand for AND: %w", err)
-		}
-		return nil
-
-	default:
-		return fmt.Errorf("unsupported operator for timestamp predicate: %s", binop.Op)
+	inner, err := buildLogsPredicate(unaryExpr.Left, columns)
+	if err != nil {
+		return nil, fmt.Errorf("building unary predicate: %w", err)
 	}
+
+	switch unaryExpr.Op {
+	case types.UnaryOpNot:
+		return logs.NotPredicate{Inner: inner}, nil
+	}
+
+	return nil, fmt.Errorf("unsupported unary operator %s in logs predicate", unaryExpr.Op)
 }
 
-// processExpr recursively processes the expression tree to update the time range.
-func (m *timestampRowPredicateMapper) processExpr(expr physical.Expression) error {
-	// verify should have already ensured expr is *physical.BinaryExpr
-	binExp := expr.(*physical.BinaryExpr)
-
-	switch binExp.Op {
-	case types.BinaryOpAnd:
-		if err := m.processExpr(binExp.Left); err != nil {
-			return err
-		}
-		return m.processExpr(binExp.Right)
-	case types.BinaryOpEq, types.BinaryOpGt, types.BinaryOpGte, types.BinaryOpLt, types.BinaryOpLte:
-		// This is a comparison operation, rebound m.res
-		// The 'right' here is binExp.Right, which could be a literal or a nested BinaryExpr.
-		// rebound will extract the actual literal value.
-		return m.rebound(binExp.Op, binExp.Right)
-	default:
-		// This case should ideally not be reached if verify is correct.
-		return fmt.Errorf("unexpected operator in processExpr: %s", binExp.Op)
-	}
+var comparisonBinaryOps = map[types.BinaryOp]struct{}{
+	types.BinaryOpEq:              {},
+	types.BinaryOpNeq:             {},
+	types.BinaryOpGt:              {},
+	types.BinaryOpGte:             {},
+	types.BinaryOpLt:              {},
+	types.BinaryOpLte:             {},
+	types.BinaryOpMatchSubstr:     {},
+	types.BinaryOpNotMatchSubstr:  {},
+	types.BinaryOpMatchRe:         {},
+	types.BinaryOpNotMatchRe:      {},
+	types.BinaryOpMatchPattern:    {},
+	types.BinaryOpNotMatchPattern: {},
 }
 
-// rebound updates the time range (m.res) based on a single comparison operation.
-// The `op` is the comparison operator (e.g., Gt, Lte).
-// The `rightExpr` is the RHS of the comparison, which might be a literal
-// or a nested binary expression (e.g., `timestamp > (timestamp = X)`).
-// This function will traverse `rightExpr` to find the innermost literal value.
-func (m *timestampRowPredicateMapper) rebound(op types.BinaryOp, rightExpr physical.Expression) error {
-	// `verify` (called by processExpr before this) now ensures that for comparison ops,
-	// the original expression's RHS was a literal, or if it was an AND, its constituent parts were.
-	// `processExpr` will pass the direct LiteralExpr from a comparison to rebound.
-	literalExpr, ok := rightExpr.(*physical.LiteralExpr)
+func buildLogsBinaryPredicate(expr physical.BinaryExpression, columns []*logs.Column) (logs.Predicate, error) {
+	binaryExpr, ok := expr.(*physical.BinaryExpr)
 	if !ok {
-		// This should not happen if verify and processExpr are correct.
-		return fmt.Errorf("internal error: rebound expected LiteralExpr, got %T for: %s", rightExpr, rightExpr.String())
+		return nil, fmt.Errorf("expected physical.BinaryExpr, got %[1]T", expr)
 	}
 
-	if literalExpr.ValueType() != datatype.Loki.Timestamp {
-		// Also should be caught by verify.
-		return fmt.Errorf("internal error: unsupported literal type in rebound: %s, expected timestamp", literalExpr.ValueType())
-	}
-	v := literalExpr.Literal.(datatype.TimestampLiteral).Value()
-	val := time.Unix(0, int64(v)).UTC()
-
-	switch op {
-	case types.BinaryOpEq: // ts == val
-		m.updateLowerBound(val, true)
-		m.updateUpperBound(val, true)
-	case types.BinaryOpGt: // ts > val
-		m.updateLowerBound(val, false)
-	case types.BinaryOpGte: // ts >= val
-		m.updateLowerBound(val, true)
-	case types.BinaryOpLt: // ts < val
-		m.updateUpperBound(val, false)
-	case types.BinaryOpLte: // ts <= val
-		m.updateUpperBound(val, true)
-	default:
-		// Should not be reached if processExpr filters operators correctly.
-		return fmt.Errorf("unsupported operator in rebound: %s", op)
-	}
-	return nil
-}
-
-// updateLowerBound updates the start of the time range (m.res.StartTime, m.res.IncludeStart).
-// `val` is the new potential start time from the condition.
-// `includeVal` indicates if this new start time is inclusive (e.g., from '>=' or '==').
-func (m *timestampRowPredicateMapper) updateLowerBound(val time.Time, includeVal bool) {
-	if val.After(m.res.StartTime) {
-		// The new value is strictly greater than the current start, so it becomes the new start.
-		m.res.StartTime = val
-		m.res.IncludeStart = includeVal
-	} else if val.Equal(m.res.StartTime) {
-		// The new value is equal to the current start.
-		// The range becomes more restrictive if the current start was exclusive and the new one is also exclusive or inclusive.
-		// Or if the current was inclusive and the new one is exclusive.
-		// Effectively, IncludeStart becomes true only if *both* the existing and new condition allow/imply inclusion.
-		// No, this should be: if new condition makes it more restrictive (i.e. current is [T and new is (T ), then new is (T )
-		// m.res.IncludeStart = m.res.IncludeStart && includeVal (This is for intersection: [a,b] AND (a,c] -> (a, min(b,c)] )
-		// m.res.IncludeStart = m.res.IncludeStart && includeVal
-		if !includeVal { // if new bound is exclusive (e.g. from `> val`)
-			m.res.IncludeStart = false // existing [val,... or (val,... combined with (> val) becomes (val,...
-		}
-		// If includeVal is true (e.g. from `>= val`), and m.res.IncludeStart was already true, it stays true.
-		// If includeVal is true, and m.res.IncludeStart was false, it stays false ( (val,...) AND [val,...] is (val,...) )
-		// This logic is subtle. Let's restate:
-		// Current Start: S, Is       (m.res.StartTime, m.res.IncludeStart)
-		// New Condition: val, includeVal
-		// if val > S: new start is val, includeVal
-		// if val == S: new start is val. IncludeStart becomes m.res.IncludeStart AND includeVal.
-		//    Example: current (S, ...), new condition S >= S. Combined: (S, ...). So if m.res.IncludeStart=false, new includeVal=true -> false.
-		//    Example: current [S, ...), new condition S > S. Combined: (S, ...). So if m.res.IncludeStart=true, new includeVal=false -> false.
-		//    This is correct for intersection.
-		m.res.IncludeStart = m.res.IncludeStart && includeVal
-	}
-	// If val is before m.res.StartTime, the current StartTime is already more restrictive, so no change.
-}
-
-// updateUpperBound updates the end of the time range (m.res.EndTime, m.res.IncludeEnd).
-// `val` is the new potential end time from the condition.
-// `includeVal` indicates if this new end time is inclusive (e.g., from '<=' or '==').
-func (m *timestampRowPredicateMapper) updateUpperBound(val time.Time, includeVal bool) {
-	if val.Before(m.res.EndTime) {
-		// The new value is strictly less than the current end, so it becomes the new end.
-		m.res.EndTime = val
-		m.res.IncludeEnd = includeVal
-	} else if val.Equal(m.res.EndTime) {
-		// The new value is equal to the current end.
-		// Similar to updateLowerBound, the inclusiveness is an AND condition.
-		// Example: current (..., S), new condition ts <= S. Combined: (..., S). m.res.IncludeEnd=false, includeVal=true -> false.
-		// Example: current (..., S], new condition ts < S. Combined: (..., S). m.res.IncludeEnd=true, includeVal=false -> false.
-		m.res.IncludeEnd = m.res.IncludeEnd && includeVal
-	}
-	// If val is after m.res.EndTime, the current EndTime is already more restrictive, so no change.
-}
-
-// mapMetadataRowPredicate converts a physical.Expression into a dataobj.Predicate for metadata filtering.
-// It supports MetadataMatcherPredicate for equality checks on metadata fields,
-// and can recursively handle AndPredicate, OrPredicate, and NotPredicate.
-func mapMetadataRowPredicate(expr physical.Expression) (logs.RowPredicate, error) {
-	switch e := expr.(type) {
-	case *physical.BinaryExpr:
-		switch e.Op {
-		case types.BinaryOpEq:
-			if e.Left.Type() != physical.ExprTypeColumn {
-				return nil, fmt.Errorf("unsupported LHS type (%v) for EQ metadata predicate, expected ColumnExpr", e.Left.Type())
-			}
-			leftColumn, ok := e.Left.(*physical.ColumnExpr)
-			if !ok { // Should not happen due to Type() check but defensive
-				return nil, fmt.Errorf("LHS of EQ metadata predicate failed to cast to ColumnExpr")
-			}
-			if leftColumn.Ref.Type != types.ColumnTypeMetadata {
-				return nil, fmt.Errorf("unsupported LHS column type (%v) for EQ metadata predicate, expected ColumnTypeMetadata", leftColumn.Ref.Type)
-			}
-
-			if e.Right.Type() != physical.ExprTypeLiteral {
-				return nil, fmt.Errorf("unsupported RHS type (%v) for EQ metadata predicate, expected LiteralExpr", e.Right.Type())
-			}
-			rightLiteral, ok := e.Right.(*physical.LiteralExpr)
-			if !ok { // Should not happen
-				return nil, fmt.Errorf("RHS of EQ metadata predicate failed to cast to LiteralExpr")
-			}
-			if rightLiteral.ValueType() != datatype.Loki.String {
-				return nil, fmt.Errorf("unsupported RHS literal type (%v) for EQ metadata predicate, expected ValueTypeStr", rightLiteral.ValueType())
-			}
-			val := rightLiteral.Literal.(datatype.StringLiteral).Value()
-
-			return logs.MetadataMatcherRowPredicate{
-				Key:   leftColumn.Ref.Column,
-				Value: val,
-			}, nil
-		case types.BinaryOpAnd:
-			leftPredicate, err := mapMetadataRowPredicate(e.Left)
-			if err != nil {
-				return nil, fmt.Errorf("failed to map left operand of AND: %w", err)
-			}
-			rightPredicate, err := mapMetadataRowPredicate(e.Right)
-			if err != nil {
-				return nil, fmt.Errorf("failed to map right operand of AND: %w", err)
-			}
-			return logs.AndRowPredicate{
-				Left:  leftPredicate,
-				Right: rightPredicate,
-			}, nil
-		case types.BinaryOpOr:
-			leftPredicate, err := mapMetadataRowPredicate(e.Left)
-			if err != nil {
-				return nil, fmt.Errorf("failed to map left operand of OR: %w", err)
-			}
-			rightPredicate, err := mapMetadataRowPredicate(e.Right)
-			if err != nil {
-				return nil, fmt.Errorf("failed to map right operand of OR: %w", err)
-			}
-			return logs.OrRowPredicate{
-				Left:  leftPredicate,
-				Right: rightPredicate,
-			}, nil
-		default:
-			return nil, fmt.Errorf("unsupported binary operator (%s) for metadata predicate, expected EQ, AND, or OR", e.Op)
-		}
-	case *physical.UnaryExpr:
-		if e.Op != types.UnaryOpNot {
-			return nil, fmt.Errorf("unsupported unary operator (%s) for metadata predicate, expected NOT", e.Op)
-		}
-		innerPredicate, err := mapMetadataRowPredicate(e.Left)
+	switch binaryExpr.Op {
+	case types.BinaryOpAnd:
+		left, err := buildLogsPredicate(binaryExpr.Left, columns)
 		if err != nil {
-			return nil, fmt.Errorf("failed to map inner expression of NOT: %w", err)
+			return nil, fmt.Errorf("building left binary predicate: %w", err)
 		}
-		return logs.NotRowPredicate{
-			Inner: innerPredicate,
-		}, nil
-	default:
-		return nil, fmt.Errorf("unsupported expression type (%T) for metadata predicate, expected BinaryExpr or UnaryExpr", expr)
-	}
-}
-
-func mapMessageRowPredicate(expr physical.Expression) (logs.RowPredicate, error) {
-	switch e := expr.(type) {
-	case *physical.BinaryExpr:
-		switch e.Op {
-
-		case types.BinaryOpMatchSubstr, types.BinaryOpNotMatchSubstr, types.BinaryOpMatchRe, types.BinaryOpNotMatchRe:
-			return matchRow(e)
-
-		case types.BinaryOpMatchPattern, types.BinaryOpNotMatchPattern:
-			return nil, fmt.Errorf("unsupported binary operator (%s) for log message predicate", e.Op)
-
-		case types.BinaryOpAnd:
-			leftPredicate, err := mapMessageRowPredicate(e.Left)
-			if err != nil {
-				return nil, fmt.Errorf("failed to map left operand of AND: %w", err)
-			}
-			rightPredicate, err := mapMessageRowPredicate(e.Right)
-			if err != nil {
-				return nil, fmt.Errorf("failed to map right operand of AND: %w", err)
-			}
-			return logs.AndRowPredicate{
-				Left:  leftPredicate,
-				Right: rightPredicate,
-			}, nil
-
-		case types.BinaryOpOr:
-			leftPredicate, err := mapMessageRowPredicate(e.Left)
-			if err != nil {
-				return nil, fmt.Errorf("failed to map left operand of OR: %w", err)
-			}
-			rightPredicate, err := mapMessageRowPredicate(e.Right)
-			if err != nil {
-				return nil, fmt.Errorf("failed to map right operand of OR: %w", err)
-			}
-			return logs.OrRowPredicate{
-				Left:  leftPredicate,
-				Right: rightPredicate,
-			}, nil
-
-		default:
-			return nil, fmt.Errorf("unsupported binary operator (%s) for log message predicate, expected MATCH_STR, NOT_MATCH_STR, MATCH_RE, NOT_MATCH_RE, AND, or OR", e.Op)
-		}
-
-	case *physical.UnaryExpr:
-		if e.Op != types.UnaryOpNot {
-			return nil, fmt.Errorf("unsupported unary operator (%s) for log message predicate, expected NOT", e.Op)
-		}
-		innerPredicate, err := mapMessageRowPredicate(e.Left)
+		right, err := buildLogsPredicate(binaryExpr.Right, columns)
 		if err != nil {
-			return nil, fmt.Errorf("failed to map inner expression of NOT: %w", err)
+			return nil, fmt.Errorf("building right binary predicate: %w", err)
 		}
-		return logs.NotRowPredicate{
-			Inner: innerPredicate,
-		}, nil
+		return logs.AndPredicate{Left: left, Right: right}, nil
 
-	default:
-		return nil, fmt.Errorf("unsupported expression type (%T) for log message predicate, expected BinaryExpr or UnaryExpr", expr)
+	case types.BinaryOpOr:
+		left, err := buildLogsPredicate(binaryExpr.Left, columns)
+		if err != nil {
+			return nil, fmt.Errorf("building left binary predicate: %w", err)
+		}
+		right, err := buildLogsPredicate(binaryExpr.Right, columns)
+		if err != nil {
+			return nil, fmt.Errorf("building right binary predicate: %w", err)
+		}
+		return logs.OrPredicate{Left: left, Right: right}, nil
 	}
+
+	if _, ok := comparisonBinaryOps[binaryExpr.Op]; ok {
+		return buildLogsComparison(binaryExpr, columns)
+	}
+
+	return nil, fmt.Errorf("expression %[1]s (type %[1]T) cannot be interpreted as a boolean", expr)
 }
 
-func matchRow(e *physical.BinaryExpr) (logs.RowPredicate, error) {
-	val, err := rhsValue(e)
+func buildLogsComparison(expr *physical.BinaryExpr, columns []*logs.Column) (logs.Predicate, error) {
+	// Currently, we only support comparisons where the left-hand side is a
+	// [physical.ColumnExpr] and the right-hand side is a [physical.LiteralExpr].
+	//
+	// Support for other cases could be added in the future:
+	//
+	// * LHS LiteralExpr, RHS ColumnExpr could be supported by inverting the
+	//   operation.
+	// * LHS LiteralExpr, RHS LiteralExpr could be supported by evaluating the
+	//   expresion immediately.
+	// * LHS ColumnExpr, RHS ColumnExpr could be supported in the future, but would need
+	//   support down to the dataset level.
+
+	columnRef, leftValid := expr.Left.(*physical.ColumnExpr)
+	literalExpr, rightValid := expr.Right.(*physical.LiteralExpr)
+
+	if !leftValid || !rightValid {
+		return nil, fmt.Errorf("binary comparisons require the left-hand operation to reference a column (got %T) and the right-hand operation to be a literal (got %T)", expr.Left, expr.Right)
+	}
+
+	// findColumn may return nil for col if the referenced column doesn't exist;
+	// this is handled in the switch statement below and converts to either
+	// [logs.FalsePredicate] or [logs.TruePredicate] depending on the operation.
+	col, err := findColumn(columnRef.Ref, columns)
+	if err != nil {
+		return nil, fmt.Errorf("finding column %s: %w", columnRef.Ref, err)
+	}
+
+	s, err := buildDataobjScalar(literalExpr.Literal)
 	if err != nil {
 		return nil, err
 	}
 
-	switch e.Op {
+	switch expr.Op {
+	case types.BinaryOpEq:
+		if col == nil && s.IsValid() {
+			return logs.FalsePredicate{}, nil // Column(NULL) == non-null: always fails
+		} else if col == nil && !s.IsValid() {
+			return logs.TruePredicate{}, nil // Column(NULL) == NULL: always passes
+		}
+		return logs.EqualPredicate{Column: col, Value: s}, nil
 
+	case types.BinaryOpNeq:
+		if col == nil && s.IsValid() {
+			return logs.TruePredicate{}, nil // Column(NULL) != non-null: always passes
+		} else if col == nil && !s.IsValid() {
+			return logs.FalsePredicate{}, nil // Column(NULL) != NULL: always fails
+		}
+		return logs.NotPredicate{Inner: logs.EqualPredicate{Column: col, Value: s}}, nil
+
+	case types.BinaryOpGt:
+		if col == nil {
+			return logs.FalsePredicate{}, nil // Column(NULL) > value: always fails
+		}
+		return logs.GreaterThanPredicate{Column: col, Value: s}, nil
+
+	case types.BinaryOpGte:
+		if col == nil {
+			return logs.FalsePredicate{}, nil // Column(NULL) >= value: always fails
+		}
+		return logs.OrPredicate{
+			Left:  logs.GreaterThanPredicate{Column: col, Value: s},
+			Right: logs.EqualPredicate{Column: col, Value: s},
+		}, nil
+
+	case types.BinaryOpLt:
+		if col == nil {
+			return logs.FalsePredicate{}, nil // Column(NULL) < value: always fails
+		}
+		return logs.LessThanPredicate{Column: col, Value: s}, nil
+
+	case types.BinaryOpLte:
+		if col == nil {
+			return logs.FalsePredicate{}, nil // Column(NULL) <= value: always fails
+		}
+		return logs.OrPredicate{
+			Left:  logs.LessThanPredicate{Column: col, Value: s},
+			Right: logs.EqualPredicate{Column: col, Value: s},
+		}, nil
+
+	case types.BinaryOpMatchSubstr, types.BinaryOpMatchRe, types.BinaryOpMatchPattern:
+		if col == nil {
+			return logs.FalsePredicate{}, nil // Match operations against a non-existent column will always fail.
+		}
+		return buildLogsMatch(col, expr.Op, s)
+
+	case types.BinaryOpNotMatchSubstr, types.BinaryOpNotMatchRe, types.BinaryOpNotMatchPattern:
+		if col == nil {
+			return logs.TruePredicate{}, nil // Not match operations against a non-existent column will always pass.
+		}
+		return buildLogsMatch(col, expr.Op, s)
+	}
+
+	return nil, fmt.Errorf("unsupported binary operator %s in logs predicate", expr.Op)
+}
+
+// findColumn finds a column by ref in the slice of columns. If ref is invalid,
+// findColumn returns an error. If the column does not exist, findColumn
+// returns nil.
+func findColumn(ref types.ColumnRef, columns []*logs.Column) (*logs.Column, error) {
+	if ref.Type != types.ColumnTypeBuiltin && ref.Type != types.ColumnTypeMetadata && ref.Type != types.ColumnTypeAmbiguous {
+		return nil, fmt.Errorf("invalid column ref %s, expected builtin or metadata", ref)
+	}
+
+	columnMatch := func(ref types.ColumnRef, column *logs.Column) bool {
+		switch {
+		case ref.Type == types.ColumnTypeBuiltin && ref.Column == types.ColumnNameBuiltinTimestamp:
+			return column.Type == logs.ColumnTypeTimestamp
+		case ref.Type == types.ColumnTypeBuiltin && ref.Column == types.ColumnNameBuiltinMessage:
+			return column.Type == logs.ColumnTypeMessage
+		case ref.Type == types.ColumnTypeMetadata || ref.Type == types.ColumnTypeAmbiguous:
+			return column.Name == ref.Column
+		}
+
+		return false
+	}
+
+	for _, column := range columns {
+		if columnMatch(ref, column) {
+			return column, nil
+		}
+	}
+
+	return nil, nil
+}
+
+// buildDataobjScalar builds a dataobj-compatible [scalar.Scalar] from a
+// [datatype.Literal].
+func buildDataobjScalar(lit datatype.Literal) (scalar.Scalar, error) {
+	// [logs.ReaderOptions.Validate] specifies that all scalars must be one of
+	// the given types:
+	//
+	// * [scalar.Null] (of any datatype)
+	// * [scalar.Int64]
+	// * [scalar.Uint64]
+	// * [scalar.Timestamp] (nanosecond precision)
+	// * [scalar.Binary]
+	//
+	// All of our mappings below evaluate to one of the above types.
+
+	switch lit := lit.(type) {
+	case datatype.NullLiteral:
+		return scalar.ScalarNull, nil
+	case datatype.IntegerLiteral:
+		return scalar.NewInt64Scalar(lit.Value()), nil
+	case datatype.BytesLiteral:
+		// [datatype.BytesLiteral] refers to byte sizes, not binary data.
+		return scalar.NewInt64Scalar(int64(lit.Value())), nil
+	case datatype.TimestampLiteral:
+		ts := arrow.Timestamp(lit.Value())
+		tsType := arrow.FixedWidthTypes.Timestamp_ns
+		return scalar.NewTimestampScalar(ts, tsType), nil
+	case datatype.StringLiteral:
+		buf := memory.NewBufferBytes([]byte(lit.Value()))
+		return scalar.NewBinaryScalar(buf, arrow.BinaryTypes.Binary), nil
+	}
+
+	return nil, fmt.Errorf("unsupported literal type %T", lit)
+}
+
+func buildLogsMatch(col *logs.Column, op types.BinaryOp, value scalar.Scalar) (logs.Predicate, error) {
+	// All the match operations require the value to be a string or a binary.
+	var find []byte
+
+	switch value := value.(type) {
+	case *scalar.Binary:
+		find = value.Data()
+	case *scalar.String:
+		find = value.Data()
+	default:
+		return nil, fmt.Errorf("unsupported scalar type %T for op %s, expected binary or string", value, op)
+	}
+
+	switch op {
 	case types.BinaryOpMatchSubstr:
-		return logs.LogMessageFilterRowPredicate{
-			Keep: func(line []byte) bool { return bytes.Contains(line, []byte(val)) },
+		return logs.FuncPredicate{
+			Column: col,
+			Keep: func(_ *logs.Column, value scalar.Scalar) bool {
+				return bytes.Contains(getBytes(value), find)
+			},
 		}, nil
 
 	case types.BinaryOpNotMatchSubstr:
-		return logs.LogMessageFilterRowPredicate{
-			Keep: func(line []byte) bool { return !bytes.Contains(line, []byte(val)) },
+		return logs.FuncPredicate{
+			Column: col,
+			Keep: func(_ *logs.Column, value scalar.Scalar) bool {
+				return !bytes.Contains(getBytes(value), find)
+			},
 		}, nil
 
 	case types.BinaryOpMatchRe:
-		re, err := regexp.Compile(val)
+		re, err := regexp.Compile(string(find))
 		if err != nil {
 			return nil, err
 		}
-		return logs.LogMessageFilterRowPredicate{
-			Keep: func(line []byte) bool { return re.Match(line) },
+		return logs.FuncPredicate{
+			Column: col,
+			Keep: func(_ *logs.Column, value scalar.Scalar) bool {
+				return re.Match(getBytes(value))
+			},
 		}, nil
 
 	case types.BinaryOpNotMatchRe:
-		re, err := regexp.Compile(val)
+		re, err := regexp.Compile(string(find))
 		if err != nil {
 			return nil, err
 		}
-		return logs.LogMessageFilterRowPredicate{
-			Keep: func(line []byte) bool { return !re.Match(line) },
+		return logs.FuncPredicate{
+			Column: col,
+			Keep: func(_ *logs.Column, value scalar.Scalar) bool {
+				return !re.Match(getBytes(value))
+			},
 		}, nil
-
-	default:
-		return nil, fmt.Errorf("unsupported binary operator (%s) for log message predicate", e.Op)
 	}
+
+	// NOTE(rfratto): [types.BinaryOpMatchPattern] and [types.BinaryOpNotMatchPattern]
+	// are currently unsupported.
+	return nil, fmt.Errorf("unrecognized match operation %s", op)
 }
 
-func rhsValue(e *physical.BinaryExpr) (string, error) {
-	op := e.Op.String()
-
-	if e.Left.Type() != physical.ExprTypeColumn {
-		return "", fmt.Errorf("unsupported LHS type (%v) for %s message predicate, expected ColumnExpr", e.Left.Type(), op)
-	}
-	leftColumn, ok := e.Left.(*physical.ColumnExpr)
-	if !ok { // Should not happen due to Type() check but defensive
-		return "", fmt.Errorf("LHS of %s message predicate failed to cast to ColumnExpr", op)
-	}
-	if leftColumn.Ref.Type != types.ColumnTypeBuiltin {
-		return "", fmt.Errorf("unsupported LHS column type (%v) for %s message predicate, expected ColumnTypeBuiltin", leftColumn.Ref.Type, op)
+func getBytes(value scalar.Scalar) []byte {
+	if !value.IsValid() {
+		return nil
 	}
 
-	if e.Right.Type() != physical.ExprTypeLiteral {
-		return "", fmt.Errorf("unsupported RHS type (%v) for %s message predicate, expected LiteralExpr", e.Right.Type(), op)
-	}
-	rightLiteral, ok := e.Right.(*physical.LiteralExpr)
-	if !ok { // Should not happen
-		return "", fmt.Errorf("RHS of %s message predicate failed to cast to LiteralExpr", op)
-	}
-	if rightLiteral.ValueType() != datatype.Loki.String {
-		return "", fmt.Errorf("unsupported RHS literal type (%v) for %s message predicate, expected ValueTypeStr", rightLiteral.ValueType(), op)
+	switch value := value.(type) {
+	case *scalar.Binary:
+		return value.Data()
+	case *scalar.String:
+		return value.Data()
 	}
 
-	return rightLiteral.Literal.(datatype.StringLiteral).Value(), nil
+	return nil
 }

--- a/pkg/engine/executor/dataobjscan_test.go
+++ b/pkg/engine/executor/dataobjscan_test.go
@@ -7,11 +7,12 @@ import (
 	"time"
 
 	"github.com/apache/arrow-go/v18/arrow"
-	"github.com/go-kit/log"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/loki/v3/pkg/dataobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/consumer/logsobj"
+	"github.com/grafana/loki/v3/pkg/dataobj/sections/logs"
+	"github.com/grafana/loki/v3/pkg/dataobj/sections/streams"
 	"github.com/grafana/loki/v3/pkg/engine/internal/datatype"
 	"github.com/grafana/loki/v3/pkg/engine/internal/types"
 	"github.com/grafana/loki/v3/pkg/engine/planner/physical"
@@ -59,16 +60,34 @@ func Test_dataobjScan(t *testing.T) {
 		},
 	})
 
+	var (
+		streamsSection *streams.Section
+		logsSection    *logs.Section
+	)
+
+	for _, sec := range obj.Sections() {
+		var err error
+
+		switch {
+		case streams.CheckSection(sec):
+			streamsSection, err = streams.Open(t.Context(), sec)
+			require.NoError(t, err, "failed to open streams section")
+
+		case logs.CheckSection(sec):
+			logsSection, err = logs.Open(t.Context(), sec)
+			require.NoError(t, err, "failed to open logs section")
+		}
+	}
+
 	t.Run("All columns", func(t *testing.T) {
 		pipeline := newDataobjScanPipeline(dataobjScanOptions{
-			Object:      obj,
-			StreamIDs:   []int64{1, 2}, // All streams
-			Section:     0,             // First section.
-			Projections: nil,           // All columns
-			Direction:   physical.DESC,
-			Limit:       0, // No limit
-			batchSize:   512,
-		}, log.NewNopLogger())
+			StreamsSection: streamsSection,
+			LogsSection:    logsSection,
+			StreamIDs:      []int64{1, 2}, // All streams
+			Projections:    nil,           // All columns
+
+			BatchSize: 512,
+		})
 
 		expectFields := []arrow.Field{
 			{Name: "env", Type: arrow.BinaryTypes.String, Metadata: labelMD, Nullable: true},
@@ -93,27 +112,26 @@ prod,notloki,NULL,notloki-pod-1,1970-01-01 00:00:02,hello world`
 
 	t.Run("Column subset", func(t *testing.T) {
 		pipeline := newDataobjScanPipeline(dataobjScanOptions{
-			Object:    obj,
-			StreamIDs: []int64{1, 2}, // All streams
-			Section:   0,             // First section.
+			StreamsSection: streamsSection,
+			LogsSection:    logsSection,
+			StreamIDs:      []int64{1, 2}, // All streams
 			Projections: []physical.ColumnExpression{
-				&physical.ColumnExpr{Ref: types.ColumnRef{Column: "timestamp", Type: types.ColumnTypeBuiltin}},
 				&physical.ColumnExpr{Ref: types.ColumnRef{Column: "env", Type: types.ColumnTypeLabel}},
+				&physical.ColumnExpr{Ref: types.ColumnRef{Column: "timestamp", Type: types.ColumnTypeBuiltin}},
 			},
-			Direction: physical.DESC,
-			Limit:     0, // No limit
-			batchSize: 512,
-		}, log.NewNopLogger())
+
+			BatchSize: 512,
+		})
 
 		expectFields := []arrow.Field{
-			{Name: "timestamp", Type: arrow.FixedWidthTypes.Timestamp_ns, Metadata: datatype.ColumnMetadataBuiltinTimestamp, Nullable: true},
 			{Name: "env", Type: arrow.BinaryTypes.String, Metadata: labelMD, Nullable: true},
+			{Name: "timestamp", Type: arrow.FixedWidthTypes.Timestamp_ns, Metadata: datatype.ColumnMetadataBuiltinTimestamp, Nullable: true},
 		}
 
-		expectCSV := `1970-01-01 00:00:10,prod
-1970-01-01 00:00:05,prod
-1970-01-01 00:00:03,prod
-1970-01-01 00:00:02,prod`
+		expectCSV := `prod,1970-01-01 00:00:10
+prod,1970-01-01 00:00:05
+prod,1970-01-01 00:00:03
+prod,1970-01-01 00:00:02`
 
 		expectRecord, err := CSVToArrow(expectFields, expectCSV)
 		require.NoError(t, err)
@@ -122,30 +140,56 @@ prod,notloki,NULL,notloki-pod-1,1970-01-01 00:00:02,hello world`
 		AssertPipelinesEqual(t, pipeline, NewBufferedPipeline(expectRecord))
 	})
 
-	t.Run("Unknown column", func(t *testing.T) {
-		// Here, we'll check for a column which only exists once in the dataobj but is
-		// ambiguous from the perspective of the caller.
+	t.Run("Streams subset", func(t *testing.T) {
 		pipeline := newDataobjScanPipeline(dataobjScanOptions{
-			Object:    obj,
-			StreamIDs: []int64{1, 2}, // All streams
-			Section:   0,             // First section.
-			Projections: []physical.ColumnExpression{
-				&physical.ColumnExpr{Ref: types.ColumnRef{Column: "env", Type: types.ColumnTypeAmbiguous}},
-			},
-			Direction: physical.DESC,
-			Limit:     0, // No limit
-			batchSize: 512,
-		}, log.NewNopLogger())
+			StreamsSection: streamsSection,
+			LogsSection:    logsSection,
+			StreamIDs:      []int64{2}, // Only stream 2
+			Projections:    nil,        // All columns
+
+			BatchSize: 512,
+		})
 
 		expectFields := []arrow.Field{
 			{Name: "env", Type: arrow.BinaryTypes.String, Metadata: labelMD, Nullable: true},
-			{Name: "env", Type: arrow.BinaryTypes.String, Metadata: metadataMD, Nullable: true},
+			{Name: "service", Type: arrow.BinaryTypes.String, Metadata: labelMD, Nullable: true},
+			{Name: "guid", Type: arrow.BinaryTypes.String, Metadata: metadataMD, Nullable: true},
+			{Name: "pod", Type: arrow.BinaryTypes.String, Metadata: metadataMD, Nullable: true},
+			{Name: "timestamp", Type: arrow.FixedWidthTypes.Timestamp_ns, Metadata: datatype.ColumnMetadataBuiltinTimestamp, Nullable: true},
+			{Name: "message", Type: arrow.BinaryTypes.String, Metadata: datatype.ColumnMetadataBuiltinMessage, Nullable: true},
 		}
 
-		expectCSV := `prod,NULL
-prod,NULL
-prod,NULL
-prod,NULL`
+		expectCSV := `prod,notloki,NULL,notloki-pod-1,1970-01-01 00:00:03,goodbye world
+prod,notloki,NULL,notloki-pod-1,1970-01-01 00:00:02,hello world`
+
+		expectRecord, err := CSVToArrow(expectFields, expectCSV)
+		require.NoError(t, err)
+		defer expectRecord.Release()
+
+		AssertPipelinesEqual(t, pipeline, NewBufferedPipeline(expectRecord))
+	})
+
+	t.Run("Ambiguous column", func(t *testing.T) {
+		// Here, we'll check for a column which only exists once in the dataobj but is
+		// ambiguous from the perspective of the caller.
+		pipeline := newDataobjScanPipeline(dataobjScanOptions{
+			StreamsSection: streamsSection,
+			LogsSection:    logsSection,
+			StreamIDs:      []int64{1, 2}, // All streams
+			Projections: []physical.ColumnExpression{
+				&physical.ColumnExpr{Ref: types.ColumnRef{Column: "env", Type: types.ColumnTypeAmbiguous}},
+			},
+			BatchSize: 512,
+		})
+
+		expectFields := []arrow.Field{
+			{Name: "env", Type: arrow.BinaryTypes.String, Metadata: labelMD, Nullable: true},
+		}
+
+		expectCSV := `prod
+prod
+prod
+prod`
 
 		expectRecord, err := CSVToArrow(expectFields, expectCSV)
 		require.NoError(t, err)
@@ -190,16 +234,33 @@ func Test_dataobjScan_DuplicateColumns(t *testing.T) {
 		},
 	})
 
+	var (
+		streamsSection *streams.Section
+		logsSection    *logs.Section
+	)
+
+	for _, sec := range obj.Sections() {
+		var err error
+
+		switch {
+		case streams.CheckSection(sec):
+			streamsSection, err = streams.Open(t.Context(), sec)
+			require.NoError(t, err, "failed to open streams section")
+
+		case logs.CheckSection(sec):
+			logsSection, err = logs.Open(t.Context(), sec)
+			require.NoError(t, err, "failed to open logs section")
+		}
+	}
+
 	t.Run("All columns", func(t *testing.T) {
 		pipeline := newDataobjScanPipeline(dataobjScanOptions{
-			Object:      obj,
-			StreamIDs:   []int64{1, 2, 3}, // All streams
-			Section:     0,                // First section.
-			Projections: nil,              // All columns
-			Direction:   physical.DESC,
-			Limit:       0, // No limit
-			batchSize:   512,
-		}, log.NewNopLogger())
+			StreamsSection: streamsSection,
+			LogsSection:    logsSection,
+			StreamIDs:      []int64{1, 2, 3}, // All streams
+			Projections:    nil,              // All columns
+			BatchSize:      512,
+		})
 
 		expectFields := []arrow.Field{
 			{Name: "env", Type: arrow.BinaryTypes.String, Metadata: labelMD, Nullable: true},
@@ -227,16 +288,14 @@ prod,NULL,pod-1,loki,NULL,override,1970-01-01 00:00:01,message 1`
 
 	t.Run("Ambiguous pod", func(t *testing.T) {
 		pipeline := newDataobjScanPipeline(dataobjScanOptions{
-			Object:    obj,
-			StreamIDs: []int64{1, 2, 3}, // All streams
-			Section:   0,                // First section.
+			StreamsSection: streamsSection,
+			LogsSection:    logsSection,
+			StreamIDs:      []int64{1, 2, 3}, // All streams
 			Projections: []physical.ColumnExpression{
 				&physical.ColumnExpr{Ref: types.ColumnRef{Column: "pod", Type: types.ColumnTypeAmbiguous}},
 			},
-			Direction: physical.DESC,
-			Limit:     0, // No limit
-			batchSize: 512,
-		}, log.NewNopLogger())
+			BatchSize: 512,
+		})
 
 		expectFields := []arrow.Field{
 			{Name: "pod", Type: arrow.BinaryTypes.String, Metadata: labelMD, Nullable: true},
@@ -256,16 +315,14 @@ pod-1,override`
 
 	t.Run("Ambiguous namespace", func(t *testing.T) {
 		pipeline := newDataobjScanPipeline(dataobjScanOptions{
-			Object:    obj,
-			StreamIDs: []int64{1, 2, 3}, // All streams
-			Section:   0,
+			StreamsSection: streamsSection,
+			LogsSection:    logsSection,
+			StreamIDs:      []int64{1, 2, 3}, // All streams
 			Projections: []physical.ColumnExpression{
 				&physical.ColumnExpr{Ref: types.ColumnRef{Column: "namespace", Type: types.ColumnTypeAmbiguous}},
 			},
-			Direction: physical.DESC,
-			Limit:     0, // No limit
-			batchSize: 512,
-		}, log.NewNopLogger())
+			BatchSize: 512,
+		})
 
 		expectFields := []arrow.Field{
 			{Name: "namespace", Type: arrow.BinaryTypes.String, Metadata: labelMD, Nullable: true},

--- a/pkg/engine/executor/executor.go
+++ b/pkg/engine/executor/executor.go
@@ -5,11 +5,15 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	"github.com/thanos-io/objstore"
 
 	"github.com/grafana/loki/v3/pkg/dataobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/logs"
+	"github.com/grafana/loki/v3/pkg/dataobj/sections/streams"
+	"github.com/grafana/loki/v3/pkg/engine/internal/types"
 	"github.com/grafana/loki/v3/pkg/engine/planner/physical"
 )
 
@@ -76,33 +80,127 @@ func (c *Context) executeDataObjScan(ctx context.Context, node *physical.DataObj
 		return errorPipeline(errors.New("no object store bucket configured"))
 	}
 
-	predicates := make([]logs.RowPredicate, 0, len(node.Predicates))
+	obj, err := dataobj.FromBucket(ctx, c.bucket, string(node.Location))
+	if err != nil {
+		return errorPipeline(fmt.Errorf("creating data object: %w", err))
+	}
+
+	var (
+		streamsSection *streams.Section
+		logsSection    *logs.Section
+	)
+
+	for _, sec := range obj.Sections().Filter(streams.CheckSection) {
+		if streamsSection != nil {
+			return errorPipeline(fmt.Errorf("multiple streams sections found in data object %q", node.Location))
+		}
+
+		var err error
+		streamsSection, err = streams.Open(ctx, sec)
+		if err != nil {
+			return errorPipeline(fmt.Errorf("opening streams section %q: %w", sec.Type, err))
+		}
+	}
+	if streamsSection == nil {
+		return errorPipeline(fmt.Errorf("streams section not found in data object %q", node.Location))
+	}
+
+	for i, sec := range obj.Sections().Filter(logs.CheckSection) {
+		if i != node.Section {
+			continue
+		}
+
+		var err error
+		logsSection, err = logs.Open(ctx, sec)
+		if err != nil {
+			return errorPipeline(fmt.Errorf("opening logs section %q: %w", sec.Type, err))
+		}
+	}
+	if logsSection == nil {
+		return errorPipeline(fmt.Errorf("logs section %d not found in data object %q", node.Section, node.Location))
+	}
+
+	predicates := make([]logs.Predicate, 0, len(node.Predicates))
 
 	for _, p := range node.Predicates {
-		conv, err := buildLogsPredicate(p)
+		conv, err := buildLogsPredicate(p, logsSection.Columns())
 		if err != nil {
 			return errorPipeline(err)
 		}
 		predicates = append(predicates, conv)
 	}
 
-	obj, err := dataobj.FromBucket(ctx, c.bucket, string(node.Location))
-	if err != nil {
-		return errorPipeline(fmt.Errorf("creating data object: %w", err))
-	}
+	var pipeline Pipeline = newDataobjScanPipeline(dataobjScanOptions{
+		// TODO(rfratto): passing the streams section means that each DataObjScan
+		// will read the entire streams section (for IDs being loaded), which is
+		// going to be quite a bit of wasted effort.
+		//
+		// Longer term, there should be a dedicated plan node which handles joining
+		// streams and log records based on StreamID, which is shared between all
+		// sections in the same object.
+		StreamsSection: streamsSection,
 
-	return newDataobjScanPipeline(dataobjScanOptions{
-		Object:      obj,
+		LogsSection: logsSection,
 		StreamIDs:   node.StreamIDs,
-		Section:     node.Section,
 		Predicates:  predicates,
 		Projections: node.Projections,
 
-		Direction: node.Direction,
-		Limit:     node.Limit,
+		// TODO(rfratto): pass custom allocator
+		Allocator: memory.DefaultAllocator,
 
-		batchSize: c.batchSize,
-	}, log.With(c.logger, "location", string(node.Location)))
+		BatchSize: c.batchSize,
+		CacheSize: 16_000_000, // TODO(rfratto): make configurable at engine level
+	})
+
+	sortType, sortDirection, err := logsSection.PrimarySortOrder()
+	if err != nil {
+		level.Warn(c.logger).Log("msg", "could not determine primary sort order for logs section, forcing topk sort", "err", err)
+	}
+
+	// Wrap our pipeline to enforce expected sorting. We always emit logs in
+	// timestamp-sorted order, so we need to sort if either the section doesn't
+	// match the expected sort order or the requested sort type is not timestamp.
+	//
+	// If it's already sorted, we wrap by LimitPipeline to enforce the limit
+	// given to the node.
+	if node.Direction != logsSortOrder(sortDirection) || sortType != logs.ColumnTypeTimestamp {
+		level.Debug(c.logger).Log("msg", "sorting logs section", "source_sort", sortType, "source_direction", sortDirection, "requested_sort", logs.ColumnTypeTimestamp, "requested_dir", node.Direction)
+
+		pipeline, err = newTopkPipeline(topkOptions{
+			Inputs: []Pipeline{pipeline},
+
+			SortBy: []physical.ColumnExpression{
+				&physical.ColumnExpr{
+					Ref: types.ColumnRef{
+						Column: types.ColumnNameBuiltinTimestamp,
+						Type:   types.ColumnTypeBuiltin,
+					},
+				},
+			},
+			Ascending: node.Direction == physical.ASC,
+			K:         int(node.Limit),
+
+			MaxUnused: int(c.batchSize) * 2,
+		})
+		if err != nil {
+			return errorPipeline(err)
+		}
+	} else if node.Limit > 0 {
+		pipeline = NewLimitPipeline(pipeline, 0, node.Limit)
+	}
+
+	return pipeline
+}
+
+func logsSortOrder(dir logs.SortDirection) physical.SortOrder {
+	switch dir {
+	case logs.SortDirectionAscending:
+		return physical.ASC
+	case logs.SortDirectionDescending:
+		return physical.DESC
+	}
+
+	return physical.SortOrder(0)
 }
 
 func (c *Context) executeSortMerge(_ context.Context, sortmerge *physical.SortMerge, inputs []Pipeline) Pipeline {

--- a/pkg/engine/executor/executor.go
+++ b/pkg/engine/executor/executor.go
@@ -20,6 +20,8 @@ import (
 type Config struct {
 	BatchSize int64
 	Bucket    objstore.Bucket
+
+	DataobjScanPageCacheSize int64
 }
 
 func Run(ctx context.Context, cfg Config, plan *physical.Plan, logger log.Logger) Pipeline {
@@ -28,6 +30,8 @@ func Run(ctx context.Context, cfg Config, plan *physical.Plan, logger log.Logger
 		batchSize: cfg.BatchSize,
 		bucket:    cfg.Bucket,
 		logger:    logger,
+
+		dataobjScanPageCacheSize: cfg.DataobjScanPageCacheSize,
 	}
 	if plan == nil {
 		return errorPipeline(errors.New("plan is nil"))
@@ -46,6 +50,8 @@ type Context struct {
 	plan      *physical.Plan
 	evaluator expressionEvaluator
 	bucket    objstore.Bucket
+
+	dataobjScanPageCacheSize int64
 }
 
 func (c *Context) execute(ctx context.Context, node physical.Node) Pipeline {
@@ -149,7 +155,7 @@ func (c *Context) executeDataObjScan(ctx context.Context, node *physical.DataObj
 		Allocator: memory.DefaultAllocator,
 
 		BatchSize: c.batchSize,
-		CacheSize: 16_000_000, // TODO(rfratto): make configurable at engine level
+		CacheSize: int(c.dataobjScanPageCacheSize),
 	})
 
 	sortType, sortDirection, err := logsSection.PrimarySortOrder()

--- a/pkg/engine/executor/schema.go
+++ b/pkg/engine/executor/schema.go
@@ -1,0 +1,68 @@
+package executor
+
+import (
+	"fmt"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+)
+
+// changeSchema creates a record with the same data as input, but with the
+// schema set to newSchema.
+//
+// changeSchema can be used for changing field names, field metadata, or
+// overall schema metadata. Field datatypes must be consistent between the
+// previous and new schemas.
+//
+// changeSchema returns an error if the new schema is not compatible with the
+// old schema.
+//
+// The returned record must be Release()d by the caller. changeSchema does not
+// change the number of references to the input record.
+func changeSchema(input arrow.Record, newSchema *arrow.Schema) (arrow.Record, error) {
+	if err := validateSchemaCompatibility(input.Schema(), newSchema); err != nil {
+		return nil, fmt.Errorf("incompatible schema: %w", err)
+	}
+
+	var (
+		numCols = input.NumCols()
+		numRows = input.NumRows()
+	)
+
+	cols := make([]arrow.Array, numCols)
+	for i := range numCols {
+		cols[i] = input.Column(int(i))
+	}
+
+	return array.NewRecord(newSchema, cols, numRows), nil
+}
+
+// validateSchemaCompatibility checks if two schemas are compatible:
+//
+// - Both schemas have the same endianness.
+// - Both schemas have the same number of fields.
+// - The data type of each field matches between the two schemas.
+// - The nullability of each field matches between the two schemas.
+//
+// validateSchemaCompatibility returns nil if the schemas are compatible.
+func validateSchemaCompatibility(a, b *arrow.Schema) error {
+	if a.NumFields() != b.NumFields() {
+		return fmt.Errorf("schemas have different number of fields: %d vs %d", a.NumFields(), b.NumFields())
+	}
+
+	if a.Endianness() != b.Endianness() {
+		return fmt.Errorf("schemas have different endianness: %s vs %s", a.Endianness(), b.Endianness())
+	}
+
+	for i := range a.NumFields() {
+		aField, bField := a.Field(i), b.Field(i)
+
+		if !arrow.TypeEqual(aField.Type, bField.Type) {
+			return fmt.Errorf("field %d has different types: %s vs %s", i, aField.Type, bField.Type)
+		} else if aField.Nullable != bField.Nullable {
+			return fmt.Errorf("field %d has different nullability: %t vs %t", i, aField.Nullable, bField.Nullable)
+		}
+	}
+
+	return nil
+}

--- a/pkg/engine/executor/schema_test.go
+++ b/pkg/engine/executor/schema_test.go
@@ -1,0 +1,51 @@
+package executor
+
+import (
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/util/arrowtest"
+)
+
+func Test_changeSchema(t *testing.T) {
+	alloc := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer alloc.AssertSize(t, 0)
+
+	var (
+		oldSchema = arrow.NewSchema([]arrow.Field{
+			{Name: "a", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+			{Name: "b", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+		}, nil)
+
+		newSchema = arrow.NewSchema([]arrow.Field{
+			{Name: "number", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+			{Name: "bool", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+		}, nil)
+	)
+
+	var (
+		data = arrowtest.Rows{
+			{"a": int64(1), "b": true},
+			{"a": int64(2), "b": false},
+		}
+
+		expect = arrowtest.Rows{
+			{"number": int64(1), "bool": true},
+			{"number": int64(2), "bool": false},
+		}
+	)
+
+	rec := data.Record(alloc, oldSchema)
+	defer rec.Release()
+
+	newRec, err := changeSchema(rec, newSchema)
+	require.NoError(t, err, "changeSchema should not return an error")
+	defer newRec.Release()
+
+	actual, err := arrowtest.RecordRows(newRec)
+	require.NoError(t, err, "arrowtest.RecordRows should not return an error")
+	require.Equal(t, expect, actual, "changed schema should match expected rows")
+}

--- a/pkg/engine/executor/stream_injector.go
+++ b/pkg/engine/executor/stream_injector.go
@@ -1,0 +1,161 @@
+package executor
+
+import (
+	"cmp"
+	"context"
+	"fmt"
+	"slices"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+
+	"github.com/grafana/loki/v3/pkg/engine/internal/datatype"
+	"github.com/grafana/loki/v3/pkg/engine/internal/types"
+)
+
+var streamInjectorColumnName = "stream_id.int64"
+
+// streamInjector injects stream labels into a logs Arrow record, replacing the
+// streams ID column with columns for the labels composing those streams.
+type streamInjector struct {
+	alloc memory.Allocator
+	view  *streamsView
+}
+
+// newStreamInjector creates a new streamInjector that uses the provided view
+// for determining stream ID labels.
+//
+// streamInjector does not take ownership of the view, so the caller is
+// responsible for closing the view when it is no longer needed.
+func newStreamInjector(alloc memory.Allocator, view *streamsView) *streamInjector {
+	return &streamInjector{alloc: alloc, view: view}
+}
+
+// Inject returns a new Arrow record where the stream ID column is replaced
+// with a set of stream label columns.
+//
+// Inject fails if there is no stream ID column in the input record, or if the
+// stream ID doesn't exist in the view given to [newStreamInjector].
+//
+// The returned record must be Release()d by the caller when no longer needed.
+func (si *streamInjector) Inject(ctx context.Context, in arrow.Record) (arrow.Record, error) {
+	streamIDIndex, err := si.findStreamIDColumn(in)
+	if err != nil {
+		return nil, fmt.Errorf("finding stream ID column: %w", err)
+	}
+
+	streamIDValues, ok := in.Column(streamIDIndex).(*array.Int64)
+	if !ok {
+		return nil, fmt.Errorf("stream ID column %q must be of type int64, got %s", streamInjectorColumnName, in.Schema().Field(streamIDIndex).Type)
+	}
+
+	type labelColumn struct {
+		Field   arrow.Field
+		Builder *array.StringBuilder
+	}
+
+	var (
+		labels      = make([]*labelColumn, 0, si.view.NumLabels())
+		labelLookup = make(map[string]*labelColumn, si.view.NumLabels())
+	)
+	defer func() {
+		for _, col := range labels {
+			col.Builder.Release()
+		}
+	}()
+
+	getColumn := func(name string) *labelColumn {
+		if col, ok := labelLookup[name]; ok {
+			return col
+		}
+
+		col := &labelColumn{
+			Field: arrow.Field{
+				Name:     name,
+				Type:     arrow.BinaryTypes.String,
+				Nullable: true,
+				Metadata: datatype.ColumnMetadata(types.ColumnTypeLabel, datatype.Loki.String),
+			},
+			Builder: array.NewStringBuilder(si.alloc),
+		}
+
+		labels = append(labels, col)
+		labelLookup[name] = col
+		return col
+	}
+
+	for i := range streamIDValues.Len() {
+		findID := streamIDValues.Value(i)
+
+		// TODO(rfratto): this flips the processing of stream IDs into row-based
+		// processing. It may be more efficient to vectorize this by building each
+		// label column all at once.
+		it, err := si.view.Labels(ctx, findID)
+		if err != nil {
+			return nil, fmt.Errorf("stream ID %d not found in section", findID)
+		}
+
+		for label := range it {
+			col := getColumn(label.Name)
+
+			// Backfill any missing NULLs in the column if needed.
+			if missing := i - col.Builder.Len(); missing > 0 {
+				col.Builder.AppendNulls(missing)
+			}
+			col.Builder.Append(label.Value)
+		}
+	}
+
+	// Sort our labels by name for consistent ordering.
+	slices.SortFunc(labels, func(a, b *labelColumn) int {
+		return cmp.Compare(a.Field.Name, b.Field.Name)
+	})
+
+	var (
+		// We preallocate enough space for all label fields + original columns
+		// minus the stream ID column (which we drop from the final record).
+
+		fields = make([]arrow.Field, 0, len(labels)+int(in.NumCols())-1)
+		arrs   = make([]arrow.Array, 0, len(labels)+int(in.NumCols())-1)
+
+		md = in.Schema().Metadata() // Use the same metadata as the input record.
+	)
+
+	// Prepare our arrays from the string builders.
+	for _, col := range labels {
+		// Backfill any final missing NULLs in the StringBuilder if needed.
+		if missing := int(in.NumRows()) - col.Builder.Len(); missing > 0 {
+			col.Builder.AppendNulls(missing)
+		}
+
+		arr := col.Builder.NewArray()
+		defer arr.Release()
+
+		fields = append(fields, col.Field)
+		arrs = append(arrs, arr)
+	}
+
+	// Add all of the original columns except the stream ID column.
+	for i := range int(in.NumCols()) {
+		if i == streamIDIndex {
+			continue
+		}
+
+		fields = append(fields, in.Schema().Field(i))
+		arrs = append(arrs, in.Column(i))
+	}
+
+	schema := arrow.NewSchemaWithEndian(fields, &md, in.Schema().Endianness())
+	return array.NewRecord(schema, arrs, in.NumRows()), nil
+}
+
+func (si *streamInjector) findStreamIDColumn(in arrow.Record) (int, error) {
+	indices := in.Schema().FieldIndices(streamInjectorColumnName)
+	if len(indices) == 0 {
+		return -1, fmt.Errorf("stream ID column %q not found in input record", streamInjectorColumnName)
+	} else if len(indices) > 1 {
+		return -1, fmt.Errorf("multiple stream ID columns found in input record: %v", indices)
+	}
+	return indices[0], nil
+}

--- a/pkg/engine/executor/stream_injector_test.go
+++ b/pkg/engine/executor/stream_injector_test.go
@@ -1,0 +1,55 @@
+package executor
+
+import (
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/util/arrowtest"
+)
+
+func Test_streamInjector(t *testing.T) {
+	alloc := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer alloc.AssertSize(t, 0)
+
+	inputStreams := []labels.Labels{
+		labels.FromStrings("app", "loki", "env", "prod", "region", "us-west"),
+		labels.FromStrings("app", "loki", "env", "dev"),
+		labels.FromStrings("app", "loki", "env", "prod", "region", "us-east"),
+	}
+
+	sec := buildStreamsSection(t, inputStreams)
+
+	input := arrowtest.Rows{
+		{"stream_id.int64": 2, "ts": int64(1), "line": "log line 1"},
+		{"stream_id.int64": 1, "ts": int64(2), "line": "log line 2"},
+		{"stream_id.int64": 3, "ts": int64(3), "line": "log line 3"},
+		{"stream_id.int64": 2, "ts": int64(4), "line": "log line 4"},
+	}
+
+	record := input.Record(alloc, input.Schema())
+	defer record.Release()
+
+	view := newStreamsView(sec, &streamsViewOptions{})
+	defer view.Close()
+
+	injector := newStreamInjector(alloc, view)
+	output, err := injector.Inject(t.Context(), record)
+	if output != nil {
+		defer output.Release()
+	}
+	require.NoError(t, err)
+
+	expect := arrowtest.Rows{
+		{"app": "loki", "env": "dev", "region": nil, "ts": int64(1), "line": "log line 1"},
+		{"app": "loki", "env": "prod", "region": "us-west", "ts": int64(2), "line": "log line 2"},
+		{"app": "loki", "env": "prod", "region": "us-east", "ts": int64(3), "line": "log line 3"},
+		{"app": "loki", "env": "dev", "region": nil, "ts": int64(4), "line": "log line 4"},
+	}
+
+	actual, err := arrowtest.RecordRows(output)
+	require.NoError(t, err, "failed to convert output record to rows")
+	require.Equal(t, expect, actual, "expected output to match input with stream labels injected")
+}

--- a/pkg/engine/executor/streams_view.go
+++ b/pkg/engine/executor/streams_view.go
@@ -1,0 +1,260 @@
+package executor
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"iter"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/apache/arrow-go/v18/arrow/scalar"
+	"github.com/prometheus/prometheus/model/labels"
+
+	"github.com/grafana/loki/v3/pkg/dataobj/sections/streams"
+)
+
+// streamsView provides a view of the streams in a section, allowing for
+// querying labels of a stream.
+//
+// streamsView lazily loads streams upon the first call.
+type streamsView struct {
+	sec           *streams.Section
+	streamIDs     []int64
+	idColumn      *streams.Column
+	searchColumns []*streams.Column // stream ID + labels
+	batchSize     int
+
+	initialized  bool
+	streams      arrow.Table
+	idRowMapping map[int64]int // Mapping of stream ID to absolute row index in the streams table.
+}
+
+type streamsViewOptions struct {
+	// StreamIDs holds the list of stream IDs to include in the view. If this
+	// slice is empty, all streams in the section are included.
+	StreamIDs []int64
+
+	// LabelColumns holds the list of label columns (stream labels) to include in
+	// the view.
+	//
+	// If this slice is empty, all label columns in the section are included.
+	LabelColumns []*streams.Column
+
+	// Maximum number of stream records to read at once. Defaults to 128.
+	BatchSize int
+}
+
+// newStreamsView creates a new view of the given streams section. Only the
+// specified ids will be included in the view.
+func newStreamsView(sec *streams.Section, opts *streamsViewOptions) *streamsView {
+	cols := opts.LabelColumns
+	if len(cols) == 0 {
+		cols = sec.Columns()
+	}
+
+	if opts.BatchSize <= 0 {
+		opts.BatchSize = 128
+	}
+
+	var streamsIDColumn *streams.Column
+
+	// We need to iterate through the original columns to find the stream ID
+	// column, since it's never included in [streamsViewOptions].
+	for _, col := range sec.Columns() {
+		if col.Type == streams.ColumnTypeStreamID {
+			streamsIDColumn = col
+			break
+		}
+	}
+
+	return &streamsView{
+		sec:           sec,
+		streamIDs:     opts.StreamIDs,
+		idColumn:      streamsIDColumn,
+		searchColumns: append([]*streams.Column{streamsIDColumn}, cols...),
+		batchSize:     opts.BatchSize,
+	}
+}
+
+// NumLabels returns the number of labels in the view.
+func (v *streamsView) NumLabels() int {
+	return len(v.searchColumns) - 1
+}
+
+// Labels iterates over all of the non-null labels of a stream with the given
+// id. If [streamsViewOptions] included a subset of labels, only those labels
+// are returned.
+func (v *streamsView) Labels(ctx context.Context, id int64) (iter.Seq[labels.Label], error) {
+	if err := v.init(ctx); err != nil {
+		return nil, err
+	}
+
+	rowColumnIndex, ok := v.idRowMapping[id]
+	if !ok {
+		return nil, fmt.Errorf("stream ID %d not found in section or not included in filter", id)
+	}
+
+	return func(yield func(labels.Label) bool) {
+		for colIndex := range int(v.streams.NumCols()) {
+			// Skip any column which isn't a label column.
+			//
+			// This is safe because [streams.Reader] guarantees that the order of
+			// columns in the Arrow schema matches the order of [streams.Column]s
+			// provided to the reader.
+			if v.searchColumns[colIndex].Type != streams.ColumnTypeLabel {
+				continue
+			}
+
+			// Find the array where our row is. While columnChunkedRow can return nil
+			// if the row isn't found, we know we're giving it a valid row index so
+			// we can bypass the check here.
+			arr, rowArrayIndex := columnChunkedRow(v.streams.Column(colIndex), rowColumnIndex)
+			if arr.IsNull(rowArrayIndex) {
+				continue
+			}
+
+			label := labels.Label{
+				Name: v.searchColumns[colIndex].Name,
+			}
+
+			switch colValues := arr.(type) {
+			case *array.String:
+				label.Value = colValues.Value(rowArrayIndex)
+			case *array.Binary:
+				label.Value = string(colValues.Value(rowArrayIndex))
+			default:
+				panic(fmt.Sprintf("unexpected column type %T for labels", colValues))
+			}
+
+			if !yield(label) {
+				return
+			}
+		}
+	}, nil
+}
+
+func (v *streamsView) init(ctx context.Context) (err error) {
+	if v.initialized {
+		return nil
+	}
+
+	if v.idColumn == nil { // Initialized in [newStreamsView].
+		// The streams builder always produces a section with a streams ID column.
+		// If we hit this, someone probably made a custom section and provided it
+		// to us.
+		return fmt.Errorf("section does not contain a stream ID column")
+	}
+
+	readerOptions := streams.ReaderOptions{
+		Columns:   v.searchColumns,
+		Allocator: memory.DefaultAllocator,
+	}
+
+	var scalarIDs []scalar.Scalar
+	for _, id := range v.streamIDs {
+		scalarIDs = append(scalarIDs, scalar.NewInt64Scalar(id))
+	}
+	if len(scalarIDs) > 0 {
+		readerOptions.Predicates = []streams.Predicate{
+			streams.InPredicate{Column: v.idColumn, Values: scalarIDs},
+		}
+	}
+
+	r := streams.NewReader(readerOptions)
+
+	var records []arrow.Record
+	defer func() {
+		for _, rec := range records {
+			rec.Release()
+		}
+	}()
+
+	for {
+		rec, err := r.Read(ctx, v.batchSize)
+		if rec != nil && rec.NumRows() > 0 {
+			records = append(records, rec)
+		}
+
+		if err != nil && !errors.Is(err, io.EOF) {
+			return err
+		} else if err != nil && errors.Is(err, io.EOF) {
+			break
+		}
+	}
+
+	table := array.NewTableFromRecords(r.Schema(), records)
+	defer func() {
+		if err != nil {
+			table.Release()
+		}
+	}()
+
+	idMapping := make(map[int64]int, table.NumRows())
+	for colIndex := range int(table.NumCols()) {
+		if v.searchColumns[colIndex].Type != streams.ColumnTypeStreamID {
+			continue
+		}
+
+		var chunkStartRow int
+
+		col := table.Column(colIndex)
+		for _, chunk := range col.Data().Chunks() {
+			idArray, ok := chunk.(*array.Int64)
+			if !ok {
+				return fmt.Errorf("expected streamds ID to be of type Int64, got %T", chunk)
+			}
+
+			for chunkRow := range idArray.Len() {
+				id := idArray.Value(chunkRow)
+				idMapping[id] = chunkStartRow + chunkRow
+			}
+
+			chunkStartRow += chunk.Len()
+		}
+
+		break // Processed the streams ID column, so we're done.
+	}
+
+	v.streams = table
+	v.initialized = true
+	v.idRowMapping = idMapping
+	return nil
+}
+
+// columnChunkedRow finds a column-wide rows in a chunked array, returning the
+// array that the row is in and the relative row index inside that array.
+func columnChunkedRow(col *arrow.Column, absoluteRow int) (arr arrow.Array, relativeRow int) {
+	var chunkStartRow int
+
+	for _, chunk := range col.Data().Chunks() {
+		// Subtract one to get the inclusive end row.
+		//
+		// e.g., if a chunk starts at row 0 and has a length of 1, then its end row
+		// is 0.
+		chunkEndRow := chunkStartRow + chunk.Len() - 1
+
+		if chunkStartRow <= absoluteRow && absoluteRow <= chunkEndRow {
+			relativeRow = absoluteRow - chunkStartRow
+			return chunk, relativeRow
+		}
+
+		// The next chunk starts one after where the current chunk ends.
+		chunkStartRow += chunk.Len()
+	}
+
+	return nil, -1 // not found
+}
+
+func (v *streamsView) Close() {
+	if !v.initialized {
+		return
+	}
+
+	v.initialized = false
+	v.streams.Release()
+	v.streams = nil
+	clear(v.idRowMapping)
+}

--- a/pkg/engine/executor/streams_view_test.go
+++ b/pkg/engine/executor/streams_view_test.go
@@ -1,0 +1,170 @@
+package executor
+
+import (
+	"bytes"
+	"iter"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/dataobj"
+	"github.com/grafana/loki/v3/pkg/dataobj/sections/streams"
+)
+
+func Test_streamsView(t *testing.T) {
+	inputStreams := []labels.Labels{
+		labels.FromStrings("app", "loki", "env", "prod", "region", "us-west"),
+		labels.FromStrings("app", "loki", "env", "dev"),
+		labels.FromStrings("app", "loki", "env", "prod", "region", "us-east"),
+	}
+
+	sec := buildStreamsSection(t, inputStreams)
+
+	t.Run("default", func(t *testing.T) {
+		view := newStreamsView(sec, &streamsViewOptions{
+			BatchSize: 1,
+		})
+
+		var actual []labels.Labels
+
+		for id := 1; id <= 3; id++ {
+			it, err := view.Labels(t.Context(), int64(id))
+			require.NoError(t, err, "failed to get labels iterator")
+			actual = append(actual, collectLabels(it))
+		}
+
+		require.Equal(t, inputStreams, actual, "expected all streams to be returned")
+	})
+
+	t.Run("one stream", func(t *testing.T) {
+		view := newStreamsView(sec, &streamsViewOptions{
+			StreamIDs: []int64{2},
+			BatchSize: 1,
+		})
+
+		var actual []labels.Labels
+
+		it, err := view.Labels(t.Context(), int64(2))
+		require.NoError(t, err, "failed to get labels iterator")
+		actual = append(actual, collectLabels(it))
+
+		expected := []labels.Labels{
+			inputStreams[1], // Stream ID 2
+		}
+		require.Equal(t, expected, actual, "expected only specified streams to be returned")
+	})
+
+	t.Run("specific streams", func(t *testing.T) {
+		view := newStreamsView(sec, &streamsViewOptions{
+			StreamIDs: []int64{2, 3},
+			BatchSize: 1,
+		})
+
+		var actual []labels.Labels
+
+		for _, id := range []int{2, 3} {
+			it, err := view.Labels(t.Context(), int64(id))
+			require.NoError(t, err, "failed to get labels iterator")
+			actual = append(actual, collectLabels(it))
+		}
+
+		expected := []labels.Labels{
+			inputStreams[1], // Stream ID 2
+			inputStreams[2], // Stream ID 3
+		}
+		require.Equal(t, expected, actual, "expected only specified streams to be returned")
+	})
+
+	t.Run("one label", func(t *testing.T) {
+		regionColumnIndex := slices.IndexFunc(sec.Columns(), func(c *streams.Column) bool {
+			return c.Name == "region"
+		})
+
+		view := newStreamsView(sec, &streamsViewOptions{
+			LabelColumns: []*streams.Column{sec.Columns()[regionColumnIndex]},
+			BatchSize:    1,
+		})
+
+		expect := []labels.Labels{
+			labels.FromStrings("region", "us-west"),
+			labels.FromStrings(),
+			labels.FromStrings("region", "us-east"),
+		}
+
+		var actual []labels.Labels
+
+		for id := 1; id <= 3; id++ {
+			it, err := view.Labels(t.Context(), int64(id))
+			require.NoError(t, err, "failed to get labels iterator")
+			actual = append(actual, collectLabels(it))
+		}
+
+		require.Equal(t, expect, actual, "expected all streams to be returned with the proper labels")
+	})
+
+	t.Run("two labels", func(t *testing.T) {
+		appColumnIndex := slices.IndexFunc(sec.Columns(), func(c *streams.Column) bool {
+			return c.Name == "app"
+		})
+		envColumnIndex := slices.IndexFunc(sec.Columns(), func(c *streams.Column) bool {
+			return c.Name == "env"
+		})
+
+		view := newStreamsView(sec, &streamsViewOptions{
+			LabelColumns: []*streams.Column{
+				sec.Columns()[appColumnIndex],
+				sec.Columns()[envColumnIndex],
+			},
+			BatchSize: 1,
+		})
+
+		expect := []labels.Labels{
+			labels.FromStrings("app", "loki", "env", "prod"),
+			labels.FromStrings("app", "loki", "env", "dev"),
+			labels.FromStrings("app", "loki", "env", "prod"),
+		}
+
+		var actual []labels.Labels
+
+		for id := 1; id <= 3; id++ {
+			it, err := view.Labels(t.Context(), int64(id))
+			require.NoError(t, err, "failed to get labels iterator")
+			actual = append(actual, collectLabels(it))
+		}
+
+		require.Equal(t, expect, actual, "expected all streams to be returned with the proper labels")
+	})
+}
+
+func buildStreamsSection(t *testing.T, streamLabels []labels.Labels) *streams.Section {
+	streamsBuilder := streams.NewBuilder(nil, 8192)
+	for _, stream := range streamLabels {
+		_ = streamsBuilder.Record(stream, time.Now().UTC(), 0)
+	}
+
+	objBuilder := dataobj.NewBuilder()
+	require.NoError(t, objBuilder.Append(streamsBuilder), "failed to append streams section")
+
+	var buf bytes.Buffer
+	_, err := objBuilder.Flush(&buf)
+	require.NoError(t, err, "failed to flush dataobj")
+
+	obj, err := dataobj.FromReaderAt(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+	require.NoError(t, err, "failed to create dataobj from reader")
+
+	sec, err := streams.Open(t.Context(), obj.Sections()[0])
+	require.NoError(t, err, "failed to open streams section")
+
+	return sec
+}
+
+func collectLabels(it iter.Seq[labels.Label]) labels.Labels {
+	var ls []labels.Label
+	for l := range it {
+		ls = append(ls, l)
+	}
+	return labels.New(ls...)
+}

--- a/pkg/engine/executor/topk.go
+++ b/pkg/engine/executor/topk.go
@@ -1,0 +1,148 @@
+package executor
+
+import (
+	"context"
+	"errors"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+
+	"github.com/grafana/loki/v3/pkg/engine/planner/physical"
+)
+
+type topkOptions struct {
+	// Input pipeliens to compute top K from.
+	Inputs []Pipeline
+
+	// SortBy is the list of columns to sort by, in order of precedence.
+	SortBy     []physical.ColumnExpression
+	Ascending  bool // Sorts lines in ascending order if true.
+	NullsFirst bool // When true, considers NULLs < non-NULLs when sorting.
+	K          int  // Number of top rows to compute.
+
+	// MaxUnused determines the maximum number of unused rows to retain. An
+	// unused row is any row from a retained record that does not contribute to
+	// the current top K.
+	//
+	// After the number of unused rows exceeds this value, retained records are
+	// compacted into a new record only containing the current used rows.
+	MaxUnused int
+}
+
+// topkPipeline performs a topk (SORT + LIMIT) operation across several input
+// pipelines.
+type topkPipeline struct {
+	inputs []Pipeline
+	batch  *topkBatch
+
+	computed bool
+	state    state
+}
+
+var _ Pipeline = (*topkPipeline)(nil)
+
+// newTopkPipeline creates a new topkPipeline with the given options.
+func newTopkPipeline(opts topkOptions) (*topkPipeline, error) {
+	fields, err := exprsToFields(opts.SortBy)
+	if err != nil {
+		return nil, err
+	}
+
+	return &topkPipeline{
+		inputs: opts.Inputs,
+		batch: &topkBatch{
+			Fields:     fields,
+			Ascending:  opts.Ascending,
+			NullsFirst: opts.NullsFirst,
+			K:          opts.K,
+			MaxUnused:  opts.MaxUnused,
+		},
+	}, nil
+}
+
+func exprsToFields(exprs []physical.ColumnExpression) ([]arrow.Field, error) {
+	fields := make([]arrow.Field, 0, len(exprs))
+	for _, expr := range exprs {
+		expr, ok := expr.(*physical.ColumnExpr)
+		if !ok {
+			panic("topkPipeline only supports ColumnExpr expressions")
+		}
+
+		if expr.Ref.Type == types.ColumnTypeAmbiguous {
+			// TODO(rfratto): It's not clear how topk should sort when there's an
+			// ambiguous column reference, since ambiguous column references can
+			// refer to multiple columns.
+			return nil, fmt.Errorf("topkPipeline does not support ambiguous column types")
+		}
+
+		dt, md := arrowTypeFromColumnRef(expr.Ref)
+
+		fields = append(fields, arrow.Field{
+			Name:     expr.Ref.Column,
+			Type:     dt,
+			Nullable: true,
+			Metadata: md,
+		})
+	}
+
+	return fields, nil
+}
+
+// Read computes the topk as the next record. Read blocks until all input
+// pipelines have been fully read and the top K rows have been computed.
+func (p *topkPipeline) Read(ctx context.Context) error {
+	if !p.computed {
+		p.state.batch, p.state.err = p.compute(ctx)
+		p.computed = true
+	} else if p.state.err == nil {
+		p.state.batch, p.state.err = nil, EOF
+	}
+
+	return p.state.err
+}
+
+func (p *topkPipeline) compute(ctx context.Context) (arrow.Record, error) {
+NextInput:
+	for _, in := range p.Inputs() {
+		for {
+			err := in.Read(ctx)
+			if err != nil && errors.Is(err, EOF) {
+				continue NextInput
+			} else if err != nil {
+				return nil, err
+			}
+
+			rec, err := in.Value()
+			if err != nil {
+				return nil, err
+			}
+
+			p.batch.Put(memory.DefaultAllocator, rec)
+
+			// Release the record; p.batch.Put will add an extra retain if necessary.
+			rec.Release()
+		}
+	}
+
+	compacted := p.batch.Compact(memory.DefaultAllocator)
+	if compacted == nil {
+		return nil, EOF
+	}
+	return compacted, nil
+}
+
+// Value returns the topk record computed by the pipeline after
+// [topkPipeline.Read] has been called.
+func (p *topkPipeline) Value() (arrow.Record, error) { return p.state.Value() }
+
+// Close closes the resources of the pipeline.
+func (p *topkPipeline) Close() {
+	p.batch.Reset()
+	for _, in := range p.inputs {
+		in.Close()
+	}
+}
+
+func (p *topkPipeline) Inputs() []Pipeline { return p.inputs }
+
+func (p *topkPipeline) Transport() Transport { return Local }

--- a/pkg/engine/executor/topk_test.go
+++ b/pkg/engine/executor/topk_test.go
@@ -1,0 +1,119 @@
+package executor
+
+import (
+	"testing"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/engine/internal/datatype"
+	"github.com/grafana/loki/v3/pkg/engine/internal/types"
+	"github.com/grafana/loki/v3/pkg/engine/planner/physical"
+	"github.com/grafana/loki/v3/pkg/util/arrowtest"
+)
+
+func Test_topk(t *testing.T) {
+	alloc := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer alloc.AssertSize(t, 0)
+
+	var (
+		fields = []arrow.Field{
+			{
+				Name:     types.ColumnNameBuiltinTimestamp,
+				Type:     arrow.FixedWidthTypes.Timestamp_ns,
+				Nullable: true,
+				Metadata: datatype.ColumnMetadata(
+					types.ColumnTypeBuiltin,
+					datatype.Loki.Timestamp,
+				),
+			},
+			{
+				Name:     types.ColumnNameBuiltinMessage,
+				Type:     arrow.BinaryTypes.String,
+				Nullable: true,
+				Metadata: datatype.ColumnMetadata(
+					types.ColumnTypeBuiltin,
+					datatype.Loki.String,
+				),
+			},
+		}
+
+		schema = arrow.NewSchema(fields, nil)
+	)
+
+	var (
+		pipelineA = NewArrowtestPipeline(alloc, schema, arrowtest.Rows{
+			{"timestamp": time.Unix(1, 0).UTC(), "message": "line A"},
+			{"timestamp": time.Unix(6, 0).UTC(), "message": "line F"},
+		}, arrowtest.Rows{
+			{"timestamp": time.Unix(2, 0).UTC(), "message": "line B"},
+			{"timestamp": time.Unix(7, 0).UTC(), "message": "line G"},
+		}, arrowtest.Rows{
+			{"timestamp": time.Unix(3, 0).UTC(), "message": "line C"},
+			{"timestamp": time.Unix(8, 0).UTC(), "message": "line H"},
+		})
+
+		pipelineB = NewArrowtestPipeline(alloc, schema, arrowtest.Rows{
+			{"timestamp": time.Unix(4, 0).UTC(), "message": "line D"},
+			{"timestamp": time.Unix(9, 0).UTC(), "message": "line I"},
+		}, arrowtest.Rows{
+			{"timestamp": time.Unix(5, 0).UTC(), "message": "line E"},
+			{"timestamp": time.Unix(10, 0).UTC(), "message": "line J"},
+		})
+	)
+
+	topkPipeline, err := newTopkPipeline(topkOptions{
+		Inputs: []Pipeline{pipelineA, pipelineB},
+		SortBy: []physical.ColumnExpression{
+			&physical.ColumnExpr{
+				Ref: types.ColumnRef{Column: types.ColumnNameBuiltinTimestamp, Type: types.ColumnTypeBuiltin},
+			},
+		},
+		Ascending: true,
+		K:         3,
+		MaxUnused: 5,
+	})
+	require.NoError(t, err, "should be able to create a topk pipeline")
+	defer topkPipeline.Close()
+
+	require.NoError(t, topkPipeline.Read(t.Context()), "should be able to read the sorted batch")
+
+	rec, err := topkPipeline.Value()
+	require.NoError(t, err)
+	defer rec.Release()
+
+	expect := arrowtest.Rows{
+		{"timestamp": time.Unix(1, 0).UTC(), "message": "line A"},
+		{"timestamp": time.Unix(2, 0).UTC(), "message": "line B"},
+		{"timestamp": time.Unix(3, 0).UTC(), "message": "line C"},
+	}
+
+	rows, err := arrowtest.RecordRows(rec)
+	require.NoError(t, err, "should be able to convert record back to rows")
+
+	require.Equal(t, expect, rows, "should return the top 3 rows in ascending order by timestamp")
+}
+
+func Test_topk_emptyPipelines(t *testing.T) {
+	topkPipeline, err := newTopkPipeline(topkOptions{
+		Inputs: []Pipeline{emptyPipeline()},
+		SortBy: []physical.ColumnExpression{
+			&physical.ColumnExpr{
+				Ref: types.ColumnRef{Column: types.ColumnNameBuiltinTimestamp, Type: types.ColumnTypeBuiltin},
+			},
+		},
+		Ascending: true,
+		K:         3,
+		MaxUnused: 5,
+	})
+	require.NoError(t, err, "should be able to create a topk pipeline")
+	defer topkPipeline.Close()
+
+	require.ErrorIs(t, topkPipeline.Read(t.Context()), EOF, "should return EOF if there are no results")
+
+	rec, err := topkPipeline.Value()
+	require.Nil(t, rec, "should not return a record if there are no results")
+	require.ErrorIs(t, err, EOF, "should return EOF if there are no results")
+}

--- a/pkg/engine/executor/util_test.go
+++ b/pkg/engine/executor/util_test.go
@@ -3,6 +3,7 @@ package executor
 import (
 	"context"
 	"errors"
+	"math"
 	"testing"
 	"time"
 
@@ -12,6 +13,7 @@ import (
 
 	"github.com/grafana/loki/v3/pkg/engine/internal/datatype"
 	"github.com/grafana/loki/v3/pkg/engine/internal/types"
+	"github.com/grafana/loki/v3/pkg/util/arrowtest"
 )
 
 var (
@@ -131,3 +133,67 @@ func collect(t *testing.T, pipeline Pipeline) (batches int64, rows int64) {
 	}
 	return batches, rows
 }
+
+// ArrowtestPipeline creates a [Pipeline] that emits test data from a sequence
+// of [arrowtest.Rows].
+type ArrowtestPipeline struct {
+	alloc  memory.Allocator
+	schema *arrow.Schema
+	rows   []arrowtest.Rows
+
+	cur   int
+	state state
+}
+
+var _ Pipeline = (*ArrowtestPipeline)(nil)
+
+// NewArrowtestPipeline creates a new ArrowtestPipeline which will emit each
+// [arrowtest.Rows] as a record.
+//
+// If schema is defined, all rows will be emitted using that schema. If schema
+// is nil, the schema is derived from each element in rows as it is emitted.
+func NewArrowtestPipeline(alloc memory.Allocator, schema *arrow.Schema, rows ...arrowtest.Rows) *ArrowtestPipeline {
+	if alloc == nil {
+		alloc = memory.DefaultAllocator
+	}
+
+	return &ArrowtestPipeline{
+		alloc:  alloc,
+		schema: schema,
+		rows:   rows,
+	}
+}
+
+// Read implements [Pipeline], converting the next [arrowtest.Rows] into a
+// [arrow.Record] and storing it in the pipeline's state. The state can then be
+// accessed via [ArrowtestPipeline.Value].
+func (p *ArrowtestPipeline) Read(_ context.Context) error {
+	if p.cur >= len(p.rows) {
+		p.state = Exhausted
+		return EOF
+	}
+
+	rows := p.rows[p.cur]
+	schema := p.schema
+
+	if schema == nil {
+		schema = rows.Schema()
+	}
+
+	p.cur++
+	p.state.batch, p.state.err = rows.Record(p.alloc, schema), nil
+	return p.state.err
+}
+
+// Value implements [Pipeline], returning the current record and error
+// determined by the latest call to [ArrowtestPipeline.Read].
+func (p *ArrowtestPipeline) Value() (arrow.Record, error) { return p.state.Value() }
+
+// Close implements [Pipeline], immediately exhausting the pipeline.
+func (p *ArrowtestPipeline) Close() { p.cur = math.MaxInt64 }
+
+// Inputs implements [Pipeline], returning nil as this pipeline has no inputs.
+func (p *ArrowtestPipeline) Inputs() []Pipeline { return nil }
+
+// Transport implements [Pipeline], returning [Local].
+func (p *ArrowtestPipeline) Transport() Transport { return Local }

--- a/pkg/logql/engine.go
+++ b/pkg/logql/engine.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/flagext"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/common/model"
@@ -169,14 +170,26 @@ type EngineOpts struct {
 
 	// CataloguePath is the path to the catalogue in the object store.
 	CataloguePath string `yaml:"-" doc:"hidden" category:"experimental"`
+
+	// DataobjScanPageCacheSize determines how many bytes of future page data
+	// should be downloaded before it's immediately needed. Used to reduce the
+	// number of roundtrips to object storage. Setting to zero disables
+	// downloading pages that are not immediately needed.
+	//
+	// This setting is only used when the v2 engine is being used.
+	DataobjScanPageCacheSize flagext.Bytes `yaml:"dataobjscan_page_cache_size" category:"experimental"`
 }
 
 func (opts *EngineOpts) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
+	_ = opts.DataobjScanPageCacheSize.Set("0B")
+
 	f.DurationVar(&opts.MaxLookBackPeriod, prefix+"max-lookback-period", 30*time.Second, "The maximum amount of time to look back for log lines. Used only for instant log queries.")
 	f.IntVar(&opts.MaxCountMinSketchHeapSize, prefix+"max-count-min-sketch-heap-size", 10_000, "The maximum number of labels the heap of a topk query using a count min sketch can track.")
 	f.BoolVar(&opts.EnableV2Engine, prefix+"enable-v2-engine", false, "Experimental: Enable next generation query engine for supported queries.")
 	f.IntVar(&opts.BatchSize, prefix+"batch-size", 100, "Experimental: Batch size of the next generation query engine.")
 	f.StringVar(&opts.CataloguePath, prefix+"catalogue-path", "", "The path to the catalogue in the object store.")
+	f.Var(&opts.DataobjScanPageCacheSize, prefix+"dataobjscan-page-cache-size", "Experimental: Maximum total size of future pages for DataObjScan to download before they are needed, for roundtrip reduction to object storage. Setting to zero disables downloading future pages. Only used in the next generation query engine.")
+
 	// Log executing query by default
 	opts.LogExecutingQuery = true
 }

--- a/pkg/util/arrowtest/arrowtest.go
+++ b/pkg/util/arrowtest/arrowtest.go
@@ -3,11 +3,9 @@ package arrowtest
 
 import (
 	"cmp"
-	"encoding/base64"
 	"fmt"
 	"slices"
 	"time"
-	"unsafe"
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
@@ -48,7 +46,7 @@ func (rows Rows) Schema() *arrow.Schema {
 		// in the following loop.
 		field := arrow.Field{
 			Name:     key,
-			Type:     scalar.MakeScalar(value).DataType(),
+			Type:     determineDatatype(value),
 			Nullable: true,
 		}
 
@@ -65,7 +63,7 @@ func (rows Rows) Schema() *arrow.Schema {
 			}
 			field := &fields[index]
 
-			gotType := scalar.MakeScalar(value).DataType()
+			gotType := determineDatatype(value)
 
 			if !arrow.TypeEqual(field.Type, gotType) {
 				// The types don't match. We need to check for nulls here:
@@ -88,6 +86,15 @@ func (rows Rows) Schema() *arrow.Schema {
 	})
 
 	return arrow.NewSchema(fields, nil)
+}
+
+func determineDatatype(value any) arrow.DataType {
+	switch value := value.(type) {
+	case time.Time:
+		return &arrow.TimestampType{Unit: arrow.Nanosecond, TimeZone: value.Location().String()}
+	default:
+		return scalar.MakeScalar(value).DataType()
+	}
 }
 
 // Record converts rows into an [arrow.Record] with the provided schema. A
@@ -113,7 +120,20 @@ func (rows Rows) Record(alloc memory.Allocator, schema *arrow.Schema) arrow.Reco
 			if value == nil {
 				fieldBuilder.AppendNull()
 				continue
-			} else if err := scalar.Append(fieldBuilder, scalar.MakeScalar(value)); err != nil {
+			}
+
+			var s scalar.Scalar
+
+			switch v := value.(type) {
+			case time.Time:
+				s = scalar.NewTimestampScalar(arrow.Timestamp(v.UnixNano()), determineDatatype(v))
+			case *time.Time:
+				s = scalar.NewTimestampScalar(arrow.Timestamp(v.UnixNano()), determineDatatype(v))
+			default:
+				s = scalar.MakeScalar(v)
+			}
+
+			if err := scalar.Append(fieldBuilder, s); err != nil {
 				panic(fmt.Sprintf("arrowtest.Record: failed to append value %v for column %q: %v", value, field.Name, err))
 			}
 		}
@@ -125,8 +145,7 @@ func (rows Rows) Record(alloc memory.Allocator, schema *arrow.Schema) arrow.Reco
 // RecordRows converts an [arrow.Record] into [Rows] for comparison in tests.
 // RecordRows requires all columns in the record to have a unique name.
 //
-// Most values are converted to their Go equivalents, with the exception of
-// timestamps, which are converted to strings using [Time].
+// All values are converted to their direct Go equivalents.
 //
 // Callers building expected [Rows] must use the same functions.
 func RecordRows(rec arrow.Record) (Rows, error) {
@@ -134,14 +153,32 @@ func RecordRows(rec arrow.Record) (Rows, error) {
 
 	for i := range int(rec.NumRows()) {
 		row := make(Row, rec.NumCols())
+
 		for j := range int(rec.NumCols()) {
-			row[rec.Schema().Field(j).Name] = rec.Column(j).GetOneForMarshal(i)
+			row[rec.Schema().Field(j).Name] = getArrayValue(rec.Column(j), i)
 		}
 
 		rows[i] = row
 	}
 
 	return rows, nil
+}
+
+// getArrayValue converts a value from an [arrow.Array] at the given index back
+// into a Go value. Timestamps have a special case so they are converted into a
+// [time.Time].
+func getArrayValue(arr arrow.Array, index int) any {
+	switch arr := arr.(type) {
+	case *array.Timestamp:
+		toTimestamp, err := arr.DataType().(*arrow.TimestampType).GetToTimeFunc()
+		if err != nil {
+			panic(err)
+		}
+		return toTimestamp(arr.Value(index))
+
+	default:
+		return arr.GetOneForMarshal(index)
+	}
 }
 
 // TableRows concatenates all chunks of the [arrow.Table] into a single
@@ -175,22 +212,4 @@ func mergeTable(alloc memory.Allocator, table arrow.Table) (arrow.Record, error)
 	}
 
 	return array.NewRecord(table.Schema(), recordColumns, table.NumRows()), nil
-}
-
-// Base64 encodes the given string as base64.
-func Base64(s string) string {
-	rawString := unsafe.Slice(unsafe.StringData(s), len(s))
-	return base64.StdEncoding.EncodeToString(rawString)
-}
-
-// Time returns a string representation of t in the format emitted by
-// [TableRows].
-//
-// Callers must configure t with the same timezone and precision used by the
-// Arrow column.
-func Time(t time.Time) string {
-	// This is the format used by [array.Timestamp.ValueStr]. Arrow will
-	// automatically truncate the timestamp before formatting it, but we bypass
-	// that here to make it the caller's responsibility instead.
-	return t.Format("2006-01-02 15:04:05.999999999Z0700")
 }

--- a/pkg/util/arrowtest/arrowtest_test.go
+++ b/pkg/util/arrowtest/arrowtest_test.go
@@ -2,6 +2,7 @@ package arrowtest_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/memory"
@@ -69,6 +70,46 @@ func TestRows_Record(t *testing.T) {
 		{"name": "Bob", "age": int64(25), "location": "Builderland"},
 		{"name": "Dennis", "age": int64(40), "location": nil},
 		{"name": "Eve", "age": int64(35), "location": "Eden"},
+	}
+
+	alloc := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer alloc.AssertSize(t, 0)
+
+	record := expect.Record(alloc, expect.Schema())
+	defer record.Release()
+
+	actual, err := arrowtest.RecordRows(record)
+	require.NoError(t, err)
+
+	require.Equal(t, expect, actual)
+}
+
+func TestRows_Record_Bytes(t *testing.T) {
+	expect := arrowtest.Rows{
+		{"name": []byte("Alice")},
+		{"name": []byte("Bob")},
+		{"name": []byte("Dennis")},
+		{"name": []byte("Eve")},
+	}
+
+	alloc := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer alloc.AssertSize(t, 0)
+
+	record := expect.Record(alloc, expect.Schema())
+	defer record.Release()
+
+	actual, err := arrowtest.RecordRows(record)
+	require.NoError(t, err)
+
+	require.Equal(t, expect, actual)
+}
+
+func TestRows_Record_Time(t *testing.T) {
+	expect := arrowtest.Rows{
+		{"name": "Alice", "last_ping": time.Unix(30, 0)},
+		{"name": "Bob", "last_ping": time.Unix(25, 0)},
+		{"name": "Dennis", "last_ping": time.Unix(40, 0)},
+		{"name": "Eve", "last_ping": time.Unix(35, 0)},
 	}
 
 	alloc := memory.NewCheckedAllocator(memory.DefaultAllocator)


### PR DESCRIPTION
This PR follows up on the work started in #17976, where DataObjScan will now use the columnar reading APIs instead of the row-based APIs. 

As a result, a few things have changed:

* Projected columns are now respected by the reader; DataObjScan will only read columns from the projected list (or all columns if the projected list is empty).

* For implementation simplicity, the sort order of columns is now consistent, regardless of projection order. 

There was quite a bit of setup work I had to do to be able to make this change; I've split the full implementation across 12 commits for easier reviews.

Additionally, DataObjScan will now force a topk sort if the scanned section is not sorted by timestamp, or not sorted by the requested sort order. When this is done, DataObjScan no longer streams values and will fully compute sorted results from the input section before emitting values. **This applies to any dataobj built prior to #18499.**