### PR TITLE
chore: remove debug logging from HTTP endpoint

### DIFF
--- a/pkg/limits/http.go
+++ b/pkg/limits/http.go
@@ -3,7 +3,6 @@ package limits
 import (
 	"net/http"
 
-	"github.com/go-kit/log/level"
 	"github.com/gorilla/mux"
 
 	"github.com/grafana/loki/v3/pkg/util"
@@ -34,18 +33,6 @@ func (s *Service) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		streamsByPolicy[stream.policy]++
 	}
 	rate := float64(sumBuckets) / s.cfg.ActiveWindow.Seconds()
-
-	// Log the calculated values for debugging
-	level.Debug(s.logger).Log(
-		"msg", "HTTP endpoint calculated stream usage",
-		"tenant", tenant,
-		"streams", streams,
-		"sum_buckets", util.HumanizeBytes(sumBuckets),
-		"rate_window_seconds", s.cfg.RateWindow.Seconds(),
-		"rate", util.HumanizeBytes(uint64(rate)),
-	)
-
-	// Use util.WriteJSONResponse to write the JSON response
 	util.WriteJSONResponse(w, httpTenantLimitsResponse{
 		Tenant:          tenant,
 		StreamsTotal:    streams,


### PR DESCRIPTION
**What this PR does / why we need it**:

Removing this as we never used it, just logging for nothing.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
