### PR TITLE
chore(cd): trigger deployment after images are published

### DIFF
--- a/.github/release-workflows.jsonnet
+++ b/.github/release-workflows.jsonnet
@@ -195,6 +195,26 @@ local weeklyImageJobs = {
           ||| % { name: '%s-image' % name }),
         ])
       for name in std.objectFields(weeklyImageJobs)
+    } + {
+      'trigger-cd': job.new()
+                    + job.withNeeds(['loki-manifest', 'loki-canary-manifest'])
+                    + job.withIf("github.ref == 'refs/heads/main'")
+                    + job.withPermissions({
+                      contents: 'read',
+                      'id-token': 'write',
+                    })
+                    + job.withEnv({
+                      IMAGE_TAG: '${{ needs.loki-image.outputs.image_tag }}',
+                    })
+                    + job.withSteps([
+                      step.new('Trigger CD workflow', 'grafana/shared-workflows/actions/trigger-argo-workflow@8b88213bca76e86f9f59b43038cc5d7545452436')  // main
+                      + step.with({
+                        instance: 'ops',
+                        namespace: 'loki-cd',
+                        workflow_template: 'loki-continuous-deployment',
+                        parameters: 'imageTag=${{ env.IMAGE_TAG }}',
+                      }),
+                    ]),
     },
   }),
 }

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -503,6 +503,25 @@
           ${OUTPUTS_IMAGE_NAME}@${IMAGE_DIGEST_AMD64} \
           ${OUTPUTS_IMAGE_NAME}@${IMAGE_DIGEST_ARM}
         docker buildx imagetools inspect $IMAGE
+  "trigger-cd":
+    "env":
+      "IMAGE_TAG": "${{ needs.loki-image.outputs.image_tag }}"
+    "if": "github.ref == 'refs/heads/main'"
+    "needs":
+    - "loki-manifest"
+    - "loki-canary-manifest"
+    "permissions":
+      "contents": "read"
+      "id-token": "write"
+    "runs-on": "ubuntu-latest"
+    "steps":
+    - "name": "Trigger CD workflow"
+      "uses": "grafana/shared-workflows/actions/trigger-argo-workflow@8b88213bca76e86f9f59b43038cc5d7545452436"
+      "with":
+        "instance": "ops"
+        "namespace": "loki-cd"
+        "parameters": "imageTag=${{ env.IMAGE_TAG }}"
+        "workflow_template": "loki-continuous-deployment"
 "name": "Publish images"
 "on":
   "push":


### PR DESCRIPTION
**What this PR does / why we need it**:

Trigger continuous deployment workflow on after loki and loki-canary images are built.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
