### PR TITLE
fix(queryrange): prevent goroutine leak in downstreamer on context cancellation

### DIFF
--- a/pkg/querier/queryrange/downstreamer.go
+++ b/pkg/querier/queryrange/downstreamer.go
@@ -195,9 +195,12 @@ func (in instance) For(
 			return nil
 		})
 		if err != nil {
-			ch <- logql.Resp{
+			select {
+			case <-ctx.Done():
+			case ch <- logql.Resp{
 				I:   -1,
 				Err: err,
+			}:
 			}
 		}
 		close(ch)


### PR DESCRIPTION
**What this PR does / why we need it**:

When the context is canceled (e.g., client disconnect, timeout), the consumer loop in `For()`
exits via `ctx.Done()`, leaving no reader for the unbuffered channel ch. The producer goroutine
then blocks forever on `ch <- logql.Resp{...}` at `downstreamer.go:198`, causing a goroutine leak.

This was originally suggested by cyriltovena in #15665 but was dropped in favor of an
alternative approach (draining the channel on the consumer side). However, #16471 later
re-introduced `ctx.Done()` to the consumer loop to fix a blocking issue, which broke the drain
assumption and re-exposed this leak.

This PR wraps the send in a select with `ctx.Done()` so the producer goroutine can exit cleanly
when the context is canceled.

**Which issue(s) this PR fixes**:
Fixes #19394

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
