### PR TITLE
feat: add prepare downscale handler

### DIFF
--- a/pkg/dataobj/consumer/http.go
+++ b/pkg/dataobj/consumer/http.go
@@ -10,6 +10,13 @@ import (
 	"github.com/grafana/loki/v3/pkg/util"
 )
 
+// PrepareDownscaleHandler is a special handler called by the rollout operator
+// immediately before the pod is downscaled. It can stop a downscale by
+// responding with a non 2xx status code.
+func (s *Service) PrepareDownscaleHandler(_ http.ResponseWriter, _ *http.Request) {
+	s.partitionInstanceLifecycler.SetRemoveOwnerOnShutdown(true)
+}
+
 // PrepareDelayedDownscaleHandler is a special handler called by the rollout
 // operator to prepare for a delayed downscale. This allows the service to
 // perform any number of actions in preparation of being scaled down at the

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -2405,6 +2405,10 @@ func (t *Loki) initDataObjConsumer() (services.Service, error) {
 	)
 	t.Server.HTTP.
 		Methods(http.MethodGet, http.MethodPost, http.MethodDelete).
+		Path("/dataobj-consumer/prepare-downscale").
+		Handler(httpMiddleware.Wrap(http.HandlerFunc(t.dataObjConsumer.PrepareDownscaleHandler)))
+	t.Server.HTTP.
+		Methods(http.MethodGet, http.MethodPost, http.MethodDelete).
 		Path("/dataobj-consumer/prepare-delayed-downscale").
 		Handler(httpMiddleware.Wrap(http.HandlerFunc(t.dataObjConsumer.PrepareDelayedDownscaleHandler)))
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request adds a prepare downscale handler so dataobj-consumers remove their ownership of partitions when we downscale. This allows partitions to be cleaned up in the ring.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
