### PR TITLE
chore: Dispatch tasks more frequently

### DIFF
--- a/pkg/engine/internal/workflow/workflow.go
+++ b/pkg/engine/internal/workflow/workflow.go
@@ -199,12 +199,11 @@ func (wf *Workflow) dispatchTasks(ctx context.Context, tasks []*Task) error {
 		lane := wf.admissionControl.get(taskType)
 		tasks := groups[taskType]
 
-		var offset int64
+		var offset, batchSize int64
 		total := int64(len(tasks))
-		maxBatchSize := min(total, lane.capacity)
 
-		for ; offset < total; offset += maxBatchSize {
-			batchSize := min(maxBatchSize, total-offset)
+		for ; offset < total; offset += batchSize {
+			batchSize = int64(1)
 			if err := lane.Acquire(ctx, batchSize); err != nil {
 				return fmt.Errorf("failed to acquire tokens from admission lane %s: %w", taskType, err)
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:
Set admission lane batch size to 1

Why? This helps avoid stalling queries because each batch needed 100% of the slots available before it would be submitted. This meant that batches were only kicked off once the slowest task from the previous batch had completed. Now, it will submit tasks as soon as there is a slot available.

Initially, I was going to do something cleverer like only submit 10% of the tasks at a time and reduce it over time, but after testing I determined that dispatching the tasks 1 at a time doesn't introduce any additional latency as most of the tasks hit the happy path and short-circuit early. I left in the batchSize variable to make it clear that we could submit a batch here in the future.

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/loki-private/issues/2200
