### PR TITLE
chore: Fix panic for queries with unsupported predicate types

### DIFF
--- a/pkg/dataobj/metastore/object.go
+++ b/pkg/dataobj/metastore/object.go
@@ -416,6 +416,10 @@ func pointerPredicateFromMatchers(matchers ...*labels.Matcher) pointers.RowPredi
 		}
 	}
 
+	if len(predicates) == 0 {
+		return nil
+	}
+
 	current := predicates[0]
 
 	for _, predicate := range predicates[1:] {

--- a/pkg/dataobj/metastore/object_test.go
+++ b/pkg/dataobj/metastore/object_test.go
@@ -328,6 +328,16 @@ func TestSectionsForStreamMatchers(t *testing.T) {
 			predicates: nil,
 			wantCount:  0,
 		},
+		{
+			name: "matching selector with unsupported predicate type",
+			matchers: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchEqual, "app", "foo"),
+			},
+			predicates: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchRegexp, "bar", "something"),
+			},
+			wantCount: 1,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a panic caused by a query with filters that aren't supported by the metastore Sections lookup.