### PR TITLE
[DOCS] un-deprecate several features in `monitoring` block

### DIFF
--- a/docs/sources/setup/install/helm/reference.md
+++ b/docs/sources/setup/install/helm/reference.md
@@ -7526,81 +7526,6 @@ false
 </td>
 		</tr>
 		<tr>
-			<td>monitoring</td>
-			<td>object</td>
-			<td>DEPRECATED Monitoring section determines which monitoring features to enable, this section is being replaced by https://github.com/grafana/meta-monitoring-chart</td>
-			<td><pre lang="json">
-{
-  "dashboards": {
-    "annotations": {},
-    "enabled": false,
-    "labels": {
-      "grafana_dashboard": "1"
-    },
-    "namespace": null
-  },
-  "rules": {
-    "additionalGroups": [],
-    "additionalRuleLabels": {},
-    "alerting": true,
-    "annotations": {},
-    "disabled": {},
-    "enabled": false,
-    "labels": {},
-    "namespace": null
-  },
-  "selfMonitoring": {
-    "enabled": false,
-    "grafanaAgent": {
-      "annotations": {},
-      "enableConfigReadAPI": false,
-      "installOperator": false,
-      "labels": {},
-      "priorityClassName": null,
-      "resources": {},
-      "tolerations": []
-    },
-    "logsInstance": {
-      "annotations": {},
-      "clients": null,
-      "labels": {}
-    },
-    "podLogs": {
-      "additionalPipelineStages": [],
-      "annotations": {},
-      "apiVersion": "monitoring.grafana.com/v1alpha1",
-      "labels": {},
-      "relabelings": []
-    },
-    "tenant": {
-      "name": "self-monitoring",
-      "password": null,
-      "secretNamespace": "{{ .Release.Namespace }}"
-    }
-  },
-  "serviceMonitor": {
-    "annotations": {},
-    "enabled": false,
-    "interval": "15s",
-    "labels": {},
-    "metricRelabelings": [],
-    "metricsInstance": {
-      "annotations": {},
-      "enabled": true,
-      "labels": {},
-      "remoteWrite": null
-    },
-    "namespaceSelector": {},
-    "relabelings": [],
-    "scheme": "http",
-    "scrapeTimeout": null,
-    "tlsConfig": null
-  }
-}
-</pre>
-</td>
-		</tr>
-		<tr>
 			<td>monitoring.dashboards.annotations</td>
 			<td>object</td>
 			<td>Additional annotations for the dashboards ConfigMap</td>
@@ -7635,24 +7560,6 @@ false
 			<td>Alternative namespace to create dashboards ConfigMap in</td>
 			<td><pre lang="json">
 null
-</pre>
-</td>
-		</tr>
-		<tr>
-			<td>monitoring.rules</td>
-			<td>object</td>
-			<td>DEPRECATED Recording rules for monitoring Loki, required for some dashboards</td>
-			<td><pre lang="json">
-{
-  "additionalGroups": [],
-  "additionalRuleLabels": {},
-  "alerting": true,
-  "annotations": {},
-  "disabled": {},
-  "enabled": false,
-  "labels": {},
-  "namespace": null
-}
 </pre>
 </td>
 		</tr>
@@ -7731,7 +7638,7 @@ null
 		<tr>
 			<td>monitoring.selfMonitoring</td>
 			<td>object</td>
