### PR TITLE
chore: Add ingester_chunks_flush_requests_total (backport release-3.5.x)

### DIFF
--- a/pkg/ingester/flush.go
+++ b/pkg/ingester/flush.go
@@ -508,6 +508,7 @@ func (i *Ingester) encodeChunk(ctx context.Context, ch *chunk.Chunk, desc *chunk
 // If the flush isn't successful, the operation for this userID is requeued allowing this and all other unflushed
 // chunk to have another opportunity to be flushed.
 func (i *Ingester) flushChunk(ctx context.Context, ch *chunk.Chunk) error {
+	i.metrics.chunksFlushRequestsTotal.Inc()
 	if err := i.store.Put(ctx, []chunk.Chunk{*ch}); err != nil {
 		i.metrics.chunksFlushFailures.Inc()
 		return fmt.Errorf("store put chunk: %w", err)

--- a/pkg/ingester/metrics.go
+++ b/pkg/ingester/metrics.go
@@ -48,6 +48,7 @@ type ingesterMetrics struct {
 	chunkAge                      prometheus.Histogram
 	chunkEncodeTime               prometheus.Histogram
 	chunksFlushFailures           prometheus.Counter
+	chunksFlushRequestsTotal      prometheus.Counter
 	chunksFlushedPerReason        *prometheus.CounterVec
 	chunkLifespan                 prometheus.Histogram
 	chunksEncoded                 *prometheus.CounterVec
@@ -241,6 +242,11 @@ func newIngesterMetrics(r prometheus.Registerer, metricsNamespace string) *inges
 			Namespace: constants.Loki,
 			Name:      "ingester_chunks_flush_failures_total",
 			Help:      "Total number of flush failures.",
+		}),
+		chunksFlushRequestsTotal: promauto.With(r).NewCounter(prometheus.CounterOpts{
+			Namespace: constants.Loki,
+			Name:      "ingester_chunks_flush_requests_total",
+			Help:      "Total number of flush requests (successful or not).",
 		}),
 		chunksFlushedPerReason: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
 			Namespace: constants.Loki,


### PR DESCRIPTION
### Summary

Backport of #18696

---

This is a duplicate of https://github.com/grafana/loki/pull/19021 but from a branch, rather than from a fork.