### PR TITLE
feat: add metric to track flush failures

### DIFF
--- a/pkg/dataobj/consumer/metrics.go
+++ b/pkg/dataobj/consumer/metrics.go
@@ -23,6 +23,7 @@ type partitionOffsetMetrics struct {
 	commitFailures prometheus.Counter
 	appendFailures prometheus.Counter
 	flushesTotal   *prometheus.CounterVec
+	flushFailures  prometheus.Counter
 
 	// Request counters
 	commitsTotal prometheus.Counter
@@ -73,6 +74,10 @@ func newPartitionOffsetMetrics() *partitionOffsetMetrics {
 			Name: "loki_dataobj_consumer_flushes_total",
 			Help: "Total number of data objects flushed.",
 		}, []string{"reason"}),
+		flushFailures: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "loki_dataobj_consumer_flush_failures_total",
+			Help: "Total number of flush failures.",
+		}),
 	}
 
 	p.currentOffset = prometheus.NewGaugeFunc(
@@ -100,6 +105,7 @@ func (p *partitionOffsetMetrics) register(reg prometheus.Registerer) error {
 		p.processedBytes,
 		p.currentOffset,
 		p.flushDuration,
+		p.flushFailures,
 	}
 
 	for _, collector := range collectors {
@@ -122,6 +128,7 @@ func (p *partitionOffsetMetrics) unregister(reg prometheus.Registerer) {
 		p.processedBytes,
 		p.currentOffset,
 		p.flushDuration,
+		p.flushFailures,
 	}
 
 	for _, collector := range collectors {

--- a/pkg/dataobj/consumer/partition_processor.go
+++ b/pkg/dataobj/consumer/partition_processor.go
@@ -261,6 +261,7 @@ func (p *partitionProcessor) processRecord(ctx context.Context, record *kgo.Reco
 	if p.shouldFlushDueToMaxAge() {
 		p.metrics.incFlushesTotal(FlushReasonMaxAge)
 		if err := p.flushAndCommit(ctx); err != nil {
+			p.metrics.flushFailures.Inc()
 			level.Error(p.logger).Log("msg", "failed to flush and commit dataobj that reached max age", "err", err)
 			return
 		}
@@ -275,6 +276,7 @@ func (p *partitionProcessor) processRecord(ctx context.Context, record *kgo.Reco
 
 		p.metrics.incFlushesTotal(FlushReasonBuilderFull)
 		if err := p.flushAndCommit(ctx); err != nil {
+			p.metrics.flushFailures.Inc()
 			level.Error(p.logger).Log("msg", "failed to flush and commit", "err", err)
 			return
 		}
@@ -403,6 +405,7 @@ func (p *partitionProcessor) idleFlush(ctx context.Context) (bool, error) {
 	}
 	p.metrics.incFlushesTotal(FlushReasonIdle)
 	if err := p.flushAndCommit(ctx); err != nil {
+		p.metrics.flushFailures.Inc()
 		return false, err
 	}
 	return true, nil


### PR DESCRIPTION
**What this PR does / why we need it**:

We don't have a metric that tracks failures.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
