### PR TITLE
fix: Pass MergePrefetchCount down to executor in worker

### DIFF
--- a/pkg/engine/internal/worker/thread.go
+++ b/pkg/engine/internal/worker/thread.go
@@ -52,11 +52,12 @@ func (s threadState) String() string {
 
 // thread represents a worker thread that executes one task at a time.
 type thread struct {
-	BatchSize      int64
-	Bucket         objstore.Bucket
-	Metastore      metastore.Metastore
-	Logger         log.Logger
-	StreamFilterer executor.RequestStreamFilterer
+	BatchSize         int64
+	MergePrefetchCount int
+	Bucket            objstore.Bucket
+	Metastore         metastore.Metastore
+	Logger            log.Logger
+	StreamFilterer    executor.RequestStreamFilterer
 
 	Metrics    *metrics
 	JobManager *jobManager
@@ -119,10 +120,11 @@ func (t *thread) runJob(ctx context.Context, job *threadJob) {
 	)
 
 	cfg := executor.Config{
-		BatchSize:      t.BatchSize,
-		Bucket:         bucket.NewXCapBucket(t.Bucket),
-		Metastore:      t.Metastore,
-		StreamFilterer: t.StreamFilterer,
+		BatchSize:         t.BatchSize,
+		MergePrefetchCount: t.MergePrefetchCount,
+		Bucket:            bucket.NewXCapBucket(t.Bucket),
+		Metastore:         t.Metastore,
+		StreamFilterer:    t.StreamFilterer,
 
 		GetExternalInputs: func(_ context.Context, node physical.Node) []executor.Pipeline {
 			streams := job.Task.Sources[node]

--- a/pkg/engine/internal/worker/worker.go
+++ b/pkg/engine/internal/worker/worker.go
@@ -64,6 +64,10 @@ type Config struct {
 	// read call of a task pipeline.
 	BatchSize int64
 
+	// MergePrefetchCount controls how many Merge inputs are prefetched simultaneously
+	// (same semantics as executor.MergePrefetchCount).
+	MergePrefetchCount int
+
 	// NumThreads is the number of worker threads to spawn. The number of
 	// threads corresponds to the number of tasks that can be executed
 	// concurrently.
@@ -185,11 +189,12 @@ func (w *Worker) run(ctx context.Context) error {
 	var threads []*thread
 	for i := range w.numThreads {
 		t := &thread{
-			BatchSize:      w.config.BatchSize,
-			Logger:         log.With(w.logger, "thread", i),
-			Bucket:         w.config.Bucket,
-			Metastore:      w.config.Metastore,
-			StreamFilterer: w.config.StreamFilterer,
+			BatchSize:         w.config.BatchSize,
+			MergePrefetchCount: w.config.MergePrefetchCount,
+			Logger:            log.With(w.logger, "thread", i),
+			Bucket:            w.config.Bucket,
+			Metastore:         w.config.Metastore,
+			StreamFilterer:    w.config.StreamFilterer,
 
 			Metrics:    w.metrics,
 			JobManager: w.jobManager,

--- a/pkg/engine/worker.go
+++ b/pkg/engine/worker.go
@@ -136,8 +136,9 @@ func NewWorker(params WorkerParams) (*Worker, error) {
 		SchedulerLookupAddress:  params.Config.SchedulerLookupAddress,
 		SchedulerLookupInterval: params.Config.SchedulerLookupInterval,
 
-		BatchSize:  int64(params.Executor.BatchSize),
-		NumThreads: params.Config.WorkerThreads,
+		BatchSize:          int64(params.Executor.BatchSize),
+		MergePrefetchCount: params.Executor.MergePrefetchCount,
+		NumThreads:         params.Config.WorkerThreads,
 
 		Endpoint: params.Endpoint,
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR forwards the configured `MergePrefetchCount` (`query-engine.merge-prefetch-count`) to the worker config so it gets applied on Merge pipelines when running queries in distributed mode.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
