### PR TITLE
chore(dataobj): rename dataset.Reader to RowReader

### DIFF
--- a/pkg/dataobj/consumer/logsobj/sort.go
+++ b/pkg/dataobj/consumer/logsobj/sort.go
@@ -32,7 +32,7 @@ func sortMergeIterator(ctx context.Context, sections []*dataobj.Section, sort lo
 			return nil, err
 		}
 
-		r := dataset.NewReader(dataset.ReaderOptions{
+		r := dataset.NewRowReader(dataset.ReaderOptions{
 			Dataset:  ds,
 			Columns:  columns,
 			Prefetch: true,

--- a/pkg/dataobj/internal/dataset/predicate.go
+++ b/pkg/dataobj/internal/dataset/predicate.go
@@ -6,7 +6,7 @@ import (
 	"unsafe"
 )
 
-// Predicate is an expression used to filter rows in a [Reader].
+// Predicate is an expression used to filter rows in a [RowReader].
 type Predicate interface{ isPredicate() }
 
 // Suppported predicates..

--- a/pkg/dataobj/sections/indexpointers/iter.go
+++ b/pkg/dataobj/sections/indexpointers/iter.go
@@ -50,7 +50,7 @@ func IterSection(ctx context.Context, section *Section) result.Seq[IndexPointer]
 			return err
 		}
 
-		r := dataset.NewReader(dataset.ReaderOptions{
+		r := dataset.NewRowReader(dataset.ReaderOptions{
 			Dataset:  dset,
 			Columns:  columns,
 			Prefetch: true,

--- a/pkg/dataobj/sections/indexpointers/row_reader.go
+++ b/pkg/dataobj/sections/indexpointers/row_reader.go
@@ -21,7 +21,7 @@ type RowReader struct {
 
 	buf []dataset.Row
 
-	reader  *dataset.Reader
+	reader  *dataset.RowReader
 	columns []dataset.Column
 
 	symbols *symbolizer.Symbolizer
@@ -104,7 +104,7 @@ func (r *RowReader) initReader() error {
 	}
 
 	if r.reader == nil {
-		r.reader = dataset.NewReader(readerOpts)
+		r.reader = dataset.NewRowReader(readerOpts)
 	} else {
 		r.reader.Reset(readerOpts)
 	}

--- a/pkg/dataobj/sections/internal/columnar/columnar_test.go
+++ b/pkg/dataobj/sections/internal/columnar/columnar_test.go
@@ -96,7 +96,7 @@ func readDataset(t *testing.T, obj *dataobj.Object) []dataset.Row {
 	dset, err := columnar.MakeDataset(sec, sec.Columns())
 	require.NoError(t, err)
 
-	reader := dataset.NewReader(dataset.ReaderOptions{
+	reader := dataset.NewRowReader(dataset.ReaderOptions{
 		Dataset: dset,
 		Columns: dset.Columns(),
 	})

--- a/pkg/dataobj/sections/internal/columnar/reader_adapter.go
+++ b/pkg/dataobj/sections/internal/columnar/reader_adapter.go
@@ -15,7 +15,7 @@ import (
 // [columnar.RecordBatch] values from a reader that only supports reads through
 // a slice of [dataset.Row].
 type ReaderAdapter struct {
-	inner    *dataset.Reader
+	inner    *dataset.RowReader
 	colTypes []datasetmd.PhysicalType
 
 	buf []dataset.Row
@@ -23,7 +23,7 @@ type ReaderAdapter struct {
 
 // NewReaderAdapter creates a ReaderAdapter with the provided dataset reader options.
 func NewReaderAdapter(innerOpts dataset.ReaderOptions) *ReaderAdapter {
-	r := &ReaderAdapter{inner: dataset.NewReader(innerOpts)}
+	r := &ReaderAdapter{inner: dataset.NewRowReader(innerOpts)}
 	r.Reset(innerOpts)
 	return r
 }

--- a/pkg/dataobj/sections/logs/iter.go
+++ b/pkg/dataobj/sections/logs/iter.go
@@ -51,7 +51,7 @@ func IterSection(ctx context.Context, section *Section) result.Seq[Record] {
 			return err
 		}
 
-		r := dataset.NewReader(dataset.ReaderOptions{
+		r := dataset.NewRowReader(dataset.ReaderOptions{
 			Dataset:  dset,
 			Columns:  columns,
 			Prefetch: true,

--- a/pkg/dataobj/sections/logs/row_reader.go
+++ b/pkg/dataobj/sections/logs/row_reader.go
@@ -27,7 +27,7 @@ type RowReader struct {
 
 	buf []dataset.Row
 
-	reader  *dataset.Reader
+	reader  *dataset.RowReader
 	columns []dataset.Column
 
 	symbols *symbolizer.Symbolizer
@@ -149,7 +149,7 @@ func (r *RowReader) initReader() error {
 	}
 
 	if r.reader == nil {
-		r.reader = dataset.NewReader(readerOpts)
+		r.reader = dataset.NewRowReader(readerOpts)
 	} else {
 		r.reader.Reset(readerOpts)
 	}

--- a/pkg/dataobj/sections/logs/table_merge.go
+++ b/pkg/dataobj/sections/logs/table_merge.go
@@ -69,7 +69,7 @@ func mergeTables(buf *tableBuffer, pageSize, pageRowCount int, compressionOpts *
 			return nil, err
 		}
 
-		r := dataset.NewReader(dataset.ReaderOptions{
+		r := dataset.NewRowReader(dataset.ReaderOptions{
 			Dataset: t,
 			Columns: dsetColumns,
 
@@ -150,7 +150,7 @@ var _ loser.Sequence = (*tableSequence)(nil)
 func tableSequenceAt(seq *tableSequence) result.Result[dataset.Row] { return seq.At() }
 func tableSequenceClose(seq *tableSequence)                         { seq.Close() }
 
-func NewDatasetSequence(r *dataset.Reader, bufferSize int) DatasetSequence {
+func NewDatasetSequence(r *dataset.RowReader, bufferSize int) DatasetSequence {
 	return DatasetSequence{
 		r:   r,
 		buf: make([]dataset.Row, bufferSize),
@@ -160,7 +160,7 @@ func NewDatasetSequence(r *dataset.Reader, bufferSize int) DatasetSequence {
 type DatasetSequence struct {
 	curValue result.Result[dataset.Row]
 
-	r *dataset.Reader
+	r *dataset.RowReader
 
 	buf  []dataset.Row
 	off  int // Offset into buf

--- a/pkg/dataobj/sections/logs/table_test.go
+++ b/pkg/dataobj/sections/logs/table_test.go
@@ -109,7 +109,7 @@ func Test_mergeTables(t *testing.T) {
 
 			var actual []string
 
-			r := dataset.NewReader(dataset.ReaderOptions{
+			r := dataset.NewRowReader(dataset.ReaderOptions{
 				Dataset: mergedTable,
 				Columns: mergedColumns,
 			})
@@ -155,7 +155,7 @@ func Test_table_backfillMetadata(t *testing.T) {
 	columns, err := result.Collect(table.ListColumns(context.Background()))
 	require.NoError(t, err)
 
-	r := dataset.NewReader(dataset.ReaderOptions{
+	r := dataset.NewRowReader(dataset.ReaderOptions{
 		Dataset: table,
 		Columns: columns,
 	})

--- a/pkg/dataobj/sections/pointers/iter.go
+++ b/pkg/dataobj/sections/pointers/iter.go
@@ -51,7 +51,7 @@ func IterSection(ctx context.Context, section *Section) result.Seq[SectionPointe
 			return err
 		}
 
-		r := dataset.NewReader(dataset.ReaderOptions{
+		r := dataset.NewRowReader(dataset.ReaderOptions{
 			Dataset:  dset,
 			Columns:  columns,
 			Prefetch: true,

--- a/pkg/dataobj/sections/pointers/row_reader.go
+++ b/pkg/dataobj/sections/pointers/row_reader.go
@@ -28,7 +28,7 @@ type RowReader struct {
 
 	buf []dataset.Row
 
-	reader  *dataset.Reader
+	reader  *dataset.RowReader
 	columns []dataset.Column
 
 	symbols *symbolizer.Symbolizer
@@ -137,7 +137,7 @@ func (r *RowReader) initReader() error {
 	}
 
 	if r.reader == nil {
-		r.reader = dataset.NewReader(readerOpts)
+		r.reader = dataset.NewRowReader(readerOpts)
 	} else {
 		r.reader.Reset(readerOpts)
 	}

--- a/pkg/dataobj/sections/streams/iter.go
+++ b/pkg/dataobj/sections/streams/iter.go
@@ -51,7 +51,7 @@ func IterSection(ctx context.Context, section *Section) result.Seq[Stream] {
 			return err
 		}
 
-		r := dataset.NewReader(dataset.ReaderOptions{
+		r := dataset.NewRowReader(dataset.ReaderOptions{
 			Dataset:  dset,
 			Columns:  columns,
 			Prefetch: true,

--- a/pkg/dataobj/sections/streams/row_reader.go
+++ b/pkg/dataobj/sections/streams/row_reader.go
@@ -23,7 +23,7 @@ type RowReader struct {
 
 	buf []dataset.Row
 
-	reader  *dataset.Reader
+	reader  *dataset.RowReader
 	columns []dataset.Column
 
 	symbols *symbolizer.Symbolizer
@@ -107,7 +107,7 @@ func (r *RowReader) initReader() error {
 	}
 
 	if r.reader == nil {
-		r.reader = dataset.NewReader(readerOpts)
+		r.reader = dataset.NewRowReader(readerOpts)
 	} else {
 		r.reader.Reset(readerOpts)
 	}


### PR DESCRIPTION
Renames the following:

* dataset.Reader to dataset.RowReader
* dataset.basicReader to dataset.basicRowReader
* dataset.readerDownloader to dataset.rowReaderDownloader

These changes make room for a new columnar implementation of dataset.Reader, which will temporarily sit alongside the RowReader implementation for a little while.

This PR does not change any logic, only renames things (including in error messages and xcap region names).