### PR TITLE
fix: Fix container variable selection in Loki/Logs rx panel

### DIFF
--- a/production/loki-mixin-compiled-ssd/dashboards/loki-logs.json
+++ b/production/loki-mixin-compiled-ssd/dashboards/loki-logs.json
@@ -514,7 +514,7 @@
             "steppedLine": false,
             "targets": [
                {
-                  "expr": "sum by (pod)(rate(container_network_receive_bytes_total{cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval]))",
+                  "expr": "sum by (pod)(rate(container_network_receive_bytes_total{cluster=\"$cluster\", namespace=\"$namespace\", container=~\"$container\"}[$__rate_interval]))",
                   "refId": "A"
                }
             ],

--- a/production/loki-mixin-compiled/dashboards/loki-logs.json
+++ b/production/loki-mixin-compiled/dashboards/loki-logs.json
@@ -514,7 +514,7 @@
             "steppedLine": false,
             "targets": [
                {
-                  "expr": "sum by (pod)(rate(container_network_receive_bytes_total{cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval]))",
+                  "expr": "sum by (pod)(rate(container_network_receive_bytes_total{cluster=\"$cluster\", namespace=\"$namespace\", container=~\"$container\"}[$__rate_interval]))",
                   "refId": "A"
                }
             ],

--- a/production/loki-mixin/dashboards/dashboard-loki-logs.json
+++ b/production/loki-mixin/dashboards/dashboard-loki-logs.json
@@ -516,7 +516,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by (pod)(rate(container_network_receive_bytes_total{cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval]))",
+          "expr": "sum by (pod)(rate(container_network_receive_bytes_total{cluster=\"$cluster\", namespace=\"$namespace\", container=~\"$container\"}[$__rate_interval]))",
           "refId": "A"
         }
       ],


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix container variable selection in Loki/Logs rx panel

**Which issue(s) this PR fixes**:
Fixes #18952 

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
