### PR TITLE
chore: rename the prepare delayed downscale handler to better communicate what it does

### DIFF
--- a/pkg/dataobj/consumer/http.go
+++ b/pkg/dataobj/consumer/http.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Copied from pkg/ingester/downscale.go.
-func (s *Service) PreparePartitionDownscaleHandler(w http.ResponseWriter, r *http.Request) {
+func (s *Service) PrepareDelayedDownscaleHandler(w http.ResponseWriter, r *http.Request) {
 	// Don't allow callers to change the shutdown configuration while we're in the middle
 	// of starting or shutting down.
 	if s.State() != services.Running {

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -2314,8 +2314,8 @@ func (t *Loki) initDataObjConsumer() (services.Service, error) {
 	httpMiddleware := middleware.Merge(
 		serverutil.RecoveryHTTPMiddleware,
 	)
-	t.Server.HTTP.Methods("POST", "GET", "DELETE").Path("/dataobj-consumer/prepare_partition_downscale").Handler(
-		httpMiddleware.Wrap(http.HandlerFunc(t.dataObjConsumer.PreparePartitionDownscaleHandler)),
+	t.Server.HTTP.Methods("POST", "GET", "DELETE").Path("/dataobj-consumer/prepare-delayed-downscale").Handler(
+		httpMiddleware.Wrap(http.HandlerFunc(t.dataObjConsumer.PrepareDelayedDownscaleHandler)),
 	)
 
 	return t.dataObjConsumer, nil


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request renames the URL before we start using it in https://github.com/grafana/deployment_tools/pull/399402.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
