### PR TITLE
feat(helm): add helm-unittest support

### DIFF
--- a/.github/workflows/helm-ci.yml
+++ b/.github/workflows/helm-ci.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   CT_CONFIGFILE: production/helm/ct.yaml
-  INTEGRARION_TESTS_DIR: production/helm/loki/test/integration
+  INTEGRATION_TESTS_DIR: production/helm/loki/test/integration
 
 jobs:
 # Temporarily disabled linting because this step doesn't easily support passing GO tags yet.
@@ -49,6 +49,7 @@ jobs:
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@0d28d3144d3a25ea2cc349d6e59901c4ff469b3b # v2.7.0
+
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |
@@ -58,7 +59,7 @@ jobs:
           fi
 
       - name: Run chart-testing (lint)
-        run: ct lint --config "${CT_CONFIGFILE}" --check-version-increment=false
+        run: ct lint --config "${CT_CONFIGFILE}"
         timeout-minutes: 10
 
       - name: Create kind cluster
@@ -103,7 +104,7 @@ jobs:
 
       - name: List tests
         id: list_tests
-        working-directory: "${{ env.INTEGRARION_TESTS_DIR }}"
+        working-directory: "${{ env.INTEGRATION_TESTS_DIR }}"
         env:
           LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
         run: |
@@ -153,5 +154,5 @@ jobs:
       - name: Run test
         run: helm-chart-toolbox/tools/helm-test/helm-test "${TEST_DIRECTORY}"
         env:
-          TEST_DIRECTORY: "source/${{ env.INTEGRARION_TESTS_DIR }}/${{ matrix.test }}"
+          TEST_DIRECTORY: "source/${{ env.INTEGRATION_TESTS_DIR }}/${{ matrix.test }}"
           DELETE_CLUSTER: true

--- a/production/helm/ct.yaml
+++ b/production/helm/ct.yaml
@@ -1,6 +1,5 @@
----
-remote: origin
-target-branch: main
+additional-commands:
+  - helm unittest --strict --file 'unittests/**/*.yaml' {{ .Path }}
 chart-dirs:
   - production/helm
 chart-repos:
@@ -8,4 +7,7 @@ chart-repos:
   - minio=https://charts.min.io
   - prometheus-community=https://prometheus-community.github.io/helm-charts
 check-version-increment: false
+remote: origin
+target-branch: main
+use-helmignore: true
 validate-maintainers: false

--- a/production/helm/loki/.helmignore
+++ b/production/helm/loki/.helmignore
@@ -30,3 +30,4 @@ README.tpl
 README.md.gotmpl
 ci
 CHANGELOG.md
+CLAUDE.md

