### PR TITLE
fix: Revert "perf: Fix memory leak in cachedIterator (#17628)"

### DIFF
--- a/pkg/iter/cache.go
+++ b/pkg/iter/cache.go
@@ -98,9 +98,6 @@ func (it *cachedIterator) Err() error { return it.iterErr }
 
 func (it *cachedIterator) Close() error {
 	it.Reset()
-	if it.wrapped != nil {
-		it.wrapped.Close()
-	}
 	return it.closeErr
 }
 
@@ -197,8 +194,5 @@ func (it *cachedSampleIterator) Err() error { return it.iterErr }
 
 func (it *cachedSampleIterator) Close() error {
 	it.Reset()
-	if it.wrapped != nil {
-		it.wrapped.Close()
-	}
 	return it.closeErr
 }


### PR DESCRIPTION
This reverts commit 87aa954e18d544833b23de3c76fb15564a0d82f9.

**What this PR does / why we need it**:

Reverts https://github.com/grafana/loki/pull/17628 as it seems to be affecting the correctness of forward queries. The exact problem is not well understood yet, but we suspect that we are closing wrapped iterator before consuming all of the required entires

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
