### PR TITLE
chore: use boltdb for tracking series processing progress in delete requests manager

### DIFF
--- a/pkg/compactor/deletion/delete_requests_manager.go
+++ b/pkg/compactor/deletion/delete_requests_manager.go
@@ -2,23 +2,25 @@ package deletion
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
 	"sync"
 	"time"
+	"unsafe"
 
 	"github.com/go-kit/log/level"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
+	"go.etcd.io/bbolt"
 
 	"github.com/grafana/loki/v3/pkg/compactor/deletionmode"
 	"github.com/grafana/loki/v3/pkg/compactor/retention"
 	"github.com/grafana/loki/v3/pkg/storage/chunk/client"
+	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/util"
 	"github.com/grafana/loki/v3/pkg/util/filter"
 	util_log "github.com/grafana/loki/v3/pkg/util/log"
 )
@@ -29,11 +31,17 @@ const (
 	statusSuccess = "success"
 	statusFail    = "fail"
 
-	seriesProgressFilename = "series_progress.json"
+	seriesProgressOldFilename = "series_progress.json"
+	seriesProgressFilename    = "series_progress.boltdb"
 
 	DeleteRequestsWithLineFilters    DeleteRequestsKind = "DeleteRequestsWithLineFilters"
 	DeleteRequestsWithoutLineFilters DeleteRequestsKind = "DeleteRequestsWithoutLineFilters"
 	DeleteRequestsAll                DeleteRequestsKind = "DeleteRequestsAll"
+)
+
+var (
+	seriesProgressVal = []byte("1")
+	boltdbBucketName  = []byte("series_progress")
 )
 
 type userDeleteRequests struct {
@@ -63,13 +71,17 @@ type DeleteRequestsManager struct {
 	jobBuilder                  *JobBuilder
 	tablesManager               TablesManager
 
-	metrics            *deleteRequestsManagerMetrics
-	wg                 sync.WaitGroup
-	batchSize          int
-	limits             Limits
-	currentBatch       *deleteRequestBatch
-	processedSeries    map[string]struct{}
-	processedSeriesMtx sync.RWMutex
+	metrics      *deleteRequestsManagerMetrics
+	wg           sync.WaitGroup
+	batchSize    int
+	limits       Limits
+	currentBatch *deleteRequestBatch
+
+	// seriesProgress file reference could be nil when there are any unexpected issues since
+	// series progress tracking is done as best effort.
+	// It would also be nil when running compactor in horizontal scaling mode.
+	// All the usages should do a nil check.
+	seriesProgress *bbolt.DB
 }
 
 func NewDeleteRequestsManager(
@@ -91,11 +103,15 @@ func NewDeleteRequestsManager(
 		HSModeEnabled:               HSModeEnabled,
 		deletionManifestStoreClient: deletionManifestStoreClient,
 
-		metrics:         metrics,
-		batchSize:       batchSize,
-		limits:          limits,
-		processedSeries: map[string]struct{}{},
-		currentBatch:    newDeleteRequestBatch(metrics),
+		metrics:      metrics,
+		batchSize:    batchSize,
+		limits:       limits,
+		currentBatch: newDeleteRequestBatch(metrics),
+	}
+
+	// remove the old json series progress file
+	if err := os.Remove(filepath.Join(workingDir, seriesProgressOldFilename)); err != nil && !os.IsNotExist(err) {
+		level.Error(util_log.Logger).Log("msg", "failed to remove old json series progress file", "err", err)
 	}
 
 	return dm, nil
@@ -110,12 +126,26 @@ func (d *DeleteRequestsManager) Init(tablesManager TablesManager, registerer pro
 				d.markRequestAsProcessed(req)
 			}
 		}, registerer)
-	}
 
