### PR TITLE
docs: prep OTEL shared content

### DIFF
--- a/docs/sources/send-data/otel/_index.md
+++ b/docs/sources/send-data/otel/_index.md
@@ -4,174 +4,15 @@ menuTitle:  OpenTelemetry
 description: Configuring the OpenTelemetry Collector to send logs to Loki.
 aliases: 
 - ../clients/k6/
-weight:  200
+weight: 200
 ---
+
+[//]: # 'Shared content for configuring the OTEL collector to import logs to Loki'
+[//]: # 'This content is located in /loki/docs/sources/shared/otel.md'
 
 # Ingesting logs to Loki using OpenTelemetry Collector
 
-Loki natively supports ingesting OpenTelemetry logs over HTTP.
-For ingesting logs to Loki using the OpenTelemetry Collector, you must use the [`otlphttp` exporter](https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/otlphttpexporter).
-
-{{< youtube id="snXhe1fDDa8" >}}
-
-For more information about using OpenTelemetry with Grafana products, refer to the [Grafana OpenTelemetry documentation](https://grafana.com/docs/opentelemetry/).
-
-## Loki configuration
-
-When logs are ingested by Loki using an OpenTelemetry protocol (OTLP) ingestion endpoint, some of the data is stored as [Structured Metadata](../../get-started/labels/structured-metadata/).
-
-You must set `allow_structured_metadata` to `true` within your Loki config file. Otherwise, Loki will reject the log payload as malformed.  Note that Structured Metadata is enabled by default in Loki 3.0 and later.
-
-```yaml
-limits_config:
-  allow_structured_metadata: true
-```
-
-## Configure the OpenTelemetry Collector to write logs into Loki
-
-You need to make the following changes to the [OpenTelemetry Collector config](https://opentelemetry.io/docs/collector/configuration/) to write logs to Loki on its OTLP ingestion endpoint.
-
-```yaml
-exporters:
-  otlphttp:
-    endpoint: http://<loki-addr>/otlp
-```
-For Grafana Cloud users, refer to [https://grafana.com/docs/grafana-cloud/send-data/otlp/send-data-otlp/](https://grafana.com/docs/grafana-cloud/send-data/otlp/send-data-otlp/).
-
-And enable it in `service.pipelines`:
-
-```yaml
-service:
-  pipelines:
-    logs:
-      receivers: [...]
-      processors: [...]
-      exporters: [..., otlphttp]
-```
-
-If you want to authenticate using basic auth, we recommend the [`basicauth` extension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/basicauthextension).
-
-```yaml
-extensions:
-  basicauth/otlp:
-    client_auth:
-      username: username
-      password: password
-
-exporters:
-  otlphttp:
-    auth:
-      authenticator: basicauth/otlp
-    endpoint: http://<loki-addr>/otlp
-
-service:
-  extensions: [basicauth/otlp]
-  pipelines:
-    logs:
-      receivers: [...]
-      processors: [...]
-      exporters: [..., otlphttp]
-```
-
-## Format considerations
-
-Since the OpenTelemetry protocol differs from the Loki storage model, here is how data in the OpenTelemetry format will be mapped by default to the Loki data model during ingestion, which can be changed as explained later:
-
-- Index labels: Resource attributes map well to index labels in Loki, since both usually identify the source of the logs. The default list of Resource Attributes to store as Index labels can be configured using `default_resource_attributes_as_index_labels` under [distributor's otlp_config](https://grafana.com/docs/loki/<LOKI_VERSION>/configure/#distributor). By default, the following resource attributes will be stored as index labels, while the remaining attributes are stored as [Structured Metadata](../../get-started/labels/structured-metadata/) with each log entry:
-  - cloud.availability_zone
-  - cloud.region
-  - container.name
-  - deployment.environment.name
-  - k8s.cluster.name
-  - k8s.container.name
-  - k8s.cronjob.name
-  - k8s.daemonset.name
-  - k8s.deployment.name
-  - k8s.job.name
-  - k8s.namespace.name
-  - k8s.pod.name
-  - k8s.replicaset.name
-  - k8s.statefulset.name
-  - service.instance.id
-  - service.name
-  - service.namespace
-
-    {{< admonition type="note" >}}
-    Because Loki has a default limit of 15 index labels, we recommend storing only select resource attributes as index labels. Although the default config selects more than 15 Resource Attributes, it should be fine since a few are mutually exclusive.
-    {{< /admonition >}}
-
-- Timestamp: One of `LogRecord.TimeUnixNano` or `LogRecord.ObservedTimestamp`, based on which one is set. If both are not set, the ingestion timestamp will be used.
-
-- LogLine: `LogRecord.Body` holds the body of the log. However, since Loki only supports Log body in string format, we will stringify non-string values using the [AsString method from the OTel collector lib](https://github.com/open-telemetry/opentelemetry-collector/blob/ab3d6c5b64701e690aaa340b0a63f443ff22c1f0/pdata/pcommon/value.go#L353).
-
-- [Structured Metadata](../../get-started/labels/structured-metadata/): Anything which can’t be stored in Index labels and LogLine would be stored as Structured Metadata. Here is a non-exhaustive list of what will be stored in Structured Metadata to give a sense of what it will hold:
-  - Resource Attributes not stored as Index labels is replicated and stored with each log entry.
-  - Everything under InstrumentationScope is replicated and stored with each log entry.
-  - Everything under LogRecord except `LogRecord.Body`, `LogRecord.TimeUnixNano` and sometimes `LogRecord.ObservedTimestamp`.
-
-Things to note before ingesting OpenTelemetry logs to Loki:
-
-- Dots (.) are converted to underscores (_).
-
-  Loki does not support `.` or any other special characters other than `_` in label names. The unsupported characters are replaced with an `_` while converting Attributes to Index Labels or Structured Metadata.
-  Also, please note that while writing the queries, you must use the normalized format, i.e. use `_` instead of special characters while querying data using OTel Attributes.
-
-  For example, `service.name` in OTLP would become `service_name` in Loki.
-
-- Flattening of nested Attributes
-
-  While converting Attributes in OTLP to Index labels or Structured Metadata, any nested attribute values are flattened out using `_` as a separator.
-  It is done in a similar way as to how it is done in the [LogQL json parser](/docs/loki/<LOKI_VERSION>/query/log_queries/#json).
-
-- Stringification of non-string Attribute values
-
-  While converting Attribute values in OTLP to Index label values or Structured Metadata, any non-string values are converted to string using [AsString method from the OTel collector lib](https://github.com/open-telemetry/opentelemetry-collector/blob/ab3d6c5b64701e690aaa340b0a63f443ff22c1f0/pdata/pcommon/value.go#L353).
-
-### Changing the default mapping of OTLP to Loki Format
-
-Loki supports [per tenant](https://grafana.com/docs/loki/<LOKI_VERSION>/configure/#limits_config) OTLP config which lets you change the default mapping of OTLP to Loki format for each tenant.
-It currently only supports changing the storage of Attributes.
-Here is what the configuration looks like:
-
-```yaml
-# OTLP log ingestion configurations
-limits_config:
-  otlp_config:
-    # Configuration for Resource Attributes to store them as index labels or
-    # Structured Metadata or drop them altogether
-    resource_attributes:
-      # Configure whether to ignore the default list of resource attributes set in
-      # 'distributor.otlp.default_resource_attributes_as_index_labels' to be
-      # stored as index labels and only use the given resource attributes config
-      [ignore_defaults: <boolean>]
-  
-      [attributes_config: <list of attributes_configs>]
-  
-    # Configuration for Scope Attributes to store them as Structured Metadata or
-    # drop them altogether
-    [scope_attributes: <list of attributes_configs>]
-  
-    # Configuration for Log Attributes to store them as Structured Metadata or
-    # drop them altogether
-    [log_attributes: <list of attributes_configs>]
-  
-  attributes_config:
-    # Configures action to take on matching Attributes. It allows one of
-    # [structured_metadata, drop] for all Attribute types. It additionally allows
-    # index_label action for Resource Attributes
-    [action: <string> | default = ""]
-  
-    # List of attributes to configure how to store them or drop them altogether
-    [attributes: <list of strings>]
-  
-    # Regex to choose attributes to configure how to store them or drop them
-    # altogether
-    [regex: <Regexp>]
-```
-
-{{< admonition type="note" >}}
-If you are a Grafana Cloud customer, open a support escalation listing the Attributes you want to promote to indexed labels, and any additional context.
-{{< /admonition >}}
+{{< docs/shared source="loki" lookup="otel.md" version="<LOKI_VERSION>">}}
 
 Here are some example configs to change the default mapping of OTLP to Loki format:
 
@@ -188,6 +29,7 @@ limits_config:
 ```
 
 With the example config, here is how various kinds of Attributes would be stored:
+
 * Store all 17 Resource Attributes mentioned earlier and `service.group` Resource Attribute as index labels.
 * Store remaining Resource Attributes as Structured Metadata.
 * Store all the Scope and Log Attributes as Structured Metadata.
@@ -205,6 +47,7 @@ limits_config:
 ```
 
 With the example config, here is how various kinds of Attributes would be stored:
+
 * **Only** store `service.group` Resource Attribute as index labels.
 * Store remaining Resource Attributes as Structured Metadata.
 * Store all the Scope and Log Attributes as Structured Metadata.
@@ -231,6 +74,7 @@ limits_config:
 ```
 
 With the example config, here is how various kinds of Attributes would be stored:
+
 * Store all 17 Resource Attributes mentioned earlier and `service.group` Resource Attribute as index labels.
 * Store remaining Resource Attributes as Structured Metadata.
 * Drop Scope Attribute named `method.name` and store all other Scope Attributes as Structured Metadata.

--- a/docs/sources/send-data/otel/native_otlp_vs_loki_exporter.md
+++ b/docs/sources/send-data/otel/native_otlp_vs_loki_exporter.md
@@ -1,8 +1,8 @@
 ---
 title: How is native OTLP endpoint different from Loki Exporter
-menuTitle:  Native OTLP endpoint vs Loki Exporter
+menuTitle: Native OTLP endpoint vs Loki Exporter
 description: Native OTLP endpoint vs Loki Exporter
-weight:  251
+weight: 251
 ---
 
 # How is native OTLP endpoint different from Loki Exporter
@@ -10,6 +10,11 @@ weight:  251
 ## Introduction
 
 OpenTelemetry (OTel) is quickly becoming an industry standard with increasing adoption. Prior to the Loki 3.0 release, there was no native support for ingesting OTel logs to Loki, which led to creation of the [LokiExporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/lokiexporter/README.md). While the LokiExporter got the job done of ingesting OTel logs to Loki, it did not provide a native user experience, and the querying experience was not optimal. As part of our effort to improve user experience with OTel, we added native OTel log ingestion support to Loki with 3.0 release.
+
+{{< admonition type="note" >}}
+The native OTLP endpoint is the recommended way to send logs to Loki. Grafana Labs is working to migrate existing customers from Loki Exporter to the native OTLP endpoint.
+For Cloud users, Adaptive Logs may not produce meaningful patterns if OTel logs are sent to the Cloud Logs endpoint. They must be sent to the OTLP endpoint.
+{{< /admonition >}}
 
 ## What has changed?
 
@@ -94,7 +99,7 @@ Taking the above-ingested log line, let us look at how the querying experience w
 - Ingested with LokiExporter: `sum(count_over_time({job="dev/auth"} |= "user logged in" | json[1h])) by (email)`
 - Ingested with Loki’s native OTel endpoint: `sum(count_over_time({service_name="auth", service_namespace="dev"} |= "user logged in"[1h])) by (email)`
 
-## Benefits of switching from LokiExporter to native OTel endpoint:
+## Benefits of switching from LokiExporter to native OTel endpoint
 
 - **Future improvements:** There is an ongoing discussion on deprecating LokiExporter, which would stop receiving future enhancements. Loki’s native OTel endpoint represents the future of our product, and all future development and enhancements will be focused there. Upgrading to the native endpoint will ensure you benefit from the latest enhancements and the best possible user experience.
 - **Simplified client config:** LokiExporter requires setting hints for managing stream labels, which defeats the purpose of choosing OTel in the first place since you can’t switch from one OTel-compatible storage to another without having to reconfigure your clients. With Loki’s native OTel endpoint, there is no added complexity in setting hints for your client to manage the labels.

--- a/docs/sources/shared/otel.md
+++ b/docs/sources/shared/otel.md
@@ -1,0 +1,192 @@
+---
+headless: true
+description: Shared file for Loki OTEL content.
+labels:
+  products:
+    - enterprise
+    - oss
+    - cloud
+---
+
+[//]: # 'This file documents configuring the OTEL collector to import logs to Loki'
+[//]: #
+[//]: # 'This shared file is included in these locations:'
+[//]: # '/website/docs/grafana-cloud/send-data/logs/collect-logs-with-otel.md'
+[//]: # '/loki/docs/loki/latest/send-data/otel/_index.md'
+[//]: #
+[//]: # 'If you make changes to this file, verify that the meaning and content are not changed in any place where the file is included.'
+[//]: # 'Any links should be fully qualified and not relative: /docs/grafana/ instead of ../grafana/.'
+
+Loki natively supports ingesting OpenTelemetry logs over HTTP.
+For ingesting logs to Loki using the OpenTelemetry Collector, you must use the [`otlphttp` exporter](https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/otlphttpexporter).
+
+{{< youtube id="snXhe1fDDa8" >}}
+
+For more information about using OpenTelemetry with Grafana products, refer to the [Grafana OpenTelemetry documentation](https://grafana.com/docs/opentelemetry/).
+
+## Loki configuration
+
+When logs are ingested by Loki using an OpenTelemetry protocol (OTLP) ingestion endpoint, some of the data is stored as [Structured Metadata](../../get-started/labels/structured-metadata/).
+
+You must set `allow_structured_metadata` to `true` within your Loki config file. Otherwise, Loki will reject the log payload as malformed.  Note that Structured Metadata is enabled by default in Loki 3.0 and later.
+
+```yaml
+limits_config:
+  allow_structured_metadata: true
+```
+
+## Configure the OpenTelemetry Collector to write logs into Loki
+
+You need to make the following changes to the [OpenTelemetry Collector config](https://opentelemetry.io/docs/collector/configuration/) to write logs to Loki on its OTLP ingestion endpoint.
+
+```yaml
+exporters:
+  otlphttp:
+    endpoint: http://<loki-addr>/otlp
+```
+
+And enable it in `service.pipelines`:
+
+```yaml
+service:
+  pipelines:
+    logs:
+      receivers: [...]
+      processors: [...]
+      exporters: [..., otlphttp]
+```
+
+If you want to authenticate using basic auth, we recommend the [`basicauth` extension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/basicauthextension).
+
+```yaml
+extensions:
+  basicauth/otlp:
+    client_auth:
+      username: username
+      password: password
+
+exporters:
+  otlphttp:
+    auth:
+      authenticator: basicauth/otlp
+    endpoint: http://<loki-addr>/otlp
+
+service:
+  extensions: [basicauth/otlp]
+  pipelines:
+    logs:
+      receivers: [...]
+      processors: [...]
+      exporters: [..., otlphttp]
+```
+
+## Format considerations
+
+Since the OpenTelemetry protocol differs from the Loki storage model, here is how data in the OpenTelemetry format will be mapped by default to the Loki data model during ingestion, which can be changed as explained later:
+
+- Index labels: Resource attributes map well to index labels in Loki, since both usually identify the source of the logs. The default list of Resource Attributes to store as Index labels can be configured using `default_resource_attributes_as_index_labels` under [distributor's otlp_config](https://grafana.com/docs/loki/<LOKI_VERSION>/configure/#distributor). By default, the following resource attributes will be stored as index labels, while the remaining attributes are stored as [Structured Metadata](../../get-started/labels/structured-metadata/) with each log entry:
+  - cloud.availability_zone
+  - cloud.region
+  - container.name
+  - deployment.environment.name
+  - k8s.cluster.name
+  - k8s.container.name
+  - k8s.cronjob.name
+  - k8s.daemonset.name
+  - k8s.deployment.name
+  - k8s.job.name
+  - k8s.namespace.name
+  - k8s.pod.name
+  - k8s.replicaset.name
+  - k8s.statefulset.name
+  - service.instance.id
+  - service.name
+  - service.namespace
+
+    {{< admonition type="note" >}}
+    Because Loki has a default limit of 15 index labels, we recommend storing only select resource attributes as index labels. Although the default config selects more than 15 Resource Attributes, it should be fine since a few are mutually exclusive.
+    {{< /admonition >}}
+
+    {{< admonition type="tip" >}}
+    For Grafana Cloud Logs, see the [current OpenTelemetry guidance](https://grafana.com/docs/grafana-cloud/send-data/otlp/otlp-format-considerations/#logs).
+    {{< /admonition >}}
+
+- Timestamp: One of `LogRecord.TimeUnixNano` or `LogRecord.ObservedTimestamp`, based on which one is set. If both are not set, the ingestion timestamp will be used.
+
+- LogLine: `LogRecord.Body` holds the body of the log. However, since Loki only supports Log body in string format, we will stringify non-string values using the [AsString method from the OTel collector lib](https://github.com/open-telemetry/opentelemetry-collector/blob/ab3d6c5b64701e690aaa340b0a63f443ff22c1f0/pdata/pcommon/value.go#L353).
+
+- [Structured Metadata](../../get-started/labels/structured-metadata/): Anything which can’t be stored in Index labels and LogLine would be stored as Structured Metadata. Here is a non-exhaustive list of what will be stored in Structured Metadata to give a sense of what it will hold:
+  - Resource Attributes not stored as Index labels is replicated and stored with each log entry.
+  - Everything under InstrumentationScope is replicated and stored with each log entry.
+  - Everything under LogRecord except `LogRecord.Body`, `LogRecord.TimeUnixNano` and sometimes `LogRecord.ObservedTimestamp`.
+
+The default list of resource attributes to store as labels can be configured using `default_resource_attributes_as_index_labels` under the [distributor's otlp_config](https://grafana.com/docs/loki/<LOKI_VERSION>/configure/#distributor). You can set global limits using [limits_config.otlp_config](/docs/loki/<LOKI_VERSION>/configure/#limits_config). If you are using Grafana Cloud, contact support to configure this setting.
+
+{{< admonition type="caution" >}}
+Because of the potential for high [cardinality](https://grafana.com/docs/loki/<LOKI_VERSION>/get-started/labels/cardinality/), `k8s.pod.name` and `service.instance.id` are no longer recommended as default labels. But because removing these resource attributes from the default labels would be a breaking change for existing users, they have not yet been deprecated as default labels. If you are a new user of Grafana Loki, we recommend that you modify your Alloy or OpenTelemetry Collector configuration to convert `k8s.pod.name` and `service.instance.id` from index labels to structured metadata.
+For sample configurations, refer to [Remove default labels](https://grafana.com/docs/loki/<LOKI_VERSION>/get-started/labels/remove-default-labels).
+{{< /admonition >}}
+
+Things to note before ingesting OpenTelemetry logs to Loki:
+
+- Dots (.) are converted to underscores (_).
+
+  Loki does not support `.` or any other special characters other than `_` in label names. The unsupported characters are replaced with an `_` while converting Attributes to Index Labels or Structured Metadata.
+  Also, please note that while writing the queries, you must use the normalized format, i.e. use `_` instead of special characters while querying data using OTel Attributes.
+
+  For example, `service.name` in OTLP would become `service_name` in Loki.
+
+- Flattening of nested Attributes
+
+  While converting Attributes in OTLP to Index labels or Structured Metadata, any nested attribute values are flattened out using `_` as a separator.
+  It is done in a similar way as to how it is done in the [LogQL json parser](/docs/loki/<LOKI_VERSION>/query/log_queries/#json).
+
+- Stringification of non-string Attribute values
+
+  While converting Attribute values in OTLP to Index label values or Structured Metadata, any non-string values are converted to string using [AsString method from the OTel collector lib](https://github.com/open-telemetry/opentelemetry-collector/blob/ab3d6c5b64701e690aaa340b0a63f443ff22c1f0/pdata/pcommon/value.go#L353).
+
+  ### Changing the default mapping of OTLP to Loki Format
+
+Loki supports [per tenant](https://grafana.com/docs/loki/<LOKI_VERSION>/configure/#limits_config) OTLP config which lets you change the default mapping of OTLP to Loki format for each tenant.
+It currently only supports changing the storage of Attributes. Here is what the config looks like:
+
+```yaml
+# OTLP log ingestion configurations
+limits_config:
+  otlp_config:
+    # Configuration for Resource Attributes to store them as index labels or
+    # Structured Metadata or drop them altogether
+    resource_attributes:
+      # Configure whether to ignore the default list of resource attributes set in
+      # 'distributor.otlp.default_resource_attributes_as_index_labels' to be
+      # stored as index labels and only use the given resource attributes config
+      [ignore_defaults: <boolean>]
+  
+      [attributes_config: <list of attributes_configs>]
+  
+    # Configuration for Scope Attributes to store them as Structured Metadata or
+    # drop them altogether
+    [scope_attributes: <list of attributes_configs>]
+  
+    # Configuration for Log Attributes to store them as Structured Metadata or
+    # drop them altogether
+    [log_attributes: <list of attributes_configs>]
+  
+  attributes_config:
+    # Configures action to take on matching Attributes. It allows one of
+    # [structured_metadata, drop] for all Attribute types. It additionally allows
+    # index_label action for Resource Attributes
+    [action: <string> | default = ""]
+  
+    # List of attributes to configure how to store them or drop them altogether
+    [attributes: <list of strings>]
+  
+    # Regex to choose attributes to configure how to store them or drop them
+    # altogether
+    [regex: <Regexp>]
+```
+
+{{< admonition type="note" >}}
+If you are a Grafana Cloud customer, open a support escalation listing the Attributes you want to promote to indexed labels, and any additional context.
+{{< /admonition >}}
+  


### PR DESCRIPTION
**What this PR does / why we need it**:
- Preps some of the Loki OTEL content to be shared with Cloud Logs by moving the content into `docs/sources/shared/otel.md`.
- Adds note that the OTLP endpoint is the recommended way to send logs, and that Adaptive Logs users should be using the OTLP endpoint.


**Special notes for your reviewer:**
Topic with the shared content is https://deploy-preview-loki-19025-zb444pucvq-vp.a.run.app/docs/loki/latest/send-data/otel/



