### PR TITLE
feat: Add kafkav2 package

### DIFF
--- a/pkg/kafkav2/client/client.go
+++ b/pkg/kafkav2/client/client.go
@@ -1,0 +1,192 @@
+package client
+
+import (
+	"context"
+	"math"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/loki/v3/pkg/kafka"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/twmb/franz-go/pkg/kgo"
+	"github.com/twmb/franz-go/pkg/kmsg"
+	"github.com/twmb/franz-go/pkg/sasl/plain"
+	"github.com/twmb/franz-go/plugin/kotel"
+	"github.com/twmb/franz-go/plugin/kprom"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// NewClient returns a new [kgo.Client] from the opts.
+func NewClient(cfg Config, namespace string, logger log.Logger, reg prometheus.Registerer, opts ...kgo.Opt) (*kgo.Client, error) {
+	reg = prometheus.WrapRegistererWith(prometheus.Labels{"client": namespace}, reg)
+
+	metrics := kprom.NewMetrics("loki_kafkav2",
+		kprom.Registerer(reg),
+		kprom.FetchAndProduceDetail(
+			kprom.Batches,
+			kprom.Records,
+			kprom.CompressedBytes,
+			kprom.UncompressedBytes,
+		),
+	)
+	clientOpts := commonOpts(cfg, logger, metrics)
+	clientOpts = append(clientOpts, opts...)
+	return kgo.NewClient(clientOpts...)
+}
+
+// ConsumerOpts returns the common options for all clients that consume records.
+func ConsumerOpts(cfg Config) []kgo.Opt {
+	opts := []kgo.Opt{
+		kgo.FetchMinBytes(int32(cfg.FetchMinBytes)),
+		kgo.FetchMaxBytes(int32(cfg.FetchMaxBytes)),
+		kgo.FetchMaxWait(cfg.FetchMaxWait),
+		kgo.FetchMaxPartitionBytes(int32(cfg.FetchMaxPartitionBytes)),
+		// This is a safety measure to avoid OOMs on invalid responses.
+		// The recommendation is to set it twice FetchMaxBytes.
+		kgo.BrokerMaxReadBytes(int32(2 * cfg.FetchMaxBytes)),
+	}
+	if cfg.Topic != "" {
+		opts = append(opts, kgo.ConsumeTopics(cfg.Topic))
+	}
+	if cfg.TopicRegex {
+		opts = append(opts, kgo.ConsumeRegex())
+	}
+	if cfg.ConsumerGroup != "" {
+		opts = append(opts, kgo.ConsumerGroup(cfg.ConsumerGroup))
+	}
+	return opts
+}
+
+// ConsumerOpts returns the common options for all clients that produce records.
+func ProducerOpts(cfg Config) []kgo.Opt {
+	return []kgo.Opt{
+		kgo.RequiredAcks(kgo.AllISRAcks()),
+
+		// By default, the Kafka client allows 1 Produce in-flight request
+		// per broker. Disabling write idempotency (which we don't need), we
+		// can increase the max number of in-flight Produce requests per
+		// broker. A higher number of in-flight requests, in addition to short
+		// buffering ("linger") in client side before firing the next Produce
+		// request allows us to reduce the end-to-end latency.
+		//
+		// The result of the multiplication of producer linger and max
+		// in-flight requests should match the maximum Produce latency
+		// expected by the Kafka backend in a steady state. For example,
+		// 50ms * 20 requests = 1s, which means the Kafka client will keep
+		// issuing a Produce request every 50ms as far as the Kafka backend
+		// doesn't take longer than 1s to process them (if it takes longer,
+		// the client will buffer data and stop issuing new Produce requests
+		// ntil some previous ones complete).
+		kgo.DisableIdempotentWrite(),
+		kgo.ProducerLinger(50 * time.Millisecond),
+		kgo.MaxProduceRequestsInflightPerBroker(cfg.MaxInFlightRequestsPerBroker),
+
+		// Unlimited number of Produce retries but a deadline on the max time
+		// a record can take to be delivered. With the default config it would
+		// retry infinitely.
+		//
+		// Details of the involved timeouts:
+		// - RecordDeliveryTimeout: how long a Kafka client Produce() call can
+		//   take for a given record. The overhead timeout is NOT applied.
+		// - ProduceRequestTimeout: how long to wait for the response to the
+		//   Produce request (the Kafka protocol message) after being sent on
+		//   the network. The actual timeout is increased by the configured
+		//   overhead.
+		//
+		// When a Produce request to Kafka fail, the client will retry up
+		// until the RecordDeliveryTimeout is reached. Once the timeout is
+		// reached, the Produce request will fail and all other buffered
+		// requests in the client (for the same partition) will fail too.
+		// See [kgo.RecordDeliveryTimeout] documentation for more info.
+		kgo.RecordRetries(math.MaxInt),
+		// Hard-code these for now while I understand how they should be used.
+		kgo.RecordDeliveryTimeout(10 * time.Second),
+		kgo.ProduceRequestTimeout(10 * time.Second),
+		kgo.RequestTimeoutOverhead(2 * time.Second),
+		kgo.ProducerBatchMaxBytes(kafka.ProducerBatchMaxBytes),
+	}
+}
+
+// commonOpts returns the common options for all clients.
+func commonOpts(cfg Config, logger log.Logger, metrics *kprom.Metrics) []kgo.Opt {
+	opts := []kgo.Opt{
+		kgo.ClientID(cfg.ClientID),
+		kgo.SeedBrokers(cfg.Address),
+
+		// A cluster metadata update is a request sent to a broker and getting
+		// back the map of partitions and the leader broker for each partition.
+		// The cluster metadata can be updated (a) periodically or (b) when
+		// some events occur (e.g. backoff due to errors).
+		//
+		// MetadataMinAge() sets the minimum time between two cluster metadata
+		// updates due to events. MetadataMaxAge() sets how frequently the
+		// periodic update should occur.
+		//
+		// It's important to note that the periodic update is also used to
+		// discover new brokers (e.g. during a rolling update or after a scale
+		// up). For this reason, it's important to run the update frequently.
+		//
+		// The other two side effects of frequently updating the cluster
+		// metadata:
+		//
+		// 1. The "metadata" request may be expensive to run on the Kafka
+		//    backend.
+		// 2. If the backend returns each time a different authoritative owner
+		//    for a partition, then each time the cluster metadata is updated
+		//    the Kafka client will create a new connection for each partition,
+		//    leading to a high connections churn rate.
+		//
+		// We currently set min and max age to the same value to have constant
+		// load on the Kafka backend: regardless there are errors or not, the
+		// metadata requests frequency doesn't change.
+		kgo.MetadataMinAge(10 * time.Second),
+		kgo.MetadataMaxAge(10 * time.Second),
+		kgo.RetryTimeoutFn(func(key int16) time.Duration {
+			switch key {
+			case ((*kmsg.ListOffsetsRequest)(nil)).Key():
+				return 10 * time.Second
+			}
+			return 30 * time.Second
+		}),
+		kgo.DialTimeout(cfg.DialTimeout),
+		kgo.WithLogger(newLogger(logger)),
+	}
+
+	// SASL plain auth.
+	if cfg.SASLUsername != "" && cfg.SASLPassword.String() != "" {
+		opts = append(opts, kgo.SASL(
+			plain.Plain(func(_ context.Context) (plain.Auth, error) {
+				return plain.Auth{
+					User: cfg.SASLUsername,
+					Pass: cfg.SASLPassword.String(),
+				}, nil
+			}),
+		))
+	}
+
+	tracer := kotel.NewTracer(
+		kotel.TracerPropagator(
+			propagation.NewCompositeTextMapPropagator(
+				sampledTraces{propagation.TraceContext{}})),
+	)
+	opts = append(opts, kgo.WithHooks(kotel.NewKotel(kotel.WithTracer(tracer)).Hooks()...))
+
+	if metrics != nil {
+		opts = append(opts, kgo.WithHooks(metrics))
+	}
+
+	return opts
+}
+
+type sampledTraces struct {
+	propagation.TextMapPropagator
+}
+
+func (o sampledTraces) Inject(ctx context.Context, carrier propagation.TextMapCarrier) {
+	sc := trace.SpanContextFromContext(ctx)
+	if !sc.IsSampled() {
+		return
+	}
+	o.TextMapPropagator.Inject(ctx, carrier)
+}

--- a/pkg/kafkav2/client/config.go
+++ b/pkg/kafkav2/client/config.go
@@ -1,0 +1,103 @@
+package client
+
+import (
+	"errors"
+	"flag"
+	"time"
+
+	"github.com/grafana/dskit/flagext"
+)
+
+// Config contains configuration options for a [kgo.Client].
+type Config struct {
+	ClientID     string         `yaml:"client_id,omitempty"`
+	Address      string         `yaml:"address,omitempty"`
+	SASLUsername string         `yaml:"sasl_username,omitempty"`
+	SASLPassword flagext.Secret `yaml:"sasl_password,omitempty"`
+	DialTimeout  time.Duration  `yaml:"dial_timeout,omitempty"`
+	Topic        string         `yaml:"topic,omitempty"`
+
+	// Consume specific configuration options.
+
+	// True if the topic name is a regular expression.
+	TopicRegex bool `yaml:"topic_regex,omitempty"`
+
+	// The (optional) name of the Consumer Group. Leave blank if direct
+	// consuming.
+	ConsumerGroup string `yaml:"consumer_group,omitempty"`
+
+	// The minimum number of bytes a broker will attempt to send during a
+	// fetch. Is used in [kgo.FetchMinBytes].
+	FetchMinBytes int `yaml:"fetch_min_bytes,omitempty"`
+
+	// The maximum number of bytes a broker will attempt to send during a
+	// fetch. Is used in [kgo.FetchMaxBytes].
+	FetchMaxBytes int `yaml:"fetch_max_bytes,omitempty"`
+
+	// The maximum amount of time a broker will wait for a fetch response
+	// to reach FetchMinBytes. Is used in [kgo.FetchMaxWait].
+	FetchMaxWait time.Duration `yaml:"fetch_max_wait,omitempty"`
+
+	// The maximum number of bytes consumed per partition per fetch request.
+	// Is used in [kgo.FetchMaxPartitionBytes].
+	FetchMaxPartitionBytes int `yaml:"fetch_max_partition_bytes,omitempty"`
+
+	// Produce specific configuration options.
+
+	// The maximum number of inflight requests per broker. Is used in
+	// [kgo.MaxInFlightRequestsPerBroker].
+	MaxInFlightRequestsPerBroker int `yaml:"max_in_flight_requests_per_broker,omitempty"`
+}
+
+// RegisterFlags registers the flags with the default prefix.
+func (c *Config) RegisterFlags(f *flag.FlagSet) {
+	c.RegisterFlagsWithPrefix("kafka-clientv2", f)
+}
+
+// RegisterFlagsWithPrefix registers the flags with the given prefix.
+func (c *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
+	f.StringVar(&c.ClientID, prefix+"client-id", "", "The client ID.")
+	f.StringVar(&c.Address, prefix+"address", "localhost:9092", "The address of the Kafka broker.")
+	f.StringVar(&c.SASLUsername, prefix+"sasl-username", "", "The SASL username for authentication to Kafka using the PLAIN mechanism. Both username and password must be set.")
+	f.Var(&c.SASLPassword, prefix+"sasl-password", "The SASL password for authentication to Kafka using the PLAIN mechanism. Both username and password must be set.")
+	f.DurationVar(&c.DialTimeout, prefix+"dial-timeout", 10*time.Second, "")
+	f.StringVar(&c.Topic, prefix+"topic", "", "The topic name.")
+
+	// Consume specific configuration options.
+	f.BoolVar(&c.TopicRegex, prefix+"topic-regex", false, "The topic name is a regular expression.")
+	f.IntVar(&c.FetchMinBytes, prefix+"fetch-min-bytes", 1, "The minimum number of bytes a broker will attempt to send during a fetch.")
+	f.IntVar(&c.FetchMaxBytes, prefix+"fetch-max-bytes", 100*1024*1024, "The maximum number of bytes a broker will attempt to send during a fetch.")
+	f.DurationVar(&c.FetchMaxWait, prefix+"fetch-max-wait", 5*time.Second, "The maximum amount of time a broker will wait for a fetch response to reach fetch-max-bytes.")
+	f.IntVar(&c.FetchMaxPartitionBytes, prefix+"fetch-max-partition-bytes", 50*1024*1024, "The maximum number of bytes consumed per partition per fetch request.")
+
+	// Produce specific configuration options.
+	f.IntVar(&c.MaxInFlightRequestsPerBroker, prefix+"max-in-flight-requests-per-broker", 1, "The maximum number of inflight requests per broker.")
+}
+
+func (c *Config) Validate() error {
+	if c.ClientID == "" {
+		return errors.New("The Client ID is required.")
+	}
+	if c.Address == "" {
+		return errors.New("The address of the Kafka broker is required.")
+	}
+	if c.DialTimeout <= 0 {
+		return errors.New("The dial timeout must be greater than 0.")
+	}
+	if c.FetchMinBytes <= 0 {
+		return errors.New("Fetch min bytes must be greater than 0.")
+	}
+	if c.FetchMaxBytes <= 0 {
+		return errors.New("Fetch max bytes must be greater than 0.")
+	}
+	if c.FetchMaxWait <= 0 {
+		return errors.New("Fetch max wait must be greater than 0.")
+	}
+	if c.FetchMaxPartitionBytes <= 0 {
+		return errors.New("Fetch max partition bytes must be greater than 0.")
+	}
+	if c.MaxInFlightRequestsPerBroker <= 0 {
+		return errors.New("Max in-flight requests per broker must be greater than 0.")
+	}
+	return nil
+}

--- a/pkg/kafkav2/client/doc.go
+++ b/pkg/kafkav2/client/doc.go
@@ -1,0 +1,53 @@
+/*
+Package client provides high-level abstractions for configuring Kafka clients,
+synchronous and asynchronous mechanisms to commit offsets for both direct
+and group consumers, and fetching offset metadata from Kafka brokers.
+
+To create a Kafka client, use the [NewClient] function. [ConsumerOpts] and
+[ProducerOpts] returns a set of options that are common for consumer and
+producer clients.
+
+	// Create a Kafka client to consume records.
+	client, err := NewClient(cfg, logger, reg, ConsumerOpts(cfg)...)
+	...
+
+	// Create a Kafka client to produce records.
+	client, err := NewClient(cfg, logger, reg, ProducerOpts(cfg)...)
+	...
+	// Create a Kafka client to consume and produce records. This requires
+	// the broker supports both consumer and producer APIs.
+	var opts []kgo.Opt
+	opts = append(opts, ConsumerOpts(cfg)...)
+	opts = append(opts, ProducerOpts(cfg)...)
+	client, err := NewClient(cfg, logger, reg, opts...)
+	...
+
+To commit offsets use either a [Committer], [GroupCommitter], [AsyncCommitter]
+or [AsyncGroupCommitter]. A [Committer], and its equivalent async
+implementation [AsyncCommitter] allows committing offsets for any topic,
+partition and consumer group; while a [GroupCommitter] its equivalent async
+implementation [AsyncGroupCommitter] allows committing offsets for any
+partitions within a single topic and consumer group.
+
+	// Commit offsets.
+	committer := NewCommitter(kadm.NewClient(client))
+	err := committer.Commit(ctx, topic, partition, consumerGroup, offset)
+	...
+
+	groupCommitter := NewGroupCommitter(kadm.NewClient(client), topic, consumerGroup)
+	err := groupCommitter.Commit(ctx, offset)
+	...
+
+	// Commit offsets async.
+	asyncCommitter := NewAsyncCommitter(kadm.NewClient(client))
+	// Can return err if context is canceled.
+	err := asyncCommitter.Commit(ctx, topic, partition, consumerGroup, offset)
+	...
+
+	asyncGroupCommitter := NewAsyncGroupCommitter(kadm.NewClient(client), topic, consumerGroup)
+	err := asyncGroupCommitter.Commit(ctx, offset)
+	...
+
+	// Commit offsets async.
+*/
+package client

--- a/pkg/kafkav2/client/logger.go
+++ b/pkg/kafkav2/client/logger.go
@@ -1,0 +1,39 @@
+package client
+
+import (
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/twmb/franz-go/pkg/kgo"
+)
+
+// logger wraps a [log.Logger] and implements the [kgo.Logger] interface.
+type logger struct {
+	logger log.Logger
+}
+
+// newLogger wraps l to implement the [kgo.Logger] interface.
+func newLogger(l log.Logger) *logger {
+	return &logger{log.With(l, "component", "kafka_client_v2")}
+}
+
+// Level implements the [kgo.Logger] interface.
+func (l *logger) Level() kgo.LogLevel {
+	// [kgo.Client] calls Level() to check what level to log at. We force
+	// it to return [kgo.LogLevelInfo] as debug level is expensive.
+	return kgo.LogLevelInfo
+}
+
+// Log implements the [kgo.Logger] interface.
+func (l *logger) Log(lev kgo.LogLevel, msg string, keyvals ...any) {
+	keyvals = append([]any{"msg", msg}, keyvals...)
+	switch lev {
+	case kgo.LogLevelDebug:
+		level.Debug(l.logger).Log(keyvals...)
+	case kgo.LogLevelInfo:
+		level.Info(l.logger).Log(keyvals...)
+	case kgo.LogLevelWarn:
+		level.Warn(l.logger).Log(keyvals...)
+	case kgo.LogLevelError:
+		level.Error(l.logger).Log(keyvals...)
+	}
+}

--- a/pkg/kafkav2/client/offset.go
+++ b/pkg/kafkav2/client/offset.go
@@ -1,0 +1,308 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/twmb/franz-go/pkg/kadm"
+	"github.com/twmb/franz-go/pkg/kerr"
+	"github.com/twmb/franz-go/pkg/kgo"
+	"github.com/twmb/franz-go/pkg/kmsg"
+)
+
+const (
+	// Special offsets in Kafka that refer to the start or end offset for
+	// a partition.
+	OffsetStart = -2
+	OffsetEnd   = -1
+)
+
+// A Committer commits offsets.
+type Committer struct {
+	client *kadm.Client
+}
+
+// NewCommitter returns a new Committer.
+func NewCommitter(client *kadm.Client) *Committer {
+	return &Committer{
+		client: client,
+	}
+}
+
+// Commit commits the offset. It returns an error if the offset could not
+// be committed.
+func (c *Committer) Commit(ctx context.Context, topic string, partition int32, consumerGroup string, offset int64) error {
+	offsets := kadm.Offsets{}
+	offsets.AddOffset(topic, partition, offset, -1)
+	committed, err := c.client.CommitOffsets(ctx, consumerGroup, offsets)
+	if err != nil {
+		return err
+	}
+	if !committed.Ok() {
+		return committed.Error()
+	}
+	return nil
+}
+
+// A GroupCommitter commits offsets for a consumer group.
+type GroupCommitter struct {
+	topic         string
+	consumerGroup string
+	*Committer
+}
+
+// NewGroupCommitter returns a new GroupCommitter.
+func NewGroupCommitter(client *kadm.Client, topic string, consumerGroup string) *GroupCommitter {
+	return &GroupCommitter{
+		topic:         topic,
+		consumerGroup: consumerGroup,
+		Committer:     NewCommitter(client),
+	}
+}
+
+// Commit commits the offset. It returns an error if the offset could not
+// be committed.
+func (c *GroupCommitter) Commit(ctx context.Context, partition int32, offset int64) error {
+	return c.Committer.Commit(ctx, c.topic, partition, c.consumerGroup, offset)
+}
+
+type commitWithPromise struct {
+	topic         string
+	partition     int32
+	consumerGroup string
+	offset        int64
+	promise       func(error)
+}
+
+// An AsyncCommitter commits offsets asynchronously.
+type AsyncCommitter struct {
+	client *kadm.Client
+	jobs   chan commitWithPromise
+}
+
+// NewAsyncCommitter returns a new AsyncCommitter. Up to n jobs can be
+// queued at a time.
+func NewAsyncCommitter(client *kadm.Client, n int64) *AsyncCommitter {
+	return &AsyncCommitter{
+		client: client,
+		jobs:   make(chan commitWithPromise, n),
+	}
+}
+
+// Run the committer loop until the context is cancelled.
+func (c *AsyncCommitter) Run(ctx context.Context) error {
+	for {
+		select {
+		case job := <-c.jobs:
+			offsets := kadm.Offsets{}
+			offsets.AddOffset(job.topic, job.partition, job.offset, -1)
+			committed, err := c.client.CommitOffsets(ctx, job.consumerGroup, offsets)
+			if err != nil {
+				job.promise(err)
+			} else if !committed.Ok() {
+				job.promise(committed.Error())
+			} else {
+				job.promise(nil)
+			}
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}
+
+// CommitAsync the offset and call the callback on completion. If the offset
+// could not be committed then an error is passed to the callback.
+func (c *AsyncCommitter) CommitAsync(
+	ctx context.Context,
+	topic string,
+	partition int32,
+	consumerGroup string,
+	offset int64,
+	callback func(err error),
+) {
+	select {
+	case <-ctx.Done():
+		callback(ctx.Err())
+	case c.jobs <- commitWithPromise{
+		topic:         topic,
+		partition:     partition,
+		consumerGroup: consumerGroup,
+		offset:        offset,
+		promise:       callback,
+	}:
+	}
+}
+
+// An AsyncGroupCommitter commits offsets for a consumer group asynchronously.
+type AsyncGroupCommitter struct {
+	*AsyncCommitter
+	topic         string
+	consumerGroup string
+}
+
+func NewAsyncGroupCommitter(client *kadm.Client, topic string, consumerGroup string, n int64) *AsyncGroupCommitter {
+	return &AsyncGroupCommitter{
+		topic:          topic,
+		consumerGroup:  consumerGroup,
+		AsyncCommitter: NewAsyncCommitter(client, n),
+	}
+}
+
+// CommitAsync the offset and call the callback on completion. If the offset
+// could not be committed then an error is passed to the callback.
+func (c *AsyncGroupCommitter) CommitAsync(
+	ctx context.Context,
+	partition int32,
+	offset int64,
+	callback func(err error),
+) {
+	select {
+	case <-ctx.Done():
+		callback(ctx.Err())
+	case c.jobs <- commitWithPromise{
+		topic:         c.topic,
+		partition:     partition,
+		consumerGroup: c.consumerGroup,
+		offset:        offset,
+		promise:       callback,
+	}:
+	}
+}
+
+// OffsetReader reads commit offsets.
+type OffsetReader struct {
+	adm           *kadm.Client
+	client        *kgo.Client
+	topic         string
+	consumerGroup string
+	logger        log.Logger
+}
+
+// NewOffsetReader returns a new OffsetReader.
+func NewOffsetReader(
+	client *kgo.Client,
+	topic string,
+	consumerGroup string,
+	logger log.Logger,
+) *OffsetReader {
+	return &OffsetReader{
+		adm:           kadm.NewClient(client),
+		client:        client,
+		topic:         topic,
+		consumerGroup: consumerGroup,
+		logger:        log.With(logger, "topic", topic, "consumer_group", consumerGroup),
+	}
+}
+
+// LastCommittedOffset returns the last committed offset for the partition.
+func (r *OffsetReader) LastCommittedOffset(ctx context.Context, partition int32) (int64, error) {
+	req := kmsg.NewPtrOffsetFetchRequest()
+	req.Group = r.consumerGroup
+	req.Topics = []kmsg.OffsetFetchRequestTopic{{
+		Topic:      r.topic,
+		Partitions: []int32{partition},
+	}}
+	resps := r.client.RequestSharded(ctx, req)
+	// Since we issued a request for only 1 partition, we expect exactly 1 response.
+	if expected, actual := 1, len(resps); actual != expected {
+		return 0, fmt.Errorf("unexpected number of responses: %d", len(resps))
+	}
+	// Ensure no error occurred.
+	res := resps[0]
+	if res.Err != nil {
+		return 0, res.Err
+	}
+	// Parse the response.
+	fetchRes, ok := res.Resp.(*kmsg.OffsetFetchResponse)
+	if !ok {
+		return 0, errors.New("unexpected response type")
+	}
+	if len(fetchRes.Groups) != 1 ||
+		len(fetchRes.Groups[0].Topics) != 1 ||
+		len(fetchRes.Groups[0].Topics[0].Partitions) != 1 {
+		level.Debug(r.logger).Log(
+			"msg", "malformed response, setting to start offset",
+		)
+		return int64(OffsetStart), nil
+	}
+	partitionRes := fetchRes.Groups[0].Topics[0].Partitions[0]
+	if err := kerr.ErrorForCode(partitionRes.ErrorCode); err != nil {
+		return 0, err
+	}
+	return partitionRes.Offset, nil
+}
+
+// NextOffset returns the first offset at or after t. If there are no offsets
+// at or after t, it returns the current end offset instead.
+func (r *OffsetReader) NextOffset(ctx context.Context, partition int32, t time.Time) (int64, error) {
+	resp, err := r.adm.ListOffsetsAfterMilli(ctx, t.UnixMilli(), r.topic)
+	if err != nil {
+		return 0, err
+	}
+	// If a topic does not exist, a special -1 partition for each non-existing
+	// topic is added to the response.
+	partitions := resp[r.topic]
+	if special, ok := partitions[-1]; ok {
+		return 0, special.Err
+	}
+	// If a partition does not exist, it will be missing.
+	listed, ok := partitions[partition]
+	if !ok {
+		return 0, fmt.Errorf("unknown partition %d", partition)
+	}
+	// Err is non-nil if the partition has a load error.
+	if listed.Err != nil {
+		return 0, listed.Err
+	}
+	return listed.Offset, nil
+}
+
+// PartitionOffset returns the last produced offset for the partition.
+func (r *OffsetReader) PartitionOffset(ctx context.Context, partition int32, position int64) (int64, error) {
+	partitionReq := kmsg.NewListOffsetsRequestTopicPartition()
+	partitionReq.Partition = partition
+	partitionReq.Timestamp = int64(position)
+
+	topicReq := kmsg.NewListOffsetsRequestTopic()
+	topicReq.Topic = r.topic
+	topicReq.Partitions = []kmsg.ListOffsetsRequestTopicPartition{partitionReq}
+
+	req := kmsg.NewPtrListOffsetsRequest()
+	req.IsolationLevel = 0 // 0 means READ_UNCOMMITTED.
+	req.Topics = []kmsg.ListOffsetsRequestTopic{topicReq}
+
+	// Even if we share the same client, other in-flight requests are not canceled once this context is canceled
+	// (or its deadline is exceeded). We've verified it with a unit test.
+	resps := r.client.RequestSharded(ctx, req)
+
+	// Since we issued a request for only 1 partition, we expect exactly 1 response.
+	if len(resps) != 1 {
+		return 0, fmt.Errorf("unexpected number of responses: %d", len(resps))
+	}
+
+	// Ensure no error occurred.
+	res := resps[0]
+	if res.Err != nil {
+		return 0, res.Err
+	}
+
+	listRes, ok := res.Resp.(*kmsg.ListOffsetsResponse)
+	if !ok {
+		return 0, errors.New("unexpected response type")
+	}
+
+	if len(listRes.Topics) != 1 ||
+		len(listRes.Topics[0].Partitions) != 1 {
+		return 0, errors.New("malformed response")
+	}
+
+	partitionRes := listRes.Topics[0].Partitions[0]
+	if err := kerr.ErrorForCode(partitionRes.ErrorCode); err != nil {
+		return 0, err
+	}
+	return partitionRes.Offset, nil
+}

--- a/pkg/kafkav2/client/offset_test.go
+++ b/pkg/kafkav2/client/offset_test.go
@@ -1,0 +1,320 @@
+package client
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/kadm"
+	"github.com/twmb/franz-go/pkg/kerr"
+	"github.com/twmb/franz-go/pkg/kfake"
+	"github.com/twmb/franz-go/pkg/kgo"
+
+	"github.com/grafana/loki/v3/pkg/kafkav2/testutil"
+)
+
+// This test asserts that the correct offset is committed for the intended
+// topic, partition and consumer group, and that no offsets are incorrectly
+// committed for any other topics, partitions or consumer groups.
+func TestCommitter_Commit(t *testing.T) {
+	const (
+		testTopic         = "test-topic"
+		testConsumerGroup = "test-consumer-group"
+	)
+	ctx := t.Context()
+	// Create a fake cluster for the test.
+	cluster, err := kfake.NewCluster(kfake.NumBrokers(1), kfake.SeedTopics(1, testTopic))
+	require.NoError(t, err)
+	t.Cleanup(cluster.Close)
+	client := testutil.MustKafkaClient(t, cluster.ListenAddrs()[0])
+	adm := kadm.NewClient(client)
+
+	// There should be no committed offsets.
+	offsets, err := adm.FetchOffsets(ctx, testConsumerGroup)
+	require.Equal(t, kerr.GroupIDNotFound, err)
+	require.Nil(t, offsets)
+
+	// Commit an offset, it should succeed.
+	m := NewCommitter(adm)
+	require.NoError(t, m.Commit(ctx, testTopic, 0, testConsumerGroup, 100))
+
+	// Check that the offset was committed.
+	offsets, err = adm.FetchOffsets(ctx, testConsumerGroup)
+	require.NoError(t, err)
+	topicOffsets, ok := offsets[testTopic]
+	require.True(t, ok)
+	require.Len(t, topicOffsets, 1)
+	offset := topicOffsets[0]
+	require.Equal(t, testTopic, offset.Topic)
+	require.Equal(t, int32(0), offset.Partition)
+	require.Equal(t, int64(100), offset.At)
+
+	// No other consumer groups should exist. If they do, we have somehow
+	// committed offsets for the wrong consumer group.
+	groups, err := adm.ListGroups(ctx)
+	require.NoError(t, err)
+	require.Len(t, groups, 1)
+	require.Contains(t, groups, testConsumerGroup)
+}
+
+func TestGroupCommitter_Commit(t *testing.T) {
+	const (
+		testTopic         = "test-topic"
+		testConsumerGroup = "test-consumer-group"
+	)
+	ctx := t.Context()
+	// Create a fake cluster for the test.
+	cluster, err := kfake.NewCluster(kfake.NumBrokers(1), kfake.SeedTopics(1, testTopic))
+	require.NoError(t, err)
+	t.Cleanup(cluster.Close)
+	client := testutil.MustKafkaClient(t, cluster.ListenAddrs()[0])
+	adm := kadm.NewClient(client)
+	m := NewGroupCommitter(adm, testTopic, testConsumerGroup)
+
+	// Commit an offset, it should succeed.
+	require.NoError(t, m.Commit(ctx, 0, 100))
+
+	// Check that the offset was committed.
+	offsets, err := adm.FetchOffsets(ctx, testConsumerGroup)
+	require.NoError(t, err)
+	topicOffsets, ok := offsets[testTopic]
+	require.True(t, ok)
+	require.Len(t, topicOffsets, 1)
+	offset := topicOffsets[0]
+	require.Equal(t, testTopic, offset.Topic)
+	require.Equal(t, int32(0), offset.Partition)
+	require.Equal(t, int64(100), offset.At)
+
+	// No other consumer groups should exist. If they do, we have somehow
+	// committed offsets for the wrong consumer group.
+	groups, err := adm.ListGroups(ctx)
+	require.NoError(t, err)
+	require.Len(t, groups, 1)
+	require.Contains(t, groups, testConsumerGroup)
+}
+
+func TestAsyncCommitter_Commit(t *testing.T) {
+	const (
+		testTopic         = "test-topic"
+		testConsumerGroup = "test-consumer-group"
+	)
+	ctx := t.Context()
+	// Create a fake cluster for the test.
+	cluster, err := kfake.NewCluster(kfake.NumBrokers(1), kfake.SeedTopics(1, testTopic))
+	require.NoError(t, err)
+	t.Cleanup(cluster.Close)
+	client := testutil.MustKafkaClient(t, cluster.ListenAddrs()[0])
+	adm := kadm.NewClient(client)
+	m := NewAsyncCommitter(adm, 1)
+
+	// Create a context with timeout in case the async job never finishes.
+	cancelCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	t.Cleanup(cancel)
+	go m.Run(cancelCtx)
+	done := make(chan struct{})
+
+	// Commit an offset, it should succeed.
+	m.CommitAsync(ctx, testTopic, 0, testConsumerGroup, 100, func(err error) {
+		require.NoError(t, err)
+		close(done)
+	})
+
+	// Wait for the job to finish.
+	select {
+	case <-done:
+	case <-cancelCtx.Done():
+		t.Fatal("CommitAsync did not complete within context deadline")
+	}
+
+	// Check that the offset was committed.
+	offsets, err := adm.FetchOffsets(ctx, testConsumerGroup)
+	require.NoError(t, err)
+	topicOffsets, ok := offsets[testTopic]
+	require.True(t, ok)
+	require.Len(t, topicOffsets, 1)
+	offset := topicOffsets[0]
+	require.Equal(t, testTopic, offset.Topic)
+	require.Equal(t, int32(0), offset.Partition)
+	require.Equal(t, int64(100), offset.At)
+
+	// No other consumer groups should exist. If they do, we have somehow
+	// committed offsets for the wrong consumer group.
+	groups, err := adm.ListGroups(ctx)
+	require.NoError(t, err)
+	require.Len(t, groups, 1)
+	require.Contains(t, groups, testConsumerGroup)
+}
+
+func TestGroupAsyncCommitter_Commit(t *testing.T) {
+	const (
+		testTopic         = "test-topic"
+		testConsumerGroup = "test-consumer-group"
+	)
+	ctx := t.Context()
+	// Create a fake cluster for the test.
+	cluster, err := kfake.NewCluster(kfake.NumBrokers(1), kfake.SeedTopics(1, testTopic))
+	require.NoError(t, err)
+	t.Cleanup(cluster.Close)
+	client := testutil.MustKafkaClient(t, cluster.ListenAddrs()[0])
+	adm := kadm.NewClient(client)
+	m := NewAsyncGroupCommitter(adm, testTopic, testConsumerGroup, 1)
+
+	// Create a context with timeout in case the async job never finishes.
+	cancelCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	t.Cleanup(cancel)
+	go m.Run(cancelCtx)
+	done := make(chan struct{})
+
+	// Commit an offset, it should succeed.
+	m.CommitAsync(ctx, 0, 100, func(err error) {
+		require.NoError(t, err)
+		close(done)
+	})
+
+	// Wait for the job to finish.
+	select {
+	case <-done:
+	case <-cancelCtx.Done():
+		t.Fatal("CommitAsync did not complete within context deadline")
+	}
+
+	// Check that the offset was committed.
+	offsets, err := adm.FetchOffsets(ctx, testConsumerGroup)
+	require.NoError(t, err)
+	topicOffsets, ok := offsets[testTopic]
+	require.True(t, ok)
+	require.Len(t, topicOffsets, 1)
+	offset := topicOffsets[0]
+	require.Equal(t, testTopic, offset.Topic)
+	require.Equal(t, int32(0), offset.Partition)
+	require.Equal(t, int64(100), offset.At)
+
+	// No other consumer groups should exist. If they do, we have somehow
+	// committed offsets for the wrong consumer group.
+	groups, err := adm.ListGroups(ctx)
+	require.NoError(t, err)
+	require.Len(t, groups, 1)
+	require.Contains(t, groups, testConsumerGroup)
+}
+
+func TestOffsetReader_LastCommittedOffset(t *testing.T) {
+	const (
+		testTopic         = "test-topic"
+		testConsumerGroup = "test-consumer-group"
+	)
+	ctx := t.Context()
+	// Create a fake cluster for the test.
+	cluster, err := kfake.NewCluster(kfake.NumBrokers(1), kfake.SeedTopics(1, testTopic))
+	require.NoError(t, err)
+	t.Cleanup(cluster.Close)
+	client := testutil.MustKafkaClient(t, cluster.ListenAddrs()[0])
+	adm := kadm.NewClient(client)
+	m := NewOffsetReader(client, testTopic, testConsumerGroup, log.NewNopLogger())
+
+	// There should be no committed offsets.
+	offset, err := m.LastCommittedOffset(ctx, 0)
+	require.NoError(t, err)
+	// -2 is a special offset which means start offset.
+	require.Equal(t, int64(-2), offset)
+
+	// Commit an offset, it should be returned in the next call.
+	toCommit := kadm.Offsets{}
+	toCommit.AddOffset(testTopic, 0, 100, -1)
+	_, err = adm.CommitOffsets(ctx, testConsumerGroup, toCommit)
+	require.NoError(t, err)
+	offset, err = m.LastCommittedOffset(ctx, 0)
+	require.NoError(t, err)
+	require.Equal(t, int64(100), offset)
+}
+
+func TestOffsetReader_NextOffset(t *testing.T) {
+	const (
+		testTopic         = "test-topic"
+		testConsumerGroup = "test-consumer-group"
+	)
+	ctx := t.Context()
+	// Create a fake cluster for the test.
+	cluster, err := kfake.NewCluster(kfake.NumBrokers(1), kfake.SeedTopics(1, testTopic))
+	require.NoError(t, err)
+	t.Cleanup(cluster.Close)
+	client := testutil.MustKafkaClient(t, cluster.ListenAddrs()[0])
+	m := NewOffsetReader(client, testTopic, testConsumerGroup, log.NewNopLogger())
+
+	// The offset should be 0 as no records have been produced.
+	now := time.Now()
+	offset, err := m.NextOffset(ctx, 0, now)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), offset)
+
+	// Produce a record, the next offset will still be 0 as this is the
+	// offset of the first record in the batch at time now.
+	res := client.ProduceSync(ctx, &kgo.Record{
+		Topic:     testTopic,
+		Key:       []byte("foo"),
+		Value:     []byte("bar"),
+		Timestamp: now,
+	})
+	require.NoError(t, res.FirstErr())
+	offset, err = m.NextOffset(ctx, 0, now)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), offset)
+
+	// Produce another record one second later, the end offset should be 1,
+	// as this is the offset of the first record in batch at time now2.
+	now2 := now.Add(time.Second)
+	res = client.ProduceSync(ctx, &kgo.Record{
+		Topic:     testTopic,
+		Key:       []byte("baz"),
+		Value:     []byte("qux"),
+		Timestamp: now2,
+	})
+	require.NoError(t, res.FirstErr())
+	offset, err = m.NextOffset(ctx, 0, now2)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), offset)
+}
+
+func TestOffsetReader_PartitionOffset(t *testing.T) {
+	const (
+		testTopic         = "test-topic"
+		testConsumerGroup = "test-consumer-group"
+	)
+	ctx := t.Context()
+	// Create a fake cluster for the test.
+	cluster, err := kfake.NewCluster(kfake.NumBrokers(1), kfake.SeedTopics(1, testTopic))
+	require.NoError(t, err)
+	t.Cleanup(cluster.Close)
+	client := testutil.MustKafkaClient(t, cluster.ListenAddrs()[0])
+	m := NewOffsetReader(client, testTopic, testConsumerGroup, log.NewNopLogger())
+
+	// The offset should be 0 as no records have been produced.
+	offset, err := m.PartitionOffset(ctx, 0, -1)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), offset)
+
+	// Produce a record, the end offset should be 1.
+	res := client.ProduceSync(ctx, &kgo.Record{
+		Topic:     testTopic,
+		Key:       []byte("foo"),
+		Value:     []byte("bar"),
+		Timestamp: time.Now(),
+	})
+	require.NoError(t, res.FirstErr())
+	offset, err = m.PartitionOffset(ctx, 0, -1)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), offset)
+
+	// Produce another record, the end offset should be 2.
+	res = client.ProduceSync(ctx, &kgo.Record{
+		Topic:     testTopic,
+		Key:       []byte("baz"),
+		Value:     []byte("qux"),
+		Timestamp: time.Now(),
+	})
+	require.NoError(t, res.FirstErr())
+	offset, err = m.PartitionOffset(ctx, 0, -1)
+	require.NoError(t, err)
+	require.Equal(t, int64(2), offset)
+}

