### PR TITLE
fix: Implement strict & keep-empty mode for logfmt parsing

### DIFF
--- a/pkg/engine/internal/planner/logical/builder.go
+++ b/pkg/engine/internal/planner/logical/builder.go
@@ -39,11 +39,13 @@ func (b *Builder) Limit(skip uint32, fetch uint32) *Builder {
 }
 
 // Parse applies a [Parse] operation to the Builder.
-func (b *Builder) Parse(kind ParserKind) *Builder {
+func (b *Builder) Parse(kind ParserKind, strict bool, keepEmpty bool) *Builder {
 	return &Builder{
 		val: &Parse{
-			Table: b.val,
-			Kind:  kind,
+			Table:     b.val,
+			Kind:      kind,
+			Strict:    strict,
+			KeepEmpty: keepEmpty,
 		},
 	}
 }

--- a/pkg/engine/internal/planner/logical/node_parse.go
+++ b/pkg/engine/internal/planner/logical/node_parse.go
@@ -30,8 +30,10 @@ func (p ParserKind) String() string {
 type Parse struct {
 	id string
 
-	Table Value // The table relation to parse from
-	Kind  ParserKind
+	Table     Value      // The table relation to parse from
+	Kind      ParserKind
+	Strict    bool       // Strict mode: fail parsing on first error
+	KeepEmpty bool       // KeepEmpty mode: retain empty values
 }
 
 // Name returns an identifier for the Parse operation.

--- a/pkg/engine/internal/planner/physical/optimizer_test.go
+++ b/pkg/engine/internal/planner/physical/optimizer_test.go
@@ -623,7 +623,7 @@ func TestProjectionPushdown_PushesRequestedKeysToParseNodes(t *testing.T) {
 				})
 
 				// Add parse but no filters requiring parsed fields
-				builder = builder.Parse(logical.ParserLogfmt)
+				builder = builder.Parse(logical.ParserLogfmt, false, false)
 				return builder.Value()
 			},
 		},
@@ -643,7 +643,7 @@ func TestProjectionPushdown_PushesRequestedKeysToParseNodes(t *testing.T) {
 				})
 
 				// Don't set RequestedKeys here - optimization should determine them
-				builder = builder.Parse(logical.ParserLogfmt)
+				builder = builder.Parse(logical.ParserLogfmt, false, false)
 
 				// Add filter with ambiguous column
 				filterExpr := &logical.BinOp{
@@ -670,7 +670,7 @@ func TestProjectionPushdown_PushesRequestedKeysToParseNodes(t *testing.T) {
 					Shard: logical.NewShard(0, 1),
 				})
 
-				builder = builder.Parse(logical.ParserLogfmt)
+				builder = builder.Parse(logical.ParserLogfmt, false, false)
 
 				// Add filter on label column (should be skipped)
 				labelFilter := &logical.BinOp{
@@ -714,7 +714,7 @@ func TestProjectionPushdown_PushesRequestedKeysToParseNodes(t *testing.T) {
 					Shard: logical.NewShard(0, 1),
 				})
 
-				builder = builder.Parse(logical.ParserLogfmt)
+				builder = builder.Parse(logical.ParserLogfmt, false, false)
 
 				// Range aggregation with PartitionBy
 				builder = builder.RangeAggregation(
@@ -749,7 +749,7 @@ func TestProjectionPushdown_PushesRequestedKeysToParseNodes(t *testing.T) {
 				})
 
 				// Don't set RequestedKeys here - optimization should determine them
-				builder = builder.Parse(logical.ParserLogfmt)
+				builder = builder.Parse(logical.ParserLogfmt, false, false)
 
 				// Add filter with ambiguous column
 				filterExpr := &logical.BinOp{

--- a/pkg/engine/internal/planner/physical/parse.go
+++ b/pkg/engine/internal/planner/physical/parse.go
@@ -11,6 +11,8 @@ type ParseNode struct {
 	id            string
 	Kind          ParserKind
 	RequestedKeys []string
+	Strict        bool // Strict mode: fail parsing on first error
+	KeepEmpty     bool // KeepEmpty mode: retain empty values
 }
 
 // ParserKind represents the type of parser to use
@@ -46,6 +48,8 @@ func (n *ParseNode) Clone() Node {
 	return &ParseNode{
 		Kind:          n.Kind,
 		RequestedKeys: slices.Clone(n.RequestedKeys),
+		Strict:        n.Strict,
+		KeepEmpty:     n.KeepEmpty,
 	}
 }
 

--- a/pkg/engine/internal/planner/physical/planner.go
+++ b/pkg/engine/internal/planner/physical/planner.go
@@ -546,7 +546,9 @@ func (p *Planner) processUnaryOp(lp *logical.UnaryOp, ctx *Context) (Node, error
 // A ParseNode initially has an empty list of RequestedKeys which will be populated during optimization.
 func (p *Planner) processParse(lp *logical.Parse, ctx *Context) (Node, error) {
 	var node Node = &ParseNode{
-		Kind: convertParserKind(lp.Kind),
+		Kind:      convertParserKind(lp.Kind),
+		Strict:    lp.Strict,
+		KeepEmpty: lp.KeepEmpty,
 	}
 	p.plan.graph.Add(node)
 

--- a/pkg/engine/internal/planner/physical/planner_test.go
+++ b/pkg/engine/internal/planner/physical/planner_test.go
@@ -270,7 +270,7 @@ func TestPlanner_Convert_WithParse(t *testing.T) {
 				Shard: logical.NewShard(0, 1),
 			},
 		).Parse(
-			logical.ParserLogfmt,
+			logical.ParserLogfmt, false, false,
 		).Select(
 			&logical.BinOp{
 				Left:  logical.NewColumnRef("level", types.ColumnTypeAmbiguous),
@@ -340,7 +340,7 @@ func TestPlanner_Convert_WithParse(t *testing.T) {
 				Shard: logical.NewShard(0, 1),
 			},
 		).Parse(
-			logical.ParserLogfmt,
+			logical.ParserLogfmt, false, false,
 		).Select(
 			&logical.BinOp{
 				Left:  logical.NewColumnRef("level", types.ColumnTypeAmbiguous),


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes logfmt parsing by implementing strict mode
* Previously, the default mode was strict so any error would drop all fields.
* Also implemented keep-empty while I was here

I'm aware of https://github.com/grafana/loki/pull/19579 which is probably conflicting but I couldn't get that PR working in order to build on top of it.

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/loki-private/issues/2058

**Special notes for your reviewer**:

**Checklist**
- [x] Tests updated
