### PR TITLE
fix(dataobj): Flush into multiple index objects when ErrBuilderFull

### DIFF
--- a/pkg/dataobj/index/indexer.go
+++ b/pkg/dataobj/index/indexer.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"sync"
@@ -18,6 +19,7 @@ import (
 	"github.com/twmb/franz-go/pkg/kgo"
 
 	"github.com/grafana/loki/v3/pkg/dataobj"
+	"github.com/grafana/loki/v3/pkg/dataobj/index/indexobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/metastore"
 )
 
@@ -32,9 +34,9 @@ type buildRequest struct {
 
 // buildResult represents the result of an index build operation
 type buildResult struct {
-	indexPath string
-	records   []*kgo.Record // Records to commit after successful build
-	err       error
+	indexPaths []string      // Multiple index paths when ErrBuilderFull causes multiple flushes
+	records    []*kgo.Record // Records to commit after successful build
+	err        error
 }
 
 // indexerConfig contains configuration for the indexer
@@ -181,7 +183,7 @@ func (si *serialIndexer) submitBuild(ctx context.Context, events []bufferedEvent
 				"partition", partition, "err", result.err)
 		} else {
 			level.Debug(si.logger).Log("msg", "build request completed",
-				"partition", partition, "index_path", result.indexPath)
+				"partition", partition, "index_count", len(result.indexPaths))
 		}
 		return result.records, result.err
 	case <-ctx.Done():
@@ -302,7 +304,7 @@ func (si *serialIndexer) processBuildRequest(req buildRequest) buildResult {
 	}
 
 	// Build the index using internal method
-	indexPath, err := si.buildIndex(req.ctx, events, req.partition)
+	indexPaths, err := si.buildIndex(req.ctx, events, req.partition)
 
 	// Update metrics
 	buildTime := time.Since(start)
@@ -310,12 +312,19 @@ func (si *serialIndexer) processBuildRequest(req buildRequest) buildResult {
 
 	if err != nil {
 		level.Error(si.logger).Log("msg", "failed to build index",
-			"partition", req.partition, "err", err, "duration", buildTime)
-		return buildResult{err: err}
+			"partition", req.partition, "err", err, "duration", buildTime,
+			"partial_indexes", len(indexPaths))
+
+		// If we have partial results, it's a partial success
+		if len(indexPaths) > 0 {
+			level.Info(si.logger).Log("msg", "partial index build success",
+				"partition", req.partition, "indexes_created", len(indexPaths))
+		}
+		return buildResult{indexPaths: indexPaths, err: err} // Return partial success
 	}
 
-	level.Debug(si.logger).Log("msg", "successfully built index",
-		"partition", req.partition, "index_path", indexPath, "duration", buildTime,
+	level.Debug(si.logger).Log("msg", "successfully built indexes",
+		"partition", req.partition, "index_paths", len(indexPaths), "duration", buildTime,
 		"events", len(events))
 
 	// Extract records for committing
@@ -325,14 +334,14 @@ func (si *serialIndexer) processBuildRequest(req buildRequest) buildResult {
 	}
 
 	return buildResult{
-		indexPath: indexPath,
-		records:   records,
-		err:       nil,
+		indexPaths: indexPaths,
+		records:    records,
+		err:        nil,
 	}
 }
 
 // buildIndex is the core index building logic (moved from builder)
