### PR TITLE
chore(tools): Add rate store standalone tool

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -2893,6 +2893,10 @@ rate_store:
   # CLI flag: -distributor.rate-store.ingester-request-timeout
   [ingester_request_timeout: <duration> | default = 500ms]
 
+  # The duration for which a rate is kept alive
+  # CLI flag: -distributor.rate-store.rate-keep-alive
+  [rate_keep_alive: <duration> | default = 10m]
+
   # If enabled, detailed logs and spans will be emitted.
   # CLI flag: -distributor.rate-store.debug
   [debug: <boolean> | default = false]

--- a/pkg/distributor/ratestore_metrics.go
+++ b/pkg/distributor/ratestore_metrics.go
@@ -20,55 +20,60 @@ type ratestoreMetrics struct {
 	refreshDuration     *instrument.HistogramCollector
 }
 
-func newRateStoreMetrics(reg prometheus.Registerer) *ratestoreMetrics {
+func newRateStoreMetrics(reg prometheus.Registerer, standalone bool) *ratestoreMetrics {
+	prefix := "rate_store"
+	if standalone {
+		prefix = "rate_store_standalone"
+	}
+
 	return &ratestoreMetrics{
 		rateRefreshFailures: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Namespace: constants.Loki,
-			Name:      "rate_store_refresh_failures_total",
+			Name:      prefix + "_refresh_failures_total",
 			Help:      "The total number of failed attempts to refresh the distributor's view of stream rates",
 		}, []string{"source"}),
 		streamCount: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
 			Namespace: constants.Loki,
-			Name:      "rate_store_streams",
+			Name:      prefix + "_streams",
 			Help:      "The number of unique streams reported by all ingesters. Sharded streams are combined",
 		}),
 		expiredCount: promauto.With(reg).NewCounter(prometheus.CounterOpts{
 			Namespace: constants.Loki,
-			Name:      "rate_store_expired_streams_total",
+			Name:      prefix + "_expired_streams_total",
 			Help:      "The number of streams that have been expired by the ratestore",
 		}),
 		maxStreamShardCount: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
 			Namespace: constants.Loki,
-			Name:      "rate_store_max_stream_shards",
+			Name:      prefix + "_max_stream_shards",
 			Help:      "The number of shards for a single stream reported by ingesters during a sync operation.",
 		}),
 		streamShardCount: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
 			Namespace: constants.Loki,
-			Name:      "rate_store_stream_shards",
+			Name:      prefix + "_stream_shards",
 			Help:      "The distribution of number of shards for a single stream reported by ingesters during a sync operation.",
 			Buckets:   []float64{0, 1, 2, 4, 8, 16, 32, 64, 128},
 		}),
 		maxStreamRate: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
 			Namespace: constants.Loki,
-			Name:      "rate_store_max_stream_rate_bytes",
+			Name:      prefix + "_max_stream_rate_bytes",
 			Help:      "The maximum stream rate for any stream reported by ingesters during a sync operation. Sharded Streams are combined.",
 		}),
 		streamRate: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
 			Namespace: constants.Loki,
-			Name:      "rate_store_stream_rate_bytes",
+			Name:      prefix + "_stream_rate_bytes",
 			Help:      "The distribution of stream rates for any stream reported by ingesters during a sync operation. Sharded Streams are combined.",
 			Buckets:   prometheus.ExponentialBuckets(20000, 2, 14), // biggest bucket is 20000*2^(14-1) = 163,840,000 (~163.84MB)
 		}),
 		maxUniqueStreamRate: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
 			Namespace: constants.Loki,
