### PR TITLE
fix(enginev2): Always compute summary when creating the stats object

### DIFF
--- a/pkg/xcap/summary.go
+++ b/pkg/xcap/summary.go
@@ -282,6 +282,8 @@ func (c *Capture) ToStatsSummary(execTime, queueTime time.Duration, totalEntries
 	// TODO: this will report the wrong value if the plan has a filter stage.
 	// pick the min of row_out from filter and scan nodes.
 	result.Querier.Store.Dataobj.PostFilterRows = readInt64(observations, StatPipelineRowsOut.Key())
+
+	result.ComputeSummary(execTime, queueTime, totalEntriesReturned)
 	return result
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Attempting to fix the stats on Thor queries
* Previously the stats were written, but the Summary was computed in the query-frontend and/or query-tee when it merged responses.
* Now, AFAICT, if the query is 100% V2 engine, query-tee doesn't need to merge responses so the stats summary is never computed. I compute it here as well. It will get overwritten later if merging happens.
