### PR TITLE
chore(engine): add Parallelize hint node

### DIFF
--- a/pkg/engine/internal/executor/executor.go
+++ b/pkg/engine/internal/executor/executor.go
@@ -97,6 +97,8 @@ func (c *Context) execute(ctx context.Context, node physical.Node) Pipeline {
 		return tracePipeline("physical.ParseNode", c.executeParse(ctx, n, inputs))
 	case *physical.ColumnCompat:
 		return tracePipeline("physical.ColumnCompat", c.executeColumnCompat(ctx, n, inputs))
+	case *physical.Parallelize:
+		return tracePipeline("physical.Parallelize", c.executeParallelize(ctx, n, inputs))
 	default:
 		return errorPipeline(ctx, fmt.Errorf("invalid node type: %T", node))
 	}
@@ -439,4 +441,17 @@ func (c *Context) executeColumnCompat(ctx context.Context, compat *physical.Colu
 	}
 
 	return newColumnCompatibilityPipeline(compat, inputs[0])
+}
+
+func (c *Context) executeParallelize(ctx context.Context, _ *physical.Parallelize, inputs []Pipeline) Pipeline {
+	if len(inputs) == 0 {
+		return emptyPipeline()
+	} else if len(inputs) > 1 {
+		return errorPipeline(ctx, fmt.Errorf("parallelize expects exactly one input, got %d", len(inputs)))
+	}
+
+	// Parallelize is a hint node to the scheduler for parallel execution. If we
+	// see an Parallelize node in the plan, we ignore it and immediately
+	// propagate up the input.
+	return inputs[0]
 }

--- a/pkg/engine/internal/planner/logical/node_logql_compat.go
+++ b/pkg/engine/internal/planner/logical/node_logql_compat.go
@@ -6,7 +6,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/engine/internal/planner/schema"
 )
 
