### PR TITLE
chore(engine): add logs for task analysis

### DIFF
--- a/pkg/engine/internal/worker/thread.go
+++ b/pkg/engine/internal/worker/thread.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/user"
 	"github.com/thanos-io/objstore"
+	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/grafana/loki/v3/pkg/dataobj/metastore"
 	"github.com/grafana/loki/v3/pkg/engine/internal/executor"
@@ -101,7 +102,10 @@ func (t *thread) runJob(ctx context.Context, job *threadJob) {
 	logger = utillog.WithContext(ctx, logger) // Extract trace ID
 
 	startTime := time.Now()
-	level.Info(logger).Log("msg", "starting task")
+	level.Info(logger).Log(
+		"msg", "starting task",
+		"plan", physical.PrintAsTree(job.Task.Fragment),
+	)
 
 	cfg := executor.Config{
 		BatchSize: t.BatchSize,
@@ -155,6 +159,11 @@ func (t *thread) runJob(ctx context.Context, job *threadJob) {
 
 	ctx, capture := xcap.NewCapture(ctx, nil)
 	defer capture.End()
+
+	ctx, region := xcap.StartRegion(ctx, "thread.runJob", xcap.WithRegionAttributes(
+		attribute.Stringer("task_id", job.Task.ULID),
+	))
+	defer region.End()
 
 	pipeline := executor.Run(ctx, cfg, job.Task.Fragment, logger)
 
@@ -218,10 +227,18 @@ func (t *thread) runJob(ctx context.Context, job *threadJob) {
 	pipeline.Close()
 	// Explicitly call End() here (even though we have a defer statement)
 	// to finalize the capture before it's included in the TaskStatusMessage.
+	region.End()
 	capture.End()
 
 	duration := time.Since(startTime)
-	level.Info(logger).Log("msg", "task completed", "duration", duration)
+
+	logValues := []any{
+		"msg", "task completed",
+		"duration", duration,
+	}
+	logValues = append(logValues, xcap.SummaryLogValues(capture)...)
+
+	level.Info(logger).Log(logValues...)
 	t.Metrics.taskExecSeconds.Observe(duration.Seconds())
 
 	// Wait for the scheduler to confirm the task has completed before
@@ -237,6 +254,8 @@ func (t *thread) runJob(ctx context.Context, job *threadJob) {
 }
 
 func (t *thread) drainPipeline(ctx context.Context, pipeline executor.Pipeline, job *threadJob, logger log.Logger) (int, error) {
+	region := xcap.RegionFromContext(ctx)
+
 	var totalRows int
 	for {
 		rec, err := pipeline.Read(ctx)
@@ -253,6 +272,7 @@ func (t *thread) drainPipeline(ctx context.Context, pipeline executor.Pipeline, 
 			continue
 		}
 
+		startSend := time.Now()
 		for _, sink := range job.Sinks {
 			err := sink.Send(ctx, rec)
 			if err != nil {
@@ -264,6 +284,7 @@ func (t *thread) drainPipeline(ctx context.Context, pipeline executor.Pipeline, 
 				continue
 			}
 		}
+		region.Record(xcap.TaskSendDuration.Observe(time.Since(startSend).Seconds()))
 	}
 
 	return totalRows, nil

--- a/pkg/xcap/exporter.go
+++ b/pkg/xcap/exporter.go
@@ -201,5 +201,12 @@ func summarizeObservations(capture *Capture) *observations {
 			normalizeKeys(),
 	)
 
+	// task stats
+	result.merge(
+		collect.fromRegions("thread.runJob", true).
+			filter(TaskRecvDuration.Key(), TaskSendDuration.Key()).
+			normalizeKeys(),
+	)
+
 	return result
 }

--- a/pkg/xcap/stats_definitions.go
+++ b/pkg/xcap/stats_definitions.go
@@ -85,3 +85,9 @@ var (
 	// Track number of predicates applied to enforce delete request filtering.
 	StatDeletePredicates = NewStatisticInt64("delete.request.predicates", AggregationTypeFirst)
 )
+
+// Task statistics.
+var (
+	TaskRecvDuration = NewStatisticFloat64("task.recv.duration", AggregationTypeSum)
+	TaskSendDuration = NewStatisticFloat64("task.send.duration", AggregationTypeSum)
+)


### PR DESCRIPTION
* Track the duration a task spends sending and receving data from other tasks.

* Log a summary of the task's xcap capture at the end of a task.

* Print the physical plan of an individual task when starting the task.