### PR TITLE
feat: per policy overridable stream limits

### DIFF
--- a/pkg/ingester/flush_test.go
+++ b/pkg/ingester/flush_test.go
@@ -290,7 +290,7 @@ func Test_flush_not_owned_stream(t *testing.T) {
 	require.True(t, found)
 	fingerprint := instance.getHashForLabels(labels.FromStrings("app", "l"))
 	require.Equal(t, model.Fingerprint(16794418009594958), fingerprint)
-	instance.ownedStreamsSvc.trackStreamOwnership(fingerprint, false)
+	instance.ownedStreamsSvc.trackStreamOwnership(fingerprint, false, noPolicy)
 
 	time.Sleep(2 * cfg.FlushCheckPeriod)
 

--- a/pkg/ingester/instance.go
+++ b/pkg/ingester/instance.go
@@ -457,9 +457,7 @@ func (i *instance) removeStream(s *stream) {
 		memoryStreams.WithLabelValues(i.instanceID).Dec()
 		memoryStreamsLabelsBytes.Sub(float64(len(s.labels.String())))
 		streamsCountStats.Add(-1)
-
-		// TODO: We should also remove it from the policy stream counts
-		i.ownedStreamsSvc.trackRemovedStream(s.fp, noPolicy)
+		i.ownedStreamsSvc.trackRemovedStream(s.fp, s.policy)
 	}
 }
 

--- a/pkg/ingester/instance.go
+++ b/pkg/ingester/instance.go
@@ -301,9 +301,6 @@ func (i *instance) createStream(ctx context.Context, pushReqStream logproto.Stre
 	retentionHours := util.RetentionHours(i.tenantsRetention.RetentionPeriodFor(i.instanceID, labels))
 	mapping := i.limiter.limits.PoliciesStreamMapping(i.instanceID)
 	policies := mapping.PolicyFor(labels)
-	if record != nil {
-		err = i.streamCountLimiter.AssertNewStreamAllowed(i.instanceID)
-	}
 
 	// NOTE: We previously resolved the policy on distributors and logged when multiple policies were matched.
 	// As on distributors, we use the first policy by alphabetical order.
@@ -319,6 +316,10 @@ func (i *instance) createStream(ctx context.Context, pushReqStream logproto.Stre
 				"policies", strings.Join(policies, ","),
 			)
 		}
+	}
+
+	if record != nil {
+		err = i.streamCountLimiter.AssertNewStreamAllowed(i.instanceID, policy)
 	}
 
 	if err != nil {

--- a/pkg/ingester/instance_test.go
+++ b/pkg/ingester/instance_test.go
@@ -322,7 +322,7 @@ func setupTestStreams(t *testing.T) (*instance, time.Time, int) {
 		require.NoError(t, err)
 		chunkfmt, headfmt, err := instance.chunkFormatAt(minTs(&testStream))
 		require.NoError(t, err)
-		chunk := newStream(chunkfmt, headfmt, cfg, limiter.rateLimitStrategy, "fake", 0, labels.EmptyLabels(), true, NewStreamRateCalculator(), NilMetrics, nil, nil, retentionHours).NewChunk()
+		chunk := newStream(chunkfmt, headfmt, cfg, limiter.rateLimitStrategy, "fake", 0, labels.EmptyLabels(), true, NewStreamRateCalculator(), NilMetrics, nil, nil, retentionHours, stream.policy).NewChunk()
 		for _, entry := range testStream.Entries {
 			dup, err := chunk.Append(&entry)
 			require.False(t, dup)
@@ -581,10 +581,11 @@ func Benchmark_instance_addNewTailer(b *testing.B) {
 	chunkfmt, headfmt, err := inst.chunkFormatAt(model.Now())
 	require.NoError(b, err)
 	retentionHours := util.RetentionHours(tenantsRetention.RetentionPeriodFor("test", lbs))
+	policy := inst.resolvePolicyForStream(lbs)
 
 	b.Run("addTailersToNewStream", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			inst.addTailersToNewStream(newStream(chunkfmt, headfmt, nil, limiter.rateLimitStrategy, "fake", 0, lbs, true, NewStreamRateCalculator(), NilMetrics, nil, nil, retentionHours))
+			inst.addTailersToNewStream(newStream(chunkfmt, headfmt, nil, limiter.rateLimitStrategy, "fake", 0, lbs, true, NewStreamRateCalculator(), NilMetrics, nil, nil, retentionHours, policy))
 		}
 	})
 }

--- a/pkg/ingester/limiter_test.go
+++ b/pkg/ingester/limiter_test.go
@@ -138,7 +138,7 @@ func TestStreamCountLimiter_AssertNewStreamAllowed(t *testing.T) {
 				return testData.streams
 			}
 			streamCountLimiter := newStreamCountLimiter("test", defaultCountSupplier, limiter, ownedStreamSvc)
-			actual := streamCountLimiter.AssertNewStreamAllowed("test", "")
+			actual := streamCountLimiter.AssertNewStreamAllowed("test", noPolicy)
 
 			assert.Equal(t, testData.expected, actual)
 		})
