### PR TITLE
feat: add histogram loki_dataobj_consumer_flush_duration_seconds

### DIFF
--- a/pkg/dataobj/consumer/partition_processor.go
+++ b/pkg/dataobj/consumer/partition_processor.go
@@ -307,6 +307,9 @@ func (p *partitionProcessor) flushAndCommit(ctx context.Context) error {
 // flush builds a complete data object from the builder, uploads it, records
 // it in the metastore, and emits an object written event to the events topic.
 func (p *partitionProcessor) flush(ctx context.Context) error {
+	timer := prometheus.NewTimer(p.metrics.flushDuration)
+	defer timer.ObserveDuration()
+
 	// The time range must be read before the flush as the builder is reset
 	// at the end of each flush, resetting the time range.
 	obj, closer, err := p.builder.Flush()


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request adds a histogram `loki_dataobj_consumer_flush_duration_seconds` that calculates the full end to end flush time, including flushing the builder, sorting it, uploading it to object storage, and emitting the metastore event to Kafka. It measures the total time we are blocked consuming records.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
