### PR TITLE
feat(metastore): metastore DI

### DIFF
--- a/pkg/dataobj/metastore/collect_sections_test.go
+++ b/pkg/dataobj/metastore/collect_sections_test.go
@@ -9,8 +9,6 @@ import (
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/memory"
-	"github.com/go-kit/log"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 	"github.com/thanos-io/objstore"
 )
@@ -78,7 +76,7 @@ func TestCollectSections_StopsOnEOFAndAggregates(t *testing.T) {
 	}, 0)
 
 	reader := &sliceRecordBatchReader{recs: []arrow.RecordBatch{empty, rec1, rec2}}
-	m := NewObjectMetastore(objstore.NewInMemBucket(), log.NewNopLogger(), prometheus.NewRegistry())
+	m := newTestObjectMetastore(objstore.NewInMemBucket())
 
 	resp, err := m.CollectSections(context.Background(), CollectSectionsRequest{Reader: reader})
 	require.NoError(t, err)
@@ -108,7 +106,7 @@ func TestCollectSections_PropagatesReaderError(t *testing.T) {
 
 	readErr := errors.New("boom")
 	reader := &sliceRecordBatchReader{recs: []arrow.RecordBatch{rec}, errs: []error{readErr}}
-	m := NewObjectMetastore(objstore.NewInMemBucket(), log.NewNopLogger(), prometheus.NewRegistry())
+	m := newTestObjectMetastore(objstore.NewInMemBucket())
 
 	_, err := m.CollectSections(context.Background(), CollectSectionsRequest{Reader: reader})
 	require.ErrorIs(t, err, readErr)
@@ -117,7 +115,7 @@ func TestCollectSections_PropagatesReaderError(t *testing.T) {
 func TestIndexSectionsReader_RequiresSelector(t *testing.T) {
 	t.Parallel()
 
-	m := NewObjectMetastore(objstore.NewInMemBucket(), log.NewNopLogger(), prometheus.NewRegistry())
+	m := newTestObjectMetastore(objstore.NewInMemBucket())
 	_, err := m.IndexSectionsReader(context.Background(), IndexSectionsReaderRequest{
 		IndexPath: "does-not-matter",
 		SectionsRequest: SectionsRequest{

--- a/pkg/dataobj/metastore/metrics.go
+++ b/pkg/dataobj/metastore/metrics.go
@@ -108,7 +108,7 @@ func (p *tocMetrics) observeMetastoreProcessing(recordTimestamp time.Time) {
 	}
 }
 
-type objectMetastoreMetrics struct {
+type ObjectMetastoreMetrics struct {
 	indexObjectsTotal                   prometheus.Histogram
 	streamFilterTotalDuration           prometheus.Histogram
 	streamFilterSections                prometheus.Histogram
@@ -122,8 +122,8 @@ type objectMetastoreMetrics struct {
 	resolvedSectionsRatio               prometheus.Histogram
 }
 
-func newObjectMetastoreMetrics() *objectMetastoreMetrics {
-	metrics := &objectMetastoreMetrics{
+func NewObjectMetastoreMetrics(reg prometheus.Registerer) *ObjectMetastoreMetrics {
+	metrics := &ObjectMetastoreMetrics{
 		indexObjectsTotal: prometheus.NewHistogram(prometheus.HistogramOpts{
 			Name:                            "loki_metastore_index_objects_total",
 			Help:                            "Total number of objects to be searched for a Metastore query",
@@ -213,11 +213,15 @@ func newObjectMetastoreMetrics() *objectMetastoreMetrics {
 			NativeHistogramMinResetDuration: 0,
 		}),
 	}
+	metrics.register(reg)
 
 	return metrics
 }
 
-func (p *objectMetastoreMetrics) register(reg prometheus.Registerer) {
+func (p *ObjectMetastoreMetrics) register(reg prometheus.Registerer) {
+	if reg == nil {
+		return
+	}
 	reg.MustRegister(p.indexObjectsTotal)
 	reg.MustRegister(p.streamFilterTotalDuration)
 	reg.MustRegister(p.streamFilterSections)

--- a/pkg/dataobj/metastore/object_bench_test.go
+++ b/pkg/dataobj/metastore/object_bench_test.go
@@ -117,7 +117,7 @@ func benchmarkReadSections(b *testing.B, bm readSectionsBenchmarkParams) {
 		}
 
 		// Create the metastore instance
-		mstore := NewObjectMetastore(bucket, log.NewNopLogger(), nil)
+		mstore := newTestObjectMetastore(bucket)
 
 		// Prepare benchmark parameters
 		benchCtx := user.InjectOrgID(ctx, tenantID)
@@ -233,7 +233,7 @@ func BenchmarkSectionsForPredicateMatchers(b *testing.B) {
 			err = metastoreTocWriter.WriteEntry(context.Background(), path, timeRanges)
 			require.NoError(b, err)
 
-			mstore := NewObjectMetastore(bucket, log.NewNopLogger(), prometheus.DefaultRegisterer)
+			mstore := newTestObjectMetastore(bucket)
 
 			matchers := []*labels.Matcher{
 				labels.MustNewMatcher(labels.MatchEqual, "app", "foo"),

--- a/pkg/dataobj/metastore/object_test.go
+++ b/pkg/dataobj/metastore/object_test.go
@@ -275,7 +275,7 @@ func TestSectionsForStreamMatchers(t *testing.T) {
 	err = metastoreTocWriter.WriteEntry(context.Background(), path, timeRanges)
 	require.NoError(t, err)
 
-	mstore := NewObjectMetastore(bucket, log.NewNopLogger(), prometheus.NewPedanticRegistry())
+	mstore := newTestObjectMetastore(bucket)
 
 	tests := []struct {
 		name       string
@@ -414,7 +414,7 @@ func TestSectionsForPredicateMatchers(t *testing.T) {
 	err = metastoreTocWriter.WriteEntry(context.Background(), path, timeRanges)
 	require.NoError(t, err)
 
-	mstore := NewObjectMetastore(bucket, log.NewNopLogger(), prometheus.NewPedanticRegistry())
+	mstore := newTestObjectMetastore(bucket)
 
 	tests := []struct {
 		name       string
@@ -489,7 +489,7 @@ func queryMetastore(t *testing.T, tenant string, mfunc func(context.Context, tim
 		builder.addStreamAndFlush(tenant, stream)
 	}
 
-	mstore := NewObjectMetastore(builder.bucket, log.NewNopLogger(), nil)
+	mstore := newTestObjectMetastore(builder.bucket)
 	defer func() {
 		require.NoError(t, mstore.bucket.Close())
 	}()
@@ -529,4 +529,8 @@ func newTestDataBuilder(t testing.TB) *testDataBuilder {
 		meta:     meta,
 		uploader: uploader,
 	}
+}
+
+func newTestObjectMetastore(bucket objstore.Bucket) *ObjectMetastore {
+	return NewObjectMetastore(bucket, Config{}, log.NewNopLogger(), NewObjectMetastoreMetrics(prometheus.NewRegistry()))
 }

--- a/pkg/engine/basic_engine.go
+++ b/pkg/engine/basic_engine.go
@@ -36,16 +36,7 @@ var ErrNotSupported = errors.New("feature not supported in new query engine")
 // NewBasic creates a new instance of the basic query engine that implements the
 // [logql.Engine] interface. The basic engine executes plans sequentially with
 // no local or distributed parallelism.
-func NewBasic(cfg ExecutorConfig, metastoreCfg metastore.Config, bucket objstore.Bucket, limits logql.Limits, reg prometheus.Registerer, logger log.Logger) *Basic {
-	var ms metastore.Metastore
-	if bucket != nil {
-		indexBucket := bucket
-		if metastoreCfg.IndexStoragePrefix != "" {
-			indexBucket = objstore.NewPrefixedBucket(bucket, metastoreCfg.IndexStoragePrefix)
-		}
-		ms = metastore.NewObjectMetastore(indexBucket, logger, reg)
-	}
-
+func NewBasic(cfg ExecutorConfig, ms metastore.Metastore, bucket objstore.Bucket, limits logql.Limits, reg prometheus.Registerer, logger log.Logger) *Basic {
 	if cfg.BatchSize <= 0 {
 		panic(fmt.Sprintf("invalid batch size for query engine. must be greater than 0, got %d", cfg.BatchSize))
 	}

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -15,7 +15,6 @@ import (
 	"github.com/grafana/dskit/user"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/model/labels"
-	"github.com/thanos-io/objstore"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -30,7 +29,6 @@ import (
 	"github.com/grafana/loki/v3/pkg/logql/syntax"
 	"github.com/grafana/loki/v3/pkg/logqlmodel"
 	"github.com/grafana/loki/v3/pkg/logqlmodel/metadata"
-	"github.com/grafana/loki/v3/pkg/storage/bucket"
 	"github.com/grafana/loki/v3/pkg/util/httpreq"
 	util_log "github.com/grafana/loki/v3/pkg/util/log"
 	"github.com/grafana/loki/v3/pkg/util/rangeio"
@@ -72,12 +70,11 @@ type Params struct {
 	Logger     log.Logger            // Logger for optional log messages.
 	Registerer prometheus.Registerer // Registerer for optional metrics.
 
-	Config          ExecutorConfig   // Config for the Engine.
-	MetastoreConfig metastore.Config // Config for the Metastore.
+	Config ExecutorConfig // Config for the Engine.
 
-	Scheduler *Scheduler      // Scheduler to manage the execution of tasks.
-	Bucket    objstore.Bucket // Bucket to read stored data from.
-	Limits    logql.Limits    // Limits to apply to engine queries.
+	Scheduler *Scheduler          // Scheduler to manage the execution of tasks.
+	Metastore metastore.Metastore // Metastore to access the indexes
+	Limits    logql.Limits        // Limits to apply to engine queries.
 }
 
 // validate validates p and applies defaults.
@@ -103,9 +100,8 @@ type Engine struct {
 	metrics     *metrics
 	rangeConfig rangeio.Config
 
-	scheduler *Scheduler      // Scheduler to manage the execution of tasks.
-	bucket    objstore.Bucket // Bucket to read stored data from.
-	limits    logql.Limits    // Limits to apply to engine queries.
+	scheduler *Scheduler   // Scheduler to manage the execution of tasks.
+	limits    logql.Limits // Limits to apply to engine queries.
 
 	metastore metastore.Metastore
 }
@@ -122,16 +118,9 @@ func New(params Params) (*Engine, error) {
 		rangeConfig: params.Config.RangeConfig,
 
 		scheduler: params.Scheduler,
-		bucket:    bucket.NewXCapBucket(params.Bucket),
 		limits:    params.Limits,
-	}
 
-	if e.bucket != nil {
-		indexBucket := e.bucket
-		if params.MetastoreConfig.IndexStoragePrefix != "" {
-			indexBucket = objstore.NewPrefixedBucket(e.bucket, params.MetastoreConfig.IndexStoragePrefix)
-		}
-		e.metastore = metastore.NewObjectMetastore(indexBucket, e.logger, params.Registerer)
+		metastore: params.Metastore,
 	}
 
 	return e, nil

--- a/pkg/engine/internal/worker/worker_test.go
+++ b/pkg/engine/internal/worker/worker_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
-	"github.com/thanos-io/objstore"
 
 	"github.com/grafana/loki/v3/pkg/dataobj/metastore"
 	"github.com/grafana/loki/v3/pkg/engine/internal/executor"
@@ -367,9 +366,10 @@ func buildWorkflow(ctx context.Context, t *testing.T, logger log.Logger, loc obj
 	require.NoError(t, err, "expected to create logical plan")
 
 	ms := metastore.NewObjectMetastore(
-		objstore.NewPrefixedBucket(loc.Bucket, loc.IndexPrefix),
+		loc.Bucket,
+		metastore.Config{IndexStoragePrefix: loc.IndexPrefix},
 		logger,
-		prometheus.NewRegistry(),
+		metastore.NewObjectMetastoreMetrics(prometheus.NewRegistry()),
 	)
 	catalog := physical.NewMetastoreCatalog(func(start time.Time, end time.Time, selectors []*labels.Matcher, predicates []*labels.Matcher) ([]*metastore.DataobjSectionDescriptor, error) {
 		resp, err := ms.Sections(ctx, metastore.SectionsRequest{

--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -38,6 +38,7 @@ import (
 	dataobjconfig "github.com/grafana/loki/v3/pkg/dataobj/config"
 	"github.com/grafana/loki/v3/pkg/dataobj/consumer"
 	dataobjindex "github.com/grafana/loki/v3/pkg/dataobj/index"
+	"github.com/grafana/loki/v3/pkg/dataobj/metastore"
 	"github.com/grafana/loki/v3/pkg/distributor"
 	"github.com/grafana/loki/v3/pkg/engine"
 	"github.com/grafana/loki/v3/pkg/indexgateway"
@@ -465,6 +466,8 @@ type Loki struct {
 	Metrics *server.Metrics
 
 	UsageTracker push.UsageTracker
+
+	metastoreMetrics *metastore.ObjectMetastoreMetrics
 }
 
 // New makes a new Loki.
@@ -474,6 +477,7 @@ func New(cfg Config) (*Loki, error) {
 		ClientMetrics:       storage.NewClientMetrics(),
 		deleteClientMetrics: deletion.NewDeleteRequestClientMetrics(prometheus.DefaultRegisterer),
 		Codec:               queryrange.DefaultCodec,
+		metastoreMetrics:    metastore.NewObjectMetastoreMetrics(prometheus.DefaultRegisterer),
 	}
 	analytics.Edition("oss")
 	loki.setupAuthMiddleware()

--- a/pkg/querier/http.go
+++ b/pkg/querier/http.go
@@ -63,7 +63,7 @@ type QuerierAPI struct {
 }
 
 // NewQuerierAPI returns an instance of the QuerierAPI.
-func NewQuerierAPI(v1Cfg Config, v2Cfg engine.Config, mCfg metastore.Config, querier Querier, limits querier_limits.Limits, store objstore.Bucket, reg prometheus.Registerer, logger log.Logger) *QuerierAPI {
+func NewQuerierAPI(v1Cfg Config, v2Cfg engine.Config, ms metastore.Metastore, querier Querier, limits querier_limits.Limits, store objstore.Bucket, reg prometheus.Registerer, logger log.Logger) *QuerierAPI {
 	q := &QuerierAPI{
 		cfgV1:    v1Cfg,
 		cfgV2:    v2Cfg,
@@ -74,7 +74,7 @@ func NewQuerierAPI(v1Cfg Config, v2Cfg engine.Config, mCfg metastore.Config, que
 	}
 
 	if v2Cfg.Enable {
-		q.engineV2 = engine.NewBasic(v2Cfg.Executor, mCfg, store, limits, reg, logger)
+		q.engineV2 = engine.NewBasic(v2Cfg.Executor, ms, store, limits, reg, logger)
 	}
 
 	return q

--- a/pkg/querier/http_test.go
+++ b/pkg/querier/http_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/mock"
 
-	"github.com/grafana/loki/v3/pkg/dataobj/metastore"
 	"github.com/grafana/loki/v3/pkg/engine"
 	"github.com/grafana/loki/v3/pkg/loghttp"
 	"github.com/grafana/loki/v3/pkg/logproto"
@@ -32,7 +31,7 @@ func TestInstantQueryHandler(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("log selector expression not allowed for instant queries", func(t *testing.T) {
-		api := NewQuerierAPI(mockQuerierConfig(), engine.Config{}, metastore.Config{}, nil, limits, nil, nil, log.NewNopLogger())
+		api := NewQuerierAPI(mockQuerierConfig(), engine.Config{}, nil, nil, limits, nil, nil, log.NewNopLogger())
 
 		ctx := user.InjectOrgID(context.Background(), "user")
 		req, err := http.NewRequestWithContext(ctx, "GET", `/api/v1/query`, nil)
@@ -420,7 +419,7 @@ func setupAPI(t *testing.T, querier *querierMock, enableMetricAggregation bool) 
 	limits, err := validation.NewOverrides(defaultLimits, nil)
 	require.NoError(t, err)
 
-	api := NewQuerierAPI(mockQuerierConfig(), engine.Config{}, metastore.Config{}, querier, limits, nil, nil, log.NewNopLogger())
+	api := NewQuerierAPI(mockQuerierConfig(), engine.Config{}, nil, querier, limits, nil, nil, log.NewNopLogger())
 	return api
 }
 

--- a/tools/querycomparator/storage.go
+++ b/tools/querycomparator/storage.go
@@ -31,9 +31,3 @@ func MustRawBucket() objstore.Bucket {
 	}
 	return bkt
 }
-
-// MustIndexBucket creates a GCS bucket client for index storage
-func MustIndexBucket() objstore.Bucket {
-	bkt := MustDataobjBucket()
-	return objstore.NewPrefixedBucket(bkt, "index/v0")
-}


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit fixes a problem that happens when we instantiate 2 metastores in a single process.
Even though this can't happen at the moment it will be the case once we introduce distributed
metastore queries - when running both schedulers and workers in the same process all of them
will need an instance of metastore. Each instance (before this PR) internally creates and
registers metastore metrics which causes panic due to exactly the same metrics were already
registered by the same registerer.

I attempt to fix this problem via creating and registering metastore metrics only once.

**Special notes for your reviewer**:

This PR is based on top of https://github.com/grafana/loki/pull/20234, please wait for https://github.com/grafana/loki/pull/20234 to be merged before reviewing.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
- [x] Change the base branch to `main` once https://github.com/grafana/loki/pull/20234 is merged
