### PR TITLE
feat(mixin): add thresholds for LokiRequestLatency

### DIFF
--- a/production/loki-mixin/alerts.libsonnet
+++ b/production/loki-mixin/alerts.libsonnet
@@ -41,14 +41,14 @@
           {
             alert: 'LokiRequestLatency',
             expr: |||
-              %(group_prefix_jobs)s_route:loki_request_duration_seconds:99quantile{route!~"(?i).*tail.*|/schedulerpb.SchedulerForQuerier/QuerierLoop"} > 1
+              %(group_prefix_jobs)s_route:loki_request_duration_seconds:99quantile{route!~"(?i).*tail.*|/schedulerpb.SchedulerForQuerier/QuerierLoop"} > %(loki_p99_request_latency_threshold_seconds)s
             ||| % $._config,
             'for': '15m',
             labels: {
               severity: 'critical',
             },
             annotations: {
-              summary: 'Loki request error latency is high.',
+              summary: 'Loki request latency is high.',
               description: std.strReplace(|||
                 {{ $labels.cluster }} {{ $labels.job }} {{ $labels.route }} is experiencing {{ printf "%.2f" $value }}s 99th percentile latency.
               |||, 'cluster', $._config.per_cluster_label),

--- a/production/loki-mixin/config.libsonnet
+++ b/production/loki-mixin/config.libsonnet
@@ -93,5 +93,8 @@
     meta_monitoring: {
       enabled: false,
     },
+
+    //Alert thresholds
+    loki_p99_request_latency_threshold_seconds: 1,
   },
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This updates LokiRequestLatency by adding configurable threshold to suit different envs.

**Which issue(s) this PR fixes**:

-

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [n/a] Documentation added
- [n/a] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [n/a] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [n/a] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
