### PR TITLE
fix(operator): Increase distributor-ingester timeout from 1s to 5s

### DIFF
--- a/operator/internal/manifests/internal/config/build_test.go
+++ b/operator/internal/manifests/internal/config/build_test.go
@@ -72,7 +72,7 @@ ingester:
 ingester_client:
   grpc_client_config:
     max_recv_msg_size: 67108864
-  remote_timeout: 1s
+  remote_timeout: 5s
 # NOTE: Keep the order of keys as in Loki docs
 # to enable easy diffs when vendoring newer
 # Loki releases.
@@ -335,7 +335,7 @@ ingester:
 ingester_client:
   grpc_client_config:
     max_recv_msg_size: 67108864
-  remote_timeout: 1s
+  remote_timeout: 5s
 # NOTE: Keep the order of keys as in Loki docs
 # to enable easy diffs when vendoring newer
 # Loki releases.
@@ -766,7 +766,7 @@ ingester:
 ingester_client:
   grpc_client_config:
     max_recv_msg_size: 67108864
-  remote_timeout: 1s
+  remote_timeout: 5s
 # NOTE: Keep the order of keys as in Loki docs
 # to enable easy diffs when vendoring newer
 # Loki releases.
@@ -1129,7 +1129,7 @@ ingester:
 ingester_client:
   grpc_client_config:
     max_recv_msg_size: 67108864
-  remote_timeout: 1s
+  remote_timeout: 5s
 # NOTE: Keep the order of keys as in Loki docs
 # to enable easy diffs when vendoring newer
 # Loki releases.
@@ -1493,7 +1493,7 @@ ingester:
 ingester_client:
   grpc_client_config:
     max_recv_msg_size: 67108864
-  remote_timeout: 1s
+  remote_timeout: 5s
 # NOTE: Keep the order of keys as in Loki docs
 # to enable easy diffs when vendoring newer
 # Loki releases.
@@ -1891,7 +1891,7 @@ ingester:
 ingester_client:
   grpc_client_config:
     max_recv_msg_size: 67108864
-  remote_timeout: 1s
+  remote_timeout: 5s
 # NOTE: Keep the order of keys as in Loki docs
 # to enable easy diffs when vendoring newer
 # Loki releases.
@@ -2231,7 +2231,7 @@ ingester:
 ingester_client:
   grpc_client_config:
     max_recv_msg_size: 67108864
-  remote_timeout: 1s
+  remote_timeout: 5s
 # NOTE: Keep the order of keys as in Loki docs
 # to enable easy diffs when vendoring newer
 # Loki releases.
@@ -2675,7 +2675,7 @@ ingester_client:
     tls_server_name: ingester-grpc.svc
     tls_cipher_suites: cipher1,cipher2
     tls_min_version: VersionTLS12
-  remote_timeout: 1s
+  remote_timeout: 5s
 # NOTE: Keep the order of keys as in Loki docs
 # to enable easy diffs when vendoring newer
 # Loki releases.
@@ -3004,7 +3004,7 @@ ingester:
 ingester_client:
   grpc_client_config:
     max_recv_msg_size: 67108864
-  remote_timeout: 1s
+  remote_timeout: 5s
 # NOTE: Keep the order of keys as in Loki docs
 # to enable easy diffs when vendoring newer
 # Loki releases.
@@ -3506,7 +3506,7 @@ ingester:
 ingester_client:
   grpc_client_config:
     max_recv_msg_size: 67108864
-  remote_timeout: 1s
+  remote_timeout: 5s
 # NOTE: Keep the order of keys as in Loki docs
 # to enable easy diffs when vendoring newer
 # Loki releases.
@@ -3772,7 +3772,7 @@ ingester:
 ingester_client:
   grpc_client_config:
     max_recv_msg_size: 67108864
-  remote_timeout: 1s
+  remote_timeout: 5s
 # NOTE: Keep the order of keys as in Loki docs
 # to enable easy diffs when vendoring newer
 # Loki releases.
@@ -4039,7 +4039,7 @@ ingester:
 ingester_client:
   grpc_client_config:
     max_recv_msg_size: 67108864
-  remote_timeout: 1s
+  remote_timeout: 5s
 # NOTE: Keep the order of keys as in Loki docs
 # to enable easy diffs when vendoring newer
 # Loki releases.
@@ -4307,7 +4307,7 @@ ingester:
 ingester_client:
   grpc_client_config:
     max_recv_msg_size: 67108864
-  remote_timeout: 1s
+  remote_timeout: 5s
 # NOTE: Keep the order of keys as in Loki docs
 # to enable easy diffs when vendoring newer
 # Loki releases.
@@ -4611,7 +4611,7 @@ ingester:
 ingester_client:
   grpc_client_config:
     max_recv_msg_size: 67108864
-  remote_timeout: 1s
+  remote_timeout: 5s
 # NOTE: Keep the order of keys as in Loki docs
 # to enable easy diffs when vendoring newer
 # Loki releases.
@@ -4913,7 +4913,7 @@ ingester:
 ingester_client:
   grpc_client_config:
     max_recv_msg_size: 67108864
-  remote_timeout: 1s
+  remote_timeout: 5s
 # NOTE: Keep the order of keys as in Loki docs
 # to enable easy diffs when vendoring newer
 # Loki releases.
@@ -5415,7 +5415,7 @@ ingester:
 ingester_client:
   grpc_client_config:
     max_recv_msg_size: 67108864
-  remote_timeout: 1s
+  remote_timeout: 5s
 # NOTE: Keep the order of keys as in Loki docs
 # to enable easy diffs when vendoring newer
 # Loki releases.
@@ -5595,7 +5595,7 @@ ingester:
 ingester_client:
   grpc_client_config:
     max_recv_msg_size: 67108864
-  remote_timeout: 1s
+  remote_timeout: 5s
 # NOTE: Keep the order of keys as in Loki docs
 # to enable easy diffs when vendoring newer
 # Loki releases.
@@ -5768,7 +5768,7 @@ ingester:
 ingester_client:
   grpc_client_config:
     max_recv_msg_size: 67108864
-  remote_timeout: 1s
+  remote_timeout: 5s
 # NOTE: Keep the order of keys as in Loki docs
 # to enable easy diffs when vendoring newer
 # Loki releases.
@@ -6163,7 +6163,7 @@ ingester:
 ingester_client:
   grpc_client_config:
     max_recv_msg_size: 67108864
-  remote_timeout: 1s
+  remote_timeout: 5s
 # NOTE: Keep the order of keys as in Loki docs
 # to enable easy diffs when vendoring newer
 # Loki releases.

--- a/operator/internal/manifests/internal/config/loki-config.yaml
+++ b/operator/internal/manifests/internal/config/loki-config.yaml
@@ -173,7 +173,7 @@ ingester_client:
     tls_cipher_suites: {{ .TLS.CipherSuitesString }}
     tls_min_version: {{ .TLS.MinTLSVersion }}
 {{- end }}
-  remote_timeout: 1s
+  remote_timeout: 5s
 # NOTE: Keep the order of keys as in Loki docs
 # to enable easy diffs when vendoring newer
 # Loki releases.


### PR DESCRIPTION
**What this PR does / why we need it**:

The Loki configuration generated by the operator currently uses a very short timeout for the distributor->ingester communication. While this worked in smaller test deployments, we have seen this lead to occasional failures in customer deployments.

This PR increases that timeout to its Loki default again.

**Which issue(s) this PR fixes**:

Fixes [LOG-8320](https://issues.redhat.com/browse/LOG-8320)

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
