### PR TITLE
chore: remove unregister metrics

### DIFF
--- a/pkg/dataobj/consumer/partition_processor.go
+++ b/pkg/dataobj/consumer/partition_processor.go
@@ -157,7 +157,6 @@ func (p *partitionProcessor) Start(ctx context.Context) func() {
 	p.wg.Add(1)
 	go func() {
 		defer func() {
-			p.unregisterMetrics()
 			level.Info(p.logger).Log("msg", "stopped partition processor")
 			p.wg.Done()
 		}()
@@ -182,14 +181,6 @@ func (p *partitionProcessor) Start(ctx context.Context) func() {
 		}
 	}()
 	return p.wg.Wait
-}
-
-func (p *partitionProcessor) unregisterMetrics() {
-	if p.builder != nil {
-		p.builder.UnregisterMetrics(p.reg)
-	}
-	p.metrics.unregister(p.reg)
-	p.uploader.UnregisterMetrics(p.reg)
 }
 
 func (p *partitionProcessor) initBuilder() error {


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit removes the call to unregister metrics in partition_processor.go. This is no longer needed as we no longer use the reader service, and as such, we have one processor for the entire lifetime of the program.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
