### PR TITLE
chore: Set scheduler lookup interval in logql bench tests

### DIFF
--- a/pkg/engine/worker.go
+++ b/pkg/engine/worker.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	"github.com/gorilla/mux"
 	"github.com/grafana/dskit/services"
 	"github.com/pkg/errors"
@@ -76,6 +77,11 @@ type Worker struct {
 func NewWorker(params WorkerParams) (*Worker, error) {
 	if params.Config.SchedulerLookupAddress != "" && params.Config.SchedulerLookupInterval == 0 {
 		return nil, errors.New("scheduler lookup interval must be non-zero when a scheduler lookup address is provided")
+	}
+
+	if params.Config.SchedulerLookupInterval < time.Second {
+		level.Warn(params.Logger).Log("msg", "scheduler lookup interval is configured to be less than 1 second, overriding to 1 second")
+		params.Config.SchedulerLookupInterval = time.Second
 	}
 
 	if params.Endpoint == "" {

--- a/pkg/logql/bench/store_dataobj_v2_engine.go
+++ b/pkg/logql/bench/store_dataobj_v2_engine.go
@@ -132,7 +132,7 @@ func dataobjV2StoreWithOpts(dataDir string, tenantID string, cfg engine.Executor
 		LocalScheduler: sched,
 		Config: engine.WorkerConfig{
 			SchedulerLookupAddress:  schedLookupAddr,
-			SchedulerLookupInterval: 60,
+			SchedulerLookupInterval: time.Minute,
 			// Try to create one thread per host CPU core. However, we always
 			// create at least 8 threads. This prevents situations where
 			// no task can make progress because a parent task hasn't been


### PR DESCRIPTION
**What this PR does / why we need it**:
Sets a default value for SchedulerLookups. It isn't a sensible value, but it avoids setting it too fast unnecessarily.
Also configures the bench tests to use a sensible value.
