### PR TITLE
chore: Fix init of engine with metastore

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -38,10 +38,11 @@ var ErrNotSupported = errors.New("feature not supported in new query engine")
 func New(opts logql.EngineOpts, cfg metastore.Config, bucket objstore.Bucket, limits logql.Limits, reg prometheus.Registerer, logger log.Logger) *QueryEngine {
 	var ms metastore.Metastore
 	if bucket != nil {
+		indexBucket := bucket
 		if cfg.IndexStoragePrefix != "" {
-			bucket = objstore.NewPrefixedBucket(bucket, cfg.IndexStoragePrefix)
+			indexBucket = objstore.NewPrefixedBucket(bucket, cfg.IndexStoragePrefix)
 		}
-		ms = metastore.NewObjectMetastore(bucket, logger, reg)
+		ms = metastore.NewObjectMetastore(indexBucket, logger, reg)
 	}
 
 	if opts.BatchSize <= 0 {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes the initialization of the engine v2 so the prefixed metastore bucket doesn't also override the engine's bucket.