### PR TITLE
backport(k279): chore: log when limits pod loses a partition (#19676)

### DIFF
--- a/pkg/limits/partition_lifecycler.go
+++ b/pkg/limits/partition_lifecycler.go
@@ -74,6 +74,17 @@ func (l *partitionLifecycler) Revoke(_ context.Context, _ *kgo.Client, topics ma
 	}
 }
 
+// Lost implements kgo.OnPartitionsLost.
+func (l *partitionLifecycler) Lost(_ context.Context, _ *kgo.Client, topics map[string][]int32) {
+	for _, partitions := range topics {
+		for _, partition := range partitions {
+			// TODO(grobinson): Implement logic to handle partition loss.
+			// For now, we just log the event to measure if it happens at all.
+			level.Warn(l.logger).Log("msg", "partition lost", "partition", partition)
+		}
+	}
+}
+
 func (l *partitionLifecycler) determineStateFromOffsets(ctx context.Context, partition int32) error {
 	logger := log.With(l.logger, "partition", partition)
 	// Get the start offset for the partition. This can be greater than zero

--- a/pkg/limits/service.go
+++ b/pkg/limits/service.go
@@ -123,6 +123,7 @@ func New(cfg Config, limits Limits, logger log.Logger, reg prometheus.Registerer
 		kgo.DisableAutoCommit(),
 		kgo.OnPartitionsAssigned(s.partitionLifecycler.Assign),
 		kgo.OnPartitionsRevoked(s.partitionLifecycler.Revoke),
+		kgo.OnPartitionsLost(s.partitionLifecycler.Lost),
 		// For now these are hardcoded, but we might choose to make them
 		// configurable in the future. We allow up to 100MB to be buffered
 		// in total, and up to 1.5MB per partition. If an instance consumes


### PR DESCRIPTION
**What this PR does / why we need it**:

Backports https://github.com/grafana/loki/pull/19676 to k279.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
