### PR TITLE
chore: clean up consumer metrics

### DIFF
--- a/pkg/dataobj/consumer/metrics.go
+++ b/pkg/dataobj/consumer/metrics.go
@@ -3,46 +3,54 @@ package consumer
 import (
 	"time"
 
-	"go.uber.org/atomic"
-
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
-type partitionOffsetMetrics struct {
-	currentOffset prometheus.GaugeFunc
-	lastOffset    atomic.Int64
-
-	// Error counters
+type metrics struct {
+	lastOffset     prometheus.Gauge
+	consumptionLag prometheus.Gauge
+	receivedBytes  prometheus.Counter
+	discardedBytes prometheus.Counter
+	records        prometheus.Counter
+	recordFailures prometheus.Counter
+	commits        prometheus.Counter
 	commitFailures prometheus.Counter
-	appendFailures prometheus.Counter
 
-	// Request counters
-	commitsTotal prometheus.Counter
-
-	latestDelay      prometheus.Gauge // Latest delta between record timestamp and current time
-	processedRecords prometheus.Counter
+	// Deprecated, will be removed in two weeklies.
+	latestDelay      prometheus.Gauge
+	currentOffset    prometheus.Gauge
 	processedBytes   prometheus.Counter
+	processedRecords prometheus.Counter
 }
 
-func newPartitionOffsetMetrics() *partitionOffsetMetrics {
-	p := &partitionOffsetMetrics{
-		appendFailures: prometheus.NewCounter(prometheus.CounterOpts{
-			Name: "loki_dataobj_consumer_append_failures_total",
-			Help: "Total number of append failures",
+func newMetrics(r prometheus.Registerer) *metrics {
+	return &metrics{
+		lastOffset: promauto.With(r).NewGauge(prometheus.GaugeOpts{
+			Name: "loki_dataobj_consumer_last_offset",
+			Help: "The last consumed offset.",
 		}),
-		latestDelay: prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: "loki_dataobj_consumer_latest_processing_delay_seconds",
-			Help: "Latest time difference bweteen record timestamp and processing time in seconds",
+		consumptionLag: promauto.With(r).NewGauge(prometheus.GaugeOpts{
+			Name: "loki_dataobj_consumer_consumption_lag_seconds",
+			Help: "The time difference between the last consumed offset and the current time in seconds.",
 		}),
-		processedRecords: prometheus.NewCounter(prometheus.CounterOpts{
-			Name: "loki_dataobj_consumer_processed_records_total",
-			Help: "Total number of records processed.",
+		receivedBytes: promauto.With(r).NewCounter(prometheus.CounterOpts{
+			Name: "loki_dataobj_consumer_received_bytes_total",
+			Help: "The sum of bytes in all Kafka records.",
 		}),
-		processedBytes: prometheus.NewCounter(prometheus.CounterOpts{
-			Name: "loki_dataobj_consumer_processed_bytes_total",
-			Help: "Total number of bytes processed.",
+		discardedBytes: promauto.With(r).NewCounter(prometheus.CounterOpts{
+			Name: "loki_dataobj_consumer_discarded_bytes_total",
+			Help: "The sum of discarded bytes from corrupted or unprocessable Kafka records.",
 		}),
-		commitsTotal: prometheus.NewCounter(prometheus.CounterOpts{
+		records: promauto.With(r).NewCounter(prometheus.CounterOpts{
+			Name: "loki_dataobj_consumer_records_total",
+			Help: "Total number of records received.",
+		}),
+		recordFailures: promauto.With(r).NewCounter(prometheus.CounterOpts{
+			Name: "loki_dataobj_consumer_record_failures_total",
+			Help: "Total number of records that failed to be processed.",
+		}),
+		commits: prometheus.NewCounter(prometheus.CounterOpts{
 			Name: "loki_dataobj_consumer_commits_total",
 			Help: "Total number of commits",
 		}),
@@ -50,73 +58,33 @@ func newPartitionOffsetMetrics() *partitionOffsetMetrics {
 			Name: "loki_dataobj_consumer_commit_failures_total",
 			Help: "Total number of commit failures",
 		}),
-	}
-
-	p.currentOffset = prometheus.NewGaugeFunc(
-		prometheus.GaugeOpts{
+		// TODO(grobinson): Remove after two minor releases.
+		latestDelay: promauto.With(r).NewGauge(prometheus.GaugeOpts{
+			Name: "loki_dataobj_consumer_latest_processing_delay_seconds",
+			Help: "Latest time difference bweteen record timestamp and processing time in seconds",
+		}),
+		currentOffset: promauto.With(r).NewGauge(prometheus.GaugeOpts{
 			Name: "loki_dataobj_consumer_current_offset",
-			Help: "The last consumed offset for this partition",
-		},
-		p.getCurrentOffset,
-	)
-
-	return p
-}
-
-func (p *partitionOffsetMetrics) getCurrentOffset() float64 {
-	return float64(p.lastOffset.Load())
-}
-
-func (p *partitionOffsetMetrics) register(reg prometheus.Registerer) error {
-	collectors := []prometheus.Collector{
-		p.appendFailures,
-		p.latestDelay,
-		p.processedRecords,
-		p.processedBytes,
-		p.currentOffset,
-		p.commitsTotal,
-		p.commitFailures,
-	}
-
-	for _, collector := range collectors {
-		if err := reg.Register(collector); err != nil {
-			if _, ok := err.(prometheus.AlreadyRegisteredError); !ok {
-				return err
-			}
-		}
-	}
-	return nil
-}
-
-func (p *partitionOffsetMetrics) unregister(reg prometheus.Registerer) {
-	collectors := []prometheus.Collector{
-		p.appendFailures,
-		p.latestDelay,
-		p.processedRecords,
-		p.processedBytes,
-		p.currentOffset,
-		p.commitsTotal,
-		p.commitFailures,
-	}
-
-	for _, collector := range collectors {
-		reg.Unregister(collector)
+			Help: "The last consumed offset.",
+		}),
+		processedBytes: promauto.With(r).NewCounter(prometheus.CounterOpts{
+			Name: "loki_dataobj_consumer_processed_bytes_total",
+			Help: "The sum of bytes in all Kafka records.",
+		}),
+		processedRecords: promauto.With(r).NewCounter(prometheus.CounterOpts{
+			Name: "loki_dataobj_consumer_processed_records_total",
+			Help: "The total number of Kafka records.",
+		}),
 	}
 }
 
-func (p *partitionOffsetMetrics) updateOffset(offset int64) {
-	p.lastOffset.Store(offset)
+func (m *metrics) setLastOffset(offset int64) {
+	m.lastOffset.Set(float64(offset))
+	m.currentOffset.Set(float64(offset))
 }
 
-func (p *partitionOffsetMetrics) incAppendFailures() {
-	p.appendFailures.Inc()
-}
-
-func (p *partitionOffsetMetrics) observeProcessingDelay(recordTimestamp time.Time) {
-	// Convert milliseconds to seconds and calculate delay
-	if !recordTimestamp.IsZero() { // Only observe if timestamp is valid
-		delay := time.Since(recordTimestamp).Seconds()
-
-		p.latestDelay.Set(delay)
-	}
+func (m *metrics) setConsumptionLag(d time.Duration) {
+	secs := float64(d.Seconds())
+	m.consumptionLag.Set(secs)
+	m.latestDelay.Set(secs)
 }

--- a/pkg/dataobj/consumer/processor_test.go
+++ b/pkg/dataobj/consumer/processor_test.go
@@ -50,7 +50,7 @@ func TestPartitionProcessor_BuilderMaxAge(t *testing.T) {
 
 		// Process a record containing some log lines. No flush should occur because
 		// the builder has not reached the maximum age.
-		proc.processRecord(ctx, newTestRecord(t, "tenant1", time.Now()))
+		require.NoError(t, proc.processRecord(ctx, newTestRecord(t, "tenant1", time.Now())))
 
 		// The first append time should be set to the current time, but no flush
 		// should have occurred.
@@ -62,7 +62,7 @@ func TestPartitionProcessor_BuilderMaxAge(t *testing.T) {
 		// the log lines from the record should be appended to the next data
 		// object, not the one that was just flushed.
 		time.Sleep(31 * time.Minute)
-		proc.processRecord(ctx, newTestRecord(t, "tenant1", time.Now()))
+		require.NoError(t, proc.processRecord(ctx, newTestRecord(t, "tenant1", time.Now())))
 
 		// The last flushed time should be updated to the current time, and so should
 		// the first append time to reflect the start of the new data object.
@@ -75,7 +75,7 @@ func TestPartitionProcessor_BuilderMaxAge(t *testing.T) {
 		// occur because the next builder has not reached the maximum age.
 		expectedLastFlushed := time.Now()
 		time.Sleep(time.Minute)
-		proc.processRecord(ctx, newTestRecord(t, "tenant1", time.Now()))
+		require.NoError(t, proc.processRecord(ctx, newTestRecord(t, "tenant1", time.Now())))
 		require.Equal(t, expectedLastFlushed, proc.firstAppend)
 		require.Equal(t, time.Now(), proc.lastAppend)
 		require.Equal(t, 1, flusher.flushes)
@@ -109,7 +109,7 @@ func TestPartitionProcessor_IdleFlush(t *testing.T) {
 
 		// Process a record containing some log lines. No flush should occur because
 		// when log lines are appended to the builder it resets the idle timeout.
-		proc.processRecord(ctx, newTestRecord(t, "tenant1", time.Now()))
+		require.NoError(t, proc.processRecord(ctx, newTestRecord(t, "tenant1", time.Now())))
 		require.False(t, proc.lastAppend.IsZero())
 		flushed, err = proc.idleFlush(ctx)
 		require.NoError(t, err)
@@ -150,10 +150,10 @@ func TestPartitionProcessor_Flush(t *testing.T) {
 
 			// Process a record containing some log lines. No flush should occur.
 			rec1 := newTestRecord(t, "tenant", time.Now())
-			proc.processRecord(ctx, rec1)
+			require.NoError(t, proc.processRecord(ctx, rec1))
 			require.Equal(t, time.Now(), proc.firstAppend)
 			require.Equal(t, time.Now(), proc.lastAppend)
-			require.Equal(t, rec1.Offset, proc.offset)
+			require.Equal(t, rec1.Offset, proc.lastOffset)
 
 			// Advance time and force a flush.
 			time.Sleep(time.Second)
@@ -185,10 +185,10 @@ func TestPartitionProcessor_Flush(t *testing.T) {
 
 			// Process a record containing some log lines. No flush should occur.
 			rec := newTestRecord(t, "tenant", time.Now())
-			proc.processRecord(ctx, rec)
+			require.NoError(t, proc.processRecord(ctx, rec))
 			require.Equal(t, time.Now(), proc.firstAppend)
 			require.Equal(t, time.Now(), proc.lastAppend)
-			require.Equal(t, rec.Offset, proc.offset)
+			require.Equal(t, rec.Offset, proc.lastOffset)
 
 			// Advance time and force a flush. This flush should fail.
 			time.Sleep(time.Second)


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request cleans up the consumer metrics. It cleans up some semantic ambiguities in the metric names, and marks deprecated metrics for later removal so we can update dashboards and autoscaling queries after two minor releases.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
