### PR TITLE
chore: remove build container from lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -388,17 +388,18 @@ publish: packages
 ########
 # Lint #
 ########
-
-# To run this efficiently on your workstation, run this from the root dir:
-# docker run --rm --tty -i -v $(pwd)/.cache:/go/cache -v $(pwd)/.pkg:/go/pkg -v $(pwd):/src/loki grafana/loki-build-image:0.24.1 lint
-lint: ## run linters
-ifeq ($(BUILD_IN_CONTAINER),true)
-	$(run_in_container)
+ifeq ($(UNAME_S),Linux)
+LINT_FLAGS="--timeout=15m --build-tags=linux,promtail_journal_enabled"
+GOFLAGS="-tags=linux,promtail_journal_enabled"
 else
+LINT_FLAGS="--timeout=15m"
+GOFLAGS=""
+endif
+lint: ## run linters
 	go version
 	golangci-lint version
-	GO111MODULE=on golangci-lint run -v --timeout 15m --build-tags linux,promtail_journal_enabled
-	GOFLAGS="-tags=linux,promtail_journal_enabled" faillint -paths \
+	golangci-lint run -v $(LINT_FLAGS)
+	GOFLAGS=$(GOFLAGS) faillint -paths \
 		"sync/atomic=go.uber.org/atomic" \
 		./...
 
@@ -411,7 +412,6 @@ else
 	faillint -paths \
 		"github.com/opentracing/opentracing-go,github.com/opentracing/opentracing-go/log,github.com/uber/jaeger-client-go,github.com/opentracing-contrib/go-stdlib/nethttp" \
 		./...
-endif
 
 ########
 # Test #


### PR DESCRIPTION
**What this PR does / why we need it**:

Ever since we upgraded the `golangci-lint` version in CI, I have had trouble running linting locally because I could no longer run it in container, since we never updated the `golangci-lint` version in the container. I think this is a _good_ this and am in favor of moving away from the build container for all but promtail stuff. That being said, the default tags in the `Makefile` don't work for all OSes (since I can get journald headers on Mac), so we need to make them conditional. This is and attempt to do so.

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
