### PR TITLE
chore: use registerers with prefix for kafka metrics

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -278,7 +278,7 @@ func New(
 
 	var kafkaWriter KafkaProducer
 	if cfg.KafkaEnabled {
-		kafkaClient, err := kafka_client.NewWriterClient("distributor", cfg.KafkaConfig, 20, logger, registerer)
+		kafkaClient, err := kafka_client.NewWriterClient("distributor", cfg.KafkaConfig, 20, logger, prometheus.WrapRegistererWithPrefix("loki_kafka_client_", registerer))
 		if err != nil {
 			return nil, fmt.Errorf("failed to start kafka client: %w", err)
 		}

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -390,7 +390,7 @@ func New(cfg Config, clientConfig client.Config, store Store, limits Limits, con
 			cfg.LifecyclerConfig.ID,
 			NewKafkaConsumerFactory(i, registerer, cfg.KafkaIngestion.KafkaConfig.MaxConsumerWorkers),
 			logger,
-			registerer,
+			prometheus.WrapRegistererWithPrefix("loki_kafka_client_", registerer),
 		)
 		if err != nil {
 			return nil, err

--- a/pkg/kafka/client/writer_client.go
+++ b/pkg/kafka/client/writer_client.go
@@ -104,7 +104,7 @@ func NewWriterClient(component string, kafkaCfg kafka.Config, maxInflightProduce
 // NewClientMetrics returns a new instance of `kprom.Metrics` (used to monitor Kafka interactions), provided
 // the `MetricsPrefix` as the `Namespace` for the default set of Prometheus metrics
 func NewClientMetrics(component string, reg prometheus.Registerer, enableKafkaHistograms bool) *kprom.Metrics {
-	return kprom.NewMetrics(MetricsPrefix,
+	return kprom.NewMetrics("",
 		kprom.Registerer(WrapPrometheusRegisterer(component, reg)),
 		// Do not export the client ID, because we use it to specify options to the backend.
 		kprom.FetchAndProduceDetail(kprom.Batches, kprom.Records, kprom.CompressedBytes, kprom.UncompressedBytes),

--- a/pkg/kafka/partition/reader.go
+++ b/pkg/kafka/partition/reader.go
@@ -53,10 +53,13 @@ type ReaderMetrics struct {
 	fetchWaitDuration prometheus.Histogram
 }
 
+// NewReaderMetrics returns new metrics for the reader.
+//
+// The [prometheus.Registerer] should be wrapped with a unique prefix to
+// avoid metric name collisions with other committers.
 func NewReaderMetrics(r prometheus.Registerer) *ReaderMetrics {
 	return &ReaderMetrics{
 		consumptionLag: promauto.With(r).NewHistogramVec(prometheus.HistogramOpts{
-			Namespace:                       client.MetricsPrefix,
 			Name:                            "partition_reader_consumption_lag_seconds",
 			Help:                            "The estimated consumption lag in seconds, measured as the difference between the current time and the timestamp of the record.",
 			NativeHistogramZeroThreshold:    math.Pow(2, -10),
@@ -66,26 +69,22 @@ func NewReaderMetrics(r prometheus.Registerer) *ReaderMetrics {
 			Buckets:                         prometheus.ExponentialBuckets(0.125, 2, 18),
 		}, []string{"phase"}),
 		fetchWaitDuration: promauto.With(r).NewHistogram(prometheus.HistogramOpts{
-			Namespace:                   client.MetricsPrefix,
 			Name:                        "partition_reader_fetch_wait_duration_seconds",
 			Help:                        "How long the reader spent waiting for a batch of records from Kafka.",
 			NativeHistogramBucketFactor: 1.1,
 		}),
 		recordsPerFetch: promauto.With(r).NewHistogram(prometheus.HistogramOpts{
-			Namespace: client.MetricsPrefix,
-			Name:      "partition_reader_records_per_fetch",
-			Help:      "The number of records received in a single fetch operation.",
-			Buckets:   prometheus.ExponentialBuckets(1, 2, 15),
+			Name:    "partition_reader_records_per_fetch",
+			Help:    "The number of records received in a single fetch operation.",
+			Buckets: prometheus.ExponentialBuckets(1, 2, 15),
 		}),
 		fetchesErrors: promauto.With(r).NewCounter(prometheus.CounterOpts{
-			Namespace: client.MetricsPrefix,
-			Name:      "partition_reader_fetch_errors_total",
-			Help:      "The number of fetch errors encountered.",
+			Name: "partition_reader_fetch_errors_total",
+			Help: "The number of fetch errors encountered.",
 		}),
 		fetchesTotal: promauto.With(r).NewCounter(prometheus.CounterOpts{
-			Namespace: client.MetricsPrefix,
-			Name:      "partition_reader_fetches_total",
-			Help:      "Total number of Kafka fetches performed.",
+			Name: "partition_reader_fetches_total",
+			Help: "Total number of Kafka fetches performed.",
 		}),
 	}
 }

--- a/pkg/kafka/partition/reader_service.go
+++ b/pkg/kafka/partition/reader_service.go
@@ -14,7 +14,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
 	"github.com/grafana/loki/v3/pkg/kafka"
-	"github.com/grafana/loki/v3/pkg/kafka/client"
 )
 
 const (
@@ -36,14 +35,12 @@ type serviceMetrics struct {
 func newServiceMetrics(r prometheus.Registerer) *serviceMetrics {
 	return &serviceMetrics{
 		partition: promauto.With(r).NewGaugeVec(prometheus.GaugeOpts{
-			Namespace: client.MetricsPrefix,
-			Name:      "partition_reader_partition",
-			Help:      "The partition ID assigned to this reader.",
+			Name: "partition_reader_partition",
+			Help: "The partition ID assigned to this reader.",
 		}, []string{"id"}),
 		phase: promauto.With(r).NewGaugeVec(prometheus.GaugeOpts{
-			Namespace: client.MetricsPrefix,
-			Name:      "partition_reader_phase",
-			Help:      "The current phase of the consumer.",
+			Name: "partition_reader_phase",
+			Help: "The current phase of the consumer.",
 		}, []string{"phase"}),
 	}
 }
@@ -70,6 +67,9 @@ type ReaderConfig struct {
 
 // mimics `NewReader` constructor but builds a reader service using
 // a reader.
+//
+// The [prometheus.Registerer] should be wrapped with a unique prefix to
+// avoid metric name collisions with other committers.
 func NewReaderService(
 	kafkaCfg kafka.Config,
 	partitionID int32,


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request updates all `loki_kafka_client` prefixed metrics to derive their prefix from a wrapped registerer instead of using the global prefix `loki_kafka_client`.

This is important as we will have two services declaring these metrics at the same time: ingesters and dataobj consumers; and we want each service to use their own metrics prefix.

The pull request is expected to be a no-op and should not rename any existing metrics. Instead, it just updates the code to derive the prefix from the registerer instead.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
