### PR TITLE
feat(helm): add namespaceOverride

### DIFF
--- a/docs/sources/setup/install/helm/reference.md
+++ b/docs/sources/setup/install/helm/reference.md
@@ -1947,7 +1947,7 @@ null
 			<td>string</td>
 			<td>Comma separated addresses list in DNS Service Discovery format</td>
 			<td><pre lang="json">
-"dnssrvnoa+_memcached-client._tcp.{{ include \"loki.resourceName\" (dict \"ctx\" $ \"component\" \"chunks-cache\" \"suffix\" $.Values.chunksCache.suffix ) }}.{{ $.Release.Namespace }}.svc"
+"dnssrvnoa+_memcached-client._tcp.{{ include \"loki.resourceName\" (dict \"ctx\" $ \"component\" \"chunks-cache\" \"suffix\" $.Values.chunksCache.suffix ) }}.{{ include \"loki.namespace\" $ }}.svc"
 </pre>
 </td>
 		</tr>
@@ -2074,7 +2074,7 @@ true
 			<td>l2 memcache configuration</td>
 			<td><pre lang="json">
 {
-  "addresses": "dnssrvnoa+_memcached-client._tcp.{{ include \"loki.resourceName\" (dict \"ctx\" $ \"component\" \"chunks-cache\" \"suffix\" $.Values.chunksCache.l2.suffix ) }}.{{ $.Release.Namespace }}.svc",
+  "addresses": "dnssrvnoa+_memcached-client._tcp.{{ include \"loki.resourceName\" (dict \"ctx\" $ \"component\" \"chunks-cache\" \"suffix\" $.Values.chunksCache.l2.suffix ) }}.{{ include \"loki.namespace\" $ }}.svc",
   "affinity": {},
   "allocatedMemory": 8192,
   "annotations": {},
@@ -2131,7 +2131,7 @@ true
 			<td>string</td>
 			<td>Comma separated addresses list in DNS Service Discovery format</td>
 			<td><pre lang="json">
-"dnssrvnoa+_memcached-client._tcp.{{ include \"loki.resourceName\" (dict \"ctx\" $ \"component\" \"chunks-cache\" \"suffix\" $.Values.chunksCache.l2.suffix ) }}.{{ $.Release.Namespace }}.svc"
+"dnssrvnoa+_memcached-client._tcp.{{ include \"loki.resourceName\" (dict \"ctx\" $ \"component\" \"chunks-cache\" \"suffix\" $.Values.chunksCache.l2.suffix ) }}.{{ include \"loki.namespace\" $ }}.svc"
 </pre>
 </td>
 		</tr>
@@ -7755,7 +7755,7 @@ false
     "tenant": {
       "name": "self-monitoring",
       "password": null,
-      "secretNamespace": "{{ .Release.Namespace }}"
+      "secretNamespace": "{{ include \"loki.namespace\" . }}"
     }
   },
   "serviceMonitor": {
@@ -7939,7 +7939,7 @@ null
   "tenant": {
     "name": "self-monitoring",
     "password": null,
-    "secretNamespace": "{{ .Release.Namespace }}"
+    "secretNamespace": "{{ include \"loki.namespace\" . }}"
   }
 }
 </pre>
@@ -8105,7 +8105,7 @@ null
 {
   "name": "self-monitoring",
   "password": null,
-  "secretNamespace": "{{ .Release.Namespace }}"
+  "secretNamespace": "{{ include \"loki.namespace\" . }}"
 }
 </pre>
 </td>
@@ -8132,8 +8132,8 @@ null
 			<td>monitoring.selfMonitoring.tenant.secretNamespace</td>
 			<td>string</td>
 			<td>Namespace to create additional tenant token secret in. Useful if your Grafana instance is in a separate namespace. Token will still be created in the canary namespace.</td>
-			<td><pre lang="json">
-"{{ .Release.Namespace }}"
+			<td><pre lang="">
+The same namespace as the loki chart is installed in.
 </pre>
 </td>
 		</tr>
@@ -8281,6 +8281,15 @@ null
 			<td>nameOverride</td>
 			<td>string</td>
 			<td>Overrides the chart's name</td>
+			<td><pre lang="json">
+null
+</pre>
+</td>
+		</tr>
+		<tr>
+			<td>namespaceOverride</td>
+			<td>string</td>
+			<td>Overrides the chart's namespace</td>
 			<td><pre lang="json">
 null
 </pre>
@@ -10751,7 +10760,7 @@ null
 			<td>string</td>
 			<td>Comma separated addresses list in DNS Service Discovery format</td>
 			<td><pre lang="json">
-"dnssrvnoa+_memcached-client._tcp.{{ include \"loki.resourceName\" (dict \"ctx\" $ \"component\" \"results-cache\") }}.{{ $.Release.Namespace }}.svc"
+"dnssrvnoa+_memcached-client._tcp.{{ include \"loki.resourceName\" (dict \"ctx\" $ \"component\" \"results-cache\") }}.{{ include \"loki.namespace\" $ }}.svc"
 </pre>
 </td>
 		</tr>

