### PR TITLE
fix: Do not override S3 region if already specified in configuration chain

### DIFF
--- a/pkg/storage/chunk/client/aws/config_test.go
+++ b/pkg/storage/chunk/client/aws/config_test.go
@@ -108,7 +108,7 @@ func TestS3ClientOptions(t *testing.T) {
 		opts := s3.Options{}
 		fn(&opts)
 
-		require.Equal(t, "", opts.Region)
+		require.Equal(t, InvalidAWSRegion, opts.Region) // it is still required to set region explicitly
 		require.Equal(t, "http://s3.us-east-0.amazonaws.com", *opts.BaseEndpoint)
 	})
 
@@ -120,7 +120,7 @@ func TestS3ClientOptions(t *testing.T) {
 		opts := s3.Options{}
 		fn(&opts)
 
-		require.Equal(t, "", opts.Region)
+		require.Equal(t, InvalidAWSRegion, opts.Region) // it is still required to set region explicitly
 		require.Equal(t, "https://s3.us-east-0.amazonaws.com", *opts.BaseEndpoint)
 	})
 

--- a/pkg/storage/chunk/client/aws/s3_storage_client.go
+++ b/pkg/storage/chunk/client/aws/s3_storage_client.go
@@ -316,7 +316,9 @@ func s3ClientConfigFunc(cfg S3Config, hedgingCfg hedging.Config, hedging bool) (
 				// s3://<key>:<secret>@us-east-0/<bucketname>
 				opts.Region = awsURL.Host
 			}
-		} else {
+		}
+		if opts.Region == "" {
+			// Not sure why this is needed, but test otherwise time out when run in CI
 			opts.Region = InvalidAWSRegion
 		}
 


### PR DESCRIPTION
### Summary

The region (and other settings) for the S3 configuration can be specified in various ways.
When the region was already set by `LoadDefaultConfig` it should not be set to `InvalidAWSRegion`.

This is a follow up on #20110

