### PR TITLE
feat(helm): Bump sidecar to latest version and /tmp volumeMount

### DIFF
--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -13,6 +13,7 @@ Entries should include a reference to the pull request that introduced the chang
 
 ## Unreleased
 
+- [FEATURE] Add the now mandatory /tmp volumeMount for sidecar. [#19759](https://github.com/grafana/loki/pull/19759)
 
 ## 6.55.0
 

--- a/production/helm/loki/templates/backend/statefulset-backend.yaml
+++ b/production/helm/loki/templates/backend/statefulset-backend.yaml
@@ -220,7 +220,9 @@ spec:
               mountPath: /tmp
             - name: sc-rules-volume
               mountPath: {{ .Values.sidecar.rules.folder | quote }}
-        {{- end}}
+            - name: sc-rules-tmp
+              mountPath: /tmp
+        {{- end }}
         {{- with .Values.backend.extraContainers }}
         {{- toYaml . | nindent 8}}
         {{- end }}
@@ -272,7 +274,9 @@ spec:
             sizeLimit: {{ .Values.sidecar.rules.sizeLimit }}
         {{- else }}
           emptyDir: {}
-        {{- end -}}
+        {{- end }}
+        - name: sc-rules-tmp
+          emptyDir: {}
         {{- end -}}
         {{- with (concat .Values.global.extraVolumes .Values.backend.extraVolumes) | uniq }}
         {{- toYaml . | nindent 8 }}

--- a/production/helm/loki/templates/ruler/statefulset-ruler.yaml
+++ b/production/helm/loki/templates/ruler/statefulset-ruler.yaml
@@ -202,7 +202,9 @@ spec:
               mountPath: /tmp
             - name: sc-rules-volume
               mountPath: {{ .Values.sidecar.rules.folder | quote }}
-        {{- end}}
+            - name: sc-rules-tmp
+              mountPath: /tmp
+        {{- end }}
         {{- with .Values.ruler.extraContainers }}
         {{- toYaml . | nindent 8}}
         {{- end }}
@@ -244,7 +246,9 @@ spec:
             sizeLimit: {{ .Values.sidecar.rules.sizeLimit }}
         {{- else }}
           emptyDir: {}
-        {{- end -}}
+        {{- end }}
+        - name: sc-rules-tmp
+          emptyDir: {}
         {{- end -}}
         {{- range $dir, $_ := .Values.ruler.directories }}
         - name: {{ include "loki.rulerRulesDirName" $dir }}

--- a/production/helm/loki/templates/single-binary/statefulset.yaml
+++ b/production/helm/loki/templates/single-binary/statefulset.yaml
@@ -230,7 +230,9 @@ spec:
               mountPath: /tmp
             - name: sc-rules-volume
               mountPath: {{ .Values.sidecar.rules.folder | quote }}
-        {{- end}}
+            - name: sc-rules-tmp
+              mountPath: /tmp
+        {{- end }}
         {{- with .Values.singleBinary.extraContainers }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -274,7 +276,9 @@ spec:
             sizeLimit: {{ .Values.sidecar.rules.sizeLimit }}
         {{- else }}
           emptyDir: {}
-        {{- end -}}
+        {{- end }}
+        - name: sc-rules-tmp
+          emptyDir: {}
         {{- end -}}
         {{- with .Values.singleBinary.extraVolumes }}
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
**What this PR does / why we need it**:

Same as https://github.com/grafana/helm-charts/issues/3936 for loki.

See also https://github.com/kiwigrid/k8s-sidecar/issues/427

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
