### PR TITLE
chore(engine): don't sort metric queries

### DIFF
--- a/pkg/engine/executor/sortmerge_test.go
+++ b/pkg/engine/executor/sortmerge_test.go
@@ -29,6 +29,7 @@ func TestSortMerge(t *testing.T) {
 					Type:   types.ColumnTypeBuiltin,
 				},
 			},
+			Order: physical.ASC,
 		}
 
 		inputs := []Pipeline{

--- a/pkg/engine/planner/logical/planner.go
+++ b/pkg/engine/planner/logical/planner.go
@@ -105,10 +105,12 @@ func buildPlanForLogQuery(expr syntax.LogSelectorExpr, params logql.Params, isMe
 		return nil, fmt.Errorf("forward search log queries are not supported: %w", errUnimplemented)
 	}
 
-	// SORT -> SortMerge
-	// We always sort DESC. ASC timestamp sorting is not supported for logs queries,
-	// and metric queries do not care about the direction.
-	builder = builder.Sort(*timestampColumnRef(), false, false)
+	if !isMetricQuery {
+		// SORT -> SortMerge
+		// We always sort DESC. ASC timestamp sorting is not supported for logs
+		// queries, and metric queries do not need sorting.
+		builder = builder.Sort(*timestampColumnRef(), false, false)
+	}
 
 	// SELECT -> Filter
 	start := params.Start()

--- a/pkg/engine/planner/logical/planner_test.go
+++ b/pkg/engine/planner/logical/planner_test.go
@@ -136,17 +136,16 @@ func TestConvertAST_MetricQuery_Success(t *testing.T) {
 	expected := `%1 = EQ label.cluster "prod"
 %2 = MATCH_RE label.namespace "loki-.*"
 %3 = AND %1 %2
-%4 = MAKETABLE [selector=%3, predicates=[%10], shard=0_of_1]
-%5 = SORT %4 [column=builtin.timestamp, asc=false, nulls_first=false]
-%6 = GTE builtin.timestamp 1970-01-01T00:55:00Z
-%7 = SELECT %5 [predicate=%6]
-%8 = LT builtin.timestamp 1970-01-01T02:00:00Z
-%9 = SELECT %7 [predicate=%8]
-%10 = MATCH_STR builtin.message "metric.go"
-%11 = SELECT %9 [predicate=%10]
-%12 = RANGE_AGGREGATION %11 [operation=count, start_ts=1970-01-01T01:00:00Z, end_ts=1970-01-01T02:00:00Z, step=0s, range=5m0s]
-%13 = VECTOR_AGGREGATION %12 [operation=sum, group_by=(ambiguous.level)]
-RETURN %13
+%4 = MAKETABLE [selector=%3, predicates=[%9], shard=0_of_1]
+%5 = GTE builtin.timestamp 1970-01-01T00:55:00Z
+%6 = SELECT %4 [predicate=%5]
+%7 = LT builtin.timestamp 1970-01-01T02:00:00Z
+%8 = SELECT %6 [predicate=%7]
+%9 = MATCH_STR builtin.message "metric.go"
+%10 = SELECT %8 [predicate=%9]
+%11 = RANGE_AGGREGATION %10 [operation=count, start_ts=1970-01-01T01:00:00Z, end_ts=1970-01-01T02:00:00Z, step=0s, range=5m0s]
+%12 = VECTOR_AGGREGATION %11 [operation=sum, group_by=(ambiguous.level)]
+RETURN %12
 `
 
 	require.Equal(t, expected, logicalPlan.String())

--- a/pkg/engine/planner/physical/planner.go
+++ b/pkg/engine/planner/physical/planner.go
@@ -172,12 +172,7 @@ func (p *Planner) processMakeTable(lp *logical.MakeTable, ctx *Context) ([]Node,
 
 	nodes := make([]Node, 0, len(objects))
 	for i := range objects {
-
-		node := &SortMerge{
-			Column: newColumnExpr(types.ColumnNameBuiltinTimestamp, types.ColumnTypeBuiltin),
-			Order:  ctx.direction, // apply direction from previously visited Sort node
-		}
-		p.plan.addNode(node)
+		scans := make([]Node, 0, len(sections[i]))
 
 		for _, section := range sections[i] {
 			scan := &DataObjScan{
@@ -187,12 +182,27 @@ func (p *Planner) processMakeTable(lp *logical.MakeTable, ctx *Context) ([]Node,
 				Direction: ctx.direction, // apply direction from previously visited Sort node
 			}
 			p.plan.addNode(scan)
-			if err := p.plan.addEdge(Edge{Parent: node, Child: scan}); err != nil {
-				return nil, err
-			}
+
+			scans = append(scans, scan)
 		}
 
-		nodes = append(nodes, node)
+		if ctx.direction != UNSORTED && len(scans) > 0 {
+			sortMerge := &SortMerge{
+				Column: newColumnExpr(types.ColumnNameBuiltinTimestamp, types.ColumnTypeBuiltin),
+				Order:  ctx.direction, // apply direction from previously visited Sort node
+			}
+			p.plan.addNode(sortMerge)
+
+			for _, scan := range scans {
+				if err := p.plan.addEdge(Edge{Parent: sortMerge, Child: scan}); err != nil {
+					return nil, err
+				}
+			}
+
+			nodes = append(nodes, sortMerge)
+		} else {
+			nodes = append(nodes, scans...)
+		}
 	}
 	return nodes, nil
 }

--- a/pkg/engine/planner/physical/planner_test.go
+++ b/pkg/engine/planner/physical/planner_test.go
@@ -110,28 +110,32 @@ func TestMockCatalog(t *testing.T) {
 
 func locations(t *testing.T, plan *Plan, nodes []Node) []string {
 	res := make([]string, 0, len(nodes))
+
+	visitor := &nodeCollectVisitor{
+		onVisitDataObjScan: func(scan *DataObjScan) error {
+			res = append(res, string(scan.Location))
+			return nil
+		},
+	}
+
 	for _, n := range nodes {
-		for _, scan := range plan.Children(n) {
-			obj, ok := scan.(*DataObjScan)
-			if !ok {
-				t.Fatalf("failed to cast Node to DataObjScan, got %T", n)
-			}
-			res = append(res, string(obj.Location))
-		}
+		plan.DFSWalk(n, visitor, PreOrderWalk)
 	}
 	return res
 }
 
 func sections(t *testing.T, plan *Plan, nodes []Node) [][]int {
 	res := make([][]int, 0, len(nodes))
+
+	visitor := &nodeCollectVisitor{
+		onVisitDataObjScan: func(scan *DataObjScan) error {
+			res = append(res, []int{scan.Section})
+			return nil
+		},
+	}
+
 	for _, n := range nodes {
-		for _, scan := range plan.Children(n) {
-			obj, ok := scan.(*DataObjScan)
-			if !ok {
-				t.Fatalf("failed to cast Node to DataObjScan, got %T", n)
-			}
-			res = append(res, []int{obj.Section})
-		}
+		plan.DFSWalk(n, visitor, PreOrderWalk)
 	}
 	return res
 }

--- a/pkg/engine/planner/physical/sortmerge.go
+++ b/pkg/engine/planner/physical/sortmerge.go
@@ -5,13 +5,16 @@ import "fmt"
 type SortOrder uint8
 
 const (
-	ASC SortOrder = iota
+	UNSORTED SortOrder = iota
+	ASC
 	DESC
 )
 
 // String returns the string representation of the [SortOrder].
 func (o SortOrder) String() string {
 	switch o {
+	case UNSORTED:
+		return "UNSORTED"
 	case ASC:
 		return "ASC"
 	case DESC:


### PR DESCRIPTION
Bypassing SortMerge for metric queries appears to significantly speed up query time.

This commit changes the default sort order from ASC to the new value UNSORTED, and removes applying sort for metric queries.

To support this change, the physical planner needed to be updated so that a SortMerge doesn't always wrap DataObjScan nodes.