### PR TITLE
chore: Autofix to make nosec comments also readable by semgrep

### DIFF
--- a/clients/pkg/promtail/targets/kafka/authentication.go
+++ b/clients/pkg/promtail/targets/kafka/authentication.go
@@ -13,7 +13,7 @@ import (
 
 func createTLSConfig(cfg promconfig.TLSConfig) (*tls.Config, error) {
 	tc := &tls.Config{
-		InsecureSkipVerify: cfg.InsecureSkipVerify, //#nosec G402 -- User has explicitly requested to disable TLS
+		InsecureSkipVerify: cfg.InsecureSkipVerify, //#nosec G402 -- User has explicitly requested to disable TLS -- nosemgrep: tls-with-insecure-cipher
 		ServerName:         cfg.ServerName,
 	}
 	// load ca cert

--- a/clients/pkg/promtail/targets/testutils/testutils.go
+++ b/clients/pkg/promtail/targets/testutils/testutils.go
@@ -16,7 +16,7 @@ var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 func RandName() string {
 	b := make([]rune, 10)
 	for i := range b {
-		b[i] = letters[randomGenerator.Intn(len(letters))] //#nosec G404 -- Generating random test data, fine.
+		b[i] = letters[randomGenerator.Intn(len(letters))] //#nosec G404 -- Generating random test data, fine. -- nosemgrep: math-random-used
 	}
 	return string(b)
 }

--- a/cmd/chunks-inspect/main.go
+++ b/cmd/chunks-inspect/main.go
@@ -126,7 +126,7 @@ func printFile(filename string, blockDetails, printLines, storeBlocks bool) {
 }
 
 func writeBlockToFile(data []byte, blockIndex int, filename string) {
-	err := os.WriteFile(filename, data, 0640) // #nosec G306 -- this is fencing off the "other" permissions
+	err := os.WriteFile(filename, data, 0640) // #nosec G306 -- this is fencing off the "other" permissions -- nosemgrep: incorrect-default-permissions
 	if err != nil {
 		log.Println("Failed to store block", blockIndex, "to file", filename, "due to error:", err)
 	} else {

--- a/integration/client/client.go
+++ b/integration/client/client.go
@@ -237,7 +237,7 @@ func (c *Client) Get(path string) (*http.Response, error) {
 // Get all the metrics
 func (c *Client) Metrics() (string, error) {
 	url := fmt.Sprintf("%s/metrics", c.baseURL)
-	res, err := http.Get(url) //#nosec G107 -- Intentionally taking user input from config
+	res, err := http.Get(url) //#nosec G107 -- Intentionally taking user input from config -- nosemgrep: tainted-url-host
 	if err != nil {
 		return "", err
 	}

--- a/integration/cluster/cluster.go
+++ b/integration/cluster/cluster.go
@@ -183,7 +183,7 @@ func New(logLevel level.Value, opts ...func(*Cluster)) *Cluster {
 
 	overridesFile := filepath.Join(sharedPath, "loki-overrides.yaml")
 
-	err = os.WriteFile(overridesFile, []byte(`overrides:`), 0640) // #nosec G306 -- this is fencing off the "other" permissions
+	err = os.WriteFile(overridesFile, []byte(`overrides:`), 0640) // #nosec G306 -- this is fencing off the "other" permissions -- nosemgrep: incorrect-default-permissions
 	if err != nil {
 		panic(fmt.Errorf("error creating overrides file: %w", err))
 	}
@@ -355,7 +355,7 @@ func (c *Component) writeConfig() error {
 		return fmt.Errorf("error getting merged config: %w", err)
 	}
 
-	if err := os.WriteFile(configFile.Name(), mergedConfig, 0640); err != nil { // #nosec G306 -- this is fencing off the "other" permissions
+	if err := os.WriteFile(configFile.Name(), mergedConfig, 0640); err != nil { // #nosec G306 -- this is fencing off the "other" permissions -- nosemgrep: incorrect-default-permissions
 		return fmt.Errorf("error writing config file: %w", err)
 	}
 
@@ -532,7 +532,7 @@ func (c *Component) SetTenantLimits(tenant string, limits validation.Limits) err
 		return err
 	}
 
-	return os.WriteFile(c.overridesFile, config, 0640) // #nosec G306 -- this is fencing off the "other" permissions
+	return os.WriteFile(c.overridesFile, config, 0640) // #nosec G306 -- this is fencing off the "other" permissions -- nosemgrep: incorrect-default-permissions
 }
 
 func (c *Component) GetTenantLimits(tenant string) validation.Limits {

--- a/integration/cluster/ruler.go
+++ b/integration/cluster/ruler.go
@@ -43,7 +43,7 @@ func (c *Component) WithTenantRules(tenantFilesMap map[string]map[string]string)
 			if err := os.Mkdir(path, 0750); err != nil {
 				return fmt.Errorf("error creating tenant %s rules path: %w", tenant, err)
 			}
-			if err := os.WriteFile(filepath.Join(path, filename), []byte(strings.TrimSpace(file)), 0640); err != nil { // #nosec G306 -- this is fencing off the "other" permissions
+			if err := os.WriteFile(filepath.Join(path, filename), []byte(strings.TrimSpace(file)), 0640); err != nil { // #nosec G306 -- this is fencing off the "other" permissions -- nosemgrep: incorrect-default-permissions
 				return fmt.Errorf("error creating rule file at path %s: %w", path, err)
 			}
 		}

--- a/pkg/canary/comparator/comparator.go
+++ b/pkg/canary/comparator/comparator.go
@@ -275,7 +275,7 @@ func (c *Comparator) run() {
 	t := time.NewTicker(c.pruneInterval)
 	// Use a random tick up to the interval for the first tick
 	firstMt := true
-	randomGenerator := rand.New(rand.NewSource(time.Now().UnixNano())) //#nosec G404 -- Random sampling for health testing purposes, does not require secure random.
+	randomGenerator := rand.New(rand.NewSource(time.Now().UnixNano())) //#nosec G404 -- Random sampling for health testing purposes, does not require secure random. -- nosemgrep: math-random-used
 	mt := time.NewTicker(time.Duration(randomGenerator.Int63n(c.metricTestInterval.Nanoseconds())))
 	sc := time.NewTicker(c.spotCheckQueryRate)
 	ct := time.NewTicker(c.cacheTestInterval)

--- a/pkg/canary/writer/writer.go
+++ b/pkg/canary/writer/writer.go
@@ -81,8 +81,8 @@ func (w *Writer) run() {
 		select {
 		case <-t.C:
 			t := time.Now()
-			if i := rand.Intn(100); i < w.outOfOrderPercentage { //#nosec G404 -- Random sampling for testing purposes, does not require secure random.
-				n := rand.Intn(int(w.outOfOrderMax.Seconds()-w.outOfOrderMin.Seconds())) + int(w.outOfOrderMin.Seconds()) //#nosec G404 -- Random sampling for testing purposes, does not require secure random.
+			if i := rand.Intn(100); i < w.outOfOrderPercentage { //#nosec G404 -- Random sampling for testing purposes, does not require secure random. -- nosemgrep: math-random-used
+				n := rand.Intn(int(w.outOfOrderMax.Seconds()-w.outOfOrderMin.Seconds())) + int(w.outOfOrderMin.Seconds()) //#nosec G404 -- Random sampling for testing purposes, does not require secure random. -- nosemgrep: math-random-used
 				t = t.Add(-time.Duration(n) * time.Second)
 			}
 			ts := strconv.FormatInt(t.UnixNano(), 10)

--- a/pkg/chunkenc/memchunk.go
+++ b/pkg/chunkenc/memchunk.go
@@ -1297,7 +1297,7 @@ func (hb *headBlock) Iterator(ctx context.Context, direction logproto.Direction,
 }
 
 func unsafeGetBytes(s string) []byte {
-	return unsafe.Slice(unsafe.StringData(s), len(s)) // #nosec G103 -- we know the string is not mutated
+	return unsafe.Slice(unsafe.StringData(s), len(s)) // #nosec G103 -- we know the string is not mutated -- nosemgrep: use-of-unsafe-block
 }
 
 func (hb *headBlock) SampleIterator(

--- a/pkg/compactor/deletion/delete_requests_manager.go
+++ b/pkg/compactor/deletion/delete_requests_manager.go
@@ -679,5 +679,5 @@ func getMaxRetentionInterval(userID string, limits Limits) time.Duration {
 }
 
 func unsafeGetBytes(s string) []byte {
-	return unsafe.Slice(unsafe.StringData(s), len(s)) // #nosec G103 -- we know the string is not mutated
+	return unsafe.Slice(unsafe.StringData(s), len(s)) // #nosec G103 -- we know the string is not mutated -- nosemgrep: use-of-unsafe-block
 }

--- a/pkg/compactor/deletion/delete_requests_store_boltdb.go
+++ b/pkg/compactor/deletion/delete_requests_store_boltdb.go
@@ -550,7 +550,7 @@ func splitUserIDAndRequestID(rangeValue string) (userID, requestID, seqID string
 
 // unsafeGetString is like yolostring but with a meaningful name
 func unsafeGetString(buf []byte) string {
-	return *((*string)(unsafe.Pointer(&buf))) // #nosec G103 -- we know the string is not mutated
+	return *((*string)(unsafe.Pointer(&buf))) // #nosec G103 -- we know the string is not mutated -- nosemgrep: use-of-unsafe-block
 }
 
 func generateCacheGenNumber() []byte {

--- a/pkg/compactor/retention/retention.go
+++ b/pkg/compactor/retention/retention.go
@@ -594,7 +594,7 @@ func CopyMarkers(src string, dst string) error {
 			return fmt.Errorf("read marker file: %w", err)
 		}
 
-		if err := os.WriteFile(filepath.Join(targetDir, marker.Name()), data, 0640); err != nil { // #nosec G306 -- this is fencing off the "other" permissions
+		if err := os.WriteFile(filepath.Join(targetDir, marker.Name()), data, 0640); err != nil { // #nosec G306 -- this is fencing off the "other" permissions -- nosemgrep: incorrect-default-permissions
 			return fmt.Errorf("write marker file: %w", err)
 		}
 	}

--- a/pkg/compactor/retention/util.go
+++ b/pkg/compactor/retention/util.go
@@ -13,11 +13,11 @@ import (
 
 // unsafeGetString is like yolostring but with a meaningful name
 func unsafeGetString(buf []byte) string {
-	return *((*string)(unsafe.Pointer(&buf))) // #nosec G103 -- we know the string is not mutated
+	return *((*string)(unsafe.Pointer(&buf))) // #nosec G103 -- we know the string is not mutated -- nosemgrep: use-of-unsafe-block
 }
 
 func unsafeGetBytes(s string) []byte {
-	return unsafe.Slice(unsafe.StringData(s), len(s)) // #nosec G103 -- we know the string is not mutated
+	return unsafe.Slice(unsafe.StringData(s), len(s)) // #nosec G103 -- we know the string is not mutated -- nosemgrep: use-of-unsafe-block
 }
 
 func copyFile(src, dst string) (int64, error) {

--- a/pkg/compactor/table.go
+++ b/pkg/compactor/table.go
@@ -318,5 +318,5 @@ func tableHasUncompactedIndex(ctx context.Context, tableName string, indexStorag
 }
 
 func unsafeGetBytes(s string) []byte {
-	return unsafe.Slice(unsafe.StringData(s), len(s)) // #nosec G103 -- we know the string is not mutated
+	return unsafe.Slice(unsafe.StringData(s), len(s)) // #nosec G103 -- we know the string is not mutated -- nosemgrep: use-of-unsafe-block
 }

--- a/pkg/compactor/testutil.go
+++ b/pkg/compactor/testutil.go
@@ -82,7 +82,7 @@ func SetupTable(t *testing.T, path string, commonDBsConfig IndexesConfig, perUse
 	idx := 0
 	for filename, content := range commonIndexes {
 		filePath := filepath.Join(path, strings.TrimSuffix(filename, ".gz"))
-		require.NoError(t, os.WriteFile(filePath, []byte(content), 0640)) // #nosec G306 -- this is fencing off the "other" permissions
+		require.NoError(t, os.WriteFile(filePath, []byte(content), 0640)) // #nosec G306 -- this is fencing off the "other" permissions -- nosemgrep: incorrect-default-permissions
 		if strings.HasSuffix(filename, ".gz") {
 			compressFile(t, filePath)
 		}
@@ -93,7 +93,7 @@ func SetupTable(t *testing.T, path string, commonDBsConfig IndexesConfig, perUse
 		require.NoError(t, util.EnsureDirectory(filepath.Join(path, userID)))
 		for filename, content := range files {
 			filePath := filepath.Join(path, userID, strings.TrimSuffix(filename, ".gz"))
-			require.NoError(t, os.WriteFile(filePath, []byte(content), 0640)) // #nosec G306 -- this is fencing off the "other" permissions
+			require.NoError(t, os.WriteFile(filePath, []byte(content), 0640)) // #nosec G306 -- this is fencing off the "other" permissions -- nosemgrep: incorrect-default-permissions
 			if strings.HasSuffix(filename, ".gz") {
 				compressFile(t, filePath)
 			}

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -765,7 +765,7 @@ func (i *Ingester) loop() {
 	// flush at the same time. Flushing at the same time can cause concurrently
 	// writing the same chunk to object storage, which in AWS S3 leads to being
 	// rate limited.
-	jitter := time.Duration(rand.Int63n(int64(float64(i.cfg.FlushCheckPeriod.Nanoseconds()) * 0.8))) //#nosec G404 -- Jitter does not require a CSPRNG.
+	jitter := time.Duration(rand.Int63n(int64(float64(i.cfg.FlushCheckPeriod.Nanoseconds()) * 0.8))) //#nosec G404 -- Jitter does not require a CSPRNG. -- nosemgrep: math-random-used
 	initialDelay := time.NewTimer(jitter)
 	defer initialDelay.Stop()
 

--- a/pkg/logproto/compat.go
+++ b/pkg/logproto/compat.go
@@ -206,7 +206,7 @@ func SampleJsoniterDecode(ptr unsafe.Pointer, iter *jsoniter.Iterator) {
 	}
 
 	bs := iter.ReadStringAsSlice()
-	ss := *(*string)(unsafe.Pointer(&bs)) // #nosec G103 -- we know the string is not mutated
+	ss := *(*string)(unsafe.Pointer(&bs)) // #nosec G103 -- we know the string is not mutated -- nosemgrep: use-of-unsafe-block
 	v, err := strconv.ParseFloat(ss, 64)
 	if err != nil {
 		iter.ReportError("logproto.LegacySample", err.Error())

--- a/pkg/logql/log/parser.go
+++ b/pkg/logql/log/parser.go
@@ -231,7 +231,7 @@ func (j *JSONParser) buildJSONPathFromPrefixBuffer() []string {
 
 	jsonPath := make([]string, 0, len(j.prefixBuffer))
 	for _, part := range j.prefixBuffer {
-		partStr := unsafe.String(unsafe.SliceData(part), len(part)) // #nosec G103 -- we know the string is not mutated
+		partStr := unsafe.String(unsafe.SliceData(part), len(part)) // #nosec G103 -- we know the string is not mutated -- nosemgrep: use-of-unsafe-block
 		// Trim _extracted suffix if the extracted field was a duplicate field
 		partStr = strings.TrimSuffix(partStr, duplicateSuffix)
 		jsonPath = append(jsonPath, partStr)

--- a/pkg/logql/log/pipeline.go
+++ b/pkg/logql/log/pipeline.go
@@ -372,9 +372,9 @@ func ReduceStages(stages []Stage) Stage {
 }
 
 func unsafeGetBytes(s string) []byte {
-	return unsafe.Slice(unsafe.StringData(s), len(s)) // #nosec G103 -- we know the string is not mutated
+	return unsafe.Slice(unsafe.StringData(s), len(s)) // #nosec G103 -- we know the string is not mutated -- nosemgrep: use-of-unsafe-block
 }
 
 func unsafeGetString(buf []byte) string {
-	return *((*string)(unsafe.Pointer(&buf))) // #nosec G103 -- we know the string is not mutated
+	return *((*string)(unsafe.Pointer(&buf))) // #nosec G103 -- we know the string is not mutated -- nosemgrep: use-of-unsafe-block
 }

--- a/pkg/logql/sketch/topk.go
+++ b/pkg/logql/sketch/topk.go
@@ -210,7 +210,7 @@ func (t *Topk) updateBF(removed, added string) {
 }
 
 func unsafeGetBytes(s string) []byte {
-	return unsafe.Slice(unsafe.StringData(s), len(s)) // #nosec G103 -- we know the string is not mutated
+	return unsafe.Slice(unsafe.StringData(s), len(s)) // #nosec G103 -- we know the string is not mutated -- nosemgrep: use-of-unsafe-block
 }
 
 // Observe is our sketch event observation function, which is a bit more complex than the original count min sketch + heap TopK

--- a/pkg/logql/test_utils.go
+++ b/pkg/logql/test_utils.go
@@ -267,7 +267,7 @@ func (m MockDownstreamer) Downstream(ctx context.Context, queries []DownstreamQu
 // create nStreams of nEntries with labelNames each where each label value
 // with the exception of the "index" label is modulo'd into a shard
 func randomStreams(nStreams, nEntries, nShards int, labelNames []string, valueField bool) (streams []logproto.Stream) {
-	r := rand.New(rand.NewSource(42)) //#nosec G404 -- Generation of test data only, no need for a cryptographic PRNG
+	r := rand.New(rand.NewSource(42)) //#nosec G404 -- Generation of test data only, no need for a cryptographic PRNG -- nosemgrep: math-random-used
 	for i := 0; i < nStreams; i++ {
 		// labels
 		stream := logproto.Stream{}

--- a/pkg/lokifrontend/frontend/v2/frontend.go
+++ b/pkg/lokifrontend/frontend/v2/frontend.go
@@ -156,7 +156,7 @@ func NewFrontend(cfg Config, ring ring.ReadRing, log log.Logger, reg prometheus.
 	// Randomize to avoid getting responses from queries sent before restart, which could lead to mixing results
 	// between different queries. Note that frontend verifies the user, so it cannot leak results between tenants.
 	// This isn't perfect, but better than nothing.
-	f.lastQueryID.Store(rand.Uint64()) //#nosec G404 -- See above comment, this can't leak data or otherwise result in a vuln, simply very rarely cause confusing behavior. A CSPRNG would not help.
+	f.lastQueryID.Store(rand.Uint64()) //#nosec G404 -- See above comment, this can't leak data or otherwise result in a vuln, simply very rarely cause confusing behavior. A CSPRNG would not help. -- nosemgrep: math-random-used
 
 	promauto.With(reg).NewGaugeFunc(prometheus.GaugeOpts{
 		Namespace: metricsNamespace,

--- a/pkg/pattern/drain/drain.go
+++ b/pkg/pattern/drain/drain.go
@@ -524,9 +524,9 @@ func (d *Drain) createTemplate(tokens, matchClusterTokens []string) []string {
 }
 
 func unsafeString(s []byte) string {
-	return unsafe.String(unsafe.SliceData(s), len(s)) // #nosec G103 -- we know the string is not mutated
+	return unsafe.String(unsafe.SliceData(s), len(s)) // #nosec G103 -- we know the string is not mutated -- nosemgrep: use-of-unsafe-block
 }
 
 func unsafeBytes(s string) []byte {
-	return unsafe.Slice(unsafe.StringData(s), len(s)) // #nosec G103 -- we know the string is not mutated
+	return unsafe.Slice(unsafe.StringData(s), len(s)) // #nosec G103 -- we know the string is not mutated -- nosemgrep: use-of-unsafe-block
 }

--- a/pkg/pattern/ingester.go
+++ b/pkg/pattern/ingester.go
@@ -326,7 +326,7 @@ func (i *Ingester) loop() {
 	// flush at the same time. Flushing at the same time can cause concurrently
 	// writing the same chunk to object storage, which in AWS S3 leads to being
 	// rate limited.
-	jitter := time.Duration(rand.Int63n(int64(float64(i.cfg.FlushCheckPeriod.Nanoseconds()) * 0.8))) //#nosec G404 -- Jitter does not require a CSPRNG
+	jitter := time.Duration(rand.Int63n(int64(float64(i.cfg.FlushCheckPeriod.Nanoseconds()) * 0.8))) //#nosec G404 -- Jitter does not require a CSPRNG -- nosemgrep: math-random-used
 	initialDelay := time.NewTimer(jitter)
 	defer initialDelay.Stop()
 

--- a/pkg/queue/tenant_queues.go
+++ b/pkg/queue/tenant_queues.go
@@ -336,7 +336,7 @@ func shuffleConsumersForTenants(userSeed int64, consumersToSelect int, allSorted
 	}
 
 	result := make(map[string]struct{}, consumersToSelect)
-	rnd := rand.New(rand.NewSource(userSeed)) //#nosec G404 -- Load spreading does not require CSPRNG
+	rnd := rand.New(rand.NewSource(userSeed)) //#nosec G404 -- Load spreading does not require CSPRNG -- nosemgrep: math-random-used
 
 	scratchpad = scratchpad[:0]
 	scratchpad = append(scratchpad, allSortedConsumers...)

--- a/pkg/storage/batch_test.go
+++ b/pkg/storage/batch_test.go
@@ -1822,5 +1822,5 @@ func newOverlappingStreams(streamCount int, entryCount int) []*logproto.Stream {
 }
 
 func unsafeGetBytes(s string) []byte {
-	return unsafe.Slice(unsafe.StringData(s), len(s)) // #nosec G103 -- we know the string is not mutated
+	return unsafe.Slice(unsafe.StringData(s), len(s)) // #nosec G103 -- we know the string is not mutated -- nosemgrep: use-of-unsafe-block
 }

--- a/pkg/storage/bloom/v1/bloom_tester.go
+++ b/pkg/storage/bloom/v1/bloom_tester.go
@@ -163,7 +163,7 @@ func (kvm keyValueMatcherTest) Matches(series labels.Labels, bloom filter.Checke
 
 	var (
 		combined    = fmt.Sprintf("%s=%s", kvm.matcher.Key, kvm.matcher.Value)
-		rawCombined = unsafe.Slice(unsafe.StringData(combined), len(combined)) // #nosec G103 -- we know the string is not mutated
+		rawCombined = unsafe.Slice(unsafe.StringData(combined), len(combined)) // #nosec G103 -- we know the string is not mutated -- nosemgrep: use-of-unsafe-block
 	)
 
 	return kvm.match(series, bloom, rawCombined)
@@ -199,7 +199,7 @@ func (kvm keyValueMatcherTest) match(series labels.Labels, bloom filter.Checker,
 // appendToBuf is the equivalent of append(buf[:prefixLen], str). len(buf) must
 // be greater than or equal to prefixLen+len(str) to avoid allocations.
 func appendToBuf(buf []byte, prefixLen int, str string) []byte {
-	rawString := unsafe.Slice(unsafe.StringData(str), len(str)) // #nosec G103 -- we know the string is not mutated
+	rawString := unsafe.Slice(unsafe.StringData(str), len(str)) // #nosec G103 -- we know the string is not mutated -- nosemgrep: use-of-unsafe-block
 	return append(buf[:prefixLen], rawString...)
 }
 

--- a/pkg/storage/chunk/cache/redis_client.go
+++ b/pkg/storage/chunk/cache/redis_client.go
@@ -74,7 +74,7 @@ func NewRedisClient(cfg *RedisConfig) (*RedisClient, error) {
 		RouteRandomly:   cfg.RouteRandomly,
 	}
 	if cfg.EnableTLS {
-		opt.TLSConfig = &tls.Config{InsecureSkipVerify: cfg.InsecureSkipVerify} //#nosec G402 -- User has explicitly requested to disable TLS
+		opt.TLSConfig = &tls.Config{InsecureSkipVerify: cfg.InsecureSkipVerify} //#nosec G402 -- User has explicitly requested to disable TLS -- nosemgrep: tls-with-insecure-cipher
 	}
 	return &RedisClient{
 		expiration: cfg.Expiration,
@@ -208,7 +208,7 @@ func (c *RedisClient) Close() error {
 
 // StringToBytes converts string to byte slice. (copied from vendor/github.com/go-redis/redis/v8/internal/util/unsafe.go)
 func StringToBytes(s string) []byte {
-	return *(*[]byte)(unsafe.Pointer( // #nosec G103 -- we know the string is not mutated
+	return *(*[]byte)(unsafe.Pointer( // #nosec G103 -- we know the string is not mutated -- nosemgrep: use-of-unsafe-block
 		&struct {
 			string
 			Cap int

--- a/pkg/storage/chunk/chunk.go
+++ b/pkg/storage/chunk/chunk.go
@@ -214,11 +214,11 @@ func readOneHexPart(hex []byte) (part []byte, i int) {
 }
 
 func unsafeGetBytes(s string) []byte {
-	return unsafe.Slice(unsafe.StringData(s), len(s)) // #nosec G103 -- we know the string is not mutated
+	return unsafe.Slice(unsafe.StringData(s), len(s)) // #nosec G103 -- we know the string is not mutated -- nosemgrep: use-of-unsafe-block
 }
 
 func unsafeGetString(buf []byte) string {
-	return *((*string)(unsafe.Pointer(&buf))) // #nosec G103 -- we know the string is not mutated
+	return *((*string)(unsafe.Pointer(&buf))) // #nosec G103 -- we know the string is not mutated -- nosemgrep: use-of-unsafe-block
 }
 
 var writerPool = sync.Pool{

--- a/pkg/storage/chunk/client/aws/s3_storage_client.go
+++ b/pkg/storage/chunk/client/aws/s3_storage_client.go
@@ -232,7 +232,7 @@ func buildS3Client(cfg S3Config, hedgingCfg hedging.Config, hedging bool) (*s3.S
 	}
 
 	tlsConfig := &tls.Config{
-		InsecureSkipVerify: cfg.HTTPConfig.InsecureSkipVerify, //#nosec G402 -- User has explicitly requested to disable TLS
+		InsecureSkipVerify: cfg.HTTPConfig.InsecureSkipVerify, //#nosec G402 -- User has explicitly requested to disable TLS -- nosemgrep: tls-with-insecure-cipher
 	}
 
 	if cfg.HTTPConfig.CAFile != "" {

--- a/pkg/storage/chunk/client/gcp/gcs_object_client.go
+++ b/pkg/storage/chunk/client/gcp/gcs_object_client.go
@@ -366,7 +366,7 @@ func gcsTransport(ctx context.Context, scope string, insecure bool, http2 bool, 
 	}
 	transportOptions := []option.ClientOption{option.WithScopes(scope)}
 	if insecure {
-		customTransport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} //#nosec G402 -- User has explicitly requested to disable TLS
+		customTransport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} //#nosec G402 -- User has explicitly requested to disable TLS -- nosemgrep: tls-with-insecure-cipher
 		transportOptions = append(transportOptions, option.WithoutAuthentication())
 	}
 	if serviceAccount.String() != "" {

--- a/pkg/storage/hack/main.go
+++ b/pkg/storage/hack/main.go
@@ -143,7 +143,7 @@ const charset = "abcdefghijklmnopqrstuvwxyz" +
 func randStringWithCharset(length int, charset string) string {
 	b := make([]byte, length)
 	for i := range b {
-		b[i] = charset[rand.Intn(len(charset)-1)] //#nosec G404 -- Generation of test data does not require CSPRNG, this is not meant to be secret.
+		b[i] = charset[rand.Intn(len(charset)-1)] //#nosec G404 -- Generation of test data does not require CSPRNG, this is not meant to be secret. -- nosemgrep: math-random-used
 	}
 	return string(b)
 }

--- a/pkg/storage/stores/series/index/caching_index_client.go
+++ b/pkg/storage/stores/series/index/caching_index_client.go
@@ -259,7 +259,7 @@ func (s *cachingIndexClient) doQueries(ctx context.Context, queries []Query, cal
 }
 
 func yoloString(buf []byte) string {
-	return *((*string)(unsafe.Pointer(&buf))) // #nosec G103 -- we know the string is not mutated
+	return *((*string)(unsafe.Pointer(&buf))) // #nosec G103 -- we know the string is not mutated -- nosemgrep: use-of-unsafe-block
 }
 
 // Iterator implements chunk.ReadBatch.

--- a/pkg/storage/stores/series/index/table_manager.go
+++ b/pkg/storage/stores/series/index/table_manager.go
@@ -228,7 +228,7 @@ func (m *TableManager) loop(ctx context.Context) error {
 
 	// Sleep for a bit to spread the sync load across different times if the tablemanagers are all started at once.
 	select {
-	case <-time.After(time.Duration(rand.Int63n(int64(m.cfg.PollInterval)))): //#nosec G404 -- This is also just essentially jitter, no need for CSPRNG.
+	case <-time.After(time.Duration(rand.Int63n(int64(m.cfg.PollInterval)))): //#nosec G404 -- This is also just essentially jitter, no need for CSPRNG. -- nosemgrep: math-random-used
 	case <-ctx.Done():
 		return nil
 	}

--- a/pkg/storage/stores/shipper/indexshipper/boltdb/compactor/util.go
+++ b/pkg/storage/stores/shipper/indexshipper/boltdb/compactor/util.go
@@ -19,7 +19,7 @@ import (
 
 // unsafeGetString is like yolostring but with a meaningful name
 func unsafeGetString(buf []byte) string {
-	return *((*string)(unsafe.Pointer(&buf))) // #nosec G103 -- we know the string is not mutated
+	return *((*string)(unsafe.Pointer(&buf))) // #nosec G103 -- we know the string is not mutated -- nosemgrep: use-of-unsafe-block
 }
 
 func createChunk(t testing.TB, chunkFormat byte, headBlockFmt chunkenc.HeadBlockFmt, userID string, lbs labels.Labels, from model.Time, through model.Time) chunk.Chunk {

--- a/pkg/storage/stores/shipper/indexshipper/downloads/testutil.go
+++ b/pkg/storage/stores/shipper/indexshipper/downloads/testutil.go
@@ -39,7 +39,7 @@ func setupIndexesAtPath(t *testing.T, userID, path string, start, end int) []str
 		fileName := buildIndexFilename(userID, start)
 		indexPath := filepath.Join(path, fileName)
 
-		require.NoError(t, os.WriteFile(indexPath, []byte(fileName), 0640)) // #nosec G306 -- this is fencing off the "other" permissions
+		require.NoError(t, os.WriteFile(indexPath, []byte(fileName), 0640)) // #nosec G306 -- this is fencing off the "other" permissions -- nosemgrep: incorrect-default-permissions
 		testIndexes = append(testIndexes, indexPath)
 	}
 

--- a/pkg/storage/stores/shipper/indexshipper/shipper.go
+++ b/pkg/storage/stores/shipper/indexshipper/shipper.go
@@ -112,7 +112,7 @@ func (cfg *Config) GetUniqueUploaderName() (string, error) {
 		if !os.IsNotExist(err) {
 			return "", err
 		}
-		if err := os.WriteFile(uploaderFilePath, []byte(uploader), 0640); err != nil { // #nosec G306 -- this is fencing off the "other" permissions
+		if err := os.WriteFile(uploaderFilePath, []byte(uploader), 0640); err != nil { // #nosec G306 -- this is fencing off the "other" permissions -- nosemgrep: incorrect-default-permissions
 			return "", err
 		}
 	} else {

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/builder.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/builder.go
@@ -108,7 +108,7 @@ func (b *Builder) Build(
 	}
 
 	// First write tenant/index-bounds-random.staging
-	rng := rand.Int63() //#nosec G404 -- just generating a random filename in a slightly unidiomatic way. Collision resistance is not a concern.
+	rng := rand.Int63() //#nosec G404 -- just generating a random filename in a slightly unidiomatic way. Collision resistance is not a concern. -- nosemgrep: math-random-used
 	name := fmt.Sprintf("%s-%x.staging", index.IndexFilename, rng)
 	tmpPath := filepath.Join(scratchDir, name)
 

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/compactor.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/compactor.go
@@ -433,5 +433,5 @@ func (c *compactedIndex) ToIndexFile() (shipperindex.Index, error) {
 }
 
 func getUnsafeBytes(s string) []byte {
-	return *((*[]byte)(unsafe.Pointer(&s))) // #nosec G103 -- we know the string is not mutated
+	return *((*[]byte)(unsafe.Pointer(&s))) // #nosec G103 -- we know the string is not mutated -- nosemgrep: use-of-unsafe-block
 }

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/index.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/index.go
@@ -2532,7 +2532,7 @@ func readChunkMetaWithForcedMintime(d *encoding.Decbuf, mint int64, chunkMeta *C
 }
 
 func yoloString(b []byte) string {
-	return *((*string)(unsafe.Pointer(&b))) // #nosec G103 -- we know the string is not mutated
+	return *((*string)(unsafe.Pointer(&b))) // #nosec G103 -- we know the string is not mutated -- nosemgrep: use-of-unsafe-block
 }
 
 func overlap(from, through, chkFrom, chkThrough int64) bool {

--- a/pkg/storage/stores/shipper/indexshipper/util/util.go
+++ b/pkg/storage/stores/shipper/indexshipper/util/util.go
@@ -82,11 +82,11 @@ func safeOpenBoltDbFile(path string, ret chan *result) {
 // }
 
 func GetUnsafeBytes(s string) []byte {
-	return *((*[]byte)(unsafe.Pointer(&s))) // #nosec G103 -- we know the string is not mutated
+	return *((*[]byte)(unsafe.Pointer(&s))) // #nosec G103 -- we know the string is not mutated -- nosemgrep: use-of-unsafe-block
 }
 
 func GetUnsafeString(buf []byte) string {
-	return *((*string)(unsafe.Pointer(&buf))) // #nosec G103 -- we know the string is not mutated
+	return *((*string)(unsafe.Pointer(&buf))) // #nosec G103 -- we know the string is not mutated -- nosemgrep: use-of-unsafe-block
 }
 
 func logPanic(p interface{}) {

--- a/pkg/tool/commands/rules.go
+++ b/pkg/tool/commands/rules.go
@@ -772,7 +772,7 @@ func save(nss map[string]rules.RuleNamespace, i bool) error {
 			filepath = filepath + ".result"
 		}
 
-		if err := os.WriteFile(filepath, payload, 0640); err != nil { // #nosec G306 -- this is fencing off the "other" permissions
+		if err := os.WriteFile(filepath, payload, 0640); err != nil { // #nosec G306 -- this is fencing off the "other" permissions -- nosemgrep: incorrect-default-permissions
 			return err
 		}
 	}

--- a/pkg/util/conv.go
+++ b/pkg/util/conv.go
@@ -13,7 +13,7 @@ func ModelLabelSetToMap(m model.LabelSet) map[string]string {
 	if len(m) == 0 {
 		return map[string]string{}
 	}
-	return *(*map[string]string)(unsafe.Pointer(&m)) // #nosec G103 -- we know the string is not mutated
+	return *(*map[string]string)(unsafe.Pointer(&m)) // #nosec G103 -- we know the string is not mutated -- nosemgrep: use-of-unsafe-block
 }
 
 // MapToModelLabelSet converts a map into a model.LabelSet
@@ -21,7 +21,7 @@ func MapToModelLabelSet(m map[string]string) model.LabelSet {
 	if len(m) == 0 {
 		return model.LabelSet{}
 	}
-	return *(*map[model.LabelName]model.LabelValue)(unsafe.Pointer(&m)) // #nosec G103 -- we know the string is not mutated
+	return *(*map[model.LabelName]model.LabelValue)(unsafe.Pointer(&m)) // #nosec G103 -- we know the string is not mutated -- nosemgrep: use-of-unsafe-block
 }
 
 // RoundToMilliseconds returns milliseconds precision time from nanoseconds.

--- a/pkg/util/shard.go
+++ b/pkg/util/shard.go
@@ -29,7 +29,7 @@ var (
 // ShuffleShardSeed returns seed for random number generator, computed from provided identifier.
 func ShuffleShardSeed(identifier, zone string) int64 {
 	// Use the identifier to compute an hash we'll use to seed the random.
-	hasher := md5.New()               //#nosec G401 -- This does not require collision resistance, this is an intentionally predictable value
+	hasher := md5.New()               //#nosec G401 -- This does not require collision resistance, this is an intentionally predictable value -- nosemgrep: use-of-md5
 	hasher.Write(YoloBuf(identifier)) // nolint:errcheck
 	if zone != "" {
 		hasher.Write(seedSeparator) // nolint:errcheck

--- a/pkg/util/ticker.go
+++ b/pkg/util/ticker.go
@@ -19,7 +19,7 @@ func NewJitter(b time.Duration, d time.Duration) Jitter {
 // Duration returns a random duration from the base duration and +/- jitter
 func (j Jitter) Duration() time.Duration {
 	base := j.base - j.deviation
-	jitter := time.Duration(rand.Int63n(int64(float64(2 * j.deviation.Nanoseconds())))) //#nosec G404 -- Jitter does not require CSPRNG
+	jitter := time.Duration(rand.Int63n(int64(float64(2 * j.deviation.Nanoseconds())))) //#nosec G404 -- Jitter does not require CSPRNG -- nosemgrep: math-random-used
 	return base + jitter
 }
 

--- a/pkg/util/time.go
+++ b/pkg/util/time.go
@@ -56,7 +56,7 @@ func DurationWithJitter(input time.Duration, variancePerc float64) time.Duration
 	}
 
 	variance := int64(float64(input) * variancePerc)
-	jitter := rand.Int63n(variance*2) - variance //#nosec G404 -- Jitter does not require CSPRNG
+	jitter := rand.Int63n(variance*2) - variance //#nosec G404 -- Jitter does not require CSPRNG -- nosemgrep: math-random-used
 
 	return input + time.Duration(jitter)
 }
@@ -69,7 +69,7 @@ func DurationWithPositiveJitter(input time.Duration, variancePerc float64) time.
 	}
 
 	variance := int64(float64(input) * variancePerc)
-	jitter := rand.Int63n(variance) //#nosec G404 -- Jitter does not require CSPRNG
+	jitter := rand.Int63n(variance) //#nosec G404 -- Jitter does not require CSPRNG -- nosemgrep: math-random-used
 
 	return input + time.Duration(jitter)
 }

--- a/pkg/util/unmarshal/unmarshal.go
+++ b/pkg/util/unmarshal/unmarshal.go
@@ -19,7 +19,7 @@ func DecodePushRequest(b io.Reader, r *logproto.PushRequest) error {
 	}
 
 	*r = logproto.PushRequest{
-		Streams: *(*[]logproto.Stream)(unsafe.Pointer(&request.Streams)), //#nosec G103 -- Just preventing an allocation, safe, there's no chance of an incorrect type cast here.
+		Streams: *(*[]logproto.Stream)(unsafe.Pointer(&request.Streams)), //#nosec G103 -- Just preventing an allocation, safe, there's no chance of an incorrect type cast here. -- nosemgrep: use-of-unsafe-block
 	}
 
 	return nil

--- a/pkg/util/yolo.go
+++ b/pkg/util/yolo.go
@@ -3,5 +3,5 @@ package util
 import "unsafe"
 
 func YoloBuf(s string) []byte {
-	return *((*[]byte)(unsafe.Pointer(&s))) //#nosec G103 -- This is used correctly; all uses of this function do not allow the mutable reference to escape
+	return *((*[]byte)(unsafe.Pointer(&s))) //#nosec G103 -- This is used correctly; all uses of this function do not allow the mutable reference to escape -- nosemgrep: use-of-unsafe-block
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Security is working on rolling out semgrep across our codebase. Because of some parser deficiencies in semgrep (the user-configurable rule engine runs after AST parsing, which discards comments), we can't just force it to respect #nosec, so this PR converts lines with valid gosec suppression directives into lines that *also* contain a valid equivalent semgrep suppression. I know it's ugly, sorry.

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [NA] Documentation added
- [NA] Tests updated
- [X] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [NA] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [NA] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
