### PR TITLE
chore(engine): propagate batch and page cache size down to streamsView

### DIFF
--- a/pkg/engine/executor/dataobjscan.go
+++ b/pkg/engine/executor/dataobjscan.go
@@ -107,6 +107,8 @@ func (s *dataobjScan) initStreams() error {
 	s.streams = newStreamsView(s.opts.StreamsSection, &streamsViewOptions{
 		StreamIDs:    s.opts.StreamIDs,
 		LabelColumns: columnsToRead,
+		BatchSize:    int(s.opts.BatchSize),
+		CacheSize:    s.opts.CacheSize,
 	})
 
 	s.streamsInjector = newStreamInjector(s.opts.Allocator, s.streams)

--- a/pkg/engine/executor/streams_view.go
+++ b/pkg/engine/executor/streams_view.go
@@ -80,6 +80,7 @@ func newStreamsView(sec *streams.Section, opts *streamsViewOptions) *streamsView
 		idColumn:      streamsIDColumn,
 		searchColumns: append([]*streams.Column{streamsIDColumn}, cols...),
 		batchSize:     opts.BatchSize,
+		pageCacheSize: opts.CacheSize,
 	}
 }
 


### PR DESCRIPTION
DataObjScan wasn't setting the batch and page cache size on newStreamsView, which meant that:

* streamsView always read in batches of 128 rows, and
* streamsView always only downloaded pages on demand, with no downloads in advance.

In my testing, properly passing down these settings makes a DataObjScan complete 15% faster when setting the batch size large enough to download the entire section. The performance difference is minimal for the streams section since they typically have far fewer pages per column, requiring fewer on-demand roundtrips.