### PR TITLE
feat: decouple offset manager from shared Kafka configuration

### DIFF
--- a/pkg/kafka/partition/committer_test.go
+++ b/pkg/kafka/partition/committer_test.go
@@ -35,13 +35,12 @@ func TestPartitionCommitter(t *testing.T) {
 	defer admClient.Close()
 
 	// Set up a committer for partition 1 and another for partition 2.
-	offsetManager, err := NewKafkaOffsetManager(
-		kafkaCfg,
+	offsetManager := NewKafkaOffsetManager(
+		client,
+		topic,
 		consumerGroup,
 		log.NewNopLogger(),
-		prometheus.NewRegistry(),
 	)
-	require.NoError(t, err)
 	partition1 := int32(1)
 	committer1 := newCommitter(
 		offsetManager,

--- a/pkg/limits/service.go
+++ b/pkg/limits/service.go
@@ -99,11 +99,15 @@ func New(cfg Config, limits Limits, logger log.Logger, reg prometheus.Registerer
 	kCfg.Topic = cfg.Topic
 	kCfg.AutoCreateTopicEnabled = true
 	kCfg.AutoCreateTopicDefaultPartitions = cfg.NumPartitions
-	offsetManager, err := partition.NewKafkaOffsetManager(
-		kCfg,
+	offsetManagerClient, err := client.NewReaderClient("partition-manager", kCfg, log.With(logger, "component", "kafka-client"), reg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create offset manager client: %w", err)
+	}
+	offsetManager := partition.NewKafkaOffsetManager(
+		offsetManagerClient,
+		cfg.Topic,
 		cfg.ConsumerGroup,
 		logger,
-		prometheus.NewRegistry(),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create offset manager: %w", err)


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit decouples the offset manager from the shared Kafka configuration. This is important as I will soon start work on a Kafka V2 client with a new configuration struct that is more generic and less coupled to the needs of partition ingesters.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
