### PR TITLE
fix(helm): make loki.storage.bucketNames are optional, if builtin minio is enabled.

### DIFF
--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -13,6 +13,7 @@ Entries should include a reference to the pull request that introduced the chang
 
 [//]: # (<AUTOMATED_UPDATES_LOCATOR> : do not remove this line. This locator is used by the CI pipeline to automatically create a changelog entry for each new Loki release. Add other chart versions and respective changelog entries bellow this line.)
 
+- [BUGFIX] make loki.storage.bucketNames are optional, if builtin minio is enabled.
 
 ## 6.34.0
 

--- a/production/helm/loki/templates/validate.yaml
+++ b/production/helm/loki/templates/validate.yaml
@@ -40,7 +40,7 @@
 {{- fail "You must provide a schema_config for Loki, one is not provided as this will be individual for every Loki cluster. See https://grafana.com/docs/loki/latest/operations/storage/schema/ for schema information. For quick testing (with no persistence) add `--set loki.useTestSchema=true`"}}
 {{- end }}
 
-{{- if (eq (include "loki.isUsingObjectStorage" . ) "true") }}
+{{- if and (eq (include "loki.isUsingObjectStorage" . ) "true") (not .Values.minio.enabled) }}
 {{- $bucketNames := .Values.loki.storage.bucketNames -}}
 {{- if not (hasKey $bucketNames "chunks") }}
 {{- fail "Please define loki.storage.bucketName.chunks" }}


### PR DESCRIPTION
**What this PR does / why we need it**:

If minio is enabled, the names of the bucket names are hard-coded and `loki.storage.bucketNames` is ignored.

https://github.com/grafana/loki/blob/e0b33535d1d58c855f13ef5d35cb152acb3e16fc/production/helm/loki/templates/_helpers.tpl#L213-L216

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

CI is currently failing: https://github.com/grafana/loki/actions/runs/16606809856/job/46981528703?pr=18510

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
