### PR TITLE
docs: Add docs for config self-serve API

### DIFF
--- a/docs/sources/operations/storage/retention.md
+++ b/docs/sources/operations/storage/retention.md
@@ -187,6 +187,10 @@ The example configurations defined above will result in the following retention 
   - Streams that have the namespace label `dev` will have a retention period of `24h` hours.
   - Streams except those with the namespace label `dev` will have the retention period of `744h`.
 
+{{< admonition type="note" >}}
+If you are a Grafana Cloud customer, you can use the [config self-serve API](https://grafana.com/docs/grafana-cloud/send-data/logs/config-self-serve/#configure-retention) to configure your tenant retention.
+{{< /admonition >}}
+
 ## Table Manager (deprecated)
 
 Retention through the [Table Manager](https://grafana.com/docs/loki/<LOKI_VERSION>/operations/storage/table-manager/) is

--- a/docs/sources/shared/otel.md
+++ b/docs/sources/shared/otel.md
@@ -187,6 +187,6 @@ limits_config:
 ```
 
 {{< admonition type="note" >}}
-If you are a Grafana Cloud customer, open a support escalation listing the Attributes you want to promote to indexed labels, and any additional context.
+If you are a Grafana Cloud customer, you can use the [config self-serve API](https://grafana.com/docs/grafana-cloud/send-data/logs/config-self-serve/#otlp-label-mappings) to configure your OTLP config.
 {{< /admonition >}}
   


### PR DESCRIPTION
**What this PR does / why we need it**:

Link to our cloud docs for configuring otlp_config and retention though the new config self-serve API.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
