### PR TITLE
docs: update docker compose

### DIFF
--- a/examples/getting-started/docker-compose.yaml
+++ b/examples/getting-started/docker-compose.yaml
@@ -16,6 +16,7 @@ services:
       - minio
     healthcheck:
       test: [ "CMD", "/usr/bin/loki", "-health" ]
+      start_period: 30s
       interval: 10s
       timeout: 5s
       retries: 5
@@ -35,6 +36,7 @@ services:
       - ./loki-config.yaml:/etc/loki/config.yaml
     healthcheck:
       test: [ "CMD", "/usr/bin/loki", "-health" ]
+      start_period: 30s
       interval: 10s
       timeout: 5s
       retries: 5
@@ -130,6 +132,7 @@ services:
       - gateway
     healthcheck:
       test: [ "CMD", "/usr/bin/loki", "-health" ]
+      start_period: 30s
       interval: 30s
       timeout: 10s
       retries: 5


### PR DESCRIPTION
**What this PR does / why we need it**:

Follow on to #20313, based on a [comment](https://github.com/grafana/loki/pull/20590#issuecomment-3845284336) on the backport PR that this file had not been updated.

While updating the command for the `read` and `write` services, noticed that we were not performing a healthcheck on the `backend` service, so added that too.

**Special notes for your reviewer**:

Check my work here. I grabbed the `backend` healthcheck lines 131-135 from the production docker-compose file from the original PR (#20590).