### PR TITLE
feat: Helm: Standardize Liveness and Readiness Probes for all Helm Chart Deployments

### DIFF
--- a/production/helm/loki/templates/admin-api/_helpers.yaml
+++ b/production/helm/loki/templates/admin-api/_helpers.yaml
@@ -22,3 +22,23 @@ adminApi selector labels
 app.kubernetes.io/component: admin-api
 target: admin-api
 {{- end }}
+
+{{/*
+adminApi readiness probe
+*/}}
+{{- define "loki.adminApi.readinessProbe" }}
+{{- with .Values.adminApi.readinessProbe | default .Values.loki.readinessProbe }}
+readinessProbe:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}
+
+{{/*
+adminApi liveness probe
+*/}}
+{{- define "loki.adminApi.livenessProbe" }}
+{{- with .Values.adminApi.livenessProbe | default .Values.loki.livenessProbe }}
+livenessProbe:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/production/helm/loki/templates/admin-api/deployment-admin-api.yaml
+++ b/production/helm/loki/templates/admin-api/deployment-admin-api.yaml
@@ -20,7 +20,7 @@ spec:
       {{- include "enterprise-logs.adminApiSelectorLabels" . | nindent 6 }}
   strategy:
     {{- toYaml .Values.adminApi.strategy | nindent 4 }}
-  revisionHistoryLimit: {{ .Values.loki.revisionHistoryLimit }}  
+  revisionHistoryLimit: {{ .Values.loki.revisionHistoryLimit }}
   template:
     metadata:
       labels:
@@ -97,14 +97,8 @@ spec:
             - name: http-memberlist
               containerPort: 7946
               protocol: TCP
-          {{- with .Values.adminApi.livenessProbe }}
-          livenessProbe:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          {{- with .Values.adminApi.readinessProbe }}
-          readinessProbe:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
+          {{- include "loki.adminApi.readinessProbe" . | nindent 10 }}
+          {{- include "loki.adminApi.livenessProbe" . | nindent 10 }}
           {{- with .Values.adminApi.startupProbe }}
           startupProbe:
             {{- toYaml . | nindent 12 }}

--- a/production/helm/loki/templates/backend/_helpers-backend.tpl
+++ b/production/helm/loki/templates/backend/_helpers-backend.tpl
@@ -30,3 +30,23 @@ backend priority class name
 priorityClassName: {{ $pcn }}
 {{- end }}
 {{- end }}
+
+{{/*
+backend readiness probe
+*/}}
+{{- define "loki.backend.readinessProbe" }}
+{{- with .Values.backend.readinessProbe | default .Values.loki.readinessProbe }}
+readinessProbe:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}
+
+{{/*
+backend liveness probe
+*/}}
+{{- define "loki.backend.livenessProbe" }}
+{{- with .Values.backend.livenessProbe | default .Values.loki.livenessProbe }}
+livenessProbe:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/production/helm/loki/templates/backend/statefulset-backend.yaml
+++ b/production/helm/loki/templates/backend/statefulset-backend.yaml
@@ -106,10 +106,8 @@ spec:
           {{- end }}
           securityContext:
             {{- toYaml .Values.loki.containerSecurityContext | nindent 12 }}
-          {{- with .Values.loki.readinessProbe }}
-          readinessProbe:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
+          {{- include "loki.backend.readinessProbe" . | nindent 10 }}
+          {{- include "loki.backend.livenessProbe" . | nindent 10 }}
           volumeMounts:
             - name: config
               mountPath: /etc/loki/config

--- a/production/helm/loki/templates/bloom-builder/_helpers-bloom-builder.tpl
+++ b/production/helm/loki/templates/bloom-builder/_helpers-bloom-builder.tpl
@@ -30,3 +30,23 @@ bloom-builder priority class name
 priorityClassName: {{ $pcn }}
 {{- end }}
 {{- end }}
+
+{{/*
+bloomBuilder readiness probe
+*/}}
+{{- define "loki.bloomBuilder.readinessProbe" }}
+{{- with .Values.bloomBuilder.readinessProbe | default .Values.loki.readinessProbe }}
+readinessProbe:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}
+
+{{/*
+bloomBuilder liveness probe
+*/}}
+{{- define "loki.bloomBuilder.livenessProbe" }}
+{{- with .Values.bloomBuilder.livenessProbe | default .Values.loki.livenessProbe }}
+livenessProbe:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/production/helm/loki/templates/bloom-builder/deployment-bloom-builder.yaml
+++ b/production/helm/loki/templates/bloom-builder/deployment-bloom-builder.yaml
@@ -87,10 +87,8 @@ spec:
           {{- end }}
           securityContext:
             {{- toYaml .Values.loki.containerSecurityContext | nindent 12 }}
