### PR TITLE
fix: apply global otlp config to tenant config only when it is updated in the overrides

### DIFF
--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -230,7 +230,7 @@ type Limits struct {
 	AllowStructuredMetadata           bool                  `yaml:"allow_structured_metadata,omitempty" json:"allow_structured_metadata,omitempty" doc:"description=Allow user to send structured metadata in push payload."`
 	MaxStructuredMetadataSize         flagext.ByteSize      `yaml:"max_structured_metadata_size" json:"max_structured_metadata_size" doc:"description=Maximum size accepted for structured metadata per log line."`
 	MaxStructuredMetadataEntriesCount int                   `yaml:"max_structured_metadata_entries_count" json:"max_structured_metadata_entries_count" doc:"description=Maximum number of structured metadata entries per log line."`
-	OTLPConfig                        push.OTLPConfig       `yaml:"otlp_config" json:"otlp_config" doc:"description=OTLP log ingestion configurations"`
+	OTLPConfig                        *push.OTLPConfig      `yaml:"otlp_config" json:"otlp_config" doc:"description=OTLP log ingestion configurations"`
 	GlobalOTLPConfig                  push.GlobalOTLPConfig `yaml:"-" json:"-"`
 
 	BlockIngestionPolicyUntil map[string]dskit_flagext.Time `yaml:"block_ingestion_policy_until" json:"block_ingestion_policy_until" category:"experimental" doc:"description=Block ingestion for policy until the configured date. The policy '*' is the global policy, which is applied to all streams not matching a policy and can be overridden by other policies. The time should be in RFC3339 format. The policy is based on the policy_stream_mapping configuration."`
@@ -508,6 +508,9 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 // SetGlobalOTLPConfig set GlobalOTLPConfig which is used while unmarshaling per-tenant otlp config to use the default list of resource attributes picked as index labels.
 func (l *Limits) SetGlobalOTLPConfig(cfg push.GlobalOTLPConfig) {
 	l.GlobalOTLPConfig = cfg
+	if l.OTLPConfig == nil {
+		l.OTLPConfig = &push.OTLPConfig{}
+	}
 	l.OTLPConfig.ApplyGlobalOTLPConfig(cfg)
 }
 
@@ -533,14 +536,21 @@ func (l *Limits) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		if err := yaml.Unmarshal(b, (*plain)(l)); err != nil {
 			return errors.Wrap(err, "cloning limits (unmarshaling)")
 		}
+		// set the otlp config to nil, which would help to detect later if it was set in the tenant override
+		l.OTLPConfig = nil
 	}
 	if err := unmarshal((*plain)(l)); err != nil {
 		return err
 	}
 
 	if defaultLimits != nil {
-		// apply relevant bits from global otlp config
-		l.OTLPConfig.ApplyGlobalOTLPConfig(defaultLimits.GlobalOTLPConfig)
+		if l.OTLPConfig == nil {
+			// no change in per-tenant OTLP config, copy the existing default config
+			l.OTLPConfig = defaultLimits.OTLPConfig
+		} else {
+			// apply relevant bits from global otlp config
+			l.OTLPConfig.ApplyGlobalOTLPConfig(defaultLimits.GlobalOTLPConfig)
+		}
 		// apply default policy stream mappings
 		if err := l.PolicyStreamMapping.ApplyDefaultPolicyStreamMappings(defaultLimits.DefaultPolicyStreamMapping); err != nil {
 			return errors.Wrap(err, "applying default policy stream mappings")
@@ -1198,7 +1208,13 @@ func (o *Overrides) MaxStructuredMetadataCount(userID string) int {
 }
 
 func (o *Overrides) OTLPConfig(userID string) push.OTLPConfig {
-	return o.getOverridesForUser(userID).OTLPConfig
+	otlpConfig := o.getOverridesForUser(userID).OTLPConfig
+	if otlpConfig == nil {
+		// this should never happen other than tests but putting it here just to avoid panic
+		otlpConfig = &push.OTLPConfig{}
+	}
+
+	return *otlpConfig
 }
 
 func (o *Overrides) BlockIngestionUntil(userID string) time.Time {

--- a/pkg/validation/limits_test.go
+++ b/pkg/validation/limits_test.go
@@ -199,7 +199,7 @@ func TestLimitsDoesNotMutate(t *testing.T) {
 				Selector: `{a="b"}`,
 			},
 		},
-		OTLPConfig: defaultOTLPConfig,
+		OTLPConfig: &defaultOTLPConfig,
 	}
 	SetDefaultLimitsForYAMLUnmarshalling(newDefaults)
 
@@ -227,7 +227,7 @@ ruler_remote_write_headers:
 						Selector: `{a="b"}`,
 					},
 				},
