### PR TITLE
docs: backport link fix 3.4

### DIFF
--- a/docs/sources/operations/storage/tsdb.md
+++ b/docs/sources/operations/storage/tsdb.md
@@ -6,7 +6,7 @@ weight: 100
 ---
 # Single Store TSDB (tsdb)
 
-Starting with Loki v2.8, TSDB is the recommended Loki index. It is heavily inspired by the Prometheus's TSDB [sub-project](https://github.com/prometheus/prometheus/tree/main/tsdb). For a deeper explanation you can read Loki maintainer Owen's [blog post](https://lokidex.com/posts/tsdb/). The short version is that this new index is more efficient, faster, and more scalable. It also resides in object storage like the [boltdb-shipper](../boltdb-shipper/) index which preceded it.
+Starting with Loki v2.8, TSDB is the recommended Loki index. It is heavily inspired by the Prometheus's TSDB [sub-project](https://github.com/prometheus/prometheus/tree/main/tsdb). For a deeper explanation you can read Loki maintainer Owen's [blog post](https://www.pikach.us/posts/tsdb/). The short version is that this new index is more efficient, faster, and more scalable. It also resides in object storage like the [boltdb-shipper](../boltdb-shipper/) index which preceded it.
 
 ## Example Configuration
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Backport https://github.com/grafana/loki/pull/18818 to 3.4 branch.