### PR TITLE
chore: Use flag to set index consumer group

### DIFF
--- a/pkg/dataobj/index/builder.go
+++ b/pkg/dataobj/index/builder.go
@@ -63,7 +63,7 @@ type downloadedObject struct {
 }
 
 const (
-	indexConsumerGroup = "index-builder"
+	defaultIndexConsumerGroup = "index-builder"
 )
 
 // An interface for the methods needed from a calculator. Useful for testing.
@@ -166,6 +166,11 @@ func NewIndexBuilder(
 		indexerConfig{QueueSize: 64},
 	)
 
+	consumerGroup := defaultIndexConsumerGroup
+	if kafkaCfg.ConsumerGroup != "" {
+		consumerGroup = kafkaCfg.ConsumerGroup
+	}
+
 	kafkaCfg.AutoCreateTopicEnabled = true
 	eventConsumerClient, err := client.NewReaderClient(
 		"index_builder",
@@ -175,7 +180,7 @@ func NewIndexBuilder(
 		kgo.ConsumeTopics(kafkaCfg.Topic),
 		kgo.InstanceID(instanceID),
 		kgo.SessionTimeout(3*time.Minute),
-		kgo.ConsumerGroup(indexConsumerGroup),
+		kgo.ConsumerGroup(consumerGroup),
 		kgo.Balancers(kgo.RoundRobinBalancer()),
 		kgo.RebalanceTimeout(5*time.Minute),
 		kgo.DisableAutoCommit(),


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows to set the index-builder's consumer group via a flag. This is useful for testing variants of the current indexing strategy without interfering with the existing indexing, as it lets you run a concurrent index-builder with only a flag change.