### PR TITLE
chore(querytee): Fix flaky proxy endpoint test panic

### DIFF
--- a/tools/querytee/proxy_endpoint_test.go
+++ b/tools/querytee/proxy_endpoint_test.go
@@ -335,7 +335,7 @@ func Test_ProxyEndpoint_SummaryMetrics(t *testing.T) {
 			require.Equal(t, uint64(tc.counts), requestCount.Load())
 
 			require.Eventually(t, func() bool {
-				return prom_testutil.ToFloat64(proxyMetrics.responsesComparedTotal) == 1
+				return prom_testutil.CollectAndCount(proxyMetrics.responsesComparedTotal) == 1
 			}, 2*time.Second, 100*time.Millisecond, "expect exactly 1 response to be compared.")
 			err := prom_testutil.CollectAndCompare(proxyMetrics.missingMetrics, strings.NewReader(tc.expectedMetrics))
 			require.NoError(t, err)


### PR DESCRIPTION
**What this PR does / why we need it**:

- What: Deflake Test_ProxyEndpoint_SummaryMetrics in tools/querytee.
- Why: prom_testutil.ToFloat64 panics when a CounterVec has 0 children, causing sporadic failures
(“collected 0 metrics instead of exactly 1”).
- How: Replace the assertion with require.Eventually(...
prom_testutil.CollectAndCount(proxyMetrics.responsesComparedTotal) == 1 ...) so we wait for the metric
without panicking.

```
Run gotestsum -- -tags=assert -covermode=atomic -coverprofile=coverage.txt -p=4 ./${MATRIX_PACKAGE}/...
✖  tools/querytee (430ms)
✓  tools/querytee/goldfish (826ms) (coverage: 55.3% of statements)

=== Failed
=== FAIL: tools/querytee Test_ProxyEndpoint_SummaryMetrics (unknown)
panic: collected 0 metrics instead of exactly 1

goroutine 189 [running]:
github.com/prometheus/client_golang/prometheus/testutil.ToFloat64({0x1a0e7e8, 0xc000016640})
	/__w/loki/loki/release/vendor/github.com/prometheus/client_golang/prometheus/testutil/testutil.go:102 +0x293
github.com/grafana/loki/v3/tools/querytee.Test_ProxyEndpoint_SummaryMetrics.func3.2()
	/__w/loki/loki/release/tools/querytee/proxy_endpoint_test.go:338 +0x25
github.com/stretchr/testify/assert.Eventually.func1()
	/__w/loki/loki/release/vendor/github.com/stretchr/testify/assert/assertions.go:1994 +0x23
created by github.com/stretchr/testify/assert.Eventually in goroutine 207
	/__w/loki/loki/release/vendor/github.com/stretchr/testify/assert/assertions.go:2005 +0x193

=== FAIL: tools/querytee Test_ProxyEndpoint_SummaryMetrics/missing-metrics-series (unknown)
panic: collected 0 metrics instead of exactly 1

goroutine 189 [running]:
github.com/prometheus/client_golang/prometheus/testutil.ToFloat64({0x1a0e7e8, 0xc000016640})
	/__w/loki/loki/release/vendor/github.com/prometheus/client_golang/prometheus/testutil/testutil.go:102 +0x293
github.com/grafana/loki/v3/tools/querytee.Test_ProxyEndpoint_SummaryMetrics.func3.2()
	/__w/loki/loki/release/tools/querytee/proxy_endpoint_test.go:338 +0x25
github.com/stretchr/testify/assert.Eventually.func1()
	/__w/loki/loki/release/vendor/github.com/stretchr/testify/assert/assertions.go:1994 +0x23
created by github.com/stretchr/testify/assert.Eventually in goroutine 207
	/__w/loki/loki/release/vendor/github.com/stretchr/testify/assert/assertions.go:2005 +0x193

DONE 90 tests, 2 failures in 75.866s
Error: Process completed with exit code 1.
```

[e.g.](https://github.com/grafana/loki/actions/runs/17222824758/job/48861664988?pr=19009)

After:

```shell
$ go test -tags=assert ./tools/querytee -run Test_ProxyEndpoint_SummaryMetrics -count=200
ok      github.com/grafana/loki/v3/tools/querytee       3.569s
```

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
