### PR TITLE
chore: improve flush unit tests with better separation

### DIFF
--- a/pkg/dataobj/consumer/partition_processor_test.go
+++ b/pkg/dataobj/consumer/partition_processor_test.go
@@ -30,75 +30,108 @@ var testBuilderConfig = logsobj.BuilderConfig{
 }
 
 func TestPartitionProcessor_Flush(t *testing.T) {
-	clock := quartz.NewMock(t)
-	p := newTestPartitionProcessor(t, clock)
-	// Wrap the TOC writer to record all of the entries.
-	tocWriter, ok := p.metastoreTocWriter.(*metastore.TableOfContentsWriter)
-	require.True(t, ok)
-	recordingTocWriter := &recordingTocWriter{TableOfContentsWriter: tocWriter}
-	p.metastoreTocWriter = recordingTocWriter
+	t.Run("has expected metastore time range", func(t *testing.T) {
+		clock := quartz.NewMock(t)
+		p := newTestPartitionProcessor(t, clock)
 
-	// The last modified timestamp should be zero.
-	require.True(t, p.lastModified.IsZero())
+		// Wrap the TOC writer to record all of the entries.
+		tocWriter, ok := p.metastoreTocWriter.(*metastore.TableOfContentsWriter)
+		require.True(t, ok)
+		recordingTocWriter := &recordingTocWriter{TableOfContentsWriter: tocWriter}
+		p.metastoreTocWriter = recordingTocWriter
 
-	// Push two streams, one minute apart.
-	now1 := clock.Now()
-	s1 := logproto.Stream{
-		Labels: `{service="test"}`,
-		Entries: []push.Entry{{
+		// Push two streams, one minute apart.
+		now1 := clock.Now()
+		s1 := logproto.Stream{
+			Labels: `{service="test"}`,
+			Entries: []push.Entry{{
+				Timestamp: now1,
+				Line:      "abc",
+			}},
+		}
+		b1, err := s1.Marshal()
+		require.NoError(t, err)
+		p.processRecord(&kgo.Record{
+			Key:       []byte("test-tenant"),
+			Value:     b1,
 			Timestamp: now1,
-			Line:      "abc",
-		}},
-	}
-	b1, err := s1.Marshal()
-	require.NoError(t, err)
-	p.processRecord(&kgo.Record{
-		Key:       []byte("test-tenant"),
-		Value:     b1,
-		Timestamp: now1,
+		})
+
+		// Push the second stream, one minute later.
+		clock.Advance(time.Minute)
+		now2 := clock.Now()
+		s2 := s1
+		s2.Entries[0].Timestamp = now2
+		b2, err := s2.Marshal()
+		require.NoError(t, err)
+		p.processRecord(&kgo.Record{
+			Key:       []byte("test-tenant"),
+			Value:     b2,
+			Timestamp: now2,
+		})
+
+		// No flush should have occurred, we will flush ourselves instead.
+		require.True(t, p.lastFlush.IsZero())
+
+		// Get the time range. We will use this to check that the metastore has
+		// the correct time range.
+		minTime, maxTime := p.builder.TimeRange()
+		require.Equal(t, now1, minTime)
+		require.Equal(t, now2, maxTime)
+
+		// Flush the data object.
+		require.NoError(t, p.flush())
+		require.Equal(t, now2, p.lastFlush)
+
+		// Flush should produce two uploads, the data object and the metastore
+		// object.
+		bucket, ok := p.bucket.(*mockBucket)
+		require.True(t, ok)
+		require.Len(t, bucket.uploads, 2)
+
+		// Check that the expected entries were written to the metastore.
+		require.Len(t, recordingTocWriter.entries, 1)
+		actual := recordingTocWriter.entries[0]
+		require.Equal(t, minTime, actual.MinTimestamp)
+		require.Equal(t, maxTime, actual.MaxTimestamp)
 	})
 
-	// Push the second stream, one minute later.
-	clock.Advance(time.Minute)
-	now2 := clock.Now()
-	s2 := s1
-	s2.Entries[0].Timestamp = now2
-	b2, err := s2.Marshal()
-	require.NoError(t, err)
-	p.processRecord(&kgo.Record{
-		Key:       []byte("test-tenant"),
-		Value:     b2,
-		Timestamp: now2,
+	t.Run("reset happens after flush", func(t *testing.T) {
+		clock := quartz.NewMock(t)
+		p := newTestPartitionProcessor(t, clock)
+
+		// All timestamps should be zero.
+		require.True(t, p.lastFlush.IsZero())
+		require.True(t, p.lastModified.IsZero())
+
+		// Push a stream.
+		now := clock.Now()
+		s := logproto.Stream{
+			Labels: `{service="test"}`,
+			Entries: []push.Entry{{
+				Timestamp: now,
+				Line:      "abc",
+			}},
+		}
+		b, err := s.Marshal()
+		require.NoError(t, err)
+		p.processRecord(&kgo.Record{
+			Key:       []byte("test-tenant"),
+			Value:     b,
+			Timestamp: now,
+		})
+
+		// No flush should have occurred, we will flush ourselves instead.
+		require.True(t, p.lastFlush.IsZero())
+
+		// The last modified timestamp should be the time of the last append.
+		require.Equal(t, now, p.lastModified)
+
+		// Flush the data object. The last modified time should also be reset.
+		require.NoError(t, p.flush())
+		require.Equal(t, now, p.lastFlush)
+		require.True(t, p.lastModified.IsZero())
 	})
-
-	// No flush should have occurred, we will flush ourselves instead.
-	require.True(t, p.lastFlush.IsZero())
-
-	// Get the time range. We will use this to check that the metastore has
-	// the correct time range.
-	minTime, maxTime := p.builder.TimeRange()
-	require.Equal(t, now1, minTime)
-	require.Equal(t, now2, maxTime)
-
-	// The last modified timestamp should be the time of the last append.
-	require.Equal(t, now2, p.lastModified)
-
-	// Flush the data object. The last modified time should also be reset.
-	require.NoError(t, p.flush())
-	require.Equal(t, now2, p.lastFlush)
-	require.True(t, p.lastModified.IsZero())
-
-	// Flush should produce two uploads, the data object and the metastore
-	// object.
-	bucket, ok := p.bucket.(*mockBucket)
-	require.True(t, ok)
-	require.Len(t, bucket.uploads, 2)
-
-	// Check that the expected entries were written to the metastore.
-	require.Len(t, recordingTocWriter.entries, 1)
-	actual := recordingTocWriter.entries[0]
-	require.Equal(t, minTime, actual.MinTimestamp)
-	require.Equal(t, maxTime, actual.MaxTimestamp)
 }
 
 func TestPartitionProcessor_IdleFlush(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request improves some of the unit tests for flushing to better separate tests that assert multiple expectations in the same method.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