--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -13,6 +13,7 @@ Entries should include a reference to the pull request that introduced the chang
 
 [//]: # (<AUTOMATED_UPDATES_LOCATOR> : do not remove this line. This locator is used by the CI pipeline to automatically create a changelog entry for each new Loki release. Add other chart versions and respective changelog entries bellow this line.)
 
+- [ENHANCEMENT] add namespaceOverride 
 - [BUGFIX] make loki.storage.bucketNames are optional, if builtin minio is enabled.
 - [FEATURE] Added a Helm Chart value to disable the rbac resource creation for the tokengen job. [#15882](https://github.com/grafana/loki/pull/15882)
 - [FEATURE] Added support to disable the rbac resource creation for the tokengen job. [#15882](https://github.com/grafana/loki/pull/15882)

--- a/production/helm/loki/ci/non-default-values.yaml
+++ b/production/helm/loki/ci/non-default-values.yaml
@@ -1,3 +1,4 @@
+namespaceOverride: loki
 deploymentMode: Distributed
 loki:
   commonConfig:

--- a/production/helm/loki/templates/NOTES.txt
+++ b/production/helm/loki/templates/NOTES.txt
@@ -9,7 +9,7 @@
 
 Tip:
 
-  Watch the deployment status using the command: kubectl get pods -w --namespace {{ $.Release.Namespace }}
+  Watch the deployment status using the command: kubectl get pods -w --namespace {{ include "loki.namespace" $ }}
 
 If pods are taking too long to schedule make sure pod affinity can be fulfilled in the current cluster.
 
@@ -70,22 +70,22 @@ You can send logs from inside the cluster using the cluster DNS:
 
 {{- if .Values.gateway.enabled }}
 
-http://{{ include "loki.gatewayFullname" . }}.{{ $.Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}/loki/api/v1/push
+http://{{ include "loki.gatewayFullname" . }}.{{ include "loki.namespace" . }}.svc.{{ .Values.global.clusterDomain }}/loki/api/v1/push
 
 {{- else }}
 {{- if eq (include "loki.deployment.isSingleBinary" .) "true" }}
 
-http://{{ include "loki.singleBinaryFullname" . }}.{{ $.Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:{{ .Values.loki.server.http_listen_port }}/loki/api/v1/push
+http://{{ include "loki.singleBinaryFullname" . }}.{{ include "loki.namespace" . }}.svc.{{ .Values.global.clusterDomain }}:{{ .Values.loki.server.http_listen_port }}/loki/api/v1/push
 
 {{- end}}
 {{- if eq (include "loki.deployment.isScalable" .) "true" }}
 
-http://{{ include "loki.writeFullname" . }}.{{ $.Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:{{ .Values.loki.server.http_listen_port }}/loki/api/v1/push
+http://{{ include "loki.writeFullname" . }}.{{ include "loki.namespace" . }}.svc.{{ .Values.global.clusterDomain }}:{{ .Values.loki.server.http_listen_port }}/loki/api/v1/push
 
 {{- end }}
 {{- if eq (include "loki.deployment.isDistributed" .) "true" }}
 
-http://{{ include "loki.distributorFullname" . }}.{{ $.Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100/loki/api/v1/push
+http://{{ include "loki.distributorFullname" . }}.{{ include "loki.namespace" . }}.svc.{{ .Values.global.clusterDomain }}:3100/loki/api/v1/push
 
 {{- end }}
 {{- end }}
@@ -93,22 +93,22 @@ http://{{ include "loki.distributorFullname" . }}.{{ $.Release.Namespace }}.svc.
 You can test to send data from outside the cluster by port-forwarding the gateway to your local machine:
 {{- if .Values.gateway.enabled }}
 
-  kubectl port-forward --namespace {{ $.Release.Namespace }} svc/{{ include "loki.gatewayFullname" . }} 3100:{{ .Values.gateway.service.port }} &
+  kubectl port-forward --namespace {{ include "loki.namespace" $ }} svc/{{ include "loki.gatewayFullname" . }} 3100:{{ .Values.gateway.service.port }} &
 
 {{- else }}
 {{- if eq (include "loki.deployment.isSingleBinary" .) "true" }}
 
-  kubectl port-forward --namespace {{ $.Release.Namespace }} svc/{{ include "loki.singleBinaryFullname" . }} 3100:{{ .Values.loki.server.http_listen_port }} &
+  kubectl port-forward --namespace {{ include "loki.namespace" $ }} svc/{{ include "loki.singleBinaryFullname" . }} 3100:{{ .Values.loki.server.http_listen_port }} &
 
 {{- end}}
 {{- if eq (include "loki.deployment.isScalable" .) "true" }}
 
-  kubectl port-forward --namespace {{ $.Release.Namespace }} svc/{{ include "loki.writeFullname" . }} 3100:{{ .Values.loki.server.http_listen_port }} &
+  kubectl port-forward --namespace {{ include "loki.namespace" $ }} svc/{{ include "loki.writeFullname" . }} 3100:{{ .Values.loki.server.http_listen_port }} &
 
 {{- end }}
 {{- if eq (include "loki.deployment.isDistributed" .) "true" }}
 
-  kubectl port-forward --namespace {{ $.Release.Namespace }} svc/{{ include "loki.distributorFullname" . }} 3100:3100 &
+  kubectl port-forward --namespace {{ include "loki.namespace" $ }} svc/{{ include "loki.distributorFullname" . }} 3100:3100 &
 
 {{- end }}
 {{- end }}
@@ -137,22 +137,22 @@ If Grafana operates within the cluster, you'll set up a new Loki datasource by u
 
 {{- if .Values.gateway.enabled }}
 
-http://{{ include "loki.gatewayFullname" . }}.{{ $.Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}/
+http://{{ include "loki.gatewayFullname" . }}.{{ include "loki.namespace" . }}.svc.{{ .Values.global.clusterDomain }}/
 
 {{- else }}
 {{- if eq (include "loki.deployment.isSingleBinary" .) "true" }}
 
-http://{{ include "loki.singleBinaryFullname" . }}.{{ $.Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:{{ .Values.loki.server.http_listen_port }}/
+http://{{ include "loki.singleBinaryFullname" . }}.{{ include "loki.namespace" . }}.svc.{{ .Values.global.clusterDomain }}:{{ .Values.loki.server.http_listen_port }}/
 
 {{- end}}
 {{- if eq (include "loki.deployment.isScalable" .) "true" }}
 
-http://{{ include "loki.readFullname" . }}.{{ $.Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:{{ .Values.loki.server.http_listen_port }}/
+http://{{ include "loki.readFullname" . }}.{{ include "loki.namespace" . }}.svc.{{ .Values.global.clusterDomain }}:{{ .Values.loki.server.http_listen_port }}/
 
 {{- end }}
 {{- if eq (include "loki.deployment.isDistributed" .) "true" }}
 
-http://{{ include "loki.queryFrontendFullname" . }}.{{ $.Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100/
+http://{{ include "loki.queryFrontendFullname" . }}.{{ include "loki.namespace" . }}.svc.{{ .Values.global.clusterDomain }}:3100/
 
 {{- end }}
 {{- end }}

--- a/production/helm/loki/templates/_helpers.tpl
+++ b/production/helm/loki/templates/_helpers.tpl
@@ -15,6 +15,17 @@ Expand the name of the chart.
 {{- end }}
 
 {{/*
+Allow the release namespace to be overridden for multi-namespace deployments in combined charts
+*/}}
+{{- define "loki.namespace" -}}
+  {{- if .Values.namespaceOverride -}}
+    {{- .Values.namespaceOverride -}}
+  {{- else -}}
+    {{- include "loki.namespace" . -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
 singleBinary fullname
 */}}
 {{- define "loki.singleBinaryFullname" -}}
@@ -702,7 +713,7 @@ Create the service endpoint including port for MinIO.
 */}}
 {{- define "loki.minio" -}}
 {{- if .Values.minio.enabled -}}
-{{- .Values.minio.address | default (printf "%s-%s.%s.svc:%s" .Release.Name "minio" .Release.Namespace (.Values.minio.service.port | toString)) -}}
+{{- .Values.minio.address | default (printf "%s-%s.%s.svc:%s" .Release.Name "minio" include "loki.namespace" . (.Values.minio.service.port | toString)) -}}
 {{- end -}}
 {{- end -}}
 
@@ -719,9 +730,9 @@ Create the service endpoint including port for MinIO.
 {{/* Determine the public host for the Loki cluster */}}
 {{- define "loki.host" -}}
 {{- $isSingleBinary := eq (include "loki.deployment.isSingleBinary" .) "true" -}}
-{{- $url := printf "%s.%s.svc.%s.:%s" (include "loki.gatewayFullname" .) .Release.Namespace .Values.global.clusterDomain (.Values.gateway.service.port | toString)  }}
+{{- $url := printf "%s.%s.svc.%s.:%s" (include "loki.gatewayFullname" .) (include "loki.namespace" .) .Values.global.clusterDomain (.Values.gateway.service.port | toString)  }}
 {{- if and $isSingleBinary (not .Values.gateway.enabled)  }}
-  {{- $url = printf "%s.%s.svc.%s.:%s" (include "loki.singleBinaryFullname" .) .Release.Namespace .Values.global.clusterDomain (.Values.loki.server.http_listen_port | toString) }}
+  {{- $url = printf "%s.%s.svc.%s.:%s" (include "loki.singleBinaryFullname" .) (include "loki.namespace" .) .Values.global.clusterDomain (.Values.loki.server.http_listen_port | toString) }}
 {{- end }}
 {{- printf "%s" $url -}}
 {{- end -}}
@@ -848,9 +859,10 @@ http {
     ########################################################
     # Configure backend targets
 
-    {{- $backendHost := include "loki.backendFullname" .}}
-    {{- $readHost := include "loki.readFullname" .}}
-    {{- $writeHost := include "loki.writeFullname" .}}
+    {{- $namespace := include "loki.namespace" . }}
+    {{- $backendHost := include "loki.backendFullname" . }}
+    {{- $readHost := include "loki.readFullname" . }}
+    {{- $writeHost := include "loki.writeFullname" . }}
 
     {{- if .Values.read.legacyReadTarget }}
     {{- $backendHost = include "loki.readFullname" . }}
@@ -858,9 +870,9 @@ http {
 
     {{- $httpSchema := .Values.gateway.nginxConfig.schema }}
 
-    {{- $writeUrl    := printf "%s://%s.%s.svc.%s:%s" $httpSchema $writeHost   .Release.Namespace .Values.global.clusterDomain (.Values.loki.server.http_listen_port | toString) }}
-    {{- $readUrl     := printf "%s://%s.%s.svc.%s:%s" $httpSchema $readHost    .Release.Namespace .Values.global.clusterDomain (.Values.loki.server.http_listen_port | toString) }}
-    {{- $backendUrl  := printf "%s://%s.%s.svc.%s:%s" $httpSchema $backendHost .Release.Namespace .Values.global.clusterDomain (.Values.loki.server.http_listen_port | toString) }}
+    {{- $writeUrl    := printf "%s://%s.%s.svc.%s:%s" $httpSchema $writeHost   $namespace .Values.global.clusterDomain (.Values.loki.server.http_listen_port | toString) }}
+    {{- $readUrl     := printf "%s://%s.%s.svc.%s:%s" $httpSchema $readHost    $namespace .Values.global.clusterDomain (.Values.loki.server.http_listen_port | toString) }}
+    {{- $backendUrl  := printf "%s://%s.%s.svc.%s:%s" $httpSchema $backendHost $namespace .Values.global.clusterDomain (.Values.loki.server.http_listen_port | toString) }}
 
     {{- if .Values.gateway.nginxConfig.customWriteUrl }}
     {{- $writeUrl  = .Values.gateway.nginxConfig.customWriteUrl }}
@@ -873,7 +885,7 @@ http {
     {{- end }}
 
     {{- $singleBinaryHost := include "loki.singleBinaryFullname" . }}
-    {{- $singleBinaryUrl  := printf "%s://%s.%s.svc.%s:%s" $httpSchema $singleBinaryHost .Release.Namespace .Values.global.clusterDomain (.Values.loki.server.http_listen_port | toString) }}
+    {{- $singleBinaryUrl  := printf "%s://%s.%s.svc.%s:%s" $httpSchema $singleBinaryHost $namespace .Values.global.clusterDomain (.Values.loki.server.http_listen_port | toString) }}
 
     {{- $distributorHost := include "loki.distributorFullname" .}}
     {{- $ingesterHost := include "loki.ingesterFullname" .}}
@@ -884,13 +896,13 @@ http {
     {{- $schedulerHost := include "loki.querySchedulerFullname" .}}
 
 
-    {{- $distributorUrl := printf "%s://%s.%s.svc.%s:%s" $httpSchema $distributorHost .Release.Namespace .Values.global.clusterDomain (.Values.loki.server.http_listen_port | toString) -}}
-    {{- $ingesterUrl := printf "%s://%s.%s.svc.%s:%s" $httpSchema $ingesterHost .Release.Namespace .Values.global.clusterDomain (.Values.loki.server.http_listen_port | toString) }}
-    {{- $queryFrontendUrl := printf "%s://%s.%s.svc.%s:%s" $httpSchema $queryFrontendHost .Release.Namespace .Values.global.clusterDomain (.Values.loki.server.http_listen_port | toString) }}
-    {{- $indexGatewayUrl := printf "%s://%s.%s.svc.%s:%s" $httpSchema $indexGatewayHost .Release.Namespace .Values.global.clusterDomain (.Values.loki.server.http_listen_port | toString) }}
-    {{- $rulerUrl := printf "%s://%s.%s.svc.%s:%s" $httpSchema $rulerHost .Release.Namespace .Values.global.clusterDomain (.Values.loki.server.http_listen_port | toString) }}
-    {{- $compactorUrl := printf "%s://%s.%s.svc.%s:%s" $httpSchema $compactorHost .Release.Namespace .Values.global.clusterDomain (.Values.loki.server.http_listen_port | toString) }}
-    {{- $schedulerUrl := printf "%s://%s.%s.svc.%s:%s" $httpSchema $schedulerHost .Release.Namespace .Values.global.clusterDomain (.Values.loki.server.http_listen_port | toString) }}
+    {{- $distributorUrl := printf "%s://%s.%s.svc.%s:%s" $httpSchema $distributorHost $namespace .Values.global.clusterDomain (.Values.loki.server.http_listen_port | toString) -}}
+    {{- $ingesterUrl := printf "%s://%s.%s.svc.%s:%s" $httpSchema $ingesterHost $namespace .Values.global.clusterDomain (.Values.loki.server.http_listen_port | toString) }}
+    {{- $queryFrontendUrl := printf "%s://%s.%s.svc.%s:%s" $httpSchema $queryFrontendHost $namespace .Values.global.clusterDomain (.Values.loki.server.http_listen_port | toString) }}
+    {{- $indexGatewayUrl := printf "%s://%s.%s.svc.%s:%s" $httpSchema $indexGatewayHost $namespace .Values.global.clusterDomain (.Values.loki.server.http_listen_port | toString) }}
+    {{- $rulerUrl := printf "%s://%s.%s.svc.%s:%s" $httpSchema $rulerHost $namespace .Values.global.clusterDomain (.Values.loki.server.http_listen_port | toString) }}
+    {{- $compactorUrl := printf "%s://%s.%s.svc.%s:%s" $httpSchema $compactorHost $namespace .Values.global.clusterDomain (.Values.loki.server.http_listen_port | toString) }}
+    {{- $schedulerUrl := printf "%s://%s.%s.svc.%s:%s" $httpSchema $schedulerHost $namespace .Values.global.clusterDomain (.Values.loki.server.http_listen_port | toString) }}
 
     {{- if eq (include "loki.deployment.isSingleBinary" .) "true"}}
     {{- $distributorUrl = $singleBinaryUrl }}
@@ -1166,7 +1178,7 @@ enableServiceLinks: false
 {{- $schedulerAddress := ""}}
 {{- $isDistributed := eq (include "loki.deployment.isDistributed" .) "true" -}}
 {{- if $isDistributed -}}
-{{- $schedulerAddress = printf "%s.%s.svc.%s:%s" (include "loki.querySchedulerFullname" .) .Release.Namespace .Values.global.clusterDomain (.Values.loki.server.grpc_listen_port | toString) -}}
+{{- $schedulerAddress = printf "%s.%s.svc.%s:%s" (include "loki.querySchedulerFullname" .) (include "loki.namespace" .) .Values.global.clusterDomain (.Values.loki.server.grpc_listen_port | toString) -}}
 {{- end -}}
 {{- printf "%s" $schedulerAddress }}
 {{- end }}
@@ -1177,7 +1189,7 @@ enableServiceLinks: false
 {{- $isDistributed := eq (include "loki.deployment.isDistributed" .) "true" -}}
 {{- if $isDistributed -}}
 {{- $querierHost := include "loki.querierFullname" .}}
-{{- $querierUrl := printf "http://%s.%s.svc.%s:3100" $querierHost .Release.Namespace .Values.global.clusterDomain }}
+{{- $querierUrl := printf "http://%s.%s.svc.%s:3100" $querierHost (include "loki.namespace" .) .Values.global.clusterDomain }}
 {{- $querierAddress = $querierUrl }}
 {{- end -}}
 {{- printf "%s" $querierAddress }}
@@ -1189,10 +1201,10 @@ enableServiceLinks: false
 {{- $isDistributed := eq (include "loki.deployment.isDistributed" .) "true" -}}
 {{- $isScalable := eq (include "loki.deployment.isScalable" .) "true" -}}
 {{- if $isDistributed -}}
-{{- $idxGatewayAddress = printf "dns+%s-headless.%s.svc.%s:%s" (include "loki.indexGatewayFullname" .) .Release.Namespace .Values.global.clusterDomain (.Values.loki.server.grpc_listen_port | toString) -}}
+{{- $idxGatewayAddress = printf "dns+%s-headless.%s.svc.%s:%s" (include "loki.indexGatewayFullname" .) (include "loki.namespace" .) .Values.global.clusterDomain (.Values.loki.server.grpc_listen_port | toString) -}}
 {{- end -}}
 {{- if $isScalable -}}
-{{- $idxGatewayAddress = printf "dns+%s-headless.%s.svc.%s:%s" (include "loki.backendFullname" .) .Release.Namespace .Values.global.clusterDomain (.Values.loki.server.grpc_listen_port | toString) -}}
+{{- $idxGatewayAddress = printf "dns+%s-headless.%s.svc.%s:%s" (include "loki.backendFullname" .) (include "loki.namespace" .) .Values.global.clusterDomain (.Values.loki.server.grpc_listen_port | toString) -}}
 {{- end -}}
 {{- printf "%s" $idxGatewayAddress }}
 {{- end }}
@@ -1203,10 +1215,10 @@ enableServiceLinks: false
 {{- $isDistributed := eq (include "loki.deployment.isDistributed" .) "true" -}}
 {{- $isScalable := eq (include "loki.deployment.isScalable" .) "true" -}}
 {{- if $isDistributed -}}
-{{- $bloomPlannerAddress = printf "%s-headless.%s.svc.%s:%s" (include "loki.bloomPlannerFullname" .) .Release.Namespace .Values.global.clusterDomain (.Values.loki.server.grpc_listen_port | toString) -}}
+{{- $bloomPlannerAddress = printf "%s-headless.%s.svc.%s:%s" (include "loki.bloomPlannerFullname" .) (include "loki.namespace" .) .Values.global.clusterDomain (.Values.loki.server.grpc_listen_port | toString) -}}
 {{- end -}}
 {{- if $isScalable -}}
-{{- $bloomPlannerAddress = printf "%s-headless.%s.svc.%s:%s" (include "loki.backendFullname" .) .Release.Namespace .Values.global.clusterDomain (.Values.loki.server.grpc_listen_port | toString) -}}
+{{- $bloomPlannerAddress = printf "%s-headless.%s.svc.%s:%s" (include "loki.backendFullname" .) (include "loki.namespace" .) .Values.global.clusterDomain (.Values.loki.server.grpc_listen_port | toString) -}}
 {{- end -}}
 {{- printf "%s" $bloomPlannerAddress}}
 {{- end }}
@@ -1217,10 +1229,10 @@ enableServiceLinks: false
 {{- $isDistributed := eq (include "loki.deployment.isDistributed" .) "true" -}}
 {{- $isScalable := eq (include "loki.deployment.isScalable" .) "true" -}}
 {{- if $isDistributed -}}
-{{- $bloomGatewayAddresses = printf "dnssrvnoa+_grpc._tcp.%s-headless.%s.svc.%s" (include "loki.bloomGatewayFullname" .) .Release.Namespace .Values.global.clusterDomain -}}
+{{- $bloomGatewayAddresses = printf "dnssrvnoa+_grpc._tcp.%s-headless.%s.svc.%s" (include "loki.bloomGatewayFullname" .) (include "loki.namespace" .) .Values.global.clusterDomain -}}
 {{- end -}}
 {{- if $isScalable -}}
-{{- $bloomGatewayAddresses = printf "dnssrvnoa+_grpc._tcp.%s-headless.%s.svc.%s" (include "loki.backendFullname" .) .Release.Namespace .Values.global.clusterDomain -}}
+{{- $bloomGatewayAddresses = printf "dnssrvnoa+_grpc._tcp.%s-headless.%s.svc.%s" (include "loki.backendFullname" .) (include "loki.namespace" .) .Values.global.clusterDomain -}}
 {{- end -}}
 {{- printf "%s" $bloomGatewayAddresses}}
 {{- end }}

--- a/production/helm/loki/templates/admin-api/deployment-admin-api.yaml
+++ b/production/helm/loki/templates/admin-api/deployment-admin-api.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "enterprise-logs.adminApiFullname" . }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "enterprise-logs.adminApiLabels" . | nindent 4 }}
     {{- with .Values.adminApi.labels }}

--- a/production/helm/loki/templates/admin-api/service-admin-api.yaml
+++ b/production/helm/loki/templates/admin-api/service-admin-api.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "enterprise-logs.adminApiFullname" . }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "enterprise-logs.adminApiLabels" . | nindent 4 }}
     {{- with .Values.adminApi.service.labels }}

