### PR TITLE
chore(engine): adjustments to log task short circuiting

### DIFF
--- a/pkg/engine/internal/scheduler/scheduler_test.go
+++ b/pkg/engine/internal/scheduler/scheduler_test.go
@@ -367,7 +367,7 @@ func TestScheduler_Start(t *testing.T) {
 		require.Equal(t, workflow.TaskStatePending, taskStatus.State, "Started tasks should move to pending state")
 	})
 
-	t.Run("Fails with existing task", func(t *testing.T) {
+	t.Run("Ignores already started tasks", func(t *testing.T) {
 		sched := newTestScheduler(t)
 
 		var (
@@ -380,8 +380,7 @@ func TestScheduler_Start(t *testing.T) {
 		)
 		require.NoError(t, sched.RegisterManifest(t.Context(), manifest), "Scheduler should accept valid manifest")
 		require.NoError(t, sched.Start(t.Context(), exampleTask), "Scheduler should start registered task")
-
-		require.Error(t, sched.Start(t.Context(), exampleTask), "Scheduler should reject already started tasks")
+		require.NoError(t, sched.Start(t.Context(), exampleTask), "Scheduler should ignore already started tasks")
 	})
 }
 

--- a/pkg/engine/internal/scheduler/wire/codec.go
+++ b/pkg/engine/internal/scheduler/wire/codec.go
@@ -316,6 +316,13 @@ func (c *protobufCodec) taskStatusFromPbTaskStatus(ts *wirepb.TaskStatus) (workf
 		status.Capture = capture
 	}
 
+	if ts.ContributingTimeRange != nil {
+		status.ContributingTimeRange = workflow.ContributingTimeRange{
+			Timestamp: ts.ContributingTimeRange.Timestamp,
+			LessThan:  ts.ContributingTimeRange.LessThan,
+		}
+	}
+
 	return status, nil
 }
 
@@ -571,6 +578,10 @@ func (c *protobufCodec) taskToPbTask(from *workflow.Task) (*wirepb.Task, error) 
 func (c *protobufCodec) taskStatusToPbTaskStatus(from workflow.TaskStatus) (*wirepb.TaskStatus, error) {
 	ts := &wirepb.TaskStatus{
 		State: c.taskStateToPbTaskState(from.State),
+		ContributingTimeRange: &wirepb.ContributingTimeRange{
+			Timestamp: from.ContributingTimeRange.Timestamp,
+			LessThan:  from.ContributingTimeRange.LessThan,
+		},
 	}
 
 	if from.Error != nil {

--- a/pkg/engine/internal/scheduler/wire/codec_test.go
+++ b/pkg/engine/internal/scheduler/wire/codec_test.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"net/netip"
 	"testing"
+	"time"
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
@@ -123,6 +124,18 @@ func TestProtobufCodec_Messages(t *testing.T) {
 				ID: taskULID,
 				Status: workflow.TaskStatus{
 					State: workflow.TaskStateRunning,
+				},
+			},
+		},
+		"TaskStatusMessage with Running state and ContributingTimeRange": {
+			message: TaskStatusMessage{
+				ID: taskULID,
+				Status: workflow.TaskStatus{
+					State: workflow.TaskStateRunning,
+					ContributingTimeRange: workflow.ContributingTimeRange{
+						Timestamp: time.Now().Add(-time.Minute),
+						LessThan:  true,
+					},
 				},
 			},
 		},

--- a/pkg/engine/internal/worker/thread.go
+++ b/pkg/engine/internal/worker/thread.go
@@ -167,7 +167,7 @@ func (t *thread) runJob(ctx context.Context, job *threadJob) {
 	// If the root pipeline can be interested in some specific contributing time range
 	// then subscribe to changes.
 	// TODO(spiridonov): find a way to subscribe on non-root pipelines.
-	notifier, ok := pipeline.(executor.ContributingTimeRangeChangedNotifier)
+	notifier, ok := executor.Unwrap(pipeline).(executor.ContributingTimeRangeChangedNotifier)
 	if ok {
 		notifier.SubscribeToTimeRangeChanges(func(ts time.Time, lessThan bool) {
 			// Send a Running task status update with the current time range

--- a/pkg/engine/internal/workflow/workflow.go
+++ b/pkg/engine/internal/workflow/workflow.go
@@ -11,6 +11,8 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/oklog/ulid/v2"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 
 	"github.com/grafana/loki/v3/pkg/engine/internal/executor"
 	"github.com/grafana/loki/v3/pkg/engine/internal/planner/physical"
@@ -18,6 +20,11 @@ import (
 	"github.com/grafana/loki/v3/pkg/logqlmodel/stats"
 	"github.com/grafana/loki/v3/pkg/xcap"
 )
+
+var shortCircuitsTotal = promauto.NewCounter(prometheus.CounterOpts{
+	Name: "loki_engine_v2_task_short_circuits_total",
+	Help: "Total number of tasks preemptively canceled by short circuiting.",
+})
 
 // Options configures a [Workflow].
 type Options struct {
@@ -379,8 +386,8 @@ func (wf *Workflow) handleNonTerminalStateChange(ctx context.Context, task *Task
 				// TODO(spiridonov): We do not check parents here right now, there is only 1 parent now,
 				// but in general a task can be canceled only if all its parents are in terminal states OR
 				// have non-inersecting contributing time range.
-
 				tasksToCancel = append(tasksToCancel, child)
+				shortCircuitsTotal.Inc()
 			}
 		}
 		wf.tasksMut.RUnlock()


### PR DESCRIPTION
Make some adjustments to short circuiting of log tasks:

* Ensure that workers can properly subscribe to time change events, even if the root pipeline is wrapping an underlying pipeline.

* Ignore cancelled tasks when enqueing, which otherwise failed the query when the workflow attempted to queue short-circuited tasks.

* Permit propagating task status changes when the task state hasn't changed.

* Serialize and deserialize ContributingTimeRange when using the protobuf codec.

* Add an counter for the number of tasks cancelled due to short circuiting.