### PR TITLE
chore(engine/logical): fix order/duplicates of SSA form

### DIFF
--- a/pkg/engine/planner/logical/builder_convert.go
+++ b/pkg/engine/planner/logical/builder_convert.go
@@ -67,8 +67,17 @@ func (b *ssaBuilder) processMakeTablePlan(plan *MakeTable) (Value, error) {
 		return nil, err
 	}
 
-	plan.id = fmt.Sprintf("%%%d", b.getID())
-	b.instructions = append(b.instructions, plan)
+	for _, pred := range plan.Predicates {
+		if _, err := b.process(pred); err != nil {
+			return nil, err
+		}
+	}
+
+	// Only append the first time we see this.
+	if plan.id == "" {
+		plan.id = fmt.Sprintf("%%%d", b.getID())
+		b.instructions = append(b.instructions, plan)
+	}
 	return plan, nil
 }
 
@@ -80,9 +89,11 @@ func (b *ssaBuilder) processSelectPlan(plan *Select) (Value, error) {
 		return nil, err
 	}
 
-	// Create a node for the select
-	plan.id = fmt.Sprintf("%%%d", b.getID())
-	b.instructions = append(b.instructions, plan)
+	// Only append the first time we see this.
+	if plan.id == "" {
+		plan.id = fmt.Sprintf("%%%d", b.getID())
+		b.instructions = append(b.instructions, plan)
+	}
 	return plan, nil
 }
 
@@ -91,8 +102,11 @@ func (b *ssaBuilder) processLimitPlan(plan *Limit) (Value, error) {
 		return nil, err
 	}
 
-	plan.id = fmt.Sprintf("%%%d", b.getID())
-	b.instructions = append(b.instructions, plan)
+	// Only append the first time we see this.
+	if plan.id == "" {
+		plan.id = fmt.Sprintf("%%%d", b.getID())
+		b.instructions = append(b.instructions, plan)
+	}
 	return plan, nil
 }
 
@@ -101,8 +115,11 @@ func (b *ssaBuilder) processSortPlan(plan *Sort) (Value, error) {
 		return nil, err
 	}
 
-	plan.id = fmt.Sprintf("%%%d", b.getID())
-	b.instructions = append(b.instructions, plan)
+	// Only append the first time we see this.
+	if plan.id == "" {
+		plan.id = fmt.Sprintf("%%%d", b.getID())
+		b.instructions = append(b.instructions, plan)
+	}
 	return plan, nil
 }
 
@@ -111,8 +128,11 @@ func (b *ssaBuilder) processParsePlan(plan *Parse) (Value, error) {
 		return nil, err
 	}
 
-	plan.id = fmt.Sprintf("%%%d", b.getID())
-	b.instructions = append(b.instructions, plan)
+	// Only append the first time we see this.
+	if plan.id == "" {
+		plan.id = fmt.Sprintf("%%%d", b.getID())
+		b.instructions = append(b.instructions, plan)
+	}
 	return plan, nil
 }
 
@@ -121,9 +141,11 @@ func (b *ssaBuilder) processUnaryOp(value *UnaryOp) (Value, error) {
 		return nil, err
 	}
 
-	// Create a node for the unary operation
-	value.id = fmt.Sprintf("%%%d", b.getID())
-	b.instructions = append(b.instructions, value)
+	// Only append the first time we see this.
+	if value.id == "" {
+		value.id = fmt.Sprintf("%%%d", b.getID())
+		b.instructions = append(b.instructions, value)
+	}
 	return value, nil
 }
 
@@ -132,8 +154,11 @@ func (b *ssaBuilder) processRangeAggregate(plan *RangeAggregation) (Value, error
 		return nil, err
 	}
 
-	plan.id = fmt.Sprintf("%%%d", b.getID())
-	b.instructions = append(b.instructions, plan)
+	// Only append the first time we see this.
+	if plan.id == "" {
+		plan.id = fmt.Sprintf("%%%d", b.getID())
+		b.instructions = append(b.instructions, plan)
+	}
 	return plan, nil
 }
 
@@ -142,8 +167,11 @@ func (b *ssaBuilder) processVectorAggregation(plan *VectorAggregation) (Value, e
 		return nil, err
 	}
 
-	plan.id = fmt.Sprintf("%%%d", b.getID())
-	b.instructions = append(b.instructions, plan)
+	// Only append the first time we see this.
+	if plan.id == "" {
+		plan.id = fmt.Sprintf("%%%d", b.getID())
+		b.instructions = append(b.instructions, plan)
+	}
 	return plan, nil
 }
 
