### PR TITLE
chore: Refactor dataobj index builder to handle buffered events from stale partitions

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -1163,10 +1163,6 @@ dataobj:
     # CLI flag: -dataobj-index-builder.max-idle-time
     [max_idle_time: <duration> | default = 30m]
 
-    # Experimental: Minimum number of events required to trigger a flush
-    # CLI flag: -dataobj-index-builder.min-flush-events
-    [min_flush_events: <int> | default = 8]
-
   metastore:
     # Experimental: A prefix to use for storing indexes in object storage. Used
     # for testing only.

--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -1155,6 +1155,18 @@ dataobj:
     # CLI flag: -dataobj-index-builder.events-per-index
     [events_per_index: <int> | default = 32]
 
+    # Experimental: How often to check for stale partitions to flush
+    # CLI flag: -dataobj-index-builder.flush-interval
+    [flush_interval: <duration> | default = 10s]
+
+    # Experimental: Maximum time to wait before flushing buffered events
+    # CLI flag: -dataobj-index-builder.max-idle-time
+    [max_idle_time: <duration> | default = 30s]
+
+    # Experimental: Minimum number of events required to trigger a flush
+    # CLI flag: -dataobj-index-builder.min-flush-events
+    [min_flush_events: <int> | default = 1]
+
   metastore:
     # Experimental: A prefix to use for storing indexes in object storage. Used
     # for testing only.

--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -1157,15 +1157,15 @@ dataobj:
 
     # Experimental: How often to check for stale partitions to flush
     # CLI flag: -dataobj-index-builder.flush-interval
-    [flush_interval: <duration> | default = 10s]
+    [flush_interval: <duration> | default = 1m]
 
     # Experimental: Maximum time to wait before flushing buffered events
     # CLI flag: -dataobj-index-builder.max-idle-time
-    [max_idle_time: <duration> | default = 30s]
+    [max_idle_time: <duration> | default = 30m]
 
     # Experimental: Minimum number of events required to trigger a flush
     # CLI flag: -dataobj-index-builder.min-flush-events
-    [min_flush_events: <int> | default = 1]
+    [min_flush_events: <int> | default = 8]
 
   metastore:
     # Experimental: A prefix to use for storing indexes in object storage. Used

--- a/pkg/dataobj/index/builder.go
+++ b/pkg/dataobj/index/builder.go
@@ -34,6 +34,17 @@ const (
 	triggerTypeFlush  triggerType = "flush"
 )
 
+func (tt triggerType) String() string {
+	switch tt {
+	case triggerTypeAppend:
+		return "append"
+	case triggerTypeFlush:
+		return "flush"
+	default:
+		return "unknown"
+	}
+}
+
 type bufferedEvent struct {
 	event  metastore.ObjectWrittenEvent
 	record *kgo.Record
@@ -439,7 +450,7 @@ func (p *Builder) bufferAndTryProcess(partition int32, newEvent *bufferedEvent, 
 			return nil, nil
 		}
 	default:
-		level.Error(p.logger).Log("msg", "unknown trigger type", "trigger", string(trigger))
+		level.Error(p.logger).Log("msg", "unknown trigger type")
 		return nil, nil
 	}
 
@@ -454,7 +465,7 @@ func (p *Builder) bufferAndTryProcess(partition int32, newEvent *bufferedEvent, 
 	p.cancelActiveCalculation = cancel
 
 	level.Debug(p.logger).Log("msg", "started processing partition",
-		"partition", partition, "events", len(eventsToProcess), "trigger", string(trigger))
+		"partition", partition, "events", len(eventsToProcess), "trigger", trigger)
 
 	return ctx, eventsToProcess
 }

--- a/pkg/dataobj/index/builder.go
+++ b/pkg/dataobj/index/builder.go
@@ -115,9 +115,14 @@ func NewIndexBuilder(
 		"component": "index_builder",
 	}, reg)
 
