### PR TITLE
chore: add shared vscode launch config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ _shared-workflows-dockerhub-login
 
 # vscode
 .vscode
+!.vscode/launch.json
 
 # nix
 nix/result

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,76 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Debug Specified Test",
+      "type": "go",
+      "request": "launch",
+      "mode": "test",
+      "program": "${fileDirname}",
+      "args": [
+        "-test.run",
+        "^${input:testName}$"
+      ],
+      "showLog": true,
+      "trace": "verbose"
+    },
+    {
+      "name": "Attach to Process",
+      "type": "go",
+      "request": "attach",
+      "mode": "local",
+      "processId": "${command:pickProcess}"
+    },
+    {
+      "name": "Debug Loki",
+      "type": "go",
+      "request": "launch",
+      "mode": "debug",
+      "program": "${workspaceFolder}/cmd/loki",
+      "args": [
+        "-config.file=${workspaceFolder}/cmd/loki/loki-local-config.yaml"
+      ],
+      "showLog": true
+    },
+    {
+      "name": "Debug Loki (Custom Config)",
+      "type": "go",
+      "request": "launch",
+      "mode": "debug",
+      "program": "${workspaceFolder}/cmd/loki",
+      "args": [
+        "-config.file=${input:configFile}"
+      ],
+      "showLog": true
+    },
+    {
+      "name": "Debug Remote Process (dlv connect)",
+      "type": "go",
+      "request": "attach",
+      "mode": "remote",
+      "remotePath": "${workspaceFolder}",
+      "port": "${input:port}",
+      "host": "localhost"
+    }
+  ],
+  "inputs": [
+    {
+      "id": "configFile",
+      "type": "promptString",
+      "description": "Path to Loki config file",
+      "default": "${workspaceFolder}/cmd/loki/loki-local-config.yaml"
+    },
+    {
+      "id": "testName",
+      "type": "promptString",
+      "description": "Test name to run"
+    },
+    {
+      "id": "port",
+      "type": "promptString",
+      "description": "Port to connect to",
+      "default": 18001
+    }
+  ]
+}
+

--- a/pkg/logql/bench/config.yaml
+++ b/pkg/logql/bench/config.yaml
@@ -78,10 +78,9 @@ storage_config:
     filesystem:
       dir: ${PWD}/pkg/logql/bench/data/storage
 
-querier:
-  engine_v2:
-    enable: true
-    batch_size: 8192
+query_engine:
+  enable: true
+  batch_size: 8192
 
 query_range:
   cache_results: false


### PR DESCRIPTION
**What this PR does / why we need it**:

Add a shared launch config for debugging with VS Code and like editors.

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
