### PR TITLE
fix: service failure on stopping kafkav2 consumer

### DIFF
--- a/pkg/dataobj/consumer/processor.go
+++ b/pkg/dataobj/consumer/processor.go
@@ -147,7 +147,7 @@ func (p *processor) Run(ctx context.Context) error {
 		case <-ctx.Done():
 			level.Info(p.logger).Log("msg", "context canceled")
 			// We don't return ctx.Err() here as it manifests as a service failure
-			// when shutting down.
+			// when stopping the service.
 			return nil
 		case rec, ok := <-p.records:
 			if !ok {

--- a/pkg/kafkav2/consumer.go
+++ b/pkg/kafkav2/consumer.go
@@ -98,7 +98,9 @@ func (c *SinglePartitionConsumer) Run(ctx context.Context) error {
 	for b.Ongoing() {
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			// We don't return ctx.Err() here as it manifests as a service failure
+			// when stopping the service.
+			return nil
 		default:
 		}
 		c.polls.Inc()


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes errors like this on shutdown:

```
caller=service.go:219 component=dataobj-consumer msg="failed to stop consumer" err="context canceled"
```

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
