### PR TITLE
feat: add gauge to track in-flight bytes

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -211,7 +211,7 @@ type Distributor struct {
 
 	// inflightBytes keeps track of the total number of bytes for all in-flight
 	// push requests.
-	inflightBytes      atomic.Uint64
+	inflightBytes      *atomic.Uint64
 	inflightBytesGauge prometheus.Gauge
 
 	// kafka metrics
@@ -396,7 +396,7 @@ func New(
 		partitionRing:         partitionRing,
 		ingestLimits:          ingestLimits,
 		numMetadataPartitions: numMetadataPartitions,
-		inflightBytes:         *atomic.NewUint64(0),
+		inflightBytes:         atomic.NewUint64(0),
 		inflightBytesGauge: promauto.With(registerer).NewGauge(prometheus.GaugeOpts{
 			Namespace: constants.Loki,
 			Name:      "distributor_inflight_bytes",


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request adds a simple gauge `loki_distributor_inflight_bytes` to measure the current number of inflight bytes of push requests. It will help us measure memory pressure from request volume.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
