### PR TITLE
chore(columnartest): add testing utility package for columnar

### DIFF
--- a/pkg/columnar/columnartest/array.go
+++ b/pkg/columnar/columnartest/array.go
@@ -1,0 +1,126 @@
+package columnartest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/columnar"
+	"github.com/grafana/loki/v3/pkg/memory"
+)
+
+// Array returns an array value representing the given kind.
+//
+// Each value must either be nil (for a null value) or a Go type that can be
+// directly converted to kind. See [Scalar] for conversion rules.
+//
+// If alloc is nil, a new allocator will be created for the returned array.
+//
+// If a value cannot be represented as the kind provided, Array fails t.
+func Array(t testing.TB, kind columnar.Kind, alloc *memory.Allocator, values ...any) columnar.Array {
+	t.Helper()
+
+	if alloc == nil {
+		alloc = memory.MakeAllocator(nil)
+	}
+
+	switch kind {
+	case columnar.KindNull:
+		return arrayNull(t, alloc, values...)
+	case columnar.KindBool:
+		return arrayBool(t, alloc, values...)
+	case columnar.KindInt64:
+		return arrayNumber[int64](t, alloc, values...)
+	case columnar.KindUint64:
+		return arrayNumber[uint64](t, alloc, values...)
+	case columnar.KindUTF8:
+		return arrayUTF8(t, alloc, values...)
+	default:
+		require.FailNow(t, "unsupported kind", "kind %s is currently not supported", kind)
+		panic("unreachable")
+	}
+}
+
+func arrayNull(t testing.TB, alloc *memory.Allocator, values ...any) *columnar.Null {
+	t.Helper()
+
+	builder := columnar.NewNullBuilder(alloc)
+	builder.Grow(len(values))
+
+	for _, value := range values {
+		require.Nil(t, value, "all values must be nil for null array")
+		builder.AppendNull()
+	}
+
+	return builder.Build()
+}
+
+func arrayBool(t testing.TB, alloc *memory.Allocator, values ...any) *columnar.Bool {
+	t.Helper()
+
+	builder := columnar.NewBoolBuilder(alloc)
+	builder.Grow(len(values))
+
+	for _, value := range values {
+		if value == nil {
+			builder.AppendNull()
+			continue
+		}
+
+		require.IsType(t, false, value, "all values must be nil or bool for bool array")
+		builder.AppendValue(value.(bool))
+	}
+
+	return builder.Build()
+}
+
+func arrayNumber[T columnar.Numeric](t testing.TB, alloc *memory.Allocator, values ...any) *columnar.Number[T] {
+	t.Helper()
+
+	builder := columnar.NewNumberBuilder[T](alloc)
+	builder.Grow(len(values))
+
+	for _, value := range values {
+		if value == nil {
+			builder.AppendNull()
+			continue
+		}
+
+		switch value := value.(type) {
+		case int:
+			builder.AppendValue(T(value))
+		case T:
+			builder.AppendValue(value)
+		default:
+			var zero T
+			require.FailNow(t, "unexpected value type", "all values must be nil, %T, or int for %T array", zero, zero)
+		}
+	}
+
+	return builder.Build()
+}
+
+func arrayUTF8(t testing.TB, alloc *memory.Allocator, values ...any) *columnar.UTF8 {
+	t.Helper()
+
+	builder := columnar.NewUTF8Builder(alloc)
+	builder.Grow(len(values))
+
+	for _, value := range values {
+		if value == nil {
+			builder.AppendNull()
+			continue
+		}
+
+		switch value := value.(type) {
+		case string:
+			builder.AppendValue([]byte(value))
+		case []byte:
+			builder.AppendValue(value)
+		default:
+			require.FailNow(t, "unexpected value type", "all values must be nil, []byte, or string for UTF8 array, found %T", value)
+		}
+	}
+
+	return builder.Build()
+}

