### PR TITLE
feat(metastore): scan stream labels and provide them to blooms

### DIFF
--- a/pkg/dataobj/metastore/apply_blooms.go
+++ b/pkg/dataobj/metastore/apply_blooms.go
@@ -22,17 +22,22 @@ import (
 	"github.com/grafana/loki/v3/pkg/xcap"
 )
 
+type streamsMetadataProvider interface {
+	GetStreamLabels(ctx context.Context, id int64) (labels.Labels, error)
+}
+
 type applyBlooms struct {
 	logger     log.Logger
 	obj        *dataobj.Object
 	predicates []*labels.Matcher
 	input      ArrowRecordBatchReader
+	streams    streamsMetadataProvider
 	region     *xcap.Region
 
 	rowsRead uint64
 }
 
-func newApplyBlooms(obj *dataobj.Object, predicates []*labels.Matcher, input ArrowRecordBatchReader, region *xcap.Region) ArrowRecordBatchReader {
+func newApplyBlooms(obj *dataobj.Object, predicates []*labels.Matcher, input ArrowRecordBatchReader, streams streamsMetadataProvider, region *xcap.Region) ArrowRecordBatchReader {
 	var equalPredicates []*labels.Matcher
 	for _, p := range predicates {
 		if p.Type == labels.MatchEqual {
@@ -44,6 +49,7 @@ func newApplyBlooms(obj *dataobj.Object, predicates []*labels.Matcher, input Arr
 		obj:        obj,
 		predicates: equalPredicates,
 		input:      input,
+		streams:    streams,
 		region:     region,
 	}
 }

--- a/pkg/dataobj/metastore/iter.go
+++ b/pkg/dataobj/metastore/iter.go
@@ -153,82 +153,6 @@ func findPointersColumnsByTypes(allColumns []*pointers.Column, columnTypes ...po
 	return result, nil
 }
 
-// forEachStreamID iterates over streams matching the matchers and time range,
-// calling f with each stream ID.
-func forEachStreamID(
-	ctx context.Context,
-	object *dataobj.Object,
-	sStart, sEnd *scalar.Timestamp,
-	matchers []*labels.Matcher,
-	f func(streamID int64),
-) error {
-	targetTenant, err := user.ExtractOrgID(ctx)
-	if err != nil {
-		return fmt.Errorf("extracting org ID: %w", err)
-	}
-
-	for _, section := range object.Sections().Filter(streams.CheckSection) {
-		if section.Tenant != targetTenant {
-			continue
-		}
-
-		sec, err := streams.Open(ctx, section)
-		if err != nil {
-			return fmt.Errorf("opening section: %w", err)
-		}
-
-		predicates, err := buildStreamReaderPredicate(sec, sStart, sEnd, matchers)
-		if err != nil {
-			return err
-		}
-
-		var idColumn *streams.Column
-		for _, col := range sec.Columns() {
-			if col.Type == streams.ColumnTypeStreamID {
-				idColumn = col
-				break
-			}
-		}
-
-		if idColumn == nil {
-			return errors.New("forEachStreamID: section is missing stream ID column")
-		}
-
-		reader := streams.NewReader(streams.ReaderOptions{
-			Columns:    []*streams.Column{idColumn},
-			Predicates: predicates,
-			Allocator:  memory.DefaultAllocator,
-		})
-
-		for {
-			rec, err := reader.Read(ctx, 1024)
-			if rec != nil && rec.NumRows() > 0 {
-				// ID column is always first in columns
-				idArray := rec.Column(0).(*array.Int64)
-				for i := range idArray.Len() {
-					if !idArray.IsNull(i) {
-						f(idArray.Value(i))
-					}
-				}
-			}
-
-			if err != nil {
-				if errors.Is(err, io.EOF) {
-					break
-				}
-				_ = reader.Close()
-				return fmt.Errorf("reading streams: %w", err)
-			}
-		}
-
-		if err := reader.Close(); err != nil {
-			return fmt.Errorf("closing reader: %w", err)
-		}
-	}
-
-	return nil
-}
-
 // buildStreamReaderPredicate builds predicates for the stream reader
 // using the provided time range and label matchers.
 func buildStreamReaderPredicate(sec *streams.Section, sStart, sEnd *scalar.Timestamp, matchers []*labels.Matcher) ([]streams.Predicate, error) {
@@ -246,6 +170,8 @@ func buildStreamReaderPredicate(sec *streams.Section, sStart, sEnd *scalar.Times
 			maxTsColumn = col
 		case streams.ColumnTypeLabel:
 			labelColumns[col.Name] = col
+		default:
+			continue
 		}
 	}
 

--- a/pkg/dataobj/metastore/object.go
+++ b/pkg/dataobj/metastore/object.go
@@ -555,8 +555,9 @@ func (m *ObjectMetastore) IndexSectionsReader(ctx context.Context, req IndexSect
 	sStart := scalar.NewTimestampScalar(arrow.Timestamp(req.SectionsRequest.Start.UnixNano()), arrow.FixedWidthTypes.Timestamp_ns)
 	sEnd := scalar.NewTimestampScalar(arrow.Timestamp(req.SectionsRequest.End.UnixNano()), arrow.FixedWidthTypes.Timestamp_ns)
 
+	// TODO(ivkalita): either merge scanPointers and applyBlooms or extract streams sections reader
 	scanner := newScanPointers(idxObj, sStart, sEnd, req.SectionsRequest.Matchers, req.Region)
-	blooms := newApplyBlooms(idxObj, req.SectionsRequest.Predicates, scanner, req.Region)
+	blooms := newApplyBlooms(idxObj, req.SectionsRequest.Predicates, scanner, scanner, req.Region)
 
 	return IndexSectionsReaderResponse{Reader: blooms}, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Scanning stream labels and providing them to bloom filters so we can disambiguate the predicates.


**Special notes for your reviewer**:

Related to https://github.com/grafana/loki/pull/20245

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
