### PR TITLE
docs: fix URL in LogCLI getting started

### DIFF
--- a/docs/sources/query/logcli/getting-started.md
+++ b/docs/sources/query/logcli/getting-started.md
@@ -68,7 +68,7 @@ Once you have installed logcli, you can run it in the following way:
 
 `logcli <command> [<flags>, <args> ...]`
 
-`<command>` points to one of the commands, detailed in the [command reference](http://localhost:3002/docs/loki/<LOKI_VERSION>/query/logcli/getting-started/#logcli-command-reference) below.
+`<command>` points to one of the commands, detailed in the [command reference](https://grafana.com/docs/loki/<LOKI_VERSION>/query/logcli/getting-started/#logcli-command-reference) below.
 
 `<flags>` is one of the subcommands available for each command.
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes "localhost" reference in a link, reported via internal Slack.

I checked `main` and the 3.4 branch, and this link is correct in those two branches, not sure how only the 3.5 branch has this issue.