### PR TITLE
chore(dataobj): stop preallocating memory for page builders

### DIFF
--- a/pkg/dataobj/internal/dataset/page_builder.go
+++ b/pkg/dataobj/internal/dataset/page_builder.go
@@ -57,8 +57,15 @@ type pageBuilder struct {
 // combination of opts.Value and opts.Encoding.
 func newPageBuilder(opts BuilderOptions) (*pageBuilder, error) {
 	var (
+		// We avoid giving an initial capacity to the buffers below to reduce
+		// the memory footprint for page builders (one per column), since it's
+		// atypical for every column to completely fill its pages.
+		//
+		// However, this will slightly increase the memory footprint for any
+		// column with at least one full page, due to how Go grows slices.
+
 		presenceBuffer = bytes.NewBuffer(nil)
-		valuesBuffer   = bytes.NewBuffer(make([]byte, 0, opts.PageSizeHint))
+		valuesBuffer   = bytes.NewBuffer(nil)
 
 		valuesWriter = newCompressWriter(valuesBuffer, opts.Compression, opts.CompressionOptions)
 	)


### PR DESCRIPTION
Initially, newPageBuilder would preallocate a buffer for the values based on the maximum page size. This was done in an attempt to prevent bytes.Buffer from growing slices beyond the configured maximum page size.

However, this added a significant amount of memory overhead for datasets with a large number of sparsely filled columns.

As it's more common for columns to be partially filled (especially for structured metadata), it's more efficient to remove the preallocation and let Go grow the buffers naturally.

This comes at the cost of full pages using slightly more memory than the page size, usually up to the next power of two, if the target page size doesn't align with a power of two.