--- a/pkg/columnar/columnartest/equality.go
+++ b/pkg/columnar/columnartest/equality.go
@@ -1,0 +1,89 @@
+package columnartest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/columnar"
+)
+
+// RequireDatumsEqual asserts that the provided datum matches the expected
+// datum, otherwise t fails.
+func RequireDatumsEqual(t testing.TB, expect, actual columnar.Datum) {
+	t.Helper()
+
+	if expectScalar, ok := expect.(columnar.Scalar); ok {
+		require.Implements(t, (*columnar.Scalar)(nil), actual)
+		RequireScalarsEqual(t, expectScalar, actual.(columnar.Scalar))
+	} else {
+		require.Implements(t, (*columnar.Array)(nil), actual)
+		RequireArraysEqual(t, expect.(columnar.Array), actual.(columnar.Array))
+	}
+}
+
+// RequireScalarsEqual asserts that the provided scalar matches the expected
+// scalar, otherwise t fails.
+func RequireScalarsEqual(t testing.TB, expect, actual columnar.Scalar) {
+	t.Helper()
+
+	require.Equal(t, expect.Kind(), actual.Kind(), "kind mismatch")
+	require.Equal(t, expect.IsNull(), actual.IsNull(), "null mismatch")
+
+	if expect.IsNull() {
+		// We don't want to compare values when expect is null, as the Value
+		// field is undefined when the scalar is null.
+		return
+	}
+
+	require.Equal(t, expect, actual)
+}
+
+// RequireArraysEqual asserts that the provided array matches the expected
+// array, otherwise t fails.
+func RequireArraysEqual(t testing.TB, expect, actual columnar.Array) {
+	t.Helper()
+
+	require.Equal(t, expect.Kind(), actual.Kind(), "kind mismatch")
+	require.Equal(t, expect.Len(), actual.Len(), "length mismatch")
+	require.Equal(t, expect.Nulls(), actual.Nulls(), "null count mismatch")
+
+	switch expect.Kind() {
+	case columnar.KindNull:
+		requireNullArraysEqual(t, expect.(*columnar.Null), actual.(*columnar.Null))
+	case columnar.KindBool:
+		requireArraysEqual(t, expect.(*columnar.Bool), actual.(*columnar.Bool))
+	case columnar.KindInt64:
+		requireArraysEqual(t, expect.(*columnar.Number[int64]), actual.(*columnar.Number[int64]))
+	case columnar.KindUint64:
+		requireArraysEqual(t, expect.(*columnar.Number[uint64]), actual.(*columnar.Number[uint64]))
+	case columnar.KindUTF8:
+		requireArraysEqual(t, expect.(*columnar.UTF8), actual.(*columnar.UTF8))
+	}
+}
+
+func requireNullArraysEqual(t testing.TB, left, right *columnar.Null) {
+	// Nothing to do here; the base checks in RequireArraysEqual covers
+	// everything that could differ between two null arrays.
+	t.Helper()
+}
+
+// valueArray is a generic representation of an Array that supports a Get(int)
+// method to get a specific value at the given index.
+type valueArray[T any] interface {
+	Len() int
+	IsNull(i int) bool
+	Get(i int) T
+}
+
+func requireArraysEqual[T any](t testing.TB, left, right valueArray[T]) {
+	t.Helper()
+
+	for i := range left.Len() {
+		require.Equal(t, left.IsNull(i), right.IsNull(i), "null mismatch at index %d", i)
+		if left.IsNull(i) || right.IsNull(i) {
+			continue
+		}
+		require.Equal(t, left.Get(i), right.Get(i), "value mismatch at index %d", i)
+	}
+}

--- a/pkg/columnar/columnartest/scalar.go
+++ b/pkg/columnar/columnartest/scalar.go
@@ -1,0 +1,96 @@
+package columnartest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/columnar"
+)
+
+// Scalar returns a scalar value representing the given kind.
+//
+// value must either be nil (meaning a null scalar value) or a type which can
+// directly be converted to kind:
+//
+//   - nil for [columnar.KindNull]
+//   - bool for [columnar.KindBool]
+//   - int64 for [columnar.KindInt64]
+//   - uint64 for [columnar.KindUint64]
+//   - string or a byte slice for [columnar.KindUTF8]
+//
+// If value cannot be represented as the kind provided, Scalar fails t.
+func Scalar(t testing.TB, kind columnar.Kind, value any) columnar.Scalar {
+	t.Helper()
+
+	switch kind {
+	case columnar.KindNull:
+		return scalarNull(t, value)
+	case columnar.KindBool:
+		return scalarBool(t, value)
+	case columnar.KindInt64:
+		return scalarNumber[int64](t, value)
+	case columnar.KindUint64:
+		return scalarNumber[uint64](t, value)
+	case columnar.KindUTF8:
+		return scalarUTF8(t, value)
+	default:
+		require.FailNow(t, "unsupported kind", "kind %s is currently not supported", kind)
+		panic("unreachable")
+	}
+}
+
+func scalarNull(t testing.TB, value any) *columnar.NullScalar {
+	t.Helper()
+
+	require.Nil(t, value, "value must be nil for null scalar")
+	return &columnar.NullScalar{}
+}
+
+func scalarBool(t testing.TB, value any) *columnar.BoolScalar {
+	t.Helper()
+
+	if value == nil {
+		return &columnar.BoolScalar{Null: true}
+	}
+
+	require.IsType(t, false, value, "value must be nil or bool for bool scalar")
+	return &columnar.BoolScalar{Value: value.(bool)}
+}
+
+func scalarNumber[T columnar.Numeric](t testing.TB, value any) *columnar.NumberScalar[T] {
+	t.Helper()
+
+	if value == nil {
+		return &columnar.NumberScalar[T]{Null: true}
+	}
+
+	switch value := value.(type) {
+	case int:
+		return &columnar.NumberScalar[T]{Value: T(value)}
+	case T:
+		return &columnar.NumberScalar[T]{Value: value}
+	}
+
+	var zero T
+	require.FailNow(t, "unexpected value type", "value must be nil, %T, or int for %T scalar", zero, zero)
+	panic("unreachable")
+}
+
+func scalarUTF8(t testing.TB, value any) *columnar.UTF8Scalar {
+	t.Helper()
+
+	if value == nil {
+		return &columnar.UTF8Scalar{Null: true}
+	}
+
+	switch value := value.(type) {
+	case []byte:
+		return &columnar.UTF8Scalar{Value: value}
+	case string:
+		return &columnar.UTF8Scalar{Value: []byte(value)}
+	}
+
+	require.FailNow(t, "unexpected value type", "value must be nil, []byte, or string for UTF8 scalar, got %T", value)
+	panic("unreachable")
+}


### PR DESCRIPTION
columnartest makes it easier for tests to create instances of columnar.Array and columnar.Scalar for test setups and to assert two arrays or scalars are equal. The concatenation test in pkg/columnar is updated to use the new package.

This was originally written for #20575, where it's currently in use (and makes testing much simpler), but I'm splitting this out into its own PR so #20584 can make use of it.