### PR TITLE
chore: add backend_alias and issuer to query-tee comparison metrics

### DIFF
--- a/pkg/querytee/proxy.go
+++ b/pkg/querytee/proxy.go
@@ -287,11 +287,13 @@ func NewProxy(
 		}
 	}
 
-	// Pre-initialize raceWins metric for all backend/route combinations
+	// Pre-initialize raceWins metric for all backend/route/issuer combinations
 	if cfg.Routing.Mode == RoutingModeRace {
 		for _, backend := range p.backends {
 			for _, route := range p.readRoutes {
-				p.metrics.raceWins.WithLabelValues(backend.name, route.RouteName)
+				for _, issuer := range []string{unknownIssuer, canaryIssuer} {
+					p.metrics.raceWins.WithLabelValues(backend.name, backend.Alias(), route.RouteName, issuer)
+				}
 			}
 		}
 	}

--- a/pkg/querytee/proxy_backend.go
+++ b/pkg/querytee/proxy_backend.go
@@ -79,6 +79,19 @@ func (b *ProxyBackend) WithFilter(f *regexp.Regexp) *ProxyBackend {
 	return b
 }
 
+// Alias returns the backend alias label value for metrics.
+// Returns "v1" for v1-preferred backends, "v2" for v2-preferred backends,
+// or "other" for non-preferred backends.
+func (b *ProxyBackend) Alias() string {
+	if b.v1Preferred {
+		return "v1"
+	}
+	if b.v2Preferred {
+		return "v2"
+	}
+	return "other"
+}
+
 func (b *ProxyBackend) ForwardRequest(orig *http.Request, body io.ReadCloser) *BackendResponse {
 	start := time.Now()
 	req, span := b.createBackendRequest(orig, body)

--- a/pkg/querytee/proxy_backend_test.go
+++ b/pkg/querytee/proxy_backend_test.go
@@ -191,3 +191,38 @@ func Test_NewProxyBackend_PreferredLogic(t *testing.T) {
 		})
 	}
 }
+
+func Test_ProxyBackend_Alias(t *testing.T) {
+	u, err := url.Parse("http://test")
+	require.NoError(t, err)
+
+	tests := map[string]struct {
+		v1Preferred   bool
+		v2Preferred   bool
+		expectedAlias string
+	}{
+		"v1 preferred backend": {
+			v1Preferred:   true,
+			v2Preferred:   false,
+			expectedAlias: "v1",
+		},
+		"v2 preferred backend": {
+			v1Preferred:   false,
+			v2Preferred:   true,
+			expectedAlias: "v2",
+		},
+		"neither preferred": {
+			v1Preferred:   false,
+			v2Preferred:   false,
+			expectedAlias: "other",
+		},
+	}
+
+	for testName, testData := range tests {
+		t.Run(testName, func(t *testing.T) {
+			b, err := NewProxyBackend("test", u, time.Second, testData.v1Preferred, testData.v2Preferred)
+			require.NoError(t, err)
+			assert.Equal(t, testData.expectedAlias, b.Alias())
+		})
+	}
+}

