### PR TITLE
chore(engine): specify invalid time range

### DIFF
--- a/pkg/engine/handler.go
+++ b/pkg/engine/handler.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/go-kit/log"
@@ -118,8 +119,8 @@ func (h *queryHandler) validateMaxEntriesLimits(ctx context.Context, expr syntax
 }
 
 func (h *queryHandler) execute(ctx context.Context, logger log.Logger, params logql.Params) (logqlmodel.Result, error) {
-	if !h.validTimeRange(params) {
-		return logqlmodel.Result{}, httpgrpc.Errorf(http.StatusNotImplemented, "query outside of acceptable time range")
+	if err := h.validateTimeRange(params); err != nil {
+		return logqlmodel.Result{}, httpgrpc.Error(http.StatusNotImplemented, err.Error())
 	}
 
 	res, err := h.exec.Execute(ctx, params)
@@ -133,13 +134,21 @@ func (h *queryHandler) execute(ctx context.Context, logger log.Logger, params lo
 	return res, nil
 }
 
-// validTimeRange asserts whether the requested time range in the params are
-// supported by the new engine.
-func (h *queryHandler) validTimeRange(params logql.Params) bool {
+// validateTimeRange returns an error if the requested time range in params is
+// outside of the time range supported by the new engine.
+func (h *queryHandler) validateTimeRange(params logql.Params) error {
 	reqStart, reqEnd := params.Start(), params.End()
 	validStart, validEnd := h.cfg.ValidQueryRange()
 
-	return !reqEnd.After(validEnd) && !reqStart.Before(validStart)
+	if !reqEnd.After(validEnd) && !reqStart.Before(validStart) {
+		return nil
+	}
+
+	return fmt.Errorf(
+		"query outside of acceptable time range: requested {start=%s, end=%s}, valid range {start=%s, end=%s}",
+		reqStart, reqEnd,
+		validStart, validEnd,
+	)
 }
 
 func (h *queryHandler) doInstantRequest(ctx context.Context, req *queryrange.LokiInstantRequest) (logqlmodel.Result, error) {


### PR DESCRIPTION
Update engine's HTTP handler to specify the invalid time range along with the acceptable time range, when the time range is invalid.