--- a/pkg/kafkav2/doc.go
+++ b/pkg/kafkav2/doc.go
@@ -1,0 +1,2 @@
+// Package kafkav2 provides high-level abstractions for Kafka.
+package kafkav2

--- a/pkg/kafkav2/partitionring/config.go
+++ b/pkg/kafkav2/partitionring/config.go
@@ -1,0 +1,67 @@
+package partitionring
+
+import (
+	"flag"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/grafana/dskit/kv"
+	"github.com/grafana/dskit/ring"
+)
+
+type Config struct {
+	KVStore kv.Config `yaml:"kvstore" doc:"description=The key-value store used to share the hash ring across multiple instances. This option needs be set on ingesters, distributors, queriers, and rulers when running in microservices mode."`
+
+	// MinOwnersCount maps to ring.PartitionInstanceLifecyclerConfig's WaitOwnersCountOnPending.
+	MinOwnersCount int `yaml:"min_partition_owners_count"`
+
+	// MinOwnersDuration maps to ring.PartitionInstanceLifecyclerConfig's WaitOwnersDurationOnPending.
+	MinOwnersDuration time.Duration `yaml:"min_partition_owners_duration"`
+
+	// DeleteInactivePartitionAfter maps to ring.PartitionInstanceLifecyclerConfig's DeleteInactivePartitionAfterDuration.
+	DeleteInactivePartitionAfter time.Duration `yaml:"delete_inactive_partition_after"`
+
+	// lifecyclerPollingInterval is the lifecycler polling interval. This setting is used to lower it in tests.
+	lifecyclerPollingInterval time.Duration
+}
+
+// RegisterFlags adds the flags required to config this to the given FlagSet
+func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
+	// Ring flags
+	cfg.KVStore.Store = "memberlist" // Override default value.
+	cfg.KVStore.RegisterFlagsWithPrefix(prefix+"partition-ring.", "collectors/", f)
+
+	f.IntVar(&cfg.MinOwnersCount, prefix+"partition-ring.min-partition-owners-count", 1, "Minimum number of owners to wait before a PENDING partition gets switched to ACTIVE.")
+	f.DurationVar(&cfg.MinOwnersDuration, prefix+"partition-ring.min-partition-owners-duration", 10*time.Second, "How long the minimum number of owners are enforced before a PENDING partition gets switched to ACTIVE.")
+	f.DurationVar(&cfg.DeleteInactivePartitionAfter, prefix+"partition-ring.delete-inactive-partition-after", 13*time.Hour, "How long to wait before an INACTIVE partition is eligible for deletion. The partition is deleted only if it has been in INACTIVE state for at least the configured duration and it has no owners registered. A value of 0 disables partitions deletion.")
+}
+
+func (cfg *Config) ToLifecyclerConfig(partitionID int32, instanceID string) ring.PartitionInstanceLifecyclerConfig {
+	return ring.PartitionInstanceLifecyclerConfig{
+		PartitionID:                          partitionID,
+		InstanceID:                           instanceID,
+		WaitOwnersCountOnPending:             cfg.MinOwnersCount,
+		WaitOwnersDurationOnPending:          cfg.MinOwnersDuration,
+		DeleteInactivePartitionAfterDuration: cfg.DeleteInactivePartitionAfter,
+		PollingInterval:                      cfg.lifecyclerPollingInterval,
+	}
+}
+
+// ExtractPartition extracts the partition number from the instance name.
+func ExtractPartition(s string) (int32, error) {
+	if strings.Contains(s, "local") || strings.HasSuffix(s, ".lan") {
+		return 0, nil
+	}
+	match := regexp.MustCompile("-([0-9]+)$").FindStringSubmatch(s)
+	if len(match) == 0 {
+		return 0, fmt.Errorf("%s does not contain a partition ID", s)
+	}
+	partition, err := strconv.ParseInt(match[1], 10, 32)
+	if err != nil {
+		return 0, fmt.Errorf("%s does not contain a partition ID", s)
+	}
+	return int32(partition), nil
+}

