### PR TITLE
feat(s3): Add S3 SSE-C support

### DIFF
--- a/docs/sources/setup/install/helm/configure-storage/_index.md
+++ b/docs/sources/setup/install/helm/configure-storage/_index.md
@@ -56,11 +56,65 @@ This guide assumes Loki will be installed in one of the modes above and that a `
      storage:
        type: "s3"
        s3:
-         region: eu-central-1
+         region: <INSERT-REGION-FOR-CLUSTER>
        bucketNames:
-         chunks: <bucket name>
-         ruler: <bucket name>
-         admin: <bucket name>
+         chunks: <BUCKET-NAME>
+         ruler: <BUCKET-NAME>
+         admin: <BUCKET-NAME>
    ```
 
    Note that `endpoint`, `secretAccessKey` and `accessKeyId` have been omitted.
+
+**Server-Side Encryption (SSE)**  
+
+
+You can configure Server-Side Encryption (SSE) for your S3 storage. There are three main SSE types available:
+
+- SSE-C: You provide and manage your own encryption key manually.
+- SSE-KMS: Uses Key Management Service (KMS) keys, providing more control over key management.
+- SSE-S3: Encryption keys are fully managed by the S3 service.
+
+{{< admonition type="caution" >}}  
+Use caution when opting for server-side encryption with customer-provided keys (SSE-C). Unlike SSE-S3 and SSE-KMS, where key rotation is handled automatically by AWS, SSE-C requires manual key rotation which can be complex and error-prone in production environments.
+{{< /admonition >}}
+
+SSE-S3 can be set as follows: 
+```yaml
+loki:
+  storage:
+    type: "s3"
+    s3:
+      region: <INSERT-REGION-FOR-CLUSTER>
+      sse:
+        type: SSE-S3
+```
+
+SSE-KMS requires setting `kms_key_id` and `kms_encryption_context`.  
+```yaml
+loki:
+  storage:
+    type: "s3"
+    s3:
+      region: <INSERT-REGION-FOR-CLUSTER>
+      sse:
+        type: SSE-KMS
+        kms_key_id: <YOUR-KMS-KEY-ID>
+        kms_encryption_context: <YOUR-KMS-ENCRYPTION-CONTEXT>
+```
+
+To use SSE-C, you must provide a 32-byte (256-bit) encryption key. The encryption algorithm is set to `AES256` by default. 
+
+{{< admonition type="warning" >}}  
+Treat the `encryption_key` as a sensitive value since it directly protects your data. Proper key management and security practices are essential, as losing this key means losing access to the encrypted objects.
+{{< /admonition >}}
+
+```yaml
+loki:
+  storage:
+    type: "s3"
+    s3:
+      region: <INSERT-REGION-FOR-CLUSTER>
+      sse:
+        type: SSE-C
+        encryption_key: <YOUR-CUSTOMER-PROVIDED-ENCRYPTION-KEY>
+```

--- a/docs/sources/setup/install/helm/install-microservices/_index.md
+++ b/docs/sources/setup/install/helm/install-microservices/_index.md
@@ -233,6 +233,22 @@ loki:
       insecure: false
       # HTTP configuration settings
       http_config: {}
+      # SSE configuration
+      #
+      # Examples
+      # 
+      # sse:
+      #   type: SSE-S3
+      #
+      # sse:
+      #   type: SSE-KMS
+      #   kms_key_id: <YOUR-KMS-KEY-ID>
+      #   kms_encryption_context: <YOUR-KMS-ENCRYPTION-CONTEXT>
+      #
+      # sse:
+      #   type: SSE-C
+      #   encryption_key: <YOUR-CUSTOMER-ENCRYPTION-KEY>
+      sse: {}
 
   deploymentMode: Distributed
 

--- a/docs/sources/setup/install/helm/install-monolithic/_index.md
+++ b/docs/sources/setup/install/helm/install-monolithic/_index.md
@@ -266,6 +266,22 @@ loki:
       insecure: false
       # HTTP configuration settings
       http_config: {}
+      # SSE configuration
+      #
+      # Examples
+      # 
+      # sse:
+      #   type: SSE-S3
+      #
+      # sse:
+      #   type: SSE-KMS
+      #   kms_key_id: <YOUR-KMS-KEY-ID>
+      #   kms_encryption_context: <YOUR-KMS-ENCRYPTION-CONTEXT>
+      #
+      # sse:
+      #   type: SSE-C
+      #   encryption_key: <YOUR-CUSTOMER-ENCRYPTION-KEY>
+      sse: {}
 
 # Disable minio storage
 minio:

--- a/docs/sources/setup/install/helm/install-scalable/_index.md
+++ b/docs/sources/setup/install/helm/install-scalable/_index.md
@@ -163,6 +163,22 @@ loki:
       insecure: false
       # HTTP configuration settings
       http_config: {}
+      # SSE configuration
+      #
+      # Examples
+      # 
+      # sse:
+      #   type: SSE-S3
+      #
+      # sse:
+      #   type: SSE-KMS
+      #   kms_key_id: <YOUR-KMS-KEY-ID>
+      #   kms_encryption_context: <YOUR-KMS-ENCRYPTION-CONTEXT>
+      #
+      # sse:
+      #   type: SSE-C
+      #   encryption_key: <YOUR-CUSTOMER-ENCRYPTION-KEY>
+      sse: {}
 
 deploymentMode: SimpleScalable
 

