### PR TITLE
docs: backport typo to 3.6

### DIFF
--- a/docs/sources/operations/storage/_index.md
+++ b/docs/sources/operations/storage/_index.md
@@ -42,7 +42,7 @@ For more information:
 
 ### ✅ Supported and recommended chunks stores
 
-- [Amazon Simple Storage Storage (S3)](https://aws.amazon.com/s3)
+- [Amazon Simple Storage Service (S3)](https://aws.amazon.com/s3)
 - [Google Cloud Storage (GCS)](https://cloud.google.com/storage/)
 - [Microsoft Azure Blob Storage](https://azure.microsoft.com/en-us/products/storage/blobs)
 - [IBM Cloud Object Storage (COS)](https://www.ibm.com/cloud/object-storage)


### PR DESCRIPTION
**What this PR does / why we need it**:

Manual backport of https://github.com/grafana/loki/pull/19905 to 3.6 branch.