### PR TITLE
feat(operator): s3 validation reject endpoints that contain a URL path

### DIFF
--- a/operator/internal/handlers/internal/storage/secrets.go
+++ b/operator/internal/handlers/internal/storage/secrets.go
@@ -42,7 +42,7 @@ var (
 	errS3EndpointUnparseable       = errors.New("can not parse S3 endpoint as URL")
 	errS3EndpointNoURL             = errors.New("endpoint for S3 must be an HTTP or HTTPS URL")
 	errS3EndpointUnsupportedScheme = errors.New("scheme of S3 endpoint URL is unsupported")
-	errS3EndpointAWSPathNotAllowed = errors.New("endpoint for AWS S3 must not include a path")
+	errS3EndpointPathNotAllowed    = errors.New("endpoint for S3 must not include a path")
 	errS3EndpointAWSInvalid        = errors.New("endpoint for AWS S3 must include correct region")
 	errS3ForcePathStyleInvalid     = errors.New(`forcepathstyle must be "true" or "false"`)
 
@@ -502,11 +502,11 @@ func validateS3Endpoint(endpoint string, region string) error {
 		return fmt.Errorf("%w: %s", errS3EndpointUnsupportedScheme, parsedURL.Scheme)
 	}
 
-	if strings.HasSuffix(parsedURL.Host, awsEndpointSuffix) {
-		if parsedURL.Path != "" && parsedURL.Path != "/" {
-			return fmt.Errorf("%w: %s", errS3EndpointAWSPathNotAllowed, parsedURL.Path)
-		}
+	if parsedURL.Path != "" && parsedURL.Path != "/" {
+		return fmt.Errorf("%w: %s", errS3EndpointPathNotAllowed, parsedURL.Path)
+	}
 
+	if strings.HasSuffix(parsedURL.Host, awsEndpointSuffix) {
 		if len(region) == 0 {
 			return fmt.Errorf("%w: %s", errSecretMissingField, storage.KeyAWSRegion)
 		}

--- a/operator/internal/handlers/internal/storage/secrets_test.go
+++ b/operator/internal/handlers/internal/storage/secrets_test.go
@@ -615,7 +615,7 @@ func TestS3Extract(t *testing.T) {
 					"access_key_secret": []byte("secret"),
 				},
 			},
-			wantCredentialMode: lokiv1.CredentialModeStatic,
+			wantError: "endpoint for S3 must not include a path: /bucket",
 		},
 		{
 			name: "aws endpoint with path",
@@ -629,7 +629,7 @@ func TestS3Extract(t *testing.T) {
 					"access_key_secret": []byte("secret"),
 				},
 			},
-			wantError: "endpoint for AWS S3 must not include a path: /bucket",
+			wantError: "endpoint for S3 must not include a path: /bucket",
 		},
 		{
 			name: "s3 region used in endpoint URL is incorrect",


### PR DESCRIPTION
**What this PR does / why we need it**:
S3 validation reject endpoints that contain a URL path

**Which issue(s) this PR fixes**:
https://issues.redhat.com/browse/LOG-7808

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
