### PR TITLE
feat(helm): add support for custom alert rule annotations

### DIFF
--- a/production/helm/loki/src/alerts.yaml.tpl
+++ b/production/helm/loki/src/alerts.yaml.tpl
@@ -7,6 +7,9 @@ groups:
         annotations:
           message: |
             {{`{{`}} $labels.job {{`}}`}} {{`{{`}} $labels.route {{`}}`}} is experiencing {{`{{`}} printf "%.2f" $value {{`}}`}}% errors.
+{{- with .Values.monitoring.rules.additionalRuleAnnotations }}
+{{ toYaml . | indent 10 }}
+{{- end }}
         expr: |
           100 * sum(rate(loki_request_duration_seconds_count{status_code=~"5.."}[2m])) by (namespace, job, route)
             /
@@ -19,11 +22,15 @@ groups:
 {{ toYaml .Values.monitoring.rules.additionalRuleLabels | indent 10 }}
 {{- end }}
 {{- end }}
+
 {{- if not (.Values.monitoring.rules.disabled.LokiRequestPanics | default false) }}
       - alert: "LokiRequestPanics"
         annotations:
           message: |
             {{`{{`}} $labels.job {{`}}`}} is experiencing {{`{{`}} printf "%.2f" $value {{`}}`}}% increase of panics.
+{{- with .Values.monitoring.rules.additionalRuleAnnotations }}
+{{ toYaml . | indent 10 }}
+{{- end }}
         expr: |
           sum(increase(loki_panic_total[10m])) by (namespace, job) > 0
         labels:
@@ -32,11 +39,15 @@ groups:
 {{ toYaml .Values.monitoring.rules.additionalRuleLabels | indent 10 }}
 {{- end }}
 {{- end }}
+
 {{- if not (.Values.monitoring.rules.disabled.LokiRequestLatency | default false) }}
       - alert: "LokiRequestLatency"
         annotations:
           message: |
             {{`{{`}} $labels.job {{`}}`}} {{`{{`}} $labels.route {{`}}`}} is experiencing {{`{{`}} printf "%.2f" $value {{`}}`}}s 99th percentile latency.
+{{- with .Values.monitoring.rules.additionalRuleAnnotations }}
+{{ toYaml . | indent 10 }}
+{{- end }}
         expr: |
           namespace_job_route:loki_request_duration_seconds:99quantile{route!~"(?i).*tail.*"} > 1
         for: "15m"
@@ -46,11 +57,15 @@ groups:
 {{ toYaml .Values.monitoring.rules.additionalRuleLabels | indent 10 }}
 {{- end }}
 {{- end }}
+
 {{- if not (.Values.monitoring.rules.disabled.LokiTooManyCompactorsRunning | default false) }}
       - alert: "LokiTooManyCompactorsRunning"
         annotations:
           message: |
             {{`{{`}} $labels.cluster {{`}}`}} {{`{{`}} $labels.namespace {{`}}`}} has had {{`{{`}} printf "%.0f" $value {{`}}`}} compactors running for more than 5m. Only one compactor should run at a time.
+{{- with .Values.monitoring.rules.additionalRuleAnnotations }}
+{{ toYaml . | indent 10 }}
+{{- end }}
         expr: |
           sum(loki_boltdb_shipper_compactor_running) by (cluster, namespace) > 1
         for: "5m"
@@ -60,6 +75,7 @@ groups:
 {{ toYaml .Values.monitoring.rules.additionalRuleLabels | indent 10 }}
 {{- end }}
 {{- end }}
+
 {{- if not (.Values.monitoring.rules.disabled.LokiCanaryLatency | default false) }}
   - name: "loki_canaries_alerts"
     rules:
@@ -67,6 +83,9 @@ groups:
         annotations:
           message: |
             {{`{{`}} $labels.job {{`}}`}} is experiencing {{`{{`}} printf "%.2f" $value {{`}}`}}s 99th percentile latency.
+{{- with .Values.monitoring.rules.additionalRuleAnnotations }}
+{{ toYaml . | indent 10 }}
+{{- end }}
         expr: |
           histogram_quantile(0.99, sum(rate(loki_canary_response_latency_seconds_bucket[5m])) by (le, namespace, job)) > 5
         for: "15m"

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -4070,6 +4070,11 @@ monitoring:
     # -- Additional labels for the rules PrometheusRule resource
     labels: {}
     # -- Additional labels for PrometheusRule alerts
+    additionalRuleAnnotations: {}
+    # e.g.:
+    # additionalRuleAnnotations:
+    #   runbook_url: "https://runbooks.example.com/oncall/loki"
+    #   summary: "What this alert means and how to respond"
     additionalRuleLabels: {}
     # -- Additional groups to add to the rules file
     additionalGroups: []


### PR DESCRIPTION
# feat(helm): add support for custom alert rule annotations

**What this PR does / why we need it**:  
This PR introduces support for adding custom annotations to Loki Helm chart alerting rules, similar to how `additionalRuleLabels` already works.  

- Adds a new `monitoring.rules.additionalRuleAnnotations` values key.  
- These annotations are merged into the `annotations:` block of each built-in alert in `alerts.yaml.tpl`.  

This enables users to enrich alerts with metadata such as `runbook_url`, `summary`, or any other contextual information without having to fork or manually patch the chart.

---

**Which issue(s) this PR fixes**:  
Fixes #<issue number>  

---

**Special notes for your reviewer**:  
- The change mirrors the existing pattern for `additionalRuleLabels`.  
- Backward compatible: if `additionalRuleAnnotations` is not defined, behavior is unchanged.  
- Example usage in `values.yaml`:  

```yaml
monitoring:
  rules:
    additionalRuleAnnotations:
      runbook_url: "https://runbooks.example.com/oncall/loki"
      summary: "Investigate upstream errors; see runbook."
```

This will render in each alert’s `annotations:` block:  

```yaml
annotations:
  message: "...existing alert message..."
  runbook_url: "https://runbooks.example.com/oncall/loki"
  summary: "Investigate upstream errors; see runbook."
```

---

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)  
- [x] Documentation added (`values.yaml` and chart README updated)  
- [ ] Tests updated (if applicable for chart validation)  
- [x] Title matches the required [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) format  

---
