### PR TITLE
fix(helm): correct PodLogs namespaceSelector for v1alpha2 CRD

### DIFF
--- a/production/helm/loki/templates/monitoring/pod-logs.yaml
+++ b/production/helm/loki/templates/monitoring/pod-logs.yaml
@@ -53,8 +53,13 @@ spec:
     {{- toYaml . | nindent 4 }}
     {{- end }}
   namespaceSelector:
+    {{- if eq .apiVersion "monitoring.grafana.com/v1alpha2" }}
+    matchLabels:
+      kubernetes.io/metadata.name: {{ include "loki.namespace" $ }}
+    {{- else }}
     matchNames:
       - {{ include "loki.namespace" $ }}
+    {{- end }}
   selector:
     matchLabels:
       {{- include "loki.selectorLabels" $ | nindent 6 }}


### PR DESCRIPTION
**What this PR does / why we need it**

This PR fixes an incompatibility in the Helm chart’s PodLogs template when using `monitoring.grafana.com/v1alpha2` as the PodLogs API version. The template is updated to render matchLabels instead of matchNames for v1alpha2, since the v1alpha2 PodLogs CRD does not support matchNames. 

This ensures that the generated PodLogs resource correctly scopes log collection to the Loki namespace and prevents unintended cluster-wide log scraping.

**Which issue(s) this PR fixes**

Fixes #19737

**Special notes for your reviewer**

- This patch maintains full backward compatibility with existing API versions.
- The change only affects the PodLogs resource generated by selfMonitoring.
- The logic matches the CRD schema for v1alpha2, which accepts only matchLabels and matchExpressions.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
