### PR TITLE
chore: segmentation kafka ingestion strategy

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -4789,20 +4789,17 @@ otlp_config:
 # the SSE type override is not set.
 [s3_sse_kms_encryption_context: <string> | default = ""]
 
-# Experimental: Controls the amount of scan tasks that can be running in
-# parallel in the new query engine. The default of 0 means unlimited parallelism
-# and all tasks will be scheduled at once.
-# CLI flag: -limits.max-scan-task-parallelism
-[max_scan_task_parallelism: <int> | default = 0]
+[max_scan_task_parallelism: <int>]
 
-# Experimental: Toggles verbose debug logging of tasks in the new query engine.
-# CLI flag: -limits.debug-engine-tasks
-[debug_engine_tasks: <boolean> | default = false]
+[debug_engine_tasks: <boolean>]
 
-# Experimental: Toggles verbose debug logging of data streams in the new query
-# engine.
-# CLI flag: -limits.debug-engine-streams
-[debug_engine_streams: <boolean> | default = false]
+[debug_engine_streams: <boolean>]
+
+# List of segmentation rules for partitioning when writing to the segment topic.
+# Supports both simple keys ('key') and key=value rules with additional keys
+# ('key=value,additional_key1,additional_key2'). Experimental.
+# CLI flag: -distributor.segmentation-rules
+[segmentation_rules: <list of strings> | default = []]
 ```
 
 ### local_storage_config

--- a/examples/segment-topic-config.yaml
+++ b/examples/segment-topic-config.yaml
@@ -1,0 +1,57 @@
+# Example configuration for flexible segmentation keys in segment topic
+# This demonstrates the key=value based segmentation rules
+
+# Global configuration
+limits_config:
+  # Segmentation rules configuration
+  segmentation_rules:
+    # Simple key rule - matches any value for service_name
+    - "service_name"
+    
+    # Key=value rule - when service_name=querier, also include tenant and cluster
+    - "service_name=querier,tenant,cluster"
+    
+    # Key=value rule - when service_name=ingester, also include tenant and region
+    - "service_name=ingester,tenant,region"
+    
+    # Key=value rule - when service_name=distributor, also include tenant and zone
+    - "service_name=distributor,tenant,zone"
+    
+    # Key=value rule with specific additional key values
+    # When service_name=querier AND tenant=94018, also include level
+    - "service_name=querier,tenant=94018,level"
+
+# Per-tenant overrides
+overrides:
+  # Tenant with high-volume querier service
+  tenant-high-volume:
+    segmentation_rules:
+      - "service_name=querier,tenant,cluster,shard"
+      - "service_name=ingester,tenant,region"
+      - "service_name"
+  
+  # Tenant with simple configuration
+  tenant-simple:
+    segmentation_rules:
+      - "service_name"
+      - "tenant"
+
+# Example of how this would work:
+#
+# For a stream with labels: {service_name="querier", tenant="tenant1", cluster="us-east-1"}
+# The segmentation key would be: "cluster=us-east-1,service_name=querier,tenant=tenant1"
+#
+# For a stream with labels: {service_name="ingester", tenant="tenant1", region="us-west-2"}
+# The segmentation key would be: "service_name=ingester,tenant=tenant1,region=us-west-2"
+#
+# For a stream with labels: {service_name="other", tenant="tenant1"}
+# The segmentation key would be: "service_name=other" (matches simple key rule)
+#
+# For a stream with labels: {service_name="querier", tenant="94018", level="info"}
+# The segmentation key would be: "level=info,service_name=querier,tenant=94018" (matches specific tenant value)
+#
+# For a stream with labels: {service_name="querier", tenant="94019", level="info"}
+# The segmentation key would be: "service_name=querier,tenant=94019" (doesn't match specific tenant=94018 rule)
+#
+# For a stream with labels: {service_name="querier", tenant="tenant1", cluster="us-east-1", shard="shard-1"}
+# The segmentation key would be: "cluster=us-east-1,service_name=querier,shard=shard-1,tenant=tenant1"

--- a/pkg/distributor/limits.go
+++ b/pkg/distributor/limits.go
@@ -48,4 +48,6 @@ type Limits interface {
 	IngestionPartitionsTenantShardSize(userID string) int
 
 	SimulatedPushLatency(userID string) time.Duration
+
+	SegmentationRules(userID string) []string
 }

--- a/pkg/distributor/segment_topic_tee.go
+++ b/pkg/distributor/segment_topic_tee.go
@@ -1,0 +1,536 @@
+package distributor
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"hash/fnv"
+	"math"
+	"math/rand"
+	"strings"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/flagext"
+	"github.com/grafana/dskit/ring"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/twmb/franz-go/pkg/kgo"
+
+	"github.com/grafana/loki/v3/pkg/kafka"
+	"github.com/grafana/loki/v3/pkg/kafka/client"
+	"github.com/grafana/loki/v3/pkg/limits/proto"
+	"github.com/grafana/loki/v3/pkg/logproto"
+	"github.com/grafana/loki/v3/pkg/logql/syntax"
+	"github.com/grafana/loki/v3/pkg/util"
+)
+
+type segmentationKey struct {
+	str  string
+	hash uint64
+}
+
+// SegmentTeeConfig configures the SegmentTopicWriter for writing logs to Kafka
+// based on configurable segmentation keys derived from stream labels and metadata.
+type SegmentTeeConfig struct {
+	Enabled bool `yaml:"enabled"`
+
+	// Topic is the Kafka topic name to write segmented logs to
+	Topic string `yaml:"topic"`
+
+	// MaxBufferedBytes is the maximum number of bytes that can be buffered before producing to Kafka
+	MaxBufferedBytes flagext.Bytes `yaml:"max_buffered_bytes"`
+
+	// MaxRecordSizeBytes is the maximum size of a single Kafka record
+	MaxRecordSizeBytes flagext.Bytes `yaml:"max_record_size_bytes"`
+
+	// NumPartitions is the total number of partitions available for the topic
+	NumPartitions int `yaml:"num_partitions"`
+
+	// VolumeThresholdBytes is the threshold above which segments get spread across multiple partitions
+	VolumeThresholdBytes flagext.Bytes `yaml:"volume_threshold_bytes"`
+
+	// VolumeCheckInterval is how often to check stream volumes for volume-aware partitioning
+	VolumeCheckInterval time.Duration `yaml:"volume_check_interval"`
+
+	// TargetThroughputPerPartition is the target throughput per partition in bytes for shuffle sharding
+	TargetThroughputPerPartition flagext.Bytes `yaml:"target_throughput_per_partition"`
+}
+
+// RegisterFlags registers the flags for the SegmentTopicConfig
+func (cfg *SegmentTeeConfig) RegisterFlags(fs *flag.FlagSet) {
+	fs.BoolVar(&cfg.Enabled, "distributor.segment-topic.enabled", false, "Enable segment topic writer.")
+	fs.StringVar(&cfg.Topic, "distributor.segment-topic.topic", "loki-segments", "Topic name for segment topic writer.")
+	cfg.MaxBufferedBytes = 100 << 20 // 100MB default
+	fs.Var(&cfg.MaxBufferedBytes, "distributor.segment-topic.max-buffered-bytes", "Maximum number of bytes that can be buffered before producing to Kafka.")
+	cfg.MaxRecordSizeBytes = kafka.MaxProducerRecordDataBytesLimit
+	fs.Var(&cfg.MaxRecordSizeBytes, "distributor.segment-topic.max-record-size-bytes", "Maximum size of a single Kafka record.")
+	fs.IntVar(&cfg.NumPartitions, "distributor.segment-topic.num-partitions", 10, "Number of partitions for the segment topic.")
+	cfg.VolumeThresholdBytes = 100 << 20 // 100MB default
+	fs.Var(&cfg.VolumeThresholdBytes, "distributor.segment-topic.volume-threshold-bytes", "Volume threshold above which streams get spread across multiple partitions.")
+	fs.DurationVar(&cfg.VolumeCheckInterval, "distributor.segment-topic.volume-check-interval", 30*time.Second, "How often to check stream volumes for volume-aware partitioning.")
+	cfg.TargetThroughputPerPartition = 10 << 20 // 10MB default
+	fs.Var(&cfg.TargetThroughputPerPartition, "distributor.segment-topic.target-throughput-per-partition", "Target throughput per partition in bytes for shuffle sharding.")
+}
+
+// Validate validates the SegmentTopicConfig
+func (cfg *SegmentTeeConfig) Validate() error {
+	if cfg.Enabled {
+		if cfg.Topic == "" {
+			return fmt.Errorf("topic name cannot be empty when segment topic writer is enabled")
+		}
+		if cfg.MaxBufferedBytes <= 0 {
+			return fmt.Errorf("max buffered bytes must be greater than 0")
+		}
+		if cfg.MaxRecordSizeBytes <= 0 {
+			return fmt.Errorf("max record size bytes must be greater than 0")
+		}
+	}
+	return nil
+}
+
+// SegmentTopicWriter implements the Tee interface to write streams to a Kafka topic
+// based on configurable segmentation keys. It always uses volume-aware partitioning
+// to distribute high-volume segments across multiple Kafka partitions, and always
+// uses shuffle sharding for tenants based on their rate limits.
+type SegmentTopicWriter struct {
+	cfg      SegmentTeeConfig
+	logger   log.Logger
+	limits   Limits
+	producer *client.Producer
+
+	// Partitioning components
+	partitionRing ring.PartitionRingReader
+	ingestLimits  *ingestLimits
+
+	// Random number generator for partition selection
+	rand *rand.Rand
+
+	// Metrics
+	teeBatchSize    prometheus.Histogram
+	teeQueueLatency prometheus.Histogram
+	teeErrors       *prometheus.CounterVec
+}
+
+// NewSegmentTopicWriter creates a new SegmentTopicWriter
+func NewSegmentTopicWriter(
+	cfg SegmentTeeConfig,
+	kafkaClient *kgo.Client,
+	limits Limits,
+	partitionRing ring.PartitionRingReader,
+	ingestLimits *ingestLimits,
+	registerer prometheus.Registerer,
+	logger log.Logger,
+) (*SegmentTopicWriter, error) {
+	if !cfg.Enabled {
+		return nil, fmt.Errorf("segment topic writer is not enabled")
+	}
+
+	if partitionRing == nil {
+		return nil, fmt.Errorf("partition ring is required for segment topic writer")
+	}
+
+	t := &SegmentTopicWriter{
+		cfg:           cfg,
+		logger:        logger,
+		limits:        limits,
+		partitionRing: partitionRing,
+		ingestLimits:  ingestLimits,
+		rand:          rand.New(rand.NewSource(time.Now().UnixNano())),
+		producer: client.NewProducer(
+			"distributor_segment_topic_tee",
+			kafkaClient,
+			int64(cfg.MaxBufferedBytes),
+			registerer,
+		),
+		teeBatchSize: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Name:    "loki_distributor_segment_topic_tee_batch_size_bytes",
+			Help:    "Size in bytes of batches sent to Kafka by the segment topic tee",
+			Buckets: prometheus.ExponentialBucketsRange(1<<10, 100<<20, 10),
+		}),
+		teeQueueLatency: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Name:    "loki_distributor_segment_topic_tee_queue_duration_seconds",
+			Help:    "Duration in seconds spent waiting in queue by the segment topic tee",
+			Buckets: prometheus.DefBuckets,
+		}),
+		teeErrors: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "loki_distributor_segment_topic_tee_errors_total",
+			Help: "Total number of errors encountered by the segment topic tee",
+		}, []string{"reason"}),
+	}
+
+	if registerer != nil {
+		registerer.MustRegister(t.teeBatchSize, t.teeQueueLatency, t.teeErrors)
+	}
+
+	return t, nil
+}
+
+// Duplicate implements the Tee interface
+func (s *SegmentTopicWriter) Duplicate(tenant string, streams []KeyedStream) {
+	if len(streams) == 0 {
+		return
+	}
+
+	go s.write(tenant, streams)
+}
+
+type streamWithKey struct {
+	stream KeyedStream
+	sKey   segmentationKey
+}
+
+// write handles the actual writing of streams to the segment topic.
+// It updates segment rates for volume tracking and converts streams to Kafka records
+// using volume-aware partitioning.
+func (s *SegmentTopicWriter) write(tenant string, streams []KeyedStream) {
+	streamsWithKeys := make([]streamWithKey, 0, len(streams))
+	for _, stream := range streams {
+		streamsWithKeys = append(streamsWithKeys, streamWithKey{
+			stream: stream,
+			sKey:   s.getSegmentationKey(stream, tenant),
+		})
+	}
+
+	// Update segment rates for volume tracking and get the results
+	segmentRates := s.updateSegmentRates(context.Background(), tenant, streamsWithKeys)
+
+	// Convert streams to Kafka records
+	records := make([]*kgo.Record, 0, len(streams))
+
+	for _, swk := range streamsWithKeys {
+		// Get the rate for this segmentation key
+		segmentRate := float64(segmentRates[swk.sKey.hash])
+
+		// TODO(EWELCH): if someone sends a huge push payload this will not be split into multiple
+		// partitions, so either we need a limit on the size of the payload or we have some risk
+		// here of overwhelming a partition. It may also be possible to split up the push request
+		// although that has challenges as well.
+		availablePartitions, err := s.getPartition(tenant, swk.sKey, segmentRate)
+		if err != nil {
+			level.Error(s.logger).Log(
+				"msg", "failed to get partitions for stream",
+				"tenant", tenant,
+				"segmentationKey", swk.sKey.str,
+				"err", err,
+			)
+			s.teeErrors.WithLabelValues("partition_error").Inc()
+			continue
+		}
+
+		// Select a single partition from the available ones to spread data across partitions
+		selectedPartition := s.selectPartition(availablePartitions)
+
+		level.Info(s.logger).Log(
+			"msg", "writing to partition",
+			"tenant", tenant,
+			"stream", swk.stream.Stream.Labels,
+			"seg_key_string", swk.sKey.str,
+			"seg_key_hash", swk.sKey.hash,
+			"available_partitions", fmt.Sprintf("%v", availablePartitions),
+			"selected_partition", selectedPartition,
+			"seg_rate", segmentRate,
+		)
+
+		// Create records for the selected partition only
+		streamRecords, err := kafka.EncodeWithTopic(s.cfg.Topic, selectedPartition, tenant, swk.stream.Stream, int(s.cfg.MaxRecordSizeBytes))
+		if err != nil {
+			level.Error(s.logger).Log(
+				"msg", "failed to encode stream",
+				"tenant", tenant,
+				"partition", selectedPartition,
+				"err", err,
+			)
+			s.teeErrors.WithLabelValues("encode_error").Inc()
+			continue
+		}
+
+		records = append(records, streamRecords...)
+	}
+
+	if len(records) == 0 {
+		return
+	}
+
+	// Send records to Kafka using the producer
+	s.producer.ProduceSync(context.Background(), records)
+}
+
+// selectPartition selects a single partition from the available partitions
+// using random selection to spread data across partitions.
+func (s *SegmentTopicWriter) selectPartition(availablePartitions []int32) int32 {
+	if len(availablePartitions) == 0 {
+		// Fallback to partition 0 if no partitions available
+		return 0
+	}
+	if len(availablePartitions) == 1 {
+		return availablePartitions[0]
+	}
+
+	// Randomly select one partition from the available ones
+	return availablePartitions[s.rand.Intn(len(availablePartitions))]
+}
+
+// getPartition determines which partition(s) to use for a given stream.
+// It always uses volume-aware partitioning and shuffle sharding for tenants.
+// Low-volume segments get a single partition, high-volume segments get multiple partitions.
+func (s *SegmentTopicWriter) getPartition(tenant string, sKey segmentationKey, segmentRate float64) ([]int32, error) {
+	// Create tenant subring once based on rate limits for shuffle sharding
+	tenantSubring := s.getTenantSubring(tenant)
+
+	// Use volume-aware partitioning with shuffle sharding
+	return s.getVolumeSpreadPartitions(sKey, tenant, tenantSubring, segmentRate)
+}
+
+// getSegmentationKey creates a segmentation key from the stream labels and metadata
+// based on the tenant's configured partitioning rules. It supports both simple keys
+// and key=value based rules with additional keys.
+func (s *SegmentTopicWriter) getSegmentationKey(stream KeyedStream, tenant string) segmentationKey {
+	// Get segmentation rules for this tenant
+	var keyStr string
+	partitioningRules := s.limits.SegmentationRules(tenant)
+	if len(partitioningRules) > 0 {
+		segmentationKey, ok := s.getSegmentationKeyFromRules(stream, tenant, partitioningRules)
+		if ok {
+			keyStr = segmentationKey
+		}
+	}
+
+	if keyStr == "" {
+		// Fallback to stream hash if no rules match
+		keyStr = fmt.Sprintf("stream_%d", stream.HashKeyNoShard)
+	}
+
+	hasher := fnv.New64a()
+	_, _ = hasher.Write([]byte(keyStr))
+	return segmentationKey{str: keyStr, hash: hasher.Sum64()}
+}
+
+// getSegmentationKeyFromRules creates a segmentation key using the new flexible rules
+func (s *SegmentTopicWriter) getSegmentationKeyFromRules(stream KeyedStream, tenant string, ruleStrings []string) (string, bool) {
+	// Parse the segmentation rules
+	config, err := ParseSegmentationConfig(ruleStrings)
+	if err != nil {
+		level.Error(s.logger).Log("msg", "failed to parse segmentation rules", "tenant", tenant, "rules", ruleStrings, "err", err)
+		return "", false
+	}
+
+	// Extract labels and structured metadata
+	labels := s.extractLabels(stream)
+	structuredMetadata := s.extractStructuredMetadata(stream)
+
+	// Get segmentation keys based on the rules
+	segmentationKeys := config.GetSegmentationKeys(labels, structuredMetadata)
+
+	if len(segmentationKeys) == 0 {
+		return "", false
+	}
+
+	// Create a stable string representation of the segmentation keys
+	var sb strings.Builder
+	for i, key := range segmentationKeys {
+		if i > 0 {
+			sb.WriteString(",")
+		}
+		sb.WriteString(key)
+		sb.WriteString("=")
+
+		// Get the value from labels or structured metadata
+		if val, exists := labels[key]; exists {
+			sb.WriteString(val)
+		} else if val, exists := structuredMetadata[key]; exists {
+			sb.WriteString(val)
+		} else {
+			// This shouldn't happen if GetSegmentationKeys is working correctly
+			level.Error(s.logger).Log("msg", "segmentation key found but no value available", "key", key, "tenant", tenant)
+			return "", false
+		}
+	}
+
+	return sb.String(), true
+}
+
+// extractLabels extracts labels from the stream
+func (s *SegmentTopicWriter) extractLabels(stream KeyedStream) map[string]string {
+	labelMap := make(map[string]string)
+	parsedLabels, err := syntax.ParseLabels(stream.Stream.Labels)
+	if err != nil {
+		level.Error(s.logger).Log("msg", "failed to parse stream labels", "labels", stream.Stream.Labels, "err", err)
+		return labelMap
+	}
+
+	parsedLabels.Range(func(lbl labels.Label) {
+		labelMap[lbl.Name] = lbl.Value
+	})
+
+	return labelMap
+}
+
+// extractStructuredMetadata extracts structured metadata from the stream entries
+func (s *SegmentTopicWriter) extractStructuredMetadata(stream KeyedStream) map[string]string {
+	metadata := make(map[string]string)
+	for _, entry := range stream.Stream.Entries {
+		for _, sm := range entry.StructuredMetadata {
+			metadata[sm.Name] = sm.Value
+		}
+	}
+	return metadata
+}
+
+// getBasePartition gets the base partition for a segmentation key
+func (s *SegmentTopicWriter) getBasePartition(segmentationKey string) int32 {
+	hasher := fnv.New64a()
+	_, _ = hasher.Write([]byte(segmentationKey))
+	hash := hasher.Sum64()
+	return int32(hash % uint64(s.cfg.NumPartitions))
+}
+
+// getVolumeSpreadPartitions gets multiple partitions for high-volume segments using shuffle sharding.
+// It uses the provided tenant subring and creates a further subring for the segment.
+// For low-volume segments, it selects a single partition from the tenant's subring.
+func (s *SegmentTopicWriter) getVolumeSpreadPartitions(sKey segmentationKey, tenant string, tenantSubring *ring.PartitionRing, segmentRate float64) ([]int32, error) {
+	// Calculate how many partitions this segment should use based on its volume
+	segmentShardSize := s.calculateShardSize(segmentRate)
+
+	// Get active partitions from the tenant's subring
+	tenantPartitions := tenantSubring.ActivePartitionIDs()
+
+	// If no active partitions, fallback to simple hash against total partitions
+	if len(tenantPartitions) == 0 {
+		return []int32{int32(sKey.hash % uint64(s.cfg.NumPartitions))}, nil
+	}
+
+	// Ensure segment shard size doesn't exceed the tenant's available partitions
+	if segmentShardSize > len(tenantPartitions) {
+		segmentShardSize = len(tenantPartitions)
+	}
+
+	// If segment only needs 1 partition, use simple hash-based selection from tenant's subring
+	if segmentShardSize <= 1 {
+		selectedPartition := tenantPartitions[sKey.hash%uint64(len(tenantPartitions))]
+		return []int32{selectedPartition}, nil
+	}
+
+	// Create a subring from the tenant's subring for this specific segment
+	segmentSubring, err := tenantSubring.ShuffleShard(sKey.str, segmentShardSize)
+	if err != nil {
+		level.Error(s.logger).Log("msg", "failed to create segment shuffle shard", "tenant", tenant, "segmentationKey", sKey.str, "shardSize", segmentShardSize, "err", err)
+		// Fallback to using all tenant partitions
+		partitions := make([]int32, len(tenantPartitions))
+		copy(partitions, tenantPartitions)
+		return partitions, nil
+	}
+
+	// Get all active partitions from the segment subring
+	activePartitions := segmentSubring.ActivePartitionIDs()
+
+	// Convert to int32 slice
+	partitions := make([]int32, len(activePartitions))
+	copy(partitions, activePartitions)
+
+	return partitions, nil
+}
+
+// calculateShardSize determines how many partitions a segment should use based on its volume
+func (s *SegmentTopicWriter) calculateShardSize(segmentRate float64) int {
+	// Calculate shard size based on current rate vs threshold
+	threshold := float64(s.cfg.VolumeThresholdBytes)
+	if threshold == 0 {
+		return 1
+	}
+
+	ratio := segmentRate / threshold
+	shardSize := int(math.Ceil(ratio))
+
+	// Ensure at least 1 partition
+	if shardSize < 1 {
+		shardSize = 1
+	}
+
+	return shardSize
+}
+
+// updateSegmentRates updates segment rates with the limits service and returns the rate results
+func (s *SegmentTopicWriter) updateSegmentRates(ctx context.Context, tenant string, streamsWithKeys []streamWithKey) map[uint64]int64 {
+	if s.ingestLimits == nil {
+		return make(map[uint64]int64)
+	}
+
+	// Group streams by segmentation key and aggregate their sizes
+	segmentSizes := make(map[uint64]int64)
+
+	for _, swk := range streamsWithKeys {
+		entriesSize, structuredMetadataSize := s.calculateStreamSizes(swk.stream.Stream)
+		totalSize := int64(entriesSize + structuredMetadataSize)
+		segmentSizes[swk.sKey.hash] += totalSize
+	}
+
+	// Prepare batch update
+	rateUpdates := make([]*proto.StreamMetadata, 0, len(segmentSizes))
+	for segmentationHash, totalSize := range segmentSizes {
+		rateUpdates = append(rateUpdates, &proto.StreamMetadata{
+			StreamHash: segmentationHash,
+			TotalSize:  uint64(totalSize),
+		})
+	}
+
+	// Update segment rates in batch and return the results
+	results, err := s.ingestLimits.UpdateRates(ctx, tenant, rateUpdates)
+	if err != nil {
+		level.Error(s.logger).Log("msg", "failed to update segment rates", "tenant", tenant, "err", err)
+		return make(map[uint64]int64)
+	}
+
+	return results
+}
+
+// calculateStreamSizes calculates the total size of a stream's entries and structured metadata
+func (s *SegmentTopicWriter) calculateStreamSizes(stream logproto.Stream) (uint64, uint64) {
+	var entriesSize, structuredMetadataSize uint64
+	for _, entry := range stream.Entries {
+		entriesSize += uint64(len(entry.Line))
+		structuredMetadataSize += uint64(util.StructuredMetadataSize(entry.StructuredMetadata))
+	}
+	return entriesSize, structuredMetadataSize
+}
+
+// tenantShardSize calculates the number of partitions a tenant should use based on their rate limit
+// This enables shuffle sharding for small tenants by limiting them to a smaller subset of partitions
+func (s *SegmentTopicWriter) tenantShardSize(tenant string) int {
+	bytesRateLimit := s.limits.IngestionRateBytes(tenant)
+	targetThroughputPerPartition := float64(s.cfg.TargetThroughputPerPartition)
+
+	// Calculate the number of partitions needed based on rate limit
+	target := int(math.Round(bytesRateLimit / targetThroughputPerPartition))
+
+	// Ensure at least 1 partition and not more than total partitions
+	if target < 1 {
+		target = 1
+	}
+	if target > s.cfg.NumPartitions {
+		target = s.cfg.NumPartitions
+	}
+
+	return target
+}
+
+// getTenantSubring creates a shuffle-sharded subring for the tenant based on their rate limits
+func (s *SegmentTopicWriter) getTenantSubring(tenant string) *ring.PartitionRing {
+	tenantShardSize := s.tenantShardSize(tenant)
+
+	// If tenant shard size equals total partitions, return the full ring
+	if tenantShardSize >= s.cfg.NumPartitions {
+		return s.partitionRing.PartitionRing()
+	}
+
+	// Create a subring using shuffle sharding with the calculated tenant shard size
+	subring, err := s.partitionRing.PartitionRing().ShuffleShard(tenant, tenantShardSize)
+	if err != nil {
+		level.Error(s.logger).Log("msg", "failed to create shuffle shard for tenant", "tenant", tenant, "shardSize", tenantShardSize, "err", err)
+		// Fallback to using the full ring
+		return s.partitionRing.PartitionRing()
+	}
+
+	return subring
+}

--- a/pkg/distributor/segment_topic_tee_test.go
+++ b/pkg/distributor/segment_topic_tee_test.go
@@ -1,0 +1,75 @@
+package distributor
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/grafana/dskit/flagext"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSegmentTopicWriter_SelectPartition(t *testing.T) {
+	cfg := SegmentTeeConfig{}
+
+	writer := &SegmentTopicWriter{
+		cfg:  cfg,
+		rand: rand.New(rand.NewSource(1)), // Use a real rand with fixed seed for testing
+	}
+
+	// Test with empty partitions
+	selected := writer.selectPartition([]int32{})
+	assert.Equal(t, int32(0), selected)
+
+	// Test with single partition
+	selected = writer.selectPartition([]int32{2})
+	assert.Equal(t, int32(2), selected)
+
+	// Test with multiple partitions (random)
+	availablePartitions := []int32{1, 2, 3}
+	selected = writer.selectPartition(availablePartitions)
+	assert.Contains(t, availablePartitions, selected)
+
+	// Test that random selection works (we can't predict the exact sequence)
+	// but we can verify that all selections are valid partitions
+	for i := 0; i < 10; i++ {
+		selected = writer.selectPartition(availablePartitions)
+		assert.Contains(t, availablePartitions, selected)
+	}
+}
+
+func TestSegmentTopicWriter_ConfigurationValidation(t *testing.T) {
+	tests := []struct {
+		name        string
+		cfg         SegmentTeeConfig
+		expectError bool
+	}{
+		{
+			name: "valid config",
+			cfg: SegmentTeeConfig{
+				Enabled:            true,
+				Topic:              "test",
+				MaxBufferedBytes:   flagext.Bytes(1024),
+				MaxRecordSizeBytes: flagext.Bytes(1024),
+			},
+			expectError: false,
+		},
+		{
+			name: "disabled config should not validate",
+			cfg: SegmentTeeConfig{
+				Enabled: false,
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cfg.Validate()
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/distributor/segmentation_config.go
+++ b/pkg/distributor/segmentation_config.go
@@ -1,0 +1,172 @@
+package distributor
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// KeyValue represents a key-value pair for segmentation rules
+type KeyValue struct {
+	Key   string
+	Value *string // nil means "any value", non-nil means "specific value"
+}
+
+// SegmentationRule represents a single segmentation rule
+type SegmentationRule struct {
+	Keys []KeyValue
+}
+
+// SegmentationConfig represents a collection of segmentation rules
+type SegmentationConfig struct {
+	Rules []SegmentationRule
+}
+
+// ParseSegmentationRule parses a single segmentation rule string
+// Format: "key" or "key=value,additional_key1,additional_key2=value2"
+func ParseSegmentationRule(ruleStr string) (*SegmentationRule, error) {
+	ruleStr = strings.TrimSpace(ruleStr)
+	if ruleStr == "" {
+		return nil, fmt.Errorf("empty rule")
+	}
+
+	// Split by comma to get individual key parts
+	parts := strings.Split(ruleStr, ",")
+	if len(parts) == 0 {
+		return nil, fmt.Errorf("invalid rule format: %s", ruleStr)
+	}
+
+	rule := &SegmentationRule{
+		Keys: make([]KeyValue, 0, len(parts)),
+	}
+
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+
+		// Check if this is a key=value pair
+		if strings.Contains(part, "=") {
+			keyValue := strings.SplitN(part, "=", 2)
+			if len(keyValue) != 2 {
+				return nil, fmt.Errorf("invalid key=value format: %s", part)
+			}
+			key := strings.TrimSpace(keyValue[0])
+			value := strings.TrimSpace(keyValue[1])
+			if key == "" {
+				return nil, fmt.Errorf("empty key in key=value pair: %s", part)
+			}
+			if value == "" {
+				return nil, fmt.Errorf("empty value in key=value pair: %s", part)
+			}
+			rule.Keys = append(rule.Keys, KeyValue{Key: key, Value: &value})
+		} else {
+			// Simple key
+			rule.Keys = append(rule.Keys, KeyValue{Key: part, Value: nil})
+		}
+	}
+
+	if len(rule.Keys) == 0 {
+		return nil, fmt.Errorf("no valid keys found in rule: %s", ruleStr)
+	}
+
+	return rule, nil
+}
+
+// ParseSegmentationConfig parses a list of segmentation rule strings
+func ParseSegmentationConfig(rules []string) (*SegmentationConfig, error) {
+	config := &SegmentationConfig{
+		Rules: make([]SegmentationRule, 0, len(rules)),
+	}
+
+	for i, ruleStr := range rules {
+		rule, err := ParseSegmentationRule(ruleStr)
+		if err != nil {
+			return nil, fmt.Errorf("rule %d: %w", i, err)
+		}
+		config.Rules = append(config.Rules, *rule)
+	}
+
+	return config, nil
+}
+
+// String returns a string representation of the rule
+func (r *SegmentationRule) String() string {
+	var parts []string
+	for _, kv := range r.Keys {
+		if kv.Value != nil {
+			parts = append(parts, fmt.Sprintf("%s=%s", kv.Key, *kv.Value))
+		} else {
+			parts = append(parts, kv.Key)
+		}
+	}
+	return strings.Join(parts, ",")
+}
+
+// Matches checks if this rule matches the given labels and structured metadata
+func (r *SegmentationRule) Matches(labels map[string]string, structuredMetadata map[string]string) bool {
+	if len(r.Keys) == 0 {
+		return false
+	}
+
+	// All keys must match their values (if specified)
+	for _, kv := range r.Keys {
+		var value string
+		var exists bool
+
+		// Check labels first, then structured metadata
+		if value, exists = labels[kv.Key]; !exists {
+			if value, exists = structuredMetadata[kv.Key]; !exists {
+				return false
+			}
+		}
+
+		// If a specific value is required, check it matches
+		if kv.Value != nil && value != *kv.Value {
+			return false
+		}
+	}
+
+	return true
+}
+
+// GetSegmentationKeys returns the segmentation keys for this rule
+func (r *SegmentationRule) GetSegmentationKeys(labels map[string]string, structuredMetadata map[string]string) []string {
+	if !r.Matches(labels, structuredMetadata) {
+		return nil
+	}
+
+	var keys []string
+	for _, kv := range r.Keys {
+		// Only include keys that exist in the data
+		if _, exists := labels[kv.Key]; exists {
+			keys = append(keys, kv.Key)
+		} else if _, exists := structuredMetadata[kv.Key]; exists {
+			keys = append(keys, kv.Key)
+		}
+	}
+
+	// Sort for consistent output
+	sort.Strings(keys)
+	return keys
+}
+
+// FindMatchingRule finds the first rule that matches the given labels and structured metadata
+func (c *SegmentationConfig) FindMatchingRule(labels map[string]string, structuredMetadata map[string]string) *SegmentationRule {
+	for i := range c.Rules {
+		if c.Rules[i].Matches(labels, structuredMetadata) {
+			return &c.Rules[i]
+		}
+	}
+	return nil
+}
+
+// GetSegmentationKeys returns the segmentation keys for the first matching rule
+func (c *SegmentationConfig) GetSegmentationKeys(labels map[string]string, structuredMetadata map[string]string) []string {
+	rule := c.FindMatchingRule(labels, structuredMetadata)
+	if rule == nil {
+		return nil
+	}
+	return rule.GetSegmentationKeys(labels, structuredMetadata)
+}

--- a/pkg/distributor/segmentation_config_test.go
+++ b/pkg/distributor/segmentation_config_test.go
@@ -1,0 +1,366 @@
+package distributor
+
+import (
+	"testing"
+)
+
+func TestParseSegmentationRule(t *testing.T) {
+	tests := []struct {
+		name        string
+		ruleStr     string
+		expected    *SegmentationRule
+		expectError bool
+	}{
+		{
+			name:    "simple key rule",
+			ruleStr: "service_name",
+			expected: &SegmentationRule{
+				Keys: []KeyValue{
+					{Key: "service_name", Value: nil},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name:    "key=value rule with additional keys",
+			ruleStr: "service_name=querier,tenant,cluster",
+			expected: &SegmentationRule{
+				Keys: []KeyValue{
+					{Key: "service_name", Value: stringPtr("querier")},
+					{Key: "tenant", Value: nil},
+					{Key: "cluster", Value: nil},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name:    "key=value rule with single additional key",
+			ruleStr: "service_name=ingester,tenant",
+			expected: &SegmentationRule{
+				Keys: []KeyValue{
+					{Key: "service_name", Value: stringPtr("ingester")},
+					{Key: "tenant", Value: nil},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name:    "key=value rule with specific additional key values",
+			ruleStr: "service_name=querier,tenant=94018,level",
+			expected: &SegmentationRule{
+				Keys: []KeyValue{
+					{Key: "service_name", Value: stringPtr("querier")},
+					{Key: "tenant", Value: stringPtr("94018")},
+					{Key: "level", Value: nil},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name:        "empty rule",
+			ruleStr:     "",
+			expected:    nil,
+			expectError: true,
+		},
+		{
+			name:        "invalid key=value format",
+			ruleStr:     "service_name=",
+			expected:    nil,
+			expectError: true,
+		},
+		{
+			name:        "empty key in key=value pair",
+			ruleStr:     "=querier,tenant",
+			expected:    nil,
+			expectError: true,
+		},
+		{
+			name:    "key=value rule without additional keys",
+			ruleStr: "service_name=querier",
+			expected: &SegmentationRule{
+				Keys: []KeyValue{
+					{Key: "service_name", Value: stringPtr("querier")},
+				},
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := ParseSegmentationRule(tt.ruleStr)
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("expected error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			if result == nil {
+				t.Errorf("expected result but got nil")
+				return
+			}
+
+			if len(result.Keys) != len(tt.expected.Keys) {
+				t.Errorf("expected %d keys, got %d", len(tt.expected.Keys), len(result.Keys))
+				return
+			}
+
+			for i, expectedKV := range tt.expected.Keys {
+				actualKV := result.Keys[i]
+				if actualKV.Key != expectedKV.Key {
+					t.Errorf("key %d: expected %s, got %s", i, expectedKV.Key, actualKV.Key)
+				}
+				if !stringPtrEqual(actualKV.Value, expectedKV.Value) {
+					t.Errorf("key %d value: expected %v, got %v", i, expectedKV.Value, actualKV.Value)
+				}
+			}
+		})
+	}
+}
+
+func TestSegmentationRule_Matches(t *testing.T) {
+	rule := &SegmentationRule{
+		Keys: []KeyValue{
+			{Key: "service_name", Value: stringPtr("querier")},
+			{Key: "tenant", Value: stringPtr("94018")},
+			{Key: "level", Value: nil},
+		},
+	}
+
+	tests := []struct {
+		name               string
+		labels             map[string]string
+		structuredMetadata map[string]string
+		expected           bool
+	}{
+		{
+			name: "exact match",
+			labels: map[string]string{
+				"service_name": "querier",
+				"tenant":       "94018",
+				"level":        "info",
+			},
+			structuredMetadata: map[string]string{},
+			expected:           true,
+		},
+		{
+			name: "match with structured metadata",
+			labels: map[string]string{
+				"service_name": "querier",
+			},
+			structuredMetadata: map[string]string{
+				"tenant": "94018",
+				"level":  "info",
+			},
+			expected: true,
+		},
+		{
+			name: "no match - wrong service_name",
+			labels: map[string]string{
+				"service_name": "ingester",
+				"tenant":       "94018",
+				"level":        "info",
+			},
+			structuredMetadata: map[string]string{},
+			expected:           false,
+		},
+		{
+			name: "no match - wrong tenant",
+			labels: map[string]string{
+				"service_name": "querier",
+				"tenant":       "12345",
+				"level":        "info",
+			},
+			structuredMetadata: map[string]string{},
+			expected:           false,
+		},
+		{
+			name: "no match - missing tenant",
+			labels: map[string]string{
+				"service_name": "querier",
+				"level":        "info",
+			},
+			structuredMetadata: map[string]string{},
+			expected:           false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := rule.Matches(tt.labels, tt.structuredMetadata)
+			if result != tt.expected {
+				t.Errorf("expected %v, got %v", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestSegmentationConfig_GetSegmentationKeys(t *testing.T) {
+	config := &SegmentationConfig{
+		Rules: []SegmentationRule{
+			{
+				Keys: []KeyValue{
+					{Key: "service_name", Value: stringPtr("querier")},
+					{Key: "tenant", Value: stringPtr("94018")},
+					{Key: "level", Value: nil},
+				},
+			},
+			{
+				Keys: []KeyValue{
+					{Key: "service_name", Value: stringPtr("ingester")},
+					{Key: "tenant", Value: nil},
+				},
+			},
+			{
+				Keys: []KeyValue{
+					{Key: "service_name", Value: nil},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name               string
+		labels             map[string]string
+		structuredMetadata map[string]string
+		expectedKeys       []string
+	}{
+		{
+			name: "match first rule",
+			labels: map[string]string{
+				"service_name": "querier",
+				"tenant":       "94018",
+				"level":        "info",
+			},
+			structuredMetadata: map[string]string{},
+			expectedKeys:       []string{"level", "service_name", "tenant"},
+		},
+		{
+			name: "match second rule",
+			labels: map[string]string{
+				"service_name": "ingester",
+				"tenant":       "12",
+			},
+			structuredMetadata: map[string]string{},
+			expectedKeys:       []string{"service_name", "tenant"},
+		},
+		{
+			name: "match third rule",
+			labels: map[string]string{
+				"service_name": "unknown",
+			},
+			structuredMetadata: map[string]string{},
+			expectedKeys:       []string{"service_name"},
+		},
+		{
+			name: "no match",
+			labels: map[string]string{
+				"foo": "bar",
+			},
+			structuredMetadata: map[string]string{},
+			expectedKeys:       nil,
+		},
+		{
+			name: "match with structured metadata",
+			labels: map[string]string{
+				"service_name": "querier",
+			},
+			structuredMetadata: map[string]string{
+				"tenant": "94018",
+				"level":  "info",
+			},
+			expectedKeys: []string{"level", "service_name", "tenant"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := config.GetSegmentationKeys(tt.labels, tt.structuredMetadata)
+			if !stringSlicesEqual(result, tt.expectedKeys) {
+				t.Errorf("expected %v, got %v", tt.expectedKeys, result)
+			}
+		})
+	}
+}
+
+func TestSegmentationRule_String(t *testing.T) {
+	tests := []struct {
+		name     string
+		rule     *SegmentationRule
+		expected string
+	}{
+		{
+			name: "simple key rule",
+			rule: &SegmentationRule{
+				Keys: []KeyValue{
+					{Key: "service_name", Value: nil},
+				},
+			},
+			expected: "service_name",
+		},
+		{
+			name: "key=value rule with additional keys",
+			rule: &SegmentationRule{
+				Keys: []KeyValue{
+					{Key: "service_name", Value: stringPtr("querier")},
+					{Key: "tenant", Value: nil},
+					{Key: "level", Value: nil},
+				},
+			},
+			expected: "service_name=querier,tenant,level",
+		},
+		{
+			name: "key=value rule with specific additional key values",
+			rule: &SegmentationRule{
+				Keys: []KeyValue{
+					{Key: "service_name", Value: stringPtr("querier")},
+					{Key: "tenant", Value: stringPtr("94018")},
+					{Key: "level", Value: nil},
+				},
+			},
+			expected: "service_name=querier,tenant=94018,level",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.rule.String()
+			if result != tt.expected {
+				t.Errorf("expected %s, got %s", tt.expected, result)
+			}
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func stringPtrEqual(a, b *string) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return *a == *b
+}
+
+func stringSlicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/go-kit/log/level"
@@ -289,6 +290,8 @@ type Limits struct {
 	MaxScanTaskParallelism int  `yaml:"max_scan_task_parallelism" json:"max_scan_task_parallelism"`
 	DebugEngineTasks       bool `yaml:"debug_engine_tasks" json:"debug_engine_tasks"`
 	DebugEngineStreams     bool `yaml:"debug_engine_streams" json:"debug_engine_streams"`
+
+	SegmentationRules []string `yaml:"segmentation_rules" json:"segmentation_rules" category:"experimental" doc:"description=List of segmentation rules for partitioning when writing to the segment topic. Supports both simple keys ('key') and key=value rules with additional keys ('key=value,additional_key1,additional_key2'). Experimental."`
 }
 
 type FieldDetectorConfig struct {
@@ -530,9 +533,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 		"Enable experimental support for running multiple query variants over the same underlying data. For example, running both a rate() and count_over_time() query over the same range selector.",
 	)
 
-	f.IntVar(&l.MaxScanTaskParallelism, "limits.max-scan-task-parallelism", 0, "Experimental: Controls the amount of scan tasks that can be running in parallel in the new query engine. The default of 0 means unlimited parallelism and all tasks will be scheduled at once.")
-	f.BoolVar(&l.DebugEngineTasks, "limits.debug-engine-tasks", false, "Experimental: Toggles verbose debug logging of tasks in the new query engine.")
-	f.BoolVar(&l.DebugEngineStreams, "limits.debug-engine-streams", false, "Experimental: Toggles verbose debug logging of data streams in the new query engine.")
+	f.Var((*dskit_flagext.StringSlice)(&l.SegmentationRules), "distributor.segmentation-rules", "Comma-separated list of segmentation rules for partitioning when writing to the segment topic. Supports both simple keys ('key') and key=value rules with additional keys ('key=value,additional_key1,additional_key2'). Experimental.")
 }
 
 // SetGlobalOTLPConfig set GlobalOTLPConfig which is used while unmarshaling per-tenant otlp config to use the default list of resource attributes picked as index labels.
@@ -645,6 +646,11 @@ func (l *Limits) Validate() error {
 
 	if l.TSDBMaxBytesPerShard <= 0 {
 		return errors.New("querier.tsdb-max-bytes-per-shard must be greater than 0")
+	}
+
+	// Validate segmentation rules
+	if err := l.validateSegmentationRules(); err != nil {
+		return err
 	}
 
 	return nil
@@ -1447,4 +1453,70 @@ func (sm *OverwriteMarshalingStringMap) UnmarshalYAML(unmarshal func(interface{}
 
 func (o *Overrides) SimulatedPushLatency(userID string) time.Duration {
 	return o.getOverridesForUser(userID).SimulatedPushLatency
+}
+
+func (o *Overrides) SegmentationRules(userID string) []string {
+	return o.getOverridesForUser(userID).SegmentationRules
+}
+
+// validateSegmentationRules validates the segmentation rules configuration
+func (l *Limits) validateSegmentationRules() error {
+	for _, ruleStr := range l.SegmentationRules {
+		if err := validateSegmentationRule(ruleStr); err != nil {
+			return fmt.Errorf("invalid segmentation rule '%s': %w", ruleStr, err)
+		}
+	}
+	return nil
+}
+
+// validateSegmentationRule validates a single segmentation rule string
+func validateSegmentationRule(ruleStr string) error {
+	ruleStr = strings.TrimSpace(ruleStr)
+	if ruleStr == "" {
+		return fmt.Errorf("empty segmentation rule")
+	}
+
+	// Check if this is a key=value rule
+	if strings.Contains(ruleStr, "=") {
+		parts := strings.Split(ruleStr, ",")
+		if len(parts) < 2 {
+			return fmt.Errorf("invalid key=value rule format: %s", ruleStr)
+		}
+
+		// First part should be key=value
+		keyValue := strings.TrimSpace(parts[0])
+		if !strings.Contains(keyValue, "=") {
+			return fmt.Errorf("first part must be key=value: %s", keyValue)
+		}
+
+		keyValueParts := strings.SplitN(keyValue, "=", 2)
+		if len(keyValueParts) != 2 {
+			return fmt.Errorf("invalid key=value format: %s", keyValue)
+		}
+
+		key := strings.TrimSpace(keyValueParts[0])
+		value := strings.TrimSpace(keyValueParts[1])
+		if key == "" || value == "" {
+			return fmt.Errorf("key and value cannot be empty: %s", keyValue)
+		}
+
+		// Additional keys are the rest of the parts
+		additionalKeys := make([]string, 0, len(parts)-1)
+		for i := 1; i < len(parts); i++ {
+			additionalKey := strings.TrimSpace(parts[i])
+			if additionalKey == "" {
+				continue
+			}
+			additionalKeys = append(additionalKeys, additionalKey)
+		}
+
+		if len(additionalKeys) == 0 {
+			return fmt.Errorf("key=value rule must have at least one additional key: %s", ruleStr)
+		}
+
+		// Additional keys can be either simple keys or key=value pairs
+		// No additional validation needed as both formats are supported
+	}
+
+	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR introduces another strategy for putting data into Kafka which introduces the idea of "segments" with "SegmentationRules"

I'm using the term "segment" here because partition is overloaded with kafka partitions.

Data is sent to this topic using this roughly this algorithm:

A tenant is first assigned to a subset of the total partitions using shuffle sharding with the shuffle shard size derived from their configured rate limit, smaller tenants will then be kept to fewer partitions and have their data spread less over the kafka topics and subsequent dataobjects.

SegmentationRules then allow configuration of further partitioning of data within a tenant, for example `service_name or service.name` would be a reasonable good default for us to use here. 

The limits service is used to track the data rate for all the data matching the segmentation key, this total rate is then used to do another layer of shuffle sharding within the current restricted partition list from the previous shuffle sharding.  This way service_names with low throughput are kept to fewer partitions than service_names with higher throughput.

Complex rules can be configured such that for example a single service_name could be further segmented by additional metadata if necessary.

Generally it should be considered that segmentation at this level in the system should be applied sparingly and judiciously, it's primarily a mechanism to make sure smaller sources of data are not negatively impacted by much larger sources of data.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
