### PR TITLE
docs: fix upgrade Helm version (#20533)

### DIFF
--- a/docs/sources/setup/upgrade/_index.md
+++ b/docs/sources/setup/upgrade/_index.md
@@ -45,6 +45,15 @@ Supported clients should check the configuration options for max send message si
 
 ## Helm Chart Upgrades
 
+### Helm Chart 6.50.0 - Respect the global registry in the sidecar image
+
+If you prefixed the sidecar container with a private registry (`sidecar.image.repository`), this is no longer necessary and is deprecated as the global registry is used starting with Helm chart 6.46.1. Therefore please use `global.imageRegistry` or alternatively, `sidecar.image.registry` for more fine-grained control.
+
+### Helm Chart 6.50.0 - Uniform naming for image digest also in the sidecar image
+
+For most images used in the helm chart, a `.digest` is available to pin an image to a specific hash. The sidecar images diverges from this convention by introducing a `.tag`.
+Starting with Helm chart 6.46.1, the `.tag` is deprecated and `.digest` should be used.
+
 ### Helm Chart 6.34.0 - Zone-aware Ingester Breaking Change
 
 {{< admonition type="warning" >}}


### PR DESCRIPTION
(cherry picked from commit 8d3a79ef34919954ac1c78089546a7c848ad786c)

**What this PR does / why we need it**:

Manual backport of #20533  to the 3.6 branch.