### PR TITLE
chore(dataobj): return Object on Builder.Flush

### DIFF
--- a/pkg/dataobj/builder.go
+++ b/pkg/dataobj/builder.go
@@ -3,6 +3,9 @@ package dataobj
 import (
 	"bytes"
 	"fmt"
+	"io"
+
+	"github.com/grafana/loki/v3/pkg/dataobj/internal/util/bufpool"
 )
 
 // A Builder builds data objects from a set of incoming log data. Log data is
@@ -56,22 +59,48 @@ func (b *Builder) Bytes() int {
 	return b.encoder.Bytes()
 }
 
-// Flush flushes all buffered data to the buffer provided. Calling Flush can
-// result in a no-op if there is no buffered data to flush.
+// Flush constructs a new Object from the accumulated sections. Allocated
+// resources for the Object must be released by calling Close on the returned
+// io.Closer. After closing, the returned Object must no longer be read.
 //
-// [Builder.Reset] is called after a successful Flush to discard any pending
-// data and allow new data to be appended.
-func (b *Builder) Flush(output *bytes.Buffer) (int64, error) {
-	sz, err := b.encoder.Flush(output)
+// Flush returns an error if the object could not be constructed.
+// [Builder.Reset] is called after a successful flush to discard any pending
+// data, allowing new data to be appended.
+func (b *Builder) Flush() (*Object, io.Closer, error) {
+	flushSize, err := b.encoder.FlushSize()
 	if err != nil {
-		return sz, fmt.Errorf("building object: %w", err)
+		return nil, nil, fmt.Errorf("determining object size: %w", err)
+	}
+
+	buf := bufpool.Get(int(flushSize))
+
+	closer := func() error {
+		bufpool.Put(buf)
+		return nil
+	}
+
+	sz, err := b.encoder.Flush(buf)
+	if err != nil {
+		return nil, nil, fmt.Errorf("flushing object: %w", err)
+	}
+
+	obj, err := FromReaderAt(bytes.NewReader(buf.Bytes()), sz)
+	if err != nil {
+		bufpool.Put(buf)
+		return nil, nil, fmt.Errorf("error building object: %w", err)
 	}
 
 	b.Reset()
-	return sz, nil
+	return obj, funcIOCloser(closer), nil
 }
 
 // Reset discards pending data and resets the builder to an empty state.
 func (b *Builder) Reset() {
 	b.encoder.Reset()
+}
+
+type funcIOCloser func() error
+
+func (fc funcIOCloser) Close() error {
+	return fc()
 }

--- a/pkg/dataobj/consumer/logsobj/builder.go
+++ b/pkg/dataobj/consumer/logsobj/builder.go
@@ -2,11 +2,11 @@
 package logsobj
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"time"
 
 	"github.com/grafana/dskit/flagext"
@@ -293,26 +293,23 @@ func (b *Builder) estimatedSize() int {
 	return size
 }
 
-type FlushStats struct {
-	MinTimestamp time.Time
-	MaxTimestamp time.Time
+// TimeRange returns the current time range of the builder.
+func (b *Builder) TimeRange() (time.Time, time.Time) {
+	return b.streams.TimeRange()
 }
 
 // Flush flushes all buffered data to the buffer provided. Calling Flush can result
 // in a no-op if there is no buffered data to flush.
 //
-// [Builder.Reset] is called after a successful Flush to discard any pending data and allow new data to be appended.
-func (b *Builder) Flush(output *bytes.Buffer) (FlushStats, error) {
+// [Builder.Reset] is called after a successful Flush to discard any pending
+// data and allow new data to be appended.
+func (b *Builder) Flush() (*dataobj.Object, io.Closer, error) {
 	if b.state == builderStateEmpty {
-		return FlushStats{}, ErrBuilderEmpty
+		return nil, nil, ErrBuilderEmpty
 	}
 
 	timer := prometheus.NewTimer(b.metrics.buildTime)
 	defer timer.ObserveDuration()
-
-	// Appending sections resets them, so we need to load the time range before
-	// appending.
-	minTime, maxTime := b.streams.TimeRange()
 
 	// Flush sections one more time in case they have data.
 	var flushErrors []error
@@ -322,34 +319,21 @@ func (b *Builder) Flush(output *bytes.Buffer) (FlushStats, error) {
 
 	if err := errors.Join(flushErrors...); err != nil {
 		b.metrics.flushFailures.Inc()
-		return FlushStats{}, fmt.Errorf("building object: %w", err)
+		return nil, nil, fmt.Errorf("building object: %w", err)
 	}
 
-	sz, err := b.builder.Flush(output)
+	obj, closer, err := b.builder.Flush()
 	if err != nil {
 		b.metrics.flushFailures.Inc()
-		return FlushStats{}, fmt.Errorf("building object: %w", err)
+		return nil, nil, fmt.Errorf("building object: %w", err)
 	}
 
-	b.metrics.builtSize.Observe(float64(sz))
-
-	var (
-		// We don't know if output was empty before calling Flush, so we only start
-		// reading from where we know writing began.
-
-		objReader = bytes.NewReader(output.Bytes()[output.Len()-int(sz):])
-		objLength = sz
-	)
-	obj, err := dataobj.FromReaderAt(objReader, objLength)
-	if err != nil {
-		b.metrics.flushFailures.Inc()
-		return FlushStats{}, fmt.Errorf("failed to create readable object: %w", err)
-	}
+	b.metrics.builtSize.Observe(float64(obj.Size()))
 
 	err = b.observeObject(context.Background(), obj)
 
 	b.Reset()
-	return FlushStats{MinTimestamp: minTime, MaxTimestamp: maxTime}, err
+	return obj, closer, err
 }
 
 func (b *Builder) observeObject(ctx context.Context, obj *dataobj.Object) error {

--- a/pkg/dataobj/consumer/partition_processor.go
+++ b/pkg/dataobj/consumer/partition_processor.go
@@ -194,20 +194,23 @@ func (p *partitionProcessor) initBuilder() error {
 	return initErr
 }
 
-func (p *partitionProcessor) flushStream(flushBuffer *bytes.Buffer) error {
-	stats, err := p.builder.Flush(flushBuffer)
+func (p *partitionProcessor) flushStream() error {
+	minTime, maxTime := p.builder.TimeRange()
+
+	obj, closer, err := p.builder.Flush()
 	if err != nil {
 		level.Error(p.logger).Log("msg", "failed to flush builder", "err", err)
 		return err
 	}
+	defer closer.Close()
 
-	objectPath, err := p.uploader.Upload(p.ctx, flushBuffer)
+	objectPath, err := p.uploader.Upload(p.ctx, obj)
 	if err != nil {
 		level.Error(p.logger).Log("msg", "failed to upload object", "err", err)
 		return err
 	}
 
-	if err := p.metastoreUpdater.Update(p.ctx, objectPath, stats.MinTimestamp, stats.MaxTimestamp); err != nil {
+	if err := p.metastoreUpdater.Update(p.ctx, objectPath, minTime, maxTime); err != nil {
 		level.Error(p.logger).Log("msg", "failed to update metastore", "err", err)
 		return err
 	}
@@ -284,17 +287,10 @@ func (p *partitionProcessor) processRecord(record *kgo.Record) {
 			return
 		}
 
-		func() {
-			flushBuffer := p.bufPool.Get().(*bytes.Buffer)
-			defer p.bufPool.Put(flushBuffer)
-
-			flushBuffer.Reset()
-
-			if err := p.flushStream(flushBuffer); err != nil {
-				level.Error(p.logger).Log("msg", "failed to flush stream", "err", err)
-				return
-			}
-		}()
+		if err := p.flushStream(); err != nil {
+			level.Error(p.logger).Log("msg", "failed to flush stream", "err", err)
+			return
+		}
 
 		if err := p.commitRecords(record); err != nil {
 			level.Error(p.logger).Log("msg", "failed to commit records", "err", err)
@@ -346,17 +342,10 @@ func (p *partitionProcessor) idleFlush() {
 		return // Avoid checking too frequently
 	}
 
-	func() {
-		flushBuffer := p.bufPool.Get().(*bytes.Buffer)
-		defer p.bufPool.Put(flushBuffer)
+	if err := p.flushStream(); err != nil {
+		level.Error(p.logger).Log("msg", "failed to flush stream", "err", err)
+		return
+	}
 
-		flushBuffer.Reset()
-
-		if err := p.flushStream(flushBuffer); err != nil {
-			level.Error(p.logger).Log("msg", "failed to flush stream", "err", err)
-			return
-		}
-
-		p.lastFlush = time.Now()
-	}()
+	p.lastFlush = time.Now()
 }

--- a/pkg/dataobj/index/builder.go
+++ b/pkg/dataobj/index/builder.go
@@ -76,9 +76,8 @@ type Builder struct {
 	bufferedEvents map[string][]metastore.ObjectWrittenEvent
 
 	// Builder initialization
-	builderCfg  indexobj.BuilderConfig
-	bucket      objstore.Bucket
-	flushBuffer *bytes.Buffer
+	builderCfg indexobj.BuilderConfig
+	bucket     objstore.Bucket
 
 	// Metrics
 	metrics *indexBuilderMetrics
@@ -137,9 +136,6 @@ func NewIndexBuilder(
 		return nil, fmt.Errorf("failed to register metrics for index builder: %w", err)
 	}
 
-	// Allocate a single buffer
-	flushBuffer := bytes.NewBuffer(make([]byte, int(float64(cfg.BuilderConfig.TargetObjectSize)*1.2)))
-
 	// Set up queues to download the next object (I/O bound) while processing the current one (CPU bound) in order to maximize throughput.
 	// Setting the channel buffer sizes caps the total memory usage by only keeping up to 3 objects in memory at a time: One being processed, one fully downloaded and one being downloaded from the queue.
 	downloadQueue := make(chan metastore.ObjectWrittenEvent, cfg.EventsPerIndex)
@@ -151,7 +147,6 @@ func NewIndexBuilder(
 		client:            eventConsumerClient,
 		logger:            logger,
 		bucket:            bucket,
-		flushBuffer:       flushBuffer,
 		downloadedObjects: downloadedObjects,
 		downloadQueue:     downloadQueue,
 		metrics:           metrics,
@@ -308,37 +303,59 @@ func (p *Builder) buildIndex(events []metastore.ObjectWrittenEvent) error {
 		return processingErrors.Err()
 	}
 
-	p.flushBuffer.Reset()
-	stats, err := p.calculator.Flush(p.flushBuffer)
+	minTime, maxTime := p.calculator.TimeRange()
+	obj, closer, err := p.calculator.Flush()
 	if err != nil {
 		return fmt.Errorf("failed to flush builder: %w", err)
 	}
+	defer closer.Close()
 
-	size := p.flushBuffer.Len()
+	key, err := ObjectKey(p.ctx, events[0].Tenant, obj)
+	if err != nil {
+		return fmt.Errorf("failed to generate object key: %w", err)
+	}
 
-	key := ObjectKey(events[0].Tenant, p.flushBuffer)
-	if err := indexStorageBucket.Upload(p.ctx, key, p.flushBuffer); err != nil {
+	reader, err := obj.Reader(p.ctx)
+	if err != nil {
+		return fmt.Errorf("failed to read object: %w", err)
+	}
+	defer reader.Close()
+
+	if err := indexStorageBucket.Upload(p.ctx, key, reader); err != nil {
 		return fmt.Errorf("failed to upload index: %w", err)
 	}
 
 	metastoreUpdater := metastore.NewUpdater(p.mCfg.Updater, indexStorageBucket, events[0].Tenant, p.logger)
-	if stats.MinTimestamp.IsZero() || stats.MaxTimestamp.IsZero() {
+	if minTime.IsZero() || maxTime.IsZero() {
 		return errors.New("failed to get min/max timestamps")
 	}
-	if err := metastoreUpdater.Update(p.ctx, key, stats.MinTimestamp, stats.MaxTimestamp); err != nil {
+	if err := metastoreUpdater.Update(p.ctx, key, minTime, maxTime); err != nil {
 		return fmt.Errorf("failed to update metastore: %w", err)
 	}
 
-	level.Info(p.logger).Log("msg", "finished building index", "tenant", events[0].Tenant, "events", len(events), "size", size, "duration", time.Since(start))
+	level.Info(p.logger).Log("msg", "finished building index", "tenant", events[0].Tenant, "events", len(events), "size", obj.Size(), "duration", time.Since(start))
 	return nil
 }
 
 // ObjectKey determines the key in object storage to upload the object to, based on our path scheme.
-func ObjectKey(tenantID string, object *bytes.Buffer) string {
-	sum := sha256.Sum224(object.Bytes())
+func ObjectKey(ctx context.Context, tenantID string, object *dataobj.Object) (string, error) {
+	h := sha256.New224()
+
+	reader, err := object.Reader(ctx)
+	if err != nil {
+		return "", err
+	}
+	defer reader.Close()
+
+	if _, err := io.Copy(h, reader); err != nil {
+		return "", err
+	}
+
+	var sumBytes [sha256.Size224]byte
+	sum := h.Sum(sumBytes[:])
 	sumStr := hex.EncodeToString(sum[:])
 
-	return fmt.Sprintf("tenant-%s/indexes/%s/%s", tenantID, sumStr[:2], sumStr[2:])
+	return fmt.Sprintf("tenant-%s/indexes/%s/%s", tenantID, sumStr[:2], sumStr[2:]), nil
 }
 
 func (p *Builder) commitRecords(record *kgo.Record) error {

--- a/pkg/dataobj/index/builder_test.go
+++ b/pkg/dataobj/index/builder_test.go
@@ -54,11 +54,15 @@ func buildLogObject(t *testing.T, app string, path string, bucket objstore.Bucke
 		require.NoError(t, err)
 	}
 
-	buf := bytes.NewBuffer(nil)
-	_, err = candidate.Flush(buf)
+	obj, closer, err := candidate.Flush()
 	require.NoError(t, err)
+	defer closer.Close()
 
-	err = bucket.Upload(context.Background(), path, buf)
+	reader, err := obj.Reader(t.Context())
+	require.NoError(t, err)
+	defer reader.Close()
+
+	err = bucket.Upload(t.Context(), path, reader)
 	require.NoError(t, err)
 }
 

--- a/pkg/dataobj/index/calculate.go
+++ b/pkg/dataobj/index/calculate.go
@@ -1,7 +1,6 @@
 package index
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -41,8 +40,12 @@ func (c *Calculator) Reset() {
 	clear(c.indexStreamIDLookup)
 }
 
-func (c *Calculator) Flush(buffer *bytes.Buffer) (indexobj.FlushStats, error) {
-	return c.indexobjBuilder.Flush(buffer)
+func (c *Calculator) TimeRange() (minTime, maxTime time.Time) {
+	return c.indexobjBuilder.TimeRange()
+}
+
+func (c *Calculator) Flush() (*dataobj.Object, io.Closer, error) {
+	return c.indexobjBuilder.Flush()
 }
 
 // Calculate reads the log data from the input logs object and appends the resulting indexes to calculator's builder.

--- a/pkg/dataobj/sections/indexpointers/builder_test.go
+++ b/pkg/dataobj/sections/indexpointers/builder_test.go
@@ -1,7 +1,6 @@
 package indexpointers
 
 import (
-	"bytes"
 	"context"
 	"testing"
 	"time"
@@ -28,13 +27,13 @@ func TestBuilder(t *testing.T) {
 		ib.Append(p.path, p.start, p.end)
 	}
 
-	var buf bytes.Buffer
 	b := dataobj.NewBuilder()
 	err := b.Append(ib)
 	require.NoError(t, err)
 
-	_, err = b.Flush(&buf)
+	obj, closer, err := b.Flush()
 	require.NoError(t, err)
+	defer closer.Close()
 
 	expect := []IndexPointer{
 		{
@@ -48,10 +47,6 @@ func TestBuilder(t *testing.T) {
 			EndTs:   unixTime(20),
 		},
 	}
-
-	bufBytes := buf.Bytes()
-	obj, err := dataobj.FromReaderAt(bytes.NewReader(bufBytes), int64(len(bufBytes)))
-	require.NoError(t, err)
 
 	var actual []IndexPointer
 	for result := range Iter(context.Background(), obj) {

--- a/pkg/dataobj/sections/indexpointers/row_reader_test.go
+++ b/pkg/dataobj/sections/indexpointers/row_reader_test.go
@@ -1,7 +1,6 @@
 package indexpointers
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"io"
@@ -37,16 +36,12 @@ func buildIndexPointersDecoder(t *testing.T, pageSize int) *Section {
 		s.Append(d.Path, d.StartTs, d.EndTs)
 	}
 
-	var buf bytes.Buffer
-
 	builder := dataobj.NewBuilder()
 	require.NoError(t, builder.Append(s))
 
-	_, err := builder.Flush(&buf)
+	obj, closer, err := builder.Flush()
 	require.NoError(t, err)
-
-	obj, err := dataobj.FromReaderAt(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
-	require.NoError(t, err)
+	t.Cleanup(func() { closer.Close() })
 
 	sec, err := Open(t.Context(), obj.Sections()[0])
 	require.NoError(t, err)

--- a/pkg/dataobj/sections/logs/builder_test.go
+++ b/pkg/dataobj/sections/logs/builder_test.go
@@ -1,8 +1,8 @@
 package logs_test
 
 import (
-	"bytes"
 	"context"
+	"io"
 	"testing"
 	"time"
 
@@ -46,8 +46,9 @@ func Test(t *testing.T) {
 		tracker.Append(record)
 	}
 
-	buf, err := buildObject(tracker)
+	obj, closer, err := buildObject(tracker)
 	require.NoError(t, err)
+	defer closer.Close()
 
 	// The order of records should be sorted by timestamp DESC then stream ID, and all
 	// metadata should be sorted by key then value.
@@ -72,9 +73,6 @@ func Test(t *testing.T) {
 		},
 	}
 
-	obj, err := dataobj.FromReaderAt(bytes.NewReader(buf), int64(len(buf)))
-	require.NoError(t, err)
-
 	i := 0
 	for result := range logs.Iter(context.Background(), obj) {
 		record, err := result.Value()
@@ -84,14 +82,10 @@ func Test(t *testing.T) {
 	}
 }
 
-func buildObject(lt *logs.Builder) ([]byte, error) {
-	var buf bytes.Buffer
-
+func buildObject(lt *logs.Builder) (*dataobj.Object, io.Closer, error) {
 	builder := dataobj.NewBuilder()
 	if err := builder.Append(lt); err != nil {
-		return nil, err
-	} else if _, err := builder.Flush(&buf); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return buf.Bytes(), nil
+	return builder.Flush()
 }

--- a/pkg/dataobj/sections/logs/reader_test.go
+++ b/pkg/dataobj/sections/logs/reader_test.go
@@ -102,12 +102,9 @@ func buildSection(t *testing.T, recs []logs.Record) *logs.Section {
 	objectBuilder := dataobj.NewBuilder()
 	require.NoError(t, objectBuilder.Append(sectionBuilder))
 
-	var buf bytes.Buffer
-	_, err := objectBuilder.Flush(&buf)
+	obj, closer, err := objectBuilder.Flush()
 	require.NoError(t, err)
-
-	obj, err := dataobj.FromReaderAt(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
-	require.NoError(t, err)
+	t.Cleanup(func() { closer.Close() })
 
 	sec, err := logs.Open(t.Context(), obj.Sections()[0])
 	require.NoError(t, err)

--- a/pkg/dataobj/sections/logs/row_reader_test.go
+++ b/pkg/dataobj/sections/logs/row_reader_test.go
@@ -1,7 +1,6 @@
 package logs
 
 import (
-	"bytes"
 	"context"
 	"slices"
 	"testing"
@@ -50,15 +49,13 @@ func buildSection(t *testing.T) *Section {
 		Line:      []byte("test2"),
 	})
 
-	out := bytes.NewBuffer(nil)
 	b := dataobj.NewBuilder()
 	err := b.Append(logsBuilder)
 	require.NoError(t, err)
-	_, err = b.Flush(out)
-	require.NoError(t, err)
 
-	obj, err := dataobj.FromReaderAt(bytes.NewReader(out.Bytes()), int64(out.Len()))
+	obj, closer, err := b.Flush()
 	require.NoError(t, err)
+	t.Cleanup(func() { closer.Close() })
 
 	var logsSection *Section
 	for _, section := range obj.Sections() {

--- a/pkg/dataobj/sections/pointers/builder_test.go
+++ b/pkg/dataobj/sections/pointers/builder_test.go
@@ -1,8 +1,8 @@
 package pointers
 
 import (
-	"bytes"
 	"context"
+	"io"
 	"testing"
 	"time"
 
@@ -36,8 +36,9 @@ func TestAddingStreams(t *testing.T) {
 		tracker.ObserveStream(tc.path, tc.section, tc.streamIDInObject, tc.streamID, tc.maxTimestamp, 0)
 	}
 
-	buf, err := buildObject(tracker)
+	obj, closer, err := buildObject(tracker)
 	require.NoError(t, err)
+	defer closer.Close()
 
 	expect := []SectionPointer{
 		{
@@ -72,9 +73,6 @@ func TestAddingStreams(t *testing.T) {
 		},
 	}
 
-	obj, err := dataobj.FromReaderAt(bytes.NewReader(buf), int64(len(buf)))
-	require.NoError(t, err)
-
 	var actual []SectionPointer
 	for result := range Iter(context.Background(), obj) {
 		pointer, err := result.Value()
@@ -105,8 +103,9 @@ func TestAddingColumnIndexes(t *testing.T) {
 		tracker.RecordColumnIndex(tc.path, tc.section, tc.columnName, tc.columnIndex, tc.valuesBloomFilter)
 	}
 
-	buf, err := buildObject(tracker)
+	obj, closer, err := buildObject(tracker)
 	require.NoError(t, err)
+	defer closer.Close()
 
 	expect := []SectionPointer{
 		{
@@ -139,9 +138,6 @@ func TestAddingColumnIndexes(t *testing.T) {
 		},
 	}
 
-	obj, err := dataobj.FromReaderAt(bytes.NewReader(buf), int64(len(buf)))
-	require.NoError(t, err)
-
 	var actual []SectionPointer
 	for result := range Iter(context.Background(), obj) {
 		pointer, err := result.Value()
@@ -152,14 +148,10 @@ func TestAddingColumnIndexes(t *testing.T) {
 	require.Equal(t, expect, actual)
 }
 
-func buildObject(st *Builder) ([]byte, error) {
-	var buf bytes.Buffer
-
+func buildObject(st *Builder) (*dataobj.Object, io.Closer, error) {
 	builder := dataobj.NewBuilder()
 	if err := builder.Append(st); err != nil {
-		return nil, err
-	} else if _, err := builder.Flush(&buf); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return buf.Bytes(), nil
+	return builder.Flush()
 }

--- a/pkg/dataobj/sections/pointers/row_reader_test.go
+++ b/pkg/dataobj/sections/pointers/row_reader_test.go
@@ -1,7 +1,6 @@
 package pointers
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"io"
@@ -44,16 +43,12 @@ func buildPointersDecoder(t *testing.T, pageSize int) *Section {
 		}
 	}
 
-	var buf bytes.Buffer
-
 	builder := dataobj.NewBuilder()
 	require.NoError(t, builder.Append(s))
 
-	_, err := builder.Flush(&buf)
+	obj, closer, err := builder.Flush()
 	require.NoError(t, err)
-
-	obj, err := dataobj.FromReaderAt(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
-	require.NoError(t, err)
+	t.Cleanup(func() { closer.Close() })
 
 	sec, err := Open(t.Context(), obj.Sections()[0])
 	require.NoError(t, err)

--- a/pkg/dataobj/sections/streams/builder_test.go
+++ b/pkg/dataobj/sections/streams/builder_test.go
@@ -1,8 +1,8 @@
 package streams_test
 
 import (
-	"bytes"
 	"context"
+	"io"
 	"strings"
 	"testing"
 	"time"
@@ -33,8 +33,9 @@ func Test(t *testing.T) {
 		tracker.Record(tc.Labels, tc.Time, tc.Size)
 	}
 
-	buf, err := buildObject(tracker)
+	obj, closer, err := buildObject(tracker)
 	require.NoError(t, err)
+	defer closer.Close()
 
 	expect := []streams.Stream{
 		{
@@ -54,9 +55,6 @@ func Test(t *testing.T) {
 			UncompressedSize: 20,
 		},
 	}
-
-	obj, err := dataobj.FromReaderAt(bytes.NewReader(buf), int64(len(buf)))
-	require.NoError(t, err)
 
 	var actual []streams.Stream
 	for result := range streams.Iter(context.Background(), obj) {
@@ -80,14 +78,10 @@ func copyLabels(in labels.Labels) labels.Labels {
 	return builder.Labels()
 }
 
-func buildObject(st *streams.Builder) ([]byte, error) {
-	var buf bytes.Buffer
-
+func buildObject(st *streams.Builder) (*dataobj.Object, io.Closer, error) {
 	builder := dataobj.NewBuilder()
 	if err := builder.Append(st); err != nil {
-		return nil, err
-	} else if _, err := builder.Flush(&buf); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return buf.Bytes(), nil
+	return builder.Flush()
 }

--- a/pkg/dataobj/sections/streams/row_reader_test.go
+++ b/pkg/dataobj/sections/streams/row_reader_test.go
@@ -1,7 +1,6 @@
 package streams_test
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"io"
@@ -89,16 +88,12 @@ func buildStreamsSection(t *testing.T, pageSize int) *streams.Section {
 		s.Record(d.Labels, d.Timestamp, d.UncompressedSize)
 	}
 
-	var buf bytes.Buffer
-
 	builder := dataobj.NewBuilder()
 	require.NoError(t, builder.Append(s))
 
-	_, err := builder.Flush(&buf)
+	obj, closer, err := builder.Flush()
 	require.NoError(t, err)
-
-	obj, err := dataobj.FromReaderAt(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
-	require.NoError(t, err)
+	t.Cleanup(func() { closer.Close() })
 
 	sec, err := streams.Open(t.Context(), obj.Sections()[0])
 	require.NoError(t, err)

--- a/pkg/dataobj/uploader/uploader.go
+++ b/pkg/dataobj/uploader/uploader.go
@@ -1,12 +1,12 @@
 package uploader
 
 import (
-	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"flag"
 	"fmt"
+	"io"
 	"time"
 
 	"github.com/go-kit/log"
@@ -14,6 +14,8 @@ import (
 	"github.com/grafana/dskit/backoff"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/thanos-io/objstore"
+
+	"github.com/grafana/loki/v3/pkg/dataobj"
 )
 
 type Config struct {
@@ -62,21 +64,39 @@ func (d *Uploader) UnregisterMetrics(reg prometheus.Registerer) {
 }
 
 // getKey determines the key in object storage to upload the object to, based on our path scheme.
-func (d *Uploader) getKey(object *bytes.Buffer) string {
-	sum := sha256.Sum224(object.Bytes())
-	sumStr := hex.EncodeToString(sum[:])
+func (d *Uploader) getKey(ctx context.Context, object *dataobj.Object) (string, error) {
+	hash := sha256.New224()
 
-	return fmt.Sprintf("tenant-%s/objects/%s/%s", d.tenantID, sumStr[:d.SHAPrefixSize], sumStr[d.SHAPrefixSize:])
+	reader, err := object.Reader(ctx)
+	if err != nil {
+		return "", err
+	}
+	defer reader.Close()
+
+	if _, err := io.Copy(hash, reader); err != nil {
+		return "", err
+	}
+
+	var sumBytes [sha256.Size224]byte
+	sum := hash.Sum(sumBytes[:0])
+	sumStr := hex.EncodeToString(sum)
+
+	return fmt.Sprintf("tenant-%s/objects/%s/%s", d.tenantID, sumStr[:d.SHAPrefixSize], sumStr[d.SHAPrefixSize:]), nil
 }
 
 // Upload uploads an object to the configured bucket and returns the key.
-func (d *Uploader) Upload(ctx context.Context, object *bytes.Buffer) (string, error) {
+func (d *Uploader) Upload(ctx context.Context, object *dataobj.Object) (key string, err error) {
 	start := time.Now()
 
 	timer := prometheus.NewTimer(d.metrics.uploadTime)
 	defer timer.ObserveDuration()
 
-	objectPath := d.getKey(object)
+	objectPath, err := d.getKey(ctx, object)
+	if err != nil {
+		d.metrics.uploadFailures.Inc()
+		d.metrics.uploadSize.WithLabelValues(statusFailure).Observe(float64(object.Size()))
+		return "", fmt.Errorf("generating object key: %w", err)
+	}
 
 	backoff := backoff.New(ctx, backoff.Config{
 		MinBackoff: 100 * time.Millisecond,
@@ -84,14 +104,21 @@ func (d *Uploader) Upload(ctx context.Context, object *bytes.Buffer) (string, er
 		MaxRetries: 20,
 	})
 
-	size := len(object.Bytes())
+	size := object.Size()
 
 	logger := log.With(d.logger, "key", objectPath, "size", size)
 
-	var err error
 	for backoff.Ongoing() {
 		level.Debug(logger).Log("msg", "attempting to upload dataobj to object storage", "attempt", backoff.NumRetries())
-		err = d.bucket.Upload(ctx, objectPath, bytes.NewReader(object.Bytes()))
+
+		err = func() error {
+			reader, err := object.Reader(ctx)
+			if err != nil {
+				return err
+			}
+			defer reader.Close()
+			return d.bucket.Upload(ctx, objectPath, reader)
+		}()
 		if err == nil {
 			break
 		}

--- a/pkg/engine/executor/dataobjscan_test.go
+++ b/pkg/engine/executor/dataobjscan_test.go
@@ -1,7 +1,6 @@
 package executor
 
 import (
-	"bytes"
 	"math"
 	"testing"
 	"time"
@@ -357,13 +356,8 @@ func buildDataobj(t testing.TB, streams []logproto.Stream) *dataobj.Object {
 		require.NoError(t, builder.Append(stream))
 	}
 
-	var buf bytes.Buffer
-	_, err = builder.Flush(&buf)
+	obj, closer, err := builder.Flush()
 	require.NoError(t, err)
-
-	r := bytes.NewReader(buf.Bytes())
-
-	obj, err := dataobj.FromReaderAt(r, r.Size())
-	require.NoError(t, err)
+	t.Cleanup(func() { closer.Close() })
 	return obj
 }

--- a/pkg/engine/executor/streams_view_test.go
+++ b/pkg/engine/executor/streams_view_test.go
@@ -1,7 +1,6 @@
 package executor
 
 import (
-	"bytes"
 	"iter"
 	"slices"
 	"testing"
@@ -148,16 +147,12 @@ func buildStreamsSection(t *testing.T, streamLabels []labels.Labels) *streams.Se
 	objBuilder := dataobj.NewBuilder()
 	require.NoError(t, objBuilder.Append(streamsBuilder), "failed to append streams section")
 
-	var buf bytes.Buffer
-	_, err := objBuilder.Flush(&buf)
+	obj, closer, err := objBuilder.Flush()
 	require.NoError(t, err, "failed to flush dataobj")
-
-	obj, err := dataobj.FromReaderAt(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
-	require.NoError(t, err, "failed to create dataobj from reader")
+	t.Cleanup(func() { closer.Close() })
 
 	sec, err := streams.Open(t.Context(), obj.Sections()[0])
 	require.NoError(t, err, "failed to open streams section")
-
 	return sec
 }
 

--- a/pkg/logql/bench/store_dataobj.go
+++ b/pkg/logql/bench/store_dataobj.go
@@ -133,20 +133,21 @@ func (s *DataObjStore) flush() error {
 	// Reset the buffer
 	s.buf.Reset()
 
-	// Flush the builder to the buffer
-	stats, err := s.builder.Flush(s.buf)
+	minTime, maxTime := s.builder.TimeRange()
+	obj, closer, err := s.builder.Flush()
 	if err != nil {
 		return fmt.Errorf("failed to flush builder: %w", err)
 	}
+	defer closer.Close()
 
 	// Upload the data object using the uploader
-	path, err := s.uploader.Upload(context.Background(), s.buf)
+	path, err := s.uploader.Upload(context.Background(), obj)
 	if err != nil {
 		return fmt.Errorf("failed to upload data object: %w", err)
 	}
 
 	// Update metastore with the new data object
-	err = s.meta.Update(context.Background(), path, stats.MinTimestamp, stats.MaxTimestamp)
+	err = s.meta.Update(context.Background(), path, minTime, maxTime)
 	if err != nil {
 		return fmt.Errorf("failed to update metastore: %w", err)
 	}
@@ -177,18 +178,30 @@ func (s *DataObjStore) Close() error {
 
 func (s *DataObjStore) buildIndex() error {
 	flushAndUpload := func(calculator *index.Calculator) error {
-		s.buf.Reset()
-		stats, err := calculator.Flush(s.buf)
+		minTime, maxTime := calculator.TimeRange()
+		obj, closer, err := calculator.Flush()
 		if err != nil {
 			return fmt.Errorf("failed to flush index: %w", err)
 		}
-		key := index.ObjectKey(s.tenantID, s.buf)
-		err = s.indexWriterBucket.Upload(context.Background(), key, s.buf)
+		defer closer.Close()
+
+		key, err := index.ObjectKey(context.Background(), s.tenantID, obj)
+		if err != nil {
+			return fmt.Errorf("failed to create object key: %w", err)
+		}
+
+		reader, err := obj.Reader(context.Background())
+		if err != nil {
+			return fmt.Errorf("failed to create reader for index object: %w", err)
+		}
+		defer reader.Close()
+
+		err = s.indexWriterBucket.Upload(context.Background(), key, reader)
 		if err != nil {
 			return fmt.Errorf("failed to upload index: %w", err)
 		}
 
-		err = s.indexMetastore.Update(context.Background(), key, stats.MinTimestamp, stats.MaxTimestamp)
+		err = s.indexMetastore.Update(context.Background(), key, minTime, maxTime)
 		if err != nil {
 			return fmt.Errorf("failed to update metastore: %w", err)
 		}


### PR DESCRIPTION
This commit updates Builder.Flush to return an Object rather than writing bytes to an argument. To support this change, dataobj.Object has two additional methods:

- dataobj.Object.Size, to retrieve the full encoded size of the object
- dataobj.Object.Reader, to read from the encoded object

This API change allows downstream users of dataobj.Builder to stream the encoded object for analysis or uploading, without requiring the caller to retain the entire object in memory at once.

In the future, this will be used to reduce the memory overhead of dataobj-consumers by buffering flushed sections on an ephemeral disk instead of in memory.