### PR TITLE
chore(dataobj): Add option to set target row limit for pages

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -1090,7 +1090,7 @@ dataobj:
       # The maximum row count for pages to use for the data object builder. A
       # value of 0 means no limit.
       # CLI flag: -dataobj-consumer.max-page-rows
-      [target_page_rows: <int> | default = 0]
+      [max_page_rows: <int> | default = 0]
 
       # The target maximum size of the encoded object and all of its encoded
       # sections (after compression), to limit memory usage of a builder.

--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -1087,9 +1087,9 @@ dataobj:
       # CLI flag: -dataobj-consumer.target-page-size
       [target_page_size: <int> | default = 2MiB]
 
-      # The target row count for pages to use for the data object builder. A
+      # The maximum row count for pages to use for the data object builder. A
       # value of 0 means no limit.
-      # CLI flag: -dataobj-consumer.target-page-rows
+      # CLI flag: -dataobj-consumer.max-page-rows
       [target_page_rows: <int> | default = 0]
 
       # The target maximum size of the encoded object and all of its encoded

--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -1125,16 +1125,16 @@ dataobj:
     [idle_flush_timeout: <duration> | default = 1h]
 
   index:
-    # The size of the target page to use for the data object builder.
+    # The size of the target page to use for the index object builder.
     # CLI flag: -dataobj-index-builder.target-page-size
     [target_page_size: <int> | default = 128KiB]
 
-    # The target row count for pages to use for the data object builder. A value
-    # of 0 means no limit.
-    # CLI flag: -dataobj-index-builder.target-page-rows
-    [target_page_rows: <int> | default = 0]
+    # The maximum row count for pages to use for the index builder. A value of 0
+    # means no limit.
+    # CLI flag: -dataobj-index-builder.max-page-rows
+    [max_page_rows: <int> | default = 0]
 
-    # The size of the target object to use for the data object builder.
+    # The size of the target object to use for the index object builder.
     # CLI flag: -dataobj-index-builder.target-object-size
     [target_object_size: <int> | default = 64MiB]
 

--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -1087,8 +1087,8 @@ dataobj:
       # CLI flag: -dataobj-consumer.target-page-size
       [target_page_size: <int> | default = 2MiB]
 
-      # The target row count for pages to use for the data object builder. Takes
-      # precedence over target-page-size if value is greater than 0.
+      # The target row count for pages to use for the data object builder. A
+      # value of 0 means no limit.
       # CLI flag: -dataobj-consumer.target-page-rows
       [target_page_rows: <int> | default = 0]
 
@@ -1129,8 +1129,8 @@ dataobj:
     # CLI flag: -dataobj-index-builder.target-page-size
     [target_page_size: <int> | default = 128KiB]
 
-    # The target row count for pages to use for the data object builder. Takes
-    # precedence over target-page-size if value is greater than 0.
+    # The target row count for pages to use for the data object builder. A value
+    # of 0 means no limit.
     # CLI flag: -dataobj-index-builder.target-page-rows
     [target_page_rows: <int> | default = 0]
 

--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -1087,6 +1087,11 @@ dataobj:
       # CLI flag: -dataobj-consumer.target-page-size
       [target_page_size: <int> | default = 2MiB]
 
+      # The target row count for pages to use for the data object builder. Takes
+      # precedence over target-page-size if value is greater than 0.
+      # CLI flag: -dataobj-consumer.target-page-rows
+      [target_page_rows: <int> | default = 0]
+
       # The target maximum size of the encoded object and all of its encoded
       # sections (after compression), to limit memory usage of a builder.
       # CLI flag: -dataobj-consumer.target-builder-memory-limit
@@ -1123,6 +1128,11 @@ dataobj:
     # The size of the target page to use for the data object builder.
     # CLI flag: -dataobj-index-builder.target-page-size
     [target_page_size: <int> | default = 128KiB]
+
+    # The target row count for pages to use for the data object builder. Takes
+    # precedence over target-page-size if value is greater than 0.
+    # CLI flag: -dataobj-index-builder.target-page-rows
+    [target_page_rows: <int> | default = 0]
 
     # The size of the target object to use for the data object builder.
     # CLI flag: -dataobj-index-builder.target-object-size