@@ -369,62 +369,8 @@ func TestConvertGlobalToLocalLimit_PartitionRing(t *testing.T) {
 	}
 }
 
-func TestLimiter_GetStreamCountLimit(t *testing.T) {
-	// Create a mock limits implementation
-	mockLimits := &mockLimits{
-		maxLocalStreams:  100,
-		maxGlobalStreams: 1000,
-		policyLimits: map[string]struct {
-			local  int
-			global int
-		}{
-			"finance": {local: 50, global: 500},
-			"ops":     {local: 25, global: 250},
-		},
-	}
-
-	// Create a simple ring strategy for testing
-	ringStrategy := &mockRingStrategy{
-		healthyInstances:  2,
-		replicationFactor: 1,
-	}
-
-	limiter := &Limiter{
-		limits:       mockLimits,
-		ringStrategy: ringStrategy,
-	}
-
-	// Test with no policy - should use original method
-	calculated, local, global, adjusted := limiter.GetStreamCountLimit("tenant1", noPolicy)
-	require.Equal(t, 100, local)
-	require.Equal(t, 1000, global)
-	require.Equal(t, 500, adjusted)   // 1000 / 2 * 1
-	require.Equal(t, 100, calculated) // min(100, 500)
-
-	// Test with finance policy - should use policy-specific limits
-	calculated, local, global, adjusted = limiter.GetStreamCountLimit("tenant1", "finance")
-	require.Equal(t, 50, local)
-	require.Equal(t, 500, global)
-	require.Equal(t, 250, adjusted)  // 500 / 2 * 1
-	require.Equal(t, 50, calculated) // min(50, 250)
-
-	// Test with ops policy - should use policy-specific limits
-	calculated, local, global, adjusted = limiter.GetStreamCountLimit("tenant1", "ops")
-	require.Equal(t, 25, local)
-	require.Equal(t, 250, global)
-	require.Equal(t, 125, adjusted)  // 250 / 2 * 1
-	require.Equal(t, 25, calculated) // min(25, 125)
-
-	// Test with non-existent policy - should use original limits
-	calculated, local, global, adjusted = limiter.GetStreamCountLimit("tenant1", "nonexistent")
-	require.Equal(t, 100, local)
-	require.Equal(t, 1000, global)
-	require.Equal(t, 500, adjusted)   // 1000 / 2 * 1
-	require.Equal(t, 100, calculated) // min(100, 500)
-}
-
-func TestStreamCountLimiter_PolicyLimitsTakePrecedence(t *testing.T) {
-	// Create a mock limits implementation
+func TestLimiter_PolicyLimitsAndPrecedence(t *testing.T) {
+	// Create a comprehensive mock limits implementation
 	mockLimits := &mockLimits{
 		maxLocalStreams:  200,
 		maxGlobalStreams: 2000,
@@ -433,6 +379,7 @@ func TestStreamCountLimiter_PolicyLimitsTakePrecedence(t *testing.T) {
 			global int
 		}{
 			"finance": {local: 100, global: 1000},
+			"ops":     {local: 50, global: 500},
 		},
 	}
 
@@ -447,33 +394,66 @@ func TestStreamCountLimiter_PolicyLimitsTakePrecedence(t *testing.T) {
 		ringStrategy: ringStrategy,
 	}
 
-	// Create a stream count limiter with a fixed limit supplier that returns 150
-	fixedLimitSupplier := func() int { return 150 }
-	streamCountLimiter := &streamCountLimiter{
-		limiter: limiter,
-	}
+	// Test 1: Limit calculation accuracy for different policies
+	t.Run("limit_calculation", func(t *testing.T) {
+		// Test with no policy - should use default limits
+		calculated, local, global, adjusted := limiter.GetStreamCountLimit("tenant1", noPolicy)
+		require.Equal(t, 200, local, "No policy should use default local limit")
+		require.Equal(t, 2000, global, "No policy should use default global limit")
+		require.Equal(t, 1000, adjusted, "Adjusted global limit should be 2000/2*1 = 1000")
+		require.Equal(t, 200, calculated, "Calculated limit should be min(200, 1000) = 200")
 
-	// Test 1: No policy specified - fixed limit should be applied
-	// No-policy limit: min(200, 2000/2) = min(200, 1000) = 200
-	// Fixed limit: 150
-	// Expected: 200 (the higher of the two)
-	calculated, _, _, _ := streamCountLimiter.getCurrentLimit("tenant1", noPolicy, fixedLimitSupplier)
-	require.Equal(t, 200, calculated, "Without policy, should use the higher of calculated and fixed limits")
+		// Test with finance policy - should use policy-specific limits
+		calculated, local, global, adjusted = limiter.GetStreamCountLimit("tenant1", "finance")
+		require.Equal(t, 100, local, "Finance policy should use policy local limit")
+		require.Equal(t, 1000, global, "Finance policy should use policy global limit")
+		require.Equal(t, 500, adjusted, "Adjusted global limit should be 1000/2*1 = 500")
+		require.Equal(t, 100, calculated, "Calculated limit should be min(100, 500) = 100")
 
-	// Test 2: Policy specified - policy limit should take precedence over fixed limit
-	// Policy limit: min(100, 1000/2) = min(100, 500) = 100
-	// Fixed limit: 150 (should be ignored when policy is specified)
-	// Expected: 100 (policy limit takes precedence)
-	calculated, _, _, _ = streamCountLimiter.getCurrentLimit("tenant1", "finance", fixedLimitSupplier)
-	require.Equal(t, 100, calculated, "With policy, policy limit should take precedence over fixed limit")
+		// Test with ops policy - should use policy-specific limits
+		calculated, local, global, adjusted = limiter.GetStreamCountLimit("tenant1", "ops")
+		require.Equal(t, 50, local, "Ops policy should use policy local limit")
+		require.Equal(t, 500, global, "Ops policy should use policy global limit")
+		require.Equal(t, 250, adjusted, "Adjusted global limit should be 500/2*1 = 250")
+		require.Equal(t, 50, calculated, "Calculated limit should be min(50, 250) = 50")
 
-	// Test 3: Verify that policy limits are actually being enforced
-	// This ensures the policy override is working correctly
-	calculated, local, global, adjusted := streamCountLimiter.getCurrentLimit("tenant1", "finance", fixedLimitSupplier)
-	require.Equal(t, 100, local, "Policy local limit should be 100")
-	require.Equal(t, 1000, global, "Policy global limit should be 1000")
-	require.Equal(t, 500, adjusted, "Policy adjusted global limit should be 500")
-	require.Equal(t, 100, calculated, "Policy calculated limit should be 100")
+		// Test with non-existent policy - should fall back to default limits
+		calculated, local, global, adjusted = limiter.GetStreamCountLimit("tenant1", "nonexistent")
+		require.Equal(t, 200, local, "Non-existent policy should use default local limit")
+		require.Equal(t, 2000, global, "Non-existent policy should use default global limit")
+		require.Equal(t, 1000, adjusted, "Adjusted global limit should be 2000/2*1 = 1000")
+		require.Equal(t, 200, calculated, "Calculated limit should be min(200, 1000) = 200")
+	})
+
+	// Test 2: Policy precedence over fixed limits
+	t.Run("policy_precedence", func(t *testing.T) {
+		// Create a stream count limiter with a fixed limit supplier that returns 150
+		fixedLimitSupplier := func() int { return 150 }
+		streamCountLimiter := &streamCountLimiter{
+			limiter: limiter,
+		}
+
+		// Test: No policy specified - fixed limit should be applied
+		// No-policy limit: min(200, 2000/2) = min(200, 1000) = 200
+		// Fixed limit: 150
+		// Expected: 200 (the higher of the two)
+		calculated, _, _, _ := streamCountLimiter.getCurrentLimit("tenant1", noPolicy, fixedLimitSupplier)
+		require.Equal(t, 200, calculated, "Without policy, should use the higher of calculated and fixed limits")
+
+		// Test: Policy specified - policy limit should take precedence over fixed limit
+		// Policy limit: min(100, 1000/2) = min(100, 500) = 100
+		// Fixed limit: 150 (should be ignored when policy is specified)
+		// Expected: 100 (policy limit takes precedence)
+		calculated, _, _, _ = streamCountLimiter.getCurrentLimit("tenant1", "finance", fixedLimitSupplier)
+		require.Equal(t, 100, calculated, "With policy, policy limit should take precedence over fixed limit")
+
+		// Test: Verify that policy limits are actually being enforced end-to-end
+		calculated, local, global, adjusted := streamCountLimiter.getCurrentLimit("tenant1", "finance", fixedLimitSupplier)
+		require.Equal(t, 100, local, "Policy local limit should be 100")
+		require.Equal(t, 1000, global, "Policy global limit should be 1000")
+		require.Equal(t, 500, adjusted, "Policy adjusted global limit should be 500")
+		require.Equal(t, 100, calculated, "Policy calculated limit should be 100")
+	})
 }
 
 // Mock implementations for testing

--- a/pkg/ingester/limiter_test.go
+++ b/pkg/ingester/limiter_test.go
@@ -467,22 +467,22 @@ type mockLimits struct {
 	}
 }
 
