### PR TITLE
chore(dataobj-consumer): Re-use builder for CopyAndSort()

### DIFF
--- a/pkg/dataobj/consumer/logsobj/builder.go
+++ b/pkg/dataobj/consumer/logsobj/builder.go
@@ -415,6 +415,8 @@ func (b *Builder) CopyAndSort(obj *dataobj.Object) (*dataobj.Object, io.Closer, 
 	dur := prometheus.NewTimer(b.metrics.sortDurationSeconds)
 	defer dur.ObserveDuration()
 
+	defer b.Reset() // always reset builder when done
+
 	ctx := context.Background()
 	sort := parseSortOrder(b.cfg.DataobjSortOrder)
 

--- a/pkg/dataobj/consumer/mock_test.go
+++ b/pkg/dataobj/consumer/mock_test.go
@@ -115,6 +115,10 @@ func (m *mockBuilder) GetEstimatedSize() int {
 	return m.builder.GetEstimatedSize()
 }
 
+func (m *mockBuilder) CopyAndSort(obj *dataobj.Object) (*dataobj.Object, io.Closer, error) {
+	return m.builder.CopyAndSort(obj)
+}
+
 func (m *mockBuilder) Flush() (*dataobj.Object, io.Closer, error) {
 	if err := m.nextErr; err != nil {
 		m.nextErr = nil

--- a/pkg/dataobj/consumer/partition_processor.go
+++ b/pkg/dataobj/consumer/partition_processor.go
@@ -35,6 +35,7 @@ type builder interface {
 	Flush() (*dataobj.Object, io.Closer, error)
 	TimeRanges() []multitenancy.TimeRange
 	UnregisterMetrics(prometheus.Registerer)
+	CopyAndSort(obj *dataobj.Object) (*dataobj.Object, io.Closer, error)
 }
 
 // committer allows mocking of certain [kgo.Client] methods in tests.
@@ -336,13 +337,7 @@ func (p *partitionProcessor) sort(obj *dataobj.Object, closer io.Closer) (*datao
 		level.Debug(p.logger).Log("msg", "partition processor sorted logs object-wide", "duration", time.Since(start))
 	}()
 
-	// Create a new object builder but do not register metrics!
-	builder, err := logsobj.NewBuilder(p.builderCfg, p.scratchStore)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return builder.CopyAndSort(obj)
+	return p.builder.CopyAndSort(obj)
 }
 
 // commits the offset of the last record processed. It should be called after


### PR DESCRIPTION
### Summary

Re-use logsobj.Builder instance in partition processor when sorting logs object wide after flushing.

The metrics for the builder in CopyAndSort are [never registered](https://github.com/grafana/loki/blob/k279/pkg/dataobj/consumer/partition_processor.go#L337), which means the loki_dataobj_sort_duration_seconds histogram is never exported/scraped.

We cannot register them with RegisterMetrics() because the metrics are already registered [here](https://github.com/grafana/loki/blob/k279/pkg/dataobj/consumer/partition_processor.go#L205), and registering them twice would cause a panic.

Closes https://github.com/grafana/loki-private/issues/2067
