### PR TITLE
chore: Reduce buffer size for bloom lookups

### DIFF
--- a/pkg/dataobj/metastore/object.go
+++ b/pkg/dataobj/metastore/object.go
@@ -813,7 +813,7 @@ func forEachObjPointer(ctx context.Context, object *dataobj.Object, predicate po
 	var reader pointers.RowReader
 	defer reader.Close()
 
-	buf := make([]pointers.SectionPointer, 1024)
+	buf := make([]pointers.SectionPointer, 128)
 
 	for _, section := range object.Sections().Filter(pointers.CheckSection) {
 		if section.Tenant != targetTenant {


### PR DESCRIPTION
**What this PR does / why we need it**:
This call will load (amongst other things) bloom filters, which can be quite large. I'm reducing the size of the buffer to (hopefully) reduce the maximum memory usage of this function, as per profiles.

<img width="1119" height="694" alt="image" src="https://github.com/user-attachments/assets/baa1d636-f98b-42f4-8ae4-e6a87264802b" />
