### PR TITLE
chore(engine): propagate worker listen address to scheduler

### DIFF
--- a/pkg/engine/internal/scheduler/scheduler_test.go
+++ b/pkg/engine/internal/scheduler/scheduler_test.go
@@ -1230,7 +1230,8 @@ func newTestScheduler(t *testing.T) *Scheduler {
 	t.Helper()
 
 	sched, err := New(Config{
-		Logger: log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr)),
+		Logger:   log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr)),
+		Listener: &wire.Local{Address: wire.LocalScheduler},
 	})
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(t.Context(), sched.Service()))

--- a/pkg/engine/internal/scheduler/wire/wire.go
+++ b/pkg/engine/internal/scheduler/wire/wire.go
@@ -26,6 +26,15 @@ type Listener interface {
 	Addr() net.Addr
 }
 
+// A Dialer establishes connections to scheduler peers.
+type Dialer interface {
+	// Dial connects to the scheduler peer at the provided "to" address. The
+	// "from" address is used to establish the address that can be used to
+	// connect back to the caller. Dial returns an error if the context is
+	// canceled or if the connection cannot be established.
+	Dial(ctx context.Context, from, to net.Addr) (Conn, error)
+}
+
 // Conn is a communication stream between two peers.
 type Conn interface {
 	// Send sends the provided Frame to the peer. Send blocks until the Frame

--- a/pkg/engine/internal/scheduler/wire/wire_http2_test.go
+++ b/pkg/engine/internal/scheduler/wire/wire_http2_test.go
@@ -44,7 +44,7 @@ func TestHTTP2BasicConnectivity(t *testing.T) {
 	}()
 
 	// Dial from client
-	clientConn, err := wire.NewHTTP2Dialer("/").Dial(ctx, listener.Addr())
+	clientConn, err := wire.NewHTTP2Dialer("/").Dial(ctx, listener.Addr(), listener.Addr())
 	require.NoError(t, err)
 	defer clientConn.Close()
 
@@ -55,6 +55,7 @@ func TestHTTP2BasicConnectivity(t *testing.T) {
 
 	// Verify addresses
 	require.Equal(t, listener.Addr(), serverConn.LocalAddr())
+	require.Equal(t, listener.Addr(), serverConn.RemoteAddr(), "advertise address not propagated")
 	t.Logf("Client local: %s, remote: %s", clientConn.LocalAddr(), clientConn.RemoteAddr())
 	t.Logf("Server local: %s, remote: %s", serverConn.LocalAddr(), serverConn.RemoteAddr())
 
@@ -134,7 +135,7 @@ func TestHTTP2WithPeers(t *testing.T) {
 	}()
 
 	// Dial from client
-	clientConn, err := wire.NewHTTP2Dialer("/").Dial(ctx, listener.Addr())
+	clientConn, err := wire.NewHTTP2Dialer("/").Dial(ctx, listener.Addr(), listener.Addr())
 	require.NoError(t, err)
 	defer clientConn.Close()
 
@@ -297,7 +298,7 @@ func TestHTTP2MultipleClients(t *testing.T) {
 			defer clientWg.Done()
 
 			// Connect
-			conn, err := wire.NewHTTP2Dialer("/").Dial(ctx, listener.Addr())
+			conn, err := wire.NewHTTP2Dialer("/").Dial(ctx, listener.Addr(), listener.Addr())
 			if err != nil {
 				t.Errorf("Client %d dial failed: %v", clientIdx, err)
 				return
@@ -406,7 +407,7 @@ func TestHTTP2ErrorHandling(t *testing.T) {
 	}()
 
 	// Dial from client
-	clientConn, err := wire.NewHTTP2Dialer("/").Dial(ctx, listener.Addr())
+	clientConn, err := wire.NewHTTP2Dialer("/").Dial(ctx, listener.Addr(), listener.Addr())
 	require.NoError(t, err)
 	defer clientConn.Close()
 
@@ -479,7 +480,7 @@ func TestHTTP2MessageFrameSerialization(t *testing.T) {
 	}()
 
 	// Dial from client
-	clientConn, err := wire.NewHTTP2Dialer("/").Dial(ctx, listener.Addr())
+	clientConn, err := wire.NewHTTP2Dialer("/").Dial(ctx, listener.Addr(), listener.Addr())
 	require.NoError(t, err)
 	defer clientConn.Close()
 

--- a/pkg/engine/internal/worker/worker_test.go
+++ b/pkg/engine/internal/worker/worker_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/engine/internal/planner/logical"
 	"github.com/grafana/loki/v3/pkg/engine/internal/planner/physical"
 	"github.com/grafana/loki/v3/pkg/engine/internal/scheduler"
+	"github.com/grafana/loki/v3/pkg/engine/internal/scheduler/wire"
 	"github.com/grafana/loki/v3/pkg/engine/internal/util/objtest"
 	"github.com/grafana/loki/v3/pkg/engine/internal/worker"
 	"github.com/grafana/loki/v3/pkg/engine/internal/workflow"
@@ -40,8 +41,9 @@ func Test(t *testing.T) {
 		logger = log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
 	}
 
-	sched := newTestScheduler(t, logger)
-	_ = newTestWorker(t, logger, builder.Location(), sched)
+	net := newTestNetwork()
+	sched := newTestScheduler(t, logger, net)
+	_ = newTestWorker(t, logger, builder.Location(), net)
 
 	ctx := user.InjectOrgID(t.Context(), objtest.Tenant)
 
@@ -94,10 +96,30 @@ func Test(t *testing.T) {
 	require.Equal(t, expected, actual)
 }
 
-func newTestScheduler(t *testing.T, logger log.Logger) *scheduler.Scheduler {
+type testNetwork struct {
+	schedulerListener *wire.Local
+	workerListener    *wire.Local
+	dialer            wire.Dialer
+}
+
+func newTestNetwork() *testNetwork {
+	schedulerListener := &wire.Local{Address: wire.LocalScheduler}
+	workerListener := &wire.Local{Address: wire.LocalWorker}
+
+	return &testNetwork{
+		schedulerListener: schedulerListener,
+		workerListener:    workerListener,
+		dialer:            wire.NewLocalDialer(schedulerListener, workerListener),
+	}
+}
+
+func newTestScheduler(t *testing.T, logger log.Logger, net *testNetwork) *scheduler.Scheduler {
 	t.Helper()
 
-	sched, err := scheduler.New(scheduler.Config{Logger: logger})
+	sched, err := scheduler.New(scheduler.Config{
+		Logger:   logger,
+		Listener: net.schedulerListener,
+	})
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(t.Context(), sched.Service()))
 
@@ -111,14 +133,17 @@ func newTestScheduler(t *testing.T, logger log.Logger) *scheduler.Scheduler {
 	return sched
 }
 
-func newTestWorker(t *testing.T, logger log.Logger, loc objtest.Location, sched *scheduler.Scheduler) *worker.Worker {
+func newTestWorker(t *testing.T, logger log.Logger, loc objtest.Location, net *testNetwork) *worker.Worker {
 	t.Helper()
 
 	w, err := worker.New(worker.Config{
-		Logger:         logger,
-		Bucket:         loc.Bucket,
-		BatchSize:      2048,
-		LocalScheduler: sched.Listener(),
+		Logger:    logger,
+		Bucket:    loc.Bucket,
+		BatchSize: 2048,
+
+		Dialer:           net.dialer,
+		Listener:         net.workerListener,
+		SchedulerAddress: wire.LocalScheduler,
 
 		// Create enough threads to guarantee all tasks can be scheduled without
 		// blocking.

--- a/pkg/engine/scheduler.go
+++ b/pkg/engine/scheduler.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"net"
+	"net/http"
 
 	"github.com/go-kit/log"
 	"github.com/gorilla/mux"
@@ -14,11 +15,11 @@ import (
 type SchedulerParams struct {
 	Logger log.Logger // Logger for optional log messages.
 
-	// Listen address of the underlying network listener.
-	// This must only be set when the scheduler runs in remote transport mode
-	// and accepts remote connections.
+	// Address to advertise to workers. Must be set when the scheduler runs in
+	// remote transport mode.
+	//
 	// If nil, the scheduler only listens for in-process connections.
-	Addr net.Addr
+	AdvertiseAddr net.Addr
 
 	// Absolute path of the endpoint where the frame handler is registered.
 	// Used for connecting to scheduler and other workers.
@@ -30,8 +31,10 @@ type SchedulerParams struct {
 type Scheduler struct {
 	// Our public API is a lightweight wrapper around the internal API.
 
-	Endpoint string
 	inner    *scheduler.Scheduler
+	endpoint string
+	listener wire.Listener
+	handler  http.Handler
 }
 
 // NewScheduler creates a new Scheduler. Use [Scheduler.Service] to manage the
@@ -44,36 +47,50 @@ func NewScheduler(params SchedulerParams) (*Scheduler, error) {
 		params.Endpoint = "/api/v2/frame"
 	}
 
-	var listener wire.Listener
-	if params.Addr != nil {
-		listener = wire.NewHTTP2Listener(
-			params.Addr,
+	var (
+		listener wire.Listener
+		handler  http.Handler
+	)
+
+	if params.AdvertiseAddr != nil {
+		remoteListener := wire.NewHTTP2Listener(
+			params.AdvertiseAddr,
 			wire.WithHTTP2ListenerLogger(params.Logger),
 			wire.WithHTTP2ListenerMaxPendingConns(10),
 		)
+		listener, handler = remoteListener, remoteListener
+	} else {
+		listener = &wire.Local{Address: wire.LocalScheduler}
 	}
 
 	inner, err := scheduler.New(scheduler.Config{
-		Logger:         params.Logger,
-		RemoteListener: listener,
+		Logger:   params.Logger,
+		Listener: listener,
 	})
 	if err != nil {
 		return nil, err
 	}
 
-	return &Scheduler{Endpoint: params.Endpoint, inner: inner}, nil
+	return &Scheduler{
+		inner:    inner,
+		endpoint: params.Endpoint,
+		listener: listener,
+		handler:  handler,
+	}, nil
 }
 
-// RegisterWorkerServer registers the [wire.Listener] of the inner scheduler as http.Handler on the privided router.
+// RegisterSchedulerServer registers the [wire.Listener] of the inner scheduler
+// as http.Handler on the provided router.
+//
+// RegisterSchedulerServer is a no-op if an advertise address is not provided.
 func (s *Scheduler) RegisterSchedulerServer(router *mux.Router) {
-	router.Path(s.Endpoint).Methods("POST").Handler(s.inner.Handler())
+	if s.handler == nil {
+		return
+	}
+	router.Path(s.endpoint).Methods("POST").Handler(s.handler)
 }
 
 // Service returns the service used to manage the lifecycle of the Scheduler.
 func (s *Scheduler) Service() services.Service {
 	return s.inner.Service()
-}
-
-func (s *Scheduler) Listener() wire.Listener {
-	return s.inner.Listener()
 }

--- a/pkg/logql/bench/store_dataobj_v2_engine.go
+++ b/pkg/logql/bench/store_dataobj_v2_engine.go
@@ -75,8 +75,8 @@ func dataobjV2StoreWithOpts(dataDir string, tenantID string, cfg engine.Executor
 	}
 
 	sched, err := engine.NewScheduler(engine.SchedulerParams{
-		Logger: logger,
-		Addr:   nil, // set explicitly to nil so local transport is used
+		Logger:        logger,
+		AdvertiseAddr: nil, // set explicitly to nil so local transport is used
 	})
 	if err != nil {
 		return nil, fmt.Errorf("creating scheduler: %w", err)
@@ -85,10 +85,10 @@ func dataobjV2StoreWithOpts(dataDir string, tenantID string, cfg engine.Executor
 	}
 
 	worker, err := engine.NewWorker(engine.WorkerParams{
-		Logger:                 logger,
-		Addr:                   nil, // set explicitly to nil so local transport is used
-		Bucket:                 bucketClient,
-		LocalSchedulerListener: sched.Listener(),
+		Logger:         logger,
+		AdvertiseAddr:  nil, // set explicitly to nil so local transport is used
+		Bucket:         bucketClient,
+		LocalScheduler: sched,
 		Config: engine.WorkerConfig{
 			// Try to create one thread per host CPU core. However, we always
 			// create at least 8 threads. This prevents situations where

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -1424,8 +1424,8 @@ func (t *Loki) initV2QueryEngineScheduler() (services.Service, error) {
 	sched, err := engine_v2.NewScheduler(engine_v2.SchedulerParams{
 		Logger: log.With(util_log.Logger, "component", "query-engine-scheduler"),
 
-		Addr:     listenAddr,
-		Endpoint: "/api/v2/frame",
+		AdvertiseAddr: listenAddr,
+		Endpoint:      "/api/v2/frame",
 	})
 	if err != nil {
 		return nil, err
@@ -1462,10 +1462,10 @@ func (t *Loki) initV2QueryEngineWorker() (services.Service, error) {
 		Config:   t.Cfg.Querier.EngineV2.Worker,
 		Executor: t.Cfg.Querier.EngineV2.Executor,
 
-		LocalSchedulerListener: t.queryEngineV2Scheduler.Listener(),
+		LocalScheduler: t.queryEngineV2Scheduler,
 
-		Addr:     listenAddr,
-		Endpoint: "/api/v2/frame",
+		AdvertiseAddr: listenAddr,
+		Endpoint:      "/api/v2/frame",
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
When workers connect to the scheduler over the network, they need to provide their listen address. The listen address is the address that other workers should connect to (e.g., for sending data along streams). Previously, the scheduler would advertise the client address of the incoming TCP connection, which can't be used to establish new connections from other addresses.

Additionally, this introduces a wire.Dialer interface for representing how workers establish connections. wire.Dialer is used to use a long-lived transport throughout the lifetime of a worker process. Previously, a new HTTP transport was created for each connection, which prevented using connection pooling from the underlying net/http library.