### PR TITLE
chore: Fix time range grouping logic in some cases

### DIFF
--- a/pkg/engine/planner/physical/planner.go
+++ b/pkg/engine/planner/physical/planner.go
@@ -234,14 +234,12 @@ func (p *Planner) processMakeTable(lp *logical.MakeTable, ctx *Context) ([]Node,
 	if err != nil {
 		return nil, err
 	}
-	sort.Slice(filteredShardDescriptors, func(i, j int) bool {
-		return filteredShardDescriptors[i].TimeRange.End.Before(filteredShardDescriptors[j].TimeRange.End)
-	})
+
 	merge := &Merge{}
 	p.plan.addNode(merge)
 	groups := overlappingShardDescriptors(filteredShardDescriptors)
 
-	if ctx.direction == DESC {
+	if ctx.direction == ASC {
 		slices.Reverse(groups)
 	}
 

--- a/pkg/engine/planner/physical/planner.go
+++ b/pkg/engine/planner/physical/planner.go
@@ -197,7 +197,7 @@ func (p *Planner) buildNodeGroup(currentGroup []FilteredShardDescriptor, baseNod
 func overlappingShardDescriptors(filteredShardDescriptors []FilteredShardDescriptor) [][]FilteredShardDescriptor {
 	// Ensure that shard descriptors are sorted by end time
 	sort.Slice(filteredShardDescriptors, func(i, j int) bool {
-		return filteredShardDescriptors[i].TimeRange.End.Before(filteredShardDescriptors[j].TimeRange.End)
+		return filteredShardDescriptors[i].TimeRange.End.After(filteredShardDescriptors[j].TimeRange.End)
 	})
 
 	groups := make([][]FilteredShardDescriptor, 0, len(filteredShardDescriptors))


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes the grouping logic for overlapping entries

Grouping of time ranges didn't work in certain cases, due to a bug in the processing order.
* If a two non-overlapping ranges are processed before a range that covers them both, only one of them will become the "main" range and form a group, the other will continue to be an isolated range.

For example, Processing the following (sorted by end time) results in:
```
range 1 -1==4------
range 2 ------6=8--
range 3 -1=======9-

produces

group 1 -1=======9- (merge 3 with 1)
group 2 ------6=8--
```
after the fix to the sorting, the groups are correctly merged by processing from the end to the beginning
```
range 3 -1=======9-
range 2 ------6=8--
range 1 -1==4------

produces

group 1 -1*******9-
```

The fix would work either way: processing the ranges in ascending order of start dates, or descending order of end dates. We use end dates so I just switched the sort func. This has the effect of reversing the group ordering too, so I adjusted the logic to only reverse for ASC queries.

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/loki-private/issues/1965

**Special notes for your reviewer**:

**Checklist**
- [x] Tests updated
