### PR TITLE
chore: should use IsZero() instead of comparison to time.Time{}

### DIFF
--- a/pkg/limits/service.go
+++ b/pkg/limits/service.go
@@ -220,7 +220,7 @@ func (s *Service) CheckReady(ctx context.Context) error {
 // partitions or the wait assign period has elapsed. It must not be called
 // without a lock on partitionReadinessMtx.
 func (s *Service) checkPartitionsAssigned(_ context.Context) error {
-	if s.partitionReadinessWaitAssignSince == (time.Time{}) {
+	if s.partitionReadinessWaitAssignSince.IsZero() {
 		s.partitionReadinessWaitAssignSince = s.clock.Now()
 	}
 	if s.clock.Since(s.partitionReadinessWaitAssignSince) < partitionReadinessWaitAssignPeriod {


### PR DESCRIPTION
**What this PR does / why we need it**:

Same behavior, but done properly 😄 . Why didn't I use `IsZero()` the first time? 😖 

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
