### PR TITLE
chore: ensure proto codec registration

### DIFF
--- a/cmd/loki/main.go
+++ b/cmd/loki/main.go
@@ -8,6 +8,19 @@ import (
 	"runtime"
 	"time"
 
+	// The go.opentelemetry.io/collector/pdata/internal/grpcencoding package
+	// registers its own encoding for proto, falling back to the existing proto
+	// encoding for non-OTLP messages.
+	//
+	// However, if no proto encoding has been registered, the fallback mechanism
+	// will panic. This can happen depending on import order, as encodings are
+	// registered via init functions. To avoid this, we force the correct import
+	// order by keeping this as the very first import.
+	//
+	// This import can be removed once the grpcencoding package includes this
+	// import itself.
+	_ "google.golang.org/grpc/encoding/proto"
+
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/log"
 	"github.com/grafana/dskit/tracing"


### PR DESCRIPTION
open-telemetry/opentelemetry-collector#13719 introduced a custom codec implementation for protobuf messages that falls back to the "default" codec for unsupported message types.

However, the "default" codec is only defined when
google.golang.org/grpc/encoding/proto is imported prior to the grpcencoding package.

If the import order is incorrect, then unmarshaling gRPC messages will panic. Ideally, the grpcencoding package should provide import the dfeault codec itself to avoid this issue. In the meantime, we can work around the mistake by importing the codec as the first non-stdlib import in our main package.