### PR TITLE
chore(engine): add information for task updates

### DIFF
--- a/pkg/engine/internal/workflow/runner.go
+++ b/pkg/engine/internal/workflow/runner.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/grafana/loki/v3/pkg/engine/internal/executor"
+	"github.com/grafana/loki/v3/pkg/logqlmodel/stats"
 )
 
 // A Runner can asynchronously execute a workflow.
@@ -91,7 +92,21 @@ func (s StreamState) String() string {
 }
 
 // TaskEventHandler is a function that handles events for changed tasks.
-type TaskEventHandler func(ctx context.Context, t *Task, newState TaskState)
+type TaskEventHandler func(ctx context.Context, t *Task, newStatus TaskStatus)
+
+// TaskStatus holds the state of a task and additional information about that
+// state.
+type TaskStatus struct {
+	State TaskState
+
+	// Error holds the error that occurred during task execution, if any. Only
+	// set when State is [TaskStateFailed].
+	Error error
+
+	// Statistics report analytics about the lifetime of a task. Only set
+	// for terminal task states (see [TaskState.Terminal]).
+	Statistics *stats.Result
+}
 
 // TaskState represents the state of a Task. It is sent as an event by a
 // [Runner] whenever a Task associated with a task changes its state.

--- a/pkg/engine/internal/workflow/workflow_test.go
+++ b/pkg/engine/internal/workflow/workflow_test.go
@@ -125,7 +125,7 @@ func TestCancellation(t *testing.T) {
 
 			// Notify the workflow that the root task has entered a terminal
 			// state.
-			rt.handler(t.Context(), rootTask, state)
+			rt.handler(t.Context(), rootTask, TaskStatus{State: state})
 
 			_ = wf.graph.Walk(rootTask, func(n *Task) error {
 				if n == rootTask {
@@ -230,7 +230,7 @@ func (f *fakeRunner) Start(ctx context.Context, handler TaskEventHandler, tasks 
 		}
 
 		// Inform handler of task state change.
-		handler(ctx, task, TaskStatePending)
+		handler(ctx, task, TaskStatus{State: TaskStatePending})
 	}
 
 	return nil
@@ -246,7 +246,7 @@ func (f *fakeRunner) Cancel(ctx context.Context, tasks ...*Task) error {
 			continue
 		}
 
-		rt.handler(ctx, task, TaskStateCancelled)
+		rt.handler(ctx, task, TaskStatus{State: TaskStateCancelled})
 		delete(f.tasks, task.ULID)
 	}
 


### PR DESCRIPTION
Updates the workflow to receive additional events about task updates:

* The error that occured if the task failed.
* The stats (if any) about the task upon reaching a terminal state.

At the moment, the error is unused, but carried over anyway to mirror the prototype. The field may be removed if we have no use for it. 