### PR TITLE
chore(bench): add instant metric queries

### DIFF
--- a/pkg/logql/bench/bench_test.go
+++ b/pkg/logql/bench/bench_test.go
@@ -165,8 +165,6 @@ func TestStorageEquality(t *testing.T) {
 				}()
 
 				t.Logf("Query information:\n%s", baseCase.Description())
-				// t.Skip(t.Name())
-
 				params, err := logql.NewLiteralParams(
 					baseCase.Query,
 					baseCase.Start,

--- a/pkg/logql/bench/cmd/bench/main.go
+++ b/pkg/logql/bench/cmd/bench/main.go
@@ -133,7 +133,7 @@ func loadBenchmarks() []string {
 		os.Exit(1)
 	}
 
-	cases := config.GenerateTestCases()
+	cases := bench.NewTestCaseGenerator(bench.DefaultTestCaseGeneratorConfig, config).Generate()
 	var names []string
 	for _, c := range cases {
 		names = append(names, c.Name())
@@ -186,7 +186,7 @@ func listBenchmarks() {
 	}
 
 	// Generate test cases
-	cases := config.GenerateTestCases()
+	cases := bench.NewTestCaseGenerator(bench.DefaultTestCaseGeneratorConfig, config).Generate()
 
 	// Print each benchmark name
 	for _, c := range cases {

--- a/pkg/logql/bench/generator_query.go
+++ b/pkg/logql/bench/generator_query.go
@@ -102,11 +102,44 @@ func (c *GeneratorConfig) generateLabelCombinations() [][]labelMatcher {
 	return combinations
 }
 
+var DefaultTestCaseGeneratorConfig = TestCaseGeneratorConfig{
+	RangeType:     "range",
+	RangeInterval: time.Hour,
+}
+
+type TestCaseGeneratorConfig struct {
+	RangeType     string        // "instant" or "range"
+	RangeInterval time.Duration // Interval for range queries, e.g. "5m", "1h"
+}
+
+type TestCaseGenerator struct {
+	logGenCfg *GeneratorConfig
+	cfg       TestCaseGeneratorConfig
+}
+
+func NewTestCaseGenerator(cfg TestCaseGeneratorConfig, logGenCfg *GeneratorConfig) *TestCaseGenerator {
+	return &TestCaseGenerator{
+		cfg:       cfg,
+		logGenCfg: logGenCfg,
+	}
+}
+
 // GenerateTestCases creates a sorted list of test cases using the configuration
-func (c *GeneratorConfig) GenerateTestCases() []TestCase {
+func (g *TestCaseGenerator) Generate() []TestCase {
 	var cases []TestCase
-	labelCombos := c.generateLabelCombinations()
-	end := c.StartTime.Add(c.TimeSpread)
+	labelCombos := g.logGenCfg.generateLabelCombinations()
+
+	start := g.logGenCfg.StartTime
+	end := g.logGenCfg.StartTime.Add(g.logGenCfg.TimeSpread)
+	rangeInterval := g.cfg.RangeInterval
+	// Calculate step size to get ~20 points over the time range
+	step := g.logGenCfg.TimeSpread / 19
+
+	if g.cfg.RangeType == "instant" {
+		// for instant queries, search the whole time spread from end
+		start = end
+		step = 0
+	}
 
 	// Use a map to track unique queries
 	uniqueQueries := make(map[string]struct{})
@@ -150,30 +183,33 @@ func (c *GeneratorConfig) GenerateTestCases() []TestCase {
 		)
 	}
 
-	// Calculate step size to get ~20 points over the time range
-	step := c.TimeSpread / 19
-
 	// Basic label selector queries with line filters and structured metadata
+	if g.cfg.RangeType != "instant" { // log queries only support range type
+		for _, combo := range labelCombos {
+			selector := g.logGenCfg.buildLabelSelector(combo)
+
+			// Basic selector
+			addBidirectional(selector, g.logGenCfg.StartTime, end)
+
+			// With structured metadata filters
+			addBidirectional(selector+` | detected_level="error"`, g.logGenCfg.StartTime, end)
+			addBidirectional(selector+` | detected_level="warn"`, g.logGenCfg.StartTime, end)
+
+			// Combined filters
+			addBidirectional(selector+` |~ "error|exception" | detected_level="error"`, g.logGenCfg.StartTime, end)
+			addBidirectional(selector+` | json | duration_seconds > 0.1 | detected_level!="debug"`, g.logGenCfg.StartTime, end)
+			addBidirectional(selector+` | logfmt | level="error" | detected_level="error"`, g.logGenCfg.StartTime, end)
+		}
+	}
+
 	for _, combo := range labelCombos {
-		selector := c.buildLabelSelector(combo)
-
-		// Basic selector
-		addBidirectional(selector, c.StartTime, end)
-
-		// With structured metadata filters
-		addBidirectional(selector+` | detected_level="error"`, c.StartTime, end)
-		addBidirectional(selector+` | detected_level="warn"`, c.StartTime, end)
-
-		// Combined filters
-		addBidirectional(selector+` |~ "error|exception" | detected_level="error"`, c.StartTime, end)
-		addBidirectional(selector+` | json | duration_seconds > 0.1 | detected_level!="debug"`, c.StartTime, end)
-		addBidirectional(selector+` | logfmt | level="error" | detected_level="error"`, c.StartTime, end)
+		selector := g.logGenCfg.buildLabelSelector(combo)
 
 		// Metric queries with structured metadata
 		baseRangeAggregationQueries := []string{
-			fmt.Sprintf(`count_over_time(%s[5m])`, selector),
-			fmt.Sprintf(`count_over_time(%s | detected_level=~"error|warn" [5m])`, selector),
-			fmt.Sprintf(`rate(%s | detected_level=~"error|warn" [5m])`, selector),
+			fmt.Sprintf(`count_over_time(%s[%s])`, selector, rangeInterval),
+			fmt.Sprintf(`count_over_time(%s | detected_level=~"error|warn" [%s])`, selector, rangeInterval),
+			fmt.Sprintf(`rate(%s | detected_level=~"error|warn" [%s])`, selector, rangeInterval),
 		}
 
 		// Single dimension aggregations
@@ -181,7 +217,7 @@ func (c *GeneratorConfig) GenerateTestCases() []TestCase {
 		for _, dim := range dimensions {
 			for _, baseMetricQuery := range baseRangeAggregationQueries {
 				query := fmt.Sprintf(`sum by (%s) (%s)`, dim, baseMetricQuery)
-				addMetricQuery(query, c.StartTime.Add(5*time.Minute), end, step)
+				addMetricQuery(query, start, end, step)
 			}
 		}
 
@@ -193,38 +229,40 @@ func (c *GeneratorConfig) GenerateTestCases() []TestCase {
 		for _, dims := range twoDimCombos {
 			for _, baseMetricQuery := range baseRangeAggregationQueries {
 				query := fmt.Sprintf(`sum by (%s, %s) (%s)`, dims[0], dims[1], baseMetricQuery)
-				addMetricQuery(query, c.StartTime.Add(5*time.Minute), end, step)
+				addMetricQuery(query, start, end, step)
 			}
-		}
-
-		// Error rates by severity
-		errorQueries := []string{
-			fmt.Sprintf(`sum by (component) (rate(%s | detected_level="error" [5m]))`, selector),
-			fmt.Sprintf(`sum by (component) (rate(%s | detected_level="warn" [5m]))`, selector),
-			fmt.Sprintf(`sum by (component, detected_level) (rate(%s | detected_level=~"error|warn" [5m]))`, selector),
-		}
-		for _, query := range errorQueries {
-			addMetricQuery(query, c.StartTime.Add(5*time.Minute), end, step)
 		}
 	}
 
 	// Dense period queries
-	for _, interval := range c.DenseIntervals {
-		combo := labelCombos[c.NewRand().Intn(len(labelCombos))]
-		selector := c.buildLabelSelector(combo)
-		addBidirectional(
-			selector+` | detected_level=~"error|warn"`,
-			interval.Start,
-			interval.Start.Add(interval.Duration),
-		)
+	for _, interval := range g.logGenCfg.DenseIntervals {
+		combo := labelCombos[g.logGenCfg.NewRand().Intn(len(labelCombos))]
+		selector := g.logGenCfg.buildLabelSelector(combo)
+		if g.cfg.RangeType != "instant" {
+			addBidirectional(
+				selector+` | detected_level=~"error|warn"`,
+				interval.Start,
+				interval.Start.Add(interval.Duration),
+			)
+		}
+
+		start := interval.Start
+		end := interval.Start.Add(interval.Duration)
+		step := interval.Duration / 19
+		rangeInterval := time.Minute
+		if g.cfg.RangeType == "instant" {
+			start = end
+			step = 0
+			rangeInterval = g.cfg.RangeInterval
+		}
 
 		// Add metric queries for dense periods
-		rateQuery := fmt.Sprintf(`sum by (component, detected_level) (rate(%s[1m]))`, selector)
+		rateQuery := fmt.Sprintf(`sum by (component, detected_level) (rate(%s[%s]))`, selector, rangeInterval)
 		addMetricQuery(
 			rateQuery,
-			interval.Start,
-			interval.Start.Add(interval.Duration),
-			interval.Duration/19,
+			start,
+			end,
+			step,
 		)
 	}
 

--- a/pkg/logql/bench/generator_test.go
+++ b/pkg/logql/bench/generator_test.go
@@ -137,8 +137,8 @@ func TestQueryDeterminism(t *testing.T) {
 	}
 
 	// Generate test cases with the same configuration
-	cases1 := cfg.GenerateTestCases()
-	cases2 := cfg.GenerateTestCases()
+	cases1 := NewTestCaseGenerator(DefaultTestCaseGeneratorConfig, &cfg).Generate()
+	cases2 := NewTestCaseGenerator(DefaultTestCaseGeneratorConfig, &cfg).Generate()
 
 	require.Equal(t, len(cases1), len(cases2), "Number of test cases should match")
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds instant metric queries to bench test which can be invoked by setting `--range-type=instant`


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
