### PR TITLE
fix(operator): upgrade OPA policy syntax for v1+

### DIFF
--- a/operator/internal/manifests/internal/gateway/lokistack-gateway.rego
+++ b/operator/internal/manifests/internal/gateway/lokistack-gateway.rego
@@ -1,24 +1,26 @@
 package lokistack
 
-import input
-import data.roles
+import rego.v1
+
 import data.roleBindings
+import data.roles
+import input
 
-default allow = false
+default allow := false
 
-allow {
-  some roleNames
-  roleNames = roleBindings[matched_role_binding[_]].roles
-  roles[i].name == roleNames[_]
-  roles[i].resources[_] = input.resource
-  roles[i].permissions[_] = input.permission
-  roles[i].tenants[_] = input.tenant
+allow if {
+	some roleNames
+	roleNames = roleBindings[matched_role_binding[_]].roles
+	roles[i].name == roleNames[_]
+	roles[i].resources[_] = input.resource
+	roles[i].permissions[_] = input.permission
+	roles[i].tenants[_] = input.tenant
 }
 
-matched_role_binding[i] {
-  roleBindings[i].subjects[_] == {"name": input.subject, "kind": "user"}
+matched_role_binding contains i if {
+	roleBindings[i].subjects[_] == {"name": input.subject, "kind": "user"}
 }
 
-matched_role_binding[i] {
-  roleBindings[i].subjects[_] == {"name": input.groups[_], "kind": "group"}
+matched_role_binding contains i if {
+	roleBindings[i].subjects[_] == {"name": input.groups[_], "kind": "group"}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Some weeks ago, observatorium/api merged a PR upgrading OPA to v1.5.1 from v0.69 (https://github.com/observatorium/api/commit/5bbdc9d2b4e920d392dd4b8148b818a8dfa26bc8)

Loki operator defaults to using observatorium/api:latest image, and as such it is now deploying this updated image for the Gateway. It bundles in a static rego policy file which now needs syntax changes to be compatible with OPA post v1.0.

**Which issue(s) this PR fixes**:
Did not open an issue for this and found none existing.
The issue is that loki-gateway instances running recent observatorium/api crash on start-up erroring on invalid OPA policy.

**Special notes for your reviewer**:
The syntax update was made with OPA itself:
```
opa fmt --v0-v1 --write lokistack-gateway.rego
```

and has been validated by manually changing the loki-gateway configmap containing the rego policy, and verifying Gateway correct start up.

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [X] Documentation added
- [X] Tests updated
- [X] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
