### PR TITLE
chore: add .zed to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,9 @@ _shared-workflows-dockerhub-login
 .vscode
 !.vscode/launch.json
 
+# zed
+.zed
+
 # nix
 nix/result
 /result

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,3 +48,6 @@ make test           # run the frontend tests
 - Document upgrading steps in `docs/sources/setup/upgrade/_index.md`
 - Preview docs locally with `make docs` from the `/docs` directory
 - Include examples and clear descriptions for public APIs
+
+## Using Tools
+- When using the `mcp__acp__Write` tool, write to a path within the current worktree to avoid sandboxing/permissions issues. This includes when writing plan files.


### PR DESCRIPTION
**What this PR does / why we need it**:

Been trying on zed, adding it to the list of ignores we have for other editors, and a small update the `CLAUDE.md` that should only affect using `claude-code` via ACP, as zed does.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
