### PR TITLE
chore: move mocks into mock.go

### DIFF
--- a/pkg/dataobj/consumer/mock_test.go
+++ b/pkg/dataobj/consumer/mock_test.go
@@ -1,0 +1,79 @@
+package consumer
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"sync"
+
+	"github.com/thanos-io/objstore"
+)
+
+// mockBucket implements objstore.Bucket interface for testing
+type mockBucket struct {
+	uploads map[string][]byte
+	mu      sync.Mutex
+}
+
+func newMockBucket() *mockBucket {
+	return &mockBucket{
+		uploads: make(map[string][]byte),
+	}
+}
+
+func (m *mockBucket) Close() error                             { return nil }
+func (m *mockBucket) Delete(_ context.Context, _ string) error { return nil }
+func (m *mockBucket) Exists(_ context.Context, name string) (bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	_, exists := m.uploads[name]
+	return exists, nil
+}
+func (m *mockBucket) Get(_ context.Context, name string) (io.ReadCloser, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	data, exists := m.uploads[name]
+	if !exists {
+		return nil, errors.New("object not found")
+	}
+	return io.NopCloser(bytes.NewReader(data)), nil
+}
+func (m *mockBucket) GetRange(_ context.Context, _ string, _, _ int64) (io.ReadCloser, error) {
+	return nil, nil
+}
+func (m *mockBucket) Upload(_ context.Context, name string, r io.Reader) error {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return err
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.uploads[name] = data
+	return nil
+}
+func (m *mockBucket) Iter(_ context.Context, _ string, _ func(string) error, _ ...objstore.IterOption) error {
+	return nil
+}
+func (m *mockBucket) Name() string { return "mock" }
+func (m *mockBucket) Attributes(_ context.Context, _ string) (objstore.ObjectAttributes, error) {
+	return objstore.ObjectAttributes{}, nil
+}
+func (m *mockBucket) GetAndReplace(_ context.Context, name string, _ func(io.ReadCloser) (io.ReadCloser, error)) error {
+	return m.Upload(context.Background(), name, io.NopCloser(bytes.NewReader([]byte{})))
+}
+func (m *mockBucket) IsAccessDeniedErr(_ error) bool {
+	return false
+}
+func (m *mockBucket) IsObjNotFoundErr(err error) bool {
+	return err != nil && err.Error() == "object not found"
+}
+func (m *mockBucket) IterWithAttributes(_ context.Context, _ string, _ func(objstore.IterObjectAttributes) error, _ ...objstore.IterOption) error {
+	return nil
+}
+func (m *mockBucket) Provider() objstore.ObjProvider {
+	return objstore.ObjProvider("MOCK")
+}
+func (m *mockBucket) SupportedIterOptions() []objstore.IterOptionType {
+	return nil
+}

--- a/pkg/dataobj/consumer/partition_processor_test.go
+++ b/pkg/dataobj/consumer/partition_processor_test.go
@@ -3,8 +3,6 @@ package consumer
 import (
 	"bytes"
 	"context"
-	"errors"
-	"io"
 	"strings"
 	"sync"
 	"testing"
@@ -13,7 +11,6 @@ import (
 	"github.com/go-kit/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
-	"github.com/thanos-io/objstore"
 	"github.com/twmb/franz-go/pkg/kgo"
 
 	"github.com/grafana/loki/v3/pkg/dataobj/consumer/logsobj"
@@ -32,74 +29,6 @@ var testBuilderConfig = logsobj.BuilderConfig{
 	BufferSize: 2048 * 8,
 
 	SectionStripeMergeLimit: 2,
-}
-
-// mockBucket implements objstore.Bucket interface for testing
-type mockBucket struct {
-	uploads map[string][]byte
-	mu      sync.Mutex
-}
-
-func newMockBucket() *mockBucket {
-	return &mockBucket{
-		uploads: make(map[string][]byte),
-	}
-}
-
-func (m *mockBucket) Close() error                             { return nil }
-func (m *mockBucket) Delete(_ context.Context, _ string) error { return nil }
-func (m *mockBucket) Exists(_ context.Context, name string) (bool, error) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	_, exists := m.uploads[name]
-	return exists, nil
-}
-func (m *mockBucket) Get(_ context.Context, name string) (io.ReadCloser, error) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	data, exists := m.uploads[name]
-	if !exists {
-		return nil, errors.New("object not found")
-	}
-	return io.NopCloser(bytes.NewReader(data)), nil
-}
-func (m *mockBucket) GetRange(_ context.Context, _ string, _, _ int64) (io.ReadCloser, error) {
-	return nil, nil
-}
-func (m *mockBucket) Upload(_ context.Context, name string, r io.Reader) error {
-	data, err := io.ReadAll(r)
-	if err != nil {
-		return err
-	}
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.uploads[name] = data
-	return nil
-}
-func (m *mockBucket) Iter(_ context.Context, _ string, _ func(string) error, _ ...objstore.IterOption) error {
-	return nil
-}
-func (m *mockBucket) Name() string { return "mock" }
-func (m *mockBucket) Attributes(_ context.Context, _ string) (objstore.ObjectAttributes, error) {
-	return objstore.ObjectAttributes{}, nil
-}
-func (m *mockBucket) GetAndReplace(_ context.Context, name string, _ func(io.ReadCloser) (io.ReadCloser, error)) error {
-	return m.Upload(context.Background(), name, io.NopCloser(bytes.NewReader([]byte{})))
-}
-func (m *mockBucket) IsAccessDeniedErr(_ error) bool {
-	return false
-}
-func (m *mockBucket) IsObjNotFoundErr(err error) bool {
-	return err != nil && err.Error() == "object not found"
-}
-func (m *mockBucket) IterWithAttributes(_ context.Context, _ string, _ func(objstore.IterObjectAttributes) error, _ ...objstore.IterOption) error {
-	return nil
-}
-func (m *mockBucket) Provider() objstore.ObjProvider {
-	return objstore.ObjProvider("MOCK")
-}
-func (m *mockBucket) SupportedIterOptions() []objstore.IterOptionType {
-	return nil
 }
 
 // TestIdleFlush tests the idle flush behavior of the partition processor


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request moves mocks into `mock.go`.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
