### PR TITLE
chore: Fix column name regression

### DIFF
--- a/pkg/engine/internal/executor/stream_injector.go
+++ b/pkg/engine/internal/executor/stream_injector.go
@@ -14,7 +14,10 @@ import (
 	"github.com/grafana/loki/v3/pkg/engine/internal/types"
 )
 
-var streamInjectorColumnName = "stream_id.int64"
+var (
+	streamInjectorColumnName  = "int64.generated.stream_id"
+	streamInjectorColumnIdent = semconv.MustParseFQN(streamInjectorColumnName)
+)
 
 // streamInjector injects stream labels into a logs Arrow record, replacing the
 // streams ID column with columns for the labels composing those streams.
@@ -40,14 +43,14 @@ func newStreamInjector(alloc memory.Allocator, view *streamsView) *streamInjecto
 //
 // The returned record must be Release()d by the caller when no longer needed.
 func (si *streamInjector) Inject(ctx context.Context, in arrow.Record) (arrow.Record, error) {
-	streamIDCol, streamIDIndex, err := columnForFQN(streamInjectorColumnName, in)
+	streamIDCol, streamIDIndex, err := columnForIdent(streamInjectorColumnIdent, in)
 	if err != nil {
 		return nil, err
 	}
 
 	streamIDValues, ok := streamIDCol.(*array.Int64)
 	if !ok {
-		return nil, fmt.Errorf("column %s must be of type int64, got %s", streamInjectorColumnName, in.Schema().Field(streamIDIndex))
+		return nil, fmt.Errorf("column %s must be of type int64, got %s", streamInjectorColumnIdent.FQN(), in.Schema().Field(streamIDIndex))
 	}
 
 	type labelColumn struct {


### PR DESCRIPTION
### Summary

The temporary streamID column from the dataobj scan node caused an error when the expression evaluator tried to parse the FQN, which was not valid any more after the recent change that implemented the semantic naming conventions.