-func (si *serialIndexer) buildIndex(ctx context.Context, events []metastore.ObjectWrittenEvent, partition int32) (string, error) {
+func (si *serialIndexer) buildIndex(ctx context.Context, events []metastore.ObjectWrittenEvent, partition int32) ([]string, error) {
 	level.Debug(si.logger).Log("msg", "building index", "events", len(events), "partition", partition)
 	start := time.Now()
 
@@ -340,28 +349,30 @@ func (si *serialIndexer) buildIndex(ctx context.Context, events []metastore.Obje
 	writeTime, err := time.Parse(time.RFC3339, events[0].WriteTime)
 	if err != nil {
 		level.Error(si.logger).Log("msg", "failed to parse write time", "err", err)
-		return "", err
+		return nil, err
 	}
 	si.builderMetrics.setProcessingDelay(writeTime)
 
-	// Trigger the downloads
+	// UNCHANGED: Trigger all downloads first (lines 347-355 from original)
 	for _, event := range events {
 		select {
 		case si.downloadQueue <- event:
 			// Successfully sent event for download
 		case <-ctx.Done():
-			return "", ctx.Err()
+			return nil, ctx.Err()
 		}
 	}
 
-	// Process the results as they are downloaded
+	// Process downloaded objects, handling ErrBuilderFull
+	var indexPaths []string
 	processingErrors := multierror.New()
+
 	for range len(events) {
 		var obj downloadedObject
 		select {
 		case obj = <-si.downloadedObjects:
 		case <-ctx.Done():
-			return "", ctx.Err()
+			return nil, ctx.Err()
 		}
 
 		objLogger := log.With(si.logger, "object_path", obj.event.ObjectPath)
@@ -372,26 +383,75 @@ func (si *serialIndexer) buildIndex(ctx context.Context, events []metastore.Obje
 			continue
 		}
 
-		reader, err := dataobj.FromReaderAt(bytes.NewReader(*obj.objectBytes), int64(len(*obj.objectBytes)))
-		if err != nil {
-			processingErrors.Add(fmt.Errorf("failed to read object: %w", err))
-			continue
-		}
+		// Process this object
+		if err := si.processObject(ctx, objLogger, obj); err != nil {
+			if errors.Is(err, indexobj.ErrBuilderFull) {
+				// Flush current index and start fresh
+				indexPath, flushErr := si.flushCurrentIndex(ctx, partition)
+				if flushErr != nil {
+					processingErrors.Add(fmt.Errorf("failed to flush index on ErrBuilderFull: %w", flushErr))
+					continue
+				}
 
-		if err := si.calculator.Calculate(ctx, objLogger, reader, obj.event.ObjectPath); err != nil {
-			processingErrors.Add(fmt.Errorf("failed to calculate index: %w", err))
-			continue
+				if indexPath != "" {
+					indexPaths = append(indexPaths, indexPath)
+					level.Debug(si.logger).Log("msg", "flushed index due to ErrBuilderFull",
+						"index_path", indexPath, "partition", partition)
+				}
+
+				// Reset calculator and retry this object
+				si.calculator.Reset()
+				if retryErr := si.processObject(ctx, objLogger, obj); retryErr != nil {
+					processingErrors.Add(fmt.Errorf("failed to process object after flush: %w", retryErr))
+					continue
+				}
+			} else {
+				processingErrors.Add(fmt.Errorf("failed to process object: %w", err))
+				continue
+			}
 		}
 	}
 
 	if processingErrors.Err() != nil {
-		return "", processingErrors.Err()
+		return indexPaths, processingErrors.Err()
 	}
 
+	// Flush final index if we have data
+	finalPath, err := si.flushCurrentIndex(ctx, partition)
+	if err != nil {
+		return indexPaths, fmt.Errorf("failed to flush final index: %w", err)
+	}
+
+	if finalPath != "" {
+		indexPaths = append(indexPaths, finalPath)
+	}
+
+	level.Debug(si.logger).Log("msg", "finished building index files", "partition", partition,
+		"events", len(events), "index_count", len(indexPaths), "duration", time.Since(start))
+
+	return indexPaths, nil
+}
+
+// processObject handles processing a single downloaded object
+func (si *serialIndexer) processObject(ctx context.Context, objLogger log.Logger, obj downloadedObject) error {
+	reader, err := dataobj.FromReaderAt(bytes.NewReader(*obj.objectBytes), int64(len(*obj.objectBytes)))
+	if err != nil {
+		return fmt.Errorf("failed to read object: %w", err)
+	}
+
+	return si.calculator.Calculate(ctx, objLogger, reader, obj.event.ObjectPath)
+}
+
+// flushCurrentIndex flushes the current calculator state to an index object
+func (si *serialIndexer) flushCurrentIndex(ctx context.Context, partition int32) (string, error) {
 	tenantTimeRanges := si.calculator.TimeRanges()
+	if len(tenantTimeRanges) == 0 {
+		return "", nil // Nothing to flush
+	}
+
 	obj, closer, err := si.calculator.Flush()
 	if err != nil {
-		return "", fmt.Errorf("failed to flush builder: %w", err)
+		return "", fmt.Errorf("failed to flush calculator: %w", err)
 	}
 	defer closer.Close()
 
@@ -415,9 +475,8 @@ func (si *serialIndexer) buildIndex(ctx context.Context, events []metastore.Obje
 		return "", fmt.Errorf("failed to update metastore ToC file: %w", err)
 	}
 
-	level.Debug(si.logger).Log("msg", "finished building new index file", "partition", partition,
-		"events", len(events), "size", obj.Size(), "duration", time.Since(start),
-		"tenants", len(tenantTimeRanges), "path", key)
+	level.Debug(si.logger).Log("msg", "flushed index object", "partition", partition,
+		"path", key, "size", obj.Size(), "tenants", len(tenantTimeRanges))
 
 	return key, nil
 }

--- a/pkg/dataobj/index/indexer_test.go
+++ b/pkg/dataobj/index/indexer_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/twmb/franz-go/pkg/kgo"
 
 	"github.com/grafana/loki/v3/pkg/dataobj"
+	"github.com/grafana/loki/v3/pkg/dataobj/index/indexobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/metastore"
 	"github.com/grafana/loki/v3/pkg/dataobj/metastore/multitenancy"
 )
@@ -292,18 +293,26 @@ func TestSerialIndexer_ConcurrentBuilds(t *testing.T) {
 
 // mockCalculator is a calculator that does nothing for use in tests
 type mockCalculator struct {
-	count  int
-	object *dataobj.Object
+	count           int
+	object          *dataobj.Object
+	flushCallCount  int
+	resetCallCount  int
+	errOnCallNumber int // Which Calculate call should return ErrBuilderFull (0 = never)
 }
 
 func (c *mockCalculator) Calculate(_ context.Context, _ log.Logger, object *dataobj.Object, _ string) error {
 	c.count++
 	c.object = object
+
+	if c.errOnCallNumber > 0 && c.count == c.errOnCallNumber {
+		return indexobj.ErrBuilderFull
+	}
 	return nil
 }
 
 func (c *mockCalculator) Flush() (*dataobj.Object, io.Closer, error) {
-	return c.object, io.NopCloser(bytes.NewReader([]byte{})), nil
+	c.flushCallCount++
+	return c.object, io.NopCloser(bytes.NewReader([]byte("test-data"))), nil
 }
 
 func (c *mockCalculator) TimeRanges() []multitenancy.TimeRange {
@@ -316,4 +325,83 @@ func (c *mockCalculator) TimeRanges() []multitenancy.TimeRange {
 	}
 }
 
-func (c *mockCalculator) Reset() {}
+func (c *mockCalculator) Reset() {
+	c.resetCallCount++
+}
+
+func TestSerialIndexer_FlushOnErrBuilderFull(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	// Set up test data - 3 events to process
+	bucket := objstore.NewInMemBucket()
+	for i := 0; i < 3; i++ {
+		buildLogObject(t, fmt.Sprintf("tenant-%d", i), fmt.Sprintf("test-path-%d", i), bucket)
+	}
+
+	events := []bufferedEvent{}
+	for i := 0; i < 3; i++ {
+		event := metastore.ObjectWrittenEvent{
+			ObjectPath: fmt.Sprintf("test-path-%d", i),
+			WriteTime:  time.Now().Format(time.RFC3339),
+		}
+
+		record := &kgo.Record{Partition: int32(0)}
+		eventBytes, err := event.Marshal()
+		require.NoError(t, err)
+		record.Value = eventBytes
+
+		events = append(events, bufferedEvent{
+			event:  event,
+			record: record,
+		})
+	}
+
+	// Create mock calculator that returns ErrBuilderFull on second call
+	mockCalc := &mockCalculator{
+		errOnCallNumber: 2, // Return ErrBuilderFull on the 2nd Calculate call
+	}
+	indexStorageBucket := objstore.NewInMemBucket()
+
+	// Create dedicated registry for this test
+	reg := prometheus.NewRegistry()
+
+	builderMetrics := newBuilderMetrics()
+	require.NoError(t, builderMetrics.register(reg))
+
+	indexerMetrics := newIndexerMetrics()
+	require.NoError(t, indexerMetrics.register(reg))
+
+	indexer := newSerialIndexer(
+		mockCalc,
+		bucket,
+		indexStorageBucket,
+		builderMetrics,
+		indexerMetrics,
+		log.NewLogfmtLogger(os.Stderr),
+		indexerConfig{QueueSize: 10},
+	)
+
+	// Start indexer service
+	require.NoError(t, indexer.StartAsync(ctx))
+	require.NoError(t, indexer.AwaitRunning(ctx))
+	defer func() {
+		indexer.StopAsync()
+		require.NoError(t, indexer.AwaitTerminated(context.Background()))
+	}()
+
+	// Submit build request with multiple events
+	records, err := indexer.submitBuild(ctx, events, 0, triggerTypeAppend)
+	require.NoError(t, err)
+	require.Len(t, records, 3) // All records should be returned
+
+	// Verify calculator behavior
+	require.Equal(t, 4, mockCalc.count)          // 3 + 1 retry = 4 calls
+	require.Equal(t, 2, mockCalc.flushCallCount) // 2 flushes (ErrBuilderFull + final)
+	require.Equal(t, 1, mockCalc.resetCallCount) // 1 reset after ErrBuilderFull
+
+	// Verify metrics - single request/build despite multiple flushes
+	require.Equal(t, float64(1), testutil.ToFloat64(indexerMetrics.totalRequests))
+	require.Equal(t, float64(1), testutil.ToFloat64(indexerMetrics.totalBuilds))
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR enhances the data object indexer to handle `ErrBuilderFull` errors by flushing the current index builder and starting a new one. When the index builder reaches capacity, instead of failing the entire operation, it now flushes the current index to storage and continues processing remaining objects with a fresh builder. This allows for more resilient processing of large batches of data objects.

Key changes:
- Modified `buildIndex()` to return multiple index paths (`[]string`) instead of a single path
- Added proper error handling for `ErrBuilderFull` with automatic flush and retry logic
- Enhanced logging to track multiple index creation
- Updated test coverage with comprehensive ErrBuilderFull scenario testing

**Which issue(s) this PR fixes**:
Fixes issue where large batches of data objects would fail processing when the index builder reached capacity.

**Special notes for your reviewer**:

The change maintains backward compatibility while adding robustness. The `buildResult` struct now contains `indexPaths []string` instead of `indexPath string`, and all consuming code has been updated accordingly. Metrics tracking remains accurate despite multiple flushes occurring within a single logical build operation.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)