### PR TITLE
fix(helm): Update querier, read, and single binary target definitions for UI enablement

### DIFF
--- a/production/helm/loki/templates/querier/_helpers-querier.tpl
+++ b/production/helm/loki/templates/querier/_helpers-querier.tpl
@@ -35,9 +35,5 @@ priorityClassName: {{ $pcn }}
 querier target
 */}}
 {{- define "loki.querierTarget" -}}
-{{- if .Values.loki.ui.enable -}}
-{{- print "querier,ui" -}}
-{{- else -}}
-{{- print "querier" -}}
-{{- end -}}
+querier{{- if .Values.loki.ui.enabled -}},ui{{- end -}}
 {{- end -}}

--- a/production/helm/loki/templates/read/_helpers-read.tpl
+++ b/production/helm/loki/templates/read/_helpers-read.tpl
@@ -35,9 +35,5 @@ priorityClassName: {{ $pcn }}
 read target
 */}}
 {{- define "loki.readTarget" -}}
-{{- if .Values.loki.ui.enable -}}
-{{- print "%s,ui" .Values.read.targetModule -}}
-{{- else -}}
-{{- print "%s" .Values.read.targetModule -}}
-{{- end -}}
+{{- .Values.read.targetModule -}}{{- if .Values.loki.ui.enabled -}},ui{{- end -}}
 {{- end -}}

--- a/production/helm/loki/templates/single-binary/_helpers-single-binary.tpl
+++ b/production/helm/loki/templates/single-binary/_helpers-single-binary.tpl
@@ -37,9 +37,5 @@ priorityClassName: {{ $pcn }}
 singleBinary target
 */}}
 {{- define "loki.singleBinaryTarget" -}}
-{{- if .Values.loki.ui.enable -}}
-{{- print "%s,ui" .Values.singleBinary.targetModule -}}
-{{- else -}}
-{{- print "%s" .Values.singleBinary.targetModule -}}
-{{- end -}}
+{{- .Values.singleBinary.targetModule -}}{{- if .Values.loki.ui.enabled -}},ui{{- end -}}
 {{- end -}}


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes an regression introduced in https://github.com/grafana/loki/pull/19390

Currently, the Loki helm chart fails to start with the following error:

```
unrecognised module name: %sall
level=info ts=2025-10-09T08:43:39.575741888Z caller=main.go:126 msg="Starting Loki" version="(version=3.5.5, branch=release-3.5.x, revision=5aa8bd27)"
level=info ts=2025-10-09T08:43:39.575768698Z caller=main.go:127 msg="Loading configuration file" filename=/etc/loki/config/config.yaml
level=error ts=2025-10-09T08:43:39.575788074Z caller=log.go:223 msg="error running loki" err="unrecognised module name: %sall"
```

and blocking all Helm related PRs

 /cc @rfratto @trevorwhitney 

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:

I skip the CHANGELOG notice, since this is fixing a bug which was not released yet.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
