### PR TITLE
fix: remove logging of sensitive data

### DIFF
--- a/tools/querytee/fanout_handler.go
+++ b/tools/querytee/fanout_handler.go
@@ -83,7 +83,7 @@ func (h *FanOutHandler) Do(ctx context.Context, req queryrangebase.Request) (que
 	}
 
 	issuer := detectIssuer(httpReq)
-	user := goldfish.ExtractUserFromQueryTags(httpReq, h.logger)
+	user := goldfish.ExtractUserFromQueryTags(httpReq)
 	level.Debug(h.logger).Log(
 		"msg", "Received request",
 		"path", httpReq.URL.Path,

--- a/tools/querytee/goldfish/manager.go
+++ b/tools/querytee/goldfish/manager.go
@@ -181,7 +181,7 @@ func (m *Manager) processQueryPair(req *http.Request, cellAResp, cellBResp *Resp
 	sample := &goldfish.QuerySample{
 		CorrelationID:      correlationID,
 		TenantID:           tenantID,
-		User:               ExtractUserFromQueryTags(req, m.logger),
+		User:               ExtractUserFromQueryTags(req),
 		IsLogsDrilldown:    isLogsDrilldownRequest(req),
 		Query:              req.URL.Query().Get("query"),
 		QueryType:          queryType,
@@ -523,7 +523,7 @@ func parseDuration(s string) time.Duration {
 	return d
 }
 
-func ExtractUserFromQueryTags(req *http.Request, logger log.Logger) string {
+func ExtractUserFromQueryTags(req *http.Request) string {
 	// Also check for X-Grafana-User header directly
 	tags := httpreq.ExtractQueryTagsFromHTTP(req)
 	grafanaUser := req.Header.Get("X-Grafana-User")

--- a/tools/querytee/goldfish/manager_test.go
+++ b/tools/querytee/goldfish/manager_test.go
@@ -402,8 +402,7 @@ func TestExtractUserFromQueryTags(t *testing.T) {
 				req.Header.Set("X-Query-Tags", tt.queryTags)
 			}
 
-			logger := log.NewNopLogger()
-			got := ExtractUserFromQueryTags(req, logger)
+			got := ExtractUserFromQueryTags(req)
 			assert.Equal(t, tt.expectedUser, got)
 		})
 	}

--- a/tools/querytee/proxy_endpoint.go
+++ b/tools/querytee/proxy_endpoint.go
@@ -132,7 +132,7 @@ func (p *ProxyEndpoint) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	traceID, _, _ := tracing.ExtractTraceSpanID(ctx)
-	user := goldfish.ExtractUserFromQueryTags(r, p.logger)
+	user := goldfish.ExtractUserFromQueryTags(r)
 	logger := log.With(p.logger, "traceID", traceID, "tenant", tenantID, "user", user)
 
 	// The codec decode/encode cycle loses custom headers, so we preserve them for downstream


### PR DESCRIPTION
**What this PR does / why we need it**:

We had debug log of request headers, which could expose sensitive information.

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
