### PR TITLE
chore: stream injector: propagate orig error

### DIFF
--- a/pkg/engine/internal/executor/stream_injector.go
+++ b/pkg/engine/internal/executor/stream_injector.go
@@ -85,7 +85,7 @@ func (si *streamInjector) Inject(ctx context.Context, in arrow.Record) (arrow.Re
 		// label column all at once.
 		it, err := si.view.Labels(ctx, findID)
 		if err != nil {
-			return nil, fmt.Errorf("stream ID %d not found in section", findID)
+			return nil, err
 		}
 
 		for label := range it {


### PR DESCRIPTION
**What this PR does / why we need it**:

`Labels` call can also read the streams section to init ID mapping. We currently log any errors from `Labels` call as missing stream ID mapping which is misleading. It is possible that the reading is context cancelled, so the original error should either be returned as is or wrapped.

I removed `stream ID %d not found in section` error as `Labels` call [already returns it if an ID is missing](https://github.com/grafana/loki/blob/aad193c43dc8fe53178518616a74d6b4db4077bc/pkg/engine/internal/executor/streams_view.go#L100).



**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