-				OTLPConfig:                defaultOTLPConfig,
+				OTLPConfig:                &defaultOTLPConfig,
 				EnforcedLabels:            []string{},
 				PolicyEnforcedLabels:      map[string][]string{},
 				PolicyStreamMapping:       PolicyStreamMapping{},
@@ -251,7 +251,7 @@ ruler_remote_write_headers:
 						Selector: `{a="b"}`,
 					},
 				},
-				OTLPConfig:                defaultOTLPConfig,
+				OTLPConfig:                &defaultOTLPConfig,
 				EnforcedLabels:            []string{},
 				PolicyEnforcedLabels:      map[string][]string{},
 				PolicyStreamMapping:       PolicyStreamMapping{},
@@ -279,7 +279,7 @@ retention_stream:
 
 				// Rest from new defaults
 				RulerRemoteWriteHeaders:   OverwriteMarshalingStringMap{map[string]string{"a": "b"}},
-				OTLPConfig:                defaultOTLPConfig,
+				OTLPConfig:                &defaultOTLPConfig,
 				EnforcedLabels:            []string{},
 				PolicyEnforcedLabels:      map[string][]string{},
 				PolicyStreamMapping:       PolicyStreamMapping{},
@@ -306,7 +306,7 @@ reject_old_samples: true
 						Selector: `{a="b"}`,
 					},
 				},
-				OTLPConfig:                defaultOTLPConfig,
+				OTLPConfig:                &defaultOTLPConfig,
 				EnforcedLabels:            []string{},
 				PolicyEnforcedLabels:      map[string][]string{},
 				PolicyStreamMapping:       PolicyStreamMapping{},
@@ -334,7 +334,7 @@ query_timeout: 5m
 						Selector: `{a="b"}`,
 					},
 				},
-				OTLPConfig:                defaultOTLPConfig,
+				OTLPConfig:                &defaultOTLPConfig,
 				EnforcedLabels:            []string{},
 				PolicyEnforcedLabels:      map[string][]string{},
 				PolicyStreamMapping:       PolicyStreamMapping{},
