### PR TITLE
fix: do not validate limits service configuration if service is disabled

### DIFF
--- a/pkg/limits/config.go
+++ b/pkg/limits/config.go
@@ -107,26 +107,30 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 }
 
 func (cfg *Config) Validate() error {
+	if !cfg.Enabled {
+		// Do not validate configuration if disabled.
+		return nil
+	}
 	if cfg.ActiveWindow <= 0 {
-		return errors.New("active-window must be greater than 0")
+		return errors.New("active window must be greater than 0")
 	}
 	if cfg.RateWindow <= 0 {
-		return errors.New("rate-window must be greater than 0")
+		return errors.New("rate window must be greater than 0")
 	}
 	if cfg.BucketSize <= 0 {
-		return errors.New("bucket-size must be greater than 0")
+		return errors.New("bucket size must be greater than 0")
 	}
 	if cfg.RateWindow%cfg.BucketSize != 0 {
-		return errors.New("rate-window must be a multiple of bucket-size")
+		return errors.New("rate window must be a multiple of bucket-size")
 	}
 	if cfg.EvictionInterval <= 0 {
-		return errors.New("eviction-interval must be greater than 0")
+		return errors.New("eviction interval must be greater than 0")
 	}
 	if cfg.NumPartitions <= 0 {
-		return errors.New("num-partitions must be greater than 0")
+		return errors.New("num partitions must be greater than 0")
 	}
 	if cfg.ConsumerGroup == "" {
-		return errors.New("consumer-group must be set")
+		return errors.New("consumer group must be set")
 	}
 	if cfg.Topic == "" {
 		return errors.New("topic must be set")


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request updates the validation for the limits service to skip validation if the service is disabled.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
