### PR TITLE
chore: upgrade to Go 1.25

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "image": "grafana/loki-build-image:0.34.6",
+  "image": "grafana/loki-build-image:0.34.8",
   "containerEnv": {
     "BUILD_IN_CONTAINER": "false"
   },

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,7 +2,7 @@
   "check":
     "uses": "grafana/loki-release/.github/workflows/check.yml@dfe753760ce6ec2f4549fc11d2df24a2aa584e3f"
     "with":
-      "build_image": "grafana/loki-build-image:0.34.7.1"
+      "build_image": "grafana/loki-build-image:0.34.8"
       "golang_ci_lint_version": "v2.5.0"
       "release_lib_ref": "dfe753760ce6ec2f4549fc11d2df24a2aa584e3f"
       "skip_validation": false

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -2,7 +2,7 @@
   "check":
     "uses": "grafana/loki-release/.github/workflows/check.yml@dfe753760ce6ec2f4549fc11d2df24a2aa584e3f"
     "with":
-      "build_image": "grafana/loki-build-image:0.34.7.1"
+      "build_image": "grafana/loki-build-image:0.34.8"
       "golang_ci_lint_version": "v2.5.0"
       "release_lib_ref": "dfe753760ce6ec2f4549fc11d2df24a2aa584e3f"
       "skip_validation": false
@@ -10,7 +10,7 @@
   "loki-canary-boringcrypto-image":
     "env":
       "BUILD_TIMEOUT": 60
-      "GO_VERSION": "1.24"
+      "GO_VERSION": "1.25"
       "IMAGE_PREFIX": "grafana"
       "RELEASE_LIB_REF": "dfe753760ce6ec2f4549fc11d2df24a2aa584e3f"
       "RELEASE_REPO": "grafana/loki"
@@ -134,7 +134,7 @@
   "loki-canary-image":
     "env":
       "BUILD_TIMEOUT": 60
-      "GO_VERSION": "1.24"
+      "GO_VERSION": "1.25"
       "IMAGE_PREFIX": "grafana"
       "RELEASE_LIB_REF": "dfe753760ce6ec2f4549fc11d2df24a2aa584e3f"
       "RELEASE_REPO": "grafana/loki"
@@ -258,7 +258,7 @@
   "loki-image":
     "env":
       "BUILD_TIMEOUT": 60
-      "GO_VERSION": "1.24"
+      "GO_VERSION": "1.25"
       "IMAGE_PREFIX": "grafana"
       "RELEASE_LIB_REF": "dfe753760ce6ec2f4549fc11d2df24a2aa584e3f"
       "RELEASE_REPO": "grafana/loki"
@@ -382,7 +382,7 @@
   "promtail-image":
     "env":
       "BUILD_TIMEOUT": 60
-      "GO_VERSION": "1.24"
+      "GO_VERSION": "1.25"
       "IMAGE_PREFIX": "grafana"
       "RELEASE_LIB_REF": "dfe753760ce6ec2f4549fc11d2df24a2aa584e3f"
       "RELEASE_REPO": "grafana/loki"

--- a/.github/workflows/minor-release-pr.yml
+++ b/.github/workflows/minor-release-pr.yml
@@ -21,7 +21,7 @@ jobs:
       pull-requests: "write"
     uses: "grafana/loki-release/.github/workflows/check.yml@dfe753760ce6ec2f4549fc11d2df24a2aa584e3f"
     with:
-      build_image: "grafana/loki-build-image:0.34.7.1"
+      build_image: "grafana/loki-build-image:0.34.8"
       golang_ci_lint_version: "v2.5.0"
       release_lib_ref: "dfe753760ce6ec2f4549fc11d2df24a2aa584e3f"
       skip_validation: false
@@ -179,10 +179,10 @@ jobs:
           --env SKIP_ARM \
           --volume .:/src/loki \
           --workdir /src/loki \
-          --entrypoint /bin/sh "grafana/loki-build-image:0.34.7.1"
+          --entrypoint /bin/sh "grafana/loki-build-image:0.34.8"
           git config --global --add safe.directory /src/loki
           echo "${NFPM_SIGNING_KEY}" > $NFPM_SIGNING_KEY_FILE
-          if echo "grafana/loki-build-image:0.34.7.1" | grep -q "golang"; then
+          if echo "grafana/loki-build-image:0.34.8" | grep -q "golang"; then
             /src/loki/.github/vendor/github.com/grafana/loki-release/workflows/install_workflow_dependencies.sh dist
           fi
           make dist packages
@@ -798,7 +798,7 @@ jobs:
         build-args: |
           IMAGE_TAG=${{ needs.version.outputs.version }}
           GOARCH=${{ steps.platform.outputs.platform_short }}
-          BUILD_IMAGE=grafana/loki-build-image:0.34.7.1
+          BUILD_IMAGE=grafana/loki-build-image:0.34.8
         context: "release"
         file: "release/clients/cmd/docker-driver/Dockerfile"
         outputs: "type=local,dest=release/plugins/loki-docker-driver-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}"

--- a/.github/workflows/patch-release-pr.yml
+++ b/.github/workflows/patch-release-pr.yml
@@ -21,7 +21,7 @@ jobs:
       pull-requests: "write"
     uses: "grafana/loki-release/.github/workflows/check.yml@dfe753760ce6ec2f4549fc11d2df24a2aa584e3f"
     with:
-      build_image: "grafana/loki-build-image:0.34.7.1"
+      build_image: "grafana/loki-build-image:0.34.8"
       golang_ci_lint_version: "v2.5.0"
       release_lib_ref: "dfe753760ce6ec2f4549fc11d2df24a2aa584e3f"
       skip_validation: false
