### PR TITLE
feat(otlp): support OpenTelemetry EventName field

### DIFF
--- a/pkg/loghttp/push/otlp.go
+++ b/pkg/loghttp/push/otlp.go
@@ -548,6 +548,14 @@ func otlpLogToPushEntry(log plog.LogRecord, otlpConfig OTLPConfig, logServiceNam
 		})
 	}
 
+	// Add EventName as structured metadata if present
+	if eventName := log.EventName(); eventName != "" {
+		structuredMetadata = append(structuredMetadata, push.LabelAdapter{
+			Name:  "event_name",
+			Value: eventName,
+		})
+	}
+
 	return logLabels, push.Entry{
 		Timestamp:          timestampFromLogRecord(log),
 		Line:               log.Body().AsString(),

--- a/pkg/loghttp/push/otlp_test.go
+++ b/pkg/loghttp/push/otlp_test.go
@@ -701,6 +701,26 @@ func TestOTLPLogToPushEntry(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "with event name",
+			buildLogRecord: func() plog.LogRecord {
+				log := plog.NewLogRecord()
+				log.Body().SetStr("log body")
+				log.SetTimestamp(pcommon.Timestamp(now.UnixNano()))
+				log.SetEventName("browser.page_view")
+				return log
+			},
+			expectedResp: push.Entry{
+				Timestamp: now,
+				Line:      "log body",
+				StructuredMetadata: push.LabelsAdapter{
+					{
+						Name:  "event_name",
+						Value: "browser.page_view",
+					},
+				},
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			_, res, err := otlpLogToPushEntry(tc.buildLogRecord(), DefaultOTLPConfig(defaultGlobalOTLPConfig), false, nil)


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds support for OpenTelemetry EventName field in Loki's OTLP log ingestion. Previously, when sending OTLP logs with EventName to Loki, the EventName field was not visible or searchable, making it difficult to work with OpenTelemetry Events.

The implementation extracts the EventName from OTLP LogRecord and stores it as structured metadata with the key `event_name`, making it searchable and filterable while avoiding high cardinality issues.

**Which issue(s) this PR fixes**:
Fixes #19260

**Special notes for your reviewer**:

- EventName is stored as structured metadata (not as a label) to maintain searchability while avoiding cardinality concerns
- The implementation follows existing patterns in the OTLP processing pipeline
- Comprehensive test coverage has been added to ensure EventName handling works correctly
- This change maintains full backward compatibility with existing OTLP log processing


**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added (inline code comments)
- [x] Tests updated (added EventName test case)
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md` (not applicable - this is additive functionality)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively (not applicable)