### PR TITLE
fix(helm): enable ruler sharding to make it work in simple scalable mode

### DIFF
--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -14,6 +14,7 @@ Entries should include a reference to the pull request that introduced the chang
 [//]: # (<AUTOMATED_UPDATES_LOCATOR> : do not remove this line. This locator is used by the CI pipeline to automatically create a changelog entry for each new Loki release. Add other chart versions and respective changelog entries bellow this line.)
 
 - [BUGFIX] make loki.storage.bucketNames are optional, if builtin minio is enabled.
+- [BUGFIX] enable ruler sharding by default to make it work in simple scalable mode, where backend component (which includes ruler) is scaled to 3 replicas by default.
 
 ## 6.34.0
 

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -515,6 +515,7 @@ loki:
   rulerConfig:
     wal:
       dir: /var/loki/ruler-wal
+    enable_sharding: true
   # -- Structured loki configuration, takes precedence over `loki.config`, `loki.schemaConfig`, `loki.storageConfig`
   structuredConfig: {}
   # -- Additional query scheduler config


### PR DESCRIPTION
**What this PR does / why we need it**:

Simple scalable deployment mode deploys 3 backend replicas by default. The ruler is included in the backend component. Therefore, ruler sharding must be enabled to prevent each ruler instance from evaluating each rule. Multiple evaluation of the same rule leads to error when remote write to Mimir is enabled (err-mimir-sample-duplicate-timestamp).

**Which issue(s) this PR fixes**:

There is no open issue about this problem.

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [X] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
