### PR TITLE
perf(dataobj-consumer): Parallelise column building when merging tables

### DIFF
--- a/pkg/dataobj/sections/logs/table.go
+++ b/pkg/dataobj/sections/logs/table.go
@@ -184,11 +184,11 @@ func (b *tableBuffer) Timestamp(pageSize, pageRowCount int) *dataset.ColumnBuild
 
 // Metadata gets or creates a metadata column for the buffer. To remove created
 // metadata columns, call [tableBuffer.CleanupMetadatas].
-func (b *tableBuffer) Metadata(key string, pageSize, pageRowCount int, compressionOpts *dataset.CompressionOptions) *dataset.ColumnBuilder {
+func (b *tableBuffer) Metadata(key string, pageSize, pageRowCount int, compressionOpts *dataset.CompressionOptions) (int, *dataset.ColumnBuilder) {
 	index, ok := b.metadataLookup[key]
 	if ok {
 		builder := b.metadatas[index]
-		return builder
+		return index, builder
 	}
 
 	col, err := dataset.NewColumnBuilder(key, dataset.BuilderOptions{
@@ -219,7 +219,7 @@ func (b *tableBuffer) Metadata(key string, pageSize, pageRowCount int, compressi
 		b.metadataLookup = make(map[string]int)
 	}
 	b.metadataLookup[key] = len(b.metadatas) - 1
-	return col
+	return len(b.metadatas) - 1, col
 }
 
 // Message gets or creates a message column for the buffer.

--- a/pkg/dataobj/sections/logs/table.go
+++ b/pkg/dataobj/sections/logs/table.go
@@ -282,10 +282,13 @@ func (b *tableBuffer) Reset() {
 	for key, mdIdx := range b.metadataLookup {
 		md := b.metadatas[mdIdx]
 		if md.EstimatedSize() <= 0 {
-			newMetadatas = append(newMetadatas, md)
-			newMetadataLookup[key] = len(newMetadatas) - 1
+			continue
 		}
+		newMetadatas = append(newMetadatas, md)
+		newMetadataLookup[key] = len(newMetadatas) - 1
 	}
+	b.metadatas = newMetadatas
+	b.metadataLookup = newMetadataLookup
 }
 
 // Flush flushes the buffer into a table. Flush returns an error if the stream,

--- a/pkg/dataobj/sections/logs/table.go
+++ b/pkg/dataobj/sections/logs/table.go
@@ -116,8 +116,7 @@ type tableBuffer struct {
 	timestamp *dataset.ColumnBuilder
 
 	metadatas      []*dataset.ColumnBuilder
-	metadataLookup map[string]int                    // map of metadata key to index in metadatas
-	usedMetadatas  map[*dataset.ColumnBuilder]string // metadata with its name.
+	metadataLookup map[string]int // map of metadata key to index in metadatas
 
 	message *dataset.ColumnBuilder
 }
@@ -186,14 +185,9 @@ func (b *tableBuffer) Timestamp(pageSize, pageRowCount int) *dataset.ColumnBuild
 // Metadata gets or creates a metadata column for the buffer. To remove created
 // metadata columns, call [tableBuffer.CleanupMetadatas].
 func (b *tableBuffer) Metadata(key string, pageSize, pageRowCount int, compressionOpts *dataset.CompressionOptions) *dataset.ColumnBuilder {
-	if b.usedMetadatas == nil {
-		b.usedMetadatas = make(map[*dataset.ColumnBuilder]string)
-	}
-
 	index, ok := b.metadataLookup[key]
 	if ok {
 		builder := b.metadatas[index]
-		b.usedMetadatas[builder] = key
 		return builder
 	}
 
@@ -225,7 +219,6 @@ func (b *tableBuffer) Metadata(key string, pageSize, pageRowCount int, compressi
 		b.metadataLookup = make(map[string]int)
 	}
 	b.metadataLookup[key] = len(b.metadatas) - 1
-	b.usedMetadatas[col] = key
 	return col
 }
 
@@ -286,22 +279,13 @@ func (b *tableBuffer) Reset() {
 		newMetadatas      = make([]*dataset.ColumnBuilder, 0, len(b.metadatas))
 		newMetadataLookup = make(map[string]int, len(b.metadatas))
 	)
-	for _, md := range b.metadatas {
-		if b.usedMetadatas == nil {
-			break // Nothing was used.
+	for key, mdIdx := range b.metadataLookup {
+		md := b.metadatas[mdIdx]
+		if md.EstimatedSize() <= 0 {
+			newMetadatas = append(newMetadatas, md)
+			newMetadataLookup[key] = len(newMetadatas) - 1
 		}
-
-		key, used := b.usedMetadatas[md]
-		if !used {
-			continue
-		}
-
-		newMetadatas = append(newMetadatas, md)
-		newMetadataLookup[key] = len(newMetadatas) - 1
 	}
-	b.metadatas = newMetadatas
-	b.metadataLookup = newMetadataLookup
-	clear(b.usedMetadatas) // Reset the used cache for next time.
 }
 
 // Flush flushes the buffer into a table. Flush returns an error if the stream,
@@ -332,9 +316,7 @@ func (b *tableBuffer) Flush() (*table, error) {
 	)
 
 	for _, metadataBuilder := range b.metadatas {
-		if b.usedMetadatas == nil {
-			continue
-		} else if _, ok := b.usedMetadatas[metadataBuilder]; !ok {
+		if metadataBuilder.EstimatedSize() <= 0 {
 			continue
 		}
 

--- a/pkg/dataobj/sections/logs/table_build.go
+++ b/pkg/dataobj/sections/logs/table_build.go
@@ -43,7 +43,7 @@ func buildTable(buf *tableBuffer, pageSize, pageRowCount int, compressionOpts *d
 		record.Metadata.Range(func(md labels.Label) {
 			// Passing around md.Value as an unsafe slice is safe here: appending
 			// values is always read-only and the byte slice will never be mutated.
-			metadataBuilder := buf.Metadata(md.Name, pageSize, pageRowCount, compressionOpts)
+			_, metadataBuilder := buf.Metadata(md.Name, pageSize, pageRowCount, compressionOpts)
 			_ = metadataBuilder.Append(row, dataset.BinaryValue(unsafeSlice(md.Value, 0)))
 		})
 		row++

--- a/pkg/dataobj/sections/logs/table_merge.go
+++ b/pkg/dataobj/sections/logs/table_merge.go
@@ -181,7 +181,7 @@ func NewColumnAppender(wg *sync.WaitGroup) *columnAppender {
 	return &columnAppender{
 		work:      work,
 		waitGroup: wg,
-		buf:       make([]*rowValue, 0, 1024),
+		buf:       make([]*rowValue, 0, 8192),
 	}
 }
 
@@ -193,8 +193,8 @@ func (ca *columnAppender) appendValue(builder *dataset.ColumnBuilder, row int, v
 	})
 	if len(ca.buf) >= cap(ca.buf) {
 		ca.work <- ca.buf
-		// Make a new buffer to avoid needing to synchronise when the worker is done with the old buffer.
-		ca.buf = make([]*rowValue, 0, 1024)
+		// Make a new buffer in order to avoid needing to synchronise when the worker is done with the old buffer.
+		ca.buf = make([]*rowValue, 0, 8192)
 	}
 }
 

--- a/pkg/dataobj/sections/logs/table_test.go
+++ b/pkg/dataobj/sections/logs/table_test.go
@@ -226,14 +226,14 @@ func BenchmarkTableBuffer_Merge(b *testing.B) {
 	}
 	// Build two datasets which each have 1000000 records with 10000 unique metadata columns
 	records := []Record{}
-	for i := range 10000 {
+	for i := range 100000 {
 		records = append(records, Record{StreamID: int64(i), Timestamp: time.Unix(int64(i), 0), Line: []byte(fmt.Sprintf("msg%d", i) + strings.Repeat("A", 1024)), Metadata: labels.FromStrings("env", "prod", "service", "api", "instance", fmt.Sprintf("instance%d", i%10000))})
 	}
 	table1 := buildTable(&tableBuffer{}, pageSize, pageRows, initialCompressionOpts, records, SortTimestampDESC)
 
 	records = []Record{}
 	offset := 10000
-	for i := range 10000 {
+	for i := range 100000 {
 		records = append(records, Record{StreamID: int64(i + offset), Timestamp: time.Unix(int64(i+offset), 0), Line: []byte(fmt.Sprintf("msg%d", i+offset) + strings.Repeat("A", 1024)), Metadata: labels.FromStrings("env", "prod", "service", "api", "instance", fmt.Sprintf("instance%d", (i+offset)%10000))})
 	}
 	table2 := buildTable(&tableBuffer{}, pageSize, pageRows, initialCompressionOpts, records, SortTimestampDESC)

--- a/pkg/dataobj/sections/logs/table_test.go
+++ b/pkg/dataobj/sections/logs/table_test.go
@@ -130,10 +130,10 @@ func Test_mergeTables(t *testing.T) {
 				}
 
 				for _, row := range rows[:n] {
-					require.Len(t, row.Values, 6)
-					require.Equal(t, datasetmd.PHYSICAL_TYPE_BINARY, row.Values[5].Type())
+					require.Len(t, row.Values, 3)
+					require.Equal(t, datasetmd.PHYSICAL_TYPE_BINARY, row.Values[2].Type())
 
-					actual = append(actual, string(row.Values[5].Binary()))
+					actual = append(actual, string(row.Values[2].Binary()))
 				}
 			}
 

--- a/pkg/dataobj/sections/logs/table_test.go
+++ b/pkg/dataobj/sections/logs/table_test.go
@@ -130,10 +130,10 @@ func Test_mergeTables(t *testing.T) {
 				}
 
 				for _, row := range rows[:n] {
-					require.Len(t, row.Values, 3)
-					require.Equal(t, datasetmd.PHYSICAL_TYPE_BINARY, row.Values[2].Type())
+					require.Len(t, row.Values, 6)
+					require.Equal(t, datasetmd.PHYSICAL_TYPE_BINARY, row.Values[5].Type())
 
-					actual = append(actual, string(row.Values[2].Binary()))
+					actual = append(actual, string(row.Values[5].Binary()))
 				}
 			}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Distributes column building in mergeTables across multiple goroutines in order to improve throughput.

Why? Based on the profiles from lagging consumers, a lot of time was spent in merge tables. In particular, flushing and compressing full pages takes time and blocks any further column appends while it happens. It is also clear from the CPU metrics that only 1 core is being utilitized, and that is limiting throughput.

Profile before changes:
<img width="816" height="652" alt="image" src="https://github.com/user-attachments/assets/40a0bbed-a3c4-4c6f-9201-1aae14dca016" />

This PR spins up a bounded number of workers based on GOMAXPROCs to process column builders concurrently. Columns must be built in order, so column values are deterministically dispatched to the same workers and channel semantics are used to guarantee ordering.
Finally, I dispatch to the workers using buffers so updates are batched and much less time is spent in channel overhead.

```
goos: darwin
goarch: arm64
pkg: github.com/grafana/loki/v3/pkg/dataobj/sections/logs
cpu: Apple M3 Max
                     │  before.txt  │              after.txt              │
                     │    sec/op    │   sec/op     vs base                │
TableBuffer_Merge-14   1269.4m ± 2%   773.6m ± 3%  -39.06% (p=0.000 n=10)

                     │  before.txt  │              after.txt               │
                     │     B/op     │     B/op      vs base                │
TableBuffer_Merge-14   823.4Mi ± 0%   507.7Mi ± 0%  -38.34% (p=0.000 n=10)

                     │ before.txt  │              after.txt              │
                     │  allocs/op  │  allocs/op   vs base                │
TableBuffer_Merge-14   2.461M ± 0%   3.125M ± 0%  +27.02% (p=0.000 n=10)
```

Profile after changes:
<img width="824" height="643" alt="image" src="https://github.com/user-attachments/assets/a9f9cccf-9582-4c41-937f-678ffe5fc44b" />

We can now regularly hit 100k+ records per second and CPU utiltisation can exceed 1 CPU when there are lots of columns.
<img width="777" height="233" alt="image" src="https://github.com/user-attachments/assets/522b5bd2-9885-41d4-9d46-b580bf156c5d" /> 
<img width="523" height="234" alt="image" src="https://github.com/user-attachments/assets/e4d2f015-4f47-4723-9b39-8407b4471323" />