### PR TITLE
fix(enginev2): Close pipeline before building query results

### DIFF
--- a/pkg/engine/internal/executor/pipeline.go
+++ b/pkg/engine/internal/executor/pipeline.go
@@ -20,7 +20,7 @@ type Pipeline interface {
 	// It returns an error if reading fails or when the pipeline is exhausted. In this case, the function returns EOF.
 	Read(context.Context) (arrow.RecordBatch, error)
 	// Close closes the resources of the pipeline.
-	// The implementation must close all the of the pipeline's inputs.
+	// The implementation must close all the of the pipeline's inputs and must be safe to call multiple times.
 	Close()
 }
 
@@ -76,8 +76,10 @@ func newGenericPipelineWithRegion(read readFunc, region *xcap.Region, inputs ...
 	}
 }
 
-var _ Pipeline = (*GenericPipeline)(nil)
-var _ RegionProvider = (*GenericPipeline)(nil)
+var (
+	_ Pipeline       = (*GenericPipeline)(nil)
+	_ RegionProvider = (*GenericPipeline)(nil)
+)
 
 // Read implements Pipeline.
 func (p *GenericPipeline) Read(ctx context.Context) (arrow.RecordBatch, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix stats propagation by ensuring the query pipeline is closed before building the results.

* Stats are only aggregated in the pipeline close method, so this must be done before returning results but we were previously doing it in a defer, after the result object was completed.
* In order to ensure we do always close the pipeline even as this code changes over time, I still deferred it but wrapped it in OnceFunc so it doesn't get called twice. It's not really a problem to call it twice right now but I decided we should avoid this edge case in the future.