### PR TITLE
ci: add path restrictions to promtail-windows-test.yml

### DIFF
--- a/.github/workflows/promtail-windows-test.yml
+++ b/.github/workflows/promtail-windows-test.yml
@@ -2,6 +2,9 @@ name: Promtail Windows Test
 on:
   pull_request:
     branches: ["main", "k*", "release-[0-9]+.[0-9]+.x"]
+    paths:
+      - clients/cmd/promtail/**
+      - clients/pkg/promtail/**
   push:
     tags: ['v[0-9].[0-9]+.[0-9]+']
     branches: ["main", "k*", "release-[0-9]+.[0-9]+.x"]


### PR DESCRIPTION
**What this PR does / why we need it**:

This test has been very flaky lately, this is quality of life improvement to only run in on PRs that touch promtails code.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
