### PR TITLE
chore: replace quartz with synctest

### DIFF
--- a/pkg/dataobj/consumer/partition_processor.go
+++ b/pkg/dataobj/consumer/partition_processor.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/coder/quartz"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/services"
@@ -78,9 +77,6 @@ type partitionProcessor struct {
 
 	recordsChan chan *kgo.Record
 	flusher     flusher
-
-	// Used for tests.
-	clock quartz.Clock
 }
 
 func newPartitionProcessor(
@@ -121,7 +117,6 @@ func newPartitionProcessor(
 		metrics:          metrics,
 		idleFlushTimeout: idleFlushTimeout,
 		maxBuilderAge:    maxBuilderAge,
-		clock:            quartz.NewReal(),
 		recordsChan:      recordsChan,
 		flusher:          flusher,
 	}
@@ -247,18 +242,18 @@ func (p *partitionProcessor) processRecord(ctx context.Context, record *kgo.Reco
 	}
 
 	if p.firstAppendTime.IsZero() {
-		p.firstAppendTime = p.clock.Now()
+		p.firstAppendTime = time.Now()
 	}
 
 	p.lastRecord = record
-	p.lastModified = p.clock.Now()
+	p.lastModified = time.Now()
 }
 
 func (p *partitionProcessor) shouldFlushDueToMaxAge() bool {
 	return p.maxBuilderAge > 0 &&
 		p.builder.GetEstimatedSize() > 0 &&
 		!p.firstAppendTime.IsZero() &&
-		p.clock.Since(p.firstAppendTime) > p.maxBuilderAge
+		time.Since(p.firstAppendTime) > p.maxBuilderAge
 }
 
 // idleFlush flushes the partition if it has exceeded the idle flush timeout.
