### PR TITLE
chore(engine): add concurrecy for merge node

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -4919,6 +4919,11 @@ engine:
   # CLI flag: -querier.engine.batch-size
   [batch_size: <int> | default = 100]
 
+  # Experimental: The number of inputs processed simultaneously by the pipeline
+  # operators.
+  # CLI flag: -querier.engine.pipeline-concurrency
+  [pipeline_concurrency: <int> | default = 4]
+
   # Experimental: Maximum total size of future pages for DataObjScan to download
   # before they are needed, for roundtrip reduction to object storage. Setting
   # to zero disables downloading future pages. Only used in the next generation

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -184,6 +184,7 @@ func (e *QueryEngine) Execute(ctx context.Context, params logql.Params) (logqlmo
 
 		cfg := executor.Config{
 			BatchSize:                int64(e.opts.BatchSize),
+			MergePipelineConcurrency: e.opts.PipelineConcurreny,
 			Bucket:                   e.bucket,
 			DataobjScanPageCacheSize: int64(e.opts.DataobjScanPageCacheSize),
 		}

--- a/pkg/engine/executor/executor.go
+++ b/pkg/engine/executor/executor.go
@@ -314,7 +314,7 @@ func (c *Context) executeMerge(ctx context.Context, _ *physical.Merge, inputs []
 		return emptyPipeline()
 	}
 
-	pipeline, err := NewMergePipeline(inputs)
+	pipeline, err := newMergePipeline(inputs, 1)
 	if err != nil {
 		return errorPipeline(ctx, err)
 	}

--- a/pkg/engine/executor/merge.go
+++ b/pkg/engine/executor/merge.go
@@ -4,103 +4,269 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"slices"
+	"sync"
 
 	"github.com/apache/arrow-go/v18/arrow"
 )
 
-// Merge is a pipeline that takes N inputs and sequentially consumes each one of them.
-// It completely exhausts an input before moving to the next one.
+var errorCancelled = errors.New("cancelled by merge pipeline")
+
+// Merge is a pipeline that takes N inputs and paralelly consumes them.
+// It completely exhausts the open inputs before loading the next one.
+
+// InputState tracks the processing state of each input pipeline
+type InputState int
+
+const (
+	InputNotStarted InputState = iota
+	InputInProgress
+	InputCompleted
+)
+
+// workerResult represents a result from an input pipeline
+type workerResult struct {
+	record    arrow.Record
+	err       error
+	inputIdx  int
+	completed bool // true when this input is fully exhausted
+}
+
+// Merge processes N inputs with configurable parallelism.
+// It maintains exactly maxConcurrency inputs in-progress at any time,
+// completely exhausting each input before moving to the next one.
 type Merge struct {
-	inputs    []Pipeline
-	exhausted []bool
-	state     state
+	inputs         []Pipeline
+	maxConcurrency int
+
+	inputStates []InputState
+	mu          sync.RWMutex // protect input state changes
+
+	resultCh chan workerResult
+	inputCh  chan int // inputs to process
+
+	ctx        context.Context    // context for worker goroutines
+	cancelFunc context.CancelFunc // cancel function to stop workers
+	wg         sync.WaitGroup
+
+	initialized bool
+	state       state
 }
 
 var _ Pipeline = (*Merge)(nil)
 
