### PR TITLE
chore: rename ExtractIngesterPartitionID() to make it generic

### DIFF
--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -365,7 +365,7 @@ func New(cfg Config, clientConfig client.Config, store Store, limits Limits, con
 	i.lifecyclerWatcher.WatchService(i.lifecycler)
 
 	if i.cfg.KafkaIngestion.Enabled {
-		i.ingestPartitionID, err = partitionring.ExtractIngesterPartitionID(cfg.LifecyclerConfig.ID)
+		i.ingestPartitionID, err = partitionring.ExtractPartitionID(cfg.LifecyclerConfig.ID)
 		if err != nil {
 			return nil, fmt.Errorf("calculating ingester partition ID: %w", err)
 		}

--- a/pkg/kafka/partitionring/parition_ring_test.go
+++ b/pkg/kafka/partitionring/parition_ring_test.go
@@ -37,9 +37,9 @@ func TestExtractIngesterPartitionID(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := ExtractIngesterPartitionID(tt.ingesterID)
+			got, err := ExtractPartitionID(tt.ingesterID)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("extractIngesterPartitionID() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("extractPartitionID() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if got != tt.want {


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request renames `ExtractIngesterPartitionID` to make it generic as we use the partition ring in more services.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