-	var err error
-	d.processedSeries, err = loadSeriesProgress(d.workingDir)
-	if err != nil {
-		return err
+		// Remove the series progress file since it is only useful when not running compactor in horizontally scalable mode.
+		if err := os.Remove(filepath.Join(d.workingDir, seriesProgressFilename)); err != nil && !os.IsNotExist(err) {
+			level.Error(util_log.Logger).Log("msg", "failed to remove series progress file", "err", err)
+		}
+	} else {
+		// Open boltdb file for storing series progress.
+		db, err := util.SafeOpenBoltdbFile(filepath.Join(d.workingDir, seriesProgressFilename))
+		if err != nil {
+			return err
+		}
+
+		// Create the bucket for storing the KVs
+		if err := db.Update(func(tx *bbolt.Tx) error {
+			_, err := tx.CreateBucketIfNotExists(boltdbBucketName)
+			return err
+		}); err != nil {
+			return err
+		}
+		d.seriesProgress = db
 	}
 
 	if err := d.deleteRequestsStore.MergeShardedRequests(context.Background()); err != nil {
@@ -137,8 +167,11 @@ func (d *DeleteRequestsManager) Start(ctx context.Context) {
 	}
 
 	d.wg.Wait()
-	if err := d.storeSeriesProgress(); err != nil {
-		level.Error(util_log.Logger).Log("msg", "failed to store series progress", "err", err)
+
+	if d.seriesProgress != nil {
+		if err := d.seriesProgress.Close(); err != nil {
+			level.Error(util_log.Logger).Log("msg", "failed to close series progress db", "err", err)
+		}
 	}
 }
 
@@ -157,10 +190,6 @@ func (d *DeleteRequestsManager) loop(ctx context.Context) {
 		case <-ticker.C:
 			if err := d.updateMetrics(); err != nil {
 				level.Error(util_log.Logger).Log("msg", "failed to update metrics", "err", err)
-			}
-
-			if err := d.storeSeriesProgress(); err != nil {
-				level.Error(util_log.Logger).Log("msg", "failed to store series progress", "err", err)
 			}
 		case <-ctx.Done():
 			return
@@ -253,27 +282,6 @@ func (d *DeleteRequestsManager) buildDeletionManifest(ctx context.Context) error
 		return err
 	}
 	d.metrics.chunksSelectedTotal.Add(float64(deletionManifestBuilder.overallChunksCount))
-
-	return nil
-}
-
-func (d *DeleteRequestsManager) storeSeriesProgress() error {
-	d.processedSeriesMtx.RLock()
-	defer d.processedSeriesMtx.RUnlock()
-
-	if len(d.processedSeries) == 0 {
-		return nil
-	}
-
-	data, err := json.Marshal(d.processedSeries)
-	if err != nil {
-		return errors.Wrap(err, "failed to json encode series progress")
-	}
-
-	err = os.WriteFile(filepath.Join(d.workingDir, seriesProgressFilename), data, 0640)
-	if err != nil {
-		return errors.Wrap(err, "failed to store series progress to the file")
-	}
 
 	return nil
 }
