### PR TITLE
chore(engine): Simplify `Pipeline` interface

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -253,15 +253,11 @@ func (e *QueryEngine) Execute(ctx context.Context, params logql.Params) (logqlmo
 
 func collectResult(ctx context.Context, pipeline executor.Pipeline, builder ResultBuilder) error {
 	for {
-		if err := pipeline.Read(ctx); err != nil {
+		rec, err := pipeline.Read(ctx)
+		if err != nil {
 			if errors.Is(err, executor.EOF) {
 				break
 			}
-			return err
-		}
-
-		rec, err := pipeline.Value()
-		if err != nil {
 			return err
 		}
 

--- a/pkg/engine/executor/dataobjscan.go
+++ b/pkg/engine/executor/dataobjscan.go
@@ -65,18 +65,12 @@ func newDataobjScanPipeline(opts dataobjScanOptions, logger log.Logger) *dataobj
 	}
 }
 
-func (s *dataobjScan) Read(ctx context.Context) error {
+func (s *dataobjScan) Read(ctx context.Context) (arrow.Record, error) {
 	if err := s.init(); err != nil {
-		return err
+		return nil, err
 	}
 
-	rec, err := s.read(ctx)
-	s.state = newState(rec, err)
-
-	if err != nil {
-		return fmt.Errorf("reading data object: %w", err)
-	}
-	return nil
+	return s.read(ctx)
 }
 
 func (s *dataobjScan) init() error {
@@ -408,10 +402,6 @@ func (s *dataobjScan) read(ctx context.Context) (arrow.Record, error) {
 
 	return s.streamsInjector.Inject(ctx, rec)
 }
-
-// Value returns the current [arrow.Record] retrieved by the previous call to
-// [dataobjScan.Read], or an error if the record cannot be read.
-func (s *dataobjScan) Value() (arrow.Record, error) { return s.state.batch, s.state.err }
 
 // Close closes s and releases all resources.
 func (s *dataobjScan) Close() {

--- a/pkg/engine/executor/executor_test.go
+++ b/pkg/engine/executor/executor_test.go
@@ -13,14 +13,14 @@ func TestExecutor(t *testing.T) {
 	t.Run("pipeline fails if plan is nil", func(t *testing.T) {
 		ctx := t.Context()
 		pipeline := Run(ctx, Config{}, nil, log.NewNopLogger())
-		err := pipeline.Read(ctx)
+		_, err := pipeline.Read(ctx)
 		require.ErrorContains(t, err, "failed to execute pipeline: plan is nil")
 	})
 
 	t.Run("pipeline fails if plan has no root node", func(t *testing.T) {
 		ctx := t.Context()
 		pipeline := Run(ctx, Config{}, &physical.Plan{}, log.NewNopLogger())
-		err := pipeline.Read(ctx)
+		_, err := pipeline.Read(ctx)
 		require.ErrorContains(t, err, "failed to execute pipeline: plan has no root node")
 	})
 }
@@ -30,7 +30,7 @@ func TestExecutor_SortMerge(t *testing.T) {
 		ctx := t.Context()
 		c := &Context{}
 		pipeline := c.executeSortMerge(ctx, &physical.SortMerge{}, nil)
-		err := pipeline.Read(ctx)
+		_, err := pipeline.Read(ctx)
 		require.ErrorContains(t, err, EOF.Error())
 	})
 }
@@ -40,7 +40,7 @@ func TestExecutor_Limit(t *testing.T) {
 		ctx := t.Context()
 		c := &Context{}
 		pipeline := c.executeLimit(ctx, &physical.Limit{}, nil)
-		err := pipeline.Read(ctx)
+		_, err := pipeline.Read(ctx)
 		require.ErrorContains(t, err, EOF.Error())
 	})
 
@@ -48,7 +48,7 @@ func TestExecutor_Limit(t *testing.T) {
 		ctx := t.Context()
 		c := &Context{}
 		pipeline := c.executeLimit(ctx, &physical.Limit{}, []Pipeline{emptyPipeline(), emptyPipeline()})
-		err := pipeline.Read(ctx)
+		_, err := pipeline.Read(ctx)
 		require.ErrorContains(t, err, "limit expects exactly one input, got 2")
 	})
 }
