### PR TITLE
docs: fixing link to Helm docs

### DIFF
--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -18,11 +18,11 @@ Helm chart for Grafana Loki and Grafana Enterprise Logs supporting monolithic, s
 | https://grafana.github.io/helm-charts | grafana-agent-operator(grafana-agent-operator) | 0.5.1 |
 | https://grafana.github.io/helm-charts | rollout_operator(rollout-operator) | 0.30.0 |
 
-Find more information in the Loki Helm Chart [documentation](https://grafana.com/docs/loki/next/installation/helm).
+Find more information in the Loki Helm Chart [documentation](https://grafana.com/docs/loki/latest/setup/install/helm/).
 
 ## Contributing
 
-Please see our [Contributing Guidelines](./CONTRIBUTING.md) for detailed information about contributing to the Loki Helm Chart.
+Please see our [Helm Contributing Guidelines](./CONTRIBUTING.md) for detailed information about contributing to the Loki Helm Chart.
 
 ## Releases
 

--- a/production/helm/loki/README.md.gotmpl
+++ b/production/helm/loki/README.md.gotmpl
@@ -8,11 +8,11 @@
 
 {{ template "chart.requirementsSection" . }}
 
-Find more information in the Loki Helm Chart [documentation](https://grafana.com/docs/loki/next/installation/helm).
+Find more information in the Loki Helm Chart [documentation](https://grafana.com/docs/loki/latest/setup/install/helm/).
 
 ## Contributing
 
-Please see our [Contributing Guidelines](./CONTRIBUTING.md) for detailed information about contributing to the Loki Helm Chart.
+Please see our [Helm Contributing Guidelines](./CONTRIBUTING.md) for detailed information about contributing to the Loki Helm Chart.
 
 ## Releases
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixing the link to the Helm documentation in the README.