### PR TITLE
fix(helm): Bump Loki chart version to 6.45.1

### DIFF
--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -3,7 +3,7 @@ name: loki
 description: Helm chart for Grafana Loki and Grafana Enterprise Logs supporting monolithic, simple scalable, and microservices modes.
 type: application
 appVersion: 3.5.7
-version: 6.45.0
+version: 6.45.1
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki


### PR DESCRIPTION
Missed one update when generating the Helm Charts

