### PR TITLE
chore: Pin kprom to 1.2.x range in Renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -98,6 +98,13 @@
       "matchUpdateTypes": ["major"],
       "automerge": false,
       "autoApprove": false
+    },
+    {
+      // Pin kprom to 1.2.x range, ignore 1.3.0+ updates due to a conflict with a metric introduced in this version.
+      // Can be upgraded once adapative metrics and Mimir have upgraded.
+      "matchPackageNames": ["github.com/twmb/franz-go/plugin/kprom"],
+      "allowedVersions": "~1.2.0",
+      "enabled": true
     }
   ],
   "digest": {


### PR DESCRIPTION
**What this PR does / why we need it**:

Prevent Renovate from upgrading github.com/twmb/franz-go/plugin/kprom
to v1.3.0+ by adding an allowedVersions rule to keep it in the 1.2.x range.

This is to prevent the new metrics introduced in this version to conflict with Mimir's and Adaptive metrics, see for more information: https://github.com/grafana/loki/pull/18785

Signed-off-by: gotjosh <josue.abreu@gmail.com>


**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
