### PR TITLE
chore: Add fmt.Stringer support to Workflow and Plan

### DIFF
--- a/pkg/engine/internal/planner/physical/plan.go
+++ b/pkg/engine/internal/planner/physical/plan.go
@@ -126,6 +126,8 @@ func (*Join) isNode()              {}
 func (*PointersScan) isNode()      {}
 func (*Merge) isNode()             {}
 
+var _ fmt.Stringer = (*Plan)(nil)
+
 // Plan represents a physical execution plan as a directed acyclic graph (DAG).
 // It maintains the relationships between nodes, tracking parent-child connections
 // and providing methods for graph traversal and manipulation.
@@ -140,6 +142,10 @@ type Plan struct {
 // FromGraph constructs a Plan from a given DAG.
 func FromGraph(graph dag.Graph[Node]) *Plan {
 	return &Plan{graph: graph}
+}
+
+func (p *Plan) String() string {
+	return PrintAsTree(p)
 }
 
 // Graph returns the underlying graph of the plan. Modifications to the returned

--- a/pkg/engine/internal/workflow/workflow.go
+++ b/pkg/engine/internal/workflow/workflow.go
@@ -52,6 +52,8 @@ type Options struct {
 	DebugStreams bool
 }
 
+var _ fmt.Stringer = (*Workflow)(nil)
+
 // Workflow represents a physical plan that has been partitioned into
 // parallelizable tasks.
 type Workflow struct {
@@ -151,6 +153,10 @@ func (wf *Workflow) init(ctx context.Context) error {
 		return err
 	}
 	return wf.runner.Listen(ctx, wf.resultsPipeline, wf.resultsStream)
+}
+
+func (wf *Workflow) String() string {
+	return Sprint(wf)
 }
 
 // Len returns the total number of tasks in the workflow.


### PR DESCRIPTION
**What this PR does / why we need it**:
Follow up to an [ill conceived PR](https://github.com/grafana/loki/pull/20650) that added completely new code to dump the contents of `workflow.Workflow` and `plan.Plan` to a human readable string. This PR much more intelligently uses existing functionality and simply makes it more discoverable.