### PR TITLE
fix(helm): support global registry override for sidecar

### DIFF
--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -3984,8 +3984,10 @@ extraObjects: null
 
 sidecar:
   image:
-    # -- The Docker registry and image for the k8s sidecar
-    repository: docker.io/kiwigrid/k8s-sidecar
+    # -- The Docker registry for the k8s sidecar
+    registry: docker.io
+    # -- Docker image repository for the k8s sidecar
+    repository: kiwigrid/k8s-sidecar
     # -- Docker image tag
     tag: 1.30.10
     # -- Docker image sha. If empty, no sha will be used


### PR DESCRIPTION
**What this PR does / why we need it**:

Since https://github.com/grafana/loki/pull/19246 the sidecar image would resolve to `<registry-mirror>/docker.io/kiwigrid/k8s-sidecar` when a global registry mirror was defined.

This commit handles the registry properly, the same way as all the other docker hub images.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

I have tested this using `helm template`. Without a global registry the output is unchanged. With a global registry, it is now resolved properly.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
