### PR TITLE
chore: eval memory changes

### DIFF
--- a/pkg/engine/internal/executor/cast.go
+++ b/pkg/engine/internal/executor/cast.go
@@ -28,10 +28,10 @@ func castFn(operation types.UnaryOp) UnaryFunction {
 		conversionFn := getConversionFunction(operation)
 		castCol, errTracker := castValues(sourceCol, conversionFn, allocator)
 		defer castCol.Release()
+		defer errTracker.releaseBuilders()
 
 		// Build error columns if needed
 		errorCol, errorDetailsCol := errTracker.buildArrays()
-		defer errTracker.releaseBuilders()
 		if errTracker.hasErrors {
 			defer errorCol.Release()
 			defer errorDetailsCol.Release()

--- a/pkg/engine/internal/executor/expressions_test.go
+++ b/pkg/engine/internal/executor/expressions_test.go
@@ -89,7 +89,8 @@ func TestEvaluateLiteralExpression(t *testing.T) {
 			e := newExpressionEvaluator()
 
 			n := len(words)
-			rec := batch(n, time.Now())
+			rec := batch(n, time.Now(), alloc)
+			defer rec.Release()
 			colVec, err := e.eval(literal, alloc, rec)
 			require.NoError(t, err)
 			require.Equalf(t, tt.arrowType, colVec.Type().ArrowType().ID(), "expected: %v got: %v", tt.arrowType.String(), colVec.Type().ArrowType().ID().String())
@@ -120,12 +121,15 @@ func TestEvaluateColumnExpression(t *testing.T) {
 		}
 
 		n := len(words)
-		rec := batch(n, time.Now())
+		rec := batch(n, time.Now(), alloc)
+		defer rec.Release()
 		colVec, err := e.eval(colExpr, alloc, rec)
 		require.NoError(t, err)
 
-		_, ok := colVec.(*Scalar)
+		col, ok := colVec.(*Scalar)
 		require.True(t, ok, "expected column vector to be a *Scalar, got %T", colVec)
+		arr := col.ToArray()
+		defer arr.Release()
 		require.Equal(t, arrow.STRING, colVec.Type().ArrowType().ID())
 	})
 
@@ -138,9 +142,12 @@ func TestEvaluateColumnExpression(t *testing.T) {
 		}
 
 		n := len(words)
-		rec := batch(n, time.Now())
+		rec := batch(n, time.Now(), alloc)
+		defer rec.Release()
 		colVec, err := e.eval(colExpr, alloc, rec)
 		require.NoError(t, err)
+		arr := colVec.ToArray()
+		defer arr.Release()
 		require.Equal(t, arrow.STRING, colVec.Type().ArrowType().ID())
 
 		for i := range n {
@@ -232,11 +239,8 @@ func collectBooleanColumnVector(vec ColumnVector) []bool {
 
 var words = []string{"one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten"}
 
-func batch(n int, now time.Time) arrow.Record {
-	// 1. Create a memory allocator
-	mem := memory.NewGoAllocator()
-
-	// 2. Define the schema
+func batch(n int, now time.Time, allocator memory.Allocator) arrow.Record {
+	// Define the schema
 	schema := arrow.NewSchema(
 		[]arrow.Field{
 			semconv.FieldFromIdent(semconv.ColumnIdentMessage, false),
@@ -245,14 +249,14 @@ func batch(n int, now time.Time) arrow.Record {
 		nil, // No metadata
 	)
 
-	// 3. Create builders for each column
-	logBuilder := array.NewStringBuilder(mem)
+	// Create builders for each column
+	logBuilder := array.NewStringBuilder(allocator)
 	defer logBuilder.Release()
 
-	tsBuilder := array.NewTimestampBuilder(mem, &arrow.TimestampType{Unit: arrow.Nanosecond, TimeZone: "UTC"})
+	tsBuilder := array.NewTimestampBuilder(allocator, &arrow.TimestampType{Unit: arrow.Nanosecond, TimeZone: "UTC"})
 	defer tsBuilder.Release()
 
-	// 4. Append data to the builders
+	// Append data to the builders
 	logs := make([]string, n)
 	ts := make([]arrow.Timestamp, n)
 
@@ -264,14 +268,14 @@ func batch(n int, now time.Time) arrow.Record {
 	tsBuilder.AppendValues(ts, nil)
 	logBuilder.AppendValues(logs, nil)
 
-	// 5. Build the arrays
+	// Build the arrays
 	logArray := logBuilder.NewArray()
 	defer logArray.Release()
 
 	tsArray := tsBuilder.NewArray()
 	defer tsArray.Release()
 
-	// 6. Create the record
+	// Create the record
 	columns := []arrow.Array{logArray, tsArray}
 	record := array.NewRecord(schema, columns, int64(n))
 
@@ -336,10 +340,8 @@ null,null,null`
 		colVec, err := e.eval(colExpr, alloc, record)
 		require.NoError(t, err)
 		require.IsType(t, &CoalesceVector{}, colVec)
-		defer colVec.Release()
 
 		arr := colVec.ToArray()
-		defer arr.Release()
 		require.IsType(t, &array.String{}, arr)
 		stringArr := arr.(*array.String)
 
@@ -418,10 +420,10 @@ func TestEvaluateUnaryCastExpression(t *testing.T) {
 		}
 
 		n := len(words)
-		rec := batch(n, time.Now())
+		rec := batch(n, time.Now(), alloc)
+		defer rec.Release()
 		colVec, err := e.eval(expr, alloc, rec)
 		require.NoError(t, err)
-		defer colVec.Release()
 
 		id := colVec.Type().ArrowType().ID()
 		require.Equal(t, arrow.STRUCT, id)
@@ -482,7 +484,6 @@ func TestEvaluateUnaryCastExpression(t *testing.T) {
 
 		colVec, err := e.eval(expr, alloc, record)
 		require.NoError(t, err)
-		defer colVec.Release()
 		id := colVec.Type().ArrowType().ID()
 		require.Equal(t, arrow.STRUCT, id)
 
@@ -534,7 +535,6 @@ func TestEvaluateUnaryCastExpression(t *testing.T) {
 
 		colVec, err := e.eval(expr, alloc, record)
 		require.NoError(t, err)
-		defer colVec.Release()
 		id := colVec.Type().ArrowType().ID()
 		require.Equal(t, arrow.STRUCT, id)
 
@@ -586,7 +586,6 @@ func TestEvaluateUnaryCastExpression(t *testing.T) {
 
 		colVec, err := e.eval(colExpr, alloc, record)
 		require.NoError(t, err)
-		defer colVec.Release()
 		id := colVec.Type().ArrowType().ID()
 		require.Equal(t, arrow.STRUCT, id)
 

--- a/pkg/engine/internal/executor/filter.go
+++ b/pkg/engine/internal/executor/filter.go
@@ -28,7 +28,6 @@ func NewFilterPipeline(filter *physical.Filter, input Pipeline, evaluator expres
 			if err != nil {
 				return nil, err
 			}
-			defer vec.Release()
 
 			arr := vec.ToArray()
 			// boolean filters are only used for filtering; they're not returned

--- a/pkg/engine/internal/executor/functions_test.go
+++ b/pkg/engine/internal/executor/functions_test.go
@@ -120,7 +120,6 @@ func createFloat64Array(mem memory.Allocator, values []float64, nulls []bool) *A
 // Helper function to extract boolean values from result
 func extractBoolValues(result ColumnVector) []bool {
 	arr := result.ToArray().(*array.Boolean)
-	defer arr.Release()
 
 	values := make([]bool, arr.Len())
 	for i := 0; i < arr.Len(); i++ {
@@ -270,14 +269,13 @@ func TestBooleanComparisonFunctions(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			lhsArray := createBoolArray(mem, tt.lhs, nil)
 			rhsArray := createBoolArray(mem, tt.rhs, nil)
-			defer lhsArray.array.Release()
-			defer rhsArray.array.Release()
 
 			fn, err := binaryFunctions.GetForSignature(tt.op, arrow.FixedWidthTypes.Boolean)
 			require.NoError(t, err)
 
-			result, err := fn.Evaluate(lhsArray, rhsArray)
+			result, err := fn.Evaluate(lhsArray, rhsArray, mem)
 			require.NoError(t, err)
+			defer result.ToArray().Release()
 
 			actual := extractBoolValues(result)
 			assert.Equal(t, tt.expected, actual)
@@ -344,14 +342,13 @@ func TestStringComparisonFunctions(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			lhsArray := createStringArray(mem, tt.lhs, nil)
 			rhsArray := createStringArray(mem, tt.rhs, nil)
-			defer lhsArray.array.Release()
-			defer rhsArray.array.Release()
 
 			fn, err := binaryFunctions.GetForSignature(tt.op, arrow.BinaryTypes.String)
 			require.NoError(t, err)
 
-			result, err := fn.Evaluate(lhsArray, rhsArray)
+			result, err := fn.Evaluate(lhsArray, rhsArray, mem)
 			require.NoError(t, err)
+			defer result.ToArray().Release()
 
 			actual := extractBoolValues(result)
 			assert.Equal(t, tt.expected, actual)
@@ -418,14 +415,13 @@ func TestIntegerComparisonFunctions(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			lhsArray := createInt64Array(mem, tt.lhs, nil)
 			rhsArray := createInt64Array(mem, tt.rhs, nil)
-			defer lhsArray.array.Release()
-			defer rhsArray.array.Release()
 
 			fn, err := binaryFunctions.GetForSignature(tt.op, arrow.PrimitiveTypes.Int64)
 			require.NoError(t, err)
 
-			result, err := fn.Evaluate(lhsArray, rhsArray)
+			result, err := fn.Evaluate(lhsArray, rhsArray, mem)
 			require.NoError(t, err)
+			defer result.ToArray().Release()
 
 			actual := extractBoolValues(result)
 			assert.Equal(t, tt.expected, actual)
@@ -492,14 +488,13 @@ func TestTimestampComparisonFunctions(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			lhsArray := createTimestampArray(mem, tt.lhs, nil)
 			rhsArray := createTimestampArray(mem, tt.rhs, nil)
-			defer lhsArray.array.Release()
-			defer rhsArray.array.Release()
 
 			fn, err := binaryFunctions.GetForSignature(tt.op, arrow.FixedWidthTypes.Timestamp_ns)
 			require.NoError(t, err)
 
-			result, err := fn.Evaluate(lhsArray, rhsArray)
+			result, err := fn.Evaluate(lhsArray, rhsArray, mem)
 			require.NoError(t, err)
+			defer result.ToArray().Release()
 
 			actual := extractBoolValues(result)
 			assert.Equal(t, tt.expected, actual)
@@ -566,14 +561,13 @@ func TestFloat64ComparisonFunctions(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			lhsArray := createFloat64Array(mem, tt.lhs, nil)
 			rhsArray := createFloat64Array(mem, tt.rhs, nil)
-			defer lhsArray.array.Release()
-			defer rhsArray.array.Release()
 
 			fn, err := binaryFunctions.GetForSignature(tt.op, arrow.PrimitiveTypes.Float64)
 			require.NoError(t, err)
 
-			result, err := fn.Evaluate(lhsArray, rhsArray)
+			result, err := fn.Evaluate(lhsArray, rhsArray, mem)
 			require.NoError(t, err)
+			defer result.ToArray().Release()
 
 			actual := extractBoolValues(result)
 			assert.Equal(t, tt.expected, actual)
@@ -640,14 +634,13 @@ func TestStringMatchingFunctions(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			lhsArray := createStringArray(mem, tt.lhs, nil)
 			rhsArray := createStringArray(mem, tt.rhs, nil)
-			defer lhsArray.array.Release()
-			defer rhsArray.array.Release()
 
 			fn, err := binaryFunctions.GetForSignature(tt.op, arrow.BinaryTypes.String)
 			require.NoError(t, err)
 
-			result, err := fn.Evaluate(lhsArray, rhsArray)
+			result, err := fn.Evaluate(lhsArray, rhsArray, mem)
 			require.NoError(t, err)
+			defer result.ToArray().Release()
 
 			actual := extractBoolValues(result)
 			assert.Equal(t, tt.expected, actual)
@@ -704,14 +697,13 @@ func TestNullValueHandling(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			lhs, rhs := tt.setup()
-			defer lhs.array.Release()
-			defer rhs.array.Release()
 
 			fn, err := binaryFunctions.GetForSignature(tt.op, tt.dataType)
 			require.NoError(t, err)
 
-			result, err := fn.Evaluate(lhs, rhs)
+			result, err := fn.Evaluate(lhs, rhs, mem)
 			require.NoError(t, err)
+			defer result.ToArray().Release()
 
 			actual := extractBoolValues(result)
 			assert.Equal(t, tt.expected, actual)
@@ -764,13 +756,11 @@ func TestArrayLengthMismatch(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			lhs, rhs := tt.setup()
-			defer lhs.array.Release()
-			defer rhs.array.Release()
 
 			fn, err := binaryFunctions.GetForSignature(tt.op, tt.dataType)
 			require.NoError(t, err)
 
-			result, err := fn.Evaluate(lhs, rhs)
+			result, err := fn.Evaluate(lhs, rhs, mem)
 			assert.Error(t, err)
 			assert.Nil(t, result)
 		})
@@ -784,13 +774,11 @@ func TestRegexCompileError(t *testing.T) {
 	// Test with invalid regex patterns
 	lhs := createStringArray(mem, []string{"hello", "world"}, nil)
 	rhs := createStringArray(mem, []string{"[", "("}, nil) // Invalid regex patterns
-	defer lhs.array.Release()
-	defer rhs.array.Release()
 
 	fn, err := binaryFunctions.GetForSignature(types.BinaryOpMatchRe, arrow.BinaryTypes.String)
 	require.NoError(t, err)
 
-	_, err = fn.Evaluate(lhs, rhs)
+	_, err = fn.Evaluate(lhs, rhs, mem)
 	require.Error(t, err)
 }
 
@@ -827,14 +815,13 @@ func TestEmptyArrays(t *testing.T) {
 	// Test with empty arrays
 	lhs := createStringArray(mem, []string{}, nil)
 	rhs := createStringArray(mem, []string{}, nil)
-	defer lhs.array.Release()
-	defer rhs.array.Release()
 
 	fn, err := binaryFunctions.GetForSignature(types.BinaryOpEq, arrow.BinaryTypes.String)
 	require.NoError(t, err)
 
-	result, err := fn.Evaluate(lhs, rhs)
+	result, err := fn.Evaluate(lhs, rhs, mem)
 	require.NoError(t, err)
+	defer result.ToArray().Release()
 
 	assert.Equal(t, int64(0), result.Len())
 }

--- a/pkg/engine/internal/executor/project.go
+++ b/pkg/engine/internal/executor/project.go
@@ -132,9 +132,10 @@ func newExpandPipeline(expressions []physical.UnaryExpression, evaluator *expres
 			if err != nil {
 				return nil, err
 			}
-			defer vec.Release()
-			if arrStruct, ok := vec.ToArray().(*array.Struct); ok {
-				defer arrStruct.Release()
+			arr := vec.ToArray()
+			defer arr.Release()
+
+			if arrStruct, ok := arr.(*array.Struct); ok {
 				structSchema, ok := arrStruct.DataType().(*arrow.StructType)
 				if !ok {
 					return nil, fmt.Errorf("unexpected type returned from evaluation, expected *arrow.StructType, got %T", arrStruct.DataType())

--- a/pkg/engine/internal/executor/vector_aggregate.go
+++ b/pkg/engine/internal/executor/vector_aggregate.go
@@ -124,7 +124,7 @@ func (v *vectorAggregationPipeline) read(ctx context.Context) (arrow.Record, err
 				if err != nil {
 					return nil, err
 				}
-			
+
 				if vec.Type() != types.Loki.String {
 					return nil, fmt.Errorf("unsupported datatype for grouping %s", vec.Type())
 				}

--- a/pkg/engine/internal/executor/vector_aggregate.go
+++ b/pkg/engine/internal/executor/vector_aggregate.go
@@ -105,7 +105,6 @@ func (v *vectorAggregationPipeline) read(ctx context.Context) (arrow.Record, err
 			if err != nil {
 				return nil, err
 			}
-			defer tsVec.Release()
 			tsCol := tsVec.ToArray().(*array.Timestamp)
 			defer tsCol.Release()
 
@@ -114,7 +113,6 @@ func (v *vectorAggregationPipeline) read(ctx context.Context) (arrow.Record, err
 			if err != nil {
 				return nil, err
 			}
-			defer valueVec.Release()
 			valueArr := valueVec.ToArray().(*array.Float64)
 			defer valueArr.Release()
 
@@ -126,8 +124,7 @@ func (v *vectorAggregationPipeline) read(ctx context.Context) (arrow.Record, err
 				if err != nil {
 					return nil, err
 				}
-				defer vec.Release()
-
+			
 				if vec.Type() != types.Loki.String {
 					return nil, fmt.Errorf("unsupported datatype for grouping %s", vec.Type())
 				}


### PR DESCRIPTION
**What this PR does / why we need it**:

* Refactored `ColumnVector` not to have public `Release` method, it confuses people, it actually should be freed only once, but with ColumnVector and underlying arrays it is unclear on whom to call Release, and people usually call on both of them which is wrong.
* Added `allocator` argument into `genericFunction` to match `unaryFunctions`
* Refactored `eval` to free memory for left and right arguments by functions themselves, not by `eval`. That removes some repeated code.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
