### PR TITLE
chore: bump Go version to 1.24.8

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -10,7 +10,7 @@
   "loki-canary-boringcrypto-image":
     "env":
       "BUILD_TIMEOUT": 60
-      "GO_VERSION": "1.24.6"
+      "GO_VERSION": "1.24.8"
       "IMAGE_PREFIX": "grafana"
       "RELEASE_LIB_REF": "83e166f5c8795fa94dec9f4cbdb82205fbb8bf2b"
       "RELEASE_REPO": "grafana/loki"
@@ -134,7 +134,7 @@
   "loki-canary-image":
     "env":
       "BUILD_TIMEOUT": 60
-      "GO_VERSION": "1.24.6"
+      "GO_VERSION": "1.24.8"
       "IMAGE_PREFIX": "grafana"
       "RELEASE_LIB_REF": "83e166f5c8795fa94dec9f4cbdb82205fbb8bf2b"
       "RELEASE_REPO": "grafana/loki"
@@ -258,7 +258,7 @@
   "loki-image":
     "env":
       "BUILD_TIMEOUT": 60
-      "GO_VERSION": "1.24.6"
+      "GO_VERSION": "1.24.8"
       "IMAGE_PREFIX": "grafana"
       "RELEASE_LIB_REF": "83e166f5c8795fa94dec9f4cbdb82205fbb8bf2b"
       "RELEASE_REPO": "grafana/loki"
@@ -382,7 +382,7 @@
   "promtail-image":
     "env":
       "BUILD_TIMEOUT": 60
-      "GO_VERSION": "1.24.6"
+      "GO_VERSION": "1.24.8"
       "IMAGE_PREFIX": "grafana"
       "RELEASE_LIB_REF": "83e166f5c8795fa94dec9f4cbdb82205fbb8bf2b"
       "RELEASE_REPO": "grafana/loki"

--- a/.github/workflows/lint-jsonnet.yml
+++ b/.github/workflows/lint-jsonnet.yml
@@ -20,7 +20,7 @@ jobs:
       - name: setup go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24.3'
+          go-version: "1.24.8"
       - name: setup jsonnet
         run: |
           go install github.com/google/go-jsonnet/cmd/jsonnet@v0.20.0

--- a/.github/workflows/logql-bench.yml
+++ b/.github/workflows/logql-bench.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.24.3'
+          go-version: "1.24.8"
 
       # The metastore generates invalid filenames for Windows (with colons),
       # which get rejected by upload-artifact. We zip these files to avoid this
@@ -105,7 +105,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.24.3'
+          go-version: "1.24.8"
 
       - name: Create results directory
         run: mkdir -p ./pkg/logql/bench/results

--- a/.github/workflows/logql-correctness.yml
+++ b/.github/workflows/logql-correctness.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.24.3'
+          go-version: "1.24.8"
 
       # The metastore generates invalid filenames for Windows (with colons),
       # which get rejected by upload-artifact. We zip these files to avoid this
@@ -74,7 +74,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.24.3'
+          go-version: "1.24.8"
 
       - name: Create results directory
         run: mkdir -p ./pkg/logql/bench/results

--- a/.github/workflows/verify-release-workflow.yaml
+++ b/.github/workflows/verify-release-workflow.yaml
@@ -14,7 +14,7 @@ jobs:
     - name: setup go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.24.3'
+        go-version: "1.24.8"
     - name: setup jsonnet
       run: |
         go install github.com/google/go-jsonnet/cmd/jsonnet@v0.20.0

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ DOCKER_INTERACTIVE_FLAGS := --tty --interactive
 endif
 
 # Ensure you run `make release-workflows` after changing this
-GO_VERSION         := 1.24.6
+GO_VERSION         := 1.24.8
 # Ensure you run `make IMAGE_TAG=<updated-tag> build-image-push` after changing this
 BUILD_IMAGE_TAG    := 0.34.6
 

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/grafana/loki/v3
 
 go 1.24.0
 
-toolchain go1.24.6
+toolchain go1.24.8
 
 require (
 	cloud.google.com/go/bigtable v1.40.1


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request bumps the Go version to 1.24.8.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
