### PR TITLE
chore: Make metastore event synchronous

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -1157,6 +1157,12 @@ dataobj:
       # CLI flag: -dataobj-metastore.enabled-tenant-ids
       [enabled_tenant_ids: <string> | default = ""]
 
+    # Experimental: The ratio of log partitions to metastore partitions. For
+    # example, a value of 10 means there is 1 metastore partition for every 10
+    # log partitions.
+    # CLI flag: -dataobj-metastore.partition-ratio
+    [partition_ratio: <int> | default = 10]
+
   querier:
     # Enable the dataobj querier.
     # CLI flag: -dataobj-querier-enabled

--- a/pkg/dataobj/consumer/mock_test.go
+++ b/pkg/dataobj/consumer/mock_test.go
@@ -38,6 +38,7 @@ func (m *mockBucket) Exists(_ context.Context, name string) (bool, error) {
 	_, exists := m.uploads[name]
 	return exists, nil
 }
+
 func (m *mockBucket) Get(_ context.Context, name string) (io.ReadCloser, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -47,9 +48,11 @@ func (m *mockBucket) Get(_ context.Context, name string) (io.ReadCloser, error) 
 	}
 	return io.NopCloser(bytes.NewReader(data)), nil
 }
+
 func (m *mockBucket) GetRange(_ context.Context, _ string, _, _ int64) (io.ReadCloser, error) {
 	return nil, nil
 }
