### PR TITLE
docs: Improve GCP deployment guide.

### DIFF
--- a/docs/sources/setup/install/helm/deployment-guides/gcp.md
+++ b/docs/sources/setup/install/helm/deployment-guides/gcp.md
@@ -204,7 +204,7 @@ serviceaccount/loki-gcp-ksa created
 ### Add IAM Policy to Buckets
 
 {{< admonition type="note" >}}
-The [pre-defined `role/storage.objectUser` role](https://cloud.google.com/storage/docs/access-control/iam-roles) is sufficient for Loki to
+The [pre-defined `roles/storage.objectUser` role](https://cloud.google.com/storage/docs/access-control/iam-roles#storage.objectUser) is sufficient for Loki to
  operate. See [IAM permissions for Cloud Storage](https://cloud.google.com/storage/docs/access-control/iam-permissions) for details about each individual
  permission. You can use this predefined role or create your own with matching permissions.
 {{< /admonition >}}
@@ -213,7 +213,7 @@ Create an IAM policy binding on the buckets using the KSA created previously and
 
 ```bash
 gcloud storage buckets add-iam-policy-binding gs://<BUCKET_NAME> \
- --role=roles/storage.objectAdmin \
+ --role=roles/storage.objectUser \
   --member=principal://iam.googleapis.com/projects/<PROJECT_NUMBER>/locations/global/workloadIdentityPools/<PROJECT_ID>.svc.id.goog/subject/ns/<NAMESPACE>/sa/<KSA_NAME> \
   --condition=None
 ```
@@ -227,7 +227,7 @@ Examples:
 
 ```bash
 gcloud storage buckets add-iam-policy-binding gs://loki-gcp-chunks \
-  --role=roles/storage.objectAdmin \
+  --role=roles/storage.objectUser \
   --member=principal://iam.googleapis.com/projects/12345678901/locations/global/workloadIdentityPools/my-project-123456.svc.id.goog/subject/ns/loki/sa/loki-gcp-ksa \
   --condition=None
 ```
@@ -236,7 +236,7 @@ and
 
 ```bash
 gcloud storage buckets add-iam-policy-binding gs://loki-gcp-ruler \
-  --role=roles/storage.objectAdmin \
+  --role=roles/storage.objectUser \
   --member=principal://iam.googleapis.com/projects/12345678901/locations/global/workloadIdentityPools/my-project-123456.svc.id.goog/subject/ns/loki/sa/loki-gcp-ksa \
   --condition=None
 ```
@@ -261,7 +261,7 @@ bindings:
   role: roles/storage.legacyObjectReader
 - members:
   - principal://iam.googleapis.com/projects/12345678901/locations/global/workloadIdentityPools/my-project-123456.svc.id.goog/subject/ns/loki/sa/loki-gcp-ksa
-  role: roles/storage.objectViewer
+  role: roles/storage.objectUser
 etag: CAI=
 kind: storage#policy
 resourceId: projects/_/buckets/loki-gcp-chunks
@@ -461,7 +461,7 @@ It is critical to define a valid `values.yaml` file for the Loki deployment. To 
 
 - **Storage:**
   - Defines where the Helm chart stores data.
-  - Set the type to `GCS` since we are using Amazon GCS.
+  - Set the type to `GCS` since we are using Google Cloud Storage.
   - Configure the bucket names for the chunks and ruler to match the buckets created earlier.
   - The `GCS` section specifies the region of the bucket.
 


### PR DESCRIPTION
- Fix reference mixup, where AWS was mentioned instead of Google Cloud Storage
- Add anchor to hyperlink that descripes the role `roles/objectUser`
- Replace `roles/objectAdmin` with `roles/objectUser` in code examples as it was mentioned earlier that user privileges are sufficient for Loki to work.

**What this PR does / why we need it**:
Improvement of the documentation

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
