### PR TITLE
chore: Implement multi-tenancy for indexobj builders

### DIFF
--- a/pkg/dataobj/consumer/partition_processor.go
+++ b/pkg/dataobj/consumer/partition_processor.go
@@ -21,6 +21,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/dataobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/consumer/logsobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/metastore"
+	"github.com/grafana/loki/v3/pkg/dataobj/metastore/multitenancy"
 	"github.com/grafana/loki/v3/pkg/dataobj/uploader"
 	"github.com/grafana/loki/v3/pkg/kafka"
 	"github.com/grafana/loki/v3/pkg/logproto"
@@ -46,7 +47,7 @@ type producer interface {
 }
 
 type tocWriter interface {
-	WriteEntry(ctx context.Context, dataobjPath string, minTimestamp, maxTimestamp time.Time) error
+	WriteEntry(ctx context.Context, dataobjPath string, timeRanges multitenancy.TimeRangeSet) error
 }
 
 type partitionProcessor struct {
@@ -136,7 +137,7 @@ func newPartitionProcessor(
 		level.Error(logger).Log("msg", "failed to register uploader metrics", "err", err)
 	}
 
-	metastoreTocWriter := metastore.NewTableOfContentsWriter(metastoreCfg, bucket, tenantID, logger)
+	metastoreTocWriter := metastore.NewTableOfContentsWriter(metastoreCfg, bucket, logger)
 	if err := metastoreTocWriter.RegisterMetrics(reg); err != nil {
 		level.Error(logger).Log("msg", "failed to register metastore updater metrics", "err", err)
 	}
@@ -244,7 +245,6 @@ func (p *partitionProcessor) emitObjectWrittenEvent(objectPath string) error {
 
 	eventBytes, err := event.Marshal()
 	if err != nil {
-		level.Error(p.logger).Log("msg", "failed to marshal metastore event", "err", err)
 		return err
 	}
 
@@ -340,13 +340,19 @@ func (p *partitionProcessor) flush() error {
 		return err
 	}
 
-	if err := p.metastoreTocWriter.WriteEntry(p.ctx, objectPath, minTime, maxTime); err != nil {
+	// TODO(benclive): Remove this Update once the indexes are being built from the metastore events
+	if err := p.metastoreTocWriter.WriteEntry(p.ctx, objectPath, multitenancy.TimeRangeSet{
+		string(p.tenantID): multitenancy.TimeRange{
+			MinTime: minTime,
+			MaxTime: maxTime,
+		},
+	}); err != nil {
 		level.Error(p.logger).Log("msg", "failed to update metastore", "err", err)
 		return err
 	}
 
 	if err := p.emitObjectWrittenEvent(objectPath); err != nil {
-		level.Error(p.logger).Log("msg", "failed to emit event", "err", err)
+		level.Error(p.logger).Log("msg", "failed to emit metastore event", "err", err)
 		return err
 	}
 

--- a/pkg/dataobj/index/builder_test.go
+++ b/pkg/dataobj/index/builder_test.go
@@ -146,7 +146,6 @@ func readAllSectionPointers(t *testing.T, bucket objstore.Bucket, indexPrefix st
 
 	for _, directory := range directories {
 		err := bucket.Iter(context.Background(), directory, func(name string) error {
-
 			objReader, err := bucket.Get(context.Background(), name)
 			require.NoError(t, err)
 			defer objReader.Close()

--- a/pkg/dataobj/index/calculate_test.go
+++ b/pkg/dataobj/index/calculate_test.go
@@ -113,16 +113,16 @@ func TestCalculator_Calculate(t *testing.T) {
 		}
 
 		// Verify we can flush the results
-		minTime, maxTime := calculator.TimeRange()
+		timeRanges := calculator.TimeRanges()
 		obj, closer, err := calculator.Flush()
 		require.NoError(t, err)
 		defer closer.Close()
 
 		require.Greater(t, obj.Size(), int64(0))
-		require.False(t, minTime.IsZero())
-		require.Equal(t, minTime, time.Unix(10, 0).UTC())
-		require.False(t, maxTime.IsZero())
-		require.Equal(t, maxTime, time.Unix(25, 0).UTC())
+		require.False(t, timeRanges[""].MinTime.IsZero())
+		require.Equal(t, timeRanges[""].MinTime, time.Unix(10, 0).UTC())
+		require.False(t, timeRanges[""].MaxTime.IsZero())
+		require.Equal(t, timeRanges[""].MaxTime, time.Unix(25, 0).UTC())
 
 		// Confirm we have multiple pointers sections
 		count := obj.Sections().Count(pointers.CheckSection)

--- a/pkg/dataobj/index/indexobj/builder.go
+++ b/pkg/dataobj/index/indexobj/builder.go
@@ -185,6 +185,7 @@ func (b *Builder) AppendIndexPointer(tenantID string, path string, startTs time.
 	tenantIndexPointers, ok := b.indexPointers[tenantID]
 	if !ok {
 		tenantIndexPointers = indexpointers.NewBuilder(b.metrics.indexPointers, int(b.cfg.TargetPageSize))
+		tenantIndexPointers.SetTenant(tenantID)
 		b.indexPointers[tenantID] = tenantIndexPointers
 	}
 

--- a/pkg/dataobj/index/indexobj/builder.go
+++ b/pkg/dataobj/index/indexobj/builder.go
@@ -15,6 +15,7 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 
 	"github.com/grafana/loki/v3/pkg/dataobj"
+	"github.com/grafana/loki/v3/pkg/dataobj/metastore/multitenancy"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/indexpointers"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/pointers"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/streams"
@@ -118,10 +119,10 @@ type Builder struct {
 
 	currentSizeEstimate int
 
-	builder       *dataobj.Builder // Inner builder for accumulating sections.
-	streams       *streams.Builder
-	pointers      *pointers.Builder
-	indexPointers *indexpointers.Builder
+	builder       *dataobj.Builder                  // Inner builder for accumulating sections.
+	streams       map[string]*streams.Builder       // The key is the TenantID.
+	pointers      map[string]*pointers.Builder      // The key is the TenantID.
+	indexPointers map[string]*indexpointers.Builder // The key is the TenantID.
 
 	state builderState
 }
@@ -149,6 +150,7 @@ func NewBuilder(cfg BuilderConfig, scratchStore scratch.Store) (*Builder, error)
 		return nil, fmt.Errorf("failed to create LRU cache: %w", err)
 	}
 
+	// TODO: Add metrics for number of tenants in each object
 	metrics := newBuilderMetrics()
 	metrics.ObserveConfig(cfg)
 
@@ -159,9 +161,9 @@ func NewBuilder(cfg BuilderConfig, scratchStore scratch.Store) (*Builder, error)
 		labelCache: labelCache,
 
 		builder:       dataobj.NewBuilder(scratchStore),
-		streams:       streams.NewBuilder(metrics.streams, int(cfg.TargetPageSize)),
-		pointers:      pointers.NewBuilder(metrics.pointers, int(cfg.TargetPageSize)),
-		indexPointers: indexpointers.NewBuilder(metrics.indexPointers, int(cfg.TargetPageSize)),
+		streams:       make(map[string]*streams.Builder),
+		pointers:      make(map[string]*pointers.Builder),
+		indexPointers: make(map[string]*indexpointers.Builder),
 	}, nil
 }
 
@@ -169,7 +171,7 @@ func (b *Builder) GetEstimatedSize() int {
 	return b.currentSizeEstimate
 }
 
-func (b *Builder) AppendIndexPointer(path string, startTs time.Time, endTs time.Time) error {
+func (b *Builder) AppendIndexPointer(tenantID string, path string, startTs time.Time, endTs time.Time) error {
 	b.metrics.appendsTotal.Inc()
 	newEntrySize := len(path) + 1 + 1 // path, startTs, endTs
 
@@ -180,10 +182,16 @@ func (b *Builder) AppendIndexPointer(path string, startTs time.Time, endTs time.
 	timer := prometheus.NewTimer(b.metrics.appendTime)
 	defer timer.ObserveDuration()
 
-	b.indexPointers.Append(path, startTs, endTs)
+	tenantIndexPointers, ok := b.indexPointers[tenantID]
+	if !ok {
+		tenantIndexPointers = indexpointers.NewBuilder(b.metrics.indexPointers, int(b.cfg.TargetPageSize))
+		b.indexPointers[tenantID] = tenantIndexPointers
+	}
 
-	if b.indexPointers.EstimatedSize() > int(b.cfg.TargetSectionSize) {
-		if err := b.builder.Append(b.indexPointers); err != nil {
+	tenantIndexPointers.Append(path, startTs, endTs)
+
+	if tenantIndexPointers.EstimatedSize() > int(b.cfg.TargetSectionSize) {
+		if err := b.builder.Append(tenantIndexPointers); err != nil {
 			return err
 		}
 	}
@@ -195,7 +203,7 @@ func (b *Builder) AppendIndexPointer(path string, startTs time.Time, endTs time.
 }
 
 // AppendStream appends a stream to the object's stream section, returning the stream ID within this object.
-func (b *Builder) AppendStream(stream streams.Stream) (int64, error) {
+func (b *Builder) AppendStream(tenantID string, stream streams.Stream) (int64, error) {
 	b.metrics.appendsTotal.Inc()
 
 	newEntrySize := labelsEstimate(stream.Labels) + 2
@@ -207,15 +215,20 @@ func (b *Builder) AppendStream(stream streams.Stream) (int64, error) {
 	timer := prometheus.NewTimer(b.metrics.appendTime)
 	defer timer.ObserveDuration()
 
+	tenantStreams, ok := b.streams[tenantID]
+	if !ok {
+		tenantStreams = streams.NewBuilder(b.metrics.streams, int(b.cfg.TargetPageSize))
+		b.streams[tenantID] = tenantStreams
+	}
 	// Record the stream in the stream section.
 	// Once to capture the min timestamp and uncompressed size, again to record the max timestamp.
-	streamID := b.streams.Record(stream.Labels, stream.MinTimestamp, stream.UncompressedSize)
-	_ = b.streams.Record(stream.Labels, stream.MaxTimestamp, 0)
+	streamID := tenantStreams.Record(stream.Labels, stream.MinTimestamp, stream.UncompressedSize)
+	_ = tenantStreams.Record(stream.Labels, stream.MaxTimestamp, 0)
 
 	// If our logs section has gotten big enough, we want to flush it to the
 	// encoder and start a new section.
-	if b.pointers.EstimatedSize() > int(b.cfg.TargetSectionSize) {
-		if err := b.builder.Append(b.pointers); err != nil {
+	if tenantStreams.EstimatedSize() > int(b.cfg.TargetSectionSize) {
+		if err := b.builder.Append(tenantStreams); err != nil {
 			b.metrics.appendFailures.Inc()
 			return 0, err
 		}
@@ -250,7 +263,7 @@ func labelsEstimate(ls labels.Labels) int {
 //
 // Once a Builder is full, call [Builder.Flush] to flush the buffered data,
 // then call Append again with the same entry.
-func (b *Builder) ObserveLogLine(path string, section int64, streamIDInObject int64, streamIDInIndex int64, ts time.Time, uncompressedSize int64) error {
+func (b *Builder) ObserveLogLine(tenantID string, path string, section int64, streamIDInObject int64, streamIDInIndex int64, ts time.Time, uncompressedSize int64) error {
 	// Check whether the buffer is full before a stream can be appended; this is
 	// tends to overestimate, but we may still go over our target size.
 	//
@@ -267,12 +280,17 @@ func (b *Builder) ObserveLogLine(path string, section int64, streamIDInObject in
 	timer := prometheus.NewTimer(b.metrics.appendTime)
 	defer timer.ObserveDuration()
 
-	b.pointers.ObserveStream(path, section, streamIDInObject, streamIDInIndex, ts, uncompressedSize)
+	tenantPointers, ok := b.pointers[tenantID]
+	if !ok {
+		tenantPointers = pointers.NewBuilder(b.metrics.pointers, int(b.cfg.TargetPageSize))
+		b.pointers[tenantID] = tenantPointers
+	}
+	tenantPointers.ObserveStream(path, section, streamIDInObject, streamIDInIndex, ts, uncompressedSize)
 
 	// If our logs section has gotten big enough, we want to flush it to the
 	// encoder and start a new section.
-	if b.pointers.EstimatedSize() > int(b.cfg.TargetSectionSize) {
-		if err := b.builder.Append(b.pointers); err != nil {
+	if tenantPointers.EstimatedSize() > int(b.cfg.TargetSectionSize) {
+		if err := b.builder.Append(tenantPointers); err != nil {
 			return err
 		}
 	}
@@ -288,7 +306,7 @@ func (b *Builder) ObserveLogLine(path string, section int64, streamIDInObject in
 //
 // Once a Builder is full, call [Builder.Flush] to flush the buffered data,
 // then call Append again with the same entry.
-func (b *Builder) AppendColumnIndex(path string, section int64, columnName string, columnIndex int64, valuesBloom []byte) error {
+func (b *Builder) AppendColumnIndex(tenantID string, path string, section int64, columnName string, columnIndex int64, valuesBloom []byte) error {
 	// Check whether the buffer is full before a stream can be appended; this is
 	// tends to overestimate, but we may still go over our target size.
 	//
@@ -305,12 +323,17 @@ func (b *Builder) AppendColumnIndex(path string, section int64, columnName strin
 	timer := prometheus.NewTimer(b.metrics.appendTime)
 	defer timer.ObserveDuration()
 
-	b.pointers.RecordColumnIndex(path, section, columnName, columnIndex, valuesBloom)
+	tenantPointers, ok := b.pointers[tenantID]
+	if !ok {
+		tenantPointers = pointers.NewBuilder(b.metrics.pointers, int(b.cfg.TargetPageSize))
+		b.pointers[tenantID] = tenantPointers
+	}
+	tenantPointers.RecordColumnIndex(path, section, columnName, columnIndex, valuesBloom)
 
 	// If our logs section has gotten big enough, we want to flush it to the
 	// encoder and start a new section.
-	if b.pointers.EstimatedSize() > int(b.cfg.TargetSectionSize) {
-		if err := b.builder.Append(b.pointers); err != nil {
+	if tenantPointers.EstimatedSize() > int(b.cfg.TargetSectionSize) {
+		if err := b.builder.Append(tenantPointers); err != nil {
 			return err
 		}
 	}
@@ -322,24 +345,37 @@ func (b *Builder) AppendColumnIndex(path string, section int64, columnName strin
 
 func (b *Builder) estimatedSize() int {
 	var size int
-	size += b.streams.EstimatedSize()
-	size += b.pointers.EstimatedSize()
-	size += b.indexPointers.EstimatedSize()
+	for _, tenantStreams := range b.streams {
+		size += tenantStreams.EstimatedSize()
+	}
+	for _, tenantPointers := range b.pointers {
+		size += tenantPointers.EstimatedSize()
+	}
+	for _, tenantIndexPointers := range b.indexPointers {
+		size += tenantIndexPointers.EstimatedSize()
+	}
 	size += b.builder.Bytes()
 	b.metrics.sizeEstimate.Set(float64(size))
 	return size
 }
 
-// TimeRange returns the time range of the data in the builder.
-func (b *Builder) TimeRange() (minTime, maxTime time.Time) {
-	return b.streams.TimeRange()
+// TimeRanges returns the time range of the data in the builder, by tenant.
+func (b *Builder) TimeRanges() multitenancy.TimeRangeSet {
+	timeRanges := make(multitenancy.TimeRangeSet, len(b.streams))
+	for tenantID, tenantStreams := range b.streams {
+		minTime, maxTime := tenantStreams.TimeRange()
+		timeRanges[tenantID] = multitenancy.TimeRange{
+			MinTime: minTime,
+			MaxTime: maxTime,
+		}
+	}
+	return timeRanges
 }
 
 // Flush flushes all buffered data to the buffer provided. Calling Flush can result
 // in a no-op if there is no buffered data to flush.
 //
-// [Builder.Reset] is called after a successful Flush to discard any pending
-// data and allow new data to be appended.
+// [Builder.Reset] is called after a successful Flush to discard any pending data and allow new data to be appended.
 func (b *Builder) Flush() (*dataobj.Object, io.Closer, error) {
 	if b.state == builderStateEmpty {
 		return nil, nil, ErrBuilderEmpty
@@ -349,12 +385,17 @@ func (b *Builder) Flush() (*dataobj.Object, io.Closer, error) {
 	timer := prometheus.NewTimer(b.metrics.buildTime)
 	defer timer.ObserveDuration()
 
-	// Flush sections one more time in case they have data.
 	var flushErrors []error
 
-	flushErrors = append(flushErrors, b.builder.Append(b.streams))
-	flushErrors = append(flushErrors, b.builder.Append(b.pointers))
-	flushErrors = append(flushErrors, b.builder.Append(b.indexPointers))
+	for _, tenantStreams := range b.streams {
+		flushErrors = append(flushErrors, b.builder.Append(tenantStreams))
+	}
+	for _, tenantPointers := range b.pointers {
+		flushErrors = append(flushErrors, b.builder.Append(tenantPointers))
+	}
+	for _, tenantIndexPointers := range b.indexPointers {
+		flushErrors = append(flushErrors, b.builder.Append(tenantIndexPointers))
+	}
 
 	if err := errors.Join(flushErrors...); err != nil {
 		b.metrics.flushFailures.Inc()
@@ -364,10 +405,11 @@ func (b *Builder) Flush() (*dataobj.Object, io.Closer, error) {
 	obj, closer, err := b.builder.Flush()
 	if err != nil {
 		b.metrics.flushFailures.Inc()
-		return nil, nil, fmt.Errorf("building object: %w", err)
+		return nil, nil, fmt.Errorf("flushing object: %w", err)
 	}
 
 	b.metrics.builtSize.Observe(float64(obj.Size()))
+
 	err = b.observeObject(context.Background(), obj)
 
 	b.Reset()
@@ -411,9 +453,15 @@ func (b *Builder) observeObject(ctx context.Context, obj *dataobj.Object) error 
 // Reset discards pending data and resets the builder to an empty state.
 func (b *Builder) Reset() {
 	b.builder.Reset()
-	b.streams.Reset()
-	b.pointers.Reset()
-	b.indexPointers.Reset()
+	for _, tenantStreams := range b.streams {
+		tenantStreams.Reset()
+	}
+	for _, tenantPointers := range b.pointers {
+		tenantPointers.Reset()
+	}
+	for _, tenantIndexPointers := range b.indexPointers {
+		tenantIndexPointers.Reset()
+	}
 
 	b.metrics.sizeEstimate.Set(0)
 	b.currentSizeEstimate = 0

--- a/pkg/dataobj/index/indexobj/builder_test.go
+++ b/pkg/dataobj/index/indexobj/builder_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/loki/v3/pkg/dataobj/sections/indexpointers"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/logs"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/pointers"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/streams"
@@ -24,6 +25,8 @@ var testBuilderConfig = BuilderConfig{
 
 	SectionStripeMergeLimit: 2,
 }
+
+const testTenant = "test-tenant"
 
 func TestBuilder(t *testing.T) {
 	testStreams := []streams.Stream{
@@ -59,6 +62,13 @@ func TestBuilder(t *testing.T) {
 			ColumnIndex:       1,
 			ValuesBloomFilter: []byte{1, 2, 3},
 		},
+		{
+			Path:              "test/path2",
+			Section:           2,
+			ColumnName:        "bar2",
+			ColumnIndex:       2,
+			ValuesBloomFilter: []byte{1, 2, 3, 4},
+		},
 	}
 
 	t.Run("Build", func(t *testing.T) {
@@ -66,11 +76,11 @@ func TestBuilder(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, stream := range testStreams {
-			_, err := builder.AppendStream(stream)
+			_, err := builder.AppendStream(testTenant, stream)
 			require.NoError(t, err)
 		}
 		for _, pointer := range testPointers {
-			err := builder.AppendColumnIndex(pointer.Path, pointer.Section, pointer.ColumnName, pointer.ColumnIndex, pointer.ValuesBloomFilter)
+			err := builder.AppendColumnIndex(testTenant, pointer.Path, pointer.Section, pointer.ColumnName, pointer.ColumnIndex, pointer.ValuesBloomFilter)
 			require.NoError(t, err)
 		}
 
@@ -81,6 +91,34 @@ func TestBuilder(t *testing.T) {
 		require.Equal(t, 1, obj.Sections().Count(streams.CheckSection))
 		require.Equal(t, 1, obj.Sections().Count(pointers.CheckSection))
 		require.Equal(t, 0, obj.Sections().Count(logs.CheckSection))
+		require.Equal(t, 0, obj.Sections().Count(indexpointers.CheckSection))
+	})
+
+	t.Run("BuildMultiTenant", func(t *testing.T) {
+		builder, err := NewBuilder(testBuilderConfig, nil)
+		require.NoError(t, err)
+
+		tenants := []string{"test-tenant-1", "test-tenant-2"}
+
+		for i, stream := range testStreams {
+			tenant := tenants[i%len(tenants)]
+			_, err := builder.AppendStream(tenant, stream)
+			require.NoError(t, err)
+		}
+		for i, pointer := range testPointers {
+			tenant := tenants[i%len(tenants)]
+			err := builder.AppendColumnIndex(tenant, pointer.Path, pointer.Section, pointer.ColumnName, pointer.ColumnIndex, pointer.ValuesBloomFilter)
+			require.NoError(t, err)
+		}
+
+		obj, closer, err := builder.Flush()
+		require.NoError(t, err)
+		defer closer.Close()
+
+		require.Equal(t, len(tenants), obj.Sections().Count(streams.CheckSection))
+		require.Equal(t, len(tenants), obj.Sections().Count(pointers.CheckSection))
+		require.Equal(t, 0, obj.Sections().Count(logs.CheckSection))
+		require.Equal(t, 0, obj.Sections().Count(indexpointers.CheckSection))
 	})
 }
 
@@ -97,7 +135,7 @@ func TestBuilder_Append(t *testing.T) {
 	for {
 		require.NoError(t, ctx.Err())
 
-		_, err := builder.AppendStream(streams.Stream{
+		_, err := builder.AppendStream(testTenant, streams.Stream{
 			ID: 1,
 			Labels: labels.New(
 				labels.Label{Name: "cluster", Value: "test"},
@@ -127,7 +165,7 @@ func TestBuilder_AppendIndexPointer(t *testing.T) {
 	for {
 		require.NoError(t, ctx.Err())
 
-		err := builder.AppendIndexPointer(fmt.Sprintf("test/path-%d", i), time.Unix(10, 0).Add(time.Duration(i)*time.Second).UTC(), time.Unix(20, 0).Add(time.Duration(i)*time.Second).UTC())
+		err := builder.AppendIndexPointer(testTenant, fmt.Sprintf("test/path-%d", i), time.Unix(10, 0).Add(time.Duration(i)*time.Second).UTC(), time.Unix(20, 0).Add(time.Duration(i)*time.Second).UTC())
 		if errors.Is(err, ErrBuilderFull) {
 			break
 		}

--- a/pkg/dataobj/metastore/metrics.go
+++ b/pkg/dataobj/metastore/metrics.go
@@ -23,24 +23,24 @@ type tocMetrics struct {
 func newTableOfContentsMetrics() *tocMetrics {
 	metrics := &tocMetrics{
 		tocReplayTime: prometheus.NewHistogram(prometheus.HistogramOpts{
-			Name:                            "loki_dataobj_consumer_metastore_replay_seconds",
-			Help:                            "Time taken to replay existing metastore data into the in-memory builder in seconds",
+			Name:                            "loki_metastore_toc_replay_seconds",
+			Help:                            "Time taken to replay existing Table of Contents data into the new builder in seconds",
 			Buckets:                         prometheus.DefBuckets,
 			NativeHistogramBucketFactor:     1.1,
 			NativeHistogramMaxBucketNumber:  100,
 			NativeHistogramMinResetDuration: 0,
 		}),
 		tocEncodingTime: prometheus.NewHistogram(prometheus.HistogramOpts{
-			Name:                            "loki_dataobj_consumer_metastore_encoding_seconds",
-			Help:                            "Time taken to add the new metadata & encode the new metastore data object in seconds",
+			Name:                            "loki_metastore_toc_encoding_seconds",
+			Help:                            "Time taken to add the new entries & encode the a single Table of Contents metastore file in seconds",
 			Buckets:                         prometheus.DefBuckets,
 			NativeHistogramBucketFactor:     1.1,
 			NativeHistogramMaxBucketNumber:  100,
 			NativeHistogramMinResetDuration: 0,
 		}),
 		tocProcessingTime: prometheus.NewHistogram(prometheus.HistogramOpts{
-			Name:                            "loki_dataobj_consumer_metastore_processing_seconds",
-			Help:                            "Total time taken to update all metastores for a flushed dataobj in seconds",
+			Name:                            "loki_metastore_toc_processing_seconds",
+			Help:                            "Total time taken to update all Table of Contents files for a metastore WriteEntry operation in seconds",
 			Buckets:                         prometheus.DefBuckets,
 			NativeHistogramBucketFactor:     1.1,
 			NativeHistogramMaxBucketNumber:  100,
@@ -86,7 +86,7 @@ func (p *tocMetrics) unregister(reg prometheus.Registerer) {
 	}
 }
 
-func (p *tocMetrics) incMetastoreWrites(status status) {
+func (p *tocMetrics) incTableOfContentsWrites(status status) {
 	p.tocWriteFailures.WithLabelValues(string(status)).Inc()
 }
 

--- a/pkg/dataobj/metastore/multitenancy/timeranges.go
+++ b/pkg/dataobj/metastore/multitenancy/timeranges.go
@@ -1,0 +1,27 @@
+package multitenancy
+
+import (
+	"iter"
+	"time"
+)
+
+type TimeRange struct {
+	MinTime time.Time
+	MaxTime time.Time
+}
+
+type TimeRangesIterator interface {
+	Iter() iter.Seq2[string, TimeRange]
+}
+
+type TimeRangeSet map[string]TimeRange
+
+func (t TimeRangeSet) Iter() iter.Seq2[string, TimeRange] {
+	return func(yield func(tenant string, timeRange TimeRange) bool) {
+		for tenant, timeRange := range t {
+			if !yield(tenant, timeRange) {
+				return
+			}
+		}
+	}
+}

--- a/pkg/dataobj/metastore/object_test.go
+++ b/pkg/dataobj/metastore/object_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/grafana/loki/v3/pkg/dataobj/consumer/logsobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/index/indexobj"
+	"github.com/grafana/loki/v3/pkg/dataobj/metastore/multitenancy"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/streams"
 	"github.com/grafana/loki/v3/pkg/dataobj/uploader"
 	"github.com/grafana/loki/v3/pkg/logproto"
@@ -84,7 +85,12 @@ func (b *testDataBuilder) addStreamAndFlush(stream logproto.Stream) {
 	path, err := b.uploader.Upload(b.t.Context(), obj)
 	require.NoError(b.t, err)
 
-	err = b.meta.WriteEntry(context.Background(), path, minTime, maxTime)
+	err = b.meta.WriteEntry(context.Background(), path, multitenancy.TimeRangeSet{
+		tenantID: multitenancy.TimeRange{
+			MinTime: minTime,
+			MaxTime: maxTime,
+		},
+	})
 	require.NoError(b.t, err)
 }
 
@@ -246,6 +252,7 @@ func TestValuesEmptyMatcher(t *testing.T) {
 
 func TestSectionsForStreamMatchers(t *testing.T) {
 	ctx := user.InjectOrgID(context.Background(), tenantID)
+	testTenant := "test-tenant"
 
 	builder, err := indexobj.NewBuilder(indexobj.BuilderConfig{
 		TargetPageSize:          1024 * 1024,
@@ -260,7 +267,7 @@ func TestSectionsForStreamMatchers(t *testing.T) {
 		lbls, err := syntax.ParseLabels(ts.Labels)
 		require.NoError(t, err)
 
-		newIdx, err := builder.AppendStream(streams.Stream{
+		newIdx, err := builder.AppendStream(testTenant, streams.Stream{
 			ID:               int64(i),
 			Labels:           lbls,
 			MinTimestamp:     ts.Entries[0].Timestamp,
@@ -268,11 +275,11 @@ func TestSectionsForStreamMatchers(t *testing.T) {
 			UncompressedSize: 0,
 		})
 		require.NoError(t, err)
-		err = builder.ObserveLogLine("test-path", 0, newIdx, int64(i), ts.Entries[0].Timestamp, int64(len(ts.Entries[0].Line)))
+		err = builder.ObserveLogLine(testTenant, "test-path", 0, newIdx, int64(i), ts.Entries[0].Timestamp, int64(len(ts.Entries[0].Line)))
 		require.NoError(t, err)
 	}
 
-	minTime, maxTime := builder.TimeRange()
+	timeRanges := builder.TimeRanges()
 
 	obj, closer, err := builder.Flush()
 	require.NoError(t, err)
@@ -286,9 +293,14 @@ func TestSectionsForStreamMatchers(t *testing.T) {
 	path, err := uploader.Upload(context.Background(), obj)
 	require.NoError(t, err)
 
-	metastoreTocWriter := NewTableOfContentsWriter(Config{}, bucket, tenantID, log.NewNopLogger())
+	metastoreTocWriter := NewTableOfContentsWriter(Config{}, bucket, log.NewNopLogger())
 
-	err = metastoreTocWriter.WriteEntry(context.Background(), path, minTime, maxTime)
+	err = metastoreTocWriter.WriteEntry(context.Background(), path, multitenancy.TimeRangeSet{
+		tenantID: multitenancy.TimeRange{
+			MinTime: timeRanges[tenantID].MinTime,
+			MaxTime: timeRanges[tenantID].MaxTime,
+		},
+	})
 	require.NoError(t, err)
 
 	mstore := NewObjectMetastore(StorageConfig{}, bucket, log.NewNopLogger(), prometheus.NewPedanticRegistry())
@@ -368,7 +380,7 @@ func newTestDataBuilder(t *testing.T, tenantID string) *testDataBuilder {
 	logger := log.NewLogfmtLogger(os.Stdout)
 	logger = log.With(logger, "test", t.Name())
 
-	meta := NewTableOfContentsWriter(Config{}, bucket, tenantID, logger)
+	meta := NewTableOfContentsWriter(Config{}, bucket, logger)
 	require.NoError(t, meta.RegisterMetrics(prometheus.NewPedanticRegistry()))
 
 	uploader := uploader.New(uploader.Config{SHAPrefixSize: 2}, bucket, tenantID, logger)

--- a/pkg/dataobj/metastore/toc_writer.go
+++ b/pkg/dataobj/metastore/toc_writer.go
@@ -95,101 +95,89 @@ func (m *TableOfContentsWriter) WriteEntry(ctx context.Context, dataobjPath stri
 		return err
 	}
 
-	var globalMinTime, globalMaxTime time.Time
-	for _, timeRange := range tenantTimeRanges.Iter() {
-		if globalMinTime.IsZero() || timeRange.MinTime.Before(globalMinTime) {
-			globalMinTime = timeRange.MinTime
-		}
-		if globalMaxTime.IsZero() || timeRange.MaxTime.After(globalMaxTime) {
-			globalMaxTime = timeRange.MaxTime
-		}
-	}
-
 	// Work our way through the metastore objects window by window, updating & creating them as needed.
 	// Each one handles its own retries in order to keep making progress in the event of a failure.
-	for tocPath, tocTimeRange := range iterTableOfContentsPaths(globalMinTime, globalMaxTime, m.cfg.Storage.IndexStoragePrefix) {
-		m.backoff.Reset()
-		for m.backoff.Ongoing() {
-			err = m.bucket.GetAndReplace(ctx, tocPath, func(existing io.ReadCloser) (io.ReadCloser, error) {
-				if existing != nil {
-					defer existing.Close()
-				}
-
-				m.buf.Reset()
-				m.tocBuilder.Reset()
-
-				if existing != nil {
-					_, err := io.Copy(m.buf, existing)
-					if err != nil {
-						return nil, errors.Wrap(err, "copying to local buffer")
+	for tenantID, timeRange := range tenantTimeRanges.Iter() {
+		for tocPath := range iterTableOfContentsPaths(tenantID, timeRange.MinTime, timeRange.MaxTime, m.cfg.Storage.IndexStoragePrefix) {
+			m.backoff.Reset()
+			for m.backoff.Ongoing() {
+				err = m.bucket.GetAndReplace(ctx, tocPath, func(existing io.ReadCloser) (io.ReadCloser, error) {
+					if existing != nil {
+						defer existing.Close()
 					}
-				}
 
-				if m.buf.Len() > 0 {
-					replayDuration := prometheus.NewTimer(m.metrics.tocReplayTime)
-					object, err := dataobj.FromReaderAt(bytes.NewReader(m.buf.Bytes()), int64(m.buf.Len()))
-					if err != nil {
-						return nil, errors.Wrap(err, "creating object from buffer")
-					}
-					err = m.copyFromExistingToc(ctx, object)
-					if err != nil {
-						return nil, errors.Wrap(err, "reading existing metastore version")
-					}
-					replayDuration.ObserveDuration()
-				}
+					m.buf.Reset()
+					m.tocBuilder.Reset()
 
-				encodingDuration := prometheus.NewTimer(m.metrics.tocEncodingTime)
-				// Append all the tenant time ranges that overlap with the current Table of Contents window.
-				for tenantID, timeRange := range tenantTimeRanges.Iter() {
-					if timeRange.MinTime.Before(tocTimeRange.MaxTime) && timeRange.MaxTime.After(tocTimeRange.MinTime) {
-						err := m.tocBuilder.AppendIndexPointer(tenantID, dataobjPath, timeRange.MinTime, timeRange.MaxTime)
+					if existing != nil {
+						_, err := io.Copy(m.buf, existing)
 						if err != nil {
-							return nil, errors.Wrap(err, "appending index pointer")
+							return nil, errors.Wrap(err, "copying to local buffer")
 						}
 					}
+
+					if m.buf.Len() > 0 {
+						replayDuration := prometheus.NewTimer(m.metrics.tocReplayTime)
+						object, err := dataobj.FromReaderAt(bytes.NewReader(m.buf.Bytes()), int64(m.buf.Len()))
+						if err != nil {
+							return nil, errors.Wrap(err, "creating object from buffer")
+						}
+						err = m.copyFromExistingToc(ctx, object)
+						if err != nil {
+							return nil, errors.Wrap(err, "reading existing metastore version")
+						}
+						replayDuration.ObserveDuration()
+					}
+
+					encodingDuration := prometheus.NewTimer(m.metrics.tocEncodingTime)
+					// Append all the tenant time ranges that overlap with the current Table of Contents window.
+					err := m.tocBuilder.AppendIndexPointer(tenantID, dataobjPath, timeRange.MinTime, timeRange.MaxTime)
+					if err != nil {
+						return nil, errors.Wrap(err, "appending index pointer")
+					}
+
+					var (
+						obj    *dataobj.Object
+						closer io.Closer
+					)
+
+					obj, closer, err = m.tocBuilder.Flush()
+					if err != nil {
+						return nil, errors.Wrap(err, "flushing metastore builder")
+					}
+
+					reader, err := obj.Reader(ctx)
+					if err != nil {
+						_ = closer.Close()
+						return nil, err
+					}
+
+					encodingDuration.ObserveDuration()
+					return &wrappedReadCloser{
+						rc: reader,
+						OnClose: func() error {
+							// We must close our object reader before closing the object
+							// itself.
+							var errs []error
+							errs = append(errs, reader.Close())
+							errs = append(errs, closer.Close())
+							return stderrors.Join(errs...)
+						},
+					}, nil
+				})
+				if err == nil {
+					level.Info(m.logger).Log("msg", "successfully merged & updated metastore", "metastore", tocPath)
+					m.metrics.incTableOfContentsWrites(statusSuccess)
+					break
 				}
-
-				var (
-					obj    *dataobj.Object
-					closer io.Closer
-				)
-
-				obj, closer, err = m.tocBuilder.Flush()
-				if err != nil {
-					return nil, errors.Wrap(err, "flushing metastore builder")
-				}
-
-				reader, err := obj.Reader(ctx)
-				if err != nil {
-					_ = closer.Close()
-					return nil, err
-				}
-
-				encodingDuration.ObserveDuration()
-				return &wrappedReadCloser{
-					rc: reader,
-					OnClose: func() error {
-						// We must close our object reader before closing the object
-						// itself.
-						var errs []error
-						errs = append(errs, reader.Close())
-						errs = append(errs, closer.Close())
-						return stderrors.Join(errs...)
-					},
-				}, nil
-			})
-			if err == nil {
-				level.Info(m.logger).Log("msg", "successfully merged & updated metastore", "metastore", tocPath)
-				m.metrics.incTableOfContentsWrites(statusSuccess)
-				break
+				level.Error(m.logger).Log("msg", "failed to get and replace metastore object", "err", err, "metastore", tocPath)
+				m.metrics.incTableOfContentsWrites(statusFailure)
+				m.backoff.Wait()
 			}
-			level.Error(m.logger).Log("msg", "failed to get and replace metastore object", "err", err, "metastore", tocPath)
-			m.metrics.incTableOfContentsWrites(statusFailure)
-			m.backoff.Wait()
-		}
 
-		// Reset at the end too so we don't leave our memory hanging around between calls.
-		m.tocBuilder.Reset()
+			// Reset at the end too so we don't leave our memory hanging around between calls.
+			m.tocBuilder.Reset()
+		}
 	}
 	return err
 }

--- a/pkg/dataobj/metastore/toc_writer_test.go
+++ b/pkg/dataobj/metastore/toc_writer_test.go
@@ -73,7 +73,7 @@ func TestTableOfContentsWriter(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		reader, err := bucket.Get(context.Background(), tableOfContentsPath(unixTime(0), ""))
+		reader, err := bucket.Get(context.Background(), tableOfContentsPath(tenantID, unixTime(0), ""))
 		require.NoError(t, err)
 
 		object, err := io.ReadAll(reader)
@@ -114,7 +114,7 @@ func newInMemoryBucket(t *testing.T, tenantID string, window time.Time, obj *dat
 
 	var (
 		bucket = objstore.NewInMemBucket()
-		path   = tableOfContentsPath(window, "")
+		path   = tableOfContentsPath(tenantID, window, "")
 	)
 
 	if obj != nil && obj.Size() > 0 {

--- a/pkg/dataobj/querier/store_test.go
+++ b/pkg/dataobj/querier/store_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/grafana/loki/v3/pkg/dataobj/consumer/logsobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/metastore"
+	"github.com/grafana/loki/v3/pkg/dataobj/metastore/multitenancy"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/logs"
 	"github.com/grafana/loki/v3/pkg/dataobj/uploader"
 	"github.com/grafana/loki/v3/pkg/iter"
@@ -475,7 +476,7 @@ func newTestDataBuilder(t *testing.T, tenantID string) *testDataBuilder {
 	}, nil)
 	require.NoError(t, err)
 
-	meta := metastore.NewTableOfContentsWriter(metastore.Config{}, bucket, tenantID, log.NewNopLogger())
+	meta := metastore.NewTableOfContentsWriter(metastore.Config{}, bucket, log.NewNopLogger())
 	require.NoError(t, meta.RegisterMetrics(prometheus.NewRegistry()))
 
 	uploader := uploader.New(uploader.Config{SHAPrefixSize: 2}, bucket, tenantID, log.NewNopLogger())
@@ -511,7 +512,12 @@ func (b *testDataBuilder) flush() {
 	require.NoError(b.t, err)
 
 	// Update metastore with the new data object
-	err = b.meta.WriteEntry(context.Background(), path, minTime, maxTime)
+	err = b.meta.WriteEntry(context.Background(), path, multitenancy.TimeRangeSet{
+		b.tenantID: multitenancy.TimeRange{
+			MinTime: minTime,
+			MaxTime: maxTime,
+		},
+	})
 	require.NoError(b.t, err)
 
 	b.builder.Reset()

--- a/pkg/logql/bench/store_dataobj.go
+++ b/pkg/logql/bench/store_dataobj.go
@@ -193,7 +193,7 @@ func (s *DataObjStore) buildIndex() error {
 		}
 		defer closer.Close()
 
-		key, err := index.ObjectKey(context.Background(), obj)
+		key, err := index.ObjectKey(context.Background(), s.tenantID, obj)
 		if err != nil {
 			return fmt.Errorf("failed to create object key: %w", err)
 		}

--- a/pkg/logql/bench/store_dataobj.go
+++ b/pkg/logql/bench/store_dataobj.go
@@ -20,6 +20,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/dataobj/index"
 	"github.com/grafana/loki/v3/pkg/dataobj/index/indexobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/metastore"
+	"github.com/grafana/loki/v3/pkg/dataobj/metastore/multitenancy"
 	"github.com/grafana/loki/v3/pkg/dataobj/querier"
 	"github.com/grafana/loki/v3/pkg/dataobj/uploader"
 	"github.com/grafana/loki/v3/pkg/logproto"
@@ -87,12 +88,12 @@ func NewDataObjStore(dir, tenantID string) (*DataObjStore, error) {
 	}
 
 	logger := level.NewFilter(log.NewLogfmtLogger(os.Stdout), level.AllowWarn())
-	logsMetastoreToc := metastore.NewTableOfContentsWriter(metastore.Config{}, bucket, tenantID, logger)
+	logsMetastoreToc := metastore.NewTableOfContentsWriter(metastore.Config{}, bucket, logger)
 	uploader := uploader.New(uploader.Config{SHAPrefixSize: 2}, bucket, tenantID, logger)
 
 	// Create prefixed bucket & metastore for indexes
 	indexWriterBucket := objstore.NewPrefixedBucket(bucket, indexDirPrefix)
-	indexMetastoreToc := metastore.NewTableOfContentsWriter(metastore.Config{}, indexWriterBucket, tenantID, logger)
+	indexMetastoreToc := metastore.NewTableOfContentsWriter(metastore.Config{}, indexWriterBucket, logger)
 
 	return &DataObjStore{
 		dir:               storeDir,
@@ -149,7 +150,12 @@ func (s *DataObjStore) flush() error {
 	}
 
 	// Update logs metastore's table of contents with the new data object
-	err = s.logsMetastoreToc.WriteEntry(context.Background(), path, minTime, maxTime)
+	err = s.logsMetastoreToc.WriteEntry(context.Background(), path, multitenancy.TimeRangeSet{
+		s.tenantID: multitenancy.TimeRange{
+			MinTime: minTime,
+			MaxTime: maxTime,
+		},
+	})
 	if err != nil {
 		return fmt.Errorf("failed to update metastore: %w", err)
 	}
@@ -180,14 +186,14 @@ func (s *DataObjStore) Close() error {
 
 func (s *DataObjStore) buildIndex() error {
 	flushAndUpload := func(calculator *index.Calculator) error {
-		minTime, maxTime := calculator.TimeRange()
+		timeRanges := calculator.TimeRanges()
 		obj, closer, err := calculator.Flush()
 		if err != nil {
 			return fmt.Errorf("failed to flush index: %w", err)
 		}
 		defer closer.Close()
 
-		key, err := index.ObjectKey(context.Background(), s.tenantID, obj)
+		key, err := index.ObjectKey(context.Background(), obj)
 		if err != nil {
 			return fmt.Errorf("failed to create object key: %w", err)
 		}
@@ -203,7 +209,7 @@ func (s *DataObjStore) buildIndex() error {
 			return fmt.Errorf("failed to upload index: %w", err)
 		}
 
-		err = s.indexMetastoreToc.WriteEntry(context.Background(), key, minTime, maxTime)
+		err = s.indexMetastoreToc.WriteEntry(context.Background(), key, timeRanges)
 		if err != nil {
 			return fmt.Errorf("failed to update metastore: %w", err)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
Converts the indexobj builder to support multi-tenancy
* This means it adds support for both the Table of Contents metastore files and the index metastore files, as they share the same builder at the moment.
* I haven't updated the calculator code yet, so the objects only contain a single tenant, even if they support more than one.
* I split this from a bigger PR so I can follow up with one which just edits the calculator code. That should make them both slightly simpler to review.

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/loki-private/issues/1769