### PR TITLE
docs: manual backport typo

### DIFF
--- a/docs/sources/operations/storage/compactor-horizontal-scaling.md
+++ b/docs/sources/operations/storage/compactor-horizontal-scaling.md
@@ -111,7 +111,7 @@ compactor:
          [max_retries: <int> | default = 3]
 ```
 
-### Config for Main mode
+### Config for Worker mode
 
 To run Compactor in Worker mode, the Horizontal Scaling Mode needs to be set to "worker" and Main compactor's GRPC address needs to be set:
 ```yaml


### PR DESCRIPTION
**What this PR does / why we need it**:

Manual backport of #20295 to 3.6 branch.