### PR TITLE
chore(engine): fix instances of double frees

### DIFF
--- a/.github/jsonnetfile.json
+++ b/.github/jsonnetfile.json
@@ -8,7 +8,7 @@
           "subdir": "workflows"
         }
       },
-      "version": "39f70c4db167e7e61065455fdbc48b50fd7c12a2"
+      "version": "1dd22f1dbfa671ac40e4a92f1a56bd9821871d44"
     }
   ],
   "legacyImports": true

--- a/.github/jsonnetfile.lock.json
+++ b/.github/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
           "subdir": "workflows"
         }
       },
-      "version": "39f70c4db167e7e61065455fdbc48b50fd7c12a2",
+      "version": "1dd22f1dbfa671ac40e4a92f1a56bd9821871d44",
       "sum": "zWhVb9aJ1waVDKRXC0TqqFKKepNwWe0ilY2STT9Xl5o="
     }
   ],

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,10 +1,10 @@
 "jobs":
   "check":
-    "uses": "grafana/loki-release/.github/workflows/check.yml@39f70c4db167e7e61065455fdbc48b50fd7c12a2"
+    "uses": "grafana/loki-release/.github/workflows/check.yml@1dd22f1dbfa671ac40e4a92f1a56bd9821871d44"
     "with":
       "build_image": "grafana/loki-build-image:0.34.6"
       "golang_ci_lint_version": "v1.64.5"
-      "release_lib_ref": "39f70c4db167e7e61065455fdbc48b50fd7c12a2"
+      "release_lib_ref": "1dd22f1dbfa671ac40e4a92f1a56bd9821871d44"
       "skip_validation": false
       "use_github_app_token": true
 "name": "check"

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -1,10 +1,10 @@
 "jobs":
   "check":
-    "uses": "grafana/loki-release/.github/workflows/check.yml@39f70c4db167e7e61065455fdbc48b50fd7c12a2"
+    "uses": "grafana/loki-release/.github/workflows/check.yml@1dd22f1dbfa671ac40e4a92f1a56bd9821871d44"
     "with":
       "build_image": "grafana/loki-build-image:0.34.6"
       "golang_ci_lint_version": "v1.64.5"
-      "release_lib_ref": "39f70c4db167e7e61065455fdbc48b50fd7c12a2"
+      "release_lib_ref": "1dd22f1dbfa671ac40e4a92f1a56bd9821871d44"
       "skip_validation": false
       "use_github_app_token": true
   "loki-canary-boringcrypto-image":
@@ -12,7 +12,7 @@
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.24.4"
       "IMAGE_PREFIX": "grafana"
-      "RELEASE_LIB_REF": "39f70c4db167e7e61065455fdbc48b50fd7c12a2"
+      "RELEASE_LIB_REF": "1dd22f1dbfa671ac40e4a92f1a56bd9821871d44"
       "RELEASE_REPO": "grafana/loki"
     "needs":
     - "check"
@@ -135,7 +135,7 @@
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.24.4"
       "IMAGE_PREFIX": "grafana"
-      "RELEASE_LIB_REF": "39f70c4db167e7e61065455fdbc48b50fd7c12a2"
+      "RELEASE_LIB_REF": "1dd22f1dbfa671ac40e4a92f1a56bd9821871d44"
       "RELEASE_REPO": "grafana/loki"
     "needs":
     - "check"
@@ -258,7 +258,7 @@
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.24.4"
       "IMAGE_PREFIX": "grafana"
-      "RELEASE_LIB_REF": "39f70c4db167e7e61065455fdbc48b50fd7c12a2"
+      "RELEASE_LIB_REF": "1dd22f1dbfa671ac40e4a92f1a56bd9821871d44"
       "RELEASE_REPO": "grafana/loki"
     "needs":
     - "check"
@@ -381,7 +381,7 @@
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.24.4"
       "IMAGE_PREFIX": "grafana"
