### PR TITLE
chore: Add tools/dev/kafka/data to .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 production/docker/.data
 .cache
+tools/dev/kafka/data


### PR DESCRIPTION
**What this PR does / why we need it**:

The Kafka development docker-compose setup creates [persistent data directories](https://github.com/grafana/loki/blob/main/tools/dev/kafka/docker-compose.yaml#L14) under tools/dev/kafka/data/grafana/ with restrictive permissions. Since .dockerignore doesn't exclude this path, Docker's build context attempts to read these directories when [copying the repository](https://github.com/grafana/loki/blob/main/cmd/loki/Dockerfile#L6), resulting in permission errors:

```
ERROR: failed to build: failed to solve: error from sender: open tools/dev/kafka/data/grafana/csv: permission denied
``` 

Adding the folder to the `.dockerignore` exclude it. We don't need that folder to build anyway. 


**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
