### PR TITLE
fix: bump go version for 3.6.x

### DIFF
--- a/.github/jsonnetfile.json
+++ b/.github/jsonnetfile.json
@@ -8,7 +8,7 @@
           "subdir": "workflows"
         }
       },
-      "version": "dfe753760ce6ec2f4549fc11d2df24a2aa584e3f"
+      "version": "fb3b12ec3e6411bcb951a5ea08cc983c2f2735fc"
     }
   ],
   "legacyImports": true

--- a/.github/jsonnetfile.lock.json
+++ b/.github/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
           "subdir": "workflows"
         }
       },
-      "version": "dfe753760ce6ec2f4549fc11d2df24a2aa584e3f",
+      "version": "fb3b12ec3e6411bcb951a5ea08cc983c2f2735fc",
       "sum": "LfNl0q+23sWMu/zwsqHfbUuEfYZMNN2xpZBRizUUHHY="
     }
   ],

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,10 +1,10 @@
 "jobs":
   "check":
-    "uses": "grafana/loki-release/.github/workflows/check.yml@dfe753760ce6ec2f4549fc11d2df24a2aa584e3f"
+    "uses": "grafana/loki-release/.github/workflows/check.yml@fb3b12ec3e6411bcb951a5ea08cc983c2f2735fc"
     "with":
-      "build_image": "grafana/loki-build-image:0.34.8"
+      "build_image": "grafana/loki-build-image:0.34.9"
       "golang_ci_lint_version": "v2.5.0"
-      "release_lib_ref": "dfe753760ce6ec2f4549fc11d2df24a2aa584e3f"
+      "release_lib_ref": "fb3b12ec3e6411bcb951a5ea08cc983c2f2735fc"
       "skip_validation": false
       "use_github_app_token": true
 "name": "check"

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -1,10 +1,10 @@
 "jobs":
   "check":
-    "uses": "grafana/loki-release/.github/workflows/check.yml@dfe753760ce6ec2f4549fc11d2df24a2aa584e3f"
+    "uses": "grafana/loki-release/.github/workflows/check.yml@fb3b12ec3e6411bcb951a5ea08cc983c2f2735fc"
     "with":
-      "build_image": "grafana/loki-build-image:0.34.8"
+      "build_image": "grafana/loki-build-image:0.34.9"
       "golang_ci_lint_version": "v2.5.0"
-      "release_lib_ref": "dfe753760ce6ec2f4549fc11d2df24a2aa584e3f"
+      "release_lib_ref": "fb3b12ec3e6411bcb951a5ea08cc983c2f2735fc"
       "skip_validation": false
       "use_github_app_token": true
   "loki-canary-boringcrypto-image":
@@ -12,7 +12,7 @@
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.25"
       "IMAGE_PREFIX": "grafana"
-      "RELEASE_LIB_REF": "dfe753760ce6ec2f4549fc11d2df24a2aa584e3f"
+      "RELEASE_LIB_REF": "fb3b12ec3e6411bcb951a5ea08cc983c2f2735fc"
       "RELEASE_REPO": "grafana/loki"
     "needs":
     - "check"
@@ -136,7 +136,7 @@
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.25"
       "IMAGE_PREFIX": "grafana"
-      "RELEASE_LIB_REF": "dfe753760ce6ec2f4549fc11d2df24a2aa584e3f"
+      "RELEASE_LIB_REF": "fb3b12ec3e6411bcb951a5ea08cc983c2f2735fc"
       "RELEASE_REPO": "grafana/loki"
     "needs":
     - "check"
@@ -260,7 +260,7 @@
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.25"
       "IMAGE_PREFIX": "grafana"
-      "RELEASE_LIB_REF": "dfe753760ce6ec2f4549fc11d2df24a2aa584e3f"
+      "RELEASE_LIB_REF": "fb3b12ec3e6411bcb951a5ea08cc983c2f2735fc"
       "RELEASE_REPO": "grafana/loki"
     "needs":
     - "check"
@@ -384,7 +384,7 @@
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.25"
       "IMAGE_PREFIX": "grafana"
-      "RELEASE_LIB_REF": "dfe753760ce6ec2f4549fc11d2df24a2aa584e3f"
+      "RELEASE_LIB_REF": "fb3b12ec3e6411bcb951a5ea08cc983c2f2735fc"
       "RELEASE_REPO": "grafana/loki"
     "needs":
     - "check"

--- a/.github/workflows/minor-release-pr.yml
+++ b/.github/workflows/minor-release-pr.yml
@@ -8,7 +8,7 @@ env:
   DRY_RUN: false
   GITHUB_APP: "loki-gh-app"
   IMAGE_PREFIX: "grafana"
-  RELEASE_LIB_REF: "dfe753760ce6ec2f4549fc11d2df24a2aa584e3f"
+  RELEASE_LIB_REF: "fb3b12ec3e6411bcb951a5ea08cc983c2f2735fc"
   RELEASE_REPO: "grafana/loki"
   SKIP_VALIDATION: false
   USE_GITHUB_APP_TOKEN: true
@@ -19,11 +19,11 @@ jobs:
       contents: "write"
       id-token: "write"
       pull-requests: "write"
-    uses: "grafana/loki-release/.github/workflows/check.yml@dfe753760ce6ec2f4549fc11d2df24a2aa584e3f"
+    uses: "grafana/loki-release/.github/workflows/check.yml@fb3b12ec3e6411bcb951a5ea08cc983c2f2735fc"
     with:
-      build_image: "grafana/loki-build-image:0.34.8"
+      build_image: "grafana/loki-build-image:0.34.9"
       golang_ci_lint_version: "v2.5.0"
