### PR TITLE
fix: deadlock when shutting down dataobj-consumers

### DIFF
--- a/pkg/dataobj/consumer/consumer.go
+++ b/pkg/dataobj/consumer/consumer.go
@@ -1,0 +1,140 @@
+package consumer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/backoff"
+	"github.com/twmb/franz-go/pkg/kgo"
+)
+
+// kafkaConsumer allows mocking of certain [kgo.Client] methods in tests.
+type kafkaConsumer interface {
+	PollFetches(context.Context) kgo.Fetches
+}
+
+// consumer polls records from the Kafka topic and passes each record to
+// its indended processor.
+type consumer struct {
+	client     kafkaConsumer
+	logger     log.Logger
+	processors map[string]map[int32]processor
+	mtx        sync.RWMutex
+}
+
+// newConsumer returns a new consumer.
+func newConsumer(client kafkaConsumer, logger log.Logger) *consumer {
+	return &consumer{
+		client:     client,
+		logger:     logger,
+		processors: make(map[string]map[int32]processor),
+	}
+}
+
+// OnRegister implements the [partitionProcessorListener] interface.
+func (c *consumer) OnRegister(topic string, partition int32, p processor) {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+	processorsByTopic, ok := c.processors[topic]
+	if !ok {
+		processorsByTopic = make(map[int32]processor)
+		c.processors[topic] = processorsByTopic
+	}
+	processorsByTopic[partition] = p
+}
+
+// OnDeregister implements the [partitionProcessorListener] interface.
+func (c *consumer) OnDeregister(topic string, partition int32) {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+	processorsByTopic, ok := c.processors[topic]
+	if !ok {
+		return
+	}
+	delete(processorsByTopic, partition)
+	if len(processorsByTopic) == 0 {
+		delete(c.processors, topic)
+	}
+}
+
+// run starts the poll loop. It is stopped when either the context is canceled
+// or the kafka client is closed.
+func (c *consumer) Run(ctx context.Context) error {
+	b := backoff.New(ctx, backoff.Config{
+		MinBackoff: 100 * time.Millisecond,
+		MaxBackoff: time.Second,
+		MaxRetries: 0,
+	})
+	for b.Ongoing() {
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+			if err := c.pollFetches(ctx); err != nil {
+				if errors.Is(err, kgo.ErrClientClosed) {
+					return nil
+				}
+				level.Error(c.logger).Log("msg", "failed to poll fetches", "err", err.Error())
+				b.Wait()
+			}
+		}
+	}
+	return nil
+}
+
+func (c *consumer) pollFetches(ctx context.Context) error {
+	fetches := c.client.PollFetches(ctx)
+	if err := fetches.Err(); err != nil {
+		return err
+	}
+	fetches.EachPartition(c.processFetchTopicPartition(ctx))
+	return nil
+}
+
+func (c *consumer) processFetchTopicPartition(_ context.Context) func(kgo.FetchTopicPartition) {
+	return func(fetch kgo.FetchTopicPartition) {
+		// If there are no records for this partition then skip it.
+		if len(fetch.Records) == 0 {
+			return
+		}
+		processor, err := c.processorForTopicPartition(fetch.Topic, fetch.Partition)
+		if err != nil {
+			// It should never happen that we fetch records for a newly
+			// assigned partition before the lifecycler has registered a
+			// processor for it. This is because [kgo.OnPartitionsAssigned]
+			// guarantees to return before the client starts fetching records
+			// for new partitions.
+			//
+			// However, it can happen the client has fetched records for a
+			// partition that has just been reassigned to another consumer.
+			// If this happens, we will attempt to process those records, but
+			// may not have a processor for them as the processor would have
+			// been deregistered via [kgo.OnPartitionsRevoked], and the
+			// following log line will be emitted.
+			level.Error(c.logger).Log("msg", "failed to get processor", "error", err.Error())
+			return
+		}
+		_ = processor.Append(fetch.Records)
+	}
+}
+
+// processorForTopicPartition returns the processor for the topic and partition.
+// It returns an error if one does not exist.
+func (c *consumer) processorForTopicPartition(topic string, partition int32) (processor, error) {
+	c.mtx.RLock()
+	defer c.mtx.RUnlock()
+	processorsByTopic, ok := c.processors[topic]
+	if !ok {
+		return nil, fmt.Errorf("unknown topic %s", topic)
+	}
+	p, ok := processorsByTopic[partition]
+	if !ok {
+		return nil, fmt.Errorf("unknown partition %d for topic %s", partition, topic)
+	}
+	return p, nil
+}