-			<td>DEPRECATED Self monitoring determines whether Loki should scrape its own logs. This feature currently relies on the Grafana Agent Operator being installed, which is installed by default using the grafana-agent-operator sub-chart. It will create custom resources for GrafanaAgent, LogsInstance, and PodLogs to configure scrape configs to scrape its own logs with the labels expected by the included dashboards.</td>
+			<td>DEPRECATED Self monitoring determines whether Loki should scrape its own logs. This feature relies on Grafana Agent Operator, which is deprecated. It will create custom resources for GrafanaAgent, LogsInstance, and PodLogs to configure scrape configs to scrape its own logs with the labels expected by the included dashboards.</td>
 			<td><pre lang="json">
 {
   "enabled": false,
@@ -8005,7 +7912,7 @@ false
 		<tr>
 			<td>monitoring.serviceMonitor.metricsInstance</td>
 			<td>object</td>
-			<td>If defined, will create a MetricsInstance for the Grafana Agent Operator.</td>
+			<td>DEPRECATED If defined, will create a MetricsInstance for the Grafana Agent Operator.</td>
 			<td><pre lang="json">
 {
   "annotations": {},

--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -14,6 +14,7 @@ Entries should include a reference to the pull request that introduced the chang
 ## Unreleased
 
 
+- un-deprecate all features in `monitoring` block except grafana-agent-operator [#19001](https://github.com/grafana/loki/pull/19001)
 
 ## 6.37.0
 

--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -16,7 +16,7 @@ Helm chart for Grafana Loki and Grafana Enterprise Logs supporting monolithic, s
 |------------|------|---------|
 | https://charts.min.io/ | minio(minio) | 5.4.0 |
 | https://grafana.github.io/helm-charts | grafana-agent-operator(grafana-agent-operator) | 0.5.1 |
-| https://grafana.github.io/helm-charts | rollout_operator(rollout-operator) | 0.30.0 |
+| https://grafana.github.io/helm-charts | rollout_operator(rollout-operator) | 0.31.0 |
 
 Find more information in the Loki Helm Chart [documentation](https://grafana.com/docs/loki/next/installation/helm).
 

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -3809,16 +3809,8 @@ sidecar:
     watchClientTimeout: 60
     # -- Log level of the sidecar container.
     logLevel: INFO
-############################################## WARNING ###############################################################
-#
-# DEPRECATED VALUES
-#
-# The following values are deprecated and will be removed in a future version of the helm chart!
-#
-############################################## WARNING ##############################################################
 
-# -- DEPRECATED Monitoring section determines which monitoring features to enable, this section is being replaced
-# by https://github.com/grafana/meta-monitoring-chart
+# Monitoring section determines which monitoring features to enable
 monitoring:
   # Dashboards for monitoring Loki
   dashboards:
@@ -3831,7 +3823,7 @@ monitoring:
     # -- Labels for the dashboards ConfigMap
     labels:
       grafana_dashboard: "1"
-  # -- DEPRECATED Recording rules for monitoring Loki, required for some dashboards
+  # Recording rules for monitoring Loki, required for some dashboards
   rules:
     # -- If enabled, create PrometheusRule resource with Loki recording rules
     enabled: false
@@ -3861,7 +3853,7 @@ monitoring:
     #       expr: sum(rate(loki_request_duration_seconds_bucket[1m])) by (le, job, route)
     #     - record: node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate
     #       expr: sum(rate(container_cpu_usage_seconds_total[1m])) by (node, namespace, pod, container)
-  #  -- DEPRECATED ServiceMonitor configuration
+  # ServiceMonitor configuration
   serviceMonitor:
     # -- If enabled, ServiceMonitor resources for Prometheus Operator are created
     enabled: false
@@ -3887,7 +3879,7 @@ monitoring:
     scheme: http
     # -- ServiceMonitor will use these tlsConfig settings to make the health check requests
     tlsConfig: null
-    # -- If defined, will create a MetricsInstance for the Grafana Agent Operator.
+    # -- DEPRECATED If defined, will create a MetricsInstance for the Grafana Agent Operator.
     metricsInstance:
       # -- If enabled, MetricsInstance resources for Grafana Agent Operator are created
       enabled: true
@@ -3898,8 +3890,7 @@ monitoring:
       # -- If defined a MetricsInstance will be created to remote write metrics.
       remoteWrite: null
   # -- DEPRECATED Self monitoring determines whether Loki should scrape its own logs.
-  # This feature currently relies on the Grafana Agent Operator being installed,
-  # which is installed by default using the grafana-agent-operator sub-chart.
+  # This feature relies on Grafana Agent Operator, which is deprecated.
   # It will create custom resources for GrafanaAgent, LogsInstance, and PodLogs to configure
   # scrape configs to scrape its own logs with the labels expected by the included dashboards.
   selfMonitoring:
@@ -3958,6 +3949,7 @@ monitoring:
       labels: {}
       # -- Additional clients for remote write
       clients: null
+
 # -- DEPRECATED Configuration for the table-manager. The table-manager is only necessary when using a deprecated
 # index type such as Cassandra, Bigtable, or DynamoDB, it has not been necessary since loki introduced self-
 # contained index types like 'boltdb-shipper' and 'tsdb'. This will be removed in a future helm chart.


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR un-deprecates all features in the `monitoring` block except grafana-agent-operator.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:


**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
