### PR TITLE
fix: race condition in TestPartitionMonitorRebalancing

### DIFF
--- a/pkg/kafka/partitionring/consumer/client_test.go
+++ b/pkg/kafka/partitionring/consumer/client_test.go
@@ -160,14 +160,14 @@ func TestPartitionMonitorRebalancing(t *testing.T) {
 
 	// Change the active partitions in the ring
 	t.Log("Changing active partitions from [0,1] to [0,1,2]")
-	mockRing.partitionIDs = []int32{0, 1, 2}
+	mockRing.UpdatePartitionIDs([]int32{0, 1, 2})
 
 	// Wait for rebalancing to occur and stabilize
 	time.Sleep(7 * time.Second)
 
 	// Change active partitions again
 	t.Log("Changing active partitions from [0,1,2] to [0,1,2,3]")
-	mockRing.partitionIDs = []int32{0, 1, 2, 3}
+	mockRing.UpdatePartitionIDs([]int32{0, 1, 2, 3})
 
 	// Wait for final rebalancing
 	time.Sleep(7 * time.Second)
@@ -312,7 +312,7 @@ func TestPartitionContinuityDuringRebalance(t *testing.T) {
 	t.Log("Adding consumer2 and changing active partitions from [0,1] to [0,1,2]")
 	consumer2 := createConsumer("consumer2")
 	defer consumer2.Close()
-	mockRing.partitionIDs = []int32{0, 1, 2}
+	mockRing.UpdatePartitionIDs([]int32{0, 1, 2})
 
 	// Let it run for a while
 	time.Sleep(5 * time.Second)


### PR DESCRIPTION
**What this PR does / why we need it**:
I was running `make test` locally and noticed that the test `TestPartitionMonitorRebalancing` is flaky, so run it with `-race` argument and noticed race condition:
```
WARNING: DATA RACE
Read at 0x00c0006a0468 by goroutine 85:
  github.com/grafana/loki/v3/pkg/kafka/partitionring/consumer.(*mockPartitionRingReader).PartitionRing()
      /home/sergey/projects/loki/pkg/kafka/partitionring/consumer/balancer_test.go:40 +0xd6
  github.com/grafana/loki/v3/pkg/kafka/partitionring/consumer.(*Client).monitorPartitions()
      /home/sergey/projects/loki/pkg/kafka/partitionring/consumer/client.go:84 +0x281
  github.com/grafana/loki/v3/pkg/kafka/partitionring/consumer.NewGroupClient.gowrap1()
      /home/sergey/projects/loki/pkg/kafka/partitionring/consumer/client.go:64 +0x33

Previous write at 0x00c0006a0468 by goroutine 29:
  github.com/grafana/loki/v3/pkg/kafka/partitionring/consumer.TestPartitionMonitorRebalancing()
      /home/sergey/projects/loki/pkg/kafka/partitionring/consumer/client_test.go:170 +0xce4
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1934 +0x21c
  testing.(*T).Run.gowrap1()
      /usr/local/go/src/testing/testing.go:1997 +0x44

Goroutine 85 (running) created at:
  github.com/grafana/loki/v3/pkg/kafka/partitionring/consumer.NewGroupClient()
      /home/sergey/projects/loki/pkg/kafka/partitionring/consumer/client.go:64 +0xaf0
  github.com/grafana/loki/v3/pkg/kafka/partitionring/consumer.TestPartitionMonitorRebalancing.func1()
      /home/sergey/projects/loki/pkg/kafka/partitionring/consumer/client_test.go:63 +0x957
  github.com/grafana/loki/v3/pkg/kafka/partitionring/consumer.TestPartitionMonitorRebalancing()
      /home/sergey/projects/loki/pkg/kafka/partitionring/consumer/client_test.go:129 +0x8e1
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1934 +0x21c
  testing.(*T).Run.gowrap1()
      /usr/local/go/src/testing/testing.go:1997 +0x44

Goroutine 29 (running) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:1997 +0x9d2
  testing.runTests.func1()
      /usr/local/go/src/testing/testing.go:2477 +0x85
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1934 +0x21c
  testing.runTests()
      /usr/local/go/src/testing/testing.go:2475 +0x96c
  testing.(*M).Run()
      /usr/local/go/src/testing/testing.go:2337 +0xed4
  main.main()
      _testmain.go:51 +0x164
```

The test uses `time.Sleep` so ideally it should be re-written without it, but anyway, I fixed race conditions by introducing a mutex to a place where it happens.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
