### PR TITLE
docs: fix typo in meta-monitoring deploy.md

### DIFF
--- a/docs/sources/operations/meta-monitoring/deploy.md
+++ b/docs/sources/operations/meta-monitoring/deploy.md
@@ -70,7 +70,7 @@ The Kubernetes Monitoring Helm chart requires a Grafana Cloud account or a separ
    ```bash
    kubectl create secret generic metrics -n meta \
     --from-literal=username=<PROMETHEUS-USER> \
-    --from-literal=password=<CLOUD-TOKEn>
+    --from-literal=password=<CLOUD-TOKEN>
 
    kubectl create secret generic logs -n meta \
     --from-literal=username=<LOKI-USER> \


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a typo in the meta-monitoring deploy.md
