### PR TITLE
chore: compute stats summary in query engine scheduler

### DIFF
--- a/pkg/xcap/summary.go
+++ b/pkg/xcap/summary.go
@@ -248,11 +248,6 @@ const regionNameDataObjScan = "DataObjScan"
 // ToStatsSummary computes a stats.Result from observations in the capture.
 func (c *Capture) ToStatsSummary(execTime, queueTime time.Duration, totalEntriesReturned int) stats.Result {
 	result := stats.Result{
-		Summary: stats.Summary{
-			ExecTime:             execTime.Seconds(),
-			QueueTime:            queueTime.Seconds(),
-			TotalEntriesReturned: int64(totalEntriesReturned),
-		},
 		Querier: stats.Querier{
 			Store: stats.Store{
 				QueryUsedV2Engine: true,
@@ -261,6 +256,7 @@ func (c *Capture) ToStatsSummary(execTime, queueTime time.Duration, totalEntries
 	}
 
 	if c == nil {
+		result.ComputeSummary(execTime, queueTime, totalEntriesReturned)
 		return result
 	}
 
@@ -282,6 +278,8 @@ func (c *Capture) ToStatsSummary(execTime, queueTime time.Duration, totalEntries
 	// TODO: this will report the wrong value if the plan has a filter stage.
 	// pick the min of row_out from filter and scan nodes.
 	result.Querier.Store.Dataobj.PostFilterRows = readInt64(observations, StatPipelineRowsOut.Key())
+
+	result.ComputeSummary(execTime, queueTime, totalEntriesReturned)
 	return result
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Stats summary was not being computed in query-engine-scheduler as it gets handled by the query-frontend when merging responses. But query-engine-scheduler can be directly hit for making queries, its important to compute summary to correctly populate the statistics field in the response.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
