### PR TITLE
chore(dataobj): Use shared zstd.Encoder pool when building data object columns

### DIFF
--- a/pkg/dataobj/internal/dataset/column_builder.go
+++ b/pkg/dataobj/internal/dataset/column_builder.go
@@ -50,9 +50,9 @@ type StatisticsOptions struct {
 
 // CompressionOptions customizes the compressor used when building pages.
 type CompressionOptions struct {
-	// Zstd holds encoding options for Zstd compression. Only used for
+	// Zstd holds compression level for Zstd compression. Only used for
 	// [datasetmd.COMPRESSION_TYPE_ZSTD].
-	Zstd []zstd.EOption
+	Zstd zstd.EncoderLevel
 }
 
 // A ColumnBuilder builds a sequence of [Value] entries of a common type into a

--- a/pkg/dataobj/sections/logs/builder.go
+++ b/pkg/dataobj/sections/logs/builder.go
@@ -175,7 +175,7 @@ func (b *Builder) flushRecords(encLevel zstd.EncoderLevel) {
 	// compression. To maintain high throughput on appends, we use the fastest
 	// compression for a stripe. Better compression is then used for sections.
 	compressionOpts := dataset.CompressionOptions{
-		Zstd: []zstd.EOption{zstd.WithEncoderLevel(encLevel)},
+		Zstd: encLevel,
 	}
 
 	stripe := buildTable(&b.stripeBuffer, b.opts.PageSizeHint, b.opts.PageMaxRowCount, compressionOpts, b.records, b.opts.SortOrder)
@@ -193,7 +193,7 @@ func (b *Builder) flushSection() *table {
 	}
 
 	compressionOpts := dataset.CompressionOptions{
-		Zstd: []zstd.EOption{zstd.WithEncoderLevel(zstd.SpeedDefault)},
+		Zstd: zstd.SpeedDefault,
 	}
 
 	section, err := mergeTablesIncremental(&b.sectionBuffer, b.opts.PageSizeHint, b.opts.PageMaxRowCount, compressionOpts, b.stripes, b.opts.StripeMergeLimit, b.opts.SortOrder)


### PR DESCRIPTION
### Summary

As of now, each column storing text (structured metadata, log lines) will hold onto a zstd compressor for the lifetime of that column. Throughout this period, encoded data will stream into the compressor and be compressed over time. This was intended to avoid keeping large encoded pages in memory.

However, each zstd compressor comes with a decent amount of memory overhead. If we get a huge spike in columns, dataobj-consumer pods can quickly become overwhelmed and OOM, with no knobs to avoid this other than scaling vertically.

This PR introduces a pool for zstd encoders that is shared among column builders and only reclaimed when flushing a page and returned when done.