--- a/production/helm/loki/templates/backend/clusterrolebinding.yaml
+++ b/production/helm/loki/templates/backend/clusterrolebinding.yaml
@@ -13,7 +13,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: {{ template "loki.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ include "loki.namespace" . }}
 roleRef:
   kind: ClusterRole
 {{- if (not .Values.rbac.useExistingRole) }}

--- a/production/helm/loki/templates/backend/hpa.yaml
+++ b/production/helm/loki/templates/backend/hpa.yaml
@@ -9,14 +9,14 @@ apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "loki.backendFullname" . }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.backendLabels" . | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: StatefulSet
-    name: {{ include "loki.backendFullname" . }}   
+    name: {{ include "loki.backendFullname" . }}
   minReplicas: {{ .Values.backend.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.backend.autoscaling.maxReplicas }}
   {{- with .Values.backend.autoscaling.behavior }}

--- a/production/helm/loki/templates/backend/poddisruptionbudget-backend.yaml
+++ b/production/helm/loki/templates/backend/poddisruptionbudget-backend.yaml
@@ -4,7 +4,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "loki.backendFullname" . }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.backendLabels" . | nindent 4 }}
 spec:

--- a/production/helm/loki/templates/backend/query-scheduler-discovery.yaml
+++ b/production/helm/loki/templates/backend/query-scheduler-discovery.yaml
@@ -5,7 +5,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "loki.querySchedulerFullname" . }}-discovery
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.backendSelectorLabels" . | nindent 4 }}
     prometheus.io/service-monitor: "false"

--- a/production/helm/loki/templates/backend/service-backend-headless.yaml
+++ b/production/helm/loki/templates/backend/service-backend-headless.yaml
@@ -5,7 +5,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "loki.backendFullname" . }}-headless
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.backendSelectorLabels" . | nindent 4 }}
     {{- with .Values.loki.serviceLabels }}

--- a/production/helm/loki/templates/backend/service-backend.yaml
+++ b/production/helm/loki/templates/backend/service-backend.yaml
@@ -5,7 +5,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "loki.backendFullname" . }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.backendLabels" . | nindent 4 }}
     {{- with .Values.loki.serviceLabels }}

--- a/production/helm/loki/templates/backend/statefulset-backend.yaml
+++ b/production/helm/loki/templates/backend/statefulset-backend.yaml
@@ -5,7 +5,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "loki.backendFullname" . }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.backendLabels" . | nindent 4 }}
     app.kubernetes.io/part-of: memberlist

--- a/production/helm/loki/templates/bloom-builder/deployment-bloom-builder.yaml
+++ b/production/helm/loki/templates/bloom-builder/deployment-bloom-builder.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "loki.bloomBuilderFullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.bloomBuilderLabels" . | nindent 4 }}
   {{- with .Values.loki.annotations }}

--- a/production/helm/loki/templates/bloom-builder/hpa.yaml
+++ b/production/helm/loki/templates/bloom-builder/hpa.yaml
@@ -5,7 +5,7 @@ apiVersion: {{ $apiVersion }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "loki.bloomBuilderFullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.bloomBuilderLabels" . | nindent 4 }}
 spec:

--- a/production/helm/loki/templates/bloom-builder/poddisruptionbudget-bloom-builder.yaml
+++ b/production/helm/loki/templates/bloom-builder/poddisruptionbudget-bloom-builder.yaml
@@ -7,7 +7,7 @@ apiVersion: {{ include "loki.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "loki.bloomBuilderFullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.bloomBuilderLabels" . | nindent 4 }}
 spec:

--- a/production/helm/loki/templates/bloom-builder/service-bloom-builder-headless.yaml
+++ b/production/helm/loki/templates/bloom-builder/service-bloom-builder-headless.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "loki.bloomBuilderFullname" . }}-headless
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.bloomBuilderLabels" . | nindent 4 }}
     {{- with .Values.bloomBuilder.serviceLabels }}

--- a/production/helm/loki/templates/bloom-builder/service-bloom-builder.yaml
+++ b/production/helm/loki/templates/bloom-builder/service-bloom-builder.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "loki.bloomBuilderFullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.bloomBuilderLabels" . | nindent 4 }}
     {{- with .Values.bloomBuilder.serviceLabels }}

--- a/production/helm/loki/templates/bloom-gateway/service-bloom-gateway-headless.yaml
+++ b/production/helm/loki/templates/bloom-gateway/service-bloom-gateway-headless.yaml
@@ -5,7 +5,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "loki.bloomGatewayFullname" . }}-headless
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.bloomGatewaySelectorLabels" . | nindent 4 }}
     {{- with .Values.bloomGateway.serviceLabels }}