-          {{- with .Values.loki.readinessProbe }}
-          readinessProbe:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
+          {{- include "loki.bloomBuilder.readinessProbe" . | nindent 10 }}
+          {{- include "loki.bloomBuilder.livenessProbe" . | nindent 10 }}
           volumeMounts:
             - name: config
               mountPath: /etc/loki/config

--- a/production/helm/loki/templates/bloom-gateway/_helpers-bloom-gateway.tpl
+++ b/production/helm/loki/templates/bloom-gateway/_helpers-bloom-gateway.tpl
@@ -32,6 +32,16 @@ readinessProbe:
 {{- end }}
 
 {{/*
+bloom gateway liveness probe
+*/}}
+{{- define "loki.bloomGateway.livenessProbe" }}
+{{- with .Values.bloomGateway.livenessProbe | default .Values.loki.livenessProbe }}
+livenessProbe:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}
+
+{{/*
 bloom gateway priority class name
 */}}
 {{- define "loki.bloomGatewayPriorityClassName" }}

--- a/production/helm/loki/templates/bloom-gateway/statefulset-bloom-gateway.yaml
+++ b/production/helm/loki/templates/bloom-gateway/statefulset-bloom-gateway.yaml
@@ -96,6 +96,7 @@ spec:
           securityContext:
             {{- toYaml .Values.loki.containerSecurityContext | nindent 12 }}
           {{- include "loki.bloomGateway.readinessProbe" . | nindent 10 }}
+          {{- include "loki.bloomGateway.livenessProbe" . | nindent 10 }}
           volumeMounts:
             - name: temp
               mountPath: /tmp

--- a/production/helm/loki/templates/bloom-planner/_helpers-bloom-planner.tpl
+++ b/production/helm/loki/templates/bloom-planner/_helpers-bloom-planner.tpl
@@ -32,6 +32,16 @@ readinessProbe:
 {{- end }}
 
 {{/*
+bloom planner liveness probe
+*/}}
+{{- define "loki.bloomPlanner.livenessProbe" }}
+{{- with .Values.bloomPlanner.livenessProbe | default .Values.loki.livenessProbe }}
+livenessProbe:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}
+
+{{/*
 bloom planner priority class name
 */}}
 {{- define "loki.bloomPlannerPriorityClassName" }}

--- a/production/helm/loki/templates/bloom-planner/statefulset-bloom-planner.yaml
+++ b/production/helm/loki/templates/bloom-planner/statefulset-bloom-planner.yaml
@@ -96,6 +96,7 @@ spec:
           securityContext:
             {{- toYaml .Values.loki.containerSecurityContext | nindent 12 }}
           {{- include "loki.bloomPlanner.readinessProbe" . | nindent 10 }}
+          {{- include "loki.bloomPlanner.livenessProbe" . | nindent 10 }}
           volumeMounts:
             - name: temp
               mountPath: /tmp

--- a/production/helm/loki/templates/distributor/_helpers-distributor.tpl
+++ b/production/helm/loki/templates/distributor/_helpers-distributor.tpl
@@ -30,3 +30,23 @@ distributor priority class name
 priorityClassName: {{ $pcn }}
 {{- end }}
 {{- end }}
+
+{{/*
+distributor readiness probe
+*/}}
+{{- define "loki.distributor.readinessProbe" }}
+{{- with .Values.distributor.readinessProbe | default .Values.loki.readinessProbe }}
+readinessProbe:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}
+
+{{/*
+distributor liveness probe
+*/}}
+{{- define "loki.distributor.livenessProbe" }}
+{{- with .Values.distributor.livenessProbe | default .Values.loki.livenessProbe }}
+livenessProbe:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/production/helm/loki/templates/distributor/deployment-distributor.yaml
+++ b/production/helm/loki/templates/distributor/deployment-distributor.yaml
@@ -101,14 +101,8 @@ spec:
           {{- end }}
           securityContext:
             {{- toYaml .Values.loki.containerSecurityContext | nindent 12 }}
