### PR TITLE
chore: expose native histogram for HTTP server metrics

### DIFF
--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -143,6 +143,7 @@ type Config struct {
 func (c *Config) RegisterFlags(f *flag.FlagSet) {
 	c.Server.MetricsNamespace = constants.Loki
 	c.Server.ExcludeRequestInLog = true
+	c.Server.MetricsNativeHistogramFactor = 1.1 // Allows native histograms for server metrics
 
 	// Set the default module list to 'all'
 	c.Target = []string{All}


### PR DESCRIPTION
HTTP server metrics only expose native histograms when MetricsNativeHistogramFactor is set programatically (it is not exposed via YAML).