### PR TITLE
docs: backport20546 3.5 branch

### DIFF
--- a/docs/sources/configure/_index.md
+++ b/docs/sources/configure/_index.md
@@ -13,7 +13,7 @@ Grafana Loki is configured in a YAML file (usually referred to as `loki.yaml` )
 which contains information on the Loki server and its individual components,
 depending on which mode Loki is launched in.
 
-Configuration examples can be found in the [Configuration Examples](examples/configuration-examples/) document.
+Configuration examples can be found in the [Configuration Examples](https://grafana.com/docs/loki/<LOKI_VERSION>/configure/examples/configuration-examples/) document.
 
 <!-- The shared `configuration.md` file is generated from `/docs/templates/configuration.template`. To make changes to the included content, modify the template file and run `make doc` from root directory to regenerate the shared file. -->
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Manual backport of https://github.com/grafana/loki/pull/20546 to 3.5 branch.