### PR TITLE
fix: Investigate recent api response changes

### DIFF
--- a/pkg/querier/queryrange/serialize.go
+++ b/pkg/querier/queryrange/serialize.go
@@ -82,6 +82,7 @@ func (rt *serializeHTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 		}
 		return
 	}
+	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 	version := loghttp.GetVersion(r.RequestURI)
 	encodingFlags := httpreq.ExtractEncodingFlags(r)
 	if err := encodeResponseJSONTo(version, response, w, encodingFlags); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes an issue where `/loki/api/v1/query_range` responses were incorrectly returning `Content-Type: text/plain; charset=utf-8` instead of `application/json; charset=UTF-8`. This caused client-side errors due to unexpected MIME types. The fix explicitly sets the `Content-Type` header for JSON responses.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:
The bug was introduced in December 2024 with the addition of Parquet support, where the `Content-Type` for JSON responses was inadvertently omitted. It became visible in the last 4 weeks due to recent changes wiring up the v2 engine handler into the query frontend, which increased traffic through the affected code path. The fix is a single line to set the header, consistent with other JSON response handling in the codebase.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)

---
[Slack Thread](https://raintank-corp.slack.com/archives/D09D3D6HPQ8/p1762550142223739?thread_ts=1762550142.223739&cid=D09D3D6HPQ8)

<a href="https://cursor.com/background-agent?bcId=bc-24d12e3d-ec75-4b54-a606-2bc55bb82d6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-24d12e3d-ec75-4b54-a606-2bc55bb82d6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