@@ -289,7 +284,7 @@ func (p *partitionProcessor) needsIdleFlush() bool {
 	if p.lastModified.IsZero() {
 		return false
 	}
-	return p.clock.Since(p.lastModified) > p.idleFlushTimeout
+	return time.Since(p.lastModified) > p.idleFlushTimeout
 }
 
 func (p *partitionProcessor) flush(ctx context.Context) error {

--- a/pkg/dataobj/consumer/partition_processor_test.go
+++ b/pkg/dataobj/consumer/partition_processor_test.go
@@ -5,9 +5,9 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"testing/synctest"
 	"time"
 
-	"github.com/coder/quartz"
 	"github.com/go-kit/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
@@ -36,117 +36,117 @@ var (
 )
 
 func TestPartitionProcessor_BuilderMaxAge(t *testing.T) {
-	var (
-		ctx     = t.Context()
-		clock   = quartz.NewMock(t)
-		reg     = prometheus.NewRegistry()
-		flusher = &mockFlusher{}
-		proc    *partitionProcessor
-	)
-	proc = newPartitionProcessor(testBuilderCfg, scratch.NewMemory(), 5*time.Minute, 30*time.Minute, "topic", 1, nil, flusher, log.NewNopLogger(), reg)
-	proc.clock = clock
+	synctest.Test(t, func(t *testing.T) {
+		var (
+			ctx     = t.Context()
+			reg     = prometheus.NewRegistry()
+			flusher = &mockFlusher{}
+			proc    *partitionProcessor
+		)
+		proc = newPartitionProcessor(testBuilderCfg, scratch.NewMemory(), 5*time.Minute, 30*time.Minute, "topic", 1, nil, flusher, log.NewNopLogger(), reg)
 
-	// Since no records have been pushed, the first append time should be zero,
-	// and no flush should have occurred.
-	require.True(t, proc.firstAppendTime.IsZero())
-	require.Equal(t, 0, flusher.flushes)
+		// Since no records have been pushed, the first append time should be zero,
+		// and no flush should have occurred.
+		require.True(t, proc.firstAppendTime.IsZero())
+		require.Equal(t, 0, flusher.flushes)
 
-	// Process a record containing some log lines. No flush should occur because
-	// the builder has not reached the maximum age.
-	proc.processRecord(ctx, newTestRecord(t, "tenant1", clock.Now()))
+		// Process a record containing some log lines. No flush should occur because
+		// the builder has not reached the maximum age.
+		proc.processRecord(ctx, newTestRecord(t, "tenant1", time.Now()))
 
-	// The first append time should be set to the current time, but no flush
-	// should have occurred.
-	require.Equal(t, clock.Now(), proc.firstAppendTime)
-	require.Equal(t, clock.Now(), proc.lastModified)
-	require.Equal(t, 0, flusher.flushes)
+		// The first append time should be set to the current time, but no flush
+		// should have occurred.
+		require.Equal(t, time.Now(), proc.firstAppendTime)
+		require.Equal(t, time.Now(), proc.lastModified)
+		require.Equal(t, 0, flusher.flushes)
 
-	// Advance the clock past the maximum age. A flush should occur, and the
-	// the log lines from the record should be appended to the next data
-	// object, not the one that was just flushed.
-	clock.Advance(31 * time.Minute)
-	proc.processRecord(ctx, newTestRecord(t, "tenant1", clock.Now()))
+		// Advance time past the maximum age. A flush should occur, and the
+		// the log lines from the record should be appended to the next data
+		// object, not the one that was just flushed.
+		time.Sleep(31 * time.Minute)
+		proc.processRecord(ctx, newTestRecord(t, "tenant1", time.Now()))
 
-	// The last flushed time should be updated to the current time, and so should
-	// the first append time to reflect the start of the new data object.
-	require.Equal(t, clock.Now(), proc.firstAppendTime)
-	require.Equal(t, clock.Now(), proc.lastModified)
-	require.NotEqual(t, proc.builder.GetEstimatedSize(), 0)
-	require.Equal(t, 1, flusher.flushes)
+		// The last flushed time should be updated to the current time, and so should
+		// the first append time to reflect the start of the new data object.
+		require.Equal(t, time.Now(), proc.firstAppendTime)
+		require.Equal(t, time.Now(), proc.lastModified)
+		require.NotEqual(t, proc.builder.GetEstimatedSize(), 0)
+		require.Equal(t, 1, flusher.flushes)
 
-	// Advance the clock one last time and push some more logs. No flush should
-	// occur because the next builder has not reached the maximum age.
-	expectedLastFlushed := clock.Now()
-	clock.Advance(time.Minute)
-	proc.processRecord(ctx, newTestRecord(t, "tenant1", clock.Now()))
-	require.Equal(t, expectedLastFlushed, proc.firstAppendTime)
-	require.Equal(t, clock.Now(), proc.lastModified)
-	require.Equal(t, 1, flusher.flushes)
+		// Advance time one last time and push some more logs. No flush should
+		// occur because the next builder has not reached the maximum age.
+		expectedLastFlushed := time.Now()
+		time.Sleep(time.Minute)
+		proc.processRecord(ctx, newTestRecord(t, "tenant1", time.Now()))
+		require.Equal(t, expectedLastFlushed, proc.firstAppendTime)
+		require.Equal(t, time.Now(), proc.lastModified)
+		require.Equal(t, 1, flusher.flushes)
 
-	// Check the metrics.
-	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
-# HELP loki_dataobj_consumer_flushes_total Total number of data objects flushed.
-# TYPE loki_dataobj_consumer_flushes_total counter
-loki_dataobj_consumer_flushes_total{partition="1",reason="max_age",topic="topic"} 1
-`), "loki_dataobj_consumer_flushes_total"))
+		// Check the metrics.
+		require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
+	# HELP loki_dataobj_consumer_flushes_total Total number of data objects flushed.
+	# TYPE loki_dataobj_consumer_flushes_total counter
+	loki_dataobj_consumer_flushes_total{partition="1",reason="max_age",topic="topic"} 1
+	`), "loki_dataobj_consumer_flushes_total"))
+	})
 }
 
 func TestPartitionProcessor_IdleFlush(t *testing.T) {
-	var (
-		ctx     = t.Context()
-		clock   = quartz.NewMock(t)
-		reg     = prometheus.NewRegistry()
-		flusher = &mockFlusher{}
-		proc    *partitionProcessor
-	)
-	proc = newPartitionProcessor(testBuilderCfg, scratch.NewMemory(), 5*time.Minute, 30*time.Minute, "topic", 1, nil, flusher, log.NewNopLogger(), reg)
-	proc.clock = clock
+	synctest.Test(t, func(t *testing.T) {
+		var (
+			ctx     = t.Context()
+			reg     = prometheus.NewRegistry()
+			flusher = &mockFlusher{}
+			proc    *partitionProcessor
+		)
+		proc = newPartitionProcessor(testBuilderCfg, scratch.NewMemory(), 5*time.Minute, 30*time.Minute, "topic", 1, nil, flusher, log.NewNopLogger(), reg)
 
-	// The builder is uninitialized, which means its size is also zero. No flush
-	// should occur.
-	flushed, err := proc.idleFlush(ctx)
-	require.NoError(t, err)
-	require.False(t, flushed)
-	require.Equal(t, 0, flusher.flushes)
+		// The builder is uninitialized, which means its size is also zero. No flush
+		// should occur.
+		flushed, err := proc.idleFlush(ctx)
+		require.NoError(t, err)
+		require.False(t, flushed)
+		require.Equal(t, 0, flusher.flushes)
 
-	// Advance the clock past the idle flush time. No flush should occur because
-	// the builder is still unitialized.
-	clock.Advance(6 * time.Minute)
-	flushed, err = proc.idleFlush(ctx)
-	require.NoError(t, err)
-	require.False(t, flushed)
-	require.Equal(t, 0, flusher.flushes)
+		// Advance time past the idle flush time. No flush should occur because
+		// the builder is still unitialized.
+		time.Sleep(6 * time.Minute)
+		flushed, err = proc.idleFlush(ctx)
+		require.NoError(t, err)
+		require.False(t, flushed)
+		require.Equal(t, 0, flusher.flushes)
 
-	// Initialize the builder. However, no flush should occur because the builder
-	// is still empty.
-	require.NoError(t, proc.initBuilder())
-	flushed, err = proc.idleFlush(ctx)
-	require.NoError(t, err)
-	require.False(t, flushed)
-	require.Equal(t, 0, flusher.flushes)
+		// Initialize the builder. However, no flush should occur because the builder
+		// is still empty.
+		require.NoError(t, proc.initBuilder())
+		flushed, err = proc.idleFlush(ctx)
+		require.NoError(t, err)
+		require.False(t, flushed)
+		require.Equal(t, 0, flusher.flushes)
 
-	// Process a record containing some log lines. No flush should occur because
-	// when log lines are appended to the builder it resets the idle timeout.
-	proc.processRecord(ctx, newTestRecord(t, "tenant1", clock.Now()))
-	require.False(t, proc.lastModified.IsZero())
-	flushed, err = proc.idleFlush(ctx)
-	require.NoError(t, err)
-	require.False(t, flushed)
-	require.Equal(t, 0, flusher.flushes)
+		// Process a record containing some log lines. No flush should occur because
+		// when log lines are appended to the builder it resets the idle timeout.
+		proc.processRecord(ctx, newTestRecord(t, "tenant1", time.Now()))
+		require.False(t, proc.lastModified.IsZero())
+		flushed, err = proc.idleFlush(ctx)
+		require.NoError(t, err)
+		require.False(t, flushed)
+		require.Equal(t, 0, flusher.flushes)
 
-	// Advance the clock past the idle timeout. A flush should occur.
-	clock.Advance(6 * time.Minute)
-	flushed, err = proc.idleFlush(ctx)
-	require.NoError(t, err)
-	require.True(t, flushed)
-	require.Equal(t, 1, flusher.flushes)
+		// Advance time past the idle timeout. A flush should occur.
+		time.Sleep(6 * time.Minute)
+		flushed, err = proc.idleFlush(ctx)
+		require.NoError(t, err)
+		require.True(t, flushed)
+		require.Equal(t, 1, flusher.flushes)
 
-	// Check the metrics.
-	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
-# HELP loki_dataobj_consumer_flushes_total Total number of data objects flushed.
-# TYPE loki_dataobj_consumer_flushes_total counter
-loki_dataobj_consumer_flushes_total{partition="1",reason="idle",topic="topic"} 1
-`), "loki_dataobj_consumer_flushes_total"))
+		// Check the metrics.
+		require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
+	# HELP loki_dataobj_consumer_flushes_total Total number of data objects flushed.
+	# TYPE loki_dataobj_consumer_flushes_total counter
+	loki_dataobj_consumer_flushes_total{partition="1",reason="idle",topic="topic"} 1
+	`), "loki_dataobj_consumer_flushes_total"))
+	})
 }
 
 // failureFlusher is a special flusher that always fails.
