### PR TITLE
chore: implement UpdateRates with simple in-memory tracker

### DIFF
--- a/pkg/limits/store_test.go
+++ b/pkg/limits/store_test.go
@@ -140,63 +140,63 @@ func TestUsageStore_Update(t *testing.T) {
 // This test asserts that we update the correct rate buckets, and as rate
 // buckets are implemented as a circular list, when we reach the end of
 // list the next bucket is the start of the list.
-// func TestUsageStore_UpdateRateBuckets(t *testing.T) {
-// 	s, err := newUsageStore(15*time.Minute, 5*time.Minute, time.Minute, 1, &mockLimits{}, prometheus.NewRegistry())
-// 	require.NoError(t, err)
-// 	clock := quartz.NewMock(t)
-// 	s.clock = clock
-// 	metadata := &proto.StreamMetadata{
-// 		StreamHash: 0x1,
-// 		TotalSize:  100,
-// 	}
-// 	// Metadata at clock.Now() should update the first rate bucket because
-// 	// the mocked clock starts at 2024-01-01T00:00:00Z.
-// 	time1 := clock.Now()
-// 	require.NoError(t, s.Update("tenant", metadata, time1))
-// 	stream, ok := s.getForTests("tenant", 0x1)
-// 	require.True(t, ok)
-// 	expected := newRateBuckets(5*time.Minute, time.Minute)
-// 	expected[0].timestamp = time1.UnixNano()
-// 	expected[0].size = 100
-// 	require.Equal(t, expected, stream.rateBuckets)
-// 	// Update the first bucket with the same metadata but 1 second later.
-// 	clock.Advance(time.Second)
-// 	time2 := clock.Now()
-// 	require.NoError(t, s.Update("tenant", metadata, time2))
-// 	expected[0].size = 200
-// 	require.Equal(t, expected, stream.rateBuckets)
-// 	// Advance the clock forward to the next bucket. Should update the second
-// 	// bucket and leave the first bucket unmodified.
-// 	clock.Advance(time.Minute)
-// 	time3 := clock.Now()
-// 	require.NoError(t, s.Update("tenant", metadata, time3))
-// 	stream, ok = s.getForTests("tenant", 0x1)
-// 	require.True(t, ok)
-// 	// As the clock is now 1 second ahead of the bucket start time, we must
-// 	// truncate the expected time to the start of the bucket.
-// 	expected[1].timestamp = time3.Truncate(time.Minute).UnixNano()
-// 	expected[1].size = 100
-// 	require.Equal(t, expected, stream.rateBuckets)
-// 	// Advance the clock to the last bucket.
-// 	clock.Advance(3 * time.Minute)
-// 	time4 := clock.Now()
-// 	require.NoError(t, s.Update("tenant", metadata, time4))
-// 	stream, ok = s.getForTests("tenant", 0x1)
-// 	require.True(t, ok)
-// 	expected[4].timestamp = time4.Truncate(time.Minute).UnixNano()
-// 	expected[4].size = 100
-// 	require.Equal(t, expected, stream.rateBuckets)
-// 	// Advance the clock one last one. It should wrap around to the start of
-// 	// the list and replace the original bucket with time1.
-// 	clock.Advance(time.Minute)
-// 	time5 := clock.Now()
-// 	require.NoError(t, s.Update("tenant", metadata, time5))
-// 	stream, ok = s.getForTests("tenant", 0x1)
-// 	require.True(t, ok)
-// 	expected[0].timestamp = time5.Truncate(time.Minute).UnixNano()
-// 	expected[0].size = 100
-// 	require.Equal(t, expected, stream.rateBuckets)
-// }
+func TestUsageStore_UpdateRates(t *testing.T) {
+	s, err := newUsageStore(15*time.Minute, 5*time.Minute, time.Minute, 1, &mockLimits{}, prometheus.NewRegistry())
+	require.NoError(t, err)
+	clock := quartz.NewMock(t)
+	s.clock = clock
+	metadata := []*proto.StreamMetadata{{
+		StreamHash: 0x1,
+		TotalSize:  100,
+	}}
+	// Metadata at clock.Now() should update the first rate bucket because
+	// the mocked clock starts at 2024-01-01T00:00:00Z.
+	time1 := clock.Now()
+	rates, err := s.UpdateRates("tenant", metadata, time1)
+	require.NoError(t, err)
+	expected := make([]rateBucket, 1, 5)
+	expected[0].timestamp = time1.UnixNano()
+	expected[0].size = 100
+	require.Len(t, rates, 1)
+	require.Equal(t, expected, rates[0].rateBuckets)
+	// Update the first bucket with the same metadata but 1 second later.
+	clock.Advance(time.Second)
+	time2 := clock.Now()
+	rates, err = s.UpdateRates("tenant", metadata, time2)
+	require.NoError(t, err)
+	expected[0].size = 200
+	require.Equal(t, expected, rates[0].rateBuckets)
+	// Advance the clock forward to the next bucket. Should update the second
+	// bucket and leave the first bucket unmodified.
+	clock.Advance(time.Minute)
+	time3 := clock.Now()
+	rates, err = s.UpdateRates("tenant", metadata, time3)
+	require.NoError(t, err)
+	// As the clock is now 1 second ahead of the bucket start time, we must
+	// truncate the expected time to the start of the bucket.
+	expected = append(expected, rateBucket{})
+	expected[1].timestamp = time3.Truncate(time.Minute).UnixNano()
+	expected[1].size = 100
+	require.Equal(t, expected, rates[0].rateBuckets)
+	// Advance the clock to the last bucket.
+	clock.Advance(3 * time.Minute)
+	time4 := clock.Now()
+	rates, err = s.UpdateRates("tenant", metadata, time4)
+	require.NoError(t, err)
+	expected = append(expected, rateBucket{})
+	expected[2].timestamp = time4.Truncate(time.Minute).UnixNano()
+	expected[2].size = 100
+	require.Equal(t, expected, rates[0].rateBuckets)
+	// Advance the clock one last one. It should wrap around to the start of
+	// the list and replace the original bucket with time1.
+	clock.Advance(time.Minute)
+	time5 := clock.Now()
+	rates, err = s.UpdateRates("tenant", metadata, time5)
+	require.NoError(t, err)
+	expected[0].timestamp = time5.Truncate(time.Minute).UnixNano()
+	expected[0].size = 100
+	require.Equal(t, expected, rates[0].rateBuckets)
+}
 
 // This test asserts that rate buckets are not updated while the TODOs are
 // in place.


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit implements `UpdateRates` with a simple in-memory tracker. It does not replicate to Kafka currently because this produces a huge amount of volume that we need to replay on every restart. For now, since rate buckets are refilled very quickly, I propose we keep these in-memory without replication while we think about how to solve this.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
