### PR TITLE
fix(compactor): fix fd leak after failed index load

### DIFF
--- a/pkg/storage/stores/shipper/indexshipper/tsdb/compactor.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/compactor.go
@@ -115,21 +115,26 @@ func (t *tableCompactor) CompactTable() error {
 
 		return nil
 	})
-	if err != nil {
-		return err
-	}
 
 	defer func() {
 		for i, idx := range multiTenantIndices {
-			if err := idx.Close(); err != nil {
-				level.Error(t.commonIndexSet.GetLogger()).Log("msg", "failed to close multi-tenant source index file", "path", downloadPaths[i], "err", err)
+			// indices or paths may not be set in case of partially failed download and open
+			if idx != nil {
+				if err := idx.Close(); err != nil {
+					level.Error(t.commonIndexSet.GetLogger()).Log("msg", "failed to close multi-tenant source index file", "path", downloadPaths[i], "err", err)
+				}
 			}
-
-			if err := os.Remove(downloadPaths[i]); err != nil {
-				level.Error(t.commonIndexSet.GetLogger()).Log("msg", "failed to remove downloaded index file", "path", downloadPaths[i], "err", err)
+			if downloadPaths[i] != "" {
+				if err := os.Remove(downloadPaths[i]); err != nil {
+					level.Error(t.commonIndexSet.GetLogger()).Log("msg", "failed to remove downloaded index file", "path", downloadPaths[i], "err", err)
+				}
 			}
 		}
 	}()
+
+	if err != nil {
+		return err
+	}
 
 	var multiTenantIndex Index = NoopIndex{}
 	if len(multiTenantIndices) > 0 {


### PR DESCRIPTION
**What this PR does / why we need it**:
In case a compaction fails due to a partially failed index fetching or loading, the successfully opened `Index` objects are not closed. The index `*TSDBFile` opens mmapped view to the file, which increases the reference count to the file description. This reference is never released.

This causes a file description leak.

This PR fixes the logic such that in the case of an partial index load failure, we Close the indices we succeeded to load.

**Which issue(s) this PR fixes**:
Looks similar to https://github.com/grafana/loki/issues/12105 but may not necessarily be the same issue.

**Special notes for your reviewer**:

Note that the file _descriptor_ is not leaked. The file descriptor to the file is owned by `os.File` of the `fileutil.MmapFile` which is eventually closed by GC finalizer. But the file description to which the descriptor referred to is leaked (`struct file` in linux).

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
