### PR TITLE
chore: Fix index generation with filesystem

### DIFF
--- a/pkg/dataobj/index/calculate_test.go
+++ b/pkg/dataobj/index/calculate_test.go
@@ -11,12 +11,13 @@ import (
 	"github.com/go-kit/log"
 	"github.com/stretchr/testify/require"
 
+	"github.com/thanos-io/objstore/providers/filesystem"
+
 	"github.com/grafana/loki/v3/pkg/dataobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/consumer/logsobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/index/indexobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/pointers"
 	"github.com/grafana/loki/v3/pkg/logproto"
-	"github.com/thanos-io/objstore/providers/filesystem"
 
 	"github.com/grafana/loki/pkg/push"
 )

--- a/pkg/dataobj/index/calculate_test.go
+++ b/pkg/dataobj/index/calculate_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/dataobj/index/indexobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/pointers"
 	"github.com/grafana/loki/v3/pkg/logproto"
+	"github.com/thanos-io/objstore/providers/filesystem"
 
 	"github.com/grafana/loki/pkg/push"
 )
@@ -99,16 +100,59 @@ func createTestLogObject(t *testing.T) *dataobj.Object {
 }
 
 func TestCalculator_Calculate(t *testing.T) {
-	t.Run("successful calculation", func(t *testing.T) {
+	logger := log.NewNopLogger()
+	t.Run("successful calculation from readerAt", func(t *testing.T) {
 		indexBuilder, err := indexobj.NewBuilder(testCalculatorConfig, nil)
 		require.NoError(t, err)
 
 		calculator := NewCalculator(indexBuilder)
 		for i := 0; i < 10; i++ {
 			obj := createTestLogObject(t)
-			logger := log.NewNopLogger()
 
 			err = calculator.Calculate(context.Background(), logger, obj, fmt.Sprintf("test/path-%d", i))
+			require.NoError(t, err)
+		}
+
+		// Verify we can flush the results
+		timeRanges := calculator.TimeRanges()
+		obj, closer, err := calculator.Flush()
+		require.NoError(t, err)
+		defer closer.Close()
+
+		require.Greater(t, obj.Size(), int64(0))
+		require.Equal(t, len(timeRanges), 1)
+		require.False(t, timeRanges[0].MinTime.IsZero())
+		require.Equal(t, timeRanges[0].MinTime, time.Unix(10, 0).UTC())
+		require.False(t, timeRanges[0].MaxTime.IsZero())
+		require.Equal(t, timeRanges[0].MaxTime, time.Unix(25, 0).UTC())
+
+		// Confirm we have multiple pointers sections
+		count := obj.Sections().Count(pointers.CheckSection)
+		require.Greater(t, count, 1)
+
+		requireValidPointers(t, obj)
+	})
+
+	t.Run("successful calculation from FS bucket", func(t *testing.T) {
+		indexBuilder, err := indexobj.NewBuilder(testCalculatorConfig, nil)
+		require.NoError(t, err)
+
+		bucket, err := filesystem.NewBucket(t.TempDir())
+		require.NoError(t, err)
+
+		calculator := NewCalculator(indexBuilder)
+		for i := 0; i < 10; i++ {
+			obj := createTestLogObject(t)
+
+			// Upload to bucket
+			reader, err := obj.Reader(context.Background())
+			require.NoError(t, err)
+			err = bucket.Upload(context.Background(), fmt.Sprintf("obj-%d", i), reader)
+			require.NoError(t, err)
+			bucketObj, err := dataobj.FromBucket(context.Background(), bucket, fmt.Sprintf("obj-%d", i))
+			require.NoError(t, err)
+
+			err = calculator.Calculate(context.Background(), logger, bucketObj, fmt.Sprintf("test/path-%d", i))
 			require.NoError(t, err)
 		}
 

--- a/pkg/logql/bench/store_dataobj.go
+++ b/pkg/logql/bench/store_dataobj.go
@@ -50,24 +50,27 @@ func NewDataObjStore(dir, tenantID string) (*DataObjStore, error) {
 	// NOTE(rfratto): DataObjStore should use a dataobj subdirectory to imitate
 	// production setup: a dataobj subdirectory in the location used for chunks.
 	storeDir := filepath.Join(dir, "dataobj")
-	if err := os.MkdirAll(storeDir, 0o755); err != nil {
+	logsTocDir := filepath.Join(storeDir, "tocs")
+	if err := os.MkdirAll(logsTocDir, 0o755); err != nil {
 		return nil, fmt.Errorf("failed to create directory: %w", err)
 	}
 
-	// Create required directories for metastore and tenant
+	// Create required directories for tenant
 	tenantDir := filepath.Join(storeDir, "tenant-"+tenantID)
-	metastoreDir := filepath.Join(tenantDir, "metastore")
-	if err := os.MkdirAll(metastoreDir, 0o755); err != nil {
+	if err := os.MkdirAll(tenantDir, 0o755); err != nil {
 		return nil, fmt.Errorf("failed to create metastore directory: %w", err)
 	}
 
 	// Create required directories for index
 	indexDirPrefix := "index/v0"
 	indexDir := filepath.Join(storeDir, indexDirPrefix)
-	tenantIndexDir := filepath.Join(indexDir, "tenant-"+tenantID)
-	metastoreIndexDir := filepath.Join(tenantIndexDir, "metastore")
-	if err := os.MkdirAll(metastoreIndexDir, 0o755); err != nil {
-		return nil, fmt.Errorf("failed to create index directory: %w", err)
+	tocDir := filepath.Join(indexDir, "tocs")
+	if err := os.MkdirAll(tocDir, 0o755); err != nil {
+		return nil, fmt.Errorf("failed to create toc directory: %w", err)
+	}
+	indexesDir := filepath.Join(indexDir, "indexes")
+	if err := os.MkdirAll(indexesDir, 0o755); err != nil {
+		return nil, fmt.Errorf("failed to create indexes directory: %w", err)
 	}
 
 	bucket, err := filesystem.NewBucket(storeDir)


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes two issues with generating indexes in the benchmark suite
* The GetAndReplace objstore method requires the directory to exist
* The index Calculator didn't work with a "real" bucket due to context calcuation. The context is cancelled after calling errgroup.Wait() but it was re-used later. The in-mem bucket & readerAt implementations don't check the context during reads so this didn't trigger the existing tests.
