### PR TITLE
feat: add support for cancelation to copy and sort

### DIFF
--- a/pkg/dataobj/consumer/logsobj/builder.go
+++ b/pkg/dataobj/consumer/logsobj/builder.go
@@ -432,16 +432,28 @@ func (b *Builder) Flush() (*dataobj.Object, io.Closer, error) {
 	return obj, closer, err
 }
 
-// CopyAndSort takes an existing [dataobj.Object] and rewrites the logs sections so the logs are sorted object-wide.
-// The order of the sections is deterministic. For each tenant, first come the streams sections in the order of the old object
-// and second come the new, rewritten logs sections. Tenants are sorted in natural order.
-func (b *Builder) CopyAndSort(obj *dataobj.Object) (*dataobj.Object, io.Closer, error) {
+// CopyAndSort takes an existing [dataobj.Object] and rewrites the logs sections
+// so the logs are sorted object-wide. The order of the sections is deterministic.
+// For each tenant, first come the streams sections in the order of the old object
+// and second come the new, rewritten logs sections. Tenants are sorted in natural
+// order.
+func (b *Builder) CopyAndSort(ctx context.Context, obj *dataobj.Object) (*dataobj.Object, io.Closer, error) {
+	// Must reset builder when done.
+	defer b.Reset()
+
+	// You will see a number of occurrences where we check if the context has
+	// been canceled. The reason is that this method is CPU intensive, and we
+	// want to allow the caller to cancel it rather than wait for it to complete
+	// and discard the result.
+	select {
+	case <-ctx.Done():
+		return nil, nil, ctx.Err()
+	default:
+	}
+
 	dur := prometheus.NewTimer(b.metrics.sortDurationSeconds)
 	defer dur.ObserveDuration()
 
-	defer b.Reset() // always reset builder when done
-
-	ctx := context.Background()
 	sort := parseSortOrder(b.cfg.DataobjSortOrder)
 
 	sb := streams.NewBuilder(b.metrics.streams, int(b.cfg.TargetPageSize), b.cfg.MaxPageRows)
@@ -459,6 +471,12 @@ func (b *Builder) CopyAndSort(obj *dataobj.Object) (*dataobj.Object, io.Closer, 
 	natsort.Sort(tenants)
 
 	for _, tenant := range tenants {
+		select {
+		case <-ctx.Done():
+			return nil, nil, ctx.Err()
+		default:
+		}
+
 		for _, sec := range obj.Sections().Filter(func(s *dataobj.Section) bool { return streams.CheckSection(s) && s.Tenant == tenant }) {
 			sb.Reset()
 			sb.SetTenant(sec.Tenant)
@@ -501,11 +519,18 @@ func (b *Builder) CopyAndSort(obj *dataobj.Object) (*dataobj.Object, io.Closer, 
 		}
 
 		for rec := range iter {
+			// Based on profiles, almost all CPU time is spent in this loop, which makes
+			// it a perfect place to check if the context has been canceled.
+			select {
+			case <-ctx.Done():
+				return nil, nil, ctx.Err()
+			default:
+			}
+
 			val, err := rec.Value()
 			if err != nil {
 				return nil, nil, err
 			}
-
 			lb.Append(val)
 
 			// If our logs section has gotten big enough, we want to flush it to the encoder and start a new section.
@@ -522,6 +547,12 @@ func (b *Builder) CopyAndSort(obj *dataobj.Object) (*dataobj.Object, io.Closer, 
 		if err := b.builder.Append(lb); err != nil {
 			return nil, nil, err
 		}
+	}
+
+	select {
+	case <-ctx.Done():
+		return nil, nil, ctx.Err()
+	default:
 	}
 
 	return b.builder.Flush()

--- a/pkg/dataobj/consumer/logsobj/builder_test.go
+++ b/pkg/dataobj/consumer/logsobj/builder_test.go
@@ -159,7 +159,7 @@ func TestBuilder_CopyAndSort(t *testing.T) {
 
 	newBuilder, _ := NewBuilder(testBuilderConfig, nil)
 
-	obj2, closer2, err := newBuilder.CopyAndSort(obj1)
+	obj2, closer2, err := newBuilder.CopyAndSort(t.Context(), obj1)
 	require.NoError(t, err)
 	defer closer2.Close()
 

--- a/pkg/dataobj/consumer/mock_test.go
+++ b/pkg/dataobj/consumer/mock_test.go
@@ -115,8 +115,8 @@ func (m *mockBuilder) GetEstimatedSize() int {
 	return m.builder.GetEstimatedSize()
 }
 
-func (m *mockBuilder) CopyAndSort(obj *dataobj.Object) (*dataobj.Object, io.Closer, error) {
-	return m.builder.CopyAndSort(obj)
+func (m *mockBuilder) CopyAndSort(ctx context.Context, obj *dataobj.Object) (*dataobj.Object, io.Closer, error) {
+	return m.builder.CopyAndSort(ctx, obj)
 }
 
 func (m *mockBuilder) Flush() (*dataobj.Object, io.Closer, error) {

--- a/pkg/dataobj/consumer/partition_processor.go
+++ b/pkg/dataobj/consumer/partition_processor.go
@@ -34,7 +34,7 @@ type builder interface {
 	Flush() (*dataobj.Object, io.Closer, error)
 	TimeRanges() []multitenancy.TimeRange
 	UnregisterMetrics(prometheus.Registerer)
-	CopyAndSort(obj *dataobj.Object) (*dataobj.Object, io.Closer, error)
+	CopyAndSort(ctx context.Context, obj *dataobj.Object) (*dataobj.Object, io.Closer, error)
 }
 
 // committer allows mocking of certain [kgo.Client] methods in tests.
@@ -318,7 +318,7 @@ func (p *partitionProcessor) flush(ctx context.Context) error {
 		return err
 	}
 
-	obj, closer, err = p.sort(obj, closer)
+	obj, closer, err = p.sort(ctx, obj, closer)
 	if err != nil {
 		level.Error(p.logger).Log("msg", "failed to sort dataobj", "err", err)
 		return err
@@ -343,7 +343,7 @@ func (p *partitionProcessor) flush(ctx context.Context) error {
 	return nil
 }
 
-func (p *partitionProcessor) sort(obj *dataobj.Object, closer io.Closer) (*dataobj.Object, io.Closer, error) {
+func (p *partitionProcessor) sort(ctx context.Context, obj *dataobj.Object, closer io.Closer) (*dataobj.Object, io.Closer, error) {
 	defer closer.Close()
 
 	start := time.Now()
@@ -351,7 +351,7 @@ func (p *partitionProcessor) sort(obj *dataobj.Object, closer io.Closer) (*datao
 		level.Debug(p.logger).Log("msg", "partition processor sorted logs object-wide", "duration", time.Since(start))
 	}()
 
-	return p.builder.CopyAndSort(obj)
+	return p.builder.CopyAndSort(ctx, obj)
 }
 
 // commits the offset of the last record processed. It should be called after

--- a/tools/dataobj-sort/main.go
+++ b/tools/dataobj-sort/main.go
@@ -59,7 +59,7 @@ func main() {
 	}
 
 	start := time.Now()
-	sortedObj, closer, err := b.CopyAndSort(orig)
+	sortedObj, closer, err := b.CopyAndSort(ctx, orig)
 	duration := time.Since(start)
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds support for context cancelation to copy and sort.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
