### PR TITLE
fix: counting of discarded log volume with otlp endpoint

### DIFF
--- a/pkg/distributor/http.go
+++ b/pkg/distributor/http.go
@@ -148,7 +148,7 @@ func (d *Distributor) pushHandler(w http.ResponseWriter, r *http.Request, pushRe
 		}
 	}
 
-	_, err = d.PushWithResolver(r.Context(), req, streamResolver, format)
+	_, err = d.PushWithResolver(r.Context(), req, streamResolver, format, *pushStats)
 	if err == nil {
 		if d.tenantConfigs.LogPushRequest(tenantID) {
 			level.Debug(logger).Log(

--- a/pkg/distributor/ingest_limits.go
+++ b/pkg/distributor/ingest_limits.go
@@ -182,7 +182,7 @@ func newExceedsLimitsRequest(tenant string, streams []KeyedStream) (*proto.Excee
 	// from the request caused it to exceed its limits.
 	streamMetadata := make([]*proto.StreamMetadata, 0, len(streams))
 	for _, stream := range streams {
-		entriesSize, structuredMetadataSize := calculateStreamSizes(stream.Stream)
+		entriesSize, structuredMetadataSize := calculateStreamSizes(stream.Stream, nil)
 		streamMetadata = append(streamMetadata, &proto.StreamMetadata{
 			StreamHash:      stream.HashKeyNoShard,
 			TotalSize:       entriesSize + structuredMetadataSize,
@@ -220,7 +220,7 @@ func newUpdateRatesRequest(tenant string, streams []SegmentedStream) (*proto.Upd
 	// from the request caused it to exceed its limits.
 	streamMetadata := make([]*proto.StreamMetadata, 0, len(streams))
 	for _, stream := range streams {
-		entriesSize, structuredMetadataSize := calculateStreamSizes(stream.Stream)
+		entriesSize, structuredMetadataSize := calculateStreamSizes(stream.Stream, nil)
 		streamMetadata = append(streamMetadata, &proto.StreamMetadata{
 			StreamHash:      stream.SegmentationKeyHash,
 			TotalSize:       entriesSize + structuredMetadataSize,

--- a/pkg/distributor/validation_metrics.go
+++ b/pkg/distributor/validation_metrics.go
@@ -1,6 +1,7 @@
 package distributor
 
 import (
+	"github.com/grafana/loki/pkg/push"
 	"github.com/grafana/loki/v3/pkg/logproto"
 	"github.com/grafana/loki/v3/pkg/util"
 )
@@ -8,6 +9,8 @@ import (
 type pushStats struct {
 	lineSize  int
 	lineCount int
+
+	lineSizeWithoutResourceAndScopeAttributes int
 }
 
 type validationMetrics struct {
@@ -23,7 +26,7 @@ func newValidationMetrics(tenantRetentionHours string) validationMetrics {
 	}
 }
 
-func (v *validationMetrics) compute(entry logproto.Entry, retentionHours string, policy string) {
+func (v *validationMetrics) compute(entry logproto.Entry, retentionHours string, policy string, resourceAndScopeAttributes push.LabelsAdapter) {
 	if _, ok := v.policyPushStats[policy]; !ok {
 		v.policyPushStats[policy] = make(map[string]pushStats)
 	}
@@ -32,13 +35,19 @@ func (v *validationMetrics) compute(entry logproto.Entry, retentionHours string,
 		v.policyPushStats[policy][retentionHours] = pushStats{}
 	}
 
-	totalEntrySize := util.EntryTotalSize(&entry)
+	totalEntrySize := util.EntryTotalSize(&entry, nil)
+	totalEntrySizeWithoutResourceAndScopeAttributes := totalEntrySize
+	if len(resourceAndScopeAttributes) != 0 {
+		totalEntrySizeWithoutResourceAndScopeAttributes = util.EntryTotalSize(&entry, resourceAndScopeAttributes)
+	}
 
 	v.aggregatedPushStats.lineSize += totalEntrySize
+	v.aggregatedPushStats.lineSizeWithoutResourceAndScopeAttributes += totalEntrySizeWithoutResourceAndScopeAttributes
 	v.aggregatedPushStats.lineCount++
 
 	stats := v.policyPushStats[policy][retentionHours]
 	stats.lineCount++
 	stats.lineSize += totalEntrySize
+	stats.lineSizeWithoutResourceAndScopeAttributes += totalEntrySizeWithoutResourceAndScopeAttributes
 	v.policyPushStats[policy][retentionHours] = stats
 }

--- a/pkg/distributor/validator.go
+++ b/pkg/distributor/validator.go
@@ -100,7 +100,7 @@ func (v Validator) ValidateEntry(ctx context.Context, vCtx validationContext, la
 	ts := entry.Timestamp.UnixNano()
 	validation.LineLengthHist.Observe(float64(len(entry.Line)))
 	structuredMetadataCount := len(entry.StructuredMetadata)
-	structuredMetadataSizeBytes := util.StructuredMetadataSize(entry.StructuredMetadata)
+	structuredMetadataSizeBytes := util.StructuredMetadataSize(entry.StructuredMetadata, nil)
 	entrySize := float64(len(entry.Line) + structuredMetadataSizeBytes)
 
 	if vCtx.rejectOldSample && ts < vCtx.rejectOldSampleMaxAge {
@@ -178,7 +178,7 @@ func (v Validator) ValidateLabels(vCtx validationContext, ls labels.Labels, stre
 		numLabelNames--
 	}
 
-	entriesSize := util.EntriesTotalSize(stream.Entries)
+	entriesSize := util.EntriesTotalSize(stream.Entries, nil)
 
 	if numLabelNames > vCtx.maxLabelNamesPerSeries {
 		v.reportDiscardedData(validation.MaxLabelNamesPerSeries, vCtx, retentionHours, policy, entriesSize, len(stream.Entries), format)

--- a/pkg/ingester/instance.go
+++ b/pkg/ingester/instance.go
@@ -375,7 +375,7 @@ func (i *instance) onStreamCreationError(ctx context.Context, pushReqStream logp
 	}
 
 	validation.DiscardedSamples.WithLabelValues(validation.StreamLimit, i.instanceID, retentionHours, policy, format).Add(float64(len(pushReqStream.Entries)))
-	bytes := util.EntriesTotalSize(pushReqStream.Entries)
+	bytes := util.EntriesTotalSize(pushReqStream.Entries, nil)
 	validation.DiscardedBytes.WithLabelValues(validation.StreamLimit, i.instanceID, retentionHours, policy, format).Add(float64(bytes))
 	if i.customStreamsTracker != nil {
 		i.customStreamsTracker.DiscardedBytesAdd(ctx, i.instanceID, validation.StreamLimit, labels, float64(bytes), format)

--- a/pkg/ingester/stream.go
+++ b/pkg/ingester/stream.go
@@ -358,7 +358,7 @@ func (s *stream) storeEntries(ctx context.Context, entries []logproto.Entry, usa
 			if chunkenc.IsOutOfOrderErr(err) {
 				s.writeFailures.Log(s.tenant, err)
 				outOfOrderSamples++
-				outOfOrderBytes += util.EntryTotalSize(&entries[i])
+				outOfOrderBytes += util.EntryTotalSize(&entries[i], nil)
 			}
 			continue
 		}
@@ -421,7 +421,7 @@ func (s *stream) validateEntries(ctx context.Context, entries []logproto.Entry, 
 			continue
 		}
 
-		entryBytes := util.EntryTotalSize(&entries[i])
+		entryBytes := util.EntryTotalSize(&entries[i], nil)
 		totalBytes += entryBytes
 
 		now := time.Now()
@@ -468,10 +468,10 @@ func (s *stream) validateEntries(ctx context.Context, entries []logproto.Entry, 
 				&validation.ErrStreamRateLimit{
 					RateLimit: flagext.ByteSize(limit),
 					Labels:    s.labelsString,
-					Bytes:     flagext.ByteSize(util.EntryTotalSize(&toStore[i])),
+					Bytes:     flagext.ByteSize(util.EntryTotalSize(&toStore[i], nil)),
 				},
 			})
-			rateLimitedBytes += util.EntryTotalSize(&toStore[i])
+			rateLimitedBytes += util.EntryTotalSize(&toStore[i], nil)
 		}
 
 		// Log the only last error to the write failures manager.

--- a/pkg/loghttp/push/otlp.go
+++ b/pkg/loghttp/push/otlp.go
@@ -240,7 +240,7 @@ func otlpToLokiPushRequest(ctx context.Context, ld plog.Logs, userID string, otl
 		}
 
 		// Calculate resource attributes metadata size for stats
-		resourceAttributesAsStructuredMetadataSize := loki_util.StructuredMetadataSize(resourceAttributesAsStructuredMetadata)
+		resourceAttributesAsStructuredMetadataSize := loki_util.StructuredMetadataSize(resourceAttributesAsStructuredMetadata, nil)
 		retentionPeriodForUser := streamResolver.RetentionPeriodFor(lbs)
 		policy := streamResolver.PolicyFor(ctx, lbs)
 
@@ -317,7 +317,7 @@ func otlpToLokiPushRequest(ctx context.Context, ld plog.Logs, userID string, otl
 				})
 			}
 
-			scopeAttributesAsStructuredMetadataSize := loki_util.StructuredMetadataSize(scopeAttributesAsStructuredMetadata)
+			scopeAttributesAsStructuredMetadataSize := loki_util.StructuredMetadataSize(scopeAttributesAsStructuredMetadata, nil)
 			stats.StructuredMetadataBytes[policy][retentionPeriodForUser] += int64(scopeAttributesAsStructuredMetadataSize)
 			totalBytesReceived += int64(scopeAttributesAsStructuredMetadataSize)
 
@@ -369,7 +369,7 @@ func otlpToLokiPushRequest(ctx context.Context, ld plog.Logs, userID string, otl
 
 				// Calculate the entry's own metadata size BEFORE adding resource and scope attributes
 				// This preserves the intent of tracking entry-specific metadata separately without requiring subtraction
-				entryOwnMetadataSize := int64(loki_util.StructuredMetadataSize(entry.StructuredMetadata))
+				entryOwnMetadataSize := int64(loki_util.StructuredMetadataSize(entry.StructuredMetadata, nil))
 
 				// if entry.StructuredMetadata doesn't have capacity to add resource and scope attributes, make a new slice with enough capacity
 				attributesAsStructuredMetadataLen := len(resourceAttributesAsStructuredMetadata) + len(scopeAttributesAsStructuredMetadata)
@@ -436,7 +436,7 @@ func otlpToLokiPushRequest(ctx context.Context, ld plog.Logs, userID string, otl
 			// It's difficult to calculate these values inline when we process the payload because promotion of resource attributes or log attributes to labels can change the stream with each entry.
 			// So for simplicity and because this logging is typically disabled, we iterate on the entries to calculate these values here.
 			for _, entry := range stream.Entries {
-				streamSizeBytes += int64(len(entry.Line)) + int64(loki_util.StructuredMetadataSize(entry.StructuredMetadata))
+				streamSizeBytes += int64(len(entry.Line)) + int64(loki_util.StructuredMetadataSize(entry.StructuredMetadata, nil))
 				if entry.Timestamp.After(mostRecentEntryTimestamp) {
 					mostRecentEntryTimestamp = entry.Timestamp
 				}

--- a/pkg/util/entry_size.go
+++ b/pkg/util/entry_size.go
@@ -8,24 +8,28 @@ import (
 	"github.com/grafana/loki/v3/pkg/util/constants"
 )
 
-func EntriesTotalSize(entries []push.Entry) int {
+func EntriesTotalSize(entries []push.Entry, resourceAndScopeAttributes push.LabelsAdapter) int {
 	size := 0
 	for _, entry := range entries {
-		size += EntryTotalSize(&entry)
+		size += EntryTotalSize(&entry, resourceAndScopeAttributes)
 	}
 	return size
 }
 
-func EntryTotalSize(entry *push.Entry) int {
-	return len(entry.Line) + StructuredMetadataSize(entry.StructuredMetadata)
+func EntryTotalSize(entry *push.Entry, resourceAndScopeAttributes push.LabelsAdapter) int {
+	return len(entry.Line) + StructuredMetadataSize(entry.StructuredMetadata, resourceAndScopeAttributes)
 }
 
 var ExcludedStructuredMetadataLabels = []string{constants.LevelLabel}
 
-func StructuredMetadataSize(metas push.LabelsAdapter) int {
+// StructuredMetadataSize calculates total size of structured metadata excluding ExcludedStructuredMetadataLabels and the given resourceAndScopeAttributes.
+func StructuredMetadataSize(metas, resourceAndScopeAttributes push.LabelsAdapter) int {
 	size := 0
 	for _, meta := range metas {
 		if slices.Contains(ExcludedStructuredMetadataLabels, meta.Name) {
+			continue
+		}
+		if resourceAndScopeAttributes != nil && slices.Contains(resourceAndScopeAttributes, meta) {
 			continue
 		}
 		size += len(meta.Name) + len(meta.Value)


### PR DESCRIPTION
**What this PR does / why we need it**:
We only index select resource and scope attributes as index labels and store the remaining as structured metadata with each log line from that resource and scope. When counting the ingest volume, we only count one replica of the resource and scope attribute stored as structured metadata. However, when logs are discarded, we count all the replicas of the resource and scope attribute stored as structured metadata, which results in reporting a higher discarded logs volume than the ingested volume.

To resolve the issue, while counting the discarded log entry size, I am eliminating resource and scope attributes stored as structured metadata, which are included in the push stats generated during log parsing.

**Checklist**
- [x] Tests updated