### PR TITLE
chore: remove prefetching for sortmerge

### DIFF
--- a/pkg/engine/internal/executor/sortmerge.go
+++ b/pkg/engine/internal/executor/sortmerge.go
@@ -27,6 +27,11 @@ func NewSortMergePipeline(inputs []Pipeline, order physical.SortOrder, column ph
 		return nil, fmt.Errorf("invalid sort order %v", order)
 	}
 
+	// Disabling prefetching to avoid increased memory footprint from loading topK for all inputs at once.
+	// for i := range inputs {
+	// inputs[i] = newPrefetchingPipeline(inputs[i])
+	//}
+
 	return &KWayMerge{
 		inputs:     inputs,
 		columnEval: evaluator.newFunc(column),


### PR DESCRIPTION
**What this PR does / why we need it**:

Remove prefetching to avoid memory pressure from loading topk for all inputs at once.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