--- a/pkg/dataobj/consumer/consumer_test.go
+++ b/pkg/dataobj/consumer/consumer_test.go
@@ -1,0 +1,64 @@
+package consumer
+
+import (
+	"testing"
+
+	"github.com/go-kit/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConsumer_OnRegister(t *testing.T) {
+	c := newConsumer(&mockKafka{}, log.NewNopLogger())
+	require.Empty(t, c.processors)
+	// Register a processor for the topic.
+	p1 := &partitionProcessor{}
+	c.OnRegister("topic1", 1, p1)
+	require.NotNil(t, c.processors["topic1"])
+	require.Same(t, p1, c.processors["topic1"][1])
+	// Register another processor for the same topic.
+	p2 := &partitionProcessor{}
+	c.OnRegister("topic1", 2, p2)
+	require.Len(t, c.processors["topic1"], 2)
+	require.Same(t, p1, c.processors["topic1"][1])
+	require.Same(t, p2, c.processors["topic1"][2])
+	// Register another processor for a different topic.
+	p3 := &partitionProcessor{}
+	c.OnRegister("topic2", 1, p3)
+	require.NotNil(t, c.processors["topic1"])
+	require.Len(t, c.processors["topic1"], 2)
+	require.Same(t, p1, c.processors["topic1"][1])
+	require.Same(t, p2, c.processors["topic1"][2])
+	require.Len(t, c.processors["topic2"], 1)
+	require.Same(t, p3, c.processors["topic2"][1])
+}
+
+func TestConsumer_OnDeregister(t *testing.T) {
+	c := newConsumer(&mockKafka{}, log.NewNopLogger())
+	require.Empty(t, c.processors)
+	// Register a bunch of processors for different topics.
+	p1 := &partitionProcessor{}
+	c.OnRegister("topic1", 1, p1)
+	p2 := &partitionProcessor{}
+	c.OnRegister("topic1", 2, p2)
+	require.Len(t, c.processors["topic1"], 2)
+	p3 := &partitionProcessor{}
+	c.OnRegister("topic2", 1, p3)
+	// Check all the processors are as expected.
+	require.NotNil(t, c.processors["topic1"])
+	require.Len(t, c.processors["topic1"], 2)
+	require.Same(t, p1, c.processors["topic1"][1])
+	require.Same(t, p2, c.processors["topic1"][2])
+	require.Len(t, c.processors["topic2"], 1)
+	require.Same(t, p3, c.processors["topic2"][1])
+	// Now deregister one and check the remaining processors.
+	c.OnDeregister("topic1", 1)
+	require.Len(t, c.processors["topic1"], 1)
+	require.Nil(t, c.processors["topic1"][1])
+	require.Same(t, p2, c.processors["topic1"][2])
+	// Now deregister the last one and check the topic is removed.
+	c.OnDeregister("topic1", 2)
+	require.Nil(t, c.processors["topic1"])
+	// The other topic should be unmodified.
+	require.Len(t, c.processors["topic2"], 1)
+	require.Same(t, p3, c.processors["topic2"][1])
+}

--- a/pkg/dataobj/consumer/partition_lifecycler.go
+++ b/pkg/dataobj/consumer/partition_lifecycler.go
@@ -1,0 +1,86 @@
+package consumer
+
+import (
+	"context"
+	"sync"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/twmb/franz-go/pkg/kgo"
+
+	"github.com/grafana/loki/v3/pkg/distributor"
+)
+
+// processorLifecycler allows mocking of partition processor lifecycler in tests.
+type processorLifecycler interface {
+	Register(ctx context.Context, client *kgo.Client, tenant string, virtualShard int32, topic string, partition int32)
+	Deregister(ctx context.Context, topic string, partition int32)
+	Stop(ctx context.Context)
+}
+
+// partitionLifecycler manages assignment and revocation of partitions.
+type partitionLifecycler struct {
+	processors processorLifecycler
+	codec      distributor.TenantPrefixCodec
+	logger     log.Logger
+	done       bool
+	mtx        sync.Mutex
+}
+
+// newPartitionLifecycler returns a new partitionLifecycler.
+func newPartitionLifecycler(
+	processors processorLifecycler,
+	codec distributor.TenantPrefixCodec,
+	logger log.Logger,
+) *partitionLifecycler {
+	return &partitionLifecycler{
+		processors: processors,
+		codec:      codec,
+		logger:     logger,
+	}
+}
+
+// Assign implements [kgo.OnPartitionsAssigned].
+func (l *partitionLifecycler) Assign(
+	ctx context.Context,
+	client *kgo.Client,
+	topics map[string][]int32,
+) {
+	l.mtx.Lock()
+	defer l.mtx.Unlock()
+	if l.done {
+		return
+	}
+	for topic, partitions := range topics {
+		tenant, virtualShard, err := l.codec.Decode(topic)
+		if err != nil {
+			level.Error(l.logger).Log("msg", "failed to decode topic", "topic", topic, "err", err)
+			continue
+		}
+		for _, partition := range partitions {
+			l.processors.Register(ctx, client, tenant, virtualShard, topic, partition)
+		}
+	}
+}
+
+// Revoke implements [kgo.OnPartitionsRevoked].
+func (l *partitionLifecycler) Revoke(
+	ctx context.Context,
+	_ *kgo.Client,
+	topics map[string][]int32) {
+	for topic, partitions := range topics {
+		for _, partition := range partitions {
+			l.processors.Deregister(ctx, topic, partition)
+		}
+	}
+}
+
+// Stop shutsdown the lifecycler.
+func (l *partitionLifecycler) Stop(ctx context.Context) {
+	level.Debug(l.logger).Log("msg", "stopping")
+	defer func() { level.Debug(l.logger).Log("msg", "stopped") }()
+	l.mtx.Lock()
+	defer l.mtx.Unlock()
+	l.processors.Stop(ctx)
+	l.done = true
+}

