### PR TITLE
chore(ci): Run `make release-workflows` to update Go version in yaml

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -10,7 +10,7 @@
   "loki-canary-boringcrypto-image":
     "env":
       "BUILD_TIMEOUT": 60
-      "GO_VERSION": "1.24.4"
+      "GO_VERSION": "1.24.6"
       "IMAGE_PREFIX": "grafana"
       "RELEASE_LIB_REF": "1dd22f1dbfa671ac40e4a92f1a56bd9821871d44"
       "RELEASE_REPO": "grafana/loki"
@@ -133,7 +133,7 @@
   "loki-canary-image":
     "env":
       "BUILD_TIMEOUT": 60
-      "GO_VERSION": "1.24.4"
+      "GO_VERSION": "1.24.6"
       "IMAGE_PREFIX": "grafana"
       "RELEASE_LIB_REF": "1dd22f1dbfa671ac40e4a92f1a56bd9821871d44"
       "RELEASE_REPO": "grafana/loki"
@@ -256,7 +256,7 @@
   "loki-image":
     "env":
       "BUILD_TIMEOUT": 60
-      "GO_VERSION": "1.24.4"
+      "GO_VERSION": "1.24.6"
       "IMAGE_PREFIX": "grafana"
       "RELEASE_LIB_REF": "1dd22f1dbfa671ac40e4a92f1a56bd9821871d44"
       "RELEASE_REPO": "grafana/loki"
@@ -379,7 +379,7 @@
   "promtail-image":
     "env":
       "BUILD_TIMEOUT": 60
-      "GO_VERSION": "1.24.4"
+      "GO_VERSION": "1.24.6"
       "IMAGE_PREFIX": "grafana"
       "RELEASE_LIB_REF": "1dd22f1dbfa671ac40e4a92f1a56bd9821871d44"
       "RELEASE_REPO": "grafana/loki"


### PR DESCRIPTION
### Summary

Running `make release-workflows` is needed after updating `GO_VERSION` in the Makefile in order to reflect the changes in the workflow files.