### PR TITLE
chore(engine): add predicate columns to projection list for metric queries

### DIFF
--- a/pkg/engine/planner/physical/optimizer.go
+++ b/pkg/engine/planner/physical/optimizer.go
@@ -198,15 +198,32 @@ func (r *projectionPushdown) apply(node Node) bool {
 		// Always project timestamp column
 		projections[len(node.PartitionBy)] = &ColumnExpr{Ref: types.ColumnRef{Column: types.ColumnNameBuiltinTimestamp, Type: types.ColumnTypeBuiltin}}
 
-		return r.applyProjectionPushdown(node, projections)
-	}
+		return r.applyProjectionPushdown(node, projections, false)
+	case *Filter:
+		projections := extractColumnsFromPredicates(node.Predicates)
+		if len(projections) == 0 {
+			return false
+		}
 
+		// Filter nodes should only add their predicate columns to projections when
+		// there's already a projection list in the plan (indicating a metric query).
+		// For log queries that read all columns, filter columns should not be projected.
+		//
+		// Setting applyIfNotEmpty argument as true for this reason.
+		return r.applyProjectionPushdown(node, projections, true)
+	}
 	return false
 }
 
-func (r *projectionPushdown) applyProjectionPushdown(node Node, projections []ColumnExpression) bool {
+// applyProjectionPushdown applies the projection pushdown rule to the given node.
+// if applyIfNotEmpty is true, it will apply the projection pushdown only if the node has existing projections.
+func (r *projectionPushdown) applyProjectionPushdown(node Node, projections []ColumnExpression, applyIfNotEmpty bool) bool {
 	switch node := node.(type) {
 	case *DataObjScan:
+		if len(node.Projections) == 0 && applyIfNotEmpty {
+			return false
+		}
+
 		// Add to scan projections if not already present
 		changed := false
 		for _, colExpr := range projections {
@@ -235,7 +252,7 @@ func (r *projectionPushdown) applyProjectionPushdown(node Node, projections []Co
 
 	anyChanged := false
 	for _, child := range r.plan.Children(node) {
-		if changed := r.applyProjectionPushdown(child, projections); changed {
+		if changed := r.applyProjectionPushdown(child, projections, applyIfNotEmpty); changed {
 			anyChanged = true
 		}
 	}
@@ -298,16 +315,56 @@ func (o *optimization) applyRules(node Node) bool {
 
 // The optimizer can optimize physical plans using the provided optimization passes.
 type optimizer struct {
-	plan   *Plan
-	passes []*optimization
+	plan          *Plan
+	optimisations []*optimization
 }
 
 func newOptimizer(plan *Plan, passes []*optimization) *optimizer {
-	return &optimizer{plan: plan, passes: passes}
+	return &optimizer{plan: plan, optimisations: passes}
 }
 
 func (o *optimizer) optimize(node Node) {
-	for _, pass := range o.passes {
-		pass.optimize(node)
+	for _, optimisation := range o.optimisations {
+		optimisation.optimize(node)
 	}
+}
+
+func extractColumnsFromPredicates(predicates []Expression) []ColumnExpression {
+	columns := make([]ColumnExpression, 0, len(predicates))
+	for _, p := range predicates {
+		extractColumnsFromExpression(p, &columns)
+	}
+
+	return deduplicateColumns(columns)
+}
+
+func extractColumnsFromExpression(expr Expression, columns *[]ColumnExpression) {
+	switch e := expr.(type) {
+	case *ColumnExpr:
+		*columns = append(*columns, e)
+	case *BinaryExpr:
+		extractColumnsFromExpression(e.Left, columns)
+		extractColumnsFromExpression(e.Right, columns)
+	case *UnaryExpr:
+		extractColumnsFromExpression(e.Left, columns)
+	default:
+		// Ignore other expression types
+	}
+}
+
+func deduplicateColumns(columns []ColumnExpression) []ColumnExpression {
+	seen := make(map[string]bool)
+	var result []ColumnExpression
+
+	for _, col := range columns {
+		if colExpr, ok := col.(*ColumnExpr); ok {
+			key := colExpr.Ref.Column
+			if !seen[key] {
+				seen[key] = true
+				result = append(result, col)
+			}
+		}
+	}
+
+	return result
 }

--- a/pkg/engine/planner/physical/planner.go
+++ b/pkg/engine/planner/physical/planner.go
@@ -317,7 +317,6 @@ func (p *Planner) processVectorAggregation(lp *logical.VectorAggregation, ctx *C
 // to the scan nodes.
 func (p *Planner) Optimize(plan *Plan) (*Plan, error) {
 	for i, root := range plan.Roots() {
-
 		optimizations := []*optimization{
 			newOptimization("PredicatePushdown", plan).withRules(
 				&predicatePushdown{plan: plan},


### PR DESCRIPTION
**What this PR does / why we need it**:

Column expressions from predicates are not being pushed down during query plan optimisation resulting in incorrect results for metric queries with filter expressions.

This PR updates the `projectionPushdown` optimiser to pushdown predicate columns from `Filter` node for metric queries

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
