### PR TITLE
chore: set Dataobj logql stats from xcap

### DIFF
--- a/pkg/xcap/summary.go
+++ b/pkg/xcap/summary.go
@@ -274,6 +274,7 @@ func (c *Capture) ToStatsSummary(execTime, queueTime time.Duration, totalEntries
 		StatDatasetSecondaryColumnUncompressedBytes.Key(),
 	)
 
+	// TODO: track and report TotalStructuredMetadataBytesProcessed
 	result.Querier.Store.Dataobj.PrePredicateDecompressedBytes = readInt64(observations, StatDatasetPrimaryColumnUncompressedBytes.Key())
 	result.Querier.Store.Dataobj.PostPredicateDecompressedBytes = readInt64(observations, StatDatasetSecondaryColumnUncompressedBytes.Key())
 	result.Querier.Store.Dataobj.PrePredicateDecompressedRows = readInt64(observations, StatDatasetPrimaryRowsRead.Key())
@@ -281,15 +282,6 @@ func (c *Capture) ToStatsSummary(execTime, queueTime time.Duration, totalEntries
 	// TODO: this will report the wrong value if the plan has a filter stage.
 	// pick the min of row_out from filter and scan nodes.
 	result.Querier.Store.Dataobj.PostFilterRows = readInt64(observations, StatPipelineRowsOut.Key())
-
-	// TODO: track and report TotalStructuredMetadataBytesProcessed
-
-	if execTime > 0 {
-		execSeconds := execTime.Seconds()
-		result.Summary.BytesProcessedPerSecond = int64(float64(result.Summary.TotalBytesProcessed) / execSeconds)
-		result.Summary.LinesProcessedPerSecond = int64(float64(result.Summary.TotalLinesProcessed) / execSeconds)
-	}
-
 	return result
 }
 

--- a/pkg/xcap/summary_test.go
+++ b/pkg/xcap/summary_test.go
@@ -134,9 +134,10 @@ func TestToStatsSummary(t *testing.T) {
 		require.Equal(t, execTime.Seconds(), result.Summary.ExecTime)
 		require.Equal(t, queueTime.Seconds(), result.Summary.QueueTime)
 		require.Equal(t, int64(entriesReturned), result.Summary.TotalEntriesReturned)
-		require.Equal(t, int64(0), result.Summary.TotalBytesProcessed)
-		require.Equal(t, int64(0), result.Summary.TotalLinesProcessed)
-		require.Equal(t, int64(0), result.Summary.TotalPostFilterLines)
+		require.Equal(t, int64(0), result.Querier.Store.Dataobj.PrePredicateDecompressedRows)
+		require.Equal(t, int64(0), result.Querier.Store.Dataobj.PrePredicateDecompressedBytes)
+		require.Equal(t, int64(0), result.Querier.Store.Dataobj.PostPredicateDecompressedBytes)
+		require.Equal(t, int64(0), result.Querier.Store.Dataobj.PostFilterRows)
 	})
 
 	t.Run("computes bytes and lines from DataObjScan regions", func(t *testing.T) {
@@ -174,20 +175,10 @@ func TestToStatsSummary(t *testing.T) {
 		require.Equal(t, queueTime.Seconds(), result.Summary.QueueTime)
 		require.Equal(t, int64(entriesReturned), result.Summary.TotalEntriesReturned)
 
-		// TotalBytesProcessed = primary + secondary = (1000+2000) + (500+1000) = 4500
-		require.Equal(t, int64(4500), result.Summary.TotalBytesProcessed)
-
-		// TotalLinesProcessed = primary_rows_read = 100 + 200 = 300
-		require.Equal(t, int64(300), result.Summary.TotalLinesProcessed)
-
-		// TotalPostFilterLines = rows_out = 80 + 150 = 230
-		require.Equal(t, int64(230), result.Summary.TotalPostFilterLines)
-
-		// BytesProcessedPerSecond = 4500 / 2 = 2250
-		require.Equal(t, int64(2250), result.Summary.BytesProcessedPerSecond)
-
-		// LinesProcessedPerSecond = 300 / 2 = 150
-		require.Equal(t, int64(150), result.Summary.LinesProcessedPerSecond)
+		require.Equal(t, int64(300), result.Querier.Store.Dataobj.PrePredicateDecompressedRows)
+		require.Equal(t, int64(3000), result.Querier.Store.Dataobj.PrePredicateDecompressedBytes)
+		require.Equal(t, int64(1500), result.Querier.Store.Dataobj.PostPredicateDecompressedBytes)
+		require.Equal(t, int64(230), result.Querier.Store.Dataobj.PostFilterRows)
 	})
 
 	t.Run("missing statistics result in zero values", func(t *testing.T) {
@@ -202,11 +193,11 @@ func TestToStatsSummary(t *testing.T) {
 		execTime := 1 * time.Second
 		result := capture.ToStatsSummary(execTime, 0, 0)
 
-		// Only primary bytes recorded
-		require.Equal(t, int64(1000), result.Summary.TotalBytesProcessed)
-		// No rows recorded
-		require.Equal(t, int64(0), result.Summary.TotalLinesProcessed)
 		require.Equal(t, int64(0), result.Summary.TotalPostFilterLines)
+		require.Equal(t, int64(0), result.Querier.Store.Dataobj.PrePredicateDecompressedRows)
+		require.Equal(t, int64(1000), result.Querier.Store.Dataobj.PrePredicateDecompressedBytes)
+		require.Equal(t, int64(0), result.Querier.Store.Dataobj.PostPredicateDecompressedBytes)
+		require.Equal(t, int64(0), result.Querier.Store.Dataobj.PostFilterRows)
 	})
 
 	t.Run("rolls up child region observations into DataObjScan", func(t *testing.T) {
@@ -227,6 +218,6 @@ func TestToStatsSummary(t *testing.T) {
 		result := capture.ToStatsSummary(time.Second, 0, 0)
 
 		// Child observations rolled up into DataObjScan: 500 + 300 = 800
-		require.Equal(t, int64(800), result.Summary.TotalBytesProcessed)
+		require.Equal(t, int64(800), result.Querier.Store.Dataobj.PrePredicateDecompressedBytes)
 	})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

xcap summary was setting logql stats Summary, but this gets ignored by the merging code in query-frontend. Instead set the stats in `Store.Dataobj` as these are the ones used to generate summary.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
