### PR TITLE
chore: Replace per section impl tenant function with generic one

### DIFF
--- a/cmd/dataobj-inspect/dump.go
+++ b/cmd/dataobj-inspect/dump.go
@@ -62,7 +62,7 @@ func (cmd *dumpCommand) dumpStreamsSection(ctx context.Context, offset int, sec 
 	}
 	bold := color.New(color.Bold)
 	bold.Println("Streams section:")
-	bold.Printf("\toffset: %d, tenant: %s\n", offset, streamsSec.Tenant())
+	bold.Printf("\toffset: %d, tenant: %s\n", offset, sec.Tenant)
 
 	tmp := make([]streams.Stream, 512)
 	r := streams.NewRowReader(streamsSec)
@@ -90,7 +90,7 @@ func (cmd *dumpCommand) dumpLogsSection(ctx context.Context, offset int, sec *da
 	}
 	bold := color.New(color.Bold)
 	bold.Println("Logs section:")
-	bold.Printf("\toffset: %d, tenant: %s\n", offset, logsSec.Tenant())
+	bold.Printf("\toffset: %d, tenant: %s\n", offset, sec.Tenant)
 	tmp := make([]logs.Record, 512)
 	r := logs.NewRowReader(logsSec)
 	for {

--- a/cmd/dataobj-inspect/stats.go
+++ b/cmd/dataobj-inspect/stats.go
@@ -97,7 +97,7 @@ func (cmd *statsCommand) printStreamsSectionStats(ctx context.Context, offset in
 	bold.Printf(
 		"\toffset: %d, tenant: %s, columns: %d, compressed size: %v, uncompressed size %v\n",
 		offset,
-		streamsSec.Tenant(),
+		sec.Tenant,
 		len(stats.Columns),
 		humanize.Bytes(stats.CompressedSize),
 		humanize.Bytes(stats.UncompressedSize),
@@ -128,7 +128,7 @@ func (cmd *statsCommand) printLogsSectionStats(ctx context.Context, offset int, 
 	bold.Printf(
 		"\toffset: %d, tenant: %s, columns: %d, compressed size: %v, uncompressed size %v\n",
 		offset,
-		logsSec.Tenant(),
+		sec.Tenant,
 		len(stats.Columns),
 		humanize.Bytes(stats.CompressedSize),
 		humanize.Bytes(stats.UncompressedSize),

--- a/pkg/dataobj/sections/logs/logs.go
+++ b/pkg/dataobj/sections/logs/logs.go
@@ -74,9 +74,6 @@ func (s *Section) init() error {
 	return nil
 }
 
-// Tenant returns the tenant that owns the section.
-func (s *Section) Tenant() string { return s.inner.Tenant() }
-
 // Columns returns the set of Columns in the section. The slice of returned
 // sections must not be mutated.
 //

--- a/pkg/dataobj/sections/streams/streams.go
+++ b/pkg/dataobj/sections/streams/streams.go
@@ -73,9 +73,6 @@ func (s *Section) init() error {
 	return nil
 }
 
-// Tenant returns the tenant that owns the section.
-func (s *Section) Tenant() string { return s.inner.Tenant() }
-
 // Columns returns the set of Columns in the section. The slice of returned
 // sections must not be mutated.
 //


### PR DESCRIPTION
**What this PR does / why we need it**:
This pull request removes the remaining usage places of `(streams|logs).Tenant()` for the generic `section.Tenant` attribute.

**Which issue(s) this PR fixes**:
Fixes grafana/loki-private/#1962

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
