### PR TITLE
docs: Update docker-compose installation to use alloy instead of promtail

### DIFF
--- a/docs/sources/setup/install/docker.md
+++ b/docs/sources/setup/install/docker.md
@@ -98,12 +98,12 @@ Run the following commands in your command line. They work for Windows or Linux 
     cd loki
     ```
 
-1. Copy and paste the following commands into your command line to download the `docker-compose.yaml` and `alloy-local-config.yaml` files.
+1. Copy and paste the following commands into your command line to download the `docker-compose.yaml` and `alloy-local-config.yaml` files.  Update the version number to match your version of Loki.
 
     ```bash
-    wget https://raw.githubusercontent.com/grafana/loki/v3.4.1/examples/getting-started/docker-compose.yaml -O docker-compose.yaml
-    wget https://raw.githubusercontent.com/grafana/loki/v3.4.1/examples/getting-started/alloy-local-config.yaml -O alloy-local-config.yaml
-    wget https://raw.githubusercontent.com/grafana/loki/v3.4.1/examples/getting-started/loki-config.yaml -O loki-config.yaml
+    wget https://raw.githubusercontent.com/grafana/loki/v3.5.7/examples/getting-started/docker-compose.yaml -O docker-compose.yaml
+    wget https://raw.githubusercontent.com/grafana/loki/v3.5.7/examples/getting-started/alloy-local-config.yaml -O alloy-local-config.yaml
+    wget https://raw.githubusercontent.com/grafana/loki/v3.5.7/examples/getting-started/loki-config.yaml -O loki-config.yaml
     ```
 
 1. With `loki` as the current working directory, run the following 'docker-compose` command:


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #19567


**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