--- a/pkg/kafkav2/partitionring/config_test.go
+++ b/pkg/kafkav2/partitionring/config_test.go
@@ -1,0 +1,54 @@
+package partitionring
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractPartition(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		expected    int32
+		expectedErr bool
+	}{
+		{
+			name:        "Valid instance returns partition number",
+			input:       "instance-5",
+			expected:    5,
+			expectedErr: false,
+		},
+		{
+			name:        "Local hostname returns 0",
+			input:       "instance-local",
+			expected:    0,
+			expectedErr: false,
+		},
+		{
+			name:        "Invalid format returns error",
+			input:       "invalid-format",
+			expected:    0,
+			expectedErr: true,
+		},
+		{
+			name:        "Invalid partition number returns error",
+			input:       "ingester-abc",
+			expected:    0,
+			expectedErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual, err := ExtractPartition(test.input)
+			if test.expectedErr {
+				require.NotNil(t, err)
+				require.Equal(t, int32(0), actual)
+			} else {
+				require.Nil(t, err)
+				require.Equal(t, test.expected, actual)
+			}
+		})
+	}
+}

--- a/pkg/kafkav2/partitionring/consumer.go
+++ b/pkg/kafkav2/partitionring/consumer.go
@@ -1,0 +1,105 @@
+package partitionring
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"sync/atomic"
+
+	"github.com/go-kit/log"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/twmb/franz-go/pkg/kgo"
+)
+
+// A SinglePartitionConsumer consumes records from a single partition.
+type SinglePartitionConsumer struct {
+	client             *kgo.Client
+	topic              string
+	partition          int32
+	initialOffset      int64
+	lastConsumedOffset atomic.Int64
+	dst                chan<- *kgo.Record
+
+	logger         log.Logger
+	recordsPerPoll prometheus.Histogram
+	pollFailures   prometheus.Counter
+	polls          prometheus.Counter
+}
+
+// NewSinglePartitionConsumer returns a new SinglePartitionConsumer. It
+// consumes records from the specified offset. It accepts the two special
+// offsets of -2 to consume from the start and -1 to consume from the end.
+func NewSinglePartitionConsumer(
+	client *kgo.Client,
+	topic string,
+	partition int32,
+	initialOffset int64,
+	dst chan<- *kgo.Record,
+	logger log.Logger,
+	r prometheus.Registerer,
+) *SinglePartitionConsumer {
+	// Wrap the registerer with labels for the topic and partition, this
+	// allows all metrics to inherit them automatically.
+	r = prometheus.WrapRegistererWith(prometheus.Labels{"topic": topic, "partition": strconv.Itoa(int(partition))}, r)
+	return &SinglePartitionConsumer{
+		client:        client,
+		topic:         topic,
+		partition:     partition,
+		initialOffset: initialOffset,
+		dst:           dst,
+		logger:        log.With(logger, "topic", topic, "partition", partition),
+		recordsPerPoll: promauto.With(r).NewHistogram(prometheus.HistogramOpts{
+			Name:    "single_partition_consumer_records_per_poll",
+			Help:    "The number of records received per poll.",
+			Buckets: prometheus.ExponentialBuckets(1, 2, 15),
+		}),
+		pollFailures: promauto.With(r).NewCounter(prometheus.CounterOpts{
+			Name: "single_partition_consumer_poll_failures_total",
+			Help: "The number of polls that failed.",
+		}),
+		polls: promauto.With(r).NewCounter(prometheus.CounterOpts{
+			Name: "single_partition_consumer_polls_total",
+			Help: "Total number of polls.",
+		}),
+	}
+}
+
+// Run polls records from the partition until the context is canceled or
+// a fatal error occurs.
+func (c *SinglePartitionConsumer) Run(ctx context.Context) error {
+	// Consume the topic and partition from the specified offset.
+	c.client.AddConsumePartitions(map[string]map[int32]kgo.Offset{
+		c.topic: map[int32]kgo.Offset{
+			c.partition: kgo.NewOffset().At(c.initialOffset),
+		},
+	})
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			c.polls.Inc()
+			fetches := c.client.PollRecords(ctx, -1)
+			// If the client is closed, or the context was canceled, return
+			// the error as no fetches were polled. We use this instead of
+			// [kgo.IsClientClosed] so we can also check if the context was
+			// canceled.
+			if err := fetches.Err0(); err != nil {
+				if errors.Is(err, kgo.ErrClientClosed) || errors.Is(err, context.Canceled) {
+					c.pollFailures.Inc()
+					return err
+				}
+			}
+			fetches.EachRecord(func(record *kgo.Record) {
+				c.lastConsumedOffset.Store(record.Offset)
+				c.dst <- record
+			})
+		}
+	}
+}
+
+// LastConsumedOffset returns the last consumed offset.
+func (c *SinglePartitionConsumer) LastConsumedOffset() int64 {
+	return c.lastConsumedOffset.Load()
+}

