### PR TITLE
fix(cd): add loki-image to needs

### DIFF
--- a/.github/release-workflows.jsonnet
+++ b/.github/release-workflows.jsonnet
@@ -197,7 +197,7 @@ local weeklyImageJobs = {
       for name in std.objectFields(weeklyImageJobs)
     } + {
       'trigger-cd': job.new()
-                    + job.withNeeds(['loki-manifest', 'loki-canary-manifest'])
+                    + job.withNeeds(['loki-image', 'loki-manifest', 'loki-canary-manifest'])
                     + job.withIf("github.ref == 'refs/heads/main'")
                     + job.withPermissions({
                       contents: 'read',

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -508,6 +508,7 @@
       "IMAGE_TAG": "${{ needs.loki-image.outputs.image_tag }}"
     "if": "github.ref == 'refs/heads/main'"
     "needs":
+    - "loki-image"
     - "loki-manifest"
     - "loki-canary-manifest"
     "permissions":


### PR DESCRIPTION
**What this PR does / why we need it**:

Adding `loki-image` to the list of trigger-cd needs. Otherwise, trigger-cd is not able to obtain `needs.loki-image.outputs.image_tag` and the image tag passed to the workflow is empty.

**Which issue(s) this PR fixes**:

https://github.com/grafana/loki/actions/runs/19368039264/job/55417596611

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
