### PR TITLE
chore: Support multi-tenancy in indexobj builder 

### DIFF
--- a/pkg/dataobj/consumer/mock_test.go
+++ b/pkg/dataobj/consumer/mock_test.go
@@ -298,10 +298,12 @@ type recordingTocWriter struct {
 }
 
 func (m *recordingTocWriter) WriteEntry(ctx context.Context, dataobjPath string, timeRanges multitenancy.TimeRangeSet) error {
-	m.entries = append(m.entries, recordedTocEntry{
-		DataObjectPath: dataobjPath,
-		MinTimestamp:   timeRanges["default"].MinTime,
-		MaxTimestamp:   timeRanges["default"].MaxTime,
-	})
+	for _, timeRange := range timeRanges {
+		m.entries = append(m.entries, recordedTocEntry{
+			DataObjectPath: dataobjPath,
+			MinTimestamp:   timeRange.MinTime,
+			MaxTimestamp:   timeRange.MaxTime,
+		})
+	}
 	return m.TableOfContentsWriter.WriteEntry(ctx, dataobjPath, timeRanges)
 }

--- a/pkg/dataobj/consumer/mock_test.go
+++ b/pkg/dataobj/consumer/mock_test.go
@@ -297,7 +297,7 @@ type recordingTocWriter struct {
 	*metastore.TableOfContentsWriter
 }
 
