### PR TITLE
chore: remove loki_dataobj_consumer_processing_delay histogram

### DIFF
--- a/pkg/dataobj/consumer/metrics.go
+++ b/pkg/dataobj/consumer/metrics.go
@@ -20,8 +20,7 @@ type partitionOffsetMetrics struct {
 	commitsTotal prometheus.Counter
 	appendsTotal prometheus.Counter
 
-	latestDelay     prometheus.Gauge     // Latest delta between record timestamp and current time
-	processingDelay prometheus.Histogram // Processing delay histogram
+	latestDelay prometheus.Gauge // Latest delta between record timestamp and current time
 
 	// Data volume metrics
 	bytesProcessed prometheus.Counter
@@ -48,14 +47,6 @@ func newPartitionOffsetMetrics() *partitionOffsetMetrics {
 		latestDelay: prometheus.NewGauge(prometheus.GaugeOpts{
 			Name: "loki_dataobj_consumer_latest_processing_delay_seconds",
 			Help: "Latest time difference bweteen record timestamp and processing time in seconds",
-		}),
-		processingDelay: prometheus.NewHistogram(prometheus.HistogramOpts{
-			Name:                            "loki_dataobj_consumer_processing_delay_seconds",
-			Help:                            "Time difference between record timestamp and processing time in seconds",
-			Buckets:                         prometheus.DefBuckets,
-			NativeHistogramBucketFactor:     1.1,
-			NativeHistogramMaxBucketNumber:  100,
-			NativeHistogramMinResetDuration: 0,
 		}),
 		bytesProcessed: prometheus.NewCounter(prometheus.CounterOpts{
 			Name: "loki_dataobj_consumer_bytes_processed_total",
@@ -84,7 +75,6 @@ func (p *partitionOffsetMetrics) register(reg prometheus.Registerer) error {
 		p.appendFailures,
 		p.appendsTotal,
 		p.latestDelay,
-		p.processingDelay,
 		p.bytesProcessed,
 		p.currentOffset,
 	}
@@ -105,7 +95,6 @@ func (p *partitionOffsetMetrics) unregister(reg prometheus.Registerer) {
 		p.appendFailures,
 		p.appendsTotal,
 		p.latestDelay,
-		p.processingDelay,
 		p.bytesProcessed,
 		p.currentOffset,
 	}
@@ -141,7 +130,6 @@ func (p *partitionOffsetMetrics) observeProcessingDelay(recordTimestamp time.Tim
 		delay := time.Since(recordTimestamp).Seconds()
 
 		p.latestDelay.Set(delay)
-		p.processingDelay.Observe(delay)
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit removes the histogram because each pod can only consume one partition. It is not possible to have observations that are not monotonically increasing.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
