### PR TITLE
chore(engine): report saturation as load when there are no workers

### DIFF
--- a/pkg/engine/internal/scheduler/collector.go
+++ b/pkg/engine/internal/scheduler/collector.go
@@ -2,7 +2,6 @@ package scheduler
 
 import (
 	"context"
-	"math"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -138,7 +137,8 @@ func computeSaturation(sched *Scheduler) float64 {
 	})
 
 	if compute == 0 {
-		return math.Inf(1)
+		// If we have no compute capacity, fall back to the load as our ratio.
+		return float64(load)
 	}
 	return float64(load) / float64(compute)
 }


### PR DESCRIPTION
Previously, the saturation would be reported as infinite when there was no compute available. This made for poor visualization, where the infinite values would not appear on a graph.

To fix visualizing the saturation, we report the load (the numerator) when there's no compute available.
