### PR TITLE
fix(CI): release scripts add newline

### DIFF
--- a/.github/workflows/scripts/helm-tagged-release.sh
+++ b/.github/workflows/scripts/helm-tagged-release.sh
@@ -47,7 +47,7 @@ update_yaml_node "${chart_file}" .version "${new_chart_version}"
 
 sed --in-place \
   --regexp-extended \
-  "s/## Unreleased/## Unreleased\n\n## ${new_chart_version}\n\n- \[CHANGE\] Changed version of Grafana Loki to ${latest_loki_tag}/g" production/helm/loki/CHANGELOG.md
+  "s/## Unreleased/## Unreleased\n\n\n## ${new_chart_version}\n\n- \[CHANGE\] Changed version of Grafana Loki to ${latest_loki_tag}/g" production/helm/loki/CHANGELOG.md
 
 make TTY='' helm-docs
 

--- a/.github/workflows/scripts/helm-weekly-release.sh
+++ b/.github/workflows/scripts/helm-weekly-release.sh
@@ -101,11 +101,11 @@ update_yaml_node "${chart_file}" .version "${new_chart_version}"
 if ${k_release}; then
   sed --in-place \
     --regexp-extended \
-    "s/## Unreleased/## Unreleased\n\n## ${new_chart_version}\n\n- \[CHANGE\] Changed version of Grafana Loki to ${latest_loki_tag}\n- \[CHANGE\] Changed version of Grafana Enterprise Logs to ${latest_gel_tag}/g" production/helm/loki/CHANGELOG.md
+    "s/## Unreleased/## Unreleased\n\n\n## ${new_chart_version}\n\n- \[CHANGE\] Changed version of Grafana Loki to ${latest_loki_tag}\n- \[CHANGE\] Changed version of Grafana Enterprise Logs to ${latest_gel_tag}/g" production/helm/loki/CHANGELOG.md
 else
   sed --in-place \
     --regexp-extended \
-    "s/## Unreleased/## Unreleased\n\n## ${new_chart_version}/g" production/helm/loki/CHANGELOG.md
+    "s/## Unreleased/## Unreleased\n\n\n## ${new_chart_version}/g" production/helm/loki/CHANGELOG.md
 fi
 
 make TTY='' helm-docs


### PR DESCRIPTION
**What this PR does / why we need it**:

I previously tried to fix this in https://github.com/grafana/loki/pull/19011 but I now realize that it wasn't 100% correct.  It solved an ephemeral issue that was remedied on the next release.  Long term we need another newline in the release script.  Demonstrated through a git-diff of the output.

```
  ## Unreleased

+
  ## 6.38.0
```

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
