### PR TITLE
fix(docker): set WORKDIR to root in loki Dockerfiles

### DIFF
--- a/cmd/loki/Dockerfile
+++ b/cmd/loki/Dockerfile
@@ -26,6 +26,7 @@ COPY --from=filesystem /etc/passwd /etc/passwd
 COPY --from=filesystem /etc/group /etc/group
 
 USER 10001
+WORKDIR /
 EXPOSE 3100
 ENTRYPOINT [ "/usr/bin/loki" ]
 CMD ["-config.file=/etc/loki/local-config.yaml"]

--- a/cmd/loki/Dockerfile.cross
+++ b/cmd/loki/Dockerfile.cross
@@ -28,6 +28,7 @@ COPY --from=filesystem /etc/passwd /etc/passwd
 COPY --from=filesystem /etc/group /etc/group
 
 USER 10001
+WORKDIR /
 EXPOSE 3100
 ENTRYPOINT [ "/usr/bin/loki" ]
 CMD ["-config.file=/etc/loki/local-config.yaml"]


### PR DESCRIPTION
Backport 13f2b1adaeb12e39d1019aa484488422feb499f1 from #19941

---

The change done in #19502 can cause problems when for instance using user namespace mappings.
This is because the distroless static image has workdir set to /home/nonroot, owned by the user
nonroot with uid of 65532 and permission of 700. Since the user is changed to
loki with uid 10001, this can cause the startup of container to fail, as there is
no permission to enter the workdir.
