### PR TITLE
chore(engine): improve performance of matching window calculation

### DIFF
--- a/pkg/engine/executor/range_aggregation_test.go
+++ b/pkg/engine/executor/range_aggregation_test.go
@@ -337,27 +337,27 @@ func TestMatcher(t *testing.T) {
 		}{
 			{
 				name:      "timestamp exactly at lowerbound (exclusive boundary)",
-				timestamp: f.lowerbound,
+				timestamp: f.bounds.start,
 				expected:  nil, // should return nil as lowerbound is exclusive
 			},
 			{
 				name:      "timestamp greater than upperbound",
-				timestamp: f.upperbound.Add(1 * time.Nanosecond),
+				timestamp: f.bounds.end.Add(1 * time.Nanosecond),
 				expected:  nil, // should return nil as lowerbound is exclusive
 			},
 			{
 				name:      "timestamp exactly at upperbound (inclusive boundary)",
-				timestamp: f.upperbound,
+				timestamp: f.bounds.end,
 				expected:  []window{windows[0]}, // should return window as upperbound is inclusive
 			},
 			{
 				name:      "timestamp just after lowerbound",
-				timestamp: f.lowerbound.Add(1 * time.Nanosecond),
+				timestamp: f.bounds.start.Add(1 * time.Nanosecond),
 				expected:  []window{windows[0]},
 			},
 			{
 				name:      "timestamp just before upperbound",
-				timestamp: f.upperbound.Add(-1 * time.Nanosecond),
+				timestamp: f.bounds.end.Add(-1 * time.Nanosecond),
 				expected:  []window{windows[0]},
 			},
 			{
@@ -390,9 +390,9 @@ func TestMatcher(t *testing.T) {
 
 		t.Run("multiple windows (should return first)", func(t *testing.T) {
 			windows := []window{
-				{start: f.lowerbound, end: f.start},
-				{start: f.lowerbound.Add(100 * time.Second), end: f.start.Add(100 * time.Second)},
-				{start: f.lowerbound.Add(200 * time.Second), end: f.start.Add(200 * time.Second)},
+				{start: f.bounds.start, end: f.start},
+				{start: f.bounds.start.Add(100 * time.Second), end: f.start.Add(100 * time.Second)},
+				{start: f.bounds.start.Add(200 * time.Second), end: f.start.Add(200 * time.Second)},
 			}
 			matcher := f.createExactMatcher(windows)
 
@@ -427,27 +427,27 @@ func TestMatcher(t *testing.T) {
 		}{
 			{
 				name:      "timestamp exactly at lowerbound (exclusive boundary)",
-				timestamp: f.lowerbound,
+				timestamp: f.bounds.start,
 				expected:  nil, // should return nil as lowerbound is exclusive
 			},
 			{
 				name:      "timestamp greater than upperbound",
-				timestamp: f.upperbound.Add(1 * time.Nanosecond),
+				timestamp: f.bounds.end.Add(1 * time.Nanosecond),
 				expected:  nil, // should return nil as lowerbound is exclusive
 			},
 			{
 				name:      "timestamp exactly at upperbound (inclusive boundary)",
-				timestamp: f.upperbound,
+				timestamp: f.bounds.end,
 				expected:  []window{windows[2]}, // should return window as upperbound is inclusive
 			},
 			{
 				name:      "timestamp just after lowerbound",
-				timestamp: f.lowerbound.Add(1 * time.Nanosecond),
+				timestamp: f.bounds.start.Add(1 * time.Nanosecond),
 				expected:  []window{windows[0]},
 			},
 			{
 				name:      "timestamp just before upperbound",
-				timestamp: f.upperbound.Add(-1 * time.Nanosecond),
+				timestamp: f.bounds.end.Add(-1 * time.Nanosecond),
 				expected:  []window{windows[2]},
 			},
 			{
@@ -495,12 +495,12 @@ func TestMatcher(t *testing.T) {
 		}{
 			{
 				name:      "timestamp exactly at lowerbound (exclusive boundary)",
-				timestamp: f.lowerbound,
+				timestamp: f.bounds.start,
 				expected:  nil, // should return nil as lowerbound is exclusive
 			},
 			{
 				name:      "timestamp greater than upperbound",
-				timestamp: f.upperbound.Add(1 * time.Nanosecond),
+				timestamp: f.bounds.end.Add(1 * time.Nanosecond),
 				expected:  nil, // should return nil as lowerbound is exclusive
 			},
 			{
@@ -530,7 +530,7 @@ func TestMatcher(t *testing.T) {
 			},
 			{
 				name:      "timestamp just before upperbound",
-				timestamp: f.upperbound.Add(-1 * time.Nanosecond),
+				timestamp: f.bounds.end.Add(-1 * time.Nanosecond),
 				expected:  []window{windows[2]},
 			},
 			{
@@ -578,12 +578,12 @@ func TestMatcher(t *testing.T) {
 		}{
 			{
 				name:      "timestamp exactly at lowerbound (exclusive boundary)",
-				timestamp: f.lowerbound,
+				timestamp: f.bounds.start,
 				expected:  nil, // should return nil as lowerbound is exclusive
 			},
 			{
 				name:      "timestamp exactly at upperbound (inclusive boundary)",
-				timestamp: f.upperbound,
+				timestamp: f.bounds.end,
 				expected:  []window{windows[2]}, // should return window as upperbound is inclusive
 			},
 			{
@@ -603,7 +603,7 @@ func TestMatcher(t *testing.T) {
 			},
 			{
 				name:      "timestamp just before upperbound",
-				timestamp: f.upperbound.Add(-1 * time.Nanosecond),
+				timestamp: f.bounds.end.Add(-1 * time.Nanosecond),
 				expected:  []window{windows[2]},
 			},
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently range aggregation linearly scans through all the possible time windows (a 24h query with a 1m step results in 1440 windows) to find the matching ones. This is quite expensive as this matching is done for each row.

This PR updates the matching code to use arithmetic which runs in constant time for cases where step >= range and for overlapping windows (step < range) it uses binary search.

```
goos: darwin
goarch: arm64
pkg: github.com/grafana/loki/v3/pkg/logql/bench
cpu: Apple M1 Pro
                                                                                                                          │ /tmp/main.txt │        /tmp/arithmetric.txt        │
                                                                                                                          │    sec/op     │   sec/op    vs base                │
LogQL/query=sum_by_(detected_level)_(count_over_time({region="ap-southeast-1"}[1m0s]))/kind=metric/store=dataobj-engine-8     11.419 ± 1%   1.337 ± 2%  -88.30% (p=0.000 n=10)
```

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
