### PR TITLE
feat(operator): Add alert LokiIngesterFlushFailureRateCritical

### DIFF
--- a/operator/internal/manifests/internal/alerts/prometheus-alerts.yaml
+++ b/operator/internal/manifests/internal/alerts/prometheus-alerts.yaml
@@ -208,7 +208,7 @@ groups:
         rate(loki_ingester_chunks_flush_requests_total[5m])
       ) by (namespace, pod)
       > 0.20
-    for: 1m
+    for: 15m
     labels:
       severity: critical
   - alert: LokistackSchemaUpgradesRequired

--- a/operator/internal/manifests/internal/alerts/testdata/test.yaml
+++ b/operator/internal/manifests/internal/alerts/testdata/test.yaml
@@ -66,6 +66,11 @@ tests:
       - series: 'loki_discarded_samples_total{namespace="my-ns", tenant="application", reason="line_too_long"}'
         values: '0x5 0+120x25 3000'
 
+      - series: 'loki_ingester_chunks_flush_failures_total{namespace="my-ns", pod="ingester-0"}'
+        values: '0+25x20'
+      - series: 'loki_ingester_chunks_flush_requests_total{namespace="my-ns", pod="ingester-0"}'
+        values: '0+100x20'
+
     alert_rule_test:
       - eval_time: 16m
         alertname: LokiRequestErrors
@@ -194,3 +199,17 @@ tests:
                 Samples are discarded because of "line_too_long" at a rate of 2 samples per second.
               summary: Loki is discarding samples during ingestion because they fail validation.
               runbook_url: "[[ .RunbookURL]]#Loki-Discarded-Samples-Warning"
+      - eval_time: 16m
+        alertname: LokiIngesterFlushFailureRateCritical
+        exp_alerts:
+          - exp_labels:
+              namespace: my-ns
+              pod: ingester-0
+              severity: critical
+            exp_annotations:
+              summary: "Loki ingester has critical flush failure rate"
+              description: |
+                Loki ingester ingester-0 in the namespace my-ns has a critical flush failure rate of
+                25% over the last 5 minutes. This requires immediate attention as data is
+                not being flushed to the storage. Validate if the storage configuration is still valid and if the storage is
+                still reachable. Current failure rate: 25% Threshold: 20%


### PR DESCRIPTION
**What this PR does / why we need it**:
A common but not immediately obvious way to misconfigure LokiStack is to provide it with a secret that is syntactically correct but invalid for accessing the object storage.

**Which issue(s) this PR fixes**:
Fixes https://issues.redhat.com/browse/LOG-6238

**Special notes for your reviewer**:
Needs https://github.com/grafana/loki/pull/18696

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