-          {{- with .Values.loki.livenessProbe }}
-          livenessProbe:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          {{- with .Values.loki.readinessProbe }}
-          readinessProbe:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
+          {{- include "loki.distributor.readinessProbe" . | nindent 10 }}
+          {{- include "loki.distributor.livenessProbe" . | nindent 10 }}
           volumeMounts:
             - name: config
               mountPath: /etc/loki/config

--- a/production/helm/loki/templates/gateway/deployment-gateway-nginx.yaml
+++ b/production/helm/loki/templates/gateway/deployment-gateway-nginx.yaml
@@ -71,6 +71,8 @@ spec:
           {{- end }}
           readinessProbe:
             {{- toYaml .Values.gateway.readinessProbe | nindent 12 }}
+          livenessProbe:
+            {{- toYaml .Values.gateway.livenessProbe | nindent 12 }}
           securityContext:
             {{- toYaml .Values.gateway.containerSecurityContext | nindent 12 }}
           {{- with .Values.gateway.lifecycle }}

--- a/production/helm/loki/templates/index-gateway/_helpers-index-gateway.tpl
+++ b/production/helm/loki/templates/index-gateway/_helpers-index-gateway.tpl
@@ -38,3 +38,23 @@ index-gateway priority class name
 priorityClassName: {{ $pcn }}
 {{- end }}
 {{- end }}
+
+{{/*
+indexGateway readiness probe
+*/}}
+{{- define "loki.indexGateway.readinessProbe" }}
+{{- with .Values.indexGateway.readinessProbe | default .Values.loki.readinessProbe }}
+readinessProbe:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}
+
+{{/*
+indexGateway liveness probe
+*/}}
+{{- define "loki.indexGateway.livenessProbe" }}
+{{- with .Values.indexGateway.livenessProbe | default .Values.loki.livenessProbe }}
+livenessProbe:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/production/helm/loki/templates/index-gateway/statefulset-index-gateway.yaml
+++ b/production/helm/loki/templates/index-gateway/statefulset-index-gateway.yaml
@@ -99,14 +99,8 @@ spec:
           {{- end }}
           securityContext:
             {{- toYaml .Values.loki.containerSecurityContext | nindent 12 }}
-          {{- with .Values.loki.livenessProbe }}
-          livenessProbe:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          {{- with .Values.loki.readinessProbe }}
-          readinessProbe:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
+          {{- include "loki.indexGateway.readinessProbe" . | nindent 10 }}
+          {{- include "loki.indexGateway.livenessProbe" . | nindent 10 }}
           volumeMounts:
             - name: config
               mountPath: /etc/loki/config

--- a/production/helm/loki/templates/overrides-exporter/_helpers-overrides-exporter.tpl
+++ b/production/helm/loki/templates/overrides-exporter/_helpers-overrides-exporter.tpl
@@ -30,3 +30,23 @@ overrides-exporter priority class name
 priorityClassName: {{ $pcn }}
 {{- end }}
 {{- end }}
+
+{{/*
+overridesExporter readiness probe
+*/}}
+{{- define "loki.overridesExporter.readinessProbe" }}
+{{- with .Values.overridesExporter.readinessProbe | default .Values.loki.readinessProbe }}
+readinessProbe:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}
+
+{{/*
+overridesExporter liveness probe
+*/}}
+{{- define "loki.overridesExporter.livenessProbe" }}
+{{- with .Values.overridesExporter.livenessProbe | default .Values.loki.livenessProbe }}
+livenessProbe:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/production/helm/loki/templates/overrides-exporter/deployment-overrides-exporter.yaml
+++ b/production/helm/loki/templates/overrides-exporter/deployment-overrides-exporter.yaml
@@ -91,10 +91,8 @@ spec:
           {{- end }}
           securityContext:
             {{- toYaml .Values.loki.containerSecurityContext | nindent 12 }}
-          {{- with .Values.loki.readinessProbe }}
-          readinessProbe:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
+          {{- include "loki.overridesExporter.readinessProbe" . | nindent 10 }}
+          {{- include "loki.overridesExporter.livenessProbe" . | nindent 10 }}
           volumeMounts:
             - name: config
               mountPath: /etc/loki/config

