### PR TITLE
chore(dataobj): permit reading subset of section metadata

### DIFF
--- a/pkg/dataobj/section.go
+++ b/pkg/dataobj/section.go
@@ -73,10 +73,21 @@ type SectionReader interface {
 	// implicitly the entire file.
 	DataRange(ctx context.Context, offset, length int64) (io.ReadCloser, error)
 
-	// Metadata opens a reader to the entire metadata region of a section.
-	// Metadata returns an error if the read fails. The returned reader is only
-	// valid as long as the provided ctx is not canceled.
-	Metadata(ctx context.Context) (io.ReadCloser, error)
+	// MetadataRange opens a reader of length bytes from the metadata region of
+	// a section. The offset argument determines where in the metadata region
+	// reading should start.
+	//
+	// MetadataRange returns an error if the read fails or if offset+length goes
+	// beyond the readable metadata region. The returned reader is only valid as long
+	// as the provided ctx is not canceled.
+	MetadataRange(ctx context.Context, offset, length int64) (io.ReadCloser, error)
+
+	// TODO(rfratto): DataSize() is only possible to implement after we fully
+	// remove support for older data objects where the data region was not
+	// explicitly specified.
+
+	// MetadataSize returns the total size of the metadata region of a section.
+	MetadataSize() int64
 }
 
 // A SectionBuilder accumulates data for a single in-progress section.

--- a/pkg/dataobj/sections/indexpointers/decoder.go
+++ b/pkg/dataobj/sections/indexpointers/decoder.go
@@ -25,7 +25,7 @@ type decoder struct {
 
 // Metadata returns the metadata for the index pointers section.
 func (rd *decoder) Metadata(ctx context.Context) (*indexpointersmd.Metadata, error) {
-	rc, err := rd.sr.Metadata(ctx)
+	rc, err := rd.sr.MetadataRange(ctx, 0, rd.sr.MetadataSize())
 	if err != nil {
 		return nil, fmt.Errorf("reading pointers section metadata: %w", err)
 	}

--- a/pkg/dataobj/sections/logs/decoder.go
+++ b/pkg/dataobj/sections/logs/decoder.go
@@ -25,7 +25,7 @@ type decoder struct {
 
 // Metadata returns the metadata for the logs section.
 func (rd *decoder) Metadata(ctx context.Context) (*logsmd.Metadata, error) {
-	rc, err := rd.sr.Metadata(ctx)
+	rc, err := rd.sr.MetadataRange(ctx, 0, rd.sr.MetadataSize())
 	if err != nil {
 		return nil, fmt.Errorf("reading streams section metadata: %w", err)
 	}

--- a/pkg/dataobj/sections/pointers/decoder.go
+++ b/pkg/dataobj/sections/pointers/decoder.go
@@ -26,7 +26,7 @@ type decoder struct {
 
 // Metadata returns the metadata for the pointers section.
 func (rd *decoder) Metadata(ctx context.Context) (*pointersmd.Metadata, error) {
-	rc, err := rd.sr.Metadata(ctx)
+	rc, err := rd.sr.MetadataRange(ctx, 0, rd.sr.MetadataSize())
 	if err != nil {
 		return nil, fmt.Errorf("reading pointers section metadata: %w", err)
 	}

--- a/pkg/dataobj/sections/streams/decoder.go
+++ b/pkg/dataobj/sections/streams/decoder.go
@@ -26,7 +26,7 @@ type decoder struct {
 
 // Metadata returns the metadata for the streams section.
 func (rd *decoder) Metadata(ctx context.Context) (*streamsmd.Metadata, error) {
-	rc, err := rd.sr.Metadata(ctx)
+	rc, err := rd.sr.MetadataRange(ctx, 0, rd.sr.MetadataSize())
 	if err != nil {
 		return nil, fmt.Errorf("reading streams section metadata: %w", err)
 	}


### PR DESCRIPTION
Originally, sections were intended to read their entire metadata region in a single call. This had the extra requirement for metadata to be as small as possible and to only include what's always necessary.

As a result of this, sections based on dataset stored additional metadata (like lists of pages per column) in the data region, allowing the sections to retrieve that optional metadata on demand.

This decision caused some issues:

- Metadata is now fragmented across a section, making it difficult to minimize the overhead of downloading metadata from object storage

- The metadata region size histogram is not representative of the true metadata size, as some metadata is stored in the data region.

This commit changes the dataobj.SectionReader interface to permit a section to read a subset of metadata. This will allow new format versions of dataset to be introduced that store optional metadata in the same metadata region.