### PR TITLE
fix(helm): Fix ingester-b volumeAttributesClassName templating

### DIFF
--- a/production/helm/loki/templates/ingester/statefulset-ingester-zone-b.yaml
+++ b/production/helm/loki/templates/ingester/statefulset-ingester-zone-b.yaml
@@ -234,9 +234,9 @@ spec:
           {{- toYaml .accessModes | nindent 10 }}
         {{- with .storageClass }}
         storageClassName: {{ if (eq "-" .) }}""{{ else }}{{ . }}{{ end }}
+        {{- end }}
         {{- with .volumeAttributesClassName }}
         volumeAttributesClassName: {{ . }}
-        {{- end }}
         {{- end }}
         resources:
           requests:


### PR DESCRIPTION
**Which issue(s) this PR fixes**:
Fixes #20183

Template error in ingester-zone-b
At line 237 there is no {{- end }} to {{- with .storageClass }}