### PR TITLE
fix: Nomad simple example

### DIFF
--- a/production/nomad/loki-simple/README.md
+++ b/production/nomad/loki-simple/README.md
@@ -22,7 +22,7 @@ To deploy a different version change `variable.version` default value or specify
 from command line:
 
 ```shell
-nomad job run -var="version=2.7.5" job.nomad.hcl
+nomad job run -var="version=3.5.7" job.nomad.hcl
 ```
 
 ### Scale Loki

--- a/production/nomad/loki-simple/config.yml
+++ b/production/nomad/loki-simple/config.yml
@@ -9,6 +9,8 @@ common:
   replication_factor: 1
   # Tell Loki which address to advertise
   instance_addr: {{ env "NOMAD_IP_grpc" }}
+  # Add the compactor address
+  compactor_address: http://loki-backend.service.consul
   ring:
     # Tell Loki which address to advertise in ring
     instance_addr: {{ env "NOMAD_IP_grpc" }}
@@ -35,7 +37,7 @@ schema_config:
       period: 24h
 
 storage_config:
-  boltdb_shipper:
+  tsdb_shipper:
     # Nomad ephemeral disk is used to store index and cache
     # it will try to preserve /alloc/data between job updates
     active_index_directory: {{ env "NOMAD_ALLOC_DIR" }}/data/index


### PR DESCRIPTION
**What this PR does / why we need it**:
The production/nomad/nomad-simple directory was having trouble working out of the box on the newer version `3.5.7`
**Which issue(s) this PR fixes**:
Fixes #14803

**Special notes for your reviewer**:
This is a small PR, I have it running on the following nomad cluster, I still have a few doubts about the `compactor_address`  config for this
Nomad:  `v1.8.1`
Consul :  `v1.18.2`


**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [X] Documentation added
- [ ] ~~Tests updated~~ Not needed
- [X] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [X] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [X] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
