### PR TITLE
feat(fluent-bit): Add dot notation support for nested JSON label extraction

### DIFF
--- a/clients/cmd/fluent-bit/loki.go
+++ b/clients/cmd/fluent-bit/loki.go
@@ -156,13 +156,28 @@ func autoLabels(records map[string]interface{}, kuberneteslbs model.LabelSet) er
 }
 
 func extractLabels(records map[string]interface{}, keys []string) model.LabelSet {
-	res := model.LabelSet{}
+	if len(keys) == 0 {
+		return model.LabelSet{}
+	}
+
+	res := make(model.LabelSet, len(keys)) // Pre-allocate with expected size
 	for _, k := range keys {
-		v, ok := records[k]
+		v, ok := getNestedValue(records, k)
 		if !ok {
 			continue
 		}
-		ln := model.LabelName(k)
+
+		// Convert dot notation to valid label name by replacing dots with underscores
+		// Only allocate new string if dots are present
+		var labelName string
+		if strings.Contains(k, ".") {
+			labelName = strings.ReplaceAll(k, ".", "_")
+		} else {
+			labelName = k
+		}
+
+		ln := model.LabelName(labelName)
+
 		// skips invalid name and values
 		if !ln.IsValidLegacy() {
 			continue
@@ -174,6 +189,91 @@ func extractLabels(records map[string]interface{}, keys []string) model.LabelSet
 		res[ln] = lv
 	}
 	return res
+}
+
+// traverseNestedMap navigates through nested maps using dot notation
+// Returns the final map and key for operations, or just the value if getValue is true
+func traverseNestedMap(records map[string]interface{}, dottedKey string, getValue bool) (interface{}, map[string]interface{}, string, bool) {
+	// Input validation
+	if records == nil || dottedKey == "" {
+		return nil, nil, "", false
+	}
+
+	if !strings.Contains(dottedKey, ".") {
+		// Handle non-nested keys directly
+		if getValue {
+			if value, exists := records[dottedKey]; exists {
+				return value, nil, "", true
+			}
+		}
+		return nil, records, dottedKey, true
+	}
+
+	keys := strings.Split(dottedKey, ".")
+
+	// Filter out empty segments (e.g., from "a..b" or ".a.b")
+	validKeys := make([]string, 0, len(keys))
+	for _, key := range keys {
+		if key != "" {
+			validKeys = append(validKeys, key)
+		}
+	}
+
+	if len(validKeys) == 0 {
+		return nil, nil, "", false
+	}
+
+	if len(validKeys) == 1 {
+		// After filtering, it's just a simple key
+		key := validKeys[0]
+		if getValue {
+			if value, exists := records[key]; exists {
+				return value, nil, "", true
+			}
+			return nil, nil, "", false
+		}
+		return nil, records, key, true
+	}
+
+	current := records
+
+	// Navigate to the target location
+	for i := 0; i < len(validKeys)-1; i++ {
+		value, exists := current[validKeys[i]]
+		if !exists {
+			return nil, nil, "", false
+		}
+
+		nextMap, ok := value.(map[string]interface{})
+		if !ok {
+			return nil, nil, "", false
+		}
+		current = nextMap
+	}
+
+	finalKey := validKeys[len(validKeys)-1]
+
+	if getValue {
+		if value, exists := current[finalKey]; exists {
+			return value, current, finalKey, true
+		}
+		return nil, nil, "", false
+	}
+
+	return nil, current, finalKey, true
+}
+
+// getNestedValue retrieves a value from a nested map using dot notation
+// For example, "log.level" will traverse records["log"]["level"]
+func getNestedValue(records map[string]interface{}, dottedKey string) (interface{}, bool) {
+	// Fast path for simple keys
+	if !strings.Contains(dottedKey, ".") {
+		value, exists := records[dottedKey]
+		return value, exists
+	}
+
+	value, _, _, ok := traverseNestedMap(records, dottedKey, true)
+	return value, ok
 }
 
 // mapLabels convert records into labels using a json map[string]interface{} mapping
@@ -215,7 +315,15 @@ func getRecordValue(key string, records map[string]interface{}) (string, bool) {
 
 func removeKeys(records map[string]interface{}, keys []string) {
 	for _, k := range keys {
-		delete(records, k)
+		removeNestedKey(records, k)
+	}
+}
+
+// removeNestedKey removes a key from the records map, supporting both regular and dot notation
+func removeNestedKey(records map[string]interface{}, dottedKey string) {
+	_, parentMap, finalKey, ok := traverseNestedMap(records, dottedKey, false)
+	if ok && parentMap != nil {
+		delete(parentMap, finalKey)
 	}
 }
 

--- a/clients/cmd/fluent-bit/loki_test.go
+++ b/clients/cmd/fluent-bit/loki_test.go
@@ -182,6 +182,13 @@ func Test_removeKeys(t *testing.T) {
 		{"remove none", map[string]interface{}{"foo": "bar"}, map[string]interface{}{"foo": "bar"}, []string{}},
 		{"remove not existing", map[string]interface{}{"foo": "bar"}, map[string]interface{}{"foo": "bar"}, []string{"bar"}},
 		{"remove one", map[string]interface{}{"foo": "bar", "bazz": "buzz"}, map[string]interface{}{"foo": "bar"}, []string{"bazz"}},
+
+		// Dot notation tests for removeKeys
+		{"remove nested key", map[string]interface{}{"log": map[string]interface{}{"level": "INFO", "message": "test"}}, map[string]interface{}{"log": map[string]interface{}{"message": "test"}}, []string{"log.level"}},
+		{"remove multiple nested keys", map[string]interface{}{"log": map[string]interface{}{"level": "INFO", "message": "test", "logger": "app"}}, map[string]interface{}{"log": map[string]interface{}{"message": "test"}}, []string{"log.level", "log.logger"}},
+		{"remove deep nested key", map[string]interface{}{"kubernetes": map[string]interface{}{"pod": map[string]interface{}{"name": "test", "namespace": "default"}}}, map[string]interface{}{"kubernetes": map[string]interface{}{"pod": map[string]interface{}{"namespace": "default"}}}, []string{"kubernetes.pod.name"}},
+		{"remove non-existing nested", map[string]interface{}{"log": map[string]interface{}{"message": "test"}}, map[string]interface{}{"log": map[string]interface{}{"message": "test"}}, []string{"log.level"}},
+		{"remove mixed regular and nested", map[string]interface{}{"service": "api", "log": map[string]interface{}{"level": "INFO", "message": "test"}}, map[string]interface{}{"log": map[string]interface{}{"message": "test"}}, []string{"service", "log.level"}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -206,6 +213,15 @@ func Test_extractLabels(t *testing.T) {
 		{"none", map[string]interface{}{"foo": nil}, []string{}, model.LabelSet{}},
 		{"missing", map[string]interface{}{"foo": "bar"}, []string{"foo", "buzz"}, model.LabelSet{"foo": "bar"}},
 		{"skip invalid", map[string]interface{}{"foo.blah": "bar", "bar": "a\xc5z"}, []string{"foo.blah", "bar"}, model.LabelSet{}},
+
+		// Dot notation tests
+		{"dot notation simple", map[string]interface{}{"log": map[string]interface{}{"level": "INFO"}}, []string{"log.level"}, model.LabelSet{"log_level": "INFO"}},
+		{"dot notation multiple levels", map[string]interface{}{"kubernetes": map[string]interface{}{"pod": map[string]interface{}{"name": "test-pod"}}}, []string{"kubernetes.pod.name"}, model.LabelSet{"kubernetes_pod_name": "test-pod"}},
+		{"dot notation mixed with regular", map[string]interface{}{"service": "api", "log": map[string]interface{}{"level": "ERROR", "logger": "app"}}, []string{"service", "log.level", "log.logger"}, model.LabelSet{"service": "api", "log_level": "ERROR", "log_logger": "app"}},
+		{"dot notation missing nested", map[string]interface{}{"log": map[string]interface{}{"message": "test"}}, []string{"log.level"}, model.LabelSet{}},
+		{"dot notation non-map intermediate", map[string]interface{}{"log": "not a map"}, []string{"log.level"}, model.LabelSet{}},
+		{"dot notation with numbers", map[string]interface{}{"metrics": map[string]interface{}{"cpu": 85.5, "memory": 1024}}, []string{"metrics.cpu", "metrics.memory"}, model.LabelSet{"metrics_cpu": "85.5", "metrics_memory": "1024"}},
+		{"dot notation with boolean", map[string]interface{}{"flags": map[string]interface{}{"enabled": true, "debug": false}}, []string{"flags.enabled", "flags.debug"}, model.LabelSet{"flags_enabled": "true", "flags_debug": "false"}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -366,5 +382,304 @@ func Test_AutoKubernetesLabels(t *testing.T) {
 				t.Errorf("mapLabels() = %v, want %v", lbs, tt.want)
 			}
 		})
+	}
+}
+
+func Test_DotNotation_EndToEnd(t *testing.T) {
+	// Example log from a Spring Boot application on AWS ECS
+	record := map[string]interface{}{
+		"@timestamp": "2024-01-15T10:30:45.123Z",
+		"service":    "payment-api",
+		"log": map[string]interface{}{
+			"level":     "ERROR",
+			"logger":    "com.example.payment.PaymentService",
+			"message":   "Payment processing failed",
+			"thread":    "http-nio-8080-exec-1",
+			"exception": "java.lang.RuntimeException: Connection timeout",
+		},
+		"kubernetes": map[string]interface{}{
+			"namespace": "production",
+			"pod": map[string]interface{}{
+				"name": "payment-api-7b6d4f9c-x2j9k",
+				"ip":   "10.0.5.42",
+			},
+			"labels": map[string]interface{}{
+				"app":     "payment-api",
+				"version": "v1.2.3",
+			},
+		},
+		"aws": map[string]interface{}{
+			"ecs": map[string]interface{}{
+				"cluster": "prod-cluster",
+				"service": "payment-service",
+				"task": map[string]interface{}{
+					"arn":    "arn:aws:ecs:us-west-2:123456789:task/abc123",
+					"family": "payment-api-task",
+				},
+			},
+		},
+		"metrics": map[string]interface{}{
+			"cpu":      85.5,
+			"memory":   2048,
+			"requests": 1500,
+		},
+	}
+
+	// Define keys to extract as labels using dot notation
+	labelKeys := []string{
+		"service",
+		"log.level",
+		"log.logger",
+		"kubernetes.namespace",
+		"kubernetes.pod.name",
+		"aws.ecs.cluster",
+		"aws.ecs.task.family",
+		"metrics.cpu",
+	}
+
+	// Extract labels
+	labels := extractLabels(record, labelKeys)
+
+	// Verify extracted labels
+	expectedLabels := model.LabelSet{
+		"service":              "payment-api",
+		"log_level":            "ERROR",
+		"log_logger":           "com.example.payment.PaymentService",
+		"kubernetes_namespace": "production",
+		"kubernetes_pod_name":  "payment-api-7b6d4f9c-x2j9k",
+		"aws_ecs_cluster":      "prod-cluster",
+		"aws_ecs_task_family":  "payment-api-task",
+		"metrics_cpu":          "85.5",
+	}
+
+	if !reflect.DeepEqual(labels, expectedLabels) {
+		t.Errorf("extractLabels() = %v, want %v", labels, expectedLabels)
+	}
+
+	// Remove the extracted keys from the record
+	removeKeys(record, labelKeys)
+
+	// Verify that nested fields are removed properly
+	if logMap, ok := record["log"].(map[string]interface{}); ok {
+		if _, exists := logMap["level"]; exists {
+			t.Error("log.level should have been removed")
+		}
+		if _, exists := logMap["logger"]; exists {
+			t.Error("log.logger should have been removed")
+		}
+		// Message should still be there (not removed)
+		if _, exists := logMap["message"]; !exists {
+			t.Error("log.message should NOT have been removed")
+		}
+	}
+
+	// Service field should be completely removed
+	if _, exists := record["service"]; exists {
+		t.Error("service field should have been removed")
+	}
+}
+
+func Test_DotNotation_EdgeCases(t *testing.T) {
+	tests := []struct {
+		name     string
+		records  map[string]interface{}
+		keys     []string
+		expected model.LabelSet
+	}{
+		{
+			"empty key list",
+			map[string]interface{}{"foo": "bar"},
+			[]string{},
+			model.LabelSet{},
+		},
+		{
+			"nil records",
+			nil,
+			[]string{"foo"},
+			model.LabelSet{},
+		},
+		{
+			"malformed dot notation - double dots",
+			map[string]interface{}{"log": map[string]interface{}{"level": "INFO"}},
+			[]string{"log..level"},
+			model.LabelSet{"log__level": "INFO"}, // Double underscore reflects double dots
+		},
+		{
+			"malformed dot notation - leading dot",
+			map[string]interface{}{"log": map[string]interface{}{"level": "INFO"}},
+			[]string{".log.level"},
+			model.LabelSet{"_log_level": "INFO"}, // Leading underscore reflects leading dot
+		},
+		{
+			"malformed dot notation - trailing dot",
+			map[string]interface{}{"log": map[string]interface{}{"level": "INFO"}},
+			[]string{"log.level."},
+			model.LabelSet{"log_level_": "INFO"}, // Trailing underscore reflects trailing dot
+		},
+		{
+			"empty string key",
+			map[string]interface{}{"foo": "bar"},
+			[]string{""},
+			model.LabelSet{},
+		},
+		{
+			"only dots key",
+			map[string]interface{}{"foo": "bar"},
+			[]string{"..."},
+			model.LabelSet{},
+		},
+		{
+			"mixed valid and invalid keys",
+			map[string]interface{}{
+				"valid": "test",
+				"log":   map[string]interface{}{"level": "INFO"},
+			},
+			[]string{"valid", "", "log.level", "missing.key"},
+			model.LabelSet{"valid": "test", "log_level": "INFO"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extractLabels(tt.records, tt.keys)
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("extractLabels() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func Test_RemoveKeys_EdgeCases(t *testing.T) {
+	tests := []struct {
+		name     string
+		records  map[string]interface{}
+		keys     []string
+		expected map[string]interface{}
+	}{
+		{
+			"empty key list",
+			map[string]interface{}{"foo": "bar"},
+			[]string{},
+			map[string]interface{}{"foo": "bar"},
+		},
+		{
+			"malformed dot notation - double dots",
+			map[string]interface{}{"log": map[string]interface{}{"level": "INFO", "message": "test"}},
+			[]string{"log..level"},
+			map[string]interface{}{"log": map[string]interface{}{"message": "test"}},
+		},
+		{
+			"empty string key",
+			map[string]interface{}{"foo": "bar"},
+			[]string{""},
+			map[string]interface{}{"foo": "bar"},
+		},
+		{
+			"only dots key",
+			map[string]interface{}{"foo": "bar"},
+			[]string{"..."},
+			map[string]interface{}{"foo": "bar"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Make a copy of the input to avoid side effects
+			recordsCopy := make(map[string]interface{})
+			for k, v := range tt.records {
+				recordsCopy[k] = v
+			}
+
+			removeKeys(recordsCopy, tt.keys)
+			if !reflect.DeepEqual(recordsCopy, tt.expected) {
+				t.Errorf("removeKeys() = %v, want %v", recordsCopy, tt.expected)
+			}
+		})
+	}
+}
+
+// Benchmarks for performance testing
+func BenchmarkExtractLabels_SimpleKeys(b *testing.B) {
+	records := map[string]interface{}{
+		"service": "api",
+		"level":   "ERROR",
+		"region":  "us-west-2",
+		"cluster": "prod",
+	}
+	keys := []string{"service", "level", "region", "cluster"}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		extractLabels(records, keys)
+	}
+}
+
+func BenchmarkExtractLabels_DotNotation(b *testing.B) {
+	records := map[string]interface{}{
+		"service": "api",
+		"log": map[string]interface{}{
+			"level":  "ERROR",
+			"logger": "com.example.Service",
+		},
+		"kubernetes": map[string]interface{}{
+			"namespace": "production",
+			"pod": map[string]interface{}{
+				"name": "api-7b6d4f9c-x2j9k",
+			},
+		},
+	}
+	keys := []string{"service", "log.level", "log.logger", "kubernetes.namespace", "kubernetes.pod.name"}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		extractLabels(records, keys)
+	}
+}
+
+func BenchmarkExtractLabels_DeepNesting(b *testing.B) {
+	records := map[string]interface{}{
+		"a": map[string]interface{}{
+			"b": map[string]interface{}{
+				"c": map[string]interface{}{
+					"d": map[string]interface{}{
+						"e": "deep_value",
+					},
+				},
+			},
+		},
+	}
+	keys := []string{"a.b.c.d.e"}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		extractLabels(records, keys)
+	}
+}
+
+func BenchmarkRemoveKeys_DotNotation(b *testing.B) {
+	baseRecord := map[string]interface{}{
+		"service": "api",
+		"log": map[string]interface{}{
+			"level":   "ERROR",
+			"logger":  "com.example.Service",
+			"message": "error occurred",
+		},
+		"kubernetes": map[string]interface{}{
+			"namespace": "production",
+			"pod": map[string]interface{}{
+				"name": "api-7b6d4f9c-x2j9k",
+			},
+		},
+	}
+	keys := []string{"service", "log.level", "log.logger"}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		// Create a fresh copy for each iteration
+		records := make(map[string]interface{})
+		for k, v := range baseRecord {
+			records[k] = v
+		}
+		removeKeys(records, keys)
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Implements dot notation syntax for the Fluent Bit Loki plugin's `LabelKeys` and `RemoveKeys` parameters, enabling simple extraction of labels from nested JSON structures without requiring separate mapping files.

  ### Before: Complex LabelMapPath Setup

  **Problem**: Extracting labels from nested JSON required separate mapping files.

  Given this JSON log from a Spring Boot application:
  ```json
  {
    "service": "payment-api",
    "log": {
      "level": "ERROR",
      "logger": "com.example.PaymentService",
      "message": "Payment processing failed"
    },
    "kubernetes": {
      "namespace": "production",
      "pod": {
        "name": "payment-api-7b6d4f9c-x2j9k"
      }
    }
  }
  ```
  Required Setup:

  1. Create mapping file /etc/fluent-bit/label-map.json:
```json
  {
    "log": {
      "level": "log_level",
      "logger": "log_logger"
    },
    "kubernetes": {
      "namespace": "k8s_namespace",
      "pod": {
        "name": "pod_name"
      }
    }
  }
```

  2. Configure Fluent Bit:
  [Output]
      Name grafana-loki
      Match *
      Url http://localhost:3100/loki/api/v1/push
      LabelMapPath /etc/fluent-bit/label-map.json
      RemoveKeys log,kubernetes

  Problems: External file management, complex syntax, hard to maintain in containers

  ### After: Simple Dot Notation

  **Solution:** Direct dot notation in configuration - no external files needed.

  Single configuration:
  [Output]
      Name grafana-loki
      Match *
      Url http://localhost:3100/loki/api/v1/push
      LabelKeys service,log.level,log.logger,kubernetes.namespace,kubernetes.pod.name
      RemoveKeys log.level,log.logger

  **Result:**
  - Labels: {service="payment-api", log_level="ERROR", log_logger="com.example.PaymentService", kubernetes_namespace="production", kubernetes_pod_name="payment-api-7b6d4f9c-x2j9k"}
  - Log Line: {"log":{"message":"Payment processing failed"},"kubernetes":{"pod":{}}}


  Dot Notation Rules

  - Syntax: Use dots to access nested fields (kubernetes.pod.name)
  - Label Names: Dots become underscores (log.level → log_level)
  - Compatibility: Works alongside regular keys (service,log.level)
  - Error Handling: Gracefully handles missing fields and malformed input



Performance Characteristics

  BenchmarkExtractLabels_SimpleKeys      264.2 ns/op   362 B/op   6 allocs/op
  BenchmarkExtractLabels_DotNotation     625.9 ns/op   677 B/op  16 allocs/op
  BenchmarkRemoveKeys_DotNotation        146.7 ns/op    64 B/op   2 allocs/op


**Which issue(s) this PR fixes**:
Fixes #6994 

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