--- a/production/helm/loki/templates/pattern-ingester/_helpers-pattern-ingester.tpl
+++ b/production/helm/loki/templates/pattern-ingester/_helpers-pattern-ingester.tpl
@@ -32,6 +32,16 @@ readinessProbe:
 {{- end }}
 
 {{/*
+pattern ingester liveness probe
+*/}}
+{{- define "loki.patternIngester.livenessProbe" }}
+{{- with .Values.patternIngester.livenessProbe | default .Values.loki.livenessProbe }}
+livenessProbe:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}
+
+{{/*
 pattern ingester priority class name
 */}}
 {{- define "loki.patternIngesterPriorityClassName" }}

--- a/production/helm/loki/templates/pattern-ingester/statefulset-pattern-ingester.yaml
+++ b/production/helm/loki/templates/pattern-ingester/statefulset-pattern-ingester.yaml
@@ -97,6 +97,7 @@ spec:
           securityContext:
             {{- toYaml .Values.loki.containerSecurityContext | nindent 12 }}
           {{- include "loki.patternIngester.readinessProbe" . | nindent 10 }}
+          {{- include "loki.patternIngester.livenessProbe" . | nindent 10 }}
           volumeMounts:
             - name: temp
               mountPath: /tmp

--- a/production/helm/loki/templates/querier/_helpers-querier.tpl
+++ b/production/helm/loki/templates/querier/_helpers-querier.tpl
@@ -30,3 +30,23 @@ querier priority class name
 priorityClassName: {{ $pcn }}
 {{- end }}
 {{- end }}
+
+{{/*
+querier readiness probe
+*/}}
+{{- define "loki.querier.readinessProbe" }}
+{{- with .Values.querier.readinessProbe | default .Values.loki.readinessProbe }}
+readinessProbe:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}
+
+{{/*
+querier liveness probe
+*/}}
+{{- define "loki.querier.livenessProbe" }}
+{{- with .Values.querier.livenessProbe | default .Values.loki.livenessProbe }}
+livenessProbe:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/production/helm/loki/templates/querier/deployment-querier.yaml
+++ b/production/helm/loki/templates/querier/deployment-querier.yaml
@@ -101,14 +101,8 @@ spec:
           {{- end }}
           securityContext:
             {{- toYaml .Values.loki.containerSecurityContext | nindent 12 }}
-          {{- with .Values.loki.livenessProbe }}
-          livenessProbe:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          {{- with .Values.loki.readinessProbe }}
-          readinessProbe:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
+          {{- include "loki.querier.readinessProbe" . | nindent 10 }}
+          {{- include "loki.querier.livenessProbe" . | nindent 10 }}
           volumeMounts:
             - name: config
               mountPath: /etc/loki/config

--- a/production/helm/loki/templates/query-frontend/_helpers-query-frontend.tpl
+++ b/production/helm/loki/templates/query-frontend/_helpers-query-frontend.tpl
@@ -30,3 +30,23 @@ query-frontend priority class name
 priorityClassName: {{ $pcn }}
 {{- end }}
 {{- end }}
+
+{{/*
+queryFrontend readiness probe
+*/}}
+{{- define "loki.queryFrontend.readinessProbe" }}
+{{- with .Values.queryFrontend.readinessProbe | default .Values.loki.readinessProbe }}
+readinessProbe:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}
+
+{{/*
+queryFrontend liveness probe
+*/}}
+{{- define "loki.queryFrontend.livenessProbe" }}
+{{- with .Values.queryFrontend.livenessProbe | default .Values.loki.livenessProbe }}
+livenessProbe:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/production/helm/loki/templates/query-frontend/deployment-query-frontend.yaml
+++ b/production/helm/loki/templates/query-frontend/deployment-query-frontend.yaml
@@ -93,10 +93,8 @@ spec:
           {{- end }}
           securityContext:
             {{- toYaml .Values.loki.containerSecurityContext | nindent 12 }}
-          {{- with .Values.loki.readinessProbe }}
-          readinessProbe:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
+          {{- include "loki.queryFrontend.readinessProbe" . | nindent 10 }}
+          {{- include "loki.queryFrontend.livenessProbe" . | nindent 10 }}
           volumeMounts:
             - name: config
               mountPath: /etc/loki/config

--- a/production/helm/loki/templates/query-scheduler/_helpers-query-scheduler.tpl
+++ b/production/helm/loki/templates/query-scheduler/_helpers-query-scheduler.tpl
@@ -38,3 +38,23 @@ query-scheduler priority class name
 priorityClassName: {{ $pcn }}
 {{- end }}
 {{- end }}