--- a/production/helm/loki/templates/bloom-gateway/statefulset-bloom-gateway.yaml
+++ b/production/helm/loki/templates/bloom-gateway/statefulset-bloom-gateway.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "loki.bloomGatewayFullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.bloomGatewayLabels" . | nindent 4 }}
   {{- with .Values.loki.annotations }}

--- a/production/helm/loki/templates/bloom-planner/service-bloom-planner-headless.yaml
+++ b/production/helm/loki/templates/bloom-planner/service-bloom-planner-headless.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "loki.bloomPlannerFullname" . }}-headless
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.bloomPlannerSelectorLabels" . | nindent 4 }}
     {{- with .Values.bloomPlanner.serviceLabels }}

--- a/production/helm/loki/templates/bloom-planner/statefulset-bloom-planner.yaml
+++ b/production/helm/loki/templates/bloom-planner/statefulset-bloom-planner.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "loki.bloomPlannerFullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.bloomPlannerLabels" . | nindent 4 }}
   {{- with .Values.loki.annotations }}

--- a/production/helm/loki/templates/ciliumnetworkpolicy.yaml
+++ b/production/helm/loki/templates/ciliumnetworkpolicy.yaml
@@ -4,7 +4,7 @@ apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
   name: {{ include "loki.name" . }}-namespace-only
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.labels" . | nindent 4 }}
 spec:
@@ -21,7 +21,7 @@ apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
   name: {{ include "loki.name" . }}-egress-dns
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.labels" . | nindent 4 }}
 spec:
@@ -41,7 +41,7 @@ apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
   name: {{ include "loki.name" . }}-ingress
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.labels" . | nindent 4 }}
 spec:
@@ -77,7 +77,7 @@ apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
   name: {{ include "loki.name" . }}-ingress-metrics
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" .}}
   labels:
     {{- include "loki.labels" . | nindent 4 }}
 spec:
@@ -109,7 +109,7 @@ apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
   name: {{ include "loki.name" . }}-egress-alertmanager
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.labels" . | nindent 4 }}
 spec:
@@ -136,7 +136,7 @@ apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
   name: {{ include "loki.name" . }}-egress-external-storage
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.labels" . | nindent 4 }}
 spec:
@@ -171,7 +171,7 @@ apiVersion: "cilium.io/v2"
 kind: CiliumNetworkPolicy
 metadata:
   name: {{ include "loki.name" . }}-{{ $component }}-world-egress
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
 spec:
   endpointSelector:
     matchLabels:
@@ -197,7 +197,7 @@ apiVersion: "cilium.io/v2"
 kind: CiliumNetworkPolicy
 metadata:
   name: {{ include "loki.name" . }}-backend-kubeapiserver-egress
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
 spec:
   endpointSelector:
     matchLabels:
@@ -215,7 +215,7 @@ apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
   name: {{ include "loki.name" . }}-egress-discovery
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.labels" . | nindent 4 }}
 spec:

--- a/production/helm/loki/templates/compactor/service-compactor.yaml
+++ b/production/helm/loki/templates/compactor/service-compactor.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "loki.compactorFullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.labels" . | nindent 4 }}
     {{- with .Values.compactor.serviceLabels }}

--- a/production/helm/loki/templates/compactor/statefulset-compactor.yaml
+++ b/production/helm/loki/templates/compactor/statefulset-compactor.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "loki.compactorFullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.compactorLabels" . | nindent 4 }}
     app.kubernetes.io/part-of: memberlist

--- a/production/helm/loki/templates/config.yaml
+++ b/production/helm/loki/templates/config.yaml
@@ -7,7 +7,7 @@ kind: ConfigMap
 {{- end }}
 metadata:
   name: {{ tpl .Values.loki.generatedConfigObjectName . }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.labels" . | nindent 4 }}
 {{- if eq .Values.loki.configStorageType "Secret" }}

--- a/production/helm/loki/templates/distributor/deployment-distributor.yaml
+++ b/production/helm/loki/templates/distributor/deployment-distributor.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "loki.distributorFullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.distributorLabels" . | nindent 4 }}
     app.kubernetes.io/part-of: memberlist

--- a/production/helm/loki/templates/distributor/hpa.yaml
+++ b/production/helm/loki/templates/distributor/hpa.yaml
@@ -5,7 +5,7 @@ apiVersion: {{ $apiVersion }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "loki.distributorFullname" . }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.distributorLabels" . | nindent 4 }}
 spec:

--- a/production/helm/loki/templates/distributor/poddisruptionbudget-distributor.yaml
+++ b/production/helm/loki/templates/distributor/poddisruptionbudget-distributor.yaml
@@ -7,7 +7,7 @@ apiVersion: {{ include "loki.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "loki.distributorFullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.distributorLabels" . | nindent 4 }}
 spec:

--- a/production/helm/loki/templates/distributor/service-distributor-headless.yaml
+++ b/production/helm/loki/templates/distributor/service-distributor-headless.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "loki.distributorFullname" . }}-headless
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.distributorSelectorLabels" . | nindent 4 }}
     {{- with .Values.distributor.serviceLabels }}

--- a/production/helm/loki/templates/distributor/service-distributor.yaml
+++ b/production/helm/loki/templates/distributor/service-distributor.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "loki.distributorFullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.distributorLabels" . | nindent 4 }}
     {{- with .Values.distributor.serviceLabels }}

--- a/production/helm/loki/templates/gateway/configmap-gateway.yaml
+++ b/production/helm/loki/templates/gateway/configmap-gateway.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "loki.gatewayFullname" . }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.gatewayLabels" . | nindent 4 }}
 data:

--- a/production/helm/loki/templates/gateway/deployment-gateway-enterprise.yaml
+++ b/production/helm/loki/templates/gateway/deployment-gateway-enterprise.yaml
@@ -5,6 +5,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "loki.gatewayFullname" . }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.gatewayLabels" . | nindent 4 }}
     {{- with .Values.enterpriseGateway.labels }}
@@ -76,22 +77,22 @@ spec:
             - -admin.client.s3.insecure={{ .Values.loki.storage.s3.insecure }}
             {{- end }}
             {{- if and $isDistributed .Values.enterpriseGateway.useDefaultProxyURLs }}
-            - -gateway.proxy.default.url=http://{{ template "loki.fullname" . }}-admin-api.{{ .Release.Namespace }}.svc:3100
-            - -gateway.proxy.admin-api.url=http://{{ template "loki.fullname" . }}-admin-api.{{ .Release.Namespace }}.svc:3100
-            - -gateway.proxy.distributor.url=dns:///{{ template "loki.fullname" . }}-distributor-headless.{{ .Release.Namespace }}.svc:9095
-            - -gateway.proxy.ingester.url=http://{{ template "loki.fullname" . }}-ingester.{{ .Release.Namespace }}.svc:3100
-            - -gateway.proxy.query-frontend.url=http://{{ template "loki.fullname" . }}-query-frontend.{{ .Release.Namespace }}.svc:3100
-            - -gateway.proxy.ruler.url=http://{{ template "loki.fullname" . }}-ruler.{{ .Release.Namespace }}.svc:3100
+            - -gateway.proxy.default.url=http://{{ template "loki.fullname" . }}-admin-api.{{ include "loki.namespace" . }}.svc:3100
+            - -gateway.proxy.admin-api.url=http://{{ template "loki.fullname" . }}-admin-api.{{ include "loki.namespace" . }}.svc:3100
+            - -gateway.proxy.distributor.url=dns:///{{ template "loki.fullname" . }}-distributor-headless.{{ include "loki.namespace" . }}.svc:9095
+            - -gateway.proxy.ingester.url=http://{{ template "loki.fullname" . }}-ingester.{{ include "loki.namespace" . }}.svc:3100
+            - -gateway.proxy.query-frontend.url=http://{{ template "loki.fullname" . }}-query-frontend.{{ include "loki.namespace" . }}.svc:3100
+            - -gateway.proxy.ruler.url=http://{{ template "loki.fullname" . }}-ruler.{{ include "loki.namespace" . }}.svc:3100
             {{- end }}
             {{- if and $isSimpleScalable .Values.enterpriseGateway.useDefaultProxyURLs }}
-            - -gateway.proxy.default.url=http://{{ template "enterprise-logs.adminApiFullname" . }}.{{ .Release.Namespace }}.svc:3100
-            - -gateway.proxy.admin-api.url=http://{{ template "enterprise-logs.adminApiFullname" . }}.{{ .Release.Namespace }}.svc:3100
-            - -gateway.proxy.compactor.url=http://{{ template "loki.backendFullname" . }}-headless.{{ .Release.Namespace }}.svc:3100
-            - -gateway.proxy.distributor.url=dns:///{{ template "loki.writeFullname" . }}-headless.{{ .Release.Namespace }}.svc:9095
-            - -gateway.proxy.ingester.url=http://{{ template "loki.writeFullname" . }}.{{ .Release.Namespace }}.svc:3100
-            - -gateway.proxy.query-frontend.url=http://{{ template "loki.readFullname" . }}.{{ .Release.Namespace }}.svc:3100
-            - -gateway.proxy.ruler.url=http://{{ template "loki.backendFullname" . }}-headless.{{ .Release.Namespace }}.svc:3100
-            - -gateway.proxy.query-scheduler.url=http://{{ template "loki.backendFullname" . }}-headless.{{ .Release.Namespace }}.svc:3100
+            - -gateway.proxy.default.url=http://{{ template "enterprise-logs.adminApiFullname" . }}.{{ include "loki.namespace" . }}.svc:3100
+            - -gateway.proxy.admin-api.url=http://{{ template "enterprise-logs.adminApiFullname" . }}.{{ include "loki.namespace" . }}.svc:3100
+            - -gateway.proxy.compactor.url=http://{{ template "loki.backendFullname" . }}-headless.{{ include "loki.namespace" . }}.svc:3100
+            - -gateway.proxy.distributor.url=dns:///{{ template "loki.writeFullname" . }}-headless.{{ include "loki.namespace" . }}.svc:9095
+            - -gateway.proxy.ingester.url=http://{{ template "loki.writeFullname" . }}.{{ include "loki.namespace" . }}.svc:3100
+            - -gateway.proxy.query-frontend.url=http://{{ template "loki.readFullname" . }}.{{ include "loki.namespace" . }}.svc:3100
+            - -gateway.proxy.ruler.url=http://{{ template "loki.backendFullname" . }}-headless.{{ include "loki.namespace" . }}.svc:3100
+            - -gateway.proxy.query-scheduler.url=http://{{ template "loki.backendFullname" . }}-headless.{{ include "loki.namespace" . }}.svc:3100
             {{- end }}
             {{- range $key, $value := .Values.enterpriseGateway.extraArgs }}
             - "-{{ $key }}={{ $value }}"

