### PR TITLE
perf(dataobj): Optimize estimate size calculation

### DIFF
--- a/pkg/dataobj/index/indexobj/builder.go
+++ b/pkg/dataobj/index/indexobj/builder.go
@@ -111,6 +111,8 @@ func (b *Builder) getIndexPointerBuilderForTenant(tenantID string) *indexpointer
 	tenantIndexPointers = indexpointers.NewBuilder(b.metrics.indexPointers, int(b.cfg.TargetPageSize), b.cfg.MaxPageRows)
 	tenantIndexPointers.SetTenant(tenantID)
 
+	b.indexPointers[tenantID] = tenantIndexPointers
+
 	return tenantIndexPointers
 }
 
@@ -153,6 +155,7 @@ func (b *Builder) getStreamsBuilderForTenant(tenantID string) *streams.Builder {
 
 	tenantStreams = streams.NewBuilder(b.metrics.streams, int(b.cfg.TargetPageSize), b.cfg.MaxPageRows)
 	tenantStreams.SetTenant(tenantID)
+
 	b.streams[tenantID] = tenantStreams
 
 	return tenantStreams
@@ -213,6 +216,7 @@ func (b *Builder) getPointersBuilderForTenant(tenantID string) *pointers.Builder
 
 	tenantPointers = pointers.NewBuilder(b.metrics.pointers, int(b.cfg.TargetPageSize), b.cfg.MaxPageRows)
 	tenantPointers.SetTenant(tenantID)
+
 	b.pointers[tenantID] = tenantPointers
 
 	return tenantPointers

--- a/pkg/dataobj/index/indexobj/builder_test.go
+++ b/pkg/dataobj/index/indexobj/builder_test.go
@@ -174,6 +174,16 @@ func TestBuilder_AppendIndexPointer(t *testing.T) {
 	}
 }
 
+func TestBuilder_ObserveLogLine(t *testing.T) {
+	builder, err := NewBuilder(testBuilderConfig, nil)
+	require.NoError(t, err)
+
+	err = builder.ObserveLogLine(testTenant, "test/path", 1, 1, 1, time.Unix(10, 0).UTC(), 100)
+	require.NoError(t, err)
+
+	require.Greater(t, builder.estimatedSize(), 0)
+}
+
 func BenchmarkIndexObjBuilder_ObserveLogLine(b *testing.B) {
 	builder, err := NewBuilder(testBuilderConfig, nil)
 	require.NoError(b, err)


### PR DESCRIPTION
**What this PR does / why we need it**:
Index-building with lots of tenants was spending a huge amount of time calculating estimated sizes. This PR significantly reduces the time spent here.

Before Profile
<img width="1059" height="675" alt="image" src="https://github.com/user-attachments/assets/8d9ec9e5-60c0-47bb-b778-c247c10a14ee" />


* Why? On every Append to the builders, it was iterating through every tenant and calculating the estimated size, even though most of them don't change. 
* Instead, I just store the diff in size after each change which makes the estimated size function very simple and quick.

Benchstat
```
goos: darwin
goarch: arm64
pkg: github.com/grafana/loki/v3/pkg/dataobj/index/indexobj
cpu: Apple M3 Max
                                  │  before.txt  │              after.txt              │
                                  │    sec/op    │   sec/op     vs base                │
IndexObjBuilder_ObserveLogLine-14   9233.0µ ± 2%   224.4µ ± 2%  -97.57% (p=0.000 n=10)

                                  │  before.txt   │              after.txt               │
                                  │     B/op      │     B/op      vs base                │
IndexObjBuilder_ObserveLogLine-14   77.693Ki ± 2%   2.050Ki ± 3%  -97.36% (p=0.000 n=10)

                                  │ before.txt  │             after.txt              │
                                  │  allocs/op  │ allocs/op   vs base                │
IndexObjBuilder_ObserveLogLine-14   40.000 ± 3%   1.000 ± 0%  -97.50% (p=0.000 n=10)
```
