### PR TITLE
docs: Troubleshooting queries Part 2

### DIFF
--- a/docs/sources/shared/troubleshoot-query.md
+++ b/docs/sources/shared/troubleshoot-query.md
@@ -486,9 +486,6 @@ The query contains too many stream matchers. This limit prevents queries with ex
 * **Use regex matchers** to consolidate multiple values:
 
    ```logql
-   # Bad: 5 matchers
-   {cluster="prod", namespace="api", pod="nginx-1", container="app", version="v2"}
-   
    # Good: 3 matchers using regex patterns
    {cluster="prod", namespace=~"api|web", pod=~"nginx-.*"}
    ```


### PR DESCRIPTION
**What this PR does / why we need it**:

Breaking https://github.com/grafana/loki/pull/20182 into smaller PRs to make reviewing easier.

PART 2 - merging blocked by https://github.com/grafana/loki/pull/20182  (MERGED)