### PR TITLE
feat(series): implement AtST

### DIFF
--- a/pkg/querier/series/series_set.go
+++ b/pkg/querier/series/series_set.go
@@ -135,7 +135,7 @@ func (c *concreteSeriesIterator) AtT() (t int64) {
 }
 
 func (c *concreteSeriesIterator) AtST() int64 {
-	// TODO(krajorama): implement AtST if needed.
+	// TODO: implement AtST if needed.
 	// See https://github.com/prometheus/prometheus/pull/17840.
 	return 0
 }
@@ -187,8 +187,6 @@ func (errIterator) AtT() (t int64) {
 }
 
 func (errIterator) AtST() int64 {
-	// TODO(krajorama): implement AtST if needed.
-	// See https://github.com/prometheus/prometheus/pull/17840.
 	return 0
 }
 
@@ -271,7 +269,7 @@ func (d DeletedSeriesIterator) AtT() (t int64) {
 }
 
 func (d DeletedSeriesIterator) AtST() int64 {
-	// TODO(krajorama): implement AtST if needed.
+	// TODO: implement AtST if needed.
 	// See https://github.com/prometheus/prometheus/pull/17840.
 	return 0
 }
@@ -359,8 +357,6 @@ func (emptySeriesIterator) AtT() (t int64) {
 }
 
 func (emptySeriesIterator) AtST() int64 {
-	// TODO(krajorama): implement AtST if needed.
-	// See https://github.com/prometheus/prometheus/pull/17840.
 	return 0
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR is a follow-up to https://github.com/prometheus/prometheus/pull/17840 Here I'm updating the `series` package to implement the new `AtST` interface with a stub.

We need this to pass currently failing builds in Grafana internal backend-enterprise, which vendors the already updated Prometheus.

Note, we figured it should be simpler to review this PR, that only adds stubbed methods, to support the interface. An alternative is to update a ton of dependencies, including `prometheus/prometheus` (like I tried in https://github.com/grafana/loki/pull/20492)

**Which issue(s) this PR fixes**:
Fixes n/a

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
