### PR TITLE
feat: support multiple sources in tracker

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -499,29 +499,6 @@ type streamTracker struct {
 	failed      atomic.Int32
 }
 
-// TODO taken from Cortex, see if we can refactor out an usable interface.
-type pushTracker struct {
-	streamsPending atomic.Int32
-	streamsFailed  atomic.Int32
-	done           chan struct{}
-	err            chan error
-}
-
-// doneWithResult records the result of a stream push.
-// If err is nil, the stream push is considered successful.
-// If err is not nil, the stream push is considered failed.
-func (p *pushTracker) doneWithResult(err error) {
-	if err == nil {
-		if p.streamsPending.Dec() == 0 {
-			p.done <- struct{}{}
-		}
-	} else {
-		if p.streamsFailed.Inc() == 1 {
-			p.err <- err
-		}
-	}
-}
-
 func (d *Distributor) waitSimulatedLatency(ctx context.Context, tenantID string, start time.Time) {
 	latency := d.validator.SimulatedPushLatency(tenantID)
 	if latency > 0 {
@@ -808,10 +785,7 @@ func (d *Distributor) PushWithResolver(ctx context.Context, req *logproto.PushRe
 	const maxExpectedReplicationSet = 5 // typical replication factor 3 plus one for inactive plus one for luck
 	var descs [maxExpectedReplicationSet]ring.InstanceDesc
 
-	tracker := pushTracker{
-		done: make(chan struct{}, 1), // buffer avoids blocking if caller terminates - sendSamples() only sends once on each
-		err:  make(chan error, 1),
-	}
+	tracker := newPushTracker()
 	streamsToWrite := 0
 	if d.cfg.IngesterEnabled {
 		streamsToWrite += len(streams)
@@ -820,7 +794,7 @@ func (d *Distributor) PushWithResolver(ctx context.Context, req *logproto.PushRe
 		streamsToWrite += len(streams)
 	}
 	// We must correctly set streamsPending before beginning any writes to ensure we don't have a race between finishing all of one path before starting the other.
-	tracker.streamsPending.Store(int32(streamsToWrite))
+	tracker.Add(int32(streamsToWrite))
 
 	if d.cfg.KafkaEnabled {
 		subring, err := d.partitionRing.PartitionRing().ShuffleShard(tenantID, d.validator.IngestionPartitionsTenantShardSize(tenantID))
@@ -828,7 +802,7 @@ func (d *Distributor) PushWithResolver(ctx context.Context, req *logproto.PushRe
 			return nil, err
 		}
 		// We don't need to create a new context like the ingester writes, because we don't return unless all writes have succeeded.
-		d.sendStreamsToKafka(ctx, streams, tenantID, &tracker, subring)
+		d.sendStreamsToKafka(ctx, streams, tenantID, tracker, subring)
 	}
 
 	if d.cfg.IngesterEnabled {
@@ -877,7 +851,7 @@ func (d *Distributor) PushWithResolver(ctx context.Context, req *logproto.PushRe
 				case d.ingesterTasks <- pushIngesterTask{
 					ingester:      ingester,
 					streamTracker: samples,
-					pushTracker:   &tracker,
+					pushTracker:   tracker,
 					ctx:           localCtx,
 					cancel:        cancel,
 				}:
@@ -887,14 +861,11 @@ func (d *Distributor) PushWithResolver(ctx context.Context, req *logproto.PushRe
 		}
 	}
 
-	select {
-	case err := <-tracker.err:
+	if err := tracker.Wait(ctx); err != nil {
 		return nil, err
-	case <-tracker.done:
-		return &logproto.PushResponse{}, validationErr
-	case <-ctx.Done():
-		return nil, ctx.Err()
 	}
+
+	return &logproto.PushResponse{}, validationErr
 }
 
 // missingEnforcedLabels returns true if the stream is missing any of the required labels.
@@ -1227,12 +1198,12 @@ func (d *Distributor) sendStreams(task pushIngesterTask) {
 			if task.streamTracker[i].failed.Inc() <= int32(task.streamTracker[i].maxFailures) {
 				continue
 			}
-			task.pushTracker.doneWithResult(err)
+			task.pushTracker.Done(err)
 		} else {
 			if task.streamTracker[i].succeeded.Inc() != int32(task.streamTracker[i].minSuccess) {
 				continue
 			}
-			task.pushTracker.doneWithResult(nil)
+			task.pushTracker.Done(nil)
 		}
 	}
 }
@@ -1271,7 +1242,7 @@ func (d *Distributor) sendStreamsToKafka(ctx context.Context, streams []KeyedStr
 			if err != nil {
 				err = fmt.Errorf("failed to write stream to kafka: %w", err)
 			}
-			tracker.doneWithResult(err)
+			tracker.Done(err)
 		}(s)
 	}
 }

--- a/pkg/distributor/tracker.go
+++ b/pkg/distributor/tracker.go
@@ -1,0 +1,95 @@
+package distributor
+
+import (
+	"context"
+	"sync"
+)
+
+// pushTracker tracks the status of pushes and waits on their completion.
+type pushTracker struct {
+	mtx      sync.Mutex    // protects the fields below.
+	n        int32         // the number of pushes.
+	doneCh   chan struct{} // closed when all pushes are done.
+	errCh    chan struct{} // closed when an error is reported.
+	done     bool          // fast path, equivalent to select { case <-t.doneCh: default: }
+	firstErr error         // the first reported error from [Done].
+}
+
+// newPushTracker returns a new, initialized [pushTracker].
+func newPushTracker() *pushTracker {
+	return &pushTracker{
+		// Both doneCh and errCh are unbuffered as they are used for signalling only.
+		doneCh: make(chan struct{}),
+		errCh:  make(chan struct{}),
+	}
+}
+
+// Add increments the number of pushes. It must not be called after the
+// last call to [Done] has completed.
+func (t *pushTracker) Add(n int32) {
+	t.mtx.Lock()
+	defer t.mtx.Unlock()
+	if t.done {
+		// We don't need to unlock the mutex as defer is run even when a
+		// panic occurs.
+		panic("Add called after last call to Done")
+	}
+	t.n += n
+	if t.n < 0 {
+		// We panic on negative counters just like [sync.WaitGroup].
+		panic("Negative counter")
+	}
+}
+
+// Done decrements the number of pushes. It accepts an optional error
+// if the push failed. If two or more calls to [Done] have an error then
+// the first error is used.
+func (t *pushTracker) Done(err error) {
+	t.mtx.Lock()
+	defer t.mtx.Unlock()
+	if t.n <= 0 {
+		// We panic here just like [sync.WaitGroup]. We don't need to unlock
+		// the mutex as defer is run even when a panic occurs.
+		panic("Done called more times than Add")
+	}
+	if err != nil && t.firstErr == nil {
+		// errCh can never be closed twice as t.firstErr is nil just once.
+		t.firstErr = err
+		close(t.errCh)
+	}
+	t.n--
+	if t.n == 0 {
+		t.done = true
+		close(t.doneCh)
+	}
+}
+
+// Wait until all pushes are done or a push fails, whichever happens
+// first.
+func (t *pushTracker) Wait(ctx context.Context) error {
+	t.mtx.Lock()
+	// We need to hold the mutex here as t.n can be incremented until doneCh is
+	// closed, while t.firstErr can be modified as neither doneCh nor errCh
+	// have been closed.
+	if t.firstErr != nil || t.n == 0 {
+		// We need to store firstErr before releasing the mutex in case
+		// t.firstErr is nil.
+		res := t.firstErr
+		t.mtx.Unlock()
+		return res
+	}
+	t.mtx.Unlock()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-t.doneCh:
+		// Must return t.firstErr as doneCh is closed if the last push failed.
+		// We don't need the mutex here as t.firstErr is never modified after
+		// doneCh is closed.
+		return t.firstErr
+	case <-t.errCh:
+		// We don't need the mutex here either as t.firstErr is never modified
+		// after errCh is closed.
+		return t.firstErr
+	}
+}

