### PR TITLE
chore(indexshipper): Close temp file after download

### DIFF
--- a/pkg/storage/stores/shipper/indexshipper/storage/util.go
+++ b/pkg/storage/stores/shipper/indexshipper/storage/util.go
@@ -62,8 +62,10 @@ func DownloadFileFromStorage(destination string, decompressFile bool, sync bool,
 		return err
 	}
 	defer func() {
-		err := os.Remove(tmpName)
-		if err != nil {
+		if err := ftmp.Close(); err != nil {
+			level.Warn(logger).Log("msg", "failed to close file", "file", tmpName)
+		}
+		if err := os.Remove(tmpName); err != nil {
 			level.Warn(logger).Log("msg", "failed to delete temp file from index download", "err", err)
 		}
 	}()
@@ -83,7 +85,7 @@ func DownloadFileFromStorage(destination string, decompressFile bool, sync bool,
 	}
 	defer func() {
 		if err := tmpReader.Close(); err != nil {
-			level.Warn(logger).Log("msg", "failed to close file", "file", destination+"-tmp")
+			level.Warn(logger).Log("msg", "failed to close file", "file", tmpName)
 		}
 	}()
 


### PR DESCRIPTION
**What this PR does / why we need it**:
When downloading a potentially compressed file, the file is first downloaded into a temp file and this temp file is then re-opened and processed. The re-opened *File is `Close()`d as expected but the initial temp *File is not. 

This PR adds the missing `Close()`.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

This regression was introduced in https://github.com/grafana/loki/pull/13202

I found this issue when I was debugging an FD exhaustion in loki. I'm marking this as a `chore` since there is no evidence this was the cause of the FD exhaustion.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
