### PR TITLE
docs: Update RN 3.5.5

### DIFF
--- a/docs/sources/release-notes/v3-5.md
+++ b/docs/sources/release-notes/v3-5.md
@@ -66,6 +66,16 @@ For important upgrade guidance, refer to the [Upgrade Guide](https://grafana.com
 
 ## Bug fixes
 
+### 3.5.5 (2025-09-11)
+
+* **otlp:** Backport fix to correctly calculate entry metadata size ([#19163](https://github.com/grafana/loki/issues/19163)) ([5aa8bd2](https://github.com/grafana/loki/commit/5aa8bd27946a1ce5267790ebe9210f93cd7111b2)).
+
+
+### 3.5.4 (2025-09-04)
+
+* **deps:** Update go version 1.24.6 in release-3.5.x ([#19096](https://github.com/grafana/loki/issues/19096)) ([ce8d705](https://github.com/grafana/loki/commit/ce8d70506c5bd905dd7ec7db8f174b9fcd264f30)).
+* **docs:** added instructions for how to upgrade zone-aware ingesters. ([#18663](https://github.com/grafana/loki/issues/18663)) ([e0de7da](https://github.com/grafana/loki/commit/e0de7dac098f66bb71000f591f4fb5bf4f5b81bf)).
+
 ### 3.5.3 (2025-07-23)
 
 * **deps:** Move to Go 1.24.5 ([#18412](https://github.com/grafana/loki/issues/18412)) ([2aa4680](https://github.com/grafana/loki/commit/2aa468065721587d0db829ff6b3cce9b73c10699)).


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates Release Notes for 3.5.5. patch
Adds RN for 3.5.4 patch to the main branch.