### PR TITLE
fix: service failed to shutdown errors when context canceled

### DIFF
--- a/pkg/dataobj/consumer/flush.go
+++ b/pkg/dataobj/consumer/flush.go
@@ -36,17 +36,17 @@ type uploader interface {
 // A flushJob contains all information needed to flush a data object builder.
 type flushJob struct {
 	builder
-	// startTime is the time of the oldest log line.
+	// startTime is the time of the oldest log line appended to the builder.
 	startTime time.Time
-	// offset contains the offset to commit on success. Typically, it is the
-	// offset of the last record appended to the data object builder.
+	// offset contains the offset to commit. It should be the offset of the
+	// last record appended to the builder.
 	offset int64
 	// done is called when the job has finished. If err is non-nil then the
 	// job failed.
 	done func(error)
 }
 
-// A flusherImpl is responsible for flushing of data object builders to data
+// A flusherImpl is responsible for flushing data object builders to data
 // objects.
 type flusherImpl struct {
 	*services.BasicService
@@ -106,7 +106,7 @@ func (f *flusherImpl) running(ctx context.Context) error {
 	return f.Run(ctx)
 }
 
-// running implements [services.StoppingFn].
+// stopping implements [services.StoppingFn].
 func (f *flusherImpl) stopping(_ error) error {
 	return nil
 }
@@ -133,7 +133,9 @@ func (f *flusherImpl) Run(ctx context.Context) error {
 	for {
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			// We don't return ctx.Err() here as it manifests as a service failure
+			// when shutting down.
+			return nil
 		case job := <-f.jobs:
 			job.done(f.jobFunc(ctx, job))
 		}

--- a/pkg/dataobj/consumer/partition_processor.go
+++ b/pkg/dataobj/consumer/partition_processor.go
@@ -139,7 +139,7 @@ func (p *partitionProcessor) running(ctx context.Context) error {
 	return p.Run(ctx)
 }
 
-// running implements [services.StoppingFn].
+// stopping implements [services.StoppingFn].
 func (p *partitionProcessor) stopping(_ error) error {
 	return nil
 }
@@ -153,7 +153,9 @@ func (p *partitionProcessor) Run(ctx context.Context) error {
 		select {
 		case <-ctx.Done():
 			level.Info(p.logger).Log("msg", "stopping partition processor, context canceled")
-			return ctx.Err()
+			// We don't return ctx.Err() here as it manifests as a service failure
+			// when shutting down.
+			return nil
 		case record, ok := <-p.recordsChan:
 			if !ok {
 				level.Info(p.logger).Log("msg", "stopping partition processor, channel closed")


### PR DESCRIPTION
**What this PR does / why we need it**:

We see failed to stop errors in the logs on shutdown because we return `ctx.Err()` from `running`.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