--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -4725,6 +4725,10 @@ otlp_config:
 # the SSE type override is not set.
 [s3_sse_kms_encryption_context: <string> | default = ""]
 
+# S3 server-side encryption customer-provided encryption key. Ignored if the SSE
+# type override is not set.
+[s3_sse_c_encryption_key: <string> | default = ""]
+
 # Experimental: Controls the amount of scan tasks that can be running in
 # parallel in the new query engine. The default of 0 means unlimited parallelism
 # and all tasks will be scheduled at once.
@@ -5912,7 +5916,7 @@ http_config:
 [storage_class: <string> | default = "STANDARD"]
 
 sse:
-  # Enable AWS Server Side Encryption. Supported values: SSE-KMS, SSE-S3.
+  # Enable AWS Server Side Encryption. Supported values: SSE-KMS, SSE-S3, SSE-C.
   # CLI flag: -<prefix>.s3.sse.type
   [type: <string> | default = ""]
 
@@ -5924,6 +5928,10 @@ sse:
   # string.
   # CLI flag: -<prefix>.s3.sse.kms-encryption-context
   [kms_encryption_context: <string> | default = ""]
+
+  # SSE-C Encryption Key used for object encryption.
+  # CLI flag: -<prefix>.s3.sse.encryption-key
+  [encryption_key: <string> | default = ""]
 
 # Configures back off when S3 get Object.
 backoff_config:
@@ -7298,7 +7306,8 @@ s3:
   [max_retries: <int> | default = 10]
 
   sse:
-    # Enable AWS Server Side Encryption. Supported values: SSE-KMS, SSE-S3.
+    # Enable AWS Server Side Encryption. Supported values: SSE-KMS, SSE-S3,
+    # SSE-C.
     # CLI flag: -<prefix>.s3.sse.type
     [type: <string> | default = ""]
 
@@ -7310,6 +7319,10 @@ s3:
     # formatted string.
     # CLI flag: -<prefix>.s3.sse.kms-encryption-context
     [kms_encryption_context: <string> | default = ""]
+
+    # SSE-C Encryption Key used for object encryption.
+    # CLI flag: -<prefix>.s3.sse.encryption-key
+    [encryption_key: <string> | default = ""]
 
   http:
     # The time an idle connection will remain idle before closing.

--- a/operator/internal/manifests/internal/config/build_test.go
+++ b/operator/internal/manifests/internal/config/build_test.go
@@ -4550,6 +4550,311 @@ overrides:
 	require.YAMLEq(t, expRCfg, string(rCfg))
 }
 
