### PR TITLE
docs: Adding link to learning journey

### DIFF
--- a/docs/sources/alert/_index.md
+++ b/docs/sources/alert/_index.md
@@ -13,13 +13,63 @@ keywords:
   - ruler
 ---
 
-# Alerting and recording rules
+# Alerting
+
+There are two types of alerts in Grafana:
+
+- **Grafana-managed alerts:** The recommended alert rule type in Grafana Alerting.
+    These alert rules can query a wide range of backend data sources, including multiple data sources in a single alert rule. They support expression-based transformations, advanced alert conditions, images in notifications, handling of error and no data states, and more.
+- **Data-source-managed alerts:** These alert rules can only query Prometheus-based data sources such as Mimir, Loki, and Prometheus. The rules are stored in the data source.
+
+To learn more about Grafana managed alerts, you can refer to the [Alerts and IRM documentation](https://grafana.com/docs/grafana-cloud/alerting-and-irm/), or take a short Learning Journey to learn how to
+
+{{< docs/learning-journeys title="Create log alert rules with Grafana Alerting" url="https://grafana.com/docs/learning-journeys/logs-alert-creation/" >}}
+
+## Use cases
+
+The Ruler's Prometheus compatibility further accentuates the marriage between metrics and logs. For those looking to get started with metrics and alerts based on logs, or wondering why this might be useful, here are a few use cases we think fit very well.
+
+### Black box monitoring
+
+We don't always control the source code of applications we run. Load balancers and a myriad of other components, both open source and closed third-party, support our applications while they don't expose the metrics we want. Some don't expose any metrics at all. The Loki alerting and recording rules can produce metrics and alert on the state of the system, bringing the components into our observability stack by using the logs. This is an incredibly powerful way to introduce advanced observability into legacy architectures.
+
+### Event alerting
+
+Sometimes you want to know whether _any_ instance of something has occurred. Alerting based on logs can be a great way to handle this, such as finding examples of leaked authentication credentials:
+
+```yaml
+- name: credentials_leak
+  rules:
+    - alert: http-credentials-leaked
+      annotations:
+        message: "{{ $labels.job }} is leaking http basic auth credentials."
+      expr: 'sum by (cluster, job, pod) (count_over_time({namespace="prod"} |~ "http(s?)://(\\w+):(\\w+)@" [5m]) > 0)'
+      for: 10m
+      labels:
+        severity: critical
+```
+
+### Alerting on high-cardinality sources
+
+Another great use case is alerting on high cardinality sources. These are things which are difficult/expensive to record as metrics because the potential label set is huge. A great example of this is per-tenant alerting in multi-tenanted systems like Loki. It's a common balancing act between the desire to have per-tenant metrics and the cardinality explosion that ensues (adding a single _tenant_ label to an existing Prometheus metric would increase its cardinality by the number of tenants).
+
+Creating these alerts in LogQL is attractive because these metrics can be extracted at _query time_, meaning we don't suffer the cardinality explosion in our metrics store.
+
+{{< admonition type="note" >}}
+As an example, we can use LogQL v2 to help Loki to monitor _itself_, alerting us when specific tenants have queries that take longer than 10s to complete! To do so, we'd use the following query: `sum by (org_id) (rate({job="loki-prod/query-frontend"} |= "metrics.go" | logfmt | duration > 10s [1m])`.
+{{< /admonition >}}
+
+## Loki alerting and recording rules
+
+This section explains how to create Loki managed rules. We support two kinds of rules: [alerting](#alerting-rules) rules and [recording](#recording-rules) rules.
+
+An alert rule consists of one or more queries and expressions that select the data you want to measure. It also contains a condition, which is the threshold that an alert rule must meet or exceed to fire.
+
+Similar to alert rules, recording rules are evaluated periodically. A recording rule pre-computes frequently used or computationally expensive queries, and saves the results as a new time series metric.
 
 Grafana Loki includes a component called the ruler. The ruler is responsible for continually evaluating a set of configurable queries and performing an action based on the result.
 
-This example configuration sources rules from a local disk.
-
-[Ruler storage](#ruler-storage) provides further details.
+This example configuration sources rules from a local disk. [Ruler storage](#ruler-storage) provides further details.
 
 ```yaml
 ruler:
@@ -35,13 +85,11 @@ ruler:
   enable_api: true
 ```
 
-We support two kinds of rules: [alerting](#alerting-rules) rules and [recording](#recording-rules) rules.
-
 ## Alerting Rules
 
 We support [Prometheus-compatible](https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/) alerting rules. From Prometheus' documentation:
 
-> Alerting rules allow you to define alert conditions based on Prometheus expression language expressions and to send notifications about firing alerts to an external service.
+_Alerting rules allow you to define alert conditions based on Prometheus expression language expressions and to send notifications about firing alerts to an external service._
 
 Loki alerting rules are exactly the same, except they use LogQL for their expressions.
 
@@ -79,8 +127,8 @@ groups:
 
 We support [Prometheus-compatible](https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/#recording-rules) recording rules. From Prometheus' documentation:
 
-> Recording rules allow you to precompute frequently needed or computationally expensive expressions and save their result as a new set of time series.
-> Querying the precomputed result will then often be much faster than executing the original expression every time it is needed. This is especially useful for dashboards, which need to query the same expression repeatedly every time they refresh.
+_Recording rules allow you to precompute frequently needed or computationally expensive expressions and save their result as a new set of time series.
+Querying the precomputed result will then often be much faster than executing the original expression every time it is needed. This is especially useful for dashboards, which need to query the same expression repeatedly every time they refresh._
 
 Loki allows you to run [metric queries](https://grafana.com/docs/loki/<LOKI_VERSION>/query/metric_queries/) over your logs, which means
 that you can derive a numeric aggregation from your logs, like calculating the number of requests over time from your NGINX access log.
@@ -166,41 +214,7 @@ Further configuration options can be found under [ruler](https://grafana.com/doc
 
 ### Operations
 
-Please refer to the [Recording Rules](https://grafana.com/docs/loki/<LOKI_VERSION>/operations/recording-rules/) page.
-
-## Use cases
-
-The Ruler's Prometheus compatibility further accentuates the marriage between metrics and logs. For those looking to get started with metrics and alerts based on logs, or wondering why this might be useful, here are a few use cases we think fit very well.
-
-### Black box monitoring
-
-We don't always control the source code of applications we run. Load balancers and a myriad of other components, both open source and closed third-party, support our applications while they don't expose the metrics we want. Some don't expose any metrics at all. The Loki alerting and recording rules can produce metrics and alert on the state of the system, bringing the components into our observability stack by using the logs. This is an incredibly powerful way to introduce advanced observability into legacy architectures.
-
-### Event alerting
-
-Sometimes you want to know whether _any_ instance of something has occurred. Alerting based on logs can be a great way to handle this, such as finding examples of leaked authentication credentials:
-
-```yaml
-- name: credentials_leak
-  rules:
-    - alert: http-credentials-leaked
-      annotations:
-        message: "{{ $labels.job }} is leaking http basic auth credentials."
-      expr: 'sum by (cluster, job, pod) (count_over_time({namespace="prod"} |~ "http(s?)://(\\w+):(\\w+)@" [5m]) > 0)'
-      for: 10m
-      labels:
-        severity: critical
-```
-
-### Alerting on high-cardinality sources
-
-Another great use case is alerting on high cardinality sources. These are things which are difficult/expensive to record as metrics because the potential label set is huge. A great example of this is per-tenant alerting in multi-tenanted systems like Loki. It's a common balancing act between the desire to have per-tenant metrics and the cardinality explosion that ensues (adding a single _tenant_ label to an existing Prometheus metric would increase its cardinality by the number of tenants).
-
-Creating these alerts in LogQL is attractive because these metrics can be extracted at _query time_, meaning we don't suffer the cardinality explosion in our metrics store.
-
-{{< admonition type="note" >}}
-As an example, we can use LogQL v2 to help Loki to monitor _itself_, alerting us when specific tenants have queries that take longer than 10s to complete! To do so, we'd use the following query: `sum by (org_id) (rate({job="loki-prod/query-frontend"} |= "metrics.go" | logfmt | duration > 10s [1m])`.
-{{< /admonition >}}
+For information on managing recording rules, refer to the [Recording Rules](https://grafana.com/docs/loki/<LOKI_VERSION>/operations/recording-rules/) page.
 
 ## Interacting with the Ruler
 
@@ -348,18 +362,12 @@ With the above configuration, the Ruler would expect the following layout:
                            /rules2.yaml
 ```
 
-Yaml files are expected to be [Prometheus-compatible](https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/) but include LogQL expressions as specified in the beginning of this doc.
+Yaml files are expected to be [Prometheus-compatible](https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/) but include LogQL expressions as specified earlier in this topic.
 
 ## Remote rule evaluation
 
 With larger deployments and complex rules, running a ruler in local evaluation mode causes problems where results could be inconsistent or incomplete compared to what you see in Grafana. To solve this, use the remote evaluation mode to evaluate rules against the query frontend. A more detailed explanation can be found in [scalability documentation](https://grafana.com/docs/loki/<LOKI_VERSION>/operations/scalability/#remote-rule-evaluation).
 
-## Future improvements
+## Metrics backends vs in-memory
 
-There are a few things coming to increase the robustness of this service. In no particular order:
-
-- Backend metric stores adapters for generated alert rule data.
-
-## Misc Details: Metrics backends vs in-memory
-
-Currently the Loki Ruler is decoupled from a backing Prometheus store. Generally, the result of evaluating rules as well as the history of the alert's state are stored as a time series. Loki is unable to store/retrieve these in order to allow it to run independently of i.e. Prometheus. As a workaround, Loki keeps a small in memory store whose purpose is to lazy load past evaluations when rescheduling or resharding Rulers. In the future, Loki will support optional metrics backends, allowing storage of these metrics for auditing and performance benefits.
+Currently the Loki Ruler is decoupled from a backing Prometheus store. Generally, the result of evaluating rules as well as the history of the alert's state are stored as a time series. Loki is unable to store/retrieve these in order to allow it to run independently of i.e. Prometheus. As a workaround, Loki keeps a small in memory store whose purpose is to lazy load past evaluations when rescheduling or resharding Rulers.


### PR DESCRIPTION
**What this PR does / why we need it**:
 - Adds information that there are two types of alerting in Grafana.
 - Adds link to Create log alert rules with Grafana Alerting learning journey.
 - Moves use cases earlier in the topic.
 - Changes formatting for quoted text from Promtheus documentation.
 - Removes content about what will happen in the future.