-	metrics := newBuilderMetrics()
-	if err := metrics.register(builderReg); err != nil {
+	builderMetrics := newBuilderMetrics()
+	if err := builderMetrics.register(builderReg); err != nil {
 		return nil, fmt.Errorf("failed to register metrics for index builder: %w", err)
+	}
+
+	indexerMetrics := newIndexerMetrics()
+	if err := indexerMetrics.register(builderReg); err != nil {
+		return nil, fmt.Errorf("failed to register indexer metrics: %w", err)
 	}
 
 	// Create index building dependencies
@@ -137,7 +142,7 @@ func NewIndexBuilder(
 		cfg:             cfg,
 		mCfg:            mCfg,
 		logger:          logger,
-		metrics:         metrics,
+		metrics:         builderMetrics,
 		partitionStates: make(map[int32]*partitionState),
 	}
 
@@ -146,7 +151,8 @@ func NewIndexBuilder(
 		calculator,
 		bucket,
 		indexStorageBucket,
-		metrics,
+		builderMetrics,
+		indexerMetrics,
 		logger,
 		indexerConfig{QueueSize: 64},
 	)

--- a/pkg/dataobj/index/builder.go
+++ b/pkg/dataobj/index/builder.go
@@ -298,7 +298,7 @@ func (p *Builder) stopping(failureCase error) error {
 	}
 	p.wg.Wait()
 	p.client.Close()
-	return nil
+	return failureCase
 }
 
 // processRecord processes a single record. It is not safe for concurrent use.

--- a/pkg/dataobj/index/builder_test.go
+++ b/pkg/dataobj/index/builder_test.go
@@ -65,7 +65,6 @@ func TestIndexBuilder_PartitionRevocation(t *testing.T) {
 		prometheus.NewRegistry(),
 	)
 	require.NoError(t, err)
-	builder.ctx = ctx
 	builder.client.Close()
 	builder.client = &mockKafkaClient{}
 
