### PR TITLE
fix(server): return status bad request code for interval limit error

### DIFF
--- a/pkg/util/server/error.go
+++ b/pkg/util/server/error.go
@@ -90,6 +90,7 @@ func ClientHTTPStatusAndError(err error) (int, error) {
 	case errors.As(err, &queryErr):
 		return http.StatusBadRequest, err
 	case errors.Is(err, logqlmodel.ErrLimit) ||
+		errors.Is(err, logqlmodel.ErrIntervalLimit) ||
 		errors.Is(err, logqlmodel.ErrParse) ||
 		errors.Is(err, logqlmodel.ErrPipeline) ||
 		errors.Is(err, logqlmodel.ErrBlocked) ||

--- a/pkg/util/server/error_test.go
+++ b/pkg/util/server/error_test.go
@@ -44,6 +44,7 @@ func Test_writeError(t *testing.T) {
 		{"mixed context and rpc deadline", util.MultiError{context.DeadlineExceeded, status.New(codes.DeadlineExceeded, context.DeadlineExceeded.Error()).Err()}, ErrDeadlineExceeded, http.StatusGatewayTimeout},
 		{"mixed context, rpc deadline and another", util.MultiError{errors.New("standard error"), context.DeadlineExceeded, status.New(codes.DeadlineExceeded, context.DeadlineExceeded.Error()).Err()}, "3 errors: standard error; context deadline exceeded; rpc error: code = DeadlineExceeded desc = context deadline exceeded", http.StatusInternalServerError},
 		{"parse error", logqlmodel.ParseError{}, "parse error : ", http.StatusBadRequest},
+		{"interval limit", logqlmodel.ErrIntervalLimit, logqlmodel.ErrIntervalLimit.Error(), http.StatusBadRequest},
 		{"httpgrpc", httpgrpc.Errorf(http.StatusBadRequest, "%s", errors.New("foo").Error()), "foo", http.StatusBadRequest},
 		{"internal", errors.New("foo"), "foo", http.StatusInternalServerError},
 		{"query error", storage_errors.ErrQueryMustContainMetricName, storage_errors.ErrQueryMustContainMetricName.Error(), http.StatusBadRequest},


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR provides a fix to thread `logqlmodel.ErrIntervalLimit` as a 400 error code (See grafana/loki/pull/8343)

**Which issue(s) this PR fixes**:
Fixes grafana/loki-private/issues/1614

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
