### PR TITLE
chore(dataobj): use reader adapter

### DIFF
--- a/pkg/dataobj/internal/arrowconv/columnar.go
+++ b/pkg/dataobj/internal/arrowconv/columnar.go
@@ -65,6 +65,30 @@ func ToRecordBatch(src columnar.RecordBatch, schema *arrow.Schema) (arrow.Record
 			)
 			arr = array.NewUint64Data(data)
 
+		case arrow.BINARY:
+			srcBinary := srcCol.(*columnar.UTF8)
+			srcBytes := srcBinary.Data()
+			dstBytes := make([]byte, len(srcBytes))
+			copy(dstBytes, srcBytes)
+
+			srcOffsetsBytes := arrow.GetBytes(srcBinary.Offsets())
+			dstOffsetsBytes := make([]byte, len(srcOffsetsBytes))
+			copy(dstOffsetsBytes, srcOffsetsBytes)
+
+			data := array.NewData(
+				field.Type,
+				int(nrows),
+				[]*arrowmemory.Buffer{
+					arrowmemory.NewBufferBytes(dstValidity),
+					arrowmemory.NewBufferBytes(dstOffsetsBytes),
+					arrowmemory.NewBufferBytes(dstBytes),
+				},
+				nil,
+				srcBinary.Nulls(),
+				0,
+			)
+			arr = array.NewBinaryData(data)
+
 		case arrow.STRING:
 			srcUTF8 := srcCol.(*columnar.UTF8)
 			srcBytes := srcUTF8.Data()

--- a/pkg/dataobj/sections/logs/reader.go
+++ b/pkg/dataobj/sections/logs/reader.go
@@ -7,15 +7,15 @@ import (
 	_ "io" // Used for documenting io.EOF.
 
 	"github.com/apache/arrow-go/v18/arrow"
-	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/apache/arrow-go/v18/arrow/scalar"
 
+	columnarv2 "github.com/grafana/loki/v3/pkg/columnar"
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/arrowconv"
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/dataset"
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/metadata/datasetmd"
-	"github.com/grafana/loki/v3/pkg/dataobj/internal/util/slicegrow"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/internal/columnar"
+	memoryv2 "github.com/grafana/loki/v3/pkg/memory"
 )
 
 // ReaderOptions customizes the behavior of a [Reader].
@@ -114,8 +114,9 @@ type Reader struct {
 	schema *arrow.Schema // Set on [Reader.Reset].
 
 	ready bool
-	inner *dataset.Reader
-	buf   []dataset.Row
+	inner *columnar.ReaderAdapter
+
+	alloc *memoryv2.Allocator
 }
 
 // NewReader creates a new Reader from the provided options. Options are not
@@ -160,63 +161,24 @@ func (r *Reader) Read(ctx context.Context, batchSize int) (arrow.RecordBatch, er
 		}
 	}
 
