### PR TITLE
chore(engine): address extra feedback from #19522 review

### DIFF
--- a/pkg/engine/internal/planner/physical/optimizer.go
+++ b/pkg/engine/internal/planner/physical/optimizer.go
@@ -461,7 +461,8 @@ func (p *parallelPushdown) canPushdown(node Node) bool {
 		return false
 	}
 
-	// foundNonParallelize is false if all children are of type [NodeTypeParallelize].
+	// foundNonParallelize is true if there is at least one child that is not of
+	// type [NodeTypeParallelize].
 	foundNonParallelize := slices.ContainsFunc(children, func(n Node) bool {
 		return n.Type() != NodeTypeParallelize
 	})

--- a/pkg/engine/internal/planner/physical/parse.go
+++ b/pkg/engine/internal/planner/physical/parse.go
@@ -41,10 +41,9 @@ func (n *ParseNode) ID() string {
 	return fmt.Sprintf("%p", n)
 }
 
-// Clone creates a copy of n.
+// Clone returns a deep copy of the node (minus its ID).
 func (n *ParseNode) Clone() Node {
 	return &ParseNode{
-		id:            n.id,
 		Kind:          n.Kind,
 		RequestedKeys: slices.Clone(n.RequestedKeys),
 	}

--- a/pkg/engine/internal/planner/physical/scanset.go
+++ b/pkg/engine/internal/planner/physical/scanset.go
@@ -68,7 +68,7 @@ func (s *ScanSet) ID() string {
 	return s.id
 }
 
-// Clone returns a copy of the node, minus its ID.
+// Clone returns a deep copy of the node (minus its ID).
 func (s *ScanSet) Clone() Node {
 	newTargets := make([]*ScanTarget, 0, len(s.Targets))
 	for _, target := range s.Targets {


### PR DESCRIPTION
Fixes an issue where the ID of a node was incorrectly copied on Clone, and clarifies comments on foundNonParallelize.