@@ -157,54 +157,53 @@ func (f *failureFlusher) FlushAsync(_ context.Context, _ builder, _ time.Time, _
 }
 
 func TestPartitionProcessor_Flush(t *testing.T) {
-	var (
-		ctx         = t.Context()
-		clock       = quartz.NewMock(t)
-		reg         = prometheus.NewRegistry()
-		mockFlusher = &mockFlusher{}
-		_           = &failureFlusher{}
-		proc        *partitionProcessor
-	)
-	proc = newPartitionProcessor(testBuilderCfg, scratch.NewMemory(), 5*time.Minute, 30*time.Minute, "topic", 1, nil, mockFlusher, log.NewNopLogger(), reg)
-	proc.clock = clock
+	synctest.Test(t, func(t *testing.T) {
+		var (
+			ctx         = t.Context()
+			reg         = prometheus.NewRegistry()
+			mockFlusher = &mockFlusher{}
+			_           = &failureFlusher{}
+			proc        *partitionProcessor
+		)
+		proc = newPartitionProcessor(testBuilderCfg, scratch.NewMemory(), 5*time.Minute, 30*time.Minute, "topic", 1, nil, mockFlusher, log.NewNopLogger(), reg)
+		// No flush should have occurred.
+		require.Equal(t, 0, mockFlusher.flushes)
 
-	// No flush should have occurred.
-	require.Equal(t, 0, mockFlusher.flushes)
+		// Process a record containing some log lines. No flush should occur.
+		rec1 := newTestRecord(t, "tenant", time.Now())
+		proc.processRecord(ctx, rec1)
+		require.Equal(t, time.Now(), proc.firstAppendTime)
+		require.Equal(t, time.Now(), proc.lastModified)
+		require.Equal(t, rec1, proc.lastRecord)
 
-	// Process a record containing some log lines. No flush should occur.
-	rec1 := newTestRecord(t, "tenant", clock.Now())
-	proc.processRecord(ctx, rec1)
-	require.Equal(t, clock.Now(), proc.firstAppendTime)
-	require.Equal(t, clock.Now(), proc.lastModified)
-	require.Equal(t, rec1, proc.lastRecord)
+		// Advance time and force a flush.
+		time.Sleep(time.Second)
+		require.NoError(t, proc.flush(ctx))
+		require.Equal(t, 1, mockFlusher.flushes)
+		// The following fields should be reset at the end of every flush.
+		require.True(t, proc.firstAppendTime.IsZero())
+		require.True(t, proc.earliestRecordTime.IsZero())
+		require.True(t, proc.lastModified.IsZero())
+		require.Nil(t, proc.lastRecord)
 
-	// Advance the clock and force a flush.
-	clock.Advance(time.Second)
-	require.NoError(t, proc.flush(ctx))
-	require.Equal(t, 1, mockFlusher.flushes)
-	// The following fields should be reset at the end of every flush.
-	require.True(t, proc.firstAppendTime.IsZero())
-	require.True(t, proc.earliestRecordTime.IsZero())
-	require.True(t, proc.lastModified.IsZero())
-	require.Nil(t, proc.lastRecord)
+		// Process another record containing some log lines. No flush should occur.
+		proc.flusher = &failureFlusher{}
+		rec2 := newTestRecord(t, "tenant", time.Now())
+		proc.processRecord(ctx, rec2)
+		require.Equal(t, time.Now(), proc.firstAppendTime)
+		require.Equal(t, time.Now(), proc.lastModified)
+		require.Equal(t, rec2, proc.lastRecord)
 
-	// Process another record containing some log lines. No flush should occur.
-	proc.flusher = &failureFlusher{}
-	rec2 := newTestRecord(t, "tenant", clock.Now())
-	proc.processRecord(ctx, rec2)
-	require.Equal(t, clock.Now(), proc.firstAppendTime)
-	require.Equal(t, clock.Now(), proc.lastModified)
-	require.Equal(t, rec2, proc.lastRecord)
-
-	// Advance the clock and force a flush. This flush should fail.
-	clock.Advance(time.Second)
-	require.EqualError(t, proc.flush(ctx), "failed to flush")
-	require.Equal(t, 1, mockFlusher.flushes)
-	// Despite the failure, the following fields should still be reset.
-	require.True(t, proc.firstAppendTime.IsZero())
-	require.True(t, proc.earliestRecordTime.IsZero())
-	require.True(t, proc.lastModified.IsZero())
-	require.Nil(t, proc.lastRecord)
+		// Advance time and force a flush. This flush should fail.
+		time.Sleep(time.Second)
+		require.EqualError(t, proc.flush(ctx), "failed to flush")
+		require.Equal(t, 1, mockFlusher.flushes)
+		// Despite the failure, the following fields should still be reset.
+		require.True(t, proc.firstAppendTime.IsZero())
+		require.True(t, proc.earliestRecordTime.IsZero())
+		require.True(t, proc.lastModified.IsZero())
+		require.Nil(t, proc.lastRecord)
+	})
 }
 
 // newTestRecord returns a new record containing the stream.


### PR DESCRIPTION
**What this PR does / why we need it**:

I introduced quartz because 6 months ago there was no easy way to test code that depends on time. That is no longer the case with Go 1.25, which adds its own package `testing/synctest`, making quartz redundant for us. 

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
