### PR TITLE
fix: panic in stats.go

### DIFF
--- a/cmd/dataobj-inspect/stats.go
+++ b/cmd/dataobj-inspect/stats.go
@@ -73,7 +73,7 @@ func (cmd *statsCommand) printStreamsSectionStats(ctx context.Context, offset in
 		humanize.Bytes(stats.UncompressedSize),
 	)
 	for _, col := range stats.Columns {
-		fmt.Printf("\t\tname: %s, type: %v, %d populated rows, %v compressed (%v), %v uncompressed\n", col.Name, col.Type[12:], col.ValuesCount, humanize.Bytes(col.CompressedSize), col.Compression[17:], humanize.Bytes(col.UncompressedSize))
+		fmt.Printf("\t\tname: %s, type: %v, %d populated rows, %v compressed (%v), %v uncompressed\n", col.Name, col.Type, col.ValuesCount, humanize.Bytes(col.CompressedSize), col.Compression[17:], humanize.Bytes(col.UncompressedSize))
 	}
 }
 
@@ -96,7 +96,7 @@ func (cmd *statsCommand) printLogsSectionStats(ctx context.Context, offset int, 
 		humanize.Bytes(stats.UncompressedSize),
 	)
 	for _, col := range stats.Columns {
-		fmt.Printf("\t\tname: %s, type: %v, %d populated rows, %v compressed (%v), %v uncompressed\n", col.Name, col.Type[12:], col.ValuesCount, humanize.Bytes(col.CompressedSize), col.Compression[17:], humanize.Bytes(col.UncompressedSize))
+		fmt.Printf("\t\tname: %s, type: %v, %d populated rows, %v compressed (%v), %v uncompressed\n", col.Name, col.Type, col.ValuesCount, humanize.Bytes(col.CompressedSize), col.Compression[17:], humanize.Bytes(col.UncompressedSize))
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a panic in the `stats` sub-command when printing the latest version of dataobjs.

```
panic: runtime error: slice bounds out of range [12:9]

goroutine 1 [running]:
main.(*statsCommand).printStreamsSectionStats(0x103478b18?, {0x10347e6f0, 0x103a2a080}, 0x1, 0x0?)
        /Users/grobinson/go/src/github.com/grafana/loki/cmd/dataobj-inspect/stats.go:76 +0x69c
main.(*statsCommand).printStats(0x140000cc090, {0x16d22f7c8?, 0x0?})
        /Users/grobinson/go/src/github.com/grafana/loki/cmd/dataobj-inspect/stats.go:48 +0x38c
main.(*statsCommand).run(...)
        /Users/grobinson/go/src/github.com/grafana/loki/cmd/dataobj-inspect/stats.go:25
github.com/alecthomas/kingpin/v2.(*actionMixin).applyActions(...)
```

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
