### PR TITLE
fix(retry): do not retry if any of multierrors is a client error

### DIFF
--- a/pkg/util/server/error.go
+++ b/pkg/util/server/error.go
@@ -71,9 +71,6 @@ func ClientHTTPStatusAndError(err error) (int, error) {
 	if ok && me.IsDeadlineExceeded() {
 		return http.StatusGatewayTimeout, errors.New(ErrDeadlineExceeded)
 	}
-	if ok && me.Is(logqlmodel.ErrParse) {
-
-	}
 
 	// Return 400 if any of the errors in the MultiError are client errors (4xx)
 	if ok {


### PR DESCRIPTION
**What this PR does / why we need it**:

Queriers always return 5xx as the status code when converting internal multi errors to http status code.
This results in retries even when the multierr contains client errors. 
 `"6 errors: rpc error: code = Code(400) desc = parse error : stage<...redacted>`

This pr updates the conversion code to return 4xx if any of the errors is a client error.


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
