### PR TITLE
fix: fix possible data loss in dataobj-consumers

### DIFF
--- a/pkg/dataobj/consumer/consumer.go
+++ b/pkg/dataobj/consumer/consumer.go
@@ -105,8 +105,8 @@ func (c *consumer) pollFetches(ctx context.Context) error {
 
 func (c *consumer) processFetchTopicPartition(_ context.Context) func(kgo.FetchTopicPartition) {
 	return func(fetch kgo.FetchTopicPartition) {
-		if fetch.Err != nil {
-			level.Error(c.logger).Log("msg", "failed to fetch records for topic partition", "topic", fetch.Topic, "partition", fetch.Partition, "err", fetch.Err.Error())
+		if err := fetch.Err; err != nil {
+			level.Error(c.logger).Log("msg", "failed to fetch records for topic partition", "topic", fetch.Topic, "partition", fetch.Partition, "err", err.Error())
 			return
 		}
 		// If there are no records for this partition then skip it.


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit fixes a mistake in how we checked errors in the dataobj-consumer. If a fetch returned an error then we would discard records for all other fetches when instead we should have processed their records, which in turn would mean data loss.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
