### PR TITLE
chore: Make section.Filter tenant aware

### DIFF
--- a/pkg/dataobj/consumer/logsobj/builder.go
+++ b/pkg/dataobj/consumer/logsobj/builder.go
@@ -458,7 +458,7 @@ func (b *Builder) CopyAndSort(obj *dataobj.Object) (*dataobj.Object, io.Closer, 
 	natsort.Sort(tenants)
 
 	for _, tenant := range tenants {
-		for _, sec := range obj.Sections().Filter(func(s *dataobj.Section) bool { return streams.CheckSection(s) && s.Tenant == tenant }) {
+		for _, sec := range obj.Sections().Filter(dataobj.ForSingleTenant(tenant), streams.CheckSection) {
 			sb.Reset()
 			sb.SetTenant(sec.Tenant)
 			// Copy section into new builder. This is *very* inefficient at the moment!
@@ -481,7 +481,7 @@ func (b *Builder) CopyAndSort(obj *dataobj.Object) (*dataobj.Object, io.Closer, 
 		}
 
 		var sections []*dataobj.Section
-		for _, sec := range obj.Sections().Filter(func(s *dataobj.Section) bool { return logs.CheckSection(s) && s.Tenant == tenant }) {
+		for _, sec := range obj.Sections().Filter(dataobj.ForSingleTenant(tenant), logs.CheckSection) {
 			sections = append(sections, sec)
 		}
 

--- a/pkg/dataobj/consumer/logsobj/builder_test.go
+++ b/pkg/dataobj/consumer/logsobj/builder_test.go
@@ -86,8 +86,8 @@ func TestBuilder(t *testing.T) {
 		require.NoError(t, err)
 		defer closer.Close()
 
-		require.Equal(t, 1, obj.Sections().Count(streams.CheckSection))
-		require.Equal(t, 1, obj.Sections().Count(logs.CheckSection))
+		require.Equal(t, 1, obj.Sections().Count(t.Context(), streams.CheckSection))
+		require.Equal(t, 1, obj.Sections().Count(t.Context(), logs.CheckSection))
 	})
 }
 
@@ -127,9 +127,9 @@ func TestBuilder_Append(t *testing.T) {
 	// to the section builder otherwise tenant will be absent from successive
 	// sections.
 	secs := obj.Sections()
-	require.Equal(t, 1, secs.Count(streams.CheckSection))
-	require.Greater(t, secs.Count(logs.CheckSection), 1)
-	for _, section := range secs.Filter(logs.CheckSection) {
+	require.Equal(t, 1, secs.Count(ctx, streams.CheckSection))
+	require.Greater(t, secs.Count(ctx, logs.CheckSection), 1)
+	for _, section := range secs.Filter(ctx, logs.CheckSection) {
 		require.Equal(t, tenant, section.Tenant)
 	}
 }

--- a/pkg/dataobj/index/calculate.go
+++ b/pkg/dataobj/index/calculate.go
@@ -81,7 +81,7 @@ func (c *Calculator) Calculate(ctx context.Context, logger log.Logger, reader *d
 	streamIDLookupByTenant := sync.Map{}
 
 	// Streams Section: process these first to ensure all streams have been added to the builder and are given new IDs.
-	for i, section := range reader.Sections().Filter(streams.CheckSection) {
+	for i, section := range reader.Sections().Filter(ctx, streams.CheckSection) {
 		g.Go(func() error {
 			streamIDLookup := make(map[int64]int64)
 			if err := c.processStreamsSection(streamsCtx, section, streamIDLookup); err != nil {
@@ -105,7 +105,7 @@ func (c *Calculator) Calculate(ctx context.Context, logger log.Logger, reader *d
 	g.SetLimit(runtime.GOMAXPROCS(0))
 	// Logs Section: these can be processed in parallel once we have the stream IDs for the tenant.
 	// TODO(benclive): Start processing logs sections as soon as the stream sections are done, tenant by tenant. That way we don't need to wait for the biggest stream sections before processing the logs.
-	for i, section := range reader.Sections().Filter(logs.CheckSection) {
+	for i, section := range reader.Sections().Filter(ctx, logs.CheckSection) {
 		g.Go(func() error {
 			sectionLogger := log.With(logger, "section", i)
 			streamIDLookup, ok := streamIDLookupByTenant.Load(section.Tenant)

--- a/pkg/dataobj/index/calculate.go
+++ b/pkg/dataobj/index/calculate.go
@@ -81,7 +81,7 @@ func (c *Calculator) Calculate(ctx context.Context, logger log.Logger, reader *d
 	streamIDLookupByTenant := sync.Map{}
 
 	// Streams Section: process these first to ensure all streams have been added to the builder and are given new IDs.
-	for i, section := range reader.Sections().Filter(ctx, streams.CheckSection) {
+	for i, section := range reader.Sections().Filter(dataobj.AllTenants(), streams.CheckSection) {
 		g.Go(func() error {
 			streamIDLookup := make(map[int64]int64)
 			if err := c.processStreamsSection(streamsCtx, section, streamIDLookup); err != nil {
@@ -105,7 +105,7 @@ func (c *Calculator) Calculate(ctx context.Context, logger log.Logger, reader *d
 	g.SetLimit(runtime.GOMAXPROCS(0))
 	// Logs Section: these can be processed in parallel once we have the stream IDs for the tenant.
 	// TODO(benclive): Start processing logs sections as soon as the stream sections are done, tenant by tenant. That way we don't need to wait for the biggest stream sections before processing the logs.
-	for i, section := range reader.Sections().Filter(ctx, logs.CheckSection) {
+	for i, section := range reader.Sections().Filter(dataobj.AllTenants(), logs.CheckSection) {
 		g.Go(func() error {
 			sectionLogger := log.With(logger, "section", i)
 			streamIDLookup, ok := streamIDLookupByTenant.Load(section.Tenant)

--- a/pkg/dataobj/index/calculate_test.go
+++ b/pkg/dataobj/index/calculate_test.go
@@ -105,10 +105,10 @@ func createTestLogObject(t *testing.T, tenants int) *dataobj.Object {
 	require.NoError(t, err)
 	t.Cleanup(func() { closer.Close() })
 
-	streamSections := obj.Sections().Count(streams.CheckSection)
+	streamSections := obj.Sections().Count(t.Context(), streams.CheckSection)
 	require.Equal(t, tenants, streamSections)
 
-	logSections := obj.Sections().Count(logs.CheckSection)
+	logSections := obj.Sections().Count(t.Context(), logs.CheckSection)
 	require.Equal(t, tenants, logSections)
 
 	return obj
@@ -146,8 +146,8 @@ func TestCalculator_Calculate(t *testing.T) {
 			require.Equal(t, time.Unix(25, 0).UTC(), timeRange.MaxTime)
 		}
 
-		// Confirm we have multiple pointers sections
-		count := obj.Sections().Count(pointers.CheckSection)
+		// Confirm we have multiple pointers sections, across all tenants
+		count := obj.Sections().Count(t.Context(), pointers.CheckSection)
 		require.GreaterOrEqual(t, count, tenants)
 
 		requireValidPointers(t, obj)
@@ -192,8 +192,8 @@ func TestCalculator_Calculate(t *testing.T) {
 			require.Equal(t, timeRange.MaxTime, time.Unix(25, 0).UTC())
 		}
 
-		// Confirm we have multiple pointers sections
-		count := obj.Sections().Count(pointers.CheckSection)
+		// Confirm we have multiple pointers sections, across all tenants
+		count := obj.Sections().Count(t.Context(), pointers.CheckSection)
 		require.GreaterOrEqual(t, count, tenants)
 
 		requireValidPointers(t, obj)
@@ -203,7 +203,7 @@ func TestCalculator_Calculate(t *testing.T) {
 func requireValidPointers(t *testing.T, obj *dataobj.Object) {
 	totalPointers := 0
 	pointersByTenant := make(map[string]int)
-	for _, section := range obj.Sections().Filter(pointers.CheckSection) {
+	for _, section := range obj.Sections().Filter(t.Context(), pointers.CheckSection) {
 		require.NotEmpty(t, section.Tenant)
 
 		sec, err := pointers.Open(context.Background(), section)

--- a/pkg/dataobj/index/calculate_test.go
+++ b/pkg/dataobj/index/calculate_test.go
@@ -105,10 +105,10 @@ func createTestLogObject(t *testing.T, tenants int) *dataobj.Object {
 	require.NoError(t, err)
 	t.Cleanup(func() { closer.Close() })
 
-	streamSections := obj.Sections().Count(t.Context(), streams.CheckSection)
+	streamSections := obj.Sections().Count(dataobj.AllTenants(), streams.CheckSection)
 	require.Equal(t, tenants, streamSections)
 
-	logSections := obj.Sections().Count(t.Context(), logs.CheckSection)
+	logSections := obj.Sections().Count(dataobj.AllTenants(), logs.CheckSection)
 	require.Equal(t, tenants, logSections)
 
 	return obj
@@ -147,7 +147,7 @@ func TestCalculator_Calculate(t *testing.T) {
 		}
 
 		// Confirm we have multiple pointers sections, across all tenants
-		count := obj.Sections().Count(t.Context(), pointers.CheckSection)
+		count := obj.Sections().Count(dataobj.AllTenants(), pointers.CheckSection)
 		require.GreaterOrEqual(t, count, tenants)
 
 		requireValidPointers(t, obj)
@@ -193,7 +193,7 @@ func TestCalculator_Calculate(t *testing.T) {
 		}
 
 		// Confirm we have multiple pointers sections, across all tenants
-		count := obj.Sections().Count(t.Context(), pointers.CheckSection)
+		count := obj.Sections().Count(dataobj.AllTenants(), pointers.CheckSection)
 		require.GreaterOrEqual(t, count, tenants)
 
 		requireValidPointers(t, obj)
@@ -203,7 +203,7 @@ func TestCalculator_Calculate(t *testing.T) {
 func requireValidPointers(t *testing.T, obj *dataobj.Object) {
 	totalPointers := 0
 	pointersByTenant := make(map[string]int)
-	for _, section := range obj.Sections().Filter(t.Context(), pointers.CheckSection) {
+	for _, section := range obj.Sections().Filter(dataobj.AllTenants(), pointers.CheckSection) {
 		require.NotEmpty(t, section.Tenant)
 
 		sec, err := pointers.Open(context.Background(), section)

--- a/pkg/dataobj/index/indexobj/builder_test.go
+++ b/pkg/dataobj/index/indexobj/builder_test.go
@@ -88,10 +88,10 @@ func TestBuilder(t *testing.T) {
 		require.NoError(t, err)
 		defer closer.Close()
 
-		require.Equal(t, 1, obj.Sections().Count(streams.CheckSection))
-		require.Equal(t, 1, obj.Sections().Count(pointers.CheckSection))
-		require.Equal(t, 0, obj.Sections().Count(logs.CheckSection))
-		require.Equal(t, 0, obj.Sections().Count(indexpointers.CheckSection))
+		require.Equal(t, 1, obj.Sections().Count(t.Context(), streams.CheckSection))
+		require.Equal(t, 1, obj.Sections().Count(t.Context(), pointers.CheckSection))
+		require.Equal(t, 0, obj.Sections().Count(t.Context(), logs.CheckSection))
+		require.Equal(t, 0, obj.Sections().Count(t.Context(), indexpointers.CheckSection))
 	})
 
 	t.Run("BuildMultiTenant", func(t *testing.T) {
@@ -115,10 +115,10 @@ func TestBuilder(t *testing.T) {
 		require.NoError(t, err)
 		defer closer.Close()
 
-		require.Equal(t, len(tenants), obj.Sections().Count(streams.CheckSection))
-		require.Equal(t, len(tenants), obj.Sections().Count(pointers.CheckSection))
-		require.Equal(t, 0, obj.Sections().Count(logs.CheckSection))
-		require.Equal(t, 0, obj.Sections().Count(indexpointers.CheckSection))
+		require.Equal(t, len(tenants), obj.Sections().Count(t.Context(), streams.CheckSection))
+		require.Equal(t, len(tenants), obj.Sections().Count(t.Context(), pointers.CheckSection))
+		require.Equal(t, 0, obj.Sections().Count(t.Context(), logs.CheckSection))
+		require.Equal(t, 0, obj.Sections().Count(t.Context(), indexpointers.CheckSection))
 	})
 }
 

--- a/pkg/dataobj/index/indexobj/builder_test.go
+++ b/pkg/dataobj/index/indexobj/builder_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/loki/v3/pkg/dataobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/consumer/logsobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/indexpointers"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/logs"
@@ -88,10 +89,10 @@ func TestBuilder(t *testing.T) {
 		require.NoError(t, err)
 		defer closer.Close()
 
-		require.Equal(t, 1, obj.Sections().Count(t.Context(), streams.CheckSection))
-		require.Equal(t, 1, obj.Sections().Count(t.Context(), pointers.CheckSection))
-		require.Equal(t, 0, obj.Sections().Count(t.Context(), logs.CheckSection))
-		require.Equal(t, 0, obj.Sections().Count(t.Context(), indexpointers.CheckSection))
+		require.Equal(t, 1, obj.Sections().Count(dataobj.ForSingleTenant(testTenant), streams.CheckSection))
+		require.Equal(t, 1, obj.Sections().Count(dataobj.ForSingleTenant(testTenant), pointers.CheckSection))
+		require.Equal(t, 0, obj.Sections().Count(dataobj.ForSingleTenant(testTenant), logs.CheckSection))
+		require.Equal(t, 0, obj.Sections().Count(dataobj.ForSingleTenant(testTenant), indexpointers.CheckSection))
 	})
 
 	t.Run("BuildMultiTenant", func(t *testing.T) {
@@ -115,10 +116,10 @@ func TestBuilder(t *testing.T) {
 		require.NoError(t, err)
 		defer closer.Close()
 
-		require.Equal(t, len(tenants), obj.Sections().Count(t.Context(), streams.CheckSection))
-		require.Equal(t, len(tenants), obj.Sections().Count(t.Context(), pointers.CheckSection))
-		require.Equal(t, 0, obj.Sections().Count(t.Context(), logs.CheckSection))
-		require.Equal(t, 0, obj.Sections().Count(t.Context(), indexpointers.CheckSection))
+		require.Equal(t, len(tenants), obj.Sections().Count(dataobj.AllTenants(), streams.CheckSection))
+		require.Equal(t, len(tenants), obj.Sections().Count(dataobj.AllTenants(), pointers.CheckSection))
+		require.Equal(t, 0, obj.Sections().Count(dataobj.AllTenants(), logs.CheckSection))
+		require.Equal(t, 0, obj.Sections().Count(dataobj.AllTenants(), indexpointers.CheckSection))
 	})
 }
 

--- a/pkg/dataobj/metastore/object.go
+++ b/pkg/dataobj/metastore/object.go
@@ -476,6 +476,11 @@ func (m *ObjectMetastore) listStreamIDsFromLogObjects(ctx context.Context, objec
 	streamIDs := make([][]int64, len(objectPaths))
 	sections := make([]int, len(objectPaths))
 
+	tenantID, err := user.ExtractOrgID(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("extracting org ID: %w", err)
+	}
+
 	g, ctx := errgroup.WithContext(ctx)
 	g.SetLimit(m.parallelism)
 
@@ -486,7 +491,7 @@ func (m *ObjectMetastore) listStreamIDsFromLogObjects(ctx context.Context, objec
 				return fmt.Errorf("getting object from bucket: %w", err)
 			}
 
-			sections[idx] = object.Sections().Count(logs.CheckSection)
+			sections[idx] = object.Sections().Count(dataobj.ForSingleTenant(tenantID), logs.CheckSection)
 			streamIDs[idx] = make([]int64, 0, 8)
 
 			return forEachStream(ctx, object, predicate, func(stream streams.Stream) {
@@ -678,19 +683,17 @@ func (m *ObjectMetastore) listObjects(ctx context.Context, path string, start, e
 }
 
 func forEachIndexPointer(ctx context.Context, object *dataobj.Object, predicate indexpointers.RowPredicate, f func(indexpointers.IndexPointer)) error {
-	targetTenant, err := user.ExtractOrgID(ctx)
-	if err != nil {
-		return fmt.Errorf("extracting org ID: %w", err)
-	}
 	var reader indexpointers.RowReader
 	defer reader.Close()
 
+	tenantID, err := user.ExtractOrgID(ctx)
+	if err != nil {
+		return fmt.Errorf("extracting org ID: %w", err)
+	}
+
 	buf := make([]indexpointers.IndexPointer, 1024)
 
-	for _, section := range object.Sections().Filter(indexpointers.CheckSection) {
-		if section.Tenant != targetTenant {
-			continue
-		}
+	for _, section := range object.Sections().Filter(dataobj.ForSingleTenant(tenantID), indexpointers.CheckSection) {
 		sec, err := indexpointers.Open(ctx, section)
 		if err != nil {
 			return fmt.Errorf("opening section: %w", err)
@@ -722,20 +725,17 @@ func forEachIndexPointer(ctx context.Context, object *dataobj.Object, predicate 
 }
 
 func forEachStream(ctx context.Context, object *dataobj.Object, predicate streams.RowPredicate, f func(streams.Stream)) error {
-	targetTenant, err := user.ExtractOrgID(ctx)
-	if err != nil {
-		return fmt.Errorf("extracting org ID: %w", err)
-	}
 	var reader streams.RowReader
 	defer reader.Close()
 
+	tenantID, err := user.ExtractOrgID(ctx)
+	if err != nil {
+		return fmt.Errorf("extracting org ID: %w", err)
+	}
+
 	buf := make([]streams.Stream, 1024)
 
-	for _, section := range object.Sections().Filter(streams.CheckSection) {
-		if section.Tenant != targetTenant {
-			continue
-		}
-
+	for _, section := range object.Sections().Filter(dataobj.ForSingleTenant(tenantID), streams.CheckSection) {
 		sec, err := streams.Open(ctx, section)
 		if err != nil {
 			return fmt.Errorf("opening section: %w", err)
@@ -765,20 +765,17 @@ func forEachStream(ctx context.Context, object *dataobj.Object, predicate stream
 }
 
 func forEachObjPointer(ctx context.Context, object *dataobj.Object, predicate pointers.RowPredicate, matchIDs []int64, f func(pointers.SectionPointer)) error {
-	targetTenant, err := user.ExtractOrgID(ctx)
-	if err != nil {
-		return fmt.Errorf("extracting org ID: %w", err)
-	}
 	var reader pointers.RowReader
 	defer reader.Close()
 
+	tenantID, err := user.ExtractOrgID(ctx)
+	if err != nil {
+		return fmt.Errorf("extracting org ID: %w", err)
+	}
+
 	buf := make([]pointers.SectionPointer, 128)
 
-	for _, section := range object.Sections().Filter(pointers.CheckSection) {
-		if section.Tenant != targetTenant {
-			continue
-		}
-
+	for _, section := range object.Sections().Filter(dataobj.ForSingleTenant(tenantID), pointers.CheckSection) {
 		sec, err := pointers.Open(ctx, section)
 		if err != nil {
 			return fmt.Errorf("opening section: %w", err)

--- a/pkg/dataobj/metastore/toc_writer.go
+++ b/pkg/dataobj/metastore/toc_writer.go
@@ -221,7 +221,7 @@ func (m *TableOfContentsWriter) copyFromExistingToc(ctx context.Context, tocObje
 	// Read index pointers from existing metastore object and write them to the builder for the new object
 	pbuf := make([]indexpointers.IndexPointer, 256)
 
-	for _, section := range tocObject.Sections().Filter(indexpointers.CheckSection) {
+	for _, section := range tocObject.Sections().Filter(dataobj.AllTenants(), indexpointers.CheckSection) {
 		sec, err := indexpointers.Open(ctx, section)
 		if err != nil {
 			return errors.Wrap(err, "opening section")

--- a/pkg/dataobj/section.go
+++ b/pkg/dataobj/section.go
@@ -5,8 +5,6 @@ import (
 	"io"
 	"iter"
 	"strconv"
-
-	"github.com/grafana/dskit/user"
 )
 
 // A Sections is a slice of [Section].
@@ -54,15 +52,6 @@ func (s Sections) Count(tenantFilter TenantFilter, predicate func(*Section) bool
 		count++
 	}
 	return count
-}
-
-func (s Sections) extractTenant(ctx context.Context) (string, bool) {
-	found := true
-	targetTenant, err := user.ExtractOrgID(ctx)
-	if err != nil {
-		found = false
-	}
-	return targetTenant, found
 }
 
 // A Section is a subset of an [Object] that holds a specific type of data. Use

--- a/pkg/dataobj/sections/indexpointers/builder_test.go
+++ b/pkg/dataobj/sections/indexpointers/builder_test.go
@@ -48,7 +48,7 @@ func TestBuilder(t *testing.T) {
 	}
 
 	var actual []IndexPointer
-	for result := range Iter(context.Background(), obj) {
+	for result := range Iter(context.Background(), obj, dataobj.AllTenants()) {
 		pointer, err := result.Value()
 		require.NoError(t, err)
 		actual = append(actual, pointer)

--- a/pkg/dataobj/sections/indexpointers/iter.go
+++ b/pkg/dataobj/sections/indexpointers/iter.go
@@ -8,7 +8,6 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/grafana/dskit/user"
 	"github.com/grafana/loki/v3/pkg/dataobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/dataset"
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/metadata/datasetmd"
@@ -19,13 +18,9 @@ import (
 
 // Iter iterates over indexpointers in the provided decoder. All indexpointers sections are
 // iterated over in order.
-func Iter(ctx context.Context, obj *dataobj.Object) result.Seq[IndexPointer] {
+func Iter(ctx context.Context, obj *dataobj.Object, tenantFilter dataobj.TenantFilter) result.Seq[IndexPointer] {
 	return result.Iter(func(yield func(IndexPointer) bool) error {
-		tenantID, err := user.ExtractOrgID(ctx)
-		if err != nil {
-			return err
-		}
-		for i, section := range obj.Sections().Filter(dataobj.ForSingleTenant(tenantID), CheckSection) {
+		for i, section := range obj.Sections().Filter(tenantFilter, CheckSection) {
 			pointersSection, err := Open(ctx, section)
 			if err != nil {
 				return fmt.Errorf("opening section %d: %w", i, err)

--- a/pkg/dataobj/sections/logs/builder_test.go
+++ b/pkg/dataobj/sections/logs/builder_test.go
@@ -78,7 +78,7 @@ func Test(t *testing.T) {
 	}
 
 	i := 0
-	for result := range logs.Iter(context.Background(), obj) {
+	for result := range logs.Iter(context.Background(), obj, dataobj.AllTenants()) {
 		record, err := result.Value()
 		require.NoError(t, err)
 		require.Equal(t, expect[i], record)

--- a/pkg/dataobj/sections/logs/iter.go
+++ b/pkg/dataobj/sections/logs/iter.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"time"
 
+	"github.com/grafana/dskit/user"
 	"github.com/grafana/loki/v3/pkg/dataobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/dataset"
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/metadata/datasetmd"
@@ -22,7 +23,11 @@ import (
 // Results objects returned to yield may be reused and must be copied for further use via DeepCopy().
 func Iter(ctx context.Context, obj *dataobj.Object) result.Seq[Record] {
 	return result.Iter(func(yield func(Record) bool) error {
-		for i, section := range obj.Sections().Filter(CheckSection) {
+		tenantID, err := user.ExtractOrgID(ctx)
+		if err != nil {
+			return err
+		}
+		for i, section := range obj.Sections().Filter(dataobj.ForSingleTenant(tenantID), CheckSection) {
 			logsSection, err := Open(ctx, section)
 			if err != nil {
 				return fmt.Errorf("opening section %d: %w", i, err)

--- a/pkg/dataobj/sections/pointers/builder_test.go
+++ b/pkg/dataobj/sections/pointers/builder_test.go
@@ -74,7 +74,7 @@ func TestAddingStreams(t *testing.T) {
 	}
 
 	var actual []SectionPointer
-	for result := range Iter(context.Background(), obj) {
+	for result := range Iter(context.Background(), obj, dataobj.AllTenants()) {
 		pointer, err := result.Value()
 		require.NoError(t, err)
 		actual = append(actual, pointer)
@@ -139,7 +139,7 @@ func TestAddingColumnIndexes(t *testing.T) {
 	}
 
 	var actual []SectionPointer
-	for result := range Iter(context.Background(), obj) {
+	for result := range Iter(context.Background(), obj, dataobj.AllTenants()) {
 		pointer, err := result.Value()
 		require.NoError(t, err)
 		actual = append(actual, pointer)

--- a/pkg/dataobj/sections/pointers/iter.go
+++ b/pkg/dataobj/sections/pointers/iter.go
@@ -8,6 +8,7 @@ import (
 	"time"
 	"unsafe"
 
+	"github.com/grafana/dskit/user"
 	"github.com/grafana/loki/v3/pkg/dataobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/dataset"
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/metadata/datasetmd"
@@ -21,7 +22,11 @@ import (
 // iterated over in order.
 func Iter(ctx context.Context, obj *dataobj.Object) result.Seq[SectionPointer] {
 	return result.Iter(func(yield func(SectionPointer) bool) error {
-		for i, section := range obj.Sections().Filter(CheckSection) {
+		tenantID, err := user.ExtractOrgID(ctx)
+		if err != nil {
+			return err
+		}
+		for i, section := range obj.Sections().Filter(dataobj.ForSingleTenant(tenantID), CheckSection) {
 			pointersSection, err := Open(ctx, section)
 			if err != nil {
 				return fmt.Errorf("opening section %d: %w", i, err)

--- a/pkg/dataobj/sections/pointers/iter.go
+++ b/pkg/dataobj/sections/pointers/iter.go
@@ -8,7 +8,6 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/grafana/dskit/user"
 	"github.com/grafana/loki/v3/pkg/dataobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/dataset"
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/metadata/datasetmd"
@@ -20,13 +19,9 @@ import (
 
 // Iter iterates over pointers in the provided decoder. All pointers sections are
 // iterated over in order.
-func Iter(ctx context.Context, obj *dataobj.Object) result.Seq[SectionPointer] {
+func Iter(ctx context.Context, obj *dataobj.Object, tenantFilter dataobj.TenantFilter) result.Seq[SectionPointer] {
 	return result.Iter(func(yield func(SectionPointer) bool) error {
-		tenantID, err := user.ExtractOrgID(ctx)
-		if err != nil {
-			return err
-		}
-		for i, section := range obj.Sections().Filter(dataobj.ForSingleTenant(tenantID), CheckSection) {
+		for i, section := range obj.Sections().Filter(tenantFilter, CheckSection) {
 			pointersSection, err := Open(ctx, section)
 			if err != nil {
 				return fmt.Errorf("opening section %d: %w", i, err)

--- a/pkg/dataobj/sections/streams/builder_test.go
+++ b/pkg/dataobj/sections/streams/builder_test.go
@@ -57,7 +57,7 @@ func Test(t *testing.T) {
 	}
 
 	var actual []streams.Stream
-	for result := range streams.Iter(context.Background(), obj) {
+	for result := range streams.Iter(context.Background(), obj, dataobj.AllTenants()) {
 		stream, err := result.Value()
 		require.NoError(t, err)
 		stream.Labels = copyLabels(stream.Labels)

--- a/pkg/dataobj/sections/streams/iter.go
+++ b/pkg/dataobj/sections/streams/iter.go
@@ -8,7 +8,6 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/grafana/dskit/user"
 	"github.com/grafana/loki/v3/pkg/dataobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/dataset"
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/metadata/datasetmd"
@@ -20,13 +19,9 @@ import (
 
 // Iter iterates over streams in the provided decoder. All streams sections are
 // iterated over in order.
-func Iter(ctx context.Context, obj *dataobj.Object) result.Seq[Stream] {
+func Iter(ctx context.Context, obj *dataobj.Object, tenantFilter dataobj.TenantFilter) result.Seq[Stream] {
 	return result.Iter(func(yield func(Stream) bool) error {
-		tenantID, err := user.ExtractOrgID(ctx)
-		if err != nil {
-			return err
-		}
-		for i, section := range obj.Sections().Filter(dataobj.ForSingleTenant(tenantID), CheckSection) {
+		for i, section := range obj.Sections().Filter(tenantFilter, CheckSection) {
 			streamsSection, err := Open(ctx, section)
 			if err != nil {
 				return fmt.Errorf("opening section %d: %w", i, err)

--- a/pkg/dataobj/sections/streams/iter.go
+++ b/pkg/dataobj/sections/streams/iter.go
@@ -8,6 +8,7 @@ import (
 	"time"
 	"unsafe"
 
+	"github.com/grafana/dskit/user"
 	"github.com/grafana/loki/v3/pkg/dataobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/dataset"
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/metadata/datasetmd"
@@ -21,7 +22,11 @@ import (
 // iterated over in order.
 func Iter(ctx context.Context, obj *dataobj.Object) result.Seq[Stream] {
 	return result.Iter(func(yield func(Stream) bool) error {
-		for i, section := range obj.Sections().Filter(CheckSection) {
+		tenantID, err := user.ExtractOrgID(ctx)
+		if err != nil {
+			return err
+		}
+		for i, section := range obj.Sections().Filter(dataobj.ForSingleTenant(tenantID), CheckSection) {
 			streamsSection, err := Open(ctx, section)
 			if err != nil {
 				return fmt.Errorf("opening section %d: %w", i, err)

--- a/pkg/engine/internal/executor/executor.go
+++ b/pkg/engine/internal/executor/executor.go
@@ -145,12 +145,12 @@ func (c *Context) executeDataObjScan(ctx context.Context, node *physical.DataObj
 		logsSection    *logs.Section
 	)
 
-	tenantID, err := user.ExtractOrgID(ctx)
+	tenant, err := user.ExtractOrgID(ctx)
 	if err != nil {
-		return errorPipeline(ctx, fmt.Errorf("extracting org ID: %w", err))
+		return errorPipeline(ctx, fmt.Errorf("missing org ID: %w", err))
 	}
 
-	for _, sec := range obj.Sections().Filter(dataobj.ForSingleTenant(tenantID), streams.CheckSection) {
+	for _, sec := range obj.Sections().Filter(dataobj.ForSingleTenant(tenant), streams.CheckSection) {
 		if streamsSection != nil {
 			return errorPipeline(ctx, fmt.Errorf("multiple streams sections found in data object %q", node.Location))
 		}
@@ -166,7 +166,7 @@ func (c *Context) executeDataObjScan(ctx context.Context, node *physical.DataObj
 		return errorPipeline(ctx, fmt.Errorf("streams section not found in data object %q", node.Location))
 	}
 
-	for i, sec := range obj.Sections().Filter(dataobj.ForSingleTenant(tenantID), logs.CheckSection) {
+	for i, sec := range obj.Sections().Filter(dataobj.ForSingleTenant(tenant), logs.CheckSection) {
 		if i != node.Section {
 			continue
 		}

--- a/pkg/engine/internal/executor/executor.go
+++ b/pkg/engine/internal/executor/executor.go
@@ -166,7 +166,7 @@ func (c *Context) executeDataObjScan(ctx context.Context, node *physical.DataObj
 		return errorPipeline(ctx, fmt.Errorf("streams section not found in data object %q", node.Location))
 	}
 
-	for i, sec := range obj.Sections().Filter(dataobj.ForSingleTenant(tenant), logs.CheckSection) {
+	for i, sec := range obj.Sections().Filter(dataobj.AllTenants(), logs.CheckSection) {
 		if i != node.Section {
 			continue
 		}

--- a/pkg/engine/internal/executor/executor.go
+++ b/pkg/engine/internal/executor/executor.go
@@ -7,12 +7,12 @@ import (
 	"strings"
 
 	"github.com/go-kit/log"
-	"github.com/grafana/dskit/user"
 	"github.com/thanos-io/objstore"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 
+	"github.com/grafana/dskit/user"
 	"github.com/grafana/loki/v3/pkg/dataobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/logs"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/streams"
@@ -144,16 +144,12 @@ func (c *Context) executeDataObjScan(ctx context.Context, node *physical.DataObj
 		logsSection    *logs.Section
 	)
 
-	tenant, err := user.ExtractOrgID(ctx)
+	tenantID, err := user.ExtractOrgID(ctx)
 	if err != nil {
-		return errorPipeline(ctx, fmt.Errorf("missing org ID: %w", err))
+		return errorPipeline(ctx, fmt.Errorf("extracting org ID: %w", err))
 	}
 
-	for _, sec := range obj.Sections().Filter(streams.CheckSection) {
-		if sec.Tenant != tenant {
-			continue
-		}
-
+	for _, sec := range obj.Sections().Filter(dataobj.ForSingleTenant(tenantID), streams.CheckSection) {
 		if streamsSection != nil {
 			return errorPipeline(ctx, fmt.Errorf("multiple streams sections found in data object %q", node.Location))
 		}
@@ -169,7 +165,7 @@ func (c *Context) executeDataObjScan(ctx context.Context, node *physical.DataObj
 		return errorPipeline(ctx, fmt.Errorf("streams section not found in data object %q", node.Location))
 	}
 
-	for i, sec := range obj.Sections().Filter(logs.CheckSection) {
+	for i, sec := range obj.Sections().Filter(dataobj.ForSingleTenant(tenantID), logs.CheckSection) {
 		if i != node.Section {
 			continue
 		}

--- a/pkg/engine/internal/executor/executor.go
+++ b/pkg/engine/internal/executor/executor.go
@@ -13,6 +13,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/grafana/dskit/user"
+
 	"github.com/grafana/loki/v3/pkg/dataobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/logs"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/streams"


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds context to Filter methods. The context is used to extract the tenant ID when filtering for sections.
If there is no tenant ID, then all sections are returned.

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/loki-private/issues/1961