### PR TITLE
fix(storage): ensure S3 endpoints use correct scheme based on insecure flag

### DIFF
--- a/pkg/storage/bucket/s3/bucket_client.go
+++ b/pkg/storage/bucket/s3/bucket_client.go
@@ -8,6 +8,8 @@ import (
 	"github.com/thanos-io/objstore"
 	"github.com/thanos-io/objstore/exthttp"
 	"github.com/thanos-io/objstore/providers/s3"
+
+	"github.com/grafana/loki/v3/pkg/storage/common/s3util"
 )
 
 const (
@@ -49,7 +51,7 @@ func newS3Config(cfg Config) (s3.Config, error) {
 
 	return s3.Config{
 		Bucket:             cfg.BucketName,
-		Endpoint:           cfg.Endpoint,
+		Endpoint:           s3util.FormatEndpoint(cfg.Endpoint, cfg.Insecure),
 		Region:             cfg.Region,
 		AccessKey:          cfg.AccessKeyID,
 		SecretKey:          cfg.SecretAccessKey.String(),

--- a/pkg/storage/bucket/s3/config_test.go
+++ b/pkg/storage/bucket/s3/config_test.go
@@ -229,3 +229,38 @@ func TestConfigRedactsCredentials(t *testing.T) {
 	require.False(t, bytes.Contains(output, []byte("secret access id")))
 	require.False(t, bytes.Contains(output, []byte("session token")))
 }
+
+func TestNewS3ConfigFormatsEndpoint(t *testing.T) {
+	tests := []struct {
+		name             string
+		cfg              Config
+		expectedEndpoint string
+	}{
+		{
+			name: "integration test - endpoint formatting is applied correctly",
+			cfg: Config{
+				Endpoint:   "s3.example.com",
+				BucketName: "test-bucket",
+				Insecure:   false,
+			},
+			expectedEndpoint: "https://s3.example.com",
+		},
+		{
+			name: "integration test - insecure flag is respected",
+			cfg: Config{
+				Endpoint:   "s3.example.com:9000",
+				BucketName: "test-bucket",
+				Insecure:   true,
+			},
+			expectedEndpoint: "http://s3.example.com:9000",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s3Cfg, err := newS3Config(tt.cfg)
+			require.NoError(t, err)
+			require.Equal(t, tt.expectedEndpoint, s3Cfg.Endpoint)
+		})
+	}
+}

--- a/pkg/storage/chunk/client/aws/s3_storage_client.go
+++ b/pkg/storage/chunk/client/aws/s3_storage_client.go
@@ -33,6 +33,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/storage/chunk/client/hedging"
 	clientutil "github.com/grafana/loki/v3/pkg/storage/chunk/client/util"
 	storageawscommon "github.com/grafana/loki/v3/pkg/storage/common/aws"
+	"github.com/grafana/loki/v3/pkg/storage/common/s3util"
 	"github.com/grafana/loki/v3/pkg/util"
 	"github.com/grafana/loki/v3/pkg/util/constants"
 	loki_instrument "github.com/grafana/loki/v3/pkg/util/instrument"
@@ -210,7 +211,7 @@ func buildS3Client(cfg S3Config, hedgingCfg hedging.Config, hedging bool) (*s3.S
 	s3Config = s3Config.WithS3ForcePathStyle(cfg.S3ForcePathStyle) // support for Path Style S3 url if has the flag
 
 	if cfg.Endpoint != "" {
-		s3Config = s3Config.WithEndpoint(cfg.Endpoint)
+		s3Config = s3Config.WithEndpoint(s3util.FormatEndpoint(cfg.Endpoint, cfg.Insecure))
 	}
 
 	if cfg.Insecure {

--- a/pkg/storage/common/s3util/endpoint.go
+++ b/pkg/storage/common/s3util/endpoint.go
@@ -1,0 +1,21 @@
+package s3util
+
+import "strings"
+
+// FormatEndpoint ensures an endpoint has the correct scheme (http:// or https://) based on the insecure flag.
+// If the endpoint already has a scheme, it is left unchanged.
+// If the endpoint is empty, it returns empty string.
+func FormatEndpoint(endpoint string, insecure bool) string {
+	if endpoint == "" {
+		return ""
+	}
+
+	if !strings.HasPrefix(endpoint, "http://") && !strings.HasPrefix(endpoint, "https://") {
+		if insecure {
+			return "http://" + endpoint
+		}
+		return "https://" + endpoint
+	}
+
+	return endpoint
+}

--- a/pkg/storage/common/s3util/endpoint_test.go
+++ b/pkg/storage/common/s3util/endpoint_test.go
@@ -1,0 +1,84 @@
+package s3util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormatEndpoint(t *testing.T) {
+	tests := []struct {
+		name             string
+		endpoint         string
+		insecure         bool
+		expectedEndpoint string
+	}{
+		{
+			name:             "endpoint without scheme and insecure=false should add https",
+			endpoint:         "s3.example.com",
+			insecure:         false,
+			expectedEndpoint: "https://s3.example.com",
+		},
+		{
+			name:             "endpoint without scheme and insecure=true should add http",
+			endpoint:         "s3.example.com",
+			insecure:         true,
+			expectedEndpoint: "http://s3.example.com",
+		},
+		{
+			name:             "endpoint with https scheme should remain unchanged",
+			endpoint:         "https://s3.example.com",
+			insecure:         false,
+			expectedEndpoint: "https://s3.example.com",
+		},
+		{
+			name:             "endpoint with http scheme should remain unchanged",
+			endpoint:         "http://s3.example.com",
+			insecure:         true,
+			expectedEndpoint: "http://s3.example.com",
+		},
+		{
+			name:             "endpoint with port and no scheme and insecure=false should add https",
+			endpoint:         "s3.example.com:9000",
+			insecure:         false,
+			expectedEndpoint: "https://s3.example.com:9000",
+		},
+		{
+			name:             "endpoint with port and no scheme and insecure=true should add http",
+			endpoint:         "s3.example.com:9000",
+			insecure:         true,
+			expectedEndpoint: "http://s3.example.com:9000",
+		},
+		{
+			name:             "empty endpoint should return empty string",
+			endpoint:         "",
+			insecure:         false,
+			expectedEndpoint: "",
+		},
+		{
+			name:             "empty endpoint with insecure=true should return empty string",
+			endpoint:         "",
+			insecure:         true,
+			expectedEndpoint: "",
+		},
+		{
+			name:             "endpoint with https scheme and insecure=true should remain unchanged",
+			endpoint:         "https://s3.example.com",
+			insecure:         true,
+			expectedEndpoint: "https://s3.example.com",
+		},
+		{
+			name:             "endpoint with http scheme and insecure=false should remain unchanged",
+			endpoint:         "http://s3.example.com",
+			insecure:         false,
+			expectedEndpoint: "http://s3.example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := FormatEndpoint(tt.endpoint, tt.insecure)
+			require.Equal(t, tt.expectedEndpoint, result)
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
When S3 endpoints are specified without http:// or https:// scheme, automatically prepend the appropriate scheme based on the insecure flag.

  - insecure=false (default) → https://
  - insecure=true → http://
  - Existing schemes are preserved unchanged

  Fixes #7290 where S3-compatible storage failed due to incorrect HTTP connections when HTTPS was expected.

**Which issue(s) this PR fixes**:
Fixes #7290

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
