### PR TITLE
fix(ruler): Don't attempt to validate Ruler.StoreConfig while using R…

### DIFF
--- a/pkg/ruler/config.go
+++ b/pkg/ruler/config.go
@@ -36,10 +36,11 @@ func (c *Config) RegisterFlags(f *flag.FlagSet) {
 
 // Validate overrides the embedded cortex variant which expects a cortex limits struct. Instead, copy the relevant bits over.
 func (c *Config) Validate() error {
-	if err := c.StoreConfig.Validate(); err != nil {
-		return fmt.Errorf("invalid ruler store config: %w", err)
+	if c.StoreConfig.Type != "" {
+		if err := c.StoreConfig.Validate(); err != nil {
+			return fmt.Errorf("invalid ruler store config: %w", err)
+		}
 	}
-
 	if err := c.RemoteWrite.Validate(); err != nil {
 		return fmt.Errorf("invalid ruler remote-write config: %w", err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Ruler doesn't need to validate config for ruler.storage while it isn't being used.
While using conf ruler_storage instead of ruler.storage, can't start Ruler without config for ruler.storage, because of configvalidation.


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
