### PR TITLE
fix: apply missing middlewares to query-tee

### DIFF
--- a/tools/querytee/handler_factory.go
+++ b/tools/querytee/handler_factory.go
@@ -2,14 +2,13 @@ package querytee
 
 import (
 	"net/http"
-	"time"
 
 	"github.com/go-kit/log"
 
-	"github.com/grafana/loki/v3/pkg/engine"
-	"github.com/grafana/loki/v3/pkg/lokifrontend/frontend"
-	"github.com/grafana/loki/v3/pkg/querier/queryrange"
+	"github.com/grafana/dskit/middleware"
 	"github.com/grafana/loki/v3/pkg/querier/queryrange/queryrangebase"
+	"github.com/grafana/loki/v3/pkg/util/httpreq"
+	"github.com/grafana/loki/v3/pkg/util/server"
 	"github.com/grafana/loki/v3/tools/querytee/comparator"
 	"github.com/grafana/loki/v3/tools/querytee/goldfish"
 )
@@ -49,11 +48,7 @@ func NewHandlerFactory(cfg HandlerFactoryConfig) *HandlerFactory {
 	}
 }
 
-// CreateHandler creates the appropriate handler based on configuration.
-// If ComparisonMinAge is 0 (legacy mode), it returns a FanOutHandler directly.
-// If ComparisonMinAge > 0 (splitting mode), it wraps the FanOutHandler with engineRouter
-// middleware to split queries based on data age.
-func (f *HandlerFactory) CreateHandler(routeName string, comp comparator.ResponsesComparator, forMetricQuery bool) queryrangebase.Handler {
+func (f *HandlerFactory) CreateHandler(routeName string, comp comparator.ResponsesComparator) http.Handler {
 	// Create the fan-out handler that sends requests to all backends
 	fanOutHandler := NewFanOutHandler(FanOutHandlerConfig{
 		Backends:           f.backends,
@@ -67,15 +62,6 @@ func (f *HandlerFactory) CreateHandler(routeName string, comp comparator.Respons
 		RouteName:          routeName,
 	})
 
-	if f.goldfishManager == nil || f.goldfishManager.ComparisonMinAge() == 0 {
-		return fanOutHandler
-	}
-
-	return f.createSplittingHandler(fanOutHandler, forMetricQuery)
-}
-
-// createSplittingHandler creates a handler that splits queries based on data age.
-func (f *HandlerFactory) createSplittingHandler(fanOutHandler *FanOutHandler, forMetricQuery bool) queryrangebase.Handler {
 	var preferredBackend *ProxyBackend
 	for _, b := range f.backends {
 		if b.preferred {
@@ -84,49 +70,19 @@ func (f *HandlerFactory) createSplittingHandler(fanOutHandler *FanOutHandler, fo
 		}
 	}
 
-	if preferredBackend == nil {
-		// No preferred backend, can't do splitting - fall back to fan-out
-		return fanOutHandler
-	}
-
-	// Create downstream round tripper for recent queries (preferred backend only)
-	preferredRT, err := frontend.NewDownstreamRoundTripper(
-		preferredBackend.endpoint.String(),
-		//TODO(twhitney): do we have this config already somewhere?
-		&http.Transport{
-			MaxIdleConnsPerHost: 100,
-			IdleConnTimeout:     90 * time.Second,
-		},
+	splittingHandler := NewSplittingHandler(
 		f.codec,
-	)
-	if err != nil {
-		// Fall back to fan-out handler if we can't create the downstream RT
-		return fanOutHandler
-	}
-
-	routerConfig := queryrange.RouterConfig{
-		Enabled:  true,
-		Start:    f.goldfishManager.ComparisonStartDate(),
-		Lag:      f.goldfishManager.ComparisonMinAge(),
-		Validate: engine.IsQuerySupported,
-		Handler:  fanOutHandler, // v2Next: fan-out to all backends for goldfish
-	}
-
-	middleware := []queryrangebase.Middleware{}
-	if forMetricQuery {
-		middleware = append(middleware, queryrangebase.StepAlignMiddleware)
-	}
-
-	// Create the engine router engineRouterMiddleware
-	engineRouterMiddleware := queryrange.NewEngineRouterMiddleware(
-		routerConfig,
-		nil, // no v1 chain middleware
-		f.codec,
-		forMetricQuery,
+		fanOutHandler,
+		f.goldfishManager,
 		f.logger,
+		preferredBackend,
 	)
-	middleware = append(middleware, engineRouterMiddleware)
 
-	// Wrap the preferred backend handler (v1Next) with the router middleware
-	return queryrangebase.MergeMiddlewares(middleware...).Wrap(preferredRT)
+	httpMiddlewares := []middleware.Interface{
+		httpreq.ExtractQueryTagsMiddleware(),
+		httpreq.PropagateHeadersMiddleware(httpreq.LokiActorPathHeader, httpreq.LokiEncodingFlagsHeader, httpreq.LokiDisablePipelineWrappersHeader),
+		server.NewPrepopulateMiddleware(),
+	}
+
+	return middleware.Merge(httpMiddlewares...).Wrap(splittingHandler)
 }

--- a/tools/querytee/proxy.go
+++ b/tools/querytee/proxy.go
@@ -300,9 +300,8 @@ func (p *Proxy) Start() error {
 			InstrumentCompares: p.cfg.InstrumentCompares,
 			EnableRace:         p.cfg.EnableRace,
 		})
-		queryHandler := routeHandlerFactory.CreateHandler(route.RouteName, comp, false)
-		metricHandler := routeHandlerFactory.CreateHandler(route.RouteName, comp, true)
-		endpoint.WithQueryHandlers(queryHandler, metricHandler, queryrange.DefaultCodec)
+		queryHandler := routeHandlerFactory.CreateHandler(route.RouteName, comp)
+		endpoint.WithQueryHandler(queryHandler)
 		level.Info(p.logger).Log(
 			"msg", "Query middleware handler attached to route",
 			"path", route.Path,

--- a/tools/querytee/proxy_endpoint.go
+++ b/tools/querytee/proxy_endpoint.go
@@ -2,7 +2,6 @@ package querytee
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -13,14 +12,9 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/pkg/errors"
 
 	"github.com/grafana/dskit/tenant"
-	"github.com/grafana/dskit/tracing"
 
-	"github.com/grafana/loki/v3/pkg/logql/syntax"
-	"github.com/grafana/loki/v3/pkg/querier/queryrange"
-	"github.com/grafana/loki/v3/pkg/querier/queryrange/queryrangebase"
 	"github.com/grafana/loki/v3/pkg/util/server"
 	"github.com/grafana/loki/v3/tools/querytee/comparator"
 	"github.com/grafana/loki/v3/tools/querytee/goldfish"
@@ -62,14 +56,7 @@ type ProxyEndpoint struct {
 
 	// Handler for processing requests using the middleware pattern.
 	// When set, ServeHTTP uses this instead of the legacy executeBackendRequests.
-	queryHandler queryrangebase.Handler
-
-	// Handler for processing metric requests using the middleware pattern.
-	// When set, ServeHTTP uses this instead of the legacy executeBackendRequests.
-	metricQueryHandler queryrangebase.Handler
-
-	// Codec for encoding/decoding requests and responses.
-	codec queryrangebase.Codec
+	queryHandler http.Handler
 }
 
 func NewProxyEndpoint(
@@ -105,12 +92,10 @@ func (p *ProxyEndpoint) WithGoldfish(manager *goldfish.Manager) *ProxyEndpoint {
 	return p
 }
 
-// WithQueryHandlers sets the middleware-based query handlers (logs and metrics) for the endpoint.
+// WithQueryHandler sets the middleware-based query handlers (logs and metrics) for the endpoint.
 // When set, ServeHTTP uses this handler instead of the legacy executeBackendRequests.
-func (p *ProxyEndpoint) WithQueryHandlers(handler, metricHandler queryrangebase.Handler, codec queryrangebase.Codec) *ProxyEndpoint {
+func (p *ProxyEndpoint) WithQueryHandler(handler http.Handler) *ProxyEndpoint {
 	p.queryHandler = handler
-	p.metricQueryHandler = metricHandler
-	p.codec = codec
 	return p
 }
 
@@ -122,95 +107,7 @@ func (p *ProxyEndpoint) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	tenantID, ctx, err := tenant.ExtractTenantIDFromHTTPRequest(r)
-	if err != nil {
-		level.Error(p.logger).Log(
-			"msg", "failed to extract tenant ID",
-			"err", err,
-			"req", r.URL.String(),
-		)
-		http.Error(w, err.Error(), http.StatusUnauthorized)
-		return
-	}
-
-	traceID, _, _ := tracing.ExtractTraceSpanID(ctx)
-	user := goldfish.ExtractUserFromQueryTags(r)
-	logger := log.With(p.logger, "traceID", traceID, "tenant", tenantID, "user", user)
-
-	// The codec decode/encode cycle loses custom headers, so we preserve them for downstream
-	headersCopy := r.Header.Clone()
-	ctx = context.WithValue(ctx, originalHTTPHeadersKey, headersCopy)
-
-	// Decode the HTTP request into a queryrangebase.Request
-	req, err := p.codec.DecodeRequest(ctx, r, nil)
-	if err != nil {
-		query := r.Form.Get("query")
-		level.Warn(logger).Log(
-			"msg", "failed to decode request",
-			"query", query,
-			"req", r.URL.String(),
-			"err", err,
-		)
-		server.WriteError(err, w)
-		return
-	}
-
-	// Execute the handler
-	var resp queryrangebase.Response
-	switch op := req.(type) {
-	case *queryrange.LokiRequest:
-		if op.Plan == nil {
-			err := errors.New("query plan is empty")
-			query := r.Form.Get("query")
-			level.Warn(logger).Log("msg", "query plan is empty", "query", query, "err", err)
-			server.WriteError(err, w)
-			return
-		}
-
-		switch op.Plan.AST.(type) {
-		case syntax.VariantsExpr, syntax.SampleExpr:
-			resp, err = p.metricQueryHandler.Do(ctx, req)
-		default:
-			resp, err = p.queryHandler.Do(ctx, req)
-		}
-	default:
-		resp, err = p.queryHandler.Do(ctx, req)
-	}
-
-	if err != nil {
-		switch r := resp.(type) {
-		case *NonDecodableResponse:
-			http.Error(w, string(r.Body), r.StatusCode)
-		default:
-			level.Warn(logger).Log("msg", "handler failed", "err", err)
-			server.WriteError(err, w)
-		}
-		return
-	}
-
-	// Encode the response back to HTTP
-	httpResp, err := p.codec.EncodeResponse(ctx, r, resp)
-	if err != nil {
-		level.Warn(logger).Log("msg", "failed to encode response", "err", err)
-		server.WriteError(err, w)
-		return
-	}
-	defer httpResp.Body.Close()
-
-	// Copy response headers
-	for key, values := range httpResp.Header {
-		for _, value := range values {
-			w.Header().Add(key, value)
-		}
-	}
-
-	// Write status code
-	w.WriteHeader(httpResp.StatusCode)
-
-	// Copy response body
-	if _, err := io.Copy(w, httpResp.Body); err != nil {
-		level.Warn(logger).Log("msg", "unable to write response body", "err", err)
-	}
+	p.queryHandler.ServeHTTP(w, r)
 }
 
 // serveWrites serves writes without a queryrangebase.Handler, since write requests cannot be decoded into a queryrangebase.Request.

--- a/tools/querytee/proxy_endpoint_test.go
+++ b/tools/querytee/proxy_endpoint_test.go
@@ -45,9 +45,8 @@ func createTestEndpoint(backends []*ProxyBackend, routeName string, comparator c
 		Metrics:         metrics,
 	})
 
-	queryHandler := handlerFactory.CreateHandler(routeName, comparator, false)
-	metricHandler := handlerFactory.CreateHandler(routeName, comparator, true)
-	endpoint.WithQueryHandlers(queryHandler, metricHandler, queryrange.DefaultCodec)
+	queryHandler := handlerFactory.CreateHandler(routeName, comparator)
+	endpoint.WithQueryHandler(queryHandler)
 	return endpoint
 }
 
@@ -65,9 +64,8 @@ func createTestEndpointWithMetrics(backends []*ProxyBackend, routeName string, c
 		InstrumentCompares: instrumentCompares,
 	})
 
-	queryHandler := handlerFactory.CreateHandler(routeName, comp, false)
-	metricQueryHandler := handlerFactory.CreateHandler(routeName, comp, true)
-	endpoint.WithQueryHandlers(queryHandler, metricQueryHandler, queryrange.DefaultCodec)
+	queryHandler := handlerFactory.CreateHandler(routeName, comp)
+	endpoint.WithQueryHandler(queryHandler)
 	return endpoint
 }
 
@@ -85,9 +83,8 @@ func createTestEndpointWithGoldfish(backends []*ProxyBackend, routeName string, 
 	})
 
 	endpoint := NewProxyEndpoint(backends, routeName, metrics, logger, nil, false)