+
 func (m *mockBucket) Upload(_ context.Context, name string, r io.Reader) error {
 	data, err := io.ReadAll(r)
 	if err != nil {
@@ -60,6 +63,7 @@ func (m *mockBucket) Upload(_ context.Context, name string, r io.Reader) error {
 	m.uploads[name] = data
 	return nil
 }
+
 func (m *mockBucket) Iter(_ context.Context, _ string, _ func(string) error, _ ...objstore.IterOption) error {
 	return nil
 }
@@ -67,21 +71,27 @@ func (m *mockBucket) Name() string { return "mock" }
 func (m *mockBucket) Attributes(_ context.Context, _ string) (objstore.ObjectAttributes, error) {
 	return objstore.ObjectAttributes{}, nil
 }
+
 func (m *mockBucket) GetAndReplace(_ context.Context, name string, _ func(io.ReadCloser) (io.ReadCloser, error)) error {
 	return m.Upload(context.Background(), name, io.NopCloser(bytes.NewReader([]byte{})))
 }
+
 func (m *mockBucket) IsAccessDeniedErr(_ error) bool {
 	return false
 }
+
 func (m *mockBucket) IsObjNotFoundErr(err error) bool {
 	return err != nil && err.Error() == "object not found"
 }
+
 func (m *mockBucket) IterWithAttributes(_ context.Context, _ string, _ func(objstore.IterObjectAttributes) error, _ ...objstore.IterOption) error {
 	return nil
 }
+
 func (m *mockBucket) Provider() objstore.ObjProvider {
 	return objstore.ObjProvider("MOCK")
 }
+
 func (m *mockBucket) SupportedIterOptions() []objstore.IterOptionType {
 	return nil
 }
@@ -98,9 +108,11 @@ func (m *mockBuilder) Append(stream logproto.Stream) error {
 	}
 	return m.builder.Append(stream)
 }
+
 func (m *mockBuilder) GetEstimatedSize() int {
 	return m.builder.GetEstimatedSize()
 }
+
 func (m *mockBuilder) Flush() (*dataobj.Object, io.Closer, error) {
 	if err := m.nextErr; err != nil {
 		m.nextErr = nil
@@ -108,9 +120,11 @@ func (m *mockBuilder) Flush() (*dataobj.Object, io.Closer, error) {
 	}
 	return m.builder.Flush()
 }
+
 func (m *mockBuilder) TimeRange() (time.Time, time.Time) {
 	return m.builder.TimeRange()
 }
+
 func (m *mockBuilder) UnregisterMetrics(r prometheus.Registerer) {
 	m.builder.UnregisterMetrics(r)
 }
@@ -125,6 +139,20 @@ type mockCommitter struct {
 func (m *mockCommitter) CommitRecords(_ context.Context, records ...*kgo.Record) error {
 	m.records = append(m.records, records...)
 	return nil
+}
+
+// A mockProducer implements the producer interface for tests.
+type mockProducer struct {
+	results []*kgo.Record
+}
+
+func (m *mockProducer) ProduceSync(_ context.Context, records ...*kgo.Record) kgo.ProduceResults {
+	m.results = append(m.results, records...)
+	return kgo.ProduceResults{
+		{
+			Err: nil,
+		},
+	}
 }
 
 type recordedTocEntry struct {

--- a/pkg/dataobj/consumer/partition_processor_test.go
+++ b/pkg/dataobj/consumer/partition_processor_test.go
@@ -132,6 +132,47 @@ func TestPartitionProcessor_Flush(t *testing.T) {
 		require.Equal(t, now, p.lastFlushed)
 		require.True(t, p.lastModified.IsZero())
 	})
+
+	t.Run("has emitted metastore event", func(t *testing.T) {
+		clock := quartz.NewMock(t)
+		p := newTestPartitionProcessor(t, clock)
+
+		producer := &mockProducer{}
+		p.eventsProducerClient = producer
+		p.partition = 23
+
+		// All timestamps should be zero.
+		require.True(t, p.lastFlushed.IsZero())
+		require.True(t, p.lastModified.IsZero())
+
+		// Push a stream.
+		now := clock.Now()
+		s := logproto.Stream{
+			Labels: `{service="test"}`,
+			Entries: []push.Entry{{
+				Timestamp: now,
+				Line:      "abc",
+			}},
+		}
+		b, err := s.Marshal()
+		require.NoError(t, err)
+		p.processRecord(&kgo.Record{
+			Key:       []byte("test-tenant"),
+			Value:     b,
+			Timestamp: now,
+		})
+
+		// No flush should have occurred, we will flush ourselves instead.
+		require.True(t, p.lastFlushed.IsZero())
+
+		// Flush the data object. The last modified time should also be reset.
+		require.NoError(t, p.flush())
+
+		// Check that the metastore event was emitted.
+		require.Len(t, producer.results, 1)
+		// Partition should be the processor's partition divided by the partition ratio, in integer division.
+		require.Equal(t, int32(2), producer.results[0].Partition)
+	})
 }
 
 func TestPartitionProcessor_IdleFlush(t *testing.T) {
@@ -328,7 +369,9 @@ func newTestPartitionProcessor(_ *testing.T, clock quartz.Clock) *partitionProce
 		&kgo.Client{},
 		testBuilderConfig,
 		uploader.Config{},
-		metastore.Config{},
+		metastore.Config{
+			PartitionRatio: 10,
+		},
 		newMockBucket(),
 		nil,
 		"test-tenant",
@@ -341,5 +384,6 @@ func newTestPartitionProcessor(_ *testing.T, clock quartz.Clock) *partitionProce
 		nil,
 	)
 	p.clock = clock
+	p.eventsProducerClient = &mockProducer{}
 	return p
 }

--- a/pkg/dataobj/metastore/config.go
+++ b/pkg/dataobj/metastore/config.go
@@ -2,6 +2,7 @@ package metastore
 
 import (
 	"flag"
+	fmt "fmt"
 
 	"github.com/grafana/dskit/flagext"
 )
@@ -21,6 +22,9 @@ func (c *Config) RegisterFlags(f *flag.FlagSet) {
 
 // Validate validates the metastore settings.
 func (c *Config) Validate() error {
+	if c.PartitionRatio <= 0 {
+		return fmt.Errorf("partition_ratio must be greater than 0, got %d", c.PartitionRatio)
+	}
 	return nil
 }
 

--- a/pkg/dataobj/metastore/config.go
+++ b/pkg/dataobj/metastore/config.go
@@ -8,13 +8,15 @@ import (
 
 // Config is the configuration block for the metastore settings.
 type Config struct {
-	Storage StorageConfig `yaml:"storage" experimental:"true"`
+	Storage        StorageConfig `yaml:"storage" experimental:"true"`
+	PartitionRatio int           `yaml:"partition_ratio" experimental:"true"`
 }
 
 // RegisterFlags registers the flags for the metastore settings.
 func (c *Config) RegisterFlags(f *flag.FlagSet) {
 	prefix := "dataobj-metastore."
 	c.Storage.RegisterFlagsWithPrefix(prefix, f)
+	f.IntVar(&c.PartitionRatio, prefix+"partition-ratio", 10, "Experimental: The ratio of log partitions to metastore partitions. For example, a value of 10 means there is 1 metastore partition for every 10 log partitions.")
 }
 
 // Validate validates the metastore settings.

--- a/pkg/dataobj/metastore/metastore.pb.go
+++ b/pkg/dataobj/metastore/metastore.pb.go
@@ -5,18 +5,21 @@ package metastore
 
 import (
 	fmt "fmt"
-	proto "github.com/gogo/protobuf/proto"
 	io "io"
 	math "math"
 	math_bits "math/bits"
 	reflect "reflect"
 	strings "strings"
+
+	proto "github.com/gogo/protobuf/proto"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
-var _ = proto.Marshal
-var _ = fmt.Errorf
-var _ = math.Inf
+var (
+	_ = proto.Marshal
+	_ = fmt.Errorf
+	_ = math.Inf
+)
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the proto package it is being compiled against.
@@ -36,9 +39,11 @@ func (*ObjectWrittenEvent) ProtoMessage() {}
 func (*ObjectWrittenEvent) Descriptor() ([]byte, []int) {
 	return fileDescriptor_fdfd617758a99d3c, []int{0}
 }
+
 func (m *ObjectWrittenEvent) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *ObjectWrittenEvent) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_ObjectWrittenEvent.Marshal(b, m, deterministic)
@@ -51,12 +56,15 @@ func (m *ObjectWrittenEvent) XXX_Marshal(b []byte, deterministic bool) ([]byte, 
 		return b[:n], nil
 	}
 }
+
 func (m *ObjectWrittenEvent) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_ObjectWrittenEvent.Merge(m, src)
 }
+
 func (m *ObjectWrittenEvent) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *ObjectWrittenEvent) XXX_DiscardUnknown() {
 	xxx_messageInfo_ObjectWrittenEvent.DiscardUnknown(m)
 }
