### PR TITLE
chore: fix test name I messed up with find and replace

### DIFF
--- a/pkg/distributor/segment_test.go
+++ b/pkg/distributor/segment_test.go
@@ -62,7 +62,7 @@ func TestSegmentationKey_Sum64(t *testing.T) {
 	require.Equal(t, k2.Sum64(), k3.Sum64())
 }
 
-func TestSegmentationPartitionresolver_keys(t *testing.T) {
+func TestSegmentationPartitionResolve_Resolve(t *testing.T) {
 	// Set up a fake empty ring.
 	emptyRing := mockPartitionRingReader{}
 	emptyRing.ring = ring.NewPartitionRing(ring.PartitionRingDesc{})


### PR DESCRIPTION
**What this PR does / why we need it**:

I messed up a test name using find and replace to change metric names in `segment_test.go` in a previous commit.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
