### PR TITLE
docs: Update link to Tanka installation documentation

### DIFF
--- a/production/ksonnet/README.md
+++ b/production/ksonnet/README.md
@@ -1,6 +1,6 @@
 # Deploy Loki to Kubernetes
 
-See the [Tanka Installation Docs](../../docs/sources/installation/tanka.md)
+See the [Tanka Installation Docs](../../docs/sources/setup/install/tanka.md)
 
 ##  Multizone ingesters
 To use multizone ingesters use following config fields

--- a/production/ksonnet/loki-simple-scalable/example/README.md
+++ b/production/ksonnet/loki-simple-scalable/example/README.md
@@ -2,7 +2,7 @@
 
 
 ## Usage
-1) Setup Tanka see the [Tanka Installation Docs](../../../../docs/sources/installation/tanka.md).
+1) Setup Tanka see the [Tanka Installation Docs](../../../../docs/sources/setup/install/tanka.md).
 2) Next, you'll need to install Jsonnet library for SSD.
 ```bash
 jb install github.com/grafana/loki/production/ksonnet/loki-simple-scalable@main


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes broken links to tanka installation docs 