### PR TITLE
docs: Adding config to reference section

### DIFF
--- a/docs/sources/reference/loki-config-ref.md
+++ b/docs/sources/reference/loki-config-ref.md
@@ -1,6 +1,6 @@
 ---
 title: Grafana Loki configuration parameters
-menuTitle: Configure
+menuTitle: Loki configuration reference
 description: Configuration reference for the parameters used to configure Grafana Loki.
 aliases:
   - ./configuration # /docs/loki/<LOKI_VERSION>/configuration/


### PR DESCRIPTION
**What this PR does / why we need it**:
I've been meaning to add the Configuration Reference topic to the Reference section of the docs, and just keep not getting around to it.  After the conversation on [this issue](https://github.com/grafana/loki/issues/19401) today, I'm finally getting around to it.

**Special notes for your reviewer:**
This PR duplicates the configuration content, publishing it in two places:

- Under Configuration in the table of contents.
- Under Reference in the table of contents.