### PR TITLE
feat: retry failed data object uploads until context canceled

### DIFF
--- a/pkg/dataobj/consumer/flush.go
+++ b/pkg/dataobj/consumer/flush.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"time"
 
 	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/backoff"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
@@ -127,17 +130,38 @@ func (f *flusherImpl) doJob(ctx context.Context, job flushJob) {
 func (f *flusherImpl) flush(ctx context.Context, job flushJob) (string, error) {
 	obj, closer, err := job.Flush()
 	if err != nil {
+		// Flush cannot be retried as the operation is non-idempotent.
 		return "", fmt.Errorf("failed to flush data object builder: %w", err)
 	}
 	defer closer.Close()
+	// Sort the sections object-wide.
 	obj, closer, err = f.sorter.Sort(ctx, obj)
 	if err != nil {
 		return "", fmt.Errorf("failed to sort data object: %w", err)
 	}
 	defer closer.Close()
-	objectPath, err := f.uploader.Upload(ctx, obj)
-	if err != nil {
-		return "", fmt.Errorf("failed to upload object: %w", err)
+	// Upload the data object. We use an exponential backoff to retry uploads
+	// until the context is canceled.
+	b := backoff.New(ctx, backoff.Config{
+		MinBackoff: 100 * time.Millisecond,
+		MaxBackoff: 10 * time.Second,
+		MaxRetries: 0,
+	})
+	var (
+		objectPath    string
+		lastUploadErr error
+	)
+	for b.Ongoing() {
+		objectPath, lastUploadErr = f.uploader.Upload(ctx, obj)
+		if lastUploadErr == nil {
+			break
+		}
+		level.Warn(f.logger).Log("msg", "failed to upload data object", "err", lastUploadErr, "attempt", b.NumRetries())
+		b.Wait()
 	}
+	if lastUploadErr != nil {
+		return "", fmt.Errorf("failed to upload data object: %w", lastUploadErr)
+	}
+
 	return objectPath, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request ensures we retry failed data object uploads until canceled.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
