### PR TITLE
chore: Fix bugs in the index-builders

### DIFF
--- a/pkg/dataobj/index/calculate.go
+++ b/pkg/dataobj/index/calculate.go
@@ -116,12 +116,20 @@ func (c *Calculator) processStreamsSection(ctx context.Context, section *dataobj
 		if n == 0 && errors.Is(err, io.EOF) {
 			break
 		}
-		for _, stream := range streamBuf[:n] {
-			newStreamID, err := c.indexobjBuilder.AppendStream(streamSection.Tenant(), stream)
-			if err != nil {
-				return fmt.Errorf("failed to append to stream: %w", err)
+		err = func() error {
+			c.builderMtx.Lock()
+			defer c.builderMtx.Unlock()
+			for _, stream := range streamBuf[:n] {
+				newStreamID, err := c.indexobjBuilder.AppendStream(streamSection.Tenant(), stream)
+				if err != nil {
+					return fmt.Errorf("failed to append to stream: %w", err)
+				}
+				streamIDLookup[stream.ID] = newStreamID
 			}
-			streamIDLookup[stream.ID] = newStreamID
+			return nil
+		}()
+		if err != nil {
+			return err
 		}
 	}
 	return nil

--- a/pkg/dataobj/index/calculate.go
+++ b/pkg/dataobj/index/calculate.go
@@ -48,7 +48,6 @@ func (c *Calculator) Flush() (*dataobj.Object, io.Closer, error) {
 // Calculate reads the log data from the input logs object and appends the resulting indexes to calculator's builder.
 // Calculate is not thread-safe.
 func (c *Calculator) Calculate(ctx context.Context, logger log.Logger, reader *dataobj.Object, objectPath string) error {
-	fmt.Println("Calculate", objectPath)
 	g, streamsCtx := errgroup.WithContext(ctx)
 	g.SetLimit(runtime.GOMAXPROCS(0))
 	streamIDLookupByTenant := sync.Map{}

--- a/pkg/dataobj/index/calculate.go
+++ b/pkg/dataobj/index/calculate.go
@@ -48,6 +48,7 @@ func (c *Calculator) Flush() (*dataobj.Object, io.Closer, error) {
 // Calculate reads the log data from the input logs object and appends the resulting indexes to calculator's builder.
 // Calculate is not thread-safe.
 func (c *Calculator) Calculate(ctx context.Context, logger log.Logger, reader *dataobj.Object, objectPath string) error {
+	fmt.Println("Calculate", objectPath)
 	g, streamsCtx := errgroup.WithContext(ctx)
 	g.SetLimit(runtime.GOMAXPROCS(0))
 	streamIDLookupByTenant := sync.Map{}

--- a/pkg/dataobj/index/calculate.go
+++ b/pkg/dataobj/index/calculate.go
@@ -120,7 +120,7 @@ func (c *Calculator) processStreamsSection(ctx context.Context, section *dataobj
 			c.builderMtx.Lock()
 			defer c.builderMtx.Unlock()
 			for _, stream := range streamBuf[:n] {
-				newStreamID, err := c.indexobjBuilder.AppendStream(streamSection.Tenant(), stream)
+				newStreamID, err := c.indexobjBuilder.AppendStream(section.Tenant, stream)
 				if err != nil {
 					return fmt.Errorf("failed to append to stream: %w", err)
 				}
@@ -152,7 +152,7 @@ func (c *Calculator) processLogsSection(ctx context.Context, sectionLogger log.L
 		return fmt.Errorf("failed to open logs section: %w", err)
 	}
 
-	tenantID := logsSection.Tenant()
+	tenantID := section.Tenant
 
 	// Fetch the column statistics in order to init the bloom filters for each column
 	stats, err := logs.ReadStats(ctx, logsSection)

--- a/pkg/dataobj/index/calculate_test.go
+++ b/pkg/dataobj/index/calculate_test.go
@@ -148,7 +148,7 @@ func TestCalculator_Calculate(t *testing.T) {
 		count := obj.Sections().Count(pointers.CheckSection)
 		require.GreaterOrEqual(t, count, tenants)
 
-		requireValidPointers(t, obj, tenants)
+		requireValidPointers(t, obj)
 	})
 
 	t.Run("successful calculation from FS bucket", func(t *testing.T) {
@@ -194,11 +194,11 @@ func TestCalculator_Calculate(t *testing.T) {
 		count := obj.Sections().Count(pointers.CheckSection)
 		require.GreaterOrEqual(t, count, tenants)
 
-		requireValidPointers(t, obj, tenants)
+		requireValidPointers(t, obj)
 	})
 }
 
-func requireValidPointers(t *testing.T, obj *dataobj.Object, tenants int) {
+func requireValidPointers(t *testing.T, obj *dataobj.Object) {
 	totalPointers := 0
 	pointersByTenant := make(map[string]int)
 	for _, section := range obj.Sections().Filter(pointers.CheckSection) {

--- a/pkg/dataobj/index/calculate_test.go
+++ b/pkg/dataobj/index/calculate_test.go
@@ -137,10 +137,8 @@ func TestCalculator_Calculate(t *testing.T) {
 		require.Equal(t, len(timeRanges), tenants)
 		for _, timeRange := range timeRanges {
 			require.NotEmpty(t, timeRange.Tenant)
-			require.False(t, timeRange.MinTime.IsZero())
-			require.Equal(t, timeRange.MinTime, time.Unix(10, 0).UTC())
-			require.False(t, timeRange.MaxTime.IsZero())
-			require.Equal(t, timeRange.MaxTime, time.Unix(25, 0).UTC())
+			require.Equal(t, time.Unix(10, 0).UTC(), timeRange.MinTime)
+			require.Equal(t, time.Unix(25, 0).UTC(), timeRange.MaxTime)
 		}
 
 		// Confirm we have multiple pointers sections

--- a/pkg/dataobj/index/indexobj/builder.go
+++ b/pkg/dataobj/index/indexobj/builder.go
@@ -227,15 +227,6 @@ func (b *Builder) AppendStream(tenantID string, stream streams.Stream) (int64, e
 	streamID := tenantStreams.Record(stream.Labels, stream.MinTimestamp, stream.UncompressedSize)
 	_ = tenantStreams.Record(stream.Labels, stream.MaxTimestamp, 0)
 
-	// If our logs section has gotten big enough, we want to flush it to the
-	// encoder and start a new section.
-	if tenantStreams.EstimatedSize() > int(b.cfg.TargetSectionSize) {
-		if err := b.builder.Append(tenantStreams); err != nil {
-			b.metrics.appendFailures.Inc()
-			return 0, err
-		}
-	}
-
 	b.currentSizeEstimate = b.estimatedSize()
 	b.state = builderStateDirty
 
@@ -386,13 +377,19 @@ func (b *Builder) Flush() (*dataobj.Object, io.Closer, error) {
 	var flushErrors []error
 
 	for _, tenantStreams := range b.streams {
-		flushErrors = append(flushErrors, b.builder.Append(tenantStreams))
+		if tenantStreams.EstimatedSize() > 0 {
+			flushErrors = append(flushErrors, b.builder.Append(tenantStreams))
+		}
 	}
 	for _, tenantPointers := range b.pointers {
-		flushErrors = append(flushErrors, b.builder.Append(tenantPointers))
+		if tenantPointers.EstimatedSize() > 0 {
+			flushErrors = append(flushErrors, b.builder.Append(tenantPointers))
+		}
 	}
 	for _, tenantIndexPointers := range b.indexPointers {
-		flushErrors = append(flushErrors, b.builder.Append(tenantIndexPointers))
+		if tenantIndexPointers.EstimatedSize() > 0 {
+			flushErrors = append(flushErrors, b.builder.Append(tenantIndexPointers))
+		}
 	}
 
 	if err := errors.Join(flushErrors...); err != nil {

--- a/pkg/dataobj/index/indexobj/builder.go
+++ b/pkg/dataobj/index/indexobj/builder.go
@@ -290,14 +290,6 @@ func (b *Builder) ObserveLogLine(tenantID string, path string, section int64, st
 	}
 	tenantPointers.ObserveStream(path, section, streamIDInObject, streamIDInIndex, ts, uncompressedSize)
 
-	// If our logs section has gotten big enough, we want to flush it to the
-	// encoder and start a new section.
-	if tenantPointers.EstimatedSize() > int(b.cfg.TargetSectionSize) {
-		if err := b.builder.Append(tenantPointers); err != nil {
-			return err
-		}
-	}
-
 	b.currentSizeEstimate = b.estimatedSize()
 	b.state = builderStateDirty
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a few bugs with the index-builder:
* Concurrent map access inside the builder after introducing parallelism in reading the stream sections
* Correctly reading tenant info from `section.Tenant` instead of `logsSection.Tenant()`, as the latter is empty (I will remove that method in another PR)
* Removing functionality to flush Pointers & Stream sections on hitting the max section size. Stream sections in log objects already do this, and Pointers sections need to maintain state about which sections have been seen to avoid duplicating data. This was never a problem for real data as they didn't get near the section size, but I picked it up as an edge case in tests.
* Fixes an edge case where a builder would fail to flush if a tenant's builder was empty.

**Which issue(s) this PR fixes**:
Part of https://github.com/grafana/loki-private/issues/1769