@@ -179,10 +179,10 @@ jobs:
           --env SKIP_ARM \
           --volume .:/src/loki \
           --workdir /src/loki \
-          --entrypoint /bin/sh "grafana/loki-build-image:0.34.7.1"
+          --entrypoint /bin/sh "grafana/loki-build-image:0.34.8"
           git config --global --add safe.directory /src/loki
           echo "${NFPM_SIGNING_KEY}" > $NFPM_SIGNING_KEY_FILE
-          if echo "grafana/loki-build-image:0.34.7.1" | grep -q "golang"; then
+          if echo "grafana/loki-build-image:0.34.8" | grep -q "golang"; then
             /src/loki/.github/vendor/github.com/grafana/loki-release/workflows/install_workflow_dependencies.sh dist
           fi
           make dist packages
@@ -798,7 +798,7 @@ jobs:
         build-args: |
           IMAGE_TAG=${{ needs.version.outputs.version }}
           GOARCH=${{ steps.platform.outputs.platform_short }}
-          BUILD_IMAGE=grafana/loki-build-image:0.34.7.1
+          BUILD_IMAGE=grafana/loki-build-image:0.34.8
         context: "release"
         file: "release/clients/cmd/docker-driver/Dockerfile"
         outputs: "type=local,dest=release/plugins/loki-docker-driver-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}"

--- a/Makefile
+++ b/Makefile
@@ -26,9 +26,9 @@ DOCKER_INTERACTIVE_FLAGS := --tty --interactive
 endif
 
 # Ensure you run `make release-workflows` after changing this
-GO_VERSION         := 1.24
+GO_VERSION         := 1.25
 # Ensure you run `make IMAGE_TAG=<updated-tag> build-image-push` after changing this
-BUILD_IMAGE_TAG    := 0.34.7.1
+BUILD_IMAGE_TAG    := 0.34.8
 
 IMAGE_TAG          ?= $(shell ./tools/image-tag)
 GIT_REVISION       := $(shell git rev-parse --short HEAD)

--- a/clients/cmd/docker-driver/Dockerfile
+++ b/clients/cmd/docker-driver/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.34.7
+ARG BUILD_IMAGE=grafana/loki-build-image:0.34.8
 ARG GOARCH=amd64
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:

--- a/clients/cmd/promtail/Dockerfile.cross
+++ b/clients/cmd/promtail/Dockerfile.cross
@@ -1,5 +1,5 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.34.6
-ARG GO_VERSION=1.24
+ARG BUILD_IMAGE=grafana/loki-build-image:0.34.8
+ARG GO_VERSION=1.25
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/promtail -f clients/cmd/promtail/Dockerfile .

--- a/clients/cmd/promtail/Dockerfile.debug
+++ b/clients/cmd/promtail/Dockerfile.debug
@@ -2,7 +2,7 @@
 # This file is intended to be called from the root like so:
 # docker build -t grafana/promtail -f clients/cmd/promtail/Dockerfile.debug .
 
-FROM grafana/loki-build-image:0.34.6 AS build
+FROM grafana/loki-build-image:0.34.8 AS build
 ARG GOARCH="amd64"
 COPY . /src/loki
 WORKDIR /src/loki

--- a/cmd/loki-canary/Dockerfile.cross
+++ b/cmd/loki-canary/Dockerfile.cross
@@ -1,5 +1,5 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.34.0
-ARG GO_VERSION=1.24
+ARG BUILD_IMAGE=grafana/loki-build-image:0.34.8
+ARG GO_VERSION=1.25
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/promtail -f cmd/promtail/Dockerfile .

--- a/cmd/loki/Dockerfile.debug
+++ b/cmd/loki/Dockerfile.debug
@@ -1,5 +1,5 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.34.0
-ARG GO_VERSION=1.24
+ARG BUILD_IMAGE=grafana/loki-build-image:0.34.8
+ARG GO_VERSION=1.25
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/loki -f cmd/loki/Dockerfile.debug .

--- a/cmd/querytee/Dockerfile.cross
+++ b/cmd/querytee/Dockerfile.cross
@@ -1,8 +1,8 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.34.7
+ARG BUILD_IMAGE=grafana/loki-build-image:0.34.8
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/promtail -f cmd/promtail/Dockerfile .
-ARG GO_VERSION=1.24
+ARG GO_VERSION=1.25
 FROM golang:${GO_VERSION} AS goenv
 RUN go env GOARCH > /goarch && \
   go env GOARM > /goarm

--- a/loki-build-image/Dockerfile
+++ b/loki-build-image/Dockerfile
@@ -4,7 +4,7 @@
 # tag of the Docker image in `../.drone/drone.jsonnet` and run `make drone`.
 # See ../docs/sources/community/maintaining/release-loki-build-image.md for instructions
 # on how to publish a new build image.
-ARG GO_VERSION=1.24
+ARG GO_VERSION=1.25
 ARG GOLANG_BASE_IMAGE=golang:${GO_VERSION}-trixie
 
 # Install helm (https://helm.sh/) and helm-docs (https://github.com/norwoodj/helm-docs) for generating Helm Chart reference.
@@ -29,7 +29,7 @@ RUN apk add --no-cache curl && \
 FROM alpine:3.22.2 AS golangci
 RUN apk add --no-cache curl && \
     cd / && \
-    curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v2.3.0
+    curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v2.4.0
 
 FROM alpine:3.22.2 AS buf
 ARG TARGETOS


### PR DESCRIPTION
This PR bumps the GO version to 1.15 similarly to https://github.com/grafana/loki/pull/20014/changes 