### PR TITLE
fix(helm): Fix incorrect context references in Helm storage templates

### DIFF
--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -13,6 +13,8 @@ Entries should include a reference to the pull request that introduced the chang
 
 [//]: # (<AUTOMATED_UPDATES_LOCATOR> : do not remove this line. This locator is used by the CI pipeline to automatically create a changelog entry for each new Loki release. Add other chart versions and respective changelog entries bellow this line.)
 
+- [BUGFIX] Fix incorrect context references in storage configuration templates for alibabacloud, swift, bos, and cos storage types.
+  
 ## 6.35.0
 
 - [CHANGE] Add `tpl()` support for `pattern_ingester`, `ingester_client` and `compactor_grpc_client` components. [#16759](https://github.com/grafana/loki/pull/16759)

--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -13,7 +13,7 @@ Entries should include a reference to the pull request that introduced the chang
 
 [//]: # (<AUTOMATED_UPDATES_LOCATOR> : do not remove this line. This locator is used by the CI pipeline to automatically create a changelog entry for each new Loki release. Add other chart versions and respective changelog entries bellow this line.)
 
-- [BUGFIX] Fix incorrect context references in storage configuration templates for alibabacloud, swift, bos, and cos storage types.
+- [BUGFIX] Fix incorrect context references in storage configuration templates for alibabacloud, swift, bos, and cos storage types. [#18740](https://github.com/grafana/loki/pull/18740)
   
 ## 6.35.0
 

--- a/production/helm/loki/templates/_helpers.tpl
+++ b/production/helm/loki/templates/_helpers.tpl
@@ -217,12 +217,15 @@ filesystem:
 Storage config for ruler
 */}}
 {{- define "loki.rulerStorageConfig" -}}
-{{- if .Values.minio.enabled -}}
+{{- if .Values.loki.storage.use_thanos_objstore -}}
+type: {{ .Values.loki.storage.object_store.type | quote }}
+{{- include "loki.thanosStorageConfig" (dict "ctx" . "bucketName" .Values.loki.storage.bucketNames.ruler) | nindent 0 }}
+{{- else if .Values.minio.enabled -}}
 type: "s3"
 s3:
   bucketnames: ruler
 {{- else if (eq (include "loki.isUsingObjectStorage" . ) "true") }}
-type: {{ .Values.loki.storage.object_store.type | quote }}
+type: {{ .Values.loki.storage.type | quote }}
 {{- include "loki.lokiStorageConfig" (dict "ctx" . "bucketName" .Values.loki.storage.bucketNames.ruler) | nindent 0 }}
 {{- else }}
 type: "local"
@@ -244,8 +247,8 @@ gcs:
 {{- else if eq .ctx.Values.loki.storage.type "azure" -}}
 azure:
 {{- include "loki.lokiStorageConfig.azure" (dict "ctx" .ctx.Values.loki.storage.azure "bucketName" $bucketName) | nindent 2 }}
-{{- else if eq .ctx.ctx.Values.loki.storage.type "alibabacloud" -}}
-{{- with .ctx.ctx.Values.loki.storage.alibabacloud }}
+{{- else if eq .ctx.Values.loki.storage.type "alibabacloud" -}}
+{{- with .ctx.Values.loki.storage.alibabacloud }}
 alibabacloud:
   {{- toYaml (mergeOverwrite dict
     (dict
@@ -256,19 +259,19 @@ alibabacloud:
     (omit . "bucket" "accessKeyId" "secretAccessKey")
   ) | nindent 2 }}
 {{- end -}}
-{{- else if eq .ctx.ctx.Values.loki.storage.type "swift" -}}
+{{- else if eq .ctx.Values.loki.storage.type "swift" -}}
 {{- with .ctx.Values.loki.storage.swift }}
 swift:
   container_name: {{ $bucketName }}
 {{- toYaml (omit . "container_name") | nindent 2 }}
 {{- end -}}
-{{- else if eq .ctx.ctx.Values.loki.storage.type "bos" -}}
+{{- else if eq .ctx.Values.loki.storage.type "bos" -}}
 {{- with .ctx.Values.loki.storage.bos }}
 bos:
   bucket_name: {{ $bucketName }}
 {{- toYaml (omit . "bucketName") | nindent 2 }}
 {{- end -}}
-{{- else if eq .ctx.ctx.Values.loki.storage.type "cos" -}}
+{{- else if eq .ctx.Values.loki.storage.type "cos" -}}
 {{- with .ctx.Values.loki.storage.cos }}
 cos:
   bucketnames: {{ $bucketName }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Problem: 
The Helm template _helpers.tpl contained incorrect context references (.ctx.ctx.Values) for several storage types that would cause template rendering failures.

Solution: Fixed context references from .ctx.ctx.Values to .ctx.Values for:
alibabacloud storage type
swift storage type
bos storage type
cos storage type


**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
