### PR TITLE
chore: quality-of-life improvement to protobuf generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -696,7 +696,7 @@ documentation-helm-reference-check:
 ########
 
 # Targets can depend on ALWAYS_BUILD to run regardless of whether the target is
-# up-to-date or not.
+# up-to-date or not because PHONY targets are always rebuilt.
 .PHONY: ALWAYS_BUILD
 ALWAYS_BUILD:
 


### PR DESCRIPTION
This change makes it possible to generate individual protobuf files without deleting the pre-existing file (if one exists).

Protobuf generation is defined using the generated filename, meaning that the command would be a no-op if the file already exists. While `make protos` automatically deletes all the generated files, it does not do this for individual targets.

Adding a phony dependency to the %.pb.go rule allows regenerating individual .pb.go files without deleting them first.