### PR TITLE
chore: Run equality tests nightly

### DIFF
--- a/.github/workflows/logql-correctness.yml
+++ b/.github/workflows/logql-correctness.yml
@@ -1,5 +1,7 @@
 name: LogQL correctness tests
 on:
+  schedule:
+    - cron: "30 2 * * 1-5" # Mon-Fri at 2.30am UTC
   workflow_dispatch:
     inputs:
       ref:
@@ -7,15 +9,10 @@ on:
         required: false
         default: 'main'
         type: 'string'
-      test_dataobj_old_engine:
-        description: 'Benchmark data object store with old engine'
-        required: false
-        default: true
-        type: 'boolean'
       test_dataobj_new_engine:
         description: 'Benchmark data object store with new engine'
         required: false
-        default: false # Disabled by default due to less complete implementation
+        default: true
         type: 'boolean'
       failfast:
         description: 'Fail fast on first test failure'
@@ -37,7 +34,7 @@ jobs:
         id: checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.ref }}
+          ref: ${{ inputs.ref || 'main' }}
 
       - name: Setup Go
         uses: actions/setup-go@v4
@@ -71,8 +68,7 @@ jobs:
           STORES=()
 
           # Use explicit equality checks to avoid template injection.
-          ${{ inputs.test_dataobj_old_engine == true }} && STORES+=("dataobj")
-          ${{ inputs.test_dataobj_new_engine == true }} && STORES+=("dataobj-engine")
+          ${{ !contains(inputs.test_dataobj_new_engine, 'false') }} && STORES+=("dataobj-engine")
 
           MATRIX_JSON=$(jq -nc --arg stores "${STORES[*]}" '{"store": $stores | split(" ")}')
           echo "matrix=$MATRIX_JSON" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a schedule trigger to run the correctness tests in Github actions every weekday at 2.30AM UTC

* Only workflow_dispatch events let you add inputs, so the scheduled run has to default the values within the actions themselves.
* I used the contains method, as outlined [here](https://stackoverflow.com/questions/72539900/schedule-trigger-github-action-workflow-with-input-parameters), to default the boolean param to true when using a scheduled run.
* I haven't tested this yet.