--- a/production/helm/loki/templates/gateway/deployment-gateway-nginx.yaml
+++ b/production/helm/loki/templates/gateway/deployment-gateway-nginx.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "loki.gatewayFullname" . }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.gatewayLabels" . | nindent 4 }}
   {{- if or (not (empty .Values.loki.annotations)) (not (empty .Values.gateway.annotations))}}

--- a/production/helm/loki/templates/gateway/hpa.yaml
+++ b/production/helm/loki/templates/gateway/hpa.yaml
@@ -8,7 +8,7 @@ apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "loki.gatewayFullname" . }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.gatewayLabels" . | nindent 4 }}
 spec:

--- a/production/helm/loki/templates/gateway/ingress-gateway.yaml
+++ b/production/helm/loki/templates/gateway/ingress-gateway.yaml
@@ -7,7 +7,7 @@ apiVersion: {{ include "loki.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ include "loki.gatewayFullname" . }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.gatewayLabels" . | nindent 4 }}
     {{- range $labelKey, $labelValue := .Values.gateway.ingress.labels }}

--- a/production/helm/loki/templates/gateway/poddisruptionbudget-gateway.yaml
+++ b/production/helm/loki/templates/gateway/poddisruptionbudget-gateway.yaml
@@ -7,7 +7,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "loki.gatewayFullname" . }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.gatewayLabels" . | nindent 4 }}
 spec:

--- a/production/helm/loki/templates/gateway/secret-gateway.yaml
+++ b/production/helm/loki/templates/gateway/secret-gateway.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "loki.gatewayFullname" $ }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" $ }}
   labels:
     {{- include "loki.gatewayLabels" $ | nindent 4 }}
 stringData:

--- a/production/helm/loki/templates/gateway/service-gateway.yaml
+++ b/production/helm/loki/templates/gateway/service-gateway.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "loki.gatewayFullname" . }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.gatewayLabels" . | nindent 4 }}
     {{- with .Values.loki.serviceLabels }}

--- a/production/helm/loki/templates/index-gateway/poddisruptionbudget-index-gateway.yaml
+++ b/production/helm/loki/templates/index-gateway/poddisruptionbudget-index-gateway.yaml
@@ -7,7 +7,7 @@ apiVersion: {{ include "loki.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "loki.indexGatewayFullname" . }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.indexGatewayLabels" . | nindent 4 }}
 spec:

--- a/production/helm/loki/templates/index-gateway/service-index-gateway-headless.yaml
+++ b/production/helm/loki/templates/index-gateway/service-index-gateway-headless.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "loki.indexGatewayFullname" . }}-headless
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.indexGatewaySelectorLabels" . | nindent 4 }}
     prometheus.io/service-monitor: "false"

--- a/production/helm/loki/templates/index-gateway/service-index-gateway.yaml
+++ b/production/helm/loki/templates/index-gateway/service-index-gateway.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "loki.indexGatewayFullname" . }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.indexGatewayLabels" . | nindent 4 }}
     {{- with .Values.indexGateway.serviceLabels }}

--- a/production/helm/loki/templates/index-gateway/statefulset-index-gateway.yaml
+++ b/production/helm/loki/templates/index-gateway/statefulset-index-gateway.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "loki.indexGatewayFullname" . }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.indexGatewayLabels" . | nindent 4 }}
   {{- with .Values.loki.annotations }}

--- a/production/helm/loki/templates/ingester/hpa-zone-a.yaml
+++ b/production/helm/loki/templates/ingester/hpa-zone-a.yaml
@@ -5,7 +5,7 @@ apiVersion: {{ $apiVersion }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "loki.ingesterFullname" . }}-zone-a
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.ingesterLabels" . | nindent 4 }}
 spec:

--- a/production/helm/loki/templates/ingester/hpa-zone-b.yaml
+++ b/production/helm/loki/templates/ingester/hpa-zone-b.yaml
@@ -5,7 +5,7 @@ apiVersion: {{ $apiVersion }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "loki.ingesterFullname" . }}-zone-b
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.ingesterLabels" . | nindent 4 }}
 spec:

--- a/production/helm/loki/templates/ingester/hpa-zone-c.yaml
+++ b/production/helm/loki/templates/ingester/hpa-zone-c.yaml
@@ -5,7 +5,7 @@ apiVersion: {{ $apiVersion }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "loki.ingesterFullname" . }}-zone-c
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.ingesterLabels" . | nindent 4 }}
 spec:

--- a/production/helm/loki/templates/ingester/hpa.yaml
+++ b/production/helm/loki/templates/ingester/hpa.yaml
@@ -5,7 +5,7 @@ apiVersion: {{ $apiVersion }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "loki.ingesterFullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.ingesterLabels" . | nindent 4 }}
 spec:

--- a/production/helm/loki/templates/ingester/poddisruptionbudget-ingester-rollout.yaml
+++ b/production/helm/loki/templates/ingester/poddisruptionbudget-ingester-rollout.yaml
@@ -7,7 +7,7 @@ apiVersion: {{ include "loki.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "loki.ingesterFullname" . }}-rollout
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.ingesterLabels" . | nindent 4 }}
 spec:

--- a/production/helm/loki/templates/ingester/poddisruptionbudget-ingester.yaml
+++ b/production/helm/loki/templates/ingester/poddisruptionbudget-ingester.yaml
@@ -7,7 +7,7 @@ apiVersion: {{ include "loki.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "loki.ingesterFullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.ingesterLabels" . | nindent 4 }}
 spec:

--- a/production/helm/loki/templates/ingester/service-ingester-headless.yaml
+++ b/production/helm/loki/templates/ingester/service-ingester-headless.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "loki.ingesterFullname" . }}-headless
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.ingesterSelectorLabels" . | nindent 4 }}
     prometheus.io/service-monitor: "false"

--- a/production/helm/loki/templates/ingester/service-ingester-zone-a-headless.yaml
+++ b/production/helm/loki/templates/ingester/service-ingester-zone-a-headless.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "loki.ingesterFullname" . }}-zone-a-headless
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.ingesterLabels" . | nindent 4 }}
     {{- with .Values.ingester.serviceLabels }}

--- a/production/helm/loki/templates/ingester/service-ingester-zone-b-headless.yaml
+++ b/production/helm/loki/templates/ingester/service-ingester-zone-b-headless.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "loki.ingesterFullname" . }}-zone-b-headless
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.ingesterLabels" . | nindent 4 }}
     {{- with .Values.ingester.serviceLabels }}

--- a/production/helm/loki/templates/ingester/service-ingester-zone-c-headless.yaml
+++ b/production/helm/loki/templates/ingester/service-ingester-zone-c-headless.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "loki.ingesterFullname" . }}-zone-c-headless
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.ingesterLabels" . | nindent 4 }}
     {{- with .Values.ingester.serviceLabels }}

--- a/production/helm/loki/templates/ingester/service-ingester.yaml
+++ b/production/helm/loki/templates/ingester/service-ingester.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "loki.ingesterFullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.ingesterLabels" . | nindent 4 }}
     {{- with .Values.ingester.serviceLabels }}

--- a/production/helm/loki/templates/ingester/statefulset-ingester-zone-a.yaml
+++ b/production/helm/loki/templates/ingester/statefulset-ingester-zone-a.yaml
@@ -5,7 +5,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "loki.ingesterFullname" . }}-zone-a
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.ingesterLabels" . | nindent 4 }}
     app.kubernetes.io/part-of: memberlist

--- a/production/helm/loki/templates/ingester/statefulset-ingester-zone-b.yaml
+++ b/production/helm/loki/templates/ingester/statefulset-ingester-zone-b.yaml
@@ -5,7 +5,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "loki.ingesterFullname" . }}-zone-b
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.ingesterLabels" . | nindent 4 }}
     app.kubernetes.io/part-of: memberlist

--- a/production/helm/loki/templates/ingester/statefulset-ingester-zone-c.yaml
+++ b/production/helm/loki/templates/ingester/statefulset-ingester-zone-c.yaml
@@ -5,7 +5,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "loki.ingesterFullname" . }}-zone-c
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.ingesterLabels" . | nindent 4 }}
     app.kubernetes.io/part-of: memberlist

--- a/production/helm/loki/templates/ingester/statefulset-ingester.yaml
+++ b/production/helm/loki/templates/ingester/statefulset-ingester.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "loki.ingesterFullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.ingesterLabels" . | nindent 4 }}
     app.kubernetes.io/part-of: memberlist

--- a/production/helm/loki/templates/ingress.yaml
+++ b/production/helm/loki/templates/ingress.yaml
@@ -4,7 +4,7 @@ apiVersion: {{ include "loki.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ include "loki.fullname" . }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.labels" . | nindent 4 }}
     {{- with .Values.ingress.labels }}

--- a/production/helm/loki/templates/loki-canary/daemonset.yaml
+++ b/production/helm/loki/templates/loki-canary/daemonset.yaml
@@ -5,7 +5,7 @@ apiVersion: apps/v1
 kind: {{ .kind }}
 metadata:
   name: {{ include "loki-canary.fullname" $ }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" $ }}
   labels:
     {{- include "loki-canary.labels" $ | nindent 4 }}
 spec:

--- a/production/helm/loki/templates/loki-canary/service.yaml
+++ b/production/helm/loki/templates/loki-canary/service.yaml
@@ -5,7 +5,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "loki-canary.fullname" $ }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" $ }}
   labels:
     {{- include "loki-canary.labels" $ | nindent 4 }}
     {{- with $.Values.loki.serviceLabels }}

--- a/production/helm/loki/templates/loki-canary/serviceaccount.yaml
+++ b/production/helm/loki/templates/loki-canary/serviceaccount.yaml
@@ -5,7 +5,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "loki-canary.fullname" $ }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" $ }}
   labels:
     {{- include "loki-canary.labels" $ | nindent 4 }}
   {{- with .annotations }}

--- a/production/helm/loki/templates/memcached/_memcached-pdb.tpl
+++ b/production/helm/loki/templates/memcached/_memcached-pdb.tpl
@@ -15,7 +15,7 @@ apiVersion: {{ include "loki.pdb.apiVersion" $.ctx }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "loki.resourceName" (dict "ctx" $.ctx "component" $.component "suffix" .suffix) }}
-  namespace: {{ $.ctx.Release.Namespace }}
+  namespace: {{ include "loki.namespace" $.ctx }}
   labels:
     {{- include "loki.selectorLabels" $.ctx | nindent 4 }}
     app.kubernetes.io/component: "memcached-{{ $.component }}{{ include "loki.memcached.suffix" .suffix }}"

--- a/production/helm/loki/templates/memcached/_memcached-statefulset.tpl
+++ b/production/helm/loki/templates/memcached/_memcached-statefulset.tpl
@@ -20,7 +20,7 @@ metadata:
     name: "memcached-{{ $.component }}{{ include "loki.memcached.suffix" .suffix }}"
   annotations:
     {{- toYaml .annotations | nindent 4 }}
