### PR TITLE
chore: Read multi-tenant objects in query-engine

### DIFF
--- a/pkg/dataobj/metastore/object_test.go
+++ b/pkg/dataobj/metastore/object_test.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/grafana/loki/v3/pkg/dataobj/consumer/logsobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/index/indexobj"
-	"github.com/grafana/loki/v3/pkg/dataobj/metastore/multitenancy"
+	"github.com/grafana/loki/v3/pkg/dataobj/sections/pointers"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/streams"
 	"github.com/grafana/loki/v3/pkg/dataobj/uploader"
 	"github.com/grafana/loki/v3/pkg/logproto"
@@ -272,8 +272,22 @@ func TestSectionsForStreamMatchers(t *testing.T) {
 		require.NoError(t, err)
 	}
 
+	// Add one more stream for a different tenant to ensure it is not resolved.
+	altTenant := "tenant-alt"
+	newIdx, err := builder.AppendStream(altTenant, streams.Stream{
+		ID:               1,
+		Labels:           labels.New(labels.Label{Name: "app", Value: "foo"}, labels.Label{Name: "tenant", Value: altTenant}),
+		MinTimestamp:     now.Add(-3 * time.Hour),
+		MaxTimestamp:     now.Add(-2 * time.Hour),
+		UncompressedSize: 5,
+	})
+	require.NoError(t, err)
+	err = builder.ObserveLogLine(altTenant, "test-path", 0, newIdx, 1, now.Add(-2*time.Hour), 5)
+	require.NoError(t, err)
+
+	// Build and store the object
 	timeRanges := builder.TimeRanges()
-	require.Len(t, timeRanges, 1)
+	require.Len(t, timeRanges, 2)
 
 	obj, closer, err := builder.Flush()
 	require.NoError(t, err)
@@ -288,15 +302,14 @@ func TestSectionsForStreamMatchers(t *testing.T) {
 	require.NoError(t, err)
 
 	metastoreTocWriter := NewTableOfContentsWriter(bucket, log.NewNopLogger())
-
-	err = metastoreTocWriter.WriteEntry(context.Background(), path, []multitenancy.TimeRange{
-		{
-			Tenant:  tenantID,
-			MinTime: timeRanges[0].MinTime,
-			MaxTime: timeRanges[0].MaxTime,
-		},
-	})
+	err = metastoreTocWriter.WriteEntry(context.Background(), path, timeRanges)
 	require.NoError(t, err)
+
+	// Note the tenants by section index, for later verification
+	tenantsBySectionIdx := make(map[int]string)
+	for idx, section := range obj.Sections().Filter(pointers.CheckSection) {
+		tenantsBySectionIdx[idx] = section.Tenant
+	}
 
 	mstore := NewObjectMetastore(bucket, log.NewNopLogger(), prometheus.NewPedanticRegistry())
 
@@ -345,6 +358,9 @@ func TestSectionsForStreamMatchers(t *testing.T) {
 			sections, err := mstore.Sections(ctx, now.Add(-time.Hour), now.Add(time.Hour), tt.matchers, tt.predicates)
 			require.NoError(t, err)
 			require.Len(t, sections, tt.wantCount)
+			for _, section := range sections {
+				require.Equal(t, tenantsBySectionIdx[int(section.SectionIdx)], tenantID)
+			}
 		})
 	}
 }

--- a/pkg/dataobj/metastore/object_test.go
+++ b/pkg/dataobj/metastore/object_test.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/grafana/loki/v3/pkg/dataobj/consumer/logsobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/index/indexobj"
-	"github.com/grafana/loki/v3/pkg/dataobj/sections/pointers"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/streams"
 	"github.com/grafana/loki/v3/pkg/dataobj/uploader"
 	"github.com/grafana/loki/v3/pkg/logproto"
@@ -268,12 +267,13 @@ func TestSectionsForStreamMatchers(t *testing.T) {
 			UncompressedSize: 0,
 		})
 		require.NoError(t, err)
-		err = builder.ObserveLogLine(tenantID, "test-path", 0, newIdx, int64(i), ts.Entries[0].Timestamp, int64(len(ts.Entries[0].Line)))
+		err = builder.ObserveLogLine(tenantID, "test-path", 1, newIdx, int64(i), ts.Entries[0].Timestamp, int64(len(ts.Entries[0].Line)))
 		require.NoError(t, err)
 	}
 
 	// Add one more stream for a different tenant to ensure it is not resolved.
 	altTenant := "tenant-alt"
