### PR TITLE
feat(single-binary): delete statefulset if volumeClaimTemplates changes

### DIFF
--- a/docs/sources/setup/install/helm/reference.md
+++ b/docs/sources/setup/install/helm/reference.md
@@ -12572,6 +12572,15 @@ true
 </td>
 		</tr>
 		<tr>
+			<td>singleBinary.persistence.enableStatefulSetRecreationForSizeChange</td>
+			<td>bool</td>
+			<td>Enable StatefulSetRecreation for changes to PVC size. This means that the StatefulSet will be deleted, recreated (with the same name) and rolled when a change to the PVC size is detected. That way the PVC can be resized without manual intervention.</td>
+			<td><pre lang="json">
+false
+</pre>
+</td>
+		</tr>
+		<tr>
 			<td>singleBinary.persistence.enabled</td>
 			<td>bool</td>
 			<td>Enable persistent disk</td>

--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -27,6 +27,7 @@ Before upgrading to this version, make sure that the CustomResourceDefinitions (
 - [BUGFIX] Use strings instead of integers for ports in CiliumNetworkPolicies [#19252](https://github.com/grafana/loki/pull/19252)
 - [FEATURE] Add replicas to loki-canary deployment [#190095](https://github.com/grafana/loki/pull/19095)
 - [FEATURE] Allow changing the retentionPolicy for the singleBinary StatefulSet [#19097](https://github.com/grafana/loki/pull/19097)
+- [FEATURE]: Allow auto-resizing the volume by recreating the StatefulSet. [#19217](https://github.com/grafana/loki/pull/19217)
 
 ## 6.41.1
 

--- a/production/helm/loki/templates/single-binary/statefulset-recreate-job.yaml
+++ b/production/helm/loki/templates/single-binary/statefulset-recreate-job.yaml
@@ -1,0 +1,147 @@
+{{- if and .Values.singleBinary.persistence.enabled .Values.singleBinary.persistence.enableStatefulSetRecreationForSizeChange -}}
+  {{- $newStatefulSet := include (print $.Template.BasePath "/single-binary/statefulset.yaml") . | fromYaml -}}
+  {{- $currentStatefulset := dict -}}
+  {{- if $newStatefulSet -}}
+    {{- $currentStatefulset = lookup $newStatefulSet.apiVersion $newStatefulSet.kind $newStatefulSet.metadata.namespace $newStatefulSet.metadata.name -}}
+    {{- $needsRecreation := false -}}
+    {{- $templates := dict -}}
+    {{- if $currentStatefulset -}}
+      {{- if ne (len $newStatefulSet.spec.volumeClaimTemplates) (len $currentStatefulset.spec.volumeClaimTemplates) -}}
+        {{- $needsRecreation = true -}}
+      {{- end -}}
+      {{- range $index, $newVolumeClaimTemplate := $newStatefulSet.spec.volumeClaimTemplates -}}
+        {{- $currentVolumeClaimTemplateSpec := dict -}}
+          {{- range $oldVolumeClaimTemplate := $currentStatefulset.spec.volumeClaimTemplates -}}
+            {{- if eq $oldVolumeClaimTemplate.metadata.name $newVolumeClaimTemplate.metadata.name -}}
+              {{- $currentVolumeClaimTemplateSpec = $oldVolumeClaimTemplate.spec -}}
+            {{- end -}}
+          {{- end -}}
+        {{- $newVolumeClaimTemplateStorageSize := $newVolumeClaimTemplate.spec.resources.requests.storage -}}
+        {{- if not $currentVolumeClaimTemplateSpec -}}
+          {{- $needsRecreation = true -}}
+        {{- else -}}
+          {{- if ne $newVolumeClaimTemplateStorageSize $currentVolumeClaimTemplateSpec.resources.requests.storage -}}
+            {{- $needsRecreation = true -}}
+            {{- $templates = set $templates $newVolumeClaimTemplate.metadata.name $newVolumeClaimTemplateStorageSize -}}
+          {{- end -}}
+        {{- end -}}
+      {{- end -}}
+    {{- end -}}
+    {{- if $needsRecreation -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $newStatefulSet.metadata.name }}-recreate
+  namespace: {{ $newStatefulSet.metadata.namespace }}
+  labels:
+    {{- include "loki.singleBinaryLabels" . | nindent 4 }}
+    app.kubernetes.io/component: statefulset-recreate-job
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  ttlSecondsAfterFinished: 300
+  template:
+    metadata:
+      labels:
+        {{- include "loki.singleBinarySelectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: statefulset-recreate-job
+    spec:
+      restartPolicy: Never
+      serviceAccountName: {{ $newStatefulSet.metadata.name }}-recreate
+      containers:
+        - name: recreate-statefulset
+          image: {{ include "loki.baseImage" (dict "service" (dict "registry" "docker.io" "repository" "rancher/kubectl" "tag" (.Capabilities.KubeVersion.Version | default "v1.33.0")) "global" .Values.global.image) }}
+          command:
+            - delete
+            - statefulset
+            - --namespace={{ $newStatefulSet.metadata.namespace }}
+            - --cascade=orphan
+            - {{ $newStatefulSet.metadata.name }}
+        {{- range $index := until (int $currentStatefulset.spec.replicas) }}
+          {{- range $template, $size := $templates }}
+        - name: patch-pvc-{{ $template }}-{{ $index }}
+          image: {{ include "loki.baseImage" (dict "service" (dict "registry" "docker.io" "repository" "rancher/kubectl" "tag" ($.Capabilities.KubeVersion.Version | default "v1.33.0")) "global" $.Values.global.image) }}
+          command:
+            - patch
+            - pvc
+            - --namespace={{ $newStatefulSet.metadata.namespace }}
+            - {{ printf "%s-%s-%d" $template $newStatefulSet.metadata.name $index }}
+            - --type='json'
+            - '-p=[{"op": "replace", "path": "/spec/resources/requests/storage", "value": "{{ $size }}"}]'
+          {{- end }}
+        {{- end }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $newStatefulSet.metadata.name }}-recreate
+  namespace: {{ $newStatefulSet.metadata.namespace }}
+  labels:
+    {{- include "loki.singleBinaryLabels" . | nindent 4 }}
+    app.kubernetes.io/component: statefulset-recreate-job
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $newStatefulSet.metadata.name }}-recreate
+  namespace: {{ $newStatefulSet.metadata.namespace }}
+  labels:
+    {{- include "loki.singleBinaryLabels" . | nindent 4 }}
+    app.kubernetes.io/component: statefulset-recreate-job
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+rules:
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets
+    resourceNames:
+      - {{ $newStatefulSet.metadata.name }}
+    verbs:
+      - delete
+  {{- if $templates }}
+  - apiGroups:
+      - v1
+    resources:
+      - persistentvolumeclaims
+    resourceNames:
+    {{- range $index := until (int $currentStatefulset.spec.replicas) }}
+      {{- range $template := $templates | keys }}
+      - {{ printf "%s-%s-%d" $template $newStatefulSet.metadata.name $index }}
+      {{- end }}
+    {{- end }}
+    verbs:
+      - patch
+  {{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $newStatefulSet.metadata.name }}-recreate
+  namespace: {{ $newStatefulSet.metadata.namespace }}
+  labels:
+    {{- include "loki.singleBinaryLabels" . | nindent 4 }}
+    app.kubernetes.io/component: statefulset-recreate-job
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+subjects:
+  - kind: ServiceAccount
+    name: {{ $newStatefulSet.metadata.name }}-recreate
+    namespace: {{ $newStatefulSet.metadata.namespace }}
+roleRef:
+  kind: Role
+  name: {{ $newStatefulSet.metadata.name }}-recreate
+  apiGroup: rbac.authorization.k8s.io
+    {{- end -}}
+  {{- end -}}
+{{- end -}}

--- a/production/helm/loki/templates/single-binary/statefulset.yaml
+++ b/production/helm/loki/templates/single-binary/statefulset.yaml
@@ -42,6 +42,9 @@ spec:
     metadata:
       annotations:
         checksum/config: {{ include "loki.configMapOrSecretContentHash" (dict "ctx" . "name" "/config.yaml") }}
+        {{- if .Values.singleBinary.persistence.enabled }}
+        storage/size: {{ .Values.singleBinary.persistence.size | quote }}
+        {{- end }}
         {{- with .Values.loki.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -1507,6 +1507,10 @@ singleBinary:
     whenDeleted: Delete
     # -- Enable StatefulSetAutoDeletePVC feature
     enableStatefulSetAutoDeletePVC: true
+    # -- Enable StatefulSetRecreation for changes to PVC size.
+    # This means that the StatefulSet will be deleted, recreated (with the same name) and rolled when a change to the
+    # PVC size is detected. That way the PVC can be resized without manual intervention.
+    enableStatefulSetRecreationForSizeChange: false
     # -- Enable persistent disk
     enabled: true
     # -- Set access modes on the PersistentVolumeClaim


### PR DESCRIPTION
This makes resizing loki gitops friendly

**What this PR does / why we need it**:

Currently resizing loki requires manual intervention.
This PR makes it possible to resize loki without manual intervention,
by orphan-deleting the statefulset which helm then recreates.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Checklist**

- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
