### PR TITLE
fix(loki-canary): set default streamvalue based on push flag unless explicitly passed

### DIFF
--- a/cmd/loki-canary/main.go
+++ b/cmd/loki-canary/main.go
@@ -95,11 +95,21 @@ func main() {
 
 	flag.Parse()
 
-	// Override streamvalue based on push flag
-	if *push {
-		*sValue = "push"
-	} else {
-		*sValue = "stdout"
+	// Check if streamvalue was explicitly passed by user
+	streamValueSet := false
+	flag.Visit(func(f *flag.Flag) {
+		if f.Name == "streamvalue" {
+			streamValueSet = true
+		}
+	})
+
+	// Override streamvalue based on push flag only if streamvalue wasn't set
+	if !streamValueSet {
+		if *push {
+			*sValue = "push"
+		} else {
+			*sValue = "stdout"
+		}
 	}
 
 	if *printVersion {

--- a/cmd/loki-canary/main.go
+++ b/cmd/loki-canary/main.go
@@ -103,7 +103,7 @@ func main() {
 		}
 	})
 
-	// Override streamvalue based on push flag only if streamvalue wasn't set
+	// Override streamvalue based on push flag if streamvalue wasn't set
 	if !streamValueSet {
 		if *push {
 			*sValue = "push"

--- a/cmd/loki-canary/main.go
+++ b/cmd/loki-canary/main.go
@@ -95,6 +95,13 @@ func main() {
 
 	flag.Parse()
 
+	// Override streamvalue based on push flag
+	if *push {
+		*sValue = "push"
+	} else {
+		*sValue = "stdout"
+	}
+
 	if *printVersion {
 		fmt.Println(version.Print("loki-canary"))
 		os.Exit(0)


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes a misleading default behavior in the `loki-canary` tool where the `-streamvalue` flag was always defaulted to `"stdout"`, regardless of whether the `-push` flag was set.

In scenarios where the `-push` flag is set to true, `loki-canary` pushes logs directly to the Loki server over HTTP and does not write logs to `stdout`. However, the default value for the `-streamvalue` flag remained `"stdout"`, which is inaccurate and potentially confusing when observing the stream name in log queries or UI.

**This PR changes the behavior so that:**

- If `-streamvalue` is **explicitly provided** via CLI, it takes precedence and is respected.
- If `-streamvalue` is **not passed**:
  - And `-push=true` → streamvalue defaults to `"push"`
  - And `-push=false` → streamvalue defaults to `"stdout"` (as before)

**Which issue(s) this PR fixes**:
Fixes #18597

**Special notes for your reviewer**:

- The logic uses `flag.Visit()` to detect whether `-streamvalue` was explicitly passed.
- This change preserves backward compatibility for users who pass `-streamvalue` explicitly.
- No configuration or API-breaking changes.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
