### PR TITLE
fix(build): remove busybox from dockerfile

### DIFF
--- a/cmd/loki/Dockerfile
+++ b/cmd/loki/Dockerfile
@@ -9,19 +9,19 @@ RUN make clean && make BUILD_IN_CONTAINER=false IMAGE_TAG=${IMAGE_TAG} loki
 
 # Prepare filesystem stage
 FROM golang:${GO_VERSION} AS filesystem
-COPY cmd/loki/loki-docker-config.yaml /tmp/local-config.yaml
-RUN mkdir -p /tmp/etc/loki /tmp/loki/rules /tmp/loki/rules-temp && \
-    cp /tmp/local-config.yaml /tmp/etc/loki/local-config.yaml && \
+COPY cmd/loki/loki-docker-config.yaml /local-config.yaml
+RUN mkdir -p /etc/loki /loki/rules /loki/rules-temp && \
+    cp /local-config.yaml /etc/loki/local-config.yaml && \
     addgroup --gid 10001 loki && \
     adduser --uid 10001 --gid 10001 --disabled-password --gecos "" loki && \
-    chown -R loki:loki /tmp/etc/loki /tmp/loki
+    chown -R loki:loki /etc/loki /loki
 
 # Final stage
 FROM gcr.io/distroless/static:nonroot
 
 COPY --from=build /src/loki/cmd/loki/loki /usr/bin/loki
-COPY --from=filesystem /tmp/etc/loki /etc/loki
-COPY --from=filesystem /tmp/loki /loki
+COPY --from=filesystem /etc/loki /etc/loki
+COPY --from=filesystem /loki /loki
 COPY --from=filesystem /etc/passwd /etc/passwd
 COPY --from=filesystem /etc/group /etc/group
 

--- a/cmd/loki/Dockerfile.cross
+++ b/cmd/loki/Dockerfile.cross
@@ -12,18 +12,18 @@ RUN make clean && GOARCH=$(cat /goarch) GOARM=$(cat /goarm) make BUILD_IN_CONTAI
 
 # Prepare filesystem stage
 FROM golang:${GO_VERSION} AS filesystem
-COPY cmd/loki/loki-local-config.yaml /tmp/local-config.yaml
-RUN mkdir -p /tmp/etc/loki /tmp/loki && \
-    cp /tmp/local-config.yaml /tmp/etc/loki/local-config.yaml && \
+COPY cmd/loki/loki-local-config.yaml /local-config.yaml
+RUN mkdir -p /etc/loki /loki && \
+    cp /local-config.yaml /etc/loki/local-config.yaml && \
     addgroup --gid 10001 loki && \
     adduser --uid 10001 --gid 10001 --disabled-password --gecos "" loki && \
-    chown -R loki:loki /tmp/etc/loki /tmp/loki
+    chown -R loki:loki /etc/loki /loki
 
 FROM gcr.io/distroless/static:nonroot
 
 COPY --from=goenv /src/loki/cmd/loki/loki /usr/bin/loki
-COPY --from=filesystem /tmp/etc/loki /etc/loki
-COPY --from=filesystem /tmp/loki /loki
+COPY --from=filesystem /etc/loki /etc/loki
+COPY --from=filesystem /loki /loki
 COPY --from=filesystem /etc/passwd /etc/passwd
 COPY --from=filesystem /etc/group /etc/group
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Busybox included on our distroless dockerfile has a list of CVEs that needs to be addressed.

Going to remove the busybox from our dockerfile and use the distroless:nonroot as base image to follow best security practices.

**Which issue(s) this PR fixes**:
Fix CVEs:

* CVE-2023-42364
* CVE-2023-42365
* CVE-2023-42363
* CVE-2023-42366
* CVE-2025-46394
* CVE-2024-58251

Running grype scanner we see no vulnerabilities on this image:

```
grype fcjack/loki:fcjack-remove-busybox-from-docker-1750bf9
 ✔ Loaded image                                                                                                                                        fcjack/loki:fcjack-remove-busybox-from-docker-1750bf9 
 ✔ Parsed image                                                                                                                      sha256:52cf41545517f7a7412bbd3fbbd0c37a77ca9bea43cae7d3d4445b36bb913bed 
 ✔ Cataloged contents                                                                                                                       695770f9714e7ecee0d246ab19f850b5bdc82abe86e20beaa2d86f3ec68edbd6 
   ├── ✔ Packages                        [351 packages]  
   ├── ✔ Executables                     [1 executables]  
   ├── ✔ File metadata                   [947 locations]  
   └── ✔ File digests                    [947 files]  
 ✔ Scanned for vulnerabilities     [0 vulnerability matches]  
   ├── by severity: 0 critical, 0 high, 0 medium, 0 low, 0 negligible
No vulnerabilities found

```