### PR TITLE
chore: use GOMEMLIMIT for logql correctness workflow

### DIFF
--- a/.github/workflows/logql-correctness.yml
+++ b/.github/workflows/logql-correctness.yml
@@ -81,6 +81,8 @@ jobs:
 
       - name: Run tests
         shell: bash # Use bash shell to propagate pipe failures
+        env:
+           GOMEMLIMIT: 28GiB # 4GiB left as headroom on 32GiB runner
         run: |
           go test \
             -v -slow-tests \


### PR DESCRIPTION
**What this PR does / why we need it**:

Setting GOMEMLIMIT to avoid cancellations as a result of OOMs. Large runners have 32GB memory, leaving 4GB of headroom

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
