### PR TITLE
chore: stop adding plans to span events

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -334,10 +334,7 @@ func (e *Engine) buildPhysicalPlan(ctx context.Context, logger log.Logger, param
 		"duration", duration.String(),
 	)
 
-	region.AddEvent("finished physical planning",
-		attribute.String("plan", physical.PrintAsTree(physicalPlan)),
-		attribute.Stringer("duration", duration),
-	)
+	region.AddEvent("finished physical planning", attribute.Stringer("duration", duration))
 	return physicalPlan, duration, nil
 }
 
@@ -378,10 +375,7 @@ func (e *Engine) buildWorkflow(ctx context.Context, logger log.Logger, physicalP
 		"duration", duration.String(),
 	)
 
-	region.AddEvent("finished execution planning",
-		attribute.String("plan", workflow.Sprint(wf)),
-		attribute.Stringer("duration", duration),
-	)
+	region.AddEvent("finished execution planning", attribute.Stringer("duration", duration))
 	return wf, duration, nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

seeing span too large errors likely due to including physical and workflow plans in span events. These can be very large when a query is scanning too many sections.
```
 msg=OpenTelemetry.ErrorHandler err="span too large to send
```

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
