### PR TITLE
ci(claude): limit users to grafanistas

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,11 +12,22 @@ on:
 
 jobs:
   claude:
+    # We check the author association to ensure that no non-members can trigger Claude,
+    #   and in turn read Vault secrets via the allowed tools (e.g. Bash(env:*) and Bash(curl:*)).
+    # We cannot ever relax this restriction.
     if: |
-      ((github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude'))))
+      (
+        (
+          github.event.pull_request.author_association == 'OWNER' ||
+          github.event.pull_request.author_association == 'MEMBER'
+        ) &&
+        (
+          (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+          (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+          (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+          (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+        )
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -39,33 +50,32 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@8b2bd6d04f7b6ac4ba5523a3a573f7843ab4b4ba  # beta
+        uses: anthropics/claude-code-action@8b2bd6d04f7b6ac4ba5523a3a573f7843ab4b4ba # beta
         with:
           anthropic_api_key: ${{ env.ANTHROPIC_API_KEY }}
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
             actions: read
-          
+
           # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4.1)
           # model: "claude-opus-4-1-20250805"
-          
+
           # Optional: Customize the trigger phrase (default: @claude)
           # trigger_phrase: "/claude"
-          
+
           # Optional: Trigger when specific user is assigned to an issue
           # assignee_trigger: "claude-bot"
-          
+
           # Optional: Allow Claude to run specific commands
           allowed_tools: "Bash(awk:*),Bash(chmod:*),Bash(curl:*),Bash(docker:*),Bash(docker-compose:*),Bash(env:*),Bash(find:*),Bash(git:*),Bash(go build:*),Bash(go get:*),Bash(go run:*),Bash(go test:*),Bash(go vet:*),Bash(gofmt:*),Bash(grep:*),Bash(head:*),Bash(ls:*),Bash(make:*),Bash(mkdir:*),Bash(nix:*),Bash(npm install:*),Bash(npm run:*),Bash(npm test:*),Bash(npx:*),Bash(rg:*),Bash(sed:*),Bash(tail:*),Bash(yarn:*),WebFetch(domain:github.com),WebFetch(domain:google.com),WebFetch(domain:localhost),WebFetch(domain:raw.githubusercontent.com)"
-          
+
           # Optional: Add custom instructions for Claude to customize its behavior for your project
           # custom_instructions: |
           #   Follow our coding standards
           #   Ensure all new code has tests
           #   Use TypeScript for new files
-          
+
           # Optional: Custom environment variables for Claude
           # claude_env: |
           #   NODE_ENV: test
-


### PR DESCRIPTION
The `issue_comment` event is not limited by GitHub's Actions approval settings. This means that the events are unconditionally triggered and trusted. They additionally run in the context of our repository, even on PRs from forks, and they get `id-token: write`, meaning they have read permissions to Vault.

With Claude, we permit all the tools that could lead to unauthorised sensitive secrets extraction. To limit this, we will only permit Grafanistas to use the tool. This cannot be relaxed in the future.

As Loki is the only vulnerable repository within our organisation, and we have already disabled the workflow in GitHub, this PR is submitted publicly. This vulnerability was found internally by Grafana's Security team.

BREAKING CHANGE: This introduces a breaking change to how the action behaves. For Grafanistas, no impact should be noticeable. For non-Grafanistas who have been developing using Claude in our repository, the bot will stop working outright.