### PR TITLE
chore(engine): fix regex simplification when there is >1 regex

### DIFF
--- a/pkg/engine/internal/planner/logical/logical_optimize.go
+++ b/pkg/engine/internal/planner/logical/logical_optimize.go
@@ -40,7 +40,10 @@ type simplifyRegexPass struct{}
 func (pass simplifyRegexPass) Apply(p *Plan) error {
 	var operandBuffer []*Value
 
-	for i, instr := range p.Instructions {
+	// NOTE(rfratto): We can't do a range loop here because we're modifying the
+	// slice as we iterate over it.
+	for i := 0; i < len(p.Instructions); i++ {
+		instr := p.Instructions[i]
 		b, ok := instr.(*BinOp)
 		if !ok || !pass.shouldApply(b) {
 			continue

--- a/pkg/engine/internal/planner/logical/logical_optimize_test.go
+++ b/pkg/engine/internal/planner/logical/logical_optimize_test.go
@@ -18,7 +18,7 @@ import (
 
 func Test_simplifyRegexPass(t *testing.T) {
 	params, err := logql.NewLiteralParams(
-		`{job="loki"} |~ "foo|bar"`,
+		`{job="loki"} !~ "debug|DEBUG|info|INFO" |~ "error|ERROR|fatal|FATAL"`,
 		time.Date(2025, time.January, 1, 0, 0, 0, 0, time.UTC),
 		time.Date(2025, time.January, 2, 0, 0, 0, 0, time.UTC),
 		0 /* step */, 0, /* duration */
@@ -31,18 +31,31 @@ func Test_simplifyRegexPass(t *testing.T) {
 
 	expect := strings.TrimSpace(`
 %1 = EQ label.job "loki"
-%2 = MATCH_STR builtin.message "foo"
-%3 = MATCH_STR builtin.message "bar"
+%2 = MATCH_STR builtin.message "debug"
+%3 = MATCH_STR builtin.message "DEBUG"
 %4 = OR %2 %3
-%5 = MAKETABLE [selector=%1, predicates=[%4], shard=0_of_1]
-%6 = GTE builtin.timestamp 2025-01-01T00:00:00Z
-%7 = SELECT %5 [predicate=%6]
-%8 = LT builtin.timestamp 2025-01-02T00:00:00Z
-%9 = SELECT %7 [predicate=%8]
-%10 = SELECT %9 [predicate=%4]
-%11 = TOPK %10 [sort_by=builtin.timestamp, k=1000, asc=false, nulls_first=false]
-%12 = LOGQL_COMPAT %11
-RETURN %12
+%5 = MATCH_STR builtin.message "info"
+%6 = OR %4 %5
+%7 = MATCH_STR builtin.message "INFO"
+%8 = OR %6 %7
+%9 = NOT(%8)
+%10 = MATCH_STR builtin.message "error"
+%11 = MATCH_STR builtin.message "ERROR"
+%12 = OR %10 %11
+%13 = MATCH_STR builtin.message "fatal"
+%14 = OR %12 %13
+%15 = MATCH_STR builtin.message "FATAL"
+%16 = OR %14 %15
+%17 = AND %9 %16
+%18 = MAKETABLE [selector=%1, predicates=[%17], shard=0_of_1]
+%19 = GTE builtin.timestamp 2025-01-01T00:00:00Z
+%20 = SELECT %18 [predicate=%19]
+%21 = LT builtin.timestamp 2025-01-02T00:00:00Z
+%22 = SELECT %20 [predicate=%21]
+%23 = SELECT %22 [predicate=%17]
+%24 = TOPK %23 [sort_by=builtin.timestamp, k=1000, asc=false, nulls_first=false]
+%25 = LOGQL_COMPAT %24
+RETURN %25
 `)
 
 	p, err := BuildPlan(params)


### PR DESCRIPTION
The regex simplification pass was failing when there was more than >1 simplifiable regex expression, due to the range loop continuing to operate on an older version of the slice.

Switching to a classic for loop fixes the issue.