### PR TITLE
feat: Separate copy and sort metrics from appends

### DIFF
--- a/pkg/dataobj/consumer/logsobj/builder.go
+++ b/pkg/dataobj/consumer/logsobj/builder.go
@@ -456,8 +456,8 @@ func (b *Builder) CopyAndSort(ctx context.Context, obj *dataobj.Object) (*dataob
 
 	sort := parseSortOrder(b.cfg.DataobjSortOrder)
 
-	sb := streams.NewBuilder(b.metrics.streams, int(b.cfg.TargetPageSize), b.cfg.MaxPageRows)
-	lb := logs.NewBuilder(b.metrics.logs, logs.BuilderOptions{
+	sb := streams.NewBuilder(b.metrics.sortStreams, int(b.cfg.TargetPageSize), b.cfg.MaxPageRows)
+	lb := logs.NewBuilder(b.metrics.sortLogs, logs.BuilderOptions{
 		PageSizeHint:     int(b.cfg.TargetPageSize),
 		PageMaxRowCount:  b.cfg.MaxPageRows,
 		BufferSize:       int(b.cfg.BufferSize),

--- a/pkg/dataobj/consumer/logsobj/builder_metrics.go
+++ b/pkg/dataobj/consumer/logsobj/builder_metrics.go
@@ -16,6 +16,9 @@ type builderMetrics struct {
 	streams *streams.Metrics
 	dataobj *dataobj.Metrics
 
+	sortLogs    *logs.Metrics
+	sortStreams *streams.Metrics
+
 	targetPageSize   prometheus.Gauge
 	targetObjectSize prometheus.Gauge
 
@@ -34,9 +37,11 @@ type builderMetrics struct {
 // logs objects.
 func newBuilderMetrics() *builderMetrics {
 	return &builderMetrics{
-		logs:    logs.NewMetrics(),
-		streams: streams.NewMetrics(),
-		dataobj: dataobj.NewMetrics(),
+		logs:        logs.NewMetrics(),
+		streams:     streams.NewMetrics(),
+		sortLogs:    logs.NewMetrics(),
+		sortStreams: streams.NewMetrics(),
+		dataobj:     dataobj.NewMetrics(),
 		targetPageSize: prometheus.NewGauge(prometheus.GaugeOpts{
 			Name: "loki_dataobj_config_target_page_size_bytes",
 			Help: "Configured target page size in bytes.",
@@ -104,8 +109,14 @@ func (m *builderMetrics) ObserveConfig(cfg BuilderConfig) {
 func (m *builderMetrics) Register(reg prometheus.Registerer) error {
 	var errs []error
 
-	errs = append(errs, m.logs.Register(reg))
-	errs = append(errs, m.streams.Register(reg))
+	appendReg := prometheus.WrapRegistererWith(prometheus.Labels{"operation": "append"}, reg)
+	errs = append(errs, m.logs.Register(appendReg))
+	errs = append(errs, m.streams.Register(appendReg))
+
+	sortReg := prometheus.WrapRegistererWith(prometheus.Labels{"operation": "sort"}, reg)
+	errs = append(errs, m.sortLogs.Register(sortReg))
+	errs = append(errs, m.sortStreams.Register(sortReg))
+
 	errs = append(errs, m.dataobj.Register(reg))
 
 	errs = append(errs, reg.Register(m.targetPageSize))
@@ -126,8 +137,14 @@ func (m *builderMetrics) Register(reg prometheus.Registerer) error {
 
 // Unregister unregisters metrics from the provided Registerer.
 func (m *builderMetrics) Unregister(reg prometheus.Registerer) {
-	m.logs.Unregister(reg)
-	m.streams.Unregister(reg)
+	appendReg := prometheus.WrapRegistererWith(prometheus.Labels{"operation": "append"}, reg)
+	m.logs.Unregister(appendReg)
+	m.streams.Unregister(appendReg)
+
+	sortReg := prometheus.WrapRegistererWith(prometheus.Labels{"operation": "sort"}, reg)
+	m.sortLogs.Unregister(sortReg)
+	m.sortStreams.Unregister(sortReg)
+
 	m.dataobj.Unregister(reg)
 
 	reg.Unregister(m.targetPageSize)


### PR DESCRIPTION
**What this PR does / why we need it**:
As of now, we share the same metrics for copying/sorting from processing Kafka records (executed by appends). I'm isolating them by separating through two metrics attributes which have a different label on them. I'm now passing the appropriate version of them to the builder, allowing a distinction of time spent on appending vs sort/copying.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
