### PR TITLE
chore: Update renovate to scan Loki 3.6

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -16,16 +16,16 @@
   prHourlyLimit: 4,
   baseBranchPatterns: [
     'main',
-    'release-3.5.x', // Update when a new release is out, 2 minors, 1 major.
-    //'release-3.4.x', // Also ensure to update the 'packageRules' section to match
-    'release-2.9.x',
+    'release-3.6.x', // Update when a new release is out, 2 minors, 1 major.
+    'release-3.5.x', // Also ensure to update the 'packageRules' section to match
+    //'release-2.9.x',
   ],
   packageRules: [
     {
       // Disable updates for all branches - we only want security updates
       matchBaseBranches: [
+        'release-3.6.x',
         'release-3.5.x',
-        'release-3.4.x',
         'release-2.9.x',
       ],
       enabled: false,


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes Loki 3.4 from Renovate, adds Loki 3.6.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
