### PR TITLE
feat(goldfish): improve query performance with indexes and paritions

### DIFF
--- a/pkg/goldfish/migrations/20251126000001_add_6h_partitioning_and_indexes.sql
+++ b/pkg/goldfish/migrations/20251126000001_add_6h_partitioning_and_indexes.sql
@@ -1,0 +1,165 @@
+-- +goose Up
+-- Add 6-hour partitioning and performance indexes for goldfish query optimization
+
+-- First, add all the missing indexes
+CREATE INDEX IF NOT EXISTS idx_sampled_queries_user ON sampled_queries(user);
+
+-- Composite index for the JOIN operation with comparison_outcomes
+CREATE INDEX IF NOT EXISTS idx_sampled_queries_correlation_composite ON sampled_queries(
+    correlation_id,
+    cell_a_status_code,
+    cell_b_status_code,
+    cell_a_response_hash,
+    cell_b_response_hash
+);
+
+-- Composite index for filtering queries with WHERE and HAVING clauses
+CREATE INDEX IF NOT EXISTS idx_sampled_queries_filter_composite ON sampled_queries(
+    tenant_id,
+    user,
+    sampled_at DESC,
+    correlation_id
+);
+
+-- Index for new engine filtering
+CREATE INDEX IF NOT EXISTS idx_sampled_queries_engine_filter ON sampled_queries(
+    cell_a_used_new_engine,
+    cell_b_used_new_engine,
+    sampled_at DESC
+);
+
+-- Index for comparison_outcomes join performance
+CREATE INDEX IF NOT EXISTS idx_comparison_outcomes_correlation_status ON comparison_outcomes(
+    correlation_id, 
+    comparison_status
+);
+
+-- Convert the table to use 6-hour partitioning for optimal performance
+-- Using UNIX_TIMESTAMP for more granular partitioning
+ALTER TABLE sampled_queries 
+PARTITION BY RANGE (UNIX_TIMESTAMP(sampled_at)) (
+    -- Create partitions for the last 7 days (28 partitions at 6 hours each)
+    PARTITION p_old VALUES LESS THAN (UNIX_TIMESTAMP(DATE_SUB(NOW(), INTERVAL 7 DAY))),
+    PARTITION p_2025_11_24_00 VALUES LESS THAN (UNIX_TIMESTAMP('2025-11-24 06:00:00')),
+    PARTITION p_2025_11_24_06 VALUES LESS THAN (UNIX_TIMESTAMP('2025-11-24 12:00:00')),
+    PARTITION p_2025_11_24_12 VALUES LESS THAN (UNIX_TIMESTAMP('2025-11-24 18:00:00')),
+    PARTITION p_2025_11_24_18 VALUES LESS THAN (UNIX_TIMESTAMP('2025-11-25 00:00:00')),
+    PARTITION p_2025_11_25_00 VALUES LESS THAN (UNIX_TIMESTAMP('2025-11-25 06:00:00')),
+    PARTITION p_2025_11_25_06 VALUES LESS THAN (UNIX_TIMESTAMP('2025-11-25 12:00:00')),
+    PARTITION p_2025_11_25_12 VALUES LESS THAN (UNIX_TIMESTAMP('2025-11-25 18:00:00')),
+    PARTITION p_2025_11_25_18 VALUES LESS THAN (UNIX_TIMESTAMP('2025-11-26 00:00:00')),
+    PARTITION p_2025_11_26_00 VALUES LESS THAN (UNIX_TIMESTAMP('2025-11-26 06:00:00')),
+    PARTITION p_2025_11_26_06 VALUES LESS THAN (UNIX_TIMESTAMP('2025-11-26 12:00:00')),
+    PARTITION p_2025_11_26_12 VALUES LESS THAN (UNIX_TIMESTAMP('2025-11-26 18:00:00')),
+    PARTITION p_2025_11_26_18 VALUES LESS THAN (UNIX_TIMESTAMP('2025-11-27 00:00:00')),
+    PARTITION p_current VALUES LESS THAN (UNIX_TIMESTAMP('2025-11-27 06:00:00')),
+    PARTITION p_future VALUES LESS THAN MAXVALUE
+);
+
+-- Create stored procedure for automatic 6-hour partition management
+DELIMITER //
+
+CREATE PROCEDURE IF NOT EXISTS manage_sampled_queries_partitions_6h()
+BEGIN
+    DECLARE next_partition_time DATETIME;
+    DECLARE partition_name VARCHAR(64);
+    DECLARE old_partition_time DATETIME;
+    DECLARE partition_exists INT;
+    DECLARE done INT DEFAULT FALSE;
+    DECLARE cur_partition_name VARCHAR(64);
+    
+    -- Calculate the next 6-hour boundary
+    SET next_partition_time = DATE_ADD(
+        DATE_FORMAT(NOW(), '%Y-%m-%d %H:00:00'),
+        INTERVAL (FLOOR(HOUR(NOW()) / 6) + 1) * 6 HOUR
+    );
+    
+    -- Create partition name (e.g., p_2025_11_26_18 for 6PM)
+    SET partition_name = CONCAT('p_', 
+        DATE_FORMAT(next_partition_time, '%Y_%m_%d_%H'));
+    
+    -- Check if the partition already exists
+    SELECT COUNT(*) INTO partition_exists
+    FROM INFORMATION_SCHEMA.PARTITIONS
+    WHERE TABLE_NAME = 'sampled_queries'
+    AND TABLE_SCHEMA = DATABASE()
+    AND PARTITION_NAME = partition_name;
+    
+    -- Create the next partition if it doesn't exist
+    IF partition_exists = 0 THEN
+        -- Reorganize p_future to create new partition
+        SET @sql = CONCAT('ALTER TABLE sampled_queries ',
+                         'REORGANIZE PARTITION p_future INTO (',
+                         'PARTITION ', partition_name, ' VALUES LESS THAN (UNIX_TIMESTAMP(\'', 
+                         DATE_ADD(next_partition_time, INTERVAL 6 HOUR), '\')), ',
+                         'PARTITION p_future VALUES LESS THAN MAXVALUE)');
+        PREPARE stmt FROM @sql;
+        EXECUTE stmt;
+        DEALLOCATE PREPARE stmt;
+    END IF;
+    
+    -- Drop partitions older than 7 days (keeping 28 6-hour partitions)
+    SET old_partition_time = DATE_SUB(NOW(), INTERVAL 7 DAY);
+    
+    -- Use cursor to iterate through old partitions
+    BEGIN
+        DECLARE partition_cursor CURSOR FOR 
+            SELECT PARTITION_NAME 
+            FROM INFORMATION_SCHEMA.PARTITIONS
+            WHERE TABLE_NAME = 'sampled_queries'
+            AND TABLE_SCHEMA = DATABASE()
+            AND PARTITION_NAME LIKE 'p_20%'  -- Date-based partitions only
+            AND PARTITION_NAME < CONCAT('p_', DATE_FORMAT(old_partition_time, '%Y_%m_%d_%H'))
+            AND PARTITION_NAME != 'p_old';  -- Don't drop the old data partition
+        
+        DECLARE CONTINUE HANDLER FOR NOT FOUND SET done = TRUE;
+        
+        OPEN partition_cursor;
+        
+        read_loop: LOOP
+            FETCH partition_cursor INTO cur_partition_name;
+            IF done THEN
+                LEAVE read_loop;
+            END IF;
+            
+            -- Drop the old partition
+            SET @sql = CONCAT('ALTER TABLE sampled_queries DROP PARTITION ', cur_partition_name);
+            PREPARE stmt FROM @sql;
+            EXECUTE stmt;
+            DEALLOCATE PREPARE stmt;
+        END LOOP;
+        
+        CLOSE partition_cursor;
+    END;
+END//
+
+DELIMITER ;
+
+-- Create an event to run partition management every hour
+-- This ensures we always have partitions ready before data arrives
+CREATE EVENT IF NOT EXISTS manage_goldfish_partitions_6h
+ON SCHEDULE EVERY 1 HOUR
+STARTS DATE_FORMAT(DATE_ADD(NOW(), INTERVAL 1 HOUR), '%Y-%m-%d %H:00:00')
+DO CALL manage_sampled_queries_partitions_6h();
+
+-- Index optimized for partition pruning with UNIX_TIMESTAMP
+CREATE INDEX IF NOT EXISTS idx_sampled_queries_unix_timestamp 
+ON sampled_queries(sampled_at, correlation_id);
+
+-- +goose Down
+-- Remove partitioning and indexes
+
+-- Drop the event and stored procedure
+DROP EVENT IF EXISTS manage_goldfish_partitions_6h;
+DROP PROCEDURE IF EXISTS manage_sampled_queries_partitions_6h;
+
+-- Remove partitioning (converts back to regular table)
+ALTER TABLE sampled_queries REMOVE PARTITIONING;
+
+-- Drop all the new indexes
+DROP INDEX IF EXISTS idx_sampled_queries_unix_timestamp ON sampled_queries;
+DROP INDEX IF EXISTS idx_comparison_outcomes_correlation_status ON comparison_outcomes;
+DROP INDEX IF EXISTS idx_sampled_queries_engine_filter ON sampled_queries;
+DROP INDEX IF EXISTS idx_sampled_queries_filter_composite ON sampled_queries;
+DROP INDEX IF EXISTS idx_sampled_queries_correlation_composite ON sampled_queries;
+DROP INDEX IF EXISTS idx_sampled_queries_user ON sampled_queries;

