### PR TITLE
chore: Adjust parameters for building dataobj in logql benchmarks

### DIFF
--- a/pkg/logql/bench/store_dataobj.go
+++ b/pkg/logql/bench/store_dataobj.go
@@ -77,8 +77,8 @@ func NewDataObjStore(dir, tenant string) (*DataObjStore, error) {
 		BuilderBaseConfig: logsobj.BuilderBaseConfig{
 			TargetPageSize:          2 * 1024 * 1024, // 2MB
 			MaxPageRows:             1000,
-			TargetObjectSize:        128 * 1024 * 1024, // 128MB
-			TargetSectionSize:       16 * 1024 * 1024,  // 16MB
+			TargetObjectSize:        256 * 1024 * 1024, // 256MB
+			TargetSectionSize:       64 * 1024 * 1024,  // 64MB
 			BufferSize:              16 * 1024 * 1024,  // 16MB
 			SectionStripeMergeLimit: 2,
 		},

--- a/pkg/logql/bench/store_dataobj.go
+++ b/pkg/logql/bench/store_dataobj.go
@@ -76,7 +76,7 @@ func NewDataObjStore(dir, tenant string) (*DataObjStore, error) {
 	builder, err := logsobj.NewBuilder(logsobj.BuilderConfig{
 		BuilderBaseConfig: logsobj.BuilderBaseConfig{
 			TargetPageSize:          2 * 1024 * 1024, // 2MB
-			MaxPageRows:             1000,
+			MaxPageRows:             8192,
 			TargetObjectSize:        256 * 1024 * 1024, // 256MB
 			TargetSectionSize:       64 * 1024 * 1024,  // 64MB
 			BufferSize:              16 * 1024 * 1024,  // 16MB


### PR DESCRIPTION
**What this PR does / why we need it**:
The previous configuration generated 88 sections for 2GB of test data
This configuration generates 23 sections for 2 GB of test data.

I think this is still enough to do the distributed work and figure out correctness, but I'm hoping they run a little faster because theres less tiny sections to read.