@@ -58,7 +58,7 @@ func TestExecutor_Filter(t *testing.T) {
 		ctx := t.Context()
 		c := &Context{}
 		pipeline := c.executeFilter(ctx, &physical.Filter{}, nil)
-		err := pipeline.Read(ctx)
+		_, err := pipeline.Read(ctx)
 		require.ErrorContains(t, err, EOF.Error())
 	})
 
@@ -66,7 +66,7 @@ func TestExecutor_Filter(t *testing.T) {
 		ctx := t.Context()
 		c := &Context{}
 		pipeline := c.executeFilter(ctx, &physical.Filter{}, []Pipeline{emptyPipeline(), emptyPipeline()})
-		err := pipeline.Read(ctx)
+		_, err := pipeline.Read(ctx)
 		require.ErrorContains(t, err, "filter expects exactly one input, got 2")
 	})
 }
@@ -76,7 +76,7 @@ func TestExecutor_Projection(t *testing.T) {
 		ctx := t.Context()
 		c := &Context{}
 		pipeline := c.executeProjection(ctx, &physical.Projection{}, nil)
-		err := pipeline.Read(ctx)
+		_, err := pipeline.Read(ctx)
 		require.ErrorContains(t, err, EOF.Error())
 	})
 
@@ -85,7 +85,7 @@ func TestExecutor_Projection(t *testing.T) {
 		cols := []physical.ColumnExpression{}
 		c := &Context{}
 		pipeline := c.executeProjection(ctx, &physical.Projection{Columns: cols}, []Pipeline{emptyPipeline()})
-		err := pipeline.Read(ctx)
+		_, err := pipeline.Read(ctx)
 		require.ErrorContains(t, err, "projection expects at least one column, got 0")
 	})
 
@@ -93,7 +93,7 @@ func TestExecutor_Projection(t *testing.T) {
 		ctx := t.Context()
 		c := &Context{}
 		pipeline := c.executeProjection(ctx, &physical.Projection{}, []Pipeline{emptyPipeline(), emptyPipeline()})
-		err := pipeline.Read(ctx)
+		_, err := pipeline.Read(ctx)
 		require.ErrorContains(t, err, "projection expects exactly one input, got 2")
 	})
 }