--- a/pkg/distributor/tracker_test.go
+++ b/pkg/distributor/tracker_test.go
@@ -1,0 +1,139 @@
+package distributor
+
+import (
+	"context"
+	"errors"
+	"math/rand"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBasicPushTracker(t *testing.T) {
+	t.Run("a new tracker that has never been incremented should never block", func(t *testing.T) {
+		tracker := newPushTracker()
+		ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+		t.Cleanup(cancel)
+		require.NoError(t, tracker.Wait(ctx))
+	})
+
+	t.Run("a canceled context should return a context canceled error", func(t *testing.T) {
+		tracker := newPushTracker()
+		tracker.Add(1)
+		ctx, cancel := context.WithTimeout(t.Context(), time.Millisecond)
+		t.Cleanup(cancel)
+		require.EqualError(t, tracker.Wait(ctx), "context deadline exceeded")
+	})
+
+	t.Run("a done tracker with no errors should return nil", func(t *testing.T) {
+		tracker := newPushTracker()
+		tracker.Add(1)
+		tracker.Done(nil)
+		ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+		t.Cleanup(cancel)
+		require.NoError(t, tracker.Wait(ctx))
+	})
+
+	t.Run("a done tracker with an error should return the error", func(t *testing.T) {
+		tracker := newPushTracker()
+		tracker.Add(1)
+		tracker.Done(errors.New("an error occurred"))
+		ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+		t.Cleanup(cancel)
+		require.EqualError(t, tracker.Wait(ctx), "an error occurred")
+	})
+
+	t.Run("a done tracker should return the first error that occurred", func(t *testing.T) {
+		tracker := newPushTracker()
+		tracker.Add(2)
+		tracker.Done(errors.New("an error occurred"))
+		tracker.Done(errors.New("another error occurred"))
+		ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+		t.Cleanup(cancel)
+		require.EqualError(t, tracker.Wait(ctx), "an error occurred")
+	})
+
+	t.Run("a done tracker should return at least one error", func(t *testing.T) {
+		t1 := newPushTracker()
+		t1.Add(2)
+		t1.Done(nil)
+		t1.Done(errors.New("an error occurred"))
+		ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+		t.Cleanup(cancel)
+		require.EqualError(t, t1.Wait(ctx), "an error occurred")
+		// And now test the opposite sequence.
+		t2 := newPushTracker()
+		t2.Add(2)
+		t2.Done(errors.New("an error occurred"))
+		t2.Done(nil)
+		ctx, cancel = context.WithTimeout(t.Context(), time.Second)
+		t.Cleanup(cancel)
+		require.EqualError(t, t2.Wait(ctx), "an error occurred")
+	})
+
+	t.Run("more Done than Add should panic", func(t *testing.T) {
+		// Should panic if Done is called before Add.
+		require.PanicsWithValue(t, "Done called more times than Add", func() {
+			tracker := newPushTracker()
+			tracker.Done(nil)
+		})
+		// Should panic if Done is called more times than Add.
+		require.PanicsWithValue(t, "Done called more times than Add", func() {
+			tracker := newPushTracker()
+			tracker.Add(1)
+			tracker.Done(nil)
+			tracker.Done(nil)
+		})
+	})
+
+	t.Run("Add after Done should panic", func(t *testing.T) {
+		require.PanicsWithValue(t, "Add called after last call to Done", func() {
+			tracker := newPushTracker()
+			tracker.Add(1)
+			tracker.Done(nil)
+			tracker.Add(1)
+		})
+	})
+
+	t.Run("Negative counter should panic", func(t *testing.T) {
+		require.PanicsWithValue(t, "Negative counter", func() {
+			tracker := newPushTracker()
+			tracker.Add(-1)
+		})
+	})
+}
+
+// Run with go test -fuzz=FuzzBasicPushTracker.
+func FuzzBasicPushTracker(f *testing.F) {
+	f.Add(uint16(100))
+	f.Fuzz(func(t *testing.T, n uint16) {
+		wg := sync.WaitGroup{}
+		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+		t.Cleanup(cancel)
+		tracker := newPushTracker()
+		tracker.Add(int32(n))
+		// Create a random number of waiters.
+		for i := 0; i < rand.Intn(100); i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				// Sleep a random time up to 100ms.
+				time.Sleep(time.Duration(rand.Intn(100)) * time.Millisecond)
+				require.NoError(t, tracker.Wait(ctx))
+			}()
+		}
+		// Done should be called for each n, cannot be random.
+		for i := 0; i < int(n); i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				// Sleep a random time up to 100ms too.
+				time.Sleep(time.Duration(rand.Intn(100)) * time.Millisecond)
+				tracker.Done(nil)
+			}()
+		}
+		wg.Wait()
+	})
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit refactors the push tracker to be safer when dealing with multiple sources (i.e. tees).

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
