### PR TITLE
chore: Use Kafka round-robin balancer for index-builder

### DIFF
--- a/pkg/dataobj/index/builder.go
+++ b/pkg/dataobj/index/builder.go
@@ -176,6 +176,7 @@ func NewIndexBuilder(
 		kgo.InstanceID(instanceID),
 		kgo.SessionTimeout(3*time.Minute),
 		kgo.ConsumerGroup(indexConsumerGroup),
+		kgo.Balancers(kgo.RoundRobinBalancer()),
 		kgo.RebalanceTimeout(5*time.Minute),
 		kgo.DisableAutoCommit(),
 		kgo.OnPartitionsRevoked(s.handlePartitionsRevoked),


### PR DESCRIPTION
**What this PR does / why we need it**:
The index-builder partitions are computed statically as [dataobj-consumer partition / 10], so consumer pods 0-9 write index events to index topic 0, pods 10-19 use partition 1, etc.

This means scaling of index-builders, and therefore reshuffling of topics, is rare. Round-robin should be perfectly fine for this case, and it makes partition assignment predicatable and the load will be even between running pods.
