### PR TITLE
docs: 3.5.8 Release Notes

### DIFF
--- a/docs/sources/release-notes/v3-5.md
+++ b/docs/sources/release-notes/v3-5.md
@@ -66,6 +66,10 @@ For important upgrade guidance, refer to the [Upgrade Guide](https://grafana.com
 
 ## Bug fixes
 
+### 3.5.8 (2025-11-05)
+
+* **deps:** Update to Go version 1.24.9 ([#19702](https://github.com/grafana/loki/issues/19702)) ([cf33543](https://github.com/grafana/loki/commit/cf335437062aa68f3ba657c89012ab499dedb738)).
+
 ### 3.5.7 (2025-10-13)
 
 This release fixes a build issue in 3.5.6 where it was not built with Go 1.24.8 as expected, but Go 1.24.1.


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates the Release Notes for 3.5.8 patch.