### PR TITLE
Customize the loki-querier probes

### DIFF
--- a/production/helm/loki/templates/querier/deployment-querier.yaml
+++ b/production/helm/loki/templates/querier/deployment-querier.yaml
@@ -104,13 +104,13 @@ spec:
           {{- end }}
           securityContext:
             {{- toYaml .Values.loki.containerSecurityContext | nindent 12 }}
-          {{- with .Values.loki.livenessProbe }}
+          {{- if .Values.loki.livenessProbe }}
           livenessProbe:
-            {{- toYaml . | nindent 12 }}
+            {{- mergeOverwrite (deepCopy (default dict .Values.loki.livenessProbe)) (default dict .Values.querier.livenessProbe) | toYaml | nindent 12 }}
           {{- end }}
-          {{- with .Values.loki.readinessProbe }}
+          {{- if .Values.loki.readinessProbe }}
           readinessProbe:
-            {{- toYaml . | nindent 12 }}
+            {{- mergeOverwrite (deepCopy (default dict .Values.loki.readinessProbe)) (default dict .Values.querier.readinessProbe) | toYaml | nindent 12 }}
           {{- end }}
           volumeMounts:
             - name: config


### PR DESCRIPTION
**What this PR does / why we need it**:
Allow the customization of the liveness and readiness probes for the loki-querier, an example is the `initialDelaySeconds`

During periods of high read requests, the loki querier pods scale up, but take 30 seconds before they are ready. This is the default value associated with the readinessProbe on the pod and triggers delays in queriers to handle queue search requests. Being able to reduce this value to 15s or 20s is a large improvement to allow queries to be executed faster.

**Which issue(s) this PR fixes**:
Fixes #19020

**Special notes for your reviewer**:
Setting the values.yaml to include the following:
```
querier:
  readinessProbe:
    initialDelaySeconds: 10
```

yields the following
```
readinessProbe:
   httpGet:
      path: /ready
      port: http-metrics
   initialDelaySeconds: 10
   timeoutSeconds: 1
```

With no override, the chart yields the following which is the default configuration:
```
readinessProbe:
   httpGet:
      path: /ready
      port: http-metrics
   initialDelaySeconds: 30
   timeoutSeconds: 1
```

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
