### PR TITLE
chore: Dedup log objects during merge

### DIFF
--- a/pkg/dataobj/sections/logs/table_merge.go
+++ b/pkg/dataobj/sections/logs/table_merge.go
@@ -1,6 +1,7 @@
 package logs
 
 import (
+	"bytes"
 	"cmp"
 	"context"
 	"errors"
@@ -9,6 +10,7 @@ import (
 	"math"
 
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/dataset"
+	"github.com/grafana/loki/v3/pkg/dataobj/internal/metadata/datasetmd"
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/result"
 	"github.com/grafana/loki/v3/pkg/util/loser"
 )
@@ -60,9 +62,7 @@ func mergeTables(buf *tableBuffer, pageSize, pageRowCount int, compressionOpts d
 		messageBuilder   = buf.Message(pageSize, pageRowCount, compressionOpts)
 	)
 
-	var (
-		tableSequences = make([]*tableSequence, 0, len(tables))
-	)
+	tableSequences := make([]*tableSequence, 0, len(tables))
 	for _, t := range tables {
 		dsetColumns, err := result.Collect(t.ListColumns(context.Background()))
 		if err != nil {
@@ -96,6 +96,7 @@ func mergeTables(buf *tableBuffer, pageSize, pageRowCount int, compressionOpts d
 	tree := loser.New(tableSequences, maxValue, tableSequenceAt, CompareForSortOrder(sort), tableSequenceClose)
 	defer tree.Close()
 
+	var prev dataset.Row
 	for tree.Next() {
 		seq := tree.Winner()
 
@@ -103,6 +104,12 @@ func mergeTables(buf *tableBuffer, pageSize, pageRowCount int, compressionOpts d
 		if err != nil {
 			return nil, err
 		}
+
+		if equalRows(prev, row) {
+			// Skip equal rows
+			continue
+		}
+		prev = row
 
 		for i, column := range seq.columns {
 			// column is guaranteed to be a *tableColumn since we got it from *table.
@@ -257,4 +264,59 @@ func CompareRows(a, b dataset.Row) int {
 		return res
 	}
 	return cmp.Compare(bTimestamp, aTimestamp)
+}
+
+// compareRows compares two rows by their first two columns. compareRows panics
+// if a or b doesn't have at least two columns, if the first column isn't a
+// int64-encoded stream ID, or if the second column isn't an int64-encoded
+// timestamp.
+func equalRows(a, b dataset.Row) bool {
+	if len(a.Values) != len(b.Values) {
+		return false
+	}
+
+	// The first two columns of each row are *always* stream ID and timestamp.
+	var (
+		aStreamID = a.Values[0].Int64()
+		bStreamID = b.Values[0].Int64()
+
+		aTimestamp = a.Values[1].Int64()
+		bTimestamp = b.Values[1].Int64()
+	)
+
+	// First, test the timestamp and stream ID to quickly discard unequal rows.
+	if bTimestamp != aTimestamp {
+		return false
+	}
+
+	if aStreamID != bStreamID {
+		return false
+	}
+
+	// Next, check each column for equality, exiting early if any column is unequal.
+	for i := 2; i < len(a.Values); i++ {
+		aType, bType := a.Values[i].Type(), b.Values[i].Type()
+		if aType != bType {
+			return false
+		}
+
+		switch aType {
+		case datasetmd.PHYSICAL_TYPE_INT64:
+			if a.Values[i].Int64() != b.Values[i].Int64() {
+				return false
+			}
+		case datasetmd.PHYSICAL_TYPE_UINT64:
+			if a.Values[i].Uint64() != b.Values[i].Uint64() {
+				return false
+			}
+		case datasetmd.PHYSICAL_TYPE_BINARY:
+			if !bytes.Equal(a.Values[i].Binary(), b.Values[i].Binary()) {
+				return false
+			}
+		default:
+			return false
+		}
+	}
+
+	return true
 }

--- a/pkg/dataobj/sections/logs/table_test.go
+++ b/pkg/dataobj/sections/logs/table_test.go
@@ -60,8 +60,8 @@ func Test_mergeTables(t *testing.T) {
 		})
 
 		tableB = buildTable(&buf, pageSize, pageRows, dataset.CompressionOptions{}, []Record{
+			{StreamID: 3, Timestamp: time.Unix(3, 0), Line: []byte("hello")},
 			{StreamID: 1, Timestamp: time.Unix(2, 0), Line: []byte("world")},
-			{StreamID: 3, Timestamp: time.Unix(1, 0), Line: []byte("goodbye")},
 			{StreamID: 3, Timestamp: time.Unix(1, 0), Line: []byte("goodbye")},
 		})
 

--- a/pkg/dataobj/sections/logs/table_test.go
+++ b/pkg/dataobj/sections/logs/table_test.go
@@ -49,9 +49,11 @@ func initBuffer(buf *tableBuffer) {
 func Test_mergeTables(t *testing.T) {
 	var buf tableBuffer
 
-	// tables need to be sorted by Timestamp DESC and StreamID ASC
+	// tables need to be sorted by Timestamp DESC and StreamID ASC.
+	// duplicates are added to ensure the resulting objects are deduplicated if all attributes match.
 	var (
 		tableA = buildTable(&buf, pageSize, pageRows, dataset.CompressionOptions{}, []Record{
+			{StreamID: 3, Timestamp: time.Unix(3, 0), Line: []byte("hello")},
 			{StreamID: 3, Timestamp: time.Unix(3, 0), Line: []byte("hello")},
 			{StreamID: 2, Timestamp: time.Unix(2, 0), Line: []byte("how")},
 			{StreamID: 1, Timestamp: time.Unix(1, 0), Line: []byte("you")},
@@ -60,10 +62,12 @@ func Test_mergeTables(t *testing.T) {
 		tableB = buildTable(&buf, pageSize, pageRows, dataset.CompressionOptions{}, []Record{
 			{StreamID: 1, Timestamp: time.Unix(2, 0), Line: []byte("world")},
 			{StreamID: 3, Timestamp: time.Unix(1, 0), Line: []byte("goodbye")},
+			{StreamID: 3, Timestamp: time.Unix(1, 0), Line: []byte("goodbye")},
 		})
 
 		tableC = buildTable(&buf, pageSize, pageRows, dataset.CompressionOptions{}, []Record{
 			{StreamID: 3, Timestamp: time.Unix(2, 0), Line: []byte("are")},
+			{StreamID: 2, Timestamp: time.Unix(1, 0), Line: []byte("doing?")},
 			{StreamID: 2, Timestamp: time.Unix(1, 0), Line: []byte("doing?")},
 		})
 	)


### PR DESCRIPTION
**What this PR does / why we need it**:
Implementing deduping of log lines when merging parts of a log object together.

* This is needed because implementing deduplication in the query engine is difficult, and may require more data to be read than necessary.
* Due to the use of kafka, duplicates are rare in this architecture. They only really appear if a client pushes the same data twice due to a retry.
* A log line could still be duplicated across sections or objects if they are pushed sufficiently far apart in time, but this eliminates duplicates within a single object which should be the vast majority of cases. Compaction could solve the others.

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/loki-private/issues/1995

**Checklist**

- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)