### PR TITLE
feat: add flush manager to control data object flush lifecycle

### DIFF
--- a/pkg/dataobj/consumer/flush_manager.go
+++ b/pkg/dataobj/consumer/flush_manager.go
@@ -1,0 +1,124 @@
+package consumer
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/backoff"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// A committer allows mocking of certain [kgo.Client] methods in tests.
+type committer interface {
+	Commit(ctx context.Context, partition int32, offset int64) error
+}
+
+// A metastoreEventEmitter allows mocking of [metastoreEvents] in tests.
+type metastoreEventEmitter interface {
+	Emit(ctx context.Context, objectPath string, earliestRecordTime time.Time) error
+}
+
+// A flusher allows mocking of flushes in tests.
+type flusher interface {
+	Flush(ctx context.Context, builder builder, reason string) (string, error)
+}
+
+// A flushManagerImpl manages the flushing of data objects and commits.
+type flushManagerImpl struct {
+	flusher         flusher
+	metastoreEvents metastoreEventEmitter
+	committer       committer
+	partition       int32
+	logger          log.Logger
+
+	// Metrics.
+	commits        prometheus.Counter
+	commitFailures prometheus.Counter
+}
+
+func newFlushManager(
+	flusher flusher,
+	metastoreEvents metastoreEventEmitter,
+	committer committer,
+	partition int32,
+	logger log.Logger,
+	r prometheus.Registerer,
+) *flushManagerImpl {
+	return &flushManagerImpl{
+		flusher:         flusher,
+		metastoreEvents: metastoreEvents,
+		committer:       committer,
+		partition:       partition,
+		logger:          logger,
+		commits: promauto.With(r).NewCounter(prometheus.CounterOpts{
+			Name: "loki_dataobj_consumer_commits_total",
+			Help: "Total number of commits.",
+		}),
+		commitFailures: promauto.With(r).NewCounter(prometheus.CounterOpts{
+			Name: "loki_dataobj_consumer_commit_failures_total",
+			Help: "Total number of commit failures.",
+		}),
+	}
+}
+
+// Flush the data object builder and, if successful, commit the offset.
+func (m *flushManagerImpl) Flush(ctx context.Context, builder builder, reason string, offset int64, earliestRecordTime time.Time) error {
+	objectPath, err := m.flusher.Flush(ctx, builder, reason)
+	if err != nil {
+		return fmt.Errorf("failed to flush data object: %w", err)
+	}
+	if err := m.emitEvent(ctx, objectPath, earliestRecordTime); err != nil {
+		return fmt.Errorf("failed to emit metastore event: %w", err)
+	}
+	if err := m.commit(ctx, offset); err != nil {
+		m.commitFailures.Inc()
+		return fmt.Errorf("failed to commit data object: %w", err)
+	}
+	return nil
+}
+
+// emitEvent emits a metastore event for the object, retries with exponential
+// backoff until successful or the context is canceled.
+func (m *flushManagerImpl) emitEvent(ctx context.Context, objectPath string, earliestRecordTime time.Time) error {
+	b := backoff.New(ctx, backoff.Config{
+		MinBackoff: 100 * time.Millisecond,
+		MaxBackoff: 10 * time.Second,
+		MaxRetries: 0,
+	})
+	var lastErr error
+	for b.Ongoing() {
+		lastErr = m.metastoreEvents.Emit(ctx, objectPath, earliestRecordTime)
+		if lastErr == nil {
+			break
+		}
+		level.Warn(m.logger).Log("msg", "failed to emit metastore event", "err", lastErr, "attempt", b.NumRetries())
+		b.Wait()
+	}
+	return lastErr
+}
+
+// commits the offset, retries with exponential backoff until successful or
+// the context is canceled.
+func (m *flushManagerImpl) commit(ctx context.Context, offset int64) error {
+	b := backoff.New(ctx, backoff.Config{
+		MinBackoff: 100 * time.Millisecond,
+		MaxBackoff: 10 * time.Second,
+		MaxRetries: 0,
+	})
+	m.commits.Inc()
+	var lastErr error
+	for b.Ongoing() {
+		lastErr = m.committer.Commit(ctx, m.partition, offset)
+		if lastErr == nil {
+			level.Debug(m.logger).Log("msg", "committed offset", "partition", m.partition, "offset", offset)
+			break
+		}
+		level.Warn(m.logger).Log("msg", "failed to commit offset", "err", lastErr, "attempt", b.NumRetries())
+		b.Wait()
+	}
+	return lastErr
+}