--- a/production/helm/loki/CLAUDE.md
+++ b/production/helm/loki/CLAUDE.md
@@ -1,0 +1,26 @@
+# Loki Helm Chart Development
+
+## Chart Structure
+
+The Loki Helm chart is located in `production/helm/loki/` and follows standard Helm conventions.
+
+```
+production/helm/loki/
+├── templates/           # Helm template files
+├── unittests/          # Helm unit tests (mirrors templates/ structure)  
+├── values.yaml         # Default chart values
+├── Chart.yaml          # Chart metadata
+└── Makefile           # Chart-specific commands
+```
+
+## Testing
+
+### Helm Unit Tests
+
+Run helm unit tests using Docker:
+
+```bash
+make helm-unittest     # run all helm unit tests
+```
+
+Unit tests are located in `unittests/` and use the [helm-unittest](https://github.com/helm-unittest/helm-unittest) plugin. The directory structure mirrors the `templates/` directory. Tests use Docker to ensure consistency across environments.

--- a/production/helm/loki/Makefile
+++ b/production/helm/loki/Makefile
@@ -1,5 +1,5 @@
 .DEFAULT_GOAL := all
-.PHONY: lint lint-yaml install-distributed install-single-binary uninstall update-chart update
+.PHONY: lint lint-yaml helm-unittest install-distributed install-single-binary uninstall update-chart update
 
 # Optional image override, example: make install-distributed IMAGE=grafana/loki:2.9.0
 IMAGE ?=
@@ -44,6 +44,9 @@ lint: lint-yaml
 
 lint-yaml:
 	yamllint -c $(CURDIR)/src/.yamllint.yaml $(CURDIR)/src
+
+helm-unittest:
+	docker run --rm -v ./:/apps helmunittest/helm-unittest:3.11.1-0.3.0 --strict --file unittests/**/*.yaml /apps
 
 # Helm chart installation targets
 install-distributed:

--- a/production/helm/loki/unittests/extra-manifests_test.yaml
+++ b/production/helm/loki/unittests/extra-manifests_test.yaml
@@ -1,0 +1,199 @@
+suite: test extra-manifests
+templates:
+  - extra-manifests.yaml
+tests:
+  - it: should render nothing when extraObjects is empty
+    set:
+      extraObjects: []
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render nothing when extraObjects is not set
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render single string object
+    set:
+      extraObjects:
+        - |
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: test-configmap
+            namespace: default
+          data:
+            key: value
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.name
+          value: test-configmap
+      - equal:
+          path: data.key
+          value: value
+
+  - it: should render single map object
+    set:
+      extraObjects:
+        - apiVersion: v1
+          kind: Secret
+          metadata:
+            name: test-secret
+            namespace: default
+          type: Opaque
+          data:
+            password: cGFzc3dvcmQ=
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Secret
+      - equal:
+          path: metadata.name
+          value: test-secret
+      - equal:
+          path: type
+          value: Opaque
+      - equal:
+          path: data.password
+          value: cGFzc3dvcmQ=
+
+  - it: should render multiple objects with mixed types
+    set:
+      extraObjects:
+        - |
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: configmap-1
+          data:
+            config: value1
+        - apiVersion: v1
+          kind: Service
+          metadata:
+            name: test-service
+          spec:
+            selector:
+              app: test
+            ports:
+              - port: 80
+        - |
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: test-deployment
+          spec:
+            replicas: 2
+    asserts:
+      - hasDocuments:
+          count: 3
+      - equal:
+          path: kind
+          value: ConfigMap
+          documentSelector:
+            path: .metadata.name
+            value: configmap-1
+      - equal:
+          path: data.config
+          value: value1
+          documentSelector:
+            path: kind
+            value: ConfigMap
+      - equal:
+          path: kind
+          value: Service
+          documentSelector:
+            path: metadata.name
+            value: test-service
+      - equal:
+          path: spec.ports[0].port
+          value: 80
+          documentSelector:
+            path: kind
+            value: Service
+      - equal:
+          path: kind
+          value: Deployment
+          documentSelector:
+            path: metadata.name
+            value: test-deployment
+      - equal:
+          path: spec.replicas
+          value: 2
+          documentSelector:
+            path: kind
+            value: Deployment
+
+  - it: should handle templating with helm values
+    set:
+      nameOverride: my-loki
+      extraObjects:
+        - |
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: {{ include "loki.name" . }}-extra-config
+            labels:
+              {{- include "loki.labels" . | nindent 4 }}
+          data:
+            config: templated-value
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.name
+          value: my-loki-extra-config
+      - isNotEmpty:
+          path: metadata.labels
+
+  - it: should render object with namespace from template
+    set:
+      extraObjects:
+        - apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: test-cm
+            namespace: "{{ .Release.Namespace }}"
+          data:
+            key: value
+    release:
+      namespace: test-namespace
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.namespace
+          value: test-namespace
+
+  - it: should handle complex nested structures
+    set:
+      extraObjects:
+        - apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: complex-config
+          data:
+            config.yaml: |
+              server:
+                port: 8080
+                host: localhost
+              database:
+                url: postgres://localhost:5432/db
+                pool_size: 10
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.name
+          value: complex-config
+      - isNotEmpty:
+          path: data["config.yaml"]


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds [helm-unittest](https://github.com/helm-unittest/helm-unittest) support. Helpful for local static testing. I added one test for now. I didn't want to overwhelm this PR with dozens of test cases. Plus if I can get it out quicker maybe others will build upon it.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
