### PR TITLE
chore(deps): Remove loki 3.4 from renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -14,7 +14,7 @@
   baseBranchPatterns: [
     'main',
     'release-3.5.x', // Update when a new release is out, 2 minors, 1 major.
-    'release-3.4.x', // Also ensure to update the 'packageRules' section to match
+    //'release-3.4.x', // Also ensure to update the 'packageRules' section to match
     'release-2.9.x',
   ],
   packageRules: [
@@ -34,7 +34,7 @@
     // global 'vulnerabilityAlerts' for this scope.
     matchBaseBranches: [
       'release-2.9.x', 
-      'release-3.4.x', 
+      //'release-3.4.x', 
       'release-3.5.x'
     ],
     matchFileNames: ['operator/**'],
@@ -190,7 +190,7 @@
     autoApprove: false,
   },
   osvVulnerabilityAlerts: true,
-  prConcurrentLimit: 25,
+  prConcurrentLimit: 40,
   rebaseWhen: 'auto',
   branchPrefix: 'deps-update/',
   postUpdateOptions: [


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes Loki 3.4 from Renovate maintenance, and also bumps the number of PRs that can be open at one time.  This is all being done so that we can clear up the Renovate pipeline, and in preparation for Loki 3.6.


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [X] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
