### PR TITLE
fix: Add special case handling for comparing empty and nil values

### DIFF
--- a/pkg/dataobj/internal/dataset/value.go
+++ b/pkg/dataobj/internal/dataset/value.go
@@ -269,8 +269,16 @@ func CompareValues(a, b *Value) int {
 	// Handle nil values first to avoid the panic if the types don't match.
 	switch {
 	case aNil && !bNil:
+		if bType == datasetmd.PHYSICAL_TYPE_BINARY && b.cap == 0 {
+			// Nil value for a and empty string for b should still be treated as equal
+			return 0
+		}
 		return -1
 	case !aNil && bNil:
+		if aType == datasetmd.PHYSICAL_TYPE_BINARY && a.cap == 0 {
+			// Empty string for a and nil value for b should still be treated as equal
+			return 0
+		}
 		return 1
 	case aNil && bNil:
 		return 0

--- a/pkg/dataobj/internal/dataset/value.go
+++ b/pkg/dataobj/internal/dataset/value.go
@@ -269,13 +269,13 @@ func CompareValues(a, b *Value) int {
 	// Handle nil values first to avoid the panic if the types don't match.
 	switch {
 	case aNil && !bNil:
-		if bType == datasetmd.PHYSICAL_TYPE_BINARY && b.cap == 0 {
+		if b.IsZero() {
 			// Nil value for a and empty string for b should still be treated as equal
 			return 0
 		}
 		return -1
 	case !aNil && bNil:
-		if aType == datasetmd.PHYSICAL_TYPE_BINARY && a.cap == 0 {
+		if a.IsZero() {
 			// Empty string for a and nil value for b should still be treated as equal
 			return 0
 		}

--- a/pkg/dataobj/internal/dataset/value.go
+++ b/pkg/dataobj/internal/dataset/value.go
@@ -269,13 +269,13 @@ func CompareValues(a, b *Value) int {
 	// Handle nil values first to avoid the panic if the types don't match.
 	switch {
 	case aNil && !bNil:
-		if b.IsZero() {
+		if bType == datasetmd.PHYSICAL_TYPE_BINARY && b.IsZero() {
 			// Nil value for a and empty string for b should still be treated as equal
 			return 0
 		}
 		return -1
 	case !aNil && bNil:
-		if a.IsZero() {
+		if aType == datasetmd.PHYSICAL_TYPE_BINARY && a.IsZero() {
 			// Empty string for a and nil value for b should still be treated as equal
 			return 0
 		}

--- a/pkg/dataobj/internal/dataset/value_test.go
+++ b/pkg/dataobj/internal/dataset/value_test.go
@@ -102,6 +102,30 @@ func BenchmarkCompareValues(b *testing.B) {
 	}
 }
 
+func TestEmptyNil_CompareValues(t *testing.T) {
+	t.Run("Empty vs empty", func(t *testing.T) {
+		a := dataset.BinaryValue([]byte{})
+		b := dataset.BinaryValue([]byte{})
+
+		require.Equal(t, dataset.CompareValues(&a, &b), 0)
+	})
+
+	t.Run("Nil vs empty", func(t *testing.T) {
+		var a dataset.Value
+		b := dataset.BinaryValue([]byte{})
+
+		require.Equal(t, dataset.CompareValues(&a, &b), 0)
+		require.Equal(t, dataset.CompareValues(&b, &a), 0)
+	})
+	t.Run("Nil vs nil", func(t *testing.T) {
+		var a dataset.Value
+		var b dataset.Value
+
+		require.Equal(t, dataset.CompareValues(&a, &b), 0)
+		require.Equal(t, dataset.CompareValues(&b, &a), 0)
+	})
+}
+
 func TestValue_MarshalBinary(t *testing.T) {
 	t.Run("Null", func(t *testing.T) {
 		var expect dataset.Value


### PR DESCRIPTION
**What this PR does / why we need it**:
We can have a predicate checking for an empty string, e.g. {"foo" = ""}. If a row has no value for the column "foo", it will return a nil value for that column. Thus, when we go to compare the row with the predicate, we will be comparing an empty value to a nil value. This change adjusts the comparison check so that we correctly handle this special case.


**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [n/a] Documentation added
- [X] Tests updated
- [X] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [n/a] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [n/a] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
