### PR TITLE
ci: fix claude workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -16,14 +16,9 @@ on:
 
 jobs:
   claude-review:
-    # Only run when the 'claude-review' label is added AND the actor is a member/owner of the org
+    # Only run when the 'claude-review' label is added
     if: |
-      github.event.label.name == 'claude-review' &&
-      (github.event.sender.type == 'User' && 
-       contains(fromJSON('["OWNER", "MEMBER"]'), github.event.sender.author_association))
-    
-    # Note: author_association can be: OWNER, MEMBER, COLLABORATOR, CONTRIBUTOR, FIRST_TIME_CONTRIBUTOR, FIRST_TIMER, NONE
-    # We're only allowing OWNER and MEMBER to ensure Vault access works
+      github.event.label.name == 'claude-review'
     
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -16,9 +16,7 @@ jobs:
       ((github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))) &&
-      (github.event.sender.type == 'User' && 
-       contains(fromJSON('["OWNER", "MEMBER"]'), github.event.sender.author_association))
+       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude'))))
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
**What this PR does / why we need it**:

Trying to figure out why the claude code review is being skipped on label, and then hopefully fix it.

So I think it's likely the user membership check, but I can run my changes until we merge since there's a check that the workflow needs to match the one on main.

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
