### PR TITLE
chore: xcap summary treat duration observation values as seconds

### DIFF
--- a/pkg/xcap/summary.go
+++ b/pkg/xcap/summary.go
@@ -135,11 +135,11 @@ func (o *observations) toLogValues() []any {
 		if strings.HasSuffix(p.name, "duration") {
 			switch val := value.(type) {
 			case float64:
-				value = time.Duration(val * 1000).String()
+				value = time.Duration(val * float64(time.Second)).String()
 			case int64:
-				value = time.Duration(val * 1000).String()
+				value = time.Duration(val * int64(time.Second)).String()
 			case uint64:
-				value = time.Duration(val * 1000).String()
+				value = time.Duration(val * uint64(time.Second)).String()
 			}
 		}
 


### PR DESCRIPTION
**What this PR does / why we need it**:


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
