### PR TITLE
chore: do not rely on GOMAXPROCS to configure the number of sub-workers to run in compactor worker

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -2659,10 +2659,9 @@ compactor_ring:
 [horizontal_scaling_mode: <string> | default = "disabled"]
 
 worker_config:
-  # Number of sub-workers to run for concurrent processing of jobs. Setting it
-  # to 0 will run a subworker per available CPU core.
+  # Number of sub-workers to run for concurrent processing of jobs.
   # CLI flag: -compactor.worker.num-sub-workers
-  [num_sub_workers: <int> | default = 0]
+  [num_sub_workers: <int> | default = 4]
 
 jobs_config:
   deletion:

--- a/pkg/compactor/jobqueue/worker.go
+++ b/pkg/compactor/jobqueue/worker.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"runtime"
 	"sync"
 	"time"
 
@@ -43,7 +42,7 @@ type WorkerConfig struct {
 }
 
 func (c *WorkerConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
-	f.IntVar(&c.NumWorkers, prefix+"num-sub-workers", 0, "Number of sub-workers to run for concurrent processing of jobs. Setting it to 0 will run a subworker per available CPU core.")
+	f.IntVar(&c.NumWorkers, prefix+"num-sub-workers", 4, "Number of sub-workers to run for concurrent processing of jobs.")
 }
 
 func (c *WorkerConfig) RegisterFlags(f *flag.FlagSet) {
@@ -51,11 +50,8 @@ func (c *WorkerConfig) RegisterFlags(f *flag.FlagSet) {
 }
 
 func (c *WorkerConfig) Validate() error {
-	if c.NumWorkers < 0 {
-		return errors.New("num_workers must be >= 0")
-	}
-	if c.NumWorkers == 0 {
-		c.NumWorkers = runtime.GOMAXPROCS(0)
+	if c.NumWorkers <= 0 {
+		return errors.New("num_workers must be > 0")
 	}
 
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:
Since programs do not have visibility into CPU requests/limits set by k8s on the pods, `runtime.GOMAXPROCS` returns the number of cores on the host. This causes us to run too many sub-workers, causing Workers to pick up more work than their capacity.

In this PR, I am removing the usage of `runtime.GOMAXPROCS` and asking the Loki operator to set a non-zero value for the number of sub-workers to run. Based on some testing, running 4 sub-workers seems a reasonable default with the current CPU request/limit default in our jsonnet.
