### PR TITLE
chore: deleted unused code from OffsetManager

### DIFF
--- a/pkg/kafka/partition/offset_manager.go
+++ b/pkg/kafka/partition/offset_manager.go
@@ -22,8 +22,8 @@ type OffsetManager interface {
 	Topic() string
 	ConsumerGroup() string
 
-	FetchLastCommittedOffset(ctx context.Context, partition int32) (int64, error)
-	FetchPartitionOffset(ctx context.Context, partition int32, position SpecialOffset) (int64, error)
+	LastCommittedOffset(ctx context.Context, partition int32) (int64, error)
+	PartitionOffset(ctx context.Context, partition int32, position SpecialOffset) (int64, error)
 	NextOffset(ctx context.Context, partition int32, t time.Time) (int64, error)
 	Commit(ctx context.Context, partition int32, offset int64) error
 }
@@ -108,8 +108,8 @@ func (r *KafkaOffsetManager) NextOffset(ctx context.Context, partition int32, t 
 	return listed.Offset, nil
 }
 
-// FetchLastCommittedOffset retrieves the last committed offset for this partition
-func (r *KafkaOffsetManager) FetchLastCommittedOffset(ctx context.Context, partitionID int32) (int64, error) {
+// LastCommittedOffset retrieves the last committed offset for this partition
+func (r *KafkaOffsetManager) LastCommittedOffset(ctx context.Context, partitionID int32) (int64, error) {
 	req := kmsg.NewPtrOffsetFetchRequest()
 	req.Topics = []kmsg.OffsetFetchRequestTopic{{
 		Topic:      r.cfg.Topic,
@@ -154,7 +154,7 @@ func (r *KafkaOffsetManager) FetchLastCommittedOffset(ctx context.Context, parti
 }
 
 // FetchPartitionOffset retrieves the offset for a specific position
-func (r *KafkaOffsetManager) FetchPartitionOffset(ctx context.Context, partitionID int32, position SpecialOffset) (int64, error) {
+func (r *KafkaOffsetManager) PartitionOffset(ctx context.Context, partitionID int32, position SpecialOffset) (int64, error) {
 	partitionReq := kmsg.NewListOffsetsRequestTopicPartition()
 	partitionReq.Partition = partitionID
 	partitionReq.Timestamp = int64(position)

--- a/pkg/limits/partition_lifecycler.go
+++ b/pkg/limits/partition_lifecycler.go
@@ -78,7 +78,7 @@ func (l *partitionLifecycler) determineStateFromOffsets(ctx context.Context, par
 	logger := log.With(l.logger, "partition", partition)
 	// Get the start offset for the partition. This can be greater than zero
 	// if a retention period has deleted old records.
-	startOffset, err := l.offsetManager.FetchPartitionOffset(
+	startOffset, err := l.offsetManager.PartitionOffset(
 		ctx, partition, kafka_partition.KafkaStartOffset)
 	if err != nil {
 		return fmt.Errorf("failed to get last produced offset: %w", err)
@@ -87,7 +87,7 @@ func (l *partitionLifecycler) determineStateFromOffsets(ctx context.Context, par
 	// record. For example, if a partition contains 1 record, then the last
 	// produced offset is 1. However, the offset of the last produced record
 	// is 0, as offsets start from 0.
-	lastProducedOffset, err := l.offsetManager.FetchPartitionOffset(
+	lastProducedOffset, err := l.offsetManager.PartitionOffset(
 		ctx, partition, kafka_partition.KafkaEndOffset)
 	if err != nil {
 		return fmt.Errorf("failed to get last produced offset: %w", err)


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR is the first of two PRs of de-coupling the offset manager from our shared Kafka configuration. It deletes some un-used code that was only used in the block builder and scheduler (since deleted), and just normalizes some method names.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
