### PR TITLE
fix: Add back taks reveive and send durations

### DIFF
--- a/pkg/xcap/exporter.go
+++ b/pkg/xcap/exporter.go
@@ -238,5 +238,12 @@ func summarizeObservations(capture *Capture) *observations {
 			normalizeKeys(),
 	)
 
+	// task recv/send stats at worker level
+	result.merge(
+		collect.fromRegions("thread.runJob", true).
+			filter(TaskRecvDuration.Key(), TaskSendDuration.Key()).
+			normalizeKeys(),
+	)
+
 	return result
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds back the stats for task receive and send duration at the worker level that were removed on #20596

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