-      "RELEASE_LIB_REF": "39f70c4db167e7e61065455fdbc48b50fd7c12a2"
+      "RELEASE_LIB_REF": "1dd22f1dbfa671ac40e4a92f1a56bd9821871d44"
       "RELEASE_REPO": "grafana/loki"
     "needs":
     - "check"

--- a/.github/workflows/minor-release-pr.yml
+++ b/.github/workflows/minor-release-pr.yml
@@ -8,7 +8,7 @@ env:
   DRY_RUN: false
   GITHUB_APP: "loki-gh-app"
   IMAGE_PREFIX: "grafana"
-  RELEASE_LIB_REF: "39f70c4db167e7e61065455fdbc48b50fd7c12a2"
+  RELEASE_LIB_REF: "1dd22f1dbfa671ac40e4a92f1a56bd9821871d44"
   RELEASE_REPO: "grafana/loki"
   SKIP_VALIDATION: false
   USE_GITHUB_APP_TOKEN: true
@@ -19,11 +19,11 @@ jobs:
       contents: "write"
       id-token: "write"
       pull-requests: "write"
-    uses: "grafana/loki-release/.github/workflows/check.yml@39f70c4db167e7e61065455fdbc48b50fd7c12a2"
+    uses: "grafana/loki-release/.github/workflows/check.yml@1dd22f1dbfa671ac40e4a92f1a56bd9821871d44"
     with:
       build_image: "grafana/loki-build-image:0.34.6"
       golang_ci_lint_version: "v1.64.5"
-      release_lib_ref: "39f70c4db167e7e61065455fdbc48b50fd7c12a2"
+      release_lib_ref: "1dd22f1dbfa671ac40e4a92f1a56bd9821871d44"
       skip_validation: false
       use_github_app_token: true
   create-release-pr:
@@ -117,7 +117,7 @@ jobs:
           --target-branch "$(echo $OUTPUTS_BRANCH | tr -d '"')" \
           --token "$(echo $OUTPUTS_TOKEN | tr -d '"')" \
           --dry-run ${{ fromJSON(env.DRY_RUN) }}
-        
+
       working-directory: "lib"
   dist:
     needs:
@@ -235,7 +235,7 @@ jobs:
       name: "Parse image platform"
       run: |
         mkdir -p images
-        
+
         platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -308,7 +308,7 @@ jobs:
       name: "Parse image platform"
       run: |
         mkdir -p images
-        
+
         platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -381,7 +381,7 @@ jobs:
       name: "Parse image platform"
       run: |
         mkdir -p images
-        
+
         platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -460,7 +460,7 @@ jobs:
       name: "Parse image platform"
       run: |
         mkdir -p images
-        
+
         platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -533,7 +533,7 @@ jobs:
       name: "Parse image platform"
       run: |
         mkdir -p images
-        
+
         platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -612,7 +612,7 @@ jobs:
       name: "Parse image platform"
       run: |
         mkdir -p images
-        
+
         platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -691,7 +691,7 @@ jobs:
       name: "Parse image platform"
       run: |
         mkdir -p images
-        
+
         platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -771,7 +771,7 @@ jobs:
       run: |
         mkdir -p images
         mkdir -p plugins
-        
+
         platform="$(echo "${{ matrix.arch}}" |  sed  "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -863,7 +863,7 @@ jobs:
       name: "Parse image platform"
       run: |
         mkdir -p images
-        
+
         platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -942,7 +942,7 @@ jobs:
       name: "Parse image platform"
       run: |
         mkdir -p images
-        
+
         platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -1041,7 +1041,7 @@ jobs:
       name: "get release version"
       run: |
         npm install
-        
+
         if [[ -z "${{ env.RELEASE_AS }}" ]]; then
           npm exec -- release-please release-pr \
             --consider-all-branches \
@@ -1071,16 +1071,16 @@ jobs:
             --token "$OUTPUTS_TOKEN" \
             --release-as "${{ env.RELEASE_AS }}"
         fi