-func (m *recordingTocWriter) WriteEntry(ctx context.Context, dataobjPath string, timeRanges multitenancy.TimeRangeSet) error {
+func (m *recordingTocWriter) WriteEntry(ctx context.Context, dataobjPath string, timeRanges []multitenancy.TimeRange) error {
 	for _, timeRange := range timeRanges {
 		m.entries = append(m.entries, recordedTocEntry{
 			DataObjectPath: dataobjPath,

--- a/pkg/dataobj/consumer/mock_test.go
+++ b/pkg/dataobj/consumer/mock_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/dataobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/consumer/logsobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/metastore"
+	"github.com/grafana/loki/v3/pkg/dataobj/metastore/multitenancy"
 	"github.com/grafana/loki/v3/pkg/logproto"
 )
 
@@ -296,11 +297,11 @@ type recordingTocWriter struct {
 	*metastore.TableOfContentsWriter
 }
 
-func (m *recordingTocWriter) WriteEntry(ctx context.Context, dataobjPath string, minTimestamp, maxTimestamp time.Time) error {
+func (m *recordingTocWriter) WriteEntry(ctx context.Context, dataobjPath string, timeRanges multitenancy.TimeRangeSet) error {
 	m.entries = append(m.entries, recordedTocEntry{
 		DataObjectPath: dataobjPath,
-		MinTimestamp:   minTimestamp,
-		MaxTimestamp:   maxTimestamp,
+		MinTimestamp:   timeRanges["default"].MinTime,
+		MaxTimestamp:   timeRanges["default"].MaxTime,
 	})
-	return m.TableOfContentsWriter.WriteEntry(ctx, dataobjPath, minTimestamp, maxTimestamp)
+	return m.TableOfContentsWriter.WriteEntry(ctx, dataobjPath, timeRanges)
 }

--- a/pkg/dataobj/consumer/partition_processor.go
+++ b/pkg/dataobj/consumer/partition_processor.go
@@ -21,6 +21,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/dataobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/consumer/logsobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/metastore"
+	"github.com/grafana/loki/v3/pkg/dataobj/metastore/multitenancy"
 	"github.com/grafana/loki/v3/pkg/dataobj/uploader"
 	"github.com/grafana/loki/v3/pkg/kafka"
 	"github.com/grafana/loki/v3/pkg/logproto"
@@ -46,7 +47,7 @@ type producer interface {
 }
 
 type tocWriter interface {
-	WriteEntry(ctx context.Context, dataobjPath string, minTimestamp, maxTimestamp time.Time) error
+	WriteEntry(ctx context.Context, dataobjPath string, timeRanges multitenancy.TimeRangeSet) error
 }
 
 type partitionProcessor struct {
@@ -340,7 +341,13 @@ func (p *partitionProcessor) flush() error {
 		return err
 	}
 
-	if err := p.metastoreTocWriter.WriteEntry(p.ctx, objectPath, minTime, maxTime); err != nil {
+	// TODO(benclive): Remove this Update once the indexes are being built from the metastore events
+	if err := p.metastoreTocWriter.WriteEntry(p.ctx, objectPath, multitenancy.TimeRangeSet{
+		string(p.tenantID): multitenancy.TimeRange{
+			MinTime: minTime,
+			MaxTime: maxTime,
+		},
+	}); err != nil {
 		level.Error(p.logger).Log("msg", "failed to update metastore", "err", err)
 		return err
 	}

--- a/pkg/dataobj/consumer/partition_processor.go
+++ b/pkg/dataobj/consumer/partition_processor.go
@@ -137,7 +137,7 @@ func newPartitionProcessor(
 		level.Error(logger).Log("msg", "failed to register uploader metrics", "err", err)
 	}
 
-	metastoreTocWriter := metastore.NewTableOfContentsWriter(metastoreCfg, bucket, tenantID, logger)
+	metastoreTocWriter := metastore.NewTableOfContentsWriter(metastoreCfg, bucket, logger)
 	if err := metastoreTocWriter.RegisterMetrics(reg); err != nil {
 		level.Error(logger).Log("msg", "failed to register metastore updater metrics", "err", err)
 	}

--- a/pkg/dataobj/consumer/partition_processor.go
+++ b/pkg/dataobj/consumer/partition_processor.go
@@ -344,7 +344,7 @@ func (p *partitionProcessor) flush() error {
 	// TODO(benclive): Remove this Update once the indexes are being built from the metastore events
 	if err := p.metastoreTocWriter.WriteEntry(p.ctx, objectPath, []multitenancy.TimeRange{
 		{
-			Tenant:  multitenancy.TenantID(p.tenantID),
+			Tenant:  string(p.tenantID),
 			MinTime: minTime,
 			MaxTime: maxTime,
 		},

--- a/pkg/dataobj/consumer/partition_processor.go
+++ b/pkg/dataobj/consumer/partition_processor.go
@@ -47,7 +47,7 @@ type producer interface {
 }
 
 type tocWriter interface {
-	WriteEntry(ctx context.Context, dataobjPath string, timeRanges multitenancy.TimeRangeSet) error
+	WriteEntry(ctx context.Context, dataobjPath string, timeRanges []multitenancy.TimeRange) error
 }
 
 type partitionProcessor struct {
@@ -342,8 +342,9 @@ func (p *partitionProcessor) flush() error {
 	}
 
 	// TODO(benclive): Remove this Update once the indexes are being built from the metastore events
-	if err := p.metastoreTocWriter.WriteEntry(p.ctx, objectPath, multitenancy.TimeRangeSet{
-		string(p.tenantID): multitenancy.TimeRange{
+	if err := p.metastoreTocWriter.WriteEntry(p.ctx, objectPath, []multitenancy.TimeRange{
+		{
+			Tenant:  multitenancy.TenantID(p.tenantID),
 			MinTime: minTime,
 			MaxTime: maxTime,
 		},

--- a/pkg/dataobj/index/builder.go
+++ b/pkg/dataobj/index/builder.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
-	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -301,7 +300,7 @@ func (p *Builder) buildIndex(events []metastore.ObjectWrittenEvent) error {
 		return processingErrors.Err()
 	}
 
-	minTime, maxTime := p.calculator.TimeRange()
+	tenantTimeRanges := p.calculator.TimeRanges()
 	obj, closer, err := p.calculator.Flush()
 	if err != nil {
 		return fmt.Errorf("failed to flush builder: %w", err)
@@ -324,11 +323,8 @@ func (p *Builder) buildIndex(events []metastore.ObjectWrittenEvent) error {
 	}
 
 	metastoreTocWriter := metastore.NewTableOfContentsWriter(p.mCfg, indexStorageBucket, events[0].Tenant, p.logger)
-	if minTime.IsZero() || maxTime.IsZero() {
-		return errors.New("failed to get min/max timestamps")
-	}
-	if err := metastoreTocWriter.WriteEntry(p.ctx, key, minTime, maxTime); err != nil {
-		return fmt.Errorf("failed to update metastore: %w", err)
+	if err := metastoreTocWriter.WriteEntry(p.ctx, key, tenantTimeRanges); err != nil {
+		return fmt.Errorf("failed to update metastore ToC file: %w", err)
 	}
 
 	level.Info(p.logger).Log("msg", "finished building index", "tenant", events[0].Tenant, "events", len(events), "size", obj.Size(), "duration", time.Since(start))

--- a/pkg/dataobj/index/builder.go
+++ b/pkg/dataobj/index/builder.go
@@ -322,7 +322,7 @@ func (p *Builder) buildIndex(events []metastore.ObjectWrittenEvent) error {
 		return fmt.Errorf("failed to upload index: %w", err)
 	}
 
-	metastoreTocWriter := metastore.NewTableOfContentsWriter(p.mCfg, indexStorageBucket, events[0].Tenant, p.logger)
+	metastoreTocWriter := metastore.NewTableOfContentsWriter(p.mCfg, indexStorageBucket, p.logger)
 	if err := metastoreTocWriter.WriteEntry(p.ctx, key, tenantTimeRanges); err != nil {
 		return fmt.Errorf("failed to update metastore ToC file: %w", err)
 	}

--- a/pkg/dataobj/index/calculate.go
+++ b/pkg/dataobj/index/calculate.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/grafana/loki/v3/pkg/dataobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/index/indexobj"
+	"github.com/grafana/loki/v3/pkg/dataobj/metastore/multitenancy"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/logs"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/streams"
 )
@@ -40,8 +41,8 @@ func (c *Calculator) Reset() {
 	clear(c.indexStreamIDLookup)
 }
 
-func (c *Calculator) TimeRange() (minTime, maxTime time.Time) {
-	return c.indexobjBuilder.TimeRange()
+func (c *Calculator) TimeRanges() multitenancy.TimeRangeSet {
+	return c.indexobjBuilder.TimeRanges()
 }
 
 func (c *Calculator) Flush() (*dataobj.Object, io.Closer, error) {
@@ -98,7 +99,7 @@ func (c *Calculator) processStreamsSection(ctx context.Context, section *dataobj
 			break
 		}
 		for _, stream := range streamBuf[:n] {
-			newStreamID, err := c.indexobjBuilder.AppendStream(stream)
+			newStreamID, err := c.indexobjBuilder.AppendStream(streamSection.Tenant(), stream)
 			if err != nil {
 				return fmt.Errorf("failed to append to stream: %w", err)
 			}
@@ -172,7 +173,7 @@ func (c *Calculator) processLogsSection(ctx context.Context, sectionLogger log.L
 		// Lock the mutex once per read for perf reasons.
 		c.builderMtx.Lock()
 		for _, log := range logsInfo[:n] {
-			err = c.indexobjBuilder.ObserveLogLine(log.objectPath, log.sectionIdx, log.streamID, c.indexStreamIDLookup[log.streamID], log.timestamp, log.length)
+			err = c.indexobjBuilder.ObserveLogLine(logsSection.Tenant(), log.objectPath, log.sectionIdx, log.streamID, c.indexStreamIDLookup[log.streamID], log.timestamp, log.length)
 			if err != nil {
 				c.builderMtx.Unlock()
 				return fmt.Errorf("failed to observe log line: %w", err)
@@ -188,7 +189,7 @@ func (c *Calculator) processLogsSection(ctx context.Context, sectionLogger log.L
 			return fmt.Errorf("failed to marshal bloom filter: %w", err)
 		}
 		c.builderMtx.Lock()
-		err = c.indexobjBuilder.AppendColumnIndex(objectPath, sectionIdx, columnName, columnIndexes[columnName], bloomBytes)
+		err = c.indexobjBuilder.AppendColumnIndex(logsSection.Tenant(), objectPath, sectionIdx, columnName, columnIndexes[columnName], bloomBytes)
 		c.builderMtx.Unlock()
 		if err != nil {
 			return fmt.Errorf("failed to append column index: %w", err)

--- a/pkg/dataobj/index/calculate.go
+++ b/pkg/dataobj/index/calculate.go
@@ -99,7 +99,7 @@ func (c *Calculator) processStreamsSection(ctx context.Context, section *dataobj
 			break
 		}
 		for _, stream := range streamBuf[:n] {
-			newStreamID, err := c.indexobjBuilder.AppendStream(multitenancy.TenantID(streamSection.Tenant()), stream)
+			newStreamID, err := c.indexobjBuilder.AppendStream(streamSection.Tenant(), stream)
 			if err != nil {
 				return fmt.Errorf("failed to append to stream: %w", err)
 			}
@@ -126,7 +126,7 @@ func (c *Calculator) processLogsSection(ctx context.Context, sectionLogger log.L
 		return fmt.Errorf("failed to open logs section: %w", err)
 	}
 
-	tenantID := multitenancy.TenantID(logsSection.Tenant())
+	tenantID := logsSection.Tenant()
 
 	// Fetch the column statistics in order to init the bloom filters for each column
 	stats, err := logs.ReadStats(ctx, logsSection)

--- a/pkg/dataobj/index/calculate_test.go
+++ b/pkg/dataobj/index/calculate_test.go
@@ -11,13 +11,12 @@ import (
 	"github.com/go-kit/log"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/loki/pkg/push"
 	"github.com/grafana/loki/v3/pkg/dataobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/consumer/logsobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/index/indexobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/pointers"
 	"github.com/grafana/loki/v3/pkg/logproto"
-
-	"github.com/grafana/loki/pkg/push"
 )
 
 var testCalculatorConfig = indexobj.BuilderConfig{
@@ -119,10 +118,11 @@ func TestCalculator_Calculate(t *testing.T) {
 		defer closer.Close()
 
 		require.Greater(t, obj.Size(), int64(0))
-		require.False(t, timeRanges[""].MinTime.IsZero())
-		require.Equal(t, timeRanges[""].MinTime, time.Unix(10, 0).UTC())
-		require.False(t, timeRanges[""].MaxTime.IsZero())
-		require.Equal(t, timeRanges[""].MaxTime, time.Unix(25, 0).UTC())
+		require.Equal(t, len(timeRanges), 1)
+		require.False(t, timeRanges[0].MinTime.IsZero())
+		require.Equal(t, timeRanges[0].MinTime, time.Unix(10, 0).UTC())
+		require.False(t, timeRanges[0].MaxTime.IsZero())
+		require.Equal(t, timeRanges[0].MaxTime, time.Unix(25, 0).UTC())
 
 		// Confirm we have multiple pointers sections
 		count := obj.Sections().Count(pointers.CheckSection)

--- a/pkg/dataobj/index/calculate_test.go
+++ b/pkg/dataobj/index/calculate_test.go
@@ -113,16 +113,16 @@ func TestCalculator_Calculate(t *testing.T) {
 		}
 
 		// Verify we can flush the results
-		minTime, maxTime := calculator.TimeRange()
+		timeRanges := calculator.TimeRanges()
 		obj, closer, err := calculator.Flush()
 		require.NoError(t, err)
 		defer closer.Close()
 
 		require.Greater(t, obj.Size(), int64(0))
-		require.False(t, minTime.IsZero())
-		require.Equal(t, minTime, time.Unix(10, 0).UTC())
-		require.False(t, maxTime.IsZero())
-		require.Equal(t, maxTime, time.Unix(25, 0).UTC())
+		require.False(t, timeRanges[""].MinTime.IsZero())
+		require.Equal(t, timeRanges[""].MinTime, time.Unix(10, 0).UTC())
+		require.False(t, timeRanges[""].MaxTime.IsZero())
+		require.Equal(t, timeRanges[""].MaxTime, time.Unix(25, 0).UTC())
 
 		// Confirm we have multiple pointers sections
 		count := obj.Sections().Count(pointers.CheckSection)

--- a/pkg/dataobj/index/calculate_test.go
+++ b/pkg/dataobj/index/calculate_test.go
@@ -11,12 +11,13 @@ import (
 	"github.com/go-kit/log"
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/loki/pkg/push"
 	"github.com/grafana/loki/v3/pkg/dataobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/consumer/logsobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/index/indexobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/pointers"
 	"github.com/grafana/loki/v3/pkg/logproto"
+
+	"github.com/grafana/loki/pkg/push"
 )
 
 var testCalculatorConfig = indexobj.BuilderConfig{

--- a/pkg/dataobj/index/indexobj/builder.go
+++ b/pkg/dataobj/index/indexobj/builder.go
@@ -219,6 +219,7 @@ func (b *Builder) AppendStream(tenantID string, stream streams.Stream) (int64, e
 	tenantStreams, ok := b.streams[tenantID]
 	if !ok {
 		tenantStreams = streams.NewBuilder(b.metrics.streams, int(b.cfg.TargetPageSize))
+		tenantStreams.SetTenant(tenantID)
 		b.streams[tenantID] = tenantStreams
 	}
 	// Record the stream in the stream section.

--- a/pkg/dataobj/index/indexobj/builder.go
+++ b/pkg/dataobj/index/indexobj/builder.go
@@ -185,6 +185,7 @@ func (b *Builder) AppendIndexPointer(tenantID multitenancy.TenantID, path string
 	tenantIndexPointers, ok := b.indexPointers[tenantID]
 	if !ok {
 		tenantIndexPointers = indexpointers.NewBuilder(b.metrics.indexPointers, int(b.cfg.TargetPageSize))
+		tenantIndexPointers.SetTenant(string(tenantID))
 		b.indexPointers[tenantID] = tenantIndexPointers
 	}
 
@@ -283,6 +284,7 @@ func (b *Builder) ObserveLogLine(tenantID multitenancy.TenantID, path string, se
 	tenantPointers, ok := b.pointers[tenantID]
 	if !ok {
 		tenantPointers = pointers.NewBuilder(b.metrics.pointers, int(b.cfg.TargetPageSize))
+		tenantPointers.SetTenant(string(tenantID))
 		b.pointers[tenantID] = tenantPointers
 	}
 	tenantPointers.ObserveStream(path, section, streamIDInObject, streamIDInIndex, ts, uncompressedSize)
@@ -326,6 +328,7 @@ func (b *Builder) AppendColumnIndex(tenantID multitenancy.TenantID, path string,
 	tenantPointers, ok := b.pointers[tenantID]
 	if !ok {
 		tenantPointers = pointers.NewBuilder(b.metrics.pointers, int(b.cfg.TargetPageSize))
+		tenantPointers.SetTenant(string(tenantID))
 		b.pointers[tenantID] = tenantPointers
 	}
 	tenantPointers.RecordColumnIndex(path, section, columnName, columnIndex, valuesBloom)

--- a/pkg/dataobj/index/indexobj/builder.go
+++ b/pkg/dataobj/index/indexobj/builder.go
@@ -185,7 +185,7 @@ func (b *Builder) AppendIndexPointer(tenantID string, path string, startTs time.
 	tenantIndexPointers, ok := b.indexPointers[tenantID]
 	if !ok {
 		tenantIndexPointers = indexpointers.NewBuilder(b.metrics.indexPointers, int(b.cfg.TargetPageSize))
-		tenantIndexPointers.SetTenant(string(tenantID))
+		tenantIndexPointers.SetTenant(tenantID)
 		b.indexPointers[tenantID] = tenantIndexPointers
 	}
 
@@ -328,7 +328,7 @@ func (b *Builder) AppendColumnIndex(tenantID string, path string, section int64,
 	tenantPointers, ok := b.pointers[tenantID]
 	if !ok {
 		tenantPointers = pointers.NewBuilder(b.metrics.pointers, int(b.cfg.TargetPageSize))
-		tenantPointers.SetTenant(string(tenantID))
+		tenantPointers.SetTenant(tenantID)
 		b.pointers[tenantID] = tenantPointers
 	}
 	tenantPointers.RecordColumnIndex(path, section, columnName, columnIndex, valuesBloom)

--- a/pkg/dataobj/index/indexobj/builder.go
+++ b/pkg/dataobj/index/indexobj/builder.go
@@ -15,6 +15,7 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 
 	"github.com/grafana/loki/v3/pkg/dataobj"
+	"github.com/grafana/loki/v3/pkg/dataobj/metastore/multitenancy"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/indexpointers"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/pointers"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/streams"
@@ -118,10 +119,10 @@ type Builder struct {
 
 	currentSizeEstimate int
 
-	builder       *dataobj.Builder // Inner builder for accumulating sections.
-	streams       *streams.Builder
-	pointers      *pointers.Builder
-	indexPointers *indexpointers.Builder
+	builder       *dataobj.Builder                  // Inner builder for accumulating sections.
+	streams       map[string]*streams.Builder       // The key is the TenantID.
+	pointers      map[string]*pointers.Builder      // The key is the TenantID.
+	indexPointers map[string]*indexpointers.Builder // The key is the TenantID.
 
 	state builderState
 }
@@ -149,6 +150,7 @@ func NewBuilder(cfg BuilderConfig, scratchStore scratch.Store) (*Builder, error)
 		return nil, fmt.Errorf("failed to create LRU cache: %w", err)
 	}
 
+	// TODO: Add metrics for number of tenants in each object
 	metrics := newBuilderMetrics()
 	metrics.ObserveConfig(cfg)
 
@@ -159,9 +161,9 @@ func NewBuilder(cfg BuilderConfig, scratchStore scratch.Store) (*Builder, error)
 		labelCache: labelCache,
 
 		builder:       dataobj.NewBuilder(scratchStore),
-		streams:       streams.NewBuilder(metrics.streams, int(cfg.TargetPageSize)),
-		pointers:      pointers.NewBuilder(metrics.pointers, int(cfg.TargetPageSize)),
-		indexPointers: indexpointers.NewBuilder(metrics.indexPointers, int(cfg.TargetPageSize)),
+		streams:       make(map[string]*streams.Builder),
+		pointers:      make(map[string]*pointers.Builder),
+		indexPointers: make(map[string]*indexpointers.Builder),
 	}, nil
 }
 
@@ -169,7 +171,7 @@ func (b *Builder) GetEstimatedSize() int {
 	return b.currentSizeEstimate
 }
 
-func (b *Builder) AppendIndexPointer(path string, startTs time.Time, endTs time.Time) error {
+func (b *Builder) AppendIndexPointer(tenantID string, path string, startTs time.Time, endTs time.Time) error {
 	b.metrics.appendsTotal.Inc()
 	newEntrySize := len(path) + 1 + 1 // path, startTs, endTs
 
@@ -180,10 +182,16 @@ func (b *Builder) AppendIndexPointer(path string, startTs time.Time, endTs time.
 	timer := prometheus.NewTimer(b.metrics.appendTime)
 	defer timer.ObserveDuration()
 
-	b.indexPointers.Append(path, startTs, endTs)
+	tenantIndexPointers, ok := b.indexPointers[tenantID]
+	if !ok {
+		tenantIndexPointers = indexpointers.NewBuilder(b.metrics.indexPointers, int(b.cfg.TargetPageSize))
+		b.indexPointers[tenantID] = tenantIndexPointers
+	}
 
-	if b.indexPointers.EstimatedSize() > int(b.cfg.TargetSectionSize) {
-		if err := b.builder.Append(b.indexPointers); err != nil {
+	tenantIndexPointers.Append(path, startTs, endTs)
+
+	if tenantIndexPointers.EstimatedSize() > int(b.cfg.TargetSectionSize) {
+		if err := b.builder.Append(tenantIndexPointers); err != nil {
 			return err
 		}
 	}
@@ -195,7 +203,7 @@ func (b *Builder) AppendIndexPointer(path string, startTs time.Time, endTs time.
 }
 
 // AppendStream appends a stream to the object's stream section, returning the stream ID within this object.
-func (b *Builder) AppendStream(stream streams.Stream) (int64, error) {
+func (b *Builder) AppendStream(tenantID string, stream streams.Stream) (int64, error) {
 	b.metrics.appendsTotal.Inc()
 
 	newEntrySize := labelsEstimate(stream.Labels) + 2
@@ -207,15 +215,20 @@ func (b *Builder) AppendStream(stream streams.Stream) (int64, error) {
 	timer := prometheus.NewTimer(b.metrics.appendTime)
 	defer timer.ObserveDuration()
 
+	tenantStreams, ok := b.streams[tenantID]
+	if !ok {
+		tenantStreams = streams.NewBuilder(b.metrics.streams, int(b.cfg.TargetPageSize))
+		b.streams[tenantID] = tenantStreams
+	}
 	// Record the stream in the stream section.
 	// Once to capture the min timestamp and uncompressed size, again to record the max timestamp.
-	streamID := b.streams.Record(stream.Labels, stream.MinTimestamp, stream.UncompressedSize)
-	_ = b.streams.Record(stream.Labels, stream.MaxTimestamp, 0)
+	streamID := tenantStreams.Record(stream.Labels, stream.MinTimestamp, stream.UncompressedSize)
+	_ = tenantStreams.Record(stream.Labels, stream.MaxTimestamp, 0)
 
 	// If our logs section has gotten big enough, we want to flush it to the
 	// encoder and start a new section.
-	if b.pointers.EstimatedSize() > int(b.cfg.TargetSectionSize) {
-		if err := b.builder.Append(b.pointers); err != nil {
+	if tenantStreams.EstimatedSize() > int(b.cfg.TargetSectionSize) {
+		if err := b.builder.Append(tenantStreams); err != nil {
 			b.metrics.appendFailures.Inc()
 			return 0, err
 		}
@@ -250,7 +263,7 @@ func labelsEstimate(ls labels.Labels) int {
 //
 // Once a Builder is full, call [Builder.Flush] to flush the buffered data,
 // then call Append again with the same entry.
-func (b *Builder) ObserveLogLine(path string, section int64, streamIDInObject int64, streamIDInIndex int64, ts time.Time, uncompressedSize int64) error {
+func (b *Builder) ObserveLogLine(tenantID string, path string, section int64, streamIDInObject int64, streamIDInIndex int64, ts time.Time, uncompressedSize int64) error {
 	// Check whether the buffer is full before a stream can be appended; this is
 	// tends to overestimate, but we may still go over our target size.
 	//
@@ -267,12 +280,17 @@ func (b *Builder) ObserveLogLine(path string, section int64, streamIDInObject in
 	timer := prometheus.NewTimer(b.metrics.appendTime)
 	defer timer.ObserveDuration()
 
-	b.pointers.ObserveStream(path, section, streamIDInObject, streamIDInIndex, ts, uncompressedSize)
+	tenantPointers, ok := b.pointers[tenantID]
+	if !ok {
+		tenantPointers = pointers.NewBuilder(b.metrics.pointers, int(b.cfg.TargetPageSize))
+		b.pointers[tenantID] = tenantPointers
+	}
+	tenantPointers.ObserveStream(path, section, streamIDInObject, streamIDInIndex, ts, uncompressedSize)
 
 	// If our logs section has gotten big enough, we want to flush it to the
 	// encoder and start a new section.
-	if b.pointers.EstimatedSize() > int(b.cfg.TargetSectionSize) {
-		if err := b.builder.Append(b.pointers); err != nil {
+	if tenantPointers.EstimatedSize() > int(b.cfg.TargetSectionSize) {
+		if err := b.builder.Append(tenantPointers); err != nil {
 			return err
 		}
 	}
@@ -288,7 +306,7 @@ func (b *Builder) ObserveLogLine(path string, section int64, streamIDInObject in
 //
 // Once a Builder is full, call [Builder.Flush] to flush the buffered data,
 // then call Append again with the same entry.
-func (b *Builder) AppendColumnIndex(path string, section int64, columnName string, columnIndex int64, valuesBloom []byte) error {
+func (b *Builder) AppendColumnIndex(tenantID string, path string, section int64, columnName string, columnIndex int64, valuesBloom []byte) error {
 	// Check whether the buffer is full before a stream can be appended; this is
 	// tends to overestimate, but we may still go over our target size.
 	//
@@ -305,12 +323,17 @@ func (b *Builder) AppendColumnIndex(path string, section int64, columnName strin
 	timer := prometheus.NewTimer(b.metrics.appendTime)
 	defer timer.ObserveDuration()
 
-	b.pointers.RecordColumnIndex(path, section, columnName, columnIndex, valuesBloom)
+	tenantPointers, ok := b.pointers[tenantID]
+	if !ok {
+		tenantPointers = pointers.NewBuilder(b.metrics.pointers, int(b.cfg.TargetPageSize))
+		b.pointers[tenantID] = tenantPointers
+	}
+	tenantPointers.RecordColumnIndex(path, section, columnName, columnIndex, valuesBloom)
 
 	// If our logs section has gotten big enough, we want to flush it to the
 	// encoder and start a new section.
-	if b.pointers.EstimatedSize() > int(b.cfg.TargetSectionSize) {
-		if err := b.builder.Append(b.pointers); err != nil {
+	if tenantPointers.EstimatedSize() > int(b.cfg.TargetSectionSize) {
+		if err := b.builder.Append(tenantPointers); err != nil {
 			return err
 		}
 	}
@@ -322,24 +345,37 @@ func (b *Builder) AppendColumnIndex(path string, section int64, columnName strin
 
 func (b *Builder) estimatedSize() int {
 	var size int
-	size += b.streams.EstimatedSize()
-	size += b.pointers.EstimatedSize()
-	size += b.indexPointers.EstimatedSize()
+	for _, tenantStreams := range b.streams {
+		size += tenantStreams.EstimatedSize()
+	}
+	for _, tenantPointers := range b.pointers {
+		size += tenantPointers.EstimatedSize()
+	}
+	for _, tenantIndexPointers := range b.indexPointers {
+		size += tenantIndexPointers.EstimatedSize()
+	}
 	size += b.builder.Bytes()
 	b.metrics.sizeEstimate.Set(float64(size))
 	return size
 }
 
-// TimeRange returns the time range of the data in the builder.
-func (b *Builder) TimeRange() (minTime, maxTime time.Time) {
-	return b.streams.TimeRange()
+// TimeRanges returns the time range of the data in the builder, by tenant.
+func (b *Builder) TimeRanges() multitenancy.TimeRangeSet {
+	timeRanges := make(multitenancy.TimeRangeSet, len(b.streams))
+	for tenantID, tenantStreams := range b.streams {
+		minTime, maxTime := tenantStreams.TimeRange()
+		timeRanges[tenantID] = multitenancy.TimeRange{
+			MinTime: minTime,
+			MaxTime: maxTime,
+		}
+	}
+	return timeRanges
 }
 
 // Flush flushes all buffered data to the buffer provided. Calling Flush can result
 // in a no-op if there is no buffered data to flush.
 //
-// [Builder.Reset] is called after a successful Flush to discard any pending
-// data and allow new data to be appended.
+// [Builder.Reset] is called after a successful Flush to discard any pending data and allow new data to be appended.
 func (b *Builder) Flush() (*dataobj.Object, io.Closer, error) {
 	if b.state == builderStateEmpty {
 		return nil, nil, ErrBuilderEmpty
@@ -349,12 +385,17 @@ func (b *Builder) Flush() (*dataobj.Object, io.Closer, error) {
 	timer := prometheus.NewTimer(b.metrics.buildTime)
 	defer timer.ObserveDuration()
 
-	// Flush sections one more time in case they have data.
 	var flushErrors []error
 
-	flushErrors = append(flushErrors, b.builder.Append(b.streams))
-	flushErrors = append(flushErrors, b.builder.Append(b.pointers))
-	flushErrors = append(flushErrors, b.builder.Append(b.indexPointers))
+	for _, tenantStreams := range b.streams {
+		flushErrors = append(flushErrors, b.builder.Append(tenantStreams))
+	}
+	for _, tenantPointers := range b.pointers {
+		flushErrors = append(flushErrors, b.builder.Append(tenantPointers))
+	}
+	for _, tenantIndexPointers := range b.indexPointers {
+		flushErrors = append(flushErrors, b.builder.Append(tenantIndexPointers))
+	}
 
 	if err := errors.Join(flushErrors...); err != nil {
 		b.metrics.flushFailures.Inc()
@@ -364,10 +405,11 @@ func (b *Builder) Flush() (*dataobj.Object, io.Closer, error) {
 	obj, closer, err := b.builder.Flush()
 	if err != nil {
 		b.metrics.flushFailures.Inc()
-		return nil, nil, fmt.Errorf("building object: %w", err)
+		return nil, nil, fmt.Errorf("flushing object: %w", err)
 	}
 
 	b.metrics.builtSize.Observe(float64(obj.Size()))
+
 	err = b.observeObject(context.Background(), obj)
 
 	b.Reset()
@@ -411,9 +453,15 @@ func (b *Builder) observeObject(ctx context.Context, obj *dataobj.Object) error 
 // Reset discards pending data and resets the builder to an empty state.
 func (b *Builder) Reset() {
 	b.builder.Reset()
-	b.streams.Reset()
-	b.pointers.Reset()
-	b.indexPointers.Reset()
+	for _, tenantStreams := range b.streams {
+		tenantStreams.Reset()
+	}
+	for _, tenantPointers := range b.pointers {
+		tenantPointers.Reset()
+	}
+	for _, tenantIndexPointers := range b.indexPointers {
+		tenantIndexPointers.Reset()
+	}
 
 	b.metrics.sizeEstimate.Set(0)
 	b.currentSizeEstimate = 0

--- a/pkg/dataobj/index/indexobj/builder_test.go
+++ b/pkg/dataobj/index/indexobj/builder_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/loki/v3/pkg/dataobj/metastore/multitenancy"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/indexpointers"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/logs"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/pointers"
@@ -99,7 +98,7 @@ func TestBuilder(t *testing.T) {
 		builder, err := NewBuilder(testBuilderConfig, nil)
 		require.NoError(t, err)
 
-		tenants := []multitenancy.TenantID{"test-tenant-1", "test-tenant-2"}
+		tenants := []string{"test-tenant-1", "test-tenant-2"}
 
 		for i, stream := range testStreams {
 			tenant := tenants[i%len(tenants)]

--- a/pkg/dataobj/index/indexobj/builder_test.go
+++ b/pkg/dataobj/index/indexobj/builder_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/loki/v3/pkg/dataobj/sections/indexpointers"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/logs"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/pointers"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/streams"
@@ -24,6 +25,8 @@ var testBuilderConfig = BuilderConfig{
 
 	SectionStripeMergeLimit: 2,
 }
+
+const testTenant = "test-tenant"
 
 func TestBuilder(t *testing.T) {
 	testStreams := []streams.Stream{
@@ -59,6 +62,13 @@ func TestBuilder(t *testing.T) {
 			ColumnIndex:       1,
 			ValuesBloomFilter: []byte{1, 2, 3},
 		},
+		{
+			Path:              "test/path2",
+			Section:           2,
+			ColumnName:        "bar2",
+			ColumnIndex:       2,
+			ValuesBloomFilter: []byte{1, 2, 3, 4},
+		},
 	}
 
 	t.Run("Build", func(t *testing.T) {
@@ -66,11 +76,11 @@ func TestBuilder(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, stream := range testStreams {
-			_, err := builder.AppendStream(stream)
+			_, err := builder.AppendStream(testTenant, stream)
 			require.NoError(t, err)
 		}
 		for _, pointer := range testPointers {
-			err := builder.AppendColumnIndex(pointer.Path, pointer.Section, pointer.ColumnName, pointer.ColumnIndex, pointer.ValuesBloomFilter)
+			err := builder.AppendColumnIndex(testTenant, pointer.Path, pointer.Section, pointer.ColumnName, pointer.ColumnIndex, pointer.ValuesBloomFilter)
 			require.NoError(t, err)
 		}
 
@@ -81,6 +91,34 @@ func TestBuilder(t *testing.T) {
 		require.Equal(t, 1, obj.Sections().Count(streams.CheckSection))
 		require.Equal(t, 1, obj.Sections().Count(pointers.CheckSection))
 		require.Equal(t, 0, obj.Sections().Count(logs.CheckSection))
+		require.Equal(t, 0, obj.Sections().Count(indexpointers.CheckSection))
+	})
+
+	t.Run("BuildMultiTenant", func(t *testing.T) {
+		builder, err := NewBuilder(testBuilderConfig, nil)
+		require.NoError(t, err)
+
+		tenants := []string{"test-tenant-1", "test-tenant-2"}
+
+		for i, stream := range testStreams {
+			tenant := tenants[i%len(tenants)]
+			_, err := builder.AppendStream(tenant, stream)
+			require.NoError(t, err)
+		}
+		for i, pointer := range testPointers {
+			tenant := tenants[i%len(tenants)]
+			err := builder.AppendColumnIndex(tenant, pointer.Path, pointer.Section, pointer.ColumnName, pointer.ColumnIndex, pointer.ValuesBloomFilter)
+			require.NoError(t, err)
+		}
+
+		obj, closer, err := builder.Flush()
+		require.NoError(t, err)
+		defer closer.Close()
+
+		require.Equal(t, len(tenants), obj.Sections().Count(streams.CheckSection))
+		require.Equal(t, len(tenants), obj.Sections().Count(pointers.CheckSection))
+		require.Equal(t, 0, obj.Sections().Count(logs.CheckSection))
+		require.Equal(t, 0, obj.Sections().Count(indexpointers.CheckSection))
 	})
 }
 
@@ -97,7 +135,7 @@ func TestBuilder_Append(t *testing.T) {
 	for {
 		require.NoError(t, ctx.Err())
 
-		_, err := builder.AppendStream(streams.Stream{
+		_, err := builder.AppendStream(testTenant, streams.Stream{
 			ID: 1,
 			Labels: labels.New(
 				labels.Label{Name: "cluster", Value: "test"},
@@ -127,7 +165,7 @@ func TestBuilder_AppendIndexPointer(t *testing.T) {
 	for {
 		require.NoError(t, ctx.Err())
 
-		err := builder.AppendIndexPointer(fmt.Sprintf("test/path-%d", i), time.Unix(10, 0).Add(time.Duration(i)*time.Second).UTC(), time.Unix(20, 0).Add(time.Duration(i)*time.Second).UTC())
+		err := builder.AppendIndexPointer(testTenant, fmt.Sprintf("test/path-%d", i), time.Unix(10, 0).Add(time.Duration(i)*time.Second).UTC(), time.Unix(20, 0).Add(time.Duration(i)*time.Second).UTC())
 		if errors.Is(err, ErrBuilderFull) {
 			break
 		}

--- a/pkg/dataobj/index/indexobj/builder_test.go
+++ b/pkg/dataobj/index/indexobj/builder_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/loki/v3/pkg/dataobj/metastore/multitenancy"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/indexpointers"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/logs"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/pointers"
@@ -98,7 +99,7 @@ func TestBuilder(t *testing.T) {
 		builder, err := NewBuilder(testBuilderConfig, nil)
 		require.NoError(t, err)
 
-		tenants := []string{"test-tenant-1", "test-tenant-2"}
+		tenants := []multitenancy.TenantID{"test-tenant-1", "test-tenant-2"}
 
 		for i, stream := range testStreams {
 			tenant := tenants[i%len(tenants)]

--- a/pkg/dataobj/metastore/metastore_test.go
+++ b/pkg/dataobj/metastore/metastore_test.go
@@ -46,8 +46,9 @@ func BenchmarkWriteMetastores(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		// Test writing metastores
 		stats := stats[i%len(stats)]
-		err := toc.WriteEntry(ctx, "path", multitenancy.TimeRangeSet{
-			tenantID: multitenancy.TimeRange{
+		err := toc.WriteEntry(ctx, "path", []multitenancy.TimeRange{
+			{
+				Tenant:  multitenancy.TenantID(tenantID),
 				MinTime: stats.MinTimestamp,
 				MaxTime: stats.MaxTimestamp,
 			},
@@ -83,8 +84,9 @@ func TestWriteMetastores(t *testing.T) {
 	require.Len(t, bucket.Objects(), 0)
 
 	// Test writing metastores
-	err := toc.WriteEntry(ctx, "test-dataobj-path", multitenancy.TimeRangeSet{
-		tenantID: multitenancy.TimeRange{
+	err := toc.WriteEntry(ctx, "test-dataobj-path", []multitenancy.TimeRange{
+		{
+			Tenant:  multitenancy.TenantID(tenantID),
 			MinTime: stats.MinTimestamp,
 			MaxTime: stats.MaxTimestamp,
 		},
@@ -102,8 +104,9 @@ func TestWriteMetastores(t *testing.T) {
 		MaxTimestamp: now,
 	}
 
-	err = toc.WriteEntry(ctx, "different-dataobj-path", multitenancy.TimeRangeSet{
-		tenantID: multitenancy.TimeRange{
+	err = toc.WriteEntry(ctx, "different-dataobj-path", []multitenancy.TimeRange{
+		{
+			Tenant:  multitenancy.TenantID(tenantID),
 			MinTime: flushResult2.MinTimestamp,
 			MaxTime: flushResult2.MaxTimestamp,
 		},
@@ -269,8 +272,9 @@ func TestDataObjectsPaths(t *testing.T) {
 			}
 
 			for _, tc := range testCases {
-				err := toc.WriteEntry(ctx, tc.path, multitenancy.TimeRangeSet{
-					tenantID: multitenancy.TimeRange{
+				err := toc.WriteEntry(ctx, tc.path, []multitenancy.TimeRange{
+					{
+						Tenant:  multitenancy.TenantID(tenantID),
 						MinTime: tc.startTime,
 						MaxTime: tc.endTime,
 					},

--- a/pkg/dataobj/metastore/metastore_test.go
+++ b/pkg/dataobj/metastore/metastore_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/grafana/dskit/backoff"
 	"github.com/grafana/dskit/user"
 	"github.com/thanos-io/objstore"
+
+	"github.com/grafana/loki/v3/pkg/dataobj/metastore/multitenancy"
 )
 
 func BenchmarkWriteMetastores(b *testing.B) {
@@ -44,7 +46,12 @@ func BenchmarkWriteMetastores(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		// Test writing metastores
 		stats := stats[i%len(stats)]
-		err := toc.WriteEntry(ctx, "path", stats.MinTimestamp, stats.MaxTimestamp)
+		err := toc.WriteEntry(ctx, "path", multitenancy.TimeRangeSet{
+			tenantID: multitenancy.TimeRange{
+				MinTime: stats.MinTimestamp,
+				MaxTime: stats.MaxTimestamp,
+			},
+		})
 		require.NoError(b, err)
 	}
 
@@ -76,7 +83,12 @@ func TestWriteMetastores(t *testing.T) {
 	require.Len(t, bucket.Objects(), 0)
 
 	// Test writing metastores
-	err := toc.WriteEntry(ctx, "test-dataobj-path", stats.MinTimestamp, stats.MaxTimestamp)
+	err := toc.WriteEntry(ctx, "test-dataobj-path", multitenancy.TimeRangeSet{
+		tenantID: multitenancy.TimeRange{
+			MinTime: stats.MinTimestamp,
+			MaxTime: stats.MaxTimestamp,
+		},
+	})
 	require.NoError(t, err)
 
 	require.Len(t, bucket.Objects(), 1)
@@ -90,7 +102,12 @@ func TestWriteMetastores(t *testing.T) {
 		MaxTimestamp: now,
 	}
 
-	err = toc.WriteEntry(ctx, "different-dataobj-path", flushResult2.MinTimestamp, flushResult2.MaxTimestamp)
+	err = toc.WriteEntry(ctx, "different-dataobj-path", multitenancy.TimeRangeSet{
+		tenantID: multitenancy.TimeRange{
+			MinTime: flushResult2.MinTimestamp,
+			MaxTime: flushResult2.MaxTimestamp,
+		},
+	})
 	require.NoError(t, err)
 
 	require.Len(t, bucket.Objects(), 1)
@@ -252,7 +269,12 @@ func TestDataObjectsPaths(t *testing.T) {
 			}
 
 			for _, tc := range testCases {
-				err := toc.WriteEntry(ctx, tc.path, tc.startTime, tc.endTime)
+				err := toc.WriteEntry(ctx, tc.path, multitenancy.TimeRangeSet{
+					tenantID: multitenancy.TimeRange{
+						MinTime: tc.startTime,
+						MaxTime: tc.endTime,
+					},
+				})
 				require.NoError(t, err)
 			}
 

--- a/pkg/dataobj/metastore/metastore_test.go
+++ b/pkg/dataobj/metastore/metastore_test.go
@@ -21,7 +21,7 @@ func BenchmarkWriteMetastores(b *testing.B) {
 	bucket := objstore.NewInMemBucket()
 	tenantID := "test-tenant"
 
-	toc := NewTableOfContentsWriter(Config{}, bucket, tenantID, log.NewNopLogger())
+	toc := NewTableOfContentsWriter(Config{}, bucket, log.NewNopLogger())
 
 	// Set limits for the test
 	toc.backoff = backoff.New(context.TODO(), backoff.Config{
@@ -48,7 +48,7 @@ func BenchmarkWriteMetastores(b *testing.B) {
 		stats := stats[i%len(stats)]
 		err := toc.WriteEntry(ctx, "path", []multitenancy.TimeRange{
 			{
-				Tenant:  multitenancy.TenantID(tenantID),
+				Tenant:  tenantID,
 				MinTime: stats.MinTimestamp,
 				MaxTime: stats.MaxTimestamp,
 			},
@@ -64,7 +64,7 @@ func TestWriteMetastores(t *testing.T) {
 	bucket := objstore.NewInMemBucket()
 	tenantID := "test-tenant"
 
-	toc := NewTableOfContentsWriter(Config{}, bucket, tenantID, log.NewNopLogger())
+	toc := NewTableOfContentsWriter(Config{}, bucket, log.NewNopLogger())
 
 	// Set limits for the test
 	toc.backoff = backoff.New(context.TODO(), backoff.Config{
@@ -86,7 +86,7 @@ func TestWriteMetastores(t *testing.T) {
 	// Test writing metastores
 	err := toc.WriteEntry(ctx, "test-dataobj-path", []multitenancy.TimeRange{
 		{
-			Tenant:  multitenancy.TenantID(tenantID),
+			Tenant:  tenantID,
 			MinTime: stats.MinTimestamp,
 			MaxTime: stats.MaxTimestamp,
 		},
@@ -106,7 +106,7 @@ func TestWriteMetastores(t *testing.T) {
 
 	err = toc.WriteEntry(ctx, "different-dataobj-path", []multitenancy.TimeRange{
 		{
-			Tenant:  multitenancy.TenantID(tenantID),
+			Tenant:  tenantID,
 			MinTime: flushResult2.MinTimestamp,
 			MaxTime: flushResult2.MaxTimestamp,
 		},
@@ -221,7 +221,7 @@ func TestDataObjectsPaths(t *testing.T) {
 					IndexStoragePrefix: tt.prefix,
 					EnabledTenantIDs:   tt.enabledTenantIDs,
 				},
-			}, bucket, tenantID, log.NewNopLogger())
+			}, bucket, log.NewNopLogger())
 
 			// Set limits for the test
 			toc.backoff = backoff.New(context.TODO(), backoff.Config{
@@ -274,7 +274,7 @@ func TestDataObjectsPaths(t *testing.T) {
 			for _, tc := range testCases {
 				err := toc.WriteEntry(ctx, tc.path, []multitenancy.TimeRange{
 					{
-						Tenant:  multitenancy.TenantID(tenantID),
+						Tenant:  tenantID,
 						MinTime: tc.startTime,
 						MaxTime: tc.endTime,
 					},

--- a/pkg/dataobj/metastore/metrics.go
+++ b/pkg/dataobj/metastore/metrics.go
@@ -23,24 +23,24 @@ type tocMetrics struct {
 func newTableOfContentsMetrics() *tocMetrics {
 	metrics := &tocMetrics{
 		tocReplayTime: prometheus.NewHistogram(prometheus.HistogramOpts{
-			Name:                            "loki_dataobj_consumer_metastore_replay_seconds",
-			Help:                            "Time taken to replay existing metastore data into the in-memory builder in seconds",
+			Name:                            "loki_metastore_toc_replay_seconds",
+			Help:                            "Time taken to replay existing Table of Contents data into the new builder in seconds",
 			Buckets:                         prometheus.DefBuckets,
 			NativeHistogramBucketFactor:     1.1,
 			NativeHistogramMaxBucketNumber:  100,
 			NativeHistogramMinResetDuration: 0,
 		}),
 		tocEncodingTime: prometheus.NewHistogram(prometheus.HistogramOpts{
-			Name:                            "loki_dataobj_consumer_metastore_encoding_seconds",
-			Help:                            "Time taken to add the new metadata & encode the new metastore data object in seconds",
+			Name:                            "loki_metastore_toc_encoding_seconds",
+			Help:                            "Time taken to add the new entries & encode the a single Table of Contents metastore file in seconds",
 			Buckets:                         prometheus.DefBuckets,
 			NativeHistogramBucketFactor:     1.1,
 			NativeHistogramMaxBucketNumber:  100,
 			NativeHistogramMinResetDuration: 0,
 		}),
 		tocProcessingTime: prometheus.NewHistogram(prometheus.HistogramOpts{
-			Name:                            "loki_dataobj_consumer_metastore_processing_seconds",
-			Help:                            "Total time taken to update all metastores for a flushed dataobj in seconds",
+			Name:                            "loki_metastore_toc_processing_seconds",
+			Help:                            "Total time taken to update all Table of Contents files for a metastore WriteEntry operation in seconds",
 			Buckets:                         prometheus.DefBuckets,
 			NativeHistogramBucketFactor:     1.1,
 			NativeHistogramMaxBucketNumber:  100,
@@ -86,7 +86,7 @@ func (p *tocMetrics) unregister(reg prometheus.Registerer) {
 	}
 }
 
-func (p *tocMetrics) incMetastoreWrites(status status) {
+func (p *tocMetrics) incTableOfContentsWrites(status status) {
 	p.tocWriteFailures.WithLabelValues(string(status)).Inc()
 }
 

--- a/pkg/dataobj/metastore/multitenancy/timeranges.go
+++ b/pkg/dataobj/metastore/multitenancy/timeranges.go
@@ -6,10 +6,7 @@ import (
 
 // TimeRange represents a time range for a specific tenant.
 type TimeRange struct {
-	Tenant  TenantID
+	Tenant  string
 	MinTime time.Time
 	MaxTime time.Time
 }
-
-// TenantID wraps a singular tenant ID string.
-type TenantID string

--- a/pkg/dataobj/metastore/multitenancy/timeranges.go
+++ b/pkg/dataobj/metastore/multitenancy/timeranges.go
@@ -1,0 +1,27 @@
+package multitenancy
+
+import (
+	"iter"
+	"time"
+)
+
+type TimeRange struct {
+	MinTime time.Time
+	MaxTime time.Time
+}
+
+type TimeRangesIterator interface {
+	Iter() iter.Seq2[string, TimeRange]
+}
+
+type TimeRangeSet map[string]TimeRange
+
+func (t TimeRangeSet) Iter() iter.Seq2[string, TimeRange] {
+	return func(yield func(tenant string, timeRange TimeRange) bool) {
+		for tenant, timeRange := range t {
+			if !yield(tenant, timeRange) {
+				return
+			}
+		}
+	}
+}

--- a/pkg/dataobj/metastore/multitenancy/timeranges.go
+++ b/pkg/dataobj/metastore/multitenancy/timeranges.go
@@ -1,27 +1,15 @@
 package multitenancy
 
 import (
-	"iter"
 	"time"
 )
 
+// TimeRange represents a time range for a specific tenant.
 type TimeRange struct {
+	Tenant  TenantID
 	MinTime time.Time
 	MaxTime time.Time
 }
 
-type TimeRangesIterator interface {
-	Iter() iter.Seq2[string, TimeRange]
-}
-
-type TimeRangeSet map[string]TimeRange
-
-func (t TimeRangeSet) Iter() iter.Seq2[string, TimeRange] {
-	return func(yield func(tenant string, timeRange TimeRange) bool) {
-		for tenant, timeRange := range t {
-			if !yield(tenant, timeRange) {
-				return
-			}
-		}
-	}
-}
+// TenantID wraps a singular tenant ID string.
+type TenantID string

--- a/pkg/dataobj/metastore/object.go
+++ b/pkg/dataobj/metastore/object.go
@@ -112,10 +112,11 @@ func iterTableOfContentsPaths(tenantID string, start, end time.Time, prefix stri
 
 	return func(yield func(t string, timeRange multitenancy.TimeRange) bool) {
 		for tocWindow := minTocWindow; !tocWindow.After(maxTocWindow); tocWindow = tocWindow.Add(metastoreWindowSize) {
-			if !yield(tableOfContentsPath(tenantID, tocWindow, prefix), multitenancy.TimeRange{
+			tocTimeRange := multitenancy.TimeRange{
 				MinTime: tocWindow,
 				MaxTime: tocWindow.Add(metastoreWindowSize),
-			}) {
+			}
+			if !yield(tableOfContentsPath(tenantID, tocWindow, prefix), tocTimeRange) {
 				return
 			}
 		}

--- a/pkg/dataobj/metastore/object_test.go
+++ b/pkg/dataobj/metastore/object_test.go
@@ -85,8 +85,9 @@ func (b *testDataBuilder) addStreamAndFlush(stream logproto.Stream) {
 	path, err := b.uploader.Upload(b.t.Context(), obj)
 	require.NoError(b.t, err)
 
-	err = b.meta.WriteEntry(context.Background(), path, multitenancy.TimeRangeSet{
-		tenantID: multitenancy.TimeRange{
+	err = b.meta.WriteEntry(context.Background(), path, []multitenancy.TimeRange{
+		{
+			Tenant:  multitenancy.TenantID(tenantID),
 			MinTime: minTime,
 			MaxTime: maxTime,
 		},
@@ -252,7 +253,7 @@ func TestValuesEmptyMatcher(t *testing.T) {
 
 func TestSectionsForStreamMatchers(t *testing.T) {
 	ctx := user.InjectOrgID(context.Background(), tenantID)
-	testTenant := "test-tenant"
+	testTenant := multitenancy.TenantID("test-tenant")
 
 	builder, err := indexobj.NewBuilder(indexobj.BuilderConfig{
 		TargetPageSize:          1024 * 1024,
@@ -295,10 +296,11 @@ func TestSectionsForStreamMatchers(t *testing.T) {
 
 	metastoreTocWriter := NewTableOfContentsWriter(Config{}, bucket, tenantID, log.NewNopLogger())
 
-	err = metastoreTocWriter.WriteEntry(context.Background(), path, multitenancy.TimeRangeSet{
-		tenantID: multitenancy.TimeRange{
-			MinTime: timeRanges[tenantID].MinTime,
-			MaxTime: timeRanges[tenantID].MaxTime,
+	err = metastoreTocWriter.WriteEntry(context.Background(), path, []multitenancy.TimeRange{
+		{
+			Tenant:  multitenancy.TenantID(tenantID),
+			MinTime: timeRanges[0].MinTime,
+			MaxTime: timeRanges[0].MaxTime,
 		},
 	})
 	require.NoError(t, err)

--- a/pkg/dataobj/metastore/toc_writer.go
+++ b/pkg/dataobj/metastore/toc_writer.go
@@ -213,7 +213,7 @@ func (m *TableOfContentsWriter) copyFromExistingToc(ctx context.Context, tocObje
 		if err != nil {
 			return errors.Wrap(err, "opening section")
 		}
-		tenantID := multitenancy.TenantID(section.Tenant)
+		tenantID := section.Tenant
 		indexPointersReader.Reset(sec)
 		for n, err := indexPointersReader.Read(ctx, pbuf); n > 0; n, err = indexPointersReader.Read(ctx, pbuf) {
 			if err != nil && err != io.EOF {

--- a/pkg/dataobj/metastore/toc_writer.go
+++ b/pkg/dataobj/metastore/toc_writer.go
@@ -87,7 +87,7 @@ func (m *TableOfContentsWriter) initBuilder() error {
 }
 
 // WriteEntry adds the provided path to the Table of Contents file. The min/max timestamps are stored as metastore for the new entry can be accessed by time.
-func (m *TableOfContentsWriter) WriteEntry(ctx context.Context, dataobjPath string, tenantTimeRanges multitenancy.TimeRangeSet) error {
+func (m *TableOfContentsWriter) WriteEntry(ctx context.Context, dataobjPath string, tenantTimeRanges []multitenancy.TimeRange) error {
 	var err error
 	processingTime := prometheus.NewTimer(m.metrics.tocProcessingTime)
 	defer processingTime.ObserveDuration()
@@ -98,7 +98,7 @@ func (m *TableOfContentsWriter) WriteEntry(ctx context.Context, dataobjPath stri
 	}
 
 	var globalMinTime, globalMaxTime time.Time
-	for _, timeRange := range tenantTimeRanges.Iter() {
+	for _, timeRange := range tenantTimeRanges {
 		if globalMinTime.IsZero() || timeRange.MinTime.Before(globalMinTime) {
 			globalMinTime = timeRange.MinTime
 		}
@@ -109,90 +109,92 @@ func (m *TableOfContentsWriter) WriteEntry(ctx context.Context, dataobjPath stri
 
 	// Work our way through the metastore objects window by window, updating & creating them as needed.
 	// Each one handles its own retries in order to keep making progress in the event of a failure.
-	prefix := storagePrefixFor(m.cfg.Storage, m.tenantID)
-	for tocPath, tocTimeRange := range iterTableOfContentsPaths(m.tenantID, globalMinTime, globalMaxTime, prefix) {
-		m.backoff.Reset()
-		for m.backoff.Ongoing() {
-			err = m.bucket.GetAndReplace(ctx, tocPath, func(existing io.ReadCloser) (io.ReadCloser, error) {
-				if existing != nil {
-					defer existing.Close()
-				}
-
-				m.buf.Reset()
-				m.tocBuilder.Reset()
-
-				if existing != nil {
-					_, err := io.Copy(m.buf, existing)
-					if err != nil {
-						return nil, errors.Wrap(err, "copying to local buffer")
+	for _, timeRange := range tenantTimeRanges {
+		prefix := storagePrefixFor(m.cfg.Storage, string(timeRange.Tenant))
+		for tocPath, tocTimeRange := range iterTableOfContentsPaths(string(timeRange.Tenant), globalMinTime, globalMaxTime, prefix) {
+			m.backoff.Reset()
+			for m.backoff.Ongoing() {
+				err = m.bucket.GetAndReplace(ctx, tocPath, func(existing io.ReadCloser) (io.ReadCloser, error) {
+					if existing != nil {
+						defer existing.Close()
 					}
-				}
 
-				if m.buf.Len() > 0 {
-					replayDuration := prometheus.NewTimer(m.metrics.tocReplayTime)
-					object, err := dataobj.FromReaderAt(bytes.NewReader(m.buf.Bytes()), int64(m.buf.Len()))
-					if err != nil {
-						return nil, errors.Wrap(err, "creating object from buffer")
-					}
-					err = m.copyFromExistingToc(ctx, object)
-					if err != nil {
-						return nil, errors.Wrap(err, "reading existing metastore version")
-					}
-					replayDuration.ObserveDuration()
-				}
+					m.buf.Reset()
+					m.tocBuilder.Reset()
 
-				encodingDuration := prometheus.NewTimer(m.metrics.tocEncodingTime)
-				// Append all the tenant time ranges that overlap with the current Table of Contents window.
-				for tenant, timeRange := range tenantTimeRanges.Iter() {
-					if timeRange.MinTime.Before(tocTimeRange.MaxTime) && timeRange.MaxTime.After(tocTimeRange.MinTime) {
-						err := m.tocBuilder.AppendIndexPointer(tenant, dataobjPath, timeRange.MinTime, timeRange.MaxTime)
+					if existing != nil {
+						_, err := io.Copy(m.buf, existing)
 						if err != nil {
-							return nil, errors.Wrap(err, "appending index pointer")
+							return nil, errors.Wrap(err, "copying to local buffer")
 						}
 					}
+
+					if m.buf.Len() > 0 {
+						replayDuration := prometheus.NewTimer(m.metrics.tocReplayTime)
+						object, err := dataobj.FromReaderAt(bytes.NewReader(m.buf.Bytes()), int64(m.buf.Len()))
+						if err != nil {
+							return nil, errors.Wrap(err, "creating object from buffer")
+						}
+						err = m.copyFromExistingToc(ctx, object)
+						if err != nil {
+							return nil, errors.Wrap(err, "reading existing metastore version")
+						}
+						replayDuration.ObserveDuration()
+					}
+
+					encodingDuration := prometheus.NewTimer(m.metrics.tocEncodingTime)
+					// Append all the tenant time ranges that overlap with the current Table of Contents window.
+					for _, timeRange := range tenantTimeRanges {
+						if timeRange.MinTime.Before(tocTimeRange.MaxTime) && timeRange.MaxTime.After(tocTimeRange.MinTime) {
+							err := m.tocBuilder.AppendIndexPointer(timeRange.Tenant, dataobjPath, timeRange.MinTime, timeRange.MaxTime)
+							if err != nil {
+								return nil, errors.Wrap(err, "appending index pointer")
+							}
+						}
+					}
+
+					var (
+						obj    *dataobj.Object
+						closer io.Closer
+					)
+
+					obj, closer, err = m.tocBuilder.Flush()
+					if err != nil {
+						return nil, errors.Wrap(err, "flushing metastore builder")
+					}
+
+					reader, err := obj.Reader(ctx)
+					if err != nil {
+						_ = closer.Close()
+						return nil, err
+					}
+
+					encodingDuration.ObserveDuration()
+					return &wrappedReadCloser{
+						rc: reader,
+						OnClose: func() error {
+							// We must close our object reader before closing the object
+							// itself.
+							var errs []error
+							errs = append(errs, reader.Close())
+							errs = append(errs, closer.Close())
+							return stderrors.Join(errs...)
+						},
+					}, nil
+				})
+				if err == nil {
+					level.Info(m.logger).Log("msg", "successfully merged & updated metastore", "metastore", tocPath)
+					m.metrics.incTableOfContentsWrites(statusSuccess)
+					break
 				}
-
-				var (
-					obj    *dataobj.Object
-					closer io.Closer
-				)
-
-				obj, closer, err = m.tocBuilder.Flush()
-				if err != nil {
-					return nil, errors.Wrap(err, "flushing metastore builder")
-				}
-
-				reader, err := obj.Reader(ctx)
-				if err != nil {
-					_ = closer.Close()
-					return nil, err
-				}
-
-				encodingDuration.ObserveDuration()
-				return &wrappedReadCloser{
-					rc: reader,
-					OnClose: func() error {
-						// We must close our object reader before closing the object
-						// itself.
-						var errs []error
-						errs = append(errs, reader.Close())
-						errs = append(errs, closer.Close())
-						return stderrors.Join(errs...)
-					},
-				}, nil
-			})
-			if err == nil {
-				level.Info(m.logger).Log("msg", "successfully merged & updated metastore", "metastore", tocPath)
-				m.metrics.incTableOfContentsWrites(statusSuccess)
-				break
+				level.Error(m.logger).Log("msg", "failed to get and replace metastore object", "err", err, "metastore", tocPath)
+				m.metrics.incTableOfContentsWrites(statusFailure)
+				m.backoff.Wait()
 			}
-			level.Error(m.logger).Log("msg", "failed to get and replace metastore object", "err", err, "metastore", tocPath)
-			m.metrics.incTableOfContentsWrites(statusFailure)
-			m.backoff.Wait()
-		}
 
-		// Reset at the end too so we don't leave our memory hanging around between calls.
-		m.tocBuilder.Reset()
+			// Reset at the end too so we don't leave our memory hanging around between calls.
+			m.tocBuilder.Reset()
+		}
 	}
 	return err
 }
@@ -228,13 +230,14 @@ func (m *TableOfContentsWriter) copyFromExistingToc(ctx context.Context, tocObje
 		if err != nil {
 			return errors.Wrap(err, "opening section")
 		}
+		tenantID := multitenancy.TenantID(section.Tenant)
 		indexPointersReader.Reset(sec)
 		for n, err := indexPointersReader.Read(ctx, pbuf); n > 0; n, err = indexPointersReader.Read(ctx, pbuf) {
 			if err != nil && err != io.EOF {
 				return errors.Wrap(err, "reading index pointers")
 			}
 			for _, indexPointer := range pbuf[:n] {
-				err = m.tocBuilder.AppendIndexPointer(section.Tenant, indexPointer.Path, indexPointer.StartTs, indexPointer.EndTs)
+				err = m.tocBuilder.AppendIndexPointer(tenantID, indexPointer.Path, indexPointer.StartTs, indexPointer.EndTs)
 				if err != nil {
 					return errors.Wrap(err, "appending index pointers")
 				}

--- a/pkg/dataobj/metastore/toc_writer.go
+++ b/pkg/dataobj/metastore/toc_writer.go
@@ -98,8 +98,8 @@ func (m *TableOfContentsWriter) WriteEntry(ctx context.Context, dataobjPath stri
 	// Work our way through the metastore objects window by window, updating & creating them as needed.
 	// Each one handles its own retries in order to keep making progress in the event of a failure.
 	for _, timeRange := range tenantTimeRanges {
-		prefix := storagePrefixFor(m.cfg.Storage, string(timeRange.Tenant))
-		for tocPath := range iterTableOfContentsPaths(string(timeRange.Tenant), timeRange.MinTime, timeRange.MaxTime, prefix) {
+		prefix := storagePrefixFor(m.cfg.Storage, timeRange.Tenant)
+		for tocPath := range iterTableOfContentsPaths(timeRange.Tenant, timeRange.MinTime, timeRange.MaxTime, prefix) {
 			m.backoff.Reset()
 			for m.backoff.Ongoing() {
 				err = m.bucket.GetAndReplace(ctx, tocPath, func(existing io.ReadCloser) (io.ReadCloser, error) {

--- a/pkg/dataobj/metastore/toc_writer_test.go
+++ b/pkg/dataobj/metastore/toc_writer_test.go
@@ -42,8 +42,9 @@ func TestTableOfContentsWriter(t *testing.T) {
 		tocBuilder.Reset()
 
 		writer := NewTableOfContentsWriter(Config{}, bucket, tenantID, log.NewNopLogger())
-		err = writer.WriteEntry(context.Background(), "testdata/metastore.obj", multitenancy.TimeRangeSet{
-			tenantID: multitenancy.TimeRange{
+		err = writer.WriteEntry(context.Background(), "testdata/metastore.obj", []multitenancy.TimeRange{
+			{
+				Tenant:  multitenancy.TenantID(tenantID),
 				MinTime: unixTime(20),
 				MaxTime: unixTime(30),
 			},
@@ -65,8 +66,9 @@ func TestTableOfContentsWriter(t *testing.T) {
 		bucket := newInMemoryBucket(t, tenantID, unixTime(0), nil)
 
 		writer := newTableOfContentsWriter(t, tenantID, bucket, builder)
-		err = writer.WriteEntry(context.Background(), "testdata/metastore.obj", multitenancy.TimeRangeSet{
-			tenantID: multitenancy.TimeRange{
+		err = writer.WriteEntry(context.Background(), "testdata/metastore.obj", []multitenancy.TimeRange{
+			{
+				Tenant:  multitenancy.TenantID(tenantID),
 				MinTime: unixTime(0),
 				MaxTime: unixTime(30),
 			},

--- a/pkg/dataobj/metastore/toc_writer_test.go
+++ b/pkg/dataobj/metastore/toc_writer_test.go
@@ -44,7 +44,7 @@ func TestTableOfContentsWriter(t *testing.T) {
 		writer := NewTableOfContentsWriter(Config{}, bucket, log.NewNopLogger())
 		err = writer.WriteEntry(context.Background(), "testdata/metastore.obj", []multitenancy.TimeRange{
 			{
-				Tenant:  multitenancy.TenantID(tenantID),
+				Tenant:  tenantID,
 				MinTime: unixTime(20),
 				MaxTime: unixTime(30),
 			},
@@ -68,7 +68,7 @@ func TestTableOfContentsWriter(t *testing.T) {
 		writer := newTableOfContentsWriter(t, tenantID, bucket, builder)
 		err = writer.WriteEntry(context.Background(), "testdata/metastore.obj", []multitenancy.TimeRange{
 			{
-				Tenant:  multitenancy.TenantID(tenantID),
+				Tenant:  tenantID,
 				MinTime: unixTime(0),
 				MaxTime: unixTime(30),
 			},
@@ -95,7 +95,6 @@ func newTableOfContentsWriter(t *testing.T, tenantID string, bucket objstore.Buc
 	updater := &TableOfContentsWriter{
 		tocBuilder: tocBuilder,
 		bucket:     bucket,
-		tenantID:   tenantID,
 		metrics:    newTableOfContentsMetrics(),
 		logger:     log.NewNopLogger(),
 		backoff: backoff.New(context.TODO(), backoff.Config{

--- a/pkg/dataobj/metastore/toc_writer_test.go
+++ b/pkg/dataobj/metastore/toc_writer_test.go
@@ -65,7 +65,7 @@ func TestTableOfContentsWriter(t *testing.T) {
 
 		bucket := newInMemoryBucket(t, tenantID, unixTime(0), nil)
 
-		writer := newTableOfContentsWriter(t, tenantID, bucket, builder)
+		writer := newTableOfContentsWriter(t, bucket, builder)
 		err = writer.WriteEntry(context.Background(), "testdata/metastore.obj", []multitenancy.TimeRange{
 			{
 				Tenant:  tenantID,
@@ -89,7 +89,7 @@ func TestTableOfContentsWriter(t *testing.T) {
 	})
 }
 
-func newTableOfContentsWriter(t *testing.T, tenantID string, bucket objstore.Bucket, tocBuilder *indexobj.Builder) *TableOfContentsWriter {
+func newTableOfContentsWriter(t *testing.T, bucket objstore.Bucket, tocBuilder *indexobj.Builder) *TableOfContentsWriter {
 	t.Helper()
 
 	updater := &TableOfContentsWriter{

--- a/pkg/dataobj/metastore/toc_writer_test.go
+++ b/pkg/dataobj/metastore/toc_writer_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func TestTableOfContentsWriter(t *testing.T) {
-	t.Run("append new top-level object to new metastore v2", func(t *testing.T) {
+	t.Run("append new top-level object to new metastore", func(t *testing.T) {
 		tenantID := "test"
 		tocBuilder, err := indexobj.NewBuilder(indexobj.BuilderConfig{
 			TargetPageSize:          tocBuilderCfg.TargetPageSize,
@@ -41,7 +41,7 @@ func TestTableOfContentsWriter(t *testing.T) {
 		bucket := newInMemoryBucket(t, tenantID, unixTime(0), obj)
 		tocBuilder.Reset()
 
-		writer := NewTableOfContentsWriter(Config{}, bucket, tenantID, log.NewNopLogger())
+		writer := NewTableOfContentsWriter(Config{}, bucket, log.NewNopLogger())
 		err = writer.WriteEntry(context.Background(), "testdata/metastore.obj", []multitenancy.TimeRange{
 			{
 				Tenant:  multitenancy.TenantID(tenantID),

--- a/pkg/dataobj/querier/store_test.go
+++ b/pkg/dataobj/querier/store_test.go
@@ -476,7 +476,7 @@ func newTestDataBuilder(t *testing.T, tenantID string) *testDataBuilder {
 	}, nil)
 	require.NoError(t, err)
 
-	meta := metastore.NewTableOfContentsWriter(metastore.Config{}, bucket, tenantID, log.NewNopLogger())
+	meta := metastore.NewTableOfContentsWriter(metastore.Config{}, bucket, log.NewNopLogger())
 	require.NoError(t, meta.RegisterMetrics(prometheus.NewRegistry()))
 
 	uploader := uploader.New(uploader.Config{SHAPrefixSize: 2}, bucket, tenantID, log.NewNopLogger())

--- a/pkg/dataobj/querier/store_test.go
+++ b/pkg/dataobj/querier/store_test.go
@@ -512,8 +512,9 @@ func (b *testDataBuilder) flush() {
 	require.NoError(b.t, err)
 
 	// Update metastore with the new data object
-	err = b.meta.WriteEntry(context.Background(), path, multitenancy.TimeRangeSet{
-		b.tenantID: multitenancy.TimeRange{
+	err = b.meta.WriteEntry(context.Background(), path, []multitenancy.TimeRange{
+		{
+			Tenant:  multitenancy.TenantID(b.tenantID),
 			MinTime: minTime,
 			MaxTime: maxTime,
 		},

--- a/pkg/dataobj/querier/store_test.go
+++ b/pkg/dataobj/querier/store_test.go
@@ -514,7 +514,7 @@ func (b *testDataBuilder) flush() {
 	// Update metastore with the new data object
 	err = b.meta.WriteEntry(context.Background(), path, []multitenancy.TimeRange{
 		{
-			Tenant:  multitenancy.TenantID(b.tenantID),
+			Tenant:  b.tenantID,
 			MinTime: minTime,
 			MaxTime: maxTime,
 		},

--- a/pkg/dataobj/querier/store_test.go
+++ b/pkg/dataobj/querier/store_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/grafana/loki/v3/pkg/dataobj/consumer/logsobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/metastore"
+	"github.com/grafana/loki/v3/pkg/dataobj/metastore/multitenancy"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/logs"
 	"github.com/grafana/loki/v3/pkg/dataobj/uploader"
 	"github.com/grafana/loki/v3/pkg/iter"
@@ -511,7 +512,12 @@ func (b *testDataBuilder) flush() {
 	require.NoError(b.t, err)
 
 	// Update metastore with the new data object
-	err = b.meta.WriteEntry(context.Background(), path, minTime, maxTime)
+	err = b.meta.WriteEntry(context.Background(), path, multitenancy.TimeRangeSet{
+		b.tenantID: multitenancy.TimeRange{
+			MinTime: minTime,
+			MaxTime: maxTime,
+		},
+	})
 	require.NoError(b.t, err)
 
 	b.builder.Reset()

--- a/pkg/dataobj/sections/indexpointers/builder.go
+++ b/pkg/dataobj/sections/indexpointers/builder.go
@@ -29,6 +29,7 @@ type IndexPointer struct {
 type Builder struct {
 	metrics  *Metrics
 	pageSize int
+	tenant   string
 
 	indexPointers []*IndexPointer
 }
@@ -43,6 +44,12 @@ func NewBuilder(metrics *Metrics, pageSize int) *Builder {
 		indexPointers: make([]*IndexPointer, 0, 1024),
 	}
 }
+
+func (b *Builder) SetTenant(tenant string) {
+	b.tenant = tenant
+}
+
+func (b *Builder) Tenant() string { return b.tenant }
 
 func (b *Builder) Type() dataobj.SectionType { return sectionType }
 
@@ -110,6 +117,8 @@ func (b *Builder) Flush(w dataobj.SectionWriter) (n int64, err error) {
 	if err := b.encodeTo(&enc); err != nil {
 		return 0, fmt.Errorf("building encoder: %w", err)
 	}
+
+	enc.SetTenant(b.tenant)
 
 	n, err = enc.Flush(w)
 	if err == nil {

--- a/pkg/dataobj/sections/pointers/builder.go
+++ b/pkg/dataobj/sections/pointers/builder.go
@@ -79,6 +79,7 @@ type streamKey struct {
 type Builder struct {
 	metrics  *Metrics
 	pageSize int
+	tenant   string
 
 	// streamLookup is a map of the stream ID in this index object to the pointer.
 	streamLookup map[streamKey]*SectionPointer
@@ -102,6 +103,12 @@ func NewBuilder(metrics *Metrics, pageSize int) *Builder {
 		pointers:     make([]*SectionPointer, 0, 1024),
 	}
 }
+
+func (b *Builder) SetTenant(tenant string) {
+	b.tenant = tenant
+}
+
+func (b *Builder) Tenant() string { return b.tenant }
 
 // Type returns the [dataobj.SectionType] of the pointers builder.
 func (b *Builder) Type() dataobj.SectionType { return sectionType }
@@ -205,6 +212,8 @@ func (b *Builder) Flush(w dataobj.SectionWriter) (n int64, err error) {
 	if err := b.encodeTo(&pointersEnc); err != nil {
 		return 0, fmt.Errorf("building encoder: %w", err)
 	}
+
+	pointersEnc.SetTenant(b.tenant)
 
 	n, err = pointersEnc.Flush(w)
 	if err == nil {

--- a/pkg/logql/bench/store_dataobj.go
+++ b/pkg/logql/bench/store_dataobj.go
@@ -152,7 +152,7 @@ func (s *DataObjStore) flush() error {
 	// Update logs metastore's table of contents with the new data object
 	err = s.logsMetastoreToc.WriteEntry(context.Background(), path, []multitenancy.TimeRange{
 		{
-			Tenant:  multitenancy.TenantID(s.tenantID),
+			Tenant:  s.tenantID,
 			MinTime: minTime,
 			MaxTime: maxTime,
 		},

--- a/pkg/logql/bench/store_dataobj.go
+++ b/pkg/logql/bench/store_dataobj.go
@@ -88,12 +88,12 @@ func NewDataObjStore(dir, tenantID string) (*DataObjStore, error) {
 	}
 
 	logger := level.NewFilter(log.NewLogfmtLogger(os.Stdout), level.AllowWarn())
-	logsMetastoreToc := metastore.NewTableOfContentsWriter(metastore.Config{}, bucket, tenantID, logger)
+	logsMetastoreToc := metastore.NewTableOfContentsWriter(metastore.Config{}, bucket, logger)
 	uploader := uploader.New(uploader.Config{SHAPrefixSize: 2}, bucket, tenantID, logger)
 
 	// Create prefixed bucket & metastore for indexes
 	indexWriterBucket := objstore.NewPrefixedBucket(bucket, indexDirPrefix)
-	indexMetastoreToc := metastore.NewTableOfContentsWriter(metastore.Config{}, indexWriterBucket, tenantID, logger)
+	indexMetastoreToc := metastore.NewTableOfContentsWriter(metastore.Config{}, indexWriterBucket, logger)
 
 	return &DataObjStore{
 		dir:               storeDir,

--- a/pkg/logql/bench/store_dataobj.go
+++ b/pkg/logql/bench/store_dataobj.go
@@ -150,8 +150,9 @@ func (s *DataObjStore) flush() error {
 	}
 
 	// Update logs metastore's table of contents with the new data object
-	err = s.logsMetastoreToc.WriteEntry(context.Background(), path, multitenancy.TimeRangeSet{
-		s.tenantID: multitenancy.TimeRange{
+	err = s.logsMetastoreToc.WriteEntry(context.Background(), path, []multitenancy.TimeRange{
+		{
+			Tenant:  multitenancy.TenantID(s.tenantID),
 			MinTime: minTime,
 			MaxTime: maxTime,
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:
Enables multi-tenancy for the indexobj builders & Table of Contents files.
* Also changes the TableOfContentsWriter to be multi-tenant, writing each tenant's time range to a separate section. This is slightly different to the experiment branch, which wrote the min/max timerange across all the tenants into a single entry. The functionality when multi-tenant should be exactly the same as single-tenant, now.

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/loki-private/issues/1769

**Special notes for your reviewer**:
* Please check multitenancy/timerange.go - I wasn't a massive fan of having a new interface in a separate package but I couldn't find an easier approch without generating import loops. I could just use `map[string]TimeRange` instead of the `TimeRangeSet` interface if thats preferred.