### PR TITLE
docs: Add AWS SDK upgrade to 3.6.0 upgrade docs

### DIFF
--- a/docs/sources/setup/upgrade/_index.md
+++ b/docs/sources/setup/upgrade/_index.md
@@ -67,7 +67,7 @@ Key points:
 
 #### Upgraded AWS SDK to v2
 
-Loki uses the official AWS SDK for configuring and communication with S3 object storage. V1 of the SDK reached its end of life on 31st, 2025, and therefore had to be replaced with v2. While the user-facing configuration in Loki did not changes, internal functionality of the object store client did change, however without affecting functionality of Loki.
+Loki uses the official AWS SDK for configuring and communication with S3 object storage. Version 1 of the SDK reached its end of life on 31st, 2025, and therefore had to be replaced with Version 2. While the user-facing configuration in Loki did not change, internal functionality of the object store client did change, without affecting functionality of Loki.
 
 Please refer to the full release notes of v2 [https://github.com/aws/aws-sdk-go-v2/releases/tag/release-2025-01-15](https://github.com/aws/aws-sdk-go-v2/releases/tag/release-2025-01-15) for further information and whether you may be impacted by any of the changes. 
 


### PR DESCRIPTION
### Summary

There have been multiple reports of slightly different behaviour of the S3 configuration/client after the [upgrade to the v2 AWS SDK](https://github.com/grafana/loki/pull/19205).

Core functionality of the S3 client is not affected, and user-facing configuration did not change with the upgrade, however, some internal changes may lead to issues with S3 compatible backends.