--- a/pkg/querytee/proxy_endpoint.go
+++ b/pkg/querytee/proxy_endpoint.go
@@ -145,7 +145,7 @@ func (p *ProxyEndpoint) serveWrites(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	p.metrics.responsesTotal.WithLabelValues(downstreamRes.backend.name, r.Method, p.routeName, detectIssuer(r)).Inc()
+	p.metrics.responsesTotal.WithLabelValues(downstreamRes.backend.name, downstreamRes.backend.Alias(), r.Method, p.routeName, detectIssuer(r)).Inc()
 }
 
 func (p *ProxyEndpoint) executeBackendRequests(r *http.Request, resCh chan *BackendResponse, goldfishSample bool) {
@@ -205,6 +205,7 @@ func (p *ProxyEndpoint) executeBackendRequests(r *http.Request, resCh chan *Back
 			lvl(p.logger).Log("msg", "Backend response", "path", r.URL.Path, "query", query, "backend", backend.name, "status", res.status, "elapsed", res.duration)
 			p.metrics.requestDuration.WithLabelValues(
 				res.backend.name,
+				res.backend.Alias(),
 				r.Method,
 				p.routeName,
 				strconv.FormatInt(int64(res.statusCode()), 10),
@@ -249,9 +250,9 @@ func (p *ProxyEndpoint) executeBackendRequests(r *http.Request, resCh chan *Back
 			}
 
 			if p.instrumentCompares && summary != nil {
-				p.metrics.missingMetrics.WithLabelValues(p.backends[i].name, p.routeName, result, issuer).Observe(float64(summary.MissingMetrics))
+				p.metrics.missingMetrics.WithLabelValues(p.backends[i].name, p.backends[i].Alias(), p.routeName, result, issuer).Observe(float64(summary.MissingMetrics))
 			}
-			p.metrics.responsesComparedTotal.WithLabelValues(p.backends[i].name, p.routeName, result, issuer).Inc()
+			p.metrics.responsesComparedTotal.WithLabelValues(p.backends[i].name, p.backends[i].Alias(), p.routeName, result, issuer).Inc()
 		}
 	}
 

--- a/pkg/querytee/proxy_endpoint_test.go
+++ b/pkg/querytee/proxy_endpoint_test.go
@@ -501,27 +501,27 @@ func Test_ProxyEndpoint_SummaryMetrics(t *testing.T) {
 			expectedMetrics: `
 			    # HELP cortex_querytee_missing_metrics_series Number of missing metrics (series) in a vector response.
 				# TYPE cortex_querytee_missing_metrics_series histogram
-				cortex_querytee_missing_metrics_series_bucket{backend="backend-2",issuer="unknown",route="test",status_code="success",le="0.005"} 0
-				cortex_querytee_missing_metrics_series_bucket{backend="backend-2",issuer="unknown",route="test",status_code="success",le="0.01"} 0
-				cortex_querytee_missing_metrics_series_bucket{backend="backend-2",issuer="unknown",route="test",status_code="success",le="0.025"} 0
-				cortex_querytee_missing_metrics_series_bucket{backend="backend-2",issuer="unknown",route="test",status_code="success",le="0.05"} 0
-				cortex_querytee_missing_metrics_series_bucket{backend="backend-2",issuer="unknown",route="test",status_code="success",le="0.1"} 0
-				cortex_querytee_missing_metrics_series_bucket{backend="backend-2",issuer="unknown",route="test",status_code="success",le="0.25"} 0
-				cortex_querytee_missing_metrics_series_bucket{backend="backend-2",issuer="unknown",route="test",status_code="success",le="0.5"} 0
-				cortex_querytee_missing_metrics_series_bucket{backend="backend-2",issuer="unknown",route="test",status_code="success",le="0.75"} 0
-				cortex_querytee_missing_metrics_series_bucket{backend="backend-2",issuer="unknown",route="test",status_code="success",le="1"} 0
-				cortex_querytee_missing_metrics_series_bucket{backend="backend-2",issuer="unknown",route="test",status_code="success",le="1.5"} 0
-				cortex_querytee_missing_metrics_series_bucket{backend="backend-2",issuer="unknown",route="test",status_code="success",le="2"} 0
-				cortex_querytee_missing_metrics_series_bucket{backend="backend-2",issuer="unknown",route="test",status_code="success",le="3"} 0
-				cortex_querytee_missing_metrics_series_bucket{backend="backend-2",issuer="unknown",route="test",status_code="success",le="4"} 0
-				cortex_querytee_missing_metrics_series_bucket{backend="backend-2",issuer="unknown",route="test",status_code="success",le="5"} 0
-				cortex_querytee_missing_metrics_series_bucket{backend="backend-2",issuer="unknown",route="test",status_code="success",le="10"} 0
-				cortex_querytee_missing_metrics_series_bucket{backend="backend-2",issuer="unknown",route="test",status_code="success",le="25"} 1
-				cortex_querytee_missing_metrics_series_bucket{backend="backend-2",issuer="unknown",route="test",status_code="success",le="50"} 1
-				cortex_querytee_missing_metrics_series_bucket{backend="backend-2",issuer="unknown",route="test",status_code="success",le="100"} 1
-				cortex_querytee_missing_metrics_series_bucket{backend="backend-2",issuer="unknown",route="test",status_code="success",le="+Inf"} 1
-				cortex_querytee_missing_metrics_series_sum{backend="backend-2",issuer="unknown",route="test",status_code="success"} 12
-				cortex_querytee_missing_metrics_series_count{backend="backend-2",issuer="unknown",route="test",status_code="success"} 1
+				cortex_querytee_missing_metrics_series_bucket{backend="backend-2",backend_alias="other",issuer="unknown",route="test",status_code="success",le="0.005"} 0
+				cortex_querytee_missing_metrics_series_bucket{backend="backend-2",backend_alias="other",issuer="unknown",route="test",status_code="success",le="0.01"} 0
+				cortex_querytee_missing_metrics_series_bucket{backend="backend-2",backend_alias="other",issuer="unknown",route="test",status_code="success",le="0.025"} 0
+				cortex_querytee_missing_metrics_series_bucket{backend="backend-2",backend_alias="other",issuer="unknown",route="test",status_code="success",le="0.05"} 0
+				cortex_querytee_missing_metrics_series_bucket{backend="backend-2",backend_alias="other",issuer="unknown",route="test",status_code="success",le="0.1"} 0
+				cortex_querytee_missing_metrics_series_bucket{backend="backend-2",backend_alias="other",issuer="unknown",route="test",status_code="success",le="0.25"} 0
+				cortex_querytee_missing_metrics_series_bucket{backend="backend-2",backend_alias="other",issuer="unknown",route="test",status_code="success",le="0.5"} 0
+				cortex_querytee_missing_metrics_series_bucket{backend="backend-2",backend_alias="other",issuer="unknown",route="test",status_code="success",le="0.75"} 0
+				cortex_querytee_missing_metrics_series_bucket{backend="backend-2",backend_alias="other",issuer="unknown",route="test",status_code="success",le="1"} 0
+				cortex_querytee_missing_metrics_series_bucket{backend="backend-2",backend_alias="other",issuer="unknown",route="test",status_code="success",le="1.5"} 0
+				cortex_querytee_missing_metrics_series_bucket{backend="backend-2",backend_alias="other",issuer="unknown",route="test",status_code="success",le="2"} 0
+				cortex_querytee_missing_metrics_series_bucket{backend="backend-2",backend_alias="other",issuer="unknown",route="test",status_code="success",le="3"} 0
+				cortex_querytee_missing_metrics_series_bucket{backend="backend-2",backend_alias="other",issuer="unknown",route="test",status_code="success",le="4"} 0
+				cortex_querytee_missing_metrics_series_bucket{backend="backend-2",backend_alias="other",issuer="unknown",route="test",status_code="success",le="5"} 0
+				cortex_querytee_missing_metrics_series_bucket{backend="backend-2",backend_alias="other",issuer="unknown",route="test",status_code="success",le="10"} 0
+				cortex_querytee_missing_metrics_series_bucket{backend="backend-2",backend_alias="other",issuer="unknown",route="test",status_code="success",le="25"} 1
+				cortex_querytee_missing_metrics_series_bucket{backend="backend-2",backend_alias="other",issuer="unknown",route="test",status_code="success",le="50"} 1
+				cortex_querytee_missing_metrics_series_bucket{backend="backend-2",backend_alias="other",issuer="unknown",route="test",status_code="success",le="100"} 1
+				cortex_querytee_missing_metrics_series_bucket{backend="backend-2",backend_alias="other",issuer="unknown",route="test",status_code="success",le="+Inf"} 1
+				cortex_querytee_missing_metrics_series_sum{backend="backend-2",backend_alias="other",issuer="unknown",route="test",status_code="success"} 12
+				cortex_querytee_missing_metrics_series_count{backend="backend-2",backend_alias="other",issuer="unknown",route="test",status_code="success"} 1
 			`,
 		},
 	} {

--- a/pkg/querytee/proxy_metrics.go
+++ b/pkg/querytee/proxy_metrics.go
@@ -41,23 +41,23 @@ func NewProxyMetrics(registerer prometheus.Registerer) *ProxyMetrics {
 			Name:      "request_duration_seconds",
 			Help:      "Time (in seconds) spent serving HTTP requests.",
 			Buckets:   []float64{.005, .01, .025, .05, .1, .25, .5, 0.75, 1, 1.5, 2, 3, 4, 5, 10, 25, 50, 100},
-		}, []string{"backend", "method", "route", "status_code", "issuer"}),
+		}, []string{"backend", "backend_alias", "method", "route", "status_code", "issuer"}),
 		responsesTotal: promauto.With(registerer).NewCounterVec(prometheus.CounterOpts{
 			Namespace: "cortex_querytee",
 			Name:      "responses_total",
 			Help:      "Total number of responses sent back to the client by the selected backend.",
-		}, []string{"backend", "method", "route", "issuer"}),
+		}, []string{"backend", "backend_alias", "method", "route", "issuer"}),
 		responsesComparedTotal: promauto.With(registerer).NewCounterVec(prometheus.CounterOpts{
 			Namespace: "cortex_querytee",
 			Name:      "responses_compared_total",
 			Help:      "Total number of responses compared per route and backend name by result.",
-		}, []string{"backend", "route", "result", "issuer"}),
+		}, []string{"backend", "backend_alias", "route", "result", "issuer"}),
 		missingMetrics: promauto.With(registerer).NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: "cortex_querytee",
 			Name:      "missing_metrics_series",
 			Help:      "Number of missing metrics (series) in a vector response.",
 			Buckets:   []float64{.005, .01, .025, .05, .1, .25, .5, 0.75, 1, 1.5, 2, 3, 4, 5, 10, 25, 50, 100},
-		}, []string{"backend", "route", "status_code", "issuer"}),
+		}, []string{"backend", "backend_alias", "route", "status_code", "issuer"}),
 
 		queriesSampled: promauto.With(registerer).NewCounterVec(prometheus.CounterOpts{
 			Namespace: "cortex_querytee",
@@ -75,7 +75,7 @@ func NewProxyMetrics(registerer prometheus.Registerer) *ProxyMetrics {
 			Namespace: "loki_querytee",
 			Name:      "race_wins_total",
 			Help:      "Total number of times each backend won the race (when racing is enabled).",
-		}, []string{"backend", "route"}),
+		}, []string{"backend", "backend_alias", "route", "issuer"}),
 	}
 
 	return m


### PR DESCRIPTION
**What this PR does / why we need it**:

A few small cleanup items for the query-tee codebase.
* add an backend alias to the comparison metrics so we can easily tell v1 from v2
* add issuer to the race metrics, so we can exclude the canary, or detect certain usage patterns.


**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