--- a/pkg/dataobj/consumer/partition_lifecycler_test.go
+++ b/pkg/dataobj/consumer/partition_lifecycler_test.go
@@ -1,0 +1,71 @@
+package consumer
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-kit/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPartitionLifecycler(t *testing.T) {
+	// We use a mock to record the calls from the lifecycler.
+	p := &mockPartitionProcessorLifecycler{}
+	l := newPartitionLifecycler(p, "test", log.NewNopLogger())
+	require.Nil(t, p.processors)
+	// Assign a couple topics and partitions.
+	topics := map[string][]int32{
+		"test.topic1.0": {0, 1, 2},
+		"test.topic2.0": {3, 4, 5},
+	}
+	l.Assign(context.TODO(), nil, topics)
+	// There should be two topics.
+	require.Len(t, p.processors, 2)
+	// The first topic should have partitions 0, 1 and 2.
+	expected1 := map[int32]struct{}{0: {}, 1: {}, 2: {}}
+	require.Equal(t, expected1, p.processors["test.topic1.0"])
+	// And the second topic should have partitions 3, 4 and 5.
+	expected2 := map[int32]struct{}{3: {}, 4: {}, 5: {}}
+	require.Equal(t, expected2, p.processors["test.topic2.0"])
+}
+
+func TestPartitionLifecycler_Revoke(t *testing.T) {
+	p := &mockPartitionProcessorLifecycler{}
+	l := newPartitionLifecycler(p, "test", log.NewNopLogger())
+	require.Nil(t, p.processors)
+	// Assign a couple topics and partitions.
+	topics := map[string][]int32{
+		"test.topic1.0": {0, 1, 2},
+		"test.topic2.0": {3, 4, 5},
+	}
+	l.Assign(context.TODO(), nil, topics)
+	// There should be two topics.
+	require.Len(t, p.processors, 2)
+	// Revoke a partition.
+	revoke1 := map[string][]int32{"test.topic1.0": {0}}
+	l.Revoke(context.TODO(), nil, revoke1)
+	// There should be two topics.
+	require.Len(t, p.processors, 2)
+	// The first topic should have partitions 1 and 2.
+	expected1 := map[int32]struct{}{1: {}, 2: {}}
+	require.Equal(t, expected1, p.processors["test.topic1.0"])
+	// And the second topic should have partitions 3, 4 and 5.
+	expected2 := map[int32]struct{}{3: {}, 4: {}, 5: {}}
+	require.Equal(t, expected2, p.processors["test.topic2.0"])
+}
+
+func TestPartitionLifecycler_Stop(t *testing.T) {
+	p := &mockPartitionProcessorLifecycler{}
+	l := newPartitionLifecycler(p, "test", log.NewNopLogger())
+	require.Nil(t, p.processors)
+	require.False(t, l.done)
+	l.Stop(context.TODO())
+	require.True(t, l.done)
+	// Once stopped, should not be able to assign partitions.
+	topics := map[string][]int32{
+		"test.topic1.0": {0, 1, 2},
+		"test.topic2.0": {3, 4, 5},
+	}
+	l.Assign(context.TODO(), nil, topics)
+	require.Nil(t, p.processors)
+}

--- a/pkg/dataobj/consumer/partition_processor_factory.go
+++ b/pkg/dataobj/consumer/partition_processor_factory.go
@@ -12,53 +12,60 @@ import (
 	"github.com/grafana/loki/v3/pkg/scratch"
 )
 
+// partitionProcessorFactory is a factory for partition processors.
 type partitionProcessorFactory struct {
 	cfg Config
 	// TODO(grobinson): We should see if we can move metastore.Config inside
 	// Config instead of having a separate field just for the metastore.
-	metastoreCfg         metastore.Config
-	client               *kgo.Client
-	eventsProducerClient *kgo.Client
-	bucket               objstore.Bucket
-	scratchStore         scratch.Store
-	logger               log.Logger
-	reg                  prometheus.Registerer
+	metastoreCfg    metastore.Config
+	metastoreEvents *kgo.Client
+	bucket          objstore.Bucket
+	scratchStore    scratch.Store
+	logger          log.Logger
+	reg             prometheus.Registerer
 }
 
 // newPartitionProcessorFactory returns a new partitionProcessorFactory.
 func newPartitionProcessorFactory(
 	cfg Config,
 	metastoreCfg metastore.Config,
-	client *kgo.Client,
-	eventsProducerClient *kgo.Client,
+	metastoreEvents *kgo.Client,
 	bucket objstore.Bucket,
 	scratchStore scratch.Store,
 	logger log.Logger,
 	reg prometheus.Registerer,
 ) *partitionProcessorFactory {
 	return &partitionProcessorFactory{
-		cfg:                  cfg,
-		metastoreCfg:         metastoreCfg,
-		client:               client,
-		eventsProducerClient: eventsProducerClient,
-		bucket:               bucket,
-		scratchStore:         scratchStore,
-		logger:               logger,
-		reg:                  reg,
+		cfg:             cfg,
+		metastoreCfg:    metastoreCfg,
+		metastoreEvents: metastoreEvents,
+		bucket:          bucket,
+		scratchStore:    scratchStore,
+		logger:          logger,
+		reg:             reg,
 	}
 }
 
 // New creates a new processor for the per-tenant topic partition.
