### PR TITLE
chore(engine): move to toggleable section prefetching

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -4880,13 +4880,6 @@ engine:
   # CLI flag: -querier.engine.merge-prefetch-count
   [merge_prefetch_count: <int> | default = 0]
 
-  # Experimental: Maximum total size of future pages for DataObjScan to download
-  # before they are needed, for roundtrip reduction to object storage. Setting
-  # to zero disables downloading future pages. Only used in the next generation
-  # query engine.
-  # CLI flag: -querier.engine.dataobjscan-page-cache-size
-  [dataobjscan_page_cache_size: <int> | default = 0B]
-
   # Configures how to read byte ranges from object storage when using the V2
   # engine.
   range_reads:

--- a/pkg/dataobj/internal/dataset/reader.go
+++ b/pkg/dataobj/internal/dataset/reader.go
@@ -29,6 +29,11 @@ type ReaderOptions struct {
 	// Expressions in Predicate may only reference columns in Columns.
 	// Holds a list of predicates that can be sequentially applied to the dataset.
 	Predicates []Predicate
+
+	// Prefetch enables bulk retrieving pages from the dataset when reading
+	// starts. To reduce read latency, this option should only be disabled when
+	// the entire Dataset is already held in memory.
+	Prefetch bool
 }
 
 // A Reader reads [Row]s from a [Dataset].