-	r.buf = slicegrow.GrowToCap(r.buf, batchSize)
-	r.buf = r.buf[:batchSize]
-
-	builder := array.NewRecordBuilder(r.opts.Allocator, r.schema)
-
-	n, readErr := r.inner.Read(ctx, r.buf)
-
-	// Preallocate all builders
-	for _, columnBuilder := range builder.Fields() {
-		columnBuilder.Reserve(n)
-	}
-
-	for rowIndex := range n {
-		row := r.buf[rowIndex]
-
-		for columnIndex, val := range row.Values {
-			if columnIndex >= len(r.opts.Columns) {
-				// Ignore columns that are not in projection list.
-				continue
-			}
-
-			columnBuilder := builder.Field(columnIndex)
-			columnType := r.opts.Columns[columnIndex].Type
-
-			if val.IsNil() {
-				columnBuilder.AppendNull()
-				continue
-			}
-
-			// Append non-null values. We switch on [ColumnType] here so it's easier
-			// to follow the mapping of ColumnType to Arrow type. The mappings here
-			// should align with both [columnToField] (for Arrow type) and
-			// [Builder.encodeTo] (for dataset type).
-			//
-			// Passing our byte slices to [array.StringBuilder.BinaryBuilder.Append] are safe; it
-			// will copy the contents of the value and we can reuse the buffer on the
-			// next call to [dataset.Reader.Read].
-			switch columnType {
-			case ColumnTypeInvalid:
-				columnBuilder.AppendNull() // Unsupported column
-			case ColumnTypeStreamID: // Appends IDs as int64
-				columnBuilder.(*array.Int64Builder).Append(val.Int64())
-			case ColumnTypeTimestamp: // Values are nanosecond timestamps as int64
-				columnBuilder.(*array.TimestampBuilder).Append(arrow.Timestamp(val.Int64()))
-			case ColumnTypeMetadata, ColumnTypeMessage: // Appends metadata and log lines as byte arrays
-				columnBuilder.(*array.StringBuilder).BinaryBuilder.Append(val.Binary())
-			default:
-				// We'll only hit this if we added a new column type but forgot to
-				// support reading it.
-				return nil, fmt.Errorf("unsupported column type %s for column %d", columnType, columnIndex)
-			}
+	defer r.alloc.Reclaim()
+	rb, readErr := r.inner.Read(ctx, r.alloc, batchSize)
+	if len(r.opts.Columns) < int(rb.NumCols()) {
+		// Ignore columns that are not in projection list.
+		arrs := make([]columnarv2.Array, len(r.opts.Columns))
+		for i := range arrs {
+			arrs[i] = rb.Column(int64(i))
 		}
+		rb = columnarv2.NewRecordBatch(rb.NumRows(), arrs)
+	}
+	result, err := arrowconv.ToRecordBatch(rb, r.schema)
+	if err != nil {
+		return nil, fmt.Errorf("convert columnar.RecordBatch to arrow.RecordBatch: %w", err)
 	}
 
 	// We only return readErr after processing n so that we properly handle n>0
 	// while also getting an error such as io.EOF.
-	return builder.NewRecordBatch(), readErr
+	return result, readErr
 }
 
 func (r *Reader) init(_ context.Context) error {
@@ -266,7 +228,7 @@ func (r *Reader) init(_ context.Context) error {
 		Prefetch:   true,
 	}
 	if r.inner == nil {
-		r.inner = dataset.NewReader(innerOptions)
+		r.inner = columnar.NewReaderAdapter(innerOptions)
 	} else {
 		r.inner.Reset(innerOptions)
 	}
@@ -412,6 +374,11 @@ func mustConvertType(dtype arrow.DataType) datasetmd.PhysicalType {
 // Reset discards any state and resets r with a new set of optiosn. This
 // permits reusing a Reader rather than allocating a new one.
 func (r *Reader) Reset(opts ReaderOptions) {
+	if r.alloc == nil {
+		r.alloc = memoryv2.MakeAllocator(nil)
+	} else {
+		r.alloc.Reset()
+	}
 	r.opts = opts
 	r.schema = columnsSchema(opts.Columns)
 

--- a/pkg/dataobj/sections/pointers/reader.go
+++ b/pkg/dataobj/sections/pointers/reader.go
@@ -7,15 +7,14 @@ import (
 	_ "io" // Used for documenting io.EOF.
 
 	"github.com/apache/arrow-go/v18/arrow"
-	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/apache/arrow-go/v18/arrow/scalar"
 
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/arrowconv"
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/dataset"
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/metadata/datasetmd"
-	"github.com/grafana/loki/v3/pkg/dataobj/internal/util/slicegrow"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/internal/columnar"
+	memoryv2 "github.com/grafana/loki/v3/pkg/memory"
 )
 
 // ReaderOptions customizes the behavior of a [Reader].
@@ -124,10 +123,9 @@ type Reader struct {
 	schema *arrow.Schema // Set on [Reader.Reset].
 
 	ready bool
-	inner *dataset.Reader
-	buf   []dataset.Row
+	inner *columnar.ReaderAdapter
 
-	builder *array.RecordBuilder
+	alloc *memoryv2.Allocator
 }
 
 // NewReader creates a new Reader from the provided options. Options are not
@@ -172,70 +170,16 @@ func (r *Reader) Read(ctx context.Context, batchSize int) (arrow.RecordBatch, er
 		}
 	}
 
-	r.buf = slicegrow.GrowToCap(r.buf, batchSize)
-	r.buf = r.buf[:batchSize]
-
-	n, readErr := r.inner.Read(ctx, r.buf)
-	r.builder.Reserve(n)
-	for rowIndex := range n {
-		row := r.buf[rowIndex]
-
-		for columnIndex, val := range row.Values {
-			columnBuilder := r.builder.Field(columnIndex)
-
-			if val.IsNil() {
-				columnBuilder.AppendNull()
-				continue
-			}
-
-			// Append non-null values. We switch on [ColumnType] here so it's easier
-			// to follow the mapping of ColumnType to Arrow type. The mappings here
-			// should align with both [columnToField] (for Arrow type) and
-			// [Builder.encodeTo] (for dataset type).
-			//
-			// Passing our byte slices to [array.StringBuilder.BinaryBuilder.Append] are safe; it
-			// will copy the contents of the value and we can reuse the buffer on the
-			// next call to [dataset.Reader.Read].
-			columnType := r.opts.Columns[columnIndex].Type
-			switch columnType {
-			case ColumnTypeInvalid:
-				columnBuilder.AppendNull() // Unsupported column
-			case ColumnTypePath:
-				columnBuilder.(*array.StringBuilder).BinaryBuilder.Append(val.Binary())
-			case ColumnTypeSection:
-				columnBuilder.(*array.Int64Builder).Append(val.Int64())
-			case ColumnTypePointerKind:
-				columnBuilder.(*array.Int64Builder).Append(val.Int64())
-
-			case ColumnTypeStreamID: // Appends IDs as int64
-				columnBuilder.(*array.Int64Builder).Append(val.Int64())
-			case ColumnTypeStreamIDRef:
-				columnBuilder.(*array.Int64Builder).Append(val.Int64())
-			case ColumnTypeMinTimestamp, ColumnTypeMaxTimestamp: // Values are nanosecond timestamps as int64
-				columnBuilder.(*array.TimestampBuilder).Append(arrow.Timestamp(val.Int64()))
-			case ColumnTypeRowCount:
-				columnBuilder.(*array.Int64Builder).Append(val.Int64())
-			case ColumnTypeUncompressedSize: // Appends uncompressed size as int64
-				columnBuilder.(*array.Int64Builder).Append(val.Int64())
-
-			case ColumnTypeColumnName:
-				columnBuilder.(*array.StringBuilder).BinaryBuilder.Append(val.Binary())
-			case ColumnTypeColumnIndex:
-				columnBuilder.(*array.Int64Builder).Append(val.Int64())
-			case ColumnTypeValuesBloomFilter:
-				columnBuilder.(*array.BinaryBuilder).Append(val.Binary())
-
-			default:
-				// We'll only hit this if we added a new column type but forgot to
-				// support reading it.
-				return nil, fmt.Errorf("unsupported column type %s for column %d", columnType, columnIndex)
-			}
-		}
+	defer r.alloc.Reclaim()
+	rb, readErr := r.inner.Read(ctx, r.alloc, batchSize)
+	result, err := arrowconv.ToRecordBatch(rb, r.schema)
+	if err != nil {
+		return nil, fmt.Errorf("convert columnar.RecordBatch to arrow.RecordBatch: %w", err)
 	}
 
 	// We only return readErr after processing n so that we properly handle n>0
 	// while also getting an error such as io.EOF.
-	return r.builder.NewRecordBatch(), readErr
+	return result, readErr
 }
 
 func (r *Reader) init() error {
@@ -278,13 +222,9 @@ func (r *Reader) init() error {
 		Prefetch:   true,
 	}
 	if r.inner == nil {
-		r.inner = dataset.NewReader(innerOptions)
+		r.inner = columnar.NewReaderAdapter(innerOptions)
 	} else {
 		r.inner.Reset(innerOptions)
-	}
-
-	if r.builder == nil {
-		r.builder = array.NewRecordBuilder(r.opts.Allocator, r.schema)
 	}
 
 	r.ready = true
@@ -428,6 +368,11 @@ func mustConvertType(dtype arrow.DataType) datasetmd.PhysicalType {
 // Reset discards any state and resets r with a new set of optiosn. This
 // permits reusing a Reader rather than allocating a new one.
 func (r *Reader) Reset(opts ReaderOptions) {
+	if r.alloc == nil {
+		r.alloc = memoryv2.MakeAllocator(nil)
+	} else {
+		r.alloc.Reset()
+	}
 	r.opts = opts
 	r.schema = columnsSchema(opts.Columns)
 
@@ -438,9 +383,6 @@ func (r *Reader) Reset(opts ReaderOptions) {
 		// fully reset on the next call to [Reader.init].
 		_ = r.inner.Close()
 	}
-	if r.builder != nil {
-		r.builder = nil
-	}
 }
 
 // Close closes the Reader and releases any resources it holds. Closed Readers
@@ -448,9 +390,6 @@ func (r *Reader) Reset(opts ReaderOptions) {
 func (r *Reader) Close() error {
 	if r.inner != nil {
 		return r.inner.Close()
-	}
-	if r.builder != nil {
-		r.builder = nil
 	}
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Continuation of https://github.com/grafana/loki/pull/20525, I'm updating logs, pointers, streams readers to use reader adapter. Also adding binary support to arrowconv.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
