### PR TITLE
fix: dataobj-consumers did not commit offsets on idle flush

### DIFF
--- a/pkg/dataobj/consumer/partition_processor_test.go
+++ b/pkg/dataobj/consumer/partition_processor_test.go
@@ -35,6 +35,10 @@ func TestPartitionProcessor_IdleFlush(t *testing.T) {
 	clock := quartz.NewMock(t)
 	p := newTestPartitionProcessor(t, clock)
 	p.idleFlushTimeout = 60 * time.Minute
+	// Use a mock committer as we don't have a real Kafka client that can
+	// commit offsets.
+	committer := &mockCommitter{}
+	p.committer = committer
 
 	// Last flush time should be initialized to the zero time.
 	require.True(t, p.lastFlush.IsZero())


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