-			Name:      "rate_store_max_unique_stream_rate_bytes",
+			Name:      prefix + "_max_unique_stream_rate_bytes",
 			Help:      "The maximum stream rate for any stream reported by ingesters during a sync operation. Sharded Streams are considered separate.",
 		}),
 		refreshDuration: instrument.NewHistogramCollector(
 			promauto.With(reg).NewHistogramVec(
 				prometheus.HistogramOpts{
 					Namespace: constants.Loki,
-					Name:      "rate_store_refresh_duration_seconds",
+					Name:      prefix + "_refresh_duration_seconds",
 					Help:      "Time spent refreshing the rate store",
 					Buckets:   prometheus.DefBuckets,
 				}, instrument.HistogramCollectorBuckets,

--- a/pkg/distributor/ratestore_test.go
+++ b/pkg/distributor/ratestore_test.go
@@ -257,14 +257,14 @@ func BenchmarkRateStore(b *testing.B) {
 	}
 }
 
-func requireRatesAndPushesEqual(t *testing.T, expectedRate int64, expectedPushes float64, r *rateStore, tenant string, streamhash uint64) {
+func requireRatesAndPushesEqual(t *testing.T, expectedRate int64, expectedPushes float64, r *RateStoreService, tenant string, streamhash uint64) {
 	actualRate, actualPushes := r.RateFor(tenant, streamhash)
 	require.Equal(t, expectedRate, actualRate)
 	require.Equal(t, expectedPushes, actualPushes)
 }
 
 func BenchmarkAggregateByShard(b *testing.B) {
-	rs := &rateStore{rates: make(map[string]map[uint64]expiringRate)}
+	rs := &RateStoreService{rates: make(map[string]map[uint64]expiringRate)}
 	rates := make(map[string]map[uint64]*logproto.StreamRate)
 	rates["fake"] = make(map[uint64]*logproto.StreamRate)
 	for i := 0; i < 1000; i++ {
@@ -357,13 +357,13 @@ func (c *fakeOverrides) ShardStreams(_ string) shardstreams.Config {
 type testContext struct {
 	ring       *fakeRing
 	clientPool *fakeClientPool
-	rateStore  *rateStore
+	rateStore  *RateStoreService
 }
 
 func setup(shardingEnabled bool) *testContext {
 	ring := newFakeRing()
 	cp := newFakeClientPool()
-	cfg := RateStoreConfig{MaxParallelism: 5, IngesterReqTimeout: time.Second, StreamRateUpdateInterval: 10 * time.Millisecond}
+	cfg := RateStoreConfig{MaxParallelism: 5, IngesterReqTimeout: time.Second, StreamRateUpdateInterval: 10 * time.Millisecond, RateKeepAlive: 10 * time.Minute}
 
 	return &testContext{
 		ring:       ring,

--- a/tools/ratestore-standalone/Dockerfile
+++ b/tools/ratestore-standalone/Dockerfile
@@ -1,0 +1,23 @@
+ARG GO_VERSION=1.24
+
+# Go build stage
+FROM golang:${GO_VERSION} AS build
+COPY . /src/loki
+WORKDIR /src/loki
+RUN CGO_ENABLED=0 go build -o ratestore-standalone ./tools/ratestore-standalone/main.go
+
+# Final stage
+FROM gcr.io/distroless/static:debug
+
+COPY --from=build /src/loki/ratestore-standalone /usr/bin/ratestore-standalone
+
+SHELL [ "/busybox/sh", "-c" ]
+
+RUN addgroup -g 10001 -S ratestore-standalone && \
+    adduser -u 10001 -S ratestore-standalone -G ratestore-standalone && \
+    chown -R ratestore-standalone:ratestore-standalone /usr/bin/ratestore-standalone && \
+    ln -s /busybox/sh /bin/sh
+
+USER 10001
+EXPOSE 3100
+ENTRYPOINT [ "/usr/bin/ratestore-standalone" ] 

--- a/tools/ratestore-standalone/main.go
+++ b/tools/ratestore-standalone/main.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/go-kit/log"       //nolint:depguard
+	"github.com/go-kit/log/level" //nolint:depguard
+	"github.com/grafana/dskit/services"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+
+	"github.com/grafana/loki/v3/tools/ratestore-standalone/standalone"
+)
+
+func main() {
+	logger := log.NewLogfmtLogger(os.Stdout)
+
+	cfg := standalone.Config{}
+	cfg.RegisterFlags(flag.CommandLine, logger)
+	flag.Parse()
+
+	logger = level.NewFilter(logger, cfg.LogLevel.Option)
+
+	// Create a new registry for Kafka metrics
+	reg := prometheus.NewRegistry()
+
+	rs, err := standalone.NewRateStoreService(cfg, reg, logger)
+	if err != nil {
+		logger.Log("msg", "Error creating rate store standalone", "err", err)
+		os.Exit(1)
+	}
+
+	if err := services.StartAndAwaitRunning(context.Background(), rs); err != nil {
+		logger.Log("msg", "Error starting rate store standalone", "err", err)
+		os.Exit(1)
+	}
+
+	// Create HTTP server for metrics
+	httpListenAddr := fmt.Sprintf(":%d", cfg.HTTPListenPort)
+
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.HandlerFor(reg, promhttp.HandlerOpts{}))
+	mux.Handle("/memberlist", rs.GetMemberlist())
+	mux.Handle("/ingester-ring", rs.GetIngesterRing())
+
+	server := &http.Server{
+		Addr:    httpListenAddr,
+		Handler: mux,
+	}
+
+	// Start HTTP server in a goroutine
+	go func() {
+		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			level.Error(logger).Log("msg", "Error starting metrics server", "err", err)
+			os.Exit(1)
+		}
+	}()
+
+	level.Info(logger).Log("msg", "Started metrics server", "addr", httpListenAddr)
+
+	// Wait for interrupt signal
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
+	<-sigChan
+
+	// Gracefully shutdown HTTP server
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := server.Shutdown(shutdownCtx); err != nil {
+		level.Error(logger).Log("msg", "Error shutting down metrics server", "err", err)
+	}
+
+	// Stop the service gracefully
+	if err := services.StopAndAwaitTerminated(context.Background(), rs); err != nil {
+		level.Error(logger).Log("msg", "Error stopping rate store standalone", "err", err)
+		os.Exit(1)
+	}
+}

--- a/tools/ratestore-standalone/standalone/config.go
+++ b/tools/ratestore-standalone/standalone/config.go
@@ -1,0 +1,64 @@
+package standalone
+
+import (
+	"flag"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/dskit/kv/memberlist"
+	dskit_log "github.com/grafana/dskit/log"
+	"github.com/grafana/dskit/ring"
+
+	"github.com/grafana/loki/v3/pkg/distributor"
+	ingester_client "github.com/grafana/loki/v3/pkg/ingester/client"
+	"github.com/grafana/loki/v3/pkg/validation"
+)
+
+const (
+	poolName         = "rate-store-standalone"
+	ingesterRingName = "ingester"
+	metricsNamespace = "rate_store_standalone"
+)
+
+type Config struct {
+	LogLevel         dskit_log.Level             `yaml:"log_level,omitempty"`
+	HTTPListenPort   int                         `yaml:"http_listen_port,omitempty"`
+	IngesterClient   ingester_client.Config      `yaml:"ingester_client,omitempty"`
+	LifecyclerConfig ring.LifecyclerConfig       `yaml:"lifecycler,omitempty"`
+	MemberlistKV     memberlist.KVConfig         `yaml:"memberlist,omitempty"`
+	RateStore        distributor.RateStoreConfig `yaml:"rate_store,omitempty"`
+	LimitsConfig     validation.Limits           `yaml:"limits_config,omitempty"`
+	TenantLimits     validation.TenantLimits     `yaml:"tenant_limits,omitempty"`
+}
+
+func (c *Config) RegisterFlags(fs *flag.FlagSet, logger log.Logger) {
+	fs.IntVar(&c.HTTPListenPort, "http-listen-port", 3100, "HTTP Listener port")
+	c.RateStore.RegisterFlagsWithPrefix("rate-store-standalone", fs)
+	c.LogLevel.RegisterFlags(fs)
+	c.IngesterClient.RegisterFlags(fs)
+	c.LifecyclerConfig.RegisterFlagsWithPrefix("", fs, logger)
+	c.MemberlistKV.RegisterFlags(fs)
+	c.LimitsConfig.RegisterFlags(fs)
+
+	// Always export metrics with custom prefix
+	c.RateStore.Standalone = true
+	// Set replication factor to 1 for standalone mode
+	c.LifecyclerConfig.RingConfig.ReplicationFactor = 1
+	// Set internal to true for ingester client
+	c.IngesterClient.Internal = true
+}
+
+type tenantLimits struct {
+	limits map[string]*validation.Limits
+}
+
+func newTenantLimits(limits map[string]*validation.Limits) *tenantLimits {
+	return &tenantLimits{
+		limits: limits,
+	}
+}
+
+func (l *tenantLimits) TenantLimits(userID string) *validation.Limits {
+	return l.limits[userID]
+}
+
+func (l *tenantLimits) AllByUserID() map[string]*validation.Limits { return l.limits }

--- a/tools/ratestore-standalone/standalone/standalone.go
+++ b/tools/ratestore-standalone/standalone/standalone.go
@@ -1,0 +1,127 @@
+package standalone
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/dskit/dns"
+	"github.com/grafana/dskit/kv/codec"
+	"github.com/grafana/dskit/kv/memberlist"
+	"github.com/grafana/dskit/netutil"
+	"github.com/grafana/dskit/ring"
+	ring_client "github.com/grafana/dskit/ring/client"
+	"github.com/grafana/dskit/services"
+	"github.com/pkg/errors"
+
+	"github.com/grafana/loki/v3/pkg/analytics"
+	"github.com/grafana/loki/v3/pkg/distributor"
+	"github.com/grafana/loki/v3/pkg/distributor/clientpool"
+	"github.com/grafana/loki/v3/pkg/distributor/shardstreams"
+	"github.com/grafana/loki/v3/pkg/ingester"
+	ingester_client "github.com/grafana/loki/v3/pkg/ingester/client"
+	"github.com/grafana/loki/v3/pkg/validation"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type Service struct {
+	services.Service
+
+	rateStore *distributor.RateStoreService
+
+	ingesterRing *ring.Ring
+	memberlistKV *memberlist.KVInitService
+
+	subservices        *services.Manager
+	subservicesWatcher *services.FailureWatcher
+}
+
+func NewRateStoreService(cfg Config, reg prometheus.Registerer, logger log.Logger) (*Service, error) {
+	var (
+		s    = &Service{}
+		srvs = []services.Service{}
+		err  error
+	)
+
+	cfg.MemberlistKV.Codecs = []codec.Codec{
+		ring.GetCodec(),
+		analytics.JSONCodec,
+		ring.GetPartitionRingCodec(),
+	}
+
+	provider := dns.NewProvider(logger, reg, dns.GolangResolverType)
+	cfg.MemberlistKV.AdvertiseAddr, err = netutil.GetFirstAddressOf(cfg.LifecyclerConfig.InfNames, logger, false)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get instance address: %w", err)
+	}
+
+	s.memberlistKV = memberlist.NewKVInitService(&cfg.MemberlistKV, logger, provider, reg)
+	cfg.LifecyclerConfig.RingConfig.KVStore.MemberlistKV = s.memberlistKV.GetMemberlistKV
+	srvs = append(srvs, s.memberlistKV)
+
+	s.ingesterRing, err = ring.New(cfg.LifecyclerConfig.RingConfig, ingesterRingName, ingester.RingKey, logger, reg)
+	if err != nil {
+		return nil, err
+	}
+	srvs = append(srvs, s.ingesterRing)
+
+	internalIngesterClientFactory := func(addr string) (ring_client.PoolClient, error) {
+		return ingester_client.New(cfg.IngesterClient, addr)
+	}
+
+	cf := clientpool.NewPool(
+		poolName,
+		cfg.IngesterClient.PoolConfig,
+		s.ingesterRing,
+		ring_client.PoolAddrFunc(internalIngesterClientFactory),
+		logger,
+		metricsNamespace,
+	)
+
+	tenantLimits := map[string]*validation.Limits{
+		"fake": {
+			ShardStreams: shardstreams.Config{
+				Enabled: true,
+			},
+		},
+	}
+
+	limits, err := validation.NewOverrides(cfg.LimitsConfig, newTenantLimits(tenantLimits))
+	if err != nil {
+		return nil, err
+	}
+
+	s.rateStore = distributor.NewRateStore(cfg.RateStore, s.ingesterRing, cf, limits, reg)
+	srvs = append(srvs, s.rateStore)
+
+	s.subservices, err = services.NewManager(srvs...)
+	if err != nil {
+		return nil, errors.Wrap(err, "services manager")
+	}
+	s.subservicesWatcher = services.NewFailureWatcher()
+	s.subservicesWatcher.WatchManager(s.subservices)
+	s.Service = services.NewBasicService(s.starting, s.running, s.stopping)
+
+	return s, nil
+}
+
+func (s *Service) starting(ctx context.Context) error {
+	return services.StartManagerAndAwaitHealthy(ctx, s.subservices)
+}
+
+func (s *Service) running(ctx context.Context) error {
+	<-ctx.Done()
+	return nil
+}
+
+func (s *Service) stopping(_ error) error {
+	return services.StopManagerAndAwaitStopped(context.Background(), s.subservices)
+}
+
+func (s *Service) GetMemberlist() *memberlist.KVInitService {
+	return s.memberlistKV
+}
+
+func (s *Service) GetIngesterRing() *ring.Ring {
+	return s.ingesterRing
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This pull request provides a new dev tool named `ratestore-standalone` to be used as a comparison tool for counters/rates exposed by the new ingest-limits service during rollouts.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