+	altTenantSection := int64(99) // Emulate a different section from a log object that doesn't collide with the main tenant's section
 	newIdx, err := builder.AppendStream(altTenant, streams.Stream{
 		ID:               1,
 		Labels:           labels.New(labels.Label{Name: "app", Value: "foo"}, labels.Label{Name: "tenant", Value: altTenant}),
@@ -282,7 +282,7 @@ func TestSectionsForStreamMatchers(t *testing.T) {
 		UncompressedSize: 5,
 	})
 	require.NoError(t, err)
-	err = builder.ObserveLogLine(altTenant, "test-path", 0, newIdx, 1, now.Add(-2*time.Hour), 5)
+	err = builder.ObserveLogLine(altTenant, "test-path", altTenantSection, newIdx, 1, now.Add(-2*time.Hour), 5)
 	require.NoError(t, err)
 
 	// Build and store the object
@@ -304,12 +304,6 @@ func TestSectionsForStreamMatchers(t *testing.T) {
 	metastoreTocWriter := NewTableOfContentsWriter(bucket, log.NewNopLogger())
 	err = metastoreTocWriter.WriteEntry(context.Background(), path, timeRanges)
 	require.NoError(t, err)
-
-	// Note the tenants by section index, for later verification
-	tenantsBySectionIdx := make(map[int]string)
-	for idx, section := range obj.Sections().Filter(pointers.CheckSection) {
-		tenantsBySectionIdx[idx] = section.Tenant
-	}
 
 	mstore := NewObjectMetastore(bucket, log.NewNopLogger(), prometheus.NewPedanticRegistry())
 
@@ -359,7 +353,7 @@ func TestSectionsForStreamMatchers(t *testing.T) {
 			require.NoError(t, err)
 			require.Len(t, sections, tt.wantCount)
 			for _, section := range sections {
-				require.Equal(t, tenantsBySectionIdx[int(section.SectionIdx)], tenantID)
+				require.NotEqual(t, section.SectionIdx, altTenantSection)
 			}
 		})
 	}

