### PR TITLE
chore(ci): Increase timeout for correctness test workflow

### DIFF
--- a/.github/workflows/logql-correctness.yml
+++ b/.github/workflows/logql-correctness.yml
@@ -83,7 +83,7 @@ jobs:
         shell: bash # Use bash shell to propagate pipe failures
         run: |
           go test \
-            -v -slow-tests \
+            -v -slow-tests -timeout=60m \
             -run=TestStorageEquality/query=.+/kind=.+/store=${{ matrix.store }}$ \
             ${{ matrix.range_type == 'instant' && '-range-type=instant' || '' }} \
             ${{ inputs.failfast == true && '-failfast' || '' }} \


### PR DESCRIPTION
### Summary

Correctness tests are rather slow and may run into a [10m timeout](https://github.com/grafana/loki/actions/runs/18453801660/job/52571696806). Increase the test timeout to 60m.
