### PR TITLE
chore: fix dataset reader failures to fill

### DIFF
--- a/pkg/dataobj/internal/dataset/reader_basic.go
+++ b/pkg/dataobj/internal/dataset/reader_basic.go
@@ -204,7 +204,9 @@ func (pr *basicReader) fill(ctx context.Context, columns []Column, s []Row) (n i
 		// We check for atEOF here instead of maxRead == 0 to preserve the pattern
 		// of io.Reader: readers may return 0, nil even when they're not at EOF.
 		if maxRead == 0 && atEOF {
-			return n, io.EOF
+			// It is possible that all the columns being filled have fewer rows than max rows in the dataset.
+			// Setting maxRead to len(s)-n so the following loop can fill the remaining rows with NULLs.
+			maxRead = len(s) - n
 		}
 
 		// Some columns may have read fewer rows than maxRead. These columns need

--- a/pkg/dataobj/sections/logs/reader.go
+++ b/pkg/dataobj/sections/logs/reader.go
@@ -261,7 +261,7 @@ func (r *Reader) init(ctx context.Context) error {
 	innerOptions := dataset.ReaderOptions{
 		Dataset:    dset,
 		Columns:    dset.Columns(),
-		Predicates: orderPredicates(preds),
+		Predicates: preds,
 		Prefetch:   true,
 	}
 	if r.inner == nil {

--- a/pkg/dataobj/sections/logs/reader.go
+++ b/pkg/dataobj/sections/logs/reader.go
@@ -259,8 +259,14 @@ func (r *Reader) init(ctx context.Context) error {
 	r.stats.LinkGlobalStats(stats.FromContext(ctx))
 
 	innerOptions := dataset.ReaderOptions{
-		Dataset:    dset,
-		Columns:    dset.Columns(),
+		Dataset: dset,
+		Columns: dset.Columns(),
+		// TODO(ashwanth): Ordering of predicate by selectivity and cost is currently disabled.
+		// This optimization can cause issues when a selective predicate operates on
+		// a column that has fewer rows than the dataset's max row count. In such cases,
+		// the predicate would limit the total number of rows we can read, even though other
+		// columns might have more data available.
+		// Predicates: orderPredicates(preds),
 		Predicates: preds,
 		Prefetch:   true,
 	}

--- a/pkg/engine/internal/executor/dataobjscan.go
+++ b/pkg/engine/internal/executor/dataobjscan.go
@@ -12,6 +12,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/apache/arrow-go/v18/arrow/scalar"
+	"github.com/go-kit/kit/log/level"
 	"github.com/go-kit/log"
 
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/logs"
@@ -349,6 +350,7 @@ NextProjection:
 func (s *dataobjScan) read(ctx context.Context) (arrow.Record, error) {
 	rec, err := s.reader.Read(ctx, int(s.opts.BatchSize))
 	if err != nil && !errors.Is(err, io.EOF) {
+		level.Error(s.logger).Log("msg", "error reading logs section", "err", err)
 		return nil, err
 	} else if (rec == nil || rec.NumRows() == 0) && errors.Is(err, io.EOF) {
 		return nil, EOF

--- a/pkg/engine/internal/executor/dataobjscan.go
+++ b/pkg/engine/internal/executor/dataobjscan.go
@@ -12,8 +12,8 @@ import (
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/apache/arrow-go/v18/arrow/scalar"
-	"github.com/go-kit/kit/log/level"
 	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/logs"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/streams"


### PR DESCRIPTION
**What this PR does / why we need it**:

Logs dataset encoder does not backfill trailing nulls in a column, as a result some of the columns can have fewer rows than max rows in the dataset. [Reader handles this by filling such columns with NULLs](https://github.com/grafana/loki/blob/5b7c3390043bdab9e803b16990e6cf32416ecc8e/pkg/dataobj/internal/dataset/reader_basic.go#L212-L216), but it misses the case where all the columns being filled have fewer rows than max rows of the dataset.

This is also removing the reordering of predicates by selectivity as it could bring forth a column with fewer rows to be evaluated first causing fewer rows to be read even if other predicate columns have rows to be read. This needs to be enabled back with a proper fix once label filters are being pushdown down to dataset reader.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
