### PR TITLE
chore(engine): Do not print ID of physical plan nodes

### DIFF
--- a/pkg/engine/planner/internal/tree/printer.go
+++ b/pkg/engine/planner/internal/tree/printer.go
@@ -28,11 +28,11 @@ func NewPrinter(w io.StringWriter) *Printer {
 // the printer's [io.StringWriter].
 // Example output:
 //
-//	SortMerge #sort order=ASC column=timestamp
-//	├── Limit #limit1 limit=1000
-//	│   └── DataObjScan #scan1 location=dataobj_1
-//	└── Limit #limit2 limit=1000
-//	    └── DataObjScan #scan2 location=dataobj_2
+//	SortMerge <0x01852d53> order=ASC column=timestamp
+//	├── Limit <0x828d1d87> limit=1000
+//	│   └── DataObjScan <0x28ce484d> location=dataobj_1
+//	└── Limit <0x1f4fefad> limit=1000
+//	    └── DataObjScan <0x75cbff84> location=dataobj_2
 func (tp *Printer) Print(root *Node) {
 	tp.printNode(root)
 	tp.printChildren(root.Comments, root.Children, "")

--- a/pkg/engine/planner/physical/printer.go
+++ b/pkg/engine/planner/physical/printer.go
@@ -26,7 +26,7 @@ func toTree(p *Plan, n Node) *tree.Node {
 }
 
 func toTreeNode(n Node) *tree.Node {
-	treeNode := tree.NewNode(n.Type().String(), n.ID())
+	treeNode := tree.NewNode(n.Type().String(), "")
 	switch node := n.(type) {
 	case *DataObjScan:
 		treeNode.Properties = []tree.Property{


### PR DESCRIPTION
### Summary

Node IDs, if not explicitly set, are the memory address of the object, so they do not have any real meaning at the moment and they clutter the plan representation, e.g. when logged. 

<img width="1312" height="714" alt="screenshot_20250923_120542" src="https://github.com/user-attachments/assets/0c220fbd-e3dc-410f-8138-c53b910ea4d4" />
 