### PR TITLE
chore(logql/bench): align data directory with production layout

### DIFF
--- a/pkg/logql/bench/store_dataobj.go
+++ b/pkg/logql/bench/store_dataobj.go
@@ -46,7 +46,8 @@ type DataObjStore struct {
 
 // NewDataObjStore creates a new DataObjStore
 func NewDataObjStore(dir, tenantID string) (*DataObjStore, error) {
-	// Create store-specific directory
+	// NOTE(rfratto): DataObjStore should use a dataobj subdirectory to imitate
+	// production setup: a dataobj subdirectory in the location used for chunks.
 	storeDir := filepath.Join(dir, "dataobj")
 	if err := os.MkdirAll(storeDir, 0o755); err != nil {
 		return nil, fmt.Errorf("failed to create directory: %w", err)


### PR DESCRIPTION
Previously, the LogQL benchmarks put chunks and dataobjs in two different directories. This prevented developers from being able to properly run Loki locally against the synthetic data, as in a real Loki setup, dataobjs are in a subdirectory of where chunks are stored.

This commit imitates that setup: put all chunk storage in in the root data/ directory, then put dataobjs in data/dataobj.