--- a/pkg/kafkav2/partitionring/consumer_test.go
+++ b/pkg/kafkav2/partitionring/consumer_test.go
@@ -1,0 +1,56 @@
+package partitionring
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/kfake"
+	"github.com/twmb/franz-go/pkg/kgo"
+
+	"github.com/grafana/loki/v3/pkg/kafkav2/testutil"
+)
+
+func TestSinglePartitionConsumer(t *testing.T) {
+	const testTopic = "test-topic"
+	ctx := t.Context()
+	cluster, err := kfake.NewCluster(kfake.NumBrokers(1), kfake.SeedTopics(1, testTopic))
+	require.NoError(t, err)
+	t.Cleanup(cluster.Close)
+
+	// Produce some records to be consumed.
+	client := testutil.MustKafkaClient(t, cluster.ListenAddrs()[0])
+	res1 := client.ProduceSync(ctx, &kgo.Record{Topic: testTopic, Key: []byte("key1"), Value: []byte("value1")})
+	require.NoError(t, res1.FirstErr())
+	res2 := client.ProduceSync(ctx, &kgo.Record{Topic: testTopic, Key: []byte("key2"), Value: []byte("value2")})
+	require.NoError(t, res2.FirstErr())
+
+	// Set up the consumer.
+	dst := make(chan *kgo.Record)
+	consumer := NewSinglePartitionConsumer(client, testTopic, 0, -2, dst, log.NewNopLogger(), prometheus.NewRegistry())
+	cancelCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	go consumer.Run(cancelCtx)
+
+	// Wait for the expected number of records to arrive.
+	var records []*kgo.Record
+	for len(records) < 2 {
+		select {
+		case <-cancelCtx.Done():
+			t.Fatal("context canceled before all records received")
+		case record := <-dst:
+			records = append(records, record)
+		}
+	}
+
+	// Check that the records are as expected.
+	require.Len(t, records, 2)
+	require.Equal(t, []byte("value1"), records[0].Value)
+	require.Equal(t, []byte("value2"), records[1].Value)
+
+	// The last consumed offset should be 1 as offsets start from 0 inclusive.
+	require.Equal(t, int64(1), consumer.LastConsumedOffset())
+}

