### PR TITLE
fix: deadlock on shutdown

### DIFF
--- a/pkg/kafkav2/consumer.go
+++ b/pkg/kafkav2/consumer.go
@@ -113,12 +113,12 @@ func (c *SinglePartitionConsumer) Run(ctx context.Context) error {
 		// we must handle both records and errors at the same time, as some brokers
 		// might be polled successfully while others return errors.
 		for record := range fetches.RecordsAll() {
+			// We must check for cancelation to avoid a deadlock. This can happen
+			// if the receiver stopped without draining the chan.
 			select {
-				// We must check for cancelation to avoid a deadlock. This can happen
-				// if the receiver stopped without draining the chan.
-				case <-ctx.Done():
-					return ctx.Err()
-				case c.records <- record:
+			case <-ctx.Done():
+				return ctx.Err()
+			case c.records <- record:
 			}
 		}
 		var numErrs int


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request fixes a deadlock on shutdown where the consumer would hang writing to `records` chan. This happens when the receiver of the chan shuts down before the consumer.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