--- a/pkg/dataobj/consumer/flush_manager_test.go
+++ b/pkg/dataobj/consumer/flush_manager_test.go
@@ -1,0 +1,87 @@
+package consumer
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/logproto"
+)
+
+func TestFlushManager(t *testing.T) {
+	t.Run("should succeed", func(t *testing.T) {
+		var (
+			now             = time.Now()
+			reg             = prometheus.NewRegistry()
+			flusher         = &mockFlusher{}
+			metastoreKafka  = &mockKafka{}
+			metastoreEvents = newMetastoreEvents(1, 10, metastoreKafka)
+			committer       = &mockCommitter{}
+			flushManager    = newFlushManager(flusher, metastoreEvents, committer, 0, log.NewNopLogger(), reg)
+		)
+		// Create a builder and append some logs so it can be flushed.
+		builder := newTestBuilder(t, reg)
+		require.NoError(t, builder.Append("test", logproto.Stream{
+			Labels: `{foo="bar"}`,
+			Entries: []logproto.Entry{
+				{Timestamp: now, Line: "test"},
+			},
+		}))
+		require.NoError(t, flushManager.Flush(t.Context(), builder, "test", 1, now))
+		// A flush should have occurred, a metastore event emitted, and the correct
+		// offset was committed.
+		require.Equal(t, 1, flusher.flushes)
+		require.Len(t, metastoreKafka.produced, 1)
+		require.Len(t, committer.offsets, 1)
+		require.Equal(t, int64(1), committer.offsets[0])
+		// Check that the metrics are correct.
+		require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
+	# HELP loki_dataobj_consumer_commits_total Total number of commits.
+	# TYPE loki_dataobj_consumer_commits_total counter
+	loki_dataobj_consumer_commits_total 1
+	# HELP loki_dataobj_consumer_commit_failures_total Total number of commit failures.
+	# TYPE loki_dataobj_consumer_commit_failures_total counter
+	loki_dataobj_consumer_commit_failures_total 0
+	`), "loki_dataobj_consumer_commits_total", "loki_dataobj_consumer_commit_failures_total"))
+	})
+
+	t.Run("should fail", func(t *testing.T) {
+		var (
+			now             = time.Now()
+			reg             = prometheus.NewRegistry()
+			flusher         = &failureFlusher{}
+			metastoreKafka  = &mockKafka{}
+			metastoreEvents = newMetastoreEvents(1, 10, metastoreKafka)
+			committer       = &mockCommitter{}
+			flushManager    = newFlushManager(flusher, metastoreEvents, committer, 0, log.NewNopLogger(), reg)
+		)
+		// Create a builder and append some logs so it can be flushed.
+		builder := newTestBuilder(t, reg)
+		require.NoError(t, builder.Append("test", logproto.Stream{
+			Labels: `{foo="bar"}`,
+			Entries: []logproto.Entry{
+				{Timestamp: now, Line: "test"},
+			},
+		}))
+		flushErr := flushManager.Flush(t.Context(), builder, "test", 1, now)
+		require.EqualError(t, flushErr, "failed to flush data object: mock error")
+		// Since no flush occurred, no event should be emitted and no offsets
+		// should be committed either.
+		require.Len(t, metastoreKafka.produced, 0)
+		require.Len(t, committer.offsets, 0)
+		// Check that the metrics are correct.
+		require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
+	# HELP loki_dataobj_consumer_commits_total Total number of commits.
+	# TYPE loki_dataobj_consumer_commits_total counter
+	loki_dataobj_consumer_commits_total 0
+	# HELP loki_dataobj_consumer_commit_failures_total Total number of commit failures.
+	# TYPE loki_dataobj_consumer_commit_failures_total counter
+	loki_dataobj_consumer_commit_failures_total 0
+	`), "loki_dataobj_consumer_commits_total", "loki_dataobj_consumer_commit_failures_total"))
+	})
+}

--- a/pkg/dataobj/consumer/flush_test.go
+++ b/pkg/dataobj/consumer/flush_test.go
@@ -27,7 +27,7 @@ func TestFlusher_Flush(t *testing.T) {
 			testUploader = &mockUploader{}
 			now          = time.Now()
 		)
-		// Init the builder and append some logs so it can be flushed.
+		// Create a builder and append some logs so it can be flushed.
 		realBuilder, err := logsobj.NewBuilder(testBuilderCfg, scratch.NewMemory())
 		require.NoError(t, err)
 		testBuilder = &mockBuilder{builder: realBuilder}

