### PR TITLE
feat: print the tenant in the dump and stats sub-commands

### DIFF
--- a/cmd/dataobj-inspect/dump.go
+++ b/cmd/dataobj-inspect/dump.go
@@ -62,7 +62,7 @@ func (cmd *dumpCommand) dumpStreamsSection(ctx context.Context, offset int, sec 
 	}
 	bold := color.New(color.Bold)
 	bold.Println("Streams section:")
-	bold.Printf("\toffset: %d\n", offset)
+	bold.Printf("\toffset: %d, tenant: %s\n", offset, streamsSec.Tenant())
 
 	tmp := make([]streams.Stream, 512)
 	r := streams.NewRowReader(streamsSec)
@@ -90,7 +90,7 @@ func (cmd *dumpCommand) dumpLogsSection(ctx context.Context, offset int, sec *da
 	}
 	bold := color.New(color.Bold)
 	bold.Println("Logs section:")
-	bold.Printf("\toffset: %d\n", offset)
+	bold.Printf("\toffset: %d, tenant: %s\n", offset, logsSec.Tenant())
 	tmp := make([]logs.Record, 512)
 	r := logs.NewRowReader(logsSec)
 	for {

--- a/cmd/dataobj-inspect/stats.go
+++ b/cmd/dataobj-inspect/stats.go
@@ -83,7 +83,7 @@ func (cmd *statsCommand) printStreamsSectionStats(ctx context.Context, offset in
 	bold := color.New(color.Bold)
 	bold.Println("Streams section:")
 	bold.Printf(
-		"\toffset: %d, tenant: %s,columns: %d, compressed size: %v, uncompressed size %v\n",
+		"\toffset: %d, tenant: %s, columns: %d, compressed size: %v, uncompressed size %v\n",
 		offset,
 		streamsSec.Tenant(),
 		len(stats.Columns),

--- a/pkg/dataobj/tools/stats.go
+++ b/pkg/dataobj/tools/stats.go
@@ -1,0 +1,51 @@
+// TODO(grobinson): Find a way to move this file into the dataobj package.
+// Today it's not possible because there is a circular dependency between the
+// dataobj package and the logs package.
+package tools
+
+import (
+	"context"
+	"errors"
+	"slices"
+
+	"github.com/grafana/loki/v3/pkg/dataobj"
+	"github.com/grafana/loki/v3/pkg/dataobj/sections/logs"
+	"github.com/grafana/loki/v3/pkg/dataobj/sections/streams"
+)
+
+type Stats struct {
+	Size     uint64
+	Sections int
+	Tenants  []string
+}
+
+// ReadStats returns statistics about the data object. ReadStats returns an
+// error if the data object couldn't be inspected or if the provided ctx is
+// canceled.
+func ReadStats(ctx context.Context, obj *dataobj.Object) (*Stats, error) {
+	s := Stats{}
+	s.Size = uint64(obj.Size())
+	for _, sec := range obj.Sections() {
+		s.Sections++
+		switch {
+		case streams.CheckSection(sec):
+			streamsSec, err := streams.Open(ctx, sec)
+			if err != nil {
+				return nil, err
+			}
+			s.Tenants = append(s.Tenants, streamsSec.Tenant())
+		case logs.CheckSection(sec):
+			logsSec, err := logs.Open(ctx, sec)
+			if err != nil {
+				return nil, err
+			}
+			s.Tenants = append(s.Tenants, logsSec.Tenant())
+		default:
+			return nil, errors.New("unknown section type")
+		}
+	}
+	// A tenant can have multiple sections, so we must deduplicate them.
+	slices.Sort(s.Tenants)
+	slices.Compact(s.Tenants)
+	return &s, nil
+}

--- a/pkg/dataobj/tools/stats.go
+++ b/pkg/dataobj/tools/stats.go
@@ -46,6 +46,6 @@ func ReadStats(ctx context.Context, obj *dataobj.Object) (*Stats, error) {
 	}
 	// A tenant can have multiple sections, so we must deduplicate them.
 	slices.Sort(s.Tenants)
-	slices.Compact(s.Tenants)
+	s.Tenants = slices.Compact(s.Tenants)
 	return &s, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request prints the tenant in the `dump` and `stats` sub-commands.

Example from `dump`:

```
Logs section:
        offset: 0, tenant: -1
                id: 41, timestamp: 2025-08-27 09:42:54.095359 +0100 BST, metadata:
                        detected_level=unknown
                id: 40, timestamp: 2025-08-27 09:42:53.032302 +0100 BST, metadata:
                        detected_level=unknown
                id: 39, timestamp: 2025-08-27 09:42:51.971561 +0100 BST, metadata:
                        detected_level=unknown
```

Example from `stats`:

```
Object:
        size: 5.2 MB, sections: 2, tenants: 2
Logs section:
        offset: 0, tenant: -1, columns: 4, compressed size: 5.2 MB, uncompressed size 5.2 MB
                name: , type: stream_id, 68 populated rows, 72 B compressed (NONE), 72 B uncompressed
                name: , type: timestamp, 68 populated rows, 249 B compressed (NONE), 249 B uncompressed
                name: detected_level, type: metadata, 68 populated rows, 47 B compressed (ZSTD), 545 B uncompressed
                name: , type: message, 68 populated rows, 5.2 MB compressed (ZSTD), 5.2 MB uncompressed
Streams section:
        offset: 1, tenant: -1,columns: 10, compressed size: 871 B, uncompressed size 1.6 kB
                name: , type: stream_id, 41 populated rows, 44 B compressed (NONE), 44 B uncompressed
                ...
```

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
