### PR TITLE
chore(helm): bump loki version

### DIFF
--- a/docs/sources/setup/install/helm/reference.md
+++ b/docs/sources/setup/install/helm/reference.md
@@ -3913,7 +3913,7 @@ null
     "pullPolicy": "IfNotPresent",
     "registry": "docker.io",
     "repository": "grafana/enterprise-logs",
-    "tag": "3.5.5"
+    "tag": "3.5.7"
   },
   "license": {
     "contents": "NOTAVALIDLICENSE"
@@ -4060,7 +4060,7 @@ null
 			<td>string</td>
 			<td>Docker image tag</td>
 			<td><pre lang="json">
-"3.5.5"
+"3.5.7"
 </pre>
 </td>
 		</tr>

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: loki
 description: Helm chart for Grafana Loki and Grafana Enterprise Logs supporting monolithic, simple scalable, and microservices modes.
 type: application
-appVersion: 3.5.5
+appVersion: 3.5.7
 version: 6.43.0
 home: https://grafana.github.io/helm-charts
 sources:

--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -1,6 +1,6 @@
 # loki
 
-![Version: 6.43.0](https://img.shields.io/badge/Version-6.43.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.5.5](https://img.shields.io/badge/AppVersion-3.5.5-informational?style=flat-square)
+![Version: 6.43.0](https://img.shields.io/badge/Version-6.43.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.5.7](https://img.shields.io/badge/AppVersion-3.5.7-informational?style=flat-square)
 
 Helm chart for Grafana Loki and Grafana Enterprise Logs supporting monolithic, simple scalable, and microservices modes.
 

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -662,7 +662,7 @@ enterprise:
     # -- Docker image repository
     repository: grafana/enterprise-logs
     # -- Docker image tag
-    tag: 3.5.5
+    tag: 3.5.7
     # -- Overrides the image tag with an image digest
     digest: null
     # -- Docker image pull policy


### PR DESCRIPTION
**What this PR does / why we need it**:
Bumps the Loki version for the next Helm Charts release (CI to do this failed)