+//
+// New requires the caller to provide the [kgo.Client] as an argument. This
+// is due to a circular dependency that occurs when creating a [kgo.Client]
+// where the partition event handlers, such as [kgo.OnPartitionsAssigned] and
+// [kgo.OnPartitionsRevoked] must be registered when the client is created.
+// However, the lifecycler cannot be created without the factory, and the
+// factory cannot be created with a [kgo.Client]. This is why New requires a
+// [kgo.Client] as an argument.
 func (f *partitionProcessorFactory) New(
 	ctx context.Context,
+	client *kgo.Client,
 	tenant string,
 	virtualShard int32,
 	topic string,
 	partition int32,
-) *partitionProcessor {
+) processor {
 	return newPartitionProcessor(
 		ctx,
-		f.client,
+		client,
 		f.cfg.BuilderConfig,
 		f.cfg.UploaderConfig,
 		f.metastoreCfg,
@@ -71,6 +78,6 @@ func (f *partitionProcessorFactory) New(
 		f.logger,
 		f.reg,
 		f.cfg.IdleFlushTimeout,
-		f.eventsProducerClient,
+		f.metastoreEvents,
 	)
 }

--- a/pkg/dataobj/consumer/partition_processor_lifecycler.go
+++ b/pkg/dataobj/consumer/partition_processor_lifecycler.go
@@ -1,0 +1,142 @@
+package consumer
+
+import (
+	"context"
+	"sync"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/twmb/franz-go/pkg/kgo"
+)
+
+type processor interface {
+	Append(records []*kgo.Record) bool
+	start()
+	stop()
+}
+
+// processorFactory allows mocking of partition processor factory in tests.
+type processorFactory interface {
+	New(ctx context.Context, client *kgo.Client, tenant string, virtualShard int32, topic string, partition int32) processor
+}
+
+// partitionProcessorListener is an interface that listens to registering
+// and deregistering of partition processors.
+type partitionProcessorListener interface {
+	OnRegister(topic string, partition int32, processor processor)
+	OnDeregister(topic string, partition int32)
+}
+
+// partitionProcessorLifecycler manages the lifecycle of partition processors.
+type partitionProcessorLifecycler struct {
+	factory    processorFactory
+	processors map[string]map[int32]processor
+	listeners  []partitionProcessorListener
+	logger     log.Logger
+	reg        prometheus.Registerer
+	mtx        sync.Mutex
+}
+
+// newPartitionProcessorLifecycler returns a new partitionProcessorLifecycler.
+func newPartitionProcessorLifecycler(
+	factory processorFactory,
+	logger log.Logger,
+	reg prometheus.Registerer,
+) *partitionProcessorLifecycler {
+	return &partitionProcessorLifecycler{
+		factory:    factory,
+		processors: make(map[string]map[int32]processor),
+		listeners:  make([]partitionProcessorListener, 0),
+		logger:     logger,
+		reg:        reg,
+	}
+}
+
+// AddListener adds a listener to the partitionProcessorLifecycler.
+func (l *partitionProcessorLifecycler) AddListener(listener partitionProcessorListener) {
+	l.mtx.Lock()
+	defer l.mtx.Unlock()
+	l.listeners = append(l.listeners, listener)
+}
+
+// RemoveListener removes a listener from the partitionProcessorLifecycler.
+func (l *partitionProcessorLifecycler) RemoveListener(listener partitionProcessorListener) {
+	l.mtx.Lock()
+	defer l.mtx.Unlock()
+	for i, next := range l.listeners {
+		if next == listener {
+			l.listeners = append(l.listeners[:i], l.listeners[i+1:]...)
+			return
+		}
+	}
+}
+
+// Register creates and starts a processor for the partition.
+func (l *partitionProcessorLifecycler) Register(
+	ctx context.Context,
+	client *kgo.Client,
+	tenant string,
+	virtualShard int32,
+	topic string,
+	partition int32,
+) {
+	level.Debug(l.logger).Log("msg", "registering processor", "topic", topic, "partition", partition)
+	l.mtx.Lock()
+	defer l.mtx.Unlock()
+	processorsByTopic, ok := l.processors[topic]
+	if !ok {
+		processorsByTopic = make(map[int32]processor)
+		l.processors[topic] = processorsByTopic
+	}
+	_, ok = processorsByTopic[partition]
+	if !ok {
+		processor := l.factory.New(ctx, client, tenant, virtualShard, topic, partition)
+		processorsByTopic[partition] = processor
+		processor.start()
+		for _, listener := range l.listeners {
+			listener.OnRegister(topic, partition, processor)
+		}
+	}
+}
+
+// Deregister stops and removes processor for the partition.
+func (l *partitionProcessorLifecycler) Deregister(_ context.Context, topic string, partition int32) {
+	level.Debug(l.logger).Log("msg", "deregistering processor", "topic", topic, "partition", partition)
+	l.mtx.Lock()
+	defer l.mtx.Unlock()
+	processorsByTopic, ok := l.processors[topic]
+	if !ok {
+		return
+	}
+	processor, ok := processorsByTopic[partition]
+	if !ok {
+		return
+	}
+	processor.stop()
+	for _, listener := range l.listeners {
+		listener.OnDeregister(topic, partition)
+	}
+	delete(processorsByTopic, partition)
+	if len(processorsByTopic) == 0 {
+		delete(l.processors, topic)
+	}
+}
+
+// Stop stops and removes all processors.
+func (l *partitionProcessorLifecycler) Stop(_ context.Context) {
+	l.mtx.Lock()
+	defer l.mtx.Unlock()
+	level.Info(l.logger).Log("msg", "stopping")
+	for topic, processors := range l.processors {
+		for partition, processor := range processors {
+			level.Debug(l.logger).Log("msg", "deregistering processor", "topic", topic, "partition", partition)
+			processor.stop()
+			for _, listener := range l.listeners {
+				listener.OnDeregister(topic, partition)
+			}
+		}
+		delete(l.processors, topic)
+	}
+	level.Info(l.logger).Log("msg", "stopped")
+}

--- a/pkg/dataobj/consumer/partition_processor_lifecycler_test.go
+++ b/pkg/dataobj/consumer/partition_processor_lifecycler_test.go
@@ -1,0 +1,87 @@
+package consumer
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-kit/log"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPartitionProcessorLifecycler_AddListener(t *testing.T) {
+	l := newPartitionProcessorLifecycler(nil, log.NewNopLogger(), prometheus.NewRegistry())
+	m := &mockPartitionProcessorListener{}
+	require.Empty(t, l.listeners)
+	l.AddListener(m)
+	require.Len(t, l.listeners, 1)
+	require.Same(t, l.listeners[0], m)
+}
+
+func TestPartitionProcessorLifecycler_RemoveListener(t *testing.T) {
+	l := newPartitionProcessorLifecycler(nil, log.NewNopLogger(), prometheus.NewRegistry())
+	m1 := &mockPartitionProcessorListener{}
+	require.Empty(t, l.listeners)
+	l.AddListener(m1)
+	m2 := &mockPartitionProcessorListener{}
+	l.AddListener(m2)
+	require.Len(t, l.listeners, 2)
+	require.Equal(t, l.listeners[0], m1)
+	require.Equal(t, l.listeners[1], m2)
+	// Remove a listener.
+	l.RemoveListener(m1)
+	require.Len(t, l.listeners, 1)
+	require.Same(t, l.listeners[0], m2)
+	// Remove the last listener.
+	l.RemoveListener(m2)
+	require.Empty(t, l.listeners)
+}
+
+func TestPartitionProcessorLifecycler_Register(t *testing.T) {
+	m := &mockPartitionProcessorFactory{}
+	l := newPartitionProcessorLifecycler(m, log.NewNopLogger(), prometheus.NewRegistry())
+	require.Empty(t, l.processors)
+	// Register a topic and partition.
+	require.Equal(t, 0, m.calls)
+	l.Register(context.TODO(), nil, "tenant1", 0, "tenant1", 0)
+	require.Len(t, l.processors["tenant1"], 1)
+	require.Equal(t, 1, m.calls)
+	// Registering the same topic and partition a second time should not call
+	// the factory.
+	l.Register(context.TODO(), nil, "tenant1", 0, "tenant1", 0)
+	require.Len(t, l.processors["tenant1"], 1)
+	require.Equal(t, 1, m.calls)
+	// Register another partition for the same tenant.
+	l.Register(context.TODO(), nil, "tenant1", 1, "tenant1", 1)
+	require.Len(t, l.processors["tenant1"], 2)
+	require.Equal(t, 2, m.calls)
+	// Register another topic and partition for a different tenant.
+	l.Register(context.TODO(), nil, "tenant2", 0, "tenant2", 0)
+	require.Len(t, l.processors["tenant1"], 2)
+	require.Len(t, l.processors["tenant2"], 1)
+	require.Equal(t, 3, m.calls)
+}
+
+func TestPartitionProcessorLifecycler_Deregister(t *testing.T) {
+	m := &mockPartitionProcessorFactory{}
+	l := newPartitionProcessorLifecycler(m, log.NewNopLogger(), prometheus.NewRegistry())
+	require.Empty(t, l.processors)
+	// Register a topic and partition.
+	require.Equal(t, 0, m.calls)
+	l.Register(context.TODO(), nil, "tenant1", 0, "tenant1", 0)
+	l.Register(context.TODO(), nil, "tenant1", 1, "tenant1", 1)
+	l.Register(context.TODO(), nil, "tenant2", 0, "tenant2", 0)
+	require.Len(t, l.processors["tenant1"], 2)
+	require.Len(t, l.processors["tenant2"], 1)
+	// Deregister a partition for a tenant.
+	l.Deregister(context.TODO(), "tenant1", 0)
+	require.Len(t, l.processors["tenant1"], 1)
+	// Check that the correct partition was deregistered.
+	require.Nil(t, l.processors["tenant1"][0])
+	require.NotNil(t, l.processors["tenant1"][1])
+	require.Len(t, l.processors["tenant2"], 1)
+	// Deregister the last partition for the tenant.
+	l.Deregister(context.TODO(), "tenant1", 1)
+	require.Nil(t, l.processors["tenant1"])
+	require.Len(t, l.processors["tenant2"], 1)
+}