--- a/pkg/dataobj/consumer/metastore.go
+++ b/pkg/dataobj/consumer/metastore.go
@@ -10,6 +10,11 @@ import (
 	"github.com/grafana/loki/v3/pkg/dataobj/metastore"
 )
 
+// A producer allows mocking of certain [kgo.Client] methods in tests.
+type producer interface {
+	ProduceSync(ctx context.Context, records ...*kgo.Record) kgo.ProduceResults
+}
+
 // metastoreEvents emits events to the metastore Kafka topic.
 type metastoreEvents struct {
 	producer       producer

--- a/pkg/dataobj/consumer/metrics.go
+++ b/pkg/dataobj/consumer/metrics.go
@@ -14,8 +14,6 @@ type metrics struct {
 	discardedBytes prometheus.Counter
 	records        prometheus.Counter
 	recordFailures prometheus.Counter
-	commits        prometheus.Counter
-	commitFailures prometheus.Counter
 
 	// Deprecated, will be removed in two weeklies.
 	latestDelay      prometheus.Gauge
@@ -49,14 +47,6 @@ func newMetrics(r prometheus.Registerer) *metrics {
 		recordFailures: promauto.With(r).NewCounter(prometheus.CounterOpts{
 			Name: "loki_dataobj_consumer_record_failures_total",
 			Help: "Total number of records that failed to be processed.",
-		}),
-		commits: prometheus.NewCounter(prometheus.CounterOpts{
-			Name: "loki_dataobj_consumer_commits_total",
-			Help: "Total number of commits",
-		}),
-		commitFailures: prometheus.NewCounter(prometheus.CounterOpts{
-			Name: "loki_dataobj_consumer_commit_failures_total",
-			Help: "Total number of commit failures",
 		}),
 		// TODO(grobinson): Remove after two minor releases.
 		latestDelay: promauto.With(r).NewGauge(prometheus.GaugeOpts{

--- a/pkg/dataobj/consumer/mock_test.go
+++ b/pkg/dataobj/consumer/mock_test.go
@@ -150,6 +150,15 @@ func (m *mockFlusher) Flush(_ context.Context, _ builder, _ string) (string, err
 	return "", nil
 }
 
+type mockFlushManager struct {
+	flushes int
+}
+
+func (m *mockFlushManager) Flush(_ context.Context, _ builder, _ string, _ int64, _ time.Time) error {
+	m.flushes++
+	return nil
+}
+
 // mockKafka mocks a [kgo.Client]. The zero value is usable.
 type mockKafka struct {
 	fetches  []kgo.Fetches

--- a/pkg/dataobj/consumer/processor_test.go
+++ b/pkg/dataobj/consumer/processor_test.go
@@ -32,21 +32,20 @@ var (
 	}
 )
 
-func TestPartitionProcessor_BuilderMaxAge(t *testing.T) {
+func TestProcessor_BuilderMaxAge(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		var (
-			ctx             = t.Context()
-			reg             = prometheus.NewRegistry()
-			flusher         = &mockFlusher{}
-			metastoreEvents = newMetastoreEvents(1, 10, &mockKafka{})
-			committer       = &mockCommitter{}
-			proc            = newProcessor(newTestBuilder(t, reg), nil, flusher, metastoreEvents, committer, 1, 5*time.Minute, 30*time.Minute, log.NewNopLogger(), reg)
+			ctx          = t.Context()
+			reg          = prometheus.NewRegistry()
+			builder      = newTestBuilder(t, reg)
+			flushManager = &mockFlushManager{}
+			proc         = newProcessor(builder, nil, flushManager, 5*time.Minute, 30*time.Minute, log.NewNopLogger(), reg)
 		)
 
 		// Since no records have been pushed, the first append time should be zero,
 		// and no flush should have occurred.
 		require.True(t, proc.firstAppend.IsZero())
-		require.Equal(t, 0, flusher.flushes)
+		require.Equal(t, 0, flushManager.flushes)
 
 		// Process a record containing some log lines. No flush should occur because
 		// the builder has not reached the maximum age.
@@ -56,7 +55,7 @@ func TestPartitionProcessor_BuilderMaxAge(t *testing.T) {
 		// should have occurred.
 		require.Equal(t, time.Now(), proc.firstAppend)
 		require.Equal(t, time.Now(), proc.lastAppend)
-		require.Equal(t, 0, flusher.flushes)
+		require.Equal(t, 0, flushManager.flushes)
 
 		// Advance time past the maximum age. A flush should occur, and the
 		// the log lines from the record should be appended to the next data
@@ -69,7 +68,7 @@ func TestPartitionProcessor_BuilderMaxAge(t *testing.T) {
 		require.Equal(t, time.Now(), proc.firstAppend)
 		require.Equal(t, time.Now(), proc.lastAppend)
 		require.NotEqual(t, proc.builder.GetEstimatedSize(), 0)
-		require.Equal(t, 1, flusher.flushes)
+		require.Equal(t, 1, flushManager.flushes)
 
 		// Advance time one last time and push some more logs. No flush should
 		// occur because the next builder has not reached the maximum age.
@@ -78,26 +77,25 @@ func TestPartitionProcessor_BuilderMaxAge(t *testing.T) {
 		require.NoError(t, proc.processRecord(ctx, newTestRecord(t, "tenant1", time.Now())))
 		require.Equal(t, expectedLastFlushed, proc.firstAppend)
 		require.Equal(t, time.Now(), proc.lastAppend)
-		require.Equal(t, 1, flusher.flushes)
+		require.Equal(t, 1, flushManager.flushes)
 	})
 }
 
 func TestPartitionProcessor_IdleFlush(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		var (
-			ctx             = t.Context()
-			reg             = prometheus.NewRegistry()
-			flusher         = &mockFlusher{}
-			metastoreEvents = newMetastoreEvents(1, 10, &mockKafka{})
-			committer       = &mockCommitter{}
-			proc            = newProcessor(newTestBuilder(t, reg), nil, flusher, metastoreEvents, committer, 1, 5*time.Minute, 30*time.Minute, log.NewNopLogger(), reg)
+			ctx          = t.Context()
+			reg          = prometheus.NewRegistry()
+			builder      = newTestBuilder(t, reg)
+			flushManager = &mockFlushManager{}
+			proc         = newProcessor(builder, nil, flushManager, 5*time.Minute, 30*time.Minute, log.NewNopLogger(), reg)
 		)
 
 		// The idle flush timeout has not been exceeded, no flush should occur.
 		flushed, err := proc.idleFlush(ctx)
 		require.NoError(t, err)
 		require.False(t, flushed)
-		require.Equal(t, 0, flusher.flushes)
+		require.Equal(t, 0, flushManager.flushes)
 
 		// Advance time past the idle flush time. No flush should occur because
 		// the builder is empty.
@@ -105,7 +103,7 @@ func TestPartitionProcessor_IdleFlush(t *testing.T) {
 		flushed, err = proc.idleFlush(ctx)
 		require.NoError(t, err)
 		require.False(t, flushed)
-		require.Equal(t, 0, flusher.flushes)
+		require.Equal(t, 0, flushManager.flushes)
 
 		// Process a record containing some log lines. No flush should occur because
 		// when log lines are appended to the builder it resets the idle timeout.
@@ -114,14 +112,14 @@ func TestPartitionProcessor_IdleFlush(t *testing.T) {
 		flushed, err = proc.idleFlush(ctx)
 		require.NoError(t, err)
 		require.False(t, flushed)
-		require.Equal(t, 0, flusher.flushes)
+		require.Equal(t, 0, flushManager.flushes)
 
 		// Advance time past the idle timeout. A flush should occur.
 		time.Sleep(6 * time.Minute)
 		flushed, err = proc.idleFlush(ctx)
 		require.NoError(t, err)
 		require.True(t, flushed)
-		require.Equal(t, 1, flusher.flushes)
+		require.Equal(t, 1, flushManager.flushes)
 	})
 }
 
@@ -129,24 +127,28 @@ func TestPartitionProcessor_IdleFlush(t *testing.T) {
 type failureFlusher struct{}
 
 func (f *failureFlusher) Flush(_ context.Context, _ builder, _ string) (string, error) {
-	return "", errors.New("failed to flush")
+	return "", errors.New("mock error")
+}
+
+type failureFlushManager struct{}
+
+func (m *failureFlushManager) Flush(_ context.Context, _ builder, _ string, _ int64, _ time.Time) error {
+	return errors.New("mock error")
 }
 
 func TestPartitionProcessor_Flush(t *testing.T) {
 	t.Run("should succeed", func(t *testing.T) {
 		synctest.Test(t, func(t *testing.T) {
 			var (
-				ctx             = t.Context()
-				reg             = prometheus.NewRegistry()
-				flusher         = &mockFlusher{}
-				metastoreKafka  = &mockKafka{}
-				metastoreEvents = newMetastoreEvents(1, 10, metastoreKafka)
-				committer       = &mockCommitter{}
-				proc            = newProcessor(newTestBuilder(t, reg), nil, flusher, metastoreEvents, committer, 1, 5*time.Minute, 30*time.Minute, log.NewNopLogger(), reg)
+				ctx          = t.Context()
+				reg          = prometheus.NewRegistry()
+				builder      = newTestBuilder(t, reg)
+				flushManager = &mockFlushManager{}
+				proc         = newProcessor(builder, nil, flushManager, 5*time.Minute, 30*time.Minute, log.NewNopLogger(), reg)
 			)
 
 			// No flush should have occurred.
-			require.Equal(t, 0, flusher.flushes)
+			require.Equal(t, 0, flushManager.flushes)
 
 			// Process a record containing some log lines. No flush should occur.
 			rec1 := newTestRecord(t, "tenant", time.Now())
@@ -158,11 +160,7 @@ func TestPartitionProcessor_Flush(t *testing.T) {
 			// Advance time and force a flush.
 			time.Sleep(time.Second)
 			require.NoError(t, proc.flush(ctx, "test"))
-			require.Equal(t, 1, flusher.flushes)
-
-			// A metastore event should have been emitted and offsets committed.
-			require.Len(t, metastoreKafka.produced, 1)
-			require.Len(t, committer.offsets, 1)
+			require.Equal(t, 1, flushManager.flushes)
 
 			// The following fields should be reset at the end of every flush.
 			require.True(t, proc.firstAppend.IsZero())
@@ -174,13 +172,11 @@ func TestPartitionProcessor_Flush(t *testing.T) {
 	t.Run("should fail", func(t *testing.T) {
 		synctest.Test(t, func(t *testing.T) {
 			var (
-				ctx             = t.Context()
-				reg             = prometheus.NewRegistry()
-				flusher         = &failureFlusher{}
-				metastoreKafka  = &mockKafka{}
-				metastoreEvents = newMetastoreEvents(1, 10, metastoreKafka)
-				committer       = &mockCommitter{}
-				proc            = newProcessor(newTestBuilder(t, reg), nil, flusher, metastoreEvents, committer, 1, 5*time.Minute, 30*time.Minute, log.NewNopLogger(), reg)
+				ctx          = t.Context()
+				reg          = prometheus.NewRegistry()
+				builder      = newTestBuilder(t, reg)
+				flushManager = &failureFlushManager{}
+				proc         = newProcessor(builder, nil, flushManager, 5*time.Minute, 30*time.Minute, log.NewNopLogger(), reg)
 			)
 
 			// Process a record containing some log lines. No flush should occur.
@@ -192,11 +188,7 @@ func TestPartitionProcessor_Flush(t *testing.T) {
 
 			// Advance time and force a flush. This flush should fail.
 			time.Sleep(time.Second)
-			require.EqualError(t, proc.flush(ctx, "forced"), "failed to flush data object: failed to flush")
-
-			// No metastore event should be emitted and no offsets committed.
-			require.Len(t, metastoreKafka.produced, 0)
-			require.Len(t, committer.offsets, 0)
+			require.EqualError(t, proc.flush(ctx, "forced"), "mock error")
 
 			// Despite the failure, the following fields should still be reset.
 			require.True(t, proc.firstAppend.IsZero())

--- a/pkg/dataobj/consumer/service.go
+++ b/pkg/dataobj/consumer/service.go
@@ -164,13 +164,18 @@ func New(kafkaCfg kafka.Config, cfg Config, mCfg metastore.Config, bucket objsto
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize data object builder: %w", err)
 	}
-	s.processor = newProcessor(
-		builder,
-		records,
+	flushManager := newFlushManager(
 		s.flusher,
 		newMetastoreEvents(partitionID, int32(mCfg.PartitionRatio), metastoreEvents),
 		committer,
 		partitionID,
+		logger,
+		wrapped,
+	)
+	s.processor = newProcessor(
+		builder,
+		records,
+		flushManager,
 		cfg.IdleFlushTimeout,
 		cfg.MaxBuilderAge,
 		logger,


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit adds a flush manager which takes care of flushing, producing a metastore event, and committing offsets, all with exponential backoff and retries. This is to make processor.go simpler and easier to test.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
