### PR TITLE
chore: Introduce parent-child memory allocators

### DIFF
--- a/pkg/memory/allocator.go
+++ b/pkg/memory/allocator.go
@@ -127,8 +127,7 @@ func (alloc *Allocator) Trim() {
 func (alloc *Allocator) returnRegion(region *Region) {
 	for i := range alloc.regions {
 		if alloc.regions[i] == region {
-			alloc.regions[i] = nil
-			alloc.empty.Set(i, true)
+			alloc.free.Set(i, true)
 			break
 		}
 	}

--- a/pkg/memory/allocator_test.go
+++ b/pkg/memory/allocator_test.go
@@ -76,7 +76,9 @@ func TestAllocator_AllocateFromParent(t *testing.T) {
 	child.Reclaim()
 	child.Trim()
 	require.Equal(t, 0, child.AllocatedBytes(), "all memory should have been trimmed")
-	require.Equal(t, parentAllocated-childAllocated, parent.AllocatedBytes(), "should have trimmed parent memory by the amount of the child's allocated memory")
+	require.Equal(t, parentAllocated, parent.AllocatedBytes(), "parent allocated memory should not have been changed because the parent was not Trimmed.")
+	require.Equal(t, 0, child.FreeBytes(), "all child memory should have been freed")
+	require.Equal(t, 5, parent.FreeBytes(), "parent memory should have the child's bytes available for allocation")
 
 	// Creating a new buffer should allocate new memory from the parent.
 	_ = child.Allocate(5)


### PR DESCRIPTION
**What this PR does / why we need it**:
Introduces parent-child relationships between allocators.

A Child allocator can manage it's own memory lifecycle via Trim/Reclaim as usual, except it will allocate memory regions from the parent.
A Parent allocator will reclaim memory from any child allocators when calling Trim/Reclaim. Any transitive memory allocated is therefore unusable after the parent is Trim/Reclaimed.
An allocator without a parent will request or return memory from the runtime, as previously.