### PR TITLE
fix: backoff cannot be canceled via ctx

### DIFF
--- a/pkg/dataobj/metastore/toc_writer.go
+++ b/pkg/dataobj/metastore/toc_writer.go
@@ -10,11 +10,11 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/grafana/dskit/backoff"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/thanos-io/objstore"
 
+	"github.com/grafana/dskit/backoff"
 	"github.com/grafana/loki/v3/pkg/dataobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/index/indexobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/metastore/multitenancy"
@@ -39,7 +39,6 @@ type TableOfContentsWriter struct {
 	metrics    *tocMetrics
 	bucket     objstore.Bucket
 	logger     log.Logger
-	backoff    *backoff.Backoff
 	buf        *bytes.Buffer
 
 	builderOnce sync.Once
@@ -50,14 +49,10 @@ func NewTableOfContentsWriter(cfg Config, bucket objstore.Bucket, logger log.Log
 	metrics := newTableOfContentsMetrics()
 
 	return &TableOfContentsWriter{
-		cfg:     cfg,
-		bucket:  bucket,
-		metrics: metrics,
-		logger:  logger,
-		backoff: backoff.New(context.TODO(), backoff.Config{
-			MinBackoff: 50 * time.Millisecond,
-			MaxBackoff: 10 * time.Second,
-		}),
+		cfg:         cfg,
+		bucket:      bucket,
+		metrics:     metrics,
+		logger:      logger,
 		builderOnce: sync.Once{},
 	}
 }
@@ -72,6 +67,7 @@ func (m *TableOfContentsWriter) UnregisterMetrics(reg prometheus.Registerer) {
 
 func (m *TableOfContentsWriter) initBuilder() error {
 	var initErr error
+
 	m.builderOnce.Do(func() {
 		m.buf = bytes.NewBuffer(make([]byte, 0, tocBuilderCfg.TargetObjectSize))
 		indexBuilder, err := indexobj.NewBuilder(tocBuilderCfg, nil)
@@ -100,8 +96,11 @@ func (m *TableOfContentsWriter) WriteEntry(ctx context.Context, dataobjPath stri
 	for _, timeRange := range tenantTimeRanges {
 		prefix := storagePrefixFor(m.cfg.Storage, timeRange.Tenant)
 		for tocPath := range iterTableOfContentsPaths(timeRange.Tenant, timeRange.MinTime, timeRange.MaxTime, prefix) {
-			m.backoff.Reset()
-			for m.backoff.Ongoing() {
+			b := backoff.New(ctx, backoff.Config{
+				MinBackoff: 50 * time.Millisecond,
+				MaxBackoff: 10 * time.Second,
+			})
+			for b.Ongoing() {
 				err = m.bucket.GetAndReplace(ctx, tocPath, func(existing io.ReadCloser) (io.ReadCloser, error) {
 					if existing != nil {
 						defer existing.Close()
@@ -172,7 +171,7 @@ func (m *TableOfContentsWriter) WriteEntry(ctx context.Context, dataobjPath stri
 				}
 				level.Error(m.logger).Log("msg", "failed to get and replace metastore object", "err", err, "metastore", tocPath)
 				m.metrics.incTableOfContentsWrites(statusFailure)
-				m.backoff.Wait()
+				b.Wait()
 			}
 
 			// Reset at the end too so we don't leave our memory hanging around between calls.

--- a/pkg/dataobj/metastore/toc_writer.go
+++ b/pkg/dataobj/metastore/toc_writer.go
@@ -10,11 +10,11 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/backoff"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/thanos-io/objstore"
 
-	"github.com/grafana/dskit/backoff"
 	"github.com/grafana/loki/v3/pkg/dataobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/index/indexobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/metastore/multitenancy"

--- a/pkg/dataobj/metastore/toc_writer_test.go
+++ b/pkg/dataobj/metastore/toc_writer_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
-	"github.com/grafana/dskit/backoff"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 	"github.com/thanos-io/objstore"
@@ -93,14 +92,10 @@ func newTableOfContentsWriter(t *testing.T, bucket objstore.Bucket, tocBuilder *
 	t.Helper()
 
 	updater := &TableOfContentsWriter{
-		tocBuilder: tocBuilder,
-		bucket:     bucket,
-		metrics:    newTableOfContentsMetrics(),
-		logger:     log.NewNopLogger(),
-		backoff: backoff.New(context.TODO(), backoff.Config{
-			MinBackoff: 50 * time.Millisecond,
-			MaxBackoff: 10 * time.Second,
-		}),
+		tocBuilder:  tocBuilder,
+		bucket:      bucket,
+		metrics:     newTableOfContentsMetrics(),
+		logger:      log.NewNopLogger(),
 		builderOnce: sync.Once{},
 		buf:         bytes.NewBuffer(make([]byte, 0, tocBuilderCfg.TargetObjectSize)),
 	}

--- a/pkg/dataobj/querier/metadata_test.go
+++ b/pkg/dataobj/querier/metadata_test.go
@@ -25,7 +25,7 @@ func TestStore_SelectSeries(t *testing.T) {
 	ctx = user.InjectOrgID(ctx, testTenant)
 
 	// Setup test data
-	now := setupTestData(t, ctx, builder)
+	now := setupTestData(ctx, t, builder)
 	meta := metastore.NewObjectMetastore(metastore.StorageConfig{}, builder.bucket, log.NewNopLogger(), nil)
 	store := NewStore(builder.bucket, log.NewNopLogger(), meta)
 
@@ -170,7 +170,7 @@ func TestStore_LabelNamesForMetricName(t *testing.T) {
 	ctx = user.InjectOrgID(ctx, testTenant)
 
 	// Setup test data
-	now := setupTestData(t, ctx, builder)
+	now := setupTestData(ctx, t, builder)
 	meta := metastore.NewObjectMetastore(metastore.StorageConfig{}, builder.bucket, log.NewNopLogger(), nil)
 	store := NewStore(builder.bucket, log.NewNopLogger(), meta)
 
@@ -240,7 +240,7 @@ func TestStore_LabelValuesForMetricName(t *testing.T) {
 	ctx = user.InjectOrgID(ctx, testTenant)
 
 	// Setup test data
-	now := setupTestData(t, ctx, builder)
+	now := setupTestData(ctx, t, builder)
 	meta := metastore.NewObjectMetastore(metastore.StorageConfig{}, builder.bucket, log.NewNopLogger(), nil)
 	store := NewStore(builder.bucket, log.NewNopLogger(), meta)
 

--- a/pkg/dataobj/querier/metadata_test.go
+++ b/pkg/dataobj/querier/metadata_test.go
@@ -21,11 +21,13 @@ func TestStore_SelectSeries(t *testing.T) {
 	builder := newTestDataBuilder(t, testTenant)
 	defer builder.close()
 
+	ctx, _ := context.WithTimeout(t.Context(), time.Second) //nolint:govet
+	ctx = user.InjectOrgID(ctx, testTenant)
+
 	// Setup test data
-	now := setupTestData(t, builder)
+	now := setupTestData(t, ctx, builder)
 	meta := metastore.NewObjectMetastore(metastore.StorageConfig{}, builder.bucket, log.NewNopLogger(), nil)
 	store := NewStore(builder.bucket, log.NewNopLogger(), meta)
-	ctx := user.InjectOrgID(context.Background(), testTenant)
 
 	tests := []struct {
 		name     string
@@ -164,11 +166,13 @@ func TestStore_LabelNamesForMetricName(t *testing.T) {
 	builder := newTestDataBuilder(t, testTenant)
 	defer builder.close()
 
+	ctx, _ := context.WithTimeout(t.Context(), time.Second) //nolint:govet
+	ctx = user.InjectOrgID(ctx, testTenant)
+
 	// Setup test data
-	now := setupTestData(t, builder)
+	now := setupTestData(t, ctx, builder)
 	meta := metastore.NewObjectMetastore(metastore.StorageConfig{}, builder.bucket, log.NewNopLogger(), nil)
 	store := NewStore(builder.bucket, log.NewNopLogger(), meta)
-	ctx := user.InjectOrgID(context.Background(), testTenant)
 
 	tests := []struct {
 		name     string
@@ -232,11 +236,13 @@ func TestStore_LabelValuesForMetricName(t *testing.T) {
 	builder := newTestDataBuilder(t, testTenant)
 	defer builder.close()
 
+	ctx, _ := context.WithTimeout(t.Context(), time.Second) //nolint:govet
+	ctx = user.InjectOrgID(ctx, testTenant)
+
 	// Setup test data
-	now := setupTestData(t, builder)
+	now := setupTestData(t, ctx, builder)
 	meta := metastore.NewObjectMetastore(metastore.StorageConfig{}, builder.bucket, log.NewNopLogger(), nil)
 	store := NewStore(builder.bucket, log.NewNopLogger(), meta)
-	ctx := user.InjectOrgID(context.Background(), testTenant)
 
 	tests := []struct {
 		name      string

--- a/pkg/dataobj/querier/store_test.go
+++ b/pkg/dataobj/querier/store_test.go
@@ -44,7 +44,7 @@ func TestStore_SelectSamples(t *testing.T) {
 	ctx = user.InjectOrgID(ctx, testTenant)
 
 	// Setup test data
-	now := setupTestData(t, ctx, builder)
+	now := setupTestData(ctx, t, builder)
 	meta := metastore.NewObjectMetastore(metastore.StorageConfig{}, builder.bucket, log.NewNopLogger(), nil)
 	store := NewStore(builder.bucket, log.NewNopLogger(), meta)
 
@@ -207,7 +207,7 @@ func TestStore_SelectLogs(t *testing.T) {
 	ctx = user.InjectOrgID(ctx, testTenant)
 
 	// Setup test data
-	now := setupTestData(t, ctx, builder)
+	now := setupTestData(ctx, t, builder)
 	meta := metastore.NewObjectMetastore(metastore.StorageConfig{}, builder.bucket, log.NewNopLogger(), nil)
 	store := NewStore(builder.bucket, log.NewLogfmtLogger(os.Stdout), meta)
 
@@ -371,7 +371,7 @@ func TestStore_SelectLogs(t *testing.T) {
 	}
 }
 
-func setupTestData(t *testing.T, ctx context.Context, builder *testDataBuilder) time.Time {
+func setupTestData(ctx context.Context, t *testing.T, builder *testDataBuilder) time.Time {
 	t.Helper()
 	now := time.Unix(0, int64(time.Hour)).UTC()
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This fixes an issue with the backoff in `writeEntry` where it could not be canceled by the caller, even if they wanted to. We now use the `ctx` from the argument instead.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
