### PR TITLE
perf: Prealloc slice in index builder when downloading objects

### DIFF
--- a/pkg/dataobj/index/indexer_test.go
+++ b/pkg/dataobj/index/indexer_test.go
@@ -427,3 +427,33 @@ func TestSerialIndexer_FlushOnBuilderFull(t *testing.T) {
 	require.Equal(t, float64(1), testutil.ToFloat64(indexerMetrics.totalRequests))
 	require.Equal(t, float64(1), testutil.ToFloat64(indexerMetrics.totalBuilds))
 }
+
+func TestDownloadObject_Success(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	bucket := objstore.NewInMemBucket()
+	testData := []byte("test data content for download")
+	objectPath := "test-object"
+
+	// Upload test object
+	require.NoError(t, bucket.Upload(ctx, objectPath, bytes.NewReader(testData)))
+
+	// Download with pre-allocation
+	result, err := downloadObject(ctx, bucket, objectPath)
+	require.NoError(t, err)
+	require.Equal(t, testData, result)
+}
+
+func TestDownloadObject_ObjectNotFound(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	bucket := objstore.NewInMemBucket()
+	objectPath := "non-existent-object"
+
+	// Try to download non-existent object
+	_, err := downloadObject(ctx, bucket, objectPath)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to fetch object from storage")
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Dataobjects can be quite large and we are currently using `io.ReadAll` to alloc the bytes buffer when building indexes. `io.ReadAll` starts at [512 bytes](https://cs.opensource.google/go/go/+/refs/tags/go1.25.6:src/io/io.go;l=710Z) and then relies on append to slowly increase the slice length until it is large enough to hold a full dataobject.

This results in considerable allocs/work done to create this slice.

<img width="2500" height="1200" alt="image" src="https://github.com/user-attachments/assets/63669143-20ab-4142-bdc3-3d87bf399d78" />

This PR uses `bucket.Attributes` to prealloc the slice if possible and falls back to the original behavior if the Attributes call fails. If we have enough confidence we can remove the fallback behavior and force an error, but I'll let a more competent team member comment :)