### PR TITLE
chore(bench): Fix logql benchmark test setup

### DIFF
--- a/pkg/logql/bench/store_dataobj_v2_engine.go
+++ b/pkg/logql/bench/store_dataobj_v2_engine.go
@@ -26,8 +26,9 @@ type DataObjV2EngineStore struct {
 }
 
 // NewDataObjV2EngineStore creates a new store that uses the v2 dataobj engine.
-func NewDataObjV2EngineStore(dataDir string, tenantID string) (*DataObjV2EngineStore, error) {
-	return dataobjV2StoreWithOpts(dataDir, tenantID, logql.EngineOpts{
+func NewDataObjV2EngineStore(dir string, tenantID string) (*DataObjV2EngineStore, error) {
+	storageDir := filepath.Join(dir, storageDir)
+	return dataobjV2StoreWithOpts(storageDir, tenantID, logql.EngineOpts{
 		EnableV2Engine: true,
 		BatchSize:      512,
 		RangeConfig:    rangeio.DefaultConfig,


### PR DESCRIPTION
### Summary

Recent pull request #19198 changed the folder structure of the benchmark dataset so it can also easily be read by a local Loki instance. However, this change broke the tests of the benchmarks itself, due to a wrong storage path, which caused the execution to not return any results.