### PR TITLE
ci: run LogQL correctness tests on applicable PRs

### DIFF
--- a/.github/workflows/logql-correctness.yml
+++ b/.github/workflows/logql-correctness.yml
@@ -29,7 +29,7 @@ jobs:
         id: checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.ref || 'main' }}
+          ref: ${{ inputs.ref }}
 
       - name: Setup Go
         uses: actions/setup-go@v4


### PR DESCRIPTION
If a PR modifies pkg/engine or pkg/dataobj, the LogQL correctness tests will now run as a non-required check.