### PR TITLE
feat(goldfish): Improve SQL query performance for Goldfish UI

### DIFF
--- a/pkg/goldfish/migrations/20250807000001_add_filter_indexes.sql
+++ b/pkg/goldfish/migrations/20250807000001_add_filter_indexes.sql
@@ -1,0 +1,15 @@
+-- +goose Up
+-- Add composite indexes aligned with common Goldfish filters and sort
+
+-- Optimize queries filtering by tenant and ordering by sampled_at DESC
+CREATE INDEX idx_sampled_queries_tenant_sampled_at ON sampled_queries(tenant_id, sampled_at DESC, correlation_id);
+
+-- Optimize queries filtering by user and ordering by sampled_at DESC
+CREATE INDEX idx_sampled_queries_user_sampled_at ON sampled_queries(user, sampled_at DESC, correlation_id);
+
+-- +goose Down
+-- Remove composite indexes
+
+DROP INDEX idx_sampled_queries_user_sampled_at ON sampled_queries;
+DROP INDEX idx_sampled_queries_tenant_sampled_at ON sampled_queries;
+


### PR DESCRIPTION
**What this PR does / why we need it**:

The Goldfish UI suffers from poor performance currently; these changes optimize critical SQL queries to allow for a snappier UI experience.

#### What Changed

- Query rewrites: Removed subquery+HAVING and computed CASE from both COUNT and list queries. Outcome
filtering now happens in WHERE; JOIN is skipped entirely for outcome=all.
- Conditional JOIN: LEFT JOIN on comparison_outcomes only when an outcome filter is requested.
- Conditional index hint: FORCE INDEX (idx_sampled_queries_sampled_at_desc) only applied when no tenant/user
filters are present.
- Result set: Dropped computed comparison_status from SELECT; UI continues deriving status from codes/
hashes.
- Indexes (migration): Added idx_sampled_queries_tenant_sampled_at (tenant_id, sampled_at DESC,
correlation_id) and idx_sampled_queries_user_sampled_at (user, sampled_at DESC, correlation_id).

#### Why It’s Faster

- Remove materialization: Eliminates subquery+HAVING over millions of rows; no CASE eval just to COUNT.
- Less work per query: Avoids unnecessary JOINs for the common “all outcomes” view; reduces rows and columns
scanned.
- Better index usage: WHERE-based outcome filters + composite indexes enable selective scans and ordered
retrieval.
- Planner-friendly: Conditional FORCE INDEX lets MySQL pick tenant/user indexes when filters exist.

#### Benefits

- Lower latency and CPU: Significant reduction in scanned rows and intermediate sets.
- Predictable pagination: ORDER BY on an indexed key; ready for optional keyset pagination if needed later.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

N/A

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
