### PR TITLE
fix: use cooperative active sticky load balancer

### DIFF
--- a/pkg/kafka/partitionring/consumer/client.go
+++ b/pkg/kafka/partitionring/consumer/client.go
@@ -38,7 +38,7 @@ func NewGroupClient(kafkaCfg kafka.Config, partitionRing ring.PartitionRingReade
 	defaultOpts := []kgo.Opt{
 		kgo.ConsumerGroup(groupName),
 		kgo.ConsumeTopics(kafkaCfg.Topic),
-		kgo.Balancers(kgo.CooperativeStickyBalancer()),
+		kgo.Balancers(NewCooperativeActiveStickyBalancer(partitionRing)),
 		kgo.ConsumeResetOffset(kgo.NewOffset().AtStart()),
 		kgo.DisableAutoCommit(),
 		kgo.RebalanceTimeout(5 * time.Minute),


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request updates dataobj-consumers to use the co-operative active sticky load balancer. It essentially works by making sure all active partitions are evenly distributed across all consumers using cooperative sticky, while any inactive partitions are distributed in a round-robin fashion to be drained.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
