### PR TITLE
chore(engine): Eliminate no-op Merge/SortMerge nodes during plan optimization

### DIFF
--- a/pkg/engine/planner/physical/optimizer.go
+++ b/pkg/engine/planner/physical/optimizer.go
@@ -35,6 +35,26 @@ func (r *removeNoopFilter) apply(node Node) bool {
 
 var _ rule = (*removeNoopFilter)(nil)
 
+// removeNoopMerge is a rule that removes merge/sortmerge nodes with only a single input
+type removeNoopMerge struct {
+	plan *Plan
+}
+
+// apply implements rule.
+func (r *removeNoopMerge) apply(node Node) bool {
+	changed := false
+	switch node := node.(type) {
+	case *Merge, *SortMerge:
+		if len(r.plan.Children(node)) <= 1 {
+			r.plan.eliminateNode(node)
+			changed = true
+		}
+	}
+	return changed
+}
+
+var _ rule = (*removeNoopMerge)(nil)
+
 // predicatePushdown is a rule that moves down filter predicates to the scan nodes.
 type predicatePushdown struct {
 	plan *Plan

--- a/pkg/engine/planner/physical/planner.go
+++ b/pkg/engine/planner/physical/planner.go
@@ -381,13 +381,16 @@ func (p *Planner) Optimize(plan *Plan) (*Plan, error) {
 		optimizations := []*optimization{
 			newOptimization("PredicatePushdown", plan).withRules(
 				&predicatePushdown{plan: plan},
-				&removeNoopFilter{plan: plan},
 			),
 			newOptimization("LimitPushdown", plan).withRules(
 				&limitPushdown{plan: plan},
 			),
 			newOptimization("ProjectionPushdown", plan).withRules(
 				&projectionPushdown{plan: plan},
+			),
+			newOptimization("Cleanup", plan).withRules(
+				&removeNoopFilter{plan: plan},
+				&removeNoopMerge{plan: plan},
 			),
 		}
 		optimizer := newOptimizer(plan, optimizations)


### PR DESCRIPTION
### Summary

`Merge` and `SortMerge` nodes with 1 or less children are effectively no-op nodes and can safely be removed from the plan during the optimization phase.