### PR TITLE
chore: Use first-wins semantics for duplicate fields in logfmt/json parsers

### DIFF
--- a/pkg/engine/internal/executor/parse_json.go
+++ b/pkg/engine/internal/executor/parse_json.go
@@ -77,7 +77,6 @@ func (j *jsonParser) process(line []byte, requestedKeys []string) (map[string]st
 	err := jsonparser.ObjectEach(line, func(key []byte, value []byte, dataType jsonparser.ValueType, _ int) error {
 		return j.parseObject(key, value, dataType, result, requestedKeyLookup)
 	})
-
 	// If there's an error, return empty result for consistency with malformed JSON handling
 	if err != nil {
 		return make(map[string]string), err
@@ -143,6 +142,11 @@ func (j *jsonParser) parseLabelValue(key, value []byte, dataType jsonparser.Valu
 	// Convert the value to string based on its type
 	parsedValue := parseValue(value, dataType)
 	if parsedValue != "" {
+		// First-wins semantics for duplicates
+		_, exists := result[keyString]
+		if exists {
+			return nil
+		}
 		result[keyString] = parsedValue
 	}
 

--- a/pkg/engine/internal/executor/parse_logfmt.go
+++ b/pkg/engine/internal/executor/parse_logfmt.go
@@ -14,7 +14,7 @@ func buildLogfmtColumns(input *array.String, requestedKeys []string, allocator m
 }
 
 // tokenizeLogfmt parses logfmt input using the standard decoder
-// Returns a map of key-value pairs with last-wins semantics for duplicates
+// Returns a map of key-value pairs with first-wins semantics for duplicates
 // If requestedKeys is provided, the result will be filtered to only include those keys
 func tokenizeLogfmt(input string, requestedKeys []string) (map[string]string, error) {
 	result := make(map[string]string)
@@ -38,11 +38,15 @@ func tokenizeLogfmt(input string, requestedKeys []string) (map[string]string, er
 
 		val := decoder.Value()
 		if len(val) == 0 {
-			//TODO: retain empty values if --keep-empty is set
+			// TODO: retain empty values if --keep-empty is set
 			continue
 		}
 
-		// Last-wins semantics for duplicates
+		// First-wins semantics for duplicates
+		_, exists := result[key]
+		if exists {
+			continue
+		}
 		result[key] = unsafeString(decoder.Value())
 	}
 

--- a/pkg/engine/internal/executor/parse_test.go
+++ b/pkg/engine/internal/executor/parse_test.go
@@ -238,6 +238,24 @@ func TestNewParsePipeline_logfmt(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "handle duplicate keys with first-wins semantics",
+			schema: arrow.NewSchema([]arrow.Field{
+				semconv.FieldFromFQN("utf8.builtin.message", true),
+			}, nil),
+			input: arrowtest.Rows{
+				{colMsg: "level=info status=200 level=debug"},
+			},
+			requestedKeys:  nil,
+			expectedFields: 3, // 3 columns: message, level, status
+			expectedOutput: arrowtest.Rows{
+				{
+					colMsg:               "level=info status=200 level=debug",
+					"utf8.parsed.level":  "info",
+					"utf8.parsed.status": "200",
+				},
+			},
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			alloc := memory.NewCheckedAllocator(memory.DefaultAllocator)
@@ -628,6 +646,23 @@ func TestNewParsePipeline_JSON(t *testing.T) {
 					"utf8.parsed.response_time":    nil,
 					"utf8.parsed.user_id":          "123",
 					"utf8.parsed.user_profile_age": "25",
+				},
+			},
+		},
+		{
+			name: "duplicate field name takes first value",
+			schema: arrow.NewSchema([]arrow.Field{
+				semconv.FieldFromFQN("utf8.builtin.message", true),
+			}, nil),
+			input: arrowtest.Rows{
+				{colMsg: `{"app": "foo", "app": "duplicate"}`},
+			},
+			requestedKeys:  nil, // Extract all keys
+			expectedFields: 2,   // message, app
+			expectedOutput: arrowtest.Rows{
+				{
+					colMsg:            `{"app": "foo", "app": "duplicate"}`,
+					"utf8.parsed.app": "foo",
 				},
 			},
 		},

--- a/pkg/logql/log/parser_test.go
+++ b/pkg/logql/log/parser_test.go
@@ -57,7 +57,8 @@ func Test_jsonParser_Parse(t *testing.T) {
 			},
 			NoParserHints(),
 		},
-		{"numeric",
+		{
+			"numeric",
 			[]byte(`{"counter":1, "price": {"_net_":5.56909}}`),
 			labels.EmptyLabels(),
 			labels.FromStrings("counter", "1",
@@ -662,6 +663,18 @@ func TestJSONExpressionParser(t *testing.T) {
 			labels.FromStrings("foo", "bar"),
 			labels.FromStrings("foo", "bar",
 				"app", `{"name":"great \"loki\""}`,
+			),
+			NoParserHints(),
+		},
+		{
+			"duplicate field name takes first value",
+			[]byte(`{"app":"foo","app":"duplicate"}`),
+			[]LabelExtractionExpr{
+				NewLabelExtractionExpr("app", `app`),
+			},
+			labels.FromStrings("foo", "bar"),
+			labels.FromStrings("foo", "bar",
+				"app", "foo",
 			),
 			NoParserHints(),
 		},
@@ -1428,7 +1441,6 @@ func TestLogfmtConsistentPrecedence(t *testing.T) {
 		require.Equal(t, ParsedLabel, cat)
 		require.True(t, ok)
 	})
-
 }
 
 func TestLogfmtExpressionParser(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Aligns the old and new engines to use first-win semantics for duplicates when parsing log lines.
* Switch to first-wins in new engine for logfmt & json
* Add tests for first-wins to the json parser in the old engine (logfmt already had one)

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/loki-private/issues/2038

**Checklist**
- [x] Tests updated