@@ -445,9 +453,6 @@ func (d *DeleteRequestsManager) shouldProcessRequest(dr DeleteRequest) (bool, er
 }
 
 func (d *DeleteRequestsManager) CanSkipSeries(userID []byte, lbls labels.Labels, seriesID []byte, _ model.Time, tableName string, _ model.Time) bool {
-	d.processedSeriesMtx.RLock()
-	defer d.processedSeriesMtx.RUnlock()
-
 	userIDStr := unsafeGetString(userID)
 
 	for _, deleteRequest := range d.currentBatch.getAllRequestsForUser(userIDStr) {
@@ -456,8 +461,9 @@ func (d *DeleteRequestsManager) CanSkipSeries(userID []byte, lbls labels.Labels,
 			continue
 		}
 
+		seriesProcessed := d.isSeriesProcessed(buildProcessedSeriesKey(deleteRequest.RequestID, deleteRequest.StartTime, deleteRequest.EndTime, seriesID, tableName))
 		// The delete request touches the series. Do not skip if the series is not processed yet.
-		if _, ok := d.processedSeries[buildProcessedSeriesKey(deleteRequest.RequestID, deleteRequest.StartTime, deleteRequest.EndTime, seriesID, tableName)]; !ok {
+		if !seriesProcessed {
 			return false
 		}
 	}
@@ -467,12 +473,28 @@ func (d *DeleteRequestsManager) CanSkipSeries(userID []byte, lbls labels.Labels,
 
 func (d *DeleteRequestsManager) Expired(userID []byte, chk retention.Chunk, lbls labels.Labels, seriesID []byte, tableName string, _ model.Time) (bool, filter.Func) {
 	return d.currentBatch.expired(userID, chk, lbls, func(request *DeleteRequest) bool {
-		d.processedSeriesMtx.RLock()
-		defer d.processedSeriesMtx.RUnlock()
-
-		_, ok := d.processedSeries[buildProcessedSeriesKey(request.RequestID, request.StartTime, request.EndTime, seriesID, tableName)]
-		return ok
+		return d.isSeriesProcessed(buildProcessedSeriesKey(request.RequestID, request.StartTime, request.EndTime, seriesID, tableName))
 	})
+}
+
+// isSeriesProcessed checks if the series with given key is processed.
+// Returns false if the series progress file reference is nil.
+func (d *DeleteRequestsManager) isSeriesProcessed(seriesKey []byte) bool {
+	if d.seriesProgress == nil {
+		return false
+	}
+	seriesProcessed := false
+	if err := d.seriesProgress.View(func(tx *bbolt.Tx) error {
+		v := tx.Bucket(boltdbBucketName).Get(seriesKey)
+		if len(v) > 0 {
+			seriesProcessed = true
+		}
+		return nil
+	}); err != nil {
+		level.Error(util_log.Logger).Log("msg", "error checking series progress", "err", err)
+	}
+
+	return seriesProcessed
 }
 
 func (d *DeleteRequestsManager) MarkPhaseStarted() {
@@ -551,14 +573,49 @@ func (d *DeleteRequestsManager) MarkPhaseFinished() {
 		level.Error(util_log.Logger).Log("msg", "failed to merge sharded requests", "err", err)
 	}
 
-	d.processedSeriesMtx.Lock()
-	defer d.processedSeriesMtx.Unlock()
-
-	d.processedSeries = map[string]struct{}{}
+	if !d.HSModeEnabled {
+		d.resetSeriesProgress()
+	}
 	d.currentBatch.reset()
+}
+
+// resetSeriesProgress removes the existing boltdb file for series progress and creates a new one.
+// We remove and recreate the file because boltdb does not reclaim the space when data is deleted.
+func (d *DeleteRequestsManager) resetSeriesProgress() {
+	// Clear the file reference so that we do not keep using the same file when any of the below cleanup operations fail.
+	// Otherwise, we will keep using the same file and end up using too much disk.
+	// We check the file reference before we read/write to d.seriesProgress.
+	seriesProgress := d.seriesProgress
+	d.seriesProgress = nil
+
+	if seriesProgress != nil {
+		if err := seriesProgress.Close(); err != nil {
+			level.Error(util_log.Logger).Log("msg", "failed to close series progress file", "err", err)
+			return
+		}
+	}
+
 	if err := os.Remove(filepath.Join(d.workingDir, seriesProgressFilename)); err != nil && !os.IsNotExist(err) {
 		level.Error(util_log.Logger).Log("msg", "failed to remove series progress file", "err", err)
+		return
 	}
+
+	db, err := util.SafeOpenBoltdbFile(filepath.Join(d.workingDir, seriesProgressFilename))
+	if err != nil {
+		level.Error(util_log.Logger).Log("msg", "failed to open series progress", "err", err)
+		return
+	}
+
+	err = db.Update(func(tx *bbolt.Tx) error {
+		_, err := tx.CreateBucketIfNotExists(boltdbBucketName)
+		return err
+	})
+	if err != nil {
+		level.Error(util_log.Logger).Log("msg", "failed to create bucket in series progress boltdb file", "err", err)
+		return
+	}
+
+	d.seriesProgress = db
 }
 
 func (d *DeleteRequestsManager) IntervalMayHaveExpiredChunks(_ model.Interval, userID string) bool {
@@ -573,14 +630,15 @@ func (d *DeleteRequestsManager) DropFromIndex(_ []byte, _ retention.Chunk, _ lab
 	return false
 }
 
+// MarkSeriesAsProcessed marks a series as processed. It ignores the operation if the series progress file reference is nil.
 func (d *DeleteRequestsManager) MarkSeriesAsProcessed(userID, seriesID []byte, lbls labels.Labels, tableName string) error {
+	if d.seriesProgress == nil {
+		return nil
+	}
 	userIDStr := unsafeGetString(userID)
 	if d.currentBatch.requestCount() == 0 {
 		return nil
 	}
-
-	d.processedSeriesMtx.Lock()
-	defer d.processedSeriesMtx.Unlock()
 
 	for _, req := range d.currentBatch.getAllRequestsForUser(userIDStr) {
 		// if the delete request does not touch the series, do not waste space in storing the marker
@@ -588,14 +646,18 @@ func (d *DeleteRequestsManager) MarkSeriesAsProcessed(userID, seriesID []byte, l
 			continue
 		}
 		processedSeriesKey := buildProcessedSeriesKey(req.RequestID, req.StartTime, req.EndTime, seriesID, tableName)
-		d.processedSeries[processedSeriesKey] = struct{}{}
+		if err := d.seriesProgress.Update(func(tx *bbolt.Tx) error {
+			return tx.Bucket(boltdbBucketName).Put(processedSeriesKey, seriesProgressVal)
+		}); err != nil {
+			level.Error(util_log.Logger).Log("msg", "error storing series progress", "err", err)
+		}
 	}
 
 	return nil
 }
 
-func buildProcessedSeriesKey(requestID string, startTime, endTime model.Time, seriesID []byte, tableName string) string {
-	return fmt.Sprintf("%s/%d/%d/%s/%s", requestID, startTime, endTime, tableName, seriesID)
+func buildProcessedSeriesKey(requestID string, startTime, endTime model.Time, seriesID []byte, tableName string) []byte {
+	return unsafeGetBytes(fmt.Sprintf("%s/%d/%d/%s/%s", requestID, startTime, endTime, tableName, seriesID))
 }
 
 func getMaxRetentionInterval(userID string, limits Limits) time.Duration {
@@ -616,18 +678,6 @@ func getMaxRetentionInterval(userID string, limits Limits) time.Duration {
 	return time.Duration(maxRetention)
 }
 
-func loadSeriesProgress(workingDir string) (map[string]struct{}, error) {
-	data, err := os.ReadFile(filepath.Join(workingDir, seriesProgressFilename))
-	if err != nil && !os.IsNotExist(err) {
-		return nil, err
-	}
-
-	processedSeries := map[string]struct{}{}
-	if len(data) > 0 {
-		if err := json.Unmarshal(data, &processedSeries); err != nil {
-			return nil, err
-		}
-	}
-
-	return processedSeries, nil
+func unsafeGetBytes(s string) []byte {
+	return unsafe.Slice(unsafe.StringData(s), len(s)) // #nosec G103 -- we know the string is not mutated
 }

--- a/pkg/compactor/deletion/delete_requests_manager_test.go
+++ b/pkg/compactor/deletion/delete_requests_manager_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
+	"go.etcd.io/bbolt"
 
 	"github.com/grafana/loki/v3/pkg/compactor/deletionmode"
 	"github.com/grafana/loki/v3/pkg/compactor/retention"
@@ -1314,21 +1315,20 @@ func TestDeleteRequestsManager_SeriesProgress(t *testing.T) {
 			require.Equal(t, tc.expExpired, isExpired)
 
 			// see if stopping the manager properly retains the progress and loads back when initialized
-			storedSeriesProgress := mgr.processedSeries
+			storedSeriesProgress := getAllSeriesProgressKeys(t, mgr.seriesProgress)
 			mgrCtxCancel()
 			wg.Wait()
 
 			mgr, err = NewDeleteRequestsManager(workingDir, deleteRequestsStore, time.Hour, 70, &fakeLimits{defaultLimit: limit{deletionMode: deletionmode.FilterAndDelete.String()}}, false, nil, nil)
 			require.NoError(t, err)
 			require.NoError(t, mgr.Init(nil, nil))
-			require.Equal(t, storedSeriesProgress, mgr.processedSeries)
+			require.Equal(t, storedSeriesProgress, getAllSeriesProgressKeys(t, mgr.seriesProgress))
 			mgr.MarkPhaseStarted()
 			require.NotNil(t, mgr.currentBatch)
 
 			// when the mark phase ends, series progress should get cleared
 			mgr.MarkPhaseFinished()
-			require.Len(t, mgr.processedSeries, 0)
-			require.NoFileExists(t, filepath.Join(workingDir, seriesProgressFilename))
+			require.Len(t, getAllSeriesProgressKeys(t, mgr.seriesProgress), 0)
 		})
 	}
 }
@@ -1356,8 +1356,7 @@ func TestDeleteRequestsManager_SeriesProgressWithTimeout(t *testing.T) {
 
 	// timeout should not clear the series progress
 	mgr.MarkPhaseFinished()
-	require.Len(t, mgr.processedSeries, 2)
-	require.NoError(t, mgr.storeSeriesProgress())
+	require.Len(t, getAllSeriesProgressKeys(t, mgr.seriesProgress), 2)
 	require.FileExists(t, filepath.Join(workingDir, seriesProgressFilename))
 
 	// load the requests again for processing
@@ -1366,7 +1365,53 @@ func TestDeleteRequestsManager_SeriesProgressWithTimeout(t *testing.T) {
 
 	// not hitting the timeout should clear the series progress
 	mgr.MarkPhaseFinished()
-	require.Len(t, mgr.processedSeries, 0)
+	require.Len(t, getAllSeriesProgressKeys(t, mgr.seriesProgress), 0)
+}
+
+func TestDeleteRequestsManagerWithoutHorizontalScalingMode_SeriesProgress(t *testing.T) {
+	workingDir := t.TempDir()
+
+	user1 := []byte("user1")
+	lblFooBar := mustParseLabel(`{foo="bar"}`)
+	deleteRequestsStore := &mockDeleteRequestsStore{deleteRequests: []DeleteRequest{
+		{RequestID: "1", Query: lblFooBar.String(), UserID: string(user1), StartTime: 0, EndTime: 100, Status: StatusReceived},
+		{RequestID: "1", Query: lblFooBar.String(), UserID: string(user1), StartTime: 100, EndTime: 200, Status: StatusReceived},
+	}}
+
+	mgr, err := NewDeleteRequestsManager(workingDir, deleteRequestsStore, time.Hour, 70, &fakeLimits{defaultLimit: limit{deletionMode: deletionmode.FilterAndDelete.String()}}, true, nil, nil)
+	require.NoError(t, err)
+	require.NoError(t, mgr.Init(struct{ TablesManager }{}, nil))
+
+	// series progress file should not have been created
+	require.Nil(t, mgr.seriesProgress)
+	require.NoFileExists(t, filepath.Join(workingDir, seriesProgressFilename))
+
+	mgr.MarkPhaseStarted()
+	require.NotNil(t, mgr.currentBatch)
+
+	// MarkSeriesAsProcessed should be just ignored and not fail
+	require.NoError(t, mgr.MarkSeriesAsProcessed(user1, []byte(lblFooBar.String()), lblFooBar, "t1"))
+	// expiry check should not fail either
+	isExpired, _ := mgr.Expired(user1, retention.Chunk{From: 0, Through: 50}, lblFooBar, []byte(lblFooBar.String()), "t1", model.Now())
+	require.True(t, isExpired)
+
+	// mark phases should not cause any trouble due to a nil series progress file reference
+	mgr.MarkPhaseTimedOut()
+	mgr.MarkPhaseFinished()
+
+	// series progress file should still not be present
+	require.Nil(t, mgr.seriesProgress)
+	require.NoFileExists(t, filepath.Join(workingDir, seriesProgressFilename))
+
+	// load the requests again for processing
+	mgr.MarkPhaseStarted()
+	require.NotNil(t, mgr.currentBatch)
+
+	// do not hit the timeout this time and see if things continue to work as usual
+	mgr.MarkPhaseFinished()
+
+	// series progress file should still not be present
+	require.Nil(t, mgr.seriesProgress)
 	require.NoFileExists(t, filepath.Join(workingDir, seriesProgressFilename))
 }
 
@@ -1485,4 +1530,17 @@ func requestsAreEqual(req1, req2 DeleteRequest) bool {
 	}
 
 	return false
+}
+
+func getAllSeriesProgressKeys(t *testing.T, db *bbolt.DB) map[string]struct{} {
+	keys := make(map[string]struct{})
+	err := db.View(func(tx *bbolt.Tx) error {
+		return tx.Bucket([]byte(boltdbBucketName)).ForEach(func(k, v []byte) error {
+			keys[string(k)] = struct{}{}
+			return nil
+		})
+	})
+	require.NoError(t, err)
+
+	return keys
 }

--- a/pkg/compactor/deletion/delete_requests_manager_test.go
+++ b/pkg/compactor/deletion/delete_requests_manager_test.go
@@ -1535,7 +1535,7 @@ func requestsAreEqual(req1, req2 DeleteRequest) bool {
 func getAllSeriesProgressKeys(t *testing.T, db *bbolt.DB) map[string]struct{} {
 	keys := make(map[string]struct{})
 	err := db.View(func(tx *bbolt.Tx) error {
-		return tx.Bucket([]byte(boltdbBucketName)).ForEach(func(k, v []byte) error {
+		return tx.Bucket(boltdbBucketName).ForEach(func(k, _ []byte) error {
 			keys[string(k)] = struct{}{}
 			return nil
 		})


### PR DESCRIPTION
**What this PR does / why we need it**:
When running the compactor in singleton mode, we track processed series to skip processing them again when the delete request processing resumes after hitting a timeout. We used to store the progress in a map and store it as a JSON file on disk to persist the progress between restarts. Today, this led to an incident because it used too much memory to track the progress and then used additional memory to JSON encode the data.

In this PR, I am adding support to store series progress in a BoltDB file. Because they are memory-mapped, we should use significantly less memory, and all the updates would normally get automatically synced to the disk.

To reduce the number of series we track, I have made it track only series with chunks to process with a line filter, since we want to avoid reprocessing on those.

**Checklist**
- [X] Tests updated
