### PR TITLE
fix: reduce FetchMaxBytes to 10MB

### DIFF
--- a/pkg/limits/service.go
+++ b/pkg/limits/service.go
@@ -125,12 +125,12 @@ func New(cfg Config, limits Limits, logger log.Logger, reg prometheus.Registerer
 		kgo.OnPartitionsRevoked(s.partitionLifecycler.Revoke),
 		kgo.OnPartitionsLost(s.partitionLifecycler.Lost),
 		// For now these are hardcoded, but we might choose to make them
-		// configurable in the future. We allow up to 100MB to be buffered
-		// in total, and up to 1.5MB per partition. If an instance consumes
+		// configurable in the future. We allow up to 10MB to be buffered
+		// per broker, and up to 1.5MB per partition. If an instance consumes
 		// all partitions, then it can buffer 1.5MB * 64 partitions = 96MB.
 		// This allows us to run with less than 512MB of allocated heap using
 		// a GOMEMLIMIT of 512MiB.
-		kgo.FetchMaxBytes(100_000_000),        // 100MB
+		kgo.FetchMaxBytes(10_000_000),         // 10MB
 		kgo.FetchMaxPartitionBytes(1_500_000), // 1.5MB
 	)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request reduces `FetchMaxBytes` from 100MB to 10MB. This was causing OOMs when connected to multiple brokers with `equal_spread`, and also putting a lot of pressure on the GC to keep within GOMEMLIMIT of 512MB. Decreasing it to 10MB seems to have no negative effect on throughput having tested it in one of our dev cells.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