-	queryHandler := handlerFactory.CreateHandler(routeName, nil, false)
-	metricQueryHandler := handlerFactory.CreateHandler(routeName, nil, true)
-	endpoint.WithQueryHandlers(queryHandler, metricQueryHandler, queryrange.DefaultCodec)
+	queryHandler := handlerFactory.CreateHandler(routeName, nil)
+	endpoint.WithQueryHandler(queryHandler)
 	endpoint.WithGoldfish(goldfishManager)
 	return endpoint
 }

--- a/tools/querytee/splitting_handler.go
+++ b/tools/querytee/splitting_handler.go
@@ -1,0 +1,211 @@
+package querytee
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/tenant"
+	"github.com/grafana/loki/v3/pkg/engine"
+	"github.com/grafana/loki/v3/pkg/logql/syntax"
+	"github.com/grafana/loki/v3/pkg/lokifrontend/frontend"
+	"github.com/grafana/loki/v3/pkg/querier/queryrange"
+	"github.com/grafana/loki/v3/pkg/querier/queryrange/queryrangebase"
+	"github.com/grafana/loki/v3/pkg/util/server"
+	"github.com/grafana/loki/v3/tools/querytee/goldfish"
+	"github.com/pkg/errors"
+)
+
+type SplittingHandler struct {
+	codec               queryrangebase.Codec
+	fanOutHandler       queryrangebase.Handler
+	goldfishManager     *goldfish.Manager
+	logger              log.Logger
+	logsQueryHandler    queryrangebase.Handler
+	metricsQueryHandler queryrangebase.Handler
+}
+
+func NewSplittingHandler(
+	codec queryrangebase.Codec,
+	fanOutHandler queryrangebase.Handler,
+	goldfishManager *goldfish.Manager,
+	logger log.Logger,
+	preferredBackend *ProxyBackend,
+) *SplittingHandler {
+	splitHandlerFactory := &splitHandlerFactory{
+		codec:            codec,
+		fanOutHandler:    fanOutHandler,
+		goldfishManager:  goldfishManager,
+		logger:           logger,
+		preferredBackend: preferredBackend,
+	}
+	metricsQueryHandler := splitHandlerFactory.createSplittingHandler(true)
+	logsQueryHandler := splitHandlerFactory.createSplittingHandler(false)
+
+	return &SplittingHandler{
+		codec:               codec,
+		fanOutHandler:       fanOutHandler,
+		goldfishManager:     goldfishManager,
+		logger:              logger,
+		logsQueryHandler:    logsQueryHandler,
+		metricsQueryHandler: metricsQueryHandler,
+	}
+}
+
+type splitHandlerFactory struct {
+	codec            queryrangebase.Codec
+	fanOutHandler    queryrangebase.Handler
+	goldfishManager  *goldfish.Manager
+	logger           log.Logger
+	preferredBackend *ProxyBackend
+}
+
+func (f *splitHandlerFactory) createSplittingHandler(forMetricQuery bool) queryrangebase.Handler {
+	if f.preferredBackend == nil {
+		// No preferred backend, can't do splitting - fall back to fan-out
+		return f.fanOutHandler
+	}
+
+	// Create downstream round tripper for recent queries (preferred backend only)
+	preferredRT, err := frontend.NewDownstreamRoundTripper(
+		f.preferredBackend.endpoint.String(),
+		&http.Transport{
+			MaxIdleConnsPerHost: 100,
+			IdleConnTimeout:     90 * time.Second,
+		},
+		f.codec,
+	)
+	if err != nil {
+		// Fall back to fan-out handler if we can't create the downstream RT
+		return f.fanOutHandler
+	}
+
+	routerConfig := queryrange.RouterConfig{
+		Enabled:  true,
+		Validate: engine.IsQuerySupported,
+		Handler:  f.fanOutHandler, // v2Next: fan-out to all backends for goldfish
+	}
+
+	if f.goldfishManager != nil {
+		routerConfig.Start = f.goldfishManager.ComparisonStartDate()
+		routerConfig.Lag = f.goldfishManager.ComparisonMinAge()
+	}
+
+	middleware := []queryrangebase.Middleware{}
+	if forMetricQuery {
+		middleware = append(middleware, queryrangebase.StepAlignMiddleware)
+	}
+
+	// Create the engine router engineRouterMiddleware
+	engineRouterMiddleware := queryrange.NewEngineRouterMiddleware(
+		routerConfig,
+		nil, // no v1 chain middleware
+		f.codec,
+		forMetricQuery,
+		f.logger,
+	)
+	middleware = append(middleware, engineRouterMiddleware)
+
+	// Wrap the preferred backend handler (v1Next) with the router middleware
+	return queryrangebase.MergeMiddlewares(middleware...).Wrap(preferredRT)
+}
+
+// ServeHTTP implements http.Handler interface to serve queries that can be split.
+// If ComparisonMinAge is 0 (legacy mode), serve the non-splitting fan-out handler directly.
+// If ComparisonMinAge > 0 (splitting mode), it wraps the fan-out handler with engineRouter
+// middleware to serve split queries based on data age.
+func (f *SplittingHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	_, ctx, err := tenant.ExtractTenantIDFromHTTPRequest(r)
+	if err != nil {
+		level.Error(f.logger).Log(
+			"msg", "failed to extract tenant ID",
+			"err", err,
+			"req", r.URL.String(),
+		)
+		http.Error(w, err.Error(), http.StatusUnauthorized)
+		return
+	}
+
+	// The codec decode/encode cycle loses custom headers, so we preserve them for downstream
+	headersCopy := r.Header.Clone()
+	ctx = context.WithValue(ctx, originalHTTPHeadersKey, headersCopy)
+
+	req, err := f.codec.DecodeRequest(ctx, r, nil)
+	if err != nil {
+		query := r.Form.Get("query")
+		level.Warn(f.logger).Log(
+			"msg", "failed to decode request",
+			"query", query,
+			"req", r.URL.String(),
+			"err", err,
+		)
+		server.WriteError(err, w)
+		return
+	}
+
+	var resp queryrangebase.Response
+	if f.goldfishManager != nil && f.goldfishManager.ComparisonMinAge() > 0 {
+		resp, err = f.serveSplits(ctx, req)
+	} else {
+		resp, err = f.fanOutHandler.Do(ctx, req)
+	}
+
+	if err != nil {
+		switch r := resp.(type) {
+		case *NonDecodableResponse:
+			http.Error(w, string(r.Body), r.StatusCode)
+		default:
+			level.Warn(f.logger).Log("msg", "handler failed", "err", err)
+			server.WriteError(err, w)
+		}
+		return
+	}
+
+	// Encode the response back to HTTP
+	httpResp, err := f.codec.EncodeResponse(ctx, r, resp)
+	if err != nil {
+		level.Warn(f.logger).Log("msg", "failed to encode response", "err", err)
+		server.WriteError(err, w)
+		return
+	}
+	defer httpResp.Body.Close()
+
+	// Copy response headers
+	for key, values := range httpResp.Header {
+		for _, value := range values {
+			w.Header().Add(key, value)
+		}
+	}
+
+	// Write status code
+	w.WriteHeader(httpResp.StatusCode)
+
+	// Copy response body
+	if _, err := io.Copy(w, httpResp.Body); err != nil {
+		level.Warn(f.logger).Log("msg", "unable to write response body", "err", err)
+	}
+}
+
+func (f *SplittingHandler) serveSplits(ctx context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
+	switch op := req.(type) {
+	case *queryrange.LokiRequest:
+		if op.Plan == nil {
+			err := errors.New("query plan is empty")
+			query := req.GetQuery()
+			level.Warn(f.logger).Log("msg", "query plan is empty", "query", query, "err", err)
+			return nil, err
+		}
+
+		switch op.Plan.AST.(type) {
+		case syntax.VariantsExpr, syntax.SampleExpr:
+			return f.metricsQueryHandler.Do(ctx, req)
+		default:
+			return f.logsQueryHandler.Do(ctx, req)
+		}
+	default:
+		return f.logsQueryHandler.Do(ctx, req)
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds some missing middlewares for propagating certain headers to downstream requests to the query-tee. This should hopefully fix a problem we're seeing with missing `__aggregated_metric__` queries, which depend on the drilldown header.

Unfortunately the missing middlewares were http.Handler instead of queryrangebase.Handler, so it took a bit of refactoring to incorporate them.

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
