### PR TITLE
chore(CI): Add image building for querytee in pr/release workflows; add multi-arch support for querytee

### DIFF
--- a/.github/release-workflows.jsonnet
+++ b/.github/release-workflows.jsonnet
@@ -29,7 +29,7 @@ local imageJobs = {
   'loki-canary': build.image('loki-canary', 'cmd/loki-canary', platform=platforms.all),
   'loki-canary-boringcrypto': build.image('loki-canary-boringcrypto', 'cmd/loki-canary-boringcrypto', platform=platforms.all),
   promtail: build.image('promtail', 'clients/cmd/promtail', platform=platforms.all),
-  querytee: build.image('loki-query-tee', 'cmd/querytee', platform=platforms.amd),
+  querytee: build.image('loki-query-tee', 'cmd/querytee', platform=platforms.all),
   'loki-docker-driver': build.dockerPlugin('loki-docker-driver', dockerPluginDir, buildImage=buildImage, platform=[r.forPlatform('linux/amd64'), r.forPlatform('linux/arm64')]),
 };
 
@@ -38,6 +38,7 @@ local weeklyImageJobs = {
   'loki-canary': build.weeklyImage('loki-canary', 'cmd/loki-canary', platform=platforms.all),
   'loki-canary-boringcrypto': build.weeklyImage('loki-canary-boringcrypto', 'cmd/loki-canary-boringcrypto', platform=platforms.all),
   promtail: build.weeklyImage('promtail', 'clients/cmd/promtail', platform=platforms.all),
+  'loki-query-tee': build.weeklyImage('loki-query-tee', 'cmd/querytee', dockerfile='Dockerfile.cross', platform=platforms.all),
 };
 
 {

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -376,6 +376,129 @@
           ${OUTPUTS_IMAGE_NAME}@${IMAGE_DIGEST_AMD64} \
           ${OUTPUTS_IMAGE_NAME}@${IMAGE_DIGEST_ARM}
         docker buildx imagetools inspect $IMAGE
+  "loki-query-tee-image":
+    "env":
+      "BUILD_TIMEOUT": 60
+      "GO_VERSION": "1.24.4"
+      "IMAGE_PREFIX": "grafana"
+      "RELEASE_LIB_REF": "39f70c4db167e7e61065455fdbc48b50fd7c12a2"
+      "RELEASE_REPO": "grafana/loki"
+    "needs":
+    - "check"
+    "outputs":
+      "image_digest_linux_amd64": "${{ steps.digest.outputs.digest_linux_amd64 }}"
+      "image_digest_linux_arm": "${{ steps.digest.outputs.digest_linux_arm }}"
+      "image_digest_linux_arm64": "${{ steps.digest.outputs.digest_linux_arm64 }}"
+      "image_name": "${{ steps.weekly-version.outputs.image_name }}"
+      "image_tag": "${{ steps.weekly-version.outputs.image_version }}"
+    "permissions":
+      "contents": "read"
+      "id-token": "write"
+    "runs-on": "${{ matrix.runs_on }}"
+    "steps":
+    - "name": "pull release library code"
+      "uses": "actions/checkout@v4"
+      "with":
+        "path": "lib"
+        "persist-credentials": false
+        "ref": "${{ env.RELEASE_LIB_REF }}"
+        "repository": "grafana/loki-release"
+    - "name": "pull code to release"
+      "uses": "actions/checkout@v4"
+      "with":
+        "path": "release"
+        "persist-credentials": false
+        "repository": "${{ env.RELEASE_REPO }}"
+    - "name": "setup node"
+      "uses": "actions/setup-node@v4"
+      "with":
+        "node-version": 20
+    - "name": "Set up Docker buildx"
+      "uses": "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
+    - "name": "Login to DockerHub (from Vault)"
+      "uses": "grafana/shared-workflows/actions/dockerhub-login@fa48192dac470ae356b3f7007229f3ac28c48a25"
+    - "id": "weekly-version"
+      "name": "Get weekly version"
+      "run": |
+        version=$(./tools/image-tag)
+        echo "image_version=$version" >> $GITHUB_OUTPUT
+        echo "image_name=${{ env.IMAGE_PREFIX }}/loki-query-tee" >> $GITHUB_OUTPUT
+        echo "image_full_name=${{ env.IMAGE_PREFIX }}/loki-query-tee:$version" >> $GITHUB_OUTPUT
+      "working-directory": "release"
+    - "id": "platform"
+      "name": "Parse image platform"
+      "run": |
+        platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
+        echo "platform=${platform}" >> $GITHUB_OUTPUT
+        echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
+      "working-directory": "release"
+    - "id": "build-push"
+      "name": "Build and push"
+      "timeout-minutes": "${{ fromJSON(env.BUILD_TIMEOUT) }}"
+      "uses": "docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1"
+      "with":
+        "build-args": |
+          IMAGE_TAG=${{ steps.weekly-version.outputs.image_version }}
+          GO_VERSION=${{ env.GO_VERSION }}
+        "context": "release"
+        "file": "release/cmd/querytee/Dockerfile.cross"
+        "outputs": "push-by-digest=true,type=image,name=${{ steps.weekly-version.outputs.image_name }},push=true"
+        "platforms": "${{ matrix.arch }}"
+        "provenance": true
+        "tags": "${{ steps.weekly-version.outputs.image_name }}"
+    - "env":
+        "OUTPUTS_DIGEST": "${{ steps.build-push.outputs.digest }}"
+      "id": "digest"
+      "name": "Process image digest"
+      "run": |
+        arch=$(echo ${{ matrix.arch }} | tr "/" "_")
+        echo "digest_$arch=$OUTPUTS_DIGEST" >> $GITHUB_OUTPUT
+      "working-directory": "release"
+    "strategy":
+      "fail-fast": true
+      "matrix":
+        "include":
+        - "arch": "linux/amd64"
+          "runs_on":
+          - "github-hosted-ubuntu-x64-small"
+        - "arch": "linux/arm64"
+          "runs_on":
+          - "github-hosted-ubuntu-arm64-small"
+        - "arch": "linux/arm"
+          "runs_on":
+          - "github-hosted-ubuntu-arm64-small"
+  "loki-query-tee-manifest":
+    "env":
+      "BUILD_TIMEOUT": 60
+      "IMAGE_DIGEST_AMD64": "${{ needs.loki-query-tee-image.outputs.image_digest_linux_amd64 }}"
+      "IMAGE_DIGEST_ARM": "${{ needs.loki-query-tee-image.outputs.image_digest_linux_arm }}"
+      "IMAGE_DIGEST_ARM64": "${{ needs.loki-query-tee-image.outputs.image_digest_linux_arm64 }}"
+      "OUTPUTS_IMAGE_NAME": "${{ needs.loki-query-tee-image.outputs.image_name }}"
+      "OUTPUTS_IMAGE_TAG": "${{ needs.loki-query-tee-image.outputs.image_tag }}"
+    "needs":
+    - "loki-query-tee-image"
+    "permissions":
+      "contents": "read"
+      "id-token": "write"
+    "runs-on": "ubuntu-latest"
+    "steps":
+    - "name": "Set up Docker buildx"
+      "uses": "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
+    - "name": "Login to DockerHub (from Vault)"
+      "uses": "grafana/shared-workflows/actions/dockerhub-login@75804962c1ba608148988c1e2dc35fbb0ee21746"
+    - "name": "Publish multi-arch manifest"
+      "run": |
+        # Unfortunately there is no better way atm than having a separate named output for each digest
+        echo "linux/arm64 $IMAGE_DIGEST_ARM64"
+        echo "linux/amd64 $IMAGE_DIGEST_AMD64"
+        echo "linux/arm   $IMAGE_DIGEST_ARM"
+        IMAGE="${OUTPUTS_IMAGE_NAME}:${OUTPUTS_IMAGE_TAG}"
+        echo "Create multi-arch manifest for $IMAGE"
+        docker buildx imagetools create -t $IMAGE \
+          ${OUTPUTS_IMAGE_NAME}@${IMAGE_DIGEST_ARM64} \
+          ${OUTPUTS_IMAGE_NAME}@${IMAGE_DIGEST_AMD64} \
+          ${OUTPUTS_IMAGE_NAME}@${IMAGE_DIGEST_ARM}
+        docker buildx imagetools inspect $IMAGE
   "promtail-image":
     "env":
       "BUILD_TIMEOUT": 60

--- a/.github/workflows/minor-release-pr.yml
+++ b/.github/workflows/minor-release-pr.yml
@@ -974,6 +974,12 @@ jobs:
         - arch: "linux/amd64"
           runs_on:
           - "github-hosted-ubuntu-x64-small"
+        - arch: "linux/arm64"
+          runs_on:
+          - "github-hosted-ubuntu-arm64-small"
+        - arch: "linux/arm"
+          runs_on:
+          - "github-hosted-ubuntu-arm64-small"
   version:
     needs:
     - "check"

--- a/.github/workflows/patch-release-pr.yml
+++ b/.github/workflows/patch-release-pr.yml
@@ -974,6 +974,12 @@ jobs:
         - arch: "linux/amd64"
           runs_on:
           - "github-hosted-ubuntu-x64-small"
+        - arch: "linux/arm64"
+          runs_on:
+          - "github-hosted-ubuntu-arm64-small"
+        - arch: "linux/arm"
+          runs_on:
+          - "github-hosted-ubuntu-arm64-small"
   version:
     needs:
     - "check"

--- a/.github/workflows/querytee-images.yml
+++ b/.github/workflows/querytee-images.yml
@@ -1,0 +1,134 @@
+name: Publish loki-query-tee images
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "cmd/querytee/**"
+      - "tools/querytee/**"
+      - ".github/workflows/querytee-images.yml"
+
+permissions:
+  contents: read
+  id-token: write
+  pull-requests: read
+
+env:
+  BUILD_TIMEOUT: 60
+  IMAGE_PREFIX: grafana
+  GO_VERSION: "1.24.4"
+
+jobs:
+  loki-query-tee-image:
+    runs-on: ${{ matrix.runs_on }}
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - arch: linux/amd64
+            runs_on:
+              - github-hosted-ubuntu-x64-small
+          - arch: linux/arm64
+            runs_on:
+              - github-hosted-ubuntu-arm64-small
+          - arch: linux/arm
+            runs_on:
+              - github-hosted-ubuntu-arm64-small
+    outputs:
+      image_digest_linux_amd64: ${{ steps.digest.outputs.digest_linux_amd64 }}
+      image_digest_linux_arm: ${{ steps.digest.outputs.digest_linux_arm }}
+      image_digest_linux_arm64: ${{ steps.digest.outputs.digest_linux_arm64 }}
+      image_name: ${{ steps.pr-version.outputs.image_name }}
+      image_tag: ${{ steps.pr-version.outputs.image_version }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2
+
+      - name: Login to DockerHub (from Vault)
+        uses: grafana/shared-workflows/actions/dockerhub-login@fa48192dac470ae356b3f7007229f3ac28c48a25
+
+      - id: pr-version
+        name: Generate version from commit SHA
+        run: |
+          SHORT_SHA=$(echo ${{ github.sha }} | cut -c1-7)
+          version="main-${SHORT_SHA}"
+          echo "image_version=$version" >> $GITHUB_OUTPUT
+          echo "image_name=${{ env.IMAGE_PREFIX }}/loki-query-tee" >> $GITHUB_OUTPUT
+          echo "image_full_name=${{ env.IMAGE_PREFIX }}/loki-query-tee:$version" >> $GITHUB_OUTPUT
+
+      - id: platform
+        name: Parse image platform
+        run: |
+          platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
+          echo "platform=${platform}" >> $GITHUB_OUTPUT
+          echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
+
+      - id: build-push
+        name: Build and push
+        timeout-minutes: ${{ fromJSON(env.BUILD_TIMEOUT) }}
+        uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1
+        with:
+          build-args: |
+            IMAGE_TAG=${{ steps.pr-version.outputs.image_version }}
+            GO_VERSION=${{ env.GO_VERSION }}
+          context: .
+          file: ./cmd/querytee/Dockerfile.cross
+          outputs: push-by-digest=true,type=image,name=${{ steps.pr-version.outputs.image_name }},push=true
+          platforms: ${{ matrix.arch }}
+          provenance: true
+          tags: ${{ steps.pr-version.outputs.image_name }}
+
+      - env:
+          OUTPUTS_DIGEST: ${{ steps.build-push.outputs.digest }}
+        id: digest
+        name: Process image digest
+        run: |
+          arch=$(echo ${{ matrix.arch }} | tr "/" "_")
+          echo "digest_$arch=$OUTPUTS_DIGEST" >> $GITHUB_OUTPUT
+
+  loki-query-tee-manifest:
+    needs:
+      - loki-query-tee-image
+    runs-on: ubuntu-latest
+    env:
+      IMAGE_DIGEST_AMD64: ${{ needs.loki-query-tee-image.outputs.image_digest_linux_amd64 }}
+      IMAGE_DIGEST_ARM: ${{ needs.loki-query-tee-image.outputs.image_digest_linux_arm }}
+      IMAGE_DIGEST_ARM64: ${{ needs.loki-query-tee-image.outputs.image_digest_linux_arm64 }}
+      OUTPUTS_IMAGE_NAME: ${{ needs.loki-query-tee-image.outputs.image_name }}
+      OUTPUTS_IMAGE_TAG: ${{ needs.loki-query-tee-image.outputs.image_tag }}
+    steps:
+      - name: Set up Docker buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2
+
+      - name: Login to DockerHub (from Vault)
+        uses: grafana/shared-workflows/actions/dockerhub-login@75804962c1ba608148988c1e2dc35fbb0ee21746
+
+      - name: Publish multi-arch manifest
+        run: |
+          # Unfortunately there is no better way atm than having a separate named output for each digest
+          echo "linux/arm64 $IMAGE_DIGEST_ARM64"
+          echo "linux/amd64 $IMAGE_DIGEST_AMD64"
+          echo "linux/arm   $IMAGE_DIGEST_ARM"
+          IMAGE="${OUTPUTS_IMAGE_NAME}:${OUTPUTS_IMAGE_TAG}"
+          echo "Create multi-arch manifest for $IMAGE"
+          docker buildx imagetools create -t $IMAGE \
+            ${OUTPUTS_IMAGE_NAME}@${IMAGE_DIGEST_ARM64} \
+            ${OUTPUTS_IMAGE_NAME}@${IMAGE_DIGEST_AMD64} \
+            ${OUTPUTS_IMAGE_NAME}@${IMAGE_DIGEST_ARM}
+          docker buildx imagetools inspect $IMAGE
+
+      - name: Print image info
+        run: |
+          IMAGE="${OUTPUTS_IMAGE_NAME}:${OUTPUTS_IMAGE_TAG}"
+          echo "### 🐳 loki-query-tee Docker Image"
+          echo ""
+          echo "Multi-arch image built and pushed:"
+          echo "\`\`\`"
+          echo "$IMAGE"
+          echo "\`\`\`"
+          echo ""
+


### PR DESCRIPTION
**What this PR does / why we need it**:

With the addition of Goldfish mode for querytee (#17959) we now want to build and publish querytee images when:
1. Changes to querytee are merged to `main`
2. On a weekly cadence similar to other Loki components 

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

N/A

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