--- a/pkg/dataobj/consumer/partition_processor_test.go
+++ b/pkg/dataobj/consumer/partition_processor_test.go
@@ -137,8 +137,8 @@ func TestPartitionProcessor_Flush(t *testing.T) {
 		clock := quartz.NewMock(t)
 		p := newTestPartitionProcessor(t, clock)
 
-		producer := &mockProducer{}
-		p.eventsProducerClient = producer
+		client := &mockKafka{}
+		p.eventsProducerClient = client
 		p.partition = 23
 
 		// All timestamps should be zero.
@@ -169,9 +169,9 @@ func TestPartitionProcessor_Flush(t *testing.T) {
 		require.NoError(t, p.flush())
 
 		// Check that the metastore event was emitted.
-		require.Len(t, producer.results, 1)
+		require.Len(t, client.produced, 1)
 		// Partition should be the processor's partition divided by the partition ratio, in integer division.
-		require.Equal(t, int32(2), producer.results[0].Partition)
+		require.Equal(t, int32(2), client.produced[0].Partition)
 	})
 }
 
@@ -384,6 +384,6 @@ func newTestPartitionProcessor(_ *testing.T, clock quartz.Clock) *partitionProce
 		nil,
 	)
 	p.clock = clock
-	p.eventsProducerClient = &mockProducer{}
+	p.eventsProducerClient = &mockKafka{}
 	return p
 }

