### PR TITLE
chore: Fix tenant info in sections when resetting

### DIFF
--- a/pkg/dataobj/consumer/logsobj/builder.go
+++ b/pkg/dataobj/consumer/logsobj/builder.go
@@ -235,6 +235,8 @@ func (b *Builder) Append(tenant string, stream logproto.Stream) error {
 			if err := b.builder.Append(lb); err != nil {
 				return err
 			}
+			// We need to set the tenant again after flushing because the builder is reset.
+			lb.SetTenant(tenant)
 		}
 	}
 

--- a/pkg/dataobj/consumer/logsobj/builder_test.go
+++ b/pkg/dataobj/consumer/logsobj/builder_test.go
@@ -117,9 +117,14 @@ func TestBuilder_Append(t *testing.T) {
 	require.NoError(t, err)
 	defer closer.Close()
 
-	require.Equal(t, 1, obj.Sections().Count(streams.CheckSection))
-	require.Greater(t, obj.Sections().Count(logs.CheckSection), 1)
-	for _, section := range obj.Sections().Filter(logs.CheckSection) {
+	// When a section builder is reset, which happens on ErrBuilderFull, the
+	// tenant is reset too. We must check that the tenant is added back
+	// to the section builder otherwise tenant will be absent from successive
+	// sections.
+	secs := obj.Sections()
+	require.Equal(t, 1, secs.Count(streams.CheckSection))
+	require.Greater(t, secs.Count(logs.CheckSection), 1)
+	for _, section := range secs.Filter(logs.CheckSection) {
 		require.Equal(t, tenant, section.Tenant)
 	}
 }

--- a/pkg/logql/bench/bench_test.go
+++ b/pkg/logql/bench/bench_test.go
@@ -386,3 +386,20 @@ func TestPrintBenchmarkQueries(t *testing.T) {
 	t.Logf("- Metric queries: %d (forward only)", metricQueries)
 	t.Logf("- Total benchmark cases: %d", len(cases))
 }
+
+func TestStoresGenerateData(t *testing.T) {
+	dir := t.TempDir()
+
+	chunkStore, err := NewChunkStore(dir, testTenant)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dataObjStore, err := NewDataObjStore(dir, testTenant)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	builder := NewBuilder(dir, DefaultOpt(), chunkStore, dataObjStore)
+	err = builder.Generate(context.Background(), 1024)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a bug with logs builder which loses tenant information after resetting the builder. This happens after flushing a full section to the dataobj.

* added a test
* also added a test for generating test data to make it easier to debug these issues