-        
+
         cat release.json
-        
-        if [[ `jq length release.json` -gt 1 ]]; then 
+
+        if [[ `jq length release.json` -gt 1 ]]; then
           echo 'release-please would create more than 1 PR, so cannot determine correct version'
           echo "pr_created=false" >> $GITHUB_OUTPUT
           exit 1
         fi
-        
-        if [[ `jq length release.json` -eq 0 ]]; then 
+
+        if [[ `jq length release.json` -eq 0 ]]; then
           echo "pr_created=false" >> $GITHUB_OUTPUT
         else
           version="$(npm run --silent get-version)"

--- a/.github/workflows/patch-release-pr.yml
+++ b/.github/workflows/patch-release-pr.yml
@@ -8,7 +8,7 @@ env:
   DRY_RUN: false
   GITHUB_APP: "loki-gh-app"
   IMAGE_PREFIX: "grafana"
-  RELEASE_LIB_REF: "39f70c4db167e7e61065455fdbc48b50fd7c12a2"
+  RELEASE_LIB_REF: "1dd22f1dbfa671ac40e4a92f1a56bd9821871d44"
   RELEASE_REPO: "grafana/loki"
   SKIP_VALIDATION: false
   USE_GITHUB_APP_TOKEN: true
@@ -19,11 +19,11 @@ jobs:
       contents: "write"
       id-token: "write"
       pull-requests: "write"
-    uses: "grafana/loki-release/.github/workflows/check.yml@39f70c4db167e7e61065455fdbc48b50fd7c12a2"
+    uses: "grafana/loki-release/.github/workflows/check.yml@1dd22f1dbfa671ac40e4a92f1a56bd9821871d44"
     with:
       build_image: "grafana/loki-build-image:0.34.6"
       golang_ci_lint_version: "v1.64.5"
-      release_lib_ref: "39f70c4db167e7e61065455fdbc48b50fd7c12a2"
+      release_lib_ref: "1dd22f1dbfa671ac40e4a92f1a56bd9821871d44"
       skip_validation: false
       use_github_app_token: true
   create-release-pr:
@@ -117,7 +117,7 @@ jobs:
           --target-branch "$(echo $OUTPUTS_BRANCH | tr -d '"')" \
           --token "$(echo $OUTPUTS_TOKEN | tr -d '"')" \
           --dry-run ${{ fromJSON(env.DRY_RUN) }}
-        
+
       working-directory: "lib"
   dist:
     needs:
@@ -235,7 +235,7 @@ jobs:
       name: "Parse image platform"
       run: |
         mkdir -p images
-        
+
         platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -308,7 +308,7 @@ jobs:
       name: "Parse image platform"
       run: |
         mkdir -p images
-        
+
         platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -381,7 +381,7 @@ jobs:
       name: "Parse image platform"
       run: |
         mkdir -p images
-        
+
         platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -460,7 +460,7 @@ jobs:
       name: "Parse image platform"
       run: |
         mkdir -p images
-        
+
         platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -533,7 +533,7 @@ jobs:
       name: "Parse image platform"
       run: |
         mkdir -p images
-        
+
         platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -612,7 +612,7 @@ jobs:
       name: "Parse image platform"
       run: |
         mkdir -p images
-        
+
         platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -691,7 +691,7 @@ jobs:
       name: "Parse image platform"
       run: |
         mkdir -p images
-        
+
         platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -771,7 +771,7 @@ jobs:
       run: |
         mkdir -p images
         mkdir -p plugins
-        
+
         platform="$(echo "${{ matrix.arch}}" |  sed  "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -863,7 +863,7 @@ jobs:
       name: "Parse image platform"
       run: |
         mkdir -p images
-        
+
         platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -942,7 +942,7 @@ jobs:
       name: "Parse image platform"
       run: |
         mkdir -p images
-        
+
         platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -1041,7 +1041,7 @@ jobs:
       name: "get release version"
       run: |
         npm install
