### PR TITLE
chore: Two small fixes for new engine

### DIFF
--- a/pkg/dataobj/metastore/object.go
+++ b/pkg/dataobj/metastore/object.go
@@ -679,6 +679,8 @@ func (m *ObjectMetastore) listObjects(ctx context.Context, path string, start, e
 	if err != nil {
 		return nil, err
 	}
+	defer objectReader.Close()
+
 	n, err := buf.ReadFrom(objectReader)
 	if err != nil {
 		return nil, fmt.Errorf("reading metastore object: %w", err)

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -48,6 +48,9 @@ func New(opts logql.EngineOpts, cfg metastore.Config, bucket objstore.Bucket, li
 	if opts.BatchSize <= 0 {
 		panic(fmt.Sprintf("invalid batch size for query engine. must be greater than 0, got %d", opts.BatchSize))
 	}
+	if opts.RangeConfig.IsZero() {
+		opts.RangeConfig = rangeio.DefaultConfig
+	}
 
 	return &QueryEngine{
 		logger:    logger,

--- a/pkg/util/rangeio/rangeio.go
+++ b/pkg/util/rangeio/rangeio.go
@@ -106,6 +106,10 @@ func (cfg *Config) RegisterFlags(prefix string, fs *flag.FlagSet) {
 	fs.IntVar(&cfg.MinRangeSize, prefix+"min-range-size", DefaultConfig.MinRangeSize, "Experimental: minimum size of a byte range")
 }
 
+func (cfg *Config) IsZero() bool {
+	return cfg.MaxParallelism == 0 && cfg.CoalesceSize == 0 && cfg.MaxRangeSize == 0 && cfg.MinRangeSize == 0
+}
+
 // effectiveParallelism returns the effective parallelism limit.
 func (cfg *Config) effectiveParallelism() int {
 	if cfg.MaxParallelism <= 0 {


### PR DESCRIPTION
**What this PR does / why we need it**:
Two small fixes:
* Closes a GCS reader that wasn't closed. This probably caused a very slow memory leak of a few KB per query.
* Sets the rangeio defaults if they aren't passed in as opts to the engine. In a querier, these are parsed from flags but in my case I was running the engine via some debug tooling which didn't pick the defaults up.
