### PR TITLE
fix(dataobj): Also apply categorize labels to parsed labels

### DIFF
--- a/pkg/engine/compat.go
+++ b/pkg/engine/compat.go
@@ -148,7 +148,9 @@ func (b *streamsResultBuilder) CollectRecord(rec arrow.RecordBatch) {
 				}
 
 				b.rowBuilders[rowIdx].parsedBuilder.Set(shortName, parsedVal)
-				b.rowBuilders[rowIdx].lbsBuilder.Set(shortName, parsedVal)
+				if !b.categorizeLabels {
+					b.rowBuilders[rowIdx].lbsBuilder.Set(shortName, parsedVal)
+				}
 				if b.rowBuilders[rowIdx].metadataBuilder.Get(shortName) != "" {
 					b.rowBuilders[rowIdx].metadataBuilder.Del(shortName)
 				}


### PR DESCRIPTION
**What this PR does / why we need it**:
The catorize labels flag is meant to group the labels under each entry by their type. We did this for structured metadata keys but did not do it for parsed keys, which results in different labels returned by classic & Thor.