### PR TITLE
docs: Update variable formatting (#19610)

### DIFF
--- a/docs/sources/alert/_index.md
+++ b/docs/sources/alert/_index.md
@@ -304,16 +304,16 @@ The [Cortex rules action](https://github.com/grafana/cortex-rules-action) introd
   uses: grafana/cortex-rules-action@master
   env:
     ACTION: check
-    RULES_DIR: <source_dir_of_rules> # Example: logs/recording_rules/,logs/alerts/
+    RULES_DIR: <SOURCE_DIR_OF_RULES> # Example: logs/recording_rules/,logs/alerts/
     BACKEND: loki
 
 - name: Deploy rules to Loki staging
   uses: grafana/cortex-rules-action@master
   env:
-    CORTEX_ADDRESS: <loki_ingress_addr>
+    CORTEX_ADDRESS: <LOKI_INGRESS_ADDR>
     CORTEX_TENANT_ID: fake
     ACTION: sync
-    RULES_DIR: <source_dir_of_rules> # Example: logs/recording_rules/,logs/alerts/
+    RULES_DIR: <SOURCE_DIR_OF_RULES> # Example: logs/recording_rules/,logs/alerts/
     BACKEND: loki
 ```
 
@@ -327,7 +327,7 @@ A full sharding-enabled Ruler example is:
 
 ```yaml
 ruler:
-  alertmanager_url: <alertmanager_endpoint>
+  alertmanager_url: <ALERTMANAGER_ENDPOINT>
   enable_alertmanager_v2: true # true by default since Loki 3.2.0
   enable_api: true
   enable_sharding: true
@@ -339,7 +339,7 @@ ruler:
   rule_path: /tmp/rules
   storage:
     gcs:
-      bucket_name: <loki-rules-bucket>
+      bucket_name: <LOKI_RULES_BUCKET>
 ```
 
 ## Ruler storage

--- a/docs/sources/community/maintaining/release/patch-vulnerabilities.md
+++ b/docs/sources/community/maintaining/release/patch-vulnerabilities.md
@@ -43,7 +43,7 @@ Before start patching vulnerabilities, know what are you patching. It can be one
 	1. Check if [dependabot already patched the dependency](https://github.com/grafana/loki/pulls?q=is%3Apr+label%3Adependencies+is%3Aclosed) or [have a PR opened to patch](https://github.com/grafana/loki/pulls?q=is%3Apr+is%3Aopen+label%3Adependencies) . If not, manually upgrade the package on the `main` branch as follows.
 
 		```shell
-		go get -u -v <package-path>@<patched-version>
+		go get -u -v <PACKAGE_PATH>@<PATCHED_VERSION>
 		go mod tidy
 		go mod vendor
 		```

--- a/docs/sources/reference/loki-http-api.md
+++ b/docs/sources/reference/loki-http-api.md
@@ -275,7 +275,7 @@ For information on how to configure Loki, refer to the [OTel Collector topic](ht
 
 <!-- vale Google.Will = NO -->
 {{< admonition type="note" >}}
-When configuring the OpenTelemetry Collector, you must use `endpoint: http://<loki-addr>/otlp`, as the collector automatically completes the endpoint.  Entering the full endpoint will generate an error.
+When configuring the OpenTelemetry Collector, you must use `endpoint: http://<LOKI_ADDR>/otlp`, as the collector automatically completes the endpoint.  Entering the full endpoint will generate an error.
 {{< /admonition >}}
 <!-- vale Google.Will = YES -->
 
@@ -451,7 +451,7 @@ To query against your hosted log tenant in Grafana Cloud, use the **User** and *
 
 ```bash
 curl -u "User:$API_TOKEN" \
-  -G -s "<URL-PROVIDED-IN-LOKI-DATA-SOURCE-SETTINGS>/loki/api/v1/query" \
+  -G -s "<URL_PROVIDED_IN_LOKI_DATA_SOURCE_SETTINGS>/loki/api/v1/query" \
   --data-urlencode 'query=sum(rate({job="varlogs"}[10m])) by (level)' | jq
 ```
 
@@ -1440,8 +1440,8 @@ Example cURL command:
 
 ```bash
 curl -X GET \
-  <compactor_addr>/loki/api/v1/delete \
-  -H 'X-Scope-OrgID: <orgid>'
+  <COMPACTOR_ADDR>/loki/api/v1/delete \
+  -H 'X-Scope-OrgID: <ORG_ID>'
 ```
 
 The same example deletion request for Grafana Enterprise Logs uses Basic Authentication and specifies the tenant name as a user; `Tenant1` is the tenant name in this example. The password in this example is an access policy token that has been defined in the API_TOKEN environment variable. The token must be for an access policy with `logs:delete` scope for the tenant specified in the user field.
@@ -1449,7 +1449,7 @@ The same example deletion request for Grafana Enterprise Logs uses Basic Authent
 ```bash
 curl -u "Tenant1:$API_TOKEN" \
   -X GET \
-  <compactor_addr>/loki/api/v1/delete
+  <COMPACTOR_ADDR>/loki/api/v1/delete
 ```
 
 ### Request cancellation of a delete request
@@ -1487,8 +1487,8 @@ Example cURL command:
 
 ```bash
 curl -X DELETE \
-  '<compactor_addr>/loki/api/v1/delete?request_id=<request_id>' \
-  -H 'X-Scope-OrgID: <tenant-id>'
+  '<COMPACTOR_ADDR>/loki/api/v1/delete?request_id=<REQUEST_ID>' \
+  -H 'X-Scope-OrgID: <TENANT_ID>'
 ```
 
 The same example deletion cancellation request for Grafana Enterprise Logs uses Basic Authentication and specifies the tenant name as a user; `Tenant1` is the tenant name in this example. The password in this example is an access policy token that has been defined in the API_TOKEN environment variable. The token must be for an access policy with `logs:delete` scope for the tenant specified in the user field.
@@ -1496,7 +1496,7 @@ The same example deletion cancellation request for Grafana Enterprise Logs uses 
 ```bash
 curl -u "Tenant1:$API_TOKEN" \
   -X DELETE \
-  '<compactor_addr>/loki/api/v1/delete?request_id=<request_id>'
+  '<COMPACTOR_ADDR>/loki/api/v1/delete?request_id=<REQUEST_ID>'
 ```
 
 ## Format a LogQL query

--- a/docs/sources/setup/install/helm/deployment-guides/aws.md
+++ b/docs/sources/setup/install/helm/deployment-guides/aws.md
@@ -61,8 +61,8 @@ apiVersion: eksctl.io/v1alpha5
 kind: ClusterConfig
 
 metadata:
-  name: <INSERT-CLUSTER-NAME>
-  region: <INSERT-REGION-FOR-CLUSTER>
+  name: <INSERT_CLUSTER_NAME>
+  region: <INSERT_REGION_FOR_CLUSTER>
   version: "1.31"
 
 iam:

--- a/docs/sources/setup/install/helm/install-scalable/_index.md
+++ b/docs/sources/setup/install/helm/install-scalable/_index.md
@@ -148,15 +148,15 @@ loki:
       # s3 URL can be used to specify the endpoint, access key, secret key, and bucket name this works well for S3 compatible storages or if you are hosting Loki on-premises and want to use S3 as the storage backend. Either use the s3 URL or the individual fields below (AWS endpoint, region, secret).
       s3: s3://access_key:secret_access_key@custom_endpoint/bucket_name
       # AWS endpoint URL
-      endpoint: <your-endpoint>
+      endpoint: <YOUR_ENDPOINT>
       # AWS region where the S3 bucket is located
-      region: <your-region>
+      region: <YOUR_REGION>
       # AWS secret access key
-      secretAccessKey: <your-secret-access-key>
+      secretAccessKey: <YOUR_SECRET_ACCESS_KEY>
       # AWS access key ID
-      accessKeyId: <your-access-key-id>
+      accessKeyId: <YOUR_ACCESS_KEY_ID>
       # AWS signature version (e.g., v2 or v4)
-      signatureVersion: <your-signature-version>
+      signatureVersion: <YOUR_SIGNATURE_VERSION>
       # Forces the path style for S3 (true/false)
       s3ForcePathStyle: false
       # Allows insecure (HTTP) connections (true/false)
@@ -205,21 +205,21 @@ loki:
     type: azure
     azure:
       # Name of the Azure Blob Storage account
-      accountName: <your-account-name>
+      accountName: <YOUR_ACCOUNT_NAME>
       # Key associated with the Azure Blob Storage account
-      accountKey: <your-account-key>
+      accountKey: <YOUR_ACCOUNT_KEY>
       # Comprehensive connection string for Azure Blob Storage account (Can be used to replace endpoint, accountName, and accountKey)
-      connectionString: <your-connection-string>
+      connectionString: <YOUR_CONNECTION_STRING>
       # Flag indicating whether to use Azure Managed Identity for authentication
       useManagedIdentity: false
       # Flag indicating whether to use a federated token for authentication
       useFederatedToken: false
       # Client ID of the user-assigned managed identity (if applicable)
-      userAssignedId: <your-user-assigned-id>
+      userAssignedId: <YOUR_USER_ASSIGNED_ID>
       # Timeout duration for requests made to the Azure Blob Storage account (in seconds)
-      requestTimeout: <your-request-timeout>
+      requestTimeout: <YOUR_REQUEST_TIMEOUT>
       # Domain suffix of the Azure Blob Storage service endpoint (e.g., core.windows.net)
-      endpointSuffix: <your-endpoint-suffix>
+      endpointSuffix: <YOUR_ENDPOINT_SUFFIX>
     bucketNames:
       chunks: "chunks"
       ruler: "ruler"


### PR DESCRIPTION
(cherry picked from commit 34f5ae3cd875ab599e93e657ccfbfb5f7cdcb22e) to 3.4 branch
Backports replacement variable formatting.
Also adds workaround for a breaking change in the Helm Chart.