@@ -127,7 +132,7 @@ func (r *Reader) Read(ctx context.Context, s []Row) (n int, err error) {
 
 	// If there are no predicates, read all columns in the dataset
 	if len(r.opts.Predicates) == 0 {
-		count, err := r.inner.ReadColumns(ctx, r.dl.PrimaryColumns(), s[:readSize])
+		count, err := r.inner.ReadColumns(ctx, r.primaryColumns(), s[:readSize])
 		if err != nil && !errors.Is(err, io.EOF) {
 			return n, err
 		} else if count == 0 && errors.Is(err, io.EOF) {
@@ -150,7 +155,7 @@ func (r *Reader) Read(ctx context.Context, s []Row) (n int, err error) {
 		}
 	}
 
-	if secondary := r.dl.SecondaryColumns(); len(secondary) > 0 && passCount > 0 {
+	if secondary := r.secondaryColumns(); len(secondary) > 0 && passCount > 0 {
 		// Mask out any ranges that aren't in s[:passCount], so that filling in
 		// secondary columns doesn't consider downloading pages not used for the
 		// Fill.
@@ -436,13 +441,43 @@ func (r *Reader) init(ctx context.Context) error {
 	}
 
 	if r.inner == nil {
-		r.inner = newBasicReader(r.dl.AllColumns())
+		r.inner = newBasicReader(r.allColumns())
 	} else {
-		r.inner.Reset(r.dl.AllColumns())
+		r.inner.Reset(r.allColumns())
 	}
 
 	r.ready = true
 	return nil
+}
+
+// allColumns returns the full set of column to read. If r was configured with
+// prefetching, wrapped columns from [readerDownloader] are returned. Otherwise,
+// the columns of the original dataset are returned.
+func (r *Reader) allColumns() []Column {
+	if r.opts.Prefetch {
+		return r.dl.AllColumns()
+	}
+	return r.dl.OrigColumns()
+}
+
+// primaryColumns returns the primary columns to read. If r was configured with
+// prefetching, wrapped columns from [readerDownloader] are returned. Otherwise,
+// the primary columns of the original dataset are returned.
+func (r *Reader) primaryColumns() []Column {
+	if r.opts.Prefetch {
+		return r.dl.PrimaryColumns()
+	}
+	return r.dl.OrigPrimaryColumns()
+}
+
+// secondaryColumns returns the secondary columns to read. If r was configured with
+// prefetching, wrapped columns from [readerDownloader] are returned. Otherwise,
+// the secondary columns of the original dataset are returned.
+func (r *Reader) secondaryColumns() []Column {
+	if r.opts.Prefetch {
+		return r.dl.SecondaryColumns()
+	}
+	return r.dl.OrigSecondaryColumns()
 }
 
 // validatePredicate ensures that all columns used in a predicate have been
@@ -488,6 +523,8 @@ func (r *Reader) validatePredicate() error {
 	return err
 }
 
+// initDownloader initializes the reader's [readerDownloader]. initDownloader is
+// always used to reduce the number of conditions.
 func (r *Reader) initDownloader(ctx context.Context) error {
 	// The downloader is initialized in three steps:
 	//
@@ -545,7 +582,7 @@ func (r *Reader) initDownloader(ctx context.Context) error {
 	r.ranges = ranges
 
 	var rowsCount uint64
-	for _, column := range r.dl.AllColumns() {
+	for _, column := range r.allColumns() {
 		rowsCount = max(rowsCount, uint64(column.ColumnDesc().RowsCount))
 	}
 
@@ -639,7 +676,7 @@ func (r *Reader) buildPredicateRanges(ctx context.Context, p Predicate) (rowRang
 		if err != nil {
 			// Predicate can't be simplfied, so we permit the full range.
 			var rowsCount uint64
-			for _, column := range r.dl.AllColumns() {
+			for _, column := range r.allColumns() {
 				rowsCount = max(rowsCount, uint64(column.ColumnDesc().RowsCount))
 			}
 			return rowRanges{{Start: 0, End: rowsCount - 1}}, nil
@@ -668,7 +705,7 @@ func (r *Reader) buildPredicateRanges(ctx context.Context, p Predicate) (rowRang
 		// We use r.dl.AllColumns instead of r.opts.Columns because the downloader
 		// will cache metadata.
 		var rowsCount uint64
-		for _, column := range r.dl.AllColumns() {
+		for _, column := range r.allColumns() {
 			rowsCount = max(rowsCount, uint64(column.ColumnDesc().RowsCount))
 		}
 		return rowRanges{{Start: 0, End: rowsCount - 1}}, nil
@@ -749,7 +786,7 @@ func simplifyNotPredicate(p NotPredicate) (Predicate, error) {
 func (r *Reader) buildColumnPredicateRanges(ctx context.Context, c Column, p Predicate) (rowRanges, error) {
 	// Get the wrapped column so that the result of c.ListPages can be cached.
 	if idx, ok := r.origColumnLookup[c]; ok {
-		c = r.dl.AllColumns()[idx]
+		c = r.allColumns()[idx]
 	} else {
 		return nil, fmt.Errorf("column %v not found in Reader columns", c)
 	}
@@ -865,7 +902,7 @@ func (r *Reader) predicateColumns(p Predicate, keep func(c Column) bool) ([]Colu
 			panic(fmt.Errorf("predicateColumns: column %v not found in Reader columns", c))
 		}
 
-		c := r.dl.AllColumns()[idx]
+		c := r.allColumns()[idx]
 		if !keep(c) {
 			continue
 		}

--- a/pkg/dataobj/internal/dataset/reader.go
+++ b/pkg/dataobj/internal/dataset/reader.go
@@ -29,15 +29,6 @@ type ReaderOptions struct {
 	// Expressions in Predicate may only reference columns in Columns.
 	// Holds a list of predicates that can be sequentially applied to the dataset.
 	Predicates []Predicate
-
-	// TargetCacheSize configures the amount of memory to target for caching
-	// pages in memory. The cache may exceed this size if the combined size of
-	// all pages required for a single call to [Reader.Reead] exceeds this value.
-	//
-	// TargetCacheSize is used to download and cache additional pages in advance
-	// of when they're needed. If TargetCacheSize is 0, only immediately required
-	// pages are cached.
-	TargetCacheSize int
 }
 
 // A Reader reads [Row]s from a [Dataset].
@@ -505,9 +496,9 @@ func (r *Reader) initDownloader(ctx context.Context) error {
 	//   3. Provide the overall dataset row ranges that will be valid to read.
 
 	if r.dl == nil {
-		r.dl = newReaderDownloader(r.opts.Dataset, r.opts.TargetCacheSize)
+		r.dl = newReaderDownloader(r.opts.Dataset)
 	} else {
-		r.dl.Reset(r.opts.Dataset, r.opts.TargetCacheSize)
+		r.dl.Reset(r.opts.Dataset)
 	}
 
 	mask := bitmask.New(len(r.opts.Columns))

--- a/pkg/dataobj/internal/dataset/reader_downloader.go
+++ b/pkg/dataobj/internal/dataset/reader_downloader.go
@@ -83,8 +83,7 @@ import (
 // Cached pages before the read range are cleared when a new uncached page is
 // requested.
 type readerDownloader struct {
-	inner           Dataset
-	targetCacheSize int
+	inner Dataset
 
 	origColumns                    []Column
 	allColumns, primary, secondary []Column
@@ -98,9 +97,9 @@ type readerDownloader struct {
 // newReaderDataset creates a new readerDataset wrapping around an inner
 // Dataset. The resulting Dataset only wraps around the provided columns.
 //
-// The amount of cached pages will target the provided cache size; the actual
-// cache may be larger if the amount of required pages for a call to
-// [Reader.Read] exceeds targetCacheSize.
+// All uncached pages that have not been pruned by
+// [readerDownloader.SetDatasetRanges] will be downloaded in bulk when an
+// uncached page is requested.
 //
 // # Initialization
 //
@@ -123,9 +122,9 @@ type readerDownloader struct {
 // If applicable, users should additionally call [readerDownloader.Mask] to
 // exclude any ranges of rows that should not be read; pages that are entirely
 // within the mask will not be downloaded.
-func newReaderDownloader(dset Dataset, targetCacheSize int) *readerDownloader {
+func newReaderDownloader(dset Dataset) *readerDownloader {
 	var rd readerDownloader
-	rd.Reset(dset, targetCacheSize)
+	rd.Reset(dset)
 	return &rd
 }
 
@@ -277,10 +276,6 @@ func (dl *readerDownloader) buildDownloadBatch(ctx context.Context, requestor *r
 		}
 
 		pageBatch = append(pageBatch, page)
-		batchSize += page.PageDesc().CompressedSize
-	}
-	if batchSize >= dl.targetCacheSize {
-		return pageBatch, nil
 	}
 
 	// Now we add P2 and P3 pages. We ignore pages that would have us exceed the
@@ -303,16 +298,8 @@ func (dl *readerDownloader) buildDownloadBatch(ctx context.Context, requestor *r
 		} else if page == requestor {
 			continue // Already added.
 		}
-		pageSize := page.PageDesc().CompressedSize
-
-		if batchSize+pageSize >= dl.targetCacheSize {
-			// We ignore pages rather than stopping immediately
-			targetReached = true
-			continue
-		}
 
 		pageBatch = append(pageBatch, page)
-		batchSize += pageSize
 	}
 	if targetReached {
 		return pageBatch, nil
@@ -327,14 +314,8 @@ func (dl *readerDownloader) buildDownloadBatch(ctx context.Context, requestor *r
 		} else if page == requestor {
 			continue // Already added.
 		}
-		pageSize := page.PageDesc().CompressedSize
-
-		if batchSize+pageSize >= dl.targetCacheSize {
-			continue
-		}
 
 		pageBatch = append(pageBatch, page)
-		batchSize += pageSize
 	}
 
 	return pageBatch, nil
@@ -460,9 +441,8 @@ func (dl *readerDownloader) iterP3Pages(ctx context.Context, primary bool) resul
 	})
 }
 
-func (dl *readerDownloader) Reset(dset Dataset, targetCacheSize int) {
+func (dl *readerDownloader) Reset(dset Dataset) {
 	dl.inner = dset
-	dl.targetCacheSize = targetCacheSize
 
 	dl.readRange = rowRange{}
 

--- a/pkg/dataobj/sections/indexpointers/iter.go
+++ b/pkg/dataobj/sections/indexpointers/iter.go
@@ -51,8 +51,9 @@ func IterSection(ctx context.Context, section *Section) result.Seq[IndexPointer]
 		}
 
 		r := dataset.NewReader(dataset.ReaderOptions{
-			Dataset: dset,
-			Columns: columns,
+			Dataset:  dset,
+			Columns:  columns,
+			Prefetch: true,
 		})
 		defer r.Close()
 

--- a/pkg/dataobj/sections/indexpointers/row_reader.go
+++ b/pkg/dataobj/sections/indexpointers/row_reader.go
@@ -100,8 +100,6 @@ func (r *RowReader) initReader() error {
 		Dataset:    dset,
 		Columns:    columns,
 		Predicates: predicates,
-
-		TargetCacheSize: 16_000_000, // Permit up to 16MB of cache pages.
 	}
 
 	if r.reader == nil {

--- a/pkg/dataobj/sections/indexpointers/row_reader.go
+++ b/pkg/dataobj/sections/indexpointers/row_reader.go
@@ -100,6 +100,7 @@ func (r *RowReader) initReader() error {
 		Dataset:    dset,
 		Columns:    columns,
 		Predicates: predicates,
+		Prefetch:   true,
 	}
 
 	if r.reader == nil {

--- a/pkg/dataobj/sections/logs/iter.go
+++ b/pkg/dataobj/sections/logs/iter.go
@@ -53,8 +53,9 @@ func IterSection(ctx context.Context, section *Section) result.Seq[Record] {
 		}
 
 		r := dataset.NewReader(dataset.ReaderOptions{
-			Dataset: dset,
-			Columns: columns,
+			Dataset:  dset,
+			Columns:  columns,
+			Prefetch: true,
 		})
 		defer r.Close()
 

--- a/pkg/dataobj/sections/logs/reader.go
+++ b/pkg/dataobj/sections/logs/reader.go
@@ -31,12 +31,6 @@ type ReaderOptions struct {
 	// Allocator to use for allocating Arrow records. If nil,
 	// [memory.DefaultAllocator] is used.
 	Allocator memory.Allocator
-
-	// PageCacheSize is the total size of additional pages to prefetch into the
-	// reader that the reader may read on future calls. Pages are prefetched any
-	// time a new page is required up to this size. Setting to 0 disables
-	// prefetching additional pages.
-	PageCacheSize int
 }
 
 // Validate returns an error if the opts is not valid. ReaderOptions are only
@@ -266,10 +260,9 @@ func (r *Reader) init(ctx context.Context) error {
 	r.stats.LinkGlobalStats(stats.FromContext(ctx))
 
 	innerOptions := dataset.ReaderOptions{
-		Dataset:         dset,
-		Columns:         dset.Columns(),
-		Predicates:      orderPredicates(preds),
-		TargetCacheSize: r.opts.PageCacheSize,
+		Dataset:    dset,
+		Columns:    dset.Columns(),
+		Predicates: orderPredicates(preds),
 	}
 	if r.inner == nil {
 		r.inner = dataset.NewReader(innerOptions)

--- a/pkg/dataobj/sections/logs/reader.go
+++ b/pkg/dataobj/sections/logs/reader.go
@@ -263,6 +263,7 @@ func (r *Reader) init(ctx context.Context) error {
 		Dataset:    dset,
 		Columns:    dset.Columns(),
 		Predicates: orderPredicates(preds),
+		Prefetch:   true,
 	}
 	if r.inner == nil {
 		r.inner = dataset.NewReader(innerOptions)

--- a/pkg/dataobj/sections/logs/row_reader.go
+++ b/pkg/dataobj/sections/logs/row_reader.go
@@ -145,8 +145,6 @@ func (r *RowReader) initReader() error {
 		Dataset:    dset,
 		Columns:    columns,
 		Predicates: orderPredicates(predicates),
-
-		TargetCacheSize: 16_000_000, // Permit up to 16MB of cache pages.
 	}
 
 	if r.reader == nil {

--- a/pkg/dataobj/sections/logs/row_reader.go
+++ b/pkg/dataobj/sections/logs/row_reader.go
@@ -145,6 +145,7 @@ func (r *RowReader) initReader() error {
 		Dataset:    dset,
 		Columns:    columns,
 		Predicates: orderPredicates(predicates),
+		Prefetch:   true,
 	}
 
 	if r.reader == nil {

--- a/pkg/dataobj/sections/logs/table_merge.go
+++ b/pkg/dataobj/sections/logs/table_merge.go
@@ -72,6 +72,9 @@ func mergeTables(buf *tableBuffer, pageSize int, compressionOpts dataset.Compres
 		r := dataset.NewReader(dataset.ReaderOptions{
 			Dataset: t,
 			Columns: dsetColumns,
+
+			// The table is in memory, so don't prefetch.
+			Prefetch: false,
 		})
 
 		tableSequences = append(tableSequences, &tableSequence{

--- a/pkg/dataobj/sections/pointers/iter.go
+++ b/pkg/dataobj/sections/pointers/iter.go
@@ -52,8 +52,9 @@ func IterSection(ctx context.Context, section *Section) result.Seq[SectionPointe
 		}
 
 		r := dataset.NewReader(dataset.ReaderOptions{
-			Dataset: dset,
-			Columns: columns,
+			Dataset:  dset,
+			Columns:  columns,
+			Prefetch: true,
 		})
 		defer r.Close()
 

--- a/pkg/dataobj/sections/pointers/row_reader.go
+++ b/pkg/dataobj/sections/pointers/row_reader.go
@@ -133,8 +133,6 @@ func (r *RowReader) initReader() error {
 		Dataset:    dset,
 		Columns:    columns,
 		Predicates: predicates,
-
-		TargetCacheSize: 16_000_000, // Permit up to 16MB of cache pages.
 	}
 
 	if r.reader == nil {

--- a/pkg/dataobj/sections/pointers/row_reader.go
+++ b/pkg/dataobj/sections/pointers/row_reader.go
@@ -133,6 +133,7 @@ func (r *RowReader) initReader() error {
 		Dataset:    dset,
 		Columns:    columns,
 		Predicates: predicates,
+		Prefetch:   true,
 	}
 
 	if r.reader == nil {

--- a/pkg/dataobj/sections/streams/iter.go
+++ b/pkg/dataobj/sections/streams/iter.go
@@ -52,8 +52,9 @@ func IterSection(ctx context.Context, section *Section) result.Seq[Stream] {
 		}
 
 		r := dataset.NewReader(dataset.ReaderOptions{
-			Dataset: dset,
-			Columns: columns,
+			Dataset:  dset,
+			Columns:  columns,
+			Prefetch: true,
 		})
 		defer r.Close()
 

--- a/pkg/dataobj/sections/streams/reader.go
+++ b/pkg/dataobj/sections/streams/reader.go
@@ -260,6 +260,7 @@ func (r *Reader) init() error {
 		Dataset:    dset,
 		Columns:    dset.Columns(),
 		Predicates: preds,
+		Prefetch:   true,
 	}
 	if r.inner == nil {
 		r.inner = dataset.NewReader(innerOptions)

--- a/pkg/dataobj/sections/streams/reader.go
+++ b/pkg/dataobj/sections/streams/reader.go
@@ -30,12 +30,6 @@ type ReaderOptions struct {
 	// Allocator to use for allocating Arrow records. If nil,
 	// [memory.DefaultAllocator] is used.
 	Allocator memory.Allocator
-
-	// PageCacheSize is the total size of additional pages to prefetch into the
-	// reader that the reader may read on future calls. Pages are prefetched any
-	// time a new page is required up to this size. Setting to 0 disables
-	// prefetching additional pages.
-	PageCacheSize int
 }
 
 // Validate returns an error if the opts is not valid. ReaderOptions are only
@@ -263,10 +257,9 @@ func (r *Reader) init() error {
 	}
 
 	innerOptions := dataset.ReaderOptions{
-		Dataset:         dset,
-		Columns:         dset.Columns(),
-		Predicates:      preds,
-		TargetCacheSize: r.opts.PageCacheSize,
+		Dataset:    dset,
+		Columns:    dset.Columns(),
+		Predicates: preds,
 	}
 	if r.inner == nil {
 		r.inner = dataset.NewReader(innerOptions)

--- a/pkg/dataobj/sections/streams/row_reader.go
+++ b/pkg/dataobj/sections/streams/row_reader.go
@@ -103,6 +103,7 @@ func (r *RowReader) initReader() error {
 		Dataset:    dset,
 		Columns:    columns,
 		Predicates: predicates,
+		Prefetch:   true,
 	}
 
 	if r.reader == nil {

--- a/pkg/dataobj/sections/streams/row_reader.go
+++ b/pkg/dataobj/sections/streams/row_reader.go
@@ -103,8 +103,6 @@ func (r *RowReader) initReader() error {
 		Dataset:    dset,
 		Columns:    columns,
 		Predicates: predicates,
-
-		TargetCacheSize: 16_000_000, // Permit up to 16MB of cache pages.
 	}
 
 	if r.reader == nil {

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -193,10 +193,9 @@ func (e *QueryEngine) Execute(ctx context.Context, params logql.Params) (logqlmo
 		timer := prometheus.NewTimer(e.metrics.execution)
 
 		cfg := executor.Config{
-			BatchSize:                int64(e.opts.BatchSize),
-			MergePrefetchCount:       e.opts.MergePrefetchCount,
-			Bucket:                   e.bucket,
-			DataobjScanPageCacheSize: int64(e.opts.DataobjScanPageCacheSize),
+			BatchSize:          int64(e.opts.BatchSize),
+			MergePrefetchCount: e.opts.MergePrefetchCount,
+			Bucket:             e.bucket,
 		}
 		pipeline := executor.Run(ctx, cfg, physicalPlan, logger)
 		defer pipeline.Close()

--- a/pkg/engine/executor/dataobjscan.go
+++ b/pkg/engine/executor/dataobjscan.go
@@ -31,7 +31,6 @@ type dataobjScanOptions struct {
 	Allocator memory.Allocator // Allocator to use for reading sections and building records.
 
 	BatchSize int64 // The buffer size for reading rows, derived from the engine batch size.
-	CacheSize int   // The size of the page cache to use for reading sections.
 }
 
 type dataobjScan struct {
@@ -108,7 +107,6 @@ func (s *dataobjScan) initStreams() error {
 		StreamIDs:    s.opts.StreamIDs,
 		LabelColumns: columnsToRead,
 		BatchSize:    int(s.opts.BatchSize),
-		CacheSize:    s.opts.CacheSize,
 	})
 
 	s.streamsInjector = newStreamInjector(s.opts.Allocator, s.streams)
@@ -213,9 +211,8 @@ func (s *dataobjScan) initLogs() error {
 		// handle that?
 		Columns: columnsToRead,
 
-		Predicates:    predicates,
-		Allocator:     s.opts.Allocator,
-		PageCacheSize: s.opts.CacheSize,
+		Predicates: predicates,
+		Allocator:  s.opts.Allocator,
 	})
 
 	// Create the engine-compatible expected schema for the logs section.

--- a/pkg/engine/executor/executor.go
+++ b/pkg/engine/executor/executor.go
@@ -27,8 +27,7 @@ type Config struct {
 	BatchSize int64
 	Bucket    objstore.Bucket
 
-	DataobjScanPageCacheSize int64
-	MergePrefetchCount       int
+	MergePrefetchCount int
 }
 
 func Run(ctx context.Context, cfg Config, plan *physical.Plan, logger log.Logger) Pipeline {
@@ -38,8 +37,6 @@ func Run(ctx context.Context, cfg Config, plan *physical.Plan, logger log.Logger
 		mergePrefetchCount: cfg.MergePrefetchCount,
 		bucket:             cfg.Bucket,
 		logger:             logger,
-
-		dataobjScanPageCacheSize: cfg.DataobjScanPageCacheSize,
 	}
 	if plan == nil {
 		return errorPipeline(ctx, errors.New("plan is nil"))
@@ -60,8 +57,7 @@ type Context struct {
 	evaluator expressionEvaluator
 	bucket    objstore.Bucket
 
-	dataobjScanPageCacheSize int64
-	mergePrefetchCount       int
+	mergePrefetchCount int
 }
 
 func (c *Context) execute(ctx context.Context, node physical.Node) Pipeline {
@@ -202,7 +198,6 @@ func (c *Context) executeDataObjScan(ctx context.Context, node *physical.DataObj
 		Allocator: memory.DefaultAllocator,
 
 		BatchSize: c.batchSize,
-		CacheSize: int(c.dataobjScanPageCacheSize),
 	}, log.With(c.logger, "location", string(node.Location), "section", node.Section))
 
 	sortType, sortDirection, err := logsSection.PrimarySortOrder()

--- a/pkg/engine/executor/streams_view.go
+++ b/pkg/engine/executor/streams_view.go
@@ -26,7 +26,6 @@ type streamsView struct {
 	idColumn      *streams.Column
 	searchColumns []*streams.Column // stream ID + labels
 	batchSize     int
-	pageCacheSize int
 
 	initialized  bool
 	streams      arrow.Table
@@ -80,7 +79,6 @@ func newStreamsView(sec *streams.Section, opts *streamsViewOptions) *streamsView
 		idColumn:      streamsIDColumn,
 		searchColumns: append([]*streams.Column{streamsIDColumn}, cols...),
 		batchSize:     opts.BatchSize,
-		pageCacheSize: opts.CacheSize,
 	}
 }
 
@@ -154,9 +152,8 @@ func (v *streamsView) init(ctx context.Context) (err error) {
 	}
 
 	readerOptions := streams.ReaderOptions{
-		Columns:       v.searchColumns,
-		Allocator:     memory.DefaultAllocator,
-		PageCacheSize: v.pageCacheSize,
+		Columns:   v.searchColumns,
+		Allocator: memory.DefaultAllocator,
 	}
 
 	var scalarIDs []scalar.Scalar

--- a/pkg/logql/engine.go
+++ b/pkg/logql/engine.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/grafana/dskit/flagext"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/common/model"
@@ -172,26 +171,15 @@ type EngineOpts struct {
 	// MergePrefetchCount controls the number of inputs that are prefetched simultaneously by any Merge node.
 	MergePrefetchCount int `yaml:"merge_prefetch_count" category:"experimental"`
 
-	// DataobjScanPageCacheSize determines how many bytes of future page data
-	// should be downloaded before it's immediately needed. Used to reduce the
-	// number of roundtrips to object storage. Setting to zero disables
-	// downloading pages that are not immediately needed.
-	//
-	// This setting is only used when the v2 engine is being used.
-	DataobjScanPageCacheSize flagext.Bytes `yaml:"dataobjscan_page_cache_size" category:"experimental"`
-
 	// RangeConfig determines how to optimize range reads in the V2 engine.
 	RangeConfig rangeio.Config `yaml:"range_reads" category:"experimental" doc:"description=Configures how to read byte ranges from object storage when using the V2 engine."`
 }
 
 func (opts *EngineOpts) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
-	_ = opts.DataobjScanPageCacheSize.Set("0B")
-
 	f.DurationVar(&opts.MaxLookBackPeriod, prefix+"max-lookback-period", 30*time.Second, "The maximum amount of time to look back for log lines. Used only for instant log queries.")
 	f.IntVar(&opts.MaxCountMinSketchHeapSize, prefix+"max-count-min-sketch-heap-size", 10_000, "The maximum number of labels the heap of a topk query using a count min sketch can track.")
 	f.BoolVar(&opts.EnableV2Engine, prefix+"enable-v2-engine", false, "Experimental: Enable next generation query engine for supported queries.")
 	f.IntVar(&opts.BatchSize, prefix+"batch-size", 100, "Experimental: Batch size of the next generation query engine.")
-	f.Var(&opts.DataobjScanPageCacheSize, prefix+"dataobjscan-page-cache-size", "Experimental: Maximum total size of future pages for DataObjScan to download before they are needed, for roundtrip reduction to object storage. Setting to zero disables downloading future pages. Only used in the next generation query engine.")
 	f.IntVar(&opts.MergePrefetchCount, prefix+"merge-prefetch-count", 0, "Experimental: The number of inputs that are prefetched simultaneously by any Merge node. A value of 0 means that only the currently processed input is prefetched, 1 means that only the next input is prefetched, and so on. A negative value means that all inputs are be prefetched in parallel.")
 
 	// Log executing query by default


### PR DESCRIPTION
`dataset.readerDownloader` was originally introduced in #16429, an attempt to balance peak memory usage of reading a section with read times by downloading a configurable size of pages in advance. 

In practice, each roundtrip to object storage adds too much of a latency hit, and we've started to set the cache limit high enough to ensure that each reader only needs a single prefetch. Given what we've found, it no longer makes sense to control peak memory usage via the prefetch size. Other options, such as downloading directly to disk, may be explored in the future. 

In the meantime, this PR removes the ability to specify a cache size. All non-pruned pages will be bulk requested using the range reader (#19067) on the first read call. Pages which have left the potential read window will continue to be eagerly removed for garbage collection. 

However, we _don't_ want to prefetch when the dataset is entirely in memory, which is the case when the logs section builder is performing k-way merge over in-memory sections. To lower the memory usage of builders, prefetching is configurable. For this initial PR, prefetching is only disabled for the logs section builder; all other reads force prefetching. 