--- a/pkg/dataobj/consumer/service.go
+++ b/pkg/dataobj/consumer/service.go
@@ -2,9 +2,6 @@ package consumer
 
 import (
 	"context"
-	"errors"
-	"strconv"
-	"sync"
 	"time"
 
 	"github.com/go-kit/log"
@@ -19,231 +16,112 @@ import (
 	"github.com/grafana/loki/v3/pkg/distributor"
 	"github.com/grafana/loki/v3/pkg/kafka"
 	"github.com/grafana/loki/v3/pkg/kafka/client"
-	"github.com/grafana/loki/v3/pkg/kafka/partitionring/consumer"
+	kafka_consumer "github.com/grafana/loki/v3/pkg/kafka/partitionring/consumer"
 	"github.com/grafana/loki/v3/pkg/scratch"
-)
-
-const (
-	groupName = "dataobj-consumer"
 )
 
 type Service struct {
 	services.Service
-
-	logger log.Logger
-	reg    prometheus.Registerer
-	client *consumer.Client
-
-	eventsProducerClient *kgo.Client
-	eventConsumerClient  *kgo.Client
-
-	cfg   Config
-	codec distributor.TenantPrefixCodec
-
-	// Partition management
-	partitionMtx      sync.RWMutex
-	partitionHandlers map[string]map[int32]*partitionProcessor
-	processorFactory  *partitionProcessorFactory
+	cfg                 Config
+	consumer            *consumer
+	consumerClient      *kafka_consumer.Client
+	partitionLifecycler *partitionLifecycler
+	metastoreEvents     *kgo.Client
+	logger              log.Logger
+	reg                 prometheus.Registerer
 }
 
 func New(kafkaCfg kafka.Config, cfg Config, mCfg metastore.Config, topicPrefix string, bucket objstore.Bucket, scratchStore scratch.Store, instanceID string, partitionRing ring.PartitionRingReader, reg prometheus.Registerer, logger log.Logger) *Service {
+	logger = log.With(logger, "component", "dataobj-consumer")
+
 	s := &Service{
-		logger:            log.With(logger, "component", groupName),
-		cfg:               cfg,
-		codec:             distributor.TenantPrefixCodec(topicPrefix),
-		partitionHandlers: make(map[string]map[int32]*partitionProcessor),
-		reg:               reg,
+		logger: logger,
+		cfg:    cfg,
+		reg:    reg,
 	}
 
-	consumerClient, err := consumer.NewGroupClient(
+	// Set up the Kafka client that produces events for the metastore. This
+	// must be done before we can set up the client that consumes records
+	// from distributors, as the code that consumes these records from also
+	// needs to be able to produce metastore events.
+	metastoreEventsCfg := kafkaCfg
+	metastoreEventsCfg.Topic = "loki.metastore-events"
+	metastoreEventsCfg.AutoCreateTopicDefaultPartitions = 1
+	metastoreEvents, err := client.NewWriterClient("loki.metastore-events", metastoreEventsCfg, 50, logger, reg)
+	if err != nil {
+		level.Error(logger).Log("msg", "failed to create producer", "err", err)
+		return nil
+	}
+	s.metastoreEvents = metastoreEvents
+
+	// Set up the Kafka client and partition processors which consume records.
+	// We use a factory to create a processor per partition as and when
+	// partitions are assigned. This keeps the dependencies for processors
+	// out of the lifecycler which makes it easier to test.
+	processorFactory := newPartitionProcessorFactory(
+		cfg,
+		mCfg,
+		metastoreEvents,
+		bucket,
+		scratchStore,
+		logger,
+		reg,
+	)
+	processorLifecycler := newPartitionProcessorLifecycler(
+		processorFactory,
+		logger,
+		reg,
+	)
+	// When a partition is assigned or revoked, the partition lifecycler will
+	// register and unregister processors as needed via the processor lifecycler.
+	codec := distributor.TenantPrefixCodec(topicPrefix)
+	partitionLifecycler := newPartitionLifecycler(processorLifecycler, codec, logger)
+	// The client calls the lifecycler whenever partitions are assigned or
+	// revoked. This is how we register and unregister processors.
+	consumerClient, err := kafka_consumer.NewGroupClient(
 		kafkaCfg,
 		partitionRing,
-		groupName,
+		"dataobj-consumer",
 		logger,
 		reg,
 		kgo.InstanceID(instanceID),
 		kgo.SessionTimeout(3*time.Minute),
 		kgo.RebalanceTimeout(5*time.Minute),
-		kgo.OnPartitionsAssigned(s.handlePartitionsAssigned),
-		kgo.OnPartitionsRevoked(func(_ context.Context, _ *kgo.Client, m map[string][]int32) {
-			s.handlePartitionsRevoked(m)
-		}),
+		kgo.OnPartitionsAssigned(partitionLifecycler.Assign),
+		kgo.OnPartitionsRevoked(partitionLifecycler.Revoke),
 	)
 	if err != nil {
 		level.Error(logger).Log("msg", "failed to create consumer", "err", err)
 		return nil
 	}
+	s.consumerClient = consumerClient
+	// The consumer is what polls records from Kafka. It is responsible for
+	// fetching records for each assigned partition and passing them to their
+	// respective partition processor. We guarantee that the consumer will
+	// not fetch records for partitions before the lifecycler has registered
+	// its processor because [kgo.onPartitionsAssigned] guarantees this
+	// callback returns before the client starts polling records for any
+	// newly assigned partitions.
+	consumer := newConsumer(consumerClient.Client, logger)
+	processorLifecycler.AddListener(consumer)
 
-	eventsKafkaCfg := kafkaCfg
-	eventsKafkaCfg.Topic = "loki.metastore-events"
-	eventsKafkaCfg.AutoCreateTopicDefaultPartitions = 1
-	eventsProducerClient, err := client.NewWriterClient("loki.metastore-events", eventsKafkaCfg, 50, logger, reg)
-	if err != nil {
-		level.Error(logger).Log("msg", "failed to create producer", "err", err)
-		return nil
-	}
-	s.client = consumerClient
-	s.eventsProducerClient = eventsProducerClient
-
-	s.processorFactory = newPartitionProcessorFactory(
-		cfg, mCfg, consumerClient.Client, eventsProducerClient, bucket, scratchStore, logger, reg)
-
-	s.Service = services.NewBasicService(nil, s.run, s.stopping)
+	s.partitionLifecycler = partitionLifecycler
+	s.consumer = consumer
+	s.Service = services.NewBasicService(nil, s.running, s.stopping)
 	return s
 }
 
-func (s *Service) handlePartitionsAssigned(ctx context.Context, _ *kgo.Client, partitions map[string][]int32) {
-	level.Info(s.logger).Log("msg", "partitions assigned", "partitions", formatPartitionsMap(partitions))
-	s.partitionMtx.Lock()
-	defer s.partitionMtx.Unlock()
-
-	for topic, parts := range partitions {
-		tenant, virtualShard, err := s.codec.Decode(topic)
-		// TODO: should propage more effectively
-		if err != nil {
-			level.Error(s.logger).Log("msg", "failed to decode topic", "topic", topic, "err", err)
-			continue
-		}
-
-		if _, ok := s.partitionHandlers[topic]; !ok {
-			s.partitionHandlers[topic] = make(map[int32]*partitionProcessor)
-		}
-
-		for _, partition := range parts {
-			processor := s.processorFactory.New(ctx, tenant, virtualShard, topic, partition)
-			s.partitionHandlers[topic][partition] = processor
-			processor.start()
-		}
-	}
+// running implements the Service interface's running method.
+func (s *Service) running(ctx context.Context) error {
+	return s.consumer.Run(ctx)
 }
 
-func (s *Service) handlePartitionsRevoked(partitions map[string][]int32) {
-	level.Info(s.logger).Log("msg", "partitions revoked", "partitions", formatPartitionsMap(partitions))
-	if s.State() == services.Stopping {
-		// On shutdown, franz-go will send one more partitionRevoked event which we need to ignore to shutdown gracefully.
-		return
-	}
-	s.partitionMtx.Lock()
-	defer s.partitionMtx.Unlock()
-
-	var wg sync.WaitGroup
-	for topic, parts := range partitions {
-		if handlers, ok := s.partitionHandlers[topic]; ok {
-			for _, partition := range parts {
-				if processor, exists := handlers[partition]; exists {
-					wg.Add(1)
-					go func(p *partitionProcessor) {
-						defer wg.Done()
-						p.stop()
-					}(processor)
-					delete(handlers, partition)
-				}
-			}
-			if len(handlers) == 0 {
-				delete(s.partitionHandlers, topic)
-			}
-		}
-	}
-	wg.Wait()
-}
-
-func (s *Service) run(ctx context.Context) error {
-	for {
-		fetches := s.client.PollRecords(ctx, -1)
-		if fetches.IsClientClosed() || ctx.Err() != nil {
-			return nil
-		}
-		if errs := fetches.Errors(); len(errs) > 0 {
-			var multiErr error
-			for _, err := range errs {
-				multiErr = errors.Join(multiErr, err.Err)
-			}
-			level.Error(s.logger).Log("msg", "error fetching records", "err", multiErr.Error())
-			continue
-		}
-		if fetches.Empty() {
-			continue
-		}
-
-		fetches.EachPartition(func(ftp kgo.FetchTopicPartition) {
-			s.partitionMtx.RLock()
-			handlers, ok := s.partitionHandlers[ftp.Topic]
-			if !ok {
-				s.partitionMtx.RUnlock()
-				return
-			}
-			processor, ok := handlers[ftp.Partition]
-			s.partitionMtx.RUnlock()
-			if !ok {
-				return
-			}
-
-			// Collect all records for this partition
-			records := ftp.Records
-			if len(records) == 0 {
-				return
-			}
-
-			// Calculate total bytes in this batch
-			var totalBytes int64
-			for _, record := range records {
-				totalBytes += int64(len(record.Value))
-			}
-
-			// Update metrics
-			processor.metrics.addBytesProcessed(totalBytes)
-
-			_ = processor.Append(records)
-		})
-	}
-}
-
+// stopping implements the Service interface's stopping method.
 func (s *Service) stopping(failureCase error) error {
-	s.partitionMtx.Lock()
-	defer s.partitionMtx.Unlock()
-
-	var wg sync.WaitGroup
-	for _, handlers := range s.partitionHandlers {
-		for _, processor := range handlers {
-			wg.Add(1)
-			go func(p *partitionProcessor) {
-				defer wg.Done()
-				p.stop()
-			}(processor)
-		}
-	}
-	wg.Wait()
-	// Only close the client once all partitions have been stopped.
-	// This is to ensure that all records have been processed before closing and offsets committed.
-	s.client.Close()
-	level.Info(s.logger).Log("msg", "consumer stopped")
+	level.Info(s.logger).Log("msg", "stopping")
+	s.partitionLifecycler.Stop(context.TODO())
+	s.consumerClient.Close()
+	s.metastoreEvents.Close()
+	level.Info(s.logger).Log("msg", "stopped")
 	return failureCase
-}
-
-// Helper function to format []int32 slice
-func formatInt32Slice(slice []int32) string {
-	if len(slice) == 0 {
-		return "[]"
-	}
-	result := "["
-	for i, v := range slice {
-		if i > 0 {
-			result += ","
-		}
-		result += strconv.Itoa(int(v))
-	}
-	result += "]"
-	return result
-}
-
-// Helper function to format map[string][]int32 into a readable string
-func formatPartitionsMap(partitions map[string][]int32) string {
-	var result string
-	for topic, parts := range partitions {
-		if len(result) > 0 {
-			result += ", "
-		}
-		result += topic + "=" + formatInt32Slice(parts)
-	}
-	return result
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit fixes a deadlock that would occur when shutting down dataobj-consumers where the stopping() and OnPartitionsRevoked() callback in service.go would both content for the same mutex.

We fix the deadlock by abstracting the management of processors into a partition processor lifeycler, and the handling partition assignment and revocation into a partition lifecycler. Meanwhile, records are polled by a consumer, and then appended to the correct partition processor.

The shutdown mechanism works by first shutting down the consumer so no more records can be fetched. It then shutsdown the lifecycler, which prevents new processors from being created should there be a group rebalance while shutting down. Last it shuts down the consumer and metatstore events clients. This eliminates the need for a shared mutex.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