+
+{{/*
+queryScheduler readiness probe
+*/}}
+{{- define "loki.queryScheduler.readinessProbe" }}
+{{- with .Values.queryScheduler.readinessProbe | default .Values.loki.readinessProbe }}
+readinessProbe:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}
+
+{{/*
+queryScheduler liveness probe
+*/}}
+{{- define "loki.queryScheduler.livenessProbe" }}
+{{- with .Values.queryScheduler.livenessProbe | default .Values.loki.livenessProbe }}
+livenessProbe:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/production/helm/loki/templates/query-scheduler/deployment-query-scheduler.yaml
+++ b/production/helm/loki/templates/query-scheduler/deployment-query-scheduler.yaml
@@ -87,14 +87,8 @@ spec:
           {{- end }}
           securityContext:
             {{- toYaml .Values.loki.containerSecurityContext | nindent 12 }}
-          {{- with .Values.loki.livenessProbe }}
-          livenessProbe:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          {{- with .Values.loki.readinessProbe }}
-          readinessProbe:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
+          {{- include "loki.queryScheduler.readinessProbe" . | nindent 10 }}
+          {{- include "loki.queryScheduler.livenessProbe" . | nindent 10 }}
           volumeMounts:
             - name: config
               mountPath: /etc/loki/config

--- a/production/helm/loki/templates/read/_helpers-read.tpl
+++ b/production/helm/loki/templates/read/_helpers-read.tpl
@@ -30,3 +30,23 @@ read priority class name
 priorityClassName: {{ $pcn }}
 {{- end }}
 {{- end }}
+
+{{/*
+read readiness probe
+*/}}
+{{- define "loki.read.readinessProbe" }}
+{{- with .Values.read.readinessProbe | default .Values.loki.readinessProbe }}
+readinessProbe:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}
+
+{{/*
+read liveness probe
+*/}}
+{{- define "loki.read.livenessProbe" }}
+{{- with .Values.read.livenessProbe | default .Values.loki.livenessProbe }}
+livenessProbe:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/production/helm/loki/templates/read/deployment-read.yaml
+++ b/production/helm/loki/templates/read/deployment-read.yaml
@@ -95,14 +95,8 @@ spec:
           {{- end }}
           securityContext:
             {{- toYaml .Values.loki.containerSecurityContext | nindent 12 }}
-          {{- with .Values.loki.readinessProbe }}
-          readinessProbe:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          {{- if .Values.read.livenessProbe }}
-          livenessProbe:
-            {{- toYaml .Values.read.livenessProbe | nindent 12 }}
-          {{- end }}
+          {{- include "loki.read.readinessProbe" . | nindent 10 }}
+          {{- include "loki.read.livenessProbe" . | nindent 10 }}
           volumeMounts:
             - name: config
               mountPath: /etc/loki/config

--- a/production/helm/loki/templates/read/statefulset-read.yaml
+++ b/production/helm/loki/templates/read/statefulset-read.yaml
@@ -102,14 +102,8 @@ spec:
           {{- end }}
           securityContext:
             {{- toYaml .Values.loki.containerSecurityContext | nindent 12 }}
-          {{- with .Values.loki.readinessProbe }}
-          readinessProbe:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          {{- if .Values.read.livenessProbe }}
-          livenessProbe:
-            {{- toYaml .Values.read.livenessProbe | nindent 12 }}
-          {{- end }}
+          {{- include "loki.read.readinessProbe" . | nindent 10 }}
+          {{- include "loki.read.livenessProbe" . | nindent 10 }}
           {{- with .Values.read.lifecycle }}
           lifecycle:
             {{- toYaml . | nindent 12 }}

--- a/production/helm/loki/templates/ruler/_helpers-ruler.tpl
+++ b/production/helm/loki/templates/ruler/_helpers-ruler.tpl
@@ -45,3 +45,23 @@ ruler priority class name
 priorityClassName: {{ $pcn }}
 {{- end }}
 {{- end }}