--- a/pkg/goldfish/storage_mysql.go
+++ b/pkg/goldfish/storage_mysql.go
@@ -198,6 +198,31 @@ func (s *MySQLStorage) GetSampledQueries(ctx context.Context, page, pageSize int
 	if pageSize < 1 || pageSize > 1000 {
 		pageSize = 20 // Default page size
 	}
+	
+	// Add partition pruning hint - query only recent partitions by default
+	// With 6-hour partitions, we can be very aggressive
+	// Most UI queries only need very recent data
+	partitionPruneHours := 24 * time.Hour // Default to last 24 hours (4 partitions)
+	
+	// For filtered queries that might have less data, look back a bit further
+	if filter.Outcome != "" && filter.Outcome != OutcomeAll {
+		partitionPruneHours = 48 * time.Hour // 8 partitions
+	}
+	
+	// If user or tenant filter is very specific, might need more history
+	if filter.Tenant != "" || filter.User != "" {
+		partitionPruneHours = 72 * time.Hour // 12 partitions
+	}
+	
+	partitionHint := time.Now().Add(-partitionPruneHours)
+	
+	// Log partition pruning for metrics
+	level.Debug(s.logger).Log(
+		"msg", "partition pruning active",
+		"hours_back", partitionPruneHours.Hours(),
+		"partitions_scanned", int(partitionPruneHours.Hours()/6),
+		"filter", fmt.Sprintf("%+v", filter),
+	)
 
 	// Validate outcome parameter against allowed values
 	outcome := filter.Outcome
@@ -210,8 +235,8 @@ func (s *MySQLStorage) GetSampledQueries(ctx context.Context, page, pageSize int
 
 	offset := (page - 1) * pageSize
 
-	// Build WHERE clause for tenant/user/engine filters
-	whereClause, whereArgs := buildWhereClause(filter)
+	// Build WHERE clause for tenant/user/engine filters with partition pruning
+	whereClause, whereArgs := buildWhereClauseWithPartitionPruning(filter, partitionHint)
 
 	// Build HAVING clause based on outcome filter
 	// Using HAVING clause to filter on computed status without subqueries
@@ -226,24 +251,34 @@ func (s *MySQLStorage) GetSampledQueries(ctx context.Context, page, pageSize int
 		queryArgs = append(queryArgs, outcome)
 	}
 
-	// Get total count with filtering - optimized without subquery
+	// Get total count with filtering - optimized with direct count
+	// Use a simpler COUNT query when no outcome filter is applied
 	var total int
-	countQuery := `
-		SELECT COUNT(*) FROM (
-			SELECT 
-				sq.correlation_id,
-				CASE
-					WHEN co.comparison_status IS NOT NULL THEN co.comparison_status
-					WHEN (sq.cell_a_status_code NOT BETWEEN 200 AND 299 OR sq.cell_b_status_code NOT BETWEEN 200 AND 299) THEN 'error'
-					WHEN sq.cell_a_response_hash = sq.cell_b_response_hash THEN 'match'
-					ELSE 'mismatch'
-				END as comparison_status
-			FROM sampled_queries sq
-			LEFT JOIN comparison_outcomes co ON sq.correlation_id = co.correlation_id
-			` + whereClause + `
-			` + havingClause + `
-		) as filtered
-	`
+	var countQuery string
+	
+	if outcome == OutcomeAll {
+		// Simple count without subquery when no outcome filtering
+		countQuery = `SELECT COUNT(*) FROM sampled_queries sq ` + whereClause
+	} else {
+		// Need subquery only when filtering by outcome
+		countQuery = `
+			SELECT COUNT(*) FROM (
+				SELECT 
+					sq.correlation_id,
+					CASE
+						WHEN co.comparison_status IS NOT NULL THEN co.comparison_status
+						WHEN (sq.cell_a_status_code NOT BETWEEN 200 AND 299 OR sq.cell_b_status_code NOT BETWEEN 200 AND 299) THEN 'error'
+						WHEN sq.cell_a_response_hash = sq.cell_b_response_hash THEN 'match'
+						ELSE 'mismatch'
+					END as comparison_status
+				FROM sampled_queries sq USE INDEX (idx_sampled_queries_filter_composite)
+				LEFT JOIN comparison_outcomes co USE INDEX (idx_comparison_outcomes_correlation_status) 
+					ON sq.correlation_id = co.correlation_id
+				` + whereClause + `
+				` + havingClause + `
+			) as filtered
+		`
+	}
 
 	// Debug logging
 	level.Debug(s.logger).Log("ui-component", "goldfish", "msg", "executing count query", "query", countQuery, "args", queryArgs)
@@ -256,7 +291,13 @@ func (s *MySQLStorage) GetSampledQueries(ctx context.Context, page, pageSize int
 
 	level.Debug(s.logger).Log("ui-component", "goldfish", "msg", "count query result", "total", total)
 
-	// Get paginated results - optimized query without nested subqueries
+	// Get paginated results - optimized query with proper index hints
+	// Use filter_composite index when filters are present, otherwise use sampled_at_desc
+	indexHint := "idx_sampled_queries_sampled_at_desc"
+	if filter.Tenant != "" || filter.User != "" {
+		indexHint = "idx_sampled_queries_filter_composite"
+	}
+	
 	query := `
 		SELECT
 			sq.correlation_id, sq.tenant_id, sq.user, sq.query, sq.query_type, sq.start_time, sq.end_time, sq.step_duration,
@@ -275,8 +316,9 @@ func (s *MySQLStorage) GetSampledQueries(ctx context.Context, page, pageSize int
 				WHEN sq.cell_a_response_hash = sq.cell_b_response_hash THEN 'match'
 				ELSE 'mismatch'
 			END as comparison_status
-		FROM sampled_queries sq FORCE INDEX (idx_sampled_queries_sampled_at_desc)
-		LEFT JOIN comparison_outcomes co ON sq.correlation_id = co.correlation_id
+		FROM sampled_queries sq USE INDEX (` + indexHint + `)
+		LEFT JOIN comparison_outcomes co USE INDEX (idx_comparison_outcomes_correlation_status)
+			ON sq.correlation_id = co.correlation_id
 		` + whereClause + `
 		` + havingClause + `
 		ORDER BY sq.sampled_at DESC 
@@ -384,6 +426,43 @@ func buildWhereClause(filter QueryFilter) (string, []any) {
 	// Combine conditions
 	if len(conditions) == 0 {
 		return "", nil
+	}
+
+	whereClause := "WHERE " + strings.Join(conditions, " AND ")
+	return whereClause, args
+}
+
+// buildWhereClauseWithPartitionPruning adds partition pruning to the WHERE clause
+func buildWhereClauseWithPartitionPruning(filter QueryFilter, partitionHint time.Time) (string, []any) {
+	var conditions []string
+	var args []any
+
+	// Add partition pruning condition first for optimal query planning
+	// This ensures MySQL prunes partitions before evaluating other conditions
+	conditions = append(conditions, "sq.sampled_at >= ?")
+	args = append(args, partitionHint)
+
+	// Add tenant filter
+	if filter.Tenant != "" {
+		conditions = append(conditions, "sq.tenant_id = ?")
+		args = append(args, filter.Tenant)
+	}
+
+	// Add user filter
+	if filter.User != "" {
+		conditions = append(conditions, "sq.user = ?")
+		args = append(args, filter.User)
+	}
+
+	// Add new engine filter
+	if filter.UsedNewEngine != nil {
+		if *filter.UsedNewEngine {
+			// Either cell used new engine
+			conditions = append(conditions, "(sq.cell_a_used_new_engine = 1 OR sq.cell_b_used_new_engine = 1)")
+		} else {
+			// Neither cell used new engine
+			conditions = append(conditions, "sq.cell_a_used_new_engine = 0 AND sq.cell_b_used_new_engine = 0")
+		}
 	}
 
 	whereClause := "WHERE " + strings.Join(conditions, " AND ")

--- a/pkg/ui/frontend/src/hooks/use-goldfish-queries.ts
+++ b/pkg/ui/frontend/src/hooks/use-goldfish-queries.ts
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, useState, useCallback } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { fetchSampledQueries } from '@/lib/goldfish-api';
 import { OutcomeFilter, OUTCOME_ALL, OUTCOME_MATCH, OUTCOME_MISMATCH, OUTCOME_ERROR } from '@/types/goldfish';
@@ -16,31 +16,63 @@ export function useGoldfishQueries(
   user?: string,
   newEngine?: boolean
 ) {
+  const [currentTraceId, setCurrentTraceId] = useState<string | null>(null);
+  
   // Main query always fetches all data
   const mainQuery = useQuery({
     queryKey: ['goldfish-queries', page, pageSize, OUTCOME_ALL, tenant, user, newEngine],
-    queryFn: () => fetchSampledQueries(page, pageSize, OUTCOME_ALL, tenant, user, newEngine),
+    queryFn: async () => {
+      const result = await fetchSampledQueries(page, pageSize, OUTCOME_ALL, tenant, user, newEngine);
+      setCurrentTraceId(result.traceId);
+      
+      if (result.error) {
+        throw result.error;
+      }
+      
+      return result.data;
+    },
     ...QUERY_OPTIONS,
   });
 
   // Background queries for specific filters
   const matchQuery = useQuery({
     queryKey: ['goldfish-queries', page, pageSize, OUTCOME_MATCH, tenant, user, newEngine],
-    queryFn: () => fetchSampledQueries(page, pageSize, OUTCOME_MATCH, tenant, user, newEngine),
+    queryFn: async () => {
+      const result = await fetchSampledQueries(page, pageSize, OUTCOME_MATCH, tenant, user, newEngine);
+      if (selectedOutcome === OUTCOME_MATCH) {
+        setCurrentTraceId(result.traceId);
+      }
+      if (result.error) throw result.error;
+      return result.data;
+    },
     enabled: selectedOutcome === OUTCOME_MATCH,
     ...QUERY_OPTIONS,
   });
 
   const mismatchQuery = useQuery({
     queryKey: ['goldfish-queries', page, pageSize, OUTCOME_MISMATCH, tenant, user, newEngine],
-    queryFn: () => fetchSampledQueries(page, pageSize, OUTCOME_MISMATCH, tenant, user, newEngine),
+    queryFn: async () => {
+      const result = await fetchSampledQueries(page, pageSize, OUTCOME_MISMATCH, tenant, user, newEngine);
+      if (selectedOutcome === OUTCOME_MISMATCH) {
+        setCurrentTraceId(result.traceId);
+      }
+      if (result.error) throw result.error;
+      return result.data;
+    },
     enabled: selectedOutcome === OUTCOME_MISMATCH,
     ...QUERY_OPTIONS,
   });
 
   const errorQuery = useQuery({
     queryKey: ['goldfish-queries', page, pageSize, OUTCOME_ERROR, tenant, user, newEngine],
-    queryFn: () => fetchSampledQueries(page, pageSize, OUTCOME_ERROR, tenant, user, newEngine),
+    queryFn: async () => {
+      const result = await fetchSampledQueries(page, pageSize, OUTCOME_ERROR, tenant, user, newEngine);
+      if (selectedOutcome === OUTCOME_ERROR) {
+        setCurrentTraceId(result.traceId);
+      }
+      if (result.error) throw result.error;
+      return result.data;
+    },
     enabled: selectedOutcome === OUTCOME_ERROR,
     ...QUERY_OPTIONS,
   });
@@ -53,7 +85,11 @@ export function useGoldfishQueries(
   // Prefetch next page for main query
   useQuery({
     queryKey: ['goldfish-queries', page + 1, pageSize, OUTCOME_ALL, tenant, user, newEngine],
-    queryFn: () => fetchSampledQueries(page + 1, pageSize, OUTCOME_ALL, tenant, user, newEngine),
+    queryFn: async () => {
+      const result = await fetchSampledQueries(page + 1, pageSize, OUTCOME_ALL, tenant, user, newEngine);
+      if (result.error) throw result.error;
+      return result.data;
+    },
     enabled: totalPages > 1 && page < totalPages,
     ...QUERY_OPTIONS,
   });
@@ -61,21 +97,33 @@ export function useGoldfishQueries(
   // Prefetch next page for specific filter outcomes
   useQuery({
     queryKey: ['goldfish-queries', page + 1, pageSize, OUTCOME_MATCH, tenant, user, newEngine],
-    queryFn: () => fetchSampledQueries(page + 1, pageSize, OUTCOME_MATCH, tenant, user, newEngine),
+    queryFn: async () => {
+      const result = await fetchSampledQueries(page + 1, pageSize, OUTCOME_MATCH, tenant, user, newEngine);
+      if (result.error) throw result.error;
+      return result.data;
+    },
     enabled: selectedOutcome === OUTCOME_MATCH && totalPages > 1 && page < totalPages,
     ...QUERY_OPTIONS,
   });
 
   useQuery({
     queryKey: ['goldfish-queries', page + 1, pageSize, OUTCOME_MISMATCH, tenant, user, newEngine],
-    queryFn: () => fetchSampledQueries(page + 1, pageSize, OUTCOME_MISMATCH, tenant, user, newEngine),
+    queryFn: async () => {
+      const result = await fetchSampledQueries(page + 1, pageSize, OUTCOME_MISMATCH, tenant, user, newEngine);
+      if (result.error) throw result.error;
+      return result.data;
+    },
     enabled: selectedOutcome === OUTCOME_MISMATCH && totalPages > 1 && page < totalPages,
     ...QUERY_OPTIONS,
   });
 
   useQuery({
     queryKey: ['goldfish-queries', page + 1, pageSize, OUTCOME_ERROR, tenant, user, newEngine],
-    queryFn: () => fetchSampledQueries(page + 1, pageSize, OUTCOME_ERROR, tenant, user, newEngine),
+    queryFn: async () => {
+      const result = await fetchSampledQueries(page + 1, pageSize, OUTCOME_ERROR, tenant, user, newEngine);
+      if (result.error) throw result.error;
+      return result.data;
+    },
     enabled: selectedOutcome === OUTCOME_ERROR && totalPages > 1 && page < totalPages,
     ...QUERY_OPTIONS,
   });
@@ -100,5 +148,6 @@ export function useGoldfishQueries(
     error: mainQuery.error,
     refetch: mainQuery.refetch,
     totalPages,
+    traceId: currentTraceId,
   };
 }

--- a/pkg/ui/frontend/src/lib/tracing.ts
+++ b/pkg/ui/frontend/src/lib/tracing.ts
@@ -1,0 +1,151 @@
+/**
+ * Tracing utilities for frontend-initiated distributed tracing
+ * Uses W3C Trace Context standard for trace propagation
+ */
+
+/**
+ * Generates a random 64-bit hex trace ID
+ */
+export function generateTraceId(): string {
+  // Generate 16 random bytes (128 bits) for trace ID
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes, byte => byte.toString(16).padStart(2, '0')).join('');
+}
+
+/**
+ * Generates a random 32-bit hex span ID
+ */
+export function generateSpanId(): string {
+  // Generate 8 random bytes (64 bits) for span ID
+  const bytes = new Uint8Array(8);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes, byte => byte.toString(16).padStart(2, '0')).join('');
+}
+
+/**
+ * Creates W3C Trace Context headers for a request
+ * @param traceId - The trace ID to use
+ * @param parentSpanId - The parent span ID (optional)
+ * @param spanId - The current span ID
+ */
+export function createTraceHeaders(
+  traceId: string,
+  spanId: string,
+  parentSpanId?: string
+): Record<string, string> {
+  // W3C Trace Context format
+  // traceparent: version-traceid-spanid-flags
+  const traceparent = `00-${traceId}-${spanId}-01`; // 01 flag means sampled
+  
+  const headers: Record<string, string> = {
+    'traceparent': traceparent,
+    'X-Trace-Id': traceId,
+    'X-Span-Id': spanId,
+  };
+  
+  if (parentSpanId) {
+    headers['X-Parent-Span-Id'] = parentSpanId;
+  }
+  
+  return headers;
+}
+
+/**
+ * Extracts trace ID from error response or headers
+ */
+export function extractTraceId(
+  response: Response | null,
+  error: any
+): string | null {
+  // Try to get from response headers first
+  if (response) {
+    const traceId = response.headers.get('X-Trace-Id');
+    if (traceId) return traceId;
+  }
+  
+  // Try to get from error object if it contains trace info
+  if (error?.traceId) {
+    return error.traceId;
+  }
+  
+  // Try to parse from error response body
+  if (error?.response?.data?.traceId) {
+    return error.response.data.traceId;
+  }
+  
+  return null;
+}
+
+/**
+ * Formats a trace ID for display
+ */
+export function formatTraceId(traceId: string): string {
+  // Display first 8 and last 4 characters for brevity
+  if (traceId.length > 16) {
+    return `${traceId.slice(0, 8)}...${traceId.slice(-4)}`;
+  }
+  return traceId;
+}
+
+/**
+ * Creates a Grafana Explore URL for viewing a trace
+ */
+export function createTraceExploreUrl(
+  traceId: string,
+  datasourceUid?: string,
+  baseUrl?: string
+): string | null {
+  if (!datasourceUid || !baseUrl) {
+    // If no datasource is configured, return null
+    return null;
+  }
+  
+  const exploreState = {
+    datasource: datasourceUid,
+    queries: [{
+      refId: 'A',
+      query: traceId,
+      datasource: {
+        type: 'tempo',
+        uid: datasourceUid,
+      },
+      queryType: 'traceql',
+      limit: 20,
+      tableType: 'traces',
+    }],
+    range: {
+      from: 'now-1h',
+      to: 'now',
+    },
+  };
+  
+  const stateJson = JSON.stringify({
+    'goldfish-trace-explore': exploreState,
+  });
+  
+  const encodedState = encodeURIComponent(stateJson);
+  return `${baseUrl}/explore?schemaVersion=1&panes=${encodedState}`;
+}
+
+/**
+ * Trace context for a request
+ */
+export interface TraceContext {
+  traceId: string;
+  spanId: string;
+  parentSpanId?: string;
+  startTime: number;
+}
+
+/**
+ * Creates a new trace context for a request
+ */
+export function createTraceContext(parentSpanId?: string): TraceContext {
+  return {
+    traceId: generateTraceId(),
+    spanId: generateSpanId(),
+    parentSpanId,
+    startTime: Date.now(),
+  };
+}

--- a/pkg/ui/frontend/src/pages/goldfish.tsx
+++ b/pkg/ui/frontend/src/pages/goldfish.tsx
@@ -31,7 +31,7 @@ export default function GoldfishPage() {
   const [page, setPage] = useState(1);
   const pageSize = 10; // Reduced since we're showing more detail per query
   
-  const { data, isLoading, error, refetch, totalPages } = useGoldfishQueries(
+  const { data, isLoading, error, refetch, totalPages, traceId } = useGoldfishQueries(
     page, 
     pageSize, 
     selectedOutcome, 
@@ -212,7 +212,26 @@ export default function GoldfishPage() {
               <Alert variant="destructive">
                 <AlertCircle className="h-4 w-4" />
                 <AlertDescription>
-                  Failed to load queries: {(error as Error).message}
+                  <div className="space-y-2">
+                    <div>Failed to load queries: {(error as Error).message}</div>
+                    {traceId && (
+                      <div className="text-xs">
+                        <span className="font-semibold">Trace ID: </span>
+                        <code className="bg-destructive/10 px-1 py-0.5 rounded">{traceId}</code>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="ml-2 h-6 px-2 text-xs"
+                          onClick={() => {
+                            // Copy trace ID to clipboard
+                            navigator.clipboard.writeText(traceId);
+                          }}
+                        >
+                          Copy
+                        </Button>
+                      </div>
+                    )}
+                  </div>
                 </AlertDescription>
               </Alert>
             )}

--- a/pkg/ui/goldfish.go
+++ b/pkg/ui/goldfish.go
@@ -5,9 +5,11 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"math"
 	"net/url"
 	"time"
 
+	"github.com/go-kit/log/level"
 	"github.com/grafana/loki/v3/pkg/goldfish"
 )
 
@@ -126,6 +128,14 @@ type GoldfishAPIResponse struct {
 
 // GetSampledQueries retrieves sampled queries from the database with pagination and outcome filtering
 func (s *Service) GetSampledQueries(page, pageSize int, filter goldfish.QueryFilter) (*GoldfishAPIResponse, error) {
+	return s.GetSampledQueriesWithContext(context.Background(), page, pageSize, filter)
+}
+
+// GetSampledQueriesWithContext retrieves sampled queries with trace context
+func (s *Service) GetSampledQueriesWithContext(ctx context.Context, page, pageSize int, filter goldfish.QueryFilter) (*GoldfishAPIResponse, error) {
+	// Extract trace ID for logging
+	traceID, _ := ctx.Value("trace-id").(string)
+
 	if !s.cfg.Goldfish.Enable {
 		return nil, ErrGoldfishDisabled
 	}
@@ -134,9 +144,65 @@ func (s *Service) GetSampledQueries(page, pageSize int, filter goldfish.QueryFil
 		return nil, ErrGoldfishNotConfigured
 	}
 
-	// Call the storage layer which returns QuerySample
-	resp, err := s.goldfishStorage.GetSampledQueries(context.Background(), page, pageSize, filter)
+	// Log the query with trace context
+	if traceID != "" {
+		level.Debug(s.logger).Log(
+			"msg", "fetching sampled queries",
+			"trace_id", traceID,
+			"page", page,
+			"pageSize", pageSize,
+			"filter", fmt.Sprintf("%+v", filter),
+		)
+	}
+
+	// Call the storage layer with context and track metrics
+	queryStart := time.Now()
+	resp, err := s.goldfishStorage.GetSampledQueries(ctx, page, pageSize, filter)
+	queryDuration := time.Since(queryStart).Seconds()
+
+	// Record database query metrics with partition info
+	if s.goldfishMetrics != nil {
+		status := "success"
+		if err != nil {
+			status = "error"
+			s.goldfishMetrics.IncrementErrors("db_query")
+		}
+
+		// Calculate which partitions were likely accessed
+		// With 6-hour partitions, we can track this more precisely
+		partitionRange := "last_24h"
+		if filter.Outcome != "" && filter.Outcome != goldfish.OutcomeAll {
+			partitionRange = "last_48h"
+		}
+		if filter.Tenant != "" || filter.User != "" {
+			partitionRange = "last_72h"
+		}
+
+		s.goldfishMetrics.RecordQueryDuration("get_sampled_queries", partitionRange, status, queryDuration)
+		s.goldfishMetrics.IncrementPartitionAccess(partitionRange, "get_sampled_queries")
+
+		if resp != nil {
+			s.goldfishMetrics.RecordQueryRows("get_sampled_queries", float64(len(resp.Queries)))
+
+			// Track data recency to validate partition strategy
+			if len(resp.Queries) > 0 {
+				oldestQuery := resp.Queries[len(resp.Queries)-1]
+				hoursOld := time.Since(oldestQuery.SampledAt).Hours()
+				partitionsAccessed := int(math.Ceil(hoursOld / 6))
+				level.Debug(s.logger).Log(
+					"msg", "query data recency",
+					"oldest_hours", hoursOld,
+					"partitions_accessed", partitionsAccessed,
+					"trace_id", traceID,
+				)
+			}
+		}
+	}
+
 	if err != nil {
+		if traceID != "" {
+			level.Error(s.logger).Log("msg", "failed to fetch from storage", "err", err, "trace_id", traceID, "query_duration_s", queryDuration)
+		}
 		return nil, err
 	}
 

--- a/pkg/ui/handler.go
+++ b/pkg/ui/handler.go
@@ -2,6 +2,7 @@
 package ui
 
 import (
+	"context"
 	"embed"
 	"encoding/json"
 	"fmt"
@@ -10,6 +11,7 @@ import (
 	"net/http/httputil"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/go-kit/log/level"
 	"github.com/gorilla/mux"
@@ -212,10 +214,45 @@ func (s *Service) writeJSONError(w http.ResponseWriter, code int, message string
 	}
 }
 
+// writeJSONErrorWithTrace writes a JSON error response with trace ID
+func (s *Service) writeJSONErrorWithTrace(w http.ResponseWriter, code int, message string, traceID string) {
+	w.Header().Set("Content-Type", contentTypeJSON)
+	if traceID != "" {
+		w.Header().Set("X-Trace-Id", traceID)
+	}
+	w.WriteHeader(code)
+	
+	errorResp := map[string]string{"error": message}
+	if traceID != "" {
+		errorResp["traceId"] = traceID
+	}
+	
+	if err := json.NewEncoder(w).Encode(errorResp); err != nil {
+		level.Error(s.logger).Log("msg", "failed to encode error response", "err", err, "trace_id", traceID)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
 func (s *Service) goldfishQueriesHandler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Extract trace context from headers
+		traceID := r.Header.Get("X-Trace-Id")
+		spanID := r.Header.Get("X-Span-Id")
+		parentSpanID := r.Header.Get("X-Parent-Span-Id")
+		
+		// If we have a trace ID from the frontend, propagate it
+		if traceID != "" {
+			w.Header().Set("X-Trace-Id", traceID)
+			// Add trace context to request context for downstream use
+			ctx := r.Context()
+			ctx = context.WithValue(ctx, "trace-id", traceID)
+			ctx = context.WithValue(ctx, "span-id", spanID)
+			ctx = context.WithValue(ctx, "parent-span-id", parentSpanID)
+			r = r.WithContext(ctx)
+		}
+		
 		if !s.cfg.Goldfish.Enable {
-			s.writeJSONError(w, http.StatusNotFound, "goldfish feature is disabled")
+			s.writeJSONErrorWithTrace(w, http.StatusNotFound, "goldfish feature is disabled", traceID)
 			return
 		}
 
@@ -271,18 +308,40 @@ func (s *Service) goldfishQueriesHandler() http.Handler {
 			}
 		}
 
-		// Get sampled queries
-		response, err := s.GetSampledQueries(page, pageSize, filter)
+		// Track request metrics
+		startTime := time.Now()
+		
+		// Get sampled queries with trace context
+		response, err := s.GetSampledQueriesWithContext(r.Context(), page, pageSize, filter)
+		
+		// Record metrics
+		duration := time.Since(startTime).Seconds()
+		if s.goldfishMetrics != nil {
+			if err != nil {
+				s.goldfishMetrics.IncrementRequests("error", filter.Outcome)
+				s.goldfishMetrics.IncrementErrors("query_failed")
+			} else {
+				s.goldfishMetrics.IncrementRequests("success", filter.Outcome)
+				if response != nil {
+					s.goldfishMetrics.RecordQueryRows("sampled_queries", float64(len(response.Queries)))
+				}
+			}
+			s.goldfishMetrics.RecordQueryDuration("api_request", "unknown", "complete", duration)
+		}
+		
 		if err != nil {
-			level.Error(s.logger).Log("msg", "failed to get sampled queries", "err", err)
-			s.writeJSONError(w, http.StatusInternalServerError, "failed to retrieve sampled queries")
+			level.Error(s.logger).Log("msg", "failed to get sampled queries", "err", err, "trace_id", traceID, "duration_s", duration)
+			s.writeJSONErrorWithTrace(w, http.StatusInternalServerError, "failed to retrieve sampled queries", traceID)
 			return
 		}
 
 		w.Header().Set("Content-Type", contentTypeJSON)
 		if err := json.NewEncoder(w).Encode(response); err != nil {
-			level.Error(s.logger).Log("msg", "failed to encode goldfish response", "err", err)
-			s.writeJSONError(w, http.StatusInternalServerError, "failed to encode response")
+			level.Error(s.logger).Log("msg", "failed to encode goldfish response", "err", err, "trace_id", traceID)
+			s.writeJSONErrorWithTrace(w, http.StatusInternalServerError, "failed to encode response", traceID)
+			if s.goldfishMetrics != nil {
+				s.goldfishMetrics.IncrementErrors("encode_failed")
+			}
 			return
 		}
 	})

--- a/pkg/ui/metrics.go
+++ b/pkg/ui/metrics.go
@@ -1,0 +1,139 @@
+package ui
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// GoldfishMetrics contains all goldfish-related metrics
+type GoldfishMetrics struct {
+	queryDuration     *prometheus.HistogramVec
+	requests          *prometheus.CounterVec
+	queryRows         *prometheus.HistogramVec
+	errors            *prometheus.CounterVec
+	partitionAccess   *prometheus.CounterVec
+	dbConnections     *prometheus.GaugeVec
+	dbConnectionWait  *prometheus.HistogramVec
+	dbConnectionError *prometheus.CounterVec
+}
+
+// NewGoldfishMetrics creates and registers goldfish metrics
+func NewGoldfishMetrics(reg prometheus.Registerer) *GoldfishMetrics {
+	return &GoldfishMetrics{
+		queryDuration: promauto.With(reg).NewHistogramVec(
+			prometheus.HistogramOpts{
+				Namespace: "loki",
+				Subsystem: "ui_goldfish",
+				Name:      "query_duration_seconds",
+				Help:      "Database query latency by partition",
+				Buckets:   prometheus.ExponentialBuckets(0.001, 2, 15), // 1ms to ~32s
+			},
+			[]string{"query_type", "partition", "status"},
+		),
+		requests: promauto.With(reg).NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: "loki",
+				Subsystem: "ui_goldfish",
+				Name:      "requests_total",
+				Help:      "Total number of goldfish API requests",
+			},
+			[]string{"status", "outcome_filter"},
+		),
+		queryRows: promauto.With(reg).NewHistogramVec(
+			prometheus.HistogramOpts{
+				Namespace: "loki",
+				Subsystem: "ui_goldfish",
+				Name:      "query_rows_total",
+				Help:      "Number of rows returned from database queries",
+				Buckets:   prometheus.ExponentialBuckets(1, 2, 10), // 1 to 1024
+			},
+			[]string{"query_type"},
+		),
+		errors: promauto.With(reg).NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: "loki",
+				Subsystem: "ui_goldfish",
+				Name:      "errors_total",
+				Help:      "Total number of errors by type",
+			},
+			[]string{"error_type"},
+		),
+		partitionAccess: promauto.With(reg).NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: "loki",
+				Subsystem: "ui_goldfish",
+				Name:      "partition_access_total",
+				Help:      "Track partition usage patterns",
+			},
+			[]string{"partition_name", "query_type"},
+		),
+		dbConnections: promauto.With(reg).NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: "loki",
+				Subsystem: "ui_goldfish",
+				Name:      "db_connections_active",
+				Help:      "Number of active database connections",
+			},
+			[]string{"state"}, // active, idle
+		),
+		dbConnectionWait: promauto.With(reg).NewHistogramVec(
+			prometheus.HistogramOpts{
+				Namespace: "loki",
+				Subsystem: "ui_goldfish",
+				Name:      "db_connection_wait_seconds",
+				Help:      "Time spent waiting for database connections",
+				Buckets:   prometheus.ExponentialBuckets(0.001, 2, 10), // 1ms to 1s
+			},
+			[]string{"pool"},
+		),
+		dbConnectionError: promauto.With(reg).NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: "loki",
+				Subsystem: "ui_goldfish",
+				Name:      "db_connection_errors_total",
+				Help:      "Total number of database connection errors",
+			},
+			[]string{"error_type"},
+		),
+	}
+}
+
+// RecordQueryDuration records the duration of a database query
+func (m *GoldfishMetrics) RecordQueryDuration(queryType, partition, status string, duration float64) {
+	m.queryDuration.WithLabelValues(queryType, partition, status).Observe(duration)
+}
+
+// IncrementRequests increments the request counter
+func (m *GoldfishMetrics) IncrementRequests(status, outcomeFilter string) {
+	m.requests.WithLabelValues(status, outcomeFilter).Inc()
+}
+
+// RecordQueryRows records the number of rows returned
+func (m *GoldfishMetrics) RecordQueryRows(queryType string, rows float64) {
+	m.queryRows.WithLabelValues(queryType).Observe(rows)
+}
+
+// IncrementErrors increments the error counter
+func (m *GoldfishMetrics) IncrementErrors(errorType string) {
+	m.errors.WithLabelValues(errorType).Inc()
+}
+
+// IncrementPartitionAccess tracks partition access
+func (m *GoldfishMetrics) IncrementPartitionAccess(partitionName, queryType string) {
+	m.partitionAccess.WithLabelValues(partitionName, queryType).Inc()
+}
+
+// SetDBConnections sets the current connection count
+func (m *GoldfishMetrics) SetDBConnections(state string, count float64) {
+	m.dbConnections.WithLabelValues(state).Set(count)
+}
+
+// RecordDBConnectionWait records connection wait time
+func (m *GoldfishMetrics) RecordDBConnectionWait(pool string, duration float64) {
+	m.dbConnectionWait.WithLabelValues(pool).Observe(duration)
+}
+
+// IncrementDBConnectionErrors increments connection errors
+func (m *GoldfishMetrics) IncrementDBConnectionErrors(errorType string) {
+	m.dbConnectionError.WithLabelValues(errorType).Inc()
+}

--- a/pkg/ui/service.go
+++ b/pkg/ui/service.go
@@ -43,6 +43,7 @@ type Service struct {
 	logger          log.Logger
 	reg             prometheus.Registerer
 	goldfishStorage goldfish.Storage
+	goldfishMetrics *GoldfishMetrics
 }
 
 func NewService(cfg Config, router *mux.Router, logger log.Logger, reg prometheus.Registerer) (*Service, error) {
@@ -89,6 +90,12 @@ func NewService(cfg Config, router *mux.Router, logger log.Logger, reg prometheu
 		client:    httpClient,
 		localAddr: advertiseAddr,
 	}
+	
+	// Initialize metrics if goldfish is enabled
+	if cfg.Goldfish.Enable {
+		svc.goldfishMetrics = NewGoldfishMetrics(reg)
+	}
+	
 	svc.Service = services.NewBasicService(nil, svc.run, svc.stop)
 	if err := svc.initUIFs(); err != nil {
 		return nil, err


### PR DESCRIPTION
**What this PR does / why we need it**:

Add performance improvements to goldfish UI to fix slow queries:

- Add 6-hour table partitioning with automatic management for optimal query performance, since most queries are for recent data
- Implement frontend-initiated distributed tracing
- Add Prometheus metrics for query latency, partition access, and error tracking
- Enhance error handling with trace IDs for debugging failed queries
- Optimize MySQL queries with partition pruning and smart index hints
- Add missing database indexes (user, composite joins, filtering)

The 6-hour partitioning strategy dramatically reduces data scanned by limiting queries to only recent partitions (4-12 partitions vs entire table). Frontend-initiated traces ensure trace IDs are available even on timeout, improving debugging capabilities.

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
