### PR TITLE
fix: remove UI from docker build

### DIFF
--- a/cmd/loki/Dockerfile
+++ b/cmd/loki/Dockerfile
@@ -1,17 +1,9 @@
 ARG GO_VERSION=1.24
 
-# UI build stage
-FROM node:22-alpine AS ui-builder
-RUN apk add --no-cache make
-COPY . /src/loki
-WORKDIR /src/loki
-RUN make -C pkg/ui/frontend build
-
 # Go build stage
 FROM golang:${GO_VERSION} AS build
 ARG IMAGE_TAG
 COPY . /src/loki
-COPY --from=ui-builder /src/loki/pkg/ui/frontend/dist /src/loki/pkg/ui/frontend/dist
 WORKDIR /src/loki
 RUN make clean && make BUILD_IN_CONTAINER=false IMAGE_TAG=${IMAGE_TAG} loki
 


### PR DESCRIPTION
**What this PR does / why we need it**:

We removed the UI from this repo after merge https://github.com/grafana/loki/pull/19390, but we missed to clean up the dockerfile that was expecting to build the UI together.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
