### PR TITLE
chore: add context.Context to Flush method

### DIFF
--- a/pkg/dataobj/builder.go
+++ b/pkg/dataobj/builder.go
@@ -1,6 +1,7 @@
 package dataobj
 
 import (
+	"context"
 	"fmt"
 	"io"
 
@@ -78,7 +79,7 @@ func (b *Builder) Bytes() int {
 // Flush returns an error if the object could not be constructed.
 // [Builder.Reset] is called after a successful flush to discard any pending
 // data, allowing new data to be appended.
-func (b *Builder) Flush() (*Object, io.Closer, error) {
+func (b *Builder) Flush(_ context.Context) (*Object, io.Closer, error) {
 	snapshot, err := b.encoder.Flush()
 	if err != nil {
 		return nil, nil, fmt.Errorf("flushing object: %w", err)

--- a/pkg/dataobj/builder_test.go
+++ b/pkg/dataobj/builder_test.go
@@ -19,7 +19,7 @@ func TestBuilder_preserve_section_version(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	obj, closer, err := builder.Flush()
+	obj, closer, err := builder.Flush(t.Context())
 	require.NoError(t, err)
 	defer closer.Close()
 
@@ -40,7 +40,7 @@ func TestBuilder_preserve_extension(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	obj, closer, err := builder.Flush()
+	obj, closer, err := builder.Flush(t.Context())
 	require.NoError(t, err)
 	defer closer.Close()
 
@@ -61,7 +61,7 @@ func TestBuilder_preserve_tenant(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	obj, closer, err := builder.Flush()
+	obj, closer, err := builder.Flush(t.Context())
 	require.NoError(t, err)
 	defer closer.Close()
 

--- a/pkg/dataobj/consumer/logsobj/builder.go
+++ b/pkg/dataobj/consumer/logsobj/builder.go
@@ -395,7 +395,7 @@ func (b *Builder) TimeRanges() []multitenancy.TimeRange {
 //
 // [Builder.Reset] is called after a successful Flush to discard any pending
 // data and allow new data to be appended.
-func (b *Builder) Flush() (*dataobj.Object, io.Closer, error) {
+func (b *Builder) Flush(ctx context.Context) (*dataobj.Object, io.Closer, error) {
 	if b.state == builderStateEmpty {
 		return nil, nil, ErrBuilderEmpty
 	}
@@ -418,7 +418,7 @@ func (b *Builder) Flush() (*dataobj.Object, io.Closer, error) {
 		return nil, nil, fmt.Errorf("building object: %w", err)
 	}
 
-	obj, closer, err := b.builder.Flush()
+	obj, closer, err := b.builder.Flush(ctx)
 	if err != nil {
 		b.metrics.flushFailures.Inc()
 		return nil, nil, fmt.Errorf("building object: %w", err)
@@ -426,7 +426,7 @@ func (b *Builder) Flush() (*dataobj.Object, io.Closer, error) {
 
 	b.metrics.builtSize.Observe(float64(obj.Size()))
 
-	err = b.observeObject(context.Background(), obj)
+	err = b.observeObject(ctx, obj)
 
 	b.Reset()
 	return obj, closer, err
@@ -524,7 +524,7 @@ func (b *Builder) CopyAndSort(obj *dataobj.Object) (*dataobj.Object, io.Closer, 
 		}
 	}
 
-	return b.builder.Flush()
+	return b.builder.Flush(ctx)
 }
 
 func (b *Builder) observeObject(ctx context.Context, obj *dataobj.Object) error {

--- a/pkg/dataobj/consumer/logsobj/builder_test.go
+++ b/pkg/dataobj/consumer/logsobj/builder_test.go
@@ -82,7 +82,7 @@ func TestBuilder(t *testing.T) {
 		for _, entry := range testStreams {
 			require.NoError(t, builder.Append("tenant", entry))
 		}
-		obj, closer, err := builder.Flush()
+		obj, closer, err := builder.Flush(t.Context())
 		require.NoError(t, err)
 		defer closer.Close()
 
@@ -118,7 +118,7 @@ func TestBuilder_Append(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	obj, closer, err := builder.Flush()
+	obj, closer, err := builder.Flush(t.Context())
 	require.NoError(t, err)
 	defer closer.Close()
 
@@ -153,7 +153,7 @@ func TestBuilder_CopyAndSort(t *testing.T) {
 		}
 	}
 
-	obj1, closer1, err := builder.Flush()
+	obj1, closer1, err := builder.Flush(t.Context())
 	require.NoError(t, err)
 	defer closer1.Close()
 

--- a/pkg/dataobj/consumer/mock_test.go
+++ b/pkg/dataobj/consumer/mock_test.go
@@ -119,12 +119,12 @@ func (m *mockBuilder) CopyAndSort(obj *dataobj.Object) (*dataobj.Object, io.Clos
 	return m.builder.CopyAndSort(obj)
 }
 
-func (m *mockBuilder) Flush() (*dataobj.Object, io.Closer, error) {
+func (m *mockBuilder) Flush(ctx context.Context) (*dataobj.Object, io.Closer, error) {
 	if err := m.nextErr; err != nil {
 		m.nextErr = nil
 		return nil, nil, err
 	}
-	return m.builder.Flush()
+	return m.builder.Flush(ctx)
 }
 
 func (m *mockBuilder) TimeRanges() []multitenancy.TimeRange {

--- a/pkg/dataobj/consumer/partition_processor.go
+++ b/pkg/dataobj/consumer/partition_processor.go
@@ -32,7 +32,7 @@ import (
 type builder interface {
 	Append(tenant string, stream logproto.Stream) error
 	GetEstimatedSize() int
-	Flush() (*dataobj.Object, io.Closer, error)
+	Flush(ctx context.Context) (*dataobj.Object, io.Closer, error)
 	TimeRanges() []multitenancy.TimeRange
 	UnregisterMetrics(prometheus.Registerer)
 	CopyAndSort(obj *dataobj.Object) (*dataobj.Object, io.Closer, error)
@@ -309,7 +309,7 @@ func (p *partitionProcessor) flushAndCommit(ctx context.Context) error {
 func (p *partitionProcessor) flush(ctx context.Context) error {
 	// The time range must be read before the flush as the builder is reset
 	// at the end of each flush, resetting the time range.
-	obj, closer, err := p.builder.Flush()
+	obj, closer, err := p.builder.Flush(ctx)
 	if err != nil {
 		level.Error(p.logger).Log("msg", "failed to flush builder", "err", err)
 		return err

--- a/pkg/dataobj/index/builder.go
+++ b/pkg/dataobj/index/builder.go
@@ -69,7 +69,7 @@ const (
 // An interface for the methods needed from a calculator. Useful for testing.
 type calculator interface {
 	Calculate(context.Context, log.Logger, *dataobj.Object, string) error
-	Flush() (*dataobj.Object, io.Closer, error)
+	Flush(ctx context.Context) (*dataobj.Object, io.Closer, error)
 	TimeRanges() []multitenancy.TimeRange
 	Reset()
 	IsFull() bool

--- a/pkg/dataobj/index/builder_test.go
+++ b/pkg/dataobj/index/builder_test.go
@@ -253,7 +253,7 @@ func buildLogObject(t *testing.T, app string, path string, bucket objstore.Bucke
 		require.NoError(t, err)
 	}
 
-	obj, closer, err := candidate.Flush()
+	obj, closer, err := candidate.Flush(t.Context())
 	require.NoError(t, err)
 	defer closer.Close()
 

--- a/pkg/dataobj/index/calculate.go
+++ b/pkg/dataobj/index/calculate.go
@@ -65,8 +65,8 @@ func (c *Calculator) TimeRanges() []multitenancy.TimeRange {
 	return c.indexobjBuilder.TimeRanges()
 }
 
-func (c *Calculator) Flush() (*dataobj.Object, io.Closer, error) {
-	return c.indexobjBuilder.Flush()
+func (c *Calculator) Flush(ctx context.Context) (*dataobj.Object, io.Closer, error) {
+	return c.indexobjBuilder.Flush(ctx)
 }
 
 func (c *Calculator) IsFull() bool {

--- a/pkg/dataobj/index/calculate_test.go
+++ b/pkg/dataobj/index/calculate_test.go
@@ -101,7 +101,7 @@ func createTestLogObject(t *testing.T, tenants int) *dataobj.Object {
 		}
 	}
 
-	obj, closer, err := builder.Flush()
+	obj, closer, err := builder.Flush(t.Context())
 	require.NoError(t, err)
 	t.Cleanup(func() { closer.Close() })
 
@@ -134,7 +134,7 @@ func TestCalculator_Calculate(t *testing.T) {
 
 		// Verify we can flush the results
 		timeRanges := calculator.TimeRanges()
-		obj, closer, err := calculator.Flush()
+		obj, closer, err := calculator.Flush(t.Context())
 		require.NoError(t, err)
 		defer closer.Close()
 
@@ -178,7 +178,7 @@ func TestCalculator_Calculate(t *testing.T) {
 
 		// Verify we can flush the results
 		timeRanges := calculator.TimeRanges()
-		obj, closer, err := calculator.Flush()
+		obj, closer, err := calculator.Flush(t.Context())
 		require.NoError(t, err)
 		defer closer.Close()
 

--- a/pkg/dataobj/index/indexer.go
+++ b/pkg/dataobj/index/indexer.go
@@ -480,7 +480,7 @@ func (si *serialIndexer) flushIndex(ctx context.Context, partition int32) (strin
 		return "", nil // Nothing to flush
 	}
 
-	obj, closer, err := si.calculator.Flush()
+	obj, closer, err := si.calculator.Flush(ctx)
 	if err != nil {
 		return "", fmt.Errorf("failed to flush calculator: %w", err)
 	}

--- a/pkg/dataobj/index/indexer_test.go
+++ b/pkg/dataobj/index/indexer_test.go
@@ -310,7 +310,7 @@ func (c *mockCalculator) Calculate(_ context.Context, _ log.Logger, object *data
 	return nil
 }
 
-func (c *mockCalculator) Flush() (*dataobj.Object, io.Closer, error) {
+func (c *mockCalculator) Flush(_ context.Context) (*dataobj.Object, io.Closer, error) {
 	c.flushCallCount++
 	return c.object, io.NopCloser(bytes.NewReader([]byte("test-data"))), nil
 }

--- a/pkg/dataobj/index/indexobj/builder.go
+++ b/pkg/dataobj/index/indexobj/builder.go
@@ -293,7 +293,7 @@ func (b *Builder) TimeRanges() []multitenancy.TimeRange {
 //
 // [Builder.Reset] is called after a successful Flush to discard any pending
 // data and allow new data to be appended.
-func (b *Builder) Flush() (*dataobj.Object, io.Closer, error) {
+func (b *Builder) Flush(ctx context.Context) (*dataobj.Object, io.Closer, error) {
 	if b.state == builderStateEmpty {
 		return nil, nil, ErrBuilderEmpty
 	}
@@ -325,7 +325,7 @@ func (b *Builder) Flush() (*dataobj.Object, io.Closer, error) {
 		return nil, nil, fmt.Errorf("building object: %w", err)
 	}
 
-	obj, closer, err := b.builder.Flush()
+	obj, closer, err := b.builder.Flush(ctx)
 	if err != nil {
 		b.metrics.flushFailures.Inc()
 		return nil, nil, fmt.Errorf("flushing object: %w", err)
@@ -333,7 +333,7 @@ func (b *Builder) Flush() (*dataobj.Object, io.Closer, error) {
 
 	b.metrics.builtSize.Observe(float64(obj.Size()))
 
-	err = b.observeObject(context.Background(), obj)
+	err = b.observeObject(ctx, obj)
 
 	b.Reset()
 	return obj, closer, err

--- a/pkg/dataobj/index/indexobj/builder_test.go
+++ b/pkg/dataobj/index/indexobj/builder_test.go
@@ -84,7 +84,7 @@ func TestBuilder(t *testing.T) {
 			require.NoError(t, err)
 		}
 
-		obj, closer, err := builder.Flush()
+		obj, closer, err := builder.Flush(t.Context())
 		require.NoError(t, err)
 		defer closer.Close()
 
@@ -111,7 +111,7 @@ func TestBuilder(t *testing.T) {
 			require.NoError(t, err)
 		}
 
-		obj, closer, err := builder.Flush()
+		obj, closer, err := builder.Flush(t.Context())
 		require.NoError(t, err)
 		defer closer.Close()
 

--- a/pkg/dataobj/metastore/apply_blooms_test.go
+++ b/pkg/dataobj/metastore/apply_blooms_test.go
@@ -92,7 +92,7 @@ func TestApplyBlooms_IgnoresNonEqualPredicates(t *testing.T) {
 func TestApplyBlooms_FiltersByBloomOnSectionKey(t *testing.T) {
 	t.Parallel()
 
-	ctx := user.InjectOrgID(context.Background(), tenantID)
+	ctx := user.InjectOrgID(t.Context(), tenantID)
 
 	builder, err := indexobj.NewBuilder(logsobj.BuilderBaseConfig{
 		TargetPageSize:          1024 * 1024,
@@ -120,7 +120,7 @@ func TestApplyBlooms_FiltersByBloomOnSectionKey(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, builder.AppendColumnIndex(tenantID, "test-path", 0, "traceID", 0, traceBloomBytes))
 
-	obj, closer, err := builder.Flush()
+	obj, closer, err := builder.Flush(ctx)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = closer.Close() })
 
@@ -160,7 +160,7 @@ func TestApplyBlooms_FiltersByBloomOnSectionKey(t *testing.T) {
 func TestApplyBlooms_PredicateMissReturnsEOF(t *testing.T) {
 	t.Parallel()
 
-	ctx := user.InjectOrgID(context.Background(), tenantID)
+	ctx := user.InjectOrgID(t.Context(), tenantID)
 
 	builder, err := indexobj.NewBuilder(logsobj.BuilderBaseConfig{
 		TargetPageSize:          1024 * 1024,
@@ -188,7 +188,7 @@ func TestApplyBlooms_PredicateMissReturnsEOF(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, builder.AppendColumnIndex(tenantID, "test-path", 0, "traceID", 0, traceBloomBytes))
 
-	obj, closer, err := builder.Flush()
+	obj, closer, err := builder.Flush(ctx)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = closer.Close() })
 

--- a/pkg/dataobj/metastore/object_test.go
+++ b/pkg/dataobj/metastore/object_test.go
@@ -78,7 +78,7 @@ func (b *testDataBuilder) addStreamAndFlush(tenant string, stream logproto.Strea
 	require.NoError(b.t, err)
 
 	timeRanges := b.builder.TimeRanges()
-	obj, closer, err := b.builder.Flush()
+	obj, closer, err := b.builder.Flush(context.TODO())
 	require.NoError(b.t, err)
 	defer closer.Close()
 
@@ -214,7 +214,7 @@ func TestValuesEmptyMatcher(t *testing.T) {
 }
 
 func TestSectionsForStreamMatchers(t *testing.T) {
-	ctx := user.InjectOrgID(context.Background(), tenantID)
+	ctx := user.InjectOrgID(t.Context(), tenantID)
 
 	builder, err := indexobj.NewBuilder(logsobj.BuilderBaseConfig{
 		TargetPageSize:          1024 * 1024,
@@ -259,7 +259,7 @@ func TestSectionsForStreamMatchers(t *testing.T) {
 	timeRanges := builder.TimeRanges()
 	require.Len(t, timeRanges, 2)
 
-	obj, closer, err := builder.Flush()
+	obj, closer, err := builder.Flush(ctx)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = closer.Close() })
 
@@ -268,11 +268,11 @@ func TestSectionsForStreamMatchers(t *testing.T) {
 	uploader := uploader.New(uploader.Config{SHAPrefixSize: 2}, bucket, log.NewNopLogger())
 	require.NoError(t, uploader.RegisterMetrics(prometheus.NewPedanticRegistry()))
 
-	path, err := uploader.Upload(context.Background(), obj)
+	path, err := uploader.Upload(ctx, obj)
 	require.NoError(t, err)
 
 	metastoreTocWriter := NewTableOfContentsWriter(bucket, log.NewNopLogger())
-	err = metastoreTocWriter.WriteEntry(context.Background(), path, timeRanges)
+	err = metastoreTocWriter.WriteEntry(ctx, path, timeRanges)
 	require.NoError(t, err)
 
 	mstore := newTestObjectMetastore(bucket)
@@ -361,7 +361,7 @@ func TestSectionsForStreamMatchers(t *testing.T) {
 }
 
 func TestSectionsForPredicateMatchers(t *testing.T) {
-	ctx := user.InjectOrgID(context.Background(), tenantID)
+	ctx := user.InjectOrgID(t.Context(), tenantID)
 
 	builder, err := indexobj.NewBuilder(logsobj.BuilderBaseConfig{
 		TargetPageSize:          1024 * 1024,
@@ -398,7 +398,7 @@ func TestSectionsForPredicateMatchers(t *testing.T) {
 	timeRanges := builder.TimeRanges()
 	require.Len(t, timeRanges, 1)
 
-	obj, closer, err := builder.Flush()
+	obj, closer, err := builder.Flush(ctx)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = closer.Close() })
 
@@ -407,11 +407,11 @@ func TestSectionsForPredicateMatchers(t *testing.T) {
 	uploader := uploader.New(uploader.Config{SHAPrefixSize: 2}, bucket, log.NewNopLogger())
 	require.NoError(t, uploader.RegisterMetrics(prometheus.NewPedanticRegistry()))
 
-	path, err := uploader.Upload(context.Background(), obj)
+	path, err := uploader.Upload(ctx, obj)
 	require.NoError(t, err)
 
 	metastoreTocWriter := NewTableOfContentsWriter(bucket, log.NewNopLogger())
-	err = metastoreTocWriter.WriteEntry(context.Background(), path, timeRanges)
+	err = metastoreTocWriter.WriteEntry(ctx, path, timeRanges)
 	require.NoError(t, err)
 
 	mstore := newTestObjectMetastore(bucket)

--- a/pkg/dataobj/metastore/scan_pointers_test.go
+++ b/pkg/dataobj/metastore/scan_pointers_test.go
@@ -53,7 +53,7 @@ func TestScanPointers_MissingOrgIDReturnsError(t *testing.T) {
 	require.NoError(t, builder.ObserveLogLine(tenantID, "test-path", 0, 1, 1, now.Add(-3*time.Hour), 5))
 	require.NoError(t, builder.ObserveLogLine(tenantID, "test-path", 0, 1, 1, now.Add(-2*time.Hour), 0))
 
-	obj, closer, err := builder.Flush()
+	obj, closer, err := builder.Flush(t.Context())
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = closer.Close() })
 
@@ -73,7 +73,7 @@ func TestScanPointers_MissingOrgIDReturnsError(t *testing.T) {
 func TestScanPointers_FiltersByStreamMatcherAndTime(t *testing.T) {
 	t.Parallel()
 
-	ctx := user.InjectOrgID(context.Background(), tenantID)
+	ctx := user.InjectOrgID(t.Context(), tenantID)
 
 	builder, err := indexobj.NewBuilder(logsobj.BuilderBaseConfig{
 		TargetPageSize:          1024 * 1024,
@@ -104,7 +104,7 @@ func TestScanPointers_FiltersByStreamMatcherAndTime(t *testing.T) {
 	require.NoError(t, builder.ObserveLogLine(tenantID, "test-path", 0, 1, 1, now.Add(-3*time.Hour), 5))
 	require.NoError(t, builder.ObserveLogLine(tenantID, "test-path", 0, 2, 2, now.Add(-3*time.Hour), 5))
 
-	obj, closer, err := builder.Flush()
+	obj, closer, err := builder.Flush(ctx)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = closer.Close() })
 

--- a/pkg/dataobj/metastore/toc_writer.go
+++ b/pkg/dataobj/metastore/toc_writer.go
@@ -155,7 +155,7 @@ func (m *TableOfContentsWriter) WriteEntry(ctx context.Context, dataobjPath stri
 					closer io.Closer
 				)
 
-				obj, closer, err = m.tocBuilder.Flush()
+				obj, closer, err = m.tocBuilder.Flush(ctx)
 				if err != nil {
 					return nil, errors.Wrap(err, "flushing metastore builder")
 				}

--- a/pkg/dataobj/metastore/toc_writer_test.go
+++ b/pkg/dataobj/metastore/toc_writer_test.go
@@ -34,7 +34,7 @@ func TestTableOfContentsWriter(t *testing.T) {
 		err = tocBuilder.AppendIndexPointer("testdata/metastore.obj", "test", unixTime(10), unixTime(20))
 		require.NoError(t, err)
 
-		obj, closer, err := tocBuilder.Flush()
+		obj, closer, err := tocBuilder.Flush(t.Context())
 		require.NoError(t, err)
 		t.Cleanup(func() { closer.Close() })
 

--- a/pkg/dataobj/sections/indexpointers/builder_test.go
+++ b/pkg/dataobj/sections/indexpointers/builder_test.go
@@ -31,7 +31,7 @@ func TestBuilder(t *testing.T) {
 	b := dataobj.NewBuilder(nil)
 	require.NoError(t, b.Append(ib))
 
-	obj, closer, err := b.Flush()
+	obj, closer, err := b.Flush(t.Context())
 	require.NoError(t, err)
 	defer closer.Close()
 

--- a/pkg/dataobj/sections/indexpointers/reader_test.go
+++ b/pkg/dataobj/sections/indexpointers/reader_test.go
@@ -146,7 +146,7 @@ func buildSection(t *testing.T, ptrData []indexpointers.IndexPointer) *indexpoin
 	objectBuilder := dataobj.NewBuilder(nil)
 	require.NoError(t, objectBuilder.Append(sectionBuilder))
 
-	obj, closer, err := objectBuilder.Flush()
+	obj, closer, err := objectBuilder.Flush(t.Context())
 	require.NoError(t, err)
 	t.Cleanup(func() { closer.Close() })
 

--- a/pkg/dataobj/sections/indexpointers/row_reader_test.go
+++ b/pkg/dataobj/sections/indexpointers/row_reader_test.go
@@ -40,7 +40,7 @@ func buildIndexPointersDecoder(t *testing.T, pageSize, pageRows int) *indexpoint
 	builder := dataobj.NewBuilder(nil)
 	require.NoError(t, builder.Append(s))
 
-	obj, closer, err := builder.Flush()
+	obj, closer, err := builder.Flush(t.Context())
 	require.NoError(t, err)
 	t.Cleanup(func() { closer.Close() })
 

--- a/pkg/dataobj/sections/internal/columnar/columnar_test.go
+++ b/pkg/dataobj/sections/internal/columnar/columnar_test.go
@@ -71,7 +71,7 @@ func buildObject(t *testing.T, columns []*dataset.MemColumn) *dataobj.Object {
 	err := objBuilder.Append(sectionBuilder)
 	require.NoError(t, err)
 
-	obj, closer, err := objBuilder.Flush()
+	obj, closer, err := objBuilder.Flush(t.Context())
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = closer.Close() })
 

--- a/pkg/dataobj/sections/logs/builder_test.go
+++ b/pkg/dataobj/sections/logs/builder_test.go
@@ -120,7 +120,7 @@ func TestLogsBuilder_10000Columns(t *testing.T) {
 	err := dataobj.Append(builder)
 	require.NoError(t, err)
 
-	_, closer, err := dataobj.Flush()
+	_, closer, err := dataobj.Flush(t.Context())
 	require.NoError(t, err)
 	require.NoError(t, closer.Close())
 }
@@ -130,5 +130,5 @@ func buildObject(lt *logs.Builder) (*dataobj.Object, io.Closer, error) {
 	if err := builder.Append(lt); err != nil {
 		return nil, nil, err
 	}
-	return builder.Flush()
+	return builder.Flush(context.TODO())
 }

--- a/pkg/dataobj/sections/logs/reader_test.go
+++ b/pkg/dataobj/sections/logs/reader_test.go
@@ -124,7 +124,7 @@ func buildSection(t *testing.T, recs []logs.Record) *logs.Section {
 	objectBuilder := dataobj.NewBuilder(nil)
 	require.NoError(t, objectBuilder.Append(sectionBuilder))
 
-	obj, closer, err := objectBuilder.Flush()
+	obj, closer, err := objectBuilder.Flush(t.Context())
 	require.NoError(t, err)
 	t.Cleanup(func() { closer.Close() })
 

--- a/pkg/dataobj/sections/logs/row_reader_test.go
+++ b/pkg/dataobj/sections/logs/row_reader_test.go
@@ -53,13 +53,13 @@ func buildSection(t *testing.T) *Section {
 	b := dataobj.NewBuilder(nil)
 	require.NoError(t, b.Append(logsBuilder))
 
-	obj, closer, err := b.Flush()
+	obj, closer, err := b.Flush(t.Context())
 	require.NoError(t, err)
 	t.Cleanup(func() { closer.Close() })
 
 	var logsSection *Section
 	for _, section := range obj.Sections() {
-		logsSection, err = Open(context.Background(), section)
+		logsSection, err = Open(t.Context(), section)
 		require.NoError(t, err)
 	}
 	return logsSection

--- a/pkg/dataobj/sections/pointers/builder_test.go
+++ b/pkg/dataobj/sections/pointers/builder_test.go
@@ -153,5 +153,5 @@ func buildObject(st *Builder) (*dataobj.Object, io.Closer, error) {
 	if err := builder.Append(st); err != nil {
 		return nil, nil, err
 	}
-	return builder.Flush()
+	return builder.Flush(context.TODO())
 }

--- a/pkg/dataobj/sections/pointers/reader_bench_test.go
+++ b/pkg/dataobj/sections/pointers/reader_bench_test.go
@@ -38,7 +38,7 @@ func buildBenchSection(b *testing.B, numPointers int) *pointers.Section {
 	objectBuilder := dataobj.NewBuilder(nil)
 	require.NoError(b, objectBuilder.Append(sectionBuilder))
 
-	obj, closer, err := objectBuilder.Flush()
+	obj, closer, err := objectBuilder.Flush(b.Context())
 	require.NoError(b, err)
 	b.Cleanup(func() { closer.Close() })
 

--- a/pkg/dataobj/sections/pointers/reader_test.go
+++ b/pkg/dataobj/sections/pointers/reader_test.go
@@ -657,7 +657,7 @@ func buildSection(t *testing.T, ptrData []pointers.SectionPointer) *pointers.Sec
 	objectBuilder := dataobj.NewBuilder(nil)
 	require.NoError(t, objectBuilder.Append(sectionBuilder))
 
-	obj, closer, err := objectBuilder.Flush()
+	obj, closer, err := objectBuilder.Flush(t.Context())
 	require.NoError(t, err)
 	t.Cleanup(func() { closer.Close() })
 

--- a/pkg/dataobj/sections/pointers/row_reader_test.go
+++ b/pkg/dataobj/sections/pointers/row_reader_test.go
@@ -108,7 +108,7 @@ func buildPointersDecoder(t *testing.T, pageSize, pageRows int) *pointers.Sectio
 	builder := dataobj.NewBuilder(nil)
 	require.NoError(t, builder.Append(s))
 
-	obj, closer, err := builder.Flush()
+	obj, closer, err := builder.Flush(t.Context())
 	require.NoError(t, err)
 	t.Cleanup(func() { closer.Close() })
 

--- a/pkg/dataobj/sections/streams/builder_test.go
+++ b/pkg/dataobj/sections/streams/builder_test.go
@@ -83,5 +83,5 @@ func buildObject(st *streams.Builder) (*dataobj.Object, io.Closer, error) {
 	if err := builder.Append(st); err != nil {
 		return nil, nil, err
 	}
-	return builder.Flush()
+	return builder.Flush(context.TODO())
 }

--- a/pkg/dataobj/sections/streams/row_reader_test.go
+++ b/pkg/dataobj/sections/streams/row_reader_test.go
@@ -91,7 +91,7 @@ func buildStreamsSection(t *testing.T, pageSize, pageRows int) *streams.Section 
 	builder := dataobj.NewBuilder(nil)
 	require.NoError(t, builder.Append(s))
 
-	obj, closer, err := builder.Flush()
+	obj, closer, err := builder.Flush(t.Context())
 	require.NoError(t, err)
 	t.Cleanup(func() { closer.Close() })
 

--- a/pkg/engine/internal/executor/dataobjscan_test.go
+++ b/pkg/engine/internal/executor/dataobjscan_test.go
@@ -348,7 +348,7 @@ func buildDataobj(t testing.TB, streams []logproto.Stream) *dataobj.Object {
 		require.NoError(t, builder.Append("tenant", stream))
 	}
 
-	obj, closer, err := builder.Flush()
+	obj, closer, err := builder.Flush(t.Context())
 	require.NoError(t, err)
 	t.Cleanup(func() { closer.Close() })
 	return obj

--- a/pkg/engine/internal/executor/streams_view_test.go
+++ b/pkg/engine/internal/executor/streams_view_test.go
@@ -147,7 +147,7 @@ func buildStreamsSection(t *testing.T, streamLabels []labels.Labels) *streams.Se
 	objBuilder := dataobj.NewBuilder(nil)
 	require.NoError(t, objBuilder.Append(streamsBuilder), "failed to append streams section")
 
-	obj, closer, err := objBuilder.Flush()
+	obj, closer, err := objBuilder.Flush(t.Context())
 	require.NoError(t, err, "failed to flush dataobj")
 	t.Cleanup(func() { closer.Close() })
 

--- a/pkg/engine/internal/util/objtest/objtest.go
+++ b/pkg/engine/internal/util/objtest/objtest.go
@@ -106,7 +106,7 @@ func (b *Builder) flush(ctx context.Context) error {
 
 	timeRanges := b.logsBuilder.TimeRanges()
 
-	obj, closer, err := b.logsBuilder.Flush()
+	obj, closer, err := b.logsBuilder.Flush(ctx)
 	if err != nil {
 		return fmt.Errorf("flushing builder: %w", err)
 	}
@@ -187,7 +187,7 @@ func (b *Builder) buildIndex(ctx context.Context) error {
 func (b *Builder) flushAndUpload(ctx context.Context, calculator *index.Calculator) error {
 	timeRanges := calculator.TimeRanges()
 
-	obj, closer, err := calculator.Flush()
+	obj, closer, err := calculator.Flush(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to flush index: %w", err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request adds support for `context.Context` to the `Flush` method in builders to support cancelation.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
