### PR TITLE
fix: Updates querier stats based on response stats(#11264)

### DIFF
--- a/pkg/querier/queryrange/stats.go
+++ b/pkg/querier/queryrange/stats.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/middleware"
+	querier_stats "github.com/grafana/loki/v3/pkg/querier/stats"
 	promql_parser "github.com/prometheus/prometheus/promql/parser"
 
 	"github.com/grafana/loki/v3/pkg/logproto"
@@ -196,6 +197,16 @@ func StatsCollectorMiddleware() queryrangebase.Middleware {
 				// Log and record metrics for the current query
 				responseStats.ComputeSummary(time.Since(start), 0, totalEntries)
 				logger.LogKV(responseStats.KVList()...)
+				// update querier_stats.Stats so that frontend component can log stats info passed through ctx
+				if querierStats := querier_stats.FromContext(ctx); querierStats != nil {
+					querierStats.AddWallTime(time.Since(start))
+					if responseStats.Summary.TotalLinesProcessed > 0 {
+						querierStats.AddFetchedSeries(uint64(responseStats.Summary.TotalLinesProcessed))
+					}
+					if responseStats.Summary.TotalBytesProcessed > 0 {
+						querierStats.AddFetchedChunkBytes(uint64(responseStats.Summary.TotalBytesProcessed))
+					}
+				}
 			}
 			ctxValue := ctx.Value(ctxKey)
 			if data, ok := ctxValue.(*queryData); ok {


### PR DESCRIPTION
Populates the querier stats with data derived from the query range response stats. This change allows the frontend component to access and log stats information passed through the context, providing a more comprehensive view of query performance.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #11264 , fix zero value in "query stats" logs.

Since `querier_stats.Stats` is set to context here but never updated before log，we'll always get zero values 
https://github.com/grafana/loki/blob/428328b452d2de19e92ce48b61da7cee25e517ed/pkg/lokifrontend/frontend/transport/handler.go#L123


logs after this fixing: 
`query_wall_time_seconds`,`fetched_series_count`,`fetched_series_count` will not be zero.

```
level=info ts=2025-09-25T07:47:56.16836Z caller=handler.go:323 org_id=xxx msg="query stats" component=query-frontend method=GET status=200 path=/loki/api/v1/query_range response_time=789.782583ms query_wall_time_seconds=0.959356417 fetched_series_count=5052 fetched_chunks_bytes=762099 param_start=1758542240865000000 param_end=1758545840865000000 param_direction=backward param_query="xxx" param_limit=1 header_x_grafana_user=huxiang header_user_agent=Grafana/8.5
```

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