@@ -141,6 +149,7 @@ func (this *ObjectWrittenEvent) Equal(that interface{}) bool {
 	}
 	return true
 }
+
 func (this *ObjectWrittenEvent) GoString() string {
 	if this == nil {
 		return "nil"
@@ -153,6 +162,7 @@ func (this *ObjectWrittenEvent) GoString() string {
 	s = append(s, "}")
 	return strings.Join(s, "")
 }
+
 func valueToGoStringMetastore(v interface{}, typ string) string {
 	rv := reflect.ValueOf(v)
 	if rv.IsNil() {
@@ -161,6 +171,7 @@ func valueToGoStringMetastore(v interface{}, typ string) string {
 	pv := reflect.Indirect(rv).Interface()
 	return fmt.Sprintf("func(v %v) *%v { return &v } ( %#v )", typ, typ, pv)
 }
+
 func (m *ObjectWrittenEvent) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
@@ -216,6 +227,7 @@ func encodeVarintMetastore(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	return base
 }
+
 func (m *ObjectWrittenEvent) Size() (n int) {
 	if m == nil {
 		return 0
@@ -240,14 +252,17 @@ func (m *ObjectWrittenEvent) Size() (n int) {
 func sovMetastore(x uint64) (n int) {
 	return (math_bits.Len64(x|1) + 6) / 7
 }
+
 func sozMetastore(x uint64) (n int) {
 	return sovMetastore(uint64((x << 1) ^ uint64((int64(x) >> 63))))
 }
+
 func (this *ObjectWrittenEvent) String() string {
 	if this == nil {
 		return "nil"
 	}
-	s := strings.Join([]string{`&ObjectWrittenEvent{`,
+	s := strings.Join([]string{
+		`&ObjectWrittenEvent{`,
 		`Tenant:` + fmt.Sprintf("%v", this.Tenant) + `,`,
 		`ObjectPath:` + fmt.Sprintf("%v", this.ObjectPath) + `,`,
 		`WriteTime:` + fmt.Sprintf("%v", this.WriteTime) + `,`,
@@ -255,6 +270,7 @@ func (this *ObjectWrittenEvent) String() string {
 	}, "")
 	return s
 }
+
 func valueToStringMetastore(v interface{}) string {
 	rv := reflect.ValueOf(v)
 	if rv.IsNil() {
@@ -263,6 +279,7 @@ func valueToStringMetastore(v interface{}) string {
 	pv := reflect.Indirect(rv).Interface()
 	return fmt.Sprintf("*%v", pv)
 }
+
 func (m *ObjectWrittenEvent) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -412,6 +429,7 @@ func (m *ObjectWrittenEvent) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func skipMetastore(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0

--- a/pkg/dataobj/metastore/metastore.pb.go
+++ b/pkg/dataobj/metastore/metastore.pb.go
@@ -5,21 +5,18 @@ package metastore
 
 import (
 	fmt "fmt"
+	proto "github.com/gogo/protobuf/proto"
 	io "io"
 	math "math"
 	math_bits "math/bits"
 	reflect "reflect"
 	strings "strings"
-
-	proto "github.com/gogo/protobuf/proto"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
-var (
-	_ = proto.Marshal
-	_ = fmt.Errorf
-	_ = math.Inf
-)
+var _ = proto.Marshal
+var _ = fmt.Errorf
+var _ = math.Inf
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the proto package it is being compiled against.
@@ -39,11 +36,9 @@ func (*ObjectWrittenEvent) ProtoMessage() {}
 func (*ObjectWrittenEvent) Descriptor() ([]byte, []int) {
 	return fileDescriptor_fdfd617758a99d3c, []int{0}
 }
-
 func (m *ObjectWrittenEvent) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *ObjectWrittenEvent) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_ObjectWrittenEvent.Marshal(b, m, deterministic)
@@ -56,15 +51,12 @@ func (m *ObjectWrittenEvent) XXX_Marshal(b []byte, deterministic bool) ([]byte, 
 		return b[:n], nil
 	}
 }
-
 func (m *ObjectWrittenEvent) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_ObjectWrittenEvent.Merge(m, src)
 }
-
 func (m *ObjectWrittenEvent) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *ObjectWrittenEvent) XXX_DiscardUnknown() {
 	xxx_messageInfo_ObjectWrittenEvent.DiscardUnknown(m)
 }
@@ -149,7 +141,6 @@ func (this *ObjectWrittenEvent) Equal(that interface{}) bool {
 	}
 	return true
 }
-
 func (this *ObjectWrittenEvent) GoString() string {
 	if this == nil {
 		return "nil"
@@ -162,7 +153,6 @@ func (this *ObjectWrittenEvent) GoString() string {
 	s = append(s, "}")
 	return strings.Join(s, "")
 }
-
 func valueToGoStringMetastore(v interface{}, typ string) string {
 	rv := reflect.ValueOf(v)
 	if rv.IsNil() {
@@ -171,7 +161,6 @@ func valueToGoStringMetastore(v interface{}, typ string) string {
 	pv := reflect.Indirect(rv).Interface()
 	return fmt.Sprintf("func(v %v) *%v { return &v } ( %#v )", typ, typ, pv)
 }
-
 func (m *ObjectWrittenEvent) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
@@ -227,7 +216,6 @@ func encodeVarintMetastore(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	return base
 }
-
 func (m *ObjectWrittenEvent) Size() (n int) {
 	if m == nil {
 		return 0
@@ -252,17 +240,14 @@ func (m *ObjectWrittenEvent) Size() (n int) {
 func sovMetastore(x uint64) (n int) {
 	return (math_bits.Len64(x|1) + 6) / 7
 }
-
 func sozMetastore(x uint64) (n int) {
 	return sovMetastore(uint64((x << 1) ^ uint64((int64(x) >> 63))))
 }
-
 func (this *ObjectWrittenEvent) String() string {
 	if this == nil {
 		return "nil"
 	}
-	s := strings.Join([]string{
-		`&ObjectWrittenEvent{`,
+	s := strings.Join([]string{`&ObjectWrittenEvent{`,
 		`Tenant:` + fmt.Sprintf("%v", this.Tenant) + `,`,
 		`ObjectPath:` + fmt.Sprintf("%v", this.ObjectPath) + `,`,
 		`WriteTime:` + fmt.Sprintf("%v", this.WriteTime) + `,`,
@@ -270,7 +255,6 @@ func (this *ObjectWrittenEvent) String() string {
 	}, "")
 	return s
 }
-
 func valueToStringMetastore(v interface{}) string {
 	rv := reflect.ValueOf(v)
 	if rv.IsNil() {
@@ -279,7 +263,6 @@ func valueToStringMetastore(v interface{}) string {
 	pv := reflect.Indirect(rv).Interface()
 	return fmt.Sprintf("*%v", pv)
 }
-
 func (m *ObjectWrittenEvent) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -429,7 +412,6 @@ func (m *ObjectWrittenEvent) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func skipMetastore(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0


### PR DESCRIPTION
**What this PR does / why we need it**:
Makes metastore events required (no more best effort)
* Adds a new parameter that picks metastore partitions by dividing the partition-processor's partition by a constant factor. I chose 10, so for every 10 logs partitions, we use a single metastore partition (e.g. for every 10 partition-ingesters, we need 1 index-builder)
* This might need to be adjusted, so when creating the topic in the first place we'll need to set it to have enough partitions.

**Which issue(s) this PR fixes**:
Part of https://github.com/grafana/loki-private/issues/1769