+func TestBuild_ConfigAndRuntimeConfig_WithS3SSEC(t *testing.T) {
+	expCfg := `
+---
+auth_enabled: true
+chunk_store_config:
+  chunk_cache_config:
+    embedded_cache:
+      enabled: true
+      max_size_mb: 500
+common:
+  storage:
+    s3:
+      endpoint: http://test.default.svc.cluster.local.:9000
+      bucketnames: loki
+      region: us-east
+      access_key_id: ${AWS_ACCESS_KEY_ID}
+      secret_access_key: ${AWS_ACCESS_KEY_SECRET}
+      sse:
+        type: SSE-C
+        # some random 32 byte string
+        encryption_key: ${AWS_SSE_C_ENCRYPTION_KEY}
+      s3forcepathstyle: true
+  compactor_grpc_address: loki-compactor-grpc-lokistack-dev.default.svc.cluster.local:9095
+  ring:
+    kvstore:
+      store: memberlist
+    heartbeat_period: 5s
+    heartbeat_timeout: 1m
+    instance_port: 9095
+compactor:
+  compaction_interval: 2h
+  working_directory: /tmp/loki/compactor
+frontend:
+  tail_proxy_url: http://loki-querier-http-lokistack-dev.default.svc.cluster.local:3100
+  compress_responses: true
+  max_outstanding_per_tenant: 4096
+  log_queries_longer_than: 5s
+frontend_worker:
+  frontend_address: loki-query-frontend-grpc-lokistack-dev.default.svc.cluster.local:9095
+  grpc_client_config:
+    max_send_msg_size: 104857600
+ingester:
+  chunk_block_size: 262144
+  chunk_encoding: snappy
+  chunk_idle_period: 1h
+  chunk_retain_period: 5m
+  chunk_target_size: 2097152
+  flush_op_timeout: 10m
+  lifecycler:
+    final_sleep: 0s
+    join_after: 30s
+    num_tokens: 512
+    ring:
+      replication_factor: 1
+  max_chunk_age: 2h
+  autoforget_unhealthy: true
+  wal:
+    enabled: true
+    dir: /tmp/wal
+    replay_memory_ceiling: 2147483648
+ingester_client:
+  grpc_client_config:
+    max_recv_msg_size: 67108864
+  remote_timeout: 1s
+# NOTE: Keep the order of keys as in Loki docs
+# to enable easy diffs when vendoring newer
+# Loki releases.
+# (See https://grafana.com/docs/loki/latest/configuration/#limits_config)
+#
+# Values for not exposed fields are taken from the grafana/loki production
+# configuration manifests.
+# (See https://github.com/grafana/loki/blob/main/production/ksonnet/loki/config.libsonnet)
+limits_config:
+  ingestion_rate_strategy: global
+  ingestion_rate_mb: 4
+  ingestion_burst_size_mb: 6
+  max_label_name_length: 1024
+  max_label_value_length: 2048
+  max_label_names_per_series: 30
+  reject_old_samples: true
+  reject_old_samples_max_age: 168h
+  creation_grace_period: 10m
+  # Keep max_streams_per_user always to 0 to default
+  # using max_global_streams_per_user always.
+  # (See https://github.com/grafana/loki/blob/main/pkg/ingester/limiter.go#L73)
+  max_streams_per_user: 0
+  max_line_size: 256000
+  max_entries_limit_per_query: 5000
+  discover_service_name: []
+  discover_log_levels: false
+  max_global_streams_per_user: 0
+  max_chunks_per_query: 2000000
+  max_query_length: 721h
+  max_query_parallelism: 32
+  tsdb_max_query_parallelism: 512
+  max_query_series: 500
+  cardinality_limit: 100000
+  max_streams_matchers_per_query: 1000
+  max_cache_freshness_per_query: 10m
+  split_queries_by_interval: 30m
+  query_timeout: 1m
+  volume_enabled: true
+  volume_max_series: 1000
+  per_stream_rate_limit: 5MB
+  per_stream_rate_limit_burst: 15MB
+  shard_streams:
+    enabled: true
+    desired_rate: 3MB
+    time_sharding_enabled: true
+  allow_structured_metadata: false
+memberlist:
+  abort_if_cluster_join_fails: true
+  advertise_port: 7946
+  bind_port: 7946
+  join_members:
+    - loki-gossip-ring-lokistack-dev.default.svc.cluster.local:7946
+  max_join_backoff: 1m
+  max_join_retries: 10
+  min_join_backoff: 1s
+  rejoin_interval: 90s
+querier:
+  engine:
+    max_look_back_period: 30s
+  extra_query_delay: 0s
+  max_concurrent: 2
+  query_ingesters_within: 3h
+  tail_max_duration: 1h
+query_range:
+  align_queries_with_step: true
+  cache_results: true
+  max_retries: 5
+  results_cache:
+    cache:
+      embedded_cache:
+        enabled: true
+        max_size_mb: 500
+  parallelise_shardable_queries: true
+schema_config:
+  configs:
+    - from: "2020-10-01"
+      index:
+        period: 24h
+        prefix: index_
+      object_store: s3
+      schema: v11
+      store: boltdb-shipper
+server:
+  graceful_shutdown_timeout: 5s
+  grpc_server_min_time_between_pings: '10s'
+  grpc_server_ping_without_stream_allowed: true
+  grpc_server_max_concurrent_streams: 1000
+  grpc_server_max_recv_msg_size: 104857600
+  grpc_server_max_send_msg_size: 104857600
+  http_listen_port: 3100
+  http_server_idle_timeout: 30s
+  http_server_read_timeout: 30s
+  http_server_write_timeout: 10m0s
+  log_level: info
+storage_config:
+  boltdb_shipper:
+    active_index_directory: /tmp/loki/index
+    cache_location: /tmp/loki/index_cache
+    cache_ttl: 24h
+    resync_interval: 5m
+    index_gateway_client:
+      server_address: dns:///loki-index-gateway-grpc-lokistack-dev.default.svc.cluster.local:9095
+tracing:
+  enabled: false
+analytics:
+  reporting_enabled: false
+`
+	expRCfg := `
+---
+overrides:
+  test-a:
+    ingestion_rate_mb: 2
+    ingestion_burst_size_mb: 5
+    max_global_streams_per_user: 1
+    max_chunks_per_query: 1000000
+`
+	opts := Options{
+		Stack: lokiv1.LokiStackSpec{
+			Replication: &lokiv1.ReplicationSpec{
+				Factor: 1,
+			},
+			Limits: &lokiv1.LimitsSpec{
+				Global: &lokiv1.LimitsTemplateSpec{
+					IngestionLimits: &lokiv1.IngestionLimitSpec{
+						IngestionRate:             4,
+						IngestionBurstSize:        6,
+						MaxLabelNameLength:        1024,
+						MaxLabelValueLength:       2048,
+						MaxLabelNamesPerSeries:    30,
+						MaxGlobalStreamsPerTenant: 0,
+						MaxLineSize:               256000,
+						PerStreamRateLimit:        5,
+						PerStreamRateLimitBurst:   15,
+						PerStreamDesiredRate:      3,
+					},
+					QueryLimits: &lokiv1.QueryLimitSpec{
+						MaxEntriesLimitPerQuery: 5000,
+						MaxChunksPerQuery:       2000000,
+						MaxQuerySeries:          500,
+						QueryTimeout:            "1m",
+						CardinalityLimit:        100000,
+						MaxVolumeSeries:         1000,
+					},
+				},
+				Tenants: map[string]lokiv1.PerTenantLimitsTemplateSpec{
+					"test-a": {
+						IngestionLimits: &lokiv1.IngestionLimitSpec{
+							IngestionRate:             2,
+							IngestionBurstSize:        5,
+							MaxGlobalStreamsPerTenant: 1,
+						},
+						QueryLimits: &lokiv1.PerTenantQueryLimitSpec{
+							QueryLimitSpec: lokiv1.QueryLimitSpec{
+								MaxChunksPerQuery: 1000000,
+							},
+						},
+					},
+				},
+			},
+		},
+		Overrides: map[string]LokiOverrides{
+			"test-a": {
+				Limits: lokiv1.PerTenantLimitsTemplateSpec{
+					IngestionLimits: &lokiv1.IngestionLimitSpec{
+						IngestionRate:             2,
+						MaxGlobalStreamsPerTenant: 1,
+						IngestionBurstSize:        5,
+					},
+					QueryLimits: &lokiv1.PerTenantQueryLimitSpec{
+						QueryLimitSpec: lokiv1.QueryLimitSpec{
+							MaxChunksPerQuery: 1000000,
+						},
+					},
+				},
+			},
+		},
+		Namespace: "test-ns",
+		Name:      "test",
+		Compactor: Address{
+			FQDN: "loki-compactor-grpc-lokistack-dev.default.svc.cluster.local",
+			Port: 9095,
+		},
+		FrontendWorker: Address{
+			FQDN: "loki-query-frontend-grpc-lokistack-dev.default.svc.cluster.local",
+			Port: 9095,
+		},
+		GossipRing: GossipRing{
+			InstancePort:         9095,
+			BindPort:             7946,
+			MembersDiscoveryAddr: "loki-gossip-ring-lokistack-dev.default.svc.cluster.local",
+		},
+		Querier: Address{
+			Protocol: "http",
+			FQDN:     "loki-querier-http-lokistack-dev.default.svc.cluster.local",
+			Port:     3100,
+		},
+		IndexGateway: Address{
+			FQDN: "loki-index-gateway-grpc-lokistack-dev.default.svc.cluster.local",
+			Port: 9095,
+		},
+		StorageDirectory: "/tmp/loki",
+		MaxConcurrent: MaxConcurrent{
+			AvailableQuerierCPUCores: 2,
+		},
+		WriteAheadLog: WriteAheadLog{
+			Directory:             "/tmp/wal",
+			IngesterMemoryRequest: 4 * 1024 * 1024 * 1024,
+		},
+		ObjectStorage: storage.Options{
+			SharedStore: lokiv1.ObjectStorageSecretS3,
+			S3: &storage.S3StorageConfig{
+				Endpoint:       "http://test.default.svc.cluster.local.:9000",
+				Region:         "us-east",
+				Buckets:        "loki",
+				ForcePathStyle: true,
+
+				SSE: storage.S3SSEConfig{
+					Type:                  storage.SSECType,
+					CustomerEncryptionKey: "${AWS_SSE_C_ENCRYPTION_KEY}",
+				},
+			},
+			Schemas: []lokiv1.ObjectStorageSchema{
+				{
+					Version:       lokiv1.ObjectStorageSchemaV11,
+					EffectiveDate: "2020-10-01",
+				},
+			},
+		},
+		Shippers: []string{"boltdb"},
+		HTTPTimeouts: HTTPTimeoutConfig{
+			IdleTimeout:  30 * time.Second,
+			ReadTimeout:  30 * time.Second,
+			WriteTimeout: 10 * time.Minute,
+		},
+	}
+	cfg, rCfg, err := Build(opts)
+	require.NoError(t, err)
+	require.YAMLEq(t, expCfg, string(cfg))
+	require.YAMLEq(t, expRCfg, string(rCfg))
+}
+
 func TestBuild_ConfigAndRuntimeConfig_WithS3SSES3(t *testing.T) {
 	expCfg := `
 ---

--- a/operator/internal/manifests/internal/config/loki-config.yaml
+++ b/operator/internal/manifests/internal/config/loki-config.yaml
@@ -53,6 +53,11 @@ common:
           ${AWS_SSE_KMS_ENCRYPTION_CONTEXT}
         {{- end }}
         {{- end}}
+        {{- if eq .Type "SSE-C" }}
+        {{- with .CustomerEncryptionKey }}
+        encryption_key: ${AWS_SSE_C_ENCRYPTION_KEY}
+        {{- end }}
+        {{- end }}
       {{- end }}
       {{- end }}
     {{- end }}

--- a/operator/internal/manifests/storage/configure_test.go
+++ b/operator/internal/manifests/storage/configure_test.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -1221,6 +1222,97 @@ func TestConfigureDeploymentForStorageType(t *testing.T) {
 			},
 		},
 		{
+			desc: "object storage S3 with SSE-C encryption key",
+			opts: Options{
+				SecretName:  "test",
+				SharedStore: lokiv1.ObjectStorageSecretS3,
+				S3: &S3StorageConfig{
+					SSE: S3SSEConfig{
+						Type:                  SSECType,
+						CustomerEncryptionKey: strings.Repeat("a", 32), // 32 bytes string
+					},
+				},
+			},
+			dpl: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: "loki-ingester",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: "loki-ingester",
+									VolumeMounts: []corev1.VolumeMount{
+										{
+											Name:      "test",
+											ReadOnly:  false,
+											MountPath: "/etc/storage/secrets",
+										},
+									},
+									Env: []corev1.EnvVar{
+										{
+											Name: EnvAWSAccessKeyID,
+											ValueFrom: &corev1.EnvVarSource{
+												SecretKeyRef: &corev1.SecretKeySelector{
+													LocalObjectReference: corev1.LocalObjectReference{
+														Name: "test",
+													},
+													Key: KeyAWSAccessKeyID,
+												},
+											},
+										},
+										{
+											Name: EnvAWSAccessKeySecret,
+											ValueFrom: &corev1.EnvVarSource{
+												SecretKeyRef: &corev1.SecretKeySelector{
+													LocalObjectReference: corev1.LocalObjectReference{
+														Name: "test",
+													},
+													Key: KeyAWSAccessKeySecret,
+												},
+											},
+										},
+										{
+											Name: EnvAWSSseCEncryptionKey,
+											ValueFrom: &corev1.EnvVarSource{
+												SecretKeyRef: &corev1.SecretKeySelector{
+													LocalObjectReference: corev1.LocalObjectReference{
+														Name: "test",
+													},
+													Key: KeyAWSSseCEncryptionKey,
+												},
+											},
+										},
+									},
+								},
+							},
+							Volumes: []corev1.Volume{
+								{
+									Name: "test",
+									VolumeSource: corev1.VolumeSource{
+										Secret: &corev1.SecretVolumeSource{
+											SecretName: "test",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			desc: "object storage Swift",
 			opts: Options{
 				SecretName:  "test",
@@ -2314,6 +2406,97 @@ func TestConfigureStatefulSetForStorageType(t *testing.T) {
 														Name: "test",
 													},
 													Key: KeyAWSSseKmsEncryptionContext,
+												},
+											},
+										},
+									},
+								},
+							},
+							Volumes: []corev1.Volume{
+								{
+									Name: "test",
+									VolumeSource: corev1.VolumeSource{
+										Secret: &corev1.SecretVolumeSource{
+											SecretName: "test",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			desc: "object storage S3 with SSE-C encryption",
+			opts: Options{
+				SecretName:  "test",
+				SharedStore: lokiv1.ObjectStorageSecretS3,
+				S3: &S3StorageConfig{
+					SSE: S3SSEConfig{
+						Type:                  SSECType,
+						CustomerEncryptionKey: strings.Repeat("a", 32),
+					},
+				},
+			},
+			sts: &appsv1.StatefulSet{
+				Spec: appsv1.StatefulSetSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: "loki-ingester",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: &appsv1.StatefulSet{
+				Spec: appsv1.StatefulSetSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: "loki-ingester",
+									VolumeMounts: []corev1.VolumeMount{
+										{
+											Name:      "test",
+											ReadOnly:  false,
+											MountPath: "/etc/storage/secrets",
+										},
+									},
+									Env: []corev1.EnvVar{
+										{
+											Name: EnvAWSAccessKeyID,
+											ValueFrom: &corev1.EnvVarSource{
+												SecretKeyRef: &corev1.SecretKeySelector{
+													LocalObjectReference: corev1.LocalObjectReference{
+														Name: "test",
+													},
+													Key: KeyAWSAccessKeyID,
+												},
+											},
+										},
+										{
+											Name: EnvAWSAccessKeySecret,
+											ValueFrom: &corev1.EnvVarSource{
+												SecretKeyRef: &corev1.SecretKeySelector{
+													LocalObjectReference: corev1.LocalObjectReference{
+														Name: "test",
+													},
+													Key: KeyAWSAccessKeySecret,
+												},
+											},
+										},
+										{
+											Name: EnvAWSSseCEncryptionKey,
+											ValueFrom: &corev1.EnvVarSource{
+												SecretKeyRef: &corev1.SecretKeySelector{
+													LocalObjectReference: corev1.LocalObjectReference{
+														Name: "test",
+													},
+													Key: KeyAWSSseCEncryptionKey,
 												},
 											},
 										},

--- a/operator/internal/manifests/storage/options.go
+++ b/operator/internal/manifests/storage/options.go
@@ -57,12 +57,16 @@ type S3SSEType string
 const (
 	SSEKMSType S3SSEType = "SSE-KMS"
 	SSES3Type  S3SSEType = "SSE-S3"
+	SSECType   S3SSEType = "SSE-C"
 )
 
 type S3SSEConfig struct {
-	Type                 S3SSEType
+	Type S3SSEType
+	// sse-kms
 	KMSKeyID             string
 	KMSEncryptionContext string
+	// sse-c
+	CustomerEncryptionKey string
 }
 
 // SwiftStorageConfig for Swift storage config

--- a/operator/internal/manifests/storage/var.go
+++ b/operator/internal/manifests/storage/var.go
@@ -13,6 +13,8 @@ const (
 	EnvAWSAccessKeySecret = "AWS_ACCESS_KEY_SECRET" //#nosec G101 -- False positive
 	// EnvAWSSseKmsEncryptionContext is the environment variable to specify the AWS KMS encryption context when using type SSE-KMS.
 	EnvAWSSseKmsEncryptionContext = "AWS_SSE_KMS_ENCRYPTION_CONTEXT"
+	// EnvAWSSseCEncryptionKey is the environment variable to specify the AWS SSE-C encryption key when using type SSE-C.
+	EnvAWSSseCEncryptionKey = "AWS_SSE_C_ENCRYPTION_KEY" //#nosec G101 -- False positive
 	// EnvAWSRoleArn is the environment variable to specify the AWS role ARN secret for the federated identity workflow.
 	EnvAWSRoleArn = "AWS_ROLE_ARN"
 	// EnvAWSWebIdentityTokenFile is the environment variable to specify the path to the web identity token file used in the federated identity workflow.
@@ -67,6 +69,8 @@ const (
 	KeyAWSSseKmsEncryptionContext = "sse_kms_encryption_context"
 	// KeyAWSSseKmsKeyID is the secret data key for the AWS SSE KMS key id.
 	KeyAWSSseKmsKeyID = "sse_kms_key_id"
+	// KeyAWSSseCEncryptionKey is the secret key for the AWS SSE-C encryption key.
+	KeyAWSSseCEncryptionKey = "sse_c_encryption_key" //#nosec G101 -- False positive
 	// KeyAWSRoleArn is the secret data key for the AWS STS role ARN.
 	KeyAWSRoleArn = "role_arn"
 	// KeyAWSAudience is the audience for the AWS STS workflow.

--- a/pkg/storage/bucket/sse_bucket_client.go
+++ b/pkg/storage/bucket/sse_bucket_client.go
@@ -22,6 +22,9 @@ type SSEConfigProvider interface {
 
 	// S3SSEKMSEncryptionContext returns the per-tenant S3 KMS-SSE key id or an empty string if not set.
 	S3SSEKMSEncryptionContext(userID string) string
+
+	// S3SSECEncryptionKey returns the per-tenant S3 SSE-C encryption key or an empty string if not set.
+	S3SSECEncryptionKey(userID string) string
 }
 
 // SSEBucketClient is a wrapper around a objstore.BucketReader that configures the object
@@ -85,9 +88,10 @@ func (b *SSEBucketClient) getCustomS3SSEConfig() (encrypt.ServerSide, error) {
 	}
 
 	cfg := s3.SSEConfig{
-		Type:                 sseType,
-		KMSKeyID:             b.cfgProvider.S3SSEKMSKeyID(b.userID),
-		KMSEncryptionContext: b.cfgProvider.S3SSEKMSEncryptionContext(b.userID),
+		Type:                  sseType,
+		KMSKeyID:              b.cfgProvider.S3SSEKMSKeyID(b.userID),
+		KMSEncryptionContext:  b.cfgProvider.S3SSEKMSEncryptionContext(b.userID),
+		CustomerEncryptionKey: b.cfgProvider.S3SSECEncryptionKey(b.userID),
 	}
 
 	sse, err := cfg.BuildMinioConfig()

--- a/pkg/storage/chunk/client/aws/s3_storage_client.go
+++ b/pkg/storage/chunk/client/aws/s3_storage_client.go
@@ -374,6 +374,15 @@ func (a *S3ObjectClient) objectAttributes(ctx context.Context, objectKey, method
 				Bucket: aws.String(a.bucketFromKey(objectKey)),
 				Key:    aws.String(a.convertObjectKey(objectKey, true)),
 			}
+
+			// if sse-c used, we need to add the customer key and its md5 hash to the request
+			// SSE-S3/SSE-KMS related headers (like x-amz-server-side-encryption-aws-kms-key-id) are required only when uploading/creating objects, not for retrieving
+			if a.sseConfig != nil && a.sseConfig.SSEType == string(bucket_s3.SSEC) {
+				headObjectInput.SSECustomerAlgorithm = aws.String(a.sseConfig.ServerSideEncryption)
+				headObjectInput.SSECustomerKey = a.sseConfig.CustomerEncryptionKeyB64
+				headObjectInput.SSECustomerKeyMD5 = a.sseConfig.CustomerEncryptionKeyMD5B64
+			}
+
 			headOutput, requestErr := a.S3.HeadObject(ctx, headObjectInput)
 			if requestErr != nil {
 				return requestErr
@@ -437,10 +446,20 @@ func (a *S3ObjectClient) GetObject(ctx context.Context, objectKey string) (io.Re
 
 		lastErr = loki_instrument.TimeRequest(ctx, "S3.GetObject", s3RequestDuration, instrument.ErrorCode, func(ctx context.Context) error {
 			var requestErr error
-			resp, requestErr = a.hedgedS3.GetObject(ctx, &s3.GetObjectInput{
+			objInput := &s3.GetObjectInput{
 				Bucket: aws.String(a.bucketFromKey(objectKey)),
 				Key:    aws.String(a.convertObjectKey(objectKey, true)),
-			})
+			}
+
+			// if sse-c used, we need to add the customer key and its md5 hash to the request
+			// SSE-S3/SSE-KMS related headers (like x-amz-server-side-encryption-aws-kms-key-id) are required only when uploading/creating objects, not for retrieving
+			if a.sseConfig != nil && a.sseConfig.SSEType == string(bucket_s3.SSEC) {
+				objInput.SSECustomerAlgorithm = aws.String(a.sseConfig.ServerSideEncryption)
+				objInput.SSECustomerKey = a.sseConfig.CustomerEncryptionKeyB64
+				objInput.SSECustomerKeyMD5 = a.sseConfig.CustomerEncryptionKeyMD5B64
+			}
+
+			resp, requestErr = a.hedgedS3.GetObject(ctx, objInput)
 			return requestErr
 		})
 
@@ -472,11 +491,22 @@ func (a *S3ObjectClient) GetObjectRange(ctx context.Context, objectKey string, o
 
 		lastErr = loki_instrument.TimeRequest(ctx, "S3.GetObject", s3RequestDuration, instrument.ErrorCode, func(ctx context.Context) error {
 			var requestErr error
-			resp, requestErr = a.hedgedS3.GetObject(ctx, &s3.GetObjectInput{
+
+			objInput := &s3.GetObjectInput{
 				Bucket: aws.String(a.bucketFromKey(objectKey)),
 				Key:    aws.String(a.convertObjectKey(objectKey, true)),
 				Range:  aws.String(fmt.Sprintf("bytes=%d-%d", offset, offset+length-1)),
-			})
+			}
+
+			// if sse-c used, we need to add the customer key and its md5 hash to the request
+			// SSE-S3/SSE-KMS related headers (like x-amz-server-side-encryption-aws-kms-key-id) are required only when uploading/creating objects, not for retrieving
+			if a.sseConfig != nil && a.sseConfig.SSEType == string(bucket_s3.SSEC) {
+				objInput.SSECustomerAlgorithm = aws.String(a.sseConfig.ServerSideEncryption)
+				objInput.SSECustomerKey = a.sseConfig.CustomerEncryptionKeyB64
+				objInput.SSECustomerKeyMD5 = a.sseConfig.CustomerEncryptionKeyMD5B64
+			}
+
+			resp, requestErr = a.hedgedS3.GetObject(ctx, objInput)
 			return requestErr
 		})
 
@@ -504,9 +534,18 @@ func (a *S3ObjectClient) PutObject(ctx context.Context, objectKey string, object
 		}
 
 		if a.sseConfig != nil {
-			putObjectInput.ServerSideEncryption = types.ServerSideEncryption(a.sseConfig.ServerSideEncryption)
-			putObjectInput.SSEKMSKeyId = a.sseConfig.KMSKeyID
-			putObjectInput.SSEKMSEncryptionContext = a.sseConfig.KMSEncryptionContext
+			switch a.sseConfig.SSEType {
+			case string(bucket_s3.SSES3):
+				putObjectInput.ServerSideEncryption = types.ServerSideEncryption(a.sseConfig.ServerSideEncryption)
+			case string(bucket_s3.SSEKMS):
+				putObjectInput.ServerSideEncryption = types.ServerSideEncryption(a.sseConfig.ServerSideEncryption)
+				putObjectInput.SSEKMSKeyId = a.sseConfig.KMSKeyID
+				putObjectInput.SSEKMSEncryptionContext = a.sseConfig.KMSEncryptionContext
+			case string(bucket_s3.SSEC):
+				putObjectInput.SSECustomerAlgorithm = aws.String(a.sseConfig.ServerSideEncryption)
+				putObjectInput.SSECustomerKey = a.sseConfig.CustomerEncryptionKeyB64
+				putObjectInput.SSECustomerKeyMD5 = a.sseConfig.CustomerEncryptionKeyMD5B64
+			}
 		}
 
 		_, err = a.S3.PutObject(ctx, putObjectInput)

--- a/pkg/storage/chunk/client/aws/sse_config_test.go
+++ b/pkg/storage/chunk/client/aws/sse_config_test.go
@@ -1,6 +1,9 @@
 package aws
 
 import (
+	"crypto/md5"
+	"encoding/base64"
+	"strings"
 	"testing"
 
 	"github.com/pkg/errors"
@@ -15,6 +18,11 @@ func TestNewSSEParsedConfig(t *testing.T) {
 	// compact form of kmsEncryptionContext
 	parsedKMSEncryptionContext := "eyJhIjoiYmMiLCJiIjoiY2QifQ=="
 
+	sseCKey := strings.Repeat("a", 32)
+	sseCKeyMD5 := md5.Sum([]byte(sseCKey))
+	sseCKeyMD5B64 := base64.StdEncoding.EncodeToString(sseCKeyMD5[:])
+	sseCKeyHashB64 := base64.StdEncoding.EncodeToString([]byte(sseCKey))
+
 	tests := []struct {
 		name        string
 		params      s3.SSEConfig
@@ -22,34 +30,37 @@ func TestNewSSEParsedConfig(t *testing.T) {
 		expectedErr error
 	}{
 		{
-			name: "Test SSE encryption with SSES3 type",
+			name: "Test SSE with SSE S3 type",
 			params: s3.SSEConfig{
 				Type: s3.SSES3,
 			},
 			expected: &SSEParsedConfig{
-				ServerSideEncryption: sseS3Type,
+				SSEType:              s3.SSES3,
+				ServerSideEncryption: sseS3EncryptionType,
 			},
 		},
 		{
-			name: "Test SSE encryption with SSEKMS type without context",
+			name: "Test SSE with SSE KMS type without context",
 			params: s3.SSEConfig{
 				Type:     s3.SSEKMS,
 				KMSKeyID: kmsKeyID,
 			},
 			expected: &SSEParsedConfig{
-				ServerSideEncryption: sseKMSType,
+				SSEType:              s3.SSEKMS,
+				ServerSideEncryption: sseKMSEncryptionType,
 				KMSKeyID:             &kmsKeyID,
 			},
 		},
 		{
-			name: "Test SSE encryption with SSEKMS type with context",
+			name: "Test SSE with SSE KMS type with context",
 			params: s3.SSEConfig{
 				Type:                 s3.SSEKMS,
 				KMSKeyID:             kmsKeyID,
 				KMSEncryptionContext: kmsEncryptionContext,
 			},
 			expected: &SSEParsedConfig{
-				ServerSideEncryption: sseKMSType,
+				SSEType:              s3.SSEKMS,
+				ServerSideEncryption: sseKMSEncryptionType,
 				KMSKeyID:             &kmsKeyID,
 				KMSEncryptionContext: &parsedKMSEncryptionContext,
 			},
@@ -62,7 +73,7 @@ func TestNewSSEParsedConfig(t *testing.T) {
 			expectedErr: errors.New("SSE type is empty or invalid"),
 		},
 		{
-			name: "Test SSE encryption with SSEKMS type without KMS Key ID",
+			name: "Test SSE with SSE KMS type without KMS Key ID",
 			params: s3.SSEConfig{
 				Type:     s3.SSEKMS,
 				KMSKeyID: "",
@@ -70,13 +81,41 @@ func TestNewSSEParsedConfig(t *testing.T) {
 			expectedErr: errors.New("KMS key id must be passed when SSE-KMS encryption is selected"),
 		},
 		{
-			name: "Test SSE with invalid KMS encryption context JSON",
+			name: "Test SSE with SSE KMS type with invalid KMS encryption context JSON",
 			params: s3.SSEConfig{
 				Type:                 s3.SSEKMS,
 				KMSKeyID:             kmsKeyID,
 				KMSEncryptionContext: `INVALID_JSON`,
 			},
 			expectedErr: errors.New("failed to parse KMS encryption context: failed to marshal KMS encryption context: json: error calling MarshalJSON for type json.RawMessage: invalid character 'I' looking for beginning of value"),
+		},
+		{
+			name: "Test SSE with SSE C type",
+			params: s3.SSEConfig{
+				Type:                  s3.SSEC,
+				CustomerEncryptionKey: sseCKey,
+			},
+			expected: &SSEParsedConfig{
+				SSEType:                     s3.SSEC,
+				ServerSideEncryption:        sseCEncryptionType,
+				CustomerEncryptionKeyB64:    &sseCKeyHashB64,
+				CustomerEncryptionKeyMD5B64: &sseCKeyMD5B64,
+			},
+		},
+		{
+			name: "Test SSE with SSE C type with invalid key length",
+			params: s3.SSEConfig{
+				Type:                  s3.SSEC,
+				CustomerEncryptionKey: "short_key",
+			},
+			expectedErr: errors.New("customer encryption key must be 32 bytes long"),
+		},
+		{
+			name: "Test SSE with SSE C type with missing key",
+			params: s3.SSEConfig{
+				Type: s3.SSEC,
+			},
+			expectedErr: errors.New("customer encryption key must be passed when SSE-C encryption is selected"),
 		},
 	}
 

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -283,6 +283,7 @@ type Limits struct {
 	S3SSEType                 string `yaml:"s3_sse_type" json:"s3_sse_type" doc:"nocli|description=S3 server-side encryption type. Required to enable server-side encryption overrides for a specific tenant. If not set, the default S3 client settings are used."`
 	S3SSEKMSKeyID             string `yaml:"s3_sse_kms_key_id" json:"s3_sse_kms_key_id" doc:"nocli|description=S3 server-side encryption KMS Key ID. Ignored if the SSE type override is not set."`
 	S3SSEKMSEncryptionContext string `yaml:"s3_sse_kms_encryption_context" json:"s3_sse_kms_encryption_context" doc:"nocli|description=S3 server-side encryption KMS encryption context. If unset and the key ID override is set, the encryption context will not be provided to S3. Ignored if the SSE type override is not set."`
+	S3SSECEncryptionKey       string `yaml:"s3_sse_c_encryption_key" json:"s3_sse_c_encryption_key" doc:"nocli|description=S3 server-side encryption customer-provided encryption key. Ignored if the SSE type override is not set."`
 
 	// Per tenant limits for the v2 execution engine
 	MaxScanTaskParallelism int `yaml:"max_scan_task_parallelism" json:"max_scan_task_parallelism"`
@@ -1362,6 +1363,11 @@ func (o *Overrides) S3SSEKMSKeyID(user string) string {
 // S3SSEKMSEncryptionContext returns the per-tenant S3 KMS-SSE encryption context.
 func (o *Overrides) S3SSEKMSEncryptionContext(user string) string {
 	return o.getOverridesForUser(user).S3SSEKMSEncryptionContext
+}
+
+// S3SSECEncryptionKey returns the per-tenant S3 SSE-C encryption key.
+func (o *Overrides) S3SSECEncryptionKey(user string) string {
+	return o.getOverridesForUser(user).S3SSECEncryptionKey
 }
 
 func (o *Overrides) MaxScanTaskParallelism(userID string) int {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds support for `SSE-C` (Server-Side Encryption with Customer-Provided Keys) to the S3 storage backend in Loki. While `SSE-S3` and `SSE-KMS` were already supported, `SSE-C` was not. Since both AWS and MinIO fully support `SSE-C` encryption and there has been community demand for this feature (see https://github.com/grafana/loki/issues/9501), we now bring this implementation to Loki.

**Which issue(s) this PR fixes**:
Fixes #9501

**Special notes for your reviewer**:
- Feedback for improvements especially regarding documentation for end users is welcome.
- Handling `SSE-C` in production can be challenging, particularly with key rotation, so I have added clear warnings and notes about this in the documentation and Helm chart. However, there was no need to change the Helm chart.
- Test coverage has been extended accordingly.
- Functionality has been verified by building Loki from source using `make loki-debug-image` and testing with a modified Loki configuration in `examples/getting-started`.
- Is there still a need to update `docs/sources/setup/upgrade/_index.md`? There is no need for upgrading anything. The changes are fully backwards compatible.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
