### PR TITLE
chore: Refactor to avoid sharing a download worker

### DIFF
--- a/pkg/dataobj/index/indexer.go
+++ b/pkg/dataobj/index/indexer.go
@@ -273,7 +273,7 @@ func getEarliestIndexedRecord(logger log.Logger, events []metastore.ObjectWritte
 // The number of events processed can be less than the number of events if the builder becomes full
 // when the trigger is triggerTypeAppend.
 func (si *serialIndexer) buildIndex(ctx context.Context, events []metastore.ObjectWrittenEvent, partition int32) (string, int, error) {
-	if len(events) < 0 {
+	if len(events) == 0 {
 		return "", 0, nil
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Replaces the shared downloadWorker with one created per index build.

* This eliminates the need for coordination in case there are leftover download requests in the queue when the build exits early due to context cancellation.
* We only start one build every 5 minutes or so, so there aren't any concerns with creating too many goroutines.
* Clean up is easier as it is done automatically by a defer statement.
* I also took the opportunity to remove the fixed buffer size on the download queue, and instead just download objects as needed.