### PR TITLE
docs: rename file

### DIFF
--- a/docs/sources/get-started/labels/_index.md
+++ b/docs/sources/get-started/labels/_index.md
@@ -101,7 +101,7 @@ The default list of resource attributes to store as labels can be configured usi
 
 {{< admonition type="caution" >}}
 Because of the potential for high [cardinality](https://grafana.com/docs/loki/<LOKI_VERSION>/get-started/labels/cardinality/), `k8s.pod.name` and `service.instance.id` are no longer recommended as default labels. But because removing these resource attributes from the default labels would be a breaking change for existing users, they have not yet been deprecated as default labels. If you are a new user of Grafana Loki, we recommend that you modify your Alloy or OpenTelemetry Collector configuration to convert `k8s.pod.name` and `service.instance.id` from index labels to structured metadata.
-For sample configurations, refer to [Remove default labels](https://grafana.com/docs/loki/<LOKI_VERSION>/get-started/labels/remove-default-labels).
+For sample configurations, refer to [Modify default labels](https://grafana.com/docs/loki/<LOKI_VERSION>/get-started/labels/modify-default-labels).
 {{< /admonition >}}
 
 ## Labeling is iterative

--- a/docs/sources/get-started/labels/modify-default-labels.md
+++ b/docs/sources/get-started/labels/modify-default-labels.md
@@ -1,11 +1,13 @@
 ---
-title: Remove default OpenTelemetry labels
-menuTitle: Remove default labels
+title: Modify default OpenTelemetry labels
+menuTitle: Modify default labels
 description: Describes how to modify your Alloy or OpenTelemetry Collector configuration to demote default index labels to structured metadata.
+aliases:
+  - ./modify-default-labels/ # /docs/loki/<LOKI_VERSION>/get-started/labels/modify-default-labels/remove-default-labels/
 weight: 400
 ---
 
-# Remove default OpenTelemetry labels
+# Modify default OpenTelemetry labels
 
 When Grafana Loki first started supporting OpenTelemetry, we selected a set of [default resource attributes to promote to labels](https://grafana.com/docs/loki/<LOKI_VERSION>/get-started/labels/#default-labels-for-opentelemetry). We included some labels such as k8s.pod.name to be consistent with the scrape configs we have been suggesting for many years for Promtail and Grafana Alloy. However, Loki has evolved a lot over the years and with the introduction of Structured Metadata we no longer recommend indexing a few of the labels we included in the defaults as they often have very high [cardinality](https://grafana.com/docs/loki/<LOKI_VERSION>/get-started/labels/cardinality/) and Structured Metadata is a much better place for them. We no longer recommend the following as default labels:
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Just a small change, I've pointed internal customers to this topic as an example of how to modify their default labels, so changing the name from "remove" to "modify".
Also added a redirect (alias), since the file name changed.