### PR TITLE
fix: Scheduler memory leak

### DIFF
--- a/pkg/engine/internal/scheduler/wire/peer.go
+++ b/pkg/engine/internal/scheduler/wire/peer.go
@@ -82,9 +82,8 @@ func (p *Peer) recvMessages(ctx context.Context) error {
 			if ctx.Err() != nil {
 				// Context got canceled; shut down
 				return nil
-			} else {
-				return err
 			}
+			return err
 		}
 
 		switch frame := frame.(type) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Each `threadJob` has one or several sinks. Each `streamSink` is a peer connection to another worker.  When streamSink was stopping, its `peer` was stopping too, but the connection was not closed. That led to a hanging connection on another side, so that this line was basically never executed (`Serve()` never returned): 

https://github.com/grafana/loki/blob/377af1aa8b9091be398746f76e646402646996ce/pkg/engine/internal/worker/worker.go#L290

That caused leaking goroutines and memory leaks which were observed in the correctness test GH job and in Ops.

This PR adds connection `Close()` when a peer is done.

**Which issue(s) this PR fixes**:
Fixes OOMing tests and schedulers in Ops.

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
