### PR TITLE
Support optional print lines flag when dumping an object

### DIFF
--- a/cmd/dataobj-inspect/dump.go
+++ b/cmd/dataobj-inspect/dump.go
@@ -18,7 +18,8 @@ import (
 
 // dumpCommand dumps the contents of the data object.
 type dumpCommand struct {
-	files *[]string
+	files      *[]string
+	printLines *bool
 }
 
 func (cmd *dumpCommand) run(c *kingpin.ParseContext) error {
@@ -105,7 +106,7 @@ func (cmd *dumpCommand) dumpLogsSection(ctx context.Context, offset int, sec *da
 			r.Metadata.Range(func(l labels.Label) {
 				fmt.Printf("\t\t\t%s=%s\n", l.Name, l.Value)
 			})
-			if len(r.Line) > 0 {
+			if *cmd.printLines && len(r.Line) > 0 {
 				bold.Printf("\t\t> ")
 				for pos, char := range string(r.Line) {
 					fmt.Printf("%c", char)
@@ -122,5 +123,6 @@ func (cmd *dumpCommand) dumpLogsSection(ctx context.Context, offset int, sec *da
 func addDumpCommand(app *kingpin.Application) {
 	cmd := &dumpCommand{}
 	dump := app.Command("dump", "Dump the contents of the data object.").Action(cmd.run)
+	cmd.printLines = dump.Flag("print-lines", "Prints the lines of each column.").Bool()
 	cmd.files = dump.Arg("file", "The file to dump.").ExistingFiles()
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Supports an optional `print-lines` flag when dumping a data object to make dumping large data objects easier.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