+
+{{/*
+ruler readiness probe
+*/}}
+{{- define "loki.ruler.readinessProbe" }}
+{{- with .Values.ruler.readinessProbe | default .Values.loki.readinessProbe }}
+readinessProbe:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}
+
+{{/*
+ruler liveness probe
+*/}}
+{{- define "loki.ruler.livenessProbe" }}
+{{- with .Values.ruler.livenessProbe | default .Values.loki.livenessProbe }}
+livenessProbe:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/production/helm/loki/templates/ruler/statefulset-ruler.yaml
+++ b/production/helm/loki/templates/ruler/statefulset-ruler.yaml
@@ -90,10 +90,8 @@ spec:
           {{- end }}
           securityContext:
             {{- toYaml .Values.loki.containerSecurityContext | nindent 12 }}
-          {{- with .Values.loki.readinessProbe }}
-          readinessProbe:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
+          {{- include "loki.ruler.readinessProbe" . | nindent 10 }}
+          {{- include "loki.ruler.livenessProbe" . | nindent 10 }}
           volumeMounts:
             - name: config
               mountPath: /etc/loki/config

--- a/production/helm/loki/templates/single-binary/_helpers-single-binary.tpl
+++ b/production/helm/loki/templates/single-binary/_helpers-single-binary.tpl
@@ -23,6 +23,26 @@ priorityClassName: {{ $pcn }}
 {{- end }}
 {{- end }}
 
+{{/*
+singleBinary readiness probe
+*/}}
+{{- define "loki.singleBinary.readinessProbe" }}
+{{- with .Values.singleBinary.readinessProbe | default .Values.loki.readinessProbe }}
+readinessProbe:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}
+
+{{/*
+singleBinary liveness probe
+*/}}
+{{- define "loki.singleBinary.livenessProbe" }}
+{{- with .Values.singleBinary.livenessProbe | default .Values.loki.livenessProbe }}
+livenessProbe:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}
+
 {{/* singleBinary replicas calculation */}}
 {{- define "loki.singleBinaryReplicas" -}}
 {{- $replicas := 1 }}

--- a/production/helm/loki/templates/single-binary/statefulset.yaml
+++ b/production/helm/loki/templates/single-binary/statefulset.yaml
@@ -109,10 +109,8 @@ spec:
           {{- end }}
           securityContext:
             {{- toYaml .Values.loki.containerSecurityContext | nindent 12 }}
-          {{- with .Values.loki.readinessProbe }}
-          readinessProbe:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
+          {{- include "loki.singleBinary.readinessProbe" . | nindent 10 }}
+          {{- include "loki.singleBinary.livenessProbe" . | nindent 10 }}
           volumeMounts:
             - name: tmp
               mountPath: /tmp

--- a/production/helm/loki/templates/table-manager/_helpers-table-manager.tpl
+++ b/production/helm/loki/templates/table-manager/_helpers-table-manager.tpl
@@ -30,3 +30,23 @@ table-manager priority class name
 priorityClassName: {{ $pcn }}
 {{- end }}
 {{- end }}
+
+{{/*
+table-manager readiness probe
+*/}}
+{{- define "loki.tableManager.readinessProbe" }}
+{{- with .Values.tableManager.readinessProbe | default .Values.loki.readinessProbe }}
+readinessProbe:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}
+
+{{/*
+table-manager liveness probe
+*/}}
+{{- define "loki.tableManager.livenessProbe" }}
+{{- with .Values.tableManager.livenessProbe | default .Values.loki.livenessProbe }}
+livenessProbe:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/production/helm/loki/templates/table-manager/deployment-table-manager.yaml
+++ b/production/helm/loki/templates/table-manager/deployment-table-manager.yaml
@@ -73,14 +73,8 @@ spec:
           {{- end }}
           securityContext:
             {{- toYaml .Values.loki.containerSecurityContext | nindent 12 }}
-          {{- with .Values.loki.livenessProbe }}
-          livenessProbe:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          {{- with .Values.loki.readinessProbe }}
-          readinessProbe:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
+          {{- include "loki.tableManager.readinessProbe" . | nindent 10 }}
+          {{- include "loki.tableManager.livenessProbe" . | nindent 10 }}
           volumeMounts:
             - name: config
               mountPath: /etc/loki/config

--- a/production/helm/loki/templates/write/_helpers-write.tpl
+++ b/production/helm/loki/templates/write/_helpers-write.tpl
@@ -30,3 +30,23 @@ write priority class name
 priorityClassName: {{ $pcn }}
 {{- end }}
 {{- end }}
