### PR TITLE
feat: add processed records metric

### DIFF
--- a/pkg/dataobj/consumer/metrics.go
+++ b/pkg/dataobj/consumer/metrics.go
@@ -20,10 +20,8 @@ type partitionOffsetMetrics struct {
 	commitsTotal prometheus.Counter
 	appendsTotal prometheus.Counter
 
-	latestDelay prometheus.Gauge // Latest delta between record timestamp and current time
-
-	// Data volume metrics
-	bytesProcessed prometheus.Counter
+	latestDelay      prometheus.Gauge // Latest delta between record timestamp and current time
+	processedRecords prometheus.Counter
 }
 
 func newPartitionOffsetMetrics() *partitionOffsetMetrics {
@@ -48,9 +46,9 @@ func newPartitionOffsetMetrics() *partitionOffsetMetrics {
 			Name: "loki_dataobj_consumer_latest_processing_delay_seconds",
 			Help: "Latest time difference bweteen record timestamp and processing time in seconds",
 		}),
-		bytesProcessed: prometheus.NewCounter(prometheus.CounterOpts{
-			Name: "loki_dataobj_consumer_bytes_processed_total",
-			Help: "Total number of bytes processed from this partition",
+		processedRecords: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "loki_dataobj_consumer_processed_records_total",
+			Help: "Total number of records processed.",
 		}),
 	}
 
@@ -75,7 +73,7 @@ func (p *partitionOffsetMetrics) register(reg prometheus.Registerer) error {
 		p.appendFailures,
 		p.appendsTotal,
 		p.latestDelay,
-		p.bytesProcessed,
+		p.processedRecords,
 		p.currentOffset,
 	}
 
@@ -95,7 +93,7 @@ func (p *partitionOffsetMetrics) unregister(reg prometheus.Registerer) {
 		p.appendFailures,
 		p.appendsTotal,
 		p.latestDelay,
-		p.bytesProcessed,
+		p.processedRecords,
 		p.currentOffset,
 	}
 
@@ -131,8 +129,4 @@ func (p *partitionOffsetMetrics) observeProcessingDelay(recordTimestamp time.Tim
 
 		p.latestDelay.Set(delay)
 	}
-}
-
-func (p *partitionOffsetMetrics) addBytesProcessed(bytes int64) {
-	p.bytesProcessed.Add(float64(bytes))
 }

--- a/pkg/dataobj/consumer/partition_processor.go
+++ b/pkg/dataobj/consumer/partition_processor.go
@@ -241,6 +241,8 @@ func (p *partitionProcessor) emitObjectWrittenEvent(ctx context.Context, objectP
 }
 
 func (p *partitionProcessor) processRecord(ctx context.Context, record partition.Record) {
+	p.metrics.processedRecords.Inc()
+
 	// Update offset metric at the end of processing
 	defer p.metrics.updateOffset(record.Offset)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This will let us keep track of how many records we process per second. We cannot use `loki_dataobj_consumer_current_offset` because it jumps from 0 to a very large number every time the pod starts.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
