### PR TITLE
fix(docker): missing permissions  to start docker

### DIFF
--- a/cmd/loki/Dockerfile
+++ b/cmd/loki/Dockerfile
@@ -20,8 +20,8 @@ RUN mkdir -p /etc/loki /loki/rules /loki/rules-temp && \
 FROM gcr.io/distroless/static:nonroot
 
 COPY --from=build /src/loki/cmd/loki/loki /usr/bin/loki
-COPY --from=filesystem /etc/loki /etc/loki
-COPY --from=filesystem /loki /loki
+COPY --from=filesystem --chown=10001:10001 /etc/loki /etc/loki
+COPY --from=filesystem --chown=10001:10001 /loki /loki
 COPY --from=filesystem /etc/passwd /etc/passwd
 COPY --from=filesystem /etc/group /etc/group
 

--- a/cmd/loki/Dockerfile.cross
+++ b/cmd/loki/Dockerfile.cross
@@ -22,8 +22,8 @@ RUN mkdir -p /etc/loki /loki && \
 FROM gcr.io/distroless/static:nonroot
 
 COPY --from=goenv /src/loki/cmd/loki/loki /usr/bin/loki
-COPY --from=filesystem /etc/loki /etc/loki
-COPY --from=filesystem /loki /loki
+COPY --from=filesystem --chown=10001:10001 /etc/loki /etc/loki
+COPY --from=filesystem --chown=10001:10001 /loki /loki
 COPY --from=filesystem /etc/passwd /etc/passwd
 COPY --from=filesystem /etc/group /etc/group
 


### PR DESCRIPTION
**What this PR does / why we need it**:

With the latest release, the docker container is failing to start up because of missing permissions.

We need to update the docker file to copy the binaries with the right permissions for the user.

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/loki/issues/19904

**Special notes for your reviewer**:

Before this change starting the docker compose was failing with missing permissions.
As we have an intermediate step we need to copy the binaries with the right permissions or the docker will fail to start.

To reproduce:

* get the latest version and try to start docker compose will fail
* After this change, docker compose should start as expected

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
