### PR TITLE
chore(engine): add periodic discovery of remote schedulers

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -5135,6 +5135,14 @@ engine_v2:
   # CLI flag: -querier.engine-v2.worker-threads
   [worker_threads: <int> | default = 0]
 
+  # Experimental: Address holding DNS SRV records of schedulers to connect to.
+  # CLI flag: -querier.engine-v2.scheduler-lookup-address
+  [scheduler_lookup_address: <string> | default = ""]
+
+  # Experimental: Interval at which to lookup new schedulers by DNS SRV records.
+  # CLI flag: -querier.engine-v2.scheduler-lookup-interval
+  [scheduler_lookup_interval: <duration> | default = 10s]
+
 # The maximum number of queries that can be simultaneously processed by the
 # querier.
 # CLI flag: -querier.max-concurrent

--- a/pkg/engine/internal/worker/scheduler_lookup.go
+++ b/pkg/engine/internal/worker/scheduler_lookup.go
@@ -1,0 +1,133 @@
+package worker
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/netip"
+	"sync"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/grpcutil"
+)
+
+type schedulerLookup struct {
+	// logger to log messages with.
+	logger log.Logger
+
+	// Watcher emits events when schedulers are found. Each found address must
+	// be an IP address.
+	watcher grpcutil.Watcher
+
+	closeOnce sync.Once
+}
+
+type handleScheduler func(ctx context.Context, addr net.Addr)
+
+func newSchedulerLookup(logger log.Logger, address string, lookupInterval time.Duration) (*schedulerLookup, error) {
+	if logger == nil {
+		logger = log.NewNopLogger()
+	}
+
+	resolver, err := grpcutil.NewDNSResolverWithFreq(lookupInterval, logger)
+	if err != nil {
+		return nil, fmt.Errorf("creating DNS resolver: %w", err)
+	}
+
+	watcher, err := resolver.Resolve(address, "")
+	if err != nil {
+		return nil, fmt.Errorf("creating DNS watcher: %w", err)
+	}
+
+	return &schedulerLookup{
+		logger:  logger,
+		watcher: watcher,
+	}, nil
+}
+
+func (l *schedulerLookup) Run(ctx context.Context, handlerFunc handleScheduler) error {
+	// Hook into context cancellation to close the watcher. We need to do this
+	// because the watcher doesn't accept a custom context when polling for
+	// changes.
+	stop := context.AfterFunc(ctx, l.closeWatcher)
+	defer stop()
+
+	var handlerWg sync.WaitGroup
+	defer handlerWg.Wait()
+
+	type handlerContext struct {
+		Context context.Context
+		Cancel  context.CancelFunc
+	}
+	handlers := make(map[string]handlerContext)
+
+	// Create a new context so we can cancel all handlers at once.
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	for {
+		updates, err := l.watcher.Next()
+		if err != nil && ctx.Err() == nil {
+			return fmt.Errorf("finding schedulers: %w", err)
+		} else if ctx.Err() != nil {
+			// The context was canceled, we can exit gracefully.
+			return nil
+		}
+
+		for _, update := range updates {
+			switch update.Op {
+			case grpcutil.Add:
+				if _, exist := handlers[update.Addr]; exist {
+					// Ignore duplicate handlers.
+					level.Warn(l.logger).Log("msg", "ignoring duplicate scheduler", "addr", update.Addr)
+					continue
+				}
+
+				addr, err := parseTCPAddr(update.Addr)
+				if err != nil {
+					level.Warn(l.logger).Log("msg", "failed to parse scheduler address", "addr", update.Addr, "err", err)
+					continue
+				}
+
+				var handler handlerContext
+				handler.Context, handler.Cancel = context.WithCancel(ctx)
+				handlers[update.Addr] = handler
+
+				handlerWg.Add(1)
+				go func() {
+					defer handlerWg.Done()
+					handlerFunc(handler.Context, addr)
+				}()
+
+			case grpcutil.Delete:
+				handler, exist := handlers[update.Addr]
+				if !exist {
+					level.Warn(l.logger).Log("msg", "ignoring unrecognized scheduler", "addr", update.Addr)
+					continue
+				}
+				handler.Cancel()
+				delete(handlers, update.Addr)
+
+			default:
+				level.Warn(l.logger).Log("msg", "unknown scheduler update operation", "op", update.Op)
+			}
+		}
+	}
+}
+
+func (l *schedulerLookup) closeWatcher() {
+	l.closeOnce.Do(func() { l.watcher.Close() })
+}
+
+// parseTCPAddr parses a TCP address string into a [net.TCPAddr]. It doesn't do
+// any name resolution: the addr must be a numeric pair of IP and port.
+func parseTCPAddr(addr string) (*net.TCPAddr, error) {
+	ap, err := netip.ParseAddrPort(addr)
+	if err != nil {
+		return nil, err
+	}
+
+	return net.TCPAddrFromAddrPort(ap), nil
+}

