### PR TITLE
chore(operator): CI fix permissions for building release image

### DIFF
--- a/.github/workflows/operator-release-please.yml
+++ b/.github/workflows/operator-release-please.yml
@@ -51,6 +51,9 @@ jobs:
     needs:
       - "releasePlease"
     if: ${{ needs.releasePlease.outputs.release_created }}
+    permissions:
+      contents: "read"
+      id-token: "write"
     uses: ./.github/workflows/operator-reusable-image-build.yml
     with:
       dockerfile: "operator/Dockerfile"


### PR DESCRIPTION
**What this PR does / why we need it**:

Because this workflow sets workflow level permission the step for building the image needs to declarative define the permissions it needs  

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
