### PR TITLE
chore: add context.Context to Tee interface

### DIFF
--- a/pkg/distributor/dataobj_tee.go
+++ b/pkg/distributor/dataobj_tee.go
@@ -72,7 +72,7 @@ func NewDataObjTee(
 }
 
 // Duplicate implements the [Tee] interface.
-func (t *DataObjTee) Duplicate(tenant string, streams []KeyedStream) {
+func (t *DataObjTee) Duplicate(_ context.Context, tenant string, streams []KeyedStream) {
 	for _, s := range streams {
 		go t.duplicate(tenant, s)
 	}

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -773,7 +773,7 @@ func (d *Distributor) PushWithResolver(ctx context.Context, req *logproto.PushRe
 	// Nil check for performance reasons, to avoid dynamic lookup and/or no-op
 	// function calls that cannot be inlined.
 	if d.tee != nil {
-		d.tee.Duplicate(tenantID, streams)
+		d.tee.Duplicate(context.WithoutCancel(ctx), tenantID, streams)
 	}
 
 	const maxExpectedReplicationSet = 5 // typical replication factor 3 plus one for inactive plus one for luck

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -2138,7 +2138,7 @@ type mockTee struct {
 	tenant     string
 }
 
-func (mt *mockTee) Duplicate(tenant string, streams []KeyedStream) {
+func (mt *mockTee) Duplicate(_ context.Context, tenant string, streams []KeyedStream) {
 	mt.mu.Lock()
 	defer mt.mu.Unlock()
 	mt.duplicated = append(mt.duplicated, streams)

--- a/pkg/distributor/tee.go
+++ b/pkg/distributor/tee.go
@@ -1,8 +1,12 @@
 package distributor
 
+import (
+	"context"
+)
+
 // Tee implementations can duplicate the log streams to another endpoint.
 type Tee interface {
-	Duplicate(tenant string, streams []KeyedStream)
+	Duplicate(ctx context.Context, tenant string, streams []KeyedStream)
 }
 
 // WrapTee wraps a new Tee around an existing Tee.
@@ -20,8 +24,8 @@ type multiTee struct {
 	tees []Tee
 }
 
-func (m *multiTee) Duplicate(tenant string, streams []KeyedStream) {
+func (m *multiTee) Duplicate(ctx context.Context, tenant string, streams []KeyedStream) {
 	for _, tee := range m.tees {
-		tee.Duplicate(tenant, streams)
+		tee.Duplicate(ctx, tenant, streams)
 	}
 }

--- a/pkg/distributor/tee_test.go
+++ b/pkg/distributor/tee_test.go
@@ -1,6 +1,7 @@
 package distributor
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/mock"
@@ -12,11 +13,12 @@ type mockedTee struct {
 	mock.Mock
 }
 
-func (m *mockedTee) Duplicate(tenant string, streams []KeyedStream) {
-	m.Called(tenant, streams)
+func (m *mockedTee) Duplicate(ctx context.Context, tenant string, streams []KeyedStream) {
+	m.Called(ctx, tenant, streams)
 }
 
 func TestWrapTee(t *testing.T) {
+	ctx := t.Context()
 	tee1 := new(mockedTee)
 	tee2 := new(mockedTee)
 	tee3 := new(mockedTee)
@@ -26,21 +28,21 @@ func TestWrapTee(t *testing.T) {
 			Stream:  push.Stream{},
 		},
 	}
-	tee1.On("Duplicate", "1", streams).Once()
-	tee1.On("Duplicate", "2", streams).Once()
-	tee2.On("Duplicate", "2", streams).Once()
-	tee1.On("Duplicate", "3", streams).Once()
-	tee2.On("Duplicate", "3", streams).Once()
-	tee3.On("Duplicate", "3", streams).Once()
+	tee1.On("Duplicate", ctx, "1", streams).Once()
+	tee1.On("Duplicate", ctx, "2", streams).Once()
+	tee2.On("Duplicate", ctx, "2", streams).Once()
+	tee1.On("Duplicate", ctx, "3", streams).Once()
+	tee2.On("Duplicate", ctx, "3", streams).Once()
+	tee3.On("Duplicate", ctx, "3", streams).Once()
 
 	wrappedTee := WrapTee(nil, tee1)
-	wrappedTee.Duplicate("1", streams)
+	wrappedTee.Duplicate(ctx, "1", streams)
 
 	wrappedTee = WrapTee(wrappedTee, tee2)
-	wrappedTee.Duplicate("2", streams)
+	wrappedTee.Duplicate(ctx, "2", streams)
 
 	wrappedTee = WrapTee(wrappedTee, tee3)
-	wrappedTee.Duplicate("3", streams)
+	wrappedTee.Duplicate(ctx, "3", streams)
 
 	tee1.AssertExpectations(t)
 	tee2.AssertExpectations(t)

--- a/pkg/pattern/tee_service.go
+++ b/pkg/pattern/tee_service.go
@@ -419,7 +419,7 @@ func (ts *TeeService) sendBatch(ctx context.Context, clientRequest clientRequest
 }
 
 // Duplicate Implements distributor.Tee which is used to tee distributor requests to pattern ingesters.
-func (ts *TeeService) Duplicate(tenant string, streams []distributor.KeyedStream) {
+func (ts *TeeService) Duplicate(_ context.Context, tenant string, streams []distributor.KeyedStream) {
 	if !ts.cfg.Enabled {
 		return
 	}

--- a/pkg/pattern/tee_service_test.go
+++ b/pkg/pattern/tee_service_test.go
@@ -70,7 +70,7 @@ func TestPatternTeeBasic(t *testing.T) {
 	require.NoError(t, tee.Start(ctx))
 
 	now := time.Now()
-	tee.Duplicate("test-tenant", []distributor.KeyedStream{
+	tee.Duplicate(ctx, "test-tenant", []distributor.KeyedStream{
 		{HashKey: 123, Stream: push.Stream{
 			Labels: `{foo="bar"}`,
 			Entries: []push.Entry{
@@ -81,7 +81,7 @@ func TestPatternTeeBasic(t *testing.T) {
 		}},
 	})
 
-	tee.Duplicate("test-tenant", []distributor.KeyedStream{
+	tee.Duplicate(ctx, "test-tenant", []distributor.KeyedStream{
 		{HashKey: 123, Stream: push.Stream{
 			Labels: `{foo="bar"}`,
 			Entries: []push.Entry{
@@ -92,7 +92,7 @@ func TestPatternTeeBasic(t *testing.T) {
 		}},
 	})
 
-	tee.Duplicate("test-tenant", []distributor.KeyedStream{
+	tee.Duplicate(ctx, "test-tenant", []distributor.KeyedStream{
 		{HashKey: 456, Stream: push.Stream{
 			Labels: `{ping="pong"}`,
 			Entries: []push.Entry{
@@ -161,14 +161,14 @@ func TestPatternTeeEmptyStream(t *testing.T) {
 
 	require.NoError(t, tee.Start(ctx))
 
-	tee.Duplicate("test-tenant", []distributor.KeyedStream{
+	tee.Duplicate(ctx, "test-tenant", []distributor.KeyedStream{
 		{HashKey: 123, Stream: push.Stream{
 			Labels:  `{foo="bar"}`,
 			Entries: []push.Entry{},
 		}},
 	})
 
-	tee.Duplicate("test-tenant", []distributor.KeyedStream{
+	tee.Duplicate(ctx, "test-tenant", []distributor.KeyedStream{
 		{HashKey: 456, Stream: push.Stream{
 			Labels:  `{ping="pong"}`,
 			Entries: []push.Entry{},


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit adds support for context.Context to the Tee interface. This is required for segmentation key support as the tee must make gRPC calls onbehalf of the tenant.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
