### PR TITLE
feat: use local distributor rate store for segmentation keys

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -288,8 +288,6 @@ func New(
 		return nil, fmt.Errorf("partition ring is required for kafka writes")
 	}
 
-	ingestLimits := newIngestLimits(limitsFrontendClient, registerer)
-
 	var kafkaWriter KafkaProducer
 	if cfg.KafkaEnabled {
 		kafkaClient, err := kafka_client.NewWriterClient("distributor", cfg.KafkaConfig, 20, logger, registerer)
@@ -300,28 +298,6 @@ func New(
 			prometheus.WrapRegistererWithPrefix("loki_", registerer),
 			kafka_client.WithRecordsInterceptor(validation.IngestionPoliciesKafkaProducerInterceptor),
 		)
-
-		if cfg.DataObjTeeConfig.Enabled {
-			resolver := NewSegmentationPartitionResolver(
-				uint64(cfg.DataObjTeeConfig.PerPartitionRateBytes),
-				dataObjConsumerPartitionRing,
-				registerer,
-				logger,
-			)
-			dataObjTee, err := NewDataObjTee(
-				&cfg.DataObjTeeConfig,
-				resolver,
-				ingestLimits,
-				overrides,
-				kafkaClient,
-				logger,
-				registerer,
-			)
-			if err != nil {
-				return nil, fmt.Errorf("failed to create data object tee: %w", err)
-			}
-			tee = WrapTee(tee, dataObjTee)
-		}
 	}
 
 	d := &Distributor{
@@ -394,7 +370,7 @@ func New(
 		writeFailuresManager:  writefailures.NewManager(logger, registerer, cfg.WriteFailuresLogging, configs, "distributor"),
 		kafkaWriter:           kafkaWriter,
 		partitionRing:         partitionRing,
-		ingestLimits:          ingestLimits,
+		ingestLimits:          newIngestLimits(limitsFrontendClient, registerer),
 		numMetadataPartitions: numMetadataPartitions,
 		inflightBytes:         atomic.NewUint64(0),
 		inflightBytesGauge: promauto.With(registerer).NewGauge(prometheus.GaugeOpts{
@@ -441,6 +417,30 @@ func New(
 		registerer,
 	)
 	d.rateStore = rs
+
+	if cfg.KafkaEnabled && cfg.DataObjTeeConfig.Enabled {
+		segmentationKeyStoreStore := newSegmentationKeyRateStore(5*time.Minute, time.Minute)
+		resolver := NewSegmentationPartitionResolver(
+			uint64(cfg.DataObjTeeConfig.PerPartitionRateBytes),
+			dataObjConsumerPartitionRing,
+			registerer,
+			logger,
+		)
+		dataObjTee, err := NewDataObjTee(
+			&cfg.DataObjTeeConfig,
+			resolver,
+			segmentationKeyStoreStore,
+			distributorsRing,
+			overrides,
+			kafkaWriter,
+			logger,
+			registerer,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create data object tee: %w", err)
+		}
+		d.tee = WrapTee(d.tee, dataObjTee)
+	}
 
 	servs = append(servs, d.ingesterClients, rs)
 	d.subservices, err = services.NewManager(servs...)

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -419,7 +419,8 @@ func New(
 	d.rateStore = rs
 
 	if cfg.KafkaEnabled && cfg.DataObjTeeConfig.Enabled {
-		segmentationKeyStoreStore := newSegmentationKeyRateStore(5*time.Minute, time.Minute)
+		segmentationKeyRateStore := newSegmentationKeyRateStore(5*time.Minute, time.Minute, logger)
+		servs = append(servs, segmentationKeyRateStore)
 		resolver := NewSegmentationPartitionResolver(
 			uint64(cfg.DataObjTeeConfig.PerPartitionRateBytes),
 			dataObjConsumerPartitionRing,
@@ -429,7 +430,7 @@ func New(
 		dataObjTee, err := NewDataObjTee(
 			&cfg.DataObjTeeConfig,
 			resolver,
-			segmentationKeyStoreStore,
+			segmentationKeyRateStore,
 			distributorsRing,
 			overrides,
 			kafkaWriter,

--- a/pkg/distributor/ingest_limits.go
+++ b/pkg/distributor/ingest_limits.go
@@ -220,10 +220,9 @@ func newUpdateRatesRequest(tenant string, streams []SegmentedStream) (*proto.Upd
 	// from the request caused it to exceed its limits.
 	streamMetadata := make([]*proto.StreamMetadata, 0, len(streams))
 	for _, stream := range streams {
-		entriesSize, structuredMetadataSize := calculateStreamSizes(stream.Stream)
 		streamMetadata = append(streamMetadata, &proto.StreamMetadata{
 			StreamHash:      stream.SegmentationKeyHash,
-			TotalSize:       entriesSize + structuredMetadataSize,
+			TotalSize:       uint64(stream.Stream.Size()),
 			IngestionPolicy: stream.Policy,
 		})
 	}

--- a/pkg/distributor/segment_ratestore.go
+++ b/pkg/distributor/segment_ratestore.go
@@ -1,0 +1,179 @@
+package distributor
+
+import (
+	"hash/fnv"
+	"sync"
+	"time"
+)
+
+const (
+	// The number of stripe locks.
+	segmentationKeyRateStoreNumStripes = 64
+)
+
+// segmentKeyRateStore tracks the ingestion rate (bytes/sec) for each
+// segmentation key.
+type segmentationKeyRateStore struct {
+	// stripes contains the rate buckets for segmentation keys. It is striped
+	// to allow concurrent reads/writes to non-overlapping stripes.
+	stripes []map[string]map[uint64][]segmentationKeyRateBucket
+	locks   []sync.Mutex
+
+	// window is the time window for the rate buckets. For example, to store
+	// the last 5 minutes of rates the window should be 5 minutes.
+	window time.Duration
+
+	// bucketSize is the size of each rate bucket. For example, to use 1
+	// minute buckets the bucketSize should be 1 minute.
+	bucketSize time.Duration
+
+	// numBuckets is calculated as the window divided by the bucketSize.
+	numBuckets int
+}
+
+type segmentationKeyRateBucket struct {
+	start time.Time
+	size  uint64
+}
+
+// newSegmentationKeyRateStore returns a new rate store for segmentation keys.
+func newSegmentationKeyRateStore(window, bucketSize time.Duration) *segmentationKeyRateStore {
+	return &segmentationKeyRateStore{
+		stripes:    make([]map[string]map[uint64][]segmentationKeyRateBucket, segmentationKeyRateStoreNumStripes),
+		locks:      make([]sync.Mutex, segmentationKeyRateStoreNumStripes),
+		window:     window,
+		bucketSize: bucketSize,
+		numBuckets: int(window / bucketSize),
+	}
+}
+
+// Update updates the rate for the segmentation key. It returns the
+// average rate over the window.
+func (s *segmentationKeyRateStore) Update(tenant string, segmentationKey SegmentationKey, n uint64, now time.Time) uint64 {
+	var result uint64
+	s.withBuckets(tenant, segmentationKey, func(buckets []segmentationKeyRateBucket) {
+		// buckets are implemented as a circular buffer. To update a bucket we
+		// need to calculate the bucket index.
+		bucketNum := now.UnixNano() / int64(s.bucketSize)
+		bucketIdx := int(bucketNum % int64(s.numBuckets))
+		bucket := buckets[bucketIdx]
+		// Once we have found the bucket, we need to check if it is inside the
+		// rate window. If not, we need to reset it before we can use it.
+		expectedBucketStart := now.Truncate(s.bucketSize)
+		if bucket.start.Before(expectedBucketStart) {
+			bucket.start = expectedBucketStart
+			bucket.size = 0
+		}
+		bucket.size += n
+		buckets[bucketIdx] = bucket
+		// Return the average rate over the window.
+		result = s.averageRate(buckets, now)
+	})
+	return result
+}
+
+// EvictExpired evicts expired entries from the store. It returns the number
+// of evicted entries.
+func (s *segmentationKeyRateStore) EvictExpired(now time.Time) int {
+	windowStart := now.Add(-s.window)
+	evicted := 0
+	for i := 0; i < len(s.locks); i++ {
+		s.locks[i].Lock()
+		for tenant, segmentationKeys := range s.stripes[i] {
+			for segmentationKey, buckets := range segmentationKeys {
+				// Count the number of buckets outside the window.
+				var expiredBuckets int
+				for _, bucket := range buckets {
+					bucketEnd := bucket.start.Add(s.bucketSize)
+					// If bucketEnd less than or equal to windowStart then
+					// it is outside the window.
+					if !bucketEnd.After(windowStart) {
+						expiredBuckets++
+					}
+				}
+				// If all buckets are outside the window the segmentation key
+				// can be deleted.
+				if expiredBuckets == len(buckets) {
+					delete(segmentationKeys, segmentationKey)
+					evicted++
+				}
+			}
+			// If the tenant has no segmentation keys left, it can be deleted
+			// too.
+			if len(segmentationKeys) == 0 {
+				delete(s.stripes[i], tenant)
+			}
+		}
+		s.locks[i].Unlock()
+	}
+	return evicted
+}
+
+// averageRate returns the average rate for buckets in the window using a
+// sliding window algorithm.
+func (s *segmentationKeyRateStore) averageRate(buckets []segmentationKeyRateBucket, now time.Time) uint64 {
+	var (
+		totalBytes   uint64
+		totalSeconds float64
+		windowStart  = now.Add(-s.window)
+	)
+	for _, bucket := range buckets {
+		bucketEnd := bucket.start.Add(s.bucketSize)
+		// Ignore buckets that are outside the window.
+		if bucket.start.IsZero() || bucketEnd.Before(windowStart) {
+			continue
+		}
+		totalBytes += bucket.size
+		// If this is the current bucket, count the number of seconds start
+		// the start of the bucket, otherwise count the full duration.
+		if now.Before(bucketEnd) {
+			totalSeconds += now.Sub(bucket.start).Seconds()
+		} else {
+			totalSeconds += s.bucketSize.Seconds()
+		}
+	}
+	if totalSeconds == 0 {
+		return 0
+	}
+	return uint64(float64(totalBytes) / totalSeconds)
+}
+
+func (s *segmentationKeyRateStore) withBuckets(tenant string, segmentationKey SegmentationKey, f func(buckets []segmentationKeyRateBucket)) {
+	segmentationKeyHash := segmentationKey.Sum64()
+	s.withLock(tenant, segmentationKey, func(stripe int) {
+		// Get the buckets for the tenant and segmentation key.
+		tenants := s.stripes[stripe]
+		if tenants == nil {
+			tenants = make(map[string]map[uint64][]segmentationKeyRateBucket)
+			s.stripes[stripe] = tenants
+		}
+		segmentationKeys, ok := tenants[tenant]
+		if !ok {
+			segmentationKeys = make(map[uint64][]segmentationKeyRateBucket)
+			tenants[tenant] = segmentationKeys
+		}
+		buckets, ok := segmentationKeys[segmentationKeyHash]
+		if !ok {
+			buckets = make([]segmentationKeyRateBucket, s.numBuckets)
+			segmentationKeys[segmentationKeyHash] = buckets
+		}
+		f(buckets)
+	})
+}
+
+func (s *segmentationKeyRateStore) withLock(tenant string, segmentationKey SegmentationKey, f func(i int)) {
+	i := s.getStripe(tenant, segmentationKey)
+	s.locks[i].Lock()
+	defer s.locks[i].Unlock()
+	f(i)
+}
+
+// getStripe returns the stripe index for the tenant and segmentation key.
+// It ensures that the same segmentation key from different tenants is
+// distributed evenly across the stripes.
+func (s *segmentationKeyRateStore) getStripe(tenant string, segmentationKey SegmentationKey) int {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(tenant))
+	_, _ = h.Write([]byte(segmentationKey))
+	return int(h.Sum64() % uint64(len(s.locks)))
+}

--- a/pkg/distributor/segment_ratestore_test.go
+++ b/pkg/distributor/segment_ratestore_test.go
@@ -1,0 +1,211 @@
+package distributor
+
+import (
+	"testing"
+	"time"
+
+	"github.com/coder/quartz"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSegmentRateStore_UpdateRate(t *testing.T) {
+	t.Run("buckets of all zeros", func(t *testing.T) {
+		clock := quartz.NewMock(t)
+		s := newSegmentationKeyRateStore(5*time.Minute, time.Minute)
+		for range 5 {
+			rate := s.Update("tenant", SegmentationKey("test"), 0, clock.Now())
+			require.Equal(t, uint64(0), rate)
+			// Update all buckets by advancing the clock one bucket size
+			// duration at a time.
+			clock.Advance(time.Minute)
+		}
+		// Ensure all buckets have been updated and each bucket contains zero.
+		s.withBuckets("tenant", SegmentationKey("test"), func(buckets []segmentationKeyRateBucket) {
+			clock := quartz.NewMock(t)
+			require.Len(t, buckets, 5)
+			for _, bucket := range buckets {
+				require.False(t, bucket.start.IsZero())
+				require.Equal(t, clock.Now(), bucket.start)
+				require.Equal(t, uint64(0), bucket.size)
+				clock.Advance(time.Minute)
+			}
+		})
+	})
+
+	t.Run("update each bucket with different rate", func(t *testing.T) {
+		clock := quartz.NewMock(t)
+		s := newSegmentationKeyRateStore(5*time.Minute, time.Minute)
+		for i := range 5 {
+			_ = s.Update("tenant", SegmentationKey("test"), uint64(i), clock.Now())
+			// Update all buckets by advancing the clock one bucket size
+			// duration at a time.
+			clock.Advance(time.Minute)
+		}
+		// Ensure all buckets have been updated and each bucket contains its
+		// expected value.
+		s.withBuckets("tenant", SegmentationKey("test"), func(buckets []segmentationKeyRateBucket) {
+			clock := quartz.NewMock(t)
+			require.Len(t, buckets, 5)
+			// Each bucket should contain the value equivalent to its index
+			// in the slice.
+			for i, bucket := range buckets {
+				require.False(t, bucket.start.IsZero())
+				require.Equal(t, clock.Now(), bucket.start)
+				require.Equal(t, uint64(i), bucket.size)
+				clock.Advance(time.Minute)
+			}
+		})
+	})
+
+	t.Run("buckets wrap around at the end of the window", func(t *testing.T) {
+		clock := quartz.NewMock(t)
+		s := newSegmentationKeyRateStore(5*time.Minute, time.Minute)
+		s.Update("tenant", SegmentationKey("test"), 1, clock.Now())
+		// Check the buckets matches expectations.
+		s.withBuckets("tenant", SegmentationKey("test"), func(buckets []segmentationKeyRateBucket) {
+			require.Equal(t, uint64(1), buckets[0].size)
+			// All other buckets should contain zeros.
+			require.Equal(t, uint64(0), buckets[1].size)
+			require.Equal(t, uint64(0), buckets[2].size)
+			require.Equal(t, uint64(0), buckets[3].size)
+			require.Equal(t, uint64(0), buckets[4].size)
+		})
+		// Advance the clock 5 minutes.
+		clock.Advance(5 * time.Minute)
+		s.Update("tenant", SegmentationKey("test"), 2, clock.Now())
+		// Check the buckets matches expectations.
+		s.withBuckets("tenant", SegmentationKey("test"), func(buckets []segmentationKeyRateBucket) {
+			require.Equal(t, uint64(2), buckets[0].size)
+			// All other buckets should contain zeros.
+			require.Equal(t, uint64(0), buckets[1].size)
+			require.Equal(t, uint64(0), buckets[2].size)
+			require.Equal(t, uint64(0), buckets[3].size)
+			require.Equal(t, uint64(0), buckets[4].size)
+		})
+	})
+
+	t.Run("buckets do not reset on wrap around", func(t *testing.T) {
+		clock := quartz.NewMock(t)
+		s := newSegmentationKeyRateStore(5*time.Minute, time.Minute)
+		for i := range 5 {
+			s.Update("tenant", SegmentationKey("test"), uint64(i), clock.Now())
+			clock.Advance(time.Minute)
+		}
+		// Check the buckets matches expectations.
+		s.withBuckets("tenant", SegmentationKey("test"), func(buckets []segmentationKeyRateBucket) {
+			require.Equal(t, uint64(0), buckets[0].size)
+			require.Equal(t, uint64(1), buckets[1].size)
+			require.Equal(t, uint64(2), buckets[2].size)
+			require.Equal(t, uint64(3), buckets[3].size)
+			require.Equal(t, uint64(4), buckets[4].size)
+		})
+		// Advance the clock 5 minutes.
+		clock.Advance(5 * time.Minute)
+		s.Update("tenant", SegmentationKey("test"), 5, clock.Now())
+		// Check the buckets matches expectations.
+		s.withBuckets("tenant", SegmentationKey("test"), func(buckets []segmentationKeyRateBucket) {
+			require.Equal(t, uint64(5), buckets[0].size)
+			require.Equal(t, uint64(1), buckets[1].size)
+			require.Equal(t, uint64(2), buckets[2].size)
+			require.Equal(t, uint64(3), buckets[3].size)
+			require.Equal(t, uint64(4), buckets[4].size)
+		})
+		// Advance the clock another minute.
+		clock.Advance(time.Minute)
+		s.Update("tenant", SegmentationKey("test"), 6, clock.Now())
+		// Check the buckets matches expectations.
+		s.withBuckets("tenant", SegmentationKey("test"), func(buckets []segmentationKeyRateBucket) {
+			require.Equal(t, uint64(5), buckets[0].size)
+			require.Equal(t, uint64(6), buckets[1].size)
+			require.Equal(t, uint64(2), buckets[2].size)
+			require.Equal(t, uint64(3), buckets[3].size)
+			require.Equal(t, uint64(4), buckets[4].size)
+		})
+	})
+
+	t.Run("buckets outside window are excluded from the average rate", func(t *testing.T) {
+		clock := quartz.NewMock(t)
+		s := newSegmentationKeyRateStore(5*time.Minute, time.Minute)
+		actual := s.Update("tenant", SegmentationKey("test"), 100, clock.Now())
+		// We don't have a per second rate as a second hasn't passed.
+		require.Equal(t, uint64(0), actual)
+		clock.Advance(59 * time.Second)
+		// Advance the clock 59 seconds. We expect the average per second rate
+		// to be 1 because integer division of 100 by 59 is 1 where the bucket
+		// contains 100, and we have 59 seconds within the window.
+		actual = s.Update("tenant", SegmentationKey("test"), 0, clock.Now())
+		require.Equal(t, uint64(1), actual)
+		// Advance the clock so we update the next bucket. This time we expect
+		// the per second rate to be 0 because integer division of 101 by 119
+		// is 0. The 119 because we have 60 seconds of the first bucket and
+		// 59 seconds of the second bucket within the window.
+		clock.Advance(time.Minute)
+		actual = s.Update("tenant", SegmentationKey("test"), 1, clock.Now())
+		require.Equal(t, uint64(0), actual)
+		// Add 199 so we have an average per second rate of 2.
+		actual = s.Update("tenant", SegmentationKey("test"), 199, clock.Now())
+		require.Equal(t, uint64(2), actual)
+		// Wrap around to the start of the window to make sure the first bucket
+		// is ignored as it is older than 5 minutes.
+		clock.Advance(4 * time.Minute)
+		actual = s.Update("tenant", SegmentationKey("test"), 0, clock.Now())
+		require.Equal(t, uint64(1), actual)
+	})
+}
+
+func TestSegmentRateStore_EvictExpired(t *testing.T) {
+	t.Run("segmentation key is evicted when all buckets outside window", func(t *testing.T) {
+		clock := quartz.NewMock(t)
+		s := newSegmentationKeyRateStore(5*time.Minute, time.Minute)
+		// No segmentation keys should be evicted.
+		require.Equal(t, 0, s.EvictExpired(clock.Now()))
+		// Update the per second rate for the segmentation key. The segmentation
+		// key should not be evicted as the bucket is within the window.
+		s.Update("tenant", SegmentationKey("test"), 100, clock.Now())
+		require.Equal(t, 0, s.EvictExpired(clock.Now()))
+		// Advance the clock 4 minutes and update the per second rate for the
+		// same segmentation key. It should not be evicted as we now have
+		// two buckets within the window.
+		clock.Advance(4 * time.Minute)
+		s.Update("tenant", SegmentationKey("test"), 100, clock.Now())
+		require.Equal(t, 0, s.EvictExpired(clock.Now()))
+		// Advance the clock 1 minute. The segmentation key should not be
+		// evicted as both buckets are still within the window.
+		clock.Advance(time.Minute)
+		require.Equal(t, 0, s.EvictExpired(clock.Now()))
+		// Advance the clock another minute. The segmentation key should not
+		// be evicted because while one bucket is now outside the window,
+		// the other bucket is still within the window.
+		clock.Advance(time.Minute)
+		require.Equal(t, 0, s.EvictExpired(clock.Now()))
+		// Advance the clock another 4 minutes. All buckets should be outside
+		// the window and the segmentation key should be evicted.
+		clock.Advance(4 * time.Minute)
+		require.Equal(t, 1, s.EvictExpired(clock.Now()))
+	})
+
+	t.Run("tenant is not evicted unless all of their segmentation keys are evicted", func(t *testing.T) {
+		clock := quartz.NewMock(t)
+		s := newSegmentationKeyRateStore(5*time.Minute, time.Minute)
+		// Add rates for two segmentation keys 4 minutes apart of each other.
+		s.Update("tenant", SegmentationKey("test1"), 100, clock.Now())
+		clock.Advance(4 * time.Minute)
+		s.Update("tenant", SegmentationKey("test2"), 200, clock.Now())
+		// Advance the clock past the end of the bucket containing test1.
+		// It should be evicted, but not test2.
+		clock.Advance(2 * time.Minute)
+		require.Equal(t, 1, s.EvictExpired(clock.Now()))
+		// Check that test2 is still present.
+		s.withBuckets("tenant", SegmentationKey("test2"), func(buckets []segmentationKeyRateBucket) {
+			var totalSize uint64
+			for _, bucket := range buckets {
+				totalSize += bucket.size
+			}
+			require.Equal(t, uint64(200), totalSize)
+		})
+		// Advance the clock past the end of the bucket containing test2.
+		// Now test2 should be evicted.
+		clock.Advance(4 * time.Minute)
+		require.Equal(t, 1, s.EvictExpired(clock.Now()))
+	})
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request updates distributors to track the rates of segmentation keys locally in-memory instead of using the limits service.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