@@ -91,7 +90,7 @@ func TestIndexBuilder_PartitionRevocation(t *testing.T) {
 		if i == 2 {
 			trigger <- struct{}{}
 		}
-		builder.processRecord(&kgo.Record{
+		builder.processRecord(ctx, &kgo.Record{
 			Value:     eventBytes,
 			Partition: int32(1),
 		})
@@ -156,7 +155,7 @@ func TestIndexBuilder(t *testing.T) {
 		eventBytes, err := event.Marshal()
 		require.NoError(t, err)
 
-		p.processRecord(&kgo.Record{
+		p.processRecord(context.Background(), &kgo.Record{
 			Value:     eventBytes,
 			Partition: int32(0),
 		})

--- a/pkg/dataobj/index/builder_test.go
+++ b/pkg/dataobj/index/builder_test.go
@@ -130,9 +130,9 @@ func TestIndexBuilder_PartitionRevocation(t *testing.T) {
 			Partition: int32(1),
 		})
 		if i < 2 {
-			// After revocation is triggered, we can't guarantee that the partition will be in the buffered events map.
-			require.NotNil(t, builder.bufferedEvents[1])
-			require.Len(t, builder.bufferedEvents[1], 0)
+			// After revocation is triggered, we can't guarantee that the partition will be in the partition states map.
+			require.NotNil(t, builder.partitionStates[1])
+			require.Len(t, builder.partitionStates[1].events, 0)
 		}
 	}
 	// Verify that the first records were processed successfully.
@@ -140,8 +140,8 @@ func TestIndexBuilder_PartitionRevocation(t *testing.T) {
 	require.NotNil(t, builder.calculator.(*mockCalculator).object)
 
 	// Verify that the partition was revoked.
-	require.Equal(t, 2, len(builder.bufferedEvents))
-	require.Nil(t, builder.bufferedEvents[1])
+	require.Equal(t, 2, len(builder.partitionStates))
+	require.Nil(t, builder.partitionStates[1])
 }
 
 func TestIndexBuilder(t *testing.T) {

--- a/pkg/dataobj/index/config.go
+++ b/pkg/dataobj/index/config.go
@@ -22,7 +22,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	cfg.BuilderConfig.RegisterFlagsWithPrefix(prefix, f)
 	f.IntVar(&cfg.EventsPerIndex, prefix+"events-per-index", 32, "Experimental: The number of events to batch before building an index")
-	f.DurationVar(&cfg.FlushInterval, prefix+"flush-interval", 10*time.Second, "Experimental: How often to check for stale partitions to flush")
-	f.DurationVar(&cfg.MaxIdleTime, prefix+"max-idle-time", 30*time.Second, "Experimental: Maximum time to wait before flushing buffered events")
-	f.IntVar(&cfg.MinFlushEvents, prefix+"min-flush-events", 1, "Experimental: Minimum number of events required to trigger a flush")
+	f.DurationVar(&cfg.FlushInterval, prefix+"flush-interval", 1*time.Minute, "Experimental: How often to check for stale partitions to flush")
+	f.DurationVar(&cfg.MaxIdleTime, prefix+"max-idle-time", 30*time.Minute, "Experimental: Maximum time to wait before flushing buffered events")
+	f.IntVar(&cfg.MinFlushEvents, prefix+"min-flush-events", 8, "Experimental: Minimum number of events required to trigger a flush")
 }

--- a/pkg/dataobj/index/config.go
+++ b/pkg/dataobj/index/config.go
@@ -12,7 +12,6 @@ type Config struct {
 	EventsPerIndex         int           `yaml:"events_per_index" experimental:"true"`
 	FlushInterval          time.Duration `yaml:"flush_interval" experimental:"true"`
 	MaxIdleTime            time.Duration `yaml:"max_idle_time" experimental:"true"`
-	MinFlushEvents         int           `yaml:"min_flush_events" experimental:"true"`
 }
 
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
@@ -24,5 +23,4 @@ func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.IntVar(&cfg.EventsPerIndex, prefix+"events-per-index", 32, "Experimental: The number of events to batch before building an index")
 	f.DurationVar(&cfg.FlushInterval, prefix+"flush-interval", 1*time.Minute, "Experimental: How often to check for stale partitions to flush")
 	f.DurationVar(&cfg.MaxIdleTime, prefix+"max-idle-time", 30*time.Minute, "Experimental: Maximum time to wait before flushing buffered events")
-	f.IntVar(&cfg.MinFlushEvents, prefix+"min-flush-events", 8, "Experimental: Minimum number of events required to trigger a flush")
 }

--- a/pkg/dataobj/index/config.go
+++ b/pkg/dataobj/index/config.go
@@ -1,0 +1,28 @@
+package index
+
+import (
+	"flag"
+	"time"
+
+	"github.com/grafana/loki/v3/pkg/dataobj/index/indexobj"
+)
+
+type Config struct {
+	indexobj.BuilderConfig `yaml:",inline"`
+	EventsPerIndex         int           `yaml:"events_per_index" experimental:"true"`
+	FlushInterval          time.Duration `yaml:"flush_interval" experimental:"true"`
+	MaxIdleTime            time.Duration `yaml:"max_idle_time" experimental:"true"`
+	MinFlushEvents         int           `yaml:"min_flush_events" experimental:"true"`
+}
+
+func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
+	cfg.RegisterFlagsWithPrefix("dataobj-index-builder.", f)
+}
+
+func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
+	cfg.BuilderConfig.RegisterFlagsWithPrefix(prefix, f)
+	f.IntVar(&cfg.EventsPerIndex, prefix+"events-per-index", 32, "Experimental: The number of events to batch before building an index")
+	f.DurationVar(&cfg.FlushInterval, prefix+"flush-interval", 10*time.Second, "Experimental: How often to check for stale partitions to flush")
+	f.DurationVar(&cfg.MaxIdleTime, prefix+"max-idle-time", 30*time.Second, "Experimental: Maximum time to wait before flushing buffered events")
+	f.IntVar(&cfg.MinFlushEvents, prefix+"min-flush-events", 1, "Experimental: Minimum number of events required to trigger a flush")
+}

--- a/pkg/dataobj/index/indexer.go
+++ b/pkg/dataobj/index/indexer.go
@@ -168,7 +168,7 @@ func (si *serialIndexer) submitBuild(ctx context.Context, events []bufferedEvent
 	case si.buildRequestChan <- req:
 		si.indexerMetrics.incRequests()
 		level.Debug(si.logger).Log("msg", "submitted build request",
-			"partition", partition, "events", len(events), "trigger", string(trigger))
+			"partition", partition, "events", len(events), "trigger", trigger)
 	case <-ctx.Done():
 		return nil, ctx.Err()
 	}
@@ -293,7 +293,7 @@ func (si *serialIndexer) processBuildRequest(req buildRequest) buildResult {
 	start := time.Now()
 
 	level.Debug(si.logger).Log("msg", "processing build request",
-		"partition", req.partition, "events", len(req.events), "trigger", string(req.trigger))
+		"partition", req.partition, "events", len(req.events), "trigger", req.trigger)
 
 	// Extract events for building
 	events := make([]metastore.ObjectWrittenEvent, len(req.events))

