### PR TITLE
chore: use tenant instead of service_name for pattern_ingester_metric_samples

### DIFF
--- a/pkg/pattern/instance.go
+++ b/pkg/pattern/instance.go
@@ -384,6 +384,6 @@ func (i *instance) writeAggregatedMetrics(
 			sturcturedMetadata,
 		)
 
-		i.metrics.metricSamples.WithLabelValues(service).Inc()
+		i.metrics.metricSamples.WithLabelValues(i.instanceID).Inc()
 	}
 }

--- a/pkg/pattern/metrics.go
+++ b/pkg/pattern/metrics.go
@@ -60,7 +60,7 @@ func newIngesterMetrics(r prometheus.Registerer, metricsNamespace string) *inges
 			Subsystem: "pattern_ingester",
 			Name:      "metric_samples",
 			Help:      "The total number of metric samples created to write back to Loki.",
-		}, []string{"service_name"}),
+		}, []string{"tenant"}),
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

In some cases `service_name` can have extremely high cardinality, resulting in 2.8M unique values in ops at times. Switching this metric to use tenant id instead to control cardinality.

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
