### PR TITLE
feat: Add ingester_chunks_flush_requests_total

### DIFF
--- a/pkg/ingester/flush.go
+++ b/pkg/ingester/flush.go
@@ -508,6 +508,7 @@ func (i *Ingester) encodeChunk(ctx context.Context, ch *chunk.Chunk, desc *chunk
 // If the flush isn't successful, the operation for this userID is requeued allowing this and all other unflushed
 // chunk to have another opportunity to be flushed.
 func (i *Ingester) flushChunk(ctx context.Context, ch *chunk.Chunk) error {
+	i.metrics.chunksFlushRequestsTotal.Inc()
 	if err := i.store.Put(ctx, []chunk.Chunk{*ch}); err != nil {
 		i.metrics.chunksFlushFailures.Inc()
 		return fmt.Errorf("store put chunk: %w", err)

--- a/pkg/ingester/metrics.go
+++ b/pkg/ingester/metrics.go
@@ -48,6 +48,7 @@ type ingesterMetrics struct {
 	chunkAge                      prometheus.Histogram
 	chunkEncodeTime               prometheus.Histogram
 	chunksFlushFailures           prometheus.Counter
+	chunksFlushRequestsTotal      prometheus.Counter
 	chunksFlushedPerReason        *prometheus.CounterVec
 	chunkLifespan                 prometheus.Histogram
 	chunksEncoded                 *prometheus.CounterVec
@@ -241,6 +242,11 @@ func newIngesterMetrics(r prometheus.Registerer, metricsNamespace string) *inges
 			Namespace: constants.Loki,
 			Name:      "ingester_chunks_flush_failures_total",
 			Help:      "Total number of flush failures.",
+		}),
+		chunksFlushRequestsTotal: promauto.With(r).NewCounter(prometheus.CounterOpts{
+			Namespace: constants.Loki,
+			Name:      "ingester_chunks_flush_requests_total",
+			Help:      "Total number of flush requests (successful or not).",
 		}),
 		chunksFlushedPerReason: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
 			Namespace: constants.Loki,


### PR DESCRIPTION
**What this PR does / why we need it**:
We want to create an alert for when object store flushes are not successful Currently there is no metric counting all flushes (successful and unsuccessful). There's ingester_chunks_flushed_total but that one just counts successful flushes (split by reason). For the alert it would be beneficial to have the ratio of failures compared to the total amount of "flush requests", so that the threshold for the alert is not based on an absolute rate.

**Which issue(s) this PR fixes**:
Related with https://issues.redhat.com/browse/LOG-6238

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
