### PR TITLE
Update default readiness probe values to match operator

### DIFF
--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -71,7 +71,10 @@ loki:
     httpGet:
       path: /ready
       port: http-metrics
-    initialDelaySeconds: 30
+    periodSeconds: 10
+    initialDelaySeconds: 15
+    successThreshold: 1
+    failureThreshold: 3
     timeoutSeconds: 1
   # Configures the startup probe for all of the Loki pods
   startupProbe: {}


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates the default readiness probes used by loki pods to match what exists in the operator based on discussion: https://github.com/grafana/loki/pull/19045#discussion_r2310872375

**Which issue(s) this PR fixes**:
Partially Fixes #19020

**Special notes for your reviewer**:

Example of rendered output from helm template
```
readinessProbe:
  failureThreshold: 3
  httpGet:
    path: /ready
    port: http-metrics
  initialDelaySeconds: 15
  periodSeconds: 10
  successThreshold: 1
  timeoutSeconds: 1
```

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