--- a/pkg/dataobj/querier/metadata_test.go
+++ b/pkg/dataobj/querier/metadata_test.go
@@ -25,7 +25,7 @@ func TestStore_SelectSeries(t *testing.T) {
 	ctx = user.InjectOrgID(ctx, testTenant)
 
 	// Setup test data
-	now := setupTestData(ctx, t, builder)
+	now := setupTestData(ctx, t, builder, testTenant)
 	meta := metastore.NewObjectMetastore(builder.bucket, log.NewNopLogger(), nil)
 	store := NewStore(builder.bucket, log.NewNopLogger(), meta)
 
@@ -170,7 +170,7 @@ func TestStore_LabelNamesForMetricName(t *testing.T) {
 	ctx = user.InjectOrgID(ctx, testTenant)
 
 	// Setup test data
-	now := setupTestData(ctx, t, builder)
+	now := setupTestData(ctx, t, builder, testTenant)
 	meta := metastore.NewObjectMetastore(builder.bucket, log.NewNopLogger(), nil)
 	store := NewStore(builder.bucket, log.NewNopLogger(), meta)
 
@@ -240,7 +240,7 @@ func TestStore_LabelValuesForMetricName(t *testing.T) {
 	ctx = user.InjectOrgID(ctx, testTenant)
 
 	// Setup test data
-	now := setupTestData(ctx, t, builder)
+	now := setupTestData(ctx, t, builder, testTenant)
 	meta := metastore.NewObjectMetastore(builder.bucket, log.NewNopLogger(), nil)
 	store := NewStore(builder.bucket, log.NewNopLogger(), meta)
 

--- a/pkg/dataobj/querier/store_test.go
+++ b/pkg/dataobj/querier/store_test.go
@@ -202,7 +202,7 @@ func TestStore_SelectLogs(t *testing.T) {
 	builder := newTestDataBuilder(t)
 	defer builder.close()
 
-	ctx, _ := context.WithTimeout(t.Context(), 300*time.Second) //nolint:govet
+	ctx, _ := context.WithTimeout(t.Context(), time.Second) //nolint:govet
 	ctx = user.InjectOrgID(ctx, testTenant)
 
 	// Setup test data

--- a/pkg/dataobj/querier/store_test.go
+++ b/pkg/dataobj/querier/store_test.go
@@ -43,7 +43,7 @@ func TestStore_SelectSamples(t *testing.T) {
 	ctx = user.InjectOrgID(ctx, testTenant)
 
 	// Setup test data
-	now := setupTestData(ctx, t, builder)
+	now := setupTestData(ctx, t, builder, testTenant)
 	meta := metastore.NewObjectMetastore(builder.bucket, log.NewNopLogger(), nil)
 	store := NewStore(builder.bucket, log.NewNopLogger(), meta)
 
@@ -202,11 +202,11 @@ func TestStore_SelectLogs(t *testing.T) {
 	builder := newTestDataBuilder(t)
 	defer builder.close()
 
-	ctx, _ := context.WithTimeout(t.Context(), time.Second) //nolint:govet
+	ctx, _ := context.WithTimeout(t.Context(), 300*time.Second) //nolint:govet
 	ctx = user.InjectOrgID(ctx, testTenant)
 
 	// Setup test data
-	now := setupTestData(ctx, t, builder)
+	now := setupTestData(ctx, t, builder, testTenant)
 	meta := metastore.NewObjectMetastore(builder.bucket, log.NewNopLogger(), nil)
 	store := NewStore(builder.bucket, log.NewLogfmtLogger(os.Stdout), meta)
 
@@ -370,13 +370,13 @@ func TestStore_SelectLogs(t *testing.T) {
 	}
 }
 
-func setupTestData(ctx context.Context, t *testing.T, builder *testDataBuilder) time.Time {
+func setupTestData(ctx context.Context, t *testing.T, builder *testDataBuilder, tenant string) time.Time {
 	t.Helper()
 	now := time.Unix(0, int64(time.Hour)).UTC()
 
 	// Data before the query range (should not be included in results)
 	builder.addStream(
-		"tenant",
+		tenant,
 		`{app="foo", env="prod"}`,
 		logproto.Entry{Timestamp: now.Add(-2 * time.Hour), Line: "foo_before1"},
 		logproto.Entry{Timestamp: now.Add(-2 * time.Hour).Add(30 * time.Second), Line: "foo_before2"},
@@ -386,7 +386,7 @@ func setupTestData(ctx context.Context, t *testing.T, builder *testDataBuilder) 
 
 	// Data within query range
 	builder.addStream(
-		"tenant",
+		tenant,
 		`{app="foo", env="prod"}`,
 		logproto.Entry{Timestamp: now, Line: "foo1"},
 		logproto.Entry{Timestamp: now.Add(30 * time.Second), Line: "foo2"},
@@ -394,7 +394,7 @@ func setupTestData(ctx context.Context, t *testing.T, builder *testDataBuilder) 
 		logproto.Entry{Timestamp: now.Add(50 * time.Second), Line: "foo4"},
 	)
 	builder.addStream(
-		"tenant",
+		tenant,
 		`{app="foo", env="dev"}`,
 		logproto.Entry{Timestamp: now.Add(10 * time.Second), Line: "foo5"},
 		logproto.Entry{Timestamp: now.Add(20 * time.Second), Line: "foo6"},
@@ -403,7 +403,7 @@ func setupTestData(ctx context.Context, t *testing.T, builder *testDataBuilder) 
 	builder.flush(ctx)
 
 	builder.addStream(
-		"tenant",
+		tenant,
 		`{app="bar", env="prod"}`,
 		logproto.Entry{Timestamp: now.Add(5 * time.Second), Line: "bar1"},
 		logproto.Entry{Timestamp: now.Add(15 * time.Second), Line: "bar2"},
@@ -411,7 +411,7 @@ func setupTestData(ctx context.Context, t *testing.T, builder *testDataBuilder) 
 		logproto.Entry{Timestamp: now.Add(40 * time.Second), Line: "bar4"},
 	)
 	builder.addStream(
-		"tenant",
+		tenant,
 		`{app="bar", env="dev"}`,
 		logproto.Entry{Timestamp: now.Add(8 * time.Second), Line: "bar5"},
 		logproto.Entry{Timestamp: now.Add(18 * time.Second), Line: "bar6"},
@@ -420,7 +420,7 @@ func setupTestData(ctx context.Context, t *testing.T, builder *testDataBuilder) 
 	builder.flush(ctx)
 
 	builder.addStream(
-		"tenant",
+		tenant,
 		`{app="baz", env="prod", team="a"}`,
 		logproto.Entry{Timestamp: now.Add(12 * time.Second), Line: "baz1"},
 		logproto.Entry{Timestamp: now.Add(22 * time.Second), Line: "baz2"},
@@ -431,7 +431,7 @@ func setupTestData(ctx context.Context, t *testing.T, builder *testDataBuilder) 
 
 	// Data after the query range (should not be included in results)
 	builder.addStream(
-		"tenant",
+		tenant,
 		`{app="foo", env="prod"}`,
 		logproto.Entry{Timestamp: now.Add(2 * time.Hour), Line: "foo_after1"},
 		logproto.Entry{Timestamp: now.Add(2 * time.Hour).Add(30 * time.Second), Line: "foo_after2"},


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds ability to handles multi-tenant objects in the query engine & metastore
* This requires objects to have the `section.Tenant` value set (which the builders on main do)
* The metastore filters for the tenant ID in the context throughout ToC and Index files
* The query engine filters for the correct stream section when initialising DataobjScans, using the tenant ID in the context.
* Also adds multi-tenant support to reading dataobj using the old engine

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/loki-private/issues/1769