-// The LOGQL_COMPAT instruction is a marker to indicate v1 engine compatibilty.
+// The LOGQL_COMPAT instruction is a marker to indicate v1 engine compatibility.
 // LogQLCompat implements [Instruction] and [Value].
 type LogQLCompat struct {
 	Value Value

--- a/pkg/engine/internal/planner/physical/optimizer.go
+++ b/pkg/engine/internal/planner/physical/optimizer.go
@@ -231,7 +231,7 @@ func (r *projectionPushdown) applyProjectionPushdown(
 		return r.handleParseNode(node, projections, applyIfNotEmpty)
 	case *RangeAggregation:
 		return r.handleRangeAggregation(node, projections)
-	case *Filter, *Merge, *SortMerge, *ColumnCompat:
+	case *Parallelize, *Filter, *Merge, *SortMerge, *ColumnCompat:
 		// Push to next direct child that cares about projections
 		return r.pushToChildren(node, projections, applyIfNotEmpty)
 	}

--- a/pkg/engine/internal/planner/physical/parallelize.go
+++ b/pkg/engine/internal/planner/physical/parallelize.go
@@ -1,0 +1,24 @@
+package physical
+
+import "fmt"
+
+// Parallelize represents a hint to the engine to partition and parallelize the
+// children branches of the Parallelize and emit results as a single sequence
+// with no guaranteed order.
+type Parallelize struct {
+	id string
+}
+
+// ID returns a string that uniquely identifies the node in the plan.
+func (p *Parallelize) ID() string {
+	if p.id == "" {
+		return fmt.Sprintf("%p", p)
+	}
+	return p.id
+}
+
+// Type returns [NodeTypeParallelize].
+func (p *Parallelize) Type() NodeType { return NodeTypeParallelize }
+
+// Accept implements the [Node] interface, dispatching itself to v.
+func (p *Parallelize) Accept(v Visitor) error { return v.VisitParallelize(p) }

--- a/pkg/engine/internal/planner/physical/plan.go
+++ b/pkg/engine/internal/planner/physical/plan.go
@@ -17,6 +17,7 @@ const (
 	NodeTypeMerge
 	NodeTypeParse
 	NodeTypeCompat
+	NodeTypeParallelize
 )
 
 func (t NodeType) String() string {
@@ -41,6 +42,8 @@ func (t NodeType) String() string {
 		return "Parse"
 	case NodeTypeCompat:
 		return "Compat"
+	case NodeTypeParallelize:
+		return "Parallelize"
 	default:
 		return "Undefined"
 	}
@@ -76,6 +79,7 @@ var _ Node = (*RangeAggregation)(nil)
 var _ Node = (*VectorAggregation)(nil)
 var _ Node = (*ParseNode)(nil)
 var _ Node = (*ColumnCompat)(nil)
+var _ Node = (*Parallelize)(nil)
 
 func (*DataObjScan) isNode()       {}
 func (*Merge) isNode()             {}
@@ -87,6 +91,7 @@ func (*RangeAggregation) isNode()  {}
 func (*VectorAggregation) isNode() {}
 func (*ParseNode) isNode()         {}
 func (*ColumnCompat) isNode()      {}
+func (*Parallelize) isNode()       {}
 
 // WalkOrder defines the order for how a node and its children are visited.
 type WalkOrder uint8

--- a/pkg/engine/internal/planner/physical/planner.go
+++ b/pkg/engine/internal/planner/physical/planner.go
@@ -245,10 +245,15 @@ func (p *Planner) processMakeTable(lp *logical.MakeTable, ctx *Context) ([]Node,
 		slices.Reverse(groups)
 	}
 
-	var node Node = &Merge{}
-	p.plan.graph.Add(node)
+	// Scan work can be parallelized across multiple workers, so we wrap
+	// everything into a single Parallelize node.
+	var parallelize Node = &Parallelize{}
+	p.plan.graph.Add(parallelize)
+
+	var merge Node = &Merge{}
+	p.plan.graph.Add(merge)
 	for _, gr := range groups {
-		if err := p.buildNodeGroup(gr, node, ctx); err != nil {
+		if err := p.buildNodeGroup(gr, merge, ctx); err != nil {
 			return nil, err
 		}
 	}
@@ -259,13 +264,18 @@ func (p *Planner) processMakeTable(lp *logical.MakeTable, ctx *Context) ([]Node,
 			Destination: types.ColumnTypeMetadata,
 			Collision:   types.ColumnTypeLabel,
 		}
-		node, err = p.wrapNodeWith(node, compat)
+		merge, err = p.wrapNodeWith(merge, compat)
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	return []Node{node}, nil
+	// Add an edge between the parallelize and the final merge node (which may
+	// have been changed after processing compatibility).
+	if err := p.plan.graph.AddEdge(dag.Edge[Node]{Parent: parallelize, Child: merge}); err != nil {
+		return nil, err
+	}
+	return []Node{parallelize}, nil
 }
 
 // Convert [logical.Select] into one [Filter] node.

--- a/pkg/engine/internal/planner/physical/planner_test.go
+++ b/pkg/engine/internal/planner/physical/planner_test.go
@@ -481,6 +481,7 @@ func TestPlanner_MakeTable_Ordering(t *testing.T) {
 		require.NoError(t, err)
 
 		expectedPlan := &Plan{}
+		parallelize := expectedPlan.graph.Add(&Parallelize{id: "parallelize"})
 		compat := expectedPlan.graph.Add(&ColumnCompat{id: "compat", Source: types.ColumnTypeMetadata, Destination: types.ColumnTypeMetadata, Collision: types.ColumnTypeLabel})
 		merge := expectedPlan.graph.Add(&Merge{id: "merge"})
 		sortMerge1 := expectedPlan.graph.Add(&SortMerge{id: "sortmerge1", Order: ASC, Column: &ColumnExpr{Ref: types.ColumnRef{Column: "timestamp", Type: types.ColumnTypeBuiltin}}})
@@ -490,6 +491,7 @@ func TestPlanner_MakeTable_Ordering(t *testing.T) {
 		scan3 := expectedPlan.graph.Add(&DataObjScan{id: "scan3", Location: "obj3", Section: 2, StreamIDs: []int64{5, 1}, Direction: ASC})
 		scan4 := expectedPlan.graph.Add(&DataObjScan{id: "scan4", Location: "obj3", Section: 3, StreamIDs: []int64{5, 1}, Direction: ASC})
 
+		_ = expectedPlan.graph.AddEdge(dag.Edge[Node]{Parent: parallelize, Child: compat})
 		_ = expectedPlan.graph.AddEdge(dag.Edge[Node]{Parent: compat, Child: merge})
 		_ = expectedPlan.graph.AddEdge(dag.Edge[Node]{Parent: merge, Child: sortMerge1})
 		_ = expectedPlan.graph.AddEdge(dag.Edge[Node]{Parent: merge, Child: sortMerge2})
@@ -517,6 +519,7 @@ func TestPlanner_MakeTable_Ordering(t *testing.T) {
 		require.NoError(t, err)
 
 		expectedPlan := &Plan{}
+		parallelize := expectedPlan.graph.Add(&Parallelize{id: "parallelize"})
 		compat := expectedPlan.graph.Add(&ColumnCompat{id: "compat", Source: types.ColumnTypeMetadata, Destination: types.ColumnTypeMetadata, Collision: types.ColumnTypeLabel})
 		merge := expectedPlan.graph.Add(&Merge{id: "merge"})
 		sortMerge1 := expectedPlan.graph.Add(&SortMerge{id: "sortmerge1", Order: DESC, Column: &ColumnExpr{Ref: types.ColumnRef{Column: "timestamp", Type: types.ColumnTypeBuiltin}}})
@@ -526,6 +529,7 @@ func TestPlanner_MakeTable_Ordering(t *testing.T) {
 		scan3 := expectedPlan.graph.Add(&DataObjScan{id: "scan3", Location: "obj3", Section: 2, StreamIDs: []int64{5, 1}, Direction: DESC})
 		scan4 := expectedPlan.graph.Add(&DataObjScan{id: "scan4", Location: "obj3", Section: 3, StreamIDs: []int64{5, 1}, Direction: DESC})
 
+		_ = expectedPlan.graph.AddEdge(dag.Edge[Node]{Parent: parallelize, Child: compat})
 		_ = expectedPlan.graph.AddEdge(dag.Edge[Node]{Parent: compat, Child: merge})
 		_ = expectedPlan.graph.AddEdge(dag.Edge[Node]{Parent: merge, Child: sortMerge1})
 		_ = expectedPlan.graph.AddEdge(dag.Edge[Node]{Parent: merge, Child: sortMerge2})

--- a/pkg/engine/internal/planner/physical/visitor.go
+++ b/pkg/engine/internal/planner/physical/visitor.go
@@ -15,4 +15,5 @@ type Visitor interface {
 	VisitVectorAggregation(*VectorAggregation) error
 	VisitParse(*ParseNode) error
 	VisitCompat(*ColumnCompat) error
+	VisitParallelize(*Parallelize) error
 }

--- a/pkg/engine/internal/planner/physical/visitor_test.go
+++ b/pkg/engine/internal/planner/physical/visitor_test.go
@@ -20,6 +20,7 @@ type nodeCollectVisitor struct {
 	onVisitRangeAggregation  func(*RangeAggregation) error
 	onVisitVectorAggregation func(*VectorAggregation) error
 	onVisitParse             func(*ParseNode) error
+	onVisitParallelize       func(*Parallelize) error
 }
 
 func (v *nodeCollectVisitor) VisitDataObjScan(n *DataObjScan) error {
@@ -97,5 +98,13 @@ func (v *nodeCollectVisitor) VisitParse(n *ParseNode) error {
 }
 
 func (v *nodeCollectVisitor) VisitCompat(*ColumnCompat) error {
+	return nil
+}
+
+func (v *nodeCollectVisitor) VisitParallelize(n *Parallelize) error {
+	if v.onVisitParallelize != nil {
+		return v.onVisitParallelize(n)
+	}
+	v.visited = append(v.visited, fmt.Sprintf("%s.%s", n.Type().String(), n.ID()))
 	return nil
 }


### PR DESCRIPTION
The new Parallelize node represents a hint to the engine to partition and parallelize the children branches of the Parallelize and emit results as a single sequence with no guaranteed order.

Parallelize is intended to be used by the scheduler for generating tasks, but will not end up in the individual task plans.

If a physical plan containing the Parallelize hint node is executed, the Parallelize node is ignored, and execution passes directly to its sole input.

This commit does not contain any optimization passes that make use of the Parallelize node. Future optimization passes can be written to "push down" operations inside parallelization for work distribution.