### PR TITLE
fix: use the custom objectExists function to work around bug in Thanos object client

### DIFF
--- a/pkg/compactor/deletion/deletion_manifest_builder.go
+++ b/pkg/compactor/deletion/deletion_manifest_builder.go
@@ -288,7 +288,7 @@ func storageHasValidManifest(ctx context.Context, deletionManifestStoreClient cl
 
 		// Check if manifest.proto exists in this directory
 		manifestPath := path.Join(string(commonPrefix), manifestFileName)
-		exists, err := deletionManifestStoreClient.ObjectExists(ctx, manifestPath)
+		exists, err := objectExists(ctx, deletionManifestStoreClient, manifestPath)
 		if err != nil {
 			return false, err
 		}

--- a/pkg/compactor/deletion/job_builder.go
+++ b/pkg/compactor/deletion/job_builder.go
@@ -170,7 +170,7 @@ func (b *JobBuilder) processManifest(ctx context.Context, manifest *deletionprot
 
 		segmentPath := path.Join(manifestPath, fmt.Sprintf("%d.proto", segmentNum))
 
-		manifestExists, err := b.deletionManifestStoreClient.ObjectExists(ctx, segmentPath)
+		manifestExists, err := objectExists(ctx, b.deletionManifestStoreClient, segmentPath)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
I missed replacing all the usages of `ObjectExists` on object storage clients with the custom `objectExists` I added to circumvent a bug in the GCS implementation of the Thanos object storage client. In this PR, I am replacing all the usages.