@@ -358,23 +358,23 @@ func TestLimitsValidation(t *testing.T) {
 		expected error
 	}{
 		{
-			limits:   Limits{DeletionMode: "disabled", BloomBlockEncoding: "none"},
+			limits:   Limits{DeletionMode: "disabled", BloomBlockEncoding: "none", OTLPConfig: &push.OTLPConfig{}},
 			expected: nil,
 		},
 		{
-			limits:   Limits{DeletionMode: "filter-only", BloomBlockEncoding: "none"},
+			limits:   Limits{DeletionMode: "filter-only", BloomBlockEncoding: "none", OTLPConfig: &push.OTLPConfig{}},
 			expected: nil,
 		},
 		{
-			limits:   Limits{DeletionMode: "filter-and-delete", BloomBlockEncoding: "none"},
+			limits:   Limits{DeletionMode: "filter-and-delete", BloomBlockEncoding: "none", OTLPConfig: &push.OTLPConfig{}},
 			expected: nil,
 		},
 		{
-			limits:   Limits{DeletionMode: "something-else", BloomBlockEncoding: "none"},
+			limits:   Limits{DeletionMode: "something-else", BloomBlockEncoding: "none", OTLPConfig: &push.OTLPConfig{}},
 			expected: deletionmode.ErrUnknownMode,
 		},
 		{
-			limits:   Limits{DeletionMode: "disabled", BloomBlockEncoding: "unknown"},
+			limits:   Limits{DeletionMode: "disabled", BloomBlockEncoding: "unknown", OTLPConfig: &push.OTLPConfig{}},
 			expected: fmt.Errorf("invalid encoding: unknown, supported: %s", compression.SupportedCodecs()),
 		},
 	} {
@@ -639,4 +639,304 @@ func TestLimits_PolicyOverrideLimits(t *testing.T) {
 	limits.PolicyOverrideLimits = nil
 	require.Equal(t, 0, overrides.PolicyMaxLocalStreamsPerUser("tenant1", "finance"))
 	require.Equal(t, 0, overrides.PolicyMaxGlobalStreamsPerUser("tenant1", "finance"))
+}
+
+func TestOTLPConfig(t *testing.T) {
+	initialDefault := defaultLimits
+	defer func() {
+		defaultLimits = initialDefault
+	}()
+
+	for _, tc := range []struct {
+		name              string
+		defaultOTLPConfig push.OTLPConfig
+		globalOTLPConfig  push.GlobalOTLPConfig
+		yaml              string
+		exp               Limits
+	}{
+		{
+			name: "no oltp config set",
+			yaml: `
+reject_old_samples: true
+`,
+			exp: Limits{
+				RejectOldSamples: true,
+				OTLPConfig:       &push.OTLPConfig{},
+
+				// set all the values which can't be nil
+				RulerRemoteWriteHeaders:   OverwriteMarshalingStringMap{map[string]string{}},
+				DiscoverServiceName:       []string{},
+				LogLevelFields:            []string{},
+				EnforcedLabels:            []string{},
+				PolicyEnforcedLabels:      map[string][]string{},
+				PolicyStreamMapping:       PolicyStreamMapping{},
+				PolicyOverrideLimits:      map[string]PolicyOverridableLimits{},
+				BlockIngestionPolicyUntil: map[string]dskit_flagext.Time{},
+			},
+		},
+		{
+			name: "only default otlp config set",
+			defaultOTLPConfig: push.OTLPConfig{
+				ResourceAttributes: push.ResourceAttributesConfig{
+					AttributesConfig: []push.AttributesConfig{
+						{
+							Action:     push.IndexLabel,
+							Attributes: []string{"foo"},
+						},
+					},
+				},
+				ScopeAttributes: []push.AttributesConfig{
+					{
+						Action:     push.Drop,
+						Attributes: []string{"scope1"},
+					},
+				},
+			},
+			yaml: `
+reject_old_samples: true
+`,
+			exp: Limits{
+				RejectOldSamples: true,
+				OTLPConfig: &push.OTLPConfig{
+					ResourceAttributes: push.ResourceAttributesConfig{
+						AttributesConfig: []push.AttributesConfig{
+							{
+								Action:     push.IndexLabel,
+								Attributes: []string{"foo"},
+							},
+						},
+					},
+					ScopeAttributes: []push.AttributesConfig{
+						{
+							Action:     push.Drop,
+							Attributes: []string{"scope1"},
+						},
+					},
+				},
+
+				// set all the values which can't be nil
+				RulerRemoteWriteHeaders:   OverwriteMarshalingStringMap{map[string]string{}},
+				DiscoverServiceName:       []string{},
+				LogLevelFields:            []string{},
+				EnforcedLabels:            []string{},
+				PolicyEnforcedLabels:      map[string][]string{},
+				PolicyStreamMapping:       PolicyStreamMapping{},
+				PolicyOverrideLimits:      map[string]PolicyOverridableLimits{},
+				BlockIngestionPolicyUntil: map[string]dskit_flagext.Time{},
+			},
+		},
+		{
+			name: "only global otlp config set",
+			globalOTLPConfig: push.GlobalOTLPConfig{
+				DefaultOTLPResourceAttributesAsIndexLabels: []string{"bar"},
+			},
+			yaml: `
+reject_old_samples: true
+`,
+			exp: Limits{
+				RejectOldSamples: true,
+				OTLPConfig: &push.OTLPConfig{
+					ResourceAttributes: push.ResourceAttributesConfig{
+						AttributesConfig: []push.AttributesConfig{
+							{
+								Action:     push.IndexLabel,
+								Attributes: []string{"bar"},
+							},
+						},
+					},
+				},
+
+				// set all the values which can't be nil
+				RulerRemoteWriteHeaders:   OverwriteMarshalingStringMap{map[string]string{}},
+				DiscoverServiceName:       []string{},
+				LogLevelFields:            []string{},
+				EnforcedLabels:            []string{},
+				PolicyEnforcedLabels:      map[string][]string{},
+				PolicyStreamMapping:       PolicyStreamMapping{},
+				PolicyOverrideLimits:      map[string]PolicyOverridableLimits{},
+				BlockIngestionPolicyUntil: map[string]dskit_flagext.Time{},
+			},
+		},
+		{
+			name: "both global and default otlp config set with no otlp config change in yaml override",
+			globalOTLPConfig: push.GlobalOTLPConfig{
+				DefaultOTLPResourceAttributesAsIndexLabels: []string{"foo"},
+			},
+			defaultOTLPConfig: push.OTLPConfig{
+				ResourceAttributes: push.ResourceAttributesConfig{
+					AttributesConfig: []push.AttributesConfig{
+						{
+							Action:     push.IndexLabel,
+							Attributes: []string{"bar"},
+						},
+					},
+				},
+				ScopeAttributes: []push.AttributesConfig{
+					{
+						Action:     push.Drop,
+						Attributes: []string{"scope1"},
+					},
+				},
+			},
+			yaml: `
+reject_old_samples: true
+`,
+			exp: Limits{
+				RejectOldSamples: true,
+				OTLPConfig: &push.OTLPConfig{
+					ResourceAttributes: push.ResourceAttributesConfig{
+						AttributesConfig: []push.AttributesConfig{
+							{
+								Action:     push.IndexLabel,
+								Attributes: []string{"foo"},
+							},
+							{
+								Action:     push.IndexLabel,
+								Attributes: []string{"bar"},
+							},
+						},
+					},
+					ScopeAttributes: []push.AttributesConfig{
+						{
+							Action:     push.Drop,
+							Attributes: []string{"scope1"},
+						},
+					},
+				},
+
+				// set all the values which can't be nil
+				RulerRemoteWriteHeaders:   OverwriteMarshalingStringMap{map[string]string{}},
+				DiscoverServiceName:       []string{},
+				LogLevelFields:            []string{},
+				EnforcedLabels:            []string{},
+				PolicyEnforcedLabels:      map[string][]string{},
+				PolicyStreamMapping:       PolicyStreamMapping{},
+				PolicyOverrideLimits:      map[string]PolicyOverridableLimits{},
+				BlockIngestionPolicyUntil: map[string]dskit_flagext.Time{},
+			},
+		},
+		{
+			name: "global and default otlp config set with additional attribute added by yaml override",
+			globalOTLPConfig: push.GlobalOTLPConfig{
+				DefaultOTLPResourceAttributesAsIndexLabels: []string{"foo"},
+			},
+			defaultOTLPConfig: push.OTLPConfig{
+				ResourceAttributes: push.ResourceAttributesConfig{
+					AttributesConfig: []push.AttributesConfig{
+						{
+							Action:     push.IndexLabel,
+							Attributes: []string{"bar"},
+						},
+					},
+				},
+				ScopeAttributes: []push.AttributesConfig{
+					{
+						Action:     push.Drop,
+						Attributes: []string{"scope1"},
+					},
+				},
+			},
+			yaml: `
+otlp_config:
+  resource_attributes:
+    attributes_config:
+      - action: index_label
+        attributes:
+          - fizz
+`,
+			exp: Limits{
+				OTLPConfig: &push.OTLPConfig{
+					ResourceAttributes: push.ResourceAttributesConfig{
+						AttributesConfig: []push.AttributesConfig{
+							{
+								Action:     push.IndexLabel,
+								Attributes: []string{"foo"},
+							},
+							{
+								Action:     push.IndexLabel,
+								Attributes: []string{"fizz"},
+							},
+						},
+					},
+				},
+
+				// set all the values which can't be nil
+				RulerRemoteWriteHeaders:   OverwriteMarshalingStringMap{map[string]string{}},
+				DiscoverServiceName:       []string{},
+				LogLevelFields:            []string{},
+				EnforcedLabels:            []string{},
+				PolicyEnforcedLabels:      map[string][]string{},
+				PolicyStreamMapping:       PolicyStreamMapping{},
+				PolicyOverrideLimits:      map[string]PolicyOverridableLimits{},
+				BlockIngestionPolicyUntil: map[string]dskit_flagext.Time{},
+			},
+		},
+		{
+			name: "global config ignored by yaml override",
+			globalOTLPConfig: push.GlobalOTLPConfig{
+				DefaultOTLPResourceAttributesAsIndexLabels: []string{"foo"},
+			},
+			defaultOTLPConfig: push.OTLPConfig{
+				ResourceAttributes: push.ResourceAttributesConfig{
+					AttributesConfig: []push.AttributesConfig{
+						{
+							Action:     push.IndexLabel,
+							Attributes: []string{"bar"},
+						},
+					},
+				},
+				ScopeAttributes: []push.AttributesConfig{
+					{
+						Action:     push.Drop,
+						Attributes: []string{"scope1"},
+					},
+				},
+			},
+			yaml: `
+otlp_config:
+  resource_attributes:
+    ignore_defaults: true
+    attributes_config:
+      - action: index_label
+        attributes:
+          - fizz
+`,
+			exp: Limits{
+				OTLPConfig: &push.OTLPConfig{
+					ResourceAttributes: push.ResourceAttributesConfig{
+						IgnoreDefaults: true,
+						AttributesConfig: []push.AttributesConfig{
+							{
+								Action:     push.IndexLabel,
+								Attributes: []string{"fizz"},
+							},
+						},
+					},
+				},
+
+				// set all the values which can't be nil
+				RulerRemoteWriteHeaders:   OverwriteMarshalingStringMap{map[string]string{}},
+				DiscoverServiceName:       []string{},
+				LogLevelFields:            []string{},
+				EnforcedLabels:            []string{},
+				PolicyEnforcedLabels:      map[string][]string{},
+				PolicyStreamMapping:       PolicyStreamMapping{},
+				PolicyOverrideLimits:      map[string]PolicyOverridableLimits{},
+				BlockIngestionPolicyUntil: map[string]dskit_flagext.Time{},
+			},
+		},
+	} {
+
+		t.Run(tc.name, func(t *testing.T) {
+			newDefaults := Limits{
+				OTLPConfig: &tc.defaultOTLPConfig,
+			}
+			newDefaults.SetGlobalOTLPConfig(tc.globalOTLPConfig)
+			SetDefaultLimitsForYAMLUnmarshalling(newDefaults)
+
+			var out Limits
+			require.Nil(t, yaml.UnmarshalStrict([]byte(tc.yaml), &out))
+			require.Equal(t, tc.exp, out)
+		})
+	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
When `default_resource_attributes_as_index_labels` is set, we add the list of attributes to promote as labels to the default and per-tenant `otlp_config` in the limits. However, while loading per-tenant overrides, we inherit the default limits configuration and apply the overrides on top of it to apply only the changes from the overrides. It causes us to copy the `default_resource_attributes_as_index_labels` twice for the tenants who have an override but do not have any changes to the `otlp_config`.

This PR fixes the issue by applying the global otlp config only to the tenants with an update in their `otlp_config`. 
The `otlp_config` would be inherited from the default config without any change for others.

**Checklist**
- [X] Tests updated