+
+{{/*
+write readiness probe
+*/}}
+{{- define "loki.write.readinessProbe" }}
+{{- with .Values.write.readinessProbe | default .Values.loki.readinessProbe }}
+readinessProbe:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}
+
+{{/*
+write liveness probe
+*/}}
+{{- define "loki.write.livenessProbe" }}
+{{- with .Values.write.livenessProbe | default .Values.loki.livenessProbe }}
+livenessProbe:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/production/helm/loki/templates/write/statefulset-write.yaml
+++ b/production/helm/loki/templates/write/statefulset-write.yaml
@@ -108,10 +108,8 @@ spec:
           {{- end }}
           securityContext:
             {{- toYaml .Values.loki.containerSecurityContext | nindent 12 }}
-          {{- with .Values.loki.readinessProbe }}
-          readinessProbe:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
+          {{- include "loki.write.readinessProbe" . | nindent 10 }}
+          {{- include "loki.write.livenessProbe" . | nindent 10 }}
           {{- if .Values.write.lifecycle }}
           lifecycle:
             {{- toYaml .Values.write.lifecycle | nindent 12 }}

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -1238,6 +1238,7 @@ gateway:
       port: http-metrics
     initialDelaySeconds: 15
     timeoutSeconds: 1
+  livenessProbe: {}
   nginxConfig:
     # -- Which schema to be used when building URLs. Can be 'http' or 'https'.
     schema: http
@@ -1494,6 +1495,10 @@ singleBinary:
   extraVolumes: []
   # -- Resource requests and limits for the single binary
   resources: {}
+  # -- readiness probe settings for single binary pods. If empty, use `loki.readinessProbe`
+  readinessProbe: {}
+  # -- liveness probe settings for single binary pods. If empty use `loki.livenessProbe`
+  livenessProbe: {}
   # -- Grace period to allow the single binary to shutdown before it is killed
   terminationGracePeriodSeconds: 30
   # -- Affinity for single binary pods.
@@ -1616,6 +1621,10 @@ write:
   extraVolumeClaimTemplates: []
   # -- Resource requests and limits for the write
   resources: {}
+  # -- readiness probe settings for write pods. If empty, use `loki.readinessProbe`
+  readinessProbe: {}
+  # -- liveness probe settings for write pods. If empty use `loki.livenessProbe`
+  livenessProbe: {}
   # -- Grace period to allow the write to shutdown before it is killed. Especially for the ingester,
   # this must be increased. It must be long enough so writes can be gracefully shutdown flushing/transferring
   # all data and to successfully leave the member ring on shutdown.
@@ -1734,6 +1743,8 @@ read:
   extraVolumes: []
   # -- Resource requests and limits for the read
   resources: {}
+  # -- readiness probe settings for read pods. If empty, use `loki.readinessProbe`
+  readinessProbe: {}
   # -- liveness probe settings for read pods. If empty, applies no livenessProbe
   livenessProbe: {}
   # -- Grace period to allow the read to shutdown before it is killed
@@ -1844,6 +1855,10 @@ backend:
   extraVolumes: []
   # -- Resource requests and limits for the backend
   resources: {}
+  # -- readiness probe settings for backend pods. If empty, use `loki.readinessProbe`
+  readinessProbe: {}
+  # -- liveness probe settings for backend pods. If empty use `loki.livenessProbe`
+  livenessProbe: {}
   # -- Grace period to allow the backend to shutdown before it is killed. Especially for the ingester,
   # this must be increased. It must be long enough so backends can be gracefully shutdown flushing/transferring
   # all data and to successfully leave the member ring on shutdown.
@@ -2156,6 +2171,10 @@ distributor:
   extraVolumes: []
   # -- Resource requests and limits for the distributor
   resources: {}
+  # -- readiness probe settings for distributor pods. If empty, use `loki.readinessProbe`
+  readinessProbe: {}
+  # -- liveness probe settings for distributor pods. If empty use `loki.livenessProbe`
+  livenessProbe: {}
   # -- Containers to add to the distributor pods
   extraContainers: []
   # -- Grace period to allow the distributor to shutdown before it is killed
@@ -2252,6 +2271,10 @@ querier:
   extraVolumes: []
   # -- Resource requests and limits for the querier
   resources: {}
+  # -- readiness probe settings for querier pods. If empty, use `loki.readinessProbe`
+  readinessProbe: {}
+  # -- liveness probe settings for querier pods. If empty use `loki.livenessProbe`
+  livenessProbe: {}
   # -- Containers to add to the querier pods
   extraContainers: []
   # -- Init containers to add to the querier pods
