### PR TITLE
fix: catch panics caused by long labels and return as errors

### DIFF
--- a/pkg/loghttp/push/push.go
+++ b/pkg/loghttp/push/push.go
@@ -391,6 +391,32 @@ func parsePushRequestBody(r *http.Request, maxRecvMsgSize int, maxDecompressedSi
 	return &req, nil
 }
 
+// safeParseLabelsWith16MBLimit wraps syntax.ParseLabels with panic recovery to catch
+// the panic that occurs when label names or values exceed 16MB (Prometheus encoding limit).
+// This prevents the distributor from crashing and instead returns a proper error to the client.
+func safeParseLabelsWith16MBLimit(labelString string, userID string) (labels.Labels, error) {
+	var result labels.Labels
+	var parseErr error
+
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				// Check if this is the specific panic we're looking for from Prometheus label encoding
+				if str, ok := r.(string); ok && strings.Contains(str, "String too long") {
+					parseErr = fmt.Errorf("label name or value exceeds maximum size of 16MB (Prometheus encoding limit) for org_id=%s", userID)
+					return
+				}
+				// For any other panic, re-panic to let it be handled by the standard panic recovery
+				panic(r)
+			}
+		}()
+
+		result, parseErr = syntax.ParseLabels(labelString)
+	}()
+
+	return result, parseErr
+}
+
 func ParseLokiRequest(userID string, r *http.Request, limits Limits, tenantConfigs *runtime.TenantConfigs, maxRecvMsgSize int, maxDecompressedSize int64, tracker UsageTracker, streamResolver StreamResolver, logger log.Logger) (*logproto.PushRequest, *Stats, error) {
 	pushStats := NewPushStats()
 
@@ -409,7 +435,7 @@ func ParseLokiRequest(userID string, r *http.Request, limits Limits, tenantConfi
 	for i := range req.Streams {
 		s := req.Streams[i]
 
-		lbs, err := syntax.ParseLabels(s.Labels)
+		lbs, err := safeParseLabelsWith16MBLimit(s.Labels, userID)
 		if err != nil {
 			return nil, nil, fmt.Errorf("couldn't parse labels: %w", err)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

We're seeing panics like the following in prod

```
panic: interface conversion: string is not error: missing method Error

goroutine 99888144 [running]:
github.com/grafana/loki/v3/pkg/util/server.onPanic({0x42a55a0, 0x40126b4870})
	/src/loki/pkg/util/server/recovery.go:57 +0x48
github.com/prometheus/prometheus/promql/parser.(*parser).recover(0x4001ef7180?, 0x4013f417c0)
	/src/loki/vendor/github.com/prometheus/prometheus/promql/parser/parse.go:339 +0x170
panic({0x42a55a0?, 0x40126b4870?})
	/usr/local/go/src/runtime/panic.go:783 +0x120
github.com/prometheus/prometheus/model/labels.sizeWhenEncoded(...)
	/src/loki/vendor/github.com/prometheus/prometheus/model/labels/labels_stringlabels.go:549
github.com/prometheus/prometheus/model/labels.labelSize(...)
	/src/loki/vendor/github.com/prometheus/prometheus/model/labels/labels_stringlabels.go:579
github.com/prometheus/prometheus/model/labels.labelsSize(...)
	/src/loki/vendor/github.com/prometheus/prometheus/model/labels/labels_stringlabels.go:569
github.com/prometheus/prometheus/model/labels.New({0x40089f3c00, 0x7, 0x8})
	/src/loki/vendor/github.com/prometheus/prometheus/model/labels/labels_stringlabels.go:314 +0x15c
```

This appears to be coming from [this code](https://github.com/prometheus/prometheus/blob/f0f40b970d49829adc688972127350348adb7ae9/model/labels/labels_stringlabels.go#L543-L551) in prometheus that panics if any label or value is over a certain size. Since this panic is a string and not an error,  the prometheus [recovery code](https://github.com/prometheus/prometheus/blob/f0f40b970d49829adc688972127350348adb7ae9/promql/parser/parse.go#L341) panics.

This is a short term fix until we can upstream the fix in prometheus, assuming my assessment here is correct.
