### PR TITLE
chore(deps): Move to unlimited PRs for renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -193,7 +193,7 @@
     autoApprove: false,
   },
   osvVulnerabilityAlerts: true,
-  prConcurrentLimit: 25,
+  prConcurrentLimit: 0,
   rebaseWhen: 'auto',
   branchPrefix: 'deps-update/',
   postUpdateOptions: [


### PR DESCRIPTION
**What this PR does / why we need it**:
Our current configuration caps the number of PRs at 25.  However, the underlying branch creation is capped at 25 also, as per the [documentation](https://docs.renovatebot.com/configuration-options/#branchconcurrentlimit).  Since we close some PRs as "won't do", we need to bump the number of branches.  Trying a value of unlimited for now.


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [X] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