@@ -2357,6 +2380,10 @@ queryFrontend:
   extraVolumes: []
   # -- Resource requests and limits for the query-frontend
   resources: {}
+  # -- readiness probe settings for query-frontend pods. If empty, use `loki.readinessProbe`
+  readinessProbe: {}
+  # -- liveness probe settings for query-frontend pods. If empty use `loki.livenessProbe`
+  livenessProbe: {}
   # -- Containers to add to the query-frontend pods
   extraContainers: []
   # -- Grace period to allow the query-frontend to shutdown before it is killed
@@ -2422,6 +2449,10 @@ queryScheduler:
   extraVolumes: []
   # -- Resource requests and limits for the query-scheduler
   resources: {}
+  # -- readiness probe settings for query-scheduler pods. If empty, use `loki.readinessProbe`
+  readinessProbe: {}
+  # -- liveness probe settings for query-scheduler pods. If empty use `loki.livenessProbe`
+  livenessProbe: {}
   # -- Containers to add to the query-scheduler pods
   extraContainers: []
   # -- Grace period to allow the query-scheduler to shutdown before it is killed
@@ -2486,6 +2517,10 @@ indexGateway:
   extraVolumes: []
   # -- Resource requests and limits for the index-gateway
   resources: {}
+  # -- readiness probe settings for index-gateway pods. If empty, use `loki.readinessProbe`
+  readinessProbe: {}
+  # -- liveness probe settings for index-gateway pods. If empty use `loki.livenessProbe`
+  livenessProbe: {}
   # -- Containers to add to the index-gateway pods
   extraContainers: []
   # -- Init containers to add to the index-gateway pods
@@ -2919,6 +2954,10 @@ bloomBuilder:
   extraVolumes: []
   # -- Resource requests and limits for the bloom-builder
   resources: {}
+  # -- readiness probe settings for bloom-builder pods. If empty, use `loki.readinessProbe`
+  readinessProbe: {}
+  # -- liveness probe settings for bloom-builder pods. If empty use `loki.livenessProbe`
+  livenessProbe: {}
   # -- Containers to add to the bloom-builder pods
   extraContainers: []
   # -- Grace period to allow the bloom-builder to shutdown before it is killed
@@ -3100,6 +3139,10 @@ ruler:
   extraVolumes: []
   # -- Resource requests and limits for the ruler
   resources: {}
+  # -- readiness probe settings for ruler pods. If empty, use `loki.readinessProbe`
+  readinessProbe: {}
+  # -- liveness probe settings for ruler pods. If empty use `loki.livenessProbe`
+  livenessProbe: {}
   # -- Containers to add to the ruler pods
   extraContainers: []
   # -- Init containers to add to the ruler pods
@@ -3252,6 +3295,10 @@ overridesExporter:
   extraVolumes: []
   # -- Resource requests and limits for the overrides-exporter
   resources: {}
+  # -- readiness probe settings for overrides-exporter pods. If empty, use `loki.readinessProbe`
+  readinessProbe: {}
+  # -- liveness probe settings for overrides-exporter pods. If empty use `loki.livenessProbe`
+  livenessProbe: {}
   # -- Containers to add to the overrides-exporter pods
   extraContainers: []
   # -- Init containers to add to the overrides-exporter pods
@@ -4039,6 +4086,10 @@ tableManager:
   extraVolumes: []
   # -- Resource requests and limits for the table-manager
   resources: {}
+  # -- readiness probe settings for table-manager pods. If empty, use `loki.readinessProbe`
+  readinessProbe: {}
+  # -- liveness probe settings for table-manager pods. If empty use `loki.livenessProbe`
+  livenessProbe: {}
   # -- Containers to add to the table-manager pods
   extraContainers: []
   # -- Grace period to allow the table-manager to shutdown before it is killed


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR standardizes the configuration for liveness probes and readiness probes for all deployments using the helm chart.

This includes adding a liveness probe configuration option for the following components:
- backend
- bloom-builder
- bloom-gateway
- bloom-planner
- gateway-nginx
- overrides-exporter
- pattern-ingester
- query-frontend
- ruler
- single-binary
- write

**Which issue(s) this PR fixes**:
Fixes #[13967]

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
