### PR TITLE
feat: add p50, p95 and p99 section sizes per tenant

### DIFF
--- a/cmd/dataobj-inspect/stats.go
+++ b/cmd/dataobj-inspect/stats.go
@@ -54,19 +54,19 @@ func (cmd *statsCommand) printObjStats(ctx context.Context, obj *dataobj.Object)
 	bold := color.New(color.Bold)
 	bold.Println("Object:")
 	fmt.Printf(
-		"\tsize: %v, sections: %d, tenants: %d\n",
+		"\tcompressed size: %v, sections: %d, tenants: %d\n",
 		humanize.Bytes(stats.Size),
 		stats.Sections,
 		len(stats.Tenants),
 	)
 	fmt.Printf(
-		"\tsection sizes:\n\t\tp50: %v, p95: %v, p99: %v\n",
+		"\tcompressed section sizes:\n\t\tp50: %v, p95: %v, p99: %v\n",
 		humanize.Bytes(uint64(stats.SectionSizeStats.Median)),
 		humanize.Bytes(uint64(stats.SectionSizeStats.P95)),
 		humanize.Bytes(uint64(stats.SectionSizeStats.P99)),
 	)
 	fmt.Printf(
-		"\tsections per tenant:\n\t\tp50: %.2f, p95: %.2f, p99: %.2f\n",
+		"\tnumber of sections per tenant:\n\t\tp50: %.2f, p95: %.2f, p99: %.2f\n",
 		stats.SectionsPerTenantStats.Median,
 		stats.SectionsPerTenantStats.P95,
 		stats.SectionsPerTenantStats.P99,

--- a/cmd/dataobj-inspect/stats.go
+++ b/cmd/dataobj-inspect/stats.go
@@ -54,10 +54,19 @@ func (cmd *statsCommand) printObjStats(ctx context.Context, obj *dataobj.Object)
 	bold := color.New(color.Bold)
 	bold.Println("Object:")
 	fmt.Printf(
-		"\tsize: %v, sections: %d, tenants: %d, sections per tenant: p50: %.2f, p95: %.2f, p99: %.2f\n",
+		"\tsize: %v, sections: %d, tenants: %d\n",
 		humanize.Bytes(stats.Size),
 		stats.Sections,
 		len(stats.Tenants),
+	)
+	fmt.Printf(
+		"\tsection sizes:\n\t\tp50: %v, p95: %v, p99: %v\n",
+		humanize.Bytes(uint64(stats.SectionSizeStats.Median)),
+		humanize.Bytes(uint64(stats.SectionSizeStats.P95)),
+		humanize.Bytes(uint64(stats.SectionSizeStats.P99)),
+	)
+	fmt.Printf(
+		"\tsections per tenant:\n\t\tp50: %.2f, p95: %.2f, p99: %.2f\n",
 		stats.SectionsPerTenantStats.Median,
 		stats.SectionsPerTenantStats.P95,
 		stats.SectionsPerTenantStats.P99,

--- a/pkg/dataobj/tools/stats.go
+++ b/pkg/dataobj/tools/stats.go
@@ -11,22 +11,16 @@ import (
 )
 
 type Stats struct {
-	Size           uint64
-	Sections       int
-	SectionSizes   []uint64
-	Tenants        []string
-	TenantSections map[string]int
-	SectionsPerTenantStats
-	SectionSizeStats
+	Size                   uint64
+	Sections               int
+	SectionSizes           []uint64
+	Tenants                []string
+	TenantSections         map[string]int
+	SectionsPerTenantStats PercentileStats
+	SectionSizeStats       PercentileStats
 }
 
-type SectionsPerTenantStats struct {
-	Median float64
-	P95    float64
-	P99    float64
-}
-
-type SectionSizeStats struct {
+type PercentileStats struct {
 	Median float64
 	P95    float64
 	P99    float64


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request adds the p50, p95 and p99 section sizes when printing the stats for a data object.

```
Object:
        size: 398 MB, sections: 142, tenants: 68
        section sizes:
                p50: 3.9 kB, p95: 44 MB, p99: 48 MB
        sections per tenant:
                p50: 2.00, p95: 2.00, p99: 8.00
Logs section:
        offset: 0, tenant: -1, columns: 51, compressed size: 47 MB, uncompressed size 537 MB
                name: , type: stream_id, 1467722 populated rows, 1.7 MB compressed (NONE), 1.7 MB uncompressed
                name: , type: timestamp, 1467722 populated rows, 4.0 MB compressed (NONE), 4.0 MB uncompressed
```

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
