### PR TITLE
fix(networkpolicy): use UDP/53 for DNS egress instead of named port

### DIFF
--- a/production/helm/loki/templates/ciliumnetworkpolicy.yaml
+++ b/production/helm/loki/templates/ciliumnetworkpolicy.yaml
@@ -33,6 +33,8 @@ spec:
     - ports:
       - port: 53
         protocol: UDP
+      - port: 53
+        protocol: TCP
     toEndpoints:
     - namespaceSelector: {}
 

--- a/production/helm/loki/templates/networkpolicy.yaml
+++ b/production/helm/loki/templates/networkpolicy.yaml
@@ -37,6 +37,8 @@ spec:
     - ports:
         - port: 53
           protocol: UDP
+        - port: 53
+          protocol: TCP
       to:
         - namespaceSelector: {}
 


### PR DESCRIPTION
Hello,

**What this PR does / why we need it**:
The current NetworkPolicy template allows DNS egress using the named port dns.
However, not all clusters define a DNS service port with that name. This can cause the policy to block DNS traffic.

This PR replaces the named port with the standard numeric port 53/UDP, ensuring DNS resolution works consistently across clusters that use standard port for DNS service.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
Should we make it configurable? (especially for clusters with a DNS service not on port 53)

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [X] Documentation added
- [X] Tests updated
- [X] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [X] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [X] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
