### PR TITLE
perf(engine): reuse existing array in genericFunction.Evaluate

### DIFF
--- a/pkg/engine/executor/functions.go
+++ b/pkg/engine/executor/functions.go
@@ -160,6 +160,7 @@ func (b *binaryFuncReg) GetForSignature(op types.BinaryOp, ltype arrow.DataType)
 type arrayType[T comparable] interface {
 	IsNull(int) bool
 	Value(int) T
+	Len() int
 }
 
 // genericFunction is a struct that implements the [BinaryFunction] interface methods
@@ -188,7 +189,7 @@ func (f *genericFunction[E, T]) Evaluate(lhs ColumnVector, rhs ColumnVector) (Co
 	builder := array.NewBooleanBuilder(mem)
 	defer builder.Release()
 
-	for i := 0; i < lhs.ToArray().Len(); i++ {
+	for i := range lhsArr.Len() {
 		if lhsArr.IsNull(i) || rhsArr.IsNull(i) {
 			builder.Append(false)
 			continue


### PR DESCRIPTION
Previously, genericFunction.Evaluate was accidentally converting the left-hand ColumnVector into an array multiple times (once per row), as the loop condition (which converted the argument into an array) was evaluated at the end of each iteration.

If the left-hand side was a CoalesceVector, this became extremely expensive. Ensuring that the left-hand side is only converting the array once makes some queries using logfmt 6x faster[^1]:

    goos: darwin
    goarch: arm64
    pkg: github.com/grafana/loki/v3/pkg/logql/bench
    cpu: Apple M2 Ultra
                                                                                                                          │ after-orig.txt │            after-logs.txt            │
                                                                                                                          │     sec/op     │    sec/op     vs base                │
    {region="ap-southeast-1",_env="dev"}_[BACKWARD]                                                                            1.082 ±  4%    1.063 ±  7%        ~ (p=0.393 n=10)
    {region="ap-southeast-1",_env="dev"}_|_detected_level="error"_[BACKWARD]                                                   1.146 ±  3%    1.147 ±  4%        ~ (p=0.684 n=10)
    {region="ap-southeast-1",_env="dev"}_|_detected_level="warn"_[BACKWARD]                                                    1.141 ±  3%    1.137 ±  3%        ~ (p=0.280 n=10)
    {region="ap-southeast-1",_env="dev"}_|_logfmt_|_level="error"_|_detected_level="error"_[BACKWARD]                          6.154 ±  1%    2.602 ±  2%  -57.72% (p=0.000 n=10)
    {region="ap-southeast-1",_env="dev"}_|=_"level"_[BACKWARD]                                                                 1.073 ± 10%    1.069 ±  9%        ~ (p=0.631 n=10)
    {region="ap-southeast-1",_env="dev"}_|~_"error|exception"_|_detected_level="error"_[BACKWARD]                              1.082 ±  6%    1.064 ±  4%        ~ (p=0.315 n=10)
    {region="ap-southeast-1"}_[BACKWARD]                                                                                       1.284 ±  5%    1.263 ±  6%        ~ (p=0.280 n=10)
    {region="ap-southeast-1"}_|_detected_level="error"_[BACKWARD]                                                              1.361 ±  3%    1.375 ±  5%        ~ (p=0.853 n=10)
    {region="ap-southeast-1"}_|_detected_level="warn"_[BACKWARD]                                                               1.410 ±  5%    1.380 ±  6%        ~ (p=0.247 n=10)
    {region="ap-southeast-1"}_|_detected_level=~"error|warn"_[BACKWARD]                                                       784.7m ±  8%   697.1m ± 17%  -11.17% (p=0.029 n=10)
    {region="ap-southeast-1"}_|_logfmt_|_level="error"_|_detected_level="error"_[BACKWARD]                                    24.473 ±  0%    4.662 ±  0%  -80.95% (p=0.000 n=10)
    {region="ap-southeast-1"}_|=_"level"_[BACKWARD]                                                                            1.229 ±  4%    1.222 ± 12%        ~ (p=0.481 n=10)
    {region="ap-southeast-1"}_|~_"error|exception"_|_detected_level="error"_[BACKWARD]                                         1.173 ±  4%    1.171 ±  3%        ~ (p=0.579 n=10)
    {service_name="grafana",_env="prod",_region="us-west-2"}_[BACKWARD]                                                       655.1m ±  3%   655.9m ±  2%        ~ (p=0.165 n=10)
    {service_name="grafana",_env="prod",_region="us-west-2"}_|_detected_level="error"_[BACKWARD]                              617.6m ±  2%   623.3m ±  2%        ~ (p=0.165 n=10)
    {service_name="grafana",_env="prod",_region="us-west-2"}_|_detected_level="warn"_[BACKWARD]                               608.6m ±  1%   619.9m ±  3%   +1.86% (p=0.005 n=10)
    {service_name="grafana",_env="prod",_region="us-west-2"}_|_logfmt_|_level="error"_|_detected_level="error"_[BACKWARD]     906.0m ±  5%   855.1m ±  5%   -5.62% (p=0.011 n=10)
    {service_name="grafana",_env="prod",_region="us-west-2"}_|=_"level"_[BACKWARD]                                            660.7m ±  6%   652.4m ±  4%        ~ (p=0.218 n=10)
    {service_name="grafana",_env="prod",_region="us-west-2"}_|~_"error|exception"_|_detected_level="error"_[BACKWARD]         488.5m ±  3%   480.7m ±  2%        ~ (p=0.075 n=10)
    {service_name="kubernetes"}_[BACKWARD]                                                                                     1.065 ±  5%    1.029 ±  5%        ~ (p=0.218 n=10)
    {service_name="kubernetes"}_|_detected_level="error"_[BACKWARD]                                                            1.132 ±  6%    1.089 ±  4%        ~ (p=0.218 n=10)
    {service_name="kubernetes"}_|_detected_level="warn"_[BACKWARD]                                                             1.084 ±  3%    1.086 ±  3%        ~ (p=0.971 n=10)
    {service_name="kubernetes"}_|_logfmt_|_level="error"_|_detected_level="error"_[BACKWARD]                                   1.056 ±  3%    1.039 ±  3%        ~ (p=0.280 n=10)
    {service_name="kubernetes"}_|=_"level"_[BACKWARD]                                                                         228.4m ±  4%   227.2m ±  2%        ~ (p=0.190 n=10)
    {service_name="kubernetes"}_|~_"error|exception"_|_detected_level="error"_[BACKWARD]                                       1.035 ±  6%    1.025 ±  2%        ~ (p=0.315 n=10)
    geomean                                                                                                                    1.118         996.5m        -10.85%

[^1]: These results were generated in the context of my scheduler prototype, and the difference in main may not be as dramatic.