### PR TITLE
Copy Helm CI tests into new framework

### DIFF
--- a/production/helm/loki/test/integration/ingress/ingress-values.yaml
+++ b/production/helm/loki/test/integration/ingress/ingress-values.yaml
@@ -1,0 +1,30 @@
+---
+gateway:
+  ingress:
+    enabled: true
+    annotations: {}
+    hosts:
+      - host: gateway.loki.example.com
+        paths:
+          - path: /
+            pathType: Prefix
+loki:
+  commonConfig:
+    replication_factor: 1
+  useTestSchema: true
+  storage:
+    bucketNames:
+      chunks: chunks
+      ruler: ruler
+      admin: admin
+read:
+  replicas: 1
+write:
+  replicas: 1
+backend:
+  replicas: 1
+monitoring:
+  lokiCanary:
+    enabled: false
+test:
+  enabled: false

--- a/production/helm/loki/test/integration/ingress/test-plan.yaml
+++ b/production/helm/loki/test/integration/ingress/test-plan.yaml
@@ -6,7 +6,7 @@ subject:
   releaseName: loki
   namespace: loki
   path: ../../..
-  valuesFile: ../../../ci/ingress-values.yaml
+  valuesFile: ingress-values.yaml
   extraArgs:
     - --dependency-update
     - --set

--- a/production/helm/loki/test/integration/single-binary/default-single-binary-values.yaml
+++ b/production/helm/loki/test/integration/single-binary/default-single-binary-values.yaml
@@ -1,0 +1,19 @@
+---
+loki:
+  commonConfig:
+    replication_factor: 1
+  useTestSchema: true
+  storage:
+    bucketNames:
+      chunks: chunks
+      ruler: ruler
+      admin: admin
+deploymentMode: SingleBinary
+singleBinary:
+  replicas: 1
+read:
+  replicas: 0
+write:
+  replicas: 0
+backend:
+  replicas: 0

--- a/production/helm/loki/test/integration/ssd/default-values.yaml
+++ b/production/helm/loki/test/integration/ssd/default-values.yaml
@@ -1,0 +1,16 @@
+---
+loki:
+  commonConfig:
+    replication_factor: 1
+  useTestSchema: true
+  storage:
+    bucketNames:
+      chunks: chunks
+      ruler: ruler
+      admin: admin
+read:
+  replicas: 1
+write:
+  replicas: 1
+backend:
+  replicas: 1

--- a/production/helm/loki/test/integration/ssd/log-generator.yaml
+++ b/production/helm/loki/test/integration/ssd/log-generator.yaml
@@ -1,0 +1,50 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: grafana
+  namespace: default
+spec:
+  interval: 1m
+  url: https://grafana.github.io/helm-charts
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: log-generator
+  namespace: default
+spec:
+  interval: 1m
+  chart:
+    spec:
+      chart: alloy
+      sourceRef:
+        kind: HelmRepository
+        name: grafana
+        namespace: default
+      interval: 1m
+  values:
+    controller:
+      type: deployment
+    alloy:
+      configMap:
+        content: |
+          logging {
+            level = "debug"
+            write_to = [loki.relabel.default.receiver]
+          }
+
+          loki.relabel "default" {
+            rule {
+              target_label = "source"
+              replacement = "log-generator"
+            }
+            forward_to = [loki.write.default.receiver]
+          }
+
+          loki.write "default" {
+            endpoint {
+              url = "http://loki-gateway.loki.svc/loki/api/v1/push"
+              tenant_id = "1"
+            }
+          }

--- a/production/helm/loki/test/integration/ssd/test-plan.yaml
+++ b/production/helm/loki/test/integration/ssd/test-plan.yaml
@@ -1,12 +1,12 @@
 ---
 apiVersion: helm-chart-toolbox.grafana.com/v1
 kind: TestPlan
-name: single-binary
+name: ssd
 subject:
   releaseName: loki
   namespace: loki
   path: ../../..
-  valuesFile: default-single-binary-values.yaml
+  valuesFile: default-values.yaml
   extraArgs:
     - --dependency-update
     - --set
@@ -37,7 +37,10 @@ tests:
     values:
       checks:
         - kind: StatefulSet
-          name: loki
+          name: loki-backend
+          namespace: loki
+        - kind: StatefulSet
+          name: loki-write
           namespace: loki
         - kind: StatefulSet
           name: loki-chunks-cache
@@ -45,10 +48,22 @@ tests:
         - kind: StatefulSet
           name: loki-results-cache
           namespace: loki
+        - kind: Deployment
+          name: loki-read
+          namespace: loki
+        - kind: Deployment
+          name: loki-gateway
+          namespace: loki
 
         # Loki services
         - kind: Service
-          name: loki
+          name: loki-backend
+          namespace: loki
+        - kind: Service
+          name: loki-read
+          namespace: loki
+        - kind: Service
+          name: loki-write
           namespace: loki
         - kind: Service
           name: loki-canary
@@ -58,9 +73,6 @@ tests:
           namespace: loki
         - kind: Service
           name: loki-gateway
-          namespace: loki
-        - kind: Service
-          name: loki-headless
           namespace: loki
         - kind: Service
           name: loki-memberlist
@@ -73,7 +85,7 @@ tests:
     values:
       tests:
         - env:
-            LOKI_URL: http://loki.loki.svc:3100/loki/api/v1/query
+            LOKI_URL: http://loki-gateway.loki.svc/loki/api/v1/query
             LOKI_TENANTID: 1
           queries:
             - query: count_over_time({source="log-generator"}[1h])


### PR DESCRIPTION
This PR takes the existing CI tests for the Helm chart and copies them over into the new testing framework based on [helm-chart-toolbox](https://github.com/grafana/helm-chart-toolbox). The goal is to get the new tests running in parallel with the old tests until we decide that we can safely retire the old testing framework.