### PR TITLE
fix: detect log level from structure metadata otlp field

### DIFF
--- a/pkg/distributor/field_detection.go
+++ b/pkg/distributor/field_detection.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/buger/jsonparser"
 	"github.com/prometheus/prometheus/model/labels"
-	"go.opentelemetry.io/collector/pdata/plog"
 
 	"github.com/grafana/loki/v3/pkg/loghttp/push"
 	"github.com/grafana/loki/v3/pkg/logproto"
@@ -153,19 +152,18 @@ func (l *FieldDetector) detectLogLevelFromLogEntry(entry logproto.Entry, structu
 		if err != nil {
 			return constants.LogLevelInfo
 		}
-		if otlpSeverityNumber == int(plog.SeverityNumberUnspecified) {
-			return constants.LogLevelUnknown
-		} else if otlpSeverityNumber <= int(plog.SeverityNumberTrace4) {
+
+		if otlpSeverityNumber >= 1 && otlpSeverityNumber <= 4 {
 			return constants.LogLevelTrace
-		} else if otlpSeverityNumber <= int(plog.SeverityNumberDebug4) {
+		} else if otlpSeverityNumber >= 5 && otlpSeverityNumber <= 8 {
 			return constants.LogLevelDebug
-		} else if otlpSeverityNumber <= int(plog.SeverityNumberInfo4) {
+		} else if otlpSeverityNumber >= 9 && otlpSeverityNumber <= 12 {
 			return constants.LogLevelInfo
-		} else if otlpSeverityNumber <= int(plog.SeverityNumberWarn4) {
+		} else if otlpSeverityNumber >= 13 && otlpSeverityNumber <= 16 {
 			return constants.LogLevelWarn
-		} else if otlpSeverityNumber <= int(plog.SeverityNumberError4) {
+		} else if otlpSeverityNumber >= 17 && otlpSeverityNumber <= 20 {
 			return constants.LogLevelError
-		} else if otlpSeverityNumber <= int(plog.SeverityNumberFatal4) {
+		} else if otlpSeverityNumber >= 21 && otlpSeverityNumber <= 24 {
 			return constants.LogLevelFatal
 		}
 		return constants.LogLevelUnknown


### PR DESCRIPTION
**What this PR does / why we need it**:

We are not covering all log levels values that are sent by otlp.
This is causing some logs to shown as unknown when should have the specific log level.

Here is the [documentation](https://opentelemetry.io/docs/specs/otel/logs/data-model/#field-severitynumber) about possible values.

Fixes: https://github.com/grafana/loki/issues/18937

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