--- a/pkg/dataobj/index/indexer.go
+++ b/pkg/dataobj/index/indexer.go
@@ -1,0 +1,493 @@
+package index
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"sync"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/multierror"
+	"github.com/grafana/dskit/services"
+	"github.com/thanos-io/objstore"
+	"github.com/twmb/franz-go/pkg/kgo"
+
+	"github.com/grafana/loki/v3/pkg/dataobj"
+	"github.com/grafana/loki/v3/pkg/dataobj/metastore"
+)
+
+// ObjectKey generates the object key for storing an index object in object storage.
+// This is a public wrapper around the generateObjectKey functionality.
+func ObjectKey(ctx context.Context, object *dataobj.Object) (string, error) {
+	h := sha256.New224()
+
+	reader, err := object.Reader(ctx)
+	if err != nil {
+		return "", err
+	}
+	defer reader.Close()
+
+	if _, err := io.Copy(h, reader); err != nil {
+		return "", err
+	}
+
+	var sumBytes [sha256.Size224]byte
+	sum := h.Sum(sumBytes[:0])
+	sumStr := hex.EncodeToString(sum[:])
+
+	return fmt.Sprintf("indexes/%s/%s", sumStr[:2], sumStr[2:]), nil
+}
+
+// buildRequest represents a request to build an index
+type buildRequest struct {
+	events     []bufferedEvent
+	partition  int32
+	trigger    triggerType
+	ctx        context.Context
+	resultChan chan buildResult
+}
+
+// buildResult represents the result of an index build operation
+type buildResult struct {
+	indexPath string
+	records   []*kgo.Record // Records to commit after successful build
+	err       error
+}
+
+// indexerConfig contains configuration for the indexer
+type indexerConfig struct {
+	QueueSize int // Size of the build request queue
+}
+
+// indexer handles serialized index building operations
+type indexer interface {
+	services.Service
+
+	// submitBuild submits a build request and waits for completion
+	submitBuild(ctx context.Context, events []bufferedEvent, partition int32, trigger triggerType) (string, []*kgo.Record, error)
+
+	// GetMetrics returns current indexer metrics
+	GetMetrics() map[string]interface{}
+}
+
+// serialIndexer implements Indexer with a single worker goroutine using dskit Service
+type serialIndexer struct {
+	services.Service
+
+	// Dependencies - no builder dependency!
+	calculator         calculator
+	objectBucket       objstore.Bucket
+	indexStorageBucket objstore.Bucket
+	metrics            *builderMetrics
+	logger             log.Logger
+
+	// Download pipeline
+	downloadQueue     chan metastore.ObjectWrittenEvent
+	downloadedObjects chan downloadedObject
+
+	// Worker management
+	buildRequestChan chan buildRequest
+	buildWorkerWg    sync.WaitGroup
+	downloadWorkerWg sync.WaitGroup
+
+	// Metrics
+	totalRequests  int64
+	totalBuilds    int64
+	totalBuildTime time.Duration
+	buildTimeMutex sync.RWMutex
+}
+
+// newSerialIndexer creates a new self-contained SerialIndexer
+func newSerialIndexer(
+	calculator calculator,
+	objectBucket objstore.Bucket,
+	indexStorageBucket objstore.Bucket,
+	metrics *builderMetrics,
+	logger log.Logger,
+	cfg indexerConfig,
+) *serialIndexer {
+	if cfg.QueueSize == 0 {
+		cfg.QueueSize = 64
+	}
+
+	si := &serialIndexer{
+		calculator:         calculator,
+		objectBucket:       objectBucket,
+		indexStorageBucket: indexStorageBucket,
+		metrics:            metrics,
+		logger:             logger,
+		buildRequestChan:   make(chan buildRequest, cfg.QueueSize),
+		downloadQueue:      make(chan metastore.ObjectWrittenEvent, 32),
+		downloadedObjects:  make(chan downloadedObject, 1),
+	}
+
+	// Initialize dskit Service
+	si.Service = services.NewBasicService(si.starting, si.running, si.stopping)
+
+	return si
+}
+
+// starting is called when the service is starting
+func (si *serialIndexer) starting(_ context.Context) error {
+	level.Info(si.logger).Log("msg", "starting serial indexer")
+	return nil
+}
+
+// running is the main service loop
+func (si *serialIndexer) running(ctx context.Context) error {
+	level.Info(si.logger).Log("msg", "serial indexer running")
+
+	// Start download worker
+	si.downloadWorkerWg.Add(1)
+	go si.downloadWorker(ctx)
+
+	// Start build worker
+	si.buildWorkerWg.Add(1)
+	go si.buildWorker(ctx)
+
+	// Wait for context cancellation
+	<-ctx.Done()
+	return nil
+}
+
+// stopping is called when the service is stopping
+func (si *serialIndexer) stopping(_ error) error {
+	level.Info(si.logger).Log("msg", "stopping serial indexer")
+
+	// Close channels to signal workers to stop
+	close(si.downloadQueue)
+	close(si.buildRequestChan)
+
+	// Wait for workers to finish
+	si.downloadWorkerWg.Wait()
+	si.buildWorkerWg.Wait()
+
+	// Close the downloaded objects channel after workers are done
+	close(si.downloadedObjects)
+
+	level.Info(si.logger).Log("msg", "stopped serial indexer")
+	return nil
+}
+
+// submitBuild submits a build request and waits for completion
+func (si *serialIndexer) submitBuild(ctx context.Context, events []bufferedEvent, partition int32, trigger triggerType) (string, []*kgo.Record, error) {
+	// Check if service is running
+	if si.State() != services.Running {
+		return "", nil, fmt.Errorf("indexer service is not running (state: %s)", si.State())
+	}
+
+	resultChan := make(chan buildResult, 1)
+
+	req := buildRequest{
+		events:     events,
+		partition:  partition,
+		trigger:    trigger,
+		ctx:        ctx,
+		resultChan: resultChan,
+	}
+
+	// Submit request
+	select {
+	case si.buildRequestChan <- req:
+		si.totalRequests++
+		level.Debug(si.logger).Log("msg", "submitted build request",
+			"partition", partition, "events", len(events), "trigger", string(trigger))
+	case <-ctx.Done():
+		return "", nil, ctx.Err()
+	}
+
+	// Wait for result
+	select {
+	case result := <-resultChan:
+		if result.err != nil {
+			level.Error(si.logger).Log("msg", "build request failed",
+				"partition", partition, "err", result.err)
+		} else {
+			level.Debug(si.logger).Log("msg", "build request completed",
+				"partition", partition, "index_path", result.indexPath)
+		}
+		return result.indexPath, result.records, result.err
+	case <-ctx.Done():
+		return "", nil, ctx.Err()
+	}
+}
+
+// downloadWorker handles object downloads
+func (si *serialIndexer) downloadWorker(ctx context.Context) {
+	defer si.downloadWorkerWg.Done()
+
+	level.Debug(si.logger).Log("msg", "download worker started")
+	defer level.Debug(si.logger).Log("msg", "download worker stopped")
+
+	for {
+		select {
+		case event, ok := <-si.downloadQueue:
+			if !ok {
+				// Channel closed, worker should exit
+				return
+			}
+
+			objLogger := log.With(si.logger, "object_path", event.ObjectPath)
+			downloadStart := time.Now()
+
+			objectReader, err := si.objectBucket.Get(ctx, event.ObjectPath)
+			if err != nil {
+				select {
+				case si.downloadedObjects <- downloadedObject{
+					event: event,
+					err:   fmt.Errorf("failed to fetch object from storage: %w", err),
+				}:
+				case <-ctx.Done():
+					return
+				}
+				continue
+			}
+
+			object, err := io.ReadAll(objectReader)
+			_ = objectReader.Close()
+			if err != nil {
+				select {
+				case si.downloadedObjects <- downloadedObject{
+					event: event,
+					err:   fmt.Errorf("failed to read object: %w", err),
+				}:
+				case <-ctx.Done():
+					return
+				}
+				continue
+			}
+
+			level.Info(objLogger).Log("msg", "downloaded object", "duration", time.Since(downloadStart),
+				"size_mb", float64(len(object))/1024/1024,
+				"avg_speed_mbps", float64(len(object))/time.Since(downloadStart).Seconds()/1024/1024)
+
+			select {
+			case si.downloadedObjects <- downloadedObject{
+				event:       event,
+				objectBytes: &object,
+			}:
+			case <-ctx.Done():
+				return
+			}
+
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+// buildWorker is the main worker goroutine that processes build requests
+func (si *serialIndexer) buildWorker(ctx context.Context) {
+	defer si.buildWorkerWg.Done()
+
+	level.Info(si.logger).Log("msg", "build worker started")
+	defer level.Info(si.logger).Log("msg", "build worker stopped")
+
+	for {
+		select {
+		case req, ok := <-si.buildRequestChan:
+			if !ok {
+				// Channel closed, worker should exit
+				return
+			}
+
+			result := si.processBuildRequest(req)
+
+			select {
+			case req.resultChan <- result:
+				// Result delivered successfully
+			case <-req.ctx.Done():
+				// Request was cancelled, but we already did the work
+				level.Debug(si.logger).Log("msg", "build request was cancelled after completion",
+					"partition", req.partition)
+			case <-ctx.Done():
+				// Service is shutting down
+				return
+			}
+
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+// processBuildRequest processes a single build request - contains the full buildIndex logic
+func (si *serialIndexer) processBuildRequest(req buildRequest) buildResult {
+	start := time.Now()
+
+	level.Debug(si.logger).Log("msg", "processing build request",
+		"partition", req.partition, "events", len(req.events), "trigger", string(req.trigger))
+
+	// Extract events for building
+	events := make([]metastore.ObjectWrittenEvent, len(req.events))
+	for i, buffered := range req.events {
+		events[i] = buffered.event
+	}
+
+	// Extract records for committing
+	records := make([]*kgo.Record, len(req.events))
+	for i, buffered := range req.events {
+		records[i] = buffered.record
+	}
+
+	// Build the index using internal method
+	indexPath, err := si.buildIndex(req.ctx, events, req.partition)
+
+	// Update metrics
+	buildTime := time.Since(start)
+	si.updateBuildMetrics(buildTime, err)
+
+	if err != nil {
+		level.Error(si.logger).Log("msg", "failed to build index",
+			"partition", req.partition, "err", err, "duration", buildTime)
+		return buildResult{err: err}
+	}
+
+	level.Debug(si.logger).Log("msg", "successfully built index",
+		"partition", req.partition, "index_path", indexPath, "duration", buildTime,
+		"events", len(events))
+
+	return buildResult{
+		indexPath: indexPath,
+		records:   records,
+		err:       nil,
+	}
+}
+
+// buildIndex is the core index building logic (moved from builder)
+func (si *serialIndexer) buildIndex(ctx context.Context, events []metastore.ObjectWrittenEvent, partition int32) (string, error) {
+	level.Debug(si.logger).Log("msg", "building index", "events", len(events), "partition", partition)
+	start := time.Now()
+
+	// Observe processing delay
+	writeTime, err := time.Parse(time.RFC3339, events[0].WriteTime)
+	if err != nil {
+		level.Error(si.logger).Log("msg", "failed to parse write time", "err", err)
+		return "", err
+	}
+	si.metrics.setProcessingDelay(writeTime)
+
+	// Trigger the downloads
+	for _, event := range events {
+		select {
+		case si.downloadQueue <- event:
+			// Successfully sent event for download
+		case <-ctx.Done():
+			return "", ctx.Err()
+		default:
+			// Channel might be closed or full, check context first
+			select {
+			case <-ctx.Done():
+				return "", ctx.Err()
+			default:
+				// Try to send with context check
+				select {
+				case si.downloadQueue <- event:
+				case <-ctx.Done():
+					return "", ctx.Err()
+				}
+			}
+		}
+	}
+
+	// Process the results as they are downloaded
+	processingErrors := multierror.New()
+	for i := 0; i < len(events); i++ {
+		var obj downloadedObject
+		select {
+		case obj = <-si.downloadedObjects:
+		case <-ctx.Done():
+			return "", ctx.Err()
+		}
+
+		objLogger := log.With(si.logger, "object_path", obj.event.ObjectPath)
+		level.Debug(objLogger).Log("msg", "processing object")
+
+		if obj.err != nil {
+			processingErrors.Add(fmt.Errorf("failed to download object: %w", obj.err))
+			continue
+		}
+
+		reader, err := dataobj.FromReaderAt(bytes.NewReader(*obj.objectBytes), int64(len(*obj.objectBytes)))
+		if err != nil {
+			processingErrors.Add(fmt.Errorf("failed to read object: %w", err))
+			continue
+		}
+
+		if err := si.calculator.Calculate(ctx, objLogger, reader, obj.event.ObjectPath); err != nil {
+			processingErrors.Add(fmt.Errorf("failed to calculate index: %w", err))
+			continue
+		}
+	}
+
+	if processingErrors.Err() != nil {
+		return "", processingErrors.Err()
+	}
+
+	tenantTimeRanges := si.calculator.TimeRanges()
+	obj, closer, err := si.calculator.Flush()
+	if err != nil {
+		return "", fmt.Errorf("failed to flush builder: %w", err)
+	}
+	defer closer.Close()
+
+	key, err := ObjectKey(ctx, obj)
+	if err != nil {
+		return "", fmt.Errorf("failed to generate object key: %w", err)
+	}
+
+	reader, err := obj.Reader(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to read object: %w", err)
+	}
+	defer reader.Close()
+
+	if err := si.indexStorageBucket.Upload(ctx, key, reader); err != nil {
+		return "", fmt.Errorf("failed to upload index: %w", err)
+	}
+
+	metastoreTocWriter := metastore.NewTableOfContentsWriter(si.indexStorageBucket, si.logger)
+	if err := metastoreTocWriter.WriteEntry(ctx, key, tenantTimeRanges); err != nil {
+		return "", fmt.Errorf("failed to update metastore ToC file: %w", err)
+	}
+
+	level.Debug(si.logger).Log("msg", "finished building new index file", "partition", partition,
+		"events", len(events), "size", obj.Size(), "duration", time.Since(start),
+		"tenants", len(tenantTimeRanges), "path", key)
+
+	return key, nil
+}
+
+// updateBuildMetrics updates internal build metrics
+func (si *serialIndexer) updateBuildMetrics(buildTime time.Duration, _ error) {
+	si.buildTimeMutex.Lock()
+	defer si.buildTimeMutex.Unlock()
+
+	si.totalBuilds++
+	si.totalBuildTime += buildTime
+}
+
+// GetMetrics returns current indexer metrics
+func (si *serialIndexer) GetMetrics() map[string]interface{} {
+	si.buildTimeMutex.RLock()
+	defer si.buildTimeMutex.RUnlock()
+
+	avgBuildTime := time.Duration(0)
+	if si.totalBuilds > 0 {
+		avgBuildTime = si.totalBuildTime / time.Duration(si.totalBuilds)
+	}
+
+	return map[string]interface{}{
+		"total_requests":   si.totalRequests,
+		"total_builds":     si.totalBuilds,
+		"total_build_time": si.totalBuildTime,
+		"avg_build_time":   avgBuildTime,
+		"queue_depth":      len(si.buildRequestChan),
+		"service_state":    si.State().String(),
+	}
+}

--- a/pkg/dataobj/index/indexer.go
+++ b/pkg/dataobj/index/indexer.go
@@ -463,4 +463,3 @@ func (si *serialIndexer) updateBuildMetrics(buildTime time.Duration, _ error) {
 	si.indexerMetrics.setBuildTime(buildTime)
 	si.indexerMetrics.setQueueDepth(len(si.buildRequestChan))
 }
-

--- a/pkg/dataobj/index/indexer_test.go
+++ b/pkg/dataobj/index/indexer_test.go
@@ -51,10 +51,10 @@ func TestSerialIndexer_BuildIndex(t *testing.T) {
 	// Create indexer with mock calculator
 	mockCalc := &mockCalculator{}
 	indexStorageBucket := objstore.NewInMemBucket()
-	
+
 	// Create dedicated registry for this test
 	reg := prometheus.NewRegistry()
-	
+
 	builderMetrics := newBuilderMetrics()
 	require.NoError(t, builderMetrics.register(reg))
 
@@ -130,10 +130,10 @@ func TestSerialIndexer_MultipleBuilds(t *testing.T) {
 	// Create indexer with mock calculator
 	mockCalc := &mockCalculator{}
 	indexStorageBucket := objstore.NewInMemBucket()
-	
+
 	// Create dedicated registry for this test
 	reg := prometheus.NewRegistry()
-	
+
 	builderMetrics := newBuilderMetrics()
 	require.NoError(t, builderMetrics.register(reg))
 
@@ -291,10 +291,10 @@ func TestSerialIndexer_ConcurrentBuilds(t *testing.T) {
 	// Create indexer with mock calculator
 	mockCalc := &mockCalculator{}
 	indexStorageBucket := objstore.NewInMemBucket()
-	
+
 	// Create dedicated registry for this test
 	reg := prometheus.NewRegistry()
-	
+
 	builderMetrics := newBuilderMetrics()
 	require.NoError(t, builderMetrics.register(reg))
 

--- a/pkg/dataobj/index/indexer_test.go
+++ b/pkg/dataobj/index/indexer_test.go
@@ -80,9 +80,8 @@ func TestSerialIndexer_BuildIndex(t *testing.T) {
 	}()
 
 	// Submit build request
-	indexPath, records, err := indexer.submitBuild(ctx, []bufferedEvent{bufferedEvt}, 0, triggerTypeNormal)
+	records, err := indexer.submitBuild(ctx, []bufferedEvent{bufferedEvt}, 0, triggerTypeAppend)
 	require.NoError(t, err)
-	require.NotEmpty(t, indexPath)
 	require.Len(t, records, 1)
 	require.Equal(t, record, records[0])
 
@@ -159,9 +158,8 @@ func TestSerialIndexer_MultipleBuilds(t *testing.T) {
 	}()
 
 	// Submit build request with multiple events
-	indexPath, records, err := indexer.submitBuild(ctx, events, 0, triggerTypeNormal)
+	records, err := indexer.submitBuild(ctx, events, 0, triggerTypeAppend)
 	require.NoError(t, err)
-	require.NotEmpty(t, indexPath)
 	require.Len(t, records, 2)
 
 	// Verify calculator processed all events
@@ -229,9 +227,8 @@ func TestSerialIndexer_FlushTrigger(t *testing.T) {
 	}()
 
 	// Submit build request with flush trigger
-	indexPath, records, err := indexer.submitBuild(ctx, []bufferedEvent{bufferedEvt}, 0, triggerTypeFlush)
+	records, err := indexer.submitBuild(ctx, []bufferedEvent{bufferedEvt}, 0, triggerTypeFlush)
 	require.NoError(t, err)
-	require.NotEmpty(t, indexPath)
 	require.Len(t, records, 1)
 
 	// Verify calculator was used
@@ -272,7 +269,7 @@ func TestSerialIndexer_ServiceNotRunning(t *testing.T) {
 	record := &kgo.Record{Partition: int32(0)}
 	bufferedEvt := bufferedEvent{event: event, record: record}
 
-	_, _, err := indexer.submitBuild(ctx, []bufferedEvent{bufferedEvt}, 0, triggerTypeNormal)
+	_, err := indexer.submitBuild(ctx, []bufferedEvent{bufferedEvt}, 0, triggerTypeAppend)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "indexer service is not running")
 }
@@ -340,7 +337,7 @@ func TestSerialIndexer_ConcurrentBuilds(t *testing.T) {
 
 			bufferedEvt := bufferedEvent{event: event, record: record}
 
-			_, _, err = indexer.submitBuild(ctx, []bufferedEvent{bufferedEvt}, int32(idx), triggerTypeNormal)
+			_, err = indexer.submitBuild(ctx, []bufferedEvent{bufferedEvt}, int32(idx), triggerTypeAppend)
 			results <- err
 		}(i)
 	}

--- a/pkg/dataobj/index/metrics.go
+++ b/pkg/dataobj/index/metrics.go
@@ -6,7 +6,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-type indexBuilderMetrics struct {
+type builderMetrics struct {
 	// Error counters
 	commitFailures prometheus.Counter
 
@@ -17,8 +17,8 @@ type indexBuilderMetrics struct {
 	processingDelay prometheus.Gauge // Latest delta between record timestamp and current time
 }
 
-func newIndexBuilderMetrics() *indexBuilderMetrics {
-	p := &indexBuilderMetrics{
+func newBuilderMetrics() *builderMetrics {
+	p := &builderMetrics{
 		commitFailures: prometheus.NewCounter(prometheus.CounterOpts{
 			Name: "loki_index_builder_commit_failures_total",
 			Help: "Total number of commit failures",
@@ -36,7 +36,7 @@ func newIndexBuilderMetrics() *indexBuilderMetrics {
 	return p
 }
 
-func (p *indexBuilderMetrics) register(reg prometheus.Registerer) error {
+func (p *builderMetrics) register(reg prometheus.Registerer) error {
 	collectors := []prometheus.Collector{
 		p.commitFailures,
 		p.commitsTotal,
@@ -53,7 +53,7 @@ func (p *indexBuilderMetrics) register(reg prometheus.Registerer) error {
 	return nil
 }
 
-func (p *indexBuilderMetrics) unregister(reg prometheus.Registerer) {
+func (p *builderMetrics) unregister(reg prometheus.Registerer) {
 	collectors := []prometheus.Collector{
 		p.commitFailures,
 		p.commitsTotal,
@@ -65,15 +65,15 @@ func (p *indexBuilderMetrics) unregister(reg prometheus.Registerer) {
 	}
 }
 
-func (p *indexBuilderMetrics) incCommitFailures() {
+func (p *builderMetrics) incCommitFailures() {
 	p.commitFailures.Inc()
 }
 
-func (p *indexBuilderMetrics) incCommitsTotal() {
+func (p *builderMetrics) incCommitsTotal() {
 	p.commitsTotal.Inc()
 }
 
-func (p *indexBuilderMetrics) setProcessingDelay(recordTimestamp time.Time) {
+func (p *builderMetrics) setProcessingDelay(recordTimestamp time.Time) {
 	// Convert milliseconds to seconds and calculate delay
 	if !recordTimestamp.IsZero() { // Only observe if timestamp is valid
 		p.processingDelay.Set(time.Since(recordTimestamp).Seconds())


### PR DESCRIPTION
**What this PR does / why we need it**:
This pull request is a medium sized refactoring of the dataobj index builder to support handling stale partitions in terms of buffered events per index but less than `Config.EventsPerIndex`. In particular:
- All the build index code is moved to a separate abstraction in `indexer.go` that the builder is feeding via a golang channel.
- The builder incorporates now a secondary async routine that flushes buffered event objects to the indexer according to configured flush timeout.

**Which issue(s) this PR fixes**:
Fixes grafana/loki-private#1967

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