-func (m *mockLimits) MaxLocalStreamsPerUser(userID string) int {
+func (m *mockLimits) MaxLocalStreamsPerUser(_ string) int {
 	return m.maxLocalStreams
 }
 
-func (m *mockLimits) MaxGlobalStreamsPerUser(userID string) int {
+func (m *mockLimits) MaxGlobalStreamsPerUser(_ string) int {
 	return m.maxGlobalStreams
 }
 
-func (m *mockLimits) PolicyMaxLocalStreamsPerUser(userID, policy string) int {
+func (m *mockLimits) PolicyMaxLocalStreamsPerUser(_, policy string) int {
 	if policyLimit, exists := m.policyLimits[policy]; exists {
 		return policyLimit.local
 	}
 	return 0
 }
 
-func (m *mockLimits) PolicyMaxGlobalStreamsPerUser(userID, policy string) int {
+func (m *mockLimits) PolicyMaxGlobalStreamsPerUser(_, policy string) int {
 	if policyLimit, exists := m.policyLimits[policy]; exists {
 		return policyLimit.global
 	}

--- a/pkg/ingester/owned_streams.go
+++ b/pkg/ingester/owned_streams.go
@@ -44,7 +44,7 @@ func (s *ownedStreamService) getOwnedStreamCount() int {
 }
 
 func (s *ownedStreamService) updateFixedLimit() (old, newVal int32) {
-	newLimit, _, _, _ := s.limiter.GetStreamCountLimit(s.tenantID)
+	newLimit, _, _, _ := s.limiter.GetStreamCountLimit(s.tenantID, "")
 	return s.fixedLimit.Swap(int32(newLimit)), int32(newLimit)
 
 }

--- a/pkg/ingester/owned_streams_test.go
+++ b/pkg/ingester/owned_streams_test.go
@@ -29,30 +29,30 @@ func Test_OwnedStreamService(t *testing.T) {
 	service.updateFixedLimit()
 	require.Equal(t, 100, service.getFixedLimit())
 
-	service.trackStreamOwnership(model.Fingerprint(1), true)
-	service.trackStreamOwnership(model.Fingerprint(2), true)
-	service.trackStreamOwnership(model.Fingerprint(3), true)
+	service.trackStreamOwnership(model.Fingerprint(1), true, noPolicy)
+	service.trackStreamOwnership(model.Fingerprint(2), true, noPolicy)
+	service.trackStreamOwnership(model.Fingerprint(3), true, noPolicy)
 	require.Equal(t, 3, service.getOwnedStreamCount())
 	require.Len(t, service.notOwnedStreams, 0)
 
 	service.resetStreamCounts()
-	service.trackStreamOwnership(model.Fingerprint(3), true)
-	service.trackStreamOwnership(model.Fingerprint(3), false)
+	service.trackStreamOwnership(model.Fingerprint(3), true, noPolicy)
+	service.trackStreamOwnership(model.Fingerprint(3), false, noPolicy)
 	require.Equal(t, 1, service.getOwnedStreamCount(),
 		"owned streams count must not be changed because not owned stream can be reported only by recalculate_owned_streams job that resets the counters before checking all the streams")
 	require.Len(t, service.notOwnedStreams, 1)
 	require.True(t, service.isStreamNotOwned(model.Fingerprint(3)))
 
 	service.resetStreamCounts()
-	service.trackStreamOwnership(model.Fingerprint(1), true)
-	service.trackStreamOwnership(model.Fingerprint(2), true)
-	service.trackStreamOwnership(model.Fingerprint(3), false)
+	service.trackStreamOwnership(model.Fingerprint(1), true, noPolicy)
+	service.trackStreamOwnership(model.Fingerprint(2), true, noPolicy)
+	service.trackStreamOwnership(model.Fingerprint(3), false, noPolicy)
 
-	service.trackRemovedStream(model.Fingerprint(3))
+	service.trackRemovedStream(model.Fingerprint(3), noPolicy)
 	require.Equal(t, 2, service.getOwnedStreamCount(), "owned stream count must be decremented only when notOwnedStream does not contain this fingerprint")
 	require.Len(t, service.notOwnedStreams, 0)
 
-	service.trackRemovedStream(model.Fingerprint(2))
+	service.trackRemovedStream(model.Fingerprint(2), noPolicy)
 	require.Equal(t, 1, service.getOwnedStreamCount())
 	require.Len(t, service.notOwnedStreams, 0)
 
@@ -61,7 +61,7 @@ func Test_OwnedStreamService(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		go func(i int) {
 			defer group.Done()
-			service.trackStreamOwnership(model.Fingerprint(i+1000), true)
+			service.trackStreamOwnership(model.Fingerprint(i+1000), true, noPolicy)
 		}(i)
 	}
 	group.Wait()
@@ -70,7 +70,7 @@ func Test_OwnedStreamService(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		go func(i int) {
 			defer group.Done()
-			service.trackRemovedStream(model.Fingerprint(i + 1000))
+			service.trackRemovedStream(model.Fingerprint(i+1000), noPolicy)
 		}(i)
 	}
 	group.Wait()
@@ -78,11 +78,55 @@ func Test_OwnedStreamService(t *testing.T) {
 	require.Equal(t, 1, service.getOwnedStreamCount(), "owned stream count must not be changed")
 
 	// simulate the effect from the recalculation job
-	service.trackStreamOwnership(model.Fingerprint(44), false)
-	service.trackStreamOwnership(model.Fingerprint(45), true)
+	service.trackStreamOwnership(model.Fingerprint(44), false, noPolicy)
+	service.trackStreamOwnership(model.Fingerprint(45), true, noPolicy)
 
 	service.resetStreamCounts()
 
 	require.Equal(t, 0, service.getOwnedStreamCount())
 	require.Len(t, service.notOwnedStreams, 0)
+}
+
+func Test_OwnedStreamService_PolicyStreamCounting(t *testing.T) {
+	limits, err := validation.NewOverrides(validation.Limits{
+		MaxGlobalStreamsPerUser: 100,
+	}, nil)
+	require.NoError(t, err)
+
+	ring := &ringCountMock{count: 30}
+	limiter := NewLimiter(limits, NilMetrics, newIngesterRingLimiterStrategy(ring, 3), &TenantBasedStrategy{limits: limits})
+
+	service := newOwnedStreamService("test", limiter)
+
+	// Initially no streams
+	require.Equal(t, 0, service.getOwnedStreamCount())
+	require.Equal(t, 0, service.getPolicyStreamCount("finance"))
+	require.Equal(t, 0, service.getPolicyStreamCount("ops"))
+
+	// Track streams with different policies
+	service.trackStreamOwnership(model.Fingerprint(1), true, "finance")
+	service.trackStreamOwnership(model.Fingerprint(2), true, "finance")
+	service.trackStreamOwnership(model.Fingerprint(3), true, "ops")
+	service.trackStreamOwnership(model.Fingerprint(4), true, noPolicy) // no policy
+
+	// Verify counts
+	require.Equal(t, 4, service.getOwnedStreamCount())               // total streams
+	require.Equal(t, 2, service.getPolicyStreamCount("finance"))     // finance policy streams
+	require.Equal(t, 1, service.getPolicyStreamCount("ops"))         // ops policy streams
+	require.Equal(t, 0, service.getPolicyStreamCount("nonexistent")) // non-existent policy
+
+	// Remove streams
+	service.trackRemovedStream(model.Fingerprint(1), "finance")
+	service.trackRemovedStream(model.Fingerprint(3), "ops")
+
+	// Verify updated counts
+	require.Equal(t, 2, service.getOwnedStreamCount())           // total streams
+	require.Equal(t, 1, service.getPolicyStreamCount("finance")) // finance policy streams
+	require.Equal(t, 0, service.getPolicyStreamCount("ops"))     // ops policy streams
+
+	// Reset and verify
+	service.resetStreamCounts()
+	require.Equal(t, 0, service.getOwnedStreamCount())
+	require.Equal(t, 0, service.getPolicyStreamCount("finance"))
+	require.Equal(t, 0, service.getPolicyStreamCount("ops"))
 }

--- a/pkg/ingester/stream.go
+++ b/pkg/ingester/stream.go
@@ -117,6 +117,7 @@ func newStream(
 	writeFailures *writefailures.Manager,
 	configs *runtime.TenantConfigs,
 	retentionHours string,
+	policy string,
 ) *stream {
 	hashNoShard, _ := ls.HashWithoutLabels(make([]byte, 0, 1024), ShardLbName)
 	return &stream{
@@ -139,6 +140,7 @@ func newStream(
 
 		configs:        configs,
 		retentionHours: retentionHours,
+		policy:         policy,
 	}
 }
 

--- a/pkg/ingester/stream_test.go
+++ b/pkg/ingester/stream_test.go
@@ -80,6 +80,7 @@ func TestMaxReturnedStreamsErrors(t *testing.T) {
 				nil,
 				nil,
 				retentionHours,
+				noPolicy,
 			)
 
 			_, err := s.Push(context.Background(), []logproto.Entry{
@@ -133,6 +134,7 @@ func TestPushDeduplication(t *testing.T) {
 		nil,
 		nil,
 		retentionHours,
+		noPolicy,
 	)
 
 	written, err := s.Push(context.Background(), []logproto.Entry{
@@ -192,6 +194,7 @@ func TestPushDeduplicationExtraMetrics(t *testing.T) {
 		manager,
 		runtimeCfg,
 		retentionHours,
+		noPolicy,
 	)
 
 	_, err = s.Push(context.Background(), []logproto.Entry{
@@ -237,6 +240,7 @@ func TestPushRejectOldCounter(t *testing.T) {
 		nil,
 		nil,
 		retentionHours,
+		noPolicy,
 	)
 
 	// counter should be 2 now since the first line will be deduped
@@ -344,6 +348,7 @@ func TestEntryErrorCorrectlyReported(t *testing.T) {
 		nil,
 		nil,
 		retentionHours,
+		noPolicy,
 	)
 	s.highestTs = time.Now()
 
@@ -382,6 +387,7 @@ func TestUnorderedPush(t *testing.T) {
 		nil,
 		nil,
 		retentionHours,
+		noPolicy,
 	)
 
 	for _, x := range []struct {
@@ -484,6 +490,7 @@ func TestPushRateLimit(t *testing.T) {
 		nil,
 		nil,
 		retentionHours,
+		noPolicy,
 	)
 
 	entries := []logproto.Entry{
@@ -524,6 +531,7 @@ func TestPushRateLimitAllOrNothing(t *testing.T) {
 		nil,
 		nil,
 		retentionHours,
+		noPolicy,
 	)
 
 	entries := []logproto.Entry{
@@ -563,6 +571,7 @@ func TestReplayAppendIgnoresValidityWindow(t *testing.T) {
 		nil,
 		nil,
 		retentionHours,
+		noPolicy,
 	)
 
 	base := time.Now()
@@ -613,7 +622,7 @@ func Benchmark_PushStream(b *testing.B) {
 	limiter := NewLimiter(limits, NilMetrics, newIngesterRingLimiterStrategy(&ringCountMock{count: 1}, 1), &TenantBasedStrategy{limits: limits})
 	chunkfmt, headfmt := defaultChunkFormat(b)
 	retentionHours := util.RetentionHours(limiter.limits.RetentionPeriod("fake"))
-	s := newStream(chunkfmt, headfmt, &Config{MaxChunkAge: 24 * time.Hour}, limiter.rateLimitStrategy, "fake", model.Fingerprint(0), ls, true, NewStreamRateCalculator(), NilMetrics, nil, nil, retentionHours)
+	s := newStream(chunkfmt, headfmt, &Config{MaxChunkAge: 24 * time.Hour}, limiter.rateLimitStrategy, "fake", model.Fingerprint(0), ls, true, NewStreamRateCalculator(), NilMetrics, nil, nil, retentionHours, noPolicy)
 	expr, err := syntax.ParseLogSelector(`{namespace="loki-dev"}`, true)
 	require.NoError(b, err)
 	t, err := newTailer("foo", expr, &fakeTailServer{}, 10)

--- a/pkg/ingester/streams_map_test.go
+++ b/pkg/ingester/streams_map_test.go
@@ -33,6 +33,7 @@ func TestStreamsMap(t *testing.T) {
 			nil,
 			nil,
 			retentionHours,
+			noPolicy,
 		),
 		newStream(
 			chunkfmt,
@@ -48,6 +49,7 @@ func TestStreamsMap(t *testing.T) {
 			nil,
 			nil,
 			retentionHours,
+			noPolicy,
 		),
 	}
 	var s *stream

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -244,8 +244,8 @@ type Limits struct {
 	// This field is not exposed in YAML/JSON as it's set programmatically.
 	DefaultPolicyStreamMapping PolicyStreamMapping `yaml:"-" json:"-"`
 
-	// PolicyOverridenLimits contains per-policy overrides for stream count limits.
-	PolicyOverridenLimits map[string]PolicyOverridableLimits `yaml:"policy_overriden_limits" json:"policy_overriden_limits" doc:"hidden"`
+	// PolicyOverrideLimits contains per-policy overrides for stream count limits.
+	PolicyOverrideLimits map[string]PolicyOverridableLimits `yaml:"policy_override_limits" json:"policy_override_limits" doc:"hidden"`
 
 	IngestionPartitionsTenantShardSize int `yaml:"ingestion_partitions_tenant_shard_size" json:"ingestion_partitions_tenant_shard_size" category:"experimental"`
 
@@ -719,10 +719,10 @@ func (o *Overrides) PolicyMaxLocalStreamsPerUser(userID, policy string) int {
 		return 0
 	}
 	limits := o.getOverridesForUser(userID)
-	if len(limits.PolicyOverridenLimits) == 0 {
+	if len(limits.PolicyOverrideLimits) == 0 {
 		return 0
 	}
-	if policyLimits, exists := limits.PolicyOverridenLimits[policy]; exists {
+	if policyLimits, exists := limits.PolicyOverrideLimits[policy]; exists {
 		return policyLimits.MaxLocalStreamsPerUser
 	}
 	return 0
@@ -741,10 +741,10 @@ func (o *Overrides) PolicyMaxGlobalStreamsPerUser(userID, policy string) int {
 		return 0
 	}
 	limits := o.getOverridesForUser(userID)
-	if len(limits.PolicyOverridenLimits) == 0 {
+	if len(limits.PolicyOverrideLimits) == 0 {
 		return 0
 	}
-	if policyLimits, exists := limits.PolicyOverridenLimits[policy]; exists {
+	if policyLimits, exists := limits.PolicyOverrideLimits[policy]; exists {
 		return policyLimits.MaxGlobalStreamsPerUser
 	}
 	return 0

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -244,6 +244,9 @@ type Limits struct {
 	// This field is not exposed in YAML/JSON as it's set programmatically.
 	DefaultPolicyStreamMapping PolicyStreamMapping `yaml:"-" json:"-"`
 
+	// PolicyOverridenLimits contains per-policy overrides for stream count limits.
+	PolicyOverridenLimits map[string]PolicyOverridableLimits `yaml:"policy_overriden_limits" json:"policy_overriden_limits" doc:"hidden"`
+
 	IngestionPartitionsTenantShardSize int `yaml:"ingestion_partitions_tenant_shard_size" json:"ingestion_partitions_tenant_shard_size" category:"experimental"`
 
 	ShardAggregations []string `yaml:"shard_aggregations,omitempty" json:"shard_aggregations,omitempty" doc:"description=List of LogQL vector and range aggregations that should be sharded."`
@@ -709,10 +712,42 @@ func (o *Overrides) MaxLocalStreamsPerUser(userID string) int {
 	return o.getOverridesForUser(userID).MaxLocalStreamsPerUser
 }
 
+// PolicyMaxLocalStreamsPerUser returns the maximum number of streams a user is allowed to store
+// in a single ingester for a specific policy. Returns 0 if no policy-specific override is set.
+func (o *Overrides) PolicyMaxLocalStreamsPerUser(userID, policy string) int {
+	if policy == "" {
+		return 0
+	}
+	limits := o.getOverridesForUser(userID)
+	if len(limits.PolicyOverridenLimits) == 0 {
+		return 0
+	}
+	if policyLimits, exists := limits.PolicyOverridenLimits[policy]; exists {
+		return policyLimits.MaxLocalStreamsPerUser
+	}
+	return 0
+}
+
 // MaxGlobalStreamsPerUser returns the maximum number of streams a user is allowed to store
 // across the cluster.
 func (o *Overrides) MaxGlobalStreamsPerUser(userID string) int {
 	return o.getOverridesForUser(userID).MaxGlobalStreamsPerUser
+}
+
+// PolicyMaxGlobalStreamsPerUser returns the maximum number of streams a user is allowed to store
+// across the cluster for a specific policy. Returns 0 if no policy-specific override is set.
+func (o *Overrides) PolicyMaxGlobalStreamsPerUser(userID, policy string) int {
+	if policy == "" {
+		return 0
+	}
+	limits := o.getOverridesForUser(userID)
+	if len(limits.PolicyOverridenLimits) == 0 {
+		return 0
+	}
+	if policyLimits, exists := limits.PolicyOverridenLimits[policy]; exists {
+		return policyLimits.MaxGlobalStreamsPerUser
+	}
+	return 0
 }
 
 // MaxChunksPerQuery returns the maximum number of chunks allowed per query.
@@ -1297,6 +1332,12 @@ func (o *Overrides) getOverridesForUser(userID string) *Limits {
 // as opposed to merging.
 type OverwriteMarshalingStringMap struct {
 	m map[string]string
+}
+
+// PolicyOverridableLimits contains limits that can be overridden on a per-policy basis.
+type PolicyOverridableLimits struct {
+	MaxLocalStreamsPerUser  int `yaml:"max_streams_per_user" json:"max_streams_per_user"`
+	MaxGlobalStreamsPerUser int `yaml:"max_global_streams_per_user" json:"max_global_streams_per_user"`
 }
 
 func NewOverwriteMarshalingStringMap(m map[string]string) OverwriteMarshalingStringMap {

--- a/pkg/validation/limits_test.go
+++ b/pkg/validation/limits_test.go
@@ -231,7 +231,7 @@ ruler_remote_write_headers:
 				EnforcedLabels:            []string{},
 				PolicyEnforcedLabels:      map[string][]string{},
 				PolicyStreamMapping:       PolicyStreamMapping{},
-				PolicyOverridenLimits:     map[string]PolicyOverridableLimits{},
+				PolicyOverrideLimits:      map[string]PolicyOverridableLimits{},
 				BlockIngestionPolicyUntil: map[string]dskit_flagext.Time{},
 			},
 		},
@@ -255,7 +255,7 @@ ruler_remote_write_headers:
 				EnforcedLabels:            []string{},
 				PolicyEnforcedLabels:      map[string][]string{},
 				PolicyStreamMapping:       PolicyStreamMapping{},
-				PolicyOverridenLimits:     map[string]PolicyOverridableLimits{},
+				PolicyOverrideLimits:      map[string]PolicyOverridableLimits{},
 				BlockIngestionPolicyUntil: map[string]dskit_flagext.Time{},
 			},
 		},
@@ -283,7 +283,7 @@ retention_stream:
 				EnforcedLabels:            []string{},
 				PolicyEnforcedLabels:      map[string][]string{},
 				PolicyStreamMapping:       PolicyStreamMapping{},
-				PolicyOverridenLimits:     map[string]PolicyOverridableLimits{},
+				PolicyOverrideLimits:      map[string]PolicyOverridableLimits{},
 				BlockIngestionPolicyUntil: map[string]dskit_flagext.Time{},
 			},
 		},
@@ -310,7 +310,7 @@ reject_old_samples: true
 				EnforcedLabels:            []string{},
 				PolicyEnforcedLabels:      map[string][]string{},
 				PolicyStreamMapping:       PolicyStreamMapping{},
-				PolicyOverridenLimits:     map[string]PolicyOverridableLimits{},
+				PolicyOverrideLimits:      map[string]PolicyOverridableLimits{},
 				BlockIngestionPolicyUntil: map[string]dskit_flagext.Time{},
 			},
 		},
@@ -338,7 +338,7 @@ query_timeout: 5m
 				EnforcedLabels:            []string{},
 				PolicyEnforcedLabels:      map[string][]string{},
 				PolicyStreamMapping:       PolicyStreamMapping{},
-				PolicyOverridenLimits:     map[string]PolicyOverridableLimits{},
+				PolicyOverrideLimits:      map[string]PolicyOverridableLimits{},
 				BlockIngestionPolicyUntil: map[string]dskit_flagext.Time{},
 			},
 		},
@@ -602,9 +602,9 @@ pattern_rate_threshold: 0.0
 	}
 }
 
-func TestLimits_PolicyOverridenLimits(t *testing.T) {
+func TestLimits_PolicyOverrideLimits(t *testing.T) {
 	limits := &Limits{
-		PolicyOverridenLimits: map[string]PolicyOverridableLimits{
+		PolicyOverrideLimits: map[string]PolicyOverridableLimits{
 			"finance": {
 				MaxLocalStreamsPerUser:  100,
 				MaxGlobalStreamsPerUser: 1000,
@@ -635,8 +635,8 @@ func TestLimits_PolicyOverridenLimits(t *testing.T) {
 	require.Equal(t, 0, overrides.PolicyMaxLocalStreamsPerUser("tenant1", ""))
 	require.Equal(t, 0, overrides.PolicyMaxGlobalStreamsPerUser("tenant1", ""))
 
-	// Test nil PolicyOverridenLimits returns 0
-	limits.PolicyOverridenLimits = nil
+	// Test nil PolicyOverrideLimits returns 0
+	limits.PolicyOverrideLimits = nil
 	require.Equal(t, 0, overrides.PolicyMaxLocalStreamsPerUser("tenant1", "finance"))
 	require.Equal(t, 0, overrides.PolicyMaxGlobalStreamsPerUser("tenant1", "finance"))
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds policy-specific overrides for `max_streams_per_user` and `max_global_streams_per_user` limits.

```yaml
limits_config:
  max_streams_per_user: 1000
  max_global_streams_per_user: 10000

overrides:
  tenant1:
    max_streams_per_user: 500
    max_global_streams_per_user: 5000
    policy_overriden_limits:
      finance:
        max_streams_per_user: 200
        max_global_streams_per_user: 2000
      ops:
        max_streams_per_user: 100
        max_global_streams_per_user: 1000
      # Streams with 'finance' policy get 200/2000 limits
      # Streams with 'ops' policy get 100/1000 limits
      # Streams without policy or different than finance or ops use tenant defaults (500/5000)
      # Global defaults (1000/10000) apply if no tenant override
```

**Special notes for your reviewer**:
- Policy-matching streams account for the regular owned streams count. Meaning that all streams matching a policy still account for the regular tenant stream limit, but streams not matching a policy do not account for the policy stream limit.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
