### PR TITLE
docs: Fix YAML indentation in S3 Object Store example for microservice Helm chart

### DIFF
--- a/docs/sources/setup/install/helm/install-microservices/_index.md
+++ b/docs/sources/setup/install/helm/install-microservices/_index.md
@@ -234,49 +234,49 @@ loki:
       # HTTP configuration settings
       http_config: {}
 
-  deploymentMode: Distributed
+deploymentMode: Distributed
 
-  # Disable minio storage
-  minio:
-      enabled: false
+# Disable minio storage
+minio:
+    enabled: false
 
-  ingester:
-    replicas: 3
-    zoneAwareReplication:
-      enabled: false
-  querier:
-    replicas: 3
-    maxUnavailable: 2
-  queryFrontend:
-    replicas: 2
-    maxUnavailable: 1
-  queryScheduler:
-    replicas: 2
-  distributor:
-    replicas: 3
-    maxUnavailable: 2
-  compactor:
-    replicas: 1
-  indexGateway:
-    replicas: 2
-    maxUnavailable: 1
+ingester:
+replicas: 3
+zoneAwareReplication:
+    enabled: false
+querier:
+replicas: 3
+maxUnavailable: 2
+queryFrontend:
+replicas: 2
+maxUnavailable: 1
+queryScheduler:
+replicas: 2
+distributor:
+replicas: 3
+maxUnavailable: 2
+compactor:
+replicas: 1
+indexGateway:
+replicas: 2
+maxUnavailable: 1
 
-  bloomPlanner:
-    replicas: 0
-  bloomBuilder:
-    replicas: 0
-  bloomGateway:
-    replicas: 0
+bloomPlanner:
+replicas: 0
+bloomBuilder:
+replicas: 0
+bloomGateway:
+replicas: 0
 
-  backend:
-    replicas: 0
-  read:
-    replicas: 0
-  write:
-    replicas: 0
+backend:
+replicas: 0
+read:
+replicas: 0
+write:
+replicas: 0
 
-  singleBinary:
-    replicas: 0
+singleBinary:
+replicas: 0
 
 ```
 {{< /collapse >}}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a YAML indentation issue in the S3 Object Store example for the microservice Helm chart in the Loki documentation (version 3.6.x). The current example places configuration keys such as deploymentMode, ingester, and querier at the same indentation level as the nested loki: block, resulting in duplicate keys and YAML unmarshal errors during deployment.

By correcting the indentation so that all configuration after the initial loki: block (starting from deploymentMode: Distributed) is at the top level (not nested under loki:), the example becomes valid YAML and deploys successfully.

**Which issue(s) this PR fixes**:
Fixes [#20027](https://github.com/grafana/loki/issues/20027)

**Special notes for your reviewer**:
The fix aligns the S3 example with the other storage examples on the page.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
