### PR TITLE
fix: Set Content-Type header for JSON responses in serializeHTTPHandler

### DIFF
--- a/pkg/querier/queryrange/serialize.go
+++ b/pkg/querier/queryrange/serialize.go
@@ -82,6 +82,7 @@ func (rt *serializeHTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 		}
 		return
 	}
+	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 	version := loghttp.GetVersion(r.RequestURI)
 	encodingFlags := httpreq.ExtractEncodingFlags(r)
 	if err := encodeResponseJSONTo(version, response, w, encodingFlags); err != nil {


### PR DESCRIPTION
The serializeHTTPHandler was missing the Content-Type header for JSON responses, causing clients to receive "text/plain; charset=utf-8" instead of the expected "application/json; charset=UTF-8".

This bug was introduced in commit d0c11a689 (Dec 2024) when Parquet support was added. The Parquet code path correctly sets the Content-Type header, but the JSON code path (the default) was left without any Content-Type header.

The issue became visible in the last 4 weeks as the v2 engine router changes (commits 72cb64962 and d721511e6) made more query_range requests flow through this code path.

This fix ensures JSON responses from /loki/api/v1/query_range and other query endpoints have the correct Content-Type header set, matching the behavior in other parts of the codebase (see codec.go lines 686, 1304).

Fixes: https://github.com/grafana/loki/issues/[issue-number] (cherry picked from commit f27ccf63bc82858bd11fd9101eea1918762956e9)

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
