### PR TITLE
chore: Fix page skipping with empty predicates

### DIFF
--- a/pkg/dataobj/internal/dataset/reader.go
+++ b/pkg/dataobj/internal/dataset/reader.go
@@ -364,7 +364,7 @@ func buildMask(full rowRange, s []Row) iter.Seq[rowRange] {
 			return
 		}
 
-		var start = full.Start
+		start := full.Start
 
 		for _, row := range s {
 			if !full.Contains(uint64(row.Index)) {
@@ -824,7 +824,8 @@ func (r *Reader) buildColumnPredicateRanges(ctx context.Context, c Column, p Pre
 
 		switch p := p.(type) {
 		case EqualPredicate: // EqualPredicate may be true if p.Value is inside the range of the page.
-			include = CompareValues(&p.Value, &minValue) >= 0 && CompareValues(&p.Value, &maxValue) <= 0
+			isEmpty := p.Value.Type() == datasetmd.PHYSICAL_TYPE_BINARY && p.Value.IsZero()
+			include = isEmpty || (CompareValues(&p.Value, &minValue) >= 0 && CompareValues(&p.Value, &maxValue) <= 0)
 		case GreaterThanPredicate: // GreaterThanPredicate may be true if maxValue of a page is greater than p.Value
 			include = CompareValues(&maxValue, &p.Value) > 0
 		case LessThanPredicate: // LessThanPredicate may be true if minValue of a page is less than p.Value


### PR DESCRIPTION
**What this PR does / why we need it**:
This fixes the page skipping behaviour when using an empty predicate.
In LogQL, an empty predicate of the form `{key=""}` matches on both an exact match for the key being an empty string (`""`), plus if that column does not exist (effectively `null`).

* This PR fixes a bug in the page skipping to explicitly include pages if the predicate is the empty string, in order to support the "column does not exist" case. 
* Previously, a page containing data in other rows but a null value for the predicate row would be skipped because the empty string was not between the min & max values present in the page. 

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/loki-private/issues/2050

**Special notes for your reviewer**:

**Checklist**
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
