### PR TITLE
chore: consistent expressionEvaluator.eval result memory ownership

### DIFF
--- a/pkg/engine/internal/executor/executor.go
+++ b/pkg/engine/internal/executor/executor.go
@@ -312,7 +312,10 @@ func (c *Context) executeFilter(ctx context.Context, filter *physical.Filter, in
 		return errorPipeline(ctx, fmt.Errorf("filter expects exactly one input, got %d", len(inputs)))
 	}
 
-	return NewFilterPipeline(filter, inputs[0], c.evaluator)
+	// Use memory allocator from context or default
+	allocator := memory.DefaultAllocator
+
+	return NewFilterPipeline(filter, inputs[0], c.evaluator, allocator)
 }
 
 func (c *Context) executeMerge(ctx context.Context, _ *physical.Merge, inputs []Pipeline) Pipeline {

--- a/pkg/engine/internal/executor/filter.go
+++ b/pkg/engine/internal/executor/filter.go
@@ -11,7 +11,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/engine/internal/planner/physical"
 )
 
-func NewFilterPipeline(filter *physical.Filter, input Pipeline, evaluator expressionEvaluator) *GenericPipeline {
+func NewFilterPipeline(filter *physical.Filter, input Pipeline, evaluator expressionEvaluator, allocator memory.Allocator) *GenericPipeline {
 	return newGenericPipeline(Local, func(ctx context.Context, inputs []Pipeline) state {
 		// Pull the next item from the input pipeline
 		input := inputs[0]
@@ -19,6 +19,7 @@ func NewFilterPipeline(filter *physical.Filter, input Pipeline, evaluator expres
 		if err != nil {
 			return failureState(err)
 		}
+		defer batch.Release()
 
 		cols := make([]*array.Boolean, 0, len(filter.Predicates))
 		defer func() {
@@ -43,7 +44,7 @@ func NewFilterPipeline(filter *physical.Filter, input Pipeline, evaluator expres
 			cols = append(cols, casted)
 		}
 
-		filtered := filterBatch(batch, func(i int) bool {
+		filtered := filterBatch(batch, allocator, func(i int) bool {
 			for _, p := range cols {
 				if !p.IsValid(i) || !p.Value(i) {
 					return false
@@ -53,7 +54,6 @@ func NewFilterPipeline(filter *physical.Filter, input Pipeline, evaluator expres
 		})
 
 		return successState(filtered)
-
 	}, input)
 }
 
@@ -66,8 +66,7 @@ func NewFilterPipeline(filter *physical.Filter, input Pipeline, evaluator expres
 // pushdown optimizations.
 //
 // We should re-think this approach.
-func filterBatch(batch arrow.Record, include func(int) bool) arrow.Record {
-	mem := memory.NewGoAllocator()
+func filterBatch(batch arrow.Record, allocator memory.Allocator, include func(int) bool) arrow.Record {
 	fields := batch.Schema().Fields()
 
 	builders := make([]array.Builder, len(fields))
@@ -85,7 +84,7 @@ func filterBatch(batch arrow.Record, include func(int) bool) arrow.Record {
 
 		switch field.Type.ID() {
 		case arrow.BOOL:
-			builder := array.NewBooleanBuilder(mem)
+			builder := array.NewBooleanBuilder(allocator)
 			builders[i] = builder
 			additions[i] = func(offset int) {
 				src := batch.Column(i).(*array.Boolean)
@@ -93,7 +92,7 @@ func filterBatch(batch arrow.Record, include func(int) bool) arrow.Record {
 			}
 
 		case arrow.STRING:
-			builder := array.NewStringBuilder(mem)
+			builder := array.NewStringBuilder(allocator)
 			builders[i] = builder
 			additions[i] = func(offset int) {
 				src := batch.Column(i).(*array.String)
@@ -101,7 +100,7 @@ func filterBatch(batch arrow.Record, include func(int) bool) arrow.Record {
 			}
 
 		case arrow.UINT64:
-			builder := array.NewUint64Builder(mem)
+			builder := array.NewUint64Builder(allocator)
 			builders[i] = builder
 			additions[i] = func(offset int) {
 				src := batch.Column(i).(*array.Uint64)
@@ -109,7 +108,7 @@ func filterBatch(batch arrow.Record, include func(int) bool) arrow.Record {
 			}
 
 		case arrow.INT64:
-			builder := array.NewInt64Builder(mem)
+			builder := array.NewInt64Builder(allocator)
 			builders[i] = builder
 			additions[i] = func(offset int) {
 				src := batch.Column(i).(*array.Int64)
@@ -117,7 +116,7 @@ func filterBatch(batch arrow.Record, include func(int) bool) arrow.Record {
 			}
 
 		case arrow.FLOAT64:
-			builder := array.NewFloat64Builder(mem)
+			builder := array.NewFloat64Builder(allocator)
 			builders[i] = builder
 			additions[i] = func(offset int) {
 				src := batch.Column(i).(*array.Float64)
@@ -125,7 +124,7 @@ func filterBatch(batch arrow.Record, include func(int) bool) arrow.Record {
 			}
 
 		case arrow.TIMESTAMP:
-			builder := array.NewTimestampBuilder(mem, &arrow.TimestampType{Unit: arrow.Nanosecond, TimeZone: "UTC"})
+			builder := array.NewTimestampBuilder(allocator, &arrow.TimestampType{Unit: arrow.Nanosecond, TimeZone: "UTC"})
 			builders[i] = builder
 			additions[i] = func(offset int) {
 				src := batch.Column(i).(*array.Timestamp)
@@ -159,6 +158,12 @@ func filterBatch(batch arrow.Record, include func(int) bool) arrow.Record {
 	for i, builder := range builders {
 		arrays[i] = builder.NewArray()
 	}
+
+	defer func() {
+		for _, a := range arrays {
+			a.Release()
+		}
+	}()
 
 	return array.NewRecord(schema, arrays, ct)
 }

--- a/pkg/engine/internal/executor/filter_test.go
+++ b/pkg/engine/internal/executor/filter_test.go
@@ -19,7 +19,9 @@ func TestNewFilterPipeline(t *testing.T) {
 	}
 
 	t.Run("filter with true literal predicate", func(t *testing.T) {
-		alloc := memory.DefaultAllocator
+		alloc := memory.NewCheckedAllocator(memory.NewGoAllocator())
+		defer alloc.AssertSize(t, 0)
+
 		schema := arrow.NewSchema(fields, nil)
 
 		// Create input data using arrowtest.Rows
@@ -41,7 +43,7 @@ func TestNewFilterPipeline(t *testing.T) {
 		}
 
 		// Create filter pipeline
-		pipeline := NewFilterPipeline(filter, input, expressionEvaluator{})
+		pipeline := NewFilterPipeline(filter, input, expressionEvaluator{}, alloc)
 		defer pipeline.Close()
 
 		// Read the pipeline output
@@ -56,7 +58,9 @@ func TestNewFilterPipeline(t *testing.T) {
 	})
 
 	t.Run("filter with false literal predicate", func(t *testing.T) {
-		alloc := memory.DefaultAllocator
+		alloc := memory.NewCheckedAllocator(memory.NewGoAllocator())
+		defer alloc.AssertSize(t, 0)
+
 		schema := arrow.NewSchema(fields, nil)
 
 		// Create input data using arrowtest.Rows
@@ -80,7 +84,7 @@ func TestNewFilterPipeline(t *testing.T) {
 		}
 
 		// Create filter pipeline
-		pipeline := NewFilterPipeline(filter, input, expressionEvaluator{})
+		pipeline := NewFilterPipeline(filter, input, expressionEvaluator{}, alloc)
 		defer pipeline.Close()
 
 		// Read the pipeline output
@@ -92,7 +96,9 @@ func TestNewFilterPipeline(t *testing.T) {
 	})
 
 	t.Run("filter on boolean column with column expression", func(t *testing.T) {
-		alloc := memory.DefaultAllocator
+		alloc := memory.NewCheckedAllocator(memory.NewGoAllocator())
+		defer alloc.AssertSize(t, 0)
+
 		schema := arrow.NewSchema(fields, nil)
 
 		// Create input data using arrowtest.Rows
@@ -117,7 +123,7 @@ func TestNewFilterPipeline(t *testing.T) {
 		}
 
 		// Create filter pipeline
-		pipeline := NewFilterPipeline(filter, input, expressionEvaluator{})
+		pipeline := NewFilterPipeline(filter, input, expressionEvaluator{}, alloc)
 		defer pipeline.Close()
 
 		// Create expected output (only rows where valid=true)
@@ -138,7 +144,9 @@ func TestNewFilterPipeline(t *testing.T) {
 	})
 
 	t.Run("filter on multiple columns with binary expressions", func(t *testing.T) {
-		alloc := memory.DefaultAllocator
+		alloc := memory.NewCheckedAllocator(memory.NewGoAllocator())
+		defer alloc.AssertSize(t, 0)
+
 		schema := arrow.NewSchema(fields, nil)
 
 		// Create input data using arrowtest.Rows
@@ -170,7 +178,7 @@ func TestNewFilterPipeline(t *testing.T) {
 		}
 
 		// Create filter pipeline
-		pipeline := NewFilterPipeline(filter, input, expressionEvaluator{})
+		pipeline := NewFilterPipeline(filter, input, expressionEvaluator{}, alloc)
 		defer pipeline.Close()
 
 		// Create expected output (only rows where name=="Bob" AND valid!=false)
@@ -191,7 +199,9 @@ func TestNewFilterPipeline(t *testing.T) {
 
 	// TODO: instead of returning empty batch, filter should read the next non-empty batch.
 	t.Run("filter on empty batch", func(t *testing.T) {
-		alloc := memory.DefaultAllocator
+		alloc := memory.NewCheckedAllocator(memory.NewGoAllocator())
+		defer alloc.AssertSize(t, 0)
+
 		schema := arrow.NewSchema(fields, nil)
 
 		// Create empty input data using arrowtest.Rows
@@ -210,7 +220,7 @@ func TestNewFilterPipeline(t *testing.T) {
 		}
 
 		// Create filter pipeline
-		pipeline := NewFilterPipeline(filter, input, expressionEvaluator{})
+		pipeline := NewFilterPipeline(filter, input, expressionEvaluator{}, alloc)
 		defer pipeline.Close()
 
 		record, err := pipeline.Read(t.Context())
@@ -223,7 +233,9 @@ func TestNewFilterPipeline(t *testing.T) {
 	})
 
 	t.Run("filter with multiple input batches", func(t *testing.T) {
-		alloc := memory.DefaultAllocator
+		alloc := memory.NewCheckedAllocator(memory.NewGoAllocator())
+		defer alloc.AssertSize(t, 0)
+
 		schema := arrow.NewSchema(fields, nil)
 
 		// Create input data split across multiple batches using arrowtest.Rows
@@ -251,7 +263,7 @@ func TestNewFilterPipeline(t *testing.T) {
 		}
 
 		// Create filter pipeline
-		pipeline := NewFilterPipeline(filter, input, expressionEvaluator{})
+		pipeline := NewFilterPipeline(filter, input, expressionEvaluator{}, alloc)
 		defer pipeline.Close()
 
 		// Create expected output (only rows where valid=true)
@@ -284,7 +296,9 @@ func TestNewFilterPipeline(t *testing.T) {
 	})
 
 	t.Run("filter with null values", func(t *testing.T) {
-		alloc := memory.DefaultAllocator
+		alloc := memory.NewCheckedAllocator(memory.NewGoAllocator())
+		defer alloc.AssertSize(t, 0)
+
 		schema := arrow.NewSchema(fields, nil)
 
 		// Create input data with null values
@@ -309,7 +323,7 @@ func TestNewFilterPipeline(t *testing.T) {
 		}
 
 		// Create filter pipeline
-		pipeline := NewFilterPipeline(filter, input, expressionEvaluator{})
+		pipeline := NewFilterPipeline(filter, input, expressionEvaluator{}, alloc)
 		defer pipeline.Close()
 
 		// Create expected output (only rows where valid=true, including null name)


### PR DESCRIPTION
**What this PR does / why we need it**:

I found an inconsistent behavior in records returned from `eval`. If there is a mathematical expression, then it returns a new column and the caller must release it. For predicates (in `filter.go`) it returns a new column if a predicate is non-trivial. If a predicate is just a `ColumnRef` (for a boolean column) it will return this column as-is, and releasing this column will cause panic (too many releases). So I added an explicit `Retain()` on all nodes of an expression, so now it is consistent and the caller must call `Release()` on all records from `eval()` without worrying was it a column reference or an expression.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
