### PR TITLE
fix(build): rpm signature config

### DIFF
--- a/tools/packaging/nfpm.jsonnet
+++ b/tools/packaging/nfpm.jsonnet
@@ -74,17 +74,4 @@ local arch = std.extVar('arch');
     src: './dist/tmp/packages/%s-linux-%s' % [name, arch],
     dst: '/usr/bin/%s' % name,
   }],
-
-  deb: {
-    signature: {
-      // Also set ${NFPM_PASSPHRASE}
-      key_file: '${NFPM_SIGNING_KEY_FILE}',
-    },
-  },
-  rpm: {
-    signature: {
-      // Also set ${NFPM_PASSPHRASE}
-      key_file: '${NFPM_SIGNING_KEY_FILE}',
-    },
-  },
 } + overrides[name]


### PR DESCRIPTION
**What this PR does / why we need it**:

The signature process is failing during the release, because of secrets.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
