### PR TITLE
fix(ingester): Write first checkpoint immediately

### DIFF
--- a/pkg/ingester/checkpoint.go
+++ b/pkg/ingester/checkpoint.go
@@ -708,13 +708,13 @@ func (c *Checkpointer) Run() {
 	defer c.iter.Stop()
 
 	for {
+		level.Info(util_log.Logger).Log("msg", "starting checkpoint")
+		if err := c.PerformCheckpoint(); err != nil {
+			level.Error(util_log.Logger).Log("msg", "error checkpointing series", "err", err)
+		}
+
 		select {
 		case <-ticker.C:
-			level.Info(util_log.Logger).Log("msg", "starting checkpoint")
-			if err := c.PerformCheckpoint(); err != nil {
-				level.Error(util_log.Logger).Log("msg", "error checkpointing series", "err", err)
-				continue
-			}
 		case <-c.quit:
 			return
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

When starting the ingester with an existing WAL, the first checkpoint can be written immediately instead after the first checkpoint_duration. This helps to avoid filling up the WAL disk after a restart.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] ~Documentation added~
- [ ] ~Tests updated~
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] ~Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`~
- [ ] ~If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)~
