### PR TITLE
chore: Ensure partition is set on partition-processor

### DIFF
--- a/pkg/dataobj/consumer/partition_processor.go
+++ b/pkg/dataobj/consumer/partition_processor.go
@@ -123,6 +123,8 @@ func newPartitionProcessor(
 	}
 
 	return &partitionProcessor{
+		topic:                   topic,
+		partition:               partition,
 		committer:               committer,
 		logger:                  logger,
 		decoder:                 decoder,

--- a/pkg/dataobj/consumer/partition_processor_test.go
+++ b/pkg/dataobj/consumer/partition_processor_test.go
@@ -319,9 +319,10 @@ func newTestPartitionProcessor(t *testing.T, clock quartz.Clock) *partitionProce
 		60*time.Minute,
 		nil,
 		"test-topic",
-		0,
+		1,
 	)
 	p.clock = clock
 	p.eventsProducerClient = &mockKafka{}
+	require.NotZero(t, p.partition)
 	return p
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Stores the partition number on the partition-processor
* This is required so the metastore events can pick the right partition
