### PR TITLE
docs: backport 20237 to 3.6 branch

### DIFF
--- a/docs/sources/get-started/quick-start/quick-start.md
+++ b/docs/sources/get-started/quick-start/quick-start.md
@@ -29,7 +29,7 @@ killercoda:
 
 # Quickstart to run Loki locally
 
-If you want to experiment with Loki, you can run Loki locally using the Docker Compose file that ships with Loki. It runs Loki in a [monolithic deployment](https://grafana.com/docs/loki/<LOKI_VERSION>/get-started/deployment-modes/#monolithic-mode) mode and includes a sample application to generate logs.
+If you want to experiment with Loki, you can run Loki locally using the Docker Compose file that ships with Loki. It runs Loki in the [simple scalable deployment](https://grafana.com/docs/loki/<LOKI_VERSION>/get-started/deployment-modes/#simple-scalable) mode and includes a sample application to generate logs.
 
 The Docker Compose configuration runs the following components, each in its own container:
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Manual backport of https://github.com/grafana/loki/pull/20237 to the 3.6 branch.