### PR TITLE
chore: Handle empty message values in v2 logs reader

### DIFF
--- a/pkg/dataobj/internal/dataset/column_test.go
+++ b/pkg/dataobj/internal/dataset/column_test.go
@@ -55,7 +55,7 @@ func TestColumnBuilder_ReadWrite(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, ColumnType{Physical: datasetmd.PHYSICAL_TYPE_BINARY, Logical: "data"}, col.Desc.Type)
 	require.Equal(t, len(in), col.Desc.RowsCount)
-	require.Equal(t, len(in)-2, col.Desc.ValuesCount) // -2 for the empty strings
+	require.Equal(t, len(in), col.Desc.ValuesCount)
 	require.GreaterOrEqual(t, len(col.Pages), len(in)/pageMaxRows)
 
 	t.Log("Uncompressed size:", col.Desc.UncompressedSize)
@@ -90,10 +90,6 @@ func TestColumnBuilder_ReadWrite(t *testing.T) {
 
 func TestColumnBuilder_MinMax(t *testing.T) {
 	var (
-		// We include the null string in the test to ensure that it's never
-		// considered in min/max ranges.
-		nullString = ""
-
 		aString = strings.Repeat("a", 100)
 		bString = strings.Repeat("b", 100)
 		cString = strings.Repeat("c", 100)
@@ -104,8 +100,6 @@ func TestColumnBuilder_MinMax(t *testing.T) {
 	)
 
 	in := []string{
-		nullString,
-
 		// We append strings out-of-order below to ensure that the min/max
 		// comparisons are working properly.
 		//

--- a/pkg/dataobj/internal/dataset/page_builder.go
+++ b/pkg/dataobj/internal/dataset/page_builder.go
@@ -99,7 +99,7 @@ func (b *pageBuilder) canAppend(n, valueSize int) bool {
 // Append appends value into the pageBuilder. Append returns true if the data
 // was appended; false if the pageBuilder is full.
 func (b *pageBuilder) Append(value Value) bool {
-	if value.IsNil() || value.IsZero() {
+	if value.IsNil() {
 		return b.AppendNull()
 	}
 

--- a/pkg/dataobj/internal/dataset/page_reader_test.go
+++ b/pkg/dataobj/internal/dataset/page_reader_test.go
@@ -116,7 +116,7 @@ func Test_pageReader_SkipRows(t *testing.T) {
 
 	page := buildPage(t, opts, pageReaderTestStrings)
 	require.Equal(t, len(pageReaderTestStrings), page.Desc.RowCount)
-	require.Equal(t, len(pageReaderTestStrings)-2, page.Desc.ValuesCount) // -2 for the empty strings
+	require.Equal(t, len(pageReaderTestStrings), page.Desc.ValuesCount)
 
 	t.Log("Uncompressed size: ", page.Desc.UncompressedSize)
 	t.Log("Compressed size: ", page.Desc.CompressedSize)

--- a/pkg/dataobj/internal/dataset/page_reader_test.go
+++ b/pkg/dataobj/internal/dataset/page_reader_test.go
@@ -34,7 +34,7 @@ func Test_pageReader(t *testing.T) {
 
 	page := buildPage(t, opts, pageReaderTestStrings)
 	require.Equal(t, len(pageReaderTestStrings), page.Desc.RowCount)
-	require.Equal(t, len(pageReaderTestStrings)-2, page.Desc.ValuesCount) // -2 for the empty strings
+	require.Equal(t, len(pageReaderTestStrings), page.Desc.ValuesCount)
 
 	t.Log("Uncompressed size: ", page.Desc.UncompressedSize)
 	t.Log("Compressed size: ", page.Desc.CompressedSize)
@@ -57,7 +57,7 @@ func Test_pageReader_SeekToStart(t *testing.T) {
 
 	page := buildPage(t, opts, pageReaderTestStrings)
 	require.Equal(t, len(pageReaderTestStrings), page.Desc.RowCount)
-	require.Equal(t, len(pageReaderTestStrings)-2, page.Desc.ValuesCount) // -2 for the empty strings
+	require.Equal(t, len(pageReaderTestStrings), page.Desc.ValuesCount)
 
 	t.Log("Uncompressed size: ", page.Desc.UncompressedSize)
 	t.Log("Compressed size: ", page.Desc.CompressedSize)
@@ -87,7 +87,7 @@ func Test_pageReader_Reset(t *testing.T) {
 
 	page := buildPage(t, opts, pageReaderTestStrings)
 	require.Equal(t, len(pageReaderTestStrings), page.Desc.RowCount)
-	require.Equal(t, len(pageReaderTestStrings)-2, page.Desc.ValuesCount) // -2 for the empty strings
+	require.Equal(t, len(pageReaderTestStrings), page.Desc.ValuesCount)
 
 	t.Log("Uncompressed size: ", page.Desc.UncompressedSize)
 	t.Log("Compressed size: ", page.Desc.CompressedSize)

--- a/pkg/dataobj/internal/dataset/page_test.go
+++ b/pkg/dataobj/internal/dataset/page_test.go
@@ -155,7 +155,7 @@ func Test_pageBuilder_WriteRead(t *testing.T) {
 	page, err := b.Flush()
 	require.NoError(t, err)
 	require.Equal(t, len(in), page.Desc.RowCount)
-	require.Equal(t, len(in)-2, page.Desc.ValuesCount) // -2 for the empty strings
+	require.Equal(t, len(in), page.Desc.ValuesCount)
 
 	t.Log("Uncompressed size: ", page.Desc.UncompressedSize)
 	t.Log("Compressed size: ", page.Desc.CompressedSize)

--- a/pkg/dataobj/internal/dataset/reader_basic_test.go
+++ b/pkg/dataobj/internal/dataset/reader_basic_test.go
@@ -114,7 +114,7 @@ func Test_basicReader_ReadColumns(t *testing.T) {
 			if testPerson.middleName != "" {
 				require.Equal(t, testPerson.middleName, string(row.Values[1].Binary()), "middle_name mismatch")
 			} else {
-				require.True(t, row.Values[1].IsNil(), "middle_name should be nil")
+				require.True(t, row.Values[1].IsZero(), "middle_name should be nil")
 			}
 			require.Equal(t, testPerson.birthYear, row.Values[3].Int64(), "birth_year mismatch")
 
@@ -212,7 +212,6 @@ func Test_partitionRows(t *testing.T) {
 			require.Equal(t, tc.expect, actual)
 		})
 	}
-
 }
 
 func Test_basicReader_Reset(t *testing.T) {

--- a/pkg/dataobj/sections/logs/reader.go
+++ b/pkg/dataobj/sections/logs/reader.go
@@ -182,12 +182,7 @@ func (r *Reader) Read(ctx context.Context, batchSize int) (arrow.Record, error) 
 			columnType := r.opts.Columns[columnIndex].Type
 
 			if val.IsNil() {
-				if columnType == ColumnTypeMessage {
-					// Message columns are required, so return an empty value instead of a NULL value.
-					columnBuilder.(*array.StringBuilder).BinaryBuilder.AppendEmptyValue()
-				} else {
-					columnBuilder.AppendNull()
-				}
+				columnBuilder.AppendNull()
 				continue
 			}
 

--- a/pkg/dataobj/sections/logs/reader.go
+++ b/pkg/dataobj/sections/logs/reader.go
@@ -179,9 +179,15 @@ func (r *Reader) Read(ctx context.Context, batchSize int) (arrow.Record, error) 
 			}
 
 			columnBuilder := builder.Field(columnIndex)
+			columnType := r.opts.Columns[columnIndex].Type
 
 			if val.IsNil() {
-				columnBuilder.AppendNull()
+				if columnType == ColumnTypeMessage {
+					// Message columns are required, so return an empty value instead of a NULL value.
+					columnBuilder.(*array.StringBuilder).BinaryBuilder.AppendEmptyValue()
+				} else {
+					columnBuilder.AppendNull()
+				}
 				continue
 			}
 
@@ -193,7 +199,6 @@ func (r *Reader) Read(ctx context.Context, batchSize int) (arrow.Record, error) 
 			// Passing our byte slices to [array.StringBuilder.BinaryBuilder.Append] are safe; it
 			// will copy the contents of the value and we can reuse the buffer on the
 			// next call to [dataset.Reader.Read].
-			columnType := r.opts.Columns[columnIndex].Type
 			switch columnType {
 			case ColumnTypeInvalid:
 				columnBuilder.AppendNull() // Unsupported column

--- a/pkg/dataobj/sections/logs/reader_test.go
+++ b/pkg/dataobj/sections/logs/reader_test.go
@@ -31,19 +31,22 @@ func TestReader(t *testing.T) {
 		{StreamID: 2, Timestamp: unixTime(30), Metadata: labels.FromStrings("trace_id", "123456"), Line: []byte("foo bar")},
 		{StreamID: 1, Timestamp: unixTime(20), Metadata: labels.FromStrings("trace_id", "abcdef"), Line: []byte("goodbye, world!")},
 		{StreamID: 1, Timestamp: unixTime(10), Metadata: labels.EmptyLabels(), Line: []byte("hello, world!")},
-		{StreamID: 1, Timestamp: unixTime(5), Metadata: labels.FromStrings("trace_id", "abcdef"), Line: []byte("")},
+		{StreamID: 1, Timestamp: unixTime(5), Metadata: labels.FromStrings("trace_id", "abcdef", "foo", ""), Line: []byte("")},
 	})
 
 	var (
 		streamID = sec.Columns()[0]
-		traceID  = sec.Columns()[2]
-		message  = sec.Columns()[3]
+		foo      = sec.Columns()[2]
+		traceID  = sec.Columns()[3]
+		message  = sec.Columns()[4]
 	)
 
 	require.Equal(t, "", streamID.Name)
 	require.Equal(t, logs.ColumnTypeStreamID, streamID.Type)
 	require.Equal(t, "trace_id", traceID.Name)
 	require.Equal(t, logs.ColumnTypeMetadata, traceID.Type)
+	require.Equal(t, "foo", foo.Name)
+	require.Equal(t, logs.ColumnTypeMetadata, foo.Type)
 	require.Equal(t, "", message.Name)
 	require.Equal(t, logs.ColumnTypeMessage, message.Type)
 
@@ -54,11 +57,11 @@ func TestReader(t *testing.T) {
 	}{
 		{
 			name:    "basic reads with predicate",
-			columns: []*logs.Column{streamID, traceID, message},
+			columns: []*logs.Column{streamID, traceID, foo, message},
 			expected: arrowtest.Rows{
-				{"stream_id.int64": int64(2), "trace_id.metadata.utf8": "123456", "message.utf8": "foo bar"},
-				{"stream_id.int64": int64(1), "trace_id.metadata.utf8": "abcdef", "message.utf8": "goodbye, world!"},
-				{"stream_id.int64": int64(1), "trace_id.metadata.utf8": "abcdef", "message.utf8": ""},
+				{"stream_id.int64": int64(2), "foo.metadata.utf8": nil, "trace_id.metadata.utf8": "123456", "message.utf8": "foo bar"},
+				{"stream_id.int64": int64(1), "foo.metadata.utf8": nil, "trace_id.metadata.utf8": "abcdef", "message.utf8": "goodbye, world!"},
+				{"stream_id.int64": int64(1), "foo.metadata.utf8": "", "trace_id.metadata.utf8": "abcdef", "message.utf8": ""},
 			},
 		},
 		// tests that the reader evaluates predicates correctly even when predicate columns are not projected.

--- a/pkg/dataobj/sections/logs/reader_test.go
+++ b/pkg/dataobj/sections/logs/reader_test.go
@@ -31,6 +31,7 @@ func TestReader(t *testing.T) {
 		{StreamID: 2, Timestamp: unixTime(30), Metadata: labels.FromStrings("trace_id", "123456"), Line: []byte("foo bar")},
 		{StreamID: 1, Timestamp: unixTime(20), Metadata: labels.FromStrings("trace_id", "abcdef"), Line: []byte("goodbye, world!")},
 		{StreamID: 1, Timestamp: unixTime(10), Metadata: labels.EmptyLabels(), Line: []byte("hello, world!")},
+		{StreamID: 1, Timestamp: unixTime(5), Metadata: labels.FromStrings("trace_id", "abcdef"), Line: []byte("")},
 	})
 
 	var (
@@ -57,6 +58,7 @@ func TestReader(t *testing.T) {
 			expected: arrowtest.Rows{
 				{"stream_id.int64": int64(2), "trace_id.metadata.utf8": "123456", "message.utf8": "foo bar"},
 				{"stream_id.int64": int64(1), "trace_id.metadata.utf8": "abcdef", "message.utf8": "goodbye, world!"},
+				{"stream_id.int64": int64(1), "trace_id.metadata.utf8": "abcdef", "message.utf8": ""},
 			},
 		},
 		// tests that the reader evaluates predicates correctly even when predicate columns are not projected.
@@ -66,6 +68,7 @@ func TestReader(t *testing.T) {
 			expected: arrowtest.Rows{
 				{"stream_id.int64": int64(2), "message.utf8": "foo bar"},
 				{"stream_id.int64": int64(1), "message.utf8": "goodbye, world!"},
+				{"stream_id.int64": int64(1), "message.utf8": ""},
 			},
 		},
 	} {
@@ -105,7 +108,6 @@ func TestReader(t *testing.T) {
 			require.NoError(t, err, "failed to get rows from table")
 			require.Equal(t, tt.expected, actual)
 		})
-
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Treat Message type columns as required, so always returns a value for them when reading logs.
* Currently we cannot differentiate between a NULL value and an empty value. For most columns, this isn't an issue but for the Message column, an empty log message is a valid value as needs to be returned for parity with the old engine.
* There are several ways to fix this, and ~I chose to return a value for Message types on Read, treating Message as a required column.~ I switched to making this fix on the logs writer instead.


**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/loki-private/issues/1989

**Special notes for your reviewer**:
I'm not certain this is the best way to fix this case. I'm happy to implement any alternative fixes such as:
* Encode empty values as actual values instead of NULLs when writing the object. Again, this would likely need to be special cased for Message types since we probably don't want this behaviour for all columns. We may be able to differentiate based on Value type == UNSPECIFIED though.
* Find out where in the new engine we are dropping the log without a message field and fixing that instead. The dataobjscan nodes return the correct values but they are not returned in the response: one of Merge, SortMerge or Limit is dropping them.

**Checklist**
- [x] Tests updated
