### PR TITLE
chore: better comments when end offset is zero

### DIFF
--- a/pkg/dataobj/consumer/downscale.go
+++ b/pkg/dataobj/consumer/downscale.go
@@ -33,8 +33,9 @@ func newOffsetCommittedDownscaleFunc(offsetManager *partition.KafkaOffsetManager
 		if err != nil {
 			return false, fmt.Errorf("failed to get end offset: %w", err)
 		}
-		// If the end offset is zero then no records have been produced for
-		// this partition, which means we can downscale.
+		// The end offset is the offset of the next record to be produced.
+		// That means if the end offset is zero no records have been produced
+		// for this partition, which in turn means we can downscale.
 		if endOffset == 0 {
 			level.Debug(logger).Log("msg", "no records produced for partition")
 			return true, nil


### PR DESCRIPTION
**What this PR does / why we need it**:

How offsets work for partitions is a bit difficult to understand at times. This pull request attempts to make it more clear.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
