### PR TITLE
chore: remove ConsumeRegex() from partitionring consumer

### DIFF
--- a/pkg/kafka/partitionring/consumer/client.go
+++ b/pkg/kafka/partitionring/consumer/client.go
@@ -37,7 +37,6 @@ type Client struct {
 func NewGroupClient(kafkaCfg kafka.Config, partitionRing ring.PartitionRingReader, groupName string, logger log.Logger, reg prometheus.Registerer, opts ...kgo.Opt) (*Client, error) {
 	defaultOpts := []kgo.Opt{
 		kgo.ConsumerGroup(groupName),
-		kgo.ConsumeRegex(),
 		kgo.ConsumeTopics(kafkaCfg.Topic),
 		kgo.Balancers(kgo.CooperativeStickyBalancer()),
 		kgo.ConsumeResetOffset(kgo.NewOffset().AtStart()),


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit removes ConsumeRegex() from the partition ring consumer for a couple of reasons:

  1. We no longer need to do regex matching against topics.
  2. I have observed that clients are still assigned topics that don't match the regex, and these topics are passed to the [kgo.OnPartitionsAssigned] callback, which means we create processors for them in memory. The topics remain assigned but are not consumed.
  3. Getting the regex correct is hard, most of the time I've observed missing ^ and $, and we end up consuming other topics that we never intended to consume.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
