### PR TITLE
chore(engine): print stringified physical planning duration

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -173,7 +173,7 @@ func (e *QueryEngine) Execute(ctx context.Context, params logql.Params) (logqlmo
 		level.Info(logger).Log(
 			"msg", "finished physical planning",
 			"plan", physical.PrintAsTree(plan),
-			"duration", durPhysicalPlanning.Seconds(),
+			"duration", durPhysicalPlanning.String(),
 		)
 		span.SetStatus(codes.Ok, "")
 		return plan, nil


### PR DESCRIPTION
This updates the duration printed when reporting physical planning completion as a stringified time.Duration rather than the number of sections. This makes it quite a lot easier to read when the duration is <100ms.
