### PR TITLE
feat: add LagCollector for consumption lag metric

### DIFF
--- a/pkg/dataobj/consumer/service.go
+++ b/pkg/dataobj/consumer/service.go
@@ -177,6 +177,9 @@ func New(kafkaCfg kafka.Config, cfg Config, mCfg metastore.Config, bucket objsto
 	)
 	s.downscalePermitted = newOffsetCommittedDownscaleFunc(s.offsetReader, partitionID, logger)
 
+	lagCollector := kafkav2.NewLagCollector(readerClient, cfg.Topic, partitionID, instanceID, logger)
+	prometheus.WrapRegistererWithPrefix("loki_dataobj_consumer_", reg).MustRegister(lagCollector)
+
 	watcher := services.NewFailureWatcher()
 	watcher.WatchService(lifecycler)
 	watcher.WatchService(partitionInstanceLifecycler)

--- a/pkg/kafkav2/lag.go
+++ b/pkg/kafkav2/lag.go
@@ -1,0 +1,83 @@
+package kafkav2
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/twmb/franz-go/pkg/kgo"
+)
+
+var (
+	consumptionLag = prometheus.NewDesc(
+		"consumption_lag",
+		"The difference between the end offset and the last committed offset.",
+		[]string{"topic", "partition"}, nil,
+	)
+)
+
+// LagCollector implements a [prometheus.Collector] that tracks consumption lag
+// measured as the difference between the end offset and the last committed offset.
+type LagCollector struct {
+	topic        string
+	partition    int32
+	offsetReader *OffsetReader
+	logger       log.Logger
+}
+
+func NewLagCollector(client *kgo.Client, topic string, partition int32, consumerGroup string, logger log.Logger) *LagCollector {
+	return &LagCollector{
+		topic:        topic,
+		partition:    partition,
+		offsetReader: NewOffsetReader(client, topic, consumerGroup, logger),
+		logger:       logger,
+	}
+}
+
+func (c *LagCollector) Collect(ch chan<- prometheus.Metric) {
+	// Collect does not currently support [context.Context]. Instead, it is idiomatic
+	// to set a short timeout to prevent scrape timeouts. More information can be found
+	// in https://github.com/prometheus/client_golang/issues/1538.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// The end offset is the offset of the next record to be produced. That means
+	// if the end offset is zero no records have been produced for this partition.
+	endOffset, err := c.offsetReader.EndOffset(ctx, c.partition)
+	if err != nil {
+		level.Error(c.logger).Log("msg", "failed to get last produced offset", "error", err)
+		return
+	}
+
+	// If some records have been produced for this partition we need to make sure
+	// the consumer has processed and committed all of them otherwise we risk data
+	// loss. If no offsets have been committed, the last committed offset is -1.
+	lastCommittedOffset, err := c.offsetReader.LastCommittedOffset(ctx, c.partition)
+	if err != nil {
+		level.Error(c.logger).Log("msg", "failed to get last committed offset", "error", err)
+		return
+	}
+
+	var delta int64
+	// If no records have been produced, the delta is zero. If at least one record
+	// has been produced, the delta is the difference between the end offset and
+	// the last committed offset. We must subtract one because the end offset is
+	// the offset of the next record to be produced.
+	if endOffset > 0 {
+		delta = endOffset - lastCommittedOffset - 1
+	}
+
+	ch <- prometheus.MustNewConstMetric(
+		consumptionLag,
+		prometheus.GaugeValue,
+		float64(delta),
+		c.topic, strconv.FormatInt(int64(c.partition), 10),
+	)
+}
+
+func (c *LagCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- consumptionLag
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request adds a custom collector called `LagCollector`. It emits a metric that compares the delta between the last committed offset and the end offset for a (topic, partition, consumer_group) triple.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
