### PR TITLE
chore(engine): Fix calculation of v2 engine range in middleware

### DIFF
--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -1180,8 +1180,8 @@ func (t *Loki) initQueryFrontendMiddleware() (_ services.Service, err error) {
 		}
 
 		v2Router = queryrange.RouterConfig{
-			V2EngineStart: start,
-			V2EngineLag:   t.Cfg.Querier.DataobjStorageLag,
+			Start: start,
+			Lag:   t.Cfg.Querier.DataobjStorageLag,
 
 			Validate: engine_v2.IsQuerySupported,
 			Handler:  handler,

--- a/pkg/querier/queryrange/engine_router.go
+++ b/pkg/querier/queryrange/engine_router.go
@@ -21,8 +21,8 @@ import (
 
 // RouterConfig configures sending queries to a separate engine.
 type RouterConfig struct {
-	V2EngineStart time.Time     // Start time of the v2 engine
-	V2EngineLag   time.Duration // Lag after which v2 engine has data
+	Start time.Time     // Start time of the v2 engine
+	Lag   time.Duration // Lag after which v2 engine has data
 
 	// Validate function to check if the query is supported by the engine.
 	Validate func(params logql.Params) bool
@@ -72,8 +72,8 @@ func newEngineRouterMiddleware(
 
 	return queryrangebase.MiddlewareFunc(func(next queryrangebase.Handler) queryrangebase.Handler {
 		return &engineRouter{
-			v2Start:        v2Config.V2EngineStart,
-			v2Lag:          v2Config.V2EngineLag,
+			v2Start:        v2Config.Start,
+			v2Lag:          v2Config.Lag,
 			v1Next:         queryrangebase.MergeMiddlewares(v1Chain...).Wrap(next),
 			v2Next:         v2Config.Handler,
 			checkV2:        v2Config.Validate,

--- a/pkg/querier/queryrange/engine_router_test.go
+++ b/pkg/querier/queryrange/engine_router_test.go
@@ -289,10 +289,10 @@ func Test_engineRouter_Do(t *testing.T) {
 	now := clock.Now().Truncate(time.Second)
 
 	routerConfig := RouterConfig{
-		V2EngineStart: now.Add(-24 * time.Hour),
-		V2EngineLag:   time.Hour,
-		Validate:      func(_ logql.Params) bool { return true },
-		Handler:       v2EngineHandler,
+		Start:    now.Add(-24 * time.Hour),
+		Lag:      time.Hour,
+		Validate: func(_ logql.Params) bool { return true },
+		Handler:  v2EngineHandler,
 	}
 
 	router := newEngineRouterMiddleware(


### PR DESCRIPTION
### Summary

The range of the v2 engine is dynamic. It starts at the statically configures start time and end at now - lag.

The implementation was incorrect in a way that the end was calculated at the instantiation of the middleware rather than at request time.