### PR TITLE
chore: Empty builder returns non-nil result

### DIFF
--- a/pkg/engine/compat.go
+++ b/pkg/engine/compat.go
@@ -25,12 +25,15 @@ type ResultBuilder interface {
 	Len() int
 }
 
-var _ ResultBuilder = &streamsResultBuilder{}
-var _ ResultBuilder = &vectorResultBuilder{}
-var _ ResultBuilder = &matrixResultBuilder{}
+var (
+	_ ResultBuilder = &streamsResultBuilder{}
+	_ ResultBuilder = &vectorResultBuilder{}
+	_ ResultBuilder = &matrixResultBuilder{}
+)
 
 func newStreamsResultBuilder() *streamsResultBuilder {
 	return &streamsResultBuilder{
+		data:    make(logqlmodel.Streams, 0),
 		streams: make(map[string]int),
 	}
 }

--- a/pkg/engine/compat_test.go
+++ b/pkg/engine/compat_test.go
@@ -31,6 +31,12 @@ func TestStreamsResultBuilder(t *testing.T) {
 	mdTypeLabel := datatype.ColumnMetadata(types.ColumnTypeLabel, datatype.Loki.String)
 	mdTypeMetadata := datatype.ColumnMetadata(types.ColumnTypeMetadata, datatype.Loki.String)
 
+	t.Run("empty builder returns non-nil result", func(t *testing.T) {
+		builder := newStreamsResultBuilder()
+		md, _ := metadata.NewContext(t.Context())
+		require.NotNil(t, builder.Build(stats.Result{}, md).Data)
+	})
+
 	t.Run("rows without log line, timestamp, or labels are ignored", func(t *testing.T) {
 		schema := arrow.NewSchema(
 			[]arrow.Field{
@@ -165,6 +171,12 @@ func TestVectorResultBuilder(t *testing.T) {
 	alloc := memory.NewCheckedAllocator(memory.DefaultAllocator)
 	defer alloc.AssertSize(t, 0)
 
+	t.Run("empty builder returns non-nil result", func(t *testing.T) {
+		builder := newVectorResultBuilder()
+		md, _ := metadata.NewContext(t.Context())
+		require.NotNil(t, builder.Build(stats.Result{}, md).Data)
+	})
+
 	t.Run("successful conversion of vector data", func(t *testing.T) {
 		schema := arrow.NewSchema(
 			[]arrow.Field{
@@ -253,6 +265,12 @@ func TestMatrixResultBuilder(t *testing.T) {
 	mdTypeString := datatype.ColumnMetadata(types.ColumnTypeAmbiguous, datatype.Loki.String)
 	alloc := memory.NewCheckedAllocator(memory.DefaultAllocator)
 	defer alloc.AssertSize(t, 0)
+
+	t.Run("empty builder returns non-nil result", func(t *testing.T) {
+		builder := newMatrixResultBuilder()
+		md, _ := metadata.NewContext(t.Context())
+		require.NotNil(t, builder.Build(stats.Result{}, md).Data)
+	})
 
 	t.Run("successful conversion of matrix data", func(t *testing.T) {
 		schema := arrow.NewSchema(


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes the LogQL correctness test suite for empty result sets.

* Right now, the new engine returns `nil` Data but the chunk engine returned an empty Data slice.
* Added tests for all 3 builders to ensure this doesn't regress later.
```
    bench_test.go:202: 
        	Error Trace:	/Users/benclive/dev/loki/pkg/logql/bench/bench_test.go:202
        	Error:      	Not equal: 
        	            	expected: logqlmodel.Streams{}
        	            	actual  : logqlmodel.Streams(nil)
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1,3 +1,2 @@
        	            	-(logqlmodel.Streams) {
        	            	-}
        	            	+(logqlmodel.Streams) <nil>
        	            	 
        	Test:       	TestStorageEquality/query={service_name="kubernetes"}_|~_"error|exception"_|_detected_level="error"_[FORWARD]/kind=log/store=dataobj-engine
        	Messages:   	store "dataobj-engine" results do not match base store "chunk"
```

**Which issue(s) this PR fixes**:
Part of https://github.com/grafana/loki-private/issues/1965
