### PR TITLE
chore: typos in comments

### DIFF
--- a/pkg/bloombuild/builder/batch.go
+++ b/pkg/bloombuild/builder/batch.go
@@ -323,7 +323,7 @@ func (i *blockLoadingIter) Close() error {
 }
 
 // Reset implements v1.ResettableIterator.
-// TODO(chaudum) Cache already fetched blocks to to avoid the overhead of
+// TODO(chaudum) Cache already fetched blocks to avoid the overhead of
 // creating the reader.
 func (i *blockLoadingIter) Reset() error {
 	if !i.initialized {

--- a/pkg/dataobj/sections/streams/row_predicate.go
+++ b/pkg/dataobj/sections/streams/row_predicate.go
@@ -39,7 +39,7 @@ type (
 	// A LabelFilterRowPredicate is a RowPredicate that requires that labels with
 	// the provided name pass a Keep function.
 	//
-	// The name is is provided to the keep function to allow the same function to
+	// The name is provided to the keep function to allow the same function to
 	// be used for multiple filter predicates.
 	//
 	// Uses of LabelFilterRowPredicate are not eligible for page filtering and

--- a/pkg/engine/internal/executor/pipeline_utils.go
+++ b/pkg/engine/internal/executor/pipeline_utils.go
@@ -30,7 +30,7 @@ func (p *BufferedPipeline) Read(_ context.Context) (arrow.RecordBatch, error) {
 		return nil, EOF
 	}
 
-	// Get the next record. The caller is responsible for releasing it it.
+	// Get the next record. The caller is responsible for releasing it.
 	return p.records[p.current], nil
 }
 

--- a/pkg/engine/internal/semconv/identifier.go
+++ b/pkg/engine/internal/semconv/identifier.go
@@ -91,7 +91,7 @@ func (i *Identifier) FQN() string {
 	return i.fqn
 }
 
-// Equal checks equality of of the identifier against a second identifier.
+// Equal checks equality of the identifier against a second identifier.
 func (i *Identifier) Equal(other *Identifier) bool {
 	if i == nil || other == nil {
 		return false

--- a/pkg/engine/internal/worker/worker.go
+++ b/pkg/engine/internal/worker/worker.go
@@ -1,4 +1,4 @@
-// Package worker provides a mechanism to to connect to the [scheduler] for
+// Package worker provides a mechanism to connect to the [scheduler] for
 // executing tasks.
 package worker
 

--- a/pkg/ingester/index/bitprefix.go
+++ b/pkg/ingester/index/bitprefix.go
@@ -54,7 +54,7 @@ func (ii *BitPrefixInvertedIndex) getShards(shard *logql.Shard) ([]*indexShard, 
 	}
 
 	// When comparing a higher shard factor to a lower inverted index shard factor
-	// we must filter resulting fingerprints as the the lower shard factor in the
+	// we must filter resulting fingerprints as the lower shard factor in the
 	// inverted index is a superset of the requested factor.
 	//
 	// For instance, the 3_of_4 shard factor maps to the bit prefix 0b11.

--- a/pkg/logql/evaluator.go
+++ b/pkg/logql/evaluator.go
@@ -184,7 +184,7 @@ func GetRangeType(q Params) QueryRangeType {
 }
 
 // ParamsWithExpressionOverride overrides the query expression so that the query
-// string and the expression can differ. This is useful for for query planning
+// string and the expression can differ. This is useful for query planning
 // when plan my not match externally available logql syntax
 type ParamsWithExpressionOverride struct {
 	Params

--- a/pkg/lokifrontend/frontend/v2/frontend.go
+++ b/pkg/lokifrontend/frontend/v2/frontend.go
@@ -414,7 +414,7 @@ func (f *Frontend) QueryResult(ctx context.Context, qrReq *frontendv2pb.QueryRes
 			level.Warn(f.log).Log("msg", "failed to write query result to the response channel", "queryID", qrReq.QueryID, "user", userID)
 		}
 	}
-	// TODO(chaudum): In case the the userIDs do not match, we do not send a
+	// TODO(chaudum): In case the userIDs do not match, we do not send a
 	// response to the req.response channel.
 	// In that case, the RoundTripGRPC method waits until the request context deadline exceeds.
 	// Only then the function finished and the request is removed from the

--- a/pkg/querier/http.go
+++ b/pkg/querier/http.go
@@ -524,7 +524,7 @@ func (q *QuerierAPI) queryStoreForPatterns(ctx context.Context, req *logproto.Qu
 		return nil, err
 	}
 
-	// Patterns are persisted as logfmt'd strings, so we need to to run the query using the LogQL engine
+	// Patterns are persisted as logfmt'd strings, so we need to run the query using the LogQL engine
 	// in order to extract the metric values from them.
 	query := q.engineV1.Query(params)
 	res, err := query.Exec(ctx)

--- a/pkg/ruler/base/api_test.go
+++ b/pkg/ruler/base/api_test.go
@@ -780,7 +780,7 @@ interval: 15s
 			err:    errors.New("invalid rules config: rule group 'rg_name' has no rules"),
 		},
 		{
-			name:   "with a a valid rules file",
+			name:   "with a valid rules file",
 			status: 202,
 			input: `
 name: test
@@ -799,7 +799,7 @@ rules:
 			output: "name: test\ninterval: 15s\nrules:\n    - record: up_rule\n      expr: up{}\n    - alert: up_alert\n      expr: sum(up{}) > 1\n      for: 30s\n      labels:\n        test: test\n      annotations:\n        test: test\n",
 		},
 		{
-			name:   "with a a valid rules file with limit parameter",
+			name:   "with a valid rules file with limit parameter",
 			status: 202,
 			input: `
 name: test

--- a/pkg/storage/common/aws/storage_class_test.go
+++ b/pkg/storage/common/aws/storage_class_test.go
@@ -17,7 +17,7 @@ func TestValidateStorageClass(t *testing.T) {
 			"foo",
 			fmt.Errorf("unsupported S3 storage class: foo. Supported values: %s", strings.Join(SupportedStorageClasses, ", ")),
 		},
-		"should not return error if storage class is is within supported values": {
+		"should not return error if storage class is within supported values": {
 			StorageClassStandardInfrequentAccess,
 			nil,
 		},

--- a/pkg/storage/stores/shipper/bloomshipper/cache.go
+++ b/pkg/storage/stores/shipper/bloomshipper/cache.go
@@ -164,7 +164,7 @@ func (b *BlockDirectory) resolveSize() error {
 }
 
 // BlockQuerier returns a new block querier from the directory.
-// The passed function `close` is called when the the returned querier is closed.
+// The passed function `close` is called when the returned querier is closed.
 func (b BlockDirectory) BlockQuerier(
 	alloc mempool.Allocator,
 	closeFunc func() error,

--- a/pkg/tool/commands/rules.go
+++ b/pkg/tool/commands/rules.go
@@ -774,7 +774,7 @@ func ruleMetric(rule rulefmt.Rule) string {
 
 // End taken from https://github.com/prometheus/prometheus/blob/8c8de46003d1800c9d40121b4a5e5de8582ef6e1/cmd/promtool/main.go#L403
 
-// save saves a set of rule files to to disk. You can specify whenever you want the
+// save saves a set of rule files to disk. You can specify whenever you want the
 // file(s) to be edited in-place.
 func save(nss map[string]rules.RuleNamespace, i bool) error {
 	for _, ns := range nss {

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -1417,7 +1417,7 @@ func (sm *OverwriteMarshalingStringMap) Map() map[string]string {
 	return sm.m
 }
 
-// MarshalJSON explicitly uses the the type receiver and not pointer receiver
+// MarshalJSON explicitly uses the type receiver and not pointer receiver
 // or it won't be called
 func (sm OverwriteMarshalingStringMap) MarshalJSON() ([]byte, error) {
 	return json.Marshal(sm.m)
@@ -1433,7 +1433,7 @@ func (sm *OverwriteMarshalingStringMap) UnmarshalJSON(val []byte) error {
 	return nil
 }
 
-// MarshalYAML explicitly uses the the type receiver and not pointer receiver
+// MarshalYAML explicitly uses the type receiver and not pointer receiver
 // or it won't be called
 func (sm OverwriteMarshalingStringMap) MarshalYAML() (interface{}, error) {
 	return sm.m, nil


### PR DESCRIPTION
Fix typos in comments:
- Doubled words: `the the`, `to to`, `a a`, `is is`, `of of`, `it it`, `for for`
- 14 files changed