### PR TITLE
chore(operator): Update to Go 1.24.4

### DIFF
--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.23.6 as builder
+FROM golang:1.24.4 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/operator/Dockerfile.cross
+++ b/operator/Dockerfile.cross
@@ -1,6 +1,6 @@
 ARG BUILD_IMAGE=grafana/loki-build-image:0.33.6
 
-FROM golang:1.23.6-alpine as goenv
+FROM golang:1.24.4-alpine as goenv
 RUN go env GOARCH > /goarch && \
   go env GOARM > /goarm
 

--- a/operator/calculator.Dockerfile
+++ b/operator/calculator.Dockerfile
@@ -1,5 +1,5 @@
 # Build the calculator binary
-FROM golang:1.23.6 as builder
+FROM golang:1.24.4 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/operator/go.mod
+++ b/operator/go.mod
@@ -1,8 +1,8 @@
 module github.com/grafana/loki/operator
 
-go 1.23.0
+go 1.24.0
 
-toolchain go1.23.6
+toolchain go1.24.4
 
 require (
 	github.com/ViaQ/logerr/v2 v2.1.0

--- a/operator/netlify.toml
+++ b/operator/netlify.toml
@@ -6,7 +6,7 @@
   # HUGO_VERSION = "..." is set by bingo which allows reproducible local environment.
   NODE_VERSION = "22.10.0"
   NPM_VERSION = "10.9.0"
-  GO_VERSION = "1.23.6"
+  GO_VERSION = "1.24.4"
 
 [context.production]
   command = "(env && make web) || (sleep 30; false)"


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the Loki Operator to use a newer Go runtime.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
