### PR TITLE
fix: Evaluation time in Goldfish query comparator

### DIFF
--- a/tools/querytee/goldfish/comparator.go
+++ b/tools/querytee/goldfish/comparator.go
@@ -66,7 +66,7 @@ func CompareResponses(sample *goldfish.QuerySample, cellAResp, cellBResp *Respon
 			// it is also possible we match some other unexpected cases
 			// where the hashes differ but the data is equivalent within tolerance (empty matrix?)
 
-			_, err := comparator.Compare(cellAResp.Body, cellBResp.Body, time.Time{})
+			_, err := comparator.Compare(cellAResp.Body, cellBResp.Body, sample.SampledAt)
 			if err == nil {
 				result.ComparisonStatus = goldfish.ComparisonStatusMatch
 				result.DifferenceDetails["tolerance_match"] = true


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously an empty `time.Time{}` was provided as an evaluation time, which essentially led to `sampleTime.After(evaluationTime.Add(-opts.SkipRecentSamples))` always being true and skipping samples in comparison.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
