### PR TITLE
feat: add p50, p95 and p99 sections per tenant to stats

### DIFF
--- a/cmd/dataobj-inspect/stats.go
+++ b/cmd/dataobj-inspect/stats.go
@@ -54,10 +54,13 @@ func (cmd *statsCommand) printObjStats(ctx context.Context, obj *dataobj.Object)
 	bold := color.New(color.Bold)
 	bold.Println("Object:")
 	fmt.Printf(
-		"\tsize: %v, sections: %d, tenants: %d\n",
+		"\tsize: %v, sections: %d, tenants: %d, sections per tenant: p50: %.2f, p95: %.2f, p99: %.2f\n",
 		humanize.Bytes(stats.Size),
 		stats.Sections,
 		len(stats.Tenants),
+		stats.SectionsPerTenantStats.Median,
+		stats.SectionsPerTenantStats.P95,
+		stats.SectionsPerTenantStats.P99,
 	)
 	for offset, sec := range obj.Sections() {
 		switch {

--- a/pkg/dataobj/tools/stats.go
+++ b/pkg/dataobj/tools/stats.go
@@ -14,9 +14,17 @@ import (
 )
 
 type Stats struct {
-	Size     uint64
-	Sections int
-	Tenants  []string
+	Size           uint64
+	Sections       int
+	Tenants        []string
+	TenantSections map[string]int
+	SectionsPerTenantStats
+}
+
+type SectionsPerTenantStats struct {
+	Median float64
+	P95    float64
+	P99    float64
 }
 
 // ReadStats returns statistics about the data object. ReadStats returns an
@@ -25,6 +33,7 @@ type Stats struct {
 func ReadStats(ctx context.Context, obj *dataobj.Object) (*Stats, error) {
 	s := Stats{}
 	s.Size = uint64(obj.Size())
+	s.TenantSections = make(map[string]int)
 	for _, sec := range obj.Sections() {
 		s.Sections++
 		switch {
@@ -33,13 +42,17 @@ func ReadStats(ctx context.Context, obj *dataobj.Object) (*Stats, error) {
 			if err != nil {
 				return nil, err
 			}
-			s.Tenants = append(s.Tenants, streamsSec.Tenant())
+			tenant := streamsSec.Tenant()
+			s.Tenants = append(s.Tenants, tenant)
+			s.TenantSections[tenant]++
 		case logs.CheckSection(sec):
 			logsSec, err := logs.Open(ctx, sec)
 			if err != nil {
 				return nil, err
 			}
-			s.Tenants = append(s.Tenants, logsSec.Tenant())
+			tenant := logsSec.Tenant()
+			s.Tenants = append(s.Tenants, tenant)
+			s.TenantSections[tenant]++
 		default:
 			return nil, errors.New("unknown section type")
 		}
@@ -47,5 +60,34 @@ func ReadStats(ctx context.Context, obj *dataobj.Object) (*Stats, error) {
 	// A tenant can have multiple sections, so we must deduplicate them.
 	slices.Sort(s.Tenants)
 	s.Tenants = slices.Compact(s.Tenants)
+	calculateSectionsPerTenantStats(&s)
 	return &s, nil
+}
+
+func calculateSectionsPerTenantStats(s *Stats) {
+	if len(s.TenantSections) == 0 {
+		return
+	}
+	counts := make([]int, 0, len(s.TenantSections))
+	for _, n := range s.TenantSections {
+		counts = append(counts, n)
+	}
+	// Data must be sorted to calculate percentiles.
+	slices.Sort(counts)
+	n := len(counts)
+	if n%2 == 0 {
+		s.SectionsPerTenantStats.Median = float64(counts[n/2-1]+counts[n/2]) / 2.0
+	} else {
+		s.SectionsPerTenantStats.Median = float64(counts[n/2])
+	}
+	idx := int(float64(n) * 0.95)
+	if idx >= n {
+		idx = n - 1
+	}
+	s.SectionsPerTenantStats.P95 = float64(counts[idx])
+	idx = int(float64(n) * 0.99)
+	if idx >= n {
+		idx = n - 1
+	}
+	s.SectionsPerTenantStats.P99 = float64(counts[idx])
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds p50, p95 and p99 sections per tenant to stats. For example:

```
Object:
        size: 398 MB, sections: 142, tenants: 68, sections per tenant: p50: 2.00, p95: 2.00, p99: 8.00
Logs section:
        offset: 0, tenant: 29, columns: 51, compressed size: 47 MB, uncompressed size 537 MB
...
```

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
