### PR TITLE
chore: Make EngineV2 use indexes in benchmarks

### DIFF
--- a/pkg/logql/bench/bench_test.go
+++ b/pkg/logql/bench/bench_test.go
@@ -36,13 +36,12 @@ var (
 const testTenant = "test-tenant"
 
 const (
-	StoreDataObj                    = "dataobj"
-	StoreDataObjV2Engine            = "dataobj-engine"
-	StoreDataObjV2EngineWithIndexes = "dataobj-engine-with-indexes"
-	StoreChunk                      = "chunk"
+	StoreDataObj         = "dataobj"
+	StoreDataObjV2Engine = "dataobj-engine"
+	StoreChunk           = "chunk"
 )
 
-var allStores = []string{StoreDataObj, StoreDataObjV2Engine, StoreDataObjV2EngineWithIndexes, StoreChunk}
+var allStores = []string{StoreDataObj, StoreDataObjV2Engine, StoreChunk}
 
 //go:generate go run ./cmd/generate/main.go -size 2147483648 -dir ./data -tenant test-tenant
 
@@ -63,12 +62,6 @@ func setupBenchmarkWithStore(tb testing.TB, storeType string) logql.Engine {
 			tb.Fatal(err)
 		}
 
-		return store.engine
-	case StoreDataObjV2EngineWithIndexes:
-		store, err := NewDataObjV2EngineWithIndexesStore(DefaultDataDir, testTenant)
-		if err != nil {
-			tb.Fatal(err)
-		}
 		return store.engine
 	case StoreDataObj:
 		store, err := NewDataObjStore(DefaultDataDir, testTenant)

--- a/pkg/logql/bench/store_dataobj_v2_engine.go
+++ b/pkg/logql/bench/store_dataobj_v2_engine.go
@@ -31,16 +31,6 @@ func NewDataObjV2EngineStore(dataDir string, tenantID string) (*DataObjV2EngineS
 		EnableV2Engine: true,
 		BatchSize:      512,
 		RangeConfig:    rangeio.DefaultConfig,
-	}, metastore.Config{})
-}
-
-// NewDataObjV2EngineWithIndexesStore creates a new store that uses the v2 dataobj engine but also with index support.
-// This is useful for comparing results between when an index is available and when it is not. Once tested, the indexed engine will be the default.
-func NewDataObjV2EngineWithIndexesStore(dataDir string, tenantID string) (*DataObjV2EngineStore, error) {
-	return dataobjV2StoreWithOpts(dataDir, tenantID, logql.EngineOpts{
-		EnableV2Engine: true,
-		BatchSize:      512,
-		RangeConfig:    rangeio.DefaultConfig,
 	}, metastore.Config{
 		IndexStoragePrefix: "index/v0",
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:
This makes the EngineV2 benchmark store use indexes by default. It removes the store named "WithIndexes" in favour of just one engine v2 benchmark.

This is required because the Catalogue no longer knows how to choose between the indexed metastore and the "direct" metastore. In addition, `main` no longer supports the direct approach and queries are required to go through the index files.

I ran a few of the equality tests to check everything was working correctly.
Depends on https://github.com/grafana/loki/pull/19064 for full functionality.