### PR TITLE
chore: Replace processingDelay histogram with a gauge metric

### DIFF
--- a/pkg/dataobj/index/builder.go
+++ b/pkg/dataobj/index/builder.go
@@ -371,7 +371,7 @@ func (p *Builder) buildIndex(ctx context.Context, events []metastore.ObjectWritt
 		level.Error(p.logger).Log("msg", "failed to parse write time", "err", err)
 		return err
 	}
-	p.metrics.observeProcessingDelay(writeTime)
+	p.metrics.setProcessingDelay(writeTime)
 
 	// Trigger the downloads
 	for _, event := range events {


### PR DESCRIPTION
**What this PR does / why we need it**:
This pull request replaces the dataobj-index-builder processing delay histogram metric with a latest delay gauge. I.e. the metric `loki_index_builder_processing_delay_seconds` replaced by `loki_index_builder_latest_processing_delay_seconds`.

**Which issue(s) this PR fixes**:
Fixes grafana/loki-private#1966

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
