### PR TITLE
fix: Respect categorizeLabels encoding flag in v2 queries

### DIFF
--- a/pkg/engine/basic_engine.go
+++ b/pkg/engine/basic_engine.go
@@ -113,6 +113,7 @@ func (e *Basic) Execute(ctx context.Context, params logql.Params) (logqlmodel.Re
 
 	logger := utillog.WithContext(ctx, e.logger)
 	logger = log.With(logger, "query", params.QueryString(), "shard", strings.Join(params.Shards(), ","), "engine", "v2")
+	encodingFlags := httpreq.ExtractEncodingFlagsFromCtx(ctx)
 
 	// Inject the range config into the context for any calls to
 	// [rangeio.ReadRanges] to make use of.
@@ -209,7 +210,7 @@ func (e *Basic) Execute(ctx context.Context, params logql.Params) (logqlmodel.Re
 		var builder ResultBuilder
 		switch params.GetExpression().(type) {
 		case syntax.LogSelectorExpr:
-			builder = newStreamsResultBuilder(params.Direction())
+			builder = newStreamsResultBuilder(params.Direction(), encodingFlags.Has(httpreq.FlagCategorizeLabels))
 		case syntax.SampleExpr:
 			if params.Step() > 0 {
 				builder = newMatrixResultBuilder()

--- a/pkg/engine/compat_bench_test.go
+++ b/pkg/engine/compat_bench_test.go
@@ -53,7 +53,6 @@ func BenchmarkStreamsResultBuilder(b *testing.B) {
 
 	for _, bm := range benchmarks {
 		b.Run(bm.name, func(b *testing.B) {
-
 			schema, labelIdents, metaIdents, parsedIdents := prepareSchema(bm.numLabels, bm.numMeta, bm.numParsed)
 			baseTime := time.Unix(0, 1620000000000000000).UTC()
 
@@ -69,7 +68,7 @@ func BenchmarkStreamsResultBuilder(b *testing.B) {
 			b.ReportAllocs()
 
 			for i := 0; i < b.N; i++ {
-				rb := newStreamsResultBuilder(logproto.BACKWARD)
+				rb := newStreamsResultBuilder(logproto.BACKWARD, false)
 				// Collect records twice on purpose to see how efficient CollectRecord is when the builder already has
 				// some data
 				rb.CollectRecord(record1)


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates the compat layer to respect `categorizeLabels` in queries.
* Categorize labels does not add structured metadata to the output streams, but instead shows the structured metadata per entry.


Streams before (many streams, 1 entry):
```
            {
                "stream": {
                    "cluster": "dev-us-central-0",
                    "container": "query-engine-scheduler",
                    "detected_level": "info",
                    "job": "loki-dev-005-gf/query-engine-scheduler",
                    "name": "query-engine-scheduler",
                    "namespace": "loki-dev-005-gf",
                    "org_id": "145265",
                    "pod": "query-engine-scheduler-69cf6d9b87-8j26w",
                    "pod_template_hash": "69cf6d9b87",
                    "service_name": "loki/query-engine-scheduler",
                    "stream": "stderr",
                    "traceID": "304ce0c9c1753a483aa6fcc84eb13a4f"
                },
                "values": [
                    [
                        "1764493182457679952",
                        "level=info ts=2025-11-30T08:59:42.385916441Z caller=engine.go:171 component=query-engine org_id=145265 traceID=304ce0c9c1753a483aa6fcc84eb13a4f engine=v2 token_id=d3ad2517-daee-4098-a5df-32d4727c1308 msg=\"starting query\" query=\"{stream=\\\"stdout\\\",pod=\\\"loki-canary-6876c7f977-lx54c\\\"} \" shard=",
                        {
                            "structuredMetadata": {
                                "detected_level": "info",
                                "org_id": "145265",
                                "pod": "query-engine-scheduler-69cf6d9b87-8j26w",
                                "pod_template_hash": "69cf6d9b87",
                                "traceID": "304ce0c9c1753a483aa6fcc84eb13a4f"
                            }
                        }
                    ]
                ]
            },
```

Streams after (1 stream, many entries):
```
                "stream": {
                    "cluster": "dev-us-central-0",
                    "container": "query-engine-scheduler",
                    "job": "loki-dev-005-gf/query-engine-scheduler",
                    "name": "query-engine-scheduler",
                    "namespace": "loki-dev-005-gf",
                    "service_name": "loki/query-engine-scheduler",
                    "stream": "stderr"
                },
                "values": [
                    [
                        "1764493202957734518",
                        "level=info ts=2025-11-30T09:00:02.862842454Z caller=engine.go:171 component=query-engine org_id=145265 traceID=5b4fc7ea9e1d0052852ef7261cbccbb4 engine=v2 token_id=d3ad2517-daee-4098-a5df-32d4727c1308 msg=\"starting query\" query=\"{stream=\\\"stdout\\\",pod=\\\"loki-canary-6876c7f977-7pkzz\\\"} \" shard=",
                        {
                            "structuredMetadata": {
                                "detected_level": "info",
                                "org_id": "145265",
                                "pod": "query-engine-scheduler-69cf6d9b87-8j26w",
                                "pod_template_hash": "69cf6d9b87",
                                "traceID": "5b4fc7ea9e1d0052852ef7261cbccbb4"
                            }
                        }
                    ],
                    [
                        "1764493202858024748",
                        "level=info ts=2025-11-30T09:00:02.8422513Z caller=engine.go:171 component=query-engine org_id=145265 traceID=cc55b31dcae228644315e41f5eae69c2 engine=v2 token_id=d3ad2517-daee-4098-a5df-32d4727c1308 msg=\"starting query\" query=\"{stream=\\\"stdout\\\",pod=\\\"loki-canary-6876c7f977-7pkzz\\\"} \" shard=",
                        {
                            "structuredMetadata": {
                                "detected_level": "info",
                                "org_id": "145265",
                                "pod": "query-engine-scheduler-69cf6d9b87-8j26w",
                                "pod_template_hash": "69cf6d9b87",
                                "traceID": "cc55b31dcae228644315e41f5eae69c2"
                            }
                        }
                    ],
```
