### PR TITLE
docs: update link to learning journey to reflect new unified journey

### DIFF
--- a/docs/sources/alert/_index.md
+++ b/docs/sources/alert/_index.md
@@ -23,7 +23,7 @@ There are two types of alerts in Grafana:
 
 To learn more about Grafana managed alerts, you can refer to the [Alerts and IRM documentation](https://grafana.com/docs/grafana-cloud/alerting-and-irm/), or take a short Learning Journey.
 
-{{< docs/learning-journeys title="Create log alert rules with Grafana Alerting" url="https://grafana.com/docs/learning-journeys/logs-alert-creation/" >}}
+{{< docs/learning-journeys title="Create infrastructure alerts" url="https://grafana.com/docs/learning-journeys/infrastructure-alerting/" >}}
 
 ## Loki alerting and recording rules
 


### PR DESCRIPTION
The new journey takes a standalone approach—users don't need existing dashboards or prior visualization experience, and can alert on either metrics or logs.

More information in https://github.com/grafana/website/pull/28857