### PR TITLE
chore(planner): fix limits pushdown to work with empty predicates

### DIFF
--- a/pkg/engine/internal/planner/physical/planner.go
+++ b/pkg/engine/internal/planner/physical/planner.go
@@ -395,14 +395,16 @@ func (p *Planner) Optimize(plan *Plan) (*Plan, error) {
 			newOptimization("PredicatePushdown", plan).withRules(
 				&predicatePushdown{plan: plan},
 			),
+			newOptimization("CleanupFilters", plan).withRules(
+				&removeNoopFilter{plan: plan},
+			),
 			newOptimization("LimitPushdown", plan).withRules(
 				&limitPushdown{plan: plan},
 			),
 			newOptimization("ProjectionPushdown", plan).withRules(
 				&projectionPushdown{plan: plan},
 			),
-			newOptimization("Cleanup", plan).withRules(
-				&removeNoopFilter{plan: plan},
+			newOptimization("CleanupMerge", plan).withRules(
 				&removeNoopMerge{plan: plan},
 			),
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

Limits pushdown does not allow the propagation of limits to the scan nodes if it encounters a Filter node. This is intended as limit should only be applied after filtering the rows.

But during optimisation runs, `predicatePushdown` can leave out a no-op Filter node in the plan which prevents limit node from propagation the limit. This PR updates the ordering of optimisations to `removeNoopFilter` before running `limitPushdown`

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