@@ -154,8 +182,11 @@ func (b *ssaBuilder) processBinOp(expr *BinOp) (Value, error) {
 		return nil, err
 	}
 
-	expr.id = fmt.Sprintf("%%%d", b.getID())
-	b.instructions = append(b.instructions, expr)
+	// Only append the first time we see this.
+	if expr.id == "" {
+		expr.id = fmt.Sprintf("%%%d", b.getID())
+		b.instructions = append(b.instructions, expr)
+	}
 	return expr, nil
 }
 

--- a/pkg/engine/planner/logical/planner_test.go
+++ b/pkg/engine/planner/logical/planner_test.go
@@ -93,22 +93,22 @@ func TestConvertAST_Success(t *testing.T) {
 	expected := `%1 = EQ label.cluster "prod"
 %2 = MATCH_RE label.namespace "loki-.*"
 %3 = AND %1 %2
-%4 = MAKETABLE [selector=%3, predicates=[%12, %18], shard=0_of_1]
-%5 = SORT %4 [column=builtin.timestamp, asc=false, nulls_first=false]
-%6 = GTE builtin.timestamp 1970-01-01T01:00:00Z
-%7 = SELECT %5 [predicate=%6]
-%8 = LT builtin.timestamp 1970-01-01T02:00:00Z
-%9 = SELECT %7 [predicate=%8]
-%10 = EQ ambiguous.foo "bar"
-%11 = EQ ambiguous.bar "baz"
-%12 = OR %10 %11
-%13 = SELECT %9 [predicate=%12]
-%14 = MATCH_STR builtin.message "metric.go"
-%15 = MATCH_STR builtin.message "foo"
-%16 = AND %14 %15
-%17 = NOT_MATCH_RE builtin.message "(a|b|c)"
-%18 = AND %16 %17
-%19 = SELECT %13 [predicate=%18]
+%4 = EQ ambiguous.foo "bar"
+%5 = EQ ambiguous.bar "baz"
+%6 = OR %4 %5
+%7 = MATCH_STR builtin.message "metric.go"
+%8 = MATCH_STR builtin.message "foo"
+%9 = AND %7 %8
+%10 = NOT_MATCH_RE builtin.message "(a|b|c)"
+%11 = AND %9 %10
+%12 = MAKETABLE [selector=%3, predicates=[%6, %11], shard=0_of_1]
+%13 = SORT %12 [column=builtin.timestamp, asc=false, nulls_first=false]
+%14 = GTE builtin.timestamp 1970-01-01T01:00:00Z
+%15 = SELECT %13 [predicate=%14]
+%16 = LT builtin.timestamp 1970-01-01T02:00:00Z
+%17 = SELECT %15 [predicate=%16]
+%18 = SELECT %17 [predicate=%6]
+%19 = SELECT %18 [predicate=%11]
 %20 = LIMIT %19 [skip=0, fetch=1000]
 RETURN %20
 `
@@ -136,13 +136,13 @@ func TestConvertAST_MetricQuery_Success(t *testing.T) {
 	expected := `%1 = EQ label.cluster "prod"
 %2 = MATCH_RE label.namespace "loki-.*"
 %3 = AND %1 %2
-%4 = MAKETABLE [selector=%3, predicates=[%9], shard=0_of_1]
-%5 = GTE builtin.timestamp 1970-01-01T00:55:00Z
-%6 = SELECT %4 [predicate=%5]
-%7 = LT builtin.timestamp 1970-01-01T02:00:00Z
-%8 = SELECT %6 [predicate=%7]
-%9 = MATCH_STR builtin.message "metric.go"
-%10 = SELECT %8 [predicate=%9]
+%4 = MATCH_STR builtin.message "metric.go"
+%5 = MAKETABLE [selector=%3, predicates=[%4], shard=0_of_1]
+%6 = GTE builtin.timestamp 1970-01-01T00:55:00Z
+%7 = SELECT %5 [predicate=%6]
+%8 = LT builtin.timestamp 1970-01-01T02:00:00Z
+%9 = SELECT %7 [predicate=%8]
+%10 = SELECT %9 [predicate=%4]
 %11 = RANGE_AGGREGATION %10 [operation=count, start_ts=1970-01-01T01:00:00Z, end_ts=1970-01-01T02:00:00Z, step=0s, range=5m0s]
 %12 = VECTOR_AGGREGATION %11 [operation=sum, group_by=(ambiguous.level)]
 RETURN %12
@@ -251,6 +251,7 @@ func TestCanExecuteQuery(t *testing.T) {
 
 			logicalPlan, err := BuildPlan(q)
 			if tt.expected {
+				t.Logf("\n%s\n", logicalPlan.String())
 				require.NoError(t, err)
 			} else {
 				require.Nil(t, logicalPlan)
@@ -272,6 +273,7 @@ func TestPlannerCreatesParseFromLogfmt(t *testing.T) {
 
 		plan, err := BuildPlan(q)
 		require.NoError(t, err)
+		t.Logf("\n%s\n", plan.String())
 
 		// Assert against the correct SSA representation
 		// Since there are no filters before logfmt, parse comes right after MAKETABLE
@@ -302,6 +304,7 @@ RETURN %11
 
 		plan, err := BuildPlan(q)
 		require.NoError(t, err)
+		t.Logf("\n%s\n", plan.String())
 
 		// Assert against the SSA representation for log query
 		expected := `%1 = EQ label.app "test"
@@ -335,19 +338,20 @@ RETURN %11
 
 		plan, err := BuildPlan(q)
 		require.NoError(t, err)
+		t.Logf("\n%s\n", plan.String())
 
 		// Expected behavior - PARSE should happen after filters that don't need parsed fields
 		expected := `%1 = EQ label.job "app"
-%2 = MAKETABLE [selector=%1, predicates=[%8, %10], shard=0_of_1]
-%3 = SORT %2 [column=builtin.timestamp, asc=false, nulls_first=false]
-%4 = GTE builtin.timestamp 1970-01-01T01:00:00Z
-%5 = SELECT %3 [predicate=%4]
-%6 = LT builtin.timestamp 1970-01-01T02:00:00Z
+%2 = MATCH_STR builtin.message "error"
+%3 = EQ ambiguous.label "value"
+%4 = MAKETABLE [selector=%1, predicates=[%2, %3], shard=0_of_1]
+%5 = SORT %4 [column=builtin.timestamp, asc=false, nulls_first=false]
+%6 = GTE builtin.timestamp 1970-01-01T01:00:00Z
 %7 = SELECT %5 [predicate=%6]
-%8 = MATCH_STR builtin.message "error"
+%8 = LT builtin.timestamp 1970-01-01T02:00:00Z
 %9 = SELECT %7 [predicate=%8]
-%10 = EQ ambiguous.label "value"
-%11 = SELECT %9 [predicate=%10]
+%10 = SELECT %9 [predicate=%2]
+%11 = SELECT %10 [predicate=%3]
 %12 = PARSE %11 [kind=logfmt]
 %13 = EQ ambiguous.level "debug"
 %14 = SELECT %12 [predicate=%13]
@@ -369,19 +373,20 @@ RETURN %15
 
 		plan, err := BuildPlan(q)
 		require.NoError(t, err)
+		t.Logf("\n%s\n", plan.String())
 
 		// Expected behavior - PARSE should happen after filters that don't need parsed fields
 		// For metric queries: no SORT, but time range filters are applied earlier
 		expected := `%1 = EQ label.job "app"
-%2 = MAKETABLE [selector=%1, predicates=[%7, %9], shard=0_of_1]
-%3 = GTE builtin.timestamp 1970-01-01T00:55:00Z
-%4 = SELECT %2 [predicate=%3]
-%5 = LT builtin.timestamp 1970-01-01T02:00:00Z
+%2 = MATCH_STR builtin.message "error"
+%3 = EQ ambiguous.label "value"
+%4 = MAKETABLE [selector=%1, predicates=[%2, %3], shard=0_of_1]
+%5 = GTE builtin.timestamp 1970-01-01T00:55:00Z
 %6 = SELECT %4 [predicate=%5]
-%7 = MATCH_STR builtin.message "error"
+%7 = LT builtin.timestamp 1970-01-01T02:00:00Z
 %8 = SELECT %6 [predicate=%7]
-%9 = EQ ambiguous.label "value"
-%10 = SELECT %8 [predicate=%9]
+%9 = SELECT %8 [predicate=%2]
+%10 = SELECT %9 [predicate=%3]
 %11 = PARSE %10 [kind=logfmt]
 %12 = EQ ambiguous.level "debug"
 %13 = SELECT %11 [predicate=%12]


### PR DESCRIPTION
This fixes the SSA form of logical plans to follow linearly, such that no instruction or value references a value (by ID) declared after it. This was caused by predicates on MAKETABLE not being added as instructions when they were first encountered.

Fixing this also revealed that an instruction/value with two references was generating a new ID for each time it was walked. This is also fixed by only generating an ID if one does not already exist.

Fixing these issues does not change the behaviour of the logical plan; it just makes the SSA printed form more consistent with how SSA forms are typically formatted.