### PR TITLE
chore: explicitly set ingester.lifecycler.id in kafka local dev config

### DIFF
--- a/tools/dev/kafka/loki-local-config.debug.yaml
+++ b/tools/dev/kafka/loki-local-config.debug.yaml
@@ -58,6 +58,8 @@ ingest_limits_frontend:
 ingester:
   kafka_ingestion:
     enabled: true
+  lifecycler:
+    id: "loki.local"
 
 distributor:
   kafka_writes_enabled: true


### PR DESCRIPTION
Under /tools/dev/kafka we offer a docker-compose that setup the development environment for testing Loki with Kafka integration

When running
```
go run ./cmd/loki/main.go --config.file=tools/dev/kafka/loki-local-config.debug.yaml --log.level=debug -target=all 
```

The ingester will derive the partition ID from the lifecyclerConfig.ID (which defaults to the hostname of the machine)
```go
	if i.cfg.KafkaIngestion.Enabled {
		i.ingestPartitionID, err = partitionring.ExtractPartitionID(cfg.LifecyclerConfig.ID)
		if err != nil {
			return nil, fmt.Errorf("calculating ingester partition ID: %w", err)
		}
		...
	}
```


The ExtractPartitionID method contains a special case for local development:
```go 
func ExtractPartitionID(s string) (int32, error) {
	if strings.Contains(s, "local") || strings.HasSuffix(s, ".lan") {
		return 0, nil
	}
...
```

Unfortunately not all local machines are suffixed by `.local` or `.lan`, for example on my desktop the hostname is set to `SegDesk` which result in this error when running loki:

```
calculating ingester partition ID: SegDesk does not contain a partition ID
error initialising module: ingester
github.com/grafana/dskit/modules.(*Manager).initModule
        /home/segflow/repos/loki/vendor/github.com/grafana/dskit/modules/modules.go:138
github.com/grafana/dskit/modules.(*Manager).InitModuleServices
        /home/segflow/repos/loki/vendor/github.com/grafana/dskit/modules/modules.go:108
github.com/grafana/loki/v3/pkg/loki.(*Loki).Run
        /home/segflow/repos/loki/pkg/loki/loki.go:555
main.main
        /home/segflow/repos/loki/cmd/loki/main.go:143
runtime.main
        /snap/go/10971/src/runtime/proc.go:285
runtime.goexit
```


This PR explicitly sets the `ingester.lifecycler.id` in the `loki-local-config.debug.yaml` to avoid this issue. 