### PR TITLE
feat: implement volume-based pattern filtering

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -920,6 +920,11 @@ pattern_ingester:
   # CLI flag: -pattern-ingester.sample-interval
   [pattern_sample_interval: <duration> | default = 10s]
 
+  # The threshold for filtering patterns by volume. Only patterns representing
+  # the top X% of log volume will be persisted (0-1).
+  # CLI flag: -pattern-ingester.volume-threshold
+  [volume_threshold: <float> | default = 0.99]
+
 # The index_gateway block configures the Loki index gateway server, responsible
 # for serving index queries without the need to constantly interact with the
 # object store.

--- a/pkg/pattern/aggregation/metrics.go
+++ b/pkg/pattern/aggregation/metrics.go
@@ -30,13 +30,11 @@ type Metrics struct {
 
 	// Pattern writing metrics
 	PatternBytesWrittenTotal *prometheus.CounterVec
-	PatternPayloadBytes      *prometheus.HistogramVec
 	PatternWritesTotal       *prometheus.CounterVec
 	PatternsActive           *prometheus.GaugeVec
 
 	// Aggregated metrics writing metrics
 	AggregatedMetricBytesWrittenTotal *prometheus.CounterVec
-	AggregatedMetricsPayloadBytes     *prometheus.HistogramVec
 }
 
 func NewMetrics(r prometheus.Registerer) *Metrics {
@@ -90,29 +88,21 @@ func NewMetrics(r prometheus.Registerer) *Metrics {
 				Subsystem: "pattern_ingester",
 				Name:      "pattern_bytes_written_total",
 				Help:      "Total bytes written for pattern payloads to Loki.",
-			}, []string{"tenant_id", "service_name"}),
-
-			PatternPayloadBytes: promauto.With(r).NewHistogramVec(prometheus.HistogramOpts{
-				Namespace: constants.Loki,
-				Subsystem: "pattern_ingester",
-				Name:      "pattern_payload_bytes",
-				Help:      "Size distribution of pattern payloads written to Loki.",
-				Buckets:   []float64{512, 2048, 8192, 32768, 131072, 524288},
-			}, []string{"tenant_id", "service_name"}),
+			}, []string{"tenant_id"}),
 
 			PatternWritesTotal: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
 				Namespace: constants.Loki,
 				Subsystem: "pattern_ingester",
 				Name:      "pattern_writes_total",
 				Help:      "Total number of pattern write operations to Loki.",
-			}, []string{"tenant_id", "service_name"}),
+			}, []string{"tenant_id"}),
 
 			PatternsActive: promauto.With(r).NewGaugeVec(prometheus.GaugeOpts{
 				Namespace: constants.Loki,
 				Subsystem: "pattern_ingester",
 				Name:      "patterns_active",
 				Help:      "Number of active patterns currently tracked in memory.",
-			}, []string{"tenant_id", "service_name"}),
+			}, []string{"tenant_id"}),
 
 			// Aggregated metrics writing metrics
 			AggregatedMetricBytesWrittenTotal: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
@@ -120,15 +110,7 @@ func NewMetrics(r prometheus.Registerer) *Metrics {
 				Subsystem: "pattern_ingester",
 				Name:      "aggregated_metric_bytes_written_total",
 				Help:      "Total bytes written for aggregated metric payloads to Loki.",
-			}, []string{"tenant_id", "service_name"}),
-
-			AggregatedMetricsPayloadBytes: promauto.With(r).NewHistogramVec(prometheus.HistogramOpts{
-				Namespace: constants.Loki,
-				Subsystem: "pattern_ingester",
-				Name:      "aggregated_metrics_payload_bytes",
-				Help:      "Size distribution of aggregated metric payloads written to Loki.",
-				Buckets:   []float64{512, 2048, 8192, 32768, 131072, 524288},
-			}, []string{"tenant_id", "service_name"}),
+			}, []string{"tenant_id"}),
 		}
 	})
 

--- a/pkg/pattern/drain/log_cluster.go
+++ b/pkg/pattern/drain/log_cluster.go
@@ -11,11 +11,13 @@ import (
 )
 
 type LogCluster struct {
-	id         int
-	Size       int
-	Tokens     []string
-	TokenState interface{}
-	Stringer   func([]string, interface{}) string
+	id          int
+	Size        int
+	Tokens      []string
+	TokenState  interface{}
+	Stringer    func([]string, interface{}) string
+	Volume      int64
+	SampleCount int64
 
 	Chunks Chunks
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds volume-based filtering to the pattern ingester to persist only the most significant patterns based on log volume. This helps reduce storage and processing overhead by filtering out low-volume patterns.

Key changes:
- Add Volume and SampleCount tracking to LogCluster to measure pattern significance
- Add VolumeThreshold configuration (default 0.99) to control filtering percentage
- Implement filterClustersByVolume function to select top X% of patterns by volume
- Integrate volume filtering into the prune() method of pattern streams
- Add comprehensive tests for volume filtering functionality
- Remove service_name from pattern metrics due to cardinality issues
- Remove histograms for capturing pattern/agg metric payloads (again because of cardinality issues)

The volume threshold represents the percentage of total log volume to retain. For example, a threshold of 0.8 keeps only the patterns that represent the top 80% of log volume, filtering out the long tail of low-volume patterns.

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
