### PR TITLE
docs: Update RN for 3.5.6

### DIFF
--- a/docs/sources/release-notes/v3-5.md
+++ b/docs/sources/release-notes/v3-5.md
@@ -66,26 +66,31 @@ For important upgrade guidance, refer to the [Upgrade Guide](https://grafana.com
 
 ## Bug fixes
 
+### 3.5.6 (2025-10-10)
+
+* **deps:** Remove CVE GHSA-2464-8j7c-4cjm ([#19469](https://github.com/grafana/loki/issues/19469)) ([f2a304a](https://github.com/grafana/loki/commit/f2a304a34d0eb35be6c09e3f525ec6986a003275)).
+* **deps:** Update module github.com/twmb/franz-go/plugin/kprom to v1.2.1 (release-3.5.x) ([#18793](https://github.com/grafana/loki/issues/18793)) ([bb7356c](https://github.com/grafana/loki/commit/bb7356c31d8b47c665cdd2188e47df6f406d3f7c)).
+* **deps:** Update to Go version to 1.24.8 ([#19454](https://github.com/grafana/loki/issues/19454)) ([#19462](https://github.com/grafana/loki/issues/19462)) ([1b8b5dd](https://github.com/grafana/loki/commit/1b8b5ddfa8b0cc68a15a6e877c9ec13947b7276a)).
+
 ### 3.5.5 (2025-09-11)
 
 * **otlp:** Backport fix to correctly calculate entry metadata size ([#19163](https://github.com/grafana/loki/issues/19163)) ([5aa8bd2](https://github.com/grafana/loki/commit/5aa8bd27946a1ce5267790ebe9210f93cd7111b2)).
 
-
 ### 3.5.4 (2025-09-04)
 
-* **deps:** Update go version 1.24.6 in release-3.5.x ([#19096](https://github.com/grafana/loki/issues/19096)) ([ce8d705](https://github.com/grafana/loki/commit/ce8d70506c5bd905dd7ec7db8f174b9fcd264f30)).
+* **deps:** Update to Go version 1.24.6 in release-3.5.x ([#19096](https://github.com/grafana/loki/issues/19096)) ([ce8d705](https://github.com/grafana/loki/commit/ce8d70506c5bd905dd7ec7db8f174b9fcd264f30)).
 * **docs:** added instructions for how to upgrade zone-aware ingesters. ([#18663](https://github.com/grafana/loki/issues/18663)) ([e0de7da](https://github.com/grafana/loki/commit/e0de7dac098f66bb71000f591f4fb5bf4f5b81bf)).
 
 ### 3.5.3 (2025-07-23)
 
-* **deps:** Move to Go 1.24.5 ([#18412](https://github.com/grafana/loki/issues/18412)) ([2aa4680](https://github.com/grafana/loki/commit/2aa468065721587d0db829ff6b3cce9b73c10699)).
-* ***WAL:** Handle WAL corruption properly on startup (backport release-3.5.x) ([#18408](https://github.com/grafana/loki/issues/18408)) ([5b8ee9a](https://github.com/grafana/loki/commit/5b8ee9a582d168cbde2cb5a0bad48283069351d6)).
+* **deps:** Update to Go version 1.24.5 ([#18412](https://github.com/grafana/loki/issues/18412)) ([2aa4680](https://github.com/grafana/loki/commit/2aa468065721587d0db829ff6b3cce9b73c10699)).
+* **WAL:** Handle WAL corruption properly on startup (backport release-3.5.x) ([#18408](https://github.com/grafana/loki/issues/18408)) ([5b8ee9a](https://github.com/grafana/loki/commit/5b8ee9a582d168cbde2cb5a0bad48283069351d6)).
 
 ### 3.5.2 (2025-04-22)
 
 * **ci:** Update release code 3.5 ([#18014](https://github.com/grafana/loki/issues/18014)) ([b1b28b0](https://github.com/grafana/loki/commit/b1b28b0970b437a071050abd8d1391a037cc3ac5)).
-* **deps:** Move to Go 1.24.2 (backport release-3.5.x) ([#17805](https://github.com/grafana/loki/issues/17805)) ([d0fbad0](https://github.com/grafana/loki/commit/d0fbad095d46ec4edceed4dc9a1eff69b0ef1565)).
-* **deps:** Move to Go 1.24.5 (backport release-3.5.x) ([#18412](https://github.com/grafana/loki/issues/18412)) ([4642c63](https://github.com/grafana/loki/commit/4642c639da0875928295b52d1a02d9ab46725db6)).
+* **deps:** Update to Go version 1.24.2 (backport release-3.5.x) ([#17805](https://github.com/grafana/loki/issues/17805)) ([d0fbad0](https://github.com/grafana/loki/commit/d0fbad095d46ec4edceed4dc9a1eff69b0ef1565)).
+* **deps:** Update to Go version 1.24.5 (backport release-3.5.x) ([#18412](https://github.com/grafana/loki/issues/18412)) ([4642c63](https://github.com/grafana/loki/commit/4642c639da0875928295b52d1a02d9ab46725db6)).
 * **frontend:** Allow resolution of v6 addresses. (backport release-3.5.x) ([#18261](https://github.com/grafana/loki/issues/18261)) ([aed4610](https://github.com/grafana/loki/commit/aed461037b9145ac8cc89813c40cfcad091ed6bf)).
 * **jsonparser:** Fix possible JSON log line corruption caused by `json` parser on query path (backport release-3.5.x) ([#18059](https://github.com/grafana/loki/issues/18059)) ([546d456](https://github.com/grafana/loki/commit/546d456b9d1d75154d1c2e42309933e346629c2b)).
 * **memberlist:** Allow resolution of advertise address from IPv6  interfaces defined in common `instance_interface_names`.(backport release-3.5.x) ([#18257](https://github.com/grafana/loki/issues/18257)) ([6f878ad](https://github.com/grafana/loki/commit/6f878ad1d02427df81b6684c7cb76711d6fee46a)).
@@ -94,7 +99,6 @@ For important upgrade guidance, refer to the [Upgrade Guide](https://grafana.com
 ### 3.5.1 (2025-05-19)
 
 * **build:** Bump loki-build-image for docker-driver (backport release-3.5.x) ([#17741](https://github.com/grafana/loki/issues/17741)) ([d4e637c](https://github.com/grafana/loki/commit/d4e637cebb842a933b21f0753c028821b1ad5c26)).
-
 
 ### 3.5 (2025-04-22)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the Release notes for version 3.5.6.
Also standardized the language used for Go updates.