### PR TITLE
chore(engine): simplify Pipeline interface

### DIFF
--- a/pkg/engine/internal/executor/compat.go
+++ b/pkg/engine/internal/executor/compat.go
@@ -16,7 +16,7 @@ import (
 func newColumnCompatibilityPipeline(compat *physical.ColumnCompat, input Pipeline) Pipeline {
 	const extracted = "_extracted"
 
-	return newGenericPipeline(Local, func(ctx context.Context, inputs []Pipeline) (arrow.Record, error) {
+	return newGenericPipeline(func(ctx context.Context, inputs []Pipeline) (arrow.Record, error) {
 		input := inputs[0]
 		batch, err := input.Read(ctx)
 		if err != nil {

--- a/pkg/engine/internal/executor/dataobjscan.go
+++ b/pkg/engine/internal/executor/dataobjscan.go
@@ -398,10 +398,3 @@ func (s *dataobjScan) Close() {
 	s.streamsInjector = nil
 	s.reader = nil
 }
-
-// Inputs implements [Pipeline] and returns nil, since dataobjScan accepts no
-// pipelines as input.
-func (s *dataobjScan) Inputs() []Pipeline { return nil }
-
-// Transport implements [Pipeline] and returns [Local].
-func (s *dataobjScan) Transport() Transport { return Local }

--- a/pkg/engine/internal/executor/filter.go
+++ b/pkg/engine/internal/executor/filter.go
@@ -12,7 +12,7 @@ import (
 )
 
 func NewFilterPipeline(filter *physical.Filter, input Pipeline, evaluator expressionEvaluator, allocator memory.Allocator) *GenericPipeline {
-	return newGenericPipeline(Local, func(ctx context.Context, inputs []Pipeline) (arrow.Record, error) {
+	return newGenericPipeline(func(ctx context.Context, inputs []Pipeline) (arrow.Record, error) {
 		// Pull the next item from the input pipeline
 		input := inputs[0]
 		batch, err := input.Read(ctx)

--- a/pkg/engine/internal/executor/limit.go
+++ b/pkg/engine/internal/executor/limit.go
@@ -14,7 +14,7 @@ func NewLimitPipeline(input Pipeline, skip, fetch uint32) *GenericPipeline {
 		limitRemaining  = int64(fetch)
 	)
 
-	return newGenericPipeline(Local, func(ctx context.Context, inputs []Pipeline) (arrow.Record, error) {
+	return newGenericPipeline(func(ctx context.Context, inputs []Pipeline) (arrow.Record, error) {
 		var length int64
 		var start, end int64
 		var batch arrow.Record

--- a/pkg/engine/internal/executor/merge.go
+++ b/pkg/engine/internal/executor/merge.go
@@ -118,13 +118,3 @@ func (m *Merge) Close() {
 		input.Close()
 	}
 }
-
-// Inputs returns the inputs of the pipeline.
-func (m *Merge) Inputs() []Pipeline {
-	return m.inputs
-}
-
-// Transport returns the type of transport of the implementation.
-func (m *Merge) Transport() Transport {
-	return Local
-}

--- a/pkg/engine/internal/executor/parse.go
+++ b/pkg/engine/internal/executor/parse.go
@@ -16,7 +16,7 @@ import (
 )
 
 func NewParsePipeline(parse *physical.ParseNode, input Pipeline, allocator memory.Allocator) *GenericPipeline {
-	return newGenericPipeline(Local, func(ctx context.Context, inputs []Pipeline) (arrow.Record, error) {
+	return newGenericPipeline(func(ctx context.Context, inputs []Pipeline) (arrow.Record, error) {
 		// Pull the next item from the input pipeline
 		input := inputs[0]
 		batch, err := input.Read(ctx)

--- a/pkg/engine/internal/executor/pipeline.go
+++ b/pkg/engine/internal/executor/pipeline.go
@@ -10,14 +10,6 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-type Transport uint8
-
-const (
-	_ Transport = iota
-	Local
-	Remote
-)
-
 // Pipeline represents a data processing pipeline that can read Arrow records.
 // It provides methods to read data, access the current record, and close resources.
 type Pipeline interface {
@@ -27,10 +19,6 @@ type Pipeline interface {
 	// Close closes the resources of the pipeline.
 	// The implementation must close all the of the pipeline's inputs.
 	Close()
-	// Inputs returns the inputs of the pipeline.
-	Inputs() []Pipeline
-	// Transport returns the type of transport of the implementation.
-	Transport() Transport
 }
 
 var (
@@ -46,25 +34,18 @@ type state struct {
 type readFunc func(context.Context, []Pipeline) (arrow.Record, error)
 
 type GenericPipeline struct {
-	t      Transport
 	inputs []Pipeline
 	read   readFunc
 }
 
-func newGenericPipeline(t Transport, read readFunc, inputs ...Pipeline) *GenericPipeline {
+func newGenericPipeline(read readFunc, inputs ...Pipeline) *GenericPipeline {
 	return &GenericPipeline{
-		t:      t,
 		read:   read,
 		inputs: inputs,
 	}
 }
 
 var _ Pipeline = (*GenericPipeline)(nil)
-
-// Inputs implements Pipeline.
-func (p *GenericPipeline) Inputs() []Pipeline {
-	return p.inputs
-}
 
 // Read implements Pipeline.
 func (p *GenericPipeline) Read(ctx context.Context) (arrow.Record, error) {
@@ -81,23 +62,18 @@ func (p *GenericPipeline) Close() {
 	}
 }
 
-// Transport implements Pipeline.
-func (p *GenericPipeline) Transport() Transport {
-	return p.t
-}
-
 func errorPipeline(ctx context.Context, err error) Pipeline {
 	span := trace.SpanFromContext(ctx)
 	span.RecordError(err)
 	span.SetStatus(codes.Error, err.Error())
 
-	return newGenericPipeline(Local, func(_ context.Context, _ []Pipeline) (arrow.Record, error) {
+	return newGenericPipeline(func(_ context.Context, _ []Pipeline) (arrow.Record, error) {
 		return nil, fmt.Errorf("failed to execute pipeline: %w", err)
 	})
 }
 
 func emptyPipeline() Pipeline {
-	return newGenericPipeline(Local, func(_ context.Context, _ []Pipeline) (arrow.Record, error) {
+	return newGenericPipeline(func(_ context.Context, _ []Pipeline) (arrow.Record, error) {
 		return nil, EOF
 	})
 }
@@ -238,10 +214,6 @@ func (p *tracedPipeline) Read(ctx context.Context) (arrow.Record, error) {
 
 func (p *tracedPipeline) Close() { p.inner.Close() }
 
-func (p *tracedPipeline) Inputs() []Pipeline { return p.inner.Inputs() }
-
-func (p *tracedPipeline) Transport() Transport { return Local }
-
 type lazyPipeline struct {
 	ctor func(ctx context.Context, inputs []Pipeline) Pipeline
 
@@ -280,9 +252,3 @@ func (lp *lazyPipeline) Close() {
 	}
 	lp.built = nil
 }
-
-// Inputs implements [Pipeline].
-func (lp *lazyPipeline) Inputs() []Pipeline { return lp.inputs }
-
-// Transport implements [Pipeline].
-func (lp *lazyPipeline) Transport() Transport { return Local }

--- a/pkg/engine/internal/executor/pipeline_test.go
+++ b/pkg/engine/internal/executor/pipeline_test.go
@@ -74,15 +74,6 @@ func TestCSVPipeline(t *testing.T) {
 	pipeline := NewBufferedPipeline(record1, record2)
 	defer pipeline.Close()
 
-	// Test pipeline behavior
-	t.Run("should have correct transport type", func(t *testing.T) {
-		require.Equal(t, Local, pipeline.Transport())
-	})
-
-	t.Run("should have no inputs", func(t *testing.T) {
-		require.Empty(t, pipeline.Inputs())
-	})
-
 	t.Run("should return records in order", func(t *testing.T) {
 		ctx := t.Context()
 
@@ -117,12 +108,6 @@ type instrumentedPipeline struct {
 	callCount map[string]int
 }
 
-// Inputs implements Pipeline.
-func (i *instrumentedPipeline) Inputs() []Pipeline {
-	i.callCount["Inputs"]++
-	return i.inner.Inputs()
-}
-
 // Close implements Pipeline.
 func (i *instrumentedPipeline) Close() {
 	i.callCount["Close"]++
@@ -133,12 +118,6 @@ func (i *instrumentedPipeline) Close() {
 func (i *instrumentedPipeline) Read(ctx context.Context) (arrow.Record, error) {
 	i.callCount["Read"]++
 	return i.inner.Read(ctx)
-}
-
-// Transport implements Pipeline.
-func (i *instrumentedPipeline) Transport() Transport {
-	i.callCount["Transport"]++
-	return i.inner.Transport()
 }
 
 var _ Pipeline = (*instrumentedPipeline)(nil)

--- a/pkg/engine/internal/executor/pipeline_utils.go
+++ b/pkg/engine/internal/executor/pipeline_utils.go
@@ -50,15 +50,3 @@ func (p *BufferedPipeline) Close() {
 	}
 	p.records = nil
 }
-
-// Inputs implements Pipeline.
-// CSV pipeline is a source, so it has no inputs.
-func (p *BufferedPipeline) Inputs() []Pipeline {
-	return nil
-}
-
-// Transport implements Pipeline.
-// CSVPipeline is always considered a Local transport.
-func (p *BufferedPipeline) Transport() Transport {
-	return Local
-}

--- a/pkg/engine/internal/executor/project.go
+++ b/pkg/engine/internal/executor/project.go
@@ -23,7 +23,7 @@ func NewProjectPipeline(input Pipeline, columns []physical.ColumnExpression, eva
 		}
 	}
 
-	return newGenericPipeline(Local, func(ctx context.Context, inputs []Pipeline) (arrow.Record, error) {
+	return newGenericPipeline(func(ctx context.Context, inputs []Pipeline) (arrow.Record, error) {
 		// Pull the next item from the input pipeline
 		input := inputs[0]
 		batch, err := input.Read(ctx)

--- a/pkg/engine/internal/executor/range_aggregation.go
+++ b/pkg/engine/internal/executor/range_aggregation.go
@@ -235,16 +235,6 @@ func (r *rangeAggregationPipeline) Close() {
 	}
 }
 
-// Inputs returns the inputs of the pipeline.
-func (r *rangeAggregationPipeline) Inputs() []Pipeline {
-	return r.inputs
-}
-
-// Transport returns the type of transport of the implementation.
-func (r *rangeAggregationPipeline) Transport() Transport {
-	return Local
-}
-
 func newMatcherFactoryFromOpts(opts rangeAggregationOptions) *matcherFactory {
 	return &matcherFactory{
 		start:    opts.startTs,

--- a/pkg/engine/internal/executor/sortmerge.go
+++ b/pkg/engine/internal/executor/sortmerge.go
@@ -66,20 +66,10 @@ func (p *KWayMerge) Close() {
 	}
 }
 
-// Inputs implements Pipeline.
-func (p *KWayMerge) Inputs() []Pipeline {
-	return p.inputs
-}
-
 // Read implements Pipeline.
 func (p *KWayMerge) Read(ctx context.Context) (arrow.Record, error) {
 	p.init(ctx)
 	return p.read(ctx)
-}
-
-// Transport implements Pipeline.
-func (p *KWayMerge) Transport() Transport {
-	return Local
 }
 
 func (p *KWayMerge) init(ctx context.Context) {

--- a/pkg/engine/internal/executor/topk.go
+++ b/pkg/engine/internal/executor/topk.go
@@ -117,7 +117,7 @@ func (p *topkPipeline) Read(ctx context.Context) (arrow.Record, error) {
 
 func (p *topkPipeline) compute(ctx context.Context) (arrow.Record, error) {
 NextInput:
-	for _, in := range p.Inputs() {
+	for _, in := range p.inputs {
 		for {
 			rec, err := in.Read(ctx)
 			if err != nil && errors.Is(err, EOF) {
@@ -147,7 +147,3 @@ func (p *topkPipeline) Close() {
 		in.Close()
 	}
 }
-
-func (p *topkPipeline) Inputs() []Pipeline { return p.inputs }
-
-func (p *topkPipeline) Transport() Transport { return Local }

--- a/pkg/engine/internal/executor/util_test.go
+++ b/pkg/engine/internal/executor/util_test.go
@@ -101,7 +101,6 @@ func newRecordGenerator(schema *arrow.Schema, batch batchFunc) *recordGenerator 
 func (p *recordGenerator) Pipeline(batchSize int64, rows int64) Pipeline {
 	var pos int64
 	return newGenericPipeline(
-		Local,
 		func(_ context.Context, _ []Pipeline) (arrow.Record, error) {
 			if pos >= rows {
 				return nil, EOF
@@ -182,9 +181,3 @@ func (p *ArrowtestPipeline) Read(_ context.Context) (arrow.Record, error) {
 
 // Close implements [Pipeline], immediately exhausting the pipeline.
 func (p *ArrowtestPipeline) Close() { p.cur = math.MaxInt64 }
-
-// Inputs implements [Pipeline], returning nil as this pipeline has no inputs.
-func (p *ArrowtestPipeline) Inputs() []Pipeline { return nil }
-
-// Transport implements [Pipeline], returning [Local].
-func (p *ArrowtestPipeline) Transport() Transport { return Local }

--- a/pkg/engine/internal/executor/vector_aggregate.go
+++ b/pkg/engine/internal/executor/vector_aggregate.go
@@ -158,13 +158,3 @@ func (v *vectorAggregationPipeline) Close() {
 		input.Close()
 	}
 }
-
-// Inputs returns the inputs of the pipeline.
-func (v *vectorAggregationPipeline) Inputs() []Pipeline {
-	return v.inputs
-}
-
-// Transport returns the transport type of the pipeline.
-func (v *vectorAggregationPipeline) Transport() Transport {
-	return Local
-}


### PR DESCRIPTION
Pipeline.Inputs was never called outside of a basic unit test, and Pipeline.Transport has no use in the upcoming scheduler.

To reduce the amount of work needed to write new nodes, these methods have been removed.
