### PR TITLE
docs: Update RN 3.6.2

### DIFF
--- a/docs/sources/release-notes/v3-6.md
+++ b/docs/sources/release-notes/v3-6.md
@@ -220,6 +220,10 @@ For important upgrade guidance, refer to the [Upgrade Guide](https://grafana.com
 
 ## Bug fixes
 
+### 3.6.2 (2025-11-25)
+
+* **deps:** Loki 3.6.1 CVE updates.
+
 ### 3.6.1 (2025-11-21)
 
 * **docker:** Missing permissions  to start Docker ([#19948](https://github.com/grafana/loki/issues/19948)) ([48b507f](https://github.com/grafana/loki/commit/48b507f62f4d5a92cbf2fcb5025a1f1cdc199411))


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the Release Notes for the 3.6.2 patch release.