### PR TITLE
chore(deps): Downgrade kprom from v1.3.0 back to v1.2.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -152,7 +152,7 @@ require (
 	github.com/twmb/franz-go/pkg/kfake v0.0.0-20241015013301-cea7aa5d8037
 	github.com/twmb/franz-go/pkg/kmsg v1.11.2
 	github.com/twmb/franz-go/plugin/kotel v1.6.0
-	github.com/twmb/franz-go/plugin/kprom v1.3.0
+	github.com/twmb/franz-go/plugin/kprom v1.2.1
 	go.opentelemetry.io/collector/pdata v1.37.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace v0.62.0
 	go.opentelemetry.io/otel/sdk v1.37.0

--- a/go.sum
+++ b/go.sum
@@ -1258,8 +1258,8 @@ github.com/twmb/franz-go/pkg/kmsg v1.11.2 h1:hIw75FpwcAjgeyfIGFqivAvwC5uNIOWRGvQ
 github.com/twmb/franz-go/pkg/kmsg v1.11.2/go.mod h1:CFfkkLysDNmukPYhGzuUcDtf46gQSqCZHMW1T4Z+wDE=
 github.com/twmb/franz-go/plugin/kotel v1.6.0 h1:hmvLn/cVw/Hn56H3aJVJu/a/fh6m8J6Ajwp0IcEHbH8=
 github.com/twmb/franz-go/plugin/kotel v1.6.0/go.mod h1:ADmLuCa/NzHdXdWfl22FsIlGCack+YrHjivirHCBJaY=
-github.com/twmb/franz-go/plugin/kprom v1.3.0 h1:hpPL0LxgDZ0WuT8U+PT9uYo0icY2/Pcodgdk4Ylgblo=
-github.com/twmb/franz-go/plugin/kprom v1.3.0/go.mod h1:7wlpDMa4Ls5GBIYb3xUUxK38g1N7qy2cLYO84zAtp/w=
+github.com/twmb/franz-go/plugin/kprom v1.2.1 h1:FGWdneW9htySYmvJ5tEuAIZepjFOuTFhHLy5TrVR+QI=
+github.com/twmb/franz-go/plugin/kprom v1.2.1/go.mod h1:+dzpKnVE6By8BDRFj240dTDJS9bP2dngmuhv7egJ3Go=
 github.com/twmb/murmur3 v1.1.6/go.mod h1:Qq/R7NUyOfr65zD+6Q5IHKsJLwP7exErjN6lyyq3OSQ=
 github.com/twmb/murmur3 v1.1.7 h1:ULWBiM04n/XoN3YMSJ6Z2pHDFLf+MeIVQU71ZPrvbWg=
 github.com/twmb/murmur3 v1.1.7/go.mod h1:Qq/R7NUyOfr65zD+6Q5IHKsJLwP7exErjN6lyyq3OSQ=

--- a/vendor/github.com/twmb/franz-go/plugin/kprom/config.go
+++ b/vendor/github.com/twmb/franz-go/plugin/kprom/config.go
@@ -1,12 +1,12 @@
 package kprom
 
 import (
-	"maps"
 	"reflect"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"maps"
 )
 
 type cfg struct {
@@ -166,7 +166,7 @@ type HistogramOpts struct {
 //	 		Buckets: prometheus.LinearBuckets(10, 10, 8),
 //	 	},
 //	 	kprom.HistogramOpts{
-//	 		Enable: kprom.ReadTime,
+//	 		Enable: kprom.ReadeTime,
 //	 		// kprom default bucket will be used
 //	 	},
 //	 ),

--- a/vendor/github.com/twmb/franz-go/plugin/kprom/kprom.go
+++ b/vendor/github.com/twmb/franz-go/plugin/kprom/kprom.go
@@ -12,9 +12,7 @@
 //	#{ns}_produce_bytes_total{node_id="#{node}",topic="#{topic}"}
 //	#{ns}_fetch_bytes_total{node_id="#{node}",topic="#{topic}"}
 //	#{ns}_buffered_produce_records_total
-//	#{ns}_buffered_produce_bytes_total
 //	#{ns}_buffered_fetch_records_total
-//	#{ns}_buffered_fetch_bytes_total
 //
 // The above metrics can be expanded considerably with options in this package,
 // allowing timings, uncompressed and compressed bytes, and different labels.
@@ -100,9 +98,7 @@ type Metrics struct {
 
 	// Buffered
 	bufferedFetchRecords   prometheus.GaugeFunc
-	bufferedFetchBytes     prometheus.GaugeFunc
 	bufferedProduceRecords prometheus.GaugeFunc
-	bufferedProduceBytes   prometheus.GaugeFunc
 
 	// Holds references to all metric collectors
 	allMetricCollectors []prometheus.Collector
@@ -359,17 +355,6 @@ func (m *Metrics) OnNewClient(client *kgo.Client) {
 		func() float64 { return float64(client.BufferedProduceRecords()) },
 	)
 
-	m.bufferedProduceBytes = factory.NewGaugeFunc(
-		prometheus.GaugeOpts{
-			Namespace:   namespace,
-			Subsystem:   subsystem,
-			ConstLabels: constLabels,
-			Name:        "buffered_produce_bytes",
-			Help:        "Total number of bytes buffered within the client ready to be produced",
-		},
-		func() float64 { return float64(client.BufferedProduceBytes()) },
-	)
-
 	m.bufferedFetchRecords = factory.NewGaugeFunc(
 		prometheus.GaugeOpts{
 			Namespace:   namespace,
@@ -379,17 +364,6 @@ func (m *Metrics) OnNewClient(client *kgo.Client) {
 			Help:        "Total number of records buffered within the client ready to be consumed",
 		},
 		func() float64 { return float64(client.BufferedFetchRecords()) },
-	)
-
-	m.bufferedFetchBytes = factory.NewGaugeFunc(
-		prometheus.GaugeOpts{
-			Namespace:   namespace,
-			Subsystem:   subsystem,
-			ConstLabels: constLabels,
-			Name:        "buffered_fetch_bytes",
-			Help:        "Total number of bytes buffered within the client ready to be consumed",
-		},
-		func() float64 { return float64(client.BufferedFetchBytes()) },
 	)
 
 	m.allMetricCollectors = append(m.allMetricCollectors,
@@ -415,9 +389,7 @@ func (m *Metrics) OnNewClient(client *kgo.Client) {
 		m.fetchBatchesTotal,
 		m.fetchRecordsTotal,
 		m.bufferedFetchRecords,
-		m.bufferedFetchBytes,
 		m.bufferedProduceRecords,
-		m.bufferedProduceBytes,
 	)
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1919,8 +1919,8 @@ github.com/twmb/franz-go/pkg/kmsg/internal/kbin
 # github.com/twmb/franz-go/plugin/kotel v1.6.0
 ## explicit; go 1.22.0
 github.com/twmb/franz-go/plugin/kotel
-# github.com/twmb/franz-go/plugin/kprom v1.3.0
-## explicit; go 1.23.8
+# github.com/twmb/franz-go/plugin/kprom v1.2.1
+## explicit; go 1.21
 github.com/twmb/franz-go/plugin/kprom
 # github.com/uber/jaeger-client-go v2.30.0+incompatible
 ## explicit


### PR DESCRIPTION
**What this PR does / why we need it**:

With https://github.com/grafana/loki/pull/18596, we upgraded kprom to a version that contains a breaking change.

The library now introduces a metric `{ns}_buffered_produce_bytes_total` which is already defined as part of both Mimir and adaptime metrics.

Rolling forward in Mimir is more complicated than rolling backwards here in Loki as I can see there are no dashboard or alerts using this metric so I propose to do that.

Without this change it's currently impossible to vendor mimir or loki into backend-enterprise.

I'll also need to tell renovate to skip this version afterward

Signed-off-by: gotjosh <josue.abreu@gmail.com>


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
