### PR TITLE
chore: panic if we consume too many topics

### DIFF
--- a/pkg/limits/partition_lifecycler.go
+++ b/pkg/limits/partition_lifecycler.go
@@ -45,8 +45,12 @@ func newPartitionLifecycler(
 
 // Assign implements kgo.OnPartitionsAssigned.
 func (l *partitionLifecycler) Assign(ctx context.Context, _ *kgo.Client, topics map[string][]int32) {
-	// We expect the client to just consume one topic.
-	// TODO(grobinson): Figure out what to do if this is not the case.
+	if len(topics) > 1 {
+		panic(fmt.Sprintf("expected one topic, received %d topics", len(topics)))
+	}
+	// We expect just one topic, and panic if topics contains more than one
+	// topic. The range over topics just makes it easier to access the first
+	// value in a map containing a single key.
 	for _, partitions := range topics {
 		l.partitionManager.Assign(partitions)
 		for _, partition := range partitions {
@@ -59,18 +63,20 @@ func (l *partitionLifecycler) Assign(ctx context.Context, _ *kgo.Client, topics 
 				l.partitionManager.SetReady(partition)
 			}
 		}
-		return
 	}
 }
 
 // Revoke implements kgo.OnPartitionsRevoked.
 func (l *partitionLifecycler) Revoke(_ context.Context, _ *kgo.Client, topics map[string][]int32) {
-	// We expect the client to just consume one topic.
-	// TODO(grobinson): Figure out what to do if this is not the case.
+	if len(topics) > 1 {
+		panic(fmt.Sprintf("expected one topic, received %d topics", len(topics)))
+	}
+	// We expect just one topic, and panic if topics contains more than one
+	// topic. The range over topics just makes it easier to access the first
+	// value in a map containing a single key.
 	for _, partitions := range topics {
 		l.partitionManager.Revoke(partitions)
 		l.usage.EvictPartitions(partitions)
-		return
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The limits service is only supposed to consume one topic at a time. If we somehow consume two or more topics then we break the guarantees of the partition manager, as partition numbers are not globally unique. We should panic if this happens.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
