### PR TITLE
refactor: move allocator into execution Context

### DIFF
--- a/pkg/engine/internal/executor/executor.go
+++ b/pkg/engine/internal/executor/executor.go
@@ -36,7 +36,7 @@ func Run(ctx context.Context, cfg Config, plan *physical.Plan, logger log.Logger
 		mergePrefetchCount: cfg.MergePrefetchCount,
 		bucket:             cfg.Bucket,
 		logger:             logger,
-		evaluator:          newExpressionEvaluator(allocator),
+		evaluator:          newExpressionEvaluator(),
 		allocator:          allocator,
 	}
 	if plan == nil {
@@ -305,7 +305,7 @@ func (c *Context) executeProjection(ctx context.Context, proj *physical.Projecti
 		return errorPipeline(ctx, fmt.Errorf("projection expects at least one expression, got 0"))
 	}
 
-	p, err := NewProjectPipeline(inputs[0], proj, &c.evaluator)
+	p, err := NewProjectPipeline(inputs[0], proj, &c.evaluator, c.allocator)
 	if err != nil {
 		return errorPipeline(ctx, err)
 	}
@@ -327,7 +327,7 @@ func (c *Context) executeRangeAggregation(ctx context.Context, plan *physical.Ra
 		return emptyPipeline()
 	}
 
-	pipeline, err := newRangeAggregationPipeline(inputs, c.evaluator, rangeAggregationOptions{
+	pipeline, err := newRangeAggregationPipeline(inputs, c.evaluator, c.allocator, rangeAggregationOptions{
 		partitionBy:   plan.PartitionBy,
 		startTs:       plan.Start,
 		endTs:         plan.End,
@@ -353,7 +353,7 @@ func (c *Context) executeVectorAggregation(ctx context.Context, plan *physical.V
 		return emptyPipeline()
 	}
 
-	pipeline, err := newVectorAggregationPipeline(inputs, plan.GroupBy, c.evaluator, plan.Operation)
+	pipeline, err := newVectorAggregationPipeline(inputs, plan.GroupBy, c.evaluator, c.allocator, plan.Operation)
 	if err != nil {
 		return errorPipeline(ctx, err)
 	}

--- a/pkg/engine/internal/executor/filter.go
+++ b/pkg/engine/internal/executor/filter.go
@@ -24,7 +24,7 @@ func NewFilterPipeline(filter *physical.Filter, input Pipeline, evaluator expres
 		cols := make([]*array.Boolean, 0, len(filter.Predicates))
 
 		for i, pred := range filter.Predicates {
-			vec, err := evaluator.eval(pred, batch)
+			vec, err := evaluator.eval(pred, allocator, batch)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/engine/internal/executor/filter_test.go
+++ b/pkg/engine/internal/executor/filter_test.go
@@ -47,7 +47,7 @@ func TestNewFilterPipeline(t *testing.T) {
 		}
 
 		// Create filter pipeline
-		e := newExpressionEvaluator(alloc)
+		e := newExpressionEvaluator()
 		pipeline := NewFilterPipeline(filter, input, e, alloc)
 		defer pipeline.Close()
 
@@ -89,7 +89,7 @@ func TestNewFilterPipeline(t *testing.T) {
 		}
 
 		// Create filter pipeline
-		e := newExpressionEvaluator(alloc)
+		e := newExpressionEvaluator()
 		pipeline := NewFilterPipeline(filter, input, e, alloc)
 		defer pipeline.Close()
 
@@ -129,7 +129,7 @@ func TestNewFilterPipeline(t *testing.T) {
 		}
 
 		// Create filter pipeline
-		e := newExpressionEvaluator(alloc)
+		e := newExpressionEvaluator()
 		pipeline := NewFilterPipeline(filter, input, e, alloc)
 		defer pipeline.Close()
 
@@ -185,7 +185,7 @@ func TestNewFilterPipeline(t *testing.T) {
 		}
 
 		// Create filter pipeline
-		e := newExpressionEvaluator(alloc)
+		e := newExpressionEvaluator()
 		pipeline := NewFilterPipeline(filter, input, e, alloc)
 		defer pipeline.Close()
 
@@ -228,7 +228,7 @@ func TestNewFilterPipeline(t *testing.T) {
 		}
 
 		// Create filter pipeline
-		e := newExpressionEvaluator(alloc)
+		e := newExpressionEvaluator()
 		pipeline := NewFilterPipeline(filter, input, e, alloc)
 		defer pipeline.Close()
 
@@ -272,7 +272,7 @@ func TestNewFilterPipeline(t *testing.T) {
 		}
 
 		// Create filter pipeline
-		e := newExpressionEvaluator(alloc)
+		e := newExpressionEvaluator()
 		pipeline := NewFilterPipeline(filter, input, e, alloc)
 		defer pipeline.Close()
 
@@ -333,7 +333,7 @@ func TestNewFilterPipeline(t *testing.T) {
 		}
 
 		// Create filter pipeline
-		e := newExpressionEvaluator(alloc)
+		e := newExpressionEvaluator()
 		pipeline := NewFilterPipeline(filter, input, e, alloc)
 		defer pipeline.Close()
 

--- a/pkg/engine/internal/executor/range_aggregation_test.go
+++ b/pkg/engine/internal/executor/range_aggregation_test.go
@@ -82,7 +82,7 @@ func TestRangeAggregationPipeline_instant(t *testing.T) {
 
 	inputA := NewArrowtestPipeline(alloc, schema, rowsPipelineA...)
 	inputB := NewArrowtestPipeline(alloc, schema, rowsPipelineB...)
-	pipeline, err := newRangeAggregationPipeline([]Pipeline{inputA, inputB}, newExpressionEvaluator(alloc), opts)
+	pipeline, err := newRangeAggregationPipeline([]Pipeline{inputA, inputB}, newExpressionEvaluator(), alloc, opts)
 	require.NoError(t, err)
 	defer pipeline.Close()
 
@@ -173,7 +173,7 @@ func TestRangeAggregationPipeline(t *testing.T) {
 
 		inputA := NewArrowtestPipeline(alloc, schema, rowsPipelineA...)
 		inputB := NewArrowtestPipeline(alloc, schema, rowsPiplelineB...)
-		pipeline, err := newRangeAggregationPipeline([]Pipeline{inputA, inputB}, newExpressionEvaluator(alloc), opts)
+		pipeline, err := newRangeAggregationPipeline([]Pipeline{inputA, inputB}, newExpressionEvaluator(), alloc, opts)
 		require.NoError(t, err)
 		defer pipeline.Close()
 
@@ -221,7 +221,7 @@ func TestRangeAggregationPipeline(t *testing.T) {
 
 		inputA := NewArrowtestPipeline(alloc, schema, rowsPipelineA...)
 		inputB := NewArrowtestPipeline(alloc, schema, rowsPiplelineB...)
-		pipeline, err := newRangeAggregationPipeline([]Pipeline{inputA, inputB}, newExpressionEvaluator(alloc), opts)
+		pipeline, err := newRangeAggregationPipeline([]Pipeline{inputA, inputB}, newExpressionEvaluator(), alloc, opts)
 		require.NoError(t, err)
 		defer pipeline.Close()
 
@@ -283,7 +283,7 @@ func TestRangeAggregationPipeline(t *testing.T) {
 
 		inputA := NewArrowtestPipeline(alloc, schema, rowsPipelineA...)
 		inputB := NewArrowtestPipeline(alloc, schema, rowsPiplelineB...)
-		pipeline, err := newRangeAggregationPipeline([]Pipeline{inputA, inputB}, newExpressionEvaluator(alloc), opts)
+		pipeline, err := newRangeAggregationPipeline([]Pipeline{inputA, inputB}, newExpressionEvaluator(), alloc, opts)
 		require.NoError(t, err)
 		defer pipeline.Close()
 

--- a/pkg/engine/internal/executor/vector_aggregate_test.go
+++ b/pkg/engine/internal/executor/vector_aggregate_test.go
@@ -88,7 +88,7 @@ func TestVectorAggregationPipeline(t *testing.T) {
 		},
 	}
 
-	pipeline, err := newVectorAggregationPipeline([]Pipeline{input1, input2}, groupBy, newExpressionEvaluator(nil), types.VectorAggregationTypeSum)
+	pipeline, err := newVectorAggregationPipeline([]Pipeline{input1, input2}, groupBy, newExpressionEvaluator(), alloc, types.VectorAggregationTypeSum)
 	require.NoError(t, err)
 	defer pipeline.Close()
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The `expressionEvaluator` no longer felt like the right place to store the state of the `allocator`, as demonstrated by the `NewFilterPipeline` call that took both an evaluator and an allocator, resulting in multiple allocators states. This PR refactors the allocator up into the execution context, and then passes it as a parameter to `.eval()`. It also cleans up a few TODOs where we were using the default allocator instead of one from a shared context.

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
