### PR TITLE
feat: decode tenant when reading streams and logs sections

### DIFF
--- a/pkg/dataobj/sections/logs/logs.go
+++ b/pkg/dataobj/sections/logs/logs.go
@@ -21,6 +21,7 @@ func CheckSection(section *dataobj.Section) bool { return section.Type == sectio
 
 // Section represents an opened logs section.
 type Section struct {
+	tenant   string
 	reader   dataobj.SectionReader
 	columns  []*Column
 	sortInfo *datasetmd.SectionSortInfo
@@ -64,9 +65,13 @@ func (s *Section) init(ctx context.Context) error {
 		})
 	}
 
+	s.tenant = metadata.Tenant
 	s.sortInfo = metadata.SortInfo
 	return nil
 }
+
+// Tenant returns the tenant that owns the section.
+func (s *Section) Tenant() string { return s.tenant }
 
 // Columns returns the set of Columns in the section. The slice of returned
 // sections must not be mutated.

--- a/pkg/dataobj/sections/streams/streams.go
+++ b/pkg/dataobj/sections/streams/streams.go
@@ -20,6 +20,7 @@ func CheckSection(section *dataobj.Section) bool { return section.Type == sectio
 
 // Section represents an opened streams section.
 type Section struct {
+	tenant  string
 	reader  dataobj.SectionReader
 	columns []*Column
 }
@@ -62,8 +63,12 @@ func (s *Section) init(ctx context.Context) error {
 		})
 	}
 
+	s.tenant = metadata.Tenant
 	return nil
 }
+
+// Tenant returns the tenant that owns the section.
+func (s *Section) Tenant() string { return s.tenant }
 
 // Columns returns the set of Columns in the section. The slice of returned
 // sections must not be mutated.


### PR DESCRIPTION
**What this PR does / why we need it**:

Based on https://github.com/grafana/loki/pull/18843.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
