### PR TITLE
chore: inject consumer group into offset manager

### DIFF
--- a/pkg/kafka/partition/offset_manager.go
+++ b/pkg/kafka/partition/offset_manager.go
@@ -31,16 +31,16 @@ type OffsetManager interface {
 var _ OffsetManager = &KafkaOffsetManager{}
 
 type KafkaOffsetManager struct {
-	client      *kgo.Client
-	adminClient *kadm.Client
-	cfg         kafka.Config
-	instanceID  string
-	logger      log.Logger
+	client        *kgo.Client
+	adminClient   *kadm.Client
+	cfg           kafka.Config
+	consumerGroup string
+	logger        log.Logger
 }
 
 func NewKafkaOffsetManager(
 	cfg kafka.Config,
-	instanceID string,
+	consumerGroup string,
 	logger log.Logger,
 	reg prometheus.Registerer,
 ) (*KafkaOffsetManager, error) {
@@ -53,7 +53,7 @@ func NewKafkaOffsetManager(
 	return newKafkaOffsetManager(
 		c,
 		cfg,
-		instanceID,
+		consumerGroup,
 		logger,
 	), nil
 }
@@ -62,15 +62,15 @@ func NewKafkaOffsetManager(
 func newKafkaOffsetManager(
 	client *kgo.Client,
 	cfg kafka.Config,
-	instanceID string,
+	consumerGroup string,
 	logger log.Logger,
 ) *KafkaOffsetManager {
 	return &KafkaOffsetManager{
-		client:      client,
-		adminClient: kadm.NewClient(client),
-		cfg:         cfg,
-		instanceID:  instanceID,
-		logger:      logger,
+		client:        client,
+		adminClient:   kadm.NewClient(client),
+		cfg:           cfg,
+		consumerGroup: consumerGroup,
+		logger:        logger,
 	}
 }
 
@@ -80,7 +80,7 @@ func (r *KafkaOffsetManager) Topic() string {
 }
 
 func (r *KafkaOffsetManager) ConsumerGroup() string {
-	return r.cfg.GetConsumerGroup(r.instanceID)
+	return r.consumerGroup
 }
 
 // NextOffset returns the first offset after the timestamp t. If the partition

--- a/pkg/kafka/partition/offset_manager.go
+++ b/pkg/kafka/partition/offset_manager.go
@@ -70,7 +70,7 @@ func newKafkaOffsetManager(
 		adminClient:   kadm.NewClient(client),
 		cfg:           cfg,
 		consumerGroup: consumerGroup,
-		logger:        logger,
+		logger:        log.With(logger, "topic", cfg.Topic, "consumer_group", consumerGroup),
 	}
 }
 

--- a/pkg/kafka/partition/reader_service.go
+++ b/pkg/kafka/partition/reader_service.go
@@ -84,9 +84,10 @@ func NewReaderService(
 		return nil, fmt.Errorf("creating kafka reader: %w", err)
 	}
 
+	consumerGroup := kafkaCfg.GetConsumerGroup(instanceID)
 	offsetManager, err := NewKafkaOffsetManager(
 		kafkaCfg,
-		instanceID,
+		consumerGroup,
 		logger,
 		reg,
 	)


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit contains another intermediate change as part of a wider effort to make the offset manager independent of the Kafka configuration. Instead of passing a `kafka.Config` to figure out the consumer group we pass it instead. This leaves just the topic to extract which we will do in another commit.


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