-        
+
         if [[ -z "${{ env.RELEASE_AS }}" ]]; then
           npm exec -- release-please release-pr \
             --consider-all-branches \
@@ -1071,16 +1071,16 @@ jobs:
             --token "$OUTPUTS_TOKEN" \
             --release-as "${{ env.RELEASE_AS }}"
         fi
-        
+
         cat release.json
-        
-        if [[ `jq length release.json` -gt 1 ]]; then 
+
+        if [[ `jq length release.json` -gt 1 ]]; then
           echo 'release-please would create more than 1 PR, so cannot determine correct version'
           echo "pr_created=false" >> $GITHUB_OUTPUT
           exit 1
         fi
-        
-        if [[ `jq length release.json` -eq 0 ]]; then 
+
+        if [[ `jq length release.json` -eq 0 ]]; then
           echo "pr_created=false" >> $GITHUB_OUTPUT
         else
           version="$(npm run --silent get-version)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_APP: "loki-gh-app"
   IMAGE_PREFIX: "grafana"
   PUBLISH_TO_GCS: false
-  RELEASE_LIB_REF: "39f70c4db167e7e61065455fdbc48b50fd7c12a2"
+  RELEASE_LIB_REF: "1dd22f1dbfa671ac40e4a92f1a56bd9821871d44"
   RELEASE_REPO: "grafana/loki"
   USE_GITHUB_APP_TOKEN: true
 jobs:
@@ -102,7 +102,7 @@ jobs:
         else
           echo "exists=true" >> $GITHUB_OUTPUT
         fi
-        
+
         if [[ "$isDraft" == "true" ]]; then
           echo "draft=true" >> $GITHUB_OUTPUT
         fi
@@ -200,27 +200,27 @@ jobs:
       run: |
         # Debug and clean the version variable
         echo "Original VERSION: $VERSION"
-        
+
         # Remove all quotes (both single and double)
         VERSION=$(echo $VERSION | tr -d '"' | tr -d "'")
         echo "After removing quotes: $VERSION"
-        
+
         # Extract version without the 'v' prefix if it exists
         VERSION="${VERSION#v}"
         echo "After removing v prefix: $VERSION"
-        
+
         # Extract major and minor versions
         MAJOR=$(echo $VERSION | cut -d. -f1)
         MINOR=$(echo $VERSION | cut -d. -f2)
         echo "MAJOR: $MAJOR, MINOR: $MINOR"
-        
+
         # Create branch name from template
         BRANCH_TEMPLATE="release-\${major}.\${minor}.x"
         BRANCH_NAME=${BRANCH_TEMPLATE//\$\{major\}/$MAJOR}
         BRANCH_NAME=${BRANCH_NAME//\$\{minor\}/$MINOR}
-        
+
         echo "Checking if branch already exists: $BRANCH_NAME"
-        
+
         # Check if branch exists
         if git ls-remote --heads origin $BRANCH_NAME | grep -q $BRANCH_NAME; then
           echo "Branch $BRANCH_NAME already exists, skipping creation"
@@ -228,16 +228,16 @@ jobs:
           echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
         else
           echo "Creating branch: $BRANCH_NAME from tag: $(echo $OUTPUTS_NAME | tr -d '"')"
-          
+
           # Create branch from the tag
           git fetch --tags
           git checkout "$(echo $OUTPUTS_BRANCH | tr -d '"')"
           git checkout -b $BRANCH_NAME
-        
+
           # explicity set the github app token to override the release branch protection
           git remote set-url origin "https://x-access-token:$(echo ${OUTPUTS_TOKEN} | tr -d '"')@github.com/${{ env.RELEASE_REPO }}"
           git push -u origin $BRANCH_NAME
-          
+
           echo "branch_exists=false" >> $GITHUB_OUTPUT
           echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
         fi


### PR DESCRIPTION
This also updates the grafana/loki-release dependency to include https://github.com/grafana/loki-release/pull/269, so that our CI detects instances of double frees.