### PR TITLE
chore(planner/physical): simplify replace code

### DIFF
--- a/pkg/engine/planner/physical/plan.go
+++ b/pkg/engine/planner/physical/plan.go
@@ -207,11 +207,10 @@ func (p *Plan) eliminateNode(node Node) {
 	parent := p.Parent(node)
 	if parent != nil {
 		idx := slices.Index(p.children[parent], node)
-		// First get rid of the node to be deleted
-		allChildren := append(p.children[parent][0:idx], p.children[parent][idx+1:]...)
-		// Then insert all the children of the node
-		allChildren = slices.Insert(allChildren, idx, p.children[node]...)
-		p.children[parent] = allChildren
+
+		// Replace node's entry in the parent's children with the children of node.
+		oldChildren := p.children[parent]
+		p.children[parent] = slices.Replace(oldChildren, idx, idx+1, p.children[node]...)
 	}
 
 	for _, child := range p.Children(node) {


### PR DESCRIPTION
Simplify code in Plan.eliminateNode by using slices.Replace to replace the old node's entry with the set of its children.

slices.Replace is valid for use even when the set of new elements in the slice is not the same size as the replaced elements.

Small update on #18978.