### PR TITLE
feat: add histogram to track the number of sections per tenant

### DIFF
--- a/pkg/dataobj/consumer/logsobj/builder_metrics.go
+++ b/pkg/dataobj/consumer/logsobj/builder_metrics.go
@@ -25,6 +25,8 @@ type builderMetrics struct {
 
 	sizeEstimate prometheus.Gauge
 	builtSize    prometheus.Histogram
+
+	tenantSections prometheus.Histogram
 }
 
 // newBuilderMetrics creates a new set of [builderMetrics] for instrumenting
@@ -103,6 +105,18 @@ func newBuilderMetrics() *builderMetrics {
 
 			Help: "Total number of flush failures.",
 		}),
+
+		tenantSections: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Namespace: "loki",
+			Subsystem: "dataobj",
+			Name:      "tenant_sections",
+			Help:      "The number of sections per tenant per data object.",
+
+			Buckets:                         prometheus.DefBuckets,
+			NativeHistogramBucketFactor:     1.1,
+			NativeHistogramMaxBucketNumber:  100,
+			NativeHistogramMinResetDuration: 0,
+		}),
 	}
 }
 
@@ -130,6 +144,8 @@ func (m *builderMetrics) Register(reg prometheus.Registerer) error {
 	errs = append(errs, reg.Register(m.builtSize))
 	errs = append(errs, reg.Register(m.flushFailures))
 
+	errs = append(errs, reg.Register(m.tenantSections))
+
 	return errors.Join(errs...)
 }
 
@@ -148,4 +164,6 @@ func (m *builderMetrics) Unregister(reg prometheus.Registerer) {
 	reg.Unregister(m.sizeEstimate)
 	reg.Unregister(m.builtSize)
 	reg.Unregister(m.flushFailures)
+
+	reg.Unregister(m.tenantSections)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request hacks together a histogram to track the number of sections per tenant in each data object.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
