### PR TITLE
fix: don't need to open section to read tenant

### DIFF
--- a/pkg/dataobj/tools/stats.go
+++ b/pkg/dataobj/tools/stats.go
@@ -5,12 +5,9 @@ package tools
 
 import (
 	"context"
-	"errors"
 	"slices"
 
 	"github.com/grafana/loki/v3/pkg/dataobj"
-	"github.com/grafana/loki/v3/pkg/dataobj/sections/logs"
-	"github.com/grafana/loki/v3/pkg/dataobj/sections/streams"
 )
 
 type Stats struct {
@@ -36,26 +33,7 @@ func ReadStats(ctx context.Context, obj *dataobj.Object) (*Stats, error) {
 	s.TenantSections = make(map[string]int)
 	for _, sec := range obj.Sections() {
 		s.Sections++
-		switch {
-		case streams.CheckSection(sec):
-			streamsSec, err := streams.Open(ctx, sec)
-			if err != nil {
-				return nil, err
-			}
-			tenant := streamsSec.Tenant()
-			s.Tenants = append(s.Tenants, tenant)
-			s.TenantSections[tenant]++
-		case logs.CheckSection(sec):
-			logsSec, err := logs.Open(ctx, sec)
-			if err != nil {
-				return nil, err
-			}
-			tenant := logsSec.Tenant()
-			s.Tenants = append(s.Tenants, tenant)
-			s.TenantSections[tenant]++
-		default:
-			return nil, errors.New("unknown section type")
-		}
+		s.Tenants = append(s.Tenants, sec.Tenant)
 	}
 	// A tenant can have multiple sections, so we must deduplicate them.
 	slices.Sort(s.Tenants)


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