--- a/pkg/engine/internal/worker/scheduler_lookup_test.go
+++ b/pkg/engine/internal/worker/scheduler_lookup_test.go
@@ -1,0 +1,91 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/dskit/grpcutil"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
+)
+
+func Test_schedulerLookup(t *testing.T) {
+	var wg sync.WaitGroup
+	defer wg.Wait()
+
+	fw := &fakeWatcher{
+		ctx: t.Context(),
+		ch:  make(chan *grpcutil.Update, 1),
+	}
+
+	// Manually create a schedulerLookup so we can hook in a custom
+	// implementation of [grpcutil.Watcher].
+	disc := &schedulerLookup{
+		logger:  log.NewNopLogger(),
+		watcher: fw,
+	}
+
+	var handlers atomic.Int64
+
+	lookupContext, lookupCancel := context.WithCancel(t.Context())
+	defer lookupCancel()
+
+	wg.Add(1)
+	go func() {
+		// Decrement the wait group once Run exits. Run won't exit until all
+		// handlers have terminated, so this validates that logic.
+		defer wg.Done()
+
+		_ = disc.Run(lookupContext, func(ctx context.Context, _ net.Addr) {
+			context.AfterFunc(ctx, func() { handlers.Dec() })
+			handlers.Inc()
+		})
+	}()
+
+	// Emit 10 schedulers, then wait for there to be one handler per
+	// scheduler.
+	for i := range 10 {
+		addr := fmt.Sprintf("127.0.0.%d:8080", i+1)
+		fw.ch <- &grpcutil.Update{Op: grpcutil.Add, Addr: addr}
+	}
+
+	require.Eventually(t, func() bool {
+		return handlers.Load() == 10
+	}, time.Minute, time.Millisecond*10, "should have 10 running handlers, ended with %d", handlers.Load())
+
+	// Delete all the schedulers, then wait for all handlers to terminate (by
+	// context).
+	for i := range 10 {
+		addr := fmt.Sprintf("127.0.0.%d:8080", i+1)
+		fw.ch <- &grpcutil.Update{Op: grpcutil.Delete, Addr: addr}
+	}
+
+	require.Eventually(t, func() bool {
+		return handlers.Load() == 0
+	}, time.Minute, time.Millisecond*10, "should have no handlers running, ended with %d", handlers.Load())
+}
+
+type fakeWatcher struct {
+	ctx context.Context
+	ch  chan *grpcutil.Update
+}
+
+func (fw fakeWatcher) Next() ([]*grpcutil.Update, error) {
+	select {
+	case <-fw.ctx.Done():
+		return nil, fw.ctx.Err()
+	case update, ok := <-fw.ch:
+		if !ok {
+			return nil, errors.New("closed")
+		}
+		return []*grpcutil.Update{update}, nil
+	}
+}
+
+func (fw fakeWatcher) Close() { close(fw.ch) }

--- a/pkg/engine/worker.go
+++ b/pkg/engine/worker.go
@@ -2,9 +2,11 @@ package engine
 
 import (
 	"flag"
+	"time"
 
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/services"
+	"github.com/pkg/errors"
 	"github.com/thanos-io/objstore"
 
 	"github.com/grafana/loki/v3/pkg/engine/internal/worker"
@@ -13,10 +15,15 @@ import (
 // WorkerConfig represents the configuration for the [Worker].
 type WorkerConfig struct {
 	WorkerThreads int `yaml:"worker_threads" category:"experimental"`
+
+	SchedulerLookupAddress  string        `yaml:"scheduler_lookup_address" category:"experimental"`
+	SchedulerLookupInterval time.Duration `yaml:"scheduler_lookup_interval" category:"experimental"`
 }
 
 func (cfg *WorkerConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.IntVar(&cfg.WorkerThreads, prefix+"worker-threads", 0, "Experimental: Number of worker threads to spawn. Each worker thread runs one task at a time. 0 means to use GOMAXPROCS value.")
+	f.StringVar(&cfg.SchedulerLookupAddress, prefix+"scheduler-lookup-address", "", "Experimental: Address holding DNS SRV records of schedulers to connect to.")
+	f.DurationVar(&cfg.SchedulerLookupInterval, prefix+"scheduler-lookup-interval", 10*time.Second, "Experimental: Interval at which to lookup new schedulers by DNS SRV records.")
 }
 
 // WorkerParams holds parameters for constructing a new [Worker].
@@ -43,10 +50,17 @@ type Worker struct {
 // NewWorker creates a new Worker instance. Use [Worker.Service] to manage the
 // lifecycle of the Worker.
 func NewWorker(params WorkerParams) (*Worker, error) {
+	if params.Config.SchedulerLookupAddress != "" && params.Config.SchedulerLookupInterval == 0 {
+		return nil, errors.New("scheduler lookup interval must be non-zero when a scheduler lookup address is provided")
+	}
+
 	inner, err := worker.New(worker.Config{
 		Logger:         params.Logger,
 		Bucket:         params.Bucket,
 		LocalScheduler: params.LocalScheduler.inner,
+
+		SchedulerLookupAddress:  params.Config.SchedulerLookupAddress,
+		SchedulerLookupInterval: params.Config.SchedulerLookupInterval,
 
 		BatchSize:  int64(params.Executor.BatchSize),
 		NumThreads: params.Config.WorkerThreads,


### PR DESCRIPTION
Add two new settings to workers:

* The scheduler lookup address specifies which address can be polled for DNS SRV records that point to running schedulers.

* The scheduler lookup interval determines the polling interval of the above address.

Whenever a new scheduler is found via the lookup, the worker will maintain a connection to that scheduler, using the existing retry logic in runSchedulerLoop. Connections to schedulers are only terminated once that scheduler is no longer listed in the DNS SRV records from the lookup address.

At the moment, connections to discovered remote schedulers will fail due to worker.dial not yet supporting remote addresses.

Internally, this uses the same mechanism used in the old scheduler for scheduler lookup when the scheduler ring isn't being used.