### PR TITLE
chore(operator): improve error message when users configure tenants in static and dynamic mode

### DIFF
--- a/operator/internal/handlers/internal/gateway/tenant_secrets.go
+++ b/operator/internal/handlers/internal/gateway/tenant_secrets.go
@@ -118,7 +118,7 @@ func extractCAPath(ctx context.Context, k k8s.Client, namespace string, tennantN
 	if err := k.Get(ctx, key, &caConfigMap); err != nil {
 		if apierrors.IsNotFound(err) {
 			return "", &status.DegradedError{
-				Message: fmt.Sprintf("Missing configmap for tenant %s", tennantName),
+				Message: fmt.Sprintf("Missing ConfigMap with CA bundle for tenant %s", tennantName),
 				Reason:  lokiv1.ReasonMissingGatewayTenantConfigMap,
 				Requeue: true,
 			}
@@ -134,7 +134,7 @@ func extractCAPath(ctx context.Context, k k8s.Client, namespace string, tennantN
 	err := checkKeyIsPresent(&caConfigMap, cmKey)
 	if err != nil {
 		return "", &status.DegradedError{
-			Message: "Invalid gateway tenant configmap contents",
+			Message: fmt.Sprintf("Invalid contents of ConfigMap with tenant %s CA bundle did not find key %s", tennantName, cmKey),
 			Reason:  lokiv1.ReasonInvalidGatewayTenantConfigMap,
 			Requeue: true,
 		}

--- a/operator/internal/handlers/internal/gateway/tenant_secrets.go
+++ b/operator/internal/handlers/internal/gateway/tenant_secrets.go
@@ -112,13 +112,13 @@ func checkKeyIsPresent(cm *corev1.ConfigMap, key string) error {
 	return nil
 }
 
-func extractCAPath(ctx context.Context, k k8s.Client, namespace string, tennantName string, caSpec *lokiv1.CASpec) (string, error) {
+func extractCAPath(ctx context.Context, k k8s.Client, namespace string, tenantName string, caSpec *lokiv1.CASpec) (string, error) {
 	var caConfigMap corev1.ConfigMap
 	key := client.ObjectKey{Name: caSpec.CA, Namespace: namespace}
 	if err := k.Get(ctx, key, &caConfigMap); err != nil {
 		if apierrors.IsNotFound(err) {
 			return "", &status.DegradedError{
-				Message: fmt.Sprintf("Missing ConfigMap with CA bundle for tenant: %s", tennantName),
+				Message: fmt.Sprintf("Missing ConfigMap with CA bundle for tenant: %s", tenantName),
 				Reason:  lokiv1.ReasonMissingGatewayTenantConfigMap,
 				Requeue: true,
 			}
@@ -134,10 +134,10 @@ func extractCAPath(ctx context.Context, k k8s.Client, namespace string, tennantN
 	err := checkKeyIsPresent(&caConfigMap, cmKey)
 	if err != nil {
 		return "", &status.DegradedError{
-			Message: fmt.Sprintf("Invalid contents of ConfigMap for tenant %q. Can not find CA bundle with key: %s", tennantName, cmKey),
+			Message: fmt.Sprintf("Invalid contents of ConfigMap for tenant %q. Can not find CA bundle with key: %s", tenantName, cmKey),
 			Reason:  lokiv1.ReasonInvalidGatewayTenantConfigMap,
 			Requeue: true,
 		}
 	}
-	return manifests.TenantCAPath(tennantName, cmKey), nil
+	return manifests.TenantCAPath(tenantName, cmKey), nil
 }

--- a/operator/internal/handlers/internal/gateway/tenant_secrets.go
+++ b/operator/internal/handlers/internal/gateway/tenant_secrets.go
@@ -118,7 +118,7 @@ func extractCAPath(ctx context.Context, k k8s.Client, namespace string, tennantN
 	if err := k.Get(ctx, key, &caConfigMap); err != nil {
 		if apierrors.IsNotFound(err) {
 			return "", &status.DegradedError{
-				Message: fmt.Sprintf("Missing ConfigMap with CA bundle for tenant %s", tennantName),
+				Message: fmt.Sprintf("Missing ConfigMap with CA bundle for tenant: %s", tennantName),
 				Reason:  lokiv1.ReasonMissingGatewayTenantConfigMap,
 				Requeue: true,
 			}
@@ -134,7 +134,7 @@ func extractCAPath(ctx context.Context, k k8s.Client, namespace string, tennantN
 	err := checkKeyIsPresent(&caConfigMap, cmKey)
 	if err != nil {
 		return "", &status.DegradedError{
-			Message: fmt.Sprintf("Invalid contents of ConfigMap with tenant %s CA bundle did not find key %s", tennantName, cmKey),
+			Message: fmt.Sprintf("Invalid contents of ConfigMap for tenant %q. Can not find CA bundle with key: %s", tennantName, cmKey),
 			Reason:  lokiv1.ReasonInvalidGatewayTenantConfigMap,
 			Requeue: true,
 		}

--- a/operator/internal/handlers/internal/gateway/tenant_secrets_test.go
+++ b/operator/internal/handlers/internal/gateway/tenant_secrets_test.go
@@ -110,7 +110,7 @@ func TestGetTenantSecrets(t *testing.T) {
 						Namespace: "some-ns",
 					},
 				},
-				errorMsg: "cluster degraded: Invalid contents of ConfigMap with tenant test CA bundle did not find key special-ca.crt",
+				errorMsg: "cluster degraded: Invalid contents of ConfigMap for tenant \"test\". Can not find CA bundle with key: special-ca.crt",
 			},
 		} {
 			t.Run(strings.Join([]string{string(mode), tc.name}, "_"), func(t *testing.T) {

--- a/operator/internal/handlers/internal/gateway/tenant_secrets_test.go
+++ b/operator/internal/handlers/internal/gateway/tenant_secrets_test.go
@@ -23,6 +23,7 @@ func TestGetTenantSecrets(t *testing.T) {
 			authNSpec []lokiv1.AuthenticationSpec
 			object    client.Object
 			expected  []*manifests.TenantSecrets
+			errorMsg  string
 		}{
 			{
 				name: "oidc",
@@ -89,12 +90,34 @@ func TestGetTenantSecrets(t *testing.T) {
 					},
 				},
 			},
+			{
+				name: "mTLS missing cm",
+				authNSpec: []lokiv1.AuthenticationSpec{
+					{
+						TenantName: "test",
+						TenantID:   "test",
+						MTLS: &lokiv1.MTLSSpec{
+							CA: &lokiv1.CASpec{
+								CA:    "test",
+								CAKey: "special-ca.crt",
+							},
+						},
+					},
+				},
+				object: &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "not-ca-bundle",
+						Namespace: "some-ns",
+					},
+				},
+				errorMsg: "cluster degraded: Invalid contents of ConfigMap with tenant test CA bundle did not find key special-ca.crt",
+			},
 		} {
 			t.Run(strings.Join([]string{string(mode), tc.name}, "_"), func(t *testing.T) {
 				k := &k8sfakes.FakeClient{}
 				s := &lokiv1.LokiStack{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "mystack",
+						Name:      "test",
 						Namespace: "some-ns",
 					},
 					Spec: lokiv1.LokiStackSpec{
@@ -112,8 +135,13 @@ func TestGetTenantSecrets(t *testing.T) {
 					return nil
 				}
 				ts, err := getTenantSecrets(context.TODO(), k, s)
-				require.NoError(t, err)
-				require.ElementsMatch(t, ts, tc.expected)
+				if tc.errorMsg != "" {
+					require.Error(t, err)
+					require.Equal(t, tc.errorMsg, err.Error())
+				} else {
+					require.NoError(t, err)
+					require.ElementsMatch(t, ts, tc.expected)
+				}
 			})
 		}
 	}

--- a/operator/internal/manifests/gateway_tenants.go
+++ b/operator/internal/manifests/gateway_tenants.go
@@ -198,13 +198,13 @@ func configureCAVolumes(d *appsv1.Deployment, tenants *lokiv1.TenantsSpec) error
 		return nil // nothing to do
 	}
 
-	mountCAConfigMap := func(container *corev1.Container, volumes *[]corev1.Volume, tennantName, configmapName string) {
+	mountCAConfigMap := func(container *corev1.Container, volumes *[]corev1.Volume, tenantName, configmapName string) {
 		container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
-			Name:      tenantCAVolumeName(tennantName),
-			MountPath: tenantCADir(tennantName),
+			Name:      tenantCAVolumeName(tenantName),
+			MountPath: tenantCADir(tenantName),
 		})
 		*volumes = append(*volumes, corev1.Volume{
-			Name: tenantCAVolumeName(tennantName),
+			Name: tenantCAVolumeName(tenantName),
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
 					LocalObjectReference: corev1.LocalObjectReference{

--- a/operator/internal/manifests/var.go
+++ b/operator/internal/manifests/var.go
@@ -308,12 +308,12 @@ func tenantCAVolumeName(tenantName string) string {
 	return fmt.Sprintf("%s-ca-bundle", tenantName)
 }
 
-func tenantCADir(tennantName string) string {
-	return path.Join(tenantCAsDir, tennantName)
+func tenantCADir(tenantName string) string {
+	return path.Join(tenantCAsDir, tenantName)
 }
 
-func TenantCAPath(tennantName, key string) string {
-	return path.Join(tenantCAsDir, tennantName, key)
+func TenantCAPath(tenantName, key string) string {
+	return path.Join(tenantCAsDir, tenantName, key)
 }
 
 func gatewayClientSecretName(stackName string) string {


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Related with https://issues.redhat.com/browse/OSPRH-19446

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
