### PR TITLE
feat: Add multi-tenant query routing support to splitting handler

### DIFF
--- a/tools/querytee/splitting_handler.go
+++ b/tools/querytee/splitting_handler.go
@@ -47,6 +47,11 @@ type SplittingHandler struct {
 	addRoutingDecisionsToWarnings bool
 }
 
+// isMultiTenant returns true if the request contains multiple tenant IDs.
+func isMultiTenant(tenants []string) bool {
+	return len(tenants) > 1
+}
+
 func NewSplittingHandler(cfg SplittingHandlerConfig, logger log.Logger) (http.Handler, error) {
 	if cfg.V1Backend == nil {
 		return tenantHandler(queryrange.NewSerializeHTTPHandler(cfg.FanOutHandler, cfg.Codec), logger), nil
@@ -149,7 +154,7 @@ func (f *splitHandlerFactory) createSplittingHandler(forMetricQuery bool, v1Hand
 //   - v2-preferred/race: Always split when splitLag > 0 (sampling only affects goldfish comparison).
 //   - v1-preferred: Skip fanout when not sampling, only split for goldfish comparison.
 func (f *SplittingHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	_, ctx, err := tenant.ExtractTenantIDFromHTTPRequest(r)
+	_, ctx, err := user.ExtractOrgIDFromHTTPRequest(r)
 	if err != nil {
 		level.Warn(f.logger).Log(
 			"msg", "failed to extract tenant ID",
@@ -182,6 +187,17 @@ func (f *SplittingHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		shouldSample = f.shouldSample(tenants, r)
 	}
 
+	// Multi-tenant queries must always go to v1 only (v2 doesn't support them)
+	if isMultiTenant(tenants) {
+		level.Info(f.logger).Log("msg", "multi-tenant query detected, routing to v1 only", "tenants", len(tenants))
+		resp, err = f.v1Handler.Do(ctx, req)
+		if resp != nil && f.addRoutingDecisionsToWarnings {
+			addWarningToResponse(resp, "multi-tenant query routed to v1 backend only (v2 does not support multi-tenant)")
+		}
+		f.writeResponse(ctx, r, w, resp, err)
+		return
+	}
+
 	// Routing decision logic:
 	// - v2-preferred/race: Always split when splitLag > 0 (sampling only affects goldfish comparison)
 	// - v1-preferred: Skip fanout when not sampling, only split for goldfish comparison
@@ -206,10 +222,15 @@ func (f *SplittingHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	f.writeResponse(ctx, r, w, resp, err)
+}
+
+// writeResponse handles encoding and writing the response back to the HTTP response writer.
+func (f *SplittingHandler) writeResponse(ctx context.Context, r *http.Request, w http.ResponseWriter, resp queryrangebase.Response, err error) {
 	if err != nil {
-		switch r := resp.(type) {
+		switch typedResp := resp.(type) {
 		case *NonDecodableResponse:
-			http.Error(w, string(r.Body), r.StatusCode)
+			http.Error(w, string(typedResp.Body), typedResp.StatusCode)
 		default:
 			level.Warn(f.logger).Log("msg", "handler failed", "err", err)
 			server.WriteError(err, w)


### PR DESCRIPTION
**What this PR does / why we need it**:

This change introduces multi-tenant query handling in the SplittingHandler, ensuring that queries with multiple tenant IDs are always routed to the v1 backend (since multi-tenant queries are not yet supported in the new query engine).

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