--- a/pkg/engine/executor/filter.go
+++ b/pkg/engine/executor/filter.go
@@ -15,12 +15,7 @@ func NewFilterPipeline(filter *physical.Filter, input Pipeline, evaluator expres
 	return newGenericPipeline(Local, func(ctx context.Context, inputs []Pipeline) state {
 		// Pull the next item from the input pipeline
 		input := inputs[0]
-		err := input.Read(ctx)
-		if err != nil {
-			return failureState(err)
-		}
-
-		batch, err := input.Value()
+		batch, err := input.Read(ctx)
 		if err != nil {
 			return failureState(err)
 		}

--- a/pkg/engine/executor/limit.go
+++ b/pkg/engine/executor/limit.go
@@ -18,6 +18,7 @@ func NewLimitPipeline(input Pipeline, skip, fetch uint32) *GenericPipeline {
 		var length int64
 		var start, end int64
 		var batch arrow.Record
+		var err error
 
 		// We skip yielding zero-length batches while offsetRemainig > 0
 		for length == 0 {
@@ -28,11 +29,10 @@ func NewLimitPipeline(input Pipeline, skip, fetch uint32) *GenericPipeline {
 
 			// Pull the next item from input
 			input := inputs[0]
-			err := input.Read(ctx)
+			batch, err = input.Read(ctx)
 			if err != nil {
 				return failureState(err)
 			}
-			batch, _ = input.Value()
 
 			// We want to slice batch so it only contains the rows we're looking for
 			// accounting for both the limit and offset.

--- a/pkg/engine/executor/limit_test.go
+++ b/pkg/engine/executor/limit_test.go
@@ -18,14 +18,14 @@ func TestExecuteLimit(t *testing.T) {
 	t.Run("with no inputs", func(t *testing.T) {
 		ctx := t.Context()
 		pipeline := c.executeLimit(ctx, &physical.Limit{}, nil)
-		err := pipeline.Read(ctx)
+		_, err := pipeline.Read(ctx)
 		require.Equal(t, EOF, err)
 	})
 
 	t.Run("with multiple inputs", func(t *testing.T) {
 		ctx := t.Context()
 		pipeline := c.executeLimit(ctx, &physical.Limit{}, []Pipeline{emptyPipeline(), emptyPipeline()})
-		err := pipeline.Read(ctx)
+		_, err := pipeline.Read(ctx)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "limit expects exactly one input, got 2")
 	})
@@ -50,10 +50,7 @@ func TestExecuteLimit(t *testing.T) {
 		defer pipeline.Close()
 
 		// Read from the pipeline
-		err = pipeline.Read(ctx)
-		require.NoError(t, err)
-
-		batch, err := pipeline.Value()
+		batch, err := pipeline.Read(ctx)
 		require.NoError(t, err)
 		require.NotNil(t, batch)
 
@@ -64,7 +61,7 @@ func TestExecuteLimit(t *testing.T) {
 		require.Equal(t, "Bob", batch.Column(0).ValueStr(0))
 
 		// Next read should return EOF
-		err = pipeline.Read(ctx)
+		_, err = pipeline.Read(ctx)
 		require.Equal(t, EOF, err)
 	})
 
@@ -142,10 +139,7 @@ func TestLimitPipeline_Skip_Fetch(t *testing.T) {
 	ctx := t.Context()
 
 	// Test first read
-	err = limit.Read(ctx)
-	require.NoError(t, err)
-
-	batch, err := limit.Value()
+	batch, err := limit.Read(ctx)
 	require.NoError(t, err)
 	require.NotNil(t, batch)
 	require.Equal(t, int64(4), batch.NumRows())
@@ -158,7 +152,7 @@ func TestLimitPipeline_Skip_Fetch(t *testing.T) {
 	}
 
 	// Next read should be EOF
-	err = limit.Read(ctx)
+	_, err = limit.Read(ctx)
 	require.Equal(t, EOF, err)
 }
 

--- a/pkg/engine/executor/merge_test.go
+++ b/pkg/engine/executor/merge_test.go
@@ -75,14 +75,13 @@ func TestMerge(t *testing.T) {
 
 			// Read all records from the merge pipeline
 			for {
-				err := m.Read(ctx)
+				rec, err := m.Read(ctx)
 				if errors.Is(err, EOF) {
 					t.Log("stop reading from pipeline:", err)
 					break
 				}
 				require.NoError(t, err, "Unexpected error during read")
 
-				rec, _ := m.Value()
 				defer rec.Release()
 
 				rows, err := arrowtest.RecordRows(rec)
@@ -118,14 +117,13 @@ func TestMerge(t *testing.T) {
 					cancel()
 				}
 
-				err := m.Read(ctx)
+				rec, err := m.Read(ctx)
 				if errors.Is(err, EOF) || errors.Is(err, context.Canceled) {
 					t.Log("stop reading from pipeline:", err)
 					break
 				}
 				require.NoError(t, err, "Unexpected error during read")
 
-				rec, _ := m.Value()
 				gotRows += rec.NumRows()
 				rec.Release()
 			}

--- a/pkg/engine/executor/pipeline.go
+++ b/pkg/engine/executor/pipeline.go
@@ -21,12 +21,9 @@ const (
 // Pipeline represents a data processing pipeline that can read Arrow records.
 // It provides methods to read data, access the current record, and close resources.
 type Pipeline interface {
-	// Read reads the next value into its state.
+	// Read collects the next value ([arrow.Record]) from the pipeline and returns it to the caller.
 	// It returns an error if reading fails or when the pipeline is exhausted. In this case, the function returns EOF.
-	// The implementation must retain the returned error in its state and return it with subsequent Value() calls.
-	Read(context.Context) error
-	// Value returns the current value in state.
-	Value() (arrow.Record, error)
+	Read(context.Context) (arrow.Record, error)
 	// Close closes the resources of the pipeline.
 	// The implementation must close all the of the pipeline's inputs.
 	Close()
@@ -87,18 +84,13 @@ func (p *GenericPipeline) Inputs() []Pipeline {
 	return p.inputs
 }
 
-// Value implements Pipeline.
-func (p *GenericPipeline) Value() (arrow.Record, error) {
-	return p.state.Value()
-}
-
 // Read implements Pipeline.
-func (p *GenericPipeline) Read(ctx context.Context) error {
+func (p *GenericPipeline) Read(ctx context.Context) (arrow.Record, error) {
 	if p.read == nil {
-		return EOF
+		return nil, EOF
 	}
-	p.state = p.read(ctx, p.inputs)
-	return p.state.err
+	s := p.read(ctx, p.inputs)
+	return s.batch, s.err
 }
 
 // Close implements Pipeline.
@@ -163,9 +155,10 @@ func newPrefetchingPipeline(p Pipeline) *prefetchWrapper {
 }
 
 // Read implements [Pipeline].
-func (p *prefetchWrapper) Read(ctx context.Context) error {
+func (p *prefetchWrapper) Read(ctx context.Context) (arrow.Record, error) {
 	p.init(ctx)
-	return p.read(ctx)
+	s := p.read(ctx)
+	return s.batch, s.err
 }
 
 func (p *prefetchWrapper) init(ctx context.Context) {
@@ -189,12 +182,11 @@ func (p prefetchWrapper) prefetch(ctx context.Context) error {
 			return ctx.Err()
 		default:
 			var s state
-			s.err = p.Pipeline.Read(ctx)
+			s.batch, s.err = p.Pipeline.Read(ctx)
 			if s.err != nil {
 				p.ch <- s
 				return s.err
 			}
-			s.batch, s.err = p.Pipeline.Value()
 
 			// Sending to channel will block until the batch is read by the parent pipeline.
 			// If the context is cancelled while waiting to send, we return.
@@ -209,20 +201,15 @@ func (p prefetchWrapper) prefetch(ctx context.Context) error {
 	}
 }
 
-func (p *prefetchWrapper) read(_ context.Context) error {
-	p.state = <-p.ch
+func (p *prefetchWrapper) read(_ context.Context) state {
+	state := <-p.ch
 
 	// Reading from a channel that is closed while waiting yields a zero-value.
 	// In that case, the pipeline should produce an error state.
-	if p.state.err == nil && p.state.batch == nil {
-		p.state = Canceled
+	if state.err == nil && state.batch == nil {
+		state = Canceled
 	}
-	return p.state.err
-}
-
-// Value implements [Pipeline].
-func (p *prefetchWrapper) Value() (arrow.Record, error) {
-	return p.state.batch, p.state.err
+	return state
 }
 
 // Close implements [Pipeline].
@@ -258,21 +245,19 @@ func tracePipeline(name string, pipeline Pipeline) *tracedPipeline {
 	}
 }
 
-func (p *tracedPipeline) Read(ctx context.Context) error {
+func (p *tracedPipeline) Read(ctx context.Context) (arrow.Record, error) {
 	ctx, span := tracer.Start(ctx, p.name+".Read")
 	defer span.End()
 
-	err := p.inner.Read(ctx)
+	res, err := p.inner.Read(ctx)
 	if err != nil && !errors.Is(err, EOF) {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 	} else {
 		span.SetStatus(codes.Ok, "")
 	}
-	return err
+	return res, err
 }
-
-func (p *tracedPipeline) Value() (arrow.Record, error) { return p.inner.Value() }
 
 func (p *tracedPipeline) Close() { p.inner.Close() }
 
@@ -304,20 +289,11 @@ var _ Pipeline = (*lazyPipeline)(nil)
 
 // Read reads the next value from the inner pipeline. If this is the first call
 // to Read, the inner  pipeline will be constructed using the provided context.
-func (lp *lazyPipeline) Read(ctx context.Context) error {
+func (lp *lazyPipeline) Read(ctx context.Context) (arrow.Record, error) {
 	if lp.built == nil {
 		lp.built = lp.ctor(ctx, lp.inputs)
 	}
 	return lp.built.Read(ctx)
-}
-
-// Value returns the current value from the lazily constructed pipeline. If the
-// pipeline has not been constructed yet, it returns an error.
-func (lp *lazyPipeline) Value() (arrow.Record, error) {
-	if lp.built == nil {
-		return nil, fmt.Errorf("lazyPipeline not built yet")
-	}
-	return lp.built.Value()
 }
 
 // Close closes the lazily constructed pipeline if it has been built.

--- a/pkg/engine/executor/pipeline_test.go
+++ b/pkg/engine/executor/pipeline_test.go
@@ -87,28 +87,20 @@ func TestCSVPipeline(t *testing.T) {
 		ctx := t.Context()
 
 		// First read should return the first record
-		err := pipeline.Read(ctx)
-		require.NoError(t, err)
-
-		batch, err := pipeline.Value()
+		batch, err := pipeline.Read(ctx)
 		require.NoError(t, err)
 		require.Equal(t, record1.NumRows(), batch.NumRows())
 		require.Equal(t, schema, batch.Schema())
 
 		// Second read should return the second record
-		err = pipeline.Read(ctx)
+		batch, err = pipeline.Read(ctx)
 		require.NoError(t, err)
 
-		batch, err = pipeline.Value()
-		require.NoError(t, err)
 		require.Equal(t, record2.NumRows(), batch.NumRows())
 		require.Equal(t, schema, batch.Schema())
 
 		// Third read should return EOF
-		err = pipeline.Read(ctx)
-		require.Equal(t, EOF, err)
-
-		_, err = pipeline.Value()
+		_, err = pipeline.Read(ctx)
 		require.Equal(t, EOF, err)
 	})
 }
@@ -138,7 +130,7 @@ func (i *instrumentedPipeline) Close() {
 }
 
 // Read implements Pipeline.
-func (i *instrumentedPipeline) Read(ctx context.Context) error {
+func (i *instrumentedPipeline) Read(ctx context.Context) (arrow.Record, error) {
 	i.callCount["Read"]++
 	return i.inner.Read(ctx)
 }
@@ -147,12 +139,6 @@ func (i *instrumentedPipeline) Read(ctx context.Context) error {
 func (i *instrumentedPipeline) Transport() Transport {
 	i.callCount["Transport"]++
 	return i.inner.Transport()
-}
-
-// Value implements Pipeline.
-func (i *instrumentedPipeline) Value() (arrow.Record, error) {
-	i.callCount["Value"]++
-	return i.inner.Value()
 }
 
 var _ Pipeline = (*instrumentedPipeline)(nil)
@@ -192,9 +178,8 @@ func Test_prefetchWrapper_Read(t *testing.T) {
 	ctx := t.Context()
 
 	// Read first batch
-	err := prefetchingPipeline.Read(ctx)
+	v, err := prefetchingPipeline.Read(ctx)
 	require.NoError(t, err)
-	v, _ := prefetchingPipeline.Value()
 	v.Release()
 	require.Equal(t, int64(2), v.NumRows())
 
@@ -202,9 +187,8 @@ func Test_prefetchWrapper_Read(t *testing.T) {
 	require.Equal(t, 2, instrumentedPipeline.callCount["Read"]) // 1 record consumed + 1 record pre-fetched
 
 	// Read second batch
-	err = prefetchingPipeline.Read(ctx)
+	v, err = prefetchingPipeline.Read(ctx)
 	require.NoError(t, err)
-	v, _ = prefetchingPipeline.Value()
 	v.Release()
 	require.Equal(t, int64(2), v.NumRows())
 
@@ -212,9 +196,8 @@ func Test_prefetchWrapper_Read(t *testing.T) {
 	require.Equal(t, 3, instrumentedPipeline.callCount["Read"]) // 2 records consumed + 1 record pre-fetched
 
 	// Read third/last batch
-	err = prefetchingPipeline.Read(ctx)
+	v, err = prefetchingPipeline.Read(ctx)
 	require.NoError(t, err)
-	v, _ = prefetchingPipeline.Value()
 	v.Release()
 	require.Equal(t, int64(1), v.NumRows())
 
@@ -222,7 +205,7 @@ func Test_prefetchWrapper_Read(t *testing.T) {
 	require.Equal(t, 4, instrumentedPipeline.callCount["Read"]) // 3 records consumed + 1 EOF pre-fetched
 
 	// Read EOF
-	err = prefetchingPipeline.Read(ctx)
+	_, err = prefetchingPipeline.Read(ctx)
 	require.ErrorContains(t, err, EOF.Error())
 
 	time.Sleep(10 * time.Millisecond)                           // ensure that next batch has been prefetched
@@ -232,7 +215,8 @@ func Test_prefetchWrapper_Read(t *testing.T) {
 func Test_prefetchWrapper_Close(t *testing.T) {
 	t.Run("initialized prefetcher", func(t *testing.T) {
 		w := newPrefetchingPipeline(emptyPipeline())
-		require.ErrorIs(t, EOF, w.Read(t.Context()))
+		_, err := w.Read(t.Context())
+		require.ErrorIs(t, EOF, err)
 		require.NotPanics(t, w.Close)
 	})
 

--- a/pkg/engine/executor/pipeline_utils_test.go
+++ b/pkg/engine/executor/pipeline_utils_test.go
@@ -34,13 +34,10 @@ func AssertPipelinesEqual(t testing.TB, left, right Pipeline) {
 				leftBatch = nil
 			}
 
-			leftErr = left.Read(ctx)
+			leftBatch, leftErr = left.Read(ctx)
 			if leftErr == nil {
-				leftBatch, leftErr = left.Value()
-				if leftErr == nil {
-					leftRemain = leftBatch.NumRows()
-					leftPos = 0
-				}
+				leftRemain = leftBatch.NumRows()
+				leftPos = 0
 			}
 		}
 
@@ -50,13 +47,10 @@ func AssertPipelinesEqual(t testing.TB, left, right Pipeline) {
 				rightBatch = nil
 			}
 
-			rightErr = right.Read(ctx)
+			rightBatch, rightErr = right.Read(ctx)
 			if rightErr == nil {
-				rightBatch, rightErr = right.Value()
-				if rightErr == nil {
-					rightRemain = rightBatch.NumRows()
-					rightPos = 0
-				}
+				rightRemain = rightBatch.NumRows()
+				rightPos = 0
 			}
 		}
 

--- a/pkg/engine/executor/project.go
+++ b/pkg/engine/executor/project.go
@@ -26,12 +26,7 @@ func NewProjectPipeline(input Pipeline, columns []physical.ColumnExpression, eva
 	return newGenericPipeline(Local, func(ctx context.Context, inputs []Pipeline) state {
 		// Pull the next item from the input pipeline
 		input := inputs[0]
-		err := input.Read(ctx)
-		if err != nil {
-			return failureState(err)
-		}
-
-		batch, err := input.Value()
+		batch, err := input.Read(ctx)
 		if err != nil {
 			return failureState(err)
 		}

--- a/pkg/engine/executor/range_aggregation_test.go
+++ b/pkg/engine/executor/range_aggregation_test.go
@@ -78,9 +78,7 @@ func TestRangeAggregationPipeline_instant(t *testing.T) {
 	defer pipeline.Close()
 
 	// Read the pipeline output
-	err = pipeline.Read(t.Context())
-	require.NoError(t, err)
-	record, err := pipeline.Value()
+	record, err := pipeline.Read(t.Context())
 	require.NoError(t, err)
 	defer record.Release()
 
@@ -169,9 +167,7 @@ func TestRangeAggregationPipeline(t *testing.T) {
 		require.NoError(t, err)
 		defer pipeline.Close()
 
-		err = pipeline.Read(t.Context())
-		require.NoError(t, err)
-		record, err := pipeline.Value()
+		record, err := pipeline.Read(t.Context())
 		require.NoError(t, err)
 		defer record.Release()
 
@@ -218,9 +214,7 @@ func TestRangeAggregationPipeline(t *testing.T) {
 		require.NoError(t, err)
 		defer pipeline.Close()
 
-		err = pipeline.Read(t.Context())
-		require.NoError(t, err)
-		record, err := pipeline.Value()
+		record, err := pipeline.Read(t.Context())
 		require.NoError(t, err)
 		defer record.Release()
 
@@ -280,9 +274,7 @@ func TestRangeAggregationPipeline(t *testing.T) {
 		require.NoError(t, err)
 		defer pipeline.Close()
 
-		err = pipeline.Read(t.Context())
-		require.NoError(t, err)
-		record, err := pipeline.Value()
+		record, err := pipeline.Read(t.Context())
 		require.NoError(t, err)
 		defer record.Release()
 

--- a/pkg/engine/executor/sortmerge_test.go
+++ b/pkg/engine/executor/sortmerge_test.go
@@ -42,7 +42,7 @@ func TestSortMerge(t *testing.T) {
 		require.NoError(t, err)
 
 		ctx := t.Context()
-		err = pipeline.Read(ctx)
+		_, err = pipeline.Read(ctx)
 		require.ErrorContains(t, err, "column is not a timestamp column")
 	})
 
@@ -70,14 +70,13 @@ func TestSortMerge(t *testing.T) {
 		timestamps := make([]arrow.Timestamp, 0, 30)
 		var batches, rows int64
 		for {
-			err := pipeline.Read(ctx)
+			batch, err := pipeline.Read(ctx)
 			if err == EOF {
 				break
 			}
 			if err != nil {
 				t.Fatalf("did not expect error, got %s", err.Error())
 			}
-			batch, _ := pipeline.Value()
 
 			tsCol, err := c.evaluator.eval(merge.Column, batch)
 			require.NoError(t, err)
@@ -118,14 +117,13 @@ func TestSortMerge(t *testing.T) {
 		timestamps := make([]arrow.Timestamp, 0, 30)
 		var batches, rows int64
 		for {
-			err := pipeline.Read(ctx)
+			batch, err := pipeline.Read(ctx)
 			if err == EOF {
 				break
 			}
 			if err != nil {
 				t.Fatalf("did not expect error, got %s", err.Error())
 			}
-			batch, _ := pipeline.Value()
 
 			tsCol, err := c.evaluator.eval(merge.Column, batch)
 			require.NoError(t, err)

--- a/pkg/engine/executor/topk_test.go
+++ b/pkg/engine/executor/topk_test.go
@@ -78,10 +78,9 @@ func Test_topk(t *testing.T) {
 	require.NoError(t, err, "should be able to create a topk pipeline")
 	defer topkPipeline.Close()
 
-	require.NoError(t, topkPipeline.Read(t.Context()), "should be able to read the sorted batch")
+	rec, err := topkPipeline.Read(t.Context())
+	require.NoError(t, err, "should be able to read the sorted batch")
 
-	rec, err := topkPipeline.Value()
-	require.NoError(t, err)
 	defer rec.Release()
 
 	expect := arrowtest.Rows{
@@ -111,9 +110,7 @@ func Test_topk_emptyPipelines(t *testing.T) {
 	require.NoError(t, err, "should be able to create a topk pipeline")
 	defer topkPipeline.Close()
 
-	require.ErrorIs(t, topkPipeline.Read(t.Context()), EOF, "should return EOF if there are no results")
-
-	rec, err := topkPipeline.Value()
-	require.Nil(t, rec, "should not return a record if there are no results")
+	rec, err := topkPipeline.Read(t.Context())
 	require.ErrorIs(t, err, EOF, "should return EOF if there are no results")
+	require.Nil(t, rec, "should not return a record if there are no results")
 }

--- a/pkg/engine/executor/vector_aggregate_test.go
+++ b/pkg/engine/executor/vector_aggregate_test.go
@@ -89,9 +89,7 @@ func TestVectorAggregationPipeline(t *testing.T) {
 	defer pipeline.Close()
 
 	// Read the pipeline output
-	err = pipeline.Read(t.Context())
-	require.NoError(t, err)
-	record, err := pipeline.Value()
+	record, err := pipeline.Read(t.Context())
 	require.NoError(t, err)
 	defer record.Release()
 


### PR DESCRIPTION
### Summary

This PR replaces the two calls to retrieve a value from the pipeline with a single one.

To do this, the `Read()` method now returns two arguments: `arrow.Record` and `error`, rather than just the error.

If the error is not `nil`, the first argument (arrow.Record) must be ignored by the caller.

The `Value()` method is not needed any more and was removed.

---

This change also got rid of the `state` field in many pipelines. However, I kept it in the `GenericPipeline` to keep the blast radius of the change minimal. It can be refactored in a follow up PR.