-  namespace: {{ $.ctx.Release.Namespace | quote }}
+  namespace: {{ include "loki.namespace" $.ctx | quote }}
 spec:
   podManagementPolicy: {{ .podManagementPolicy }}
   replicas: {{ .replicas }}

--- a/production/helm/loki/templates/memcached/_memcached-svc.tpl
+++ b/production/helm/loki/templates/memcached/_memcached-svc.tpl
@@ -22,7 +22,7 @@ metadata:
     {{- end }}
   annotations:
     {{- toYaml .service.annotations | nindent 4 }}
-  namespace: {{ $.ctx.Release.Namespace | quote }}
+  namespace: {{ include "loki.namespace" $.ctx | quote }}
 spec:
   type: ClusterIP
   clusterIP: None

--- a/production/helm/loki/templates/monitoring/_helpers-monitoring.tpl
+++ b/production/helm/loki/templates/monitoring/_helpers-monitoring.tpl
@@ -3,11 +3,11 @@ Client definition for LogsInstance
 */}}
 {{- define "loki.logsInstanceClient" -}}
 {{- $isSingleBinary := eq (include "loki.deployment.isSingleBinary" .) "true" -}}
-{{- $url := printf "http://%s.%s.svc.%s:%s/loki/api/v1/push" (include "loki.writeFullname" .) .Release.Namespace .Values.global.clusterDomain ( .Values.loki.server.http_listen_port | toString ) }}
+{{- $url := printf "http://%s.%s.svc.%s:%s/loki/api/v1/push" (include "loki.writeFullname" .) (include "loki.namespace" .) .Values.global.clusterDomain ( .Values.loki.server.http_listen_port | toString ) }}
 {{- if $isSingleBinary  }}
-  {{- $url = printf "http://%s.%s.svc.%s:%s/loki/api/v1/push" (include "loki.singleBinaryFullname" .) .Release.Namespace .Values.global.clusterDomain ( .Values.loki.server.http_listen_port | toString ) }}
+  {{- $url = printf "http://%s.%s.svc.%s:%s/loki/api/v1/push" (include "loki.singleBinaryFullname" .) (include "loki.namespace" .) .Values.global.clusterDomain ( .Values.loki.server.http_listen_port | toString ) }}
 {{- else if .Values.gateway.enabled -}}
-  {{- $url = printf "http://%s.%s.svc.%s/loki/api/v1/push" (include "loki.gatewayFullname" .) .Release.Namespace .Values.global.clusterDomain }}
+  {{- $url = printf "http://%s.%s.svc.%s/loki/api/v1/push" (include "loki.gatewayFullname" .) (include "loki.namespace" .) .Values.global.clusterDomain }}
 {{- end -}}
 - url: {{ $url }}
   externalLabels:

--- a/production/helm/loki/templates/monitoring/dashboards/configmap-1.yaml
+++ b/production/helm/loki/templates/monitoring/dashboards/configmap-1.yaml
@@ -5,7 +5,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "loki.dashboardsName" $ }}-1
-  namespace: {{ .namespace | default $.Release.Namespace }}
+  namespace: {{ .namespace | default (include "loki.namespace" $) }}
   labels:
     {{- include "loki.labels" $ | nindent 4 }}
     {{- with .labels }}

--- a/production/helm/loki/templates/monitoring/dashboards/configmap-2.yaml
+++ b/production/helm/loki/templates/monitoring/dashboards/configmap-2.yaml
@@ -5,7 +5,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "loki.dashboardsName" $ }}-2
-  namespace: {{ .namespace | default $.Release.Namespace }}
+  namespace: {{ .namespace | default (include "loki.namespace" $) }}
   labels:
     {{- include "loki.labels" $ | nindent 4 }}
     {{- with .labels }}

--- a/production/helm/loki/templates/monitoring/grafana-agent.yaml
+++ b/production/helm/loki/templates/monitoring/grafana-agent.yaml
@@ -4,7 +4,7 @@ apiVersion: monitoring.grafana.com/v1alpha1
 kind: GrafanaAgent
 metadata:
   name: {{ include "loki.fullname" $ }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" $ }}
   labels:
     {{- include "loki.labels" $ | nindent 4 }}
     {{- with .labels }}
@@ -45,7 +45,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "loki.fullname" $ }}-grafana-agent
-  namespace: {{ .namespace | default $.Release.Namespace }}
+  namespace: {{ .namespace | default (include "loki.namespace" $) }}
 
 ---
 
@@ -95,6 +95,6 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ include "loki.fullname" $ }}-grafana-agent
-  namespace: {{ .namespace | default $.Release.Namespace }}
+  namespace: {{ .namespace | default (include "loki.namespace" $) }}
 {{- end}}
 {{- end}}

--- a/production/helm/loki/templates/monitoring/logs-instance.yaml
+++ b/production/helm/loki/templates/monitoring/logs-instance.yaml
@@ -4,7 +4,7 @@ apiVersion: monitoring.grafana.com/v1alpha1
 kind: LogsInstance
 metadata:
   name: {{ include "loki.fullname" $ }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" $ }}
   {{- with .annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/production/helm/loki/templates/monitoring/loki-alerts.yaml
+++ b/production/helm/loki/templates/monitoring/loki-alerts.yaml
@@ -14,7 +14,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   name: {{ include "loki.fullname" $ }}-loki-alerts
-  namespace: {{ .namespace | default $.Release.Namespace }}
+  namespace: {{ .namespace | default (include "loki.namespace" $) }}
 spec:
   groups:
   {{- include "loki.ruleGroupToYaml" (tpl ($.Files.Get "src/alerts.yaml.tpl") $ | fromYaml).groups | indent 4 }}

--- a/production/helm/loki/templates/monitoring/loki-rules.yaml
+++ b/production/helm/loki/templates/monitoring/loki-rules.yaml
@@ -14,7 +14,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   name: {{ include "loki.fullname" $ }}-loki-rules
-  namespace: {{ .namespace | default $.Release.Namespace }}
+  namespace: {{ .namespace | default (include "loki.namespace" $) }}
 spec:
   groups:
   {{- include "loki.ruleGroupToYaml" (tpl ($.Files.Get "src/rules.yaml.tpl") $ | fromYaml).groups | indent 4 }}

--- a/production/helm/loki/templates/monitoring/pod-logs.yaml
+++ b/production/helm/loki/templates/monitoring/pod-logs.yaml
@@ -5,7 +5,7 @@ apiVersion: {{ .apiVersion }}
 kind: PodLogs
 metadata:
   name: {{ include "loki.fullname" $ }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" $ }}
   {{- with .annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -54,7 +54,7 @@ spec:
     {{- end }}
   namespaceSelector:
     matchNames:
-      - {{ $.Release.Namespace }}
+      - {{ include "loki.namespace" $ }}
   selector:
     matchLabels:
       {{- include "loki.selectorLabels" $ | nindent 6 }}

--- a/production/helm/loki/templates/monitoring/servicemonitor.yaml
+++ b/production/helm/loki/templates/monitoring/servicemonitor.yaml
@@ -5,7 +5,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "loki.fullname" $ }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" $ }}
   {{- with .annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -40,7 +40,7 @@ spec:
       relabelings:
         - sourceLabels: [job]
           action: replace
-          replacement: "{{ $.Release.Namespace }}/$1"
+          replacement: "{{ include "loki.namespace" $ }}/$1"
           targetLabel: job
         - action: replace
           replacement: "{{ include "loki.clusterLabel" $ }}"

--- a/production/helm/loki/templates/networkpolicy.yaml
+++ b/production/helm/loki/templates/networkpolicy.yaml
@@ -4,7 +4,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ include "loki.name" . }}-namespace-only
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.labels" . | nindent 4 }}
 spec:
@@ -24,7 +24,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ include "loki.name" . }}-egress-dns
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.labels" . | nindent 4 }}
 spec:
@@ -45,7 +45,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ include "loki.name" . }}-ingress
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.labels" . | nindent 4 }}
 spec:
@@ -83,7 +83,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ include "loki.name" . }}-ingress-metrics
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.labels" . | nindent 4 }}
 spec:
@@ -117,7 +117,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ include "loki.name" . }}-egress-alertmanager
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" $ }}
   labels:
     {{- include "loki.labels" . | nindent 4 }}
 spec:
@@ -146,7 +146,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ include "loki.name" . }}-egress-external-storage
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" $ }}
   labels:
     {{- include "loki.labels" . | nindent 4 }}
 spec:
@@ -178,7 +178,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ include "loki.name" . }}-egress-discovery
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" $ }}
   labels:
     {{- include "loki.labels" . | nindent 4 }}
 spec:

--- a/production/helm/loki/templates/overrides-exporter/deployment-overrides-exporter.yaml
+++ b/production/helm/loki/templates/overrides-exporter/deployment-overrides-exporter.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "loki.overridesExporterFullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.overridesExporterLabels" . | nindent 4 }}
   {{- with .Values.loki.annotations }}

--- a/production/helm/loki/templates/overrides-exporter/poddisruptionbudget-overrides-exporter.yaml
+++ b/production/helm/loki/templates/overrides-exporter/poddisruptionbudget-overrides-exporter.yaml
@@ -7,7 +7,7 @@ apiVersion: {{ include "loki.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "loki.overridesExporterFullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.overridesExporterLabels" . | nindent 4 }}
 spec:

--- a/production/helm/loki/templates/overrides-exporter/service-overrides-exporter-headless.yaml
+++ b/production/helm/loki/templates/overrides-exporter/service-overrides-exporter-headless.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "loki.overridesExporterFullname" . }}-headless
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.overridesExporterLabels" . | nindent 4 }}
     {{- with .Values.overridesExporter.serviceLabels }}

--- a/production/helm/loki/templates/overrides-exporter/service-overrides-exporter.yaml
+++ b/production/helm/loki/templates/overrides-exporter/service-overrides-exporter.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "loki.overridesExporterFullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.overridesExporterLabels" . | nindent 4 }}
     {{- with .Values.overridesExporter.serviceLabels }}

--- a/production/helm/loki/templates/pattern-ingester/poddisruptionbudget-pattern-ingester.yaml
+++ b/production/helm/loki/templates/pattern-ingester/poddisruptionbudget-pattern-ingester.yaml
@@ -4,7 +4,7 @@ apiVersion: {{ include "loki.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "loki.patternIngesterFullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.patternIngesterLabels" . | nindent 4 }}
 spec:

--- a/production/helm/loki/templates/pattern-ingester/statefulset-pattern-ingester.yaml
+++ b/production/helm/loki/templates/pattern-ingester/statefulset-pattern-ingester.yaml
@@ -5,7 +5,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "loki.patternIngesterFullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.patternIngesterLabels" . | nindent 4 }}
   {{- with .Values.loki.annotations }}

