### PR TITLE
feat: add replicas to loki-canary deployment

### DIFF
--- a/production/helm/loki/templates/loki-canary/daemonset.yaml
+++ b/production/helm/loki/templates/loki-canary/daemonset.yaml
@@ -12,9 +12,8 @@ spec:
   selector:
     matchLabels:
       {{- include "loki-canary.selectorLabels" $ | nindent 6 }}
-  
   {{- if eq .kind "Deployment" }}
-  replicas: 1
+  replicas: {{ .replicas }}
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -828,6 +828,8 @@ lokiCanary:
     type: RollingUpdate
     rollingUpdate:
       maxUnavailable: 1
+  # -- Replicas for the `loki-canary` when using a Deployment
+  replicas: 1
 ######################################################################################################################
 #
 # Service Accounts and Kubernetes RBAC


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, there's no middle ground between deploying the canary as a single replica or deploying to your entire cluster. For very large clusters, this can result in a lot of pressure on Loki. But using a single canary replica doesn't give a huge amount of confidence on the health of the deployment.

Default to 1 replica so this is a no-op change for existing setups.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
