### PR TITLE
feat(helm): allow rendering chunk_store_config map

### DIFF
--- a/docs/sources/setup/install/helm/reference.md
+++ b/docs/sources/setup/install/helm/reference.md
@@ -2208,6 +2208,15 @@ null
 </td>
 		</tr>
 		<tr>
+			<td>chunksCache.chunkStoreConfig</td>
+			<td>object</td>
+			<td>Renders chunk_store_config block</td>
+			<td><pre lang="json">
+{}
+</pre>
+</td>
+		</tr>
+		<tr>
 			<td>chunksCache.connectionLimit</td>
 			<td>int</td>
 			<td>Maximum number of connections allowed</td>

--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -27,6 +27,7 @@ Entries should include a reference to the pull request that introduced the chang
 - [BUGFIX] Do not mark loki.storage.bucketNames.chunks as required, if minio is used. [#19871](https://github.com/grafana/loki/pull/19871)
 - [BUGFIX] Don't mark loki.storage.bucketNames.chunks as required, if an s3 url is provided. [#19873](https://github.com/grafana/loki/pull/19873)
 - [BUGFIX] do not mark loki.storage.bucketNames.ruler as required, if rulerConfig.storage.type is local. [#19882](https://github.com/grafana/loki/pull/19882)
+- [ENHANCEMENT] Allow rendering subvars of chunk_store_config [#20042](https://github.com/grafana/loki/pull/20042)
 
 ## 6.46.0
 

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -223,8 +223,8 @@ loki:
     {{- if .Values.chunksCache.enabled }}
     {{- with .Values.chunksCache }}
     chunk_store_config:
-      {{- with .chunk_store_config }}
-      {{- toYaml . | nindent 6 }}
+      {{- with .chunkStoreConfig }}
+      {{- toYaml . | nindent 2 }}
       {{- end }}
       chunk_cache_config:
         default_validity: {{ .defaultValidity }}
@@ -240,7 +240,6 @@ loki:
           consistent_hash: true
           timeout: {{ .timeout }}
           max_idle_conns: 72
-      {{- end }}
       {{- end }}
       {{- with .Values.chunksCache.l2 }}
       {{- if .enabled }}
@@ -3747,6 +3746,8 @@ resultsCache:
     # -- PVC additional labels
     labels: {}
 chunksCache:
+  # -- Renders chunk_store_config block
+  chunkStoreConfig: {}
   # -- Append to the name of the resources to make names different for l1 and l2
   suffix: ""
   # -- Specifies whether memcached based chunks-cache should be enabled


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, there is no possibility to render subvars of chunk_store_config, i.e., `skip_query_writeback_cache_older_than`, when not using structuredConfig or rewriting full loki.config block

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
