### PR TITLE
feat: dataobj-consumer add processed bytes metric

### DIFF
--- a/pkg/dataobj/consumer/metrics.go
+++ b/pkg/dataobj/consumer/metrics.go
@@ -21,6 +21,7 @@ type partitionOffsetMetrics struct {
 
 	latestDelay      prometheus.Gauge // Latest delta between record timestamp and current time
 	processedRecords prometheus.Counter
+	processedBytes   prometheus.Counter
 }
 
 func newPartitionOffsetMetrics() *partitionOffsetMetrics {
@@ -45,6 +46,10 @@ func newPartitionOffsetMetrics() *partitionOffsetMetrics {
 			Name: "loki_dataobj_consumer_processed_records_total",
 			Help: "Total number of records processed.",
 		}),
+		processedBytes: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "loki_dataobj_consumer_processed_bytes_total",
+			Help: "Total number of bytes processed.",
+		}),
 	}
 
 	p.currentOffset = prometheus.NewGaugeFunc(
@@ -68,6 +73,7 @@ func (p *partitionOffsetMetrics) register(reg prometheus.Registerer) error {
 		p.appendFailures,
 		p.latestDelay,
 		p.processedRecords,
+		p.processedBytes,
 		p.currentOffset,
 	}
 
@@ -87,6 +93,7 @@ func (p *partitionOffsetMetrics) unregister(reg prometheus.Registerer) {
 		p.appendFailures,
 		p.latestDelay,
 		p.processedRecords,
+		p.processedBytes,
 		p.currentOffset,
 	}
 

--- a/pkg/dataobj/consumer/partition_processor.go
+++ b/pkg/dataobj/consumer/partition_processor.go
@@ -266,6 +266,8 @@ func (p *partitionProcessor) processRecord(ctx context.Context, record partition
 		return
 	}
 
+	p.metrics.processedBytes.Add(float64(stream.Size()))
+
 	if err := p.builder.Append(tenant, stream); err != nil {
 		if !errors.Is(err, logsobj.ErrBuilderFull) {
 			level.Error(p.logger).Log("msg", "failed to append stream", "err", err)


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request adds a new metric `loki_dataobj_consumer_processed_bytes_total` so we can track how many bytes/sec we process per pod. This will help us understand why some pods might experience consumption lag but not others.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