-func NewMergePipeline(inputs []Pipeline) (*Merge, error) {
+// newMergePipeline creates a new merge pipeline that merges N inputs into a single output.
+// maxConcurrency controls how many inputs are processed simultaneously.
+// Set maxConcurrency to 0 or negative for full parallelism (one goroutine per input).
+// Set maxConcurrency to 1 for sequential processing.
+func newMergePipeline(inputs []Pipeline, maxConcurrency int) (*Merge, error) {
 	if len(inputs) == 0 {
-		return nil, fmt.Errorf("no inputs provided for merge pipeline")
+		return nil, fmt.Errorf("merge pipeline: no inputs provided")
 	}
 
-	for i := range inputs {
-		inputs[i] = newPrefetchingPipeline(inputs[i])
+	// default to number of inputs if maxConcurrency is 0 or negative.
+	if maxConcurrency <= 0 || maxConcurrency > len(inputs) {
+		maxConcurrency = len(inputs)
 	}
 
 	return &Merge{
-		inputs:    inputs,
-		exhausted: make([]bool, len(inputs)),
+		inputs:         inputs,
+		maxConcurrency: maxConcurrency,
+		inputStates:    make([]InputState, len(inputs)),
 	}, nil
 }
 
-// Read reads the next value into its state.
-// It returns an error if reading fails or when the pipeline is exhausted.
+func (m *Merge) init(ctx context.Context) {
+	if m.initialized {
+		return
+	}
+
+	m.ctx, m.cancelFunc = context.WithCancel(ctx)
+
+	// Buffer size equals maxConcurrency to ensure workers can send results without blocking
+	// while maintaining backpressure: when buffer is full, workers block on send until
+	// parent consumes results.
+	m.resultCh = make(chan workerResult, m.maxConcurrency)
+
+	m.inputCh = make(chan int, len(m.inputs))
+	for i := range m.inputs {
+		m.inputCh <- i // fill the pool with input indices
+	}
+	for range m.maxConcurrency {
+		m.wg.Add(1)
+		go m.inputWorker()
+	}
+
+	m.initialized = true
+}
+
+// inputWorker processes inputs from the available pool
+func (m *Merge) inputWorker() {
+	defer m.wg.Done()
+
+	for {
+		select {
+		case <-m.ctx.Done():
+			return
+		case inputIdx, ok := <-m.inputCh:
+			if !ok {
+				return // channel closed, normal shutdown
+			}
+			m.processInput(inputIdx)
+		}
+	}
+}
+
+// processInput completely exhausts a single input pipeline
+func (m *Merge) processInput(inputIdx int) {
+	m.updateInputState(inputIdx, InputInProgress)
+
+	input := newPrefetchingPipeline(m.inputs[inputIdx])
+	defer input.Close()
+
+	for {
+		if m.ctx.Err() != nil {
+			return
+		}
+
+		var result workerResult
+		err := input.Read(m.ctx)
+
+		record, _ := input.Value()
+		result = workerResult{
+			record:   record,
+			err:      err,
+			inputIdx: inputIdx,
+		}
+
+		select {
+		case m.resultCh <- result:
+			// sent successfully
+		case <-m.ctx.Done():
+			if result.record != nil {
+				result.record.Release()
+			}
+			return
+		}
+
+		// Irrespective of the error, we return here to avoid further Reads.
+		if err != nil {
+			return
+		}
+	}
+}
+
+// updateInputState safely updates the state of an input
+func (m *Merge) updateInputState(inputIdx int, state InputState) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.inputStates[inputIdx] = state
+}
+
+// allInputsCompleted checks if all inputs have finished processing
+func (m *Merge) allInputsCompleted() bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	for _, state := range m.inputStates {
+		if state != InputCompleted {
+			return false
+		}
+	}
+	return true
+}
+
+// Read reads the next value into its state from any of the parallel inputs.
 func (m *Merge) Read(ctx context.Context) error {
 	if m.state.err != nil {
 		return m.state.err
 	}
 
-	record, err := m.read(ctx)
-	m.state = newState(record, err)
+	m.init(ctx)
 
-	if err != nil {
-		return fmt.Errorf("run merge: %w", err)
-	}
-
-	return nil
-}
-
-func (m *Merge) read(ctx context.Context) (arrow.Record, error) {
-	if !slices.Contains(m.exhausted, false) {
-		return nil, EOF
-	}
-
-	for i, input := range m.inputs {
-		if m.exhausted[i] {
-			continue
-		}
-
-		if err := input.Read(ctx); err != nil {
-			if errors.Is(err, EOF) {
-				input.Close()
-				m.exhausted[i] = true
+	for {
+		select {
+		case <-ctx.Done():
+			m.state = newState(nil, ctx.Err())
+			return fmt.Errorf("run merge: %w", m.state.err)
+		case result := <-m.resultCh:
+			if m.state.err != nil {
+				// ignore results if we already have an error in state
+				// next set of errors could also be a result of work cancellation from calling m.cancelFunc()
 				continue
 			}
 
-			return nil, err
+			if result.err != nil {
+				if errors.Is(result.err, EOF) {
+					m.updateInputState(result.inputIdx, InputCompleted)
+					if m.allInputsCompleted() {
+						m.state = Exhausted
+						return fmt.Errorf("run merge: %w", m.state.err)
+					}
+
+					continue // continue with next input
+				}
+
+				// non EOF error, stop all work.
+				m.cancelFunc()
+			}
+
+			// We got a data record
+			m.state = newState(result.record, result.err)
+			if m.state.err != nil {
+				return fmt.Errorf("run merge: %w", m.state.err)
+			}
+
+			return nil
 		}
-
-		// not updating reference counts as this pipeline is not consuming
-		// the record.
-		return input.Value()
 	}
-
-	// return EOF if none of the inputs returned a record.
-	return nil, EOF
 }
 
-// Close implements Pipeline.
+// Value returns the current value in state.
+func (m *Merge) Value() (arrow.Record, error) {
+	return m.state.Value()
+}
+
+// Close closes all resources and stops all worker goroutines.
 func (m *Merge) Close() {
-	for i, input := range m.inputs {
-		// exhausted inputs are already closed
-		if !m.exhausted[i] {
-			input.Close()
+	// close the input channel to avoid workers from picking work.
+	if m.inputCh != nil {
+		close(m.inputCh)
+	}
+
+	// stop in-progress work
+	if m.cancelFunc != nil {
+		m.cancelFunc()
+	}
+
+	m.wg.Wait()
+
+	if m.resultCh != nil {
+		// Drain any remaining records and release them
+		for {
+			select {
+			case result := <-m.resultCh:
+				if result.record != nil {
+					result.record.Release()
+				}
+			default:
+				goto done
+			}
 		}
+	done:
+		close(m.resultCh)
+	}
+
+	for _, input := range m.inputs {
+		input.Close()
 	}
 }
 
-// Inputs implements Pipeline.
+// Inputs returns the inputs of the pipeline.
 func (m *Merge) Inputs() []Pipeline {
 	return m.inputs
 }
 
-// Transport implements Pipeline.
+// Transport returns the type of transport of the implementation.
 func (m *Merge) Transport() Transport {
 	return Local
-}
-
-// Value implements Pipeline.
-func (m *Merge) Value() (arrow.Record, error) {
-	return m.state.Value()
 }

--- a/pkg/engine/executor/merge_test.go
+++ b/pkg/engine/executor/merge_test.go
@@ -133,7 +133,7 @@ func TestMerge_concurrency(t *testing.T) {
 			recordRows := make(arrowtest.Rows, numRows)
 
 			for k := range numRows {
-				recordRows[k] = map[string]interface{}{
+				recordRows[k] = map[string]any{
 					"ts":  int64(i*100 + j*10 + k),
 					"msg": fmt.Sprintf("%s_row_%d", recordID, k),
 				}

--- a/pkg/engine/executor/merge_test.go
+++ b/pkg/engine/executor/merge_test.go
@@ -2,9 +2,12 @@ package executor
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"testing"
 	"time"
 
+	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/stretchr/testify/require"
 
@@ -72,12 +75,13 @@ func TestMerge(t *testing.T) {
 		pipelineB = NewArrowtestPipeline(alloc, schema, rowsInput2...)
 	)
 
-	m, err := NewMergePipeline([]Pipeline{pipelineA, pipelineB})
+	m, err := newMergePipeline([]Pipeline{pipelineA, pipelineB}, 1)
 	require.NoError(t, err)
 
 	var got []arrowtest.Rows
+	ctx := context.Background()
 	for {
-		err = m.Read(context.Background())
+		err = m.Read(ctx)
 		if err != nil {
 			break
 		}
@@ -94,4 +98,89 @@ func TestMerge(t *testing.T) {
 	require.ErrorIs(t, err, EOF)
 
 	require.Equal(t, append(rowsInput1, rowsInput2...), got)
+}
+
+func TestMerge_concurrency(t *testing.T) {
+	alloc := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer alloc.AssertSize(t, 0)
+
+	schema := arrow.NewSchema([]arrow.Field{
+		{
+			Name:     "ts",
+			Type:     arrow.PrimitiveTypes.Int64,
+			Nullable: true,
+		},
+		{
+			Name:     "msg",
+			Type:     arrow.BinaryTypes.String,
+			Nullable: true,
+		},
+	}, nil)
+
+	pipelineInputs := make([][]arrowtest.Rows, 10)
+	var expectedRows []arrowtest.Rows
+
+	// create records for each input pipeline
+	for i := range len(pipelineInputs) {
+		// Each pipeline has 2-4 records with unique identifiers
+		numRecords := 2 + (i % 3) // 2, 3, or 4 records per pipeline
+		rows := make([]arrowtest.Rows, numRecords)
+
+		for j := range numRecords {
+			recordID := fmt.Sprintf("pipeline_%d_record_%d", i, j)
+			// Each record has 3-5 rows
+			numRows := 3 + (j % 3) // 3, 4, or 5 rows per record
+			recordRows := make(arrowtest.Rows, numRows)
+
+			for k := range numRows {
+				recordRows[k] = map[string]interface{}{
+					"ts":  int64(i*100 + j*10 + k),
+					"msg": fmt.Sprintf("%s_row_%d", recordID, k),
+				}
+			}
+			rows[j] = recordRows
+		}
+
+		// Accumulate expected rows
+		expectedRows = append(expectedRows, rows...)
+		pipelineInputs[i] = rows
+	}
+
+	// Test different concurrency settings
+	for _, maxConcurrency := range []int{1, 3, 5, 10} {
+		t.Run(fmt.Sprintf("concurrency=%d", maxConcurrency), func(t *testing.T) {
+			// Create fresh pipelines using the pre-generated data
+			pipelines := make([]Pipeline, 10)
+			for i := range len(pipelines) {
+				pipelines[i] = NewArrowtestPipeline(alloc, schema, pipelineInputs[i]...)
+			}
+
+			m, err := newMergePipeline(pipelines, maxConcurrency)
+			require.NoError(t, err)
+			defer m.Close()
+
+			ctx := context.Background()
+			var actualRows []arrowtest.Rows
+
+			// Read all records from the merge pipeline
+			for {
+				err := m.Read(ctx)
+				if errors.Is(err, EOF) {
+					break
+				}
+				require.NoError(t, err, "Unexpected error during read")
+
+				rec, _ := m.Value()
+				defer rec.Release()
+
+				rows, err := arrowtest.RecordRows(rec)
+				require.NoError(t, err)
+
+				actualRows = append(actualRows, rows)
+			}
+
+			// Compare actual vs expected rows
+			require.ElementsMatch(t, expectedRows, actualRows)
+		})
+	}
 }

--- a/pkg/logql/engine.go
+++ b/pkg/logql/engine.go
@@ -168,6 +168,9 @@ type EngineOpts struct {
 	// Batch size of the v2 execution engine.
 	BatchSize int `yaml:"batch_size" category:"experimental"`
 
+	// PipelineConcurreny controls the number of inputs processed simultaneously by the pipeline operators.
+	PipelineConcurreny int `yaml:"pipeline_concurrency" category:"experimental"`
+
 	// DataobjScanPageCacheSize determines how many bytes of future page data
 	// should be downloaded before it's immediately needed. Used to reduce the
 	// number of roundtrips to object storage. Setting to zero disables
@@ -185,6 +188,7 @@ func (opts *EngineOpts) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) 
 	f.BoolVar(&opts.EnableV2Engine, prefix+"enable-v2-engine", false, "Experimental: Enable next generation query engine for supported queries.")
 	f.IntVar(&opts.BatchSize, prefix+"batch-size", 100, "Experimental: Batch size of the next generation query engine.")
 	f.Var(&opts.DataobjScanPageCacheSize, prefix+"dataobjscan-page-cache-size", "Experimental: Maximum total size of future pages for DataObjScan to download before they are needed, for roundtrip reduction to object storage. Setting to zero disables downloading future pages. Only used in the next generation query engine.")
+	f.IntVar(&opts.PipelineConcurreny, prefix+"pipeline-concurrency", 4, "Experimental: The number of inputs processed simultaneously by the pipeline operators.")
 
 	// Log executing query by default
 	opts.LogExecutingQuery = true


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds support for merge node to be able to process from inputs concurrently. `maxConcurrency` controls how many inputs are processed simultaneously. It also controls the number of open prefetch Pipelines to allow all of these inputs to load the next record in parallel.

The gains from this would be limited by how fast the parent node is able to consume from merge. If the parent is slow to consume, the back pressure would slow down the parallel workers.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
