### PR TITLE
chore(dataobj): read non-projected predicate columns

### DIFF
--- a/pkg/dataobj/sections/logs/reader.go
+++ b/pkg/dataobj/sections/logs/reader.go
@@ -424,49 +424,14 @@ func (r *Reader) Close() error {
 	return nil
 }
 
-func predicateColumns(predicates []Predicate) []*Column {
-	columns := make([]*Column, 0, len(predicates))
-	for _, p := range predicates {
-		walkPredicate(p, func(p Predicate) bool {
-			switch p := p.(type) {
-			case nil: // End of walk; nothing to do.
-
-			case AndPredicate: // Nothing to do.
-			case OrPredicate: // Nothing to do.
-			case NotPredicate: // Nothing to do.
-			case TruePredicate: // Nothing to do.
-			case FalsePredicate: // Nothing to do.
-
-			case EqualPredicate:
-				columns = append(columns, p.Column)
-			case InPredicate:
-				columns = append(columns, p.Column)
-			case GreaterThanPredicate:
-				columns = append(columns, p.Column)
-			case LessThanPredicate:
-				columns = append(columns, p.Column)
-			case FuncPredicate:
-				columns = append(columns, p.Column)
-
-			default:
-				panic(fmt.Sprintf("unrecognized predicate type %T", p))
-			}
-
-			return true
-		})
-	}
-
-	return columns
-}
-
 func appendMissingColumns(dst, src []*Column) []*Column {
-	columnLookup := make(map[*Column]struct{}, len(dst))
+	exists := make(map[*Column]struct{}, len(dst))
 	for _, col := range dst {
-		columnLookup[col] = struct{}{}
+		exists[col] = struct{}{}
 	}
 
 	for _, col := range src {
-		if _, ok := columnLookup[col]; !ok {
+		if _, ok := exists[col]; !ok {
 			// Not seen, add it.
 			dst = append(dst, col)
 		}

--- a/pkg/logql/bench/generator_query.go
+++ b/pkg/logql/bench/generator_query.go
@@ -191,6 +191,9 @@ func (g *TestCaseGenerator) Generate() []TestCase {
 			// Basic selector
 			addBidirectional(selector, g.logGenCfg.StartTime, end)
 
+			// With line filter
+			addBidirectional(selector+` |= "level"`, g.logGenCfg.StartTime, end)
+
 			// With structured metadata filters
 			addBidirectional(selector+` | detected_level="error"`, g.logGenCfg.StartTime, end)
 			addBidirectional(selector+` | detected_level="warn"`, g.logGenCfg.StartTime, end)
@@ -209,6 +212,7 @@ func (g *TestCaseGenerator) Generate() []TestCase {
 		baseRangeAggregationQueries := []string{
 			fmt.Sprintf(`count_over_time(%s[%s])`, selector, rangeInterval),
 			fmt.Sprintf(`count_over_time(%s | detected_level=~"error|warn" [%s])`, selector, rangeInterval),
+			fmt.Sprintf(`count_over_time(%s |= "level" [%s])`, selector, rangeInterval),
 			fmt.Sprintf(`rate(%s | detected_level=~"error|warn" [%s])`, selector, rangeInterval),
 		}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Logs reader composes columns dataset only using columns that are in the projection list. But there are cases where column referred by a predicate is not projected, it will only be used to filter the rows and is not part of the resulting record schema.

Metric queries with line filter currently fail for this reason as log message is not projected and does not get included in the dataset.

This pr adds non-projected predicate columns to the columns dataset. It also removes a validation step in `logs.Reader` that checks whether the columns referred by predicates are part of `ReaderOptions.Columns` (projection list) since predicate columns need not always be projected.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
