### PR TITLE
feat: add enabled flag for dataobjs

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -1342,6 +1342,10 @@ dataobj:
   # CLI flag: -dataobj-storage-bucket-prefix
   [storage_bucket_prefix: <string> | default = "dataobj/"]
 
+  # Enable data objects.
+  # CLI flag: -dataobj.enabled
+  [enabled: <boolean> | default = false]
+
 ingest_limits:
   # Enable the ingest limits service.
   # CLI flag: -ingest-limits.enabled

--- a/pkg/dataobj/config/config.go
+++ b/pkg/dataobj/config/config.go
@@ -14,16 +14,32 @@ type Config struct {
 	Metastore metastore.Config `yaml:"metastore"`
 	// StorageBucketPrefix is the prefix to use for the storage bucket.
 	StorageBucketPrefix string `yaml:"storage_bucket_prefix"`
+	Enabled             bool   `yaml:"enabled"`
 }
 
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	cfg.Consumer.RegisterFlags(f)
 	cfg.Index.RegisterFlags(f)
 	cfg.Metastore.RegisterFlags(f)
-	f.StringVar(&cfg.StorageBucketPrefix, "dataobj-storage-bucket-prefix", "dataobj/", "The prefix to use for the storage bucket.")
+	f.StringVar(
+		&cfg.StorageBucketPrefix,
+		"dataobj-storage-bucket-prefix",
+		"dataobj/",
+		"The prefix to use for the storage bucket.",
+	)
+	f.BoolVar(
+		&cfg.Enabled,
+		"dataobj.enabled",
+		false,
+		"Enable data objects.",
+	)
 }
 
 func (cfg *Config) Validate() error {
+	if !cfg.Enabled {
+		// Do not validate configuration if disabled.
+		return nil
+	}
 	if err := cfg.Consumer.Validate(); err != nil {
 		return err
 	}

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -2134,7 +2134,7 @@ func (t *Loki) initUI() (services.Service, error) {
 }
 
 func (t *Loki) initDataObjConsumerRing() (_ services.Service, err error) {
-	if !t.Cfg.Ingester.KafkaIngestion.Enabled {
+	if !t.Cfg.DataObj.Enabled {
 		return nil, nil
 	}
 
@@ -2160,7 +2160,7 @@ func (t *Loki) initDataObjConsumerRing() (_ services.Service, err error) {
 }
 
 func (t *Loki) initDataObjConsumerPartitionRing() (services.Service, error) {
-	if !t.Cfg.Ingester.KafkaIngestion.Enabled {
+	if !t.Cfg.DataObj.Enabled {
 		return nil, nil
 	}
 	kvClient, err := kv.NewClient(
@@ -2198,7 +2198,7 @@ func (t *Loki) initDataObjConsumerPartitionRing() (services.Service, error) {
 }
 
 func (t *Loki) initDataObjConsumer() (services.Service, error) {
-	if !t.Cfg.Ingester.KafkaIngestion.Enabled {
+	if !t.Cfg.DataObj.Enabled {
 		return nil, nil
 	}
 	store, err := t.createDataObjBucket("dataobj-consumer")
@@ -2236,7 +2236,7 @@ func (t *Loki) initDataObjConsumer() (services.Service, error) {
 }
 
 func (t *Loki) initDataObjIndexBuilder() (services.Service, error) {
-	if !t.Cfg.Ingester.KafkaIngestion.Enabled {
+	if !t.Cfg.DataObj.Enabled {
 		return nil, nil
 	}
 	store, err := t.createDataObjBucket("dataobj-index-builder")


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit adds a separate enabled flag for dataobjs so they can be enabled and disabled independently of kafka ingestion.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
