### PR TITLE
fix(engine): Don't attempt to release batch reference on read for merge node

### DIFF
--- a/pkg/engine/executor/merge.go
+++ b/pkg/engine/executor/merge.go
@@ -41,10 +41,6 @@ func (m *Merge) Read(ctx context.Context) error {
 		return m.state.err
 	}
 
-	if m.state.batch != nil {
-		m.state.batch.Release()
-	}
-
 	record, err := m.read(ctx)
 	m.state = newState(record, err)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The upstream node should be responsible for calling Release; Merge should not call Release on read.  The current behavior can cause a use after free bug when there is a node upstream of Merge that uses the record more than once (e.g. SortMerge).


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
