### PR TITLE
chore(ci): Fix `lint` target in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -389,10 +389,10 @@ publish: packages
 # Lint #
 ########
 ifeq ($(UNAME_S),Linux)
-LINT_FLAGS="--timeout=15m --build-tags=linux,promtail_journal_enabled"
-GOFLAGS="-tags=linux,promtail_journal_enabled"
+LINT_FLAGS=--timeout=15m --build-tags=linux,promtail_journal_enabled
+GOFLAGS=-tags=linux,promtail_journal_enabled
 else
-LINT_FLAGS="--timeout=15m"
+LINT_FLAGS=--timeout=15m
 GOFLAGS=""
 endif
 lint: ## run linters


### PR DESCRIPTION
### Summary 

The quotes in variable definition are considered literals, and therefore the target constructs a command that looks like this

```
golangci-lint run -v "--timeout=900 --build-tags=linux,promtail_journal_enabled"
```

rather than this

```
golangci-lint run -v --timeout=15m --build-tags=linux,promtail_journal_enabled
```

resulting in an error like that

```
Error: invalid argument "15m --build-tags=linux,promtail_journal_enabled" for "--timeout" flag: time: unknown unit "m --build-tags=linux,promtail_journal_enabled" in duration "15m --build-tags=linux,promtail_journal_enabled"
```