### PR TITLE
chore: move appends total metric into builder

### DIFF
--- a/pkg/dataobj/consumer/logsobj/builder.go
+++ b/pkg/dataobj/consumer/logsobj/builder.go
@@ -271,6 +271,7 @@ func (b *Builder) Append(tenant string, stream logproto.Stream) error {
 	b.initBuilder(tenant)
 	sb, lb := b.streams[tenant], b.logs[tenant]
 
+	b.metrics.appends.Inc()
 	timer := prometheus.NewTimer(b.metrics.appendTime)
 	defer timer.ObserveDuration()
 

--- a/pkg/dataobj/consumer/logsobj/builder_metrics.go
+++ b/pkg/dataobj/consumer/logsobj/builder_metrics.go
@@ -19,6 +19,7 @@ type builderMetrics struct {
 	targetPageSize   prometheus.Gauge
 	targetObjectSize prometheus.Gauge
 
+	appends       prometheus.Counter
 	appendTime    prometheus.Histogram
 	buildTime     prometheus.Histogram
 	flushFailures prometheus.Counter
@@ -43,7 +44,6 @@ func newBuilderMetrics() *builderMetrics {
 
 			Help: "Configured target page size in bytes.",
 		}),
-
 		targetObjectSize: prometheus.NewGauge(prometheus.GaugeOpts{
 			Namespace: "loki",
 			Subsystem: "dataobj",
@@ -51,7 +51,12 @@ func newBuilderMetrics() *builderMetrics {
 
 			Help: "Configured target object size in bytes.",
 		}),
-
+		appends: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: "loki",
+			Subsystem: "dataobj",
+			Name:      "appends_total",
+			Help:      "Total number of appends.",
+		}),
 		appendTime: prometheus.NewHistogram(prometheus.HistogramOpts{
 			Namespace: "loki",
 			Subsystem: "dataobj",
@@ -64,7 +69,6 @@ func newBuilderMetrics() *builderMetrics {
 			NativeHistogramMaxBucketNumber:  100,
 			NativeHistogramMinResetDuration: 0,
 		}),
-
 		buildTime: prometheus.NewHistogram(prometheus.HistogramOpts{
 			Namespace: "loki",
 			Subsystem: "dataobj",
@@ -77,7 +81,6 @@ func newBuilderMetrics() *builderMetrics {
 			NativeHistogramMaxBucketNumber:  100,
 			NativeHistogramMinResetDuration: 0,
 		}),
-
 		sizeEstimate: prometheus.NewGauge(prometheus.GaugeOpts{
 			Namespace: "loki",
 			Subsystem: "dataobj",
@@ -85,7 +88,6 @@ func newBuilderMetrics() *builderMetrics {
 
 			Help: "Current estimated size of the data object in bytes.",
 		}),
-
 		builtSize: prometheus.NewHistogram(prometheus.HistogramOpts{
 			Namespace: "loki",
 			Subsystem: "dataobj",
@@ -97,7 +99,6 @@ func newBuilderMetrics() *builderMetrics {
 			NativeHistogramMaxBucketNumber:  100,
 			NativeHistogramMinResetDuration: 0,
 		}),
-
 		flushFailures: prometheus.NewCounter(prometheus.CounterOpts{
 			Namespace: "loki",
 			Subsystem: "dataobj",
@@ -105,7 +106,6 @@ func newBuilderMetrics() *builderMetrics {
 
 			Help: "Total number of flush failures.",
 		}),
-
 		sortDurationSeconds: prometheus.NewHistogram(prometheus.HistogramOpts{
 			Namespace: "loki",
 			Subsystem: "dataobj",
@@ -137,6 +137,7 @@ func (m *builderMetrics) Register(reg prometheus.Registerer) error {
 	errs = append(errs, reg.Register(m.targetPageSize))
 	errs = append(errs, reg.Register(m.targetObjectSize))
 
+	errs = append(errs, reg.Register(m.appends))
 	errs = append(errs, reg.Register(m.appendTime))
 	errs = append(errs, reg.Register(m.buildTime))
 
@@ -158,6 +159,7 @@ func (m *builderMetrics) Unregister(reg prometheus.Registerer) {
 	reg.Unregister(m.targetPageSize)
 	reg.Unregister(m.targetObjectSize)
 
+	reg.Unregister(m.appends)
 	reg.Unregister(m.appendTime)
 	reg.Unregister(m.buildTime)
 

--- a/pkg/dataobj/consumer/metrics.go
+++ b/pkg/dataobj/consumer/metrics.go
@@ -18,7 +18,6 @@ type partitionOffsetMetrics struct {
 
 	// Request counters
 	commitsTotal prometheus.Counter
-	appendsTotal prometheus.Counter
 
 	latestDelay      prometheus.Gauge // Latest delta between record timestamp and current time
 	processedRecords prometheus.Counter
@@ -37,10 +36,6 @@ func newPartitionOffsetMetrics() *partitionOffsetMetrics {
 		commitsTotal: prometheus.NewCounter(prometheus.CounterOpts{
 			Name: "loki_dataobj_consumer_commits_total",
 			Help: "Total number of commits",
-		}),
-		appendsTotal: prometheus.NewCounter(prometheus.CounterOpts{
-			Name: "loki_dataobj_consumer_appends_total",
-			Help: "Total number of appends",
 		}),
 		latestDelay: prometheus.NewGauge(prometheus.GaugeOpts{
 			Name: "loki_dataobj_consumer_latest_processing_delay_seconds",
@@ -71,7 +66,6 @@ func (p *partitionOffsetMetrics) register(reg prometheus.Registerer) error {
 	collectors := []prometheus.Collector{
 		p.commitFailures,
 		p.appendFailures,
-		p.appendsTotal,
 		p.latestDelay,
 		p.processedRecords,
 		p.currentOffset,
@@ -91,7 +85,6 @@ func (p *partitionOffsetMetrics) unregister(reg prometheus.Registerer) {
 	collectors := []prometheus.Collector{
 		p.commitFailures,
 		p.appendFailures,
-		p.appendsTotal,
 		p.latestDelay,
 		p.processedRecords,
 		p.currentOffset,
@@ -112,10 +105,6 @@ func (p *partitionOffsetMetrics) incCommitFailures() {
 
 func (p *partitionOffsetMetrics) incAppendFailures() {
 	p.appendFailures.Inc()
-}
-
-func (p *partitionOffsetMetrics) incAppendsTotal() {
-	p.appendsTotal.Inc()
 }
 
 func (p *partitionOffsetMetrics) incCommitsTotal() {

--- a/pkg/dataobj/consumer/partition_processor.go
+++ b/pkg/dataobj/consumer/partition_processor.go
@@ -266,7 +266,6 @@ func (p *partitionProcessor) processRecord(ctx context.Context, record partition
 		return
 	}
 
-	p.metrics.incAppendsTotal()
 	if err := p.builder.Append(tenant, stream); err != nil {
 		if !errors.Is(err, logsobj.ErrBuilderFull) {
 			level.Error(p.logger).Log("msg", "failed to append stream", "err", err)
@@ -279,7 +278,6 @@ func (p *partitionProcessor) processRecord(ctx context.Context, record partition
 			return
 		}
 
-		p.metrics.incAppendsTotal()
 		if err := p.builder.Append(tenant, stream); err != nil {
 			level.Error(p.logger).Log("msg", "failed to append stream after flushing", "err", err)
 			p.metrics.incAppendFailures()


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request moves this metric into the builder alongside append duration histogram.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
