### PR TITLE
fix(helm): add single-binary to networkpolicy

### DIFF
--- a/production/helm/loki/templates/networkpolicy.yaml
+++ b/production/helm/loki/templates/networkpolicy.yaml
@@ -63,6 +63,9 @@ spec:
         {{- else }}
           - read
           - write
+          {{- if eq (include "loki.deployment.isSingleBinary" .) "true" }}
+          {{- include "loki.singleBinarySelectorLabels" . | nindent 10 }}
+          {{- end }}
         {{- end }}
     matchLabels:
       {{- include "loki.selectorLabels" . | nindent 6 }}


### PR DESCRIPTION
Otherwise the single-binary pods are not selected and the ingress will filter out traffic to them.

**What this PR does / why we need it**: When starting in single-binary mode, the pods have `app.kubernetes.io/component=single-binary`, but the ingress network policy filter with components `write` and `read` only. So there's no ingress traffic getting through.

**Which issue(s) this PR fixes**:
Fixes #19199

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
