### PR TITLE
feat: shuffle shard on tenant rate limit

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -307,6 +307,7 @@ func New(
 				&cfg.DataObjTeeConfig,
 				resolver,
 				ingestLimits,
+				overrides,
 				kafkaClient,
 				logger,
 				registerer,

--- a/pkg/distributor/segment_test.go
+++ b/pkg/distributor/segment_test.go
@@ -62,7 +62,7 @@ func TestSegmentationKey_Sum64(t *testing.T) {
 	require.Equal(t, k2.Sum64(), k3.Sum64())
 }
 
-func TestSegmentationPartitionResolve_Resolve(t *testing.T) {
+func TestSegmentationPartitionResolver_Resolve(t *testing.T) {
 	// Set up a fake empty ring.
 	emptyRing := mockPartitionRingReader{}
 	emptyRing.ring = ring.NewPartitionRing(ring.PartitionRingDesc{})
@@ -87,35 +87,10 @@ func TestSegmentationPartitionResolve_Resolve(t *testing.T) {
 		},
 	})
 
-	t.Run("uses random shuffle if rate unknown", func(t *testing.T) {
-		reg := prometheus.NewRegistry()
-		resolver := NewSegmentationPartitionResolver(1024, ringWithActivePartition, reg, log.NewNopLogger())
-		partition, err := resolver.Resolve(t.Context(), SegmentationKey("test"), 0)
-		require.NoError(t, err)
-		// Should return partition 1 since that is the only active partition.
-		require.Equal(t, int32(1), partition)
-		// Check the metrics to make sure it fell back to random shuffle.
-		require.NoError(t, testutil.GatherAndCompare(reg, bytes.NewBufferString(`
-			# HELP loki_distributor_segmentation_partition_resolver_keys_randomly_sharded_total Total number of segmentation keys that fell back to a random active partition due to absent rate.
-			# TYPE loki_distributor_segmentation_partition_resolver_keys_randomly_sharded_total counter
-			loki_distributor_segmentation_partition_resolver_keys_randomly_sharded_total 1
-			# HELP loki_distributor_segmentation_partition_resolver_keys_failed_total Total number of segmentation keys that could not be resolved.
-			# TYPE loki_distributor_segmentation_partition_resolver_keys_failed_total counter
-			loki_distributor_segmentation_partition_resolver_keys_failed_total 0
-			# HELP loki_distributor_segmentation_partition_resolver_keys_total Total number of segmentation keys passed to the resolver.
-			# TYPE loki_distributor_segmentation_partition_resolver_keys_total counter
-			loki_distributor_segmentation_partition_resolver_keys_total 1
-		`),
-			"loki_distributor_segmentation_partition_resolver_keys_allback_total",
-			"loki_distributor_segmentation_partition_resolver_keys_failed_total",
-			"loki_distributor_segmentation_partition_resolver_keys_total",
-		))
-	})
-
-	t.Run("returns error if rate unknown and no active partitions", func(t *testing.T) {
+	t.Run("returns error if no active partitions", func(t *testing.T) {
 		reg := prometheus.NewRegistry()
 		resolver := NewSegmentationPartitionResolver(1024, emptyRing, reg, log.NewNopLogger())
-		partition, err := resolver.Resolve(t.Context(), SegmentationKey("test"), 0)
+		partition, err := resolver.Resolve(t.Context(), "tenant", SegmentationKey("test"), 0, 0)
 		require.EqualError(t, err, "no active partitions")
 		require.Equal(t, int32(0), partition)
 		// Check the metrics to make sure it fell back to random shuffle and
@@ -137,10 +112,35 @@ func TestSegmentationPartitionResolve_Resolve(t *testing.T) {
 		))
 	})
 
+	t.Run("uses random shuffle if rate unknown", func(t *testing.T) {
+		reg := prometheus.NewRegistry()
+		resolver := NewSegmentationPartitionResolver(1024, ringWithActivePartition, reg, log.NewNopLogger())
+		partition, err := resolver.Resolve(t.Context(), "tenant", SegmentationKey("test"), 0, 0)
+		require.NoError(t, err)
+		// Should return partition 1 since that is the only active partition.
+		require.Equal(t, int32(1), partition)
+		// Check the metrics to make sure it fell back to random shuffle.
+		require.NoError(t, testutil.GatherAndCompare(reg, bytes.NewBufferString(`
+			# HELP loki_distributor_segmentation_partition_resolver_keys_randomly_sharded_total Total number of segmentation keys that fell back to a random active partition due to absent rate.
+			# TYPE loki_distributor_segmentation_partition_resolver_keys_randomly_sharded_total counter
+			loki_distributor_segmentation_partition_resolver_keys_randomly_sharded_total 1
+			# HELP loki_distributor_segmentation_partition_resolver_keys_failed_total Total number of segmentation keys that could not be resolved.
+			# TYPE loki_distributor_segmentation_partition_resolver_keys_failed_total counter
+			loki_distributor_segmentation_partition_resolver_keys_failed_total 0
+			# HELP loki_distributor_segmentation_partition_resolver_keys_total Total number of segmentation keys passed to the resolver.
+			# TYPE loki_distributor_segmentation_partition_resolver_keys_total counter
+			loki_distributor_segmentation_partition_resolver_keys_total 1
+		`),
+			"loki_distributor_segmentation_partition_resolver_keys_allback_total",
+			"loki_distributor_segmentation_partition_resolver_keys_failed_total",
+			"loki_distributor_segmentation_partition_resolver_keys_total",
+		))
+	})
+
 	t.Run("shuffle shards on segmentation key if rate is known", func(t *testing.T) {
 		reg := prometheus.NewRegistry()
 		resolver := NewSegmentationPartitionResolver(1024, ringWithActivePartition, reg, log.NewNopLogger())
-		partition, err := resolver.Resolve(t.Context(), SegmentationKey("test"), 512)
+		partition, err := resolver.Resolve(t.Context(), "tenant", SegmentationKey("test"), 512, 0)
 		require.NoError(t, err)
 		require.Equal(t, int32(1), partition)
 		require.NoError(t, testutil.GatherAndCompare(reg, bytes.NewBufferString(`
@@ -158,5 +158,125 @@ func TestSegmentationPartitionResolve_Resolve(t *testing.T) {
 			"loki_distributor_segmentation_partition_resolver_keys_failed_total",
 			"loki_distributor_segmentation_partition_resolver_keys_total",
 		))
+	})
+}
+
+func TestSegmentationPartitionResolver_GetTenantSubring(t *testing.T) {
+	// Set up a fake partition ring with two active partitions.
+	ringWithActivePartitions := mockPartitionRingReader{}
+	ringWithActivePartitions.ring = ring.NewPartitionRing(ring.PartitionRingDesc{
+		Partitions: map[int32]ring.PartitionDesc{
+			1: {
+				Id:             1,
+				Tokens:         []uint32{1},
+				State:          ring.PartitionActive,
+				StateTimestamp: time.Now().Unix(),
+			},
+			2: {
+				Id:             2,
+				Tokens:         []uint32{2},
+				State:          ring.PartitionActive,
+				StateTimestamp: time.Now().Unix(),
+			},
+		},
+		Owners: map[string]ring.OwnerDesc{
+			"owner1": {
+				OwnedPartition:   1,
+				State:            ring.OwnerActive,
+				UpdatedTimestamp: time.Now().Unix(),
+			},
+			"owner2": {
+				OwnedPartition:   2,
+				State:            ring.OwnerActive,
+				UpdatedTimestamp: time.Now().Unix(),
+			},
+		},
+	})
+
+	t.Run("no rate returns full ring", func(t *testing.T) {
+		reg := prometheus.NewRegistry()
+		resolver := NewSegmentationPartitionResolver(1024, ringWithActivePartitions, reg, log.NewNopLogger())
+		ring := ringWithActivePartitions.PartitionRing()
+		subring, err := resolver.getTenantSubring(t.Context(), ring, "tenant", 0)
+		require.NoError(t, err)
+		require.Equal(t, ring, subring)
+	})
+
+	t.Run("rate equals partition rate returns subring with one partition", func(t *testing.T) {
+		reg := prometheus.NewRegistry()
+		resolver := NewSegmentationPartitionResolver(1024, ringWithActivePartitions, reg, log.NewNopLogger())
+		ring := ringWithActivePartitions.PartitionRing()
+		subring, err := resolver.getTenantSubring(t.Context(), ring, "tenant", 1024)
+		require.NoError(t, err)
+		require.Equal(t, 1, subring.ActivePartitionsCount())
+	})
+
+	t.Run("rate exceeds partition rate returns subring with all partitions", func(t *testing.T) {
+		reg := prometheus.NewRegistry()
+		resolver := NewSegmentationPartitionResolver(1024, ringWithActivePartitions, reg, log.NewNopLogger())
+		ring := ringWithActivePartitions.PartitionRing()
+		subring, err := resolver.getTenantSubring(t.Context(), ring, "tenant", 2048)
+		require.NoError(t, err)
+		require.Equal(t, 2, subring.ActivePartitionsCount())
+	})
+}
+
+func TestSegmentationPartitionResolver_GetSegmentationKeySubring(t *testing.T) {
+	// Set up a fake partition ring with two active partitions.
+	ringWithActivePartitions := mockPartitionRingReader{}
+	ringWithActivePartitions.ring = ring.NewPartitionRing(ring.PartitionRingDesc{
+		Partitions: map[int32]ring.PartitionDesc{
+			1: {
+				Id:             1,
+				Tokens:         []uint32{1},
+				State:          ring.PartitionActive,
+				StateTimestamp: time.Now().Unix(),
+			},
+			2: {
+				Id:             2,
+				Tokens:         []uint32{2},
+				State:          ring.PartitionActive,
+				StateTimestamp: time.Now().Unix(),
+			},
+		},
+		Owners: map[string]ring.OwnerDesc{
+			"owner1": {
+				OwnedPartition:   1,
+				State:            ring.OwnerActive,
+				UpdatedTimestamp: time.Now().Unix(),
+			},
+			"owner2": {
+				OwnedPartition:   2,
+				State:            ring.OwnerActive,
+				UpdatedTimestamp: time.Now().Unix(),
+			},
+		},
+	})
+
+	t.Run("no rate returns full ring", func(t *testing.T) {
+		reg := prometheus.NewRegistry()
+		resolver := NewSegmentationPartitionResolver(1024, ringWithActivePartitions, reg, log.NewNopLogger())
+		ring := ringWithActivePartitions.PartitionRing()
+		subring, err := resolver.getSegmentationKeySubring(t.Context(), ring, SegmentationKey("test"), 0)
+		require.NoError(t, err)
+		require.Equal(t, ring, subring)
+	})
+
+	t.Run("rate equals partition rate returns subring with one partition", func(t *testing.T) {
+		reg := prometheus.NewRegistry()
+		resolver := NewSegmentationPartitionResolver(1024, ringWithActivePartitions, reg, log.NewNopLogger())
+		ring := ringWithActivePartitions.PartitionRing()
+		subring, err := resolver.getSegmentationKeySubring(t.Context(), ring, SegmentationKey("test"), 1024)
+		require.NoError(t, err)
+		require.Equal(t, 1, subring.ActivePartitionsCount())
+	})
+
+	t.Run("rate exceeds partition rate returns subring with all partitions", func(t *testing.T) {
+		reg := prometheus.NewRegistry()
+		resolver := NewSegmentationPartitionResolver(1024, ringWithActivePartitions, reg, log.NewNopLogger())
+		ring := ringWithActivePartitions.PartitionRing()
+		subring, err := resolver.getSegmentationKeySubring(t.Context(), ring, SegmentationKey("test"), 2048)
+		require.NoError(t, err)
+		require.Equal(t, 2, subring.ActivePartitionsCount())
 	})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request adds support for shuffle sharding based on the tenant rate limit. It helps co-locate segmentation keys for low volume tenants together into the same data object, improving query performance for queries that query two or more segmentation keys at the same time. For example:

```
{service_name=~"foo|bar"}
```

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
