### PR TITLE
chore(docs): Fix link to helm chart values.yaml

### DIFF
--- a/docs/sources/operations/meta-monitoring/deploy.md
+++ b/docs/sources/operations/meta-monitoring/deploy.md
@@ -93,7 +93,7 @@ Now that you have prepared your environment and collected the necessary credenti
 1. Download the `values.yaml` file from the Kubernetes Monitoring Helm chart repository:
 
    ```bash
-   curl -O https://raw.githubusercontent.com/grafana/loki/main/production/meta-monitoring/values.yaml
+   curl -O https://raw.githubusercontent.com/grafana/loki/main/production/helm/meta-monitoring/values.yaml
    ```
 
 1. Open the `values.yaml` file in a text editor of your choosing and add the Prometheus and Loki endpoints.


### PR DESCRIPTION
**What this PR does / why we need it**:
Follow on to [this](https://github.com/grafana/loki/pull/16835) and [this](https://github.com/grafana/loki/pull/16665) PR.

**Which issue(s) this PR fixes**:
Fixes location of `values.yaml` file.

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [X] Documentation added
- [ ] Tests updated
- [X] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
