### PR TITLE
docs: update note in labels topic

### DIFF
--- a/docs/sources/get-started/labels/_index.md
+++ b/docs/sources/get-started/labels/_index.md
@@ -44,7 +44,7 @@ Loki automatically tries to populate a default `service_name` label while ingest
 - Grafana Cloud Application Observability
 
 {{< admonition type="note" >}}
-If you are already applying a `service_name`, Loki will use that value.
+If you are already applying a `service_name`, Loki will use that value. For example, if you are using the Kubernetes monitoring Helm Chart, the Alloy configuration applies a `service_name` by default.
 {{< /admonition >}}
 
 Loki will attempt to create the `service_name` label by looking for the following labels in this order:


### PR DESCRIPTION
**What this PR does / why we need it**:

Clarifies that in k8s, service_name is already applied by default with the alloy configuration

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/support-escalations/issues/18953