-      release_lib_ref: "dfe753760ce6ec2f4549fc11d2df24a2aa584e3f"
+      release_lib_ref: "fb3b12ec3e6411bcb951a5ea08cc983c2f2735fc"
       skip_validation: false
       use_github_app_token: true
   create-release-pr:
@@ -179,10 +179,10 @@ jobs:
           --env SKIP_ARM \
           --volume .:/src/loki \
           --workdir /src/loki \
-          --entrypoint /bin/sh "grafana/loki-build-image:0.34.8"
+          --entrypoint /bin/sh "grafana/loki-build-image:0.34.9"
           git config --global --add safe.directory /src/loki
           echo "${NFPM_SIGNING_KEY}" > $NFPM_SIGNING_KEY_FILE
-          if echo "grafana/loki-build-image:0.34.8" | grep -q "golang"; then
+          if echo "grafana/loki-build-image:0.34.9" | grep -q "golang"; then
             /src/loki/.github/vendor/github.com/grafana/loki-release/workflows/install_workflow_dependencies.sh dist
           fi
           make dist packages
@@ -798,7 +798,7 @@ jobs:
         build-args: |
           IMAGE_TAG=${{ needs.version.outputs.version }}
           GOARCH=${{ steps.platform.outputs.platform_short }}
-          BUILD_IMAGE=grafana/loki-build-image:0.34.8
+          BUILD_IMAGE=grafana/loki-build-image:0.34.9
         context: "release"
         file: "release/clients/cmd/docker-driver/Dockerfile"
         outputs: "type=local,dest=release/plugins/loki-docker-driver-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}"

--- a/.github/workflows/patch-release-pr.yml
+++ b/.github/workflows/patch-release-pr.yml
@@ -8,7 +8,7 @@ env:
   DRY_RUN: false
   GITHUB_APP: "loki-gh-app"
   IMAGE_PREFIX: "grafana"
-  RELEASE_LIB_REF: "dfe753760ce6ec2f4549fc11d2df24a2aa584e3f"
+  RELEASE_LIB_REF: "fb3b12ec3e6411bcb951a5ea08cc983c2f2735fc"
   RELEASE_REPO: "grafana/loki"
   SKIP_VALIDATION: false
   USE_GITHUB_APP_TOKEN: true
@@ -19,11 +19,11 @@ jobs:
       contents: "write"
       id-token: "write"
       pull-requests: "write"
-    uses: "grafana/loki-release/.github/workflows/check.yml@dfe753760ce6ec2f4549fc11d2df24a2aa584e3f"
+    uses: "grafana/loki-release/.github/workflows/check.yml@fb3b12ec3e6411bcb951a5ea08cc983c2f2735fc"
     with:
-      build_image: "grafana/loki-build-image:0.34.8"
+      build_image: "grafana/loki-build-image:0.34.9"
       golang_ci_lint_version: "v2.5.0"
-      release_lib_ref: "dfe753760ce6ec2f4549fc11d2df24a2aa584e3f"
+      release_lib_ref: "fb3b12ec3e6411bcb951a5ea08cc983c2f2735fc"
       skip_validation: false
       use_github_app_token: true
   create-release-pr:
@@ -179,10 +179,10 @@ jobs:
           --env SKIP_ARM \
           --volume .:/src/loki \
           --workdir /src/loki \
-          --entrypoint /bin/sh "grafana/loki-build-image:0.34.8"
+          --entrypoint /bin/sh "grafana/loki-build-image:0.34.9"
           git config --global --add safe.directory /src/loki
           echo "${NFPM_SIGNING_KEY}" > $NFPM_SIGNING_KEY_FILE
-          if echo "grafana/loki-build-image:0.34.8" | grep -q "golang"; then
+          if echo "grafana/loki-build-image:0.34.9" | grep -q "golang"; then
             /src/loki/.github/vendor/github.com/grafana/loki-release/workflows/install_workflow_dependencies.sh dist
           fi
           make dist packages
@@ -798,7 +798,7 @@ jobs:
         build-args: |
           IMAGE_TAG=${{ needs.version.outputs.version }}
           GOARCH=${{ steps.platform.outputs.platform_short }}
-          BUILD_IMAGE=grafana/loki-build-image:0.34.8
+          BUILD_IMAGE=grafana/loki-build-image:0.34.9
         context: "release"
         file: "release/clients/cmd/docker-driver/Dockerfile"
         outputs: "type=local,dest=release/plugins/loki-docker-driver-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_APP: "loki-gh-app"
   IMAGE_PREFIX: "grafana"
   PUBLISH_TO_GCS: false
-  RELEASE_LIB_REF: "dfe753760ce6ec2f4549fc11d2df24a2aa584e3f"
+  RELEASE_LIB_REF: "fb3b12ec3e6411bcb951a5ea08cc983c2f2735fc"
   RELEASE_REPO: "grafana/loki"
   USE_GITHUB_APP_TOKEN: true
 jobs:

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ endif
 # Ensure you run `make release-workflows` after changing this
 GO_VERSION         := 1.25
 # Ensure you run `make IMAGE_TAG=<updated-tag> build-image-push` after changing this
-BUILD_IMAGE_TAG    := 0.34.8
+BUILD_IMAGE_TAG    := 0.34.9
 
 IMAGE_TAG          ?= $(shell ./tools/image-tag)
 GIT_REVISION       := $(shell git rev-parse --short HEAD)


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes some vulnerabilities by bumping the go version the binary is compiled with. The Docker image is already using the correct version, this only affects binaries posted to the release page.

This also bumps the loki-release sha to the latest.