--- a/production/helm/loki/templates/provisioner/job-provisioner.yaml
+++ b/production/helm/loki/templates/provisioner/job-provisioner.yaml
@@ -4,7 +4,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ template "enterprise-logs.provisionerFullname" . }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "enterprise-logs.provisionerLabels" . | nindent 4 }}
     {{- with .Values.enterprise.provisioner.labels }}
@@ -105,7 +105,7 @@ spec:
                   --from-literal=token-write="$(cat /bootstrap/token-write-{{ .name }})" \
                   --from-literal=token-read="$(cat /bootstrap/token-read-{{ .name }})"
               {{- end }}
-              {{- $namespace := $.Release.Namespace }}
+              {{- $namespace := include "loki.namespace" $ }}
               {{- with .Values.monitoring.selfMonitoring.tenant }}
               {{- $secretNamespace := tpl .secretNamespace $ }}
               ! test -s /bootstrap/token-self-monitoring || \

--- a/production/helm/loki/templates/provisioner/role-provisioner.yaml
+++ b/production/helm/loki/templates/provisioner/role-provisioner.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ if not .Values.rbac.namespaced }}Cluster{{ end }}Role
 metadata:
   name: {{ template "enterprise-logs.provisionerFullname" . }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "enterprise-logs.provisionerLabels" . | nindent 4 }}
     {{- with .Values.enterprise.provisioner.labels }}

--- a/production/helm/loki/templates/provisioner/rolebinding-provisioner.yaml
+++ b/production/helm/loki/templates/provisioner/rolebinding-provisioner.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ if not .Values.rbac.namespaced }}Cluster{{ end }}RoleBinding
 metadata:
   name: {{ template "enterprise-logs.provisionerFullname" . }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "enterprise-logs.provisionerLabels" . | nindent 4 }}
     {{- with .Values.enterprise.provisioner.labels }}
@@ -22,5 +22,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "enterprise-logs.provisionerFullname" . }}
-    namespace: {{ $.Release.Namespace }}
+    namespace: {{ include "loki.namespace" $ }}
 {{- end }}

--- a/production/helm/loki/templates/provisioner/serviceaccount-provisioner.yaml
+++ b/production/helm/loki/templates/provisioner/serviceaccount-provisioner.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "enterprise-logs.provisionerFullname" . }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "enterprise-logs.provisionerLabels" . | nindent 4 }}
     {{- with .Values.enterprise.provisioner.labels }}

--- a/production/helm/loki/templates/querier/deployment-querier.yaml
+++ b/production/helm/loki/templates/querier/deployment-querier.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "loki.querierFullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.querierLabels" . | nindent 4 }}
     app.kubernetes.io/part-of: memberlist

--- a/production/helm/loki/templates/querier/hpa.yaml
+++ b/production/helm/loki/templates/querier/hpa.yaml
@@ -5,7 +5,7 @@ apiVersion: {{ $apiVersion }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "loki.querierFullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.querierLabels" . | nindent 4 }}
 spec:

--- a/production/helm/loki/templates/querier/poddisruptionbudget-querier.yaml
+++ b/production/helm/loki/templates/querier/poddisruptionbudget-querier.yaml
@@ -7,7 +7,7 @@ apiVersion: {{ include "loki.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "loki.querierFullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.querierLabels" . | nindent 4 }}
 spec:

--- a/production/helm/loki/templates/querier/service-querier.yaml
+++ b/production/helm/loki/templates/querier/service-querier.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "loki.querierFullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.querierLabels" . | nindent 4 }}
     {{- with .Values.querier.serviceLabels }}

--- a/production/helm/loki/templates/query-frontend/deployment-query-frontend.yaml
+++ b/production/helm/loki/templates/query-frontend/deployment-query-frontend.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "loki.queryFrontendFullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.queryFrontendLabels" . | nindent 4 }}
   {{- with .Values.loki.annotations }}

--- a/production/helm/loki/templates/query-frontend/hpa.yaml
+++ b/production/helm/loki/templates/query-frontend/hpa.yaml
@@ -5,7 +5,7 @@ apiVersion: {{ $apiVersion }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "loki.queryFrontendFullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.queryFrontendLabels" . | nindent 4 }}
 spec:

--- a/production/helm/loki/templates/query-frontend/poddisruptionbudget-query-frontend.yaml
+++ b/production/helm/loki/templates/query-frontend/poddisruptionbudget-query-frontend.yaml
@@ -7,7 +7,7 @@ apiVersion: {{ include "loki.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "loki.queryFrontendFullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.queryFrontendLabels" . | nindent 4 }}
 spec:

--- a/production/helm/loki/templates/query-frontend/service-query-frontend-headless.yaml
+++ b/production/helm/loki/templates/query-frontend/service-query-frontend-headless.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "loki.queryFrontendFullname" . }}-headless
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.queryFrontendLabels" . | nindent 4 }}
     {{- with .Values.queryFrontend.serviceLabels }}

--- a/production/helm/loki/templates/query-frontend/service-query-frontend.yaml
+++ b/production/helm/loki/templates/query-frontend/service-query-frontend.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "loki.queryFrontendFullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.queryFrontendLabels" . | nindent 4 }}
     {{- with .Values.queryFrontend.serviceLabels }}

--- a/production/helm/loki/templates/query-scheduler/deployment-query-scheduler.yaml
+++ b/production/helm/loki/templates/query-scheduler/deployment-query-scheduler.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "loki.querySchedulerFullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.querySchedulerLabels" . | nindent 4 }}
   {{- with .Values.loki.annotations }}

--- a/production/helm/loki/templates/query-scheduler/poddisruptionbudget-query-scheduler.yaml
+++ b/production/helm/loki/templates/query-scheduler/poddisruptionbudget-query-scheduler.yaml
@@ -7,7 +7,7 @@ apiVersion: {{ include "loki.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "loki.querySchedulerFullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.querySchedulerLabels" . | nindent 4 }}
 spec:

--- a/production/helm/loki/templates/query-scheduler/service-query-scheduler.yaml
+++ b/production/helm/loki/templates/query-scheduler/service-query-scheduler.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "loki.querySchedulerFullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.querySchedulerLabels" . | nindent 4 }}
     {{- with .Values.queryScheduler.serviceLabels }}

--- a/production/helm/loki/templates/read/deployment-read.yaml
+++ b/production/helm/loki/templates/read/deployment-read.yaml
@@ -5,7 +5,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "loki.readFullname" . }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" $ }}
   labels:
     app.kubernetes.io/part-of: memberlist
     {{- include "loki.readLabels" . | nindent 4 }}
@@ -71,7 +71,7 @@ spec:
             - -config.file=/etc/loki/config/config.yaml
             - -target={{ .Values.read.targetModule }}
             - -legacy-read-mode=false
-            - -common.compactor-grpc-address={{ include "loki.backendFullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:{{ .Values.loki.server.grpc_listen_port }}
+            - -common.compactor-grpc-address={{ include "loki.backendFullname" . }}.{{ include "loki.namespace" . }}.svc.{{ .Values.global.clusterDomain }}:{{ .Values.loki.server.grpc_listen_port }}
             {{- with (concat .Values.global.extraArgs .Values.read.extraArgs) | uniq }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/production/helm/loki/templates/read/hpa.yaml
+++ b/production/helm/loki/templates/read/hpa.yaml
@@ -9,7 +9,7 @@ apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "loki.readFullname" . }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" $ }}
   labels:
     {{- include "loki.readLabels" . | nindent 4 }}
 spec:

--- a/production/helm/loki/templates/read/poddisruptionbudget-read.yaml
+++ b/production/helm/loki/templates/read/poddisruptionbudget-read.yaml
@@ -4,7 +4,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "loki.readFullname" . }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.readLabels" . | nindent 4 }}
 spec:

--- a/production/helm/loki/templates/read/service-read-headless.yaml
+++ b/production/helm/loki/templates/read/service-read-headless.yaml
@@ -5,7 +5,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "loki.readFullname" . }}-headless
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.readSelectorLabels" . | nindent 4 }}
     {{- with .Values.loki.serviceLabels }}

--- a/production/helm/loki/templates/read/service-read.yaml
+++ b/production/helm/loki/templates/read/service-read.yaml
@@ -5,7 +5,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "loki.readFullname" . }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.readLabels" . | nindent 4 }}
     {{- with .Values.loki.serviceLabels }}

--- a/production/helm/loki/templates/read/statefulset-read.yaml
+++ b/production/helm/loki/templates/read/statefulset-read.yaml
@@ -5,7 +5,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "loki.readFullname" . }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     app.kubernetes.io/part-of: memberlist
     {{- include "loki.readLabels" . | nindent 4 }}

--- a/production/helm/loki/templates/results-cache/poddisruptionbudget-results-cache.yaml
+++ b/production/helm/loki/templates/results-cache/poddisruptionbudget-results-cache.yaml
@@ -4,7 +4,7 @@ apiVersion: {{ include "loki.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "loki.fullname" . }}-memcached-results-cache
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: memcached-results-cache

--- a/production/helm/loki/templates/role.yaml
+++ b/production/helm/loki/templates/role.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "loki.name" . }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.labels" . | nindent 4 }}
 rules:

--- a/production/helm/loki/templates/rolebinding.yaml
+++ b/production/helm/loki/templates/rolebinding.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "loki.name" . }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.labels" . | nindent 4 }}
 roleRef:
@@ -13,5 +13,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ include "loki.serviceAccountName" . }}
-    namespace: {{ $.Release.Namespace }}
+    namespace: {{ include "loki.namespace" $ }}
 {{- end }}

--- a/production/helm/loki/templates/ruler/configmap-ruler.yaml
+++ b/production/helm/loki/templates/ruler/configmap-ruler.yaml
@@ -6,7 +6,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "loki.rulerFullname" $ }}-{{ include "loki.rulerRulesDirName" $dir }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" $ }}
   labels:
     {{- include "loki.rulerLabels" $ | nindent 4 }}
 data:

--- a/production/helm/loki/templates/ruler/poddisruptionbudget-ruler.yaml
+++ b/production/helm/loki/templates/ruler/poddisruptionbudget-ruler.yaml
@@ -7,7 +7,7 @@ apiVersion: {{ include "loki.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "loki.rulerFullname" . }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.rulerLabels" . | nindent 4 }}
 spec:

--- a/production/helm/loki/templates/ruler/service-ruler.yaml
+++ b/production/helm/loki/templates/ruler/service-ruler.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "loki.rulerFullname" . }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.rulerSelectorLabels" . | nindent 4 }}
     {{- with .Values.ruler.serviceLabels }}

