### PR TITLE
feat(logcli): Allow custom headers to be passed 

### DIFF
--- a/cmd/logcli/main.go
+++ b/cmd/logcli/main.go
@@ -593,6 +593,7 @@ func newQueryClient(app *kingpin.Application) client.Client {
 	app.Flag("proxy-url", "The http or https proxy to use when making requests. Can also be set using LOKI_HTTP_PROXY_URL env var.").Default("").Envar("LOKI_HTTP_PROXY_URL").StringVar(&client.ProxyURL)
 	app.Flag("compress", "Request that Loki compress returned data in transit. Can also be set using LOKI_HTTP_COMPRESSION env var.").Default("false").Envar("LOKI_HTTP_COMPRESSION").BoolVar(&client.Compression)
 	app.Flag("envproxy", "Use ProxyFromEnvironment to use net/http ProxyFromEnvironment configuration, eg HTTP_PROXY").Default("false").Envar("LOKI_ENV_PROXY").BoolVar(&client.EnvironmentProxy)
+	app.Flag("header", "Add custom HTTP headers to requests. Can be specified multiple times. Format: 'Header-Name: value'").StringsVar(&client.CustomHeaders)
 
 	return client
 }

--- a/pkg/logcli/client/client.go
+++ b/pkg/logcli/client/client.go
@@ -94,6 +94,7 @@ type DefaultClient struct {
 	BackoffConfig    BackoffConfig
 	Compression      bool
 	EnvironmentProxy bool
+	CustomHeaders    []string
 }
 
 // Query uses the /api/v1/query endpoint to execute an instant query
@@ -646,6 +647,22 @@ func (c *DefaultClient) getHTTPRequestHeader() (http.Header, error) {
 
 	if c.QueryTags != "" {
 		h.Set(HTTPQueryTags, c.QueryTags)
+	}
+
+	// Add custom headers
+	if c.CustomHeaders != nil {
+		for _, header := range c.CustomHeaders {
+			parts := strings.SplitN(header, ":", 2)
+			if len(parts) != 2 {
+				return nil, fmt.Errorf("invalid header format: %q. Expected format: 'Header-Name: value'", header)
+			}
+			key := strings.TrimSpace(parts[0])
+			value := strings.TrimSpace(parts[1])
+			if key == "" {
+				return nil, fmt.Errorf("header name cannot be empty in header: %q", header)
+			}
+			h.Set(key, value)
+		}
 	}
 
 	if (c.Username != "" || c.Password != "") && (len(c.BearerToken) > 0 || len(c.BearerTokenFile) > 0) {

--- a/pkg/logcli/client/client_test.go
+++ b/pkg/logcli/client/client_test.go
@@ -59,12 +59,36 @@ func Test_getHTTPRequestHeader(t *testing.T) {
 		}, http.Header{
 			"Authorization": []string{"Bearer " + "secureToken"},
 		}, false},
+		{"custom-headers", DefaultClient{
+			CustomHeaders: []string{"X-Custom-Header: custom-value", "X-Another-Header: another-value"},
+		}, http.Header{
+			"X-Custom-Header":  []string{"custom-value"},
+			"X-Another-Header": []string{"another-value"},
+		}, false},
+		{"custom-headers-with-spaces", DefaultClient{
+			CustomHeaders: []string{"X-Custom-Header:  custom-value  ", "X-Another-Header:  another-value  "},
+		}, http.Header{
+			"X-Custom-Header":  []string{"custom-value"},
+			"X-Another-Header": []string{"another-value"},
+		}, false},
+		{"custom-headers-invalid-format", DefaultClient{
+			CustomHeaders: []string{"InvalidHeader"},
+		}, nil, true},
+		{"custom-headers-empty-name", DefaultClient{
+			CustomHeaders: []string{" : value"},
+		}, nil, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := tt.client.getHTTPRequestHeader()
 			if (err != nil) != tt.wantErr {
 				t.Errorf("getHTTPRequestHeader() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			// If we expect an error, we shouldn't have any headers
+			if tt.wantErr {
+				assert.Nil(t, got)
 				return
 			}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows specifying custom headers when querying with `logcli`. Useful if there is some proxy in-between you and the loki instance that requires extra headers e.g. When querying the loki instance behind grafana you'll need to pass [X-Grafana-Org-Id](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/#x-grafana-org-id-header) header if the datasource is under a different organisation

**Which issue(s) this PR fixes**:
Fixes #10200

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
