### PR TITLE
feat: enable racing in the querytee

### DIFF
--- a/tools/querytee/goldfish/end_to_end_test.go
+++ b/tools/querytee/goldfish/end_to_end_test.go
@@ -124,7 +124,7 @@ func TestGoldfishEndToEnd(t *testing.T) {
 	}
 
 	// Send to Goldfish for processing
-	manager.SendToGoldfish(req, cellAResp, cellBResp, false)
+	manager.SendToGoldfish(req, cellAResp, cellBResp)
 
 	// Wait for async processing
 	time.Sleep(100 * time.Millisecond)
@@ -244,7 +244,7 @@ func TestGoldfishMismatchDetection(t *testing.T) {
 		SpanID:      "",
 	}
 
-	manager.SendToGoldfish(req, cellAResp, cellBResp, false)
+	manager.SendToGoldfish(req, cellAResp, cellBResp)
 
 	time.Sleep(100 * time.Millisecond)
 
@@ -333,7 +333,7 @@ func TestGoldfishFloatingPointMismatchDetection(t *testing.T) {
 		SpanID:      "",
 	}
 
-	manager.SendToGoldfish(req, cellAResp, cellBResp, false)
+	manager.SendToGoldfish(req, cellAResp, cellBResp)
 
 	time.Sleep(100 * time.Millisecond)
 
@@ -435,7 +435,7 @@ func TestGoldfishNewEngineDetection(t *testing.T) {
 		SpanID:      "",
 	}
 
-	manager.SendToGoldfish(req, cellAResp, cellBResp, false)
+	manager.SendToGoldfish(req, cellAResp, cellBResp)
 
 	time.Sleep(100 * time.Millisecond)
 

--- a/tools/querytee/goldfish/manager.go
+++ b/tools/querytee/goldfish/manager.go
@@ -121,7 +121,7 @@ type BackendResponse struct {
 	SpanID      string
 }
 
-func (m *Manager) SendToGoldfish(httpReq *http.Request, cellAResp, cellBResp *BackendResponse, cellAWon bool) {
+func (m *Manager) SendToGoldfish(httpReq *http.Request, cellAResp, cellBResp *BackendResponse) {
 	if !m.config.Enabled {
 		return
 	}
@@ -146,12 +146,12 @@ func (m *Manager) SendToGoldfish(httpReq *http.Request, cellAResp, cellBResp *Ba
 	}
 	cellBData.BackendName = cellBResp.BackendName
 
-	m.processQueryPair(httpReq, cellAData, cellBData, cellAWon)
+	m.processQueryPair(httpReq, cellAData, cellBData)
 }
 
 // processQueryPair processes a sampled query pair from both cells.
 // It extracts performance statistics, compares responses, persists raw payloads when configured, and stores metadata/results.
-func (m *Manager) processQueryPair(req *http.Request, cellAResp, cellBResp *ResponseData, cellAWon bool) {
+func (m *Manager) processQueryPair(req *http.Request, cellAResp, cellBResp *ResponseData) {
 	// Use a detached context with timeout since this runs async
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
@@ -202,8 +202,6 @@ func (m *Manager) processQueryPair(req *http.Request, cellAResp, cellBResp *Resp
 		CellBSpanID:        cellBResp.SpanID,
 		CellAUsedNewEngine: cellAResp.UsedNewEngine,
 		CellBUsedNewEngine: cellBResp.UsedNewEngine,
-		CellAWon:           cellAWon,
-		CellBWon:           !cellAWon,
 		SampledAt:          sampledAt,
 	}
 

--- a/tools/querytee/goldfish/manager_test.go
+++ b/tools/querytee/goldfish/manager_test.go
@@ -157,7 +157,7 @@ func TestManager_ProcessQueryPair(t *testing.T) {
 		UsedNewEngine: true,
 	}
 
-	manager.processQueryPair(req, cellAResp, cellBResp, false)
+	manager.processQueryPair(req, cellAResp, cellBResp)
 
 	// Give async processing time to complete
 	time.Sleep(100 * time.Millisecond)
@@ -260,7 +260,7 @@ func Test_ProcessQueryPair_populatesTraceIDs(t *testing.T) {
 		TraceID:       "trace-cell-b-456",
 	}
 
-	manager.processQueryPair(req, cellAResp, cellBResp, false)
+	manager.processQueryPair(req, cellAResp, cellBResp)
 
 	// Give async processing time to complete
 	time.Sleep(100 * time.Millisecond)
@@ -344,7 +344,7 @@ func TestProcessQueryPairCapturesUser(t *testing.T) {
 				UsedNewEngine: false,
 			}
 
-			manager.processQueryPair(req, cellAResp, cellBResp, false)
+			manager.processQueryPair(req, cellAResp, cellBResp)
 
 			// Give async processing time to complete
 			time.Sleep(100 * time.Millisecond)
@@ -481,7 +481,7 @@ func TestProcessQueryPair_CapturesLogsDrilldown(t *testing.T) {
 				UsedNewEngine: false,
 			}
 
-			manager.processQueryPair(req, cellAResp, cellBResp, false)
+			manager.processQueryPair(req, cellAResp, cellBResp)
 
 			// Give async processing time to complete
 			time.Sleep(100 * time.Millisecond)
@@ -577,7 +577,7 @@ func TestManagerResultPersistenceModes(t *testing.T) {
 				BackendName: "cell-b",
 			}
 
-			manager.processQueryPair(req, cellA, cellB, false)
+			manager.processQueryPair(req, cellA, cellB)
 
 			require.Equal(t, tt.expectStores, len(results.calls))
 

--- a/tools/querytee/proxy_endpoint.go
+++ b/tools/querytee/proxy_endpoint.go
@@ -499,5 +499,5 @@ func (p *ProxyEndpoint) processWithGoldfish(r *http.Request, cellAResp, cellBRes
 		SpanID:      cellBResp.spanID,
 	}
 
-	p.goldfishManager.SendToGoldfish(r, cellAGoldfishResp, cellBGoldfishResp, false)
+	p.goldfishManager.SendToGoldfish(r, cellAGoldfishResp, cellBGoldfishResp)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR enables racing in the querytee, allowing us to serve the split from the engine that returned a result the fastest, instead of always returning the result from the preferred/v1 engine.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