--- a/pkg/kafkav2/provisioning/topic.go
+++ b/pkg/kafkav2/provisioning/topic.go
@@ -1,0 +1,54 @@
+package provisioning
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/twmb/franz-go/pkg/kadm"
+)
+
+// A TopicEntry contains a single topic.
+type TopicEntry struct {
+	Name              string `json:"name" yaml:"name"`
+	Partitions        int32  `json:"partitions" yaml:"partitions"`
+	ReplicationFactor int16  `json:"replication_factor" yaml:"replication_factor"`
+}
+
+// A TopicProvisioner provisions Kafka topics.
+type TopicProvisioner struct {
+	client *kadm.Client
+}
+
+// NewTopicProvisioner returns a new TopicProvisioner.
+func NewTopicProvisioner(client *kadm.Client) *TopicProvisioner {
+	return &TopicProvisioner{
+		client: client,
+	}
+}
+
+// Provision provisions each topic in entries. It returns an error if any
+// topic could be not be created.
+func (p *TopicProvisioner) Provision(ctx context.Context, entries []TopicEntry) error {
+	for _, entry := range entries {
+		if err := p.ProvisionTopic(ctx, entry.Name, entry.Partitions, entry.ReplicationFactor); err != nil {
+			return fmt.Errorf("failed to provision topic %s: %w", entry.Name, err)
+		}
+	}
+	return nil
+}
+
+// ProvisionTopic provisions a Kafka topic.
+func (p *TopicProvisioner) ProvisionTopic(ctx context.Context, topic string, partitions int32, replicationFactor int16) error {
+	resp, err := p.client.CreateTopics(ctx, partitions, replicationFactor, nil, topic)
+	if err != nil {
+		// err will be non-nil if the request could not be sent, or a response
+		// was not received from the broker.
+		return err
+	}
+	// err will be non-nil if the a request and response was received, but
+	// the topic could not be created. For example, if the topic already exists.
+	if err = resp.Error(); err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/kafkav2/testutil/util.go
+++ b/pkg/kafkav2/testutil/util.go
@@ -1,0 +1,24 @@
+package testutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/kgo"
+)
+
+// MustKafkaClient returns a new Kafka client for tests. It fails the test
+// if an error occurs.
+func MustKafkaClient(t *testing.T, seed string, opts ...kgo.Opt) *kgo.Client {
+	clientOpts := []kgo.Opt{
+		kgo.SeedBrokers(seed),
+		kgo.AllowAutoTopicCreation(),
+		// We will choose the partition of each record.
+		kgo.RecordPartitioner(kgo.ManualPartitioner()),
+	}
+	clientOpts = append(clientOpts, opts...)
+	client, err := kgo.NewClient(clientOpts...)
+	require.NoError(t, err)
+	t.Cleanup(client.Close)
+	return client
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit adds the initial version of a new `kafkav2` package to replace the existing `kafka` package. It offers all of the same features as the original `kafka` package but it does so in a way that favors re-usuable and composable components instead of more monolithic abstractions.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