--- a/production/helm/loki/templates/ruler/statefulset-ruler.yaml
+++ b/production/helm/loki/templates/ruler/statefulset-ruler.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "loki.rulerFullname" . }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.rulerLabels" . | nindent 4 }}
     app.kubernetes.io/part-of: memberlist

--- a/production/helm/loki/templates/runtime-configmap.yaml
+++ b/production/helm/loki/templates/runtime-configmap.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "loki.name" . }}-runtime
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.labels" . | nindent 4 }}
 data:

--- a/production/helm/loki/templates/secret-license.yaml
+++ b/production/helm/loki/templates/secret-license.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: enterprise-logs-license
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.labels" . | nindent 4 }}
 data:

--- a/production/helm/loki/templates/service-memberlist.yaml
+++ b/production/helm/loki/templates/service-memberlist.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "loki.memberlist" . }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.labels" . | nindent 4 }}
   annotations:

--- a/production/helm/loki/templates/serviceaccount.yaml
+++ b/production/helm/loki/templates/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "loki.serviceAccountName" . }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.labels }}

--- a/production/helm/loki/templates/single-binary/hpa.yaml
+++ b/production/helm/loki/templates/single-binary/hpa.yaml
@@ -10,7 +10,7 @@ apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "loki.singleBinaryFullname" . }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.singleBinaryLabels" . | nindent 4 }}
 spec:

--- a/production/helm/loki/templates/single-binary/pdb.yaml
+++ b/production/helm/loki/templates/single-binary/pdb.yaml
@@ -5,7 +5,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "loki.fullname" . }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.labels" . | nindent 4 }}
 spec:

--- a/production/helm/loki/templates/single-binary/service-headless.yaml
+++ b/production/helm/loki/templates/single-binary/service-headless.yaml
@@ -5,7 +5,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "loki.name" . }}-headless
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.labels" . | nindent 4 }}
     {{- with .Values.loki.serviceLabels }}

--- a/production/helm/loki/templates/single-binary/service.yaml
+++ b/production/helm/loki/templates/single-binary/service.yaml
@@ -5,7 +5,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "loki.singleBinaryFullname" . }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.labels" . | nindent 4 }}
     {{- with .Values.loki.serviceLabels }}

--- a/production/helm/loki/templates/single-binary/statefulset.yaml
+++ b/production/helm/loki/templates/single-binary/statefulset.yaml
@@ -5,7 +5,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "loki.singleBinaryFullname" . }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.singleBinaryLabels" . | nindent 4 }}
     app.kubernetes.io/part-of: memberlist

--- a/production/helm/loki/templates/table-manager/deployment-table-manager.yaml
+++ b/production/helm/loki/templates/table-manager/deployment-table-manager.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "loki.tableManagerFullname" . }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.tableManagerLabels" . | nindent 4 }}
   annotations:

--- a/production/helm/loki/templates/table-manager/service-table-manager.yaml
+++ b/production/helm/loki/templates/table-manager/service-table-manager.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "loki.fullname" . }}-table-manager
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.labels" . | nindent 4 }}
     {{- with .Values.loki.serviceLabels }}

--- a/production/helm/loki/templates/table-manager/servicemonitor-table-manager.yaml
+++ b/production/helm/loki/templates/table-manager/servicemonitor-table-manager.yaml
@@ -5,8 +5,10 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "loki.tableManagerFullname" $ }}
-  {{- with .namespace }}
-  namespace: {{ . }}
+  {{- if .namespace }}
+  namespace: {{ .namespace }}
+  {{- else }}
+  namespace: {{ include "loki.namespace" . }}
   {{- end }}
   {{- with .annotations }}
   annotations:

--- a/production/helm/loki/templates/tests/test-canary.yaml
+++ b/production/helm/loki/templates/tests/test-canary.yaml
@@ -5,7 +5,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: "{{ include "loki.name" $ }}-helm-test"
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" $ }}
   labels:
     {{- include "loki.helmTestLabels" $ | nindent 4 }}
     {{- with .labels }}

--- a/production/helm/loki/templates/tokengen/clusterrolebinding-tokengen.yaml
+++ b/production/helm/loki/templates/tokengen/clusterrolebinding-tokengen.yaml
@@ -21,5 +21,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "enterprise-logs.tokengenFullname" . }}
-    namespace: {{ $.Release.Namespace }}
+    namespace: {{ include "loki.namespace" . }}
 {{- end }}

--- a/production/helm/loki/templates/tokengen/job-tokengen.yaml
+++ b/production/helm/loki/templates/tokengen/job-tokengen.yaml
@@ -4,7 +4,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ template "enterprise-logs.tokengenFullname" . }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "enterprise-logs.tokengenLabels" . | nindent 4 }}
     {{- with .Values.enterprise.tokengen.labels }}

--- a/production/helm/loki/templates/tokengen/serviceaccount-tokengen.yaml
+++ b/production/helm/loki/templates/tokengen/serviceaccount-tokengen.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "enterprise-logs.tokengenFullname" . }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "enterprise-logs.tokengenLabels" . | nindent 4 }}
     {{- with .Values.enterprise.tokengen.labels }}

--- a/production/helm/loki/templates/write/hpa.yaml
+++ b/production/helm/loki/templates/write/hpa.yaml
@@ -9,7 +9,7 @@ apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "loki.writeFullname" . }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.writeLabels" . | nindent 4 }}
 spec:

--- a/production/helm/loki/templates/write/poddisruptionbudget-write.yaml
+++ b/production/helm/loki/templates/write/poddisruptionbudget-write.yaml
@@ -4,7 +4,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "loki.writeFullname" . }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.writeLabels" . | nindent 4 }}
 spec:

--- a/production/helm/loki/templates/write/service-write-headless.yaml
+++ b/production/helm/loki/templates/write/service-write-headless.yaml
@@ -5,7 +5,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "loki.writeFullname" . }}-headless
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.writeSelectorLabels" . | nindent 4 }}
     {{- with .Values.loki.serviceLabels }}

--- a/production/helm/loki/templates/write/service-write.yaml
+++ b/production/helm/loki/templates/write/service-write.yaml
@@ -5,7 +5,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "loki.writeFullname" . }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.writeLabels" . | nindent 4 }}
     {{- with .Values.loki.serviceLabels }}

--- a/production/helm/loki/templates/write/statefulset-write.yaml
+++ b/production/helm/loki/templates/write/statefulset-write.yaml
@@ -5,7 +5,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "loki.writeFullname" . }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.writeLabels" . | nindent 4 }}
     app.kubernetes.io/part-of: memberlist

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -39,6 +39,8 @@ global:
 nameOverride: null
 # -- Overrides the chart's computed fullname
 fullnameOverride: null
+# -- Overrides the chart's namespace
+namespaceOverride: null
 # -- Overrides the chart's cluster label
 clusterLabelOverride: null
 # -- Image pull secrets for Docker images
@@ -314,7 +316,7 @@ loki:
       enabled: true
       discovery:
         join_peers:
-          - '{{ include "loki.queryFrontendFullname" . }}.{{ $.Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}'
+          - '{{ include "loki.queryFrontendFullname" . }}.{{ include "loki.namespace" . }}.svc.{{ .Values.global.clusterDomain }}'
     {{- end }}
     {{- with .Values.loki.querier }}
     querier:
@@ -3317,7 +3319,7 @@ resultsCache:
   # -- Specifies whether memcached based results-cache should be enabled
   enabled: true
   # -- Comma separated addresses list in DNS Service Discovery format
-  addresses: dnssrvnoa+_memcached-client._tcp.{{ include "loki.resourceName" (dict "ctx" $ "component" "results-cache") }}.{{ $.Release.Namespace }}.svc
+  addresses: dnssrvnoa+_memcached-client._tcp.{{ include "loki.resourceName" (dict "ctx" $ "component" "results-cache") }}.{{ include "loki.namespace" $ }}.svc
   # -- Specify how long cached results should be stored in the results-cache before being expired
   defaultValidity: 12h
   # -- Memcached operation timeout
@@ -3420,7 +3422,7 @@ chunksCache:
   # -- Specifies whether memcached based chunks-cache should be enabled
   enabled: true
   # -- Comma separated addresses list in DNS Service Discovery format
-  addresses: dnssrvnoa+_memcached-client._tcp.{{ include "loki.resourceName" (dict "ctx" $ "component" "chunks-cache" "suffix" $.Values.chunksCache.suffix ) }}.{{ $.Release.Namespace }}.svc
+  addresses: dnssrvnoa+_memcached-client._tcp.{{ include "loki.resourceName" (dict "ctx" $ "component" "chunks-cache" "suffix" $.Values.chunksCache.suffix ) }}.{{ include "loki.namespace" $ }}.svc
   # -- Batchsize for sending and receiving chunks from chunks cache
   batchSize: 4
   # -- Parallel threads for sending and receiving chunks from chunks cache
@@ -3530,7 +3532,7 @@ chunksCache:
     # -- Specifies whether memcached based chunks-cache-l2 should be enabled
     enabled: false
     # -- Comma separated addresses list in DNS Service Discovery format
-    addresses: dnssrvnoa+_memcached-client._tcp.{{ include "loki.resourceName" (dict "ctx" $ "component" "chunks-cache" "suffix" $.Values.chunksCache.l2.suffix ) }}.{{ $.Release.Namespace }}.svc
+    addresses: 'dnssrvnoa+_memcached-client._tcp.{{ include "loki.resourceName" (dict "ctx" $ "component" "chunks-cache" "suffix" $.Values.chunksCache.l2.suffix ) }}.{{ include "loki.namespace" $ }}.svc'
     # -- Batchsize for sending and receiving chunks from chunks cache
     batchSize: 4
     # -- Parallel threads for sending and receiving chunks from chunks cache
@@ -3900,7 +3902,8 @@ monitoring:
       password: null
       # -- Namespace to create additional tenant token secret in. Useful if your Grafana instance
       # is in a separate namespace. Token will still be created in the canary namespace.
-      secretNamespace: "{{ .Release.Namespace }}"
+      # @default -- The same namespace as the loki chart is installed in.
+      secretNamespace: '{{ include "loki.namespace" . }}'
     # -- DEPRECATED Grafana Agent configuration
     grafanaAgent:
       # -- DEPRECATED Controls whether to install the Grafana Agent Operator and its CRDs.


### PR DESCRIPTION
**What this PR does / why we need it**:

Allow overriding namespace for Loki helm chart resources.

**Which issue(s) this PR fixes**:
- Fixes https://github.com/grafana/loki/issues/8044
- Fixes #11989
- Fixes #12321

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