--- a/pkg/dataobj/consumer/logsobj/builder.go
+++ b/pkg/dataobj/consumer/logsobj/builder.go
@@ -179,6 +179,7 @@ func (b *Builder) initBuilder(tenant string) {
 	if _, ok := b.logs[tenant]; !ok {
 		lb := logs.NewBuilder(b.metrics.logs, logs.BuilderOptions{
 			PageSizeHint:     int(b.cfg.TargetPageSize),
+			PageMaxRowCount:  b.cfg.TargetPageRows,
 			BufferSize:       int(b.cfg.BufferSize),
 			StripeMergeLimit: b.cfg.SectionStripeMergeLimit,
 		})

--- a/pkg/dataobj/consumer/logsobj/builder.go
+++ b/pkg/dataobj/consumer/logsobj/builder.go
@@ -38,7 +38,8 @@ type BuilderConfig struct {
 	TargetPageSize flagext.Bytes `yaml:"target_page_size"`
 
 	// TargetPageRows configures a target row count for encoded pages within the data
-	// object.
+	// object. If set to 0 or negative number, the page size will not be limited by a
+	// row count.
 	TargetPageRows int `yaml:"target_page_rows"`
 
 	// TODO(rfratto): We need an additional parameter for TargetMetadataSize, as
@@ -76,7 +77,7 @@ func (cfg *BuilderConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet
 	_ = cfg.TargetSectionSize.Set("128MB")
 
 	f.Var(&cfg.TargetPageSize, prefix+"target-page-size", "The target maximum amount of uncompressed data to hold in data pages (for columnar sections). Uncompressed size is used for consistent I/O and planning.")
-	f.IntVar(&cfg.TargetPageRows, prefix+"target-page-rows", 0, "The target row count for pages to use for the data object builder. Takes precedence over target-page-size if value is greater than 0.")
+	f.IntVar(&cfg.TargetPageRows, prefix+"target-page-rows", 0, "The target row count for pages to use for the data object builder. A value of 0 means no limit.")
 	f.Var(&cfg.TargetObjectSize, prefix+"target-builder-memory-limit", "The target maximum size of the encoded object and all of its encoded sections (after compression), to limit memory usage of a builder.")
 	f.Var(&cfg.TargetSectionSize, prefix+"target-section-size", "The target maximum amount of uncompressed data to hold in sections, for sections that support being limited by size. Uncompressed size is used for consistent I/O and planning.")
 	f.Var(&cfg.BufferSize, prefix+"buffer-size", "The size of logs to buffer in memory before adding into columnar builders, used to reduce CPU load of sorting.")

--- a/pkg/dataobj/consumer/logsobj/builder.go
+++ b/pkg/dataobj/consumer/logsobj/builder.go
@@ -40,7 +40,7 @@ type BuilderConfig struct {
 	// MaxPageRows configures a maximum row count for encoded pages within the data
 	// object. If set to 0 or negative number, the page size will not be limited by a
 	// row count.
-	MaxPageRows int `yaml:"target_page_rows"`
+	MaxPageRows int `yaml:"max_page_rows"`
 
 	// TODO(rfratto): We need an additional parameter for TargetMetadataSize, as
 	// metadata payloads can't be split and must be downloaded in a single

--- a/pkg/dataobj/consumer/logsobj/builder.go
+++ b/pkg/dataobj/consumer/logsobj/builder.go
@@ -37,6 +37,10 @@ type BuilderConfig struct {
 	// object. TargetPageSize accounts for encoding, but not for compression.
 	TargetPageSize flagext.Bytes `yaml:"target_page_size"`
 
+	// TargetPageRows configures a target row count for encoded pages within the data
+	// object.
+	TargetPageRows int `yaml:"target_page_rows"`
+
 	// TODO(rfratto): We need an additional parameter for TargetMetadataSize, as
 	// metadata payloads can't be split and must be downloaded in a single
 	// request.
@@ -72,6 +76,7 @@ func (cfg *BuilderConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet
 	_ = cfg.TargetSectionSize.Set("128MB")
 
 	f.Var(&cfg.TargetPageSize, prefix+"target-page-size", "The target maximum amount of uncompressed data to hold in data pages (for columnar sections). Uncompressed size is used for consistent I/O and planning.")
+	f.IntVar(&cfg.TargetPageRows, prefix+"target-page-rows", 0, "The target row count for pages to use for the data object builder. Takes precedence over target-page-size if value is greater than 0.")
 	f.Var(&cfg.TargetObjectSize, prefix+"target-builder-memory-limit", "The target maximum size of the encoded object and all of its encoded sections (after compression), to limit memory usage of a builder.")
 	f.Var(&cfg.TargetSectionSize, prefix+"target-section-size", "The target maximum amount of uncompressed data to hold in sections, for sections that support being limited by size. Uncompressed size is used for consistent I/O and planning.")
 	f.Var(&cfg.BufferSize, prefix+"buffer-size", "The size of logs to buffer in memory before adding into columnar builders, used to reduce CPU load of sorting.")
@@ -167,7 +172,7 @@ func NewBuilder(cfg BuilderConfig, scratchStore scratch.Store) (*Builder, error)
 // initBuilder initializes the builders for the tenant.
 func (b *Builder) initBuilder(tenant string) {
 	if _, ok := b.streams[tenant]; !ok {
-		sb := streams.NewBuilder(b.metrics.streams, int(b.cfg.TargetPageSize))
+		sb := streams.NewBuilder(b.metrics.streams, int(b.cfg.TargetPageSize), b.cfg.TargetPageRows)
 		sb.SetTenant(tenant)
 		b.streams[tenant] = sb
 	}

--- a/pkg/dataobj/index/indexobj/builder.go
+++ b/pkg/dataobj/index/indexobj/builder.go
@@ -36,7 +36,8 @@ type BuilderConfig struct {
 	TargetPageSize flagext.Bytes `yaml:"target_page_size"`
 
 	// TargetPageRows configures a target row count for encoded pages within the data
-	// object.
+	// object. If set to 0 or negative number, the page size will not be limited by a
+	// row count.
 	TargetPageRows int `yaml:"target_page_rows"`
 
 	// TODO(rfratto): We need an additional parameter for TargetMetadataSize, as
@@ -74,7 +75,7 @@ func (cfg *BuilderConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet
 	_ = cfg.TargetSectionSize.Set("16MB")
 
 	f.Var(&cfg.TargetPageSize, prefix+"target-page-size", "The size of the target page to use for the data object builder.")
-	f.IntVar(&cfg.TargetPageRows, prefix+"target-page-rows", 0, "The target row count for pages to use for the data object builder. Takes precedence over target-page-size if value is greater than 0.")
+	f.IntVar(&cfg.TargetPageRows, prefix+"target-page-rows", 0, "The target row count for pages to use for the data object builder. A value of 0 means no limit.")
 	f.Var(&cfg.TargetObjectSize, prefix+"target-object-size", "The size of the target object to use for the data object builder.")
 	f.Var(&cfg.TargetSectionSize, prefix+"target-section-size", "Configures a maximum size for sections, for sections that support it.")
 	f.Var(&cfg.BufferSize, prefix+"buffer-size", "The size of the buffer to use for sorting logs.")

--- a/pkg/dataobj/index/indexobj/builder.go
+++ b/pkg/dataobj/index/indexobj/builder.go
@@ -280,7 +280,7 @@ func (b *Builder) ObserveLogLine(tenantID string, path string, section int64, st
 
 	tenantPointers, ok := b.pointers[tenantID]
 	if !ok {
-		tenantPointers = pointers.NewBuilder(b.metrics.pointers, int(b.cfg.TargetPageSize))
+		tenantPointers = pointers.NewBuilder(b.metrics.pointers, int(b.cfg.TargetPageSize), b.cfg.TargetPageRows)
 		tenantPointers.SetTenant(tenantID)
 		b.pointers[tenantID] = tenantPointers
 	}
@@ -316,7 +316,7 @@ func (b *Builder) AppendColumnIndex(tenantID string, path string, section int64,
 
 	tenantPointers, ok := b.pointers[tenantID]
 	if !ok {
-		tenantPointers = pointers.NewBuilder(b.metrics.pointers, int(b.cfg.TargetPageSize))
+		tenantPointers = pointers.NewBuilder(b.metrics.pointers, int(b.cfg.TargetPageSize), b.cfg.TargetPageRows)
 		tenantPointers.SetTenant(tenantID)
 		b.pointers[tenantID] = tenantPointers
 	}

--- a/pkg/dataobj/internal/dataset/column_builder.go
+++ b/pkg/dataobj/internal/dataset/column_builder.go
@@ -15,6 +15,11 @@ type BuilderOptions struct {
 	// slightly larger or smaller.
 	PageSizeHint int
 
+	// PageMaxRowCount is the limit for the number of rows of the page.
+	// When 0 or a negative number, then builders use the [BuilderOptions.PageSizeHint]
+	// option to determine when a page needs to be flushed.
+	PageMaxRowCount int
+
 	// Type is the type of data in the column. Type.Physical is used for
 	// encoding; Type.Logical is used as a hint to readers.
 	Type ColumnType

--- a/pkg/dataobj/internal/dataset/page_builder.go
+++ b/pkg/dataobj/internal/dataset/page_builder.go
@@ -89,14 +89,21 @@ func (b *pageBuilder) Append(value Value) bool {
 		return b.AppendNull()
 	}
 
-	// We can't accurately know whether adding value would tip us over the page
-	// size: we don't know the current state of the encoders and we don't know
-	// for sure how much space value will fill.
-	//
-	// We use a rough estimate which will tend to overshoot the page size, making
-	// sure we rarely go over.
-	if sz := b.EstimatedSize(); sz > 0 && sz+valueSize(value) > b.opts.PageSizeHint {
-		return false
+	// If [dataobj.BuilderOptions.PageMaxRowCount] is specified it takes presedence over the [dataobj.BuilderOptions.PageSizeHint].
+	if b.opts.PageMaxRowCount > 0 {
+		if b.Rows() >= b.opts.PageMaxRowCount {
+			return false
+		}
+	} else {
+		// We can't accurately know whether adding value would tip us over the page
+		// size: we don't know the current state of the encoders and we don't know
+		// for sure how much space value will fill.
+		//
+		// We use a rough estimate which will tend to overshoot the page size, making
+		// sure we rarely go over.
+		if sz := b.EstimatedSize(); sz > 0 && sz+valueSize(value) > b.opts.PageSizeHint {
+			return false
+		}
 	}
 
 	// Update statistics. We only do this for non-NULL values,
@@ -121,13 +128,20 @@ func (b *pageBuilder) Append(value Value) bool {
 // AppendNull appends a NULL value to the Builder. AppendNull returns true if
 // the NULL was appended, or false if the Builder is full.
 func (b *pageBuilder) AppendNull() bool {
-	// See comment in Append for why we can only estimate the cost of appending a
-	// value.
-	//
-	// Here we assume appending a NULL costs one byte, but in reality most NULLs
-	// have no cost depending on the state of our bitmap encoder.
-	if sz := b.EstimatedSize(); sz > 0 && sz+1 > b.opts.PageSizeHint {
-		return false
+	// If [dataobj.BuilderOptions.PageMaxRowCount] is specified it takes presedence over the [dataobj.BuilderOptions.PageSizeHint].
+	if b.opts.PageMaxRowCount > 0 {
+		if b.Rows() >= b.opts.PageMaxRowCount {
+			return false
+		}
+	} else {
+		// See comment in Append for why we can only estimate the cost of appending a
+		// value.
+		//
+		// Here we assume appending a NULL costs one byte, but in reality most NULLs
+		// have no cost depending on the state of our bitmap encoder.
+		if sz := b.EstimatedSize(); sz > 0 && sz+1 > b.opts.PageSizeHint {
+			return false
+		}
 	}
 
 	// The following call won't fail; it only returns an error when the
@@ -143,6 +157,11 @@ func (b *pageBuilder) AppendNull() bool {
 // AppendNulls appends n NULL values to the Builder. AppendNulls returns true if
 // the NULLs were appended, or false if the Builder is full.
 func (b *pageBuilder) AppendNulls(n uint64) bool {
+	// If [dataobj.BuilderOptions.PageMaxRowCount] is specified it takes presedence over the [dataobj.BuilderOptions.PageSizeHint].
+	if b.opts.PageMaxRowCount > 0 && b.Rows() >= b.opts.PageMaxRowCount {
+		return false
+	}
+
 	// This is tricky to estimate without knowing the encoder state.
 	//
 	// For N nulls:

--- a/pkg/dataobj/internal/dataset/page_builder.go
+++ b/pkg/dataobj/internal/dataset/page_builder.go
@@ -85,7 +85,7 @@ func newPageBuilder(opts BuilderOptions) (*pageBuilder, error) {
 // The function canAppend checks whether `n` values with a total value size of `valueSize` can be appended to the current page
 // based on the options [dataobj.BuilderOptions.PageMaxRowCount] and [dataobj.BuilderOptions.PageSizeHint].
 func (b *pageBuilder) canAppend(n, valueSize int) bool {
-	if b.opts.PageMaxRowCount > 0 && b.Rows()+n > b.opts.PageMaxRowCount {
+	if rows := b.Rows(); b.opts.PageMaxRowCount > 0 && rows > 0 && b.Rows()+n > b.opts.PageMaxRowCount {
 		return false
 	}
 	if sz := b.EstimatedSize(); b.opts.PageSizeHint > 0 && sz > 0 && sz+valueSize > b.opts.PageSizeHint {

--- a/pkg/dataobj/metastore/toc_writer.go
+++ b/pkg/dataobj/metastore/toc_writer.go
@@ -28,6 +28,9 @@ var tocBuilderCfg = indexobj.BuilderConfig{
 	BufferSize:        32 * 1024 * 1024, // 8x page size
 	TargetSectionSize: 4 * 1024 * 1024,  // object size / 8
 
+	// TODO(chaudum): Should we set the page limit by the number of rows, rather than by bytes size?
+	// TargetPageRows: 20000,
+
 	SectionStripeMergeLimit: 2,
 }
 

--- a/pkg/dataobj/metastore/toc_writer.go
+++ b/pkg/dataobj/metastore/toc_writer.go
@@ -29,7 +29,7 @@ var tocBuilderCfg = indexobj.BuilderConfig{
 	TargetSectionSize: 4 * 1024 * 1024,  // object size / 8
 
 	// TODO(chaudum): Should we set the page limit by the number of rows, rather than by bytes size?
-	// TargetPageRows: 20000,
+	// MaxPageRows: 20000,
 
 	SectionStripeMergeLimit: 2,
 }

--- a/pkg/dataobj/sections/indexpointers/builder.go
+++ b/pkg/dataobj/sections/indexpointers/builder.go
@@ -27,20 +27,22 @@ type IndexPointer struct {
 }
 
 type Builder struct {
-	metrics  *Metrics
-	pageSize int
-	tenant   string
+	metrics      *Metrics
+	pageSize     int
+	pageRowCount int
+	tenant       string
 
 	indexPointers []*IndexPointer
 }
 
-func NewBuilder(metrics *Metrics, pageSize int) *Builder {
+func NewBuilder(metrics *Metrics, pageSize, pageRowCount int) *Builder {
 	if metrics == nil {
 		metrics = NewMetrics()
 	}
 	return &Builder{
 		metrics:       metrics,
 		pageSize:      pageSize,
+		pageRowCount:  pageRowCount,
 		indexPointers: make([]*IndexPointer, 0, 1024),
 	}
 }
@@ -143,7 +145,8 @@ func (b *Builder) Reset() {
 
 func (b *Builder) encodeTo(enc *columnar.Encoder) error {
 	pathBuilder, err := dataset.NewColumnBuilder("path", dataset.BuilderOptions{
-		PageSizeHint: b.pageSize,
+		PageSizeHint:    b.pageSize,
+		PageMaxRowCount: b.pageRowCount,
 		Type: dataset.ColumnType{
 			Physical: datasetmd_v2.PHYSICAL_TYPE_BINARY,
 			Logical:  ColumnTypePath.String(),
@@ -159,7 +162,8 @@ func (b *Builder) encodeTo(enc *columnar.Encoder) error {
 	}
 
 	minTimestampBuilder, err := dataset.NewColumnBuilder("min_timestamp", dataset.BuilderOptions{
-		PageSizeHint: b.pageSize,
+		PageSizeHint:    b.pageSize,
+		PageMaxRowCount: b.pageRowCount,
 		Type: dataset.ColumnType{
 			Physical: datasetmd_v2.PHYSICAL_TYPE_INT64,
 			Logical:  ColumnTypeMinTimestamp.String(),
@@ -175,7 +179,8 @@ func (b *Builder) encodeTo(enc *columnar.Encoder) error {
 	}
 
 	maxTimestampBuilder, err := dataset.NewColumnBuilder("max_timestamp", dataset.BuilderOptions{
-		PageSizeHint: b.pageSize,
+		PageSizeHint:    b.pageSize,
+		PageMaxRowCount: b.pageRowCount,
 		Type: dataset.ColumnType{
 			Physical: datasetmd_v2.PHYSICAL_TYPE_INT64,
 			Logical:  ColumnTypeMaxTimestamp.String(),

--- a/pkg/dataobj/sections/indexpointers/builder_test.go
+++ b/pkg/dataobj/sections/indexpointers/builder_test.go
@@ -22,7 +22,7 @@ func TestBuilder(t *testing.T) {
 		{path: "bar", start: unixTime(10), end: unixTime(20)},
 	}
 
-	ib := NewBuilder(nil, 1024)
+	ib := NewBuilder(nil, 1024, 0)
 	for _, p := range pp {
 		ib.Append(p.path, p.start, p.end)
 	}

--- a/pkg/dataobj/sections/indexpointers/row_reader_test.go
+++ b/pkg/dataobj/sections/indexpointers/row_reader_test.go
@@ -21,17 +21,17 @@ var indexPointerTestData = []IndexPointer{
 func unixTime(sec int64) time.Time { return time.Unix(sec, 0) }
 
 func TestRowReader(t *testing.T) {
-	dec := buildIndexPointersDecoder(t, 100) // Many pages
+	dec := buildIndexPointersDecoder(t, 100, 0) // Many pages
 	r := NewRowReader(dec)
 	actual, err := readAllIndexPointers(context.Background(), r)
 	require.NoError(t, err)
 	require.Equal(t, indexPointerTestData, actual)
 }
 
-func buildIndexPointersDecoder(t *testing.T, pageSize int) *Section {
+func buildIndexPointersDecoder(t *testing.T, pageSize, pageRows int) *Section {
 	t.Helper()
 
-	s := NewBuilder(nil, pageSize)
+	s := NewBuilder(nil, pageSize, pageRows)
 	for _, d := range indexPointerTestData {
 		s.Append(d.Path, d.StartTs, d.EndTs)
 	}

--- a/pkg/dataobj/sections/logs/table.go
+++ b/pkg/dataobj/sections/logs/table.go
@@ -123,13 +123,14 @@ type tableBuffer struct {
 }
 
 // StreamID gets or creates a stream ID column for the buffer.
-func (b *tableBuffer) StreamID(pageSize int) *dataset.ColumnBuilder {
+func (b *tableBuffer) StreamID(pageSize, pageRowCount int) *dataset.ColumnBuilder {
 	if b.streamID != nil {
 		return b.streamID
 	}
 
 	col, err := dataset.NewColumnBuilder("", dataset.BuilderOptions{
-		PageSizeHint: pageSize,
+		PageSizeHint:    pageSize,
+		PageMaxRowCount: pageRowCount,
 		Type: dataset.ColumnType{
 			Physical: datasetmd.PHYSICAL_TYPE_INT64,
 			Logical:  ColumnTypeStreamID.String(),
@@ -153,13 +154,14 @@ func (b *tableBuffer) StreamID(pageSize int) *dataset.ColumnBuilder {
 }
 
 // Timestamp gets or creates a timestamp column for the buffer.
-func (b *tableBuffer) Timestamp(pageSize int) *dataset.ColumnBuilder {
+func (b *tableBuffer) Timestamp(pageSize, pageRowCount int) *dataset.ColumnBuilder {
 	if b.timestamp != nil {
 		return b.timestamp
 	}
 
 	col, err := dataset.NewColumnBuilder("", dataset.BuilderOptions{
-		PageSizeHint: pageSize,
+		PageSizeHint:    pageSize,
+		PageMaxRowCount: pageRowCount,
 		Type: dataset.ColumnType{
 			Physical: datasetmd.PHYSICAL_TYPE_INT64,
 			Logical:  ColumnTypeTimestamp.String(),
@@ -183,7 +185,7 @@ func (b *tableBuffer) Timestamp(pageSize int) *dataset.ColumnBuilder {
 
 // Metadata gets or creates a metadata column for the buffer. To remove created
 // metadata columns, call [tableBuffer.CleanupMetadatas].
-func (b *tableBuffer) Metadata(key string, pageSize int, compressionOpts dataset.CompressionOptions) *dataset.ColumnBuilder {
+func (b *tableBuffer) Metadata(key string, pageSize, pageRowCount int, compressionOpts dataset.CompressionOptions) *dataset.ColumnBuilder {
 	if b.usedMetadatas == nil {
 		b.usedMetadatas = make(map[*dataset.ColumnBuilder]string)
 	}
@@ -196,7 +198,8 @@ func (b *tableBuffer) Metadata(key string, pageSize int, compressionOpts dataset
 	}
 
 	col, err := dataset.NewColumnBuilder(key, dataset.BuilderOptions{
-		PageSizeHint: pageSize,
+		PageSizeHint:    pageSize,
+		PageMaxRowCount: pageRowCount,
 		Type: dataset.ColumnType{
 			Physical: datasetmd.PHYSICAL_TYPE_BINARY,
 			Logical:  ColumnTypeMetadata.String(),
@@ -227,13 +230,14 @@ func (b *tableBuffer) Metadata(key string, pageSize int, compressionOpts dataset
 }
 
 // Message gets or creates a message column for the buffer.
-func (b *tableBuffer) Message(pageSize int, compressionOpts dataset.CompressionOptions) *dataset.ColumnBuilder {
+func (b *tableBuffer) Message(pageSize, pageRowCount int, compressionOpts dataset.CompressionOptions) *dataset.ColumnBuilder {
 	if b.message != nil {
 		return b.message
 	}
 
 	col, err := dataset.NewColumnBuilder("", dataset.BuilderOptions{
-		PageSizeHint: pageSize,
+		PageSizeHint:    pageSize,
+		PageMaxRowCount: pageRowCount,
 		Type: dataset.ColumnType{
 			Physical: datasetmd.PHYSICAL_TYPE_BINARY,
 			Logical:  ColumnTypeMessage.String(),

--- a/pkg/dataobj/sections/logs/table_build.go
+++ b/pkg/dataobj/sections/logs/table_build.go
@@ -11,15 +11,15 @@ import (
 
 // buildTable builds a table from the set of provided records. The records are
 // sorted with [sortRecords] prior to building the table.
-func buildTable(buf *tableBuffer, pageSize int, compressionOpts dataset.CompressionOptions, records []Record) *table {
+func buildTable(buf *tableBuffer, pageSize, pageRowCount int, compressionOpts dataset.CompressionOptions, records []Record) *table {
 	sortRecords(records)
 
 	buf.Reset()
 
 	var (
-		streamIDBuilder  = buf.StreamID(pageSize)
-		timestampBuilder = buf.Timestamp(pageSize)
-		messageBuilder   = buf.Message(pageSize, compressionOpts)
+		streamIDBuilder  = buf.StreamID(pageSize, pageRowCount)
+		timestampBuilder = buf.Timestamp(pageSize, pageRowCount)
+		messageBuilder   = buf.Message(pageSize, pageRowCount, compressionOpts)
 	)
 
 	for i, record := range records {
@@ -34,7 +34,7 @@ func buildTable(buf *tableBuffer, pageSize int, compressionOpts dataset.Compress
 		record.Metadata.Range(func(md labels.Label) {
 			// Passing around md.Value as an unsafe slice is safe here: appending
 			// values is always read-only and the byte slice will never be mutated.
-			metadataBuilder := buf.Metadata(md.Name, pageSize, compressionOpts)
+			metadataBuilder := buf.Metadata(md.Name, pageSize, pageRowCount, compressionOpts)
 			_ = metadataBuilder.Append(i, dataset.BinaryValue(unsafeSlice(md.Value, 0)))
 		})
 	}

--- a/pkg/dataobj/sections/logs/table_merge.go
+++ b/pkg/dataobj/sections/logs/table_merge.go
@@ -18,7 +18,7 @@ import (
 // tables are open at a time.
 //
 // mergeTablesIncremental panics if maxMergeSize is less than 2.
-func mergeTablesIncremental(buf *tableBuffer, pageSize int, compressionOpts dataset.CompressionOptions, tables []*table, maxMergeSize int) (*table, error) {
+func mergeTablesIncremental(buf *tableBuffer, pageSize, pageRowCount int, compressionOpts dataset.CompressionOptions, tables []*table, maxMergeSize int) (*table, error) {
 	if maxMergeSize < 2 {
 		panic("mergeTablesIncremental: merge size must be at least 2, got " + fmt.Sprint(maxMergeSize))
 	}
@@ -26,7 +26,7 @@ func mergeTablesIncremental(buf *tableBuffer, pageSize int, compressionOpts data
 	// Even if there's only one table, we still pass to mergeTables to ensure
 	// it's compressed with compressionOpts.
 	if len(tables) == 1 {
-		return mergeTables(buf, pageSize, compressionOpts, tables)
+		return mergeTables(buf, pageSize, pageRowCount, compressionOpts, tables)
 	}
 
 	in := tables
@@ -36,7 +36,7 @@ func mergeTablesIncremental(buf *tableBuffer, pageSize int, compressionOpts data
 
 		for i := 0; i < len(in); i += maxMergeSize {
 			set := in[i:min(i+maxMergeSize, len(in))]
-			merged, err := mergeTables(buf, pageSize, compressionOpts, set)
+			merged, err := mergeTables(buf, pageSize, pageRowCount, compressionOpts, set)
 			if err != nil {
 				return nil, err
 			}
@@ -51,13 +51,13 @@ func mergeTablesIncremental(buf *tableBuffer, pageSize int, compressionOpts data
 
 // mergeTables merges the provided sorted tables into a new single sorted table
 // using k-way merge.
-func mergeTables(buf *tableBuffer, pageSize int, compressionOpts dataset.CompressionOptions, tables []*table) (*table, error) {
+func mergeTables(buf *tableBuffer, pageSize, pageRowCount int, compressionOpts dataset.CompressionOptions, tables []*table) (*table, error) {
 	buf.Reset()
 
 	var (
-		streamIDBuilder  = buf.StreamID(pageSize)
-		timestampBuilder = buf.Timestamp(pageSize)
-		messageBuilder   = buf.Message(pageSize, compressionOpts)
+		streamIDBuilder  = buf.StreamID(pageSize, pageRowCount)
+		timestampBuilder = buf.Timestamp(pageSize, pageRowCount)
+		messageBuilder   = buf.Message(pageSize, pageRowCount, compressionOpts)
 	)
 
 	var (
@@ -117,7 +117,7 @@ func mergeTables(buf *tableBuffer, pageSize int, compressionOpts dataset.Compres
 			case ColumnTypeTimestamp:
 				_ = timestampBuilder.Append(rows, value)
 			case ColumnTypeMetadata:
-				columnBuilder := buf.Metadata(column.Desc.Tag, pageSize, compressionOpts)
+				columnBuilder := buf.Metadata(column.Desc.Tag, pageSize, pageRowCount, compressionOpts)
 				_ = columnBuilder.Append(rows, value)
 			case ColumnTypeMessage:
 				_ = messageBuilder.Append(rows, value)

--- a/pkg/dataobj/sections/logs/table_test.go
+++ b/pkg/dataobj/sections/logs/table_test.go
@@ -15,19 +15,24 @@ import (
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/result"
 )
 
+var (
+	pageSize = 1024
+	pageRows = 0
+)
+
 func Test_table_metadataCleanup(t *testing.T) {
 	var buf tableBuffer
 	initBuffer(&buf)
 
-	_ = buf.Metadata("foo", 1024, dataset.CompressionOptions{})
-	_ = buf.Metadata("bar", 1024, dataset.CompressionOptions{})
+	_ = buf.Metadata("foo", pageSize, pageRows, dataset.CompressionOptions{})
+	_ = buf.Metadata("bar", pageSize, pageRows, dataset.CompressionOptions{})
 
 	table, err := buf.Flush()
 	require.NoError(t, err)
 	require.Equal(t, 2, len(table.Metadatas))
 
 	initBuffer(&buf)
-	_ = buf.Metadata("bar", 1024, dataset.CompressionOptions{})
+	_ = buf.Metadata("bar", pageSize, pageRows, dataset.CompressionOptions{})
 
 	table, err = buf.Flush()
 	require.NoError(t, err)
@@ -36,9 +41,9 @@ func Test_table_metadataCleanup(t *testing.T) {
 }
 
 func initBuffer(buf *tableBuffer) {
-	buf.StreamID(1024)
-	buf.Timestamp(1024)
-	buf.Message(1024, dataset.CompressionOptions{})
+	buf.StreamID(pageSize, pageRows)
+	buf.Timestamp(pageSize, pageRows)
+	buf.Message(pageSize, pageRows, dataset.CompressionOptions{})
 }
 
 func Test_mergeTables(t *testing.T) {
@@ -46,24 +51,24 @@ func Test_mergeTables(t *testing.T) {
 
 	// tables need to be sorted by Timestamp DESC and StreamID ASC
 	var (
-		tableA = buildTable(&buf, 1024, dataset.CompressionOptions{}, []Record{
+		tableA = buildTable(&buf, pageSize, pageRows, dataset.CompressionOptions{}, []Record{
 			{StreamID: 3, Timestamp: time.Unix(3, 0), Line: []byte("hello")},
 			{StreamID: 2, Timestamp: time.Unix(2, 0), Line: []byte("how")},
 			{StreamID: 1, Timestamp: time.Unix(1, 0), Line: []byte("you")},
 		})
 
-		tableB = buildTable(&buf, 1024, dataset.CompressionOptions{}, []Record{
+		tableB = buildTable(&buf, pageSize, pageRows, dataset.CompressionOptions{}, []Record{
 			{StreamID: 1, Timestamp: time.Unix(2, 0), Line: []byte("world")},
 			{StreamID: 3, Timestamp: time.Unix(1, 0), Line: []byte("goodbye")},
 		})
 
-		tableC = buildTable(&buf, 1024, dataset.CompressionOptions{}, []Record{
+		tableC = buildTable(&buf, pageSize, pageRows, dataset.CompressionOptions{}, []Record{
 			{StreamID: 3, Timestamp: time.Unix(2, 0), Line: []byte("are")},
 			{StreamID: 2, Timestamp: time.Unix(1, 0), Line: []byte("doing?")},
 		})
 	)
 
-	mergedTable, err := mergeTables(&buf, 1024, dataset.CompressionOptions{}, []*table{tableA, tableB, tableC})
+	mergedTable, err := mergeTables(&buf, pageSize, pageRows, dataset.CompressionOptions{}, []*table{tableA, tableB, tableC})
 	require.NoError(t, err)
 
 	mergedColumns, err := result.Collect(mergedTable.ListColumns(context.Background()))
@@ -76,7 +81,7 @@ func Test_mergeTables(t *testing.T) {
 		Columns: mergedColumns,
 	})
 
-	rows := make([]dataset.Row, 1024)
+	rows := make([]dataset.Row, pageSize)
 
 	for {
 		n, err := r.Read(context.Background(), rows)

--- a/pkg/dataobj/sections/pointers/builder.go
+++ b/pkg/dataobj/sections/pointers/builder.go
@@ -360,7 +360,7 @@ func (b *Builder) encodeTo(enc *columnar.Encoder) error {
 	// (which may fail due to a caller) since we guarantee correct usage of the
 	// encoding API.
 	{
-		var errs []error
+		errs := make([]error, 0, 12) // 12 possible errors for 12 columns. Better check if encodeColumn(enc, ...) returns not nil?
 		errs = append(errs, encodeColumn(enc, ColumnTypePath, pathBuilder))
 		errs = append(errs, encodeColumn(enc, ColumnTypeSection, sectionBuilder))
 		errs = append(errs, encodeColumn(enc, ColumnTypePointerKind, pointerKindBuilder))

--- a/pkg/dataobj/sections/pointers/builder.go
+++ b/pkg/dataobj/sections/pointers/builder.go
@@ -92,13 +92,14 @@ type Builder struct {
 
 // NewBuilder creates a new pointers section builder. The pageSize argument
 // specifies how large pages should be.
-func NewBuilder(metrics *Metrics, pageSize int) *Builder {
+func NewBuilder(metrics *Metrics, pageSize, pageRows int) *Builder {
 	if metrics == nil {
 		metrics = NewMetrics()
 	}
 	return &Builder{
-		metrics:  metrics,
-		pageSize: pageSize,
+		metrics:      metrics,
+		pageSize:     pageSize,
+		pageRowCount: pageRows,
 
 		streamLookup: make(map[streamKey]*SectionPointer),
 		pointers:     make([]*SectionPointer, 0, 1024),

--- a/pkg/dataobj/sections/pointers/builder.go
+++ b/pkg/dataobj/sections/pointers/builder.go
@@ -77,9 +77,10 @@ type streamKey struct {
 
 // Builder builds a pointers section.
 type Builder struct {
-	metrics  *Metrics
-	pageSize int
-	tenant   string
+	metrics      *Metrics
+	pageSize     int
+	pageRowCount int
+	tenant       string
 
 	// streamLookup is a map of the stream ID in this index object to the pointer.
 	streamLookup map[streamKey]*SectionPointer
@@ -244,7 +245,8 @@ func (b *Builder) encodeTo(enc *columnar.Encoder) error {
 	//    keys and values.
 
 	pathBuilder, err := dataset.NewColumnBuilder("path", dataset.BuilderOptions{
-		PageSizeHint: b.pageSize,
+		PageSizeHint:    b.pageSize,
+		PageMaxRowCount: b.pageRowCount,
 		Type: dataset.ColumnType{
 			Physical: datasetmd.PHYSICAL_TYPE_BINARY,
 			Logical:  ColumnTypePath.String(),
@@ -258,44 +260,45 @@ func (b *Builder) encodeTo(enc *columnar.Encoder) error {
 	if err != nil {
 		return fmt.Errorf("creating path column: %w", err)
 	}
-	sectionBuilder, err := numberColumnBuilder(ColumnTypeSection, b.pageSize)
+	sectionBuilder, err := numberColumnBuilder(ColumnTypeSection, b.pageSize, b.pageRowCount)
 	if err != nil {
 		return fmt.Errorf("creating section column: %w", err)
 	}
-	pointerKindBuilder, err := numberColumnBuilder(ColumnTypePointerKind, b.pageSize)
+	pointerKindBuilder, err := numberColumnBuilder(ColumnTypePointerKind, b.pageSize, b.pageRowCount)
 	if err != nil {
 		return fmt.Errorf("creating pointer kind column: %w", err)
 	}
 
 	// Stream info
-	idBuilder, err := numberColumnBuilder(ColumnTypeStreamID, b.pageSize)
+	idBuilder, err := numberColumnBuilder(ColumnTypeStreamID, b.pageSize, b.pageRowCount)
 	if err != nil {
 		return fmt.Errorf("creating ID column: %w", err)
 	}
-	streamIDRefBuilder, err := numberColumnBuilder(ColumnTypeStreamIDRef, b.pageSize)
+	streamIDRefBuilder, err := numberColumnBuilder(ColumnTypeStreamIDRef, b.pageSize, b.pageRowCount)
 	if err != nil {
 		return fmt.Errorf("creating stream ID in object column: %w", err)
 	}
-	minTimestampBuilder, err := numberColumnBuilder(ColumnTypeMinTimestamp, b.pageSize)
+	minTimestampBuilder, err := numberColumnBuilder(ColumnTypeMinTimestamp, b.pageSize, b.pageRowCount)
 	if err != nil {
 		return fmt.Errorf("creating minimum timestamp column: %w", err)
 	}
-	maxTimestampBuilder, err := numberColumnBuilder(ColumnTypeMaxTimestamp, b.pageSize)
+	maxTimestampBuilder, err := numberColumnBuilder(ColumnTypeMaxTimestamp, b.pageSize, b.pageRowCount)
 	if err != nil {
 		return fmt.Errorf("creating maximum timestamp column: %w", err)
 	}
-	rowCountBuilder, err := numberColumnBuilder(ColumnTypeRowCount, b.pageSize)
+	rowCountBuilder, err := numberColumnBuilder(ColumnTypeRowCount, b.pageSize, b.pageRowCount)
 	if err != nil {
 		return fmt.Errorf("creating rows column: %w", err)
 	}
-	uncompressedSizeBuilder, err := numberColumnBuilder(ColumnTypeUncompressedSize, b.pageSize)
+	uncompressedSizeBuilder, err := numberColumnBuilder(ColumnTypeUncompressedSize, b.pageSize, b.pageRowCount)
 	if err != nil {
 		return fmt.Errorf("creating uncompressed size column: %w", err)
 	}
 
 	// Column index info
 	columnNameBuilder, err := dataset.NewColumnBuilder("column_name", dataset.BuilderOptions{
-		PageSizeHint: b.pageSize,
+		PageSizeHint:    b.pageSize,
+		PageMaxRowCount: b.pageRowCount,
 		Type: dataset.ColumnType{
 			Physical: datasetmd.PHYSICAL_TYPE_BINARY,
 			Logical:  ColumnTypeColumnName.String(),
@@ -310,13 +313,14 @@ func (b *Builder) encodeTo(enc *columnar.Encoder) error {
 		return fmt.Errorf("creating column name column: %w", err)
 	}
 
-	columnIndexBuilder, err := numberColumnBuilder(ColumnTypeColumnIndex, b.pageSize)
+	columnIndexBuilder, err := numberColumnBuilder(ColumnTypeColumnIndex, b.pageSize, b.pageRowCount)
 	if err != nil {
 		return fmt.Errorf("creating column index column: %w", err)
 	}
 
 	valuesBloomFilterBuilder, err := dataset.NewColumnBuilder("values_bloom_filter", dataset.BuilderOptions{
-		PageSizeHint: b.pageSize,
+		PageSizeHint:    b.pageSize,
+		PageMaxRowCount: b.pageRowCount,
 		Type: dataset.ColumnType{
 			Physical: datasetmd.PHYSICAL_TYPE_BINARY,
 			Logical:  ColumnTypeValuesBloomFilter.String(),
@@ -377,9 +381,10 @@ func (b *Builder) encodeTo(enc *columnar.Encoder) error {
 	return nil
 }
 
-func numberColumnBuilder(logicalType ColumnType, pageSize int) (*dataset.ColumnBuilder, error) {
+func numberColumnBuilder(logicalType ColumnType, pageSize, pageRowCount int) (*dataset.ColumnBuilder, error) {
 	return dataset.NewColumnBuilder("", dataset.BuilderOptions{
-		PageSizeHint: pageSize,
+		PageSizeHint:    pageSize,
+		PageMaxRowCount: pageRowCount,
 		Type: dataset.ColumnType{
 			Physical: datasetmd.PHYSICAL_TYPE_INT64,
 			Logical:  logicalType.String(),

--- a/pkg/dataobj/sections/pointers/builder_test.go
+++ b/pkg/dataobj/sections/pointers/builder_test.go
@@ -29,7 +29,7 @@ func TestAddingStreams(t *testing.T) {
 		{path: "bar", section: 1, pointerKind: PointerKindStreamIndex, streamIDInObject: -2, streamID: 2, minTimestamp: time.Unix(100, 0), maxTimestamp: time.Unix(101, 0), rowsCount: 2, uncompressedSize: 20},
 	}
 
-	tracker := NewBuilder(nil, 1024)
+	tracker := NewBuilder(nil, 1024, 0)
 	for _, tc := range tt {
 		tracker.ObserveStream(tc.path, tc.section, tc.streamIDInObject, tc.streamID, tc.minTimestamp, tc.uncompressedSize)
 		// We Observe twice to track the max timestamp too. But we don't want to count the size twice.
@@ -98,7 +98,7 @@ func TestAddingColumnIndexes(t *testing.T) {
 		{path: "bar", section: 1, pointerKind: PointerKindColumnIndex, columnName: "testColumn2", columnIndex: 1, valuesBloomFilter: []byte{1, 2, 3, 4}},
 	}
 
-	tracker := NewBuilder(nil, 1024)
+	tracker := NewBuilder(nil, 1024, 0)
 	for _, tc := range tt {
 		tracker.RecordColumnIndex(tc.path, tc.section, tc.columnName, tc.columnIndex, tc.valuesBloomFilter)
 	}

--- a/pkg/dataobj/sections/pointers/row_reader_test.go
+++ b/pkg/dataobj/sections/pointers/row_reader_test.go
@@ -21,7 +21,7 @@ var pointerTestData = []SectionPointer{
 }
 
 func TestRowReader(t *testing.T) {
-	dec := buildPointersDecoder(t, 100) // Many pages
+	dec := buildPointersDecoder(t, 0, 2) // 3 pages
 	r := NewRowReader(dec)
 	actual, err := readAllPointers(context.Background(), r)
 	require.NoError(t, err)
@@ -30,10 +30,10 @@ func TestRowReader(t *testing.T) {
 
 func unixTime(sec int64) time.Time { return time.Unix(sec, 0) }
 
-func buildPointersDecoder(t *testing.T, pageSize int) *Section {
+func buildPointersDecoder(t *testing.T, pageSize, pageRows int) *Section {
 	t.Helper()
 
-	s := NewBuilder(nil, pageSize)
+	s := NewBuilder(nil, pageSize, pageRows)
 	for _, d := range pointerTestData {
 		if d.PointerKind == PointerKindStreamIndex {
 			s.ObserveStream(d.Path, d.Section, d.StreamIDRef, d.StreamID, d.StartTs, d.UncompressedSize)

--- a/pkg/dataobj/sections/streams/builder_test.go
+++ b/pkg/dataobj/sections/streams/builder_test.go
@@ -28,7 +28,7 @@ func Test(t *testing.T) {
 		{labels.FromStrings("cluster", "test", "app", "foo"), time.Unix(9, 0), 5},
 	}
 
-	tracker := streams.NewBuilder(nil, 1024)
+	tracker := streams.NewBuilder(nil, 1024, 0)
 	for _, tc := range tt {
 		tracker.Record(tc.Labels, tc.Time, tc.Size)
 	}

--- a/pkg/dataobj/sections/streams/reader_test.go
+++ b/pkg/dataobj/sections/streams/reader_test.go
@@ -51,7 +51,7 @@ func TestReader(t *testing.T) {
 		},
 	}
 
-	sec := buildStreamsSection(t, 1)
+	sec := buildStreamsSection(t, 1, 0)
 
 	r := streams.NewReader(streams.ReaderOptions{
 		Columns:    sec.Columns(),
@@ -86,7 +86,7 @@ func TestReader_Predicate(t *testing.T) {
 		},
 	}
 
-	sec := buildStreamsSection(t, 1)
+	sec := buildStreamsSection(t, 1, 0)
 
 	appLabel := sec.Columns()[5]
 	require.Equal(t, "app", appLabel.Name)
@@ -130,7 +130,7 @@ func TestReader_InPredicate(t *testing.T) {
 		},
 	}
 
-	sec := buildStreamsSection(t, 1)
+	sec := buildStreamsSection(t, 1, 0)
 
 	streamID := sec.Columns()[0]
 	require.Equal(t, "", streamID.Name)
@@ -179,7 +179,7 @@ func TestReader_ColumnSubset(t *testing.T) {
 		},
 	}
 
-	sec := buildStreamsSection(t, 1)
+	sec := buildStreamsSection(t, 1, 0)
 
 	var (
 		streamID = sec.Columns()[0]

--- a/pkg/dataobj/sections/streams/row_reader_test.go
+++ b/pkg/dataobj/sections/streams/row_reader_test.go
@@ -35,7 +35,7 @@ func TestRowReader(t *testing.T) {
 		{3, unixTime(25), unixTime(30), 35, labels.FromStrings("cluster", "test", "app", "baz"), 2},
 	}
 
-	sec := buildStreamsSection(t, 1) // Many pages
+	sec := buildStreamsSection(t, 1, 0) // Many pages
 	r := streams.NewRowReader(sec)
 	actual, err := readAllStreams(context.Background(), r)
 	require.NoError(t, err)
@@ -47,7 +47,7 @@ func TestRowReader_AddLabelMatcher(t *testing.T) {
 		{2, unixTime(5), unixTime(20), 45, labels.FromStrings("cluster", "test", "app", "bar"), 2},
 	}
 
-	sec := buildStreamsSection(t, 1) // Many pages
+	sec := buildStreamsSection(t, 1, 0) // Many pages
 	r := streams.NewRowReader(sec)
 	require.NoError(t, r.SetPredicate(streams.LabelMatcherRowPredicate{Name: "app", Value: "bar"}))
 
@@ -62,7 +62,7 @@ func TestRowReader_AddLabelFilter(t *testing.T) {
 		{3, unixTime(25), unixTime(30), 35, labels.FromStrings("cluster", "test", "app", "baz"), 2},
 	}
 
-	sec := buildStreamsSection(t, 1) // Many pages
+	sec := buildStreamsSection(t, 1, 0) // Many pages
 	r := streams.NewRowReader(sec)
 	err := r.SetPredicate(streams.LabelFilterRowPredicate{
 		Name: "app",
@@ -80,10 +80,10 @@ func TestRowReader_AddLabelFilter(t *testing.T) {
 
 func unixTime(sec int64) time.Time { return time.Unix(sec, 0) }
 
-func buildStreamsSection(t *testing.T, pageSize int) *streams.Section {
+func buildStreamsSection(t *testing.T, pageSize, pageRows int) *streams.Section {
 	t.Helper()
 
-	s := streams.NewBuilder(nil, pageSize)
+	s := streams.NewBuilder(nil, pageSize, pageRows)
 	for _, d := range streamsTestdata {
 		s.Record(d.Labels, d.Timestamp, d.UncompressedSize)
 	}

--- a/pkg/engine/executor/streams_view_test.go
+++ b/pkg/engine/executor/streams_view_test.go
@@ -139,7 +139,7 @@ func Test_streamsView(t *testing.T) {
 }
 
 func buildStreamsSection(t *testing.T, streamLabels []labels.Labels) *streams.Section {
-	streamsBuilder := streams.NewBuilder(nil, 8192)
+	streamsBuilder := streams.NewBuilder(nil, 8192, 0)
 	for _, stream := range streamLabels {
 		_ = streamsBuilder.Record(stream, time.Now().UTC(), 0)
 	}


### PR DESCRIPTION
### Summary

This PR introduces an option for the column builder to limit the number of rows in a page.

It can be set for logs object and index objects separately using `-dataobj-consumer.max-page-rows` and `-dataobj-index-builder.max-page-rows` respectively.