### PR TITLE
Add metric to track records discarded

### DIFF
--- a/pkg/dataobj/consumer/service.go
+++ b/pkg/dataobj/consumer/service.go
@@ -176,6 +176,7 @@ func (s *Service) run(ctx context.Context) error {
 			s.partitionMtx.RLock()
 			handlers, ok := s.partitionHandlers[ftp.Topic]
 			if !ok {
+				s.processorNotReady.Inc()
 				s.partitionMtx.RUnlock()
 				return
 			}

--- a/pkg/dataobj/consumer/service.go
+++ b/pkg/dataobj/consumer/service.go
@@ -182,13 +182,13 @@ func (s *Service) run(ctx context.Context) error {
 			processor, ok := handlers[ftp.Partition]
 			s.partitionMtx.RUnlock()
 			if !ok {
+				s.processorNotReady.Inc()
 				return
 			}
 
 			// Collect all records for this partition
 			records := ftp.Records
 			if len(records) == 0 {
-				s.processorNotReady.Inc()
 				return
 			}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request adds a metric to track the number of records discarded if partition processors are not ready.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
