### PR TITLE
feat(deletion): return request ID in response header

### DIFF
--- a/pkg/compactor/deletion/request_handler.go
+++ b/pkg/compactor/deletion/request_handler.go
@@ -105,6 +105,7 @@ func (dm *DeleteRequestHandler) AddDeleteRequestHandler(w http.ResponseWriter, r
 	)
 
 	dm.metrics.deleteRequestsReceivedTotal.WithLabelValues(userID).Inc()
+	w.Header().Set("X-Delete-Request-ID", requestID)
 	w.WriteHeader(http.StatusNoContent)
 }
 


### PR DESCRIPTION
Add X-Delete-Request-ID response header to AddDeleteRequestHandler to allow clients to retrieve and track the delete request ID after creation. This improves the API usability by providing the request ID without requiring clients to poll the GET endpoint.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/loki/issues/19387

**Special notes for your reviewer**:
Mack found me at Obscon and here we are.