### PR TITLE
fix: fix context canceled stops reader from cleaning up

### DIFF
--- a/pkg/kafka/partition/reader_service.go
+++ b/pkg/kafka/partition/reader_service.go
@@ -200,12 +200,10 @@ func (s *ReaderService) processConsumerLagAtStartup(ctx context.Context, logger 
 		return fmt.Errorf("failed to create consumer: %w", err)
 	}
 
-	cancelCtx, cancel := context.WithCancel(ctx)
 	recordsCh := make(chan []Record)
-	wait := consumer.Start(cancelCtx, recordsCh)
+	wait := consumer.Start(ctx, recordsCh)
 	defer func() {
 		close(recordsCh)
-		cancel()
 		wait()
 	}()
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit fixes a bug where cancelling the context when there are no more records prevented the reader from cleaning up. For example, when changing from starting to running phase after processing consumer lag at startup. This is a problem for dataobj-consumers which might want to build an object and flush a metastore event.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
